### PR TITLE
zephyr: PullStatus enum to fix worker hot-spin

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -331,6 +331,23 @@ class WorkerState(enum.Enum):
     DEAD = "dead"
 
 
+class PullStatus(enum.StrEnum):
+    """Control signals returned by ``ZephyrCoordinator.pull_task`` in place of a task.
+
+    Three explicit states make the slot's required response unambiguous:
+
+    - ``NO_WORK_BACKOFF``: queue is empty mid-stage; slot sleeps and retries.
+    - ``STAGE_COMPLETED``: this stage's pool is done (boundary or epoch-stale slot);
+      slot exits and the worker re-pools for the next stage.
+    - ``SHUTDOWN``: pipeline is finished or the coordinator is shutting down;
+      slot exits and the worker breaks its outer loop.
+    """
+
+    NO_WORK_BACKOFF = enum.auto()
+    STAGE_COMPLETED = enum.auto()
+    SHUTDOWN = enum.auto()
+
+
 @dataclass
 class ShardTask:
     """Describes a unit of work for a worker: one shard through one stage."""
@@ -845,19 +862,25 @@ class ZephyrCoordinator:
                 self._worker_states[worker_id] = WorkerState.FAILED
                 self._maybe_requeue_worker_task(worker_id)
 
-    def pull_task(self, worker_id: str, epoch: int | None = None) -> tuple[ShardTask, int, dict] | str | None:
+    def pull_task(self, worker_id: str, epoch: int | None = None) -> tuple[ShardTask, int, dict] | PullStatus:
         """Called by workers to get next task.
 
         Args:
             worker_id: Unique ID for this worker slot.
             epoch: Stage epoch the slot was registered under. If provided and it
                 no longer matches the coordinator's current epoch, the slot has
-                survived into a later stage and receives SHUTDOWN immediately.
+                survived into a later stage and is told STAGE_COMPLETED so the
+                worker re-registers under the new epoch.
 
         Returns:
-            - (task, attempt, config) tuple if task available
-            - "SHUTDOWN" string if coordinator is shutting down or epoch is stale
-            - None if no task available (worker should backoff and retry)
+            - ``(task, attempt, config)`` if a task is available.
+            - ``PullStatus.SHUTDOWN`` if the coordinator is shutting down or the
+              last stage has no more work to hand out — the worker should exit.
+            - ``PullStatus.STAGE_COMPLETED`` at a non-last stage boundary or when
+              the slot's epoch is stale — slot exits, worker re-pools for the
+              next stage.
+            - ``PullStatus.NO_WORK_BACKOFF`` if the queue is empty mid-stage —
+              slot should sleep and retry.
         """
         with self._lock:
             self._last_seen[worker_id] = time.monotonic()
@@ -865,28 +888,33 @@ class ZephyrCoordinator:
 
             if self._shutdown_event.is_set():
                 self._worker_states[worker_id] = WorkerState.DEAD
-                return "SHUTDOWN"
+                return PullStatus.SHUTDOWN
 
             if epoch is not None and epoch != self._stage_epoch:
-                # This slot was created for an earlier stage and missed its SHUTDOWN
+                # Slot was created for an earlier stage and missed its STAGE_COMPLETED
                 # (e.g. it was sleeping through the _mark_stage_complete window).
-                # Send SHUTDOWN now so it exits before picking up next-stage tasks.
+                # Tell it the stage is over so the worker re-registers under the new epoch.
                 self._worker_states[worker_id] = WorkerState.DEAD
-                return "SHUTDOWN"
+                return PullStatus.STAGE_COMPLETED
 
             if self._fatal_error:
-                return None
+                return PullStatus.NO_WORK_BACKOFF
 
             if not self._task_queue:
-                if self._is_last_stage or self._stage_complete:
-                    # No more work to hand out — exit immediately.  If an
-                    # in-flight worker crashes and its shard is requeued, Iris
-                    # restarts the worker which re-registers and picks it up.
-                    # _check_worker_group() detects permanent worker-job death
-                    # as a failsafe so we never deadlock.
+                if self._is_last_stage:
+                    # Last stage has no more tasks to hand out — pipeline is winding
+                    # down for this worker. If an in-flight peer crashes and its
+                    # shard is requeued, Iris restarts the worker which re-registers
+                    # and picks it up. _check_worker_group() detects permanent
+                    # worker-job death as a failsafe so we never deadlock.
                     self._worker_states[worker_id] = WorkerState.DEAD
-                    return "SHUTDOWN"
-                return None
+                    return PullStatus.SHUTDOWN
+                if self._stage_complete:
+                    # Non-last stage boundary — slot exits so the worker can re-pool
+                    # at the size required by the next stage (map vs reduce).
+                    self._worker_states[worker_id] = WorkerState.DEAD
+                    return PullStatus.STAGE_COMPLETED
+                return PullStatus.NO_WORK_BACKOFF
 
             task = self._task_queue.popleft()
             attempt = self._task_attempts[task.shard_idx]
@@ -1400,14 +1428,17 @@ class ZephyrWorker:
             num_active_workers = len(self._active_sub_ids)
             self._active_runners = [self._stage_runner_factory(num_active_workers) for _ in range(num_active_workers)]
 
+            # Slots write their final PullStatus here before returning so we can
+            # tell a stage-boundary exit from a pipeline-shutdown exit.
+            slot_statuses: list[PullStatus | None] = [None] * num_active_workers
             threads = [
                 threading.Thread(
                     target=self._poll_loop,
-                    args=(self._coordinator, sub_id, runner, stage_epoch),
+                    args=(self._coordinator, sub_id, runner, stage_epoch, slot_statuses, i),
                     daemon=True,
                     name=f"zephyr-poll-{sub_id}",
                 )
-                for sub_id, runner in zip(self._active_sub_ids, self._active_runners, strict=True)
+                for i, (sub_id, runner) in enumerate(zip(self._active_sub_ids, self._active_runners, strict=True))
             ]
             for t in threads:
                 t.start()
@@ -1423,6 +1454,12 @@ class ZephyrWorker:
                     self._coordinator.deregister_worker.remote(sub_id).result(timeout=10.0)
                 except Exception:
                     logger.warning("[%s] deregister_worker failed for %s (ignoring)", self._worker_id, sub_id)
+
+            # Any slot seeing SHUTDOWN means the pipeline is done for this worker
+            # — no next stage will come, so break instead of polling forever.
+            if any(s == PullStatus.SHUTDOWN for s in slot_statuses):
+                logger.info("[%s] Pipeline shutdown signaled by slot — exiting stage manager", self._worker_id)
+                break
 
         logger.info("[%s] Stage manager exiting", self._worker_id)
         if self._host_shutdown_event is not None:
@@ -1508,12 +1545,25 @@ class ZephyrWorker:
             self._shutdown_event.wait(timeout=interval)
         logger.debug("[%s] Heartbeat loop exiting after %d beats", self._worker_id, heartbeat_count)
 
-    def _poll_loop(self, coordinator: ActorHandle, worker_id: str, stage_runner: StageRunner, epoch: int = 0) -> None:
-        """Single-slot polling loop. Exits on SHUTDOWN signal or coordinator death.
+    def _poll_loop(
+        self,
+        coordinator: ActorHandle,
+        worker_id: str,
+        stage_runner: StageRunner,
+        epoch: int,
+        status_holder: list[PullStatus | None],
+        slot_idx: int,
+    ) -> None:
+        """Single-slot polling loop. Exits on STAGE_COMPLETED / SHUTDOWN or coordinator death.
 
         ``epoch`` is the stage epoch returned by ``register_worker``; it is passed
         on every ``pull_task`` call so the coordinator can detect slots that survived
-        past stage completion and send them SHUTDOWN before they pick up next-stage tasks.
+        past stage completion and send STAGE_COMPLETED before they pick up next-stage tasks.
+
+        On exit, the slot writes its final ``PullStatus`` to
+        ``status_holder[slot_idx]`` so the stage manager can distinguish a
+        stage-boundary exit (re-pool for next stage) from a pipeline-shutdown
+        exit (break the outer loop).
         """
         task_count = 0
         backoff = ExponentialBackoff(initial=0.1, maximum=5.0)
@@ -1543,11 +1593,17 @@ class ZephyrWorker:
 
             future = None
 
-            if response == "SHUTDOWN":
+            if response == PullStatus.SHUTDOWN:
                 logger.info("[%s] Received SHUTDOWN", worker_id)
-                break
+                status_holder[slot_idx] = PullStatus.SHUTDOWN
+                return
 
-            if response is None:
+            if response == PullStatus.STAGE_COMPLETED:
+                logger.info("[%s] Stage completed", worker_id)
+                status_holder[slot_idx] = PullStatus.STAGE_COMPLETED
+                return
+
+            if response == PullStatus.NO_WORK_BACKOFF:
                 time.sleep(backoff.next_interval())
                 continue
 

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1593,19 +1593,14 @@ class ZephyrWorker:
 
             future = None
 
-            if response == PullStatus.SHUTDOWN:
-                logger.info("[%s] Received SHUTDOWN", worker_id)
-                status_holder[slot_idx] = PullStatus.SHUTDOWN
-                return
-
-            if response == PullStatus.STAGE_COMPLETED:
-                logger.info("[%s] Stage completed", worker_id)
-                status_holder[slot_idx] = PullStatus.STAGE_COMPLETED
-                return
-
             if response == PullStatus.NO_WORK_BACKOFF:
                 time.sleep(backoff.next_interval())
                 continue
+
+            if isinstance(response, PullStatus):
+                logger.debug("[%s] Received %s", worker_id, response.name)
+                status_holder[slot_idx] = response
+                return
 
             backoff.reset()
             task, attempt, config = response

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -25,6 +25,7 @@ from zephyr.execution import (
     CounterSnapshot,
     ListShard,
     PickleDiskChunk,
+    PullStatus,
     ShardTask,
     TaskResult,
     WorkerState,
@@ -33,7 +34,7 @@ from zephyr.execution import (
     ZephyrWorkerError,
     zephyr_worker_ctx,
 )
-from zephyr.plan import compute_plan
+from zephyr.plan import PhysicalStage, StageType, compute_plan
 
 
 def test_simple_map(zephyr_ctx):
@@ -261,7 +262,7 @@ def test_status_reports_alive_workers_not_total(actor_context, tmp_path):
 
     # worker-0 pulls the task so it becomes in-flight
     pulled = coord.pull_task("worker-0")
-    assert pulled is not None and pulled != "SHUTDOWN"
+    assert isinstance(pulled, tuple)
 
     # Simulate 2 workers dying via heartbeat timeout
     coord._last_seen["worker-0"] = 0.0
@@ -280,7 +281,7 @@ def test_status_reports_alive_workers_not_total(actor_context, tmp_path):
 
     # worker-2 picks up the requeued task
     pulled2 = coord.pull_task("worker-2")
-    assert pulled2 is not None and pulled2 != "SHUTDOWN"
+    assert isinstance(pulled2, tuple)
 
     # Simulate worker-0 re-registering while worker-2 holds the task in-flight
     # (race between heartbeat requeue and re-registration).
@@ -298,6 +299,100 @@ def test_status_reports_alive_workers_not_total(actor_context, tmp_path):
     coord.register_worker("worker-2", MagicMock())
     assert "worker-2" not in coord._in_flight  # in-flight cleared
     assert len(coord._task_queue) == 1  # task was requeued
+
+
+def _make_task(stage_name: str = "test", shard_idx: int = 0) -> ShardTask:
+    return ShardTask(
+        shard_idx=shard_idx,
+        total_shards=1,
+        shard=ListShard(refs=[]),
+        operations=[],
+        stage_name=stage_name,
+    )
+
+
+def test_pull_task_returns_shutdown_on_last_stage_tail(actor_context, tmp_path):
+    """During the last stage's tail (queue drained, in-flight tasks still
+    finishing), a fresh slot's ``pull_task`` must return SHUTDOWN so the worker
+    breaks its outer loop instead of respawning slots that would just get
+    killed again — that's the original hot-spin bug.
+    """
+    coord = ZephyrCoordinator()
+    coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
+    coord._current_stage = PhysicalStage(operations=[], stage_type=StageType.MAP_WORKER)
+    coord._start_stage("tail", 0, [_make_task("tail")], is_last_stage=True)
+
+    coord.register_worker("worker-0", MagicMock())
+    assert isinstance(coord.pull_task("worker-0"), tuple)  # drain the queue
+
+    coord.register_worker("worker-1", MagicMock())
+    assert coord.pull_task("worker-1") == PullStatus.SHUTDOWN
+
+
+def test_pull_task_returns_no_work_backoff_mid_non_last_stage(actor_context, tmp_path):
+    """Mid-stage on a non-last stage with the queue drained but in-flight tasks
+    running: NO_WORK_BACKOFF, not SHUTDOWN or STAGE_COMPLETED — the slot must
+    stay alive and keep polling so it can pick up requeued tasks or the eventual
+    stage-end signal.
+    """
+    coord = ZephyrCoordinator()
+    coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
+    coord._current_stage = PhysicalStage(operations=[], stage_type=StageType.MAP_WORKER)
+    coord._start_stage("mid", 0, [_make_task("mid")], is_last_stage=False)
+
+    coord.register_worker("worker-0", MagicMock())
+    assert isinstance(coord.pull_task("worker-0"), tuple)  # drain the queue
+
+    coord.register_worker("worker-1", MagicMock())
+    assert coord.pull_task("worker-1") == PullStatus.NO_WORK_BACKOFF
+
+
+def test_pull_task_returns_stage_completed_after_mark_stage_complete(actor_context, tmp_path):
+    """At a non-last stage boundary (after ``_mark_stage_complete``), pull_task
+    returns STAGE_COMPLETED so slots tear down and the worker re-pools at the
+    size required by the next stage.
+    """
+    coord = ZephyrCoordinator()
+    coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
+    coord._current_stage = PhysicalStage(operations=[], stage_type=StageType.MAP_WORKER)
+    coord._start_stage("mid", 0, [_make_task("mid")], is_last_stage=False)
+
+    coord.register_worker("worker-0", MagicMock())
+    coord.pull_task("worker-0")  # drain the queue
+    coord._mark_stage_complete()
+
+    assert coord.pull_task("worker-0") == PullStatus.STAGE_COMPLETED
+
+
+def test_pull_task_returns_stage_completed_on_epoch_mismatch(actor_context, tmp_path):
+    """A slot that woke late and is still tagged with a stale epoch must get
+    STAGE_COMPLETED, not SHUTDOWN — the worker should re-register under the new
+    epoch and continue, not exit.
+    """
+    coord = ZephyrCoordinator()
+    coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
+    coord._current_stage = PhysicalStage(operations=[], stage_type=StageType.MAP_WORKER)
+    coord._start_stage("first", 0, [_make_task("first")], is_last_stage=False)
+    stale_epoch = coord._stage_epoch
+    coord._start_stage("second", 1, [_make_task("second")], is_last_stage=False)
+    assert coord._stage_epoch != stale_epoch
+
+    coord.register_worker("worker-0", MagicMock())
+    assert coord.pull_task("worker-0", epoch=stale_epoch) == PullStatus.STAGE_COMPLETED
+
+
+def test_pull_task_returns_shutdown_on_coordinator_shutdown(actor_context, tmp_path):
+    """When the coordinator's shutdown_event is set, all pull_task calls return
+    SHUTDOWN regardless of stage state.
+    """
+    coord = ZephyrCoordinator()
+    coord.set_chunk_config(str(tmp_path / "chunks"), "test-exec")
+    coord._current_stage = PhysicalStage(operations=[], stage_type=StageType.MAP_WORKER)
+    coord._start_stage("any", 0, [_make_task("any")], is_last_stage=False)
+    coord._shutdown_event.set()
+
+    coord.register_worker("worker-0", MagicMock())
+    assert coord.pull_task("worker-0") == PullStatus.SHUTDOWN
 
 
 def test_log_status_omits_throughput_when_counters_missing(actor_context, tmp_path, caplog):
@@ -364,8 +459,7 @@ def test_no_duplicate_results_on_heartbeat_timeout(actor_context, tmp_path):
 
     # Worker A pulls task (attempt 0)
     pulled = coord.pull_task("worker-A")
-    assert pulled is not None
-    assert pulled != "SHUTDOWN"
+    assert isinstance(pulled, tuple)
     _task_a, attempt_a, _config = pulled
 
     # Simulate heartbeat timeout: mark worker-A stale and requeue
@@ -377,8 +471,7 @@ def test_no_duplicate_results_on_heartbeat_timeout(actor_context, tmp_path):
 
     # Worker B picks up the requeued task (attempt 1)
     pulled_b = coord.pull_task("worker-B")
-    assert pulled_b is not None
-    assert pulled_b != "SHUTDOWN"
+    assert isinstance(pulled_b, tuple)
     _task_b, attempt_b, _config = pulled_b
     assert attempt_b == 1
 
@@ -515,7 +608,7 @@ def test_report_error_requeues_until_max_shard_failures(actor_context, tmp_path)
     # Each failure should re-queue until the limit
     for i in range(MAX_SHARD_FAILURES - 1):
         pulled = coord.pull_task("worker-0")
-        assert pulled is not None and pulled != "SHUTDOWN"
+        assert isinstance(pulled, tuple)
         _task, _attempt, _config = pulled
         coord.report_error("worker-0", 0, f"error-{i}")
         assert coord._fatal_error is None, f"Should not abort on failure {i + 1}"
@@ -523,7 +616,7 @@ def test_report_error_requeues_until_max_shard_failures(actor_context, tmp_path)
 
     # The final failure should set _fatal_error
     pulled = coord.pull_task("worker-0")
-    assert pulled is not None and pulled != "SHUTDOWN"
+    assert isinstance(pulled, tuple)
     coord.report_error("worker-0", 0, "final-error")
     assert coord._fatal_error is not None
     assert "Shard 0" in coord._fatal_error
@@ -548,7 +641,7 @@ def test_heartbeat_timeouts_do_not_count_toward_shard_failures(actor_context, tm
     # Far more heartbeat timeouts than MAX_SHARD_FAILURES — must not abort.
     for _ in range(MAX_SHARD_FAILURES * 5):
         pulled = coord.pull_task("worker-0")
-        assert pulled is not None and pulled != "SHUTDOWN"
+        assert isinstance(pulled, tuple)
         coord._last_seen["worker-0"] = 0.0
         coord.check_heartbeats(timeout=0.0)
         assert coord._fatal_error is None
@@ -556,7 +649,7 @@ def test_heartbeat_timeouts_do_not_count_toward_shard_failures(actor_context, tm
     # Task-error budget is untouched; a successful completion closes the shard.
     assert coord._task_error_attempts[0] == 0
     pulled = coord.pull_task("worker-0")
-    assert pulled is not None and pulled != "SHUTDOWN"
+    assert isinstance(pulled, tuple)
     _task, attempt, _config = pulled
     coord.report_result("worker-0", 0, attempt, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
     assert coord._completed_shards == 1
@@ -588,14 +681,14 @@ def test_repeated_infra_failures_on_same_shard_eventually_abort(actor_context, t
     # One short of the cap: still re-queues, no abort yet.
     for _ in range(MAX_SHARD_INFRA_FAILURES - 1):
         pulled = coord.pull_task("worker-0")
-        assert pulled is not None and pulled != "SHUTDOWN"
+        assert isinstance(pulled, tuple)
         coord._last_seen["worker-0"] = 0.0
         coord.check_heartbeats(timeout=0.0)
         assert coord._fatal_error is None
 
     # The next failure crosses the cap and aborts.
     pulled = coord.pull_task("worker-0")
-    assert pulled is not None and pulled != "SHUTDOWN"
+    assert isinstance(pulled, tuple)
     coord._last_seen["worker-0"] = 0.0
     coord.check_heartbeats(timeout=0.0)
 
@@ -629,13 +722,13 @@ def test_max_shard_failures_override_via_initialize(actor_context, tmp_path):
 
     # First failure: re-queues, no abort.
     pulled = coord.pull_task("worker-0")
-    assert pulled is not None and pulled != "SHUTDOWN"
+    assert isinstance(pulled, tuple)
     coord.report_error("worker-0", 0, "error-1")
     assert coord._fatal_error is None
 
     # Second failure: hits the custom cap of 2 → abort.
     pulled = coord.pull_task("worker-0")
-    assert pulled is not None and pulled != "SHUTDOWN"
+    assert isinstance(pulled, tuple)
     coord.report_error("worker-0", 0, "error-2")
     assert coord._fatal_error is not None
     assert "Shard 0" in coord._fatal_error
@@ -667,14 +760,14 @@ def test_max_shard_infra_failures_override_via_initialize(actor_context, tmp_pat
 
     # First infra failure: re-queues, no abort.
     pulled = coord.pull_task("worker-0")
-    assert pulled is not None and pulled != "SHUTDOWN"
+    assert isinstance(pulled, tuple)
     coord._last_seen["worker-0"] = 0.0
     coord.check_heartbeats(timeout=0.0)
     assert coord._fatal_error is None
 
     # Second infra failure: hits the custom cap of 2 → abort.
     pulled = coord.pull_task("worker-0")
-    assert pulled is not None and pulled != "SHUTDOWN"
+    assert isinstance(pulled, tuple)
     coord._last_seen["worker-0"] = 0.0
     coord.check_heartbeats(timeout=0.0)
     assert coord._fatal_error is not None
@@ -699,7 +792,7 @@ def test_worker_reregistration_does_not_count_toward_shard_failures(actor_contex
 
     for _ in range(MAX_SHARD_FAILURES * 5):
         pulled = coord.pull_task("worker-0")
-        assert pulled is not None and pulled != "SHUTDOWN"
+        assert isinstance(pulled, tuple)
         # Simulate preemption + Iris reconstruction: worker re-registers while
         # a task is still recorded as in-flight on the old handle.
         coord.register_worker("worker-0", MagicMock())
@@ -727,7 +820,7 @@ def test_report_error_still_aborts_at_max_shard_failures_after_preemptions(actor
     # Several preemption cycles first — these must not count.
     for _ in range(5):
         pulled = coord.pull_task("worker-0")
-        assert pulled is not None and pulled != "SHUTDOWN"
+        assert isinstance(pulled, tuple)
         coord._last_seen["worker-0"] = 0.0
         coord.check_heartbeats(timeout=0.0)
 
@@ -736,7 +829,7 @@ def test_report_error_still_aborts_at_max_shard_failures_after_preemptions(actor
     # Now MAX_SHARD_FAILURES explicit task errors should abort.
     for i in range(MAX_SHARD_FAILURES):
         pulled = coord.pull_task("worker-0")
-        assert pulled is not None and pulled != "SHUTDOWN"
+        assert isinstance(pulled, tuple)
         coord.report_error("worker-0", 0, f"boom-{i}")
 
     assert coord._fatal_error is not None
@@ -804,7 +897,7 @@ def test_wait_for_stage_resets_dead_timer_on_recovery(actor_context, tmp_path):
         time.sleep(0.1)
         coord.register_worker("worker-0", MagicMock())
         pulled = coord.pull_task("worker-0")
-        assert pulled is not None and pulled != "SHUTDOWN"
+        assert isinstance(pulled, tuple)
         _task, attempt, _config = pulled
         coord.report_result("worker-0", 0, attempt, TaskResult(shard=ListShard(refs=[])), CounterSnapshot.empty())
 


### PR DESCRIPTION
* fix hot-spin bug in zephyr coordinator <--> worker comms, avoid restarting zephyr worker thread pool just to kill it
* `pull_task` used to overload `"SHUTDOWN"` for both end-of-stage and end-of-pipeline, plus `None` for backoff — `_stage_manager` couldn't tell them apart, so it always looped and re-registered slots [^1]
* introduce `PullStatus(StrEnum)` with `NO_WORK_BACKOFF` / `STAGE_COMPLETED` / `SHUTDOWN`; `pull_task` returns `tuple | PullStatus` (no more `None` sentinel)
  * coordinator shutdown or queue empty + `_is_last_stage` → `SHUTDOWN`
  * epoch mismatch or queue empty + `_stage_complete` → `STAGE_COMPLETED`
  * queue empty mid-stage or `_fatal_error` → `NO_WORK_BACKOFF`
* `_poll_loop` writes its final `PullStatus` into a per-slot list; `_stage_manager` `break`s the outer loop iff any slot saw `SHUTDOWN`, otherwise re-pools for the next stage
* falls out: real eager worker exit at end-of-pipeline (today the worker process only exits when `ZephyrContext.shutdown()` arrives via RPC)
* runners untouched — `PullStatus` only travels between `pull_task` and `_poll_loop`; `InlineRunner` / `SubprocessRunner` sit below `_execute_shard`

[^1]: the spin was bounded — once `_mark_stage_complete` ran, `_current_stage` flipped to `None` and the manager backed off. but in between it could fire dozens of `register_worker` / `pull_task` / `deregister_worker` RPCs per worker per second