### PR TITLE
[iris] Expand v4-reserved sizes with chip-budget-derived caps

### DIFF
--- a/lib/iris/config/marin.yaml
+++ b/lib/iris/config/marin.yaml
@@ -149,15 +149,18 @@ tpu_pools:
       gcp:
         service_account: iris-worker@hai-gcp-models.iam.gserviceaccount.com
         runtime_version: tpu-ubuntu2204-base
+    # max_slices = 2048 / size for each entry (~2048-chip-equivalent reservation
+    # in TensorCore units; sizes >2048 omitted since they'd exceed the budget).
     sizes:
-      32:   { buffer_slices: 0, max_slices: 1 }
-      64:   { buffer_slices: 0, max_slices: 1 }
-      128:  { buffer_slices: 0, max_slices: 1 }
-      256:  { buffer_slices: 0, max_slices: 1 }
-      512:  { buffer_slices: 0, max_slices: 1 }
-      1024: { buffer_slices: 0, max_slices: 1 }
+      8:    { buffer_slices: 0, max_slices: 256 }
+      16:   { buffer_slices: 0, max_slices: 128 }
+      32:   { buffer_slices: 0, max_slices: 64 }
+      64:   { buffer_slices: 0, max_slices: 32 }
+      128:  { buffer_slices: 0, max_slices: 16 }
+      256:  { buffer_slices: 0, max_slices: 8 }
+      512:  { buffer_slices: 0, max_slices: 4 }
+      1024: { buffer_slices: 0, max_slices: 2 }
       2048: { buffer_slices: 0, max_slices: 1 }
-      4096: { buffer_slices: 0, max_slices: 1 }
 
 # ---------------------------------------------------------------------------
 # Non-TPU scale groups (not part of tpu_pools)


### PR DESCRIPTION
## Summary
- Adds sizes **8** and **16** to the `v4-reserved` scale group in `marin.yaml` so iris can schedule v4-8 / v4-16 jobs against the reservation. Previously only sizes 32+ were declared, and the autoscaler had no entry for v4-reserved_8 even after a controller restart — jobs requesting it stalled at whatever workers happened to be pre-warmed.
- Replaces the uniform `max_slices: 1` with `max_slices = 2048 / size` for every declared size, matching a ~2048-chip-equivalent reservation (in TensorCore units, since v4 slice names count TensorCores at 2 per chip).
- Drops the 4096 entry, since a single slice of v4-4096 alone would exceed the budget.

## Test plan
- [ ] `iris cluster controller serve --dry-run --config lib/iris/config/marin.yaml` parses without errors
- [ ] Controller restart picks up `tpu_v4-reserved_8-us-central2-b` and shows it in `iris rpc controller get-autoscaler-status`
- [ ] A test v4-8 reserved submit lands on the new group instead of stalling pending