### PR TITLE
iris: stabilize e2e smoke flakes (cluster-boot timeout, worker-detail screenshot)

### DIFF
--- a/lib/iris/tests/e2e/conftest.py
+++ b/lib/iris/tests/e2e/conftest.py
@@ -79,7 +79,10 @@ def pytest_addoption(parser):
 
 
 # Cloud mode needs much longer timeouts: GCE provisioning can take 20 minutes,
-# and individual tests need time for remote job execution.
+# and individual tests need time for remote job execution. Local mode's first
+# smoke test pays the module-scoped fixture's wait_for_workers(timeout=60) cost,
+# so it gets its own larger budget; subsequent tests reuse the booted cluster.
+_LOCAL_FIXTURE_TIMEOUT = 120  # first smoke test absorbs cluster boot + worker registration
 _LOCAL_E2E_TIMEOUT = 30  # local e2e tests boot clusters + run jobs
 _CLOUD_FIXTURE_TIMEOUT = 1200  # 20 min for cluster provisioning
 _CLOUD_TEST_TIMEOUT = 120  # 2 min per test
@@ -88,7 +91,7 @@ _CLOUD_TEST_TIMEOUT = 120  # 2 min per test
 def pytest_collection_modifyitems(config, items):
     """Set appropriate timeouts for e2e tests.
 
-    Local mode: 30s default (cluster boot + job execution).
+    Local mode: 30s default; first smoke test gets 120s to cover cluster boot.
     Cloud mode: 20 min for first smoke test (provisioning), 2 min for the rest.
     """
     is_cloud = config.getoption("--iris-controller-url") is not None
@@ -99,17 +102,19 @@ def pytest_collection_modifyitems(config, items):
     for item in items:
         if item.get_closest_marker("timeout"):
             continue
+        uses_smoke = "smoke_cluster" in getattr(item, "fixturenames", ())
         if is_cloud:
-            if "smoke_cluster" in getattr(item, "fixturenames", ()):
-                if first_smoke_test:
-                    item.add_marker(pytest.mark.timeout(_CLOUD_FIXTURE_TIMEOUT))
-                    first_smoke_test = False
-                else:
-                    item.add_marker(pytest.mark.timeout(_CLOUD_TEST_TIMEOUT))
+            if uses_smoke and first_smoke_test:
+                item.add_marker(pytest.mark.timeout(_CLOUD_FIXTURE_TIMEOUT))
+                first_smoke_test = False
             else:
                 item.add_marker(pytest.mark.timeout(_CLOUD_TEST_TIMEOUT))
         else:
-            item.add_marker(pytest.mark.timeout(_LOCAL_E2E_TIMEOUT))
+            if uses_smoke and first_smoke_test:
+                item.add_marker(pytest.mark.timeout(_LOCAL_FIXTURE_TIMEOUT))
+                first_smoke_test = False
+            else:
+                item.add_marker(pytest.mark.timeout(_LOCAL_E2E_TIMEOUT))
 
 
 @dataclass

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -199,6 +199,30 @@ def smoke_screenshot(smoke_page, tmp_path_factory):
     return capture
 
 
+def _wait_for_worker_detail_screenshot_ready(page, worker_id: str) -> None:
+    # WorkerDetail.vue uniquely nulls `data` in its workerId watch, so a late
+    # re-fire can flip the page back to the "Loading worker..." overlay after a
+    # naive wait passes. Anchor on h3 sections that only render in the
+    # v-else-if="data" branch, then settle + re-verify to catch the transient.
+    check = """
+        (workerId) => {
+            const text = document.body.textContent || "";
+            const routeReady = decodeURIComponent(window.location.hash) === `#/worker/${workerId}`;
+            const headings = Array.from(document.querySelectorAll("h3"))
+                .map((heading) => (heading.textContent || "").trim().toLowerCase());
+            return routeReady
+                && !text.includes("Loading worker...")
+                && text.includes(workerId)
+                && text.includes("Healthy")
+                && headings.includes("identity")
+                && headings.includes("task history");
+        }
+    """
+    page.wait_for_function(check, arg=worker_id, timeout=15000)
+    page.wait_for_timeout(250)
+    page.wait_for_function(check, arg=worker_id, timeout=5000)
+
+
 def _wait_for_job_detail_screenshot_ready(page, job_id: str) -> None:
     page.wait_for_function(
         """
@@ -445,12 +469,7 @@ def test_dashboard_worker_detail(smoke_cluster, smoke_page, smoke_screenshot, ca
     dashboard_goto(smoke_page, f"{smoke_cluster.url}/worker/{worker_id}")
     wait_for_dashboard_ready(smoke_page)
 
-    smoke_page.wait_for_function(
-        f"() => document.body.textContent.includes('{worker_id}') && "
-        "document.body.textContent.includes('Healthy') && "
-        "!document.body.textContent.includes('Loading worker...')",
-        timeout=15000,
-    )
+    _wait_for_worker_detail_screenshot_ready(smoke_page, worker_id)
     smoke_screenshot(
         "worker-detail", "Worker detail page with identity info, health badge, metric sparklines, and task history"
     )


### PR DESCRIPTION
* ref https://github.com/marin-community/marin/pull/5988#issuecomment-4557918035, https://github.com/marin-community/marin/actions/runs/26533862546/job/78157538637, https://github.com/marin-community/marin/actions/runs/26535556248/job/78163372340
* first e2e smoke test now gets a 120s budget to absorb cluster boot
  * module-scoped `smoke_cluster` fixture calls `wait_for_workers(timeout=60)` during setup; the first test to consume it inherits that cost under `pytest-timeout`, but the 30s local cap was too tight on cold GH runners
  * mirror the cloud-mode pattern: first smoke test gets the larger budget via `_LOCAL_FIXTURE_TIMEOUT`, subsequent tests reuse the booted cluster at the normal `_LOCAL_E2E_TIMEOUT` (30s)
* `test_dashboard_worker_detail` screenshot wait now anchors on `v-else-if="data"` h3 sections and re-verifies after a brief settle [^1]
  * new `_wait_for_worker_detail_screenshot_ready` helper mirrors `_wait_for_job_detail_screenshot_ready`: route-ready, worker_id, "Healthy", `identity` + `task history` headings present, no "Loading worker..."
  * `wait_for_function` → 250ms settle → re-`wait_for_function` to catch the transient flip before the screenshot lands

[^1]: `WorkerDetail.vue` is unique among dashboard pages in nulling `data` inside `watch(props.workerId, ...)`, so a late re-fire after the existing text-only wait passed could flip the page back to the "Loading worker..." overlay just in time for `page.screenshot()`. Other detail pages keep stale data through refetches, so they don't show this race.