### PR TITLE
Add fakeray: a Ray-Core shim that runs Ray workloads on Iris/Fray

### DIFF
--- a/.agents/projects/20260531_fray_smallpond_fakeray_design.md
+++ b/.agents/projects/20260531_fray_smallpond_fakeray_design.md
@@ -1,0 +1,584 @@
+# `fakeray`: a Ray-compatible shim for running smallpond on Iris/Fray
+
+Status: **Draft / design sketch.** Not implemented. No code committed.
+Author: agent-generated (exploration of "run smallpond on Iris").
+Date: 2026-05-31.
+
+## TL;DR
+
+smallpond drives its execution through a tiny slice of the Ray Core API
+(`@ray.remote`, `ObjectRef`, `put`/`get`/`wait`). We can satisfy that slice with
+a ~10-function shim module (`fakeray`) that:
+
+1. installs in place of `ray` (`import fakeray as ray`),
+2. runs a small **ready-queue DAG scheduler** in the smallpond driver process, and
+3. dispatches each task to a pool of long-lived **Fray actors** (one Iris job
+   each), collecting results over RPC.
+
+The load-bearing fact that makes this cheap: **smallpond intermediate `DataSet`s
+are path descriptors, not data.** Bulk data already lands as Parquet on
+`data_root`. So the shim's "object store" only ferries kilobyte pickles between
+the driver and actors — the terabytes never traverse the shim.
+
+The genuinely hard part is **not** the shim. It is that fan-out requires
+`data_root` to be a filesystem every actor can read and write — the role 3FS
+plays in the original design. On Iris there is no 3FS, so we either mount a
+shared POSIX FS on every actor or make smallpond's file I/O `gs://`-native.
+That is the real cost and risk; the shim itself is ~300–400 LOC.
+
+Recommended sequencing: prove the shim against Fray `LocalClient` (one node,
+local disk — no shared-FS problem) first, then tackle the shared-FS story for
+true Iris multi-node fan-out.
+
+---
+
+## 1. Goal and non-goals
+
+### Goal
+Let an unmodified-as-possible smallpond program
+
+```python
+import smallpond
+sp = smallpond.init(num_executors=0)
+df = sp.read_parquet("gs://.../in/*.parquet").repartition(256, hash_by="k")
+df = sp.partial_sql("select k, count(*) from {0} group by k", df)
+df.write_parquet("gs://.../out/")
+```
+
+execute its task DAG **distributed across Iris workers** via Fray, instead of
+inside a single embedded Ray cluster in one container.
+
+### Non-goals
+- Re-implementing Ray's in-memory distributed object store with zero-copy / cross-node
+  shared memory. We exploit smallpond's file-materialized data model to avoid this.
+- Supporting Ray APIs smallpond does not use (Ray Data, Datasets, Tune, Serve,
+  placement groups, named/detached actors, `ray.remote` *actors*, nested remotes).
+- GPU scheduling fidelity. smallpond passes `num_gpus`; v1 treats the pool as
+  CPU slots and logs that GPU packing is not honored.
+- Replacing the single-container Option A (real Ray inside one Iris task). That
+  remains the cheaper path for non-fan-out workloads; see §15.
+
+---
+
+## 2. What smallpond actually requires from Ray
+
+Every Ray call site in smallpond (verified by grep over `smallpond/`):
+
+| Ray surface | Where | Use |
+|---|---|---|
+| `ray.init(address, num_cpus, _memory, runtime_env, dashboard_*, _metrics_export_port)` → `.address_info["gcs_address"]` | `session.py:79` | start/connect cluster; smallpond reads `gcs_address` |
+| `ray.shutdown()` | `session.py:154` | teardown |
+| `ray.timeline(path)` | `session.py:258` | dump chrome-trace timeline |
+| `@ray.remote` (bare) + `fn._function_name = ...` | `task.py:1001,1039` | wrap a task's exec as a remote function |
+| `.options(name=, num_cpus=, num_gpus=, memory=)` | `task.py:1041` | per-task resource + name |
+| `RemoteFn.remote(task, *dep_refs)` → `ObjectRef` | `task.py:1052` | dispatch; deps passed as refs |
+| `ray.put(dataset)` → `ObjectRef` | `task.py:995` | wrap an already-materialized output (resume / boundary data) |
+| `ray.ObjectRef` (type/annotation) | `task.py:601,982` | the handle type stored on each task node |
+| `ray.get(refs, timeout=)` | `dataframe.py:131,182,261` | block for results; surface exceptions |
+| `ray.wait(refs, num_returns=, timeout=0, fetch_local=False)` → `(ready, not_ready)` | `dataframe.py:173,243` | non-blocking progress poll |
+| `ray.exceptions.RuntimeEnvSetupError` | `dataframe.py:262` | caught around dispatch |
+
+That is the **entire** contract. Note the DAG is built lazily and recursively:
+`Task.run_on_ray()` calls `dep.run_on_ray()` for each input first (getting their
+`ObjectRef`s), then `exec_task.options(...).remote(task, *dep_refs)`. Real Ray:
+(a) returns each ref immediately, (b) treats `ObjectRef` arguments as
+dependency edges, (c) auto-dereferences them to the actual `DataSet` values
+when finally invoking `exec_task`. The shim must reproduce exactly those three
+behaviors.
+
+### 2.1 The fact that makes this tractable
+
+`smallpond/logical/dataset.py`: the `DataSet` hierarchy is **path-based**.
+`ParquetDataSet`/`CsvDataSet`/`JsonDataSet`/`FileSet` carry `paths` + `root_dir`
+(via `__slots__`), not data. `PartitionedDataSet` holds a list of such
+descriptors. The actual bytes are Parquet files on `data_root`, written
+atomically by `task.exec()` and read back by the next task via DuckDB/pyarrow.
+
+Consequences:
+- An `ObjectRef` only needs to carry a **pickled descriptor** (sub-KB to KB).
+- Passing a dep's value to a downstream actor over RPC is cheap.
+- The shim **never moves bulk data**; it moves filenames. Workers read/write the
+  bulk directly against shared storage.
+
+The two exceptions are boundary sources `ArrowTableDataSet` (`.table`) and
+`PandasDataSet` (`.df`), which hold in-memory data from `sp.from_arrow/from_pandas`.
+These do travel over RPC if used as a remote input. They are user-supplied
+constructor inputs (typically small); we accept this and note it (§13).
+
+---
+
+## 3. Why Iris/Fray don't provide this directly
+
+Fray's `Client` protocol (`lib/fray/src/fray/client.py`) offers:
+- `submit(JobRequest) -> JobHandle` — coarse: one job == one container == one
+  `uv sync` + process. Too heavy for per-DAG-node dispatch.
+- `create_actor_group(actor_class, *, name, count, resources) -> ActorGroup` with
+  `wait_ready() -> [ActorHandle]`; `handle.method.remote(*args) -> ActorFuture`;
+  `future.result()`. Actors are long-lived Iris jobs hosting an `ActorServer`;
+  methods are RPCs (args cloudpickled). `ActorConfig(max_concurrency=N)`.
+- `wait_all([JobHandle])`, `JobHandle.wait/status`.
+
+What Fray/Iris **lack** vs Ray: (1) an object store (`put`/`get` of live values
+addressable cluster-wide), and (2) a fine-grained futures-DAG scheduler. The
+shim supplies both — cheaply, because (1) reduces to "pickle a descriptor" and
+(2) is a textbook ready-queue over a fixed actor pool.
+
+Mapping the actor calling convention is a near-perfect fit: Fray's
+`handle.method.remote(*args) -> ActorFuture; .result()` is exactly the
+future semantics the shim's scheduler needs.
+
+---
+
+## 4. Architecture
+
+```
+            Iris job: smallpond driver  (user's `iris job run`)
+            ┌───────────────────────────────────────────────┐
+            │  import fakeray as ray                          │
+            │  smallpond.Session  (builds logical plan)       │
+            │                                                 │
+            │  fakeray.RemoteFn.remote(task, *dep_refs)       │
+            │        └─► register node in DAG, return ref     │
+            │                                                 │
+            │  fakeray Scheduler (ready-queue, in-process)    │
+            │   • node ready when all dep refs resolved       │
+            │   • assign to a free actor slot                 │
+            │   • actor.run_task.remote(task, *dep_values)    │
+            │   • on result: mark ref ready, unblock children │
+            │                                                 │
+            │  Fray ActorGroup  (current_client())            │
+            └─────────┬───────────────┬───────────────┬───────┘
+                      │ RPC            │ RPC           │ RPC
+              ┌───────▼──────┐ ┌───────▼──────┐ ┌──────▼───────┐
+              │ Iris job:    │ │ Iris job:    │ │ Iris job:    │
+              │ Executor #0  │ │ Executor #1  │ │ Executor #M-1│
+              │ run_task():  │ │              │ │              │
+              │  task.exec() │ │   ...        │ │   ...        │
+              └──────┬───────┘ └──────┬───────┘ └──────┬───────┘
+                     │ read/write bulk Parquet         │
+                     ▼                ▼                ▼
+            ┌───────────────────────────────────────────────┐
+            │   SHARED data_root  (gs:// or mounted FS)       │  ← the hard part
+            └───────────────────────────────────────────────┘
+```
+
+Three pieces:
+1. **`fakeray` module** — the Ray API surface (§6). Pure glue + the scheduler.
+2. **`Scheduler`** — in the driver; ready-queue over actor slots (§7).
+3. **`SmallpondExecutorActor`** — a Fray actor that runs one `task.exec()` (§8).
+
+The driver is the user's Iris job (the "head"). It owns the DAG, the scheduler,
+and the `ActorGroup`. Actors are dumb executors.
+
+---
+
+## 5. `ObjectRef` and the "object store"
+
+`ObjectRef` is a driver-local handle backed by a `concurrent.futures.Future`:
+
+```python
+@dataclass(eq=False)
+class ObjectRef:
+    id: str                       # uuid; identity-based equality (eq=False)
+    _fut: "Future[Any]"           # resolves to the task's return value (a DataSet)
+```
+
+- `ray.put(value)` → a ref whose future is already resolved to `value`. Used for
+  resume (`load(ray_dataset_path)`) and boundary datasets.
+- A `.remote(...)` call → a ref whose future the scheduler resolves when the
+  actor returns the output `DataSet`.
+- `ray.get(ref)` → `ref._fut.result()` (driving the scheduler meanwhile);
+  re-raises the task exception if the future failed.
+- Dependency dereferencing: when the scheduler dispatches a node, it replaces
+  each `ObjectRef` argument with `ref._fut.result()` (already resolved, since the
+  node is only ready once deps are done) before sending to the actor. This
+  reproduces Ray's auto-deref.
+
+Because values are descriptors, the "store" is just the set of resolved futures
+held in the driver. Optional **persistence (B2):** also write each descriptor to
+`{data_root}/_fakeray/objs/{id}.pkl`. smallpond *already* writes
+`ray_dataset_path` per task and checks it on re-run, so B2 is largely redundant
+with smallpond's own resume; v1 keeps refs in-memory and leans on smallpond for
+idempotency/resume.
+
+---
+
+## 6. The `fakeray` API surface
+
+```python
+# fakeray/__init__.py   (sketch — illustrative, not final)
+
+_SCHED: "Scheduler | None" = None
+
+class RuntimeEnvSetupError(RuntimeError): ...
+class exceptions:                      # smallpond does `ray.exceptions.RuntimeEnvSetupError`
+    RuntimeEnvSetupError = RuntimeEnvSetupError
+
+def init(address=None, *, num_cpus=None, _memory=None,
+         runtime_env=None, **_ignored):
+    """Start the scheduler + Fray actor pool. Ignores Ray-specific kwargs."""
+    global _SCHED
+    cfg = FakeRayConfig.from_env()           # pool_size, ram per actor, image/extras
+    client = current_client()                # IrisClient in a job, else LocalClient
+    _SCHED = Scheduler(client, cfg, runtime_env=runtime_env)
+    _SCHED.start()                           # create_actor_group + wait_ready
+    return _InitResult(address_info={"gcs_address": "fakeray://local"})
+
+def shutdown():
+    global _SCHED
+    if _SCHED: _SCHED.shutdown(); _SCHED = None
+
+def put(value) -> ObjectRef:
+    return _SCHED.put(value)
+
+def get(refs, timeout=None):
+    scalar = isinstance(refs, ObjectRef)
+    out = _SCHED.get([refs] if scalar else list(refs), timeout=timeout)
+    return out[0] if scalar else out
+
+def wait(refs, *, num_returns=1, timeout=None, fetch_local=True):
+    return _SCHED.wait(list(refs), num_returns=num_returns, timeout=timeout)
+
+def timeline(path):                          # best-effort; Iris has its own UI
+    _SCHED.dump_timeline(path)
+
+def remote(fn=None, **opts):
+    # supports bare @remote and @remote(**opts)
+    def wrap(f): return RemoteFunction(f, opts)
+    return wrap(fn) if fn is not None else wrap
+
+class RemoteFunction:
+    def __init__(self, fn, opts): self._fn, self._opts = fn, dict(opts)
+    def options(self, **opts):               # name, num_cpus, num_gpus, memory
+        merged = {**self._opts, **opts}; return RemoteFunction(self._fn, merged)
+    def remote(self, *args, **kwargs) -> ObjectRef:
+        return _SCHED.submit_task(self._fn, args, kwargs, self._opts)
+    def __setattr__(self, k, v):             # smallpond sets `_function_name`
+        object.__setattr__(self, k, v)
+```
+
+Install it (primary): edit the three `import ray` lines in the patched fork to
+`import fakeray as ray`. Alternative (zero fork edits): `sys.modules["ray"] =
+fakeray` before `import smallpond` — fragile w.r.t. import order; documented but
+not preferred, consistent with the repo's "no ad-hoc compatibility hacks" rule.
+
+---
+
+## 7. The scheduler (ready-queue over an actor pool)
+
+```python
+class Scheduler:
+    def __init__(self, client, cfg, runtime_env=None):
+        self._client, self._cfg = client, cfg
+        self._nodes: dict[str, _Node] = {}          # ref.id -> node
+        self._free: queue.SimpleQueue[ActorHandle] = queue.SimpleQueue()
+        self._lock = threading.Lock()
+
+    def start(self):
+        env = create_environment(workspace=os.getcwd(),
+                                 extras=self._cfg.extras)     # smallpond + duckdb etc
+        self._group = self._client.create_actor_group(
+            SmallpondExecutorActor, name="smallpond-exec",
+            count=self._cfg.pool_size,
+            resources=ResourceConfig(cpu=self._cfg.cpu, ram=self._cfg.ram),
+            actor_config=ActorConfig(max_concurrency=1))      # 1 task per actor
+        for h in self._group.wait_ready(count=self._cfg.pool_size):
+            self._free.put(h)
+
+    # called from RemoteFunction.remote(); returns immediately
+    def submit_task(self, fn, args, kwargs, opts) -> ObjectRef:
+        dep_refs = [a for a in args if isinstance(a, ObjectRef)]
+        ref = ObjectRef(id=uuid4().hex, _fut=Future())
+        self._nodes[ref.id] = _Node(ref, fn, args, kwargs, opts,
+                                    pending={d.id for d in dep_refs})
+        self._maybe_ready(ref.id)
+        return ref
+
+    # block until all `targets` resolved, pumping the scheduler
+    def get(self, targets, timeout=None):
+        deadline = _deadline(timeout)
+        while not all(t._fut.done() for t in targets):
+            self._tick(deadline)                  # dispatch ready, reap finished
+        return [t._fut.result() for t in targets] # re-raises on failure
+
+    def _tick(self, deadline):
+        # 1. dispatch every ready node to a free actor
+        for node in self._ready_nodes():
+            try:
+                actor = self._free.get(timeout=_left(deadline))
+            except queue.Empty:
+                break
+            values = [self._deref(a) for a in node.args]      # ObjectRef -> DataSet
+            fut = actor.run_task.remote(node.fn_payload, values, node.kwargs)
+            self._inflight[node.ref.id] = (actor, fut, node)
+        # 2. reap any finished inflight calls
+        for rid, (actor, fut, node) in list(self._inflight.items()):
+            if fut_done(fut):
+                self._free.put(actor)
+                del self._inflight[rid]
+                try:
+                    node.ref._fut.set_result(fut.result())
+                except Exception as e:
+                    node.ref._fut.set_exception(e)
+                self._unblock_children(rid)
+```
+
+Notes:
+- **Ready** = all `pending` dep ids resolved. `_unblock_children` removes the
+  finished id from dependents' `pending` sets.
+- `run_task` receives a cloudpickled callable payload + already-dereferenced
+  input `DataSet`s. The fn payload is smallpond's nested `exec_task` closure; we
+  pickle `(fn, task)` — `task` is the real payload, `fn` is generic.
+- v1 is **slot-based**: `pool_size` actors, `max_concurrency=1`, so ≤ pool_size
+  concurrent tasks. `opts["num_cpus"]/["memory"]` are recorded for the actor's
+  `ResourceConfig` at pool-creation time, not used for per-task bin-packing
+  (§13).
+- `ray.wait(..., timeout=0)` → one non-blocking `_tick` then partition targets
+  into `(ready, not_ready)`. This matches smallpond's progress-poll usage.
+- The scheduler is single-threaded (driven by `get`/`wait` calls); `ActorFuture`
+  polling uses Fray's RPC futures. No background thread needed for v1, which
+  keeps failure semantics simple.
+
+---
+
+## 8. The executor actor
+
+```python
+class SmallpondExecutorActor:
+    """Long-lived Fray actor. One method: run a single smallpond task."""
+    def __init__(self):
+        # imports happen once per actor process; warms duckdb, arrow, smallpond
+        import smallpond.execution.task  # noqa: F401
+
+    def run_task(self, fn_payload: bytes, input_datasets: list, kwargs: dict):
+        import cloudpickle
+        fn, task = cloudpickle.loads(fn_payload)
+        # reproduce what smallpond's exec_task body does:
+        task.input_datasets = list(input_datasets)
+        status = task.exec()
+        if status != WorkStatus.SUCCEED:
+            raise task.exception or RuntimeError(f"task {task.key} failed: {status}")
+        dump(task.output, task.ray_dataset_path, atomic_write=True)  # smallpond resume
+        return task.output                                           # descriptor over RPC
+```
+
+This is essentially smallpond's existing `exec_task` closure body (`task.py:1002`)
+lifted into an actor method. We can literally reuse that code. The actor:
+- reads inputs' bulk data lazily inside `task.exec()` (DuckDB opens the Parquet
+  paths from the input descriptors — against shared storage);
+- writes its output Parquet to `data_root` (shared storage);
+- returns only the output descriptor.
+
+Pool warmth: because actors persist, the per-task cost is one RPC + one
+`task.exec()`, **not** a container build / `uv sync`. The `uv sync` happens once
+when each actor job starts.
+
+---
+
+## 9. Integration with smallpond
+
+1. **Use `num_executors=0`.** This stops `Session.__init__` from calling
+   `platform.start_job(worker.py ...)` (which would `ray start` real workers).
+   The shim owns parallelism; pool size comes from `FakeRayConfig` (env/arg), not
+   `num_executors`. Document this clearly — it is the one behavioral wart.
+2. **`import fakeray as ray`** in `session.py`, `task.py`, `dataframe.py`
+   (3 lines in the fork) — or `sys.modules` injection (§6).
+3. **`data_root` must be shared** (§10). The driver and every actor resolve the
+   same `data_root`; smallpond already threads it through `RuntimeContext`.
+4. Boundary I/O (`read_parquet`/`write_parquet`) already accepts arbitrary paths;
+   `gs://` works iff smallpond's reader/writer honor fsspec for those (DuckDB
+   `httpfs`/pyarrow do; the descriptor `dump`/`load` and marker files are the gap).
+5. `ray.init`'s `runtime_env` (smallpond sets `LD_PRELOAD`, malloc tuning,
+   `ARROW_*`, thread caps) → the shim maps these into the actor `JobRequest`
+   `environment.env_vars` so executors inherit the same tuning.
+
+Resulting user code is unchanged except `init(num_executors=0)` + an
+environment setting for pool size:
+
+```python
+import fakeray; fakeray.configure(pool_size=64, data_root="gs://marin-eu-west4/tmp/ttl=7d/rav/sp")
+import smallpond
+sp = smallpond.init(num_executors=0, data_root="gs://marin-eu-west4/tmp/ttl=7d/rav/sp")
+```
+
+---
+
+## 10. The shared-filesystem problem (the actual hard part)
+
+smallpond was built for **3FS**: a POSIX-mounted, cluster-shared filesystem. Every
+worker does ordinary `open()` on a 3FS path and sees the same bytes. The Ray
+shim does nothing to change smallpond's assumption that `data_root` is shared.
+On Iris there is no 3FS, so we must provide an equivalent. Options, worst-to-best
+for a first cut:
+
+- **(FS-1) Per-actor local disk — does NOT work for fan-out.** Each Iris task has
+  its own ephemeral disk; actor A cannot read actor B's Parquet. Only viable for
+  the single-node staging milestone (§11), where one box's local disk is shared
+  among threads/processes.
+
+- **(FS-2) `gs://` via fsspec, end to end.** Make `data_root` a GCS path and
+  ensure *all* of smallpond's I/O goes through fsspec/`gcsfs`:
+  - Bulk Parquet read/write: DuckDB (`httpfs`/`gcs` secret) and pyarrow already
+    support `gs://`. Needs config wiring + a credentials story in the actor.
+  - **Gap:** smallpond's `io/filesystem.py` `dump`/`load` and the marker/status
+    files use local `open()` (verified: `open(path, "wb")`). These must become
+    fsspec-backed for `gs://`. This is the bulk of the real work — a focused but
+    non-trivial edit to smallpond's I/O layer, plus correctness review of every
+    `os.path`/`os.makedirs`/`os.path.exists` on `data_root` (markers, atomic
+    rename — GCS has no atomic rename; `atomic_write` via temp+rename needs an
+    object-store-aware implementation).
+  - Cost driver / policy: keep `data_root` in the **same region** as the workers
+    (per repo rules on cross-region egress); use a `tmp/ttl=7d/...` prefix.
+
+- **(FS-3) Mounted shared POSIX FS (gcsfuse / Filestore / Lustre).** If a shared
+  mount is available on all Iris workers at a common path, smallpond runs almost
+  unmodified (it just does `open()`), exactly like 3FS. This is the **lowest-code,
+  highest-ops** option: it needs the mount provisioned on the worker image /
+  pod spec, which is an Iris/infra change, not a smallpond change. gcsfuse has
+  weak POSIX semantics (no atomic rename, slow metadata) that may collide with
+  smallpond's atomic-write assumptions; Filestore/Lustre are stronger but cost
+  more and are regional.
+
+**Recommendation:** FS-3 if a shared mount can be provisioned (cheapest code,
+mirrors 3FS); otherwise FS-2 with a careful audit of smallpond's atomic-write /
+rename / existence checks. Either way, **this — not the shim — is where the
+effort and risk concentrate.** The shim is inert without it.
+
+---
+
+## 11. Staging plan (each stage independently testable)
+
+1. **`fakeray` over Fray `LocalClient`, single box.** No Iris, no shared FS
+   (local disk is shared among in-process actors). Proves the scheduler,
+   `ObjectRef`/`get`/`wait`/`put` semantics, and auto-deref against the *real*
+   smallpond DAG. Acceptance: the prices.parquet quickstart and a repartition→sql
+   job produce byte-identical results to stock single-node smallpond. Zero
+   infra. This is the milestone that de-risks the shim itself.
+2. **`fakeray` over Fray `IrisClient`, single worker, local `data_root`.** Proves
+   actor hosting, RPC payload sizes, env/`LD_PRELOAD` propagation, pool warmup.
+   Still no fan-out (one actor). Acceptance: same job green as an Iris job.
+3. **Shared-FS spike (FS-2 or FS-3).** Smallest possible: two actors on two
+   workers, a 2-partition repartition, `data_root=gs://...`. This is the
+   go/no-go for multi-node. Acceptance: partition written by actor A is read by
+   actor B; final output correct.
+4. **Scale + fidelity.** Pool of N, GraySort-style shuffle on real data; add
+   resource-aware admission (§13), speculative-exec passthrough (§12), timeline.
+
+Stop after stage 1–2 if the goal is only "validate the approach"; stages 3–4 are
+the real-fan-out investment.
+
+---
+
+## 12. Failure handling & retries
+
+- **Task failure:** actor raises → `ActorFuture` errors → scheduler sets the
+  ref's future exception → `ray.get` re-raises. This matches Ray and lets
+  smallpond's `dataframe.py` error path run.
+- **smallpond's own retry:** `exec_task` already counts retries via
+  `ray_marker_path` files and resumes finished tasks via `ray_dataset_path`. With
+  a shared `data_root` this keeps working unchanged — a re-dispatched task sees
+  its marker/finished state. This is a reason to prefer leaning on smallpond's
+  fault tolerance over inventing new shim-level logic.
+- **Actor/worker death (preemption):** Fray `ActorGroup.is_done()` /
+  `ActorConfig(max_restarts, max_task_retries)` cover actor restarts. The
+  scheduler must detect an actor that vanished mid-task (RPC error), return its
+  slot, and re-dispatch the node (its inputs are still resolved). v1: on RPC
+  failure, re-queue the node up to `max_task_retries`, then fail the job.
+- **Speculative execution:** smallpond supports it; the shim does **not** drive
+  it in v1 (no duplicate dispatch). Acceptable — it's an optimization, off by
+  default in single-cluster mode. Note as a future item.
+
+---
+
+## 13. Fidelity & known limitations (state them, don't hide them)
+
+- **Resource packing:** v1 is slot-based (N actors × 1 concurrent task). Ray
+  packs by `num_cpus`/`memory` per task; we don't. A job with heterogeneous
+  per-task memory may under/over-subscribe. Mitigation later: weighted admission
+  (track free cpu/mem per actor; `max_concurrency>1`; bin-pack). Log the
+  discrepancy so it's visible.
+- **GPU tasks:** `num_gpus` ignored beyond optionally sizing the actor pool's
+  `ResourceConfig`. Out of scope for the CPU-shuffle target.
+- **Boundary data over RPC:** `ArrowTableDataSet`/`PandasDataSet` carry real
+  bytes; large `from_pandas` inputs cross RPC. Mitigation: spill these to a
+  Parquet file in `data_root` at `put` time and replace with a `ParquetDataSet`
+  descriptor (keeps the "only descriptors on the wire" invariant).
+- **`ray.timeline`:** best-effort or no-op; Iris dashboard is the real
+  observability surface.
+- **Single-driver scheduler throughput:** one Python thread dispatching. Fine for
+  thousands of tasks; for the 50-node/100k-task GraySort regime, the dispatch
+  loop and RPC fan-out may need a background pump thread or batched dispatch.
+  Measure in stage 4.
+- **No atomic rename on object stores:** smallpond's `atomic_write` (temp +
+  rename) must be reimplemented for `gs://` (write temp object + server-side
+  copy/compose, or per-task unique names + manifest). Tracked under FS-2.
+
+---
+
+## 14. Testing
+
+- **Unit (LocalClient):** scheduler ready-queue ordering; `get`/`wait`/`put`
+  semantics; auto-deref; exception propagation; a diamond DAG (A→{B,C}→D) yields
+  correct topo execution. No mocks beyond the Fray `LocalClient` boundary.
+- **Integration (LocalClient, real smallpond):** quickstart + repartition + join;
+  assert output Parquet equals stock smallpond (externally-observable behavior,
+  not log strings — per repo testing policy).
+- **Integration (IrisClient):** stage-2/3 jobs as `requires_cluster` tests;
+  assert final dataset correctness and that work landed on ≥2 workers (via Iris
+  job summary task→worker mapping).
+- **Fault injection:** kill an actor mid-task; assert re-dispatch + correct
+  result (reuses smallpond's `fault_inject_prob`).
+
+---
+
+## 15. Alternatives considered
+
+- **Option A — real Ray inside one Iris task (single-node).** ~30 lines of
+  packaging fixes (already prototyped); only blocker is the container's 64 MB
+  `/dev/shm` starving Ray's object store (Iris sets `--shm-size=100g` for
+  TPU/GPU tasks only — `lib/iris/.../runtime/docker.py`). Cheaper and correct for
+  non-fan-out workloads. The fakeray shim is only worth it when you specifically
+  want smallpond to distribute across Iris workers. **A and the shim are
+  complementary, not competing** — A is the fast path, the shim is the scale path.
+- **Real Ray multi-node on Iris** (Iris launches a real Ray head + `ray start`
+  workers, smallpond unchanged). Reproduces smallpond's stock multi-node design,
+  but means running a second scheduler/cluster inside Iris (double scheduling,
+  the head-in-a-task awkwardness, the shm issue ×N) and a Ray-version treadmill.
+  The shim avoids standing up Ray entirely.
+- **Full in-memory object store** (true `ray.put` cross-node value transfer).
+  Rejected: that is rebuilding Ray, and unnecessary given file-materialized
+  DataSets.
+
+---
+
+## 16. Effort & risk
+
+- **Shim + scheduler + actor (stages 1–2):** small and well-bounded, ~300–400
+  LOC, a few days including tests. Low risk — the API contract is tiny and the
+  Fray actor future maps cleanly.
+- **Shared-FS for fan-out (stage 3, the real cost):** medium-to-high risk,
+  depends entirely on FS-3 availability vs FS-2 effort. The atomic-write/rename
+  and existence-check audit of smallpond's I/O layer is the most likely source of
+  subtle correctness bugs. Budget the majority of the project here.
+- **Scale/fidelity (stage 4):** optional, demand-driven.
+
+Net: the shim is the easy, fun 20%; the shared filesystem is the load-bearing
+80%. Don't start the shim expecting fan-out for free — fan-out is bought with the
+filesystem.
+
+---
+
+## 17. Open questions / decisions for a human
+
+1. Is a shared POSIX mount (gcsfuse/Filestore/Lustre) provisionable on Iris CPU
+   workers? If yes → FS-3, smallpond nearly unmodified. If no → commit to FS-2
+   (fsspec-native smallpond I/O).
+2. Is multi-node smallpond actually wanted, or is single-node (Option A, fix
+   `/dev/shm`) sufficient for the real use case? The shim only pays off for #1=yes
+   and this=multi-node.
+3. Fork policy: explicit `import fakeray as ray` edits in the smallpond fork
+   (clean, debuggable) vs `sys.modules` injection (zero fork edits, fragile)?
+4. Where does `fakeray` live — a module inside the smallpond fork, or a small
+   standalone package that depends on `fray`? (Dependency direction allows
+   smallpond→fray; fray must not depend on smallpond.)
+```

--- a/.agents/projects/20260602_fray_ray_actors_pg_design.md
+++ b/.agents/projects/20260602_fray_ray_actors_pg_design.md
@@ -1,0 +1,175 @@
+# fray-ray: extending the fakeray shim to Ray actors + placement groups
+
+Status: **Draft / in progress.** Scopes the work to run actor-heavy Ray
+workloads (e.g. [SkyRL](https://github.com/novasky-ai/skyrl)) on Iris/Fray.
+Date: 2026-06-02. Builds on `20260531_fray_smallpond_fakeray_design.md`.
+
+## TL;DR
+
+- The existing `lib/fakeray` shim covers the **stateless-function** slice of Ray
+  Core (`@ray.remote` def, `ObjectRef`, `get`/`wait`/`put`). That was enough for
+  smallpond.
+- Actor-heavy frameworks (SkyRL, OpenRLHF, verl) need three more things:
+  **stateful `@ray.remote` classes**, **`ray.util.placement_group`**, and
+  **named actors** (`ray.get_actor`/`ray.kill`). A fail-fast probe confirmed all
+  three currently break (see Evidence).
+- **Actors map cleanly onto Fray** — `Client.create_actor` already returns a
+  handle whose `.method.remote()` yields a future. This is a real but bounded
+  build.
+- **Placement groups are the open design risk.** Ray's PG model (named bundles,
+  `strategy=PACK/SPREAD`, fractional-GPU colocation, `PlacementGroupScheduling
+  Strategy` capture) has no clean Iris equivalent. v1 implements a **best-effort,
+  non-strict** shim and *documents the gap loudly* rather than faking colocation
+  guarantees.
+- **GPU collectives are out of scope** (NCCL weight broadcast policy→inference).
+  The shim sets actors up; cross-actor GPU comm is the framework's job and needs
+  Fray actors to exchange IPs — noted, not built.
+
+## Evidence (fail-fast probe, 2026-06-02)
+
+Real SkyRL idioms run under `fakeray.install()` (LocalClient, no torch/SkyRL
+install — just the Ray call patterns):
+
+| SkyRL idiom | result | root cause |
+|---|---|---|
+| `@ray.remote` def + `get` | **OK** | the smallpond surface |
+| `@ray.remote` **class** + `.method.remote()` | FAIL | `'ObjectRef' has no attribute 'add'` — `remote()` treats a class like a function |
+| `placement_group([...], strategy="PACK")` | FAIL | `No module named 'ray.util'` |
+| `Actor.options(num_gpus=, placement_group=).remote()` | FAIL | same actor gap |
+| `ray.get_actor(name)` | FAIL | `module 'fakeray' has no attribute 'get_actor'` |
+
+SkyRL's real usage counts (grep over the repo): `placement_group` 88×,
+`PlacementGroup` 67×, `@ray.remote` 11× (on classes: `RegistryActor`,
+`InfoActor`, `RayJaxBackendImpl`), `ray.util.placement_group` 14×, `ActorPool`
+6×, `ray.get_actor` 3×, `ray.kill` 4×. Pinned `ray==2.51.1`.
+
+## What Ray gives that we must emulate
+
+### 1. Stateful actors
+```python
+@ray.remote
+class Worker:
+    def __init__(self, cfg): ...
+    def step(self, batch): ...
+
+h = Worker.options(num_gpus=1).remote(cfg)   # construct -> ActorHandle
+ray.get(h.step.remote(batch))                # method call -> ObjectRef
+```
+Ray: `@ray.remote` on a class returns an `ActorClass`; `.remote(*args)`
+constructs the actor (a process) and returns an `ActorHandle`;
+`handle.method.remote(*a)` enqueues a call and returns an `ObjectRef`;
+`ray.get(ref)` awaits it.
+
+### 2. Placement groups
+```python
+pg = placement_group([{"GPU":1,"CPU":1}] * n, strategy="PACK")
+ray.get(pg.ready())
+Actor.options(
+    num_gpus=1,
+    scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg, placement_group_bundle_index=i),
+).remote(...)
+```
+Ray reserves *bundles* atomically (gang), `PACK` = same node where possible,
+`SPREAD` = across nodes; fractional GPU (`num_gpus=0.2`) lets multiple actors
+**colocate** on one device. Actors are then pinned to a specific bundle index.
+
+### 3. Named actors
+`ray.get_actor("name")` resolves a named/detached actor anywhere in the cluster;
+`ray.kill(handle)` tears one down.
+
+## How each maps onto Fray/Iris
+
+### Actors → Fray actors (clean)
+Fray's `Client` already has the matching shape:
+- `create_actor(actor_class, *args, name=, resources=, actor_config=) -> ActorHandle`
+- `handle.method.remote(*a) -> ActorFuture` (`.result()` blocks)
+- hosted as an Iris job running `_host_actor` (or LocalActor in-process)
+
+Shim plan:
+- `remote()` inspects the target: **class → `ActorClass`**, function → existing
+  `RemoteFunction` (unchanged).
+- `ActorClass.remote(*args)` / `.options(num_gpus=, resources=, name=, ...)
+  .remote(*args)` → `client.create_actor(cls, *args, resources=<mapped>,
+  name=<auto or given>)` → wrap the Fray `ActorHandle` in a fakeray `ActorHandle`.
+- fakeray `ActorHandle.__getattr__(method)` → `ActorMethodStub`; `.remote(*a)`
+  calls Fray `handle.method.remote(*a)` and **adapts the `ActorFuture` into a
+  fakeray `ObjectRef`** (wrap a `concurrent.futures.Future`, resolve it from a
+  small waiter thread) so `ray.get`/`ray.wait` work uniformly with task refs.
+- `.options(num_gpus=, num_cpus=, memory=, resources=, name=, ...)` → build a
+  Fray `ResourceConfig` (`with_gpu`/`with_tpu`/cpu) + `ActorConfig`.
+- `ray.get_actor(name)` → resolve via the client's actor registry / a
+  fakeray-side `name -> handle` map. `ray.kill(handle)` → handle's job
+  `terminate()`.
+
+Registry: keep a process-global `{name: fakeray ActorHandle}` in the scheduler
+so `get_actor` works within a driver; cross-process named lookup defers to Fray's
+Iris resolver where available.
+
+### Placement groups → best-effort, NON-strict (the risk)
+There is no Iris primitive for "reserve N GPU bundles atomically with PACK/SPREAD
+and pin actor i to bundle j." Options:
+
+- **v1 (this work): capture, don't colocate.** `placement_group(bundles,
+  strategy)` returns a lightweight `PlacementGroup` object that just *remembers*
+  the bundle list + strategy. `pg.ready()` returns an already-resolved ref.
+  `PlacementGroupSchedulingStrategy(placement_group=pg, bundle_index=i)` passed to
+  `.options()` is unwrapped to the **i-th bundle's resources** (e.g. `{GPU:1}`)
+  and turned into a per-actor `ResourceConfig`. Iris then schedules each actor
+  independently with those resources.
+  - **What you get:** the right *number and size* of GPU actors.
+  - **What you DON'T get:** the gang/atomicity (actors may come up incrementally),
+    PACK/SPREAD locality, and fractional-GPU colocation on one device. `region`
+    can approximate PACK at coarse grain.
+  - **Loudly logged**: `fakeray: placement_group strategy=PACK is advisory; Iris
+    schedules bundles independently (no colocation/atomic-gang guarantee)`.
+- **v2 (future, if needed):** map a whole PG → one Fray `create_actor_group` with
+  `coscheduling` (gang) + region pinning, and hand out bundle indices as actor
+  indices. Closer to PACK, still no fractional-GPU colocation. Bigger change;
+  only do it if a workload actually depends on strict gang/locality.
+- **Fractional GPU colocation** (`num_gpus=0.2`, 5 actors per device) likely does
+  **not** work on Iris (device attach is whole-device). Flag as unsupported;
+  workloads needing it must drop to 1 actor/GPU.
+
+### GPU collectives → out of scope
+SkyRL does NCCL weight broadcast policy→inference across actors. The shim only
+provisions the actors; the framework builds the process group from actor IPs.
+Fray actors do expose addresses, so it's *possible* the framework's own
+rendezvous works unmodified — but verifying that is a separate milestone, not
+part of the shim.
+
+## Public surface added
+
+```
+fakeray.remote(cls_or_fn)            # now dispatches class -> ActorClass
+fakeray.ActorClass.remote/.options   # construct actors
+fakeray.ActorHandle.<method>.remote  # actor-method calls -> ObjectRef
+fakeray.get_actor(name) / kill(h) / cancel(ref)
+fakeray.util.placement_group(bundles, strategy=...) -> PlacementGroup
+fakeray.util.scheduling_strategies.PlacementGroupSchedulingStrategy
+fakeray.util.scheduling_strategies.NodeAffinitySchedulingStrategy   # accepted, best-effort
+# installed as ray.util / ray.util.placement_group / ray.util.scheduling_strategies
+```
+
+`install()` must register the `ray.util.*` submodules in `sys.modules` (same
+reason `ray.exceptions` is registered — dotted imports bypass `__getattr__`).
+
+## Staging
+
+1. **Actor model** (clean): class detection, `ActorClass`, `ActorHandle`,
+   method→ObjectRef adapter, `.options()` resource mapping, `get_actor`/`kill`.
+   Make probe checks 2, 4, 5 pass on LocalClient.
+2. **`ray.util.placement_group` shim** (best-effort): `PlacementGroup`,
+   `pg.ready()`, strategy capture, `PlacementGroupSchedulingStrategy` unwrap,
+   `sys.modules` registration. Make probe check 3 pass.
+3. **Regression test**: fold the probe into `lib/fakeray/tests`.
+4. (Later) Iris-backend validation with a tiny 2-actor GPU job; PG v2 + collective
+   verification only if a real SkyRL example demands it.
+
+## Honest scope
+
+- This makes the **API present and locally correct** (LocalClient) for SkyRL's
+  Ray surface. It does **not** claim SkyRL trains correctly on Iris — placement
+  locality, fractional-GPU colocation, and NCCL rendezvous are explicitly
+  best-effort / out of scope and must be validated against a real run.
+- Same as before: this is the fakeray side only. SkyRL itself may need its own
+  packaging/bundle work to run on Iris (separate from the shim).

--- a/lib/fakeray/README.md
+++ b/lib/fakeray/README.md
@@ -1,0 +1,100 @@
+# fakeray
+
+A Ray-Core-compatible **shim** that executes tasks on Iris via
+[Fray](../fray), instead of a real Ray cluster. Built to run
+[smallpond](https://github.com/deepseek-ai/smallpond) — which drives execution
+through a small slice of the Ray Core API — on Marin infrastructure.
+
+Status: **sketch / stage 1–2 proven.** Single-node (Fray `LocalClient`) works
+end to end, including an unmodified smallpond quickstart. Multi-node fan-out on
+Iris is gated on the shared-filesystem story — see the design doc at
+`.agents/projects/20260531_fray_smallpond_fakeray_design.md`.
+
+## What it implements
+
+The exact Ray surface smallpond uses, nothing more:
+
+`init` · `shutdown` · `put` · `get` · `wait` · `remote` (`@ray.remote`,
+`.options(...)`, `.remote(...)`) · `ObjectRef` · `timeline` (no-op) ·
+`exceptions.{RuntimeEnvSetupError, GetTimeoutError, RayTaskError, RayError}`.
+
+An `ObjectRef` is a driver-local `concurrent.futures.Future`. A ready-queue
+scheduler dispatches each remote call to a pool of Fray actors (one worker
+thread per actor slot, blocking on `ActorFuture.result()`). Values passed
+between tasks are smallpond `DataSet` *descriptors* (parquet paths), not bulk
+data, so nothing large crosses the shim — the data lives on `data_root`.
+
+## Layout
+
+```
+lib/fakeray/
+  src/fakeray/            # the implementation (distribution: marin-fakeray)
+    __init__.py           #   public Ray-compatible API
+    _object_ref.py        #   ObjectRef (Future-backed)
+    _scheduler.py         #   ready-queue DAG scheduler + FakeRayConfig
+    _executor.py          #   FakeRayExecutor (the Fray actor)
+    exceptions.py         #   Ray-compatible exception types
+  ray-shim/               # a SEPARATE distribution literally named `ray`
+    src/ray/__init__.py   #   re-exports everything from fakeray
+    src/ray/exceptions.py #   real submodule so `import ray.exceptions` resolves
+  tests/                  # stage-1 tests over Fray LocalClient
+```
+
+## Exposing it as `ray`
+
+Two ways to make a library's `import ray` resolve to this shim.
+
+### 1. Runtime install (no build, no resolver changes)
+
+```python
+import fakeray
+fakeray.install()      # swaps sys.modules["ray"] (and ray.exceptions)
+import smallpond        # smallpond's `import ray` now binds to fakeray
+```
+
+Must run **before** the requiring library is imported. Wins even when real
+`ray` is installed in the same environment (verified against ray 2.55.1).
+Registers `ray.exceptions` explicitly, because dotted submodule imports resolve
+through `sys.modules`, not a package `__getattr__`.
+
+### 2. uv override (no source edits to the requirer)
+
+Force the sibling `ray`-named distribution in, beating the transitive
+`ray>=x` constraint:
+
+```bash
+( cd lib/fakeray && uv build --wheel -o dist . && uv build --wheel -o dist ray-shim )
+```
+```toml
+# in the consuming project's pyproject.toml
+[tool.uv]
+override-dependencies = ["ray @ file:///abs/path/to/dist/ray-2.55.0-py3-none-any.whl"]
+```
+
+`override-dependencies` is the one uv lever that overrides *transitive*
+requirements; the stub's version is cosmetic. (Mechanism per the design note;
+the version is kept ≥ smallpond's `ray>=2.10` floor for any non-overridden path.)
+
+## Tests
+
+Not yet a uv-workspace member (deliberate, while it's a sketch). Run against the
+marin venv with pytest available:
+
+```bash
+PYTHONPATH=lib/fakeray/src uv run --no-project --python .venv/bin/python \
+  --with pytest --with marin-fray --with-editable lib/fakeray \
+  python -m pytest lib/fakeray/tests -c lib/fakeray/pytest.ini
+```
+
+Covers: remote/get round-trip, ObjectRef auto-deref, a diamond DAG, `put` refs
+as deps, ordered list-`get`, non-blocking `wait(timeout=0)`, task-failure
+propagation to `get`, and descendant poisoning (a dependent of a failed task
+raises rather than hanging).
+
+## Known limitations (v1)
+
+- Slot-based scheduling (N actors × 1 task); `num_cpus`/`memory` per-task are
+  recorded but not bin-packed.
+- `timeline` is a no-op (use the Iris dashboard).
+- Multi-node requires a shared `data_root` (gcsfuse/Filestore, or fsspec-native
+  smallpond I/O). The shim is inert without it. See the design doc §10.

--- a/lib/fakeray/examples/skyrl_min.py
+++ b/lib/fakeray/examples/skyrl_min.py
@@ -1,0 +1,100 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Minimal SkyRL-shaped workload, runnable on Iris via the fakeray shim.
+
+This is NOT full SkyRL (which needs GPUs + torch + vLLM). It reproduces SkyRL's
+*Ray usage pattern* with a tiny CPU example, exercising the shim's actor +
+placement-group surface the way an RL post-training framework would:
+
+  * ``placement_group([{CPU:1}] * world_size, strategy="PACK")`` + ``pg.ready()``
+  * a ``@ray.remote`` worker class (à la SkyRL ``PolicyWorker``)
+  * an actor group whose members are pinned to PG bundles via
+    ``PlacementGroupSchedulingStrategy`` (à la ``PPORayActorGroup``)
+  * driver coordination via the SkyRL ``async_run_ray_method`` idiom: invoke a
+    method on every actor → list of ``ObjectRef`` → ``ray.get(...)``
+  * a few PPO-ish steps: broadcast a weight, each worker computes, driver reduces
+
+Run locally::
+
+    PYTHONPATH=lib/fakeray/src python lib/fakeray/examples/skyrl_min.py
+
+Run on Iris (from a bundle that includes fakeray + the marin libs)::
+
+    iris ... job run --cpu 2 --memory 2g --no-preemptible --region europe-west4 \
+        -- python skyrl_min.py --world-size 2 --steps 3 --region europe-west4
+
+Verified SUCCEEDED on the marin cluster (europe-west4): the PolicyWorker actors
+register as real Iris endpoints and the driver coordinates them through the shim.
+"""
+
+import argparse
+
+import fakeray
+from fakeray._scheduler import FakeRayConfig
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--world-size", type=int, default=2)
+    ap.add_argument("--steps", type=int, default=3)
+    ap.add_argument("--region", default=None)
+    args = ap.parse_args()
+
+    fakeray.set_config(FakeRayConfig(pool_size=args.world_size, device="cpu", region=args.region))
+    fakeray.install()
+
+    import ray
+    from ray.util.placement_group import placement_group
+    from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+    ray.init()
+
+    # one CPU bundle per worker (SkyRL: one GPU bundle per rank)
+    pg = placement_group([{"CPU": 1}] * args.world_size, strategy="PACK")
+    ray.get(pg.ready())
+
+    @ray.remote
+    class PolicyWorker:
+        def __init__(self, rank: int, world_size: int):
+            self.rank = rank
+            self.world_size = world_size
+            self.weight = 0.0
+
+        def init_model(self):
+            return {"rank": self.rank, "ready": True}
+
+        def set_weight(self, w):
+            self.weight = w
+            return self.rank
+
+        def train_step(self, batch):
+            return self.weight + self.rank + batch
+
+    workers = [
+        PolicyWorker.options(
+            scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg, placement_group_bundle_index=i)
+        ).remote(i, args.world_size)
+        for i in range(args.world_size)
+    ]
+
+    def async_run(method: str, *a):
+        """SkyRL's async_run_ray_method: call `method` on every actor, return refs."""
+        return [getattr(w, method).remote(*a) for w in workers]
+
+    print(f"SKYRL_MIN init: {ray.get(async_run('init_model'))}", flush=True)
+
+    weight = 1.0
+    for step in range(args.steps):
+        ray.get(async_run("set_weight", weight))
+        contribs = ray.get(async_run("train_step", float(step)))
+        weight = sum(contribs) / len(contribs)
+        print(f"SKYRL_MIN step {step}: contribs={contribs} -> weight={weight}", flush=True)
+
+    print("SKYRL_MIN_RESULT_BEGIN", flush=True)
+    print(f"world_size={args.world_size} steps={args.steps} final_weight={weight}", flush=True)
+    print("SKYRL_MIN_RESULT_END", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/fakeray/examples/skyrl_real_pg.py
+++ b/lib/fakeray/examples/skyrl_real_pg.py
@@ -1,0 +1,111 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Run SkyRL's REAL placement-group resolution orchestration via the shim.
+
+Unlike skyrl_min.py (which mimics SkyRL idioms), this lifts SkyRL's *actual*
+orchestration functions VERBATIM from
+  novasky-ai/skyrl : skyrl/train/utils/utils.py
+  (_probe_bundle_placement, ResolvedPlacementGroup, get_ray_pg_ready_with_timeout)
+and runs them through fakeray. Those functions are pure-Ray (the surrounding
+module is unimportable on CPU only because of torch/transformers imports), so
+copying them is the cheapest way to exercise SkyRL's real Ray orchestration.
+
+The one CPU concession: SkyRL's InfoActor is `@ray.remote(num_gpus=1)` and reads
+`ray.get_gpu_ids()[0]`. We keep the exact structure but use a CPU bundle and a
+GPU-id that falls back to the bundle index on CPU, so the orchestration path
+(placement_group_table -> InfoActor per bundle -> get id -> kill -> sort) runs
+unchanged. On a real GPU cluster the unmodified SkyRL code would run as-is.
+"""
+
+import argparse
+import functools
+
+import fakeray
+from fakeray._scheduler import FakeRayConfig
+
+
+def main() -> None:
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--num-bundles", type=int, default=2)
+    ap.add_argument("--region", default=None)
+    args = ap.parse_args()
+
+    fakeray.set_config(FakeRayConfig(pool_size=args.num_bundles, device="cpu", region=args.region))
+    fakeray.install()
+
+    import ray
+    from ray.util.placement_group import placement_group, placement_group_table
+    from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+    ray.init()
+
+    # ---- BEGIN code lifted from SkyRL utils.py (verbatim except InfoActor cpu) ----
+    @ray.remote
+    class InfoActor:
+        def get_gpu_id(self):
+            gpus = ray.get_gpu_ids()
+            return gpus[0] if gpus else 0  # CPU fallback; real SkyRL: gpus[0]
+
+    def _probe_bundle_placement(pg):
+        pg_data = placement_group_table(pg)
+        num_bundles = len(pg_data["bundles"])
+        bundle_to_node_ids = pg_data["bundles_to_node_id"]
+
+        info_actors = []
+        for i in range(num_bundles):
+            info_actors.append(
+                InfoActor.options(
+                    num_cpus=0.01,
+                    scheduling_strategy=PlacementGroupSchedulingStrategy(
+                        placement_group=pg,
+                        placement_group_bundle_index=i,
+                    ),
+                ).remote()
+            )
+
+        gpu_ids = ray.get([actor.get_gpu_id.remote() for actor in info_actors])
+        for actor in info_actors:
+            ray.kill(actor)
+
+        bundle_infos = [(i, bundle_to_node_ids[i], gpu_ids[i]) for i in range(num_bundles)]
+        return sorted(bundle_infos, key=lambda x: (x[1], x[2]))
+
+    class ResolvedPlacementGroup:
+        def __init__(self, pg):
+            self.pg = pg
+            self._bundle_placement = None
+
+        def _get_bundle_placement(self):
+            if self._bundle_placement is None:
+                self._bundle_placement = _probe_bundle_placement(self.pg)
+            return self._bundle_placement
+
+        @functools.cached_property
+        def reordered_bundle_indices(self):
+            return [info[0] for info in self._get_bundle_placement()]
+
+        @functools.cached_property
+        def bundle_node_ids(self):
+            return [info[1] for info in self._get_bundle_placement()]
+
+        @functools.cached_property
+        def num_nodes(self):
+            return len(set(self.bundle_node_ids))
+
+    # ---- END lifted code ----
+
+    pg = placement_group([{"CPU": 1}] * args.num_bundles, strategy="PACK")
+    ray.get(pg.ready(), timeout=60)
+
+    rpg = ResolvedPlacementGroup(pg)
+    print("SKYRL_REAL_PG_BEGIN", flush=True)
+    print(f"num_bundles={args.num_bundles}", flush=True)
+    print(f"reordered_bundle_indices={rpg.reordered_bundle_indices}", flush=True)
+    print(f"bundle_node_ids={rpg.bundle_node_ids}", flush=True)
+    print(f"num_nodes={rpg.num_nodes}", flush=True)
+    print("SKYRL_REAL_PG_END", flush=True)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/fakeray/pyproject.toml
+++ b/lib/fakeray/pyproject.toml
@@ -1,0 +1,35 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# NOTE: intentionally NOT a member of the root [tool.uv.workspace] yet — this is
+# a sketch. Run it via PYTHONPATH=lib/fakeray/src against the marin venv (which
+# already provides marin-fray + marin-iris). Wire into the workspace once the
+# design is accepted.
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "marin-fakeray"
+version = "0.0.1"
+description = "A Ray-Core-compatible shim that executes tasks on Iris via Fray."
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "marin-fray",
+]
+
+[project.optional-dependencies]
+# Convenience: pull the real package smallpond targets, only for parity testing.
+# Not needed to use the shim.
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/fakeray"]
+
+# The sibling distribution that is *named* `ray` (the uv override target) lives
+# in ./ray-shim and is built separately. See README "Exposing as `ray`".
+
+[dependency-groups]
+dev = [
+    "pytest>=8.0",
+]

--- a/lib/fakeray/pytest.ini
+++ b/lib/fakeray/pytest.ini
@@ -1,0 +1,5 @@
+[pytest]
+# Standalone config so the package's tests don't inherit the marin root
+# addopts (which require plugins absent from a minimal env).
+addopts = -q
+testpaths = tests

--- a/lib/fakeray/ray-shim/pyproject.toml
+++ b/lib/fakeray/ray-shim/pyproject.toml
@@ -1,0 +1,29 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+# A distribution literally named `ray`. Its sole purpose is to be forced in via
+# uv `override-dependencies`, beating a requirer's transitive `ray>=x`
+# constraint, so that `import ray` resolves to the fakeray shim.
+#
+# Build: `uv build` here -> dist/ray-<version>-py3-none-any.whl
+# Then in the consuming project:
+#   [tool.uv]
+#   override-dependencies = ["ray @ file:///abs/path/to/ray-<version>-py3-none-any.whl"]
+
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "ray"
+# Cosmetic: override ignores the requirer's specifier. Kept >= smallpond's
+# `ray >= 2.10.0` floor so any *non*-overridden resolver is still satisfied.
+version = "2.55.0"
+description = "Shim distribution: redirects `import ray` to the fakeray/Fray backend."
+requires-python = ">=3.11,<3.13"
+dependencies = [
+    "marin-fakeray",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ray"]

--- a/lib/fakeray/ray-shim/src/ray/__init__.py
+++ b/lib/fakeray/ray-shim/src/ray/__init__.py
@@ -1,0 +1,43 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Top-level ``ray`` package that forwards to the fakeray shim.
+
+When this distribution is installed in place of real Ray (via uv
+``override-dependencies``), ``import ray`` and ``from ray import ...`` resolve
+here, and every public name is re-exported from :mod:`fakeray`. The
+``ray.exceptions`` submodule is provided as a real module file so that
+``import ray.exceptions`` (which smallpond does at module load) resolves through
+``sys.modules`` — a package ``__getattr__`` alone does not serve dotted
+submodule imports.
+"""
+
+from __future__ import annotations
+
+from fakeray import (
+    ObjectRef,
+    RemoteFunction,
+    exceptions,
+    get,
+    init,
+    is_initialized,
+    put,
+    remote,
+    shutdown,
+    timeline,
+    wait,
+)
+
+__all__ = [
+    "ObjectRef",
+    "RemoteFunction",
+    "exceptions",
+    "get",
+    "init",
+    "is_initialized",
+    "put",
+    "remote",
+    "shutdown",
+    "timeline",
+    "wait",
+]

--- a/lib/fakeray/ray-shim/src/ray/exceptions.py
+++ b/lib/fakeray/ray-shim/src/ray/exceptions.py
@@ -1,0 +1,15 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""``ray.exceptions`` -> ``fakeray.exceptions``.
+
+A real module file (not a ``__getattr__`` shim) so that smallpond's
+``import ray.exceptions`` resolves. Re-exports the Ray-compatible names.
+"""
+
+from fakeray.exceptions import (  # noqa: F401
+    GetTimeoutError,
+    RayError,
+    RayTaskError,
+    RuntimeEnvSetupError,
+)

--- a/lib/fakeray/src/fakeray/__init__.py
+++ b/lib/fakeray/src/fakeray/__init__.py
@@ -135,8 +135,19 @@ def wait(
 
 
 def timeline(filename: str) -> None:
-    """Ray-compat no-op. Iris provides its own dashboard/timeline."""
-    logger.debug("fakeray.timeline(%s): no-op (use the Iris dashboard)", filename)
+    """Write an empty Chrome-trace timeline.
+
+    fakeray has no Ray timeline to export (use the Iris dashboard for real
+    observability), but callers like smallpond immediately re-open the file and
+    ``json.load`` it, so we must produce a valid empty trace rather than no file.
+    """
+    import json
+
+    try:
+        with open(filename, "w") as f:
+            json.dump([], f)
+    except OSError as e:
+        logger.debug("fakeray.timeline(%s): could not write placeholder: %s", filename, e)
 
 
 class RemoteFunction:

--- a/lib/fakeray/src/fakeray/__init__.py
+++ b/lib/fakeray/src/fakeray/__init__.py
@@ -24,6 +24,7 @@ Two ways to put this in front of an ``import ray``:
 from __future__ import annotations
 
 import logging
+import os
 import sys
 from typing import Any
 
@@ -47,6 +48,7 @@ __all__ = [
     "exceptions",
     "get",
     "get_actor",
+    "get_gpu_ids",
     "init",
     "install",
     "is_initialized",
@@ -209,6 +211,19 @@ def kill(actor: ActorHandle) -> None:
 def cancel(ref: ObjectRef) -> None:
     """Best-effort task cancel (Ray-compat). No-op once dispatched."""
     logger.debug("fakeray.cancel(%s): best-effort no-op", getattr(ref, "id", ref))
+
+
+def get_gpu_ids() -> list:
+    """Ray-compat ``ray.get_gpu_ids()`` — GPU ids assigned to this worker.
+
+    Reads ``CUDA_VISIBLE_DEVICES`` if Iris set it for a GPU task; otherwise
+    returns ``[]`` (CPU). Callers that index ``[0]`` unconditionally (e.g.
+    SkyRL's InfoActor) only run under GPU placement, where this is populated.
+    """
+    cuda = os.environ.get("CUDA_VISIBLE_DEVICES", "").strip()
+    if not cuda:
+        return []
+    return [int(x) if x.isdigit() else x for x in cuda.split(",") if x]
 
 
 def install() -> None:

--- a/lib/fakeray/src/fakeray/__init__.py
+++ b/lib/fakeray/src/fakeray/__init__.py
@@ -1,0 +1,178 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""fakeray: a Ray-Core-compatible execution shim backed by Fray/Iris.
+
+Implements the subset of the Ray Core API that smallpond uses
+(``init``/``shutdown``/``put``/``get``/``wait``/``remote``/``ObjectRef`` +
+``exceptions``), dispatching each remote call to a pool of Fray actors instead
+of a real Ray cluster.
+
+Two ways to put this in front of an ``import ray``:
+
+1. **uv override (recommended, no source edits).** Install the sibling
+   distribution named ``ray`` (under ``ray-shim/``) and force it in via
+   ``[tool.uv] override-dependencies = ["ray @ <wheel>"]``. The requirer's
+   ``ray>=x`` constraint is replaced and ``import ray`` resolves to this shim.
+   See ``lib/fakeray/README.md``.
+
+2. **Runtime install.** Call ``fakeray.install()`` before the requirer imports
+   ``ray``; it registers this module (and ``fakeray.exceptions``) under the
+   ``ray`` name in ``sys.modules``.
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any
+
+from fray.current_client import current_client
+
+from fakeray import exceptions
+from fakeray._object_ref import ObjectRef
+from fakeray._scheduler import FakeRayConfig, Scheduler
+
+logger = logging.getLogger(__name__)
+
+__all__ = [
+    "ObjectRef",
+    "RemoteFunction",
+    "exceptions",
+    "get",
+    "init",
+    "install",
+    "is_initialized",
+    "put",
+    "remote",
+    "set_config",
+    "shutdown",
+    "timeline",
+    "wait",
+]
+
+# Module-global scheduler, created by init(). One per driver process — matching
+# Ray's single-cluster-per-process model.
+_scheduler: Scheduler | None = None
+_config_override: FakeRayConfig | None = None
+
+
+def set_config(config: FakeRayConfig) -> None:
+    """Override pool sizing/resources before ``init`` (instead of env vars)."""
+    global _config_override
+    _config_override = config
+
+
+def is_initialized() -> bool:
+    return _scheduler is not None
+
+
+class _InitResult:
+    """Return value of ``init``; smallpond reads ``.address_info['gcs_address']``."""
+
+    def __init__(self, address: str):
+        self.address_info = {"gcs_address": address, "address": address}
+
+
+def init(
+    address: str | None = None,
+    *,
+    num_cpus: int | None = None,
+    runtime_env: dict | None = None,
+    **_ignored: Any,
+) -> _InitResult:
+    """Start the Fray-backed scheduler + actor pool.
+
+    Ray-specific kwargs (``_memory``, ``dashboard_host``, ``dashboard_port``,
+    ``_metrics_export_port``, ``log_to_driver``, …) are accepted and ignored.
+    """
+    global _scheduler
+    if _scheduler is not None:
+        logger.info("fakeray.init: already initialized; reusing scheduler")
+        return _InitResult("fakeray://existing")
+
+    config = _config_override or FakeRayConfig.from_env(num_cpus=num_cpus)
+    client = current_client()
+    logger.info("fakeray.init: client=%s config=%s", type(client).__name__, config)
+    _scheduler = Scheduler(client, config, runtime_env=runtime_env)
+    _scheduler.start()
+    return _InitResult("fakeray://local")
+
+
+def shutdown() -> None:
+    global _scheduler
+    if _scheduler is None:
+        return
+    _scheduler.shutdown()
+    _scheduler = None
+
+
+def _require() -> Scheduler:
+    if _scheduler is None:
+        raise RuntimeError("fakeray not initialized; call fakeray.init() first")
+    return _scheduler
+
+
+def put(value: Any) -> ObjectRef:
+    return _require().put(value)
+
+
+def get(refs: ObjectRef | list[ObjectRef], timeout: float | None = None) -> Any:
+    scalar = isinstance(refs, ObjectRef)
+    ref_list = [refs] if scalar else list(refs)
+    out = _require().get(ref_list, timeout=timeout)
+    return out[0] if scalar else out
+
+
+def wait(
+    refs: list[ObjectRef],
+    *,
+    num_returns: int = 1,
+    timeout: float | None = None,
+    fetch_local: bool = True,  # accepted for Ray-compat; values are descriptors
+) -> tuple[list[ObjectRef], list[ObjectRef]]:
+    return _require().wait(list(refs), num_returns=num_returns, timeout=timeout)
+
+
+def timeline(filename: str) -> None:
+    """Ray-compat no-op. Iris provides its own dashboard/timeline."""
+    logger.debug("fakeray.timeline(%s): no-op (use the Iris dashboard)", filename)
+
+
+class RemoteFunction:
+    """What ``@ray.remote`` returns. Supports ``.options(...).remote(...)``."""
+
+    def __init__(self, fn: Any, opts: dict | None = None):
+        self._fn = fn
+        self._opts = dict(opts or {})
+
+    def options(self, **opts: Any) -> RemoteFunction:
+        merged = {**self._opts, **opts}
+        return RemoteFunction(self._fn, merged)
+
+    def remote(self, *args: Any, **kwargs: Any) -> ObjectRef:
+        return _require().submit_task(self._fn, args, kwargs, self._opts)
+
+
+def remote(fn: Any = None, **opts: Any) -> Any:
+    """``@ray.remote`` and ``@ray.remote(num_cpus=..., ...)`` decorator."""
+    if fn is not None and callable(fn) and not opts:
+        return RemoteFunction(fn)
+
+    def wrap(f: Any) -> RemoteFunction:
+        return RemoteFunction(f, opts)
+
+    return wrap
+
+
+def install() -> None:
+    """Register this shim under the ``ray`` name in ``sys.modules``.
+
+    Call before the requiring library imports ``ray``. Also registers the
+    ``ray.exceptions`` submodule, because ``import ray.exceptions`` (which
+    smallpond does) is NOT served by a module-level ``__getattr__`` — Python
+    resolves dotted imports through ``sys.modules`` entries directly.
+    """
+    sys.modules["ray"] = sys.modules[__name__]
+    sys.modules["ray.exceptions"] = exceptions
+    logger.info("fakeray.install: registered shim as 'ray' in sys.modules")

--- a/lib/fakeray/src/fakeray/__init__.py
+++ b/lib/fakeray/src/fakeray/__init__.py
@@ -29,25 +29,34 @@ from typing import Any
 
 from fray.current_client import current_client
 
-from fakeray import exceptions
+from fakeray import exceptions, util
+from fakeray._actor import ActorClass, ActorHandle
+from fakeray._actor import get_actor as _get_actor
+from fakeray._actor import kill as _kill
 from fakeray._object_ref import ObjectRef
 from fakeray._scheduler import FakeRayConfig, Scheduler
 
 logger = logging.getLogger(__name__)
 
 __all__ = [
+    "ActorClass",
+    "ActorHandle",
     "ObjectRef",
     "RemoteFunction",
+    "cancel",
     "exceptions",
     "get",
+    "get_actor",
     "init",
     "install",
     "is_initialized",
+    "kill",
     "put",
     "remote",
     "set_config",
     "shutdown",
     "timeline",
+    "util",
     "wait",
 ]
 
@@ -165,15 +174,41 @@ class RemoteFunction:
         return _require().submit_task(self._fn, args, kwargs, self._opts)
 
 
-def remote(fn: Any = None, **opts: Any) -> Any:
-    """``@ray.remote`` and ``@ray.remote(num_cpus=..., ...)`` decorator."""
-    if fn is not None and callable(fn) and not opts:
-        return RemoteFunction(fn)
+def _wrap_remote(target: Any, opts: dict) -> Any:
+    """Class -> stateful ActorClass; function -> RemoteFunction."""
+    if isinstance(target, type):
+        return ActorClass(target, opts)
+    return RemoteFunction(target, opts)
 
-    def wrap(f: Any) -> RemoteFunction:
-        return RemoteFunction(f, opts)
+
+def remote(fn: Any = None, **opts: Any) -> Any:
+    """``@ray.remote`` decorator for both functions and actor classes.
+
+    Bare ``@ray.remote`` or ``@ray.remote(num_gpus=1, ...)``, applied to a def
+    (-> RemoteFunction) or a class (-> ActorClass).
+    """
+    if fn is not None and not opts:
+        return _wrap_remote(fn, {})
+
+    def wrap(target: Any) -> Any:
+        return _wrap_remote(target, opts)
 
     return wrap
+
+
+def get_actor(name: str) -> ActorHandle:
+    """Resolve a named actor (Ray-compat)."""
+    return _get_actor(name)
+
+
+def kill(actor: ActorHandle) -> None:
+    """Terminate an actor (Ray-compat)."""
+    _kill(actor)
+
+
+def cancel(ref: ObjectRef) -> None:
+    """Best-effort task cancel (Ray-compat). No-op once dispatched."""
+    logger.debug("fakeray.cancel(%s): best-effort no-op", getattr(ref, "id", ref))
 
 
 def install() -> None:
@@ -184,6 +219,20 @@ def install() -> None:
     smallpond does) is NOT served by a module-level ``__getattr__`` — Python
     resolves dotted imports through ``sys.modules`` entries directly.
     """
+    import importlib
+
+    # Import the SUBMODULES by full path. (A plain `from fakeray.util import
+    # placement_group` would bind the re-exported *function* of that name in
+    # util/__init__, not the module — which then can't satisfy
+    # `from ray.util.placement_group import placement_group`.)
+    pg_mod = importlib.import_module("fakeray.util.placement_group")
+    ss_mod = importlib.import_module("fakeray.util.scheduling_strategies")
+
     sys.modules["ray"] = sys.modules[__name__]
     sys.modules["ray.exceptions"] = exceptions
-    logger.info("fakeray.install: registered shim as 'ray' in sys.modules")
+    # Dotted submodule imports resolve through sys.modules, not __getattr__, so
+    # register each ray.util.* path SkyRL imports explicitly.
+    sys.modules["ray.util"] = util
+    sys.modules["ray.util.placement_group"] = pg_mod
+    sys.modules["ray.util.scheduling_strategies"] = ss_mod
+    logger.info("fakeray.install: registered shim as 'ray' (+ ray.util.*) in sys.modules")

--- a/lib/fakeray/src/fakeray/_actor.py
+++ b/lib/fakeray/src/fakeray/_actor.py
@@ -1,0 +1,168 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ray-compatible stateful actors, backed by Fray actors.
+
+Ray's actor model: ``@ray.remote`` on a class yields an ``ActorClass``;
+``.remote(*args)`` constructs the actor (a process) and returns an
+``ActorHandle``; ``handle.method.remote(*a)`` enqueues a call and returns an
+``ObjectRef``; ``ray.get(ref)`` awaits it.
+
+We map each of those onto Fray:
+- ``ActorClass.remote()`` -> ``Client.create_actor(...)`` -> a Fray ActorHandle
+- ``handle.method.remote(*a)`` -> Fray ``handle.method.remote(*a)`` (an
+  ``ActorFuture``), adapted into a fakeray ``ObjectRef`` so ``get``/``wait``
+  work uniformly with task refs.
+
+Resource options on ``.options(num_gpus=, num_cpus=, memory=, resources=, ...)``
+become a Fray ``ResourceConfig``; ``scheduling_strategy=PlacementGroupScheduling
+Strategy(...)`` is unwrapped to the bundle's resources (best-effort — see the
+placement-group shim and the design note).
+"""
+
+from __future__ import annotations
+
+import threading
+import uuid
+from concurrent.futures import Future
+from typing import Any
+
+from fray.types import ActorConfig, CpuConfig, GpuConfig, ResourceConfig
+
+from fakeray._object_ref import ObjectRef
+
+# process-global registry so ray.get_actor(name) can resolve handles created in
+# this driver. Cross-process named lookup defers to Fray's resolver (not v1).
+_actor_registry: dict[str, ActorHandle] = {}
+
+
+def _resources_from_options(opts: dict) -> ResourceConfig:
+    """Map Ray ``.options(...)`` kwargs to a Fray ResourceConfig.
+
+    Recognizes ``num_cpus``/``num_gpus``/``memory``/``resources`` and unwraps a
+    ``PlacementGroupSchedulingStrategy`` into the bundle's resources. Unknown
+    keys are ignored (Ray accepts many; we map the ones that affect placement).
+    """
+    num_gpus = opts.get("num_gpus")
+    num_cpus = opts.get("num_cpus")
+    memory = opts.get("memory")
+
+    # A placement-group bundle, if one was passed via scheduling_strategy.
+    strategy = opts.get("scheduling_strategy")
+    bundle = getattr(strategy, "_bundle", None)
+    if bundle is not None:
+        num_gpus = bundle.get("GPU", num_gpus)
+        num_cpus = bundle.get("CPU", num_cpus)
+
+    cpu = float(num_cpus) if num_cpus is not None else 1.0
+    ram = _as_ram(memory)
+
+    if num_gpus and num_gpus >= 1:
+        # whole-GPU actor; fractional GPU (colocation) is not supported on Iris.
+        return ResourceConfig(device=GpuConfig(variant="auto", count=int(num_gpus)), cpu=max(cpu, 1.0), ram=ram)
+    return ResourceConfig(device=CpuConfig(), cpu=cpu, ram=ram)
+
+
+def _as_ram(memory: Any) -> str:
+    if memory is None:
+        return "4g"
+    if isinstance(memory, str):
+        return memory
+    # Ray takes bytes for `memory`; Fray wants a human string.
+    return f"{int(int(memory) / (1024**3)) or 1}g"
+
+
+class ActorMethodStub:
+    """``handle.method`` — call ``.remote(*a)`` to invoke it."""
+
+    def __init__(self, handle: ActorHandle, method: str):
+        self._handle = handle
+        self._method = method
+
+    def remote(self, *args: Any, **kwargs: Any) -> ObjectRef:
+        fray_future = getattr(self._handle._fray_handle, self._method).remote(*args, **kwargs)
+        return _future_to_ref(fray_future)
+
+    def __call__(self, *args: Any, **kwargs: Any) -> Any:
+        # Ray disallows direct calls on actor methods; mirror that.
+        raise TypeError(f"actor methods must be invoked via .remote(); got {self._method}(...)")
+
+
+def _future_to_ref(fray_future: Any) -> ObjectRef:
+    """Adapt a Fray ActorFuture into a fakeray ObjectRef.
+
+    A small daemon thread blocks on ``ActorFuture.result()`` (the one method the
+    Fray protocol guarantees) and resolves a ``concurrent.futures.Future`` that
+    backs the ObjectRef — so ``ray.get``/``ray.wait`` treat actor-method results
+    exactly like task results.
+    """
+    fut: Future = Future()
+
+    def _await() -> None:
+        try:
+            fut.set_result(fray_future.result())
+        except Exception as e:
+            fut.set_exception(e)
+
+    threading.Thread(target=_await, daemon=True).start()
+    return ObjectRef(id=uuid.uuid4().hex, future=fut)
+
+
+class ActorHandle:
+    """Handle to a live actor. ``handle.method.remote(*a)`` -> ObjectRef."""
+
+    def __init__(self, fray_handle: Any, name: str):
+        self._fray_handle = fray_handle
+        self._name = name
+
+    def __getattr__(self, method: str) -> ActorMethodStub:
+        if method.startswith("_"):
+            raise AttributeError(method)
+        return ActorMethodStub(self, method)
+
+
+class ActorClass:
+    """What ``@ray.remote`` returns for a class. Construct via ``.remote(*a)``."""
+
+    def __init__(self, cls: type, opts: dict | None = None):
+        self._cls = cls
+        self._opts = dict(opts or {})
+
+    def options(self, **opts: Any) -> ActorClass:
+        return ActorClass(self._cls, {**self._opts, **opts})
+
+    def remote(self, *args: Any, **kwargs: Any) -> ActorHandle:
+        # Imported lazily to avoid a module cycle (scheduler -> actor -> client).
+        from fray.current_client import current_client
+
+        name = self._opts.get("name") or f"{self._cls.__name__}-{uuid.uuid4().hex[:8]}"
+        resources = _resources_from_options(self._opts)
+        client = current_client()
+        fray_handle = client.create_actor(
+            self._cls,
+            *args,
+            name=name,
+            resources=resources,
+            actor_config=ActorConfig(max_concurrency=self._opts.get("max_concurrency", 1)),
+            **kwargs,
+        )
+        handle = ActorHandle(fray_handle, name)
+        _actor_registry[name] = handle
+        return handle
+
+
+def get_actor(name: str) -> ActorHandle:
+    """Resolve a named actor created in this driver."""
+    handle = _actor_registry.get(name)
+    if handle is None:
+        raise ValueError(f"Failed to look up actor with name '{name}'")
+    return handle
+
+
+def kill(handle: ActorHandle) -> None:
+    """Terminate an actor (best-effort)."""
+    fray_handle = getattr(handle, "_fray_handle", None)
+    stop = getattr(fray_handle, "shutdown", None) or getattr(fray_handle, "terminate", None)
+    if stop is not None:
+        stop()
+    _actor_registry.pop(getattr(handle, "_name", ""), None)

--- a/lib/fakeray/src/fakeray/_actor.py
+++ b/lib/fakeray/src/fakeray/_actor.py
@@ -110,11 +110,18 @@ def _future_to_ref(fray_future: Any) -> ObjectRef:
 
 
 class ActorHandle:
-    """Handle to a live actor. ``handle.method.remote(*a)`` -> ObjectRef."""
+    """Handle to a live actor. ``handle.method.remote(*a)`` -> ObjectRef.
 
-    def __init__(self, fray_handle: Any, name: str):
+    Holds the backing Fray actor *group* (created with count=1) so the actor can
+    be torn down via ``ray.kill`` — the per-actor handle itself has no terminate
+    method, and on the Iris backend ``getattr(handle, "shutdown")`` would
+    resolve to a *remote method call* (NotFound), not teardown.
+    """
+
+    def __init__(self, fray_handle: Any, name: str, group: Any = None):
         self._fray_handle = fray_handle
         self._name = name
+        self._group = group
 
     def __getattr__(self, method: str) -> ActorMethodStub:
         if method.startswith("_"):
@@ -139,15 +146,19 @@ class ActorClass:
         name = self._opts.get("name") or f"{self._cls.__name__}-{uuid.uuid4().hex[:8]}"
         resources = _resources_from_options(self._opts)
         client = current_client()
-        fray_handle = client.create_actor(
+        # Create a 1-actor group (not create_actor) so we retain the group, which
+        # is the only object exposing teardown (.shutdown) for ray.kill.
+        group = client.create_actor_group(
             self._cls,
             *args,
             name=name,
+            count=1,
             resources=resources,
             actor_config=ActorConfig(max_concurrency=self._opts.get("max_concurrency", 1)),
             **kwargs,
         )
-        handle = ActorHandle(fray_handle, name)
+        fray_handle = group.wait_ready(count=1)[0]
+        handle = ActorHandle(fray_handle, name, group=group)
         _actor_registry[name] = handle
         return handle
 
@@ -161,9 +172,13 @@ def get_actor(name: str) -> ActorHandle:
 
 
 def kill(handle: ActorHandle) -> None:
-    """Terminate an actor (best-effort)."""
-    fray_handle = getattr(handle, "_fray_handle", None)
-    stop = getattr(fray_handle, "shutdown", None) or getattr(fray_handle, "terminate", None)
-    if stop is not None:
-        stop()
-    _actor_registry.pop(getattr(handle, "_name", ""), None)
+    """Terminate an actor (best-effort) via its backing Fray actor group.
+
+    NB: must go through the group's ``shutdown`` — NOT ``getattr(handle,
+    "shutdown")``, which on the Iris backend resolves to a remote *method call*
+    (``Method 'shutdown' not found``) rather than teardown.
+    """
+    group = handle._group
+    if group is not None and hasattr(group, "shutdown"):
+        group.shutdown()
+    _actor_registry.pop(handle._name, None)

--- a/lib/fakeray/src/fakeray/_actor.py
+++ b/lib/fakeray/src/fakeray/_actor.py
@@ -39,9 +39,10 @@ _actor_registry: dict[str, ActorHandle] = {}
 def _resources_from_options(opts: dict) -> ResourceConfig:
     """Map Ray ``.options(...)`` kwargs to a Fray ResourceConfig.
 
-    Recognizes ``num_cpus``/``num_gpus``/``memory``/``resources`` and unwraps a
-    ``PlacementGroupSchedulingStrategy`` into the bundle's resources. Unknown
-    keys are ignored (Ray accepts many; we map the ones that affect placement).
+    Reads ``num_cpus``/``num_gpus``/``memory`` and unwraps a
+    ``PlacementGroupSchedulingStrategy`` into the target bundle's resources.
+    Other Ray option keys are ignored (Ray accepts many; we map only the ones
+    that affect Iris placement).
     """
     num_gpus = opts.get("num_gpus")
     num_cpus = opts.get("num_cpus")

--- a/lib/fakeray/src/fakeray/_executor.py
+++ b/lib/fakeray/src/fakeray/_executor.py
@@ -30,8 +30,14 @@ class FakeRayExecutor:
     """
 
     def __init__(self) -> None:
-        # Per-process warmup happens lazily on first import inside the payload.
-        logger.info("FakeRayExecutor actor started")
+        # Each actor is a separate process (a separate Iris job replica) and did
+        # NOT inherit the driver's sys.modules. Re-install the shim here so that
+        # `import ray` inside an unpickled task payload binds to fakeray rather
+        # than failing (the bundle ships no real `ray`).
+        import fakeray
+
+        fakeray.install()
+        logger.info("FakeRayExecutor actor started (ray shim installed)")
 
     def run(self, payload: bytes) -> bytes:
         """Execute a cloudpickled (fn, args, kwargs) and return pickled result.

--- a/lib/fakeray/src/fakeray/_executor.py
+++ b/lib/fakeray/src/fakeray/_executor.py
@@ -1,0 +1,45 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The Fray actor that executes one remote call.
+
+A single long-lived actor per pool slot. ``run`` receives a cloudpickled
+``(callable, args, kwargs)`` payload where each argument has already been
+dereferenced by the scheduler (no ObjectRefs cross the wire), invokes it, and
+returns the (cloudpickled) result.
+
+Keeping the actor generic — it just runs whatever callable it is handed — is
+what keeps fakeray smallpond-agnostic. smallpond's ``exec_task`` body is an
+ordinary function as far as the actor is concerned.
+"""
+
+from __future__ import annotations
+
+import logging
+
+import cloudpickle
+
+logger = logging.getLogger(__name__)
+
+
+class FakeRayExecutor:
+    """Stateless executor actor. One ``run`` call == one remote task.
+
+    Resources (cpu/ram) are set on the actor at pool-creation time; this class
+    holds no per-task resource logic in v1 (slot-based scheduling).
+    """
+
+    def __init__(self) -> None:
+        # Per-process warmup happens lazily on first import inside the payload.
+        logger.info("FakeRayExecutor actor started")
+
+    def run(self, payload: bytes) -> bytes:
+        """Execute a cloudpickled (fn, args, kwargs) and return pickled result.
+
+        Args and kwargs are concrete values (the scheduler resolved any
+        ObjectRefs before dispatch). Exceptions propagate to the caller's
+        ActorFuture, which the scheduler turns into a failed ObjectRef.
+        """
+        fn, args, kwargs = cloudpickle.loads(payload)
+        result = fn(*args, **kwargs)
+        return cloudpickle.dumps(result)

--- a/lib/fakeray/src/fakeray/_object_ref.py
+++ b/lib/fakeray/src/fakeray/_object_ref.py
@@ -1,0 +1,39 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""ObjectRef: a driver-local handle to a (future) task result.
+
+Unlike Ray's distributed object store, a fakeray ``ObjectRef`` is backed by a
+plain ``concurrent.futures.Future`` living in the driver process. This is
+sufficient because the values smallpond passes between tasks are *path
+descriptors* (``DataSet`` objects holding parquet paths), not bulk data — the
+terabytes live on the shared filesystem and never traverse the ref.
+"""
+
+from __future__ import annotations
+
+from concurrent.futures import Future
+from dataclasses import dataclass, field
+
+
+@dataclass(eq=False)
+class ObjectRef:
+    """Handle to the result of a remote call.
+
+    ``eq=False`` keeps identity-based hashing so refs are usable as dict keys
+    and set members, matching Ray's ObjectRef semantics.
+    """
+
+    id: str
+    future: Future = field(repr=False)
+
+    def _done(self) -> bool:
+        return self.future.done()
+
+    def _result(self, timeout: float | None = None) -> object:
+        # Re-raises the task's exception if the future failed.
+        return self.future.result(timeout=timeout)
+
+    def __repr__(self) -> str:
+        state = "ready" if self.future.done() else "pending"
+        return f"ObjectRef({self.id[:8]}, {state})"

--- a/lib/fakeray/src/fakeray/_placement.py
+++ b/lib/fakeray/src/fakeray/_placement.py
@@ -53,9 +53,32 @@ class PlacementGroup:
     def bundle_resources(self, index: int) -> dict:
         return self.bundles[index] if 0 <= index < len(self.bundles) else {}
 
+    @property
+    def bundle_specs(self) -> list[dict]:
+        """Ray-compat alias used by e.g. SkyRL's get_ray_pg_ready_with_timeout."""
+        return self.bundles
+
 
 def placement_group(bundles: list[dict], strategy: str = "PACK", **_ignored: Any) -> PlacementGroup:
     return PlacementGroup(bundles, strategy=strategy)
+
+
+def placement_group_table(pg: PlacementGroup) -> dict:
+    """Ray-compat ``placement_group_table`` (best-effort).
+
+    Real Ray returns per-bundle node/resource placement. We have no bundle->node
+    reservation (bundles are scheduled independently), so every bundle reports a
+    single synthetic node id. Callers that only need bundle count + a stable
+    node mapping (e.g. SkyRL's ``_probe_bundle_placement``) work; callers that
+    depend on real cross-node bundle ordering do not (documented limitation).
+    """
+    n = len(pg.bundles)
+    return {
+        "bundles": dict(enumerate(pg.bundles)),
+        "bundles_to_node_id": {i: "fakeray-node-0" for i in range(n)},
+        "strategy": pg.strategy,
+        "state": "CREATED",
+    }
 
 
 def remove_placement_group(pg: PlacementGroup) -> None:

--- a/lib/fakeray/src/fakeray/_placement.py
+++ b/lib/fakeray/src/fakeray/_placement.py
@@ -1,0 +1,63 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Best-effort ``ray.util.placement_group`` shim.
+
+Ray reserves *bundles* of resources atomically (gang) and lets actors pin to a
+bundle index, with ``PACK``/``SPREAD`` locality and fractional-GPU colocation.
+Iris has no matching primitive, so v1 **captures** the bundle list + strategy
+without enforcing colocation or atomicity: each actor scheduled "into" the group
+is sized from its bundle and scheduled independently by Iris.
+
+This makes the API present and gives the right number/size of GPU actors. It does
+NOT provide PACK/SPREAD locality, atomic gang bring-up, or fractional-GPU
+colocation — see the design note. The discrepancy is logged loudly.
+"""
+
+from __future__ import annotations
+
+import logging
+from concurrent.futures import Future
+from typing import Any
+
+from fakeray._object_ref import ObjectRef
+
+logger = logging.getLogger(__name__)
+
+
+class PlacementGroup:
+    """Lightweight stand-in for a Ray PlacementGroup.
+
+    Holds the requested bundles + strategy. ``ready()`` resolves immediately
+    (no real reservation happens).
+    """
+
+    def __init__(self, bundles: list[dict], strategy: str = "PACK"):
+        self.bundles = list(bundles)
+        self.strategy = strategy
+        logger.warning(
+            "fakeray: placement_group(strategy=%s, %d bundles) is ADVISORY — Iris schedules "
+            "bundles independently (no PACK/SPREAD locality, atomic gang, or fractional-GPU "
+            "colocation). See the fray-ray design note.",
+            strategy,
+            len(bundles),
+        )
+
+    def ready(self) -> ObjectRef:
+        fut: Future = Future()
+        fut.set_result(self)
+        import uuid
+
+        return ObjectRef(id=uuid.uuid4().hex, future=fut)
+
+    def bundle_resources(self, index: int) -> dict:
+        return self.bundles[index] if 0 <= index < len(self.bundles) else {}
+
+
+def placement_group(bundles: list[dict], strategy: str = "PACK", **_ignored: Any) -> PlacementGroup:
+    return PlacementGroup(bundles, strategy=strategy)
+
+
+def remove_placement_group(pg: PlacementGroup) -> None:
+    """No-op: nothing was reserved."""
+    return None

--- a/lib/fakeray/src/fakeray/_scheduler.py
+++ b/lib/fakeray/src/fakeray/_scheduler.py
@@ -53,18 +53,43 @@ _POISON = object()  # sentinel pushed to the ready queue to stop worker threads
 
 @dataclass
 class FakeRayConfig:
-    """Pool sizing and per-actor resources. Read once at ``init``."""
+    """Pool sizing and per-actor resources. Read once at ``init``.
+
+    ``device`` selects the worker hardware for the actor pool. ``"cpu"`` uses a
+    plain CPU ResourceConfig; a TPU variant string (e.g. ``"v6e-4"``) borrows
+    that TPU host's VM for CPU-bound duckdb work (the chips sit idle). With
+    ``preemptible=True`` and a TPU device the pool lands on the cheap
+    preemptible TPU groups — pair with ``max_task_retries`` so the scheduler
+    survives actor preemption (see Scheduler re-dispatch).
+    """
 
     pool_size: int = 4
     cpu: float = 1.0
     ram: str = "4g"
+    device: str = "cpu"
+    preemptible: bool = True
+    region: str | None = None
+    max_task_retries: int = 3
 
     @staticmethod
     def from_env(num_cpus: int | None = None) -> FakeRayConfig:
         pool = int(os.environ.get("FAKERAY_POOL_SIZE", num_cpus or 4))
         cpu = float(os.environ.get("FAKERAY_ACTOR_CPU", "1"))
         ram = os.environ.get("FAKERAY_ACTOR_RAM", "4g")
-        return FakeRayConfig(pool_size=max(1, pool), cpu=cpu, ram=ram)
+        device = os.environ.get("FAKERAY_DEVICE", "cpu")
+        region = os.environ.get("FAKERAY_REGION") or None
+        preemptible = os.environ.get("FAKERAY_PREEMPTIBLE", "1") != "0"
+        return FakeRayConfig(
+            pool_size=max(1, pool), cpu=cpu, ram=ram, device=device, region=region, preemptible=preemptible
+        )
+
+    def resource_config(self) -> ResourceConfig:
+        """Build the Fray ResourceConfig for one actor in the pool."""
+        regions = [self.region] if self.region else None
+        if self.device and self.device != "cpu":
+            # TPU host VM: with_tpu sets sensible cpu/ram defaults for the host.
+            return ResourceConfig.with_tpu(self.device, preemptible=self.preemptible, regions=regions)
+        return ResourceConfig(cpu=self.cpu, ram=self.ram, preemptible=self.preemptible, regions=regions)
 
 
 @dataclass
@@ -78,6 +103,7 @@ class _Node:
     opts: dict
     pending: set[str] = field(default_factory=set)  # dep ref ids not yet completed
     queued: bool = False
+    attempts: int = 0  # dispatch attempts so far (for preemption re-dispatch)
 
 
 class Scheduler:
@@ -104,13 +130,22 @@ class Scheduler:
         if self._started:
             return
         n = self._config.pool_size
-        logger.info("fakeray: starting actor pool of %d", n)
+        resources = self._config.resource_config()
+        logger.info(
+            "fakeray: starting actor pool of %d (device=%s preemptible=%s region=%s)",
+            n,
+            self._config.device,
+            self._config.preemptible,
+            self._config.region,
+        )
         self._group = self._client.create_actor_group(
             FakeRayExecutor,
             name="fakeray-exec",
             count=n,
-            resources=ResourceConfig(cpu=self._config.cpu, ram=self._config.ram),
-            actor_config=ActorConfig(max_concurrency=1),
+            resources=resources,
+            # Auto-restart preempted actors; bound task retries so the scheduler's
+            # re-dispatch (on actor death) doesn't loop forever.
+            actor_config=ActorConfig(max_concurrency=1, max_task_retries=self._config.max_task_retries),
         )
         handles = self._group.wait_ready(count=n)
         for i, handle in enumerate(handles):
@@ -205,6 +240,7 @@ class Scheduler:
             node: _Node = item
             if node.ref.future.done():
                 continue  # poisoned by a failed dependency before we got to it
+            node.attempts += 1
             try:
                 values = [self._deref(a) for a in node.args]
                 kwargs = {k: self._deref(v) for k, v in node.kwargs.items()}
@@ -212,8 +248,28 @@ class Scheduler:
                 result_bytes = actor_handle.run.remote(payload).result()
                 result = cloudpickle.loads(result_bytes)
             except Exception as e:
-                logger.warning("fakeray: task %s failed: %s", node.ref.id[:8], e)
-                self._settle_failure(node.ref.id, e)
+                # An exception here is either a real task error or a dead actor
+                # (preemption). We can't always tell them apart, so retry up to
+                # max_task_retries: smallpond tasks are idempotent (shared-root
+                # markers + unique output keys), so re-running a genuinely failing
+                # task just re-fails deterministically and settles after the cap.
+                # A surviving worker thread picks up the re-queued node.
+                if node.attempts <= self._config.max_task_retries:
+                    logger.warning(
+                        "fakeray: task %s attempt %d failed (%s); re-dispatching",
+                        node.ref.id[:8],
+                        node.attempts,
+                        type(e).__name__,
+                    )
+                    self._ready.put(node)
+                else:
+                    logger.warning(
+                        "fakeray: task %s failed after %d attempts: %s",
+                        node.ref.id[:8],
+                        node.attempts,
+                        e,
+                    )
+                    self._settle_failure(node.ref.id, e)
                 continue
             self._settle_success(node.ref.id, result)
 

--- a/lib/fakeray/src/fakeray/_scheduler.py
+++ b/lib/fakeray/src/fakeray/_scheduler.py
@@ -1,0 +1,261 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The fakeray DAG scheduler.
+
+A ready-queue scheduler that runs in the driver process and dispatches each
+remote call to a fixed pool of Fray actors. Design choices:
+
+- **One worker thread per actor slot.** Each thread pulls a ready node, claims
+  its dedicated actor, sends the payload, and blocks on the ``ActorFuture``.
+  This relies only on ``ActorFuture.result()`` — the single method the Fray
+  ``ActorFuture`` protocol guarantees — so it works identically on the local
+  and Iris backends without depending on ``.done()`` or done-callbacks.
+
+- **Dependencies are ObjectRefs passed as args.** A node is *ready* when every
+  dep ref it references has completed. The scheduler dereferences ObjectRef
+  args to concrete values just before dispatch, reproducing Ray's auto-deref.
+
+- **Futures live in the driver.** ``ObjectRef.future`` is a
+  ``concurrent.futures.Future`` the scheduler owns, so ``get``/``wait`` use
+  ordinary future semantics regardless of backend.
+
+Failure propagation: when a node fails, its exception is set on its ObjectRef
+*and* propagated to all transitive descendants, so ``get`` on a downstream ref
+raises instead of hanging forever.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import queue
+import threading
+import uuid
+from collections import defaultdict
+from concurrent.futures import Future
+from concurrent.futures import TimeoutError as FuturesTimeout
+from dataclasses import dataclass, field
+from typing import Any
+
+import cloudpickle
+from fray.client import Client
+from fray.types import ActorConfig, ResourceConfig
+
+from fakeray._executor import FakeRayExecutor
+from fakeray._object_ref import ObjectRef
+from fakeray.exceptions import GetTimeoutError
+
+logger = logging.getLogger(__name__)
+
+_POISON = object()  # sentinel pushed to the ready queue to stop worker threads
+
+
+@dataclass
+class FakeRayConfig:
+    """Pool sizing and per-actor resources. Read once at ``init``."""
+
+    pool_size: int = 4
+    cpu: float = 1.0
+    ram: str = "4g"
+
+    @staticmethod
+    def from_env(num_cpus: int | None = None) -> FakeRayConfig:
+        pool = int(os.environ.get("FAKERAY_POOL_SIZE", num_cpus or 4))
+        cpu = float(os.environ.get("FAKERAY_ACTOR_CPU", "1"))
+        ram = os.environ.get("FAKERAY_ACTOR_RAM", "4g")
+        return FakeRayConfig(pool_size=max(1, pool), cpu=cpu, ram=ram)
+
+
+@dataclass
+class _Node:
+    """A registered remote call awaiting (or undergoing) execution."""
+
+    ref: ObjectRef
+    payload_fn: Any
+    args: tuple
+    kwargs: dict
+    opts: dict
+    pending: set[str] = field(default_factory=set)  # dep ref ids not yet completed
+    queued: bool = False
+
+
+class Scheduler:
+    """Owns the Fray actor pool and drives the task DAG to completion."""
+
+    def __init__(self, client: Client, config: FakeRayConfig, *, runtime_env: dict | None = None):
+        self._client = client
+        self._config = config
+        self._runtime_env = runtime_env or {}
+
+        self._lock = threading.Lock()
+        self._nodes: dict[str, _Node] = {}
+        self._children: dict[str, list[str]] = defaultdict(list)
+        self._completed: set[str] = set()  # ids whose value/exc is settled (nodes + puts)
+        self._ready: queue.SimpleQueue = queue.SimpleQueue()
+
+        self._group = None
+        self._workers: list[threading.Thread] = []
+        self._started = False
+
+    # ---- lifecycle ------------------------------------------------------
+
+    def start(self) -> None:
+        if self._started:
+            return
+        n = self._config.pool_size
+        logger.info("fakeray: starting actor pool of %d", n)
+        self._group = self._client.create_actor_group(
+            FakeRayExecutor,
+            name="fakeray-exec",
+            count=n,
+            resources=ResourceConfig(cpu=self._config.cpu, ram=self._config.ram),
+            actor_config=ActorConfig(max_concurrency=1),
+        )
+        handles = self._group.wait_ready(count=n)
+        for i, handle in enumerate(handles):
+            t = threading.Thread(target=self._worker_loop, args=(handle,), name=f"fakeray-worker-{i}", daemon=True)
+            t.start()
+            self._workers.append(t)
+        self._started = True
+
+    def shutdown(self) -> None:
+        for _ in self._workers:
+            self._ready.put(_POISON)
+        for t in self._workers:
+            t.join(timeout=5.0)
+        self._workers = []
+        if self._group is not None:
+            self._group.shutdown()
+            self._group = None
+        self._started = False
+
+    # ---- public object-store ops ---------------------------------------
+
+    def put(self, value: Any) -> ObjectRef:
+        fut: Future = Future()
+        fut.set_result(value)
+        ref = ObjectRef(id=uuid.uuid4().hex, future=fut)
+        with self._lock:
+            self._completed.add(ref.id)
+        return ref
+
+    def submit_task(self, fn: Any, args: tuple, kwargs: dict, opts: dict) -> ObjectRef:
+        """Register a remote call; return its ObjectRef immediately."""
+        ref = ObjectRef(id=uuid.uuid4().hex, future=Future())
+        node = _Node(ref=ref, payload_fn=fn, args=tuple(args), kwargs=dict(kwargs), opts=dict(opts))
+
+        dep_ids = [a.id for a in (*args, *kwargs.values()) if isinstance(a, ObjectRef)]
+        with self._lock:
+            for dep_id in dep_ids:
+                if dep_id in self._completed:
+                    continue  # put-ref or already-finished node — contributes no edge
+                node.pending.add(dep_id)
+                self._children[dep_id].append(ref.id)
+            self._nodes[ref.id] = node
+            ready_now = not node.pending
+            if ready_now:
+                node.queued = True
+        if ready_now:
+            self._ready.put(node)
+        return ref
+
+    # ---- get / wait -----------------------------------------------------
+
+    def get(self, refs: list[ObjectRef], timeout: float | None) -> list[Any]:
+        out: list[Any] = []
+        import time
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+        for ref in refs:
+            remaining = None if deadline is None else max(0.0, deadline - time.monotonic())
+            try:
+                out.append(ref.future.result(timeout=remaining))
+            except FuturesTimeout as e:
+                raise GetTimeoutError(f"get() timed out after {timeout}s") from e
+        return out
+
+    def wait(
+        self, refs: list[ObjectRef], *, num_returns: int, timeout: float | None
+    ) -> tuple[list[ObjectRef], list[ObjectRef]]:
+        import time
+
+        deadline = None if timeout is None else time.monotonic() + timeout
+
+        def _done(r: Any) -> bool:
+            return isinstance(r, ObjectRef) and r.future.done()
+
+        while True:
+            ready = [r for r in refs if _done(r)]
+            not_ready = [r for r in refs if not _done(r)]
+            if len(ready) >= num_returns:
+                break
+            if timeout == 0 or (deadline is not None and time.monotonic() >= deadline):
+                break
+            time.sleep(0.01)
+        return ready, not_ready
+
+    # ---- worker loop ----------------------------------------------------
+
+    def _worker_loop(self, actor_handle: Any) -> None:
+        while True:
+            item = self._ready.get()
+            if item is _POISON:
+                return
+            node: _Node = item
+            if node.ref.future.done():
+                continue  # poisoned by a failed dependency before we got to it
+            try:
+                values = [self._deref(a) for a in node.args]
+                kwargs = {k: self._deref(v) for k, v in node.kwargs.items()}
+                payload = cloudpickle.dumps((node.payload_fn, tuple(values), kwargs))
+                result_bytes = actor_handle.run.remote(payload).result()
+                result = cloudpickle.loads(result_bytes)
+            except Exception as e:
+                logger.warning("fakeray: task %s failed: %s", node.ref.id[:8], e)
+                self._settle_failure(node.ref.id, e)
+                continue
+            self._settle_success(node.ref.id, result)
+
+    @staticmethod
+    def _deref(value: Any) -> Any:
+        if isinstance(value, ObjectRef):
+            return value.future.result()  # node is ready => already resolved
+        return value
+
+    def _settle_success(self, node_id: str, value: Any) -> None:
+        with self._lock:
+            self._completed.add(node_id)
+            newly_ready = self._unblock_children_locked(node_id)
+        self._nodes[node_id].ref.future.set_result(value)
+        for n in newly_ready:
+            self._ready.put(n)
+
+    def _settle_failure(self, node_id: str, exc: BaseException) -> None:
+        """Fail this node and poison all transitive descendants."""
+        to_fail = [node_id]
+        seen: set[str] = set()
+        while to_fail:
+            nid = to_fail.pop()
+            if nid in seen:
+                continue
+            seen.add(nid)
+            with self._lock:
+                self._completed.add(nid)
+                child_ids = list(self._children.get(nid, []))
+            node = self._nodes.get(nid)
+            if node is not None and not node.ref.future.done():
+                node.ref.future.set_exception(exc)
+            to_fail.extend(child_ids)
+
+    def _unblock_children_locked(self, done_id: str) -> list[_Node]:
+        newly_ready: list[_Node] = []
+        for child_id in self._children.get(done_id, []):
+            child = self._nodes.get(child_id)
+            if child is None or child.queued or child.ref.future.done():
+                continue
+            child.pending.discard(done_id)
+            if not child.pending:
+                child.queued = True
+                newly_ready.append(child)
+        return newly_ready

--- a/lib/fakeray/src/fakeray/exceptions.py
+++ b/lib/fakeray/src/fakeray/exceptions.py
@@ -1,0 +1,40 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Ray-compatible exception types.
+
+smallpond references ``ray.exceptions.RuntimeEnvSetupError`` (caught around
+dispatch) and relies on a timeout error being raised by ``ray.get(..., timeout=0)``
+on an unfinished object. We provide the minimal set with the Ray names so the
+shim is drop-in.
+"""
+
+from __future__ import annotations
+
+
+class RayError(Exception):
+    """Base class for Ray-compatible errors."""
+
+
+class GetTimeoutError(RayError, TimeoutError):
+    """Raised by ``get`` when objects are not ready within the timeout.
+
+    Subclasses ``TimeoutError`` so callers that catch either name work.
+    """
+
+
+class RuntimeEnvSetupError(RayError, RuntimeError):
+    """Raised when a worker's runtime environment fails to set up.
+
+    smallpond catches this specifically and retries; the shim never raises it
+    in normal operation, but the type must exist for ``except`` clauses.
+    """
+
+
+class RayTaskError(RayError, RuntimeError):
+    """Wraps an exception raised inside a remote task.
+
+    The shim re-raises the *original* task exception from ``get`` rather than
+    wrapping it, matching what smallpond's broad ``except Exception`` expects.
+    This type exists for API completeness.
+    """

--- a/lib/fakeray/src/fakeray/util/__init__.py
+++ b/lib/fakeray/src/fakeray/util/__init__.py
@@ -1,0 +1,22 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""``ray.util`` shim namespace (placement groups, scheduling strategies)."""
+
+from fakeray._placement import PlacementGroup, placement_group, remove_placement_group
+
+__all__ = [
+    "PlacementGroup",
+    "placement_group",
+    "remove_placement_group",
+]
+
+
+def get_node_ip_address() -> str:
+    """Best-effort local IP (Ray-compat helper used by some frameworks)."""
+    import socket
+
+    try:
+        return socket.gethostbyname(socket.gethostname())
+    except OSError:
+        return "127.0.0.1"

--- a/lib/fakeray/src/fakeray/util/__init__.py
+++ b/lib/fakeray/src/fakeray/util/__init__.py
@@ -3,11 +3,17 @@
 
 """``ray.util`` shim namespace (placement groups, scheduling strategies)."""
 
-from fakeray._placement import PlacementGroup, placement_group, remove_placement_group
+from fakeray._placement import (
+    PlacementGroup,
+    placement_group,
+    placement_group_table,
+    remove_placement_group,
+)
 
 __all__ = [
     "PlacementGroup",
     "placement_group",
+    "placement_group_table",
     "remove_placement_group",
 ]
 

--- a/lib/fakeray/src/fakeray/util/placement_group.py
+++ b/lib/fakeray/src/fakeray/util/placement_group.py
@@ -4,6 +4,11 @@
 """``ray.util.placement_group`` — re-export the shim so ``from
 ray.util.placement_group import placement_group`` resolves (SkyRL's import)."""
 
-from fakeray._placement import PlacementGroup, placement_group, remove_placement_group
+from fakeray._placement import (
+    PlacementGroup,
+    placement_group,
+    placement_group_table,
+    remove_placement_group,
+)
 
-__all__ = ["PlacementGroup", "placement_group", "remove_placement_group"]
+__all__ = ["PlacementGroup", "placement_group", "placement_group_table", "remove_placement_group"]

--- a/lib/fakeray/src/fakeray/util/placement_group.py
+++ b/lib/fakeray/src/fakeray/util/placement_group.py
@@ -1,0 +1,9 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""``ray.util.placement_group`` — re-export the shim so ``from
+ray.util.placement_group import placement_group`` resolves (SkyRL's import)."""
+
+from fakeray._placement import PlacementGroup, placement_group, remove_placement_group
+
+__all__ = ["PlacementGroup", "placement_group", "remove_placement_group"]

--- a/lib/fakeray/src/fakeray/util/scheduling_strategies.py
+++ b/lib/fakeray/src/fakeray/util/scheduling_strategies.py
@@ -1,0 +1,43 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""``ray.util.scheduling_strategies`` shim.
+
+The strategies are accepted and reduced to the information the actor scheduler
+can actually use: a placement-group strategy carries the target bundle's
+resources (so ``.options(scheduling_strategy=...)`` can size the actor); a node-
+affinity strategy is accepted but best-effort (Iris picks the node).
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+
+class PlacementGroupSchedulingStrategy:
+    """Carries a bundle's resources to ``.options()`` (best-effort placement)."""
+
+    def __init__(
+        self,
+        placement_group: Any,
+        placement_group_bundle_index: int = -1,
+        placement_group_capture_child_tasks: bool | None = None,
+        **_ignored: Any,
+    ):
+        self.placement_group = placement_group
+        self.placement_group_bundle_index = placement_group_bundle_index
+        # `_bundle` is what _resources_from_options() reads.
+        idx = placement_group_bundle_index if placement_group_bundle_index >= 0 else 0
+        self._bundle = placement_group.bundle_resources(idx) if hasattr(placement_group, "bundle_resources") else {}
+
+
+class NodeAffinitySchedulingStrategy:
+    """Accepted for Ray-compat; node pinning is best-effort (Iris decides)."""
+
+    def __init__(self, node_id: str | None = None, soft: bool = True, **_ignored: Any):
+        self.node_id = node_id
+        self.soft = soft
+        self._bundle = None
+
+
+__all__ = ["NodeAffinitySchedulingStrategy", "PlacementGroupSchedulingStrategy"]

--- a/lib/fakeray/tests/test_actors_local.py
+++ b/lib/fakeray/tests/test_actors_local.py
@@ -92,6 +92,21 @@ def test_placement_group_and_scheduling_strategy():
     assert ray.get(h.go.remote()) == 1
 
 
+def test_kill_actor():
+    # ray.kill must tear down via the actor's backing group, not by resolving a
+    # remote "shutdown" method on the handle (which the Iris backend rejects).
+    @ray.remote
+    class A:
+        def ping(self):
+            return "pong"
+
+    h = A.options(name="killme").remote()
+    assert ray.get(h.ping.remote()) == "pong"
+    ray.kill(h)
+    with pytest.raises(ValueError):
+        ray.get_actor("killme")  # gone from the registry
+
+
 def test_actor_method_exception_propagates():
     @ray.remote
     class Boom:

--- a/lib/fakeray/tests/test_actors_local.py
+++ b/lib/fakeray/tests/test_actors_local.py
@@ -1,0 +1,103 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Actor + placement-group surface over Fray LocalClient.
+
+These cover the Ray features actor-heavy frameworks (e.g. SkyRL) need beyond the
+stateless-task surface: ``@ray.remote`` classes, actor-method calls, named-actor
+lookup, ``.options(num_gpus=, scheduling_strategy=)``, and the
+``ray.util.placement_group`` shim. Mirrors /tmp's SkyRL fail-fast probe.
+"""
+
+from __future__ import annotations
+
+import fakeray as ray
+import pytest
+from fakeray._scheduler import FakeRayConfig
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cluster():
+    ray.set_config(FakeRayConfig(pool_size=2))
+    ray.init()
+    yield
+    ray.shutdown()
+
+
+def test_function_remote_still_works():
+    @ray.remote
+    def f(x):
+        return x + 1
+
+    assert ray.get(f.remote(41)) == 42
+
+
+def test_stateful_actor_method_calls():
+    @ray.remote
+    class Counter:
+        def __init__(self):
+            self.n = 0
+
+        def add(self, x):
+            self.n += x
+            return self.n
+
+    h = Counter.remote()
+    assert ray.get(h.add.remote(5)) == 5
+    assert ray.get(h.add.remote(3)) == 8  # state persists across calls
+
+
+def test_actor_options_resources():
+    @ray.remote
+    class A:
+        def ping(self):
+            return "pong"
+
+    h = A.options(num_gpus=1, num_cpus=2).remote()
+    assert ray.get(h.ping.remote()) == "pong"
+
+
+def test_named_actor_lookup():
+    @ray.remote
+    class Info:
+        def who(self):
+            return "info"
+
+    Info.options(name="InfoActor").remote()
+    h = ray.get_actor("InfoActor")
+    assert ray.get(h.who.remote()) == "info"
+
+
+def test_get_actor_missing_raises():
+    with pytest.raises(ValueError, match="nope"):
+        ray.get_actor("nope")
+
+
+def test_placement_group_and_scheduling_strategy():
+    from ray.util.placement_group import placement_group
+    from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
+
+    pg = placement_group([{"CPU": 1}, {"CPU": 1}], strategy="PACK")
+    ray.get(pg.ready())
+
+    @ray.remote
+    class W:
+        def go(self):
+            return 1
+
+    # actor pinned to a bundle via the scheduling strategy (best-effort)
+    h = W.options(
+        scheduling_strategy=PlacementGroupSchedulingStrategy(placement_group=pg, placement_group_bundle_index=0)
+    ).remote()
+    assert ray.get(h.go.remote()) == 1
+
+
+def test_actor_method_exception_propagates():
+    @ray.remote
+    class Boom:
+        def explode(self):
+            raise ValueError("kaboom")
+
+    h = Boom.remote()
+    with pytest.raises(ValueError, match="kaboom"):
+        ray.get(h.explode.remote())

--- a/lib/fakeray/tests/test_scheduler_local.py
+++ b/lib/fakeray/tests/test_scheduler_local.py
@@ -1,0 +1,86 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Stage-1 tests: fakeray over Fray LocalClient, no smallpond, no Iris.
+
+Proves the Ray-compatible surface against a real DAG:
+- remote/get round-trip and auto-deref of ObjectRef args
+- a diamond DAG (A -> {B, C} -> D) executes in dependency order
+- put() refs are usable as deps
+- wait(timeout=0) is a non-blocking poll
+- a failing task propagates its exception to get() and to descendants
+"""
+
+from __future__ import annotations
+
+import fakeray as ray
+import pytest
+from fakeray._scheduler import FakeRayConfig
+
+
+@pytest.fixture(autouse=True)
+def _fresh_cluster():
+    ray.set_config(FakeRayConfig(pool_size=4))
+    ray.init()
+    yield
+    ray.shutdown()
+
+
+@ray.remote
+def add(a, b):
+    return a + b
+
+
+@ray.remote
+def inc(x):
+    return x + 1
+
+
+def test_remote_get_roundtrip():
+    assert ray.get(add.remote(2, 3)) == 5
+
+
+def test_auto_deref_of_dependency_refs():
+    a = inc.remote(10)  # 11
+    b = inc.remote(a)  # depends on a -> 12
+    assert ray.get(b) == 12
+
+
+def test_diamond_dag():
+    a = inc.remote(0)  # 1
+    b = add.remote(a, 10)  # 11
+    c = add.remote(a, 100)  # 101
+    d = add.remote(b, c)  # 112
+    assert ray.get(d) == 112
+
+
+def test_put_ref_as_dependency():
+    base = ray.put(41)
+    assert ray.get(inc.remote(base)) == 42
+
+
+def test_get_list_preserves_order():
+    refs = [inc.remote(i) for i in range(5)]
+    assert ray.get(refs) == [1, 2, 3, 4, 5]
+
+
+def test_wait_nonblocking_poll():
+    ready, not_ready = ray.wait([inc.remote(1)], num_returns=1, timeout=0)
+    assert len(ready) + len(not_ready) == 1
+
+
+@ray.remote
+def boom(_x):
+    raise ValueError("kaboom")
+
+
+def test_failure_propagates_to_get():
+    with pytest.raises(ValueError, match="kaboom"):
+        ray.get(boom.remote(1))
+
+
+def test_failure_poisons_descendants():
+    bad = boom.remote(1)
+    downstream = inc.remote(bad)  # never runnable; must not hang
+    with pytest.raises(ValueError, match="kaboom"):
+        ray.get(downstream, timeout=10)

--- a/lib/fakeray/tests/test_scheduler_local.py
+++ b/lib/fakeray/tests/test_scheduler_local.py
@@ -13,6 +13,8 @@ Proves the Ray-compatible surface against a real DAG:
 
 from __future__ import annotations
 
+import os
+
 import fakeray as ray
 import pytest
 from fakeray._scheduler import FakeRayConfig
@@ -84,3 +86,38 @@ def test_failure_poisons_descendants():
     downstream = inc.remote(bad)  # never runnable; must not hang
     with pytest.raises(ValueError, match="kaboom"):
         ray.get(downstream, timeout=10)
+
+
+# Simulate an actor that dies (raises) the first few calls then recovers — i.e.
+# preemption + Fray restart. The attempt counter must live OUTSIDE the pickled
+# function (a module global is captured by-value through cloudpickle and would
+# reset every dispatch), so we count via an on-disk file the remote fn updates.
+def flaky_via_file(x, counter_path, fail_times):
+    n = 0
+    if os.path.exists(counter_path):
+        with open(counter_path) as f:
+            n = int(f.read() or "0")
+    n += 1
+    with open(counter_path, "w") as f:
+        f.write(str(n))
+    if n <= fail_times:
+        raise RuntimeError(f"simulated preemption #{n}")
+    return x * 10
+
+
+def test_redispatch_recovers_from_transient_failure(tmp_path):
+    """A task whose first attempts fail is re-dispatched and eventually succeeds."""
+    counter = str(tmp_path / "attempts")
+    # default max_task_retries=3 → up to 4 attempts; fail 2, succeed on the 3rd.
+    fn = ray.remote(flaky_via_file)
+    assert ray.get(fn.remote(5, counter, 2), timeout=30) == 50
+    with open(counter) as f:
+        assert int(f.read()) == 3
+
+
+def test_redispatch_gives_up_after_max_retries(tmp_path):
+    """A persistently failing task settles as failed once retries are exhausted."""
+    counter = str(tmp_path / "attempts")
+    fn = ray.remote(flaky_via_file)
+    with pytest.raises(RuntimeError, match="simulated preemption"):
+        ray.get(fn.remote(5, counter, 999), timeout=30)


### PR DESCRIPTION
* `lib/fakeray`: a drop-in shim for the Ray Core API, dispatching to **Fray actors / tasks** instead of a real Ray cluster — so Ray-based tools run on Iris
* covers two tiers
  * **stateless tasks** (smallpond): `@ray.remote` def, `ObjectRef`, `get`/`wait`/`put`
  * **stateful actors** (SkyRL-class frameworks): `@ray.remote` class, `handle.method.remote()`, named actors, placement groups
* `ObjectRef` = a driver-local `concurrent.futures.Future`; no distributed object store [^1]
* ready-queue scheduler dispatches ready task nodes to one worker thread per actor slot, blocking only on `ActorFuture.result()` (portable across the Fray local and Iris backends); auto-derefs `ObjectRef` args and propagates failures to descendants
* `@ray.remote` detects class vs function — class → `ActorClass` (`.remote()`/`.options()` → fray `create_actor` → `ActorHandle`; `handle.method.remote()` adapts the fray `ActorFuture` into an `ObjectRef`); function → `RemoteFunction` (unchanged)
* `.options(num_gpus=/num_cpus=/memory=/scheduling_strategy=)` → fray `ResourceConfig`; `ray.get_actor`/`kill`/`cancel`
* `ray.util.placement_group` + `ray.util.scheduling_strategies` shims — **best-effort** [^2]
* pool can run on CPU or (preemptible) TPU host VMs (`FakeRayConfig.device`); scheduler **re-dispatches a task whose actor died** (preemption) up to `max_task_retries` — safe because smallpond tasks are idempotent
* exposed as `ray` two ways: `fakeray.install()` (swaps `sys.modules["ray"]`, also registers `ray.exceptions` + `ray.util.*`) and a sibling `ray`-named distribution (`ray-shim/`) for uv `override-dependencies`
* tested (17 unit tests, Fray `LocalClient`)
  * tasks: diamond DAG, auto-deref, `put`-deps, `wait`, failure propagation + descendant poisoning, re-dispatch recover/give-up
  * actors: stateful method calls, `.options` resources, named-actor lookup + missing-raises, placement_group + scheduling strategy, actor-method exception propagation
  * the 5 real SkyRL idioms that failed a fail-fast probe (actor class, `placement_group(strategy=PACK)`, `.options(num_gpus=, placement_group=)`, `get_actor`) are now all green
* end-to-end on the marin cluster: smallpond repartition+aggregate over real parquet in `europe-west4`, non-preemptible root + 4-actor preemptible `v6e-4` pool across 4 workers (`/rav/sp-bigjob` SUCCEEDED), output to `gs://`
* not wired into the root uv workspace yet (deliberate while it's a sketch); draft for early review

[^1]: works because the values smallpond passes between tasks are `DataSet` path descriptors (parquet paths), not bulk data — the data lives on the shared filesystem / `gs://` and never traverses the ref
[^2]: bundles are **captured** (right number/size of GPU actors) but scheduled independently by Iris — **no** PACK/SPREAD locality, atomic gang bring-up, or fractional-GPU colocation; GPU collectives (NCCL weight broadcast) are out of scope. running an actor-heavy framework like SkyRL also needs its own bundle/packaging work — this PR only makes the Ray *surface* resolve. see `.agents/projects/20260602_fray_ray_actors_pg_design.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)