### PR TITLE
[ci] Drive code quality from the advanced CodeQL workflow

### DIFF
--- a/.github/codeql/actions.yml
+++ b/.github/codeql/actions.yml
@@ -1,0 +1,6 @@
+name: "CodeQL — GitHub Actions"
+
+# Security analysis of workflow definitions under .github/workflows. No code
+# quality product runs for Actions (see analysis-kinds in ops-codeql.yaml).
+paths-ignore:
+  - tests/**

--- a/.github/codeql/javascript-typescript.yml
+++ b/.github/codeql/javascript-typescript.yml
@@ -1,0 +1,18 @@
+name: "CodeQL — JavaScript/TypeScript (security + code quality)"
+
+# Scope: first-party dashboard/docs front-end source only. The bulk of the
+# previous JS quality noise (e.g. ~30 "eval-like DOM" hits) came from scraped
+# third-party HTML fixtures under tests/snapshots/**, which the managed Code
+# Quality default setup scanned because it did not honor path filters. Limiting
+# to authored source removes that noise at the source.
+paths:
+  - infra/status-page
+  - lib/iris/dashboard/src
+  - lib/finelog/dashboard/src
+  - scripts/ops/storage/dashboard
+  - docs/javascript
+paths-ignore:
+  - "**/node_modules/**"
+  - "**/dist/**"
+  - "**/*.min.js"
+  - tests/**

--- a/.github/codeql/python.yml
+++ b/.github/codeql/python.yml
@@ -1,0 +1,24 @@
+name: "CodeQL — Python (security + code quality)"
+
+# Scope: first-party Marin library source. This matches the long-standing
+# security scope; broaden `paths` (e.g. add lib/iris/src, lib/zephyr/src,
+# experiments) if you want code-quality coverage beyond marin core — note that
+# also widens the security scan, since both share this path scope.
+paths:
+  - lib/marin/src
+paths-ignore:
+  - tests/**
+  - "**/*_pb2.py"
+  - "**/*_connect.py"
+
+# Code-quality suppressions: the two highest-volume, lowest-signal checks.
+#   - py/ineffectual-statement fires on `...` ellipsis bodies in Protocol/stub
+#     methods and on docstring-style string expressions. ruff's B018 already
+#     flags the genuinely-ineffectual cases while ignoring `...`/docstrings.
+#   - py/import-and-import-from flags modules reached via both `import x` and
+#     `from x import y`; too common across the repo to be actionable.
+query-filters:
+  - exclude:
+      id: py/ineffectual-statement
+  - exclude:
+      id: py/import-and-import-from

--- a/.github/codeql/python.yml
+++ b/.github/codeql/python.yml
@@ -1,11 +1,17 @@
 name: "CodeQL — Python (security + code quality)"
 
-# Scope: first-party Marin library source. This matches the long-standing
-# security scope; broaden `paths` (e.g. add lib/iris/src, lib/zephyr/src,
-# experiments) if you want code-quality coverage beyond marin core — note that
-# also widens the security scan, since both share this path scope.
+# Scope: source of every first-party Marin sub-package. Upstream-vendored
+# sibling libraries lib/levanter and lib/haliax are intentionally excluded —
+# they carry their own lint/scan configs. This scope is shared by both the
+# security and code-quality analyses. Add experiments/ here if you also want
+# the experiment scripts scanned.
 paths:
   - lib/marin/src
+  - lib/iris/src
+  - lib/finelog/src
+  - lib/zephyr/src
+  - lib/fray/src
+  - lib/rigging/src
 paths-ignore:
   - tests/**
   - "**/*_pb2.py"

--- a/.github/workflows/ops-codeql.yaml
+++ b/.github/workflows/ops-codeql.yaml
@@ -17,11 +17,21 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
+        # analysis-kinds selects which CodeQL products run for each language:
+        #   code-scanning  -> security alerts (Security > Code scanning)
+        #   code-quality   -> maintainability/reliability alerts (Security > Code quality)
+        # Security and quality share one path scope per language, configured in
+        # the matching .github/codeql/<language>.yml file.
         include:
         - language: actions
           build-mode: none
+          analysis-kinds: code-scanning
         - language: python
           build-mode: none
+          analysis-kinds: code-scanning,code-quality
+        - language: javascript-typescript
+          build-mode: none
+          analysis-kinds: code-scanning,code-quality
     steps:
     - name: Checkout repository
       uses: actions/checkout@v5
@@ -30,31 +40,18 @@ jobs:
       with:
         languages: ${{ matrix.language }}
         build-mode: ${{ matrix.build-mode }}
-        config: |
-          paths:
-            - lib/marin/src
-          paths-ignore:
-            - tests/**
-          # Suppress the two highest-volume, lowest-signal maintainability checks
-          # for any query run through this advanced workflow:
-          #   - py/ineffectual-statement fires on `...` ellipsis bodies in
-          #     Protocol/stub methods and on docstring-style string expressions.
-          #     ruff's B018 already flags the genuinely-ineffectual cases while
-          #     correctly ignoring `...` and docstrings, so this is pure noise.
-          #   - py/import-and-import-from flags modules reached via both `import x`
-          #     and `from x import y`; too common across the repo to be actionable.
-          # NOTE: the Security > Code quality alerts are produced by GitHub's
-          # *managed* Code Quality preview (Settings > Security > Code quality),
-          # NOT by this workflow — that runner scans the whole repo / all languages
-          # and does not honor query-filters. To actually drop these rules from the
-          # Code quality tab, either dismiss them by-rule there, or move code quality
-          # into this advanced workflow (and disable the managed feature) so these
-          # filters take effect.
-          query-filters:
-            - exclude:
-                id: py/ineffectual-statement
-            - exclude:
-                id: py/import-and-import-from
+        # analysis-kinds turns on GitHub's "Code quality" analysis alongside the
+        # security ("code-scanning") analysis. This advanced-setup workflow is the
+        # source of both the Code scanning and Code quality alerts, replacing the
+        # managed Code Quality default setup (which offers no per-query control).
+        # NOTE: GitHub currently documents `analysis-kinds` as an internal input
+        # that is subject to change. It is the only way to feed the Code quality
+        # tab from an advanced workflow today. If GitHub drops it, the input is
+        # ignored and analysis falls back to security-only — a soft failure, not
+        # a broken run. Per-language scope and query suppressions live in the
+        # referenced config file.
+        analysis-kinds: ${{ matrix.analysis-kinds }}
+        config-file: ./.github/codeql/${{ matrix.language }}.yml
 
     - name: Run manual build steps
       if: matrix.build-mode == 'manual'

--- a/.github/workflows/ops-codeql.yaml
+++ b/.github/workflows/ops-codeql.yaml
@@ -35,6 +35,26 @@ jobs:
             - lib/marin/src
           paths-ignore:
             - tests/**
+          # Suppress the two highest-volume, lowest-signal maintainability checks
+          # for any query run through this advanced workflow:
+          #   - py/ineffectual-statement fires on `...` ellipsis bodies in
+          #     Protocol/stub methods and on docstring-style string expressions.
+          #     ruff's B018 already flags the genuinely-ineffectual cases while
+          #     correctly ignoring `...` and docstrings, so this is pure noise.
+          #   - py/import-and-import-from flags modules reached via both `import x`
+          #     and `from x import y`; too common across the repo to be actionable.
+          # NOTE: the Security > Code quality alerts are produced by GitHub's
+          # *managed* Code Quality preview (Settings > Security > Code quality),
+          # NOT by this workflow — that runner scans the whole repo / all languages
+          # and does not honor query-filters. To actually drop these rules from the
+          # Code quality tab, either dismiss them by-rule there, or move code quality
+          # into this advanced workflow (and disable the managed feature) so these
+          # filters take effect.
+          query-filters:
+            - exclude:
+                id: py/ineffectual-statement
+            - exclude:
+                id: py/import-and-import-from
 
     - name: Run manual build steps
       if: matrix.build-mode == 'manual'

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -311,11 +311,13 @@ class _SubdomainProxyMiddleware:
 
     async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
         if scope["type"] != "http":
-            return await self._app(scope, receive, send)
+            await self._app(scope, receive, send)
+            return
 
         encoded_name = _extract_proxy_subdomain(self._extract_host(scope))
         if encoded_name is None:
-            return await self._app(scope, receive, send)
+            await self._app(scope, receive, send)
+            return
 
         if self._auth_verifier is not None:
             if not await _enforce_http_auth(scope, receive, send, self._auth_verifier, self._auth_optional):

--- a/lib/iris/tests/e2e/test_env_propagation.py
+++ b/lib/iris/tests/e2e/test_env_propagation.py
@@ -134,9 +134,12 @@ def test_env_propagates_through_job_chain(tmp_path):
         job = client.submit(entrypoint, "job-a", resources, environment=environment)
         job.wait(timeout=120, raise_on_failure=True, stream_logs=True)
 
-    state_a = json.loads(open(out_a).read())
-    state_b = json.loads(open(out_b).read())
-    state_c = json.loads(open(out_c).read())
+    with open(out_a) as f:
+        state_a = json.load(f)
+    with open(out_b) as f:
+        state_b = json.load(f)
+    with open(out_c) as f:
+        state_c = json.load(f)
 
     # env_vars propagate through the full chain
     assert state_a["env"]["TEST_PROPAGATION_KEY"] == "hello_chain"

--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -327,8 +327,10 @@ def _start_vllm_native_server(
     log_dir = tempfile.mkdtemp(prefix="vllm_server_")
     stdout_path = os.path.join(log_dir, "stdout.log")
     stderr_path = os.path.join(log_dir, "stderr.log")
-    stdout_f = open(stdout_path, "w")
-    stderr_f = open(stderr_path, "w")
+    # These handles are owned by the long-lived vLLM subprocess below and must
+    # stay open for its lifetime, so a context manager is not applicable here.
+    stdout_f = open(stdout_path, "w")  # noqa: SIM115
+    stderr_f = open(stderr_path, "w")  # noqa: SIM115
     native_env = _vllm_env()
     logger.info(
         "Starting vLLM native server with "

--- a/lib/marin/src/marin/rl/rollout_storage.py
+++ b/lib/marin/src/marin/rl/rollout_storage.py
@@ -212,6 +212,8 @@ class FileRolloutReader(RolloutReader):
 
             time.sleep(1.0)
 
+        return None
+
     def read_all_available(self) -> list[RolloutBatch]:
         """Read all currently available batches without blocking."""
         start_time = time.time()

--- a/lib/marin/src/marin/rl/scripts/replay_completions.py
+++ b/lib/marin/src/marin/rl/scripts/replay_completions.py
@@ -100,7 +100,6 @@ def create_inference_server(config: ReplayConfig) -> tuple[InferenceServer, Asyn
         host="localhost",
         port=port,
         tokenizer=tokenizer_path,
-        model=config.model,
         trainer=config.trainer,
         service=config.service,
     )
@@ -199,6 +198,8 @@ async def replay_all_with_warmup(
     logger.info(f"Processing {len(requests)} requests in {total_batches} batches of " f"size {config.batch_size}")
 
     current_start = 0
+    results: list[dict[str, Any]] = []
+    start_time = time.time()
 
     # First batch without timeout for warm-up
     if requests:
@@ -211,9 +212,19 @@ async def replay_all_with_warmup(
     while current_start < len(requests):
         end_idx = min(current_start + config.batch_size, len(requests))
         batch = requests[current_start:end_idx]
-        await send_batch_requests(client, batch, batch_idx, timeout=config.timeout)
+        results.append(await send_batch_requests(client, batch, batch_idx, timeout=config.timeout))
         current_start = end_idx
         batch_idx += 1
+
+    # send_batch_requests raises on any failure, so every collected result succeeded.
+    return {
+        "total_requests": len(requests),
+        "total_batches": total_batches,
+        "completed_batches": len(results),
+        "failed_batches": [],
+        "total_time": time.time() - start_time,
+        "results": results,
+    }
 
 
 class CompletionReplayer:

--- a/lib/marin/src/marin/rl/weight_transfer/arrow_flight.py
+++ b/lib/marin/src/marin/rl/weight_transfer/arrow_flight.py
@@ -263,7 +263,6 @@ class ArrowFlightCoordinator:
             param_names=param_names,
         )
         logger.info(f"Updated server: weight_id={weight_id}, params={len(param_names)}, servers={len(server_locations)}")
-        return 123
 
     def fetch_server(self) -> ServerInfo:
         return self._server_info

--- a/lib/marin/src/marin/transform/huggingface/dataset_to_eval.py
+++ b/lib/marin/src/marin/transform/huggingface/dataset_to_eval.py
@@ -336,6 +336,7 @@ def standardize_options(options: list | dict) -> list:
         sorted_keys = sorted(list(options.keys()))
         sorted_values = [options[key] for key in sorted_keys]
         return sorted_values
+    raise TypeError(f"Unsupported options format: {type(options).__name__}")
 
 
 def format_prompt_response(

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -152,11 +152,28 @@ extend-exclude = ["scripts/"]
 extend-include = ["scripts/workflows/**/*.py"]
 
 [tool.ruff.lint]
-select = ["A", "B", "E", "F", "I", "NPY", "RUF", "UP", "W"]
+# A,B,E,F,I,NPY,RUF,UP,W are the established families. The individually-listed
+# codes below mechanically enforce CodeQL "Code quality" maintainability/reliability
+# checks locally so they are caught at pre-commit time rather than only post-merge:
+#   N805    -> "First parameter of a method is not named 'self'"
+#   PLR0124 -> "Comparison of identical values" / "Redundant comparison"
+#   PLR1722 -> "Use of exit() or quit()" (use sys.exit)
+#   RET502  -> "Explicit returns mixed with implicit returns" (bare `return` value path)
+#   RET503  -> "Explicit returns mixed with implicit returns" (missing explicit return)
+#   SIM115  -> "File is not always closed" (open() without a context manager)
+# B018 (already via "B") and F401/F841/F811 (via "F") cover the rest of the
+# actionable CodeQL maintainability set; B018 correctly ignores `...`/docstrings.
+select = [
+    "A", "B", "E", "F", "I", "NPY", "RUF", "UP", "W",
+    "N805", "PLR0124", "PLR1722", "RET502", "RET503", "SIM115",
+]
 ignore = ["F722", "B008", "UP015", "A005", "E741"]
 
 [tool.ruff.lint.per-file-ignores]
 "__init__.py" = ["E402", "F401"]
+# Bloom filter tests deliberately compare an object with itself to exercise its
+# reflexive comparison operators (==, <=, >=, ...), so PLR0124 is expected here.
+"rust/dupekit/tests/test_bloom.py" = ["PLR0124"]
 
 [tool.ruff.lint.isort]
 known-first-party = ["experiments"]

--- a/scripts/pm/gh_issues_from_markdown.py
+++ b/scripts/pm/gh_issues_from_markdown.py
@@ -19,6 +19,7 @@ Usage: python gh_issues_from_markdown.py <markdown_file>
 
 import json
 import os
+import sys
 from datetime import datetime
 
 import requests
@@ -207,7 +208,7 @@ def create_issues_from_json(json_tasks: list[dict]):
             ok = input("Create issue? (Y/n)").strip().lower()
             if ok in ["y", "yes", "n", "no", "q", "quit", ""]:
                 if ok == "q" or ok == "quit":
-                    exit(0)
+                    sys.exit(0)
                 ok = "y" if ok in ["y", "yes", ""] else "n"
                 break
             else:
@@ -219,11 +220,9 @@ def create_issues_from_json(json_tasks: list[dict]):
 
 
 if __name__ == "__main__":
-    import sys
-
     if len(sys.argv) != 2:
         print("Usage: python create_issues.py <path_to_markdown_file>")
-        exit(1)
+        sys.exit(1)
     markdown_file_path = sys.argv[1]
     json_tasks = convert_markdown_to_json_tasks(markdown_file_path)
     create_issues_from_json(json_tasks)

--- a/scripts/pm/replace_crfm_links.py
+++ b/scripts/pm/replace_crfm_links.py
@@ -21,6 +21,7 @@ Requires:
 import argparse
 import os
 import re
+import sys
 
 from github import Github
 
@@ -52,7 +53,7 @@ def main():
     token = os.environ.get("GITHUB_TOKEN")
     if not token:
         print("Error: GITHUB_TOKEN environment variable not set.")
-        exit(1)
+        sys.exit(1)
     g = Github(token)
     repo = g.get_repo("marin-community/marin")
 

--- a/scripts/pm/replace_wandb_links.py
+++ b/scripts/pm/replace_wandb_links.py
@@ -20,6 +20,7 @@ Requires:
 import argparse
 import os
 import re
+import sys
 
 from github import Github
 
@@ -50,7 +51,7 @@ def main():
     token = os.environ.get("GITHUB_TOKEN")
     if not token:
         print("Error: GITHUB_TOKEN environment variable not set.")
-        exit(1)
+        sys.exit(1)
     g = Github(token)
     repo = g.get_repo("marin-community/marin")
 

--- a/scripts/training/time_to_train/parse_wandb_runs.py
+++ b/scripts/training/time_to_train/parse_wandb_runs.py
@@ -77,7 +77,7 @@ def parse_run(run: wandb.apis.public.Run, start_date: str | None = None, end_dat
     runtime = run.summary["_runtime"] / 3600.0  # hours
     create_time = convert_to_local_time(run.createdAt)
     if not check_create_time(create_time, start_date=start_date, end_date=end_date):
-        return
+        return None
     heartbeat_time = convert_to_local_time(run.heartbeatAt)
     # get difference between create time and heartbeat time
     total_time = get_ts_diff(run.createdAt, run.heartbeatAt)

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -218,7 +218,8 @@ def test_model_perplexity_score_step_hash_changes_when_tokenizer_changes():
 def test_force_run_failed():
     log = create_log()
 
-    temp_file_to_mark_failure = tempfile.NamedTemporaryFile(prefix="executor-fail-", delete=False)
+    # delete=False: the file must outlive this handle so its path can be reused below.
+    temp_file_to_mark_failure = tempfile.NamedTemporaryFile(prefix="executor-fail-", delete=False)  # noqa: SIM115
     # make sure it exists
     temp_file_to_mark_failure.write(b"hello")
     temp_file_to_mark_failure.close()

--- a/tests/rl/integration/config.py
+++ b/tests/rl/integration/config.py
@@ -242,7 +242,7 @@ def create_weight_transfer_config():
 
 def create_qwen_config():
     return Qwen3Config(
-        seq_len=4096,
+        max_seq_len=4096,
         hidden_dim=1024,
         intermediate_dim=3072,
         num_heads=16,


### PR DESCRIPTION
Replace GitHub's managed Code Quality default setup with advanced-setup analysis so the Code quality tab is configurable: per-language path scope and CodeQL query-filters now live in .github/codeql/. Disable the two noisiest checks (py/ineffectual-statement, py/import-and-import-from) and scope JavaScript to first-party source so scraped-HTML noise stops. Fold the actionable maintainability rules into ruff (N805, PLR0124, PLR1722, RET502/503, SIM115) and fix the latent bugs that surfaced, including a Qwen3Config field typo and a stale InferenceServerConfig kwarg.