### PR TITLE
zephyr: fail actor on coordinator-unreachable so iris retries

### DIFF
--- a/lib/fray/src/fray/actor.py
+++ b/lib/fray/src/fray/actor.py
@@ -12,7 +12,7 @@ from __future__ import annotations
 
 import threading
 from contextvars import ContextVar
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from typing import Any, Protocol
 
 
@@ -26,8 +26,10 @@ class ActorHandle(Protocol):
 class ActorContext:
     """Context available to actors during execution.
 
-    ``shutdown_event`` is set by the actor when it is ready to exit; the
-    backend creates the event and blocks on it to tear the actor down.
+    To exit, the actor sets ``shutdown_event`` (clean — task SUCCEEDED) or
+    calls ``fail(exc)`` (task FAILED — retry policy applies). Backends create
+    the event and block on it; on wake, they re-raise the first recorded
+    error if any.
     """
 
     handle: ActorHandle
@@ -41,6 +43,15 @@ class ActorContext:
 
     shutdown_event: threading.Event | None = None
     """Set by the actor when ready to exit; backends wait on it."""
+
+    _errors: list[BaseException] = field(default_factory=list, repr=False)
+    """Fray-internal: errors recorded via ``fail()``; backends inspect after wait."""
+
+    def fail(self, exc: BaseException) -> None:
+        """Request failure exit. Backends re-raise so retry policy applies."""
+        self._errors.append(exc)
+        if self.shutdown_event is not None:
+            self.shutdown_event.set()
 
 
 class HostedActor:

--- a/lib/fray/src/fray/actor.py
+++ b/lib/fray/src/fray/actor.py
@@ -28,8 +28,7 @@ class ActorContext:
 
     To exit, the actor sets ``shutdown_event`` (clean — task SUCCEEDED) or
     calls ``fail(exc)`` (task FAILED — retry policy applies). Backends create
-    the event and block on it; on wake, they re-raise the first recorded
-    error if any.
+    the event and block on it; on wake, they inspect recorded errors.
     """
 
     handle: ActorHandle

--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -246,6 +246,9 @@ def _host_actor(actor_class: type, args: tuple, kwargs: dict, name_prefix: str) 
     shutdown_event.wait()
     logger.info(f"Actor {actor_name} shutting down")
     server.stop()
+    if actor_ctx._errors:
+        logger.error("Actor %s recorded %d failure(s); raising the first", actor_name, len(actor_ctx._errors))
+        raise actor_ctx._errors[0]
 
 
 class IrisActorHandle:

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -364,6 +364,10 @@ class ZephyrWorkerError(RuntimeError):
     """Raised when a worker encounters a fatal (non-transient) error."""
 
 
+class CoordinatorUnreachable(RuntimeError):
+    """Worker lost contact with the coordinator. Retryable at the iris task level."""
+
+
 # Application errors that should never be retried by the execute() retry loop.
 # These are deterministic errors (bad plan, invalid config, programming bugs)
 # that would fail identically on every attempt. Infrastructure errors (OSError,
@@ -1360,10 +1364,10 @@ class ZephyrWorker:
 
         # Capture actor context while ContextVar is still set (child threads
         # in Python <3.12 don't inherit it).
-        actor_ctx = current_actor()
-        self._host_shutdown_event = actor_ctx.shutdown_event
-        self._worker_id = f"{actor_ctx.group_name}-{actor_ctx.index}"
-        self._actor_handle = actor_ctx.handle
+        self._actor_ctx = current_actor()
+        self._host_shutdown_event = self._actor_ctx.shutdown_event
+        self._worker_id = f"{self._actor_ctx.group_name}-{self._actor_ctx.index}"
+        self._actor_handle = self._actor_ctx.handle
 
         threading.Thread(
             target=self._heartbeat_loop,
@@ -1538,6 +1542,14 @@ class ZephyrWorker:
                         "[%s] %d consecutive heartbeat failures — coordinator unreachable, shutting down",
                         self._worker_id,
                         consecutive_failures,
+                    )
+                    # Fail the actor so iris records the task as FAILED and the
+                    # worker group's max_task_retries policy reschedules this
+                    # replica. Setting only _shutdown_event would drain the
+                    # worker but exit cleanly — iris would record SUCCEEDED
+                    # and never retry.
+                    self._actor_ctx.fail(
+                        CoordinatorUnreachable(f"{consecutive_failures} consecutive heartbeat failures")
                     )
                     self._shutdown_event.set()
                     break

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1543,11 +1543,6 @@ class ZephyrWorker:
                         self._worker_id,
                         consecutive_failures,
                     )
-                    # Fail the actor so iris records the task as FAILED and the
-                    # worker group's max_task_retries policy reschedules this
-                    # replica. Setting only _shutdown_event would drain the
-                    # worker but exit cleanly — iris would record SUCCEEDED
-                    # and never retry.
                     self._actor_ctx.fail(
                         CoordinatorUnreachable(f"{consecutive_failures} consecutive heartbeat failures")
                     )

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -22,6 +22,7 @@ from zephyr.dataset import Dataset
 from zephyr.execution import (
     MAX_SHARD_FAILURES,
     MAX_SHARD_INFRA_FAILURES,
+    CoordinatorUnreachable,
     CounterSnapshot,
     ListShard,
     PickleDiskChunk,
@@ -31,6 +32,7 @@ from zephyr.execution import (
     WorkerState,
     ZephyrContext,
     ZephyrCoordinator,
+    ZephyrWorker,
     ZephyrWorkerError,
     zephyr_worker_ctx,
 )
@@ -1291,6 +1293,56 @@ def test_stage_index_correct_with_join(local_client, tmp_path):
         # stage_label format: "stage{stage_idx}-{stage_name}"
         expected_idx = int(main_name.split("-")[0].replace("stage", ""))
         assert main_idx == expected_idx, f"{main_name!r} has current_stage_index={main_idx}, expected {expected_idx}"
+
+
+def test_heartbeat_failures_fail_actor_context():
+    """After max consecutive heartbeat failures, the worker records a
+    ``CoordinatorUnreachable`` on its actor context and sets the host
+    shutdown event so ``_host_actor`` re-raises it.
+
+    Without this, the worker would set only its internal ``_shutdown_event``
+    and exit cleanly — iris would mark the task SUCCEEDED and never retry.
+    """
+    from concurrent.futures import Future
+
+    from fray.actor import ActorContext
+
+    class _FailingMethod:
+        def remote(self, *args, **kwargs):
+            f: Future = Future()
+            f.set_exception(ConnectionError("simulated coordinator unreachable"))
+            return f
+
+    class _FailingCoordinator:
+        def __getattr__(self, name):
+            return _FailingMethod()
+
+    shutdown_event = threading.Event()
+    actor_ctx = ActorContext(
+        handle=MagicMock(),
+        index=0,
+        group_name="test-worker",
+        shutdown_event=shutdown_event,
+    )
+
+    worker = ZephyrWorker.__new__(ZephyrWorker)
+    worker._actor_ctx = actor_ctx
+    worker._shutdown_event = threading.Event()
+    worker._active_sub_ids = []
+    worker._worker_id = "test-worker-0"
+    worker._report_worker_iris_status = lambda: None
+
+    t = threading.Thread(
+        target=worker._heartbeat_loop,
+        kwargs={"coordinator": _FailingCoordinator(), "interval": 0.01, "max_consecutive_failures": 3},
+    )
+    t.start()
+    t.join(timeout=5.0)
+
+    assert not t.is_alive(), "heartbeat loop did not exit after exhausting failure budget"
+    assert shutdown_event.is_set(), "actor_ctx.shutdown_event should have been set by fail()"
+    assert actor_ctx._errors, "expected at least one error recorded on actor_ctx"
+    assert isinstance(actor_ctx._errors[0], CoordinatorUnreachable)
 
 
 # --- Integration tests (all backends) ---

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -11,11 +11,13 @@ import os
 import threading
 import time
 import uuid
+from concurrent.futures import Future
 from pathlib import Path
 from unittest.mock import MagicMock
 
 import pytest
 from fray import ResourceConfig
+from fray.actor import ActorContext
 from fray.local_backend import LocalClient
 from zephyr import counters
 from zephyr.dataset import Dataset
@@ -1303,9 +1305,6 @@ def test_heartbeat_failures_fail_actor_context():
     Without this, the worker would set only its internal ``_shutdown_event``
     and exit cleanly — iris would mark the task SUCCEEDED and never retry.
     """
-    from concurrent.futures import Future
-
-    from fray.actor import ActorContext
 
     class _FailingMethod:
         def remote(self, *args, **kwargs):


### PR DESCRIPTION
* fail the actor task (instead of clean-exiting) when a zephyr worker gives up after 5 consecutive heartbeat failures, so iris records it as FAILED and `ActorConfig(max_task_retries=10)` on the worker group reschedules the replica
* previously: heartbeat-giveup set zephyr's internal `_shutdown_event` and the actor's `shutdown_event`, `_host_actor` returned normally, iris saw SUCCEEDED, worker silently disappeared with no retry [^1]
* add a failure channel on `fray.actor.ActorContext`: private `_errors: list[BaseException]` field + public `fail(exc)` helper that appends and signals `shutdown_event`
  * `ActorContext` stays `frozen=True`; only the list contents mutate
* `fray.iris_backend._host_actor` re-raises `_errors[0]` after `shutdown_event.wait()` so the iris task records as FAILED
  * logs the recorded failure count first in case multiple subsystems failed
* new `CoordinatorUnreachable(RuntimeError)` in `zephyr.execution`; heartbeat-giveup path calls `self._actor_ctx.fail(CoordinatorUnreachable(...))` before setting its internal shutdown
* graceful pipeline-completion exit path is unchanged — `shutdown_event` set with no `_errors` → `_host_actor` returns normally → SUCCEEDED
* test exercises `_heartbeat_loop` against a coordinator stub whose RPCs always raise; asserts the loop exits, the actor shutdown event fires, and a `CoordinatorUnreachable` is recorded

[^1]: not a recent regression — the heartbeat-failure detection has set the host shutdown event since #3041 (Feb 2026); #4163 swapped `ray.kill()` for the `_host_shutdown_event`/`exit_actor()` path but kept the same "exit cleanly on giveup" behavior. iris-driven worker restart on coordinator-unreachable was never working.