### PR TITLE
[SFT] Add filtered Open R1 code dataset controls

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -38,12 +38,18 @@ Current datasets:
 23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
 24. lm-provers/FineProofs-SFT
 25. lm-provers/FineProofs-SFT/proof-only
+26. open-r1/verifiable-coding-problems-python_decontaminated-tested
+27. open-r1/OpenThoughts-114k-Code_decontaminated
+28. open-r1/codeforces-cots/solutions_decontaminated/finish_stop
+29. open-r1/codeforces-cots/solutions_py_decontaminated/finish_stop
+30. open-r1/ioi-cots/ac-target-subtask-finish-stop
+31. open-r1/ioi-cots/all-subtasks-100-finish-stop
 """
 
 import dataclasses
 import hashlib
 import json
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 from typing import Any
 
@@ -141,6 +147,7 @@ def multi_turn_adapter(
     metadata_remap: dict[str, str] | None = None,
     replacements: dict[str, str] | None = None,
     extra_metadata_fn=None,
+    row_filter_fn: Callable[[dict[str, Any]], bool] | None = None,
 ) -> TransformAdapter:
     return TransformAdapter(
         dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
@@ -153,6 +160,7 @@ def multi_turn_adapter(
         metadata_remap=metadata_remap or {},
         replacements=replacements,
         extra_metadata_fn=extra_metadata_fn,
+        row_filter_fn=row_filter_fn,
     )
 
 
@@ -165,6 +173,7 @@ def instruction_response_adapter(
     metadata_remap: dict[str, str] | None = None,
     replacements: dict[str, str] | None = None,
     extra_metadata_fn=None,
+    row_filter_fn: Callable[[dict[str, Any]], bool] | None = None,
 ) -> TransformAdapter:
     return TransformAdapter(
         dataset_format=InputDatasetFormat.INSTRUCTION_RESPONSE,
@@ -175,6 +184,7 @@ def instruction_response_adapter(
         metadata_remap=metadata_remap or {},
         replacements=replacements,
         extra_metadata_fn=extra_metadata_fn,
+        row_filter_fn=row_filter_fn,
     )
 
 
@@ -185,6 +195,7 @@ def instruct_column_response_adapter(
     metadata_remap: dict[str, str] | None = None,
     replacements: dict[str, str] | None = None,
     extra_metadata_fn=None,
+    row_filter_fn: Callable[[dict[str, Any]], bool] | None = None,
 ) -> TransformAdapter:
     return TransformAdapter(
         dataset_format=InputDatasetFormat.INSTRUCT_COLUMN_RESPONSE,
@@ -194,6 +205,7 @@ def instruct_column_response_adapter(
         metadata_remap=metadata_remap or {},
         replacements=replacements,
         extra_metadata_fn=extra_metadata_fn,
+        row_filter_fn=row_filter_fn,
     )
 
 
@@ -209,6 +221,7 @@ def instruct_msg_response_adapter(
     metadata_remap: dict[str, str] | None = None,
     replacements: dict[str, str] | None = None,
     extra_metadata_fn=None,
+    row_filter_fn: Callable[[dict[str, Any]], bool] | None = None,
 ) -> TransformAdapter:
     return TransformAdapter(
         dataset_format=InputDatasetFormat.INSTRUCT_MSG_RESPONSE,
@@ -222,6 +235,7 @@ def instruct_msg_response_adapter(
         metadata_remap=metadata_remap or {},
         replacements=replacements,
         extra_metadata_fn=extra_metadata_fn,
+        row_filter_fn=row_filter_fn,
     )
 
 
@@ -243,6 +257,62 @@ class ReasoningToChatKwargs:
 
 
 reasoning_to_chat_kwargs = ReasoningToChatKwargs()
+
+OPEN_R1_VERIFIABLE_CODE_HF_ID = "open-r1/verifiable-coding-problems-python_decontaminated-tested"
+OPEN_R1_VERIFIABLE_CODE_REVISION = "77ace849f7cc8f10d23945c748f9ff464427f83b"
+OPEN_R1_VERIFIABLE_CODE_METADATA_COLUMNS = ["source", "task_type", "in_source_id", "problem_id", "test_reward"]
+
+OPEN_R1_OPENTHOUGHTS_CODE_HF_ID = "open-r1/OpenThoughts-114k-Code_decontaminated"
+OPEN_R1_OPENTHOUGHTS_CODE_REVISION = "b90307fcdb68ae52d01f60cfd38d5f0b4852115a"
+OPEN_R1_OPENTHOUGHTS_CODE_METADATA_COLUMNS = ["domain", "source", "num_tokens"]
+
+OPEN_R1_CODEFORCES_COTS_HF_ID = "open-r1/codeforces-cots"
+OPEN_R1_CODEFORCES_COTS_REVISION = "39ac85c150806230473c70ad72c31f6232fe3f41"
+OPEN_R1_CODEFORCES_COTS_PRIMARY_SPLITS = ["solutions_decontaminated", "solutions_py_decontaminated"]
+OPEN_R1_CODEFORCES_COTS_METADATA_COLUMNS = [
+    "id",
+    "contest_id",
+    "contest_type",
+    "contest_start_year",
+    "index",
+    "title",
+    "problem_type",
+    "finish_reason",
+]
+
+OPEN_R1_IOI_COTS_HF_ID = "open-r1/ioi-cots"
+OPEN_R1_IOI_COTS_REVISION = "d07e70f8ed8b8b0b1843046a2a140b9dac9e9741"
+OPEN_R1_IOI_COTS_METADATA_COLUMNS = [
+    "year",
+    "day",
+    "problem_name",
+    "problem_id",
+    "target_subtask",
+    "uuid",
+    "finish_reason",
+    "code_compiles",
+    "target_subtask_score",
+    "target_subtask_status",
+    "all_subtasks_points",
+]
+
+
+def finish_reason_stop(row: dict[str, Any]) -> bool:
+    return row.get("finish_reason") == "stop"
+
+
+def ioi_target_subtask_ac(row: dict[str, Any]) -> bool:
+    return (
+        finish_reason_stop(row)
+        and row.get("code_compiles") is True
+        and row.get("target_subtask_status") == "AC"
+        and row.get("target_subtask_score") == 1.0
+    )
+
+
+def ioi_all_subtasks_100(row: dict[str, Any]) -> bool:
+    return ioi_target_subtask_ac(row) and row.get("all_subtasks_points") == 100.0
+
 
 SYNTHETIC2_SFT_VERIFIED_HF_ID = "PrimeIntellect/SYNTHETIC-2-SFT-verified"
 SYNTHETIC2_SFT_VERIFIED_REVISION = "fce247fe48af8ff9624fb51d1de63aa1b2332cef"
@@ -358,6 +428,45 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         adapter=multi_turn_adapter(),
         metadata_columns=["system", "source", "generated_token_count", "correct"],
         name="open-r1/OpenThoughts-114k-math",
+    ),
+    OPEN_R1_VERIFIABLE_CODE_HF_ID: InstructionDatasetConfig(
+        hf_dataset_id=OPEN_R1_VERIFIABLE_CODE_HF_ID,
+        revision=OPEN_R1_VERIFIABLE_CODE_REVISION,
+        adapter=instruction_response_adapter(
+            instruction_column="problem",
+            response_column="gold_standard_solution",
+        ),
+        metadata_columns=OPEN_R1_VERIFIABLE_CODE_METADATA_COLUMNS,
+        name=OPEN_R1_VERIFIABLE_CODE_HF_ID,
+        subsets=["default"],
+        splits=["train"],
+    ),
+    OPEN_R1_OPENTHOUGHTS_CODE_HF_ID: InstructionDatasetConfig(
+        hf_dataset_id=OPEN_R1_OPENTHOUGHTS_CODE_HF_ID,
+        revision=OPEN_R1_OPENTHOUGHTS_CODE_REVISION,
+        adapter=multi_turn_adapter(),
+        metadata_columns=OPEN_R1_OPENTHOUGHTS_CODE_METADATA_COLUMNS,
+        name=OPEN_R1_OPENTHOUGHTS_CODE_HF_ID,
+        subsets=["default"],
+        splits=["train"],
+    ),
+    "open-r1/ioi-cots/ac-target-subtask-finish-stop": InstructionDatasetConfig(
+        hf_dataset_id=OPEN_R1_IOI_COTS_HF_ID,
+        revision=OPEN_R1_IOI_COTS_REVISION,
+        adapter=multi_turn_adapter(row_filter_fn=ioi_target_subtask_ac),
+        metadata_columns=OPEN_R1_IOI_COTS_METADATA_COLUMNS,
+        name="open-r1/ioi-cots/ac-target-subtask-finish-stop",
+        subsets=["default"],
+        splits=["train"],
+    ),
+    "open-r1/ioi-cots/all-subtasks-100-finish-stop": InstructionDatasetConfig(
+        hf_dataset_id=OPEN_R1_IOI_COTS_HF_ID,
+        revision=OPEN_R1_IOI_COTS_REVISION,
+        adapter=multi_turn_adapter(row_filter_fn=ioi_all_subtasks_100),
+        metadata_columns=OPEN_R1_IOI_COTS_METADATA_COLUMNS,
+        name="open-r1/ioi-cots/all-subtasks-100-finish-stop",
+        subsets=["default"],
+        splits=["train"],
     ),
     "bespokelabs/Bespoke-Stratos-17k": InstructionDatasetConfig(
         hf_dataset_id="bespokelabs/Bespoke-Stratos-17k",
@@ -560,6 +669,18 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         splits=["genselect"],
     ),
 }
+
+for split_name in OPEN_R1_CODEFORCES_COTS_PRIMARY_SPLITS:
+    dataset_key = f"{OPEN_R1_CODEFORCES_COTS_HF_ID}/{split_name}/finish_stop"
+    INSTRUCTION_DATASET_NAME_TO_CONFIG[dataset_key] = InstructionDatasetConfig(
+        name=dataset_key,
+        hf_dataset_id=OPEN_R1_CODEFORCES_COTS_HF_ID,
+        revision=OPEN_R1_CODEFORCES_COTS_REVISION,
+        adapter=multi_turn_adapter(row_filter_fn=finish_reason_stop),
+        metadata_columns=OPEN_R1_CODEFORCES_COTS_METADATA_COLUMNS,
+        subsets=[split_name],
+        splits=["train"],
+    )
 
 for split_name in SMOLTALK2_SPLITS:
     dataset_key = f"HuggingFaceTB/smoltalk2/{split_name}"

--- a/lib/marin/src/marin/transform/conversation/adapters.py
+++ b/lib/marin/src/marin/transform/conversation/adapters.py
@@ -87,6 +87,7 @@ class TransformAdapter:
     metadata_remap: dict[str, str] = field(default_factory=dict)
     replacements: dict[str, str] | None = None
     extra_metadata_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+    row_filter_fn: Callable[[dict[str, Any]], bool] | None = None
 
     def transform_conversation_to_openai_format(
         self,

--- a/lib/marin/src/marin/transform/conversation/transform_conversation.py
+++ b/lib/marin/src/marin/transform/conversation/transform_conversation.py
@@ -120,6 +120,9 @@ def _normalize_tool_structures(message: dict) -> dict:
 
 def transform_row(row: dict, cfg: TransformSFTDatasetConfig, adapter: TransformAdapter):
     source = unwrap_versioned_value(cfg.source)
+    if adapter.row_filter_fn is not None and not adapter.row_filter_fn(row):
+        return None
+
     transformed_row_messages: list[OpenAIChatMessage] | None = adapter.transform_conversation_to_openai_format(row)
 
     if transformed_row_messages is None:

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -25,6 +25,98 @@ SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
     ],
 }
 
+OPEN_R1_VERIFIABLE_CODE_KEY = "open-r1/verifiable-coding-problems-python_decontaminated-tested"
+OPEN_R1_VERIFIABLE_CODE_REVISION = "77ace849f7cc8f10d23945c748f9ff464427f83b"
+OPEN_R1_OPENTHOUGHTS_CODE_KEY = "open-r1/OpenThoughts-114k-Code_decontaminated"
+OPEN_R1_OPENTHOUGHTS_CODE_REVISION = "b90307fcdb68ae52d01f60cfd38d5f0b4852115a"
+OPEN_R1_CODEFORCES_COTS_HF_ID = "open-r1/codeforces-cots"
+OPEN_R1_CODEFORCES_COTS_REVISION = "39ac85c150806230473c70ad72c31f6232fe3f41"
+OPEN_R1_CODEFORCES_COTS_VIEWS = [
+    ("open-r1/codeforces-cots/solutions_decontaminated/finish_stop", "solutions_decontaminated"),
+    ("open-r1/codeforces-cots/solutions_py_decontaminated/finish_stop", "solutions_py_decontaminated"),
+]
+OPEN_R1_IOI_COTS_HF_ID = "open-r1/ioi-cots"
+OPEN_R1_IOI_COTS_REVISION = "d07e70f8ed8b8b0b1843046a2a140b9dac9e9741"
+OPEN_R1_IOI_BASE_KEY = "open-r1/ioi-cots/ac-target-subtask-finish-stop"
+OPEN_R1_IOI_STRICT_KEY = "open-r1/ioi-cots/all-subtasks-100-finish-stop"
+
+OPEN_R1_VERIFIABLE_CODE_SAMPLE = {
+    "source": "apps",
+    "task_type": "prime_rl_code",
+    "in_source_id": "apps-17",
+    "problem": "Write a Python function that returns the square of an integer.",
+    "gold_standard_solution": "def square(n: int) -> int:\n    return n * n",
+    "problem_id": "apps-17",
+    "test_reward": 1.0,
+    "verification_info": {"private_tests": ["large verifier blob"]},
+}
+
+OPEN_R1_OPENTHOUGHTS_CODE_SAMPLE = {
+    "problem": "Return the maximum element in a list.",
+    "deepseek_reasoning": "We can scan once.",
+    "deepseek_solution": "def solve(nums):\n    return max(nums)",
+    "ground_truth_solution": "def solve(nums):\n    return max(nums)",
+    "domain": "python",
+    "source": "lcb",
+    "test_cases": [{"input": "[1, 3, 2]", "output": "3"}],
+    "starter_code": "",
+    "messages": [
+        {"role": "user", "content": "Return the maximum element in a list."},
+        {"role": "assistant", "content": "<think>Scan once.</think>\ndef solve(nums):\n    return max(nums)"},
+    ],
+    "num_tokens": 128,
+}
+
+OPEN_R1_CODEFORCES_SAMPLE = {
+    "id": "cf-1000-a",
+    "contest_id": 1000,
+    "contest_type": "cf",
+    "contest_start_year": 2018,
+    "index": "A",
+    "title": "Codeforces Problem A",
+    "problem_type": "programming",
+    "finish_reason": "stop",
+    "accepted_solutions": ["large solution blob"],
+    "public_tests_ms": [{"input": "1", "output": "1"}],
+    "messages": [
+        {"role": "user", "content": "Solve Codeforces Problem A."},
+        {"role": "assistant", "content": "<think>Derive the invariant.</think>\n```cpp\nint main(){}\n```"},
+    ],
+}
+
+OPEN_R1_IOI_SAMPLE = {
+    "year": 2024,
+    "day": 1,
+    "problem_name": "Nile",
+    "problem_id": "2024-day1-nile",
+    "target_subtask": "subtask_1",
+    "prompt": "Implement the solution.",
+    "generation": "We need a data structure.",
+    "uuid": "ioi-row-1",
+    "metadata": {"difficulty": "hard"},
+    "finish_reason": "stop",
+    "code": "#include <bits/stdc++.h>",
+    "code_compiles": True,
+    "target_subtask_score": 1.0,
+    "target_subtask_status": "AC",
+    "all_subtasks_points": 100.0,
+    "all_subtasks_results": [{"status": "AC"}],
+    "messages": [
+        {"role": "user", "content": "Solve the IOI subtask."},
+        {
+            "role": "assistant",
+            "content": "<think>Use the target subtask constraints.</think>" "\n```cpp\nint main(){}\n```",
+        },
+    ],
+}
+
+
+def transform_instruction_row(dataset_key: str, row: dict):
+    step = get_instruction_dataset(dataset_key)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+    return step, cfg, adapter, transform_row(row, cfg, adapter)
+
 
 def test_fineproofs_sft_datasets_are_registered():
     raw_dataset = INSTRUCTION_DATASET_NAME_TO_CONFIG["lm-provers/FineProofs-SFT"]
@@ -105,3 +197,130 @@ def test_synthetic2_sft_verified_step_transforms_chat_rows():
         "task_type": "prime_rl_code",
         "reward": 1.0,
     }
+
+
+def test_open_r1_verifiable_code_step_transforms_problem_solution_rows():
+    step, cfg, adapter, result = transform_instruction_row(OPEN_R1_VERIFIABLE_CODE_KEY, OPEN_R1_VERIFIABLE_CODE_SAMPLE)
+
+    assert step.name == f"documents/{OPEN_R1_VERIFIABLE_CODE_KEY}"
+    assert unwrap_versioned_value(cfg.source) == OPEN_R1_VERIFIABLE_CODE_KEY
+    assert unwrap_versioned_value(cfg.revision) == OPEN_R1_VERIFIABLE_CODE_REVISION
+    assert unwrap_versioned_value(cfg.subsets) == ["default"]
+    assert adapter.dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE
+    assert adapter.instruction_column == "problem"
+    assert adapter.response_column == "gold_standard_solution"
+
+    assert result is not None
+    assert result.source == OPEN_R1_VERIFIABLE_CODE_KEY
+    assert [message.role for message in result.messages] == ["user", "assistant"]
+    assert result.messages[0].content == OPEN_R1_VERIFIABLE_CODE_SAMPLE["problem"]
+    assert result.messages[1].content == OPEN_R1_VERIFIABLE_CODE_SAMPLE["gold_standard_solution"]
+    assert result.metadata == {
+        "source": "apps",
+        "task_type": "prime_rl_code",
+        "in_source_id": "apps-17",
+        "problem_id": "apps-17",
+        "test_reward": 1.0,
+    }
+
+
+def test_open_r1_openthoughts_code_step_transforms_messages():
+    step, cfg, adapter, result = transform_instruction_row(
+        OPEN_R1_OPENTHOUGHTS_CODE_KEY,
+        OPEN_R1_OPENTHOUGHTS_CODE_SAMPLE,
+    )
+
+    assert step.name == f"documents/{OPEN_R1_OPENTHOUGHTS_CODE_KEY}"
+    assert unwrap_versioned_value(cfg.source) == OPEN_R1_OPENTHOUGHTS_CODE_KEY
+    assert unwrap_versioned_value(cfg.revision) == OPEN_R1_OPENTHOUGHTS_CODE_REVISION
+    assert unwrap_versioned_value(cfg.subsets) == ["default"]
+    assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+
+    assert result is not None
+    assert result.source == OPEN_R1_OPENTHOUGHTS_CODE_KEY
+    assert [message.role for message in result.messages] == ["user", "assistant"]
+    assert result.messages[0].content == "Return the maximum element in a list."
+    assert result.messages[1].content == "<|start_think|>Scan once.<|end_think|>\ndef solve(nums):\n    return max(nums)"
+    assert result.metadata == {"domain": "python", "source": "lcb", "num_tokens": 128}
+
+
+def test_open_r1_codeforces_views_transform_and_filter_finished_generations():
+    for dataset_key, subset_name in OPEN_R1_CODEFORCES_COTS_VIEWS:
+        step, cfg, adapter, result = transform_instruction_row(dataset_key, OPEN_R1_CODEFORCES_SAMPLE)
+
+        assert step.name == f"documents/{dataset_key}"
+        assert unwrap_versioned_value(cfg.source) == OPEN_R1_CODEFORCES_COTS_HF_ID
+        assert unwrap_versioned_value(cfg.revision) == OPEN_R1_CODEFORCES_COTS_REVISION
+        assert unwrap_versioned_value(cfg.subsets) == [subset_name]
+        assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+
+        assert result is not None
+        assert result.source == OPEN_R1_CODEFORCES_COTS_HF_ID
+        assert [message.role for message in result.messages] == ["user", "assistant"]
+        assert (
+            result.messages[1].content == "<|start_think|>Derive the invariant.<|end_think|>\n```cpp\nint main(){}\n```"
+        )
+        assert result.metadata == {
+            "id": "cf-1000-a",
+            "contest_id": 1000,
+            "contest_type": "cf",
+            "contest_start_year": 2018,
+            "index": "A",
+            "title": "Codeforces Problem A",
+            "problem_type": "programming",
+            "finish_reason": "stop",
+        }
+
+        truncated_row = {**OPEN_R1_CODEFORCES_SAMPLE, "finish_reason": "length"}
+        assert transform_row(truncated_row, cfg, adapter) is None
+
+
+def test_open_r1_ioi_base_view_filters_to_target_subtask_ac_rows():
+    step, cfg, adapter, result = transform_instruction_row(OPEN_R1_IOI_BASE_KEY, OPEN_R1_IOI_SAMPLE)
+
+    assert step.name == f"documents/{OPEN_R1_IOI_BASE_KEY}"
+    assert unwrap_versioned_value(cfg.source) == OPEN_R1_IOI_COTS_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == OPEN_R1_IOI_COTS_REVISION
+    assert unwrap_versioned_value(cfg.subsets) == ["default"]
+    assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+
+    assert result is not None
+    assert result.source == OPEN_R1_IOI_COTS_HF_ID
+    assert [message.role for message in result.messages] == ["user", "assistant"]
+    assert result.messages[1].content == (
+        "<|start_think|>Use the target subtask constraints.<|end_think|>\n```cpp\nint main(){}\n```"
+    )
+    assert result.metadata == {
+        "year": 2024,
+        "day": 1,
+        "problem_name": "Nile",
+        "problem_id": "2024-day1-nile",
+        "target_subtask": "subtask_1",
+        "uuid": "ioi-row-1",
+        "finish_reason": "stop",
+        "code_compiles": True,
+        "target_subtask_score": 1.0,
+        "target_subtask_status": "AC",
+        "all_subtasks_points": 100.0,
+    }
+
+    for field_name, rejected_value in [
+        ("finish_reason", "length"),
+        ("code_compiles", False),
+        ("target_subtask_status", "WA"),
+        ("target_subtask_score", 0.5),
+    ]:
+        assert transform_row({**OPEN_R1_IOI_SAMPLE, field_name: rejected_value}, cfg, adapter) is None
+
+
+def test_open_r1_ioi_strict_view_requires_full_points():
+    step, cfg, adapter, result = transform_instruction_row(OPEN_R1_IOI_STRICT_KEY, OPEN_R1_IOI_SAMPLE)
+
+    assert step.name == f"documents/{OPEN_R1_IOI_STRICT_KEY}"
+    assert unwrap_versioned_value(cfg.source) == OPEN_R1_IOI_COTS_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == OPEN_R1_IOI_COTS_REVISION
+    assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+    assert result is not None
+
+    partial_row = {**OPEN_R1_IOI_SAMPLE, "all_subtasks_points": 99.0}
+    assert transform_row(partial_row, cfg, adapter) is None


### PR DESCRIPTION
Register Open R1 verified Python, OpenThoughts code, filtered Codeforces, and score-filtered IOI SFT controls in the instruction dataset registry. Adds an adapter-level row filter hook so truncated Codeforces rows and weak IOI rows are skipped while preserving small metadata. Validated with focused instruction dataset and conversation transform tests plus Marin pre-commit.