### PR TITLE
[SFT] Add SYNTHETIC-2 verified SFT dataset

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -28,15 +28,16 @@ Current datasets:
 13. bespokelabs/Bespoke-Stratos-17k
 14. HuggingFaceTB/smoltalk
 15. PrimeIntellect/verifiable-math-problems
-16. sherryy/tulu-3-sft-personas-instruction-following-expanded
-17. facebook/natural_reasoning
-18. HuggingFaceTB/smoltalk2
-19. nvidia/Nemotron-Post-Training-Dataset-v1
-20. nvidia/Nemotron-Post-Training-Dataset-v2
-21. HuggingFaceH4/no_robots
-22. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
-23. lm-provers/FineProofs-SFT
-24. lm-provers/FineProofs-SFT/proof-only
+16. PrimeIntellect/SYNTHETIC-2-SFT-verified
+17. sherryy/tulu-3-sft-personas-instruction-following-expanded
+18. facebook/natural_reasoning
+19. HuggingFaceTB/smoltalk2
+20. nvidia/Nemotron-Post-Training-Dataset-v1
+21. nvidia/Nemotron-Post-Training-Dataset-v2
+22. HuggingFaceH4/no_robots
+23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
+24. lm-provers/FineProofs-SFT
+25. lm-provers/FineProofs-SFT/proof-only
 """
 
 import dataclasses
@@ -242,6 +243,10 @@ class ReasoningToChatKwargs:
 
 reasoning_to_chat_kwargs = ReasoningToChatKwargs()
 
+SYNTHETIC2_SFT_VERIFIED_HF_ID = "PrimeIntellect/SYNTHETIC-2-SFT-verified"
+SYNTHETIC2_SFT_VERIFIED_REVISION = "fce247fe48af8ff9624fb51d1de63aa1b2332cef"
+SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS = ["problem_id", "task_type", "reward"]
+
 FINEPROOFS_SFT_REVISION = "73661e6"
 FINEPROOFS_SFT_METADATA_COLUMNS = [
     "category",
@@ -393,6 +398,15 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         ),
         metadata_columns=["source", "task_type", "problem_id"],
         name="PrimeIntellect/verifiable-math-problems",
+    ),
+    SYNTHETIC2_SFT_VERIFIED_HF_ID: InstructionDatasetConfig(
+        hf_dataset_id=SYNTHETIC2_SFT_VERIFIED_HF_ID,
+        revision=SYNTHETIC2_SFT_VERIFIED_REVISION,
+        adapter=multi_turn_adapter(),
+        metadata_columns=SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
+        name=SYNTHETIC2_SFT_VERIFIED_HF_ID,
+        subsets=["default"],
+        splits=["train"],
     ),
     "lm-provers/FineProofs-SFT": InstructionDatasetConfig(
         hf_dataset_id="lm-provers/FineProofs-SFT",

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -3,13 +3,27 @@
 
 from marin.execution.executor import unwrap_versioned_value
 from marin.transform.conversation.adapters import InputDatasetFormat
+from marin.transform.conversation.transform_conversation import transform_row
 
 from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_METADATA_COLUMNS,
     FINEPROOFS_SFT_REVISION,
     INSTRUCTION_DATASET_NAME_TO_CONFIG,
+    SYNTHETIC2_SFT_VERIFIED_HF_ID,
+    SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
+    SYNTHETIC2_SFT_VERIFIED_REVISION,
     get_instruction_dataset,
 )
+
+SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
+    "problem_id": "prime_rl_code_21747",
+    "task_type": "prime_rl_code",
+    "reward": 1.0,
+    "messages": [
+        {"role": "user", "content": "Write Python code to count the intersection of two sets."},
+        {"role": "assistant", "content": "<think>Use set intersection.</think>\n```python\nprint(len(a & b))\n```"},
+    ],
+}
 
 
 def test_fineproofs_sft_datasets_are_registered():
@@ -55,3 +69,39 @@ def test_get_instruction_dataset_preserves_fineproofs_config():
     assert unwrap_versioned_value(proof_only_cfg.metadata_columns) == FINEPROOFS_SFT_METADATA_COLUMNS
     assert unwrap_versioned_value(proof_only_cfg.adapter).dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE
     assert proof_only_step.name == "documents/lm-provers/FineProofs-SFT/proof-only"
+
+
+def test_synthetic2_sft_verified_step_transforms_chat_rows():
+    step = get_instruction_dataset(SYNTHETIC2_SFT_VERIFIED_HF_ID)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    assert step.name == "documents/PrimeIntellect/SYNTHETIC-2-SFT-verified"
+    assert step.override_output_path is not None
+    assert step.override_output_path.startswith(
+        f"documents/PrimeIntellect--SYNTHETIC-2-SFT-verified-{SYNTHETIC2_SFT_VERIFIED_REVISION}-"
+    )
+    assert unwrap_versioned_value(cfg.source) == SYNTHETIC2_SFT_VERIFIED_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == SYNTHETIC2_SFT_VERIFIED_REVISION
+    assert unwrap_versioned_value(cfg.subsets) == ["default"]
+    assert unwrap_versioned_value(cfg.splits) == ["train"]
+    assert unwrap_versioned_value(cfg.metadata_columns) == SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS
+    assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+
+    result = transform_row(SYNTHETIC2_SFT_VERIFIED_SAMPLE, cfg, adapter)
+
+    assert result is not None
+    assert result.source == SYNTHETIC2_SFT_VERIFIED_HF_ID
+    assert [message.role for message in result.messages] == ["user", "assistant"]
+    assert result.messages[0].content == "Write Python code to count the intersection of two sets."
+    assert result.messages[1].content == "\n".join(
+        [
+            "<|start_think|>Use set intersection.<|end_think|>",
+            "```python\nprint(len(a & b))\n```",
+        ]
+    )
+    assert result.metadata == {
+        "problem_id": "prime_rl_code_21747",
+        "task_type": "prime_rl_code",
+        "reward": 1.0,
+    }


### PR DESCRIPTION
Registers PrimeIntellect/SYNTHETIC-2-SFT-verified as a revision-pinned SFT dataset using the existing multi-turn chat adapter, default train split, and metadata columns for problem id, task type, and reward. Adds integrated coverage that builds the real executor step and transforms a representative chat row, checking source, roles, think-token rewriting, and metadata preservation. Tested with changed-files pre-commit and focused pytest.