### PR TITLE
[tokenize] Reduce memory pressure in `_exemplar_for`

### DIFF
--- a/.github/workflows/marin-canary-datakit-tier3.yaml
+++ b/.github/workflows/marin-canary-datakit-tier3.yaml
@@ -69,14 +69,10 @@ jobs:
         shell: bash -l {0}
         run: |
           set -euo pipefail
-          # TODO: drop --memory=4G/--enable-extra-resources and --no-preemptible
-          # once the tokenize job is fixed.
           JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
             job run --no-wait \
             --region=europe-west4 \
-            --memory=4G --disk=5G --cpu=1 --extra=cpu \
-            --enable-extra-resources \
-            --no-preemptible \
+            --disk=5G --cpu=1 --extra=cpu \
             --priority production \
             -e SMOKE_RUN_ID "$SMOKE_RUN_ID" \
             -e FERRY_STATUS_PATH "$FERRY_STATUS_PATH" \

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -33,7 +33,7 @@ from levanter.data.text import (
 )
 from levanter.tokenizers import TokenizerBackend
 from rigging.log_setup import configure_logging
-from zephyr import Dataset, ZephyrContext
+from zephyr import Dataset, InputFileSpec, ZephyrContext
 from zephyr.dataset import FileEntry
 from zephyr.readers import load_file
 
@@ -275,7 +275,7 @@ def _exemplar_for(
 
     first_non_empty: str | None = None
     for path in candidates:
-        if next(iter(load_file(path)), None) is not None:
+        if next(iter(load_file(InputFileSpec(path=path, columns=["id"]))), None) is not None:
             first_non_empty = path
             break
     if first_non_empty is None:


### PR DESCRIPTION
The current implementation reads the entire parquet file into memory on the coordinator (which should, generally, be pretty light). This creates a lot of memory pressure that can lead to OOMs. This only reads the id column, since the only thing the code cares about it whether it's empty or not.
