### PR TITLE
Fix Iris in-cluster DynamicClient auth

### DIFF
--- a/lib/iris/src/iris/cluster/providers/k8s/service.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/service.py
@@ -204,7 +204,15 @@ class CloudK8sService:
 
         try:
             kubernetes.config.load_incluster_config()
-            return kubernetes.client.ApiClient()
+            api_client = kubernetes.client.ApiClient()
+            # Kubernetes client v36 DynamicClient uses "BearerToken", while
+            # load_incluster_config() stores the pod token under "authorization":
+            # https://github.com/kubernetes-client/python/blob/v36.0.0/kubernetes/base/dynamic/client.py#L274-L288
+            # https://github.com/kubernetes-client/python/blob/v36.0.0/kubernetes/base/config/incluster_config.py#L87-L92
+            auth_token = api_client.configuration.api_key.get("authorization")
+            if auth_token:
+                api_client.configuration.api_key["BearerToken"] = auth_token
+            return api_client
         except kubernetes.config.ConfigException:
             return kubernetes.config.new_client_from_config()
 


### PR DESCRIPTION
## Summary

Fix Iris controller auth on CoreWeave when the controller image resolves `kubernetes==36.0.0`.

In Kubernetes Python client v36, `DynamicClient` reads bearer auth from `configuration.api_key["BearerToken"]`, while `load_incluster_config()` stores the pod service-account token as `configuration.api_key["authorization"]`. This patch mirrors the in-cluster token into `BearerToken` before Iris creates DynamicClient-backed services.

Upstream source:
- DynamicClient uses `BearerToken`: https://github.com/kubernetes-client/python/blob/v36.0.0/kubernetes/base/dynamic/client.py#L274-L288
- In-cluster config writes `authorization`: https://github.com/kubernetes-client/python/blob/v36.0.0/kubernetes/base/config/incluster_config.py#L87-L92

## Testing

- `cd lib/iris && uv run pytest tests/cluster/providers/k8s/test_cloud_k8s_service.py` (`39 passed`)
- `./infra/pre-commit.py --files lib/iris/src/iris/cluster/providers/k8s/service.py lib/iris/tests/cluster/providers/k8s/test_cloud_k8s_service.py`
- CoreWeave manual check in `iris-ci`: started a temporary pod with the failing image `ghcr.io/marin-community/iris-controller:c5c66cd` (`kubernetes==36.0.0`), mounted the patched `service.py`, and ran `CloudK8sService(...).list_json(...)`. The call succeeded with `cloud_k8s_service_ok 1`, `bearertoken_alias True`, and `default_header_auth False`. The temporary pod/configmap were deleted after the check; the Iris controller was not restarted.