### PR TITLE
[posttrain] Add Dolci Think Python SFT dataset

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -38,6 +38,7 @@ Current datasets:
 23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
 24. lm-provers/FineProofs-SFT
 25. lm-provers/FineProofs-SFT/proof-only
+26. allenai/Dolci-Think-SFT-Python
 """
 
 import dataclasses
@@ -248,6 +249,10 @@ SYNTHETIC2_SFT_VERIFIED_HF_ID = "PrimeIntellect/SYNTHETIC-2-SFT-verified"
 SYNTHETIC2_SFT_VERIFIED_REVISION = "fce247fe48af8ff9624fb51d1de63aa1b2332cef"
 SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS = ["problem_id", "task_type", "reward"]
 
+DOLCI_THINK_SFT_PYTHON_HF_ID = "allenai/Dolci-Think-SFT-Python"
+DOLCI_THINK_SFT_PYTHON_REVISION = "36fcd3f93e8e702f793e1d77be44e7849d727a95"
+DOLCI_THINK_SFT_PYTHON_METADATA_COLUMNS = ["sample_id", "question_id", "correct"]
+
 FINEPROOFS_SFT_REVISION = "73661e6"
 FINEPROOFS_SFT_METADATA_COLUMNS = [
     "category",
@@ -406,6 +411,15 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         adapter=multi_turn_adapter(),
         metadata_columns=SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
         name=SYNTHETIC2_SFT_VERIFIED_HF_ID,
+        subsets=["default"],
+        splits=["train"],
+    ),
+    DOLCI_THINK_SFT_PYTHON_HF_ID: InstructionDatasetConfig(
+        hf_dataset_id=DOLCI_THINK_SFT_PYTHON_HF_ID,
+        revision=DOLCI_THINK_SFT_PYTHON_REVISION,
+        adapter=multi_turn_adapter(),
+        metadata_columns=DOLCI_THINK_SFT_PYTHON_METADATA_COLUMNS,
+        name=DOLCI_THINK_SFT_PYTHON_HF_ID,
         subsets=["default"],
         splits=["train"],
     ),

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -6,6 +6,9 @@ from marin.transform.conversation.adapters import InputDatasetFormat
 from marin.transform.conversation.transform_conversation import transform_row
 
 from experiments.posttrain.instruction_datasets import (
+    DOLCI_THINK_SFT_PYTHON_HF_ID,
+    DOLCI_THINK_SFT_PYTHON_METADATA_COLUMNS,
+    DOLCI_THINK_SFT_PYTHON_REVISION,
     FINEPROOFS_SFT_METADATA_COLUMNS,
     FINEPROOFS_SFT_REVISION,
     INSTRUCTION_DATASET_NAME_TO_CONFIG,
@@ -23,6 +26,27 @@ SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
         {"role": "user", "content": "Write Python code to count the intersection of two sets."},
         {"role": "assistant", "content": "<think>Use set intersection.</think>\n```python\nprint(len(a & b))\n```"},
     ],
+}
+
+DOLCI_THINK_SFT_PYTHON_SAMPLE = {
+    "messages": [
+        {
+            "role": "user",
+            "content": "Write a Python function add_one(x) that returns x + 1.",
+        },
+        {
+            "role": "assistant",
+            "content": "\n".join(
+                [
+                    "<think>This answer is intentionally wrong.</think>",
+                    "```python\ndef add_one(x):\n    return x - 1\n```",
+                ]
+            ),
+        },
+    ],
+    "sample_id": "93eb9369-60d5-4fb5-bcd8-d43daec74ae4",
+    "question_id": "2b72ffc99cf5fa0c7397ef611f0a35ebb510f44cb2d63d77602b7250d2e4b476",
+    "correct": False,
 }
 
 
@@ -104,4 +128,40 @@ def test_synthetic2_sft_verified_step_transforms_chat_rows():
         "problem_id": "prime_rl_code_21747",
         "task_type": "prime_rl_code",
         "reward": 1.0,
+    }
+
+
+def test_dolci_think_sft_python_step_transforms_chat_rows():
+    step = get_instruction_dataset(DOLCI_THINK_SFT_PYTHON_HF_ID)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    assert step.name == "documents/allenai/Dolci-Think-SFT-Python"
+    assert step.override_output_path is not None
+    assert step.override_output_path.startswith(
+        f"documents/allenai--Dolci-Think-SFT-Python-{DOLCI_THINK_SFT_PYTHON_REVISION}-"
+    )
+    assert unwrap_versioned_value(cfg.source) == DOLCI_THINK_SFT_PYTHON_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == DOLCI_THINK_SFT_PYTHON_REVISION
+    assert unwrap_versioned_value(cfg.subsets) == ["default"]
+    assert unwrap_versioned_value(cfg.splits) == ["train"]
+    assert unwrap_versioned_value(cfg.metadata_columns) == DOLCI_THINK_SFT_PYTHON_METADATA_COLUMNS
+    assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+
+    result = transform_row(DOLCI_THINK_SFT_PYTHON_SAMPLE, cfg, adapter)
+
+    assert result is not None
+    assert result.source == DOLCI_THINK_SFT_PYTHON_HF_ID
+    assert [message.role for message in result.messages] == ["user", "assistant"]
+    assert result.messages[0].content == "Write a Python function add_one(x) that returns x + 1."
+    assert result.messages[1].content == "\n".join(
+        [
+            "<|start_think|>This answer is intentionally wrong.<|end_think|>",
+            "```python\ndef add_one(x):\n    return x - 1\n```",
+        ]
+    )
+    assert result.metadata == {
+        "sample_id": "93eb9369-60d5-4fb5-bcd8-d43daec74ae4",
+        "question_id": "2b72ffc99cf5fa0c7397ef611f0a35ebb510f44cb2d63d77602b7250d2e4b476",
+        "correct": False,
     }


### PR DESCRIPTION
Register allenai/Dolci-Think-SFT-Python as a post-training instruction dataset pinned to the default train split and full HF revision. Preserve sample_id, question_id, and correct metadata so raw rows, including incorrect completions, remain auditable. Adds a focused transform test covering registry wiring, think-token normalization, and metadata preservation. Validated with focused pytest and pre-commit.