### PR TITLE
[iris] stamp BUILD_DATE on every wheel build

### DIFF
--- a/lib/iris/hatch_build.py
+++ b/lib/iris/hatch_build.py
@@ -1,0 +1,57 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Hatchling build hook: stamp ``iris/_build_info.py`` on every wheel build.
+
+The Iris controller rejects clients whose ``client_revision_date`` predates a
+server-side floor (see :mod:`iris.version`). That date comes from
+``BUILD_DATE``, which this hook sets from ``git log`` on the iris source tree
+(so a wheel reports the age of the code it was built from), falling back to the
+build day when no git history is reachable. The stamped file is force-included
+into the wheel rather than written to the tracked source, keeping working trees
+clean.
+"""
+
+from __future__ import annotations
+
+import subprocess
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+
+from hatchling.builders.hooks.plugin.interface import BuildHookInterface
+
+
+class CustomBuildHook(BuildHookInterface):
+    def initialize(self, version: str, build_data: dict) -> None:
+        # Only the wheel ships importable code. Editable installs keep the
+        # git-log fallback (their tree is the live repo), so leave them alone.
+        if self.target_name != "wheel" or build_data.get("editable"):
+            return
+
+        stamped = (
+            "# Copyright The Marin Authors\n"
+            "# SPDX-License-Identifier: Apache-2.0\n\n"
+            "# Auto-generated at build time by lib/iris/hatch_build.py.\n\n"
+            f'BUILD_DATE = "{self._resolve_date()}"\n'
+        )
+        tmp = Path(tempfile.mkdtemp(prefix="iris-build-info-")) / "_build_info.py"
+        tmp.write_text(stamped)
+        build_data.setdefault("force_include", {})[str(tmp)] = "iris/_build_info.py"
+
+    def _resolve_date(self) -> str:
+        """Committer date (YYYY-MM-DD) of the iris source tree, or build day."""
+        root = Path(self.root)
+        try:
+            out = subprocess.check_output(
+                ["git", "log", "-1", "--format=%cs", "--", (root / "src" / "iris").as_posix()],
+                cwd=root,
+                text=True,
+                stderr=subprocess.DEVNULL,
+                timeout=5.0,
+            ).strip()
+            if out:
+                return out
+        except (subprocess.SubprocessError, OSError):
+            pass
+        return datetime.now(timezone.utc).strftime("%Y-%m-%d")

--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -79,6 +79,12 @@ packages = ["src/iris"]
 # probe in _bundled_iris_config_dir() in iris.cli.main).
 "config" = "iris/config"
 
+# Stamp iris/_build_info.py with the client revision date on every wheel build
+# (not just published ones), so non-editable git installs report a real date to
+# the controller instead of being rejected as stale. See hatch_build.py.
+[tool.hatch.build.targets.wheel.hooks.custom]
+path = "hatch_build.py"
+
 [tool.hatch.build.targets.sdist]
 # Without an explicit sdist scope, hatchling sweeps the whole iris/ directory
 # and bundles ~146 MiB of dashboard/node_modules (git-ignored but still on


### PR DESCRIPTION
Problem: when installing Marin from the latest patch of the git repo via pip/uv, a common iris client issue occurs: The version checkout is parsed as blank for dev releases, and thus it falls back to a way earlier version. This blocks launching things in iris, because the client does a version check to see if it is compatible with the server.


CC: @eric-czech: I think this is the solution to the iris client error that you mentioned in the meeting the other day. I experienced it too in the MarinFold repo, and my agent figured out the root cause. 

---

🤖 

Non-editable installs straight from a git URL (pip/uv install git+https://...) build through plain hatchling, bypassing scripts/python_libs_package.py, and the installed tree has no .git for iris.version's git-log fallback. BUILD_DATE stays empty, so the controller treats the client as the ancient feature-introduction build and rejects it ("client is too old").

Add a hatchling build hook that stamps iris/_build_info.py during every wheel build, resolving the date from `git log` on the iris source tree (matching iris.version._git_iris_date) with a build-day fallback when no git history is reachable. The file is force-included into the wheel, so tracked sources and editable installs are unaffected.
