### PR TITLE
[posttrain] Refresh NVIDIA science SFT datasets

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -38,6 +38,7 @@ Current datasets:
 23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
 24. lm-provers/FineProofs-SFT
 25. lm-provers/FineProofs-SFT/proof-only
+26. nvidia/Nemotron-Science-v1
 """
 
 import dataclasses
@@ -141,6 +142,7 @@ def multi_turn_adapter(
     metadata_remap: dict[str, str] | None = None,
     replacements: dict[str, str] | None = None,
     extra_metadata_fn=None,
+    message_passthrough_keys: Sequence[str] = (),
 ) -> TransformAdapter:
     return TransformAdapter(
         dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
@@ -153,6 +155,7 @@ def multi_turn_adapter(
         metadata_remap=metadata_remap or {},
         replacements=replacements,
         extra_metadata_fn=extra_metadata_fn,
+        message_passthrough_keys=tuple(message_passthrough_keys),
     )
 
 
@@ -256,6 +259,11 @@ FINEPROOFS_SFT_METADATA_COLUMNS = [
     "qwen3-4b-thinking-reward@128",
     "source",
 ]
+
+NEMOTRON_SCIENCE_V1_HF_ID = "nvidia/Nemotron-Science-v1"
+NEMOTRON_SCIENCE_V1_REVISION = "82e1af468197076b4f0f392c239274eac032adc7"
+NEMOTRON_SCIENCE_V1_SPLITS = ["MCQ", "RQA"]
+NEMOTRON_SCIENCE_V1_METADATA_COLUMNS = ["uuid", "license", "used_in"]
 
 
 INSTRUCTION_DATASET_NAME_TO_CONFIG = {
@@ -595,6 +603,18 @@ for split_name in NEMOTRON_V1_SPLITS:
         splits=[split_name],
     )
 
+for split_name in NEMOTRON_SCIENCE_V1_SPLITS:
+    dataset_key = f"{NEMOTRON_SCIENCE_V1_HF_ID}/{split_name}"
+    INSTRUCTION_DATASET_NAME_TO_CONFIG[dataset_key] = InstructionDatasetConfig(
+        name=dataset_key,
+        hf_dataset_id=NEMOTRON_SCIENCE_V1_HF_ID,
+        revision=NEMOTRON_SCIENCE_V1_REVISION,
+        adapter=multi_turn_adapter(message_passthrough_keys=("reasoning_content",)),
+        metadata_columns=NEMOTRON_SCIENCE_V1_METADATA_COLUMNS,
+        subsets=["default"],
+        splits=[split_name],
+    )
+
 
 def get_directory_friendly_dataset_name(hf_dataset_id: str) -> str:
     dataset_name = hf_dataset_id.replace("/", "--")
@@ -611,6 +631,8 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
 
     adapter_dict = dataclasses.asdict(adapter)
     adapter_dict["dataset_format"] = adapter_dict["dataset_format"].value
+    if not adapter_dict.get("message_passthrough_keys"):
+        adapter_dict.pop("message_passthrough_keys", None)
 
     def canonicalize(value):
         if isinstance(value, dict):

--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -38,7 +38,8 @@ Current datasets:
 23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
 24. lm-provers/FineProofs-SFT
 25. lm-provers/FineProofs-SFT/proof-only
-26. nvidia/Nemotron-Science-v1
+26. nvidia/Nemotron-SFT-Science-v2
+27. nvidia/OpenScienceReasoning-2
 """
 
 import dataclasses
@@ -260,10 +261,28 @@ FINEPROOFS_SFT_METADATA_COLUMNS = [
     "source",
 ]
 
-NEMOTRON_SCIENCE_V1_HF_ID = "nvidia/Nemotron-Science-v1"
-NEMOTRON_SCIENCE_V1_REVISION = "82e1af468197076b4f0f392c239274eac032adc7"
-NEMOTRON_SCIENCE_V1_SPLITS = ["MCQ", "RQA"]
-NEMOTRON_SCIENCE_V1_METADATA_COLUMNS = ["uuid", "license", "used_in"]
+NEMOTRON_SFT_SCIENCE_V2_HF_ID = "nvidia/Nemotron-SFT-Science-v2"
+NEMOTRON_SFT_SCIENCE_V2_REVISION = "6536a5021222a94126968e8c92f29ee47fc8a7df"
+NEMOTRON_SFT_SCIENCE_V2_SUBSETS = ["rqa", "so", "syn_mcq", "vendor"]
+NEMOTRON_SFT_SCIENCE_V2_METADATA_COLUMNS = ["uuid", "license", "used_in", "metadata", "tools"]
+NEMOTRON_SFT_SCIENCE_V2_MESSAGE_PASSTHROUGH_KEYS = (
+    "reasoning_content",
+    "tool_calls",
+    "function_call",
+    "tool_call_id",
+    "name",
+)
+
+OPENSCIENCE_REASONING_2_HF_ID = "nvidia/OpenScienceReasoning-2"
+OPENSCIENCE_REASONING_2_REVISION = "174b02c9cdf231f220765b2a1d5ece4550921894"
+OPENSCIENCE_REASONING_2_METADATA_COLUMNS = ["expected_answer"]
+
+
+def science_v2_extra_columns(row: dict[str, Any]) -> dict[str, Any]:
+    tools = row.get("tools")
+    if isinstance(tools, list) and tools:
+        return {"chat_template_kwargs": {"tools": tools}}
+    return {}
 
 
 INSTRUCTION_DATASET_NAME_TO_CONFIG = {
@@ -567,6 +586,18 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         name="nvidia/OpenMathReasoning/genselect",
         splits=["genselect"],
     ),
+    OPENSCIENCE_REASONING_2_HF_ID: InstructionDatasetConfig(
+        hf_dataset_id=OPENSCIENCE_REASONING_2_HF_ID,
+        revision=OPENSCIENCE_REASONING_2_REVISION,
+        adapter=instruction_response_adapter(
+            instruction_column="input",
+            response_column="output",
+        ),
+        metadata_columns=OPENSCIENCE_REASONING_2_METADATA_COLUMNS,
+        name=OPENSCIENCE_REASONING_2_HF_ID,
+        subsets=["default"],
+        splits=["train"],
+    ),
 }
 
 for split_name in SMOLTALK2_SPLITS:
@@ -603,16 +634,19 @@ for split_name in NEMOTRON_V1_SPLITS:
         splits=[split_name],
     )
 
-for split_name in NEMOTRON_SCIENCE_V1_SPLITS:
-    dataset_key = f"{NEMOTRON_SCIENCE_V1_HF_ID}/{split_name}"
+for subset_name in NEMOTRON_SFT_SCIENCE_V2_SUBSETS:
+    dataset_key = f"{NEMOTRON_SFT_SCIENCE_V2_HF_ID}/{subset_name}"
     INSTRUCTION_DATASET_NAME_TO_CONFIG[dataset_key] = InstructionDatasetConfig(
         name=dataset_key,
-        hf_dataset_id=NEMOTRON_SCIENCE_V1_HF_ID,
-        revision=NEMOTRON_SCIENCE_V1_REVISION,
-        adapter=multi_turn_adapter(message_passthrough_keys=("reasoning_content",)),
-        metadata_columns=NEMOTRON_SCIENCE_V1_METADATA_COLUMNS,
-        subsets=["default"],
-        splits=[split_name],
+        hf_dataset_id=NEMOTRON_SFT_SCIENCE_V2_HF_ID,
+        revision=NEMOTRON_SFT_SCIENCE_V2_REVISION,
+        adapter=multi_turn_adapter(
+            extra_metadata_fn=science_v2_extra_columns,
+            message_passthrough_keys=NEMOTRON_SFT_SCIENCE_V2_MESSAGE_PASSTHROUGH_KEYS,
+        ),
+        metadata_columns=NEMOTRON_SFT_SCIENCE_V2_METADATA_COLUMNS,
+        subsets=[subset_name],
+        splits=["train"],
     )
 
 

--- a/lib/marin/src/marin/transform/conversation/adapters.py
+++ b/lib/marin/src/marin/transform/conversation/adapters.py
@@ -87,6 +87,7 @@ class TransformAdapter:
     metadata_remap: dict[str, str] = field(default_factory=dict)
     replacements: dict[str, str] | None = None
     extra_metadata_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None
+    message_passthrough_keys: tuple[str, ...] = ()
 
     def transform_conversation_to_openai_format(
         self,
@@ -128,7 +129,10 @@ class TransformAdapter:
             conversation = row[self.conversation_column]
             for conv in conversation:
                 role = role_to_openai_role[conv[self.role_key]]
-                messages.append(OpenAIChatMessage(role=role, content=conv[self.content_key]))
+                extra_fields = {
+                    key: conv[key] for key in self.message_passthrough_keys if key in conv and conv[key] is not None
+                }
+                messages.append(OpenAIChatMessage(role=role, content=conv[self.content_key], **extra_fields))
             return messages
         elif self.dataset_format == InputDatasetFormat.INSTRUCT_COLUMN_RESPONSE:
             messages = []

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -10,10 +10,6 @@ from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_METADATA_COLUMNS,
     FINEPROOFS_SFT_REVISION,
     INSTRUCTION_DATASET_NAME_TO_CONFIG,
-    NEMOTRON_SCIENCE_V1_HF_ID,
-    NEMOTRON_SCIENCE_V1_METADATA_COLUMNS,
-    NEMOTRON_SCIENCE_V1_REVISION,
-    NEMOTRON_SCIENCE_V1_SPLITS,
     SYNTHETIC2_SFT_VERIFIED_HF_ID,
     SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
     SYNTHETIC2_SFT_VERIFIED_REVISION,
@@ -33,22 +29,81 @@ SYNTHETIC2_SFT_VERIFIED_OUTPUT_PATH = (
     f"documents/PrimeIntellect--SYNTHETIC-2-SFT-verified-{SYNTHETIC2_SFT_VERIFIED_REVISION}-409fa9"
 )
 
-NEMOTRON_SCIENCE_V1_SAMPLE = {
-    "uuid": "science-row-1",
-    "license": "cc-by-4.0",
+NEMOTRON_SFT_SCIENCE_V2_TOOL = {
+    "type": "function",
+    "function": {
+        "name": "evaluate_code",
+        "description": "Evaluates Python code.",
+        "parameters": {"type": "object", "properties": {"source_code": {"type": "string"}}},
+    },
+}
+
+NEMOTRON_SFT_SCIENCE_V2_SAMPLE = {
+    "uuid": "science-v2-row-1",
+    "license": "CC BY-SA 4.0",
     "used_in": ["nano_v3"],
+    "metadata": {
+        "topic": "Physics",
+        "subtopic": "Classical Mechanics",
+        "question_format": "MCQ",
+        "generation_model": "DeepSeek-V3.2",
+    },
     "messages": [
         {
             "role": "user",
-            "content": "Which choice best explains predictive genetic testing?",
-            "reasoning_content": None,
+            "content": "What is 2 + 2? Use the available tool and select the correct option.",
         },
         {
             "role": "assistant",
-            "content": "The Best Answer is C.",
-            "reasoning_content": "Predictive testing checks future disease risk in an asymptomatic person.",
+            "content": None,
+            "tool_calls": [
+                {
+                    "index": -1,
+                    "function": {"arguments": '{"source_code": "print(2 + 2)"}', "name": "evaluate_code"},
+                    "id": "call_calc",
+                    "type": "function",
+                }
+            ],
+            "function_call": None,
+            "reasoning_content": "I should compute the value exactly before selecting an option.",
+        },
+        {
+            "role": "tool",
+            "name": "evaluate_code",
+            "tool_call_id": "call_calc",
+            "content": "4",
+        },
+        {
+            "role": "assistant",
+            "content": "The correct option is 4.",
+            "tool_calls": None,
+            "function_call": None,
+            "reasoning_content": "The tool returned 4, so the arithmetic result is 4.",
         },
     ],
+    "tools": [NEMOTRON_SFT_SCIENCE_V2_TOOL],
+}
+
+EXPECTED_NEMOTRON_SFT_SCIENCE_V2_HF_ID = "nvidia/Nemotron-SFT-Science-v2"
+EXPECTED_NEMOTRON_SFT_SCIENCE_V2_REVISION = "6536a5021222a94126968e8c92f29ee47fc8a7df"
+EXPECTED_NEMOTRON_SFT_SCIENCE_V2_SUBSETS = ("rqa", "so", "syn_mcq", "vendor")
+EXPECTED_NEMOTRON_SFT_SCIENCE_V2_METADATA_COLUMNS = ["uuid", "license", "used_in", "metadata", "tools"]
+EXPECTED_NEMOTRON_SFT_SCIENCE_V2_MESSAGE_PASSTHROUGH_KEYS = (
+    "reasoning_content",
+    "tool_calls",
+    "function_call",
+    "tool_call_id",
+    "name",
+)
+
+EXPECTED_OPENSCIENCE_REASONING_2_HF_ID = "nvidia/OpenScienceReasoning-2"
+EXPECTED_OPENSCIENCE_REASONING_2_REVISION = "174b02c9cdf231f220765b2a1d5ece4550921894"
+EXPECTED_OPENSCIENCE_REASONING_2_METADATA_COLUMNS = ["expected_answer"]
+
+OPENSCIENCE_REASONING_2_SAMPLE = {
+    "expected_answer": "C",
+    "input": "Choose the answer. What does 2 + 2 equal?\n\nA: 3\nB: 5\nC: 4",
+    "output": "<think>\nAdd the two integers.\n</think>\nThe answer is \\boxed{C}.",
 }
 
 
@@ -135,9 +190,9 @@ def test_empty_message_passthrough_keys_preserve_existing_sft_output_path():
     assert step.override_output_path == SYNTHETIC2_SFT_VERIFIED_OUTPUT_PATH
 
 
-@pytest.mark.parametrize("split", NEMOTRON_SCIENCE_V1_SPLITS)
-def test_nemotron_science_v1_step_transforms_chat_rows(split):
-    dataset_key = f"{NEMOTRON_SCIENCE_V1_HF_ID}/{split}"
+@pytest.mark.parametrize("subset", EXPECTED_NEMOTRON_SFT_SCIENCE_V2_SUBSETS)
+def test_nemotron_sft_science_v2_lanes_are_registered(subset):
+    dataset_key = f"{EXPECTED_NEMOTRON_SFT_SCIENCE_V2_HF_ID}/{subset}"
     step = get_instruction_dataset(dataset_key)
     cfg = step.config
     adapter = unwrap_versioned_value(cfg.adapter)
@@ -145,39 +200,116 @@ def test_nemotron_science_v1_step_transforms_chat_rows(split):
     assert step.name == f"documents/{dataset_key}"
     assert step.override_output_path is not None
     assert step.override_output_path.startswith(
-        f"documents/nvidia--Nemotron-Science-v1--{split}-{NEMOTRON_SCIENCE_V1_REVISION}-"
+        f"documents/nvidia--Nemotron-SFT-Science-v2--{subset}-{EXPECTED_NEMOTRON_SFT_SCIENCE_V2_REVISION}-"
     )
-    assert unwrap_versioned_value(cfg.source) == NEMOTRON_SCIENCE_V1_HF_ID
-    assert unwrap_versioned_value(cfg.revision) == NEMOTRON_SCIENCE_V1_REVISION
-    assert unwrap_versioned_value(cfg.subsets) == ["default"]
-    assert unwrap_versioned_value(cfg.splits) == [split]
-    assert unwrap_versioned_value(cfg.metadata_columns) == NEMOTRON_SCIENCE_V1_METADATA_COLUMNS
+    assert unwrap_versioned_value(cfg.source) == EXPECTED_NEMOTRON_SFT_SCIENCE_V2_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == EXPECTED_NEMOTRON_SFT_SCIENCE_V2_REVISION
+    assert unwrap_versioned_value(cfg.subsets) == [subset]
+    assert unwrap_versioned_value(cfg.splits) == ["train"]
+    assert unwrap_versioned_value(cfg.metadata_columns) == EXPECTED_NEMOTRON_SFT_SCIENCE_V2_METADATA_COLUMNS
+    assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+    assert adapter.message_passthrough_keys == EXPECTED_NEMOTRON_SFT_SCIENCE_V2_MESSAGE_PASSTHROUGH_KEYS
 
-    result = transform_row(NEMOTRON_SCIENCE_V1_SAMPLE, cfg, adapter)
+
+def test_nemotron_sft_science_v2_tool_trace_preserves_training_fields():
+    step = get_instruction_dataset(f"{EXPECTED_NEMOTRON_SFT_SCIENCE_V2_HF_ID}/rqa")
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    result = transform_row(NEMOTRON_SFT_SCIENCE_V2_SAMPLE, cfg, adapter)
 
     assert result is not None
-    assert result.source == NEMOTRON_SCIENCE_V1_HF_ID
+    assert result.source == EXPECTED_NEMOTRON_SFT_SCIENCE_V2_HF_ID
     assert result.messages[0].model_dump(exclude_none=True) == {
         "role": "user",
-        "content": "Which choice best explains predictive genetic testing?",
+        "content": "What is 2 + 2? Use the available tool and select the correct option.",
     }
     assert result.messages[1].model_dump(exclude_none=True) == {
         "role": "assistant",
-        "content": "The Best Answer is C.",
-        "reasoning_content": "Predictive testing checks future disease risk in an asymptomatic person.",
+        "tool_calls": [
+            {
+                "index": -1,
+                "function": {"arguments": {"source_code": "print(2 + 2)"}, "name": "evaluate_code"},
+                "id": "call_calc",
+                "type": "function",
+            }
+        ],
+        "reasoning_content": "I should compute the value exactly before selecting an option.",
+    }
+    assert result.messages[2].model_dump(exclude_none=True) == {
+        "role": "tool",
+        "content": "4",
+        "name": "evaluate_code",
+        "tool_call_id": "call_calc",
+    }
+    assert result.messages[3].model_dump(exclude_none=True) == {
+        "role": "assistant",
+        "content": "The correct option is 4.",
+        "reasoning_content": "The tool returned 4, so the arithmetic result is 4.",
     }
     assert result.metadata == {
-        "uuid": "science-row-1",
-        "license": "cc-by-4.0",
+        "uuid": "science-v2-row-1",
+        "license": "CC BY-SA 4.0",
         "used_in": ["nano_v3"],
+        "metadata": {
+            "topic": "Physics",
+            "subtopic": "Classical Mechanics",
+            "question_format": "MCQ",
+            "generation_model": "DeepSeek-V3.2",
+        },
+        "tools": [NEMOTRON_SFT_SCIENCE_V2_TOOL],
     }
+    assert result.model_dump()["chat_template_kwargs"] == {"tools": [NEMOTRON_SFT_SCIENCE_V2_TOOL]}
 
 
-def test_nemotron_science_v1_split_steps_have_distinct_outputs():
-    output_paths = {
-        get_instruction_dataset(f"{NEMOTRON_SCIENCE_V1_HF_ID}/{split}").override_output_path
-        for split in NEMOTRON_SCIENCE_V1_SPLITS
+def test_nemotron_sft_science_v2_string_tools_column_stays_metadata_only():
+    step = get_instruction_dataset(f"{EXPECTED_NEMOTRON_SFT_SCIENCE_V2_HF_ID}/vendor")
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+    vendor_sample = {**NEMOTRON_SFT_SCIENCE_V2_SAMPLE, "tools": ""}
+
+    result = transform_row(vendor_sample, cfg, adapter)
+
+    assert result is not None
+    assert result.metadata["tools"] == ""
+    assert "chat_template_kwargs" not in result.model_dump()
+
+
+def test_nemotron_science_v1_lanes_are_replaced_by_science_v2():
+    assert all(
+        not dataset_key.startswith("nvidia/Nemotron-Science-v1/") for dataset_key in INSTRUCTION_DATASET_NAME_TO_CONFIG
+    )
+
+
+def test_openscience_reasoning_2_step_transforms_instruction_response_rows():
+    step = get_instruction_dataset(EXPECTED_OPENSCIENCE_REASONING_2_HF_ID)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    assert step.name == f"documents/{EXPECTED_OPENSCIENCE_REASONING_2_HF_ID}"
+    assert step.override_output_path is not None
+    assert step.override_output_path.startswith(
+        f"documents/nvidia--OpenScienceReasoning-2-{EXPECTED_OPENSCIENCE_REASONING_2_REVISION}-"
+    )
+    assert unwrap_versioned_value(cfg.source) == EXPECTED_OPENSCIENCE_REASONING_2_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == EXPECTED_OPENSCIENCE_REASONING_2_REVISION
+    assert unwrap_versioned_value(cfg.subsets) == ["default"]
+    assert unwrap_versioned_value(cfg.splits) == ["train"]
+    assert unwrap_versioned_value(cfg.metadata_columns) == EXPECTED_OPENSCIENCE_REASONING_2_METADATA_COLUMNS
+    assert adapter.dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE
+    assert adapter.instruction_column == "input"
+    assert adapter.response_column == "output"
+
+    result = transform_row(OPENSCIENCE_REASONING_2_SAMPLE, cfg, adapter)
+
+    assert result is not None
+    assert result.source == EXPECTED_OPENSCIENCE_REASONING_2_HF_ID
+    assert result.messages[0].model_dump(exclude_none=True) == {
+        "role": "user",
+        "content": "Choose the answer. What does 2 + 2 equal?\n\nA: 3\nB: 5\nC: 4",
     }
-
-    assert None not in output_paths
-    assert len(output_paths) == len(NEMOTRON_SCIENCE_V1_SPLITS)
+    assert result.messages[1].model_dump(exclude_none=True) == {
+        "role": "assistant",
+        "content": "<|start_think|>\nAdd the two integers.\n<|end_think|>\nThe answer is \\boxed{C}.",
+    }
+    assert result.metadata == {"expected_answer": "C"}

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
 from marin.execution.executor import unwrap_versioned_value
 from marin.transform.conversation.adapters import InputDatasetFormat
 from marin.transform.conversation.transform_conversation import transform_row
@@ -9,6 +10,10 @@ from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_METADATA_COLUMNS,
     FINEPROOFS_SFT_REVISION,
     INSTRUCTION_DATASET_NAME_TO_CONFIG,
+    NEMOTRON_SCIENCE_V1_HF_ID,
+    NEMOTRON_SCIENCE_V1_METADATA_COLUMNS,
+    NEMOTRON_SCIENCE_V1_REVISION,
+    NEMOTRON_SCIENCE_V1_SPLITS,
     SYNTHETIC2_SFT_VERIFIED_HF_ID,
     SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
     SYNTHETIC2_SFT_VERIFIED_REVISION,
@@ -22,6 +27,27 @@ SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
     "messages": [
         {"role": "user", "content": "Write Python code to count the intersection of two sets."},
         {"role": "assistant", "content": "<think>Use set intersection.</think>\n```python\nprint(len(a & b))\n```"},
+    ],
+}
+SYNTHETIC2_SFT_VERIFIED_OUTPUT_PATH = (
+    f"documents/PrimeIntellect--SYNTHETIC-2-SFT-verified-{SYNTHETIC2_SFT_VERIFIED_REVISION}-409fa9"
+)
+
+NEMOTRON_SCIENCE_V1_SAMPLE = {
+    "uuid": "science-row-1",
+    "license": "cc-by-4.0",
+    "used_in": ["nano_v3"],
+    "messages": [
+        {
+            "role": "user",
+            "content": "Which choice best explains predictive genetic testing?",
+            "reasoning_content": None,
+        },
+        {
+            "role": "assistant",
+            "content": "The Best Answer is C.",
+            "reasoning_content": "Predictive testing checks future disease risk in an asymptomatic person.",
+        },
     ],
 }
 
@@ -77,10 +103,6 @@ def test_synthetic2_sft_verified_step_transforms_chat_rows():
     adapter = unwrap_versioned_value(cfg.adapter)
 
     assert step.name == "documents/PrimeIntellect/SYNTHETIC-2-SFT-verified"
-    assert step.override_output_path is not None
-    assert step.override_output_path.startswith(
-        f"documents/PrimeIntellect--SYNTHETIC-2-SFT-verified-{SYNTHETIC2_SFT_VERIFIED_REVISION}-"
-    )
     assert unwrap_versioned_value(cfg.source) == SYNTHETIC2_SFT_VERIFIED_HF_ID
     assert unwrap_versioned_value(cfg.revision) == SYNTHETIC2_SFT_VERIFIED_REVISION
     assert unwrap_versioned_value(cfg.subsets) == ["default"]
@@ -105,3 +127,57 @@ def test_synthetic2_sft_verified_step_transforms_chat_rows():
         "task_type": "prime_rl_code",
         "reward": 1.0,
     }
+
+
+def test_empty_message_passthrough_keys_preserve_existing_sft_output_path():
+    step = get_instruction_dataset(SYNTHETIC2_SFT_VERIFIED_HF_ID)
+
+    assert step.override_output_path == SYNTHETIC2_SFT_VERIFIED_OUTPUT_PATH
+
+
+@pytest.mark.parametrize("split", NEMOTRON_SCIENCE_V1_SPLITS)
+def test_nemotron_science_v1_step_transforms_chat_rows(split):
+    dataset_key = f"{NEMOTRON_SCIENCE_V1_HF_ID}/{split}"
+    step = get_instruction_dataset(dataset_key)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    assert step.name == f"documents/{dataset_key}"
+    assert step.override_output_path is not None
+    assert step.override_output_path.startswith(
+        f"documents/nvidia--Nemotron-Science-v1--{split}-{NEMOTRON_SCIENCE_V1_REVISION}-"
+    )
+    assert unwrap_versioned_value(cfg.source) == NEMOTRON_SCIENCE_V1_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == NEMOTRON_SCIENCE_V1_REVISION
+    assert unwrap_versioned_value(cfg.subsets) == ["default"]
+    assert unwrap_versioned_value(cfg.splits) == [split]
+    assert unwrap_versioned_value(cfg.metadata_columns) == NEMOTRON_SCIENCE_V1_METADATA_COLUMNS
+
+    result = transform_row(NEMOTRON_SCIENCE_V1_SAMPLE, cfg, adapter)
+
+    assert result is not None
+    assert result.source == NEMOTRON_SCIENCE_V1_HF_ID
+    assert result.messages[0].model_dump(exclude_none=True) == {
+        "role": "user",
+        "content": "Which choice best explains predictive genetic testing?",
+    }
+    assert result.messages[1].model_dump(exclude_none=True) == {
+        "role": "assistant",
+        "content": "The Best Answer is C.",
+        "reasoning_content": "Predictive testing checks future disease risk in an asymptomatic person.",
+    }
+    assert result.metadata == {
+        "uuid": "science-row-1",
+        "license": "cc-by-4.0",
+        "used_in": ["nano_v3"],
+    }
+
+
+def test_nemotron_science_v1_split_steps_have_distinct_outputs():
+    output_paths = {
+        get_instruction_dataset(f"{NEMOTRON_SCIENCE_V1_HF_ID}/{split}").override_output_path
+        for split in NEMOTRON_SCIENCE_V1_SPLITS
+    }
+
+    assert None not in output_paths
+    assert len(output_paths) == len(NEMOTRON_SCIENCE_V1_SPLITS)

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -122,8 +122,8 @@ class TestTransformAdapters:
         assert messages[1].role == "assistant"
         assert messages[2].role == "system"
 
-    def test_multi_turn_adapter_preserves_requested_message_fields(self):
-        """Test explicit per-message passthrough fields."""
+    def test_multi_turn_adapter_preserves_requested_tool_trace_fields(self):
+        """Test explicit per-message passthrough fields used by tool traces."""
         adapter = TransformAdapter(
             dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
             conversation_column="messages",
@@ -132,27 +132,52 @@ class TestTransformAdapters:
             user_value="user",
             assistant_value="assistant",
             system_value="system",
-            message_passthrough_keys=("reasoning_content",),
+            message_passthrough_keys=("reasoning_content", "tool_calls", "name", "tool_call_id"),
         )
         row = {
             "messages": [
-                {"role": "user", "content": "Question", "reasoning_content": None},
+                {"role": "user", "content": "Compute 2 + 2.", "reasoning_content": None},
                 {
                     "role": "assistant",
-                    "content": "Final answer",
-                    "reasoning_content": "Hidden chain for training template.",
+                    "content": None,
+                    "tool_calls": [
+                        {
+                            "id": "call_calc",
+                            "type": "function",
+                            "function": {"name": "evaluate_code", "arguments": '{"source_code": "print(2 + 2)"}'},
+                        }
+                    ],
+                    "reasoning_content": "Use the calculator tool.",
+                },
+                {
+                    "role": "tool",
+                    "name": "evaluate_code",
+                    "tool_call_id": "call_calc",
+                    "content": "4",
                 },
             ]
         }
 
         messages = adapter.transform_conversation_to_openai_format(row)
 
-        assert len(messages) == 2
-        assert messages[0].model_dump(exclude_none=True) == {"role": "user", "content": "Question"}
+        assert len(messages) == 3
+        assert messages[0].model_dump(exclude_none=True) == {"role": "user", "content": "Compute 2 + 2."}
         assert messages[1].model_dump(exclude_none=True) == {
             "role": "assistant",
-            "content": "Final answer",
-            "reasoning_content": "Hidden chain for training template.",
+            "tool_calls": [
+                {
+                    "id": "call_calc",
+                    "type": "function",
+                    "function": {"name": "evaluate_code", "arguments": '{"source_code": "print(2 + 2)"}'},
+                }
+            ],
+            "reasoning_content": "Use the calculator tool.",
+        }
+        assert messages[2].model_dump(exclude_none=True) == {
+            "role": "tool",
+            "content": "4",
+            "name": "evaluate_code",
+            "tool_call_id": "call_calc",
         }
 
 

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -122,6 +122,39 @@ class TestTransformAdapters:
         assert messages[1].role == "assistant"
         assert messages[2].role == "system"
 
+    def test_multi_turn_adapter_preserves_requested_message_fields(self):
+        """Test explicit per-message passthrough fields."""
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+            conversation_column="messages",
+            role_key="role",
+            content_key="content",
+            user_value="user",
+            assistant_value="assistant",
+            system_value="system",
+            message_passthrough_keys=("reasoning_content",),
+        )
+        row = {
+            "messages": [
+                {"role": "user", "content": "Question", "reasoning_content": None},
+                {
+                    "role": "assistant",
+                    "content": "Final answer",
+                    "reasoning_content": "Hidden chain for training template.",
+                },
+            ]
+        }
+
+        messages = adapter.transform_conversation_to_openai_format(row)
+
+        assert len(messages) == 2
+        assert messages[0].model_dump(exclude_none=True) == {"role": "user", "content": "Question"}
+        assert messages[1].model_dump(exclude_none=True) == {
+            "role": "assistant",
+            "content": "Final answer",
+            "reasoning_content": "Hidden chain for training template.",
+        }
+
 
 class TestTransformRow:
     """Test the transform_row function."""


### PR DESCRIPTION
Add pinned `nvidia/Nemotron-SFT-Science-v2` subset lanes and pinned `nvidia/OpenScienceReasoning-2` as direct science reasoning SFT inputs in the posttrain instruction-dataset registry. Science-v2 keeps reasoning and tool trace fields, forwards list-valued tool schemas through `chat_template_kwargs`, and leaves string-valued vendor `tools` metadata out of chat template args so downstream templating receives the right per-example tool context.

Retire the earlier `nvidia/Nemotron-Science-v1` registry entries as part of moving the science lane to the newer NVIDIA releases. The dataset tests exercise real transforms for Science-v2 tool traces, vendor metadata-only tools, OpenScienceReasoning-2 think-tag rewriting, and the existing SFT output path compatibility guard.