### PR TITLE
Add more time for datakit canaries

### DIFF
--- a/.github/workflows/marin-canary-datakit-tier1.yaml
+++ b/.github/workflows/marin-canary-datakit-tier1.yaml
@@ -13,7 +13,7 @@ permissions:
 jobs:
   datakit-smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 120
+    timeout-minutes: 350
     concurrency:
       group: datakit-smoke
       cancel-in-progress: true

--- a/.github/workflows/marin-canary-datakit-tier2.yaml
+++ b/.github/workflows/marin-canary-datakit-tier2.yaml
@@ -11,7 +11,7 @@ permissions:
 jobs:
   datakit-tier2-ferry:
     runs-on: ubuntu-latest
-    timeout-minutes: 180  # ~10–20 min run; ample buffer
+    timeout-minutes: 350
     concurrency:
       group: datakit-tier2-ferry
       cancel-in-progress: true


### PR DESCRIPTION
Add more time for datakit canaries. We need to figure out a way to make these more stable between runs, in the meantime give more time.