### PR TITLE
[SFT] Add OpenR1 Math 220K dataset

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -25,19 +25,20 @@ Current datasets:
 10. cognitivecomputations/dolphin-r1-nonreasoning
 11. cognitivecomputations/dolphin-r1-reasoning
 12. open-r1/OpenThoughts-114k-math
-13. bespokelabs/Bespoke-Stratos-17k
-14. HuggingFaceTB/smoltalk
-15. PrimeIntellect/verifiable-math-problems
-16. PrimeIntellect/SYNTHETIC-2-SFT-verified
-17. sherryy/tulu-3-sft-personas-instruction-following-expanded
-18. facebook/natural_reasoning
-19. HuggingFaceTB/smoltalk2
-20. nvidia/Nemotron-Post-Training-Dataset-v1
-21. nvidia/Nemotron-Post-Training-Dataset-v2
-22. HuggingFaceH4/no_robots
-23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
-24. lm-provers/FineProofs-SFT
-25. lm-provers/FineProofs-SFT/proof-only
+13. open-r1/OpenR1-Math-220k/default
+14. bespokelabs/Bespoke-Stratos-17k
+15. HuggingFaceTB/smoltalk
+16. PrimeIntellect/verifiable-math-problems
+17. PrimeIntellect/SYNTHETIC-2-SFT-verified
+18. sherryy/tulu-3-sft-personas-instruction-following-expanded
+19. facebook/natural_reasoning
+20. HuggingFaceTB/smoltalk2
+21. nvidia/Nemotron-Post-Training-Dataset-v1
+22. nvidia/Nemotron-Post-Training-Dataset-v2
+23. HuggingFaceH4/no_robots
+24. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
+25. lm-provers/FineProofs-SFT
+26. lm-provers/FineProofs-SFT/proof-only
 """
 
 import dataclasses
@@ -257,6 +258,18 @@ FINEPROOFS_SFT_METADATA_COLUMNS = [
     "source",
 ]
 
+OPENR1_MATH_220K_HF_ID = "open-r1/OpenR1-Math-220k"
+OPENR1_MATH_220K_DEFAULT_NAME = "open-r1/OpenR1-Math-220k/default"
+OPENR1_MATH_220K_REVISION = "e4e141ec9dea9f8326f4d347be56105859b2bd68"
+OPENR1_MATH_220K_METADATA_COLUMNS = [
+    "answer",
+    "problem_type",
+    "question_type",
+    "source",
+    "uuid",
+    "correctness_count",
+]
+
 
 INSTRUCTION_DATASET_NAME_TO_CONFIG = {
     "meta-math/MetaMathQA": InstructionDatasetConfig(
@@ -358,6 +371,15 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         adapter=multi_turn_adapter(),
         metadata_columns=["system", "source", "generated_token_count", "correct"],
         name="open-r1/OpenThoughts-114k-math",
+    ),
+    OPENR1_MATH_220K_DEFAULT_NAME: InstructionDatasetConfig(
+        hf_dataset_id=OPENR1_MATH_220K_HF_ID,
+        revision=OPENR1_MATH_220K_REVISION,
+        adapter=multi_turn_adapter(),
+        metadata_columns=OPENR1_MATH_220K_METADATA_COLUMNS,
+        name=OPENR1_MATH_220K_DEFAULT_NAME,
+        subsets=["default"],
+        splits=["train"],
     ),
     "bespokelabs/Bespoke-Stratos-17k": InstructionDatasetConfig(
         hf_dataset_id="bespokelabs/Bespoke-Stratos-17k",

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -9,6 +9,7 @@ from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_METADATA_COLUMNS,
     FINEPROOFS_SFT_REVISION,
     INSTRUCTION_DATASET_NAME_TO_CONFIG,
+    OPENR1_MATH_220K_DEFAULT_NAME,
     SYNTHETIC2_SFT_VERIFIED_HF_ID,
     SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
     SYNTHETIC2_SFT_VERIFIED_REVISION,
@@ -22,6 +23,29 @@ SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
     "messages": [
         {"role": "user", "content": "Write Python code to count the intersection of two sets."},
         {"role": "assistant", "content": "<think>Use set intersection.</think>\n```python\nprint(len(a & b))\n```"},
+    ],
+}
+
+OPENR1_MATH_220K_SAMPLE = {
+    "problem": "Solve $x + 2 = 5$.",
+    "solution": "Subtract 2 from both sides to get $x=3$.",
+    "answer": "3",
+    "problem_type": "Algebra",
+    "question_type": "math-word-problem",
+    "source": "olympiads",
+    "uuid": "586fd646-76d6-5070-8c81-9993ab9d8559",
+    "is_reasoning_complete": [True, True],
+    "generations": [
+        "<think>Subtract 2 from both sides.</think>\nThe answer is \\boxed{3}.",
+        "<think>Move constants to the right.</think>\nThe answer is \\boxed{3}.",
+    ],
+    "correctness_math_verify": [True, True],
+    "correctness_llama": None,
+    "finish_reasons": ["stop", "stop"],
+    "correctness_count": 2,
+    "messages": [
+        {"role": "user", "content": "Solve $x + 2 = 5$."},
+        {"role": "assistant", "content": "<think>Subtract 2 from both sides.</think>\nThe answer is \\boxed{3}."},
     ],
 }
 
@@ -69,6 +93,58 @@ def test_get_instruction_dataset_preserves_fineproofs_config():
     assert unwrap_versioned_value(proof_only_cfg.metadata_columns) == FINEPROOFS_SFT_METADATA_COLUMNS
     assert unwrap_versioned_value(proof_only_cfg.adapter).dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE
     assert proof_only_step.name == "documents/lm-provers/FineProofs-SFT/proof-only"
+
+
+def test_openr1_math_220k_default_step_transforms_chat_rows():
+    expected_source = "open-r1/OpenR1-Math-220k"
+    expected_revision = "e4e141ec9dea9f8326f4d347be56105859b2bd68"
+    expected_metadata_columns = [
+        "answer",
+        "problem_type",
+        "question_type",
+        "source",
+        "uuid",
+        "correctness_count",
+    ]
+    expected_output_path_prefix = f"documents/open-r1--OpenR1-Math-220k--default-{expected_revision}-"
+
+    step = get_instruction_dataset(OPENR1_MATH_220K_DEFAULT_NAME)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    assert step.name == "documents/open-r1/OpenR1-Math-220k/default"
+    assert step.override_output_path is not None
+    assert step.override_output_path.startswith(expected_output_path_prefix)
+    assert unwrap_versioned_value(cfg.source) == expected_source
+    assert unwrap_versioned_value(cfg.revision) == expected_revision
+    assert unwrap_versioned_value(cfg.subsets) == ["default"]
+    assert unwrap_versioned_value(cfg.splits) == ["train"]
+    assert unwrap_versioned_value(cfg.metadata_columns) == expected_metadata_columns
+    assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+
+    result = transform_row(OPENR1_MATH_220K_SAMPLE, cfg, adapter)
+
+    assert result is not None
+    assert result.source == expected_source
+    assert [message.role for message in result.messages] == ["user", "assistant"]
+    assert result.messages[0].content == "Solve $x + 2 = 5$."
+    assert result.messages[1].content == "\n".join(
+        [
+            "<|start_think|>Subtract 2 from both sides.<|end_think|>",
+            "The answer is \\boxed{3}.",
+        ]
+    )
+    assert result.metadata == {
+        "answer": "3",
+        "problem_type": "Algebra",
+        "question_type": "math-word-problem",
+        "source": "olympiads",
+        "uuid": "586fd646-76d6-5070-8c81-9993ab9d8559",
+        "correctness_count": 2,
+    }
+    assert "problem" not in result.metadata
+    assert "solution" not in result.metadata
+    assert "generations" not in result.metadata
 
 
 def test_synthetic2_sft_verified_step_transforms_chat_rows():


### PR DESCRIPTION
Register the default open-r1/OpenR1-Math-220k config as a pinned post-training SFT dataset with compact metadata. It reuses the existing multi-turn adapter for the dataset's messages column and adds a focused transform test for step construction, reasoning tag replacement, roles, and metadata filtering.