### PR TITLE
[posttrain] Refresh NVIDIA math reasoning SFT datasets

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -282,20 +282,31 @@ FINEPROOFS_SFT_METADATA_COLUMNS = [
     "source",
 ]
 
-NEMOTRON_SFT_MATH_V3_HF_ID = "nvidia/Nemotron-SFT-Math-v3"
-NEMOTRON_SFT_MATH_V3_REVISION = "ff4439c1073c87e006ab7ee5f1e5e28c4790dab3"
-NEMOTRON_SFT_MATH_V3_METADATA_COLUMNS = [
+NEMOTRON_SFT_MATH_V4_HF_ID = "nvidia/Nemotron-SFT-Math-v4"
+NEMOTRON_SFT_MATH_V4_REVISION = "a94e56aeddcf6e75d28c8bd210f40fa62309288d"
+NEMOTRON_SFT_MATH_V4_METADATA_COLUMNS = [
     "uuid",
     "expected_answer",
     "problem",
-    "changed_answer_to_majority",
-    "data_source",
     "used_in",
+    "metadata",
+    "source",
+    "dataset",
+    "subset",
     "license",
-    "url",
-    "user_name",
-    "user_url",
-    "tool_usage",
+]
+
+NEMOTRON_MATH_PROOFS_V2_HF_ID = "nvidia/Nemotron-Math-Proofs-v2"
+NEMOTRON_MATH_PROOFS_V2_REVISION = "d857c6b46a63ad97cfbd7b4254e2edf53e9d1666"
+NEMOTRON_MATH_PROOFS_V2_METADATA_COLUMNS = [
+    "uuid",
+    "problem",
+    "used_in",
+    "metadata",
+    "source",
+    "dataset",
+    "subset",
+    "license",
 ]
 
 NEMOTRON_MATH_V2_HF_ID = "nvidia/Nemotron-Math-v2"
@@ -650,21 +661,41 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
     ),
 }
 
-for view_name, tool_usage, max_examples_per_split in [
-    ("no-tool-pilot", "without Python TIR", 100_000),
-    ("python-tir-pilot", "with Python TIR", 100_000),
-    ("no-tool", "without Python TIR", None),
-    ("python-tir", "with Python TIR", None),
+for view_name, subset, max_examples_per_split in [
+    ("cot-pilot", "cot", 100_000),
+    ("tir-pilot", "tir", 100_000),
+    ("cot", "cot", None),
+    ("tir", "tir", None),
 ]:
-    dataset_key = f"{NEMOTRON_SFT_MATH_V3_HF_ID}/{view_name}"
+    dataset_key = f"{NEMOTRON_SFT_MATH_V4_HF_ID}/{view_name}"
     INSTRUCTION_DATASET_NAME_TO_CONFIG[dataset_key] = InstructionDatasetConfig(
         name=dataset_key,
-        hf_dataset_id=NEMOTRON_SFT_MATH_V3_HF_ID,
-        revision=NEMOTRON_SFT_MATH_V3_REVISION,
+        hf_dataset_id=NEMOTRON_SFT_MATH_V4_HF_ID,
+        revision=NEMOTRON_SFT_MATH_V4_REVISION,
         adapter=structured_multi_turn_adapter(metadata_remap={"tools": "tools"}),
-        metadata_columns=NEMOTRON_SFT_MATH_V3_METADATA_COLUMNS,
+        metadata_columns=NEMOTRON_SFT_MATH_V4_METADATA_COLUMNS,
         splits=["train"],
-        row_filters=[RowFilter("tool_usage", RowFilterOperator.EQUALS, tool_usage)],
+        row_filters=[RowFilter("subset", RowFilterOperator.EQUALS, subset)],
+        max_examples_per_split=max_examples_per_split,
+    )
+
+for view_name, subset, max_examples_per_split in [
+    ("proof-pilot", "proof", 2_000),
+    ("verification-pilot", "verification", 2_000),
+    ("meta-verification-pilot", "meta-verification", 2_000),
+    ("proof", "proof", None),
+    ("verification", "verification", None),
+    ("meta-verification", "meta-verification", None),
+]:
+    dataset_key = f"{NEMOTRON_MATH_PROOFS_V2_HF_ID}/{view_name}"
+    INSTRUCTION_DATASET_NAME_TO_CONFIG[dataset_key] = InstructionDatasetConfig(
+        name=dataset_key,
+        hf_dataset_id=NEMOTRON_MATH_PROOFS_V2_HF_ID,
+        revision=NEMOTRON_MATH_PROOFS_V2_REVISION,
+        adapter=structured_multi_turn_adapter(metadata_remap={"tools": "tools"}),
+        metadata_columns=NEMOTRON_MATH_PROOFS_V2_METADATA_COLUMNS,
+        splits=["train"],
+        row_filters=[RowFilter("subset", RowFilterOperator.EQUALS, subset)],
         max_examples_per_split=max_examples_per_split,
     )
 

--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -45,16 +45,19 @@ import hashlib
 import json
 from collections.abc import Sequence
 from dataclasses import dataclass, field
+from enum import Enum
 from typing import Any
 
 from marin.execution.executor import executor_main
 from marin.execution.types import ExecutorStep, output_path_of, this_output_path, versioned
-from marin.transform.conversation.adapters import InputDatasetFormat, TransformAdapter
+from marin.transform.conversation.adapters import InputDatasetFormat, ReasoningContentMode, TransformAdapter
 from marin.transform.conversation.conversation_to_dolma import (
     ConversationToDolmaConfig,
     convert_conversation_to_dolma,
 )
 from marin.transform.conversation.transform_conversation import (
+    RowFilter,
+    RowFilterOperator,
     TransformSFTDatasetConfig,
     transform_hf_dataset,
 )
@@ -117,6 +120,8 @@ class InstructionDatasetConfig:
         subsets: Data subsets (from HuggingFace config) to use. Empty list indicates to use all/default subset(s).
         splits: Data splits (e.g., `train`, `validation`) to use. Empty list indicates to use all splits.
                 Defaults to `train` only
+        row_filters: Filters to apply before transforming raw rows.
+        max_examples_per_split: Optional deterministic cap per split after filtering.
         name: Optional friendly name for the dataset; defaults to `hf_dataset_id`.
         max_parallelism: Max number of parallel data processing tasks. Reduce if needed to avoid HF rate limits.
     """
@@ -128,6 +133,8 @@ class InstructionDatasetConfig:
     name: str | None = None
     subsets: list[str] = field(default_factory=lambda: [])
     splits: list[str] = field(default_factory=lambda: ["train"])
+    row_filters: list[RowFilter] = field(default_factory=list)
+    max_examples_per_split: int | None = None
     max_parallelism: int | None = 32  # 32 works for free users; set to None to use default behavior (full parallelism)
 
 
@@ -152,6 +159,24 @@ def multi_turn_adapter(
         content_key=content_key,
         metadata_remap=metadata_remap or {},
         replacements=replacements,
+        extra_metadata_fn=extra_metadata_fn,
+    )
+
+
+def structured_multi_turn_adapter(
+    *,
+    conversation_column: str = "messages",
+    reasoning_content_mode: ReasoningContentMode = ReasoningContentMode.PRESERVE_FIELD,
+    metadata_remap: dict[str, str] | None = None,
+    extra_metadata_fn=None,
+) -> TransformAdapter:
+    return TransformAdapter(
+        dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+        conversation_column=conversation_column,
+        reasoning_content_key="reasoning_content",
+        reasoning_content_mode=reasoning_content_mode,
+        message_passthrough_keys=("reasoning_content", "tool_calls", "tool_call_id", "name"),
+        metadata_remap=metadata_remap or {},
         extra_metadata_fn=extra_metadata_fn,
     )
 
@@ -256,6 +281,48 @@ FINEPROOFS_SFT_METADATA_COLUMNS = [
     "qwen3-4b-thinking-reward@128",
     "source",
 ]
+
+NEMOTRON_SFT_MATH_V3_HF_ID = "nvidia/Nemotron-SFT-Math-v3"
+NEMOTRON_SFT_MATH_V3_REVISION = "ff4439c1073c87e006ab7ee5f1e5e28c4790dab3"
+NEMOTRON_SFT_MATH_V3_METADATA_COLUMNS = [
+    "uuid",
+    "expected_answer",
+    "problem",
+    "changed_answer_to_majority",
+    "data_source",
+    "used_in",
+    "license",
+    "url",
+    "user_name",
+    "user_url",
+    "tool_usage",
+]
+
+NEMOTRON_MATH_V2_HF_ID = "nvidia/Nemotron-Math-v2"
+NEMOTRON_MATH_V2_REVISION = "8e793210e175b6406c752a870f585f62de98c0d3"
+NEMOTRON_MATH_V2_METADATA_COLUMNS = [
+    "uuid",
+    "expected_answer",
+    "problem",
+    "original_expected_answer",
+    "changed_answer_to_majority",
+    "data_source",
+    "used_in",
+    "metadata",
+    "license",
+    "url",
+    "user_name",
+    "user_url",
+]
+
+NEMOTRON_PRISMMATH_HF_ID = "nvidia/Nemotron-PrismMath"
+NEMOTRON_PRISMMATH_REVISION = "8a35a0602167ad1f1ec9d6db5e72281e486738a7"
+NEMOTRON_PRISMMATH_METADATA_COLUMNS = ["id"]
+
+OPENMATHINSTRUCT2_HF_ID = "nvidia/OpenMathInstruct-2"
+OPENMATHINSTRUCT2_REVISION = "469216e3f46f4dacf476b382e192485ea51a143e"
+OPENMATHINSTRUCT2_TRAIN_1M_HF_ID = f"{OPENMATHINSTRUCT2_HF_ID}/train_1M"
+OPENMATHINSTRUCT2_METADATA_COLUMNS = ["expected_answer", "problem_source"]
 
 
 INSTRUCTION_DATASET_NAME_TO_CONFIG = {
@@ -559,7 +626,67 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         name="nvidia/OpenMathReasoning/genselect",
         splits=["genselect"],
     ),
+    NEMOTRON_PRISMMATH_HF_ID: InstructionDatasetConfig(
+        hf_dataset_id=NEMOTRON_PRISMMATH_HF_ID,
+        revision=NEMOTRON_PRISMMATH_REVISION,
+        adapter=instruction_response_adapter(
+            instruction_column="problem",
+            response_column="solution",
+        ),
+        metadata_columns=NEMOTRON_PRISMMATH_METADATA_COLUMNS,
+        name=NEMOTRON_PRISMMATH_HF_ID,
+        splits=["train"],
+    ),
+    OPENMATHINSTRUCT2_TRAIN_1M_HF_ID: InstructionDatasetConfig(
+        hf_dataset_id=OPENMATHINSTRUCT2_HF_ID,
+        revision=OPENMATHINSTRUCT2_REVISION,
+        adapter=instruction_response_adapter(
+            instruction_column="problem",
+            response_column="generated_solution",
+        ),
+        metadata_columns=OPENMATHINSTRUCT2_METADATA_COLUMNS,
+        name=OPENMATHINSTRUCT2_TRAIN_1M_HF_ID,
+        splits=["train_1M"],
+    ),
 }
+
+for view_name, tool_usage, max_examples_per_split in [
+    ("no-tool-pilot", "without Python TIR", 100_000),
+    ("python-tir-pilot", "with Python TIR", 100_000),
+    ("no-tool", "without Python TIR", None),
+    ("python-tir", "with Python TIR", None),
+]:
+    dataset_key = f"{NEMOTRON_SFT_MATH_V3_HF_ID}/{view_name}"
+    INSTRUCTION_DATASET_NAME_TO_CONFIG[dataset_key] = InstructionDatasetConfig(
+        name=dataset_key,
+        hf_dataset_id=NEMOTRON_SFT_MATH_V3_HF_ID,
+        revision=NEMOTRON_SFT_MATH_V3_REVISION,
+        adapter=structured_multi_turn_adapter(metadata_remap={"tools": "tools"}),
+        metadata_columns=NEMOTRON_SFT_MATH_V3_METADATA_COLUMNS,
+        splits=["train"],
+        row_filters=[RowFilter("tool_usage", RowFilterOperator.EQUALS, tool_usage)],
+        max_examples_per_split=max_examples_per_split,
+    )
+
+INSTRUCTION_DATASET_NAME_TO_CONFIG[f"{NEMOTRON_MATH_V2_HF_ID}/high-pilot"] = InstructionDatasetConfig(
+    name=f"{NEMOTRON_MATH_V2_HF_ID}/high-pilot",
+    hf_dataset_id=NEMOTRON_MATH_V2_HF_ID,
+    revision=NEMOTRON_MATH_V2_REVISION,
+    adapter=structured_multi_turn_adapter(metadata_remap={"tools": "tools"}),
+    metadata_columns=NEMOTRON_MATH_V2_METADATA_COLUMNS,
+    splits=["high_part00", "high_part01", "high_part02"],
+    max_examples_per_split=50_000,
+)
+
+INSTRUCTION_DATASET_NAME_TO_CONFIG[f"{NEMOTRON_MATH_V2_HF_ID}/medium-pilot"] = InstructionDatasetConfig(
+    name=f"{NEMOTRON_MATH_V2_HF_ID}/medium-pilot",
+    hf_dataset_id=NEMOTRON_MATH_V2_HF_ID,
+    revision=NEMOTRON_MATH_V2_REVISION,
+    adapter=structured_multi_turn_adapter(metadata_remap={"tools": "tools"}),
+    metadata_columns=NEMOTRON_MATH_V2_METADATA_COLUMNS,
+    splits=["medium"],
+    max_examples_per_split=150_000,
+)
 
 for split_name in SMOLTALK2_SPLITS:
     dataset_key = f"HuggingFaceTB/smoltalk2/{split_name}"
@@ -613,6 +740,10 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
     adapter_dict["dataset_format"] = adapter_dict["dataset_format"].value
 
     def canonicalize(value):
+        if dataclasses.is_dataclass(value):
+            return canonicalize(dataclasses.asdict(value))
+        if isinstance(value, Enum):
+            return value.value
         if isinstance(value, dict):
             return {k: canonicalize(v) for k, v in sorted(value.items())}
         if isinstance(value, list):
@@ -628,6 +759,8 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
         {dataset_cfg.revision}\
         -{sorted(dataset_cfg.subsets)}\
         -{sorted(dataset_cfg.splits)}\
+        -{canonicalize(dataset_cfg.row_filters)}\
+        -{dataset_cfg.max_examples_per_split}\
         -{adapter_signature_str}"
     hashed_config_str = hashlib.md5(config_str.encode()).hexdigest()[:6]
 
@@ -642,6 +775,8 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
             adapter=versioned(adapter),
             subsets=versioned(dataset_cfg.subsets),
             splits=versioned(dataset_cfg.splits),
+            row_filters=versioned(dataset_cfg.row_filters),
+            max_examples_per_split=versioned(dataset_cfg.max_examples_per_split),
             max_parallelism=dataset_cfg.max_parallelism,
         ),
         override_output_path=f"documents/{dataset_name}-{dataset_cfg.revision}-{hashed_config_str}",

--- a/lib/marin/src/marin/transform/conversation/adapters.py
+++ b/lib/marin/src/marin/transform/conversation/adapters.py
@@ -4,7 +4,7 @@
 import dataclasses
 from collections.abc import Callable
 from dataclasses import dataclass, field
-from enum import Enum
+from enum import Enum, StrEnum
 from typing import Any
 
 from marin.core.conversation import OpenAIChatMessage
@@ -55,6 +55,13 @@ class InputDatasetFormat(str, Enum):
     INSTRUCT_MSG_RESPONSE = "instruct_msg_response"
 
 
+class ReasoningContentMode(StrEnum):
+    """How to handle a separate reasoning field in assistant messages."""
+
+    PRESERVE_FIELD = "preserve_field"
+    DROP = "drop"
+
+
 @dataclass
 class TransformAdapter:
     dataset_format: InputDatasetFormat = InputDatasetFormat.INSTRUCTION_RESPONSE
@@ -80,6 +87,9 @@ class TransformAdapter:
     system_value: str = "system"
     content_key: str = "content"
     tool_value: str = "tool"
+    reasoning_content_key: str = ""
+    reasoning_content_mode: ReasoningContentMode = ReasoningContentMode.DROP
+    message_passthrough_keys: tuple[str, ...] = ()
 
     # If specified, the key will be used to select the message with
     # best metric in multiple turn conversations
@@ -128,7 +138,25 @@ class TransformAdapter:
             conversation = row[self.conversation_column]
             for conv in conversation:
                 role = role_to_openai_role[conv[self.role_key]]
-                messages.append(OpenAIChatMessage(role=role, content=conv[self.content_key]))
+                content = conv[self.content_key]
+                message_fields: dict[str, Any] = {"role": role, "content": content}
+                for key in self.message_passthrough_keys:
+                    if key in {self.role_key, self.content_key}:
+                        continue
+                    if key not in conv:
+                        continue
+                    value = conv[key]
+                    if value is None:
+                        continue
+                    if value == "":
+                        continue
+                    if isinstance(value, list) and not value:
+                        continue
+                    if key == self.reasoning_content_key:
+                        if self.reasoning_content_mode == ReasoningContentMode.DROP:
+                            continue
+                    message_fields[key] = value
+                messages.append(OpenAIChatMessage(**message_fields))
             return messages
         elif self.dataset_format == InputDatasetFormat.INSTRUCT_COLUMN_RESPONSE:
             messages = []

--- a/lib/marin/src/marin/transform/conversation/transform_conversation.py
+++ b/lib/marin/src/marin/transform/conversation/transform_conversation.py
@@ -19,6 +19,7 @@ from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
+from enum import StrEnum
 from pathlib import Path
 from typing import Any
 
@@ -39,6 +40,24 @@ DEFAULT_TEXT_REPLACEMENTS = {"<think>": "<|start_think|>", "</think>": "<|end_th
 logger = logging.getLogger(__name__)
 
 
+class RowFilterOperator(StrEnum):
+    """Supported row filter operations for streamed SFT transforms."""
+
+    EQUALS = "equals"
+    NOT_EQUALS = "not_equals"
+    NON_EMPTY = "non_empty"
+    EMPTY = "empty"
+
+
+@dataclass(frozen=True)
+class RowFilter:
+    """Filter applied to raw dataset rows before transforming them."""
+
+    column: str
+    operator: RowFilterOperator
+    value: Any | None = None
+
+
 @dataclass(frozen=True)
 class TransformSFTDatasetConfig:
     """Base configuration to transform a conversation dataset from huggingface json to OpenAI format.
@@ -51,6 +70,8 @@ class TransformSFTDatasetConfig:
         adapter (TransformAdapter): Adapter responsible for mapping raw rows into OpenAI chat format.
         subsets (list[str]): Data subsets (from HuggingFace config) to use. Empty list indicates all/default subset(s).
         splits (list[str]): Data splits (e.g., `train`, `validation`) to use. Empty list indicates all splits.
+        row_filters (list[RowFilter]): Filters to apply to raw rows before transformation.
+        max_examples_per_split (int | None): Optional deterministic cap per split after filtering.
         max_parallelism (int | None): Maximum number of concurrent shard processing tasks.
             Set to lower values to avoid HF rate limits. Set to None for default behavior (full concurrency).
     """
@@ -62,6 +83,8 @@ class TransformSFTDatasetConfig:
     adapter: TransformAdapter
     subsets: list[str] = field(default_factory=lambda: [])  # Default behavior is to use all subsets
     splits: list[str] = field(default_factory=lambda: ["train"])  # Set to train; empty set means everything
+    row_filters: list[RowFilter] = field(default_factory=list)
+    max_examples_per_split: int | None = None
     max_parallelism: int | None = None  # None means use default behavior (full concurrency)
 
 
@@ -79,11 +102,11 @@ class ShardTask:
     cfg: TransformSFTDatasetConfig
 
 
-def generate_hash_from_messages(messages: list[dict[str, str]]) -> str:
+def generate_hash_from_messages(messages: list[dict[str, Any]]) -> str:
     """Generate a hash from a list of messages.
 
     Args:
-        messages (List[Dict[str, str]]): A list of messages.
+        messages (List[Dict[str, Any]]): A list of messages.
 
     Returns:
         str: A hash of the messages.
@@ -116,6 +139,50 @@ def _normalize_tool_structures(message: dict) -> dict:
         message["tool_calls"] = normalized_calls
 
     return message
+
+
+def _has_value(value: object) -> bool:
+    if value is None:
+        return False
+    if value == "":
+        return False
+    if isinstance(value, Sequence) and not isinstance(value, str):
+        return len(value) > 0
+    if isinstance(value, dict):
+        return len(value) > 0
+    return True
+
+
+def row_matches_filters(row: dict[str, Any], row_filters: Sequence[RowFilter]) -> bool:
+    """Return whether a raw dataset row satisfies all configured filters."""
+
+    for row_filter in row_filters:
+        operator = RowFilterOperator(row_filter.operator)
+        value = row.get(row_filter.column)
+        if operator == RowFilterOperator.EQUALS and value != row_filter.value:
+            return False
+        if operator == RowFilterOperator.NOT_EQUALS and value == row_filter.value:
+            return False
+        if operator == RowFilterOperator.NON_EMPTY and not _has_value(value):
+            return False
+        if operator == RowFilterOperator.EMPTY and _has_value(value):
+            return False
+    return True
+
+
+def shard_example_limit(max_examples_per_split: int | None, num_shards: int, shard_idx: int) -> int | None:
+    """Return a deterministic per-shard cap for a split-level example limit."""
+
+    if max_examples_per_split is None:
+        return None
+    if max_examples_per_split < 0:
+        raise ValueError("max_examples_per_split must be non-negative.")
+    if num_shards <= 0:
+        raise ValueError("num_shards must be positive.")
+    if shard_idx < 0 or shard_idx >= num_shards:
+        raise ValueError("shard_idx must be within num_shards.")
+    base, remainder = divmod(max_examples_per_split, num_shards)
+    return base + int(shard_idx < remainder)
 
 
 def transform_row(row: dict, cfg: TransformSFTDatasetConfig, adapter: TransformAdapter):
@@ -314,6 +381,9 @@ def process_shard_task(task: ShardTask) -> dict:
     Loads a specific shard from HuggingFace Hub, transforms records, and writes to output file.
     """
     adapter = unwrap_versioned_value(task.cfg.adapter).copy()
+    row_filters = unwrap_versioned_value(task.cfg.row_filters) or []
+    max_examples_per_split = unwrap_versioned_value(task.cfg.max_examples_per_split)
+    shard_limit = shard_example_limit(max_examples_per_split, task.num_shards, task.shard_idx)
 
     subset_name = task.subset or "default"
     output_filename = _shard_filename(task.output_path, task.shard_idx)
@@ -342,9 +412,17 @@ def process_shard_task(task: ShardTask) -> dict:
 
     def transform_records():
         """Generator that yields transformed records."""
+        written_count = 0
+        if shard_limit == 0:
+            return
         for raw_row in shard_dataset:
+            if not row_matches_filters(raw_row, row_filters):
+                continue
+            if shard_limit is not None and written_count >= shard_limit:
+                break
             transformed_row = transform_row(raw_row, task.cfg, adapter)
             if transformed_row is not None:
+                written_count += 1
                 yield transformed_row.model_dump()
 
     result = write_jsonl_file(transform_records(), output_filename)

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -3,7 +3,7 @@
 
 from marin.execution.executor import unwrap_versioned_value
 from marin.transform.conversation.adapters import InputDatasetFormat
-from marin.transform.conversation.transform_conversation import transform_row
+from marin.transform.conversation.transform_conversation import row_matches_filters, transform_row
 
 from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_METADATA_COLUMNS,
@@ -23,6 +23,43 @@ SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
         {"role": "user", "content": "Write Python code to count the intersection of two sets."},
         {"role": "assistant", "content": "<think>Use set intersection.</think>\n```python\nprint(len(a & b))\n```"},
     ],
+}
+
+NEMOTRON_STRUCTURED_SAMPLE = {
+    "uuid": "math-row-1",
+    "expected_answer": "4",
+    "problem": "Solve 2 + 2.",
+    "original_expected_answer": "4",
+    "changed_answer_to_majority": False,
+    "data_source": "aops",
+    "used_in": ["train"],
+    "metadata": {
+        "reason_high_with_tool": {"count": 1, "pass": 1, "accuracy": 1.0},
+        "reason_medium_no_tool": {"count": 1, "pass": 1, "accuracy": 1.0},
+    },
+    "license": "cc-by-4.0",
+    "url": "https://example.com/problem",
+    "user_name": "example-user",
+    "user_url": "https://example.com/user",
+    "tool_usage": "with Python TIR",
+    "messages": [
+        {"role": "user", "content": "Solve 2 + 2."},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "Use Python for the arithmetic.",
+            "tool_calls": [
+                {
+                    "id": "call_python",
+                    "type": "function",
+                    "function": {"name": "python", "arguments": '{"code": "2 + 2"}'},
+                }
+            ],
+        },
+        {"role": "tool", "name": "python", "tool_call_id": "call_python", "content": "4"},
+        {"role": "assistant", "content": "\\boxed{4}", "reasoning_content": ""},
+    ],
+    "tools": [{"type": "function", "function": {"name": "python", "parameters": {}}}],
 }
 
 
@@ -69,6 +106,105 @@ def test_get_instruction_dataset_preserves_fineproofs_config():
     assert unwrap_versioned_value(proof_only_cfg.metadata_columns) == FINEPROOFS_SFT_METADATA_COLUMNS
     assert unwrap_versioned_value(proof_only_cfg.adapter).dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE
     assert proof_only_step.name == "documents/lm-provers/FineProofs-SFT/proof-only"
+
+
+def test_nemotron_sft_math_v3_views_filter_caps_and_transform_tool_rows():
+    python_tir_step = get_instruction_dataset("nvidia/Nemotron-SFT-Math-v3/python-tir-pilot")
+    python_tir_cfg = python_tir_step.config
+    no_tool_cfg = get_instruction_dataset("nvidia/Nemotron-SFT-Math-v3/no-tool-pilot").config
+    full_python_cfg = get_instruction_dataset("nvidia/Nemotron-SFT-Math-v3/python-tir").config
+
+    assert row_matches_filters(NEMOTRON_STRUCTURED_SAMPLE, unwrap_versioned_value(python_tir_cfg.row_filters))
+    assert not row_matches_filters(NEMOTRON_STRUCTURED_SAMPLE, unwrap_versioned_value(no_tool_cfg.row_filters))
+    assert unwrap_versioned_value(python_tir_cfg.max_examples_per_split) == 100_000
+    assert unwrap_versioned_value(full_python_cfg.max_examples_per_split) is None
+
+    result = transform_row(NEMOTRON_STRUCTURED_SAMPLE, python_tir_cfg, unwrap_versioned_value(python_tir_cfg.adapter))
+
+    assert result is not None
+    dumped = result.model_dump()
+    assert dumped["tools"] == NEMOTRON_STRUCTURED_SAMPLE["tools"]
+    assert dumped["messages"][1]["reasoning_content"] == "Use Python for the arithmetic."
+    assert dumped["messages"][1]["tool_calls"][0]["function"]["arguments"] == {"code": "2 + 2"}
+    assert dumped["messages"][2]["role"] == "tool"
+    assert dumped["messages"][2]["tool_call_id"] == "call_python"
+    assert result.metadata["tool_usage"] == "with Python TIR"
+
+
+def test_nemotron_math_v2_pilot_views_target_reasoning_splits_and_transform_tool_rows():
+    high_step = get_instruction_dataset("nvidia/Nemotron-Math-v2/high-pilot")
+    high_cfg = high_step.config
+    medium_step = get_instruction_dataset("nvidia/Nemotron-Math-v2/medium-pilot")
+    medium_cfg = medium_step.config
+
+    assert unwrap_versioned_value(high_cfg.splits) == ["high_part00", "high_part01", "high_part02"]
+    assert unwrap_versioned_value(high_cfg.max_examples_per_split) == 50_000
+    assert unwrap_versioned_value(medium_cfg.splits) == ["medium"]
+    assert unwrap_versioned_value(medium_cfg.max_examples_per_split) == 150_000
+    assert high_step.override_output_path != medium_step.override_output_path
+
+    result = transform_row(NEMOTRON_STRUCTURED_SAMPLE, high_cfg, unwrap_versioned_value(high_cfg.adapter))
+
+    assert result is not None
+    dumped = result.model_dump()
+    assert dumped["tools"] == NEMOTRON_STRUCTURED_SAMPLE["tools"]
+    assert dumped["messages"][1]["reasoning_content"] == "Use Python for the arithmetic."
+    assert dumped["messages"][1]["tool_calls"][0]["function"]["arguments"] == {"code": "2 + 2"}
+    assert result.metadata["metadata"]["reason_high_with_tool"]["accuracy"] == 1.0
+    assert result.metadata["used_in"] == ["train"]
+
+
+def test_prismmath_and_openmathinstruct2_registered_adapters_transform_rows():
+    prism_step = get_instruction_dataset("nvidia/Nemotron-PrismMath")
+    prism_cfg = prism_step.config
+    openmath_step = get_instruction_dataset("nvidia/OpenMathInstruct-2/train_1M")
+    openmath_cfg = openmath_step.config
+
+    prism_result = transform_row(
+        {"id": "prism-1", "problem": "Find x if x + 1 = 3.", "solution": "Subtract 1 to get x = 2."},
+        prism_cfg,
+        unwrap_versioned_value(prism_cfg.adapter),
+    )
+    openmath_result = transform_row(
+        {
+            "problem": "Compute 6 * 7.",
+            "generated_solution": "6 * 7 = 42.",
+            "expected_answer": "42",
+            "problem_source": "MATH",
+        },
+        openmath_cfg,
+        unwrap_versioned_value(openmath_cfg.adapter),
+    )
+
+    assert prism_result is not None
+    assert [message.content for message in prism_result.messages] == [
+        "Find x if x + 1 = 3.",
+        "Subtract 1 to get x = 2.",
+    ]
+    assert prism_result.metadata == {"id": "prism-1"}
+
+    assert openmath_result is not None
+    assert unwrap_versioned_value(openmath_cfg.splits) == ["train_1M"]
+    assert [message.content for message in openmath_result.messages] == ["Compute 6 * 7.", "6 * 7 = 42."]
+    assert openmath_result.metadata == {"expected_answer": "42", "problem_source": "MATH"}
+
+
+def test_new_dataset_view_output_paths_are_unique():
+    dataset_keys = [
+        "nvidia/Nemotron-SFT-Math-v3/no-tool-pilot",
+        "nvidia/Nemotron-SFT-Math-v3/python-tir-pilot",
+        "nvidia/Nemotron-SFT-Math-v3/no-tool",
+        "nvidia/Nemotron-SFT-Math-v3/python-tir",
+        "nvidia/Nemotron-Math-v2/high-pilot",
+        "nvidia/Nemotron-Math-v2/medium-pilot",
+        "nvidia/Nemotron-PrismMath",
+        "nvidia/OpenMathInstruct-2/train_1M",
+    ]
+
+    output_paths = [get_instruction_dataset(dataset_key).override_output_path for dataset_key in dataset_keys]
+
+    assert all(output_path is not None and output_path.startswith("documents/") for output_path in output_paths)
+    assert len(output_paths) == len(set(output_paths))
 
 
 def test_synthetic2_sft_verified_step_transforms_chat_rows():

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -1,9 +1,16 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from dataclasses import replace
+
 from marin.execution.executor import unwrap_versioned_value
 from marin.transform.conversation.adapters import InputDatasetFormat
-from marin.transform.conversation.transform_conversation import row_matches_filters, transform_row
+from marin.transform.conversation.transform_conversation import (
+    RowFilter,
+    RowFilterOperator,
+    row_matches_filters,
+    transform_row,
+)
 
 from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_METADATA_COLUMNS,
@@ -12,7 +19,10 @@ from experiments.posttrain.instruction_datasets import (
     SYNTHETIC2_SFT_VERIFIED_HF_ID,
     SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
     SYNTHETIC2_SFT_VERIFIED_REVISION,
+    InstructionDatasetConfig,
     get_instruction_dataset,
+    structured_multi_turn_adapter,
+    transform_dataset_step,
 )
 
 SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
@@ -37,11 +47,13 @@ NEMOTRON_STRUCTURED_SAMPLE = {
         "reason_high_with_tool": {"count": 1, "pass": 1, "accuracy": 1.0},
         "reason_medium_no_tool": {"count": 1, "pass": 1, "accuracy": 1.0},
     },
+    "source": "AoPS",
+    "dataset": "Nemotron-SFT-Math-v4",
+    "subset": "tir",
     "license": "cc-by-4.0",
     "url": "https://example.com/problem",
     "user_name": "example-user",
     "user_url": "https://example.com/user",
-    "tool_usage": "with Python TIR",
     "messages": [
         {"role": "user", "content": "Solve 2 + 2."},
         {
@@ -60,6 +72,26 @@ NEMOTRON_STRUCTURED_SAMPLE = {
         {"role": "assistant", "content": "\\boxed{4}", "reasoning_content": ""},
     ],
     "tools": [{"type": "function", "function": {"name": "python", "parameters": {}}}],
+}
+
+NEMOTRON_PROOFS_V2_SAMPLE = {
+    "uuid": "proof-row-1",
+    "problem": "Prove that sqrt(3) is irrational.",
+    "used_in": ["ultra_v3"],
+    "metadata": [],
+    "source": "AoPS",
+    "dataset": "Nemotron-Math-Proofs-v2",
+    "subset": "proof",
+    "license": "CC BY 4.0",
+    "messages": [
+        {"role": "user", "content": "Prove that sqrt(3) is irrational."},
+        {
+            "role": "assistant",
+            "content": "## Solution\nAssume sqrt(3)=p/q in lowest terms and derive a contradiction.",
+            "reasoning_content": "Use the standard prime divisibility argument.",
+        },
+    ],
+    "tools": [],
 }
 
 
@@ -108,18 +140,21 @@ def test_get_instruction_dataset_preserves_fineproofs_config():
     assert proof_only_step.name == "documents/lm-provers/FineProofs-SFT/proof-only"
 
 
-def test_nemotron_sft_math_v3_views_filter_caps_and_transform_tool_rows():
-    python_tir_step = get_instruction_dataset("nvidia/Nemotron-SFT-Math-v3/python-tir-pilot")
-    python_tir_cfg = python_tir_step.config
-    no_tool_cfg = get_instruction_dataset("nvidia/Nemotron-SFT-Math-v3/no-tool-pilot").config
-    full_python_cfg = get_instruction_dataset("nvidia/Nemotron-SFT-Math-v3/python-tir").config
+def test_nemotron_sft_math_v4_views_filter_caps_and_transform_tool_rows():
+    tir_step = get_instruction_dataset("nvidia/Nemotron-SFT-Math-v4/tir-pilot")
+    tir_cfg = tir_step.config
+    cot_cfg = get_instruction_dataset("nvidia/Nemotron-SFT-Math-v4/cot-pilot").config
+    full_tir_cfg = get_instruction_dataset("nvidia/Nemotron-SFT-Math-v4/tir").config
 
-    assert row_matches_filters(NEMOTRON_STRUCTURED_SAMPLE, unwrap_versioned_value(python_tir_cfg.row_filters))
-    assert not row_matches_filters(NEMOTRON_STRUCTURED_SAMPLE, unwrap_versioned_value(no_tool_cfg.row_filters))
-    assert unwrap_versioned_value(python_tir_cfg.max_examples_per_split) == 100_000
-    assert unwrap_versioned_value(full_python_cfg.max_examples_per_split) is None
+    assert unwrap_versioned_value(tir_cfg.source) == "nvidia/Nemotron-SFT-Math-v4"
+    assert unwrap_versioned_value(tir_cfg.revision) == "a94e56aeddcf6e75d28c8bd210f40fa62309288d"
+    assert unwrap_versioned_value(tir_cfg.splits) == ["train"]
+    assert row_matches_filters(NEMOTRON_STRUCTURED_SAMPLE, unwrap_versioned_value(tir_cfg.row_filters))
+    assert not row_matches_filters(NEMOTRON_STRUCTURED_SAMPLE, unwrap_versioned_value(cot_cfg.row_filters))
+    assert unwrap_versioned_value(tir_cfg.max_examples_per_split) == 100_000
+    assert unwrap_versioned_value(full_tir_cfg.max_examples_per_split) is None
 
-    result = transform_row(NEMOTRON_STRUCTURED_SAMPLE, python_tir_cfg, unwrap_versioned_value(python_tir_cfg.adapter))
+    result = transform_row(NEMOTRON_STRUCTURED_SAMPLE, tir_cfg, unwrap_versioned_value(tir_cfg.adapter))
 
     assert result is not None
     dumped = result.model_dump()
@@ -128,7 +163,55 @@ def test_nemotron_sft_math_v3_views_filter_caps_and_transform_tool_rows():
     assert dumped["messages"][1]["tool_calls"][0]["function"]["arguments"] == {"code": "2 + 2"}
     assert dumped["messages"][2]["role"] == "tool"
     assert dumped["messages"][2]["tool_call_id"] == "call_python"
-    assert result.metadata["tool_usage"] == "with Python TIR"
+    assert result.metadata == {
+        "uuid": "math-row-1",
+        "expected_answer": "4",
+        "problem": "Solve 2 + 2.",
+        "used_in": ["train"],
+        "metadata": {
+            "reason_high_with_tool": {"count": 1, "pass": 1, "accuracy": 1.0},
+            "reason_medium_no_tool": {"count": 1, "pass": 1, "accuracy": 1.0},
+        },
+        "source": "AoPS",
+        "dataset": "Nemotron-SFT-Math-v4",
+        "subset": "tir",
+        "license": "cc-by-4.0",
+    }
+
+
+def test_nemotron_math_proofs_v2_views_filter_caps_and_transform_proof_rows():
+    proof_step = get_instruction_dataset("nvidia/Nemotron-Math-Proofs-v2/proof-pilot")
+    proof_cfg = proof_step.config
+    verification_cfg = get_instruction_dataset("nvidia/Nemotron-Math-Proofs-v2/verification-pilot").config
+    meta_verification_cfg = get_instruction_dataset("nvidia/Nemotron-Math-Proofs-v2/meta-verification-pilot").config
+    full_proof_cfg = get_instruction_dataset("nvidia/Nemotron-Math-Proofs-v2/proof").config
+
+    assert unwrap_versioned_value(proof_cfg.source) == "nvidia/Nemotron-Math-Proofs-v2"
+    assert unwrap_versioned_value(proof_cfg.revision) == "d857c6b46a63ad97cfbd7b4254e2edf53e9d1666"
+    assert unwrap_versioned_value(proof_cfg.splits) == ["train"]
+    assert row_matches_filters(NEMOTRON_PROOFS_V2_SAMPLE, unwrap_versioned_value(proof_cfg.row_filters))
+    assert not row_matches_filters(NEMOTRON_PROOFS_V2_SAMPLE, unwrap_versioned_value(verification_cfg.row_filters))
+    assert not row_matches_filters(NEMOTRON_PROOFS_V2_SAMPLE, unwrap_versioned_value(meta_verification_cfg.row_filters))
+    assert unwrap_versioned_value(proof_cfg.max_examples_per_split) == 2_000
+    assert unwrap_versioned_value(full_proof_cfg.max_examples_per_split) is None
+
+    result = transform_row(NEMOTRON_PROOFS_V2_SAMPLE, proof_cfg, unwrap_versioned_value(proof_cfg.adapter))
+
+    assert result is not None
+    dumped = result.model_dump()
+    assert dumped["tools"] == []
+    assert dumped["messages"][0]["content"] == "Prove that sqrt(3) is irrational."
+    assert dumped["messages"][1]["reasoning_content"] == "Use the standard prime divisibility argument."
+    assert result.metadata == {
+        "uuid": "proof-row-1",
+        "problem": "Prove that sqrt(3) is irrational.",
+        "used_in": ["ultra_v3"],
+        "metadata": [],
+        "source": "AoPS",
+        "dataset": "Nemotron-Math-Proofs-v2",
+        "subset": "proof",
+        "license": "CC BY 4.0",
+    }
 
 
 def test_nemotron_math_v2_pilot_views_target_reasoning_splits_and_transform_tool_rows():
@@ -189,22 +272,28 @@ def test_prismmath_and_openmathinstruct2_registered_adapters_transform_rows():
     assert openmath_result.metadata == {"expected_answer": "42", "problem_source": "MATH"}
 
 
-def test_new_dataset_view_output_paths_are_unique():
-    dataset_keys = [
-        "nvidia/Nemotron-SFT-Math-v3/no-tool-pilot",
-        "nvidia/Nemotron-SFT-Math-v3/python-tir-pilot",
-        "nvidia/Nemotron-SFT-Math-v3/no-tool",
-        "nvidia/Nemotron-SFT-Math-v3/python-tir",
-        "nvidia/Nemotron-Math-v2/high-pilot",
-        "nvidia/Nemotron-Math-v2/medium-pilot",
-        "nvidia/Nemotron-PrismMath",
-        "nvidia/OpenMathInstruct-2/train_1M",
-    ]
+def test_dataset_view_output_path_hash_accounts_for_filters_and_caps():
+    base_cfg = InstructionDatasetConfig(
+        hf_dataset_id="nvidia/Nemotron-SFT-Math-v4",
+        revision="a94e56aeddcf6e75d28c8bd210f40fa62309288d",
+        adapter=structured_multi_turn_adapter(metadata_remap={"tools": "tools"}),
+        metadata_columns=["subset"],
+        name="nvidia/Nemotron-SFT-Math-v4/shared-name",
+        splits=["train"],
+        row_filters=[RowFilter("subset", RowFilterOperator.EQUALS, "cot")],
+        max_examples_per_split=100_000,
+    )
+    tir_cfg = replace(base_cfg, row_filters=[RowFilter("subset", RowFilterOperator.EQUALS, "tir")])
+    uncapped_cot_cfg = replace(base_cfg, max_examples_per_split=None)
 
-    output_paths = [get_instruction_dataset(dataset_key).override_output_path for dataset_key in dataset_keys]
+    cot_step = transform_dataset_step(base_cfg)
+    tir_step = transform_dataset_step(tir_cfg)
+    uncapped_cot_step = transform_dataset_step(uncapped_cot_cfg)
 
-    assert all(output_path is not None and output_path.startswith("documents/") for output_path in output_paths)
-    assert len(output_paths) == len(set(output_paths))
+    assert cot_step.name == tir_step.name == uncapped_cot_step.name
+    assert cot_step.override_output_path != tir_step.override_output_path
+    assert cot_step.override_output_path != uncapped_cot_step.override_output_path
+    assert tir_step.override_output_path != uncapped_cot_step.override_output_path
 
 
 def test_synthetic2_sft_verified_step_transforms_chat_rows():

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -5,11 +5,15 @@
 
 from pathlib import Path
 
-from marin.transform.conversation.adapters import InputDatasetFormat, TransformAdapter
+from marin.transform.conversation.adapters import InputDatasetFormat, ReasoningContentMode, TransformAdapter
 from marin.transform.conversation.conversation_to_dolma import transform_conversation_to_dolma
 from marin.transform.conversation.preference_data_adapters import PreferenceTransformAdapter
 from marin.transform.conversation.transform_conversation import (
+    RowFilter,
+    RowFilterOperator,
     TransformSFTDatasetConfig,
+    row_matches_filters,
+    shard_example_limit,
     transform_row,
 )
 
@@ -78,6 +82,29 @@ FINEPROOFS_METADATA_COLUMNS = [
     "source",
 ]
 
+NEMOTRON_TOOL_TRACE_SAMPLE = {
+    "messages": [
+        {"role": "user", "content": "Solve 2 + 2."},
+        {
+            "role": "assistant",
+            "content": "",
+            "reasoning_content": "I should compute the sum.",
+            "tool_calls": [
+                {
+                    "id": "call_python",
+                    "type": "function",
+                    "function": {"name": "python", "arguments": '{"code": "2 + 2"}'},
+                }
+            ],
+        },
+        {"role": "tool", "name": "python", "tool_call_id": "call_python", "content": "4"},
+        {"role": "assistant", "content": "\\boxed{4}", "reasoning_content": ""},
+    ],
+    "tools": [{"type": "function", "function": {"name": "python", "parameters": {}}}],
+    "tool_usage": "with Python TIR",
+    "license": "cc-by-4.0",
+}
+
 
 class TestTransformAdapters:
     """Test the different adapter formats."""
@@ -121,6 +148,25 @@ class TestTransformAdapters:
         assert messages[0].content == "Explain quantum computing"
         assert messages[1].role == "assistant"
         assert messages[2].role == "system"
+
+    def test_single_column_adapter_preserves_structured_tool_messages(self):
+        """Test Nemotron-style structured messages with reasoning and tool calls."""
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+            reasoning_content_key="reasoning_content",
+            reasoning_content_mode=ReasoningContentMode.PRESERVE_FIELD,
+            message_passthrough_keys=("reasoning_content", "tool_calls", "tool_call_id", "name"),
+        )
+
+        messages = adapter.transform_conversation_to_openai_format(NEMOTRON_TOOL_TRACE_SAMPLE)
+        dumped = [message.model_dump() for message in messages]
+
+        assert [message.role for message in messages] == ["user", "assistant", "tool", "assistant"]
+        assert dumped[1]["reasoning_content"] == "I should compute the sum."
+        assert dumped[1]["tool_calls"] == NEMOTRON_TOOL_TRACE_SAMPLE["messages"][1]["tool_calls"]
+        assert dumped[2]["name"] == "python"
+        assert dumped[2]["tool_call_id"] == "call_python"
+        assert "reasoning_content" not in dumped[3]
 
 
 class TestTransformRow:
@@ -243,6 +289,54 @@ class TestTransformRow:
         }
 
         assert transform_row(row, cfg, adapter) is None
+
+    def test_nemotron_structured_row_preserves_tools_and_normalizes_tool_calls(self):
+        """Test structured multi-turn rows with top-level tools metadata."""
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+            reasoning_content_key="reasoning_content",
+            reasoning_content_mode=ReasoningContentMode.PRESERVE_FIELD,
+            message_passthrough_keys=("reasoning_content", "tool_calls", "tool_call_id", "name"),
+            metadata_remap={"tools": "tools"},
+        )
+        cfg = TransformSFTDatasetConfig(
+            source="nvidia/Nemotron-SFT-Math-v3",
+            revision="ff4439c",
+            output_path="/tmp/output",
+            metadata_columns=["tool_usage", "license"],
+            adapter=adapter,
+        )
+
+        result = transform_row(NEMOTRON_TOOL_TRACE_SAMPLE, cfg, adapter)
+
+        assert result is not None
+        dumped = result.model_dump()
+        assert dumped["tools"] == NEMOTRON_TOOL_TRACE_SAMPLE["tools"]
+        assert result.metadata == {"tool_usage": "with Python TIR", "license": "cc-by-4.0"}
+        assert dumped["messages"][1]["reasoning_content"] == "I should compute the sum."
+        assert dumped["messages"][1]["tool_calls"][0]["function"]["arguments"] == {"code": "2 + 2"}
+        assert dumped["messages"][2]["role"] == "tool"
+        assert dumped["messages"][2]["tool_call_id"] == "call_python"
+
+    def test_row_filters_support_tool_usage_and_presence_checks(self):
+        """Test row filters used for dataset views."""
+        assert row_matches_filters(
+            NEMOTRON_TOOL_TRACE_SAMPLE,
+            [RowFilter("tool_usage", RowFilterOperator.EQUALS, "with Python TIR")],
+        )
+        assert not row_matches_filters(
+            NEMOTRON_TOOL_TRACE_SAMPLE,
+            [RowFilter("tool_usage", RowFilterOperator.EQUALS, "without Python TIR")],
+        )
+        assert row_matches_filters(NEMOTRON_TOOL_TRACE_SAMPLE, [RowFilter("tools", RowFilterOperator.NON_EMPTY)])
+        assert row_matches_filters({"tools": []}, [RowFilter("tools", RowFilterOperator.EMPTY)])
+
+    def test_shard_example_limit_distributes_split_cap_deterministically(self):
+        limits = [shard_example_limit(100, 6, shard_idx) for shard_idx in range(6)]
+
+        assert limits == [17, 17, 17, 17, 16, 16]
+        assert sum(limit for limit in limits if limit is not None) == 100
+        assert shard_example_limit(None, 6, 0) is None
 
 
 class TestPreferenceDataTransform:

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -101,7 +101,8 @@ NEMOTRON_TOOL_TRACE_SAMPLE = {
         {"role": "assistant", "content": "\\boxed{4}", "reasoning_content": ""},
     ],
     "tools": [{"type": "function", "function": {"name": "python", "parameters": {}}}],
-    "tool_usage": "with Python TIR",
+    "subset": "tir",
+    "dataset": "Nemotron-SFT-Math-v4",
     "license": "cc-by-4.0",
 }
 
@@ -300,10 +301,10 @@ class TestTransformRow:
             metadata_remap={"tools": "tools"},
         )
         cfg = TransformSFTDatasetConfig(
-            source="nvidia/Nemotron-SFT-Math-v3",
-            revision="ff4439c",
+            source="nvidia/Nemotron-SFT-Math-v4",
+            revision="a94e56a",
             output_path="/tmp/output",
-            metadata_columns=["tool_usage", "license"],
+            metadata_columns=["subset", "dataset", "license"],
             adapter=adapter,
         )
 
@@ -312,21 +313,33 @@ class TestTransformRow:
         assert result is not None
         dumped = result.model_dump()
         assert dumped["tools"] == NEMOTRON_TOOL_TRACE_SAMPLE["tools"]
-        assert result.metadata == {"tool_usage": "with Python TIR", "license": "cc-by-4.0"}
+        assert result.metadata == {
+            "subset": "tir",
+            "dataset": "Nemotron-SFT-Math-v4",
+            "license": "cc-by-4.0",
+        }
         assert dumped["messages"][1]["reasoning_content"] == "I should compute the sum."
         assert dumped["messages"][1]["tool_calls"][0]["function"]["arguments"] == {"code": "2 + 2"}
         assert dumped["messages"][2]["role"] == "tool"
         assert dumped["messages"][2]["tool_call_id"] == "call_python"
 
-    def test_row_filters_support_tool_usage_and_presence_checks(self):
+    def test_row_filters_support_subset_and_presence_checks(self):
         """Test row filters used for dataset views."""
         assert row_matches_filters(
             NEMOTRON_TOOL_TRACE_SAMPLE,
-            [RowFilter("tool_usage", RowFilterOperator.EQUALS, "with Python TIR")],
+            [RowFilter("subset", RowFilterOperator.EQUALS, "tir")],
         )
         assert not row_matches_filters(
             NEMOTRON_TOOL_TRACE_SAMPLE,
-            [RowFilter("tool_usage", RowFilterOperator.EQUALS, "without Python TIR")],
+            [RowFilter("subset", RowFilterOperator.EQUALS, "cot")],
+        )
+        assert row_matches_filters(
+            NEMOTRON_TOOL_TRACE_SAMPLE,
+            [RowFilter("subset", RowFilterOperator.NOT_EQUALS, "cot")],
+        )
+        assert not row_matches_filters(
+            NEMOTRON_TOOL_TRACE_SAMPLE,
+            [RowFilter("subset", RowFilterOperator.NOT_EQUALS, "tir")],
         )
         assert row_matches_filters(NEMOTRON_TOOL_TRACE_SAMPLE, [RowFilter("tools", RowFilterOperator.NON_EMPTY)])
         assert row_matches_filters({"tools": []}, [RowFilter("tools", RowFilterOperator.EMPTY)])
@@ -336,6 +349,7 @@ class TestTransformRow:
 
         assert limits == [17, 17, 17, 17, 16, 16]
         assert sum(limit for limit in limits if limit is not None) == 100
+        assert shard_example_limit(0, 6, 0) == 0
         assert shard_example_limit(None, 6, 0) is None
 
 


### PR DESCRIPTION
Register NVIDIA math-reasoning SFT dataset views for Nemotron-SFT-Math-v4 COT and TIR, Nemotron-Math-v2 high- and medium-reasoning pilots, Nemotron-PrismMath, OpenMathInstruct-2/train_1M, and Nemotron-Math-Proofs-v2 proof, verification, and meta-verification lanes. The v4 math views keep NVIDIA's current COT/TIR split explicit, while OpenMathInstruct-2 stays bounded to the curated 1M training split to avoid a bulk synthetic import. Proofs-v2 is kept in its own natural-language proof lane with small pilots and full views so long proof traces do not get blended into the general math SFT controls. Preserve structured chat fields required by these datasets, including reasoning_content, tool calls, tool messages, and top-level tools. Row filters and deterministic pilot caps make each view addressable without dataset-specific transform code, and output paths account for filters and caps so views cannot collide.