### PR TITLE
Remove TPU lockfile cleanup helper

### DIFF
--- a/lib/marin/src/marin/export/levanter_checkpoint.py
+++ b/lib/marin/src/marin/export/levanter_checkpoint.py
@@ -27,7 +27,6 @@ from levanter.trainer import TrainerConfig
 from marin.execution.types import ExecutorStep, InputName, VersionedValue, ensure_versioned, this_output_path
 from marin.training.run_environment import add_run_env_variables
 from marin.training.training import _add_default_env_variables
-from marin.utils import remove_tpu_lockfile_on_exit
 
 logger = logging.getLogger(__name__)
 
@@ -97,10 +96,6 @@ def convert_checkpoint_to_hf(config: ConvertCheckpointStepConfig) -> None:
     def convert_task():
         export_lm_to_hf.main(convert_config)
 
-    def _run_with_lockfile():
-        with remove_tpu_lockfile_on_exit():
-            convert_task()
-
     if isinstance(config.resources.device, TpuConfig):
         assert config.resources.replicas == 1, "Export currently works on single slices at present."
 
@@ -113,7 +108,7 @@ def convert_checkpoint_to_hf(config: ConvertCheckpointStepConfig) -> None:
     client = current_client()
     job_request = JobRequest(
         name="convert-checkpoint-to-hf",
-        entrypoint=Entrypoint.from_callable(_run_with_lockfile),
+        entrypoint=Entrypoint.from_callable(convert_task),
         resources=config.resources,
         environment=create_environment(env_vars=env, extras=extras),
     )

--- a/lib/marin/src/marin/inference/vllm_smoke_test.py
+++ b/lib/marin/src/marin/inference/vllm_smoke_test.py
@@ -14,7 +14,6 @@ from fray.types import Entrypoint, JobRequest, ResourceConfig, create_environmen
 
 from marin.evaluation.evaluators.evaluator import ModelConfig
 from marin.inference.vllm_server import VllmEnvironment
-from marin.utils import remove_tpu_lockfile_on_exit
 
 
 def run_one_query(
@@ -181,24 +180,23 @@ def main(argv: list[str] | None = None) -> int:
         env_vars["VLLM_XLA_CACHE_PATH"] = args.local_cache_dir
 
     def _run() -> None:
-        with remove_tpu_lockfile_on_exit():
-            for i in range(args.repeat):
-                start = time.time()
-                try:
-                    output = run_one_query(
-                        model_name_or_path=args.model,
-                        prompt=args.prompt,
-                        load_format=args.load_format,
-                        max_model_len=args.max_model_len,
-                        port=args.port,
-                        use_completions=args.use_completions,
-                    )
-                except Exception:
-                    traceback.print_exc()
-                    raise
-                elapsed = time.time() - start
-                print(f"[run {i + 1}/{args.repeat}] {elapsed:.1f}s")
-                print(output)
+        for i in range(args.repeat):
+            start = time.time()
+            try:
+                output = run_one_query(
+                    model_name_or_path=args.model,
+                    prompt=args.prompt,
+                    load_format=args.load_format,
+                    max_model_len=args.max_model_len,
+                    port=args.port,
+                    use_completions=args.use_completions,
+                )
+            except Exception:
+                traceback.print_exc()
+                raise
+            elapsed = time.time() - start
+            print(f"[run {i + 1}/{args.repeat}] {elapsed:.1f}s")
+            print(output)
 
     client = current_client()
     resources = ResourceConfig.with_tpu(args.tpu_type)

--- a/lib/marin/src/marin/rl/orchestration.py
+++ b/lib/marin/src/marin/rl/orchestration.py
@@ -33,7 +33,6 @@ from marin.rl.train_worker import TrainWorker
 from marin.rl.weight_transfer import WeightTransferMode
 from marin.rl.weight_transfer.arrow_flight import ArrowFlightCoordinator
 from marin.training.run_environment import add_run_env_variables
-from marin.utils import remove_tpu_lockfile_on_exit
 from rigging.log_setup import configure_logging
 
 logger = logging.getLogger(__name__)
@@ -310,29 +309,27 @@ def _create_runtime_handles(client: Client, config: RLJobConfig) -> _HostedRunti
 def _train_worker_entry(train_config, runtime: RLRuntimeHandles) -> None:
     """Entrypoint for the training worker child job."""
     configure_logging(level=logging.INFO)
-    with remove_tpu_lockfile_on_exit():
-        try:
-            worker = TrainWorker(config=train_config, runtime=runtime)
-            worker.train()
-            runtime.run_state.mark_completed.remote().result()
-        except Exception:
-            logger.exception("TRAIN WORKER CRASHED (orchestration entrypoint)")
-            # Do not mark the shared run state failed here. This function runs
-            # inside a single trainer task attempt, and Iris may retry the same
-            # child job under the still-running coordinator. If we flip the
-            # shared run_state to FAILED on an attempt-local crash, rollout
-            # workers interpret that as whole-run terminal failure and exit
-            # cleanly, leaving the retried trainer without rollout jobs.
-            raise
+    try:
+        worker = TrainWorker(config=train_config, runtime=runtime)
+        worker.train()
+        runtime.run_state.mark_completed.remote().result()
+    except Exception:
+        logger.exception("TRAIN WORKER CRASHED (orchestration entrypoint)")
+        # Do not mark the shared run state failed here. This function runs
+        # inside a single trainer task attempt, and Iris may retry the same
+        # child job under the still-running coordinator. If we flip the
+        # shared run_state to FAILED on an attempt-local crash, rollout
+        # workers interpret that as whole-run terminal failure and exit
+        # cleanly, leaving the retried trainer without rollout jobs.
+        raise
 
 
 def _rollout_worker_entry(rollout_config, runtime: RLRuntimeHandles) -> None:
     """Entrypoint for a rollout worker child job."""
     configure_logging(level=logging.INFO)
-    with remove_tpu_lockfile_on_exit():
-        try:
-            worker = RolloutWorker(config=rollout_config, runtime=runtime)
-            worker.run()
-        except Exception:
-            logger.exception("ROLLOUT WORKER CRASHED (orchestration entrypoint)")
-            raise
+    try:
+        worker = RolloutWorker(config=rollout_config, runtime=runtime)
+        worker.run()
+    except Exception:
+        logger.exception("ROLLOUT WORKER CRASHED (orchestration entrypoint)")
+        raise

--- a/lib/marin/src/marin/utils.py
+++ b/lib/marin/src/marin/utils.py
@@ -1,11 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import logging
 import os
-import subprocess
-from collections.abc import Iterator
-from contextlib import contextmanager
 from datetime import datetime
 from typing import Any
 
@@ -16,8 +12,6 @@ import requests
 from huggingface_hub.utils import HfHubHTTPError
 from rigging.filesystem import url_to_fs
 from rigging.timing import ExponentialBackoff, retry_with_backoff
-
-logger = logging.getLogger(__name__)
 
 
 def fsspec_exists(file_path: str) -> bool:
@@ -215,35 +209,6 @@ def rebase_file_path(
             dot_idx = rel_path.rfind(".")
             rel_path = (rel_path[:dot_idx] if dot_idx != -1 else rel_path) + new_extension
     return os.path.join(base_out_path, rel_path)
-
-
-@contextmanager
-def remove_tpu_lockfile_on_exit() -> Iterator[None]:
-    """Context manager that removes the TPU lockfile when the block exits."""
-    try:
-        yield
-    finally:
-        _hacky_remove_tpu_lockfile()
-
-
-def _hacky_remove_tpu_lockfile():
-    """
-    This is a hack to remove the lockfile that TPU pods create on the host filesystem.
-
-    libtpu only allows one process to access the TPU at a time, and it uses a lockfile to enforce this.
-    Ordinarily a lockfile would be removed when the process exits, but a long-running worker process may not exit until
-    the node is shut down. This means that the lockfile can persist across tasks. This doesn't apply to tasks that fork a
-    new process to do the TPU work, but does apply to tasks that run the TPU code in the same long-running worker
-    process.
-    """
-    try:
-        os.unlink("/tmp/libtpu_lockfile")
-    except FileNotFoundError:
-        pass
-    except PermissionError:
-        result = subprocess.run(["sudo", "rm", "-f", "/tmp/libtpu_lockfile"], capture_output=True)
-        if result.returncode != 0:
-            logger.error("Failed to remove lockfile: %s", result.stderr.decode(errors="replace"))
 
 
 def get_directory_friendly_name(name: str) -> str:


### PR DESCRIPTION
## Summary

Remove the `remove_tpu_lockfile_on_exit` helper and unwrap its remaining Marin call sites. The helper was a Ray-era workaround for reusing long-running worker processes across TPU tasks; current Iris/Fray task execution no longer relies on that cleanup path.

This updates:

- checkpoint export task submission
- TPU vLLM smoke-test task entrypoint
- RL train/rollout worker entrypoints
- `marin.utils`, removing the helper and now-unused imports

The standalone TPU CI VM cleanup commands under `infra/tpu-ci` are intentionally left alone because they are VM hygiene outside this Marin helper/call path.

## Validation

- `PYTHONPATH=tests:. uv run --package marin-core --extra cpu --frozen ruff check lib/marin/src/marin/utils.py lib/marin/src/marin/export/levanter_checkpoint.py lib/marin/src/marin/inference/vllm_smoke_test.py lib/marin/src/marin/rl/orchestration.py`
- `PYTHONPATH=tests:. uv run --package marin-core --extra cpu --frozen ruff format --check lib/marin/src/marin/utils.py lib/marin/src/marin/export/levanter_checkpoint.py lib/marin/src/marin/inference/vllm_smoke_test.py lib/marin/src/marin/rl/orchestration.py`
- `PYTHONPATH=tests:. uv run --package marin-core --extra cpu --frozen pytest tests/test_utils.py tests/rl/test_orchestration.py --tb=short -q`
- `git diff --check`