### PR TITLE
[levanter] Close temp config handles after creation

### DIFF
--- a/lib/levanter/src/levanter/config.py
+++ b/lib/levanter/src/levanter/config.py
@@ -140,11 +140,11 @@ def _maybe_get_config_path_and_cmdline_args(args: List[str]):
                 fs: AbstractFileSystem
                 fs, fs_path = url_to_fs(config_path)
                 temp_file = tempfile.NamedTemporaryFile(prefix="config", suffix=".yaml", delete=False)
-                # Bind ``temp_file`` per-iteration via a default arg: without this, every lambda
-                # captures the same loop variable and only the final temp file would be unlinked.
-                atexit.register(lambda tf=temp_file: os.unlink(tf.name))
-                fs.get(fs_path, temp_file.name)
-                config_path = temp_file.name
+                temp_config_path = temp_file.name
+                temp_file.close()
+                atexit.register(lambda path=temp_config_path: os.unlink(path))
+                fs.get(fs_path, temp_config_path)
+                config_path = temp_config_path
 
             config_paths.append(config_path)
             del args[config_path_index]
@@ -156,12 +156,13 @@ def _maybe_get_config_path_and_cmdline_args(args: List[str]):
         elif len(config_paths) > 1:
             # merge the configs by concatenating them
             temp_merged_config_path = tempfile.NamedTemporaryFile(prefix="config_merged", suffix=".yaml", delete=False)
-            atexit.register(lambda: os.unlink(temp_merged_config_path.name))
-            with open(temp_merged_config_path.name, "w") as f:
+            merged_config_path = temp_merged_config_path.name
+            temp_merged_config_path.close()
+            atexit.register(lambda path=merged_config_path: os.unlink(path))
+            with open(merged_config_path, "w") as f:
                 for config_path in config_paths:
                     with open(config_path) as config_file:
                         f.write(config_file.read())
-            merged_config_path = temp_merged_config_path.name
         else:
             raise ValueError("No config path found in args")
 

--- a/lib/levanter/tests/test_config.py
+++ b/lib/levanter/tests/test_config.py
@@ -2,9 +2,10 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
+import os
 
 import fsspec
-
+import pytest
 
 import levanter.config
 from levanter.data.text import LmDataConfig, UrlDatasetSourceConfig
@@ -31,6 +32,23 @@ def test_main_wrapper_loads_from_fsspec():
         assert config.x == 2
 
     main()
+
+
+def test_remote_config_temp_file_handle_is_closed():
+    fd_dir = "/proc/self/fd"
+    if not os.path.isdir(fd_dir):
+        pytest.skip("/proc/self/fd is required to inspect open file descriptors")
+
+    with fsspec.open("memory://test_fd.yaml", "w") as f:
+        f.write("project: test\n")
+
+    config_path, remaining_args = levanter.config._maybe_get_config_path_and_cmdline_args(
+        ["--config_path", "memory://test_fd.yaml"]
+    )
+
+    assert remaining_args == []
+    assert os.path.exists(config_path)
+    assert _open_file_descriptors_for_path(config_path) == []
 
 
 def test_lm_dataset_config():
@@ -103,3 +121,15 @@ def _write_yaml_to_memory(yaml: str, path: str = "memory://test.yaml"):
     with fsspec.open(path, "w") as f:
         f.write(yaml)
     return path
+
+
+def _open_file_descriptors_for_path(path: str):
+    open_fds = []
+    for fd in os.listdir("/proc/self/fd"):
+        try:
+            fd_path = os.readlink(os.path.join("/proc/self/fd", fd))
+        except FileNotFoundError:
+            continue
+        if fd_path == path:
+            open_fds.append(fd)
+    return open_fds


### PR DESCRIPTION
Close URL and merged config NamedTemporaryFile handles after recording their paths, then register atexit cleanup lambdas that capture only path strings. Adds a regression test that verifies downloaded remote config files do not remain open after argument normalization.

Refs #5903