### PR TITLE
[datakit] Revert partition_id stamp on normalize output

### DIFF
--- a/lib/marin/src/marin/datakit/__init__.py
+++ b/lib/marin/src/marin/datakit/__init__.py
@@ -3,14 +3,10 @@
 
 """Datakit: composable pipeline stages with a standard Parquet format.
 
-The standard format pins three mandatory columns on every normalized record:
-``id`` (deterministic content hash), ``text`` (UTF-8 primary content), and
-``partition_id`` (int, the output shard the row was written to at normalize
-time). The shard count itself lives on the artifact, not the row.
-
-Downstream stages preserve ``partition_id`` and use it as the ``group_by`` key
-when a global shuffle (e.g. cross-document dedup) needs to land output back
-co-partitioned with the source.
+The standard format pins two mandatory columns on every normalized record:
+``id`` (deterministic content hash) and ``text`` (UTF-8 primary content).
+The partition index lives in the filename (``part-NNNNN-of-MMMMM.parquet``)
+and is derived at reader time from sorted file order, not stamped per row.
 """
 
 

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -3,13 +3,13 @@
 
 """Decontaminate normalized data against eval sources.
 
-Reads datakit-normalized Parquet (``id``, ``text``, ``partition_id``), builds an
-in-memory bloom filter from the eval text, and emits a co-partitioned Parquet
+Reads datakit-normalized Parquet (``id``, ``text``), builds an in-memory
+bloom filter from the eval text, and emits a co-partitioned Parquet
 attributes dataset marking which records overlap with eval text.
 
 Schema of the emitted Parquet attributes:
     id             : string         — matches source document id
-    partition_id   : int            — matches source partition
+    partition_id   : int            — source partition index (from sorted file order)
     contaminated   : bool           — max paragraph overlap meets the threshold
     max_overlap    : float          — highest paragraph overlap fraction in [0, 1]
     matched_hashes : list[uint64]   — bloom-hit ngram hashes from this record
@@ -317,12 +317,11 @@ def _make_marker(
                         matched.update(hits)
                     contaminated = max_score > 0 and max_score >= threshold
                     counters.increment("decon/contaminated" if contaminated else "decon/clean")
-                    # Fall back to shard.shard_idx for legacy v1 NormalizedData (pre-partition_id).
-                    # With reshard(num_shards=N) on a sorted file list, shard.shard_idx matches
-                    # the input's "part-NNNNN-of-NNNNN" partition number.
+                    # With reshard(num_shards=N) on a sorted file list, shard.shard_idx
+                    # matches the input's "part-NNNNN-of-NNNNN" partition number.
                     yield {
                         "id": record["id"],
-                        "partition_id": record.get("partition_id", shard.shard_idx),
+                        "partition_id": shard.shard_idx,
                         "contaminated": contaminated,
                         "max_overlap": max_score,
                         "matched_hashes": list(matched),

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -5,14 +5,9 @@
 
 Reads raw files (JSONL, Parquet, etc.) discovered recursively under a single
 input directory, transforms each record into the standard schema (``id``,
-``text``, ``partition_id``, plus all original columns), deduplicates by
-content, sorts by ``id`` within each partition, and writes Parquet output
-with ``part-{shard}-of-{total}`` naming.
-
-``partition_id`` (int) is stamped at write time and equals the row's output
-shard index. The shard count itself lives on the artifact
-(``NormalizedData.num_partitions``) — downstream stages use the column as the
-``group_by`` key for global shuffles and the field for filename construction.
+``text``, plus all original columns), deduplicates by content, sorts by ``id``
+within each partition, and writes Parquet output with
+``part-{shard}-of-{total}`` naming.
 
 All discovered files are merged into a single output: main records land in
 ``<output_path>/outputs/main/`` and (when dedup is enabled) duplicates land in
@@ -37,7 +32,6 @@ from zephyr import Dataset, ShardInfo, ZephyrContext, counters, write_parquet_fi
 from zephyr.readers import SUPPORTED_EXTENSIONS, load_file
 from zephyr.writers import ThreadedBatchWriter
 
-from marin.datakit import partition_filename
 from marin.execution.step_spec import StepSpec
 
 logger = logging.getLogger(__name__)
@@ -75,19 +69,12 @@ class NormalizedData(BaseModel):
     Attributes:
         main_output_dir: Directory containing the main output Parquet files.
         dup_output_dir: Directory containing the duplicate side output Parquet files.
-        num_partitions: Number of output shards. Matches the ``-of-NNNNN``
-            suffix in filenames and the ``partition_id`` column's value range
-            (``0 <= partition_id < num_partitions``). Downstream shufflers
-            need this to construct co-partitioned filenames without globbing.
-            ``None`` on legacy ``v1`` artifacts that pre-date the field;
-            always populated on ``v2``+ writes.
         counters: Aggregated zephyr counters.
     """
 
-    version: str = "v2"
+    version: str = "v1"
     main_output_dir: str
     dup_output_dir: str
-    num_partitions: int | None = None
     counters: dict[str, int]
 
 
@@ -283,9 +270,8 @@ def _make_split_writer(
         shard: ShardInfo,
     ) -> Iterator[dict[str, dict[str, Any]]]:
         # NOTE: we could add support for split_existing - but we intentionally don't
-        filename = partition_filename(shard.shard_idx, shard.total_shards)
-        main_path = f"{output_dir}/outputs/main/{filename}"
-        dup_path = f"{output_dir}/outputs/dups/{filename}"
+        main_path = f"{output_dir}/outputs/main/part-{shard.shard_idx:05d}-of-{shard.total_shards:05d}.parquet"
+        dup_path = f"{output_dir}/outputs/dups/part-{shard.shard_idx:05d}-of-{shard.total_shards:05d}.parquet"
 
         # Results are populated by each writer thread. Safe to read only after
         # the ThreadedBatchWriter context exits (which joins the thread).
@@ -302,9 +288,6 @@ def _make_split_writer(
             ThreadedBatchWriter(write_to(dup_path, "dup")) as dup_writer,
         ):
             for item in records:
-                # Stamp partition_id at the writer so it reflects the actual
-                # output shard, not anything inferred upstream of group_by.
-                item.data["partition_id"] = shard.shard_idx
                 if isinstance(item, MainOutput):
                     counters.increment("normalize/unique_records_out")
                     main_writer.submit(item.data)
@@ -474,7 +457,6 @@ def normalize_to_parquet(
     return NormalizedData(
         main_output_dir=os.path.join(output_path, "outputs/main"),
         dup_output_dir=os.path.join(output_path, "outputs/dups"),
-        num_partitions=num_shards,
         counters=counters_dict,
     )
 
@@ -494,7 +476,6 @@ def normalize_step(
     relative_input_path: str | None = None,
     file_extensions: tuple[str, ...] | None = None,
     dedup_mode: DedupMode = DedupMode.EXACT,
-    version: str | None = None,
     bare: bool = False,
 ) -> StepSpec:
     """Create a StepSpec that normalizes downloaded data to Parquet.
@@ -518,14 +499,6 @@ def normalize_step(
             ``zephyr.readers.load_file``.
         dedup_mode: How to deduplicate records within each output shard.
             Defaults to ``DedupMode.EXACT``; use ``DedupMode.NONE`` to skip.
-        version: Opt-in cache-invalidation knob. When set (e.g. ``"v2"``),
-            the value is included in ``hash_attrs`` so the step's ``hash_id``
-            differs from any prior cached run. Use this when you need
-            ``partition_id``-aware downstream consumers and are willing to
-            recompute. Default ``None`` keeps cache identity with pre-v2
-            step specs — ``normalize_to_parquet`` itself always stamps
-            ``partition_id``, so existing caches stay hits but new runs still
-            produce v2 output.
     """
     if relative_input_path:
         # ``os.path.join`` collapses redundant separators when ``download.output_path``
@@ -549,10 +522,6 @@ def normalize_step(
     # identical to pre-feature step specs (cache identity).
     if bare:
         hash_attrs["bare"] = bare
-    # Only include the version key when the caller explicitly opts in, so
-    # default callers preserve their existing hash_id and cache hits.
-    if version is not None:
-        hash_attrs["version"] = version
 
     return StepSpec(
         name=name,

--- a/tests/datakit/test_decon.py
+++ b/tests/datakit/test_decon.py
@@ -22,7 +22,7 @@ def flow_backend_ctx():
 
 
 def _write_input_parquet(path: Path, records: list[dict]) -> None:
-    """Write datakit-normalized-shaped Parquet (id, text, partition_id)."""
+    """Write datakit-normalized-shaped Parquet (id, text)."""
     path.parent.mkdir(parents=True, exist_ok=True)
     pq.write_table(pa.Table.from_pylist(records), str(path))
 
@@ -43,12 +43,11 @@ def _read_attributes(output_dir: Path) -> dict[str, dict]:
     return rows
 
 
-def _as_source(input_dir: Path, num_partitions: int) -> NormalizedData:
+def _as_source(input_dir: Path) -> NormalizedData:
     """Wrap a flat directory of test Parquet files as a NormalizedData artifact."""
     return NormalizedData(
         main_output_dir=str(input_dir),
         dup_output_dir=str(input_dir / "_dups_unused"),
-        num_partitions=num_partitions,
         counters={},
     )
 
@@ -113,7 +112,7 @@ def fox_corpus(tmp_path: Path):
 def test_decon_ngram_flags_high_overlap_and_gates_low(fox_corpus):
     """n=3 with threshold=0.5: verbatim and high-overlap records flagged; low-overlap and unique gated out."""
     attrs = decon_to_parquet(
-        normalized_data=_as_source(Path(fox_corpus["input_dir"]), num_partitions=2),
+        normalized_data=_as_source(Path(fox_corpus["input_dir"])),
         eval_data_sources=fox_corpus["eval_dir"],
         output_path=fox_corpus["output_dir"],
         ngram=NGramConfig(ngram_length=3, stride=0, overlap_threshold=0.5),
@@ -138,7 +137,7 @@ def test_decon_ngram_flags_high_overlap_and_gates_low(fox_corpus):
 def test_decon_exact_paragraph_match(fox_corpus):
     """ngram=None: whole-paragraph match. Verbatim records flagged; near-match gated out (different bytes)."""
     decon_to_parquet(
-        normalized_data=_as_source(Path(fox_corpus["input_dir"]), num_partitions=2),
+        normalized_data=_as_source(Path(fox_corpus["input_dir"])),
         eval_data_sources=fox_corpus["eval_dir"],
         output_path=fox_corpus["output_dir"],
         ngram=None,
@@ -159,7 +158,7 @@ def test_decon_exact_paragraph_match(fox_corpus):
 def test_decon_preserves_partition_filenames(fox_corpus):
     """Output partition filenames mirror input filenames 1:1 (co-partitioning invariant)."""
     decon_to_parquet(
-        normalized_data=_as_source(Path(fox_corpus["input_dir"]), num_partitions=2),
+        normalized_data=_as_source(Path(fox_corpus["input_dir"])),
         eval_data_sources=fox_corpus["eval_dir"],
         output_path=fox_corpus["output_dir"],
         ngram=NGramConfig(ngram_length=3, overlap_threshold=0.5),
@@ -174,7 +173,7 @@ def test_decon_preserves_partition_filenames(fox_corpus):
 def test_decon_output_schema(fox_corpus):
     """Output Parquet has exactly {id, partition_id, contaminated, max_overlap, matched_hashes}."""
     decon_to_parquet(
-        normalized_data=_as_source(Path(fox_corpus["input_dir"]), num_partitions=2),
+        normalized_data=_as_source(Path(fox_corpus["input_dir"])),
         eval_data_sources=fox_corpus["eval_dir"],
         output_path=fox_corpus["output_dir"],
         ngram=NGramConfig(ngram_length=3, overlap_threshold=0.5),
@@ -197,7 +196,7 @@ def test_decon_output_schema(fox_corpus):
 def test_decon_emits_eval_hash_index_sidecar(fox_corpus):
     """Build writes a hash → eval_id Parquet sidecar with the expected schema."""
     attrs = decon_to_parquet(
-        normalized_data=_as_source(Path(fox_corpus["input_dir"]), num_partitions=2),
+        normalized_data=_as_source(Path(fox_corpus["input_dir"])),
         eval_data_sources=fox_corpus["eval_dir"],
         output_path=fox_corpus["output_dir"],
         ngram=NGramConfig(ngram_length=3, overlap_threshold=0.5),
@@ -220,7 +219,7 @@ def test_decon_emits_eval_hash_index_sidecar(fox_corpus):
 def test_decon_matched_hashes_join_recovers_eval_id(fox_corpus):
     """A contaminated record's matched_hashes joined with the sidecar attributes back to its eval."""
     attrs = decon_to_parquet(
-        normalized_data=_as_source(Path(fox_corpus["input_dir"]), num_partitions=2),
+        normalized_data=_as_source(Path(fox_corpus["input_dir"])),
         eval_data_sources=fox_corpus["eval_dir"],
         output_path=fox_corpus["output_dir"],
         ngram=NGramConfig(ngram_length=3, overlap_threshold=0.5),
@@ -257,7 +256,7 @@ def test_decon_overlap_threshold_gates(fox_corpus, threshold, expect_high_flagge
     It's flagged at thresholds ≤ 0.89 and gated above; pin the gate behavior across thresholds.
     """
     decon_to_parquet(
-        normalized_data=_as_source(Path(fox_corpus["input_dir"]), num_partitions=2),
+        normalized_data=_as_source(Path(fox_corpus["input_dir"])),
         eval_data_sources=fox_corpus["eval_dir"],
         output_path=fox_corpus["output_dir"],
         ngram=NGramConfig(ngram_length=3, overlap_threshold=threshold),
@@ -280,7 +279,7 @@ def test_decon_empty_input_raises(tmp_path: Path):
 
     with pytest.raises(FileNotFoundError):
         decon_to_parquet(
-            normalized_data=_as_source(input_dir, num_partitions=1),
+            normalized_data=_as_source(input_dir),
             eval_data_sources=str(eval_dir),
             output_path=str(output_dir),
             ngram=NGramConfig(ngram_length=3),
@@ -318,7 +317,7 @@ def test_decon_eval_dir_with_sidecar_files_is_safe(tmp_path: Path):
 
     # Must not raise.
     decon_to_parquet(
-        normalized_data=_as_source(input_dir, num_partitions=1),
+        normalized_data=_as_source(input_dir),
         eval_data_sources=str(eval_dir),
         output_path=str(output_dir),
         ngram=NGramConfig(ngram_length=3, overlap_threshold=0.5),
@@ -353,7 +352,7 @@ def test_decon_fallback_eval_id_uses_full_path_for_uniqueness(tmp_path: Path):
     )
 
     attrs = decon_to_parquet(
-        normalized_data=_as_source(input_dir, num_partitions=1),
+        normalized_data=_as_source(input_dir),
         eval_data_sources=str(eval_dir),
         output_path=str(output_dir),
         ngram=NGramConfig(ngram_length=3, overlap_threshold=0.5),
@@ -371,13 +370,12 @@ def test_decon_fallback_eval_id_uses_full_path_for_uniqueness(tmp_path: Path):
     assert any("/b/" in e for e in eval_ids)
 
 
-def test_decon_v1_input_without_partition_id_column(tmp_path: Path):
-    """Legacy v1 NormalizedData (pre-partition_id) is supported via shard.shard_idx fallback.
+def test_decon_synthesizes_partition_id_from_shard_index(tmp_path: Path):
+    """Decon synthesizes partition_id from shard.shard_idx (sorted-file order).
 
-    Datasets normalized before the v2 partition_id stamp don't carry the column.
-    Decon should still produce co-partitioned output with synthesized partition_id
-    derived from the shard index (matches the input's part-NNNNN-of-MMMMM naming
-    when files are processed in sorted order).
+    Input records carry only id and text; the output's partition_id column is
+    derived at read time from the shard index, matching the input's
+    part-NNNNN-of-MMMMM naming.
     """
     eval_dir = tmp_path / "eval"
     input_dir = tmp_path / "input"
@@ -396,7 +394,7 @@ def test_decon_v1_input_without_partition_id_column(tmp_path: Path):
     )
 
     decon_to_parquet(
-        normalized_data=_as_source(input_dir, num_partitions=2),
+        normalized_data=_as_source(input_dir),
         eval_data_sources=str(eval_dir),
         output_path=str(output_dir),
         ngram=NGramConfig(ngram_length=3, overlap_threshold=0.5),
@@ -438,7 +436,7 @@ def test_decon_short_paragraphs_below_ngram_length_contribute_nothing(tmp_path: 
     )
 
     decon_to_parquet(
-        normalized_data=_as_source(input_dir, num_partitions=1),
+        normalized_data=_as_source(input_dir),
         eval_data_sources=str(eval_dir),
         output_path=str(output_dir),
         ngram=NGramConfig(ngram_length=8, overlap_threshold=0.5),
@@ -476,7 +474,7 @@ def _run_decon_one_shot(
     _write_eval_jsonl(eval_dir / "eval.jsonl.gz", eval_records)
     _write_input_parquet(input_dir / "part-00000-of-00001.parquet", input_records)
     decon_to_parquet(
-        normalized_data=_as_source(input_dir, num_partitions=1),
+        normalized_data=_as_source(input_dir),
         eval_data_sources=str(eval_dir),
         output_path=str(output_dir),
         ngram=ngram,

--- a/tests/datakit/test_normalize.py
+++ b/tests/datakit/test_normalize.py
@@ -5,13 +5,11 @@
 
 import gzip
 import json
-import re
 from pathlib import Path
 
 import pyarrow.parquet as pq
 import pytest
 from fray import LocalClient, set_current_client
-from marin.datakit import partition_filename
 from marin.datakit.normalize import generate_id, normalize_to_parquet
 
 
@@ -134,9 +132,7 @@ def test_bare_mode_strips_extra_columns(tmp_path: Path, write_jsonl_gz):
     results = _read_all_parquet(output_dir)
     assert len(results) == 2
     for r in results:
-        # bare drops record-level extras; partition_id is stamped on later by
-        # the writer and is independent of bare mode.
-        assert set(r.keys()) - {"partition_id"} == {"id", "text", "source_id"}
+        assert set(r.keys()) == {"id", "text", "source_id"}
     assert {r["source_id"] for r in results} == {"a", "b"}
     assert {r["text"] for r in results} == {"row a", "row b"}
 
@@ -252,94 +248,6 @@ def test_whitespace_compaction(tmp_path: Path, write_jsonl_gz):
     assert by_source["pathological"]["id"] == generate_id("before" + " " * 100 + "after")
     # Normal docs are untouched
     assert by_source["normal"]["text"] == "Hello world"
-
-
-def test_partition_id_stamped_single_shard(tmp_path: Path, write_jsonl_gz):
-    """Every output row carries an int partition_id; with a single shard it's 0."""
-    input_dir = tmp_path / "input"
-    output_dir = tmp_path / "output"
-
-    write_jsonl_gz(
-        input_dir / "data.jsonl.gz",
-        [{"text": "doc one"}, {"text": "doc two"}, {"text": "doc three"}],
-    )
-
-    result = normalize_to_parquet(input_path=str(input_dir), output_path=str(output_dir))
-
-    assert result.num_partitions == 1
-    rows = _read_all_parquet(output_dir)
-    assert len(rows) == 3
-    assert all(isinstance(r["partition_id"], int) for r in rows)
-    assert all(r["partition_id"] == 0 for r in rows)
-
-    # Filename matches the helper's output and the single partition.
-    main_files = sorted((output_dir / "outputs" / "main").glob("*.parquet"))
-    assert [p.name for p in main_files] == [partition_filename(0, 1)]
-
-
-def test_partition_id_matches_filename_across_shards(tmp_path: Path, write_jsonl_gz):
-    """With multiple output shards, every row's partition_id matches its filename suffix."""
-    input_dir = tmp_path / "input"
-    output_dir = tmp_path / "output"
-
-    # Varied per-record content so xxh3_128 distributes ids across shards;
-    # tiny target_partition_bytes forces multi-shard output.
-    records = [{"text": f"document {i} with unique content payload {i * 7919}"} for i in range(50)]
-    write_jsonl_gz(input_dir / "data.jsonl.gz", records)
-
-    result = normalize_to_parquet(
-        input_path=str(input_dir),
-        output_path=str(output_dir),
-        target_partition_bytes=50,
-    )
-
-    assert result.num_partitions > 1
-
-    main_dir = output_dir / "outputs" / "main"
-    files = sorted(main_dir.glob("*.parquet"))
-    assert files, "expected at least one output file"
-
-    seen_partition_ids: set[int] = set()
-    filename_re = re.compile(r"part-(\d+)-of-(\d+)\.parquet")
-    for pf in files:
-        m = filename_re.match(pf.name)
-        assert m, f"unexpected filename: {pf.name}"
-        expected_id = int(m.group(1))
-        assert int(m.group(2)) == result.num_partitions
-
-        rows = pq.read_table(str(pf)).to_pylist()
-        for row in rows:
-            assert row["partition_id"] == expected_id
-        if rows:
-            seen_partition_ids.add(expected_id)
-
-    # Sanity: hash distribution actually spread records across partitions.
-    assert len(seen_partition_ids) > 1
-
-
-def test_partition_id_stamped_on_dup_side_output(tmp_path: Path, write_jsonl_gz):
-    """Duplicate records also receive partition_id matching their dup-shard filename."""
-    input_dir = tmp_path / "input"
-    output_dir = tmp_path / "output"
-
-    write_jsonl_gz(
-        input_dir / "data.jsonl.gz",
-        [
-            {"text": "Duplicate text", "source": "first"},
-            {"text": "Duplicate text", "source": "second"},
-            {"text": "Unique text"},
-        ],
-    )
-
-    normalize_to_parquet(input_path=str(input_dir), output_path=str(output_dir))
-
-    dup_files = sorted((output_dir / "outputs" / "dups").glob("*.parquet"))
-    assert dup_files, "expected at least one dup-side output"
-    dup_rows: list[dict] = []
-    for pf in dup_files:
-        dup_rows.extend(pq.read_table(str(pf)).to_pylist())
-    assert len(dup_rows) == 1
-    assert dup_rows[0]["partition_id"] == 0
 
 
 def test_no_input_files_raises(tmp_path: Path):


### PR DESCRIPTION
Normalize no longer writes partition_id on rows or num_partitions on NormalizedData; decon now synthesizes partition_id from shard.shard_idx (reader-time derivation, the v1-fallback path made the only path). Cached normalize outputs stay valid without rewriting.

Reverts the row-stamp portion of #5437.