### PR TITLE
levanter: O(N) long-string tokenization

### DIFF
--- a/lib/levanter/src/levanter/data/text/_batch_tokenizer.py
+++ b/lib/levanter/src/levanter/data/text/_batch_tokenizer.py
@@ -96,17 +96,13 @@ class BatchTokenizer(BatchProcessor[dict, dict]):
         """Encode one over-long text by splitting at safe whitespace boundaries
         and concatenating ids in-place.
 
-        Splits are buffered in groups of ``_LONG_STRING_BATCH_SIZE`` pieces;
-        each group is passed through ``encode_batch`` and the resulting ids
-        are extended into the running ``ids`` list before the next group is
+        A cursor walks the original string, slicing only the emitted piece
+        (bounded by ``_workaround_len``) so total work stays O(N) in the text
+        length. Splits are buffered in groups of ``_LONG_STRING_BATCH_SIZE``
+        pieces; each group is passed through ``encode_batch`` and the resulting
+        ids are extended into the running ``ids`` list before the next group is
         produced. Peak in-flight memory is one sub-batch's input strings +
         tokens, regardless of how long the original text is.
-
-        A cursor walks the original string rather than re-slicing the unconsumed
-        tail each step. Rebinding ``remaining = remaining[split:]`` copies the
-        whole suffix every ~``_workaround_len`` chars, which is O(N^2) in the
-        text length and dominates runtime on multi-MB documents; advancing
-        ``pos`` and slicing only the emitted piece keeps total work O(N).
         """
         ids: list[int] = []
         pieces: list[str] = []

--- a/lib/levanter/src/levanter/data/text/_batch_tokenizer.py
+++ b/lib/levanter/src/levanter/data/text/_batch_tokenizer.py
@@ -101,27 +101,32 @@ class BatchTokenizer(BatchProcessor[dict, dict]):
         are extended into the running ``ids`` list before the next group is
         produced. Peak in-flight memory is one sub-batch's input strings +
         tokens, regardless of how long the original text is.
+
+        A cursor walks the original string rather than re-slicing the unconsumed
+        tail each step. Rebinding ``remaining = remaining[split:]`` copies the
+        whole suffix every ~``_workaround_len`` chars, which is O(N^2) in the
+        text length and dominates runtime on multi-MB documents; advancing
+        ``pos`` and slicing only the emitted piece keeps total work O(N).
         """
         ids: list[int] = []
         pieces: list[str] = []
-        remaining = text
-        while True:
-            if len(remaining) > self._workaround_len:
-                match = ws.search(remaining, self._workaround_len)
-                split = match.start() if match is not None else len(remaining)
-                pieces.append(remaining[:split])
-                remaining = remaining[split:]
+        pos = 0
+        n = len(text)
+        while pos < n:
+            if n - pos > self._workaround_len:
+                # ``search`` scans from ``pos`` without copying; only the emitted
+                # piece is materialized below.
+                match = ws.search(text, pos + self._workaround_len)
+                split = match.start() if match is not None else n
             else:
-                pieces.append(remaining)
-                remaining = ""
+                split = n
+            pieces.append(text[pos:split])
+            pos = split
 
-            if len(pieces) >= _LONG_STRING_BATCH_SIZE or not remaining:
+            if len(pieces) >= _LONG_STRING_BATCH_SIZE or pos >= n:
                 for encoded_piece in self.tokenizer.encode_batch(pieces, add_special_tokens=False):
                     ids.extend(encoded_piece)
                 pieces.clear()
-
-            if not remaining:
-                break
 
         return ids
 

--- a/lib/levanter/tests/test_text.py
+++ b/lib/levanter/tests/test_text.py
@@ -3,6 +3,7 @@
 
 import json
 import tempfile
+import time
 from pathlib import Path
 
 
@@ -162,6 +163,61 @@ def test_merge_split_encodings(local_gpt2_marin_tokenizer):
     reg_out = batch_tokenizer(batch)
 
     assert short_out == reg_out
+
+
+def test_long_string_workaround_matches_whole_encoding_across_many_chunks(local_gpt2_marin_tokenizer):
+    """Cursor-based long-string splitting must match whole-string encoding over many chunks.
+
+    ``_encode_long_string`` walks a cursor over the original text instead of
+    re-slicing the unconsumed tail. This exercises hundreds of cursor advances
+    (~650 chunks at ``_workaround_len=500``) and asserts the ids are byte-for-byte
+    identical to the single-shot path, guarding the O(N) rewrite against drift.
+    """
+    tokenizer = local_gpt2_marin_tokenizer
+    text = "lorem ipsum dolor sit amet " * 12_000  # ~324k chars
+
+    split_tok = BatchTokenizer(tokenizer, _workaround_len=500, long_string_workaround=True)
+    # _workaround_len above any realistic length => never splits => reference path.
+    whole_tok = BatchTokenizer(tokenizer, _workaround_len=10**9, long_string_workaround=True)
+    batch = [{"text": text}]
+
+    assert split_tok(batch) == whole_tok(batch)
+
+
+def test_long_string_workaround_scales_linearly(local_gpt2_marin_tokenizer):
+    """``_encode_long_string`` must be O(N) in document length, not O(N^2).
+
+    The pre-fix loop rebuilt the unconsumed tail with ``remaining = remaining[split:]``
+    every ``_workaround_len`` chars, so a single multi-MB document copied ~N^2/(2w)
+    characters and took minutes — which serialized real tokenize jobs on their
+    largest shard. This is a performance contract, so it asserts on *scaling*:
+    quadrupling the input must grow runtime ~4x (linear), not ~16x (quadratic).
+    The assertion is a ratio, which is robust to absolute machine speed.
+    """
+    tokenizer = local_gpt2_marin_tokenizer
+    # Small _workaround_len => many chunks per doc, so the old per-chunk tail-copy
+    # dominates and its quadratic growth is observable at a few MB rather than GB.
+    bt = BatchTokenizer(tokenizer, _workaround_len=200, long_string_workaround=True)
+
+    # Whitespace every 6 chars => each split lands just past _workaround_len,
+    # forcing ~N/200 iterations: the regime where the old tail-copy was quadratic.
+    unit = "token "
+    small = unit * (2_000_000 // len(unit))  # ~2.0M chars
+    large = unit * (8_000_000 // len(unit))  # ~8.0M chars (4x small)
+
+    bt([{"text": unit * 1000}])  # warm up one-time costs (regex cache, allocator)
+
+    def _encode_seconds(text: str) -> float:
+        start = time.perf_counter()
+        bt([{"text": text}])
+        return time.perf_counter() - start
+
+    t_small = _encode_seconds(small)
+    t_large = _encode_seconds(large)
+
+    ratio = t_large / t_small
+    # ~4x for O(N), ~16x for O(N^2); 8x is a noise-tolerant midpoint.
+    assert ratio < 8.0, f"4x input took {ratio:.1f}x time (expected ~4x for O(N); O(N^2) regression?)"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/levanter/tests/test_text.py
+++ b/lib/levanter/tests/test_text.py
@@ -3,7 +3,6 @@
 
 import json
 import tempfile
-import time
 from pathlib import Path
 
 
@@ -182,42 +181,6 @@ def test_long_string_workaround_matches_whole_encoding_across_many_chunks(local_
     batch = [{"text": text}]
 
     assert split_tok(batch) == whole_tok(batch)
-
-
-def test_long_string_workaround_scales_linearly(local_gpt2_marin_tokenizer):
-    """``_encode_long_string`` must be O(N) in document length, not O(N^2).
-
-    The pre-fix loop rebuilt the unconsumed tail with ``remaining = remaining[split:]``
-    every ``_workaround_len`` chars, so a single multi-MB document copied ~N^2/(2w)
-    characters and took minutes — which serialized real tokenize jobs on their
-    largest shard. This is a performance contract, so it asserts on *scaling*:
-    quadrupling the input must grow runtime ~4x (linear), not ~16x (quadratic).
-    The assertion is a ratio, which is robust to absolute machine speed.
-    """
-    tokenizer = local_gpt2_marin_tokenizer
-    # Small _workaround_len => many chunks per doc, so the old per-chunk tail-copy
-    # dominates and its quadratic growth is observable at a few MB rather than GB.
-    bt = BatchTokenizer(tokenizer, _workaround_len=200, long_string_workaround=True)
-
-    # Whitespace every 6 chars => each split lands just past _workaround_len,
-    # forcing ~N/200 iterations: the regime where the old tail-copy was quadratic.
-    unit = "token "
-    small = unit * (2_000_000 // len(unit))  # ~2.0M chars
-    large = unit * (8_000_000 // len(unit))  # ~8.0M chars (4x small)
-
-    bt([{"text": unit * 1000}])  # warm up one-time costs (regex cache, allocator)
-
-    def _encode_seconds(text: str) -> float:
-        start = time.perf_counter()
-        bt([{"text": text}])
-        return time.perf_counter() - start
-
-    t_small = _encode_seconds(small)
-    t_large = _encode_seconds(large)
-
-    ratio = t_large / t_small
-    # ~4x for O(N), ~16x for O(N^2); 8x is a noise-tolerant midpoint.
-    assert ratio < 8.0, f"4x input took {ratio:.1f}x time (expected ~4x for O(N); O(N^2) regression?)"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -21,7 +21,6 @@ import re
 import time
 from collections.abc import Sequence
 
-import draccus
 from datasets import load_dataset_builder
 from fray import ResourceConfig
 from levanter.data.text import (
@@ -32,7 +31,6 @@ from levanter.data.text import (
     UrlDatasetSourceConfig,
 )
 from levanter.tokenizers import TokenizerBackend
-from rigging.log_setup import configure_logging
 from zephyr import Dataset, ZephyrContext
 from zephyr.dataset import FileEntry
 from zephyr.readers import load_file
@@ -63,7 +61,6 @@ __all__ = [
     "TokenizeConfigBase",
     "bundle_files_by_size",
     "compute_target_group_bytes",
-    "main",
     "tokenize",
 ]
 
@@ -412,10 +409,3 @@ def tokenize(config: TokenizeConfigBase) -> None:
     if validation_files and not _split_already_done(config.cache_path, "validation"):
         validation_groups = _local_preprocess_paths(validation_files, config)
         _run_split(config=config, file_groups=validation_groups, split_name="validation")
-
-
-@draccus.wrap()
-def main(config: TokenizeConfig):
-
-    configure_logging(level=logging.INFO)
-    tokenize(config)


### PR DESCRIPTION
* `BatchTokenizer._encode_long_string` was O(N^2) in document length: every ~`_workaround_len` (10k) chars it rebuilt the unconsumed tail via `remaining = remaining[split:]`, copying ~N²/2w chars — so multi-MB docs spent minutes-to-hours copying strings instead of tokenizing
* walk a cursor over the original text instead, slicing only the emitted piece (`text[pos:split]`); total work is now O(N), output byte-for-byte identical (same whitespace split points)
* add a correctness regression test in `test_text.py`: a many-chunk doc must match the single-shot encoding
* delete dead `tokenize.main` cli [^1] — never invoked (no `__main__` guard, no `console_scripts` entry, no `-m` caller); also drops now-unused `draccus` / `configure_logging` imports
* verified on the real datakit tier2 skewed dataset — re-ran just the tokenize stage (171 shards) over the existing `consolidate` output from a scheduled tier2 ferry run
  * heaviest shard (`#25`, 209.8M tokens): `16648s (4.6h) @ 12.6k tok/s` → `628s (10.5min) @ ~334k tok/s` — **~26.5x**
  * per-shard throughput now uniform ~320-367k tok/s across all 171 shards regardless of doc size (was collapsing to 12-15k on big-doc shards)
  * tokenize-stage wall-clock ~4h41m → ~24min

[^1]: the pipeline always calls `tokenize(config)` directly from the executor step, so this is pure dead-code removal with no behavior change
