### PR TITLE
[posttrain] Add Datakit-backed MathNet text SFT pilot

### DIFF
--- a/experiments/posttrain/mathnet_sft.py
+++ b/experiments/posttrain/mathnet_sft.py
@@ -1,0 +1,25 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Text-only SFT tokenization step for ShadenA/MathNet."""
+
+from levanter.data.text import ChatLmDatasetFormat
+from marin.datakit.download.mathnet import mathnet_text_sft_primary_step
+from marin.execution.executor import executor_main
+
+from experiments.defaults import default_tokenize
+from experiments.marin_models import marin_tokenizer
+
+mathnet_text_sft_primary = mathnet_text_sft_primary_step()
+mathnet_text_sft_primary_executor = mathnet_text_sft_primary.as_executor_step()
+
+mathnet_text_sft_primary_tokenized = default_tokenize(
+    name="mathnet-v0-text-sft-primary-marin-tokenizer",
+    dataset=mathnet_text_sft_primary_executor / "**/*.jsonl.gz",
+    tokenizer=marin_tokenizer,
+    format=ChatLmDatasetFormat(),
+)
+
+
+if __name__ == "__main__":
+    executor_main(steps=[mathnet_text_sft_primary_executor, mathnet_text_sft_primary_tokenized])

--- a/lib/marin/src/marin/datakit/download/mathnet.py
+++ b/lib/marin/src/marin/datakit/download/mathnet.py
@@ -1,0 +1,220 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""ShadenA/MathNet text-only SFT dataset download and transform.
+
+The first MathNet view keeps only examples that can be rendered as text:
+problem markdown in the user turn and one official solution in the assistant
+turn. Rows with attached images are left for a later multimodal pipeline.
+"""
+
+from collections.abc import Mapping
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from enum import StrEnum
+from typing import Any
+
+import fsspec
+from fray import ResourceConfig
+from zephyr import Dataset, ZephyrContext, counters, load_parquet
+
+from marin.core.conversation import DolmaConversationOutput, OpenAIChatMessage
+from marin.datakit.download.huggingface import download_hf_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "ShadenA/MathNet"
+HF_REVISION = "ae12e35eef0fc52bbbef270d6ef0f5b002252eb9"
+HF_URLS_GLOB = ["data/all/train-*.parquet"]
+LICENSE = "cc-by-4.0"
+ATTACHED_IMAGE_MARKER = "attached_image_"
+TEXT_SFT_VIEW = "text_sft_primary"
+RAW_STEP_NAME = "raw/mathnet-v0"
+PROCESSED_STEP_NAME = "processed/mathnet-v0/text-sft-primary"
+
+
+class MathNetLanguagePolicy(StrEnum):
+    ENGLISH_OR_UNKNOWN = "english_or_unknown"
+    ALL_LANGUAGES = "all_languages"
+
+
+class MathNetSolutionPolicy(StrEnum):
+    FIRST = "first"
+    ALL = "all"
+
+
+@dataclass(frozen=True)
+class MathNetTextSftConfig:
+    raw_input_path: str
+    output_path: str
+    language_policy: MathNetLanguagePolicy = MathNetLanguagePolicy.ENGLISH_OR_UNKNOWN
+    solution_policy: MathNetSolutionPolicy = MathNetSolutionPolicy.FIRST
+    excluded_ids_path: str = ""
+
+
+def has_attached_image_reference(text: str | None) -> bool:
+    return bool(text and ATTACHED_IMAGE_MARKER in text)
+
+
+def row_requires_image(row: Mapping[str, Any]) -> bool:
+    if row.get("images"):
+        return True
+    return has_attached_image_reference(row.get("problem_markdown"))
+
+
+def keep_language(language: str | None, policy: MathNetLanguagePolicy) -> bool:
+    if policy == MathNetLanguagePolicy.ALL_LANGUAGES:
+        return True
+    return language in (None, "", "en", "English")
+
+
+def selected_solutions(row: Mapping[str, Any], policy: MathNetSolutionPolicy) -> list[tuple[int, str]]:
+    solutions = [solution.strip() for solution in row.get("solutions_markdown") or []]
+    indexed = [(idx, solution) for idx, solution in enumerate(solutions) if solution]
+    if policy == MathNetSolutionPolicy.FIRST:
+        return indexed[:1]
+    return indexed
+
+
+def _load_excluded_ids(excluded_ids_path: str) -> set[str]:
+    if not excluded_ids_path:
+        return set()
+
+    with fsspec.open(excluded_ids_path, "rt", encoding="utf-8") as handle:
+        return {line.strip() for line in handle if line.strip()}
+
+
+def _conversation_id(mathnet_id: str, solution_index: int) -> str:
+    return f"mathnet:{HF_REVISION}:{mathnet_id}:solution-{solution_index}"
+
+
+def row_to_text_sft_records(
+    row: Mapping[str, Any],
+    cfg: MathNetTextSftConfig,
+    excluded_ids: set[str] | None = None,
+) -> list[dict[str, Any]]:
+    mathnet_id = str(row.get("id") or "").strip()
+    if not mathnet_id:
+        counters.increment("mathnet/skipped_empty_id")
+        return []
+
+    if mathnet_id in (excluded_ids or set()):
+        counters.increment("mathnet/skipped_benchmark_exclusion")
+        return []
+
+    problem = (row.get("problem_markdown") or "").strip()
+    if not problem:
+        counters.increment("mathnet/skipped_empty_problem")
+        return []
+
+    if row_requires_image(row):
+        counters.increment("mathnet/skipped_image")
+        return []
+
+    language = row.get("language")
+    if not keep_language(language, cfg.language_policy):
+        counters.increment("mathnet/skipped_language")
+        return []
+
+    solutions = selected_solutions(row, cfg.solution_policy)
+    if not solutions:
+        counters.increment("mathnet/skipped_empty_solution")
+        return []
+
+    records: list[dict[str, Any]] = []
+    solution_count = len([solution for solution in row.get("solutions_markdown") or [] if solution and solution.strip()])
+    for solution_index, solution in solutions:
+        if has_attached_image_reference(solution):
+            counters.increment("mathnet/skipped_image")
+            continue
+
+        output = DolmaConversationOutput(
+            id=_conversation_id(mathnet_id, solution_index),
+            source=HF_DATASET_ID,
+            messages=[
+                OpenAIChatMessage(role="user", content=problem),
+                OpenAIChatMessage(role="assistant", content=solution),
+            ],
+            added=datetime.now(UTC).isoformat(),
+            created="",
+            metadata={
+                "hf_revision": HF_REVISION,
+                "license": LICENSE,
+                "mathnet_id": mathnet_id,
+                "country": row.get("country"),
+                "competition": row.get("competition"),
+                "topics_flat": row.get("topics_flat") or [],
+                "language": language,
+                "problem_type": row.get("problem_type"),
+                "final_answer": row.get("final_answer"),
+                "solution_index": solution_index,
+                "solution_count": solution_count,
+                "view": TEXT_SFT_VIEW,
+                "has_images": False,
+                "language_policy": cfg.language_policy.value,
+                "solution_policy": cfg.solution_policy.value,
+                "excluded_ids_path": cfg.excluded_ids_path,
+            },
+        )
+        records.append(output.model_dump(mode="json"))
+
+    if records:
+        counters.increment("mathnet/kept", len(records))
+    return records
+
+
+def transform_text_sft(cfg: MathNetTextSftConfig) -> None:
+    excluded_ids = _load_excluded_ids(cfg.excluded_ids_path)
+    pipeline = (
+        Dataset.from_files(f"{cfg.raw_input_path}/data/all/*.parquet")
+        .flat_map(load_parquet)
+        .flat_map(lambda row: row_to_text_sft_records(row, cfg, excluded_ids))
+        .write_jsonl(
+            f"{cfg.output_path}/data-{{shard:05d}}-of-{{total:05d}}.jsonl.gz",
+            skip_existing=True,
+        )
+    )
+    ctx = ZephyrContext(name="mathnet-text-sft-transform", resources=ResourceConfig(cpu=1, ram="8g"))
+    ctx.execute(pipeline)
+
+
+def download_mathnet_raw_step() -> StepSpec:
+    """Download the deduplicated MathNet v0 ``all`` parquet shards."""
+    return download_hf_step(
+        RAW_STEP_NAME,
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=HF_URLS_GLOB,
+        worker_resources=ResourceConfig(cpu=1, ram="8g", disk="5g"),
+    )
+
+
+def mathnet_text_sft_primary_step(
+    *,
+    language_policy: MathNetLanguagePolicy = MathNetLanguagePolicy.ENGLISH_OR_UNKNOWN,
+    solution_policy: MathNetSolutionPolicy = MathNetSolutionPolicy.FIRST,
+    excluded_ids_path: str = "",
+) -> StepSpec:
+    """Create the text-only MathNet SFT processed-data step."""
+    raw = download_mathnet_raw_step()
+    return StepSpec(
+        name=PROCESSED_STEP_NAME,
+        deps=[raw],
+        fn=lambda output_path: transform_text_sft(
+            MathNetTextSftConfig(
+                raw_input_path=raw.output_path,
+                output_path=output_path,
+                language_policy=language_policy,
+                solution_policy=solution_policy,
+                excluded_ids_path=excluded_ids_path,
+            )
+        ),
+        hash_attrs={
+            "hf_dataset_id": HF_DATASET_ID,
+            "hf_revision": HF_REVISION,
+            "hf_urls_glob": HF_URLS_GLOB,
+            "language_policy": language_policy.value,
+            "solution_policy": solution_policy.value,
+            "excluded_ids_path": excluded_ids_path,
+            "version": "v1",
+        },
+    )

--- a/tests/datakit/download/test_mathnet.py
+++ b/tests/datakit/download/test_mathnet.py
@@ -7,18 +7,15 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 from marin.datakit.download.mathnet import (
-    HF_DATASET_ID,
     MathNetLanguagePolicy,
     MathNetSolutionPolicy,
     MathNetTextSftConfig,
-    download_mathnet_raw_step,
-    mathnet_text_sft_primary_step,
     row_to_text_sft_records,
     transform_text_sft,
 )
 
+EXPECTED_SOURCE = "ShadenA/MathNet"
 EXPECTED_HF_REVISION = "ae12e35eef0fc52bbbef270d6ef0f5b002252eb9"
-EXPECTED_ALL_TRAIN_GLOB = ["data/all/train-*.parquet"]
 
 
 def _base_config(
@@ -59,7 +56,7 @@ def test_text_only_row_becomes_two_message_record():
     assert len(records) == 1
     record = records[0]
     assert record["id"] == f"mathnet:{EXPECTED_HF_REVISION}:abc123:solution-0"
-    assert record["source"] == HF_DATASET_ID
+    assert record["source"] == EXPECTED_SOURCE
     assert record["messages"] == [
         {
             "role": "user",
@@ -179,42 +176,6 @@ def test_all_languages_policy_keeps_non_english_rows():
 
     assert len(records) == 1
     assert records[0]["metadata"]["language_policy"] == "all_languages"
-
-
-def test_excluded_ids_are_skipped():
-    row = _base_row(id="heldout")
-
-    assert row_to_text_sft_records(row, _base_config(), {"heldout"}) == []
-
-
-def test_download_step_restricts_to_default_all_config_train_files():
-    step = download_mathnet_raw_step()
-
-    assert step.name == "raw/mathnet-v0"
-    assert step.deps == []
-    assert step.hash_attrs == {
-        "hf_dataset_id": HF_DATASET_ID,
-        "revision": EXPECTED_HF_REVISION,
-        "hf_urls_glob": EXPECTED_ALL_TRAIN_GLOB,
-        "append_sha_to_path": False,
-    }
-
-
-def test_processed_step_records_policy_in_hash_attrs():
-    step = mathnet_text_sft_primary_step(
-        language_policy=MathNetLanguagePolicy.ALL_LANGUAGES,
-        solution_policy=MathNetSolutionPolicy.ALL,
-        excluded_ids_path="gs://example/heldout.txt",
-    )
-
-    assert step.name == "processed/mathnet-v0/text-sft-primary"
-    assert [dep.name for dep in step.deps] == ["raw/mathnet-v0"]
-    assert step.hash_attrs["hf_dataset_id"] == HF_DATASET_ID
-    assert step.hash_attrs["hf_revision"] == EXPECTED_HF_REVISION
-    assert step.hash_attrs["hf_urls_glob"] == EXPECTED_ALL_TRAIN_GLOB
-    assert step.hash_attrs["language_policy"] == "all_languages"
-    assert step.hash_attrs["solution_policy"] == "all"
-    assert step.hash_attrs["excluded_ids_path"] == "gs://example/heldout.txt"
 
 
 def test_transform_text_sft_filters_and_writes_chat_jsonl(tmp_path: Path, read_all_jsonl_gz):

--- a/tests/datakit/download/test_mathnet.py
+++ b/tests/datakit/download/test_mathnet.py
@@ -7,17 +7,18 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import pytest
 from marin.datakit.download.mathnet import (
-    HF_REVISION,
-    HF_URLS_GLOB,
+    HF_DATASET_ID,
     MathNetLanguagePolicy,
     MathNetSolutionPolicy,
     MathNetTextSftConfig,
-    _load_excluded_ids,
     download_mathnet_raw_step,
     mathnet_text_sft_primary_step,
     row_to_text_sft_records,
     transform_text_sft,
 )
+
+EXPECTED_HF_REVISION = "ae12e35eef0fc52bbbef270d6ef0f5b002252eb9"
+EXPECTED_ALL_TRAIN_GLOB = ["data/all/train-*.parquet"]
 
 
 def _base_config(
@@ -57,8 +58,8 @@ def test_text_only_row_becomes_two_message_record():
 
     assert len(records) == 1
     record = records[0]
-    assert record["id"] == f"mathnet:{HF_REVISION}:abc123:solution-0"
-    assert record["source"] == "ShadenA/MathNet"
+    assert record["id"] == f"mathnet:{EXPECTED_HF_REVISION}:abc123:solution-0"
+    assert record["source"] == HF_DATASET_ID
     assert record["messages"] == [
         {
             "role": "user",
@@ -86,7 +87,7 @@ def test_text_only_row_becomes_two_message_record():
     assert record["metadata"]["solution_count"] == 1
     assert record["metadata"]["language_policy"] == "english_or_unknown"
     assert record["metadata"]["solution_policy"] == "first"
-    assert record["metadata"]["hf_revision"] == HF_REVISION
+    assert record["metadata"]["hf_revision"] == EXPECTED_HF_REVISION
     assert record["metadata"]["license"] == "cc-by-4.0"
 
 
@@ -96,7 +97,7 @@ def test_first_solution_policy_uses_first_non_empty_solution():
     records = row_to_text_sft_records(row, _base_config())
 
     assert len(records) == 1
-    assert records[0]["id"] == f"mathnet:{HF_REVISION}:abc123:solution-1"
+    assert records[0]["id"] == f"mathnet:{EXPECTED_HF_REVISION}:abc123:solution-1"
     assert records[0]["messages"][1]["content"] == "First usable solution."
     assert records[0]["metadata"]["solution_count"] == 2
 
@@ -107,8 +108,8 @@ def test_all_solution_policy_expands_each_non_empty_solution():
     records = row_to_text_sft_records(row, _base_config(solution_policy=MathNetSolutionPolicy.ALL))
 
     assert [record["id"] for record in records] == [
-        f"mathnet:{HF_REVISION}:abc123:solution-0",
-        f"mathnet:{HF_REVISION}:abc123:solution-2",
+        f"mathnet:{EXPECTED_HF_REVISION}:abc123:solution-0",
+        f"mathnet:{EXPECTED_HF_REVISION}:abc123:solution-2",
     ]
     assert [record["messages"][1]["content"] for record in records] == ["First solution.", "Second solution."]
 
@@ -140,7 +141,7 @@ def test_all_solution_policy_skips_only_image_dependent_solution_variants():
     records = row_to_text_sft_records(row, _base_config(solution_policy=MathNetSolutionPolicy.ALL))
 
     assert len(records) == 1
-    assert records[0]["id"] == f"mathnet:{HF_REVISION}:abc123:solution-0"
+    assert records[0]["id"] == f"mathnet:{EXPECTED_HF_REVISION}:abc123:solution-0"
     assert records[0]["messages"][1]["content"] == "Text-only solution."
 
 
@@ -186,19 +187,17 @@ def test_excluded_ids_are_skipped():
     assert row_to_text_sft_records(row, _base_config(), {"heldout"}) == []
 
 
-def test_load_excluded_ids_reads_one_id_per_line(tmp_path: Path):
-    excluded_path = tmp_path / "heldout.txt"
-    excluded_path.write_text("abc123\n\nxyz789\n", encoding="utf-8")
-
-    assert _load_excluded_ids(str(excluded_path)) == {"abc123", "xyz789"}
-
-
-def test_download_step_restricts_to_default_all_config_files():
+def test_download_step_restricts_to_default_all_config_train_files():
     step = download_mathnet_raw_step()
 
-    assert step.hash_attrs["hf_dataset_id"] == "ShadenA/MathNet"
-    assert step.hash_attrs["revision"] == HF_REVISION
-    assert step.hash_attrs["hf_urls_glob"] == HF_URLS_GLOB
+    assert step.name == "raw/mathnet-v0"
+    assert step.deps == []
+    assert step.hash_attrs == {
+        "hf_dataset_id": HF_DATASET_ID,
+        "revision": EXPECTED_HF_REVISION,
+        "hf_urls_glob": EXPECTED_ALL_TRAIN_GLOB,
+        "append_sha_to_path": False,
+    }
 
 
 def test_processed_step_records_policy_in_hash_attrs():
@@ -209,30 +208,61 @@ def test_processed_step_records_policy_in_hash_attrs():
     )
 
     assert step.name == "processed/mathnet-v0/text-sft-primary"
-    assert step.hash_attrs["hf_dataset_id"] == "ShadenA/MathNet"
-    assert step.hash_attrs["hf_revision"] == HF_REVISION
-    assert step.hash_attrs["hf_urls_glob"] == HF_URLS_GLOB
+    assert [dep.name for dep in step.deps] == ["raw/mathnet-v0"]
+    assert step.hash_attrs["hf_dataset_id"] == HF_DATASET_ID
+    assert step.hash_attrs["hf_revision"] == EXPECTED_HF_REVISION
+    assert step.hash_attrs["hf_urls_glob"] == EXPECTED_ALL_TRAIN_GLOB
     assert step.hash_attrs["language_policy"] == "all_languages"
     assert step.hash_attrs["solution_policy"] == "all"
     assert step.hash_attrs["excluded_ids_path"] == "gs://example/heldout.txt"
 
 
-def test_transform_text_sft_writes_chat_jsonl(tmp_path: Path, read_all_jsonl_gz):
+def test_transform_text_sft_filters_and_writes_chat_jsonl(tmp_path: Path, read_all_jsonl_gz):
     raw_dir = tmp_path / "raw"
     raw_shard = raw_dir / "data" / "all" / "train-00000-of-00001.parquet"
     raw_shard.parent.mkdir(parents=True)
-    pq.write_table(pa.Table.from_pylist([_base_row()]), raw_shard)
+    pq.write_table(
+        pa.Table.from_pylist(
+            [
+                _base_row(id="kept", problem_markdown="Solve $x+1=2$.", solutions_markdown=["Subtract 1 to get $x=1$."]),
+                _base_row(id="heldout"),
+                _base_row(id="needs_image", problem_markdown="Use attached_image_1.png to solve this."),
+                _base_row(id="spanish", language="Spanish"),
+                _base_row(id="empty_solution", solutions_markdown=["", "   "]),
+            ]
+        ),
+        raw_shard,
+    )
+    excluded_ids = tmp_path / "heldout.txt"
+    excluded_ids.write_text("heldout\n\nunused-id\n", encoding="utf-8")
 
     output_dir = tmp_path / "processed"
     transform_text_sft(
         MathNetTextSftConfig(
             raw_input_path=str(raw_dir),
             output_path=str(output_dir),
+            excluded_ids_path=str(excluded_ids),
         )
     )
 
     records = read_all_jsonl_gz(output_dir)
     assert len(records) == 1
-    assert records[0]["id"] == f"mathnet:{HF_REVISION}:abc123:solution-0"
-    assert records[0]["messages"][0]["role"] == "user"
-    assert records[0]["messages"][1]["role"] == "assistant"
+    assert records[0]["id"] == f"mathnet:{EXPECTED_HF_REVISION}:kept:solution-0"
+    assert records[0]["messages"] == [
+        {
+            "role": "user",
+            "content": "Solve $x+1=2$.",
+            "name": None,
+            "tool_calls": None,
+            "tool_call_id": None,
+        },
+        {
+            "role": "assistant",
+            "content": "Subtract 1 to get $x=1$.",
+            "name": None,
+            "tool_calls": None,
+            "tool_call_id": None,
+        },
+    ]
+    assert records[0]["metadata"]["mathnet_id"] == "kept"
+    assert records[0]["metadata"]["excluded_ids_path"] == str(excluded_ids)

--- a/tests/datakit/download/test_mathnet.py
+++ b/tests/datakit/download/test_mathnet.py
@@ -1,0 +1,238 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from marin.datakit.download.mathnet import (
+    HF_REVISION,
+    HF_URLS_GLOB,
+    MathNetLanguagePolicy,
+    MathNetSolutionPolicy,
+    MathNetTextSftConfig,
+    _load_excluded_ids,
+    download_mathnet_raw_step,
+    mathnet_text_sft_primary_step,
+    row_to_text_sft_records,
+    transform_text_sft,
+)
+
+
+def _base_config(
+    *,
+    language_policy: MathNetLanguagePolicy = MathNetLanguagePolicy.ENGLISH_OR_UNKNOWN,
+    solution_policy: MathNetSolutionPolicy = MathNetSolutionPolicy.FIRST,
+    excluded_ids_path: str = "",
+) -> MathNetTextSftConfig:
+    return MathNetTextSftConfig(
+        raw_input_path="/raw",
+        output_path="/processed",
+        language_policy=language_policy,
+        solution_policy=solution_policy,
+        excluded_ids_path=excluded_ids_path,
+    )
+
+
+def _base_row(**overrides):
+    row = {
+        "id": "abc123",
+        "problem_markdown": "Prove that $a+b=b+a$.",
+        "solutions_markdown": ["Addition is commutative."],
+        "images": [],
+        "country": "United States",
+        "competition": "Example Olympiad",
+        "topics_flat": ["Algebra"],
+        "language": "English",
+        "problem_type": "proof only",
+        "final_answer": None,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_text_only_row_becomes_two_message_record():
+    records = row_to_text_sft_records(_base_row(), _base_config())
+
+    assert len(records) == 1
+    record = records[0]
+    assert record["id"] == f"mathnet:{HF_REVISION}:abc123:solution-0"
+    assert record["source"] == "ShadenA/MathNet"
+    assert record["messages"] == [
+        {
+            "role": "user",
+            "content": "Prove that $a+b=b+a$.",
+            "name": None,
+            "tool_calls": None,
+            "tool_call_id": None,
+        },
+        {
+            "role": "assistant",
+            "content": "Addition is commutative.",
+            "name": None,
+            "tool_calls": None,
+            "tool_call_id": None,
+        },
+    ]
+    assert record["metadata"]["mathnet_id"] == "abc123"
+    assert record["metadata"]["country"] == "United States"
+    assert record["metadata"]["competition"] == "Example Olympiad"
+    assert record["metadata"]["topics_flat"] == ["Algebra"]
+    assert record["metadata"]["language"] == "English"
+    assert record["metadata"]["problem_type"] == "proof only"
+    assert record["metadata"]["final_answer"] is None
+    assert record["metadata"]["solution_index"] == 0
+    assert record["metadata"]["solution_count"] == 1
+    assert record["metadata"]["language_policy"] == "english_or_unknown"
+    assert record["metadata"]["solution_policy"] == "first"
+    assert record["metadata"]["hf_revision"] == HF_REVISION
+    assert record["metadata"]["license"] == "cc-by-4.0"
+
+
+def test_first_solution_policy_uses_first_non_empty_solution():
+    row = _base_row(solutions_markdown=["", "First usable solution.", "Second usable solution."])
+
+    records = row_to_text_sft_records(row, _base_config())
+
+    assert len(records) == 1
+    assert records[0]["id"] == f"mathnet:{HF_REVISION}:abc123:solution-1"
+    assert records[0]["messages"][1]["content"] == "First usable solution."
+    assert records[0]["metadata"]["solution_count"] == 2
+
+
+def test_all_solution_policy_expands_each_non_empty_solution():
+    row = _base_row(solutions_markdown=["First solution.", "", "Second solution."])
+
+    records = row_to_text_sft_records(row, _base_config(solution_policy=MathNetSolutionPolicy.ALL))
+
+    assert [record["id"] for record in records] == [
+        f"mathnet:{HF_REVISION}:abc123:solution-0",
+        f"mathnet:{HF_REVISION}:abc123:solution-2",
+    ]
+    assert [record["messages"][1]["content"] for record in records] == ["First solution.", "Second solution."]
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        _base_row(images=[{"path": "diagram.png"}]),
+        _base_row(problem_markdown="Use this figure.\n![](attached_image_1.png)"),
+        _base_row(solutions_markdown=["Refer to the figure.\n![](attached_image_1.png)"]),
+    ],
+)
+def test_image_dependent_rows_are_skipped(row):
+    assert row_to_text_sft_records(row, _base_config()) == []
+
+
+def test_first_solution_policy_ignores_unselected_image_dependent_solution():
+    row = _base_row(solutions_markdown=["Text-only solution.", "Figure solution.\n![](attached_image_1.png)"])
+
+    records = row_to_text_sft_records(row, _base_config())
+
+    assert len(records) == 1
+    assert records[0]["messages"][1]["content"] == "Text-only solution."
+
+
+def test_all_solution_policy_skips_only_image_dependent_solution_variants():
+    row = _base_row(solutions_markdown=["Text-only solution.", "Figure solution.\n![](attached_image_1.png)"])
+
+    records = row_to_text_sft_records(row, _base_config(solution_policy=MathNetSolutionPolicy.ALL))
+
+    assert len(records) == 1
+    assert records[0]["id"] == f"mathnet:{HF_REVISION}:abc123:solution-0"
+    assert records[0]["messages"][1]["content"] == "Text-only solution."
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        _base_row(id=""),
+        _base_row(problem_markdown=""),
+        _base_row(solutions_markdown=[]),
+        _base_row(solutions_markdown=["", "   "]),
+    ],
+)
+def test_empty_id_problem_or_solution_rows_are_skipped(row):
+    assert row_to_text_sft_records(row, _base_config()) == []
+
+
+@pytest.mark.parametrize("language", [None, "", "en", "English"])
+def test_english_or_unknown_language_policy_keeps_primary_languages(language):
+    records = row_to_text_sft_records(_base_row(language=language), _base_config())
+
+    assert len(records) == 1
+    assert records[0]["metadata"]["language"] == language
+
+
+def test_english_or_unknown_language_policy_skips_non_english_rows():
+    row = _base_row(language="Spanish")
+
+    assert row_to_text_sft_records(row, _base_config()) == []
+
+
+def test_all_languages_policy_keeps_non_english_rows():
+    row = _base_row(language="Spanish")
+
+    records = row_to_text_sft_records(row, _base_config(language_policy=MathNetLanguagePolicy.ALL_LANGUAGES))
+
+    assert len(records) == 1
+    assert records[0]["metadata"]["language_policy"] == "all_languages"
+
+
+def test_excluded_ids_are_skipped():
+    row = _base_row(id="heldout")
+
+    assert row_to_text_sft_records(row, _base_config(), {"heldout"}) == []
+
+
+def test_load_excluded_ids_reads_one_id_per_line(tmp_path: Path):
+    excluded_path = tmp_path / "heldout.txt"
+    excluded_path.write_text("abc123\n\nxyz789\n", encoding="utf-8")
+
+    assert _load_excluded_ids(str(excluded_path)) == {"abc123", "xyz789"}
+
+
+def test_download_step_restricts_to_default_all_config_files():
+    step = download_mathnet_raw_step()
+
+    assert step.hash_attrs["hf_dataset_id"] == "ShadenA/MathNet"
+    assert step.hash_attrs["revision"] == HF_REVISION
+    assert step.hash_attrs["hf_urls_glob"] == HF_URLS_GLOB
+
+
+def test_processed_step_records_policy_in_hash_attrs():
+    step = mathnet_text_sft_primary_step(
+        language_policy=MathNetLanguagePolicy.ALL_LANGUAGES,
+        solution_policy=MathNetSolutionPolicy.ALL,
+        excluded_ids_path="gs://example/heldout.txt",
+    )
+
+    assert step.name == "processed/mathnet-v0/text-sft-primary"
+    assert step.hash_attrs["hf_dataset_id"] == "ShadenA/MathNet"
+    assert step.hash_attrs["hf_revision"] == HF_REVISION
+    assert step.hash_attrs["hf_urls_glob"] == HF_URLS_GLOB
+    assert step.hash_attrs["language_policy"] == "all_languages"
+    assert step.hash_attrs["solution_policy"] == "all"
+    assert step.hash_attrs["excluded_ids_path"] == "gs://example/heldout.txt"
+
+
+def test_transform_text_sft_writes_chat_jsonl(tmp_path: Path, read_all_jsonl_gz):
+    raw_dir = tmp_path / "raw"
+    raw_shard = raw_dir / "data" / "all" / "train-00000-of-00001.parquet"
+    raw_shard.parent.mkdir(parents=True)
+    pq.write_table(pa.Table.from_pylist([_base_row()]), raw_shard)
+
+    output_dir = tmp_path / "processed"
+    transform_text_sft(
+        MathNetTextSftConfig(
+            raw_input_path=str(raw_dir),
+            output_path=str(output_dir),
+        )
+    )
+
+    records = read_all_jsonl_gz(output_dir)
+    assert len(records) == 1
+    assert records[0]["id"] == f"mathnet:{HF_REVISION}:abc123:solution-0"
+    assert records[0]["messages"][0]["role"] == "user"
+    assert records[0]["messages"][1]["role"] == "assistant"


### PR DESCRIPTION
Adds a pinned MathNet text-only SFT transform that downloads the public all/train shards, filters image-dependent or held-out rows, and emits OpenAI chat-format problem/solution records. Adds a posttrain tokenization entrypoint and focused tests for filtering, solution selection, benchmark exclusions, and local transform behavior. Validated with ./infra/pre-commit.py --changed-files --fix and focused pytest.