### PR TITLE
[datakit] Optimize the nemotron ferry

### DIFF
--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -100,7 +100,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
         worker_resources=ResourceConfig(cpu=2, ram="16g", disk="5g"),
         max_workers=512,
         override_output_path=f"{base}/normalize",
-    )
+    )  # ~1,380 output shards
 
     minhash = StepSpec(
         name="datakit-nemotron-smoke/minhash",
@@ -108,11 +108,12 @@ def build_steps(run_id: str) -> list[StepSpec]:
         fn=lambda output_path: compute_minhash_attrs(
             source=Artifact.from_path(normalized, NormalizedData),
             output_path=output_path,
-            worker_resources=ResourceConfig(cpu=5, ram="16g", disk="5g"),
-            max_workers=512,
+            worker_resources=ResourceConfig(cpu=3.5, ram="12g", disk="5g"),
+            max_workers=460,
+            map_workers_per_actor=3,
         ),
         override_output_path=f"{base}/minhash",
-    )
+    )  # ~1,380 output shards
 
     deduped = StepSpec(
         name="datakit-nemotron-smoke/fuzzy_dups",
@@ -121,12 +122,13 @@ def build_steps(run_id: str) -> list[StepSpec]:
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[Artifact.from_path(minhash, MinHashAttrData)],
             output_path=output_path,
-            max_parallelism=512,
+            max_parallelism=690,
             cc_max_iterations=3,
-            worker_resources=ResourceConfig(cpu=1, ram="16g", disk="5g"),
+            worker_resources=ResourceConfig(cpu=2.5, ram="20g", disk="5g"),
+            map_workers_per_actor=2,
         ),
         override_output_path=f"{base}/fuzzy_dups",
-    )
+    )  # ~1,380 output shards
 
     consolidated = StepSpec(
         name="datakit-nemotron-smoke/consolidate",
@@ -146,11 +148,12 @@ def build_steps(run_id: str) -> list[StepSpec]:
                     keep_if_missing=True,
                 ),
             ],
-            worker_resources=ResourceConfig(cpu=1, ram="16g", disk="5g"),
-            max_workers=512,
+            worker_resources=ResourceConfig(cpu=8.5, ram="16g", disk="5g"),
+            max_workers=173,
+            map_workers_per_actor=8,
         ),
         override_output_path=f"{base}/consolidate",
-    )
+    )  # ~1,380 output shards
 
     tokenized = StepSpec(
         name="datakit-nemotron-smoke/tokenize",
@@ -162,12 +165,13 @@ def build_steps(run_id: str) -> list[StepSpec]:
                 validation_paths=[],
                 cache_path=output_path,
                 tokenizer="gpt2",
-                max_workers=512,
-                worker_resources=ResourceConfig(ram="16g", disk="5g"),
+                max_workers=460,
+                worker_resources=ResourceConfig(cpu=3.5, ram="15g", disk="5g"),
+                map_workers_per_actor=3,
             )
         ),
         override_output_path=f"{base}/tokens",
-    )
+    )  # ~1,380 output shards
 
     return [download, normalized, minhash, deduped, consolidated, tokenized]
 

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -148,6 +148,7 @@ def consolidate(
     filetype: str = "jsonl.gz",
     worker_resources: ResourceConfig | None = None,
     max_workers: int | None = None,
+    map_workers_per_actor: int | None = None,
 ) -> ZephyrExecutionResult:
     """Consolidate documents by applying filters based on attributes.
 
@@ -165,6 +166,7 @@ def consolidate(
             packs multiple workers per VM and OOMs on heavy-tailed inputs where
             a single doc can blow past the per-worker share.
         max_workers: Maximum number of Zephyr workers (defaults to Zephyr's default).
+        map_workers_per_actor: Number of workers per actor for the map stage.
     """
     input_paths = sorted(fsspec_glob(os.path.join(input_path, f"**/*.{filetype}")))
     if not input_paths:
@@ -192,6 +194,8 @@ def consolidate(
     if worker_resources is None:
         worker_resources = ResourceConfig(cpu=2, ram="4g")
     ctx_kwargs: dict = {"name": "consolidate-filter", "resources": worker_resources}
+    if map_workers_per_actor is not None:
+        ctx_kwargs["map_workers_per_actor"] = map_workers_per_actor
     if max_workers is not None:
         ctx_kwargs["max_workers"] = max_workers
     ctx = ZephyrContext(**ctx_kwargs)

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -237,6 +237,7 @@ def compute_fuzzy_dups_attrs(
     max_parallelism: int,
     worker_resources: ResourceConfig | None = None,
     coordinator_resources: ResourceConfig | None = None,
+    map_workers_per_actor: int | None = None,
 ) -> FuzzyDupsAttrData:
     """Mark fuzzy-duplicate cluster membership across one or more ``MinHashAttrData`` inputs.
 
@@ -288,6 +289,8 @@ def compute_fuzzy_dups_attrs(
     }
     if coordinator_resources is not None:
         ctx_kwargs["coordinator_resources"] = coordinator_resources
+    if map_workers_per_actor is not None:
+        ctx_kwargs["map_workers_per_actor"] = map_workers_per_actor
     ctx = ZephyrContext(**ctx_kwargs)
 
     # Cap shard count at max_parallelism. Each group reads its attr files

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -123,6 +123,7 @@ def compute_minhash_attrs(
     seed: int = 42,
     worker_resources: ResourceConfig | None = None,
     max_workers: int | None = None,
+    map_workers_per_actor: int | None = None,
 ) -> MinHashAttrData:
     """Compute MinHash bucket attributes for *source* and persist as Parquet.
 
@@ -174,6 +175,8 @@ def compute_minhash_attrs(
     }
     if max_workers is not None:
         ctx_kwargs["max_workers"] = max_workers
+    if map_workers_per_actor is not None:
+        ctx_kwargs["map_workers_per_actor"] = map_workers_per_actor
     ctx = ZephyrContext(**ctx_kwargs)
 
     # Preserve source basenames; zephyr's `{basename}` placeholder is synthetic.

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -83,6 +83,7 @@ class TokenizeConfigBase(abc.ABC):
 
     max_workers: int = 4096
     worker_resources: ResourceConfig = dataclasses.field(default_factory=lambda: ResourceConfig(ram="10g", disk="5g"))
+    map_workers_per_actor: int | None = None
 
     tokenizer_backend: TokenizerBackend = TokenizerBackend.HF
     """Backend to use for tokenization. HF uses the HuggingFace tokenizers library directly.
@@ -330,6 +331,8 @@ def _run_split(
         max_workers=min(config.max_workers, len(file_groups)),
         name=f"tokenize-{split_name}",
     )
+    if config.map_workers_per_actor is not None:
+        ctx.map_workers_per_actor = config.map_workers_per_actor
     # Broadcast tokenizer config to workers. We send name + backend rather than
     # the tokenizer object because not all backends support pickling.
     ctx.put("tokenizer_name", config.tokenizer)


### PR DESCRIPTION
This tunes the Nemotron ferry to keep the full number of output shards from normalize in flight and then uses extra threads to process them in parallel. I tried to be reasonably conservative here, but we could probably tune it further.

I still don't actually have `production` priority (I assume that requires an Iris deploy), so I ran my test with `interactive`. It was faster across the board for actual task wall time, except for `normalize`, which I didn't actually change and I think the slowness is the result of it running 2.5 times because it got preempted. @ravwojdyla would be interesting if you wanted to kick this off with production priority.

<table>
  <tr>
    <th>Baseline</th>
    <th>This PR</th>
  </tr>
  <tr>
    <td>
<code>"wall_seconds_total": 6822.146,
"stage_wall_seconds": {
  "tokenize": 2323.32,
  "consolidate": 329.975,
  "fuzzy_dups": 2149.28,
  "minhash": 1155.259,
  "normalize": 567.383
},
"sum_task_wall_seconds_total": 1689487.543,
"stage_sum_task_wall_seconds": {
  "normalize": 171286.572,
  "minhash": 326978.25,
  "fuzzy_dups": 600393.88,
  "consolidate": 53901.989,
  "tokenize": 536900.312
}</code>
    </td>
    <td>
<code>"wall_seconds_total": 9001.454,
"stage_wall_seconds": {
  "tokenize": 2208.522,
  "consolidate": 560.585,
  "fuzzy_dups": 3499.334,
  "minhash": 1039.469,
  "normalize": 2407.428
},
"sum_task_wall_seconds_total": 1109374.367,
"stage_sum_task_wall_seconds": {
  "normalize": 394126.965,
  "minhash": 110935.643,
  "fuzzy_dups": 410550.06,
  "consolidate": 42926.551,
  "tokenize": 150835.148
}</code>
    </td>
  </tr>
</table>
