### PR TITLE
[iris] Do not tear down live TPUs on slow create-status

### DIFF
--- a/lib/iris/src/iris/cluster/providers/gcp/fake.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/fake.py
@@ -25,6 +25,7 @@ from iris.cluster.providers.gcp.local import LocalSliceHandle
 from iris.cluster.providers.gcp.service import (
     KNOWN_GCP_ZONES,
     KNOWN_TPU_TYPES,
+    OperationStatus,
     QueuedResourceInfo,
     TpuCreateRequest,
     TpuInfo,
@@ -93,6 +94,9 @@ class InMemoryGcpService:
         self._tpus: dict[tuple[str, str], TpuInfo] = {}
         self._vms: dict[tuple[str, str], VmInfo] = {}
         self._queued_resources: set[tuple[str, str]] = set()  # TPUs created via queued_resource_create
+        # Create-LRO status by operation name; defaults to done-ok, tests can
+        # override via set_operation_status to simulate a failed/pending LRO.
+        self._operation_statuses: dict[str, OperationStatus] = {}
 
         # Failure injection (DRY_RUN/LOCAL only)
         self._injected_failures: dict[str, InfraError] = {}
@@ -209,6 +213,8 @@ class InMemoryGcpService:
         seq = len(self._tpus)
         endpoints = [f"10.0.{seq}.{i}" for i in range(vm_count)]
 
+        op_name = f"projects/{self._project_id}/locations/{request.zone}/operations/{request.name}-create"
+        self._operation_statuses.setdefault(op_name, OperationStatus(done=True))
         info = TpuInfo(
             name=request.name,
             state="CREATING",
@@ -220,9 +226,18 @@ class InMemoryGcpService:
             network_endpoints=endpoints,
             external_network_endpoints=[None] * len(endpoints),
             created_at=Timestamp.now(),
+            operation_name=op_name,
         )
         self._tpus[(request.name, request.zone)] = info
         return info
+
+    def tpu_operation_status(self, operation_name: str) -> OperationStatus:
+        self._check_injected_failure("tpu_operation_status")
+        return self._operation_statuses.get(operation_name, OperationStatus(done=True))
+
+    def set_operation_status(self, operation_name: str, status: OperationStatus) -> None:
+        """Override the reported status of a create LRO (DRY_RUN/LOCAL only)."""
+        self._operation_statuses[operation_name] = status
 
     def tpu_delete(self, name: str, zone: str) -> None:
         self._check_injected_failure("tpu_delete")

--- a/lib/iris/src/iris/cluster/providers/gcp/handles.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/handles.py
@@ -103,14 +103,30 @@ def _composite_slice_state(
     cloud_state: CloudSliceState,
     bootstrap_state: CloudSliceState | None,
 ) -> CloudSliceState:
-    """Compose cloud lifecycle with bootstrap lifecycle into effective slice state."""
-    if cloud_state != CloudSliceState.READY:
+    """Compose cloud lifecycle with bootstrap lifecycle into effective slice state.
+
+    Worker health is canonical for liveness: once bootstrap is READY the slice
+    is READY even if the GCP-reported cloud state still lags at CREATING — a TPU
+    can boot and serve long before its create operation flips to READY. A slice
+    rediscovered on controller restart (no bootstrap monitoring) carries a READY
+    bootstrap sentinel, so it too becomes READY and is validated by the
+    autoscaler's health probe, which reaps it if the workers are in fact dead.
+
+    Cloud states that mean "gone or doomed" — FAILED, DELETING, and UNKNOWN (no
+    longer describable) — are authoritative and override the bootstrap verdict,
+    so a torn-down or vanished node never lingers as READY on a stale sentinel.
+    """
+    if cloud_state in (CloudSliceState.FAILED, CloudSliceState.DELETING, CloudSliceState.UNKNOWN):
         return cloud_state
-    if bootstrap_state is None:
-        return CloudSliceState.BOOTSTRAPPING
     if bootstrap_state == CloudSliceState.FAILED:
         return CloudSliceState.FAILED
-    return CloudSliceState.READY
+    if bootstrap_state == CloudSliceState.READY:
+        return CloudSliceState.READY
+    # Bootstrap still in progress: surface BOOTSTRAPPING once cloud is READY,
+    # otherwise reflect the raw cloud state (CREATING/REPAIRING).
+    if cloud_state == CloudSliceState.READY:
+        return CloudSliceState.BOOTSTRAPPING
+    return cloud_state
 
 
 # ============================================================================
@@ -225,6 +241,7 @@ class GcpSliceHandle:
         _service_account: str | None = None,
         _bootstrapping: bool = False,
         _is_queued_resource: bool = False,
+        _create_operation: str = "",
     ):
         self._slice_id = _slice_id
         self._zone = _zone
@@ -239,6 +256,7 @@ class GcpSliceHandle:
         self._ssh_config = _ssh_config
         self._service_account = _service_account
         self.is_queued_resource: bool = _is_queued_resource
+        self._create_operation = _create_operation
         self._bootstrap_state: CloudSliceState | None = None if _bootstrapping else CloudSliceState.READY
         self._bootstrap_lock = threading.Lock()
 

--- a/lib/iris/src/iris/cluster/providers/gcp/service.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/service.py
@@ -85,18 +85,6 @@ _OPERATION_TIMEOUT = 600  # seconds to wait for an operation to complete
 _RPC_CODE_RESOURCE_EXHAUSTED = 8
 
 
-def _default_tpu_operation_timeout(accelerator_type: str) -> float:
-    """Return an LRO timeout sized for TPU topology."""
-    topology = next((topology for topology in TPU_TOPOLOGIES if topology.name == accelerator_type), None)
-    if topology is None:
-        return _OPERATION_TIMEOUT
-    if topology.vm_count >= 256:
-        return 1800.0
-    if topology.vm_count >= 64:
-        return 900.0
-    return _OPERATION_TIMEOUT
-
-
 # ============================================================================
 # Data types
 # ============================================================================
@@ -116,6 +104,34 @@ class TpuInfo:
     network_endpoints: list[str]  # Internal IP addresses
     external_network_endpoints: list[str | None]
     created_at: Timestamp
+    # Name of the in-flight create operation (LRO), populated only by
+    # tpu_create(). Empty for describe/list results. The bootstrap loop polls
+    # this via tpu_operation_status() to fail fast on quota/stockout while
+    # otherwise letting worker health — not the LRO — decide readiness.
+    operation_name: str = ""
+
+
+@dataclass(frozen=True)
+class OperationStatus:
+    """Status of an async GCP long-running operation (LRO)."""
+
+    done: bool
+    error_code: int | None = None
+    error_message: str | None = None
+
+
+def operation_error(status: OperationStatus) -> InfraError | None:
+    """Translate a completed-with-error operation into the exception to raise.
+
+    Returns None when the operation has no error (still running, or succeeded).
+    Quota/stockout (RESOURCE_EXHAUSTED) maps to QuotaExhaustedError so the
+    autoscaler backs off quietly instead of treating it as a boot failure.
+    """
+    if status.error_code is None:
+        return None
+    if status.error_code == _RPC_CODE_RESOURCE_EXHAUSTED:
+        return QuotaExhaustedError(status.error_message or "resource exhausted")
+    return InfraError(f"TPU operation failed: {status.error_message}")
 
 
 @dataclass
@@ -241,6 +257,7 @@ class GcpService(Protocol):
     def project_id(self) -> str: ...
 
     def tpu_create(self, request: TpuCreateRequest) -> TpuInfo: ...
+    def tpu_operation_status(self, operation_name: str) -> OperationStatus: ...
     def tpu_delete(self, name: str, zone: str) -> None: ...
     def tpu_describe(self, name: str, zone: str) -> TpuInfo | None: ...
     def tpu_list(self, zones: list[str], labels: dict[str, str] | None = None) -> list[TpuInfo]: ...
@@ -507,30 +524,29 @@ class CloudGcpService:
                 raise InfraError(f"Operation {operation_name} timed out after {timeout}s")
             time.sleep(backoff.next_interval())
 
-    def _wait_tpu_operation(self, operation_name: str, timeout: float = _OPERATION_TIMEOUT) -> dict:
-        url = f"{_TPU_BASE}/{operation_name}"
-        deadline = time.monotonic() + timeout
-        backoff = ExponentialBackoff(initial=1.0, maximum=30.0, factor=1.5)
-        while True:
-            resp = self._client.get(url, headers=self._headers())
-            self._classify_response(resp)
-            data = resp.json()
-            if data.get("done"):
-                if "error" in data:
-                    error = data["error"]
-                    msg = error.get("message", str(error))
-                    # Zone stockouts ("no more capacity in the zone ...") come
-                    # back as RESOURCE_EXHAUSTED on the LRO rather than on the
-                    # initial HTTP response. Surface them as QuotaExhaustedError
-                    # so the autoscaler treats them like any other quota hit
-                    # (terse warning + backoff, no stack trace).
-                    if error.get("code") == _RPC_CODE_RESOURCE_EXHAUSTED:
-                        raise QuotaExhaustedError(msg)
-                    raise InfraError(f"TPU operation failed: {msg}")
-                return data
-            if time.monotonic() >= deadline:
-                raise InfraError(f"TPU operation {operation_name} timed out after {timeout}s")
-            time.sleep(backoff.next_interval())
+    def tpu_operation_status(self, operation_name: str) -> OperationStatus:
+        """Fetch the current status of a TPU create/delete LRO (single GET).
+
+        A still-running operation returns done=False. A completed operation
+        returns done=True with error_code/error_message set when it failed.
+        Zone stockouts come back here as RESOURCE_EXHAUSTED rather than on the
+        initial create response; callers use operation_error() to classify.
+        """
+        if not operation_name or "/operations/" not in operation_name:
+            return OperationStatus(done=True)
+        resp = self._client.get(f"{_TPU_BASE}/{operation_name}", headers=self._headers())
+        self._classify_response(resp)
+        data = resp.json()
+        if not data.get("done"):
+            return OperationStatus(done=False)
+        error = data.get("error")
+        if error:
+            return OperationStatus(
+                done=True,
+                error_code=error.get("code"),
+                error_message=error.get("message", str(error)),
+            )
+        return OperationStatus(done=True)
 
     # ========================================================================
     # Low-level REST helpers
@@ -573,17 +589,31 @@ class CloudGcpService:
 
         logger.info("Creating TPU: %s (type=%s, zone=%s)", request.name, request.accelerator_type, request.zone)
 
-        # POST to create, wait for LRO, then GET the final node state
+        # POST to submit the create LRO and return immediately, reporting the node
+        # as CREATING. We do NOT wait for the operation to report done: GCP can
+        # leave a create LRO unfinished long after the node has booted and
+        # registered workers, and blocking here used to tear down live slices on a
+        # spurious timeout. The bootstrap loop polls this operation (via
+        # tpu_operation_status) only to fail fast on quota/stockout; readiness is
+        # decided by worker health, and node details are read later via describe.
         url = f"{_TPU_BASE}/{self._tpu_parent(request.zone)}/nodes"
         resp = self._client.post(url, params={"nodeId": request.name}, headers=self._headers(), json=body)
         self._classify_response(resp)
-        data = resp.json()
-        op_name = data.get("name", "")
-        if op_name and "/operations/" in op_name:
-            self._wait_tpu_operation(op_name, timeout=_default_tpu_operation_timeout(request.accelerator_type))
+        op_name = resp.json().get("name", "")
 
-        tpu_data = self._tpu_get(request.name, request.zone)
-        return _parse_tpu_info(tpu_data, request.zone)
+        return TpuInfo(
+            name=request.name,
+            state="CREATING",
+            accelerator_type=request.accelerator_type,
+            zone=request.zone,
+            labels=dict(request.labels),
+            metadata=dict(request.metadata),
+            service_account=request.service_account,
+            network_endpoints=[],
+            external_network_endpoints=[],
+            created_at=Timestamp.now(),
+            operation_name=op_name,
+        )
 
     def tpu_delete(self, name: str, zone: str) -> None:
         logger.info("Deleting TPU (async): %s", name)

--- a/lib/iris/src/iris/cluster/providers/gcp/workers.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/workers.py
@@ -43,6 +43,7 @@ from iris.cluster.providers.gcp.service import (
     GcpService,
     TpuCreateRequest,
     VmCreateRequest,
+    operation_error,
 )
 from iris.cluster.providers.gcp.ssh import OS_LOGIN_METADATA, ssh_impersonate_service_account
 from iris.cluster.providers.remote_exec import GceRemoteExec
@@ -91,49 +92,44 @@ DEFAULT_MACHINE_TYPE = "n2-standard-4"
 DEFAULT_BOOT_DISK_SIZE_GB = 50
 # pd-ssd provides ~6000 IOPS vs ~38 on pd-standard, critical for controller DB
 DEFAULT_BOOT_DISK_TYPE = "pd-ssd"
-DEFAULT_TPU_CLOUD_READY_TIMEOUT = 600.0
-DEFAULT_TPU_BOOTSTRAP_TIMEOUT = 600.0
+# Generous backstops: these only bound a genuinely-stuck node. Real failures
+# (create-LRO error, a slice entering DELETING) abort the bootstrap immediately,
+# so waiting longer here costs nothing but tolerates slow provisioning.
+DEFAULT_TPU_IP_WAIT_TIMEOUT = 60 * 60.0
+DEFAULT_TPU_BOOTSTRAP_TIMEOUT = 60 * 60.0
 RESERVED_TPU_ASSIGN_TIMEOUT = 4 * 60 * 60.0
 RESERVED_TPU_PROVISION_TIMEOUT = 2 * 60 * 60.0
 TPU_BOOTSTRAP_PROGRESS_LOG_INTERVAL = 60.0
 TPU_BOOTSTRAP_DIAGNOSTIC_LIMIT = 8
 
 
-def _default_tpu_cloud_ready_timeout(worker_count: int) -> float:
-    """Return a cloud READY timeout sized for TPU pod startup."""
+def _default_tpu_ip_wait_timeout(worker_count: int) -> float:
+    """Return a timeout for workers to acquire IPs, sized for TPU pod startup."""
     if worker_count >= 256:
-        return 1800.0
+        return 3 * DEFAULT_TPU_IP_WAIT_TIMEOUT
     if worker_count >= 64:
-        return 900.0
-    return DEFAULT_TPU_CLOUD_READY_TIMEOUT
+        return 2 * DEFAULT_TPU_IP_WAIT_TIMEOUT
+    return DEFAULT_TPU_IP_WAIT_TIMEOUT
 
 
 def _default_tpu_bootstrap_timeout(worker_count: int) -> float:
     """Return a worker health timeout sized for TPU pod bootstrap."""
     if worker_count >= 256:
-        return 1800.0
+        return 3 * DEFAULT_TPU_BOOTSTRAP_TIMEOUT
     if worker_count >= 64:
-        return 900.0
+        return 2 * DEFAULT_TPU_BOOTSTRAP_TIMEOUT
     return DEFAULT_TPU_BOOTSTRAP_TIMEOUT
 
 
 def _summarize_missing_workers(
     missing_workers: list[str],
-    last_probe_errors: dict[str, str],
     limit: int = TPU_BOOTSTRAP_DIAGNOSTIC_LIMIT,
 ) -> str:
-    """Summarize missing TPU workers and their last probe errors for logs."""
+    """Summarize TPU workers that have not yet reported healthy, for logs."""
     if not missing_workers:
         return "none"
 
-    rendered: list[str] = []
-    for worker_id in missing_workers[:limit]:
-        probe_error = last_probe_errors.get(worker_id)
-        if probe_error:
-            rendered.append(f"{worker_id} ({probe_error})")
-        else:
-            rendered.append(worker_id)
-
+    rendered = list(missing_workers[:limit])
     if len(missing_workers) > limit:
         rendered.append(f"... +{len(missing_workers) - limit} more")
 
@@ -298,14 +294,6 @@ class GcpWorkerProvider:
             return image
         return rewrite_ghcr_to_ar_remote(image, multi_region, self._project_id)
 
-    def _best_effort_delete_tpu(self, slice_id: str, zone: str) -> None:
-        """Try to delete a TPU VM that may have been partially created."""
-        logger.info("Best-effort async cleanup of TPU %s in %s", slice_id, zone)
-        try:
-            self._gcp.tpu_delete(slice_id, zone)
-        except InfraError as e:
-            logger.warning("Cleanup of TPU %s failed: %s", slice_id, e)
-
     def _best_effort_delete_vm(self, vm_name: str, zone: str) -> None:
         """Try to delete a GCE VM that may have been partially created."""
         logger.info("Best-effort cleanup of VM %s in %s", vm_name, zone)
@@ -451,11 +439,11 @@ class GcpWorkerProvider:
         )
 
         logger.info("Creating TPU slice: %s (type=%s, zone=%s)", slice_id, config.accelerator_variant, gcp.zone)
-        try:
-            self._gcp.tpu_create(request)
-        except InfraError:
-            self._best_effort_delete_tpu(slice_id, gcp.zone)
-            raise
+        # Submit the create and return immediately. The create LRO is no longer
+        # waited on here: the bootstrap loop watches it for quota/stockout and
+        # otherwise lets worker health decide readiness, so a slow create-status
+        # response can never tear down a slice that has already booted workers.
+        tpu_info = self._gcp.tpu_create(request)
 
         handle = GcpSliceHandle(
             _slice_id=slice_id,
@@ -470,6 +458,7 @@ class GcpWorkerProvider:
             _ssh_config=self._ssh_config,
             _service_account=request.service_account,
             _bootstrapping=worker_config is not None,
+            _create_operation=tpu_info.operation_name,
         )
 
         if worker_config:
@@ -822,20 +811,38 @@ class GcpWorkerProvider:
 # ============================================================================
 
 
+def _raise_if_create_failed(gcp_service: GcpService, handle: GcpSliceHandle) -> None:
+    """Fail fast if the slice's create LRO completed with an error.
+
+    A pending or successful operation is a no-op; only a completed-with-error
+    operation raises (quota/stockout as QuotaExhaustedError, else InfraError).
+    Reserved (queued-resource) slices have no create LRO — their failures
+    surface through the queued-resource state instead.
+    """
+    if not handle._create_operation:
+        return
+    error = operation_error(gcp_service.tpu_operation_status(handle._create_operation))
+    if error is not None:
+        raise error
+
+
 def _run_tpu_bootstrap(
     gcp_service: GcpService,
     project_id: str,
     handle: GcpSliceHandle,
     poll_interval: float = 10.0,
-    cloud_ready_timeout: float | None = None,
+    ip_wait_timeout: float | None = None,
     bootstrap_timeout: float | None = None,
     queued_resource_poll_interval: float = 60.0,
 ) -> None:
     """Monitor TPU startup-script bootstrap via health endpoint polling.
 
     Phase 0 (reserved only): Wait for queued resource to become ACTIVE.
-    Phase 1: Wait for cloud READY with all worker IPs.
-    Phase 2: Poll worker health endpoints until all respond healthy.
+    Phase 1: Watch the create LRO for failure and wait for every worker to
+        acquire an IP. We do NOT wait for GCP to report cloud READY — a TPU
+        routinely serves workers while its node still reports CREATING.
+    Phase 2: Poll worker health endpoints until all respond healthy; this is
+        the canonical readiness signal.
     On timeout: query Cloud Logging for [iris-init] entries for diagnostics.
     """
     try:
@@ -846,18 +853,18 @@ def _run_tpu_bootstrap(
             "Cannot size bootstrap timeouts."
         ) from e
 
-    effective_cloud_ready_timeout = cloud_ready_timeout
-    if effective_cloud_ready_timeout is None:
-        effective_cloud_ready_timeout = _default_tpu_cloud_ready_timeout(worker_count)
+    effective_ip_wait_timeout = ip_wait_timeout
+    if effective_ip_wait_timeout is None:
+        effective_ip_wait_timeout = _default_tpu_ip_wait_timeout(worker_count)
 
     effective_bootstrap_timeout = bootstrap_timeout
     if effective_bootstrap_timeout is None:
         effective_bootstrap_timeout = _default_tpu_bootstrap_timeout(worker_count)
 
     logger.info(
-        "Using TPU bootstrap timeouts for %s: cloud_ready_timeout=%ss bootstrap_timeout=%ss worker_count=%d",
+        "Using TPU bootstrap timeouts for %s: ip_wait_timeout=%ss bootstrap_timeout=%ss worker_count=%d",
         handle.slice_id,
-        effective_cloud_ready_timeout,
+        effective_ip_wait_timeout,
         effective_bootstrap_timeout,
         worker_count,
     )
@@ -868,33 +875,33 @@ def _run_tpu_bootstrap(
     if handle.is_queued_resource:
         _wait_for_queued_resource_activation(gcp_service, handle, queued_resource_poll_interval)
 
-    # Phase 1: once the QR is ACTIVE (or immediately for non-queued TPUs),
-    # wait for the TPU VM to reach READY with all worker IPs.
-    cloud_deadline = Deadline.from_now(Duration.from_seconds(effective_cloud_ready_timeout))
-    cloud_backoff = ExponentialBackoff(initial=1.0, maximum=30.0, factor=1.5)
+    # Phase 1: wait for every worker to acquire an internal IP. The create LRO
+    # is watched only to fail fast on quota/stockout; its completion is not a
+    # readiness gate, so a slow create-status response cannot strand the slice.
+    ip_deadline = Deadline.from_now(Duration.from_seconds(effective_ip_wait_timeout))
+    ip_backoff = ExponentialBackoff(initial=1.0, maximum=30.0, factor=1.5)
 
-    while not cloud_deadline.expired():
+    while not ip_deadline.expired():
+        _raise_if_create_failed(gcp_service, handle)
         cloud_status = handle._describe_cloud()
         if cloud_status.state in (CloudSliceState.FAILED, CloudSliceState.DELETING):
-            raise InfraError(f"Slice {handle.slice_id} entered {cloud_status.state} while waiting for cloud READY")
-        if cloud_status.state == CloudSliceState.READY:
-            all_have_ips = all(w.internal_address for w in cloud_status.workers)
-            if all_have_ips and len(cloud_status.workers) == cloud_status.worker_count:
-                break
-            logger.info(
-                "Slice %s is READY but only %d/%d workers have IPs, waiting...",
-                handle.slice_id,
-                sum(1 for w in cloud_status.workers if w.internal_address),
-                cloud_status.worker_count,
-            )
-        time.sleep(cloud_backoff.next_interval())
+            raise InfraError(f"Slice {handle.slice_id} entered {cloud_status.state} during bootstrap")
+        if cloud_status.workers and all(w.internal_address for w in cloud_status.workers):
+            break
+        logger.info(
+            "Slice %s waiting for worker IPs: %d/%d (cloud state=%s)",
+            handle.slice_id,
+            sum(1 for w in cloud_status.workers if w.internal_address),
+            cloud_status.worker_count,
+            cloud_status.state,
+        )
+        time.sleep(ip_backoff.next_interval())
     else:
-        raise InfraError(f"Slice {handle.slice_id} did not reach cloud READY within {effective_cloud_ready_timeout}s")
+        raise InfraError(f"Slice {handle.slice_id} did not acquire worker IPs within {effective_ip_wait_timeout}s")
 
     workers = cloud_status.workers
     worker_urls = [(w.worker_id, w.worker_url) for w in workers]
     healthy_workers: set[str] = set()
-    last_probe_errors: dict[str, str] = {}
     health_deadline = Deadline.from_now(Duration.from_seconds(effective_bootstrap_timeout))
     next_progress_log = time.monotonic() + TPU_BOOTSTRAP_PROGRESS_LOG_INTERVAL
 
@@ -906,16 +913,9 @@ def _run_tpu_bootstrap(
 
     while not health_deadline.expired():
         for worker_id, worker_url in worker_urls:
-            if worker_id in healthy_workers:
-                continue
-            try:
-                resp = urllib.request.urlopen(f"{worker_url}/health", timeout=5)
-                if resp.status == 200:
-                    healthy_workers.add(worker_id)
-                    last_probe_errors.pop(worker_id, None)
-                    logger.info("Worker %s is healthy", worker_id)
-            except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError) as e:
-                last_probe_errors[worker_id] = str(e).strip() or type(e).__name__
+            if worker_id not in healthy_workers and _probe_worker_health(worker_url):
+                healthy_workers.add(worker_id)
+                logger.info("Worker %s is healthy", worker_id)
 
         if len(healthy_workers) == len(worker_urls):
             break
@@ -926,7 +926,7 @@ def _run_tpu_bootstrap(
                 handle.slice_id,
                 len(healthy_workers),
                 len(worker_urls),
-                _summarize_missing_workers(missing_workers, last_probe_errors),
+                _summarize_missing_workers(missing_workers),
             )
             next_progress_log = time.monotonic() + TPU_BOOTSTRAP_PROGRESS_LOG_INTERVAL
         time.sleep(poll_interval)
@@ -937,7 +937,7 @@ def _run_tpu_bootstrap(
             handle.slice_id,
             len(healthy_workers),
             len(worker_urls),
-            _summarize_missing_workers(missing_workers, last_probe_errors),
+            _summarize_missing_workers(missing_workers),
         )
         _fetch_bootstrap_logs(gcp_service, handle)
         raise InfraError(

--- a/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
@@ -9,6 +9,7 @@ backed by in-memory fakes rather than MagicMock.
 """
 
 import threading
+import unittest.mock
 
 from iris.cluster.constraints import DeviceType, PlacementRequirements
 from iris.cluster.controller.autoscaler import Autoscaler
@@ -233,7 +234,11 @@ class TestAutoscalerWaterfallEndToEnd:
         total = group_primary.slice_count() + group_fallback.slice_count()
         assert total == 3
 
-    def test_demand_cascades_through_priority_groups_on_backoff(self):
+    # The fallback slice now reports READY as soon as it has worker IPs (worker
+    # health is canonical), so run_once health-probes it. Stub the probe — the
+    # fake's synthetic IPs have no server and would otherwise block on timeouts.
+    @unittest.mock.patch("iris.cluster.controller.autoscaler.runtime._probe_worker_health", return_value=True)
+    def test_demand_cascades_through_priority_groups_on_backoff(self, _mock_probe):
         """E2E: primary keeps failing creates -> detector HOSTILE -> cascades to fallback."""
         config_primary = make_scale_group_config(name="primary", max_slices=5, priority=10, zones=["us-central1-a"])
         config_fallback = make_scale_group_config(name="fallback", max_slices=5, priority=20, zones=["us-central1-a"])

--- a/lib/iris/tests/cluster/providers/gcp/test_cloud_service_integration.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_cloud_service_integration.py
@@ -23,6 +23,7 @@ from iris.cluster.providers.gcp.service import (
     CloudGcpService,
     TpuCreateRequest,
     VmCreateRequest,
+    operation_error,
 )
 from iris.cluster.providers.types import QuotaExhaustedError
 from iris.rpc import config_pb2
@@ -368,9 +369,12 @@ def test_tpu_full_lifecycle(svc: CloudGcpService, backend: GcpFakeBackend):
 
     log_str = _dump_http_log(backend.http_log)
 
+    # Create returns immediately with the node CREATING and the create LRO name;
+    # it no longer blocks for READY (that would let a slow create-status tear
+    # down a live slice — see #6087).
     assert tpu.name == "test-slice", f"Expected test-slice, got {tpu.name}\n{log_str}"
-    assert tpu.state == "READY", f"Expected READY, got {tpu.state}\n{log_str}"
-    assert len(tpu.network_endpoints) == 4, f"Expected 4 endpoints, got {tpu.network_endpoints}\n{log_str}"
+    assert tpu.state == "CREATING", f"Expected CREATING, got {tpu.state}\n{log_str}"
+    assert tpu.operation_name, f"Expected a create operation name\n{log_str}"
 
     # Verify the create request body was correct
     create_req = next(e for e in backend.http_log if e.method == "POST" and "nodeId=test-slice" in e.url)
@@ -383,10 +387,15 @@ def test_tpu_full_lifecycle(svc: CloudGcpService, backend: GcpFakeBackend):
     assert create_req.request_body["serviceAccount"] == {"email": "worker@test.iam.gserviceaccount.com"}
     assert create_req.request_body["networkConfig"]["enableExternalIps"] is True
 
-    # Describe should return the same TPU
+    # Polling the create operation (as the bootstrap loop does) completes it
+    # without error and the node then reaches READY with its endpoints.
+    status = svc.tpu_operation_status(tpu.operation_name)
+    assert status.done
+    assert operation_error(status) is None
     described = svc.tpu_describe("test-slice", ZONE_EU)
     assert described is not None
     assert described.state == "READY"
+    assert len(described.network_endpoints) == 4, f"Expected 4 endpoints, got {described.network_endpoints}\n{log_str}"
 
     # List with label filter
     results = svc.tpu_list(zones=[ZONE_EU], labels={"iris-managed": "true"})
@@ -513,10 +522,11 @@ def test_serial_port_output(svc: CloudGcpService, backend: GcpFakeBackend):
 # ========================================================================
 
 
-def test_tpu_create_lro_resource_exhausted_raises_quota_error(svc: CloudGcpService, backend: GcpFakeBackend):
-    """LRO finishing with code=8 (RESOURCE_EXHAUSTED) raises QuotaExhaustedError,
-    not generic InfraError. This lets the autoscaler log it without a stack trace."""
-    # Inject a pending operation whose poll returns an error with code 8
+def test_tpu_operation_status_resource_exhausted_maps_to_quota_error(svc: CloudGcpService, backend: GcpFakeBackend):
+    """A create LRO finishing with code=8 (RESOURCE_EXHAUSTED) classifies as
+    QuotaExhaustedError via operation_error, not generic InfraError, so the
+    autoscaler logs it without a stack trace. The create itself no longer waits
+    on the LRO (#6087); the bootstrap loop polls this status instead."""
     op_name = f"projects/{PROJECT}/locations/{ZONE_EU}/operations/op-tpu-stockout"
     backend.operations[op_name] = {
         "name": op_name,
@@ -527,23 +537,8 @@ def test_tpu_create_lro_resource_exhausted_raises_quota_error(svc: CloudGcpServi
         },
     }
 
-    # Patch the POST to return this operation name
-    orig_handle = backend._handle_tpu
-
-    def _patched_tpu(method, url, body):
-        if method == "POST" and "/nodes" in url and "nodeId=" in url:
-            return httpx.Response(200, json={"name": op_name, "done": False})
-        return orig_handle(method, url, body)
-
-    backend._handle_tpu = _patched_tpu
-
-    with pytest.raises(QuotaExhaustedError, match="no more capacity"):
-        svc.tpu_create(
-            TpuCreateRequest(
-                name="stockout-tpu",
-                zone=ZONE_EU,
-                accelerator_type="v5litepod-16",
-                runtime_version="v2-alpha-tpuv5-lite",
-                capacity_type=config_pb2.CAPACITY_TYPE_PREEMPTIBLE,
-            )
-        )
+    status = svc.tpu_operation_status(op_name)
+    assert status.done
+    err = operation_error(status)
+    assert isinstance(err, QuotaExhaustedError)
+    assert "no more capacity" in str(err)

--- a/lib/iris/tests/cluster/providers/gcp/test_platform.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_platform.py
@@ -17,10 +17,16 @@ from dataclasses import dataclass
 import pytest
 from iris.cluster.providers.gcp.controller import GcpControllerProvider
 from iris.cluster.providers.gcp.fake import InMemoryGcpService
-from iris.cluster.providers.gcp.handles import GcpVmSliceHandle, _build_gce_resource_name
-from iris.cluster.providers.gcp.service import VmCreateRequest
+from iris.cluster.providers.gcp.handles import (
+    GcpSliceHandle,
+    GcpVmSliceHandle,
+    _build_gce_resource_name,
+    _composite_slice_state,
+)
+from iris.cluster.providers.gcp.service import OperationStatus, VmCreateRequest
 from iris.cluster.providers.gcp.workers import (
     GcpWorkerProvider,
+    _run_tpu_bootstrap,
     _run_vm_slice_bootstrap,
     _validate_slice_config,
 )
@@ -1061,3 +1067,126 @@ def test_vm_bootstrap_cloud_not_ready_raises_phase1_timeout():
             cloud_ready_timeout=0.05,
             bootstrap_timeout=300.0,
         )
+
+
+def _make_tpu_slice_for_bootstrap(
+    gcp_service: InMemoryGcpService,
+    zone: str = "us-central2-b",
+) -> GcpSliceHandle:
+    """Create a TPU slice (bootstrap thread suppressed) for direct _run_tpu_bootstrap testing.
+
+    The fake leaves the node at CREATING with synthetic worker IPs — the #6087
+    scenario where workers are up while the cloud create-status still lags.
+    """
+    gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project")
+    platform = GcpWorkerProvider(gcp_config, label_prefix="iris", worker_port=10001, gcp_service=gcp_service)
+
+    cfg = config_pb2.SliceConfig(
+        name_prefix="iris-tpu",
+        accelerator_type=config_pb2.ACCELERATOR_TYPE_TPU,
+        accelerator_variant="v5litepod-8",
+    )
+    cfg.gcp.zone = zone
+    cfg.gcp.runtime_version = "tpu-ubuntu2204-base"
+    wc = config_pb2.WorkerConfig(
+        docker_image="test-image:latest",
+        port=10001,
+        controller_address="controller:10000",
+        cache_dir="/var/cache/iris",
+    )
+
+    with unittest.mock.patch("iris.cluster.providers.gcp.workers.threading.Thread"):
+        handle = platform.create_slice(cfg, worker_config=wc)
+    assert isinstance(handle, GcpSliceHandle)
+    return handle
+
+
+def test_tpu_bootstrap_marks_ready_while_cloud_stuck_creating():
+    """Regression for #6087: a TPU whose cloud status is stuck CREATING but whose
+    workers answer /health becomes READY and is never deleted."""
+    gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
+    handle = _make_tpu_slice_for_bootstrap(gcp_service)
+    assert gcp_service.tpu_describe(handle.slice_id, handle.zone).state == "CREATING"
+
+    with unittest.mock.patch("iris.cluster.providers.gcp.workers._probe_worker_health", return_value=True):
+        _run_tpu_bootstrap(
+            gcp_service,
+            "test-project",
+            handle,
+            poll_interval=0.01,
+            ip_wait_timeout=5.0,
+            bootstrap_timeout=5.0,
+        )
+
+    assert handle._bootstrap_state == CloudSliceState.READY
+    assert handle.describe().state == CloudSliceState.READY
+    # Slice was kept despite the cloud status never reaching READY.
+    surviving = gcp_service.tpu_describe(handle.slice_id, handle.zone)
+    assert surviving is not None
+    assert surviving.state == "CREATING"
+
+
+@pytest.mark.parametrize(
+    "error_code, expected_exc",
+    [(8, QuotaExhaustedError), (13, InfraError)],
+)
+def test_tpu_bootstrap_fails_fast_on_create_operation_error(error_code, expected_exc):
+    """A create LRO that completes with an error aborts bootstrap immediately,
+    mapping RESOURCE_EXHAUSTED to QuotaExhaustedError and other codes to InfraError."""
+    gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
+    handle = _make_tpu_slice_for_bootstrap(gcp_service)
+    gcp_service.set_operation_status(
+        handle._create_operation,
+        OperationStatus(done=True, error_code=error_code, error_message="boom"),
+    )
+
+    with unittest.mock.patch("iris.cluster.providers.gcp.workers._probe_worker_health", return_value=False):
+        with pytest.raises(expected_exc):
+            _run_tpu_bootstrap(
+                gcp_service,
+                "test-project",
+                handle,
+                poll_interval=0.01,
+                ip_wait_timeout=5.0,
+                bootstrap_timeout=5.0,
+            )
+
+
+def test_tpu_bootstrap_aborts_when_slice_enters_deleting():
+    """A slice torn down (terminal cloud state) during bootstrap aborts rather than waiting out the timeout."""
+    gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
+    handle = _make_tpu_slice_for_bootstrap(gcp_service)
+    gcp_service.advance_tpu_state(handle.slice_id, handle.zone, "DELETING")
+
+    with unittest.mock.patch("iris.cluster.providers.gcp.workers._probe_worker_health", return_value=False):
+        with pytest.raises(InfraError):
+            _run_tpu_bootstrap(
+                gcp_service,
+                "test-project",
+                handle,
+                poll_interval=0.01,
+                ip_wait_timeout=5.0,
+                bootstrap_timeout=5.0,
+            )
+
+
+@pytest.mark.parametrize(
+    "cloud_state, bootstrap_state, expected",
+    [
+        # #6087 fix: confirmed-healthy workers win over a laggy CREATING cloud state.
+        (CloudSliceState.CREATING, CloudSliceState.READY, CloudSliceState.READY),
+        # Bootstrap still in progress: reflect the raw cloud state.
+        (CloudSliceState.CREATING, None, CloudSliceState.CREATING),
+        (CloudSliceState.READY, None, CloudSliceState.BOOTSTRAPPING),
+        (CloudSliceState.READY, CloudSliceState.READY, CloudSliceState.READY),
+        # Gone/doomed cloud states override the bootstrap verdict so a vanished
+        # node never lingers as READY on a stale sentinel.
+        (CloudSliceState.DELETING, CloudSliceState.READY, CloudSliceState.DELETING),
+        (CloudSliceState.FAILED, CloudSliceState.READY, CloudSliceState.FAILED),
+        (CloudSliceState.UNKNOWN, CloudSliceState.READY, CloudSliceState.UNKNOWN),
+        # Bootstrap failure surfaces as FAILED.
+        (CloudSliceState.CREATING, CloudSliceState.FAILED, CloudSliceState.FAILED),
+    ],
+)
+def test_composite_slice_state(cloud_state, bootstrap_state, expected):
+    assert _composite_slice_state(cloud_state, bootstrap_state) == expected

--- a/lib/iris/tests/cluster/providers/gcp/test_vm_lifecycle.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_vm_lifecycle.py
@@ -7,6 +7,8 @@ These tests use GcpWorkerProvider with InMemoryGcpService(DRY_RUN) and don't
 need a full cluster fixture.
 """
 
+import unittest.mock
+
 import pytest
 from iris.cluster.providers.gcp.fake import InMemoryGcpService
 from iris.cluster.providers.gcp.workers import GcpWorkerProvider
@@ -51,12 +53,19 @@ def test_tpu_quota_exceeded_retry():
 
 
 def test_tpu_init_stuck():
-    """TPU never becomes READY (stuck in CREATING)."""
+    """A monitored TPU whose workers never become healthy stays non-READY (CREATING)."""
     service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
     platform = GcpWorkerProvider(_make_gcp_config(), label_prefix="test", worker_port=10001, gcp_service=service)
-    handle = platform.create_slice(_make_slice_config("stuck"))
 
-    # TPU stays in CREATING (we never advance it to READY)
+    # Bootstrap-monitored slice (worker_config) with the bootstrap thread
+    # suppressed: bootstrap never reports healthy, so the slice must not present
+    # as READY while the node sits in CREATING.
+    wc = config_pb2.WorkerConfig(
+        docker_image="img:latest", port=10001, controller_address="c:10000", cache_dir="/var/cache/iris"
+    )
+    with unittest.mock.patch("iris.cluster.providers.gcp.workers.threading.Thread"):
+        handle = platform.create_slice(_make_slice_config("stuck"), worker_config=wc)
+
     status = handle.describe()
     assert status.state == CloudSliceState.CREATING
 


### PR DESCRIPTION
Submit the TPU create operation without blocking on it and let worker health,
not GCP's create-status, decide readiness. A slow create operation could
previously time out and delete a TPU that had already booted, registered
workers, and started a task. The bootstrap loop now waits for worker IPs and
polls the create operation only to fail fast on quota/stockout; a slice is
READY once its workers answer health, even while the node still reports
CREATING. Timeouts become generous backstops since real failures abort early.

Fixes #6087