### PR TITLE
[RL] Add GRPO, Dr.GRPO, and DAPO losses

### DIFF
--- a/lib/marin/src/marin/rl/curriculum.py
+++ b/lib/marin/src/marin/rl/curriculum.py
@@ -135,6 +135,11 @@ class CurriculumConfig:
         """Maximum output tokens across all lessons in the curriculum."""
         return max(lesson.sampling_params.max_output_tokens for lesson in self.lessons.values())
 
+    @property
+    def max_train_output_tokens(self) -> int:
+        """Maximum train response budget across all lessons in the curriculum."""
+        return max(lesson.sampling_params.train_decoding.max_output_tokens for lesson in self.lessons.values())
+
 
 def _validate_dependencies(lesson_configs: dict[str, LessonConfig]):
     """Validate that lesson dependencies form a valid DAG (no cycles)."""

--- a/lib/marin/src/marin/rl/kl_regularization.py
+++ b/lib/marin/src/marin/rl/kl_regularization.py
@@ -77,7 +77,8 @@ def k3_from_log_ratio(log_ratio: jax.Array) -> jax.Array:
 
 def masked_response_mean(values: jax.Array, loss_masks: jax.Array) -> jax.Array:
     """Average per-example masked response values across the batch."""
-    return jnp.mean(jnp.sum(values * loss_masks, axis=1) / jnp.sum(loss_masks, axis=1))
+    response_token_counts = jnp.maximum(jnp.sum(loss_masks, axis=1), 1.0)
+    return jnp.mean(jnp.sum(values * loss_masks, axis=1) / response_token_counts)
 
 
 def kl_penalty_from_log_ratio(log_ratio: jax.Array, mode: KLMode) -> jax.Array:

--- a/lib/marin/src/marin/rl/replay_buffer.py
+++ b/lib/marin/src/marin/rl/replay_buffer.py
@@ -19,11 +19,60 @@ import numpy as np
 from marin.rl.rl_losses import RLLossModule
 
 from .rollout_storage import RolloutReader
-from .types import RolloutBatch, RolloutWithAdvantage
+from .types import Rollout, RolloutBatch, RolloutWithAdvantage
 
 logger = logging.getLogger(__name__)
 
 # TODO(power) - move advantage calculation and separate it from count
+
+
+@dataclass
+class SoftOverlongPenaltyConfig:
+    """Linearly penalize responses that enter the final decoding-length buffer."""
+
+    buffer_length: int
+    """Number of tokens at the end of the response budget to penalize."""
+
+    penalty_factor: float
+    """Maximum reward penalty applied at or beyond the response budget."""
+
+    def __post_init__(self):
+        if self.buffer_length <= 0:
+            raise ValueError(f"buffer_length must be positive, got {self.buffer_length}")
+        if self.penalty_factor < 0.0:
+            raise ValueError(f"penalty_factor must be non-negative, got {self.penalty_factor}")
+
+
+def soft_overlong_penalty(response_length: int, max_output_tokens: int, config: SoftOverlongPenaltyConfig) -> float:
+    """Return the DAPO soft overlong reward penalty for a response length."""
+    if config.buffer_length > max_output_tokens:
+        raise ValueError(
+            "SoftOverlongPenaltyConfig.buffer_length must be less than or equal to rollout "
+            f"max_output_tokens, got {config.buffer_length} and {max_output_tokens}"
+        )
+
+    penalty_start = max_output_tokens - config.buffer_length
+    if response_length <= penalty_start:
+        return 0.0
+
+    penalty_fraction = min((response_length - penalty_start) / config.buffer_length, 1.0)
+    return penalty_fraction * config.penalty_factor
+
+
+def apply_soft_overlong_penalty(rollout: Rollout, config: SoftOverlongPenaltyConfig | None) -> Rollout:
+    """Return a rollout with DAPO soft overlong reward shaping applied."""
+    if config is None:
+        return rollout
+
+    penalty = soft_overlong_penalty(
+        response_length=int(rollout.response_tokens.size),
+        max_output_tokens=rollout.decoding.max_output_tokens,
+        config=config,
+    )
+    if penalty == 0.0:
+        return rollout
+
+    return dataclasses.replace(rollout, episode_reward=rollout.episode_reward - penalty)
 
 
 @dataclass
@@ -47,6 +96,9 @@ class ReplayBufferConfig:
 
     filter_out_groups_with_no_variance: bool = False
     """Filter out groups with no variance in rewards."""
+
+    soft_overlong_penalty: SoftOverlongPenaltyConfig | None = None
+    """Optional DAPO soft overlong reward shaping applied before advantage computation."""
 
 
 @dataclass
@@ -76,9 +128,14 @@ class ReplayBuffer:
     filter_out_groups_with_no_variance: bool
     loss_module: RLLossModule
     seed: int
+    soft_overlong_penalty: SoftOverlongPenaltyConfig | None = None
 
     _total_batches_added: int = 0
     _total_batches_sampled: int = 0
+    _total_reward_groups_seen: int = 0
+    _total_reward_groups_dropped_no_variance: int = 0
+    _total_soft_overlong_penalty_count: int = 0
+    _total_soft_overlong_penalty_sum: float = 0.0
     _lock: threading.Lock = dataclasses.field(default_factory=threading.Lock)
     _current_step: int = 0
     _rng: np.random.Generator = dataclasses.field(init=False)
@@ -117,6 +174,7 @@ class ReplayBuffer:
             max_rollout_step_delay=config.max_rollout_step_delay,
             max_rollout_timestamp_delay=config.max_rollout_timestamp_delay,
             filter_out_groups_with_no_variance=config.filter_out_groups_with_no_variance,
+            soft_overlong_penalty=config.soft_overlong_penalty,
             loss_module=loss_module,
             seed=seed,
         )
@@ -184,6 +242,10 @@ class ReplayBuffer:
         """
         env_examples: dict[str, list[RolloutWithCount]] = defaultdict(list)
         current_time = time.time()
+        reward_groups_seen = 0
+        reward_groups_dropped_no_variance = 0
+        soft_overlong_penalty_count = 0
+        soft_overlong_penalty_sum = 0.0
 
         for batch in new_batches:
             if not batch.groups or not batch.groups[0].rollouts:
@@ -206,28 +268,49 @@ class ReplayBuffer:
             self._total_batches_added += 1
 
             for group_idx, group in enumerate(batch.groups):
-                # Compute RLOO advantages for the group
-                advantages = self.loss_module.compute_advantages(group.rollouts)
+                if not group.rollouts:
+                    continue
+
+                reward_groups_seen += 1
+                shaped_rollouts = []
+                for rollout in group.rollouts:
+                    shaped_rollout = apply_soft_overlong_penalty(rollout, self.soft_overlong_penalty)
+                    penalty = rollout.episode_reward - shaped_rollout.episode_reward
+                    if penalty > 0.0:
+                        soft_overlong_penalty_count += 1
+                        soft_overlong_penalty_sum += penalty
+                    shaped_rollouts.append(shaped_rollout)
+
+                advantages = self.loss_module.compute_advantages(shaped_rollouts)
                 maybe_used_rollouts = []
-                for rollout_idx, (rollout, advantage) in enumerate(zip(group.rollouts, advantages, strict=True)):
+                for rollout_idx, (rollout, advantage) in enumerate(zip(shaped_rollouts, advantages, strict=True)):
                     individual = RolloutWithCount(
                         rollout=rollout, advantage=advantage, usage_count=0, weight_step=rollout_step
                     )
                     maybe_used_rollouts.append(individual)
                     batch_rewards[group_idx, rollout_idx] = rollout.episode_reward
 
+                env_name = shaped_rollouts[0].env_name
                 if np.std(batch_rewards[group_idx]) > 0.0:
-                    env_examples[rollout.env_name].extend(maybe_used_rollouts)
-                else:  # group has no variance in rewards
-                    if not self.filter_out_groups_with_no_variance:
-                        env_examples[rollout.env_name].extend(maybe_used_rollouts)
+                    env_examples[env_name].extend(maybe_used_rollouts)
+                    continue
 
-                    logger.info(f"Group {group_idx} has no variance in rewards")
+                if self.filter_out_groups_with_no_variance:
+                    reward_groups_dropped_no_variance += 1
+                else:
+                    env_examples[env_name].extend(maybe_used_rollouts)
+
+                logger.info(f"Group {group_idx} has no variance in rewards")
 
             logger.info(f"Reward mean across all groups: {batch_rewards.mean()}")
             logger.info(f"Reward std across all groups: {batch_rewards.std(axis=1).mean()}")
 
         with self._lock:
+            self._total_reward_groups_seen += reward_groups_seen
+            self._total_reward_groups_dropped_no_variance += reward_groups_dropped_no_variance
+            self._total_soft_overlong_penalty_count += soft_overlong_penalty_count
+            self._total_soft_overlong_penalty_sum += soft_overlong_penalty_sum
+
             for env_name, examples in env_examples.items():
                 if env_name in self.rollout_storage:
                     self.rollout_storage[env_name].extend(examples)
@@ -305,12 +388,26 @@ class ReplayBuffer:
         """Get buffer statistics for monitoring."""
         with self._lock:
             env_sizes = {env: len(rollouts) for env, rollouts in self.rollout_storage.items()}
+            reward_groups_accepted = self._total_reward_groups_seen - self._total_reward_groups_dropped_no_variance
+            reward_group_acceptance_rate = (
+                reward_groups_accepted / self._total_reward_groups_seen if self._total_reward_groups_seen > 0 else 0.0
+            )
+            soft_overlong_penalty_mean = (
+                self._total_soft_overlong_penalty_sum / self._total_soft_overlong_penalty_count
+                if self._total_soft_overlong_penalty_count > 0
+                else 0.0
+            )
             return {
                 "total_size": sum(env_sizes.values()),
                 "env_sizes": env_sizes,
                 "num_environments": len(self.rollout_storage),
                 "total_batches_added": self._total_batches_added,
                 "total_batches_sampled": self._total_batches_sampled,
+                "reward_groups_seen": self._total_reward_groups_seen,
+                "reward_groups_dropped_no_variance": self._total_reward_groups_dropped_no_variance,
+                "reward_group_acceptance_rate": reward_group_acceptance_rate,
+                "soft_overlong_penalty_count": self._total_soft_overlong_penalty_count,
+                "soft_overlong_penalty_mean": soft_overlong_penalty_mean,
             }
 
 

--- a/lib/marin/src/marin/rl/replay_buffer.py
+++ b/lib/marin/src/marin/rl/replay_buffer.py
@@ -186,11 +186,11 @@ class ReplayBuffer:
         current_time = time.time()
 
         for batch in new_batches:
-            # R[num_groups, num_rollouts_per_group]
-            batch_rewards = np.zeros((len(batch.groups), len(batch.groups[0].rollouts)), dtype=np.float32)
-
             if not batch.groups or not batch.groups[0].rollouts:
                 continue
+
+            # R[num_groups, num_rollouts_per_group]
+            batch_rewards = np.zeros((len(batch.groups), len(batch.groups[0].rollouts)), dtype=np.float32)
 
             # Read weight_step from first rollout's metadata
             first_rollout = batch.groups[0].rollouts[0]

--- a/lib/marin/src/marin/rl/rl_losses.py
+++ b/lib/marin/src/marin/rl/rl_losses.py
@@ -5,6 +5,7 @@
 
 from collections.abc import Callable
 from dataclasses import dataclass
+from enum import StrEnum
 from typing import Protocol
 
 import equinox as eqx
@@ -47,6 +48,14 @@ class RLLossModule(Protocol):
     def create_loss_fn(self, reference_model: eqx.Module | None, train_model: eqx.Module) -> Callable:
         """Create the loss function for training."""
         ...
+
+
+class PolicyGradientReducer(StrEnum):
+    """How response-token policy-gradient objectives are reduced to a scalar."""
+
+    PER_SEQUENCE_TOKEN_MEAN = "per_sequence_token_mean"
+    CURRENT_BATCH_TOKEN_NORMALIZED = "current_batch_token_normalized"
+    FIXED_RESPONSE_BUDGET = "fixed_response_budget"
 
 
 def compute_metadata_metrics(
@@ -225,6 +234,8 @@ def compute_ppo_loss_objective(
     *,
     clip_epsilon_low: float,
     clip_epsilon_high: float,
+    reducer: PolicyGradientReducer,
+    fixed_response_budget: int | None = None,
     trainer_inference_importance_sampling_ratio: jax.Array | None = None,
     response_truncated_array: jax.Array | None = None,  # [batch]
 ):
@@ -244,8 +255,12 @@ def compute_ppo_loss_objective(
         batch_size, _ = loss_objective.shape
         loss_objective = loss_objective * (1 - response_truncated_array.reshape(batch_size, 1))
 
-    # Default to DAPO loss (matches original active behavior)
-    loss = compute_dapo_loss(loss_objective, loss_masks)
+    loss = reduce_policy_gradient_loss(
+        loss_objective,
+        loss_masks,
+        reducer,
+        fixed_response_budget=fixed_response_budget,
+    )
 
     per_batch_loss = jnp.sum(loss_objective * loss_masks, axis=1) / jnp.sum(loss_masks, axis=1)
     metadata = {
@@ -255,15 +270,30 @@ def compute_ppo_loss_objective(
     return loss, metadata
 
 
-def compute_dapo_loss(
+def reduce_policy_gradient_loss(
     loss_objective: jax.Array,
     loss_masks: jax.Array,
+    reducer: PolicyGradientReducer,
+    *,
+    fixed_response_budget: int | None = None,
 ) -> jax.Array:
-    """Compute DAPO-like loss (global token normalization).
+    """Reduce a token-level policy-gradient objective to a scalar loss."""
+    per_sequence_objective = jnp.sum(loss_objective * loss_masks, axis=1)
 
-    Divides by total tokens across all examples in the batch, not per-example.
-    """
-    return -1 * jnp.mean(jnp.sum(loss_objective * loss_masks, axis=1) / jnp.sum(loss_masks))
+    if reducer == PolicyGradientReducer.PER_SEQUENCE_TOKEN_MEAN:
+        return -1 * jnp.mean(per_sequence_objective / jnp.sum(loss_masks, axis=1))
+
+    if reducer == PolicyGradientReducer.CURRENT_BATCH_TOKEN_NORMALIZED:
+        return -1 * jnp.mean(per_sequence_objective / jnp.sum(loss_masks))
+
+    if reducer == PolicyGradientReducer.FIXED_RESPONSE_BUDGET:
+        if fixed_response_budget is None:
+            raise ValueError("fixed_response_budget is required for FIXED_RESPONSE_BUDGET reduction")
+        if fixed_response_budget <= 0:
+            raise ValueError(f"fixed_response_budget must be positive, got {fixed_response_budget}")
+        return -1 * jnp.mean(per_sequence_objective / fixed_response_budget)
+
+    raise ValueError(f"Unknown policy-gradient reducer: {reducer}")
 
 
 def importance_sampling_ratio(
@@ -284,7 +314,7 @@ def importance_sampling_ratio(
     return prob_difference
 
 
-def rloo_loss_with_importance_sampling(
+def policy_gradient_loss_with_importance_sampling(
     model: LmHeadModel,
     reference_model: LmHeadModel | None,
     batch: TrainingBatch,
@@ -298,18 +328,22 @@ def rloo_loss_with_importance_sampling(
     synchronous: bool = False,
     do_overlong_filtering: bool = False,
     log_policy_entropy: bool = False,
+    reducer: PolicyGradientReducer,
+    fixed_response_budget: int | None = None,
     compute_policy_stats_fn: Callable = compute_logprobs_and_entropy,
 ) -> tuple[jax.Array, dict[str, Metric]]:
-    """Compute RLOO (Reward Leave-One-Out) loss with importance sampling for off-policy data.
+    """Compute clipped policy-gradient loss with importance sampling for off-policy data.
 
     Args:
         model: The language model
-        batch: Training batch containing rollout data with RLOO advantages
+        batch: Training batch containing rollout data with precomputed advantages
         key: JAX random key for dropout
         kl: KL regularization configuration
         clip_epsilon_low: Lower clipping epsilon for importance sampling ratio
         clip_epsilon_high: Upper clipping epsilon for importance sampling ratio
         log_policy_entropy: Whether to log exact full-vocabulary policy entropy
+        reducer: Reduction rule for the token-level policy-gradient objective
+        fixed_response_budget: Fixed response budget for Dr.GRPO-style reduction
         compute_policy_stats_fn: Function to compute logprobs and optional entropy
 
     Returns:
@@ -366,14 +400,13 @@ def rloo_loss_with_importance_sampling(
         loss_masks=loss_masks_array,
         clip_epsilon_low=clip_epsilon_low,
         clip_epsilon_high=clip_epsilon_high,
+        reducer=reducer,
+        fixed_response_budget=fixed_response_budget,
         trainer_inference_importance_sampling_ratio=trainer_inference_importance_sampling_ratio,
         response_truncated_array=batch.truncated if do_overlong_filtering else None,
     )
 
-    # RLOO loss with importance sampling
-    # batch["loss_weights"] contains RLOO advantages: r_i - mean(r_j for j≠i)
-    # weighted_loss = -clipped_ratio * loss_weights_array * loss_masks_array
-    # KL regularization
+    # KL regularization is additive to the clipped policy-gradient objective.
 
     log_ratio = jnp.zeros_like(current_logprobs)
     kl_penalty = jnp.zeros_like(current_logprobs)
@@ -436,7 +469,7 @@ def rloo_loss_with_importance_sampling(
 
 def compute_rloo_advantages(rollouts: list[Rollout]) -> np.ndarray:
     """Compute RLOO (Reward Leave-One-Out) advantages for a group of rollouts."""
-    rewards = np.array([r.episode_reward for r in rollouts])
+    rewards = np.asarray([r.episode_reward for r in rollouts], dtype=np.float32)
 
     n = len(rewards)
     if n <= 1:
@@ -446,6 +479,54 @@ def compute_rloo_advantages(rollouts: list[Rollout]) -> np.ndarray:
     leave_one_out_baselines = (total - rewards) / (n - 1)
     advantages = rewards - leave_one_out_baselines
     return advantages
+
+
+def compute_group_centered_advantages(
+    rollouts: list[Rollout],
+    *,
+    normalize_by_std: bool,
+    epsilon: float = 1e-6,
+) -> np.ndarray:
+    """Compute group-relative advantages for GRPO-style objectives."""
+    rewards = np.asarray([r.episode_reward for r in rollouts], dtype=np.float32)
+    if len(rewards) <= 1:
+        return np.zeros_like(rewards)
+
+    advantages = rewards - np.mean(rewards)
+    if not normalize_by_std:
+        return advantages
+
+    reward_std = np.std(rewards, ddof=1)
+    if reward_std <= 0.0:
+        return np.zeros_like(rewards)
+
+    return advantages / (reward_std + epsilon)
+
+
+def _policy_stats_fn_for_loss(vocab_tile_size: int | None, log_policy_entropy: bool) -> Callable:
+    if log_policy_entropy and vocab_tile_size is not None:
+        raise ValueError(
+            "Exact policy entropy is not supported with vocab_tile_size yet. "
+            "Set vocab_tile_size=None or implement chunked entropy first."
+        )
+
+    if vocab_tile_size is None:
+        return compute_logprobs_and_entropy
+
+    def compute_policy_stats_fn(m, b, k, *, compute_entropy: bool):
+        if compute_entropy:
+            raise ValueError("Exact policy entropy is not supported with vocab_tile_size yet")
+        return chunked_compute_logprobs(m, b, k, vocab_tile_size), None
+
+    return compute_policy_stats_fn
+
+
+def _validate_fixed_response_budget(batch: TrainingBatch, fixed_response_budget: int) -> None:
+    if batch.max_output_tokens != fixed_response_budget:
+        raise ValueError(
+            "DrGRPOLoss.max_output_tokens must match TrainingBatch.max_output_tokens, "
+            f"got {fixed_response_budget} and {batch.max_output_tokens}"
+        )
 
 
 @dataclass
@@ -478,24 +559,10 @@ class RLOOLoss(RLLossModule):
         """Create the loss function for training."""
         if self.needs_reference_model() and reference_model is None:
             raise ValueError("reference_model is required when KL regularization is enabled")
-        if self.log_policy_entropy and self.vocab_tile_size is not None:
-            raise ValueError(
-                "Exact policy entropy is not supported with vocab_tile_size yet. "
-                "Set vocab_tile_size=None or implement chunked entropy first."
-            )
+        compute_policy_stats_fn = _policy_stats_fn_for_loss(self.vocab_tile_size, self.log_policy_entropy)
 
         def loss_fn(model, batch, key):
-            if self.vocab_tile_size is not None:
-
-                def compute_policy_stats_fn(m, b, k, *, compute_entropy: bool):
-                    if compute_entropy:
-                        raise ValueError("Exact policy entropy is not supported with vocab_tile_size yet")
-                    return chunked_compute_logprobs(m, b, k, self.vocab_tile_size), None
-
-            else:
-                compute_policy_stats_fn = compute_logprobs_and_entropy
-
-            return rloo_loss_with_importance_sampling(
+            return policy_gradient_loss_with_importance_sampling(
                 model,
                 reference_model,
                 batch,
@@ -508,6 +575,129 @@ class RLOOLoss(RLLossModule):
                 do_trainer_inference_mismatch_importance_sampling=self.do_trainer_inference_mismatch_importance_sampling,
                 do_overlong_filtering=self.do_overlong_filtering,
                 log_policy_entropy=self.log_policy_entropy,
+                reducer=PolicyGradientReducer.CURRENT_BATCH_TOKEN_NORMALIZED,
+                compute_policy_stats_fn=compute_policy_stats_fn,
+            )
+
+        return loss_fn
+
+
+@dataclass
+class GRPOLoss(RLLossModule):
+    """GRPO loss with group-centered, optionally std-normalized advantages."""
+
+    kl: KLConfig
+    normalize_by_group_std: bool = True
+    reducer: PolicyGradientReducer = PolicyGradientReducer.PER_SEQUENCE_TOKEN_MEAN
+    clip_epsilon_low: float = 0.2
+    clip_epsilon_high: float = 0.2
+    tis_importance_sampling_ratio_max: float = 2.0
+    synchronous: bool = False
+    do_trainer_inference_mismatch_importance_sampling: bool = False
+    do_overlong_filtering: bool = False
+    vocab_tile_size: int | None = None
+    log_policy_entropy: bool = False
+
+    def __post_init__(self):
+        if self.reducer == PolicyGradientReducer.FIXED_RESPONSE_BUDGET:
+            raise ValueError("Use DrGRPOLoss for fixed response-budget reduction")
+
+    def build(self, reference_model: eqx.Module) -> eqx.Module:
+        """Initialize any learned components (e.g., value heads)."""
+        return self
+
+    def compute_advantages(self, rollout_group: list[Rollout]) -> np.ndarray:
+        """Compute group-centered advantages for a group of rollouts."""
+        return compute_group_centered_advantages(
+            rollout_group,
+            normalize_by_std=self.normalize_by_group_std,
+        )
+
+    def needs_reference_model(self) -> bool:
+        """Return whether KL regularization requires a reference model."""
+        return self.kl.enabled()
+
+    def create_loss_fn(self, reference_model: eqx.Module | None, train_model: eqx.Module) -> Callable:
+        """Create the loss function for training."""
+        if self.needs_reference_model() and reference_model is None:
+            raise ValueError("reference_model is required when KL regularization is enabled")
+        compute_policy_stats_fn = _policy_stats_fn_for_loss(self.vocab_tile_size, self.log_policy_entropy)
+
+        def loss_fn(model, batch, key):
+            return policy_gradient_loss_with_importance_sampling(
+                model,
+                reference_model,
+                batch,
+                key=key,
+                kl=self.kl,
+                clip_epsilon_low=self.clip_epsilon_low,
+                clip_epsilon_high=self.clip_epsilon_high,
+                tis_importance_sampling_ratio_max=self.tis_importance_sampling_ratio_max,
+                synchronous=self.synchronous,
+                do_trainer_inference_mismatch_importance_sampling=self.do_trainer_inference_mismatch_importance_sampling,
+                do_overlong_filtering=self.do_overlong_filtering,
+                log_policy_entropy=self.log_policy_entropy,
+                reducer=self.reducer,
+                compute_policy_stats_fn=compute_policy_stats_fn,
+            )
+
+        return loss_fn
+
+
+@dataclass
+class DrGRPOLoss(RLLossModule):
+    """Dr.GRPO loss with mean-centered advantages and fixed response-budget reduction."""
+
+    max_output_tokens: int
+    kl: KLConfig
+    clip_epsilon_low: float = 0.2
+    clip_epsilon_high: float = 0.2
+    tis_importance_sampling_ratio_max: float = 2.0
+    synchronous: bool = False
+    do_trainer_inference_mismatch_importance_sampling: bool = False
+    do_overlong_filtering: bool = False
+    vocab_tile_size: int | None = None
+    log_policy_entropy: bool = False
+
+    def __post_init__(self):
+        if self.max_output_tokens <= 0:
+            raise ValueError(f"max_output_tokens must be positive, got {self.max_output_tokens}")
+
+    def build(self, reference_model: eqx.Module) -> eqx.Module:
+        """Initialize any learned components (e.g., value heads)."""
+        return self
+
+    def compute_advantages(self, rollout_group: list[Rollout]) -> np.ndarray:
+        """Compute mean-centered advantages for a group of rollouts."""
+        return compute_group_centered_advantages(rollout_group, normalize_by_std=False)
+
+    def needs_reference_model(self) -> bool:
+        """Return whether KL regularization requires a reference model."""
+        return self.kl.enabled()
+
+    def create_loss_fn(self, reference_model: eqx.Module | None, train_model: eqx.Module) -> Callable:
+        """Create the loss function for training."""
+        if self.needs_reference_model() and reference_model is None:
+            raise ValueError("reference_model is required when KL regularization is enabled")
+        compute_policy_stats_fn = _policy_stats_fn_for_loss(self.vocab_tile_size, self.log_policy_entropy)
+
+        def loss_fn(model, batch, key):
+            _validate_fixed_response_budget(batch, self.max_output_tokens)
+            return policy_gradient_loss_with_importance_sampling(
+                model,
+                reference_model,
+                batch,
+                key=key,
+                kl=self.kl,
+                clip_epsilon_low=self.clip_epsilon_low,
+                clip_epsilon_high=self.clip_epsilon_high,
+                tis_importance_sampling_ratio_max=self.tis_importance_sampling_ratio_max,
+                synchronous=self.synchronous,
+                do_trainer_inference_mismatch_importance_sampling=self.do_trainer_inference_mismatch_importance_sampling,
+                do_overlong_filtering=self.do_overlong_filtering,
+                log_policy_entropy=self.log_policy_entropy,
+                reducer=PolicyGradientReducer.FIXED_RESPONSE_BUDGET,
+                fixed_response_budget=self.max_output_tokens,
                 compute_policy_stats_fn=compute_policy_stats_fn,
             )
 

--- a/lib/marin/src/marin/rl/rl_losses.py
+++ b/lib/marin/src/marin/rl/rl_losses.py
@@ -54,6 +54,7 @@ class PolicyGradientReducer(StrEnum):
     """How response-token policy-gradient objectives are reduced to a scalar."""
 
     PER_SEQUENCE_TOKEN_MEAN = "per_sequence_token_mean"
+    ACTIVE_TOKEN_MEAN = "active_token_mean"
     CURRENT_BATCH_TOKEN_NORMALIZED = "current_batch_token_normalized"
     FIXED_RESPONSE_BUDGET = "fixed_response_budget"
 
@@ -66,20 +67,24 @@ def compute_metadata_metrics(
 ) -> dict[str, Metric]:
     """Compute metadata metrics for the loss function."""
     batch_size, _ = policy_logprobs_array.shape
+    response_token_counts = jnp.sum(loss_masks_array, axis=1)
+    safe_response_token_counts = jnp.maximum(response_token_counts, 1.0)
+    total_response_tokens = jnp.maximum(jnp.sum(loss_masks_array), 1.0)
 
-    mean_ratio_difference = jnp.sum(
-        (jnp.abs(jnp.exp(current_logprobs) - jnp.exp(policy_logprobs_array))) * loss_masks_array, axis=1
-    ) / jnp.sum(loss_masks_array, axis=1)
+    mean_ratio_difference = (
+        jnp.sum((jnp.abs(jnp.exp(current_logprobs) - jnp.exp(policy_logprobs_array))) * loss_masks_array, axis=1)
+        / safe_response_token_counts
+    )
     mean_ratio_difference = jnp.mean(mean_ratio_difference)
 
     flattened_current_logprobs = current_logprobs.reshape(-1)
     flattened_policy_logprobs = policy_logprobs_array.reshape(-1)
     flattened_loss_masks = loss_masks_array.reshape(-1)
 
-    policy_entropy = -jnp.sum(flattened_policy_logprobs * flattened_loss_masks) / jnp.sum(flattened_loss_masks)
-    current_entropy = -jnp.sum(flattened_current_logprobs * flattened_loss_masks) / jnp.sum(flattened_loss_masks)
+    policy_entropy = -jnp.sum(flattened_policy_logprobs * flattened_loss_masks) / total_response_tokens
+    current_entropy = -jnp.sum(flattened_current_logprobs * flattened_loss_masks) / total_response_tokens
 
-    mean_advantages = jnp.sum(loss_weights_array * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
+    mean_advantages = jnp.sum(loss_weights_array * loss_masks_array, axis=1) / safe_response_token_counts
     mean_advantages = jnp.mean(mean_advantages)
 
     max_ratio_diff = jnp.max(jnp.abs(jnp.exp(current_logprobs) - jnp.exp(policy_logprobs_array)) * loss_masks_array)
@@ -251,18 +256,23 @@ def compute_ppo_loss_objective(
     if trainer_inference_importance_sampling_ratio is not None:
         loss_objective = trainer_inference_importance_sampling_ratio * loss_objective
 
+    effective_loss_masks = loss_masks
     if response_truncated_array is not None:
         batch_size, _ = loss_objective.shape
-        loss_objective = loss_objective * (1 - response_truncated_array.reshape(batch_size, 1))
+        response_truncated_array = jnp.asarray(response_truncated_array, dtype=loss_objective.dtype)
+        response_keep_mask = 1.0 - response_truncated_array.reshape(batch_size, 1)
+        loss_objective = loss_objective * response_keep_mask
+        effective_loss_masks = loss_masks * response_keep_mask
 
     loss = reduce_policy_gradient_loss(
         loss_objective,
-        loss_masks,
+        effective_loss_masks,
         reducer,
         fixed_response_budget=fixed_response_budget,
     )
 
-    per_batch_loss = jnp.sum(loss_objective * loss_masks, axis=1) / jnp.sum(loss_masks, axis=1)
+    per_batch_loss_denominator = jnp.maximum(jnp.sum(effective_loss_masks, axis=1), 1.0)
+    per_batch_loss = jnp.sum(loss_objective * effective_loss_masks, axis=1) / per_batch_loss_denominator
     metadata = {
         "loss_max_over_batch": Metric.from_value((-jnp.max(per_batch_loss)).astype(jnp.float32), ReductionType.MAX),
         "loss_std_over_batch": Metric.from_value(jnp.std(per_batch_loss).astype(jnp.float32), ReductionType.MEAN),
@@ -281,10 +291,13 @@ def reduce_policy_gradient_loss(
     per_sequence_objective = jnp.sum(loss_objective * loss_masks, axis=1)
 
     if reducer == PolicyGradientReducer.PER_SEQUENCE_TOKEN_MEAN:
-        return -1 * jnp.mean(per_sequence_objective / jnp.sum(loss_masks, axis=1))
+        return -1 * jnp.mean(per_sequence_objective / jnp.maximum(jnp.sum(loss_masks, axis=1), 1.0))
+
+    if reducer == PolicyGradientReducer.ACTIVE_TOKEN_MEAN:
+        return -1 * jnp.sum(per_sequence_objective) / jnp.maximum(jnp.sum(loss_masks), 1.0)
 
     if reducer == PolicyGradientReducer.CURRENT_BATCH_TOKEN_NORMALIZED:
-        return -1 * jnp.mean(per_sequence_objective / jnp.sum(loss_masks))
+        return -1 * jnp.mean(per_sequence_objective / jnp.maximum(jnp.sum(loss_masks), 1.0))
 
     if reducer == PolicyGradientReducer.FIXED_RESPONSE_BUDGET:
         if fixed_response_budget is None:
@@ -352,6 +365,11 @@ def policy_gradient_loss_with_importance_sampling(
     policy_logprobs_array = batch.policy_logprobs.array
     loss_weights_array = batch.loss_weights.array
     loss_masks_array = batch.loss_masks.array
+    effective_loss_masks_array = loss_masks_array
+    if do_overlong_filtering:
+        batch_size, _ = loss_masks_array.shape
+        truncated_array = jnp.asarray(batch.truncated, dtype=loss_masks_array.dtype)
+        effective_loss_masks_array = loss_masks_array * (1.0 - truncated_array.reshape(batch_size, 1))
 
     # Get logits from current policy
     current_logprobs, current_policy_entropy = compute_policy_stats_fn(
@@ -378,7 +396,8 @@ def policy_gradient_loss_with_importance_sampling(
 
     # Compute fraction of ratios that were clipped
     is_clipped = jnp.logical_or(ratio > 1.0 + clip_epsilon_high, ratio < 1.0 - clip_epsilon_low)
-    clip_fraction = jnp.mean(jnp.sum(is_clipped * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1))
+    effective_response_token_counts = jnp.maximum(jnp.sum(effective_loss_masks_array, axis=1), 1.0)
+    clip_fraction = jnp.mean(jnp.sum(is_clipped * effective_loss_masks_array, axis=1) / effective_response_token_counts)
 
     if do_trainer_inference_mismatch_importance_sampling:
         trainer_inference_importance_sampling_ratio = importance_sampling_ratio(
@@ -411,7 +430,7 @@ def policy_gradient_loss_with_importance_sampling(
     log_ratio = jnp.zeros_like(current_logprobs)
     kl_penalty = jnp.zeros_like(current_logprobs)
     kl_loss = jnp.asarray(0.0, dtype=current_logprobs.dtype)
-    kl_statistics = kl_statistics_from_log_ratio(log_ratio, loss_masks_array)
+    kl_statistics = kl_statistics_from_log_ratio(log_ratio, effective_loss_masks_array)
     if kl.enabled():
         if reference_model is None:
             raise ValueError("reference_model is required when KL regularization is enabled")
@@ -421,18 +440,20 @@ def policy_gradient_loss_with_importance_sampling(
         reference_logprobs = reference_logprobs * loss_masks_array
         log_ratio = token_log_ratio(current_logprobs, reference_logprobs)
         kl_penalty = kl_penalty_from_log_ratio(log_ratio, kl.mode)
-        kl_statistics = kl_statistics_from_log_ratio(log_ratio, loss_masks_array)
-        kl_loss = kl.beta * masked_response_mean(kl_penalty, loss_masks_array)
+        kl_statistics = kl_statistics_from_log_ratio(log_ratio, effective_loss_masks_array)
+        kl_loss = kl.beta * masked_response_mean(kl_penalty, effective_loss_masks_array)
 
     loss = reinforce_loss + kl_loss
 
     trainer_inference_importance_sampling_ratio_mean = jnp.mean(
-        jnp.sum(trainer_inference_importance_sampling_ratio * loss_masks_array, axis=1)
-        / jnp.sum(loss_masks_array, axis=1)
+        jnp.sum(trainer_inference_importance_sampling_ratio * effective_loss_masks_array, axis=1)
+        / effective_response_token_counts
     )
-    ratio_mean_over_responses_only = jnp.mean(jnp.sum(ratio, axis=1) / jnp.sum(loss_masks_array, axis=1))
+    ratio_mean_over_responses_only = jnp.mean(
+        jnp.sum(ratio * effective_loss_masks_array, axis=1) / effective_response_token_counts
+    )
     clipped_ratio_mean_over_responses_only = jnp.mean(
-        jnp.sum(clipped_ratio * loss_masks_array, axis=1) / jnp.sum(loss_masks_array, axis=1)
+        jnp.sum(clipped_ratio * effective_loss_masks_array, axis=1) / effective_response_token_counts
     )
 
     metrics = {
@@ -452,14 +473,20 @@ def policy_gradient_loss_with_importance_sampling(
         ),
         "temperature": Metric.from_value(jnp.mean(batch.temperature.array).astype(jnp.float32), ReductionType.MEAN),
         "top_k": Metric.from_value(jnp.mean(batch.top_k.array).astype(jnp.float32), ReductionType.MEAN),
-        **compute_metadata_metrics(current_logprobs, policy_logprobs_array, loss_weights_array, loss_masks_array),
+        **compute_metadata_metrics(
+            current_logprobs, policy_logprobs_array, loss_weights_array, effective_loss_masks_array
+        ),
         **metadata,
     }
+    if do_overlong_filtering:
+        metrics["hard_overlong_filtered_fraction"] = Metric.from_value(
+            jnp.mean(jnp.asarray(batch.truncated, dtype=jnp.float32)), ReductionType.MEAN
+        )
 
     if log_policy_entropy:
         if current_policy_entropy is None:
             raise ValueError("compute_policy_stats_fn must return entropy when log_policy_entropy=True")
-        policy_entropy = masked_response_mean(current_policy_entropy, loss_masks_array)
+        policy_entropy = masked_response_mean(current_policy_entropy, effective_loss_masks_array)
         metrics["current_policy_entropy"] = Metric.from_value(
             jax.lax.stop_gradient(policy_entropy).astype(jnp.float32), ReductionType.MEAN
         )
@@ -602,7 +629,7 @@ class GRPOLoss(RLLossModule):
         if self.reducer == PolicyGradientReducer.FIXED_RESPONSE_BUDGET:
             raise ValueError("Use DrGRPOLoss for fixed response-budget reduction")
 
-    def build(self, reference_model: eqx.Module) -> eqx.Module:
+    def build(self, reference_model: eqx.Module) -> RLLossModule:
         """Initialize any learned components (e.g., value heads)."""
         return self
 
@@ -645,6 +672,74 @@ class GRPOLoss(RLLossModule):
 
 
 @dataclass
+class DAPOLoss(RLLossModule):
+    """DAPO loss: GRPO advantages with active-token reduction and clip-higher defaults."""
+
+    kl: KLConfig
+    normalize_by_group_std: bool = True
+    clip_epsilon_low: float = 0.2
+    clip_epsilon_high: float = 0.28
+    tis_importance_sampling_ratio_max: float = 2.0
+    synchronous: bool = False
+    do_trainer_inference_mismatch_importance_sampling: bool = False
+    do_overlong_filtering: bool = True
+    vocab_tile_size: int | None = None
+    log_policy_entropy: bool = False
+
+    def __post_init__(self):
+        if self.clip_epsilon_low < 0.0:
+            raise ValueError(f"clip_epsilon_low must be non-negative, got {self.clip_epsilon_low}")
+        if self.clip_epsilon_high < 0.0:
+            raise ValueError(f"clip_epsilon_high must be non-negative, got {self.clip_epsilon_high}")
+        if self.clip_epsilon_high < self.clip_epsilon_low:
+            raise ValueError(
+                "DAPOLoss.clip_epsilon_high must be greater than or equal to "
+                f"clip_epsilon_low, got {self.clip_epsilon_high} and {self.clip_epsilon_low}"
+            )
+
+    def build(self, reference_model: eqx.Module) -> RLLossModule:
+        """Initialize any learned components (e.g., value heads)."""
+        return self
+
+    def compute_advantages(self, rollout_group: list[Rollout]) -> np.ndarray:
+        """Compute DAPO group-centered advantages for a group of rollouts."""
+        return compute_group_centered_advantages(
+            rollout_group,
+            normalize_by_std=self.normalize_by_group_std,
+        )
+
+    def needs_reference_model(self) -> bool:
+        """Return whether KL regularization requires a reference model."""
+        return self.kl.enabled()
+
+    def create_loss_fn(self, reference_model: eqx.Module | None, train_model: eqx.Module) -> Callable:
+        """Create the loss function for training."""
+        if self.needs_reference_model() and reference_model is None:
+            raise ValueError("reference_model is required when KL regularization is enabled")
+        compute_policy_stats_fn = _policy_stats_fn_for_loss(self.vocab_tile_size, self.log_policy_entropy)
+
+        def loss_fn(model, batch, key):
+            return policy_gradient_loss_with_importance_sampling(
+                model,
+                reference_model,
+                batch,
+                key=key,
+                kl=self.kl,
+                clip_epsilon_low=self.clip_epsilon_low,
+                clip_epsilon_high=self.clip_epsilon_high,
+                tis_importance_sampling_ratio_max=self.tis_importance_sampling_ratio_max,
+                synchronous=self.synchronous,
+                do_trainer_inference_mismatch_importance_sampling=self.do_trainer_inference_mismatch_importance_sampling,
+                do_overlong_filtering=self.do_overlong_filtering,
+                log_policy_entropy=self.log_policy_entropy,
+                reducer=PolicyGradientReducer.ACTIVE_TOKEN_MEAN,
+                compute_policy_stats_fn=compute_policy_stats_fn,
+            )
+
+        return loss_fn
+
+
+@dataclass
 class DrGRPOLoss(RLLossModule):
     """Dr.GRPO loss with mean-centered advantages and fixed response-budget reduction."""
 
@@ -663,7 +758,7 @@ class DrGRPOLoss(RLLossModule):
         if self.max_output_tokens <= 0:
             raise ValueError(f"max_output_tokens must be positive, got {self.max_output_tokens}")
 
-    def build(self, reference_model: eqx.Module) -> eqx.Module:
+    def build(self, reference_model: eqx.Module) -> RLLossModule:
         """Initialize any learned components (e.g., value heads)."""
         return self
 

--- a/lib/marin/src/marin/rl/train_batch.py
+++ b/lib/marin/src/marin/rl/train_batch.py
@@ -31,7 +31,7 @@ def trim_and_pad(ary: np.ndarray, max_seq_len: int, pad_to: int, padding_value: 
 def convert_rollout_to_training_format(
     rollout: Rollout,
     advantage: float,
-    max_tokens: int,
+    max_seq_len: int,
     pad_to: int,
     pad_token_id: int,
 ) -> dict:
@@ -40,7 +40,7 @@ def convert_rollout_to_training_format(
     Args:
         rollout: The rollout data to convert
         advantage: Precomputed advantage value for this rollout
-        max_tokens: Maximum sequence length for truncation
+        max_seq_len: Maximum sequence length for prompt plus response truncation
         pad_to: Target length to pad to after truncation
         pad_token_id: Token ID to use for padding
 
@@ -70,8 +70,6 @@ def convert_rollout_to_training_format(
         [np.zeros(len(rollout.prompt_tokens), dtype=np.float32), rollout.response_logprobs.astype(np.float32)]
     )
 
-    max_seq_len = max_tokens
-
     input_ids = trim_and_pad(input_tokens, max_seq_len, pad_to, padding_value=pad_token_id)
     position_ids = trim_and_pad(position_ids, max_seq_len, pad_to, padding_value=0)
     loss_weight = trim_and_pad(loss_weight, max_seq_len, pad_to, padding_value=0)
@@ -92,7 +90,8 @@ def convert_rollout_to_training_format(
 
 def create_training_batch_from_rollouts(
     individual_rollouts: list[RolloutWithAdvantage],
-    max_tokens: int,
+    max_seq_len: int,
+    max_output_tokens: int,
     pad_token_id: int,
     pad_to_multiple: int | None = None,
 ) -> TrainingBatch:
@@ -100,7 +99,8 @@ def create_training_batch_from_rollouts(
 
     Args:
         individual_rollouts: List of RolloutWithAdvantage objects with precomputed advantages
-        max_tokens: Maximum sequence length for truncation
+        max_seq_len: Maximum sequence length for prompt plus response truncation
+        max_output_tokens: Maximum response length used for generation and fixed-budget losses
         pad_token_id: Token ID to use for padding
         pad_to_multiple: Optional multiple to pad sequence length to for FlashAttention
 
@@ -110,7 +110,6 @@ def create_training_batch_from_rollouts(
     if not individual_rollouts:
         raise ValueError("Cannot create batch from empty rollout list")
 
-    max_seq_len = max_tokens
     batch_max_len = max(
         min(len(individual.rollout.prompt_tokens) + len(individual.rollout.response_tokens), max_seq_len)
         for individual in individual_rollouts
@@ -120,8 +119,8 @@ def create_training_batch_from_rollouts(
         pad_to = ((batch_max_len + pad_to_multiple - 1) // pad_to_multiple) * pad_to_multiple
         if pad_to > max_seq_len:
             raise ValueError(
-                "Rounded batch padding length exceeds max_tokens. "
-                f"batch_max_len={batch_max_len}, pad_to_multiple={pad_to_multiple}, max_tokens={max_seq_len}. "
+                "Rounded batch padding length exceeds max_seq_len. "
+                f"batch_max_len={batch_max_len}, pad_to_multiple={pad_to_multiple}, max_seq_len={max_seq_len}. "
                 "Increase max_seq_len or reduce flash_attention_block_size."
             )
 
@@ -130,7 +129,7 @@ def create_training_batch_from_rollouts(
         training_example = convert_rollout_to_training_format(
             individual.rollout,
             individual.advantage,
-            max_tokens,
+            max_seq_len,
             pad_to,
             pad_token_id,
         )
@@ -162,7 +161,8 @@ def create_training_batch_from_rollouts(
         temperature=hax.named(stacked["temperature"], ["batch"]),
         top_k=hax.named(stacked["top_k"], ["batch"]),
         truncated=stacked["truncated"],
-        max_output_tokens=max_tokens,
+        max_seq_len=max_seq_len,
+        max_output_tokens=max_output_tokens,
     )
 
     return batch

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -42,7 +42,7 @@ from marin.rl.runtime import RLRuntimeHandles
 from marin.rl.weight_transfer import WeightTransferConfig
 
 from .replay_buffer import ReplayBuffer, ReplayBufferConfig, ReplayDataLoader, RolloutWithCount
-from .rl_losses import RLLossModule
+from .rl_losses import DrGRPOLoss, RLLossModule
 from .rollout_storage import RolloutStorageConfig
 from .train_batch import create_training_batch_from_rollouts
 
@@ -132,6 +132,26 @@ def _training_step_timing_metrics(step_duration: float, batch_prep_timing: Batch
     }
 
 
+def _validate_dr_grpo_train_response_budget(curriculum_config: CurriculumConfig, loss: RLLossModule) -> None:
+    if not isinstance(loss, DrGRPOLoss):
+        return
+
+    mismatched_budgets = {
+        lesson_id: lesson.sampling_params.train_decoding.max_output_tokens
+        for lesson_id, lesson in curriculum_config.lessons.items()
+        if lesson.sampling_params.train_decoding.max_output_tokens != loss.max_output_tokens
+    }
+    if not mismatched_budgets:
+        return
+
+    lesson_summary = ", ".join(f"{lesson_id}={budget}" for lesson_id, budget in sorted(mismatched_budgets.items()))
+    raise ValueError(
+        "DrGRPOLoss requires every lesson's train_decoding.max_output_tokens to match "
+        "DrGRPOLoss.max_output_tokens. "
+        f"DrGRPOLoss.max_output_tokens={loss.max_output_tokens}; mismatched lessons: {lesson_summary}"
+    )
+
+
 @dataclass
 class TrainWorkerConfig:
     """Configuration for Levanter-based RL training worker."""
@@ -156,6 +176,9 @@ class TrainWorkerConfig:
 
     seed: int = 0
     """Random seed for replay buffer sampling and model construction."""
+
+    def __post_init__(self):
+        _validate_dr_grpo_train_response_budget(self.curriculum_config, self.loss)
 
 
 class StreamingRolloutLoader:
@@ -183,8 +206,9 @@ class StreamingRolloutLoader:
         self.config = config
         self.timeout = 60.0
 
-        # Get max_seq_len from curriculum (total sequence length for prompt + response)
-        self.max_tokens = self.config.curriculum_config.max_seq_len
+        # Track total sequence length separately from the response budget used by fixed-budget RL losses.
+        self.max_seq_len = self.config.curriculum_config.max_seq_len
+        self.max_output_tokens = self.config.curriculum_config.max_train_output_tokens
 
         is_splash = getattr(self.config.model, "attn_backend", None) == AttentionBackend.SPLASH
         flash_block_size = getattr(self.config.model, "flash_attention_block_size", None)
@@ -229,7 +253,11 @@ class StreamingRolloutLoader:
             # Measure batch creation time
             batch_start = time.time()
             batch = create_training_batch_from_rollouts(
-                rollouts, self.max_tokens, self.pad_token_id, self.pad_to_multiple
+                rollouts,
+                self.max_seq_len,
+                self.max_output_tokens,
+                self.pad_token_id,
+                self.pad_to_multiple,
             )
             batch_time = time.time() - batch_start
 

--- a/lib/marin/src/marin/rl/types.py
+++ b/lib/marin/src/marin/rl/types.py
@@ -114,6 +114,7 @@ class TrainingBatch(eqx.Module):
     temperature: ht.Float[NamedArray, "batch"]  # noqa: F821
     top_k: ht.Int[NamedArray, "batch"]  # noqa: F821
     truncated: jax.Array  # [batch] # Make this haxtyped array?
+    max_seq_len: int
     max_output_tokens: int
 
     def __len__(self) -> int:

--- a/tests/rl/test_loss.py
+++ b/tests/rl/test_loss.py
@@ -6,6 +6,7 @@ from types import SimpleNamespace
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from marin.rl import train_batch
 from marin.rl.decoding import DecodingConfig
 from marin.rl.kl_regularization import (
     KLConfig,
@@ -16,12 +17,16 @@ from marin.rl.kl_regularization import (
     masked_response_mean,
 )
 from marin.rl.rl_losses import (
+    DrGRPOLoss,
+    GRPOLoss,
+    PolicyGradientReducer,
     RLOOLoss,
+    compute_group_centered_advantages,
     compute_ppo_loss_objective,
     compute_rloo_advantages,
-    rloo_loss_with_importance_sampling,
+    policy_gradient_loss_with_importance_sampling,
 )
-from marin.rl.types import Rollout
+from marin.rl.types import Rollout, RolloutWithAdvantage
 
 
 class DummyNamedArray:
@@ -67,6 +72,7 @@ def create_test_training_batch():
         temperature=DummyNamedArray(jnp.array([1.0], dtype=jnp.float32)),
         top_k=DummyNamedArray(jnp.array([0], dtype=jnp.int32)),
         truncated=jnp.array([0], dtype=jnp.float32),
+        max_seq_len=3,
         max_output_tokens=3,
     )
 
@@ -94,6 +100,49 @@ def test_compute_rloo_advantages():
     for i, rollout_group in enumerate(rollout_groups):
         advantages = compute_rloo_advantages(rollout_group)
         np.testing.assert_array_equal(advantages, expected_advantages[i])
+
+
+def test_compute_group_centered_advantages_without_std_normalization():
+    rollout_group = [
+        create_test_rollout(unique_id=0, episode_reward=0.0),
+        create_test_rollout(unique_id=1, episode_reward=1.0),
+        create_test_rollout(unique_id=2, episode_reward=0.0),
+    ]
+
+    advantages = compute_group_centered_advantages(rollout_group, normalize_by_std=False)
+
+    np.testing.assert_allclose(advantages, [-1.0 / 3.0, 2.0 / 3.0, -1.0 / 3.0], atol=1e-6)
+
+
+def test_compute_group_centered_advantages_uses_sample_std_normalization():
+    rewards = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+    rollout_group = [
+        create_test_rollout(unique_id=0, episode_reward=float(rewards[0])),
+        create_test_rollout(unique_id=1, episode_reward=float(rewards[1])),
+        create_test_rollout(unique_id=2, episode_reward=float(rewards[2])),
+    ]
+
+    advantages = compute_group_centered_advantages(rollout_group, normalize_by_std=True)
+    expected = (rewards - np.mean(rewards)) / (np.std(rewards, ddof=1) + 1e-6)
+
+    np.testing.assert_allclose(advantages, expected, atol=1e-6)
+
+
+def test_compute_group_centered_advantages_handles_singleton_and_zero_variance():
+    singleton = [create_test_rollout(unique_id=0, episode_reward=1.0)]
+    zero_variance = [
+        create_test_rollout(unique_id=0, episode_reward=1.0),
+        create_test_rollout(unique_id=1, episode_reward=1.0),
+    ]
+
+    np.testing.assert_array_equal(
+        compute_group_centered_advantages(singleton, normalize_by_std=True),
+        np.array([0.0], dtype=np.float32),
+    )
+    np.testing.assert_array_equal(
+        compute_group_centered_advantages(zero_variance, normalize_by_std=True),
+        np.zeros(2, dtype=np.float32),
+    )
 
 
 @pytest.mark.parametrize(
@@ -163,6 +212,7 @@ def test_ppo_objective(
         loss_masks,
         clip_epsilon_low=clip_epsilon,
         clip_epsilon_high=clip_epsilon,
+        reducer=PolicyGradientReducer.PER_SEQUENCE_TOKEN_MEAN,
         trainer_inference_importance_sampling_ratio=trainer_inference_importance_sampling_ratio,
     )
 
@@ -180,6 +230,55 @@ def test_kl_penalty_dispatches_selected_estimator():
         rtol=1e-6,
         atol=0.0,
     )
+
+
+def test_ppo_objective_current_batch_token_normalized_matches_existing_rloo_reducer():
+    importance_sampling_ratio = jnp.ones((2, 4), dtype=jnp.float32)
+    loss_weights = jnp.array([[1.0, 1.0, 0.0, 0.0], [2.0, 2.0, 2.0, 2.0]], dtype=jnp.float32)
+    loss_masks = jnp.array([[1.0, 1.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]], dtype=jnp.float32)
+
+    loss, _ = compute_ppo_loss_objective(
+        importance_sampling_ratio,
+        loss_weights,
+        loss_masks,
+        clip_epsilon_low=0.2,
+        clip_epsilon_high=0.2,
+        reducer=PolicyGradientReducer.CURRENT_BATCH_TOKEN_NORMALIZED,
+    )
+
+    # This intentionally preserves the current behavior: row sums are divided by
+    # total batch response tokens, then averaged across rows.
+    np.testing.assert_allclose(loss, -((2.0 / 6.0) + (8.0 / 6.0)) / 2.0)
+
+
+def test_ppo_objective_fixed_response_budget_reducer():
+    importance_sampling_ratio = jnp.ones((2, 4), dtype=jnp.float32)
+    loss_weights = jnp.array([[1.0, 1.0, 0.0, 0.0], [2.0, 2.0, 2.0, 2.0]], dtype=jnp.float32)
+    loss_masks = jnp.array([[1.0, 1.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]], dtype=jnp.float32)
+
+    loss, _ = compute_ppo_loss_objective(
+        importance_sampling_ratio,
+        loss_weights,
+        loss_masks,
+        clip_epsilon_low=0.2,
+        clip_epsilon_high=0.2,
+        reducer=PolicyGradientReducer.FIXED_RESPONSE_BUDGET,
+        fixed_response_budget=4,
+    )
+
+    np.testing.assert_allclose(loss, -((2.0 / 4.0) + (8.0 / 4.0)) / 2.0)
+
+
+def test_ppo_objective_fixed_response_budget_requires_budget():
+    with pytest.raises(ValueError, match="fixed_response_budget is required"):
+        compute_ppo_loss_objective(
+            jnp.ones((1, 2), dtype=jnp.float32),
+            jnp.ones((1, 2), dtype=jnp.float32),
+            jnp.ones((1, 2), dtype=jnp.float32),
+            clip_epsilon_low=0.2,
+            clip_epsilon_high=0.2,
+            reducer=PolicyGradientReducer.FIXED_RESPONSE_BUDGET,
+        )
 
 
 def test_k3_helper_matches_stable_closed_form():
@@ -255,6 +354,7 @@ def test_rloo_loss_reports_selected_kl_loss(mode: KLMode, expected_kl_loss: floa
         temperature=SimpleNamespace(array=np.ones((1, 4), dtype=np.float32)),
         top_k=SimpleNamespace(array=np.full((1, 4), 16, dtype=np.float32)),
         truncated=np.array([0.0], dtype=np.float32),
+        max_seq_len=4,
         max_output_tokens=2,
     )
 
@@ -266,7 +366,7 @@ def test_rloo_loss_reports_selected_kl_loss(mode: KLMode, expected_kl_loss: floa
             return reference_logprobs, None
         raise AssertionError("unexpected model passed to compute_policy_stats_fn")
 
-    loss, metrics = rloo_loss_with_importance_sampling(
+    loss, metrics = policy_gradient_loss_with_importance_sampling(
         current_model,
         reference_model,
         batch,
@@ -275,6 +375,7 @@ def test_rloo_loss_reports_selected_kl_loss(mode: KLMode, expected_kl_loss: floa
         clip_epsilon_low=0.2,
         clip_epsilon_high=0.2,
         tis_importance_sampling_ratio_max=2.0,
+        reducer=PolicyGradientReducer.CURRENT_BATCH_TOKEN_NORMALIZED,
         compute_policy_stats_fn=compute_policy_stats_fn,
     )
 
@@ -304,7 +405,7 @@ def test_rloo_loss_policy_entropy_metric_is_opt_in_and_loss_neutral():
         assert compute_entropy
         return current_logprobs, current_policy_entropy
 
-    loss, metrics = rloo_loss_with_importance_sampling(
+    loss, metrics = policy_gradient_loss_with_importance_sampling(
         model=None,
         reference_model=None,
         batch=batch,
@@ -314,6 +415,7 @@ def test_rloo_loss_policy_entropy_metric_is_opt_in_and_loss_neutral():
         clip_epsilon_high=0.2,
         tis_importance_sampling_ratio_max=2.0,
         log_policy_entropy=True,
+        reducer=PolicyGradientReducer.CURRENT_BATCH_TOKEN_NORMALIZED,
         compute_policy_stats_fn=compute_policy_stats_fn,
     )
 
@@ -332,7 +434,7 @@ def test_rloo_loss_skips_policy_entropy_when_metric_disabled():
         assert not compute_entropy
         return current_logprobs, None
 
-    loss, metrics = rloo_loss_with_importance_sampling(
+    loss, metrics = policy_gradient_loss_with_importance_sampling(
         model=None,
         reference_model=None,
         batch=batch,
@@ -342,6 +444,7 @@ def test_rloo_loss_skips_policy_entropy_when_metric_disabled():
         clip_epsilon_high=0.2,
         tis_importance_sampling_ratio_max=2.0,
         log_policy_entropy=False,
+        reducer=PolicyGradientReducer.CURRENT_BATCH_TOKEN_NORMALIZED,
         compute_policy_stats_fn=compute_policy_stats_fn,
     )
 
@@ -368,7 +471,7 @@ def test_rloo_loss_policy_entropy_does_not_request_reference_entropy():
         assert compute_entropy
         return current_logprobs, current_policy_entropy
 
-    loss, metrics = rloo_loss_with_importance_sampling(
+    loss, metrics = policy_gradient_loss_with_importance_sampling(
         model=current_model,
         reference_model=reference_model,
         batch=batch,
@@ -378,6 +481,7 @@ def test_rloo_loss_policy_entropy_does_not_request_reference_entropy():
         clip_epsilon_high=0.2,
         tis_importance_sampling_ratio_max=2.0,
         log_policy_entropy=True,
+        reducer=PolicyGradientReducer.CURRENT_BATCH_TOKEN_NORMALIZED,
         compute_policy_stats_fn=compute_policy_stats_fn,
     )
 
@@ -395,7 +499,7 @@ def test_rloo_loss_rejects_missing_policy_entropy_when_metric_enabled():
         return jnp.array([[0.0, 0.0, 0.0]], dtype=jnp.float32), None
 
     with pytest.raises(ValueError, match="must return entropy"):
-        rloo_loss_with_importance_sampling(
+        policy_gradient_loss_with_importance_sampling(
             model=None,
             reference_model=None,
             batch=batch,
@@ -405,6 +509,7 @@ def test_rloo_loss_rejects_missing_policy_entropy_when_metric_enabled():
             clip_epsilon_high=0.2,
             tis_importance_sampling_ratio_max=2.0,
             log_policy_entropy=True,
+            reducer=PolicyGradientReducer.CURRENT_BATCH_TOKEN_NORMALIZED,
             compute_policy_stats_fn=compute_policy_stats_fn,
         )
 
@@ -420,3 +525,71 @@ def test_rloo_loss_module_allows_vocab_tiling_when_policy_entropy_disabled():
     RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0), log_policy_entropy=False, vocab_tile_size=1024).create_loss_fn(
         reference_model=None, train_model=None
     )
+
+
+def test_grpo_loss_computes_std_normalized_group_advantages_by_default():
+    rewards = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+    rollout_group = [
+        create_test_rollout(unique_id=0, episode_reward=float(rewards[0])),
+        create_test_rollout(unique_id=1, episode_reward=float(rewards[1])),
+        create_test_rollout(unique_id=2, episode_reward=float(rewards[2])),
+    ]
+    loss_module = GRPOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0))
+
+    advantages = loss_module.compute_advantages(rollout_group)
+    expected = (rewards - np.mean(rewards)) / (np.std(rewards, ddof=1) + 1e-6)
+
+    np.testing.assert_allclose(advantages, expected, atol=1e-6)
+
+
+def test_grpo_loss_rejects_fixed_response_budget_reducer():
+    with pytest.raises(ValueError, match="Use DrGRPOLoss"):
+        GRPOLoss(
+            kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+            reducer=PolicyGradientReducer.FIXED_RESPONSE_BUDGET,
+        )
+
+
+def test_grpo_loss_reference_model_semantics_match_rloo():
+    assert not GRPOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)).needs_reference_model()
+    assert GRPOLoss(kl=KLConfig(mode=KLMode.K2_LOSS, beta=0.01)).needs_reference_model()
+
+    with pytest.raises(ValueError, match="reference_model is required"):
+        GRPOLoss(kl=KLConfig(mode=KLMode.K2_LOSS, beta=0.01)).create_loss_fn(
+            reference_model=None,
+            train_model=None,
+        )
+
+
+def test_dr_grpo_loss_uses_mean_centered_group_advantages_without_std_normalization():
+    rollout_group = [
+        create_test_rollout(unique_id=0, episode_reward=0.0),
+        create_test_rollout(unique_id=1, episode_reward=1.0),
+        create_test_rollout(unique_id=2, episode_reward=0.0),
+    ]
+    loss_module = DrGRPOLoss(max_output_tokens=8, kl=KLConfig(mode=KLMode.NONE, beta=0.0))
+
+    advantages = loss_module.compute_advantages(rollout_group)
+
+    np.testing.assert_allclose(advantages, [-1.0 / 3.0, 2.0 / 3.0, -1.0 / 3.0], atol=1e-6)
+
+
+def test_dr_grpo_loss_rejects_non_positive_response_budget():
+    with pytest.raises(ValueError, match="max_output_tokens must be positive"):
+        DrGRPOLoss(max_output_tokens=0, kl=KLConfig(mode=KLMode.NONE, beta=0.0))
+
+
+def test_dr_grpo_loss_rejects_batch_response_budget_mismatch():
+    batch = train_batch.create_training_batch_from_rollouts(
+        [RolloutWithAdvantage(rollout=create_test_rollout(prompt_len=2, response_len=3), advantage=1.0)],
+        max_seq_len=8,
+        max_output_tokens=3,
+        pad_token_id=0,
+    )
+    loss_fn = DrGRPOLoss(max_output_tokens=2, kl=KLConfig(mode=KLMode.NONE, beta=0.0)).create_loss_fn(
+        reference_model=None,
+        train_model=None,
+    )
+
+    with pytest.raises(ValueError, match=r"must match TrainingBatch\.max_output_tokens"):
+        loss_fn(model=None, batch=batch, key=None)

--- a/tests/rl/test_loss.py
+++ b/tests/rl/test_loss.py
@@ -17,6 +17,7 @@ from marin.rl.kl_regularization import (
     masked_response_mean,
 )
 from marin.rl.rl_losses import (
+    DAPOLoss,
     DrGRPOLoss,
     GRPOLoss,
     PolicyGradientReducer,
@@ -40,6 +41,8 @@ def create_test_rollout(
     env_name: str = "test_env",
     episode_reward: float = 1.0,
     unique_id: int = 12345,
+    is_truncated: bool = False,
+    max_output_tokens: int = 512,
 ) -> Rollout:
     """Create a test rollout with predictable token values."""
     prompt_tokens = np.full(prompt_len, unique_id, dtype=np.int32)
@@ -55,8 +58,8 @@ def create_test_rollout(
         response_logprobs=response_logprobs,
         token_rewards=token_rewards,
         episode_reward=episode_reward,
-        decoding=DecodingConfig(temperature=1.0).as_trace(),
-        is_truncated=False,
+        decoding=DecodingConfig(temperature=1.0, max_output_tokens=max_output_tokens).as_trace(),
+        is_truncated=is_truncated,
     )
 
 
@@ -251,6 +254,67 @@ def test_ppo_objective_current_batch_token_normalized_matches_existing_rloo_redu
     np.testing.assert_allclose(loss, -((2.0 / 6.0) + (8.0 / 6.0)) / 2.0)
 
 
+def test_ppo_objective_active_token_mean_normalizes_by_active_response_tokens():
+    importance_sampling_ratio = jnp.ones((2, 4), dtype=jnp.float32)
+    loss_weights = jnp.array([[1.0, 1.0, 0.0, 0.0], [2.0, 2.0, 2.0, 2.0]], dtype=jnp.float32)
+    loss_masks = jnp.array([[1.0, 1.0, 0.0, 0.0], [1.0, 1.0, 1.0, 1.0]], dtype=jnp.float32)
+
+    loss, _ = compute_ppo_loss_objective(
+        importance_sampling_ratio,
+        loss_weights,
+        loss_masks,
+        clip_epsilon_low=0.2,
+        clip_epsilon_high=0.2,
+        reducer=PolicyGradientReducer.ACTIVE_TOKEN_MEAN,
+    )
+
+    np.testing.assert_allclose(loss, -(2.0 + 8.0) / 6.0)
+
+
+def test_ppo_objective_active_token_mean_excludes_hard_filtered_overlong_tokens():
+    importance_sampling_ratio = jnp.ones((2, 2), dtype=jnp.float32)
+    loss_weights = jnp.array([[10.0, 10.0], [2.0, 2.0]], dtype=jnp.float32)
+    loss_masks = jnp.ones((2, 2), dtype=jnp.float32)
+
+    loss, _ = compute_ppo_loss_objective(
+        importance_sampling_ratio,
+        loss_weights,
+        loss_masks,
+        clip_epsilon_low=0.2,
+        clip_epsilon_high=0.2,
+        reducer=PolicyGradientReducer.ACTIVE_TOKEN_MEAN,
+        response_truncated_array=jnp.array([True, False]),
+    )
+
+    np.testing.assert_allclose(loss, -(2.0 + 2.0) / 2.0)
+
+
+def test_ppo_objective_clip_high_allows_dapo_clip_higher_range():
+    importance_sampling_ratio = jnp.array([[1.25]], dtype=jnp.float32)
+    loss_weights = jnp.array([[1.0]], dtype=jnp.float32)
+    loss_masks = jnp.array([[1.0]], dtype=jnp.float32)
+
+    dapo_loss, _ = compute_ppo_loss_objective(
+        importance_sampling_ratio,
+        loss_weights,
+        loss_masks,
+        clip_epsilon_low=0.2,
+        clip_epsilon_high=0.28,
+        reducer=PolicyGradientReducer.ACTIVE_TOKEN_MEAN,
+    )
+    grpo_loss, _ = compute_ppo_loss_objective(
+        importance_sampling_ratio,
+        loss_weights,
+        loss_masks,
+        clip_epsilon_low=0.2,
+        clip_epsilon_high=0.2,
+        reducer=PolicyGradientReducer.ACTIVE_TOKEN_MEAN,
+    )
+
+    np.testing.assert_allclose(dapo_loss, -1.25)
+    np.testing.assert_allclose(grpo_loss, -1.2)
+
+
 def test_ppo_objective_fixed_response_budget_reducer():
     importance_sampling_ratio = jnp.ones((2, 4), dtype=jnp.float32)
     loss_weights = jnp.array([[1.0, 1.0, 0.0, 0.0], [2.0, 2.0, 2.0, 2.0]], dtype=jnp.float32)
@@ -316,6 +380,13 @@ def test_masked_response_mean_ignores_prompt_positions():
     loss_masks = np.array([[0.0, 0.0, 1.0, 1.0], [0.0, 0.0, 1.0, 1.0]], dtype=np.float32)
 
     np.testing.assert_allclose(masked_response_mean(values, loss_masks), 3.0)
+
+
+def test_masked_response_mean_treats_zero_mask_rows_as_zero_contribution():
+    values = np.array([[10.0, 10.0], [2.0, 6.0]], dtype=np.float32)
+    loss_masks = np.array([[0.0, 0.0], [1.0, 1.0]], dtype=np.float32)
+
+    np.testing.assert_allclose(masked_response_mean(values, loss_masks), 2.0)
 
 
 def test_rloo_loss_needs_reference_model_only_when_kl_enabled():
@@ -491,6 +562,85 @@ def test_rloo_loss_policy_entropy_does_not_request_reference_entropy():
     assert calls == [(current_model, True), (reference_model, False)]
 
 
+def test_policy_gradient_loss_hard_overlong_filter_metrics_use_effective_masks():
+    batch = SimpleNamespace(
+        policy_logprobs=SimpleNamespace(array=np.zeros((2, 2), dtype=np.float32)),
+        loss_weights=SimpleNamespace(array=np.array([[0.0, 10.0], [0.0, 2.0]], dtype=np.float32)),
+        loss_masks=SimpleNamespace(array=np.array([[0.0, 1.0], [0.0, 1.0]], dtype=np.float32)),
+        temperature=SimpleNamespace(array=np.ones(2, dtype=np.float32)),
+        top_k=SimpleNamespace(array=np.full(2, 16, dtype=np.float32)),
+        truncated=np.array([True, False]),
+        max_seq_len=2,
+        max_output_tokens=1,
+    )
+
+    def compute_policy_stats_fn(_model, _batch, _key, *, compute_entropy: bool):
+        assert not compute_entropy
+        return jnp.zeros((2, 2), dtype=jnp.float32), None
+
+    loss, metrics = policy_gradient_loss_with_importance_sampling(
+        model=None,
+        reference_model=None,
+        batch=batch,
+        key=None,
+        kl=KLConfig(mode=KLMode.NONE, beta=0.0),
+        clip_epsilon_low=0.2,
+        clip_epsilon_high=0.2,
+        tis_importance_sampling_ratio_max=2.0,
+        do_overlong_filtering=True,
+        reducer=PolicyGradientReducer.ACTIVE_TOKEN_MEAN,
+        compute_policy_stats_fn=compute_policy_stats_fn,
+    )
+
+    assert loss == pytest.approx(-2.0)
+    assert metrics["response_tokens_length"].value() == pytest.approx(0.5)
+    assert metrics["mean_advantages"].value() == pytest.approx(1.0)
+    assert metrics["hard_overlong_filtered_fraction"].value() == pytest.approx(0.5)
+
+
+def test_policy_gradient_loss_hard_overlong_filter_excludes_filtered_tokens_from_kl_loss():
+    current_model = object()
+    reference_model = object()
+    current_logprobs = np.zeros((2, 2), dtype=np.float32)
+    reference_logprobs = np.array([[0.0, -2.0], [0.0, -1.0]], dtype=np.float32)
+    batch = SimpleNamespace(
+        policy_logprobs=SimpleNamespace(array=current_logprobs),
+        loss_weights=SimpleNamespace(array=np.zeros((2, 2), dtype=np.float32)),
+        loss_masks=SimpleNamespace(array=np.array([[0.0, 1.0], [0.0, 1.0]], dtype=np.float32)),
+        temperature=SimpleNamespace(array=np.ones(2, dtype=np.float32)),
+        top_k=SimpleNamespace(array=np.full(2, 16, dtype=np.float32)),
+        truncated=np.array([True, False]),
+        max_seq_len=2,
+        max_output_tokens=1,
+    )
+
+    def compute_policy_stats_fn(model, _batch, _key, *, compute_entropy: bool):
+        assert not compute_entropy
+        if model is current_model:
+            return current_logprobs, None
+        if model is reference_model:
+            return reference_logprobs, None
+        raise AssertionError("unexpected model passed to compute_policy_stats_fn")
+
+    loss, metrics = policy_gradient_loss_with_importance_sampling(
+        model=current_model,
+        reference_model=reference_model,
+        batch=batch,
+        key=None,
+        kl=KLConfig(mode=KLMode.K2_LOSS, beta=0.1),
+        clip_epsilon_low=0.2,
+        clip_epsilon_high=0.2,
+        tis_importance_sampling_ratio_max=2.0,
+        do_overlong_filtering=True,
+        reducer=PolicyGradientReducer.ACTIVE_TOKEN_MEAN,
+        compute_policy_stats_fn=compute_policy_stats_fn,
+    )
+
+    assert loss == pytest.approx(0.025)
+    assert metrics["kl_loss"].value() == pytest.approx(0.025)
+    assert metrics["kl_k2_mean"].value() == pytest.approx(0.25)
+
+
 def test_rloo_loss_rejects_missing_policy_entropy_when_metric_enabled():
     batch = create_test_training_batch()
 
@@ -559,6 +709,26 @@ def test_grpo_loss_reference_model_semantics_match_rloo():
             reference_model=None,
             train_model=None,
         )
+
+
+def test_dapo_loss_computes_std_normalized_group_advantages():
+    rewards = np.array([0.0, 1.0, 0.0], dtype=np.float32)
+    rollout_group = [
+        create_test_rollout(unique_id=0, episode_reward=float(rewards[0])),
+        create_test_rollout(unique_id=1, episode_reward=float(rewards[1])),
+        create_test_rollout(unique_id=2, episode_reward=float(rewards[2])),
+    ]
+    loss_module = DAPOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0))
+
+    advantages = loss_module.compute_advantages(rollout_group)
+    expected = (rewards - np.mean(rewards)) / (np.std(rewards, ddof=1) + 1e-6)
+
+    np.testing.assert_allclose(advantages, expected, atol=1e-6)
+
+
+def test_dapo_loss_rejects_non_higher_clip_high():
+    with pytest.raises(ValueError, match="clip_epsilon_high"):
+        DAPOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0), clip_epsilon_low=0.28, clip_epsilon_high=0.2)
 
 
 def test_dr_grpo_loss_uses_mean_centered_group_advantages_without_std_normalization():

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -12,7 +12,7 @@ try:
     from marin.rl import train_batch
     from marin.rl.decoding import DecodingConfig
     from marin.rl.kl_regularization import KLConfig, KLMode
-    from marin.rl.replay_buffer import ReplayBuffer, ReplayDataLoader
+    from marin.rl.replay_buffer import ReplayBuffer, ReplayDataLoader, SoftOverlongPenaltyConfig, soft_overlong_penalty
     from marin.rl.rl_losses import RLOOLoss
 except ImportError:
     pytest.skip("Post training imports unavailable", allow_module_level=True)
@@ -88,6 +88,28 @@ def create_test_batch(
     return RolloutBatch(groups=[group], metadata=batch_metadata)
 
 
+def create_rollout(
+    *,
+    response_len: int,
+    episode_reward: float,
+    max_output_tokens: int,
+    unique_id: int,
+    env_name: str = "test_env",
+) -> Rollout:
+    return Rollout(
+        env_name=env_name,
+        env_example_id=f"example_{unique_id}",
+        prompt_tokens=np.array([unique_id], dtype=np.int32),
+        response_tokens=np.arange(response_len, dtype=np.int32),
+        response_logprobs=np.full(response_len, -0.5, dtype=np.float32),
+        token_rewards=np.zeros(response_len, dtype=np.float32),
+        episode_reward=episode_reward,
+        decoding=DecodingConfig(temperature=1.0, max_output_tokens=max_output_tokens).as_trace(),
+        is_truncated=response_len >= max_output_tokens,
+        metadata=RolloutMetadata(worker_id="test_worker", timestamp=time.time(), weight_step=0),
+    )
+
+
 def test_replay_buffer_ignores_empty_rollout_batches():
     replay_buffer = ReplayBuffer(
         capacity=100,
@@ -112,6 +134,93 @@ def test_replay_buffer_ignores_empty_rollout_batches():
 
     assert replay_buffer.size() == 0
     assert replay_buffer.get_stats()["total_batches_added"] == 0
+
+
+def test_soft_overlong_penalty_is_linear_inside_response_buffer():
+    config = SoftOverlongPenaltyConfig(buffer_length=4, penalty_factor=2.0)
+
+    assert soft_overlong_penalty(response_length=6, max_output_tokens=10, config=config) == pytest.approx(0.0)
+    assert soft_overlong_penalty(response_length=8, max_output_tokens=10, config=config) == pytest.approx(1.0)
+    assert soft_overlong_penalty(response_length=10, max_output_tokens=10, config=config) == pytest.approx(2.0)
+    assert soft_overlong_penalty(response_length=12, max_output_tokens=10, config=config) == pytest.approx(2.0)
+
+
+def test_replay_buffer_soft_overlong_penalty_runs_before_advantages_and_variance_filter():
+    penalty_config = SoftOverlongPenaltyConfig(buffer_length=4, penalty_factor=1.0)
+    metadata = RolloutMetadata(worker_id="test_worker", timestamp=time.time(), weight_step=0)
+    batch = RolloutBatch(
+        groups=[
+            RolloutGroup(
+                rollouts=[
+                    create_rollout(response_len=4, episode_reward=1.0, max_output_tokens=8, unique_id=0),
+                    create_rollout(response_len=8, episode_reward=1.0, max_output_tokens=8, unique_id=1),
+                ]
+            )
+        ],
+        metadata=metadata,
+    )
+    replay_buffer = ReplayBuffer(
+        capacity=100,
+        local_batch_size=2,
+        alpha=3.0,
+        total_processes=1,
+        max_samples=-1,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        filter_out_groups_with_no_variance=True,
+        soft_overlong_penalty=penalty_config,
+        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
+        seed=42,
+    )
+
+    replay_buffer.add_batches([batch])
+
+    assert replay_buffer.size() == 2
+    stored_rollouts = replay_buffer.rollout_storage["test_env"]
+    rewards_and_advantages = sorted((r.rollout.episode_reward, r.advantage) for r in stored_rollouts)
+    assert rewards_and_advantages == pytest.approx([(0.0, -1.0), (1.0, 1.0)])
+    stats = replay_buffer.get_stats()
+    assert stats["reward_groups_seen"] == 1
+    assert stats["reward_groups_dropped_no_variance"] == 0
+    assert stats["reward_group_acceptance_rate"] == pytest.approx(1.0)
+    assert stats["soft_overlong_penalty_count"] == 1
+    assert stats["soft_overlong_penalty_mean"] == pytest.approx(1.0)
+
+
+def test_replay_buffer_variance_filter_drops_unshaped_zero_variance_group():
+    metadata = RolloutMetadata(worker_id="test_worker", timestamp=time.time(), weight_step=0)
+    batch = RolloutBatch(
+        groups=[
+            RolloutGroup(
+                rollouts=[
+                    create_rollout(response_len=4, episode_reward=1.0, max_output_tokens=8, unique_id=0),
+                    create_rollout(response_len=4, episode_reward=1.0, max_output_tokens=8, unique_id=1),
+                ]
+            )
+        ],
+        metadata=metadata,
+    )
+    replay_buffer = ReplayBuffer(
+        capacity=100,
+        local_batch_size=2,
+        alpha=3.0,
+        total_processes=1,
+        max_samples=-1,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        filter_out_groups_with_no_variance=True,
+        soft_overlong_penalty=None,
+        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
+        seed=42,
+    )
+
+    replay_buffer.add_batches([batch])
+
+    stats = replay_buffer.get_stats()
+    assert replay_buffer.size() == 0
+    assert stats["reward_groups_seen"] == 1
+    assert stats["reward_groups_dropped_no_variance"] == 1
+    assert stats["reward_group_acceptance_rate"] == pytest.approx(0.0)
 
 
 def test_replay_buffer():

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -27,9 +27,9 @@ from marin.rl.types import (
 )
 
 
-def rollouts_to_training_batch(rollouts, max_tokens=32, pad_token_id=0):
+def rollouts_to_training_batch(rollouts, max_seq_len=32, max_output_tokens=16, pad_token_id=0):
     """Helper function to convert rollouts to training batch for testing."""
-    return train_batch.create_training_batch_from_rollouts(rollouts, max_tokens, pad_token_id)
+    return train_batch.create_training_batch_from_rollouts(rollouts, max_seq_len, max_output_tokens, pad_token_id)
 
 
 def create_test_batch(
@@ -86,6 +86,32 @@ def create_test_batch(
 
     # Create batch
     return RolloutBatch(groups=[group], metadata=batch_metadata)
+
+
+def test_replay_buffer_ignores_empty_rollout_batches():
+    replay_buffer = ReplayBuffer(
+        capacity=100,
+        local_batch_size=4,
+        alpha=3.0,
+        total_processes=1,
+        max_samples=-1,
+        max_rollout_step_delay=1000,
+        max_rollout_timestamp_delay=3600.0,
+        filter_out_groups_with_no_variance=False,
+        loss_module=RLOOLoss(kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
+        seed=42,
+    )
+    metadata = RolloutMetadata(worker_id="test_worker", timestamp=time.time(), weight_step=0)
+
+    replay_buffer.add_batches(
+        [
+            RolloutBatch(groups=[], metadata=metadata),
+            RolloutBatch(groups=[RolloutGroup(rollouts=[])], metadata=metadata),
+        ]
+    )
+
+    assert replay_buffer.size() == 0
+    assert replay_buffer.get_stats()["total_batches_added"] == 0
 
 
 def test_replay_buffer():

--- a/tests/rl/test_train_batch.py
+++ b/tests/rl/test_train_batch.py
@@ -58,7 +58,9 @@ def test_basic_conversion():
     rollout = create_test_rollout(prompt_len=4, response_len=3)
     advantage = 2.5
 
-    result = train_batch.convert_rollout_to_training_format(rollout, advantage, max_tokens=16, pad_token_id=0, pad_to=16)
+    result = train_batch.convert_rollout_to_training_format(
+        rollout, advantage, max_seq_len=16, pad_token_id=0, pad_to=16
+    )
 
     # Check all expected keys are present
     expected_keys = {
@@ -73,7 +75,7 @@ def test_basic_conversion():
     }
     assert set(result.keys()) == expected_keys
 
-    # Check shapes - should be padded to max_tokens
+    # Check shapes - should be padded to max_seq_len
     for _, value in result.items():
         if isinstance(value, np.ndarray):
             assert len(value) == 16
@@ -84,7 +86,9 @@ def test_loss_mask_correct():
     rollout = create_test_rollout(prompt_len=4, response_len=3)
     advantage = 1.0
 
-    result = train_batch.convert_rollout_to_training_format(rollout, advantage, max_tokens=16, pad_token_id=0, pad_to=16)
+    result = train_batch.convert_rollout_to_training_format(
+        rollout, advantage, max_seq_len=16, pad_token_id=0, pad_to=16
+    )
 
     loss_mask = result["loss_masks"]
 
@@ -100,7 +104,9 @@ def test_loss_weights_have_advantage():
     rollout = create_test_rollout(prompt_len=4, response_len=3)
     advantage = 2.5
 
-    result = train_batch.convert_rollout_to_training_format(rollout, advantage, max_tokens=16, pad_token_id=0, pad_to=16)
+    result = train_batch.convert_rollout_to_training_format(
+        rollout, advantage, max_seq_len=16, pad_token_id=0, pad_to=16
+    )
 
     loss_weights = result["loss_weights"]
 
@@ -113,7 +119,7 @@ def test_token_sequence_shifted_correctly():
     """Test that input sequence contains full prompt+response (shifting now happens in rl_losses.py)."""
     rollout = create_test_rollout(prompt_len=3, response_len=2)
 
-    result = train_batch.convert_rollout_to_training_format(rollout, 1.0, max_tokens=16, pad_token_id=0, pad_to=16)
+    result = train_batch.convert_rollout_to_training_format(rollout, 1.0, max_seq_len=16, pad_token_id=0, pad_to=16)
 
     # Original tokens: prompt=[12345, 12345, 12345], response=[1000, 1001]
     # input_ids should contain the full sequence: [12345, 12345, 12345, 1000, 1001]
@@ -131,7 +137,7 @@ def test_token_sequence_shifted_correctly():
 def test_empty_rollouts_raises_error():
     """Test that empty rollout list raises ValueError."""
     with pytest.raises(ValueError, match="Cannot create batch from empty rollout list"):
-        train_batch.create_training_batch_from_rollouts([], max_tokens=16, pad_token_id=0)
+        train_batch.create_training_batch_from_rollouts([], max_seq_len=16, max_output_tokens=8, pad_token_id=0)
 
 
 def test_single_rollout_batch_creation():
@@ -139,11 +145,15 @@ def test_single_rollout_batch_creation():
     rollout = create_test_rollout()
     individual = RolloutWithAdvantage(rollout=rollout, advantage=1.5)
 
-    batch = train_batch.create_training_batch_from_rollouts([individual], max_tokens=16, pad_token_id=0)
+    batch = train_batch.create_training_batch_from_rollouts(
+        [individual], max_seq_len=16, max_output_tokens=8, pad_token_id=0
+    )
 
     # Should have batch size 1
     assert len(batch) == 1
     assert batch.input_ids.axis_size("batch") == 1
+    assert batch.max_seq_len == 16
+    assert batch.max_output_tokens == 8
 
     # Check that advantage was applied correctly
     # Loss weights should have the advantage value for response tokens
@@ -161,7 +171,9 @@ def test_multiple_rollouts_batch_creation():
         individual = RolloutWithAdvantage(rollout=rollout, advantage=advantage)
         individual_rollouts.append(individual)
 
-    batch = train_batch.create_training_batch_from_rollouts(individual_rollouts, max_tokens=16, pad_token_id=0)
+    batch = train_batch.create_training_batch_from_rollouts(
+        individual_rollouts, max_seq_len=16, max_output_tokens=8, pad_token_id=0
+    )
 
     # Should have batch size 3
     assert len(batch) == 3
@@ -186,10 +198,12 @@ def test_padding_consistency():
 
     individual_rollouts = [RolloutWithAdvantage(rollout=rollout, advantage=1.0) for rollout in rollouts]
 
-    batch = train_batch.create_training_batch_from_rollouts(individual_rollouts, max_tokens=16, pad_token_id=999)
+    batch = train_batch.create_training_batch_from_rollouts(
+        individual_rollouts, max_seq_len=16, max_output_tokens=8, pad_token_id=999
+    )
 
     # All sequences should have the same length after padding
-    assert batch.input_ids.axis_size("position") == 10  # max_tokens (dynamic padding to max in batch)
+    assert batch.input_ids.axis_size("position") == 10  # dynamic padding to max in batch
 
     # Check that padding tokens are present where expected
     # For the shortest rollout (prompt_len=3, response_len=1, total=4)
@@ -202,7 +216,9 @@ def test_batch_dtypes():
     rollout = create_test_rollout(prompt_len=4, response_len=3)
     individual = RolloutWithAdvantage(rollout=rollout, advantage=1.5)
 
-    batch = train_batch.create_training_batch_from_rollouts([individual], max_tokens=16, pad_token_id=0)
+    batch = train_batch.create_training_batch_from_rollouts(
+        [individual], max_seq_len=16, max_output_tokens=8, pad_token_id=0
+    )
 
     # Token IDs and position IDs should be integers
     assert batch.input_ids.array.dtype == np.int32

--- a/tests/rl/test_train_worker.py
+++ b/tests/rl/test_train_worker.py
@@ -2,19 +2,108 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from types import SimpleNamespace
+from typing import Any, cast
 
 import pytest
+from marin.rl.curriculum import CurriculumConfig, LessonConfig
+from marin.rl.decoding import DecodingConfig, SamplingParams
+from marin.rl.environments.base import EnvConfig
 from marin.rl.kl_regularization import KLConfig, KLMode
-from marin.rl.rl_losses import RLOOLoss
+from marin.rl.rl_losses import DrGRPOLoss, RLOOLoss
 from marin.rl.train_worker import (
     BatchPrepTiming,
     InitialRolloutState,
+    StreamingRolloutLoader,
     TrainWorker,
+    TrainWorkerConfig,
     _initial_rollout_state,
     _resume_safe_weight_transfer_metrics,
     _training_step_timing_metrics,
 )
 from marin.rl.weight_transfer.base import WeightTransferServerMetrics
+
+
+def _test_env_config(seed: int = 0) -> EnvConfig:
+    return EnvConfig(
+        env_class="marin.rl.environments.mock_env.MockEnv",
+        env_args={"task_type": "cats", "seed": seed},
+    )
+
+
+def _curriculum_with_response_budgets(
+    train_budgets: dict[str, int],
+    *,
+    eval_budget: int | None = None,
+) -> CurriculumConfig:
+    lessons = {}
+    for index, (lesson_id, train_budget) in enumerate(train_budgets.items()):
+        train_decoding = DecodingConfig(max_output_tokens=train_budget)
+        eval_decoding = None
+        if eval_budget is not None:
+            eval_decoding = DecodingConfig(max_output_tokens=eval_budget)
+        lessons[lesson_id] = LessonConfig(
+            lesson_id=lesson_id,
+            env_config=_test_env_config(seed=index),
+            sampling_params=SamplingParams(train_decoding=train_decoding, eval_decoding=eval_decoding),
+        )
+
+    return CurriculumConfig(max_seq_len=1024, lessons=lessons)
+
+
+def _train_worker_config(curriculum: CurriculumConfig, loss: Any) -> TrainWorkerConfig:
+    return TrainWorkerConfig(
+        rollout_storage=cast(Any, object()),
+        model=cast(Any, object()),
+        trainer=cast(Any, object()),
+        optimizer=cast(Any, object()),
+        replay_buffer=cast(Any, object()),
+        weight_transfer=cast(Any, object()),
+        curriculum_config=curriculum,
+        loss=loss,
+        tokenizer=cast(Any, object()),
+        run_id="test-run",
+    )
+
+
+def test_train_worker_config_allows_dr_grpo_with_uniform_train_response_budget():
+    curriculum = _curriculum_with_response_budgets(
+        {"lesson_a": 64, "lesson_b": 64},
+        eval_budget=128,
+    )
+
+    config = _train_worker_config(
+        curriculum,
+        DrGRPOLoss(max_output_tokens=64, kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
+    )
+
+    assert config.curriculum_config.max_train_output_tokens == 64
+    assert config.curriculum_config.max_output_tokens == 128
+
+
+def test_train_worker_config_rejects_dr_grpo_with_mixed_train_response_budgets():
+    curriculum = _curriculum_with_response_budgets({"short": 32, "long": 64})
+
+    with pytest.raises(ValueError, match="short=32"):
+        _train_worker_config(
+            curriculum,
+            DrGRPOLoss(max_output_tokens=64, kl=KLConfig(mode=KLMode.NONE, beta=0.0)),
+        )
+
+
+def test_streaming_rollout_loader_uses_train_response_budget_not_eval_budget():
+    curriculum = _curriculum_with_response_budgets(
+        {"lesson_a": 32, "lesson_b": 32},
+        eval_budget=128,
+    )
+    config = SimpleNamespace(
+        curriculum_config=curriculum,
+        model=SimpleNamespace(attn_backend=None, flash_attention_block_size=None),
+        tokenizer=SimpleNamespace(pad_token_id=0, eos_token_id=1),
+    )
+
+    loader = StreamingRolloutLoader(data_loader=cast(Any, object()), config=cast(Any, config))
+
+    assert loader.max_output_tokens == 32
 
 
 def test_drop_bootstrap_model_references_clears_reference_model_when_kl_disabled():


### PR DESCRIPTION
Add GRPO, Dr.GRPO, and DAPO to Marin RL using shared clipped policy-gradient plumbing, explicit reduction modes, and rollout-aware batch metadata. GRPO adds group-centered normalized advantages, Dr.GRPO adds fixed response-budget normalization, and DAPO adds active-token normalization, clip-higher behavior, and hard-overlong masking. Replay-buffer reward shaping now supports optional soft overlong penalties before advantage computation and variance filtering so dynamic filtering and loss denominators use the same rollout semantics.
