### PR TITLE
fray: thread-safe lazy resolve in IrisActorHandle

### DIFF
--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -254,6 +254,7 @@ class IrisActorHandle:
     def __init__(self, endpoint_name: str):
         self._endpoint_name = endpoint_name
         self._client: Any = None  # Lazily resolved ActorClient
+        self._resolve_lock = threading.Lock()
 
     def __getstate__(self) -> dict:
         # Only serialize the endpoint name - client is lazily resolved
@@ -262,10 +263,15 @@ class IrisActorHandle:
     def __setstate__(self, state: dict) -> None:
         self._endpoint_name = state["endpoint_name"]
         self._client = None
+        self._resolve_lock = threading.Lock()
 
     def _resolve(self) -> Any:
         """Resolve endpoint to ActorClient via IrisContext."""
-        if self._client is None:
+        if self._client is not None:
+            return self._client
+        with self._resolve_lock:
+            if self._client is not None:
+                return self._client
             ctx = get_iris_ctx()
             if ctx is None:
                 raise RuntimeError(
@@ -273,7 +279,7 @@ class IrisActorHandle:
                     "Call from within an Iris job or set context via iris_ctx_scope()."
                 )
             self._client = ActorClient(ctx.resolver, self._endpoint_name)
-        return self._client
+            return self._client
 
     def __getattr__(self, method_name: str) -> _IrisActorMethod:
         if method_name.startswith("_"):


### PR DESCRIPTION
* https://github.com/marin-community/marin/pull/5814 now starts multiple threads that race to resolve the coordinator
* guard `IrisActorHandle._resolve()` against concurrent first callers
* before: heartbeat + stage-manager threads racing on a freshly unpickled handle both saw `self._client is None`, each built their own `ActorClient`, each cold-started a TCP connection and logged `Resolving name ...` — visible at zephyr worker startup as paired duplicate resolve log lines [^1]
* add `self._resolve_lock = threading.Lock()` in `__init__` and recreate it in `__setstate__` (locks aren't picklable)
* `_resolve()` now uses double-checked locking — fast path stays lock-free for the warm case, only one thread builds the `ActorClient` under contention

[^1]: e.g. two back-to-back `Resolving name /rav/.../zephyr-normalize-...-coord-0` lines at the same timestamp from `StageManagerActor.__init__` spawning heartbeat and stage-manager daemon threads that both immediately call `coordinator.get_current_stage_type.remote()`.