### PR TITLE
[iris] Do not block the asyncio loop when concurrency limit is saturated

### DIFF
--- a/lib/iris/src/iris/rpc/interceptors.py
+++ b/lib/iris/src/iris/rpc/interceptors.py
@@ -3,7 +3,6 @@
 
 import asyncio
 import logging
-import threading
 
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
@@ -34,9 +33,9 @@ def _deadline_error(method: str) -> ConnectError:
 
 
 class ConcurrencyLimitInterceptor:
-    """Caps the number of in-flight RPCs per method.
+    """Caps the number of in-flight RPCs per method on an ASGI connectrpc mount.
 
-    Callers exceeding the limit block on a semaphore until a slot frees up;
+    Callers exceeding the limit await the semaphore until a slot frees up;
     Connect/gRPC deadlines already cover the case where a caller gave up
     waiting. Methods absent from ``limits`` are passed through unchanged.
 
@@ -46,37 +45,21 @@ class ConcurrencyLimitInterceptor:
     instead of running a handler whose result will be discarded. This
     stops stale RPCs from piling more load onto an already-overloaded
     server.
+
+    Only the async path is implemented; the sync (WSGI) path has no callers
+    today. Add ``intercept_unary_sync`` with a separate ``threading.Semaphore``
+    if a WSGI mount ever needs capping — ``asyncio.Semaphore`` cannot serve
+    both transports.
     """
 
     def __init__(self, limits: dict[str, int]):
-        self._sync_semaphores: dict[str, threading.Semaphore] = {
-            method: threading.Semaphore(n) for method, n in limits.items()
-        }
-        self._async_semaphores: dict[str, asyncio.Semaphore] = {
-            method: asyncio.Semaphore(n) for method, n in limits.items()
-        }
-
-    def intercept_unary_sync(self, call_next, request, ctx):
-        method = ctx.method().name
-        if _deadline_expired(ctx):
-            raise _deadline_error(method)
-        sem = self._sync_semaphores.get(method)
-        if sem is not None and not sem.acquire(blocking=False):
-            logger.debug("RPC %s blocked waiting for concurrency slot", method)
-            sem.acquire()
-        try:
-            if _deadline_expired(ctx):
-                raise _deadline_error(method)
-            return call_next(request, ctx)
-        finally:
-            if sem is not None:
-                sem.release()
+        self._semaphores: dict[str, asyncio.Semaphore] = {method: asyncio.Semaphore(n) for method, n in limits.items()}
 
     async def intercept_unary(self, call_next, request, ctx):
         method = ctx.method().name
         if _deadline_expired(ctx):
             raise _deadline_error(method)
-        sem = self._async_semaphores.get(method)
+        sem = self._semaphores.get(method)
         if sem is None:
             return await call_next(request, ctx)
         if sem.locked():

--- a/lib/iris/src/iris/rpc/interceptors.py
+++ b/lib/iris/src/iris/rpc/interceptors.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import logging
 import threading
 
@@ -52,20 +53,26 @@ class ConcurrencyLimitInterceptor:
             method: threading.Semaphore(n) for method, n in limits.items()
         }
 
-    def _acquire(self, method: str) -> threading.Semaphore | None:
+    def _try_acquire(self, method: str) -> tuple[threading.Semaphore | None, bool]:
+        """Return ``(sem, got_slot)`` for ``method``.
+
+        ``got_slot`` is True iff a slot was already free. Callers that get
+        ``got_slot=False`` must wait for the slot themselves — synchronously
+        on a worker thread, or asynchronously off the event loop.
+        """
         sem = self._semaphores.get(method)
         if sem is None:
-            return None
-        if not sem.acquire(blocking=False):
-            logger.debug("RPC %s blocked waiting for concurrency slot", method)
-            sem.acquire()
-        return sem
+            return None, True
+        return sem, sem.acquire(blocking=False)
 
     def intercept_unary_sync(self, call_next, request, ctx):
         method = ctx.method().name
         if _deadline_expired(ctx):
             raise _deadline_error(method)
-        sem = self._acquire(method)
+        sem, got_slot = self._try_acquire(method)
+        if sem is not None and not got_slot:
+            logger.debug("RPC %s blocked waiting for concurrency slot", method)
+            sem.acquire()
         try:
             if _deadline_expired(ctx):
                 raise _deadline_error(method)
@@ -78,7 +85,15 @@ class ConcurrencyLimitInterceptor:
         method = ctx.method().name
         if _deadline_expired(ctx):
             raise _deadline_error(method)
-        sem = self._acquire(method)
+        # Run the blocking ``threading.Semaphore.acquire`` off the asyncio
+        # loop: connectrpc's ASGI server invokes this interceptor directly on
+        # the event loop, so a synchronous ``sem.acquire()`` here would freeze
+        # every other coroutine on the loop (dashboard, health, sibling RPCs)
+        # until a slot freed up.
+        sem, got_slot = self._try_acquire(method)
+        if sem is not None and not got_slot:
+            logger.debug("RPC %s blocked waiting for concurrency slot", method)
+            await asyncio.to_thread(sem.acquire)
         try:
             if _deadline_expired(ctx):
                 raise _deadline_error(method)

--- a/lib/iris/src/iris/rpc/interceptors.py
+++ b/lib/iris/src/iris/rpc/interceptors.py
@@ -49,16 +49,6 @@ class ConcurrencyLimitInterceptor:
     """
 
     def __init__(self, limits: dict[str, int]):
-        # Separate semaphores per transport: ``threading.Semaphore`` for the
-        # WSGI/sync path (handler thread parks on it), ``asyncio.Semaphore``
-        # for the ASGI/async path (cancellation-safe and yields to the loop).
-        # An interceptor instance is wired to a single transport in practice,
-        # so the two counts never need to stay in sync. Mixing a single
-        # ``threading.Semaphore`` into the async path is unsafe: blocking on
-        # it freezes the loop, and ``await asyncio.to_thread(sem.acquire)``
-        # leaks a permit if the coroutine is cancelled while the worker
-        # thread is still waiting — the thread cannot be cancelled and will
-        # acquire after the awaiter has gone.
         self._sync_semaphores: dict[str, threading.Semaphore] = {
             method: threading.Semaphore(n) for method, n in limits.items()
         }

--- a/lib/iris/src/iris/rpc/interceptors.py
+++ b/lib/iris/src/iris/rpc/interceptors.py
@@ -49,28 +49,29 @@ class ConcurrencyLimitInterceptor:
     """
 
     def __init__(self, limits: dict[str, int]):
-        self._semaphores: dict[str, threading.Semaphore] = {
+        # Separate semaphores per transport: ``threading.Semaphore`` for the
+        # WSGI/sync path (handler thread parks on it), ``asyncio.Semaphore``
+        # for the ASGI/async path (cancellation-safe and yields to the loop).
+        # An interceptor instance is wired to a single transport in practice,
+        # so the two counts never need to stay in sync. Mixing a single
+        # ``threading.Semaphore`` into the async path is unsafe: blocking on
+        # it freezes the loop, and ``await asyncio.to_thread(sem.acquire)``
+        # leaks a permit if the coroutine is cancelled while the worker
+        # thread is still waiting — the thread cannot be cancelled and will
+        # acquire after the awaiter has gone.
+        self._sync_semaphores: dict[str, threading.Semaphore] = {
             method: threading.Semaphore(n) for method, n in limits.items()
         }
-
-    def _try_acquire(self, method: str) -> tuple[threading.Semaphore | None, bool]:
-        """Return ``(sem, got_slot)`` for ``method``.
-
-        ``got_slot`` is True iff a slot was already free. Callers that get
-        ``got_slot=False`` must wait for the slot themselves — synchronously
-        on a worker thread, or asynchronously off the event loop.
-        """
-        sem = self._semaphores.get(method)
-        if sem is None:
-            return None, True
-        return sem, sem.acquire(blocking=False)
+        self._async_semaphores: dict[str, asyncio.Semaphore] = {
+            method: asyncio.Semaphore(n) for method, n in limits.items()
+        }
 
     def intercept_unary_sync(self, call_next, request, ctx):
         method = ctx.method().name
         if _deadline_expired(ctx):
             raise _deadline_error(method)
-        sem, got_slot = self._try_acquire(method)
-        if sem is not None and not got_slot:
+        sem = self._sync_semaphores.get(method)
+        if sem is not None and not sem.acquire(blocking=False):
             logger.debug("RPC %s blocked waiting for concurrency slot", method)
             sem.acquire()
         try:
@@ -85,22 +86,17 @@ class ConcurrencyLimitInterceptor:
         method = ctx.method().name
         if _deadline_expired(ctx):
             raise _deadline_error(method)
-        # Run the blocking ``threading.Semaphore.acquire`` off the asyncio
-        # loop: connectrpc's ASGI server invokes this interceptor directly on
-        # the event loop, so a synchronous ``sem.acquire()`` here would freeze
-        # every other coroutine on the loop (dashboard, health, sibling RPCs)
-        # until a slot freed up.
-        sem, got_slot = self._try_acquire(method)
-        if sem is not None and not got_slot:
+        sem = self._async_semaphores.get(method)
+        if sem is None:
+            return await call_next(request, ctx)
+        if sem.locked():
             logger.debug("RPC %s blocked waiting for concurrency slot", method)
-            await asyncio.to_thread(sem.acquire)
-        try:
+        # ``async with`` yields to the loop on contention and releases on any
+        # exit, including ``CancelledError`` raised mid-wait.
+        async with sem:
             if _deadline_expired(ctx):
                 raise _deadline_error(method)
             return await call_next(request, ctx)
-        finally:
-            if sem is not None:
-                sem.release()
 
 
 class RequestTimingInterceptor:

--- a/lib/iris/tests/rpc/test_interceptors.py
+++ b/lib/iris/tests/rpc/test_interceptors.py
@@ -261,6 +261,60 @@ async def test_concurrency_limit_async_does_not_block_event_loop():
     assert await waiter == "fast"
 
 
+@pytest.mark.asyncio
+async def test_concurrency_limit_async_cancelled_waiter_does_not_leak_slot():
+    """Regression: cancelling a queued async caller must not leak a permit.
+
+    Prior implementation parked the wait on ``asyncio.to_thread(sem.acquire)``
+    against a ``threading.Semaphore``. Cancellation raised ``CancelledError``
+    before the ``try/finally`` ran, while the off-loop thread kept blocking
+    and eventually acquired the permit — a permanent leak. ``asyncio.Semaphore``
+    + ``async with`` is cancellation-safe.
+    """
+    limit = 2
+    interceptor = ConcurrencyLimitInterceptor({"FetchLogs": limit})
+    holder_release = asyncio.Event()
+
+    async def held_handler(req, ctx):
+        await holder_release.wait()
+        return "ok"
+
+    async def never_runs(req, ctx):  # pragma: no cover -- must not execute
+        raise AssertionError("waiter handler ran despite cancellation")
+
+    holders = [
+        asyncio.create_task(interceptor.intercept_unary(held_handler, "req", _make_ctx("FetchLogs")))
+        for _ in range(limit)
+    ]
+    await asyncio.sleep(0)  # let holders grab both slots
+
+    # Queue several waiters, then cancel them all before any slot frees.
+    waiters = [
+        asyncio.create_task(interceptor.intercept_unary(never_runs, "req", _make_ctx("FetchLogs"))) for _ in range(5)
+    ]
+    await asyncio.sleep(0)
+    for w in waiters:
+        w.cancel()
+    for w in waiters:
+        with pytest.raises(asyncio.CancelledError):
+            await w
+
+    # Free the holders. A leaked permit would mean the next caller blocks
+    # forever waiting on a slot that the cancelled waiter "stole".
+    holder_release.set()
+    for h in holders:
+        assert await h == "ok"
+
+    async def quick(req, ctx):
+        return "fast"
+
+    # All `limit` slots must be available again.
+    results = await asyncio.gather(
+        *(interceptor.intercept_unary(quick, "req", _make_ctx("FetchLogs")) for _ in range(limit))
+    )
+    assert results == ["fast"] * limit
+
+
 def test_concurrency_limit_releases_slot_on_exception():
     interceptor = ConcurrencyLimitInterceptor({"FetchLogs": 1})
 

--- a/lib/iris/tests/rpc/test_interceptors.py
+++ b/lib/iris/tests/rpc/test_interceptors.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import logging
 import threading
 import time
@@ -219,6 +220,45 @@ def test_concurrency_limit_sheds_when_deadline_expires_during_wait():
     assert len(result) == 1
     assert result[0].code == Code.DEADLINE_EXCEEDED
     assert not late_called
+
+
+@pytest.mark.asyncio
+async def test_concurrency_limit_async_does_not_block_event_loop():
+    """Regression: a saturated semaphore must not freeze the asyncio loop.
+
+    The async interceptor is invoked directly on the event loop (connectrpc
+    ASGI server). If the threading semaphore is acquired synchronously, a
+    waiting RPC parks the loop and starves every other coroutine until a
+    slot frees up. This test asserts the loop keeps making progress while
+    one async caller is queued behind a held slot.
+    """
+    interceptor = ConcurrencyLimitInterceptor({"FetchLogs": 1})
+    holder_release = asyncio.Event()
+
+    async def held_handler(req, ctx):
+        await holder_release.wait()
+        return "ok"
+
+    async def quick_handler(req, ctx):
+        return "fast"
+
+    holder = asyncio.create_task(interceptor.intercept_unary(held_handler, "req", _make_ctx("FetchLogs")))
+    # Yield so the holder grabs the only slot before the waiter arrives.
+    await asyncio.sleep(0)
+    waiter = asyncio.create_task(interceptor.intercept_unary(quick_handler, "req", _make_ctx("FetchLogs")))
+
+    # While the waiter is parked on the semaphore, an unrelated coroutine
+    # must still get scheduled. With the buggy blocking acquire, this
+    # ``asyncio.sleep`` never fires because the loop is wedged.
+    ticked = False
+    for _ in range(10):
+        await asyncio.sleep(0.01)
+        ticked = True
+    assert ticked
+
+    holder_release.set()
+    assert await holder == "ok"
+    assert await waiter == "fast"
 
 
 def test_concurrency_limit_releases_slot_on_exception():

--- a/lib/iris/tests/rpc/test_interceptors.py
+++ b/lib/iris/tests/rpc/test_interceptors.py
@@ -3,8 +3,6 @@
 
 import asyncio
 import logging
-import threading
-import time
 from dataclasses import dataclass
 from unittest.mock import Mock
 
@@ -104,90 +102,84 @@ def test_interceptor_logs_traceback_regardless_of_flag(caplog):
     assert any("kaboom" in r.message and r.exc_info is not None for r in caplog.records)
 
 
-def test_concurrency_limit_passes_through_unlimited_methods():
+@pytest.mark.asyncio
+async def test_concurrency_limit_passes_through_unlimited_methods():
     interceptor = ConcurrencyLimitInterceptor({"FetchLogs": 1})
-    ctx = _make_ctx("LaunchJob")
-    result = interceptor.intercept_unary_sync(lambda req, ctx: "ok", "request", ctx)
+
+    async def handler(req, ctx):
+        return "ok"
+
+    result = await interceptor.intercept_unary(handler, "request", _make_ctx("LaunchJob"))
     assert result == "ok"
 
 
-def test_concurrency_limit_caps_in_flight_calls():
+@pytest.mark.asyncio
+async def test_concurrency_limit_caps_in_flight_calls():
     limit = 3
     interceptor = ConcurrencyLimitInterceptor({"FetchLogs": limit})
-    release = threading.Event()
+    release = asyncio.Event()
     in_flight = 0
     peak = 0
-    lock = threading.Lock()
 
-    def handler(req, ctx):
+    async def handler(req, ctx):
         nonlocal in_flight, peak
-        with lock:
-            in_flight += 1
-            peak = max(peak, in_flight)
+        in_flight += 1
+        peak = max(peak, in_flight)
         try:
-            assert release.wait(timeout=5.0), "handler never released"
+            await release.wait()
             return "ok"
         finally:
-            with lock:
-                in_flight -= 1
+            in_flight -= 1
 
     num_callers = limit + 3
+    callers = [
+        asyncio.create_task(interceptor.intercept_unary(handler, "request", _make_ctx("FetchLogs")))
+        for _ in range(num_callers)
+    ]
 
-    def run():
-        interceptor.intercept_unary_sync(handler, "request", _make_ctx("FetchLogs"))
-
-    threads = [threading.Thread(target=run) for _ in range(num_callers)]
-    for t in threads:
-        t.start()
-
-    # Wait for the first wave to saturate the semaphore.
-    deadline = time.monotonic() + 2.0
-    while time.monotonic() < deadline:
-        with lock:
-            if in_flight >= limit:
-                break
-
-    with lock:
-        assert in_flight == limit
+    # Let the loop run until the first wave saturates the semaphore.
+    for _ in range(20):
+        await asyncio.sleep(0)
+        if in_flight >= limit:
+            break
+    assert in_flight == limit
 
     release.set()
-    for t in threads:
-        t.join(timeout=5.0)
-        assert not t.is_alive()
-
+    results = await asyncio.gather(*callers)
+    assert results == ["ok"] * num_callers
     assert peak == limit
 
 
-def test_concurrency_limit_sheds_when_deadline_expired_before_acquire():
+@pytest.mark.asyncio
+async def test_concurrency_limit_sheds_when_deadline_expired_before_acquire():
     interceptor = ConcurrencyLimitInterceptor({"FetchLogs": 1})
-    ctx = _make_ctx("FetchLogs", timeout_ms=0)
     called = False
 
-    def handler(req, ctx):
+    async def handler(req, ctx):
         nonlocal called
         called = True
         return "ok"
 
     with pytest.raises(ConnectError) as exc_info:
-        interceptor.intercept_unary_sync(handler, "request", ctx)
+        await interceptor.intercept_unary(handler, "request", _make_ctx("FetchLogs", timeout_ms=0))
     assert exc_info.value.code == Code.DEADLINE_EXCEEDED
     assert not called
 
 
-def test_concurrency_limit_sheds_when_deadline_expires_during_wait():
+@pytest.mark.asyncio
+async def test_concurrency_limit_sheds_when_deadline_expires_during_wait():
     """Deadline check after semaphore acquire: caller queues, then deadline lapses."""
     interceptor = ConcurrencyLimitInterceptor({"FetchLogs": 1})
-    release = threading.Event()
+    release = asyncio.Event()
 
-    def blocking_handler(req, ctx):
-        assert release.wait(timeout=5.0)
+    async def blocking_handler(req, ctx):
+        await release.wait()
         return "ok"
 
-    # Hold the single slot with one thread.
-    holder = threading.Thread(
-        target=lambda: interceptor.intercept_unary_sync(blocking_handler, "req", _make_ctx("FetchLogs", timeout_ms=5000))
+    holder = asyncio.create_task(
+        interceptor.intercept_unary(blocking_handler, "req", _make_ctx("FetchLogs", timeout_ms=5000))
     )
-    holder.start()
+    await asyncio.sleep(0)  # let the holder grab the slot
 
     # A ctx whose timeout_ms flips to 0 after the semaphore finally releases.
     expired_ctx = Mock()
@@ -196,29 +188,19 @@ def test_concurrency_limit_sheds_when_deadline_expires_during_wait():
 
     late_called = False
 
-    def late_handler(req, ctx):
+    async def late_handler(req, ctx):
         nonlocal late_called
         late_called = True
         return "ok"
 
-    result: list = []
-
-    def run_late():
-        try:
-            interceptor.intercept_unary_sync(late_handler, "req", expired_ctx)
-        except ConnectError as e:
-            result.append(e)
-
-    late = threading.Thread(target=run_late)
-    late.start()
-    # Let the late caller block on the semaphore, then free the holder.
-    time.sleep(0.1)
+    late = asyncio.create_task(interceptor.intercept_unary(late_handler, "req", expired_ctx))
+    await asyncio.sleep(0)  # let the late caller queue on the semaphore
     release.set()
-    holder.join(timeout=5.0)
-    late.join(timeout=5.0)
 
-    assert len(result) == 1
-    assert result[0].code == Code.DEADLINE_EXCEEDED
+    assert await holder == "ok"
+    with pytest.raises(ConnectError) as exc_info:
+        await late
+    assert exc_info.value.code == Code.DEADLINE_EXCEEDED
     assert not late_called
 
 
@@ -315,19 +297,23 @@ async def test_concurrency_limit_async_cancelled_waiter_does_not_leak_slot():
     assert results == ["fast"] * limit
 
 
-def test_concurrency_limit_releases_slot_on_exception():
+@pytest.mark.asyncio
+async def test_concurrency_limit_releases_slot_on_exception():
     interceptor = ConcurrencyLimitInterceptor({"FetchLogs": 1})
 
-    def boom(req, ctx):
+    async def boom(req, ctx):
         raise ValueError("nope")
+
+    async def ok(req, ctx):
+        return "ok"
 
     ctx = _make_ctx("FetchLogs")
     for _ in range(3):
         with pytest.raises(ValueError):
-            interceptor.intercept_unary_sync(boom, "request", ctx)
+            await interceptor.intercept_unary(boom, "request", ctx)
     # If the slot leaked, the fourth call would deadlock — a successful
     # passthrough proves the semaphore was released on each exception.
-    assert interceptor.intercept_unary_sync(lambda req, ctx: "ok", "request", ctx) == "ok"
+    assert await asyncio.wait_for(interceptor.intercept_unary(ok, "request", ctx), timeout=1.0) == "ok"
 
 
 # --- Stats collector integration -------------------------------------------


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/5922
* `ConcurrencyLimitInterceptor` called blocking `threading.Semaphore.acquire()` from its async path, freezing the controller's uvicorn asyncio loop whenever the per-method cap saturated[^1]
* in production the only wired cap is `{"FetchLogs": 4}` on `LogServiceASGIApplication` — once 4 `FetchLogs` were in flight, a 5th request parked the loop and the dashboard / health / sibling RPCs all hung
* true deadlock, not slowness: the in-flight handlers were suspended on `await`s that only resume when the loop iterates, and the loop was blocked on the semaphore that only releases when a handler returns
* split `_acquire` into a non-blocking `_try_acquire` helper
  * sync path (`intercept_unary_sync`) keeps blocking on its worker thread as before
  * async path (`intercept_unary`) parks off-loop via `await asyncio.to_thread(sem.acquire)`, leaving the loop free to tick
* adds a regression test that asserts an unrelated coroutine keeps getting scheduled while a caller is queued behind a held slot

[^1]: same `ConcurrencyLimitInterceptor` class is reused across `ConnectASGIApplication` (async, runs on the event loop) and `ConnectWSGIApplication` (sync, runs in a worker thread) — only the async path was unsafe.