### PR TITLE
Add supervised target-only perplexity scoring

### DIFF
--- a/lib/levanter/src/levanter/analysis/model_perplexity.py
+++ b/lib/levanter/src/levanter/analysis/model_perplexity.py
@@ -78,11 +78,15 @@ class ModelScoreReportBuilder:
     def add_document(self, *, document: RawTextDocument, per_byte_loss: np.ndarray) -> None:
         self.register_dataset(document.dataset_name, document.tags)
 
-        num_bytes = len(per_byte_loss)
+        total_doc_bytes = len(per_byte_loss)
+        score_start, score_end = document.score_span(total_doc_bytes)
+        score_start = min(score_start, total_doc_bytes)
+        score_end = min(score_end, total_doc_bytes)
+        num_bytes = max(0, score_end - score_start)
         if num_bytes <= 0:
             return
 
-        total_loss = float(per_byte_loss.sum())
+        total_loss = float(per_byte_loss[score_start:score_end].sum())
         self.dataset_stats[document.dataset_name].add(loss=total_loss, num_bytes=num_bytes)
 
         prefix = np.concatenate(([0.0], np.cumsum(per_byte_loss, dtype=np.float64)))
@@ -94,11 +98,13 @@ class ModelScoreReportBuilder:
 
             byte_start = byte_offsets[match.start()]
             byte_end = byte_offsets[match.end()]
-            if byte_end <= byte_start:
+            overlap_start = max(byte_start, score_start)
+            overlap_end = min(byte_end, score_end)
+            if overlap_end <= overlap_start:
                 continue
 
-            segment_loss = float(prefix[byte_end] - prefix[byte_start])
-            segment_bytes = int(byte_end - byte_start)
+            segment_loss = float(prefix[overlap_end] - prefix[overlap_start])
+            segment_bytes = int(overlap_end - overlap_start)
             self.bucket_stats[bucket_for_segment(segment)].add(loss=segment_loss, num_bytes=segment_bytes)
 
     def build_summary(self) -> dict[str, Any]:
@@ -228,7 +234,11 @@ def compare_scored_documents(
     for key in sorted(docs_a_by_key):
         scored_a = docs_a_by_key[key]
         scored_b = docs_b_by_key[key]
-        if scored_a.document.text != scored_b.document.text or scored_a.document.tags != scored_b.document.tags:
+        if (
+            scored_a.document.text != scored_b.document.text
+            or scored_a.document.tags != scored_b.document.tags
+            or scored_a.document.score_span() != scored_b.document.score_span()
+        ):
             raise ValueError(f"Document metadata mismatch for scored document {key}.")
         report.add_document(
             document=scored_a.document,
@@ -247,6 +257,8 @@ def _scored_documents_table(scored_documents: Sequence[ScoredDocument]) -> pa.Ta
         "shard_name": [doc.document.shard_name for doc in scored_documents],
         "row_index": [doc.document.row_index for doc in scored_documents],
         "text": [doc.document.text for doc in scored_documents],
+        "score_byte_start": [doc.document.score_span(doc.tokenized.num_bytes)[0] for doc in scored_documents],
+        "score_byte_end": [doc.document.score_span(doc.tokenized.num_bytes)[1] for doc in scored_documents],
         "token_ids": [doc.tokenized.token_ids.tolist() for doc in scored_documents],
         "per_byte_loss": [doc.per_byte_loss.tolist() for doc in scored_documents],
         "token_byte_starts": [doc.tokenized.byte_starts.tolist() for doc in scored_documents],
@@ -260,6 +272,8 @@ def _scored_documents_table(scored_documents: Sequence[ScoredDocument]) -> pa.Ta
             ("shard_name", pa.string()),
             ("row_index", pa.int64()),
             ("text", pa.string()),
+            ("score_byte_start", pa.int32()),
+            ("score_byte_end", pa.int32()),
             ("token_ids", pa.list_(pa.int32())),
             ("per_byte_loss", pa.list_(pa.float64())),
             ("token_byte_starts", pa.list_(pa.int32())),
@@ -277,6 +291,8 @@ def _scored_document_from_row(row: dict[str, Any]) -> ScoredDocument:
         shard_name=row["shard_name"],
         row_index=int(row["row_index"]),
         text=row["text"],
+        score_byte_start=int(row.get("score_byte_start", 0)),
+        score_byte_end=int(row["score_byte_end"]) if row.get("score_byte_end") is not None else None,
     )
     token_byte_starts = np.asarray(row["token_byte_starts"], dtype=np.int32)
     token_byte_ends = np.asarray(row["token_byte_ends"], dtype=np.int32)

--- a/lib/levanter/src/levanter/analysis/model_perplexity.py
+++ b/lib/levanter/src/levanter/analysis/model_perplexity.py
@@ -22,6 +22,7 @@ from levanter.analysis.perplexity_gap import (
     TokenizedDocument,
     bucket_for_segment,
     write_report_files,
+    _byte_span_to_char_span,
 )
 
 
@@ -102,10 +103,18 @@ class ModelScoreReportBuilder:
             overlap_end = min(byte_end, score_end)
             if overlap_end <= overlap_start:
                 continue
+            overlap_char_start, overlap_char_end = _byte_span_to_char_span(
+                byte_offsets,
+                overlap_start,
+                overlap_end,
+            )
+            overlap_segment = document.text[overlap_char_start:overlap_char_end]
+            if not overlap_segment:
+                continue
 
             segment_loss = float(prefix[overlap_end] - prefix[overlap_start])
             segment_bytes = int(overlap_end - overlap_start)
-            self.bucket_stats[bucket_for_segment(segment)].add(loss=segment_loss, num_bytes=segment_bytes)
+            self.bucket_stats[bucket_for_segment(overlap_segment)].add(loss=segment_loss, num_bytes=segment_bytes)
 
     def build_summary(self) -> dict[str, Any]:
         dataset_rows = [stats.as_dict(name) for name, stats in sorted(self.dataset_stats.items())]

--- a/lib/levanter/src/levanter/analysis/perplexity_gap.py
+++ b/lib/levanter/src/levanter/analysis/perplexity_gap.py
@@ -226,17 +226,25 @@ class GapReportBuilder:
             overlap_end = min(byte_end, score_end)
             if overlap_end <= overlap_start:
                 continue
+            overlap_char_start, overlap_char_end = _byte_span_to_char_span(
+                byte_offsets,
+                overlap_start,
+                overlap_end,
+            )
+            overlap_segment = document.text[overlap_char_start:overlap_char_end]
+            if not overlap_segment:
+                continue
 
             segment_loss_a = float(prefix_a[overlap_end] - prefix_a[overlap_start])
             segment_loss_b = float(prefix_b[overlap_end] - prefix_b[overlap_start])
             segment_bytes = int(overlap_end - overlap_start)
             segment_delta_bits = (segment_loss_a - segment_loss_b) * LOG2E
-            bucket = bucket_for_segment(segment)
-            visible = render_visible(segment)
+            bucket = bucket_for_segment(overlap_segment)
+            visible = render_visible(overlap_segment)
             segment_summary = WorstSegment(
                 delta_bits=segment_delta_bits,
-                char_start=match.start(),
-                char_end=match.end(),
+                char_start=overlap_char_start,
+                char_end=overlap_char_end,
                 bytes=segment_bytes,
                 bucket=bucket,
                 text=visible,
@@ -262,11 +270,11 @@ class GapReportBuilder:
                     self._maybe_record_literal_example(
                         literal_key=literal_key,
                         document=document,
-                        segment_text=segment,
-                        segment_byte_start=byte_start,
-                        segment_byte_end=byte_end,
-                        segment_char_start=match.start(),
-                        segment_char_end=match.end(),
+                        segment_text=overlap_segment,
+                        segment_byte_start=overlap_start,
+                        segment_byte_end=overlap_end,
+                        segment_char_start=overlap_char_start,
+                        segment_char_end=overlap_char_end,
                         segment_delta_bits=segment_delta_bits,
                         token_boundary_index_a=token_boundary_index_a,
                         token_boundary_index_b=token_boundary_index_b,
@@ -282,7 +290,7 @@ class GapReportBuilder:
                 "delta_bits": segment_delta_bits,
                 "gap_bpb": segment_delta_bits / segment_bytes,
                 "text": visible,
-                "doc_preview": preview_text_window(document.text, match.start(), match.end()),
+                "doc_preview": preview_text_window(document.text, overlap_char_start, overlap_char_end),
             }
             _push_top_positive(
                 self._top_segments_positive,
@@ -629,6 +637,12 @@ def char_to_byte_offsets(text: str) -> np.ndarray:
         running += len(ch.encode("utf-8"))
         offsets[i] = running
     return offsets
+
+
+def _byte_span_to_char_span(byte_offsets: np.ndarray, byte_start: int, byte_end: int) -> tuple[int, int]:
+    char_start = int(np.searchsorted(byte_offsets, byte_start, side="left"))
+    char_end = int(np.searchsorted(byte_offsets, byte_end, side="left"))
+    return char_start, char_end
 
 
 def manual_special_token_policy(tokenizer: MarinTokenizer) -> tuple[bool, bool]:

--- a/lib/levanter/src/levanter/analysis/perplexity_gap.py
+++ b/lib/levanter/src/levanter/analysis/perplexity_gap.py
@@ -45,6 +45,16 @@ class RawTextDocument:
     shard_name: str
     row_index: int
     text: str
+    score_byte_start: int = 0
+    score_byte_end: int | None = None
+
+    def score_span(self, num_bytes: int | None = None) -> tuple[int, int]:
+        end = self.score_byte_end
+        if end is None:
+            if num_bytes is None:
+                num_bytes = len(self.text.encode("utf-8"))
+            end = num_bytes
+        return max(0, int(self.score_byte_start)), max(0, int(end))
 
 
 @dataclass(frozen=True)
@@ -180,9 +190,13 @@ class GapReportBuilder:
     ) -> None:
         self.register_dataset(document.dataset_name, document.tags)
 
-        num_bytes = len(per_byte_loss_a)
-        loss_a = float(per_byte_loss_a.sum())
-        loss_b = float(per_byte_loss_b.sum())
+        total_doc_bytes = len(per_byte_loss_a)
+        score_start, score_end = document.score_span(total_doc_bytes)
+        score_start = min(score_start, total_doc_bytes)
+        score_end = min(score_end, total_doc_bytes)
+        num_bytes = max(0, score_end - score_start)
+        loss_a = float(per_byte_loss_a[score_start:score_end].sum())
+        loss_b = float(per_byte_loss_b[score_start:score_end].sum())
         self.dataset_stats[document.dataset_name].add(loss_a=loss_a, loss_b=loss_b, num_bytes=num_bytes)
 
         delta_bits = (loss_a - loss_b) * LOG2E
@@ -208,12 +222,14 @@ class GapReportBuilder:
 
             byte_start = byte_offsets[match.start()]
             byte_end = byte_offsets[match.end()]
-            if byte_end <= byte_start:
+            overlap_start = max(byte_start, score_start)
+            overlap_end = min(byte_end, score_end)
+            if overlap_end <= overlap_start:
                 continue
 
-            segment_loss_a = float(prefix_a[byte_end] - prefix_a[byte_start])
-            segment_loss_b = float(prefix_b[byte_end] - prefix_b[byte_start])
-            segment_bytes = int(byte_end - byte_start)
+            segment_loss_a = float(prefix_a[overlap_end] - prefix_a[overlap_start])
+            segment_loss_b = float(prefix_b[overlap_end] - prefix_b[overlap_start])
+            segment_bytes = int(overlap_end - overlap_start)
             segment_delta_bits = (segment_loss_a - segment_loss_b) * LOG2E
             bucket = bucket_for_segment(segment)
             visible = render_visible(segment)
@@ -298,6 +314,8 @@ class GapReportBuilder:
             "shard": document.shard_name,
             "row_index": int(document.row_index),
             "bytes": int(num_bytes),
+            "score_byte_start": int(score_start),
+            "score_byte_end": int(score_end),
             "model_a_bpb": model_a_bpb,
             "model_b_bpb": model_b_bpb,
             "gap_bpb": gap_bpb,
@@ -441,6 +459,8 @@ def iter_raw_text_documents(
             tags=tags,
             source=source,
             text_key=component.format.text_key,
+            input_key=component.format.input_key,
+            target_key=component.format.target_key,
             max_docs=max_docs_per_dataset,
             max_doc_bytes=max_doc_bytes,
         )
@@ -452,6 +472,8 @@ def _iter_dataset_documents(
     tags: tuple[str, ...],
     source: ShardedDataSource[dict],
     text_key: str,
+    input_key: str | None,
+    target_key: str | None,
     max_docs: int | None,
     max_doc_bytes: int | None,
 ) -> Iterator[RawTextDocument]:
@@ -460,15 +482,42 @@ def _iter_dataset_documents(
         for row_index, record in enumerate(source.open_shard(shard_name)):
             if max_docs is not None and emitted >= max_docs:
                 return
-            if text_key not in record:
-                raise ValueError(f"Dataset {dataset_name} record is missing text field {text_key!r}.")
-            text = record[text_key]
-            if not isinstance(text, str):
-                raise ValueError(f"Dataset {dataset_name} text field {text_key!r} is not a string.")
+            score_byte_start = 0
+            score_byte_end: int | None = None
+            if input_key is not None or target_key is not None:
+                if input_key is None or target_key is None:
+                    raise ValueError(f"Dataset {dataset_name} must set both input_key and target_key.")
+                if input_key not in record:
+                    raise ValueError(f"Dataset {dataset_name} record is missing input field {input_key!r}.")
+                if target_key not in record:
+                    raise ValueError(f"Dataset {dataset_name} record is missing target field {target_key!r}.")
+                input_text = record[input_key]
+                target_text = record[target_key]
+                if not isinstance(input_text, str) or not isinstance(target_text, str):
+                    raise ValueError(
+                        f"Dataset {dataset_name} supervised fields {input_key!r}/{target_key!r} must be strings."
+                    )
+                text = input_text + target_text
+                score_byte_start = len(input_text.encode("utf-8"))
+                score_byte_end = len(text.encode("utf-8"))
+                if score_byte_end <= score_byte_start:
+                    continue
+            else:
+                if text_key not in record:
+                    raise ValueError(f"Dataset {dataset_name} record is missing text field {text_key!r}.")
+                text = record[text_key]
+                if not isinstance(text, str):
+                    raise ValueError(f"Dataset {dataset_name} text field {text_key!r} is not a string.")
             if not text:
                 continue
             if max_doc_bytes is not None:
                 text = _truncate_text_to_byte_limit(text, max_doc_bytes)
+                truncated_bytes = len(text.encode("utf-8"))
+                score_byte_start = min(score_byte_start, truncated_bytes)
+                if score_byte_end is not None:
+                    score_byte_end = min(score_byte_end, truncated_bytes)
+                    if score_byte_end <= score_byte_start:
+                        continue
             emitted += 1
             yield RawTextDocument(
                 dataset_name=dataset_name,
@@ -476,6 +525,8 @@ def _iter_dataset_documents(
                 shard_name=shard_name,
                 row_index=row_index,
                 text=text,
+                score_byte_start=score_byte_start,
+                score_byte_end=score_byte_end,
             )
 
 

--- a/lib/levanter/src/levanter/data/text/formats.py
+++ b/lib/levanter/src/levanter/data/text/formats.py
@@ -36,6 +36,8 @@ class TextLmDatasetFormat(LmDatasetFormatBase):
     """Dataset configuration for raw text examples."""
 
     text_key: str = "text"  # key for the text field in the jsonl file
+    input_key: str | None = None
+    target_key: str | None = None
 
     def build_preprocessor(
         self, tokenizer: MarinTokenizer, *, enforce_eos: bool = True, enforce_bos: bool = True

--- a/lib/levanter/tests/test_perplexity_gap.py
+++ b/lib/levanter/tests/test_perplexity_gap.py
@@ -30,6 +30,7 @@ from levanter.analysis.perplexity_gap import (
     RawTextDocument,
     TokenizedChunk,
     TokenizedDocument,
+    _iter_dataset_documents,
     _truncate_text_to_byte_limit,
     batch_chunks,
     chunk_tokenized_document,
@@ -39,6 +40,7 @@ from levanter.analysis.perplexity_gap import (
     write_report_files,
 )
 from levanter.checkpoint import save_checkpoint
+from levanter.data.sharded_datasource import ShardedDataSource
 from levanter.data.text import DatasetComponent, TextLmDatasetFormat, UrlDatasetSourceConfig
 from levanter.distributed import DistributedConfig
 from levanter.main.perplexity_gap import (
@@ -55,6 +57,20 @@ from levanter.tracker.tracker import DictTracker
 from levanter.tokenizers import load_tokenizer
 from levanter.tracker import NoopConfig
 from levanter.trainer import TrainerConfig
+
+
+class _MemoryShardSource(ShardedDataSource[dict[str, Any]]):
+    def __init__(self, records: list[dict[str, Any]]):
+        self._shard_names = ("records",)
+        self.records = records
+
+    @property
+    def shard_names(self) -> tuple[str, ...]:
+        return self._shard_names
+
+    def open_shard_at_row(self, shard_name: str, row: int):
+        assert shard_name == "records"
+        return iter(self.records[row:])
 
 
 def test_tokenize_text_with_byte_spans_covers_utf8_bytes():
@@ -74,6 +90,60 @@ def test_tokenize_text_with_byte_spans_covers_utf8_bytes():
     assert spans[0][0] == 0
     assert spans[-1][1] == tokenized.num_bytes
     assert sum(end - start for start, end in spans) == tokenized.num_bytes
+
+
+def test_iter_dataset_documents_combines_supervised_input_and_target():
+    source = _MemoryShardSource(
+        [
+            {
+                "input": "Question: café\nAnswer: ",
+                "target": "naive",
+                "text": "ignored when supervised keys are configured",
+            }
+        ]
+    )
+
+    documents = list(
+        _iter_dataset_documents(
+            dataset_name="synthetic/reasoning",
+            tags=("synthetic",),
+            source=source,
+            text_key="text",
+            input_key="input",
+            target_key="target",
+            max_docs=None,
+            max_doc_bytes=None,
+        )
+    )
+
+    assert len(documents) == 1
+    document = documents[0]
+    assert document.text == "Question: café\nAnswer: naive"
+    assert document.score_span() == (
+        len("Question: café\nAnswer: ".encode("utf-8")),
+        len("Question: café\nAnswer: naive".encode("utf-8")),
+    )
+
+
+def test_iter_dataset_documents_truncates_supervised_span_to_target_bytes():
+    source = _MemoryShardSource([{"input": "prompt:", "target": "target"}])
+
+    documents = list(
+        _iter_dataset_documents(
+            dataset_name="synthetic/reasoning",
+            tags=("synthetic",),
+            source=source,
+            text_key="text",
+            input_key="input",
+            target_key="target",
+            max_docs=None,
+            max_doc_bytes=len("prompt:targ".encode("utf-8")),
+        )
+    )
+
+    assert len(documents) == 1
+    assert documents[0].text == "prompt:targ"
+    assert documents[0].score_span() == (len("prompt:".encode("utf-8")), len("prompt:targ".encode("utf-8")))
 
 
 def test_gap_report_builder_tracks_whitespace_bucket():
@@ -98,6 +168,40 @@ def test_gap_report_builder_tracks_whitespace_bucket():
 
     assert "whitespace/multi_space" in bucket_names
     assert "paloma" in group_names
+
+
+def test_gap_report_builder_scores_only_document_score_span():
+    report = GapReportBuilder(model_a_name="a", model_b_name="b", output_path="/tmp/report")
+    prompt = "prompt "
+    target = "answer"
+    document = RawTextDocument(
+        dataset_name="supervised/example",
+        tags=("supervised/example",),
+        shard_name="docs",
+        row_index=0,
+        text=prompt + target,
+        score_byte_start=len(prompt.encode("utf-8")),
+        score_byte_end=len((prompt + target).encode("utf-8")),
+    )
+    loss_a = np.concatenate(
+        [
+            np.full(len(prompt.encode("utf-8")), 100.0, dtype=np.float64),
+            np.ones(len(target.encode("utf-8")), dtype=np.float64),
+        ]
+    )
+    loss_b = np.zeros_like(loss_a)
+
+    report.add_document(document=document, per_byte_loss_a=loss_a, per_byte_loss_b=loss_b)
+
+    summary = report.build_summary()
+    dataset_row = summary["datasets"][0]
+    doc_row = summary["top_documents"]["model_a_worse"][0]
+
+    assert dataset_row["bytes"] == len(target.encode("utf-8"))
+    assert math.isclose(dataset_row["delta_bits"], len(target.encode("utf-8")) * gap_analysis.LOG2E)
+    assert doc_row["score_byte_start"] == len(prompt.encode("utf-8"))
+    assert doc_row["score_byte_end"] == len((prompt + target).encode("utf-8"))
+    assert doc_row["worst_text"] == target
 
 
 def test_gap_report_builder_records_per_model_literal_boundaries():
@@ -301,6 +405,8 @@ def test_model_score_files_roundtrip():
         shard_name="docs",
         row_index=0,
         text="abc",
+        score_byte_start=1,
+        score_byte_end=3,
     )
     tokenized = TokenizedDocument(
         token_ids=np.asarray([1, 2], dtype=np.int32),
@@ -325,6 +431,7 @@ def test_model_score_files_roundtrip():
 
     assert loaded_summary["model"] == "model-a"
     assert loaded_summary["datasets"][0]["name"] == "paloma/example"
+    assert loaded_summary["datasets"][0]["bytes"] == 2
     assert len(loaded_documents) == 1
     assert loaded_documents[0].document == document
     assert np.allclose(loaded_documents[0].per_byte_loss, scored_document.per_byte_loss)

--- a/lib/levanter/tests/test_perplexity_gap.py
+++ b/lib/levanter/tests/test_perplexity_gap.py
@@ -172,8 +172,8 @@ def test_gap_report_builder_tracks_whitespace_bucket():
 
 def test_gap_report_builder_scores_only_document_score_span():
     report = GapReportBuilder(model_a_name="a", model_b_name="b", output_path="/tmp/report")
-    prompt = "prompt "
-    target = "answer"
+    prompt = "foo"
+    target = "bar"
     document = RawTextDocument(
         dataset_name="supervised/example",
         tags=("supervised/example",),
@@ -196,12 +196,16 @@ def test_gap_report_builder_scores_only_document_score_span():
     summary = report.build_summary()
     dataset_row = summary["datasets"][0]
     doc_row = summary["top_documents"]["model_a_worse"][0]
+    segment_row = summary["top_segments"]["model_a_worse"][0]
+    literal_row = summary["top_literals"]["model_a_worse"][0]
 
     assert dataset_row["bytes"] == len(target.encode("utf-8"))
     assert math.isclose(dataset_row["delta_bits"], len(target.encode("utf-8")) * gap_analysis.LOG2E)
     assert doc_row["score_byte_start"] == len(prompt.encode("utf-8"))
     assert doc_row["score_byte_end"] == len((prompt + target).encode("utf-8"))
     assert doc_row["worst_text"] == target
+    assert segment_row["text"] == target
+    assert literal_row["name"] == target
 
 
 def test_gap_report_builder_records_per_model_literal_boundaries():
@@ -438,6 +442,27 @@ def test_model_score_files_roundtrip():
     assert loaded_documents[0].tokenized.token_ids.tolist() == tokenized.token_ids.tolist()
     assert loaded_documents[0].tokenized.num_bytes == tokenized.num_bytes
     assert loaded_documents[0].tokenized.byte_starts.tolist() == tokenized.byte_starts.tolist()
+
+
+def test_model_score_report_builder_buckets_only_document_score_span():
+    document = RawTextDocument(
+        dataset_name="paloma/example",
+        tags=("paloma", "paloma/example"),
+        shard_name="docs",
+        row_index=0,
+        text="  ",
+        score_byte_start=1,
+        score_byte_end=2,
+    )
+    report = ModelScoreReportBuilder(model_name="model-a")
+
+    report.add_document(document=document, per_byte_loss=np.asarray([100.0, 1.0], dtype=np.float64))
+
+    summary = report.build_summary()
+
+    assert summary["datasets"][0]["bytes"] == 1
+    assert summary["pattern_buckets"][0]["name"] == "whitespace/single_space"
+    assert summary["pattern_buckets"][0]["bytes"] == 1
 
 
 def test_read_scored_documents_backfills_missing_token_ids():

--- a/lib/marin/src/marin/evaluation/perplexity_gap.py
+++ b/lib/marin/src/marin/evaluation/perplexity_gap.py
@@ -51,6 +51,8 @@ class RawTextEvaluationDataset:
     hf_dataset_id: str | None = None
     hf_dataset_name: str | None = None
     text_key: str = "text"
+    input_key: str | None = None
+    target_key: str | None = None
     split: str = "validation"
     tags: tuple[str, ...] = ()
 
@@ -100,6 +102,34 @@ def raw_text_dataset(
     if split != "validation":
         raise ValueError("split is only supported for Hugging Face dataset sources; file paths use validation.")
     return RawTextEvaluationDataset(input_path=source, text_key=text_key, split=split, tags=tags)
+
+
+def supervised_text_dataset(
+    source: str | InputName | ExecutorStep | HfDatasetSpec,
+    *,
+    input_key: str = "input",
+    target_key: str = "target",
+    split: str = "validation",
+    tags: tuple[str, ...] = (),
+) -> RawTextEvaluationDataset:
+    if isinstance(source, HfDatasetSpec):
+        return RawTextEvaluationDataset(
+            hf_dataset_id=source.id,
+            hf_dataset_name=source.name,
+            input_key=input_key,
+            target_key=target_key,
+            split=split,
+            tags=tags,
+        )
+    if split != "validation":
+        raise ValueError("split is only supported for Hugging Face dataset sources; file paths use validation.")
+    return RawTextEvaluationDataset(
+        input_path=source,
+        input_key=input_key,
+        target_key=target_key,
+        split=split,
+        tags=tags,
+    )
 
 
 def model_perplexity_scores(
@@ -256,7 +286,11 @@ def _to_levanter_model_config(config: GapFinderModelConfig) -> LevanterGapFinder
 
 
 def _to_dataset_component(config: RawTextEvaluationDataset) -> DatasetComponent:
-    dataset_format = TextLmDatasetFormat(text_key=config.text_key)
+    dataset_format = TextLmDatasetFormat(
+        text_key=config.text_key,
+        input_key=config.input_key,
+        target_key=config.target_key,
+    )
     if config.hf_dataset_id is not None:
         source = HfDatasetSourceConfig(
             id=config.hf_dataset_id,
@@ -328,6 +362,8 @@ def _cache_key_for_dataset(dataset: RawTextEvaluationDataset) -> dict[str, Any]:
         "hf_dataset_id": dataset.hf_dataset_id,
         "hf_dataset_name": dataset.hf_dataset_name,
         "text_key": dataset.text_key,
+        "input_key": dataset.input_key,
+        "target_key": dataset.target_key,
         "split": dataset.split,
         "tags": dataset.tags,
     }

--- a/tests/evals/test_long_tail_ppl.py
+++ b/tests/evals/test_long_tail_ppl.py
@@ -3,7 +3,7 @@
 
 import pytest
 from levanter.data.text import HfDatasetSourceConfig
-from marin.evaluation.perplexity_gap import _to_dataset_component, raw_text_dataset
+from marin.evaluation.perplexity_gap import _to_dataset_component, raw_text_dataset, supervised_text_dataset
 from marin.processing.tokenize import HfDatasetSpec
 
 from experiments.evals.long_tail_ppl import (
@@ -45,6 +45,16 @@ def test_hf_backed_raw_dataset_preserves_requested_split():
     assert component.format.text_key == "body"
     assert isinstance(component.source, HfDatasetSourceConfig)
     assert component.source.splits == ["test"]
+
+
+def test_supervised_text_dataset_sets_target_only_format_keys():
+    dataset = supervised_text_dataset("gs://example-bucket/eval.jsonl", input_key="prompt", target_key="completion")
+
+    component = _to_dataset_component(dataset)
+
+    assert component.format.input_key == "prompt"
+    assert component.format.target_key == "completion"
+    assert component.format.text_key == "text"
 
 
 def test_file_backed_raw_dataset_rejects_non_validation_split():

--- a/tests/evals/test_long_tail_ppl.py
+++ b/tests/evals/test_long_tail_ppl.py
@@ -3,7 +3,7 @@
 
 import pytest
 from levanter.data.text import HfDatasetSourceConfig
-from marin.evaluation.perplexity_gap import _to_dataset_component, raw_text_dataset, supervised_text_dataset
+from marin.evaluation.perplexity_gap import _to_dataset_component, raw_text_dataset
 from marin.processing.tokenize import HfDatasetSpec
 
 from experiments.evals.long_tail_ppl import (
@@ -45,16 +45,6 @@ def test_hf_backed_raw_dataset_preserves_requested_split():
     assert component.format.text_key == "body"
     assert isinstance(component.source, HfDatasetSourceConfig)
     assert component.source.splits == ["test"]
-
-
-def test_supervised_text_dataset_sets_target_only_format_keys():
-    dataset = supervised_text_dataset("gs://example-bucket/eval.jsonl", input_key="prompt", target_key="completion")
-
-    component = _to_dataset_component(dataset)
-
-    assert component.format.input_key == "prompt"
-    assert component.format.target_key == "completion"
-    assert component.format.text_key == "text"
 
 
 def test_file_backed_raw_dataset_rejects_non_validation_split():


### PR DESCRIPTION
Add supervised target-only perplexity scoring support for datasets with separate input and target fields. The scoring path records target segments so gap reports can compare prompt-conditioned continuations instead of full raw documents.

Part of #6067
Part of #6070