### PR TITLE
[Grug] Add DeepEP MoE backend

### DIFF
--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -798,3 +798,21 @@
 - Next action:
   - Resubmitted the same payload-order diagnostic without the unsupported `shard_map` keyword as B200 Slurm job `50053`.
   - Use job `50053` to decide whether the remaining full-MoE mismatch is in exchange ordering or return/combine logic.
+
+### 2026-05-22 01:08 - B200 payload-order check hit shard_map output spec mismatch
+- Experiment ID: `B200-EP-025`
+- Hypothesis:
+  - The corrected two-GPU payload-order diagnostic should isolate whether CUDA `ragged_all_to_all` preserves token-rank payload order.
+- Command:
+  - B200 Slurm job `50053`.
+  - Code commit: `9887b433b09cf4e20e80de0c4795f1ebd0934e5c`.
+  - Two-GPU payload-order diagnostic for x, top-k metadata, weights, and source-token metadata.
+- Result:
+  - Job `50053` allocated two B200 GPUs but failed before running the exchange:
+    - failure: `ValueError: shard_map applied to the function '<lambda>' was given out_specs which require replication which can't be statically inferred`
+  - No `B200_PAYLOAD_CHECK` result was emitted.
+- Interpretation:
+  - This is still a diagnostic-wrapper issue, not payload-order evidence.
+  - The local output sharding spec was too narrow for the inferred data/expert variation in the returned `recv_sizes`.
+- Next action:
+  - Resubmitted the payload-order diagnostic with output specs that include the data and expert mesh axes where inference requires them as B200 Slurm job `50059`.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -353,8 +353,36 @@
     - `tokens=524288`, `shared_expert_dim=2048`, DeepEP only
     - `tokens=786432`, `shared_expert_dim=0`, both kernels
 - Result:
-  - Pending at submission.
+  - In progress.
+  - First observed case:
+    - `tokens=393216`, `shared_expert_dim=2048`, kernel `current`: no result line, exited `134`.
+    - The error log showed a collective rendezvous termination after an all-gather; the script continued to the next case.
+  - Remaining cases are still pending or running.
 - Interpretation:
-  - This should separate memory-envelope failure from latency crossover and preserve any later case results even if one case fails.
+  - This is already below the `524288` shared-expert OOM point, so the current ring boundary for shared-expert `topk=8` appears to be at or below `393216` tokens in this harness.
+  - The per-case timeout/script structure is working: a failed current case did not stop the DeepEP follow-up.
 - Next action:
   - Watch job `49775`.
+
+### 2026-05-21 13:25 - Submit larger expert-size sweep
+- Experiment ID: `B200-EP-012`
+- Hypothesis:
+  - Increasing per-expert MLP width should shift pressure toward local expert compute and memory, giving a clearer signal about whether the remaining B200 gap is transport/scheduling or expert-kernel dominated.
+- Command:
+  - Submitted job `49779` with dependency `afterany:49775`.
+  - Benchmark command family: `bench_moe_hillclimb.py --hidden 5120 --mlp-dim 4096 --experts 64 --topk 8 --distribution random --bench-pass forward_backward --ep-list 8 --warmup 1 --iters 3`
+  - Each case has a per-case timeout.
+- Config:
+  - hardware target: 8 B200 GPUs on one NVLinked node
+  - kernels: `current`, `deepep_transport_capped_prewarmed`
+  - shapes:
+    - `tokens=131072`, `shared_expert_dim=0`, both kernels
+    - `tokens=131072`, `shared_expert_dim=2048`, both kernels
+    - `tokens=262144`, `shared_expert_dim=0`, both kernels
+    - `tokens=262144`, `shared_expert_dim=2048`, both kernels
+- Result:
+  - Pending at submission.
+- Interpretation:
+  - This is a conservative expert-size push: larger `mlp_dim`, but token counts stay below the known shared-expert OOM edge.
+- Next action:
+  - Let job `49775` finish first, then watch job `49779`.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -737,3 +737,25 @@
   - B200 CUDA correctness remains pending on jobs `49916` and `49917`.
 - Next action:
   - Wait for the B200 correctness jobs. If they remain pending, use the held GPU debug allocation once available to inspect full `token_ragged_a2a` value/gradient mismatch directly.
+
+### 2026-05-21 17:54 - Submit TPU32 token-ragged benchmark
+- Experiment ID: `B200-EP-022`
+- Hypothesis:
+  - A 32-chip TPU run can test whether token-level `ragged_all_to_all` has useful scaling as a transport pattern, independent of GPU-only DeepEP kernels.
+- Code:
+  - Added `.agents/scripts/bench_moe_hillclimb_tpu_pure_layout.py`.
+  - The wrapper initializes JAX distributed under Iris and replaces the GPU-only DeepEP layout helper with a pure-JAX token-to-rank layout implementation before calling the existing MoE hillclimb benchmark.
+- Command:
+  - Submitted Iris job `/dlwh/token-ragged-tpu32-v5lite`.
+  - TPU type: `v5litepod-32`, 8 Iris replicas.
+  - Benchmark command family:
+    - `bench_moe_hillclimb_tpu_pure_layout.py --tokens 131072 --hidden 2048 --mlp-dim 2048 --experts 256 --shared-expert-dim 0 --topk 8 --distribution random --bench-pass forward_backward --ep-list 32 --warmup 1 --iters 3 --dtype bfloat16`
+  - Kernels:
+    - `stream_ring`
+    - `token_ragged_a2a`
+- Result:
+  - Submitted and pending/running state not yet recorded.
+- Interpretation:
+  - This is not a DeepEP parity measurement. It is a TPU transport-scaling probe for token-rank ragged exchange versus the stream-ring baseline at `topk=8`.
+- Next action:
+  - Babysit `/dlwh/token-ragged-tpu32-v5lite`; if it fails during compile or runtime, fall back to a payload-only token ragged A2A microbenchmark on the same TPU topology.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -360,11 +360,15 @@
     - `tokens=393216`, `shared_expert_dim=2048`, kernel `deepep_transport_capped_prewarmed`: no result line, exited `124`.
       - The per-case timeout fired after 15 minutes.
     - `tokens=524288`, `shared_expert_dim=2048`, kernel `deepep_transport_capped_prewarmed`: running at the time of observation.
+      - No result line, exited `124`.
+      - The per-case timeout fired after large GPU OOM allocation failures and collective rendezvous waits.
+    - `tokens=786432`, `shared_expert_dim=0`, kernel `current`: running at the time of observation.
       - The error log is already showing large GPU OOM allocation failures and collective rendezvous waits.
-  - Remaining no-shared `786432` cases are still pending.
+  - Remaining no-shared DeepEP `786432` case is still pending.
 - Interpretation:
   - This is already below the `524288` shared-expert OOM point, so the usable shared-expert `topk=8` boundary appears to be below `393216` tokens in this harness for both current ring and restored DeepEP.
   - The shared-expert failure mode is no longer a small latency gap; it is memory/runtime robustness at high token count.
+  - The no-shared `786432` current case is also beyond the current memory envelope in this harness; `524288` no-shared remains the largest completed no-shared point so far.
   - The per-case timeout/script structure is working: a failed current case did not stop the DeepEP follow-up.
 - Next action:
   - Watch job `49775`.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -916,3 +916,62 @@
   - The remaining reproduction gap is likely tied to production-ish BF16/topk=8 shape, capacity/segment pressure, or the benchmark's `stream_ring` comparison path rather than the basic token-rank protocol.
 - Next action:
   - Run a reduced BF16/topk=8 reproduction that compares `token_ragged_a2a` and `stream_ring` at a smaller but less toy shape, then bisect shape/capacity if the mismatch appears.
+
+### 2026-05-22 08:40 - Reduced BF16 top-k=8 reproduction shows large absolute mismatch
+- Experiment ID: `B200-EP-031`
+- Hypothesis:
+  - The full `token_ragged_a2a` mismatch may require a less toy BF16/top-k=8 shape even though the tiny float32 diagnostics passed.
+- Command:
+  - B200 Slurm jobs `50133` and `50134`.
+  - Code commit: `9887b433b09cf4e20e80de0c4795f1ebd0934e5c`.
+  - Shape:
+    - EP: `2`
+    - tokens: `8192`
+    - hidden: `1024`
+    - MLP dim: `1024`
+    - experts: `64`
+    - top-k: `8`
+    - shared expert dim: `0`
+    - dtype: `bfloat16`
+  - Compared `token_ragged_a2a` against `stream_ring` for forward output and loss gradients.
+- Result:
+  - Job `50133` failed in the measurement script while taking a max over zero-size shared-expert gradients.
+  - Corrected job `50134` completed successfully:
+    - `B200_BF16_REPRO tokens=8192 hidden=1024 mlp_dim=1024 experts=64 topk=8 out_max_abs=5.120000e+02 grad_max_abs=6.000000e+00 stream_loss=7.645470e+07 token_loss=7.645422e+07`
+- Interpretation:
+  - This reduced BF16/top-k=8 shape reproduces the large absolute error seen in the original B200 sanity checks.
+  - The losses are still very close in relative terms, so the next question is whether this is true semantic mismatch or BF16 numeric amplification from unscaled random weights and different ragged matmul ordering.
+- Next action:
+  - Run a normalized-error follow-up that prints output norms, relative error, and a scaled-weight case. If relative error stays small and scaled weights reduce absolute error, treat this as a tolerance/reference issue; if not, bisect shape and capacity.
+
+### 2026-05-22 08:40 - BF16 mismatch scales with output magnitude
+- Experiment ID: `B200-EP-032`
+- Hypothesis:
+  - If the reduced BF16/top-k=8 mismatch is numeric amplification rather than token-routing semantics, the relative error should stay small and the absolute error should shrink when weights are scaled down.
+- Command:
+  - B200 Slurm job `50136`.
+  - Code commit: `9887b433b09cf4e20e80de0c4795f1ebd0934e5c`.
+  - Same EP2 BF16/top-k=8 shape as job `50134`.
+  - Compared unscaled random weights with weights scaled by `1 / sqrt(hidden)`.
+- Result:
+  - Job `50136` completed successfully.
+  - Unscaled:
+    - output max-absolute error: `5.120000e+02`
+    - stream max absolute output: `5.248000e+04`
+    - diff RMS: `3.349279e+01`
+    - stream RMS: `8.743832e+03`
+    - relative L2: `3.830448e-03`
+    - relative max: `9.756098e-03`
+  - Scaled by `1 / sqrt(hidden)`:
+    - output max-absolute error: `1.562500e-02`
+    - stream max absolute output: `1.375000e+00`
+    - diff RMS: `8.601259e-04`
+    - stream RMS: `2.249349e-01`
+    - relative L2: `3.823887e-03`
+    - relative max: `1.136364e-02`
+- Interpretation:
+  - The large absolute BF16 mismatch scales with output magnitude. Relative RMS error is stable at about `0.38%` across unscaled and scaled weights.
+  - Combined with the passing payload, no-GMM, identity `ragged_dot`, and tiny full-MLP checks, this points to BF16 numeric differences between the token-rank path and stream-ring path, not a semantic token routing bug.
+  - The correctness gate should use relative/error-norm checks for BF16, or use scaled/model-like initialization for absolute checks.
+- Next action:
+  - Treat `token_ragged_a2a` as semantically correct under BF16 relative tolerance and resume performance work. The next useful B200 run is a production-ish timing comparison, but prior timing already showed the current pure-JAX token-ragged path is much slower than stream-ring and DeepEP, so optimization should focus on reducing the number of ragged exchanges or using a fused/custom transport.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -136,3 +136,30 @@
   - The next route to 5-10% of DeepEP is not incremental `ragged_all_to_all` tuning; it requires a DeepEP baseline and then a transport/full-block replacement candidate.
 - Next action:
   - Recover a runnable DeepEP full-block `forward_backward` baseline on the same 4-GPU shape.
+
+### 2026-05-21 11:07 - Resurrect historical JAX DeepEP baseline on B200
+- Experiment ID: `B200-EP-005`
+- Hypothesis:
+  - The last known runnable JAX DeepEP bridge can still provide a same-shape 4-GPU anchor if patched for Blackwell codegen and current import constraints.
+- Command:
+  - Submitted job `49680`, then job `49681` after patching the historical checkout.
+  - Benchmark command family: `bench_moe_hillclimb.py --tokens 32768 --hidden 5120 --mlp-dim 2560 --experts 32 --shared-expert-dim 0 --topk 2 --distribution random --bench-pass forward_backward --kernel deepep_transport_capped_prewarmed --ep-list 4 --warmup 1 --iters 3`
+- Config:
+  - hardware: 4 B200 GPUs on one NVLinked node
+  - historical Marin commit: `95e2e589c`
+  - DeepEP source ref: `7febc6e`
+  - scratch-only compatibility patches:
+    - allow `sm_100` / Torch arch `10.0` in the transport FFI build
+    - avoid importing optional orchestration dependencies from the historical package root
+- Result:
+  - Job `49680` failed before benchmark due to a missing optional orchestration dependency in the historical package root.
+  - Job `49681` completed with exit code `0`.
+  - Exact caps: `max_recv_tokens=14592`, `max_local_assignments=16512`, `recv_factor=2.245614`, `assign_factor=3.968992`.
+  - `deepep_transport_capped_prewarmed`, `ep=4`, `forward_backward`: `0.024093 s`, `1.360M tok/s`.
+  - The run emitted CUDA teardown warnings after the result line; Slurm still recorded the job as completed successfully.
+- Interpretation:
+  - The historical JAX DeepEP bridge is now runnable on B200 for the 4-GPU full-block `forward_backward` shape.
+  - At this shape, current-tree `ring` is faster than this resurrected historical JAX DeepEP baseline: `0.007157 s` vs `0.024093 s`, or about `3.37x` higher throughput.
+  - This should not be treated as a final DeepEP parity win. It compares current `ring` against an old JAX bridge plus scratch-only compatibility patches, not a production-quality current DeepEP/Megatron full-block reference.
+- Next action:
+  - Make the DeepEP baseline durable in the current branch or build a fairer current DeepEP reference before spending time on a Triton/CUTLASS transport replacement.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -90,3 +90,25 @@
     - `ragged_all_to_all`, `forward`
     - `ring`, `forward_backward`
     - `ragged_all_to_all`, `forward_backward`
+
+### 2026-05-21 10:54 - Submit first B200 EP smoke
+- Experiment ID: `B200-EP-003`
+- Hypothesis:
+  - A one-node 8-GPU smoke can establish whether current `ring` and `ragged_all_to_all` both run on B200 before scaling the matrix.
+- Command:
+  - Submitted a Slurm wrapper from the isolated `research/b200-grug-ep` checkout.
+  - Benchmark command family: `.agents/scripts/bench_grug_ep.py --tokens 32768 --hidden-dim 5120 --intermediate-dim 2560 --local-experts 8 --topk 2 --num-devices 8 --warmup 1 --iters 3 --dtype bf16`
+- Config:
+  - first job: `49676`
+  - retry job: `49677`
+  - pass modes: `forward`, `forward_backward`
+  - implementations: `ring`, `ragged_all_to_all`
+- Result:
+  - Job `49676` failed before benchmark rows were emitted.
+  - The allocated node exposed only 7 B200 devices to JAX, and the benchmark rejected the requested 8-device mesh.
+  - The retry job `49677` was submitted with the bad node excluded and was pending on resources at last check.
+- Interpretation:
+  - The first failure is an infrastructure/device-health failure, not an EP performance result.
+  - The script's explicit device-count check did the right thing by refusing to benchmark a partial node.
+- Next action:
+  - Wait for retry job `49677`; if it runs cleanly, record JSON rows and then decide whether to test the full #5894 local-row shape.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -354,12 +354,17 @@
     - `tokens=786432`, `shared_expert_dim=0`, both kernels
 - Result:
   - In progress.
-  - First observed case:
+  - Observed cases:
     - `tokens=393216`, `shared_expert_dim=2048`, kernel `current`: no result line, exited `134`.
-    - The error log showed a collective rendezvous termination after an all-gather; the script continued to the next case.
-  - Remaining cases are still pending or running.
+      - The error log showed a collective rendezvous termination after an all-gather; the script continued to the next case.
+    - `tokens=393216`, `shared_expert_dim=2048`, kernel `deepep_transport_capped_prewarmed`: no result line, exited `124`.
+      - The per-case timeout fired after 15 minutes.
+    - `tokens=524288`, `shared_expert_dim=2048`, kernel `deepep_transport_capped_prewarmed`: running at the time of observation.
+      - The error log is already showing large GPU OOM allocation failures and collective rendezvous waits.
+  - Remaining no-shared `786432` cases are still pending.
 - Interpretation:
-  - This is already below the `524288` shared-expert OOM point, so the current ring boundary for shared-expert `topk=8` appears to be at or below `393216` tokens in this harness.
+  - This is already below the `524288` shared-expert OOM point, so the usable shared-expert `topk=8` boundary appears to be below `393216` tokens in this harness for both current ring and restored DeepEP.
+  - The shared-expert failure mode is no longer a small latency gap; it is memory/runtime robustness at high token count.
   - The per-case timeout/script structure is working: a failed current case did not stop the DeepEP follow-up.
 - Next action:
   - Watch job `49775`.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -685,3 +685,30 @@
   - The output-offset fix was necessary but not sufficient. The remaining bug is likely in token-level metadata ordering on the return path or in the local token-to-assignment expansion after dispatch.
 - Next action:
   - Stop timing `token_ragged_a2a` until it passes the two-GPU value/gradient check. Next debug step is an instrumented two-GPU toy case that compares token payload order, returned source-token order, and local assignment counts against the stream-ring/reference path.
+
+### 2026-05-21 17:00 - Isolate token ragged payload exchange on TPU
+- Experiment ID: `B200-EP-020`
+- Hypothesis:
+  - Before debugging the full `token_ragged_a2a` MoE path, isolate whether JAX `ragged_all_to_all` preserves the token-rank payload order and float metadata needed by the protocol.
+- Command:
+  - Ran a two-way TPU toy check that:
+    - builds deterministic token payloads, top-k expert ids, weights, and source-token ids;
+    - packs each token once per destination rank with `_pack_token_rank_payload`;
+    - exchanges x, top-k, weights, and source-token metadata with `jax.lax.ragged_all_to_all`;
+    - compares received rows against a NumPy reference ordering.
+- Config:
+  - TPU debug holder: single-host v5p-8
+  - toy shape: `ep_size=2`, `tokens_per_rank=32`, `hidden=8`, `num_experts=16`, `topk=4`
+  - metadata path: top-k and source-token ids encoded as `float32` payloads for this diagnostic
+- Result:
+  - Payload-only check passed:
+    - `TPU_PAYLOAD_CHECK max_abs=0.000000e+00`
+    - received sizes: `[[32, 32], [32, 32]]`
+  - A full end-to-end TPU check still failed before correctness comparison because the TPU Megablox GMM path hit a Mosaic compile error: `Bad lhs type` in the GMM accumulator matmul.
+  - B200 jobs `49916` and `49917` were still pending at the last queue check.
+- Interpretation:
+  - The token-rank `ragged_all_to_all` exchange ordering is correct for the isolated payload path, including the diagnostic float metadata path.
+  - The remaining full-MoE TPU blocker is separate from the exchange itself and is now the TPU GMM compile failure.
+  - This does not yet prove the B200 full `token_ragged_a2a` path correct; the pending B200 jobs are still needed for CUDA correctness and timing.
+- Next action:
+  - Use the held TPU to reduce the Megablox/Pallas GMM compile failure separately, while waiting for the B200 two-GPU correctness jobs.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -112,3 +112,27 @@
   - The script's explicit device-count check did the right thing by refusing to benchmark a partial node.
 - Next action:
   - Wait for retry job `49677`; if it runs cleanly, record JSON rows and then decide whether to test the full #5894 local-row shape.
+
+### 2026-05-21 11:00 - Back off to 4 GPUs and measure current EP backends
+- Experiment ID: `B200-EP-004`
+- Hypothesis:
+  - A 4-GPU full-block smoke can identify whether either checked-in EP backend is worth pursuing while full-node resources are unavailable.
+- Command:
+  - Canceled pending jobs `49677` and `49678`.
+  - Submitted job `49679`.
+  - Benchmark command family: `.agents/scripts/bench_grug_ep.py --tokens 32768 --hidden-dim 5120 --intermediate-dim 2560 --local-experts 8 --topk 2 --num-devices 4 --warmup 1 --iters 3 --dtype bf16`
+- Config:
+  - hardware: 4 B200 GPUs on one NVLinked node
+  - implementations: `ring`, `ragged_all_to_all`
+  - pass modes: `forward`, `forward_backward`
+- Result:
+  - `ring`, `forward`: `0.002853 s`, `11.485M tok/s`
+  - `ragged_all_to_all`, `forward`: `0.040758 s`, `0.804M tok/s`
+  - `ring`, `forward_backward`: `0.007157 s`, `4.579M tok/s`
+  - `ragged_all_to_all`, `forward_backward`: `0.083056 s`, `0.395M tok/s`
+- Interpretation:
+  - The checked-in JAX `ragged_all_to_all` backend is more than 10x slower than `ring` on this B200 slice.
+  - `ring` is the only current-tree baseline worth comparing against DeepEP or a new full-block Triton/CUTLASS path.
+  - The next route to 5-10% of DeepEP is not incremental `ragged_all_to_all` tuning; it requires a DeepEP baseline and then a transport/full-block replacement candidate.
+- Next action:
+  - Recover a runnable DeepEP full-block `forward_backward` baseline on the same 4-GPU shape.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -326,8 +326,35 @@
     - `tokens=524288`, `shared_expert_dim=2048`
     - `tokens=1048576`, `shared_expert_dim=0`
 - Result:
+  - Job `49766` was cancelled after the first case wedged.
+  - The first case was `tokens=524288`, `shared_expert_dim=2048`, kernel `current`.
+  - No result line was emitted before cancellation.
+  - The error log showed repeated GPU OOM allocation failures followed by collective rendezvous waits.
+- Interpretation:
+  - `tokens=524288`, `shared_expert_dim=2048`, `topk=8` is beyond the current ring path's memory envelope in this harness.
+  - This is a stronger boundary than a `>10%` latency miss: current did not complete the first case.
+  - The original script let the OOM wedge the first process, so it did not reach the no-shared token-pressure case.
+- Next action:
+  - Relaunch with per-case timeouts and a smaller shared-expert boundary point.
+
+### 2026-05-21 13:19 - Submit topk=8 boundary retry
+- Experiment ID: `B200-EP-011`
+- Hypothesis:
+  - Since `524288` with shared experts OOMed on the current ring path, the useful follow-up is a smaller shared-expert point plus a larger no-shared token-pressure point with timeouts so one OOM cannot block the rest.
+- Command:
+  - Submitted job `49775`.
+  - Benchmark command family: `bench_moe_hillclimb.py --hidden 5120 --mlp-dim 2560 --experts 64 --topk 8 --distribution random --bench-pass forward_backward --ep-list 8 --warmup 1 --iters 3`
+  - Each case has a per-case timeout.
+- Config:
+  - hardware target: 8 B200 GPUs on one NVLinked node
+  - kernels: `current`, `deepep_transport_capped_prewarmed`
+  - shapes:
+    - `tokens=393216`, `shared_expert_dim=2048`, both kernels
+    - `tokens=524288`, `shared_expert_dim=2048`, DeepEP only
+    - `tokens=786432`, `shared_expert_dim=0`, both kernels
+- Result:
   - Pending at submission.
 - Interpretation:
-  - This follow-up should tell us whether the observed `topk=8` token-pressure boundary crosses the `10%` threshold, or remains within the requested parity band.
+  - This should separate memory-envelope failure from latency crossover and preserve any later case results even if one case fails.
 - Next action:
-  - Watch job `49766`; if the gap exceeds `10%`, shift from parity validation to transport/scheduling optimization.
+  - Watch job `49775`.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -413,3 +413,28 @@
   - The `262144` current case may not fit the present harness memory envelope at `mlp_dim=4096`.
 - Next action:
   - Let job `49779` finish or time out, then decide whether to profile the `131072` case or reduce the `262144` case to isolate memory from scheduling.
+
+### 2026-05-21 10:36 - Submit EP4 larger expert anchor
+- Experiment ID: `B200-EP-013`
+- Hypothesis:
+  - The large `mlp_dim=4096` gap might depend on EP8 communication pressure; run the same global MoE shape on 4 GPUs to check whether the current path still loses badly.
+- Command:
+  - Submitted job `49801`.
+  - Benchmark command family: `bench_moe_hillclimb.py --tokens 131072 --hidden 5120 --mlp-dim 4096 --experts 64 --topk 8 --distribution random --bench-pass forward_backward --ep-list 4 --warmup 1 --iters 3`
+  - Each case has a per-case timeout.
+- Config:
+  - hardware target: 4 B200 GPUs on one NVLinked node
+  - kernels: `current`, `deepep_transport_capped_prewarmed`
+  - shapes:
+    - `tokens=131072`, `shared_expert_dim=0`, both kernels
+    - `tokens=131072`, `shared_expert_dim=2048`, both kernels
+  - Note:
+    - This keeps the global model at `experts=64`, so EP4 has `16` local experts per GPU.
+    - If we want to preserve `8` local experts per GPU instead, run a separate `experts=32` control.
+- Result:
+  - Running.
+  - First observed case: `tokens=131072`, `shared_expert_dim=0`, kernel `current`.
+- Interpretation:
+  - Pending.
+- Next action:
+  - Watch job `49801` and compare the EP4 gap against the EP8 `B200-EP-012` anchor.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -759,3 +759,23 @@
   - This is not a DeepEP parity measurement. It is a TPU transport-scaling probe for token-rank ragged exchange versus the stream-ring baseline at `topk=8`.
 - Next action:
   - Babysit `/dlwh/token-ragged-tpu32-v5lite`; if it fails during compile or runtime, fall back to a payload-only token ragged A2A microbenchmark on the same TPU topology.
+
+### 2026-05-21 21:44 - B200 float-metadata token-ragged retry
+- Experiment ID: `B200-EP-023`
+- Hypothesis:
+  - If the B200 `token_ragged_a2a` mismatch came from integer payload handling through `ragged_all_to_all`, carrying top-k and source-token metadata as `float32` payloads should fix the two-GPU correctness check.
+- Command:
+  - B200 Slurm job `49916`.
+  - Code commit: `9887b433b09cf4e20e80de0c4795f1ebd0934e5c`.
+  - Two-GPU correctness-only sanity check comparing `token_ragged_a2a` against `stream_ring`.
+- Result:
+  - Job `49916` completed with exit code `0`.
+  - Result stayed incorrect:
+    - output max-absolute error vs `stream_ring`: `1.280000e+02`
+    - gradient max-absolute error vs `stream_ring`: `8.000000e+00`
+  - The paired two-GPU debug hold job `49917` failed/cancelled after allocation and did not provide an interactive debug window.
+- Interpretation:
+  - The B200 correctness bug is not explained by int32 token metadata payloads alone. The float-metadata diagnostic reproduced the same output and gradient errors as the prior two-GPU run.
+  - The TPU payload-only check still shows the token-rank exchange order can be correct in isolation, so the remaining bug is more likely in the full return/combine path or local token-to-assignment expansion under the real CUDA execution.
+- Next action:
+  - Submit a new short two-GPU debug/sanity path that prints token payload order, returned source-token order, per-rank counts, and local assignment counts for a tiny deterministic case before running the full MLP comparison.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -674,8 +674,11 @@
     - `deepep_transport_capped_prewarmed`: `0.043299 s`, `0.757M tok/s`
   - Root cause found after the job: the benchmark-local `_shard_a2a_params` helper had stale `ragged_all_to_all` output-offset semantics compared with the checked-in Grug helper. It used receiver-local cumulative offsets instead of sender-side output offsets, which can permute receive segments.
   - Fixed the offset helper in commit `a625b06e1` and submitted retry job `49892`.
+  - Job `49892` allocated four B200 GPUs but failed after GPU discovery, before producing correctness output. No benchmark result was emitted.
+  - Submitted job `49902` as a two-GPU correctness-only sanity check while waiting for four-GPU resources. It failed before running the check because the batch script tried to update the checkout from GitHub inside the batch allocation, where repository authentication was not available.
 - Interpretation:
   - The pre-fix result is not evidence against token-level `ragged_all_to_all`; it was using the wrong receive layout.
   - The pre-fix timing is still useful as a warning that the JAX path has multiple ragged exchanges plus metadata traffic, so correctness must be established before treating its timing as meaningful.
+  - The post-fix jobs have not yet tested correctness; both failures were operational, before the value/gradient comparison.
 - Next action:
-  - Watch job `49892`. If the small correctness check passes, use the timing smoke to decide whether to run the full `tokens=131072`, `mlp_dim=4096`, `topk=8` EP4/EP8 anchors.
+  - Resubmit a no-pull two-GPU sanity job and keep the four-GPU timing retry queued separately. If the small correctness check passes, use the four-GPU timing smoke to decide whether to run the full `tokens=131072`, `mlp_dim=4096`, `topk=8` EP4/EP8 anchors.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -403,16 +403,20 @@
       - `deepep_transport_capped_prewarmed`: `0.110731 s`, `1.184M tok/s`
       - DeepEP is about `43.9%` faster on wall time.
       - DeepEP exact caps: `max_recv_tokens=89344`, `max_local_assignments=131584`, `recv_factor=1.467049`, `assign_factor=7.968872`.
+    - `tokens=262144`, `shared_expert_dim=0`:
+      - `current`: no result line, exited `124`.
+      - `deepep_transport_capped_prewarmed`: `0.219625 s`, `1.194M tok/s`
+      - This is a completion boundary: DeepEP completed, while the current path timed out after GPU OOM and collective rendezvous failures.
+      - DeepEP exact caps: `max_recv_tokens=178816`, `max_local_assignments=263168`, `recv_factor=1.465999`, `assign_factor=7.968872`.
   - Current running case:
-    - `tokens=262144`, `shared_expert_dim=0`, kernel `current`.
-    - The error stream is showing large GPU OOM allocation failures followed by NCCL communicator initialization failure and collective rendezvous waits.
+    - `tokens=262144`, `shared_expert_dim=2048`, kernel `current`.
 - Interpretation:
   - Increasing expert width exposed a large gap immediately, even at `131072` tokens.
   - The current ring path is now far outside the requested `5-10%` parity window on full fwd+bwd MoE MLP.
   - Because both shared and no-shared cases lose by roughly the same amount, the next likely bottleneck is the combination of token exchange and local expert GEMM scheduling/overlap rather than shared-expert work alone.
-  - The `262144` current case may not fit the present harness memory envelope at `mlp_dim=4096`.
+  - The `262144` no-shared case confirms the memory/runtime boundary: DeepEP completes at the larger token count, while the current path does not.
 - Next action:
-  - Let job `49779` finish or time out, then decide whether to profile the `131072` case or reduce the `262144` case to isolate memory from scheduling.
+  - Let the `262144` shared-expert current case finish or time out, then profile the `131072` anchor and investigate why the current path materializes too much state at `262144`.
 
 ### 2026-05-21 10:36 - Submit EP4 larger expert anchor
 - Experiment ID: `B200-EP-013`
@@ -433,16 +437,22 @@
     - If we want to preserve `8` local experts per GPU instead, run a separate `experts=32` control.
 - Result:
   - Running.
-  - Observed cases:
+  - Completed or result-emitting cases:
     - `tokens=131072`, `shared_expert_dim=0`, kernel `current`:
       - `current`: `0.194346 s`, `0.674M tok/s`
     - `tokens=131072`, `shared_expert_dim=0`, kernel `deepep_transport_capped_prewarmed`:
       - `deepep_transport_capped_prewarmed`: `0.160582 s`, `0.816M tok/s`
       - DeepEP is about `17.4%` faster on wall time.
       - DeepEP exact caps: `max_recv_tokens=120064`, `max_local_assignments=262912`, `recv_factor=1.091684`, `assign_factor=3.988315`.
+    - `tokens=131072`, `shared_expert_dim=2048`, kernel `current`:
+      - `current`: `0.200196 s`, `0.655M tok/s`
+    - `tokens=131072`, `shared_expert_dim=2048`, kernel `deepep_transport_capped_prewarmed`:
+      - `deepep_transport_capped_prewarmed`: `0.171901 s`, `0.762M tok/s`
+      - DeepEP is about `14.1%` faster on wall time.
+      - DeepEP exact caps: `max_recv_tokens=120064`, `max_local_assignments=262912`, `recv_factor=1.091684`, `assign_factor=3.988315`.
       - The result line has emitted; the case end line has not emitted yet.
 - Interpretation:
-  - The `mlp_dim=4096` gap is present on EP4 for the same global `experts=64` shape, but the first no-shared point is smaller than the EP8 gap.
-  - This suggests the EP8 result is not purely an 8-GPU artifact; however, the gap still grows with EP size or local/global layout.
+  - The `mlp_dim=4096` gap is present on EP4 for the same global `experts=64` shape, but it is smaller than the EP8 gap.
+  - EP4 shows a `14-17%` DeepEP advantage, while EP8 showed a `40-44%` advantage at the same `131072` token shape. The problem is therefore not purely an 8-GPU artifact, but it does worsen with EP size or local/global layout.
 - Next action:
-  - Watch job `49801` and compare the EP4 gap against the EP8 `B200-EP-012` anchor.
+  - Wait for the final case end line, then decide whether to run an EP4 `experts=32` control that preserves `8` local experts per GPU.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -645,3 +645,25 @@
   - The residual EP8 gap is now small enough that profile-driven transport work is more useful than broad variant sweeps. The next discriminator should profile `stream_ring` vs DeepEP at EP8 or test recipe-shaped anchors to see whether the slight gap grows with hidden/expert size.
 - Next action:
   - Promote `stream_ring` toward the production EP path, while keeping a focused EP8 profile/probe task for the remaining `~10-11%` gap.
+
+### 2026-05-21 16:41 - Submit token-level JAX ragged all-to-all smoke
+- Experiment ID: `B200-EP-019`
+- Hypothesis:
+  - DeepEP's communication advantage may come from token-to-rank ragged exchange rather than assignment-to-expert exchange. A JAX `ragged_all_to_all` path that sends each token at most once per destination rank may recover most of DeepEP's transport behavior without depending on DeepEP's transport kernels.
+- Code:
+  - Added benchmark-only kernel `token_ragged_a2a` in `bench_moe_hillclimb.py`.
+  - The variant uses DeepEP's layout kernel for token reachability metadata, then uses JAX `ragged_all_to_all` for dispatch and return combine.
+  - Each receiver expands the received token metadata into local expert assignments before the existing grouped expert GEMMs.
+- Command:
+  - Submitted job `49881` for a small value/gradient smoke and a 4-GPU timing check.
+  - Job `49881` failed before reaching the benchmark because the allocated node exposed only three usable CUDA devices for a four-GPU request.
+  - Submitted retry job `49882` excluding that node.
+  - Benchmark command family for timing smoke: `bench_moe_hillclimb.py --tokens 32768 --hidden 5120 --mlp-dim 4096 --experts 64 --shared-expert-dim 0 --topk 8 --distribution random --bench-pass forward_backward --ep-list 4 --warmup 1 --iters 3`
+- Config:
+  - hardware target: 4 B200 GPUs on one NVLinked node
+  - kernels: `token_ragged_a2a`, `stream_ring`, `deepep_transport_capped_prewarmed`
+  - preflight correctness check: compare `token_ragged_a2a` against `stream_ring` on a smaller EP4 shape for output and gradient max-absolute error.
+- Result:
+  - Job `49882` is pending.
+- Next action:
+  - Watch job `49882`. If the small correctness check passes, use the timing smoke to decide whether to run the full `tokens=131072`, `mlp_dim=4096`, `topk=8` EP4/EP8 anchors.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -712,3 +712,28 @@
   - This does not yet prove the B200 full `token_ragged_a2a` path correct; the pending B200 jobs are still needed for CUDA correctness and timing.
 - Next action:
   - Use the held TPU to reduce the Megablox/Pallas GMM compile failure separately, while waiting for the B200 two-GPU correctness jobs.
+
+### 2026-05-21 17:22 - Diagnose TPU Megablox GMM compile failure
+- Experiment ID: `B200-EP-021`
+- Hypothesis:
+  - The TPU Mosaic `Bad lhs type` failure in the full `token_ragged_a2a` sanity path may be a narrow-shape Megablox autodiff lowering issue rather than a token exchange bug.
+- Command:
+  - Reduced the failure on the held TPU by comparing:
+    - direct Megablox `gmm` calls;
+    - minimal `shard_map` calls through `haliax.nn.ragged_dot(..., implementation="megablox")`;
+    - full `token_ragged_a2a` forward and forward+backward with a pure-JAX dispatch-layout shim.
+  - Ran the focused dispatch test:
+    - `uv run pytest -o addopts='' lib/haliax/tests/test_ragged_dot_dispatch.py`
+- Result:
+  - Direct Megablox `gmm` compiled on TPU for BF16 and FP32 inputs, with both FP32 and input-dtype outputs.
+  - Minimal `shard_map` Megablox `ragged_dot` compiled for small and production-like dimensions.
+  - Full `token_ragged_a2a` forward compiled for tested hidden sizes, but the forward+backward narrow sanity shape failed before correctness comparison.
+  - Added a pre-lowering guard in `haliax.nn.ragged_dot` so automatic TPU dispatch falls back to XLA for narrow Megablox shapes; explicit `implementation="megablox"` now rejects those shapes early with a clear error.
+  - Reduced TPU forward+backward sanity then completed:
+    - `TOKEN_RAGGED_GMM_CHECK loss=183.443726 grad_l1=2677.305054`
+- Interpretation:
+  - The TPU failure is separate from the payload exchange. It is a narrow-shape Megablox/Pallas lowering constraint in the sanity path.
+  - Production-sized TPU Megablox GMM is not generally broken by this observation, so the workaround is intentionally narrow.
+  - B200 CUDA correctness remains pending on jobs `49916` and `49917`.
+- Next action:
+  - Wait for the B200 correctness jobs. If they remain pending, use the held GPU debug allocation once available to inspect full `token_ragged_a2a` value/gradient mismatch directly.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -1,0 +1,92 @@
+# B200 Grug Expert Parallelism: Research Logbook
+
+## Scope
+- Goal: find the best expert-parallel Grug MoE path for NVLinked B200 nodes.
+- Primary metric(s): forward and forward+backward tokens/sec for Grug MoE EP8 shapes, with compile-including and steady-state timings separated.
+- Constraints:
+  - Use issue #3841 as historical DeepEP context, not as the only active tracking issue.
+  - Use issue #5894 as the current B200 grouped-matmul baseline thread.
+  - Do not publish private cluster/source names in logged files or GitHub comments.
+  - Keep throwaway sweep harnesses out of production paths unless they become reusable.
+  - Compare one axis at a time: EP backend, GMM tile/backend, then dispatch/combine replacement.
+- GitHub issues:
+  - https://github.com/marin-community/marin/issues/3841
+  - https://github.com/marin-community/marin/issues/5894
+  - https://github.com/marin-community/marin/issues/5815
+  - https://github.com/marin-community/marin/issues/5328
+- Experiment ID prefix: `B200-EP`
+
+## Baseline
+- Date: 2026-05-21
+- Code refs:
+  - `lib/levanter/src/levanter/grug/grug_moe.py`
+  - `lib/levanter/src/levanter/grug/_moe/ep_ring.py`
+  - `lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py`
+  - `lib/haliax/src/haliax/nn/ragged_dot.py`
+  - `lib/levanter/src/levanter/grug/_moe/sonic.py`
+- Fixed baseline case:
+  - hardware: one NVLinked B200 node
+  - dtype: BF16
+  - local experts: 8
+  - rows: 32768
+  - hidden: 5120
+  - intermediate: 2560
+  - implementation candidates: `ring`, `ragged_all_to_all`, local `sonic`/`scatter` controls
+- Inherited B200 GMM baseline from issue #5894:
+  - old BF16 Triton default tile: `block_m=128`, `block_n=128`, `block_k=32`, `warps=4`, `stages=4`
+  - Blackwell candidate tile: `block_m=128`, `block_n=256`, `block_k=32`, `warps=4`, `stages=4`
+  - W13: `1.8789 ms -> 1.5735 ms`
+  - W2: `1.0781 ms -> 0.8985 ms`
+  - public-path confirmation: W13 `1.5811 ms`, W2 `0.8996 ms`
+- Historical DeepEP facts from issue #3841:
+  - The best H100 thread combined expert-padded W13/W2, fast shared accumulation, and capped DeepEP send-token knobs.
+  - Large `topk=2` rows reached parity or better against sealed Megatron anchors.
+  - The remaining hard row was `262144`, `topk=8`, `shared_expert_dim=2048`, `forward_backward`.
+  - The last attribution pointed at replicated shared-gradient all-reduce scheduling and dtype, not local GMM math alone.
+
+## Experiment Log
+
+### 2026-05-21 10:13 - Kickoff and baseline recovery
+- Experiment ID: `B200-EP-001`
+- Hypothesis:
+  - B200 EP performance should start from the Blackwell BF16 ragged-dot tile baseline, then measure full EP backends before resurrecting older DeepEP code.
+- Command:
+  - `gh issue view 3841 --repo marin-community/marin --json number,title,state,labels,body,url,comments`
+  - `gh issue view 5894 --repo marin-community/marin --json number,title,state,labels,body,url,comments`
+  - `git cherry-pick 8a036b797`
+- Config:
+  - branch: `research/b200-grug-ep`
+  - starting commit: `b01a88dd0`
+  - cherry-picked commit: `8a036b797`
+- Result:
+  - Confirmed #3841 is the historical DeepEP residual-overlap thread.
+  - Confirmed #5894 is the active B200 GMM thread and records the first Blackwell tile win.
+  - Brought the Blackwell-only `block_n=256` ragged-dot default onto this branch with focused dispatch tests.
+- Interpretation:
+  - The first B200 EP comparison should use the Blackwell tile as baseline to avoid retesting an already-won local GMM setting.
+  - The next measurement must compare full EP paths, because local GMM-only wins do not answer dispatch/combine or collective scheduling.
+- Next action:
+  - Run one-node B200 smoke and benchmark matrix for `ring` vs `ragged_all_to_all`, using the same BF16 shape family as #5894.
+
+### 2026-05-21 10:39 - Add reusable EP benchmark scaffold
+- Experiment ID: `B200-EP-002`
+- Hypothesis:
+  - A minimal JSON-emitting benchmark script is enough for the first one-axis B200 sweep without bringing back the full historical DeepEP hillclimb harness.
+- Command:
+  - `uv run --project lib/haliax --group dev pytest -q -o addopts='' tests/test_ragged_dot_dispatch.py`
+  - `uv run python .agents/scripts/bench_grug_ep.py --tokens 16 --hidden-dim 16 --intermediate-dim 8 --local-experts 1 --topk 1 --num-devices 1 --warmup 0 --iters 1 --implementations ring --pass-mode forward`
+- Config:
+  - benchmark script: `.agents/scripts/bench_grug_ep.py`
+  - smoke shape: CPU-sized local fallback, not an EP performance claim
+- Result:
+  - Ragged-dot dispatch tests passed: `6 passed`.
+  - Benchmark smoke emitted one JSON timing row.
+- Interpretation:
+  - The scaffold is syntactically usable and catches the JAX 0.9 explicit-axis mesh requirement.
+  - Performance claims still require the B200 run.
+- Next action:
+  - Run the script on a single B200 node with 8 GPUs for:
+    - `ring`, `forward`
+    - `ragged_all_to_all`, `forward`
+    - `ring`, `forward_backward`
+    - `ragged_all_to_all`, `forward_backward`

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -243,8 +243,27 @@
     - `tokens=131072`, `shared_expert_dim=2048`
     - `tokens=262144`, `shared_expert_dim=0`
 - Result:
-  - Pending at submission.
+  - Job `49750` started on 8 B200 GPUs.
+  - Partial results at the 10-minute check:
+    - `tokens=32768`, `shared_expert_dim=2048`:
+      - `current`: `0.015817 s`, `2.072M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.016488 s`, `1.987M tok/s`
+      - `current` is about `4.1%` faster on wall time.
+    - `tokens=65536`, `shared_expert_dim=0`:
+      - `current`: `0.029809 s`, `2.199M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.031265 s`, `2.096M tok/s`
+      - `current` is about `4.7%` faster on wall time.
+    - `tokens=65536`, `shared_expert_dim=2048`:
+      - `current`: `0.032064 s`, `2.044M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.032978 s`, `1.987M tok/s`
+      - `current` is about `2.8%` faster on wall time.
+    - `tokens=131072`, `shared_expert_dim=0`:
+      - `current`: `0.063556 s`, `2.062M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.063620 s`, `2.060M tok/s`
+      - effectively tied, with `current` about `0.1%` faster on wall time.
+  - The `tokens=131072`, `shared_expert_dim=0` DeepEP case had emitted a result line but had not emitted its `CASE_END` line yet at the check.
 - Interpretation:
-  - This is the first boundary-finding sweep after the 4-GPU and 8-GPU `topk=2` parity checks.
+  - In the completed early `topk=8` cases, ring still has not lost; it is faster at the smaller/shared shapes and tied at `131072` no-shared.
+  - The first likely breakpoint remains the still-running `131072` shared case or the `262144` no-shared case.
 - Next action:
   - Watch job `49750`; record every completed shape and preserve failures as data.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -163,3 +163,38 @@
   - This should not be treated as a final DeepEP parity win. It compares current `ring` against an old JAX bridge plus scratch-only compatibility patches, not a production-quality current DeepEP/Megatron full-block reference.
 - Next action:
   - Make the DeepEP baseline durable in the current branch or build a fairer current DeepEP reference before spending time on a Triton/CUTLASS transport replacement.
+
+### 2026-05-21 11:21 - Current-branch DeepEP parity check
+- Experiment ID: `B200-EP-006`
+- Hypothesis:
+  - Once the DeepEP bridge is restored in the current branch, the current Grug `ring` backend should be compared against the same-process DeepEP path with production EP capacity settings.
+- Command:
+  - Restored the DeepEP FFI package and `bench_moe_hillclimb.py` into the current branch.
+  - Patched `ragged_dot` Pallas index dtypes so the current Triton backward path traces under `JAX_ENABLE_X64=1`.
+  - Submitted jobs `49682` through `49686`.
+  - Current EP command family: `.agents/scripts/bench_grug_ep.py --tokens 32768 --hidden-dim 5120 --intermediate-dim 2560 --local-experts 8 --topk 2 --num-devices 4 --dtype bf16 --pass-mode forward_backward --implementations ring`
+  - DeepEP command family: `bench_moe_hillclimb.py --tokens 32768 --hidden 5120 --mlp-dim 2560 --experts 32 --shared-expert-dim 0 --topk 2 --distribution random --bench-pass forward_backward --kernel deepep_transport_capped_prewarmed --ep-list 4`
+- Config:
+  - hardware: 4 B200 GPUs on one NVLinked node
+  - current branch commit: `5b433a7d1`
+  - EP capacity factor: `1.25`
+  - DeepEP exact caps: `max_recv_tokens=14592`, `max_local_assignments=16512`, `recv_factor=2.245614`, `assign_factor=3.968992`
+- Result:
+  - Job `49682` corrected current EP matrix:
+    - `ring`, `forward`: `0.003179 s`, `10.307M tok/s`, `0` dropped assignments
+    - `ragged_all_to_all`, `forward`: `0.041205 s`, `0.795M tok/s`, `0` dropped assignments
+    - `ring`, `forward_backward`: `0.008153 s`, `4.019M tok/s`, `0` dropped assignments
+    - `ragged_all_to_all`, `forward_backward`: `0.084363 s`, `0.388M tok/s`, `0` dropped assignments
+  - Job `49683` failed before measurement because the allocation exposed only 3 usable devices to JAX.
+  - Job `49684` exposed a current `ragged_dot` Triton/Pallas x64 index dtype bug in the DeepEP backward path; fixed by commit `5b433a7d1`.
+  - Job `49685` current-branch DeepEP check:
+    - `deepep_transport_capped_prewarmed`, `ep=4`, `forward_backward`: `0.009477 s`, `3.458M tok/s`
+  - Job `49686` same-allocation side-by-side check with `warmup=2`, `iters=10`:
+    - current `ring`, `forward_backward`: `0.008234 s`, `3.980M tok/s`, `0` dropped assignments
+    - current-branch `deepep_transport_capped_prewarmed`, `forward_backward`: `0.009369 s`, `3.498M tok/s`
+- Interpretation:
+  - On the measured 4-GPU B200 full-block shape, current `ring` is faster than the restored current-branch JAX DeepEP path by about `12.1%` in wall time on the side-by-side run.
+  - This clears the immediate 4-GPU parity bar for the JAX full-block fwd+bwd path; the next proof point is 8 GPUs once a full usable node is available.
+  - The checked-in `ragged_all_to_all` path remains more than 10x slower than `ring`; do not spend more time on it unless replacing the collective schedule wholesale.
+- Next action:
+  - Run the side-by-side current `ring` vs restored DeepEP comparison on 8 GPUs, then decide whether a custom Triton/CUTLASS transport is still necessary or whether the work should shift to hardening the restored DeepEP benchmark and scaling/shape sweeps.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -391,7 +391,7 @@
     - `tokens=262144`, `shared_expert_dim=0`, both kernels
     - `tokens=262144`, `shared_expert_dim=2048`, both kernels
 - Result:
-  - Job `49779` is running.
+  - Job `49779` completed with exit code `0`.
   - Completed cases:
     - `tokens=131072`, `shared_expert_dim=0`:
       - `current`: `0.181974 s`, `0.720M tok/s`
@@ -408,15 +408,18 @@
       - `deepep_transport_capped_prewarmed`: `0.219625 s`, `1.194M tok/s`
       - This is a completion boundary: DeepEP completed, while the current path timed out after GPU OOM and collective rendezvous failures.
       - DeepEP exact caps: `max_recv_tokens=178816`, `max_local_assignments=263168`, `recv_factor=1.465999`, `assign_factor=7.968872`.
-  - Current running case:
-    - `tokens=262144`, `shared_expert_dim=2048`, kernel `current`.
+    - `tokens=262144`, `shared_expert_dim=2048`:
+      - `current`: no result line, exited `124`.
+      - `deepep_transport_capped_prewarmed`: `0.223786 s`, `1.171M tok/s`
+      - This is another completion boundary: DeepEP completed, while the current path timed out.
+      - DeepEP exact caps: `max_recv_tokens=178816`, `max_local_assignments=263168`, `recv_factor=1.465999`, `assign_factor=7.968872`.
 - Interpretation:
   - Increasing expert width exposed a large gap immediately, even at `131072` tokens.
   - The current ring path is now far outside the requested `5-10%` parity window on full fwd+bwd MoE MLP.
   - Because both shared and no-shared cases lose by roughly the same amount, the next likely bottleneck is the combination of token exchange and local expert GEMM scheduling/overlap rather than shared-expert work alone.
-  - The `262144` no-shared case confirms the memory/runtime boundary: DeepEP completes at the larger token count, while the current path does not.
+  - The `262144` cases confirm the memory/runtime boundary: DeepEP completes at the larger token count, while the current path does not, both with and without shared experts.
 - Next action:
-  - Let the `262144` shared-expert current case finish or time out, then profile the `131072` anchor and investigate why the current path materializes too much state at `262144`.
+  - Use EP4 as the operating scale for implementation work, then re-check EP8 once an improved path is available.
 
 ### 2026-05-21 10:36 - Submit EP4 larger expert anchor
 - Experiment ID: `B200-EP-013`
@@ -436,8 +439,8 @@
     - This keeps the global model at `experts=64`, so EP4 has `16` local experts per GPU.
     - If we want to preserve `8` local experts per GPU instead, run a separate `experts=32` control.
 - Result:
-  - Running.
-  - Completed or result-emitting cases:
+  - Job `49801` completed with exit code `0`.
+  - Completed cases:
     - `tokens=131072`, `shared_expert_dim=0`, kernel `current`:
       - `current`: `0.194346 s`, `0.674M tok/s`
     - `tokens=131072`, `shared_expert_dim=0`, kernel `deepep_transport_capped_prewarmed`:
@@ -450,9 +453,128 @@
       - `deepep_transport_capped_prewarmed`: `0.171901 s`, `0.762M tok/s`
       - DeepEP is about `14.1%` faster on wall time.
       - DeepEP exact caps: `max_recv_tokens=120064`, `max_local_assignments=262912`, `recv_factor=1.091684`, `assign_factor=3.988315`.
-      - The result line has emitted; the case end line has not emitted yet.
 - Interpretation:
   - The `mlp_dim=4096` gap is present on EP4 for the same global `experts=64` shape, but it is smaller than the EP8 gap.
   - EP4 shows a `14-17%` DeepEP advantage, while EP8 showed a `40-44%` advantage at the same `131072` token shape. The problem is therefore not purely an 8-GPU artifact, but it does worsen with EP size or local/global layout.
 - Next action:
-  - Wait for the final case end line, then decide whether to run an EP4 `experts=32` control that preserves `8` local experts per GPU.
+  - Operate at this EP4 scale for the next iteration: use it to decompose the gap before returning to EP8.
+
+### 2026-05-21 10:43 - Submit EP4 decomposition anchor
+- Experiment ID: `B200-EP-014`
+- Hypothesis:
+  - The EP4 `mlp_dim=4096` anchor is cheap enough to iterate on and still reproduces a `14-17%` DeepEP advantage. Run cumulative DeepEP transport probes to identify whether the time is dominated by dispatch/pack, first ragged GEMM, activation, second ragged GEMM, or combine.
+- Command:
+  - Submitted job `49810`.
+  - Benchmark command family: `bench_moe_hillclimb.py --tokens 131072 --hidden 5120 --mlp-dim 4096 --experts 64 --shared-expert-dim 0 --topk 8 --distribution random --bench-pass forward_backward --ep-list 4 --warmup 1 --iters 3`
+  - Each case has a per-case timeout.
+- Config:
+  - hardware target: 4 B200 GPUs on one NVLinked node
+  - kernels:
+    - `current`
+    - `deepep_transport_first_ragged_dot_probe`
+    - `deepep_transport_gate_probe`
+    - `deepep_transport_second_ragged_dot_probe`
+    - `deepep_transport_capped_prewarmed`
+  - shape: `tokens=131072`, `hidden=5120`, `mlp_dim=4096`, `experts=64`, `topk=8`, `shared_expert_dim=0`, fwd+bwd.
+- Result:
+  - Job `49810` completed with exit code `0`.
+  - Results:
+    - `current`: `0.192763 s`, `0.680M tok/s`
+    - `deepep_transport_first_ragged_dot_probe`: `0.161756 s`, `0.810M tok/s`
+    - `deepep_transport_gate_probe`: `0.202126 s`, `0.648M tok/s`
+    - `deepep_transport_second_ragged_dot_probe`: `0.267500 s`, `0.490M tok/s`
+    - `deepep_transport_capped_prewarmed`: `0.158097 s`, `0.829M tok/s`
+      - DeepEP exact caps: `max_recv_tokens=120064`, `max_local_assignments=262912`, `recv_factor=1.091684`, `assign_factor=3.988315`.
+- Interpretation:
+  - The EP4 no-shared gap is stable: DeepEP is about `18.0%` faster than current in this repeat.
+  - The probe kernels should not be read as clean cumulative phase timings: the full capped DeepEP path is faster than the gate and second-ragged-dot probes, so those probes are using slower diagnostic paths or changing enough of the backward graph to distort phase attribution.
+  - The first-ragged-dot probe is close to full capped DeepEP, which still points at the current ring path's global all-gather/materialization as the first concrete optimization target.
+- Next action:
+  - Sweep the existing current-path variants at the EP4 anchor before writing new kernels.
+
+### 2026-05-21 10:54 - Submit EP4 current-path variant sweep
+- Experiment ID: `B200-EP-015`
+- Hypothesis:
+  - Existing current-path variants may already isolate a faster counting, packing, all-to-all, scatter, or backward-combine choice at the EP4 `mlp_dim=4096` anchor.
+- Command:
+  - Submitted job `49811`.
+  - Benchmark command family: `bench_moe_hillclimb.py --tokens 131072 --hidden 5120 --mlp-dim 4096 --experts 64 --shared-expert-dim 0 --topk 8 --distribution random --bench-pass forward_backward --ep-list 4 --warmup 1 --iters 3`
+  - Each case has a per-case timeout.
+- Config:
+  - hardware target: 4 B200 GPUs on one NVLinked node
+  - shape: `tokens=131072`, `hidden=5120`, `mlp_dim=4096`, `experts=64`, `topk=8`, `shared_expert_dim=0`, fwd+bwd.
+  - kernels:
+    - `current`, `cumsum`, `packed_return`, `stream_ring`
+    - `ragged_a2a`, `deepep_layout_ragged_a2a`
+    - `prefix_counts`, `vector_prefix`, `onehot_counts`, `padded_take`
+    - `segment_sum`, `sorted_segment_sum`, `prefix_segment_sum`, `vector_sorted_segment_sum`
+    - `owner_local_scatter`, `lax_scatter`
+    - `take_segment_bwd`, `take_sorted_segment_bwd`, `owner_local_take`
+    - `weight_cast`, `narrow_meta`
+    - `deepep_transport_capped_prewarmed`
+- Result:
+  - Job `49811` completed with exit code `0`.
+  - Results:
+    - `deepep_transport_capped_prewarmed`: `0.162267 s`, `0.808M tok/s`
+    - `stream_ring`: `0.174792 s`, `0.750M tok/s`
+    - `padded_take`: `0.187466 s`, `0.699M tok/s`
+    - `onehot_counts`: `0.188501 s`, `0.695M tok/s`
+    - `prefix_counts`: `0.190201 s`, `0.689M tok/s`
+    - `take_segment_bwd`: `0.190920 s`, `0.687M tok/s`
+    - `lax_scatter`: `0.191231 s`, `0.685M tok/s`
+    - `prefix_segment_sum`: `0.192139 s`, `0.682M tok/s`
+    - `segment_sum`: `0.192214 s`, `0.682M tok/s`
+    - `owner_local_take`: `0.192385 s`, `0.681M tok/s`
+    - `weight_cast`: `0.192893 s`, `0.680M tok/s`
+    - `current`: `0.192940 s`, `0.679M tok/s`
+    - `vector_prefix`: `0.193392 s`, `0.678M tok/s`
+    - `narrow_meta`: `0.194278 s`, `0.675M tok/s`
+    - `owner_local_scatter`: `0.196997 s`, `0.665M tok/s`
+    - `cumsum`: `0.235193 s`, `0.557M tok/s`
+    - `packed_return`: `0.241644 s`, `0.542M tok/s`
+    - `sorted_segment_sum`: `0.277624 s`, `0.472M tok/s`
+    - `take_sorted_segment_bwd`: `0.278600 s`, `0.470M tok/s`
+    - `vector_sorted_segment_sum`: `0.283091 s`, `0.463M tok/s`
+    - `ragged_a2a`: no result line, exited `1`.
+    - `deepep_layout_ragged_a2a`: no result line, exited `1`.
+  - DeepEP exact caps: `max_recv_tokens=120064`, `max_local_assignments=262912`, `recv_factor=1.091684`, `assign_factor=3.988315`.
+- Interpretation:
+  - `stream_ring` is the only existing non-DeepEP variant that materially improves the EP4 anchor.
+  - At this operating scale, `stream_ring` is about `9.4%` faster than `current` and about `7.7%` slower than DeepEP on wall time, so it reaches the requested `5-10%` parity window for the no-shared anchor.
+  - Most smaller metadata/scatter/counting variants are within noise of `current`; sorted segment-sum variants are much slower.
+  - This points to `stream_ring` as the immediate implementation path to validate with shared experts, not a fresh Triton/CUTLASS local-GEMM rewrite.
+- Next action:
+  - Validate `stream_ring` against DeepEP at the same EP4 scale with both `shared_expert_dim=0` and `shared_expert_dim=2048`.
+
+### 2026-05-21 10:59 - Submit EP4 stream-ring validation
+- Experiment ID: `B200-EP-016`
+- Hypothesis:
+  - Since `stream_ring` is within `5-10%` of DeepEP on the EP4 no-shared anchor, it may be the shortest path to parity at this operating scale. Validate it with a slightly longer timing loop and with shared experts enabled.
+- Command:
+  - Submitted job `49812`.
+  - Benchmark command family: `bench_moe_hillclimb.py --tokens 131072 --hidden 5120 --mlp-dim 4096 --experts 64 --topk 8 --distribution random --bench-pass forward_backward --ep-list 4 --warmup 1 --iters 5`
+- Config:
+  - hardware target: 4 B200 GPUs on one NVLinked node
+  - kernels: `stream_ring`, `deepep_transport_capped_prewarmed`
+  - shapes:
+    - `tokens=131072`, `shared_expert_dim=0`, both kernels
+    - `tokens=131072`, `shared_expert_dim=2048`, both kernels
+- Result:
+  - Job `49812` completed with exit code `0`.
+  - Results:
+    - `tokens=131072`, `shared_expert_dim=0`:
+      - `stream_ring`: `0.173944 s`, `0.754M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.162149 s`, `0.808M tok/s`
+      - `stream_ring` is about `7.3%` slower than DeepEP on wall time.
+      - DeepEP exact caps: `max_recv_tokens=120064`, `max_local_assignments=262912`, `recv_factor=1.091684`, `assign_factor=3.988315`.
+    - `tokens=131072`, `shared_expert_dim=2048`:
+      - `stream_ring`: `0.182407 s`, `0.719M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.172454 s`, `0.760M tok/s`
+      - `stream_ring` is about `5.8%` slower than DeepEP on wall time.
+      - DeepEP exact caps: `max_recv_tokens=120064`, `max_local_assignments=262912`, `recv_factor=1.091684`, `assign_factor=3.988315`.
+- Interpretation:
+  - `stream_ring` validates inside the requested `5-10%` parity window at the EP4 operating scale, both with and without shared experts.
+  - The validated gap is much smaller than the original current path gap: `stream_ring` is about `10.9%` faster than current on the no-shared anchor and about `8.9%` faster than current on the shared anchor, using the `B200-EP-013` current timings as reference.
+  - This makes `stream_ring` the best immediate baseline for implementation work. A fresh Triton/CUTLASS local-GEMM rewrite is not the first move unless `stream_ring` fails at EP8 or recipe-shaped anchors.
+- Next action:
+  - Promote `stream_ring` as the EP4 development baseline, then re-check EP8 and recipe-shaped anchors.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -664,6 +664,18 @@
   - kernels: `token_ragged_a2a`, `stream_ring`, `deepep_transport_capped_prewarmed`
   - preflight correctness check: compare `token_ragged_a2a` against `stream_ring` on a smaller EP4 shape for output and gradient max-absolute error.
 - Result:
-  - Job `49882` is pending.
+  - Job `49882` completed with exit code `0` against code commit `250f88488`.
+  - The first `token_ragged_a2a` implementation compiled and ran, but failed semantic validation:
+    - output max-absolute error vs `stream_ring`: `1.280000e+02`
+    - gradient max-absolute error vs `stream_ring`: `4.000000e+00`
+  - Timing smoke for the same pre-fix implementation:
+    - `token_ragged_a2a`: `0.338680 s`, `0.097M tok/s`
+    - `stream_ring`: `0.105866 s`, `0.310M tok/s`
+    - `deepep_transport_capped_prewarmed`: `0.043299 s`, `0.757M tok/s`
+  - Root cause found after the job: the benchmark-local `_shard_a2a_params` helper had stale `ragged_all_to_all` output-offset semantics compared with the checked-in Grug helper. It used receiver-local cumulative offsets instead of sender-side output offsets, which can permute receive segments.
+  - Fixed the offset helper in commit `a625b06e1` and submitted retry job `49892`.
+- Interpretation:
+  - The pre-fix result is not evidence against token-level `ragged_all_to_all`; it was using the wrong receive layout.
+  - The pre-fix timing is still useful as a warning that the JAX path has multiple ragged exchanges plus metadata traffic, so correctness must be established before treating its timing as meaningful.
 - Next action:
-  - Watch job `49882`. If the small correctness check passes, use the timing smoke to decide whether to run the full `tokens=131072`, `mlp_dim=4096`, `topk=8` EP4/EP8 anchors.
+  - Watch job `49892`. If the small correctness check passes, use the timing smoke to decide whether to run the full `tokens=131072`, `mlp_dim=4096`, `topk=8` EP4/EP8 anchors.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -612,3 +612,36 @@
   - Operational note: Sonic/Triton experiments need `jax-triton` and a CUDA assembler new enough for Triton's emitted PTX. Keep that in job scripts for future Triton probes.
 - Next action:
   - Keep `stream_ring` as the EP4 development baseline. Re-check the same `topk=8`, `mlp_dim=4096` anchor at EP8 with `stream_ring` before deciding whether a DeepEP-style transport rewrite is necessary.
+
+### 2026-05-21 12:12 - Validate stream ring at EP8
+- Experiment ID: `B200-EP-018`
+- Hypothesis:
+  - `stream_ring` closed the EP4 gap to the requested parity window. Re-check the original EP8 scale to determine whether the remaining problem is only the old current path or whether EP8 still needs transport work.
+- Command:
+  - Submitted job `49818`.
+  - Benchmark command family: `bench_moe_hillclimb.py --tokens 131072 --hidden 5120 --mlp-dim 4096 --experts 64 --topk 8 --distribution random --bench-pass forward_backward --ep-list 8 --warmup 1 --iters 5`
+- Config:
+  - hardware target: 8 B200 GPUs on one NVLinked node
+  - kernels: `stream_ring`, `deepep_transport_capped_prewarmed`
+  - shapes:
+    - `tokens=131072`, `shared_expert_dim=0`, both kernels
+    - `tokens=131072`, `shared_expert_dim=2048`, both kernels
+- Result:
+  - Job `49818` completed with exit code `0`.
+  - Results:
+    - `tokens=131072`, `shared_expert_dim=0`:
+      - `stream_ring`: `0.095364 s`, `1.374M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.086349 s`, `1.518M tok/s`
+      - `stream_ring` is about `10.4%` slower than DeepEP on wall time.
+      - DeepEP exact caps: `max_recv_tokens=89344`, `max_local_assignments=131584`, `recv_factor=1.467049`, `assign_factor=7.968872`.
+    - `tokens=131072`, `shared_expert_dim=2048`:
+      - `stream_ring`: `0.099782 s`, `1.314M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.090154 s`, `1.454M tok/s`
+      - `stream_ring` is about `10.7%` slower than DeepEP on wall time.
+      - DeepEP exact caps: `max_recv_tokens=89344`, `max_local_assignments=131584`, `recv_factor=1.467049`, `assign_factor=7.968872`.
+- Interpretation:
+  - `stream_ring` nearly reaches the requested `5-10%` parity window at EP8 but lands just outside it on both shared and no-shared anchors.
+  - This is still a major improvement over the old EP8 current-path gap (`40-44%` DeepEP advantage at the same shape), so the production path should probably move toward `stream_ring` first.
+  - The residual EP8 gap is now small enough that profile-driven transport work is more useful than broad variant sweeps. The next discriminator should profile `stream_ring` vs DeepEP at EP8 or test recipe-shaped anchors to see whether the slight gap grows with hidden/expert size.
+- Next action:
+  - Promote `stream_ring` toward the production EP path, while keeping a focused EP8 profile/probe task for the remaining `~10-11%` gap.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -578,3 +578,37 @@
   - This makes `stream_ring` the best immediate baseline for implementation work. A fresh Triton/CUTLASS local-GEMM rewrite is not the first move unless `stream_ring` fails at EP8 or recipe-shaped anchors.
 - Next action:
   - Promote `stream_ring` as the EP4 development baseline, then re-check EP8 and recipe-shaped anchors.
+
+### 2026-05-21 11:48 - Test Sonic-style combine inside stream ring
+- Experiment ID: `B200-EP-017`
+- Hypothesis:
+  - The best `stream_ring` variant still uses a scatter-add combine inside each ring step. Replacing that combine with Sonic's fixed-top-k Triton gather/combine may reduce backward combine overhead while preserving the stream-ring communication pattern.
+- Code:
+  - Added benchmark-only kernel `stream_ring_sonic_combine` in `bench_moe_hillclimb.py`.
+  - The variant builds fixed `(tokens, topk)` dispatch positions from the local compacted assignments and calls the existing Sonic gather/combine kernel for each ring step.
+- Command:
+  - Submitted job `49815`.
+  - Submitted retry job `49816` after adding the missing `jax-triton` dependency in a scratch-local Python target; canceled once the failure mode was identified.
+  - Submitted job `49817` under a newer CUDA module for the Sonic-only cases.
+  - Benchmark command family: `bench_moe_hillclimb.py --tokens 131072 --hidden 5120 --mlp-dim 4096 --experts 64 --topk 8 --distribution random --bench-pass forward_backward --ep-list 4 --warmup 1 --iters 5`
+- Config:
+  - hardware target: 4 B200 GPUs on one NVLinked node
+  - shape: `tokens=131072`, `hidden=5120`, `mlp_dim=4096`, `experts=64`, `topk=8`, fwd+bwd.
+  - compared `stream_ring`, `stream_ring_sonic_combine`, and `deepep_transport_capped_prewarmed` for `shared_expert_dim=0` and `shared_expert_dim=2048`.
+- Result:
+  - Job `49815` completed with exit code `0`, but both `stream_ring_sonic_combine` cases exited `1` because the runtime environment lacked `jax-triton`.
+  - Job `49816` confirmed the next failure mode with `jax-triton` present: the CUDA 12 assembler rejected the PTX version emitted by Triton. The job was canceled after the failure reproduced.
+  - Job `49817` completed both Sonic-combine cases under a newer CUDA module:
+    - `shared_expert_dim=0`, `stream_ring_sonic_combine`: `0.175608 s`, `0.746M tok/s`
+    - `shared_expert_dim=2048`, `stream_ring_sonic_combine`: `0.184465 s`, `0.711M tok/s`
+  - Same-run-family baselines from job `49815`:
+    - `shared_expert_dim=0`, `stream_ring`: `0.173550 s`, `0.755M tok/s`
+    - `shared_expert_dim=0`, `deepep_transport_capped_prewarmed`: `0.162848 s`, `0.805M tok/s`
+    - `shared_expert_dim=2048`, `stream_ring`: `0.182891 s`, `0.717M tok/s`
+    - `shared_expert_dim=2048`, `deepep_transport_capped_prewarmed`: `0.169560 s`, `0.773M tok/s`
+- Interpretation:
+  - Sonic-style combine is not an improvement at this EP4 anchor. It is about `1.2%` slower than `stream_ring` without shared experts and about `0.9%` slower with shared experts.
+  - The remaining `stream_ring` gap to DeepEP is not primarily the local scatter-add combine. The next useful work is either promoting `stream_ring` into the production path or re-checking EP8 scaling, not another local-combine swap.
+  - Operational note: Sonic/Triton experiments need `jax-triton` and a CUDA assembler new enough for Triton's emitted PTX. Keep that in job scripts for future Triton probes.
+- Next action:
+  - Keep `stream_ring` as the EP4 development baseline. Re-check the same `topk=8`, `mlp_dim=4096` anchor at EP8 with `stream_ring` before deciding whether a DeepEP-style transport rewrite is necessary.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -363,12 +363,15 @@
       - No result line, exited `124`.
       - The per-case timeout fired after large GPU OOM allocation failures and collective rendezvous waits.
     - `tokens=786432`, `shared_expert_dim=0`, kernel `current`: running at the time of observation.
+      - No result line, exited `124`.
+      - The per-case timeout fired after large GPU OOM allocation failures and collective rendezvous waits.
+    - `tokens=786432`, `shared_expert_dim=0`, kernel `deepep_transport_capped_prewarmed`: running at the time of observation.
       - The error log is already showing large GPU OOM allocation failures and collective rendezvous waits.
-  - Remaining no-shared DeepEP `786432` case is still pending.
 - Interpretation:
   - This is already below the `524288` shared-expert OOM point, so the usable shared-expert `topk=8` boundary appears to be below `393216` tokens in this harness for both current ring and restored DeepEP.
   - The shared-expert failure mode is no longer a small latency gap; it is memory/runtime robustness at high token count.
   - The no-shared `786432` current case is also beyond the current memory envelope in this harness; `524288` no-shared remains the largest completed no-shared point so far.
+  - DeepEP has not yet completed the `786432` no-shared case, but it is showing the same memory pressure pattern.
   - The per-case timeout/script structure is working: a failed current case did not stop the DeepEP follow-up.
 - Next action:
   - Watch job `49775`.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -433,8 +433,16 @@
     - If we want to preserve `8` local experts per GPU instead, run a separate `experts=32` control.
 - Result:
   - Running.
-  - First observed case: `tokens=131072`, `shared_expert_dim=0`, kernel `current`.
+  - Observed cases:
+    - `tokens=131072`, `shared_expert_dim=0`, kernel `current`:
+      - `current`: `0.194346 s`, `0.674M tok/s`
+    - `tokens=131072`, `shared_expert_dim=0`, kernel `deepep_transport_capped_prewarmed`:
+      - `deepep_transport_capped_prewarmed`: `0.160582 s`, `0.816M tok/s`
+      - DeepEP is about `17.4%` faster on wall time.
+      - DeepEP exact caps: `max_recv_tokens=120064`, `max_local_assignments=262912`, `recv_factor=1.091684`, `assign_factor=3.988315`.
+      - The result line has emitted; the case end line has not emitted yet.
 - Interpretation:
-  - Pending.
+  - The `mlp_dim=4096` gap is present on EP4 for the same global `experts=64` shape, but the first no-shared point is smaller than the EP8 gap.
+  - This suggests the EP8 result is not purely an 8-GPU artifact; however, the gap still grows with EP size or local/global layout.
 - Next action:
   - Watch job `49801` and compare the EP4 gap against the EP8 `B200-EP-012` anchor.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -198,3 +198,24 @@
   - The checked-in `ragged_all_to_all` path remains more than 10x slower than `ring`; do not spend more time on it unless replacing the collective schedule wholesale.
 - Next action:
   - Run the side-by-side current `ring` vs restored DeepEP comparison on 8 GPUs, then decide whether a custom Triton/CUTLASS transport is still necessary or whether the work should shift to hardening the restored DeepEP benchmark and scaling/shape sweeps.
+
+### 2026-05-21 11:26 - 8-GPU retry status
+- Experiment ID: `B200-EP-007`
+- Hypothesis:
+  - The 4-GPU parity result should be rechecked on a full 8-GPU B200 node with the same side-by-side harness.
+- Command:
+  - Submitted job `49687`: `b200_compare_current_deepep8.sh`.
+  - Submitted job `49688` with the node that exposed only 7 usable devices excluded.
+- Config:
+  - target hardware: 8 B200 GPUs on one NVLinked node
+  - current `ring`: `local_experts=8`, `num_devices=8`, `topk=2`, `forward_backward`
+  - DeepEP: `experts=64`, `ep=8`, `topk=2`, `forward_backward`
+- Result:
+  - Job `49687` failed before benchmark rows were emitted.
+  - The allocation had 8 physical B200s, but JAX failed to create a stream executor for one device and exposed only 7 usable devices.
+  - Job `49688` was submitted after excluding that node and was pending on resources at last check.
+- Interpretation:
+  - The 8-GPU comparison is blocked on full-node device health / availability, not on the code path.
+  - The current evidence remains the 4-GPU same-allocation result from `B200-EP-006`.
+- Next action:
+  - Let the pending 8-GPU retry run if resources free up; otherwise resume from `B200-EP-006` and either retry later or broaden 4-GPU shape sweeps.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -224,3 +224,27 @@
   - A custom Triton/CUTLASS transport replacement is not currently justified by these B200 parity numbers; the next value is shape coverage and hardening.
 - Next action:
   - Broaden the sweep across token count, `topk`, and shared-expert settings, especially the historically hard `topk=8` / shared-expert fwd+bwd cases.
+
+### 2026-05-21 12:04 - Submit topk=8 shape sweep
+- Experiment ID: `B200-EP-008`
+- Hypothesis:
+  - The measured `topk=2` parity point is not enough; ring should lose first as `topk=8`, token count, and shared-expert backward pressure increase.
+- Command:
+  - Submitted job `49750`.
+  - Benchmark command family: `bench_moe_hillclimb.py --hidden 5120 --mlp-dim 2560 --experts 64 --topk 8 --distribution random --bench-pass forward_backward --ep-list 8 --warmup 1 --iters 3`
+- Config:
+  - hardware target: 8 B200 GPUs on one NVLinked node
+  - kernels: `current`, `deepep_transport_capped_prewarmed`
+  - shapes:
+    - `tokens=32768`, `shared_expert_dim=2048`
+    - `tokens=65536`, `shared_expert_dim=0`
+    - `tokens=65536`, `shared_expert_dim=2048`
+    - `tokens=131072`, `shared_expert_dim=0`
+    - `tokens=131072`, `shared_expert_dim=2048`
+    - `tokens=262144`, `shared_expert_dim=0`
+- Result:
+  - Pending at submission.
+- Interpretation:
+  - This is the first boundary-finding sweep after the 4-GPU and 8-GPU `topk=2` parity checks.
+- Next action:
+  - Watch job `49750`; record every completed shape and preserve failures as data.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -243,8 +243,8 @@
     - `tokens=131072`, `shared_expert_dim=2048`
     - `tokens=262144`, `shared_expert_dim=0`
 - Result:
-  - Job `49750` started on 8 B200 GPUs.
-  - Partial results at the 10-minute check:
+  - Job `49750` completed with exit code `0`.
+  - Results:
     - `tokens=32768`, `shared_expert_dim=2048`:
       - `current`: `0.015817 s`, `2.072M tok/s`
       - `deepep_transport_capped_prewarmed`: `0.016488 s`, `1.987M tok/s`
@@ -261,9 +261,38 @@
       - `current`: `0.063556 s`, `2.062M tok/s`
       - `deepep_transport_capped_prewarmed`: `0.063620 s`, `2.060M tok/s`
       - effectively tied, with `current` about `0.1%` faster on wall time.
-  - The `tokens=131072`, `shared_expert_dim=0` DeepEP case had emitted a result line but had not emitted its `CASE_END` line yet at the check.
+    - `tokens=131072`, `shared_expert_dim=2048`:
+      - `current`: `0.068007 s`, `1.927M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.067086 s`, `1.954M tok/s`
+      - DeepEP is about `1.4%` faster on wall time.
+    - `tokens=262144`, `shared_expert_dim=0`:
+      - `current`: `0.132050 s`, `1.985M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.129119 s`, `2.030M tok/s`
+      - DeepEP is about `2.2%` faster on wall time.
+  - DeepEP emitted CUDA teardown warnings after result lines; Slurm recorded the job as completed successfully.
 - Interpretation:
-  - In the completed early `topk=8` cases, ring still has not lost; it is faster at the smaller/shared shapes and tied at `131072` no-shared.
-  - The first likely breakpoint remains the still-running `131072` shared case or the `262144` no-shared case.
+  - `topk=8` does produce the expected crossover, but the gap is still small on B200.
+  - Ring is faster at smaller token counts, effectively tied at `131072` no-shared, and loses by only `1-2%` on the heavier `131072` shared and `262144` no-shared cases.
+  - We still do not have a B200 shape where ring is outside the requested 5-10% DeepEP window.
 - Next action:
-  - Watch job `49750`; record every completed shape and preserve failures as data.
+  - Push beyond this sweep: test `tokens=262144`, `shared_expert_dim=2048`, and then larger token counts if memory allows.
+
+### 2026-05-21 12:52 - Submit topk=8 stress sweep
+- Experiment ID: `B200-EP-009`
+- Hypothesis:
+  - Since ring only lost by `1-2%` in the completed `topk=8` sweep, the next likely stressors are `tokens=262144` with shared experts and `tokens=524288` without shared experts.
+- Command:
+  - Submitted job `49753`.
+  - Benchmark command family: `bench_moe_hillclimb.py --hidden 5120 --mlp-dim 2560 --experts 64 --topk 8 --distribution random --bench-pass forward_backward --ep-list 8 --warmup 1 --iters 3`
+- Config:
+  - hardware target: 8 B200 GPUs on one NVLinked node
+  - kernels: `current`, `deepep_transport_capped_prewarmed`
+  - shapes:
+    - `tokens=262144`, `shared_expert_dim=2048`
+    - `tokens=524288`, `shared_expert_dim=0`
+- Result:
+  - Pending at submission.
+- Interpretation:
+  - This is now a boundary stress test rather than a broad sweep.
+- Next action:
+  - Watch job `49753`; if these still stay within the parity window, shift to repeatability and correctness hardening rather than transport replacement.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -291,8 +291,23 @@
     - `tokens=262144`, `shared_expert_dim=2048`
     - `tokens=524288`, `shared_expert_dim=0`
 - Result:
-  - Pending at submission.
+  - Job `49753` completed with exit code `0`.
+  - Results:
+    - `tokens=262144`, `shared_expert_dim=2048`:
+      - `current`: `0.139057 s`, `1.885M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.137598 s`, `1.905M tok/s`
+      - DeepEP is about `1.0%` faster on wall time.
+      - DeepEP exact caps: `max_recv_tokens=178816`, `max_local_assignments=263168`, `recv_factor=1.465999`, `assign_factor=7.968872`.
+    - `tokens=524288`, `shared_expert_dim=0`:
+      - `current`: `0.279768 s`, `1.874M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.258105 s`, `2.031M tok/s`
+      - DeepEP is about `7.7%` faster on wall time.
+      - DeepEP exact caps: `max_recv_tokens=356736`, `max_local_assignments=525696`, `recv_factor=1.469681`, `assign_factor=7.978573`.
+  - DeepEP emitted timeout-check and CUDA teardown warnings after result lines; Slurm recorded the job as completed successfully.
 - Interpretation:
-  - This is now a boundary stress test rather than a broad sweep.
+  - This is the first B200 `topk=8` stress point where the current ring path is clearly losing rather than tying, but it is still within the requested 5-10% parity window.
+  - The observed boundary is token-count pressure rather than shared-expert pressure: `262144` with shared experts is only about `1%` behind, while `524288` without shared experts is about `7.7%` behind.
+  - A transport replacement is now plausible but not yet forced; the next useful decision point is whether the gap keeps widening at larger token counts or whether targeted scheduling/overlap fixes can recover the `524288` case.
 - Next action:
-  - Watch job `49753`; if these still stay within the parity window, shift to repeatability and correctness hardening rather than transport replacement.
+  - Run one narrow follow-up if memory allows: `tokens=524288`, `shared_expert_dim=2048`, `topk=8`, and optionally `tokens=1048576`, `shared_expert_dim=0` if the no-shared case fits comfortably.
+  - If the gap exceeds `10%`, prioritize transport/scheduling work; if it stays under `10%`, prioritize repeatability and correctness hardening around the restored DeepEP baseline and the current ring path.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -213,9 +213,14 @@
 - Result:
   - Job `49687` failed before benchmark rows were emitted.
   - The allocation had 8 physical B200s, but JAX failed to create a stream executor for one device and exposed only 7 usable devices.
-  - Job `49688` was submitted after excluding that node and was pending on resources at last check.
+  - Job `49688` completed with exit code `0`.
+  - `ring`, `forward_backward`: `0.005574 s`, `5.878M tok/s`, `0` dropped assignments.
+  - `deepep_transport_capped_prewarmed`, `ep=8`, `forward_backward`: `0.005509 s`, `5.948M tok/s`.
+  - DeepEP exact caps: `max_recv_tokens=7936`, `max_local_assignments=8320`, `recv_factor=4.129032`, `assign_factor=7.876923`.
+  - The DeepEP run emitted CUDA teardown warnings after the result line; Slurm recorded the job as completed successfully.
 - Interpretation:
-  - The 8-GPU comparison is blocked on full-node device health / availability, not on the code path.
-  - The current evidence remains the 4-GPU same-allocation result from `B200-EP-006`.
+  - The 8-GPU B200 full-block fwd+bwd shape is at parity: restored current-branch DeepEP is about `1.2%` faster than current `ring` on wall time.
+  - This confirms the current JAX `ring` path is within the requested 5-10% window for both the 4-GPU and 8-GPU B200 checks run so far.
+  - A custom Triton/CUTLASS transport replacement is not currently justified by these B200 parity numbers; the next value is shape coverage and hardening.
 - Next action:
-  - Let the pending 8-GPU retry run if resources free up; otherwise resume from `B200-EP-006` and either retry later or broaden 4-GPU shape sweeps.
+  - Broaden the sweep across token count, `topk`, and shared-expert settings, especially the historically hard `topk=8` / shared-expert fwd+bwd cases.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -975,3 +975,37 @@
   - The correctness gate should use relative/error-norm checks for BF16, or use scaled/model-like initialization for absolute checks.
 - Next action:
   - Treat `token_ragged_a2a` as semantically correct under BF16 relative tolerance and resume performance work. The next useful B200 run is a production-ish timing comparison, but prior timing already showed the current pure-JAX token-ragged path is much slower than stream-ring and DeepEP, so optimization should focus on reducing the number of ragged exchanges or using a fused/custom transport.
+
+### 2026-05-22 10:39 - Production-ish EP4 timing confirms token-ragged is not competitive
+- Experiment ID: `B200-EP-033`
+- Hypothesis:
+  - With correctness treated as acceptable under BF16 relative tolerance, the next question is whether the pure-JAX `token_ragged_a2a` transport is performance-competitive with `stream_ring` and DeepEP on a production-ish EP4 shape.
+- Command:
+  - B200 Slurm job `50158`.
+  - Code commit: `9887b433b09cf4e20e80de0c4795f1ebd0934e5c`.
+  - Shape:
+    - EP: `4`
+    - tokens: `131072`
+    - hidden: `2048`
+    - MLP dim: `2048`
+    - experts: `256`
+    - top-k: `8`
+    - shared expert dim: `0`
+    - dtype: `bfloat16`
+    - pass: forward + backward
+- Result:
+  - Job `50158` completed and emitted timings:
+    - `stream_ring`: `0.075300 s`, `1.740673M tok/s`
+    - `token_ragged_a2a`: `0.283252 s`, `0.462740M tok/s`
+    - `deepep_transport_capped_prewarmed`: `0.067122 s`, `1.952747M tok/s`
+  - DeepEP also emitted timeout/launch-failure diagnostics during teardown after the timing result, but the Slurm job exit code was `0`.
+- Interpretation:
+  - `token_ragged_a2a` is semantically useful as a JAX prototype, but not performance-competitive in its current form:
+    - about `3.76x` slower than `stream_ring`
+    - about `4.22x` slower than DeepEP
+  - On this shape, `stream_ring` is only about `12%` slower than DeepEP, so it remains the best non-DeepEP baseline.
+  - The pure-JAX token-ragged path pays too much for multiple ragged exchanges and separate metadata movement.
+- Next action:
+  - Stop trying to optimize this exact multi-ragged JAX transport. The viable next paths are:
+    - wire DeepEP for the production path; or
+    - build a fused/custom transport that sends token payload and metadata together and avoids repeated `ragged_all_to_all` calls.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -835,3 +835,84 @@
   - The remaining likely bug is after the dispatch payload exchange: local token-to-assignment expansion, assignment collapse, return exchange, scatter-add combine, or interaction with `ragged_dot` ordering.
 - Next action:
   - Stop debugging the dispatch payload exchange. Next B200 diagnostic should isolate the no-GMM path: dispatch tokens, expand assignments, collapse weighted identity outputs, return them, and compare against a direct per-token weighted reference.
+
+### 2026-05-22 02:09 - B200 no-GMM return/combine path passes
+- Experiment ID: `B200-EP-027`
+- Hypothesis:
+  - If dispatch, local assignment expansion, assignment collapse, return exchange, and scatter-add combine are correct, then replacing the expert computation with an identity should return `x * sum(topk_weights)` for each token.
+- Command:
+  - B200 Slurm job `50060`.
+  - Code commit: `9887b433b09cf4e20e80de0c4795f1ebd0934e5c`.
+  - Two-GPU no-GMM token-ragged diagnostic.
+- Result:
+  - Job `50060` completed successfully.
+  - No-GMM identity path matched the direct per-token reference:
+    - `B200_NO_GMM_CHECK max_abs=9.536743e-07`
+    - actual L1: `1.544883e+03`
+    - expected L1: `1.544883e+03`
+- Interpretation:
+  - The full `token_ragged_a2a` mismatch is not explained by dispatch payload ordering, return exchange ordering, source-token return metadata, assignment collapse, or source scatter-add combine.
+  - The remaining likely source is the expert computation stage, especially `ragged_dot` ordering/segment semantics under the token-rank-expanded layout, or the two-matmul gated MLP composition.
+- Next action:
+  - Submitted an identity `ragged_dot` diagnostic in the same token-rank path as B200 Slurm job `50061`. If that passes, reduce the full two-matmul gated MLP stage with deterministic small weights and compare against a host reference.
+
+### 2026-05-22 02:10 - B200 identity ragged-dot diagnostic hit shard_map VMA check
+- Experiment ID: `B200-EP-028`
+- Hypothesis:
+  - An identity `ragged_dot` inside the already-validated token-rank dispatch/return path should isolate whether `ragged_dot` ordering or segment semantics are the remaining source of the full `token_ragged_a2a` mismatch.
+- Command:
+  - B200 Slurm job `50061`.
+  - Code commit: `9887b433b09cf4e20e80de0c4795f1ebd0934e5c`.
+  - Two-GPU identity `ragged_dot` diagnostic.
+- Result:
+  - Job `50061` allocated two B200 GPUs but failed before producing a semantic result.
+  - Failure:
+    - `ValueError: When check_vma=True on jax.shard_map, manual_axis_type on jax.ShapeDtypeStruct must not be None`
+  - No `B200_RDOT_ID_CHECK` result was emitted.
+- Interpretation:
+  - This is another diagnostic-wrapper issue, not evidence about `ragged_dot` ordering.
+  - The Pallas-backed `ragged_dot` path needs the outer `shard_map` VMA check disabled in this standalone diagnostic.
+- Next action:
+  - Resubmitted the same identity `ragged_dot` diagnostic with `jax.shard_map(..., check_vma=False)` as B200 Slurm job `50127`.
+
+### 2026-05-22 02:34 - B200 identity ragged-dot path is close but not exact
+- Experiment ID: `B200-EP-029`
+- Hypothesis:
+  - If a single identity `ragged_dot` preserves assignment ordering in the token-rank path, the returned result should match the direct `x * sum(topk_weights)` reference up to matmul precision.
+- Command:
+  - B200 Slurm job `50127`.
+  - Code commit: `9887b433b09cf4e20e80de0c4795f1ebd0934e5c`.
+  - Two-GPU identity `ragged_dot` diagnostic with `jax.shard_map(..., check_vma=False)`.
+- Result:
+  - Job `50127` completed successfully.
+  - Identity `ragged_dot` path:
+    - `B200_RDOT_ID_CHECK max_abs=2.838612e-03`
+    - actual L1: `1.544884e+03`
+    - expected L1: `1.544883e+03`
+- Interpretation:
+  - A single identity `ragged_dot` does not show an ordering-scale failure. The residual is small compared with the full `token_ragged_a2a` mismatch and is consistent with low-level matmul precision rather than swapped or missing assignments.
+  - The remaining likely source is the full two-matmul gated MLP composition, its `ragged_dot` segment boundaries across the two calls, or the benchmark's reference comparison path.
+- Next action:
+  - Submitted a deterministic full two-matmul gated MLP check on the same tiny two-GPU token-rank shape against a direct host reference as B200 Slurm job `50128`.
+
+### 2026-05-22 02:35 - B200 tiny deterministic full MLP is close to host reference
+- Experiment ID: `B200-EP-030`
+- Hypothesis:
+  - If the full two-ragged-dot gated MLP composition is the source of the large `token_ragged_a2a` mismatch, a tiny deterministic two-GPU full-MLP check should show a semantic-scale error against a direct host reference.
+- Command:
+  - B200 Slurm job `50128`.
+  - Code commit: `9887b433b09cf4e20e80de0c4795f1ebd0934e5c`.
+  - Two-GPU deterministic full two-matmul gated MLP check with float32 inputs/weights.
+- Result:
+  - Job `50128` completed successfully.
+  - Full tiny MLP against direct host reference:
+    - `B200_FULL_MLP_REF_CHECK max_abs=2.333984e-01`
+    - actual L1: `1.291824e+05`
+    - expected L1: `1.291821e+05`
+    - dropped: `0`
+- Interpretation:
+  - The tiny float32 full-MLP path does not reproduce the large production correctness failure. The error is small relative to output scale and consistent with GPU matmul precision.
+  - Dispatch payload exchange, no-GMM return/combine, identity `ragged_dot`, and tiny deterministic full MLP are now all free of ordering-scale errors.
+  - The remaining reproduction gap is likely tied to production-ish BF16/topk=8 shape, capacity/segment pressure, or the benchmark's `stream_ring` comparison path rather than the basic token-rank protocol.
+- Next action:
+  - Run a reduced BF16/topk=8 reproduction that compares `token_ragged_a2a` and `stream_ring` at a smaller but less toy shape, then bisect shape/capacity if the mismatch appears.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -311,3 +311,23 @@
 - Next action:
   - Run one narrow follow-up if memory allows: `tokens=524288`, `shared_expert_dim=2048`, `topk=8`, and optionally `tokens=1048576`, `shared_expert_dim=0` if the no-shared case fits comfortably.
   - If the gap exceeds `10%`, prioritize transport/scheduling work; if it stays under `10%`, prioritize repeatability and correctness hardening around the restored DeepEP baseline and the current ring path.
+
+### 2026-05-21 13:12 - Submit topk=8 boundary follow-up
+- Experiment ID: `B200-EP-010`
+- Hypothesis:
+  - The `524288` no-shared stress case showed DeepEP about `7.7%` faster, so the next boundary checks are adding shared-expert backward work at the same token count and doubling tokens without shared experts.
+- Command:
+  - Submitted job `49766`.
+  - Benchmark command family: `bench_moe_hillclimb.py --hidden 5120 --mlp-dim 2560 --experts 64 --topk 8 --distribution random --bench-pass forward_backward --ep-list 8 --warmup 1 --iters 3`
+- Config:
+  - hardware target: 8 B200 GPUs on one NVLinked node
+  - kernels: `current`, `deepep_transport_capped_prewarmed`
+  - shapes:
+    - `tokens=524288`, `shared_expert_dim=2048`
+    - `tokens=1048576`, `shared_expert_dim=0`
+- Result:
+  - Pending at submission.
+- Interpretation:
+  - This follow-up should tell us whether the observed `topk=8` token-pressure boundary crosses the `10%` threshold, or remains within the requested parity band.
+- Next action:
+  - Watch job `49766`; if the gap exceeds `10%`, shift from parity validation to transport/scheduling optimization.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -779,3 +779,22 @@
   - The TPU payload-only check still shows the token-rank exchange order can be correct in isolation, so the remaining bug is more likely in the full return/combine path or local token-to-assignment expansion under the real CUDA execution.
 - Next action:
   - Submit a new short two-GPU debug/sanity path that prints token payload order, returned source-token order, per-rank counts, and local assignment counts for a tiny deterministic case before running the full MLP comparison.
+
+### 2026-05-22 00:38 - B200 payload-order check hit shard_map API mismatch
+- Experiment ID: `B200-EP-024`
+- Hypothesis:
+  - The full B200 `token_ragged_a2a` mismatch may come from CUDA `ragged_all_to_all` payload ordering, so isolate the token-rank payload exchange before debugging the return/combine path.
+- Command:
+  - B200 Slurm job `50045`.
+  - Code commit: `9887b433b09cf4e20e80de0c4795f1ebd0934e5c`.
+  - Two-GPU payload-order diagnostic for x, top-k metadata, weights, and source-token metadata.
+- Result:
+  - Job `50045` allocated two B200 GPUs but failed before running the exchange:
+    - failure: `TypeError: shard_map() got an unexpected keyword argument 'check_vma'`
+  - No `B200_PAYLOAD_CHECK` result was emitted.
+- Interpretation:
+  - This is an operational/API-compatibility failure, not evidence for or against the token-rank payload-order hypothesis.
+  - The diagnostic script needs to use the local JAX-compatible `shard_map` signature before the B200 payload-order question can be answered.
+- Next action:
+  - Resubmitted the same payload-order diagnostic without the unsupported `shard_map` keyword as B200 Slurm job `50053`.
+  - Use job `50053` to decide whether the remaining full-MoE mismatch is in exchange ordering or return/combine logic.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -676,9 +676,12 @@
   - Fixed the offset helper in commit `a625b06e1` and submitted retry job `49892`.
   - Job `49892` allocated four B200 GPUs but failed after GPU discovery, before producing correctness output. No benchmark result was emitted.
   - Submitted job `49902` as a two-GPU correctness-only sanity check while waiting for four-GPU resources. It failed before running the check because the batch script tried to update the checkout from GitHub inside the batch allocation, where repository authentication was not available.
+  - Submitted no-pull two-GPU retry job `49910` against commit `a625b06e1`. It completed with exit code `0`, but the post-offset-fix token-ragged path still failed semantic validation:
+    - output max-absolute error vs `stream_ring`: `1.280000e+02`
+    - gradient max-absolute error vs `stream_ring`: `8.000000e+00`
 - Interpretation:
   - The pre-fix result is not evidence against token-level `ragged_all_to_all`; it was using the wrong receive layout.
   - The pre-fix timing is still useful as a warning that the JAX path has multiple ragged exchanges plus metadata traffic, so correctness must be established before treating its timing as meaningful.
-  - The post-fix jobs have not yet tested correctness; both failures were operational, before the value/gradient comparison.
+  - The output-offset fix was necessary but not sufficient. The remaining bug is likely in token-level metadata ordering on the return path or in the local token-to-assignment expansion after dispatch.
 - Next action:
-  - Resubmit a no-pull two-GPU sanity job and keep the four-GPU timing retry queued separately. If the small correctness check passes, use the four-GPU timing smoke to decide whether to run the full `tokens=131072`, `mlp_dim=4096`, `topk=8` EP4/EP8 anchors.
+  - Stop timing `token_ragged_a2a` until it passes the two-GPU value/gradient check. Next debug step is an instrumented two-GPU toy case that compares token payload order, returned source-token order, and local assignment counts against the stream-ring/reference path.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -353,28 +353,26 @@
     - `tokens=524288`, `shared_expert_dim=2048`, DeepEP only
     - `tokens=786432`, `shared_expert_dim=0`, both kernels
 - Result:
-  - In progress.
-  - Observed cases:
+  - Job `49775` completed with exit code `0`, but all benchmark cases failed or timed out before emitting a result line.
+  - Cases:
     - `tokens=393216`, `shared_expert_dim=2048`, kernel `current`: no result line, exited `134`.
       - The error log showed a collective rendezvous termination after an all-gather; the script continued to the next case.
     - `tokens=393216`, `shared_expert_dim=2048`, kernel `deepep_transport_capped_prewarmed`: no result line, exited `124`.
       - The per-case timeout fired after 15 minutes.
-    - `tokens=524288`, `shared_expert_dim=2048`, kernel `deepep_transport_capped_prewarmed`: running at the time of observation.
-      - No result line, exited `124`.
+    - `tokens=524288`, `shared_expert_dim=2048`, kernel `deepep_transport_capped_prewarmed`: no result line, exited `124`.
       - The per-case timeout fired after large GPU OOM allocation failures and collective rendezvous waits.
-    - `tokens=786432`, `shared_expert_dim=0`, kernel `current`: running at the time of observation.
-      - No result line, exited `124`.
+    - `tokens=786432`, `shared_expert_dim=0`, kernel `current`: no result line, exited `124`.
       - The per-case timeout fired after large GPU OOM allocation failures and collective rendezvous waits.
-    - `tokens=786432`, `shared_expert_dim=0`, kernel `deepep_transport_capped_prewarmed`: running at the time of observation.
-      - The error log is already showing large GPU OOM allocation failures and collective rendezvous waits.
+    - `tokens=786432`, `shared_expert_dim=0`, kernel `deepep_transport_capped_prewarmed`: no result line, exited `124`.
+      - The per-case timeout fired after large GPU OOM allocation failures and collective rendezvous waits.
 - Interpretation:
   - This is already below the `524288` shared-expert OOM point, so the usable shared-expert `topk=8` boundary appears to be below `393216` tokens in this harness for both current ring and restored DeepEP.
   - The shared-expert failure mode is no longer a small latency gap; it is memory/runtime robustness at high token count.
   - The no-shared `786432` current case is also beyond the current memory envelope in this harness; `524288` no-shared remains the largest completed no-shared point so far.
-  - DeepEP has not yet completed the `786432` no-shared case, but it is showing the same memory pressure pattern.
+  - DeepEP also failed to complete the `786432` no-shared case under the same per-case timeout, so this sweep did not find a larger valid no-shared point.
   - The per-case timeout/script structure is working: a failed current case did not stop the DeepEP follow-up.
 - Next action:
-  - Watch job `49775`.
+  - Use the `mlp_dim=4096` sweep to find whether larger expert compute exposes a latency gap before the memory boundary.
 
 ### 2026-05-21 13:25 - Submit larger expert-size sweep
 - Experiment ID: `B200-EP-012`
@@ -393,8 +391,25 @@
     - `tokens=262144`, `shared_expert_dim=0`, both kernels
     - `tokens=262144`, `shared_expert_dim=2048`, both kernels
 - Result:
-  - Pending at submission.
+  - Job `49779` is running.
+  - Completed cases:
+    - `tokens=131072`, `shared_expert_dim=0`:
+      - `current`: `0.181974 s`, `0.720M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.108659 s`, `1.206M tok/s`
+      - DeepEP is about `40.3%` faster on wall time.
+      - DeepEP exact caps: `max_recv_tokens=89344`, `max_local_assignments=131584`, `recv_factor=1.467049`, `assign_factor=7.968872`.
+    - `tokens=131072`, `shared_expert_dim=2048`:
+      - `current`: `0.197305 s`, `0.664M tok/s`
+      - `deepep_transport_capped_prewarmed`: `0.110731 s`, `1.184M tok/s`
+      - DeepEP is about `43.9%` faster on wall time.
+      - DeepEP exact caps: `max_recv_tokens=89344`, `max_local_assignments=131584`, `recv_factor=1.467049`, `assign_factor=7.968872`.
+  - Current running case:
+    - `tokens=262144`, `shared_expert_dim=0`, kernel `current`.
+    - The error stream is showing large GPU OOM allocation failures followed by NCCL communicator initialization failure and collective rendezvous waits.
 - Interpretation:
-  - This is a conservative expert-size push: larger `mlp_dim`, but token counts stay below the known shared-expert OOM edge.
+  - Increasing expert width exposed a large gap immediately, even at `131072` tokens.
+  - The current ring path is now far outside the requested `5-10%` parity window on full fwd+bwd MoE MLP.
+  - Because both shared and no-shared cases lose by roughly the same amount, the next likely bottleneck is the combination of token exchange and local expert GEMM scheduling/overlap rather than shared-expert work alone.
+  - The `262144` current case may not fit the present harness memory envelope at `mlp_dim=4096`.
 - Next action:
-  - Let job `49775` finish first, then watch job `49779`.
+  - Let job `49779` finish or time out, then decide whether to profile the `131072` case or reduce the `262144` case to isolate memory from scheduling.

--- a/.agents/logbooks/b200-grug-ep.md
+++ b/.agents/logbooks/b200-grug-ep.md
@@ -816,3 +816,22 @@
   - The local output sharding spec was too narrow for the inferred data/expert variation in the returned `recv_sizes`.
 - Next action:
   - Resubmitted the payload-order diagnostic with output specs that include the data and expert mesh axes where inference requires them as B200 Slurm job `50059`.
+
+### 2026-05-22 01:28 - B200 token-rank payload exchange passes
+- Experiment ID: `B200-EP-026`
+- Hypothesis:
+  - If CUDA `ragged_all_to_all` is preserving the packed token-rank payload order, the isolated two-GPU payload diagnostic should exactly match the NumPy reference order for x, top-k metadata, weights, and source-token metadata.
+- Command:
+  - B200 Slurm job `50059`.
+  - Code commit: `9887b433b09cf4e20e80de0c4795f1ebd0934e5c`.
+  - Two-GPU payload-order diagnostic after fixing the local `shard_map` wrapper.
+- Result:
+  - Job `50059` completed successfully.
+  - Isolated payload exchange matched exactly:
+    - `B200_PAYLOAD_CHECK max_abs=0.000000e+00`
+    - received sizes: `[[32, 32], [32, 32]]`
+- Interpretation:
+  - The B200 mismatch in the full `token_ragged_a2a` MoE path is not explained by CUDA `ragged_all_to_all` reordering the token-rank payloads in the dispatch exchange.
+  - The remaining likely bug is after the dispatch payload exchange: local token-to-assignment expansion, assignment collapse, return exchange, scatter-add combine, or interaction with `ragged_dot` ordering.
+- Next action:
+  - Stop debugging the dispatch payload exchange. Next B200 diagnostic should isolate the no-GMM path: dispatch tokens, expand assignments, collapse weighted identity outputs, return them, and compare against a direct per-token weighted reference.

--- a/.agents/projects/b200-grug-ep-next-steps.md
+++ b/.agents/projects/b200-grug-ep-next-steps.md
@@ -13,6 +13,16 @@ shape:
 This is no longer a parity-validation problem. It is now a concrete regression
 case for the current path.
 
+The operating scale for the next iteration is EP4 on the same global model
+shape: `tokens=131072`, `hidden=5120`, `mlp_dim=4096`, `experts=64`, `topk=8`.
+EP4 still shows a `14-17%` DeepEP advantage, but completes quickly enough for
+probe runs and code hillclimbing.
+
+Latest result: the existing `stream_ring` variant is within the target parity
+window on the EP4 anchor: about `7.3%` slower than DeepEP without shared experts
+and about `5.8%` slower with `shared_expert_dim=2048`. Treat `stream_ring` as
+the EP4 development baseline before starting a fresh transport rewrite.
+
 ## Recipe-Derived Anchor Shapes
 
 The large-run MoE sizing table in `experiments/grug/moe/README.md` gives:
@@ -40,10 +50,11 @@ run recipe `topk=4` as a control after the gap is understood.
    - If it completes, use both `131072` and `262144` to check gap scaling.
 
 2. Freeze a small debug matrix around the fitting bad case.
-   - Required shape: `tokens=131072`, `hidden=5120`, `mlp_dim=4096`,
-     `experts=64`, `topk=8`, `ep=8`, fwd+bwd.
+   - Primary development shape: `tokens=131072`, `hidden=5120`,
+     `mlp_dim=4096`, `experts=64`, `topk=8`, `ep=4`, fwd+bwd.
+   - Confirming shape: same config with `ep=8` before making headline claims.
    - Run both `shared_expert_dim=0` and `shared_expert_dim=2048`.
-   - Repeat current and DeepEP once to verify the `40-44%` gap is stable.
+   - Repeat current and DeepEP once after each meaningful code change.
 
 3. Decompose the bad case before changing kernels.
    - Run the existing probe kernels for DeepEP transport and expert-compute
@@ -52,7 +63,14 @@ run recipe `topk=4` as a control after the gap is understood.
    - Separate time into routing/counting, token exchange, first ragged GEMM,
      activation/gating, second ragged GEMM, and output combine.
 
-4. Test recipe-shaped anchors after the debug shape is decomposed.
+4. Promote `stream_ring` before writing new kernels.
+   - Make `stream_ring` the EP4 development baseline.
+   - Re-check EP8 with `stream_ring` before investing in a DeepEP-style
+     transport rewrite.
+   - If EP8 reopens the gap, isolate whether the loss is EP-size communication
+     scaling, local/global layout, or memory pressure.
+
+5. Test recipe-shaped anchors after the debug shape is decomposed.
    - `1e24` proxy: start with `hidden=7680`, `mlp_dim=3840`,
      `shared_expert_dim=7680`, `tokens=32768` and `65536`, `topk=8`.
    - `1e25` proxy: start with `hidden=11264`, `mlp_dim=5632`,
@@ -61,7 +79,7 @@ run recipe `topk=4` as a control after the gap is understood.
    - Include `shared_expert_dim=0` for each proxy to separate shared-expert
      cost from EP transport and expert GEMM cost.
 
-5. Only then pick the implementation track.
+6. Only then pick the implementation track.
    - If current loses mostly in exchange/combine, port the DeepEP-style
      transport schedule directly.
    - If current loses mostly in ragged GEMM, focus on the JAX/CUTLASS/Triton

--- a/.agents/projects/b200-grug-ep-next-steps.md
+++ b/.agents/projects/b200-grug-ep-next-steps.md
@@ -28,6 +28,11 @@ fixed-top-k Triton combine did not improve the EP4 anchor. The Sonic-combine
 variant was about `1%` slower than `stream_ring`, so the remaining gap is not
 primarily the local combine primitive.
 
+EP8 follow-up: `stream_ring` is still a large improvement over the old current
+path, but lands just outside the target parity window at the `131072`,
+`hidden=5120`, `mlp_dim=4096`, `topk=8` anchor: about `10.4%` slower than DeepEP
+without shared experts and about `10.7%` slower with `shared_expert_dim=2048`.
+
 ## Recipe-Derived Anchor Shapes
 
 The large-run MoE sizing table in `experiments/grug/moe/README.md` gives:
@@ -72,10 +77,9 @@ run recipe `topk=4` as a control after the gap is understood.
    - Make `stream_ring` the EP4 development baseline.
    - Do not pursue the Sonic-style local combine swap further for this shape;
      it tested slightly slower than the scatter-add combine.
-   - Re-check EP8 with `stream_ring` before investing in a DeepEP-style
-     transport rewrite.
-   - If EP8 reopens the gap, isolate whether the loss is EP-size communication
-     scaling, local/global layout, or memory pressure.
+   - EP8 now shows a residual `~10-11%` gap rather than the old `40-44%` gap.
+     Promote `stream_ring`, but keep one profile/probe task for the remaining
+     EP8 transport difference.
 
 5. Test recipe-shaped anchors after the debug shape is decomposed.
    - `1e24` proxy: start with `hidden=7680`, `mlp_dim=3840`,

--- a/.agents/projects/b200-grug-ep-next-steps.md
+++ b/.agents/projects/b200-grug-ep-next-steps.md
@@ -23,6 +23,11 @@ window on the EP4 anchor: about `7.3%` slower than DeepEP without shared experts
 and about `5.8%` slower with `shared_expert_dim=2048`. Treat `stream_ring` as
 the EP4 development baseline before starting a fresh transport rewrite.
 
+Follow-up: replacing stream-ring's local scatter-add combine with Sonic's
+fixed-top-k Triton combine did not improve the EP4 anchor. The Sonic-combine
+variant was about `1%` slower than `stream_ring`, so the remaining gap is not
+primarily the local combine primitive.
+
 ## Recipe-Derived Anchor Shapes
 
 The large-run MoE sizing table in `experiments/grug/moe/README.md` gives:
@@ -65,6 +70,8 @@ run recipe `topk=4` as a control after the gap is understood.
 
 4. Promote `stream_ring` before writing new kernels.
    - Make `stream_ring` the EP4 development baseline.
+   - Do not pursue the Sonic-style local combine swap further for this shape;
+     it tested slightly slower than the scatter-add combine.
    - Re-check EP8 with `stream_ring` before investing in a DeepEP-style
      transport rewrite.
    - If EP8 reopens the gap, isolate whether the loss is EP-size communication

--- a/.agents/projects/b200-grug-ep-next-steps.md
+++ b/.agents/projects/b200-grug-ep-next-steps.md
@@ -33,6 +33,11 @@ path, but lands just outside the target parity window at the `131072`,
 `hidden=5120`, `mlp_dim=4096`, `topk=8` anchor: about `10.4%` slower than DeepEP
 without shared experts and about `10.7%` slower with `shared_expert_dim=2048`.
 
+Current experiment: test whether JAX `ragged_all_to_all` can express the
+DeepEP-like token-to-rank protocol. The benchmark-only `token_ragged_a2a`
+variant uses DeepEP layout metadata for the first smoke, but performs dispatch
+and combine with JAX ragged all-to-all.
+
 ## Recipe-Derived Anchor Shapes
 
 The large-run MoE sizing table in `experiments/grug/moe/README.md` gives:
@@ -80,6 +85,9 @@ run recipe `topk=4` as a control after the gap is understood.
    - EP8 now shows a residual `~10-11%` gap rather than the old `40-44%` gap.
      Promote `stream_ring`, but keep one profile/probe task for the remaining
      EP8 transport difference.
+   - First probe the `token_ragged_a2a` benchmark variant. If it works and is
+     competitive, it is a cleaner path than committing directly to DeepEP
+     transport FFI.
 
 5. Test recipe-shaped anchors after the debug shape is decomposed.
    - `1e24` proxy: start with `hidden=7680`, `mlp_dim=3840`,

--- a/.agents/projects/b200-grug-ep-next-steps.md
+++ b/.agents/projects/b200-grug-ep-next-steps.md
@@ -1,0 +1,77 @@
+# B200 Grug EP Next Steps
+
+## Current Decision Point
+
+The `mlp_dim=4096`, `topk=8`, EP8 sweep found a large gap at the first completed
+shape:
+
+- `tokens=131072`, `hidden=5120`, `mlp_dim=4096`, `shared_expert_dim=0`:
+  DeepEP is about `40.3%` faster than the current ring path.
+- `tokens=131072`, `hidden=5120`, `mlp_dim=4096`, `shared_expert_dim=2048`:
+  DeepEP is about `43.9%` faster than the current ring path.
+
+This is no longer a parity-validation problem. It is now a concrete regression
+case for the current path.
+
+## Recipe-Derived Anchor Shapes
+
+The large-run MoE sizing table in `experiments/grug/moe/README.md` gives:
+
+| Budget | Approx dim | Layers | Active width | Shared width | Recipe top-k |
+| --- | ---: | ---: | ---: | ---: | ---: |
+| `1e24` | `d7590` | `71` | `hidden/2`, rounded to 128 | `hidden` | `4` |
+| `1e25` | `d11150` | `102` | `hidden/2`, rounded to 128 | `hidden` | `4` |
+
+The benchmark-relevant rounded candidates are:
+
+| Budget | Hidden candidates | Expert `mlp_dim` | Shared expert dim |
+| --- | --- | ---: | ---: |
+| `1e24` | `7552` or `7680` | `3840` | hidden |
+| `1e25` | `11136` or `11264` | `5632` | hidden |
+
+For this transport study, keep `topk=8` as the stress setting, and optionally
+run recipe `topk=4` as a control after the gap is understood.
+
+## Plan
+
+1. Finish and log job `49779`.
+   - If `262144`, `hidden=5120`, `mlp_dim=4096` fails for the current path,
+     treat `131072` as the fitting debug anchor.
+   - If it completes, use both `131072` and `262144` to check gap scaling.
+
+2. Freeze a small debug matrix around the fitting bad case.
+   - Required shape: `tokens=131072`, `hidden=5120`, `mlp_dim=4096`,
+     `experts=64`, `topk=8`, `ep=8`, fwd+bwd.
+   - Run both `shared_expert_dim=0` and `shared_expert_dim=2048`.
+   - Repeat current and DeepEP once to verify the `40-44%` gap is stable.
+
+3. Decompose the bad case before changing kernels.
+   - Run the existing probe kernels for DeepEP transport and expert-compute
+     phases.
+   - Capture XLA profiles for current and DeepEP on the `131072` anchor.
+   - Separate time into routing/counting, token exchange, first ragged GEMM,
+     activation/gating, second ragged GEMM, and output combine.
+
+4. Test recipe-shaped anchors after the debug shape is decomposed.
+   - `1e24` proxy: start with `hidden=7680`, `mlp_dim=3840`,
+     `shared_expert_dim=7680`, `tokens=32768` and `65536`, `topk=8`.
+   - `1e25` proxy: start with `hidden=11264`, `mlp_dim=5632`,
+     `shared_expert_dim=11264`, `tokens=8192`, `16384`, and `32768`,
+     `topk=8`.
+   - Include `shared_expert_dim=0` for each proxy to separate shared-expert
+     cost from EP transport and expert GEMM cost.
+
+5. Only then pick the implementation track.
+   - If current loses mostly in exchange/combine, port the DeepEP-style
+     transport schedule directly.
+   - If current loses mostly in ragged GEMM, focus on the JAX/CUTLASS/Triton
+     GMM path and grouping layout.
+   - If current loses mostly in backward memory pressure, reduce materialized
+     all-gather state before touching GEMM kernels.
+
+## Stop Criteria
+
+- Short-term: current path is within `5-10%` of DeepEP on the fitting
+  `131072`, `hidden=5120`, `mlp_dim=4096`, `topk=8` fwd+bwd anchor.
+- Recipe-shaped: current path is within `5-10%` on the largest fitting `1e24`
+  proxy and has a clear failure mode for the `1e25` proxy if it does not fit.

--- a/.agents/scripts/bench_grug_ep.py
+++ b/.agents/scripts/bench_grug_ep.py
@@ -1,0 +1,228 @@
+#!/usr/bin/env python3
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Benchmark Grug MoE expert-parallel backends on local JAX devices."""
+
+import argparse
+import json
+import time
+from collections.abc import Callable
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import AxisType, Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from levanter.grug.grug_moe import moe_mlp
+from levanter.utils.activation import ActivationFunctionEnum
+
+
+def _json_print(payload: dict) -> None:
+    if jax.process_index() == 0:
+        print(json.dumps(payload, sort_keys=True), flush=True)
+
+
+def _block_until_ready(value):
+    return jax.block_until_ready(jax.tree_util.tree_map(lambda x: x, value))
+
+
+def _time_call(fn: Callable, args: tuple, *, warmup: int, iters: int) -> tuple[float, float]:
+    start_compile = time.perf_counter()
+    _block_until_ready(fn(*args))
+    compile_s = time.perf_counter() - start_compile
+
+    for _ in range(warmup):
+        _block_until_ready(fn(*args))
+
+    start = time.perf_counter()
+    for _ in range(iters):
+        _block_until_ready(fn(*args))
+    steady_s = (time.perf_counter() - start) / iters
+    return compile_s, steady_s
+
+
+def _make_mesh(num_devices: int, *, data_axis: int, model_axis: int) -> Mesh:
+    devices = np.asarray(jax.devices()[:num_devices], dtype=object)
+    if devices.size != num_devices:
+        raise ValueError(f"Requested {num_devices} devices, but JAX only sees {devices.size}")
+    if num_devices % (data_axis * model_axis) != 0:
+        raise ValueError(
+            f"num_devices={num_devices} must be divisible by data_axis * model_axis={data_axis * model_axis}"
+        )
+    expert_axis = num_devices // (data_axis * model_axis)
+    return Mesh(
+        devices.reshape(data_axis, expert_axis, model_axis),
+        ("data", "expert", "model"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit, AxisType.Explicit),
+    )
+
+
+def _sharded_inputs(
+    *,
+    mesh: Mesh,
+    tokens: int,
+    hidden_dim: int,
+    intermediate_dim: int,
+    local_experts: int,
+    topk: int,
+    dtype: jnp.dtype,
+    seed: int,
+):
+    expert_axis = mesh.shape["expert"]
+    num_experts = local_experts * expert_axis
+    keys = jax.random.split(jax.random.key(seed), 6)
+    batch_sharding = NamedSharding(mesh, P(("data", "expert"), None))
+    expert_sharding = NamedSharding(mesh, P("expert", None, None))
+
+    x = jax.random.normal(keys[0], (tokens, hidden_dim), dtype=dtype)
+    selected_experts = jax.random.randint(keys[1], (tokens, topk), 0, num_experts, dtype=jnp.int32)
+    combine_logits = jax.random.normal(keys[2], (tokens, topk), dtype=jnp.float32)
+    combine_weights = jax.nn.softmax(combine_logits, axis=-1).astype(dtype)
+    w_gate = jax.random.normal(keys[3], (num_experts, hidden_dim, intermediate_dim), dtype=dtype)
+    w_up = jax.random.normal(keys[4], (num_experts, hidden_dim, intermediate_dim), dtype=dtype)
+    w_down = jax.random.normal(keys[5], (num_experts, intermediate_dim, hidden_dim), dtype=dtype)
+    w_gate_up = jnp.concatenate([w_gate, w_up], axis=-1)
+
+    return (
+        jax.device_put(x, batch_sharding),
+        jax.device_put(selected_experts, batch_sharding),
+        jax.device_put(combine_weights, batch_sharding),
+        jax.device_put(w_gate_up, expert_sharding),
+        jax.device_put(w_down, expert_sharding),
+    )
+
+
+def _forward_fn(
+    x,
+    selected_experts,
+    combine_weights,
+    w_gate_up,
+    w_down,
+    *,
+    mesh: Mesh,
+    implementation: str,
+    capacity_factor: float,
+):
+    return moe_mlp(
+        x,
+        selected_experts,
+        combine_weights,
+        w_gate_up,
+        w_down,
+        activation=ActivationFunctionEnum.silu,
+        implementation=implementation,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _loss_fn(
+    x,
+    selected_experts,
+    combine_weights,
+    w_gate_up,
+    w_down,
+    *,
+    mesh: Mesh,
+    implementation: str,
+    capacity_factor: float,
+):
+    out = _forward_fn(
+        x,
+        selected_experts,
+        combine_weights,
+        w_gate_up,
+        w_down,
+        mesh=mesh,
+        implementation=implementation,
+        capacity_factor=capacity_factor,
+    )
+    return jnp.mean(out.astype(jnp.float32) * out.astype(jnp.float32))
+
+
+def _parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--tokens", type=int, default=131072)
+    parser.add_argument("--hidden-dim", type=int, default=5120)
+    parser.add_argument("--intermediate-dim", type=int, default=2560)
+    parser.add_argument("--local-experts", type=int, default=8)
+    parser.add_argument("--topk", type=int, default=2)
+    parser.add_argument("--capacity-factor", type=float, default=1.0)
+    parser.add_argument("--num-devices", type=int, default=0)
+    parser.add_argument("--data-axis", type=int, default=1)
+    parser.add_argument("--model-axis", type=int, default=1)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--iters", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--dtype", choices=("bf16", "fp32"), default="bf16")
+    parser.add_argument("--pass-mode", choices=("forward", "forward_backward"), default="forward")
+    parser.add_argument("--implementations", nargs="+", default=("ring", "ragged_all_to_all"))
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = _parse_args()
+    dtype = jnp.bfloat16 if args.dtype == "bf16" else jnp.float32
+    num_devices = args.num_devices or jax.local_device_count()
+    mesh = _make_mesh(num_devices, data_axis=args.data_axis, model_axis=args.model_axis)
+
+    with jax.set_mesh(mesh):
+        inputs = _sharded_inputs(
+            mesh=mesh,
+            tokens=args.tokens,
+            hidden_dim=args.hidden_dim,
+            intermediate_dim=args.intermediate_dim,
+            local_experts=args.local_experts,
+            topk=args.topk,
+            dtype=dtype,
+            seed=args.seed,
+        )
+
+        for implementation in args.implementations:
+            if args.pass_mode == "forward":
+                bench_fn = jax.jit(
+                    partial(
+                        _forward_fn,
+                        mesh=mesh,
+                        implementation=implementation,
+                        capacity_factor=args.capacity_factor,
+                    )
+                )
+            else:
+                bench_fn = jax.jit(
+                    jax.value_and_grad(
+                        partial(
+                            _loss_fn,
+                            mesh=mesh,
+                            implementation=implementation,
+                            capacity_factor=args.capacity_factor,
+                        ),
+                        argnums=(0, 3, 4),
+                    )
+                )
+
+            compile_s, steady_s = _time_call(bench_fn, inputs, warmup=args.warmup, iters=args.iters)
+            _json_print(
+                {
+                    "implementation": implementation,
+                    "pass_mode": args.pass_mode,
+                    "compile_s": compile_s,
+                    "steady_s": steady_s,
+                    "tokens_per_s": args.tokens / steady_s,
+                    "tokens": args.tokens,
+                    "topk": args.topk,
+                    "hidden_dim": args.hidden_dim,
+                    "intermediate_dim": args.intermediate_dim,
+                    "local_experts": args.local_experts,
+                    "expert_axis": mesh.shape["expert"],
+                    "num_devices": num_devices,
+                    "dtype": args.dtype,
+                    "capacity_factor": args.capacity_factor,
+                }
+            )
+
+
+if __name__ == "__main__":
+    main()

--- a/.agents/scripts/bench_grug_ep.py
+++ b/.agents/scripts/bench_grug_ep.py
@@ -15,6 +15,7 @@ import jax.numpy as jnp
 import numpy as np
 from jax.sharding import AxisType, Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
+from levanter.grug._moe.common import _DEFAULT_EP_CAPACITY_FACTOR
 from levanter.grug.grug_moe import moe_mlp
 from levanter.utils.activation import ActivationFunctionEnum
 
@@ -41,6 +42,20 @@ def _time_call(fn: Callable, args: tuple, *, warmup: int, iters: int) -> tuple[f
         _block_until_ready(fn(*args))
     steady_s = (time.perf_counter() - start) / iters
     return compile_s, steady_s
+
+
+def _scalar_int(value) -> int:
+    return int(np.asarray(jax.device_get(value)))
+
+
+def _benchmark_dropped_assignments(value, *, pass_mode: str) -> int:
+    if pass_mode == "forward":
+        _, dropped = value
+        return _scalar_int(dropped)
+
+    (loss, dropped), _ = value
+    del loss
+    return _scalar_int(dropped)
 
 
 def _make_mesh(num_devices: int, *, data_axis: int, model_axis: int) -> Mesh:
@@ -115,6 +130,7 @@ def _forward_fn(
         implementation=implementation,
         mesh=mesh,
         capacity_factor=capacity_factor,
+        report_capacity_overflow=True,
     )
 
 
@@ -139,7 +155,11 @@ def _loss_fn(
         implementation=implementation,
         capacity_factor=capacity_factor,
     )
-    return jnp.mean(out.astype(jnp.float32) * out.astype(jnp.float32))
+    if isinstance(out, tuple):
+        out, dropped = out
+    else:
+        dropped = jnp.array(0, dtype=jnp.int32)
+    return jnp.mean(out.astype(jnp.float32) * out.astype(jnp.float32)), dropped
 
 
 def _parse_args() -> argparse.Namespace:
@@ -149,7 +169,7 @@ def _parse_args() -> argparse.Namespace:
     parser.add_argument("--intermediate-dim", type=int, default=2560)
     parser.add_argument("--local-experts", type=int, default=8)
     parser.add_argument("--topk", type=int, default=2)
-    parser.add_argument("--capacity-factor", type=float, default=1.0)
+    parser.add_argument("--capacity-factor", type=float, default=_DEFAULT_EP_CAPACITY_FACTOR)
     parser.add_argument("--num-devices", type=int, default=0)
     parser.add_argument("--data-axis", type=int, default=1)
     parser.add_argument("--model-axis", type=int, default=1)
@@ -199,11 +219,13 @@ def main() -> None:
                             implementation=implementation,
                             capacity_factor=args.capacity_factor,
                         ),
+                        has_aux=True,
                         argnums=(0, 3, 4),
                     )
                 )
 
             compile_s, steady_s = _time_call(bench_fn, inputs, warmup=args.warmup, iters=args.iters)
+            dropped_assignments = _benchmark_dropped_assignments(bench_fn(*inputs), pass_mode=args.pass_mode)
             _json_print(
                 {
                     "implementation": implementation,
@@ -220,6 +242,7 @@ def main() -> None:
                     "num_devices": num_devices,
                     "dtype": args.dtype,
                     "capacity_factor": args.capacity_factor,
+                    "dropped_assignments": dropped_assignments,
                 }
             )
 

--- a/.agents/scripts/bench_moe_hillclimb_tpu_pure_layout.py
+++ b/.agents/scripts/bench_moe_hillclimb_tpu_pure_layout.py
@@ -1,0 +1,40 @@
+#!/usr/bin/env python3
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run the MoE hillclimb benchmark on TPU with a pure-JAX token layout.
+
+The token-ragged benchmark path normally uses the DeepEP layout helper for
+token-to-rank reachability. DeepEP itself is GPU-only, but the layout semantics
+are simple enough to reproduce in JAX for TPU transport experiments.
+"""
+
+import jax.numpy as jnp
+from iris.runtime.jax_init import initialize_jax
+
+from lib.levanter.scripts.bench import bench_moe_hillclimb as bench
+
+
+def pure_jax_dispatch_layout(
+    selected_experts: jnp.ndarray,
+    *,
+    num_ranks: int,
+    num_experts: int,
+) -> tuple[jnp.ndarray, jnp.ndarray, jnp.ndarray]:
+    local_experts = num_experts // num_ranks
+    ranks = selected_experts // local_experts
+    rank_ids = jnp.arange(num_ranks, dtype=ranks.dtype)
+    is_token_in_rank = jnp.any(ranks[:, :, None] == rank_ids, axis=1)
+    num_tokens_per_rank = jnp.sum(is_token_in_rank.astype(jnp.int32), axis=0)
+    num_tokens_per_expert = jnp.bincount(selected_experts.reshape(-1), length=num_experts).astype(jnp.int32)
+    return num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank
+
+
+def main() -> None:
+    initialize_jax()
+    bench.deepep_get_dispatch_layout = pure_jax_dispatch_layout
+    bench.main()
+
+
+if __name__ == "__main__":
+    main()

--- a/docs/debug-log-token-ragged-gmm.md
+++ b/docs/debug-log-token-ragged-gmm.md
@@ -1,0 +1,46 @@
+# Debugging log for token-ragged Megablox GMM
+
+Goal: diagnose the TPU Mosaic compile failure seen in the `token_ragged_a2a`
+sanity path and keep the fix scoped to ragged GMM dispatch.
+
+## Initial status
+
+The token-rank `ragged_all_to_all` payload exchange had already passed a TPU toy
+check with exact payload agreement. The full end-to-end sanity path still failed
+before correctness comparison in the TPU Megablox GMM path.
+
+## Hypothesis 1
+
+The failure might be a raw JAX 0.10 Megablox `gmm` compile issue for bf16 inputs
+with f32 accumulation.
+
+## Results
+
+Direct Megablox `gmm` calls compiled on TPU for bf16 and f32 inputs, for both
+f32 and input-dtype outputs. A minimal `shard_map` wrapper around
+`haliax.nn.ragged_dot(..., implementation="megablox")` also compiled for small
+and production-like dimensions.
+
+## Hypothesis 2
+
+The failure is specific to the end-to-end autodiff trace for narrow sanity
+dimensions.
+
+## Results
+
+With the benchmark's DeepEP layout call replaced by a pure-JAX equivalent, the
+full `token_ragged_a2a` forward path compiled for hidden sizes 8, 128, and 512.
+The forward+backward path failed only for the tiny hidden-size case. The failing
+lowering used a Megablox/Pallas block shape that is invalid for TPU Mosaic when
+one of the matmul dimensions is below the TPU block constraint.
+
+## Changes to make
+
+Add a pre-lowering guard in `haliax.nn.ragged_dot` so automatic TPU dispatch
+uses XLA instead of Megablox for narrow shapes. Leave explicit Megablox requests
+as early failures with a clear error.
+
+## Results
+
+After the guard, the reduced TPU forward+backward `token_ragged_a2a` sanity
+case completed with the narrow GMM path falling back to XLA.

--- a/lib/haliax/src/haliax/nn/ragged_dot.py
+++ b/lib/haliax/src/haliax/nn/ragged_dot.py
@@ -96,6 +96,7 @@ def _triton_ragged_dot_kernel(
 
     @pl.when(start_m < hi)
     def _compute():
+        zero_i32 = jnp.asarray(0, dtype=jnp.int32)
         span_m = pl.ds(start_m, block_m)
         acc = jnp.zeros((block_m, out_ref.shape[1]), dtype=jnp.float32)
         k = a_ref.shape[1]
@@ -104,14 +105,18 @@ def _triton_ragged_dot_kernel(
             start_k = i * block_k
             span_k = pl.ds(start_k, block_k)
             a = plgpu.load(a_ref.at[span_m, span_k])
-            b = plgpu.load(b_ref.at[span_k, pl.ds(0, b_ref.shape[1])])
+            b = plgpu.load(b_ref.at[span_k, pl.ds(zero_i32, b_ref.shape[1])])
             dtype = jnp.result_type(a, b)
             return acc + pl.dot(a.astype(dtype), b.astype(dtype))
 
         num_k_blocks = pl.cdiv(k, block_k)
         acc = jax.lax.fori_loop(0, num_k_blocks, body, acc)
         mask = (start_m + jnp.arange(block_m)) < hi
-        plgpu.store(out_ref.at[span_m, pl.ds(0, out_ref.shape[1])], acc.astype(out_ref.dtype), mask=mask[:, None])
+        plgpu.store(
+            out_ref.at[span_m, pl.ds(zero_i32, out_ref.shape[1])],
+            acc.astype(out_ref.dtype),
+            mask=mask[:, None],
+        )
 
 
 def _triton_default_block_sizes(m: int, k: int, n: int) -> tuple[int, int, int]:
@@ -173,7 +178,8 @@ def _triton_ragged_contracting_dim_dot_kernel(
         dtype = jnp.result_type(a, b)
         return acc + pl.dot(a.astype(dtype).T, b.astype(dtype))
 
-    num_k_blocks = jnp.maximum(pl.cdiv(jnp.int32(hi - lo), block_k), 1)
+    block_k_i32 = jnp.asarray(block_k, dtype=jnp.int32)
+    num_k_blocks = jnp.maximum(pl.cdiv(jnp.int32(hi - lo), block_k_i32), 1)
     acc = jnp.zeros((block_m, out_ref.shape[1]), dtype=jnp.float32)
     acc = jax.lax.fori_loop(0, num_k_blocks - 1, body, acc)
     acc = body(num_k_blocks - 1, acc, mask_k=True)

--- a/lib/haliax/src/haliax/nn/ragged_dot.py
+++ b/lib/haliax/src/haliax/nn/ragged_dot.py
@@ -42,6 +42,7 @@ _AUTO_FALLBACK_EXCEPTIONS = (NotImplementedError, RuntimeError)
 _HAS_WARNED_AUTO_FALLBACK = False
 _TRITON_DEFAULT_BLOCK_N = 128
 _TRITON_BLACKWELL_BLOCK_N = 256
+_TPU_MEGABLOX_MIN_AUTODIFF_DIM = 128
 
 
 def _is_blackwell_gpu_backend() -> bool:
@@ -67,6 +68,11 @@ def _is_blackwell_gpu_backend() -> bool:
 def _ragged_dot_megablox_impl(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
     if _gmm_megablox is None:
         raise NotImplementedError("megablox GMM is not available (TPU-only)")
+    if jax.default_backend() == "tpu" and min(lhs.shape[1], rhs.shape[2]) < _TPU_MEGABLOX_MIN_AUTODIFF_DIM:
+        raise NotImplementedError(
+            "megablox GMM is not selected for TPU ragged_dot shapes with contracting or output dimensions "
+            f"below {_TPU_MEGABLOX_MIN_AUTODIFF_DIM}; use the XLA implementation for these narrow shapes."
+        )
     tile_size = (512, 1024, 1024)  # (m, k, n)
     m, k, n = lhs.shape[0], lhs.shape[1], rhs.shape[2]
     return _gmm_megablox(

--- a/lib/haliax/src/haliax/nn/ragged_dot.py
+++ b/lib/haliax/src/haliax/nn/ragged_dot.py
@@ -40,6 +40,28 @@ except (ImportError, ModuleNotFoundError):
 Implementation: TypeAlias = Literal["auto", "megablox", "triton", "xla"]
 _AUTO_FALLBACK_EXCEPTIONS = (NotImplementedError, RuntimeError)
 _HAS_WARNED_AUTO_FALLBACK = False
+_TRITON_DEFAULT_BLOCK_N = 128
+_TRITON_BLACKWELL_BLOCK_N = 256
+
+
+def _is_blackwell_gpu_backend() -> bool:
+    if jax.default_backend() != "gpu":
+        return False
+    try:
+        devices = jax.devices("gpu")
+    except RuntimeError:
+        return False
+    if not devices:
+        return False
+    device = devices[0]
+    compute_capability = getattr(device, "compute_capability", None)
+    if compute_capability is not None:
+        try:
+            return float(compute_capability) >= 10.0
+        except (TypeError, ValueError):
+            pass
+    device_kind = getattr(device, "device_kind", "")
+    return any(name in device_kind for name in ("B200", "B300", "GB200", "GB300"))
 
 
 def _ragged_dot_megablox_impl(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
@@ -92,14 +114,20 @@ def _triton_ragged_dot_kernel(
         plgpu.store(out_ref.at[span_m, pl.ds(0, out_ref.shape[1])], acc.astype(out_ref.dtype), mask=mask[:, None])
 
 
+def _triton_default_block_sizes(m: int, k: int, n: int) -> tuple[int, int, int]:
+    block_m = min(128, int(pl.next_power_of_2(m)))
+    max_block_n = _TRITON_BLACKWELL_BLOCK_N if _is_blackwell_gpu_backend() else _TRITON_DEFAULT_BLOCK_N
+    block_n = min(max_block_n, int(pl.next_power_of_2(n)))
+    block_k = min(32, int(pl.next_power_of_2(k)))
+    return block_m, block_n, block_k
+
+
 def _triton_default_pallas_call(lhs: jax.Array, rhs: jax.Array, group_sizes: jax.Array) -> jax.Array:
     """Raw Pallas-Triton grouped matmul for the default ragged-dot layout."""
     m, k = lhs.shape
     num_groups, _, n = rhs.shape
 
-    block_m = min(128, int(pl.next_power_of_2(m)))
-    block_n = min(128, int(pl.next_power_of_2(n)))
-    block_k = min(32, int(pl.next_power_of_2(k)))
+    block_m, block_n, block_k = _triton_default_block_sizes(m, k, n)
 
     cum_rows = jnp.cumulative_sum(group_sizes, include_initial=True)
 

--- a/lib/haliax/tests/test_ragged_dot_dispatch.py
+++ b/lib/haliax/tests/test_ragged_dot_dispatch.py
@@ -73,6 +73,18 @@ def test_ragged_dot_gpu_auto_uses_triton_when_available(monkeypatch):
     assert jnp.array_equal(auto_out, expected)
 
 
+def test_triton_default_block_sizes_use_blackwell_n_tile(monkeypatch):
+    monkeypatch.setattr(ragged_dot_module, "_is_blackwell_gpu_backend", lambda: True)
+
+    assert ragged_dot_module._triton_default_block_sizes(32768, 5120, 5120) == (128, 256, 32)
+
+
+def test_triton_default_block_sizes_keep_non_blackwell_n_tile(monkeypatch):
+    monkeypatch.setattr(ragged_dot_module, "_is_blackwell_gpu_backend", lambda: False)
+
+    assert ragged_dot_module._triton_default_block_sizes(32768, 5120, 5120) == (128, 128, 32)
+
+
 def test_triton_custom_vjp_routes_backward_through_triton_layouts(monkeypatch):
     lhs, rhs, group_sizes = _inputs()
     calls = []

--- a/lib/haliax/tests/test_ragged_dot_dispatch.py
+++ b/lib/haliax/tests/test_ragged_dot_dispatch.py
@@ -73,6 +73,27 @@ def test_ragged_dot_gpu_auto_uses_triton_when_available(monkeypatch):
     assert jnp.array_equal(auto_out, expected)
 
 
+def test_tpu_auto_uses_xla_for_narrow_megablox_shapes(monkeypatch):
+    lhs, rhs, group_sizes = _inputs()
+    xla_out = jnp.full((lhs.shape[0], rhs.shape[2]), 23.0, dtype=lhs.dtype)
+    monkeypatch.setattr(ragged_dot_module.jax, "default_backend", lambda: "tpu")
+    monkeypatch.setattr(ragged_dot_module, "_gmm_megablox", object())
+    monkeypatch.setattr(ragged_dot_module, "_ragged_dot_xla_impl", lambda *_: xla_out)
+
+    auto_out = ragged_dot(lhs, rhs, group_sizes, implementation="auto")
+
+    assert jnp.array_equal(auto_out, xla_out)
+
+
+def test_explicit_megablox_rejects_narrow_shapes(monkeypatch):
+    lhs, rhs, group_sizes = _inputs()
+    monkeypatch.setattr(ragged_dot_module.jax, "default_backend", lambda: "tpu")
+    monkeypatch.setattr(ragged_dot_module, "_gmm_megablox", object())
+
+    with pytest.raises(NotImplementedError, match="below 128"):
+        ragged_dot(lhs, rhs, group_sizes, implementation="megablox")
+
+
 def test_triton_default_block_sizes_use_blackwell_n_tile(monkeypatch):
     monkeypatch.setattr(ragged_dot_module, "_is_blackwell_gpu_backend", lambda: True)
 

--- a/lib/levanter/docs/dev/DeepEP.md
+++ b/lib/levanter/docs/dev/DeepEP.md
@@ -1,0 +1,67 @@
+# DeepEP for Grug MoE on NVIDIA GPUs
+
+Levanter has an experimental JAX FFI integration for DeepEP intranode expert-parallel dispatch and combine. The
+integration is optional: ordinary installs keep using the built-in Grug MoE backends, and DeepEP is only loaded when a
+DeepEP-backed backend or benchmark path is selected.
+
+## Install
+
+DeepEP is treated as an external source checkout rather than a vendored package.
+
+```bash
+git clone https://github.com/deepseek-ai/DeepEP.git /path/to/DeepEP
+export DEEPEP_SRC_ROOT=/path/to/DeepEP
+export DEEPEP_CUDA_ARCH=sm_100  # B200/GB200. Use sm_90 or sm_90a for H100-class systems.
+```
+
+The raw FFI build path needs `nvcc` on `PATH`. The compiled objects are cached under `~/.cache/marin` by default. To
+put the cache somewhere else:
+
+```bash
+export MARIN_DEEPEP_CACHE_DIR=/path/to/cache
+```
+
+For environments where raw `nvcc` linking does not find the CUDA/PyTorch runtime libraries cleanly, the transport FFI
+also supports a Torch extension build:
+
+```bash
+export DEEPEP_BUILD_WITH_TORCH_EXTENSION=1
+```
+
+Keep `DEEPEP_LOAD_AS_PYTHON_MODULE=0` with the Torch extension build path. The Python-module loader is for the raw FFI
+artifact path.
+
+## Preflight
+
+Run the preflight before launching a GPU job:
+
+```bash
+uv run python -m levanter.kernels.deepep.preflight
+```
+
+The preflight checks:
+
+- `DEEPEP_SRC_ROOT` is set and contains the DeepEP transport sources.
+- `nvcc` is available.
+- `DEEPEP_CUDA_ARCH` is one of `sm_90`, `sm_90a`, or `sm_100`.
+- incompatible FFI loader/build flags are not set together.
+
+The first real use compiles the layout and transport FFI libraries into the cache. On B200, use `DEEPEP_CUDA_ARCH=sm_100`
+so the cached object targets the right device.
+
+## Backend Selection
+
+For a Grug MoE block with an expert mesh axis, select:
+
+```yaml
+model:
+  moe_implementation: deepep
+```
+
+The backend currently targets intranode expert parallelism: the expert group must span all visible local GPUs in the
+process, and the hidden dimension must be divisible by 8. If those constraints do not hold, use `implementation: ring`
+as the built-in fallback.
+
+The benchmark harness also contains capped DeepEP variants that precompute tighter receive capacities for comparing
+transport performance. The production backend uses conservative static capacities for correctness and integration
+simplicity; capacity tightening is the next optimization once the runtime config path settles.

--- a/lib/levanter/docs/dev/DeepEP.md
+++ b/lib/levanter/docs/dev/DeepEP.md
@@ -51,15 +51,14 @@ so the cached object targets the right device.
 
 ## Backend Selection
 
-For a Grug MoE block with an expert mesh axis, select:
+For a Grug MoE block with an expert mesh axis, set the config object field:
 
-```yaml
-model:
-  moe_implementation: deepep
+```python
+config = dataclasses.replace(config, moe_implementation="deepep")
 ```
 
 The backend currently targets intranode expert parallelism: the expert group must span all visible local GPUs in the
-process, and the hidden dimension must be divisible by 8. If those constraints do not hold, use `implementation: ring`
+process, and the hidden dimension must be divisible by 8. If those constraints do not hold, use `moe_implementation="ring"`
 as the built-in fallback.
 
 The benchmark harness also contains capped DeepEP variants that precompute tighter receive capacities for comparing

--- a/lib/levanter/mkdocs.yml
+++ b/lib/levanter/mkdocs.yml
@@ -111,6 +111,7 @@ nav:
   - 'Developer Guide':
       - 'dev/Port-Models.md'
       - 'dev/GPU-Docker-Dev.md'
+      - 'dev/DeepEP.md'
   - 'FAQ' : 'faq.md'
   - Other:
       - Release Announcement: 'Levanter-1.0-Release.md'

--- a/lib/levanter/scripts/bench/bench_moe_hillclimb.py
+++ b/lib/levanter/scripts/bench/bench_moe_hillclimb.py
@@ -1,0 +1,4692 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Focused MoE hillclimb harness for the functional Grug MoE kernels.
+
+This harness compares the current `levanter.grug.grug_moe.moe_mlp` path against
+the pre-optimization EP ring implementation that globally sorted all gathered
+assignments before filtering to local experts. It keeps routing fixed so the
+timing reflects kernel/collective work rather than router noise.
+"""
+
+import argparse
+import os
+import time
+from collections.abc import Callable
+from functools import partial
+from pathlib import Path
+from typing import Literal
+
+import numpy as np
+
+import jax
+import jax.distributed
+import jax.numpy as jnp
+from haliax.nn.ragged_dot import ragged_dot
+from jax import shard_map
+from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P, get_abstract_mesh
+
+from levanter.grug import grug_moe as grug_moe_lib
+from levanter.kernels.deepep import deepep_combine_intranode, deepep_dispatch_intranode, deepep_get_dispatch_layout
+from levanter.utils.activation import ActivationFunctionEnum
+
+Distribution = Literal["random", "runs"]
+Kernel = Literal[
+    "legacy",
+    "current",
+    "cumsum",
+    "packed_return",
+    "stream_ring",
+    "ragged_a2a",
+    "deepep_layout_ragged_a2a",
+    "deepep_transport_identity",
+    "deepep_transport_assignments_identity",
+    "deepep_transport_first_ragged_dot_probe",
+    "deepep_transport_gate_probe",
+    "deepep_transport_second_ragged_dot_probe",
+    "deepep_transport",
+    "deepep_transport_prewarmed",
+    "deepep_transport_capped",
+    "deepep_transport_capped_prewarmed",
+    "deepep_transport_staged",
+    "prefix_counts",
+    "vector_prefix",
+    "onehot_counts",
+    "padded_take",
+    "segment_sum",
+    "sorted_segment_sum",
+    "prefix_segment_sum",
+    "vector_sorted_segment_sum",
+    "owner_local_scatter",
+    "lax_scatter",
+    "take_segment_bwd",
+    "take_sorted_segment_bwd",
+    "owner_local_take",
+    "weight_cast",
+    "narrow_meta",
+]
+BenchPass = Literal["forward", "forward_backward"]
+
+
+def _print0(*args, **kwargs) -> None:
+    if jax.process_index() == 0:
+        print(*args, **kwargs)
+
+
+def _round_up_capacity(value: int, *, multiple: int) -> int:
+    return ((value + multiple - 1) // multiple) * multiple
+
+
+def _time_fn(fn: Callable, *args, warmup: int = 2, iters: int = 5) -> float:
+    compiled = jax.jit(fn)
+    jax.block_until_ready(compiled(*args))
+    for _ in range(warmup):
+        jax.block_until_ready(compiled(*args))
+    start = time.perf_counter()
+    for _ in range(iters):
+        jax.block_until_ready(compiled(*args))
+    return (time.perf_counter() - start) / iters
+
+
+def _sort_activations(
+    inputs: jax.Array,
+    sort_indices: jax.Array,
+) -> jax.Array:
+    if inputs.shape[0] != sort_indices.shape[0]:
+        raise ValueError(f"Expected matching leading dims, got {inputs.shape[0]} and {sort_indices.shape[0]}")
+    return _sort_activations_custom(inputs, sort_indices)
+
+
+@jax.custom_vjp
+def _sort_activations_custom(inputs: jax.Array, sort_indices: jax.Array) -> jax.Array:
+    return inputs[sort_indices, ...]
+
+
+def _sort_activations_custom_fwd(inputs: jax.Array, sort_indices: jax.Array) -> tuple[jax.Array, jax.Array]:
+    return _sort_activations_custom(inputs, sort_indices), sort_indices
+
+
+def _sort_activations_custom_bwd(residuals: jax.Array, grads: jax.Array) -> tuple[jax.Array, None]:
+    sort_indices = residuals
+    return _sort_activations_custom(grads, jnp.argsort(sort_indices)), None
+
+
+_sort_activations_custom.defvjp(_sort_activations_custom_fwd, _sort_activations_custom_bwd)
+
+
+@jax.custom_vjp
+def _take_tokens_segment_sum(inputs: jax.Array, token_indices: jax.Array) -> jax.Array:
+    return inputs[token_indices, ...]
+
+
+def _take_tokens_segment_sum_fwd(
+    inputs: jax.Array, token_indices: jax.Array
+) -> tuple[jax.Array, tuple[jax.Array, int]]:
+    return _take_tokens_segment_sum(inputs, token_indices), (token_indices, inputs.shape[0])
+
+
+def _take_tokens_segment_sum_bwd(residuals: tuple[jax.Array, int], grads: jax.Array) -> tuple[jax.Array, None]:
+    token_indices, tokens = residuals
+    grad_inputs = jax.ops.segment_sum(grads, token_indices, num_segments=tokens, indices_are_sorted=False)
+    return grad_inputs, None
+
+
+_take_tokens_segment_sum.defvjp(_take_tokens_segment_sum_fwd, _take_tokens_segment_sum_bwd)
+
+
+@jax.custom_vjp
+def _take_tokens_sorted_segment_sum(inputs: jax.Array, token_indices: jax.Array) -> jax.Array:
+    return inputs[token_indices, ...]
+
+
+def _take_tokens_sorted_segment_sum_fwd(
+    inputs: jax.Array, token_indices: jax.Array
+) -> tuple[jax.Array, tuple[jax.Array, int]]:
+    return _take_tokens_sorted_segment_sum(inputs, token_indices), (token_indices, inputs.shape[0])
+
+
+def _take_tokens_sorted_segment_sum_bwd(residuals: tuple[jax.Array, int], grads: jax.Array) -> tuple[jax.Array, None]:
+    token_indices, tokens = residuals
+    sort_idx = jnp.argsort(token_indices)
+    token_sorted = jnp.take(token_indices, sort_idx, axis=0)
+    grads_sorted = _sort_activations(grads, sort_idx)
+    grad_inputs = jax.ops.segment_sum(grads_sorted, token_sorted, num_segments=tokens, indices_are_sorted=True)
+    return grad_inputs, None
+
+
+_take_tokens_sorted_segment_sum.defvjp(_take_tokens_sorted_segment_sum_fwd, _take_tokens_sorted_segment_sum_bwd)
+
+
+def _profile_fn(
+    fn: Callable,
+    *args,
+    warmup: int,
+    iters: int,
+    profile_dir: Path,
+    profile_name: str,
+) -> float:
+    compiled = jax.jit(fn)
+    jax.block_until_ready(compiled(*args))
+    for _ in range(warmup):
+        jax.block_until_ready(compiled(*args))
+
+    os.makedirs(profile_dir, exist_ok=True)
+    jax.profiler.start_trace(str(profile_dir), create_perfetto_link=False, create_perfetto_trace=True)
+    start = time.perf_counter()
+    try:
+        for step in range(iters):
+            with jax.profiler.StepTraceAnnotation(profile_name, step_num=step):
+                jax.block_until_ready(compiled(*args))
+    finally:
+        jax.profiler.stop_trace()
+    return (time.perf_counter() - start) / iters
+
+
+def _sample_router_logits(
+    key: jax.Array,
+    *,
+    tokens: int,
+    experts: int,
+    distribution: Distribution,
+    run_alpha: float,
+    run_noise_scale: float,
+) -> jax.Array:
+    if distribution == "random":
+        return jax.random.normal(key, (tokens, experts), dtype=jnp.float32)
+
+    if distribution == "runs":
+        seed = int(jax.random.randint(key, shape=(), minval=0, maxval=2**31 - 1))
+        rng = np.random.default_rng(seed)
+        mean_run = max(2.0, 1.0 / max(1e-6, 1.0 - run_alpha))
+        p = min(0.9, max(0.01, 1.0 / mean_run))
+
+        assigned = np.empty((tokens,), dtype=np.int32)
+        loads = np.zeros((experts,), dtype=np.int32)
+        prev_expert = -1
+        pos = 0
+        while pos < tokens:
+            run_len = int(rng.geometric(p))
+            run_len = min(run_len, tokens - pos)
+            min_load = int(np.min(loads))
+            candidates = np.flatnonzero(loads == min_load)
+            if prev_expert in candidates and candidates.size > 1:
+                candidates = candidates[candidates != prev_expert]
+            expert = int(rng.choice(candidates))
+            assigned[pos : pos + run_len] = expert
+            loads[expert] += run_len
+            prev_expert = expert
+            pos += run_len
+
+        logits = rng.normal(loc=0.0, scale=float(run_noise_scale), size=(tokens, experts)).astype(np.float32)
+        logits[np.arange(tokens), assigned] += 6.0
+        return jnp.asarray(logits, dtype=jnp.float32)
+
+    raise ValueError(f"Unknown distribution: {distribution}")
+
+
+def _route_topk(router_logits: jax.Array, *, topk: int) -> tuple[jax.Array, jax.Array]:
+    topk_logits, topk_idx = jax.lax.top_k(router_logits, topk)
+    topk_weights = jax.nn.softmax(topk_logits, axis=-1)
+    return topk_idx.astype(jnp.int32), topk_weights.astype(router_logits.dtype)
+
+
+def _shared_mlp(
+    x: jax.Array,
+    shared_w13: jax.Array,
+    shared_w2: jax.Array,
+) -> jax.Array:
+    shared_dim = shared_w2.shape[0]
+    if shared_dim == 0:
+        return jnp.zeros_like(x)
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, get_abstract_mesh())
+    shared13 = jnp.einsum("td,dm->tm", x, shared_w13, out_sharding=batch_spec, preferred_element_type=jnp.float32)
+    gate, up = jnp.split(shared13, [shared_dim], axis=-1)
+    shared_gated = jax.nn.silu(gate) * up
+    shared_out = jnp.einsum(
+        "tm,md->td",
+        shared_gated,
+        shared_w2,
+        out_sharding=batch_spec,
+        preferred_element_type=jnp.float32,
+    )
+    return shared_out.astype(x.dtype)
+
+
+def _moe_mlp_ep_ring_local_legacy(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    with jax.named_scope("gather"):
+        x_global = jax.lax.all_gather(x_local, "expert", tiled=True)
+        selected_experts_global = jax.lax.all_gather(selected_experts_local, "expert", tiled=True)
+        combine_weights_global = jax.lax.all_gather(combine_weights_local, "expert", tiled=True)
+
+        tokens = x_global.shape[0]
+        topk = selected_experts_global.shape[1]
+        assignments = tokens * topk
+        expert_flat = selected_experts_global.reshape(assignments)
+        weight_flat = combine_weights_global.reshape(assignments)
+        token_flat = jnp.arange(assignments, dtype=jnp.int32) // topk
+
+        sort_idx = jnp.argsort(expert_flat, axis=0)
+        expert_sorted = jnp.take(expert_flat, sort_idx, axis=0)
+        token_sorted = jnp.take(token_flat, sort_idx, axis=0)
+        weight_sorted = jnp.take(weight_flat, sort_idx, axis=0).astype(x_local.dtype)
+
+        local_experts = moe_w13_local.shape[0]
+        if num_experts % local_experts != 0:
+            raise ValueError(
+                f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+            )
+
+        ep_size = num_experts // local_experts
+        local_capacity = int(np.ceil(capacity_factor * assignments / ep_size))
+        local_capacity = max(local_experts, local_capacity)
+
+        expert_axis = jax.lax.axis_index("expert")
+        expert_start = expert_axis * local_experts
+        expert_end = expert_start + local_experts
+        local_mask = jnp.logical_and(expert_sorted >= expert_start, expert_sorted < expert_end)
+
+        local_idx = jnp.nonzero(local_mask, size=local_capacity, fill_value=0)[0]
+        local_count = jnp.sum(local_mask, dtype=jnp.int32)
+        dropped_local = jnp.maximum(local_count - local_capacity, 0)
+        valid = jnp.arange(local_capacity, dtype=jnp.int32) < local_count
+        valid_weight = valid.astype(jnp.float32)
+
+        token_local = jnp.take(token_sorted, local_idx, axis=0)
+        expert_local = jnp.take(expert_sorted, local_idx, axis=0) - expert_start
+        weight_local = jnp.take(weight_sorted, local_idx, axis=0)
+
+        x_take = jnp.take(x_global, token_local, axis=0)
+        x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))
+        weight_dispatch = jnp.where(valid, weight_local, jnp.zeros_like(weight_local))
+        expert_local = jnp.where(valid, expert_local, 0)
+
+    group_sizes = jnp.bincount(expert_local, weights=valid_weight, length=local_experts).astype(jnp.int32)
+    group_sizes = group_sizes.at[-1].add(local_capacity - jnp.sum(group_sizes, dtype=jnp.int32))
+
+    with jax.named_scope("moe_up_down"):
+        w13_out = ragged_dot(x_dispatch, moe_w13_local, group_sizes)
+        moe_dim = moe_w2_local.shape[1]
+        gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+        out_dispatch = ragged_dot(activation_fn(gate) * up, moe_w2_local, group_sizes)
+
+    with jax.named_scope("scatter"):
+        out_global = jnp.zeros_like(x_global).at[token_local].add(out_dispatch * weight_dispatch[:, None], mode="drop")
+        out_local = jax.lax.psum_scatter(out_global, "expert", scatter_dimension=0, tiled=True)
+        dropped_total = jax.lax.psum(dropped_local, ("data", "expert"))
+    return out_local, dropped_total
+
+
+def _moe_mlp_legacy(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        out, _ = grug_moe_lib._moe_mlp_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        )
+        return out
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+    local_expert_spec = P("expert", None, None) if has_expert_axis else P(None, None, None)
+
+    if has_expert_axis and expert_axis_size > 1:
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_ring_local_legacy,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+                capacity_factor=capacity_factor,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    shard_fn = shard_map(
+        partial(
+            grug_moe_lib._moe_mlp_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        ),
+        mesh=mesh,
+        in_specs=(
+            batch_spec,
+            batch_spec,
+            batch_spec,
+            local_expert_spec,
+            local_expert_spec,
+        ),
+        out_specs=(batch_spec, P()),
+        check_vma=False,
+    )
+    out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+    return out
+
+
+def _prefix_cap_counts(counts: jax.Array, *, capacity: int) -> jax.Array:
+    accepted = []
+    remaining = jnp.array(capacity, dtype=jnp.int32)
+    for expert in range(int(counts.shape[0])):
+        take = jnp.minimum(counts[expert], remaining)
+        accepted.append(take)
+        remaining = jnp.maximum(remaining - take, 0)
+    return jnp.stack(accepted, axis=0)
+
+
+def _compact_local_assignments_cumsum(
+    x_source: jax.Array,
+    token_flat: jax.Array,
+    local_expert: jax.Array,
+    local_mask: jax.Array,
+    weight_flat: jax.Array,
+    *,
+    local_experts: int,
+    local_capacity: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+    expert_ids = jnp.arange(local_experts, dtype=jnp.int32)
+    safe_expert = jnp.where(local_mask, local_expert, 0)
+    expert_mask = local_mask[:, None] & (safe_expert[:, None] == expert_ids[None, :])
+    counts = jnp.sum(expert_mask, axis=0, dtype=jnp.int32)
+    accepted_counts = _prefix_cap_counts(counts, capacity=local_capacity)
+    dropped_local = jnp.sum(counts, dtype=jnp.int32) - jnp.sum(accepted_counts, dtype=jnp.int32)
+
+    pos_within = jnp.cumsum(expert_mask.astype(jnp.int32), axis=0) - 1
+    pos_within_local = jnp.take_along_axis(pos_within, safe_expert[:, None], axis=1).squeeze(1)
+    expert_offsets = jnp.cumsum(accepted_counts, dtype=jnp.int32) - accepted_counts
+    accepted_limit = jnp.take(accepted_counts, safe_expert, axis=0)
+    dest_pos = jnp.take(expert_offsets, safe_expert, axis=0) + pos_within_local
+    accepted_mask = local_mask & (pos_within_local < accepted_limit)
+    scatter_idx = jnp.where(accepted_mask, dest_pos, local_capacity)
+
+    token_local = jnp.zeros((local_capacity,), dtype=jnp.int32).at[scatter_idx].set(token_flat, mode="drop")
+    expert_local = jnp.zeros((local_capacity,), dtype=jnp.int32).at[scatter_idx].set(safe_expert, mode="drop")
+    weight_local = jnp.zeros((local_capacity,), dtype=weight_flat.dtype).at[scatter_idx].set(weight_flat, mode="drop")
+    x_take = jnp.take(x_source, token_flat, axis=0)
+    x_dispatch = (
+        jnp.zeros((local_capacity, x_source.shape[1]), dtype=x_source.dtype).at[scatter_idx].set(x_take, mode="drop")
+    )
+
+    group_sizes = accepted_counts.at[-1].add(local_capacity - jnp.sum(accepted_counts, dtype=jnp.int32))
+    return token_local, expert_local, weight_local.astype(x_source.dtype), x_dispatch, group_sizes, dropped_local
+
+
+def _moe_mlp_ep_ring_local_cumsum(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    with jax.named_scope("gather"):
+        x_global = jax.lax.all_gather(x_local, "expert", tiled=True)
+        selected_experts_global = jax.lax.all_gather(selected_experts_local, "expert", tiled=True)
+        combine_weights_global = jax.lax.all_gather(combine_weights_local, "expert", tiled=True)
+
+        tokens = x_global.shape[0]
+        topk = selected_experts_global.shape[1]
+        assignments = tokens * topk
+        expert_flat = selected_experts_global.reshape(assignments)
+        weight_flat = combine_weights_global.reshape(assignments)
+        token_flat = jnp.arange(assignments, dtype=jnp.int32) // topk
+
+        local_experts = moe_w13_local.shape[0]
+        if num_experts % local_experts != 0:
+            raise ValueError(
+                f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+            )
+
+        ep_size = num_experts // local_experts
+        local_capacity = int(np.ceil(capacity_factor * assignments / ep_size))
+        local_capacity = max(local_experts, local_capacity)
+
+        expert_axis = jax.lax.axis_index("expert")
+        expert_start = expert_axis * local_experts
+        local_expert = expert_flat - expert_start
+        local_mask = jnp.logical_and(local_expert >= 0, local_expert < local_experts)
+
+        token_local, expert_local, weight_dispatch, x_dispatch, group_sizes, dropped_local = (
+            _compact_local_assignments_cumsum(
+                x_global,
+                token_flat,
+                local_expert,
+                local_mask,
+                weight_flat,
+                local_experts=local_experts,
+                local_capacity=local_capacity,
+            )
+        )
+
+    with jax.named_scope("moe_up_down"):
+        w13_out = ragged_dot(x_dispatch, moe_w13_local, group_sizes)
+        moe_dim = moe_w2_local.shape[1]
+        gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+        out_dispatch = ragged_dot(activation_fn(gate) * up, moe_w2_local, group_sizes)
+
+    with jax.named_scope("scatter"):
+        out_global = jnp.zeros_like(x_global).at[token_local].add(out_dispatch * weight_dispatch[:, None], mode="drop")
+        out_local = jax.lax.psum_scatter(out_global, "expert", scatter_dimension=0, tiled=True)
+        dropped_total = jax.lax.psum(dropped_local, ("data", "expert"))
+    return out_local, dropped_total
+
+
+def _moe_mlp_cumsum(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        out, _ = grug_moe_lib._moe_mlp_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        )
+        return out
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+    local_expert_spec = P("expert", None, None) if has_expert_axis else P(None, None, None)
+
+    if has_expert_axis and expert_axis_size > 1:
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_ring_local_cumsum,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+                capacity_factor=capacity_factor,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    shard_fn = shard_map(
+        partial(
+            grug_moe_lib._moe_mlp_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        ),
+        mesh=mesh,
+        in_specs=(
+            batch_spec,
+            batch_spec,
+            batch_spec,
+            local_expert_spec,
+            local_expert_spec,
+        ),
+        out_specs=(batch_spec, P()),
+        check_vma=False,
+    )
+    out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+    return out
+
+
+def _pack_by_shard(
+    payload: jax.Array,
+    token_local: jax.Array,
+    shard_ids: jax.Array,
+    *,
+    num_shards: int,
+    capacity: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    flat_size = int(token_local.shape[0])
+    flat_pos = jnp.arange(flat_size, dtype=jnp.int32)
+
+    packed_payload = []
+    packed_tokens = []
+    packed_valid = []
+    dropped_total = jnp.array(0, dtype=jnp.int32)
+
+    for shard in range(num_shards):
+        shard_mask = shard_ids == shard
+        shard_count = jnp.sum(shard_mask, dtype=jnp.int32)
+        dropped_total = dropped_total + jnp.maximum(shard_count - capacity, 0)
+        valid = jnp.arange(capacity, dtype=jnp.int32) < shard_count
+        selection_key = jnp.where(shard_mask, flat_size - flat_pos, -1)
+        _, shard_idx = jax.lax.top_k(selection_key, capacity)
+
+        shard_payload = jnp.take(payload, shard_idx, axis=0)
+        shard_tokens = jnp.take(token_local, shard_idx, axis=0)
+        shard_payload = jnp.where(valid[:, None], shard_payload, jnp.zeros_like(shard_payload))
+        shard_tokens = jnp.where(valid, shard_tokens, 0)
+
+        packed_payload.append(shard_payload)
+        packed_tokens.append(shard_tokens)
+        packed_valid.append(valid)
+
+    return (
+        jnp.stack(packed_payload, axis=0),
+        jnp.stack(packed_tokens, axis=0),
+        jnp.stack(packed_valid, axis=0),
+        dropped_total,
+    )
+
+
+def _compact_local_assignments_topk(
+    x_source: jax.Array,
+    local_expert: jax.Array,
+    local_mask: jax.Array,
+    weight_flat: jax.Array,
+    *,
+    local_experts: int,
+    local_capacity: int,
+    topk: int,
+    ep_size: int | None = None,
+    take_fn: Callable[[jax.Array, jax.Array], jax.Array] | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+    if take_fn is None:
+        take_fn = _take_with_gather
+    local_count = jnp.sum(local_mask, dtype=jnp.int32)
+    dropped_local = jnp.maximum(local_count - local_capacity, 0)
+    valid = jnp.arange(local_capacity, dtype=jnp.int32) < local_count
+    valid_weight = valid.astype(jnp.float32)
+
+    local_expert = jnp.where(local_mask, local_expert, 0)
+    assignments = int(local_expert.shape[0])
+    flat_pos = jnp.arange(assignments, dtype=jnp.int32)
+    order_key = local_expert * assignments + flat_pos
+    max_order_key = local_experts * assignments
+    selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
+    _, local_idx = jax.lax.top_k(selection_key, local_capacity)
+
+    token_local = jnp.floor_divide(local_idx, topk)
+    expert_local = jnp.take(local_expert, local_idx, axis=0)
+    weight_local = jnp.take(weight_flat, local_idx, axis=0).astype(x_source.dtype)
+    x_take = take_fn(x_source, token_local)
+    x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))
+    weight_dispatch = jnp.where(valid, weight_local, jnp.zeros_like(weight_local))
+    expert_local = jnp.where(valid, expert_local, 0)
+    group_sizes = jnp.bincount(expert_local, weights=valid_weight, length=local_experts).astype(jnp.int32)
+    group_sizes = group_sizes.at[-1].add(local_capacity - jnp.sum(group_sizes, dtype=jnp.int32))
+    return token_local, weight_dispatch, x_dispatch, group_sizes, dropped_local
+
+
+def _compact_local_assignments_prefix_counts(
+    x_source: jax.Array,
+    local_expert: jax.Array,
+    local_mask: jax.Array,
+    weight_flat: jax.Array,
+    *,
+    local_experts: int,
+    local_capacity: int,
+    topk: int,
+    ep_size: int | None = None,
+    take_fn: Callable[[jax.Array, jax.Array], jax.Array] | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+    if take_fn is None:
+        take_fn = _take_with_gather
+    local_expert = jnp.where(local_mask, local_expert, 0)
+    counts = jnp.bincount(local_expert, weights=local_mask.astype(jnp.int32), length=local_experts).astype(jnp.int32)
+    accepted_counts = _prefix_cap_counts(counts, capacity=local_capacity)
+    accepted_total = jnp.sum(accepted_counts, dtype=jnp.int32)
+    dropped_local = jnp.sum(counts, dtype=jnp.int32) - accepted_total
+    valid = jnp.arange(local_capacity, dtype=jnp.int32) < accepted_total
+
+    assignments = int(local_expert.shape[0])
+    flat_pos = jnp.arange(assignments, dtype=jnp.int32)
+    order_key = local_expert * assignments + flat_pos
+    max_order_key = local_experts * assignments
+    selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
+    _, local_idx = jax.lax.top_k(selection_key, local_capacity)
+
+    token_local = jnp.floor_divide(local_idx, topk)
+    weight_local = jnp.take(weight_flat, local_idx, axis=0).astype(x_source.dtype)
+    x_take = take_fn(x_source, token_local)
+    x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))
+    weight_dispatch = jnp.where(valid, weight_local, jnp.zeros_like(weight_local))
+    group_sizes = accepted_counts.at[-1].add(local_capacity - jnp.sum(accepted_counts, dtype=jnp.int32))
+    return token_local, weight_dispatch, x_dispatch, group_sizes, dropped_local
+
+
+def _prefix_cap_counts_vectorized(counts: jax.Array, *, capacity: int) -> jax.Array:
+    capacity_i32 = jnp.array(capacity, dtype=jnp.int32)
+    prefix_before = jnp.cumsum(counts, dtype=jnp.int32) - counts
+    remaining = jnp.maximum(capacity_i32 - prefix_before, 0)
+    return jnp.minimum(counts, remaining)
+
+
+def _compact_local_assignments_vector_prefix(
+    x_source: jax.Array,
+    local_expert: jax.Array,
+    local_mask: jax.Array,
+    weight_flat: jax.Array,
+    *,
+    local_experts: int,
+    local_capacity: int,
+    topk: int,
+    ep_size: int | None = None,
+    take_fn: Callable[[jax.Array, jax.Array], jax.Array] | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+    if take_fn is None:
+        take_fn = _take_with_gather
+    local_expert = jnp.where(local_mask, local_expert, 0)
+    counts = jnp.bincount(local_expert, weights=local_mask.astype(jnp.int32), length=local_experts).astype(jnp.int32)
+    accepted_counts = _prefix_cap_counts_vectorized(counts, capacity=local_capacity)
+    accepted_total = jnp.sum(accepted_counts, dtype=jnp.int32)
+    dropped_local = jnp.sum(counts, dtype=jnp.int32) - accepted_total
+    valid = jnp.arange(local_capacity, dtype=jnp.int32) < accepted_total
+
+    assignments = int(local_expert.shape[0])
+    flat_pos = jnp.arange(assignments, dtype=jnp.int32)
+    order_key = local_expert * assignments + flat_pos
+    max_order_key = local_experts * assignments
+    selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
+    _, local_idx = jax.lax.top_k(selection_key, local_capacity)
+
+    token_local = jnp.floor_divide(local_idx, topk)
+    weight_local = jnp.take(weight_flat, local_idx, axis=0).astype(x_source.dtype)
+    x_take = take_fn(x_source, token_local)
+    x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))
+    weight_dispatch = jnp.where(valid, weight_local, jnp.zeros_like(weight_local))
+    group_sizes = accepted_counts.at[-1].add(local_capacity - jnp.sum(accepted_counts, dtype=jnp.int32))
+    return token_local, weight_dispatch, x_dispatch, group_sizes, dropped_local
+
+
+def _compact_local_assignments_onehot_counts(
+    x_source: jax.Array,
+    local_expert: jax.Array,
+    local_mask: jax.Array,
+    weight_flat: jax.Array,
+    *,
+    local_experts: int,
+    local_capacity: int,
+    topk: int,
+    ep_size: int | None = None,
+    take_fn: Callable[[jax.Array, jax.Array], jax.Array] | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+    if take_fn is None:
+        take_fn = _take_with_gather
+    local_expert = jnp.where(local_mask, local_expert, 0)
+    expert_ids = jnp.arange(local_experts, dtype=jnp.int32)
+    local_mask_i32 = local_mask.astype(jnp.int32)
+    counts = jnp.sum(
+        (local_expert[:, None] == expert_ids[None, :]).astype(jnp.int32) * local_mask_i32[:, None],
+        axis=0,
+        dtype=jnp.int32,
+    )
+    accepted_counts = _prefix_cap_counts(counts, capacity=local_capacity)
+    accepted_total = jnp.sum(accepted_counts, dtype=jnp.int32)
+    dropped_local = jnp.sum(counts, dtype=jnp.int32) - accepted_total
+    valid = jnp.arange(local_capacity, dtype=jnp.int32) < accepted_total
+
+    assignments = int(local_expert.shape[0])
+    flat_pos = jnp.arange(assignments, dtype=jnp.int32)
+    order_key = local_expert * assignments + flat_pos
+    max_order_key = local_experts * assignments
+    selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
+    _, local_idx = jax.lax.top_k(selection_key, local_capacity)
+
+    token_local = jnp.floor_divide(local_idx, topk)
+    weight_local = jnp.take(weight_flat, local_idx, axis=0).astype(x_source.dtype)
+    x_take = take_fn(x_source, token_local)
+    x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))
+    weight_dispatch = jnp.where(valid, weight_local, jnp.zeros_like(weight_local))
+    group_sizes = accepted_counts.at[-1].add(local_capacity - jnp.sum(accepted_counts, dtype=jnp.int32))
+    return token_local, weight_dispatch, x_dispatch, group_sizes, dropped_local
+
+
+def _compact_local_assignments_padded_take(
+    x_source: jax.Array,
+    local_expert: jax.Array,
+    local_mask: jax.Array,
+    weight_flat: jax.Array,
+    *,
+    local_experts: int,
+    local_capacity: int,
+    topk: int,
+    ep_size: int | None = None,
+    take_fn: Callable[[jax.Array, jax.Array], jax.Array] | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+    local_expert = jnp.where(local_mask, local_expert, 0)
+    expert_ids = jnp.arange(local_experts, dtype=jnp.int32)
+    local_mask_i32 = local_mask.astype(jnp.int32)
+    counts = jnp.sum(
+        (local_expert[:, None] == expert_ids[None, :]).astype(jnp.int32) * local_mask_i32[:, None],
+        axis=0,
+        dtype=jnp.int32,
+    )
+    accepted_counts = _prefix_cap_counts(counts, capacity=local_capacity)
+    accepted_total = jnp.sum(accepted_counts, dtype=jnp.int32)
+    dropped_local = jnp.sum(counts, dtype=jnp.int32) - accepted_total
+    valid = jnp.arange(local_capacity, dtype=jnp.int32) < accepted_total
+
+    assignments = int(local_expert.shape[0])
+    flat_pos = jnp.arange(assignments, dtype=jnp.int32)
+    order_key = local_expert * assignments + flat_pos
+    max_order_key = local_experts * assignments
+    selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
+    _, local_idx = jax.lax.top_k(selection_key, local_capacity)
+
+    tokens = x_source.shape[0]
+    token_local = jnp.floor_divide(local_idx, topk)
+    token_take = jnp.where(valid, token_local, tokens)
+    weight_take = jnp.where(valid, local_idx, assignments)
+
+    zero_x = jnp.zeros((1, x_source.shape[1]), dtype=x_source.dtype)
+    x_padded = jnp.concatenate([x_source, zero_x], axis=0)
+    x_dispatch = jnp.take(x_padded, token_take, axis=0)
+
+    zero_w = jnp.zeros((1,), dtype=weight_flat.dtype)
+    weight_padded = jnp.concatenate([weight_flat, zero_w], axis=0)
+    weight_dispatch = jnp.take(weight_padded, weight_take, axis=0).astype(x_source.dtype)
+
+    group_sizes = accepted_counts.at[-1].add(local_capacity - jnp.sum(accepted_counts, dtype=jnp.int32))
+    return token_local, weight_dispatch, x_dispatch, group_sizes, dropped_local
+
+
+def _compact_local_assignments_owner_local_take(
+    x_source: jax.Array,
+    local_expert: jax.Array,
+    local_mask: jax.Array,
+    weight_flat: jax.Array,
+    *,
+    local_experts: int,
+    local_capacity: int,
+    topk: int,
+    ep_size: int | None = None,
+    take_fn: Callable[[jax.Array, jax.Array], jax.Array] | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+    if ep_size is None:
+        raise ValueError("owner_local_take requires ep_size")
+
+    local_expert = jnp.where(local_mask, local_expert, 0)
+    expert_ids = jnp.arange(local_experts, dtype=jnp.int32)
+    local_mask_i32 = local_mask.astype(jnp.int32)
+    counts = jnp.sum(
+        (local_expert[:, None] == expert_ids[None, :]).astype(jnp.int32) * local_mask_i32[:, None],
+        axis=0,
+        dtype=jnp.int32,
+    )
+    accepted_counts = _prefix_cap_counts(counts, capacity=local_capacity)
+    accepted_total = jnp.sum(accepted_counts, dtype=jnp.int32)
+    dropped_local = jnp.sum(counts, dtype=jnp.int32) - accepted_total
+    valid = jnp.arange(local_capacity, dtype=jnp.int32) < accepted_total
+
+    assignments = int(local_expert.shape[0])
+    flat_pos = jnp.arange(assignments, dtype=jnp.int32)
+    order_key = local_expert * assignments + flat_pos
+    max_order_key = local_experts * assignments
+    selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
+    _, local_idx = jax.lax.top_k(selection_key, local_capacity)
+
+    token_local = jnp.floor_divide(local_idx, topk)
+    weight_local = jnp.take(weight_flat, local_idx, axis=0).astype(x_source.dtype)
+
+    tokens = x_source.shape[0]
+    tokens_per_shard = tokens // ep_size
+    owner = jnp.floor_divide(token_local, tokens_per_shard)
+    local_token = jnp.remainder(token_local, tokens_per_shard)
+    x_by_owner = x_source.reshape(ep_size, tokens_per_shard, x_source.shape[1])
+    x_take = x_by_owner[owner, local_token]
+    x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))
+    weight_dispatch = jnp.where(valid, weight_local, jnp.zeros_like(weight_local))
+    group_sizes = accepted_counts.at[-1].add(local_capacity - jnp.sum(accepted_counts, dtype=jnp.int32))
+    return token_local, weight_dispatch, x_dispatch, group_sizes, dropped_local
+
+
+def _scatter_with_add(
+    out_dispatch: jax.Array,
+    weight_dispatch: jax.Array,
+    token_local: jax.Array,
+    *,
+    tokens: int,
+    ep_size: int,
+) -> jax.Array:
+    out_weighted = out_dispatch * weight_dispatch[:, None]
+    out_shape = (tokens, out_weighted.shape[1])
+    return jnp.zeros(out_shape, dtype=out_weighted.dtype).at[token_local].add(out_weighted, mode="drop")
+
+
+def _scatter_with_segment_sum(
+    out_dispatch: jax.Array,
+    weight_dispatch: jax.Array,
+    token_local: jax.Array,
+    *,
+    tokens: int,
+    ep_size: int,
+) -> jax.Array:
+    out_weighted = out_dispatch * weight_dispatch[:, None]
+    return jax.ops.segment_sum(out_weighted, token_local, num_segments=tokens, indices_are_sorted=False)
+
+
+def _scatter_with_sorted_segment_sum(
+    out_dispatch: jax.Array,
+    weight_dispatch: jax.Array,
+    token_local: jax.Array,
+    *,
+    tokens: int,
+    ep_size: int,
+) -> jax.Array:
+    out_weighted = out_dispatch * weight_dispatch[:, None]
+    sort_idx = jnp.argsort(token_local)
+    token_sorted = jnp.take(token_local, sort_idx, axis=0)
+    out_sorted = _sort_activations(out_weighted, sort_idx)
+    return jax.ops.segment_sum(out_sorted, token_sorted, num_segments=tokens, indices_are_sorted=True)
+
+
+def _scatter_with_owner_local_add(
+    out_dispatch: jax.Array,
+    weight_dispatch: jax.Array,
+    token_local: jax.Array,
+    *,
+    tokens: int,
+    ep_size: int,
+) -> jax.Array:
+    out_weighted = out_dispatch * weight_dispatch[:, None]
+    tokens_per_shard = tokens // ep_size
+    owner = jnp.floor_divide(token_local, tokens_per_shard)
+    local_token = jnp.remainder(token_local, tokens_per_shard)
+    out_shape = (ep_size, tokens_per_shard, out_weighted.shape[1])
+    return jnp.zeros(out_shape, dtype=out_weighted.dtype).at[owner, local_token].add(out_weighted, mode="drop")
+
+
+def _scatter_with_lax_scatter_add(
+    out_dispatch: jax.Array,
+    weight_dispatch: jax.Array,
+    token_local: jax.Array,
+    *,
+    tokens: int,
+    ep_size: int,
+) -> jax.Array:
+    out_weighted = out_dispatch * weight_dispatch[:, None]
+    indices = token_local[:, None]
+    dnums = jax.lax.ScatterDimensionNumbers(
+        update_window_dims=(1,),
+        inserted_window_dims=(0,),
+        scatter_dims_to_operand_dims=(0,),
+    )
+    init = jnp.zeros((tokens, out_weighted.shape[1]), dtype=out_weighted.dtype)
+    return jax.lax.scatter_add(init, indices, out_weighted, dnums, indices_are_sorted=False, unique_indices=False)
+
+
+def _take_with_gather(x_source: jax.Array, token_local: jax.Array) -> jax.Array:
+    return jnp.take(x_source, token_local, axis=0)
+
+
+def _take_with_segment_sum_bwd(x_source: jax.Array, token_local: jax.Array) -> jax.Array:
+    return _take_tokens_segment_sum(x_source, token_local)
+
+
+def _take_with_sorted_segment_sum_bwd(x_source: jax.Array, token_local: jax.Array) -> jax.Array:
+    return _take_tokens_sorted_segment_sum(x_source, token_local)
+
+
+def _moe_mlp_ep_ring_local_variant(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+    compact_fn: Callable[..., tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]],
+    scatter_fn: Callable[..., jax.Array],
+    take_fn: Callable[[jax.Array, jax.Array], jax.Array] = _take_with_gather,
+    gather_weight_dtype: jnp.dtype | None = None,
+    gather_expert_dtype: jnp.dtype | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    with jax.named_scope("gather"):
+        x_global = jax.lax.all_gather(x_local, "expert", tiled=True)
+        selected_gather = (
+            selected_experts_local.astype(gather_expert_dtype)
+            if gather_expert_dtype is not None
+            else selected_experts_local
+        )
+        weight_gather = (
+            combine_weights_local.astype(gather_weight_dtype)
+            if gather_weight_dtype is not None
+            else combine_weights_local
+        )
+        selected_experts_global = jax.lax.all_gather(selected_gather, "expert", tiled=True).astype(jnp.int32)
+        combine_weights_global = jax.lax.all_gather(weight_gather, "expert", tiled=True)
+
+        tokens = x_global.shape[0]
+        topk = selected_experts_global.shape[1]
+        assignments = tokens * topk
+        expert_flat = selected_experts_global.reshape(assignments)
+        weight_flat = combine_weights_global.reshape(assignments)
+
+        local_experts = moe_w13_local.shape[0]
+        if num_experts % local_experts != 0:
+            raise ValueError(
+                f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+            )
+
+        ep_size = num_experts // local_experts
+        local_capacity = int(np.ceil(capacity_factor * assignments / ep_size))
+        local_capacity = max(local_experts, local_capacity)
+
+        expert_axis = jax.lax.axis_index("expert")
+        expert_start = expert_axis * local_experts
+        local_expert = expert_flat - expert_start
+        local_mask = jnp.logical_and(local_expert >= 0, local_expert < local_experts)
+
+        token_local, weight_dispatch, x_dispatch, group_sizes, dropped_local = compact_fn(
+            x_global,
+            local_expert,
+            local_mask,
+            weight_flat,
+            local_experts=local_experts,
+            local_capacity=local_capacity,
+            topk=topk,
+            ep_size=ep_size,
+            take_fn=take_fn,
+        )
+
+    with jax.named_scope("moe_up_down"):
+        w13_out = ragged_dot(x_dispatch, moe_w13_local, group_sizes)
+        moe_dim = moe_w2_local.shape[1]
+        gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+        out_dispatch = ragged_dot(activation_fn(gate) * up, moe_w2_local, group_sizes)
+
+    with jax.named_scope("scatter"):
+        out_global = scatter_fn(
+            out_dispatch,
+            weight_dispatch,
+            token_local,
+            tokens=tokens,
+            ep_size=ep_size,
+        )
+        out_local = jax.lax.psum_scatter(out_global, "expert", scatter_dimension=0, tiled=True)
+        out_local = jnp.reshape(out_local, (x_local.shape[0], x_local.shape[1]))
+        dropped_total = jax.lax.psum(dropped_local, ("data", "expert"))
+    return out_local, dropped_total
+
+
+def _permute_by_global_expert(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    *,
+    num_experts: int,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    topk = selected_experts_local.shape[1]
+    flat_selected = selected_experts_local.reshape(-1)
+    sorted_indices = jnp.argsort(flat_selected)
+    repeated_x = jnp.repeat(x_local, topk, axis=0)
+    sorted_x = _sort_activations(repeated_x, sorted_indices)
+    group_sizes = jnp.bincount(flat_selected, length=num_experts).astype(jnp.int32)
+    return sorted_x, sorted_indices, flat_selected, group_sizes
+
+
+def _unpermute_from_global_expert(
+    intermediate: jax.Array,
+    sorted_indices: jax.Array,
+    combine_weights_local: jax.Array,
+    *,
+    tokens_per_shard: int,
+    topk: int,
+) -> jax.Array:
+    unsorted = _sort_activations(intermediate, jnp.argsort(sorted_indices))
+    reshaped = unsorted.reshape(tokens_per_shard, topk, -1)
+    return jnp.einsum(
+        "tkd,tk->td", reshaped, combine_weights_local.astype(reshaped.dtype), preferred_element_type=jnp.float32
+    )
+
+
+def _shard_a2a_params(
+    shard_counts: jax.Array, shard_id: jax.Array
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    row = shard_counts[shard_id]
+    input_offsets = jnp.cumsum(jnp.concatenate((jnp.array([0], dtype=row.dtype), row[:-1])))
+    send_sizes = row
+
+    zero_row = jnp.zeros((1, shard_counts.shape[1]), dtype=shard_counts.dtype)
+    cumulative = jnp.cumsum(jnp.concatenate((zero_row, shard_counts), axis=0), axis=0, dtype=shard_counts.dtype)
+    output_offsets = cumulative[shard_id]
+    recv_sizes = shard_counts[:, shard_id]
+    return input_offsets, send_sizes, output_offsets, recv_sizes
+
+
+def _local_permute_from_counts(
+    inputs: jax.Array,
+    global_group_sizes: jax.Array,
+    *,
+    local_expert_size: int,
+    shard_index: jax.Array,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    all_shard_local_sizes = jax.lax.dynamic_slice_in_dim(
+        global_group_sizes,
+        start_index=shard_index * local_expert_size,
+        slice_size=local_expert_size,
+        axis=1,
+    )
+    local_group_sizes = jnp.sum(all_shard_local_sizes, axis=0)
+    local_sizes = all_shard_local_sizes.reshape(-1)
+    total_valid = jnp.sum(local_sizes, dtype=jnp.int32)
+    segment_ends = jnp.cumsum(local_sizes, dtype=jnp.int32)
+    positions = jnp.arange(inputs.shape[0], dtype=jnp.int32)
+    segment_index = jnp.searchsorted(segment_ends, positions, side="right")
+    local_expert_ids = jnp.where(positions < total_valid, segment_index % local_expert_size, local_expert_size)
+    sorted_indices = jnp.argsort(local_expert_ids)
+    sorted_inputs = _sort_activations(inputs, sorted_indices)
+    sorted_inputs = jnp.where((jnp.arange(inputs.shape[0], dtype=jnp.int32) < total_valid)[:, None], sorted_inputs, 0)
+    group_sizes = local_group_sizes.at[-1].add(inputs.shape[0] - total_valid)
+    return sorted_inputs, sorted_indices, group_sizes
+
+
+def _deepep_transport_layout_counts_local(
+    selected_experts_local: jax.Array,
+    *,
+    num_experts: int,
+    num_ranks: int,
+) -> tuple[jax.Array, jax.Array]:
+    num_tokens_per_rank, num_tokens_per_expert, _ = deepep_get_dispatch_layout(
+        selected_experts_local,
+        num_ranks=num_ranks,
+        num_experts=num_experts,
+    )
+    return num_tokens_per_rank[None, :], num_tokens_per_expert[None, :]
+
+
+def _pack_deepep_local_assignments(
+    recv_x: jax.Array,
+    recv_topk_idx: jax.Array,
+    recv_topk_weights: jax.Array,
+    *,
+    expert_start: jax.Array,
+    local_experts: int,
+    num_recv_tokens: jax.Array,
+    max_local_assignments: int | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    max_recv_tokens, topk = recv_topk_idx.shape
+    total_assignments = max_recv_tokens * topk
+    packed_assignments = (
+        total_assignments if max_local_assignments is None else min(max_local_assignments, total_assignments)
+    )
+
+    recv_token_indices = jnp.repeat(jnp.arange(max_recv_tokens, dtype=jnp.int32), topk)
+    expert_flat = (recv_topk_idx.reshape(-1) - expert_start).astype(jnp.int32)
+    recv_valid = jnp.arange(max_recv_tokens, dtype=jnp.int32) < num_recv_tokens
+    local_mask = recv_valid[:, None] & (recv_topk_idx >= expert_start) & (recv_topk_idx < expert_start + local_experts)
+    local_mask_flat = local_mask.reshape(-1)
+    local_bucket = jnp.where(local_mask_flat, expert_flat, local_experts)
+    local_group_sizes = jnp.bincount(local_bucket, length=local_experts + 1).astype(jnp.int32)[:-1]
+    total_valid = jnp.sum(local_group_sizes, dtype=jnp.int32)
+
+    flat_positions = jnp.arange(total_assignments, dtype=jnp.int32)
+    order_key = local_bucket * total_assignments + flat_positions
+    max_order_key = (local_experts + 1) * total_assignments
+    selection_key = jnp.where(local_mask_flat, max_order_key - order_key, -1)
+    _, sorted_assignment_indices = jax.lax.top_k(selection_key, total_assignments)
+    sorted_assignment_indices = sorted_assignment_indices[:packed_assignments]
+
+    recv_token_indices = jnp.take(recv_token_indices, sorted_assignment_indices, axis=0)
+    x_dispatch = jnp.take(recv_x, recv_token_indices, axis=0)
+    assignment_weights = jnp.take(recv_topk_weights.reshape(-1), sorted_assignment_indices, axis=0).astype(
+        recv_x.dtype
+    )
+    valid_sorted = jnp.arange(packed_assignments, dtype=jnp.int32) < total_valid
+    x_dispatch = jnp.where(valid_sorted[:, None], x_dispatch, 0)
+    assignment_weights = jnp.where(valid_sorted, assignment_weights, 0)
+    return x_dispatch, assignment_weights, recv_token_indices, local_group_sizes
+
+
+def _collapse_deepep_local_assignments(
+    out_dispatch: jax.Array,
+    assignment_weights: jax.Array,
+    recv_token_indices: jax.Array,
+    *,
+    recv_capacity: int,
+    num_recv_tokens: jax.Array,
+) -> jax.Array:
+    recv_out = jax.ops.segment_sum(
+        out_dispatch * assignment_weights[:, None],
+        recv_token_indices,
+        num_segments=recv_capacity,
+        indices_are_sorted=False,
+    )
+    recv_valid = jnp.arange(recv_capacity, dtype=jnp.int32) < num_recv_tokens
+    return jnp.where(recv_valid[:, None], recv_out, 0)
+
+
+def _deepep_transport_exact_caps(
+    selected_experts: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh,
+    num_experts: int,
+    capacity_multiple: int = 128,
+) -> tuple[int, int]:
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+    if num_experts % expert_axis_size != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by expert axis size={expert_axis_size} for capped DeepEP"
+        )
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(selected_experts, mesh)
+    shard_fn = shard_map(
+        partial(
+            _deepep_transport_layout_counts_local,
+            num_experts=num_experts,
+            num_ranks=expert_axis_size,
+        ),
+        mesh=mesh,
+        in_specs=(batch_spec,),
+        out_specs=(P("expert", None), P("expert", None)),
+        check_vma=False,
+    )
+    num_tokens_per_rank, num_tokens_per_expert = jax.jit(shard_fn)(selected_experts)
+    num_tokens_per_rank_host = np.asarray(jax.device_get(num_tokens_per_rank), dtype=np.int32)
+    num_tokens_per_expert_host = np.asarray(jax.device_get(num_tokens_per_expert), dtype=np.int32)
+    local_experts = num_experts // expert_axis_size
+    recv_tokens_per_rank = np.sum(num_tokens_per_rank_host, axis=0, dtype=np.int64)
+    global_assignments_per_expert = np.sum(num_tokens_per_expert_host, axis=0, dtype=np.int64)
+    local_assignments_per_rank = global_assignments_per_expert.reshape(expert_axis_size, local_experts).sum(
+        axis=1, dtype=np.int64
+    )
+    max_recv_tokens = _round_up_capacity(int(np.max(recv_tokens_per_rank)), multiple=capacity_multiple)
+    max_local_assignments = _round_up_capacity(int(np.max(local_assignments_per_rank)), multiple=capacity_multiple)
+    _print0(
+        "DEEPEP_EXACT_CAPS "
+        f"max_recv_tokens={max_recv_tokens} "
+        f"max_local_assignments={max_local_assignments} "
+        f"recv_factor={(selected_experts.shape[0] / expert_axis_size * expert_axis_size) / max_recv_tokens:.6f} "
+        f"assign_factor={((selected_experts.shape[0] / expert_axis_size) * expert_axis_size * selected_experts.shape[1]) / max_local_assignments:.6f}"
+    )
+    return max_recv_tokens, max_local_assignments
+
+
+def _fit_probe_output_to_hidden(probe_out: jax.Array, *, hidden_dim: int) -> jax.Array:
+    if probe_out.shape[1] == hidden_dim:
+        return probe_out
+    if probe_out.shape[1] > hidden_dim:
+        return probe_out[:, :hidden_dim]
+
+    pad_width = hidden_dim - probe_out.shape[1]
+    return jnp.pad(probe_out, ((0, 0), (0, pad_width)))
+
+
+def _moe_mlp_ep_ragged_a2a_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+
+    shard_id = jax.lax.axis_index("expert")
+    ep_size = num_experts // local_experts
+    tokens_per_shard = x_local.shape[0]
+    topk = selected_experts_local.shape[1]
+    assignments_per_shard = tokens_per_shard * topk
+    recv_capacity = max(local_experts, int(np.ceil(capacity_factor * assignments_per_shard)))
+
+    with jax.named_scope("dispatch"):
+        sorted_x, sorted_indices, _, group_sizes = _permute_by_global_expert(
+            x_local,
+            selected_experts_local,
+            num_experts=num_experts,
+        )
+        shard_counts = jnp.sum(group_sizes.reshape(ep_size, local_experts), axis=1).astype(jnp.int32)
+        all_shard_counts = jax.lax.all_gather(shard_counts, "expert")
+        input_offsets, send_sizes, output_offsets, recv_sizes = _shard_a2a_params(all_shard_counts, shard_id)
+        dispatch_out_shape = jnp.zeros((recv_capacity, x_local.shape[1]), dtype=x_local.dtype)
+        x_dispatched = jax.lax.ragged_all_to_all(
+            sorted_x,
+            dispatch_out_shape,
+            input_offsets,
+            send_sizes,
+            output_offsets,
+            recv_sizes,
+            axis_name="expert",
+        )
+        global_group_sizes = jax.lax.all_gather(group_sizes.astype(jnp.int32), "expert")
+        x_dispatch, local_sorted_indices, local_group_sizes = _local_permute_from_counts(
+            x_dispatched,
+            global_group_sizes,
+            local_expert_size=local_experts,
+            shard_index=shard_id,
+        )
+
+    with jax.named_scope("moe_up_down"):
+        w13_out = ragged_dot(x_dispatch, moe_w13_local, local_group_sizes)
+        moe_dim = moe_w2_local.shape[1]
+        gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+        out_dispatch = ragged_dot(activation_fn(gate) * up, moe_w2_local, local_group_sizes)
+
+    with jax.named_scope("combine"):
+        local_output = _sort_activations(out_dispatch, jnp.argsort(local_sorted_indices))
+        return_out_shape = jnp.zeros((assignments_per_shard, x_local.shape[1]), dtype=local_output.dtype)
+        return_input_offsets, return_send_sizes, return_output_offsets, return_recv_sizes = _shard_a2a_params(
+            all_shard_counts.T, shard_id
+        )
+        returned = jax.lax.ragged_all_to_all(
+            local_output,
+            return_out_shape,
+            return_input_offsets,
+            return_send_sizes,
+            return_output_offsets,
+            return_recv_sizes,
+            axis_name="expert",
+        )
+        out_local = _unpermute_from_global_expert(
+            returned,
+            sorted_indices,
+            combine_weights_local,
+            tokens_per_shard=tokens_per_shard,
+            topk=topk,
+        ).astype(x_local.dtype)
+        dropped_total = jnp.array(0, dtype=jnp.int32)
+    return out_local, dropped_total
+
+
+def _moe_mlp_ragged_a2a(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        out, _ = grug_moe_lib._moe_mlp_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        )
+        return out
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+    local_expert_spec = P("expert", None, None) if has_expert_axis else P(None, None, None)
+
+    if has_expert_axis and expert_axis_size > 1:
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_ragged_a2a_local,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+                capacity_factor=capacity_factor,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    shard_fn = shard_map(
+        partial(
+            grug_moe_lib._moe_mlp_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        ),
+        mesh=mesh,
+        in_specs=(
+            batch_spec,
+            batch_spec,
+            batch_spec,
+            local_expert_spec,
+            local_expert_spec,
+        ),
+        out_specs=(batch_spec, P()),
+        check_vma=False,
+    )
+    out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+    return out
+
+
+def _moe_mlp_ep_ragged_a2a_deepep_layout_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+
+    shard_id = jax.lax.axis_index("expert")
+    ep_size = num_experts // local_experts
+    tokens_per_shard = x_local.shape[0]
+    topk = selected_experts_local.shape[1]
+    assignments_per_shard = tokens_per_shard * topk
+    recv_capacity = max(local_experts, int(np.ceil(capacity_factor * assignments_per_shard)))
+
+    with jax.named_scope("dispatch"):
+        sorted_x, sorted_indices, _, _ = _permute_by_global_expert(
+            x_local,
+            selected_experts_local,
+            num_experts=num_experts,
+        )
+        _, group_sizes, _ = deepep_get_dispatch_layout(
+            selected_experts_local,
+            num_ranks=ep_size,
+            num_experts=num_experts,
+        )
+        group_sizes = group_sizes.astype(jnp.int32)
+        # DeepEP exposes token-per-rank reachability separately, but this ragged_a2a path
+        # still dispatches repeated token assignments, so the send sizes must come from
+        # per-expert assignment counts.
+        shard_counts = jnp.sum(group_sizes.reshape(ep_size, local_experts), axis=1).astype(jnp.int32)
+        all_shard_counts = jax.lax.all_gather(shard_counts, "expert")
+        input_offsets, send_sizes, output_offsets, recv_sizes = _shard_a2a_params(all_shard_counts, shard_id)
+        dispatch_out_shape = jnp.zeros((recv_capacity, x_local.shape[1]), dtype=x_local.dtype)
+        x_dispatched = jax.lax.ragged_all_to_all(
+            sorted_x,
+            dispatch_out_shape,
+            input_offsets,
+            send_sizes,
+            output_offsets,
+            recv_sizes,
+            axis_name="expert",
+        )
+        global_group_sizes = jax.lax.all_gather(group_sizes, "expert")
+        x_dispatch, local_sorted_indices, local_group_sizes = _local_permute_from_counts(
+            x_dispatched,
+            global_group_sizes,
+            local_expert_size=local_experts,
+            shard_index=shard_id,
+        )
+
+    with jax.named_scope("moe_up_down"):
+        w13_out = ragged_dot(x_dispatch, moe_w13_local, local_group_sizes)
+        moe_dim = moe_w2_local.shape[1]
+        gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+        out_dispatch = ragged_dot(activation_fn(gate) * up, moe_w2_local, local_group_sizes)
+
+    with jax.named_scope("combine"):
+        local_output = _sort_activations(out_dispatch, jnp.argsort(local_sorted_indices))
+        return_out_shape = jnp.zeros((assignments_per_shard, x_local.shape[1]), dtype=local_output.dtype)
+        return_input_offsets, return_send_sizes, return_output_offsets, return_recv_sizes = _shard_a2a_params(
+            all_shard_counts.T, shard_id
+        )
+        returned = jax.lax.ragged_all_to_all(
+            local_output,
+            return_out_shape,
+            return_input_offsets,
+            return_send_sizes,
+            return_output_offsets,
+            return_recv_sizes,
+            axis_name="expert",
+        )
+        out_local = _unpermute_from_global_expert(
+            returned,
+            sorted_indices,
+            combine_weights_local,
+            tokens_per_shard=tokens_per_shard,
+            topk=topk,
+        ).astype(x_local.dtype)
+        dropped_total = jnp.array(0, dtype=jnp.int32)
+    return out_local, dropped_total
+
+
+def _moe_mlp_ep_deepep_transport_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    max_recv_tokens: int | None = None,
+    max_local_assignments: int | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+    if x_local.shape[1] % 8 != 0:
+        raise ValueError(f"DeepEP transport requires hidden % 8 == 0, got hidden={x_local.shape[1]}")
+
+    shard_id = jax.lax.axis_index("expert")
+    ep_size = num_experts // local_experts
+    expert_start = shard_id * local_experts
+
+    with jax.named_scope("dispatch"):
+        num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
+            selected_experts_local,
+            num_ranks=ep_size,
+            num_experts=num_experts,
+        )
+        (
+            recv_x,
+            recv_topk_idx,
+            recv_topk_weights,
+            recv_src_idx,
+            rank_prefix_matrix,
+            channel_prefix_matrix,
+            recv_channel_prefix_matrix,
+            send_head,
+            _local_expert_counts,
+            num_recv_tokens,
+        ) = deepep_dispatch_intranode(
+            x_local,
+            selected_experts_local,
+            combine_weights_local,
+            num_tokens_per_rank,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            num_experts=num_experts,
+            max_recv_tokens=max_recv_tokens,
+        )
+        num_recv_tokens_scalar = jnp.squeeze(num_recv_tokens, axis=0)
+        x_dispatch, assignment_weights, recv_token_indices, local_group_sizes = _pack_deepep_local_assignments(
+            recv_x,
+            recv_topk_idx,
+            recv_topk_weights,
+            expert_start=expert_start,
+            local_experts=local_experts,
+            num_recv_tokens=num_recv_tokens_scalar,
+            max_local_assignments=max_local_assignments,
+        )
+
+    with jax.named_scope("moe_up_down"):
+        w13_out = ragged_dot(x_dispatch, moe_w13_local, local_group_sizes)
+        moe_dim = moe_w2_local.shape[1]
+        gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+        out_dispatch = ragged_dot(activation_fn(gate) * up, moe_w2_local, local_group_sizes)
+
+    with jax.named_scope("combine"):
+        recv_out = _collapse_deepep_local_assignments(
+            out_dispatch,
+            assignment_weights,
+            recv_token_indices,
+            recv_capacity=recv_x.shape[0],
+            num_recv_tokens=num_recv_tokens_scalar,
+        )
+        out_local, _ = deepep_combine_intranode(
+            recv_out,
+            recv_topk_weights,
+            recv_src_idx,
+            rank_prefix_matrix,
+            channel_prefix_matrix,
+            recv_channel_prefix_matrix,
+            send_head,
+            num_recv_tokens,
+            is_token_in_rank,
+        )
+        dropped_total = jnp.array(0, dtype=jnp.int32)
+    return out_local.astype(x_local.dtype), dropped_total
+
+
+def _moe_mlp_ragged_a2a_deepep_layout(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        out, _ = grug_moe_lib._moe_mlp_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        )
+        return out
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+    local_expert_spec = P("expert", None, None) if has_expert_axis else P(None, None, None)
+
+    if has_expert_axis and expert_axis_size > 1:
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_ragged_a2a_deepep_layout_local,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+                capacity_factor=capacity_factor,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    shard_fn = shard_map(
+        partial(
+            grug_moe_lib._moe_mlp_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        ),
+        mesh=mesh,
+        in_specs=(
+            batch_spec,
+            batch_spec,
+            batch_spec,
+            local_expert_spec,
+            local_expert_spec,
+        ),
+        out_specs=(batch_spec, P()),
+        check_vma=False,
+    )
+    out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+    return out
+
+
+def _moe_mlp_deepep_transport(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    max_recv_tokens: int | None = None,
+    max_local_assignments: int | None = None,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        out, _ = grug_moe_lib._moe_mlp_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        )
+        return out
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+    local_expert_spec = P("expert", None, None) if has_expert_axis else P(None, None, None)
+
+    if has_expert_axis and expert_axis_size > 1:
+        if grug_moe_lib._mesh_axis_size(mesh, "data") != 1:
+            raise ValueError(
+                "deepep_transport currently requires the expert group to span all visible local GPUs; "
+                f"got data axis size={grug_moe_lib._mesh_axis_size(mesh, 'data')} and expert axis size={expert_axis_size}"
+            )
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_deepep_transport_local,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+                max_recv_tokens=max_recv_tokens,
+                max_local_assignments=max_local_assignments,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    shard_fn = shard_map(
+        partial(
+            grug_moe_lib._moe_mlp_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        ),
+        mesh=mesh,
+        in_specs=(
+            batch_spec,
+            batch_spec,
+            batch_spec,
+            local_expert_spec,
+            local_expert_spec,
+        ),
+        out_specs=(batch_spec, P()),
+        check_vma=False,
+    )
+    out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+    return out
+
+
+def _moe_mlp_ep_deepep_transport_dispatch_pack_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    *,
+    num_experts: int,
+    local_experts: int,
+    max_recv_tokens: int | None = None,
+    max_local_assignments: int | None = None,
+) -> tuple[
+    jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array
+]:
+    shard_id = jax.lax.axis_index("expert")
+    ep_size = num_experts // local_experts
+    expert_start = shard_id * local_experts
+
+    num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
+        selected_experts_local,
+        num_ranks=ep_size,
+        num_experts=num_experts,
+    )
+    (
+        recv_x,
+        recv_topk_idx,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        _local_expert_counts,
+        num_recv_tokens,
+    ) = deepep_dispatch_intranode(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        num_tokens_per_rank,
+        num_tokens_per_expert,
+        is_token_in_rank,
+        num_experts=num_experts,
+        max_recv_tokens=max_recv_tokens,
+    )
+    num_recv_tokens_scalar = jnp.squeeze(num_recv_tokens, axis=0)
+    x_dispatch, assignment_weights, recv_token_indices, local_group_sizes = _pack_deepep_local_assignments(
+        recv_x,
+        recv_topk_idx,
+        recv_topk_weights,
+        expert_start=expert_start,
+        local_experts=local_experts,
+        num_recv_tokens=num_recv_tokens_scalar,
+        max_local_assignments=max_local_assignments,
+    )
+    return (
+        x_dispatch,
+        assignment_weights,
+        recv_token_indices,
+        local_group_sizes,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+        is_token_in_rank,
+    )
+
+
+def _moe_mlp_deepep_transport_dispatch_pack(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    num_experts: int,
+    max_recv_tokens: int | None = None,
+    max_local_assignments: int | None = None,
+) -> tuple[
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+    jax.Array,
+]:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+    if mesh is None or mesh.empty or not has_expert_axis or expert_axis_size <= 1:
+        raise ValueError("deepep_transport_staged requires expert parallel mesh")
+    if grug_moe_lib._mesh_axis_size(mesh, "data") != 1:
+        raise ValueError(
+            "deepep_transport_staged currently requires the expert group to span all visible local GPUs; "
+            f"got data axis size={grug_moe_lib._mesh_axis_size(mesh, 'data')} and expert axis size={expert_axis_size}"
+        )
+    if num_experts % expert_axis_size != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by expert axis size={expert_axis_size} for staged DeepEP"
+        )
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+    shard_fn = shard_map(
+        partial(
+            _moe_mlp_ep_deepep_transport_dispatch_pack_local,
+            num_experts=num_experts,
+            local_experts=num_experts // expert_axis_size,
+            max_recv_tokens=max_recv_tokens,
+            max_local_assignments=max_local_assignments,
+        ),
+        mesh=mesh,
+        in_specs=(batch_spec, batch_spec, batch_spec),
+        out_specs=(
+            P("expert", None),
+            P("expert"),
+            P("expert"),
+            P("expert"),
+            P("expert", None),
+            P("expert"),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert"),
+            batch_spec,
+        ),
+        check_vma=False,
+    )
+    return shard_fn(x, selected_experts, combine_weights)
+
+
+def _moe_mlp_ep_deepep_transport_local_compute_local(
+    x_dispatch: jax.Array,
+    local_group_sizes: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+) -> jax.Array:
+    w13_out = ragged_dot(x_dispatch, moe_w13_local, local_group_sizes)
+    moe_dim = moe_w2_local.shape[1]
+    gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+    return ragged_dot(activation_fn(gate) * up, moe_w2_local, local_group_sizes)
+
+
+def _moe_mlp_deepep_transport_local_compute(
+    x_dispatch: jax.Array,
+    local_group_sizes: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+    shard_fn = shard_map(
+        partial(
+            _moe_mlp_ep_deepep_transport_local_compute_local,
+            activation_fn=activation_fn,
+        ),
+        mesh=mesh,
+        in_specs=(
+            P("expert", None),
+            P("expert"),
+            P("expert", None, None),
+            P("expert", None, None),
+        ),
+        out_specs=P("expert", None),
+        check_vma=False,
+    )
+    return shard_fn(x_dispatch, local_group_sizes, w_up_gate, w_down)
+
+
+def _moe_mlp_ep_deepep_transport_collapse_combine_local(
+    out_dispatch: jax.Array,
+    assignment_weights: jax.Array,
+    recv_token_indices: jax.Array,
+    recv_topk_weights: jax.Array,
+    recv_src_idx: jax.Array,
+    rank_prefix_matrix: jax.Array,
+    channel_prefix_matrix: jax.Array,
+    recv_channel_prefix_matrix: jax.Array,
+    send_head: jax.Array,
+    num_recv_tokens: jax.Array,
+    is_token_in_rank: jax.Array,
+) -> jax.Array:
+    num_recv_tokens_scalar = jnp.squeeze(num_recv_tokens, axis=0)
+    recv_out = _collapse_deepep_local_assignments(
+        out_dispatch,
+        assignment_weights,
+        recv_token_indices,
+        recv_capacity=recv_topk_weights.shape[0],
+        num_recv_tokens=num_recv_tokens_scalar,
+    )
+    out_local, _ = deepep_combine_intranode(
+        recv_out,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+        is_token_in_rank,
+    )
+    return out_local
+
+
+def _moe_mlp_deepep_transport_collapse_combine(
+    out_dispatch: jax.Array,
+    assignment_weights: jax.Array,
+    recv_token_indices: jax.Array,
+    recv_topk_weights: jax.Array,
+    recv_src_idx: jax.Array,
+    rank_prefix_matrix: jax.Array,
+    channel_prefix_matrix: jax.Array,
+    recv_channel_prefix_matrix: jax.Array,
+    send_head: jax.Array,
+    num_recv_tokens: jax.Array,
+    is_token_in_rank: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    batch_spec = grug_moe_lib._batch_spec(mesh)
+    shard_fn = shard_map(
+        _moe_mlp_ep_deepep_transport_collapse_combine_local,
+        mesh=mesh,
+        in_specs=(
+            P("expert", None),
+            P("expert"),
+            P("expert"),
+            P("expert", None),
+            P("expert"),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert"),
+            batch_spec,
+        ),
+        out_specs=batch_spec,
+        check_vma=False,
+    )
+    return shard_fn(
+        out_dispatch,
+        assignment_weights,
+        recv_token_indices,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+        is_token_in_rank,
+    )
+
+
+def _moe_mlp_ep_deepep_transport_identity_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    _moe_w13_local: jax.Array,
+    _moe_w2_local: jax.Array,
+    *,
+    num_experts: int,
+) -> tuple[jax.Array, jax.Array]:
+    local_experts = _moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+
+    ep_size = num_experts // local_experts
+    num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
+        selected_experts_local,
+        num_ranks=ep_size,
+        num_experts=num_experts,
+    )
+    (
+        recv_x,
+        _recv_topk_idx,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        _local_expert_counts,
+        num_recv_tokens,
+    ) = deepep_dispatch_intranode(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        num_tokens_per_rank,
+        num_tokens_per_expert,
+        is_token_in_rank,
+        num_experts=num_experts,
+    )
+    out_local, _ = deepep_combine_intranode(
+        recv_x,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+        is_token_in_rank,
+    )
+    fanout = jnp.maximum(jnp.sum(is_token_in_rank.astype(jnp.int32), axis=1), 1)
+    return (out_local / fanout[:, None]).astype(x_local.dtype), jnp.array(0, dtype=jnp.int32)
+
+
+def _moe_mlp_deepep_transport_identity(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        return x
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+
+    if has_expert_axis and expert_axis_size > 1:
+        if grug_moe_lib._mesh_axis_size(mesh, "data") != 1:
+            raise ValueError(
+                "deepep_transport_identity currently requires the expert group to span all visible local GPUs; "
+                f"got data axis size={grug_moe_lib._mesh_axis_size(mesh, 'data')} and expert axis size={expert_axis_size}"
+            )
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_deepep_transport_identity_local,
+                num_experts=num_experts,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    return x
+
+
+def _moe_mlp_ep_deepep_transport_assignments_identity_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    _moe_w2_local: jax.Array,
+    *,
+    num_experts: int,
+) -> tuple[jax.Array, jax.Array]:
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+    if x_local.shape[1] % 8 != 0:
+        raise ValueError(f"DeepEP transport requires hidden % 8 == 0, got hidden={x_local.shape[1]}")
+
+    shard_id = jax.lax.axis_index("expert")
+    ep_size = num_experts // local_experts
+    expert_start = shard_id * local_experts
+
+    num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
+        selected_experts_local,
+        num_ranks=ep_size,
+        num_experts=num_experts,
+    )
+    (
+        recv_x,
+        recv_topk_idx,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        _local_expert_counts,
+        num_recv_tokens,
+    ) = deepep_dispatch_intranode(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        num_tokens_per_rank,
+        num_tokens_per_expert,
+        is_token_in_rank,
+        num_experts=num_experts,
+    )
+    num_recv_tokens_scalar = jnp.squeeze(num_recv_tokens, axis=0)
+    x_dispatch, assignment_weights, recv_token_indices, _local_group_sizes = _pack_deepep_local_assignments(
+        recv_x,
+        recv_topk_idx,
+        recv_topk_weights,
+        expert_start=expert_start,
+        local_experts=local_experts,
+        num_recv_tokens=num_recv_tokens_scalar,
+    )
+    recv_out = _collapse_deepep_local_assignments(
+        x_dispatch,
+        assignment_weights,
+        recv_token_indices,
+        recv_capacity=recv_x.shape[0],
+        num_recv_tokens=num_recv_tokens_scalar,
+    )
+    out_local, _ = deepep_combine_intranode(
+        recv_out,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+        is_token_in_rank,
+    )
+    return out_local.astype(x_local.dtype), jnp.array(0, dtype=jnp.int32)
+
+
+def _moe_mlp_deepep_transport_assignments_identity(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        return x
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+
+    if has_expert_axis and expert_axis_size > 1:
+        if grug_moe_lib._mesh_axis_size(mesh, "data") != 1:
+            raise ValueError(
+                "deepep_transport_assignments_identity currently requires the expert group to span all visible local "
+                f"GPUs; got data axis size={grug_moe_lib._mesh_axis_size(mesh, 'data')} and expert axis size={expert_axis_size}"
+            )
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_deepep_transport_assignments_identity_local,
+                num_experts=num_experts,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    return x
+
+
+def _moe_mlp_ep_deepep_transport_first_ragged_dot_probe_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    _moe_w2_local: jax.Array,
+    *,
+    num_experts: int,
+) -> tuple[jax.Array, jax.Array]:
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+    if x_local.shape[1] % 8 != 0:
+        raise ValueError(f"DeepEP transport requires hidden % 8 == 0, got hidden={x_local.shape[1]}")
+
+    shard_id = jax.lax.axis_index("expert")
+    ep_size = num_experts // local_experts
+    expert_start = shard_id * local_experts
+
+    num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
+        selected_experts_local,
+        num_ranks=ep_size,
+        num_experts=num_experts,
+    )
+    (
+        recv_x,
+        recv_topk_idx,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        _local_expert_counts,
+        num_recv_tokens,
+    ) = deepep_dispatch_intranode(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        num_tokens_per_rank,
+        num_tokens_per_expert,
+        is_token_in_rank,
+        num_experts=num_experts,
+    )
+    num_recv_tokens_scalar = jnp.squeeze(num_recv_tokens, axis=0)
+    x_dispatch, assignment_weights, recv_token_indices, local_group_sizes = _pack_deepep_local_assignments(
+        recv_x,
+        recv_topk_idx,
+        recv_topk_weights,
+        expert_start=expert_start,
+        local_experts=local_experts,
+        num_recv_tokens=num_recv_tokens_scalar,
+    )
+    probe_out = ragged_dot(x_dispatch, moe_w13_local, local_group_sizes)
+    recv_out = _collapse_deepep_local_assignments(
+        _fit_probe_output_to_hidden(probe_out, hidden_dim=x_local.shape[1]),
+        assignment_weights,
+        recv_token_indices,
+        recv_capacity=recv_x.shape[0],
+        num_recv_tokens=num_recv_tokens_scalar,
+    )
+    out_local, _ = deepep_combine_intranode(
+        recv_out,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+        is_token_in_rank,
+    )
+    return out_local.astype(x_local.dtype), jnp.array(0, dtype=jnp.int32)
+
+
+def _moe_mlp_deepep_transport_first_ragged_dot_probe(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        return x
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+
+    if has_expert_axis and expert_axis_size > 1:
+        if grug_moe_lib._mesh_axis_size(mesh, "data") != 1:
+            raise ValueError(
+                "deepep_transport_first_ragged_dot_probe currently requires the expert group to span all visible "
+                f"local GPUs; got data axis size={grug_moe_lib._mesh_axis_size(mesh, 'data')} and expert axis "
+                f"size={expert_axis_size}"
+            )
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_deepep_transport_first_ragged_dot_probe_local,
+                num_experts=num_experts,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    return x
+
+
+def _moe_mlp_ep_deepep_transport_gate_probe_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+) -> tuple[jax.Array, jax.Array]:
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+    if x_local.shape[1] % 8 != 0:
+        raise ValueError(f"DeepEP transport requires hidden % 8 == 0, got hidden={x_local.shape[1]}")
+
+    shard_id = jax.lax.axis_index("expert")
+    ep_size = num_experts // local_experts
+    expert_start = shard_id * local_experts
+
+    num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
+        selected_experts_local,
+        num_ranks=ep_size,
+        num_experts=num_experts,
+    )
+    (
+        recv_x,
+        recv_topk_idx,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        _local_expert_counts,
+        num_recv_tokens,
+    ) = deepep_dispatch_intranode(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        num_tokens_per_rank,
+        num_tokens_per_expert,
+        is_token_in_rank,
+        num_experts=num_experts,
+    )
+    num_recv_tokens_scalar = jnp.squeeze(num_recv_tokens, axis=0)
+    x_dispatch, assignment_weights, recv_token_indices, local_group_sizes = _pack_deepep_local_assignments(
+        recv_x,
+        recv_topk_idx,
+        recv_topk_weights,
+        expert_start=expert_start,
+        local_experts=local_experts,
+        num_recv_tokens=num_recv_tokens_scalar,
+    )
+    w13_out = ragged_dot(x_dispatch, moe_w13_local, local_group_sizes)
+    moe_dim = moe_w2_local.shape[1]
+    gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+    probe_out = activation_fn(gate) * up
+    recv_out = _collapse_deepep_local_assignments(
+        _fit_probe_output_to_hidden(probe_out, hidden_dim=x_local.shape[1]),
+        assignment_weights,
+        recv_token_indices,
+        recv_capacity=recv_x.shape[0],
+        num_recv_tokens=num_recv_tokens_scalar,
+    )
+    out_local, _ = deepep_combine_intranode(
+        recv_out,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+        is_token_in_rank,
+    )
+    return out_local.astype(x_local.dtype), jnp.array(0, dtype=jnp.int32)
+
+
+def _moe_mlp_deepep_transport_gate_probe(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+
+    if mesh is None or mesh.empty:
+        return x
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+
+    if has_expert_axis and expert_axis_size > 1:
+        if grug_moe_lib._mesh_axis_size(mesh, "data") != 1:
+            raise ValueError(
+                "deepep_transport_gate_probe currently requires the expert group to span all visible local GPUs; "
+                f"got data axis size={grug_moe_lib._mesh_axis_size(mesh, 'data')} and expert axis size={expert_axis_size}"
+            )
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_deepep_transport_gate_probe_local,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    return x
+
+
+def _moe_mlp_ep_deepep_transport_second_ragged_dot_probe_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+) -> tuple[jax.Array, jax.Array]:
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+    if x_local.shape[1] % 8 != 0:
+        raise ValueError(f"DeepEP transport requires hidden % 8 == 0, got hidden={x_local.shape[1]}")
+
+    shard_id = jax.lax.axis_index("expert")
+    ep_size = num_experts // local_experts
+    expert_start = shard_id * local_experts
+
+    num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
+        selected_experts_local,
+        num_ranks=ep_size,
+        num_experts=num_experts,
+    )
+    (
+        recv_x,
+        recv_topk_idx,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        _local_expert_counts,
+        num_recv_tokens,
+    ) = deepep_dispatch_intranode(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        num_tokens_per_rank,
+        num_tokens_per_expert,
+        is_token_in_rank,
+        num_experts=num_experts,
+    )
+    num_recv_tokens_scalar = jnp.squeeze(num_recv_tokens, axis=0)
+    x_dispatch, assignment_weights, recv_token_indices, local_group_sizes = _pack_deepep_local_assignments(
+        recv_x,
+        recv_topk_idx,
+        recv_topk_weights,
+        expert_start=expert_start,
+        local_experts=local_experts,
+        num_recv_tokens=num_recv_tokens_scalar,
+    )
+    w13_out = ragged_dot(x_dispatch, moe_w13_local, local_group_sizes)
+    moe_dim = moe_w2_local.shape[1]
+    gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+    probe_out = ragged_dot(activation_fn(gate) * up, moe_w2_local, local_group_sizes)
+    recv_out = _collapse_deepep_local_assignments(
+        probe_out,
+        assignment_weights,
+        recv_token_indices,
+        recv_capacity=recv_x.shape[0],
+        num_recv_tokens=num_recv_tokens_scalar,
+    )
+    out_local, _ = deepep_combine_intranode(
+        recv_out,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+        is_token_in_rank,
+    )
+    return out_local.astype(x_local.dtype), jnp.array(0, dtype=jnp.int32)
+
+
+def _moe_mlp_deepep_transport_second_ragged_dot_probe(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+
+    if mesh is None or mesh.empty:
+        return x
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+
+    if has_expert_axis and expert_axis_size > 1:
+        if grug_moe_lib._mesh_axis_size(mesh, "data") != 1:
+            raise ValueError(
+                "deepep_transport_second_ragged_dot_probe currently requires the expert group to span all visible "
+                f"local GPUs; got data axis size={grug_moe_lib._mesh_axis_size(mesh, 'data')} and expert axis "
+                f"size={expert_axis_size}"
+            )
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_deepep_transport_second_ragged_dot_probe_local,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    return x
+
+
+def _moe_mlp_ep_ring_local_prefix_counts(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_prefix_counts,
+        scatter_fn=_scatter_with_add,
+    )
+
+
+def _moe_mlp_ep_ring_local_vector_prefix(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_vector_prefix,
+        scatter_fn=_scatter_with_add,
+    )
+
+
+def _moe_mlp_ep_ring_local_onehot_counts(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_onehot_counts,
+        scatter_fn=_scatter_with_add,
+    )
+
+
+def _moe_mlp_ep_ring_local_padded_take(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_padded_take,
+        scatter_fn=_scatter_with_add,
+    )
+
+
+def _moe_mlp_ep_ring_local_segment_sum(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_topk,
+        scatter_fn=_scatter_with_segment_sum,
+    )
+
+
+def _moe_mlp_ep_ring_local_sorted_segment_sum(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_topk,
+        scatter_fn=_scatter_with_sorted_segment_sum,
+    )
+
+
+def _moe_mlp_ep_ring_local_prefix_segment_sum(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_prefix_counts,
+        scatter_fn=_scatter_with_segment_sum,
+    )
+
+
+def _moe_mlp_ep_ring_local_vector_sorted_segment_sum(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_vector_prefix,
+        scatter_fn=_scatter_with_sorted_segment_sum,
+    )
+
+
+def _moe_mlp_ep_ring_local_owner_local_scatter(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_onehot_counts,
+        scatter_fn=_scatter_with_owner_local_add,
+    )
+
+
+def _moe_mlp_ep_ring_local_lax_scatter(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_onehot_counts,
+        scatter_fn=_scatter_with_lax_scatter_add,
+    )
+
+
+def _moe_mlp_ep_ring_local_take_segment_bwd(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_onehot_counts,
+        scatter_fn=_scatter_with_add,
+        take_fn=_take_with_segment_sum_bwd,
+    )
+
+
+def _moe_mlp_ep_ring_local_take_sorted_segment_bwd(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_onehot_counts,
+        scatter_fn=_scatter_with_add,
+        take_fn=_take_with_sorted_segment_sum_bwd,
+    )
+
+
+def _moe_mlp_ep_ring_local_owner_local_take(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_owner_local_take,
+        scatter_fn=_scatter_with_add,
+    )
+
+
+def _moe_mlp_ep_ring_local_weight_cast(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_prefix_counts,
+        scatter_fn=_scatter_with_add,
+        gather_weight_dtype=x_local.dtype,
+    )
+
+
+def _moe_mlp_ep_ring_local_narrow_meta(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    return _moe_mlp_ep_ring_local_variant(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        moe_w13_local,
+        moe_w2_local,
+        activation_fn=activation_fn,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        compact_fn=_compact_local_assignments_prefix_counts,
+        scatter_fn=_scatter_with_add,
+        gather_weight_dtype=x_local.dtype,
+        gather_expert_dtype=jnp.uint16,
+    )
+
+
+def _moe_mlp_ring_variant(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    local_ring_fn: Callable[..., tuple[jax.Array, jax.Array]],
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        out, _ = grug_moe_lib._moe_mlp_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        )
+        return out
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+    local_expert_spec = P("expert", None, None) if has_expert_axis else P(None, None, None)
+
+    if has_expert_axis and expert_axis_size > 1:
+        shard_fn = shard_map(
+            partial(
+                local_ring_fn,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+                capacity_factor=capacity_factor,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    shard_fn = shard_map(
+        partial(
+            grug_moe_lib._moe_mlp_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        ),
+        mesh=mesh,
+        in_specs=(
+            batch_spec,
+            batch_spec,
+            batch_spec,
+            local_expert_spec,
+            local_expert_spec,
+        ),
+        out_specs=(batch_spec, P()),
+        check_vma=False,
+    )
+    out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+    return out
+
+
+def _moe_mlp_prefix_counts(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_prefix_counts,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_vector_prefix(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_vector_prefix,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_onehot_counts(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_onehot_counts,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_padded_take(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_padded_take,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_segment_sum(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_segment_sum,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_sorted_segment_sum(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_sorted_segment_sum,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_prefix_segment_sum(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_prefix_segment_sum,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_vector_sorted_segment_sum(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_vector_sorted_segment_sum,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_owner_local_scatter(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_owner_local_scatter,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_lax_scatter(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_lax_scatter,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_take_segment_bwd(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_take_segment_bwd,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_take_sorted_segment_bwd(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_take_sorted_segment_bwd,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_owner_local_take(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_owner_local_take,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_weight_cast(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_weight_cast,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_narrow_meta(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    return _moe_mlp_ring_variant(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        local_ring_fn=_moe_mlp_ep_ring_local_narrow_meta,
+        mesh=mesh,
+        capacity_factor=capacity_factor,
+    )
+
+
+def _moe_mlp_ep_ring_local_packed_return(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    with jax.named_scope("gather"):
+        x_global = jax.lax.all_gather(x_local, "expert", tiled=True)
+        selected_experts_global = jax.lax.all_gather(selected_experts_local, "expert", tiled=True)
+        combine_weights_global = jax.lax.all_gather(combine_weights_local, "expert", tiled=True)
+
+        tokens = x_global.shape[0]
+        topk = selected_experts_global.shape[1]
+        assignments = tokens * topk
+        expert_flat = selected_experts_global.reshape(assignments)
+        weight_flat = combine_weights_global.reshape(assignments)
+        token_flat = jnp.arange(assignments, dtype=jnp.int32) // topk
+
+        local_experts = moe_w13_local.shape[0]
+        if num_experts % local_experts != 0:
+            raise ValueError(
+                f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+            )
+
+        ep_size = num_experts // local_experts
+        local_capacity = int(np.ceil(capacity_factor * assignments / ep_size))
+        local_capacity = max(local_experts, local_capacity)
+
+        expert_axis = jax.lax.axis_index("expert")
+        expert_start = expert_axis * local_experts
+        local_expert = expert_flat - expert_start
+        local_mask = jnp.logical_and(local_expert >= 0, local_expert < local_experts)
+        local_count = jnp.sum(local_mask, dtype=jnp.int32)
+        dropped_local = jnp.maximum(local_count - local_capacity, 0)
+        valid = jnp.arange(local_capacity, dtype=jnp.int32) < local_count
+        valid_weight = valid.astype(jnp.float32)
+
+        local_expert = jnp.where(local_mask, local_expert, 0)
+        flat_pos = jnp.arange(assignments, dtype=jnp.int32)
+        order_key = local_expert * assignments + flat_pos
+        max_order_key = local_experts * assignments
+        selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
+        _, local_idx = jax.lax.top_k(selection_key, local_capacity)
+
+        token_local = jnp.take(token_flat, local_idx, axis=0)
+        expert_local = jnp.take(local_expert, local_idx, axis=0)
+        weight_local = jnp.take(weight_flat, local_idx, axis=0).astype(x_local.dtype)
+
+        x_take = jnp.take(x_global, token_local, axis=0)
+        x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))
+        weight_dispatch = jnp.where(valid, weight_local, jnp.zeros_like(weight_local))
+        expert_local = jnp.where(valid, expert_local, 0)
+
+    group_sizes = jnp.bincount(expert_local, weights=valid_weight, length=local_experts).astype(jnp.int32)
+    group_sizes = group_sizes.at[-1].add(local_capacity - jnp.sum(group_sizes, dtype=jnp.int32))
+
+    with jax.named_scope("moe_up_down"):
+        w13_out = ragged_dot(x_dispatch, moe_w13_local, group_sizes)
+        moe_dim = moe_w2_local.shape[1]
+        gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+        out_dispatch = ragged_dot(activation_fn(gate) * up, moe_w2_local, group_sizes)
+
+    with jax.named_scope("scatter"):
+        tokens_per_shard = x_local.shape[0]
+        owner_shard = token_local // tokens_per_shard
+        owner_token = token_local % tokens_per_shard
+        out_weighted = out_dispatch * weight_dispatch[:, None]
+        per_owner_capacity = max(1, int(np.ceil(capacity_factor * local_capacity / ep_size)))
+        packed_out, packed_token, packed_valid, dropped_return = _pack_by_shard(
+            out_weighted,
+            owner_token,
+            owner_shard,
+            num_shards=ep_size,
+            capacity=per_owner_capacity,
+        )
+
+        returned_out = jax.lax.all_to_all(packed_out, "expert", split_axis=0, concat_axis=0, tiled=False)
+        returned_token = jax.lax.all_to_all(packed_token, "expert", split_axis=0, concat_axis=0, tiled=False)
+        returned_valid = jax.lax.all_to_all(packed_valid, "expert", split_axis=0, concat_axis=0, tiled=False)
+
+        out_local = (
+            jnp.zeros_like(x_local)
+            .at[returned_token]
+            .add(
+                jnp.where(returned_valid[..., None], returned_out, jnp.zeros_like(returned_out)),
+                mode="drop",
+            )
+        )
+        dropped_total = jax.lax.psum(dropped_local + dropped_return, ("data", "expert"))
+    return out_local, dropped_total
+
+
+def _moe_mlp_ep_stream_ring_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+
+    ep_size = num_experts // local_experts
+    expert_axis = jax.lax.axis_index("expert")
+    expert_start = expert_axis * local_experts
+
+    tokens_per_chunk = x_local.shape[0]
+    topk = selected_experts_local.shape[1]
+    assignments_per_chunk = tokens_per_chunk * topk
+    local_capacity = int(np.ceil(capacity_factor * assignments_per_chunk / ep_size))
+    local_capacity = max(local_experts, local_capacity)
+
+    next_perm = [(src, (src + 1) % ep_size) for src in range(ep_size)]
+
+    def ring_step(carry, _):
+        x_chunk, selected_chunk, weight_chunk, out_chunk, dropped_acc = carry
+
+        expert_flat = selected_chunk.reshape(assignments_per_chunk)
+        weight_flat = weight_chunk.reshape(assignments_per_chunk)
+        local_expert = expert_flat - expert_start
+        local_mask = jnp.logical_and(local_expert >= 0, local_expert < local_experts)
+
+        token_local, weight_dispatch, x_dispatch, group_sizes, dropped_local = _compact_local_assignments_topk(
+            x_chunk,
+            local_expert,
+            local_mask,
+            weight_flat,
+            local_experts=local_experts,
+            local_capacity=local_capacity,
+            topk=topk,
+        )
+
+        w13_out = ragged_dot(x_dispatch, moe_w13_local, group_sizes)
+        moe_dim = moe_w2_local.shape[1]
+        gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+        out_dispatch = ragged_dot(activation_fn(gate) * up, moe_w2_local, group_sizes)
+        out_chunk = out_chunk.at[token_local].add(out_dispatch * weight_dispatch[:, None], mode="drop")
+
+        return (
+            jax.lax.ppermute(x_chunk, "expert", next_perm),
+            jax.lax.ppermute(selected_chunk, "expert", next_perm),
+            jax.lax.ppermute(weight_chunk, "expert", next_perm),
+            jax.lax.ppermute(out_chunk, "expert", next_perm),
+            dropped_acc + dropped_local,
+        ), None
+
+    init_carry = (
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        jnp.zeros_like(x_local),
+        jnp.array(0, dtype=jnp.int32),
+    )
+    final_carry, _ = jax.lax.scan(ring_step, init_carry, xs=None, length=ep_size)
+    _, _, _, out_local, dropped_local_total = final_carry
+    dropped_total = jax.lax.psum(dropped_local_total, ("data", "expert"))
+    return out_local, dropped_total
+
+
+def _moe_mlp_stream_ring(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        out, _ = grug_moe_lib._moe_mlp_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        )
+        return out
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+    local_expert_spec = P("expert", None, None) if has_expert_axis else P(None, None, None)
+
+    if has_expert_axis and expert_axis_size > 1:
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_stream_ring_local,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+                capacity_factor=capacity_factor,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    shard_fn = shard_map(
+        partial(
+            grug_moe_lib._moe_mlp_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        ),
+        mesh=mesh,
+        in_specs=(
+            batch_spec,
+            batch_spec,
+            batch_spec,
+            local_expert_spec,
+            local_expert_spec,
+        ),
+        out_specs=(batch_spec, P()),
+        check_vma=False,
+    )
+    out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+    return out
+
+
+def _moe_mlp_packed_return(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        out, _ = grug_moe_lib._moe_mlp_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        )
+        return out
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+    local_expert_spec = P("expert", None, None) if has_expert_axis else P(None, None, None)
+
+    if has_expert_axis and expert_axis_size > 1:
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_ring_local_packed_return,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+                capacity_factor=capacity_factor,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    shard_fn = shard_map(
+        partial(
+            grug_moe_lib._moe_mlp_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        ),
+        mesh=mesh,
+        in_specs=(
+            batch_spec,
+            batch_spec,
+            batch_spec,
+            local_expert_spec,
+            local_expert_spec,
+        ),
+        out_specs=(batch_spec, P()),
+        check_vma=False,
+    )
+    out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+    return out
+
+
+def _make_mesh(ep_size: int) -> Mesh:
+    devices = jax.devices()
+    if not devices:
+        raise RuntimeError("No JAX devices available")
+    if len(devices) % ep_size != 0:
+        raise ValueError(f"ep_size={ep_size} must divide local device count={len(devices)}")
+
+    mesh_devices = np.array(devices).reshape(len(devices) // ep_size, ep_size, 1)
+    return Mesh(
+        mesh_devices,
+        axis_names=("data", "expert", "model"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit, AxisType.Explicit),
+    )
+
+
+def _shard_inputs(
+    mesh: Mesh,
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+    batch_sharding = NamedSharding(mesh, P(("data", "expert"), None))
+    expert_sharding = NamedSharding(mesh, P("expert", None, None))
+    return (
+        jax.sharding.reshard(x, batch_sharding),
+        jax.sharding.reshard(selected_experts, batch_sharding),
+        jax.sharding.reshard(combine_weights, batch_sharding),
+        jax.sharding.reshard(w_up_gate, expert_sharding),
+        jax.sharding.reshard(w_down, expert_sharding),
+    )
+
+
+def _shard_shared_weights(mesh: Mesh, shared_w13: jax.Array, shared_w2: jax.Array) -> tuple[jax.Array, jax.Array]:
+    replicated = NamedSharding(mesh, P(None, None))
+    return (
+        jax.sharding.reshard(shared_w13, replicated),
+        jax.sharding.reshard(shared_w2, replicated),
+    )
+
+
+def _forward(
+    kernel: Kernel,
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    shared_w13: jax.Array,
+    shared_w2: jax.Array,
+) -> jax.Array:
+    if kernel == "legacy":
+        routed = _moe_mlp_legacy(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "current":
+        routed = grug_moe_lib.moe_mlp(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation=ActivationFunctionEnum.silu,
+        )
+    elif kernel == "cumsum":
+        routed = _moe_mlp_cumsum(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "packed_return":
+        routed = _moe_mlp_packed_return(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "stream_ring":
+        routed = _moe_mlp_stream_ring(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "ragged_a2a":
+        routed = _moe_mlp_ragged_a2a(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "deepep_layout_ragged_a2a":
+        routed = _moe_mlp_ragged_a2a_deepep_layout(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "deepep_transport_identity":
+        routed = _moe_mlp_deepep_transport_identity(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "deepep_transport_assignments_identity":
+        routed = _moe_mlp_deepep_transport_assignments_identity(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "deepep_transport_first_ragged_dot_probe":
+        routed = _moe_mlp_deepep_transport_first_ragged_dot_probe(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "deepep_transport_gate_probe":
+        routed = _moe_mlp_deepep_transport_gate_probe(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "deepep_transport_second_ragged_dot_probe":
+        routed = _moe_mlp_deepep_transport_second_ragged_dot_probe(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "deepep_transport":
+        routed = _moe_mlp_deepep_transport(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "prefix_counts":
+        routed = _moe_mlp_prefix_counts(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "vector_prefix":
+        routed = _moe_mlp_vector_prefix(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "onehot_counts":
+        routed = _moe_mlp_onehot_counts(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "padded_take":
+        routed = _moe_mlp_padded_take(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "segment_sum":
+        routed = _moe_mlp_segment_sum(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "sorted_segment_sum":
+        routed = _moe_mlp_sorted_segment_sum(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "prefix_segment_sum":
+        routed = _moe_mlp_prefix_segment_sum(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "vector_sorted_segment_sum":
+        routed = _moe_mlp_vector_sorted_segment_sum(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "owner_local_scatter":
+        routed = _moe_mlp_owner_local_scatter(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "lax_scatter":
+        routed = _moe_mlp_lax_scatter(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "take_segment_bwd":
+        routed = _moe_mlp_take_segment_bwd(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "take_sorted_segment_bwd":
+        routed = _moe_mlp_take_sorted_segment_bwd(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "owner_local_take":
+        routed = _moe_mlp_owner_local_take(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "weight_cast":
+        routed = _moe_mlp_weight_cast(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "narrow_meta":
+        routed = _moe_mlp_narrow_meta(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    else:
+        raise ValueError(f"Unknown kernel: {kernel}")
+
+    if kernel in {
+        "deepep_transport_identity",
+        "deepep_transport_assignments_identity",
+        "deepep_transport_first_ragged_dot_probe",
+        "deepep_transport_gate_probe",
+        "deepep_transport_second_ragged_dot_probe",
+    }:
+        return routed
+    return routed + _shared_mlp(x, shared_w13, shared_w2)
+
+
+def _loss_and_grads(
+    kernel: Kernel,
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    shared_w13: jax.Array,
+    shared_w2: jax.Array,
+) -> tuple[jax.Array, tuple[jax.Array, ...]]:
+    def loss_fn(x_in, w_up_gate_in, w_down_in, shared_w13_in, shared_w2_in):
+        y = _forward(
+            kernel,
+            x_in,
+            selected_experts,
+            combine_weights,
+            w_up_gate_in,
+            w_down_in,
+            shared_w13_in,
+            shared_w2_in,
+        )
+        return jnp.mean(jnp.square(y.astype(jnp.float32)))
+
+    return jax.value_and_grad(loss_fn, argnums=(0, 1, 2, 3, 4))(x, w_up_gate, w_down, shared_w13, shared_w2)
+
+
+def _time_deepep_transport_staged_forward(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    shared_w13: jax.Array,
+    shared_w2: jax.Array,
+    *,
+    warmup: int,
+    iters: int,
+) -> float:
+    _prewarm_deepep_transport_local_compute(x, selected_experts, w_up_gate, w_down, shared_w13, shared_w2)
+
+    mesh = x.sharding.mesh
+    num_experts = int(w_up_gate.shape[0])
+    dispatch_pack = jax.jit(partial(_moe_mlp_deepep_transport_dispatch_pack, mesh=mesh, num_experts=num_experts))
+    local_compute = jax.jit(partial(_moe_mlp_deepep_transport_local_compute, mesh=mesh))
+    collapse_combine = jax.jit(partial(_moe_mlp_deepep_transport_collapse_combine, mesh=mesh))
+    shared_mlp = jax.jit(_shared_mlp)
+
+    def run_once() -> jax.Array:
+        (
+            x_dispatch,
+            assignment_weights,
+            recv_token_indices,
+            local_group_sizes,
+            recv_topk_weights,
+            recv_src_idx,
+            rank_prefix_matrix,
+            channel_prefix_matrix,
+            recv_channel_prefix_matrix,
+            send_head,
+            num_recv_tokens,
+            is_token_in_rank,
+        ) = dispatch_pack(x, selected_experts, combine_weights)
+        out_dispatch = local_compute(x_dispatch, local_group_sizes, w_up_gate, w_down)
+        routed = collapse_combine(
+            out_dispatch,
+            assignment_weights,
+            recv_token_indices,
+            recv_topk_weights,
+            recv_src_idx,
+            rank_prefix_matrix,
+            channel_prefix_matrix,
+            recv_channel_prefix_matrix,
+            send_head,
+            num_recv_tokens,
+            is_token_in_rank,
+        )
+        return routed + shared_mlp(x, shared_w13, shared_w2)
+
+    jax.block_until_ready(run_once())
+    for _ in range(warmup):
+        jax.block_until_ready(run_once())
+    start = time.perf_counter()
+    for _ in range(iters):
+        jax.block_until_ready(run_once())
+    return (time.perf_counter() - start) / iters
+
+
+def _prewarm_deepep_transport_local_compute(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    shared_w13: jax.Array,
+    shared_w2: jax.Array,
+    *,
+    max_local_assignments: int | None = None,
+) -> None:
+    mesh = x.sharding.mesh
+    num_experts = int(w_up_gate.shape[0])
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+    local_assignments = (
+        x.shape[0] * selected_experts.shape[1] if max_local_assignments is None else max_local_assignments
+    )
+    local_compute = jax.jit(partial(_moe_mlp_deepep_transport_local_compute, mesh=mesh))
+    shared_mlp = jax.jit(_shared_mlp)
+    dispatch_spec = jax.ShapeDtypeStruct(
+        (expert_axis_size * local_assignments, x.shape[1]),
+        x.dtype,
+        sharding=NamedSharding(mesh, P("expert", None)),
+    )
+    group_sizes_spec = jax.ShapeDtypeStruct(
+        (num_experts,),
+        jnp.int32,
+        sharding=NamedSharding(mesh, P("expert")),
+    )
+
+    local_compute.lower(dispatch_spec, group_sizes_spec, w_up_gate, w_down).compile()
+    jax.block_until_ready(shared_mlp(x, shared_w13, shared_w2))
+
+
+def _forward_deepep_transport_capped(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    shared_w13: jax.Array,
+    shared_w2: jax.Array,
+    *,
+    max_recv_tokens: int,
+    max_local_assignments: int,
+) -> jax.Array:
+    routed = _moe_mlp_deepep_transport(
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        max_recv_tokens=max_recv_tokens,
+        max_local_assignments=max_local_assignments,
+    )
+    return routed + _shared_mlp(x, shared_w13, shared_w2)
+
+
+def _time_deepep_transport_forward_prewarmed(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    shared_w13: jax.Array,
+    shared_w2: jax.Array,
+    *,
+    warmup: int,
+    iters: int,
+) -> float:
+    _prewarm_deepep_transport_local_compute(x, selected_experts, w_up_gate, w_down, shared_w13, shared_w2)
+    return _time_fn(
+        partial(_forward, "deepep_transport"),
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        shared_w13,
+        shared_w2,
+        warmup=warmup,
+        iters=iters,
+    )
+
+
+def _time_deepep_transport_forward_capped_prewarmed(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    shared_w13: jax.Array,
+    shared_w2: jax.Array,
+    *,
+    warmup: int,
+    iters: int,
+) -> float:
+    mesh = x.sharding.mesh
+    num_experts = int(w_up_gate.shape[0])
+    max_recv_tokens, max_local_assignments = _deepep_transport_exact_caps(
+        selected_experts,
+        mesh=mesh,
+        num_experts=num_experts,
+    )
+    _prewarm_deepep_transport_local_compute(
+        x,
+        selected_experts,
+        w_up_gate,
+        w_down,
+        shared_w13,
+        shared_w2,
+        max_local_assignments=max_local_assignments,
+    )
+    return _time_fn(
+        partial(
+            _forward_deepep_transport_capped,
+            max_recv_tokens=max_recv_tokens,
+            max_local_assignments=max_local_assignments,
+        ),
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        shared_w13,
+        shared_w2,
+        warmup=warmup,
+        iters=iters,
+    )
+
+
+def _time_deepep_transport_forward_capped(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    shared_w13: jax.Array,
+    shared_w2: jax.Array,
+    *,
+    warmup: int,
+    iters: int,
+) -> float:
+    mesh = x.sharding.mesh
+    num_experts = int(w_up_gate.shape[0])
+    max_recv_tokens, max_local_assignments = _deepep_transport_exact_caps(
+        selected_experts,
+        mesh=mesh,
+        num_experts=num_experts,
+    )
+    return _time_fn(
+        partial(
+            _forward_deepep_transport_capped,
+            max_recv_tokens=max_recv_tokens,
+            max_local_assignments=max_local_assignments,
+        ),
+        x,
+        selected_experts,
+        combine_weights,
+        w_up_gate,
+        w_down,
+        shared_w13,
+        shared_w2,
+        warmup=warmup,
+        iters=iters,
+    )
+
+
+def _time_deepep_transport_forward_backward_capped_prewarmed(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    shared_w13: jax.Array,
+    shared_w2: jax.Array,
+    *,
+    warmup: int,
+    iters: int,
+) -> float:
+    mesh = x.sharding.mesh
+    num_experts = int(w_up_gate.shape[0])
+    max_recv_tokens, max_local_assignments = _deepep_transport_exact_caps(
+        selected_experts,
+        mesh=mesh,
+        num_experts=num_experts,
+    )
+    _prewarm_deepep_transport_local_compute(
+        x,
+        selected_experts,
+        w_up_gate,
+        w_down,
+        shared_w13,
+        shared_w2,
+        max_local_assignments=max_local_assignments,
+    )
+
+    def loss_fn(x_in, w_up_gate_in, w_down_in, shared_w13_in, shared_w2_in):
+        y = _forward_deepep_transport_capped(
+            x_in,
+            selected_experts,
+            combine_weights,
+            w_up_gate_in,
+            w_down_in,
+            shared_w13_in,
+            shared_w2_in,
+            max_recv_tokens=max_recv_tokens,
+            max_local_assignments=max_local_assignments,
+        )
+        return jnp.mean(jnp.square(y.astype(jnp.float32)))
+
+    grad_fn = jax.value_and_grad(loss_fn, argnums=(0, 1, 2, 3, 4))
+    return _time_fn(
+        grad_fn,
+        x,
+        w_up_gate,
+        w_down,
+        shared_w13,
+        shared_w2,
+        warmup=warmup,
+        iters=iters,
+    )
+
+
+def _flatten_tree_max_abs(tree_a, tree_b) -> float:
+    leaves_a = jax.tree.leaves(tree_a)
+    leaves_b = jax.tree.leaves(tree_b)
+    return max(
+        float(jnp.max(jnp.abs(a.astype(jnp.float32) - b.astype(jnp.float32)))) for a, b in zip(leaves_a, leaves_b)
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Benchmark legacy vs current functional Grug MoE kernels.")
+    parser.add_argument("--coordinator-address", type=str, default=None)
+    parser.add_argument("--num-processes", type=int, default=None)
+    parser.add_argument("--process-id", type=int, default=None)
+    parser.add_argument("--tokens", type=int, default=32_768)
+    parser.add_argument("--hidden", type=int, default=2_048)
+    parser.add_argument("--mlp-dim", type=int, default=768)
+    parser.add_argument("--experts", type=int, default=128)
+    parser.add_argument("--topk", type=int, default=8)
+    parser.add_argument("--shared-expert-dim", type=int, default=2_048)
+    parser.add_argument("--dtype", type=str, default="bfloat16")
+    parser.add_argument("--distribution", choices=["random", "runs"], default="random")
+    parser.add_argument("--run-alpha", type=float, default=0.98)
+    parser.add_argument("--run-noise-scale", type=float, default=0.35)
+    parser.add_argument("--bench-pass", choices=["forward", "forward_backward"], default="forward_backward")
+    parser.add_argument(
+        "--kernel",
+        choices=[
+            "legacy",
+            "current",
+            "cumsum",
+            "packed_return",
+            "stream_ring",
+            "ragged_a2a",
+            "deepep_layout_ragged_a2a",
+            "deepep_transport_identity",
+            "deepep_transport_assignments_identity",
+            "deepep_transport_first_ragged_dot_probe",
+            "deepep_transport_gate_probe",
+            "deepep_transport_second_ragged_dot_probe",
+            "deepep_transport",
+            "deepep_transport_prewarmed",
+            "deepep_transport_capped",
+            "deepep_transport_capped_prewarmed",
+            "deepep_transport_staged",
+            "prefix_counts",
+            "vector_prefix",
+            "onehot_counts",
+            "padded_take",
+            "segment_sum",
+            "sorted_segment_sum",
+            "prefix_segment_sum",
+            "vector_sorted_segment_sum",
+            "owner_local_scatter",
+            "lax_scatter",
+            "take_segment_bwd",
+            "take_sorted_segment_bwd",
+            "owner_local_take",
+            "weight_cast",
+            "narrow_meta",
+            "both",
+        ],
+        default="both",
+    )
+    parser.add_argument("--ep-list", type=str, default="1,2,4,8")
+    parser.add_argument("--capacity-factor", type=float, default=grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR)
+    parser.add_argument("--warmup", type=int, default=2)
+    parser.add_argument("--iters", type=int, default=5)
+    parser.add_argument("--seed", type=int, default=0)
+    parser.add_argument("--check-equivalence", action="store_true")
+    parser.add_argument("--profile-root", type=Path, default=None)
+    args = parser.parse_args()
+
+    if args.coordinator_address is not None or args.num_processes is not None or args.process_id is not None:
+        if args.coordinator_address is None or args.num_processes is None or args.process_id is None:
+            raise ValueError(
+                "--coordinator-address, --num-processes, and --process-id must be set together for multihost runs"
+            )
+        jax.distributed.initialize(
+            coordinator_address=args.coordinator_address,
+            num_processes=args.num_processes,
+            process_id=args.process_id,
+        )
+
+    dtype = jnp.dtype(args.dtype)
+    eps = [int(tok.strip()) for tok in args.ep_list.split(",") if tok.strip()]
+    kernels: list[Kernel] = ["legacy", "current"] if args.kernel == "both" else [args.kernel]
+
+    if args.profile_root is not None:
+        if len(eps) != 1:
+            raise ValueError("--profile-root requires exactly one EP value in --ep-list")
+        if len(kernels) != 1:
+            raise ValueError("--profile-root requires exactly one kernel via --kernel")
+        if args.check_equivalence:
+            raise ValueError("--profile-root cannot be combined with --check-equivalence")
+
+    key = jax.random.PRNGKey(args.seed)
+    key_x, key_router, key_w13, key_w2, key_sw13, key_sw2 = jax.random.split(key, 6)
+
+    x = jax.random.normal(key_x, (args.tokens, args.hidden), dtype=dtype)
+    router_logits = _sample_router_logits(
+        key_router,
+        tokens=args.tokens,
+        experts=args.experts,
+        distribution=args.distribution,
+        run_alpha=args.run_alpha,
+        run_noise_scale=args.run_noise_scale,
+    )
+    selected_experts, combine_weights = _route_topk(router_logits, topk=args.topk)
+    combine_weights = combine_weights.astype(dtype)
+
+    w_up_gate = jax.random.normal(key_w13, (args.experts, args.hidden, 2 * args.mlp_dim), dtype=dtype)
+    w_down = jax.random.normal(key_w2, (args.experts, args.mlp_dim, args.hidden), dtype=dtype)
+    shared_w13 = jax.random.normal(key_sw13, (args.hidden, 2 * args.shared_expert_dim), dtype=dtype)
+    shared_w2 = jax.random.normal(key_sw2, (args.shared_expert_dim, args.hidden), dtype=dtype)
+
+    _print0(f"devices={jax.devices()}")
+    _print0(
+        "shape "
+        f"tokens={args.tokens} hidden={args.hidden} mlp_dim={args.mlp_dim} experts={args.experts} "
+        f"topk={args.topk} shared_expert_dim={args.shared_expert_dim} dtype={dtype} "
+        f"distribution={args.distribution} bench_pass={args.bench_pass} capacity_factor={args.capacity_factor}"
+    )
+
+    for ep_size in eps:
+        mesh = _make_mesh(ep_size)
+        with jax.set_mesh(mesh):
+            x_sharded, selected_sharded, weights_sharded, w13_sharded, w2_sharded = _shard_inputs(
+                mesh, x, selected_experts, combine_weights, w_up_gate, w_down
+            )
+            shared_w13_sharded, shared_w2_sharded = _shard_shared_weights(mesh, shared_w13, shared_w2)
+            if args.check_equivalence and set(kernels) == {"legacy", "current"}:
+                legacy_out = jax.jit(_forward, static_argnums=0)(
+                    "legacy",
+                    x_sharded,
+                    selected_sharded,
+                    weights_sharded,
+                    w13_sharded,
+                    w2_sharded,
+                    shared_w13_sharded,
+                    shared_w2_sharded,
+                )
+                current_out = jax.jit(_forward, static_argnums=0)(
+                    "current",
+                    x_sharded,
+                    selected_sharded,
+                    weights_sharded,
+                    w13_sharded,
+                    w2_sharded,
+                    shared_w13_sharded,
+                    shared_w2_sharded,
+                )
+                out_max_abs = float(jnp.max(jnp.abs(legacy_out.astype(jnp.float32) - current_out.astype(jnp.float32))))
+                _, legacy_grads = jax.jit(_loss_and_grads, static_argnums=0)(
+                    "legacy",
+                    x_sharded,
+                    selected_sharded,
+                    weights_sharded,
+                    w13_sharded,
+                    w2_sharded,
+                    shared_w13_sharded,
+                    shared_w2_sharded,
+                )
+                _, current_grads = jax.jit(_loss_and_grads, static_argnums=0)(
+                    "current",
+                    x_sharded,
+                    selected_sharded,
+                    weights_sharded,
+                    w13_sharded,
+                    w2_sharded,
+                    shared_w13_sharded,
+                    shared_w2_sharded,
+                )
+                grad_max_abs = _flatten_tree_max_abs(legacy_grads, current_grads)
+                _print0(f"CHECK ep={ep_size} out_max_abs={out_max_abs:.6e} grad_max_abs={grad_max_abs:.6e}")
+
+            for kernel in kernels:
+                forward_fn = partial(_forward, kernel)
+                grad_fn = partial(_loss_and_grads, kernel)
+                profile_name = f"moe_{kernel}_ep{ep_size}_{args.bench_pass}"
+                if args.bench_pass == "forward":
+                    if kernel == "deepep_transport_prewarmed":
+                        if args.profile_root is not None:
+                            raise ValueError("deepep_transport_prewarmed does not yet support --profile-root")
+                        dt = _time_deepep_transport_forward_prewarmed(
+                            x_sharded,
+                            selected_sharded,
+                            weights_sharded,
+                            w13_sharded,
+                            w2_sharded,
+                            shared_w13_sharded,
+                            shared_w2_sharded,
+                            warmup=args.warmup,
+                            iters=args.iters,
+                        )
+                    elif kernel == "deepep_transport_capped":
+                        if args.profile_root is not None:
+                            raise ValueError("deepep_transport_capped does not yet support --profile-root")
+                        dt = _time_deepep_transport_forward_capped(
+                            x_sharded,
+                            selected_sharded,
+                            weights_sharded,
+                            w13_sharded,
+                            w2_sharded,
+                            shared_w13_sharded,
+                            shared_w2_sharded,
+                            warmup=args.warmup,
+                            iters=args.iters,
+                        )
+                    elif kernel == "deepep_transport_capped_prewarmed":
+                        if args.profile_root is not None:
+                            raise ValueError("deepep_transport_capped_prewarmed does not yet support --profile-root")
+                        dt = _time_deepep_transport_forward_capped_prewarmed(
+                            x_sharded,
+                            selected_sharded,
+                            weights_sharded,
+                            w13_sharded,
+                            w2_sharded,
+                            shared_w13_sharded,
+                            shared_w2_sharded,
+                            warmup=args.warmup,
+                            iters=args.iters,
+                        )
+                    elif kernel == "deepep_transport_staged":
+                        if args.profile_root is not None:
+                            raise ValueError("deepep_transport_staged does not yet support --profile-root")
+                        dt = _time_deepep_transport_staged_forward(
+                            x_sharded,
+                            selected_sharded,
+                            weights_sharded,
+                            w13_sharded,
+                            w2_sharded,
+                            shared_w13_sharded,
+                            shared_w2_sharded,
+                            warmup=args.warmup,
+                            iters=args.iters,
+                        )
+                    elif args.profile_root is not None:
+                        dt = _profile_fn(
+                            forward_fn,
+                            x_sharded,
+                            selected_sharded,
+                            weights_sharded,
+                            w13_sharded,
+                            w2_sharded,
+                            shared_w13_sharded,
+                            shared_w2_sharded,
+                            warmup=args.warmup,
+                            iters=args.iters,
+                            profile_dir=args.profile_root,
+                            profile_name=profile_name,
+                        )
+                    else:
+                        dt = _time_fn(
+                            forward_fn,
+                            x_sharded,
+                            selected_sharded,
+                            weights_sharded,
+                            w13_sharded,
+                            w2_sharded,
+                            shared_w13_sharded,
+                            shared_w2_sharded,
+                            warmup=args.warmup,
+                            iters=args.iters,
+                        )
+                else:
+                    if kernel in {"deepep_transport_prewarmed", "deepep_transport_capped", "deepep_transport_staged"}:
+                        raise ValueError(f"{kernel} currently supports only --bench-pass=forward")
+                    if kernel == "deepep_transport_capped_prewarmed":
+                        if args.profile_root is not None:
+                            raise ValueError("deepep_transport_capped_prewarmed does not yet support --profile-root")
+                        dt = _time_deepep_transport_forward_backward_capped_prewarmed(
+                            x_sharded,
+                            selected_sharded,
+                            weights_sharded,
+                            w13_sharded,
+                            w2_sharded,
+                            shared_w13_sharded,
+                            shared_w2_sharded,
+                            warmup=args.warmup,
+                            iters=args.iters,
+                        )
+                    elif args.profile_root is not None:
+                        dt = _profile_fn(
+                            grad_fn,
+                            x_sharded,
+                            selected_sharded,
+                            weights_sharded,
+                            w13_sharded,
+                            w2_sharded,
+                            shared_w13_sharded,
+                            shared_w2_sharded,
+                            warmup=args.warmup,
+                            iters=args.iters,
+                            profile_dir=args.profile_root,
+                            profile_name=profile_name,
+                        )
+                    else:
+                        dt = _time_fn(
+                            grad_fn,
+                            x_sharded,
+                            selected_sharded,
+                            weights_sharded,
+                            w13_sharded,
+                            w2_sharded,
+                            shared_w13_sharded,
+                            shared_w2_sharded,
+                            warmup=args.warmup,
+                            iters=args.iters,
+                        )
+
+                _print0(
+                    "RESULT "
+                    f"kernel={kernel} ep={ep_size} pass={args.bench_pass} "
+                    f"time_s={dt:.6f} tokens_per_s={args.tokens / dt:.2f}"
+                )
+                if args.profile_root is not None:
+                    _print0(f"PROFILE kernel={kernel} ep={ep_size} dir={args.profile_root}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/levanter/scripts/bench/bench_moe_hillclimb.py
+++ b/lib/levanter/scripts/bench/bench_moe_hillclimb.py
@@ -41,6 +41,7 @@ Kernel = Literal[
     "stream_ring_sonic_combine",
     "ragged_a2a",
     "deepep_layout_ragged_a2a",
+    "token_ragged_a2a",
     "deepep_transport_identity",
     "deepep_transport_assignments_identity",
     "deepep_transport_first_ragged_dot_probe",
@@ -1264,6 +1265,31 @@ def _collapse_deepep_local_assignments(
     return jnp.where(recv_valid[:, None], recv_out, 0)
 
 
+def _pack_token_rank_payload(
+    payload: jax.Array,
+    is_token_in_rank: jax.Array,
+    num_tokens_per_rank: jax.Array,
+    *,
+    send_capacity: int,
+) -> jax.Array:
+    tokens, ep_size = is_token_in_rank.shape
+    rank_token_mask = jnp.swapaxes(is_token_in_rank, 0, 1)
+    rank_token_mask_i32 = rank_token_mask.astype(jnp.int32)
+    rank_offsets = jnp.cumsum(num_tokens_per_rank, dtype=jnp.int32) - num_tokens_per_rank
+    within_rank = jnp.cumsum(rank_token_mask_i32, axis=1, dtype=jnp.int32) - 1
+    packed_position = (rank_offsets[:, None] + within_rank).reshape(ep_size * tokens)
+
+    token_ids = jnp.broadcast_to(jnp.arange(tokens, dtype=jnp.int32), (ep_size, tokens)).reshape(ep_size * tokens)
+    valid = rank_token_mask.reshape(ep_size * tokens)
+    dummy_position = jnp.array(send_capacity, dtype=jnp.int32)
+    safe_position = jnp.where(valid, packed_position, dummy_position)
+    values = jnp.take(payload, token_ids, axis=0)
+
+    packed_shape = (send_capacity + 1, *payload.shape[1:])
+    packed = jnp.zeros(packed_shape, dtype=payload.dtype).at[safe_position].set(values)
+    return packed[:send_capacity]
+
+
 def _deepep_transport_exact_caps(
     selected_experts: jax.Array,
     *,
@@ -1571,6 +1597,163 @@ def _moe_mlp_ep_ragged_a2a_deepep_layout_local(
     return out_local, dropped_total
 
 
+def _moe_mlp_ep_token_ragged_a2a_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+
+    shard_id = jax.lax.axis_index("expert")
+    ep_size = num_experts // local_experts
+    expert_start = shard_id * local_experts
+    tokens_per_shard = x_local.shape[0]
+    topk = selected_experts_local.shape[1]
+    token_fanout_capacity = tokens_per_shard * min(topk, ep_size)
+    local_assignment_capacity = max(local_experts, int(np.ceil(capacity_factor * tokens_per_shard * topk)))
+
+    with jax.named_scope("dispatch"):
+        num_tokens_per_rank, _num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
+            selected_experts_local,
+            num_ranks=ep_size,
+            num_experts=num_experts,
+        )
+        x_payload = _pack_token_rank_payload(
+            x_local,
+            is_token_in_rank,
+            num_tokens_per_rank,
+            send_capacity=token_fanout_capacity,
+        )
+        topk_payload = _pack_token_rank_payload(
+            selected_experts_local.astype(jnp.int64),
+            is_token_in_rank,
+            num_tokens_per_rank,
+            send_capacity=token_fanout_capacity,
+        )
+        weight_payload = _pack_token_rank_payload(
+            combine_weights_local,
+            is_token_in_rank,
+            num_tokens_per_rank,
+            send_capacity=token_fanout_capacity,
+        )
+        src_token_payload = _pack_token_rank_payload(
+            jnp.arange(tokens_per_shard, dtype=jnp.int32)[:, None],
+            is_token_in_rank,
+            num_tokens_per_rank,
+            send_capacity=token_fanout_capacity,
+        )
+
+        all_shard_counts = jax.lax.all_gather(num_tokens_per_rank.astype(jnp.int32), "expert")
+        input_offsets, send_sizes, output_offsets, recv_sizes = _shard_a2a_params(all_shard_counts, shard_id)
+        recv_token_capacity = token_fanout_capacity
+        num_recv_tokens = jnp.sum(recv_sizes, dtype=jnp.int32)
+
+        recv_x = jax.lax.ragged_all_to_all(
+            x_payload,
+            jnp.zeros((recv_token_capacity, x_local.shape[1]), dtype=x_local.dtype),
+            input_offsets,
+            send_sizes,
+            output_offsets,
+            recv_sizes,
+            axis_name="expert",
+        )
+        recv_topk_idx = jax.lax.ragged_all_to_all(
+            topk_payload,
+            jnp.zeros((recv_token_capacity, topk), dtype=topk_payload.dtype),
+            input_offsets,
+            send_sizes,
+            output_offsets,
+            recv_sizes,
+            axis_name="expert",
+        )
+        recv_topk_weights = jax.lax.ragged_all_to_all(
+            weight_payload,
+            jnp.zeros((recv_token_capacity, topk), dtype=weight_payload.dtype),
+            input_offsets,
+            send_sizes,
+            output_offsets,
+            recv_sizes,
+            axis_name="expert",
+        )
+        recv_src_token = jax.lax.ragged_all_to_all(
+            src_token_payload,
+            jnp.zeros((recv_token_capacity, 1), dtype=src_token_payload.dtype),
+            input_offsets,
+            send_sizes,
+            output_offsets,
+            recv_sizes,
+            axis_name="expert",
+        )
+        recv_src_token = jnp.squeeze(recv_src_token, axis=1)
+
+        x_dispatch, assignment_weights, recv_token_indices, local_group_sizes = _pack_deepep_local_assignments(
+            recv_x,
+            recv_topk_idx,
+            recv_topk_weights,
+            expert_start=expert_start,
+            local_experts=local_experts,
+            num_recv_tokens=num_recv_tokens,
+            max_local_assignments=local_assignment_capacity,
+        )
+
+    with jax.named_scope("moe_up_down"):
+        w13_out = ragged_dot(x_dispatch, moe_w13_local, local_group_sizes)
+        moe_dim = moe_w2_local.shape[1]
+        gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+        out_dispatch = ragged_dot(activation_fn(gate) * up, moe_w2_local, local_group_sizes)
+
+    with jax.named_scope("combine"):
+        recv_out = _collapse_deepep_local_assignments(
+            out_dispatch,
+            assignment_weights,
+            recv_token_indices,
+            recv_capacity=recv_token_capacity,
+            num_recv_tokens=num_recv_tokens,
+        )
+        return_input_offsets, return_send_sizes, return_output_offsets, return_recv_sizes = _shard_a2a_params(
+            all_shard_counts.T,
+            shard_id,
+        )
+        returned_out = jax.lax.ragged_all_to_all(
+            recv_out,
+            jnp.zeros((token_fanout_capacity, x_local.shape[1]), dtype=recv_out.dtype),
+            return_input_offsets,
+            return_send_sizes,
+            return_output_offsets,
+            return_recv_sizes,
+            axis_name="expert",
+        )
+        returned_token = jax.lax.ragged_all_to_all(
+            recv_src_token[:, None],
+            jnp.zeros((token_fanout_capacity, 1), dtype=recv_src_token.dtype),
+            return_input_offsets,
+            return_send_sizes,
+            return_output_offsets,
+            return_recv_sizes,
+            axis_name="expert",
+        )
+        returned_token = jnp.squeeze(returned_token, axis=1)
+        num_returned_tokens = jnp.sum(num_tokens_per_rank, dtype=jnp.int32)
+        return_valid = jnp.arange(token_fanout_capacity, dtype=jnp.int32) < num_returned_tokens
+        out_local = (
+            jnp.zeros_like(x_local)
+            .at[returned_token]
+            .add(jnp.where(return_valid[:, None], returned_out, jnp.zeros_like(returned_out)), mode="drop")
+        )
+        dropped_total = jnp.array(0, dtype=jnp.int32)
+    return out_local.astype(x_local.dtype), dropped_total
+
+
 def _moe_mlp_ep_deepep_transport_local(
     x_local: jax.Array,
     selected_experts_local: jax.Array,
@@ -1699,6 +1882,82 @@ def _moe_mlp_ragged_a2a_deepep_layout(
         shard_fn = shard_map(
             partial(
                 _moe_mlp_ep_ragged_a2a_deepep_layout_local,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+                capacity_factor=capacity_factor,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    shard_fn = shard_map(
+        partial(
+            grug_moe_lib._moe_mlp_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        ),
+        mesh=mesh,
+        in_specs=(
+            batch_spec,
+            batch_spec,
+            batch_spec,
+            local_expert_spec,
+            local_expert_spec,
+        ),
+        out_specs=(batch_spec, P()),
+        check_vma=False,
+    )
+    out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+    return out
+
+
+def _moe_mlp_token_ragged_a2a(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        out, _ = grug_moe_lib._moe_mlp_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        )
+        return out
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+    local_expert_spec = P("expert", None, None) if has_expert_axis else P(None, None, None)
+
+    if has_expert_axis and expert_axis_size > 1:
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_token_ragged_a2a_local,
                 activation_fn=activation_fn,
                 num_experts=num_experts,
                 capacity_factor=capacity_factor,
@@ -4094,6 +4353,14 @@ def _forward(
             w_up_gate,
             w_down,
         )
+    elif kernel == "token_ragged_a2a":
+        routed = _moe_mlp_token_ragged_a2a(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
     elif kernel == "deepep_transport_identity":
         routed = _moe_mlp_deepep_transport_identity(
             x,
@@ -4621,6 +4888,7 @@ def main() -> None:
             "stream_ring_sonic_combine",
             "ragged_a2a",
             "deepep_layout_ragged_a2a",
+            "token_ragged_a2a",
             "deepep_transport_identity",
             "deepep_transport_assignments_identity",
             "deepep_transport_first_ragged_dot_probe",

--- a/lib/levanter/scripts/bench/bench_moe_hillclimb.py
+++ b/lib/levanter/scripts/bench/bench_moe_hillclimb.py
@@ -1634,7 +1634,7 @@ def _moe_mlp_ep_token_ragged_a2a_local(
             send_capacity=token_fanout_capacity,
         )
         topk_payload = _pack_token_rank_payload(
-            selected_experts_local.astype(jnp.int64),
+            selected_experts_local.astype(jnp.int32),
             is_token_in_rank,
             num_tokens_per_rank,
             send_capacity=token_fanout_capacity,

--- a/lib/levanter/scripts/bench/bench_moe_hillclimb.py
+++ b/lib/levanter/scripts/bench/bench_moe_hillclimb.py
@@ -1156,10 +1156,9 @@ def _shard_a2a_params(
     input_offsets = jnp.cumsum(jnp.concatenate((jnp.array([0], dtype=row.dtype), row[:-1])))
     send_sizes = row
 
-    zero_row = jnp.zeros((1, shard_counts.shape[1]), dtype=shard_counts.dtype)
-    cumulative = jnp.cumsum(jnp.concatenate((zero_row, shard_counts), axis=0), axis=0, dtype=shard_counts.dtype)
-    output_offsets = cumulative[shard_id]
     recv_sizes = shard_counts[:, shard_id]
+    sender_output_offsets = jnp.cumsum(shard_counts, axis=0, dtype=shard_counts.dtype) - shard_counts
+    output_offsets = sender_output_offsets[shard_id]
     return input_offsets, send_sizes, output_offsets, recv_sizes
 
 

--- a/lib/levanter/scripts/bench/bench_moe_hillclimb.py
+++ b/lib/levanter/scripts/bench/bench_moe_hillclimb.py
@@ -1634,7 +1634,7 @@ def _moe_mlp_ep_token_ragged_a2a_local(
             send_capacity=token_fanout_capacity,
         )
         topk_payload = _pack_token_rank_payload(
-            selected_experts_local.astype(jnp.int32),
+            selected_experts_local.astype(jnp.float32),
             is_token_in_rank,
             num_tokens_per_rank,
             send_capacity=token_fanout_capacity,
@@ -1646,7 +1646,7 @@ def _moe_mlp_ep_token_ragged_a2a_local(
             send_capacity=token_fanout_capacity,
         )
         src_token_payload = _pack_token_rank_payload(
-            jnp.arange(tokens_per_shard, dtype=jnp.int32)[:, None],
+            jnp.arange(tokens_per_shard, dtype=jnp.float32)[:, None],
             is_token_in_rank,
             num_tokens_per_rank,
             send_capacity=token_fanout_capacity,
@@ -1675,6 +1675,7 @@ def _moe_mlp_ep_token_ragged_a2a_local(
             recv_sizes,
             axis_name="expert",
         )
+        recv_topk_idx = recv_topk_idx.astype(jnp.int32)
         recv_topk_weights = jax.lax.ragged_all_to_all(
             weight_payload,
             jnp.zeros((recv_token_capacity, topk), dtype=weight_payload.dtype),
@@ -1693,7 +1694,7 @@ def _moe_mlp_ep_token_ragged_a2a_local(
             recv_sizes,
             axis_name="expert",
         )
-        recv_src_token = jnp.squeeze(recv_src_token, axis=1)
+        recv_src_token = jnp.squeeze(recv_src_token, axis=1).astype(jnp.int32)
 
         x_dispatch, assignment_weights, recv_token_indices, local_group_sizes = _pack_deepep_local_assignments(
             recv_x,
@@ -1733,15 +1734,15 @@ def _moe_mlp_ep_token_ragged_a2a_local(
             axis_name="expert",
         )
         returned_token = jax.lax.ragged_all_to_all(
-            recv_src_token[:, None],
-            jnp.zeros((token_fanout_capacity, 1), dtype=recv_src_token.dtype),
+            recv_src_token.astype(jnp.float32)[:, None],
+            jnp.zeros((token_fanout_capacity, 1), dtype=jnp.float32),
             return_input_offsets,
             return_send_sizes,
             return_output_offsets,
             return_recv_sizes,
             axis_name="expert",
         )
-        returned_token = jnp.squeeze(returned_token, axis=1)
+        returned_token = jnp.squeeze(returned_token, axis=1).astype(jnp.int32)
         num_returned_tokens = jnp.sum(num_tokens_per_rank, dtype=jnp.int32)
         return_valid = jnp.arange(token_fanout_capacity, dtype=jnp.int32) < num_returned_tokens
         out_local = (

--- a/lib/levanter/scripts/bench/bench_moe_hillclimb.py
+++ b/lib/levanter/scripts/bench/bench_moe_hillclimb.py
@@ -27,6 +27,7 @@ from jax import shard_map
 from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P, get_abstract_mesh
 
 from levanter.grug import grug_moe as grug_moe_lib
+from levanter.grug._moe.sonic import sonic_gather_sum
 from levanter.kernels.deepep import deepep_combine_intranode, deepep_dispatch_intranode, deepep_get_dispatch_layout
 from levanter.utils.activation import ActivationFunctionEnum
 
@@ -37,6 +38,7 @@ Kernel = Literal[
     "cumsum",
     "packed_return",
     "stream_ring",
+    "stream_ring_sonic_combine",
     "ragged_a2a",
     "deepep_layout_ragged_a2a",
     "deepep_transport_identity",
@@ -667,6 +669,59 @@ def _compact_local_assignments_topk(
     group_sizes = jnp.bincount(expert_local, weights=valid_weight, length=local_experts).astype(jnp.int32)
     group_sizes = group_sizes.at[-1].add(local_capacity - jnp.sum(group_sizes, dtype=jnp.int32))
     return token_local, weight_dispatch, x_dispatch, group_sizes, dropped_local
+
+
+def _compact_local_assignments_topk_with_positions(
+    x_source: jax.Array,
+    local_expert: jax.Array,
+    local_mask: jax.Array,
+    weight_flat: jax.Array,
+    *,
+    local_experts: int,
+    local_capacity: int,
+    topk: int,
+    ep_size: int | None = None,
+    take_fn: Callable[[jax.Array, jax.Array], jax.Array] | None = None,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array, jax.Array]:
+    if take_fn is None:
+        take_fn = _take_with_gather
+    local_count = jnp.sum(local_mask, dtype=jnp.int32)
+    dropped_local = jnp.maximum(local_count - local_capacity, 0)
+    valid = jnp.arange(local_capacity, dtype=jnp.int32) < local_count
+    valid_weight = valid.astype(jnp.float32)
+
+    local_expert = jnp.where(local_mask, local_expert, 0)
+    assignments = int(local_expert.shape[0])
+    flat_pos = jnp.arange(assignments, dtype=jnp.int32)
+    order_key = local_expert * assignments + flat_pos
+    max_order_key = local_experts * assignments
+    selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
+    _, local_idx = jax.lax.top_k(selection_key, local_capacity)
+
+    token_local = jnp.floor_divide(local_idx, topk)
+    expert_local = jnp.take(local_expert, local_idx, axis=0)
+    weight_local = jnp.take(weight_flat, local_idx, axis=0).astype(x_source.dtype)
+    x_take = take_fn(x_source, token_local)
+    x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))
+    weight_dispatch = jnp.where(valid, weight_local, jnp.zeros_like(weight_local))
+    expert_local = jnp.where(valid, expert_local, 0)
+    group_sizes = jnp.bincount(expert_local, weights=valid_weight, length=local_experts).astype(jnp.int32)
+    group_sizes = group_sizes.at[-1].add(local_capacity - jnp.sum(group_sizes, dtype=jnp.int32))
+
+    inverse_size = assignments + 1
+    dummy_assignment = jnp.array(assignments, dtype=jnp.int32)
+    safe_assignment = jnp.where(valid, local_idx, dummy_assignment)
+    dispatch_rows = jnp.arange(local_capacity, dtype=jnp.int32)
+    dispatch_positions_flat = (
+        jnp.zeros((inverse_size,), dtype=jnp.int32).at[safe_assignment].set(dispatch_rows)[:assignments]
+    )
+    sonic_weights_flat = (
+        jnp.zeros((inverse_size,), dtype=x_source.dtype).at[safe_assignment].set(weight_dispatch)[:assignments]
+    )
+
+    dispatch_positions = dispatch_positions_flat.reshape((x_source.shape[0], topk))
+    sonic_weights = sonic_weights_flat.reshape((x_source.shape[0], topk))
+    return x_dispatch, group_sizes, dropped_local, dispatch_positions, sonic_weights
 
 
 def _compact_local_assignments_prefix_counts(
@@ -3616,6 +3671,84 @@ def _moe_mlp_ep_stream_ring_local(
     return out_local, dropped_total
 
 
+def _moe_mlp_ep_stream_ring_sonic_combine_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+
+    ep_size = num_experts // local_experts
+    expert_axis = jax.lax.axis_index("expert")
+    expert_start = expert_axis * local_experts
+
+    tokens_per_chunk = x_local.shape[0]
+    topk = selected_experts_local.shape[1]
+    assignments_per_chunk = tokens_per_chunk * topk
+    local_capacity = int(np.ceil(capacity_factor * assignments_per_chunk / ep_size))
+    local_capacity = max(local_experts, local_capacity)
+
+    next_perm = [(src, (src + 1) % ep_size) for src in range(ep_size)]
+
+    def ring_step(carry, _):
+        x_chunk, selected_chunk, weight_chunk, out_chunk, dropped_acc = carry
+
+        expert_flat = selected_chunk.reshape(assignments_per_chunk)
+        weight_flat = weight_chunk.reshape(assignments_per_chunk)
+        local_expert = expert_flat - expert_start
+        local_mask = jnp.logical_and(local_expert >= 0, local_expert < local_experts)
+
+        x_dispatch, group_sizes, dropped_local, dispatch_positions, sonic_weights = (
+            _compact_local_assignments_topk_with_positions(
+                x_chunk,
+                local_expert,
+                local_mask,
+                weight_flat,
+                local_experts=local_experts,
+                local_capacity=local_capacity,
+                topk=topk,
+            )
+        )
+
+        w13_out = ragged_dot(x_dispatch, moe_w13_local, group_sizes)
+        moe_dim = moe_w2_local.shape[1]
+        gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
+        out_dispatch = ragged_dot(activation_fn(gate) * up, moe_w2_local, group_sizes)
+        out_chunk = out_chunk + sonic_gather_sum(out_dispatch, dispatch_positions, sonic_weights).astype(
+            out_chunk.dtype
+        )
+
+        return (
+            jax.lax.ppermute(x_chunk, "expert", next_perm),
+            jax.lax.ppermute(selected_chunk, "expert", next_perm),
+            jax.lax.ppermute(weight_chunk, "expert", next_perm),
+            jax.lax.ppermute(out_chunk, "expert", next_perm),
+            dropped_acc + dropped_local,
+        ), None
+
+    init_carry = (
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        jnp.zeros_like(x_local),
+        jnp.array(0, dtype=jnp.int32),
+    )
+    final_carry, _ = jax.lax.scan(ring_step, init_carry, xs=None, length=ep_size)
+    _, _, _, out_local, dropped_local_total = final_carry
+    dropped_total = jax.lax.psum(dropped_local_total, ("data", "expert"))
+    return out_local, dropped_total
+
+
 def _moe_mlp_stream_ring(
     x: jax.Array,
     selected_experts: jax.Array,
@@ -3653,6 +3786,82 @@ def _moe_mlp_stream_ring(
         shard_fn = shard_map(
             partial(
                 _moe_mlp_ep_stream_ring_local,
+                activation_fn=activation_fn,
+                num_experts=num_experts,
+                capacity_factor=capacity_factor,
+            ),
+            mesh=mesh,
+            in_specs=(
+                batch_spec,
+                batch_spec,
+                batch_spec,
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(batch_spec, P()),
+            check_vma=False,
+        )
+        out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        return out
+
+    shard_fn = shard_map(
+        partial(
+            grug_moe_lib._moe_mlp_local,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        ),
+        mesh=mesh,
+        in_specs=(
+            batch_spec,
+            batch_spec,
+            batch_spec,
+            local_expert_spec,
+            local_expert_spec,
+        ),
+        out_specs=(batch_spec, P()),
+        check_vma=False,
+    )
+    out, _ = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+    return out
+
+
+def _moe_mlp_stream_ring_sonic_combine(
+    x: jax.Array,
+    selected_experts: jax.Array,
+    combine_weights: jax.Array,
+    w_up_gate: jax.Array,
+    w_down: jax.Array,
+    *,
+    mesh: jax.sharding.AbstractMesh | None = None,
+    capacity_factor: float = grug_moe_lib._DEFAULT_EP_CAPACITY_FACTOR,
+) -> jax.Array:
+    if mesh is None:
+        mesh = get_abstract_mesh()
+
+    activation_fn = ActivationFunctionEnum.silu.to_jax_fn()
+    num_experts = int(w_up_gate.shape[0])
+    has_expert_axis = grug_moe_lib._mesh_has_axis(mesh, "expert")
+    expert_axis_size = grug_moe_lib._mesh_axis_size(mesh, "expert")
+
+    if mesh is None or mesh.empty:
+        out, _ = grug_moe_lib._moe_mlp_local(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+            activation_fn=activation_fn,
+            num_experts=num_experts,
+        )
+        return out
+
+    batch_spec = grug_moe_lib._batch_spec_from_x(x, mesh)
+    local_expert_spec = P("expert", None, None) if has_expert_axis else P(None, None, None)
+
+    if has_expert_axis and expert_axis_size > 1:
+        shard_fn = shard_map(
+            partial(
+                _moe_mlp_ep_stream_ring_sonic_combine_local,
                 activation_fn=activation_fn,
                 num_experts=num_experts,
                 capacity_factor=capacity_factor,
@@ -3855,6 +4064,14 @@ def _forward(
         )
     elif kernel == "stream_ring":
         routed = _moe_mlp_stream_ring(
+            x,
+            selected_experts,
+            combine_weights,
+            w_up_gate,
+            w_down,
+        )
+    elif kernel == "stream_ring_sonic_combine":
+        routed = _moe_mlp_stream_ring_sonic_combine(
             x,
             selected_experts,
             combine_weights,
@@ -4401,6 +4618,7 @@ def main() -> None:
             "cumsum",
             "packed_return",
             "stream_ring",
+            "stream_ring_sonic_combine",
             "ragged_a2a",
             "deepep_layout_ragged_a2a",
             "deepep_transport_identity",

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -23,11 +23,12 @@ MoeActivation: TypeAlias = ActivationFunctionEnum | Callable[[jax.Array], jax.Ar
 MoeImplementation: TypeAlias = Literal[
     "ring",  # Expert-parallel all-gather + psum-scatter backend.
     "ragged_all_to_all",  # Expert-parallel ragged all-to-all backend.
+    "deepep",  # Expert-parallel DeepEP intranode dispatch/combine backend.
     "scatter",  # Single-process grouped GMM with scatter-add combine.
     "sonic",  # Single-process raw Sonic Triton gather/combine backend.
 ]
 _VALID_MOE_IMPLEMENTATIONS = get_args(MoeImplementation)
-_EP_MOE_IMPLEMENTATIONS = ("ring", "ragged_all_to_all")
+_EP_MOE_IMPLEMENTATIONS = ("ring", "ragged_all_to_all", "deepep")
 # Local means no collectives over an expert axis. These backends can still run
 # under ordinary data/model sharding through the no-EP shard_map path.
 _LOCAL_MOE_IMPLEMENTATIONS = (

--- a/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
@@ -1,0 +1,173 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepEP intranode expert-parallel Grug MoE backend."""
+
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+from haliax.jax_utils import tree_checkpoint_name
+from haliax.nn.ragged_dot import ragged_dot
+
+from levanter.grug._moe.common import (
+    _CHECKPOINT_DISPATCH_INPUT,
+    _CHECKPOINT_DISPATCH_OUTPUT,
+    _CHECKPOINT_EXPERT_HIDDEN,
+    split_moe_w13_output,
+)
+from levanter.kernels.deepep import deepep_combine_intranode, deepep_dispatch_intranode, deepep_get_dispatch_layout
+
+
+def _pack_deepep_local_assignments(
+    recv_x: jax.Array,
+    recv_topk_idx: jax.Array,
+    recv_topk_weights: jax.Array,
+    *,
+    expert_start: jax.Array,
+    local_experts: int,
+    num_recv_tokens: jax.Array,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    max_recv_tokens, topk = recv_topk_idx.shape
+    total_assignments = max_recv_tokens * topk
+
+    recv_token_indices = jnp.repeat(jnp.arange(max_recv_tokens, dtype=jnp.int32), topk)
+    expert_flat = (recv_topk_idx.reshape(-1) - expert_start).astype(jnp.int32)
+    recv_valid = jnp.arange(max_recv_tokens, dtype=jnp.int32) < num_recv_tokens
+    local_mask = recv_valid[:, None] & (recv_topk_idx >= expert_start) & (recv_topk_idx < expert_start + local_experts)
+    local_mask_flat = local_mask.reshape(-1)
+    local_bucket = jnp.where(local_mask_flat, expert_flat, local_experts)
+    local_group_sizes = jnp.bincount(local_bucket, length=local_experts + 1).astype(jnp.int32)[:-1]
+    total_valid = jnp.sum(local_group_sizes, dtype=jnp.int32)
+
+    flat_positions = jnp.arange(total_assignments, dtype=jnp.int32)
+    order_key = local_bucket * total_assignments + flat_positions
+    max_order_key = (local_experts + 1) * total_assignments
+    selection_key = jnp.where(local_mask_flat, max_order_key - order_key, -1)
+    _, sorted_assignment_indices = jax.lax.top_k(selection_key, total_assignments)
+
+    recv_token_indices = jnp.take(recv_token_indices, sorted_assignment_indices, axis=0)
+    x_dispatch = jnp.take(recv_x, recv_token_indices, axis=0)
+    assignment_weights = jnp.take(recv_topk_weights.reshape(-1), sorted_assignment_indices, axis=0).astype(
+        recv_x.dtype
+    )
+    valid_sorted = jnp.arange(total_assignments, dtype=jnp.int32) < total_valid
+    x_dispatch = jnp.where(valid_sorted[:, None], x_dispatch, 0)
+    assignment_weights = jnp.where(valid_sorted, assignment_weights, 0)
+    return x_dispatch, assignment_weights, recv_token_indices, local_group_sizes
+
+
+def _collapse_deepep_local_assignments(
+    out_dispatch: jax.Array,
+    assignment_weights: jax.Array,
+    recv_token_indices: jax.Array,
+    *,
+    recv_capacity: int,
+    num_recv_tokens: jax.Array,
+) -> jax.Array:
+    recv_out = jax.ops.segment_sum(
+        out_dispatch * assignment_weights[:, None],
+        recv_token_indices,
+        num_segments=recv_capacity,
+        indices_are_sorted=False,
+    )
+    recv_valid = jnp.arange(recv_capacity, dtype=jnp.int32) < num_recv_tokens
+    return jnp.where(recv_valid[:, None], recv_out, 0)
+
+
+def _moe_mlp_ep_deepep_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
+    moe_w13_local: jax.Array,
+    moe_w2_local: jax.Array,
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+) -> tuple[jax.Array, jax.Array]:
+    """DeepEP dispatch/combine path for an intranode expert mesh."""
+    del capacity_factor
+    local_experts = moe_w13_local.shape[0]
+    if num_experts % local_experts != 0:
+        raise ValueError(
+            f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
+        )
+    if x_local.shape[1] % 8 != 0:
+        raise ValueError(f"DeepEP transport requires hidden % 8 == 0, got hidden={x_local.shape[1]}")
+
+    shard_id = jax.lax.axis_index("expert")
+    ep_size = num_experts // local_experts
+    expert_start = shard_id * local_experts
+    max_recv_tokens = x_local.shape[0] * ep_size
+
+    with jax.named_scope("dispatch"):
+        num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
+            selected_experts_local,
+            num_ranks=ep_size,
+            num_experts=num_experts,
+        )
+        (
+            recv_x,
+            recv_topk_idx,
+            recv_topk_weights,
+            recv_src_idx,
+            rank_prefix_matrix,
+            channel_prefix_matrix,
+            recv_channel_prefix_matrix,
+            send_head,
+            _local_expert_counts,
+            num_recv_tokens,
+        ) = deepep_dispatch_intranode(
+            x_local,
+            selected_experts_local,
+            combine_weights_local,
+            num_tokens_per_rank,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            num_experts=num_experts,
+            max_recv_tokens=max_recv_tokens,
+        )
+        num_recv_tokens_scalar = jnp.squeeze(num_recv_tokens, axis=0)
+        x_dispatch, assignment_weights, recv_token_indices, local_group_sizes = _pack_deepep_local_assignments(
+            recv_x,
+            recv_topk_idx,
+            recv_topk_weights,
+            expert_start=expert_start,
+            local_experts=local_experts,
+            num_recv_tokens=num_recv_tokens_scalar,
+        )
+        x_dispatch = tree_checkpoint_name(x_dispatch, _CHECKPOINT_DISPATCH_INPUT)
+
+    with jax.named_scope("moe_up_down"):
+        w13_out = tree_checkpoint_name(
+            ragged_dot(x_dispatch, moe_w13_local, local_group_sizes), _CHECKPOINT_EXPERT_HIDDEN
+        )
+        moe_dim = moe_w2_local.shape[1]
+        gate, up = split_moe_w13_output(w13_out, intermediate_dim=moe_dim, interleaved=False)
+        out_dispatch = tree_checkpoint_name(
+            ragged_dot(activation_fn(gate) * up, moe_w2_local, local_group_sizes),
+            _CHECKPOINT_DISPATCH_OUTPUT,
+        )
+
+    with jax.named_scope("combine"):
+        recv_out = _collapse_deepep_local_assignments(
+            out_dispatch,
+            assignment_weights,
+            recv_token_indices,
+            recv_capacity=recv_x.shape[0],
+            num_recv_tokens=num_recv_tokens_scalar,
+        )
+        out_local, _ = deepep_combine_intranode(
+            recv_out,
+            recv_topk_weights,
+            recv_src_idx,
+            rank_prefix_matrix,
+            channel_prefix_matrix,
+            recv_channel_prefix_matrix,
+            send_head,
+            num_recv_tokens,
+            is_token_in_rank,
+        )
+        dropped_total = jnp.array(0, dtype=jnp.int32)
+    return out_local.astype(x_local.dtype), dropped_total

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -42,6 +42,7 @@ from levanter.grug._moe.ep_common import (
     _expand_from_keep_mask as _expand_from_keep_mask,
     _shard_a2a_params as _shard_a2a_params,
 )
+from levanter.grug._moe.ep_deepep import _moe_mlp_ep_deepep_local
 from levanter.grug._moe.ep_ragged_all_to_all import _moe_mlp_ep_ragged_a2a_local
 from levanter.grug._moe.ep_ring import _moe_mlp_ep_ring_local
 from levanter.grug._moe.local import _moe_mlp_local
@@ -208,6 +209,8 @@ def moe_mlp(
             shard_local_fn = _moe_mlp_ep_ring_local
         elif resolved_implementation == "ragged_all_to_all":
             shard_local_fn = _moe_mlp_ep_ragged_a2a_local
+        elif resolved_implementation == "deepep":
+            shard_local_fn = _moe_mlp_ep_deepep_local
         else:
             raise AssertionError(f"Unhandled MoE implementation {resolved_implementation!r}")
 

--- a/lib/levanter/src/levanter/kernels/deepep/__init__.py
+++ b/lib/levanter/src/levanter/kernels/deepep/__init__.py
@@ -1,0 +1,22 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepEP-backed JAX kernel helpers."""
+
+from .layout_ffi import deepep_get_dispatch_layout
+from .transport_ffi import (
+    deepep_combine_intranode,
+    deepep_dispatch_intranode,
+    ensure_intranode_runtime,
+    run_host_dispatch_round,
+    shutdown_intranode_runtime,
+)
+
+__all__ = [
+    "deepep_combine_intranode",
+    "deepep_dispatch_intranode",
+    "deepep_get_dispatch_layout",
+    "ensure_intranode_runtime",
+    "run_host_dispatch_round",
+    "shutdown_intranode_runtime",
+]

--- a/lib/levanter/src/levanter/kernels/deepep/__init__.py
+++ b/lib/levanter/src/levanter/kernels/deepep/__init__.py
@@ -3,6 +3,7 @@
 
 """DeepEP-backed JAX kernel helpers."""
 
+from .availability import deepep_install_help, deepep_preflight_status
 from .layout_ffi import deepep_get_dispatch_layout
 from .transport_ffi import (
     deepep_combine_intranode,
@@ -16,6 +17,8 @@ __all__ = [
     "deepep_combine_intranode",
     "deepep_dispatch_intranode",
     "deepep_get_dispatch_layout",
+    "deepep_install_help",
+    "deepep_preflight_status",
     "ensure_intranode_runtime",
     "run_host_dispatch_round",
     "shutdown_intranode_runtime",

--- a/lib/levanter/src/levanter/kernels/deepep/availability.py
+++ b/lib/levanter/src/levanter/kernels/deepep/availability.py
@@ -1,0 +1,166 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""DeepEP source-tree and build-environment helpers."""
+
+from __future__ import annotations
+
+import os
+import shutil
+from dataclasses import dataclass
+from pathlib import Path
+
+DEEPEP_SRC_ENV = "DEEPEP_SRC_ROOT"
+DEEPEP_CACHE_ENV = "MARIN_DEEPEP_CACHE_DIR"
+DEEPEP_CUDA_ARCH_ENV = "DEEPEP_CUDA_ARCH"
+DISABLE_SM90_ENV = "DISABLE_SM90_FEATURES"
+BUILD_WITH_TORCH_EXTENSION_ENV = "DEEPEP_BUILD_WITH_TORCH_EXTENSION"
+LOAD_AS_PYTHON_MODULE_ENV = "DEEPEP_LOAD_AS_PYTHON_MODULE"
+
+LAYOUT_REQUIRED_FILES = ("csrc/kernels/layout.cu",)
+TRANSPORT_REQUIRED_FILES = (
+    "csrc/config.hpp",
+    "csrc/kernels/api.cuh",
+    "csrc/kernels/configs.cuh",
+    "csrc/kernels/layout.cu",
+    "csrc/kernels/runtime.cu",
+    "csrc/kernels/intranode.cu",
+)
+
+_SUPPORTED_ARCHES = ("sm_90", "sm_90a", "sm_100")
+
+
+@dataclass(frozen=True)
+class DeepEPPreflightStatus:
+    """Result of a cheap DeepEP environment check."""
+
+    source_root: Path | None
+    cache_root: Path
+    cuda_arch: str
+    nvcc_path: str | None
+    missing_source_files: tuple[Path, ...]
+    errors: tuple[str, ...]
+    warnings: tuple[str, ...]
+
+    @property
+    def ok(self) -> bool:
+        return not self.errors
+
+
+def deepep_install_help() -> str:
+    return (
+        "DeepEP support expects an external DeepEP source checkout. Set "
+        f"{DEEPEP_SRC_ENV}=/path/to/DeepEP and, on B200/GB200, set {DEEPEP_CUDA_ARCH_ENV}=sm_100. "
+        f"Compiled JAX FFI objects are cached under {DEEPEP_CACHE_ENV} when set, otherwise under "
+        "~/.cache/marin."
+    )
+
+
+def deepep_cache_root(component: str) -> Path:
+    base = Path(os.environ.get(DEEPEP_CACHE_ENV, Path.home() / ".cache" / "marin")).expanduser()
+    return base.resolve() / component
+
+
+def deepep_cuda_arch() -> str:
+    arch = os.environ.get(DEEPEP_CUDA_ARCH_ENV, "sm_90").strip()
+    if arch not in _SUPPORTED_ARCHES:
+        supported = ", ".join(_SUPPORTED_ARCHES)
+        raise RuntimeError(f"{DEEPEP_CUDA_ARCH_ENV} must be one of {supported}, got {arch!r}")
+    return arch
+
+
+def deepep_cuda_arch_flag() -> list[str]:
+    arch = deepep_cuda_arch()
+    compute = arch.replace("sm_", "compute_", 1)
+    return [f"-gencode=arch={compute},code={arch}"]
+
+
+def deepep_torch_cuda_arch_list() -> str:
+    if env_flag(DISABLE_SM90_ENV):
+        return "8.0"
+    arch = deepep_cuda_arch()
+    if arch == "sm_90":
+        return "9.0"
+    if arch == "sm_90a":
+        return "9.0a"
+    if arch == "sm_100":
+        return "10.0"
+    raise AssertionError(f"Unhandled DeepEP CUDA architecture {arch!r}")
+
+
+def env_flag(name: str) -> bool:
+    return bool(int(os.environ.get(name, "0")))
+
+
+def missing_deepep_source_files(root: Path, required_files: tuple[str, ...]) -> tuple[Path, ...]:
+    return tuple(root / relative for relative in required_files if not (root / relative).is_file())
+
+
+def deepep_source_root(
+    *,
+    required_files: tuple[str, ...],
+    purpose: str,
+) -> Path:
+    raw = os.environ.get(DEEPEP_SRC_ENV)
+    if not raw:
+        raise RuntimeError(f"{DEEPEP_SRC_ENV} must point at a DeepEP checkout before using {purpose}.")
+    root = Path(raw).expanduser().resolve()
+    missing = missing_deepep_source_files(root, required_files)
+    if missing:
+        missing_text = ", ".join(str(path.relative_to(root)) for path in missing)
+        raise RuntimeError(f"{DEEPEP_SRC_ENV}={root} is missing DeepEP files required for {purpose}: {missing_text}")
+    return root
+
+
+def deepep_preflight_status(
+    *,
+    required_files: tuple[str, ...] = TRANSPORT_REQUIRED_FILES,
+    component: str = "deepep_transport_ffi",
+) -> DeepEPPreflightStatus:
+    errors: list[str] = []
+    warnings: list[str] = []
+    root: Path | None = None
+    missing: tuple[Path, ...] = ()
+
+    raw_root = os.environ.get(DEEPEP_SRC_ENV)
+    if raw_root:
+        root = Path(raw_root).expanduser().resolve()
+        missing = missing_deepep_source_files(root, required_files)
+        if missing:
+            relative_missing = []
+            for path in missing:
+                try:
+                    relative_missing.append(str(path.relative_to(root)))
+                except ValueError:
+                    relative_missing.append(str(path))
+            errors.append(f"{DEEPEP_SRC_ENV} is missing required files: {', '.join(relative_missing)}")
+    else:
+        errors.append(f"{DEEPEP_SRC_ENV} is not set")
+
+    try:
+        arch = deepep_cuda_arch()
+    except RuntimeError as exc:
+        arch = os.environ.get(DEEPEP_CUDA_ARCH_ENV, "sm_90").strip()
+        errors.append(str(exc))
+
+    nvcc_path = shutil.which("nvcc")
+    if nvcc_path is None:
+        errors.append("nvcc is not on PATH")
+
+    if env_flag(BUILD_WITH_TORCH_EXTENSION_ENV) and env_flag(LOAD_AS_PYTHON_MODULE_ENV):
+        errors.append(
+            f"{BUILD_WITH_TORCH_EXTENSION_ENV}=1 is not supported together with {LOAD_AS_PYTHON_MODULE_ENV}=1"
+        )
+
+    if arch != "sm_100":
+        warnings.append(f"{DEEPEP_CUDA_ARCH_ENV}={arch}; use sm_100 for B200/GB200.")
+
+    return DeepEPPreflightStatus(
+        source_root=root,
+        cache_root=deepep_cache_root(component),
+        cuda_arch=arch,
+        nvcc_path=nvcc_path,
+        missing_source_files=missing,
+        errors=tuple(errors),
+        warnings=tuple(warnings),
+    )

--- a/lib/levanter/src/levanter/kernels/deepep/csrc/deepep_layout_ffi.cu
+++ b/lib/levanter/src/levanter/kernels/deepep/csrc/deepep_layout_ffi.cu
@@ -1,0 +1,83 @@
+// Copyright The Levanter Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <cstdint>
+#include <limits>
+#include <string>
+
+#include <cuda_runtime_api.h>
+
+#include "xla/ffi/api/ffi.h"
+
+#include "kernels/api.cuh"
+
+namespace ffi = xla::ffi;
+
+namespace {
+
+ffi::Error DeepepGetDispatchLayout(
+    cudaStream_t stream,
+    ffi::Buffer<ffi::S64, 2> topk_idx,
+    ffi::Result<ffi::Buffer<ffi::S32, 1>> num_tokens_per_rank,
+    ffi::Result<ffi::Buffer<ffi::S32, 1>> num_tokens_per_expert,
+    ffi::Result<ffi::Buffer<ffi::PRED, 2>> is_token_in_rank) {
+  const auto topk_dims = topk_idx.dimensions();
+  const auto rank_dims = num_tokens_per_rank->dimensions();
+  const auto expert_dims = num_tokens_per_expert->dimensions();
+  const auto token_rank_dims = is_token_in_rank->dimensions();
+
+  if (topk_dims.size() != 2) {
+    return ffi::Error::InvalidArgument("topk_idx must be rank-2");
+  }
+  if (rank_dims.size() != 1 || expert_dims.size() != 1) {
+    return ffi::Error::InvalidArgument("DeepEP layout outputs have unexpected ranks");
+  }
+  if (token_rank_dims.size() != 2) {
+    return ffi::Error::InvalidArgument("is_token_in_rank must be rank-2");
+  }
+
+  const int64_t num_tokens = topk_dims[0];
+  const int64_t num_topk = topk_dims[1];
+  const int64_t num_ranks = rank_dims[0];
+  const int64_t num_experts = expert_dims[0];
+
+  if (token_rank_dims[0] != num_tokens || token_rank_dims[1] != num_ranks) {
+    return ffi::Error::InvalidArgument("is_token_in_rank shape must be [tokens, num_ranks]");
+  }
+  if (num_tokens > static_cast<int64_t>(std::numeric_limits<int>::max()) ||
+      num_topk > static_cast<int64_t>(std::numeric_limits<int>::max()) ||
+      num_ranks > static_cast<int64_t>(std::numeric_limits<int>::max()) ||
+      num_experts > static_cast<int64_t>(std::numeric_limits<int>::max())) {
+    return ffi::Error::InvalidArgument("DeepEP layout dimensions exceed int32 kernel limits");
+  }
+
+  deep_ep::layout::get_dispatch_layout(
+      topk_idx.typed_data(),
+      num_tokens_per_rank->typed_data(),
+      nullptr,
+      num_tokens_per_expert->typed_data(),
+      is_token_in_rank->typed_data(),
+      static_cast<int>(num_tokens),
+      static_cast<int>(num_topk),
+      static_cast<int>(num_ranks),
+      static_cast<int>(num_experts),
+      stream);
+  return ffi::Error::Success();
+}
+
+auto DeepepGetDispatchLayoutBinding() {
+  return ffi::Ffi::Bind()
+      .Ctx<ffi::PlatformStream<cudaStream_t>>()
+      .Arg<ffi::Buffer<ffi::S64, 2>>()
+      .Ret<ffi::Buffer<ffi::S32, 1>>()
+      .Ret<ffi::Buffer<ffi::S32, 1>>()
+      .Ret<ffi::Buffer<ffi::PRED, 2>>();
+}
+
+}  // namespace
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    levanter_deepep_get_dispatch_layout,
+    DeepepGetDispatchLayout,
+    DeepepGetDispatchLayoutBinding(),
+    {ffi::Traits::kCmdBufferCompatible});

--- a/lib/levanter/src/levanter/kernels/deepep/csrc/deepep_transport_ffi.cu
+++ b/lib/levanter/src/levanter/kernels/deepep/csrc/deepep_transport_ffi.cu
@@ -1,0 +1,1454 @@
+// Copyright The Levanter Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <algorithm>
+#include <chrono>
+#include <condition_variable>
+#include <cstdint>
+#include <cstring>
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <stdexcept>
+#include <cstdlib>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include <cuda_runtime_api.h>
+
+#include "config.hpp"
+#include "kernels/api.cuh"
+#include "xla/ffi/api/ffi.h"
+
+namespace ffi = xla::ffi;
+
+namespace {
+
+constexpr int kMaxPeers = NUM_MAX_NVL_PEERS;
+constexpr int kCounterTimeoutSeconds = NUM_CPU_TIMEOUT_SECS;
+constexpr int kProbeDispatchTokens = 4096;
+constexpr int kProbeDispatchHidden = 2048;
+constexpr int kProbeDispatchTopK = 2;
+constexpr int kProbeDispatchExperts = 128;
+
+struct DispatchConfig {
+  int num_sms;
+  int num_max_send_tokens;
+  int num_max_recv_tokens;
+
+  bool operator==(const DispatchConfig& other) const {
+    return num_sms == other.num_sms && num_max_send_tokens == other.num_max_send_tokens &&
+           num_max_recv_tokens == other.num_max_recv_tokens;
+  }
+};
+
+struct DeviceRuntime {
+  int rank = -1;
+  int num_ranks = 0;
+  int device_id = -1;
+  int64_t num_nvl_bytes = 0;
+  bool peer_synced = false;
+  DispatchConfig dispatch_config{};
+  DispatchConfig combine_config{};
+
+  void* local_buffer = nullptr;
+  void* buffer_ptrs[kMaxPeers] = {nullptr};
+  void** buffer_ptrs_gpu = nullptr;
+  int* barrier_signal_ptrs[kMaxPeers] = {nullptr};
+  int** barrier_signal_ptrs_gpu = nullptr;
+  int* recv_channel_offset_scratch = nullptr;
+
+  volatile int* moe_recv_counter = nullptr;
+  int* moe_recv_counter_mapped = nullptr;
+  volatile int* moe_recv_expert_counter = nullptr;
+  int* moe_recv_expert_counter_mapped = nullptr;
+  int last_num_recv_tokens = -1;
+
+  cudaStream_t aux_stream = nullptr;
+
+  int dispatch_num_channels() const { return dispatch_config.num_sms / 2; }
+  int combine_num_channels() const { return combine_config.num_sms / 2; }
+};
+
+class ThreadBarrier {
+ public:
+  explicit ThreadBarrier(int count) : count_(count), remaining_(count), generation_(0) {}
+
+  void Wait() {
+    std::unique_lock<std::mutex> lock(mu_);
+    const int generation = generation_;
+    remaining_ -= 1;
+    if (remaining_ == 0) {
+      generation_ += 1;
+      remaining_ = count_;
+      cv_.notify_all();
+      return;
+    }
+    cv_.wait(lock, [&] { return generation_ != generation; });
+  }
+
+ private:
+  const int count_;
+  int remaining_;
+  int generation_;
+  std::mutex mu_;
+  std::condition_variable cv_;
+};
+
+std::string& LastErrorStorage() {
+  static std::string error;
+  return error;
+}
+
+void SetLastError(std::string message) { LastErrorStorage() = std::move(message); }
+
+bool HostDispatchDebugEnabled() {
+  static const bool enabled = []() {
+    const char* value = std::getenv("LEVANTER_DEEPEP_HOST_DISPATCH_DEBUG");
+    return value != nullptr && value[0] != '\0' && value[0] != '0';
+  }();
+  return enabled;
+}
+
+void LogHostDispatchStage(
+    int rank,
+    const char* stage,
+    int num_tokens,
+    int hidden,
+    int num_experts,
+    int num_topk,
+    int num_recv_tokens = -1) {
+  if (!HostDispatchDebugEnabled()) {
+    return;
+  }
+  fprintf(
+      stderr,
+      "HOST_DISPATCH_STAGE {\"rank\":%d,\"stage\":\"%s\",\"num_tokens\":%d,\"hidden\":%d,"
+      "\"num_experts\":%d,\"num_topk\":%d,\"num_recv_tokens\":%d}\n",
+      rank,
+      stage,
+      num_tokens,
+      hidden,
+      num_experts,
+      num_topk,
+      num_recv_tokens);
+}
+
+ffi::Error CudaError(cudaError_t status, const char* context) {
+  if (status == cudaSuccess) {
+    return ffi::Error::Success();
+  }
+  return ffi::Error::Internal(std::string(context) + ": " + cudaGetErrorString(status));
+}
+
+void ThrowOnCuda(cudaError_t status, const char* context) {
+  if (status != cudaSuccess) {
+    throw std::runtime_error(std::string(context) + ": " + cudaGetErrorString(status));
+  }
+}
+
+void EnablePeerAccess(int peer_device_id) {
+  cudaError_t status = cudaDeviceEnablePeerAccess(peer_device_id, 0);
+  if (status == cudaSuccess) {
+    return;
+  }
+  if (status == cudaErrorPeerAccessAlreadyEnabled) {
+    // cudaDeviceEnablePeerAccess leaves the runtime last-error state set even when
+    // peer access is already enabled. Clear it so later JAX/XLA CUDA calls do not
+    // fail before their own work starts.
+    (void)cudaGetLastError();
+    return;
+  }
+  throw std::runtime_error(std::string("cudaDeviceEnablePeerAccess: ") + cudaGetErrorString(status));
+}
+
+size_t Align128(size_t value) {
+  return ((value + NUM_BUFFER_ALIGNMENT_BYTES - 1) / NUM_BUFFER_ALIGNMENT_BYTES) * NUM_BUFFER_ALIGNMENT_BYTES;
+}
+
+size_t GetNvlBufferSizeHint(const DispatchConfig& config, int64_t hidden_bytes, int num_ranks) {
+  constexpr int kNumMaxTopK = 128;
+  constexpr int kNumMaxScales = 128;
+  const int num_rdma_ranks = std::max(num_ranks / NUM_MAX_NVL_PEERS, 1);
+  const int num_nvl_ranks = std::min(num_ranks, NUM_MAX_NVL_PEERS);
+  const int num_channels = config.num_sms / 2;
+
+  size_t num_bytes = 0;
+  num_bytes += static_cast<size_t>(num_channels) * num_nvl_ranks * (2 * num_rdma_ranks + 3) * sizeof(int);
+  num_bytes += static_cast<size_t>(num_channels) * num_nvl_ranks * config.num_max_recv_tokens * hidden_bytes;
+  num_bytes += static_cast<size_t>(num_channels) * num_nvl_ranks * config.num_max_recv_tokens * kNumMaxTopK * sizeof(int64_t);
+  num_bytes += static_cast<size_t>(num_channels) * num_nvl_ranks * config.num_max_recv_tokens * kNumMaxTopK * sizeof(float);
+  num_bytes += static_cast<size_t>(num_channels) * num_nvl_ranks * config.num_max_recv_tokens * kNumMaxScales * sizeof(float);
+  return Align128(num_bytes);
+}
+
+class RuntimeManager {
+ public:
+  static RuntimeManager& Instance() {
+    static RuntimeManager manager;
+    return manager;
+  }
+
+  void Init(
+      int num_ranks,
+      int64_t hidden_bytes,
+      DispatchConfig dispatch_config,
+      DispatchConfig combine_config) {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (initialized_ && num_ranks_ == num_ranks && hidden_bytes_ == hidden_bytes &&
+        dispatch_config_ == dispatch_config && combine_config_ == combine_config) {
+      return;
+    }
+    DestroyLocked();
+
+    if (num_ranks <= 0 || num_ranks > kMaxPeers) {
+      throw std::runtime_error("DeepEP intranode JAX runtime only supports 1..8 ranks");
+    }
+    if (dispatch_config.num_sms % 2 != 0 || combine_config.num_sms % 2 != 0) {
+      throw std::runtime_error("DeepEP intranode configs must use an even SM count");
+    }
+    int device_count = 0;
+    ThrowOnCuda(cudaGetDeviceCount(&device_count), "cudaGetDeviceCount");
+    if (device_count != num_ranks) {
+      throw std::runtime_error(
+          "DeepEP intranode JAX runtime currently requires the expert group to span all visible local GPUs");
+    }
+
+    num_ranks_ = num_ranks;
+    hidden_bytes_ = hidden_bytes;
+    dispatch_config_ = dispatch_config;
+    combine_config_ = combine_config;
+    num_nvl_bytes_ = static_cast<int64_t>(std::max(
+        GetNvlBufferSizeHint(dispatch_config, hidden_bytes, num_ranks),
+        GetNvlBufferSizeHint(combine_config, hidden_bytes, num_ranks)));
+    runtimes_.resize(num_ranks);
+
+    int original_device = 0;
+    ThrowOnCuda(cudaGetDevice(&original_device), "cudaGetDevice");
+    try {
+      for (int rank = 0; rank < num_ranks; ++rank) {
+        ThrowOnCuda(cudaSetDevice(rank), "cudaSetDevice(init)");
+        runtimes_[rank] = std::make_unique<DeviceRuntime>();
+        InitLocalRuntime(*runtimes_[rank], rank);
+      }
+      for (int rank = 0; rank < num_ranks; ++rank) {
+        ThrowOnCuda(cudaSetDevice(rank), "cudaSetDevice(sync)");
+        SyncLocalRuntime(*runtimes_[rank]);
+      }
+    } catch (...) {
+      ThrowOnCuda(cudaSetDevice(original_device), "cudaSetDevice(restore-after-init-failure)");
+      DestroyLocked();
+      throw;
+    }
+    ThrowOnCuda(cudaSetDevice(original_device), "cudaSetDevice(restore)");
+    initialized_ = true;
+  }
+
+  void Shutdown() {
+    std::lock_guard<std::mutex> lock(mu_);
+    DestroyLocked();
+  }
+
+  DeviceRuntime& RuntimeForCurrentDevice() {
+    std::lock_guard<std::mutex> lock(mu_);
+    if (!initialized_) {
+      throw std::runtime_error("DeepEP intranode JAX runtime is not initialized");
+    }
+    int device_id = 0;
+    ThrowOnCuda(cudaGetDevice(&device_id), "cudaGetDevice(current)");
+    for (auto& runtime : runtimes_) {
+      if (runtime != nullptr && runtime->device_id == device_id) {
+        return *runtime;
+      }
+    }
+    throw std::runtime_error("No DeepEP intranode JAX runtime found for the current CUDA device");
+  }
+
+ private:
+  RuntimeManager() = default;
+
+  void InitLocalRuntime(DeviceRuntime& runtime, int rank) {
+    runtime.rank = rank;
+    runtime.num_ranks = num_ranks_;
+    runtime.device_id = rank;
+    runtime.num_nvl_bytes = num_nvl_bytes_;
+    runtime.dispatch_config = dispatch_config_;
+    runtime.combine_config = combine_config_;
+
+    const size_t barrier_signal_bytes = kMaxPeers * sizeof(int);
+    const size_t buffer_ptr_bytes = kMaxPeers * sizeof(void*);
+    const size_t barrier_signal_ptr_bytes = kMaxPeers * sizeof(int*);
+    ThrowOnCuda(
+        cudaMalloc(
+            &runtime.local_buffer,
+            runtime.num_nvl_bytes + barrier_signal_bytes + buffer_ptr_bytes + barrier_signal_ptr_bytes),
+        "cudaMalloc(local_buffer)");
+    runtime.buffer_ptrs[rank] = runtime.local_buffer;
+    runtime.buffer_ptrs_gpu = reinterpret_cast<void**>(
+        static_cast<uint8_t*>(runtime.local_buffer) + runtime.num_nvl_bytes + barrier_signal_bytes);
+    runtime.barrier_signal_ptrs[rank] =
+        reinterpret_cast<int*>(static_cast<uint8_t*>(runtime.local_buffer) + runtime.num_nvl_bytes);
+    runtime.barrier_signal_ptrs_gpu = reinterpret_cast<int**>(
+        static_cast<uint8_t*>(runtime.local_buffer) + runtime.num_nvl_bytes + barrier_signal_bytes + buffer_ptr_bytes);
+    ThrowOnCuda(cudaMemset(runtime.barrier_signal_ptrs[rank], 0, barrier_signal_bytes), "cudaMemset(barrier_signal)");
+
+    ThrowOnCuda(
+        cudaMalloc(
+            &runtime.recv_channel_offset_scratch,
+            runtime.dispatch_num_channels() * runtime.num_ranks * sizeof(int)),
+        "cudaMalloc(recv_channel_offset_scratch)");
+
+    void* recv_counter = nullptr;
+    ThrowOnCuda(cudaMallocHost(&recv_counter, sizeof(int), cudaHostAllocMapped), "cudaMallocHost(moe_recv_counter)");
+    runtime.moe_recv_counter = reinterpret_cast<volatile int*>(recv_counter);
+    int* recv_counter_host = const_cast<int*>(runtime.moe_recv_counter);
+    ThrowOnCuda(
+        cudaHostGetDevicePointer(
+            reinterpret_cast<void**>(&runtime.moe_recv_counter_mapped),
+            recv_counter_host,
+            0),
+        "cudaHostGetDevicePointer(moe_recv_counter)");
+    *runtime.moe_recv_counter = -1;
+
+    void* recv_expert_counter = nullptr;
+    ThrowOnCuda(
+        cudaMallocHost(&recv_expert_counter, sizeof(int) * NUM_MAX_LOCAL_EXPERTS, cudaHostAllocMapped),
+        "cudaMallocHost(moe_recv_expert_counter)");
+    runtime.moe_recv_expert_counter = reinterpret_cast<volatile int*>(recv_expert_counter);
+    int* recv_expert_counter_host = const_cast<int*>(runtime.moe_recv_expert_counter);
+    ThrowOnCuda(
+        cudaHostGetDevicePointer(
+            reinterpret_cast<void**>(&runtime.moe_recv_expert_counter_mapped),
+            recv_expert_counter_host,
+            0),
+        "cudaHostGetDevicePointer(moe_recv_expert_counter)");
+    for (int i = 0; i < NUM_MAX_LOCAL_EXPERTS; ++i) {
+      runtime.moe_recv_expert_counter[i] = -1;
+    }
+
+    ThrowOnCuda(cudaStreamCreateWithFlags(&runtime.aux_stream, cudaStreamNonBlocking), "cudaStreamCreateWithFlags");
+  }
+
+  void SyncLocalRuntime(DeviceRuntime& runtime) {
+    for (int peer = 0; peer < runtime.num_ranks; ++peer) {
+      if (peer == runtime.rank) {
+        continue;
+      }
+      int can_access_peer = 0;
+      ThrowOnCuda(
+          cudaDeviceCanAccessPeer(&can_access_peer, runtime.device_id, runtimes_[peer]->device_id),
+          "cudaDeviceCanAccessPeer");
+      if (can_access_peer == 0) {
+        throw std::runtime_error("DeepEP intranode JAX runtime requires peer access between all local GPUs");
+      }
+      EnablePeerAccess(runtimes_[peer]->device_id);
+      runtime.buffer_ptrs[peer] = runtimes_[peer]->local_buffer;
+      runtime.barrier_signal_ptrs[peer] =
+          reinterpret_cast<int*>(static_cast<uint8_t*>(runtime.buffer_ptrs[peer]) + runtime.num_nvl_bytes);
+    }
+    ThrowOnCuda(
+        cudaMemcpy(
+            runtime.buffer_ptrs_gpu,
+            runtime.buffer_ptrs,
+            sizeof(void*) * kMaxPeers,
+            cudaMemcpyHostToDevice),
+        "cudaMemcpy(buffer_ptrs_gpu)");
+    ThrowOnCuda(
+        cudaMemcpy(
+            runtime.barrier_signal_ptrs_gpu,
+            runtime.barrier_signal_ptrs,
+            sizeof(int*) * kMaxPeers,
+            cudaMemcpyHostToDevice),
+        "cudaMemcpy(barrier_signal_ptrs_gpu)");
+    ThrowOnCuda(cudaDeviceSynchronize(), "cudaDeviceSynchronize(sync)");
+    runtime.peer_synced = true;
+  }
+
+  void DestroyLocked() {
+    if (runtimes_.empty()) {
+      initialized_ = false;
+      num_ranks_ = 0;
+      hidden_bytes_ = 0;
+      num_nvl_bytes_ = 0;
+      return;
+    }
+
+    int original_device = 0;
+    cudaGetDevice(&original_device);
+    for (auto& runtime_ptr : runtimes_) {
+      if (runtime_ptr == nullptr) {
+        continue;
+      }
+      DeviceRuntime& runtime = *runtime_ptr;
+      cudaSetDevice(runtime.device_id);
+      if (runtime.peer_synced && runtime.barrier_signal_ptrs_gpu != nullptr && runtime.aux_stream != nullptr) {
+        deep_ep::intranode::barrier(runtime.barrier_signal_ptrs_gpu, runtime.rank, runtime.num_ranks, runtime.aux_stream);
+        cudaStreamSynchronize(runtime.aux_stream);
+      }
+      if (runtime.aux_stream != nullptr) {
+        cudaStreamDestroy(runtime.aux_stream);
+      }
+      if (runtime.recv_channel_offset_scratch != nullptr) {
+        cudaFree(runtime.recv_channel_offset_scratch);
+      }
+      if (runtime.local_buffer != nullptr) {
+        cudaFree(runtime.local_buffer);
+      }
+      if (runtime.moe_recv_counter != nullptr) {
+        cudaFreeHost(const_cast<int*>(runtime.moe_recv_counter));
+      }
+      if (runtime.moe_recv_expert_counter != nullptr) {
+        cudaFreeHost(const_cast<int*>(runtime.moe_recv_expert_counter));
+      }
+    }
+    cudaSetDevice(original_device);
+    runtimes_.clear();
+    initialized_ = false;
+    num_ranks_ = 0;
+    hidden_bytes_ = 0;
+    num_nvl_bytes_ = 0;
+  }
+
+  std::mutex mu_;
+  bool initialized_ = false;
+  int num_ranks_ = 0;
+  int64_t hidden_bytes_ = 0;
+  int64_t num_nvl_bytes_ = 0;
+  DispatchConfig dispatch_config_{};
+  DispatchConfig combine_config_{};
+  std::vector<std::unique_ptr<DeviceRuntime>> runtimes_;
+};
+
+void ResetRecvCounters(DeviceRuntime& runtime, int num_local_experts) {
+  *runtime.moe_recv_counter = -1;
+  for (int i = 0; i < num_local_experts; ++i) {
+    runtime.moe_recv_expert_counter[i] = -1;
+  }
+}
+
+void WaitForRecvCounts(DeviceRuntime& runtime, int num_local_experts, int* num_recv_tokens_out) {
+  auto start_time = std::chrono::high_resolution_clock::now();
+  while (true) {
+    int num_recv_tokens = static_cast<int>(*runtime.moe_recv_counter);
+    bool ready = (num_recv_tokens >= 0);
+    for (int i = 0; i < num_local_experts && ready; ++i) {
+      ready &= runtime.moe_recv_expert_counter[i] >= 0;
+    }
+    if (ready) {
+      *num_recv_tokens_out = num_recv_tokens;
+      return;
+    }
+    auto elapsed = std::chrono::duration_cast<std::chrono::seconds>(
+        std::chrono::high_resolution_clock::now() - start_time);
+    if (elapsed.count() > kCounterTimeoutSeconds) {
+      throw std::runtime_error("DeepEP intranode JAX dispatch timed out waiting for recv counters");
+    }
+  }
+}
+
+void DispatchOnCurrentDevice(
+    DeviceRuntime& runtime,
+    cudaStream_t stream,
+    const nv_bfloat16* x,
+    const int64_t* topk_idx,
+    const float* topk_weights,
+    const int* num_tokens_per_rank,
+    const int* num_tokens_per_expert,
+    const bool* is_token_in_rank,
+    int num_tokens,
+    int hidden,
+    int num_topk,
+    int num_experts,
+    nv_bfloat16* recv_x,
+    int64_t* recv_topk_idx,
+    float* recv_topk_weights,
+    int* recv_src_idx,
+    int* rank_prefix_matrix,
+    int* channel_prefix_matrix,
+    int* recv_channel_prefix_matrix,
+    int* send_head,
+    int* local_expert_counts,
+    int* num_recv_tokens_out,
+    int max_recv_tokens,
+    bool synchronize_after_launch) {
+  if (hidden <= 0 || (hidden * static_cast<int>(sizeof(nv_bfloat16))) % sizeof(int4) != 0) {
+    throw std::runtime_error("DeepEP intranode dispatch requires hidden*element_size divisible by int4");
+  }
+  if (num_experts % runtime.num_ranks != 0) {
+    throw std::runtime_error("DeepEP intranode dispatch requires num_experts divisible by num_ranks");
+  }
+  const int num_local_experts = num_experts / runtime.num_ranks;
+
+  ResetRecvCounters(runtime, num_local_experts);
+  LogHostDispatchStage(runtime.rank, "before_notify_dispatch", num_tokens, hidden, num_experts, num_topk);
+  const int num_memset_int = runtime.dispatch_num_channels() * runtime.num_ranks * 4;
+  deep_ep::intranode::notify_dispatch(
+      num_tokens_per_rank,
+      runtime.moe_recv_counter_mapped,
+      runtime.num_ranks,
+      num_tokens_per_expert,
+      runtime.moe_recv_expert_counter_mapped,
+      num_experts,
+      num_tokens,
+      is_token_in_rank,
+      channel_prefix_matrix,
+      rank_prefix_matrix,
+      num_memset_int,
+      1,
+      runtime.buffer_ptrs_gpu,
+      runtime.barrier_signal_ptrs_gpu,
+      runtime.rank,
+      stream,
+      runtime.dispatch_num_channels());
+  LogHostDispatchStage(runtime.rank, "after_notify_dispatch", num_tokens, hidden, num_experts, num_topk);
+
+  int num_recv_tokens = -1;
+  WaitForRecvCounts(runtime, num_local_experts, &num_recv_tokens);
+  LogHostDispatchStage(
+      runtime.rank,
+      "after_wait_for_recv_counts",
+      num_tokens,
+      hidden,
+      num_experts,
+      num_topk,
+      num_recv_tokens);
+  if (num_recv_tokens > max_recv_tokens) {
+    throw std::runtime_error("DeepEP intranode dispatch recv buffer is smaller than actual recv tokens");
+  }
+  ThrowOnCuda(
+      cudaMemcpyAsync(
+          local_expert_counts,
+          const_cast<int*>(runtime.moe_recv_expert_counter),
+          sizeof(int) * num_local_experts,
+          cudaMemcpyHostToDevice,
+          stream),
+      "cudaMemcpyAsync(local_expert_counts)");
+  *num_recv_tokens_out = num_recv_tokens;
+
+#if defined(LEVANTER_DEEPEP_EXTENDED_INTRNODE_DISPATCH)
+  deep_ep::intranode::dispatch(
+      recv_x,
+      nullptr,
+      nullptr,
+      recv_src_idx,
+      recv_topk_idx,
+      recv_topk_weights,
+      recv_channel_prefix_matrix,
+      send_head,
+      x,
+      nullptr,
+      nullptr,
+      topk_idx,
+      topk_weights,
+      is_token_in_rank,
+      channel_prefix_matrix,
+      num_tokens,
+      0,
+      hidden * static_cast<int>(sizeof(nv_bfloat16)) / sizeof(int4),
+      num_topk,
+      num_experts,
+      0,
+      0,
+      0,
+      0,
+      0,
+      0,
+      runtime.buffer_ptrs_gpu,
+      runtime.rank,
+      runtime.num_ranks,
+      stream,
+      runtime.dispatch_config.num_sms,
+      runtime.dispatch_config.num_max_send_tokens,
+      runtime.dispatch_config.num_max_recv_tokens);
+#else
+  deep_ep::intranode::dispatch(
+      recv_x,
+      nullptr,
+      recv_src_idx,
+      recv_topk_idx,
+      recv_topk_weights,
+      recv_channel_prefix_matrix,
+      send_head,
+      x,
+      nullptr,
+      topk_idx,
+      topk_weights,
+      is_token_in_rank,
+      channel_prefix_matrix,
+      num_tokens,
+      0,
+      hidden * static_cast<int>(sizeof(nv_bfloat16)) / sizeof(int4),
+      num_topk,
+      num_experts,
+      0,
+      0,
+      0,
+      runtime.buffer_ptrs_gpu,
+      runtime.rank,
+      runtime.num_ranks,
+      stream,
+      runtime.dispatch_config.num_sms,
+      runtime.dispatch_config.num_max_send_tokens,
+      runtime.dispatch_config.num_max_recv_tokens);
+#endif
+  LogHostDispatchStage(
+      runtime.rank,
+      "after_dispatch_launch",
+      num_tokens,
+      hidden,
+      num_experts,
+      num_topk,
+      num_recv_tokens);
+  if (!synchronize_after_launch) {
+    return;
+  }
+
+  ThrowOnCuda(cudaStreamSynchronize(stream), "cudaStreamSynchronize(dispatch)");
+  LogHostDispatchStage(
+      runtime.rank,
+      "after_dispatch_sync",
+      num_tokens,
+      hidden,
+      num_experts,
+      num_topk,
+      num_recv_tokens);
+}
+
+ffi::Error DispatchIntranode(
+    cudaStream_t stream,
+    ffi::Buffer<ffi::BF16, 2> x,
+    ffi::Buffer<ffi::S64, 2> topk_idx,
+    ffi::Buffer<ffi::F32, 2> topk_weights,
+    ffi::Buffer<ffi::S32, 1> num_tokens_per_rank,
+    ffi::Buffer<ffi::S32, 1> num_tokens_per_expert,
+    ffi::Buffer<ffi::PRED, 2> is_token_in_rank,
+    int32_t num_experts,
+    ffi::Result<ffi::Buffer<ffi::BF16, 2>> recv_x,
+    ffi::Result<ffi::Buffer<ffi::S64, 2>> recv_topk_idx,
+    ffi::Result<ffi::Buffer<ffi::F32, 2>> recv_topk_weights,
+    ffi::Result<ffi::Buffer<ffi::S32, 1>> recv_src_idx,
+    ffi::Result<ffi::Buffer<ffi::S32, 2>> rank_prefix_matrix,
+    ffi::Result<ffi::Buffer<ffi::S32, 2>> channel_prefix_matrix,
+    ffi::Result<ffi::Buffer<ffi::S32, 2>> recv_channel_prefix_matrix,
+    ffi::Result<ffi::Buffer<ffi::S32, 2>> send_head,
+    ffi::Result<ffi::Buffer<ffi::S32, 1>> local_expert_counts,
+    ffi::Result<ffi::Buffer<ffi::S32, 1>> num_recv_tokens_buffer) {
+  try {
+    DeviceRuntime& runtime = RuntimeManager::Instance().RuntimeForCurrentDevice();
+    const auto x_dims = x.dimensions();
+    const auto topk_dims = topk_idx.dimensions();
+    const auto rank_dims = num_tokens_per_rank.dimensions();
+    const auto expert_dims = num_tokens_per_expert.dimensions();
+    const auto token_rank_dims = is_token_in_rank.dimensions();
+    if (x_dims.size() != 2 || topk_dims.size() != 2) {
+      return ffi::Error::InvalidArgument("DeepEP intranode dispatch expects rank-2 x and topk_idx");
+    }
+    if (rank_dims.size() != 1 || expert_dims.size() != 1 || token_rank_dims.size() != 2) {
+      return ffi::Error::InvalidArgument("DeepEP intranode dispatch metadata ranks are invalid");
+    }
+    const int num_tokens = static_cast<int>(x_dims[0]);
+    const int hidden = static_cast<int>(x_dims[1]);
+    const int num_topk = static_cast<int>(topk_dims[1]);
+    if (topk_dims[0] != num_tokens || topk_weights.dimensions()[0] != num_tokens ||
+        topk_weights.dimensions()[1] != num_topk) {
+      return ffi::Error::InvalidArgument("DeepEP intranode dispatch top-k tensors must match x");
+    }
+    if (rank_dims[0] != runtime.num_ranks || token_rank_dims[0] != num_tokens ||
+        token_rank_dims[1] != runtime.num_ranks) {
+      return ffi::Error::InvalidArgument("DeepEP intranode dispatch rank metadata shape mismatch");
+    }
+    if (expert_dims[0] != num_experts) {
+      return ffi::Error::InvalidArgument("DeepEP intranode dispatch expert metadata shape mismatch");
+    }
+    if (hidden <= 0 || (hidden * static_cast<int>(ffi::ByteWidth(ffi::BF16))) % sizeof(int4) != 0) {
+      return ffi::Error::InvalidArgument("DeepEP intranode dispatch requires hidden*element_size divisible by int4");
+    }
+    if (num_experts % runtime.num_ranks != 0) {
+      return ffi::Error::InvalidArgument("DeepEP intranode dispatch requires num_experts divisible by num_ranks");
+    }
+    const int num_local_experts = num_experts / runtime.num_ranks;
+    if (local_expert_counts->dimensions().size() != 1 || local_expert_counts->dimensions()[0] != num_local_experts) {
+      return ffi::Error::InvalidArgument("DeepEP intranode dispatch local_expert_counts shape mismatch");
+    }
+    if (num_recv_tokens_buffer->dimensions().size() != 1 || num_recv_tokens_buffer->dimensions()[0] != 1) {
+      return ffi::Error::InvalidArgument("DeepEP intranode dispatch num_recv_tokens buffer must have shape [1]");
+    }
+    const int num_channels = runtime.dispatch_num_channels();
+    if (rank_prefix_matrix->dimensions().size() != 2 ||
+        rank_prefix_matrix->dimensions()[0] != runtime.num_ranks ||
+        rank_prefix_matrix->dimensions()[1] != runtime.num_ranks ||
+        channel_prefix_matrix->dimensions().size() != 2 ||
+        channel_prefix_matrix->dimensions()[0] != runtime.num_ranks ||
+        channel_prefix_matrix->dimensions()[1] != num_channels ||
+        recv_channel_prefix_matrix->dimensions().size() != 2 ||
+        recv_channel_prefix_matrix->dimensions()[0] != runtime.num_ranks ||
+        recv_channel_prefix_matrix->dimensions()[1] != num_channels ||
+        send_head->dimensions().size() != 2 ||
+        send_head->dimensions()[0] != num_tokens ||
+        send_head->dimensions()[1] != runtime.num_ranks) {
+      return ffi::Error::InvalidArgument("DeepEP intranode dispatch handle tensor shapes are invalid");
+    }
+    if (recv_x->dimensions().size() != 2 || recv_x->dimensions()[1] != hidden ||
+        recv_src_idx->dimensions().size() != 1 || recv_src_idx->dimensions()[0] != recv_x->dimensions()[0] ||
+        recv_topk_idx->dimensions().size() != 2 || recv_topk_idx->dimensions()[0] != recv_x->dimensions()[0] ||
+        recv_topk_idx->dimensions()[1] != num_topk ||
+        recv_topk_weights->dimensions().size() != 2 || recv_topk_weights->dimensions()[0] != recv_x->dimensions()[0] ||
+        recv_topk_weights->dimensions()[1] != num_topk) {
+      return ffi::Error::InvalidArgument("DeepEP intranode dispatch recv tensor shapes are invalid");
+    }
+
+    int num_recv_tokens = -1;
+    DispatchOnCurrentDevice(
+        runtime,
+        stream,
+        reinterpret_cast<const nv_bfloat16*>(x.typed_data()),
+        topk_idx.typed_data(),
+        topk_weights.typed_data(),
+        num_tokens_per_rank.typed_data(),
+        num_tokens_per_expert.typed_data(),
+        is_token_in_rank.typed_data(),
+        num_tokens,
+        hidden,
+        num_topk,
+        num_experts,
+        reinterpret_cast<nv_bfloat16*>(recv_x->typed_data()),
+        recv_topk_idx->typed_data(),
+        recv_topk_weights->typed_data(),
+        recv_src_idx->typed_data(),
+        rank_prefix_matrix->typed_data(),
+        channel_prefix_matrix->typed_data(),
+        recv_channel_prefix_matrix->typed_data(),
+        send_head->typed_data(),
+        local_expert_counts->typed_data(),
+        &num_recv_tokens,
+        static_cast<int>(recv_x->dimensions()[0]),
+        false);
+
+    cudaError_t status = cudaSuccess;
+    runtime.last_num_recv_tokens = num_recv_tokens;
+    status = cudaMemcpyAsync(
+        num_recv_tokens_buffer->typed_data(),
+        &runtime.last_num_recv_tokens,
+        sizeof(int),
+        cudaMemcpyHostToDevice,
+        stream);
+    if (status != cudaSuccess) {
+      return CudaError(status, "cudaMemcpyAsync(num_recv_tokens)");
+    }
+    return ffi::Error::Success();
+  } catch (const std::exception& exc) {
+    return ffi::Error::Internal(exc.what());
+  }
+}
+
+ffi::Error DispatchIntranodeCached(
+    cudaStream_t stream,
+    ffi::Buffer<ffi::BF16, 2> x,
+    ffi::Buffer<ffi::PRED, 2> is_token_in_rank,
+    ffi::Buffer<ffi::S32, 2> rank_prefix_matrix,
+    ffi::Buffer<ffi::S32, 2> channel_prefix_matrix,
+    ffi::Buffer<ffi::S32, 1> num_recv_tokens_buffer,
+    ffi::Result<ffi::Buffer<ffi::BF16, 2>> recv_x,
+    ffi::Result<ffi::Buffer<ffi::S32, 1>> recv_src_idx,
+    ffi::Result<ffi::Buffer<ffi::S32, 2>> recv_channel_prefix_matrix,
+    ffi::Result<ffi::Buffer<ffi::S32, 2>> send_head) {
+  try {
+    DeviceRuntime& runtime = RuntimeManager::Instance().RuntimeForCurrentDevice();
+    if (num_recv_tokens_buffer.dimensions().size() != 1 || num_recv_tokens_buffer.dimensions()[0] != 1) {
+      return ffi::Error::InvalidArgument(
+          "DeepEP intranode cached dispatch expects num_recv_tokens shape [1]");
+    }
+    int num_recv_tokens = -1;
+    cudaError_t status = cudaMemcpyAsync(
+        &num_recv_tokens,
+        num_recv_tokens_buffer.typed_data(),
+        sizeof(int),
+        cudaMemcpyDeviceToHost,
+        stream);
+    if (status != cudaSuccess) {
+      return CudaError(status, "cudaMemcpyAsync(read num_recv_tokens)");
+    }
+    status = cudaStreamSynchronize(stream);
+    if (status != cudaSuccess) {
+      return CudaError(status, "cudaStreamSynchronize(read num_recv_tokens)");
+    }
+
+    const auto x_dims = x.dimensions();
+    const auto token_rank_dims = is_token_in_rank.dimensions();
+    const auto rank_dims = rank_prefix_matrix.dimensions();
+    const auto channel_dims = channel_prefix_matrix.dimensions();
+    const auto recv_x_dims = recv_x->dimensions();
+    const auto recv_src_dims = recv_src_idx->dimensions();
+    const auto recv_channel_dims = recv_channel_prefix_matrix->dimensions();
+    const auto send_head_dims = send_head->dimensions();
+    if (x_dims.size() != 2 || token_rank_dims.size() != 2 || rank_dims.size() != 2 || channel_dims.size() != 2 ||
+        recv_x_dims.size() != 2 || recv_src_dims.size() != 1 || recv_channel_dims.size() != 2 ||
+        send_head_dims.size() != 2) {
+      return ffi::Error::InvalidArgument("DeepEP intranode cached dispatch expects rank-1/2 tensors");
+    }
+    const int num_tokens = static_cast<int>(x_dims[0]);
+    const int hidden = static_cast<int>(x_dims[1]);
+    const int num_channels = runtime.dispatch_num_channels();
+    if (hidden <= 0 || (hidden * static_cast<int>(ffi::ByteWidth(ffi::BF16))) % sizeof(int4) != 0) {
+      return ffi::Error::InvalidArgument(
+          "DeepEP intranode cached dispatch requires hidden*element_size divisible by int4");
+    }
+    if (token_rank_dims[0] != num_tokens || token_rank_dims[1] != runtime.num_ranks) {
+      return ffi::Error::InvalidArgument(
+          "DeepEP intranode cached dispatch token/rank metadata shape mismatch");
+    }
+    if (rank_dims[0] != runtime.num_ranks || rank_dims[1] != runtime.num_ranks ||
+        channel_dims[0] != runtime.num_ranks || channel_dims[1] != num_channels) {
+      return ffi::Error::InvalidArgument(
+          "DeepEP intranode cached dispatch handle tensor shapes are invalid");
+    }
+    if (recv_x_dims[1] != hidden || recv_src_dims[0] != recv_x_dims[0] || recv_x_dims[0] < num_recv_tokens ||
+        recv_channel_dims[0] != runtime.num_ranks || recv_channel_dims[1] != num_channels ||
+        send_head_dims[0] != num_tokens || send_head_dims[1] != runtime.num_ranks) {
+      return ffi::Error::InvalidArgument(
+          "DeepEP intranode cached dispatch output tensor shapes are invalid");
+    }
+    if (num_recv_tokens < 0) {
+      return ffi::Error::InvalidArgument("DeepEP intranode cached dispatch num_recv_tokens is out of range");
+    }
+
+    const int num_memset_int = runtime.dispatch_num_channels() * runtime.num_ranks * 4;
+    deep_ep::intranode::cached_notify_dispatch(
+        rank_prefix_matrix.typed_data(),
+        num_memset_int,
+        runtime.buffer_ptrs_gpu,
+        runtime.barrier_signal_ptrs_gpu,
+        runtime.rank,
+        runtime.num_ranks,
+        stream);
+
+#if defined(LEVANTER_DEEPEP_EXTENDED_INTRNODE_DISPATCH)
+    deep_ep::intranode::dispatch(
+        recv_x->typed_data(),
+        nullptr,
+        nullptr,
+        recv_src_idx->typed_data(),
+        nullptr,
+        nullptr,
+        recv_channel_prefix_matrix->typed_data(),
+        send_head->typed_data(),
+        x.typed_data(),
+        nullptr,
+        nullptr,
+        nullptr,
+        nullptr,
+        is_token_in_rank.typed_data(),
+        channel_prefix_matrix.typed_data(),
+        num_tokens,
+        num_recv_tokens,
+        hidden * static_cast<int>(ffi::ByteWidth(ffi::BF16)) / sizeof(int4),
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        runtime.buffer_ptrs_gpu,
+        runtime.rank,
+        runtime.num_ranks,
+        stream,
+        runtime.dispatch_config.num_sms,
+        runtime.dispatch_config.num_max_send_tokens,
+        runtime.dispatch_config.num_max_recv_tokens);
+#else
+    deep_ep::intranode::dispatch(
+        recv_x->typed_data(),
+        nullptr,
+        recv_src_idx->typed_data(),
+        nullptr,
+        nullptr,
+        recv_channel_prefix_matrix->typed_data(),
+        send_head->typed_data(),
+        x.typed_data(),
+        nullptr,
+        nullptr,
+        nullptr,
+        is_token_in_rank.typed_data(),
+        channel_prefix_matrix.typed_data(),
+        num_tokens,
+        num_recv_tokens,
+        hidden * static_cast<int>(ffi::ByteWidth(ffi::BF16)) / sizeof(int4),
+        0,
+        0,
+        0,
+        0,
+        0,
+        runtime.buffer_ptrs_gpu,
+        runtime.rank,
+        runtime.num_ranks,
+        stream,
+        runtime.dispatch_config.num_sms,
+        runtime.dispatch_config.num_max_send_tokens,
+        runtime.dispatch_config.num_max_recv_tokens);
+#endif
+    return ffi::Error::Success();
+  } catch (const std::exception& exc) {
+    return ffi::Error::Internal(exc.what());
+  }
+}
+
+ffi::Error CombineIntranode(
+    cudaStream_t stream,
+    ffi::Buffer<ffi::BF16, 2> recv_x,
+    ffi::Buffer<ffi::F32, 2> recv_topk_weights,
+    ffi::Buffer<ffi::S32, 1> recv_src_idx,
+    ffi::Buffer<ffi::S32, 2> rank_prefix_matrix,
+    ffi::Buffer<ffi::S32, 2> channel_prefix_matrix,
+    ffi::Buffer<ffi::S32, 2> send_head,
+    ffi::Buffer<ffi::S32, 1> num_recv_tokens_buffer,
+    ffi::Result<ffi::Buffer<ffi::BF16, 2>> combined_x,
+    ffi::Result<ffi::Buffer<ffi::F32, 2>> combined_topk_weights,
+    ffi::Result<ffi::Buffer<ffi::S32, 2>> send_head_out) {
+  try {
+    DeviceRuntime& runtime = RuntimeManager::Instance().RuntimeForCurrentDevice();
+    if (num_recv_tokens_buffer.dimensions().size() != 1 || num_recv_tokens_buffer.dimensions()[0] != 1) {
+      return ffi::Error::InvalidArgument("DeepEP intranode combine expects num_recv_tokens shape [1]");
+    }
+    int num_recv_tokens = -1;
+    cudaError_t status = cudaMemcpyAsync(
+        &num_recv_tokens,
+        num_recv_tokens_buffer.typed_data(),
+        sizeof(int),
+        cudaMemcpyDeviceToHost,
+        stream);
+    if (status != cudaSuccess) {
+      return CudaError(status, "cudaMemcpyAsync(read num_recv_tokens)");
+    }
+    status = cudaStreamSynchronize(stream);
+    if (status != cudaSuccess) {
+      return CudaError(status, "cudaStreamSynchronize(read num_recv_tokens)");
+    }
+
+    const auto recv_x_dims = recv_x.dimensions();
+    const auto recv_topk_dims = recv_topk_weights.dimensions();
+    const auto src_dims = recv_src_idx.dimensions();
+    const auto rank_dims = rank_prefix_matrix.dimensions();
+    const auto channel_dims = channel_prefix_matrix.dimensions();
+    const auto send_head_dims = send_head.dimensions();
+    if (recv_x_dims.size() != 2 || recv_topk_dims.size() != 2 || src_dims.size() != 1 ||
+        rank_dims.size() != 2 || channel_dims.size() != 2 || send_head_dims.size() != 2) {
+      return ffi::Error::InvalidArgument("DeepEP intranode combine expects rank-1/2 tensors");
+    }
+    const int hidden = static_cast<int>(recv_x_dims[1]);
+    const int num_topk = static_cast<int>(recv_topk_dims[1]);
+    const int combined_tokens = static_cast<int>(send_head_dims[0]);
+    if (recv_topk_dims[0] != recv_x_dims[0] || src_dims[0] != recv_x_dims[0]) {
+      return ffi::Error::InvalidArgument("DeepEP intranode combine recv tensors must share the same leading dim");
+    }
+    if (num_recv_tokens < 0 || num_recv_tokens > recv_x_dims[0]) {
+      return ffi::Error::InvalidArgument("DeepEP intranode combine num_recv_tokens is out of range");
+    }
+    if (rank_dims[0] != runtime.num_ranks || rank_dims[1] != runtime.num_ranks ||
+        channel_dims[0] != runtime.num_ranks || channel_dims[1] != runtime.combine_num_channels() ||
+        send_head_dims[1] != runtime.num_ranks) {
+      return ffi::Error::InvalidArgument("DeepEP intranode combine handle tensor shapes are invalid");
+    }
+    if (combined_x->dimensions().size() != 2 || combined_x->dimensions()[0] != combined_tokens ||
+        combined_x->dimensions()[1] != hidden ||
+        combined_topk_weights->dimensions().size() != 2 ||
+        combined_topk_weights->dimensions()[0] != combined_tokens ||
+        combined_topk_weights->dimensions()[1] != num_topk ||
+        send_head_out->dimensions().size() != 2 ||
+        send_head_out->dimensions()[0] != combined_tokens ||
+        send_head_out->dimensions()[1] != runtime.num_ranks) {
+      return ffi::Error::InvalidArgument("DeepEP intranode combine output shapes are invalid");
+    }
+
+    if (send_head_out->typed_data() != send_head.typed_data()) {
+      status = cudaMemcpyAsync(
+          send_head_out->typed_data(),
+          send_head.typed_data(),
+          sizeof(int) * combined_tokens * runtime.num_ranks,
+          cudaMemcpyDeviceToDevice,
+          stream);
+      if (status != cudaSuccess) {
+        return CudaError(status, "cudaMemcpyAsync(copy send_head)");
+      }
+    }
+
+    deep_ep::intranode::cached_notify_combine(
+        runtime.buffer_ptrs_gpu,
+        send_head_out->typed_data(),
+        runtime.combine_num_channels(),
+        combined_tokens,
+        runtime.combine_num_channels() * runtime.num_ranks * 2,
+        runtime.barrier_signal_ptrs_gpu,
+        runtime.rank,
+        runtime.num_ranks,
+        stream);
+
+    deep_ep::intranode::combine(
+        CUDA_R_16BF,
+        combined_x->typed_data(),
+        combined_topk_weights->typed_data(),
+        recv_x.typed_data(),
+        recv_topk_weights.typed_data(),
+        nullptr,
+        nullptr,
+        recv_src_idx.typed_data(),
+        rank_prefix_matrix.typed_data(),
+        channel_prefix_matrix.typed_data(),
+        send_head_out->typed_data(),
+        num_recv_tokens,
+        combined_tokens,
+        hidden,
+        num_topk,
+        runtime.buffer_ptrs_gpu,
+        runtime.rank,
+        runtime.num_ranks,
+        stream,
+        runtime.combine_config.num_sms,
+        runtime.combine_config.num_max_send_tokens,
+        runtime.combine_config.num_max_recv_tokens);
+    return ffi::Error::Success();
+  } catch (const std::exception& exc) {
+    return ffi::Error::Internal(exc.what());
+  }
+}
+
+auto DispatchBinding() {
+  return ffi::Ffi::Bind()
+      .Ctx<ffi::PlatformStream<cudaStream_t>>()
+      .Arg<ffi::Buffer<ffi::BF16, 2>>()
+      .Arg<ffi::Buffer<ffi::S64, 2>>()
+      .Arg<ffi::Buffer<ffi::F32, 2>>()
+      .Arg<ffi::Buffer<ffi::S32, 1>>()
+      .Arg<ffi::Buffer<ffi::S32, 1>>()
+      .Arg<ffi::Buffer<ffi::PRED, 2>>()
+      .Attr<int32_t>("num_experts")
+      .Ret<ffi::Buffer<ffi::BF16, 2>>()
+      .Ret<ffi::Buffer<ffi::S64, 2>>()
+      .Ret<ffi::Buffer<ffi::F32, 2>>()
+      .Ret<ffi::Buffer<ffi::S32, 1>>()
+      .Ret<ffi::Buffer<ffi::S32, 2>>()
+      .Ret<ffi::Buffer<ffi::S32, 2>>()
+      .Ret<ffi::Buffer<ffi::S32, 2>>()
+      .Ret<ffi::Buffer<ffi::S32, 2>>()
+      .Ret<ffi::Buffer<ffi::S32, 1>>()
+      .Ret<ffi::Buffer<ffi::S32, 1>>();
+}
+
+auto DispatchCachedBinding() {
+  return ffi::Ffi::Bind()
+      .Ctx<ffi::PlatformStream<cudaStream_t>>()
+      .Arg<ffi::Buffer<ffi::BF16, 2>>()
+      .Arg<ffi::Buffer<ffi::PRED, 2>>()
+      .Arg<ffi::Buffer<ffi::S32, 2>>()
+      .Arg<ffi::Buffer<ffi::S32, 2>>()
+      .Arg<ffi::Buffer<ffi::S32, 1>>()
+      .Ret<ffi::Buffer<ffi::BF16, 2>>()
+      .Ret<ffi::Buffer<ffi::S32, 1>>()
+      .Ret<ffi::Buffer<ffi::S32, 2>>()
+      .Ret<ffi::Buffer<ffi::S32, 2>>();
+}
+
+auto CombineBinding() {
+  return ffi::Ffi::Bind()
+      .Ctx<ffi::PlatformStream<cudaStream_t>>()
+      .Arg<ffi::Buffer<ffi::BF16, 2>>()
+      .Arg<ffi::Buffer<ffi::F32, 2>>()
+      .Arg<ffi::Buffer<ffi::S32, 1>>()
+      .Arg<ffi::Buffer<ffi::S32, 2>>()
+      .Arg<ffi::Buffer<ffi::S32, 2>>()
+      .Arg<ffi::Buffer<ffi::S32, 2>>()
+      .Arg<ffi::Buffer<ffi::S32, 1>>()
+      .Ret<ffi::Buffer<ffi::BF16, 2>>()
+      .Ret<ffi::Buffer<ffi::F32, 2>>()
+      .Ret<ffi::Buffer<ffi::S32, 2>>();
+}
+
+}  // namespace
+
+extern "C" int levanter_deepep_init_intranode_runtime(
+    int num_ranks,
+    int64_t hidden_bytes,
+    int dispatch_num_sms,
+    int dispatch_num_max_send_tokens,
+    int dispatch_num_max_recv_tokens,
+    int combine_num_sms,
+    int combine_num_max_send_tokens,
+    int combine_num_max_recv_tokens) {
+  try {
+    RuntimeManager::Instance().Init(
+        num_ranks,
+        hidden_bytes,
+        DispatchConfig{dispatch_num_sms, dispatch_num_max_send_tokens, dispatch_num_max_recv_tokens},
+        DispatchConfig{combine_num_sms, combine_num_max_send_tokens, combine_num_max_recv_tokens});
+    SetLastError("");
+    return 0;
+  } catch (const std::exception& exc) {
+    SetLastError(exc.what());
+    return 1;
+  }
+}
+
+extern "C" void levanter_deepep_shutdown_intranode_runtime() {
+  try {
+    RuntimeManager::Instance().Shutdown();
+    SetLastError("");
+  } catch (const std::exception& exc) {
+    SetLastError(exc.what());
+  }
+}
+
+extern "C" const char* levanter_deepep_last_error() { return LastErrorStorage().c_str(); }
+
+extern "C" int levanter_deepep_run_host_dispatch_round(
+    int num_tokens,
+    int hidden,
+    int num_experts,
+    int num_topk) {
+  try {
+    if (num_tokens <= 0 || hidden <= 0 || num_experts <= 0 || num_topk <= 0) {
+      throw std::runtime_error("host dispatch round requires positive num_tokens/hidden/experts/topk");
+    }
+
+    RuntimeManager& manager = RuntimeManager::Instance();
+    DeviceRuntime& runtime0 = manager.RuntimeForCurrentDevice();
+    const int num_ranks = runtime0.num_ranks;
+    const int local_experts = num_experts / num_ranks;
+    if (num_experts % num_ranks != 0) {
+      throw std::runtime_error("host dispatch round requires num_experts divisible by num_ranks");
+    }
+    if (num_topk > num_ranks) {
+      throw std::runtime_error("host dispatch round currently requires num_topk <= num_ranks");
+    }
+
+    ThreadBarrier barrier(num_ranks);
+    std::mutex error_mu;
+    std::optional<std::string> first_error;
+    std::vector<std::thread> threads;
+    threads.reserve(num_ranks);
+
+    for (int rank = 0; rank < num_ranks; ++rank) {
+      threads.emplace_back([&, rank]() {
+        try {
+          ThrowOnCuda(cudaSetDevice(rank), "cudaSetDevice(host dispatch round)");
+          DeviceRuntime& runtime = manager.RuntimeForCurrentDevice();
+          LogHostDispatchStage(rank, "thread_start", num_tokens, hidden, num_experts, num_topk);
+
+          std::vector<void*> allocations;
+          auto allocate_zeroed = [&](size_t num_bytes, const char* context) -> void* {
+            void* ptr = nullptr;
+            ThrowOnCuda(cudaMalloc(&ptr, num_bytes), context);
+            allocations.push_back(ptr);
+            ThrowOnCuda(cudaMemset(ptr, 0, num_bytes), context);
+            return ptr;
+          };
+
+          const int recv_capacity = num_tokens * num_ranks;
+          const int num_channels = runtime.dispatch_num_channels();
+          const size_t x_bytes = static_cast<size_t>(num_tokens) * hidden * sizeof(nv_bfloat16);
+          const size_t topk_idx_bytes = static_cast<size_t>(num_tokens) * num_topk * sizeof(int64_t);
+          const size_t topk_weights_bytes = static_cast<size_t>(num_tokens) * num_topk * sizeof(float);
+          const size_t rank_counts_bytes = static_cast<size_t>(num_ranks) * sizeof(int);
+          const size_t expert_counts_bytes = static_cast<size_t>(num_experts) * sizeof(int);
+          const size_t token_rank_bytes = static_cast<size_t>(num_tokens) * num_ranks * sizeof(bool);
+          const size_t recv_x_bytes = static_cast<size_t>(recv_capacity) * hidden * sizeof(nv_bfloat16);
+          const size_t recv_topk_idx_bytes = static_cast<size_t>(recv_capacity) * num_topk * sizeof(int64_t);
+          const size_t recv_topk_weights_bytes = static_cast<size_t>(recv_capacity) * num_topk * sizeof(float);
+          const size_t recv_src_idx_bytes = static_cast<size_t>(recv_capacity) * sizeof(int);
+          const size_t rank_prefix_bytes = static_cast<size_t>(num_ranks) * num_ranks * sizeof(int);
+          const size_t channel_prefix_bytes = static_cast<size_t>(num_ranks) * num_channels * sizeof(int);
+          const size_t send_head_bytes = static_cast<size_t>(num_tokens) * num_ranks * sizeof(int);
+          const size_t local_expert_counts_bytes = static_cast<size_t>(local_experts) * sizeof(int);
+
+          auto* x = reinterpret_cast<nv_bfloat16*>(allocate_zeroed(x_bytes, "cudaMalloc(host round x)"));
+          auto* topk_idx = reinterpret_cast<int64_t*>(allocate_zeroed(topk_idx_bytes, "cudaMalloc(host round topk_idx)"));
+          auto* topk_weights =
+              reinterpret_cast<float*>(allocate_zeroed(topk_weights_bytes, "cudaMalloc(host round topk_weights)"));
+          auto* num_tokens_per_rank =
+              reinterpret_cast<int*>(allocate_zeroed(rank_counts_bytes, "cudaMalloc(host round num_tokens_per_rank)"));
+          auto* num_tokens_per_expert = reinterpret_cast<int*>(
+              allocate_zeroed(expert_counts_bytes, "cudaMalloc(host round num_tokens_per_expert)"));
+          auto* is_token_in_rank =
+              reinterpret_cast<bool*>(allocate_zeroed(token_rank_bytes, "cudaMalloc(host round is_token_in_rank)"));
+          auto* recv_x = reinterpret_cast<nv_bfloat16*>(allocate_zeroed(recv_x_bytes, "cudaMalloc(host round recv_x)"));
+          auto* recv_topk_idx = reinterpret_cast<int64_t*>(
+              allocate_zeroed(recv_topk_idx_bytes, "cudaMalloc(host round recv_topk_idx)"));
+          auto* recv_topk_weights = reinterpret_cast<float*>(
+              allocate_zeroed(recv_topk_weights_bytes, "cudaMalloc(host round recv_topk_weights)"));
+          auto* recv_src_idx =
+              reinterpret_cast<int*>(allocate_zeroed(recv_src_idx_bytes, "cudaMalloc(host round recv_src_idx)"));
+          auto* rank_prefix_matrix =
+              reinterpret_cast<int*>(allocate_zeroed(rank_prefix_bytes, "cudaMalloc(host round rank_prefix)"));
+          auto* channel_prefix_matrix =
+              reinterpret_cast<int*>(allocate_zeroed(channel_prefix_bytes, "cudaMalloc(host round channel_prefix)"));
+          auto* recv_channel_prefix_matrix = reinterpret_cast<int*>(
+              allocate_zeroed(channel_prefix_bytes, "cudaMalloc(host round recv_channel_prefix)"));
+          auto* send_head =
+              reinterpret_cast<int*>(allocate_zeroed(send_head_bytes, "cudaMalloc(host round send_head)"));
+          auto* local_expert_counts = reinterpret_cast<int*>(
+              allocate_zeroed(local_expert_counts_bytes, "cudaMalloc(host round local_expert_counts)"));
+
+          std::vector<int64_t> host_topk_idx(static_cast<size_t>(num_tokens) * num_topk);
+          std::vector<float> host_topk_weights(static_cast<size_t>(num_tokens) * num_topk, 1.0f / num_topk);
+          std::vector<int> host_num_tokens_per_rank(num_ranks, 0);
+          std::vector<int> host_num_tokens_per_expert(num_experts, 0);
+          std::vector<uint8_t> host_is_token_in_rank(static_cast<size_t>(num_tokens) * num_ranks, 0);
+
+          for (int slot = 0; slot < num_topk; ++slot) {
+            const int dest_rank = (rank + 1 + slot) % num_ranks;
+            const int expert = dest_rank * local_experts + (slot % local_experts);
+            host_num_tokens_per_rank[dest_rank] = num_tokens;
+            host_num_tokens_per_expert[expert] = num_tokens;
+            for (int token = 0; token < num_tokens; ++token) {
+              host_topk_idx[token * num_topk + slot] = expert;
+              host_is_token_in_rank[token * num_ranks + dest_rank] = 1;
+            }
+          }
+
+          ThrowOnCuda(
+              cudaMemcpy(topk_idx, host_topk_idx.data(), topk_idx_bytes, cudaMemcpyHostToDevice),
+              "cudaMemcpy(host round topk_idx)");
+          ThrowOnCuda(
+              cudaMemcpy(topk_weights, host_topk_weights.data(), topk_weights_bytes, cudaMemcpyHostToDevice),
+              "cudaMemcpy(host round topk_weights)");
+          ThrowOnCuda(
+              cudaMemcpy(
+                  num_tokens_per_rank, host_num_tokens_per_rank.data(), rank_counts_bytes, cudaMemcpyHostToDevice),
+              "cudaMemcpy(host round num_tokens_per_rank)");
+          ThrowOnCuda(
+              cudaMemcpy(
+                  num_tokens_per_expert,
+                  host_num_tokens_per_expert.data(),
+                  expert_counts_bytes,
+                  cudaMemcpyHostToDevice),
+              "cudaMemcpy(host round num_tokens_per_expert)");
+          ThrowOnCuda(
+              cudaMemcpy(is_token_in_rank, host_is_token_in_rank.data(), token_rank_bytes, cudaMemcpyHostToDevice),
+              "cudaMemcpy(host round is_token_in_rank)");
+
+          LogHostDispatchStage(rank, "before_barrier", num_tokens, hidden, num_experts, num_topk);
+          barrier.Wait();
+          LogHostDispatchStage(rank, "after_barrier", num_tokens, hidden, num_experts, num_topk);
+
+          int num_recv_tokens = -1;
+          DispatchOnCurrentDevice(
+              runtime,
+              runtime.aux_stream,
+              x,
+              topk_idx,
+              topk_weights,
+              num_tokens_per_rank,
+              num_tokens_per_expert,
+              is_token_in_rank,
+              num_tokens,
+              hidden,
+              num_topk,
+              num_experts,
+              recv_x,
+              recv_topk_idx,
+              recv_topk_weights,
+              recv_src_idx,
+              rank_prefix_matrix,
+              channel_prefix_matrix,
+              recv_channel_prefix_matrix,
+              send_head,
+              local_expert_counts,
+              &num_recv_tokens,
+              recv_capacity,
+              false);
+          LogHostDispatchStage(
+              rank,
+              "before_launch_sync_barrier",
+              num_tokens,
+              hidden,
+              num_experts,
+              num_topk,
+              num_recv_tokens);
+          barrier.Wait();
+          LogHostDispatchStage(
+              rank,
+              "after_launch_sync_barrier",
+              num_tokens,
+              hidden,
+              num_experts,
+              num_topk,
+              num_recv_tokens);
+          ThrowOnCuda(cudaStreamSynchronize(runtime.aux_stream), "cudaStreamSynchronize(dispatch)");
+          LogHostDispatchStage(
+              rank,
+              "after_dispatch_sync",
+              num_tokens,
+              hidden,
+              num_experts,
+              num_topk,
+              num_recv_tokens);
+          LogHostDispatchStage(
+              rank,
+              "thread_done",
+              num_tokens,
+              hidden,
+              num_experts,
+              num_topk,
+              num_recv_tokens);
+
+          for (void* ptr : allocations) {
+            cudaFree(ptr);
+          }
+        } catch (const std::exception& exc) {
+          fprintf(stderr, "HOST_DISPATCH_ERROR {\"rank\":%d,\"error\":\"%s\"}\n", rank, exc.what());
+          std::lock_guard<std::mutex> lock(error_mu);
+          if (!first_error.has_value()) {
+            first_error = "rank " + std::to_string(rank) + ": " + exc.what();
+          }
+        }
+      });
+    }
+
+    for (auto& thread : threads) {
+      thread.join();
+    }
+    if (first_error.has_value()) {
+      throw std::runtime_error(*first_error);
+    }
+
+    SetLastError("");
+    return 0;
+  } catch (const std::exception& exc) {
+    SetLastError(exc.what());
+    return 1;
+  }
+}
+
+extern "C" int levanter_deepep_probe_dispatch_kernel_attributes() {
+  try {
+    DeviceRuntime& runtime = RuntimeManager::Instance().RuntimeForCurrentDevice();
+    std::vector<void*> allocations;
+    auto allocate_zeroed = [&](size_t num_bytes, const char* context) -> void* {
+      void* ptr = nullptr;
+      ThrowOnCuda(cudaMalloc(&ptr, num_bytes), context);
+      allocations.push_back(ptr);
+      ThrowOnCuda(cudaMemset(ptr, 0, num_bytes), context);
+      return ptr;
+    };
+
+    const int hidden_int4 = kProbeDispatchHidden * static_cast<int>(sizeof(nv_bfloat16)) / sizeof(int4);
+    const int max_recv_tokens = kProbeDispatchTokens * runtime.num_ranks;
+    const size_t x_bytes = static_cast<size_t>(kProbeDispatchTokens) * kProbeDispatchHidden * sizeof(nv_bfloat16);
+    const size_t recv_x_bytes = static_cast<size_t>(max_recv_tokens) * kProbeDispatchHidden * sizeof(nv_bfloat16);
+    const size_t topk_idx_bytes = static_cast<size_t>(kProbeDispatchTokens) * kProbeDispatchTopK * sizeof(int64_t);
+    const size_t recv_topk_idx_bytes = static_cast<size_t>(max_recv_tokens) * kProbeDispatchTopK * sizeof(int64_t);
+    const size_t topk_weights_bytes = static_cast<size_t>(kProbeDispatchTokens) * kProbeDispatchTopK * sizeof(float);
+    const size_t recv_topk_weights_bytes = static_cast<size_t>(max_recv_tokens) * kProbeDispatchTopK * sizeof(float);
+    const size_t recv_src_idx_bytes = static_cast<size_t>(max_recv_tokens) * sizeof(int);
+    const size_t send_head_bytes = static_cast<size_t>(kProbeDispatchTokens) * runtime.num_ranks * sizeof(int);
+    const size_t token_rank_bytes = static_cast<size_t>(kProbeDispatchTokens) * runtime.num_ranks * sizeof(bool);
+    const size_t channel_prefix_bytes =
+        static_cast<size_t>(runtime.num_ranks) * runtime.dispatch_num_channels() * sizeof(int);
+
+    void* recv_x = allocate_zeroed(recv_x_bytes, "cudaMalloc(probe recv_x)");
+    void* recv_src_idx = allocate_zeroed(recv_src_idx_bytes, "cudaMalloc(probe recv_src_idx)");
+    void* recv_topk_idx = allocate_zeroed(recv_topk_idx_bytes, "cudaMalloc(probe recv_topk_idx)");
+    void* recv_topk_weights = allocate_zeroed(recv_topk_weights_bytes, "cudaMalloc(probe recv_topk_weights)");
+    void* send_head = allocate_zeroed(send_head_bytes, "cudaMalloc(probe send_head)");
+    void* x = allocate_zeroed(x_bytes, "cudaMalloc(probe x)");
+    void* topk_idx = allocate_zeroed(topk_idx_bytes, "cudaMalloc(probe topk_idx)");
+    void* topk_weights = allocate_zeroed(topk_weights_bytes, "cudaMalloc(probe topk_weights)");
+    void* is_token_in_rank = allocate_zeroed(token_rank_bytes, "cudaMalloc(probe is_token_in_rank)");
+    void* channel_prefix_matrix = allocate_zeroed(channel_prefix_bytes, "cudaMalloc(probe channel_prefix_matrix)");
+
+#if defined(LEVANTER_DEEPEP_EXTENDED_INTRNODE_DISPATCH)
+    deep_ep::intranode::dispatch(
+        recv_x,
+        nullptr,
+        nullptr,
+        reinterpret_cast<int*>(recv_src_idx),
+        reinterpret_cast<int64_t*>(recv_topk_idx),
+        reinterpret_cast<float*>(recv_topk_weights),
+        runtime.recv_channel_offset_scratch,
+        reinterpret_cast<int*>(send_head),
+        x,
+        nullptr,
+        nullptr,
+        reinterpret_cast<const int64_t*>(topk_idx),
+        reinterpret_cast<const float*>(topk_weights),
+        reinterpret_cast<const bool*>(is_token_in_rank),
+        reinterpret_cast<const int*>(channel_prefix_matrix),
+        kProbeDispatchTokens,
+        0,
+        hidden_int4,
+        kProbeDispatchTopK,
+        kProbeDispatchExperts,
+        0,
+        0,
+        0,
+        0,
+        0,
+        0,
+        runtime.buffer_ptrs_gpu,
+        runtime.rank,
+        runtime.num_ranks,
+        runtime.aux_stream,
+        runtime.dispatch_config.num_sms,
+        runtime.dispatch_config.num_max_send_tokens,
+        runtime.dispatch_config.num_max_recv_tokens);
+#else
+    deep_ep::intranode::dispatch(
+        recv_x,
+        nullptr,
+        reinterpret_cast<int*>(recv_src_idx),
+        reinterpret_cast<int64_t*>(recv_topk_idx),
+        reinterpret_cast<float*>(recv_topk_weights),
+        runtime.recv_channel_offset_scratch,
+        reinterpret_cast<int*>(send_head),
+        x,
+        nullptr,
+        reinterpret_cast<const int64_t*>(topk_idx),
+        reinterpret_cast<const float*>(topk_weights),
+        reinterpret_cast<const bool*>(is_token_in_rank),
+        reinterpret_cast<const int*>(channel_prefix_matrix),
+        kProbeDispatchTokens,
+        0,
+        hidden_int4,
+        kProbeDispatchTopK,
+        kProbeDispatchExperts,
+        0,
+        0,
+        0,
+        runtime.buffer_ptrs_gpu,
+        runtime.rank,
+        runtime.num_ranks,
+        runtime.aux_stream,
+        runtime.dispatch_config.num_sms,
+        runtime.dispatch_config.num_max_send_tokens,
+        runtime.dispatch_config.num_max_recv_tokens);
+#endif
+    ThrowOnCuda(cudaStreamSynchronize(runtime.aux_stream), "cudaStreamSynchronize(probe dispatch)");
+
+    for (void* ptr : allocations) {
+      cudaFree(ptr);
+    }
+
+    SetLastError("");
+    return 0;
+  } catch (const std::exception& exc) {
+    SetLastError(exc.what());
+    return 1;
+  }
+}
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    levanter_deepep_dispatch_intranode,
+    DispatchIntranode,
+    DispatchBinding());
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    levanter_deepep_dispatch_intranode_cached,
+    DispatchIntranodeCached,
+    DispatchCachedBinding());
+
+XLA_FFI_DEFINE_HANDLER_SYMBOL(
+    levanter_deepep_combine_intranode,
+    CombineIntranode,
+    CombineBinding());

--- a/lib/levanter/src/levanter/kernels/deepep/csrc/deepep_transport_pyext.cc
+++ b/lib/levanter/src/levanter/kernels/deepep/csrc/deepep_transport_pyext.cc
@@ -1,0 +1,29 @@
+// Copyright The Levanter Authors
+// SPDX-License-Identifier: Apache-2.0
+
+#include <Python.h>
+
+#define LEVANTER_STRINGIFY_IMPL(value) #value
+#define LEVANTER_STRINGIFY(value) LEVANTER_STRINGIFY_IMPL(value)
+#define LEVANTER_PYINIT_NAME_IMPL(name) PyInit_##name
+#define LEVANTER_PYINIT_NAME(name) LEVANTER_PYINIT_NAME_IMPL(name)
+
+#ifndef LEVANTER_DEEPEP_PYEXT_MODULE_NAME
+#error "LEVANTER_DEEPEP_PYEXT_MODULE_NAME must be defined"
+#endif
+
+namespace {
+
+PyModuleDef kModuleDef = {
+    PyModuleDef_HEAD_INIT,
+    LEVANTER_STRINGIFY(LEVANTER_DEEPEP_PYEXT_MODULE_NAME),
+    nullptr,
+    -1,
+    nullptr,
+};
+
+}  // namespace
+
+extern "C" PyMODINIT_FUNC LEVANTER_PYINIT_NAME(LEVANTER_DEEPEP_PYEXT_MODULE_NAME)(void) {
+  return PyModule_Create(&kModuleDef);
+}

--- a/lib/levanter/src/levanter/kernels/deepep/layout_ffi.py
+++ b/lib/levanter/src/levanter/kernels/deepep/layout_ffi.py
@@ -1,0 +1,135 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""JAX FFI wrapper for DeepEP's CUDA dispatch-layout kernel.
+
+This wrapper intentionally targets the narrowest DeepEP entry point that has a
+raw CUDA API and no Torch process-group dependency:
+`deep_ep::layout::get_dispatch_layout`.
+"""
+
+from __future__ import annotations
+
+import ctypes
+import hashlib
+import os
+import subprocess
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import jaxlib
+
+_TARGET_NAME = "levanter_deepep_get_dispatch_layout"
+_DEEPEP_SRC_ENV = "DEEPEP_SRC_ROOT"
+
+
+def _jaxlib_include_dir() -> Path:
+    return Path(jaxlib.__file__).resolve().parent / "include"
+
+
+def _repo_root() -> Path:
+    return Path(__file__).resolve().parents[6]
+
+
+def _ffi_source() -> Path:
+    return Path(__file__).resolve().parent / "csrc" / "deepep_layout_ffi.cu"
+
+
+def _deepep_source_root() -> Path:
+    raw = os.environ.get(_DEEPEP_SRC_ENV)
+    if not raw:
+        raise RuntimeError(
+            f"{_DEEPEP_SRC_ENV} must point at a DeepEP checkout before using the DeepEP JAX FFI layout kernel."
+        )
+    root = Path(raw).expanduser().resolve()
+    if not (root / "csrc" / "kernels" / "layout.cu").is_file():
+        raise RuntimeError(f"{_DEEPEP_SRC_ENV}={root} does not look like a DeepEP source checkout")
+    return root
+
+
+def _cache_root() -> Path:
+    return Path.home() / ".cache" / "marin" / "deepep_layout_ffi"
+
+
+def _shared_library_path() -> Path:
+    deepep_root = _deepep_source_root()
+    key = hashlib.sha256()
+    for path in (_ffi_source(), deepep_root / "csrc" / "kernels" / "layout.cu"):
+        key.update(path.read_bytes())
+    key.update(str(_jaxlib_include_dir()).encode("utf-8"))
+    key.update(str(deepep_root).encode("utf-8"))
+    digest = key.hexdigest()[:16]
+    out_dir = _cache_root() / digest
+    out_dir.mkdir(parents=True, exist_ok=True)
+    return out_dir / "libdeepep_layout_ffi.so"
+
+
+def _build_shared_library(out_path: Path) -> None:
+    deepep_root = _deepep_source_root()
+    jax_include = _jaxlib_include_dir()
+    cmd = [
+        "nvcc",
+        "-std=c++17",
+        "-shared",
+        "-Xcompiler",
+        "-fPIC",
+        "-O3",
+        "-DDISABLE_NVSHMEM",
+        "-I",
+        str(jax_include),
+        "-I",
+        str(deepep_root),
+        "-I",
+        str(deepep_root / "csrc"),
+        str(_ffi_source()),
+        str(deepep_root / "csrc" / "kernels" / "layout.cu"),
+        "-o",
+        str(out_path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def _load_library() -> ctypes.CDLL:
+    lib_path = _shared_library_path()
+    if not lib_path.exists():
+        _build_shared_library(lib_path)
+    return ctypes.cdll.LoadLibrary(str(lib_path))
+
+
+def _register_target() -> None:
+    if getattr(_register_target, "_done", False):
+        return
+    library = _load_library()
+    handler = getattr(library, _TARGET_NAME)
+    handler.restype = ctypes.c_void_p
+    jax.ffi.register_ffi_target(
+        _TARGET_NAME,
+        jax.ffi.pycapsule(handler),
+        platform="CUDA",
+        api_version=1,
+    )
+    jax.ffi.register_ffi_target_as_batch_partitionable(_TARGET_NAME)
+    _register_target._done = True
+
+
+def deepep_get_dispatch_layout(
+    topk_idx: jax.Array,
+    *,
+    num_ranks: int,
+    num_experts: int,
+) -> tuple[jax.Array, jax.Array, jax.Array]:
+    """Run DeepEP's CUDA dispatch-layout kernel via JAX FFI."""
+    _register_target()
+    topk_idx_i64 = jnp.asarray(topk_idx, dtype=jnp.int64)
+    tokens, topk = topk_idx_i64.shape
+    result_shape_dtypes = (
+        jax.ShapeDtypeStruct((num_ranks,), jnp.int32),
+        jax.ShapeDtypeStruct((num_experts,), jnp.int32),
+        jax.ShapeDtypeStruct((tokens, num_ranks), jnp.bool_),
+    )
+    return jax.ffi.ffi_call(
+        _TARGET_NAME,
+        result_shape_dtypes,
+        vmap_method="broadcast_all",
+    )(topk_idx_i64)

--- a/lib/levanter/src/levanter/kernels/deepep/layout_ffi.py
+++ b/lib/levanter/src/levanter/kernels/deepep/layout_ffi.py
@@ -12,24 +12,24 @@ from __future__ import annotations
 
 import ctypes
 import hashlib
-import os
 import subprocess
 from pathlib import Path
 
 import jax
 import jax.numpy as jnp
 import jaxlib
+from levanter.kernels.deepep.availability import (
+    LAYOUT_REQUIRED_FILES,
+    deepep_cache_root,
+    deepep_cuda_arch_flag,
+    deepep_source_root,
+)
 
 _TARGET_NAME = "levanter_deepep_get_dispatch_layout"
-_DEEPEP_SRC_ENV = "DEEPEP_SRC_ROOT"
 
 
 def _jaxlib_include_dir() -> Path:
     return Path(jaxlib.__file__).resolve().parent / "include"
-
-
-def _repo_root() -> Path:
-    return Path(__file__).resolve().parents[6]
 
 
 def _ffi_source() -> Path:
@@ -37,19 +37,11 @@ def _ffi_source() -> Path:
 
 
 def _deepep_source_root() -> Path:
-    raw = os.environ.get(_DEEPEP_SRC_ENV)
-    if not raw:
-        raise RuntimeError(
-            f"{_DEEPEP_SRC_ENV} must point at a DeepEP checkout before using the DeepEP JAX FFI layout kernel."
-        )
-    root = Path(raw).expanduser().resolve()
-    if not (root / "csrc" / "kernels" / "layout.cu").is_file():
-        raise RuntimeError(f"{_DEEPEP_SRC_ENV}={root} does not look like a DeepEP source checkout")
-    return root
+    return deepep_source_root(required_files=LAYOUT_REQUIRED_FILES, purpose="the DeepEP JAX FFI layout kernel")
 
 
 def _cache_root() -> Path:
-    return Path.home() / ".cache" / "marin" / "deepep_layout_ffi"
+    return deepep_cache_root("deepep_layout_ffi")
 
 
 def _shared_library_path() -> Path:
@@ -59,6 +51,7 @@ def _shared_library_path() -> Path:
         key.update(path.read_bytes())
     key.update(str(_jaxlib_include_dir()).encode("utf-8"))
     key.update(str(deepep_root).encode("utf-8"))
+    key.update(" ".join(deepep_cuda_arch_flag()).encode("utf-8"))
     digest = key.hexdigest()[:16]
     out_dir = _cache_root() / digest
     out_dir.mkdir(parents=True, exist_ok=True)
@@ -76,6 +69,7 @@ def _build_shared_library(out_path: Path) -> None:
         "-fPIC",
         "-O3",
         "-DDISABLE_NVSHMEM",
+        *deepep_cuda_arch_flag(),
         "-I",
         str(jax_include),
         "-I",

--- a/lib/levanter/src/levanter/kernels/deepep/preflight.py
+++ b/lib/levanter/src/levanter/kernels/deepep/preflight.py
@@ -1,0 +1,52 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""CLI preflight check for Levanter's DeepEP JAX FFI integration."""
+
+from __future__ import annotations
+
+import argparse
+import sys
+
+from levanter.kernels.deepep.availability import (
+    LAYOUT_REQUIRED_FILES,
+    TRANSPORT_REQUIRED_FILES,
+    deepep_install_help,
+    deepep_preflight_status,
+)
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--component",
+        choices=("layout", "transport"),
+        default="transport",
+        help="DeepEP FFI component to check. Transport includes layout dependencies.",
+    )
+    args = parser.parse_args(argv)
+
+    required_files = LAYOUT_REQUIRED_FILES if args.component == "layout" else TRANSPORT_REQUIRED_FILES
+    cache_component = "deepep_layout_ffi" if args.component == "layout" else "deepep_transport_ffi"
+    status = deepep_preflight_status(required_files=required_files, component=cache_component)
+
+    print("DeepEP preflight")
+    print(f"  component: {args.component}")
+    print(f"  source_root: {status.source_root or '<unset>'}")
+    print(f"  cache_root: {status.cache_root}")
+    print(f"  cuda_arch: {status.cuda_arch}")
+    print(f"  nvcc: {status.nvcc_path or '<missing>'}")
+    for warning in status.warnings:
+        print(f"  warning: {warning}")
+    for error in status.errors:
+        print(f"  error: {error}")
+
+    if not status.ok:
+        print()
+        print(deepep_install_help())
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/levanter/src/levanter/kernels/deepep/transport_ffi.py
+++ b/lib/levanter/src/levanter/kernels/deepep/transport_ffi.py
@@ -1,0 +1,1180 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""JAX FFI wrappers for DeepEP's intranode dispatch/combine kernels."""
+
+from __future__ import annotations
+
+import atexit
+import ctypes
+import hashlib
+import importlib.machinery
+import importlib.util
+import os
+import shutil
+import subprocess
+import sys
+import sysconfig
+from dataclasses import dataclass
+from functools import partial
+from pathlib import Path
+
+import jax
+import jax.numpy as jnp
+import jaxlib
+import numpy as np
+
+_DISPATCH_TARGET = "levanter_deepep_dispatch_intranode"
+_DISPATCH_CACHED_TARGET = "levanter_deepep_dispatch_intranode_cached"
+_COMBINE_TARGET = "levanter_deepep_combine_intranode"
+_INIT_SYMBOL = "levanter_deepep_init_intranode_runtime"
+_SHUTDOWN_SYMBOL = "levanter_deepep_shutdown_intranode_runtime"
+_LAST_ERROR_SYMBOL = "levanter_deepep_last_error"
+_PROBE_DISPATCH_SYMBOL = "levanter_deepep_probe_dispatch_kernel_attributes"
+_RUN_HOST_DISPATCH_SYMBOL = "levanter_deepep_run_host_dispatch_round"
+_DEEPEP_SRC_ENV = "DEEPEP_SRC_ROOT"
+_DEEPEP_CUDA_ARCH_ENV = "DEEPEP_CUDA_ARCH"
+_DISABLE_SM90_ENV = "DISABLE_SM90_FEATURES"
+_BUILD_WITH_TORCH_EXTENSION_ENV = "DEEPEP_BUILD_WITH_TORCH_EXTENSION"
+_LOAD_AS_PYTHON_MODULE_ENV = "DEEPEP_LOAD_AS_PYTHON_MODULE"
+_EXTENDED_INTRNODE_DISPATCH_MACRO = "LEVANTER_DEEPEP_EXTENDED_INTRNODE_DISPATCH"
+_PYEXT_MODULE_NAME_MACRO = "LEVANTER_DEEPEP_PYEXT_MODULE_NAME"
+_BUILD_CACHE_SCHEMA_VERSION = "transport_ffi_raw_dlink_v5"
+_LIBRARY_DLOPEN_MODE = getattr(os, "RTLD_NOW", 0) | getattr(ctypes, "RTLD_GLOBAL", 0)
+
+
+@dataclass(frozen=True)
+class IntranodeConfig:
+    num_sms: int
+    num_max_send_tokens: int
+    num_max_recv_tokens: int
+
+
+@dataclass(frozen=True)
+class BuildArtifact:
+    library_path: Path
+    module_name: str | None
+
+
+_DEFAULT_DISPATCH_CONFIGS = {
+    2: IntranodeConfig(num_sms=20, num_max_send_tokens=24, num_max_recv_tokens=256),
+    4: IntranodeConfig(num_sms=20, num_max_send_tokens=6, num_max_recv_tokens=256),
+    8: IntranodeConfig(num_sms=20, num_max_send_tokens=6, num_max_recv_tokens=256),
+}
+
+_DEFAULT_COMBINE_CONFIGS = {
+    2: IntranodeConfig(num_sms=20, num_max_send_tokens=10, num_max_recv_tokens=256),
+    4: IntranodeConfig(num_sms=20, num_max_send_tokens=9, num_max_recv_tokens=256),
+    8: IntranodeConfig(num_sms=20, num_max_send_tokens=4, num_max_recv_tokens=256),
+}
+
+
+def _jaxlib_include_dir() -> Path:
+    return Path(jaxlib.__file__).resolve().parent / "include"
+
+
+def _ffi_source() -> Path:
+    return Path(__file__).resolve().parent / "csrc" / "deepep_transport_ffi.cu"
+
+
+def _python_extension_source() -> Path:
+    return Path(__file__).resolve().parent / "csrc" / "deepep_transport_pyext.cc"
+
+
+def _cuda_sources(deepep_root: Path) -> tuple[Path, ...]:
+    return (
+        _ffi_source(),
+        deepep_root / "csrc" / "kernels" / "runtime.cu",
+        deepep_root / "csrc" / "kernels" / "layout.cu",
+        deepep_root / "csrc" / "kernels" / "intranode.cu",
+    )
+
+
+def _deepep_source_root() -> Path:
+    raw = os.environ.get(_DEEPEP_SRC_ENV)
+    if not raw:
+        raise RuntimeError(
+            f"{_DEEPEP_SRC_ENV} must point at a DeepEP checkout before using the DeepEP JAX FFI transport kernels."
+        )
+    root = Path(raw).expanduser().resolve()
+    required = (
+        root / "csrc" / "kernels" / "layout.cu",
+        root / "csrc" / "kernels" / "runtime.cu",
+        root / "csrc" / "kernels" / "intranode.cu",
+    )
+    if not all(path.is_file() for path in required):
+        raise RuntimeError(f"{_DEEPEP_SRC_ENV}={root} does not look like a DeepEP source checkout")
+    return root
+
+
+def _cache_root() -> Path:
+    return Path.home() / ".cache" / "marin" / "deepep_transport_ffi"
+
+
+def _python_extension_suffix() -> str:
+    suffix = sysconfig.get_config_var("EXT_SUFFIX")
+    if suffix:
+        return suffix
+    if not importlib.machinery.EXTENSION_SUFFIXES:
+        raise RuntimeError("Could not determine the Python extension suffix for DeepEP transport FFI")
+    return importlib.machinery.EXTENSION_SUFFIXES[0]
+
+
+def _python_include_dirs() -> tuple[Path, ...]:
+    include_dirs: list[Path] = []
+    for key in ("include", "platinclude"):
+        raw = sysconfig.get_paths().get(key)
+        if not raw:
+            continue
+        path = Path(raw)
+        if path not in include_dirs:
+            include_dirs.append(path)
+    if not include_dirs:
+        raise RuntimeError("Could not determine Python include directories for DeepEP transport FFI")
+    return tuple(include_dirs)
+
+
+def _cuda_arch_flag() -> list[str]:
+    arch = os.environ.get(_DEEPEP_CUDA_ARCH_ENV, "sm_90").strip()
+    if not arch.startswith("sm_"):
+        raise RuntimeError(f"{_DEEPEP_CUDA_ARCH_ENV} must look like sm_90, sm_90a, or sm_100, got {arch!r}")
+    compute = arch.replace("sm_", "compute_", 1)
+    return [f"-gencode=arch={compute},code={arch}"]
+
+
+def _sm90_compile_flags() -> list[str]:
+    if int(os.environ.get(_DISABLE_SM90_ENV, "0")):
+        return ["-DDISABLE_SM90_FEATURES"]
+    return []
+
+
+def _use_torch_extension_build() -> bool:
+    return bool(int(os.environ.get(_BUILD_WITH_TORCH_EXTENSION_ENV, "0")))
+
+
+def _load_as_python_module() -> bool:
+    return bool(int(os.environ.get(_LOAD_AS_PYTHON_MODULE_ENV, "0")))
+
+
+def _torch_cuda_arch_list() -> str:
+    if int(os.environ.get(_DISABLE_SM90_ENV, "0")):
+        return "8.0"
+    arch = os.environ.get(_DEEPEP_CUDA_ARCH_ENV, "sm_90").strip()
+    if arch == "sm_90":
+        return "9.0"
+    if arch == "sm_90a":
+        return "9.0a"
+    if arch == "sm_100":
+        return "10.0"
+    raise RuntimeError(f"Unsupported {_DEEPEP_CUDA_ARCH_ENV}={arch!r} for torch extension build")
+
+
+def _preload_torch_shared_libraries() -> None:
+    import torch
+
+    lib_dir = Path(torch.__file__).resolve().parent / "lib"
+    if not lib_dir.is_dir():
+        raise RuntimeError(f"Could not find Torch shared libraries under {lib_dir}")
+    torch_libraries = (
+        "libc10.so",
+        "libc10_cuda.so",
+        "libtorch_cpu.so",
+        "libtorch_cuda.so",
+        "libtorch.so",
+        "libtorch_python.so",
+    )
+    for library_name in torch_libraries:
+        library_path = lib_dir / library_name
+        if not library_path.is_file():
+            continue
+        ctypes.CDLL(str(library_path), mode=_LIBRARY_DLOPEN_MODE)
+
+
+def _build_artifact() -> BuildArtifact:
+    deepep_root = _deepep_source_root()
+    key = hashlib.sha256()
+    sources = _cuda_sources(deepep_root) + (
+        deepep_root / "csrc" / "config.hpp",
+        deepep_root / "csrc" / "kernels" / "api.cuh",
+        deepep_root / "csrc" / "kernels" / "configs.cuh",
+    )
+    for path in sources:
+        key.update(path.read_bytes())
+    if _load_as_python_module():
+        key.update(_python_extension_source().read_bytes())
+    key.update(Path(__file__).read_bytes())
+    key.update(str(_jaxlib_include_dir()).encode("utf-8"))
+    key.update(str(deepep_root).encode("utf-8"))
+    key.update(_BUILD_CACHE_SCHEMA_VERSION.encode("utf-8"))
+    key.update(" ".join(_cuda_arch_flag()).encode("utf-8"))
+    key.update(" ".join(_sm90_compile_flags()).encode("utf-8"))
+    key.update(str(int(_has_extended_intranode_dispatch_signature(deepep_root))).encode("utf-8"))
+    key.update(str(int(_use_torch_extension_build())).encode("utf-8"))
+    key.update(str(int(_load_as_python_module())).encode("utf-8"))
+    digest = key.hexdigest()[:16]
+    out_dir = _cache_root() / digest
+    out_dir.mkdir(parents=True, exist_ok=True)
+    if _load_as_python_module():
+        module_name = f"deepep_transport_ffi_{digest}"
+        return BuildArtifact(
+            library_path=out_dir / f"{module_name}{_python_extension_suffix()}",
+            module_name=module_name,
+        )
+    return BuildArtifact(library_path=out_dir / "libdeepep_transport_ffi.so", module_name=None)
+
+
+def _shared_library_path() -> Path:
+    return _build_artifact().library_path
+
+
+def _nvcc_common_flags(deepep_root: Path, compatibility_flags: list[str]) -> list[str]:
+    return [
+        "-std=c++17",
+        "-Xcompiler",
+        "-fPIC",
+        "--expt-relaxed-constexpr",
+        "-O3",
+        "-DDISABLE_NVSHMEM",
+        "-DDISABLE_AGGRESSIVE_PTX_INSTRS",
+        *compatibility_flags,
+        *_sm90_compile_flags(),
+        *_cuda_arch_flag(),
+        "-I",
+        str(_jaxlib_include_dir()),
+        "-I",
+        str(deepep_root),
+        "-I",
+        str(deepep_root / "csrc"),
+    ]
+
+
+def _build_object_files(
+    *,
+    build_dir: Path,
+    deepep_root: Path,
+    compatibility_flags: list[str],
+) -> list[Path]:
+    objects_dir = build_dir / "objects"
+    objects_dir.mkdir(parents=True, exist_ok=True)
+    common_flags = _nvcc_common_flags(deepep_root, compatibility_flags)
+    compile_flags = [
+        "nvcc",
+        *common_flags,
+        "-rdc=true",
+        "--ptxas-options=--register-usage-level=10",
+        "-c",
+    ]
+
+    object_paths: list[Path] = []
+    for source in _cuda_sources(deepep_root):
+        object_path = objects_dir / f"{source.stem}.o"
+        cmd = [
+            *compile_flags,
+            str(source),
+            "-o",
+            str(object_path),
+        ]
+        subprocess.run(cmd, check=True)
+        object_paths.append(object_path)
+    return object_paths
+
+
+def _build_python_extension_shim_object(*, build_dir: Path, module_name: str) -> Path:
+    object_path = build_dir / "deepep_transport_pyext.o"
+    include_flags: list[str] = []
+    for include_dir in _python_include_dirs():
+        include_flags.extend(["-I", str(include_dir)])
+    cmd = [
+        "c++",
+        "-std=c++17",
+        "-O3",
+        "-fPIC",
+        f"-D{_PYEXT_MODULE_NAME_MACRO}={module_name}",
+        *include_flags,
+        "-c",
+        str(_python_extension_source()),
+        "-o",
+        str(object_path),
+    ]
+    subprocess.run(cmd, check=True)
+    return object_path
+
+
+def _device_link_objects(
+    *,
+    build_dir: Path,
+    deepep_root: Path,
+    compatibility_flags: list[str],
+    object_paths: list[Path],
+) -> Path:
+    dlink_object = build_dir / "deepep_transport_ffi.dlink.o"
+    common_flags = _nvcc_common_flags(deepep_root, compatibility_flags)
+    cmd = [
+        "nvcc",
+        *common_flags,
+        "-dlink",
+        *[str(path) for path in object_paths],
+        "-o",
+        str(dlink_object),
+    ]
+    subprocess.run(cmd, check=True)
+    return dlink_object
+
+
+def _link_shared_library(
+    *,
+    out_path: Path,
+    object_paths: list[Path],
+    dlink_object: Path,
+    extra_object_paths: list[Path] | None = None,
+) -> None:
+    all_object_paths = [*object_paths, *(extra_object_paths or [])]
+    cmd = [
+        "nvcc",
+        "-shared",
+        "-Xcompiler",
+        "-fPIC",
+        "--cudart=shared",
+        *_cuda_arch_flag(),
+        *[str(path) for path in all_object_paths],
+        str(dlink_object),
+        "-lcuda",
+        "-o",
+        str(out_path),
+    ]
+    subprocess.run(cmd, check=True)
+
+
+def _build_raw_shared_library(artifact: BuildArtifact, deepep_root: Path, compatibility_flags: list[str]) -> None:
+    if _use_torch_extension_build() and _load_as_python_module():
+        raise RuntimeError(
+            f"{_BUILD_WITH_TORCH_EXTENSION_ENV}=1 is not yet supported with {_LOAD_AS_PYTHON_MODULE_ENV}=1"
+        )
+    out_path = artifact.library_path
+    build_dir = out_path.parent / "raw_build"
+    build_dir.mkdir(parents=True, exist_ok=True)
+    object_paths = _build_object_files(
+        build_dir=build_dir,
+        deepep_root=deepep_root,
+        compatibility_flags=compatibility_flags,
+    )
+    dlink_object = _device_link_objects(
+        build_dir=build_dir,
+        deepep_root=deepep_root,
+        compatibility_flags=compatibility_flags,
+        object_paths=object_paths,
+    )
+    extra_object_paths: list[Path] = []
+    if artifact.module_name is not None:
+        extra_object_paths.append(
+            _build_python_extension_shim_object(build_dir=build_dir, module_name=artifact.module_name)
+        )
+    _link_shared_library(
+        out_path=out_path,
+        object_paths=object_paths,
+        dlink_object=dlink_object,
+        extra_object_paths=extra_object_paths,
+    )
+
+
+def _build_shared_library(artifact: BuildArtifact) -> None:
+    deepep_root = _deepep_source_root()
+    compatibility_flags = _compatibility_compile_flags(deepep_root)
+    out_path = artifact.library_path
+    if _use_torch_extension_build() and _load_as_python_module():
+        raise RuntimeError(
+            f"{_BUILD_WITH_TORCH_EXTENSION_ENV}=1 is not yet supported with {_LOAD_AS_PYTHON_MODULE_ENV}=1"
+        )
+    if _use_torch_extension_build():
+        _build_with_torch_extension(out_path, deepep_root, compatibility_flags)
+        return
+    _build_raw_shared_library(artifact, deepep_root, compatibility_flags)
+
+
+def _build_with_torch_extension(out_path: Path, deepep_root: Path, compatibility_flags: list[str]) -> None:
+    from torch.utils import cpp_extension
+
+    build_dir = out_path.parent
+    name = f"deepep_transport_ffi_{build_dir.name}"
+    previous_arch_list = os.environ.get("TORCH_CUDA_ARCH_LIST")
+    os.environ["TORCH_CUDA_ARCH_LIST"] = _torch_cuda_arch_list()
+    try:
+        cpp_extension.load(
+            name=name,
+            sources=[
+                str(_ffi_source()),
+                str(deepep_root / "csrc" / "kernels" / "runtime.cu"),
+                str(deepep_root / "csrc" / "kernels" / "layout.cu"),
+                str(deepep_root / "csrc" / "kernels" / "intranode.cu"),
+            ],
+            extra_cuda_cflags=[
+                "-O3",
+                "-DDISABLE_NVSHMEM",
+                "-DDISABLE_AGGRESSIVE_PTX_INSTRS",
+                *compatibility_flags,
+                "-rdc=true",
+                "--ptxas-options=--register-usage-level=10",
+                *_sm90_compile_flags(),
+            ],
+            extra_include_paths=[
+                str(_jaxlib_include_dir()),
+                str(deepep_root),
+                str(deepep_root / "csrc"),
+            ],
+            build_directory=str(build_dir),
+            verbose=True,
+            with_cuda=True,
+            is_python_module=False,
+        )
+    finally:
+        if previous_arch_list is None:
+            os.environ.pop("TORCH_CUDA_ARCH_LIST", None)
+        else:
+            os.environ["TORCH_CUDA_ARCH_LIST"] = previous_arch_list
+
+    suffixes = importlib.machinery.EXTENSION_SUFFIXES
+    candidates = []
+    for suffix in suffixes:
+        candidates.extend(build_dir.glob(f"{name}*{suffix}"))
+    if not candidates:
+        raise RuntimeError(f"torch cpp_extension did not produce a shared library in {build_dir}")
+    built_path = max(candidates, key=lambda path: path.stat().st_mtime)
+    if built_path != out_path:
+        shutil.copy2(built_path, out_path)
+
+
+def _load_torch_extension_python_module(artifact: BuildArtifact):
+    if artifact.module_name is None:
+        raise RuntimeError("Torch extension Python-module load requires a module-named build artifact")
+
+    cached_module = getattr(_load_torch_extension_python_module, "_module", None)
+    cached_path = getattr(_load_torch_extension_python_module, "_path", None)
+    if cached_module is not None and cached_path == artifact.library_path:
+        return cached_module
+
+    deepep_root = _deepep_source_root()
+    compatibility_flags = _compatibility_compile_flags(deepep_root)
+    build_dir = artifact.library_path.parent
+    build_dir.mkdir(parents=True, exist_ok=True)
+    setup_path = build_dir / "setup.py"
+    setup_path.write_text(
+        "\n".join(
+            (
+                "from setuptools import setup",
+                "from torch.utils.cpp_extension import BuildExtension, CUDAExtension",
+                "",
+                f"MODULE_NAME = {artifact.module_name!r}",
+                f"SOURCES = {([str(_python_extension_source()), str(_ffi_source()), *[str(path) for path in _cuda_sources(deepep_root)[1:]]])!r}",
+                f"INCLUDE_DIRS = {[str(_jaxlib_include_dir()), str(deepep_root), str(deepep_root / 'csrc')]!r}",
+                f"CXX_FLAGS = {['-O3', f'-D{_PYEXT_MODULE_NAME_MACRO}={artifact.module_name}']!r}",
+                (
+                    "NVCC_FLAGS = "
+                    + repr(
+                        [
+                            "-O3",
+                            "-DDISABLE_NVSHMEM",
+                            "-DDISABLE_AGGRESSIVE_PTX_INSTRS",
+                            *compatibility_flags,
+                            "-rdc=true",
+                            "--ptxas-options=--register-usage-level=10",
+                            *_sm90_compile_flags(),
+                        ]
+                    )
+                ),
+                "NVCC_DLINK_FLAGS = ['-dlink']",
+                "",
+                "setup(",
+                "    name=MODULE_NAME,",
+                "    ext_modules=[",
+                "        CUDAExtension(",
+                "            name=MODULE_NAME,",
+                "            sources=SOURCES,",
+                "            include_dirs=INCLUDE_DIRS,",
+                "            extra_compile_args={",
+                "                'cxx': CXX_FLAGS,",
+                "                'nvcc': NVCC_FLAGS,",
+                "                'nvcc_dlink': NVCC_DLINK_FLAGS,",
+                "            },",
+                "            extra_link_args=['-lcuda'],",
+                "            dlink=True,",
+                "        )",
+                "    ],",
+                "    cmdclass={'build_ext': BuildExtension},",
+                ")",
+            )
+        )
+        + "\n"
+    )
+    build_env = os.environ.copy()
+    build_env["TORCH_CUDA_ARCH_LIST"] = _torch_cuda_arch_list()
+    subprocess.run(
+        [sys.executable, str(setup_path), "build_ext", "--inplace"],
+        cwd=build_dir,
+        env=build_env,
+        check=True,
+    )
+    if not artifact.library_path.exists():
+        candidates = sorted(build_dir.glob(f"{artifact.module_name}*{_python_extension_suffix()}"))
+        if not candidates:
+            raise RuntimeError(f"CUDAExtension build did not produce {artifact.library_path.name} in {build_dir}")
+        if candidates[-1] != artifact.library_path:
+            shutil.copy2(candidates[-1], artifact.library_path)
+
+    _preload_torch_shared_libraries()
+    module = _load_python_module(artifact)
+    module_path = Path(module.__file__).resolve()
+    _load_torch_extension_python_module._module = module
+    _load_torch_extension_python_module._path = module_path
+    return module
+
+
+def _has_extended_intranode_dispatch_signature(deepep_root: Path) -> bool:
+    api_header = deepep_root / "csrc" / "kernels" / "api.cuh"
+    return "recv_x_sf_scale_for_nvfp4" in api_header.read_text()
+
+
+def _compatibility_compile_flags(deepep_root: Path) -> list[str]:
+    if _has_extended_intranode_dispatch_signature(deepep_root):
+        return [f"-D{_EXTENDED_INTRNODE_DISPATCH_MACRO}=1"]
+    return []
+
+
+def _load_library() -> ctypes.CDLL:
+    artifact = _build_artifact()
+    if _use_torch_extension_build() and _load_as_python_module():
+        module = _load_torch_extension_python_module(artifact)
+        return ctypes.CDLL(str(Path(module.__file__).resolve()), mode=_LIBRARY_DLOPEN_MODE)
+    if not artifact.library_path.exists():
+        _build_shared_library(artifact)
+    if artifact.module_name is not None:
+        module = _load_python_module(artifact)
+        return ctypes.CDLL(str(Path(module.__file__).resolve()), mode=_LIBRARY_DLOPEN_MODE)
+    return ctypes.CDLL(str(artifact.library_path), mode=_LIBRARY_DLOPEN_MODE)
+
+
+def _load_python_module(artifact: BuildArtifact):
+    if artifact.module_name is None:
+        raise RuntimeError("Build artifact does not describe a Python extension module")
+    cached_module = getattr(_load_python_module, "_module", None)
+    cached_path = getattr(_load_python_module, "_path", None)
+    if cached_module is not None and cached_path == artifact.library_path:
+        return cached_module
+
+    spec = importlib.util.spec_from_file_location(artifact.module_name, artifact.library_path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"Could not create a Python extension spec for {artifact.library_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[artifact.module_name] = module
+    spec.loader.exec_module(module)
+    _load_python_module._module = module
+    _load_python_module._path = artifact.library_path
+    return module
+
+
+def _register_targets() -> None:
+    if getattr(_register_targets, "_done", False):
+        return
+    library = _load_library()
+    for target in (_DISPATCH_TARGET, _DISPATCH_CACHED_TARGET, _COMBINE_TARGET):
+        handler = getattr(library, target)
+        handler.restype = ctypes.c_void_p
+        jax.ffi.register_ffi_target(
+            target,
+            jax.ffi.pycapsule(handler),
+            platform="CUDA",
+            api_version=1,
+        )
+        jax.ffi.register_ffi_target_as_batch_partitionable(target)
+    _register_targets._done = True
+
+
+def _library_function(name: str):
+    library = _load_library()
+    return getattr(library, name)
+
+
+def _materialize_cotangent(
+    cotangent: jax.Array | jax.custom_derivatives.SymbolicZero,
+    *,
+    dtype: jnp.dtype,
+    shape: tuple[int, ...] | None = None,
+    reference: jax.Array | None = None,
+) -> jax.Array:
+    if reference is None and shape is None:
+        raise ValueError("Either reference or shape must be provided when materializing a cotangent.")
+    if isinstance(cotangent, jax.custom_derivatives.SymbolicZero):
+        if reference is not None:
+            return jnp.zeros_like(reference, dtype=dtype)
+        return jnp.zeros(shape, dtype=dtype)
+    return jnp.asarray(cotangent, dtype=dtype)
+
+
+def _default_dispatch_config(num_ranks: int) -> IntranodeConfig:
+    if num_ranks not in _DEFAULT_DISPATCH_CONFIGS:
+        raise ValueError(f"Unsupported DeepEP intranode dispatch rank count: {num_ranks}")
+    return _DEFAULT_DISPATCH_CONFIGS[num_ranks]
+
+
+def _default_combine_config(num_ranks: int) -> IntranodeConfig:
+    if num_ranks not in _DEFAULT_COMBINE_CONFIGS:
+        raise ValueError(f"Unsupported DeepEP intranode combine rank count: {num_ranks}")
+    return _DEFAULT_COMBINE_CONFIGS[num_ranks]
+
+
+def shutdown_intranode_runtime() -> None:
+    if getattr(ensure_intranode_runtime, "_signature", None) is None:
+        return
+    shutdown = _library_function(_SHUTDOWN_SYMBOL)
+    shutdown.argtypes = []
+    shutdown.restype = None
+    shutdown()
+    setattr(ensure_intranode_runtime, "_signature", None)
+
+
+atexit.register(shutdown_intranode_runtime)
+
+
+def ensure_intranode_runtime(
+    *,
+    num_ranks: int,
+    hidden_bytes: int,
+    dispatch_config: IntranodeConfig | None = None,
+    combine_config: IntranodeConfig | None = None,
+) -> None:
+    _register_targets()
+    dispatch = dispatch_config or _default_dispatch_config(num_ranks)
+    combine = combine_config or _default_combine_config(num_ranks)
+    signature = (num_ranks, hidden_bytes, dispatch, combine)
+    if getattr(ensure_intranode_runtime, "_signature", None) == signature:
+        return
+
+    local_gpu_devices = [device for device in jax.local_devices() if device.platform == "gpu"]
+    if len(local_gpu_devices) != num_ranks:
+        raise RuntimeError(
+            f"DeepEP JAX intranode runtime currently expects the expert group to span all visible local GPUs; "
+            f"got num_ranks={num_ranks} and visible_gpus={len(local_gpu_devices)}."
+        )
+
+    init = _library_function(_INIT_SYMBOL)
+    init.argtypes = [
+        ctypes.c_int,
+        ctypes.c_int64,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+        ctypes.c_int,
+    ]
+    init.restype = ctypes.c_int
+
+    status = init(
+        num_ranks,
+        hidden_bytes,
+        dispatch.num_sms,
+        dispatch.num_max_send_tokens,
+        dispatch.num_max_recv_tokens,
+        combine.num_sms,
+        combine.num_max_send_tokens,
+        combine.num_max_recv_tokens,
+    )
+    if status != 0:
+        last_error = _library_function(_LAST_ERROR_SYMBOL)
+        last_error.argtypes = []
+        last_error.restype = ctypes.c_char_p
+        message = last_error()
+        text = message.decode("utf-8") if message else "unknown error"
+        raise RuntimeError(f"Failed to initialize DeepEP intranode JAX runtime: {text}")
+    ensure_intranode_runtime._signature = signature
+
+
+def probe_dispatch_kernel_attributes() -> dict[str, int | str]:
+    """Call the DeepEP dispatch host wrapper outside XLA execution."""
+    probe = _library_function(_PROBE_DISPATCH_SYMBOL)
+    probe.argtypes = []
+    probe.restype = ctypes.c_int
+
+    status = probe()
+    result: dict[str, int | str] = {"probe_status_code": int(status)}
+    last_error = _library_function(_LAST_ERROR_SYMBOL)
+    last_error.argtypes = []
+    last_error.restype = ctypes.c_char_p
+    message = last_error()
+    text = message.decode("utf-8") if message else ""
+    result["last_error"] = text
+    if status != 0:
+        raise RuntimeError(f"Failed to probe DeepEP dispatch kernel attributes: {text}")
+    return result
+
+
+def run_host_dispatch_round(
+    *,
+    num_tokens: int,
+    hidden: int,
+    num_experts: int,
+    num_topk: int,
+) -> dict[str, int | str]:
+    """Run a same-process all-ranks dispatch round outside XLA execution."""
+    run = _library_function(_RUN_HOST_DISPATCH_SYMBOL)
+    run.argtypes = [ctypes.c_int, ctypes.c_int, ctypes.c_int, ctypes.c_int]
+    run.restype = ctypes.c_int
+
+    status = run(num_tokens, hidden, num_experts, num_topk)
+    result: dict[str, int | str] = {
+        "host_dispatch_status_code": int(status),
+        "num_tokens": int(num_tokens),
+        "hidden": int(hidden),
+        "num_experts": int(num_experts),
+        "num_topk": int(num_topk),
+    }
+    last_error = _library_function(_LAST_ERROR_SYMBOL)
+    last_error.argtypes = []
+    last_error.restype = ctypes.c_char_p
+    message = last_error()
+    text = message.decode("utf-8") if message else ""
+    result["last_error"] = text
+    if status != 0:
+        raise RuntimeError(f"Failed to run DeepEP host dispatch round: {text}")
+    return result
+
+
+def _resolve_runtime(
+    *,
+    x: jax.Array,
+    num_ranks: int,
+    dispatch_config: IntranodeConfig | None,
+    combine_config: IntranodeConfig | None,
+) -> IntranodeConfig:
+    _register_targets()
+    hidden_bytes = x.shape[1] * max(jnp.dtype(x.dtype).itemsize, 2)
+    ensure_intranode_runtime(
+        num_ranks=num_ranks,
+        hidden_bytes=hidden_bytes,
+        dispatch_config=dispatch_config,
+        combine_config=combine_config,
+    )
+    return dispatch_config or _default_dispatch_config(num_ranks)
+
+
+def _dispatch_intranode_impl(
+    x: jax.Array,
+    topk_idx: jax.Array,
+    topk_weights: jax.Array,
+    num_tokens_per_rank: jax.Array,
+    num_tokens_per_expert: jax.Array,
+    is_token_in_rank: jax.Array,
+    *,
+    num_experts: int,
+    dispatch_config: IntranodeConfig | None,
+    combine_config: IntranodeConfig | None,
+    max_recv_tokens: int | None,
+) -> tuple[
+    jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array
+]:
+    num_ranks = int(num_tokens_per_rank.shape[0])
+    resolved_dispatch_config = _resolve_runtime(
+        x=x,
+        num_ranks=num_ranks,
+        dispatch_config=dispatch_config,
+        combine_config=combine_config,
+    )
+
+    x_bf16 = jnp.asarray(x, dtype=jnp.bfloat16)
+    topk_idx_i64 = jnp.asarray(topk_idx, dtype=jnp.int64)
+    topk_weights_f32 = jnp.asarray(topk_weights, dtype=jnp.float32)
+    num_tokens_per_rank_i32 = jnp.asarray(num_tokens_per_rank, dtype=jnp.int32)
+    num_tokens_per_expert_i32 = jnp.asarray(num_tokens_per_expert, dtype=jnp.int32)
+    local_experts = num_experts // num_ranks
+    if max_recv_tokens is None:
+        max_recv_tokens = x_bf16.shape[0] * num_ranks
+    elif max_recv_tokens <= 0:
+        raise ValueError(f"max_recv_tokens must be positive, got {max_recv_tokens}")
+    num_channels = resolved_dispatch_config.num_sms // 2
+    topk = topk_idx_i64.shape[1]
+    result_shape_dtypes = (
+        jax.ShapeDtypeStruct((max_recv_tokens, x_bf16.shape[1]), x_bf16.dtype),
+        jax.ShapeDtypeStruct((max_recv_tokens, topk), jnp.int64),
+        jax.ShapeDtypeStruct((max_recv_tokens, topk), jnp.float32),
+        jax.ShapeDtypeStruct((max_recv_tokens,), jnp.int32),
+        jax.ShapeDtypeStruct((num_ranks, num_ranks), jnp.int32),
+        jax.ShapeDtypeStruct((num_ranks, num_channels), jnp.int32),
+        jax.ShapeDtypeStruct((num_ranks, num_channels), jnp.int32),
+        jax.ShapeDtypeStruct((x_bf16.shape[0], num_ranks), jnp.int32),
+        jax.ShapeDtypeStruct((local_experts,), jnp.int32),
+        jax.ShapeDtypeStruct((1,), jnp.int32),
+    )
+    return jax.ffi.ffi_call(
+        _DISPATCH_TARGET,
+        result_shape_dtypes,
+        has_side_effect=True,
+        vmap_method="broadcast_all",
+    )(
+        x_bf16,
+        topk_idx_i64,
+        topk_weights_f32,
+        num_tokens_per_rank_i32,
+        num_tokens_per_expert_i32,
+        is_token_in_rank,
+        num_experts=np.int32(num_experts),
+    )
+
+
+def _dispatch_intranode_cached_impl(
+    x: jax.Array,
+    is_token_in_rank: jax.Array,
+    rank_prefix_matrix: jax.Array,
+    channel_prefix_matrix: jax.Array,
+    num_recv_tokens: jax.Array,
+    *,
+    dispatch_config: IntranodeConfig | None,
+    combine_config: IntranodeConfig | None,
+    max_recv_tokens: int,
+) -> jax.Array:
+    if max_recv_tokens <= 0:
+        raise ValueError(f"max_recv_tokens must be positive, got {max_recv_tokens}")
+    num_ranks = int(rank_prefix_matrix.shape[0])
+    resolved_dispatch_config = _resolve_runtime(
+        x=x,
+        num_ranks=num_ranks,
+        dispatch_config=dispatch_config,
+        combine_config=combine_config,
+    )
+
+    x_bf16 = jnp.asarray(x, dtype=jnp.bfloat16)
+    is_token_in_rank_bool = jnp.asarray(is_token_in_rank, dtype=jnp.bool_)
+    rank_prefix_matrix_i32 = jnp.asarray(rank_prefix_matrix, dtype=jnp.int32)
+    channel_prefix_matrix_i32 = jnp.asarray(channel_prefix_matrix, dtype=jnp.int32)
+    num_recv_tokens_i32 = jnp.asarray(num_recv_tokens, dtype=jnp.int32)
+    num_channels = resolved_dispatch_config.num_sms // 2
+    result_shape_dtypes = (
+        jax.ShapeDtypeStruct((max_recv_tokens, x_bf16.shape[1]), x_bf16.dtype),
+        jax.ShapeDtypeStruct((max_recv_tokens,), jnp.int32),
+        jax.ShapeDtypeStruct((num_ranks, num_channels), jnp.int32),
+        jax.ShapeDtypeStruct((x_bf16.shape[0], num_ranks), jnp.int32),
+    )
+    recv_x, _, _, _ = jax.ffi.ffi_call(
+        _DISPATCH_CACHED_TARGET,
+        result_shape_dtypes,
+        has_side_effect=True,
+        vmap_method="broadcast_all",
+    )(
+        x_bf16,
+        is_token_in_rank_bool,
+        rank_prefix_matrix_i32,
+        channel_prefix_matrix_i32,
+        num_recv_tokens_i32,
+    )
+    recv_token_limit = jnp.squeeze(num_recv_tokens_i32, axis=0)
+    recv_valid = jnp.arange(max_recv_tokens, dtype=jnp.int32) < recv_token_limit
+    return jnp.where(recv_valid[:, None], recv_x, 0)
+
+
+def _combine_intranode_impl(
+    recv_x: jax.Array,
+    recv_topk_weights: jax.Array,
+    recv_src_idx: jax.Array,
+    rank_prefix_matrix: jax.Array,
+    channel_prefix_matrix: jax.Array,
+    send_head: jax.Array,
+    num_recv_tokens: jax.Array,
+) -> tuple[jax.Array, jax.Array]:
+    _register_targets()
+    recv_x_bf16 = jnp.asarray(recv_x, dtype=jnp.bfloat16)
+    recv_topk_weights_f32 = jnp.asarray(recv_topk_weights, dtype=jnp.float32)
+    recv_src_idx_i32 = jnp.asarray(recv_src_idx, dtype=jnp.int32)
+    rank_prefix_matrix_i32 = jnp.asarray(rank_prefix_matrix, dtype=jnp.int32)
+    channel_prefix_matrix_i32 = jnp.asarray(channel_prefix_matrix, dtype=jnp.int32)
+    send_head_i32 = jnp.asarray(send_head, dtype=jnp.int32)
+    num_recv_tokens_i32 = jnp.asarray(num_recv_tokens, dtype=jnp.int32)
+    topk = recv_topk_weights_f32.shape[1]
+    result_shape_dtypes = (
+        jax.ShapeDtypeStruct((send_head_i32.shape[0], recv_x_bf16.shape[1]), recv_x_bf16.dtype),
+        jax.ShapeDtypeStruct((send_head_i32.shape[0], topk), jnp.float32),
+        jax.ShapeDtypeStruct(send_head_i32.shape, send_head_i32.dtype),
+    )
+    combined_x, combined_topk_weights, _ = jax.ffi.ffi_call(
+        _COMBINE_TARGET,
+        result_shape_dtypes,
+        has_side_effect=True,
+        vmap_method="broadcast_all",
+        input_output_aliases={5: 2},
+    )(
+        recv_x_bf16,
+        recv_topk_weights_f32,
+        recv_src_idx_i32,
+        rank_prefix_matrix_i32,
+        channel_prefix_matrix_i32,
+        send_head_i32,
+        num_recv_tokens_i32,
+    )
+    return combined_x, combined_topk_weights
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(6, 7, 8, 9))
+def _dispatch_intranode_with_vjp(
+    x: jax.Array,
+    topk_idx: jax.Array,
+    topk_weights: jax.Array,
+    num_tokens_per_rank: jax.Array,
+    num_tokens_per_expert: jax.Array,
+    is_token_in_rank: jax.Array,
+    num_experts: int,
+    dispatch_config: IntranodeConfig | None,
+    combine_config: IntranodeConfig | None,
+    max_recv_tokens: int | None,
+) -> tuple[
+    jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array
+]:
+    return _dispatch_intranode_impl(
+        x,
+        topk_idx,
+        topk_weights,
+        num_tokens_per_rank,
+        num_tokens_per_expert,
+        is_token_in_rank,
+        num_experts=num_experts,
+        dispatch_config=dispatch_config,
+        combine_config=combine_config,
+        max_recv_tokens=max_recv_tokens,
+    )
+
+
+def _dispatch_intranode_with_vjp_fwd(
+    x: jax.Array,
+    topk_idx: jax.Array,
+    topk_weights: jax.Array,
+    num_tokens_per_rank: jax.Array,
+    num_tokens_per_expert: jax.Array,
+    is_token_in_rank: jax.Array,
+    num_experts: int,
+    dispatch_config: IntranodeConfig | None,
+    combine_config: IntranodeConfig | None,
+    max_recv_tokens: int | None,
+):
+    outputs = _dispatch_intranode_impl(
+        x,
+        topk_idx,
+        topk_weights,
+        num_tokens_per_rank,
+        num_tokens_per_expert,
+        is_token_in_rank,
+        num_experts=num_experts,
+        dispatch_config=dispatch_config,
+        combine_config=combine_config,
+        max_recv_tokens=max_recv_tokens,
+    )
+    (
+        recv_x,
+        _,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        _,
+        recv_channel_prefix_matrix,
+        send_head,
+        _,
+        num_recv_tokens,
+    ) = outputs
+    residuals = (
+        recv_x,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+    )
+    return outputs, residuals
+
+
+def _dispatch_intranode_with_vjp_bwd(
+    num_experts: int,
+    dispatch_config: IntranodeConfig | None,
+    combine_config: IntranodeConfig | None,
+    max_recv_tokens: int | None,
+    residuals,
+    cotangents,
+):
+    (
+        recv_x,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+    ) = residuals
+    grad_recv_x = _materialize_cotangent(cotangents[0], dtype=recv_x.dtype, reference=recv_x)
+    grad_recv_topk_weights = _materialize_cotangent(
+        cotangents[2],
+        dtype=recv_topk_weights.dtype,
+        reference=recv_topk_weights,
+    )
+    grad_x, grad_topk_weights = _combine_intranode_impl(
+        grad_recv_x,
+        grad_recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+    )
+    return grad_x, None, grad_topk_weights, None, None, None
+
+
+_dispatch_intranode_with_vjp.defvjp(
+    _dispatch_intranode_with_vjp_fwd,
+    _dispatch_intranode_with_vjp_bwd,
+)
+
+
+@jax.custom_vjp
+def _combine_intranode_with_vjp(
+    recv_x: jax.Array,
+    recv_topk_weights: jax.Array,
+    recv_src_idx: jax.Array,
+    rank_prefix_matrix: jax.Array,
+    dispatch_channel_prefix_matrix: jax.Array,
+    recv_channel_prefix_matrix: jax.Array,
+    send_head: jax.Array,
+    num_recv_tokens: jax.Array,
+    is_token_in_rank: jax.Array,
+) -> tuple[jax.Array, jax.Array]:
+    return _combine_intranode_impl(
+        recv_x,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+    )
+
+
+def _combine_intranode_with_vjp_fwd(
+    recv_x: jax.Array,
+    recv_topk_weights: jax.Array,
+    recv_src_idx: jax.Array,
+    rank_prefix_matrix: jax.Array,
+    dispatch_channel_prefix_matrix: jax.Array,
+    recv_channel_prefix_matrix: jax.Array,
+    send_head: jax.Array,
+    num_recv_tokens: jax.Array,
+    is_token_in_rank: jax.Array,
+):
+    outputs = _combine_intranode_impl(
+        recv_x,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+    )
+    residuals = (
+        recv_x,
+        recv_topk_weights,
+        rank_prefix_matrix,
+        dispatch_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+        is_token_in_rank,
+    )
+    return outputs, residuals
+
+
+def _combine_intranode_with_vjp_bwd(residuals, cotangents):
+    (
+        recv_x,
+        recv_topk_weights,
+        rank_prefix_matrix,
+        dispatch_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+        is_token_in_rank,
+    ) = residuals
+    grad_combined_x = _materialize_cotangent(
+        cotangents[0],
+        dtype=recv_x.dtype,
+        shape=(send_head.shape[0], recv_x.shape[1]),
+    )
+    grad_recv_x = _dispatch_intranode_cached_impl(
+        grad_combined_x,
+        is_token_in_rank,
+        rank_prefix_matrix,
+        dispatch_channel_prefix_matrix,
+        num_recv_tokens,
+        dispatch_config=None,
+        combine_config=None,
+        max_recv_tokens=recv_x.shape[0],
+    )
+    return (
+        grad_recv_x,
+        jnp.zeros_like(recv_topk_weights),
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+        None,
+    )
+
+
+_combine_intranode_with_vjp.defvjp(
+    _combine_intranode_with_vjp_fwd,
+    _combine_intranode_with_vjp_bwd,
+)
+
+
+def deepep_dispatch_intranode(
+    x: jax.Array,
+    topk_idx: jax.Array,
+    topk_weights: jax.Array,
+    num_tokens_per_rank: jax.Array,
+    num_tokens_per_expert: jax.Array,
+    is_token_in_rank: jax.Array,
+    *,
+    num_experts: int,
+    dispatch_config: IntranodeConfig | None = None,
+    combine_config: IntranodeConfig | None = None,
+    max_recv_tokens: int | None = None,
+) -> tuple[
+    jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array, jax.Array
+]:
+    return _dispatch_intranode_with_vjp(
+        x,
+        topk_idx,
+        topk_weights,
+        num_tokens_per_rank,
+        num_tokens_per_expert,
+        is_token_in_rank,
+        num_experts,
+        dispatch_config,
+        combine_config,
+        max_recv_tokens,
+    )
+
+
+def deepep_combine_intranode(
+    recv_x: jax.Array,
+    recv_topk_weights: jax.Array,
+    recv_src_idx: jax.Array,
+    rank_prefix_matrix: jax.Array,
+    dispatch_channel_prefix_matrix: jax.Array,
+    recv_channel_prefix_matrix: jax.Array,
+    send_head: jax.Array,
+    num_recv_tokens: jax.Array,
+    is_token_in_rank: jax.Array,
+) -> tuple[jax.Array, jax.Array]:
+    return _combine_intranode_with_vjp(
+        recv_x,
+        recv_topk_weights,
+        recv_src_idx,
+        rank_prefix_matrix,
+        dispatch_channel_prefix_matrix,
+        recv_channel_prefix_matrix,
+        send_head,
+        num_recv_tokens,
+        is_token_in_rank,
+    )

--- a/lib/levanter/src/levanter/kernels/deepep/transport_ffi.py
+++ b/lib/levanter/src/levanter/kernels/deepep/transport_ffi.py
@@ -23,6 +23,17 @@ import jax
 import jax.numpy as jnp
 import jaxlib
 import numpy as np
+from levanter.kernels.deepep.availability import (
+    BUILD_WITH_TORCH_EXTENSION_ENV,
+    DISABLE_SM90_ENV,
+    LOAD_AS_PYTHON_MODULE_ENV,
+    TRANSPORT_REQUIRED_FILES,
+    deepep_cache_root,
+    deepep_cuda_arch_flag,
+    deepep_source_root,
+    deepep_torch_cuda_arch_list,
+    env_flag,
+)
 
 _DISPATCH_TARGET = "levanter_deepep_dispatch_intranode"
 _DISPATCH_CACHED_TARGET = "levanter_deepep_dispatch_intranode_cached"
@@ -32,11 +43,6 @@ _SHUTDOWN_SYMBOL = "levanter_deepep_shutdown_intranode_runtime"
 _LAST_ERROR_SYMBOL = "levanter_deepep_last_error"
 _PROBE_DISPATCH_SYMBOL = "levanter_deepep_probe_dispatch_kernel_attributes"
 _RUN_HOST_DISPATCH_SYMBOL = "levanter_deepep_run_host_dispatch_round"
-_DEEPEP_SRC_ENV = "DEEPEP_SRC_ROOT"
-_DEEPEP_CUDA_ARCH_ENV = "DEEPEP_CUDA_ARCH"
-_DISABLE_SM90_ENV = "DISABLE_SM90_FEATURES"
-_BUILD_WITH_TORCH_EXTENSION_ENV = "DEEPEP_BUILD_WITH_TORCH_EXTENSION"
-_LOAD_AS_PYTHON_MODULE_ENV = "DEEPEP_LOAD_AS_PYTHON_MODULE"
 _EXTENDED_INTRNODE_DISPATCH_MACRO = "LEVANTER_DEEPEP_EXTENDED_INTRNODE_DISPATCH"
 _PYEXT_MODULE_NAME_MACRO = "LEVANTER_DEEPEP_PYEXT_MODULE_NAME"
 _BUILD_CACHE_SCHEMA_VERSION = "transport_ffi_raw_dlink_v5"
@@ -91,24 +97,11 @@ def _cuda_sources(deepep_root: Path) -> tuple[Path, ...]:
 
 
 def _deepep_source_root() -> Path:
-    raw = os.environ.get(_DEEPEP_SRC_ENV)
-    if not raw:
-        raise RuntimeError(
-            f"{_DEEPEP_SRC_ENV} must point at a DeepEP checkout before using the DeepEP JAX FFI transport kernels."
-        )
-    root = Path(raw).expanduser().resolve()
-    required = (
-        root / "csrc" / "kernels" / "layout.cu",
-        root / "csrc" / "kernels" / "runtime.cu",
-        root / "csrc" / "kernels" / "intranode.cu",
-    )
-    if not all(path.is_file() for path in required):
-        raise RuntimeError(f"{_DEEPEP_SRC_ENV}={root} does not look like a DeepEP source checkout")
-    return root
+    return deepep_source_root(required_files=TRANSPORT_REQUIRED_FILES, purpose="the DeepEP JAX FFI transport kernels")
 
 
 def _cache_root() -> Path:
-    return Path.home() / ".cache" / "marin" / "deepep_transport_ffi"
+    return deepep_cache_root("deepep_transport_ffi")
 
 
 def _python_extension_suffix() -> str:
@@ -135,38 +128,25 @@ def _python_include_dirs() -> tuple[Path, ...]:
 
 
 def _cuda_arch_flag() -> list[str]:
-    arch = os.environ.get(_DEEPEP_CUDA_ARCH_ENV, "sm_90").strip()
-    if not arch.startswith("sm_"):
-        raise RuntimeError(f"{_DEEPEP_CUDA_ARCH_ENV} must look like sm_90, sm_90a, or sm_100, got {arch!r}")
-    compute = arch.replace("sm_", "compute_", 1)
-    return [f"-gencode=arch={compute},code={arch}"]
+    return deepep_cuda_arch_flag()
 
 
 def _sm90_compile_flags() -> list[str]:
-    if int(os.environ.get(_DISABLE_SM90_ENV, "0")):
+    if env_flag(DISABLE_SM90_ENV):
         return ["-DDISABLE_SM90_FEATURES"]
     return []
 
 
 def _use_torch_extension_build() -> bool:
-    return bool(int(os.environ.get(_BUILD_WITH_TORCH_EXTENSION_ENV, "0")))
+    return env_flag(BUILD_WITH_TORCH_EXTENSION_ENV)
 
 
 def _load_as_python_module() -> bool:
-    return bool(int(os.environ.get(_LOAD_AS_PYTHON_MODULE_ENV, "0")))
+    return env_flag(LOAD_AS_PYTHON_MODULE_ENV)
 
 
 def _torch_cuda_arch_list() -> str:
-    if int(os.environ.get(_DISABLE_SM90_ENV, "0")):
-        return "8.0"
-    arch = os.environ.get(_DEEPEP_CUDA_ARCH_ENV, "sm_90").strip()
-    if arch == "sm_90":
-        return "9.0"
-    if arch == "sm_90a":
-        return "9.0a"
-    if arch == "sm_100":
-        return "10.0"
-    raise RuntimeError(f"Unsupported {_DEEPEP_CUDA_ARCH_ENV}={arch!r} for torch extension build")
+    return deepep_torch_cuda_arch_list()
 
 
 def _preload_torch_shared_libraries() -> None:
@@ -348,7 +328,7 @@ def _link_shared_library(
 def _build_raw_shared_library(artifact: BuildArtifact, deepep_root: Path, compatibility_flags: list[str]) -> None:
     if _use_torch_extension_build() and _load_as_python_module():
         raise RuntimeError(
-            f"{_BUILD_WITH_TORCH_EXTENSION_ENV}=1 is not yet supported with {_LOAD_AS_PYTHON_MODULE_ENV}=1"
+            f"{BUILD_WITH_TORCH_EXTENSION_ENV}=1 is not yet supported with {LOAD_AS_PYTHON_MODULE_ENV}=1"
         )
     out_path = artifact.library_path
     build_dir = out_path.parent / "raw_build"
@@ -383,7 +363,7 @@ def _build_shared_library(artifact: BuildArtifact) -> None:
     out_path = artifact.library_path
     if _use_torch_extension_build() and _load_as_python_module():
         raise RuntimeError(
-            f"{_BUILD_WITH_TORCH_EXTENSION_ENV}=1 is not yet supported with {_LOAD_AS_PYTHON_MODULE_ENV}=1"
+            f"{BUILD_WITH_TORCH_EXTENSION_ENV}=1 is not yet supported with {LOAD_AS_PYTHON_MODULE_ENV}=1"
         )
     if _use_torch_extension_build():
         _build_with_torch_extension(out_path, deepep_root, compatibility_flags)

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -171,6 +171,10 @@ def test_moe_mlp_default_matches_explicit_ring_without_ep_axis():
     np.testing.assert_allclose(np.asarray(y_default), np.asarray(y_ring), rtol=1e-5, atol=1e-5)
 
 
+def test_resolve_moe_implementation_accepts_deepep_backend():
+    assert grug_moe.resolve_moe_implementation("deepep") == "deepep"
+
+
 def test_prepare_moe_dispatch_indices_match_materialized_dispatch():
     x, selected_experts, combine_weights, _w_up_gate, _w_down = _make_inputs(
         key=jax.random.key(28),

--- a/lib/levanter/tests/kernels/test_deepep_availability.py
+++ b/lib/levanter/tests/kernels/test_deepep_availability.py
@@ -1,0 +1,57 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pytest
+
+from levanter.kernels.deepep.availability import (
+    DEEPEP_CACHE_ENV,
+    DEEPEP_CUDA_ARCH_ENV,
+    DEEPEP_SRC_ENV,
+    TRANSPORT_REQUIRED_FILES,
+    deepep_cache_root,
+    deepep_cuda_arch_flag,
+    deepep_source_root,
+)
+
+
+def _write_deepep_skeleton(root: Path, files: tuple[str, ...] = TRANSPORT_REQUIRED_FILES) -> None:
+    for relative in files:
+        path = root / relative
+        path.parent.mkdir(parents=True, exist_ok=True)
+        path.write_text("// test\n")
+
+
+def test_deepep_source_root_accepts_required_source_tree(tmp_path, monkeypatch):
+    _write_deepep_skeleton(tmp_path)
+    monkeypatch.setenv(DEEPEP_SRC_ENV, str(tmp_path))
+
+    assert deepep_source_root(required_files=TRANSPORT_REQUIRED_FILES, purpose="test") == tmp_path.resolve()
+
+
+def test_deepep_source_root_reports_missing_files(tmp_path, monkeypatch):
+    _write_deepep_skeleton(tmp_path, files=("csrc/kernels/layout.cu",))
+    monkeypatch.setenv(DEEPEP_SRC_ENV, str(tmp_path))
+
+    with pytest.raises(RuntimeError, match="runtime.cu"):
+        deepep_source_root(required_files=TRANSPORT_REQUIRED_FILES, purpose="test")
+
+
+def test_deepep_cuda_arch_flag_supports_b200(monkeypatch):
+    monkeypatch.setenv(DEEPEP_CUDA_ARCH_ENV, "sm_100")
+
+    assert deepep_cuda_arch_flag() == ["-gencode=arch=compute_100,code=sm_100"]
+
+
+def test_deepep_cuda_arch_flag_rejects_unknown_arch(monkeypatch):
+    monkeypatch.setenv(DEEPEP_CUDA_ARCH_ENV, "compute_100")
+
+    with pytest.raises(RuntimeError, match=DEEPEP_CUDA_ARCH_ENV):
+        deepep_cuda_arch_flag()
+
+
+def test_deepep_cache_root_can_be_overridden(tmp_path, monkeypatch):
+    monkeypatch.setenv(DEEPEP_CACHE_ENV, str(tmp_path))
+
+    assert deepep_cache_root("deepep_transport_ffi") == tmp_path.resolve() / "deepep_transport_ffi"


### PR DESCRIPTION
Wire DeepEP dispatch and combine into the Grug expert-parallel MoE path and add installation preflight docs. Keep the pure-JAX token-ragged experiments and B200 research log on the branch to preserve the benchmark trail.

Part of #3841