### PR TITLE
[evals] Add surface probe v2 generators

### DIFF
--- a/experiments/evals/synthetic_delimiter_format_ppl.py
+++ b/experiments/evals/synthetic_delimiter_format_ppl.py
@@ -1,0 +1,411 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""HF-backed delimiter, whitespace, and table-format target-only PPL slices."""
+
+from __future__ import annotations
+
+import csv
+import io
+import json
+import os
+import posixpath
+import random
+from collections.abc import Callable
+from dataclasses import dataclass
+from enum import StrEnum
+
+import fsspec
+from levanter.utils import fsspec_utils
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, supervised_text_dataset
+from marin.execution.step_spec import StepSpec
+from marin.processing.tokenize import HfDatasetSpec
+
+EPIC_5005 = 5005
+SYNTHETIC_DELIMITER_FORMAT_ISSUE = 5618
+SYNTHETIC_DELIMITER_FORMAT_HF_DATASET_ID = "marin-community/synth-delimiter-format-ppl"
+SYNTHETIC_DELIMITER_FORMAT_SOURCE = "generated_synthetic_delimiter_format_ppl_v1"
+SYNTHETIC_DELIMITER_FORMAT_HF_REVISION = "5d3d6dfdd1f1dd8a691099edade2f210d2f2e2e8"
+SYNTHETIC_DELIMITER_FORMAT_SEED = 6505
+EXAMPLES_PER_CONFIG = 1000
+LOCAL_SAMPLE_EXAMPLES_PER_CONFIG = 4
+RAW_SHARD_NAME = "data-00000-of-00001.jsonl.gz"
+
+
+class DelimiterFormatFamily(StrEnum):
+    DELIMITED_FIELDS = "delimited_fields"
+    TABLE_ROWS = "table_rows"
+    WHITESPACE_CONTROL = "whitespace_control"
+
+
+@dataclass(frozen=True)
+class DelimiterFormatPplSlice:
+    family: DelimiterFormatFamily
+    task_name: str
+    hf_config_name: str
+
+    @property
+    def registry_key(self) -> str:
+        return posixpath.join("synthetic_delimiter_format_ppl", self.family.value, self.task_name)
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        return (
+            "synthetic_delimiter_format_ppl",
+            f"epic:{EPIC_5005}",
+            f"issue:{SYNTHETIC_DELIMITER_FORMAT_ISSUE}",
+            f"family:{self.family.value}",
+            f"task:{self.task_name}",
+            f"seed:{SYNTHETIC_DELIMITER_FORMAT_SEED}",
+            f"examples:{EXAMPLES_PER_CONFIG}",
+            f"source:{SYNTHETIC_DELIMITER_FORMAT_SOURCE}",
+            f"hf_revision:{SYNTHETIC_DELIMITER_FORMAT_HF_REVISION}",
+            "loss:target_only",
+            "format:supervised",
+        )
+
+    def to_raw_text_dataset(self, *, hf_dataset_id: str) -> RawTextEvaluationDataset:
+        return supervised_text_dataset(
+            HfDatasetSpec(
+                id=hf_dataset_id,
+                name=self.hf_config_name,
+                revision=SYNTHETIC_DELIMITER_FORMAT_HF_REVISION,
+            ),
+            input_key="input",
+            target_key="target",
+            split="validation",
+            tags=self.tags,
+        )
+
+
+def _slice(
+    *,
+    family: DelimiterFormatFamily,
+    task_name: str,
+) -> DelimiterFormatPplSlice:
+    return DelimiterFormatPplSlice(
+        family=family,
+        task_name=task_name,
+        hf_config_name=task_name,
+    )
+
+
+SYNTHETIC_DELIMITER_FORMAT_PPL_SLICES: tuple[DelimiterFormatPplSlice, ...] = (
+    _slice(family=DelimiterFormatFamily.DELIMITED_FIELDS, task_name="tsv_next_field"),
+    _slice(family=DelimiterFormatFamily.DELIMITED_FIELDS, task_name="csv_next_field"),
+    _slice(family=DelimiterFormatFamily.DELIMITED_FIELDS, task_name="rare_control_delimiters"),
+    _slice(family=DelimiterFormatFamily.TABLE_ROWS, task_name="pipe_rows"),
+    _slice(family=DelimiterFormatFamily.TABLE_ROWS, task_name="fixed_width_rows"),
+    _slice(family=DelimiterFormatFamily.TABLE_ROWS, task_name="markdown_table_rows"),
+    _slice(family=DelimiterFormatFamily.WHITESPACE_CONTROL, task_name="aligned_space_columns"),
+    _slice(family=DelimiterFormatFamily.WHITESPACE_CONTROL, task_name="python_indentation_or_makefile_tabs"),
+)
+
+
+def synthetic_delimiter_format_raw_validation_sets(
+    *, hf_dataset_id: str = SYNTHETIC_DELIMITER_FORMAT_HF_DATASET_ID
+) -> dict[str, RawTextEvaluationDataset]:
+    return {
+        slice_.registry_key: slice_.to_raw_text_dataset(hf_dataset_id=hf_dataset_id)
+        for slice_ in SYNTHETIC_DELIMITER_FORMAT_PPL_SLICES
+    }
+
+
+def _record(
+    *,
+    task_name: str,
+    row_index: int,
+    seed: int,
+    input_text: str,
+    target: str,
+    metadata: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "id": f"{task_name}_{row_index:05d}",
+        "input": input_text,
+        "target": target,
+        "subset": task_name,
+        "task": task_name,
+        "seed": seed,
+        "metadata": metadata,
+    }
+
+
+def _word(rng: random.Random, prefix: str) -> str:
+    syllables = ("al", "br", "cy", "dox", "emi", "flux", "garn", "hel", "ion", "juno", "kest", "luma")
+    return prefix + rng.choice(syllables) + str(rng.randint(10, 99))
+
+
+def _csv_row(values: list[str]) -> str:
+    sink = io.StringIO()
+    writer = csv.writer(sink, lineterminator="")
+    writer.writerow(values)
+    return sink.getvalue()
+
+
+def _generate_tsv_next_field(rng: random.Random, row_index: int, seed: int) -> dict[str, object]:
+    columns = ("record_id", "batch", "status", "checksum")
+    rows = []
+    for offset in range(4):
+        rows.append(
+            [
+                f"rec-{row_index:04d}-{offset}",
+                _word(rng, "b"),
+                rng.choice(("queued", "ready", "blocked", "done")),
+                f"{rng.randrange(16**6):06x}",
+            ]
+        )
+    target_row = [
+        f"rec-{row_index:04d}-4",
+        _word(rng, "b"),
+        rng.choice(("queued", "ready", "blocked", "done")),
+        f"{rng.randrange(16**6):06x}",
+    ]
+    input_text = "\t".join(columns) + "\n" + "\n".join("\t".join(row) for row in rows) + "\n"
+    return _record(
+        task_name="tsv_next_field",
+        row_index=row_index,
+        seed=seed,
+        input_text=input_text,
+        target="\t".join(target_row) + "\n",
+        metadata={"delimiter": "\\t", "columns": columns, "target_columns": columns},
+    )
+
+
+def _generate_csv_next_field(rng: random.Random, row_index: int, seed: int) -> dict[str, object]:
+    columns = ("ticket", "owner", "note", "amount")
+    notes = ("needs, review", 'quoted "ok"', "plain", "comma, inside")
+    rows = []
+    for i in range(3):
+        rows.append(
+            [
+                f"T-{row_index:04d}-{i}",
+                _word(rng, "u"),
+                rng.choice(notes),
+                f"{rng.randint(100, 999)}.{rng.randint(0, 99):02d}",
+            ]
+        )
+    target_row = [
+        f"T-{row_index:04d}-3",
+        _word(rng, "u"),
+        rng.choice(notes),
+        f"{rng.randint(100, 999)}.{rng.randint(0, 99):02d}",
+    ]
+    input_text = _csv_row(list(columns)) + "\n" + "\n".join(_csv_row(row) for row in rows) + "\n"
+    return _record(
+        task_name="csv_next_field",
+        row_index=row_index,
+        seed=seed,
+        input_text=input_text,
+        target=_csv_row(target_row) + "\n",
+        metadata={"delimiter": ",", "quotechar": '"', "columns": columns, "target_columns": columns},
+    )
+
+
+def _generate_rare_control_delimiters(rng: random.Random, row_index: int, seed: int) -> dict[str, object]:
+    delimiter = rng.choice(("\x1f", "\x1e", "\x1d"))
+    delimiter_name = {"\x1f": "unit_separator", "\x1e": "record_separator", "\x1d": "group_separator"}[delimiter]
+    rows = []
+    for i in range(4):
+        rows.append([f"k{row_index:04d}_{i}", _word(rng, "v"), f"{rng.randint(1000, 9999)}"])
+    target_row = [f"k{row_index:04d}_4", _word(rng, "v"), f"{rng.randint(1000, 9999)}"]
+    input_text = "\n".join(delimiter.join(row) for row in rows) + "\n"
+    return _record(
+        task_name="rare_control_delimiters",
+        row_index=row_index,
+        seed=seed,
+        input_text=input_text,
+        target=delimiter.join(target_row) + "\n",
+        metadata={"delimiter_codepoint": f"U+{ord(delimiter):04X}", "delimiter_name": delimiter_name},
+    )
+
+
+def _generate_pipe_rows(rng: random.Random, row_index: int, seed: int) -> dict[str, object]:
+    rows = []
+    for i in range(4):
+        rows.append([f"node-{i}", rng.choice(("east", "west", "north", "south")), str(rng.randint(1, 9))])
+    target_row = ["node-4", rng.choice(("east", "west", "north", "south")), str(rng.randint(1, 9))]
+    input_text = "\n".join(" | ".join(row) for row in rows) + "\n"
+    return _record(
+        task_name="pipe_rows",
+        row_index=row_index,
+        seed=seed,
+        input_text=input_text,
+        target=" | ".join(target_row) + "\n",
+        metadata={"delimiter": "|", "space_padded": True},
+    )
+
+
+def _generate_fixed_width_rows(rng: random.Random, row_index: int, seed: int) -> dict[str, object]:
+    widths = (8, 10, 6)
+
+    def render(row: list[str]) -> str:
+        return f"{row[0]:<{widths[0]}}{row[1]:>{widths[1]}}{row[2]:>{widths[2]}}"
+
+    rows = [[f"A{row_index:03d}{i}", str(rng.randint(100, 9999)), f"{rng.randint(0, 99)}%"] for i in range(4)]
+    target_row = [f"A{row_index:03d}4", str(rng.randint(100, 9999)), f"{rng.randint(0, 99)}%"]
+    input_text = "\n".join(render(row) for row in rows) + "\n"
+    return _record(
+        task_name="fixed_width_rows",
+        row_index=row_index,
+        seed=seed,
+        input_text=input_text,
+        target=render(target_row) + "\n",
+        metadata={"widths": widths, "target_columns": (1, 2, 3)},
+    )
+
+
+def _generate_markdown_table_rows(rng: random.Random, row_index: int, seed: int) -> dict[str, object]:
+    columns = ("key", "mode", "value")
+    rows = [[f"`k{row_index}_{i}`", rng.choice(("read", "write", "sync")), str(rng.randint(10, 99))] for i in range(3)]
+    target_row = [f"`k{row_index}_3`", rng.choice(("read", "write", "sync")), str(rng.randint(10, 99))]
+    input_text = (
+        "| "
+        + " | ".join(columns)
+        + " |\n"
+        + "| --- | --- | --- |\n"
+        + "\n".join("| " + " | ".join(row) + " |" for row in rows)
+        + "\n"
+    )
+    return _record(
+        task_name="markdown_table_rows",
+        row_index=row_index,
+        seed=seed,
+        input_text=input_text,
+        target="| " + " | ".join(target_row) + " |\n",
+        metadata={"delimiter": "|", "table_format": "markdown"},
+    )
+
+
+def _generate_aligned_space_columns(rng: random.Random, row_index: int, seed: int) -> dict[str, object]:
+    widths = (12, 9, 7)
+
+    def render(row: list[str]) -> str:
+        return f"{row[0]:<{widths[0]}}{row[1]:>{widths[1]}}{row[2]:>{widths[2]}}"
+
+    rows = [[_word(rng, "col"), str(rng.randint(1, 999)), rng.choice(("ok", "hold", "fail"))] for _ in range(5)]
+    target_row = [_word(rng, "col"), str(rng.randint(1, 999)), rng.choice(("ok", "hold", "fail"))]
+    input_text = "\n".join(render(row) for row in rows) + "\n"
+    return _record(
+        task_name="aligned_space_columns",
+        row_index=row_index,
+        seed=seed,
+        input_text=input_text,
+        target=render(target_row) + "\n",
+        metadata={"widths": widths, "alignment": ("left", "right", "right")},
+    )
+
+
+def _generate_python_indentation_or_makefile_tabs(rng: random.Random, row_index: int, seed: int) -> dict[str, object]:
+    if rng.random() < 0.5:
+        indent = " " * rng.choice((4, 8))
+        item = _word(rng, "item")
+        input_text = (
+            "def normalize_example(items):\n"
+            "    total = 0\n"
+            "    for item in items:\n"
+            "        total += item.value\n"
+            "    return total\n\n"
+            f"def normalize_{row_index}(items):\n"
+            f"{indent}total = 0\n"
+            f"{indent}for item in items:\n"
+        )
+        target = f"{indent * 2}total += item.{item}\n{indent}return total\n"
+        metadata = {"format": "python", "indent": len(indent), "target_requires_leading_spaces": True}
+    else:
+        target_name = f"build_{row_index}"
+        command = rng.choice(("python -m pytest", "ruff check .", "mkdir -p dist", "touch $@"))
+        second_command = rng.choice(("python -m build", "ruff format .", "cp -r assets dist/", "chmod +x $@"))
+        input_text = (
+            "build_example: src/build_example.py\n"
+            "\tpython -m pytest\n"
+            "\tpython -m build\n\n"
+            f"{target_name}: src/{target_name}.py\n"
+        )
+        target = "\t" + command + "\n\t" + second_command + "\n"
+        metadata = {"format": "makefile", "target_requires_leading_tab": True}
+    return _record(
+        task_name="python_indentation_or_makefile_tabs",
+        row_index=row_index,
+        seed=seed,
+        input_text=input_text,
+        target=target,
+        metadata=metadata,
+    )
+
+
+_GENERATORS: dict[str, Callable[[random.Random, int, int], dict[str, object]]] = {
+    "tsv_next_field": _generate_tsv_next_field,
+    "csv_next_field": _generate_csv_next_field,
+    "rare_control_delimiters": _generate_rare_control_delimiters,
+    "pipe_rows": _generate_pipe_rows,
+    "fixed_width_rows": _generate_fixed_width_rows,
+    "markdown_table_rows": _generate_markdown_table_rows,
+    "aligned_space_columns": _generate_aligned_space_columns,
+    "python_indentation_or_makefile_tabs": _generate_python_indentation_or_makefile_tabs,
+}
+
+
+def iter_synthetic_delimiter_format_records(
+    *,
+    examples_per_config: int = EXAMPLES_PER_CONFIG,
+    seed: int = SYNTHETIC_DELIMITER_FORMAT_SEED,
+) -> tuple[dict[str, object], ...]:
+    records: list[dict[str, object]] = []
+    for config_index, slice_ in enumerate(SYNTHETIC_DELIMITER_FORMAT_PPL_SLICES):
+        rng = random.Random(seed + config_index * 1_000_003)
+        generator = _GENERATORS[slice_.task_name]
+        for row_index in range(examples_per_config):
+            records.append(generator(rng, row_index, seed))
+    return tuple(records)
+
+
+def materialize_synthetic_delimiter_format_raw(
+    output_path: str,
+    *,
+    examples_per_config: int = EXAMPLES_PER_CONFIG,
+    seed: int = SYNTHETIC_DELIMITER_FORMAT_SEED,
+) -> None:
+    fsspec_utils.mkdirs(output_path)
+    records_by_subset: dict[str, list[dict[str, object]]] = {
+        slice_.task_name: [] for slice_ in SYNTHETIC_DELIMITER_FORMAT_PPL_SLICES
+    }
+    for record in iter_synthetic_delimiter_format_records(examples_per_config=examples_per_config, seed=seed):
+        records_by_subset[str(record["subset"])].append(record)
+
+    for subset, records in records_by_subset.items():
+        output_file = os.path.join(output_path, subset, RAW_SHARD_NAME)
+        fsspec_utils.mkdirs(os.path.dirname(output_file))
+        with fsspec.open(output_file, "wt", compression="gzip") as sink:
+            for record in records:
+                sink.write(json.dumps(record, ensure_ascii=True, separators=(",", ":")))
+                sink.write("\n")
+
+
+synthetic_delimiter_format_raw = StepSpec(
+    name=os.path.join("raw", "evals", "synthetic_delimiter_format_ppl"),
+    fn=materialize_synthetic_delimiter_format_raw,
+    hash_attrs={
+        "source": SYNTHETIC_DELIMITER_FORMAT_SOURCE,
+        "examples_per_config": EXAMPLES_PER_CONFIG,
+        "seed": SYNTHETIC_DELIMITER_FORMAT_SEED,
+        "schema": ("input", "target", "id", "subset", "task", "seed", "metadata"),
+    },
+)
+
+
+def write_local_sample_jsonl(
+    output_file: str,
+    *,
+    examples_per_config: int = LOCAL_SAMPLE_EXAMPLES_PER_CONFIG,
+    seed: int = SYNTHETIC_DELIMITER_FORMAT_SEED,
+) -> None:
+    fsspec_utils.mkdirs(os.path.dirname(output_file))
+    with fsspec.open(output_file, "wt") as sink:
+        for record in iter_synthetic_delimiter_format_records(examples_per_config=examples_per_config, seed=seed):
+            sink.write(json.dumps(record, ensure_ascii=True, separators=(",", ":")))
+            sink.write("\n")
+
+
+if __name__ == "__main__":
+    write_local_sample_jsonl("/tmp/marin_synthetic_delimiter_format_ppl_sample.jsonl")

--- a/experiments/evals/synthetic_identifier_encoding_ppl.py
+++ b/experiments/evals/synthetic_identifier_encoding_ppl.py
@@ -1,0 +1,355 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""HF-backed identifier grammar and encoded-text PPL validation slices."""
+
+from __future__ import annotations
+
+import argparse
+import base64
+import json
+import posixpath
+import random
+import string
+import uuid
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+from urllib.parse import quote
+
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, supervised_text_dataset
+from marin.processing.tokenize import HfDatasetSpec
+
+EPIC_5005 = 5005
+IDENTIFIER_ENCODING_ISSUE = 5618
+IDENTIFIER_ENCODING_HF_DATASET_ID = "marin-community/synth-identifier-encoding-ppl"
+IDENTIFIER_ENCODING_SOURCE = "generated_identifier_encoding_ppl_v1"
+IDENTIFIER_ENCODING_HF_REVISION = "8e12c75bb1c9f4fed228b99d22f636ca426cf9b4"
+IDENTIFIER_ENCODING_SEED = 5615
+EXAMPLES_PER_CONFIG = 1000
+
+
+class IdentifierEncodingFamily(StrEnum):
+    IDENTIFIER_GRAMMARS = "identifier_grammars"
+    ENCODED_TEXT = "encoded_text"
+    ESCAPED_TEXT = "escaped_text"
+
+
+@dataclass(frozen=True)
+class IdentifierEncodingPplSlice:
+    family: IdentifierEncodingFamily
+    task_name: str
+    hf_config_name: str
+
+    @property
+    def registry_key(self) -> str:
+        return posixpath.join("synthetic_identifier_encoding_ppl", self.family.value, self.task_name)
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        return (
+            "synthetic_identifier_encoding_ppl",
+            f"epic:{EPIC_5005}",
+            f"issue:{IDENTIFIER_ENCODING_ISSUE}",
+            f"family:{self.family.value}",
+            f"task:{self.task_name}",
+            f"seed:{IDENTIFIER_ENCODING_SEED}",
+            f"examples:{EXAMPLES_PER_CONFIG}",
+            f"source:{IDENTIFIER_ENCODING_SOURCE}",
+            f"hf_revision:{IDENTIFIER_ENCODING_HF_REVISION}",
+            "loss:target_only",
+        )
+
+    def to_raw_text_dataset(self, *, hf_dataset_id: str) -> RawTextEvaluationDataset:
+        return supervised_text_dataset(
+            HfDatasetSpec(
+                id=hf_dataset_id,
+                name=self.hf_config_name,
+                revision=IDENTIFIER_ENCODING_HF_REVISION,
+            ),
+            input_key="input",
+            target_key="target",
+            split="validation",
+            tags=self.tags,
+        )
+
+
+IDENTIFIER_ENCODING_PPL_SLICES: tuple[IdentifierEncodingPplSlice, ...] = (
+    IdentifierEncodingPplSlice(
+        family=IdentifierEncodingFamily.IDENTIFIER_GRAMMARS,
+        task_name="package_names_versions",
+        hf_config_name="package_names_versions",
+    ),
+    IdentifierEncodingPplSlice(
+        family=IdentifierEncodingFamily.IDENTIFIER_GRAMMARS,
+        task_name="commit_hashes",
+        hf_config_name="commit_hashes",
+    ),
+    IdentifierEncodingPplSlice(
+        family=IdentifierEncodingFamily.IDENTIFIER_GRAMMARS,
+        task_name="uuid_build_ids",
+        hf_config_name="uuid_build_ids",
+    ),
+    IdentifierEncodingPplSlice(
+        family=IdentifierEncodingFamily.IDENTIFIER_GRAMMARS,
+        task_name="bio_accessions",
+        hf_config_name="bio_accessions",
+    ),
+    IdentifierEncodingPplSlice(
+        family=IdentifierEncodingFamily.IDENTIFIER_GRAMMARS,
+        task_name="mixed_case_symbolic_identifiers",
+        hf_config_name="mixed_case_symbolic_identifiers",
+    ),
+    IdentifierEncodingPplSlice(
+        family=IdentifierEncodingFamily.ENCODED_TEXT,
+        task_name="base64_continuation",
+        hf_config_name="base64_continuation",
+    ),
+    IdentifierEncodingPplSlice(
+        family=IdentifierEncodingFamily.ENCODED_TEXT,
+        task_name="data_image_base64_prefixes",
+        hf_config_name="data_image_base64_prefixes",
+    ),
+    IdentifierEncodingPplSlice(
+        family=IdentifierEncodingFamily.ENCODED_TEXT,
+        task_name="hex_dump_continuation",
+        hf_config_name="hex_dump_continuation",
+    ),
+    IdentifierEncodingPplSlice(
+        family=IdentifierEncodingFamily.ESCAPED_TEXT,
+        task_name="url_query_escaping",
+        hf_config_name="url_query_escaping",
+    ),
+    IdentifierEncodingPplSlice(
+        family=IdentifierEncodingFamily.ESCAPED_TEXT,
+        task_name="json_unicode_byte_escapes",
+        hf_config_name="json_unicode_byte_escapes",
+    ),
+)
+
+
+def identifier_encoding_raw_validation_sets(
+    *,
+    hf_dataset_id: str = IDENTIFIER_ENCODING_HF_DATASET_ID,
+) -> dict[str, RawTextEvaluationDataset]:
+    return {
+        slice_.registry_key: slice_.to_raw_text_dataset(hf_dataset_id=hf_dataset_id)
+        for slice_ in IDENTIFIER_ENCODING_PPL_SLICES
+    }
+
+
+def generate_identifier_encoding_rows(
+    slice_: IdentifierEncodingPplSlice,
+    *,
+    examples: int = EXAMPLES_PER_CONFIG,
+    seed: int = IDENTIFIER_ENCODING_SEED,
+) -> list[dict[str, Any]]:
+    rows: list[dict[str, Any]] = []
+    slice_offset = IDENTIFIER_ENCODING_PPL_SLICES.index(slice_) * 1_000_003
+    for row_index in range(examples):
+        rng = random.Random(seed + slice_offset + row_index)
+        input_text, target, metadata = _example_for_task(slice_.task_name, rng)
+        rows.append(
+            {
+                "input": input_text,
+                "target": target,
+                "id": f"{slice_.hf_config_name}-{row_index:06d}",
+                "subset": slice_.hf_config_name,
+                "task": slice_.task_name,
+                "seed": seed,
+                "metadata": {
+                    "family": slice_.family.value,
+                    "row_index": row_index,
+                    **metadata,
+                },
+            }
+        )
+    return rows
+
+
+def write_identifier_encoding_jsonl_configs(
+    output_dir: str | Path,
+    *,
+    examples: int = EXAMPLES_PER_CONFIG,
+    seed: int = IDENTIFIER_ENCODING_SEED,
+) -> Path:
+    path = Path(output_dir)
+    path.mkdir(parents=True, exist_ok=True)
+    for slice_ in IDENTIFIER_ENCODING_PPL_SLICES:
+        output_file = path / f"{slice_.hf_config_name}.jsonl"
+        with output_file.open("w", encoding="utf-8") as handle:
+            for row in generate_identifier_encoding_rows(slice_, examples=examples, seed=seed):
+                handle.write(json.dumps(row, sort_keys=True) + "\n")
+    return path
+
+
+def generate_tiny_identifier_encoding_sample(*, seed: int = IDENTIFIER_ENCODING_SEED) -> list[dict[str, Any]]:
+    """Generate one schema-valid sample row per slice for local inspection."""
+    rows: list[dict[str, Any]] = []
+    for slice_ in IDENTIFIER_ENCODING_PPL_SLICES:
+        rows.extend(generate_identifier_encoding_rows(slice_, examples=1, seed=seed))
+    return rows
+
+
+def write_tiny_identifier_encoding_sample(
+    output_path: str | Path = Path(__file__).with_name("synthetic_identifier_encoding_ppl_sample.jsonl"),
+    *,
+    seed: int = IDENTIFIER_ENCODING_SEED,
+) -> Path:
+    path = Path(output_path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as handle:
+        for row in generate_tiny_identifier_encoding_sample(seed=seed):
+            handle.write(json.dumps(row, sort_keys=True) + "\n")
+    return path
+
+
+def _example_for_task(task_name: str, rng: random.Random) -> tuple[str, str, dict[str, Any]]:
+    if task_name == "package_names_versions":
+        scope = rng.choice(("@marin", "@levanter", "@haliax"))
+        package = f"{scope}/{_kebab_identifier(rng)}"
+        version = f"{rng.randint(0, 9)}.{rng.randint(0, 20)}.{rng.randint(0, 30)}"
+        return (
+            f'"node_modules/{scope}/": ' + '{"resolved":"https://registry.npmjs.org/',
+            f"{package}/-/{package.split('/')[-1]}-{version}.tgz\"}}\n",
+            {"grammar": "npm_package_tarball", "version": version},
+        )
+
+    if task_name == "commit_hashes":
+        prefix = _hex(rng, 12)
+        suffix = _hex(rng, 28)
+        return (
+            f'source_commit = "{prefix}',
+            f'{suffix}"\n',
+            {"grammar": "sha1_hex", "prefix_length": len(prefix)},
+        )
+
+    if task_name == "uuid_build_ids":
+        value = str(uuid.UUID(int=rng.getrandbits(128)))
+        cutoff = rng.choice((8, 13, 18))
+        return (
+            f'org.opencontainers.image.revision="{value[:cutoff]}',
+            f'{value[cutoff:]}"\n',
+            {"grammar": "uuid4_like", "prefix_length": cutoff},
+        )
+
+    if task_name == "bio_accessions":
+        prefix = rng.choice(("NM_", "XM_", "XP_", "SRR", "ERR", "GCA_"))
+        digits = "".join(rng.choice(string.digits) for _ in range(9))
+        accession = f"{prefix}{digits}.{rng.randint(1, 9)}"
+        cutoff = rng.randint(3, min(8, len(accession) - 2))
+        return (
+            f"sample_id\torganism\taccession\nS{rng.randint(100, 999)}\tH_sapiens\t{accession[:cutoff]}",
+            f"{accession[cutoff:]}\n",
+            {"grammar": "bio_accession", "accession_prefix": prefix},
+        )
+
+    if task_name == "mixed_case_symbolic_identifiers":
+        identifier = f"{_camel_identifier(rng)}::{_snake_identifier(rng)}::{_constant_identifier(rng)}"
+        cutoff = rng.randint(8, len(identifier) - 4)
+        return (
+            f"symbol={identifier[:cutoff]}",
+            f"{identifier[cutoff:]}\n",
+            {"grammar": "mixed_case_symbol_path", "prefix_length": cutoff},
+        )
+
+    if task_name == "base64_continuation":
+        payload = bytes(rng.randrange(256) for _ in range(48))
+        encoded = base64.b64encode(payload).decode("ascii")
+        cutoff = 24
+        return (
+            f'payload_b64="{encoded[:cutoff]}',
+            f'{encoded[cutoff:]}"\n',
+            {"grammar": "base64", "payload_bytes": len(payload)},
+        )
+
+    if task_name == "data_image_base64_prefixes":
+        mime = rng.choice(("png", "jpeg", "gif", "webp"))
+        header = f"data:image/{mime};base64,"
+        encoded = base64.b64encode(bytes(rng.randrange(256) for _ in range(36))).decode("ascii")
+        return (
+            f'<img alt="sparkline" src="{header}',
+            f'{encoded}">\n',
+            {"grammar": "data_uri_image_base64", "mime": f"image/{mime}"},
+        )
+
+    if task_name == "hex_dump_continuation":
+        offset = rng.randrange(0x1000, 0x9000, 16)
+        byte_values = [rng.randrange(256) for _ in range(16)]
+        left = " ".join(f"{value:02x}" for value in byte_values[:8])
+        right = " ".join(f"{value:02x}" for value in byte_values[8:])
+        return (
+            f"{offset:08x}  {left}  ",
+            f"{right}  |{_ascii_gutter(byte_values)}|\n",
+            {"grammar": "hexdump", "offset": offset},
+        )
+
+    if task_name == "url_query_escaping":
+        raw_value = rng.choice(("alpha beta/gamma", 'json:{"x":1}', "email=a+b@example.com"))
+        escaped = quote(raw_value, safe="")
+        cutoff = rng.randint(6, len(escaped) - 3)
+        return (
+            f"https://example.invalid/search?q={escaped[:cutoff]}",
+            f"{escaped[cutoff:]}&src=eval\n",
+            {"grammar": "percent_encoded_query", "raw_value": raw_value},
+        )
+
+    if task_name == "json_unicode_byte_escapes":
+        escaped = "".join(f"\\u{rng.randrange(0x20, 0x7F):04x}" for _ in range(6))
+        byte_escapes = "".join(f"\\x{rng.randrange(256):02x}" for _ in range(4))
+        value = f"{escaped}{byte_escapes}"
+        cutoff = rng.randrange(6, len(value) - 4, 2)
+        return (
+            '{"escaped":"' f"{value[:cutoff]}",
+            f'{value[cutoff:]}"}}\n',
+            {"grammar": "json_unicode_and_byte_escapes", "prefix_length": cutoff},
+        )
+
+    raise ValueError(f"Unknown identifier encoding task: {task_name}")
+
+
+def _hex(rng: random.Random, n_chars: int) -> str:
+    return "".join(rng.choice("0123456789abcdef") for _ in range(n_chars))
+
+
+def _kebab_identifier(rng: random.Random) -> str:
+    return "-".join(_word(rng).lower() for _ in range(rng.randint(2, 4)))
+
+
+def _snake_identifier(rng: random.Random) -> str:
+    return "_".join(_word(rng).lower() for _ in range(rng.randint(2, 3)))
+
+
+def _constant_identifier(rng: random.Random) -> str:
+    return "_".join(_word(rng).upper() for _ in range(rng.randint(2, 3)))
+
+
+def _camel_identifier(rng: random.Random) -> str:
+    words = [_word(rng) for _ in range(rng.randint(2, 4))]
+    return words[0].lower() + "".join(word.title() for word in words[1:])
+
+
+def _word(rng: random.Random) -> str:
+    alphabet = string.ascii_lowercase
+    return rng.choice(alphabet) + "".join(rng.choice(alphabet + string.digits) for _ in range(rng.randint(3, 7)))
+
+
+def _ascii_gutter(byte_values: Iterable[int]) -> str:
+    return "".join(chr(value) if 32 <= value <= 126 else "." for value in byte_values)
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate synthetic identifier/encoding PPL JSONL configs.")
+    parser.add_argument("--output-dir", type=Path)
+    parser.add_argument("--examples", type=int, default=EXAMPLES_PER_CONFIG)
+    args = parser.parse_args()
+    if args.output_dir is None:
+        print(write_tiny_identifier_encoding_sample())
+    else:
+        print(write_identifier_encoding_jsonl_configs(args.output_dir, examples=args.examples))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/evals/synthetic_machine_records_ppl.py
+++ b/experiments/evals/synthetic_machine_records_ppl.py
@@ -192,10 +192,14 @@ def _choice(rng: random.Random, values: tuple[str, ...]) -> str:
     return values[rng.randrange(len(values))]
 
 
+def _clock_field(value: int) -> int:
+    return value % 60
+
+
 def _service_log_record(
     slice_: MachineRecordPplSlice, index: int, rng: random.Random
 ) -> tuple[str, str, dict[str, Any]]:
-    minute = 10 + index
+    minute = _clock_field(10 + index)
     host = f"node-{rng.randint(1, 9):02d}"
     pod = f"api-{rng.randrange(1000, 9999)}"
     if slice_.subset == "zeek":
@@ -269,10 +273,11 @@ def _trace_error_record(
 
 def _ci_log_record(slice_: MachineRecordPplSlice, index: int, rng: random.Random) -> tuple[str, str, dict[str, Any]]:
     step = _choice(rng, ("Install dependencies", "Run unit tests", "Build image", "Upload coverage"))
+    minute = _clock_field(20 + index)
     input_text = _base_prompt(
         slice_.subset,
         slice_.task_name,
-        f"2026-05-11T14:{20 + index:02d}:00.0000000Z ##[group]{step}\n"
+        f"2026-05-11T14:{minute:02d}:00.0000000Z ##[group]{step}\n"
         "2026-05-11T14:20:01.0000000Z shell: /usr/bin/bash -e {0}\n"
         "2026-05-11T14:20:02.0000000Z ",
     )
@@ -282,6 +287,7 @@ def _ci_log_record(slice_: MachineRecordPplSlice, index: int, rng: random.Random
 
 def _json_log_record(slice_: MachineRecordPplSlice, index: int, rng: random.Random) -> tuple[str, str, dict[str, Any]]:
     request_id = f"req-{rng.randrange(16**10):010x}"
+    second = _clock_field(10 + index)
     input_text = _base_prompt(
         slice_.subset,
         slice_.task_name,
@@ -294,7 +300,7 @@ def _json_log_record(slice_: MachineRecordPplSlice, index: int, rng: random.Rand
         "latency_ms": rng.randint(12, 900),
         "message": "request completed",
     }
-    target = f'{10 + index:02d}Z",' + json.dumps(target_obj, sort_keys=True)[1:] + "\n"
+    target = f'{second:02d}Z",' + json.dumps(target_obj, sort_keys=True)[1:] + "\n"
     return input_text, target, {"request_id": request_id}
 
 

--- a/experiments/evals/synthetic_machine_records_ppl.py
+++ b/experiments/evals/synthetic_machine_records_ppl.py
@@ -1,0 +1,416 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""HF-backed synthetic machine-record PPL validation slices.
+
+These slices are supervised target-only probes for machine-generated records:
+logs, events, stack traces, config files, and manifests. The prompt is plain
+base-model continuation context; only the held-out target continuation should
+contribute to loss.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import posixpath
+import random
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+from typing import Any
+
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, supervised_text_dataset
+from marin.processing.tokenize import HfDatasetSpec
+
+EPIC_5005 = 5005
+SYNTHETIC_MACHINE_RECORDS_ISSUE = 5618
+SYNTHETIC_MACHINE_RECORDS_HF_DATASET_ID = "marin-community/synth-machine-records-ppl"
+SYNTHETIC_MACHINE_RECORDS_SOURCE = "generated_synthetic_machine_records_ppl_v1"
+SYNTHETIC_MACHINE_RECORDS_HF_REVISION = "5efd713c2781e0a1a82dd850acd7d8de14f81748"
+SYNTHETIC_MACHINE_RECORDS_SEED = 20260511
+EXAMPLES_PER_CONFIG = 1000
+
+
+class MachineRecordFamily(StrEnum):
+    SERVICE_LOGS = "service_logs"
+    TRACE_ERRORS = "trace_errors"
+    CI_LOGS = "ci_logs"
+    STRUCTURED_LOGS = "structured_logs"
+    CONFIG_MANIFESTS = "config_manifests"
+
+
+@dataclass(frozen=True)
+class MachineRecordPplSlice:
+    family: MachineRecordFamily
+    task_name: str
+    hf_config_name: str
+    subset: str
+
+    @property
+    def registry_key(self) -> str:
+        return posixpath.join("synthetic_machine_records_ppl", self.family.value, self.task_name)
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        return (
+            "synthetic_machine_records_ppl",
+            f"epic:{EPIC_5005}",
+            f"issue:{SYNTHETIC_MACHINE_RECORDS_ISSUE}",
+            f"family:{self.family.value}",
+            f"task:{self.task_name}",
+            f"subset:{self.subset}",
+            f"seed:{SYNTHETIC_MACHINE_RECORDS_SEED}",
+            f"examples:{EXAMPLES_PER_CONFIG}",
+            f"source:{SYNTHETIC_MACHINE_RECORDS_SOURCE}",
+            f"hf_revision:{SYNTHETIC_MACHINE_RECORDS_HF_REVISION}",
+            "loss:target_only",
+        )
+
+    def to_raw_text_dataset(self, *, hf_dataset_id: str) -> RawTextEvaluationDataset:
+        return supervised_text_dataset(
+            HfDatasetSpec(
+                id=hf_dataset_id,
+                name=self.hf_config_name,
+                revision=SYNTHETIC_MACHINE_RECORDS_HF_REVISION,
+            ),
+            input_key="input",
+            target_key="target",
+            split="validation",
+            tags=self.tags,
+        )
+
+
+MACHINE_RECORD_PPL_SLICES: tuple[MachineRecordPplSlice, ...] = (
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.SERVICE_LOGS,
+        task_name="zeek_conn_http_dns",
+        hf_config_name="service_logs_zeek_conn_http_dns",
+        subset="zeek",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.SERVICE_LOGS,
+        task_name="nginx_access_error",
+        hf_config_name="service_logs_nginx_access_error",
+        subset="nginx",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.SERVICE_LOGS,
+        task_name="k8s_system_events",
+        hf_config_name="service_logs_k8s_system_events",
+        subset="k8s",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.SERVICE_LOGS,
+        task_name="systemd_journal",
+        hf_config_name="service_logs_systemd_journal",
+        subset="system",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.TRACE_ERRORS,
+        task_name="python_tracebacks",
+        hf_config_name="trace_errors_python_tracebacks",
+        subset="python_traceback",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.TRACE_ERRORS,
+        task_name="compiler_errors",
+        hf_config_name="trace_errors_compiler_errors",
+        subset="compiler",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.CI_LOGS,
+        task_name="github_actions_jobs",
+        hf_config_name="ci_logs_github_actions_jobs",
+        subset="github_actions",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.STRUCTURED_LOGS,
+        task_name="json_application_logs",
+        hf_config_name="structured_logs_json_application_logs",
+        subset="json_logs",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.CONFIG_MANIFESTS,
+        task_name="package_json",
+        hf_config_name="config_manifests_package_json",
+        subset="package_json",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.CONFIG_MANIFESTS,
+        task_name="pyproject_toml",
+        hf_config_name="config_manifests_pyproject_toml",
+        subset="pyproject",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.CONFIG_MANIFESTS,
+        task_name="github_actions_yaml",
+        hf_config_name="config_manifests_github_actions_yaml",
+        subset="github_actions_yaml",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.CONFIG_MANIFESTS,
+        task_name="dockerfile",
+        hf_config_name="config_manifests_dockerfile",
+        subset="dockerfile",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.CONFIG_MANIFESTS,
+        task_name="terraform_hcl",
+        hf_config_name="config_manifests_terraform_hcl",
+        subset="terraform",
+    ),
+    MachineRecordPplSlice(
+        family=MachineRecordFamily.CONFIG_MANIFESTS,
+        task_name="kubernetes_yaml",
+        hf_config_name="config_manifests_kubernetes_yaml",
+        subset="kubernetes_yaml",
+    ),
+)
+
+
+def synthetic_machine_records_raw_validation_sets(
+    *,
+    hf_dataset_id: str = SYNTHETIC_MACHINE_RECORDS_HF_DATASET_ID,
+) -> dict[str, RawTextEvaluationDataset]:
+    return {
+        slice_.registry_key: slice_.to_raw_text_dataset(hf_dataset_id=hf_dataset_id)
+        for slice_ in MACHINE_RECORD_PPL_SLICES
+    }
+
+
+Record = dict[str, Any]
+RecordGenerator = Callable[[MachineRecordPplSlice, int, random.Random], tuple[str, str, dict[str, Any]]]
+
+
+def _base_prompt(_subset: str, _task: str, context: str) -> str:
+    return context
+
+
+def _choice(rng: random.Random, values: tuple[str, ...]) -> str:
+    return values[rng.randrange(len(values))]
+
+
+def _service_log_record(
+    slice_: MachineRecordPplSlice, index: int, rng: random.Random
+) -> tuple[str, str, dict[str, Any]]:
+    minute = 10 + index
+    host = f"node-{rng.randint(1, 9):02d}"
+    pod = f"api-{rng.randrange(1000, 9999)}"
+    if slice_.subset == "zeek":
+        uid = f"C{rng.randrange(10**8, 10**9)}"
+        input_text = _base_prompt(
+            slice_.subset,
+            slice_.task_name,
+            "#separator \\x09\n#set_separator\t,\n#fields\tts\tuid\tid.orig_h\tid.resp_h\tproto\tservice\tduration\n"
+            f"171543{minute}.120000\t{uid}\t10.4.1.{rng.randint(2, 240)}\t172.16.8.{rng.randint(2, 240)}\t",
+        )
+        target = f"tcp\thttp\t0.{rng.randint(100000, 999999)}\n"
+    elif slice_.subset == "nginx":
+        input_text = _base_prompt(
+            slice_.subset,
+            slice_.task_name,
+            f'10.12.4.{rng.randint(2, 240)} - - [11/May/2026:14:{minute}:02 +0000] "GET /v1/',
+        )
+        target = f'healthz HTTP/1.1" 200 {rng.randint(42, 512)} "-" "kube-probe/1.30"\n'
+    elif slice_.subset == "k8s":
+        input_text = _base_prompt(
+            slice_.subset,
+            slice_.task_name,
+            f"{minute}m Normal Pulled pod/{pod} Successfully pulled image ",
+        )
+        target = f'"registry.local/{pod}:sha-{rng.randrange(16**8):08x}" in {rng.randint(1, 9)}.{rng.randint(10, 99)}s\n'
+    else:
+        input_text = _base_prompt(
+            slice_.subset,
+            slice_.task_name,
+            f"May 11 14:{minute}:17 {host} systemd[1]: ",
+        )
+        target = f"Started {_choice(rng, ('container runtime', 'session cleanup', 'log rotation'))} service.\n"
+    return input_text, target, {"host": host, "minute": minute}
+
+
+def _trace_error_record(
+    slice_: MachineRecordPplSlice, index: int, rng: random.Random
+) -> tuple[str, str, dict[str, Any]]:
+    module = _choice(rng, ("loader", "scheduler", "serializer", "worker"))
+    if slice_.subset == "python_traceback":
+        line = rng.randint(40, 240)
+        input_text = _base_prompt(
+            slice_.subset,
+            slice_.task_name,
+            "Traceback (most recent call last):\n"
+            f'  File "/srv/app/{module}.py", line {line}, in run\n'
+            '    result = handler(payload["items"])\n'
+            f'  File "/srv/app/{module}.py", line {line + 18}, in handler\n'
+            '    return items[0]["',
+        )
+        missing_key = _choice(rng, ("status", "checksum", "tenant_id"))
+        target = f"{missing_key}\"]\nKeyError: '{missing_key}'\n"
+        return input_text, target, {"module": module, "line": line}
+
+    file_name = f"src/{module}.rs"
+    line = rng.randint(8, 160)
+    input_text = _base_prompt(
+        slice_.subset,
+        slice_.task_name,
+        f"error[E0308]: mismatched types\n  --> {file_name}:{line}:",
+    )
+    returned = _choice(rng, ("None", "0", "payload"))
+    target = (
+        f"{rng.randint(5, 80)}\n"
+        "   |\n"
+        f"{line} |     return {returned};\n"
+        "   |            ^^^^^ expected `Result<Job, Error>`, found `Option<_>`\n"
+    )
+    return input_text, target, {"file": file_name, "line": line}
+
+
+def _ci_log_record(slice_: MachineRecordPplSlice, index: int, rng: random.Random) -> tuple[str, str, dict[str, Any]]:
+    step = _choice(rng, ("Install dependencies", "Run unit tests", "Build image", "Upload coverage"))
+    input_text = _base_prompt(
+        slice_.subset,
+        slice_.task_name,
+        f"2026-05-11T14:{20 + index:02d}:00.0000000Z ##[group]{step}\n"
+        "2026-05-11T14:20:01.0000000Z shell: /usr/bin/bash -e {0}\n"
+        "2026-05-11T14:20:02.0000000Z ",
+    )
+    target = f"##[command]{_choice(rng, ('uv run pytest tests', 'docker build -t app:${{ github.sha }} .', 'npm ci'))}\n"
+    return input_text, target, {"ci_step": step}
+
+
+def _json_log_record(slice_: MachineRecordPplSlice, index: int, rng: random.Random) -> tuple[str, str, dict[str, Any]]:
+    request_id = f"req-{rng.randrange(16**10):010x}"
+    input_text = _base_prompt(
+        slice_.subset,
+        slice_.task_name,
+        '{"ts":"2026-05-11T14:32:',
+    )
+    target_obj = {
+        "level": _choice(rng, ("INFO", "WARN", "ERROR")),
+        "service": _choice(rng, ("api", "billing", "worker")),
+        "request_id": request_id,
+        "latency_ms": rng.randint(12, 900),
+        "message": "request completed",
+    }
+    target = f'{10 + index:02d}Z",' + json.dumps(target_obj, sort_keys=True)[1:] + "\n"
+    return input_text, target, {"request_id": request_id}
+
+
+def _manifest_record(slice_: MachineRecordPplSlice, index: int, rng: random.Random) -> tuple[str, str, dict[str, Any]]:
+    name = f"svc-{rng.randint(10, 99)}"
+    if slice_.subset == "package_json":
+        input_text = _base_prompt(
+            slice_.subset,
+            slice_.task_name,
+            '{\n  "name": "@example/service",\n  "version": "0.',
+        )
+        target = (
+            f'{index}.0",\n'
+            '  "scripts": {"test": "vitest run", "build": "tsc -p tsconfig.json"},\n'
+            '  "dependencies": {"zod": "^3.23.8"}\n'
+            "}\n"
+        )
+    elif slice_.subset == "pyproject":
+        input_text = _base_prompt(
+            slice_.subset,
+            slice_.task_name,
+            '[project]\nname = "machine-records"\nversion = "0.',
+        )
+        target = (
+            f'{index}.0"\n'
+            'requires-python = ">=3.11"\n'
+            'dependencies = ["pydantic>=2", "rich>=13"]\n\n'
+            "[tool.pytest.ini_options]\n"
+            'addopts = "-q"\n'
+        )
+    elif slice_.subset == "github_actions_yaml":
+        input_text = _base_prompt(
+            slice_.subset, slice_.task_name, "name: ci\non:\n  pull_request:\n\njobs:\n  test:\n    runs-on: "
+        )
+        target = (
+            "ubuntu-latest\n"
+            "    steps:\n"
+            "      - uses: actions/checkout@v4\n"
+            "      - uses: astral-sh/setup-uv@v5\n"
+            "      - run: uv run pytest\n"
+        )
+    elif slice_.subset == "dockerfile":
+        input_text = _base_prompt(
+            slice_.subset, slice_.task_name, "FROM python:3.12-slim\nWORKDIR /app\nCOPY pyproject.toml uv.lock ./\nRUN "
+        )
+        target = 'pip install uv && uv sync --frozen --no-dev\nCOPY . .\nCMD ["python", "-m", "service.main"]\n'
+    elif slice_.subset == "terraform":
+        input_text = _base_prompt(slice_.subset, slice_.task_name, 'resource "aws_s3_bucket" "logs" {\n  bucket = "')
+        target = f'{name}-logs"\n  force_destroy = false\n\n  tags = {{\n    Environment = "staging"\n  }}\n}}\n'
+    else:
+        input_text = _base_prompt(
+            slice_.subset, slice_.task_name, "apiVersion: apps/v1\nkind: Deployment\nmetadata:\n  name: "
+        )
+        target = f"{name}\nspec:\n  replicas: {rng.randint(2, 5)}\n  selector:\n    matchLabels:\n      app: {name}\n"
+    return input_text, target, {"name": name}
+
+
+_GENERATORS_BY_FAMILY: dict[MachineRecordFamily, RecordGenerator] = {
+    MachineRecordFamily.SERVICE_LOGS: _service_log_record,
+    MachineRecordFamily.TRACE_ERRORS: _trace_error_record,
+    MachineRecordFamily.CI_LOGS: _ci_log_record,
+    MachineRecordFamily.STRUCTURED_LOGS: _json_log_record,
+    MachineRecordFamily.CONFIG_MANIFESTS: _manifest_record,
+}
+
+
+def machine_record_example(
+    slice_: MachineRecordPplSlice, index: int, *, seed: int = SYNTHETIC_MACHINE_RECORDS_SEED
+) -> Record:
+    rng = random.Random(seed + index * 1009 + sum(ord(ch) for ch in slice_.registry_key))
+    input_text, target, metadata = _GENERATORS_BY_FAMILY[slice_.family](slice_, index, rng)
+    return {
+        "input": input_text,
+        "target": target,
+        "id": f"{slice_.hf_config_name}-{index:06d}",
+        "subset": slice_.subset,
+        "task": slice_.task_name,
+        "seed": seed,
+        "metadata": {
+            "family": slice_.family.value,
+            "hf_config_name": slice_.hf_config_name,
+            **metadata,
+        },
+    }
+
+
+def iter_machine_record_examples(
+    *,
+    examples_per_config: int,
+    slices: Iterable[MachineRecordPplSlice] = MACHINE_RECORD_PPL_SLICES,
+    seed: int = SYNTHETIC_MACHINE_RECORDS_SEED,
+) -> Iterable[Record]:
+    for slice_ in slices:
+        for index in range(examples_per_config):
+            yield machine_record_example(slice_, index, seed=seed)
+
+
+def write_jsonl(path: Path, records: Iterable[Record]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("w", encoding="utf-8") as f:
+        for record in records:
+            f.write(json.dumps(record, sort_keys=True) + "\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a local synthetic machine-record PPL JSONL sample.")
+    parser.add_argument("--output", type=Path, required=True)
+    parser.add_argument("--examples-per-config", type=int, default=1)
+    parser.add_argument("--seed", type=int, default=SYNTHETIC_MACHINE_RECORDS_SEED)
+    args = parser.parse_args()
+
+    write_jsonl(
+        args.output,
+        iter_machine_record_examples(examples_per_config=args.examples_per_config, seed=args.seed),
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/evals/synthetic_patch_diff_ppl.py
+++ b/experiments/evals/synthetic_patch_diff_ppl.py
@@ -1,0 +1,321 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""HF-backed synthetic patch/diff PPL validation slices.
+
+These slices are supervised continuation probes: each row provides repository
+or review context in ``input`` and scores only the patch-aware continuation in
+``target``. The provider is intentionally standalone so the shared all-available
+perplexity wiring can opt in later.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import posixpath
+import random
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+from pathlib import Path
+
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, supervised_text_dataset
+from marin.processing.tokenize import HfDatasetSpec
+
+EPIC_5005 = 5005
+SYNTHETIC_PATCH_DIFF_TRACKING_ISSUE: int | None = 5618
+SYNTHETIC_PATCH_DIFF_HF_DATASET_ID = "marin-community/synth-patch-diff-ppl"
+SYNTHETIC_PATCH_DIFF_SOURCE = "generated_synthetic_patch_diff_ppl_v1"
+SYNTHETIC_PATCH_DIFF_HF_REVISION = "7b7e44357aef62325a69d9b3e56241d90a277e5c"
+SYNTHETIC_PATCH_DIFF_SEED = 4693
+EXAMPLES_PER_CONFIG = 1000
+LOCAL_SAMPLE_EXAMPLES_PER_CONFIG = 2
+
+
+class SyntheticPatchDiffSubset(StrEnum):
+    UNIFIED_DIFF_HUNKS = "unified_diff_hunks"
+    FILE_PATH_LINE_REFS = "file_path_line_refs"
+    REVIEW_COMMENT_THREADS = "review_comment_threads"
+    FAILING_TEST_TRACE_TO_PATCH = "failing_test_trace_to_patch"
+    COMMIT_MESSAGE_METADATA = "commit_message_metadata"
+    GH_PR_EVENT_PATCH = "gh_pr_event_patch"
+
+
+@dataclass(frozen=True)
+class SyntheticPatchDiffPplSlice:
+    subset: SyntheticPatchDiffSubset
+    task_name: str
+    hf_config_name: str
+
+    @property
+    def registry_key(self) -> str:
+        return posixpath.join("synthetic_patch_diff_ppl", self.subset.value)
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        return (
+            "synthetic_patch_diff_ppl",
+            f"epic:{EPIC_5005}",
+            *((f"issue:{SYNTHETIC_PATCH_DIFF_TRACKING_ISSUE}",) if SYNTHETIC_PATCH_DIFF_TRACKING_ISSUE else ()),
+            f"subset:{self.subset.value}",
+            f"task:{self.task_name}",
+            f"seed:{SYNTHETIC_PATCH_DIFF_SEED}",
+            f"examples:{EXAMPLES_PER_CONFIG}",
+            f"source:{SYNTHETIC_PATCH_DIFF_SOURCE}",
+            f"hf_revision:{SYNTHETIC_PATCH_DIFF_HF_REVISION}",
+            "loss:target_only",
+        )
+
+    def to_raw_text_dataset(self, *, hf_dataset_id: str) -> RawTextEvaluationDataset:
+        return supervised_text_dataset(
+            HfDatasetSpec(
+                id=hf_dataset_id,
+                name=self.hf_config_name,
+                revision=SYNTHETIC_PATCH_DIFF_HF_REVISION,
+            ),
+            input_key="input",
+            target_key="target",
+            split="validation",
+            tags=self.tags,
+        )
+
+
+SYNTHETIC_PATCH_DIFF_PPL_SLICES: tuple[SyntheticPatchDiffPplSlice, ...] = tuple(
+    SyntheticPatchDiffPplSlice(subset=subset, task_name=subset.value, hf_config_name=subset.value)
+    for subset in SyntheticPatchDiffSubset
+)
+
+
+def synthetic_patch_diff_raw_validation_sets(
+    *, hf_dataset_id: str = SYNTHETIC_PATCH_DIFF_HF_DATASET_ID
+) -> dict[str, RawTextEvaluationDataset]:
+    return {
+        slice_.registry_key: slice_.to_raw_text_dataset(hf_dataset_id=hf_dataset_id)
+        for slice_ in SYNTHETIC_PATCH_DIFF_PPL_SLICES
+    }
+
+
+def _base_metadata(subset: SyntheticPatchDiffSubset, row_index: int, seed: int) -> dict[str, object]:
+    return {
+        "generator": SYNTHETIC_PATCH_DIFF_SOURCE,
+        "version": 1,
+        "subset": subset.value,
+        "row_index": row_index,
+        "repo": f"example/repo-{row_index % 17:02d}",
+        "language": ("python", "typescript", "rust")[row_index % 3],
+        "license": "synthetic",
+        "eval_only": True,
+        "seed": seed,
+    }
+
+
+def _record(
+    *,
+    subset: SyntheticPatchDiffSubset,
+    row_index: int,
+    seed: int,
+    input_text: str,
+    target: str,
+    metadata: dict[str, object],
+) -> dict[str, object]:
+    return {
+        "id": f"{subset.value}_{row_index:05d}",
+        "subset": subset.value,
+        "task": subset.value,
+        "seed": seed,
+        "input": input_text,
+        "target": target if target.endswith("\n") else f"{target}\n",
+        "metadata": metadata,
+    }
+
+
+def _python_diff(row_index: int, rng: random.Random) -> tuple[str, str, dict[str, object]]:
+    before_name = f"compute_total_{row_index % 11}"
+    guard_value = rng.randint(2, 9)
+    file_path = f"src/payments/reconcile_{row_index % 7}.py"
+    hunk_header = f"@@ -{12 + row_index % 13},7 +{12 + row_index % 13},9 @@"
+    input_text = (
+        f"File: {file_path}\n"
+        "Bug: empty batches should return 0 and large values must keep cents precision.\n"
+        "Diff prefix:\n"
+        f"diff --git a/{file_path} b/{file_path}\n"
+        f"--- a/{file_path}\n"
+        f"+++ b/{file_path}\n"
+        f"{hunk_header}\n"
+        f" def {before_name}(items):\n"
+        "-    total = sum(item.amount for item in items)\n"
+    )
+    target = (
+        "+    if not items:\n"
+        "+        return 0\n"
+        "+    total = sum(item.amount_cents for item in items)\n"
+        f"+    if total > {guard_value} * 100_000:\n"
+        '+        logger.info("large reconciliation batch")\n'
+        "     return total\n"
+    )
+    metadata = {"file_path": file_path, "hunk_header": hunk_header, "bug_type": "diff_completion"}
+    return input_text, target, metadata
+
+
+def _line_ref(row_index: int) -> tuple[str, str, dict[str, object]]:
+    file_path = f"lib/service/worker_{row_index % 9}.ts"
+    line = 40 + row_index % 30
+    input_text = (
+        f"Diagnostic: retry loop exits one attempt early in {file_path}.\n"
+        "Source excerpt:\n"
+        f"{line - 2}: const maxAttempts = config.maxAttempts ?? 3;\n"
+        f"{line - 1}: for (let attempt = 1; attempt < maxAttempts; attempt++) {{\n"
+        f"{line}:   await runAttempt(attempt);\n"
+        f"{line + 1}: }}\n"
+        "Reference:\n"
+    )
+    target = f"{file_path}:{line - 1} uses `< maxAttempts`; change it to `<= maxAttempts` so the final retry runs.\n"
+    metadata = {"file_path": file_path, "line": line - 1, "symbol": "maxAttempts"}
+    return input_text, target, metadata
+
+
+def _review_thread(row_index: int) -> tuple[str, str, dict[str, object]]:
+    file_path = f"app/models/cache_{row_index % 5}.py"
+    input_text = (
+        f"PR #{1200 + row_index}: cache invalidation cleanup\n"
+        f"Review comment on {file_path}:{73 + row_index % 8}: This deletes entries while iterating over the dict.\n"
+        "Author draft: Good catch. I will\n"
+    )
+    target = (
+        "iterate over `list(cache.keys())` before deleting expired entries and add a regression test for mixed live and "
+        "expired keys.\n"
+    )
+    metadata = {"file_path": file_path, "line": 73 + row_index % 8, "thread_state": "needs_patch"}
+    return input_text, target, metadata
+
+
+def _failing_trace(row_index: int) -> tuple[str, str, dict[str, object]]:
+    test_name = f"tests/test_parser_{row_index % 6}.py::test_preserves_blank_lines"
+    file_path = f"src/parser/render_{row_index % 4}.py"
+    input_text = (
+        f"Failing test: {test_name}\n"
+        "Trace:\n"
+        "E   AssertionError: assert 'a\\nb' == 'a\\n\\nb'\n"
+        "Current code:\n"
+        f'def render_block(lines):\n    return "\\n".join(line for line in lines if line)\n'
+        f"Patch for {file_path}:\n"
+    )
+    target = (
+        "@@ -1,2 +1,2 @@\n"
+        " def render_block(lines):\n"
+        '-    return "\\n".join(line for line in lines if line)\n'
+        '+    return "\\n".join(lines)\n'
+    )
+    metadata = {"file_path": file_path, "failing_test": test_name, "failure": "blank_line_dropped"}
+    return input_text, target, metadata
+
+
+def _commit_metadata(row_index: int) -> tuple[str, str, dict[str, object]]:
+    scope = ("evals", "tokenize", "scheduler", "docs")[row_index % 4]
+    pr_number = 3000 + row_index
+    input_text = (
+        f"PR: #{pr_number}\n"
+        f"Files: experiments/{scope}/probe.py, tests/{scope}/test_probe.py\n"
+        "Stats: +84 -12\n"
+        f"Subject: {scope}: add target-only patch probe\n\n"
+    )
+    target = (
+        "Adds a supervised continuation slice for patch-like artifacts and covers the provider keys with a small "
+        "registry test.\n\n"
+        "Tracking issue: TBD\n"
+    )
+    metadata = {"pr_number": pr_number, "scope": scope, "files_changed": 2}
+    return input_text, target, metadata
+
+
+def _gh_pr_event_patch(row_index: int) -> tuple[str, str, dict[str, object]]:
+    pr_number = 4100 + row_index
+    file_path = f"pkg/api/client_{row_index % 8}.go"
+    input_text = (
+        "{"
+        f'"event":"pull_request","action":"synchronize","number":{pr_number},'
+        f'"head":"feature/retry-{row_index % 5}","base":"main",'
+        f'"file":"{file_path}","patch":"'
+    )
+    target = (
+        "@@ -22,7 +22,7 @@ func retryDelay(attempt int) time.Duration {\\n"
+        "-\\treturn time.Duration(attempt) * time.Second\\n"
+        "+\\treturn time.Duration(1<<attempt) * time.Second\\n"
+        '"}\n'
+    )
+    metadata = {"pr_number": pr_number, "file_path": file_path, "event": "pull_request.synchronize"}
+    return input_text, target, metadata
+
+
+def synthetic_patch_diff_record(
+    subset: SyntheticPatchDiffSubset | str,
+    *,
+    row_index: int,
+    seed: int = SYNTHETIC_PATCH_DIFF_SEED,
+) -> dict[str, object]:
+    resolved_subset = SyntheticPatchDiffSubset(subset)
+    rng = random.Random(seed + 1009 * row_index + 31 * list(SyntheticPatchDiffSubset).index(resolved_subset))
+    renderers = {
+        SyntheticPatchDiffSubset.UNIFIED_DIFF_HUNKS: _python_diff,
+        SyntheticPatchDiffSubset.FILE_PATH_LINE_REFS: lambda index, _rng: _line_ref(index),
+        SyntheticPatchDiffSubset.REVIEW_COMMENT_THREADS: lambda index, _rng: _review_thread(index),
+        SyntheticPatchDiffSubset.FAILING_TEST_TRACE_TO_PATCH: lambda index, _rng: _failing_trace(index),
+        SyntheticPatchDiffSubset.COMMIT_MESSAGE_METADATA: lambda index, _rng: _commit_metadata(index),
+        SyntheticPatchDiffSubset.GH_PR_EVENT_PATCH: lambda index, _rng: _gh_pr_event_patch(index),
+    }
+    input_text, target, subset_metadata = renderers[resolved_subset](row_index, rng)
+    metadata = _base_metadata(resolved_subset, row_index, seed)
+    metadata.update(subset_metadata)
+    return _record(
+        subset=resolved_subset,
+        row_index=row_index,
+        seed=seed,
+        input_text=input_text,
+        target=target,
+        metadata=metadata,
+    )
+
+
+def iter_synthetic_patch_diff_records(
+    *,
+    subsets: Iterable[SyntheticPatchDiffSubset | str] = tuple(SyntheticPatchDiffSubset),
+    examples_per_config: int = EXAMPLES_PER_CONFIG,
+    seed: int = SYNTHETIC_PATCH_DIFF_SEED,
+) -> Iterable[dict[str, object]]:
+    for subset in subsets:
+        resolved_subset = SyntheticPatchDiffSubset(subset)
+        for row_index in range(examples_per_config):
+            yield synthetic_patch_diff_record(resolved_subset, row_index=row_index, seed=seed)
+
+
+def write_local_sample(
+    output_path: str | Path,
+    *,
+    examples_per_config: int = LOCAL_SAMPLE_EXAMPLES_PER_CONFIG,
+    seed: int = SYNTHETIC_PATCH_DIFF_SEED,
+) -> None:
+    output_dir = Path(output_path)
+    output_dir.mkdir(parents=True, exist_ok=True)
+    for subset in SyntheticPatchDiffSubset:
+        with (output_dir / f"{subset.value}.jsonl").open("w", encoding="utf-8") as sink:
+            for row in iter_synthetic_patch_diff_records(
+                subsets=(subset,),
+                examples_per_config=examples_per_config,
+                seed=seed,
+            ):
+                sink.write(json.dumps(row, ensure_ascii=True, sort_keys=True))
+                sink.write("\n")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate a local synthetic patch/diff PPL sample.")
+    parser.add_argument("output_path", type=Path)
+    parser.add_argument("--examples-per-config", type=int, default=LOCAL_SAMPLE_EXAMPLES_PER_CONFIG)
+    parser.add_argument("--seed", type=int, default=SYNTHETIC_PATCH_DIFF_SEED)
+    args = parser.parse_args()
+    write_local_sample(args.output_path, examples_per_config=args.examples_per_config, seed=args.seed)
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/evals/synthetic_patch_diff_ppl.py
+++ b/experiments/evals/synthetic_patch_diff_ppl.py
@@ -134,7 +134,7 @@ def _python_diff(row_index: int, rng: random.Random) -> tuple[str, str, dict[str
     before_name = f"compute_total_{row_index % 11}"
     guard_value = rng.randint(2, 9)
     file_path = f"src/payments/reconcile_{row_index % 7}.py"
-    hunk_header = f"@@ -{12 + row_index % 13},7 +{12 + row_index % 13},9 @@"
+    hunk_header = f"@@ -{12 + row_index % 13},3 +{12 + row_index % 13},7 @@"
     input_text = (
         f"File: {file_path}\n"
         "Bug: empty batches should return 0 and large values must keep cents precision.\n"

--- a/experiments/evals/synthetic_reasoning_ppl.py
+++ b/experiments/evals/synthetic_reasoning_ppl.py
@@ -1,0 +1,162 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""HF-backed synthetic reasoning PPL validation slices for issue #4148."""
+
+from __future__ import annotations
+
+import posixpath
+from dataclasses import dataclass
+from enum import StrEnum
+
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, supervised_text_dataset
+from marin.processing.tokenize import HfDatasetSpec
+
+EPIC_5005 = 5005
+SYNTHETIC_REASONING_ISSUE = 4148
+ISSUE_5052 = 5052
+SYNTHETIC_REASONING_HF_DATASET_ID = "marin-community/synth-reasoning-arrow-icl-ppl"
+SYNTHETIC_REASONING_HF_REVISION = "0cedc373025ae08edf24e24d73eeda75980ddf8c"
+SYNTHETIC_REASONING_SOURCE = "generated_synthetic_reasoning_arrow_icl_v1"
+SYNTHETIC_REASONING_SOURCE_REPO = "marin-community/synth-bootstrap-trial"
+SYNTHETIC_REASONING_PROMPT_FORMAT = "arrow_5shot_icl_v1"
+SYNTHETIC_REASONING_ICL_SHOTS = 5
+DEV_SEED_BASE = 1 << 30
+EXAMPLES_PER_SUBCORPUS = 1000
+
+STEPMATH_TASKS: tuple[str, ...] = (
+    "arithmetic",
+    "algebra_linear_equation",
+)
+
+LEGACY_STEPMATH_ALIAS_TASKS: tuple[str, ...] = (
+    "arithmetic_5shot_icl",
+    "algebra_linear_equation_3shot_icl",
+)
+
+NATIVE_TASKS: tuple[str, ...] = (
+    "bfs_shortest_path",
+    "binary_search",
+    "coin_change_dp",
+    "connected_components",
+    "dijkstra_shortest_path",
+    "edit_distance_dp",
+    "euclid_gcd",
+    "floyd_warshall_apsp",
+    "insertion_sort",
+    "interval_scheduling",
+    "kmp_string_search",
+    "knapsack_01_dp",
+    "lcs_dp",
+    "lis_dp",
+    "n_queens_backtracking",
+    "parentheses_balance",
+    "prim_mst",
+    "propositional_entailment",
+    "topological_sort",
+    "union_find_connectivity",
+)
+
+LEGACY_NATIVE_ALIAS_TASKS: tuple[str, ...] = (
+    "binary_search_5shot_icl",
+    "euclid_gcd_5shot_icl",
+    "parentheses_balance_5shot_icl",
+    "edit_distance_dp_1shot_icl",
+    "interval_scheduling_1shot_icl",
+    "kmp_string_search_1shot_icl",
+    "knapsack_01_dp_1shot_icl",
+    "lcs_dp_1shot_icl",
+    "n_queens_backtracking_1shot_icl",
+    "union_find_connectivity_1shot_icl",
+)
+
+CLRS_STYLE_TASKS: tuple[str, ...] = (
+    "clrs_bfs",
+    "clrs_binary_search",
+    "clrs_connected_components",
+    "clrs_dijkstra",
+    "clrs_floyd_warshall",
+    "clrs_insertion_sort",
+    "clrs_lcs_length",
+    "clrs_lis",
+    "clrs_mst_prim",
+    "clrs_topological_sort",
+)
+
+
+class SyntheticReasoningFamily(StrEnum):
+    STEPMATH = "stepmath"
+    NATIVE = "native"
+    CLRS_STYLE = "clrs_style"
+
+
+@dataclass(frozen=True)
+class SyntheticReasoningPplSlice:
+    family: SyntheticReasoningFamily
+    task_name: str
+    hf_config_name: str
+    icl_shots: int = SYNTHETIC_REASONING_ICL_SHOTS
+
+    @property
+    def registry_key(self) -> str:
+        return posixpath.join("synthetic_reasoning_ppl", self.family.value, self.task_name)
+
+    @property
+    def tags(self) -> tuple[str, ...]:
+        return (
+            "synthetic_reasoning_ppl",
+            f"epic:{EPIC_5005}",
+            f"issue:{SYNTHETIC_REASONING_ISSUE}",
+            f"issue:{ISSUE_5052}",
+            f"family:{self.family.value}",
+            f"task:{self.task_name}",
+            f"seed:{DEV_SEED_BASE}",
+            f"examples:{EXAMPLES_PER_SUBCORPUS}",
+            f"source:{SYNTHETIC_REASONING_SOURCE}",
+            f"source_repo:{SYNTHETIC_REASONING_SOURCE_REPO}",
+            f"hf_revision:{SYNTHETIC_REASONING_HF_REVISION}",
+            f"prompt_format:{SYNTHETIC_REASONING_PROMPT_FORMAT}",
+            f"icl_shots:{self.icl_shots}",
+            "loss:target_only",
+        )
+
+    def to_raw_text_dataset(self, *, hf_dataset_id: str) -> RawTextEvaluationDataset:
+        return supervised_text_dataset(
+            HfDatasetSpec(
+                id=hf_dataset_id,
+                name=self.hf_config_name,
+                revision=SYNTHETIC_REASONING_HF_REVISION,
+            ),
+            input_key="input",
+            target_key="target",
+            split="validation",
+            tags=self.tags,
+        )
+
+
+def _slice(
+    *,
+    family: SyntheticReasoningFamily,
+    task_name: str,
+) -> SyntheticReasoningPplSlice:
+    return SyntheticReasoningPplSlice(
+        family=family,
+        task_name=task_name,
+        hf_config_name=f"{family.value}_{task_name}_arrow_5shot_icl",
+    )
+
+
+SYNTHETIC_REASONING_PPL_SLICES: tuple[SyntheticReasoningPplSlice, ...] = (
+    *(_slice(family=SyntheticReasoningFamily.STEPMATH, task_name=task) for task in STEPMATH_TASKS),
+    *(_slice(family=SyntheticReasoningFamily.NATIVE, task_name=task) for task in NATIVE_TASKS),
+    *(_slice(family=SyntheticReasoningFamily.CLRS_STYLE, task_name=task) for task in CLRS_STYLE_TASKS),
+)
+
+
+def synthetic_reasoning_raw_validation_sets(
+    *, hf_dataset_id: str = SYNTHETIC_REASONING_HF_DATASET_ID
+) -> dict[str, RawTextEvaluationDataset]:
+    return {
+        slice_.registry_key: slice_.to_raw_text_dataset(hf_dataset_id=hf_dataset_id)
+        for slice_ in SYNTHETIC_REASONING_PPL_SLICES
+    }

--- a/experiments/exp5052_synthetic_reasoning_ppl.py
+++ b/experiments/exp5052_synthetic_reasoning_ppl.py
@@ -1,0 +1,14 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Issue #5052: HF-backed synthetic reasoning PPL dev slices."""
+
+from marin.execution.executor import executor_main
+
+from experiments.evals.synthetic_reasoning_ppl import synthetic_reasoning_raw_validation_sets
+
+RAW_SYNTHETIC_REASONING_VALIDATION_SETS = synthetic_reasoning_raw_validation_sets()
+
+
+if __name__ == "__main__":
+    executor_main(steps=[])

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -267,6 +267,7 @@ class HfDatasetSourceConfig(LmDatasetSourceConfigBase):
 
     id: str = dataclasses.field(kw_only=True)
     name: str | None = None  # name for hf dataset
+    revision: str | None = None  # revision, branch, or tag for hf dataset
     stream: bool = True  # whether to use streaming when doing hf
     splits: list[str] | None = None
 
@@ -276,7 +277,13 @@ class HfDatasetSourceConfig(LmDatasetSourceConfigBase):
             return None
         if self.id is not None:
             try:
-                ds = WrappedHFDataSource(self.id, split=split, name=self.name, streaming=self.stream)
+                ds = WrappedHFDataSource(
+                    self.id,
+                    split=split,
+                    name=self.name,
+                    revision=self.revision,
+                    streaming=self.stream,
+                )
             except ValueError as e:
                 # if the message starts with Bad split, then just return None
                 if str(e).startswith("Bad split"):

--- a/lib/marin/src/marin/evaluation/perplexity_gap.py
+++ b/lib/marin/src/marin/evaluation/perplexity_gap.py
@@ -56,6 +56,7 @@ class RawTextEvaluationDataset:
     input_path: str | InputName | ExecutorStep | None = None
     hf_dataset_id: str | None = None
     hf_dataset_name: str | None = None
+    hf_dataset_revision: str | None = None
     text_key: str = "text"
     input_key: str | None = None
     target_key: str | None = None
@@ -102,6 +103,7 @@ def raw_text_dataset(
         return RawTextEvaluationDataset(
             hf_dataset_id=source.id,
             hf_dataset_name=source.name,
+            hf_dataset_revision=source.revision,
             text_key=text_key,
             split=split,
             tags=tags,
@@ -123,6 +125,7 @@ def supervised_text_dataset(
         return RawTextEvaluationDataset(
             hf_dataset_id=source.id,
             hf_dataset_name=source.name,
+            hf_dataset_revision=source.revision,
             input_key=input_key,
             target_key=target_key,
             split=split,
@@ -308,6 +311,7 @@ def _to_dataset_component(config: RawTextEvaluationDataset) -> DatasetComponent:
         source = HfDatasetSourceConfig(
             id=config.hf_dataset_id,
             name=config.hf_dataset_name,
+            revision=config.hf_dataset_revision,
             format=dataset_format,
             splits=[config.split],
         )
@@ -374,6 +378,7 @@ def _cache_key_for_dataset(dataset: RawTextEvaluationDataset) -> dict[str, Any]:
         "input_path": input_path,
         "hf_dataset_id": dataset.hf_dataset_id,
         "hf_dataset_name": dataset.hf_dataset_name,
+        "hf_dataset_revision": dataset.hf_dataset_revision,
         "text_key": dataset.text_key,
         "input_key": dataset.input_key,
         "target_key": dataset.target_key,

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -74,6 +74,7 @@ class HfDatasetSpec:
 
     id: str
     name: str | None = None
+    revision: str | None = None
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)

--- a/tests/evals/test_long_tail_ppl.py
+++ b/tests/evals/test_long_tail_ppl.py
@@ -3,7 +3,12 @@
 
 import pytest
 from levanter.data.text import HfDatasetSourceConfig, SupervisedLmDatasetFormat
-from marin.evaluation.perplexity_gap import _to_dataset_component, raw_text_dataset, supervised_text_dataset
+from marin.evaluation.perplexity_gap import (
+    _cache_key_for_dataset,
+    _to_dataset_component,
+    raw_text_dataset,
+    supervised_text_dataset,
+)
 from marin.processing.tokenize import HfDatasetSpec
 
 from experiments.evals.long_tail_ppl import (
@@ -37,19 +42,25 @@ def test_long_tail_registry_rendering_mentions_issue_links():
 
 
 def test_hf_backed_raw_dataset_preserves_requested_split():
-    dataset = raw_text_dataset(HfDatasetSpec(id="example/dataset"), text_key="body", split="test")
+    dataset = raw_text_dataset(
+        HfDatasetSpec(id="example/dataset", name="raw_config", revision="raw-revision-abc123"),
+        text_key="body",
+        split="test",
+    )
 
     component = _to_dataset_component(dataset)
 
     assert component.split == "test"
     assert component.format.text_key == "body"
     assert isinstance(component.source, HfDatasetSourceConfig)
+    assert component.source.name == "raw_config"
+    assert component.source.revision == "raw-revision-abc123"
     assert component.source.splits == ["test"]
 
 
 def test_hf_backed_supervised_dataset_uses_supervised_format():
     dataset = supervised_text_dataset(
-        HfDatasetSpec(id="example/dataset"),
+        HfDatasetSpec(id="example/dataset", name="supervised_config", revision="supervised-revision-def456"),
         input_key="prompt",
         target_key="completion",
         split="test",
@@ -62,7 +73,26 @@ def test_hf_backed_supervised_dataset_uses_supervised_format():
     assert component.format.input_key == "prompt"
     assert component.format.target_key == "completion"
     assert isinstance(component.source, HfDatasetSourceConfig)
+    assert component.source.name == "supervised_config"
+    assert component.source.revision == "supervised-revision-def456"
     assert component.source.splits == ["test"]
+
+
+def test_hf_dataset_revision_changes_per_dataset_score_cache_key():
+    old_dataset = supervised_text_dataset(
+        HfDatasetSpec(id="example/dataset", name="config", revision="old-commit"),
+        input_key="prompt",
+        target_key="completion",
+    )
+    new_dataset = supervised_text_dataset(
+        HfDatasetSpec(id="example/dataset", name="config", revision="new-commit"),
+        input_key="prompt",
+        target_key="completion",
+    )
+
+    assert _cache_key_for_dataset(old_dataset)["hf_dataset_revision"] == "old-commit"
+    assert _cache_key_for_dataset(new_dataset)["hf_dataset_revision"] == "new-commit"
+    assert _cache_key_for_dataset(old_dataset) != _cache_key_for_dataset(new_dataset)
 
 
 def test_file_backed_raw_dataset_rejects_non_validation_split():

--- a/tests/evals/test_synthetic_delimiter_format_ppl.py
+++ b/tests/evals/test_synthetic_delimiter_format_ppl.py
@@ -1,0 +1,62 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from experiments.evals.synthetic_delimiter_format_ppl import (
+    iter_synthetic_delimiter_format_records,
+    synthetic_delimiter_format_raw_validation_sets,
+)
+
+EXPECTED_DELIMITER_KEYS = {
+    "synthetic_delimiter_format_ppl/delimited_fields/tsv_next_field",
+    "synthetic_delimiter_format_ppl/delimited_fields/csv_next_field",
+    "synthetic_delimiter_format_ppl/delimited_fields/rare_control_delimiters",
+    "synthetic_delimiter_format_ppl/table_rows/pipe_rows",
+    "synthetic_delimiter_format_ppl/table_rows/fixed_width_rows",
+    "synthetic_delimiter_format_ppl/table_rows/markdown_table_rows",
+    "synthetic_delimiter_format_ppl/whitespace_control/aligned_space_columns",
+    "synthetic_delimiter_format_ppl/whitespace_control/python_indentation_or_makefile_tabs",
+}
+
+
+def test_synthetic_delimiter_format_registry_uses_supervised_target_only_format():
+    datasets = synthetic_delimiter_format_raw_validation_sets()
+
+    assert set(datasets) == EXPECTED_DELIMITER_KEYS
+    for key, dataset in datasets.items():
+        assert dataset.hf_dataset_name == key.rsplit("/", maxsplit=1)[-1]
+        assert dataset.input_key == "input"
+        assert dataset.target_key == "target"
+        assert dataset.split == "validation"
+        assert "loss:target_only" in dataset.tags
+
+
+def test_synthetic_delimiter_format_examples_are_raw_continuations_with_non_tiny_targets():
+    rows = iter_synthetic_delimiter_format_records(examples_per_config=2)
+    instruction_fragments = ("Complete ", "Continue ", "Task:", "User:", "Assistant:")
+
+    assert len(rows) == 16
+    for row in rows:
+        assert set(row) == {"id", "input", "target", "subset", "task", "seed", "metadata"}
+        assert row["input"]
+        assert not any(fragment in row["input"] for fragment in instruction_fragments)
+        assert row["target"].endswith("\n")
+        assert len(row["target"].encode("utf-8")) >= 16
+
+
+def test_delimiter_examples_score_whole_rows_not_single_fields():
+    rows_by_task = {row["task"]: row for row in iter_synthetic_delimiter_format_records(examples_per_config=1)}
+
+    tsv = rows_by_task["tsv_next_field"]
+    assert tsv["input"].startswith("record_id\tbatch\tstatus\tchecksum\nrec-0000-0\t")
+    assert str(tsv["target"]).startswith("rec-0000-4\t")
+    assert str(tsv["target"]).count("\t") == 3
+
+    pipe = rows_by_task["pipe_rows"]
+    assert str(pipe["input"]).startswith("node-0 | ")
+    assert str(pipe["target"]).startswith("node-4 | ")
+    assert str(pipe["target"]).count(" | ") == 2
+
+    indentation = rows_by_task["python_indentation_or_makefile_tabs"]
+    assert str(indentation["input"]).startswith("build_example: src/build_example.py\n\tpython -m pytest")
+    assert str(indentation["target"]).startswith("\t")
+    assert str(indentation["target"]).count("\n") == 2

--- a/tests/evals/test_synthetic_identifier_encoding_ppl.py
+++ b/tests/evals/test_synthetic_identifier_encoding_ppl.py
@@ -1,0 +1,83 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from experiments.evals.synthetic_identifier_encoding_ppl import (
+    IDENTIFIER_ENCODING_HF_DATASET_ID,
+    generate_tiny_identifier_encoding_sample,
+    identifier_encoding_raw_validation_sets,
+)
+
+EXPECTED_IDENTIFIER_KEYS = {
+    "synthetic_identifier_encoding_ppl/encoded_text/base64_continuation",
+    "synthetic_identifier_encoding_ppl/encoded_text/data_image_base64_prefixes",
+    "synthetic_identifier_encoding_ppl/encoded_text/hex_dump_continuation",
+    "synthetic_identifier_encoding_ppl/escaped_text/json_unicode_byte_escapes",
+    "synthetic_identifier_encoding_ppl/escaped_text/url_query_escaping",
+    "synthetic_identifier_encoding_ppl/identifier_grammars/bio_accessions",
+    "synthetic_identifier_encoding_ppl/identifier_grammars/commit_hashes",
+    "synthetic_identifier_encoding_ppl/identifier_grammars/mixed_case_symbolic_identifiers",
+    "synthetic_identifier_encoding_ppl/identifier_grammars/package_names_versions",
+    "synthetic_identifier_encoding_ppl/identifier_grammars/uuid_build_ids",
+}
+
+EXPECTED_SUBSET_BY_TASK = {
+    "base64_continuation": "base64_continuation",
+    "bio_accessions": "bio_accessions",
+    "commit_hashes": "commit_hashes",
+    "data_image_base64_prefixes": "data_image_base64_prefixes",
+    "hex_dump_continuation": "hex_dump_continuation",
+    "json_unicode_byte_escapes": "json_unicode_byte_escapes",
+    "mixed_case_symbolic_identifiers": "mixed_case_symbolic_identifiers",
+    "package_names_versions": "package_names_versions",
+    "url_query_escaping": "url_query_escaping",
+    "uuid_build_ids": "uuid_build_ids",
+}
+
+
+def test_identifier_encoding_registry_uses_supervised_target_only_format() -> None:
+    datasets = identifier_encoding_raw_validation_sets()
+
+    assert set(datasets) == EXPECTED_IDENTIFIER_KEYS
+
+    for key, dataset in datasets.items():
+        assert key.startswith("synthetic_identifier_encoding_ppl/")
+        assert dataset.hf_dataset_id == IDENTIFIER_ENCODING_HF_DATASET_ID
+        assert dataset.input_key == "input"
+        assert dataset.target_key == "target"
+        assert dataset.split == "validation"
+        assert "loss:target_only" in dataset.tags
+
+
+def test_tiny_identifier_encoding_sample_has_expected_schema_and_base_model_prompts() -> None:
+    rows = generate_tiny_identifier_encoding_sample()
+    instruction_fragments = ("Complete ", "Continue ", "Task:", "User:", "Assistant:")
+
+    assert len(rows) == 10
+    for row in rows:
+        assert set(row) == {"input", "target", "id", "subset", "task", "seed", "metadata"}
+        assert row["input"]
+        assert row["target"].endswith("\n")
+        assert row["subset"] == EXPECTED_SUBSET_BY_TASK[row["task"]]
+        assert row["metadata"]["family"] in {"identifier_grammars", "encoded_text", "escaped_text"}
+        assert not any(fragment in row["input"] for fragment in instruction_fragments)
+
+
+def test_identifier_examples_are_raw_field_continuations():
+    rows_by_task = {row["task"]: row for row in generate_tiny_identifier_encoding_sample()}
+
+    package = rows_by_task["package_names_versions"]
+    assert str(package["input"]).startswith('"node_modules/@')
+    assert "registry.npmjs.org" in str(package["input"])
+    assert ".tgz" in str(package["target"])
+
+    base64_row = rows_by_task["base64_continuation"]
+    assert str(base64_row["input"]).startswith('payload_b64="')
+    assert str(base64_row["target"]).endswith('"\n')
+
+    hexdump = rows_by_task["hex_dump_continuation"]
+    assert str(hexdump["input"])[8:10] == "  "
+    assert "|" in str(hexdump["target"])
+
+    url_row = rows_by_task["url_query_escaping"]
+    assert str(url_row["input"]).startswith("https://example.invalid/search?q=")
+    assert str(url_row["target"]).endswith("&src=eval\n")

--- a/tests/evals/test_synthetic_machine_records_ppl.py
+++ b/tests/evals/test_synthetic_machine_records_ppl.py
@@ -1,0 +1,73 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from experiments.evals.synthetic_machine_records_ppl import (
+    iter_machine_record_examples,
+    synthetic_machine_records_raw_validation_sets,
+)
+
+EXPECTED_MACHINE_RECORD_KEYS = {
+    "synthetic_machine_records_ppl/ci_logs/github_actions_jobs",
+    "synthetic_machine_records_ppl/config_manifests/dockerfile",
+    "synthetic_machine_records_ppl/config_manifests/github_actions_yaml",
+    "synthetic_machine_records_ppl/config_manifests/kubernetes_yaml",
+    "synthetic_machine_records_ppl/config_manifests/package_json",
+    "synthetic_machine_records_ppl/config_manifests/pyproject_toml",
+    "synthetic_machine_records_ppl/config_manifests/terraform_hcl",
+    "synthetic_machine_records_ppl/service_logs/k8s_system_events",
+    "synthetic_machine_records_ppl/service_logs/nginx_access_error",
+    "synthetic_machine_records_ppl/service_logs/systemd_journal",
+    "synthetic_machine_records_ppl/service_logs/zeek_conn_http_dns",
+    "synthetic_machine_records_ppl/structured_logs/json_application_logs",
+    "synthetic_machine_records_ppl/trace_errors/compiler_errors",
+    "synthetic_machine_records_ppl/trace_errors/python_tracebacks",
+}
+
+
+def test_machine_records_registry_uses_supervised_target_only_format():
+    datasets = synthetic_machine_records_raw_validation_sets()
+
+    assert set(datasets) == EXPECTED_MACHINE_RECORD_KEYS
+
+    dataset = datasets["synthetic_machine_records_ppl/service_logs/zeek_conn_http_dns"]
+    assert dataset.input_key == "input"
+    assert dataset.target_key == "target"
+    assert "loss:target_only" in dataset.tags
+    assert "subset:zeek" in dataset.tags
+
+
+def test_machine_record_examples_have_required_schema():
+    records = list(iter_machine_record_examples(examples_per_config=1))
+    instruction_fragments = ("Machine record subset:", "Task:", "User:", "Assistant:")
+
+    assert len(records) == 14
+    for record in records:
+        assert set(record) == {"input", "target", "id", "subset", "task", "seed", "metadata"}
+        assert record["input"]
+        assert not any(fragment in record["input"] for fragment in instruction_fragments)
+        assert record["target"]
+        assert record["id"].endswith("-000000")
+        assert record["subset"]
+        assert record["task"]
+        assert isinstance(record["seed"], int)
+        assert isinstance(record["metadata"], dict)
+
+
+def test_machine_record_examples_keep_native_record_shapes():
+    records_by_task = {record["task"]: record for record in iter_machine_record_examples(examples_per_config=1)}
+
+    zeek = records_by_task["zeek_conn_http_dns"]
+    assert str(zeek["input"]).startswith("#separator \\x09\n#set_separator\t,\n#fields\tts\tuid")
+    assert str(zeek["target"]).startswith("tcp\thttp\t0.")
+
+    systemd = records_by_task["systemd_journal"]
+    assert str(systemd["input"]).startswith("May 11 14:10:17 node-")
+    assert str(systemd["target"]).startswith("Started ")
+
+    package_json = records_by_task["package_json"]
+    assert str(package_json["input"]).startswith('{\n  "name": "@example/service",\n  "version": "0.')
+    assert '"dependencies"' in str(package_json["target"])
+
+    dockerfile = records_by_task["dockerfile"]
+    assert str(dockerfile["input"]).startswith("FROM python:3.12-slim\nWORKDIR /app")
+    assert str(dockerfile["target"]).endswith('CMD ["python", "-m", "service.main"]\n')

--- a/tests/evals/test_synthetic_machine_records_ppl.py
+++ b/tests/evals/test_synthetic_machine_records_ppl.py
@@ -1,6 +1,8 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import re
+
 from experiments.evals.synthetic_machine_records_ppl import (
     iter_machine_record_examples,
     synthetic_machine_records_raw_validation_sets,
@@ -71,3 +73,15 @@ def test_machine_record_examples_keep_native_record_shapes():
     dockerfile = records_by_task["dockerfile"]
     assert str(dockerfile["input"]).startswith("FROM python:3.12-slim\nWORKDIR /app")
     assert str(dockerfile["target"]).endswith('CMD ["python", "-m", "service.main"]\n')
+
+
+def test_machine_record_timestamps_keep_valid_clock_fields():
+    records = list(iter_machine_record_examples(examples_per_config=125))
+    timestamp_pattern = re.compile(r"14:(?P<minute>\d{2})(?::(?P<second>\d{2}))?")
+
+    for record in records:
+        text = f"{record['input']}{record['target']}"
+        for match in timestamp_pattern.finditer(text):
+            assert int(match.group("minute")) < 60
+            if match.group("second") is not None:
+                assert int(match.group("second")) < 60

--- a/tests/evals/test_synthetic_patch_diff_ppl.py
+++ b/tests/evals/test_synthetic_patch_diff_ppl.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import re
 
 from experiments.evals.synthetic_patch_diff_ppl import (
     EXAMPLES_PER_CONFIG,
@@ -86,6 +87,17 @@ def test_patch_diff_examples_preserve_patch_artifact_shapes():
     gh_event = records_by_subset["gh_pr_event_patch"]
     assert str(gh_event["input"]).startswith('{"event":"pull_request"')
     assert str(gh_event["target"]).startswith("@@ -22,7 +22,7 @@")
+
+
+def test_unified_diff_hunk_header_counts_match_body():
+    record = synthetic_patch_diff_record(SyntheticPatchDiffSubset.UNIFIED_DIFF_HUNKS, row_index=0)
+    hunk = f"{record['input']}{record['target']}"
+    header = next(line for line in hunk.splitlines() if line.startswith("@@ "))
+    old_count, new_count = (int(count) for count in re.match(r"@@ -\d+,(\d+) \+\d+,(\d+) @@", header).groups())
+    body = hunk.split(f"{header}\n", maxsplit=1)[1].splitlines()
+
+    assert sum(not line.startswith("+") for line in body) == old_count
+    assert sum(not line.startswith("-") for line in body) == new_count
 
 
 def test_write_local_sample_creates_jsonl_per_hf_config(tmp_path):

--- a/tests/evals/test_synthetic_patch_diff_ppl.py
+++ b/tests/evals/test_synthetic_patch_diff_ppl.py
@@ -1,0 +1,100 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+from experiments.evals.synthetic_patch_diff_ppl import (
+    EXAMPLES_PER_CONFIG,
+    SYNTHETIC_PATCH_DIFF_HF_DATASET_ID,
+    SyntheticPatchDiffSubset,
+    iter_synthetic_patch_diff_records,
+    synthetic_patch_diff_raw_validation_sets,
+    synthetic_patch_diff_record,
+    write_local_sample,
+)
+
+EXPECTED_PATCH_KEYS = {
+    "synthetic_patch_diff_ppl/commit_message_metadata",
+    "synthetic_patch_diff_ppl/failing_test_trace_to_patch",
+    "synthetic_patch_diff_ppl/file_path_line_refs",
+    "synthetic_patch_diff_ppl/gh_pr_event_patch",
+    "synthetic_patch_diff_ppl/review_comment_threads",
+    "synthetic_patch_diff_ppl/unified_diff_hunks",
+}
+
+EXPECTED_PATCH_SUBSETS = (
+    "unified_diff_hunks",
+    "file_path_line_refs",
+    "review_comment_threads",
+    "failing_test_trace_to_patch",
+    "commit_message_metadata",
+    "gh_pr_event_patch",
+)
+
+
+def test_synthetic_patch_diff_raw_validation_sets_use_supervised_target_only_format():
+    datasets = synthetic_patch_diff_raw_validation_sets()
+
+    assert set(datasets) == EXPECTED_PATCH_KEYS
+    for key, dataset in datasets.items():
+        subset = key.rsplit("/", maxsplit=1)[-1]
+        assert dataset.hf_dataset_id == SYNTHETIC_PATCH_DIFF_HF_DATASET_ID
+        assert dataset.hf_dataset_name == subset
+        assert dataset.input_key == "input"
+        assert dataset.target_key == "target"
+        assert dataset.split == "validation"
+        assert "loss:target_only" in dataset.tags
+        assert f"subset:{subset}" in dataset.tags
+        assert f"examples:{EXAMPLES_PER_CONFIG}" in dataset.tags
+
+
+def test_synthetic_patch_diff_record_has_required_schema_and_patch_target():
+    record = synthetic_patch_diff_record(SyntheticPatchDiffSubset.FAILING_TEST_TRACE_TO_PATCH, row_index=3)
+
+    assert set(record) == {"id", "subset", "task", "seed", "input", "target", "metadata"}
+    assert record["subset"] == "failing_test_trace_to_patch"
+    assert record["task"] == "failing_test_trace_to_patch"
+    assert "Write the minimal patch hunk" not in str(record["input"])
+    assert str(record["input"]).startswith("Failing test:")
+    assert "@@ -1,2 +1,2 @@" in str(record["target"])
+    assert str(record["target"]).endswith("\n")
+    assert isinstance(record["metadata"], dict)
+    assert record["metadata"]["eval_only"] is True
+
+
+def test_iter_records_covers_each_subset_with_requested_count():
+    records = list(iter_synthetic_patch_diff_records(examples_per_config=1))
+    instruction_fragments = ("Complete ", "Continue ", "Given ", "Write ", "Task:", "User:", "Assistant:")
+
+    assert [record["subset"] for record in records] == list(EXPECTED_PATCH_SUBSETS)
+    assert all(record["input"] for record in records)
+    assert all(not any(fragment in record["input"] for fragment in instruction_fragments) for record in records)
+    assert all(record["target"] for record in records)
+
+
+def test_patch_diff_examples_preserve_patch_artifact_shapes():
+    records_by_subset = {record["subset"]: record for record in iter_synthetic_patch_diff_records(examples_per_config=1)}
+
+    unified_diff = records_by_subset["unified_diff_hunks"]
+    assert str(unified_diff["input"]).startswith("File: src/payments/reconcile_0.py\nBug:")
+    assert str(unified_diff["target"]).startswith("+    if not items:\n")
+
+    line_ref = records_by_subset["file_path_line_refs"]
+    assert str(line_ref["input"]).startswith("Diagnostic: retry loop exits one attempt early")
+    assert str(line_ref["target"]).startswith("lib/service/worker_0.ts:39 uses `< maxAttempts`")
+
+    gh_event = records_by_subset["gh_pr_event_patch"]
+    assert str(gh_event["input"]).startswith('{"event":"pull_request"')
+    assert str(gh_event["target"]).startswith("@@ -22,7 +22,7 @@")
+
+
+def test_write_local_sample_creates_jsonl_per_hf_config(tmp_path):
+    write_local_sample(tmp_path, examples_per_config=1)
+
+    for subset in EXPECTED_PATCH_SUBSETS:
+        sample_path = tmp_path / f"{subset}.jsonl"
+        assert sample_path.exists()
+        rows = [json.loads(line) for line in sample_path.read_text(encoding="utf-8").splitlines()]
+        assert len(rows) == 1
+        assert rows[0]["subset"] == subset
+        assert set(rows[0]) == {"id", "subset", "task", "seed", "input", "target", "metadata"}

--- a/tests/evals/test_synthetic_reasoning_ppl.py
+++ b/tests/evals/test_synthetic_reasoning_ppl.py
@@ -1,0 +1,98 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from experiments.evals.synthetic_reasoning_ppl import (
+    SYNTHETIC_REASONING_HF_DATASET_ID,
+    SYNTHETIC_REASONING_ICL_SHOTS,
+    SYNTHETIC_REASONING_PROMPT_FORMAT,
+    synthetic_reasoning_raw_validation_sets,
+)
+
+EXPECTED_SYNTHETIC_REASONING_KEYS = {
+    "synthetic_reasoning_ppl/clrs_style/clrs_bfs",
+    "synthetic_reasoning_ppl/clrs_style/clrs_binary_search",
+    "synthetic_reasoning_ppl/clrs_style/clrs_connected_components",
+    "synthetic_reasoning_ppl/clrs_style/clrs_dijkstra",
+    "synthetic_reasoning_ppl/clrs_style/clrs_floyd_warshall",
+    "synthetic_reasoning_ppl/clrs_style/clrs_insertion_sort",
+    "synthetic_reasoning_ppl/clrs_style/clrs_lcs_length",
+    "synthetic_reasoning_ppl/clrs_style/clrs_lis",
+    "synthetic_reasoning_ppl/clrs_style/clrs_mst_prim",
+    "synthetic_reasoning_ppl/clrs_style/clrs_topological_sort",
+    "synthetic_reasoning_ppl/native/bfs_shortest_path",
+    "synthetic_reasoning_ppl/native/binary_search",
+    "synthetic_reasoning_ppl/native/coin_change_dp",
+    "synthetic_reasoning_ppl/native/connected_components",
+    "synthetic_reasoning_ppl/native/dijkstra_shortest_path",
+    "synthetic_reasoning_ppl/native/edit_distance_dp",
+    "synthetic_reasoning_ppl/native/euclid_gcd",
+    "synthetic_reasoning_ppl/native/floyd_warshall_apsp",
+    "synthetic_reasoning_ppl/native/insertion_sort",
+    "synthetic_reasoning_ppl/native/interval_scheduling",
+    "synthetic_reasoning_ppl/native/kmp_string_search",
+    "synthetic_reasoning_ppl/native/knapsack_01_dp",
+    "synthetic_reasoning_ppl/native/lcs_dp",
+    "synthetic_reasoning_ppl/native/lis_dp",
+    "synthetic_reasoning_ppl/native/n_queens_backtracking",
+    "synthetic_reasoning_ppl/native/parentheses_balance",
+    "synthetic_reasoning_ppl/native/prim_mst",
+    "synthetic_reasoning_ppl/native/propositional_entailment",
+    "synthetic_reasoning_ppl/native/topological_sort",
+    "synthetic_reasoning_ppl/native/union_find_connectivity",
+    "synthetic_reasoning_ppl/stepmath/algebra_linear_equation",
+    "synthetic_reasoning_ppl/stepmath/arithmetic",
+}
+
+REMOVED_LEGACY_ALIAS_KEYS = {
+    "synthetic_reasoning_ppl/native/binary_search_5shot_icl",
+    "synthetic_reasoning_ppl/native/edit_distance_dp_1shot_icl",
+    "synthetic_reasoning_ppl/native/euclid_gcd_5shot_icl",
+    "synthetic_reasoning_ppl/native/interval_scheduling_1shot_icl",
+    "synthetic_reasoning_ppl/native/kmp_string_search_1shot_icl",
+    "synthetic_reasoning_ppl/native/knapsack_01_dp_1shot_icl",
+    "synthetic_reasoning_ppl/native/lcs_dp_1shot_icl",
+    "synthetic_reasoning_ppl/native/n_queens_backtracking_1shot_icl",
+    "synthetic_reasoning_ppl/native/parentheses_balance_5shot_icl",
+    "synthetic_reasoning_ppl/native/union_find_connectivity_1shot_icl",
+    "synthetic_reasoning_ppl/stepmath/algebra_linear_equation_3shot_icl",
+    "synthetic_reasoning_ppl/stepmath/arithmetic_5shot_icl",
+}
+
+
+def test_synthetic_reasoning_registry_uses_pinned_arrow_icl_target_only_configs():
+    datasets = synthetic_reasoning_raw_validation_sets()
+
+    assert set(datasets) == EXPECTED_SYNTHETIC_REASONING_KEYS
+
+    for key in (
+        "synthetic_reasoning_ppl/native/euclid_gcd",
+        "synthetic_reasoning_ppl/native/connected_components",
+        "synthetic_reasoning_ppl/clrs_style/clrs_bfs",
+        "synthetic_reasoning_ppl/stepmath/arithmetic",
+    ):
+        dataset = datasets[key]
+        assert dataset.hf_dataset_id == SYNTHETIC_REASONING_HF_DATASET_ID
+        assert dataset.hf_dataset_revision == "0cedc373025ae08edf24e24d73eeda75980ddf8c"
+        assert dataset.hf_dataset_name is not None
+        assert dataset.hf_dataset_name.endswith("_arrow_5shot_icl")
+        assert dataset.input_key == "input"
+        assert dataset.target_key == "target"
+        assert "loss:target_only" in dataset.tags
+        assert f"icl_shots:{SYNTHETIC_REASONING_ICL_SHOTS}" in dataset.tags
+        assert f"prompt_format:{SYNTHETIC_REASONING_PROMPT_FORMAT}" in dataset.tags
+
+    assert datasets["synthetic_reasoning_ppl/native/euclid_gcd"].hf_dataset_name == ("native_euclid_gcd_arrow_5shot_icl")
+    assert datasets["synthetic_reasoning_ppl/clrs_style/clrs_bfs"].hf_dataset_name == (
+        "clrs_style_clrs_bfs_arrow_5shot_icl"
+    )
+
+
+def test_legacy_icl_slice_aliases_are_not_registered_twice():
+    datasets = synthetic_reasoning_raw_validation_sets()
+
+    assert datasets.keys().isdisjoint(REMOVED_LEGACY_ALIAS_KEYS)
+
+    assert datasets["synthetic_reasoning_ppl/stepmath/arithmetic"].hf_dataset_name == (
+        "stepmath_arithmetic_arrow_5shot_icl"
+    )
+    assert datasets["synthetic_reasoning_ppl/native/euclid_gcd"].hf_dataset_name == ("native_euclid_gcd_arrow_5shot_icl")

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -1,14 +1,15 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from marin.execution.executor import unwrap_versioned_value
+from marin.transform.conversation.adapters import InputDatasetFormat
+
 from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_METADATA_COLUMNS,
     FINEPROOFS_SFT_REVISION,
     INSTRUCTION_DATASET_NAME_TO_CONFIG,
     get_instruction_dataset,
 )
-from marin.execution.executor import unwrap_versioned_value
-from marin.transform.conversation.adapters import InputDatasetFormat
 
 
 def test_fineproofs_sft_datasets_are_registered():


### PR DESCRIPTION
Add v2 synthetic surface-form probe generators with raw continuation prompts, longer delimiter targets, and target-only supervised dataset metadata. These are intended for the next HF upload and dashboard rerun after the canonical synthetic reasoning PR lands.

Part of #5618