### PR TITLE
Fix TokenMonster BPB accounting

### DIFF
--- a/experiments/exp_tokenizer_sensitivity_d1024_perplexity_gap.py
+++ b/experiments/exp_tokenizer_sensitivity_d1024_perplexity_gap.py
@@ -1,0 +1,150 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Raw perplexity-gap evals for tokenizer sensitivity d1024 runs.
+
+Uses the finished d1024 tokenizer-sensitivity checkpoints from #5821 and
+compares each tokenizer arm against the llama3-128k arm. The unfinished
+marin-128k arm is intentionally excluded.
+"""
+
+from __future__ import annotations
+
+from dataclasses import replace
+
+from fray.types import ResourceConfig
+from levanter.tokenizers import TokenizerBackend
+
+from experiments.defaults import default_raw_validation_sets
+from experiments.grug.moe.model import GrugModelConfig
+from marin.evaluation.perplexity_gap import (
+    GapFinderModelConfig,
+    model_perplexity_gap_from_scores,
+    model_perplexity_scores,
+)
+from marin.execution.executor import executor_main
+
+
+RESOURCE_CONFIG = ResourceConfig.with_tpu(["v6e-8", "v5litepod-8"], regions=["europe-west4"])
+DATASETS = default_raw_validation_sets()
+
+BASE_CHECKPOINT_DIR = "gs://marin-eu-west4/data/datakit/train/tokenizer-sensitivity-moe-ladder/2026-05-25/d1024"
+
+BASE_MODEL = GrugModelConfig(
+    hidden_dim=1024,
+    intermediate_dim=512,
+    shared_expert_intermediate_dim=1024,
+    num_layers=11,
+    num_heads=8,
+    num_kv_heads=2,
+    num_experts=64,
+    num_experts_per_token=4,
+    max_seq_len=4096,
+    sliding_window=4096,
+    qk_mult=1.3,
+    initializer_std=0.015625,
+    layer_norm_eps=1e-5,
+    router_z_loss_coef=0.001,
+    vocab_size=128_256,
+)
+
+
+def native_model(
+    *,
+    arm: str,
+    tokenizer: str,
+    vocab_size: int,
+    tokenizer_backend: TokenizerBackend = TokenizerBackend.HF,
+) -> GapFinderModelConfig:
+    return GapFinderModelConfig(
+        checkpoint_path=f"{BASE_CHECKPOINT_DIR}/{arm}/checkpoints",
+        checkpoint_is_hf=False,
+        model=replace(BASE_MODEL, vocab_size=vocab_size),
+        tokenizer=tokenizer,
+        tokenizer_backend=tokenizer_backend,
+    )
+
+
+MODELS = {
+    "llama3-128k": native_model(
+        arm="llama3-128k",
+        tokenizer="meta-llama/Meta-Llama-3.1-8B",
+        vocab_size=128_256,
+    ),
+    "qwen3-152k": native_model(
+        arm="qwen3-152k",
+        tokenizer="Qwen/Qwen3-0.6B",
+        vocab_size=151_936,
+    ),
+    "gemma3-262k": native_model(
+        arm="gemma3-262k",
+        tokenizer="google/gemma-3-4b-it",
+        vocab_size=262_145,
+    ),
+    "gpt-oss-200k": native_model(
+        arm="gpt-oss-200k",
+        tokenizer="openai/gpt-oss-20b",
+        vocab_size=200_019,
+    ),
+    "tokenmonster-englishcode-32k": native_model(
+        arm="tokenmonster-englishcode-32k",
+        tokenizer="tokenmonster:englishcode-32000-consistent-v1",
+        tokenizer_backend=TokenizerBackend.TOKENMONSTER,
+        vocab_size=32_000,
+    ),
+}
+
+SCORE_STEPS = {
+    arm: model_perplexity_scores(
+        name=f"tokenizer-sensitivity-d1024/{arm}",
+        model=model,
+        datasets=DATASETS,
+        resource_config=RESOURCE_CONFIG,
+        per_device_batch_size=16,
+        max_eval_length=4096,
+        max_docs_per_dataset=256,
+        max_doc_bytes=32_768,
+        wandb_tags=[
+            "eval=model-perplexity",
+            "issue=5821",
+            "tokenizer-sensitivity",
+            "d1024",
+            f"model={arm}",
+            "baseline=llama3-128k" if arm == "llama3-128k" else "comparison=llama3-128k",
+            "region=europe-west4",
+        ],
+    )
+    for arm, model in MODELS.items()
+}
+
+BASELINE = "llama3-128k"
+GAP_STEPS = [
+    model_perplexity_gap_from_scores(
+        name=f"tokenizer-sensitivity-d1024/{arm}-vs-{BASELINE}",
+        model_a_name=arm,
+        model_b_name=BASELINE,
+        model_a_scores_path=SCORE_STEPS[arm].as_input_name(),
+        model_b_scores_path=SCORE_STEPS[BASELINE].as_input_name(),
+        wandb_tags=[
+            "eval=perplexity-gap",
+            "issue=5821",
+            "tokenizer-sensitivity",
+            "d1024",
+            f"model_a={arm}",
+            f"model_b={BASELINE}",
+            "region=europe-west4",
+        ],
+    )
+    for arm in MODELS
+    if arm != BASELINE
+]
+
+
+if __name__ == "__main__":
+    executor_main(
+        GAP_STEPS,
+        description=(
+            "Compare finished tokenizer-sensitivity d1024 arms against the llama3-128k baseline on raw "
+            "Paloma and uncheatable eval datasets. The unfinished marin-128k arm is excluded."
+        ),
+    )

--- a/lib/levanter/src/levanter/analysis/perplexity_gap.py
+++ b/lib/levanter/src/levanter/analysis/perplexity_gap.py
@@ -563,6 +563,16 @@ def _truncate_text_to_byte_limit(text: str, max_doc_bytes: int) -> str:
 
 
 def tokenize_text_with_byte_spans(tokenizer: MarinTokenizer, hf_tokenizer: Any, text: str) -> TokenizedDocument:
+    custom_offsets = getattr(tokenizer, "tokenize_with_byte_offsets", None)
+    if custom_offsets is not None:
+        ids, byte_starts, byte_ends, num_bytes = custom_offsets(text)
+        return TokenizedDocument(
+            token_ids=np.asarray(ids, dtype=np.int32),
+            byte_starts=np.asarray(byte_starts, dtype=np.int32),
+            byte_ends=np.asarray(byte_ends, dtype=np.int32),
+            num_bytes=int(num_bytes),
+        )
+
     parts = _safe_split_for_tokenizer(text)
     ids: list[int] = []
     char_spans: list[tuple[int, int]] = []

--- a/lib/levanter/src/levanter/eval.py
+++ b/lib/levanter/src/levanter/eval.py
@@ -121,6 +121,10 @@ class EvalResult:
     macro_bpb: Optional[float] = None
     tag_macro_bpb: Optional[dict[str, float]] = None
     tag_micro_bpb: Optional[dict[str, float]] = None
+    micro_bpb_fixed: Optional[float] = None
+    macro_bpb_fixed: Optional[float] = None
+    tag_macro_bpb_fixed: Optional[dict[str, float]] = None
+    tag_micro_bpb_fixed: Optional[dict[str, float]] = None
 
 
 @dataclasses.dataclass
@@ -536,14 +540,20 @@ def construct_log_dict(evaluator, eval_result, total_time, prefix):
             logger.info(f"{tag} micro loss: {loss:.3f}")
     if tokenizer is not None:
         log_dict[_join_prefix(prefix, "bpb")] = eval_result.micro_bpb
+        log_dict[_join_prefix(prefix, "bpb_fixed")] = eval_result.micro_bpb_fixed
         if has_tags:
             log_dict[_join_prefix(prefix, "macro_bpb")] = eval_result.macro_bpb
+            log_dict[_join_prefix(prefix, "macro_bpb_fixed")] = eval_result.macro_bpb_fixed
         for tag, bpb in eval_result.tag_micro_bpb.items():
             log_dict[_join_prefix(prefix, tag) + "/bpb"] = bpb
+        for tag, bpb in eval_result.tag_micro_bpb_fixed.items():
+            log_dict[_join_prefix(prefix, tag) + "/bpb_fixed"] = bpb
 
         if has_tags:
             for tag, bpb in eval_result.tag_macro_bpb.items():
                 log_dict[_join_prefix(prefix, tag) + "/macro_bpb"] = bpb
+            for tag, bpb in eval_result.tag_macro_bpb_fixed.items():
+                log_dict[_join_prefix(prefix, tag) + "/macro_bpb_fixed"] = bpb
     return log_dict
 
 
@@ -646,10 +656,14 @@ class TaggedEvaluator(Generic[Ex, M]):
                 bpb_per_tag = this_loss_per_tag / jnp.maximum(bytes_per_tag, 1.0) * log2e
 
                 bpb_mean = state.bpb.add(bpb, this_weights)
+                bpb_fixed_mean = state.bpb_fixed.add(bpb, this_bytes)
                 state = dataclasses.replace(state, bpb=bpb_mean)
+                state = dataclasses.replace(state, bpb_fixed=bpb_fixed_mean)
                 if len(self.dataset.tag_to_index) > 0:
                     bpb_per_tag_mean = state.bpb_per_tag.add(bpb_per_tag, this_weights_per_tag)
+                    bpb_fixed_per_tag_mean = state.bpb_fixed_per_tag.add(bpb_per_tag, bytes_per_tag)
                     state = dataclasses.replace(state, bpb_per_tag=bpb_per_tag_mean)
+                    state = dataclasses.replace(state, bpb_fixed_per_tag=bpb_fixed_per_tag_mean)
 
             return state
 
@@ -676,19 +690,28 @@ class TaggedEvaluator(Generic[Ex, M]):
             micro_bpb = state.bpb.mean.item()
             tag_avg_bpb = state.bpb_per_tag.mean
             macro_avg_bpb = jnp.mean(tag_avg_bpb).item()
+            micro_bpb_fixed = state.bpb_fixed.mean.item()
+            tag_avg_bpb_fixed = state.bpb_fixed_per_tag.mean
+            macro_avg_bpb_fixed = jnp.mean(tag_avg_bpb_fixed).item()
         else:
             micro_bpb = None
             macro_avg_bpb = None
+            micro_bpb_fixed = None
+            macro_avg_bpb_fixed = None
 
         tag_macro_loss: dict[str, float] = {}
         tag_micro_loss: dict[str, float] = {}
         tag_macro_bpb: dict[str, float] = {}
         tag_micro_bpb: dict[str, float] = {}
+        tag_macro_bpb_fixed: dict[str, float] = {}
+        tag_micro_bpb_fixed: dict[str, float] = {}
 
         mean_loss_per_tag_cpu = np.array(state.loss_per_tag.mean)
         total_tokens_per_tag_cpu = np.array(state.loss_per_tag.total)
         mean_bits_per_tag_cpu = np.array(state.bpb_per_tag.mean)
-        total_bytes_per_tag_cpu = np.array(state.bpb_per_tag.total)
+        total_bpb_weights_per_tag_cpu = np.array(state.bpb_per_tag.total)
+        mean_bits_fixed_per_tag_cpu = np.array(state.bpb_fixed_per_tag.mean)
+        total_bytes_fixed_per_tag_cpu = np.array(state.bpb_fixed_per_tag.total)
 
         for parent, children in self.hierarchy.items():
             mask = np.zeros(self.dataset.num_tags, dtype=bool)
@@ -700,12 +723,17 @@ class TaggedEvaluator(Generic[Ex, M]):
 
             if self.bytes_per_token is not None:
                 tag_macro_bpb[parent] = np.mean(mean_bits_per_tag_cpu, where=mask)
-                tag_micro_bpb[parent] = np.average(mean_bits_per_tag_cpu, weights=total_bytes_per_tag_cpu * mask)
+                tag_micro_bpb[parent] = np.average(mean_bits_per_tag_cpu, weights=total_bpb_weights_per_tag_cpu * mask)
+                tag_macro_bpb_fixed[parent] = np.mean(mean_bits_fixed_per_tag_cpu, where=mask)
+                tag_micro_bpb_fixed[parent] = np.average(
+                    mean_bits_fixed_per_tag_cpu, weights=total_bytes_fixed_per_tag_cpu * mask
+                )
 
         for tag, index in self.dataset.tag_to_index.items():
             tag_micro_loss[tag] = float(mean_loss_per_tag_cpu[index])
             if self.bytes_per_token is not None:
                 tag_micro_bpb[tag] = float(mean_bits_per_tag_cpu[index])
+                tag_micro_bpb_fixed[tag] = float(mean_bits_fixed_per_tag_cpu[index])
 
         return EvalResult(
             micro_avg_loss,
@@ -717,6 +745,10 @@ class TaggedEvaluator(Generic[Ex, M]):
             macro_avg_bpb,
             tag_macro_bpb,
             tag_micro_bpb,
+            micro_bpb_fixed,
+            macro_avg_bpb_fixed,
+            tag_macro_bpb_fixed,
+            tag_micro_bpb_fixed,
         )
 
     def _construct_tag_hierarchy(self) -> dict[str, list[int]]:
@@ -897,14 +929,16 @@ class LabeledEvaluator(Generic[Ex, M]):
 class _EvalRunningMeans(eqx.Module):
     token_avg_loss: RunningMean  # average loss averaged over all tokens
     loss_per_tag: RunningMean  # average loss per tag
-    bpb: RunningMean  # bits per byte averaged over all tokens
-    bpb_per_tag: RunningMean  # bits per byte per tag
+    bpb: RunningMean  # historical bits per byte, averaged with token weights
+    bpb_per_tag: RunningMean  # historical bits per byte per tag, averaged with token weights
+    bpb_fixed: RunningMean  # bits per byte averaged with byte weights
+    bpb_fixed_per_tag: RunningMean  # bits per byte per tag, averaged with byte weights
 
     @staticmethod
     def zeros_like(total: Float[Array, "..."], per_tag: Float[Array, "tag"]) -> "_EvalRunningMeans":
         z = RunningMean.zeros_like(total)
         per_tag = RunningMean.zeros_like(per_tag)
-        return _EvalRunningMeans(z, per_tag, z, per_tag)
+        return _EvalRunningMeans(z, per_tag, z, per_tag, z, per_tag)
 
 
 class _LabeledEvalRunningMeans(eqx.Module):

--- a/lib/levanter/src/levanter/main/perplexity_gap.py
+++ b/lib/levanter/src/levanter/main/perplexity_gap.py
@@ -177,7 +177,7 @@ def score_main(config: ModelPerplexityConfig) -> None:
             if docs_processed % 32 == 0:
                 logger.info("Processed %s documents for model perplexity scores", docs_processed)
 
-        token_id_to_text = _token_id_to_text(scored_documents, runner.hf_tokenizer)
+        token_id_to_text = _token_id_to_text(scored_documents, runner.tokenizer)
         summary = report.build_summary()
         write_model_score_files(
             config.output_path,
@@ -299,12 +299,12 @@ def _load_model_runner(
 
     tokenizer = load_tokenizer(spec.tokenizer, backend=spec.tokenizer_backend)
     hf_tokenizer = tokenizer.as_hf_tokenizer()
-    if not getattr(hf_tokenizer, "is_fast", False):
+    if not getattr(tokenizer, "tokenize_with_byte_offsets", None) and not getattr(hf_tokenizer, "is_fast", False):
         raise ValueError(f"Tokenizer {spec.tokenizer!r} does not expose a fast tokenizer with offset mappings.")
 
     key = jax.random.PRNGKey(0)
     vocab_size = len(tokenizer)
-    eval_length = min(max_eval_length, spec.model.max_Pos.size)
+    eval_length = min(max_eval_length, _model_max_seq_len(spec.model))
     EvalBatch = trainer.EvalBatch
     Pos = Axis("position", eval_length)
     Vocab = round_axis_for_partitioning(Axis("vocab", vocab_size), compute_axis_mapping)
@@ -317,8 +317,20 @@ def _load_model_runner(
     def compute_losses(model: LmHeadModel, batch: GrugLmExample):
         model = inference_mode(model, True)
         model = mp.cast_to_compute(model)
-        named_batch = named_lm_example_from_grug(batch, Pos=Pos, batch_axis=EvalBatch)
-        return model.compute_next_token_loss(named_batch, reduction=None, reduction_axis=()).array
+        if hasattr(model, "compute_next_token_loss"):
+            named_batch = named_lm_example_from_grug(batch, Pos=Pos, batch_axis=EvalBatch)
+            return model.compute_next_token_loss(named_batch, reduction=None, reduction_axis=()).array
+
+        if hasattr(model, "next_token_loss"):
+            return model.next_token_loss(
+                batch.tokens,
+                batch.loss_weight,
+                mask=batch.attn_mask,
+                reduction="none",
+                logsumexp_weight=None,
+            )
+
+        raise TypeError(f"Model {type(model).__name__} does not expose a next-token loss method.")
 
     if spec.checkpoint_is_hf:
         model_config = spec.model
@@ -334,9 +346,9 @@ def _load_model_runner(
         )
     else:
         with use_cpu_device():
-            model = eqx.filter_eval_shape(spec.model.build, Vocab, key=key)
+            model = _init_native_model_shape(spec.model, Vocab, key=key)
             checkpoint_path = latest_checkpoint_path(spec.checkpoint_path)
-            model = load_checkpoint(model, checkpoint_path, subpath="model")
+            model = _load_native_checkpoint(model, checkpoint_path, spec.model)
         model = hax.shard_with_axis_mapping(model, parameter_axis_mapping)
 
     label = _model_label(spec)
@@ -348,6 +360,145 @@ def _load_model_runner(
         eval_batch_size=trainer.eval_batch_size,
         eval_length=eval_length,
         compute_losses=compute_losses,
+    )
+
+
+def _model_max_seq_len(model_config: Any) -> int:
+    max_pos = getattr(model_config, "max_Pos", None)
+    if max_pos is not None:
+        return max_pos.size
+
+    max_seq_len = getattr(model_config, "max_seq_len", None)
+    if max_seq_len is not None:
+        return max_seq_len
+
+    raise ValueError(f"Model config {type(model_config).__name__} does not expose max_Pos or max_seq_len.")
+
+
+def _init_native_model_shape(model_config: Any, Vocab: Axis, *, key: jax.Array) -> Any:
+    build = getattr(model_config, "build", None)
+    if build is not None:
+        return eqx.filter_eval_shape(build, Vocab, key=key)
+
+    if type(model_config).__name__ == "GrugModelConfig":
+        from experiments.grug.moe.model import Transformer
+
+        return eqx.filter_eval_shape(Transformer.init, model_config, key=key)
+
+    raise ValueError(f"Model config {type(model_config).__name__} cannot initialize native checkpoints.")
+
+
+def _load_native_checkpoint(model: Any, checkpoint_path: str, model_config: Any) -> Any:
+    if type(model_config).__name__ == "GrugModelConfig":
+        compat_model = _grug_model_to_checkpoint_compat(model)
+        compat_model = load_checkpoint(compat_model, checkpoint_path, subpath="params")
+        return _checkpoint_compat_to_grug_model(compat_model, model)
+
+    return load_checkpoint(model, checkpoint_path, subpath="model")
+
+
+class _GrugCheckpointExpertMLP(eqx.Module):
+    w_gate_up: Any
+    w_down: Any
+
+
+class _GrugCheckpointMoEMLP(eqx.Module):
+    router: Any
+    router_bias: Any
+    expert_mlp: _GrugCheckpointExpertMLP
+    cfg: Any = eqx.field(static=True)
+
+
+class _GrugCheckpointBlock(eqx.Module):
+    rms_attn: Any
+    attn_gated_norm: Any
+    attn: Any
+    rms_mlp: Any
+    mlp_gated_norm: Any
+    mlp: _GrugCheckpointMoEMLP
+    shared: Any
+
+
+class _GrugCheckpointTransformer(eqx.Module):
+    token_embed: Any
+    embed_norm: Any
+    embed_gated_norm: Any
+    output_proj: Any
+    blocks: tuple[_GrugCheckpointBlock, ...]
+    final_norm: Any
+    final_gated_norm: Any
+    config: Any = eqx.field(static=True)
+
+
+def _grug_model_to_checkpoint_compat(model: Any) -> _GrugCheckpointTransformer:
+    blocks = []
+    for block in model.blocks:
+        compat_mlp = _GrugCheckpointMoEMLP(
+            router=block.mlp.router,
+            router_bias=block.mlp.router_bias,
+            expert_mlp=_GrugCheckpointExpertMLP(
+                w_gate_up=block.mlp.w_gate_up,
+                w_down=block.mlp.w_down,
+            ),
+            cfg=block.mlp.cfg,
+        )
+        blocks.append(
+            _GrugCheckpointBlock(
+                rms_attn=block.rms_attn,
+                attn_gated_norm=block.attn_gated_norm,
+                attn=block.attn,
+                rms_mlp=block.rms_mlp,
+                mlp_gated_norm=block.mlp_gated_norm,
+                mlp=compat_mlp,
+                shared=block.shared,
+            )
+        )
+
+    return _GrugCheckpointTransformer(
+        token_embed=model.token_embed,
+        embed_norm=model.embed_norm,
+        embed_gated_norm=model.embed_gated_norm,
+        output_proj=model.output_proj,
+        blocks=tuple(blocks),
+        final_norm=model.final_norm,
+        final_gated_norm=model.final_gated_norm,
+        config=model.config,
+    )
+
+
+def _checkpoint_compat_to_grug_model(compat_model: _GrugCheckpointTransformer, model_shape: Any) -> Any:
+    from experiments.grug.moe.model import Block, MoEMLP, Transformer
+
+    blocks = []
+    for compat_block in compat_model.blocks:
+        mlp = MoEMLP(
+            router=compat_block.mlp.router,
+            router_bias=compat_block.mlp.router_bias,
+            w_gate_up=compat_block.mlp.expert_mlp.w_gate_up,
+            w_down=compat_block.mlp.expert_mlp.w_down,
+            cfg=compat_block.mlp.cfg,
+        )
+        blocks.append(
+            Block(
+                rms_attn=compat_block.rms_attn,
+                attn_gated_norm=compat_block.attn_gated_norm,
+                attn=compat_block.attn,
+                rms_mlp=compat_block.rms_mlp,
+                mlp_gated_norm=compat_block.mlp_gated_norm,
+                mlp=mlp,
+                shared=compat_block.shared,
+            )
+        )
+
+    return Transformer(
+        token_embed=compat_model.token_embed,
+        embed_norm=compat_model.embed_norm,
+        embed_gated_norm=compat_model.embed_gated_norm,
+        output_proj=compat_model.output_proj,
+        blocks=tuple(blocks),
+        final_norm=compat_model.final_norm,
+        final_gated_norm=compat_model.final_gated_norm,
+        config=model_shape.config,
     )
 
 
@@ -456,13 +607,38 @@ def _log_report_artifact(summary: dict[str, Any]) -> None:
     if jax.process_index() != 0:
         return
 
-    with tempfile.TemporaryDirectory(prefix="perplexity-gap-report-") as tmpdir:
-        write_report_files(tmpdir, summary)
-        levanter.tracker.current_tracker().log_artifact(
-            tmpdir,
-            name="perplexity_gap_report",
-            type="perplexity_gap_report",
-        )
+    tmpdir = tempfile.mkdtemp(prefix="perplexity-gap-report-")
+    write_report_files(tmpdir, summary)
+    levanter.tracker.current_tracker().log_artifact(
+        tmpdir,
+        name="perplexity_gap_report",
+        type="perplexity_gap_report",
+    )
+
+
+def _log_model_score_artifact(
+    summary: dict[str, Any],
+    scored_documents: Sequence[ScoredDocument],
+    *,
+    vocab_size: int | None = None,
+    token_id_to_text: dict[int, str] | None = None,
+) -> None:
+    if jax.process_index() != 0:
+        return
+
+    tmpdir = tempfile.mkdtemp(prefix="model-perplexity-scores-")
+    write_model_score_files(
+        tmpdir,
+        summary,
+        scored_documents,
+        vocab_size=vocab_size,
+        token_id_to_text=token_id_to_text,
+    )
+    levanter.tracker.current_tracker().log_artifact(
+        tmpdir,
+        name="model_perplexity_scores",
+        type="model_perplexity_scores",
+    )
 
 
 if __name__ == "__main__":

--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -16,6 +16,7 @@ Usage:
 
 import contextlib
 import dataclasses
+import bisect
 import functools
 import json
 import logging
@@ -23,6 +24,7 @@ import os
 import re
 import shutil
 import tempfile
+import unicodedata
 from enum import StrEnum
 from typing import Any, Protocol, runtime_checkable
 
@@ -567,9 +569,304 @@ class KitokenMarinTokenizer:
         return AutoTokenizer.from_pretrained(self._name_or_path, trust_remote_code=True)
 
 
+@dataclasses.dataclass(frozen=True)
+class TokenMonsterMarinTokenizer:
+    """MarinTokenizer backed by TokenMonster.
+
+    TokenMonster uses capcode/control tokens and byte fallback tokens whose
+    source-byte contribution is not the same as the raw token string length.
+    The custom byte-offset path below keeps raw perplexity-gap accounting on
+    original text bytes.
+    """
+
+    _tokenizer: Any
+    _name_or_path: str
+    _vocab: dict[str, int] = dataclasses.field(default_factory=dict, repr=False)
+    _id_to_token: dict[int, str] = dataclasses.field(default_factory=dict, repr=False)
+    _all_special_ids: list[int] = dataclasses.field(default_factory=list)
+
+    @property
+    def name_or_path(self) -> str:
+        return self._name_or_path
+
+    @property
+    def vocab_size(self) -> int:
+        return int(self._tokenizer.vocab_size)
+
+    @property
+    def bos_token_id(self) -> int | None:
+        return None
+
+    @property
+    def eos_token_id(self) -> int | None:
+        return None
+
+    @property
+    def pad_token_id(self) -> int | None:
+        return None
+
+    @property
+    def bos_token(self) -> str | None:
+        return None
+
+    @property
+    def eos_token(self) -> str | None:
+        return None
+
+    @property
+    def chat_template(self) -> str | None:
+        return None
+
+    def __len__(self) -> int:
+        return self.vocab_size
+
+    def encode(self, text: str, *, add_special_tokens: bool = False) -> list[int]:
+        del add_special_tokens
+        return [int(token_id) for token_id in self._tokenizer.tokenize(text)]
+
+    def decode(self, ids: list[int], *, skip_special_tokens: bool = False) -> str:
+        del skip_special_tokens
+        return self._tokenizer.decode([int(token_id) for token_id in ids])
+
+    def encode_batch(self, texts: list[str], *, add_special_tokens: bool = False) -> list[list[int]]:
+        return [self.encode(text, add_special_tokens=add_special_tokens) for text in texts]
+
+    def get_vocab(self) -> dict[str, int]:
+        return self._vocab
+
+    def convert_ids_to_tokens(self, ids: int | list[int]) -> str | list[str]:
+        if isinstance(ids, int):
+            return self._id_to_token.get(ids, self._tokenizer.id_to_token(ids))
+        return [self.convert_ids_to_tokens(i) for i in ids]
+
+    def convert_tokens_to_ids(self, tokens: str | list[str]) -> int | list[int]:
+        if isinstance(tokens, str):
+            return self._vocab.get(tokens, -1)
+        return [self.convert_tokens_to_ids(token) for token in tokens]
+
+    def id_to_token(self, idx: int) -> str:
+        return self._tokenizer.id_to_token(int(idx))
+
+    def id_to_token_decoded(self, idx: int) -> str:
+        return self._tokenizer.id_to_token_decoded(int(idx))
+
+    def get_dictionary(self) -> dict[int, dict[str, Any]]:
+        return self._tokenizer.get_dictionary()
+
+    @property
+    def all_special_ids(self) -> list[int]:
+        return self._all_special_ids
+
+    def apply_chat_template(
+        self,
+        conversation: list[dict[str, str]],
+        *,
+        tokenize: bool = True,
+        add_generation_prompt: bool = False,
+        **kwargs,
+    ) -> str | list[int]:
+        raise ValueError(f"Tokenizer {self._name_or_path} has no chat template")
+
+    def apply_chat_template_with_masks(
+        self,
+        conversations: list[list[dict[str, str]]],
+        *,
+        chat_template: str | None = None,
+        **kwargs,
+    ) -> dict[str, list[list[int]]]:
+        raise ValueError(f"Tokenizer {self._name_or_path} has no chat template")
+
+    def as_hf_tokenizer(self) -> Any:
+        return self
+
+    def tokenize_with_byte_offsets(self, text: str) -> tuple[list[int], list[int], list[int], int]:
+        from levanter.utils.hf_utils import byte_length_of_token
+
+        ids = self.encode(text, add_special_tokens=False)
+        starts: list[int] = []
+        ends: list[int] = []
+        offset = 0
+        carried_adjustment = 0
+        for token_id in ids:
+            token_bytes = byte_length_of_token(self, token_id)
+            if token_bytes < 0:
+                starts.append(-1)
+                ends.append(-1)
+                carried_adjustment += token_bytes
+                continue
+
+            effective_bytes = token_bytes + carried_adjustment
+            carried_adjustment = 0
+            if effective_bytes <= 0:
+                starts.append(-1)
+                ends.append(-1)
+                continue
+            starts.append(offset)
+            offset += effective_bytes
+            ends.append(offset)
+
+        num_bytes = len(text.encode("utf-8"))
+        if offset != num_bytes:
+            decoded = self.decode(ids)
+            if decoded == text:
+                starts, ends = _scale_tokenmonster_byte_spans(starts, ends, source_byte_length=offset, num_bytes=num_bytes)
+                offset = num_bytes
+            else:
+                remapped = _remap_normalized_tokenmonster_offsets(
+                    text,
+                    decoded,
+                    starts,
+                    ends,
+                    normalized_byte_length=offset,
+                )
+                if remapped is None:
+                    raise ValueError(f"TokenMonster tokenizer did not round-trip input text for {self._name_or_path}.")
+                starts, ends = remapped
+                offset = num_bytes
+
+        return ids, starts, ends, num_bytes
+
+
+def _remap_normalized_tokenmonster_offsets(
+    text: str,
+    decoded: str,
+    starts: list[int],
+    ends: list[int],
+    *,
+    normalized_byte_length: int,
+) -> tuple[list[int], list[int]] | None:
+    for normalization in ("NFD", "NFKD", "NFC", "NFKC"):
+        normalized = unicodedata.normalize(normalization, text)
+        if decoded != normalized:
+            continue
+        normalized_bytes = len(normalized.encode("utf-8"))
+        normalized_starts, normalized_ends = starts, ends
+        if normalized_bytes != normalized_byte_length:
+            normalized_starts, normalized_ends = _scale_tokenmonster_byte_spans(
+                starts,
+                ends,
+                source_byte_length=normalized_byte_length,
+                num_bytes=normalized_bytes,
+            )
+        return _remap_normalized_byte_spans_to_original(
+            text, normalized, normalized_starts, normalized_ends, normalization
+        )
+    return None
+
+
+def _remap_normalized_byte_spans_to_original(
+    text: str,
+    normalized: str,
+    starts: list[int],
+    ends: list[int],
+    normalization: str,
+) -> tuple[list[int], list[int]]:
+    normalized_pieces: list[str] = []
+    normalized_byte_to_original_byte: dict[int, int] = {}
+    normalized_offset = 0
+    original_offset = 0
+    for ch in text:
+        original_end = original_offset + len(ch.encode("utf-8"))
+        normalized_piece = unicodedata.normalize(normalization, ch)
+        normalized_pieces.append(normalized_piece)
+        normalized_piece_bytes = len(normalized_piece.encode("utf-8"))
+        if normalized_piece_bytes == 0:
+            original_offset = original_end
+            continue
+
+        piece_offset = 0
+        normalized_byte_to_original_byte[normalized_offset] = original_offset
+        for piece_ch in normalized_piece:
+            piece_offset += len(piece_ch.encode("utf-8"))
+            normalized_byte_to_original_byte[normalized_offset + piece_offset] = original_offset + round(
+                piece_offset * (original_end - original_offset) / normalized_piece_bytes
+            )
+        normalized_offset += normalized_piece_bytes
+        original_offset = original_end
+
+    if "".join(normalized_pieces) != normalized:
+        return _scale_tokenmonster_byte_spans(
+            starts,
+            ends,
+            source_byte_length=len(normalized.encode("utf-8")),
+            num_bytes=len(text.encode("utf-8")),
+        )
+
+    normalized_boundaries = sorted(normalized_byte_to_original_byte)
+
+    def remap_byte(byte_offset: int, *, is_end: bool) -> int:
+        if byte_offset in normalized_byte_to_original_byte:
+            return normalized_byte_to_original_byte[byte_offset]
+
+        if is_end:
+            index = bisect.bisect_left(normalized_boundaries, byte_offset)
+            if index >= len(normalized_boundaries):
+                return original_offset
+        else:
+            index = bisect.bisect_right(normalized_boundaries, byte_offset) - 1
+            if index < 0:
+                return 0
+        return normalized_byte_to_original_byte[normalized_boundaries[index]]
+
+    remapped_starts: list[int] = []
+    remapped_ends: list[int] = []
+    for start, end in zip(starts, ends, strict=True):
+        if start < 0 or end < 0:
+            remapped_starts.append(-1)
+            remapped_ends.append(-1)
+            continue
+
+        original_start = remap_byte(start, is_end=False)
+        original_end = remap_byte(end, is_end=True)
+        if original_end <= original_start:
+            remapped_starts.append(-1)
+            remapped_ends.append(-1)
+            continue
+
+        remapped_starts.append(original_start)
+        remapped_ends.append(original_end)
+
+    return remapped_starts, remapped_ends
+
+
+def _scale_tokenmonster_byte_spans(
+    starts: list[int],
+    ends: list[int],
+    *,
+    source_byte_length: int,
+    num_bytes: int,
+) -> tuple[list[int], list[int]]:
+    if source_byte_length <= 0:
+        return starts, ends
+
+    def scale(byte_offset: int) -> int:
+        return min(num_bytes, max(0, round(byte_offset * num_bytes / source_byte_length)))
+
+    scaled_starts: list[int] = []
+    scaled_ends: list[int] = []
+    for start, end in zip(starts, ends, strict=True):
+        if start < 0 or end < 0:
+            scaled_starts.append(-1)
+            scaled_ends.append(-1)
+            continue
+
+        scaled_start = scale(start)
+        scaled_end = scale(end)
+        if scaled_end <= scaled_start:
+            scaled_starts.append(-1)
+            scaled_ends.append(-1)
+            continue
+
+        scaled_starts.append(scaled_start)
+        scaled_ends.append(scaled_end)
+
+    return scaled_starts, scaled_ends
+
+
 class TokenizerBackend(StrEnum):
     HF = "hf"
     KITOKEN = "kitoken"
+    TOKENMONSTER = "tokenmonster"
 
 
 @functools.lru_cache(maxsize=32)
@@ -583,6 +880,9 @@ def load_tokenizer(
     Files are staged once via mirror://tokenizers/ (GCS/S3) before falling back
     to HF Hub. Cached per (name_or_path, backend).
     """
+    if backend == TokenizerBackend.TOKENMONSTER or name_or_path.startswith("tokenmonster:"):
+        return _load_tokenmonster_tokenizer(name_or_path)
+
     local_dir = _stage_tokenizer(name_or_path) if not os.path.isdir(name_or_path) else name_or_path
     if backend == TokenizerBackend.HF:
         tok = _load_hf_tokenizer(local_dir)
@@ -996,4 +1296,25 @@ def _load_kitoken_tokenizer(name_or_path: str) -> KitokenMarinTokenizer:
         _prepend_bos=prepend_bos,
         _vocab=vocab,
         _id_to_token={v: k for k, v in vocab.items()},
+    )
+
+
+def _load_tokenmonster_tokenizer(name_or_path: str) -> TokenMonsterMarinTokenizer:
+    import tokenmonster
+
+    vocab_name = name_or_path.removeprefix("tokenmonster:")
+    tok = tokenmonster.load(vocab_name)
+    dictionary = tok.get_dictionary()
+    vocab = {info["token"]: token_id for token_id, info in dictionary.items()}
+    id_to_token = {token_id: info["token"] for token_id, info in dictionary.items()}
+    all_special_ids = [
+        token_id for token_id, info in dictionary.items() if info.get("type") in {2, "special"}
+    ]
+
+    return TokenMonsterMarinTokenizer(
+        _tokenizer=tok,
+        _name_or_path=name_or_path,
+        _vocab=vocab,
+        _id_to_token=id_to_token,
+        _all_special_ids=all_special_ids,
     )

--- a/lib/levanter/src/levanter/utils/hf_utils.py
+++ b/lib/levanter/src/levanter/utils/hf_utils.py
@@ -10,6 +10,8 @@ from levanter.utils.logging import silence_transformer_nag
 
 silence_transformer_nag()
 
+_TOKENMONSTER_DICTIONARY_CACHE: dict[int, dict] = {}
+
 # HfTokenizer is retained only for callers that need the actual HF transformers
 # tokenizer object (hf_checkpoints, lora save_pretrained, etc.).
 if TYPE_CHECKING:
@@ -28,8 +30,12 @@ def byte_length_of_token(tokenizer: MarinTokenizer, idx: int) -> int:
     special tokens (0 bytes), hex-encoded byte tokens like <0x16>, and normal
     tokens (decoded via a prefix trick to preserve leading spaces).
     """
+    tokenmonster_length = _tokenmonster_byte_length_of_token(tokenizer, idx)
+    if tokenmonster_length is not None:
+        return tokenmonster_length
+
     token_repr = tokenizer.convert_ids_to_tokens(idx)
-    if idx in tokenizer.all_special_ids:
+    if idx in getattr(tokenizer, "all_special_ids", ()):
         return 0
     if m := re.match(r"<0x([0-9A-Fa-f]+)>", token_repr):
         return len(bytes.fromhex(m.group(1)))
@@ -38,3 +44,46 @@ def byte_length_of_token(tokenizer: MarinTokenizer, idx: int) -> int:
     excess_bytes = len(".".encode("utf-8"))
     decoded = tokenizer.decode([extra_token, idx]).encode("utf-8")
     return len(decoded) - excess_bytes
+
+
+def _tokenmonster_byte_length_of_token(tokenizer: MarinTokenizer, idx: int) -> int | None:
+    """Return TokenMonster source-byte contribution when metadata is available.
+
+    TokenMonster tokens can carry capcode/control markers in their raw token
+    strings. Those markers are not source text bytes, and the delete-space
+    marker can reduce the byte length of the following decoded token. Using
+    ``decode([prefix, token])`` or the raw token string therefore inflates BPB
+    denominators for capitalized words. TokenMonster exposes the already
+    decoded token text; use that and account for standalone delete markers.
+    """
+    id_to_token_decoded = getattr(tokenizer, "id_to_token_decoded", None)
+    if id_to_token_decoded is None:
+        return None
+
+    convert_ids_to_tokens = getattr(tokenizer, "convert_ids_to_tokens", None)
+    id_to_token = getattr(tokenizer, "id_to_token", None)
+    if convert_ids_to_tokens is not None:
+        token_repr = convert_ids_to_tokens(idx)
+    elif id_to_token is not None:
+        token_repr = id_to_token(idx)
+    else:
+        return None
+    token_decoded = id_to_token_decoded(idx)
+
+    token_type = None
+    get_dictionary = getattr(tokenizer, "get_dictionary", None)
+    if get_dictionary is not None:
+        dictionary = _TOKENMONSTER_DICTIONARY_CACHE.setdefault(id(tokenizer), get_dictionary())
+        token_info = dictionary.get(idx, {})
+        token_type = token_info.get("type")
+
+    if token_type in {2, "special"} or idx in getattr(tokenizer, "all_special_ids", ()):
+        return 0
+
+    if isinstance(token_repr, str) and token_repr == "\ufffd" and idx < 256:
+        return 1
+
+    if token_decoded == "" and isinstance(token_repr, str) and token_repr.startswith("D"):
+        return -1
+
+    return len(token_decoded.encode("utf-8"))

--- a/lib/levanter/tests/test_eval.py
+++ b/lib/levanter/tests/test_eval.py
@@ -9,6 +9,7 @@ import haliax as hax
 import jax
 import jax.numpy as jnp
 import numpy as np
+import pytest
 from haliax import Axis
 from haliax.partitioning import ResourceAxis
 
@@ -36,6 +37,63 @@ from levanter.utils.tree_utils import inference_mode
 
 from .test_lm_model_loss import ToyLmConfig, ToyLmHeadModel
 from .test_utils import use_test_mesh
+
+
+class _FixedByteTokenizer:
+    all_special_ids = []
+
+    def get_vocab(self):
+        return {"a": 0, "longtoken": 1}
+
+    def convert_ids_to_tokens(self, idx):
+        return ["a", "longtoken"][idx]
+
+    def encode(self, text, *, add_special_tokens=False):
+        del text, add_special_tokens
+        return [0]
+
+    def decode(self, ids, *, skip_special_tokens=False):
+        del skip_special_tokens
+        return "".join(self.convert_ids_to_tokens(i) for i in ids)
+
+
+def test_tagged_evaluator_logs_historical_bpb_and_byte_weighted_bpb_fixed():
+    EvalBatch = Axis("batch", 1)
+    examples = [
+        GrugLmExample.causal(jnp.asarray([0], dtype=jnp.int32)),
+        GrugLmExample.causal(jnp.asarray([1], dtype=jnp.int32)),
+    ]
+    dataset = ListAsyncDataset(examples)
+
+    def loss_fn(_model, batch: GrugLmExample) -> LossFnOutput:
+        return (
+            jnp.ones_like(batch.tokens, dtype=jnp.float32),
+            jnp.ones_like(batch.tokens, dtype=jnp.float32),
+            batch.tokens,
+        )
+
+    with use_test_mesh(tensor_parallelism=1) as mesh:
+        evaluator = TaggedEvaluator(
+            EvalBatch=EvalBatch,
+            tagged_eval_sets=[(dataset, ["tiny"])],
+            loss_fn=loss_fn,
+            tokenizer=_FixedByteTokenizer(),
+            device_mesh=mesh,
+            axis_mapping={EvalBatch.name: ResourceAxis.DATA},
+        )
+        result = evaluator.evaluate(jnp.zeros((), dtype=jnp.float32))
+
+    expected_bpb = np.mean(
+        [
+            np.log2(np.e) / len("a".encode("utf-8")),
+            np.log2(np.e) / len("longtoken".encode("utf-8")),
+        ]
+    )
+    expected_bpb_fixed = 2.0 * np.log2(np.e) / (
+        len("a".encode("utf-8")) + len("longtoken".encode("utf-8"))
+    )
+    assert result.micro_bpb == pytest.approx(expected_bpb)
+    assert result.micro_bpb_fixed == pytest.approx(expected_bpb_fixed)
 
 
 def test_tagged_evaluator_accepts_grug_lm_examples():

--- a/lib/levanter/tests/test_hf_utils.py
+++ b/lib/levanter/tests/test_hf_utils.py
@@ -5,11 +5,74 @@ import os
 
 import fsspec
 import huggingface_hub
+import pytest
 from fsspec import AbstractFileSystem
 from test_utils import skip_if_hf_model_not_accessible
 
 from levanter.compat.hf_checkpoints import _patch_hf_hub_download, load_tokenizer
 from levanter.utils.hf_utils import byte_length_of_token
+
+
+class _FakeTokenMonsterTokenizer:
+    _tokens = {
+        37: ("D", "", "single"),
+        517: ("DC", "", "regular"),
+        82: ("\ufffd", "\ufffd", "single"),
+        114: ("\ufffd", "\ufffd", "single"),
+        171: ("\ufffd", "\ufffd", "single"),
+        8231: (" hello", " hello", "regular"),
+        12709: ("C world", " World", "regular"),
+        999: ("<eos>", "<eos>", "special"),
+    }
+    all_special_ids = [999]
+
+    def convert_ids_to_tokens(self, idx):
+        return self._tokens[idx][0]
+
+    def id_to_token_decoded(self, idx):
+        return self._tokens[idx][1]
+
+    def get_dictionary(self):
+        return {
+            idx: {"id": idx, "token": token, "token_decoded": decoded, "type": token_type}
+            for idx, (token, decoded, token_type) in self._tokens.items()
+        }
+
+
+def test_byte_length_of_token_tokenmonster_capcode_markers():
+    tok = _FakeTokenMonsterTokenizer()
+
+    assert byte_length_of_token(tok, 37) == -1
+    assert byte_length_of_token(tok, 517) == -1
+    assert byte_length_of_token(tok, 8231) == len(" hello".encode("utf-8"))
+    assert byte_length_of_token(tok, 12709) == len(" World".encode("utf-8"))
+    assert byte_length_of_token(tok, 999) == 0
+
+    # TokenMonster decodes "DC" + " hello" + "C world" as "Hello World".
+    assert sum(byte_length_of_token(tok, token_id) for token_id in [517, 8231, 12709]) == len(
+        "Hello World".encode("utf-8")
+    )
+    # Byte fallback tokens can show up as replacement characters individually.
+    assert sum(byte_length_of_token(tok, token_id) for token_id in [171, 82, 114]) == len("⇧".encode("utf-8"))
+
+
+def test_tokenmonster_byte_offsets_handle_normalized_unicode():
+    pytest.importorskip("tokenmonster")
+    from levanter.tokenizers import TokenizerBackend
+    from levanter.tokenizers import load_tokenizer as load_marin_tokenizer
+
+    tok = load_marin_tokenizer(
+        "tokenmonster:englishcode-32000-consistent-v1",
+        backend=TokenizerBackend.TOKENMONSTER,
+    )
+    text = "Stefan Talijanović"
+
+    ids, starts, ends, num_bytes = tok.tokenize_with_byte_offsets(text)
+
+    assert tok.decode(ids) == "Stefan Talijanovic\u0301"
+    assert num_bytes == len(text.encode("utf-8"))
+    assert all((start < 0 and end < 0) or (0 <= start < end <= num_bytes) for start, end in zip(starts, ends))
+    assert max(end for end in ends if end >= 0) == num_bytes
 
 
 def test_load_tokenizer_in_memory_fs():

--- a/lib/marin/src/marin/evaluation/perplexity_gap.py
+++ b/lib/marin/src/marin/evaluation/perplexity_gap.py
@@ -31,7 +31,7 @@ from levanter.main.perplexity_gap import (
 from levanter.models.lm_model import LmConfig
 from levanter.tokenizers import TokenizerBackend
 from levanter.tracker.wandb import WandbConfig
-from levanter.trainer import TrainerConfig
+from levanter.trainer import MeshConfig, TrainerConfig
 
 from marin.execution.types import ExecutorStep, InputName, VersionedValue, this_output_path, versioned
 from marin.processing.tokenize import HfDatasetSpec
@@ -235,6 +235,8 @@ def find_model_perplexity_scores(config: ModelPerplexityScoreConfig) -> None:
         trainer=TrainerConfig(
             tracker=WandbConfig(project=WANDB_PROJECT, tags=tags, name=run_name),
             per_device_eval_parallelism=config.per_device_batch_size,
+            mesh=MeshConfig(axes={"expert": 1, "model": 1}),
+            use_explicit_mesh_axes=True,
         ),
         output_path=config.output_path,
         max_eval_length=config.max_eval_length,
@@ -245,11 +247,12 @@ def find_model_perplexity_scores(config: ModelPerplexityScoreConfig) -> None:
     assert isinstance(config.resource_config.device, TpuConfig), "find_model_perplexity_scores requires TPU resources"
 
     client = current_client()
+    pip_packages = ["tokenmonster==1.1.12"] if _uses_tokenmonster(config.model) else []
     job_request = JobRequest(
         name=f"model-perplexity-scores-{run_name}",
         resources=config.resource_config,
         entrypoint=Entrypoint.from_callable(score_main, args=[levanter_config]),
-        environment=create_environment(extras=["tpu"]),
+        environment=create_environment(extras=["tpu"], pip_packages=pip_packages),
     )
     job = client.submit(job_request)
     job.wait(raise_on_failure=True)
@@ -365,6 +368,12 @@ def _cache_key_for_model(config: GapFinderModelConfig) -> dict[str, Any]:
         "tokenizer_backend": config.tokenizer_backend.value,
         "trust_remote_code": config.trust_remote_code,
     }
+
+
+def _uses_tokenmonster(config: GapFinderModelConfig) -> bool:
+    return config.tokenizer_backend == TokenizerBackend.TOKENMONSTER or (
+        isinstance(config.tokenizer, str) and config.tokenizer.startswith("tokenmonster:")
+    )
 
 
 def _cache_key_for_dataset(dataset: RawTextEvaluationDataset) -> dict[str, Any]:


### PR DESCRIPTION
## Summary

Fixes TokenMonster BPB/perplexity-gap accounting for tokenizer-sensitivity evals in #5821.

TokenMonster raw tokens can include capcode / shift / control markers and byte fallback representations whose token-string bytes do not match original source UTF-8 bytes. This PR adds a TokenMonster tokenizer backend and custom byte-offset path so raw perplexity scoring uses original document bytes.

This keeps the historical `bpb` metric semantics for continuity and adds the corrected byte-weighted metric as `bpb_fixed`.

## Changes

- Add `TokenizerBackend.TOKENMONSTER` and `TokenMonsterMarinTokenizer`.
- Add TokenMonster byte-offset generation against original UTF-8 source bytes.
- Count TokenMonster special/control tokens as 0 source bytes.
- Count byte fallback ids as source bytes rather than replacement-glyph bytes.
- Handle delete-space markers as byte adjustments.
- Allow raw perplexity-gap scoring to use tokenizer-provided byte offsets.
- Keep historical `bpb` token-weighted aggregation and add byte-weighted `bpb_fixed`.
- Log `macro_bpb_fixed`, per-tag `.../bpb_fixed`, and per-tag `.../macro_bpb_fixed` alongside existing BPB metrics.
- Add native Grug checkpoint loading support for the perplexity-gap scorer.
- Add d1024 tokenizer-sensitivity gap experiment using `llama3-128k` as baseline.

## Results

Patched d1024 `bpb_fixed` summary:

| tokenizer | overall BPB | Paloma BPB | Uncheatable BPB |
|---|---:|---:|---:|
| `llama3-128k` | 0.94288 | 0.98032 | 0.85852 |
| `qwen3-152k` | 0.94321 | 0.97992 | 0.86048 |
| `gemma3-262k` | 0.93881 | 0.97767 | 0.85123 |
| `gpt-oss-200k` | 0.93911 | 0.97737 | 0.85289 |
| `tokenmonster-englishcode-32k` | 0.95095 | 0.98886 | 0.86551 |

Gap vs `llama3-128k`:

| tokenizer | overall gap BPB | readout |
|---|---:|---|
| `qwen3-152k` | +0.00033 | basically tied / slight overall worse |
| `gemma3-262k` | -0.00408 | best overall |
| `gpt-oss-200k` | -0.00377 | close second |
| `tokenmonster-englishcode-32k` | +0.00807 | worse overall after patched accounting |

Experiment artifact:
https://marin.community/data-browser/experiment?path=gs%3A//marin-eu-west4/experiments/exp_tokenizer_sensitivity_d1024_perplexity_gap-c91f6c.json

## Test Plan

```bash
/Users/pc0618/Downloads/marin/.venv/bin/python -m pytest \
  lib/levanter/tests/test_hf_utils.py::test_byte_length_of_token_tokenmonster_capcode_markers \
  lib/levanter/tests/test_hf_utils.py::test_tokenmonster_byte_offsets_handle_normalized_unicode \
  lib/levanter/tests/test_eval.py::test_tagged_evaluator_logs_historical_bpb_and_byte_weighted_bpb_fixed
```

Result: `3 passed`.
