### PR TITLE
[Design] Artifact.from_id + ArtifactRegistry

### DIFF
--- a/.agents/projects/artifact_from_id/design.md
+++ b/.agents/projects/artifact_from_id/design.md
@@ -4,7 +4,7 @@ _Why are we doing this? What's the benefit?_
 
 Today an artifact's identity is its GCS path. `Artifact.from_path(...)` resolves the metadata sidecar under that path, which is fine until the path needs to change — and we can't easily restructure GCS. Downstream code can't refer to a dataset or model checkpoint by a stable name; it has to know the exact computed path that produced it.
 
-We want a path-independent way to refer to artifacts: `Artifact.from_id("datasets/fineweb-resiliparse", "v3", NormalizedData)` should resolve to the same payload regardless of where the bytes live, today or after a re-org. This requires a small registry that maps `(id, version) → path + metadata`, with a default backed by GCS / local filesystem and a user-supplied override hook.
+We want a path-independent way to refer to artifacts: `Artifact.from_id("datasets/fineweb-resiliparse", "2026.05.29", NormalizedData)` should resolve to the same payload regardless of where the bytes live, today or after a re-org. This requires a small registry that maps `(id, version) → path + metadata`, with a default backed by GCS / local filesystem and a user-supplied override hook.
 
 ## Background
 
@@ -21,7 +21,7 @@ _What's hard?_
 The core mechanics are easy; the contentious bits are policy choices.
 
 1. **Concurrent writes on object storage.** GCS has no native locking. We avoid this at v1 with a layout where concurrent registrations of distinct `(id, version)` pairs never touch the same key; same-pair races are last-writer-wins. CAS (`if-generation-match`) is a clean follow-up.
-2. **Version flavor is a one-way door.** Once callers pin `"v3"`, changing the version model (content-hash, monotonic-int) costs a migration. We pick *user-supplied string* and accept that immutability discipline now lives with the caller.
+2. **Version flavor is a one-way door.** Once callers pin a version string, changing the version model costs a migration. We pick **CalVer** — `YYYY.MM.DD` with an optional `-<modifier>` suffix (`2026.10.01-fall-hero`) — validated by regex *and* an actual date parse. The modifier alphabet is restricted to `[A-Za-z0-9._-]`; no `/`, since the whole version is a single path segment. This buys lexical-equals-chronological ordering for free, gives provenance (the date the artifact was minted), and leaves room for hero / RC suffixes; see Decisions for what we considered instead.
 
 ## Costs / Risks
 
@@ -48,7 +48,7 @@ Two new pieces in `lib/marin/src/marin/execution/`:
 <registry-root>/<namespace>/<name>/<version>.json
 ```
 
-Example: `gs://marin-us-central2/artifact_registry/datasets/fineweb-resiliparse/v3.json`. The hot path is id+version → known key (O(1) GET); directory size doesn't matter for reads. Concurrent writers of distinct `(id, version)` pairs never contend; same-pair races are last-writer-wins (no CAS at v1).
+Example: `gs://marin-us-central2/artifact_registry/datasets/fineweb-resiliparse/2026.05.29.json`. The hot path is id+version → known key (O(1) GET); directory size doesn't matter for reads. Concurrent writers of distinct `(id, version)` pairs never contend; same-pair races are last-writer-wins (no CAS at v1).
 
 **Immutability is registry-level only.** A registered `(id, version)` always points at the same `uri`, but the bytes at that `uri` are protected by GCS IAM, not by this design. Anyone with write access can delete or repoint the underlying artifact; the open content-hash field would let `from_id` detect this.
 
@@ -57,7 +57,9 @@ Example: `gs://marin-us-central2/artifact_registry/datasets/fineweb-resiliparse/
 - *Sharded prefix* (`<name[-2:]>/<name>/<version[-2:]>/<version>.json`) — rejected: reads go straight to a known key, and "list all versions" is a debugging operation. Adding sharding later is a one-time migration.
 - *Single global `registry.json`* — rejected (worst concurrency, worst diff-ability).
 - *SQL-backed service* — out of scope; the manifest-file shape parallels DVC and HF-as-git, the right reference class for a library component.
-- *Content-addressable storage (content-hash as identity)* — **considered and rejected.** Marin already content-addresses one layer down ([`step_spec.py:90`](https://github.com/marin-community/marin/blob/f07122bbd20376b97e8951ac75f0eb8a7ebee7e3/lib/marin/src/marin/execution/step_spec.py#L90)), so the registry hash would mostly duplicate that. More importantly, humans say "give me `fineweb-resiliparse` v3", not "`sha256:e3b0c44…`" — content-hash naming reintroduces the path-coupling problem we're trying to leave. Callers pick the version string; `register` fails on collision. A content-hash field for verification (not identity) remains an Open Question.
+- *Content-addressable storage (content-hash as identity)* — **considered and rejected.** Marin already content-addresses one layer down ([`step_spec.py:90`](https://github.com/marin-community/marin/blob/f07122bbd20376b97e8951ac75f0eb8a7ebee7e3/lib/marin/src/marin/execution/step_spec.py#L90)), so the registry hash would mostly duplicate that. More importantly, humans say "give me `fineweb-resiliparse` from 2026-05-29", not "`sha256:e3b0c44…`" — content-hash naming reintroduces the path-coupling problem we're trying to leave. Callers pick the version string; `register` fails on collision. A content-hash field for verification (not identity) remains an Open Question.
+- *Free-form version strings* (the original draft: `[A-Za-z0-9_.-]+`) — **rejected** in favor of CalVer. Free-form gives no ordering, no provenance, no shared vocabulary; pinning structure now is cheaper than retrofitting it later.
+- *Semver via `packaging.version()` (3-tuple, ordered)* — **considered.** Strict semver maps badly to datasets and trained checkpoints — "what's a breaking change for `fineweb-resiliparse`?" doesn't have an obvious answer, and the major/minor/patch discipline is overhead without payoff for this domain. CalVer doubles as a creation date and the zero-padded prefix gives lexical=chronological sort for free.
 - *Mutable aliases (`latest`, `prod`, …)* — **intentionally not supported, non-goal not deferral.** The registry is `(id, version) → uri` and nothing else. Callers needing a "latest" pointer maintain it themselves. Rationale: aliases drift implicitly on every registration, breaking reproducibility of old run logs without anyone touching them — exactly the failure mode the registry exists to prevent.
 
 **`Artifact.from_id`** delegates to existing machinery after resolving:
@@ -67,7 +69,7 @@ Example: `gs://marin-us-central2/artifact_registry/datasets/fineweb-resiliparse/
 def from_id(
     cls,
     id: str,                          # "<namespace>/<name>", e.g. "datasets/fineweb-resiliparse"
-    version: str,                      # user-supplied, immutable, e.g. "v3"
+    version: str,                      # CalVer YYYY.MM.DD[-suffix], e.g. "2026.05.29-fall-hero"
     artifact_type: type[T] | None = None,  # Pydantic schema, same role as in from_path
     *,
     registry: ArtifactRegistry | None = None,
@@ -91,7 +93,7 @@ Integration tests against the local-FS backend cover the load-bearing behaviors:
 
 - Round-trip: `register(id, "v1", uri, MyModel)` then `from_id(id, "v1", MyModel)` returns the same payload via the existing `from_path` deserialization.
 - Immutability: second `register(id, "v1", ...)` raises a typed error; the original entry is untouched.
-- ID validation: malformed ids (`"foo"`, `"foo/"`, `"a/b/c"`, empty version) raise `ValueError` before any FS access.
+- ID and version validation: malformed ids (`"foo"`, `"foo/"`, `"a/b/c"`) and non-CalVer versions (`"v3"`, `"2026.5.29"`, `"2026.02.30"`) raise `InvalidArtifactIdError` before any FS access.
 - Manifest layout invariant: a registered entry lands at the expected path. (Pins the on-disk contract.)
 - Override: `from_id(..., registry=other)` ignores the default singleton.
 

--- a/.agents/projects/artifact_from_id/design.md
+++ b/.agents/projects/artifact_from_id/design.md
@@ -1,0 +1,104 @@
+# Artifact.from_id + ArtifactRegistry
+
+_Why are we doing this? What's the benefit?_
+
+Today an artifact's identity is its GCS path. `Artifact.from_path(...)` resolves the metadata sidecar under that path, which is fine until the path needs to change — and we can't easily restructure GCS. Downstream code can't refer to a dataset or model checkpoint by a stable name; it has to know the exact computed path that produced it.
+
+We want a path-independent way to refer to artifacts: `Artifact.from_id("datasets/fineweb-resiliparse", "v3", NormalizedData)` should resolve to the same payload regardless of where the bytes live, today or after a re-org. This requires a small registry that maps `(id, version) → path + metadata`, with a default backed by GCS / local filesystem and a user-supplied override hook.
+
+## Background
+
+Current state, prior art, and pitfalls survey: see [`research.md`](./research.md). Short version:
+
+- `Artifact` is a JSON metadata envelope (`artifact.json` sidecar) over Pydantic payloads like `PathMetadata`, `TokenizedAttrData`. `from_path(base, type)` requires `type` to subclass `BaseModel`. ([`lib/marin/src/marin/execution/artifact.py:32`](https://github.com/marin-community/marin/blob/f07122bbd20376b97e8951ac75f0eb8a7ebee7e3/lib/marin/src/marin/execution/artifact.py#L32))
+- Marin already has *content-addressed* path hashes from the executor ([`step_spec.py:90`](https://github.com/marin-community/marin/blob/f07122bbd20376b97e8951ac75f0eb8a7ebee7e3/lib/marin/src/marin/execution/step_spec.py#L90)) and *schema* versions inside payloads. This proposal adds a third axis: a **logical name + user-supplied version** that is independent of both.
+- No existing registry in `marin/execution/`. Prior art (MLflow, W&B, DVC, HF Hub) converges on `(name, version) → metadata + pointer`, with mutable aliases layered over immutable versions. A manifest-file-on-storage registry is firmly in the DVC / HF-as-git camp.
+
+## Challenges
+
+_What's hard?_
+
+The core mechanics are easy; the contentious bits are policy choices.
+
+1. **Concurrent writes on object storage.** GCS has no native locking. We avoid this at v1 with a layout where concurrent registrations of distinct `(id, version)` pairs never touch the same key; same-pair races are last-writer-wins. CAS (`if-generation-match`) is a clean follow-up.
+2. **Version flavor is a one-way door.** Once callers pin `"v3"`, changing the version model (content-hash, monotonic-int) costs a migration. We pick *user-supplied string* and accept that immutability discipline now lives with the caller.
+
+## Costs / Risks
+
+- New surface area in `lib/marin/src/marin/execution/` that downstream code will start depending on.
+- Two ways to load the same artifact — `from_path` (legacy) and `from_id` (new). `from_id` delegates to `from_path` so the typed-loader behavior stays in one place; the duplication is API-only.
+- Users must *register* artifacts before `from_id` works. Existing pipelines keep working unchanged; only consumers who want id-based lookup pay the one-line `registry.register(...)` cost.
+
+## Design
+
+_How are we doing this?_
+
+Two new pieces in `lib/marin/src/marin/execution/`:
+
+**`ArtifactRegistry`** — an interface plus a default `FilesystemArtifactRegistry` backed by GCS or local FS via `rigging.filesystem` / `url_to_fs` (the abstractions `artifact.py` already uses, [artifact.py:9](https://github.com/marin-community/marin/blob/f07122bbd20376b97e8951ac75f0eb8a7ebee7e3/lib/marin/src/marin/execution/artifact.py#L9)). Two methods:
+
+- `register(id, version, uri) -> ArtifactEntry` — fails loudly if `(id, version)` already exists. No overwrite, no upsert at v1.
+- `lookup(id, version) -> ArtifactEntry` — returns the stored entry or raises `ArtifactNotFoundError`.
+
+`ArtifactEntry` is a minimal Pydantic record: `id`, `version`, `uri`. It serves both as the persisted file schema and as the return type of `lookup` / `register`. Extra fields (`created_at`, `metadata`, `artifact_type`) are deferred until there's a consumer for them — easier to add later than to deprecate.
+
+**Manifest layout** is one file per `(id, version)`:
+
+```
+<registry-root>/<namespace>/<name>/<version>.json
+```
+
+Example: `gs://marin-us-central2/artifact_registry/datasets/fineweb-resiliparse/v3.json`. The hot path is id+version → known key (O(1) GET); directory size doesn't matter for reads. Concurrent writers of distinct `(id, version)` pairs never contend; same-pair races are last-writer-wins (no CAS at v1).
+
+**Immutability is registry-level only.** A registered `(id, version)` always points at the same `uri`, but the bytes at that `uri` are protected by GCS IAM, not by this design. Anyone with write access can delete or repoint the underlying artifact; the open content-hash field would let `from_id` detect this.
+
+**Decisions / considered alternatives.**
+
+- *Sharded prefix* (`<name[-2:]>/<name>/<version[-2:]>/<version>.json`) — rejected: reads go straight to a known key, and "list all versions" is a debugging operation. Adding sharding later is a one-time migration.
+- *Single global `registry.json`* — rejected (worst concurrency, worst diff-ability).
+- *SQL-backed service* — out of scope; the manifest-file shape parallels DVC and HF-as-git, the right reference class for a library component.
+- *Content-addressable storage (content-hash as identity)* — **considered and rejected.** Marin already content-addresses one layer down ([`step_spec.py:90`](https://github.com/marin-community/marin/blob/f07122bbd20376b97e8951ac75f0eb8a7ebee7e3/lib/marin/src/marin/execution/step_spec.py#L90)), so the registry hash would mostly duplicate that. More importantly, humans say "give me `fineweb-resiliparse` v3", not "`sha256:e3b0c44…`" — content-hash naming reintroduces the path-coupling problem we're trying to leave. Callers pick the version string; `register` fails on collision. A content-hash field for verification (not identity) remains an Open Question.
+- *Mutable aliases (`latest`, `prod`, …)* — **intentionally not supported, non-goal not deferral.** The registry is `(id, version) → uri` and nothing else. Callers needing a "latest" pointer maintain it themselves. Rationale: aliases drift implicitly on every registration, breaking reproducibility of old run logs without anyone touching them — exactly the failure mode the registry exists to prevent.
+
+**`Artifact.from_id`** delegates to existing machinery after resolving:
+
+```python
+@classmethod
+def from_id(
+    cls,
+    id: str,                          # "<namespace>/<name>", e.g. "datasets/fineweb-resiliparse"
+    version: str,                      # user-supplied, immutable, e.g. "v3"
+    artifact_type: type[T] | None = None,  # Pydantic schema, same role as in from_path
+    *,
+    registry: ArtifactRegistry | None = None,
+) -> T | PathMetadata | dict[str, Any]:
+    reg = registry or get_default_registry()
+    entry = reg.lookup(id, version)
+    return cls.from_path(entry.uri, artifact_type)
+```
+
+`get_default_registry()` returns a module-level singleton built from `MARIN_ARTIFACT_REGISTRY` (default `{marin_prefix()}/artifact_registry`). Tests and notebook users pass `registry=` to override.
+
+**IDs** are strict `<namespace>/<name>` (one slash, both segments non-empty, restricted character set). `register` and `lookup` validate this up-front; ambiguous inputs raise immediately.
+
+**Out of scope** at v1: explicit overwrite / upsert, content hashing in entries, multi-writer transactional semantics, the auto-registration shortcut from step outputs, deletion / garbage collection. Each is a clean follow-up; see [`spec.md`](./spec.md) for the explicit out-of-scope list. Mutable aliases (`latest`, `prod`, …) are a non-goal, not a deferral — see Decisions.
+
+## Testing
+
+_Agents make mistakes — how do we catch them?_
+
+Integration tests against the local-FS backend cover the load-bearing behaviors:
+
+- Round-trip: `register(id, "v1", uri, MyModel)` then `from_id(id, "v1", MyModel)` returns the same payload via the existing `from_path` deserialization.
+- Immutability: second `register(id, "v1", ...)` raises a typed error; the original entry is untouched.
+- ID validation: malformed ids (`"foo"`, `"foo/"`, `"a/b/c"`, empty version) raise `ValueError` before any FS access.
+- Manifest layout invariant: a registered entry lands at the expected path. (Pins the on-disk contract.)
+- Override: `from_id(..., registry=other)` ignores the default singleton.
+
+We will also run one smoke test against a GCS sandbox bucket to confirm the same suite passes with a `gs://` registry root — this is the only test that exercises the real object-store semantics we care about.
+
+## Open Questions
+
+- **Content hash on `ArtifactEntry` for verification (not identity)?** Adding the field later is cheap (`extra="ignore"` on the model), but writing it only on new registrations leaves the registry mixed-mode forever. If reviewers want it, we add it at v1.
+- **Per-region registries vs. one canonical region?** Marin runs in multiple regions and we don't want cross-region reads on the read path. Leaning per-region. Interacts with `uri` portability: a `us-east1` registry recording a `gs://marin-us-central2/...` uri is a cross-region pointer that may want to be a registration-time error.
+- **Should `Artifact.save` auto-publish?** Tempting but couples the registry to every step output. Leaning *no* — explicit `registry.register(...)` — but reviewers may have a better instinct.

--- a/.agents/projects/artifact_from_id/research.md
+++ b/.agents/projects/artifact_from_id/research.md
@@ -1,0 +1,114 @@
+# Research: `Artifact.from_id` + `ArtifactRegistry`
+
+Background research for the design doc. Persisted so the 1-pager can stay short.
+
+## 1. `Artifact` today
+
+`lib/marin/src/marin/execution/artifact.py` (118 lines). Static-method-only loader/saver for step outputs — no instance state.
+
+- `Artifact.from_path(base_path: str | StepSpec, artifact_type: type[T] | None = None) -> T | PathMetadata | dict[str, Any]` (artifact.py:32–61)
+  - Loads `{base_path}/artifact.json` (legacy: `.artifact`) and deserializes via Pydantic `BaseModel.model_validate_json()` when `artifact_type` is provided; otherwise returns the raw dict.
+  - Type check: `if not issubclass(artifact_type, BaseModel): raise TypeError(...)` (l.56–58). So `artifact_type` MUST be a Pydantic `BaseModel`.
+  - Fallback: if the sidecar is missing but a sibling `.executor_status` reads `SUCCESS`, synthesize `PathMetadata(path=base_path)` (l.64–83).
+- `Artifact.save(value, base_path)` (artifact.py:86–97): writes `artifact.json` for any Pydantic `BaseModel`, dataclass, or JSON-serializable.
+
+**What an Artifact IS in this codebase**: the JSON metadata envelope around a step's output. Concrete payloads are Pydantic models like `PathMetadata` (single path), `PathsMetadata` (sharded), `NormalizedData`, `TokenizedAttrData`, `LevanterStoreData`. The artifact is metadata + pointer(s), not the bytes.
+
+## 2. Call sites (representative)
+
+All call sites are **lazy deserialization at consumption time** — a downstream step opens an upstream output by its computed path and asks for a typed view.
+
+- `lib/marin/src/marin/processing/tokenize/attributes.py:39–58` — `Artifact.from_path(step, NormalizedData)` → produces `TokenizedAttrData`, `.save()` to emit.
+- `lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py:38,125` — chained normalize → minhash → fuzzy-dups via `from_path`.
+- `lib/marin/src/marin/processing/tokenize/store_builder.py:145` — collects multiple tokenized split artifacts.
+- `lib/marin/src/marin/execution/step_runner.py:140,165` — `Artifact.save(result, output_path)` after a step function returns.
+
+No call site constructs `Artifact` directly; everything goes through `from_path` / `save`.
+
+## 3. Adjacent registry / id concepts
+
+- **No existing artifact registry.** No module named `registry` in `lib/marin/src/marin/execution/`.
+- `lib/marin/src/marin/datakit/ingestion_manifest.py:1–80` — Pydantic ingestion manifests (source policies, sampling caps, fingerprints). Governance sidecar, not a lookup table.
+- `lib/marin/src/marin/execution/executor.py:30–77,848–875` — executor versioning: `VersionedValue` wrapper marks fields that participate in the step's hash. The **path itself is the version**; no id → path map.
+
+## 4. Versioning conventions in Marin
+
+Content-addressed path hashes:
+
+- `lib/marin/src/marin/execution/step_spec.py:90–101` — `hash_id = sha256(json.dumps({name, hash_attrs, sorted(dep_names)}))[:8]` (l.96). Step output path: `{marin_prefix()}/{name}_{hash_id}` (l.116). Example: `gs://marin-us-central2/documents/fineweb-resiliparse-8c2f3a`.
+- Schema-level versioning lives inside the artifact JSON itself — e.g. `NormalizedData.version = "v1"` (`lib/marin/src/marin/datakit/normalize.py:75`).
+
+So Marin already has two version-like notions: the **step-hash** (8-char hex, content-addressed, machine-derived) and the **schema-version string** inside the payload (semver-ish, human-curated). The new `Artifact.from_id(id, version)` introduces a third axis — a **user-facing logical name + version** decoupled from both.
+
+## 5. Filesystem abstraction
+
+No unified wrapper; code switches between two layers:
+
+- `rigging.filesystem` — `marin_prefix()` (root path), `open_url(...)` context manager for read/write across GCS + local. Imported in artifact.py:9 and used at l.49, l.53, l.88.
+- `lib/marin/src/marin/utils.py` — fsspec helpers: `fsspec_exists`, `fsspec_glob`, `fsspec_mkdirs`. `url_to_fs(...)` is used elsewhere to obtain a filesystem object from a URL.
+
+The registry should be backed by `rigging.filesystem` / `url_to_fs` so it works on both GCS and local paths with no hardcoded scheme.
+
+## 6. The "optional model" parameter
+
+User asked for `Artifact.from_id(<id>, <version>, <optional-model>)`. Strongly likely interpretation: **a Pydantic schema class to deserialize the payload into** — i.e. it parallels the existing `artifact_type` parameter on `from_path` (artifact.py:33). When `None`, you get the raw dict / `PathMetadata` fallback; when provided, you get a typed instance.
+
+I'll confirm this with the user in Phase 3 — but treating "model" as "Pydantic schema" is consistent with every existing call site and with the artifact.py contract.
+
+## 7. Prior design docs
+
+Skimmed `.agents/projects/`. None on artifact identity / registries / GCS reorganization.
+
+## 8. GitHub issues
+
+`gh issue list --search "artifact registry"`, `gh issue list --search "artifact id"`:
+
+- #5864 (OPEN) — `[marin] _discover_files treats artifact.json sidecar as JSONL data`. Tangential; confirms `artifact.json` is now a known sidecar convention.
+- #5057 (OPEN) — unrelated (evals).
+
+No prior issue dedicated to artifact-id or a registry.
+
+---
+
+## Prior art (web pass)
+
+Quick read of well-known artifact registries to anchor reviewer expectations.
+
+**MLflow Model Registry.** Flat string `name` + monotonically-increasing integer per name. Mutable aliases (`@champion`) and stage tags layered on top. Stores metadata + URI pointer; bytes live in the artifact store. Typed via "flavor" recorded in an `MLmodel` YAML. **SQL-backed** service.
+
+**W&B Artifacts.** `entity/project/name` + `type` ("dataset", "model", ...). Version is monotonic `v0, v1, ...` per collection, **assigned by content checksum** (re-logging identical content doesn't bump). Mutable aliases. Server + content-addressed blob store.
+
+**DVC.** ID = workspace-relative path of a `.dvc` pointer; version = **content hash (MD5)**. Registry is flat files on disk (`.dvc` + `dvc.lock`) tracked in git. Untyped blobs.
+
+**Hugging Face Hub.** ID = `namespace/repo_name` + `repo_type`; version (`revision`) is a **git ref** (commit SHA, branch, or tag). Registry literally is git (LFS for big files).
+
+### Convergent choices
+
+- Universal: `(name, version)` pair; name is a string, often namespaced.
+- Universal: registry stores **metadata + pointer**, not bytes.
+- Universal: **mutable aliases** (`latest`, `best`, …) layered over immutable versions.
+- Strong trend: content-hash-derived immutability (DVC, W&B, HF git SHA). MLflow's pure integer counter is the outlier.
+
+### Divergent choices reviewers will probe
+
+- **Version flavor**: monotonic int vs. content hash vs. user-supplied semver/tag.
+- **Namespacing**: flat vs. `user/repo` vs. `entity/project/name`.
+- **Typed vs. blob**: a cheap `type: str` field enables tooling later.
+- **Registry transport**: SQL service vs. flat files in storage. A manifest-file design is firmly in the DVC / HF-as-git camp — say so explicitly.
+
+### Pitfalls of small in-process registries
+
+- **Non-atomic manifest writes** → corrupt registry on crash. Tempfile + rename locally; **GCS generation-preconditioned write** (`if-generation-match`) for object stores.
+- **Concurrent writers** → lost updates. Either object-store CAS or document a single-writer / leased-writer model.
+- **Mutable versions** → silent reproducibility loss. Versions must be immutable; new content ⇒ new version.
+- **Alias drift** → record the *resolved* immutable version alongside any alias in run logs.
+- **Pointer-only entries** → record a content hash even if version is human-supplied (DVC and W&B both do).
+- **Absolute URIs in the manifest** → non-portable across buckets/regions. Store relative keys + a separately-configured root.
+- **No GC / orphan story** → decide upfront whether the registry is append-only.
+- **Unbounded metadata schemas** → pin a minimal typed schema (`id, version, type, uri, content_hash, created_at, metadata: dict`) from day one.
+
+Sources (snapshot 2026-05-20):
+- MLflow Model Registry docs
+- W&B Artifacts (aliases, versioning)
+- DVC internal files (`.dvc`, `dvc.lock`)
+- Hugging Face Hub revisions

--- a/.agents/projects/artifact_from_id/spec.md
+++ b/.agents/projects/artifact_from_id/spec.md
@@ -1,0 +1,285 @@
+# Spec: `Artifact.from_id` + `ArtifactRegistry`
+
+Concrete contracts for the design in [`design.md`](./design.md). Implementation lives elsewhere; this file pins the public surface reviewers are asked to agree to.
+
+## Files
+
+| Purpose | Path |
+|---|---|
+| New: registry protocol, default impl, errors, singleton helpers | `lib/marin/src/marin/execution/artifact_registry.py` |
+| Modified: add `Artifact.from_id` classmethod | `lib/marin/src/marin/execution/artifact.py` |
+| New: tests | `tests/execution/test_artifact_registry.py` |
+
+No proto, no schema-registry tables, no migrations. The registry's persisted format is JSON on the filesystem (described below).
+
+## Constants
+
+```python
+# lib/marin/src/marin/execution/artifact_registry.py
+
+DEFAULT_REGISTRY_ENV: str = "MARIN_ARTIFACT_REGISTRY"
+"""Environment variable read by `get_default_registry()` to locate the default registry root.
+   When unset, the default is `f"{marin_prefix()}/artifact_registry"`."""
+
+ID_SEPARATOR: str = "/"
+"""Separator between namespace and name in an artifact id."""
+```
+
+## `ArtifactEntry`
+
+```python
+class ArtifactEntry(pydantic.BaseModel):
+    """Persisted record for a single (id, version) artifact registration.
+
+    This is both the wire format of `<root>/<namespace>/<name>/<version>.json` and the
+    return type of `ArtifactRegistry.register` / `ArtifactRegistry.lookup`. Entries are
+    immutable once written; the on-disk file is overwritten by a future explicit-upsert
+    feature only (out of scope at v1).
+
+    Frozen (`model_config = ConfigDict(frozen=True, extra="ignore")`): callers cannot mutate
+    a returned entry. Unknown fields read from disk are ignored, so adding optional fields
+    (`created_at`, `content_hash`, `metadata`, `artifact_type`) in a future revision will
+    not break readers running older code.
+    """
+
+    id: str
+    """Artifact id in the form `<namespace>/<name>`. Validated by `validate_id`."""
+
+    version: str
+    """User-supplied version string. Validated by `validate_version`."""
+
+    uri: str
+    """Location of the artifact bytes — the `base_path` argument to `Artifact.from_path`.
+       MUST be absolute: either a URI with scheme (`gs://...`, `file://...`) or an absolute
+       local path (`/...`). Relative paths are rejected by `register` to avoid having the
+       same registered entry resolve differently in different processes."""
+```
+
+## `ArtifactRegistry` protocol
+
+```python
+class ArtifactRegistry(typing.Protocol):
+    """A `(id, version) → uri` map. Append-only at v1; existing entries cannot be
+    overwritten or removed. Concrete impls back the protocol with filesystem,
+    in-memory, or test-double storage."""
+
+    def register(self, id: str, version: str, uri: str) -> ArtifactEntry:
+        """Record `(id, version) → uri`.
+
+        Raises `ArtifactAlreadyExistsError` if an entry for `(id, version)` already
+        exists; the existing entry is not modified. Raises `InvalidArtifactIdError`
+        on a malformed id, version, or non-absolute uri. Returns the newly-written
+        entry on success.
+
+        Implementations MUST write to storage before returning, and MUST do so atomically
+        — the manifest file is either fully present and valid, or absent. On local
+        filesystems this is `tempfile + os.replace`; on GCS, per-object PUT is naturally
+        atomic. Implementations MUST treat the existence check + write as best-effort
+        against concurrent writers — two processes racing to register the *same*
+        `(id, version)` may both believe they succeeded (last-writer-wins on the file).
+        v1 does not provide CAS; callers needing it should coordinate externally."""
+
+    def lookup(self, id: str, version: str) -> ArtifactEntry:
+        """Look up the entry for `(id, version)`.
+
+        Raises `ArtifactNotFoundError` if no entry exists. Raises `InvalidArtifactIdError`
+        on malformed inputs. Raises `ArtifactRegistryError` if the manifest file exists
+        but is unreadable, not valid UTF-8, not valid JSON, or fails `ArtifactEntry`
+        validation (the underlying exception is chained via `raise ... from`). Performs
+        an O(1) GET against storage — never lists."""
+```
+
+## `FilesystemArtifactRegistry`
+
+```python
+class FilesystemArtifactRegistry(ArtifactRegistry):
+    """The default `ArtifactRegistry`. Backed by GCS or local filesystem via
+    `rigging.filesystem.open_url` / `fsspec`. Stores one JSON file per entry at:
+
+        {root}/{namespace}/{name}/{version}.json
+
+    where the file contents are `ArtifactEntry.model_dump_json()`.
+
+    `root` may be any URI accepted by `rigging.filesystem` (e.g. `gs://bucket/prefix`,
+    `/local/path`). Trailing slashes are normalized away. The registry does not create
+    the root directory eagerly; the first `register` call creates intermediate
+    directories as needed.
+
+    The instance is cheap to construct and holds no open file handles. Multiple
+    instances pointing at the same root are interchangeable."""
+
+    def __init__(self, root: str) -> None:
+        """Store the normalized `root`. Performs NO I/O and does NOT validate that `root`
+           is reachable, exists, or is writable. The first `register` / `lookup` call
+           surfaces I/O errors. Empty string and non-string inputs raise `TypeError` /
+           `ValueError`."""
+
+    @property
+    def root(self) -> str:
+        """The normalized registry root URI (trailing slashes stripped)."""
+
+    def register(self, id: str, version: str, uri: str) -> ArtifactEntry: ...
+
+    def lookup(self, id: str, version: str) -> ArtifactEntry: ...
+
+    def entry_path(self, id: str, version: str) -> str:
+        """Return the storage path for a given entry. Public: pins the on-disk layout
+           contract for tooling, tests, and human introspection (`gsutil cat $(...)`)."""
+```
+
+## Singleton helpers
+
+```python
+def get_default_registry() -> ArtifactRegistry:
+    """Return the process-wide default registry, constructing it on first call from
+    `os.environ[DEFAULT_REGISTRY_ENV]` (fallback: `f"{marin_prefix()}/artifact_registry"`).
+    Raises `RuntimeError` if both the env var is unset AND `marin_prefix()` is unset /
+    raises — the registry has no sensible default in that case and the caller must set
+    one explicitly via `set_default_registry` or the env var.
+
+    The returned instance is cached at module scope. Re-reading the env var requires
+    `set_default_registry(None)` to clear the cache; this is intentional — env-var
+    flips mid-process are not a supported use case.
+
+    Thread-safety: the first call is NOT guarded by a lock. In multi-threaded entrypoints,
+    call `get_default_registry()` once during startup before forking threads so the cache
+    is populated. Concurrent first-call races may construct multiple instances, of which
+    one wins the cache slot; the others are GC'd. This is safe but wasteful."""
+
+
+def set_default_registry(registry: ArtifactRegistry | None) -> None:
+    """Override (or clear) the module-level default. Passing `None` clears the cache
+    so the next `get_default_registry()` call re-reads the environment.
+
+    In-flight callers retain whatever reference `get_default_registry()` already returned
+    to them — swapping the default does not invalidate already-resolved registries. Tests
+    that flip the default should use a fixture that restores the prior value in teardown.
+
+    Primary consumer: tests, notebooks, and any caller that needs a non-default registry
+    without threading it through every `Artifact.from_id` call site."""
+```
+
+## `Artifact.from_id`
+
+Added to the existing `Artifact` class in `lib/marin/src/marin/execution/artifact.py`.
+
+```python
+@classmethod
+def from_id(
+    cls,
+    id: str,
+    version: str,
+    /,
+    artifact_type: type[T] | None = None,
+    *,
+    registry: ArtifactRegistry | None = None,
+) -> T | PathMetadata | dict[str, Any]:
+    """Load an artifact by registry id + version.
+
+    `id` and `version` are positional-only — callers always write `Artifact.from_id("ns/n",
+    "v3", ...)`, never `Artifact.from_id(version="v3", id="ns/n")`. This keeps every call
+    site readable and aligns with the `from_path` shape.
+
+    Resolves `(id, version)` against `registry` (or the module-level default if
+    `registry is None`) to obtain a URI, then delegates to `Artifact.from_path(uri,
+    artifact_type)` — meaning the return value, the `PathMetadata` fallback (synthesized
+    when the sidecar is missing but `.executor_status` reads `SUCCESS`), and the
+    `artifact_type` deserialization semantics are identical to the path-based loader.
+
+    `artifact_type`, if provided, MUST be a Pydantic `BaseModel` subclass (the existing
+    contract on `from_path` — see `artifact.py` today). The registry does not record
+    the type; the caller asserts it on read.
+
+    Raises whatever `ArtifactRegistry.lookup` raises (`ArtifactNotFoundError`,
+    `InvalidArtifactIdError`, `ArtifactRegistryError`), plus whatever `Artifact.from_path`
+    raises on the resolved URI."""
+```
+
+## ID and version validation
+
+Both `register` and `lookup` validate their `id` and `version` arguments before any I/O. Validation rules:
+
+```python
+ID_PATTERN: typing.Final = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
+VERSION_PATTERN: typing.Final = re.compile(r"^[A-Za-z0-9_.-]+$")
+
+def validate_id(id: str) -> tuple[str, str]:
+    """Returns `(namespace, name)`. Raises `InvalidArtifactIdError` if the id is not
+    exactly one `/`-separated pair of non-empty segments matching `ID_PATTERN`."""
+
+def validate_version(version: str) -> str:
+    """Returns the version unchanged. Raises `InvalidArtifactIdError` if it does not
+    match `VERSION_PATTERN`."""
+```
+
+The pattern is intentionally narrow — anything we allow becomes part of a GCS path, so we disallow `/`, whitespace, and shell metacharacters by construction. The validators are exposed (no leading underscore) so callers generating ids can pre-check.
+
+## Errors
+
+```python
+class ArtifactRegistryError(Exception):
+    """Base class for all registry errors. Catch this to handle registry failures
+    generically; catch the subclasses for specific cases."""
+
+
+class ArtifactNotFoundError(ArtifactRegistryError, KeyError):
+    """No entry exists for `(id, version)`. Subclasses `KeyError` so existing
+    `dict`-style consumers keep working.
+
+    `__init__` calls `super().__init__((id, version))` so `KeyError`'s `args[0]` is the
+    `(id, version)` tuple — preserving the `KeyError` contract while keeping both fields
+    accessible via `.id` and `.version` attributes."""
+
+    id: str
+    version: str
+
+    def __init__(self, id: str, version: str) -> None: ...
+
+
+class ArtifactAlreadyExistsError(ArtifactRegistryError):
+    """An entry for `(id, version)` already exists; `register` refuses to overwrite.
+    The existing entry is exposed on `.existing` so callers can compare."""
+
+    existing: ArtifactEntry
+
+    def __init__(self, existing: ArtifactEntry) -> None: ...
+
+
+class InvalidArtifactIdError(ArtifactRegistryError, ValueError):
+    """Malformed id or version. Subclasses `ValueError` for ergonomics."""
+```
+
+## Persisted shape
+
+One JSON file per `(id, version)`:
+
+- Path: `{root}/{namespace}/{name}/{version}.json`
+- Contents: `ArtifactEntry.model_dump_json()` (UTF-8, no enclosing array).
+- Encoding: UTF-8 with no BOM. No trailing newline guarantee.
+
+Example (`gs://marin-us-central2/artifact_registry/datasets/fineweb-resiliparse/v3.json`):
+
+```json
+{"id": "datasets/fineweb-resiliparse", "version": "v3", "uri": "gs://marin-us-central2/documents/fineweb-resiliparse-8c2f3a"}
+```
+
+The `uri` is typically itself a content-addressed executor output (the `_8c2f3a` suffix is the executor step hash from `step_spec.py`). The registry layer adds logical naming on top of that existing content-addressed storage.
+
+The file is the source of truth. There is no index file, no companion `_meta`, no schema-registry registration. Listing all versions of an id is a recursive prefix scan under `{root}/{namespace}/{name}/`.
+
+## Out of scope (v1)
+
+Listed explicitly so reviewers know what *not* to push back on. Each is a clean follow-up; none are foreclosed:
+
+- **Mutable aliases** (`latest`, `prod`, `@champion`). Non-goal, not a deferral — see Decisions in `design.md`.
+- **Explicit overwrite / upsert.** `register(..., overwrite=True)` was scoped out for v1.
+- **Content-addressable storage** (content-hash as identity). Considered and rejected — see Decisions in `design.md`.
+- **Content-hash field on `ArtifactEntry`** for verification (not identity). Open question.
+- **Auto-registration from `Artifact.save`.** Steps that want registry coverage call `registry.register(...)` explicitly.
+- **Deletion / garbage collection.** No `delete(id, version)` at v1. The registry is append-only by convention.
+- **Multi-writer transactional semantics** (GCS CAS via `if-generation-match`, distributed locking, etc.).
+- **Listing APIs** (`list_ids()`, `list_versions(id)`). When a consumer needs one, we add it.
+- **Test helper context manager** (`use_registry(reg)`). Deferred — callers can write a local pytest fixture; we'll formalize one when a consumer asks.
+- **Per-region federation.** One registry root per process. Cross-region resolution is out of scope.
+- **Migrating existing `from_path` call sites.** `from_id` is purely additive; `from_path` stays.
+- **Path sharding in the manifest layout.** Considered and rejected at v1 — see Decisions in `design.md`.

--- a/.agents/projects/artifact_from_id/spec.md
+++ b/.agents/projects/artifact_from_id/spec.md
@@ -46,7 +46,10 @@ class ArtifactEntry(pydantic.BaseModel):
     """Artifact id in the form `<namespace>/<name>`. Validated by `validate_id`."""
 
     version: str
-    """User-supplied version string. Validated by `validate_version`."""
+    """CalVer version string `YYYY.MM.DD` with optional `-<modifier>` suffix
+       (e.g. `"2026.05.29"`, `"2026.10.01-fall-hero"`). Validated by `validate_version`,
+       which both pattern-matches AND constructs a `datetime.date` to reject impossible
+       calendar dates."""
 
     uri: str
     """Location of the artifact bytes — the `base_path` argument to `Artifact.from_path`.
@@ -177,7 +180,7 @@ def from_id(
     """Load an artifact by registry id + version.
 
     `id` and `version` are positional-only — callers always write `Artifact.from_id("ns/n",
-    "v3", ...)`, never `Artifact.from_id(version="v3", id="ns/n")`. This keeps every call
+    "2026.05.29", ...)`, never `Artifact.from_id(version="2026.05.29", id="ns/n")`. This keeps every call
     site readable and aligns with the `from_path` shape.
 
     Resolves `(id, version)` against `registry` (or the module-level default if
@@ -201,18 +204,36 @@ Both `register` and `lookup` validate their `id` and `version` arguments before 
 
 ```python
 ID_PATTERN: typing.Final = re.compile(r"^[A-Za-z0-9_.-]+/[A-Za-z0-9_.-]+$")
-VERSION_PATTERN: typing.Final = re.compile(r"^[A-Za-z0-9_.-]+$")
+VERSION_PATTERN: typing.Final = re.compile(
+    r"^(?P<year>\d{4})\.(?P<month>\d{2})\.(?P<day>\d{2})(?:-(?P<suffix>[A-Za-z0-9][A-Za-z0-9._-]*))?$"
+)
 
 def validate_id(id: str) -> tuple[str, str]:
     """Returns `(namespace, name)`. Raises `InvalidArtifactIdError` if the id is not
     exactly one `/`-separated pair of non-empty segments matching `ID_PATTERN`."""
 
 def validate_version(version: str) -> str:
-    """Returns the version unchanged. Raises `InvalidArtifactIdError` if it does not
-    match `VERSION_PATTERN`."""
+    """Returns the version unchanged on success. The version MUST be CalVer:
+    `YYYY.MM.DD` with optional `-<modifier>` suffix where the modifier begins with
+    an alphanumeric and contains only `[A-Za-z0-9._-]`.
+
+    Validation is two-step: first `VERSION_PATTERN` rejects shape mismatches; then the
+    `(year, month, day)` groups are passed to `datetime.date(...)` to reject impossible
+    calendar dates (e.g. `2026.02.30`, `2026.13.01`). Either check failing raises
+    `InvalidArtifactIdError`.
+
+    The modifier MUST NOT contain `/` — the whole version becomes a single path segment
+    in `{root}/{namespace}/{name}/{version}.json`, and embedded slashes would silently
+    create directory levels and break `lookup`. `/` is excluded by `VERSION_PATTERN`'s
+    suffix alphabet; this is called out here so it isn't lost in the regex.
+
+    Examples accepted: `"2026.05.29"`, `"2026.10.01-fall-hero"`, `"2026.10.01-rc1"`.
+    Examples rejected: `"v3"`, `"2026.5.29"` (no zero-pad), `"2026.02.30"` (impossible
+    date), `"2026.10.01-"` (empty suffix), `"2026.10.01--foo"` (suffix must start with
+    alphanumeric), `"2026.10.01-foo/bar"` (slash in modifier)."""
 ```
 
-The pattern is intentionally narrow — anything we allow becomes part of a GCS path, so we disallow `/`, whitespace, and shell metacharacters by construction. The validators are exposed (no leading underscore) so callers generating ids can pre-check.
+The id pattern is intentionally narrow — anything we allow becomes part of a GCS path, so the alphabet excludes `/`, whitespace, and shell metacharacters. CalVer for versions gives lexical sort = chronological sort (zero-padded date prefix) and embeds provenance. The validators are exposed (no leading underscore) so callers generating ids or versions can pre-check.
 
 ## Errors
 
@@ -257,10 +278,10 @@ One JSON file per `(id, version)`:
 - Contents: `ArtifactEntry.model_dump_json()` (UTF-8, no enclosing array).
 - Encoding: UTF-8 with no BOM. No trailing newline guarantee.
 
-Example (`gs://marin-us-central2/artifact_registry/datasets/fineweb-resiliparse/v3.json`):
+Example (`gs://marin-us-central2/artifact_registry/datasets/fineweb-resiliparse/2026.05.29.json`):
 
 ```json
-{"id": "datasets/fineweb-resiliparse", "version": "v3", "uri": "gs://marin-us-central2/documents/fineweb-resiliparse-8c2f3a"}
+{"id": "datasets/fineweb-resiliparse", "version": "2026.05.29", "uri": "gs://marin-us-central2/documents/fineweb-resiliparse-8c2f3a"}
 ```
 
 The `uri` is typically itself a content-addressed executor output (the `_8c2f3a` suffix is the executor step hash from `step_spec.py`). The registry layer adds logical naming on top of that existing content-addressed storage.


### PR DESCRIPTION
* design doc (1-pager) for path-independent artifact loading
* `Artifact.from_id(id, version, artifact_type, *, registry=None)` resolves via an `ArtifactRegistry` and delegates to existing `Artifact.from_path`
* new `ArtifactRegistry` protocol + default `FilesystemArtifactRegistry` backed by GCS / local fs via `rigging.filesystem`
  * one json file per entry at `{root}/{namespace}/{name}/{version}.json`
  * default root from `MARIN_ARTIFACT_REGISTRY` env, fallback `{marin_prefix()}/artifact_registry`
  * append-only at v1; `register` fails loudly on duplicate `(id, version)`
* ids strict `<namespace>/<name>`, versions user-supplied strings, both restricted to `[A-Za-z0-9_.-]`
* `ArtifactEntry` is a frozen pydantic record of `id`, `version`, `uri`
* mutable aliases (`latest`, `prod`) are a **non-goal**, not a deferral[^1]
* content-addressable storage considered and rejected[^2]
* files under `.agents/projects/artifact_from_id/`: `design.md` (1-pager), `research.md` (refs + prior-art digest), `spec.md` (public surface)
* discussion welcome — see Open Questions in `design.md`

[^1]: aliases drift implicitly on every registration, breaking reproducibility of old run logs without anyone touching them
[^2]: marin already content-addresses one layer down via executor step hashes; content-hash naming reintroduces the path-coupling problem this design exists to escape