### PR TITLE
[iris] In-task finelog stats write direct, not via controller proxy

### DIFF
--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -11,6 +11,8 @@ via submitted jobs, and deferred actor handle resolution.
 from __future__ import annotations
 
 import logging
+import os
+import sys
 import threading
 import time
 from concurrent.futures import Future
@@ -242,19 +244,34 @@ def _host_actor(actor_class: type, args: tuple, kwargs: dict, name_prefix: str) 
     ctx.registry.register(actor_name, address)
     logger.info(f"Actor {actor_name} ready and listening")
 
-    try:
-        # Block until the actor signals shutdown via shutdown_event
-        shutdown_event.wait()
-    finally:
-        logger.info(f"Actor {actor_name} shutting down")
-        server.stop()
-        # Drain and join in-task finelog flush threads before the interpreter finalizes.
-        if ctx.client is not None:
-            ctx.client.shutdown()
+    # Block until the actor signals shutdown via shutdown_event
+    shutdown_event.wait()
+    logger.info(f"Actor {actor_name} shutting down")
+    server.stop()
 
-    if actor_ctx._errors:
-        logger.error("Actor %s recorded %d failure(s); raising the first", actor_name, len(actor_ctx._errors))
-        raise actor_ctx._errors[0]
+    failed = bool(actor_ctx._errors)
+    if failed:
+        logger.error(
+            "Actor %s recorded %d failure(s); first: %r",
+            actor_name,
+            len(actor_ctx._errors),
+            actor_ctx._errors[0],
+            exc_info=actor_ctx._errors[0],
+        )
+
+    # WORKAROUND for the pyqwest interpreter-shutdown crash: CPython
+    # finalization force-unwinds pyqwest's native (tokio) threads and aborts the
+    # process (SIGABRT/SIGSEGV, exit 134/139). Best-effort drain the in-task
+    # finelog client, then hard-exit via os._exit to skip finalization entirely.
+    # Success/failure is encoded in the exit code since this bypasses the raise.
+    if ctx.client is not None:
+        try:
+            ctx.client.shutdown()
+        except Exception:
+            logger.warning("in-task client shutdown failed (ignored before os._exit)", exc_info=True)
+    sys.stdout.flush()
+    sys.stderr.flush()
+    os._exit(1 if failed else 0)
 
 
 class IrisActorHandle:

--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -242,10 +242,16 @@ def _host_actor(actor_class: type, args: tuple, kwargs: dict, name_prefix: str) 
     ctx.registry.register(actor_name, address)
     logger.info(f"Actor {actor_name} ready and listening")
 
-    # Block until the actor signals shutdown via shutdown_event
-    shutdown_event.wait()
-    logger.info(f"Actor {actor_name} shutting down")
-    server.stop()
+    try:
+        # Block until the actor signals shutdown via shutdown_event
+        shutdown_event.wait()
+    finally:
+        logger.info(f"Actor {actor_name} shutting down")
+        server.stop()
+        # Drain and join in-task finelog flush threads before the interpreter finalizes.
+        if ctx.client is not None:
+            ctx.client.shutdown()
+
     if actor_ctx._errors:
         logger.error("Actor %s recorded %d failure(s); raising the first", actor_name, len(actor_ctx._errors))
         raise actor_ctx._errors[0]

--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -487,7 +487,11 @@ class IrisClient:
         timeout_ms: int = 30000,
         token_provider: TokenProvider | None = None,
     ) -> "IrisClient":
-        """Create an IrisClient for RPC-based cluster execution.
+        """Create an IrisClient for an external client (CLI, laptop, notebook).
+
+        Finelog logs/stats are routed through the controller, the only ingress
+        an external client can reach. In-cluster callers should use
+        :meth:`in_cluster` instead.
 
         Args:
             controller_address: Controller URL (e.g., "http://localhost:8080")
@@ -502,6 +506,53 @@ class IrisClient:
         Returns:
             IrisClient wrapping RemoteClusterClient
         """
+        return cls._make(
+            controller_address,
+            workspace=workspace,
+            bundle_id=bundle_id,
+            timeout_ms=timeout_ms,
+            token_provider=token_provider,
+            direct_log_server=False,
+        )
+
+    @classmethod
+    def in_cluster(
+        cls,
+        controller_address: str,
+        *,
+        workspace: Path | None = None,
+        bundle_id: str | None = None,
+        timeout_ms: int = 30000,
+        token_provider: TokenProvider | None = None,
+    ) -> "IrisClient":
+        """Create an IrisClient for code running inside the cluster (in-task).
+
+        Same as :meth:`remote`, except finelog logs/stats are written straight
+        to the resolved finelog server instead of through the controller's
+        StatsServiceProxy — so high-frequency task-status pushes don't compete
+        for the controller's RPC thread pool. Only valid where the finelog
+        server's internal address is reachable (i.e. inside the cluster).
+        """
+        return cls._make(
+            controller_address,
+            workspace=workspace,
+            bundle_id=bundle_id,
+            timeout_ms=timeout_ms,
+            token_provider=token_provider,
+            direct_log_server=True,
+        )
+
+    @classmethod
+    def _make(
+        cls,
+        controller_address: str,
+        *,
+        workspace: Path | None,
+        bundle_id: str | None,
+        timeout_ms: int,
+        token_provider: TokenProvider | None,
+        direct_log_server: bool,
+    ) -> "IrisClient":
         interceptors = []
         if token_provider is not None:
             interceptors.append(AuthTokenInjector(token_provider))
@@ -512,6 +563,7 @@ class IrisClient:
             workspace=workspace,
             timeout_ms=timeout_ms,
             interceptors=interceptors,
+            direct_log_server=direct_log_server,
         )
         return cls(cluster)
 
@@ -1034,7 +1086,9 @@ def get_iris_ctx() -> IrisContext | None:
     client = None
     if job_info.controller_address:
         bundle_id = job_info.bundle_id
-        client = IrisClient.remote(
+        # In-task code runs inside the cluster and can reach the finelog server
+        # directly, so task-status pushes bypass the controller's StatsServiceProxy.
+        client = IrisClient.in_cluster(
             controller_address=job_info.controller_address,
             bundle_id=bundle_id,
         )

--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -512,7 +512,7 @@ class IrisClient:
             bundle_id=bundle_id,
             timeout_ms=timeout_ms,
             token_provider=token_provider,
-            direct_log_server=False,
+            use_controller_proxy=True,
         )
 
     @classmethod
@@ -539,7 +539,7 @@ class IrisClient:
             bundle_id=bundle_id,
             timeout_ms=timeout_ms,
             token_provider=token_provider,
-            direct_log_server=True,
+            use_controller_proxy=False,
         )
 
     @classmethod
@@ -551,7 +551,7 @@ class IrisClient:
         bundle_id: str | None,
         timeout_ms: int,
         token_provider: TokenProvider | None,
-        direct_log_server: bool,
+        use_controller_proxy: bool,
     ) -> "IrisClient":
         interceptors = []
         if token_provider is not None:
@@ -563,7 +563,7 @@ class IrisClient:
             workspace=workspace,
             timeout_ms=timeout_ms,
             interceptors=interceptors,
-            direct_log_server=direct_log_server,
+            use_controller_proxy=use_controller_proxy,
         )
         return cls(cluster)
 

--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -18,6 +18,7 @@ from finelog.rpc import logging_pb2
 from rigging.timing import Deadline, Duration, ExponentialBackoff
 
 from iris.cluster.client.bundle import BundleCreator
+from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
 from iris.cluster.log_keys import build_log_source
 from iris.cluster.runtime.entrypoint import build_runtime_entrypoint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, JobName, TaskAttempt, adjust_tpu_replicas, is_job_finished
@@ -71,6 +72,7 @@ class RemoteClusterClient:
         workspace: Path | None = None,
         timeout_ms: int = 30000,
         interceptors: Iterable[InterceptorSync] = (),
+        direct_log_server: bool = False,
     ):
         """Initialize RPC cluster operations.
 
@@ -80,6 +82,13 @@ class RemoteClusterClient:
             workspace: Path to workspace directory. Bundle is created lazily on first job submission.
             timeout_ms: RPC timeout in milliseconds
             interceptors: Client-side interceptors (e.g. AuthTokenInjector for token auth)
+            direct_log_server: Resolve ``/system/log-server`` via the controller's
+                endpoint registry and connect the finelog ``LogClient`` straight to
+                that address, instead of routing log/stats RPCs through the
+                controller's StatsServiceProxy. Only safe for clients running
+                *inside* the cluster (e.g. in-task code), which can reach the
+                finelog server's internal address; external clients (CLI over a
+                tunnel) cannot and must keep the default (controller-proxied) path.
         """
         self._address = controller_address
         self._bundle_id = bundle_id
@@ -93,11 +102,24 @@ class RemoteClusterClient:
             accept_compression=IRIS_RPC_COMPRESSIONS,
             send_compression=None,
         )
-        self._log_client = LogClient.connect(
-            controller_address,
-            timeout_ms=timeout_ms,
-            interceptors=interceptors,
-        )
+        # In-cluster clients resolve the finelog endpoint and write direct so
+        # task-status pushes don't pile up on the controller's RPC thread pool;
+        # external clients route through the controller, the only ingress they
+        # can reach. The resolver fires lazily on first table/log use, so this
+        # adds no RPC for CLI calls that never touch logs.
+        if direct_log_server:
+            self._log_client = LogClient.connect(
+                LOG_SERVER_ENDPOINT_NAME,
+                resolver=self._resolve_log_server,
+                timeout_ms=timeout_ms,
+                interceptors=interceptors,
+            )
+        else:
+            self._log_client = LogClient.connect(
+                controller_address,
+                timeout_ms=timeout_ms,
+                interceptors=interceptors,
+            )
         # Deferred so CLI calls that never push status (submit_job, list_jobs,
         # get_status) don't spawn a finelog flush thread.
         self._task_status_table = None
@@ -387,6 +409,18 @@ class RemoteClusterClient:
             return list(response.endpoints)
 
         return call_with_retry("list_endpoints", _call)
+
+    def _resolve_log_server(self, endpoint_name: str) -> str:
+        """Resolve ``endpoint_name`` to the finelog server's address via the registry.
+
+        Invoked by the finelog ``LogClient`` (when ``direct_log_server`` is set)
+        to turn the logical ``/system/log-server`` name into the concrete address
+        the controller advertises.
+        """
+        endpoints = self.list_endpoints(endpoint_name, exact=True)
+        if not endpoints:
+            raise ConnectionError(f"No {endpoint_name!r} endpoint registered on controller")
+        return endpoints[0].address
 
     def list_workers(self) -> list[controller_pb2.Controller.WorkerHealthStatus]:
         """List all workers registered with the controller."""

--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -72,7 +72,7 @@ class RemoteClusterClient:
         workspace: Path | None = None,
         timeout_ms: int = 30000,
         interceptors: Iterable[InterceptorSync] = (),
-        direct_log_server: bool = False,
+        use_controller_proxy: bool = True,
     ):
         """Initialize RPC cluster operations.
 
@@ -82,19 +82,20 @@ class RemoteClusterClient:
             workspace: Path to workspace directory. Bundle is created lazily on first job submission.
             timeout_ms: RPC timeout in milliseconds
             interceptors: Client-side interceptors (e.g. AuthTokenInjector for token auth)
-            direct_log_server: Resolve ``/system/log-server`` via the controller's
-                endpoint registry and connect the finelog ``LogClient`` straight to
-                that address, instead of routing log/stats RPCs through the
-                controller's StatsServiceProxy. Only safe for clients running
-                *inside* the cluster (e.g. in-task code), which can reach the
-                finelog server's internal address; external clients (CLI over a
-                tunnel) cannot and must keep the default (controller-proxied) path.
+            use_controller_proxy: Route service RPCs (currently finelog
+                logs/stats) through the controller instead of resolving the
+                backing service's address from the controller's endpoint
+                registry and connecting straight to it. The direct path is only
+                safe for clients running *inside* the cluster, which can reach
+                internal service addresses; external clients (CLI over a
+                tunnel) cannot and must keep the default proxied path.
         """
         self._address = controller_address
         self._bundle_id = bundle_id
         self._workspace = workspace.resolve() if workspace is not None else None
         self._bundle_blob: bytes | None = None
         self._timeout_ms = timeout_ms
+        self._use_controller_proxy = use_controller_proxy
         self._client = ControllerServiceClientSync(
             address=controller_address,
             timeout_ms=timeout_ms,
@@ -107,19 +108,12 @@ class RemoteClusterClient:
         # external clients route through the controller, the only ingress they
         # can reach. The resolver fires lazily on first table/log use, so this
         # adds no RPC for CLI calls that never touch logs.
-        if direct_log_server:
-            self._log_client = LogClient.connect(
-                LOG_SERVER_ENDPOINT_NAME,
-                resolver=self._resolve_log_server,
-                timeout_ms=timeout_ms,
-                interceptors=interceptors,
-            )
-        else:
-            self._log_client = LogClient.connect(
-                controller_address,
-                timeout_ms=timeout_ms,
-                interceptors=interceptors,
-            )
+        self._log_client = LogClient.connect(
+            LOG_SERVER_ENDPOINT_NAME,
+            resolver=self._resolve_endpoint,
+            timeout_ms=timeout_ms,
+            interceptors=interceptors,
+        )
         # Deferred so CLI calls that never push status (submit_job, list_jobs,
         # get_status) don't spawn a finelog flush thread.
         self._task_status_table = None
@@ -410,13 +404,16 @@ class RemoteClusterClient:
 
         return call_with_retry("list_endpoints", _call)
 
-    def _resolve_log_server(self, endpoint_name: str) -> str:
-        """Resolve ``endpoint_name`` to the finelog server's address via the registry.
+    def _resolve_endpoint(self, endpoint_name: str) -> str:
+        """Resolve ``endpoint_name`` to a service address.
 
-        Invoked by the finelog ``LogClient`` (when ``direct_log_server`` is set)
-        to turn the logical ``/system/log-server`` name into the concrete address
-        the controller advertises.
+        When ``use_controller_proxy`` is set (external clients), returns the
+        controller address so RPCs flow through its proxies; otherwise looks
+        the name up in the controller's endpoint registry and returns the
+        backing service's direct address.
         """
+        if self._use_controller_proxy:
+            return self._address
         endpoints = self.list_endpoints(endpoint_name, exact=True)
         if not endpoints:
             raise ConnectionError(f"No {endpoint_name!r} endpoint registered on controller")

--- a/lib/iris/src/iris/cluster/controller/main.py
+++ b/lib/iris/src/iris/cluster/controller/main.py
@@ -30,7 +30,7 @@ from iris.cluster.controller.budget import reconcile_user_budget_tiers
 from iris.cluster.controller.checkpoint import download_checkpoint_to_local
 from iris.cluster.controller.controller import Controller, ControllerConfig
 from iris.cluster.controller.db import ControllerDB
-from iris.cluster.endpoints import resolve_endpoint_uri
+from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME, resolve_endpoint_uri
 from iris.cluster.providers.factory import create_provider_bundle
 from iris.cluster.providers.k8s.tasks import K8sTaskProvider
 from iris.rpc import config_pb2
@@ -41,8 +41,6 @@ logger = logging.getLogger(__name__)
 LOCAL_STATE_DIR_DEFAULT = Path("/var/cache/iris/controller")
 DRY_RUN_STATE_DIR_ROOT = Path("/tmp/dry-run")
 HOURLY_CHECKPOINT_SECONDS = 3600.0
-
-LOG_SERVER_ENDPOINT_NAME = "/system/log-server"
 
 
 def _resolve_cluster_endpoints(cluster_config: config_pb2.IrisClusterConfig) -> dict[str, str]:

--- a/lib/iris/src/iris/cluster/endpoints.py
+++ b/lib/iris/src/iris/cluster/endpoints.py
@@ -43,6 +43,10 @@ import google.auth
 
 logger = logging.getLogger(__name__)
 
+# Logical registry name for the finelog log/stats server. Clients resolve this
+# via the controller's endpoint registry to the concrete finelog address.
+LOG_SERVER_ENDPOINT_NAME = "/system/log-server"
+
 SchemeResolver = Callable[[str, dict[str, str]], str]
 
 _REGISTRY: dict[str, SchemeResolver] = {}

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -16,6 +16,7 @@ from rigging.timing import Deadline, Duration, ExponentialBackoff, RateLimiter
 
 from iris.chaos import chaos
 from iris.cluster.bundle import BundleStore
+from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
 from iris.cluster.log_keys import worker_log_key
 from iris.cluster.runtime.docker import DockerRuntime
 from iris.cluster.runtime.profile import (
@@ -261,7 +262,7 @@ class Worker:
 
         if self._config.controller_address:
             self._log_client = LogClient.connect(
-                "/system/log-server",
+                LOG_SERVER_ENDPOINT_NAME,
                 interceptors=interceptors,
                 resolver=self._resolve_log_service,
             )


### PR DESCRIPTION
* in-task clients (zephyr coordinator + every worker) push status text via `report_task_status_text`, which wrote `iris.task_status` to the finelog `StatsService` on the *controller* url
  * controller's `StatsServiceProxy` then forwards each `WriteRows` synchronously on its 64-thread `rpc-handler` pool [^1]
  * `(#workers + #coordinators)` writes every 10s saturate the pool when the finelog backend is slow, starving controller RPCs
* add `IrisClient.in_cluster()` — resolves `/system/log-server` from the controller registry and points the finelog `LogClient` straight at the finelog server (mirrors the worker daemon)
* in-task ctx builder now uses `in_cluster()`; `IrisClient.remote()` keeps the controller-routed path for external clients that can't reach the finelog internal address [^2]
* `direct_log_server` stays an internal `RemoteClusterClient` knob — the public surface is the two named constructors
* hoist `LOG_SERVER_ENDPOINT_NAME` into `iris.cluster.endpoints` as the single source of truth (`controller/main.py`, `worker.py` import it)

[^1]: not addressed here: the proxy uses the *sync* `StatsServiceClientSync` via `asyncio.to_thread` on the shared `rpc-handler` default executor, so any slow inbound `WriteRows` can starve RPC serving regardless of source — separate hardening (async client / dedicated executor).
[^2]: only verified reachable on the GCP path (task containers run `--network=host`); CoreWeave/K8s pod→finelog reachability not yet validated.