### PR TITLE
[finelog] Defer table registration to the flush thread

### DIFF
--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -183,6 +183,12 @@ class Table:
     flush thread, and retry/backoff with resolver invalidation on transient
     server failures. Created via :meth:`LogClient.get_table`; closing the
     LogClient drains every Table.
+
+    Registration is deferred to the flush thread: if a ``registrar`` is given,
+    it is invoked once before the first send to register the namespace and
+    return its effective schema. A failing registration is treated like any
+    other flush failure (retried with backoff, or the batch dropped on a
+    non-retryable error) and never blocks the caller that created the Table.
     """
 
     def __init__(
@@ -192,6 +198,7 @@ class Table:
         schema: Schema,
         flusher: Callable[[str, pa.RecordBatch], None],
         querier: Callable[[str], pa.Table] | None = None,
+        registrar: Callable[[], Schema] | None = None,
         flush_interval: float = DEFAULT_FLUSH_INTERVAL,
         batch_rows: int = DEFAULT_BATCH_ROWS,
         max_buffer_bytes: int = DEFAULT_MAX_BUFFER_BYTES,
@@ -203,6 +210,12 @@ class Table:
         self._arrow_schema = schema_to_arrow(schema)
         self._flusher = flusher
         self._querier = querier
+        # When set, the flush thread calls this once before its first send to
+        # register the namespace; the returned effective schema replaces the
+        # locally-requested one for Arrow encoding. ``None`` means the
+        # namespace is already registered server-side (e.g. ``log``).
+        self._registrar = registrar
+        self._registered = registrar is None
         self._flush_interval = flush_interval
         self._batch_rows = batch_rows
         self._max_buffer_bytes = max_buffer_bytes
@@ -391,6 +404,7 @@ class Table:
             return 0, []
         rows = [item.payload for item in items]
         try:
+            self._ensure_registered()
             batch = _rows_to_record_batch(rows, self._arrow_schema, self._schema)
             self._flusher(self._namespace, batch)
         except Exception as exc:
@@ -409,6 +423,22 @@ class Table:
                 return items[-1].seq, []
             return 0, items
         return items[-1].seq, []
+
+    def _ensure_registered(self) -> None:
+        """Register the namespace on first send, adopting its effective schema.
+
+        Runs on the flush thread only, so the (re)assignment of ``_schema`` /
+        ``_arrow_schema`` does not race the Arrow encode that follows. A raised
+        exception propagates to :meth:`_send`, which treats it as a flush
+        failure.
+        """
+        if self._registered:
+            return
+        assert self._registrar is not None
+        effective = self._registrar()
+        self._schema = effective
+        self._arrow_schema = schema_to_arrow(effective)
+        self._registered = True
 
 
 class LogClient:
@@ -547,7 +577,15 @@ class LogClient:
         *,
         storage_policy: StoragePolicy = StoragePolicy(),
     ) -> Table:
-        """Idempotently register ``namespace`` and return a Table handle.
+        """Return a Table handle for ``namespace``, registering it lazily.
+
+        The handle is returned immediately without contacting the server: the
+        ``register_table`` RPC is deferred to the Table's flush thread, which
+        runs it once before the first send. A connectivity or schema failure
+        there is handled as a normal flush failure (retried with backoff, or
+        the batch dropped) and never propagates to this caller, so a caller
+        that only needs to enqueue rows is never blocked by an unavailable
+        finelog server.
 
         ``storage_policy`` is a per-namespace retention override; an
         empty policy inherits the server defaults. A non-empty policy
@@ -563,10 +601,29 @@ class LogClient:
         else:
             raise SchemaValidationError(f"schema must be a Schema or a dataclass class, got {type(schema).__name__}")
 
-        existing = self._tables.get(namespace)
-        if existing is not None:
-            return existing
+        with self._lock:
+            if self._closed:
+                raise RuntimeError("LogClient is closed")
+            existing = self._tables.get(namespace)
+            if existing is not None:
+                return existing
+            table = Table(
+                namespace=namespace,
+                schema=requested,
+                flusher=self._stats_flush,
+                querier=self._stats_query,
+                registrar=lambda: self._register_table(namespace, requested, storage_policy),
+            )
+            self._tables[namespace] = table
+            return table
 
+    def _register_table(self, namespace: str, requested: Schema, storage_policy: StoragePolicy) -> Schema:
+        """Run the ``register_table`` RPC and return the effective schema.
+
+        Called from a Table's flush thread. Raises the underlying transport
+        error (not a translated domain error) so the caller's retryability
+        check sees the original ConnectError code.
+        """
         client = self._get_stats_client()
         try:
             response = client.register_table(
@@ -577,24 +634,13 @@ class LogClient:
                 )
             )
         except ConnectError as exc:
-            raise _translate_connect_error(exc) from exc
-        effective = schema_from_proto(response.effective_schema)
-        table = Table(
-            namespace=namespace,
-            schema=effective,
-            flusher=self._stats_flush,
-            querier=self._stats_query,
-        )
-        with self._lock:
-            if self._closed:
-                table.close()
-                raise RuntimeError("LogClient is closed")
-            existing = self._tables.get(namespace)
-            if existing is not None:
-                table.close()
-                return existing
-            self._tables[namespace] = table
-        return table
+            if is_retryable_error(exc):
+                self._invalidate(_format_exc_summary(exc))
+            raise
+        except (ConnectionError, OSError, TimeoutError) as exc:
+            self._invalidate(_format_exc_summary(exc))
+            raise
+        return schema_from_proto(response.effective_schema)
 
     def drop_table(self, namespace: str) -> None:
         """Remove ``namespace`` from the registry and delete its local data."""

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -20,7 +20,6 @@ from finelog.client import log_client as log_client_mod
 from finelog.errors import (
     InvalidNamespaceError,
     QueryResultTooLargeError,
-    SchemaConflictError,
     SchemaValidationError,
 )
 from finelog.rpc import finelog_stats_pb2 as stats_pb2
@@ -326,11 +325,14 @@ def test_get_table_forwards_storage_policy(tracked_clients):
     """An explicit StoragePolicy on get_table is sent on the register_table request."""
     client = LogClient.connect("http://h:1")
     try:
-        client.get_table(
+        table = client.get_table(
             "iris.worker",
             WorkerStat,
             storage_policy=StoragePolicy(max_bytes=100, max_age_seconds=60),
         )
+        # Registration is deferred to the flush thread; force it with a write+flush.
+        table.write([WorkerStat(worker_id="w-1", timestamp_ms=1, mem_bytes=1)])
+        assert table.flush(timeout=5.0) == FlushResult.SUCCEEDED
         policy = tracked_clients[0].registered_policies["iris.worker"]
         assert policy.max_bytes == 100
         assert policy.max_age_seconds == 60
@@ -343,7 +345,10 @@ def test_get_table_default_policy_is_empty(tracked_clients):
     """No policy argument sends an empty proto (all zeros = inherit defaults)."""
     client = LogClient.connect("http://h:1")
     try:
-        client.get_table("iris.worker", WorkerStat)
+        table = client.get_table("iris.worker", WorkerStat)
+        # Registration is deferred to the flush thread; force it with a write+flush.
+        table.write([WorkerStat(worker_id="w-1", timestamp_ms=1, mem_bytes=1)])
+        assert table.flush(timeout=5.0) == FlushResult.SUCCEEDED
         policy = tracked_clients[0].registered_policies["iris.worker"]
         assert policy.max_bytes == 0
         assert policy.max_age_seconds == 0
@@ -384,29 +389,70 @@ def test_drop_table_unknown_is_no_op(tracked_clients, monkeypatch):
     client = LogClient.connect("http://h:1")
     try:
         client.get_table("iris.worker", WorkerStat)
-        original_drop = tracked_clients[0].drop_table
+        client.drop_table("iris.worker")  # first drop lazily constructs the stats client
 
         def fail_drop(request):
             raise ConnectError(Code.NOT_FOUND, "namespace not registered")
 
         tracked_clients[0].drop_table = fail_drop  # type: ignore[method-assign]
         client.drop_table("iris.unknown")  # must not raise
-        tracked_clients[0].drop_table = original_drop  # type: ignore[method-assign]
     finally:
         client.close()
 
 
-def test_get_table_propagates_schema_conflict(tracked_clients, monkeypatch):
+def test_get_table_registration_conflict_drops_batch(tracked_clients, monkeypatch):
+    """A non-retryable registration failure is handled as a flush failure.
+
+    Registration happens on the flush thread, so a schema conflict cannot
+    propagate to the caller of get_table. The offending batch is dropped (the
+    error is non-retryable) and the Table stays usable without crashing.
+    """
+
+    def conflict(self, request):
+        raise ConnectError(Code.FAILED_PRECONDITION, "type mismatch")
+
+    monkeypatch.setattr(_FakeStatsServiceClient, "register_table", conflict)
     client = LogClient.connect("http://h:1")
     try:
-        client.get_table("iris.metric", WorkerStat)
+        table = client.get_table("iris.worker", WorkerStat)
+        table.write([WorkerStat(worker_id="w-1", timestamp_ms=1, mem_bytes=1)])
+        # Non-retryable: the batch is dropped, the flush resolves, nothing raises.
+        assert table.flush(timeout=5.0) == FlushResult.SUCCEEDED
+        assert tracked_clients[0].writes == []
+    finally:
+        client.close()
 
-        def conflict(request):
-            raise ConnectError(Code.FAILED_PRECONDITION, "type mismatch")
 
-        tracked_clients[0].register_table = conflict  # type: ignore[method-assign]
-        with pytest.raises(SchemaConflictError):
-            client.get_table("iris.other", WorkerStat)
+def test_get_table_retries_transient_registration_failure(tracked_clients, monkeypatch):
+    """A retryable registration failure is retried on the flush thread.
+
+    The first register attempt raises UNAVAILABLE; the flush thread backs off
+    and retries, then the write lands once registration succeeds. ``get_table``
+    itself never blocks or raises.
+    """
+    monkeypatch.setattr(log_client_mod, "_BACKOFF_INITIAL", 1e-9)
+    monkeypatch.setattr(log_client_mod, "_BACKOFF_MAX", 1e-9)
+
+    calls = {"n": 0}
+    real_register = _FakeStatsServiceClient.register_table
+
+    def flaky_register(self, request):
+        calls["n"] += 1
+        if calls["n"] == 1:
+            raise ConnectError(Code.UNAVAILABLE, "down")
+        return real_register(self, request)
+
+    monkeypatch.setattr(_FakeStatsServiceClient, "register_table", flaky_register)
+    client = LogClient.connect("http://h:1")
+    try:
+        table = client.get_table("iris.worker", WorkerStat)
+        table.write([WorkerStat(worker_id="w-1", timestamp_ms=1, mem_bytes=128)])
+        assert table.flush(timeout=5.0) == FlushResult.SUCCEEDED
+        # First attempt failed and re-resolved the endpoint; the retry registered
+        # and wrote against the freshly constructed client.
+        assert calls["n"] >= 2
+        landed = any(w.namespace == "iris.worker" for c in tracked_clients for w in c.writes)
+        assert landed
     finally:
         client.close()
 
@@ -419,11 +465,12 @@ def test_table_query_round_trips(tracked_clients):
         def handler(_sql: str) -> pa.Table:
             return pa.table({"worker_id": ["w-1", "w-2"], "mem_bytes": [10, 20]})
 
+        table.query("SELECT 1")  # lazily construct the stats client
         tracked_clients[0].query_handler = handler
         result = table.query('SELECT worker_id, mem_bytes FROM "iris.worker"')
         assert result.column_names == ["worker_id", "mem_bytes"]
         assert result.column("worker_id").to_pylist() == ["w-1", "w-2"]
-        assert tracked_clients[0].queries == ['SELECT worker_id, mem_bytes FROM "iris.worker"']
+        assert tracked_clients[0].queries[-1] == 'SELECT worker_id, mem_bytes FROM "iris.worker"'
     finally:
         client.close()
 
@@ -432,6 +479,7 @@ def test_table_query_raises_on_too_large(tracked_clients):
     client = LogClient.connect("http://h:1")
     try:
         table = client.get_table("iris.worker", WorkerStat)
+        table.query("SELECT 1")  # lazily construct the stats client
         tracked_clients[0].query_handler = lambda _sql: pa.table({"worker_id": ["w"] * 5})
         with pytest.raises(QueryResultTooLargeError):
             table.query('SELECT * FROM "iris.worker"', max_rows=2)
@@ -470,6 +518,7 @@ def test_table_query_translates_invalid_argument(tracked_clients):
     client = LogClient.connect("http://h:1")
     try:
         table = client.get_table("iris.worker", WorkerStat)
+        table.query("SELECT 1")  # lazily construct the stats client
         tracked_clients[0].errors.append(ConnectError(Code.INVALID_ARGUMENT, "syntax error"))
         with pytest.raises(SchemaValidationError):
             table.query("not valid sql")


### PR DESCRIPTION
LogClient.get_table now returns a Table handle immediately instead of running register_table on the calling thread, which blocked and timed out when finelog was unavailable (e.g. controller startup). The flush thread registers the namespace lazily before its first send; registration failures are treated like any flush failure (retried with backoff, or the batch dropped on a non-retryable error) and never block the caller. Adds regression tests.