### PR TITLE
[posttrain] Add Nemotron finance SFT dataset

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -38,6 +38,7 @@ Current datasets:
 23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
 24. lm-provers/FineProofs-SFT
 25. lm-provers/FineProofs-SFT/proof-only
+26. nvidia/Nemotron-SpecializedDomains-Finance-v1
 """
 
 import dataclasses
@@ -156,6 +157,31 @@ def multi_turn_adapter(
     )
 
 
+def multi_turn_reasoning_adapter(
+    conversation_column: str = "messages",
+    role_key: str = "role",
+    user_value: str = "user",
+    assistant_value: str = "assistant",
+    system_value: str = "system",
+    content_key: str = "content",
+    metadata_remap: dict[str, str] | None = None,
+    replacements: dict[str, str] | None = None,
+    extra_metadata_fn=None,
+) -> TransformAdapter:
+    return TransformAdapter(
+        dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN_WITH_REASONING,
+        conversation_column=conversation_column,
+        role_key=role_key,
+        user_value=user_value,
+        assistant_value=assistant_value,
+        system_value=system_value,
+        content_key=content_key,
+        metadata_remap=metadata_remap or {},
+        replacements=replacements,
+        extra_metadata_fn=extra_metadata_fn,
+    )
+
+
 def instruction_response_adapter(
     *,
     instruction_column: str,
@@ -256,6 +282,9 @@ FINEPROOFS_SFT_METADATA_COLUMNS = [
     "qwen3-4b-thinking-reward@128",
     "source",
 ]
+
+NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_REVISION = "5a21b106168facb96ced11b883c2a9b4788ee939"
+NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_METADATA_COLUMNS = ["uuid", "license", "used_in"]
 
 
 INSTRUCTION_DATASET_NAME_TO_CONFIG = {
@@ -429,6 +458,16 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         name="lm-provers/FineProofs-SFT/proof-only",
         subsets=["default"],
         splits=["train"],
+    ),
+    "nvidia/Nemotron-SpecializedDomains-Finance-v1": InstructionDatasetConfig(
+        hf_dataset_id="nvidia/Nemotron-SpecializedDomains-Finance-v1",
+        revision=NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_REVISION,
+        adapter=multi_turn_reasoning_adapter(),
+        metadata_columns=NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_METADATA_COLUMNS,
+        name="nvidia/Nemotron-SpecializedDomains-Finance-v1",
+        subsets=["default"],
+        splits=["train"],
+        max_parallelism=16,
     ),
     "sherryy/tulu-3-sft-personas-instruction-following-expanded": InstructionDatasetConfig(
         hf_dataset_id="sherryy/tulu-3-sft-personas-instruction-following-expanded",

--- a/lib/marin/src/marin/transform/conversation/adapters.py
+++ b/lib/marin/src/marin/transform/conversation/adapters.py
@@ -50,6 +50,7 @@ class InputDatasetFormat(str, Enum):
     """
 
     SINGLE_COLUMN_MULTI_TURN = "messages"
+    SINGLE_COLUMN_MULTI_TURN_WITH_REASONING = "messages_with_reasoning_content"
     INSTRUCTION_RESPONSE = "instruction_response"
     INSTRUCT_COLUMN_RESPONSE = "instruct_column_response"
     INSTRUCT_MSG_RESPONSE = "instruct_msg_response"
@@ -117,7 +118,10 @@ class TransformAdapter:
             messages.append(OpenAIChatMessage(role="user", content=instruction))
             messages.append(OpenAIChatMessage(role="assistant", content=response))
             return messages
-        elif self.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN:
+        elif self.dataset_format in {
+            InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+            InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN_WITH_REASONING,
+        }:
             messages = []
             role_to_openai_role = {
                 self.user_value: "user",
@@ -128,7 +132,12 @@ class TransformAdapter:
             conversation = row[self.conversation_column]
             for conv in conversation:
                 role = role_to_openai_role[conv[self.role_key]]
-                messages.append(OpenAIChatMessage(role=role, content=conv[self.content_key]))
+                message_kwargs = {"role": role, "content": conv[self.content_key]}
+                if self.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN_WITH_REASONING:
+                    reasoning_content = conv.get("reasoning_content")
+                    if isinstance(reasoning_content, str) and reasoning_content:
+                        message_kwargs["reasoning_content"] = reasoning_content
+                messages.append(OpenAIChatMessage(**message_kwargs))
             return messages
         elif self.dataset_format == InputDatasetFormat.INSTRUCT_COLUMN_RESPONSE:
             messages = []

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -25,6 +25,25 @@ SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
     ],
 }
 
+NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_HF_ID = "nvidia/Nemotron-SpecializedDomains-Finance-v1"
+NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_SAMPLE = {
+    "messages": [
+        {"role": "system", "content": ""},
+        {
+            "role": "user",
+            "content": "You are given a financial text extracted from 10-K or 10-Q files.\n\nQuestion: What changed?",
+        },
+        {
+            "role": "assistant",
+            "reasoning_content": "Compare the 2021 and 2020 net interest figures.",
+            "content": "Answer: Net interest expense decreased by about 2.9%.",
+        },
+    ],
+    "uuid": "6a4ce9e3-0010-55ea-b730-1bf4cc5db85e",
+    "license": "cc-by-4.0",
+    "used_in": ["super_v3"],
+}
+
 
 def test_fineproofs_sft_datasets_are_registered():
     raw_dataset = INSTRUCTION_DATASET_NAME_TO_CONFIG["lm-provers/FineProofs-SFT"]
@@ -105,3 +124,47 @@ def test_synthetic2_sft_verified_step_transforms_chat_rows():
         "task_type": "prime_rl_code",
         "reward": 1.0,
     }
+
+
+def test_nemotron_specialized_domains_finance_transform_preserves_reasoning_content():
+    step = get_instruction_dataset(NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_HF_ID)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+    expected_user_prompt = "You are given a financial text extracted from 10-K or 10-Q files.\n\nQuestion: What changed?"
+
+    result = transform_row(NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_SAMPLE, cfg, adapter)
+
+    assert result is not None
+    assert result.source == NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_HF_ID
+    assert [message.role for message in result.messages] == ["system", "user", "assistant"]
+    assert result.messages[0].content == ""
+    assert result.messages[1].content == expected_user_prompt
+    assistant_message = result.messages[2].model_dump()
+    assert assistant_message["content"] == "Answer: Net interest expense decreased by about 2.9%."
+    assert assistant_message["reasoning_content"] == "Compare the 2021 and 2020 net interest figures."
+    assert result.metadata == {
+        "uuid": "6a4ce9e3-0010-55ea-b730-1bf4cc5db85e",
+        "license": "cc-by-4.0",
+        "used_in": ["super_v3"],
+    }
+
+
+def test_nemotron_specialized_domains_finance_transform_allows_answer_only_rows():
+    step = get_instruction_dataset(NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_HF_ID)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+    sample = {
+        **NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_SAMPLE,
+        "messages": [
+            {"role": "user", "content": "Question: What changed?"},
+            {"role": "assistant", "content": "Answer: Revenue increased."},
+        ],
+    }
+
+    result = transform_row(sample, cfg, adapter)
+
+    assert result is not None
+    assert result.source == NEMOTRON_SPECIALIZED_DOMAINS_FINANCE_HF_ID
+    assistant_message = result.messages[1].model_dump()
+    assert assistant_message["content"] == "Answer: Revenue increased."
+    assert "reasoning_content" not in assistant_message


### PR DESCRIPTION
Register nvidia/Nemotron-SpecializedDomains-Finance-v1 as a post-training instruction dataset and preserve optional assistant reasoning_content in multi-turn conversation rows. The import keeps finance provenance metadata and adds focused transform coverage for reasoning-preserving and answer-only examples. Validated with focused instruction dataset tests and changed-files pre-commit.