### PR TITLE
[iris] Reap hung py-spy profilers and clear ptrace group-stops

### DIFF
--- a/lib/iris/src/iris/cluster/providers/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/fake.py
@@ -757,6 +757,10 @@ class InMemoryK8sService:
         timeout: float | None = None,
     ) -> ExecResult:
         self._check_failure("exec")
+        # The profiler SIGCONT-recovery sweep is side-channel plumbing, not a
+        # profiler invocation, so it must not consume a queued profiler response.
+        if any("kill -CONT" in arg for arg in cmd):
+            return ExecResult(returncode=0, stdout="", stderr="")
         # Return queued response if available
         if self._exec_responses.get(pod_name):
             return self._exec_responses[pod_name].pop(0)

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -18,8 +18,9 @@ import re
 import shlex
 import threading
 import time
-from collections.abc import Sequence
+from collections.abc import Iterator, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -1091,8 +1092,13 @@ class _K8sProfileDispatch:
     pyspy_bin: str = "py-spy"
     memray_bin: str = "memray"
 
-    def tmp_path(self, suffix: str) -> str:
-        return f"/tmp/iris-profile.{suffix}"
+    @contextmanager
+    def scratch(self, *suffixes: str) -> Iterator[tuple[str, ...]]:
+        paths = tuple(f"/tmp/iris-profile.{suffix}" for suffix in suffixes)
+        try:
+            yield paths
+        finally:
+            self.kubectl.rm_files(self.pod_name, list(paths), container="task")
 
     def exec_profiler(self, cmd: list[str], *, sample_timeout: int) -> ExecResult:
         watchdog_cmd = wrap_with_kill_watchdog(cmd, sample_timeout)
@@ -1106,9 +1112,6 @@ class _K8sProfileDispatch:
 
     def read_file(self, path: str) -> bytes:
         return self.kubectl.read_file(self.pod_name, path, container="task")
-
-    def rm_files(self, paths: list[str]) -> None:
-        self.kubectl.rm_files(self.pod_name, paths, container="task")
 
     def _venv_exec(self, cmd: list[str], *, timeout: int) -> ExecResult:
         shell_cmd = ["bash", "-lc", f"source /app/.venv/bin/activate 2>/dev/null; {shlex.join(cmd)}"]

--- a/lib/iris/src/iris/cluster/providers/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/providers/k8s/tasks.py
@@ -44,14 +44,15 @@ from iris.cluster.providers.k8s.service import K8sService
 from iris.cluster.providers.k8s.types import K8sResource, KubectlError, KubectlLogLine, parse_k8s_quantity
 from iris.cluster.runtime.env import build_common_iris_env, normalize_workdir_relative_path
 from iris.cluster.runtime.profile import (
+    PROFILER_WATCHDOG_GRACE_SECONDS,
+    ExecResult,
     IrisProfile,
-    build_memray_attach_cmd,
-    build_memray_transform_cmd,
     build_profile_row,
-    build_pyspy_cmd,
-    build_pyspy_dump_cmd,
-    resolve_cpu_spec,
-    resolve_memory_spec,
+    capture_cpu,
+    capture_memory_attach,
+    capture_threads,
+    sigcont_sweep_argv,
+    wrap_with_kill_watchdog,
 )
 from iris.cluster.types import JobName, TaskAttempt, get_gpu_count
 from iris.cluster.worker.stats import build_task_stat
@@ -1076,6 +1077,51 @@ def _get_pod_node_name(kubectl: K8sService, pod_name: str) -> str:
     return pod.get("spec", {}).get("nodeName", "") or ""
 
 
+@dataclass(frozen=True)
+class _K8sProfileDispatch:
+    """``ProfileDispatch`` backed by ``kubectl exec`` into a task pod.
+
+    Profiler and transform commands run with the task venv activated. Profilers
+    run in the pod's isolated PID namespace, so ``exec_profiler`` applies the
+    kill-watchdog and SIGCONT recovery (see ``runtime.profile``).
+    """
+
+    kubectl: K8sService
+    pod_name: str
+    pyspy_bin: str = "py-spy"
+    memray_bin: str = "memray"
+
+    def tmp_path(self, suffix: str) -> str:
+        return f"/tmp/iris-profile.{suffix}"
+
+    def exec_profiler(self, cmd: list[str], *, sample_timeout: int) -> ExecResult:
+        watchdog_cmd = wrap_with_kill_watchdog(cmd, sample_timeout)
+        try:
+            return self._venv_exec(watchdog_cmd, timeout=sample_timeout + PROFILER_WATCHDOG_GRACE_SECONDS)
+        finally:
+            self._sigcont_sweep()
+
+    def exec(self, cmd: list[str], *, timeout: int) -> ExecResult:
+        return self._venv_exec(cmd, timeout=timeout)
+
+    def read_file(self, path: str) -> bytes:
+        return self.kubectl.read_file(self.pod_name, path, container="task")
+
+    def rm_files(self, paths: list[str]) -> None:
+        self.kubectl.rm_files(self.pod_name, paths, container="task")
+
+    def _venv_exec(self, cmd: list[str], *, timeout: int) -> ExecResult:
+        shell_cmd = ["bash", "-lc", f"source /app/.venv/bin/activate 2>/dev/null; {shlex.join(cmd)}"]
+        result = self.kubectl.exec(self.pod_name, shell_cmd, container="task", timeout=timeout)
+        return ExecResult(result.returncode, (result.stdout or "").encode("utf-8"), result.stderr or "")
+
+    def _sigcont_sweep(self) -> None:
+        try:
+            self.kubectl.exec(self.pod_name, sigcont_sweep_argv(), container="task", timeout=10)
+        except Exception as e:
+            logger.warning("SIGCONT sweep failed for pod %s: %s", self.pod_name, e)
+
+
 @dataclass
 class K8sTaskProvider:
     """Executes tasks as Kubernetes Pods without worker daemons.
@@ -1205,18 +1251,21 @@ class K8sTaskProvider:
         pod_name = _pod_name(JobName.from_wire(task_id), attempt_id)
         duration = request.duration_seconds or 10
         profile_type = request.profile_type
+        dispatch = _K8sProfileDispatch(self.kubectl, pod_name)
 
         try:
             if profile_type.HasField("threads"):
-                resp = self._profile_threads(pod_name, profile_type.threads)
+                data = capture_threads(dispatch, pid="1", include_locals=profile_type.threads.locals)
             elif profile_type.HasField("cpu"):
-                resp = self._profile_cpu(pod_name, profile_type.cpu, duration)
+                data = capture_cpu(dispatch, profile_type.cpu, duration, pid="1")
             elif profile_type.HasField("memory"):
-                resp = self._profile_memory(pod_name, profile_type.memory, duration)
+                data = capture_memory_attach(dispatch, profile_type.memory, duration, pid="1")
             else:
                 return job_pb2.ProfileTaskResponse(error="Unknown profile type")
         except Exception as e:
             return job_pb2.ProfileTaskResponse(error=str(e))
+
+        resp = job_pb2.ProfileTaskResponse(profile_data=data)
 
         if self.profile_table is not None and resp.profile_data:
             pod_node_name = _get_pod_node_name(self.kubectl, pod_name)
@@ -1261,66 +1310,6 @@ class K8sTaskProvider:
     def get_cluster_status(self) -> controller_pb2.Controller.GetKubernetesClusterStatusResponse:
         """Return cluster status from the latest sync() snapshot. No kubectl calls."""
         return self._cluster_state.to_status_response(self.namespace)
-
-    # -------------------------------------------------------------------------
-    # Profiling helpers
-    # -------------------------------------------------------------------------
-
-    def _kubectl_exec_shell(self, pod_name: str, cmd: str, timeout: float | None = None) -> str:
-        """Execute a shell command in a task pod with venv activation.
-
-        Returns stdout. Raises RuntimeError on non-zero exit.
-        """
-        shell_cmd = ["bash", "-lc", f"source /app/.venv/bin/activate 2>/dev/null; {cmd}"]
-        result = self.kubectl.exec(pod_name, shell_cmd, container="task", timeout=timeout)
-        if result.returncode != 0:
-            raise RuntimeError(f"kubectl exec failed (exit {result.returncode}): {result.stderr}")
-        return result.stdout
-
-    def _profile_threads(self, pod_name: str, threads_config: job_pb2.ThreadsProfile) -> job_pb2.ProfileTaskResponse:
-        """Get thread stacks via py-spy dump."""
-        cmd = shlex.join(build_pyspy_dump_cmd("1", include_locals=threads_config.locals))
-        stdout = self._kubectl_exec_shell(pod_name, cmd, timeout=30)
-        return job_pb2.ProfileTaskResponse(profile_data=stdout.encode("utf-8"))
-
-    def _profile_cpu(self, pod_name: str, cpu_config: job_pb2.CpuProfile, duration: int) -> job_pb2.ProfileTaskResponse:
-        """Record CPU profile via py-spy."""
-        spec = resolve_cpu_spec(cpu_config, duration, pid="1")
-        output_path = f"/tmp/iris-profile.{spec.ext}"
-        cmd = shlex.join(build_pyspy_cmd(spec, py_spy_bin="py-spy", output_path=output_path))
-        self._kubectl_exec_shell(pod_name, cmd, timeout=duration + 30)
-        data = self.kubectl.read_file(pod_name, output_path, container="task")
-        self.kubectl.rm_files(pod_name, [output_path], container="task")
-        return job_pb2.ProfileTaskResponse(profile_data=data)
-
-    def _profile_memory(
-        self, pod_name: str, memory_config: job_pb2.MemoryProfile, duration: int
-    ) -> job_pb2.ProfileTaskResponse:
-        """Record memory profile via memray."""
-        spec = resolve_memory_spec(memory_config, duration, pid="1")
-        trace_path = "/tmp/iris-memray.bin"
-        output_path = f"/tmp/iris-memray.{spec.ext}"
-
-        attach_cmd = shlex.join(build_memray_attach_cmd(spec, memray_bin="memray", trace_path=trace_path))
-        self._kubectl_exec_shell(pod_name, attach_cmd, timeout=duration + 30)
-
-        if spec.is_raw:
-            data = self.kubectl.read_file(pod_name, trace_path, container="task")
-            self.kubectl.rm_files(pod_name, [trace_path], container="task")
-            return job_pb2.ProfileTaskResponse(profile_data=data)
-
-        transform_cmd = shlex.join(
-            build_memray_transform_cmd(spec, memray_bin="memray", trace_path=trace_path, output_path=output_path)
-        )
-        transform_stdout = self._kubectl_exec_shell(pod_name, transform_cmd, timeout=30)
-
-        if spec.output_is_file:
-            data = self.kubectl.read_file(pod_name, output_path, container="task")
-        else:
-            data = transform_stdout.encode("utf-8")
-
-        self.kubectl.rm_files(pod_name, [trace_path, output_path], container="task")
-        return job_pb2.ProfileTaskResponse(profile_data=data)
 
     # -------------------------------------------------------------------------
     # Internal helpers

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -21,7 +21,8 @@ import subprocess
 import threading
 import time
 import uuid
-from collections.abc import Callable
+from collections.abc import Callable, Iterator
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
 from pathlib import Path
@@ -93,8 +94,13 @@ class _DockerProfileDispatch:
     pyspy_bin: str = "/app/.venv/bin/py-spy"
     memray_bin: str = "/app/.venv/bin/memray"
 
-    def tmp_path(self, suffix: str) -> str:
-        return f"/tmp/iris-profile-{uuid.uuid4().hex[:8]}.{suffix}"
+    @contextmanager
+    def scratch(self, *suffixes: str) -> Iterator[tuple[str, ...]]:
+        paths = tuple(f"/tmp/iris-profile-{uuid.uuid4().hex[:8]}.{suffix}" for suffix in suffixes)
+        try:
+            yield paths
+        finally:
+            subprocess.run(["docker", "exec", self.container_id, "rm", "-f", *paths], capture_output=True, timeout=10)
 
     def exec_profiler(self, cmd: list[str], *, sample_timeout: int) -> ExecResult:
         watchdog_cmd = wrap_with_kill_watchdog(cmd, sample_timeout)
@@ -114,9 +120,6 @@ class _DockerProfileDispatch:
         if result.returncode != 0:
             raise RuntimeError(f"Failed to read {path}: {result.stderr.decode('utf-8', 'replace')}")
         return result.stdout
-
-    def rm_files(self, paths: list[str]) -> None:
-        subprocess.run(["docker", "exec", self.container_id, "rm", "-f", *paths], capture_output=True, timeout=10)
 
     def _sigcont_sweep(self) -> None:
         try:

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -31,12 +31,13 @@ from rigging.timing import Timestamp
 from iris.cluster.bundle import BundleStore
 from iris.cluster.runtime.env import write_workdir_files
 from iris.cluster.runtime.profile import (
-    build_memray_attach_cmd,
-    build_memray_transform_cmd,
-    build_pyspy_cmd,
-    build_pyspy_dump_cmd,
-    resolve_cpu_spec,
-    resolve_memory_spec,
+    PROFILER_WATCHDOG_GRACE_SECONDS,
+    ExecResult,
+    capture_cpu,
+    capture_memory_attach,
+    capture_threads,
+    sigcont_sweep_argv,
+    wrap_with_kill_watchdog,
 )
 from iris.cluster.runtime.types import (
     ContainerConfig,
@@ -77,6 +78,56 @@ def _is_docker_infra_error(stderr: str) -> bool:
     """Return True if *stderr* matches a known infrastructure failure pattern."""
     stderr_lower = stderr.lower()
     return any(p.lower() in stderr_lower for p in _INFRA_ERROR_PATTERNS)
+
+
+@dataclass(frozen=True)
+class _DockerProfileDispatch:
+    """``ProfileDispatch`` backed by ``docker exec`` into a task container.
+
+    Profilers run in the container's isolated PID namespace, so ``exec_profiler``
+    applies the kill-watchdog and SIGCONT recovery (see ``runtime.profile``);
+    ``exec`` runs non-attaching transform/read commands directly.
+    """
+
+    container_id: str
+    pyspy_bin: str = "/app/.venv/bin/py-spy"
+    memray_bin: str = "/app/.venv/bin/memray"
+
+    def tmp_path(self, suffix: str) -> str:
+        return f"/tmp/iris-profile-{uuid.uuid4().hex[:8]}.{suffix}"
+
+    def exec_profiler(self, cmd: list[str], *, sample_timeout: int) -> ExecResult:
+        watchdog_cmd = wrap_with_kill_watchdog(cmd, sample_timeout)
+        try:
+            return self.exec(watchdog_cmd, timeout=sample_timeout + PROFILER_WATCHDOG_GRACE_SECONDS)
+        finally:
+            self._sigcont_sweep()
+
+    def exec(self, cmd: list[str], *, timeout: int) -> ExecResult:
+        result = subprocess.run(
+            ["docker", "exec", self.container_id, *cmd], capture_output=True, text=True, timeout=timeout
+        )
+        return ExecResult(result.returncode, (result.stdout or "").encode("utf-8"), result.stderr or "")
+
+    def read_file(self, path: str) -> bytes:
+        result = subprocess.run(["docker", "exec", self.container_id, "cat", path], capture_output=True, timeout=5)
+        if result.returncode != 0:
+            raise RuntimeError(f"Failed to read {path}: {result.stderr.decode('utf-8', 'replace')}")
+        return result.stdout
+
+    def rm_files(self, paths: list[str]) -> None:
+        subprocess.run(["docker", "exec", self.container_id, "rm", "-f", *paths], capture_output=True, timeout=10)
+
+    def _sigcont_sweep(self) -> None:
+        try:
+            subprocess.run(
+                ["docker", "exec", self.container_id, *sigcont_sweep_argv()],
+                capture_output=True,
+                text=True,
+                timeout=10,
+            )
+        except (subprocess.SubprocessError, OSError) as e:
+            logger.warning("SIGCONT sweep failed for container %s: %s", self.container_id, e)
 
 
 # Network sysctl tuning for containers with their own network namespace (#3066).
@@ -498,100 +549,15 @@ exec {quoted_cmd}
         if not container_id:
             raise RuntimeError("Cannot profile: no running container")
 
-        profile_id = uuid.uuid4().hex[:8]
-
+        dispatch = _DockerProfileDispatch(container_id)
         if profile_type.HasField("threads"):
-            return self._profile_threads(container_id, include_locals=profile_type.threads.locals)
+            return capture_threads(dispatch, pid="1", include_locals=profile_type.threads.locals)
         elif profile_type.HasField("cpu"):
-            return self._profile_cpu(container_id, duration_seconds, profile_type.cpu, profile_id)
+            return capture_cpu(dispatch, profile_type.cpu, duration_seconds, pid="1")
         elif profile_type.HasField("memory"):
-            return self._profile_memory(container_id, duration_seconds, profile_type.memory, profile_id)
+            return capture_memory_attach(dispatch, profile_type.memory, duration_seconds, pid="1")
         else:
             raise RuntimeError("ProfileType must specify cpu, memory, or threads profiler")
-
-    def _profile_threads(self, container_id: str, *, include_locals: bool = False) -> bytes:
-        """Collect thread stacks from the container using py-spy dump."""
-        cmd = build_pyspy_dump_cmd(pid="1", py_spy_bin="/app/.venv/bin/py-spy", include_locals=include_locals)
-        result = self._docker_exec(container_id, cmd, capture_output=True, text=True, timeout=30)
-        if result.returncode != 0:
-            raise RuntimeError(f"py-spy dump failed: {result.stderr}")
-        return result.stdout.encode("utf-8")
-
-    def _docker_exec(self, container_id: str, cmd: list[str], **kwargs) -> subprocess.CompletedProcess:
-        return subprocess.run(["docker", "exec", container_id, *cmd], **kwargs)
-
-    def _docker_read_file(self, container_id: str, path: str) -> bytes:
-        result = self._docker_exec(container_id, ["cat", path], capture_output=True, timeout=5)
-        if result.returncode != 0:
-            raise RuntimeError(f"Failed to read {path}: {result.stderr}")
-        return result.stdout
-
-    def _docker_rm_files(self, container_id: str, paths: list[str]) -> None:
-        self._docker_exec(container_id, ["rm", "-f", *paths], capture_output=True, timeout=10)
-
-    def _profile_cpu(
-        self, container_id: str, duration_seconds: int, cpu_config: "job_pb2.CpuProfile", profile_id: str
-    ) -> bytes:
-        """Profile CPU using py-spy."""
-        spec = resolve_cpu_spec(cpu_config, duration_seconds, pid="1")
-        output_path = f"/tmp/profile-cpu-{profile_id}.{spec.ext}"
-        cmd = build_pyspy_cmd(spec, py_spy_bin="/app/.venv/bin/py-spy", output_path=output_path)
-
-        logger.info(
-            "CPU profiling container %s for %ds (format=%s, rate=%dHz)",
-            container_id,
-            duration_seconds,
-            spec.py_spy_format,
-            spec.rate_hz,
-        )
-        try:
-            # py-spy needs extra headroom beyond the sample duration for writing output
-            result = self._docker_exec(container_id, cmd, capture_output=True, text=True, timeout=duration_seconds + 30)
-            if result.returncode != 0:
-                raise RuntimeError(f"py-spy failed: {result.stderr}")
-            return self._docker_read_file(container_id, output_path)
-        finally:
-            self._docker_rm_files(container_id, [output_path])
-
-    def _profile_memory(
-        self, container_id: str, duration_seconds: int, memory_config: "job_pb2.MemoryProfile", profile_id: str
-    ) -> bytes:
-        """Profile memory using memray."""
-        spec = resolve_memory_spec(memory_config, duration_seconds, pid="1")
-        memray_bin = "/app/.venv/bin/memray"
-        trace_path = f"/tmp/memray-trace-{profile_id}.bin"
-        output_path = f"/tmp/memray-output-{profile_id}.{spec.ext}"
-
-        attach_cmd = build_memray_attach_cmd(spec, memray_bin, trace_path)
-
-        logger.info(
-            "Memory profiling container %s for %ds (format=%s, leaks=%s)",
-            container_id,
-            duration_seconds,
-            spec.reporter,
-            spec.leaks,
-        )
-        try:
-            result = self._docker_exec(
-                container_id, attach_cmd, capture_output=True, text=True, timeout=duration_seconds + 10
-            )
-            if result.returncode != 0:
-                raise RuntimeError(f"memray attach failed: {result.stderr}")
-
-            if spec.is_raw:
-                return self._docker_read_file(container_id, trace_path)
-
-            transform_cmd = build_memray_transform_cmd(spec, memray_bin, trace_path, output_path)
-            result = self._docker_exec(container_id, transform_cmd, capture_output=True, text=True, timeout=30)
-            if result.returncode != 0:
-                raise RuntimeError(f"memray {spec.reporter} failed: {result.stderr}")
-
-            if spec.output_is_file:
-                return self._docker_read_file(container_id, output_path)
-            else:
-                return result.stdout.encode("utf-8")
-        finally:
-            self._docker_rm_files(container_id, [trace_path, output_path])
 
     def cleanup(self) -> None:
         """Remove the run container and clean up resources."""

--- a/lib/iris/src/iris/cluster/runtime/process.py
+++ b/lib/iris/src/iris/cluster/runtime/process.py
@@ -35,12 +35,10 @@ from pathlib import Path
 from iris.cluster.bundle import BundleStore
 from iris.cluster.runtime.env import write_workdir_files
 from iris.cluster.runtime.profile import (
-    build_memray_attach_cmd,
-    build_memray_transform_cmd,
-    build_pyspy_cmd,
-    resolve_cpu_spec,
-    resolve_memory_spec,
-    run_pyspy_dump,
+    LocalProfileDispatch,
+    capture_cpu,
+    capture_memory_attach,
+    capture_threads,
 )
 from iris.cluster.runtime.types import (
     ContainerConfig,
@@ -508,97 +506,48 @@ class ProcessContainerHandle:
         return 0
 
     def profile(self, duration_seconds: int, profile_type: job_pb2.ProfileType) -> bytes:
-        """Profile the running process using py-spy (CPU), memray (memory), or thread dump."""
+        """Profile the running process using py-spy (CPU), memray (memory), or thread dump.
 
+        Runs profilers as host subprocesses sharing this worker's PID namespace.
+        Python's own subprocess timeout reaps a hung profiler, and the profiled
+        child's process group is SIGCONT'd afterward to clear a py-spy group-stop
+        (see ``LocalProfileDispatch``). CPU/memory fall back to a stub when the
+        profiler tool is missing; thread dumps propagate errors.
+        """
         if not self._container or not self._container._process:
             raise RuntimeError("Cannot profile: no running process")
 
+        pid = self._container._process.pid
+        dispatch = LocalProfileDispatch(resume_pid=pid)
+
         if profile_type.HasField("threads"):
-            pid = str(self._container._process.pid)
-            return run_pyspy_dump(pid, include_locals=profile_type.threads.locals)
+            return capture_threads(dispatch, pid=str(pid), include_locals=profile_type.threads.locals)
         elif profile_type.HasField("cpu"):
-            return self._profile_cpu(duration_seconds, profile_type.cpu)
+            return self._profile_cpu(dispatch, pid, duration_seconds, profile_type.cpu)
         elif profile_type.HasField("memory"):
-            return self._profile_memory(duration_seconds, profile_type.memory)
+            return self._profile_memory(dispatch, pid, duration_seconds, profile_type.memory)
         else:
             raise RuntimeError("ProfileType must specify cpu, memory, or threads profiler")
 
-    def _profile_cpu(self, duration_seconds: int, cpu_config: job_pb2.CpuProfile) -> bytes:
-        """Profile CPU using py-spy, with fallback stub."""
-        pid = self._container._process.pid
-        spec = resolve_cpu_spec(cpu_config, duration_seconds, pid=str(pid))
-
-        output_path = None
+    def _profile_cpu(
+        self, dispatch: LocalProfileDispatch, pid: int, duration_seconds: int, cpu_config: job_pb2.CpuProfile
+    ) -> bytes:
+        """Profile CPU using py-spy, falling back to a stub when py-spy is unavailable."""
         try:
-            with tempfile.NamedTemporaryFile(suffix=f".{spec.ext}", delete=False) as f:
-                output_path = f.name
+            return capture_cpu(dispatch, cpu_config, duration_seconds, pid=str(pid))
+        except (FileNotFoundError, subprocess.TimeoutExpired, PermissionError, RuntimeError) as e:
+            logger.warning("py-spy CPU profile failed for PID %s (%s); falling back to stub", pid, e)
+            return _cpu_profile_stub(cpu_config.format)
 
-            cmd = build_pyspy_cmd(spec, py_spy_bin="py-spy", output_path=output_path)
-            result = subprocess.run(cmd, capture_output=True, text=True, timeout=duration_seconds + 30)
-            if result.returncode == 0:
-                return Path(output_path).read_bytes()
-        except FileNotFoundError:
-            logger.warning("py-spy not found; falling back to stub profile for PID %s", pid)
-        except subprocess.TimeoutExpired:
-            logger.warning("py-spy timed out; falling back to stub profile for PID %s", pid)
-        except PermissionError:
-            logger.warning("py-spy lacks permission to attach; falling back to stub profile for PID %s", pid)
-        finally:
-            if output_path is not None:
-                Path(output_path).unlink(missing_ok=True)
-
-        return _cpu_profile_stub(cpu_config.format)
-
-    def _profile_memory(self, duration_seconds: int, memory_config: job_pb2.MemoryProfile) -> bytes:
-        """Profile memory using memray, with fallback stub."""
-        pid = self._container._process.pid
-        spec = resolve_memory_spec(memory_config, duration_seconds, pid=str(pid))
-
-        trace_path = None
-        output_path = None
+    def _profile_memory(
+        self, dispatch: LocalProfileDispatch, pid: int, duration_seconds: int, memory_config: job_pb2.MemoryProfile
+    ) -> bytes:
+        """Profile memory using memray, falling back to a stub when memray is unavailable."""
         try:
-            with tempfile.NamedTemporaryFile(suffix=".bin", delete=False) as f:
-                trace_path = f.name
-
-            attach_cmd = build_memray_attach_cmd(spec, memray_bin="memray", trace_path=trace_path)
-            result = subprocess.run(attach_cmd, capture_output=True, text=True, timeout=duration_seconds + 10)
-            if result.returncode != 0:
-                raise RuntimeError(f"memray attach failed: {result.stderr}")
-
-            if spec.is_raw:
-                return Path(trace_path).read_bytes()
-
-            if spec.output_is_file:
-                with tempfile.NamedTemporaryFile(suffix=f".{spec.ext}", delete=False) as f:
-                    output_path = f.name
-
-            transform_cmd = build_memray_transform_cmd(
-                spec, memray_bin="memray", trace_path=trace_path, output_path=output_path or ""
-            )
-            result = subprocess.run(transform_cmd, capture_output=True, text=True, timeout=30)
-            if result.returncode != 0:
-                raise RuntimeError(f"memray {spec.reporter} failed: {result.stderr}")
-
-            if spec.output_is_file:
-                return Path(output_path).read_bytes()
-            else:
-                return result.stdout.encode("utf-8")
-
-        except FileNotFoundError:
-            logger.warning("memray not found; falling back to stub profile for PID %s", pid)
-        except subprocess.TimeoutExpired:
-            logger.warning("memray timed out; falling back to stub profile for PID %s", pid)
-        except PermissionError:
-            logger.warning("memray lacks permission to attach; falling back to stub profile for PID %s", pid)
-        except RuntimeError:
-            logger.warning("memray failed for PID %s; falling back to stub", pid, exc_info=True)
-        finally:
-            if trace_path is not None:
-                Path(trace_path).unlink(missing_ok=True)
-            if output_path is not None:
-                Path(output_path).unlink(missing_ok=True)
-
-        return _memory_profile_stub(memory_config.format)
+            return capture_memory_attach(dispatch, memory_config, duration_seconds, pid=str(pid))
+        except (FileNotFoundError, subprocess.TimeoutExpired, PermissionError, RuntimeError) as e:
+            logger.warning("memray memory profile failed for PID %s (%s); falling back to stub", pid, e)
+            return _memory_profile_stub(memory_config.format)
 
     def cleanup(self) -> None:
         """Kill the subprocess and clean up resources."""

--- a/lib/iris/src/iris/cluster/runtime/profile.py
+++ b/lib/iris/src/iris/cluster/runtime/profile.py
@@ -16,14 +16,16 @@ from __future__ import annotations
 import logging
 import os
 import shutil
+import signal
 import subprocess
+import sys
 import tempfile
 import time
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
 from pathlib import Path
-from typing import ClassVar
+from typing import ClassVar, Protocol
 
 from iris.rpc import job_pb2
 
@@ -209,6 +211,216 @@ def build_pyspy_dump_cmd(
     return cmd
 
 
+# Workaround for https://github.com/benfred/py-spy/issues/846: py-spy dump --subprocesses
+# exits non-zero when it walks into a non-Python child (e.g. wandb-core, a Go binary), even
+# though the parent dump already went to stdout. Drop this once py-spy fixes the upstream bug.
+_PYSPY_NON_PYTHON_CHILD_ERROR = "Failed to find python version from target process"
+
+# Headroom a healthy profiler needs beyond the sample window to attach and write
+# its output. These set the in-environment watchdog deadline; the dispatcher's
+# own client-side timeout is a few seconds longer (see PROFILER_WATCHDOG_GRACE_SECONDS).
+CPU_WRITE_HEADROOM_SECONDS = 30
+MEMRAY_ATTACH_HEADROOM_SECONDS = 30
+THREAD_DUMP_TIMEOUT_SECONDS = 30
+
+
+# ---------------------------------------------------------------------------
+# ptrace profiler safety: watchdog + group-stop recovery
+# ---------------------------------------------------------------------------
+# py-spy and ``memray attach`` attach to the target via ptrace, which pauses it
+# while sampling. Two failure modes can freeze the target indefinitely when the
+# profiler is launched into an isolated PID namespace over a client connection
+# (``docker exec`` / ``kubectl exec``):
+#
+#   1. Orphaned profiler. A client-side ``subprocess.run(timeout=...)`` only
+#      kills the local exec *client*; the in-namespace profiler keeps running
+#      and keeps the target ptrace-stopped (observed: zephyr shards stalled for
+#      hours). Wrapping the profiler in GNU ``timeout --signal=KILL`` makes the
+#      container/pod reap it regardless of the client.
+#
+#   2. Lingering group-stop. py-spy attaches via ``PTRACE_ATTACH``, which
+#      delivers SIGSTOP. Per ptrace(2), a SIGKILL'd tracer only auto-resumes a
+#      *ptrace*-stopped tracee, not a *group*-stopped one, so a profiler that
+#      dies or exits before detaching cleanly can leave the target in
+#      job-control stop (``T``), needing SIGCONT (benfred/py-spy#390, still seen
+#      on recent releases).
+#
+# Both are specific to the exec-into-namespace model and are handled inside the
+# namespaced dispatchers' ``exec_profiler``. A direct ``subprocess.run`` profiler
+# (process runtime, controller self-profile) is reaped by Python's own timeout
+# and shares the host PID namespace, so it needs no ``timeout`` wrapper and
+# recovers (if at all) by SIGCONT-ing the profiled child's process group.
+PROFILER_WATCHDOG_GRACE_SECONDS = 5
+
+
+def wrap_with_kill_watchdog(cmd: list[str], sample_timeout: int) -> list[str]:
+    """Prefix a profiler command with ``timeout --signal=KILL`` so a hung profiler self-reaps."""
+    return ["timeout", "--signal=KILL", str(sample_timeout), *cmd]
+
+
+def sigcont_sweep_argv() -> list[str]:
+    """Command that SIGCONTs every process in the (container/pod) PID namespace.
+
+    Clears a group-stop a ptrace profiler may have left. Sweeps ``/proc`` so it
+    needs no procps, reaches ``--subprocesses`` children, and signals PID 1
+    (which the ``kill -1`` broadcast deliberately skips). SIGCONT is a no-op on
+    running processes. Only safe where the PID namespace is isolated.
+    """
+    return ["sh", "-c", 'for p in /proc/[0-9]*; do kill -CONT "${p##*/}" 2>/dev/null; done; true']
+
+
+@dataclass(frozen=True)
+class ExecResult:
+    """Normalized result of running a command in a target environment."""
+
+    returncode: int
+    stdout: bytes
+    stderr: str
+
+
+class ProfileDispatch(Protocol):
+    """Where/how a profiling backend runs commands and moves files.
+
+    The ``capture_*`` functions own *what* to run (which py-spy/memray command,
+    when to read output, how to interpret exit codes); a dispatch implementation
+    owns *where* it runs — ``docker exec``, ``kubectl exec``, or a host
+    subprocess. ``exec_profiler`` runs a ptrace-attaching profiler and is
+    responsible for reaping a hung profiler and clearing any group-stop it leaves
+    (see the module notes above); ``exec`` runs non-attaching helpers (e.g.
+    ``memray`` transform) that never touch the live target.
+    """
+
+    pyspy_bin: str
+    memray_bin: str
+
+    def tmp_path(self, suffix: str) -> str:
+        """Return a fresh temp path (with ``.suffix``) writable by the profiler."""
+        ...
+
+    def exec_profiler(self, cmd: list[str], *, sample_timeout: int) -> ExecResult:
+        """Run a ptrace-attaching profiler, reaping it and clearing any group-stop."""
+        ...
+
+    def exec(self, cmd: list[str], *, timeout: int) -> ExecResult:
+        """Run a non-attaching helper command."""
+        ...
+
+    def read_file(self, path: str) -> bytes:
+        """Read a file produced by a profiler in the target environment."""
+        ...
+
+    def rm_files(self, paths: list[str]) -> None:
+        """Best-effort removal of temp files in the target environment."""
+        ...
+
+
+def capture_cpu(
+    dispatch: ProfileDispatch,
+    cpu_config: job_pb2.CpuProfile,
+    duration_seconds: int,
+    *,
+    pid: str,
+    subprocesses: bool = True,
+) -> bytes:
+    """Record a CPU profile with py-spy and return the encoded output bytes."""
+    spec = resolve_cpu_spec(cpu_config, duration_seconds, pid=pid)
+    output_path = dispatch.tmp_path(spec.ext)
+    cmd = build_pyspy_cmd(spec, dispatch.pyspy_bin, output_path, subprocesses=subprocesses)
+    try:
+        result = dispatch.exec_profiler(cmd, sample_timeout=duration_seconds + CPU_WRITE_HEADROOM_SECONDS)
+        if result.returncode != 0:
+            raise RuntimeError(f"py-spy record failed (exit {result.returncode}): {result.stderr}")
+        return dispatch.read_file(output_path)
+    finally:
+        dispatch.rm_files([output_path])
+
+
+def capture_threads(
+    dispatch: ProfileDispatch, *, pid: str, include_locals: bool = False, subprocesses: bool = True
+) -> bytes:
+    """Collect thread stacks with py-spy dump and return the raw stdout bytes."""
+    cmd = build_pyspy_dump_cmd(pid, dispatch.pyspy_bin, include_locals=include_locals, subprocesses=subprocesses)
+    result = dispatch.exec_profiler(cmd, sample_timeout=THREAD_DUMP_TIMEOUT_SECONDS)
+    if result.returncode != 0:
+        partial_ok = subprocesses and bool(result.stdout.strip()) and _PYSPY_NON_PYTHON_CHILD_ERROR in result.stderr
+        if not partial_ok:
+            raise RuntimeError(f"py-spy dump failed (exit {result.returncode}): {result.stderr}")
+    return result.stdout
+
+
+def capture_memory_attach(
+    dispatch: ProfileDispatch, memory_config: job_pb2.MemoryProfile, duration_seconds: int, *, pid: str
+) -> bytes:
+    """Profile memory by attaching memray to a running process, then transforming the trace."""
+    spec = resolve_memory_spec(memory_config, duration_seconds, pid=pid)
+    trace_path = dispatch.tmp_path("bin")
+    output_path = None
+    try:
+        attach_cmd = build_memray_attach_cmd(spec, dispatch.memray_bin, trace_path)
+        result = dispatch.exec_profiler(attach_cmd, sample_timeout=duration_seconds + MEMRAY_ATTACH_HEADROOM_SECONDS)
+        if result.returncode != 0:
+            raise RuntimeError(f"memray attach failed (exit {result.returncode}): {result.stderr}")
+
+        if spec.is_raw:
+            return dispatch.read_file(trace_path)
+
+        if spec.output_is_file:
+            output_path = dispatch.tmp_path(spec.ext)
+
+        transform_cmd = build_memray_transform_cmd(spec, dispatch.memray_bin, trace_path, output_path or "")
+        result = dispatch.exec(transform_cmd, timeout=30)
+        if result.returncode != 0:
+            raise RuntimeError(f"memray {spec.reporter} failed (exit {result.returncode}): {result.stderr}")
+
+        return dispatch.read_file(output_path) if spec.output_is_file else result.stdout
+    finally:
+        dispatch.rm_files([trace_path, *([output_path] if output_path else [])])
+
+
+@dataclass
+class LocalProfileDispatch:
+    """Run profilers as host subprocesses, sharing the host PID namespace.
+
+    Python's own subprocess timeout reaps a hung profiler (no orphan), so no
+    ``timeout`` wrapper is used. ``resume_pid`` (when set) is SIGCONT'd by
+    process group after each attach to clear a py-spy group-stop; self-profiling
+    leaves it ``None`` because a group-stopped process cannot signal itself.
+    """
+
+    pyspy_bin: str = "py-spy"
+    memray_bin: str = "memray"
+    resume_pid: int | None = None
+
+    def tmp_path(self, suffix: str) -> str:
+        with tempfile.NamedTemporaryFile(suffix=f".{suffix}", delete=False) as f:
+            return f.name
+
+    def exec_profiler(self, cmd: list[str], *, sample_timeout: int) -> ExecResult:
+        try:
+            return self.exec(cmd, timeout=sample_timeout)
+        finally:
+            self._resume()
+
+    def exec(self, cmd: list[str], *, timeout: int) -> ExecResult:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=timeout)
+        return ExecResult(result.returncode, (result.stdout or "").encode("utf-8"), result.stderr or "")
+
+    def read_file(self, path: str) -> bytes:
+        return Path(path).read_bytes()
+
+    def rm_files(self, paths: list[str]) -> None:
+        for path in paths:
+            Path(path).unlink(missing_ok=True)
+
+    def _resume(self) -> None:
+        if self.resume_pid is None or sys.platform != "linux":
+            return
+        try:
+            os.killpg(os.getpgid(self.resume_pid), signal.SIGCONT)
+        except (ProcessLookupError, PermissionError):
+            pass
+
+
 def profile_local_process(duration_seconds: int, profile_type: job_pb2.ProfileType) -> bytes:
     """Profile the current interpreter process using py-spy or memray.
 
@@ -216,55 +428,21 @@ def profile_local_process(duration_seconds: int, profile_type: job_pb2.ProfileTy
     Raises RuntimeError immediately if the required tool is not installed.
     """
     pid = str(os.getpid())
+    # Self-profiling shares this process's PID namespace and cannot SIGCONT
+    # itself, so resume_pid stays None and --subprocesses is off.
+    dispatch = LocalProfileDispatch()
 
     if profile_type.HasField("threads"):
         _check_tool("py-spy")
-        return run_pyspy_dump(pid, include_locals=profile_type.threads.locals, subprocesses=False)
+        return capture_threads(dispatch, pid=pid, include_locals=profile_type.threads.locals, subprocesses=False)
     elif profile_type.HasField("cpu"):
         _check_tool("py-spy")
-        return _run_pyspy_record(pid, duration_seconds, profile_type.cpu)
+        return capture_cpu(dispatch, profile_type.cpu, duration_seconds, pid=pid, subprocesses=False)
     elif profile_type.HasField("memory"):
         _check_tool("memray")
         return _run_memray_profile(pid, duration_seconds, profile_type.memory)
     else:
         raise RuntimeError("ProfileType must specify cpu, memory, or threads profiler")
-
-
-# Workaround for https://github.com/benfred/py-spy/issues/846: py-spy dump --subprocesses
-# exits non-zero when it walks into a non-Python child (e.g. wandb-core, a Go binary), even
-# though the parent dump already went to stdout. Drop this once py-spy fixes the upstream bug.
-_PYSPY_NON_PYTHON_CHILD_ERROR = "Failed to find python version from target process"
-
-
-def run_pyspy_dump(
-    pid: str, py_spy_bin: str = "py-spy", *, include_locals: bool = False, subprocesses: bool = True
-) -> bytes:
-    """Run py-spy dump to collect thread stacks from a process."""
-    cmd = build_pyspy_dump_cmd(pid, py_spy_bin, include_locals=include_locals, subprocesses=subprocesses)
-    result = subprocess.run(cmd, capture_output=True, text=True, timeout=30)
-    if result.returncode != 0:
-        partial_ok = subprocesses and bool(result.stdout.strip()) and _PYSPY_NON_PYTHON_CHILD_ERROR in result.stderr
-        if not partial_ok:
-            raise RuntimeError(f"py-spy dump failed: {result.stderr}")
-    return result.stdout.encode("utf-8")
-
-
-def _run_pyspy_record(pid: str, duration_seconds: int, cpu_config: job_pb2.CpuProfile) -> bytes:
-    """Run py-spy record against a local process and return the output."""
-    spec = resolve_cpu_spec(cpu_config, duration_seconds, pid=pid)
-    output_path = None
-    try:
-        with tempfile.NamedTemporaryFile(suffix=f".{spec.ext}", delete=False) as f:
-            output_path = f.name
-
-        cmd = build_pyspy_cmd(spec, py_spy_bin="py-spy", output_path=output_path, subprocesses=False)
-        result = subprocess.run(cmd, capture_output=True, text=True, timeout=duration_seconds + 30)
-        if result.returncode != 0:
-            raise RuntimeError(f"py-spy record failed: {result.stderr}")
-        return Path(output_path).read_bytes()
-    finally:
-        if output_path is not None:
-            Path(output_path).unlink(missing_ok=True)
 
 
 def _run_memray_profile(pid: str, duration_seconds: int, memory_config: job_pb2.MemoryProfile) -> bytes:

--- a/lib/iris/src/iris/cluster/runtime/profile.py
+++ b/lib/iris/src/iris/cluster/runtime/profile.py
@@ -21,6 +21,8 @@ import subprocess
 import sys
 import tempfile
 import time
+from collections.abc import Iterator
+from contextlib import AbstractContextManager, contextmanager
 from dataclasses import dataclass
 from datetime import UTC, datetime
 from enum import StrEnum
@@ -293,8 +295,8 @@ class ProfileDispatch(Protocol):
     pyspy_bin: str
     memray_bin: str
 
-    def tmp_path(self, suffix: str) -> str:
-        """Return a fresh temp path (with ``.suffix``) writable by the profiler."""
+    def scratch(self, *suffixes: str) -> AbstractContextManager[tuple[str, ...]]:
+        """Yield one temp path per suffix, removing them all on context exit."""
         ...
 
     def exec_profiler(self, cmd: list[str], *, sample_timeout: int) -> ExecResult:
@@ -309,10 +311,6 @@ class ProfileDispatch(Protocol):
         """Read a file produced by a profiler in the target environment."""
         ...
 
-    def rm_files(self, paths: list[str]) -> None:
-        """Best-effort removal of temp files in the target environment."""
-        ...
-
 
 def capture_cpu(
     dispatch: ProfileDispatch,
@@ -324,15 +322,12 @@ def capture_cpu(
 ) -> bytes:
     """Record a CPU profile with py-spy and return the encoded output bytes."""
     spec = resolve_cpu_spec(cpu_config, duration_seconds, pid=pid)
-    output_path = dispatch.tmp_path(spec.ext)
-    cmd = build_pyspy_cmd(spec, dispatch.pyspy_bin, output_path, subprocesses=subprocesses)
-    try:
+    with dispatch.scratch(spec.ext) as (output_path,):
+        cmd = build_pyspy_cmd(spec, dispatch.pyspy_bin, output_path, subprocesses=subprocesses)
         result = dispatch.exec_profiler(cmd, sample_timeout=duration_seconds + CPU_WRITE_HEADROOM_SECONDS)
         if result.returncode != 0:
             raise RuntimeError(f"py-spy record failed (exit {result.returncode}): {result.stderr}")
         return dispatch.read_file(output_path)
-    finally:
-        dispatch.rm_files([output_path])
 
 
 def capture_threads(
@@ -353,9 +348,7 @@ def capture_memory_attach(
 ) -> bytes:
     """Profile memory by attaching memray to a running process, then transforming the trace."""
     spec = resolve_memory_spec(memory_config, duration_seconds, pid=pid)
-    trace_path = dispatch.tmp_path("bin")
-    output_path = None
-    try:
+    with dispatch.scratch("bin", spec.ext) as (trace_path, output_path):
         attach_cmd = build_memray_attach_cmd(spec, dispatch.memray_bin, trace_path)
         result = dispatch.exec_profiler(attach_cmd, sample_timeout=duration_seconds + MEMRAY_ATTACH_HEADROOM_SECONDS)
         if result.returncode != 0:
@@ -364,17 +357,14 @@ def capture_memory_attach(
         if spec.is_raw:
             return dispatch.read_file(trace_path)
 
-        if spec.output_is_file:
-            output_path = dispatch.tmp_path(spec.ext)
-
-        transform_cmd = build_memray_transform_cmd(spec, dispatch.memray_bin, trace_path, output_path or "")
+        transform_cmd = build_memray_transform_cmd(
+            spec, dispatch.memray_bin, trace_path, output_path if spec.output_is_file else ""
+        )
         result = dispatch.exec(transform_cmd, timeout=30)
         if result.returncode != 0:
             raise RuntimeError(f"memray {spec.reporter} failed (exit {result.returncode}): {result.stderr}")
 
         return dispatch.read_file(output_path) if spec.output_is_file else result.stdout
-    finally:
-        dispatch.rm_files([trace_path, *([output_path] if output_path else [])])
 
 
 @dataclass
@@ -391,9 +381,17 @@ class LocalProfileDispatch:
     memray_bin: str = "memray"
     resume_pid: int | None = None
 
-    def tmp_path(self, suffix: str) -> str:
-        with tempfile.NamedTemporaryFile(suffix=f".{suffix}", delete=False) as f:
-            return f.name
+    @contextmanager
+    def scratch(self, *suffixes: str) -> Iterator[tuple[str, ...]]:
+        paths = []
+        for suffix in suffixes:
+            with tempfile.NamedTemporaryFile(suffix=f".{suffix}", delete=False) as f:
+                paths.append(f.name)
+        try:
+            yield tuple(paths)
+        finally:
+            for path in paths:
+                Path(path).unlink(missing_ok=True)
 
     def exec_profiler(self, cmd: list[str], *, sample_timeout: int) -> ExecResult:
         try:
@@ -407,10 +405,6 @@ class LocalProfileDispatch:
 
     def read_file(self, path: str) -> bytes:
         return Path(path).read_bytes()
-
-    def rm_files(self, paths: list[str]) -> None:
-        for path in paths:
-            Path(path).unlink(missing_ok=True)
 
     def _resume(self) -> None:
         if self.resume_pid is None or sys.platform != "linux":

--- a/lib/iris/tests/cluster/providers/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/providers/k8s/test_provider.py
@@ -780,7 +780,7 @@ def test_profile_memory_flamegraph_via_kubectl_exec(provider, k8s):
     # Two exec calls: attach + transform
     k8s.set_exec_response(pod_name, _success_cp())
     k8s.set_exec_response(pod_name, _success_cp())
-    k8s.set_file_content(pod_name, "/tmp/iris-memray.html", b"<html>flamegraph</html>")
+    k8s.set_file_content(pod_name, "/tmp/iris-profile.html", b"<html>flamegraph</html>")
 
     request = job_pb2.ProfileTaskRequest(
         target="/job/0",

--- a/lib/iris/tests/cluster/runtime/test_docker_runtime.py
+++ b/lib/iris/tests/cluster/runtime/test_docker_runtime.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 
 import pytest
 from iris.cluster.bundle import BundleStore
-from iris.cluster.runtime.docker import DockerRuntime, _DockerProfileDispatch
+from iris.cluster.runtime.docker import DockerRuntime
 from iris.cluster.runtime.types import MountKind, MountSpec
 
 
@@ -103,73 +103,3 @@ def test_stage_bundle(monkeypatch, tmp_path, runtime, mock_bundle_store):
     )
     assert len(calls) == 0
     mock_bundle_store.extract_bundle_to.assert_called_once_with("abc", workdir)
-
-
-# ---------------------------------------------------------------------------
-# _DockerProfileDispatch: in-container `timeout --signal=KILL` reaps a hung
-# profiler and a SIGCONT sweep clears any group-stop it leaves, so an orphaned
-# `docker exec` can never hold the target ptrace-stopped (py-spy#390).
-# ---------------------------------------------------------------------------
-
-
-def _docker_exec_payload(cmd: list[str]) -> list[str]:
-    """Strip the leading ``docker exec <cid>`` wrapper from a captured argv."""
-    assert cmd[:2] == ["docker", "exec"]
-    return cmd[3:]
-
-
-def test_exec_profiler_wraps_in_kill_watchdog_with_longer_host_backstop(monkeypatch):
-    """The profiler runs under `timeout --signal=KILL`; the host timeout is longer."""
-    calls: list[tuple[list[str], dict]] = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append((cmd, kwargs))
-        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
-    monkeypatch.setattr("iris.cluster.runtime.docker.subprocess.run", fake_run)
-
-    dispatch = _DockerProfileDispatch("cid123")
-    dispatch.exec_profiler(["/app/.venv/bin/py-spy", "record", "--pid", "1"], sample_timeout=35)
-
-    cmd, kwargs = calls[0]
-    payload = _docker_exec_payload(cmd)
-    assert payload[:3] == ["timeout", "--signal=KILL", "35"]
-    assert payload[3].endswith("py-spy")
-    # Host backstop outlives the in-container watchdog so the watchdog wins.
-    assert kwargs["timeout"] > 35
-
-
-def test_exec_profiler_sends_sigcont_sweep_after_profiler_exits(monkeypatch):
-    """After the profiler exits, a SIGCONT sweep clears any lingering group-stop."""
-    calls: list[list[str]] = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
-    monkeypatch.setattr("iris.cluster.runtime.docker.subprocess.run", fake_run)
-
-    _DockerProfileDispatch("cid123").exec_profiler(["/app/.venv/bin/py-spy", "dump"], sample_timeout=30)
-
-    payloads = [_docker_exec_payload(c) for c in calls]
-    assert payloads[0][0] == "timeout"  # profiler first, under the watchdog
-    sweep = payloads[-1]
-    assert sweep[0] == "sh" and "kill -CONT" in sweep[-1]
-
-
-def test_exec_profiler_sigcont_runs_even_when_profiler_raises(monkeypatch):
-    """A host-side timeout must not skip the SIGCONT recovery."""
-    calls: list[list[str]] = []
-
-    def fake_run(cmd, **kwargs):
-        calls.append(cmd)
-        if _docker_exec_payload(cmd)[0] == "timeout":
-            raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
-        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
-
-    monkeypatch.setattr("iris.cluster.runtime.docker.subprocess.run", fake_run)
-
-    with pytest.raises(subprocess.TimeoutExpired):
-        _DockerProfileDispatch("cid123").exec_profiler(["py-spy", "dump"], sample_timeout=30)
-
-    assert any(_docker_exec_payload(c)[0] == "sh" and "kill -CONT" in c[-1] for c in calls)

--- a/lib/iris/tests/cluster/runtime/test_docker_runtime.py
+++ b/lib/iris/tests/cluster/runtime/test_docker_runtime.py
@@ -10,7 +10,7 @@ from unittest.mock import Mock
 
 import pytest
 from iris.cluster.bundle import BundleStore
-from iris.cluster.runtime.docker import DockerRuntime
+from iris.cluster.runtime.docker import DockerRuntime, _DockerProfileDispatch
 from iris.cluster.runtime.types import MountKind, MountSpec
 
 
@@ -103,3 +103,73 @@ def test_stage_bundle(monkeypatch, tmp_path, runtime, mock_bundle_store):
     )
     assert len(calls) == 0
     mock_bundle_store.extract_bundle_to.assert_called_once_with("abc", workdir)
+
+
+# ---------------------------------------------------------------------------
+# _DockerProfileDispatch: in-container `timeout --signal=KILL` reaps a hung
+# profiler and a SIGCONT sweep clears any group-stop it leaves, so an orphaned
+# `docker exec` can never hold the target ptrace-stopped (py-spy#390).
+# ---------------------------------------------------------------------------
+
+
+def _docker_exec_payload(cmd: list[str]) -> list[str]:
+    """Strip the leading ``docker exec <cid>`` wrapper from a captured argv."""
+    assert cmd[:2] == ["docker", "exec"]
+    return cmd[3:]
+
+
+def test_exec_profiler_wraps_in_kill_watchdog_with_longer_host_backstop(monkeypatch):
+    """The profiler runs under `timeout --signal=KILL`; the host timeout is longer."""
+    calls: list[tuple[list[str], dict]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append((cmd, kwargs))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("iris.cluster.runtime.docker.subprocess.run", fake_run)
+
+    dispatch = _DockerProfileDispatch("cid123")
+    dispatch.exec_profiler(["/app/.venv/bin/py-spy", "record", "--pid", "1"], sample_timeout=35)
+
+    cmd, kwargs = calls[0]
+    payload = _docker_exec_payload(cmd)
+    assert payload[:3] == ["timeout", "--signal=KILL", "35"]
+    assert payload[3].endswith("py-spy")
+    # Host backstop outlives the in-container watchdog so the watchdog wins.
+    assert kwargs["timeout"] > 35
+
+
+def test_exec_profiler_sends_sigcont_sweep_after_profiler_exits(monkeypatch):
+    """After the profiler exits, a SIGCONT sweep clears any lingering group-stop."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("iris.cluster.runtime.docker.subprocess.run", fake_run)
+
+    _DockerProfileDispatch("cid123").exec_profiler(["/app/.venv/bin/py-spy", "dump"], sample_timeout=30)
+
+    payloads = [_docker_exec_payload(c) for c in calls]
+    assert payloads[0][0] == "timeout"  # profiler first, under the watchdog
+    sweep = payloads[-1]
+    assert sweep[0] == "sh" and "kill -CONT" in sweep[-1]
+
+
+def test_exec_profiler_sigcont_runs_even_when_profiler_raises(monkeypatch):
+    """A host-side timeout must not skip the SIGCONT recovery."""
+    calls: list[list[str]] = []
+
+    def fake_run(cmd, **kwargs):
+        calls.append(cmd)
+        if _docker_exec_payload(cmd)[0] == "timeout":
+            raise subprocess.TimeoutExpired(cmd, kwargs.get("timeout"))
+        return subprocess.CompletedProcess(cmd, 0, stdout="", stderr="")
+
+    monkeypatch.setattr("iris.cluster.runtime.docker.subprocess.run", fake_run)
+
+    with pytest.raises(subprocess.TimeoutExpired):
+        _DockerProfileDispatch("cid123").exec_profiler(["py-spy", "dump"], sample_timeout=30)
+
+    assert any(_docker_exec_payload(c)[0] == "sh" and "kill -CONT" in c[-1] for c in calls)

--- a/lib/iris/tests/cluster/runtime/test_profile.py
+++ b/lib/iris/tests/cluster/runtime/test_profile.py
@@ -26,8 +26,6 @@ from iris.cluster.runtime.profile import (
     capture_threads,
     resolve_cpu_spec,
     resolve_memory_spec,
-    sigcont_sweep_argv,
-    wrap_with_kill_watchdog,
 )
 from iris.rpc import job_pb2
 
@@ -217,24 +215,6 @@ def test_run_memray_profile_stats_returns_valid_json():
 
 
 # ---------------------------------------------------------------------------
-# Watchdog / recovery command construction
-# ---------------------------------------------------------------------------
-
-
-def test_wrap_with_kill_watchdog_prefixes_timeout_sigkill():
-    wrapped = wrap_with_kill_watchdog(["py-spy", "record"], sample_timeout=42)
-    assert wrapped == ["timeout", "--signal=KILL", "42", "py-spy", "record"]
-
-
-def test_sigcont_sweep_continues_every_pid_via_proc():
-    argv = sigcont_sweep_argv()
-    assert argv[0] == "sh"
-    # Sweeps /proc (no procps) and SIGCONTs each pid, including PID 1.
-    assert "/proc/[0-9]*" in argv[-1]
-    assert "kill -CONT" in argv[-1]
-
-
-# ---------------------------------------------------------------------------
 # Shared capture_* orchestration, exercised through a fake dispatch
 # ---------------------------------------------------------------------------
 
@@ -248,8 +228,6 @@ class FakeDispatch:
     files: dict[str, bytes] = field(default_factory=dict)
     profiler_result: ExecResult = field(default_factory=lambda: ExecResult(0, b"", ""))
     transform_result: ExecResult = field(default_factory=lambda: ExecResult(0, b"", ""))
-    profiler_cmds: list[list[str]] = field(default_factory=list)
-    transform_cmds: list[list[str]] = field(default_factory=list)
     removed: list[str] = field(default_factory=list)
     _counter: int = 0
 
@@ -265,11 +243,9 @@ class FakeDispatch:
             self.removed.extend(paths)
 
     def exec_profiler(self, cmd, *, sample_timeout):
-        self.profiler_cmds.append(cmd)
         return self.profiler_result
 
     def exec(self, cmd, *, timeout):
-        self.transform_cmds.append(cmd)
         return self.transform_result
 
     def read_file(self, path):
@@ -285,7 +261,6 @@ def test_capture_cpu_records_reads_and_cleans_up():
     data = capture_cpu(dispatch, cfg, duration_seconds=5, pid="1")
 
     assert data == b"speedscope-bytes"
-    assert dispatch.profiler_cmds[0][:2] == ["py-spy", "record"]
     assert dispatch.removed == ["/tmp/fake-1.json"]
 
 
@@ -303,7 +278,6 @@ def test_capture_threads_returns_stdout_bytes():
     dispatch = FakeDispatch(profiler_result=ExecResult(0, b"Thread 0x1\n  main.py:1", ""))
     data = capture_threads(dispatch, pid="1")
     assert b"Thread 0x1" in data
-    assert dispatch.profiler_cmds[0][:2] == ["py-spy", "dump"]
 
 
 def test_capture_threads_tolerates_non_python_child_with_partial_output():
@@ -329,8 +303,6 @@ def test_capture_memory_flamegraph_attaches_transforms_reads_file():
     data = capture_memory_attach(dispatch, cfg, duration_seconds=5, pid="1")
 
     assert data == b"<html>flamegraph</html>"
-    assert dispatch.profiler_cmds[0][:2] == ["memray", "attach"]
-    assert dispatch.transform_cmds[0][:2] == ["memray", "flamegraph"]
     assert dispatch.removed == ["/tmp/fake-1.bin", "/tmp/fake-2.html"]
 
 

--- a/lib/iris/tests/cluster/runtime/test_profile.py
+++ b/lib/iris/tests/cluster/runtime/test_profile.py
@@ -11,6 +11,7 @@ import json
 import os
 import threading
 import time
+from contextlib import contextmanager
 from dataclasses import dataclass, field
 
 import pytest
@@ -252,9 +253,16 @@ class FakeDispatch:
     removed: list[str] = field(default_factory=list)
     _counter: int = 0
 
-    def tmp_path(self, suffix: str) -> str:
-        self._counter += 1
-        return f"/tmp/fake-{self._counter}.{suffix}"
+    @contextmanager
+    def scratch(self, *suffixes):
+        paths = []
+        for suffix in suffixes:
+            self._counter += 1
+            paths.append(f"/tmp/fake-{self._counter}.{suffix}")
+        try:
+            yield tuple(paths)
+        finally:
+            self.removed.extend(paths)
 
     def exec_profiler(self, cmd, *, sample_timeout):
         self.profiler_cmds.append(cmd)
@@ -266,9 +274,6 @@ class FakeDispatch:
 
     def read_file(self, path):
         return self.files[path]
-
-    def rm_files(self, paths):
-        self.removed.extend(paths)
 
 
 def test_capture_cpu_records_reads_and_cleans_up():
@@ -336,4 +341,6 @@ def test_capture_memory_table_returns_transform_stdout():
     data = capture_memory_attach(dispatch, cfg, duration_seconds=5, pid="1")
 
     assert data == b"ALLOC SIZE FILE"
-    assert dispatch.removed == ["/tmp/fake-1.bin"]  # table writes no output file
+    # Both scratch paths are reserved up front and cleaned up, even though the
+    # table reporter writes to stdout and never uses the .txt output file.
+    assert dispatch.removed == ["/tmp/fake-1.bin", "/tmp/fake-2.txt"]

--- a/lib/iris/tests/cluster/runtime/test_profile.py
+++ b/lib/iris/tests/cluster/runtime/test_profile.py
@@ -11,15 +11,22 @@ import json
 import os
 import threading
 import time
+from dataclasses import dataclass, field
 
 import pytest
 from iris.cluster.runtime.profile import (
+    ExecResult,
     _run_memray_profile,
     build_memray_attach_cmd,
     build_memray_transform_cmd,
     build_pyspy_cmd,
+    capture_cpu,
+    capture_memory_attach,
+    capture_threads,
     resolve_cpu_spec,
     resolve_memory_spec,
+    sigcont_sweep_argv,
+    wrap_with_kill_watchdog,
 )
 from iris.rpc import job_pb2
 
@@ -206,3 +213,127 @@ def test_run_memray_profile_stats_returns_valid_json():
     result = _run_memray_profile(pid, duration_seconds=1, memory_config=cfg)
     data = json.loads(result)
     assert "total_num_allocations" in data
+
+
+# ---------------------------------------------------------------------------
+# Watchdog / recovery command construction
+# ---------------------------------------------------------------------------
+
+
+def test_wrap_with_kill_watchdog_prefixes_timeout_sigkill():
+    wrapped = wrap_with_kill_watchdog(["py-spy", "record"], sample_timeout=42)
+    assert wrapped == ["timeout", "--signal=KILL", "42", "py-spy", "record"]
+
+
+def test_sigcont_sweep_continues_every_pid_via_proc():
+    argv = sigcont_sweep_argv()
+    assert argv[0] == "sh"
+    # Sweeps /proc (no procps) and SIGCONTs each pid, including PID 1.
+    assert "/proc/[0-9]*" in argv[-1]
+    assert "kill -CONT" in argv[-1]
+
+
+# ---------------------------------------------------------------------------
+# Shared capture_* orchestration, exercised through a fake dispatch
+# ---------------------------------------------------------------------------
+
+
+@dataclass
+class FakeDispatch:
+    """In-memory ProfileDispatch: records commands and serves canned files."""
+
+    pyspy_bin: str = "py-spy"
+    memray_bin: str = "memray"
+    files: dict[str, bytes] = field(default_factory=dict)
+    profiler_result: ExecResult = field(default_factory=lambda: ExecResult(0, b"", ""))
+    transform_result: ExecResult = field(default_factory=lambda: ExecResult(0, b"", ""))
+    profiler_cmds: list[list[str]] = field(default_factory=list)
+    transform_cmds: list[list[str]] = field(default_factory=list)
+    removed: list[str] = field(default_factory=list)
+    _counter: int = 0
+
+    def tmp_path(self, suffix: str) -> str:
+        self._counter += 1
+        return f"/tmp/fake-{self._counter}.{suffix}"
+
+    def exec_profiler(self, cmd, *, sample_timeout):
+        self.profiler_cmds.append(cmd)
+        return self.profiler_result
+
+    def exec(self, cmd, *, timeout):
+        self.transform_cmds.append(cmd)
+        return self.transform_result
+
+    def read_file(self, path):
+        return self.files[path]
+
+    def rm_files(self, paths):
+        self.removed.extend(paths)
+
+
+def test_capture_cpu_records_reads_and_cleans_up():
+    dispatch = FakeDispatch()
+    # py-spy writes to the dispatch-chosen output path; serve its bytes back.
+    dispatch.files["/tmp/fake-1.json"] = b"speedscope-bytes"
+    cfg = job_pb2.CpuProfile(format=job_pb2.CpuProfile.SPEEDSCOPE)
+
+    data = capture_cpu(dispatch, cfg, duration_seconds=5, pid="1")
+
+    assert data == b"speedscope-bytes"
+    assert dispatch.profiler_cmds[0][:2] == ["py-spy", "record"]
+    assert dispatch.removed == ["/tmp/fake-1.json"]
+
+
+def test_capture_cpu_raises_on_nonzero_exit():
+    dispatch = FakeDispatch(profiler_result=ExecResult(137, b"", "killed"))
+    cfg = job_pb2.CpuProfile(format=job_pb2.CpuProfile.SPEEDSCOPE)
+
+    with pytest.raises(RuntimeError, match="py-spy record failed"):
+        capture_cpu(dispatch, cfg, duration_seconds=5, pid="1")
+    # Output temp file is still cleaned up on failure.
+    assert dispatch.removed == ["/tmp/fake-1.json"]
+
+
+def test_capture_threads_returns_stdout_bytes():
+    dispatch = FakeDispatch(profiler_result=ExecResult(0, b"Thread 0x1\n  main.py:1", ""))
+    data = capture_threads(dispatch, pid="1")
+    assert b"Thread 0x1" in data
+    assert dispatch.profiler_cmds[0][:2] == ["py-spy", "dump"]
+
+
+def test_capture_threads_tolerates_non_python_child_with_partial_output():
+    """py-spy dump --subprocesses exits non-zero on a non-Python child but still dumps."""
+    dispatch = FakeDispatch(
+        profiler_result=ExecResult(1, b"Thread 0x1\n  main.py:1", "Failed to find python version from target process")
+    )
+    data = capture_threads(dispatch, pid="1", subprocesses=True)
+    assert b"Thread 0x1" in data
+
+
+def test_capture_threads_raises_on_real_failure():
+    dispatch = FakeDispatch(profiler_result=ExecResult(1, b"", "no such process"))
+    with pytest.raises(RuntimeError, match="py-spy dump failed"):
+        capture_threads(dispatch, pid="1")
+
+
+def test_capture_memory_flamegraph_attaches_transforms_reads_file():
+    dispatch = FakeDispatch()
+    dispatch.files["/tmp/fake-2.html"] = b"<html>flamegraph</html>"  # fake-1 is the .bin trace
+    cfg = job_pb2.MemoryProfile(format=job_pb2.MemoryProfile.FLAMEGRAPH)
+
+    data = capture_memory_attach(dispatch, cfg, duration_seconds=5, pid="1")
+
+    assert data == b"<html>flamegraph</html>"
+    assert dispatch.profiler_cmds[0][:2] == ["memray", "attach"]
+    assert dispatch.transform_cmds[0][:2] == ["memray", "flamegraph"]
+    assert dispatch.removed == ["/tmp/fake-1.bin", "/tmp/fake-2.html"]
+
+
+def test_capture_memory_table_returns_transform_stdout():
+    dispatch = FakeDispatch(transform_result=ExecResult(0, b"ALLOC SIZE FILE", ""))
+    cfg = job_pb2.MemoryProfile(format=job_pb2.MemoryProfile.TABLE)
+
+    data = capture_memory_attach(dispatch, cfg, duration_seconds=5, pid="1")
+
+    assert data == b"ALLOC SIZE FILE"
+    assert dispatch.removed == ["/tmp/fake-1.bin"]  # table writes no output file


### PR DESCRIPTION
Periodic CPU profiling runs py-spy --native (blocking ptrace) via docker/kubectl exec. A wedged py-spy holds the target ptrace-stopped, and the client-side timeout only kills the exec client, leaving the in-namespace profiler orphaned and the target frozen for hours. Profilers now run under `timeout --signal=KILL` so the container/pod reaps them, followed by a SIGCONT sweep since PTRACE_ATTACH's SIGSTOP can leave a group-stop a killed tracer never clears (benfred/py-spy#390). The capture algorithm moves into profile.py behind a ProfileDispatch protocol; docker, k8s, and local backends differ only in dispatch. Fixes the stall on both docker and CoreWeave k8s.

Fixes #6019