### PR TITLE
[iris] Bump RPC handler pool to 1024 threads

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -142,7 +142,7 @@ _UNLIMITED = sys.maxsize
 # every other RPC, including the worker heartbeats that would unblock the
 # drain. Install a wider, named pool so a burst of slow handlers cannot
 # starve the rest.
-_RPC_HANDLER_THREADS = 64
+_RPC_HANDLER_THREADS = 1024
 
 
 def _install_rpc_executor(server: uvicorn.Server, *, max_workers: int) -> None:


### PR DESCRIPTION
Raise _RPC_HANDLER_THREADS from 64 to 1024 so a burst of slow sync handlers (e.g. launch_job blocking in _wait_until_job_drained) cannot starve worker heartbeats and other RPCs. The threads are cheap and idle; 64 still head-of-line blocked under load.