### PR TITLE
[Grug] Set checkpoint retention to final-only

### DIFF
--- a/experiments/grug/base/launch.py
+++ b/experiments/grug/base/launch.py
@@ -119,7 +119,7 @@ def _build_grug_run_config(
             temporary_base_path=temporary_checkpoint_base_path(output_path),
             append_run_id_to_base_path=False,
             save_interval=timedelta(minutes=10),
-            keep=[{"every": 1000}],
+            keep=[],
         ),
     )
 

--- a/experiments/grug/base/launch.py
+++ b/experiments/grug/base/launch.py
@@ -119,7 +119,7 @@ def _build_grug_run_config(
             temporary_base_path=temporary_checkpoint_base_path(output_path),
             append_run_id_to_base_path=False,
             save_interval=timedelta(minutes=10),
-            keep=[],
+            keep=None,
         ),
     )
 

--- a/experiments/grug/modular_opt/launch.py
+++ b/experiments/grug/modular_opt/launch.py
@@ -209,7 +209,7 @@ def run_grug_modular_opt_trial(config: GrugModularOptLaunchConfig) -> None:
             temporary_base_path=temporary_checkpoint_base_path(config.output_path),
             append_run_id_to_base_path=False,
             save_interval=timedelta(minutes=10),
-            keep=[{"every": 1000}],
+            keep=[],
         ),
     )
 

--- a/experiments/grug/modular_opt/launch.py
+++ b/experiments/grug/modular_opt/launch.py
@@ -209,7 +209,7 @@ def run_grug_modular_opt_trial(config: GrugModularOptLaunchConfig) -> None:
             temporary_base_path=temporary_checkpoint_base_path(config.output_path),
             append_run_id_to_base_path=False,
             save_interval=timedelta(minutes=10),
-            keep=[],
+            keep=None,
         ),
     )
 

--- a/experiments/grug/moe/launch.py
+++ b/experiments/grug/moe/launch.py
@@ -96,7 +96,7 @@ def run_grug_moe_trial(config: GrugMoeLaunchConfig) -> None:
             temporary_base_path=temporary_checkpoint_base_path(config.output_path),
             append_run_id_to_base_path=False,
             save_interval=timedelta(minutes=10),
-            keep=[],
+            keep=None,
         ),
     )
 

--- a/experiments/grug/moe/launch.py
+++ b/experiments/grug/moe/launch.py
@@ -96,7 +96,7 @@ def run_grug_moe_trial(config: GrugMoeLaunchConfig) -> None:
             temporary_base_path=temporary_checkpoint_base_path(config.output_path),
             append_run_id_to_base_path=False,
             save_interval=timedelta(minutes=10),
-            keep=[{"every": 1000}],
+            keep=[],
         ),
     )
 

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -1019,9 +1019,8 @@ class CheckpointerConfig:
     save_interval: timedelta = timedelta(minutes=15)
     # TODO: I'd like to write this, but it's not supported by draccus
     # keep: List[CheckpointInterval] = field(default_factory=lambda: [CheckpointInterval(every=1000)])
-    keep: List[dict] = field(
-        default_factory=lambda: [dict(every=10000)]
-    )  # list of dicts with two keys: every and until
+    keep: Optional[List[dict]] = field(default_factory=lambda: [dict(every=10000)])
+    """Permanent checkpoint intervals. None means only forced checkpoints, such as the final checkpoint."""
 
     append_run_id_to_base_path: bool = True
     delete_old_temp_checkpoints: bool = True
@@ -1048,7 +1047,7 @@ class CheckpointerConfig:
         return os.path.expanduser(self.temporary_base_path)
 
     def create(self, run_id) -> Checkpointer:
-        keeps = [CheckpointInterval(**k) for k in self.keep]
+        keeps = [CheckpointInterval(**k) for k in self.keep or []]
         return Checkpointer(
             base_path=self.expanded_path(run_id),
             save_interval=self.save_interval,
@@ -1071,7 +1070,7 @@ class CheckpointerConfig:
         # validate the checkpoint intervals.
         # we want to make sure that the intervals are monotonic. only the last one can be None
         prev_interval = None
-        for interval in self.keep:
+        for interval in self.keep or []:
             if prev_interval is not None:
                 assert prev_interval["until"] is not None, "Only the last checkpoint interval can be None"
                 assert (

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -348,6 +348,12 @@ def test_checkpointer_config_no_temporary_base_path():
     assert config.expanded_temporary_path("run1") is None
 
 
+def test_checkpointer_config_keep_none_means_no_step_policies(tmp_path):
+    config = CheckpointerConfig(base_path=str(tmp_path / "checkpoints"), keep=None)
+    checkpointer = config.create("run1")
+    assert checkpointer.step_policies == []
+
+
 def test_trainer_config_checkpoint_search_paths():
     config = dataclasses.replace(
         TrainerConfig(),

--- a/tests/test_grug_launch_checkpoint_paths.py
+++ b/tests/test_grug_launch_checkpoint_paths.py
@@ -1,19 +1,25 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import ast
 import os
+from pathlib import Path
 from typing import Any
 from unittest.mock import patch
 
+import pytest
 from fray.cluster import ResourceConfig
 from levanter.optim import AdamConfig
 from levanter.tracker import NoopConfig
 
-import experiments.grug.modular_opt.launch as modular_opt_launch
-import experiments.grug.moe.launch as moe_launch
 from experiments.grug.base.launch import GRUG_130M_MODEL, GrugBaseLaunchConfig, resolve_grug_run_config
 
 _DUMMY_DATA: Any = object()
+_GRUG_LAUNCHERS = [
+    Path("experiments/grug/base/launch.py"),
+    Path("experiments/grug/moe/launch.py"),
+    Path("experiments/grug/modular_opt/launch.py"),
+]
 
 
 def test_resolve_grug_run_config_sets_temporary_checkpoint_base_path():
@@ -59,57 +65,22 @@ def test_resolve_grug_run_config_sets_temporary_checkpoint_base_path():
     assert checkpointer.keep == []
 
 
-def test_moe_grug_launch_uses_final_only_permanent_retention():
-    captured_run_config: Any = None
+@pytest.mark.parametrize("launcher_path", _GRUG_LAUNCHERS)
+def test_grug_launchers_use_final_only_permanent_retention(launcher_path: Path):
+    tree = ast.parse(launcher_path.read_text())
+    keep_values = []
 
-    def capture_run_config(run_config):
-        nonlocal captured_run_config
-        captured_run_config = run_config
+    for node in ast.walk(tree):
+        if not isinstance(node, ast.Call):
+            continue
 
-    with patch.object(moe_launch, "run_grug", side_effect=capture_run_config):
-        moe_launch.run_grug_moe_trial(
-            moe_launch.GrugMoeLaunchConfig(
-                model=moe_launch.GRUG_MOE_TRIAL_MODEL,
-                data=_DUMMY_DATA,
-                output_path="gs://marin-us-east5/experiments/grug/moe-trial",
-                run_id="grug-moe-retention-test",
-                resources=ResourceConfig.with_cpu(),
-                steps=1,
-                batch_size=1,
-                seed=0,
-                mp="params=float32,compute=bfloat16,output=bfloat16",
-                tracker=NoopConfig(),
-                optimizer=AdamConfig(),
-                eval=None,
-            )
-        )
+        func = node.func
+        if not isinstance(func, ast.Name) or func.id != "CheckpointerConfig":
+            continue
 
-    assert captured_run_config.trainer.trainer.checkpointer.keep == []
+        for keyword in node.keywords:
+            if keyword.arg == "keep":
+                keep_values.append(keyword.value)
 
-
-def test_modular_opt_grug_launch_uses_final_only_permanent_retention():
-    captured_run_config: Any = None
-
-    def capture_run_config(run_config):
-        nonlocal captured_run_config
-        captured_run_config = run_config
-
-    with patch.object(modular_opt_launch, "run_grug", side_effect=capture_run_config):
-        modular_opt_launch.run_grug_modular_opt_trial(
-            modular_opt_launch.GrugModularOptLaunchConfig(
-                model=modular_opt_launch.GRUG_130M_MODEL,
-                data=_DUMMY_DATA,
-                output_path="gs://marin-us-east5/experiments/grug/modular-opt-trial",
-                run_id="grug-modular-opt-retention-test",
-                resources=ResourceConfig.with_cpu(),
-                steps=1,
-                batch_size=1,
-                seed=0,
-                mp="params=float32,compute=bfloat16,output=bfloat16",
-                tracker=NoopConfig(),
-                optimizer=AdamConfig(),
-                eval=None,
-            )
-        )
-
-    assert captured_run_config.trainer.trainer.checkpointer.keep == []
+    assert keep_values
+    assert all(isinstance(value, ast.List) and len(value.elts) == 0 for value in keep_values)

--- a/tests/test_grug_launch_checkpoint_paths.py
+++ b/tests/test_grug_launch_checkpoint_paths.py
@@ -62,7 +62,7 @@ def test_resolve_grug_run_config_sets_temporary_checkpoint_base_path():
         "gs://marin-us-east5/experiments/grug/base-trial/checkpoints",
         "gs://marin-us-east5/tmp/ttl=14d/" "checkpoints-temp/marin-us-east5/experiments/grug/base-trial/checkpoints",
     ]
-    assert checkpointer.keep == []
+    assert checkpointer.keep is None
 
 
 @pytest.mark.parametrize("launcher_path", _GRUG_LAUNCHERS)
@@ -83,4 +83,4 @@ def test_grug_launchers_use_final_only_permanent_retention(launcher_path: Path):
                 keep_values.append(keyword.value)
 
     assert keep_values
-    assert all(isinstance(value, ast.List) and len(value.elts) == 0 for value in keep_values)
+    assert all(isinstance(value, ast.Constant) and value.value is None for value in keep_values)

--- a/tests/test_grug_launch_checkpoint_paths.py
+++ b/tests/test_grug_launch_checkpoint_paths.py
@@ -9,6 +9,8 @@ from fray.cluster import ResourceConfig
 from levanter.optim import AdamConfig
 from levanter.tracker import NoopConfig
 
+import experiments.grug.modular_opt.launch as modular_opt_launch
+import experiments.grug.moe.launch as moe_launch
 from experiments.grug.base.launch import GRUG_130M_MODEL, GrugBaseLaunchConfig, resolve_grug_run_config
 
 _DUMMY_DATA: Any = object()
@@ -54,3 +56,60 @@ def test_resolve_grug_run_config_sets_temporary_checkpoint_base_path():
         "gs://marin-us-east5/experiments/grug/base-trial/checkpoints",
         "gs://marin-us-east5/tmp/ttl=14d/" "checkpoints-temp/marin-us-east5/experiments/grug/base-trial/checkpoints",
     ]
+    assert checkpointer.keep == []
+
+
+def test_moe_grug_launch_uses_final_only_permanent_retention():
+    captured_run_config: Any = None
+
+    def capture_run_config(run_config):
+        nonlocal captured_run_config
+        captured_run_config = run_config
+
+    with patch.object(moe_launch, "run_grug", side_effect=capture_run_config):
+        moe_launch.run_grug_moe_trial(
+            moe_launch.GrugMoeLaunchConfig(
+                model=moe_launch.GRUG_MOE_TRIAL_MODEL,
+                data=_DUMMY_DATA,
+                output_path="gs://marin-us-east5/experiments/grug/moe-trial",
+                run_id="grug-moe-retention-test",
+                resources=ResourceConfig.with_cpu(),
+                steps=1,
+                batch_size=1,
+                seed=0,
+                mp="params=float32,compute=bfloat16,output=bfloat16",
+                tracker=NoopConfig(),
+                optimizer=AdamConfig(),
+                eval=None,
+            )
+        )
+
+    assert captured_run_config.trainer.trainer.checkpointer.keep == []
+
+
+def test_modular_opt_grug_launch_uses_final_only_permanent_retention():
+    captured_run_config: Any = None
+
+    def capture_run_config(run_config):
+        nonlocal captured_run_config
+        captured_run_config = run_config
+
+    with patch.object(modular_opt_launch, "run_grug", side_effect=capture_run_config):
+        modular_opt_launch.run_grug_modular_opt_trial(
+            modular_opt_launch.GrugModularOptLaunchConfig(
+                model=modular_opt_launch.GRUG_130M_MODEL,
+                data=_DUMMY_DATA,
+                output_path="gs://marin-us-east5/experiments/grug/modular-opt-trial",
+                run_id="grug-modular-opt-retention-test",
+                resources=ResourceConfig.with_cpu(),
+                steps=1,
+                batch_size=1,
+                seed=0,
+                mp="params=float32,compute=bfloat16,output=bfloat16",
+                tracker=NoopConfig(),
+                optimizer=AdamConfig(),
+                eval=None,
+            )
+        )
+
+    assert captured_run_config.trainer.trainer.checkpointer.keep == []


### PR DESCRIPTION
Set Grug base, MoE, and modular-opt launchers to use keep=None for final-only permanent checkpoint retention. CheckpointerConfig now treats explicit keep=None as no step-policy checkpoints while preserving the existing default for direct callers. Ordinary Grug runs stay on temporary preemption recovery plus final checkpoints instead of sparse permanent anchors.