### PR TITLE
[Levanter] Fix lm-eval multihost broadcast placement

### DIFF
--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -418,6 +418,19 @@ def get_padding_count_from_batch(batch: LmExample, pad_token_id: int) -> tuple[i
     return padding_count, total_tokens
 
 
+def _eval_pad_token_id(tokenizer: MarinTokenizer) -> int:
+    pad_token_id = tokenizer.pad_token_id
+    if pad_token_id is not None:
+        return pad_token_id
+
+    eos_token_id = tokenizer.eos_token_id
+    if eos_token_id is None:
+        raise ValueError("LM eval harness requires either a pad token or an eos token for packed batches.")
+
+    logger.warning("No pad token set. Using eos token for evaluation padding.")
+    return eos_token_id
+
+
 class LevanterHarnessLM(TemplateLM):
     """
     Levanter implementation of the LM Eval Harness TemplateLM interface.
@@ -587,9 +600,7 @@ class LevanterHarnessLM(TemplateLM):
         Downstream tasks should attempt to use loglikelihood instead of other
         LM calls whenever possible.
         """
-        if self.tokenizer.pad_token_id is None:
-            logger.warning("No pad token set. Setting to eos token.")
-            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+        pad_token_id = _eval_pad_token_id(self.tokenizer)
 
         current_task = getattr(self, "_current_task", "loglikelihood_task")
         for request in requests:
@@ -605,7 +616,13 @@ class LevanterHarnessLM(TemplateLM):
                 }
             )
 
-        packed = _pack_requests(requests, self.tokenizer, self.EvalPos, self.leader.max_packed_segments)
+        packed = _pack_requests(
+            requests,
+            self.tokenizer,
+            self.EvalPos,
+            self.leader.max_packed_segments,
+            pad_token_id=pad_token_id,
+        )
         packed_iterator = stack_batches(iter(packed), self.EvalPos, self.EvalBatch)
         packed_iterator = BackgroundIterator(packed_iterator, max_capacity=1024)
 
@@ -626,7 +643,7 @@ class LevanterHarnessLM(TemplateLM):
                 batch, self.leader.max_packed_segments * self.EvalBatch.size
             )
 
-            padding_count, batch_tokens = get_padding_count_from_batch(batch, self.tokenizer.pad_token_id)
+            padding_count, batch_tokens = get_padding_count_from_batch(batch, pad_token_id)
 
             out_ids, out_lls, out_correct = self.leader.dispatch_loglikelihood(batch)
 
@@ -766,9 +783,7 @@ class LevanterHarnessLM(TemplateLM):
         # Implement simple generation using InferenceEngine.
         # requests: list[Instance] where args[0] = prompt, args[1] may be stop strings (list[str])
         # kwargs may include max_gen_toks, temperature, n (n_generations), seed
-        if self.tokenizer.pad_token_id is None:
-            logger.warning("No pad token set. Setting to eos token.")
-            self.tokenizer.pad_token_id = self.tokenizer.eos_token_id
+        _eval_pad_token_id(self.tokenizer)
 
         # Require a model with paged decode support
         if not hasattr(self.leader.model, "initial_cache") or not hasattr(self.leader.model, "decode"):
@@ -1730,6 +1745,7 @@ def _pack_requests(
     tokenizer: MarinTokenizer,
     Pos: hax.Axis,
     max_pack_size: int,
+    pad_token_id: int,
 ) -> list[LmExample]:
     packed_iterator = _iterate_tokenized_requests(requests, tokenizer, Pos.size, batch_size=128)
     # TODO: use a better packing algorithm?
@@ -1737,7 +1753,7 @@ def _pack_requests(
         Pos,
         packed_iterator,
         max_segments_per_example=max_pack_size,
-        pad_token=tokenizer.pad_token_id,
+        pad_token=pad_token_id,
     )
 
 

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -338,7 +338,7 @@ class _LmEvalHarnessWorker:
                 raise ValueError(f"Unknown message type: {message}")
 
     def _receive_message(self):
-        stop_message = jnp.array(_Message.STOP)
+        stop_message = np.array(_Message.STOP)
         message = broadcast_shard(stop_message, PartitionSpec())
         return message.item()
 
@@ -354,7 +354,7 @@ class _LmEvalHarnessWorker:
 
     def _send_message(self, message):
         assert jax.process_index() == 0
-        out = broadcast_shard(jnp.array(message), PartitionSpec())
+        out = broadcast_shard(np.array(message), PartitionSpec())
         return out
 
     def _send_payload(self, payload):
@@ -622,16 +622,11 @@ class LevanterHarnessLM(TemplateLM):
             # Handle profiler start/stop based on step
             self._handle_profiler_step()
 
-            batch = hax.shard(batch, self.axis_resources)
-
             segments_this_batch = get_segment_ids_from_batch(
                 batch, self.leader.max_packed_segments * self.EvalBatch.size
             )
 
             padding_count, batch_tokens = get_padding_count_from_batch(batch, self.tokenizer.pad_token_id)
-            batch = jax.device_put(batch)
-
-            batch = jax.device_put(batch)
 
             out_ids, out_lls, out_correct = self.leader.dispatch_loglikelihood(batch)
 

--- a/lib/levanter/src/levanter/utils/jax_utils.py
+++ b/lib/levanter/src/levanter/utils/jax_utils.py
@@ -432,12 +432,12 @@ def broadcast_shard(x: T, out_axis_specs: Any, source: int = 0) -> T:
 
     def pre_jit(x):
         if jax.process_index() == source:
-            inp = np.array(x)
+            inp = np.asarray(jax.device_get(x))
         else:
-            inp = jnp.zeros(x.shape, dtype=x.dtype)
+            inp = np.zeros(x.shape, dtype=x.dtype)
 
         shape = (len(jax.devices()),) + inp.shape
-        inp = jnp.expand_dims(inp, axis=0)
+        inp = np.expand_dims(inp, axis=0)
         out = jax.make_array_from_callback(shape, sharding, lambda _: inp)
 
         return out

--- a/tests/evals/test_lm_eval_harness_padding.py
+++ b/tests/evals/test_lm_eval_harness_padding.py
@@ -1,0 +1,40 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+
+import haliax as hax
+import jax
+import numpy as np
+from levanter.eval_harness import _eval_pad_token_id, _pack_requests
+
+
+@dataclasses.dataclass(frozen=True)
+class FrozenTokenizerWithoutPad:
+    eos_token_id: int = 99
+    pad_token_id: int | None = None
+
+    def encode_batch(self, texts: list[str]) -> list[list[int]]:
+        return [[ord(char) for char in text] for text in texts]
+
+
+@dataclasses.dataclass(frozen=True)
+class Request:
+    args: tuple[str, str]
+
+
+def test_pack_requests_uses_eos_for_frozen_tokenizer_without_pad():
+    tokenizer = FrozenTokenizerWithoutPad()
+
+    pad_token_id = _eval_pad_token_id(tokenizer)
+    packed = _pack_requests(
+        [Request(args=("a", "b"))],
+        tokenizer,
+        hax.Axis("position", 4),
+        max_pack_size=64,
+        pad_token_id=pad_token_id,
+    )
+
+    tokens = np.asarray(jax.device_get(packed[0].tokens.array))
+    np.testing.assert_array_equal(tokens, np.array([ord("a"), ord("b"), tokenizer.eos_token_id, tokenizer.eos_token_id]))
+    assert tokenizer.pad_token_id is None


### PR DESCRIPTION
Keep lm-eval harness control values and broadcast callback payloads on host NumPy arrays so multi-host TPU workers do not feed non-fully-addressable JAX arrays into device_put. Let the payload broadcast path handle placement instead of re-putting the packed eval batch.

Fixes #4437