### PR TITLE
[posttrain] Add Nemotron Math Proofs SFT dataset

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -38,6 +38,7 @@ Current datasets:
 23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
 24. lm-provers/FineProofs-SFT
 25. lm-provers/FineProofs-SFT/proof-only
+26. nvidia/Nemotron-Math-Proofs-v1
 """
 
 import dataclasses
@@ -156,6 +157,31 @@ def multi_turn_adapter(
     )
 
 
+def non_empty_multi_turn_adapter(
+    conversation_column: str = "messages",
+    role_key: str = "role",
+    user_value: str = "user",
+    assistant_value: str = "assistant",
+    system_value: str = "system",
+    content_key: str = "content",
+    metadata_remap: dict[str, str] | None = None,
+    replacements: dict[str, str] | None = None,
+    extra_metadata_fn=None,
+) -> TransformAdapter:
+    return TransformAdapter(
+        dataset_format=InputDatasetFormat.NON_EMPTY_SINGLE_COLUMN_MULTI_TURN,
+        conversation_column=conversation_column,
+        role_key=role_key,
+        user_value=user_value,
+        assistant_value=assistant_value,
+        system_value=system_value,
+        content_key=content_key,
+        metadata_remap=metadata_remap or {},
+        replacements=replacements,
+        extra_metadata_fn=extra_metadata_fn,
+    )
+
+
 def instruction_response_adapter(
     *,
     instruction_column: str,
@@ -255,6 +281,22 @@ FINEPROOFS_SFT_METADATA_COLUMNS = [
     "gemini-3-pro-grade",
     "qwen3-4b-thinking-reward@128",
     "source",
+]
+
+NEMOTRON_MATH_PROOFS_V1_HF_ID = "nvidia/Nemotron-Math-Proofs-v1"
+NEMOTRON_MATH_PROOFS_V1_REVISION = "97229c5"
+NEMOTRON_MATH_PROOFS_V1_METADATA_COLUMNS = [
+    "uuid",
+    "problem",
+    "source",
+    "formal_statement",
+    "lean_header",
+    "url",
+    "user_name",
+    "user_url",
+    "sft_line_number",
+    "used_in",
+    "license",
 ]
 
 
@@ -429,6 +471,15 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         name="lm-provers/FineProofs-SFT/proof-only",
         subsets=["default"],
         splits=["train"],
+    ),
+    NEMOTRON_MATH_PROOFS_V1_HF_ID: InstructionDatasetConfig(
+        hf_dataset_id=NEMOTRON_MATH_PROOFS_V1_HF_ID,
+        revision=NEMOTRON_MATH_PROOFS_V1_REVISION,
+        adapter=non_empty_multi_turn_adapter(),
+        metadata_columns=NEMOTRON_MATH_PROOFS_V1_METADATA_COLUMNS,
+        name=NEMOTRON_MATH_PROOFS_V1_HF_ID,
+        subsets=["default"],
+        splits=["lean"],
     ),
     "sherryy/tulu-3-sft-personas-instruction-following-expanded": InstructionDatasetConfig(
         hf_dataset_id="sherryy/tulu-3-sft-personas-instruction-following-expanded",

--- a/lib/marin/src/marin/transform/conversation/adapters.py
+++ b/lib/marin/src/marin/transform/conversation/adapters.py
@@ -21,6 +21,9 @@ class InputDatasetFormat(str, Enum):
     |  {"role": "assistant", "content": "..."}] |
     | ----------------------------------------- |
 
+    NON_EMPTY_SINGLE_COLUMN_MULTI_TURN is the same format, except empty conversations
+    are skipped instead of becoming empty SFT examples.
+
 
     INSTRUCTION_RESPONSE example:
     In the huggingface dataset, there exists two columns with a single message each.
@@ -50,6 +53,7 @@ class InputDatasetFormat(str, Enum):
     """
 
     SINGLE_COLUMN_MULTI_TURN = "messages"
+    NON_EMPTY_SINGLE_COLUMN_MULTI_TURN = "non_empty_messages"
     INSTRUCTION_RESPONSE = "instruction_response"
     INSTRUCT_COLUMN_RESPONSE = "instruct_column_response"
     INSTRUCT_MSG_RESPONSE = "instruct_msg_response"
@@ -117,7 +121,10 @@ class TransformAdapter:
             messages.append(OpenAIChatMessage(role="user", content=instruction))
             messages.append(OpenAIChatMessage(role="assistant", content=response))
             return messages
-        elif self.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN:
+        elif self.dataset_format in (
+            InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+            InputDatasetFormat.NON_EMPTY_SINGLE_COLUMN_MULTI_TURN,
+        ):
             messages = []
             role_to_openai_role = {
                 self.user_value: "user",
@@ -126,6 +133,8 @@ class TransformAdapter:
                 self.tool_value: "tool",
             }
             conversation = row[self.conversation_column]
+            if self.dataset_format == InputDatasetFormat.NON_EMPTY_SINGLE_COLUMN_MULTI_TURN and not conversation:
+                return None
             for conv in conversation:
                 role = role_to_openai_role[conv[self.role_key]]
                 messages.append(OpenAIChatMessage(role=role, content=conv[self.content_key]))

--- a/lib/marin/src/marin/transform/conversation/transform_conversation.py
+++ b/lib/marin/src/marin/transform/conversation/transform_conversation.py
@@ -25,13 +25,13 @@ from typing import Any
 import datasets
 import draccus
 import fsspec
-from marin.core.conversation import DolmaConversationOutput, OpenAIChatMessage
+from marin.core.conversation import DolmaConversationOutput
 from marin.execution import unwrap_versioned_value
 from marin.utils import fsspec_mkdirs, load_dataset_with_backoff
 from rigging.filesystem import url_to_fs
 from zephyr import Dataset, ZephyrContext, load_jsonl, write_jsonl_file
 
-from .adapters import TransformAdapter
+from .adapters import InputDatasetFormat, TransformAdapter
 
 _RESERVED_TOP_LEVEL_FIELDS = {"id", "source", "messages", "added", "created", "metadata"}
 DEFAULT_TEXT_REPLACEMENTS = {"<think>": "<|start_think|>", "</think>": "<|end_think|>"}
@@ -120,10 +120,11 @@ def _normalize_tool_structures(message: dict) -> dict:
 
 def transform_row(row: dict, cfg: TransformSFTDatasetConfig, adapter: TransformAdapter):
     source = unwrap_versioned_value(cfg.source)
-    transformed_row_messages: list[OpenAIChatMessage] | None = adapter.transform_conversation_to_openai_format(row)
+    transformed_row_messages = adapter.transform_conversation_to_openai_format(row)
 
     if transformed_row_messages is None:
-        logger.warning(f"{source} returning no valid messages")
+        if adapter.dataset_format != InputDatasetFormat.NON_EMPTY_SINGLE_COLUMN_MULTI_TURN:
+            logger.warning(f"{source} returning no valid messages")
         return None
 
     messages: list[dict[str, Any]] = [message.model_dump() for message in transformed_row_messages]

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -9,6 +9,8 @@ from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_METADATA_COLUMNS,
     FINEPROOFS_SFT_REVISION,
     INSTRUCTION_DATASET_NAME_TO_CONFIG,
+    NEMOTRON_MATH_PROOFS_V1_HF_ID,
+    NEMOTRON_MATH_PROOFS_V1_METADATA_COLUMNS,
     SYNTHETIC2_SFT_VERIFIED_HF_ID,
     SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
     SYNTHETIC2_SFT_VERIFIED_REVISION,
@@ -23,6 +25,41 @@ SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
         {"role": "user", "content": "Write Python code to count the intersection of two sets."},
         {"role": "assistant", "content": "<think>Use set intersection.</think>\n```python\nprint(len(a & b))\n```"},
     ],
+}
+
+NEMOTRON_MATH_PROOFS_SAMPLE = {
+    "problem": "Is a single point topologically connected?",
+    "source": "mathstack",
+    "formal_statement": "theorem problem_542224 (x : X) : MyIsConnected ({x} : Set X) := by sorry",
+    "lean_header": "import Mathlib\nimport Aesop",
+    "url": "https://math.stackexchange.com/questions/1577525/is-a-single-point-topologically-connected",
+    "user_name": "PurdueCHE",
+    "user_url": "https://math.stackexchange.com/users/251332/purdueche",
+    "sft_line_number": 175604,
+    "messages": [
+        {"role": "user", "content": "Complete the following Lean 4 code.\n\n```lean4\nimport Mathlib\n..."},
+        {"role": "assistant", "content": "```lean4\nimport Mathlib\nimport Aesop\n```"},
+    ],
+    "uuid": "d7207623-6048-5d38-a9d9-62666b1668b2",
+    "used_in": [],
+    "tools": [],
+    "license": "cc-by-sa-4.0",
+}
+
+NEMOTRON_MATH_PROOFS_THEOREM_ONLY_SAMPLE = {
+    "problem": "Prove that there exists a polynomial P with the requested root.",
+    "source": "aops",
+    "formal_statement": "theorem problem_568570 : True := by sorry",
+    "lean_header": "import Mathlib\nimport Aesop",
+    "url": None,
+    "user_name": None,
+    "user_url": None,
+    "sft_line_number": None,
+    "messages": [],
+    "uuid": "b2ee7144-44aa-5d7f-8acc-812fae259c90",
+    "used_in": [],
+    "tools": [],
+    "license": "cc-by-4.0",
 }
 
 
@@ -69,6 +106,28 @@ def test_get_instruction_dataset_preserves_fineproofs_config():
     assert unwrap_versioned_value(proof_only_cfg.metadata_columns) == FINEPROOFS_SFT_METADATA_COLUMNS
     assert unwrap_versioned_value(proof_only_cfg.adapter).dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE
     assert proof_only_step.name == "documents/lm-provers/FineProofs-SFT/proof-only"
+
+
+def test_nemotron_math_proofs_registry_step_transforms_proofs_and_skips_theorem_only_rows():
+    step = get_instruction_dataset(NEMOTRON_MATH_PROOFS_V1_HF_ID)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    assert unwrap_versioned_value(cfg.subsets) == ["default"]
+    assert unwrap_versioned_value(cfg.splits) == ["lean"]
+
+    proof_row = transform_row(NEMOTRON_MATH_PROOFS_SAMPLE, cfg, adapter)
+    theorem_only_row = transform_row(NEMOTRON_MATH_PROOFS_THEOREM_ONLY_SAMPLE, cfg, adapter)
+
+    assert proof_row is not None
+    assert proof_row.source == NEMOTRON_MATH_PROOFS_V1_HF_ID
+    assert [message.role for message in proof_row.messages] == ["user", "assistant"]
+    assert proof_row.messages[0].content == NEMOTRON_MATH_PROOFS_SAMPLE["messages"][0]["content"]
+    assert proof_row.messages[1].content == NEMOTRON_MATH_PROOFS_SAMPLE["messages"][1]["content"]
+    assert proof_row.metadata == {
+        column: NEMOTRON_MATH_PROOFS_SAMPLE[column] for column in NEMOTRON_MATH_PROOFS_V1_METADATA_COLUMNS
+    }
+    assert theorem_only_row is None
 
 
 def test_synthetic2_sft_verified_step_transforms_chat_rows():

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -3,6 +3,7 @@
 
 """Tests for conversation data transformation scripts."""
 
+import logging
 from pathlib import Path
 
 from marin.transform.conversation.adapters import InputDatasetFormat, TransformAdapter
@@ -77,6 +78,22 @@ FINEPROOFS_METADATA_COLUMNS = [
     "qwen3-4b-thinking-reward@128",
     "source",
 ]
+
+NEMOTRON_MATH_PROOFS_THEOREM_ONLY_SAMPLE = {
+    "problem": "Prove that there exists a polynomial P with the requested root.",
+    "source": "aops",
+    "formal_statement": "theorem problem_568570 : True := by sorry",
+    "lean_header": "import Mathlib\nimport Aesop",
+    "url": None,
+    "user_name": None,
+    "user_url": None,
+    "sft_line_number": None,
+    "messages": [],
+    "uuid": "b2ee7144-44aa-5d7f-8acc-812fae259c90",
+    "used_in": [],
+    "tools": [],
+    "license": "cc-by-4.0",
+}
 
 
 class TestTransformAdapters:
@@ -243,6 +260,23 @@ class TestTransformRow:
         }
 
         assert transform_row(row, cfg, adapter) is None
+
+    def test_nemotron_math_proofs_theorem_only_row_is_skipped_without_warning(self, caplog):
+        """Test theorem-only rows do not become empty SFT examples."""
+        adapter = TransformAdapter(dataset_format=InputDatasetFormat.NON_EMPTY_SINGLE_COLUMN_MULTI_TURN)
+        cfg = TransformSFTDatasetConfig(
+            source="nvidia/Nemotron-Math-Proofs-v1",
+            revision="97229c5",
+            output_path="/tmp/output",
+            metadata_columns=[],
+            adapter=adapter,
+        )
+
+        with caplog.at_level(logging.WARNING, logger="marin.transform.conversation.transform_conversation"):
+            result = transform_row(NEMOTRON_MATH_PROOFS_THEOREM_ONLY_SAMPLE, cfg, adapter)
+
+        assert result is None
+        assert "returning no valid messages" not in caplog.text
 
 
 class TestPreferenceDataTransform:


### PR DESCRIPTION
Register nvidia/Nemotron-Math-Proofs-v1 as a pinned post-training SFT dataset on the lean split. Adds a non-empty multi-turn adapter so proof-attempt rows keep user/assistant Lean conversations and theorem-only rows with empty messages are skipped without noisy warnings. Adds registry-to-transform and skip regression coverage.
