### PR TITLE
iris: trim Reconcile observation payload to desired set

### DIFF
--- a/lib/iris/docs/reconcile_rpc.md
+++ b/lib/iris/docs/reconcile_rpc.md
@@ -1,0 +1,121 @@
+# Reconcile RPC: worker control plane
+
+The Reconcile RPC collapses the legacy `StartTasks` + `PollTasks` pair (and the
+implicit `StopTasks` dispatch) into a single unary call per worker per tick.
+One request carries the controller's **complete desired attempt set** for that
+worker; one response carries the **complete observed set** plus a
+`WorkerHealth` block. No more split-brain windows between "we told the worker
+to start X" and "we polled and the worker hadn't seen X yet"; no third RPC for
+stops. Both the legacy and new wires remain in tree behind a rollout flag
+through Phase D.
+
+## Wire
+
+Proto: [`lib/iris/src/iris/rpc/worker.proto:106`](../src/iris/rpc/worker.proto)
+defines `ReconcileRequest` (`worker_id`, repeated `DesiredAttempt`) and
+`ReconcileResponse` (`worker_id`, repeated `AttemptObservation`,
+`WorkerHealth`). Service method is
+[`worker.proto:194`](../src/iris/rpc/worker.proto). `DesiredAttempt.intent`
+is a `oneof { AttemptSpec run; StopReason stop }`. `AttemptSpec.request` is
+populated only on the dispatch tick for an `ASSIGNED` attempt; subsequent ticks
+omit it and the worker pulls from cache (see
+[`reconcile.py:71`](../src/iris/cluster/controller/reconcile.py)).
+
+## Control flow
+
+```mermaid
+sequenceDiagram
+    participant Loop as Controller<br/>_reconcile_worker_batch
+    participant Pure as reconcile.py<br/>reconcile_workers()
+    participant Prov as WorkerProvider<br/>reconcile_workers()
+    participant W1 as Worker A<br/>(RPC path)
+    participant W2 as Worker B<br/>(legacy path)
+    participant Apply as transitions<br/>apply_reconcile_result
+
+    Loop->>Pure: ReconcileInputs (rows + job_specs)
+    Pure-->>Loop: list[WorkerReconcilePlan]
+    Loop->>Prov: plans, addresses, rpc_worker_ids
+    par RPC fanout
+        Prov->>W1: Reconcile(ReconcileRequest)
+        W1-->>Prov: ReconcileResponse(observed, health)
+    and Legacy fanout
+        Prov->>W2: StartTasks(...)
+        Prov->>W2: PollTasks(...)
+        W2-->>Prov: acks + task statuses
+    end
+    Prov-->>Loop: list[ReconcileResult]
+    Loop->>Apply: per-worker (plan, result)
+```
+
+## Pure compute vs. transport
+
+`controller._reconcile_worker_batch`
+([`controller.py:2391`](../src/iris/cluster/controller/controller.py)) snapshots
+DB rows, calls `reconcile_workers(inputs)`
+([`reconcile.py:66`](../src/iris/cluster/controller/reconcile.py)) to produce
+one `WorkerReconcilePlan` per worker (proto built once, reused on both wires),
+then routes through `WorkerProvider.reconcile_workers`
+([`worker_provider.py:271`](../src/iris/cluster/controller/worker_provider.py)).
+The provider partitions plans by `rpc_worker_ids` and runs both fanouts under a
+single `asyncio.gather` capped by `self.parallelism`. The legacy path
+([`_reconcile_one_legacy`, `worker_provider.py:202`](../src/iris/cluster/controller/worker_provider.py))
+synthesizes a `ReconcileResult` from its `StartTasks` acks + `PollTasks`
+response via
+[`_legacy_results_to_reconcile_results`, `worker_provider.py:362`](../src/iris/cluster/controller/worker_provider.py)
+so the apply layer
+([`transitions.apply_reconcile_result`, `transitions.py:1988`](../src/iris/cluster/controller/transitions.py))
+sees one shape regardless of wire.
+
+## Worker side
+
+`WorkerLifecycle.handle_reconcile`
+([`worker.py:1050`](../src/iris/cluster/worker/worker.py)) processes each
+`DesiredAttempt` (run or stop intent), kills any local attempt not in the
+desired set ("zombie"), synthesizes `TASK_STATE_MISSING` observations for run
+intents that resolved to nothing locally, and attaches a fresh `WorkerHealth`.
+The RPC entry point is
+[`WorkerService.reconcile`, `service.py:171`](../src/iris/cluster/worker/service.py).
+
+The observation set is bounded: the worker emits an `AttemptObservation` only
+for attempts the controller asked about (`DesiredAttempt` resolves to a local
+attempt) or for zombies it is killing this tick (so the controller can confirm
+the kill it implicitly requested). Terminal local history outside the desired
+set is suppressed — previously a worker could emit hundreds of stale terminal
+observations per tick, each driving a DB write on the apply side. The
+controller mirrors this in
+[`transitions._filter_observations_to_plan`, `transitions.py`](../src/iris/cluster/controller/transitions.py):
+observations whose attempt is not in the per-worker `WorkerReconcilePlan` are
+dropped (DEBUG-logged) before any work is done.
+
+## Rollout
+
+Resolved once at controller startup from `IRIS_RECONCILE_PREFIX`
+([`main.py:218`](../src/iris/cluster/controller/main.py)) into
+`ControllerConfig.reconcile_rpc_prefix`
+([`controller.py:1300`](../src/iris/cluster/controller/controller.py)):
+
+| `IRIS_RECONCILE_PREFIX` | Behavior |
+|---|---|
+| unset | legacy wire for all workers |
+| `*` | Reconcile RPC for all workers |
+| `<prefix>` | Reconcile RPC for `worker_id.startswith(prefix)`, legacy otherwise |
+
+Per-tick routing lives at
+[`controller.py:2402`](../src/iris/cluster/controller/controller.py). The
+prefix is frozen at startup — widen it by restarting the controller (see
+the `restart-iris` skill). Tests covering each mode:
+[`test_reconcile.py:1199`](../tests/cluster/controller/test_reconcile.py) and
+the `_observation_for_all_run` cases around
+[`test_reconcile.py:1078`](../tests/cluster/controller/test_reconcile.py).
+
+## Monitoring
+
+Every worker handled via the RPC wire emits one structured INFO line per tick
+to the `iris.cluster.controller.reconcile_rollout` logger
+([`worker_provider.py:441`](../src/iris/cluster/controller/worker_provider.py),
+emitter at
+[`worker_provider.py:446`](../src/iris/cluster/controller/worker_provider.py)):
+`desired_run`, `desired_stop`, observation counts by state, run/stop ids, and
+`error`. Dial verbosity on that logger independently of the controller root.
+The logger and `_log_rpc_rollout` are explicitly tagged for deletion alongside
+the legacy wire.

--- a/lib/iris/src/iris/cluster/controller/transitions.py
+++ b/lib/iris/src/iris/cluster/controller/transitions.py
@@ -351,6 +351,48 @@ def task_updates_from_proto(entries) -> list[TaskUpdate]:
     return updates
 
 
+def _filter_observations_to_plan(
+    plan: WorkerReconcilePlan,
+    observations: list[worker_pb2.Worker.AttemptObservation],
+    worker_id: WorkerId,
+) -> list[worker_pb2.Worker.AttemptObservation]:
+    """Drop observations whose attempt is not in the per-worker plan we sent.
+
+    Membership: observation matches if its ``attempt_uid`` is in the plan's
+    non-empty UID set OR its ``(task_id, attempt_id)`` composite is in the
+    plan's composite set. The composite fallback covers legacy-wire workers
+    and pre-upgrade attempts whose observations carry an empty UID.
+
+    The legacy synthesizer in ``_legacy_results_to_reconcile_results`` only
+    produces observations sourced from ``expected_tasks`` / ``start_tasks``,
+    both built from the same plan — so this filter is a no-op on that wire.
+    """
+    plan_uids: set[str] = set()
+    plan_composites: set[tuple[str, int]] = set()
+    for desired in plan.request.desired:
+        if desired.attempt_uid:
+            plan_uids.add(desired.attempt_uid)
+        plan_composites.add((desired.task_id, desired.attempt_id))
+
+    kept: list[worker_pb2.Worker.AttemptObservation] = []
+    dropped = 0
+    for obs in observations:
+        if obs.attempt_uid and obs.attempt_uid in plan_uids:
+            kept.append(obs)
+            continue
+        if (obs.task_id, obs.attempt_id) in plan_composites:
+            kept.append(obs)
+            continue
+        dropped += 1
+    if dropped:
+        logger.debug(
+            "apply_reconcile_result: worker %s sent %d observations outside the plan; dropping",
+            worker_id,
+            dropped,
+        )
+    return kept
+
+
 @dataclass(frozen=True)
 class HeartbeatApplyRequest:
     """Batch of worker heartbeat updates applied atomically."""
@@ -2027,7 +2069,15 @@ class ControllerTransitions:
             return TxResult()
         self._health.heartbeat([worker_id], now_ms)
 
-        all_updates = self._observations_to_updates(cur, result.observations)
+        # Drop observations that fall outside the plan we just sent. Protects
+        # against an old worker volunteering its terminal-state local history
+        # (seen in prod: 287 obs for 1 desired RUNNING attempt) and against any
+        # other extra-observation drift between worker and controller.
+        observations = _filter_observations_to_plan(plan, result.observations, worker_id)
+        if not observations:
+            return TxResult()
+
+        all_updates = self._observations_to_updates(cur, observations)
         if not all_updates:
             return TxResult()
 

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -1070,6 +1070,7 @@ class Worker:
                     desired_attempts.add(id(match))
             snapshot = list(self._tasks)
 
+        zombie_attempts: set[int] = set()
         for task in snapshot:
             if id(task) in desired_attempts or task.status in self._TERMINAL_STATES:
                 continue
@@ -1078,12 +1079,22 @@ class Worker:
                 task.task_id,
                 task.attempt_id,
             )
+            zombie_attempts.add(id(task))
             self._kill_async(task)
 
+        # Observations are bounded by what the controller asked about. Emitting
+        # terminal local history the controller did not request is wasted wire
+        # bandwidth and a wasted DB write on the apply side. We report:
+        #   - attempts that resolve to a DesiredAttempt (live or terminal twin
+        #     the controller still tracks), and
+        #   - zombies we are killing this tick, so the controller can confirm
+        #     the kill it implicitly requested by omitting the attempt.
         observations: list[worker_pb2.Worker.AttemptObservation] = []
         with self._lock:
             snapshot = list(self._tasks)
             for task in snapshot:
+                if id(task) not in desired_attempts and id(task) not in zombie_attempts:
+                    continue
                 observations.append(self._build_observation(task))
 
             # Synthesize MISSING for run intents that resolved to no local attempt.

--- a/lib/iris/tests/cluster/controller/test_reconcile.py
+++ b/lib/iris/tests/cluster/controller/test_reconcile.py
@@ -9,8 +9,8 @@ Three layers, exercised in order:
    proto per worker from a ``ReconcileInputs`` snapshot. No DB.
 2. **Wire & dispatch** — ``WorkerProvider.reconcile_workers`` fans out via a
    fake stub factory and synthesizes ``ReconcileResult.observations`` for both
-   the ``Reconcile`` RPC wire (``use_reconcile_rpc=True``) and the legacy
-   ``StartTasks`` + ``PollTasks`` wire (``use_reconcile_rpc=False``).
+   the ``Reconcile`` RPC wire (worker in ``rpc_worker_ids``) and the legacy
+   ``StartTasks`` + ``PollTasks`` wire (worker not in ``rpc_worker_ids``).
 3. **Apply + e2e** — ``ControllerTransitions.apply_reconcile_result`` against
    real SQLite DB state, plus a handful of end-to-end convergence ticks driven
    through ``Controller._reconcile_worker_batch``.
@@ -511,16 +511,17 @@ def _provider_with_stub(stub: _FakeWorkerStub | None = None) -> tuple[WorkerProv
 
 
 def _reconcile_one(provider: WorkerProvider, plan: WorkerReconcilePlan, *, rpc: bool, address: str = _W1_ADDR):
-    return provider.reconcile_workers([plan], {WorkerId(_W1): address}, use_reconcile_rpc=rpc)
+    rpc_worker_ids = {WorkerId(_W1)} if rpc else set()
+    return provider.reconcile_workers([plan], {WorkerId(_W1): address}, rpc_worker_ids=rpc_worker_ids)
 
 
 def test_reconcile_workers_empty_short_circuits():
     provider, _ = _provider_with_stub()
-    assert provider.reconcile_workers([], {}, use_reconcile_rpc=True) == []
-    assert provider.reconcile_workers([], {}, use_reconcile_rpc=False) == []
+    assert provider.reconcile_workers([], {}, rpc_worker_ids={WorkerId(_W1)}) == []
+    assert provider.reconcile_workers([], {}, rpc_worker_ids=set()) == []
 
 
-# --- New wire (use_reconcile_rpc=True) ---------------------------------------
+# --- New wire (worker in rpc_worker_ids) -------------------------------------
 
 
 def test_reconcile_rpc_forwards_observations_and_skips_legacy_wire():
@@ -554,7 +555,7 @@ def test_reconcile_rpc_failure_returns_error_and_empty_observations():
     assert list(results[0].observations) == []
 
 
-# --- Legacy wire (use_reconcile_rpc=False) -----------------------------------
+# --- Legacy wire (worker not in rpc_worker_ids) ------------------------------
 
 
 def test_legacy_wire_splits_desired_into_start_expected_stop():
@@ -573,7 +574,7 @@ def test_legacy_wire_splits_desired_into_start_expected_stop():
         ],
     )
 
-    results = provider.reconcile_workers([plan], {WorkerId(_W1): _W1_ADDR}, use_reconcile_rpc=False)
+    results = provider.reconcile_workers([plan], {WorkerId(_W1): _W1_ADDR}, rpc_worker_ids=set())
 
     assert len(stub.start_calls) == 1
     started = list(stub.start_calls[0].tasks)
@@ -686,8 +687,27 @@ def _apply_observations(
     state: ControllerTransitions,
     worker_id: str,
     observations: list[worker_pb2.Worker.AttemptObservation],
+    *,
+    plan: WorkerReconcilePlan | None = None,
 ):
-    plan = _make_plan(worker_id)
+    """Apply observations under a plan that requests them by default.
+
+    The controller drops observations whose attempt is not in the per-worker
+    plan (see ``_filter_observations_to_plan``). Tests focused on observation
+    semantics get a plan that asks for every supplied observation; tests that
+    need to exercise the filter pass an explicit ``plan``.
+    """
+    if plan is None:
+        desired = [
+            worker_pb2.Worker.DesiredAttempt(
+                attempt_uid=obs.attempt_uid,
+                run=worker_pb2.Worker.AttemptSpec(),
+                task_id=obs.task_id,
+                attempt_id=obs.attempt_id,
+            )
+            for obs in observations
+        ]
+        plan = _make_plan(worker_id, desired=desired)
     result = ReconcileResult(worker_id=WorkerId(worker_id), observations=observations, error=None)
     with state._db.transaction() as cur:
         return state.apply_reconcile_result(cur, plan, result, _NOW)
@@ -826,6 +846,52 @@ def test_apply_result_on_unknown_worker_is_a_noop():
         result = _apply_observations(state, "ghost-worker", [])
         assert result.tasks_to_kill == set()
         assert result.task_kill_workers == {}
+
+
+def test_observation_outside_plan_is_dropped():
+    """An observation whose attempt is not in the per-worker plan is dropped.
+
+    Defends against the prod waste case: an old or out-of-sync worker
+    volunteering observations for attempts the controller has forgotten about.
+    Each accepted observation would otherwise drive a DB write.
+    """
+    with make_controller_state() as state:
+        live_task, live_attempt = _setup_running_task(state)
+
+        # The plan only desires the live attempt; the worker also sends a
+        # terminal observation for a stale attempt the controller never asked
+        # about.
+        stale_task = _task_id("stale-history")
+        plan = _make_plan(_W1, desired=[_desired_run(live_task, live_attempt, spec=None)])
+        observations = [
+            _obs(live_task, live_attempt, job_pb2.TASK_STATE_RUNNING),
+            _obs(stale_task, 0, job_pb2.TASK_STATE_SUCCEEDED, exit_code=0),
+        ]
+        _apply_observations(state, _W1, observations, plan=plan)
+
+        # Live attempt's RUNNING was applied; stale observation was dropped
+        # without raising even though the attempt has no row.
+        assert query_task(state, live_task).state == job_pb2.TASK_STATE_RUNNING
+        assert query_task(state, stale_task) is None
+
+
+def test_observation_inside_plan_matches_by_composite_when_uid_empty():
+    """An observation with empty UID is kept when its composite is in the plan.
+
+    Covers the legacy wire and pre-UID adopted attempts whose observations
+    carry an empty ``attempt_uid`` but a valid composite key.
+    """
+    with make_controller_state() as state:
+        task_id, attempt_id = _setup_running_task(state)
+        # Plan carries the desired attempt; observation has empty UID.
+        plan = _make_plan(_W1, desired=[_desired_run(task_id, attempt_id, spec=None)])
+        _apply_observations(
+            state,
+            _W1,
+            [_obs(task_id, attempt_id, job_pb2.TASK_STATE_SUCCEEDED, exit_code=0)],
+            plan=plan,
+        )
+        assert query_task(state, task_id).state == job_pb2.TASK_STATE_SUCCEEDED
 
 
 # --- Coscheduled cascade ----------------------------------------------------
@@ -1020,9 +1086,9 @@ class _ScriptedProvider:
     the right wire was selected and the right plans were dispatched.
     """
 
-    use_reconcile_rpc_expected: bool
+    rpc_worker_ids_expected: set[WorkerId]
     script: list[Any] = field(default_factory=list)
-    calls: list[tuple[list[WorkerReconcilePlan], dict, bool]] = field(default_factory=list)
+    calls: list[tuple[list[WorkerReconcilePlan], dict, set[WorkerId]]] = field(default_factory=list)
 
     def get_process_status(self, *_args, **_kwargs):
         raise NotImplementedError
@@ -1036,11 +1102,11 @@ class _ScriptedProvider:
     def ping_workers(self, workers):
         return []
 
-    def reconcile_workers(self, plans, addresses, *, use_reconcile_rpc):
-        self.calls.append((list(plans), dict(addresses), use_reconcile_rpc))
+    def reconcile_workers(self, plans, addresses, *, rpc_worker_ids):
+        self.calls.append((list(plans), dict(addresses), set(rpc_worker_ids)))
         assert (
-            use_reconcile_rpc == self.use_reconcile_rpc_expected
-        ), f"expected use_reconcile_rpc={self.use_reconcile_rpc_expected}, got {use_reconcile_rpc}"
+            set(rpc_worker_ids) == self.rpc_worker_ids_expected
+        ), f"expected rpc_worker_ids={self.rpc_worker_ids_expected}, got {set(rpc_worker_ids)}"
         tick = len(self.calls) - 1
         responder = self.script[tick] if tick < len(self.script) else (lambda plan: [])
         return [ReconcileResult(worker_id=p.worker_id, observations=responder(p), error=None) for p in plans]
@@ -1072,8 +1138,9 @@ def test_e2e_converges_to_succeeded_through_both_wires(flag, make_controller):
         lambda plan: _observation_for_all_run(plan, job_pb2.TASK_STATE_RUNNING),
         lambda plan: _observation_for_all_run(plan, job_pb2.TASK_STATE_SUCCEEDED, exit_code=0),
     ]
-    provider = _ScriptedProvider(use_reconcile_rpc_expected=flag, script=script)
-    ctrl = make_controller(provider=provider, reconcile_rpc_enabled=flag)
+    expected_ids = {WorkerId(_W1)} if flag else set()
+    provider = _ScriptedProvider(rpc_worker_ids_expected=expected_ids, script=script)
+    ctrl = make_controller(provider=provider, reconcile_rpc_prefix="*" if flag else None)
     state = ctrl._transitions
 
     wid = register_worker(state, _W1, _W1_ADDR, make_worker_metadata())
@@ -1112,8 +1179,8 @@ def test_e2e_missing_observation_fails_attempt_with_worker_lost_spec(make_contro
         lambda _plan: [],  # tick 1: ASSIGNED dispatch
         lambda plan: _observation_for_all_run(plan, job_pb2.TASK_STATE_MISSING),
     ]
-    provider = _ScriptedProvider(use_reconcile_rpc_expected=True, script=script)
-    ctrl = make_controller(provider=provider, reconcile_rpc_enabled=True)
+    provider = _ScriptedProvider(rpc_worker_ids_expected={WorkerId(_W1)}, script=script)
+    ctrl = make_controller(provider=provider, reconcile_rpc_prefix="*")
     state = ctrl._transitions
 
     wid = register_worker(state, _W1, _W1_ADDR, make_worker_metadata())
@@ -1167,8 +1234,8 @@ def test_e2e_converges_with_uid_echoing_worker(make_controller):
         lambda plan: _observation_for_all_run_uid_only(plan, job_pb2.TASK_STATE_RUNNING),
         lambda plan: _observation_for_all_run_uid_only(plan, job_pb2.TASK_STATE_SUCCEEDED, exit_code=0),
     ]
-    provider = _ScriptedProvider(use_reconcile_rpc_expected=True, script=script)
-    ctrl = make_controller(provider=provider, reconcile_rpc_enabled=True)
+    provider = _ScriptedProvider(rpc_worker_ids_expected={WorkerId(_W1)}, script=script)
+    ctrl = make_controller(provider=provider, reconcile_rpc_prefix="*")
     state = ctrl._transitions
 
     wid = register_worker(state, _W1, _W1_ADDR, make_worker_metadata())
@@ -1192,3 +1259,29 @@ def test_e2e_converges_with_uid_echoing_worker(make_controller):
     task_final = query_task(state, task_id)
     assert task_final.state == job_pb2.TASK_STATE_SUCCEEDED
     assert query_job(state, task_final.job_id).state == job_pb2.JOB_STATE_SUCCEEDED
+
+
+def test_reconcile_rpc_prefix_selects_only_matching_workers(make_controller):
+    """``reconcile_rpc_prefix`` routes only prefix-matching workers via the RPC wire.
+
+    Registers two workers (``worker-1`` and ``worker-2``), sets the prefix to
+    ``"worker-1"``, and asserts the controller hands the provider exactly
+    ``{worker-1}`` as the RPC-enabled set. The assertion lives inside
+    ``_ScriptedProvider.reconcile_workers``; reaching the end of the batch
+    without AssertionError is the proof.
+    """
+    provider = _ScriptedProvider(
+        rpc_worker_ids_expected={WorkerId(_W1)},
+        script=[lambda _plan: []],
+    )
+    ctrl = make_controller(provider=provider, reconcile_rpc_prefix="worker-1")
+    state = ctrl._transitions
+
+    register_worker(state, _W1, _W1_ADDR, make_worker_metadata())
+    register_worker(state, _W2, f"{_W2}:8080", make_worker_metadata())
+
+    ctrl._reconcile_worker_batch()
+
+    assert len(provider.calls) == 1
+    _, _, rpc_ids = provider.calls[0]
+    assert rpc_ids == {WorkerId(_W1)}

--- a/lib/iris/tests/cluster/worker/test_reconcile.py
+++ b/lib/iris/tests/cluster/worker/test_reconcile.py
@@ -283,6 +283,78 @@ def test_terminal_attempt_retained_and_observed_on_later_reconcile(worker, mock_
     assert obs[(task_id, 0)].state == job_pb2.TASK_STATE_SUCCEEDED
 
 
+def test_terminal_attempt_not_in_desired_is_not_observed(worker, mock_runtime):
+    """Terminal local history the controller did not ask about is NOT emitted.
+
+    Reproduces the prod waste case where a worker emitted 287 observations,
+    one for the desired RUNNING attempt and 286 for terminal-state attempts
+    the controller had long since forgotten about. Each unwanted observation
+    would otherwise cost a DB write on the apply side.
+    """
+    finished_task_id = _task_id("finished")
+    finished_req = create_run_task_request(task_id=finished_task_id, attempt_id=0)
+    live_task_id = _task_id("live")
+    live_req = create_run_task_request(task_id=live_task_id, attempt_id=0)
+
+    finished_handle = create_mock_container_handle(
+        status_sequence=[ContainerStatus(phase=ContainerPhase.STOPPED, exit_code=0)],
+    )
+    live_handle = create_mock_container_handle(
+        status_sequence=[ContainerStatus(phase=ContainerPhase.RUNNING)] * 100,
+    )
+    mock_runtime.create_container = Mock(side_effect=[finished_handle, live_handle])
+
+    # Drive the finished task to terminal state with controller still asking
+    # about it, then drop it from the desired set on the next tick.
+    _reconcile(worker, [_run_desired(finished_task_id, 0, run_request=finished_req)])
+    finished = worker.get_task(finished_task_id, attempt_id=0)
+    assert finished is not None
+    finished.thread.join(timeout=5.0)
+    assert finished.status == job_pb2.TASK_STATE_SUCCEEDED
+
+    # Start a live task; reconcile with ONLY the live task in the desired set.
+    response = _reconcile(worker, [_run_desired(live_task_id, 0, run_request=live_req)])
+
+    obs = _observations_by_key(response)
+    assert (live_task_id, 0) in obs, "Live attempt in desired set must be observed"
+    assert (
+        finished_task_id,
+        0,
+    ) not in obs, "Terminal attempt outside desired set must NOT be observed (this is the prod waste case)"
+    # The terminal task is still retained locally — only the observation is suppressed.
+    assert worker.get_task(finished_task_id, attempt_id=0) is finished
+
+    worker.kill_task(live_task_id)
+    live = worker.get_task(live_task_id, attempt_id=0)
+    if live and live.thread:
+        live.thread.join(timeout=5.0)
+
+
+def test_zombie_kill_emits_observation(worker, mock_runtime):
+    """A zombie being killed this tick is observed so the controller sees the kill."""
+    task_id = _task_id("zombie-obs")
+    run_req = create_run_task_request(task_id=task_id, attempt_id=0)
+
+    mock_runtime.create_container = Mock(
+        return_value=create_mock_container_handle(
+            status_sequence=[ContainerStatus(phase=ContainerPhase.RUNNING)] * 100,
+        )
+    )
+
+    worker.submit_task(run_req)
+    task = worker.get_task(task_id, attempt_id=0)
+    assert task is not None
+    wait_for_condition(lambda: task.status == job_pb2.TASK_STATE_RUNNING)
+
+    # Empty desired — the running attempt is a zombie and must be observed so
+    # the controller can confirm the kill it implicitly requested.
+    response = _reconcile(worker, [])
+    obs = _observations_by_key(response)
+    assert (task_id, 0) in obs, "Zombie kill must be reported to the controller"
+
+    task.thread.join(timeout=5.0)
+
+
 def test_reconcile_response_includes_worker_id(worker):
     """ReconcileResponse always includes the worker_id."""
     response = _reconcile(worker, [])


### PR DESCRIPTION
## Summary

- **Worker (`WorkerLifecycle.handle_reconcile`)**: emit an `AttemptObservation` only for attempts that resolve to a `DesiredAttempt` in the request, or for zombies the worker is killing this tick (so the controller can confirm the kill it implicitly requested). Terminal local history outside the desired set is suppressed.
- **Controller (`transitions.apply_reconcile_result`)**: drop observations whose `attempt_uid`/composite is not in the per-worker `WorkerReconcilePlan` we just sent. Defense in depth against an old or out-of-sync worker; drops are logged at DEBUG, not INFO.

## Why

In a marin production tick we observed one worker emitting **287 `AttemptObservation`s for 1 desired RUNNING attempt** — the other 286 were terminal-state local history (states `{6:1, 4:279, 5:6, 3:1}`) the controller had long since forgotten about. Each accepted observation drives a DB write on the apply side, so this is wasted both on the wire and downstream.

## Legacy-wire compatibility

The legacy synthesizer (`_legacy_results_to_reconcile_results` in `worker_provider.py`) only produces observations sourced from `expected_tasks` (built from the same plan's run intents) and `start_tasks` rejection acks (also keyed by run-intent `task_id`). All those observations match the plan's composite set, so Fix 2's filter is a no-op on the legacy wire.

## Test plan

- [x] `uv run pytest lib/iris/tests/cluster/controller/test_reconcile.py lib/iris/tests/cluster/worker/` — 170 passed.
- [x] New worker tests: `test_terminal_attempt_not_in_desired_is_not_observed` (the prod waste case) and `test_zombie_kill_emits_observation` (controller still sees zombie kills).
- [x] New controller tests: `test_observation_outside_plan_is_dropped` and `test_observation_inside_plan_matches_by_composite_when_uid_empty` (legacy / pre-UID adopted attempts).
- [x] Existing tests `test_e2e_converges_to_succeeded_through_both_wires[True/False]` exercise the full path on both wires and pass unchanged.
- [x] `./infra/pre-commit.py --files <changed> --fix` clean.