### PR TITLE
[levanter] Fix tokenizer BPB accounting

### DIFF
--- a/lib/levanter/src/levanter/analysis/perplexity_gap.py
+++ b/lib/levanter/src/levanter/analysis/perplexity_gap.py
@@ -593,6 +593,14 @@ def tokenize_text_with_byte_spans(tokenizer: MarinTokenizer, hf_tokenizer: Any, 
             byte_starts.append(byte_offsets[start])
             byte_ends.append(byte_offsets[end])
 
+    _validate_source_token_spans(
+        hf_tokenizer=hf_tokenizer,
+        text=text,
+        token_ids=ids,
+        byte_starts=byte_starts,
+        byte_ends=byte_ends,
+    )
+
     need_bos, need_eos = manual_special_token_policy(tokenizer)
     if need_bos and tokenizer.bos_token_id is not None:
         ids = [tokenizer.bos_token_id, *ids]
@@ -609,6 +617,134 @@ def tokenize_text_with_byte_spans(tokenizer: MarinTokenizer, hf_tokenizer: Any, 
         byte_ends=np.asarray(byte_ends, dtype=np.int32),
         num_bytes=int(byte_offsets[-1]),
     )
+
+
+def _validate_source_token_spans(
+    *,
+    hf_tokenizer: Any,
+    text: str,
+    token_ids: Sequence[int],
+    byte_starts: Sequence[int],
+    byte_ends: Sequence[int],
+) -> None:
+    """Validate that tokenizer offsets are usable for source-byte BPB attribution.
+
+    BPB scoring spreads each next-token loss over the token's source byte span.
+    That is only meaningful when non-special source tokens form an ordered
+    partition of the decoded source bytes. Byte-level tokenizers may emit
+    multiple tokens for one Unicode character; those tokens have the same byte
+    span and are accepted as one source-byte group.
+    """
+    if len(token_ids) != len(byte_starts) or len(token_ids) != len(byte_ends):
+        raise ValueError("Token ids and byte spans must have the same length.")
+
+    source_bytes = text.encode("utf-8")
+    num_bytes = len(source_bytes)
+    if not token_ids:
+        if num_bytes == 0:
+            return
+        raise ValueError("Tokenizer produced no source tokens for non-empty text.")
+
+    current_group_end: int | None = None
+    current_group_start: int | None = None
+    current_group_ids: list[int] = []
+    for index, (token_id, start, end) in enumerate(zip(token_ids, byte_starts, byte_ends, strict=True)):
+        token_id = int(token_id)
+        start = int(start)
+        end = int(end)
+        if start < 0 or end <= start:
+            raise ValueError(
+                "Tokenizer produced a source token without a positive source byte span "
+                f"at token index {index} (token_id={token_id}, span=({start}, {end})). "
+                "Per-byte BPB would drop this token's loss."
+            )
+        if end > num_bytes:
+            raise ValueError(
+                f"Tokenizer byte span ({start}, {end}) exceeds document length {num_bytes} at token index {index}."
+            )
+
+        if current_group_end is None:
+            if start != 0:
+                raise ValueError(
+                    f"Tokenizer byte spans start at byte {start}, leaving source bytes [0, {start}) unscored."
+                )
+            current_group_start = start
+            current_group_end = end
+            current_group_ids = [token_id]
+        elif end == current_group_end:
+            if start != current_group_start:
+                raise ValueError(
+                    "Tokenizer emitted multiple tokens for one byte boundary with inconsistent starts: "
+                    f"expected {current_group_start}, got {start} at token index {index}."
+                )
+            current_group_ids.append(token_id)
+        elif end > current_group_end:
+            assert current_group_start is not None
+            _validate_decoded_span(
+                hf_tokenizer=hf_tokenizer,
+                token_ids=current_group_ids,
+                source_bytes=source_bytes,
+                byte_start=current_group_start,
+                byte_end=current_group_end,
+            )
+            if start != current_group_end:
+                raise ValueError(
+                    "Tokenizer byte spans must advance without gaps or partial overlaps: "
+                    f"previous group ended at {current_group_end}, next span starts at {start}."
+                )
+            current_group_start = start
+            current_group_end = end
+            current_group_ids = [token_id]
+        else:
+            raise ValueError(
+                "Tokenizer byte spans must be ordered by decoded source prefix: "
+                f"token index {index} ended at {end} after prior group ended at {current_group_end}."
+            )
+
+    assert current_group_end is not None
+    assert current_group_start is not None
+    _validate_decoded_span(
+        hf_tokenizer=hf_tokenizer,
+        token_ids=current_group_ids,
+        source_bytes=source_bytes,
+        byte_start=current_group_start,
+        byte_end=current_group_end,
+    )
+    if current_group_end != num_bytes:
+        raise ValueError(
+            f"Tokenizer byte spans end at byte {current_group_end}, leaving source bytes "
+            f"[{current_group_end}, {num_bytes}) unscored."
+        )
+
+
+def _validate_decoded_span(
+    *,
+    hf_tokenizer: Any,
+    token_ids: Sequence[int],
+    source_bytes: bytes,
+    byte_start: int,
+    byte_end: int,
+) -> None:
+    decoded = _decode_token_ids(hf_tokenizer, token_ids)
+    try:
+        expected = source_bytes[byte_start:byte_end].decode("utf-8")
+    except UnicodeDecodeError as e:
+        raise ValueError(
+            "Tokenizer offset mapping split a UTF-8 codepoint: "
+            f"bytes [{byte_start}, {byte_end}) are not a valid source-text span."
+        ) from e
+    if decoded != expected:
+        raise ValueError(
+            "Tokenizer offset mapping is not source-aligned: "
+            f"decoded token group for bytes [{byte_start}, {byte_end}) is {decoded!r}, expected {expected!r}."
+        )
+
+
+def _decode_token_ids(hf_tokenizer: Any, token_ids: Sequence[int]) -> str:
+    try:
+        return hf_tokenizer.decode(list(token_ids), clean_up_tokenization_spaces=False)
+    except TypeError:
+        return hf_tokenizer.decode(list(token_ids))
 
 
 def chunk_tokenized_document(

--- a/lib/levanter/src/levanter/analysis/perplexity_gap.py
+++ b/lib/levanter/src/levanter/analysis/perplexity_gap.py
@@ -648,6 +648,7 @@ def _validate_source_token_spans(
     current_group_end: int | None = None
     current_group_start: int | None = None
     current_group_ids: list[int] = []
+    previous_group_ids: list[int] = []
     for index, (token_id, start, end) in enumerate(zip(token_ids, byte_starts, byte_ends, strict=True)):
         token_id = int(token_id)
         start = int(start)
@@ -683,6 +684,7 @@ def _validate_source_token_spans(
             _validate_decoded_span(
                 hf_tokenizer=hf_tokenizer,
                 token_ids=current_group_ids,
+                previous_token_ids=previous_group_ids,
                 source_bytes=source_bytes,
                 byte_start=current_group_start,
                 byte_end=current_group_end,
@@ -692,6 +694,7 @@ def _validate_source_token_spans(
                     "Tokenizer byte spans must advance without gaps or partial overlaps: "
                     f"previous group ended at {current_group_end}, next span starts at {start}."
                 )
+            previous_group_ids = current_group_ids
             current_group_start = start
             current_group_end = end
             current_group_ids = [token_id]
@@ -706,6 +709,7 @@ def _validate_source_token_spans(
     _validate_decoded_span(
         hf_tokenizer=hf_tokenizer,
         token_ids=current_group_ids,
+        previous_token_ids=previous_group_ids,
         source_bytes=source_bytes,
         byte_start=current_group_start,
         byte_end=current_group_end,
@@ -721,11 +725,11 @@ def _validate_decoded_span(
     *,
     hf_tokenizer: Any,
     token_ids: Sequence[int],
+    previous_token_ids: Sequence[int],
     source_bytes: bytes,
     byte_start: int,
     byte_end: int,
 ) -> None:
-    decoded = _decode_token_ids(hf_tokenizer, token_ids)
     try:
         expected = source_bytes[byte_start:byte_end].decode("utf-8")
     except UnicodeDecodeError as e:
@@ -733,11 +737,32 @@ def _validate_decoded_span(
             "Tokenizer offset mapping split a UTF-8 codepoint: "
             f"bytes [{byte_start}, {byte_end}) are not a valid source-text span."
         ) from e
-    if decoded != expected:
-        raise ValueError(
-            "Tokenizer offset mapping is not source-aligned: "
-            f"decoded token group for bytes [{byte_start}, {byte_end}) is {decoded!r}, expected {expected!r}."
-        )
+    decoded = _decode_token_ids(hf_tokenizer, token_ids)
+    if decoded == expected:
+        return
+    if previous_token_ids:
+        decoded_with_context = _decode_token_ids_with_context(hf_tokenizer, previous_token_ids, token_ids)
+        if decoded_with_context == expected:
+            return
+        decoded_detail = f"{decoded!r} without context and {decoded_with_context!r} with left context"
+    else:
+        decoded_detail = f"{decoded!r}"
+    raise ValueError(
+        "Tokenizer offset mapping is not source-aligned: "
+        f"decoded token group for bytes [{byte_start}, {byte_end}) is {decoded_detail}, expected {expected!r}."
+    )
+
+
+def _decode_token_ids_with_context(
+    hf_tokenizer: Any,
+    previous_token_ids: Sequence[int],
+    token_ids: Sequence[int],
+) -> str:
+    decoded_prefix = _decode_token_ids(hf_tokenizer, previous_token_ids)
+    decoded_with_span = _decode_token_ids(hf_tokenizer, [*previous_token_ids, *token_ids])
+    if decoded_with_span.startswith(decoded_prefix):
+        return decoded_with_span[len(decoded_prefix) :]
+    return decoded_with_span
 
 
 def _decode_token_ids(hf_tokenizer: Any, token_ids: Sequence[int]) -> str:

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -244,6 +244,16 @@ def _calculate_bytes_per_token_type(tokenizer: MarinTokenizer) -> Optional[Int[A
     return jnp.array(byte_lengths)
 
 
+def _bpb_from_totals(loss: jax.Array, bytes_: jax.Array) -> jax.Array:
+    return jnp.where(bytes_ > 0, loss * jnp.log2(jnp.e) / bytes_, jnp.nan)
+
+
+def _bpb_from_numpy_totals(loss: float, bytes_: float) -> float:
+    if bytes_ <= 0:
+        return float("nan")
+    return float(loss * np.log2(np.e) / bytes_)
+
+
 def _ensure_named_lm_example(batch: LmEvalExample, *, EvalBatch: hax.Axis, model_pos: hax.Axis) -> LmExample:
     if isinstance(batch, LmExample):
         return batch
@@ -607,7 +617,6 @@ class TaggedEvaluator(Generic[Ex, M]):
 
     def _make_accum_for_batch(self) -> Callable[[M, "_EvalRunningMeans", Ex, BatchedTagArray], "_EvalRunningMeans"]:
         bytes_per_token = self.bytes_per_token
-        log2e = jnp.log2(jnp.e)
         per_tag_out_sharding = None if self.device_mesh is None else NamedSharding(self.device_mesh, P(None))
         per_pos_out_sharding = self.per_pos_out_sharding
 
@@ -642,14 +651,13 @@ class TaggedEvaluator(Generic[Ex, M]):
                     "bt,bt,bk->k", bytes_per_pos, weights, tags, out_sharding=per_tag_out_sharding
                 )
 
-                bpb = this_loss / jnp.maximum(this_bytes, 1.0) * log2e
-                bpb_per_tag = this_loss_per_tag / jnp.maximum(bytes_per_tag, 1.0) * log2e
-
-                bpb_mean = state.bpb.add(bpb, this_weights)
-                state = dataclasses.replace(state, bpb=bpb_mean)
-                if len(self.dataset.tag_to_index) > 0:
-                    bpb_per_tag_mean = state.bpb_per_tag.add(bpb_per_tag, this_weights_per_tag)
-                    state = dataclasses.replace(state, bpb_per_tag=bpb_per_tag_mean)
+                state = dataclasses.replace(
+                    state,
+                    bpb_loss=state.bpb_loss + this_loss,
+                    bpb_bytes=state.bpb_bytes + this_bytes,
+                    bpb_loss_per_tag=state.bpb_loss_per_tag + this_loss_per_tag,
+                    bpb_bytes_per_tag=state.bpb_bytes_per_tag + bytes_per_tag,
+                )
 
             return state
 
@@ -673,9 +681,12 @@ class TaggedEvaluator(Generic[Ex, M]):
         macro_avg_loss = jnp.mean(tag_avg_loss).item()
 
         if self.bytes_per_token is not None:
-            micro_bpb = state.bpb.mean.item()
-            tag_avg_bpb = state.bpb_per_tag.mean
-            macro_avg_bpb = jnp.mean(tag_avg_bpb).item()
+            micro_bpb = _bpb_from_totals(state.bpb_loss, state.bpb_bytes).item()
+            tag_avg_bpb = _bpb_from_totals(state.bpb_loss_per_tag, state.bpb_bytes_per_tag)
+            tag_avg_bpb_cpu = np.array(tag_avg_bpb)
+            total_bpb_bytes_per_tag_cpu = np.array(state.bpb_bytes_per_tag)
+            bpb_tag_mask = total_bpb_bytes_per_tag_cpu > 0
+            macro_avg_bpb = float(np.mean(tag_avg_bpb_cpu[bpb_tag_mask])) if np.any(bpb_tag_mask) else float("nan")
         else:
             micro_bpb = None
             macro_avg_bpb = None
@@ -687,8 +698,9 @@ class TaggedEvaluator(Generic[Ex, M]):
 
         mean_loss_per_tag_cpu = np.array(state.loss_per_tag.mean)
         total_tokens_per_tag_cpu = np.array(state.loss_per_tag.total)
-        mean_bits_per_tag_cpu = np.array(state.bpb_per_tag.mean)
-        total_bytes_per_tag_cpu = np.array(state.bpb_per_tag.total)
+        bpb_loss_per_tag_cpu = np.array(state.bpb_loss_per_tag)
+        bpb_bytes_per_tag_cpu = np.array(state.bpb_bytes_per_tag)
+        mean_bits_per_tag_cpu = np.array(_bpb_from_totals(state.bpb_loss_per_tag, state.bpb_bytes_per_tag))
 
         for parent, children in self.hierarchy.items():
             mask = np.zeros(self.dataset.num_tags, dtype=bool)
@@ -699,8 +711,13 @@ class TaggedEvaluator(Generic[Ex, M]):
             tag_micro_loss[parent] = np.average(mean_loss_per_tag_cpu, weights=total_tokens_per_tag_cpu * mask)
 
             if self.bytes_per_token is not None:
-                tag_macro_bpb[parent] = np.mean(mean_bits_per_tag_cpu, where=mask)
-                tag_micro_bpb[parent] = np.average(mean_bits_per_tag_cpu, weights=total_bytes_per_tag_cpu * mask)
+                bpb_mask = mask & (bpb_bytes_per_tag_cpu > 0)
+                tag_macro_bpb[parent] = (
+                    float(np.mean(mean_bits_per_tag_cpu[bpb_mask])) if np.any(bpb_mask) else float("nan")
+                )
+                parent_loss = float(np.sum(bpb_loss_per_tag_cpu[mask]))
+                parent_bytes = float(np.sum(bpb_bytes_per_tag_cpu[mask]))
+                tag_micro_bpb[parent] = _bpb_from_numpy_totals(parent_loss, parent_bytes)
 
         for tag, index in self.dataset.tag_to_index.items():
             tag_micro_loss[tag] = float(mean_loss_per_tag_cpu[index])
@@ -815,7 +832,6 @@ class LabeledEvaluator(Generic[Ex, M]):
         bytes_per_token = self.bytes_per_token
         aggregate_label_ids = self.aggregate_label_ids
         valid_label_ids = aggregate_label_ids >= 0
-        log2e = jnp.log2(jnp.e)
         per_pos_out_sharding = self.per_pos_out_sharding
 
         @hax.named_jit(axis_resources=self.axis_mapping)
@@ -847,9 +863,11 @@ class LabeledEvaluator(Generic[Ex, M]):
                     bytes_per_pos[:, None, :] * weights_per_aggregate,
                     axis=(0, 2),
                 )
-                bpb_per_label = this_loss_per_label / jnp.maximum(bytes_per_label, 1.0) * log2e
-                bpb_per_label_mean = state.bpb_per_label.add(bpb_per_label, bytes_per_label)
-                state = dataclasses.replace(state, bpb_per_label=bpb_per_label_mean)
+                state = dataclasses.replace(
+                    state,
+                    bpb_loss_per_label=state.bpb_loss_per_label + this_loss_per_label,
+                    bpb_bytes_per_label=state.bpb_bytes_per_label + bytes_per_label,
+                )
 
             return state
 
@@ -876,7 +894,7 @@ class LabeledEvaluator(Generic[Ex, M]):
 
         label_bpb = None
         if self.bytes_per_token is not None:
-            label_bpb_cpu = np.array(state.bpb_per_label.mean)
+            label_bpb_cpu = np.array(_bpb_from_totals(state.bpb_loss_per_label, state.bpb_bytes_per_label))
             label_bpb = {
                 name: float(label_bpb_cpu[index])
                 for index, name in enumerate(self.aggregate_names)
@@ -897,21 +915,24 @@ class LabeledEvaluator(Generic[Ex, M]):
 class _EvalRunningMeans(eqx.Module):
     token_avg_loss: RunningMean  # average loss averaged over all tokens
     loss_per_tag: RunningMean  # average loss per tag
-    bpb: RunningMean  # bits per byte averaged over all tokens
-    bpb_per_tag: RunningMean  # bits per byte per tag
+    bpb_loss: Float[Array, "..."]  # summed BPB numerator, in nats
+    bpb_bytes: Float[Array, "..."]  # summed BPB denominator, in bytes
+    bpb_loss_per_tag: Float[Array, "tag"]
+    bpb_bytes_per_tag: Float[Array, "tag"]
 
     @staticmethod
     def zeros_like(total: Float[Array, "..."], per_tag: Float[Array, "tag"]) -> "_EvalRunningMeans":
         z = RunningMean.zeros_like(total)
-        per_tag = RunningMean.zeros_like(per_tag)
-        return _EvalRunningMeans(z, per_tag, z, per_tag)
+        per_tag_mean = RunningMean.zeros_like(per_tag)
+        return _EvalRunningMeans(z, per_tag_mean, total * 0.0, total * 0.0, per_tag * 0.0, per_tag * 0.0)
 
 
 class _LabeledEvalRunningMeans(eqx.Module):
     loss_per_label: RunningMean
-    bpb_per_label: RunningMean
+    bpb_loss_per_label: Float[Array, "label"]
+    bpb_bytes_per_label: Float[Array, "label"]
 
     @staticmethod
     def zeros_like(per_label: Float[Array, "label"]) -> "_LabeledEvalRunningMeans":
         per_label_mean = RunningMean.zeros_like(per_label)
-        return _LabeledEvalRunningMeans(per_label_mean, per_label_mean)
+        return _LabeledEvalRunningMeans(per_label_mean, per_label * 0.0, per_label * 0.0)

--- a/lib/levanter/tests/test_eval.py
+++ b/lib/levanter/tests/test_eval.py
@@ -38,6 +38,30 @@ from .test_lm_model_loss import ToyLmConfig, ToyLmHeadModel
 from .test_utils import use_test_mesh
 
 
+class _ByteLengthTokenizer:
+    bos_token_id = None
+    eos_token_id = None
+    pad_token_id = None
+    all_special_ids = []
+
+    def get_vocab(self) -> dict[str, int]:
+        return {".": 0, "<zero-byte>": 1, "abc": 2}
+
+    def convert_ids_to_tokens(self, ids: int | list[int]) -> str | list[str]:
+        token_strings = {0: ".", 1: "<zero-byte>", 2: "abc"}
+        if isinstance(ids, int):
+            return token_strings[ids]
+        return [token_strings[token_id] for token_id in ids]
+
+    def encode(self, text: str, *, add_special_tokens: bool = False) -> list[int]:
+        assert text == "."
+        return [0]
+
+    def decode(self, ids: list[int], *, skip_special_tokens: bool = False) -> str:
+        token_text = {0: ".", 1: "", 2: "abc"}
+        return "".join(token_text[token_id] for token_id in ids)
+
+
 def test_tagged_evaluator_accepts_grug_lm_examples():
     cfg = ToyLmConfig(max_seq_len=8, embed_dim=16)
     Vocab = Axis("vocab", 32)
@@ -77,6 +101,36 @@ def test_tagged_evaluator_accepts_grug_lm_examples():
 
     assert np.isfinite(result.micro_avg_loss)
     assert "grug" in result.tag_micro_losses
+
+
+def test_tagged_evaluator_bpb_includes_zero_byte_token_loss():
+    EvalBatch = Axis("batch", 2)
+    examples = [
+        GrugLmExample(tokens=jnp.array([1, 1], dtype=jnp.int32), loss_weight=jnp.ones((2,), dtype=jnp.float32)),
+        GrugLmExample(tokens=jnp.array([1, 1], dtype=jnp.int32), loss_weight=jnp.ones((2,), dtype=jnp.float32)),
+        GrugLmExample(tokens=jnp.array([2, 2], dtype=jnp.int32), loss_weight=jnp.ones((2,), dtype=jnp.float32)),
+        GrugLmExample(tokens=jnp.array([2, 2], dtype=jnp.int32), loss_weight=jnp.ones((2,), dtype=jnp.float32)),
+    ]
+
+    def loss_fn(_model, batch: GrugLmExample) -> LossFnOutput:
+        losses = jnp.ones_like(batch.tokens, dtype=jnp.float32)
+        return losses, batch.loss_weight, batch.tokens
+
+    with use_test_mesh(tensor_parallelism=1) as mesh:
+        evaluator = TaggedEvaluator(
+            EvalBatch=EvalBatch,
+            tagged_eval_sets=[(ListAsyncDataset(examples), ["root/mix"])],
+            loss_fn=loss_fn,
+            tokenizer=_ByteLengthTokenizer(),
+            device_mesh=mesh,
+            axis_mapping={EvalBatch.name: ResourceAxis.DATA},
+        )
+        result = evaluator.evaluate(None)
+
+    expected_bpb = 8.0 * np.log2(np.e) / 12.0
+    np.testing.assert_allclose(result.micro_bpb, expected_bpb)
+    np.testing.assert_allclose(result.tag_micro_bpb["root/mix"], expected_bpb)
+    np.testing.assert_allclose(result.tag_micro_bpb["root"], expected_bpb)
 
 
 def test_tagged_evaluator_accepts_mixed_lm_example_types():
@@ -238,6 +292,36 @@ def test_labeled_evaluator_aggregates_exclusive_loss_labels():
     np.testing.assert_allclose(result.label_losses["tool_observation"], 4.0)
     np.testing.assert_allclose(result.label_token_counts["assistant"], EvalBatch.size * 2)
     assert "dont_score" not in result.label_losses
+
+
+def test_labeled_evaluator_bpb_includes_zero_byte_token_loss():
+    EvalBatch = Axis("batch", 2)
+    examples = [
+        LabeledLmExample(tokens=jnp.array([1, 1], dtype=jnp.int32), loss_labels=jnp.ones((2,), dtype=jnp.int32)),
+        LabeledLmExample(tokens=jnp.array([1, 1], dtype=jnp.int32), loss_labels=jnp.ones((2,), dtype=jnp.int32)),
+        LabeledLmExample(tokens=jnp.array([2, 2], dtype=jnp.int32), loss_labels=jnp.ones((2,), dtype=jnp.int32)),
+        LabeledLmExample(tokens=jnp.array([2, 2], dtype=jnp.int32), loss_labels=jnp.ones((2,), dtype=jnp.int32)),
+    ]
+    label_spec = LossLabelSpec(id_to_name={1: "target"})
+
+    def loss_fn(_model, batch: LabeledLmExample) -> LabeledLossFnOutput:
+        losses = jnp.ones_like(batch.tokens, dtype=jnp.float32)
+        return losses, batch.loss_labels, batch.tokens
+
+    with use_test_mesh(tensor_parallelism=1) as mesh:
+        evaluator = LabeledEvaluator(
+            EvalBatch=EvalBatch,
+            eval_set=ListAsyncDataset(examples),
+            label_spec=label_spec,
+            loss_fn=loss_fn,
+            tokenizer=_ByteLengthTokenizer(),
+            device_mesh=mesh,
+            axis_mapping={EvalBatch.name: ResourceAxis.DATA},
+        )
+        result = evaluator.evaluate(None)
+
+    expected_bpb = 8.0 * np.log2(np.e) / 12.0
+    np.testing.assert_allclose(result.label_bpb["target"], expected_bpb)
 
 
 def test_labeled_lm_evaluator_accepts_labeled_lm_examples():

--- a/lib/levanter/tests/test_eval.py
+++ b/lib/levanter/tests/test_eval.py
@@ -104,7 +104,7 @@ def test_tagged_evaluator_accepts_grug_lm_examples():
 
 
 def test_tagged_evaluator_bpb_includes_zero_byte_token_loss():
-    EvalBatch = Axis("batch", 2)
+    EvalBatch = Axis("batch", max(2, len(jax.devices())))
     examples = [
         GrugLmExample(tokens=jnp.array([1, 1], dtype=jnp.int32), loss_weight=jnp.ones((2,), dtype=jnp.float32)),
         GrugLmExample(tokens=jnp.array([1, 1], dtype=jnp.int32), loss_weight=jnp.ones((2,), dtype=jnp.float32)),
@@ -295,7 +295,7 @@ def test_labeled_evaluator_aggregates_exclusive_loss_labels():
 
 
 def test_labeled_evaluator_bpb_includes_zero_byte_token_loss():
-    EvalBatch = Axis("batch", 2)
+    EvalBatch = Axis("batch", max(2, len(jax.devices())))
     examples = [
         LabeledLmExample(tokens=jnp.array([1, 1], dtype=jnp.int32), loss_labels=jnp.ones((2,), dtype=jnp.int32)),
         LabeledLmExample(tokens=jnp.array([1, 1], dtype=jnp.int32), loss_labels=jnp.ones((2,), dtype=jnp.int32)),

--- a/lib/levanter/tests/test_perplexity_gap.py
+++ b/lib/levanter/tests/test_perplexity_gap.py
@@ -77,10 +77,38 @@ class _MemoryShardSource(ShardedDataSource[dict[str, Any]]):
         return iter(self.records[row:])
 
 
+class _FakeTokenizer:
+    bos_token_id = None
+    eos_token_id = None
+
+    def encode(self, text: str, *, add_special_tokens: bool = False) -> list[int]:
+        return []
+
+
+class _FakeOffsetTokenizer:
+    def __init__(
+        self,
+        *,
+        input_ids: list[int],
+        offset_mapping: list[tuple[int, int]],
+        decoded_prefixes: dict[tuple[int, ...], str],
+    ):
+        self.input_ids = input_ids
+        self.offset_mapping = offset_mapping
+        self.decoded_prefixes = decoded_prefixes
+
+    def __call__(self, text: str, *, add_special_tokens: bool = False, return_offsets_mapping: bool = False):
+        assert return_offsets_mapping
+        return {"input_ids": self.input_ids, "offset_mapping": self.offset_mapping}
+
+    def decode(self, token_ids: list[int], *, clean_up_tokenization_spaces: bool = False) -> str:
+        return self.decoded_prefixes[tuple(token_ids)]
+
+
 def test_tokenize_text_with_byte_spans_covers_utf8_bytes():
     tokenizer = load_tokenizer("gpt2")
     hf_tokenizer = tokenizer.as_hf_tokenizer()
-    text = "hello  \nnaive café"
+    text = "hello  \nnaive café 🙂"
 
     tokenized = tokenize_text_with_byte_spans(tokenizer, hf_tokenizer, text)
 
@@ -93,7 +121,34 @@ def test_tokenize_text_with_byte_spans_covers_utf8_bytes():
     assert spans
     assert spans[0][0] == 0
     assert spans[-1][1] == tokenized.num_bytes
-    assert sum(end - start for start, end in spans) == tokenized.num_bytes
+
+
+def test_tokenize_text_with_byte_spans_rejects_shifted_offsets():
+    hf_tokenizer = _FakeOffsetTokenizer(
+        input_ids=[1, 2],
+        offset_mapping=[(0, 2), (2, 6)],
+        decoded_prefixes={
+            (1,): "abc",
+            (1, 2): "abcdef",
+        },
+    )
+
+    with pytest.raises(ValueError, match="offset mapping is not source-aligned"):
+        tokenize_text_with_byte_spans(_FakeTokenizer(), hf_tokenizer, "abcdef")
+
+
+def test_tokenize_text_with_byte_spans_rejects_zero_width_source_tokens():
+    hf_tokenizer = _FakeOffsetTokenizer(
+        input_ids=[1, 2],
+        offset_mapping=[(0, 0), (0, 5)],
+        decoded_prefixes={
+            (1,): "",
+            (1, 2): "Hello",
+        },
+    )
+
+    with pytest.raises(ValueError, match="without a positive source byte span"):
+        tokenize_text_with_byte_spans(_FakeTokenizer(), hf_tokenizer, "Hello")
 
 
 def test_iter_dataset_documents_combines_supervised_input_and_target():

--- a/lib/levanter/tests/test_perplexity_gap.py
+++ b/lib/levanter/tests/test_perplexity_gap.py
@@ -123,6 +123,23 @@ def test_tokenize_text_with_byte_spans_covers_utf8_bytes():
     assert spans[-1][1] == tokenized.num_bytes
 
 
+def test_tokenize_text_with_byte_spans_accepts_context_sensitive_decode():
+    hf_tokenizer = _FakeOffsetTokenizer(
+        input_ids=[1, 2],
+        offset_mapping=[(0, 1), (1, 7)],
+        decoded_prefixes={
+            (1,): "x",
+            (2,): "hello",
+            (1, 2): "x hello",
+        },
+    )
+
+    tokenized = tokenize_text_with_byte_spans(_FakeTokenizer(), hf_tokenizer, "x hello")
+
+    assert tokenized.byte_starts.tolist() == [0, 1]
+    assert tokenized.byte_ends.tolist() == [1, 7]
+
+
 def test_tokenize_text_with_byte_spans_rejects_shifted_offsets():
     hf_tokenizer = _FakeOffsetTokenizer(
         input_ids=[1, 2],


### PR DESCRIPTION
Fix tokenizer BPB accounting so loss is aggregated against decoded byte totals instead of token-weighted batch BPB, preserving loss from zero-byte token IDs. Also fail fast when perplexity-gap token offsets are not source-aligned, preventing TokenMonster-style marker offsets from silently corrupting BPB artifacts and heatmaps. Adds regression coverage for zero-byte token loss and invalid source spans.

Part of #5821