### PR TITLE
[ci] Bump datakit tier2 ferry entrypoint memory to 2G

### DIFF
--- a/.github/workflows/marin-canary-datakit-tier2.yaml
+++ b/.github/workflows/marin-canary-datakit-tier2.yaml
@@ -71,6 +71,7 @@ jobs:
           set -euo pipefail
           JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
             job run --no-wait \
+            --memory=2G \
             --extra=cpu \
             -e SMOKE_RUN_ID "$SMOKE_RUN_ID" \
             -e FERRY_STATUS_PATH "$FERRY_STATUS_PATH" \

--- a/scripts/datakit/submit_perf_run.py
+++ b/scripts/datakit/submit_perf_run.py
@@ -99,11 +99,10 @@ TIERS: dict[str, TierConfig] = {
         priority="production",
     ),
     # marin-canary-datakit-tier2.yaml — synthetic skewed long-tail stress.
-    # Uses iris defaults for memory/disk/cpu/priority (no overrides in the
-    # workflow), so we leave them unset here too.
     "2": TierConfig(
         ferry_module="experiments.ferries.datakit_tier2_skewed_ferry",
         extra="cpu",
+        memory="2G",
     ),
     # marin-canary-datakit-tier3.yaml — Nemotron quality=high, max_files=1000.
     # `FERRY_TEST_MAX_FILES=1000` caps the staged shard count to ~10% of the


### PR DESCRIPTION
Match the memory budget used by the canary ferries (marin-canary-ferry, marin-canary-ferry-coreweave) which already pass --memory=2G to iris job run.