### PR TITLE
Move atomic_rename from zephyr.writers to rigging.filesystem

### DIFF
--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -29,7 +29,8 @@ from jaxtyping import PyTree
 from tqdm_loggable.tqdm_logging import tqdm_logging
 from zephyr import Dataset, ZephyrContext
 from zephyr import counters as zephyr_counters
-from zephyr.writers import ThreadedBatchWriter, atomic_rename, batchify, ensure_parent_dir
+from rigging.filesystem import atomic_rename
+from zephyr.writers import ThreadedBatchWriter, batchify, ensure_parent_dir
 
 from levanter.data.dataset import AsyncDataset
 from levanter.utils.jax_utils import broadcast_one_to_all

--- a/lib/marin/src/marin/datakit/download/ar5iv.py
+++ b/lib/marin/src/marin/datakit/download/ar5iv.py
@@ -13,10 +13,9 @@ from collections import defaultdict
 from dataclasses import dataclass
 
 import draccus
-from rigging.filesystem import open_url
+from rigging.filesystem import atomic_rename, open_url
 from rigging.log_setup import configure_logging
 from zephyr import Dataset, ZephyrContext
-from zephyr.writers import atomic_rename
 
 from marin.execution.step_spec import StepSpec
 

--- a/lib/marin/src/marin/datakit/download/formal_methods_evals.py
+++ b/lib/marin/src/marin/datakit/download/formal_methods_evals.py
@@ -37,9 +37,8 @@ from dataclasses import dataclass
 from typing import Any
 
 import zstandard
-from rigging.filesystem import open_url
+from rigging.filesystem import atomic_rename, open_url
 from zephyr import Dataset, ZephyrContext
-from zephyr.writers import atomic_rename
 
 from marin.datakit.download.http_session import build_retrying_session
 from marin.datakit.ingestion_manifest import (

--- a/lib/marin/src/marin/datakit/download/game_music_evals.py
+++ b/lib/marin/src/marin/datakit/download/game_music_evals.py
@@ -14,8 +14,7 @@ from dataclasses import dataclass
 from typing import Any
 
 import zstandard
-from rigging.filesystem import open_url
-from zephyr.writers import atomic_rename
+from rigging.filesystem import atomic_rename, open_url
 
 from marin.datakit.download.http_session import build_retrying_session
 from marin.datakit.ingestion_manifest import (

--- a/lib/marin/src/marin/datakit/download/gh_archive.py
+++ b/lib/marin/src/marin/datakit/download/gh_archive.py
@@ -17,8 +17,7 @@ from datetime import date, datetime, timedelta
 from typing import Any
 from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
-from rigging.filesystem import open_url
-from zephyr.writers import atomic_rename
+from rigging.filesystem import atomic_rename, open_url
 
 from marin.execution.step_spec import StepSpec
 from marin.utils import fsspec_exists, fsspec_mkdirs

--- a/lib/marin/src/marin/datakit/download/huggingface.py
+++ b/lib/marin/src/marin/datakit/download/huggingface.py
@@ -18,9 +18,9 @@ import huggingface_hub
 from fray import ResourceConfig
 from huggingface_hub.errors import HfHubHTTPError
 from packaging.version import Version
-from rigging.filesystem import open_url, url_to_fs
+from rigging.filesystem import atomic_rename, open_url, url_to_fs
 from rigging.log_setup import configure_logging
-from zephyr import Dataset, ZephyrContext, atomic_rename
+from zephyr import Dataset, ZephyrContext
 
 from marin.execution.step_spec import StepSpec
 from marin.execution.types import THIS_OUTPUT_PATH

--- a/lib/marin/src/marin/datakit/download/massive.py
+++ b/lib/marin/src/marin/datakit/download/massive.py
@@ -26,10 +26,9 @@ import tarfile
 import tempfile
 
 from fray import ResourceConfig
-from rigging.filesystem import open_url, url_to_fs
+from rigging.filesystem import atomic_rename, open_url, url_to_fs
 from zephyr import Dataset, ZephyrContext
 from zephyr.readers import load_jsonl
-from zephyr.writers import atomic_rename
 
 from marin.datakit.download.http_session import build_retrying_session
 from marin.datakit.normalize import normalize_step

--- a/lib/marin/src/marin/datakit/download/nemotron_v1.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_v1.py
@@ -10,9 +10,8 @@ from collections.abc import Iterator
 
 import zstandard
 from fray.cluster import ResourceConfig
-from rigging.filesystem import open_url
+from rigging.filesystem import atomic_rename, open_url
 from zephyr import Dataset, ZephyrContext
-from zephyr.writers import atomic_rename
 
 from marin.datakit.download.http_session import build_retrying_session
 from marin.datakit.normalize import normalize_step

--- a/lib/marin/src/marin/datakit/download/npm_registry_metadata.py
+++ b/lib/marin/src/marin/datakit/download/npm_registry_metadata.py
@@ -25,8 +25,7 @@ from dataclasses import dataclass, field
 from typing import Any
 from urllib.parse import quote
 
-from rigging.filesystem import open_url, url_to_fs
-from zephyr.writers import atomic_rename
+from rigging.filesystem import atomic_rename, open_url, url_to_fs
 
 from marin.datakit.download.http_session import build_retrying_session
 from marin.datakit.ingestion_manifest import (

--- a/lib/marin/src/marin/datakit/download/uncheatable_eval.py
+++ b/lib/marin/src/marin/datakit/download/uncheatable_eval.py
@@ -15,9 +15,8 @@ from dataclasses import dataclass
 from typing import Any
 
 import requests
-from rigging.filesystem import open_url
+from rigging.filesystem import atomic_rename, open_url
 from zephyr import Dataset, ZephyrContext
-from zephyr.writers import atomic_rename
 
 from marin.datakit.download.http_session import build_retrying_session
 from marin.execution import THIS_OUTPUT_PATH, ExecutorStep, VersionedValue

--- a/lib/marin/src/marin/datakit/download/uwf_zeek.py
+++ b/lib/marin/src/marin/datakit/download/uwf_zeek.py
@@ -32,8 +32,7 @@ from typing import Any
 from urllib.parse import urljoin
 
 import requests
-from rigging.filesystem import open_url
-from zephyr.writers import atomic_rename
+from rigging.filesystem import atomic_rename, open_url
 
 from marin.datakit.download.http_session import build_retrying_session
 from marin.execution.step_spec import StepSpec

--- a/lib/marin/src/marin/datakit/download/wikipedia.py
+++ b/lib/marin/src/marin/datakit/download/wikipedia.py
@@ -16,9 +16,9 @@ import tarfile
 from collections.abc import Iterable
 
 import requests
-from rigging.filesystem import open_url
+from rigging.filesystem import atomic_rename, open_url
 from tqdm_loggable.auto import tqdm
-from zephyr import Dataset, ZephyrContext, atomic_rename, load_jsonl
+from zephyr import Dataset, ZephyrContext, load_jsonl
 
 from marin.execution.step_spec import StepSpec
 from marin.utils import fsspec_size

--- a/lib/marin/src/marin/datakit/ingestion_manifest.py
+++ b/lib/marin/src/marin/datakit/ingestion_manifest.py
@@ -12,9 +12,8 @@ from enum import StrEnum, auto
 from typing import Any
 
 from pydantic import BaseModel, ConfigDict, Field
-from rigging.filesystem import open_url
+from rigging.filesystem import atomic_rename, open_url
 from typing_extensions import TypeAliasType
-from zephyr.writers import atomic_rename
 
 from marin.utils import fsspec_mkdirs
 

--- a/lib/marin/src/marin/transform/evaluation/raw_lm_eval.py
+++ b/lib/marin/src/marin/transform/evaluation/raw_lm_eval.py
@@ -23,8 +23,7 @@ from marin.datakit.ingestion_manifest import (
     write_ingestion_metadata_json,
 )
 from marin.utils import fsspec_mkdirs, fsspec_url
-from rigging.filesystem import open_url, url_to_fs
-from zephyr.writers import atomic_rename
+from rigging.filesystem import atomic_rename, open_url, url_to_fs
 
 
 class LmEvalRawRenderer(StrEnum):

--- a/lib/marin/src/marin/transform/huggingface/raw_text.py
+++ b/lib/marin/src/marin/transform/huggingface/raw_text.py
@@ -21,9 +21,8 @@ from marin.datakit.ingestion_manifest import (
 )
 from marin.transform.huggingface.dataset_to_eval import get_nested_item
 from marin.utils import fsspec_mkdirs, fsspec_url
-from rigging.filesystem import open_url, url_to_fs
+from rigging.filesystem import atomic_rename, open_url, url_to_fs
 from zephyr import Dataset, ZephyrContext
-from zephyr.writers import atomic_rename
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/transform/structured_text/table_records.py
+++ b/lib/marin/src/marin/transform/structured_text/table_records.py
@@ -29,8 +29,7 @@ from marin.datakit.ingestion_manifest import (
     write_ingestion_metadata_json,
 )
 from marin.utils import fsspec_mkdirs, fsspec_url
-from rigging.filesystem import open_url, url_to_fs
-from zephyr.writers import atomic_rename
+from rigging.filesystem import atomic_rename, open_url, url_to_fs
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/transform/structured_text/web_data_commons.py
+++ b/lib/marin/src/marin/transform/structured_text/web_data_commons.py
@@ -34,8 +34,7 @@ from marin.datakit.ingestion_manifest import (
     write_ingestion_metadata_json,
 )
 from marin.utils import fsspec_mkdirs
-from rigging.filesystem import open_url, url_to_fs
-from zephyr.writers import atomic_rename
+from rigging.filesystem import atomic_rename, open_url, url_to_fs
 
 logger = logging.getLogger(__name__)
 

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -35,6 +35,7 @@ import threading
 import time
 import urllib.error
 import urllib.request
+import uuid
 from collections.abc import Callable, Generator, Sequence
 from pathlib import PurePath
 from typing import Any
@@ -43,6 +44,7 @@ import fsspec
 from google.api_core.exceptions import Forbidden as GcpForbiddenException
 
 from rigging.distributed_lock import create_lock, default_worker_id
+from rigging.timing import ExponentialBackoff, retry_with_backoff
 
 logger = logging.getLogger(__name__)
 
@@ -773,6 +775,97 @@ def filesystem(protocol: str, **kwargs: Any) -> Any:
     if _is_gcs_protocol(protocol):
         fs = CrossRegionGuardedFS(fs)
     return fs
+
+
+# ---------------------------------------------------------------------------
+# Atomic write-and-rename
+
+
+def unique_temp_path(output_path: str) -> str:
+    """Return a unique temporary path derived from ``output_path``.
+
+    Appends ``.tmp.<uuid>`` to avoid collisions when multiple writers target the
+    same output path (e.g. during network-partition induced worker races).
+    """
+    return f"{output_path}.tmp.{uuid.uuid4().hex}"
+
+
+# AWS error codes that are safe to retry on a server-side multipart copy
+# (``s3fs.S3FileSystem.mv``). ``InvalidPart`` is the R2-specific symptom:
+# every ``UploadPartCopy`` returns 200 but ``CompleteMultipartUpload`` then
+# claims one or more parts are missing.
+_TRANSIENT_S3_ERROR_CODES = frozenset(
+    {
+        "InvalidPart",
+        "InternalError",
+        "ServiceUnavailable",
+        "SlowDown",
+        "RequestTimeout",
+        "RequestTimeTooSkewed",
+    }
+)
+
+# Fragments matched against ``str(exc)`` for the case where s3fs has already
+# translated the underlying ``botocore.ClientError`` into an ``OSError`` and
+# the structured error code is no longer reachable.
+_TRANSIENT_S3_MESSAGE_FRAGMENTS = (
+    "specified parts could not be found",
+    "InternalError",
+    "ServiceUnavailable",
+    "SlowDown",
+    "RequestTimeout",
+)
+
+
+def _is_transient_s3_error(exc: BaseException) -> bool:
+    response = getattr(exc, "response", None)
+    if isinstance(response, dict):
+        code = response.get("Error", {}).get("Code")
+        if code in _TRANSIENT_S3_ERROR_CODES:
+            return True
+    msg = str(exc)
+    return any(frag in msg for frag in _TRANSIENT_S3_MESSAGE_FRAGMENTS)
+
+
+def _mv_with_retry(fs: Any, src: str, dst: str) -> None:
+    retry_with_backoff(
+        lambda: fs.mv(src, dst, recursive=True),
+        retryable=_is_transient_s3_error,
+        max_attempts=4,
+        backoff=ExponentialBackoff(initial=1.0, maximum=8.0, factor=2.0),
+        operation=f"atomic_rename fs.mv {src} -> {dst}",
+    )
+
+
+@contextlib.contextmanager
+def atomic_rename(output_path: str, fs: Any = None) -> Generator[str, None, None]:
+    """Atomic write-and-rename via a sibling temp key.
+
+    Yields ``<output_path>.tmp.<uuid>``; on clean exit, ``fs.mv`` renames the
+    temp into the final path. On exception, the temp key is best-effort
+    deleted and the original exception re-raised.
+
+    Callers may pass a pre-constructed ``fs`` to reuse a configured
+    filesystem (e.g. an ``S3FileSystem`` with ``fixed_upload_size=True``)
+    instead of letting atomic_rename build a default one from ``output_path``.
+
+    Example:
+        with atomic_rename("output.jsonl.gz") as tmp_path:
+            write_data(tmp_path)
+        # File is now at output.jsonl.gz
+    """
+    temp_path = unique_temp_path(output_path)
+    if fs is None:
+        fs = url_to_fs(output_path)[0]
+    try:
+        yield temp_path
+        _mv_with_retry(fs, temp_path, output_path)
+    except Exception:
+        # Best-effort cleanup: temp file may not exist (writer crashed before
+        # creating it) so we tolerate any rm error and re-raise the original.
+        with contextlib.suppress(Exception):
+            fs.rm(temp_path)
+        raise
 
 
 # ---------------------------------------------------------------------------

--- a/lib/rigging/tests/test_filesystem.py
+++ b/lib/rigging/tests/test_filesystem.py
@@ -1,0 +1,45 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for filesystem helpers."""
+
+from pathlib import Path
+
+import pytest
+from rigging.filesystem import atomic_rename, unique_temp_path
+
+
+def test_unique_temp_path_produces_distinct_paths():
+    """Each call to unique_temp_path returns a different path."""
+    paths = {unique_temp_path("/some/output.txt") for _ in range(10)}
+    assert len(paths) == 10
+    for p in paths:
+        assert p.startswith("/some/output.txt.tmp.")
+
+
+def test_atomic_rename_uses_unique_temp_paths(tmp_path):
+    """Concurrent atomic_rename calls use distinct temp paths (UUID collision avoidance)."""
+    output = str(tmp_path / "out.txt")
+    observed_temps = []
+
+    for _ in range(5):
+        with atomic_rename(output) as temp_path:
+            observed_temps.append(temp_path)
+            Path(temp_path).write_text("data")
+
+    assert len(set(observed_temps)) == 5, "Each call should produce a unique temp path"
+    for tp in observed_temps:
+        assert ".tmp." in tp
+
+
+def test_atomic_rename_cleans_up_on_error(tmp_path):
+    """Temp file is removed when the context raises an exception."""
+    output = str(tmp_path / "out.txt")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        with atomic_rename(output) as temp_path:
+            Path(temp_path).write_text("bad")
+            raise RuntimeError("boom")
+
+    assert not Path(temp_path).exists()
+    assert not Path(output).exists()

--- a/lib/zephyr/src/zephyr/__init__.py
+++ b/lib/zephyr/src/zephyr/__init__.py
@@ -25,7 +25,7 @@ from zephyr.readers import (
     load_vortex,
     load_zip_members,
 )
-from zephyr.writers import atomic_rename, write_jsonl_file, write_parquet_file, write_vortex_file
+from zephyr.writers import write_jsonl_file, write_parquet_file, write_vortex_file
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +39,6 @@ __all__ = [
     "WorkerContext",
     "ZephyrContext",
     "ZephyrExecutionResult",
-    "atomic_rename",
     "col",
     "compute_plan",
     "counters",

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -41,7 +41,7 @@ from fray.local_backend import LocalClient
 from fray.types import Entrypoint, JobRequest
 from iris.client import get_iris_ctx
 from iris.cluster.client.job_info import get_job_info
-from rigging.filesystem import marin_temp_bucket, open_url, url_to_fs
+from rigging.filesystem import marin_temp_bucket, open_url, unique_temp_path, url_to_fs
 from rigging.timing import ExponentialBackoff, RateLimiter, log_time
 
 from zephyr.dataset import Dataset
@@ -57,7 +57,7 @@ from zephyr.plan import (
     compute_plan,
 )
 from zephyr.shuffle import ListShard, MemChunk, _write_scatter
-from zephyr.writers import INTERMEDIATE_CHUNK_SIZE, batchify, ensure_parent_dir, unique_temp_path
+from zephyr.writers import INTERMEDIATE_CHUNK_SIZE, batchify, ensure_parent_dir
 
 logger = logging.getLogger(__name__)
 

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -10,9 +10,8 @@ import logging
 import os
 import queue
 import threading
-import uuid
 from collections.abc import Callable, Iterable
-from contextlib import contextmanager, suppress
+from contextlib import contextmanager
 from dataclasses import asdict, is_dataclass
 from typing import Any
 
@@ -21,8 +20,7 @@ import pyarrow as pa
 import pyarrow.parquet as pq
 import vortex
 import zstandard as zstd
-from rigging.filesystem import url_to_fs
-from rigging.timing import ExponentialBackoff, retry_with_backoff
+from rigging.filesystem import atomic_rename, url_to_fs
 
 from zephyr import counters
 
@@ -43,97 +41,6 @@ _MICRO_BATCH_SIZE = 8
 # Number of items per intermediate pickle chunk between non-scatter stages.
 # Used by ``_write_pickle_chunks`` in execution.py.
 INTERMEDIATE_CHUNK_SIZE = 100_000
-
-
-def unique_temp_path(output_path: str) -> str:
-    """Return a unique temporary path derived from ``output_path``.
-
-    Appends ``.tmp.<uuid>`` to avoid collisions when multiple writers target the
-    same output path (e.g. during network-partition induced worker races).
-    """
-    return f"{output_path}.tmp.{uuid.uuid4().hex}"
-
-
-# AWS error codes that are safe to retry on a server-side multipart copy
-# (``s3fs.S3FileSystem.mv``). ``InvalidPart`` is the R2-specific symptom:
-# every ``UploadPartCopy`` returns 200 but ``CompleteMultipartUpload`` then
-# claims one or more parts are missing.
-_TRANSIENT_S3_ERROR_CODES = frozenset(
-    {
-        "InvalidPart",
-        "InternalError",
-        "ServiceUnavailable",
-        "SlowDown",
-        "RequestTimeout",
-        "RequestTimeTooSkewed",
-    }
-)
-
-# Fragments matched against ``str(exc)`` for the case where s3fs has already
-# translated the underlying ``botocore.ClientError`` into an ``OSError`` and
-# the structured error code is no longer reachable.
-_TRANSIENT_S3_MESSAGE_FRAGMENTS = (
-    "specified parts could not be found",
-    "InternalError",
-    "ServiceUnavailable",
-    "SlowDown",
-    "RequestTimeout",
-)
-
-
-def _is_transient_s3_error(exc: BaseException) -> bool:
-    response = getattr(exc, "response", None)
-    if isinstance(response, dict):
-        code = response.get("Error", {}).get("Code")
-        if code in _TRANSIENT_S3_ERROR_CODES:
-            return True
-    msg = str(exc)
-    return any(frag in msg for frag in _TRANSIENT_S3_MESSAGE_FRAGMENTS)
-
-
-def _mv_with_retry(fs: Any, src: str, dst: str) -> None:
-    def _on_retry(exc: Exception, _attempt: int) -> None:
-        counters.increment("zephyr/atomic_rename_retries")
-
-    retry_with_backoff(
-        lambda: fs.mv(src, dst, recursive=True),
-        retryable=_is_transient_s3_error,
-        max_attempts=4,
-        backoff=ExponentialBackoff(initial=1.0, maximum=8.0, factor=2.0),
-        on_retry=_on_retry,
-        operation=f"atomic_rename fs.mv {src} -> {dst}",
-    )
-
-
-@contextmanager
-def atomic_rename(output_path: str, fs: Any = None) -> Iterable[str]:
-    """Atomic write-and-rename via a sibling temp key.
-
-    Yields ``<output_path>.tmp.<uuid>``; on clean exit, ``fs.mv`` renames the
-    temp into the final path. On exception, the temp key is best-effort
-    deleted and the original exception re-raised.
-
-    Callers may pass a pre-constructed ``fs`` to reuse a configured
-    filesystem (e.g. an ``S3FileSystem`` with ``fixed_upload_size=True``)
-    instead of letting atomic_rename build a default one from ``output_path``.
-
-    Example:
-        with atomic_rename("output.jsonl.gz") as tmp_path:
-            write_data(tmp_path)
-        # File is now at output.jsonl.gz
-    """
-    temp_path = unique_temp_path(output_path)
-    if fs is None:
-        fs = url_to_fs(output_path)[0]
-    try:
-        yield temp_path
-        _mv_with_retry(fs, temp_path, output_path)
-    except Exception:
-        # Best-effort cleanup: temp file may not exist (writer crashed before
-        # creating it) so we tolerate any rm error and re-raise the original.
-        with suppress(Exception):
-            fs.rm(temp_path)
-        raise
 
 
 def ensure_parent_dir(path: str) -> None:

--- a/lib/zephyr/tests/test_writers.py
+++ b/lib/zephyr/tests/test_writers.py
@@ -11,48 +11,10 @@ import pyarrow.parquet as pq
 import pytest
 import vortex
 from zephyr.writers import (
-    atomic_rename,
     infer_arrow_schema,
-    unique_temp_path,
     write_parquet_file,
     write_vortex_file,
 )
-
-
-def test_unique_temp_path_produces_distinct_paths():
-    """Each call to unique_temp_path returns a different path."""
-    paths = {unique_temp_path("/some/output.txt") for _ in range(10)}
-    assert len(paths) == 10
-    for p in paths:
-        assert p.startswith("/some/output.txt.tmp.")
-
-
-def test_atomic_rename_uses_unique_temp_paths(tmp_path):
-    """Concurrent atomic_rename calls use distinct temp paths (UUID collision avoidance)."""
-    output = str(tmp_path / "out.txt")
-    observed_temps = []
-
-    for _ in range(5):
-        with atomic_rename(output) as temp_path:
-            observed_temps.append(temp_path)
-            Path(temp_path).write_text("data")
-
-    assert len(set(observed_temps)) == 5, "Each call should produce a unique temp path"
-    for tp in observed_temps:
-        assert ".tmp." in tp
-
-
-def test_atomic_rename_cleans_up_on_error(tmp_path):
-    """Temp file is removed when the context raises an exception."""
-    output = str(tmp_path / "out.txt")
-
-    with pytest.raises(RuntimeError, match="boom"):
-        with atomic_rename(output) as temp_path:
-            Path(temp_path).write_text("bad")
-            raise RuntimeError("boom")
-
-    assert not Path(temp_path).exists()
-    assert not Path(output).exists()
 
 
 def test_write_vortex_file_basic():

--- a/scripts/datakit/sync_datakit.py
+++ b/scripts/datakit/sync_datakit.py
@@ -37,7 +37,7 @@ For each source, this script builds a single :class:`StepSpec`. The step's
   and the shard is re-copied.
 * Otherwise, streams every file in the shard from source to a sibling
   ``.tmp.<uuid>`` key at the destination and publishes it via
-  :func:`zephyr.writers.atomic_rename` (the per-file copies fan out across
+  :func:`rigging.filesystem.atomic_rename` (the per-file copies fan out across
   ``copy_threads`` threads), then Zephyr writes the per-shard JSONL — that
   output IS the resume marker. When the destination is ``s3://``, the dst
   ``S3FileSystem`` is constructed with ``fixed_upload_size=True`` so R2
@@ -83,11 +83,10 @@ from marin.datakit.sources import DatakitSource, all_sources
 from marin.execution.executor_step_status import STATUS_SUCCESS, StatusFile, StepAlreadyDone, step_lock
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
-from rigging.filesystem import marin_prefix
+from rigging.filesystem import atomic_rename, marin_prefix
 from rigging.log_setup import configure_logging
 from zephyr import Dataset, ZephyrContext, counters
 from zephyr.plan import deterministic_hash
-from zephyr.writers import atomic_rename
 
 logger = logging.getLogger(__name__)
 
@@ -112,7 +111,7 @@ class SyncScope(StrEnum):
     NORMALIZED = "normalized"
 
 
-# Matches the ``.tmp.<uuid.hex>`` suffix that ``zephyr.writers.atomic_rename``
+# Matches the ``.tmp.<uuid.hex>`` suffix that ``rigging.filesystem.atomic_rename``
 # uses for its intermediate write key. Used to filter orphan leftovers out
 # of source listings (see ``_list_relative_files``).
 _ATOMIC_RENAME_TMP_RE = re.compile(r"\.tmp\.[0-9a-f]{32}$")
@@ -306,7 +305,7 @@ def _list_relative_files(src_dir: str) -> list[tuple[str, str]]:
             # the whole leaf is done.
             continue
         if _ATOMIC_RENAME_TMP_RE.search(rel):
-            # Orphans from a prior interrupted sync: ``zephyr.writers.atomic_rename``
+            # Orphans from a prior interrupted sync: ``rigging.filesystem.atomic_rename``
             # writes ``<dst>.tmp.<uuid.hex>`` then ``fs.mv``s; if the worker is
             # SIGKILLed between the two, the temp lingers. They're never
             # legitimate datakit content — skip them so they don't propagate.


### PR DESCRIPTION
## What

Moves `atomic_rename` and its helpers (`unique_temp_path`, the transient-S3 retry logic, `_mv_with_retry`) from `zephyr.writers` down to `rigging.filesystem`. These are generic filesystem utilities, not zephyr-specific, so callers can now depend on the lower layer directly instead of reaching through zephyr.

## Changes

- `rigging.filesystem` gains `atomic_rename` / `unique_temp_path` (+ transient-S3 retry helpers).
- Dropped the `zephyr/atomic_rename_retries` counter — rigging sits below zephyr and cannot import `zephyr.counters`. Retry-with-backoff behavior is otherwise unchanged.
- Repointed all callsites (marin, levanter, scripts) to `rigging.filesystem`.
- `zephyr.writers` / `zephyr.execution` now import these from rigging; removed the `zephyr` package re-export of `atomic_rename`.
- Moved the `atomic_rename` / `unique_temp_path` tests to `lib/rigging/tests/test_filesystem.py`.

## Verification

- `pytest lib/rigging/tests/test_filesystem.py lib/zephyr/tests/test_writers.py` — 16 passed
- 21 affected modules import cleanly; `zephyr.atomic_rename` re-export removed
- `pre-commit.py` (ruff / black / pyrefly) — all checks passed

🤖 Generated with [Claude Code](https://claude.com/claude-code)