### PR TITLE
nightshift: raise slow-test threshold from 8s to 60s

### DIFF
--- a/infra/scripts/nightshift_ci_tests.py
+++ b/infra/scripts/nightshift_ci_tests.py
@@ -33,7 +33,7 @@ MAX_RUNS_PER_WORKFLOW = 5
 MAX_CANDIDATES = 8
 MAX_CANDIDATES_PER_FILE = 2
 MIN_FAILURE_RUNS = 2
-MIN_SLOW_SECONDS = 8.0
+MIN_SLOW_SECONDS = 60.0
 # Require a test to land in the per-workflow `--durations` slow window in at least
 # this many distinct runs before treating it as actionable. Single-observation
 # slow hits are dominated by JIT warm-up cost and cold imports; they are not


### PR DESCRIPTION
## Summary
- `MIN_SLOW_SECONDS` in `infra/scripts/nightshift_ci_tests.py` is bumped from 8s to 60s.
- 8s was too aggressive — it surfaced tests dominated by JIT warm-up, cold imports, and fixture setup rather than real perf regressions. 60s focuses the nightly audit on tests slow enough to warrant attention.

## Test plan
- [ ] Next scheduled run of `Ops - Nightshift CI Tests` produces a shorter, more actionable slow-test candidate list.