### PR TITLE
[Posttrain] Add AceReason 1.1 SFT views

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -38,6 +38,9 @@ Current datasets:
 23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
 24. lm-provers/FineProofs-SFT
 25. lm-provers/FineProofs-SFT/proof-only
+26. nvidia/AceReason-1.1-SFT
+27. nvidia/AceReason-1.1-SFT/math
+28. nvidia/AceReason-1.1-SFT/code
 """
 
 import dataclasses
@@ -55,6 +58,7 @@ from marin.transform.conversation.conversation_to_dolma import (
     convert_conversation_to_dolma,
 )
 from marin.transform.conversation.transform_conversation import (
+    RowFilter,
     TransformSFTDatasetConfig,
     transform_hf_dataset,
 )
@@ -117,6 +121,7 @@ class InstructionDatasetConfig:
         subsets: Data subsets (from HuggingFace config) to use. Empty list indicates to use all/default subset(s).
         splits: Data splits (e.g., `train`, `validation`) to use. Empty list indicates to use all splits.
                 Defaults to `train` only
+        row_filters: Exact-match filters to select source rows before transforming them.
         name: Optional friendly name for the dataset; defaults to `hf_dataset_id`.
         max_parallelism: Max number of parallel data processing tasks. Reduce if needed to avoid HF rate limits.
     """
@@ -128,6 +133,7 @@ class InstructionDatasetConfig:
     name: str | None = None
     subsets: list[str] = field(default_factory=lambda: [])
     splits: list[str] = field(default_factory=lambda: ["train"])
+    row_filters: list[RowFilter] = field(default_factory=list)
     max_parallelism: int | None = 32  # 32 works for free users; set to None to use default behavior (full parallelism)
 
 
@@ -256,6 +262,10 @@ FINEPROOFS_SFT_METADATA_COLUMNS = [
     "qwen3-4b-thinking-reward@128",
     "source",
 ]
+
+ACE_REASON_1_1_SFT_HF_ID = "nvidia/AceReason-1.1-SFT"
+ACE_REASON_1_1_SFT_REVISION = "5ac692742de9f2481f8274d022dc78d5fc96c249"
+ACE_REASON_1_1_SFT_METADATA_COLUMNS = ["category", "source"]
 
 
 INSTRUCTION_DATASET_NAME_TO_CONFIG = {
@@ -408,6 +418,44 @@ INSTRUCTION_DATASET_NAME_TO_CONFIG = {
         name=SYNTHETIC2_SFT_VERIFIED_HF_ID,
         subsets=["default"],
         splits=["train"],
+    ),
+    ACE_REASON_1_1_SFT_HF_ID: InstructionDatasetConfig(
+        hf_dataset_id=ACE_REASON_1_1_SFT_HF_ID,
+        revision=ACE_REASON_1_1_SFT_REVISION,
+        adapter=instruction_response_adapter(
+            instruction_column="input",
+            response_column="output",
+        ),
+        metadata_columns=ACE_REASON_1_1_SFT_METADATA_COLUMNS,
+        name=ACE_REASON_1_1_SFT_HF_ID,
+        subsets=["default"],
+        splits=["train"],
+    ),
+    f"{ACE_REASON_1_1_SFT_HF_ID}/math": InstructionDatasetConfig(
+        hf_dataset_id=ACE_REASON_1_1_SFT_HF_ID,
+        revision=ACE_REASON_1_1_SFT_REVISION,
+        adapter=instruction_response_adapter(
+            instruction_column="input",
+            response_column="output",
+        ),
+        metadata_columns=ACE_REASON_1_1_SFT_METADATA_COLUMNS,
+        name=f"{ACE_REASON_1_1_SFT_HF_ID}/math",
+        subsets=["default"],
+        splits=["train"],
+        row_filters=[RowFilter(column="category", allowed_values=["math"])],
+    ),
+    f"{ACE_REASON_1_1_SFT_HF_ID}/code": InstructionDatasetConfig(
+        hf_dataset_id=ACE_REASON_1_1_SFT_HF_ID,
+        revision=ACE_REASON_1_1_SFT_REVISION,
+        adapter=instruction_response_adapter(
+            instruction_column="input",
+            response_column="output",
+        ),
+        metadata_columns=ACE_REASON_1_1_SFT_METADATA_COLUMNS,
+        name=f"{ACE_REASON_1_1_SFT_HF_ID}/code",
+        subsets=["default"],
+        splits=["train"],
+        row_filters=[RowFilter(column="category", allowed_values=["code"])],
     ),
     "lm-provers/FineProofs-SFT": InstructionDatasetConfig(
         hf_dataset_id="lm-provers/FineProofs-SFT",
@@ -623,11 +671,14 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
 
     adapter_signature = canonicalize(adapter_dict)
     adapter_signature_str = json.dumps(adapter_signature, sort_keys=True)
+    row_filters_signature = canonicalize([dataclasses.asdict(row_filter) for row_filter in dataset_cfg.row_filters])
+    row_filters_signature_str = json.dumps(row_filters_signature, sort_keys=True)
 
     config_str = f"{dataset_name}-\
         {dataset_cfg.revision}\
         -{sorted(dataset_cfg.subsets)}\
         -{sorted(dataset_cfg.splits)}\
+        -{row_filters_signature_str}\
         -{adapter_signature_str}"
     hashed_config_str = hashlib.md5(config_str.encode()).hexdigest()[:6]
 
@@ -642,6 +693,7 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
             adapter=versioned(adapter),
             subsets=versioned(dataset_cfg.subsets),
             splits=versioned(dataset_cfg.splits),
+            row_filters=versioned(dataset_cfg.row_filters),
             max_parallelism=dataset_cfg.max_parallelism,
         ),
         override_output_path=f"documents/{dataset_name}-{dataset_cfg.revision}-{hashed_config_str}",

--- a/lib/marin/src/marin/transform/conversation/transform_conversation.py
+++ b/lib/marin/src/marin/transform/conversation/transform_conversation.py
@@ -40,6 +40,14 @@ logger = logging.getLogger(__name__)
 
 
 @dataclass(frozen=True)
+class RowFilter:
+    """Exact-match filter for selecting rows before conversation transformation."""
+
+    column: str
+    allowed_values: list[str]
+
+
+@dataclass(frozen=True)
 class TransformSFTDatasetConfig:
     """Base configuration to transform a conversation dataset from huggingface json to OpenAI format.
 
@@ -51,6 +59,7 @@ class TransformSFTDatasetConfig:
         adapter (TransformAdapter): Adapter responsible for mapping raw rows into OpenAI chat format.
         subsets (list[str]): Data subsets (from HuggingFace config) to use. Empty list indicates all/default subset(s).
         splits (list[str]): Data splits (e.g., `train`, `validation`) to use. Empty list indicates all splits.
+        row_filters (list[RowFilter]): Exact-match filters applied before transforming rows.
         max_parallelism (int | None): Maximum number of concurrent shard processing tasks.
             Set to lower values to avoid HF rate limits. Set to None for default behavior (full concurrency).
     """
@@ -62,6 +71,7 @@ class TransformSFTDatasetConfig:
     adapter: TransformAdapter
     subsets: list[str] = field(default_factory=lambda: [])  # Default behavior is to use all subsets
     splits: list[str] = field(default_factory=lambda: ["train"])  # Set to train; empty set means everything
+    row_filters: list[RowFilter] = field(default_factory=list)
     max_parallelism: int | None = None  # None means use default behavior (full concurrency)
 
 
@@ -118,8 +128,21 @@ def _normalize_tool_structures(message: dict) -> dict:
     return message
 
 
+def _row_matches_filters(row: dict[str, Any], row_filters: Sequence[RowFilter]) -> bool:
+    for row_filter in row_filters:
+        if row_filter.column not in row:
+            raise ValueError(f"Row filter column '{row_filter.column}' is missing from source row.")
+        if row[row_filter.column] not in row_filter.allowed_values:
+            return False
+    return True
+
+
 def transform_row(row: dict, cfg: TransformSFTDatasetConfig, adapter: TransformAdapter):
     source = unwrap_versioned_value(cfg.source)
+    row_filters = unwrap_versioned_value(cfg.row_filters)
+    if row_filters and not _row_matches_filters(row, row_filters):
+        return None
+
     transformed_row_messages: list[OpenAIChatMessage] | None = adapter.transform_conversation_to_openai_format(row)
 
     if transformed_row_messages is None:

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -6,6 +6,7 @@ from marin.transform.conversation.adapters import InputDatasetFormat
 from marin.transform.conversation.transform_conversation import transform_row
 
 from experiments.posttrain.instruction_datasets import (
+    ACE_REASON_1_1_SFT_HF_ID,
     FINEPROOFS_SFT_METADATA_COLUMNS,
     FINEPROOFS_SFT_REVISION,
     INSTRUCTION_DATASET_NAME_TO_CONFIG,
@@ -24,6 +25,46 @@ SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
         {"role": "assistant", "content": "<think>Use set intersection.</think>\n```python\nprint(len(a & b))\n```"},
     ],
 }
+
+ACE_REASON_MATH_SAMPLE = {
+    "category": "math",
+    "source": "OpenMathReasoning",
+    "input": "Find all prime numbers p such that p^3 + 1 = k^2.",
+    "output": "<think>Factor p^3 + 1 and compare factors.</think>\nThe only prime is p = 2.",
+}
+
+ACE_REASON_CODE_SAMPLE = {
+    "category": "code",
+    "source": "OpenCodeReasoning",
+    "input": "Write a function to detect a directed cycle.",
+    "output": "<think>Use DFS colors.</think>\n```python\ndef has_cycle(graph): ...\n```",
+}
+
+ACE_REASON_MATH_ASSISTANT = "\n".join(
+    [
+        "<|start_think|>Factor p^3 + 1 and compare factors.<|end_think|>",
+        "The only prime is p = 2.",
+    ]
+)
+
+ACE_REASON_CODE_ASSISTANT = "\n".join(
+    [
+        "<|start_think|>Use DFS colors.<|end_think|>",
+        "```python\ndef has_cycle(graph): ...\n```",
+    ]
+)
+
+
+def _assert_acereason_transform_result(result, source_row, expected_assistant):
+    assert result is not None
+    assert result.source == ACE_REASON_1_1_SFT_HF_ID
+    assert [message.role for message in result.messages] == ["user", "assistant"]
+    assert result.messages[0].content == source_row["input"]
+    assert result.messages[1].content == expected_assistant
+    assert result.metadata == {
+        "category": source_row["category"],
+        "source": source_row["source"],
+    }
 
 
 def test_fineproofs_sft_datasets_are_registered():
@@ -105,3 +146,41 @@ def test_synthetic2_sft_verified_step_transforms_chat_rows():
         "task_type": "prime_rl_code",
         "reward": 1.0,
     }
+
+
+def test_acereason_sft_full_view_transforms_math_and_code_rows():
+    step = get_instruction_dataset(ACE_REASON_1_1_SFT_HF_ID)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    math_result = transform_row(ACE_REASON_MATH_SAMPLE, cfg, adapter)
+    code_result = transform_row(ACE_REASON_CODE_SAMPLE, cfg, adapter)
+
+    _assert_acereason_transform_result(math_result, ACE_REASON_MATH_SAMPLE, ACE_REASON_MATH_ASSISTANT)
+    _assert_acereason_transform_result(code_result, ACE_REASON_CODE_SAMPLE, ACE_REASON_CODE_ASSISTANT)
+
+
+def test_acereason_sft_math_view_transforms_only_math_rows():
+    step = get_instruction_dataset(f"{ACE_REASON_1_1_SFT_HF_ID}/math")
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    code_row_with_math_source = {**ACE_REASON_CODE_SAMPLE, "source": ACE_REASON_MATH_SAMPLE["source"]}
+    result = transform_row(ACE_REASON_MATH_SAMPLE, cfg, adapter)
+    skipped = transform_row(code_row_with_math_source, cfg, adapter)
+
+    _assert_acereason_transform_result(result, ACE_REASON_MATH_SAMPLE, ACE_REASON_MATH_ASSISTANT)
+    assert skipped is None
+
+
+def test_acereason_sft_code_view_transforms_only_code_rows():
+    step = get_instruction_dataset(f"{ACE_REASON_1_1_SFT_HF_ID}/code")
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    math_row_with_code_source = {**ACE_REASON_MATH_SAMPLE, "source": ACE_REASON_CODE_SAMPLE["source"]}
+    result = transform_row(ACE_REASON_CODE_SAMPLE, cfg, adapter)
+    skipped = transform_row(math_row_with_code_source, cfg, adapter)
+
+    _assert_acereason_transform_result(result, ACE_REASON_CODE_SAMPLE, ACE_REASON_CODE_ASSISTANT)
+    assert skipped is None

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -5,10 +5,12 @@
 
 from pathlib import Path
 
+import pytest
 from marin.transform.conversation.adapters import InputDatasetFormat, TransformAdapter
 from marin.transform.conversation.conversation_to_dolma import transform_conversation_to_dolma
 from marin.transform.conversation.preference_data_adapters import PreferenceTransformAdapter
 from marin.transform.conversation.transform_conversation import (
+    RowFilter,
     TransformSFTDatasetConfig,
     transform_row,
 )
@@ -243,6 +245,55 @@ class TestTransformRow:
         }
 
         assert transform_row(row, cfg, adapter) is None
+
+    def test_transform_row_applies_exact_match_row_filters(self):
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.INSTRUCTION_RESPONSE,
+            instruction_column="instruction",
+            response_column="response",
+        )
+        cfg = TransformSFTDatasetConfig(
+            source="test/dataset",
+            revision="main",
+            output_path="/tmp/output",
+            metadata_columns=["category"],
+            adapter=adapter,
+            row_filters=[RowFilter(column="category", allowed_values=["math"])],
+        )
+
+        accepted = transform_row(
+            {"category": "math", "instruction": "Solve 2 + 2.", "response": "4"},
+            cfg,
+            adapter,
+        )
+        skipped = transform_row(
+            {"category": "code", "instruction": "Write a function.", "response": "def f(): pass"},
+            cfg,
+            adapter,
+        )
+
+        assert accepted is not None
+        assert accepted.messages[0].content == "Solve 2 + 2."
+        assert accepted.metadata == {"category": "math"}
+        assert skipped is None
+
+    def test_transform_row_requires_row_filter_columns_to_exist(self):
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.INSTRUCTION_RESPONSE,
+            instruction_column="instruction",
+            response_column="response",
+        )
+        cfg = TransformSFTDatasetConfig(
+            source="test/dataset",
+            revision="main",
+            output_path="/tmp/output",
+            metadata_columns=[],
+            adapter=adapter,
+            row_filters=[RowFilter(column="category", allowed_values=["math"])],
+        )
+
+        with pytest.raises(ValueError, match="Row filter column 'category' is missing"):
+            transform_row({"instruction": "Solve 2 + 2.", "response": "4"}, cfg, adapter)
 
 
 class TestPreferenceDataTransform:


### PR DESCRIPTION
Register nvidia/AceReason-1.1-SFT as full, math, and code SFT views using the existing instruction-response transform path. Adds row-filter support so category-specific views can materialize from one source while preserving category and source metadata, with focused transform tests for full-view conversion, filtered skips, and missing filter columns.