### PR TITLE
[posttrain] Add Nemotron SFT instruction-following chat datasets

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -38,6 +38,8 @@ Current datasets:
 23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
 24. lm-provers/FineProofs-SFT
 25. lm-provers/FineProofs-SFT/proof-only
+26. nvidia/Nemotron-SFT-Instruction-Following-Chat-v2
+27. nvidia/Nemotron-SFT-Instruction-Following-Chat-v3
 """
 
 import dataclasses
@@ -122,6 +124,11 @@ NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_FEATURES = {
     "used_in": {"feature": {"dtype": "string", "_type": "Value"}, "_type": "List"},
     "reasoning": {"dtype": "string", "_type": "Value"},
 }
+
+NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID = "nvidia/Nemotron-SFT-Instruction-Following-Chat-v3"
+NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_REVISION = "be3b3e04ef605ac9d3f8f35b9d5a632f4a3a3402"
+NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_SPLITS = ["instruction_following"]
+NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_METADATA_COLUMNS = ["uuid", "used_in", "metadata"]
 
 
 @dataclass(frozen=True)
@@ -267,6 +274,25 @@ class ReasoningToChatKwargs:
 
 
 reasoning_to_chat_kwargs = ReasoningToChatKwargs()
+
+
+def reasoning_content_to_chat_kwargs(row: dict[str, Any]) -> dict[str, Any]:
+    """Toggle thinking mode based on assistant messages with explicit reasoning content."""
+    messages = row.get("messages")
+    if not isinstance(messages, list):
+        return {}
+
+    for message in messages:
+        if not isinstance(message, dict):
+            continue
+        if message.get("role") != "assistant":
+            continue
+        reasoning_content = message.get("reasoning_content")
+        if isinstance(reasoning_content, str) and reasoning_content.strip():
+            return {"chat_template_kwargs": {"enable_thinking": True}}
+
+    return {"chat_template_kwargs": {"enable_thinking": False}}
+
 
 SYNTHETIC2_SFT_VERIFIED_HF_ID = "PrimeIntellect/SYNTHETIC-2-SFT-verified"
 SYNTHETIC2_SFT_VERIFIED_REVISION = "fce247fe48af8ff9624fb51d1de63aa1b2332cef"
@@ -632,6 +658,20 @@ for split_name in NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_SPLITS:
         metadata_columns=NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_METADATA_COLUMNS,
         splits=[split_name],
         load_dataset_features=NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_FEATURES,
+    )
+
+for split_name in NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_SPLITS:
+    dataset_key = f"{NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID}/{split_name}"
+    INSTRUCTION_DATASET_NAME_TO_CONFIG[dataset_key] = InstructionDatasetConfig(
+        name=dataset_key,
+        hf_dataset_id=NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID,
+        revision=NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_REVISION,
+        adapter=multi_turn_adapter(
+            reasoning_content_key="reasoning_content",
+            extra_metadata_fn=reasoning_content_to_chat_kwargs,
+        ),
+        metadata_columns=NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_METADATA_COLUMNS,
+        splits=[split_name],
     )
 
 

--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -104,6 +104,25 @@ NEMOTRON_V2_SPLITS = [
 
 NEMOTRON_V1_SPLITS = ["chat", "code", "math", "stem", "tool_calling"]
 
+NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID = "nvidia/Nemotron-SFT-Instruction-Following-Chat-v2"
+NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_REVISION = "1a9454ed054b8544503ab8d8c0a519d141a44c5b"
+NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_SPLITS = ["reasoning_off", "reasoning_on"]
+NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_METADATA_COLUMNS = ["uuid", "license", "used_in", "reasoning"]
+NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_FEATURES = {
+    "messages": {
+        "feature": {
+            "role": {"dtype": "string", "_type": "Value"},
+            "content": {"dtype": "string", "_type": "Value"},
+            "reasoning_content": {"dtype": "string", "_type": "Value"},
+        },
+        "_type": "List",
+    },
+    "uuid": {"dtype": "string", "_type": "Value"},
+    "license": {"dtype": "string", "_type": "Value"},
+    "used_in": {"feature": {"dtype": "string", "_type": "Value"}, "_type": "List"},
+    "reasoning": {"dtype": "string", "_type": "Value"},
+}
+
 
 @dataclass(frozen=True)
 class InstructionDatasetConfig:
@@ -111,7 +130,7 @@ class InstructionDatasetConfig:
 
     Args:
         hf_dataset_id: The Hugging Face repo id of the dataset.
-        revision: The revision of the dataset to download. A 7-character commit hash.
+        revision: The revision of the dataset to download.
         adapter: Adapter that converts rows from this dataset to OpenAI chat format.
         metadata_columns: The columns to extract from the dataset. Check the dataset's schema for available columns.
         subsets: Data subsets (from HuggingFace config) to use. Empty list indicates to use all/default subset(s).
@@ -119,6 +138,8 @@ class InstructionDatasetConfig:
                 Defaults to `train` only
         name: Optional friendly name for the dataset; defaults to `hf_dataset_id`.
         max_parallelism: Max number of parallel data processing tasks. Reduce if needed to avoid HF rate limits.
+        load_dataset_features: Optional serialized Hugging Face features override for datasets with inconsistent
+            inferred split schemas.
     """
 
     hf_dataset_id: str
@@ -129,6 +150,7 @@ class InstructionDatasetConfig:
     subsets: list[str] = field(default_factory=lambda: [])
     splits: list[str] = field(default_factory=lambda: ["train"])
     max_parallelism: int | None = 32  # 32 works for free users; set to None to use default behavior (full parallelism)
+    load_dataset_features: dict[str, Any] | None = None
 
 
 def multi_turn_adapter(
@@ -138,6 +160,7 @@ def multi_turn_adapter(
     assistant_value: str = "assistant",
     system_value: str = "system",
     content_key: str = "content",
+    reasoning_content_key: str = "",
     metadata_remap: dict[str, str] | None = None,
     replacements: dict[str, str] | None = None,
     extra_metadata_fn=None,
@@ -150,6 +173,7 @@ def multi_turn_adapter(
         assistant_value=assistant_value,
         system_value=system_value,
         content_key=content_key,
+        reasoning_content_key=reasoning_content_key,
         metadata_remap=metadata_remap or {},
         replacements=replacements,
         extra_metadata_fn=extra_metadata_fn,
@@ -595,6 +619,21 @@ for split_name in NEMOTRON_V1_SPLITS:
         splits=[split_name],
     )
 
+for split_name in NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_SPLITS:
+    dataset_key = f"{NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID}/{split_name}"
+    INSTRUCTION_DATASET_NAME_TO_CONFIG[dataset_key] = InstructionDatasetConfig(
+        name=dataset_key,
+        hf_dataset_id=NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID,
+        revision=NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_REVISION,
+        adapter=multi_turn_adapter(
+            reasoning_content_key="reasoning_content",
+            extra_metadata_fn=reasoning_to_chat_kwargs,
+        ),
+        metadata_columns=NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_METADATA_COLUMNS,
+        splits=[split_name],
+        load_dataset_features=NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_FEATURES,
+    )
+
 
 def get_directory_friendly_dataset_name(hf_dataset_id: str) -> str:
     dataset_name = hf_dataset_id.replace("/", "--")
@@ -611,6 +650,8 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
 
     adapter_dict = dataclasses.asdict(adapter)
     adapter_dict["dataset_format"] = adapter_dict["dataset_format"].value
+    if adapter_dict.get("reasoning_content_key") == "":
+        del adapter_dict["reasoning_content_key"]
 
     def canonicalize(value):
         if isinstance(value, dict):
@@ -629,6 +670,9 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
         -{sorted(dataset_cfg.subsets)}\
         -{sorted(dataset_cfg.splits)}\
         -{adapter_signature_str}"
+    if dataset_cfg.load_dataset_features is not None:
+        features_signature = json.dumps(canonicalize(dataset_cfg.load_dataset_features), sort_keys=True)
+        config_str = f"{config_str}-{features_signature}"
     hashed_config_str = hashlib.md5(config_str.encode()).hexdigest()[:6]
 
     transform_step = ExecutorStep(
@@ -642,6 +686,7 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
             adapter=versioned(adapter),
             subsets=versioned(dataset_cfg.subsets),
             splits=versioned(dataset_cfg.splits),
+            load_dataset_features=versioned(dataset_cfg.load_dataset_features),
             max_parallelism=dataset_cfg.max_parallelism,
         ),
         override_output_path=f"documents/{dataset_name}-{dataset_cfg.revision}-{hashed_config_str}",

--- a/lib/marin/src/marin/transform/conversation/adapters.py
+++ b/lib/marin/src/marin/transform/conversation/adapters.py
@@ -132,7 +132,7 @@ class TransformAdapter:
                 content = conv[self.content_key]
                 if role == "assistant" and self.reasoning_content_key:
                     reasoning_content = conv.get(self.reasoning_content_key)
-                    if reasoning_content:
+                    if isinstance(reasoning_content, str) and reasoning_content.strip():
                         content = f"<think>{reasoning_content}</think>\n{content}"
                 messages.append(OpenAIChatMessage(role=role, content=content))
             return messages

--- a/lib/marin/src/marin/transform/conversation/adapters.py
+++ b/lib/marin/src/marin/transform/conversation/adapters.py
@@ -79,6 +79,7 @@ class TransformAdapter:
     assistant_value: str = "assistant"
     system_value: str = "system"
     content_key: str = "content"
+    reasoning_content_key: str = ""
     tool_value: str = "tool"
 
     # If specified, the key will be used to select the message with
@@ -128,7 +129,12 @@ class TransformAdapter:
             conversation = row[self.conversation_column]
             for conv in conversation:
                 role = role_to_openai_role[conv[self.role_key]]
-                messages.append(OpenAIChatMessage(role=role, content=conv[self.content_key]))
+                content = conv[self.content_key]
+                if role == "assistant" and self.reasoning_content_key:
+                    reasoning_content = conv.get(self.reasoning_content_key)
+                    if reasoning_content:
+                        content = f"<think>{reasoning_content}</think>\n{content}"
+                messages.append(OpenAIChatMessage(role=role, content=content))
             return messages
         elif self.dataset_format == InputDatasetFormat.INSTRUCT_COLUMN_RESPONSE:
             messages = []

--- a/lib/marin/src/marin/transform/conversation/transform_conversation.py
+++ b/lib/marin/src/marin/transform/conversation/transform_conversation.py
@@ -51,6 +51,7 @@ class TransformSFTDatasetConfig:
         adapter (TransformAdapter): Adapter responsible for mapping raw rows into OpenAI chat format.
         subsets (list[str]): Data subsets (from HuggingFace config) to use. Empty list indicates all/default subset(s).
         splits (list[str]): Data splits (e.g., `train`, `validation`) to use. Empty list indicates all splits.
+        load_dataset_features (dict | None): Optional serialized Hugging Face features override.
         max_parallelism (int | None): Maximum number of concurrent shard processing tasks.
             Set to lower values to avoid HF rate limits. Set to None for default behavior (full concurrency).
     """
@@ -62,6 +63,7 @@ class TransformSFTDatasetConfig:
     adapter: TransformAdapter
     subsets: list[str] = field(default_factory=lambda: [])  # Default behavior is to use all subsets
     splits: list[str] = field(default_factory=lambda: ["train"])  # Set to train; empty set means everything
+    load_dataset_features: dict[str, Any] | None = None
     max_parallelism: int | None = None  # None means use default behavior (full concurrency)
 
 
@@ -221,11 +223,24 @@ def _get_available_splits(cfg: TransformSFTDatasetConfig, subset: str | None) ->
     return [split for split in split_names if split not in ("validation", "test")]
 
 
+def _load_dataset_features(cfg: TransformSFTDatasetConfig) -> datasets.Features | None:
+    load_dataset_features = unwrap_versioned_value(cfg.load_dataset_features)
+    if load_dataset_features is None:
+        return None
+    return datasets.Features.from_dict(load_dataset_features)
+
+
 def _shard_filename(output_path: str, shard_idx: int) -> str:
     return os.path.join(output_path, f"shard_{shard_idx:05d}.jsonl.gz")
 
 
-def _streaming_dataset_kwargs(source: str, split: str, revision: str, subset: str | None) -> dict[str, object]:
+def _streaming_dataset_kwargs(
+    source: str,
+    split: str,
+    revision: str,
+    subset: str | None,
+    features: datasets.Features | None = None,
+) -> dict[str, object]:
     """Build kwargs for a streaming ``datasets.load_dataset`` call.
 
     The HF config name is omitted for the default/unnamed subset so the loader
@@ -239,6 +254,8 @@ def _streaming_dataset_kwargs(source: str, split: str, revision: str, subset: st
     }
     if subset not in (None, "default"):
         kwargs["name"] = subset
+    if features is not None:
+        kwargs["features"] = features
     return kwargs
 
 
@@ -288,7 +305,13 @@ def get_dataset_tasks(cfg: TransformSFTDatasetConfig):
 
             dataset = load_dataset_with_backoff(
                 context=f"{source} subset={subset_name} split={split}",
-                **_streaming_dataset_kwargs(source, split, revision, subset),
+                **_streaming_dataset_kwargs(
+                    source,
+                    split,
+                    revision,
+                    subset,
+                    features=_load_dataset_features(cfg),
+                ),
             )
             num_shards = dataset.num_shards
             if not num_shards:
@@ -336,7 +359,13 @@ def process_shard_task(task: ShardTask) -> dict:
 
     dataset = load_dataset_with_backoff(
         context=f"{task.source} subset={subset_name} split={task.split} shard={task.shard_idx}",
-        **_streaming_dataset_kwargs(task.source, task.split, task.revision, task.subset),
+        **_streaming_dataset_kwargs(
+            task.source,
+            task.split,
+            task.revision,
+            task.subset,
+            features=_load_dataset_features(task.cfg),
+        ),
     )
     shard_dataset = dataset.shard(num_shards=task.num_shards, index=task.shard_idx)
 

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -15,6 +15,9 @@ from experiments.posttrain.instruction_datasets import (
     NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID,
     NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_METADATA_COLUMNS,
     NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_REVISION,
+    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID,
+    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_METADATA_COLUMNS,
+    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_REVISION,
     SYNTHETIC2_SFT_VERIFIED_HF_ID,
     SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
     SYNTHETIC2_SFT_VERIFIED_REVISION,
@@ -55,6 +58,27 @@ NEMOTRON_SFT_REASONING_ON_SAMPLE = {
             "role": "assistant",
             "content": "I look forward to meeting you.",
             "reasoning_content": "The phrase should use the gerund after 'look forward to'.",
+        },
+    ],
+}
+
+NEMOTRON_SFT_V3_INSTRUCTION_FOLLOWING_SAMPLE = {
+    "uuid": "4dd07659-302a-40c0-933b-7ed2b7661638",
+    "used_in": ["ultra_v3"],
+    "metadata": {
+        "seed_dataset": "allenai/tulu-3-sft-personas-instruction-following",
+        "seed_prompt_sha256": "d178cc7601e92234c0d84fbb0cafe64432e4821271bde8c1024fcf8ea44a89c3",
+        "model": "openai/GPT-OSS-120B",
+        "reward_model": None,
+        "train_turns": [False, False, True],
+    },
+    "messages": [
+        {"role": "system", "content": "You are a helpful assistant."},
+        {"role": "user", "content": "Explain why useHistory is unavailable in react-router-dom v6."},
+        {
+            "role": "assistant",
+            "reasoning_content": "React Router v6 removed useHistory and replaced it with useNavigate.",
+            "content": "In react-router-dom v6, useHistory was removed. Use useNavigate instead.",
         },
     ],
 }
@@ -173,6 +197,43 @@ def test_nemotron_sft_instruction_following_chat_v2_features_accept_both_message
     assert reasoning_off["messages"][2]["reasoning_content"] is None
     expected_reasoning = "The phrase should use the gerund after 'look forward to'."
     assert reasoning_on["messages"][2]["reasoning_content"] == expected_reasoning
+
+
+def test_nemotron_sft_instruction_following_chat_v3_transforms_instruction_following_rows():
+    dataset_key = f"{NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID}/instruction_following"
+    step = get_instruction_dataset(dataset_key)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    assert step.name == f"documents/{dataset_key}"
+    assert step.override_output_path is not None
+    assert "instruction_following" in step.override_output_path
+    assert f"{NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID}/chat" not in INSTRUCTION_DATASET_NAME_TO_CONFIG
+    assert unwrap_versioned_value(cfg.source) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_REVISION
+    assert unwrap_versioned_value(cfg.splits) == ["instruction_following"]
+    assert unwrap_versioned_value(cfg.metadata_columns) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_METADATA_COLUMNS
+    assert unwrap_versioned_value(cfg.load_dataset_features) is None
+    assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+    assert adapter.reasoning_content_key == "reasoning_content"
+
+    result = transform_row(NEMOTRON_SFT_V3_INSTRUCTION_FOLLOWING_SAMPLE, cfg, adapter)
+
+    assert result is not None
+    assert result.source == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID
+    assert [message.role for message in result.messages] == ["system", "user", "assistant"]
+    assert result.messages[2].content == "\n".join(
+        [
+            "<|start_think|>React Router v6 removed useHistory and replaced it with useNavigate.<|end_think|>",
+            "In react-router-dom v6, useHistory was removed. Use useNavigate instead.",
+        ]
+    )
+    assert result.metadata == {
+        "uuid": "4dd07659-302a-40c0-933b-7ed2b7661638",
+        "used_in": ["ultra_v3"],
+        "metadata": NEMOTRON_SFT_V3_INSTRUCTION_FOLLOWING_SAMPLE["metadata"],
+    }
+    assert result.model_dump()["chat_template_kwargs"] == {"enable_thinking": True}
 
 
 def test_default_reasoning_content_key_does_not_rehash_existing_instruction_datasets():

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -1,6 +1,8 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import pytest
+from datasets import Features
 from marin.execution.executor import unwrap_versioned_value
 from marin.transform.conversation.adapters import InputDatasetFormat
 from marin.transform.conversation.transform_conversation import transform_row
@@ -9,6 +11,10 @@ from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_METADATA_COLUMNS,
     FINEPROOFS_SFT_REVISION,
     INSTRUCTION_DATASET_NAME_TO_CONFIG,
+    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_FEATURES,
+    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID,
+    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_METADATA_COLUMNS,
+    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_REVISION,
     SYNTHETIC2_SFT_VERIFIED_HF_ID,
     SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
     SYNTHETIC2_SFT_VERIFIED_REVISION,
@@ -22,6 +28,34 @@ SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
     "messages": [
         {"role": "user", "content": "Write Python code to count the intersection of two sets."},
         {"role": "assistant", "content": "<think>Use set intersection.</think>\n```python\nprint(len(a & b))\n```"},
+    ],
+}
+
+NEMOTRON_SFT_REASONING_OFF_SAMPLE = {
+    "uuid": "8ebb12a4-4f9a-4dd1-bd04-3473ef2450a2",
+    "license": "ODC-By",
+    "used_in": ["super_v3"],
+    "reasoning": "off",
+    "messages": [
+        {"role": "system", "content": "", "reasoning_content": None},
+        {"role": "user", "content": "Polish the sentence: I look forward to meet you.", "reasoning_content": None},
+        {"role": "assistant", "content": "I look forward to meeting you.", "reasoning_content": None},
+    ],
+}
+
+NEMOTRON_SFT_REASONING_ON_SAMPLE = {
+    "uuid": "ba6e772a-e496-4d39-b6c3-7f1205a12719",
+    "license": "ODC-By",
+    "used_in": ["super_v3"],
+    "reasoning": "on",
+    "messages": [
+        {"role": "system", "content": "", "reasoning_content": None},
+        {"role": "user", "content": "Polish the sentence: I look forward to meet you.", "reasoning_content": None},
+        {
+            "role": "assistant",
+            "content": "I look forward to meeting you.",
+            "reasoning_content": "The phrase should use the gerund after 'look forward to'.",
+        },
     ],
 }
 
@@ -69,6 +103,85 @@ def test_get_instruction_dataset_preserves_fineproofs_config():
     assert unwrap_versioned_value(proof_only_cfg.metadata_columns) == FINEPROOFS_SFT_METADATA_COLUMNS
     assert unwrap_versioned_value(proof_only_cfg.adapter).dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE
     assert proof_only_step.name == "documents/lm-provers/FineProofs-SFT/proof-only"
+
+
+@pytest.mark.parametrize(
+    ("split", "sample", "expected_assistant_content", "expected_thinking"),
+    [
+        (
+            "reasoning_off",
+            NEMOTRON_SFT_REASONING_OFF_SAMPLE,
+            "I look forward to meeting you.",
+            False,
+        ),
+        (
+            "reasoning_on",
+            NEMOTRON_SFT_REASONING_ON_SAMPLE,
+            "\n".join(
+                [
+                    "<|start_think|>The phrase should use the gerund after 'look forward to'.<|end_think|>",
+                    "I look forward to meeting you.",
+                ]
+            ),
+            True,
+        ),
+    ],
+)
+def test_nemotron_sft_instruction_following_chat_v2_transforms_reasoning_split_rows(
+    split,
+    sample,
+    expected_assistant_content,
+    expected_thinking,
+):
+    dataset_key = f"{NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID}/{split}"
+    step = get_instruction_dataset(dataset_key)
+    cfg = step.config
+    adapter = unwrap_versioned_value(cfg.adapter)
+
+    assert step.name == f"documents/{dataset_key}"
+    assert step.override_output_path is not None
+    assert split in step.override_output_path
+    assert unwrap_versioned_value(cfg.source) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_REVISION
+    assert unwrap_versioned_value(cfg.splits) == [split]
+    assert unwrap_versioned_value(cfg.metadata_columns) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_METADATA_COLUMNS
+    assert unwrap_versioned_value(cfg.load_dataset_features) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_FEATURES
+    assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
+    assert adapter.reasoning_content_key == "reasoning_content"
+
+    result = transform_row(sample, cfg, adapter)
+
+    assert result is not None
+    assert result.source == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID
+    assert [message.role for message in result.messages] == ["system", "user", "assistant"]
+    assert result.messages[2].content == expected_assistant_content
+    assert result.metadata == {
+        "uuid": sample["uuid"],
+        "license": "ODC-By",
+        "used_in": ["super_v3"],
+        "reasoning": split.removeprefix("reasoning_"),
+    }
+    assert result.model_dump()["chat_template_kwargs"] == {"enable_thinking": expected_thinking}
+
+
+def test_nemotron_sft_instruction_following_chat_v2_features_accept_both_message_shapes():
+    features = Features.from_dict(NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_FEATURES)
+
+    reasoning_off = features.encode_example(NEMOTRON_SFT_REASONING_OFF_SAMPLE)
+    reasoning_on = features.encode_example(NEMOTRON_SFT_REASONING_ON_SAMPLE)
+
+    assert reasoning_off["messages"][2]["reasoning_content"] is None
+    expected_reasoning = "The phrase should use the gerund after 'look forward to'."
+    assert reasoning_on["messages"][2]["reasoning_content"] == expected_reasoning
+
+
+def test_default_reasoning_content_key_does_not_rehash_existing_instruction_datasets():
+    step = get_instruction_dataset(SYNTHETIC2_SFT_VERIFIED_HF_ID)
+
+    assert (
+        step.override_output_path
+        == f"documents/PrimeIntellect--SYNTHETIC-2-SFT-verified-{SYNTHETIC2_SFT_VERIFIED_REVISION}-409fa9"
+    )
 
 
 def test_synthetic2_sft_verified_step_transforms_chat_rows():

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -12,17 +12,16 @@ from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_REVISION,
     INSTRUCTION_DATASET_NAME_TO_CONFIG,
     NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_FEATURES,
-    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID,
-    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_METADATA_COLUMNS,
-    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_REVISION,
-    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID,
-    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_METADATA_COLUMNS,
-    NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_REVISION,
     SYNTHETIC2_SFT_VERIFIED_HF_ID,
     SYNTHETIC2_SFT_VERIFIED_METADATA_COLUMNS,
     SYNTHETIC2_SFT_VERIFIED_REVISION,
     get_instruction_dataset,
 )
+
+NEMOTRON_SFT_IF_CHAT_V2_HF_ID = "nvidia/Nemotron-SFT-Instruction-Following-Chat-v2"
+NEMOTRON_SFT_IF_CHAT_V2_REVISION = "1a9454ed054b8544503ab8d8c0a519d141a44c5b"
+NEMOTRON_SFT_IF_CHAT_V3_HF_ID = "nvidia/Nemotron-SFT-Instruction-Following-Chat-v3"
+NEMOTRON_SFT_IF_CHAT_V3_REVISION = "be3b3e04ef605ac9d3f8f35b9d5a632f4a3a3402"
 
 SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
     "problem_id": "prime_rl_code_21747",
@@ -80,6 +79,23 @@ NEMOTRON_SFT_V3_INSTRUCTION_FOLLOWING_SAMPLE = {
             "reasoning_content": "React Router v6 removed useHistory and replaced it with useNavigate.",
             "content": "In react-router-dom v6, useHistory was removed. Use useNavigate instead.",
         },
+    ],
+}
+
+NEMOTRON_SFT_V3_NO_REASONING_SAMPLE = {
+    "uuid": "1f875358-47c4-444a-97c4-8b252a5f132a",
+    "used_in": ["ultra_v3"],
+    "metadata": {
+        "seed_dataset": "allenai/tulu-3-sft-personas-instruction-following",
+        "seed_prompt_sha256": "8e86d2834d9ebd0bc6a0ba599950a1f7d8b59cb9dc4daafca8d970feff9d77ab",
+        "model": "openai/GPT-OSS-120B",
+        "reward_model": None,
+        "train_turns": [False, False, True],
+    },
+    "messages": [
+        {"role": "system", "content": "You are a concise assistant."},
+        {"role": "user", "content": "Name the HTTP status code for a missing page."},
+        {"role": "assistant", "reasoning_content": "", "content": "404 Not Found."},
     ],
 }
 
@@ -157,7 +173,7 @@ def test_nemotron_sft_instruction_following_chat_v2_transforms_reasoning_split_r
     expected_assistant_content,
     expected_thinking,
 ):
-    dataset_key = f"{NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID}/{split}"
+    dataset_key = f"{NEMOTRON_SFT_IF_CHAT_V2_HF_ID}/{split}"
     step = get_instruction_dataset(dataset_key)
     cfg = step.config
     adapter = unwrap_versioned_value(cfg.adapter)
@@ -165,10 +181,9 @@ def test_nemotron_sft_instruction_following_chat_v2_transforms_reasoning_split_r
     assert step.name == f"documents/{dataset_key}"
     assert step.override_output_path is not None
     assert split in step.override_output_path
-    assert unwrap_versioned_value(cfg.source) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID
-    assert unwrap_versioned_value(cfg.revision) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_REVISION
+    assert unwrap_versioned_value(cfg.source) == NEMOTRON_SFT_IF_CHAT_V2_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == NEMOTRON_SFT_IF_CHAT_V2_REVISION
     assert unwrap_versioned_value(cfg.splits) == [split]
-    assert unwrap_versioned_value(cfg.metadata_columns) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_METADATA_COLUMNS
     assert unwrap_versioned_value(cfg.load_dataset_features) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_FEATURES
     assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
     assert adapter.reasoning_content_key == "reasoning_content"
@@ -176,7 +191,7 @@ def test_nemotron_sft_instruction_following_chat_v2_transforms_reasoning_split_r
     result = transform_row(sample, cfg, adapter)
 
     assert result is not None
-    assert result.source == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V2_HF_ID
+    assert result.source == NEMOTRON_SFT_IF_CHAT_V2_HF_ID
     assert [message.role for message in result.messages] == ["system", "user", "assistant"]
     assert result.messages[2].content == expected_assistant_content
     assert result.metadata == {
@@ -199,8 +214,32 @@ def test_nemotron_sft_instruction_following_chat_v2_features_accept_both_message
     assert reasoning_on["messages"][2]["reasoning_content"] == expected_reasoning
 
 
-def test_nemotron_sft_instruction_following_chat_v3_transforms_instruction_following_rows():
-    dataset_key = f"{NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID}/instruction_following"
+@pytest.mark.parametrize(
+    ("sample", "expected_assistant_content", "expected_thinking"),
+    [
+        (
+            NEMOTRON_SFT_V3_INSTRUCTION_FOLLOWING_SAMPLE,
+            "\n".join(
+                [
+                    "<|start_think|>React Router v6 removed useHistory and replaced it with useNavigate.<|end_think|>",
+                    "In react-router-dom v6, useHistory was removed. Use useNavigate instead.",
+                ]
+            ),
+            True,
+        ),
+        (
+            NEMOTRON_SFT_V3_NO_REASONING_SAMPLE,
+            "404 Not Found.",
+            False,
+        ),
+    ],
+)
+def test_nemotron_sft_instruction_following_chat_v3_transforms_instruction_following_rows(
+    sample,
+    expected_assistant_content,
+    expected_thinking,
+):
+    dataset_key = f"{NEMOTRON_SFT_IF_CHAT_V3_HF_ID}/instruction_following"
     step = get_instruction_dataset(dataset_key)
     cfg = step.config
     adapter = unwrap_versioned_value(cfg.adapter)
@@ -208,32 +247,26 @@ def test_nemotron_sft_instruction_following_chat_v3_transforms_instruction_follo
     assert step.name == f"documents/{dataset_key}"
     assert step.override_output_path is not None
     assert "instruction_following" in step.override_output_path
-    assert f"{NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID}/chat" not in INSTRUCTION_DATASET_NAME_TO_CONFIG
-    assert unwrap_versioned_value(cfg.source) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID
-    assert unwrap_versioned_value(cfg.revision) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_REVISION
+    assert f"{NEMOTRON_SFT_IF_CHAT_V3_HF_ID}/chat" not in INSTRUCTION_DATASET_NAME_TO_CONFIG
+    assert unwrap_versioned_value(cfg.source) == NEMOTRON_SFT_IF_CHAT_V3_HF_ID
+    assert unwrap_versioned_value(cfg.revision) == NEMOTRON_SFT_IF_CHAT_V3_REVISION
     assert unwrap_versioned_value(cfg.splits) == ["instruction_following"]
-    assert unwrap_versioned_value(cfg.metadata_columns) == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_METADATA_COLUMNS
     assert unwrap_versioned_value(cfg.load_dataset_features) is None
     assert adapter.dataset_format == InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN
     assert adapter.reasoning_content_key == "reasoning_content"
 
-    result = transform_row(NEMOTRON_SFT_V3_INSTRUCTION_FOLLOWING_SAMPLE, cfg, adapter)
+    result = transform_row(sample, cfg, adapter)
 
     assert result is not None
-    assert result.source == NEMOTRON_SFT_INSTRUCTION_FOLLOWING_CHAT_V3_HF_ID
+    assert result.source == NEMOTRON_SFT_IF_CHAT_V3_HF_ID
     assert [message.role for message in result.messages] == ["system", "user", "assistant"]
-    assert result.messages[2].content == "\n".join(
-        [
-            "<|start_think|>React Router v6 removed useHistory and replaced it with useNavigate.<|end_think|>",
-            "In react-router-dom v6, useHistory was removed. Use useNavigate instead.",
-        ]
-    )
+    assert result.messages[2].content == expected_assistant_content
     assert result.metadata == {
-        "uuid": "4dd07659-302a-40c0-933b-7ed2b7661638",
+        "uuid": sample["uuid"],
         "used_in": ["ultra_v3"],
-        "metadata": NEMOTRON_SFT_V3_INSTRUCTION_FOLLOWING_SAMPLE["metadata"],
+        "metadata": sample["metadata"],
     }
-    assert result.model_dump()["chat_template_kwargs"] == {"enable_thinking": True}
+    assert result.model_dump()["chat_template_kwargs"] == {"enable_thinking": expected_thinking}
 
 
 def test_default_reasoning_content_key_does_not_rehash_existing_instruction_datasets():


### PR DESCRIPTION
Register nvidia/Nemotron-SFT-Instruction-Following-Chat-v2 by split and nvidia/Nemotron-SFT-Instruction-Following-Chat-v3 instruction_following for SFT instruction-following and broad chat training. Preserve assistant reasoning_content by folding it into think tags before the standard conversation transform rewrites them, add the v2 schema override needed for mixed reasoning_content nullability, and keep existing instruction dataset output paths stable when reasoning_content_key is unused.