### PR TITLE
[Grug] Reshard MoE block before MLP

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -58,6 +58,10 @@ def _batch_spec() -> P:
     return P(("data", "expert"))
 
 
+def _batch_reshard(x: jax.Array) -> jax.Array:
+    return reshard(x, _batch_spec())
+
+
 @dataclass(frozen=True)
 class GrugModelConfig:
     """Hyperparameters for the grug MoE transformer.
@@ -451,8 +455,8 @@ class Block(eqx.Module):
         mask: AttentionMask | jax.Array,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         attn_in = self.attn_gated_norm(self.rms_attn(x))
-        x = x + self.attn(attn_in, mask)
-        mlp_in = self.mlp_gated_norm(self.rms_mlp(x))
+        x = _batch_reshard(x + self.attn(attn_in, mask))
+        mlp_in = _batch_reshard(self.mlp_gated_norm(self.rms_mlp(x)))
         mlp_out, router_stats = self.mlp(mlp_in)
         if self.shared is not None:
             mlp_out = mlp_out + self.shared(mlp_in, activation=ActivationFunctionEnum.silu)


### PR DESCRIPTION
Reshard the Grug MoE block residual and gated MLP input back to the batch/expert layout before routed and shared experts run. This removes the attention-to-MLP layout cliff used by the issue5815 FA4 THD full-block benchmark. Adds a contract test for the boundary reshards.

Part of #5815