### PR TITLE
[iris] Add benjaminfeuer to researcher budget tier

### DIFF
--- a/lib/iris/config/marin.yaml
+++ b/lib/iris/config/marin.yaml
@@ -220,5 +220,6 @@ user_budgets:
       - kaiyue
       - ryan
       - marinazh
+      - benjaminfeuer
     budget_limit: 75000
     max_band: PRIORITY_BAND_INTERACTIVE


### PR DESCRIPTION
Add benjaminfeuer to the Researchers tier in marin.yaml so his budget persists across controller restarts. The controller truncates user_budgets and reconciles from this config on every restart, so a live iris user budget set already in place for him would otherwise be wiped.