### PR TITLE
[finelog] Per-namespace storage retention; cap iris.task_status at 1h / 100MB

### DIFF
--- a/lib/finelog/src/finelog/client/__init__.py
+++ b/lib/finelog/src/finelog/client/__init__.py
@@ -22,6 +22,7 @@ from finelog.errors import (
     SchemaValidationError,
     StatsError,
 )
+from finelog.store.policy import StoragePolicy
 
 __all__ = [
     "FlushResult",
@@ -33,6 +34,7 @@ __all__ = [
     "SchemaConflictError",
     "SchemaValidationError",
     "StatsError",
+    "StoragePolicy",
     "Table",
     "schema_from_dataclass",
 ]

--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -41,6 +41,7 @@ from finelog.rpc import logging_pb2
 from finelog.rpc.finelog_stats_connect import StatsServiceClientSync
 from finelog.rpc.logging_connect import LogServiceClientSync
 from finelog.store.log_namespace import LOG_REGISTERED_SCHEMA
+from finelog.store.policy import StoragePolicy, policy_to_proto
 from finelog.store.schema import (
     IMPLICIT_SEQ_COLUMN,
     Column,
@@ -539,8 +540,20 @@ class LogClient:
             return FlushResult.SUCCEEDED
         return table.flush(timeout=timeout)
 
-    def get_table(self, namespace: str, schema: type | Schema) -> Table:
-        """Idempotently register ``namespace`` and return a Table handle."""
+    def get_table(
+        self,
+        namespace: str,
+        schema: type | Schema,
+        *,
+        storage_policy: StoragePolicy = StoragePolicy(),
+    ) -> Table:
+        """Idempotently register ``namespace`` and return a Table handle.
+
+        ``storage_policy`` is a per-namespace retention override; an
+        empty policy inherits the server defaults. A non-empty policy
+        on a re-register replaces the namespace's current policy
+        (last-write-wins).
+        """
         if namespace == LOG_NAMESPACE:
             raise InvalidNamespaceError("use write_batch/query for the privileged 'log' namespace")
         if isinstance(schema, Schema):
@@ -560,6 +573,7 @@ class LogClient:
                 stats_pb2.RegisterTableRequest(
                     namespace=namespace,
                     schema=schema_to_proto(requested),
+                    storage_policy=policy_to_proto(storage_policy),
                 )
             )
         except ConnectError as exc:

--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -41,7 +41,7 @@ from finelog.rpc import logging_pb2
 from finelog.rpc.finelog_stats_connect import StatsServiceClientSync
 from finelog.rpc.logging_connect import LogServiceClientSync
 from finelog.store.log_namespace import LOG_REGISTERED_SCHEMA
-from finelog.store.policy import StoragePolicy, policy_to_proto
+from finelog.store.policy import StoragePolicy
 from finelog.store.schema import (
     IMPLICIT_SEQ_COLUMN,
     Column,
@@ -573,7 +573,7 @@ class LogClient:
                 stats_pb2.RegisterTableRequest(
                     namespace=namespace,
                     schema=schema_to_proto(requested),
-                    storage_policy=policy_to_proto(storage_policy),
+                    storage_policy=storage_policy.to_proto(),
                 )
             )
         except ConnectError as exc:

--- a/lib/finelog/src/finelog/proto/finelog_stats.proto
+++ b/lib/finelog/src/finelog/proto/finelog_stats.proto
@@ -71,8 +71,11 @@ message StoragePolicy {
 message RegisterTableRequest {
   string namespace = 1;
   Schema schema = 2;
-  // Optional retention overrides. Omit (or send an empty StoragePolicy)
-  // to use the server-wide defaults.
+  // Optional retention overrides. On fresh registration, an empty
+  // policy inherits the server-wide defaults. On re-register, an empty
+  // policy means "no opinion" and the namespace's existing policy is
+  // preserved — so an older client that doesn't know about policies
+  // can't wipe a tighter policy set by a newer client.
   StoragePolicy storage_policy = 3;
 }
 

--- a/lib/finelog/src/finelog/proto/finelog_stats.proto
+++ b/lib/finelog/src/finelog/proto/finelog_stats.proto
@@ -50,6 +50,20 @@ message Schema {
 // Row or Value type; the column types in the table above (ColumnType)
 // describe the Arrow types the server accepts.
 
+// Per-namespace retention overrides. All fields are optional; a field
+// left at zero is "inherit the server default" (a missing/unset field
+// in proto3 semantics). Non-zero values override the corresponding
+// CompactionConfig knob for this namespace only.
+message StoragePolicy {
+  // Per-namespace count cap on locally-tracked segments. 0 = inherit.
+  int32 max_segments = 1;
+  // Per-namespace byte cap on locally-tracked segments. 0 = inherit.
+  int64 max_bytes = 2;
+  // Drop any L>=1 BOTH segment older than ``now - max_age_seconds``.
+  // 0 = disabled (no age-based eviction).
+  int64 max_age_seconds = 3;
+}
+
 // ============================================================================
 // STATS SERVICE
 // ============================================================================
@@ -57,6 +71,9 @@ message Schema {
 message RegisterTableRequest {
   string namespace = 1;
   Schema schema = 2;
+  // Optional retention overrides. Omit (or send an empty StoragePolicy)
+  // to use the server-wide defaults.
+  StoragePolicy storage_policy = 3;
 }
 
 message RegisterTableResponse {
@@ -65,6 +82,8 @@ message RegisterTableResponse {
   // registered schema, or when the request was a subset of the existing
   // registered schema.
   Schema effective_schema = 1;
+  // Policy now in force for the namespace.
+  StoragePolicy effective_policy = 2;
 }
 
 message WriteRowsRequest {
@@ -120,6 +139,7 @@ message NamespaceInfo {
   int64 min_seq = 5;          // 0 if empty
   int64 max_seq = 6;          // 0 if empty
   int32 segment_count = 7;    // sealed (logs_*) + in-flight (tmp_*) parquet files
+  StoragePolicy storage_policy = 8;  // retention overrides; empty if all defaults
 }
 
 message ListNamespacesRequest {}

--- a/lib/finelog/src/finelog/rpc/finelog_stats_pb2.py
+++ b/lib/finelog/src/finelog/rpc/finelog_stats_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13\x66inelog_stats.proto\x12\rfinelog.stats\"g\n\x06\x43olumn\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12-\n\x04type\x18\x02 \x01(\x0e\x32\x19.finelog.stats.ColumnTypeR\x04type\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\"X\n\x06Schema\x12/\n\x07\x63olumns\x18\x01 \x03(\x0b\x32\x15.finelog.stats.ColumnR\x07\x63olumns\x12\x1d\n\nkey_column\x18\x02 \x01(\tR\tkeyColumn\"c\n\x14RegisterTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\"Y\n\x15RegisterTableResponse\x12@\n\x10\x65\x66\x66\x65\x63tive_schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x0f\x65\x66\x66\x65\x63tiveSchema\"M\n\x10WriteRowsRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x1b\n\tarrow_ipc\x18\x02 \x01(\x0cR\x08\x61rrowIpc\"6\n\x11WriteRowsResponse\x12!\n\x0crows_written\x18\x01 \x01(\x03R\x0browsWritten\" \n\x0cQueryRequest\x12\x10\n\x03sql\x18\x01 \x01(\tR\x03sql\"I\n\rQueryResponse\x12\x1b\n\tarrow_ipc\x18\x01 \x01(\x0cR\x08\x61rrowIpc\x12\x1b\n\trow_count\x18\x02 \x01(\x03R\x08rowCount\"0\n\x10\x44ropTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"\x13\n\x11\x44ropTableResponse\"\xed\x01\n\rNamespaceInfo\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\x12\x1b\n\trow_count\x18\x03 \x01(\x03R\x08rowCount\x12\x1b\n\tbyte_size\x18\x04 \x01(\x03R\x08\x62yteSize\x12\x17\n\x07min_seq\x18\x05 \x01(\x03R\x06minSeq\x12\x17\n\x07max_seq\x18\x06 \x01(\x03R\x06maxSeq\x12#\n\rsegment_count\x18\x07 \x01(\x05R\x0csegmentCount\"\x17\n\x15ListNamespacesRequest\"V\n\x16ListNamespacesResponse\x12<\n\nnamespaces\x18\x01 \x03(\x0b\x32\x1c.finelog.stats.NamespaceInfoR\nnamespaces\"5\n\x15GetTableSchemaRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"G\n\x16GetTableSchemaResponse\x12-\n\x06schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema*\xcf\x01\n\nColumnType\x12\x17\n\x13\x43OLUMN_TYPE_UNKNOWN\x10\x00\x12\x16\n\x12\x43OLUMN_TYPE_STRING\x10\x01\x12\x15\n\x11\x43OLUMN_TYPE_INT64\x10\x02\x12\x17\n\x13\x43OLUMN_TYPE_FLOAT64\x10\x03\x12\x14\n\x10\x43OLUMN_TYPE_BOOL\x10\x04\x12\x1c\n\x18\x43OLUMN_TYPE_TIMESTAMP_MS\x10\x05\x12\x15\n\x11\x43OLUMN_TYPE_BYTES\x10\x06\x12\x15\n\x11\x43OLUMN_TYPE_INT32\x10\x07\x32\x8c\x04\n\x0cStatsService\x12Z\n\rRegisterTable\x12#.finelog.stats.RegisterTableRequest\x1a$.finelog.stats.RegisterTableResponse\x12N\n\tWriteRows\x12\x1f.finelog.stats.WriteRowsRequest\x1a .finelog.stats.WriteRowsResponse\x12\x42\n\x05Query\x12\x1b.finelog.stats.QueryRequest\x1a\x1c.finelog.stats.QueryResponse\x12N\n\tDropTable\x12\x1f.finelog.stats.DropTableRequest\x1a .finelog.stats.DropTableResponse\x12]\n\x0eListNamespaces\x12$.finelog.stats.ListNamespacesRequest\x1a%.finelog.stats.ListNamespacesResponse\x12]\n\x0eGetTableSchema\x12$.finelog.stats.GetTableSchemaRequest\x1a%.finelog.stats.GetTableSchemaResponseB{\n\x11\x63om.finelog.statsB\x11\x46inelogStatsProtoP\x01\xa2\x02\x03\x46SX\xaa\x02\rFinelog.Stats\xca\x02\rFinelog\\Stats\xe2\x02\x19\x46inelog\\Stats\\GPBMetadata\xea\x02\x0e\x46inelog::Statsb\x08\x65\x64itionsp\xe8\x07')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13\x66inelog_stats.proto\x12\rfinelog.stats\"g\n\x06\x43olumn\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12-\n\x04type\x18\x02 \x01(\x0e\x32\x19.finelog.stats.ColumnTypeR\x04type\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\"X\n\x06Schema\x12/\n\x07\x63olumns\x18\x01 \x03(\x0b\x32\x15.finelog.stats.ColumnR\x07\x63olumns\x12\x1d\n\nkey_column\x18\x02 \x01(\tR\tkeyColumn\"w\n\rStoragePolicy\x12!\n\x0cmax_segments\x18\x01 \x01(\x05R\x0bmaxSegments\x12\x1b\n\tmax_bytes\x18\x02 \x01(\x03R\x08maxBytes\x12&\n\x0fmax_age_seconds\x18\x03 \x01(\x03R\rmaxAgeSeconds\"\xa8\x01\n\x14RegisterTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\x12\x43\n\x0estorage_policy\x18\x03 \x01(\x0b\x32\x1c.finelog.stats.StoragePolicyR\rstoragePolicy\"\xa2\x01\n\x15RegisterTableResponse\x12@\n\x10\x65\x66\x66\x65\x63tive_schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x0f\x65\x66\x66\x65\x63tiveSchema\x12G\n\x10\x65\x66\x66\x65\x63tive_policy\x18\x02 \x01(\x0b\x32\x1c.finelog.stats.StoragePolicyR\x0f\x65\x66\x66\x65\x63tivePolicy\"M\n\x10WriteRowsRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x1b\n\tarrow_ipc\x18\x02 \x01(\x0cR\x08\x61rrowIpc\"6\n\x11WriteRowsResponse\x12!\n\x0crows_written\x18\x01 \x01(\x03R\x0browsWritten\" \n\x0cQueryRequest\x12\x10\n\x03sql\x18\x01 \x01(\tR\x03sql\"I\n\rQueryResponse\x12\x1b\n\tarrow_ipc\x18\x01 \x01(\x0cR\x08\x61rrowIpc\x12\x1b\n\trow_count\x18\x02 \x01(\x03R\x08rowCount\"0\n\x10\x44ropTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"\x13\n\x11\x44ropTableResponse\"\xb2\x02\n\rNamespaceInfo\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\x12\x1b\n\trow_count\x18\x03 \x01(\x03R\x08rowCount\x12\x1b\n\tbyte_size\x18\x04 \x01(\x03R\x08\x62yteSize\x12\x17\n\x07min_seq\x18\x05 \x01(\x03R\x06minSeq\x12\x17\n\x07max_seq\x18\x06 \x01(\x03R\x06maxSeq\x12#\n\rsegment_count\x18\x07 \x01(\x05R\x0csegmentCount\x12\x43\n\x0estorage_policy\x18\x08 \x01(\x0b\x32\x1c.finelog.stats.StoragePolicyR\rstoragePolicy\"\x17\n\x15ListNamespacesRequest\"V\n\x16ListNamespacesResponse\x12<\n\nnamespaces\x18\x01 \x03(\x0b\x32\x1c.finelog.stats.NamespaceInfoR\nnamespaces\"5\n\x15GetTableSchemaRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"G\n\x16GetTableSchemaResponse\x12-\n\x06schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema*\xcf\x01\n\nColumnType\x12\x17\n\x13\x43OLUMN_TYPE_UNKNOWN\x10\x00\x12\x16\n\x12\x43OLUMN_TYPE_STRING\x10\x01\x12\x15\n\x11\x43OLUMN_TYPE_INT64\x10\x02\x12\x17\n\x13\x43OLUMN_TYPE_FLOAT64\x10\x03\x12\x14\n\x10\x43OLUMN_TYPE_BOOL\x10\x04\x12\x1c\n\x18\x43OLUMN_TYPE_TIMESTAMP_MS\x10\x05\x12\x15\n\x11\x43OLUMN_TYPE_BYTES\x10\x06\x12\x15\n\x11\x43OLUMN_TYPE_INT32\x10\x07\x32\x8c\x04\n\x0cStatsService\x12Z\n\rRegisterTable\x12#.finelog.stats.RegisterTableRequest\x1a$.finelog.stats.RegisterTableResponse\x12N\n\tWriteRows\x12\x1f.finelog.stats.WriteRowsRequest\x1a .finelog.stats.WriteRowsResponse\x12\x42\n\x05Query\x12\x1b.finelog.stats.QueryRequest\x1a\x1c.finelog.stats.QueryResponse\x12N\n\tDropTable\x12\x1f.finelog.stats.DropTableRequest\x1a .finelog.stats.DropTableResponse\x12]\n\x0eListNamespaces\x12$.finelog.stats.ListNamespacesRequest\x1a%.finelog.stats.ListNamespacesResponse\x12]\n\x0eGetTableSchema\x12$.finelog.stats.GetTableSchemaRequest\x1a%.finelog.stats.GetTableSchemaResponseB{\n\x11\x63om.finelog.statsB\x11\x46inelogStatsProtoP\x01\xa2\x02\x03\x46SX\xaa\x02\rFinelog.Stats\xca\x02\rFinelog\\Stats\xe2\x02\x19\x46inelog\\Stats\\GPBMetadata\xea\x02\x0e\x46inelog::Statsb\x08\x65\x64itionsp\xe8\x07')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,38 +32,40 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'finelog_stats_pb2', _global
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\021com.finelog.statsB\021FinelogStatsProtoP\001\242\002\003FSX\252\002\rFinelog.Stats\312\002\rFinelog\\Stats\342\002\031Finelog\\Stats\\GPBMetadata\352\002\016Finelog::Stats'
-  _globals['_COLUMNTYPE']._serialized_start=1222
-  _globals['_COLUMNTYPE']._serialized_end=1429
+  _globals['_COLUMNTYPE']._serialized_start=1556
+  _globals['_COLUMNTYPE']._serialized_end=1763
   _globals['_COLUMN']._serialized_start=38
   _globals['_COLUMN']._serialized_end=141
   _globals['_SCHEMA']._serialized_start=143
   _globals['_SCHEMA']._serialized_end=231
-  _globals['_REGISTERTABLEREQUEST']._serialized_start=233
-  _globals['_REGISTERTABLEREQUEST']._serialized_end=332
-  _globals['_REGISTERTABLERESPONSE']._serialized_start=334
-  _globals['_REGISTERTABLERESPONSE']._serialized_end=423
-  _globals['_WRITEROWSREQUEST']._serialized_start=425
-  _globals['_WRITEROWSREQUEST']._serialized_end=502
-  _globals['_WRITEROWSRESPONSE']._serialized_start=504
-  _globals['_WRITEROWSRESPONSE']._serialized_end=558
-  _globals['_QUERYREQUEST']._serialized_start=560
-  _globals['_QUERYREQUEST']._serialized_end=592
-  _globals['_QUERYRESPONSE']._serialized_start=594
-  _globals['_QUERYRESPONSE']._serialized_end=667
-  _globals['_DROPTABLEREQUEST']._serialized_start=669
-  _globals['_DROPTABLEREQUEST']._serialized_end=717
-  _globals['_DROPTABLERESPONSE']._serialized_start=719
-  _globals['_DROPTABLERESPONSE']._serialized_end=738
-  _globals['_NAMESPACEINFO']._serialized_start=741
-  _globals['_NAMESPACEINFO']._serialized_end=978
-  _globals['_LISTNAMESPACESREQUEST']._serialized_start=980
-  _globals['_LISTNAMESPACESREQUEST']._serialized_end=1003
-  _globals['_LISTNAMESPACESRESPONSE']._serialized_start=1005
-  _globals['_LISTNAMESPACESRESPONSE']._serialized_end=1091
-  _globals['_GETTABLESCHEMAREQUEST']._serialized_start=1093
-  _globals['_GETTABLESCHEMAREQUEST']._serialized_end=1146
-  _globals['_GETTABLESCHEMARESPONSE']._serialized_start=1148
-  _globals['_GETTABLESCHEMARESPONSE']._serialized_end=1219
-  _globals['_STATSSERVICE']._serialized_start=1432
-  _globals['_STATSSERVICE']._serialized_end=1956
+  _globals['_STORAGEPOLICY']._serialized_start=233
+  _globals['_STORAGEPOLICY']._serialized_end=352
+  _globals['_REGISTERTABLEREQUEST']._serialized_start=355
+  _globals['_REGISTERTABLEREQUEST']._serialized_end=523
+  _globals['_REGISTERTABLERESPONSE']._serialized_start=526
+  _globals['_REGISTERTABLERESPONSE']._serialized_end=688
+  _globals['_WRITEROWSREQUEST']._serialized_start=690
+  _globals['_WRITEROWSREQUEST']._serialized_end=767
+  _globals['_WRITEROWSRESPONSE']._serialized_start=769
+  _globals['_WRITEROWSRESPONSE']._serialized_end=823
+  _globals['_QUERYREQUEST']._serialized_start=825
+  _globals['_QUERYREQUEST']._serialized_end=857
+  _globals['_QUERYRESPONSE']._serialized_start=859
+  _globals['_QUERYRESPONSE']._serialized_end=932
+  _globals['_DROPTABLEREQUEST']._serialized_start=934
+  _globals['_DROPTABLEREQUEST']._serialized_end=982
+  _globals['_DROPTABLERESPONSE']._serialized_start=984
+  _globals['_DROPTABLERESPONSE']._serialized_end=1003
+  _globals['_NAMESPACEINFO']._serialized_start=1006
+  _globals['_NAMESPACEINFO']._serialized_end=1312
+  _globals['_LISTNAMESPACESREQUEST']._serialized_start=1314
+  _globals['_LISTNAMESPACESREQUEST']._serialized_end=1337
+  _globals['_LISTNAMESPACESRESPONSE']._serialized_start=1339
+  _globals['_LISTNAMESPACESRESPONSE']._serialized_end=1425
+  _globals['_GETTABLESCHEMAREQUEST']._serialized_start=1427
+  _globals['_GETTABLESCHEMAREQUEST']._serialized_end=1480
+  _globals['_GETTABLESCHEMARESPONSE']._serialized_start=1482
+  _globals['_GETTABLESCHEMARESPONSE']._serialized_end=1553
+  _globals['_STATSSERVICE']._serialized_start=1766
+  _globals['_STATSSERVICE']._serialized_end=2290
 # @@protoc_insertion_point(module_scope)

--- a/lib/finelog/src/finelog/rpc/finelog_stats_pb2.pyi
+++ b/lib/finelog/src/finelog/rpc/finelog_stats_pb2.pyi
@@ -44,19 +44,33 @@ class Schema(_message.Message):
     key_column: str
     def __init__(self, columns: _Optional[_Iterable[_Union[Column, _Mapping]]] = ..., key_column: _Optional[str] = ...) -> None: ...
 
+class StoragePolicy(_message.Message):
+    __slots__ = ("max_segments", "max_bytes", "max_age_seconds")
+    MAX_SEGMENTS_FIELD_NUMBER: _ClassVar[int]
+    MAX_BYTES_FIELD_NUMBER: _ClassVar[int]
+    MAX_AGE_SECONDS_FIELD_NUMBER: _ClassVar[int]
+    max_segments: int
+    max_bytes: int
+    max_age_seconds: int
+    def __init__(self, max_segments: _Optional[int] = ..., max_bytes: _Optional[int] = ..., max_age_seconds: _Optional[int] = ...) -> None: ...
+
 class RegisterTableRequest(_message.Message):
-    __slots__ = ("namespace", "schema")
+    __slots__ = ("namespace", "schema", "storage_policy")
     NAMESPACE_FIELD_NUMBER: _ClassVar[int]
     SCHEMA_FIELD_NUMBER: _ClassVar[int]
+    STORAGE_POLICY_FIELD_NUMBER: _ClassVar[int]
     namespace: str
     schema: Schema
-    def __init__(self, namespace: _Optional[str] = ..., schema: _Optional[_Union[Schema, _Mapping]] = ...) -> None: ...
+    storage_policy: StoragePolicy
+    def __init__(self, namespace: _Optional[str] = ..., schema: _Optional[_Union[Schema, _Mapping]] = ..., storage_policy: _Optional[_Union[StoragePolicy, _Mapping]] = ...) -> None: ...
 
 class RegisterTableResponse(_message.Message):
-    __slots__ = ("effective_schema",)
+    __slots__ = ("effective_schema", "effective_policy")
     EFFECTIVE_SCHEMA_FIELD_NUMBER: _ClassVar[int]
+    EFFECTIVE_POLICY_FIELD_NUMBER: _ClassVar[int]
     effective_schema: Schema
-    def __init__(self, effective_schema: _Optional[_Union[Schema, _Mapping]] = ...) -> None: ...
+    effective_policy: StoragePolicy
+    def __init__(self, effective_schema: _Optional[_Union[Schema, _Mapping]] = ..., effective_policy: _Optional[_Union[StoragePolicy, _Mapping]] = ...) -> None: ...
 
 class WriteRowsRequest(_message.Message):
     __slots__ = ("namespace", "arrow_ipc")
@@ -97,7 +111,7 @@ class DropTableResponse(_message.Message):
     def __init__(self) -> None: ...
 
 class NamespaceInfo(_message.Message):
-    __slots__ = ("namespace", "schema", "row_count", "byte_size", "min_seq", "max_seq", "segment_count")
+    __slots__ = ("namespace", "schema", "row_count", "byte_size", "min_seq", "max_seq", "segment_count", "storage_policy")
     NAMESPACE_FIELD_NUMBER: _ClassVar[int]
     SCHEMA_FIELD_NUMBER: _ClassVar[int]
     ROW_COUNT_FIELD_NUMBER: _ClassVar[int]
@@ -105,6 +119,7 @@ class NamespaceInfo(_message.Message):
     MIN_SEQ_FIELD_NUMBER: _ClassVar[int]
     MAX_SEQ_FIELD_NUMBER: _ClassVar[int]
     SEGMENT_COUNT_FIELD_NUMBER: _ClassVar[int]
+    STORAGE_POLICY_FIELD_NUMBER: _ClassVar[int]
     namespace: str
     schema: Schema
     row_count: int
@@ -112,7 +127,8 @@ class NamespaceInfo(_message.Message):
     min_seq: int
     max_seq: int
     segment_count: int
-    def __init__(self, namespace: _Optional[str] = ..., schema: _Optional[_Union[Schema, _Mapping]] = ..., row_count: _Optional[int] = ..., byte_size: _Optional[int] = ..., min_seq: _Optional[int] = ..., max_seq: _Optional[int] = ..., segment_count: _Optional[int] = ...) -> None: ...
+    storage_policy: StoragePolicy
+    def __init__(self, namespace: _Optional[str] = ..., schema: _Optional[_Union[Schema, _Mapping]] = ..., row_count: _Optional[int] = ..., byte_size: _Optional[int] = ..., min_seq: _Optional[int] = ..., max_seq: _Optional[int] = ..., segment_count: _Optional[int] = ..., storage_policy: _Optional[_Union[StoragePolicy, _Mapping]] = ...) -> None: ...
 
 class ListNamespacesRequest(_message.Message):
     __slots__ = ()

--- a/lib/finelog/src/finelog/server/stats_service.py
+++ b/lib/finelog/src/finelog/server/stats_service.py
@@ -24,6 +24,7 @@ from connectrpc.errors import ConnectError
 
 from finelog.rpc import finelog_stats_pb2 as stats_pb2
 from finelog.store import LogStore
+from finelog.store.policy import policy_from_proto, policy_to_proto
 from finelog.store.schema import (
     InvalidNamespaceError,
     NamespaceNotFoundError,
@@ -68,14 +69,21 @@ class StatsServiceImpl:
     ) -> stats_pb2.RegisterTableResponse:
         try:
             schema = schema_from_proto(request.schema)
-            effective = await asyncio.to_thread(self._log_store.register_table, request.namespace, schema)
+            policy = policy_from_proto(request.storage_policy)
+            effective_schema = await asyncio.to_thread(self._log_store.register_table, request.namespace, schema, policy)
         except InvalidNamespaceError as exc:
             raise ConnectError(Code.INVALID_ARGUMENT, str(exc)) from exc
         except SchemaConflictError as exc:
             raise ConnectError(Code.FAILED_PRECONDITION, str(exc)) from exc
         except SchemaValidationError as exc:
             raise ConnectError(Code.INVALID_ARGUMENT, str(exc)) from exc
-        return stats_pb2.RegisterTableResponse(effective_schema=schema_to_proto(effective))
+        # Policy is last-write-wins, so the request's policy is now in
+        # force; surface it back so clients can confirm.
+        effective_policy = self._log_store.catalog.get_policy(request.namespace)
+        return stats_pb2.RegisterTableResponse(
+            effective_schema=schema_to_proto(effective_schema),
+            effective_policy=policy_to_proto(effective_policy),
+        )
 
     async def write_rows(
         self,
@@ -144,8 +152,9 @@ class StatsServiceImpl:
                 min_seq=stats.min_seq,
                 max_seq=stats.max_seq,
                 segment_count=stats.segment_count,
+                storage_policy=policy_to_proto(policy),
             )
-            for name, schema, stats in entries
+            for name, schema, stats, policy in entries
         ]
         return stats_pb2.ListNamespacesResponse(namespaces=infos)
 

--- a/lib/finelog/src/finelog/server/stats_service.py
+++ b/lib/finelog/src/finelog/server/stats_service.py
@@ -24,7 +24,7 @@ from connectrpc.errors import ConnectError
 
 from finelog.rpc import finelog_stats_pb2 as stats_pb2
 from finelog.store import LogStore
-from finelog.store.policy import policy_from_proto, policy_to_proto
+from finelog.store.policy import StoragePolicy
 from finelog.store.schema import (
     InvalidNamespaceError,
     NamespaceNotFoundError,
@@ -69,7 +69,7 @@ class StatsServiceImpl:
     ) -> stats_pb2.RegisterTableResponse:
         try:
             schema = schema_from_proto(request.schema)
-            policy = policy_from_proto(request.storage_policy)
+            policy = StoragePolicy.from_proto(request.storage_policy)
             effective_schema = await asyncio.to_thread(self._log_store.register_table, request.namespace, schema, policy)
         except InvalidNamespaceError as exc:
             raise ConnectError(Code.INVALID_ARGUMENT, str(exc)) from exc
@@ -82,7 +82,7 @@ class StatsServiceImpl:
         effective_policy = self._log_store.catalog.get_policy(request.namespace)
         return stats_pb2.RegisterTableResponse(
             effective_schema=schema_to_proto(effective_schema),
-            effective_policy=policy_to_proto(effective_policy),
+            effective_policy=effective_policy.to_proto(),
         )
 
     async def write_rows(
@@ -152,7 +152,7 @@ class StatsServiceImpl:
                 min_seq=stats.min_seq,
                 max_seq=stats.max_seq,
                 segment_count=stats.segment_count,
-                storage_policy=policy_to_proto(policy),
+                storage_policy=policy.to_proto(),
             )
             for name, schema, stats, policy in entries
         ]

--- a/lib/finelog/src/finelog/store/catalog.py
+++ b/lib/finelog/src/finelog/store/catalog.py
@@ -457,3 +457,33 @@ class Catalog:
         if row is None:
             return None
         return self._row_from_tuple(row)
+
+    def select_aged_eviction_candidate(self, namespace: str, cutoff_ms: int) -> SegmentRow | None:
+        """Pick the oldest-by-``created_at_ms`` evictable segment past ``cutoff_ms``.
+
+        Same eligibility as :meth:`select_eviction_candidate` (``level >= 1``
+        and ``location = 'BOTH'``). Ordering by ``created_at_ms`` (not
+        ``min_seq``) matters because compaction outputs inherit their
+        inputs' ``min_seq`` but get a fresh ``created_at_ms`` — so a
+        low-``min_seq`` segment can be the *youngest* one in the
+        namespace, and a ``min_seq``-ordered scan would short-circuit
+        on it and miss strictly-older siblings at higher ``min_seq``.
+        Returns ``None`` if no eligible segment is older than the cutoff.
+        """
+        with self._lock:
+            row = self._conn.execute(
+                f"""
+                SELECT {self._SEGMENT_COLUMNS}
+                FROM segments
+                WHERE namespace = ?
+                  AND level >= 1
+                  AND location = ?
+                  AND created_at_ms < ?
+                ORDER BY created_at_ms ASC
+                LIMIT 1
+                """,
+                [namespace, SegmentLocation.BOTH.value, cutoff_ms],
+            ).fetchone()
+        if row is None:
+            return None
+        return self._row_from_tuple(row)

--- a/lib/finelog/src/finelog/store/catalog.py
+++ b/lib/finelog/src/finelog/store/catalog.py
@@ -48,6 +48,7 @@ from threading import RLock
 import duckdb
 
 from finelog.store.migrations import apply_migrations, transactional
+from finelog.store.policy import StoragePolicy
 from finelog.store.schema import (
     InvalidNamespaceError,
     NamespaceNotFoundError,
@@ -152,9 +153,10 @@ class Catalog:
         self,
         name: str,
         stored_schema: Schema,
-        factory: Callable[[Schema], LogNamespaceProtocol],
+        factory: Callable[[Schema, StoragePolicy], LogNamespaceProtocol],
         *,
         on_existing: Callable[[LogNamespaceProtocol], Schema],
+        policy: StoragePolicy = StoragePolicy(),
     ) -> Schema:
         """Atomically register ``name`` or evolve the existing namespace.
 
@@ -165,6 +167,12 @@ class Catalog:
         ``_namespaces`` publish are inside one ``self._lock`` acquire;
         ``RLock`` lets the factory's namespace constructor call back
         into other catalog methods on the same thread.
+
+        ``policy`` is the per-namespace retention override. On fresh
+        registration it is persisted in ``storage_policies`` and passed
+        to the factory. Existing-namespace evolution is delegated to
+        ``on_existing``; policy updates on re-register are handled by
+        the caller via ``upsert_policy``.
 
         Returns the effective schema in both branches: ``stored_schema``
         for a fresh registration, or whatever ``on_existing`` resolves
@@ -180,8 +188,9 @@ class Catalog:
             if existing is not None:
                 return on_existing(existing)
 
-            ns = factory(stored_schema)
+            ns = factory(stored_schema, policy)
             self.upsert(name, stored_schema)
+            self.upsert_policy(name, policy)
             self._namespaces[name] = ns
             self._registered_at[name] = len(self._registered_at)
             return stored_schema
@@ -221,10 +230,42 @@ class Catalog:
         return {name: schema_from_json(payload) for name, payload in rows}
 
     def delete(self, namespace: str) -> None:
-        """Remove the namespace row and any segment rows. Idempotent."""
+        """Remove the namespace row, segment rows, and policy row. Idempotent."""
         with self._lock:
             self._conn.execute("DELETE FROM segments WHERE namespace = ?", [namespace])
+            self._conn.execute("DELETE FROM storage_policies WHERE namespace = ?", [namespace])
             self._conn.execute("DELETE FROM namespaces WHERE namespace = ?", [namespace])
+
+    # ----- storage_policies table ---------------------------------------
+
+    def get_policy(self, namespace: str) -> StoragePolicy:
+        """Return the persisted policy or an empty (inherit-all) policy."""
+        with self._lock:
+            row = self._conn.execute(
+                "SELECT max_segments, max_bytes, max_age_seconds FROM storage_policies WHERE namespace = ?",
+                [namespace],
+            ).fetchone()
+        if row is None:
+            return StoragePolicy()
+        return StoragePolicy(max_segments=row[0], max_bytes=row[1], max_age_seconds=row[2])
+
+    def upsert_policy(self, namespace: str, policy: StoragePolicy) -> None:
+        """Persist ``policy``, or delete the row if every field is ``None``."""
+        with self._lock:
+            if policy.is_empty():
+                self._conn.execute("DELETE FROM storage_policies WHERE namespace = ?", [namespace])
+                return
+            self._conn.execute(
+                """
+                INSERT INTO storage_policies (namespace, max_segments, max_bytes, max_age_seconds)
+                VALUES (?, ?, ?, ?)
+                ON CONFLICT (namespace) DO UPDATE
+                  SET max_segments    = excluded.max_segments,
+                      max_bytes       = excluded.max_bytes,
+                      max_age_seconds = excluded.max_age_seconds
+                """,
+                [namespace, policy.max_segments, policy.max_bytes, policy.max_age_seconds],
+            )
 
     def upsert(self, namespace: str, schema: Schema) -> None:
         """Insert or evolve the row for ``namespace``.

--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -426,8 +426,11 @@ class DuckDBLogStore:
         Implicit ``seq`` is stamped at this boundary so the on-disk layout
         is uniform across namespaces. ``policy`` is a per-namespace
         retention override; an empty policy inherits the cluster-wide
-        defaults. Re-register with a different policy updates the
-        existing namespace's policy (last-write-wins).
+        defaults. On re-register an empty policy is treated as
+        "no opinion" and the existing policy is kept — otherwise an old
+        client that doesn't know about policies would wipe a tighter
+        policy a newer client had installed. A non-empty policy
+        overwrites whole-record.
         """
         namespace_dir = self._namespace_dir(name)
         resolve_key_column(schema)
@@ -439,11 +442,9 @@ class DuckDBLogStore:
             if effective != existing_ns.schema:
                 self.catalog.upsert(name, effective)
                 existing_ns.update_schema(effective)
-            # Policy is overridden whole-record on re-register; the
-            # catalog persists the new policy and the live namespace
-            # picks it up on the next eviction tick.
-            self.catalog.upsert_policy(name, policy)
-            existing_ns.update_policy(policy)
+            if not policy.is_empty():
+                self.catalog.upsert_policy(name, policy)
+                existing_ns.update_policy(policy)
             return effective
 
         return self.catalog.register_or_evolve(

--- a/lib/finelog/src/finelog/store/duckdb_store.py
+++ b/lib/finelog/src/finelog/store/duckdb_store.py
@@ -52,6 +52,7 @@ from finelog.store.log_namespace import (
     DiskLogNamespace,
     MemoryLogNamespace,
 )
+from finelog.store.policy import StoragePolicy
 from finelog.store.rwlock import RWLock
 from finelog.store.schema import (
     MAX_WRITE_ROWS_BYTES,
@@ -356,7 +357,13 @@ class DuckDBLogStore:
         self._rehydrate_from_registry()
         self._ensure_log_namespace_registered()
 
-    def _make_namespace(self, name: str, schema: Schema, namespace_dir: Path | None) -> LogNamespaceProtocol:
+    def _make_namespace(
+        self,
+        name: str,
+        schema: Schema,
+        namespace_dir: Path | None,
+        policy: StoragePolicy = StoragePolicy(),
+    ) -> LogNamespaceProtocol:
         if self._data_dir is None:
             return MemoryLogNamespace(
                 name=name,
@@ -373,13 +380,15 @@ class DuckDBLogStore:
             query_visibility_lock=self._query_visibility_lock,
             read_pool=self._pool,
             catalog=self.catalog,
+            storage_policy=policy,
             **self._disk_namespace_kwargs,
         )
 
     def _rehydrate_from_registry(self) -> None:
         for name, schema in self.catalog.list_all().items():
             namespace_dir = self._namespace_dir(name)
-            ns = self._make_namespace(name, schema, namespace_dir)
+            policy = self.catalog.get_policy(name)
+            ns = self._make_namespace(name, schema, namespace_dir, policy)
             self.catalog.insert_live(name, ns)
 
     def _ensure_log_namespace_registered(self) -> None:
@@ -392,7 +401,7 @@ class DuckDBLogStore:
         self.catalog.register_or_evolve(
             LOG_NAMESPACE_NAME,
             stored_schema,
-            lambda schema: self._make_namespace(LOG_NAMESPACE_NAME, schema, log_dir),
+            lambda schema, policy: self._make_namespace(LOG_NAMESPACE_NAME, schema, log_dir, policy),
             on_existing=lambda existing: existing.schema,
         )
 
@@ -406,11 +415,19 @@ class DuckDBLogStore:
             return self._data_dir / LOG_NAMESPACE_DIR
         return _validate_namespace_name(name, self._data_dir)
 
-    def register_table(self, name: str, schema: Schema) -> Schema:
+    def register_table(
+        self,
+        name: str,
+        schema: Schema,
+        policy: StoragePolicy = StoragePolicy(),
+    ) -> Schema:
         """Register or evolve ``name`` to ``schema``; return the effective schema.
 
         Implicit ``seq`` is stamped at this boundary so the on-disk layout
-        is uniform across namespaces.
+        is uniform across namespaces. ``policy`` is a per-namespace
+        retention override; an empty policy inherits the cluster-wide
+        defaults. Re-register with a different policy updates the
+        existing namespace's policy (last-write-wins).
         """
         namespace_dir = self._namespace_dir(name)
         resolve_key_column(schema)
@@ -422,17 +439,23 @@ class DuckDBLogStore:
             if effective != existing_ns.schema:
                 self.catalog.upsert(name, effective)
                 existing_ns.update_schema(effective)
+            # Policy is overridden whole-record on re-register; the
+            # catalog persists the new policy and the live namespace
+            # picks it up on the next eviction tick.
+            self.catalog.upsert_policy(name, policy)
+            existing_ns.update_policy(policy)
             return effective
 
         return self.catalog.register_or_evolve(
             name,
             stored_schema,
-            lambda effective_schema: self._make_namespace(name, effective_schema, namespace_dir),
+            lambda eff_schema, eff_policy: self._make_namespace(name, eff_schema, namespace_dir, eff_policy),
             on_existing=on_existing,
+            policy=policy,
         )
 
-    def list_namespaces_with_stats(self) -> list[tuple[str, Schema, NamespaceStats]]:
-        """Return ``(name, schema, stats)`` for every live namespace.
+    def list_namespaces_with_stats(self) -> list[tuple[str, Schema, NamespaceStats, StoragePolicy]]:
+        """Return ``(name, schema, stats, policy)`` for every live namespace.
 
         Backs ``StatsService.ListNamespaces`` — the dashboard relies on
         it to render the summary table without issuing per-namespace
@@ -444,7 +467,7 @@ class DuckDBLogStore:
         # registry snapshot to release the catalog lock before any stats()
         # call so a slow namespace can't stall this call for every other.
         namespaces = self.catalog.snapshot_live()
-        return [(name, ns.schema, ns.stats()) for name, ns in namespaces]
+        return [(name, ns.schema, ns.stats(), self.catalog.get_policy(name)) for name, ns in namespaces]
 
     def get_table_schema(self, name: str) -> Schema:
         return self.catalog.require_live(name).schema

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -1930,7 +1930,7 @@ class MemoryLogNamespace:
     def update_policy(self, new_policy: StoragePolicy) -> None:
         # In-memory namespaces don't evict; policy is accepted for
         # protocol uniformity and ignored.
-        del new_policy
+        pass
 
     def evict_segment(self, path: str) -> int:
         return 0

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -1634,16 +1634,18 @@ class DiskLogNamespace:
             )
 
         # Age trim: independent of size; only L>=1 BOTH segments are
-        # eligible (same predicate as select_eviction_candidate). Iterate
-        # oldest-first; stop as soon as a still-young segment is hit so
-        # we don't scan the whole deque per tick.
+        # eligible. Order by created_at_ms (not min_seq) because
+        # compaction outputs inherit their inputs' min_seq but get a
+        # fresh created_at_ms — so the lowest-min_seq segment can be
+        # the youngest, and a min_seq scan would short-circuit on it
+        # and miss strictly-older siblings at higher min_seq.
         if max_age_ms is None:
             return
         cutoff_ms = int(time.time() * 1000) - max_age_ms
         while True:
             with self._insertion_lock:
-                row = self._catalog.select_eviction_candidate(self.name)
-            if row is None or row.created_at_ms >= cutoff_ms:
+                row = self._catalog.select_aged_eviction_candidate(self.name, cutoff_ms)
+            if row is None:
                 return
             self.evict_segment(row.path)
             logger.info(

--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -50,6 +50,7 @@ from finelog.store.compactor import (
     parse_seg_filename,
     seg_filename,
 )
+from finelog.store.policy import StoragePolicy
 from finelog.store.rwlock import RWLock
 from finelog.store.schema import (
     IMPLICIT_SEQ_COLUMN,
@@ -465,6 +466,7 @@ class DiskLogNamespace:
         read_pool: _ReadPoolProtocol,
         catalog: Catalog,
         merge_semaphore: threading.Semaphore,
+        storage_policy: StoragePolicy = StoragePolicy(),
     ) -> None:
         self.name = name
         self.schema = schema
@@ -477,6 +479,9 @@ class DiskLogNamespace:
 
         self._segment_target_bytes = segment_target_bytes
         self._compactor = Compactor(compaction_config)
+        # Per-namespace retention overrides; ``None`` fields fall back to
+        # the cluster-wide CompactionConfig caps inside _eviction_step.
+        self._storage_policy = storage_policy
 
         # Per-namespace insertion mutex. Guards ``_buffers`` (seq counter,
         # ram chunks, flushing buffer) and ``_local_segments``. Writes to
@@ -852,6 +857,10 @@ class DiskLogNamespace:
         _assert_additive_schema_evolution(self.schema, new_schema)
         self.schema = new_schema
         self._arrow_schema = schema_to_arrow(new_schema)
+
+    def update_policy(self, new_policy: StoragePolicy) -> None:
+        """Swap in a new retention policy. Picked up on the next eviction tick."""
+        self._storage_policy = new_policy
 
     def _flush_loop(self) -> None:
         """Drain in-RAM chunks to L0 on a timer or explicit wake.
@@ -1588,25 +1597,33 @@ class DiskLogNamespace:
     def _eviction_step(self) -> None:
         """Evict the namespace's oldest L>=1 copied segments until under caps.
 
-        Runs at the tail of every compaction tick. Per-namespace caps live
-        on ``CompactionConfig`` (``max_segments_per_namespace``,
-        ``max_bytes_per_namespace``); FIFO-by-min_seq picks the oldest
-        eligible segment.
+        Runs at the tail of every compaction tick. Caps are resolved from
+        the per-namespace :class:`StoragePolicy` first; unset fields fall
+        back to the cluster-wide ``CompactionConfig`` values. Size /
+        count caps trim oldest-first by ``min_seq``; the policy's
+        ``max_age_seconds`` (when set) additionally drops any eligible
+        segment whose ``created_at_ms`` is older than ``now - max_age``.
         """
         config = self._compactor.config
+        policy = self._storage_policy
+        max_segments = policy.max_segments if policy.max_segments is not None else config.max_segments_per_namespace
+        max_bytes = policy.max_bytes if policy.max_bytes is not None else config.max_bytes_per_namespace
+        max_age_ms = policy.max_age_seconds * 1000 if policy.max_age_seconds is not None else None
+
+        # Size + count trim: FIFO-by-min_seq through select_eviction_candidate.
         while True:
             with self._insertion_lock:
                 seg_count = len(self._local_segments)
                 byte_total = sum(s.size_bytes for s in self._local_segments)
-            if seg_count <= config.max_segments_per_namespace and byte_total <= config.max_bytes_per_namespace:
-                return
+            if seg_count <= max_segments and byte_total <= max_bytes:
+                break
             with self._insertion_lock:
                 row = self._catalog.select_eviction_candidate(self.name)
             if row is None:
                 # Over the cap but nothing eligible (everything still L0,
                 # or terminal segments not yet copied). Bail and let the
                 # next tick try again.
-                return
+                break
             self.evict_segment(row.path)
             logger.info(
                 "Evicted L%d segment %s (bytes=%d, remaining=%d segments)",
@@ -1614,6 +1631,27 @@ class DiskLogNamespace:
                 Path(row.path).name,
                 row.byte_size,
                 seg_count - 1,
+            )
+
+        # Age trim: independent of size; only L>=1 BOTH segments are
+        # eligible (same predicate as select_eviction_candidate). Iterate
+        # oldest-first; stop as soon as a still-young segment is hit so
+        # we don't scan the whole deque per tick.
+        if max_age_ms is None:
+            return
+        cutoff_ms = int(time.time() * 1000) - max_age_ms
+        while True:
+            with self._insertion_lock:
+                row = self._catalog.select_eviction_candidate(self.name)
+            if row is None or row.created_at_ms >= cutoff_ms:
+                return
+            self.evict_segment(row.path)
+            logger.info(
+                "Aged out L%d segment %s (created_at_ms=%d, cutoff_ms=%d)",
+                row.level,
+                Path(row.path).name,
+                row.created_at_ms,
+                cutoff_ms,
             )
 
     def query_snapshot(self) -> list[LocalSegment]:
@@ -1886,6 +1924,11 @@ class MemoryLogNamespace:
             self._table = _project_to_schema(self._table, new_arrow)
             self.schema = new_schema
             self._arrow_schema = new_arrow
+
+    def update_policy(self, new_policy: StoragePolicy) -> None:
+        # In-memory namespaces don't evict; policy is accepted for
+        # protocol uniformity and ignored.
+        del new_policy
 
     def evict_segment(self, path: str) -> int:
         return 0

--- a/lib/finelog/src/finelog/store/migrations/0007_storage_policies.py
+++ b/lib/finelog/src/finelog/store/migrations/0007_storage_policies.py
@@ -1,0 +1,36 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-namespace storage retention overrides.
+
+One row per namespace that wants to override the cluster-wide eviction
+caps. ``max_segments`` / ``max_bytes`` shadow the corresponding
+:class:`finelog.store.compactor.CompactionConfig` fields;
+``max_age_seconds`` has no default-config analogue and enables a new
+age-based eviction path. NULL in any column means "inherit / disabled".
+
+A namespace with no row in this table behaves exactly as before.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import duckdb
+
+from finelog.store.migrations._runner import transactional
+
+
+def migrate(conn: duckdb.DuckDBPyConnection, *, data_dir: Path | None) -> None:
+    del data_dir
+    with transactional(conn):
+        conn.execute(
+            """
+            CREATE TABLE IF NOT EXISTS storage_policies (
+                namespace        TEXT PRIMARY KEY,
+                max_segments     INTEGER,
+                max_bytes        BIGINT,
+                max_age_seconds  BIGINT
+            )
+            """
+        )

--- a/lib/finelog/src/finelog/store/policy.py
+++ b/lib/finelog/src/finelog/store/policy.py
@@ -1,0 +1,73 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-namespace storage retention policy.
+
+A :class:`StoragePolicy` lets a caller tighten or loosen the eviction
+caps for a single namespace at register time. Fields left as ``None``
+inherit the cluster-wide defaults baked into the store's
+:class:`finelog.store.compactor.CompactionConfig`; explicit values
+override on a per-field basis.
+
+The policy is persisted in the catalog's ``storage_policies`` table
+(see ``finelog.store.migrations.0007_storage_policies``) and threaded
+through to :class:`finelog.store.log_namespace.DiskLogNamespace`, which
+consults the effective values inside its eviction step.
+
+``max_age_seconds`` is the only knob that introduces a behavior the
+default config has no analogue for: it evicts any L>=1 BOTH segment
+whose ``created_at_ms`` is older than ``now - max_age_seconds``, on
+top of the existing size / count caps.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from finelog.rpc import finelog_stats_pb2 as stats_pb2
+
+
+@dataclass(frozen=True)
+class StoragePolicy:
+    """Per-namespace retention overrides.
+
+    Any field left as ``None`` inherits the store-wide
+    :class:`finelog.store.compactor.CompactionConfig` value. Explicit
+    values are absolute (not deltas).
+
+    Attributes:
+        max_segments: Per-namespace count cap on locally-tracked
+            segments. Overrides ``CompactionConfig.max_segments_per_namespace``.
+        max_bytes: Per-namespace byte cap on locally-tracked segments.
+            Overrides ``CompactionConfig.max_bytes_per_namespace``.
+        max_age_seconds: Drop any L>=1 BOTH segment whose
+            ``created_at_ms`` is older than ``now - max_age_seconds``.
+            No default-config analogue; ``None`` disables age-based
+            eviction.
+    """
+
+    max_segments: int | None = None
+    max_bytes: int | None = None
+    max_age_seconds: int | None = None
+
+    def is_empty(self) -> bool:
+        """True iff every field is ``None`` (i.e. inherit-all)."""
+        return self.max_segments is None and self.max_bytes is None and self.max_age_seconds is None
+
+
+def policy_from_proto(msg: stats_pb2.StoragePolicy) -> StoragePolicy:
+    """Decode a wire policy. Zero in proto3 means "inherit"."""
+    return StoragePolicy(
+        max_segments=msg.max_segments or None,
+        max_bytes=msg.max_bytes or None,
+        max_age_seconds=msg.max_age_seconds or None,
+    )
+
+
+def policy_to_proto(policy: StoragePolicy) -> stats_pb2.StoragePolicy:
+    """Encode a policy for the wire. ``None`` round-trips as proto3's zero."""
+    return stats_pb2.StoragePolicy(
+        max_segments=policy.max_segments or 0,
+        max_bytes=policy.max_bytes or 0,
+        max_age_seconds=policy.max_age_seconds or 0,
+    )

--- a/lib/finelog/src/finelog/store/policy.py
+++ b/lib/finelog/src/finelog/store/policy.py
@@ -54,20 +54,19 @@ class StoragePolicy:
         """True iff every field is ``None`` (i.e. inherit-all)."""
         return self.max_segments is None and self.max_bytes is None and self.max_age_seconds is None
 
+    @classmethod
+    def from_proto(cls, msg: stats_pb2.StoragePolicy) -> StoragePolicy:
+        """Decode a wire policy. Zero in proto3 means "inherit"."""
+        return cls(
+            max_segments=msg.max_segments or None,
+            max_bytes=msg.max_bytes or None,
+            max_age_seconds=msg.max_age_seconds or None,
+        )
 
-def policy_from_proto(msg: stats_pb2.StoragePolicy) -> StoragePolicy:
-    """Decode a wire policy. Zero in proto3 means "inherit"."""
-    return StoragePolicy(
-        max_segments=msg.max_segments or None,
-        max_bytes=msg.max_bytes or None,
-        max_age_seconds=msg.max_age_seconds or None,
-    )
-
-
-def policy_to_proto(policy: StoragePolicy) -> stats_pb2.StoragePolicy:
-    """Encode a policy for the wire. ``None`` round-trips as proto3's zero."""
-    return stats_pb2.StoragePolicy(
-        max_segments=policy.max_segments or 0,
-        max_bytes=policy.max_bytes or 0,
-        max_age_seconds=policy.max_age_seconds or 0,
-    )
+    def to_proto(self) -> stats_pb2.StoragePolicy:
+        """Encode a policy for the wire. ``None`` round-trips as proto3's zero."""
+        return stats_pb2.StoragePolicy(
+            max_segments=self.max_segments or 0,
+            max_bytes=self.max_bytes or 0,
+            max_age_seconds=self.max_age_seconds or 0,
+        )

--- a/lib/finelog/src/finelog/store/types.py
+++ b/lib/finelog/src/finelog/store/types.py
@@ -16,6 +16,7 @@ from enum import StrEnum
 from typing import Protocol
 
 from finelog.rpc import logging_pb2
+from finelog.store.policy import StoragePolicy
 from finelog.store.schema import AlignedBatch, Schema
 from finelog.types import LogReadResult
 
@@ -137,6 +138,8 @@ class LogNamespaceProtocol(Protocol):
     def all_segments_unlocked(self) -> list[LocalSegment]: ...
 
     def update_schema(self, new_schema: Schema) -> None: ...
+
+    def update_policy(self, new_policy: StoragePolicy) -> None: ...
 
     def evict_segment(self, path: str) -> int: ...
 

--- a/lib/finelog/tests/test_catalog_stats.py
+++ b/lib/finelog/tests/test_catalog_stats.py
@@ -25,7 +25,7 @@ from tests.conftest import _ipc_bytes, _seal, _worker_batch, _worker_schema
 
 
 def _stats(store: DuckDBLogStore, namespace: str) -> NamespaceStats:
-    for name, _schema, stats in store.list_namespaces_with_stats():
+    for name, _schema, stats, _policy in store.list_namespaces_with_stats():
         if name == namespace:
             return stats
     raise KeyError(namespace)

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -15,7 +15,7 @@ import pyarrow.ipc as paipc
 import pytest
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
-from finelog.client import FlushResult, LogClient, RemoteLogHandler, schema_from_dataclass
+from finelog.client import FlushResult, LogClient, RemoteLogHandler, StoragePolicy, schema_from_dataclass
 from finelog.client import log_client as log_client_mod
 from finelog.errors import (
     InvalidNamespaceError,
@@ -324,8 +324,6 @@ def test_get_table_with_explicit_schema(tracked_clients):
 
 def test_get_table_forwards_storage_policy(tracked_clients):
     """An explicit StoragePolicy on get_table is sent on the register_table request."""
-    from finelog.client import StoragePolicy
-
     client = LogClient.connect("http://h:1")
     try:
         client.get_table(

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -88,6 +88,7 @@ class _FakeStatsServiceClient:
     def __init__(self, address, **_kwargs):
         self.address = address
         self.registered: dict[str, stats_pb2.Schema] = {}
+        self.registered_policies: dict[str, stats_pb2.StoragePolicy] = {}
         self.writes: list[stats_pb2.WriteRowsRequest] = []
         self.drops: list[str] = []
         self.queries: list[str] = []
@@ -96,7 +97,11 @@ class _FakeStatsServiceClient:
 
     def register_table(self, request):
         self.registered[request.namespace] = request.schema
-        return stats_pb2.RegisterTableResponse(effective_schema=request.schema)
+        self.registered_policies[request.namespace] = request.storage_policy
+        return stats_pb2.RegisterTableResponse(
+            effective_schema=request.schema,
+            effective_policy=request.storage_policy,
+        )
 
     def write_rows(self, request):
         if self.errors:
@@ -313,6 +318,38 @@ def test_get_table_with_explicit_schema(tracked_clients):
         assert table.schema.key_column == "ts"
         table.write([SimpleNamespace(ts=1, value=1.5)])
         assert table.flush(timeout=5.0) == FlushResult.SUCCEEDED
+    finally:
+        client.close()
+
+
+def test_get_table_forwards_storage_policy(tracked_clients):
+    """An explicit StoragePolicy on get_table is sent on the register_table request."""
+    from finelog.client import StoragePolicy
+
+    client = LogClient.connect("http://h:1")
+    try:
+        client.get_table(
+            "iris.worker",
+            WorkerStat,
+            storage_policy=StoragePolicy(max_bytes=100, max_age_seconds=60),
+        )
+        policy = tracked_clients[0].registered_policies["iris.worker"]
+        assert policy.max_bytes == 100
+        assert policy.max_age_seconds == 60
+        assert policy.max_segments == 0  # unset → proto3 zero
+    finally:
+        client.close()
+
+
+def test_get_table_default_policy_is_empty(tracked_clients):
+    """No policy argument sends an empty proto (all zeros = inherit defaults)."""
+    client = LogClient.connect("http://h:1")
+    try:
+        client.get_table("iris.worker", WorkerStat)
+        policy = tracked_clients[0].registered_policies["iris.worker"]
+        assert policy.max_bytes == 0
+        assert policy.max_age_seconds == 0
+        assert policy.max_segments == 0
     finally:
         client.close()
 

--- a/lib/finelog/tests/test_migrations.py
+++ b/lib/finelog/tests/test_migrations.py
@@ -38,6 +38,7 @@ def test_fresh_registry_runs_baseline_migration(tmp_path):
             "0004_segment_copied_at.py",
             "0005_segments_level_index.py",
             "0006_segment_lifecycle.py",
+            "0007_storage_policies.py",
         ]
     finally:
         db.close()
@@ -54,6 +55,7 @@ def test_reopen_is_idempotent(tmp_path):
             "0004_segment_copied_at.py",
             "0005_segments_level_index.py",
             "0006_segment_lifecycle.py",
+            "0007_storage_policies.py",
         ]
     finally:
         db.close()
@@ -87,6 +89,7 @@ def test_pre_migrations_database_inherits_baseline(tmp_path):
             "0004_segment_copied_at.py",
             "0005_segments_level_index.py",
             "0006_segment_lifecycle.py",
+            "0007_storage_policies.py",
         ]
     finally:
         db.close()

--- a/lib/finelog/tests/test_storage_policy.py
+++ b/lib/finelog/tests/test_storage_policy.py
@@ -57,14 +57,23 @@ def test_register_table_persists_policy_across_reopens(tmp_path: Path):
 
 
 def test_register_table_updates_policy_on_re_register(tmp_path: Path):
-    """Last-write-wins: the most recent register_table policy overrides."""
+    """A non-empty re-register policy overrides; an empty one keeps the existing.
+
+    The empty-policy carve-out is what protects newer-client policies from
+    being wiped by older clients that don't know to send one.
+    """
     store = DuckDBLogStore(log_dir=tmp_path / "data")
     try:
         store.register_table("ns", _worker_schema(), StoragePolicy(max_bytes=1024))
         assert store.catalog.get_policy("ns") == StoragePolicy(max_bytes=1024)
 
-        # Re-register with a different policy.
+        # Re-register with a non-empty policy overrides whole-record.
         store.register_table("ns", _worker_schema(), StoragePolicy(max_age_seconds=10))
+        assert store.catalog.get_policy("ns") == StoragePolicy(max_age_seconds=10)
+
+        # Re-register with an empty policy preserves the existing one
+        # (old-client-safe).
+        store.register_table("ns", _worker_schema(), StoragePolicy())
         assert store.catalog.get_policy("ns") == StoragePolicy(max_age_seconds=10)
     finally:
         store.close()

--- a/lib/finelog/tests/test_storage_policy.py
+++ b/lib/finelog/tests/test_storage_policy.py
@@ -11,7 +11,7 @@ from pathlib import Path
 from finelog.store.catalog import Catalog
 from finelog.store.compactor import CompactionConfig
 from finelog.store.duckdb_store import DuckDBLogStore
-from finelog.store.policy import StoragePolicy, policy_from_proto, policy_to_proto
+from finelog.store.policy import StoragePolicy
 
 from tests.conftest import _ipc_bytes, _seal, _worker_batch, _worker_schema
 
@@ -19,11 +19,11 @@ from tests.conftest import _ipc_bytes, _seal, _worker_batch, _worker_schema
 def test_policy_proto_round_trip():
     """Zero in proto maps to None in dataclass and vice versa."""
     src = StoragePolicy(max_segments=5, max_bytes=100, max_age_seconds=3600)
-    assert policy_from_proto(policy_to_proto(src)) == src
+    assert StoragePolicy.from_proto(src.to_proto()) == src
 
     empty = StoragePolicy()
     assert empty.is_empty()
-    assert policy_from_proto(policy_to_proto(empty)) == empty
+    assert StoragePolicy.from_proto(empty.to_proto()) == empty
 
 
 def test_catalog_persists_policy(tmp_path: Path):

--- a/lib/finelog/tests/test_storage_policy.py
+++ b/lib/finelog/tests/test_storage_policy.py
@@ -1,0 +1,166 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-namespace StoragePolicy: persistence, override semantics, and eviction."""
+
+from __future__ import annotations
+
+import time
+from pathlib import Path
+
+from finelog.store.catalog import Catalog
+from finelog.store.compactor import CompactionConfig
+from finelog.store.duckdb_store import DuckDBLogStore
+from finelog.store.policy import StoragePolicy, policy_from_proto, policy_to_proto
+
+from tests.conftest import _ipc_bytes, _seal, _worker_batch, _worker_schema
+
+
+def test_policy_proto_round_trip():
+    """Zero in proto maps to None in dataclass and vice versa."""
+    src = StoragePolicy(max_segments=5, max_bytes=100, max_age_seconds=3600)
+    assert policy_from_proto(policy_to_proto(src)) == src
+
+    empty = StoragePolicy()
+    assert empty.is_empty()
+    assert policy_from_proto(policy_to_proto(empty)) == empty
+
+
+def test_catalog_persists_policy(tmp_path: Path):
+    cat = Catalog(tmp_path)
+    try:
+        policy = StoragePolicy(max_segments=3, max_bytes=1024, max_age_seconds=60)
+        cat.upsert_policy("ns.a", policy)
+        assert cat.get_policy("ns.a") == policy
+        # Empty policy clears the row.
+        cat.upsert_policy("ns.a", StoragePolicy())
+        assert cat.get_policy("ns.a").is_empty()
+    finally:
+        cat.close()
+
+
+def test_register_table_persists_policy_across_reopens(tmp_path: Path):
+    policy = StoragePolicy(max_bytes=1024, max_age_seconds=42)
+    store = DuckDBLogStore(log_dir=tmp_path / "data")
+    try:
+        store.register_table("ns", _worker_schema(), policy)
+        assert store.catalog.get_policy("ns") == policy
+    finally:
+        store.close()
+
+    # Reopen; policy survives.
+    store = DuckDBLogStore(log_dir=tmp_path / "data")
+    try:
+        assert store.catalog.get_policy("ns") == policy
+    finally:
+        store.close()
+
+
+def test_register_table_updates_policy_on_re_register(tmp_path: Path):
+    """Last-write-wins: the most recent register_table policy overrides."""
+    store = DuckDBLogStore(log_dir=tmp_path / "data")
+    try:
+        store.register_table("ns", _worker_schema(), StoragePolicy(max_bytes=1024))
+        assert store.catalog.get_policy("ns") == StoragePolicy(max_bytes=1024)
+
+        # Re-register with a different policy.
+        store.register_table("ns", _worker_schema(), StoragePolicy(max_age_seconds=10))
+        assert store.catalog.get_policy("ns") == StoragePolicy(max_age_seconds=10)
+    finally:
+        store.close()
+
+
+def test_drop_table_clears_policy(tmp_path: Path):
+    store = DuckDBLogStore(log_dir=tmp_path / "data")
+    try:
+        store.register_table("ns", _worker_schema(), StoragePolicy(max_bytes=1024))
+        store.drop_table("ns")
+        assert store.catalog.get_policy("ns").is_empty()
+    finally:
+        store.close()
+
+
+def test_per_namespace_policy_overrides_global_segment_cap(tmp_path: Path):
+    """A tight per-namespace max_segments evicts before the global cap would."""
+    # Global cap is loose (10); per-namespace cap is 1.
+    config = CompactionConfig(max_segments_per_namespace=10, level_targets=(1,))
+    store = DuckDBLogStore(
+        log_dir=tmp_path / "data",
+        remote_log_dir=str(tmp_path / "remote"),
+        compaction_config=config,
+    )
+    try:
+        store.register_table("ns", _worker_schema(), StoragePolicy(max_segments=1))
+
+        store.write_rows("ns", _ipc_bytes(_worker_batch(["a"], [1], [1])))
+        _seal(store, "ns")
+        first = sorted((tmp_path / "data" / "ns").glob("seg_L1_*.parquet"))
+        assert len(first) == 1
+        first_path = first[0]
+
+        store.write_rows("ns", _ipc_bytes(_worker_batch(["b"], [2], [2])))
+        _seal(store, "ns")
+        store.catalog["ns"].compact()
+
+        remaining = sorted((tmp_path / "data" / "ns").glob("seg_L1_*.parquet"))
+        assert len(remaining) == 1
+        assert remaining[0] != first_path
+    finally:
+        store.close()
+
+
+def test_age_eviction_drops_old_segments(tmp_path: Path):
+    """``max_age_seconds`` evicts any L>=1 BOTH segment older than the cutoff."""
+    config = CompactionConfig(max_segments_per_namespace=100, level_targets=(1,))
+    store = DuckDBLogStore(
+        log_dir=tmp_path / "data",
+        remote_log_dir=str(tmp_path / "remote"),
+        compaction_config=config,
+    )
+    try:
+        store.register_table("ns", _worker_schema(), StoragePolicy(max_age_seconds=1))
+
+        store.write_rows("ns", _ipc_bytes(_worker_batch(["a"], [1], [1])))
+        _seal(store, "ns")
+        before = sorted((tmp_path / "data" / "ns").glob("seg_L1_*.parquet"))
+        assert len(before) == 1
+        old_path = before[0]
+
+        # Backdate the segment's catalog created_at_ms to 1 hour ago so
+        # it lands strictly outside the 1s retention window, without
+        # paying the wall-clock cost.
+        old_ms = int(time.time() * 1000) - 3600 * 1000
+        store.catalog._conn.execute(
+            "UPDATE segments SET created_at_ms = ? WHERE namespace = 'ns'",
+            [old_ms],
+        )
+
+        store.catalog["ns"].compact()
+        remaining = sorted((tmp_path / "data" / "ns").glob("seg_L1_*.parquet"))
+        assert remaining == []
+        # Aged-out segment is preserved remotely (BOTH -> REMOTE in the catalog).
+        assert (tmp_path / "remote" / "ns" / old_path.name).exists()
+    finally:
+        store.close()
+
+
+def test_age_eviction_keeps_recent_segments(tmp_path: Path):
+    """Recent segments are not aged out even when the policy is tight."""
+    config = CompactionConfig(max_segments_per_namespace=100, level_targets=(1,))
+    store = DuckDBLogStore(
+        log_dir=tmp_path / "data",
+        remote_log_dir=str(tmp_path / "remote"),
+        compaction_config=config,
+    )
+    try:
+        # 1-hour retention: a just-written segment must survive.
+        store.register_table("ns", _worker_schema(), StoragePolicy(max_age_seconds=3600))
+
+        store.write_rows("ns", _ipc_bytes(_worker_batch(["a"], [1], [1])))
+        _seal(store, "ns")
+        store.catalog["ns"].compact()
+
+        remaining = sorted((tmp_path / "data" / "ns").glob("seg_L1_*.parquet"))
+        assert len(remaining) == 1
+    finally:
+        store.close()

--- a/lib/finelog/tests/test_storage_policy.py
+++ b/lib/finelog/tests/test_storage_policy.py
@@ -153,6 +153,57 @@ def test_age_eviction_drops_old_segments(tmp_path: Path):
         store.close()
 
 
+def test_age_eviction_scans_by_created_at_not_min_seq(tmp_path: Path):
+    """Age trim picks the oldest-by-time segment even when it sits at higher min_seq.
+
+    A compaction output inherits the smallest input's ``min_seq`` but
+    gets a fresh ``created_at_ms``. A naive min_seq-ordered eviction
+    would see that fresh segment first, decide it's young enough, and
+    short-circuit — missing an older sibling at a higher min_seq.
+    """
+    config = CompactionConfig(max_segments_per_namespace=100, level_targets=(1,))
+    store = DuckDBLogStore(
+        log_dir=tmp_path / "data",
+        remote_log_dir=str(tmp_path / "remote"),
+        compaction_config=config,
+    )
+    try:
+        store.register_table("ns", _worker_schema(), StoragePolicy(max_age_seconds=1))
+
+        # Two distinct segments. We'll forge the (min_seq, created_at_ms)
+        # combination directly in the catalog rows: the low-min_seq one
+        # is fresh, the higher-min_seq one is old.
+        store.write_rows("ns", _ipc_bytes(_worker_batch(["a"], [1], [1])))
+        _seal(store, "ns")
+        store.write_rows("ns", _ipc_bytes(_worker_batch(["b"], [2], [2])))
+        _seal(store, "ns")
+        segs = sorted((tmp_path / "data" / "ns").glob("seg_L1_*.parquet"))
+        assert len(segs) == 2
+
+        now_ms = int(time.time() * 1000)
+        rows = store.catalog.list_segments("ns")
+        # Low min_seq → freshly compacted (cr=now); high min_seq → old (cr=now-1h).
+        low = min(rows, key=lambda r: r.min_seq)
+        high = max(rows, key=lambda r: r.min_seq)
+        store.catalog._conn.execute(
+            "UPDATE segments SET created_at_ms = ? WHERE namespace = 'ns' AND path = ?",
+            [now_ms, low.path],
+        )
+        store.catalog._conn.execute(
+            "UPDATE segments SET created_at_ms = ? WHERE namespace = 'ns' AND path = ?",
+            [now_ms - 3600 * 1000, high.path],
+        )
+
+        store.catalog["ns"].compact()
+
+        remaining = {r.path for r in store.catalog.list_segments("ns") if r.location.value != "REMOTE"}
+        # The old (high min_seq) segment is gone; the fresh (low min_seq) one stays.
+        assert high.path not in remaining
+        assert low.path in remaining
+    finally:
+        store.close()
+
+
 def test_age_eviction_keeps_recent_segments(tmp_path: Path):
     """Recent segments are not aged out even when the policy is tight."""
     config = CompactionConfig(max_segments_per_namespace=100, level_targets=(1,))

--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -21,7 +21,7 @@ from iris.cluster.client.bundle import BundleCreator
 from iris.cluster.log_store_helpers import build_log_source
 from iris.cluster.runtime.entrypoint import build_runtime_entrypoint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, JobName, TaskAttempt, adjust_tpu_replicas, is_job_finished
-from iris.cluster.worker.stats import TASK_STATUS_NAMESPACE, TaskStatusRow
+from iris.cluster.worker.stats import TASK_STATUS_NAMESPACE, TASK_STATUS_STORAGE_POLICY, TaskStatusRow
 from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.compression import IRIS_RPC_COMPRESSIONS
 from iris.rpc.controller_connect import ControllerServiceClientSync
@@ -524,7 +524,11 @@ class RemoteClusterClient:
         so a finelog outage cannot abort task execution.
         """
         if self._task_status_table is None:
-            self._task_status_table = self._log_client.get_table(TASK_STATUS_NAMESPACE, TaskStatusRow)
+            self._task_status_table = self._log_client.get_table(
+                TASK_STATUS_NAMESPACE,
+                TaskStatusRow,
+                storage_policy=TASK_STATUS_STORAGE_POLICY,
+            )
         self._task_status_table.write(
             [
                 TaskStatusRow(

--- a/lib/iris/src/iris/cluster/worker/stats.py
+++ b/lib/iris/src/iris/cluster/worker/stats.py
@@ -24,6 +24,7 @@ from datetime import datetime, timezone
 from enum import StrEnum
 from typing import ClassVar
 
+from finelog.client import StoragePolicy
 from rigging.timing import Timestamp
 
 from iris.rpc import job_pb2
@@ -31,6 +32,16 @@ from iris.rpc import job_pb2
 WORKER_STATS_NAMESPACE = "iris.worker"
 TASK_STATS_NAMESPACE = "iris.task"
 TASK_STATUS_NAMESPACE = "iris.task_status"
+
+# Task status rows are only useful while a task is still running — once
+# the job ends the data is dead weight on the finelog server. Cap the
+# namespace at ~1 hour of history or 100 MiB, whichever fires first.
+# Worker / task stats keep the cluster-wide defaults so historical
+# resource-usage queries continue to work.
+TASK_STATUS_STORAGE_POLICY = StoragePolicy(
+    max_bytes=100 * 1024 * 1024,
+    max_age_seconds=3600,
+)
 
 
 def stats_timestamp() -> datetime:


### PR DESCRIPTION
Adds StoragePolicy (max_segments / max_bytes / max_age_seconds) settable per-namespace at register_table time. Persisted in a new storage_policies catalog table; eviction step applies overrides on top of CompactionConfig defaults and adds age-based trimming. iris.task_status registers with max_bytes=100 MiB and max_age_seconds=3600 so finished-task rows roll off automatically.