### PR TITLE
levanter: add missing @classmethod to Gemma3Config.from_hf_config

### DIFF
--- a/lib/levanter/src/levanter/models/gemma.py
+++ b/lib/levanter/src/levanter/models/gemma.py
@@ -868,6 +868,7 @@ class Gemma3Config(Gemma2Config):
         )
         return cfg
 
+    @classmethod
     def from_hf_config(cls, hf_config: HfConfig) -> "Gemma3Config":  # type: ignore[override]
         """Create a :class:`Gemma3Config` from a HuggingFace configuration."""
         if hf_config.hidden_activation is None:

--- a/lib/levanter/tests/test_gemma.py
+++ b/lib/levanter/tests/test_gemma.py
@@ -498,6 +498,34 @@ def test_gemma3_decoder_layer(num_kv_heads):
     chex.assert_trees_all_close(hf_out[0].detach().cpu().numpy(), lev_out.array, rtol=1e-4, atol=1e-4)
 
 
+def test_gemma3_config_from_hf_config_roundtrip():
+    """Regression: ``Gemma3Config.from_hf_config`` must be callable on the
+    class. Previously the override was missing ``@classmethod``, so calling
+    ``Gemma3Config.from_hf_config(hf_config)`` bound ``hf_config`` to ``cls``
+    and raised ``TypeError: from_hf_config() missing 1 required positional
+    argument: 'hf_config'``. The parent ``Gemma2Config.from_hf_config`` and
+    ``GemmaConfig.from_hf_config`` are already classmethods.
+    """
+    cfg = Gemma3Config(
+        max_seq_len=128,
+        hidden_dim=16,
+        num_heads=4,
+        num_kv_heads=4,
+        gradient_checkpointing=False,
+        head_dim=4,
+        query_pre_attn_scalar=4,
+        num_layers=2,
+    )
+    hf_config = cfg.to_hf_config(1000)
+    roundtripped = Gemma3Config.from_hf_config(hf_config)
+
+    assert isinstance(roundtripped, Gemma3Config)
+    assert roundtripped.hidden_dim == cfg.hidden_dim
+    assert roundtripped.num_layers == cfg.num_layers
+    assert roundtripped.num_heads == cfg.num_heads
+    assert roundtripped.num_kv_heads == cfg.num_kv_heads
+
+
 @skip_if_hf_model_not_accessible("google/gemma-3-1b-pt")
 @skip_if_no_torch
 def test_gemma3_roundtrip():


### PR DESCRIPTION
## Summary

`Gemma3Config.from_hf_config` (`lib/levanter/src/levanter/models/gemma.py:871`) overrides the inherited classmethod from `Gemma2Config`/`GemmaConfig`, but the override is missing the `@classmethod` decorator. The first parameter is named `cls` and the line carries a `# type: ignore[override]` comment — both confirming the author intended a classmethod override.

Because the override resolves to a plain function on the class, calling

```python
Gemma3Config.from_hf_config(hf_config)
```

binds `hf_config` to `cls` and crashes:

```
TypeError: from_hf_config() missing 1 required positional argument: 'hf_config'
```

`GemmaConfig.from_hf_config` (line 138) and `Gemma2Config.from_hf_config` (line 544) are both correctly decorated. The fix is a one-line addition.

This path is reachable from the HF compat layer (`HFCheckpointConverter.load_pretrained` → `config_from_hf_checkpoint` → `LevConfigClass.from_hf_config(hf_config)` at `lib/levanter/src/levanter/compat/hf_checkpoints.py:612`).

## Test

Adds `test_gemma3_config_from_hf_config_roundtrip` next to the existing `test_gemma3_roundtrip`. It constructs a small `Gemma3Config`, converts it to an HF config, and round-trips through `from_hf_config`. Unlike the existing test, it doesn't need torch or HF model access (no `@skip_if_no_torch` / `@skip_if_hf_model_not_accessible` gating), so it actually runs in default CI.

On `main` it fails with the `TypeError` above before reaching any assertion; with this change it passes and verifies basic field round-trip.

## Notes

No related open PRs (`gh pr list --search "gemma3 OR Gemma3Config"`). No test currently pins the buggy behavior.

🤖 This PR was prepared with AI assistance (Claude). Per the repository's `AGENTS.md`, the `agent-generated` label is requested but I don't have repo permissions to apply it — please add if appropriate. I (the human submitter) reviewed every changed line and confirmed the failure mode on a minimal stand-in: a regular `def f(cls, x)` overriding a parent `@classmethod` reproduces the exact `TypeError` when called as `Class.f(obj)`.