### PR TITLE
Support Grug checkpoints in perplexity gap

### DIFF
--- a/lib/levanter/src/levanter/main/perplexity_gap.py
+++ b/lib/levanter/src/levanter/main/perplexity_gap.py
@@ -304,7 +304,7 @@ def _load_model_runner(
 
     key = jax.random.PRNGKey(0)
     vocab_size = len(tokenizer)
-    eval_length = min(max_eval_length, spec.model.max_Pos.size)
+    eval_length = min(max_eval_length, _model_max_seq_len(spec.model))
     EvalBatch = trainer.EvalBatch
     Pos = Axis("position", eval_length)
     Vocab = round_axis_for_partitioning(Axis("vocab", vocab_size), compute_axis_mapping)
@@ -317,8 +317,20 @@ def _load_model_runner(
     def compute_losses(model: LmHeadModel, batch: GrugLmExample):
         model = inference_mode(model, True)
         model = mp.cast_to_compute(model)
-        named_batch = named_lm_example_from_grug(batch, Pos=Pos, batch_axis=EvalBatch)
-        return model.compute_next_token_loss(named_batch, reduction=None, reduction_axis=()).array
+        if hasattr(model, "compute_next_token_loss"):
+            named_batch = named_lm_example_from_grug(batch, Pos=Pos, batch_axis=EvalBatch)
+            return model.compute_next_token_loss(named_batch, reduction=None, reduction_axis=()).array
+
+        if hasattr(model, "next_token_loss"):
+            return model.next_token_loss(
+                batch.tokens,
+                batch.loss_weight,
+                mask=batch.attn_mask,
+                reduction="none",
+                logsumexp_weight=None,
+            )
+
+        raise TypeError(f"Model {type(model).__name__} does not expose a next-token loss method.")
 
     if spec.checkpoint_is_hf:
         model_config = spec.model
@@ -334,9 +346,9 @@ def _load_model_runner(
         )
     else:
         with use_cpu_device():
-            model = eqx.filter_eval_shape(spec.model.build, Vocab, key=key)
+            model = _init_native_model_shape(spec.model, Vocab, key=key)
             checkpoint_path = latest_checkpoint_path(spec.checkpoint_path)
-            model = load_checkpoint(model, checkpoint_path, subpath="model")
+            model = _load_native_checkpoint(model, checkpoint_path, spec.model)
         model = hax.shard_with_axis_mapping(model, parameter_axis_mapping)
 
     label = _model_label(spec)
@@ -348,6 +360,158 @@ def _load_model_runner(
         eval_batch_size=trainer.eval_batch_size,
         eval_length=eval_length,
         compute_losses=compute_losses,
+    )
+
+
+def _model_max_seq_len(model_config: Any) -> int:
+    """Return the max sequence length across Levanter and Grug config shapes."""
+    max_pos = getattr(model_config, "max_Pos", None)
+    if max_pos is not None:
+        return max_pos.size
+
+    max_seq_len = getattr(model_config, "max_seq_len", None)
+    if max_seq_len is not None:
+        return max_seq_len
+
+    raise ValueError(f"Model config {type(model_config).__name__} does not expose max_Pos or max_seq_len.")
+
+
+def _init_native_model_shape(model_config: Any, Vocab: Axis, *, key: jax.Array) -> Any:
+    """Initialize an eval-shape model for native Levanter or Grug checkpoints."""
+    build = getattr(model_config, "build", None)
+    if build is not None:
+        return eqx.filter_eval_shape(build, Vocab, key=key)
+
+    if type(model_config).__name__ == "GrugModelConfig":
+        from experiments.grug.moe.model import Transformer
+
+        return eqx.filter_eval_shape(Transformer.init, model_config, key=key)
+
+    raise ValueError(f"Model config {type(model_config).__name__} cannot initialize native checkpoints.")
+
+
+def _load_native_checkpoint(model: Any, checkpoint_path: str, model_config: Any) -> Any:
+    """Load a native checkpoint, including Grug's params-subtree format."""
+    if type(model_config).__name__ == "GrugModelConfig":
+        compat_model = _grug_model_to_checkpoint_compat(model)
+        compat_model = load_checkpoint(compat_model, checkpoint_path, subpath="params")
+        return _checkpoint_compat_to_grug_model(compat_model, model)
+
+    return load_checkpoint(model, checkpoint_path, subpath="model")
+
+
+class _GrugCheckpointExpertMLP(eqx.Module):
+    """Compatibility view for old Grug checkpoint expert MLP leaves."""
+
+    w_gate_up: Any
+    w_down: Any
+
+
+class _GrugCheckpointMoEMLP(eqx.Module):
+    """Compatibility view for old Grug MoE checkpoints with expert_mlp."""
+
+    router: Any
+    router_bias: Any
+    expert_mlp: _GrugCheckpointExpertMLP
+    cfg: Any = eqx.field(static=True)
+
+
+class _GrugCheckpointBlock(eqx.Module):
+    """Compatibility block matching the older Grug checkpoint tree."""
+
+    rms_attn: Any
+    attn_gated_norm: Any
+    attn: Any
+    rms_mlp: Any
+    mlp_gated_norm: Any
+    mlp: _GrugCheckpointMoEMLP
+    shared: Any
+
+
+class _GrugCheckpointTransformer(eqx.Module):
+    """Compatibility transformer matching the older Grug checkpoint tree."""
+
+    token_embed: Any
+    embed_norm: Any
+    embed_gated_norm: Any
+    output_proj: Any
+    blocks: tuple[_GrugCheckpointBlock, ...]
+    final_norm: Any
+    final_gated_norm: Any
+    config: Any = eqx.field(static=True)
+
+
+def _grug_model_to_checkpoint_compat(model: Any) -> _GrugCheckpointTransformer:
+    """Wrap the current Grug model shape with the older checkpoint layout."""
+    blocks = []
+    for block in model.blocks:
+        compat_mlp = _GrugCheckpointMoEMLP(
+            router=block.mlp.router,
+            router_bias=block.mlp.router_bias,
+            expert_mlp=_GrugCheckpointExpertMLP(
+                w_gate_up=block.mlp.w_gate_up,
+                w_down=block.mlp.w_down,
+            ),
+            cfg=block.mlp.cfg,
+        )
+        blocks.append(
+            _GrugCheckpointBlock(
+                rms_attn=block.rms_attn,
+                attn_gated_norm=block.attn_gated_norm,
+                attn=block.attn,
+                rms_mlp=block.rms_mlp,
+                mlp_gated_norm=block.mlp_gated_norm,
+                mlp=compat_mlp,
+                shared=block.shared,
+            )
+        )
+
+    return _GrugCheckpointTransformer(
+        token_embed=model.token_embed,
+        embed_norm=model.embed_norm,
+        embed_gated_norm=model.embed_gated_norm,
+        output_proj=model.output_proj,
+        blocks=tuple(blocks),
+        final_norm=model.final_norm,
+        final_gated_norm=model.final_gated_norm,
+        config=model.config,
+    )
+
+
+def _checkpoint_compat_to_grug_model(compat_model: _GrugCheckpointTransformer, model_shape: Any) -> Any:
+    """Convert a loaded compatibility checkpoint back to the current Grug model."""
+    from experiments.grug.moe.model import Block, MoEMLP, Transformer
+
+    blocks = []
+    for compat_block in compat_model.blocks:
+        mlp = MoEMLP(
+            router=compat_block.mlp.router,
+            router_bias=compat_block.mlp.router_bias,
+            w_gate_up=compat_block.mlp.expert_mlp.w_gate_up,
+            w_down=compat_block.mlp.expert_mlp.w_down,
+            cfg=compat_block.mlp.cfg,
+        )
+        blocks.append(
+            Block(
+                rms_attn=compat_block.rms_attn,
+                attn_gated_norm=compat_block.attn_gated_norm,
+                attn=compat_block.attn,
+                rms_mlp=compat_block.rms_mlp,
+                mlp_gated_norm=compat_block.mlp_gated_norm,
+                mlp=mlp,
+                shared=compat_block.shared,
+            )
+        )
+
+    return Transformer(
+        token_embed=compat_model.token_embed,
+        embed_norm=compat_model.embed_norm,
+        embed_gated_norm=compat_model.embed_gated_norm,
+        output_proj=compat_model.output_proj,
+        blocks=tuple(blocks),
+        final_norm=compat_model.final_norm,
+        final_gated_norm=compat_model.final_gated_norm,
+        config=model_shape.config,
     )
 
 

--- a/lib/marin/src/marin/evaluation/perplexity_gap.py
+++ b/lib/marin/src/marin/evaluation/perplexity_gap.py
@@ -31,7 +31,7 @@ from levanter.main.perplexity_gap import (
 from levanter.models.lm_model import LmConfig
 from levanter.tokenizers import TokenizerBackend
 from levanter.tracker.wandb import WandbConfig
-from levanter.trainer import TrainerConfig
+from levanter.trainer import MeshConfig, TrainerConfig
 
 from marin.execution.types import ExecutorStep, InputName, VersionedValue, this_output_path, versioned
 from marin.processing.tokenize import HfDatasetSpec
@@ -235,6 +235,8 @@ def find_model_perplexity_scores(config: ModelPerplexityScoreConfig) -> None:
         trainer=TrainerConfig(
             tracker=WandbConfig(project=WANDB_PROJECT, tags=tags, name=run_name),
             per_device_eval_parallelism=config.per_device_batch_size,
+            mesh=MeshConfig(axes={"expert": 1, "model": 1}),
+            use_explicit_mesh_axes=True,
         ),
         output_path=config.output_path,
         max_eval_length=config.max_eval_length,


### PR DESCRIPTION
## Summary

Adds native Grug checkpoint support to the perplexity-gap/model-score runner.

This PR focuses only on Grug runner plumbing:

- supports model configs that expose `max_seq_len` instead of `max_Pos`
- initializes native `GrugModelConfig` checkpoints through `experiments.grug.moe.model.Transformer`
- loads Grug checkpoints from the `params` subpath
- maps older checkpoint `expert_mlp` MoE layout into the current `MoEMLP` layout
- supports Grug models exposing `next_token_loss` instead of `compute_next_token_loss`
- configures score jobs with explicit `expert` and `model` mesh axes
- documents the Grug checkpoint compatibility helpers

It intentionally excludes TokenMonster BPB accounting and the one-off d1024 experiment launcher.

## Validation

```bash
uv run --package marin-levanter --group test pytest \
  lib/levanter/tests/test_perplexity_gap.py::test_score_main_writes_outputs_without_uploading_model_score_artifact
```

Result: 1 passed.