### PR TITLE
[nightshift] Align prompts with author-pr skill (plain-text PRs)

### DIFF
--- a/infra/scripts/nightshift_ci_tests.py
+++ b/infra/scripts/nightshift_ci_tests.py
@@ -11,7 +11,6 @@ import json
 import logging
 import os
 import re
-import secrets
 import subprocess
 import tempfile
 import zipfile
@@ -341,7 +340,6 @@ def select_candidates(ranked: list[dict[str, Any]]) -> list[dict[str, Any]]:
 def build_prompt(
     *,
     date: str,
-    haiku_seed: str,
     candidate_file: Path,
     log_root: Path,
     repo: str,
@@ -350,10 +348,6 @@ def build_prompt(
     """Build the agent prompt for one CI-test audit run."""
     return f"""\
 You are the Nightshift CI Test Audit agent.
-
-Your random seed is: {haiku_seed}
-Use this seed to compose a haiku about test maintenance. Include it as the
-epigraph of any PR you create.
 
 ## Context
 
@@ -378,6 +372,8 @@ Treat `unstable` as a hypothesis from log evidence, not a proven flake. Confirm
 against the code and test intent before changing behavior.
 
 Read `AGENTS.md` for project conventions.
+Before opening any PR, read `.agents/skills/author-pr/SKILL.md`; its
+plain-text PR format is mandatory.
 
 ## Rules of Engagement
 
@@ -402,7 +398,10 @@ Read `AGENTS.md` for project conventions.
   1. Create or use branch `nightshift/ci-tests-{date.replace('-', '')}`.
   2. Push and open a PR titled `[nightshift] investigate slow/flaky CI tests`.
   3. Add labels `agent-generated` and `nightshift`.
-  4. Begin the PR body with your haiku.
+  4. Body: follow `.agents/skills/author-pr/SKILL.md` exactly — plain text,
+     commit-style, no markdown headers, bullet lists, tables, or emoji,
+     under ~80 words. Reference any related issue with `Fixes #NNNN` or
+     `Part of #NNNN`; omit the link only if no related issue exists.
   5. Enable automerge with squash.
 - Otherwise, exit cleanly and explain in plain text why no fix was justified.
   Do not open an issue. Do not create an empty PR. Do not edit unrelated files.
@@ -492,7 +491,6 @@ def main() -> None:
 
         prompt = build_prompt(
             date=date,
-            haiku_seed=secrets.token_hex(4),
             candidate_file=candidate_file,
             log_root=logs_root,
             repo=repo,

--- a/infra/scripts/nightshift_cleanup.py
+++ b/infra/scripts/nightshift_cleanup.py
@@ -6,7 +6,6 @@
 import datetime
 import json
 import logging
-import secrets
 import shutil
 import subprocess
 import tempfile
@@ -19,8 +18,6 @@ SUBPROJECTS = ["lib/marin/src/marin", "lib/iris/src/iris", "lib/zephyr/src/zephy
 
 SCOUT_PROMPT = """\
 You are a Nightshift Scout Agent assigned to: {subproject}
-
-Your random seed is: {haiku_seed}
 
 ## Your Mission
 
@@ -81,10 +78,6 @@ If you find nothing worth changing, write:
 MERGE_PROMPT = """\
 You are the Nightshift Merge Agent.
 
-Your random seed is: {haiku_seed}
-Use this seed to compose a haiku about code maintenance. Include it
-as the epigraph of your PR description.
-
 ## Context
 
 Parallel scout agents searched these subprojects for cleanup opportunities.
@@ -113,9 +106,17 @@ The scout worktrees with their commits are at these paths:
    git rebase origin/main
    ```
 
-4. Open a PR:
+4. Read `AGENTS.md` for project conventions and read
+   `.agents/skills/author-pr/SKILL.md` before authoring the PR — its
+   plain-text format is mandatory.
+
+5. Open a PR:
    - Title: `[nightshift] {date} multi-cleanup`
-   - Body: your haiku as epigraph, then a combined summary of all scout findings
+   - Body: follow `.agents/skills/author-pr/SKILL.md` exactly — plain text,
+     commit-style, no markdown headers, bullet lists, tables, or emoji,
+     under ~80 words. Briefly summarize what each scout changed and why.
+     Reference any related issue with `Fixes #NNNN` or `Part of #NNNN`;
+     omit the link only if no related issue exists.
    - Labels: `agent-generated`, `nightshift`
 
 5. Enable automerge:
@@ -160,11 +161,9 @@ def run_scout(subproject: str, worktree_path: Path) -> tuple[str, dict, str]:
     """Run a single scout agent in a pre-created git worktree."""
     with tempfile.NamedTemporaryFile(suffix=".json", prefix=f"nightshift-{worktree_path.name}-", delete=False) as f:
         result_file = f.name
-    haiku_seed = secrets.token_hex(4)
 
     prompt = SCOUT_PROMPT.format(
         subproject=subproject,
-        haiku_seed=haiku_seed,
         result_file=result_file,
     )
 
@@ -196,7 +195,7 @@ def run_scout(subproject: str, worktree_path: Path) -> tuple[str, dict, str]:
     return subproject, result, str(worktree_path)
 
 
-def run_merge(date: str, haiku_seed: str, scout_results: list[dict], worktree_info: list[tuple[str, str]]) -> None:
+def run_merge(date: str, scout_results: list[dict], worktree_info: list[tuple[str, str]]) -> None:
     """Run the merge agent to combine scout results into a single PR."""
     results_text = "\n".join(
         f"### {r['subproject']}\n- Status: {r['status']}\n- Summary: {r.get('summary', 'N/A')}" for r in scout_results
@@ -204,7 +203,6 @@ def run_merge(date: str, haiku_seed: str, scout_results: list[dict], worktree_in
     worktree_text = "\n".join(f"- `{subproject}`: `{path}`" for subproject, path in worktree_info)
 
     prompt = MERGE_PROMPT.format(
-        haiku_seed=haiku_seed,
         scout_results=results_text,
         worktree_info=worktree_text,
         date=date,
@@ -279,9 +277,8 @@ def main() -> None:
         cleanup_worktrees(repo_root)
         return
 
-    haiku_seed = secrets.token_hex(4)
     try:
-        run_merge(date, haiku_seed, scout_results, worktree_info)
+        run_merge(date, scout_results, worktree_info)
     finally:
         cleanup_worktrees(repo_root)
 

--- a/infra/scripts/nightshift_doc_drift.py
+++ b/infra/scripts/nightshift_doc_drift.py
@@ -9,20 +9,16 @@ import subprocess
 DOC_DRIFT_PROMPT = """\
 You are the Nightshift Doc Drift detector.
 
-## Ritual
-
-Your random seed is: {run_id}-{run_attempt}
-Before you begin, use this seed to inspire a haiku about
-documentation drift. Keep the haiku — you will include it as an epigraph
-in any PR or issue you create.
-
 ## Scope
 
-Sample a single subfolder of `docs/` to focus on. Use your random seed
-to pick one at random. If the chosen subfolder has fewer than 3 markdown
-files, expand to its parent.
+Your random seed is: {run_id}-{run_attempt}
+Sample a single subfolder of `docs/` to focus on. Use this seed to pick
+one at random. If the chosen subfolder has fewer than 3 markdown files,
+expand to its parent.
 
 Read `AGENTS.md` for project conventions.
+Before opening any PR, read `.agents/skills/author-pr/SKILL.md`; its
+plain-text PR format is mandatory.
 
 ## Mission
 
@@ -56,17 +52,21 @@ is found, exit cleanly with a brief summary of what you checked.
 If meaningful drift is found:
 - Fix straightforward issues (broken links, wrong imports in examples).
 - For larger issues, file a GitHub issue with labels `documentation`,
-  `agent-generated`, and `nightshift`. Begin the body with your haiku.
+  `agent-generated`, and `nightshift`. Keep the title and body terse:
+  describe the observed drift and the concrete follow-up needed.
 - If you made fixes, open a PR following these steps:
   1. Before pushing, ensure your branch is up to date with origin/main:
      ```
      git fetch origin main
      git rebase origin/main
      ```
-  2. Push and open the PR:
+  2. Push and open the PR. Follow `.agents/skills/author-pr/SKILL.md`
+     exactly: plain-text commit-style body (no markdown headers, bullet
+     lists, tables, or emoji), under ~80 words. Reference any related
+     issue with `Fixes #NNNN` or `Part of #NNNN`; if you filed a tracking
+     issue in the step above, link it with `Part of #NNNN`.
      - Title: `[nightshift] fix documentation drift`
      - Labels: `agent-generated`, `nightshift`
-     - Begin the PR body with your haiku.
   3. Enable automerge on the PR:
      ```
      gh pr merge --auto --squash <PR_NUMBER>
@@ -74,7 +74,7 @@ If meaningful drift is found:
   4. Pick a reviewer by finding who has recently touched the files you changed.
      Use GitHub login names (NOT emails):
      ```
-     gh api '/repos/{owner}/{repo}/commits?path=<changed_file>&per_page=20' \
+     gh api '/repos/{{owner}}/{{repo}}/commits?path=<changed_file>&per_page=20' \
        --jq '.[].author.login' | grep -v '\\[bot\\]' | sort | uniq -c | sort -rn | head -5
      ```
      Pick the top human contributor and request their review:

--- a/tests/test_nightshift_prompts.py
+++ b/tests/test_nightshift_prompts.py
@@ -1,0 +1,81 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Regression tests for the nightshift agent prompts.
+
+Issue #3782: the scheduled nightshift prompts in `infra/scripts/nightshift_*.py`
+used to instruct agents to write stylized PR/issue bodies (haiku epigraphs) that
+conflict with the canonical plain-text PR style. These tests pin the prompts to
+the post-fix contract:
+
+- no "haiku" / "epigraph" instructions anywhere
+- prompts that open PRs point at `.agents/skills/author-pr/SKILL.md`
+- prompts that open PRs require an issue-linked PR body (`Fixes #NNNN` /
+  `Part of #NNNN`)
+- every prompt still `.format()`-renders without unbound placeholders, using the
+  exact kwargs their caller passes.
+"""
+from __future__ import annotations
+
+import importlib.util
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+SCRIPTS_DIR = REPO_ROOT / "infra" / "scripts"
+
+
+def _load(name: str) -> ModuleType:
+    path = SCRIPTS_DIR / f"{name}.py"
+    spec = importlib.util.spec_from_file_location(name, path)
+    assert spec is not None and spec.loader is not None
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture(scope="module")
+def rendered_prompts() -> dict[str, str]:
+    """Render every nightshift prompt with the kwargs its caller actually uses."""
+    doc_drift = _load("nightshift_doc_drift")
+    cleanup = _load("nightshift_cleanup")
+    ci_tests = _load("nightshift_ci_tests")
+
+    return {
+        "doc_drift": doc_drift.DOC_DRIFT_PROMPT.format(run_id="abc", run_attempt="1"),
+        "scout": cleanup.SCOUT_PROMPT.format(
+            subproject="lib/marin/src/marin", result_file="/tmp/x.json"
+        ),
+        "merge": cleanup.MERGE_PROMPT.format(
+            scout_results="X", worktree_info="Y", date="20260530"
+        ),
+        "ci_tests": ci_tests.build_prompt(
+            date="2026-05-30",
+            candidate_file=Path("/tmp/c.json"),
+            log_root=Path("/tmp/l"),
+            repo="o/r",
+            candidates=[],
+        ),
+    }
+
+
+PR_AUTHORING_PROMPTS = ("doc_drift", "merge", "ci_tests")
+
+
+@pytest.mark.parametrize("name", ["doc_drift", "scout", "merge", "ci_tests"])
+def test_no_haiku_or_epigraph(rendered_prompts: dict[str, str], name: str) -> None:
+    text = rendered_prompts[name].lower()
+    assert "haiku" not in text
+    assert "epigraph" not in text
+
+
+@pytest.mark.parametrize("name", PR_AUTHORING_PROMPTS)
+def test_points_at_author_pr_skill(rendered_prompts: dict[str, str], name: str) -> None:
+    assert ".agents/skills/author-pr/SKILL.md" in rendered_prompts[name]
+
+
+@pytest.mark.parametrize("name", PR_AUTHORING_PROMPTS)
+def test_requires_issue_link(rendered_prompts: dict[str, str], name: str) -> None:
+    text = rendered_prompts[name]
+    assert "Fixes #NNNN" in text or "Part of #NNNN" in text


### PR DESCRIPTION
Drop the haiku/epigraph ritual from the nightshift doc-drift, cleanup merge, and CI-test audit prompts; point them at .agents/skills/author-pr/SKILL.md and require plain-text commit-style PR bodies that reference an issue with Fixes or Part of. Also fixes a pre-existing KeyError in nightshift_doc_drift.py where {owner}/{repo} was not escaped before .format(). Adds a regression test.

Fixes #3782