### PR TITLE
tokenize: remove `_exemplar_for`, derive exemplar from shards

### DIFF
--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -832,6 +832,11 @@ def write_levanter_cache(
         output_path: Path to output cache directory
         metadata: Metadata for the cache
         batch_size: Number of records to accumulate before flushing to disk.
+
+    Returns:
+        ``{"path", "count", "exemplar"}`` where ``exemplar`` is the first record
+        written (or ``None`` for an empty shard). Callers that need a structural
+        template for cache consolidation can reuse it instead of re-deriving one.
     """
     if batch_size < 1:
         raise ValueError(f"batch_size must be >= 1, got {batch_size}")
@@ -842,7 +847,7 @@ def write_levanter_cache(
     try:
         exemplar = next(record_iter)
     except StopIteration:
-        return {"path": output_path, "count": 0}
+        return {"path": output_path, "count": 0, "exemplar": None}
 
     count = 0
     logger.info("write_levanter_cache: starting write to %s (batch_size=%d)", output_path, batch_size)
@@ -870,7 +875,7 @@ def write_levanter_cache(
     with open_url(f"{output_path}/.success", "w") as f:
         f.write("")
 
-    return {"path": output_path, "count": count}
+    return {"path": output_path, "count": count, "exemplar": exemplar}
 
 
 def _serialize_json_and_commit(path: str, obj):

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -452,6 +452,7 @@ def test_write_levanter_cache_end_to_end():
 
         assert result["path"] == output_path
         assert result["count"] == len(records)
+        assert result["exemplar"] == records[0]
         assert Path(output_path, ".success").exists()
 
         store = TreeStore.open(records[0], output_path, mode="r", cache_metadata=False)

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -30,7 +30,7 @@ import logging
 import os
 import time
 
-import pyarrow.parquet as pq
+import numpy as np
 from fray import ResourceConfig
 from levanter.store.cache import CacheLedger, consolidate_shard_cache_ledgers, write_levanter_cache
 from pydantic import BaseModel
@@ -93,12 +93,23 @@ def _strip_id(record: dict) -> dict:
     return {k: v for k, v in record.items() if k != "id"}
 
 
+def _structural_exemplar(record: dict) -> dict:
+    """Shrink a record to a structural template for cache consolidation.
+
+    :func:`consolidate_shard_cache_ledgers` only needs the exemplar's pytree
+    structure and leaf dtypes to open a ``TreeStore``, never its values. Slicing
+    sequence leaves to a single element keeps the per-shard payload returned to
+    the coordinator tiny — a full document can be megabytes for long-context
+    data, and we return one per shard.
+    """
+    return {k: v[:1] if isinstance(v, np.ndarray | list | tuple) else v for k, v in record.items()}
+
+
 def build_from_datasets(
     *,
     ctx: ZephyrContext,
     dataset: Dataset,
     output_path: str,
-    exemplar: dict,
     batch_size: int | None = None,
     skip_existing: bool = True,
 ) -> CacheLedger:
@@ -106,9 +117,7 @@ def build_from_datasets(
 
     The dataset is expected to yield per-doc records shaped like
     ``{id, input_ids, ...}``. ``id`` is stripped before writing because
-    ``TreeStore`` stores positional concatenated arrays, not keyed rows. The
-    exemplar must already be in the post-strip shape (no ``id``); pass an
-    exemplar derived from the post-tokenize record after dropping ``id``.
+    ``TreeStore`` stores positional concatenated arrays, not keyed rows.
 
     The dataset's shard structure determines the number of per-shard Levanter
     caches written under ``{output_path}/part-NNNNN-of-MMMMM``. Those shard
@@ -116,15 +125,16 @@ def build_from_datasets(
     step only writes a top-level ``shard_ledger.json`` that references them by
     relative path (sharded layout, see Levanter ``#5430``).
 
+    The structural exemplar that :func:`consolidate_shard_cache_ledgers` needs as
+    a fallback is taken from the shard writes themselves (first non-empty shard),
+    so no separate pass over the inputs is required.
+
     Args:
         ctx: Zephyr context. The caller is responsible for setting any tokenizer
             shared values (``ctx.put('tokenizer_name', ...)`` etc.) before calling
             if the upstream dataset relies on them.
         dataset: Zephyr ``Dataset`` of tokenized records.
         output_path: Destination cache directory.
-        exemplar: Output exemplar (without ``id``). Used as a fallback by
-            :func:`consolidate_shard_cache_ledgers` to derive ``field_counts``
-            for any shard whose own ledger lacks them.
         batch_size: Per-shard Levanter cache flush size. ``None`` keeps Levanter's
             default (16384). Lower values reduce peak memory for datasets with
             very large documents.
@@ -133,9 +143,6 @@ def build_from_datasets(
     Returns:
         The merged sharded ``CacheLedger``.
     """
-    if "id" in exemplar:
-        raise ValueError("build_from_datasets: exemplar must not contain 'id'; pass a stripped exemplar")
-
     pipeline_start = time.monotonic()
 
     output_pattern = f"{output_path}/part-{{shard:05d}}-of-{{total:05d}}"
@@ -144,21 +151,30 @@ def build_from_datasets(
         write_kwargs["batch_size"] = batch_size
 
     def _write_shard(records, shard_info):
+        """Write one shard and emit ``(path, exemplar)``.
+
+        ``exemplar`` is ``None`` for empty shards and for skipped (already-written)
+        shards; the coordinator picks the first non-``None`` one for consolidation.
+        """
         shard_path = format_shard_path(output_pattern, shard_info.shard_idx, shard_info.total_shards)
         if skip_existing:
             fs = url_to_fs(shard_path)[0]
             if fs.exists(f"{shard_path}/.success"):
                 logger.info("Skipping write, output exists: %s", shard_path)
-                yield shard_path
+                yield (shard_path, None)
                 return
         result = write_levanter_cache(records, shard_path, **write_kwargs)
-        yield result["path"]
+        exemplar = result["exemplar"]
+        yield (shard_path, _structural_exemplar(exemplar) if exemplar is not None else None)
 
     temp_shards = dataset.map(_strip_id).map_shard(_write_shard)
 
     tokenize_start = time.monotonic()
-    shard_paths = ctx.execute(temp_shards).results
+    shard_results = ctx.execute(temp_shards).results
     tokenize_elapsed = time.monotonic() - tokenize_start
+
+    shard_paths = [path for path, _ in shard_results]
+    exemplar = next((ex for _, ex in shard_results if ex is not None), None)
 
     consolidate_start = time.monotonic()
     logger.info("Consolidating %d shards into %s", len(shard_paths), output_path)
@@ -226,34 +242,15 @@ def _split_shard_paths(sources: list[TokenizedAttrData], split: str) -> list[str
     return paths
 
 
-def _first_nonempty_exemplar(shard_paths: list[str]) -> dict:
-    """Return the first record (id stripped) from the first non-empty shard.
-
-    Co-partitioned attribute datasets may legitimately have empty partitions
-    (filtering, sparse splits); skipping them lets the store build proceed as
-    long as at least one shard has rows.
-    """
-    for path in shard_paths:
-        fs, resolved = url_to_fs(path)
-        with fs.open(resolved, "rb") as f:
-            pf = pq.ParquetFile(f)
-            if pf.metadata.num_rows == 0:
-                continue
-            first_batch = next(pf.iter_batches(batch_size=1))
-        return _strip_id(first_batch.to_pylist()[0])
-    raise ValueError(f"All {len(shard_paths)} attribute shards are empty; cannot derive exemplar")
-
-
 def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
     """Build one Levanter cache per split from :class:`TokenizedAttrData` sources.
 
     For each split that exists in any source, this:
 
     1. Collects parquet shard paths across all sources.
-    2. Derives an exemplar from the first non-empty shard's first record.
-    3. Runs :func:`build_from_datasets` to write per-shard caches and a
+    2. Runs :func:`build_from_datasets` to write per-shard caches and a
        top-level sharded ledger.
-    4. Writes ``.stats.json`` next to the ledger.
+    3. Writes ``.stats.json`` next to the ledger.
 
     Splits with no shards are skipped. If a split's ledger already exists,
     this loads the existing stats rather than rebuilding.
@@ -274,7 +271,6 @@ def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
             continue
 
         split_output = os.path.join(config.cache_path, split)
-        exemplar = _first_nonempty_exemplar(shard_paths)
 
         if _ledger_exists(split_output):
             logger.info("Shard ledger already exists for %s at %s; loading", split, split_output)
@@ -291,7 +287,6 @@ def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
                 ctx=ctx,
                 dataset=dataset,
                 output_path=split_output,
-                exemplar=exemplar,
                 batch_size=config.levanter_batch_size,
             )
 

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -101,6 +101,10 @@ def _structural_exemplar(record: dict) -> dict:
     sequence leaves to a single element keeps the per-shard payload returned to
     the coordinator tiny — a full document can be megabytes for long-context
     data, and we return one per shard.
+
+    This is an optimization to avoid materializing too much data on the
+    entrypoint: every shard ships its exemplar back, but only the structure is
+    needed, so we never pull whole documents onto the coordinator.
     """
     return {k: v[:1] if isinstance(v, np.ndarray | list | tuple) else v for k, v in record.items()}
 

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -125,10 +125,6 @@ def build_from_datasets(
     step only writes a top-level ``shard_ledger.json`` that references them by
     relative path (sharded layout, see Levanter ``#5430``).
 
-    The structural exemplar that :func:`consolidate_shard_cache_ledgers` needs as
-    a fallback is taken from the shard writes themselves (first non-empty shard),
-    so no separate pass over the inputs is required.
-
     Args:
         ctx: Zephyr context. The caller is responsible for setting any tokenizer
             shared values (``ctx.put('tokenizer_name', ...)`` etc.) before calling

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -253,58 +253,6 @@ def _split_already_done(cache_path: str, split_name: str) -> bool:
     return False
 
 
-def _exemplar_for(
-    file_groups: list[list[str]],
-    *,
-    config: TokenizeConfigBase,
-) -> dict:
-    """Compute a post-tokenize exemplar by running one record through the pipeline.
-
-    The exemplar still carries ``id`` (because the shared tokenize pipeline emits
-    ``{id, input_ids, ...}``); :func:`build_from_datasets` strips it before
-    writing the cache.
-
-    Scans input files in order until one yields a record. Tolerates sparse
-    inputs (e.g. filtered ``write_parquet`` output where leading shards happen
-    to be empty) instead of failing on ``results[0]``.
-    """
-    sample_path = parquet_window_hint(file_groups)
-    candidates = [path for group in file_groups for path in group]
-    if not candidates:
-        raise ValueError("_exemplar_for: file_groups is empty")
-
-    first_non_empty: str | None = None
-    for path in candidates:
-        if next(iter(load_file(path)), None) is not None:
-            first_non_empty = path
-            break
-    if first_non_empty is None:
-        raise ValueError(f"_exemplar_for: no records found across {len(candidates)} input files")
-
-    ds = Dataset.from_list([first_non_empty]).flat_map(load_file)
-    pipeline, _ = tokenize_pipeline(
-        ds,
-        data_format=config.format,
-        sample_count=1,
-        sample_parquet_path=sample_path,
-        levanter_batch_size=None,
-    )
-    ctx = ZephyrContext(
-        resources=config.worker_resources,
-        max_workers=1,
-        name="tokenize-exemplar",
-    )
-    ctx.put("tokenizer_name", config.tokenizer)
-    ctx.put("tokenizer_backend", config.tokenizer_backend)
-    return ctx.execute(pipeline, verbose=False).results[0]
-
-
-def _strip_id(record: dict) -> dict:
-    if "id" not in record:
-        return record
-    return {k: v for k, v in record.items() if k != "id"}
-
-
 def _run_split(
     *,
     config: TokenizeConfigBase,
@@ -335,14 +283,10 @@ def _run_split(
     ctx.put("tokenizer_name", config.tokenizer)
     ctx.put("tokenizer_backend", config.tokenizer_backend)
 
-    logger.info("Computing exemplar for cache consolidation")
-    exemplar = _strip_id(_exemplar_for(file_groups, config=config))
-
     ledger = build_from_datasets(
         ctx=ctx,
         dataset=tokenized_ds,
         output_path=prefix,
-        exemplar=exemplar,
         batch_size=batch_size,
     )
 

--- a/tests/processing/tokenize/test_split_tokenize.py
+++ b/tests/processing/tokenize/test_split_tokenize.py
@@ -29,7 +29,7 @@ from marin.processing.tokenize.attributes import (
 )
 from marin.processing.tokenize.store_builder import (
     BuildLevanterStoreConfig,
-    _first_nonempty_exemplar,
+    _structural_exemplar,
     build_levanter_store,
     build_levanter_store_step,
 )
@@ -272,32 +272,21 @@ def test_build_levanter_store_step_requires_at_least_one_source():
         build_levanter_store_step(name="store", tokenize_steps=[])
 
 
-def _write_attr_shard(path, ids: list[str], input_ids_lists: list[list[int]]) -> None:
-    """Write a small attribute parquet file with the canonical {id, input_ids} schema."""
-    schema = pa.schema([("id", pa.string()), ("input_ids", pa.list_(pa.int32()))])
-    table = pa.Table.from_pylist(
-        [{"id": i, "input_ids": ii} for i, ii in zip(ids, input_ids_lists, strict=True)],
-        schema=schema,
-    )
-    pq.write_table(table, str(path))
-
-
-def test_first_nonempty_exemplar_skips_empty_leading_shards(tmp_path):
-    """Empty shards must not block exemplar derivation when later shards have rows."""
-    empty = tmp_path / "part-00000-of-00002.parquet"
-    nonempty = tmp_path / "part-00001-of-00002.parquet"
-    _write_attr_shard(empty, ids=[], input_ids_lists=[])
-    _write_attr_shard(nonempty, ids=["abc"], input_ids_lists=[[1, 2, 3]])
-
-    exemplar = _first_nonempty_exemplar([str(empty), str(nonempty)])
-    assert exemplar == {"input_ids": [1, 2, 3]}
-
-
-def test_first_nonempty_exemplar_raises_when_all_empty(tmp_path):
-    p = tmp_path / "part-00000-of-00001.parquet"
-    _write_attr_shard(p, ids=[], input_ids_lists=[])
-    with pytest.raises(ValueError, match="empty"):
-        _first_nonempty_exemplar([str(p)])
+def test_structural_exemplar_slices_sequence_leaves():
+    """Sequence leaves shrink to one element; scalars/strings pass through whole."""
+    record = {
+        "input_ids": np.arange(1000, dtype=np.int32),
+        "segment_ids": [0, 0, 1, 1, 2],
+        "weights": (0.5, 0.25, 0.25),
+        "doc_id": "abc-123",
+        "length": 1000,
+    }
+    out = _structural_exemplar(record)
+    assert np.array_equal(out["input_ids"], np.array([0], dtype=np.int32))
+    assert out["segment_ids"] == [0]
+    assert out["weights"] == (0.5,)
+    assert out["doc_id"] == "abc-123"
+    assert out["length"] == 1000
 
 
 def test_build_levanter_store_step_hash_id_changes_with_batch_size():

--- a/tests/processing/tokenize/test_tokenize.py
+++ b/tests/processing/tokenize/test_tokenize.py
@@ -236,8 +236,9 @@ def test_tokenize_full_pipeline_integration(tmp_path):
 
 
 @pytest.mark.slow
-def test_exemplar_for_skips_empty_leading_shard(tmp_path):
-    """Regression for #5790."""
+def test_tokenize_skips_empty_leading_shard(tmp_path):
+    """Regression for #5790: a sparse leading shard (empty parquet) must not break
+    tokenization. The consolidation exemplar is taken from the first non-empty shard."""
     # train_paths must not contain "test"; pytest's tmp_path always does.
     with tempfile.TemporaryDirectory(prefix="sparse_") as raw_dir:
         data_dir = Path(raw_dir)


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/6008
* drop `_exemplar_for`; the consolidation exemplar now falls out of the main tokenize job instead of a separate Zephyr pass over the inputs
* `write_levanter_cache` now returns the first record it already extracts as `exemplar` (`None` for empty shards) in its result dict
* `build_from_datasets` drops its `exemplar` parameter — `_write_shard` emits `(path, exemplar)` and the coordinator picks the first non-`None` one [^1] for `consolidate_shard_cache_ledgers`
* add `_structural_exemplar` — slices sequence leaves to one element so the per-shard payload returned to the coordinator stays tiny [^2]
* remove `_first_nonempty_exemplar` from `build_levanter_store` (its coordinator-side parquet re-read is now redundant)
* tests
  * `test_write_levanter_cache_end_to_end` asserts the new `exemplar` key
  * replace the two `_first_nonempty_exemplar` unit tests with `test_structural_exemplar_slices_sequence_leaves`
  * rename `test_exemplar_for_skips_empty_leading_shard` → `test_tokenize_skips_empty_leading_shard` (now an end-to-end sparse-input test, #5790 still covered)

[^1]: this naturally skips empty/leading shards, replacing the empty-skipping logic both `_exemplar_for` and `_first_nonempty_exemplar` used to carry
[^2]: shard ledgers from `write_levanter_cache` always carry `field_counts`, so the exemplar is only a fallback in consolidation and never needs the full record — a full long-context doc would otherwise be megabytes × thousands of shards back to the coordinator, the memory pressure #6001 was chasing
