### PR TITLE
Add prompt-format and code-interpretation PPL suites

### DIFF
--- a/experiments/evals/code_interpretation_ppl.py
+++ b/experiments/evals/code_interpretation_ppl.py
@@ -1,0 +1,158 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Code-interpretation supervised PPL slices for issue #6070."""
+
+from __future__ import annotations
+
+from marin.datakit.ingestion_manifest import (
+    IdentityTreatment,
+    IngestionPolicy,
+    IngestionSourceManifest,
+    SampleCapConfig,
+    SecretRedaction,
+    StagingMetadata,
+    UsagePolicy,
+)
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, supervised_text_dataset
+from marin.execution.executor import executor_main
+from marin.execution.step_spec import StepSpec
+from marin.transform.evaluation.code_interpretation import (
+    CODE_INTERPRETATION_NUM_FEWSHOT,
+    CODE_INTERPRETATION_RENDERER_VERSION,
+    CODE_INTERPRETATION_TASKS,
+    CODE_INTERPRETATION_TEMPLATES,
+    DEFAULT_CODE_INTERPRETATION_OUTPUT_FILENAME,
+    CodeInterpretationStagingConfig,
+    stage_code_interpretation_source,
+)
+
+CODE_INTERPRETATION_ISSUE = 6070
+CODE_INTERPRETATION_PREFIX = "code_interpretation"
+CODE_INTERPRETATION_DATASET_ID = "marin/code_interpretation_static"
+
+
+def _eval_only_policy() -> IngestionPolicy:
+    return IngestionPolicy(
+        usage_policy=UsagePolicy.EVAL_ONLY,
+        use_policy="Eval-only code-interpretation probes. Do not mix into training.",
+        requires_sanitization=False,
+        identity_treatment=IdentityTreatment.PRESERVE,
+        secret_redaction=SecretRedaction.NONE,
+        contamination_risk="high: examples are intentionally held-out eval probes",
+        provenance_notes=(
+            "Deterministic static examples created to isolate Python-like expression and helper-definition "
+            "interpretation. Slices use 5-shot support and score only the held-out output continuation."
+        ),
+    )
+
+
+def _manifest_for_slice(
+    task_key: str, task_family: str, template_key: str, heldout_count: int
+) -> IngestionSourceManifest:
+    slice_key = f"{CODE_INTERPRETATION_PREFIX}/{task_key}/{template_key}"
+    return IngestionSourceManifest(
+        dataset_key=CODE_INTERPRETATION_DATASET_ID,
+        slice_key=slice_key,
+        source_label=slice_key,
+        source_urls=(f"https://github.com/marin-community/marin/issues/{CODE_INTERPRETATION_ISSUE}",),
+        source_license="Apache-2.0",
+        source_format="deterministic_static_code_interpretation_examples",
+        surface_form=f"{CODE_INTERPRETATION_NUM_FEWSHOT}shot_{template_key}_target_only",
+        policy=_eval_only_policy(),
+        staging=StagingMetadata(
+            transform_name="stage_code_interpretation_source",
+            serializer_name=template_key,
+            split="validation",
+            subset=task_key,
+            metadata={
+                "task_key": task_key,
+                "task_family": task_family,
+                "template_key": template_key,
+                "renderer_version": CODE_INTERPRETATION_RENDERER_VERSION,
+                "num_fewshot": CODE_INTERPRETATION_NUM_FEWSHOT,
+            },
+        ),
+        issue_numbers=(CODE_INTERPRETATION_ISSUE,),
+        sample_caps=SampleCapConfig(max_examples=heldout_count),
+        source_metadata={"construction": "static deterministic examples; no external download"},
+    )
+
+
+CODE_INTERPRETATION_SOURCE_MANIFESTS: dict[str, IngestionSourceManifest] = {
+    f"{CODE_INTERPRETATION_PREFIX}/{task.key}/{template.key}": _manifest_for_slice(
+        task.key,
+        task.family,
+        template.key,
+        len(task.heldout_examples),
+    )
+    for task in CODE_INTERPRETATION_TASKS
+    for template in CODE_INTERPRETATION_TEMPLATES
+}
+
+
+def _stage_step(task_key: str, template_key: str) -> StepSpec:
+    dataset_key = f"{CODE_INTERPRETATION_PREFIX}/{task_key}/{template_key}"
+    manifest = CODE_INTERPRETATION_SOURCE_MANIFESTS[dataset_key]
+    return StepSpec(
+        name=f"evaluation/{dataset_key}",
+        deps=[],
+        fn=lambda output_path: stage_code_interpretation_source(
+            CodeInterpretationStagingConfig(
+                output_path=output_path,
+                task_key=task_key,
+                template_key=template_key,
+                source_manifest=manifest,
+                content_fingerprint=manifest.fingerprint(),
+            )
+        ),
+        hash_attrs={
+            "dataset_key": dataset_key,
+            "manifest_fingerprint": manifest.fingerprint(),
+            "task_key": task_key,
+            "template_key": template_key,
+            "renderer_version": CODE_INTERPRETATION_RENDERER_VERSION,
+            "output_filename": DEFAULT_CODE_INTERPRETATION_OUTPUT_FILENAME,
+        },
+    )
+
+
+CODE_INTERPRETATION_STAGED: dict[str, StepSpec] = {
+    dataset_key: _stage_step(
+        str(manifest.staging.metadata["task_key"]),
+        str(manifest.staging.metadata["template_key"]),
+    )
+    for dataset_key, manifest in CODE_INTERPRETATION_SOURCE_MANIFESTS.items()
+}
+
+
+def code_interpretation_validation_sets() -> dict[str, RawTextEvaluationDataset]:
+    """Return code-interpretation slices for supervised target-only PPL scoring."""
+
+    datasets: dict[str, RawTextEvaluationDataset] = {}
+    for dataset_key, step in CODE_INTERPRETATION_STAGED.items():
+        manifest = CODE_INTERPRETATION_SOURCE_MANIFESTS[dataset_key]
+        metadata = manifest.staging.metadata or {}
+        task_key = str(metadata["task_key"])
+        task_family = str(metadata["task_family"])
+        template_key = str(metadata["template_key"])
+        datasets[dataset_key] = supervised_text_dataset(
+            step.as_executor_step().cd(DEFAULT_CODE_INTERPRETATION_OUTPUT_FILENAME),
+            tags=(
+                CODE_INTERPRETATION_PREFIX,
+                f"issue:{CODE_INTERPRETATION_ISSUE}",
+                f"task:{task_key}",
+                f"task_family:{task_family}",
+                f"template:{template_key}",
+                f"num_fewshot:{CODE_INTERPRETATION_NUM_FEWSHOT}",
+                "format:supervised_target_only",
+            ),
+        )
+    return datasets
+
+
+if __name__ == "__main__":
+    executor_main(
+        steps=[step.as_executor_step() for step in CODE_INTERPRETATION_STAGED.values()],
+        description="Stage code-interpretation supervised PPL slices for issue #6070.",
+    )

--- a/experiments/evals/perplexity_gap_registry.py
+++ b/experiments/evals/perplexity_gap_registry.py
@@ -27,8 +27,10 @@ from marin.execution.types import ExecutorStep
 
 from experiments.bio_chem_notation import bio_chem_raw_validation_sets
 from experiments.defaults import default_raw_validation_sets
+from experiments.evals.code_interpretation_ppl import code_interpretation_validation_sets
 from experiments.evals.fineweb2_multilingual import fineweb2_multilingual_raw_validation_sets
 from experiments.evals.formal_hardware_ppl import formal_hardware_raw_validation_sets
+from experiments.evals.prompt_format_sensitivity import prompt_format_sensitivity_validation_sets
 from experiments.evals.web_markup_image_text_ppl import web_markup_image_text_raw_validation_sets
 from experiments.marin_models import marin_tokenizer
 
@@ -110,6 +112,22 @@ def bio_chem_bundle() -> PerplexityGapBundle:
     )
 
 
+def prompt_format_sensitivity_bundle() -> PerplexityGapBundle:
+    return PerplexityGapBundle(
+        key="prompt_format_sensitivity",
+        description="Static 5-shot tasks rendered through many prompt templates to measure surface sensitivity.",
+        datasets_factory=prompt_format_sensitivity_validation_sets,
+    )
+
+
+def code_interpretation_bundle() -> PerplexityGapBundle:
+    return PerplexityGapBundle(
+        key="code_interpretation",
+        description="Static 5-shot Python-like expression and helper-definition interpretation slices.",
+        datasets_factory=code_interpretation_validation_sets,
+    )
+
+
 def registered_perplexity_gap_bundles() -> tuple[PerplexityGapBundle, ...]:
     return (
         base_raw_bundle(),
@@ -117,6 +135,8 @@ def registered_perplexity_gap_bundles() -> tuple[PerplexityGapBundle, ...]:
         web_markup_image_text_bundle(),
         formal_hardware_bundle(),
         bio_chem_bundle(),
+        prompt_format_sensitivity_bundle(),
+        code_interpretation_bundle(),
     )
 
 

--- a/experiments/evals/prompt_format_sensitivity.py
+++ b/experiments/evals/prompt_format_sensitivity.py
@@ -1,0 +1,152 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Prompt-format sensitivity supervised PPL slices for issue #6067."""
+
+from __future__ import annotations
+
+from marin.datakit.ingestion_manifest import (
+    IdentityTreatment,
+    IngestionPolicy,
+    IngestionSourceManifest,
+    SampleCapConfig,
+    SecretRedaction,
+    StagingMetadata,
+    UsagePolicy,
+)
+from marin.evaluation.perplexity_gap import RawTextEvaluationDataset, supervised_text_dataset
+from marin.execution.executor import executor_main
+from marin.execution.step_spec import StepSpec
+from marin.transform.evaluation.prompt_format_sensitivity import (
+    DEFAULT_PROMPT_FORMAT_OUTPUT_FILENAME,
+    PROMPT_FORMAT_NUM_FEWSHOT,
+    PROMPT_FORMAT_RENDERER_VERSION,
+    PROMPT_FORMAT_TASKS,
+    PROMPT_FORMAT_TEMPLATES,
+    PromptFormatSensitivityStagingConfig,
+    stage_prompt_format_sensitivity_source,
+)
+
+PROMPT_FORMAT_SENSITIVITY_ISSUE = 6067
+PROMPT_FORMAT_SENSITIVITY_PREFIX = "prompt_format_sensitivity"
+PROMPT_FORMAT_SENSITIVITY_DATASET_ID = "marin/prompt_format_sensitivity_static"
+
+
+def _eval_only_policy() -> IngestionPolicy:
+    return IngestionPolicy(
+        usage_policy=UsagePolicy.EVAL_ONLY,
+        use_policy="Eval-only prompt-format sensitivity probes. Do not mix into training.",
+        requires_sanitization=False,
+        identity_treatment=IdentityTreatment.PRESERVE,
+        secret_redaction=SecretRedaction.NONE,
+        contamination_risk="high: examples are intentionally held-out eval probes",
+        provenance_notes=(
+            "Deterministic static examples created to isolate prompt surface-form sensitivity. "
+            "Every slice uses the same 5-shot support/query semantics for a task and changes only rendering."
+        ),
+    )
+
+
+def _manifest_for_slice(task_key: str, template_key: str, heldout_count: int) -> IngestionSourceManifest:
+    slice_key = f"{PROMPT_FORMAT_SENSITIVITY_PREFIX}/{task_key}/{template_key}"
+    return IngestionSourceManifest(
+        dataset_key=PROMPT_FORMAT_SENSITIVITY_DATASET_ID,
+        slice_key=slice_key,
+        source_label=slice_key,
+        source_urls=(f"https://github.com/marin-community/marin/issues/{PROMPT_FORMAT_SENSITIVITY_ISSUE}",),
+        source_license="Apache-2.0",
+        source_format="deterministic_static_prompt_format_examples",
+        surface_form=f"{PROMPT_FORMAT_NUM_FEWSHOT}shot_{template_key}_target_only",
+        policy=_eval_only_policy(),
+        staging=StagingMetadata(
+            transform_name="stage_prompt_format_sensitivity_source",
+            serializer_name=template_key,
+            split="validation",
+            subset=task_key,
+            metadata={
+                "task_key": task_key,
+                "template_key": template_key,
+                "renderer_version": PROMPT_FORMAT_RENDERER_VERSION,
+                "num_fewshot": PROMPT_FORMAT_NUM_FEWSHOT,
+            },
+        ),
+        issue_numbers=(PROMPT_FORMAT_SENSITIVITY_ISSUE,),
+        sample_caps=SampleCapConfig(max_examples=heldout_count),
+        source_metadata={"construction": "static deterministic examples; no external download"},
+    )
+
+
+PROMPT_FORMAT_SENSITIVITY_SOURCE_MANIFESTS: dict[str, IngestionSourceManifest] = {
+    f"{PROMPT_FORMAT_SENSITIVITY_PREFIX}/{task.key}/{template.key}": _manifest_for_slice(
+        task.key,
+        template.key,
+        len(task.heldout_examples),
+    )
+    for task in PROMPT_FORMAT_TASKS
+    for template in PROMPT_FORMAT_TEMPLATES
+}
+
+
+def _stage_step(task_key: str, template_key: str) -> StepSpec:
+    dataset_key = f"{PROMPT_FORMAT_SENSITIVITY_PREFIX}/{task_key}/{template_key}"
+    manifest = PROMPT_FORMAT_SENSITIVITY_SOURCE_MANIFESTS[dataset_key]
+    return StepSpec(
+        name=f"evaluation/{dataset_key}",
+        deps=[],
+        fn=lambda output_path: stage_prompt_format_sensitivity_source(
+            PromptFormatSensitivityStagingConfig(
+                output_path=output_path,
+                task_key=task_key,
+                template_key=template_key,
+                source_manifest=manifest,
+                content_fingerprint=manifest.fingerprint(),
+            )
+        ),
+        hash_attrs={
+            "dataset_key": dataset_key,
+            "manifest_fingerprint": manifest.fingerprint(),
+            "task_key": task_key,
+            "template_key": template_key,
+            "renderer_version": PROMPT_FORMAT_RENDERER_VERSION,
+            "output_filename": DEFAULT_PROMPT_FORMAT_OUTPUT_FILENAME,
+        },
+    )
+
+
+PROMPT_FORMAT_SENSITIVITY_STAGED: dict[str, StepSpec] = {
+    dataset_key: _stage_step(
+        str(manifest.staging.metadata["task_key"]),
+        str(manifest.staging.metadata["template_key"]),
+    )
+    for dataset_key, manifest in PROMPT_FORMAT_SENSITIVITY_SOURCE_MANIFESTS.items()
+}
+
+
+def prompt_format_sensitivity_validation_sets() -> dict[str, RawTextEvaluationDataset]:
+    """Return prompt-format sensitivity slices for supervised target-only PPL scoring."""
+
+    datasets: dict[str, RawTextEvaluationDataset] = {}
+    for dataset_key, step in PROMPT_FORMAT_SENSITIVITY_STAGED.items():
+        manifest = PROMPT_FORMAT_SENSITIVITY_SOURCE_MANIFESTS[dataset_key]
+        metadata = manifest.staging.metadata or {}
+        task_key = str(metadata["task_key"])
+        template_key = str(metadata["template_key"])
+        datasets[dataset_key] = supervised_text_dataset(
+            step.as_executor_step().cd(DEFAULT_PROMPT_FORMAT_OUTPUT_FILENAME),
+            tags=(
+                PROMPT_FORMAT_SENSITIVITY_PREFIX,
+                f"issue:{PROMPT_FORMAT_SENSITIVITY_ISSUE}",
+                f"task:{task_key}",
+                f"template:{template_key}",
+                f"num_fewshot:{PROMPT_FORMAT_NUM_FEWSHOT}",
+                "format:supervised_target_only",
+            ),
+        )
+    return datasets
+
+
+if __name__ == "__main__":
+    executor_main(
+        steps=[step.as_executor_step() for step in PROMPT_FORMAT_SENSITIVITY_STAGED.values()],
+        description="Stage prompt-format sensitivity supervised PPL slices for issue #6067.",
+    )

--- a/experiments/exp_model_perplexity_gap_code_interpretation_32b.py
+++ b/experiments/exp_model_perplexity_gap_code_interpretation_32b.py
@@ -1,0 +1,97 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Marin 32B vs Qwen3 32B code-interpretation gap run."""
+
+from __future__ import annotations
+
+from fray.types import ResourceConfig
+from marin.evaluation.perplexity_gap import (
+    GapFinderModelConfig,
+    model_perplexity_gap_from_scores,
+    model_perplexity_scores,
+)
+from marin.execution.executor import ExecutorStep, executor_main
+
+from experiments.evals.code_interpretation_ppl import CODE_INTERPRETATION_ISSUE, code_interpretation_validation_sets
+from experiments.marin_models import marin_tokenizer
+
+RUN_KEY = "main_gap_32b_code_interpretation_issue6070_v1"
+RESOURCE_CONFIG = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
+MAX_DOCS_PER_DATASET = 256
+MAX_DOC_BYTES = 32_768
+DATASET_BUNDLE = "code_interpretation"
+
+DATASETS = code_interpretation_validation_sets()
+
+MARIN_MODEL = GapFinderModelConfig(
+    checkpoint_path="marin-community/marin-32b-base",
+    checkpoint_is_hf=True,
+    tokenizer=marin_tokenizer,
+)
+QWEN3_MODEL = GapFinderModelConfig(
+    checkpoint_path="Qwen/Qwen3-32B",
+    checkpoint_is_hf=True,
+    tokenizer="Qwen/Qwen3-32B",
+)
+
+MARIN_SCORES = model_perplexity_scores(
+    name=f"{RUN_KEY}/marin_32b",
+    model=MARIN_MODEL,
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=1,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
+    wandb_tags=[
+        "eval=model-perplexity",
+        f"dataset_bundle={DATASET_BUNDLE}",
+        "model=marin-community/marin-32b-base",
+        "region=us-central1",
+        f"issue:{CODE_INTERPRETATION_ISSUE}",
+    ],
+)
+
+QWEN3_SCORES = model_perplexity_scores(
+    name=f"{RUN_KEY}/qwen3_32b",
+    model=QWEN3_MODEL,
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=1,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
+    wandb_tags=[
+        "eval=model-perplexity",
+        f"dataset_bundle={DATASET_BUNDLE}",
+        "model=Qwen/Qwen3-32B",
+        "region=us-central1",
+        f"issue:{CODE_INTERPRETATION_ISSUE}",
+    ],
+)
+
+GAP = model_perplexity_gap_from_scores(
+    name=f"{RUN_KEY}/marin_32b-vs-qwen3_32b",
+    model_a_name="marin-community/marin-32b-base",
+    model_b_name="Qwen/Qwen3-32B",
+    model_a_scores_path=MARIN_SCORES.as_input_name(),
+    model_b_scores_path=QWEN3_SCORES.as_input_name(),
+    wandb_tags=[
+        "eval=perplexity-gap",
+        f"dataset_bundle={DATASET_BUNDLE}",
+        "model_a=marin-community/marin-32b-base",
+        "model_b=Qwen/Qwen3-32B",
+        "region=us-central1",
+        f"issue:{CODE_INTERPRETATION_ISSUE}",
+    ],
+)
+
+STEPS: list[ExecutorStep] = [GAP]
+
+
+if __name__ == "__main__":
+    executor_main(
+        STEPS,
+        description="Run Marin 32B vs Qwen3 32B perplexity gap on code-interpretation slices.",
+    )

--- a/experiments/exp_model_perplexity_gap_prompt_format_sensitivity_32b.py
+++ b/experiments/exp_model_perplexity_gap_prompt_format_sensitivity_32b.py
@@ -1,0 +1,97 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Marin 32B vs Qwen3 32B prompt-format sensitivity gap run."""
+
+from __future__ import annotations
+
+from fray.types import ResourceConfig
+from marin.evaluation.perplexity_gap import (
+    GapFinderModelConfig,
+    model_perplexity_gap_from_scores,
+    model_perplexity_scores,
+)
+from marin.execution.executor import ExecutorStep, executor_main
+
+from experiments.evals.prompt_format_sensitivity import prompt_format_sensitivity_validation_sets
+from experiments.marin_models import marin_tokenizer
+
+RUN_KEY = "main_gap_32b_prompt_format_sensitivity_issue6067_v2"
+RESOURCE_CONFIG = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
+MAX_DOCS_PER_DATASET = 256
+MAX_DOC_BYTES = 32_768
+DATASET_BUNDLE = "prompt_format_sensitivity"
+
+DATASETS = prompt_format_sensitivity_validation_sets()
+
+MARIN_MODEL = GapFinderModelConfig(
+    checkpoint_path="marin-community/marin-32b-base",
+    checkpoint_is_hf=True,
+    tokenizer=marin_tokenizer,
+)
+QWEN3_MODEL = GapFinderModelConfig(
+    checkpoint_path="Qwen/Qwen3-32B",
+    checkpoint_is_hf=True,
+    tokenizer="Qwen/Qwen3-32B",
+)
+
+MARIN_SCORES = model_perplexity_scores(
+    name=f"{RUN_KEY}/marin_32b",
+    model=MARIN_MODEL,
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=1,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
+    wandb_tags=[
+        "eval=model-perplexity",
+        f"dataset_bundle={DATASET_BUNDLE}",
+        "model=marin-community/marin-32b-base",
+        "region=us-central1",
+        "issue:6067",
+    ],
+)
+
+QWEN3_SCORES = model_perplexity_scores(
+    name=f"{RUN_KEY}/qwen3_32b",
+    model=QWEN3_MODEL,
+    datasets=DATASETS,
+    resource_config=RESOURCE_CONFIG,
+    per_device_batch_size=1,
+    max_eval_length=4096,
+    max_docs_per_dataset=MAX_DOCS_PER_DATASET,
+    max_doc_bytes=MAX_DOC_BYTES,
+    wandb_tags=[
+        "eval=model-perplexity",
+        f"dataset_bundle={DATASET_BUNDLE}",
+        "model=Qwen/Qwen3-32B",
+        "region=us-central1",
+        "issue:6067",
+    ],
+)
+
+GAP = model_perplexity_gap_from_scores(
+    name=f"{RUN_KEY}/marin_32b-vs-qwen3_32b",
+    model_a_name="marin-community/marin-32b-base",
+    model_b_name="Qwen/Qwen3-32B",
+    model_a_scores_path=MARIN_SCORES.as_input_name(),
+    model_b_scores_path=QWEN3_SCORES.as_input_name(),
+    wandb_tags=[
+        "eval=perplexity-gap",
+        f"dataset_bundle={DATASET_BUNDLE}",
+        "model_a=marin-community/marin-32b-base",
+        "model_b=Qwen/Qwen3-32B",
+        "region=us-central1",
+        "issue:6067",
+    ],
+)
+
+STEPS: list[ExecutorStep] = [GAP]
+
+
+if __name__ == "__main__":
+    executor_main(
+        STEPS,
+        description="Run Marin 32B vs Qwen3 32B perplexity gap on prompt-format sensitivity slices.",
+    )

--- a/lib/marin/src/marin/transform/evaluation/code_interpretation.py
+++ b/lib/marin/src/marin/transform/evaluation/code_interpretation.py
@@ -1,0 +1,362 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic code-interpretation records for supervised PPL evals."""
+
+from __future__ import annotations
+
+import json
+import posixpath
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from marin.datakit.ingestion_manifest import (
+    IngestionSourceManifest,
+    MaterializedOutputMetadata,
+    write_ingestion_metadata_json,
+)
+from marin.utils import fsspec_mkdirs
+from rigging.filesystem import open_url, url_to_fs
+from zephyr.writers import atomic_rename
+
+CODE_INTERPRETATION_NUM_FEWSHOT = 5
+CODE_INTERPRETATION_RENDERER_VERSION = "v1"
+DEFAULT_CODE_INTERPRETATION_OUTPUT_FILENAME = "staged.jsonl.gz"
+
+
+@dataclass(frozen=True)
+class CodeInterpretationExample:
+    """One static Python-like program/expression and its output."""
+
+    example_id: str
+    code: str
+    target: str
+
+
+@dataclass(frozen=True)
+class CodeInterpretationTask:
+    """A fixed code-interpretation task with five support examples."""
+
+    key: str
+    family: str
+    title: str
+    description: str
+    support_examples: tuple[CodeInterpretationExample, ...]
+    heldout_examples: tuple[CodeInterpretationExample, ...]
+
+
+@dataclass(frozen=True)
+class CodeInterpretationTemplate:
+    """A surface form that renders supports and an unfinished held-out query."""
+
+    key: str
+    family: str
+    description: str
+    renderer: Callable[[CodeInterpretationExample, bool], str]
+
+
+@dataclass(frozen=True)
+class CodeInterpretationStagingConfig:
+    """Configuration for staging one code-interpretation slice."""
+
+    output_path: str
+    task_key: str
+    template_key: str
+    output_filename: str = DEFAULT_CODE_INTERPRETATION_OUTPUT_FILENAME
+    source_manifest: IngestionSourceManifest | None = None
+    content_fingerprint: str = ""
+
+
+def _examples(prefix: str, pairs: tuple[tuple[str, str], ...]) -> tuple[CodeInterpretationExample, ...]:
+    return tuple(
+        CodeInterpretationExample(example_id=f"{prefix}-{index:02d}", code=code, target=target)
+        for index, (code, target) in enumerate(pairs, start=1)
+    )
+
+
+def _as_repl_input(code: str) -> str:
+    prompted_lines: list[str] = []
+    for index, line in enumerate(code.splitlines()):
+        prompt = ">>> " if index == 0 or (line and not line.startswith(" ")) else "... "
+        prompted_lines.append(f"{prompt}{line}")
+    return "\n".join(prompted_lines)
+
+
+def _render_python_repl(example: CodeInterpretationExample, include_target: bool) -> str:
+    rendered = _as_repl_input(example.code)
+    return f"{rendered}\n{example.target if include_target else ''}"
+
+
+def _render_python_doctest(example: CodeInterpretationExample, include_target: bool) -> str:
+    return _render_python_repl(example, include_target)
+
+
+def _render_arrow_control(example: CodeInterpretationExample, include_target: bool) -> str:
+    target = example.target if include_target else ""
+    return f"Python:\n{example.code}\n=> {target}"
+
+
+CODE_INTERPRETATION_TEMPLATES: tuple[CodeInterpretationTemplate, ...] = (
+    CodeInterpretationTemplate(
+        "python_repl",
+        "code_transcript",
+        "natural Python REPL transcript",
+        _render_python_repl,
+    ),
+    CodeInterpretationTemplate(
+        "python_doctest",
+        "code_transcript",
+        "Python doctest-style transcript",
+        _render_python_doctest,
+    ),
+    CodeInterpretationTemplate(
+        "arrow_control",
+        "neutral_control",
+        "code block with neutral arrow output",
+        _render_arrow_control,
+    ),
+)
+CODE_INTERPRETATION_TEMPLATES_BY_KEY = {template.key: template for template in CODE_INTERPRETATION_TEMPLATES}
+
+
+CODE_INTERPRETATION_TASKS: tuple[CodeInterpretationTask, ...] = (
+    CodeInterpretationTask(
+        key="expression_strings_collections",
+        family="expression_only",
+        title="String and collection expression interpretation",
+        description="Evaluate the final value of a small Python expression using strings, lists, dicts, and indexing.",
+        support_examples=_examples(
+            "expr-strings-support",
+            (
+                ("len('marin') + 4", "9"),
+                ("'-'.join(['red', 'blue']).upper()", "RED-BLUE"),
+                ("sorted(['delta', 'alpha', 'beta'])[0]", "alpha"),
+                ("{'a': 2, 'b': 5}['b'] * 3", "15"),
+                ("'abcdef'[1:5:2]", "bd"),
+            ),
+        ),
+        heldout_examples=_examples(
+            "expr-strings-heldout",
+            (
+                ("len('prompt') * 7", "42"),
+                ("'-'.join(reversed(['north', 'east']))", "east-north"),
+                ("{'x': [4, 8], 'y': [3]}['x'][1] + 6", "14"),
+            ),
+        ),
+    ),
+    CodeInterpretationTask(
+        key="expression_arithmetic_slices",
+        family="expression_only",
+        title="Arithmetic and slicing expression interpretation",
+        description=(
+            "Evaluate the final value of a small Python expression using arithmetic, comprehensions, and slices."
+        ),
+        support_examples=_examples(
+            "expr-arith-support",
+            (
+                ("sum([3, 5, 8])", "16"),
+                ("sum(x * x for x in [1, 2, 5])", "30"),
+                ("[n + 2 for n in [4, 7, 9]][-1]", "11"),
+                ("min([12, 4, 9]) + max([1, 7, 3])", "11"),
+                ("list(range(2, 9, 3))[1]", "5"),
+            ),
+        ),
+        heldout_examples=_examples(
+            "expr-arith-heldout",
+            (
+                ("sum(x * x for x in [2, 3, 4])", "29"),
+                ("[n * 2 for n in range(3, 7)][2]", "10"),
+                ("sum([10, -3, 65]) // 4", "18"),
+            ),
+        ),
+    ),
+    CodeInterpretationTask(
+        key="function_definition_calls",
+        family="function_definition",
+        title="Function and class definition interpretation",
+        description="Read simple helper definitions and evaluate the final call or expression.",
+        support_examples=_examples(
+            "fn-support",
+            (
+                (
+                    "def double_then_shift(x):\n" "    value = x * 2\n" "    return value + 3\n" "double_then_shift(5)",
+                    "13",
+                ),
+                (
+                    "def join_edges(items):\n"
+                    "    return items[0] + ':' + items[-1]\n"
+                    "join_edges(['red', 'green', 'blue'])",
+                    "red:blue",
+                ),
+                (
+                    "def clipped_total(values, cap):\n"
+                    "    total = sum(values)\n"
+                    "    return min(total, cap)\n"
+                    "clipped_total([4, 9, 6], 15)",
+                    "15",
+                ),
+                (
+                    "def label_size(name, count):\n"
+                    "    if count >= 4:\n"
+                    "        return name.upper()\n"
+                    "    return name.lower()\n"
+                    "label_size('Box', 3)",
+                    "box",
+                ),
+                (
+                    "class CounterBox:\n"
+                    "    def __init__(self, start):\n"
+                    "        self.total = start\n"
+                    "    def add(self, value):\n"
+                    "        self.total += value\n"
+                    "        return self.total\n"
+                    "box = CounterBox(4)\n"
+                    "(box.add(3), box.add(5))",
+                    "(7, 12)",
+                ),
+            ),
+        ),
+        heldout_examples=_examples(
+            "fn-heldout",
+            (
+                (
+                    "def edge_repeat(text):\n" "    return text[0] + text[-1] * 2\n" "edge_repeat('marin')",
+                    "mnn",
+                ),
+                (
+                    "def scale_and_tag(x, tag):\n"
+                    "    y = x * 4\n"
+                    "    return tag + ':' + str(y - 1)\n"
+                    "scale_and_tag(6, 'job')",
+                    "job:23",
+                ),
+                (
+                    "class PairBox:\n"
+                    "    def __init__(self, left, right):\n"
+                    "        self.left = left\n"
+                    "        self.right = right\n"
+                    "    def flipped(self):\n"
+                    "        return self.right + '-' + self.left\n"
+                    "PairBox('north', 'east').flipped().upper()",
+                    "EAST-NORTH",
+                ),
+            ),
+        ),
+    ),
+)
+CODE_INTERPRETATION_TASKS_BY_KEY = {task.key: task for task in CODE_INTERPRETATION_TASKS}
+
+
+def render_code_interpretation_input(
+    *,
+    task: CodeInterpretationTask,
+    template: CodeInterpretationTemplate,
+    heldout: CodeInterpretationExample,
+) -> str:
+    """Render five support examples and one unfinished held-out query."""
+
+    if len(task.support_examples) != CODE_INTERPRETATION_NUM_FEWSHOT:
+        raise ValueError(f"{task.key} must have exactly {CODE_INTERPRETATION_NUM_FEWSHOT} support examples")
+    header = f"Task: {task.title}\nInstruction: {task.description}\nFormat: {template.description}"
+    blocks = [header, *(template.renderer(example, True) for example in task.support_examples)]
+    blocks.append(template.renderer(heldout, False))
+    return "\n\n".join(blocks)
+
+
+def render_code_interpretation_target(
+    *,
+    template: CodeInterpretationTemplate,
+    heldout: CodeInterpretationExample,
+) -> str:
+    """Render the scored continuation for an unfinished held-out query."""
+
+    unfinished = template.renderer(heldout, False)
+    finished = template.renderer(heldout, True)
+    if not finished.startswith(unfinished):
+        raise ValueError(f"{template.key} renderer must extend its unfinished held-out query")
+    return finished[len(unfinished) :]
+
+
+def code_interpretation_record(task_key: str, template_key: str, heldout_index: int) -> dict[str, Any]:
+    """Return one supervised target-only record for a task/template/held-out index."""
+
+    task = CODE_INTERPRETATION_TASKS_BY_KEY[task_key]
+    template = CODE_INTERPRETATION_TEMPLATES_BY_KEY[template_key]
+    heldout = task.heldout_examples[heldout_index]
+    return {
+        "id": f"{task.key}/{template.key}/{heldout.example_id}",
+        "input": render_code_interpretation_input(task=task, template=template, heldout=heldout),
+        "target": render_code_interpretation_target(template=template, heldout=heldout),
+        "source": "code_interpretation_static",
+        "provenance": {
+            "task_key": task.key,
+            "task_family": task.family,
+            "template_key": template.key,
+            "template_family": template.family,
+            "renderer_version": CODE_INTERPRETATION_RENDERER_VERSION,
+            "num_fewshot": CODE_INTERPRETATION_NUM_FEWSHOT,
+            "support_example_ids": [example.example_id for example in task.support_examples],
+            "heldout_example_id": heldout.example_id,
+            "semantic_target": heldout.target,
+            "heldout_code": heldout.code,
+        },
+    }
+
+
+def stage_code_interpretation_source(cfg: CodeInterpretationStagingConfig) -> dict[str, Any]:
+    """Stage one code-interpretation task/template slice as JSONL."""
+
+    if cfg.source_manifest is not None and cfg.content_fingerprint:
+        expected = cfg.source_manifest.fingerprint()
+        if cfg.content_fingerprint != expected:
+            raise ValueError(
+                f"content_fingerprint mismatch: config has {cfg.content_fingerprint}, source manifest has {expected}"
+            )
+
+    task = CODE_INTERPRETATION_TASKS_BY_KEY[cfg.task_key]
+    if cfg.template_key not in CODE_INTERPRETATION_TEMPLATES_BY_KEY:
+        raise ValueError(f"Unknown code-interpretation template: {cfg.template_key}")
+    if len(task.support_examples) != CODE_INTERPRETATION_NUM_FEWSHOT:
+        raise ValueError(f"{cfg.task_key} must have exactly {CODE_INTERPRETATION_NUM_FEWSHOT} support examples")
+
+    fsspec_mkdirs(cfg.output_path, exist_ok=True)
+    out_file = posixpath.join(cfg.output_path, cfg.output_filename)
+    compression = "gzip" if out_file.endswith(".gz") else None
+
+    with atomic_rename(out_file) as temp_path:
+        with open_url(temp_path, "wt", encoding="utf-8", compression=compression) as outfile:
+            for heldout_index in range(len(task.heldout_examples)):
+                json.dump(code_interpretation_record(cfg.task_key, cfg.template_key, heldout_index), outfile)
+                outfile.write("\n")
+
+    fs, _ = url_to_fs(out_file)
+    output_size = int(fs.info(out_file)["size"])
+    result: dict[str, Any] = {
+        "record_count": len(task.heldout_examples),
+        "bytes_written": output_size,
+        "output_file": out_file,
+    }
+
+    if cfg.source_manifest is not None:
+        metadata_path = write_ingestion_metadata_json(
+            manifest=cfg.source_manifest,
+            materialized_output=MaterializedOutputMetadata(
+                input_path="code_interpretation_static",
+                output_path=cfg.output_path,
+                output_file=out_file,
+                record_count=len(task.heldout_examples),
+                bytes_written=output_size,
+                metadata={
+                    "task_key": cfg.task_key,
+                    "task_family": task.family,
+                    "template_key": cfg.template_key,
+                    "renderer_version": CODE_INTERPRETATION_RENDERER_VERSION,
+                    "num_fewshot": CODE_INTERPRETATION_NUM_FEWSHOT,
+                    "heldout_examples": len(task.heldout_examples),
+                },
+            ),
+        )
+        result["metadata_file"] = metadata_path
+
+    return result

--- a/lib/marin/src/marin/transform/evaluation/prompt_format_sensitivity.py
+++ b/lib/marin/src/marin/transform/evaluation/prompt_format_sensitivity.py
@@ -1,0 +1,576 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deterministic prompt-format sensitivity records for supervised PPL evals."""
+
+from __future__ import annotations
+
+import csv
+import html
+import io
+import json
+import posixpath
+import re
+from collections.abc import Callable
+from dataclasses import dataclass
+from typing import Any
+
+from marin.datakit.ingestion_manifest import (
+    IngestionSourceManifest,
+    MaterializedOutputMetadata,
+    write_ingestion_metadata_json,
+)
+from marin.utils import fsspec_mkdirs
+from rigging.filesystem import open_url, url_to_fs
+from zephyr.writers import atomic_rename
+
+PROMPT_FORMAT_NUM_FEWSHOT = 5
+DEFAULT_PROMPT_FORMAT_OUTPUT_FILENAME = "staged.jsonl.gz"
+PROMPT_FORMAT_RENDERER_VERSION = "v2"
+
+_INDENT_RE = re.compile(r"^", re.MULTILINE)
+
+
+@dataclass(frozen=True)
+class PromptFormatExample:
+    """One semantic input/output pair used across prompt surface forms."""
+
+    example_id: str
+    input_text: str
+    target: str
+
+
+@dataclass(frozen=True)
+class PromptFormatTask:
+    """A fixed task with five support examples and held-out queries."""
+
+    key: str
+    title: str
+    description: str
+    support_examples: tuple[PromptFormatExample, ...]
+    heldout_examples: tuple[PromptFormatExample, ...]
+
+
+@dataclass(frozen=True)
+class PromptFormatTemplate:
+    """A prompt surface form that can render support rows and an unfinished query."""
+
+    key: str
+    family: str
+    description: str
+    renderer: Callable[[PromptFormatExample, bool], str]
+
+
+@dataclass(frozen=True)
+class PromptFormatSensitivityStagingConfig:
+    """Configuration for staging one task/template slice."""
+
+    output_path: str
+    task_key: str
+    template_key: str
+    output_filename: str = DEFAULT_PROMPT_FORMAT_OUTPUT_FILENAME
+    source_manifest: IngestionSourceManifest | None = None
+    content_fingerprint: str = ""
+
+
+def _indent(text: str, spaces: int = 4) -> str:
+    return _INDENT_RE.sub(" " * spaces, text)
+
+
+def _json_string(text: str) -> str:
+    return json.dumps(text, ensure_ascii=True)
+
+
+def _csv_field(text: str) -> str:
+    stream = io.StringIO()
+    writer = csv.writer(stream, lineterminator="")
+    writer.writerow([text])
+    return stream.getvalue()
+
+
+def _csv_pair(input_text: str, target: str) -> str:
+    stream = io.StringIO()
+    writer = csv.writer(stream, lineterminator="")
+    writer.writerow([input_text, target])
+    return stream.getvalue()
+
+
+def _tsv_field(text: str) -> str:
+    return text.replace("\\", "\\\\").replace("\t", "\\t").replace("\n", "\\n")
+
+
+def _markdown_cell(text: str) -> str:
+    return text.replace("|", "\\|").replace("\n", "<br>")
+
+
+def _triple_quoted(text: str) -> str:
+    return text.replace('"""', '\\"\\"\\"')
+
+
+def _render_arrow(example: PromptFormatExample, include_target: bool) -> str:
+    return f"{example.input_text}\n-> {example.target if include_target else ''}"
+
+
+def _render_equals(example: PromptFormatExample, include_target: bool) -> str:
+    return f"{example.input_text}\n= {example.target if include_target else ''}"
+
+
+def _render_colon_mapping(example: PromptFormatExample, include_target: bool) -> str:
+    return f"Input: {example.input_text}\nOutput: {example.target if include_target else ''}"
+
+
+def _render_key_value_block(example: PromptFormatExample, include_target: bool) -> str:
+    return f"input:\n{example.input_text}\n\noutput:\n{example.target if include_target else ''}"
+
+
+def _render_qa(example: PromptFormatExample, include_target: bool) -> str:
+    return f"Q: {example.input_text}\nA: {example.target if include_target else ''}"
+
+
+def _render_faq(example: PromptFormatExample, include_target: bool) -> str:
+    return f"FAQ entry\nQuestion: {example.input_text}\nAnswer: {example.target if include_target else ''}"
+
+
+def _render_flashcard(example: PromptFormatExample, include_target: bool) -> str:
+    return f"Front: {example.input_text}\nBack: {example.target if include_target else ''}"
+
+
+def _render_problem_solution(example: PromptFormatExample, include_target: bool) -> str:
+    return f"Problem:\n{example.input_text}\n\nSolution:\n{example.target if include_target else ''}"
+
+
+def _render_labeled_example(example: PromptFormatExample, include_target: bool) -> str:
+    return f"Example\nGiven:\n{example.input_text}\nResult:\n{example.target if include_target else ''}"
+
+
+def _render_bullet_list(example: PromptFormatExample, include_target: bool) -> str:
+    return f"- input: {example.input_text}\n  output: {example.target if include_target else ''}"
+
+
+def _render_numbered(example: PromptFormatExample, include_target: bool) -> str:
+    return f"1. Given {example.input_text}\n2. Return {example.target if include_target else ''}"
+
+
+def _render_json_object(example: PromptFormatExample, include_target: bool) -> str:
+    prefix = f'{{"input": {_json_string(example.input_text)}, "output": '
+    return f"{prefix}{_json_string(example.target)}}}" if include_target else prefix
+
+
+def _render_jsonl(example: PromptFormatExample, include_target: bool) -> str:
+    return _render_json_object(example, include_target)
+
+
+def _render_yaml(example: PromptFormatExample, include_target: bool) -> str:
+    prefix = f"- input: |-\n{_indent(example.input_text)}\n  output: "
+    return f"{prefix}{example.target}" if include_target else prefix
+
+
+def _render_xml(example: PromptFormatExample, include_target: bool) -> str:
+    prefix = f"<example><input>{html.escape(example.input_text)}</input><output>"
+    suffix = "</output></example>"
+    return f"{prefix}{html.escape(example.target)}{suffix}" if include_target else prefix
+
+
+def _render_csv(example: PromptFormatExample, include_target: bool) -> str:
+    if include_target:
+        return _csv_pair(example.input_text, example.target)
+    return f"{_csv_field(example.input_text)},"
+
+
+def _render_tsv(example: PromptFormatExample, include_target: bool) -> str:
+    output = _tsv_field(example.target) if include_target else ""
+    return f"{_tsv_field(example.input_text)}\t{output}"
+
+
+def _render_markdown_table(example: PromptFormatExample, include_target: bool) -> str:
+    output = _markdown_cell(example.target) if include_target else ""
+    return f"| {_markdown_cell(example.input_text)} | {output}"
+
+
+def _render_python_doctest(example: PromptFormatExample, include_target: bool) -> str:
+    return f'>>> solve("""{_triple_quoted(example.input_text)}""")\n{example.target if include_target else ""}'
+
+
+def _render_python_repl(example: PromptFormatExample, include_target: bool) -> str:
+    return f">>> solve({_json_string(example.input_text)})\n{example.target if include_target else ''}"
+
+
+def _render_shell(example: PromptFormatExample, include_target: bool) -> str:
+    return f"$ solve <<'INPUT'\n{example.input_text}\nINPUT\n{example.target if include_target else ''}"
+
+
+def _render_sql(example: PromptFormatExample, include_target: bool) -> str:
+    output = example.target if include_target else ""
+    return f"SELECT solve($${example.input_text}$$) AS output;\noutput\n------\n{output}"
+
+
+def _render_toml(example: PromptFormatExample, include_target: bool) -> str:
+    prefix = f'[[example]]\ninput = """{_triple_quoted(example.input_text)}"""\noutput = """'
+    return f'{prefix}{_triple_quoted(example.target)}"""' if include_target else prefix
+
+
+def _render_ini(example: PromptFormatExample, include_target: bool) -> str:
+    return f"[example]\ninput={example.input_text}\noutput={example.target if include_target else ''}"
+
+
+def _render_s_expression(example: PromptFormatExample, include_target: bool) -> str:
+    prefix = f"(example (input {_json_string(example.input_text)}) (output "
+    return f"{prefix}{_json_string(example.target)}))" if include_target else prefix
+
+
+def _render_html_dl(example: PromptFormatExample, include_target: bool) -> str:
+    prefix = f"<dl><dt>{html.escape(example.input_text)}</dt><dd>"
+    suffix = "</dd></dl>"
+    return f"{prefix}{html.escape(example.target)}{suffix}" if include_target else prefix
+
+
+PROMPT_FORMAT_TEMPLATES: tuple[PromptFormatTemplate, ...] = (
+    PromptFormatTemplate("plain_arrow", "plain", "input arrow output", _render_arrow),
+    PromptFormatTemplate("plain_equals", "plain", "input equals output", _render_equals),
+    PromptFormatTemplate("colon_mapping", "plain", "Input/Output colon labels", _render_colon_mapping),
+    PromptFormatTemplate("key_value_block", "plain", "lowercase key/value block", _render_key_value_block),
+    PromptFormatTemplate("qa", "qa", "Q/A pairs", _render_qa),
+    PromptFormatTemplate("faq", "qa", "FAQ entry", _render_faq),
+    PromptFormatTemplate("flashcard", "qa", "front/back flashcard", _render_flashcard),
+    PromptFormatTemplate("problem_solution", "qa", "problem/solution block", _render_problem_solution),
+    PromptFormatTemplate("labeled_example", "plain", "given/result example", _render_labeled_example),
+    PromptFormatTemplate("bullet_list", "plain", "bullet key/value list", _render_bullet_list),
+    PromptFormatTemplate("numbered_steps", "plain", "numbered given/return steps", _render_numbered),
+    PromptFormatTemplate("json_object", "structured", "JSON object", _render_json_object),
+    PromptFormatTemplate("jsonl", "structured", "JSONL records", _render_jsonl),
+    PromptFormatTemplate("yaml", "structured", "YAML sequence", _render_yaml),
+    PromptFormatTemplate("xml", "structured", "XML example element", _render_xml),
+    PromptFormatTemplate("csv", "table", "CSV row", _render_csv),
+    PromptFormatTemplate("tsv", "table", "TSV row", _render_tsv),
+    PromptFormatTemplate("markdown_table", "table", "Markdown table row", _render_markdown_table),
+    PromptFormatTemplate("python_doctest", "code", "Python doctest", _render_python_doctest),
+    PromptFormatTemplate("python_repl", "code", "Python REPL", _render_python_repl),
+    PromptFormatTemplate("shell_transcript", "code", "shell transcript", _render_shell),
+    PromptFormatTemplate("sql_result", "code", "SQL result transcript", _render_sql),
+    PromptFormatTemplate("toml", "structured", "TOML record", _render_toml),
+    PromptFormatTemplate("ini", "structured", "INI section", _render_ini),
+    PromptFormatTemplate("s_expression", "structured", "S-expression", _render_s_expression),
+    PromptFormatTemplate("html_dl", "structured", "HTML description list", _render_html_dl),
+)
+PROMPT_FORMAT_TEMPLATES_BY_KEY = {template.key: template for template in PROMPT_FORMAT_TEMPLATES}
+
+
+def _examples(prefix: str, pairs: tuple[tuple[str, str], ...]) -> tuple[PromptFormatExample, ...]:
+    return tuple(
+        PromptFormatExample(example_id=f"{prefix}-{index:02d}", input_text=input_text, target=target)
+        for index, (input_text, target) in enumerate(pairs, start=1)
+    )
+
+
+PROMPT_FORMAT_TASKS: tuple[PromptFormatTask, ...] = (
+    PromptFormatTask(
+        key="mcqa_science",
+        title="Science multiple choice",
+        description="Choose the correct answer text for a multiple-choice science question.",
+        support_examples=_examples(
+            "mcqa-support",
+            (
+                (
+                    "Question: Which planet is known as the Red Planet?\nA. Venus\nB. Mars\nC. Jupiter\nD. Neptune",
+                    "Mars is known as the Red Planet.",
+                ),
+                (
+                    "Question: What gas do plants absorb during photosynthesis?\n"
+                    "A. Oxygen\nB. Nitrogen\nC. Carbon dioxide\nD. Helium",
+                    "Plants absorb carbon dioxide during photosynthesis.",
+                ),
+                (
+                    "Question: Which organ pumps blood through the human body?\nA. Lung\nB. Heart\nC. Kidney\nD. Liver",
+                    "The heart pumps blood through the human body.",
+                ),
+                (
+                    "Question: What force pulls objects toward Earth?\n"
+                    "A. Magnetism\nB. Friction\nC. Gravity\nD. Evaporation",
+                    "Gravity pulls objects toward Earth.",
+                ),
+                (
+                    "Question: Water freezes at what temperature at sea level?\n"
+                    "A. 0 degrees Celsius\nB. 10 degrees Celsius\n"
+                    "C. 50 degrees Celsius\nD. 100 degrees Celsius",
+                    "Water freezes at 0 degrees Celsius at sea level.",
+                ),
+            ),
+        ),
+        heldout_examples=_examples(
+            "mcqa-heldout",
+            (
+                (
+                    "Question: Which part of a plant takes in water from soil?\nA. Flower\nB. Root\nC. Petal\nD. Seed",
+                    "The root takes in water from soil.",
+                ),
+                (
+                    "Question: Which celestial body gives Earth most of its light?\n"
+                    "A. Moon\nB. Sun\nC. Mars\nD. Polaris",
+                    "The Sun gives Earth most of its light.",
+                ),
+                (
+                    "Question: Which material is a good electrical conductor?\nA. Rubber\nB. Copper\nC. Glass\nD. Wood",
+                    "Copper is a good electrical conductor.",
+                ),
+            ),
+        ),
+    ),
+    PromptFormatTask(
+        key="short_factual_qa",
+        title="Short factual QA",
+        description="Answer the factual question with a concise sentence.",
+        support_examples=_examples(
+            "qa-support",
+            (
+                ("What city is the capital of Japan?", "Tokyo is the capital of Japan."),
+                ("Who wrote the play Hamlet?", "William Shakespeare wrote Hamlet."),
+                ("What instrument measures atmospheric pressure?", "A barometer measures atmospheric pressure."),
+                ("Which ocean borders California?", "The Pacific Ocean borders California."),
+                ("What is the largest mammal?", "The blue whale is the largest mammal."),
+            ),
+        ),
+        heldout_examples=_examples(
+            "qa-heldout",
+            (
+                ("What city is the capital of Canada?", "Ottawa is the capital of Canada."),
+                ("Who painted the Mona Lisa?", "Leonardo da Vinci painted the Mona Lisa."),
+                ("Which planet has the most prominent ring system?", "Saturn has the most prominent ring system."),
+            ),
+        ),
+    ),
+    PromptFormatTask(
+        key="news_classification",
+        title="News classification",
+        description="Classify the news blurb into a stable topic label.",
+        support_examples=_examples(
+            "class-support",
+            (
+                (
+                    "Stocks rose after the central bank signaled slower rate increases.",
+                    "Business and finance news",
+                ),
+                ("The striker scored twice in the championship match.", "Sports competition report"),
+                (
+                    "Researchers announced a battery that charges in under ten minutes.",
+                    "Science and technology news",
+                ),
+                ("The senate committee advanced the revised budget bill.", "Politics and government news"),
+                ("A new museum exhibition opened downtown this weekend.", "Arts and culture news"),
+            ),
+        ),
+        heldout_examples=_examples(
+            "class-heldout",
+            (
+                (
+                    "The software company released a smaller language model for phones.",
+                    "Science and technology news",
+                ),
+                ("The mayor proposed new rules for short-term rentals.", "Politics and government news"),
+                ("The tennis final was delayed by heavy rain.", "Sports competition report"),
+            ),
+        ),
+    ),
+    PromptFormatTask(
+        key="string_transformation",
+        title="String transformation",
+        description="Normalize the record into REGION-ID-COLOR with a four digit id.",
+        support_examples=_examples(
+            "transform-support",
+            (
+                ("region=west; id=42; color=blue", "WEST-0042-BLUE"),
+                ("region=north; id=7; color=green", "NORTH-0007-GREEN"),
+                ("region=south; id=315; color=red", "SOUTH-0315-RED"),
+                ("region=east; id=90; color=yellow", "EAST-0090-YELLOW"),
+                ("region=central; id=5; color=purple", "CENTRAL-0005-PURPLE"),
+            ),
+        ),
+        heldout_examples=_examples(
+            "transform-heldout",
+            (
+                ("region=west; id=108; color=orange", "WEST-0108-ORANGE"),
+                ("region=north; id=64; color=silver", "NORTH-0064-SILVER"),
+                ("region=east; id=901; color=black", "EAST-0901-BLACK"),
+            ),
+        ),
+    ),
+    PromptFormatTask(
+        key="record_extraction",
+        title="Structured record extraction",
+        description="Extract the requested fields as a compact field list.",
+        support_examples=_examples(
+            "extract-support",
+            (
+                (
+                    "Order 1842 ships to Lima on 2026-03-14 with 12 crates of valves.",
+                    "order_id=1842; city=Lima; date=2026-03-14; items=valves; quantity=12",
+                ),
+                (
+                    "Ticket 9001 assigns Priya to audit two routers in Oslo before 2026-04-02.",
+                    "ticket_id=9001; owner=Priya; city=Oslo; date=2026-04-02; assets=routers; quantity=2",
+                ),
+                (
+                    "Batch 77 sends 5 microscopes and 3 lenses to Accra on 2026-01-09.",
+                    "batch_id=77; city=Accra; date=2026-01-09; items=microscopes,lenses; quantity=8",
+                ),
+                (
+                    "Case 312 lists Omar as reviewer for the Berlin archive due 2026-02-20.",
+                    "case_id=312; owner=Omar; city=Berlin; date=2026-02-20; asset=archive",
+                ),
+                (
+                    "Shipment 451 sends 6 pumps to Quito for Mina on 2026-05-18.",
+                    "shipment_id=451; owner=Mina; city=Quito; date=2026-05-18; items=pumps; quantity=6",
+                ),
+            ),
+        ),
+        heldout_examples=_examples(
+            "extract-heldout",
+            (
+                (
+                    "Order 2880 ships 9 sensors to Tallinn for Jules on 2026-06-03.",
+                    "order_id=2880; owner=Jules; city=Tallinn; date=2026-06-03; items=sensors; quantity=9",
+                ),
+                (
+                    "Ticket 415 asks Nia to inspect 4 bridges in Porto by 2026-07-11.",
+                    "ticket_id=415; owner=Nia; city=Porto; date=2026-07-11; assets=bridges; quantity=4",
+                ),
+                (
+                    "Batch 63 delivers 2 cameras and 8 tripods to Busan on 2026-08-22.",
+                    "batch_id=63; city=Busan; date=2026-08-22; items=cameras,tripods; quantity=10",
+                ),
+            ),
+        ),
+    ),
+    PromptFormatTask(
+        key="python_repl",
+        title="Python REPL reasoning",
+        description="Return the deterministic result of the small Python-like expression.",
+        support_examples=_examples(
+            "code-support",
+            (
+                ("len('marin') + 4", "9"),
+                ("'-'.join(['red', 'blue']).upper()", "RED-BLUE"),
+                ("sum([3, 5, 8])", "16"),
+                ("sorted(['delta', 'alpha', 'beta'])[0]", "alpha"),
+                ("{'a': 2, 'b': 5}['b'] * 3", "15"),
+            ),
+        ),
+        heldout_examples=_examples(
+            "code-heldout",
+            (
+                ("len('prompt') * 7", "42"),
+                ("'-'.join(reversed(['north', 'east']))", "east-north"),
+                ("sum(x * x for x in [2, 3, 4])", "29"),
+            ),
+        ),
+    ),
+)
+PROMPT_FORMAT_TASKS_BY_KEY = {task.key: task for task in PROMPT_FORMAT_TASKS}
+
+
+def render_prompt_format_input(
+    *,
+    task: PromptFormatTask,
+    template: PromptFormatTemplate,
+    heldout: PromptFormatExample,
+) -> str:
+    """Render five support examples and one unfinished held-out query."""
+
+    if len(task.support_examples) != PROMPT_FORMAT_NUM_FEWSHOT:
+        raise ValueError(f"{task.key} must have exactly {PROMPT_FORMAT_NUM_FEWSHOT} support examples")
+    header = f"Task: {task.title}\nInstruction: {task.description}\nFormat: {template.description}"
+    blocks = [header, *(template.renderer(example, True) for example in task.support_examples)]
+    blocks.append(template.renderer(heldout, False))
+    return "\n\n".join(blocks)
+
+
+def render_prompt_format_target(*, template: PromptFormatTemplate, heldout: PromptFormatExample) -> str:
+    """Render the scored continuation for an unfinished held-out query."""
+
+    unfinished = template.renderer(heldout, False)
+    finished = template.renderer(heldout, True)
+    if not finished.startswith(unfinished):
+        raise ValueError(f"{template.key} renderer must extend its unfinished held-out query")
+    return finished[len(unfinished) :]
+
+
+def prompt_format_record(task_key: str, template_key: str, heldout_index: int) -> dict[str, Any]:
+    """Return one supervised target-only record for a task/template/held-out index."""
+
+    task = PROMPT_FORMAT_TASKS_BY_KEY[task_key]
+    template = PROMPT_FORMAT_TEMPLATES_BY_KEY[template_key]
+    heldout = task.heldout_examples[heldout_index]
+    return {
+        "id": f"{task.key}/{template.key}/{heldout.example_id}",
+        "input": render_prompt_format_input(task=task, template=template, heldout=heldout),
+        "target": render_prompt_format_target(template=template, heldout=heldout),
+        "source": "prompt_format_sensitivity_static",
+        "provenance": {
+            "task_key": task.key,
+            "template_key": template.key,
+            "template_family": template.family,
+            "renderer_version": PROMPT_FORMAT_RENDERER_VERSION,
+            "num_fewshot": PROMPT_FORMAT_NUM_FEWSHOT,
+            "support_example_ids": [example.example_id for example in task.support_examples],
+            "heldout_example_id": heldout.example_id,
+            "semantic_target": heldout.target,
+        },
+    }
+
+
+def stage_prompt_format_sensitivity_source(cfg: PromptFormatSensitivityStagingConfig) -> dict[str, Any]:
+    """Stage one prompt-format sensitivity task/template slice as JSONL."""
+
+    if cfg.source_manifest is not None and cfg.content_fingerprint:
+        expected = cfg.source_manifest.fingerprint()
+        if cfg.content_fingerprint != expected:
+            raise ValueError(
+                f"content_fingerprint mismatch: config has {cfg.content_fingerprint}, source manifest has {expected}"
+            )
+
+    task = PROMPT_FORMAT_TASKS_BY_KEY[cfg.task_key]
+    if cfg.template_key not in PROMPT_FORMAT_TEMPLATES_BY_KEY:
+        raise ValueError(f"Unknown prompt-format template: {cfg.template_key}")
+    if len(task.support_examples) != PROMPT_FORMAT_NUM_FEWSHOT:
+        raise ValueError(f"{cfg.task_key} must have exactly {PROMPT_FORMAT_NUM_FEWSHOT} support examples")
+
+    fsspec_mkdirs(cfg.output_path, exist_ok=True)
+    out_file = posixpath.join(cfg.output_path, cfg.output_filename)
+    compression = "gzip" if out_file.endswith(".gz") else None
+
+    with atomic_rename(out_file) as temp_path:
+        with open_url(temp_path, "wt", encoding="utf-8", compression=compression) as outfile:
+            for heldout_index in range(len(task.heldout_examples)):
+                json.dump(
+                    prompt_format_record(cfg.task_key, cfg.template_key, heldout_index), outfile, ensure_ascii=True
+                )
+                outfile.write("\n")
+
+    fs, _ = url_to_fs(out_file)
+    output_size = int(fs.info(out_file)["size"])
+    result: dict[str, Any] = {
+        "record_count": len(task.heldout_examples),
+        "bytes_written": output_size,
+        "output_file": out_file,
+    }
+
+    if cfg.source_manifest is not None:
+        metadata_path = write_ingestion_metadata_json(
+            manifest=cfg.source_manifest,
+            materialized_output=MaterializedOutputMetadata(
+                input_path="prompt_format_sensitivity_static",
+                output_path=cfg.output_path,
+                output_file=out_file,
+                record_count=len(task.heldout_examples),
+                bytes_written=output_size,
+                metadata={
+                    "task_key": cfg.task_key,
+                    "template_key": cfg.template_key,
+                    "renderer_version": PROMPT_FORMAT_RENDERER_VERSION,
+                    "num_fewshot": PROMPT_FORMAT_NUM_FEWSHOT,
+                    "heldout_examples": len(task.heldout_examples),
+                },
+            ),
+        )
+        result["metadata_file"] = metadata_path
+
+    return result

--- a/tests/transform/test_code_interpretation.py
+++ b/tests/transform/test_code_interpretation.py
@@ -1,0 +1,101 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import gzip
+import json
+from pathlib import Path
+
+from marin.transform.evaluation.code_interpretation import (
+    CODE_INTERPRETATION_NUM_FEWSHOT,
+    CODE_INTERPRETATION_TASKS_BY_KEY,
+    CODE_INTERPRETATION_TEMPLATES,
+    DEFAULT_CODE_INTERPRETATION_OUTPUT_FILENAME,
+    CodeInterpretationStagingConfig,
+    code_interpretation_record,
+    stage_code_interpretation_source,
+)
+
+
+def _read_records(output_path: Path) -> list[dict]:
+    with gzip.open(output_path / DEFAULT_CODE_INTERPRETATION_OUTPUT_FILENAME, "rt", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def test_repl_expression_record_scores_only_output_line() -> None:
+    record = code_interpretation_record("expression_strings_collections", "python_repl", 0)
+
+    assert record["input"].endswith(">>> len('prompt') * 7\n")
+    assert record["target"] == "42"
+    assert record["target"] not in record["input"]
+    assert record["input"].count(">>> ") >= CODE_INTERPRETATION_NUM_FEWSHOT + 1
+    assert record["provenance"]["task_family"] == "expression_only"
+    assert record["provenance"]["semantic_target"] == "42"
+
+
+def test_doctest_function_definition_record_completes_to_expected_output() -> None:
+    record = code_interpretation_record("function_definition_calls", "python_doctest", 0)
+    rendered = record["input"] + record["target"]
+
+    assert (
+        ">>> def edge_repeat(text):\n...     return text[0] + text[-1] * 2\n>>> edge_repeat('marin')\n"
+        in record["input"]
+    )
+    assert rendered.endswith(">>> edge_repeat('marin')\nmnn")
+    assert "mnn" not in record["input"]
+    assert record["provenance"]["task_family"] == "function_definition"
+    assert record["provenance"]["heldout_code"].startswith("def edge_repeat")
+
+
+def test_function_definition_class_record_preserves_semantic_target_and_provenance() -> None:
+    record = code_interpretation_record("function_definition_calls", "python_repl", 2)
+
+    assert "class PairBox:" in record["input"]
+    assert "PairBox('north', 'east').flipped().upper()" in record["input"]
+    assert record["target"] == "EAST-NORTH"
+    assert record["target"] not in record["input"]
+    assert record["provenance"]["support_example_ids"] == [
+        "fn-support-01",
+        "fn-support-02",
+        "fn-support-03",
+        "fn-support-04",
+        "fn-support-05",
+    ]
+    assert record["provenance"]["semantic_target"] == "EAST-NORTH"
+
+
+def test_every_slice_renders_heldout_query_unfinished() -> None:
+    for task in CODE_INTERPRETATION_TASKS_BY_KEY.values():
+        for template in CODE_INTERPRETATION_TEMPLATES:
+            for heldout_index, heldout in enumerate(task.heldout_examples):
+                record = code_interpretation_record(task.key, template.key, heldout_index)
+                unfinished_query = template.renderer(heldout, False)
+                finished_query = template.renderer(heldout, True)
+
+                assert record["input"].endswith(unfinished_query)
+                assert not record["input"].endswith(finished_query)
+                assert record["target"] == finished_query[len(unfinished_query) :]
+                assert record["target"] not in record["input"]
+                assert (record["input"] + record["target"]).endswith(finished_query)
+                assert record["provenance"]["semantic_target"] == heldout.target
+
+
+def test_stage_code_interpretation_source_writes_valid_target_only_jsonl(tmp_path: Path) -> None:
+    result = stage_code_interpretation_source(
+        CodeInterpretationStagingConfig(
+            output_path=str(tmp_path),
+            task_key="function_definition_calls",
+            template_key="python_repl",
+        )
+    )
+
+    task = CODE_INTERPRETATION_TASKS_BY_KEY["function_definition_calls"]
+    records = _read_records(tmp_path)
+    assert result["record_count"] == len(task.heldout_examples)
+    assert len(records) == len(task.heldout_examples)
+    for record, heldout in zip(records, task.heldout_examples, strict=True):
+        assert set(record) == {"id", "input", "target", "source", "provenance"}
+        assert record["input"].endswith("\n")
+        assert record["target"] == heldout.target
+        assert heldout.target not in record["input"]
+        assert record["provenance"]["task_family"] == "function_definition"
+        assert record["provenance"]["num_fewshot"] == CODE_INTERPRETATION_NUM_FEWSHOT

--- a/tests/transform/test_prompt_format_sensitivity.py
+++ b/tests/transform/test_prompt_format_sensitivity.py
@@ -1,0 +1,121 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import gzip
+import json
+from pathlib import Path
+
+from marin.transform.evaluation.prompt_format_sensitivity import (
+    DEFAULT_PROMPT_FORMAT_OUTPUT_FILENAME,
+    PROMPT_FORMAT_NUM_FEWSHOT,
+    PROMPT_FORMAT_TASKS_BY_KEY,
+    PROMPT_FORMAT_TEMPLATES,
+    PromptFormatSensitivityStagingConfig,
+    prompt_format_record,
+    stage_prompt_format_sensitivity_source,
+)
+
+
+def _read_records(output_path: Path) -> list[dict]:
+    with gzip.open(output_path / DEFAULT_PROMPT_FORMAT_OUTPUT_FILENAME, "rt", encoding="utf-8") as handle:
+        return [json.loads(line) for line in handle if line.strip()]
+
+
+def test_prompt_format_record_keeps_heldout_target_out_of_input() -> None:
+    record = prompt_format_record("mcqa_science", "qa", 0)
+
+    assert record["target"] == "The root takes in water from soil."
+    assert record["input"].endswith("A: ")
+    assert record["target"] not in record["input"]
+    assert record["input"].count("\nA: ") == PROMPT_FORMAT_NUM_FEWSHOT + 1
+    assert record["provenance"]["support_example_ids"] == [
+        "mcqa-support-01",
+        "mcqa-support-02",
+        "mcqa-support-03",
+        "mcqa-support-04",
+        "mcqa-support-05",
+    ]
+
+
+def test_prompt_format_templates_preserve_identical_targets_for_same_task_item() -> None:
+    template_keys = ["plain_arrow", "json_object", "yaml", "csv", "python_doctest", "shell_transcript"]
+    records = [prompt_format_record("short_factual_qa", template_key, 1) for template_key in template_keys]
+    semantic_target = "Leonardo da Vinci painted the Mona Lisa."
+
+    assert len({record["input"] for record in records}) == len(template_keys)
+    for record in records:
+        assert semantic_target in record["target"]
+        assert semantic_target not in record["input"]
+        assert record["provenance"]["semantic_target"] == semantic_target
+        assert record["provenance"]["num_fewshot"] == 5
+
+
+def test_prompt_format_markdown_table_renders_supports_and_unfinished_query() -> None:
+    record = prompt_format_record("string_transformation", "markdown_table", 0)
+
+    assert "| Input | Output |" not in record["input"]
+    assert "| region=west; id=42; color=blue | WEST-0042-BLUE" in record["input"]
+    assert "| region=west; id=108; color=orange | " in record["input"]
+    assert "WEST-0108-ORANGE" not in record["input"]
+    assert record["target"] == "WEST-0108-ORANGE"
+
+
+def test_prompt_format_jsonl_target_completes_valid_heldout_record() -> None:
+    record = prompt_format_record("mcqa_science", "jsonl", 2)
+    rendered = record["input"] + record["target"]
+
+    jsonl_records = [json.loads(line) for line in rendered.splitlines() if line.startswith("{")]
+
+    assert len(jsonl_records) == PROMPT_FORMAT_NUM_FEWSHOT + 1
+    assert jsonl_records[-1] == {
+        "input": "Question: Which material is a good electrical conductor?\nA. Rubber\nB. Copper\nC. Glass\nD. Wood",
+        "output": "Copper is a good electrical conductor.",
+    }
+
+
+def test_prompt_format_record_extraction_uses_template_neutral_field_list() -> None:
+    record = prompt_format_record("record_extraction", "qa", 0)
+
+    assert '"order_id"' not in record["input"]
+    assert '"order_id"' not in record["target"]
+    assert record["provenance"]["semantic_target"] == (
+        "order_id=2880; owner=Jules; city=Tallinn; date=2026-06-03; items=sensors; quantity=9"
+    )
+    assert record["input"].endswith("A: ")
+    assert record["target"] == record["provenance"]["semantic_target"]
+
+
+def test_prompt_format_every_slice_renders_heldout_query_unfinished() -> None:
+    for task in PROMPT_FORMAT_TASKS_BY_KEY.values():
+        for template in PROMPT_FORMAT_TEMPLATES:
+            for heldout_index, heldout in enumerate(task.heldout_examples):
+                record = prompt_format_record(task.key, template.key, heldout_index)
+                unfinished_query = template.renderer(heldout, False)
+                finished_query = template.renderer(heldout, True)
+
+                assert record["input"].endswith(unfinished_query)
+                assert not record["input"].endswith(finished_query)
+                assert record["target"] == finished_query[len(unfinished_query) :]
+                assert (record["input"] + record["target"]).endswith(finished_query)
+                assert record["provenance"]["semantic_target"] == heldout.target
+
+
+def test_stage_prompt_format_sensitivity_source_writes_target_only_records(tmp_path: Path) -> None:
+    result = stage_prompt_format_sensitivity_source(
+        PromptFormatSensitivityStagingConfig(
+            output_path=str(tmp_path),
+            task_key="record_extraction",
+            template_key="xml",
+        )
+    )
+
+    task = PROMPT_FORMAT_TASKS_BY_KEY["record_extraction"]
+    records = _read_records(tmp_path)
+    assert result["record_count"] == len(task.heldout_examples)
+    for record, heldout in zip(records, task.heldout_examples, strict=True):
+        assert record["input"].endswith("<output>")
+        assert record["target"].endswith("</output></example>")
+        assert heldout.target not in record["input"]
+        assert record["provenance"]["semantic_target"] == heldout.target
+        assert record["provenance"]["template_key"] == "xml"
+        assert record["provenance"]["num_fewshot"] == PROMPT_FORMAT_NUM_FEWSHOT


### PR DESCRIPTION
Add static supervised target-only prompt-format sensitivity and code-interpretation eval suites with 32B gap runner scripts. These probes cover prompt surface robustness and Python REPL/doctest-style expression/function interpretation without adding registry-only tests.

Part of #6067
Part of #6070