### PR TITLE
iris: stamp finished_at_ms when worker confirms terminal attempt

### DIFF
--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -1785,8 +1785,21 @@ class ControllerTransitions:
             # The attempt is already terminal (e.g. preempted, killed) but the task has
             # been rolled back to PENDING for retry and current_attempt_id still points
             # at the dead attempt. Reviving it would produce an inconsistent row where
-            # state contradicts finished_at_ms/error.
+            # state contradicts finished_at_ms/error. We still complete the deferred
+            # finalization the producing transition (preempt_task / cancel_*) is waiting
+            # for: stamp ``finished_at_ms`` when the worker confirms a terminal state.
+            # Without this the attempt row stays counted by ``resource_usage_by_worker``
+            # and ghost-pins the worker's capacity (see #5918).
             if attempt.state in TERMINAL_TASK_STATES:
+                if attempt.finished_at_ms is None and int(update.new_state) in TERMINAL_TASK_STATES:
+                    cur.execute(
+                        sa_update(task_attempts_table)
+                        .where(
+                            task_attempts_table.c.task_id == update.task_id,
+                            task_attempts_table.c.attempt_id == update.attempt_id,
+                        )
+                        .values(finished_at_ms=now_ms)
+                    )
                 logger.debug(
                     "Dropping late update for terminal attempt: task=%s attempt=%d attempt_state=%d reported=%d",
                     update.task_id,

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -1000,6 +1000,54 @@ def test_preemption_nonexistent_task_is_noop():
         assert result.tasks_to_kill == set()
 
 
+def test_preempt_then_worker_terminal_heartbeat_stamps_finished_at_ms():
+    """Regression for #5918: worker's post-preempt terminal heartbeat must finalize the attempt.
+
+    ``preempt_task`` marks the attempt PREEMPTED via ``_mark_task_producing_transition``,
+    which deliberately leaves ``finished_at_ms`` NULL and relies on the worker's
+    subsequent terminal-state heartbeat to stamp it. Without the stamp the row
+    stays counted by ``resource_usage_by_worker`` and ghost-pins the worker's
+    capacity for as long as the worker lives.
+    """
+    with make_controller_state() as state:
+        harness = ControllerTestHarness(state)
+        w1 = harness.add_worker("w1", cpu=4)
+
+        tasks = harness.submit("/alice/job", cpu=1, replicas=1, max_retries_preemption=5)
+        task = tasks[0]
+        harness.dispatch(task, w1)
+        attempt_id = query_task(state, task.task_id).current_attempt_id
+
+        # Producer transition: attempt PREEMPTED, finished_at_ms left NULL on purpose.
+        with state._db.transaction() as cur:
+            state.preempt_task(cur, task.task_id, reason="preempted by /bob/prod-job:0")
+        attempt = query_attempt(state, task.task_id, attempt_id)
+        assert attempt.state == job_pb2.TASK_STATE_PREEMPTED
+        assert attempt.finished_at_ms is None, "producer transition should leave finalization for heartbeat"
+
+        # Worker's heartbeat for the now-terminal attempt — the deferred finalization.
+        with state._db.transaction() as cur:
+            state.apply_task_updates(
+                cur,
+                HeartbeatApplyRequest(
+                    worker_id=w1,
+                    updates=[
+                        TaskUpdate(
+                            task_id=task.task_id,
+                            attempt_id=attempt_id,
+                            new_state=job_pb2.TASK_STATE_KILLED,
+                        )
+                    ],
+                ),
+            )
+
+        attempt = query_attempt(state, task.task_id, attempt_id)
+        assert attempt.finished_at_ms is not None, (
+            "worker's terminal-state heartbeat must stamp finished_at_ms on the preempted "
+            "attempt; otherwise the row stays in resource_usage_by_worker and ghost-pins capacity"
+        )
+
+
 def test_preemption_terminal_task_is_noop():
     """Preempting an already-finished task is a no-op."""
     with make_controller_state() as state:


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/5918
* stamp `finished_at_ms` on a heartbeat update for an already-terminal attempt instead of dropping it silently
* `_apply_task_transitions` at `transitions.py:1789-1797` hit `if attempt.state in TERMINAL_TASK_STATES: continue` — the producing transition (`preempt_task` / `cancel_*`) had marked the attempt terminal but deliberately left `finished_at_ms` NULL[^1], expecting this very heartbeat path to stamp it
* without the stamp the row stayed counted by `resource_usage_by_worker` (partial index `idx_task_attempts_live_workerbound`) and ghost-pinned the worker's capacity for as long as the worker lived
* observed in production: 377 worker-bound ghost rows cluster-wide pinning ~10 TiB / ~2k cores, with one `tpu_v4-reserved_2048-us-central2-b` slice rendered effectively unschedulable for 32 GiB tasks
* preserves the "don't revive a terminal attempt" invariant — `state` and `error` untouched, only `finished_at_ms` flipped from NULL to `now_ms`
* regression test: `test_preempt_then_worker_terminal_heartbeat_stamps_finished_at_ms`

[^1]: documented design in `_mark_task_producing_transition` (transitions.py:582-587): "Leaving `finished_at_ms` NULL keeps the worker capacity reserved until the worker confirms termination via heartbeat".
