### PR TITLE
[SFT] Add WebInstruct-verified dataset

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -26,18 +26,19 @@ Current datasets:
 11. cognitivecomputations/dolphin-r1-reasoning
 12. open-r1/OpenThoughts-114k-math
 13. bespokelabs/Bespoke-Stratos-17k
-14. HuggingFaceTB/smoltalk
-15. PrimeIntellect/verifiable-math-problems
-16. PrimeIntellect/SYNTHETIC-2-SFT-verified
-17. sherryy/tulu-3-sft-personas-instruction-following-expanded
-18. facebook/natural_reasoning
-19. HuggingFaceTB/smoltalk2
-20. nvidia/Nemotron-Post-Training-Dataset-v1
-21. nvidia/Nemotron-Post-Training-Dataset-v2
-22. HuggingFaceH4/no_robots
-23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
-24. lm-provers/FineProofs-SFT
-25. lm-provers/FineProofs-SFT/proof-only
+14. TIGER-Lab/WebInstruct-verified
+15. HuggingFaceTB/smoltalk
+16. PrimeIntellect/verifiable-math-problems
+17. PrimeIntellect/SYNTHETIC-2-SFT-verified
+18. sherryy/tulu-3-sft-personas-instruction-following-expanded
+19. facebook/natural_reasoning
+20. HuggingFaceTB/smoltalk2
+21. nvidia/Nemotron-Post-Training-Dataset-v1
+22. nvidia/Nemotron-Post-Training-Dataset-v2
+23. HuggingFaceH4/no_robots
+24. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
+25. lm-provers/FineProofs-SFT
+26. lm-provers/FineProofs-SFT/proof-only
 """
 
 import dataclasses
@@ -244,6 +245,10 @@ class ReasoningToChatKwargs:
 
 reasoning_to_chat_kwargs = ReasoningToChatKwargs()
 
+WEBINSTRUCT_VERIFIED_HF_ID = "TIGER-Lab/WebInstruct-verified"
+WEBINSTRUCT_VERIFIED_REVISION = "3e8a350b3a935d68fe70bdf379692500abc9ff51"
+WEBINSTRUCT_VERIFIED_METADATA_COLUMNS = ["id", "answer_type", "category", "difficulty"]
+
 SYNTHETIC2_SFT_VERIFIED_HF_ID = "PrimeIntellect/SYNTHETIC-2-SFT-verified"
 SYNTHETIC2_SFT_VERIFIED_REVISION = "fce247fe48af8ff9624fb51d1de63aa1b2332cef"
 SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS = ["problem_id", "task_type", "reward"]
@@ -373,6 +378,18 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         ),
         metadata_columns=[],
         name="bespokelabs/Bespoke-Stratos-17k",
+    ),
+    WEBINSTRUCT_VERIFIED_HF_ID: InstructionDatasetConfig(
+        hf_dataset_id=WEBINSTRUCT_VERIFIED_HF_ID,
+        revision=WEBINSTRUCT_VERIFIED_REVISION,
+        adapter=instruction_response_adapter(
+            instruction_column="question",
+            response_column="answer",
+        ),
+        metadata_columns=WEBINSTRUCT_VERIFIED_METADATA_COLUMNS,
+        name=WEBINSTRUCT_VERIFIED_HF_ID,
+        subsets=["default"],
+        splits=["train"],
     ),
     "HuggingFaceTB/smoltalk": InstructionDatasetConfig(
         hf_dataset_id="HuggingFaceTB/smoltalk",

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -12,6 +12,9 @@ from experiments.posttrain.instruction_datasets import (
     SYNTHETIC2_SFT_VERIFIED_HF_ID,
     SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
     SYNTHETIC2_SFT_VERIFIED_REVISION,
+    WEBINSTRUCT_VERIFIED_HF_ID,
+    WEBINSTRUCT_VERIFIED_METADATA_COLUMNS,
+    WEBINSTRUCT_VERIFIED_REVISION,
     get_instruction_dataset,
 )
 
@@ -23,6 +26,18 @@ SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
         {"role": "user", "content": "Write Python code to count the intersection of two sets."},
         {"role": "assistant", "content": "<think>Use set intersection.</think>\n```python\nprint(len(a & b))\n```"},
     ],
+}
+
+WEBINSTRUCT_VERIFIED_SAMPLE = {
+    "id": "1177521",
+    "question": (
+        "Write a formula for the fourth degree polynomial p(x) whose graph is symmetric about the y-axis, "
+        "which has a y-intercept of 10, and global maxima at (3,253) and (-3,253)."
+    ),
+    "answer": "y(x) = -3x^4 + 54x^2 + 10",
+    "answer_type": "Expression",
+    "category": "Mathematics",
+    "difficulty": "University",
 }
 
 
@@ -104,4 +119,37 @@ def test_synthetic2_sft_verified_step_transforms_chat_rows():
         "problem_id": "prime_rl_code_21747",
         "task_type": "prime_rl_code",
         "reward": 1.0,
+    }
+
+
+def test_webinstruct_verified_step_transforms_question_answer_rows():
+    step = get_instruction_dataset(WEBINSTRUCT_VERIFIED_HF_ID)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    result = transform_row(WEBINSTRUCT_VERIFIED_SAMPLE, cfg, adapter)
+
+    assert result is not None
+    assert step.name == "documents/TIGER-Lab/WebInstruct-verified"
+    assert step.override_output_path is not None
+    assert step.override_output_path.startswith(
+        f"documents/TIGER-Lab--WebInstruct-verified-{WEBINSTRUCT_VERIFIED_REVISION}-"
+    )
+    assert unwrap_versioned_value(cfg.source) == WEBINSTRUCT_VERIFIED_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == WEBINSTRUCT_VERIFIED_REVISION
+    assert unwrap_versioned_value(cfg.subsets) == ["default"]
+    assert unwrap_versioned_value(cfg.splits) == ["train"]
+    assert unwrap_versioned_value(cfg.metadata_columns) == WEBINSTRUCT_VERIFIED_METADATA_COLUMNS
+    assert adapter.dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE
+    assert adapter.instruction_column == "question"
+    assert adapter.response_column == "answer"
+    assert result.source == WEBINSTRUCT_VERIFIED_HF_ID
+    assert [message.role for message in result.messages] == ["user", "assistant"]
+    assert result.messages[0].content == WEBINSTRUCT_VERIFIED_SAMPLE["question"]
+    assert result.messages[1].content == WEBINSTRUCT_VERIFIED_SAMPLE["answer"]
+    assert result.metadata == {
+        "id": "1177521",
+        "answer_type": "Expression",
+        "category": "Mathematics",
+        "difficulty": "University",
     }


### PR DESCRIPTION
Register TIGER-Lab/WebInstruct-verified in the post-training instruction dataset registry with the pinned verified revision, default train split, question-to-answer adapter, and source metadata for answer type, category, difficulty, and id. Adds a registry-to-transform test that exercises the generated ExecutorStep and verifies the row becomes user/assistant messages with preserved metadata.

Validated with focused and adjacent instruction dataset tests plus pre-commit.