### PR TITLE
[RL] Add sampled-token on-policy distillation MVP

### DIFF
--- a/experiments/llama_3_8b_hybrid_opd_math500.py
+++ b/experiments/llama_3_8b_hybrid_opd_math500.py
@@ -1,0 +1,278 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# nodryrun because vLLM is not installed by default
+
+"""Executor-backed hybrid reward+OPD Math500 smoke launcher for Llama 3.1 8B."""
+
+import argparse
+import logging
+import os
+
+from levanter.checkpoint import CheckpointDebugConfig
+from marin.execution.executor import executor_main
+from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.opd_losses import HybridRLOOOPDSampledTokenReverseKLLoss
+from marin.rl.rl_experiment_utils import RLExperimentConfig, executor_main_config_for_rl_experiment, make_rl_step
+from marin.rl.teacher import INITIAL_POLICY_TEACHER_CHECKPOINT, TeacherConfig
+
+from experiments.llama_3_8b_rl_math500 import (
+    DEFAULT_CHECKPOINTER_SAVE_INTERVAL,
+    DEFAULT_EVAL_FREQUENCY,
+    DEFAULT_EVAL_N_EXAMPLES,
+    DEFAULT_MAX_INPUT_TOKENS,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    DEFAULT_TPU_TYPE,
+    DEFAULT_TPU_WORKER_RAM,
+    LLAMA_3_1_8B_INSTRUCT,
+    PROJECT_NAME,
+    build_math500_curriculum,
+    build_run_name,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_EXPERIMENT_NAME_SUFFIX = "hybrid-opd-math500-smoke"
+DEFAULT_NUM_TRAIN_STEPS = 20
+DEFAULT_N_PROMPTS = 16
+DEFAULT_N_GENERATIONS_PER_PROMPT = 4
+DEFAULT_OPD_COEF = 0.1
+DEFAULT_TRAIN_BATCH_SIZE = DEFAULT_N_PROMPTS * DEFAULT_N_GENERATIONS_PER_PROMPT
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--run-name",
+        default=None,
+        help="Stable logical run name for checkpoint/W&B resume across relaunches. "
+        "If omitted, a fresh timestamped name is generated.",
+    )
+    parser.add_argument(
+        "--experiment-name-suffix",
+        default=DEFAULT_EXPERIMENT_NAME_SUFFIX,
+        help="Suffix used in the executor step name, checkpoint path, and W&B runs.",
+    )
+    parser.add_argument(
+        "--teacher-checkpoint",
+        default=None,
+        help="Teacher checkpoint or Hugging Face repo. If omitted, uses the student initial checkpoint.",
+    )
+    parser.add_argument(
+        "--opd-coef",
+        type=float,
+        default=DEFAULT_OPD_COEF,
+        help="Coefficient on the sampled-token OPD advantage before adding it to reward advantages.",
+    )
+    parser.add_argument(
+        "--num-train-steps",
+        type=int,
+        default=DEFAULT_NUM_TRAIN_STEPS,
+        help="Number of trainer steps to run.",
+    )
+    parser.add_argument(
+        "--n-prompts",
+        type=int,
+        default=DEFAULT_N_PROMPTS,
+        help="Number of prompts sampled per rollout batch.",
+    )
+    parser.add_argument(
+        "--n-generations-per-prompt",
+        type=int,
+        default=DEFAULT_N_GENERATIONS_PER_PROMPT,
+        help="Number of grouped generations per prompt for RLOO reward advantages.",
+    )
+    parser.add_argument(
+        "--train-batch-size",
+        type=int,
+        default=DEFAULT_TRAIN_BATCH_SIZE,
+        help="Trainer batch size. Keep this aligned with available smoke rollout count.",
+    )
+    parser.add_argument(
+        "--eval-frequency",
+        type=int,
+        default=DEFAULT_EVAL_FREQUENCY,
+        help="Full-eval cadence in completed trainer steps.",
+    )
+    parser.add_argument(
+        "--checkpointer-save-interval",
+        type=int,
+        default=DEFAULT_CHECKPOINTER_SAVE_INTERVAL,
+        help="Seconds between trainer checkpoint saves.",
+    )
+    parser.add_argument(
+        "--keep-last-temporary-checkpoints",
+        type=int,
+        default=5,
+        help="Number of complete temporary checkpoints to retain after a successful temporary checkpoint save. "
+        "Use 0 to delete temporary checkpoints after they commit.",
+    )
+    parser.add_argument(
+        "--debug-checkpointer",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable verbose trainer-side checkpoint diagnostics.",
+    )
+    parser.add_argument(
+        "--debug-checkpointer-log-interval",
+        type=float,
+        default=60.0,
+        help="Seconds between checkpoint progress logs when debug checkpointer is enabled.",
+    )
+    parser.add_argument(
+        "--debug-checkpointer-dump-stacks-after",
+        type=float,
+        default=60.0,
+        help="Dump Python thread stacks after this many seconds in one checkpoint phase.",
+    )
+    parser.add_argument(
+        "--train-tpu-type",
+        default=DEFAULT_TPU_TYPE,
+        help="TPU type for the trainer job.",
+    )
+    parser.add_argument(
+        "--inference-tpu-type",
+        default=DEFAULT_TPU_TYPE,
+        help="TPU type for rollout worker jobs.",
+    )
+    parser.add_argument(
+        "--num-train-slices",
+        type=int,
+        default=1,
+        help="Number of TPU slices for the trainer job.",
+    )
+    parser.add_argument(
+        "--train-ram",
+        default=DEFAULT_TPU_WORKER_RAM,
+        help="Host RAM request for the trainer TPU job.",
+    )
+    parser.add_argument(
+        "--inference-ram",
+        default=DEFAULT_TPU_WORKER_RAM,
+        help="Host RAM request for the rollout TPU job.",
+    )
+    parser.add_argument(
+        "--zone",
+        default=None,
+        help="Optional concrete zone for trainer and rollout TPU jobs.",
+    )
+    parser.add_argument(
+        "--project-name",
+        default=PROJECT_NAME,
+        help="W&B project name for trainer and rollout runs.",
+    )
+    return parser.parse_args()
+
+
+def build_experiment_config(args: argparse.Namespace) -> RLExperimentConfig:
+    total_rollouts_per_batch = args.n_prompts * args.n_generations_per_prompt
+    if args.n_generations_per_prompt <= 1:
+        raise ValueError("n_generations_per_prompt must be > 1 for hybrid reward+OPD RLOO")
+    if args.train_batch_size > total_rollouts_per_batch:
+        raise ValueError("train_batch_size must be <= n_prompts * n_generations_per_prompt")
+
+    teacher_checkpoint = args.teacher_checkpoint or INITIAL_POLICY_TEACHER_CHECKPOINT
+
+    tags = [
+        "rl",
+        "opd",
+        "hybrid-reward-opd",
+        "sampled-token-reverse-kl",
+        "math500",
+        args.experiment_name_suffix,
+        LLAMA_3_1_8B_INSTRUCT.safe_name,
+    ]
+
+    return RLExperimentConfig(
+        model_config=LLAMA_3_1_8B_INSTRUCT,
+        rl_loss=HybridRLOOOPDSampledTokenReverseKLLoss(
+            kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+            opd_coef=args.opd_coef,
+            clip_epsilon_low=0.2,
+            clip_epsilon_high=0.28,
+            synchronous=True,
+            do_trainer_inference_mismatch_importance_sampling=True,
+            tis_importance_sampling_ratio_max=2.0,
+            do_overlong_filtering=True,
+            vocab_tile_size=32064,
+        ),
+        teacher=TeacherConfig(checkpoint=teacher_checkpoint),
+        experiment_name_suffix=args.experiment_name_suffix,
+        project_name=args.project_name,
+        tags=tags,
+        num_train_steps=args.num_train_steps,
+        checkpointer_save_interval=args.checkpointer_save_interval,
+        keep_last_temporary_checkpoints=args.keep_last_temporary_checkpoints,
+        checkpoint_debug=CheckpointDebugConfig(
+            enabled=args.debug_checkpointer,
+            log_interval=args.debug_checkpointer_log_interval,
+            dump_stacks_after=args.debug_checkpointer_dump_stacks_after,
+        ),
+        train_batch_size=args.train_batch_size,
+        per_device_parallelism=16,
+        learning_rate=1e-7,
+        max_input_tokens=DEFAULT_MAX_INPUT_TOKENS,
+        max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
+        n_prompts=args.n_prompts,
+        n_generations_per_prompt=args.n_generations_per_prompt,
+        replay_buffer_max_samples=1,
+        num_rollout_workers=1,
+        train_tpu_type=args.train_tpu_type,
+        inference_tpu_type=args.inference_tpu_type,
+        num_train_slices=args.num_train_slices,
+        train_ram=args.train_ram,
+        inference_ram=args.inference_ram,
+        zone=args.zone,
+        inflight_weight_updates=False,
+        max_rollout_step_delay=0,
+        weight_transfer_sync_interval_steps=1,
+        max_weight_transfer_wait_time=600,
+        inference_n=args.n_generations_per_prompt,
+    )
+
+
+def main() -> None:
+    if os.getenv("CI") is not None:
+        logger.info("Skipping experiment execution on CI environment.")
+        return
+
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO)
+
+    experiment_config = build_experiment_config(args)
+    run_name = build_run_name(experiment_config, args.run_name)
+    curriculum = build_math500_curriculum(run_name, experiment_config, args.eval_frequency)
+    step = make_rl_step(
+        name=run_name,
+        config=experiment_config,
+        curriculum=curriculum,
+    )
+    executor_config = executor_main_config_for_rl_experiment(experiment_config)
+    rl_loss = experiment_config.rl_loss
+    if not isinstance(rl_loss, HybridRLOOOPDSampledTokenReverseKLLoss):
+        raise TypeError(f"Expected HybridRLOOOPDSampledTokenReverseKLLoss, got {type(rl_loss)}")
+
+    logger.info(
+        "Launching executor hybrid OPD Math500 run %s (teacher=%s, opd_coef=%.4f, train_tpu=%s, "
+        "inference_tpu=%s, train_ram=%s, inference_ram=%s, zone=%s, executor_prefix=%s, eval_examples=%d)",
+        run_name,
+        experiment_config.teacher.checkpoint if experiment_config.teacher is not None else None,
+        rl_loss.opd_coef,
+        experiment_config.train_tpu_type,
+        experiment_config.inference_tpu_type,
+        experiment_config.train_ram,
+        experiment_config.inference_ram,
+        experiment_config.zone,
+        executor_config.prefix,
+        DEFAULT_EVAL_N_EXAMPLES,
+    )
+
+    executor_main(
+        executor_config,
+        steps=[step],
+        description="Executor-backed hybrid reward+sampled-token OPD Math500 smoke run for Llama 3.1 8B",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/llama_3_8b_hybrid_opd_math500.py
+++ b/experiments/llama_3_8b_hybrid_opd_math500.py
@@ -3,20 +3,21 @@
 
 # nodryrun because vLLM is not installed by default
 
-"""Executor-backed hybrid reward+OPD Math500 smoke launcher for Llama 3.1 8B."""
+"""Lazy-artifact hybrid reward+OPD Math500 smoke launcher for Llama 3.1 8B."""
 
 import argparse
 import logging
 import os
 
 from levanter.checkpoint import CheckpointDebugConfig
-from marin.execution.executor import executor_main
+from marin.execution.lazy import lower
+from marin.execution.step_runner import StepRunner
 from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.opd_losses import HybridRLOOOPDSampledTokenReverseKLLoss
-from marin.rl.rl_experiment_utils import RLExperimentConfig, executor_main_config_for_rl_experiment, make_rl_step
+from marin.rl.rl_experiment_utils import RLExperimentConfig, make_rl_step
 from marin.rl.teacher import INITIAL_POLICY_TEACHER_CHECKPOINT, TeacherConfig
 
-from experiments.llama_3_8b_rl_math500 import (
+from experiments.llama_3_8b_opd_math500_common import (
     DEFAULT_CHECKPOINTER_SAVE_INTERVAL,
     DEFAULT_EVAL_FREQUENCY,
     DEFAULT_EVAL_N_EXAMPLES,
@@ -26,6 +27,7 @@ from experiments.llama_3_8b_rl_math500 import (
     DEFAULT_TPU_WORKER_RAM,
     LLAMA_3_1_8B_INSTRUCT,
     PROJECT_NAME,
+    RL_STEP_VERSION,
     build_math500_curriculum,
     build_run_name,
 )
@@ -227,7 +229,6 @@ def build_experiment_config(args: argparse.Namespace) -> RLExperimentConfig:
         max_rollout_step_delay=0,
         weight_transfer_sync_interval_steps=1,
         max_weight_transfer_wait_time=600,
-        inference_n=args.n_generations_per_prompt,
     )
 
 
@@ -246,15 +247,15 @@ def main() -> None:
         name=run_name,
         config=experiment_config,
         curriculum=curriculum,
+        version=RL_STEP_VERSION,
     )
-    executor_config = executor_main_config_for_rl_experiment(experiment_config)
     rl_loss = experiment_config.rl_loss
     if not isinstance(rl_loss, HybridRLOOOPDSampledTokenReverseKLLoss):
         raise TypeError(f"Expected HybridRLOOOPDSampledTokenReverseKLLoss, got {type(rl_loss)}")
 
     logger.info(
-        "Launching executor hybrid OPD Math500 run %s (teacher=%s, opd_coef=%.4f, train_tpu=%s, "
-        "inference_tpu=%s, train_ram=%s, inference_ram=%s, zone=%s, executor_prefix=%s, eval_examples=%d)",
+        "Launching hybrid OPD Math500 run %s (teacher=%s, opd_coef=%.4f, train_tpu=%s, "
+        "inference_tpu=%s, train_ram=%s, inference_ram=%s, zone=%s, output_path=%s, eval_examples=%d)",
         run_name,
         experiment_config.teacher.checkpoint if experiment_config.teacher is not None else None,
         rl_loss.opd_coef,
@@ -263,15 +264,11 @@ def main() -> None:
         experiment_config.train_ram,
         experiment_config.inference_ram,
         experiment_config.zone,
-        executor_config.prefix,
+        step.path(),
         DEFAULT_EVAL_N_EXAMPLES,
     )
 
-    executor_main(
-        executor_config,
-        steps=[step],
-        description="Executor-backed hybrid reward+sampled-token OPD Math500 smoke run for Llama 3.1 8B",
-    )
+    StepRunner().run([lower(step)])
 
 
 if __name__ == "__main__":

--- a/experiments/llama_3_8b_opd_math500.py
+++ b/experiments/llama_3_8b_opd_math500.py
@@ -1,0 +1,250 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# nodryrun because vLLM is not installed by default
+
+"""Executor-backed OPD Math500 smoke launcher for Llama 3.1 8B."""
+
+import argparse
+import logging
+import os
+
+from levanter.checkpoint import CheckpointDebugConfig
+from marin.execution.executor import executor_main
+from marin.rl.opd_losses import OPDSampledTokenReverseKLLoss
+from marin.rl.rl_experiment_utils import RLExperimentConfig, executor_main_config_for_rl_experiment, make_rl_step
+from marin.rl.teacher import INITIAL_POLICY_TEACHER_CHECKPOINT, TeacherConfig
+
+from experiments.llama_3_8b_rl_math500 import (
+    DEFAULT_CHECKPOINTER_SAVE_INTERVAL,
+    DEFAULT_EVAL_FREQUENCY,
+    DEFAULT_EVAL_N_EXAMPLES,
+    DEFAULT_MAX_INPUT_TOKENS,
+    DEFAULT_MAX_OUTPUT_TOKENS,
+    DEFAULT_TPU_TYPE,
+    DEFAULT_TPU_WORKER_RAM,
+    LLAMA_3_1_8B_INSTRUCT,
+    PROJECT_NAME,
+    build_math500_curriculum,
+    build_run_name,
+)
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_EXPERIMENT_NAME_SUFFIX = "opd-math500-smoke"
+DEFAULT_NUM_TRAIN_STEPS = 20
+DEFAULT_N_PROMPTS = 16
+DEFAULT_TRAIN_BATCH_SIZE = 16
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--run-name",
+        default=None,
+        help="Stable logical run name for checkpoint/W&B resume across relaunches. "
+        "If omitted, a fresh timestamped name is generated.",
+    )
+    parser.add_argument(
+        "--experiment-name-suffix",
+        default=DEFAULT_EXPERIMENT_NAME_SUFFIX,
+        help="Suffix used in the executor step name, checkpoint path, and W&B runs.",
+    )
+    parser.add_argument(
+        "--teacher-checkpoint",
+        default=None,
+        help="Teacher checkpoint or Hugging Face repo. If omitted, uses the student initial checkpoint.",
+    )
+    parser.add_argument(
+        "--num-train-steps",
+        type=int,
+        default=DEFAULT_NUM_TRAIN_STEPS,
+        help="Number of trainer steps to run.",
+    )
+    parser.add_argument(
+        "--n-prompts",
+        type=int,
+        default=DEFAULT_N_PROMPTS,
+        help="Number of prompts sampled per rollout batch.",
+    )
+    parser.add_argument(
+        "--train-batch-size",
+        type=int,
+        default=DEFAULT_TRAIN_BATCH_SIZE,
+        help="Trainer batch size. Keep this aligned with available smoke rollout count.",
+    )
+    parser.add_argument(
+        "--eval-frequency",
+        type=int,
+        default=DEFAULT_EVAL_FREQUENCY,
+        help="Full-eval cadence in completed trainer steps.",
+    )
+    parser.add_argument(
+        "--checkpointer-save-interval",
+        type=int,
+        default=DEFAULT_CHECKPOINTER_SAVE_INTERVAL,
+        help="Seconds between trainer checkpoint saves.",
+    )
+    parser.add_argument(
+        "--keep-last-temporary-checkpoints",
+        type=int,
+        default=5,
+        help="Number of complete temporary checkpoints to retain after a successful temporary checkpoint save. "
+        "Use 0 to delete temporary checkpoints after they commit.",
+    )
+    parser.add_argument(
+        "--debug-checkpointer",
+        action=argparse.BooleanOptionalAction,
+        default=False,
+        help="Enable verbose trainer-side checkpoint diagnostics.",
+    )
+    parser.add_argument(
+        "--debug-checkpointer-log-interval",
+        type=float,
+        default=60.0,
+        help="Seconds between checkpoint progress logs when debug checkpointer is enabled.",
+    )
+    parser.add_argument(
+        "--debug-checkpointer-dump-stacks-after",
+        type=float,
+        default=60.0,
+        help="Dump Python thread stacks after this many seconds in one checkpoint phase.",
+    )
+    parser.add_argument(
+        "--train-tpu-type",
+        default=DEFAULT_TPU_TYPE,
+        help="TPU type for the trainer job.",
+    )
+    parser.add_argument(
+        "--inference-tpu-type",
+        default=DEFAULT_TPU_TYPE,
+        help="TPU type for rollout worker jobs.",
+    )
+    parser.add_argument(
+        "--num-train-slices",
+        type=int,
+        default=1,
+        help="Number of TPU slices for the trainer job.",
+    )
+    parser.add_argument(
+        "--train-ram",
+        default=DEFAULT_TPU_WORKER_RAM,
+        help="Host RAM request for the trainer TPU job.",
+    )
+    parser.add_argument(
+        "--inference-ram",
+        default=DEFAULT_TPU_WORKER_RAM,
+        help="Host RAM request for the rollout TPU job.",
+    )
+    parser.add_argument(
+        "--zone",
+        default=None,
+        help="Optional concrete zone for trainer and rollout TPU jobs.",
+    )
+    parser.add_argument(
+        "--project-name",
+        default=PROJECT_NAME,
+        help="W&B project name for trainer and rollout runs.",
+    )
+    return parser.parse_args()
+
+
+def build_experiment_config(args: argparse.Namespace) -> RLExperimentConfig:
+    if args.train_batch_size > args.n_prompts:
+        raise ValueError("train_batch_size must be <= n_prompts for the OPD smoke run")
+
+    teacher_checkpoint = args.teacher_checkpoint or INITIAL_POLICY_TEACHER_CHECKPOINT
+
+    tags = [
+        "rl",
+        "opd",
+        "sampled-token-reverse-kl",
+        "math500",
+        args.experiment_name_suffix,
+        LLAMA_3_1_8B_INSTRUCT.safe_name,
+    ]
+
+    return RLExperimentConfig(
+        model_config=LLAMA_3_1_8B_INSTRUCT,
+        rl_loss=OPDSampledTokenReverseKLLoss(
+            synchronous=False,
+            clip_epsilon_low=None,
+            clip_epsilon_high=None,
+            vocab_tile_size=32064,
+        ),
+        teacher=TeacherConfig(checkpoint=teacher_checkpoint),
+        experiment_name_suffix=args.experiment_name_suffix,
+        project_name=args.project_name,
+        tags=tags,
+        num_train_steps=args.num_train_steps,
+        checkpointer_save_interval=args.checkpointer_save_interval,
+        keep_last_temporary_checkpoints=args.keep_last_temporary_checkpoints,
+        checkpoint_debug=CheckpointDebugConfig(
+            enabled=args.debug_checkpointer,
+            log_interval=args.debug_checkpointer_log_interval,
+            dump_stacks_after=args.debug_checkpointer_dump_stacks_after,
+        ),
+        train_batch_size=args.train_batch_size,
+        per_device_parallelism=16,
+        learning_rate=1e-7,
+        max_input_tokens=DEFAULT_MAX_INPUT_TOKENS,
+        max_output_tokens=DEFAULT_MAX_OUTPUT_TOKENS,
+        n_prompts=args.n_prompts,
+        n_generations_per_prompt=1,
+        replay_buffer_max_samples=1,
+        num_rollout_workers=1,
+        train_tpu_type=args.train_tpu_type,
+        inference_tpu_type=args.inference_tpu_type,
+        num_train_slices=args.num_train_slices,
+        train_ram=args.train_ram,
+        inference_ram=args.inference_ram,
+        zone=args.zone,
+        inflight_weight_updates=False,
+        max_rollout_step_delay=0,
+        weight_transfer_sync_interval_steps=1,
+        max_weight_transfer_wait_time=600,
+        inference_n=1,
+    )
+
+
+def main() -> None:
+    if os.getenv("CI") is not None:
+        logger.info("Skipping experiment execution on CI environment.")
+        return
+
+    args = parse_args()
+    logging.basicConfig(level=logging.INFO)
+
+    experiment_config = build_experiment_config(args)
+    run_name = build_run_name(experiment_config, args.run_name)
+    curriculum = build_math500_curriculum(run_name, experiment_config, args.eval_frequency)
+    step = make_rl_step(
+        name=run_name,
+        config=experiment_config,
+        curriculum=curriculum,
+    )
+    executor_config = executor_main_config_for_rl_experiment(experiment_config)
+
+    logger.info(
+        "Launching executor OPD Math500 run %s (teacher=%s, train_tpu=%s, inference_tpu=%s, "
+        "train_ram=%s, inference_ram=%s, zone=%s, executor_prefix=%s, eval_examples=%d)",
+        run_name,
+        experiment_config.teacher.checkpoint if experiment_config.teacher is not None else None,
+        experiment_config.train_tpu_type,
+        experiment_config.inference_tpu_type,
+        experiment_config.train_ram,
+        experiment_config.inference_ram,
+        experiment_config.zone,
+        executor_config.prefix,
+        DEFAULT_EVAL_N_EXAMPLES,
+    )
+
+    executor_main(
+        executor_config,
+        steps=[step],
+        description="Executor-backed sampled-token OPD Math500 smoke run for Llama 3.1 8B",
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/llama_3_8b_opd_math500.py
+++ b/experiments/llama_3_8b_opd_math500.py
@@ -3,19 +3,20 @@
 
 # nodryrun because vLLM is not installed by default
 
-"""Executor-backed OPD Math500 smoke launcher for Llama 3.1 8B."""
+"""Lazy-artifact OPD Math500 smoke launcher for Llama 3.1 8B."""
 
 import argparse
 import logging
 import os
 
 from levanter.checkpoint import CheckpointDebugConfig
-from marin.execution.executor import executor_main
+from marin.execution.lazy import lower
+from marin.execution.step_runner import StepRunner
 from marin.rl.opd_losses import OPDSampledTokenReverseKLLoss
-from marin.rl.rl_experiment_utils import RLExperimentConfig, executor_main_config_for_rl_experiment, make_rl_step
+from marin.rl.rl_experiment_utils import RLExperimentConfig, make_rl_step
 from marin.rl.teacher import INITIAL_POLICY_TEACHER_CHECKPOINT, TeacherConfig
 
-from experiments.llama_3_8b_rl_math500 import (
+from experiments.llama_3_8b_opd_math500_common import (
     DEFAULT_CHECKPOINTER_SAVE_INTERVAL,
     DEFAULT_EVAL_FREQUENCY,
     DEFAULT_EVAL_N_EXAMPLES,
@@ -25,6 +26,7 @@ from experiments.llama_3_8b_rl_math500 import (
     DEFAULT_TPU_WORKER_RAM,
     LLAMA_3_1_8B_INSTRUCT,
     PROJECT_NAME,
+    RL_STEP_VERSION,
     build_math500_curriculum,
     build_run_name,
 )
@@ -203,7 +205,6 @@ def build_experiment_config(args: argparse.Namespace) -> RLExperimentConfig:
         max_rollout_step_delay=0,
         weight_transfer_sync_interval_steps=1,
         max_weight_transfer_wait_time=600,
-        inference_n=1,
     )
 
 
@@ -222,12 +223,12 @@ def main() -> None:
         name=run_name,
         config=experiment_config,
         curriculum=curriculum,
+        version=RL_STEP_VERSION,
     )
-    executor_config = executor_main_config_for_rl_experiment(experiment_config)
 
     logger.info(
-        "Launching executor OPD Math500 run %s (teacher=%s, train_tpu=%s, inference_tpu=%s, "
-        "train_ram=%s, inference_ram=%s, zone=%s, executor_prefix=%s, eval_examples=%d)",
+        "Launching OPD Math500 run %s (teacher=%s, train_tpu=%s, inference_tpu=%s, "
+        "train_ram=%s, inference_ram=%s, zone=%s, output_path=%s, eval_examples=%d)",
         run_name,
         experiment_config.teacher.checkpoint if experiment_config.teacher is not None else None,
         experiment_config.train_tpu_type,
@@ -235,15 +236,11 @@ def main() -> None:
         experiment_config.train_ram,
         experiment_config.inference_ram,
         experiment_config.zone,
-        executor_config.prefix,
+        step.path(),
         DEFAULT_EVAL_N_EXAMPLES,
     )
 
-    executor_main(
-        executor_config,
-        steps=[step],
-        description="Executor-backed sampled-token OPD Math500 smoke run for Llama 3.1 8B",
-    )
+    StepRunner().run([lower(step)])
 
 
 if __name__ == "__main__":

--- a/experiments/llama_3_8b_opd_math500_common.py
+++ b/experiments/llama_3_8b_opd_math500_common.py
@@ -1,0 +1,73 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared Llama 3.1 8B Math500 settings for OPD smoke launchers."""
+
+import datetime
+
+from levanter.models.llama import LlamaConfig
+from marin.rl.curriculum import CurriculumConfig, LessonConfig
+from marin.rl.decoding import SamplingParams
+from marin.rl.environments import EnvConfig
+from marin.rl.rl_experiment_utils import (
+    ModelConfig,
+    RLExperimentConfig,
+    config_class_path,
+    default_train_decoding_for_experiment,
+)
+
+from experiments.models import llama_3_1_8b_instruct
+
+MODEL_NAME = "meta-llama/Llama-3.1-8B-Instruct"
+PROJECT_NAME = "marin_iris_rl_debug"
+DEFAULT_CHECKPOINTER_SAVE_INTERVAL = 600
+DEFAULT_EVAL_FREQUENCY = 1
+DEFAULT_TPU_TYPE = "v5p-8"
+DEFAULT_TPU_WORKER_RAM = "400g"
+DEFAULT_MAX_INPUT_TOKENS = 1024
+DEFAULT_MAX_OUTPUT_TOKENS = 1024
+DEFAULT_EVAL_N_EXAMPLES = 500
+RL_STEP_VERSION = "dev"
+
+LLAMA_3_1_8B_INSTRUCT = ModelConfig(
+    name=MODEL_NAME,
+    type="llama",
+    artifact=llama_3_1_8b_instruct,
+    config_class_path=config_class_path(LlamaConfig),
+)
+
+
+def build_math500_curriculum(run_id: str, config: RLExperimentConfig, eval_frequency: int) -> CurriculumConfig:
+    sampling_params = SamplingParams(
+        n_prompts=config.n_prompts,
+        n_generations_per_prompt=config.n_generations_per_prompt,
+        train_decoding=default_train_decoding_for_experiment(config),
+    )
+
+    return CurriculumConfig(
+        lessons={
+            "math_full": LessonConfig(
+                lesson_id="math_full",
+                env_config=EnvConfig(
+                    env_class="marin.rl.environments.math_env.MathEnv",
+                    env_args={"seed": 42},
+                ),
+                dependencies=[],
+                sampling_params=sampling_params,
+            ),
+        },
+        eval_frequency=eval_frequency,
+        micro_eval_frequency=None,
+        actor_name=f"curriculum-{run_id}",
+        eval_n_examples=DEFAULT_EVAL_N_EXAMPLES,
+        max_seq_len=config.max_input_tokens + config.max_output_tokens,
+    )
+
+
+def build_run_name(config: RLExperimentConfig, explicit_run_name: str | None) -> str:
+    if explicit_run_name is not None:
+        return explicit_run_name
+
+    datestamp = datetime.datetime.now(datetime.UTC).strftime("%Y%m%d-%H%M%S")
+    model_base_name = config.model_config.name.split("/")[-1].lower().replace("-instruct", "i")
+    return f"{model_base_name}-{config.experiment_name_suffix}-{datestamp}"

--- a/lib/marin/src/marin/rl/job_config.py
+++ b/lib/marin/src/marin/rl/job_config.py
@@ -32,6 +32,7 @@ from marin.rl.replay_buffer import ReplayBufferConfig
 from marin.rl.rl_losses import RLLossModule
 from marin.rl.rollout_storage import RolloutStorageConfig, StorageType
 from marin.rl.rollout_worker import RolloutTrackerConfig, RolloutWorkerConfig
+from marin.rl.teacher import TeacherConfig
 from marin.rl.train_worker import TrainWorkerConfig
 from marin.rl.weight_transfer import WeightTransferConfig
 from marin.utilities.json_encoder import CustomJsonEncoder
@@ -117,6 +118,7 @@ class RLJobConfig:
 
     # Model & initialization (with defaults)
     initial_checkpoint: str | None = None
+    teacher: TeacherConfig | None = None
 
     # Infrastructure
     rollout_storage: RolloutStorageConfig = field(
@@ -204,6 +206,12 @@ def build_worker_configs(config: RLJobConfig) -> tuple[TrainWorkerConfig, Rollou
     can call it without importing :class:`~marin.rl.rl_job.RLJob`, which would
     re-introduce the rl_job <-> orchestration import cycle.
     """
+    loss_needs_teacher = config.train_params.rl_loss.needs_teacher_model()
+    if loss_needs_teacher and config.teacher is None:
+        raise ValueError("TeacherConfig is required when the RL loss needs a teacher model")
+    if not loss_needs_teacher and config.teacher is not None:
+        raise ValueError("TeacherConfig was provided, but the configured RL loss does not use a teacher model")
+
     # Create tokenizer
     tokenizer = make_tokenizer(config.tokenizer)
 
@@ -263,6 +271,7 @@ def build_worker_configs(config: RLJobConfig) -> tuple[TrainWorkerConfig, Rollou
         trainer=config.trainer,
         optimizer=config.train_params.optimizer,
         loss=config.train_params.rl_loss,
+        teacher=config.teacher,
         tokenizer=tokenizer,
         replay_buffer=config.train_params.replay_buffer,
         initial_checkpoint=config.initial_checkpoint,

--- a/lib/marin/src/marin/rl/opd_losses.py
+++ b/lib/marin/src/marin/rl/opd_losses.py
@@ -121,7 +121,7 @@ class OPDSampledTokenReverseKLLoss(RLLossModule):
         if self.clip_epsilon_high is not None and self.clip_epsilon_high < 0.0:
             raise ValueError("clip_epsilon_high must be non-negative")
 
-    def build(self, reference_model: eqx.Module) -> eqx.Module:
+    def build(self, reference_model: eqx.Module) -> RLLossModule:
         """Initialize learned components."""
         return self
 
@@ -242,7 +242,6 @@ def hybrid_rloo_sampled_token_reverse_kl_opd_loss(
         loss_masks=loss_masks,
         clip_epsilon_low=clip_epsilon_low,
         clip_epsilon_high=clip_epsilon_high,
-        max_output_tokens=batch.max_output_tokens,
         trainer_inference_importance_sampling_ratio=trainer_inference_importance_sampling_ratio,
         response_truncated_array=batch.truncated if do_overlong_filtering else None,
     )
@@ -357,7 +356,7 @@ class HybridRLOOOPDSampledTokenReverseKLLoss(RLLossModule):
         if self.tis_importance_sampling_ratio_max <= 0.0:
             raise ValueError("tis_importance_sampling_ratio_max must be positive")
 
-    def build(self, reference_model: eqx.Module) -> eqx.Module:
+    def build(self, reference_model: eqx.Module) -> RLLossModule:
         """Initialize learned components."""
         return self
 

--- a/lib/marin/src/marin/rl/opd_losses.py
+++ b/lib/marin/src/marin/rl/opd_losses.py
@@ -1,0 +1,424 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""On-policy distillation losses for RL training."""
+
+from collections.abc import Callable
+from dataclasses import dataclass
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import numpy as np
+from levanter.metrics import Metric, ReductionType
+from levanter.models.lm_model import LmHeadModel
+from marin.rl.kl_regularization import (
+    KLConfig,
+    kl_penalty_from_log_ratio,
+    kl_statistics_from_log_ratio,
+    masked_response_mean,
+    token_log_ratio,
+)
+from marin.rl.rl_losses import (
+    RLLossModule,
+    chunked_compute_logprobs,
+    compute_logprobs,
+    compute_logprobs_and_entropy,
+    compute_metadata_metrics,
+    compute_ppo_loss_objective,
+    compute_rloo_advantages,
+    importance_sampling_ratio,
+)
+from marin.rl.types import Rollout, TrainingBatch
+
+
+def sampled_token_reverse_kl_opd_loss(
+    model: LmHeadModel,
+    teacher_model: LmHeadModel,
+    batch: TrainingBatch,
+    *,
+    key: jax.Array | None,
+    synchronous: bool,
+    clip_epsilon_low: float | None,
+    clip_epsilon_high: float | None,
+    compute_policy_logprobs_fn: Callable[[LmHeadModel, TrainingBatch, jax.Array | None], jax.Array] = compute_logprobs,
+) -> tuple[jax.Array, dict[str, Metric]]:
+    """Compute sampled-token reverse-KL OPD with an importance-sampling policy gradient.
+
+    This is the train-time form used by the MVP: rollouts carry behavior-policy
+    logprobs for sampled response tokens, and the teacher is scored locally on
+    exactly those tokens.
+    """
+    behavior_logprobs = jax.lax.stop_gradient(batch.policy_logprobs.array)
+    loss_masks = batch.loss_masks.array
+
+    current_logprobs = compute_policy_logprobs_fn(model, batch, key) * loss_masks
+    teacher_logprobs = jax.lax.stop_gradient(compute_policy_logprobs_fn(teacher_model, batch, None) * loss_masks)
+    behavior_logprobs = behavior_logprobs * loss_masks
+
+    teacher_advantage = jax.lax.stop_gradient((teacher_logprobs - behavior_logprobs) * loss_masks)
+    behavior_logprobs_for_ratio = current_logprobs if synchronous else behavior_logprobs
+    ratio = importance_sampling_ratio(
+        current_logprobs,
+        behavior_logprobs_for_ratio,
+        loss_masks,
+        stop_current_logprob_gradient=False,
+        stop_policy_logprob_gradient=True,
+    )
+
+    unclipped_objective = ratio * teacher_advantage
+    objective = unclipped_objective
+    clipped_ratio = ratio
+    clip_fraction = jnp.asarray(0.0, dtype=jnp.float32)
+    if clip_epsilon_low is not None and clip_epsilon_high is not None:
+        clipped_ratio = jnp.clip(ratio, min=1.0 - clip_epsilon_low, max=1.0 + clip_epsilon_high)
+        clipped_objective = clipped_ratio * teacher_advantage
+        objective = jnp.minimum(unclipped_objective, clipped_objective)
+        is_clipped = jnp.logical_or(ratio > 1.0 + clip_epsilon_high, ratio < 1.0 - clip_epsilon_low)
+        clip_fraction = masked_response_mean(is_clipped.astype(jnp.float32), loss_masks)
+
+    loss = -masked_response_mean(objective, loss_masks)
+
+    ratio_mean = masked_response_mean(ratio, loss_masks)
+    clipped_ratio_mean = masked_response_mean(clipped_ratio, loss_masks)
+    teacher_advantage_mean = masked_response_mean(teacher_advantage, loss_masks)
+    current_teacher_gap_mean = masked_response_mean(current_logprobs - teacher_logprobs, loss_masks)
+    behavior_teacher_gap_mean = masked_response_mean(behavior_logprobs - teacher_logprobs, loss_masks)
+
+    metrics = {
+        "opd/sampled_token_reverse_kl_loss": Metric.from_value(loss.astype(jnp.float32), ReductionType.MEAN),
+        "opd/teacher_advantage_mean": Metric.from_value(teacher_advantage_mean.astype(jnp.float32), ReductionType.MEAN),
+        "opd/current_teacher_gap_mean": Metric.from_value(
+            current_teacher_gap_mean.astype(jnp.float32), ReductionType.MEAN
+        ),
+        "opd/behavior_teacher_gap_mean": Metric.from_value(
+            behavior_teacher_gap_mean.astype(jnp.float32), ReductionType.MEAN
+        ),
+        "opd/ratio_mean": Metric.from_value(ratio_mean.astype(jnp.float32), ReductionType.MEAN),
+        "opd/clipped_ratio_mean": Metric.from_value(clipped_ratio_mean.astype(jnp.float32), ReductionType.MEAN),
+        "opd/clip_fraction": Metric.from_value(clip_fraction.astype(jnp.float32), ReductionType.MEAN),
+        "opd/temperature": Metric.from_value(jnp.mean(batch.temperature.array).astype(jnp.float32), ReductionType.MEAN),
+        "opd/top_k": Metric.from_value(jnp.mean(batch.top_k.array).astype(jnp.float32), ReductionType.MEAN),
+    }
+
+    return loss, metrics
+
+
+@dataclass
+class OPDSampledTokenReverseKLLoss(RLLossModule):
+    """Sampled-token reverse-KL OPD loss with a local teacher model."""
+
+    synchronous: bool = False
+    clip_epsilon_low: float | None = None
+    clip_epsilon_high: float | None = None
+    vocab_tile_size: int | None = None
+
+    def __post_init__(self) -> None:
+        if (self.clip_epsilon_low is None) != (self.clip_epsilon_high is None):
+            raise ValueError("clip_epsilon_low and clip_epsilon_high must be set together")
+        if self.clip_epsilon_low is not None and self.clip_epsilon_low < 0.0:
+            raise ValueError("clip_epsilon_low must be non-negative")
+        if self.clip_epsilon_high is not None and self.clip_epsilon_high < 0.0:
+            raise ValueError("clip_epsilon_high must be non-negative")
+
+    def build(self, reference_model: eqx.Module) -> eqx.Module:
+        """Initialize learned components."""
+        return self
+
+    def compute_advantages(self, rollout_group: list[Rollout]) -> np.ndarray:
+        """Use unit advantages; teacher scoring supplies token-level OPD signal."""
+        return np.ones(len(rollout_group), dtype=np.float32)
+
+    def needs_reference_model(self) -> bool:
+        """Return whether this loss needs a separately retained reference model."""
+        return False
+
+    def needs_teacher_model(self) -> bool:
+        """Return whether this loss needs a separately retained teacher model."""
+        return True
+
+    def create_loss_fn(
+        self,
+        reference_model: eqx.Module | None,
+        train_model: eqx.Module,
+        *,
+        teacher_model: eqx.Module | None = None,
+    ) -> Callable:
+        """Create the loss function for training."""
+        del reference_model, train_model
+        if teacher_model is None:
+            raise ValueError("teacher_model is required for OPDSampledTokenReverseKLLoss")
+
+        if self.vocab_tile_size is not None:
+
+            def compute_policy_logprobs_fn(m, b, k):
+                return chunked_compute_logprobs(m, b, k, self.vocab_tile_size)
+
+        else:
+            compute_policy_logprobs_fn = compute_logprobs
+
+        def loss_fn(model, batch, key):
+            return sampled_token_reverse_kl_opd_loss(
+                model,
+                teacher_model,
+                batch,
+                key=key,
+                synchronous=self.synchronous,
+                clip_epsilon_low=self.clip_epsilon_low,
+                clip_epsilon_high=self.clip_epsilon_high,
+                compute_policy_logprobs_fn=compute_policy_logprobs_fn,
+            )
+
+        return loss_fn
+
+
+def hybrid_rloo_sampled_token_reverse_kl_opd_loss(
+    model: LmHeadModel,
+    reference_model: LmHeadModel | None,
+    teacher_model: LmHeadModel,
+    batch: TrainingBatch,
+    *,
+    key: jax.Array | None,
+    kl: KLConfig,
+    opd_coef: float,
+    clip_epsilon_low: float,
+    clip_epsilon_high: float,
+    tis_importance_sampling_ratio_max: float,
+    synchronous: bool = False,
+    do_trainer_inference_mismatch_importance_sampling: bool = False,
+    do_overlong_filtering: bool = False,
+    log_policy_entropy: bool = False,
+    compute_policy_stats_fn: Callable = compute_logprobs_and_entropy,
+) -> tuple[jax.Array, dict[str, Metric]]:
+    """Compute hybrid RLOO reward and sampled-token reverse-KL OPD loss."""
+    behavior_logprobs = jax.lax.stop_gradient(batch.policy_logprobs.array)
+    reward_advantages = jax.lax.stop_gradient(batch.loss_weights.array)
+    loss_masks = batch.loss_masks.array
+
+    current_logprobs, current_policy_entropy = compute_policy_stats_fn(
+        model, batch, key, compute_entropy=log_policy_entropy
+    )
+    current_logprobs = current_logprobs * loss_masks
+
+    teacher_logprobs, _teacher_entropy = compute_policy_stats_fn(teacher_model, batch, None, compute_entropy=False)
+    teacher_logprobs = jax.lax.stop_gradient(teacher_logprobs * loss_masks)
+    behavior_logprobs = behavior_logprobs * loss_masks
+    reward_advantages = reward_advantages * loss_masks
+
+    opd_advantages = jax.lax.stop_gradient((teacher_logprobs - behavior_logprobs) * loss_masks)
+    scaled_opd_advantages = opd_coef * opd_advantages
+    combined_advantages = reward_advantages + scaled_opd_advantages
+
+    behavior_logprobs_for_ratio = current_logprobs if synchronous else behavior_logprobs
+    ratio = importance_sampling_ratio(
+        current_logprobs,
+        behavior_logprobs_for_ratio,
+        loss_masks,
+        stop_current_logprob_gradient=False,
+        stop_policy_logprob_gradient=True,
+    )
+
+    clipped_ratio = jnp.clip(ratio, min=1.0 - clip_epsilon_low, max=1.0 + clip_epsilon_high)
+    is_clipped = jnp.logical_or(ratio > 1.0 + clip_epsilon_high, ratio < 1.0 - clip_epsilon_low)
+    clip_fraction = masked_response_mean(is_clipped.astype(jnp.float32), loss_masks)
+
+    if do_trainer_inference_mismatch_importance_sampling:
+        trainer_inference_importance_sampling_ratio = importance_sampling_ratio(
+            current_logprobs,
+            behavior_logprobs,
+            loss_masks,
+            stop_current_logprob_gradient=True,
+            stop_policy_logprob_gradient=True,
+        )
+        trainer_inference_importance_sampling_ratio = jnp.minimum(
+            trainer_inference_importance_sampling_ratio, tis_importance_sampling_ratio_max
+        )
+    else:
+        trainer_inference_importance_sampling_ratio = jnp.ones_like(current_logprobs)
+
+    reinforce_loss, metadata = compute_ppo_loss_objective(
+        importance_sampling_ratio=ratio,
+        loss_weights=combined_advantages,
+        loss_masks=loss_masks,
+        clip_epsilon_low=clip_epsilon_low,
+        clip_epsilon_high=clip_epsilon_high,
+        max_output_tokens=batch.max_output_tokens,
+        trainer_inference_importance_sampling_ratio=trainer_inference_importance_sampling_ratio,
+        response_truncated_array=batch.truncated if do_overlong_filtering else None,
+    )
+
+    component_multiplier = ratio * trainer_inference_importance_sampling_ratio
+    if do_overlong_filtering:
+        batch_size, _ = component_multiplier.shape
+        component_multiplier = component_multiplier * (1 - batch.truncated.reshape(batch_size, 1))
+
+    reward_loss = -masked_response_mean(component_multiplier * reward_advantages, loss_masks)
+    opd_loss = -masked_response_mean(component_multiplier * scaled_opd_advantages, loss_masks)
+    combined_unclipped_loss = -masked_response_mean(component_multiplier * combined_advantages, loss_masks)
+
+    log_ratio = jnp.zeros_like(current_logprobs)
+    kl_loss = jnp.asarray(0.0, dtype=current_logprobs.dtype)
+    kl_statistics = kl_statistics_from_log_ratio(log_ratio, loss_masks)
+    if kl.enabled():
+        if reference_model is None:
+            raise ValueError("reference_model is required when KL regularization is enabled")
+        reference_logprobs, _reference_entropy = compute_policy_stats_fn(
+            reference_model, batch, key, compute_entropy=False
+        )
+        reference_logprobs = reference_logprobs * loss_masks
+        log_ratio = token_log_ratio(current_logprobs, reference_logprobs)
+        kl_penalty = kl_penalty_from_log_ratio(log_ratio, kl.mode)
+        kl_statistics = kl_statistics_from_log_ratio(log_ratio, loss_masks)
+        kl_loss = kl.beta * masked_response_mean(kl_penalty, loss_masks)
+
+    loss = reinforce_loss + kl_loss
+
+    trainer_inference_importance_sampling_ratio_mean = masked_response_mean(
+        trainer_inference_importance_sampling_ratio, loss_masks
+    )
+    ratio_mean = masked_response_mean(ratio, loss_masks)
+    clipped_ratio_mean = masked_response_mean(clipped_ratio, loss_masks)
+    reward_advantage_mean = masked_response_mean(reward_advantages, loss_masks)
+    opd_advantage_mean = masked_response_mean(opd_advantages, loss_masks)
+    combined_advantage_mean = masked_response_mean(combined_advantages, loss_masks)
+    current_teacher_gap_mean = masked_response_mean(current_logprobs - teacher_logprobs, loss_masks)
+    behavior_teacher_gap_mean = masked_response_mean(behavior_logprobs - teacher_logprobs, loss_masks)
+
+    metrics = {
+        "ratio_mean": Metric.from_value(ratio_mean.astype(jnp.float32), ReductionType.MEAN),
+        "clipped_ratio_mean": Metric.from_value(clipped_ratio_mean.astype(jnp.float32), ReductionType.MEAN),
+        "clip_fraction": Metric.from_value(clip_fraction.astype(jnp.float32), ReductionType.MEAN),
+        "reinforce_loss": Metric.from_value(reinforce_loss.astype(jnp.float32), ReductionType.MEAN),
+        "hybrid/combined_reinforce_loss": Metric.from_value(reinforce_loss.astype(jnp.float32), ReductionType.MEAN),
+        "hybrid/reward_loss": Metric.from_value(reward_loss.astype(jnp.float32), ReductionType.MEAN),
+        "hybrid/opd_loss": Metric.from_value(opd_loss.astype(jnp.float32), ReductionType.MEAN),
+        "hybrid/combined_unclipped_loss": Metric.from_value(
+            combined_unclipped_loss.astype(jnp.float32), ReductionType.MEAN
+        ),
+        "hybrid/opd_coef": Metric.from_value(jnp.asarray(opd_coef, dtype=jnp.float32), ReductionType.MEAN),
+        "hybrid/reward_advantage_mean": Metric.from_value(reward_advantage_mean.astype(jnp.float32), ReductionType.MEAN),
+        "hybrid/opd_advantage_mean": Metric.from_value(opd_advantage_mean.astype(jnp.float32), ReductionType.MEAN),
+        "hybrid/combined_advantage_mean": Metric.from_value(
+            combined_advantage_mean.astype(jnp.float32), ReductionType.MEAN
+        ),
+        "hybrid/current_teacher_gap_mean": Metric.from_value(
+            current_teacher_gap_mean.astype(jnp.float32), ReductionType.MEAN
+        ),
+        "hybrid/behavior_teacher_gap_mean": Metric.from_value(
+            behavior_teacher_gap_mean.astype(jnp.float32), ReductionType.MEAN
+        ),
+        "kl_loss": Metric.from_value(jnp.asarray(kl_loss, dtype=jnp.float32), ReductionType.MEAN),
+        "kl_beta": Metric.from_value(jnp.asarray(kl.beta, dtype=jnp.float32), ReductionType.MEAN),
+        "kl_k1_mean": Metric.from_value(jnp.asarray(kl_statistics.k1_mean, dtype=jnp.float32), ReductionType.MEAN),
+        "kl_k2_mean": Metric.from_value(jnp.asarray(kl_statistics.k2_mean, dtype=jnp.float32), ReductionType.MEAN),
+        "kl_k3_mean": Metric.from_value(jnp.asarray(kl_statistics.k3_mean, dtype=jnp.float32), ReductionType.MEAN),
+        "trainer_inference_importance_sampling_ratio_mean": Metric.from_value(
+            trainer_inference_importance_sampling_ratio_mean.astype(jnp.float32), ReductionType.MEAN
+        ),
+        "temperature": Metric.from_value(jnp.mean(batch.temperature.array).astype(jnp.float32), ReductionType.MEAN),
+        "top_k": Metric.from_value(jnp.mean(batch.top_k.array).astype(jnp.float32), ReductionType.MEAN),
+        **compute_metadata_metrics(current_logprobs, behavior_logprobs, combined_advantages, loss_masks),
+        **metadata,
+    }
+
+    if log_policy_entropy:
+        if current_policy_entropy is None:
+            raise ValueError("compute_policy_stats_fn must return entropy when log_policy_entropy=True")
+        policy_entropy = masked_response_mean(current_policy_entropy, loss_masks)
+        metrics["current_policy_entropy"] = Metric.from_value(
+            jax.lax.stop_gradient(policy_entropy).astype(jnp.float32), ReductionType.MEAN
+        )
+
+    return loss, metrics
+
+
+@dataclass
+class HybridRLOOOPDSampledTokenReverseKLLoss(RLLossModule):
+    """RLOO reward loss plus sampled-token reverse-KL OPD from a local teacher."""
+
+    kl: KLConfig
+    opd_coef: float
+    clip_epsilon_low: float = 0.2
+    clip_epsilon_high: float = 0.2
+    tis_importance_sampling_ratio_max: float = 2.0
+    synchronous: bool = False
+    do_trainer_inference_mismatch_importance_sampling: bool = False
+    do_overlong_filtering: bool = False
+    vocab_tile_size: int | None = None
+    log_policy_entropy: bool = False
+
+    def __post_init__(self) -> None:
+        if self.opd_coef < 0.0:
+            raise ValueError("opd_coef must be non-negative")
+        if self.clip_epsilon_low < 0.0:
+            raise ValueError("clip_epsilon_low must be non-negative")
+        if self.clip_epsilon_high < 0.0:
+            raise ValueError("clip_epsilon_high must be non-negative")
+        if self.tis_importance_sampling_ratio_max <= 0.0:
+            raise ValueError("tis_importance_sampling_ratio_max must be positive")
+
+    def build(self, reference_model: eqx.Module) -> eqx.Module:
+        """Initialize learned components."""
+        return self
+
+    def compute_advantages(self, rollout_group: list[Rollout]) -> np.ndarray:
+        """Compute reward advantages with RLOO; OPD adds a token-level advantage at loss time."""
+        return compute_rloo_advantages(rollout_group)
+
+    def needs_reference_model(self) -> bool:
+        """Return whether KL regularization requires a reference model."""
+        return self.kl.enabled()
+
+    def needs_teacher_model(self) -> bool:
+        """Return whether this loss needs a separately retained teacher model."""
+        return True
+
+    def create_loss_fn(
+        self,
+        reference_model: eqx.Module | None,
+        train_model: eqx.Module,
+        *,
+        teacher_model: eqx.Module | None = None,
+    ) -> Callable:
+        """Create the loss function for training."""
+        del train_model
+        if self.needs_reference_model() and reference_model is None:
+            raise ValueError("reference_model is required when KL regularization is enabled")
+        if teacher_model is None:
+            raise ValueError("teacher_model is required for HybridRLOOOPDSampledTokenReverseKLLoss")
+        if self.log_policy_entropy and self.vocab_tile_size is not None:
+            raise ValueError(
+                "Exact policy entropy is not supported with vocab_tile_size yet. "
+                "Set vocab_tile_size=None or implement chunked entropy first."
+            )
+
+        if self.vocab_tile_size is not None:
+
+            def compute_policy_stats_fn(m, b, k, *, compute_entropy: bool):
+                if compute_entropy:
+                    raise ValueError("Exact policy entropy is not supported with vocab_tile_size yet")
+                return chunked_compute_logprobs(m, b, k, self.vocab_tile_size), None
+
+        else:
+            compute_policy_stats_fn = compute_logprobs_and_entropy
+
+        def loss_fn(model, batch, key):
+            return hybrid_rloo_sampled_token_reverse_kl_opd_loss(
+                model,
+                reference_model,
+                teacher_model,
+                batch,
+                key=key,
+                kl=self.kl,
+                opd_coef=self.opd_coef,
+                clip_epsilon_low=self.clip_epsilon_low,
+                clip_epsilon_high=self.clip_epsilon_high,
+                tis_importance_sampling_ratio_max=self.tis_importance_sampling_ratio_max,
+                synchronous=self.synchronous,
+                do_trainer_inference_mismatch_importance_sampling=self.do_trainer_inference_mismatch_importance_sampling,
+                do_overlong_filtering=self.do_overlong_filtering,
+                log_policy_entropy=self.log_policy_entropy,
+                compute_policy_stats_fn=compute_policy_stats_fn,
+            )
+
+        return loss_fn

--- a/lib/marin/src/marin/rl/replay_buffer.py
+++ b/lib/marin/src/marin/rl/replay_buffer.py
@@ -186,11 +186,11 @@ class ReplayBuffer:
         current_time = time.time()
 
         for batch in new_batches:
-            # R[num_groups, num_rollouts_per_group]
-            batch_rewards = np.zeros((len(batch.groups), len(batch.groups[0].rollouts)), dtype=np.float32)
-
             if not batch.groups or not batch.groups[0].rollouts:
                 continue
+
+            # R[num_groups, num_rollouts_per_group]
+            batch_rewards = np.zeros((len(batch.groups), len(batch.groups[0].rollouts)), dtype=np.float32)
 
             # Read weight_step from first rollout's metadata
             first_rollout = batch.groups[0].rollouts[0]

--- a/lib/marin/src/marin/rl/rl_experiment_utils.py
+++ b/lib/marin/src/marin/rl/rl_experiment_utils.py
@@ -34,6 +34,7 @@ from marin.rl.rl_job import RLJob, RLJobConfig, RunConfig, TrainParams
 from marin.rl.rl_losses import RLLossModule
 from marin.rl.rollout_storage import RolloutStorageConfig, StorageType
 from marin.rl.rollout_worker import RolloutTrackerConfig
+from marin.rl.teacher import INITIAL_POLICY_TEACHER_CHECKPOINT, TeacherConfig
 from marin.rl.weight_transfer import WeightTransferConfig, WeightTransferMode
 from marin.training.training import LevanterCheckpoint
 
@@ -77,6 +78,7 @@ class RLExperimentConfig:
     model_config: ModelConfig
     rl_loss: RLLossModule
     experiment_name_suffix: str
+    teacher: TeacherConfig | None = None
 
     # trainer params
     train_batch_size: int = 1024
@@ -172,6 +174,14 @@ def _vllm_load_format_for_model_path(model_path: str) -> str:
         return "runai_streamer"
 
     return "dummy"
+
+
+def _resolve_teacher_config(teacher: TeacherConfig | None, model_path: str) -> TeacherConfig | None:
+    if teacher is None:
+        return None
+    if teacher.checkpoint == INITIAL_POLICY_TEACHER_CHECKPOINT:
+        return dataclasses.replace(teacher, checkpoint=model_path)
+    return teacher
 
 
 def config_class_path(config_class: type[HFCompatConfig]) -> str:
@@ -324,6 +334,7 @@ def _build_rl_job_config(
             fallback_sampling=_build_vllm_fallback_sampling_config(config),
         ),
         initial_checkpoint=model_path,
+        teacher=_resolve_teacher_config(config.teacher, model_path),
         rollout_storage=rollout_storage,
         weight_transfer=weight_transfer,
         run_id=name,

--- a/lib/marin/src/marin/rl/rl_losses.py
+++ b/lib/marin/src/marin/rl/rl_losses.py
@@ -44,7 +44,17 @@ class RLLossModule(Protocol):
         """Return whether this loss needs a separately retained reference model."""
         ...
 
-    def create_loss_fn(self, reference_model: eqx.Module | None, train_model: eqx.Module) -> Callable:
+    def needs_teacher_model(self) -> bool:
+        """Return whether this loss needs a separately retained teacher model."""
+        ...
+
+    def create_loss_fn(
+        self,
+        reference_model: eqx.Module | None,
+        train_model: eqx.Module,
+        *,
+        teacher_model: eqx.Module | None = None,
+    ) -> Callable:
         """Create the loss function for training."""
         ...
 
@@ -474,8 +484,19 @@ class RLOOLoss(RLLossModule):
         """Return whether KL regularization requires a reference model."""
         return self.kl.enabled()
 
-    def create_loss_fn(self, reference_model: eqx.Module | None, train_model: eqx.Module) -> Callable:
+    def needs_teacher_model(self) -> bool:
+        """Return whether this loss needs a separately retained teacher model."""
+        return False
+
+    def create_loss_fn(
+        self,
+        reference_model: eqx.Module | None,
+        train_model: eqx.Module,
+        *,
+        teacher_model: eqx.Module | None = None,
+    ) -> Callable:
         """Create the loss function for training."""
+        del teacher_model
         if self.needs_reference_model() and reference_model is None:
             raise ValueError("reference_model is required when KL regularization is enabled")
         if self.log_policy_entropy and self.vocab_tile_size is not None:

--- a/lib/marin/src/marin/rl/teacher.py
+++ b/lib/marin/src/marin/rl/teacher.py
@@ -1,0 +1,34 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Teacher-model configuration for RL distillation losses."""
+
+from dataclasses import dataclass
+from enum import StrEnum
+
+INITIAL_POLICY_TEACHER_CHECKPOINT = "initial_policy_checkpoint"
+"""Marker resolved by RL experiment launchers to the runtime student initial checkpoint."""
+
+
+class TeacherScoringMode(StrEnum):
+    """Supported teacher scoring modes."""
+
+    LOCAL_SAMPLED_TOKEN = "local_sampled_token"
+
+
+@dataclass(frozen=True)
+class TeacherConfig:
+    """Configuration for a local teacher model used by train-time losses."""
+
+    checkpoint: str
+    """Checkpoint or Hugging Face repo used to load the teacher model."""
+
+    scoring_mode: TeacherScoringMode = TeacherScoringMode.LOCAL_SAMPLED_TOKEN
+    """Teacher scoring implementation. The MVP supports sampled-token scoring only."""
+
+    def __post_init__(self) -> None:
+        if not self.checkpoint:
+            raise ValueError("TeacherConfig.checkpoint must be non-empty")
+
+        if not isinstance(self.scoring_mode, TeacherScoringMode):
+            object.__setattr__(self, "scoring_mode", TeacherScoringMode(self.scoring_mode))

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -39,6 +39,7 @@ from marin.rl import weight_transfer
 from marin.rl.curriculum import CurriculumConfig
 from marin.rl.model_utils import load_model_from_checkpoint
 from marin.rl.runtime import RLRuntimeHandles
+from marin.rl.teacher import INITIAL_POLICY_TEACHER_CHECKPOINT, TeacherConfig, TeacherScoringMode
 from marin.rl.weight_transfer import WeightTransferConfig
 
 from .replay_buffer import ReplayBuffer, ReplayBufferConfig, ReplayDataLoader, RolloutWithCount
@@ -144,6 +145,7 @@ class TrainWorkerConfig:
     weight_transfer: WeightTransferConfig
     curriculum_config: CurriculumConfig
     loss: RLLossModule
+    teacher: TeacherConfig | None
     tokenizer: MarinTokenizer
     run_id: str
 
@@ -270,6 +272,7 @@ class TrainWorker:
     loss_module: RLLossModule
     initial_model: LmHeadModel | None
     reference_model: LmHeadModel | None
+    teacher_model: LmHeadModel | None
 
     def __init__(
         self,
@@ -337,9 +340,20 @@ class TrainWorker:
     def _build_models(self):
         """Build the initial policy model and optional retained reference model."""
         config = self.config
-        model_key = jrandom.PRNGKey(config.seed)
+        model_key, teacher_key = jrandom.split(jrandom.PRNGKey(config.seed))
         vocab_size = config.vocab_size if config.vocab_size is not None else self.tokenizer.vocab_size
         Vocab = hax.Axis("vocab", vocab_size)
+        loss_needs_teacher = self.loss_module.needs_teacher_model()
+        teacher_config = config.teacher
+
+        if not loss_needs_teacher and teacher_config is not None:
+            raise ValueError("TeacherConfig was provided, but the configured RL loss does not use a teacher model")
+        if loss_needs_teacher and teacher_config is None:
+            raise ValueError("TeacherConfig is required when the RL loss needs a teacher model")
+        if loss_needs_teacher and teacher_config.scoring_mode != TeacherScoringMode.LOCAL_SAMPLED_TOKEN:
+            raise ValueError(f"Unsupported teacher scoring mode: {teacher_config.scoring_mode}")
+        if loss_needs_teacher and teacher_config.checkpoint == INITIAL_POLICY_TEACHER_CHECKPOINT:
+            raise ValueError("TeacherConfig checkpoint marker was not resolved before TrainWorker model loading")
 
         if config.initial_checkpoint is not None:
             logger.info(f"Loading initial model from checkpoint: {config.initial_checkpoint}")
@@ -362,6 +376,23 @@ class TrainWorker:
         # Keep compatibility for callers that inspect the worker immediately after construction.
         # The zero-KL path clears this alias once trainer state has been materialized.
         self.reference_model = self.initial_model
+        self.teacher_model = None
+
+        if not loss_needs_teacher:
+            return
+
+        assert teacher_config is not None
+        logger.info("Loading teacher model from checkpoint: %s", teacher_config.checkpoint)
+        self.teacher_model = load_model_from_checkpoint(
+            checkpoint=teacher_config.checkpoint,
+            model_config=config.model,
+            trainer_config=config.trainer,
+            vocab_axis=Vocab,
+            tokenizer=self.tokenizer,
+            mesh=config.trainer.device_mesh,
+            axis_mapping=self.config.trainer.parameter_axis_mapping,
+            key=teacher_key,
+        )
 
     def _drop_bootstrap_model_references(self) -> None:
         """Release one-shot bootstrap model references once trainer state exists."""
@@ -450,7 +481,7 @@ class TrainWorker:
         try:
             config = self.config
             optimizer = config.optimizer.build(config.trainer.num_train_steps)
-            loss_fn = self.loss_module.create_loss_fn(self.reference_model, None)
+            loss_fn = self.loss_module.create_loss_fn(self.reference_model, None, teacher_model=self.teacher_model)
 
             @jax.jit
             def _loss_function(model, batch, key):

--- a/tests/rl/integration/config.py
+++ b/tests/rl/integration/config.py
@@ -321,6 +321,7 @@ def create_nano_train_worker_config(rollout_storage: RolloutStorageConfig, outpu
             clip_epsilon_low=5.0,
             clip_epsilon_high=5.0,
         ),
+        teacher=None,
         initial_checkpoint=None,
     )
 

--- a/tests/rl/test_loss.py
+++ b/tests/rl/test_loss.py
@@ -228,6 +228,10 @@ def test_rloo_loss_needs_reference_model_only_when_kl_enabled():
     assert RLOOLoss(kl=KLConfig(mode=KLMode.K2_LOSS, beta=0.01)).needs_reference_model()
 
 
+def test_rloo_loss_does_not_need_teacher_model():
+    assert not RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)).needs_teacher_model()
+
+
 @pytest.mark.parametrize("mode", [KLMode.K1_LOSS, KLMode.K2_LOSS, KLMode.K3_LOSS])
 def test_rloo_loss_rejects_missing_reference_model_when_kl_enabled(mode: KLMode):
     with pytest.raises(ValueError, match="reference_model is required"):

--- a/tests/rl/test_opd_experiments.py
+++ b/tests/rl/test_opd_experiments.py
@@ -1,0 +1,115 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+from marin.rl.opd_losses import HybridRLOOOPDSampledTokenReverseKLLoss, OPDSampledTokenReverseKLLoss
+from marin.rl.teacher import INITIAL_POLICY_TEACHER_CHECKPOINT
+
+from experiments import llama_3_8b_hybrid_opd_math500, llama_3_8b_opd_math500
+
+
+def _opd_args(**overrides):
+    defaults = {
+        "teacher_checkpoint": None,
+        "experiment_name_suffix": "opd-test",
+        "project_name": "test-project",
+        "num_train_steps": 7,
+        "checkpointer_save_interval": 600,
+        "keep_last_temporary_checkpoints": 5,
+        "debug_checkpointer": False,
+        "debug_checkpointer_log_interval": 60.0,
+        "debug_checkpointer_dump_stacks_after": 60.0,
+        "train_batch_size": 16,
+        "n_prompts": 16,
+        "train_tpu_type": "v5p-8",
+        "inference_tpu_type": "v5p-8",
+        "num_train_slices": 1,
+        "train_ram": "400g",
+        "inference_ram": "400g",
+        "zone": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def _hybrid_args(**overrides):
+    defaults = {
+        "teacher_checkpoint": "teacher-checkpoint",
+        "opd_coef": 0.125,
+        "experiment_name_suffix": "hybrid-test",
+        "project_name": "test-project",
+        "num_train_steps": 7,
+        "checkpointer_save_interval": 600,
+        "keep_last_temporary_checkpoints": 5,
+        "debug_checkpointer": False,
+        "debug_checkpointer_log_interval": 60.0,
+        "debug_checkpointer_dump_stacks_after": 60.0,
+        "train_batch_size": 64,
+        "n_prompts": 16,
+        "n_generations_per_prompt": 4,
+        "train_tpu_type": "v5p-8",
+        "inference_tpu_type": "v5p-8",
+        "num_train_slices": 1,
+        "train_ram": "400g",
+        "inference_ram": "400g",
+        "zone": None,
+    }
+    defaults.update(overrides)
+    return SimpleNamespace(**defaults)
+
+
+def test_opd_math500_config_defaults_teacher_to_initial_policy_marker():
+    config = llama_3_8b_opd_math500.build_experiment_config(_opd_args())
+
+    assert isinstance(config.rl_loss, OPDSampledTokenReverseKLLoss)
+    assert config.teacher is not None
+    assert config.teacher.checkpoint == INITIAL_POLICY_TEACHER_CHECKPOINT
+    assert config.n_generations_per_prompt == 1
+    assert config.inference_n == 1
+    assert config.train_batch_size == 16
+
+
+def test_opd_math500_config_allows_explicit_teacher_checkpoint():
+    config = llama_3_8b_opd_math500.build_experiment_config(_opd_args(teacher_checkpoint="teacher-checkpoint"))
+
+    assert config.teacher is not None
+    assert config.teacher.checkpoint == "teacher-checkpoint"
+
+
+def test_opd_math500_config_rejects_batch_larger_than_rollout_batch():
+    with pytest.raises(ValueError, match="train_batch_size"):
+        llama_3_8b_opd_math500.build_experiment_config(_opd_args(train_batch_size=17))
+
+
+def test_hybrid_opd_math500_config_defaults_teacher_to_initial_policy_marker():
+    config = llama_3_8b_hybrid_opd_math500.build_experiment_config(_hybrid_args(teacher_checkpoint=None))
+
+    assert config.teacher is not None
+    assert config.teacher.checkpoint == INITIAL_POLICY_TEACHER_CHECKPOINT
+
+
+def test_hybrid_opd_math500_config_uses_grouped_rollouts_and_matching_inference_n():
+    config = llama_3_8b_hybrid_opd_math500.build_experiment_config(_hybrid_args())
+
+    assert isinstance(config.rl_loss, HybridRLOOOPDSampledTokenReverseKLLoss)
+    assert config.rl_loss.opd_coef == pytest.approx(0.125)
+    assert config.teacher is not None
+    assert config.teacher.checkpoint == "teacher-checkpoint"
+    assert config.n_generations_per_prompt == 4
+    assert config.inference_n == config.n_generations_per_prompt
+    assert config.train_batch_size == 64
+    assert not config.inflight_weight_updates
+    assert config.max_rollout_step_delay == 0
+    assert config.replay_buffer_max_samples == 1
+
+
+def test_hybrid_opd_math500_config_rejects_group_size_one():
+    with pytest.raises(ValueError, match="must be > 1"):
+        llama_3_8b_hybrid_opd_math500.build_experiment_config(_hybrid_args(n_generations_per_prompt=1))
+
+
+def test_hybrid_opd_math500_config_rejects_batch_larger_than_rollout_batch():
+    with pytest.raises(ValueError, match="train_batch_size"):
+        llama_3_8b_hybrid_opd_math500.build_experiment_config(_hybrid_args(train_batch_size=65))

--- a/tests/rl/test_opd_experiments.py
+++ b/tests/rl/test_opd_experiments.py
@@ -4,8 +4,6 @@
 from types import SimpleNamespace
 
 import pytest
-from marin.rl.opd_losses import HybridRLOOOPDSampledTokenReverseKLLoss, OPDSampledTokenReverseKLLoss
-from marin.rl.teacher import INITIAL_POLICY_TEACHER_CHECKPOINT
 
 from experiments import llama_3_8b_hybrid_opd_math500, llama_3_8b_opd_math500
 
@@ -60,49 +58,9 @@ def _hybrid_args(**overrides):
     return SimpleNamespace(**defaults)
 
 
-def test_opd_math500_config_defaults_teacher_to_initial_policy_marker():
-    config = llama_3_8b_opd_math500.build_experiment_config(_opd_args())
-
-    assert isinstance(config.rl_loss, OPDSampledTokenReverseKLLoss)
-    assert config.teacher is not None
-    assert config.teacher.checkpoint == INITIAL_POLICY_TEACHER_CHECKPOINT
-    assert config.n_generations_per_prompt == 1
-    assert config.inference_n == 1
-    assert config.train_batch_size == 16
-
-
-def test_opd_math500_config_allows_explicit_teacher_checkpoint():
-    config = llama_3_8b_opd_math500.build_experiment_config(_opd_args(teacher_checkpoint="teacher-checkpoint"))
-
-    assert config.teacher is not None
-    assert config.teacher.checkpoint == "teacher-checkpoint"
-
-
 def test_opd_math500_config_rejects_batch_larger_than_rollout_batch():
     with pytest.raises(ValueError, match="train_batch_size"):
         llama_3_8b_opd_math500.build_experiment_config(_opd_args(train_batch_size=17))
-
-
-def test_hybrid_opd_math500_config_defaults_teacher_to_initial_policy_marker():
-    config = llama_3_8b_hybrid_opd_math500.build_experiment_config(_hybrid_args(teacher_checkpoint=None))
-
-    assert config.teacher is not None
-    assert config.teacher.checkpoint == INITIAL_POLICY_TEACHER_CHECKPOINT
-
-
-def test_hybrid_opd_math500_config_uses_grouped_rollouts_and_matching_inference_n():
-    config = llama_3_8b_hybrid_opd_math500.build_experiment_config(_hybrid_args())
-
-    assert isinstance(config.rl_loss, HybridRLOOOPDSampledTokenReverseKLLoss)
-    assert config.rl_loss.opd_coef == pytest.approx(0.125)
-    assert config.teacher is not None
-    assert config.teacher.checkpoint == "teacher-checkpoint"
-    assert config.n_generations_per_prompt == 4
-    assert config.inference_n == config.n_generations_per_prompt
-    assert config.train_batch_size == 64
-    assert not config.inflight_weight_updates
-    assert config.max_rollout_step_delay == 0
-    assert config.replay_buffer_max_samples == 1
 
 
 def test_hybrid_opd_math500_config_rejects_group_size_one():

--- a/tests/rl/test_opd_losses.py
+++ b/tests/rl/test_opd_losses.py
@@ -14,7 +14,6 @@ from marin.rl.opd_losses import (
     sampled_token_reverse_kl_opd_loss,
 )
 from marin.rl.rl_losses import rloo_loss_with_importance_sampling
-from marin.rl.teacher import TeacherConfig, TeacherScoringMode
 
 
 class DummyNamedArray:
@@ -45,21 +44,9 @@ def create_test_batch(
     )
 
 
-def test_teacher_config_normalizes_scoring_mode():
-    teacher = TeacherConfig(checkpoint="teacher", scoring_mode="local_sampled_token")
-
-    assert teacher.scoring_mode is TeacherScoringMode.LOCAL_SAMPLED_TOKEN
-
-
 def test_opd_loss_rejects_missing_teacher_model():
     with pytest.raises(ValueError, match="teacher_model is required"):
         OPDSampledTokenReverseKLLoss().create_loss_fn(reference_model=None, train_model=None)
-
-
-def test_opd_advantages_are_unit_weights():
-    loss = OPDSampledTokenReverseKLLoss()
-
-    np.testing.assert_array_equal(loss.compute_advantages([object(), object(), object()]), np.ones(3))
 
 
 def test_sampled_token_opd_loss_is_zero_when_teacher_behavior_and_current_match():

--- a/tests/rl/test_opd_losses.py
+++ b/tests/rl/test_opd_losses.py
@@ -51,13 +51,6 @@ def test_teacher_config_normalizes_scoring_mode():
     assert teacher.scoring_mode is TeacherScoringMode.LOCAL_SAMPLED_TOKEN
 
 
-def test_opd_loss_requests_teacher_and_not_reference():
-    loss = OPDSampledTokenReverseKLLoss()
-
-    assert loss.needs_teacher_model()
-    assert not loss.needs_reference_model()
-
-
 def test_opd_loss_rejects_missing_teacher_model():
     with pytest.raises(ValueError, match="teacher_model is required"):
         OPDSampledTokenReverseKLLoss().create_loss_fn(reference_model=None, train_model=None)
@@ -190,7 +183,7 @@ def test_sampled_token_opd_loss_clips_negative_advantages_like_ppo_objective():
     assert metrics["opd/clip_fraction"].value() == pytest.approx(1.0)
 
 
-def test_hybrid_loss_requests_teacher_and_reference_when_kl_enabled():
+def test_hybrid_loss_rejects_missing_required_models():
     no_kl_loss = HybridRLOOOPDSampledTokenReverseKLLoss(
         kl=KLConfig(mode=KLMode.NONE, beta=0.0),
         opd_coef=0.1,
@@ -199,11 +192,6 @@ def test_hybrid_loss_requests_teacher_and_reference_when_kl_enabled():
         kl=KLConfig(mode=KLMode.K2_LOSS, beta=0.1),
         opd_coef=0.1,
     )
-
-    assert no_kl_loss.needs_teacher_model()
-    assert not no_kl_loss.needs_reference_model()
-    assert kl_loss.needs_teacher_model()
-    assert kl_loss.needs_reference_model()
 
     with pytest.raises(ValueError, match="teacher_model is required"):
         no_kl_loss.create_loss_fn(reference_model=None, train_model=None)
@@ -227,7 +215,6 @@ def test_hybrid_loss_uses_rloo_reward_advantages():
 
 def test_hybrid_loss_with_zero_opd_coef_matches_rloo_reward_loss():
     current_model = object()
-    reference_model = object()
     teacher_model = object()
     behavior_logprobs = jnp.array([[0.0, -1.0, -1.0]], dtype=jnp.float32)
     reward_advantages = jnp.array([[0.0, 0.25, -0.5]], dtype=jnp.float32)
@@ -240,7 +227,7 @@ def test_hybrid_loss_with_zero_opd_coef_matches_rloo_reward_loss():
 
     def compute_policy_stats(model, _batch, _key, *, compute_entropy: bool):
         assert not compute_entropy
-        if model in {current_model, reference_model, teacher_model}:
+        if model in {current_model, teacher_model}:
             return behavior_logprobs, None
         raise AssertionError("unexpected model")
 
@@ -360,6 +347,13 @@ def test_hybrid_loss_combines_reward_and_opd_advantages():
     assert metrics["hybrid/reward_advantage_mean"].value() == pytest.approx(0.25)
     assert metrics["hybrid/opd_advantage_mean"].value() == pytest.approx(0.75)
     assert metrics["hybrid/combined_advantage_mean"].value() == pytest.approx(0.625)
+    assert metrics["hybrid/reward_loss"].value() == pytest.approx(-0.25)
+    assert metrics["hybrid/opd_loss"].value() == pytest.approx(-0.375)
+    assert metrics["hybrid/combined_reinforce_loss"].value() == pytest.approx(-0.625)
+    assert metrics["hybrid/opd_coef"].value() == pytest.approx(0.5)
+    assert metrics["hybrid/current_teacher_gap_mean"].value() == pytest.approx(-0.75)
+    assert metrics["hybrid/behavior_teacher_gap_mean"].value() == pytest.approx(-0.75)
+    assert metrics["kl_loss"].value() == pytest.approx(0.0)
     assert loss == pytest.approx(-0.625)
 
 
@@ -401,55 +395,3 @@ def test_hybrid_loss_clips_negative_combined_advantages_like_ppo_objective():
 
     assert loss == pytest.approx(0.45)
     assert metrics["clip_fraction"].value() == pytest.approx(1.0)
-
-
-def test_hybrid_loss_reports_expected_metrics():
-    current_model = object()
-    teacher_model = object()
-    behavior_logprobs = jnp.array([[0.0, -1.0, -2.0]], dtype=jnp.float32)
-    teacher_logprobs = jnp.array([[0.0, -0.5, -1.0]], dtype=jnp.float32)
-    reward_advantages = jnp.array([[0.0, 1.0, -0.5]], dtype=jnp.float32)
-    loss_masks = jnp.array([[0.0, 1.0, 1.0]], dtype=jnp.float32)
-    batch = create_test_batch(
-        behavior_logprobs=behavior_logprobs,
-        loss_weights=reward_advantages,
-        loss_masks=loss_masks,
-    )
-
-    def compute_policy_stats(model, _batch, _key, *, compute_entropy: bool):
-        assert not compute_entropy
-        if model is current_model:
-            return behavior_logprobs, None
-        if model is teacher_model:
-            return teacher_logprobs, None
-        raise AssertionError("unexpected model")
-
-    _loss, metrics = hybrid_rloo_sampled_token_reverse_kl_opd_loss(
-        current_model,
-        reference_model=None,
-        teacher_model=teacher_model,
-        batch=batch,
-        key=None,
-        kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-        opd_coef=0.5,
-        clip_epsilon_low=10.0,
-        clip_epsilon_high=10.0,
-        tis_importance_sampling_ratio_max=2.0,
-        compute_policy_stats_fn=compute_policy_stats,
-    )
-
-    expected_metric_names = {
-        "hybrid/reward_loss",
-        "hybrid/opd_loss",
-        "hybrid/combined_reinforce_loss",
-        "hybrid/opd_coef",
-        "hybrid/reward_advantage_mean",
-        "hybrid/opd_advantage_mean",
-        "hybrid/combined_advantage_mean",
-        "hybrid/current_teacher_gap_mean",
-        "hybrid/behavior_teacher_gap_mean",
-        "ratio_mean",
-        "clip_fraction",
-        "kl_loss",
-    }
-    assert expected_metric_names <= metrics.keys()

--- a/tests/rl/test_opd_losses.py
+++ b/tests/rl/test_opd_losses.py
@@ -1,0 +1,455 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.opd_losses import (
+    HybridRLOOOPDSampledTokenReverseKLLoss,
+    OPDSampledTokenReverseKLLoss,
+    hybrid_rloo_sampled_token_reverse_kl_opd_loss,
+    sampled_token_reverse_kl_opd_loss,
+)
+from marin.rl.rl_losses import rloo_loss_with_importance_sampling
+from marin.rl.teacher import TeacherConfig, TeacherScoringMode
+
+
+class DummyNamedArray:
+    def __init__(self, array):
+        self.array = jnp.asarray(array)
+
+
+def create_test_batch(
+    *,
+    behavior_logprobs,
+    loss_masks,
+    loss_weights=None,
+    truncated=None,
+):
+    if loss_weights is None:
+        loss_weights = jnp.zeros_like(behavior_logprobs)
+    if truncated is None:
+        truncated = jnp.zeros((behavior_logprobs.shape[0],), dtype=jnp.float32)
+
+    return SimpleNamespace(
+        policy_logprobs=DummyNamedArray(behavior_logprobs),
+        loss_weights=DummyNamedArray(loss_weights),
+        loss_masks=DummyNamedArray(loss_masks),
+        temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
+        top_k=DummyNamedArray(jnp.array([0], dtype=jnp.int32)),
+        truncated=truncated,
+        max_output_tokens=behavior_logprobs.shape[-1],
+    )
+
+
+def test_teacher_config_normalizes_scoring_mode():
+    teacher = TeacherConfig(checkpoint="teacher", scoring_mode="local_sampled_token")
+
+    assert teacher.scoring_mode is TeacherScoringMode.LOCAL_SAMPLED_TOKEN
+
+
+def test_opd_loss_requests_teacher_and_not_reference():
+    loss = OPDSampledTokenReverseKLLoss()
+
+    assert loss.needs_teacher_model()
+    assert not loss.needs_reference_model()
+
+
+def test_opd_loss_rejects_missing_teacher_model():
+    with pytest.raises(ValueError, match="teacher_model is required"):
+        OPDSampledTokenReverseKLLoss().create_loss_fn(reference_model=None, train_model=None)
+
+
+def test_opd_advantages_are_unit_weights():
+    loss = OPDSampledTokenReverseKLLoss()
+
+    np.testing.assert_array_equal(loss.compute_advantages([object(), object(), object()]), np.ones(3))
+
+
+def test_sampled_token_opd_loss_is_zero_when_teacher_behavior_and_current_match():
+    current_model = object()
+    teacher_model = object()
+    logprobs = jnp.array([[0.0, -0.5, -1.0]], dtype=jnp.float32)
+    loss_masks = jnp.array([[0.0, 1.0, 1.0]], dtype=jnp.float32)
+    batch = create_test_batch(behavior_logprobs=logprobs, loss_masks=loss_masks)
+
+    def compute_logprobs(model, _batch, _key):
+        if model in {current_model, teacher_model}:
+            return logprobs
+        raise AssertionError("unexpected model")
+
+    loss, metrics = sampled_token_reverse_kl_opd_loss(
+        current_model,
+        teacher_model,
+        batch,
+        key=None,
+        synchronous=False,
+        clip_epsilon_low=None,
+        clip_epsilon_high=None,
+        compute_policy_logprobs_fn=compute_logprobs,
+    )
+
+    assert loss == pytest.approx(0.0)
+    assert metrics["opd/teacher_advantage_mean"].value() == pytest.approx(0.0)
+    assert metrics["opd/ratio_mean"].value() == pytest.approx(1.0)
+
+
+def test_sampled_token_opd_loss_uses_teacher_logprob_minus_behavior_logprob_advantage():
+    current_model = object()
+    teacher_model = object()
+    behavior_logprobs = jnp.array([[0.0, -1.0, -2.0]], dtype=jnp.float32)
+    teacher_logprobs = jnp.array([[0.0, -0.5, -1.0]], dtype=jnp.float32)
+    loss_masks = jnp.array([[0.0, 1.0, 1.0]], dtype=jnp.float32)
+    batch = create_test_batch(behavior_logprobs=behavior_logprobs, loss_masks=loss_masks)
+
+    def compute_logprobs(model, _batch, _key):
+        if model is current_model:
+            return behavior_logprobs
+        if model is teacher_model:
+            return teacher_logprobs
+        raise AssertionError("unexpected model")
+
+    loss, metrics = sampled_token_reverse_kl_opd_loss(
+        current_model,
+        teacher_model,
+        batch,
+        key=None,
+        synchronous=False,
+        clip_epsilon_low=None,
+        clip_epsilon_high=None,
+        compute_policy_logprobs_fn=compute_logprobs,
+    )
+
+    assert loss == pytest.approx(-0.75)
+    assert metrics["opd/teacher_advantage_mean"].value() == pytest.approx(0.75)
+    assert metrics["opd/behavior_teacher_gap_mean"].value() == pytest.approx(-0.75)
+
+
+def test_sampled_token_opd_loss_clips_importance_ratio_when_configured():
+    current_model = object()
+    teacher_model = object()
+    behavior_logprobs = jnp.array([[0.0, -1.0, -1.0]], dtype=jnp.float32)
+    current_logprobs = jnp.array([[0.0, -0.5, -0.5]], dtype=jnp.float32)
+    teacher_logprobs = jnp.array([[0.0, -0.25, -0.25]], dtype=jnp.float32)
+    loss_masks = jnp.array([[0.0, 1.0, 1.0]], dtype=jnp.float32)
+    batch = create_test_batch(behavior_logprobs=behavior_logprobs, loss_masks=loss_masks)
+
+    def compute_logprobs(model, _batch, _key):
+        if model is current_model:
+            return current_logprobs
+        if model is teacher_model:
+            return teacher_logprobs
+        raise AssertionError("unexpected model")
+
+    loss, metrics = sampled_token_reverse_kl_opd_loss(
+        current_model,
+        teacher_model,
+        batch,
+        key=None,
+        synchronous=False,
+        clip_epsilon_low=0.1,
+        clip_epsilon_high=0.1,
+        compute_policy_logprobs_fn=compute_logprobs,
+    )
+
+    assert loss == pytest.approx(-0.825)
+    assert metrics["opd/clip_fraction"].value() == pytest.approx(1.0)
+
+
+def test_sampled_token_opd_loss_clips_negative_advantages_like_ppo_objective():
+    current_model = object()
+    teacher_model = object()
+    behavior_logprobs = jnp.array([[0.0, -1.0, -1.0]], dtype=jnp.float32)
+    current_logprobs = jnp.array([[0.0, -2.0, -2.0]], dtype=jnp.float32)
+    teacher_logprobs = jnp.array([[0.0, -1.5, -1.5]], dtype=jnp.float32)
+    loss_masks = jnp.array([[0.0, 1.0, 1.0]], dtype=jnp.float32)
+    batch = create_test_batch(behavior_logprobs=behavior_logprobs, loss_masks=loss_masks)
+
+    def compute_logprobs(model, _batch, _key):
+        if model is current_model:
+            return current_logprobs
+        if model is teacher_model:
+            return teacher_logprobs
+        raise AssertionError("unexpected model")
+
+    loss, metrics = sampled_token_reverse_kl_opd_loss(
+        current_model,
+        teacher_model,
+        batch,
+        key=None,
+        synchronous=False,
+        clip_epsilon_low=0.1,
+        clip_epsilon_high=0.1,
+        compute_policy_logprobs_fn=compute_logprobs,
+    )
+
+    assert loss == pytest.approx(0.45)
+    assert metrics["opd/clip_fraction"].value() == pytest.approx(1.0)
+
+
+def test_hybrid_loss_requests_teacher_and_reference_when_kl_enabled():
+    no_kl_loss = HybridRLOOOPDSampledTokenReverseKLLoss(
+        kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+        opd_coef=0.1,
+    )
+    kl_loss = HybridRLOOOPDSampledTokenReverseKLLoss(
+        kl=KLConfig(mode=KLMode.K2_LOSS, beta=0.1),
+        opd_coef=0.1,
+    )
+
+    assert no_kl_loss.needs_teacher_model()
+    assert not no_kl_loss.needs_reference_model()
+    assert kl_loss.needs_teacher_model()
+    assert kl_loss.needs_reference_model()
+
+    with pytest.raises(ValueError, match="teacher_model is required"):
+        no_kl_loss.create_loss_fn(reference_model=None, train_model=None)
+    with pytest.raises(ValueError, match="reference_model is required"):
+        kl_loss.create_loss_fn(reference_model=None, train_model=None, teacher_model=object())
+
+
+def test_hybrid_loss_uses_rloo_reward_advantages():
+    loss = HybridRLOOOPDSampledTokenReverseKLLoss(
+        kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+        opd_coef=0.1,
+    )
+    rollouts = [
+        SimpleNamespace(episode_reward=0.0),
+        SimpleNamespace(episode_reward=1.0),
+        SimpleNamespace(episode_reward=0.0),
+    ]
+
+    np.testing.assert_allclose(loss.compute_advantages(rollouts), np.array([-0.5, 1.0, -0.5]))
+
+
+def test_hybrid_loss_with_zero_opd_coef_matches_rloo_reward_loss():
+    current_model = object()
+    reference_model = object()
+    teacher_model = object()
+    behavior_logprobs = jnp.array([[0.0, -1.0, -1.0]], dtype=jnp.float32)
+    reward_advantages = jnp.array([[0.0, 0.25, -0.5]], dtype=jnp.float32)
+    loss_masks = jnp.array([[0.0, 1.0, 1.0]], dtype=jnp.float32)
+    batch = create_test_batch(
+        behavior_logprobs=behavior_logprobs,
+        loss_weights=reward_advantages,
+        loss_masks=loss_masks,
+    )
+
+    def compute_policy_stats(model, _batch, _key, *, compute_entropy: bool):
+        assert not compute_entropy
+        if model in {current_model, reference_model, teacher_model}:
+            return behavior_logprobs, None
+        raise AssertionError("unexpected model")
+
+    hybrid_loss, hybrid_metrics = hybrid_rloo_sampled_token_reverse_kl_opd_loss(
+        current_model,
+        reference_model=None,
+        teacher_model=teacher_model,
+        batch=batch,
+        key=None,
+        kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+        opd_coef=0.0,
+        clip_epsilon_low=0.2,
+        clip_epsilon_high=0.2,
+        tis_importance_sampling_ratio_max=2.0,
+        compute_policy_stats_fn=compute_policy_stats,
+    )
+    rloo_loss, rloo_metrics = rloo_loss_with_importance_sampling(
+        current_model,
+        reference_model=None,
+        batch=batch,
+        key=None,
+        kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+        clip_epsilon_low=0.2,
+        clip_epsilon_high=0.2,
+        tis_importance_sampling_ratio_max=2.0,
+        compute_policy_stats_fn=compute_policy_stats,
+    )
+
+    assert hybrid_loss == pytest.approx(rloo_loss)
+    assert hybrid_metrics["hybrid/opd_loss"].value() == pytest.approx(0.0)
+    assert hybrid_metrics["reinforce_loss"].value() == pytest.approx(rloo_metrics["reinforce_loss"].value())
+
+
+def test_hybrid_loss_with_zero_reward_advantage_matches_sampled_token_opd_loss():
+    current_model = object()
+    teacher_model = object()
+    behavior_logprobs = jnp.array([[0.0, -1.0, -2.0]], dtype=jnp.float32)
+    teacher_logprobs = jnp.array([[0.0, -0.5, -1.0]], dtype=jnp.float32)
+    loss_masks = jnp.array([[0.0, 1.0, 1.0]], dtype=jnp.float32)
+    batch = create_test_batch(behavior_logprobs=behavior_logprobs, loss_masks=loss_masks)
+
+    def compute_policy_stats(model, _batch, _key, *, compute_entropy: bool):
+        assert not compute_entropy
+        if model is current_model:
+            return behavior_logprobs, None
+        if model is teacher_model:
+            return teacher_logprobs, None
+        raise AssertionError("unexpected model")
+
+    def compute_logprobs(model, _batch, _key):
+        logprobs, _entropy = compute_policy_stats(model, _batch, _key, compute_entropy=False)
+        return logprobs
+
+    hybrid_loss, hybrid_metrics = hybrid_rloo_sampled_token_reverse_kl_opd_loss(
+        current_model,
+        reference_model=None,
+        teacher_model=teacher_model,
+        batch=batch,
+        key=None,
+        kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+        opd_coef=1.0,
+        clip_epsilon_low=10.0,
+        clip_epsilon_high=10.0,
+        tis_importance_sampling_ratio_max=2.0,
+        compute_policy_stats_fn=compute_policy_stats,
+    )
+    opd_loss, _opd_metrics = sampled_token_reverse_kl_opd_loss(
+        current_model,
+        teacher_model,
+        batch,
+        key=None,
+        synchronous=False,
+        clip_epsilon_low=None,
+        clip_epsilon_high=None,
+        compute_policy_logprobs_fn=compute_logprobs,
+    )
+
+    assert hybrid_loss == pytest.approx(opd_loss)
+    assert hybrid_metrics["hybrid/opd_advantage_mean"].value() == pytest.approx(0.75)
+
+
+def test_hybrid_loss_combines_reward_and_opd_advantages():
+    current_model = object()
+    teacher_model = object()
+    behavior_logprobs = jnp.array([[0.0, -1.0, -2.0]], dtype=jnp.float32)
+    teacher_logprobs = jnp.array([[0.0, -0.5, -1.0]], dtype=jnp.float32)
+    reward_advantages = jnp.array([[0.0, 1.0, -0.5]], dtype=jnp.float32)
+    loss_masks = jnp.array([[0.0, 1.0, 1.0]], dtype=jnp.float32)
+    batch = create_test_batch(
+        behavior_logprobs=behavior_logprobs,
+        loss_weights=reward_advantages,
+        loss_masks=loss_masks,
+    )
+
+    def compute_policy_stats(model, _batch, _key, *, compute_entropy: bool):
+        assert not compute_entropy
+        if model is current_model:
+            return behavior_logprobs, None
+        if model is teacher_model:
+            return teacher_logprobs, None
+        raise AssertionError("unexpected model")
+
+    loss, metrics = hybrid_rloo_sampled_token_reverse_kl_opd_loss(
+        current_model,
+        reference_model=None,
+        teacher_model=teacher_model,
+        batch=batch,
+        key=None,
+        kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+        opd_coef=0.5,
+        clip_epsilon_low=10.0,
+        clip_epsilon_high=10.0,
+        tis_importance_sampling_ratio_max=2.0,
+        compute_policy_stats_fn=compute_policy_stats,
+    )
+
+    assert metrics["hybrid/reward_advantage_mean"].value() == pytest.approx(0.25)
+    assert metrics["hybrid/opd_advantage_mean"].value() == pytest.approx(0.75)
+    assert metrics["hybrid/combined_advantage_mean"].value() == pytest.approx(0.625)
+    assert loss == pytest.approx(-0.625)
+
+
+def test_hybrid_loss_clips_negative_combined_advantages_like_ppo_objective():
+    current_model = object()
+    teacher_model = object()
+    behavior_logprobs = jnp.array([[0.0, -1.0, -1.0]], dtype=jnp.float32)
+    current_logprobs = jnp.array([[0.0, -2.0, -2.0]], dtype=jnp.float32)
+    teacher_logprobs = jnp.array([[0.0, -1.5, -1.5]], dtype=jnp.float32)
+    reward_advantages = jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32)
+    loss_masks = jnp.array([[0.0, 1.0, 1.0]], dtype=jnp.float32)
+    batch = create_test_batch(
+        behavior_logprobs=behavior_logprobs,
+        loss_weights=reward_advantages,
+        loss_masks=loss_masks,
+    )
+
+    def compute_policy_stats(model, _batch, _key, *, compute_entropy: bool):
+        assert not compute_entropy
+        if model is current_model:
+            return current_logprobs, None
+        if model is teacher_model:
+            return teacher_logprobs, None
+        raise AssertionError("unexpected model")
+
+    loss, metrics = hybrid_rloo_sampled_token_reverse_kl_opd_loss(
+        current_model,
+        reference_model=None,
+        teacher_model=teacher_model,
+        batch=batch,
+        key=None,
+        kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+        opd_coef=1.0,
+        clip_epsilon_low=0.1,
+        clip_epsilon_high=0.1,
+        tis_importance_sampling_ratio_max=2.0,
+        compute_policy_stats_fn=compute_policy_stats,
+    )
+
+    assert loss == pytest.approx(0.45)
+    assert metrics["clip_fraction"].value() == pytest.approx(1.0)
+
+
+def test_hybrid_loss_reports_expected_metrics():
+    current_model = object()
+    teacher_model = object()
+    behavior_logprobs = jnp.array([[0.0, -1.0, -2.0]], dtype=jnp.float32)
+    teacher_logprobs = jnp.array([[0.0, -0.5, -1.0]], dtype=jnp.float32)
+    reward_advantages = jnp.array([[0.0, 1.0, -0.5]], dtype=jnp.float32)
+    loss_masks = jnp.array([[0.0, 1.0, 1.0]], dtype=jnp.float32)
+    batch = create_test_batch(
+        behavior_logprobs=behavior_logprobs,
+        loss_weights=reward_advantages,
+        loss_masks=loss_masks,
+    )
+
+    def compute_policy_stats(model, _batch, _key, *, compute_entropy: bool):
+        assert not compute_entropy
+        if model is current_model:
+            return behavior_logprobs, None
+        if model is teacher_model:
+            return teacher_logprobs, None
+        raise AssertionError("unexpected model")
+
+    _loss, metrics = hybrid_rloo_sampled_token_reverse_kl_opd_loss(
+        current_model,
+        reference_model=None,
+        teacher_model=teacher_model,
+        batch=batch,
+        key=None,
+        kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+        opd_coef=0.5,
+        clip_epsilon_low=10.0,
+        clip_epsilon_high=10.0,
+        tis_importance_sampling_ratio_max=2.0,
+        compute_policy_stats_fn=compute_policy_stats,
+    )
+
+    expected_metric_names = {
+        "hybrid/reward_loss",
+        "hybrid/opd_loss",
+        "hybrid/combined_reinforce_loss",
+        "hybrid/opd_coef",
+        "hybrid/reward_advantage_mean",
+        "hybrid/opd_advantage_mean",
+        "hybrid/combined_advantage_mean",
+        "hybrid/current_teacher_gap_mean",
+        "hybrid/behavior_teacher_gap_mean",
+        "ratio_mean",
+        "clip_fraction",
+        "kl_loss",
+    }
+    assert expected_metric_names <= metrics.keys()

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -142,6 +142,25 @@ def test_replay_buffer():
         assert rollouts is not None
 
 
+def test_replay_buffer_ignores_empty_rollout_batches():
+    replay_buffer = ReplayBuffer(
+        capacity=100,
+        local_batch_size=4,
+        alpha=3.0,
+        total_processes=1,
+        max_samples=-1,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        filter_out_groups_with_no_variance=False,
+        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
+        seed=42,
+    )
+
+    replay_buffer.add_batches([RolloutBatch(groups=[], metadata=RolloutMetadata())])
+
+    assert replay_buffer.size() == 0
+
+
 def test_replay_buffer_recency_bias():
     """Test that high recency bias strongly favors recent (higher index) samples."""
     # Create a batch with 100 rollouts across multiple groups for better testing

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -23,6 +23,7 @@ from marin.rl.rl_experiment_utils import (
     make_rl_step,
 )
 from marin.rl.rl_losses import RLOOLoss
+from marin.rl.teacher import INITIAL_POLICY_TEACHER_CHECKPOINT, TeacherConfig
 from marin.training.training import LevanterCheckpoint
 
 MODEL_NAME = "meta-llama/Llama-3.1-8B-Instruct"
@@ -229,6 +230,28 @@ def test_build_rl_job_config_uses_dummy_load_format_for_non_object_store_model_p
 
     assert job_config.inference_config.engine.load_format == "dummy"
     assert job_config.inference_config.engine.canonical_model_name == MODEL_NAME
+
+
+def test_build_rl_job_config_resolves_initial_policy_teacher_checkpoint(monkeypatch):
+    class _FakeConverter:
+        def __init__(self, *args, **kwargs):
+            self.default_hf_config = SimpleNamespace(vocab_size=32000)
+
+    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
+    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
+
+    job_config = _build_rl_job_config(
+        name="rl-test",
+        config=dataclasses.replace(
+            _test_config(train_tpu_type="v5p-8", inference_tpu_type="v5p-8"),
+            teacher=TeacherConfig(checkpoint=INITIAL_POLICY_TEACHER_CHECKPOINT),
+        ),
+        curriculum=_test_curriculum(),
+        model_path="gs://marin-us-central1/models/test-model",
+        output_path="gs://marin-us-central1/rl_testing/rl-test",
+    )
+
+    assert job_config.teacher == TeacherConfig(checkpoint="gs://marin-us-central1/models/test-model")
 
 
 def test_run_rl_experiment_step_returns_a_path_ref(monkeypatch):

--- a/tests/rl/test_rl_job.py
+++ b/tests/rl/test_rl_job.py
@@ -1,0 +1,73 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from types import SimpleNamespace
+
+import pytest
+from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.opd_losses import HybridRLOOOPDSampledTokenReverseKLLoss, OPDSampledTokenReverseKLLoss
+from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
+from marin.rl.rl_losses import RLOOLoss
+from marin.rl.teacher import TeacherConfig
+
+
+def _job_config(*, rl_loss, teacher: TeacherConfig | None) -> RLJobConfig:
+    return RLJobConfig(
+        model=object(),
+        trainer=SimpleNamespace(device_mesh=None, compute_axis_mapping={}, seed=0),
+        train_params=TrainParams(optimizer=object(), rl_loss=rl_loss),
+        curriculum=SimpleNamespace(
+            lessons={"lesson": SimpleNamespace(sampling_params=SimpleNamespace(n_generations_per_prompt=1))},
+            max_seq_len=8,
+        ),
+        tokenizer=SimpleNamespace(vocab_size=8, pad_token_id=0, eos_token_id=0),
+        inference_type="vllm",
+        inference_config=SimpleNamespace(),
+        initial_checkpoint="student-checkpoint",
+        teacher=teacher,
+    )
+
+
+def test_rl_job_threads_teacher_config_to_train_worker():
+    teacher = TeacherConfig(checkpoint="teacher-checkpoint")
+    job = RLJob(_job_config(rl_loss=OPDSampledTokenReverseKLLoss(), teacher=teacher))
+
+    train_config, _rollout_config = job.to_worker_configs()
+
+    assert train_config.teacher == teacher
+
+
+def test_rl_job_threads_teacher_config_for_hybrid_loss():
+    teacher = TeacherConfig(checkpoint="teacher-checkpoint")
+    job = RLJob(
+        _job_config(
+            rl_loss=HybridRLOOOPDSampledTokenReverseKLLoss(
+                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+                opd_coef=0.1,
+            ),
+            teacher=teacher,
+        )
+    )
+
+    train_config, _rollout_config = job.to_worker_configs()
+
+    assert train_config.teacher == teacher
+
+
+def test_rl_job_requires_teacher_config_for_teacher_loss():
+    job = RLJob(_job_config(rl_loss=OPDSampledTokenReverseKLLoss(), teacher=None))
+
+    with pytest.raises(ValueError, match="TeacherConfig is required"):
+        job.to_worker_configs()
+
+
+def test_rl_job_rejects_teacher_config_for_non_teacher_loss():
+    job = RLJob(
+        _job_config(
+            rl_loss=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
+            teacher=TeacherConfig(checkpoint="teacher-checkpoint"),
+        )
+    )
+
+    with pytest.raises(ValueError, match="does not use a teacher"):
+        job.to_worker_configs()

--- a/tests/rl/test_rl_job.py
+++ b/tests/rl/test_rl_job.py
@@ -28,34 +28,37 @@ def _job_config(*, rl_loss, teacher: TeacherConfig | None) -> RLJobConfig:
     )
 
 
-def test_rl_job_threads_teacher_config_to_train_worker():
+@pytest.mark.parametrize(
+    "rl_loss",
+    [
+        OPDSampledTokenReverseKLLoss(),
+        HybridRLOOOPDSampledTokenReverseKLLoss(
+            kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+            opd_coef=0.1,
+        ),
+    ],
+)
+def test_rl_job_threads_teacher_config_to_train_worker(rl_loss):
     teacher = TeacherConfig(checkpoint="teacher-checkpoint")
-    job = RLJob(_job_config(rl_loss=OPDSampledTokenReverseKLLoss(), teacher=teacher))
+    job = RLJob(_job_config(rl_loss=rl_loss, teacher=teacher))
 
     train_config, _rollout_config = job.to_worker_configs()
 
     assert train_config.teacher == teacher
 
 
-def test_rl_job_threads_teacher_config_for_hybrid_loss():
-    teacher = TeacherConfig(checkpoint="teacher-checkpoint")
-    job = RLJob(
-        _job_config(
-            rl_loss=HybridRLOOOPDSampledTokenReverseKLLoss(
-                kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-                opd_coef=0.1,
-            ),
-            teacher=teacher,
-        )
-    )
-
-    train_config, _rollout_config = job.to_worker_configs()
-
-    assert train_config.teacher == teacher
-
-
-def test_rl_job_requires_teacher_config_for_teacher_loss():
-    job = RLJob(_job_config(rl_loss=OPDSampledTokenReverseKLLoss(), teacher=None))
+@pytest.mark.parametrize(
+    "rl_loss",
+    [
+        OPDSampledTokenReverseKLLoss(),
+        HybridRLOOOPDSampledTokenReverseKLLoss(
+            kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+            opd_coef=0.1,
+        ),
+    ],
+)
+def test_rl_job_requires_teacher_config_for_teacher_loss(rl_loss):
+    job = RLJob(_job_config(rl_loss=rl_loss, teacher=None))
 
     with pytest.raises(ValueError, match="TeacherConfig is required"):
         job.to_worker_configs()

--- a/tests/rl/test_rl_job.py
+++ b/tests/rl/test_rl_job.py
@@ -9,12 +9,13 @@ from marin.rl.opd_losses import HybridRLOOOPDSampledTokenReverseKLLoss, OPDSampl
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
 from marin.rl.teacher import TeacherConfig
+from marin.rl.train_worker import TrainWorker
 
 
 def _job_config(*, rl_loss, teacher: TeacherConfig | None) -> RLJobConfig:
     return RLJobConfig(
         model=object(),
-        trainer=SimpleNamespace(device_mesh=None, compute_axis_mapping={}, seed=0),
+        trainer=SimpleNamespace(device_mesh=None, compute_axis_mapping={}, parameter_axis_mapping={}, seed=0),
         train_params=TrainParams(optimizer=object(), rl_loss=rl_loss),
         curriculum=SimpleNamespace(
             lessons={"lesson": SimpleNamespace(sampling_params=SimpleNamespace(n_generations_per_prompt=1))},
@@ -28,23 +29,28 @@ def _job_config(*, rl_loss, teacher: TeacherConfig | None) -> RLJobConfig:
     )
 
 
-@pytest.mark.parametrize(
-    "rl_loss",
-    [
-        OPDSampledTokenReverseKLLoss(),
-        HybridRLOOOPDSampledTokenReverseKLLoss(
-            kl=KLConfig(mode=KLMode.NONE, beta=0.0),
-            opd_coef=0.1,
-        ),
-    ],
-)
-def test_rl_job_threads_teacher_config_to_train_worker(rl_loss):
+def test_rl_job_worker_config_loads_required_teacher(monkeypatch):
+    calls = []
+
+    def fake_load_model_from_checkpoint(**kwargs):
+        calls.append(kwargs)
+        return f"model:{kwargs['checkpoint']}"
+
+    monkeypatch.setattr("marin.rl.train_worker.load_model_from_checkpoint", fake_load_model_from_checkpoint)
+
     teacher = TeacherConfig(checkpoint="teacher-checkpoint")
-    job = RLJob(_job_config(rl_loss=rl_loss, teacher=teacher))
+    job = RLJob(_job_config(rl_loss=OPDSampledTokenReverseKLLoss(), teacher=teacher))
 
     train_config, _rollout_config = job.to_worker_configs()
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = train_config
+    worker.tokenizer = train_config.tokenizer
+    worker.loss_module = train_config.loss
 
-    assert train_config.teacher == teacher
+    worker._build_models()
+
+    assert [call["checkpoint"] for call in calls] == ["student-checkpoint", "teacher-checkpoint"]
+    assert worker.teacher_model == "model:teacher-checkpoint"
 
 
 @pytest.mark.parametrize(

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -5,6 +5,7 @@ from types import SimpleNamespace
 
 import pytest
 from marin.rl.kl_regularization import KLConfig, KLMode
+from marin.rl.opd_losses import OPDSampledTokenReverseKLLoss
 from marin.rl.rl_losses import RLOOLoss
 from marin.rl.teacher import INITIAL_POLICY_TEACHER_CHECKPOINT, TeacherConfig
 from marin.rl.train_worker import (
@@ -48,10 +49,6 @@ def test_drop_bootstrap_model_references_preserves_reference_model_when_kl_enabl
 def test_build_models_loads_teacher_when_loss_requires_teacher(monkeypatch):
     calls = []
 
-    class _TeacherLoss:
-        def needs_teacher_model(self) -> bool:
-            return True
-
     def fake_load_model_from_checkpoint(**kwargs):
         calls.append(kwargs)
         return f"model:{kwargs['checkpoint']}"
@@ -68,7 +65,7 @@ def test_build_models_loads_teacher_when_loss_requires_teacher(monkeypatch):
         trainer=SimpleNamespace(device_mesh=None, parameter_axis_mapping={}),
     )
     worker.tokenizer = SimpleNamespace(vocab_size=8)
-    worker.loss_module = _TeacherLoss()
+    worker.loss_module = OPDSampledTokenReverseKLLoss()
 
     worker._build_models()
 
@@ -80,10 +77,6 @@ def test_build_models_loads_teacher_when_loss_requires_teacher(monkeypatch):
 
 def test_build_models_rejects_missing_teacher_config_when_loss_requires_teacher(monkeypatch):
     calls = []
-
-    class _TeacherLoss:
-        def needs_teacher_model(self) -> bool:
-            return True
 
     monkeypatch.setattr(
         "marin.rl.train_worker.load_model_from_checkpoint",
@@ -100,7 +93,7 @@ def test_build_models_rejects_missing_teacher_config_when_loss_requires_teacher(
         trainer=SimpleNamespace(device_mesh=None, parameter_axis_mapping={}),
     )
     worker.tokenizer = SimpleNamespace(vocab_size=8)
-    worker.loss_module = _TeacherLoss()
+    worker.loss_module = OPDSampledTokenReverseKLLoss()
 
     with pytest.raises(ValueError, match="TeacherConfig is required"):
         worker._build_models()
@@ -109,10 +102,6 @@ def test_build_models_rejects_missing_teacher_config_when_loss_requires_teacher(
 
 def test_build_models_rejects_unused_teacher_config(monkeypatch):
     calls = []
-
-    class _NoTeacherLoss:
-        def needs_teacher_model(self) -> bool:
-            return False
 
     monkeypatch.setattr(
         "marin.rl.train_worker.load_model_from_checkpoint",
@@ -129,7 +118,7 @@ def test_build_models_rejects_unused_teacher_config(monkeypatch):
         trainer=SimpleNamespace(device_mesh=None, parameter_axis_mapping={}),
     )
     worker.tokenizer = SimpleNamespace(vocab_size=8)
-    worker.loss_module = _NoTeacherLoss()
+    worker.loss_module = RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0))
 
     with pytest.raises(ValueError, match="does not use a teacher"):
         worker._build_models()
@@ -138,10 +127,6 @@ def test_build_models_rejects_unused_teacher_config(monkeypatch):
 
 def test_build_models_rejects_unresolved_initial_policy_teacher_marker(monkeypatch):
     calls = []
-
-    class _TeacherLoss:
-        def needs_teacher_model(self) -> bool:
-            return True
 
     monkeypatch.setattr(
         "marin.rl.train_worker.load_model_from_checkpoint",
@@ -158,7 +143,7 @@ def test_build_models_rejects_unresolved_initial_policy_teacher_marker(monkeypat
         trainer=SimpleNamespace(device_mesh=None, parameter_axis_mapping={}),
     )
     worker.tokenizer = SimpleNamespace(vocab_size=8)
-    worker.loss_module = _TeacherLoss()
+    worker.loss_module = OPDSampledTokenReverseKLLoss()
 
     with pytest.raises(ValueError, match="checkpoint marker was not resolved"):
         worker._build_models()

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import pytest
 from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.rl_losses import RLOOLoss
+from marin.rl.teacher import INITIAL_POLICY_TEACHER_CHECKPOINT, TeacherConfig
 from marin.rl.train_worker import (
     BatchPrepTiming,
     InitialRolloutState,
@@ -42,6 +43,126 @@ def test_drop_bootstrap_model_references_preserves_reference_model_when_kl_enabl
 
     assert worker.initial_model is None
     assert worker.reference_model is model
+
+
+def test_build_models_loads_teacher_when_loss_requires_teacher(monkeypatch):
+    calls = []
+
+    class _TeacherLoss:
+        def needs_teacher_model(self) -> bool:
+            return True
+
+    def fake_load_model_from_checkpoint(**kwargs):
+        calls.append(kwargs)
+        return f"model:{kwargs['checkpoint']}"
+
+    monkeypatch.setattr("marin.rl.train_worker.load_model_from_checkpoint", fake_load_model_from_checkpoint)
+
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        seed=0,
+        vocab_size=8,
+        initial_checkpoint="student-checkpoint",
+        teacher=TeacherConfig(checkpoint="teacher-checkpoint"),
+        model=object(),
+        trainer=SimpleNamespace(device_mesh=None, parameter_axis_mapping={}),
+    )
+    worker.tokenizer = SimpleNamespace(vocab_size=8)
+    worker.loss_module = _TeacherLoss()
+
+    worker._build_models()
+
+    assert [call["checkpoint"] for call in calls] == ["student-checkpoint", "teacher-checkpoint"]
+    assert worker.initial_model == "model:student-checkpoint"
+    assert worker.reference_model == "model:student-checkpoint"
+    assert worker.teacher_model == "model:teacher-checkpoint"
+
+
+def test_build_models_rejects_missing_teacher_config_when_loss_requires_teacher(monkeypatch):
+    calls = []
+
+    class _TeacherLoss:
+        def needs_teacher_model(self) -> bool:
+            return True
+
+    monkeypatch.setattr(
+        "marin.rl.train_worker.load_model_from_checkpoint",
+        lambda **kwargs: calls.append(kwargs) or f"model:{kwargs['checkpoint']}",
+    )
+
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        seed=0,
+        vocab_size=8,
+        initial_checkpoint="student-checkpoint",
+        teacher=None,
+        model=object(),
+        trainer=SimpleNamespace(device_mesh=None, parameter_axis_mapping={}),
+    )
+    worker.tokenizer = SimpleNamespace(vocab_size=8)
+    worker.loss_module = _TeacherLoss()
+
+    with pytest.raises(ValueError, match="TeacherConfig is required"):
+        worker._build_models()
+    assert calls == []
+
+
+def test_build_models_rejects_unused_teacher_config(monkeypatch):
+    calls = []
+
+    class _NoTeacherLoss:
+        def needs_teacher_model(self) -> bool:
+            return False
+
+    monkeypatch.setattr(
+        "marin.rl.train_worker.load_model_from_checkpoint",
+        lambda **kwargs: calls.append(kwargs) or f"model:{kwargs['checkpoint']}",
+    )
+
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        seed=0,
+        vocab_size=8,
+        initial_checkpoint="student-checkpoint",
+        teacher=TeacherConfig(checkpoint="teacher-checkpoint"),
+        model=object(),
+        trainer=SimpleNamespace(device_mesh=None, parameter_axis_mapping={}),
+    )
+    worker.tokenizer = SimpleNamespace(vocab_size=8)
+    worker.loss_module = _NoTeacherLoss()
+
+    with pytest.raises(ValueError, match="does not use a teacher"):
+        worker._build_models()
+    assert calls == []
+
+
+def test_build_models_rejects_unresolved_initial_policy_teacher_marker(monkeypatch):
+    calls = []
+
+    class _TeacherLoss:
+        def needs_teacher_model(self) -> bool:
+            return True
+
+    monkeypatch.setattr(
+        "marin.rl.train_worker.load_model_from_checkpoint",
+        lambda **kwargs: calls.append(kwargs) or f"model:{kwargs['checkpoint']}",
+    )
+
+    worker = TrainWorker.__new__(TrainWorker)
+    worker.config = SimpleNamespace(
+        seed=0,
+        vocab_size=8,
+        initial_checkpoint="student-checkpoint",
+        teacher=TeacherConfig(checkpoint=INITIAL_POLICY_TEACHER_CHECKPOINT),
+        model=object(),
+        trainer=SimpleNamespace(device_mesh=None, parameter_axis_mapping={}),
+    )
+    worker.tokenizer = SimpleNamespace(vocab_size=8)
+    worker.loss_module = _TeacherLoss()
+
+    with pytest.raises(ValueError, match="checkpoint marker was not resolved"):
+        worker._build_models()
+    assert calls == []
 
 
 def test_record_train_step_updates_replay_buffer_and_shared_run_state():
@@ -114,6 +235,7 @@ def test_train_bootstraps_fresh_run_with_step_minus_one(monkeypatch):
     waited_weight_steps: list[int] = []
     replay_steps: list[int] = []
     published_steps: list[int] = []
+    loss_fn_args = []
 
     class _FakeRemoteMethod:
         def remote(self, step: int) -> None:
@@ -166,8 +288,16 @@ def test_train_bootstraps_fresh_run_with_step_minus_one(monkeypatch):
         optimizer=SimpleNamespace(build=lambda num_steps: object()),
         weight_transfer=SimpleNamespace(debug_weight_transfer=False, sync_interval_steps=1),
     )
-    worker.loss_module = SimpleNamespace(create_loss_fn=lambda reference_model, _: lambda model, batch, key: 0.0)
-    worker.reference_model = object()
+    reference_model = object()
+    teacher_model = object()
+    worker.loss_module = SimpleNamespace(
+        create_loss_fn=lambda reference_model, _, *, teacher_model=None: loss_fn_args.append(
+            (reference_model, teacher_model)
+        )
+        or (lambda model, batch, key: 0.0)
+    )
+    worker.reference_model = reference_model
+    worker.teacher_model = teacher_model
     worker.initial_model = object()
     worker.replay_buffer = SimpleNamespace(set_current_step=replay_steps.append)
     worker.replay_loader = _FakeReplayLoader()
@@ -185,6 +315,7 @@ def test_train_bootstraps_fresh_run_with_step_minus_one(monkeypatch):
     assert published_steps == []
     assert served_weight_steps == [-1]
     assert waited_weight_steps == [-1]
+    assert loss_fn_args == [(reference_model, teacher_model)]
 
 
 def test_train_reuses_recovered_step_on_resume(monkeypatch):
@@ -244,8 +375,11 @@ def test_train_reuses_recovered_step_on_resume(monkeypatch):
         optimizer=SimpleNamespace(build=lambda num_steps: object()),
         weight_transfer=SimpleNamespace(debug_weight_transfer=False, sync_interval_steps=1),
     )
-    worker.loss_module = SimpleNamespace(create_loss_fn=lambda reference_model, _: lambda model, batch, key: 0.0)
+    worker.loss_module = SimpleNamespace(
+        create_loss_fn=lambda reference_model, _, *, teacher_model=None: lambda model, batch, key: 0.0
+    )
     worker.reference_model = object()
+    worker.teacher_model = None
     worker.initial_model = object()
     worker.replay_buffer = SimpleNamespace(set_current_step=replay_steps.append)
     worker.replay_loader = _FakeReplayLoader()

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -46,35 +46,6 @@ def test_drop_bootstrap_model_references_preserves_reference_model_when_kl_enabl
     assert worker.reference_model is model
 
 
-def test_build_models_loads_teacher_when_loss_requires_teacher(monkeypatch):
-    calls = []
-
-    def fake_load_model_from_checkpoint(**kwargs):
-        calls.append(kwargs)
-        return f"model:{kwargs['checkpoint']}"
-
-    monkeypatch.setattr("marin.rl.train_worker.load_model_from_checkpoint", fake_load_model_from_checkpoint)
-
-    worker = TrainWorker.__new__(TrainWorker)
-    worker.config = SimpleNamespace(
-        seed=0,
-        vocab_size=8,
-        initial_checkpoint="student-checkpoint",
-        teacher=TeacherConfig(checkpoint="teacher-checkpoint"),
-        model=object(),
-        trainer=SimpleNamespace(device_mesh=None, parameter_axis_mapping={}),
-    )
-    worker.tokenizer = SimpleNamespace(vocab_size=8)
-    worker.loss_module = OPDSampledTokenReverseKLLoss()
-
-    worker._build_models()
-
-    assert [call["checkpoint"] for call in calls] == ["student-checkpoint", "teacher-checkpoint"]
-    assert worker.initial_model == "model:student-checkpoint"
-    assert worker.reference_model == "model:student-checkpoint"
-    assert worker.teacher_model == "model:teacher-checkpoint"
-
-
 def test_build_models_rejects_missing_teacher_config_when_loss_requires_teacher(monkeypatch):
     calls = []
 


### PR DESCRIPTION
Adds sampled-token OPD and hybrid RLOO+OPD losses with local teacher loading on the current RL path. Threads teacher config through RL jobs/workers and adds Math500 smoke launchers plus focused regression coverage for pure OPD, hybrid reward+OPD, replay, and launch config.

Related issue: #5853