### PR TITLE
[evals] Add canonical synthetic reasoning PPL slices

### DIFF
--- a/experiments/evals/synthetic_reasoning_ppl.py
+++ b/experiments/evals/synthetic_reasoning_ppl.py
@@ -1,0 +1,162 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""HF-backed synthetic reasoning PPL validation slices for issue #4148."""
+
+from __future__ import annotations
+
+import posixpath
+from dataclasses import dataclass
+from enum import StrEnum
+
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, supervised_text_dataset
+from marin.processing.tokenize import HfDatasetSpec
+
+EPIC_5005 = 5005
+SYNTHETIC_REASONING_ISSUE = 4148
+ISSUE_5052 = 5052
+SYNTHETIC_REASONING_HF_DATASET_ID = "marin-community/synth-reasoning-arrow-icl-ppl"
+SYNTHETIC_REASONING_HF_REVISION = "0cedc373025ae08edf24e24d73eeda75980ddf8c"
+SYNTHETIC_REASONING_SOURCE = "generated_synthetic_reasoning_arrow_icl_v1"
+SYNTHETIC_REASONING_SOURCE_REPO = "marin-community/synth-bootstrap-trial"
+SYNTHETIC_REASONING_PROMPT_FORMAT = "arrow_5shot_icl_v1"
+SYNTHETIC_REASONING_ICL_SHOTS = 5
+DEV_SEED_BASE = 1 << 30
+EXAMPLES_PER_SUBCORPUS = 1000
+
+STEPMATH_TASKS: tuple[str, ...] = (
+    "arithmetic",
+    "algebra_linear_equation",
+)
+
+LEGACY_STEPMATH_ALIAS_TASKS: tuple[str, ...] = (
+    "arithmetic_5shot_icl",
+    "algebra_linear_equation_3shot_icl",
+)
+
+NATIVE_TASKS: tuple[str, ...] = (
+    "bfs_shortest_path",
+    "binary_search",
+    "coin_change_dp",
+    "connected_components",
+    "dijkstra_shortest_path",
+    "edit_distance_dp",
+    "euclid_gcd",
+    "floyd_warshall_apsp",
+    "insertion_sort",
+    "interval_scheduling",
+    "kmp_string_search",
+    "knapsack_01_dp",
+    "lcs_dp",
+    "lis_dp",
+    "n_queens_backtracking",
+    "parentheses_balance",
+    "prim_mst",
+    "propositional_entailment",
+    "topological_sort",
+    "union_find_connectivity",
+)
+
+LEGACY_NATIVE_ALIAS_TASKS: tuple[str, ...] = (
+    "binary_search_5shot_icl",
+    "euclid_gcd_5shot_icl",
+    "parentheses_balance_5shot_icl",
+    "edit_distance_dp_1shot_icl",
+    "interval_scheduling_1shot_icl",
+    "kmp_string_search_1shot_icl",
+    "knapsack_01_dp_1shot_icl",
+    "lcs_dp_1shot_icl",
+    "n_queens_backtracking_1shot_icl",
+    "union_find_connectivity_1shot_icl",
+)
+
+CLRS_STYLE_TASKS: tuple[str, ...] = (
+    "clrs_bfs",
+    "clrs_binary_search",
+    "clrs_connected_components",
+    "clrs_dijkstra",
+    "clrs_floyd_warshall",
+    "clrs_insertion_sort",
+    "clrs_lcs_length",
+    "clrs_lis",
+    "clrs_mst_prim",
+    "clrs_topological_sort",
+)
+
+
+class SyntheticReasoningFamily(StrEnum):
+    STEPMATH = "stepmath"
+    NATIVE = "native"
+    CLRS_STYLE = "clrs_style"
+
+
+@dataclass(frozen=True)
+class SyntheticReasoningPplSlice:
+    family: SyntheticReasoningFamily
+    task_name: str
+    hf_config_name: str
+    icl_shots: int = SYNTHETIC_REASONING_ICL_SHOTS
+
+    @property
+    def registry_key(self) -> str:
+        return posixpath.join("synthetic_reasoning_ppl", self.family.value, self.task_name)
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        return (
+            "synthetic_reasoning_ppl",
+            f"epic:{EPIC_5005}",
+            f"issue:{SYNTHETIC_REASONING_ISSUE}",
+            f"issue:{ISSUE_5052}",
+            f"family:{self.family.value}",
+            f"task:{self.task_name}",
+            f"seed:{DEV_SEED_BASE}",
+            f"examples:{EXAMPLES_PER_SUBCORPUS}",
+            f"source:{SYNTHETIC_REASONING_SOURCE}",
+            f"source_repo:{SYNTHETIC_REASONING_SOURCE_REPO}",
+            f"hf_revision:{SYNTHETIC_REASONING_HF_REVISION}",
+            f"prompt_format:{SYNTHETIC_REASONING_PROMPT_FORMAT}",
+            f"icl_shots:{self.icl_shots}",
+            "loss:target_only",
+        )
+
+    def to_raw_text_dataset(self, *, hf_dataset_id: str) -> RawTextEvaluationDataset:
+        return supervised_text_dataset(
+            HfDatasetSpec(
+                id=hf_dataset_id,
+                name=self.hf_config_name,
+                revision=SYNTHETIC_REASONING_HF_REVISION,
+            ),
+            input_key="input",
+            target_key="target",
+            split="validation",
+            tags=self.tags,
+        )
+
+
+def _slice(
+    *,
+    family: SyntheticReasoningFamily,
+    task_name: str,
+) -> SyntheticReasoningPplSlice:
+    return SyntheticReasoningPplSlice(
+        family=family,
+        task_name=task_name,
+        hf_config_name=f"{family.value}_{task_name}_arrow_5shot_icl",
+    )
+
+
+SYNTHETIC_REASONING_PPL_SLICES: tuple[SyntheticReasoningPplSlice, ...] = (
+    *(_slice(family=SyntheticReasoningFamily.STEPMATH, task_name=task) for task in STEPMATH_TASKS),
+    *(_slice(family=SyntheticReasoningFamily.NATIVE, task_name=task) for task in NATIVE_TASKS),
+    *(_slice(family=SyntheticReasoningFamily.CLRS_STYLE, task_name=task) for task in CLRS_STYLE_TASKS),
+)
+
+
+def synthetic_reasoning_raw_validation_sets(
+    *, hf_dataset_id: str = SYNTHETIC_REASONING_HF_DATASET_ID
+) -> dict[str, RawTextEvaluationDataset]:
+    return {
+        slice_.registry_key: slice_.to_raw_text_dataset(hf_dataset_id=hf_dataset_id)
+        for slice_ in SYNTHETIC_REASONING_PPL_SLICES
+    }

--- a/experiments/exp5052_synthetic_reasoning_ppl.py
+++ b/experiments/exp5052_synthetic_reasoning_ppl.py
@@ -1,0 +1,14 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Issue #5052: HF-backed synthetic reasoning PPL dev slices."""
+
+from marin.execution.executor import executor_main
+
+from experiments.evals.synthetic_reasoning_ppl import synthetic_reasoning_raw_validation_sets
+
+RAW_SYNTHETIC_REASONING_VALIDATION_SETS = synthetic_reasoning_raw_validation_sets()
+
+
+if __name__ == "__main__":
+    executor_main(steps=[])

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -267,6 +267,7 @@ class HfDatasetSourceConfig(LmDatasetSourceConfigBase):
 
     id: str = dataclasses.field(kw_only=True)
     name: str | None = None  # name for hf dataset
+    revision: str | None = None  # revision, branch, or tag for hf dataset
     stream: bool = True  # whether to use streaming when doing hf
     splits: list[str] | None = None
 
@@ -276,7 +277,13 @@ class HfDatasetSourceConfig(LmDatasetSourceConfigBase):
             return None
         if self.id is not None:
             try:
-                ds = WrappedHFDataSource(self.id, split=split, name=self.name, streaming=self.stream)
+                ds = WrappedHFDataSource(
+                    self.id,
+                    split=split,
+                    name=self.name,
+                    revision=self.revision,
+                    streaming=self.stream,
+                )
             except ValueError as e:
                 # if the message starts with Bad split, then just return None
                 if str(e).startswith("Bad split"):

--- a/lib/marin/src/marin/evaluation/perplexity_gap.py
+++ b/lib/marin/src/marin/evaluation/perplexity_gap.py
@@ -56,6 +56,7 @@ class RawTextEvaluationDataset:
     input_path: str | InputName | ExecutorStep | None = None
     hf_dataset_id: str | None = None
     hf_dataset_name: str | None = None
+    hf_dataset_revision: str | None = None
     text_key: str = "text"
     input_key: str | None = None
     target_key: str | None = None
@@ -102,6 +103,7 @@ def raw_text_dataset(
         return RawTextEvaluationDataset(
             hf_dataset_id=source.id,
             hf_dataset_name=source.name,
+            hf_dataset_revision=source.revision,
             text_key=text_key,
             split=split,
             tags=tags,
@@ -123,6 +125,7 @@ def supervised_text_dataset(
         return RawTextEvaluationDataset(
             hf_dataset_id=source.id,
             hf_dataset_name=source.name,
+            hf_dataset_revision=source.revision,
             input_key=input_key,
             target_key=target_key,
             split=split,
@@ -308,6 +311,7 @@ def _to_dataset_component(config: RawTextEvaluationDataset) -> DatasetComponent:
         source = HfDatasetSourceConfig(
             id=config.hf_dataset_id,
             name=config.hf_dataset_name,
+            revision=config.hf_dataset_revision,
             format=dataset_format,
             splits=[config.split],
         )
@@ -374,6 +378,7 @@ def _cache_key_for_dataset(dataset: RawTextEvaluationDataset) -> dict[str, Any]:
         "input_path": input_path,
         "hf_dataset_id": dataset.hf_dataset_id,
         "hf_dataset_name": dataset.hf_dataset_name,
+        "hf_dataset_revision": dataset.hf_dataset_revision,
         "text_key": dataset.text_key,
         "input_key": dataset.input_key,
         "target_key": dataset.target_key,

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -74,6 +74,7 @@ class HfDatasetSpec:
 
     id: str
     name: str | None = None
+    revision: str | None = None
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/tests/evals/test_long_tail_ppl.py
+++ b/tests/evals/test_long_tail_ppl.py
@@ -3,7 +3,12 @@
 
 import pytest
 from levanter.data.text import HfDatasetSourceConfig, SupervisedLmDatasetFormat
-from marin.evaluation.perplexity_gap import _to_dataset_component, raw_text_dataset, supervised_text_dataset
+from marin.evaluation.perplexity_gap import (
+    _cache_key_for_dataset,
+    _to_dataset_component,
+    raw_text_dataset,
+    supervised_text_dataset,
+)
 from marin.processing.tokenize import HfDatasetSpec
 
 from experiments.evals.long_tail_ppl import (
@@ -37,19 +42,25 @@ def test_long_tail_registry_rendering_mentions_issue_links():
 
 
 def test_hf_backed_raw_dataset_preserves_requested_split():
-    dataset = raw_text_dataset(HfDatasetSpec(id="example/dataset"), text_key="body", split="test")
+    dataset = raw_text_dataset(
+        HfDatasetSpec(id="example/dataset", name="raw_config", revision="raw-revision-abc123"),
+        text_key="body",
+        split="test",
+    )
 
     component = _to_dataset_component(dataset)
 
     assert component.split == "test"
     assert component.format.text_key == "body"
     assert isinstance(component.source, HfDatasetSourceConfig)
+    assert component.source.name == "raw_config"
+    assert component.source.revision == "raw-revision-abc123"
     assert component.source.splits == ["test"]
 
 
 def test_hf_backed_supervised_dataset_uses_supervised_format():
     dataset = supervised_text_dataset(
-        HfDatasetSpec(id="example/dataset"),
+        HfDatasetSpec(id="example/dataset", name="supervised_config", revision="supervised-revision-def456"),
         input_key="prompt",
         target_key="completion",
         split="test",
@@ -62,7 +73,26 @@ def test_hf_backed_supervised_dataset_uses_supervised_format():
     assert component.format.input_key == "prompt"
     assert component.format.target_key == "completion"
     assert isinstance(component.source, HfDatasetSourceConfig)
+    assert component.source.name == "supervised_config"
+    assert component.source.revision == "supervised-revision-def456"
     assert component.source.splits == ["test"]
+
+
+def test_hf_dataset_revision_changes_per_dataset_score_cache_key():
+    old_dataset = supervised_text_dataset(
+        HfDatasetSpec(id="example/dataset", name="config", revision="old-commit"),
+        input_key="prompt",
+        target_key="completion",
+    )
+    new_dataset = supervised_text_dataset(
+        HfDatasetSpec(id="example/dataset", name="config", revision="new-commit"),
+        input_key="prompt",
+        target_key="completion",
+    )
+
+    assert _cache_key_for_dataset(old_dataset)["hf_dataset_revision"] == "old-commit"
+    assert _cache_key_for_dataset(new_dataset)["hf_dataset_revision"] == "new-commit"
+    assert _cache_key_for_dataset(old_dataset) != _cache_key_for_dataset(new_dataset)
 
 
 def test_file_backed_raw_dataset_rejects_non_validation_split():

--- a/tests/evals/test_synthetic_reasoning_ppl.py
+++ b/tests/evals/test_synthetic_reasoning_ppl.py
@@ -1,0 +1,98 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from experiments.evals.synthetic_reasoning_ppl import (
+    SYNTHETIC_REASONING_HF_DATASET_ID,
+    SYNTHETIC_REASONING_ICL_SHOTS,
+    SYNTHETIC_REASONING_PROMPT_FORMAT,
+    synthetic_reasoning_raw_validation_sets,
+)
+
+EXPECTED_SYNTHETIC_REASONING_KEYS = {
+    "synthetic_reasoning_ppl/clrs_style/clrs_bfs",
+    "synthetic_reasoning_ppl/clrs_style/clrs_binary_search",
+    "synthetic_reasoning_ppl/clrs_style/clrs_connected_components",
+    "synthetic_reasoning_ppl/clrs_style/clrs_dijkstra",
+    "synthetic_reasoning_ppl/clrs_style/clrs_floyd_warshall",
+    "synthetic_reasoning_ppl/clrs_style/clrs_insertion_sort",
+    "synthetic_reasoning_ppl/clrs_style/clrs_lcs_length",
+    "synthetic_reasoning_ppl/clrs_style/clrs_lis",
+    "synthetic_reasoning_ppl/clrs_style/clrs_mst_prim",
+    "synthetic_reasoning_ppl/clrs_style/clrs_topological_sort",
+    "synthetic_reasoning_ppl/native/bfs_shortest_path",
+    "synthetic_reasoning_ppl/native/binary_search",
+    "synthetic_reasoning_ppl/native/coin_change_dp",
+    "synthetic_reasoning_ppl/native/connected_components",
+    "synthetic_reasoning_ppl/native/dijkstra_shortest_path",
+    "synthetic_reasoning_ppl/native/edit_distance_dp",
+    "synthetic_reasoning_ppl/native/euclid_gcd",
+    "synthetic_reasoning_ppl/native/floyd_warshall_apsp",
+    "synthetic_reasoning_ppl/native/insertion_sort",
+    "synthetic_reasoning_ppl/native/interval_scheduling",
+    "synthetic_reasoning_ppl/native/kmp_string_search",
+    "synthetic_reasoning_ppl/native/knapsack_01_dp",
+    "synthetic_reasoning_ppl/native/lcs_dp",
+    "synthetic_reasoning_ppl/native/lis_dp",
+    "synthetic_reasoning_ppl/native/n_queens_backtracking",
+    "synthetic_reasoning_ppl/native/parentheses_balance",
+    "synthetic_reasoning_ppl/native/prim_mst",
+    "synthetic_reasoning_ppl/native/propositional_entailment",
+    "synthetic_reasoning_ppl/native/topological_sort",
+    "synthetic_reasoning_ppl/native/union_find_connectivity",
+    "synthetic_reasoning_ppl/stepmath/algebra_linear_equation",
+    "synthetic_reasoning_ppl/stepmath/arithmetic",
+}
+
+REMOVED_LEGACY_ALIAS_KEYS = {
+    "synthetic_reasoning_ppl/native/binary_search_5shot_icl",
+    "synthetic_reasoning_ppl/native/edit_distance_dp_1shot_icl",
+    "synthetic_reasoning_ppl/native/euclid_gcd_5shot_icl",
+    "synthetic_reasoning_ppl/native/interval_scheduling_1shot_icl",
+    "synthetic_reasoning_ppl/native/kmp_string_search_1shot_icl",
+    "synthetic_reasoning_ppl/native/knapsack_01_dp_1shot_icl",
+    "synthetic_reasoning_ppl/native/lcs_dp_1shot_icl",
+    "synthetic_reasoning_ppl/native/n_queens_backtracking_1shot_icl",
+    "synthetic_reasoning_ppl/native/parentheses_balance_5shot_icl",
+    "synthetic_reasoning_ppl/native/union_find_connectivity_1shot_icl",
+    "synthetic_reasoning_ppl/stepmath/algebra_linear_equation_3shot_icl",
+    "synthetic_reasoning_ppl/stepmath/arithmetic_5shot_icl",
+}
+
+
+def test_synthetic_reasoning_registry_uses_pinned_arrow_icl_target_only_configs():
+    datasets = synthetic_reasoning_raw_validation_sets()
+
+    assert set(datasets) == EXPECTED_SYNTHETIC_REASONING_KEYS
+
+    for key in (
+        "synthetic_reasoning_ppl/native/euclid_gcd",
+        "synthetic_reasoning_ppl/native/connected_components",
+        "synthetic_reasoning_ppl/clrs_style/clrs_bfs",
+        "synthetic_reasoning_ppl/stepmath/arithmetic",
+    ):
+        dataset = datasets[key]
+        assert dataset.hf_dataset_id == SYNTHETIC_REASONING_HF_DATASET_ID
+        assert dataset.hf_dataset_revision == "0cedc373025ae08edf24e24d73eeda75980ddf8c"
+        assert dataset.hf_dataset_name is not None
+        assert dataset.hf_dataset_name.endswith("_arrow_5shot_icl")
+        assert dataset.input_key == "input"
+        assert dataset.target_key == "target"
+        assert "loss:target_only" in dataset.tags
+        assert f"icl_shots:{SYNTHETIC_REASONING_ICL_SHOTS}" in dataset.tags
+        assert f"prompt_format:{SYNTHETIC_REASONING_PROMPT_FORMAT}" in dataset.tags
+
+    assert datasets["synthetic_reasoning_ppl/native/euclid_gcd"].hf_dataset_name == ("native_euclid_gcd_arrow_5shot_icl")
+    assert datasets["synthetic_reasoning_ppl/clrs_style/clrs_bfs"].hf_dataset_name == (
+        "clrs_style_clrs_bfs_arrow_5shot_icl"
+    )
+
+
+def test_legacy_icl_slice_aliases_are_not_registered_twice():
+    datasets = synthetic_reasoning_raw_validation_sets()
+
+    assert datasets.keys().isdisjoint(REMOVED_LEGACY_ALIAS_KEYS)
+
+    assert datasets["synthetic_reasoning_ppl/stepmath/arithmetic"].hf_dataset_name == (
+        "stepmath_arithmetic_arrow_5shot_icl"
+    )
+    assert datasets["synthetic_reasoning_ppl/native/euclid_gcd"].hf_dataset_name == ("native_euclid_gcd_arrow_5shot_icl")

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -1,14 +1,15 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from marin.execution.executor import unwrap_versioned_value
+from marin.transform.conversation.adapters import InputDatasetFormat
+
 from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_METADATA_COLUMNS,
     FINEPROOFS_SFT_REVISION,
     INSTRUCTION_DATASET_NAME_TO_CONFIG,
     get_instruction_dataset,
 )
-from marin.execution.executor import unwrap_versioned_value
-from marin.transform.conversation.adapters import InputDatasetFormat
 
 
 def test_fineproofs_sft_datasets_are_registered():


### PR DESCRIPTION
Add the HF-backed synthetic reasoning PPL provider using the canonical arrow-ICL task names only, so legacy ICL aliases no longer double-count byte-identical slices. Thread HF dataset revisions through perplexity dataset configs so these evals are pinned for reproducible scoring.

Part of #5618