### PR TITLE
Add temporary checkpoint retention count

### DIFF
--- a/experiments/llama_3_8b_rl_math500.py
+++ b/experiments/llama_3_8b_rl_math500.py
@@ -138,7 +138,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--keep-last-temporary-checkpoints",
         type=int,
-        default=1,
+        default=5,
         help="Number of complete temporary checkpoints to retain after a successful temporary checkpoint save. "
         "Use 0 to delete temporary checkpoints after they commit.",
     )

--- a/experiments/llama_3_8b_rl_math500.py
+++ b/experiments/llama_3_8b_rl_math500.py
@@ -136,11 +136,11 @@ def parse_args() -> argparse.Namespace:
         help="Seconds between trainer checkpoint saves.",
     )
     parser.add_argument(
-        "--delete-previous-temporary-checkpoint-after-save",
-        action=argparse.BooleanOptionalAction,
-        default=False,
-        help="Delete the previous temporary checkpoint after a successful new save. "
-        "Defaults to false to match the current clean 500-step baseline.",
+        "--keep-last-temporary-checkpoints",
+        type=int,
+        default=1,
+        help="Number of complete temporary checkpoints to retain after a successful temporary checkpoint save. "
+        "Use 0 to delete temporary checkpoints after they commit.",
     )
     parser.add_argument(
         "--debug-checkpointer",
@@ -230,7 +230,7 @@ def build_experiment_config(args: argparse.Namespace) -> RLExperimentConfig:
         tags=tags,
         num_train_steps=args.num_train_steps,
         checkpointer_save_interval=args.checkpointer_save_interval,
-        delete_previous_temporary_checkpoint_after_save=args.delete_previous_temporary_checkpoint_after_save,
+        keep_last_temporary_checkpoints=args.keep_last_temporary_checkpoints,
         checkpoint_debug=CheckpointDebugConfig(
             enabled=args.debug_checkpointer,
             log_interval=args.debug_checkpointer_log_interval,

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -369,6 +369,33 @@ class CheckpointDebugConfig:
         self.validate()
 
 
+@dataclass(frozen=True)
+class _TemporaryCheckpointRecord:
+    path: str
+    step: int
+    timestamp: datetime.datetime
+
+
+def _temporary_checkpoint_sort_key(record: _TemporaryCheckpointRecord) -> tuple[int, datetime.datetime, str]:
+    return (record.step, record.timestamp, record.path)
+
+
+def _temporary_checkpoint_record(checkpoint_path: str) -> _TemporaryCheckpointRecord | None:
+    try:
+        metadata = _load_metadata(checkpoint_path)
+        if not metadata.get("is_temporary", False):
+            return None
+
+        return _TemporaryCheckpointRecord(
+            path=checkpoint_path,
+            step=int(metadata["step"]),
+            timestamp=datetime.datetime.fromisoformat(metadata["timestamp"]),
+        )
+    except Exception:
+        logger.exception("Error loading metadata for checkpoint %s", checkpoint_path)
+        return None
+
+
 class Checkpointer:
     """
     A checkpointer class that saves checkpoints with two different, but overlapping policies: time and step.
@@ -383,7 +410,7 @@ class Checkpointer:
         default_factory=lambda: [CheckpointInterval(every=1000)]
     )
 
-    _last_temporary_checkpoint: Optional[str] = None
+    _temporary_checkpoints: list["_TemporaryCheckpointRecord"]
 
     def __init__(
         self,
@@ -395,7 +422,7 @@ class Checkpointer:
         keep_params: PyTree[FilterSpec] = True,
         dt_now_injection: Optional[Callable[[], datetime.datetime]] = None,
         delete_old_temp_checkpoints: bool = True,
-        delete_previous_temporary_checkpoint_after_save: bool = True,
+        keep_last_temporary_checkpoints: int = 1,
         debug: CheckpointDebugConfig | None = None,
     ):
         """
@@ -416,10 +443,14 @@ class Checkpointer:
             keep_params: a PyTree of FilterSpecs that specifies which parameters to keep in the checkpoint
             dt_now_injection: a function that returns the current time. useful for testing
             delete_old_temp_checkpoints: if True, carry forward a temporary checkpoint discovered at startup so the
-                next successful save can clean it up.
-            delete_previous_temporary_checkpoint_after_save: if True, delete the previously saved temporary checkpoint
-                after a new checkpoint commits successfully.
+                next successful save can clean it up according to keep_last_temporary_checkpoints.
+            keep_last_temporary_checkpoints: number of complete temporary checkpoints to retain after a temporary
+                checkpoint commits successfully. Set to 0 to delete temporary checkpoints after they commit. Permanent
+                checkpoints still clean up temporary checkpoints because they supersede them for recovery.
         """
+        if keep_last_temporary_checkpoints < 0:
+            raise ValueError("keep_last_temporary_checkpoints must be non-negative")
+
         self.base_path = str(base_path)
         self.temporary_base_path = str(temporary_base_path) if temporary_base_path is not None else None
         self.save_interval = save_interval
@@ -428,8 +459,9 @@ class Checkpointer:
         self._dt_now_injection = dt_now_injection or datetime.datetime.now
         self._last_save_time = self._dt_now_injection()
         self._last_save_step = 0
-        self.delete_previous_temporary_checkpoint_after_save = delete_previous_temporary_checkpoint_after_save
+        self.keep_last_temporary_checkpoints = keep_last_temporary_checkpoints
         self.debug = debug or CheckpointDebugConfig()
+        self._temporary_checkpoints = []
 
         # ensure that the step_policies are sorted. We could sort, but instead we'll just insist that they are sorted
         # since it's probably a typo if they aren't
@@ -455,23 +487,13 @@ class Checkpointer:
             self._async_checkpoint_remover_thread.start()
             self._checkpoint_being_removed = None
 
-        # discover latest checkpoint and see if it's temporary
-        self._last_temporary_checkpoint = None
-        # Check both base_path and temporary_base_path for prior temporary checkpoints
-        search_paths = [self.base_path]
-        if self.temporary_base_path is not None:
-            search_paths.append(self.temporary_base_path)
-        for search_path in search_paths:
-            latest_checkpoint = discover_latest_checkpoint(search_path)
-            if latest_checkpoint is not None and delete_old_temp_checkpoints:
-                metadata = _load_metadata(latest_checkpoint)
-                if metadata.get("is_temporary", False):
-                    logger.info(
-                        f"Found prior temporary checkpoint {latest_checkpoint}. We will delete it after"
-                        " saving a new checkpoint."
-                    )
-                    self._last_temporary_checkpoint = latest_checkpoint
-                    break
+        if jax.process_index() == 0 and delete_old_temp_checkpoints:
+            self._temporary_checkpoints = self._discover_temporary_checkpoints()
+            if self._temporary_checkpoints:
+                logger.info(
+                    "Found prior temporary checkpoints %s. They will be cleaned up after saving a new checkpoint.",
+                    [record.path for record in self._temporary_checkpoints],
+                )
 
     def load_checkpoint(
         self,
@@ -545,7 +567,6 @@ class Checkpointer:
                 logger.info(f"Saving temporary checkpoint at step {step}.")
 
         if should_save:
-            last_checkpoint = self._last_temporary_checkpoint
             destination = f"step-{step}"
 
             # Route temporary checkpoints to temporary_base_path when configured
@@ -554,38 +575,15 @@ class Checkpointer:
             else:
                 save_base_path = self.base_path
 
-            if not save_permanent_ckpt:
-                self._last_temporary_checkpoint = os.path.join(save_base_path, destination)
-            else:
-                self._last_temporary_checkpoint = None
+            checkpoint_path = os.path.join(save_base_path, destination)
 
             def callback():
-                if last_checkpoint is not None:
-                    if not self.delete_previous_temporary_checkpoint_after_save:
-                        logger.info(
-                            "Keeping previous temporary checkpoint %s after saving new checkpoint because "
-                            "delete_previous_temporary_checkpoint_after_save=False.",
-                            last_checkpoint,
-                        )
-                        return
-                    # check if we still want to delete it. Sometimes we like to replace the metadata of the last
-                    # checkpoint. It'd be nice if the process weren't manual, but this is a good compromise
-                    try:
-                        last_metadata = _load_metadata(last_checkpoint)
-                        if last_metadata.get("is_temporary", False):
-                            logger.info(
-                                f"Deleting old temporary checkpoint {last_checkpoint} after saving new checkpoint."
-                            )
-                            # we can delete the last temporary checkpoint now
-                            self._rm_checkpoint(last_checkpoint)
-                        else:
-                            logger.info(
-                                f"Not deleting old temporary checkpoint {last_checkpoint} because it is no longer"
-                                " temporary."
-                            )
-                    except FileNotFoundError:
-                        logger.warning(f"Could not load metadata for last temporary checkpoint {last_checkpoint}.")
-                        # if we can't load the metadata, we can't delete it, so just log a warning
+                if jax.process_index() == 0:
+                    if not save_permanent_ckpt:
+                        self._record_temporary_checkpoint(checkpoint_path)
+                        self._prune_temporary_checkpoints(self.keep_last_temporary_checkpoints)
+                    else:
+                        self._prune_temporary_checkpoints(0)
 
             self.save_checkpoint(
                 tree=tree,
@@ -595,6 +593,56 @@ class Checkpointer:
                 is_temporary=not save_permanent_ckpt,
                 base_path_override=save_base_path,
             )
+
+    def _discover_temporary_checkpoints(self) -> list["_TemporaryCheckpointRecord"]:
+        search_paths = [self.base_path]
+        if self.temporary_base_path is not None:
+            search_paths.append(self.temporary_base_path)
+
+        records_by_path: dict[str, _TemporaryCheckpointRecord] = {}
+        for search_path in search_paths:
+            for checkpoint_path in _discover_checkpoint_paths_single(search_path):
+                record = _temporary_checkpoint_record(checkpoint_path)
+                if record is not None:
+                    records_by_path[record.path] = record
+
+        return sorted(records_by_path.values(), key=_temporary_checkpoint_sort_key)
+
+    def _record_temporary_checkpoint(self, checkpoint_path: str) -> None:
+        record = _temporary_checkpoint_record(checkpoint_path)
+        if record is None:
+            logger.warning(
+                "New checkpoint %s was expected to be temporary but metadata does not say so.", checkpoint_path
+            )
+            return
+
+        records_by_path = {existing.path: existing for existing in self._temporary_checkpoints}
+        records_by_path[record.path] = record
+        self._temporary_checkpoints = sorted(records_by_path.values(), key=_temporary_checkpoint_sort_key)
+
+    def _prune_temporary_checkpoints(self, keep: int) -> None:
+        if keep == 0:
+            retained: list[_TemporaryCheckpointRecord] = []
+            to_delete = self._temporary_checkpoints
+        else:
+            retained = self._temporary_checkpoints[-keep:]
+            to_delete = self._temporary_checkpoints[:-keep]
+
+        for record in to_delete:
+            try:
+                metadata = _load_metadata(record.path)
+            except FileNotFoundError:
+                logger.warning("Could not load metadata for temporary checkpoint %s.", record.path)
+                continue
+
+            if metadata.get("is_temporary", False):
+                logger.info("Deleting old temporary checkpoint %s after saving new checkpoint.", record.path)
+                self._rm_checkpoint(record.path)
+            else:
+                logger.info("Not deleting checkpoint %s because it is no longer temporary.", record.path)
+                retained.append(record)
+
+        self._temporary_checkpoints = sorted(retained, key=_temporary_checkpoint_sort_key)
 
     def _get_current_step_save_interval(self, step):
         # binary search for the correct interval
@@ -974,23 +1022,10 @@ def latest_checkpoint_path(checkpoint_path: PathLike, *additional_paths: PathLik
 
 def _discover_latest_checkpoint_single(checkpoint_path: str) -> Optional[str]:
     """Discover the latest checkpoint in a single root path."""
-    fs: AbstractFileSystem
-    fs, _ = _get_fs_and_plain_path(checkpoint_path)
-
-    def is_checkpoint_dir(path: str):
-        return fs.exists(os.path.join(path, "metadata.json"))
-
-    def maybe_unstrip_protocol(path: str):
-        base_path_protocol = urllib.parse.urlparse(str(checkpoint_path)).scheme
-        if base_path_protocol != "" and not urllib.parse.urlparse(path).scheme != "":
-            return f"{base_path_protocol}://{path}"
-        return path
-
-    ckpt_dirs = [maybe_unstrip_protocol(d) for d in fs.glob(os.path.join(checkpoint_path, "*")) if fs.isdir(d)]
-    ckpt_dirs.append(checkpoint_path)
-    ckpt_dirs = [d for d in ckpt_dirs if is_checkpoint_dir(d)]
+    ckpt_dirs = _discover_checkpoint_paths_single(checkpoint_path)
 
     def checkpoint_sort_key(ckpt_dir):
+        fs, _ = _get_fs_and_plain_path(ckpt_dir)
         metadata = json.load(fs.open(os.path.join(ckpt_dir, "metadata.json")))
         return (datetime.datetime.fromisoformat(metadata["timestamp"]), metadata["step"])
 
@@ -999,6 +1034,25 @@ def _discover_latest_checkpoint_single(checkpoint_path: str) -> Optional[str]:
         return out
     else:
         return None
+
+
+def _discover_checkpoint_paths_single(checkpoint_path: str) -> list[str]:
+    """Discover valid checkpoint directories in a single root path."""
+    fs: AbstractFileSystem
+    fs, _ = _get_fs_and_plain_path(checkpoint_path)
+
+    def is_checkpoint_dir(path: str):
+        return fs.exists(os.path.join(path, "metadata.json"))
+
+    def maybe_unstrip_protocol(path: str):
+        base_path_protocol = urllib.parse.urlparse(str(checkpoint_path)).scheme
+        if base_path_protocol != "" and urllib.parse.urlparse(path).scheme == "":
+            return f"{base_path_protocol}://{path}"
+        return path
+
+    ckpt_dirs = [maybe_unstrip_protocol(d) for d in fs.glob(os.path.join(checkpoint_path, "*")) if fs.isdir(d)]
+    ckpt_dirs.append(checkpoint_path)
+    return sorted(d for d in ckpt_dirs if is_checkpoint_dir(d))
 
 
 def _get_fs_and_plain_path(path, fs=None):
@@ -1029,8 +1083,8 @@ class CheckpointerConfig:
 
     This is useful if the run is being preempted and restarted, and you want to keep the old checkpoints.
     """
-    delete_previous_temporary_checkpoint_after_save: bool = True
-    """If True, delete the previously saved temporary checkpoint after a successful new save."""
+    keep_last_temporary_checkpoints: int = 1
+    """Number of complete temporary checkpoints to retain after a successful temporary checkpoint commit."""
     debug: CheckpointDebugConfig = field(default_factory=CheckpointDebugConfig)
     """Checkpoint-path diagnostics. Disabled by default."""
 
@@ -1054,7 +1108,7 @@ class CheckpointerConfig:
             step_policies=keeps,
             temporary_base_path=self.expanded_temporary_path(run_id),
             delete_old_temp_checkpoints=self.delete_old_temp_checkpoints,
-            delete_previous_temporary_checkpoint_after_save=self.delete_previous_temporary_checkpoint_after_save,
+            keep_last_temporary_checkpoints=self.keep_last_temporary_checkpoints,
             debug=self.debug,
         )
 
@@ -1066,6 +1120,8 @@ class CheckpointerConfig:
             self.temporary_base_path = os.path.expanduser(self.temporary_base_path)
         if isinstance(self.debug, dict):
             self.debug = CheckpointDebugConfig(**self.debug)
+        if self.keep_last_temporary_checkpoints < 0:
+            raise ValueError("keep_last_temporary_checkpoints must be non-negative")
 
         # validate the checkpoint intervals.
         # we want to make sure that the intervals are monotonic. only the last one can be None

--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -383,17 +383,18 @@ def _temporary_checkpoint_sort_key(record: _TemporaryCheckpointRecord) -> tuple[
 def _temporary_checkpoint_record(checkpoint_path: str) -> _TemporaryCheckpointRecord | None:
     try:
         metadata = _load_metadata(checkpoint_path)
-        if not metadata.get("is_temporary", False):
-            return None
-
-        return _TemporaryCheckpointRecord(
-            path=checkpoint_path,
-            step=int(metadata["step"]),
-            timestamp=datetime.datetime.fromisoformat(metadata["timestamp"]),
-        )
-    except Exception:
-        logger.exception("Error loading metadata for checkpoint %s", checkpoint_path)
+    except FileNotFoundError:
+        logger.warning("Could not load metadata for checkpoint %s.", checkpoint_path)
         return None
+
+    if not metadata.get("is_temporary", False):
+        return None
+
+    return _TemporaryCheckpointRecord(
+        path=checkpoint_path,
+        step=int(metadata["step"]),
+        timestamp=datetime.datetime.fromisoformat(metadata["timestamp"]),
+    )
 
 
 class Checkpointer:

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -372,7 +372,7 @@ def test_trainer_config_checkpoint_search_paths():
 def test_checkpointer_config_propagates_debug_settings():
     config = CheckpointerConfig(
         base_path="/tmp/checkpoints",
-        delete_previous_temporary_checkpoint_after_save=False,
+        keep_last_temporary_checkpoints=3,
         debug=CheckpointDebugConfig(
             enabled=True,
             log_interval=12.5,
@@ -386,7 +386,7 @@ def test_checkpointer_config_propagates_debug_settings():
 
     checkpointer = config.create("run-1")
 
-    assert checkpointer.delete_previous_temporary_checkpoint_after_save is False
+    assert checkpointer.keep_last_temporary_checkpoints == 3
     assert checkpointer.debug.enabled is True
     assert checkpointer.debug.log_interval == 12.5
     assert checkpointer.debug.dump_stacks_after == 45.0
@@ -516,7 +516,7 @@ def test_checkpointer_deletes_previous_checkpoints_under_relative_base_paths():
         assert _get_checkpoint_steps(tmpdir) == [2]
 
 
-def test_checkpointer_can_keep_previous_temporary_checkpoint_after_save():
+def test_checkpointer_keeps_configured_temporary_checkpoints_after_save():
     fake_now = datetime.datetime(2021, 1, 1, 0, 0, 0)
     tick = 10
 
@@ -530,7 +530,7 @@ def test_checkpointer_can_keep_previous_temporary_checkpoint_after_save():
             timedelta(seconds=tick),
             [],
             dt_now_injection=lambda: fake_now,
-            delete_previous_temporary_checkpoint_after_save=False,
+            keep_last_temporary_checkpoints=2,
         )
 
         _on_step(checkpointer, 0)
@@ -544,6 +544,77 @@ def test_checkpointer_can_keep_previous_temporary_checkpoint_after_save():
         _on_step(checkpointer, 2)
         checkpointer.wait_until_finished()
         assert _get_checkpoint_steps(tmpdir) == [1, 2]
+
+        advance_time(tick)
+        _on_step(checkpointer, 3)
+        checkpointer.wait_until_finished()
+        assert _get_checkpoint_steps(tmpdir) == [2, 3]
+
+
+def test_checkpointer_keep_zero_deletes_temporary_checkpoint_after_commit():
+    fake_now = datetime.datetime(2021, 1, 1, 0, 0, 0)
+    tick = 10
+
+    def advance_time(delta_seconds):
+        nonlocal fake_now
+        fake_now += timedelta(seconds=delta_seconds)
+
+    with tempfile.TemporaryDirectory(prefix="checkpoints") as tmpdir:
+        checkpointer = Checkpointer(
+            tmpdir,
+            timedelta(seconds=tick),
+            [],
+            dt_now_injection=lambda: fake_now,
+            keep_last_temporary_checkpoints=0,
+        )
+
+        _on_step(checkpointer, 0)
+
+        advance_time(tick)
+        _on_step(checkpointer, 1)
+        checkpointer.wait_until_finished()
+
+        assert _get_checkpoint_steps(tmpdir) == []
+
+
+def test_checkpointer_discovers_temporary_checkpoints_across_base_paths_for_retention():
+    fake_now = datetime.datetime(2021, 1, 1, 0, 0, 0)
+    tick = 10
+
+    def advance_time(delta_seconds):
+        nonlocal fake_now
+        fake_now += timedelta(seconds=delta_seconds)
+
+    with tempfile.TemporaryDirectory() as permanent_dir, tempfile.TemporaryDirectory() as temp_dir:
+        save_checkpoint(dict(model=1), step=2, checkpoint_path=f"{permanent_dir}/step-2", is_temporary=True)
+        save_checkpoint(dict(model=2), step=8, checkpoint_path=f"{permanent_dir}/step-8", is_temporary=True)
+        save_checkpoint(dict(model=3), step=9, checkpoint_path=f"{permanent_dir}/step-9", is_temporary=False)
+        save_checkpoint(dict(model=4), step=7, checkpoint_path=f"{temp_dir}/step-7", is_temporary=True)
+
+        checkpointer = Checkpointer(
+            permanent_dir,
+            timedelta(seconds=tick),
+            [],
+            temporary_base_path=temp_dir,
+            dt_now_injection=lambda: fake_now,
+            keep_last_temporary_checkpoints=2,
+        )
+
+        _on_step(checkpointer, 0)
+        advance_time(tick)
+        _on_step(checkpointer, 10)
+        checkpointer.wait_until_finished()
+
+        assert _get_checkpoint_steps(permanent_dir) == [8, 9]
+        assert _get_checkpoint_steps(temp_dir) == [10]
+
+
+def test_checkpointer_rejects_negative_keep_last_temporary_checkpoints(tmp_path):
+    with pytest.raises(ValueError, match="keep_last_temporary_checkpoints must be non-negative"):
+        Checkpointer(tmp_path / "checkpoints", None, [], keep_last_temporary_checkpoints=-1)
+
+    with pytest.raises(ValueError, match="keep_last_temporary_checkpoints must be non-negative"):
+        CheckpointerConfig(keep_last_temporary_checkpoints=-1)
 
 
 def test_checkpointer_force_save_uses_permanent_path_even_when_time_policy_elapsed():

--- a/lib/marin/src/marin/rl/rl_experiment_utils.py
+++ b/lib/marin/src/marin/rl/rl_experiment_utils.py
@@ -82,7 +82,7 @@ class RLExperimentConfig:
     num_train_steps: int = 500
     steps_per_eval: int = 100
     checkpointer_save_interval: int = 600
-    keep_last_temporary_checkpoints: int = 1
+    keep_last_temporary_checkpoints: int = 5
     checkpoint_debug: CheckpointDebugConfig = dataclasses.field(default_factory=CheckpointDebugConfig)
 
     # wandb

--- a/lib/marin/src/marin/rl/rl_experiment_utils.py
+++ b/lib/marin/src/marin/rl/rl_experiment_utils.py
@@ -82,7 +82,7 @@ class RLExperimentConfig:
     num_train_steps: int = 500
     steps_per_eval: int = 100
     checkpointer_save_interval: int = 600
-    delete_previous_temporary_checkpoint_after_save: bool = True
+    keep_last_temporary_checkpoints: int = 1
     checkpoint_debug: CheckpointDebugConfig = dataclasses.field(default_factory=CheckpointDebugConfig)
 
     # wandb
@@ -270,7 +270,7 @@ def _build_rl_job_config(
         checkpointer=CheckpointerConfig(
             base_path=checkpoints_path,
             save_interval=datetime.timedelta(seconds=config.checkpointer_save_interval),
-            delete_previous_temporary_checkpoint_after_save=config.delete_previous_temporary_checkpoint_after_save,
+            keep_last_temporary_checkpoints=config.keep_last_temporary_checkpoints,
             debug=config.checkpoint_debug,
         ),
         mesh=MeshConfig(

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -61,7 +61,7 @@ def _test_config(
     train_ram: str | None = None,
     inference_ram: str | None = None,
     zone: str | None = None,
-    delete_previous_temporary_checkpoint_after_save: bool = True,
+    keep_last_temporary_checkpoints: int = 1,
     checkpoint_debug: CheckpointDebugConfig | None = None,
 ) -> RLExperimentConfig:
     return RLExperimentConfig(
@@ -87,7 +87,7 @@ def _test_config(
         train_ram=train_ram,
         inference_ram=inference_ram,
         zone=zone,
-        delete_previous_temporary_checkpoint_after_save=delete_previous_temporary_checkpoint_after_save,
+        keep_last_temporary_checkpoints=keep_last_temporary_checkpoints,
         checkpoint_debug=checkpoint_debug or CheckpointDebugConfig(),
     )
 
@@ -281,7 +281,7 @@ def test_build_rl_job_config_propagates_checkpoint_controls_and_instance_id(monk
             train_tpu_type="v5p-8",
             inference_tpu_type="v5p-8",
             zone="us-central1-b",
-            delete_previous_temporary_checkpoint_after_save=False,
+            keep_last_temporary_checkpoints=3,
             checkpoint_debug=CheckpointDebugConfig(
                 enabled=True,
                 log_interval=15.0,
@@ -298,7 +298,7 @@ def test_build_rl_job_config_propagates_checkpoint_controls_and_instance_id(monk
     assert job_config.run_config.zone == "us-central1-b"
     assert job_config.curriculum.actor_name == "curriculum-rl-test-instance"
     assert job_config.weight_transfer.coordinator_name == "wt-coord-rl-test-instance"
-    assert not job_config.trainer.checkpointer.delete_previous_temporary_checkpoint_after_save
+    assert job_config.trainer.checkpointer.keep_last_temporary_checkpoints == 3
     assert job_config.trainer.checkpointer.debug.enabled
     assert job_config.trainer.checkpointer.debug.log_interval == 15.0
     assert job_config.trainer.checkpointer.debug.dump_stacks_after == 45.0

--- a/tests/rl/test_rl_experiment_utils.py
+++ b/tests/rl/test_rl_experiment_utils.py
@@ -5,7 +5,6 @@ import dataclasses
 from types import SimpleNamespace
 
 import pytest
-from levanter.checkpoint import CheckpointDebugConfig
 from levanter.models.llama import LlamaConfig
 from marin.execution.artifact import PathMetadata
 from marin.execution.executor import ExecutorStep, output_path_of
@@ -58,11 +57,6 @@ def _test_config(
     *,
     train_tpu_type: str,
     inference_tpu_type: str,
-    train_ram: str | None = None,
-    inference_ram: str | None = None,
-    zone: str | None = None,
-    keep_last_temporary_checkpoints: int = 1,
-    checkpoint_debug: CheckpointDebugConfig | None = None,
 ) -> RLExperimentConfig:
     return RLExperimentConfig(
         model_config=ModelConfig(
@@ -84,11 +78,6 @@ def _test_config(
         experiment_name_suffix="test",
         train_tpu_type=train_tpu_type,
         inference_tpu_type=inference_tpu_type,
-        train_ram=train_ram,
-        inference_ram=inference_ram,
-        zone=zone,
-        keep_last_temporary_checkpoints=keep_last_temporary_checkpoints,
-        checkpoint_debug=checkpoint_debug or CheckpointDebugConfig(),
     )
 
 
@@ -240,68 +229,6 @@ def test_build_rl_job_config_uses_dummy_load_format_for_non_object_store_model_p
 
     assert job_config.inference_config.engine.load_format == "dummy"
     assert job_config.inference_config.engine.canonical_model_name == MODEL_NAME
-
-
-def test_build_rl_job_config_propagates_ram_overrides(monkeypatch):
-    class _FakeConverter:
-        def __init__(self, *args, **kwargs):
-            self.default_hf_config = SimpleNamespace(vocab_size=32000)
-
-    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
-    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
-
-    job_config = _build_rl_job_config(
-        name="rl-test",
-        config=_test_config(
-            train_tpu_type="v5p-8",
-            inference_tpu_type="v5p-8",
-            train_ram="300g",
-            inference_ram="300g",
-        ),
-        curriculum=_test_curriculum(),
-        model_path="gs://marin-us-central1/models/test-model",
-        output_path="gs://marin-us-central1/rl_testing/rl-test",
-    )
-
-    assert job_config.run_config.train_ram == "300g"
-    assert job_config.run_config.inference_ram == "300g"
-
-
-def test_build_rl_job_config_propagates_checkpoint_controls_and_instance_id(monkeypatch):
-    class _FakeConverter:
-        def __init__(self, *args, **kwargs):
-            self.default_hf_config = SimpleNamespace(vocab_size=32000)
-
-    monkeypatch.setattr("marin.rl.rl_experiment_utils._resolve_config_class", lambda _path: _FakeRuntimeLmConfig)
-    monkeypatch.setattr("marin.rl.rl_experiment_utils.HFCheckpointConverter", _FakeConverter)
-
-    job_config = _build_rl_job_config(
-        name="rl-test",
-        config=_test_config(
-            train_tpu_type="v5p-8",
-            inference_tpu_type="v5p-8",
-            zone="us-central1-b",
-            keep_last_temporary_checkpoints=3,
-            checkpoint_debug=CheckpointDebugConfig(
-                enabled=True,
-                log_interval=15.0,
-                dump_stacks_after=45.0,
-            ),
-        ),
-        curriculum=_test_curriculum(),
-        model_path="gs://marin-us-central1/models/test-model",
-        output_path="gs://marin-us-central1/rl_testing/rl-test",
-        instance_id="rl-test-instance",
-    )
-
-    assert job_config.instance_id == "rl-test-instance"
-    assert job_config.run_config.zone == "us-central1-b"
-    assert job_config.curriculum.actor_name == "curriculum-rl-test-instance"
-    assert job_config.weight_transfer.coordinator_name == "wt-coord-rl-test-instance"
-    assert job_config.trainer.checkpointer.keep_last_temporary_checkpoints == 3
-    assert job_config.trainer.checkpointer.debug.enabled
-    assert job_config.trainer.checkpointer.debug.log_interval == 15.0
-    assert job_config.trainer.checkpointer.debug.dump_stacks_after == 45.0
 
 
 def test_run_rl_experiment_step_returns_serializable_path_metadata(monkeypatch):


### PR DESCRIPTION
Replace single temporary-checkpoint deletion with keep_last_temporary_checkpoints so Levanter can retain a configurable number of temporary checkpoints while preserving permanent checkpoint cleanup. Update focused checkpoint and RL config tests.