### PR TITLE
[codex] Support kubernetes v36 in Iris

### DIFF
--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -35,7 +35,7 @@ dependencies = [
 controller = [
     "duckdb>=1.0.0",
     "pyarrow>=19.0.0",
-    "kubernetes>=31.0.0,<36",
+    "kubernetes>=31.0.0,<37",
 ]
 worker = []
 
@@ -53,7 +53,7 @@ examples = [
 dev = [
     "duckdb>=1.0.0",
     "pyarrow>=19.0.0",
-    "kubernetes>=31.0.0,<36",
+    "kubernetes>=31.0.0,<37",
     "ipykernel>=7.1.0",
     "jupyter>=1.1.1",
     "nbconvert>=7.16.6",

--- a/lib/iris/src/iris/cluster/providers/k8s/service.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/service.py
@@ -15,7 +15,7 @@ from collections.abc import Iterator
 from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import Protocol, runtime_checkable
+from typing import Any, Protocol, runtime_checkable
 
 try:
     import kubernetes
@@ -54,6 +54,45 @@ DEFAULT_TIMEOUT: float = 60.0
 
 # Threshold for slow-operation warnings (milliseconds)
 _SLOW_THRESHOLD_MS: int = 2000
+
+
+def _sync_bearer_token_alias(configuration: kubernetes.client.Configuration) -> None:
+    token = configuration.api_key.get("authorization")
+    if token is not None:
+        # kubernetes-client/python v36 Configuration.auth_settings() reads
+        # api_key["BearerToken"], while the config loaders still write bearer
+        # tokens to api_key["authorization"].
+        configuration.api_key["BearerToken"] = token
+
+
+def _keep_bearer_token_alias_fresh(configuration: kubernetes.client.Configuration) -> None:
+    refresh_hook = configuration.refresh_api_key_hook
+    _sync_bearer_token_alias(configuration)
+
+    if refresh_hook is None:
+        return
+
+    def refresh_with_bearer_token_alias(client_configuration: kubernetes.client.Configuration) -> None:
+        refresh_hook(client_configuration)
+        _sync_bearer_token_alias(client_configuration)
+        client_configuration.refresh_api_key_hook = refresh_with_bearer_token_alias
+
+    configuration.refresh_api_key_hook = refresh_with_bearer_token_alias
+
+
+def _pod_log_response_text(response: Any) -> str:
+    data = getattr(response, "data", response)
+    if isinstance(data, bytes):
+        return data.decode("utf-8", errors="replace")
+    if isinstance(data, str):
+        return data
+    return str(data)
+
+
+def _release_pod_log_response(response: Any) -> None:
+    release_conn = getattr(response, "release_conn", None)
+    if callable(release_conn):
+        release_conn()
 
 
 @runtime_checkable
@@ -198,15 +237,21 @@ class CloudK8sService:
 
     def create_api_client(self) -> kubernetes.client.ApiClient:
         if self.kubeconfig_path:
-            return kubernetes.config.new_client_from_config(
+            api_client = kubernetes.config.new_client_from_config(
                 config_file=self.kubeconfig_path,
             )
+            _keep_bearer_token_alias_fresh(api_client.configuration)
+            return api_client
 
         try:
-            kubernetes.config.load_incluster_config()
-            return kubernetes.client.ApiClient()
+            config = kubernetes.client.Configuration()
+            kubernetes.config.load_incluster_config(client_configuration=config)
+            _keep_bearer_token_alias_fresh(config)
+            return kubernetes.client.ApiClient(config)
         except kubernetes.config.ConfigException:
-            return kubernetes.config.new_client_from_config()
+            api_client = kubernetes.config.new_client_from_config()
+            _keep_bearer_token_alias_fresh(api_client.configuration)
+            return api_client
 
     def _resource_api(self, resource: K8sResource):
         """Get the DynamicClient resource handle for a K8sResource enum member."""
@@ -476,11 +521,16 @@ class CloudK8sService:
                     "namespace": self.namespace,
                     "tail_lines": tail,
                     "previous": previous,
+                    "_preload_content": False,
                     "_request_timeout": self.timeout,
                 }
                 if container:
                     kwargs["container"] = container
-                return self._core_v1.read_namespaced_pod_log(**kwargs)
+                response = self._core_v1.read_namespaced_pod_log(**kwargs)
+                try:
+                    return _pod_log_response_text(response)
+                finally:
+                    _release_pod_log_response(response)
             except ApiException as e:
                 if e.status == 404:
                     return ""
@@ -509,6 +559,7 @@ class CloudK8sService:
                     "name": pod_name,
                     "namespace": self.namespace,
                     "timestamps": True,
+                    "_preload_content": False,
                     "_request_timeout": 15.0,
                 }
                 if container:
@@ -520,7 +571,11 @@ class CloudK8sService:
                 if limit_bytes is not None:
                     kwargs["limit_bytes"] = limit_bytes
 
-                raw = self._core_v1.read_namespaced_pod_log(**kwargs)
+                response = self._core_v1.read_namespaced_pod_log(**kwargs)
+                try:
+                    raw = _pod_log_response_text(response)
+                finally:
+                    _release_pod_log_response(response)
             except ApiException as e:
                 if e.status == 404:
                     return KubectlLogResult(lines=[], last_timestamp=since_time)

--- a/lib/iris/tests/cluster/providers/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_cloud_k8s_service.py
@@ -5,8 +5,30 @@
 
 from __future__ import annotations
 
+from datetime import datetime, timezone
+
 import pytest
+from iris.cluster.providers.k8s import service as k8s_service
 from iris.cluster.providers.k8s.types import K8sResource
+
+
+class _LogResponse:
+    def __init__(self, data: bytes):
+        self.data = data
+        self.released = False
+
+    def release_conn(self):
+        self.released = True
+
+
+class _CoreV1WithLogResponse:
+    def __init__(self, response: _LogResponse):
+        self.response = response
+        self.kwargs = None
+
+    def read_namespaced_pod_log(self, **kwargs):
+        self.kwargs = kwargs
+        return self.response
 
 
 # Test item_path construction for namespaced resources
@@ -126,3 +148,91 @@ def test_api_base_paths():
     assert K8sResource.DEPLOYMENTS.api_base() == "/apis/apps/v1"
     assert K8sResource.CLUSTER_ROLES.api_base() == "/apis/rbac.authorization.k8s.io/v1"
     assert K8sResource.NODE_POOLS.api_base() == "/apis/compute.coreweave.com/v1alpha1"
+
+
+def test_bearer_token_alias_is_added_for_incluster_auth():
+    if k8s_service.kubernetes is None:
+        pytest.skip("kubernetes client is not installed")
+
+    config = k8s_service.kubernetes.client.Configuration()
+    config.api_key["authorization"] = "bearer token-1"
+
+    k8s_service._keep_bearer_token_alias_fresh(config)
+
+    assert config.api_key["BearerToken"] == "bearer token-1"
+    assert config.get_api_key_with_prefix("BearerToken") == "bearer token-1"
+
+
+def test_bearer_token_alias_tracks_incluster_token_refresh():
+    if k8s_service.kubernetes is None:
+        pytest.skip("kubernetes client is not installed")
+
+    config = k8s_service.kubernetes.client.Configuration()
+    config.api_key["authorization"] = "bearer token-1"
+
+    def refresh(client_configuration):
+        client_configuration.api_key["authorization"] = "bearer token-2"
+        client_configuration.refresh_api_key_hook = refresh
+
+    config.refresh_api_key_hook = refresh
+    k8s_service._keep_bearer_token_alias_fresh(config)
+
+    assert config.get_api_key_with_prefix("BearerToken") == "bearer token-2"
+    assert config.api_key["BearerToken"] == "bearer token-2"
+    assert config.refresh_api_key_hook is not refresh
+
+
+def test_create_api_client_syncs_bearer_token_for_kubeconfig(monkeypatch):
+    if k8s_service.kubernetes is None:
+        pytest.skip("kubernetes client is not installed")
+
+    config = k8s_service.kubernetes.client.Configuration()
+    config.api_key["authorization"] = "bearer token-1"
+    api_client = k8s_service.kubernetes.client.ApiClient(config)
+
+    def new_client_from_config(config_file=None):
+        assert config_file == "/tmp/kubeconfig"
+        return api_client
+
+    monkeypatch.setattr(k8s_service.kubernetes.config, "new_client_from_config", new_client_from_config)
+    service = k8s_service.CloudK8sService.__new__(k8s_service.CloudK8sService)
+    service.kubeconfig_path = "/tmp/kubeconfig"
+
+    assert service.create_api_client() is api_client
+    assert config.api_key["BearerToken"] == "bearer token-1"
+
+
+def test_logs_decode_raw_response_bytes():
+    response = _LogResponse(b"line 1\nline 2\n")
+    core_v1 = _CoreV1WithLogResponse(response)
+    service = k8s_service.CloudK8sService.__new__(k8s_service.CloudK8sService)
+    service.namespace = "test-ns"
+    service.timeout = 60.0
+    service._core_v1 = core_v1
+
+    assert service.logs("pod-1", container="task", tail=10) == "line 1\nline 2\n"
+    assert core_v1.kwargs["_preload_content"] is False
+    assert core_v1.kwargs["container"] == "task"
+    assert response.released
+
+
+def test_stream_logs_decodes_raw_response_bytes():
+    response = _LogResponse(
+        b"2026-05-22T16:45:12.158721540Z I20260522 16:45:12 iris.test.verbose info-marker\n"
+        b"2026-05-22T16:45:12.158728857Z W20260522 16:45:12 iris.test.verbose warning-marker\n"
+    )
+    core_v1 = _CoreV1WithLogResponse(response)
+    service = k8s_service.CloudK8sService.__new__(k8s_service.CloudK8sService)
+    service.namespace = "test-ns"
+    service._core_v1 = core_v1
+
+    result = service.stream_logs("pod-1", container="task", limit_bytes=100_000)
+
+    assert core_v1.kwargs["_preload_content"] is False
+    assert core_v1.kwargs["container"] == "task"
+    assert response.released
+    assert [line.data for line in result.lines] == [
+        "I20260522 16:45:12 iris.test.verbose info-marker",
+        "W20260522 16:45:12 iris.test.verbose warning-marker",
+    ]
+    assert result.last_timestamp == datetime(2026, 5, 22, 16, 45, 12, 158728, tzinfo=timezone.utc)

--- a/uv.lock
+++ b/uv.lock
@@ -4400,9 +4400,10 @@ wheels = [
 
 [[package]]
 name = "kubernetes"
-version = "35.0.0"
+version = "36.0.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "aiohttp" },
     { name = "certifi" },
     { name = "durationpy" },
     { name = "python-dateutil" },
@@ -4413,9 +4414,9 @@ dependencies = [
     { name = "urllib3" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2c/8f/85bf51ad4150f64e8c665daf0d9dfe9787ae92005efb9a4d1cba592bd79d/kubernetes-35.0.0.tar.gz", hash = "sha256:3d00d344944239821458b9efd484d6df9f011da367ecb155dadf9513f05f09ee", size = 1094642, upload-time = "2026-01-16T01:05:27.76Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/bf/59/dc635e4e9afb3884bc5c57f14fe23783e4c04601aa20b835ac75c41d1625/kubernetes-36.0.0.tar.gz", hash = "sha256:027b606bb8032e6c6464a53236bdd9bd9a94c237e1063bc45a303c25b304ced9", size = 2346728, upload-time = "2026-05-20T20:44:24.28Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0c/70/05b685ea2dffcb2adbf3cdcea5d8865b7bc66f67249084cf845012a0ff13/kubernetes-35.0.0-py2.py3-none-any.whl", hash = "sha256:39e2b33b46e5834ef6c3985ebfe2047ab39135d41de51ce7641a7ca5b372a13d", size = 2017602, upload-time = "2026-01-16T01:05:25.991Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/d2/6f99ca9c7eb961dfdd45b9643101399a8ee20922c662c362c91e9cc7e832/kubernetes-36.0.0-py2.py3-none-any.whl", hash = "sha256:a766433357ec9f90db7565cccf52e28e7fca40b0ef366c80a6022adbc0ac0425", size = 4660469, upload-time = "2026-05-20T20:44:20.893Z" },
 ]
 
 [[package]]
@@ -5519,7 +5520,7 @@ requires-dist = [
     { name = "grpcio", specifier = ">=1.76.0" },
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "humanfriendly", specifier = ">=10.0" },
-    { name = "kubernetes", marker = "extra == 'controller'", specifier = ">=31.0.0,<36" },
+    { name = "kubernetes", marker = "extra == 'controller'", specifier = ">=31.0.0,<37" },
     { name = "marin-finelog", editable = "lib/finelog" },
     { name = "marin-rigging", editable = "lib/rigging" },
     { name = "pyarrow", marker = "extra == 'controller'", specifier = ">=19.0.0" },
@@ -5541,7 +5542,7 @@ dev = [
     { name = "duckdb", specifier = ">=1.0.0" },
     { name = "ipykernel", specifier = ">=7.1.0" },
     { name = "jupyter", specifier = ">=1.1.1" },
-    { name = "kubernetes", specifier = ">=31.0.0,<36" },
+    { name = "kubernetes", specifier = ">=31.0.0,<37" },
     { name = "nbconvert", specifier = ">=7.16.6" },
     { name = "nbformat", specifier = ">=5.10.4" },
     { name = "pillow", specifier = ">=10.0.0" },


### PR DESCRIPTION
## Summary
- Allow Iris to run with `kubernetes==36.0.0`.
- Bridge the v36 bearer-token key change for kubeconfig and in-cluster clients.
- Decode pod logs from raw response bytes before `limit_bytes` trimming.

## Upstream Auth Change
`kubernetes==36.0.0` changed the generated client auth lookup from `authorization` to `BearerToken`, but the released v36 config loaders still populate `authorization`. Iris mirrors the loaded token into both keys so generated APIs authenticate and refresh hooks keep both aliases current.

The core upstream quote is from the [release-36.0 changelog](https://github.com/kubernetes-client/python/blob/release-36.0/CHANGELOG.md#L240-L248): `Configuration auth uses 'BearerToken' instead of 'authorization' in api_key.`

<details>
<summary>Additional upstream evidence</summary>

- The v36 generated client checks `BearerToken`: [`if 'BearerToken' in self.api_key:`](https://github.com/kubernetes-client/python/blob/v36.0.0/kubernetes/client/configuration.py#L409-L416)
- The v36 in-cluster loader still writes `authorization`: [`client_configuration.api_key['authorization'] = self.token`](https://github.com/kubernetes-client/python/blob/v36.0.0/kubernetes/base/config/incluster_config.py#L91-L100)
- The v36 kubeconfig loader still writes `authorization`: [`client_configuration.api_key['authorization'] = self.token`](https://github.com/kubernetes-client/python/blob/v36.0.0/kubernetes/base/config/kube_config.py#L542-L548)
- Upstream fix PR [kubernetes-client/python#2585](https://github.com/kubernetes-client/python/pull/2585) describes the same loader mismatch as `they still write api_key['authorization']` and the failure mode as `silently send unauthenticated requests`.
- Upstream issue [kubernetes-client/python#2582](https://github.com/kubernetes-client/python/issues/2582) matches the observed failure shape: `headers: {}` and `system:anonymous`.

</details>

## Validation
- `cd lib/iris && uv run --group dev python -m pytest --tb=short tests/cluster/providers/k8s/test_cloud_k8s_service.py` (44 passed)
- `cd lib/iris && uv run --group dev python -m pytest --tb=short tests/cluster/providers/k8s` (250 passed)
- `./infra/pre-commit.py --files lib/iris/src/iris/cluster/providers/k8s/service.py lib/iris/tests/cluster/providers/k8s/test_cloud_k8s_service.py lib/iris/pyproject.toml uv.lock` (passed)
- Manual CW kubeconfig repro lists pods in `iris-ci` with both auth aliases present.
- Manual CW in-cluster probe confirmed `kubernetes 36.0.0` and both auth aliases.
- CoreWeave smoke passed on the pre-rebase equivalent patch: run `26311058587`, job `77461399389`.