### PR TITLE
[iris] Rate-limit TPU CreateNode globally across scale groups

### DIFF
--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -108,12 +108,11 @@ class AvailabilityState:
 DEFAULT_SCALE_UP_RATE_LIMIT = 16  # per minute
 DEFAULT_SCALE_DOWN_RATE_LIMIT = 32  # per minute
 
-# GCP's TPU Admin API permits 91 CreateNode requests/min/project. Cap autoscaler
+# GCP's TPU Admin API permits 91 CreateNode requests/min/project; cap autoscaler
 # launches below that so manual create-slice and controller VM provisioning,
 # which share the same quota, retain headroom. A single bucket is shared across
 # all scale groups; per-group buckets only bound one group, so this is the only
 # limiter that bounds the aggregate CreateNode rate.
-CREATE_NODE_QUOTA_PER_MINUTE = 91
 DEFAULT_CREATE_RATE_LIMIT_PER_MINUTE = 80
 DEFAULT_IDLE_THRESHOLD = Duration.from_minutes(10)
 DEFAULT_QUOTA_TIMEOUT = Duration.from_minutes(5)

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -109,11 +109,10 @@ DEFAULT_SCALE_UP_RATE_LIMIT = 16  # per minute
 DEFAULT_SCALE_DOWN_RATE_LIMIT = 32  # per minute
 
 # GCP's TPU Admin API permits 91 CreateNode requests/min/project; cap autoscaler
-# launches below that so manual create-slice and controller VM provisioning,
-# which share the same quota, retain headroom. A single bucket is shared across
-# all scale groups; per-group buckets only bound one group, so this is the only
-# limiter that bounds the aggregate CreateNode rate.
-DEFAULT_CREATE_RATE_LIMIT_PER_MINUTE = 80
+# launches at that rate. A single bucket is shared across all scale groups;
+# per-group buckets only bound one group, so this is the only limiter that
+# bounds the aggregate CreateNode rate.
+DEFAULT_CREATE_RATE_LIMIT_PER_MINUTE = 91
 DEFAULT_IDLE_THRESHOLD = Duration.from_minutes(10)
 DEFAULT_QUOTA_TIMEOUT = Duration.from_minutes(5)
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -107,6 +107,14 @@ class AvailabilityState:
 
 DEFAULT_SCALE_UP_RATE_LIMIT = 16  # per minute
 DEFAULT_SCALE_DOWN_RATE_LIMIT = 32  # per minute
+
+# GCP's TPU Admin API permits 91 CreateNode requests/min/project. Cap autoscaler
+# launches below that so manual create-slice and controller VM provisioning,
+# which share the same quota, retain headroom. A single bucket is shared across
+# all scale groups; per-group buckets only bound one group, so this is the only
+# limiter that bounds the aggregate CreateNode rate.
+CREATE_NODE_QUOTA_PER_MINUTE = 91
+DEFAULT_CREATE_RATE_LIMIT_PER_MINUTE = 80
 DEFAULT_IDLE_THRESHOLD = Duration.from_minutes(10)
 DEFAULT_QUOTA_TIMEOUT = Duration.from_minutes(5)
 
@@ -311,6 +319,7 @@ class ScalingGroup:
         scale_up_rate_limit: int = DEFAULT_SCALE_UP_RATE_LIMIT,
         scale_down_rate_limit: int = DEFAULT_SCALE_DOWN_RATE_LIMIT,
         short_lived_threshold: Duration = DEFAULT_SHORT_LIVED_THRESHOLD,
+        create_limiter: TokenBucket | None = None,
         detector: BackoffDetector | None = None,
         db: ControllerDB | None = None,
     ):
@@ -350,6 +359,11 @@ class ScalingGroup:
 
         # Scale-down rate limiter, owned by the group (not health-modulated).
         self._scale_down_bucket = TokenBucket(capacity=scale_down_rate_limit, refill_period=Duration.from_minutes(1))
+
+        # Global slice-create limiter, shared across all groups by the autoscaler
+        # so the aggregate CreateNode rate stays within the cloud API quota. None
+        # disables the global cap (e.g. LOCAL mode, isolated unit tests).
+        self._create_limiter = create_limiter
 
         # Upsert scaling group row so it exists for future updates
         if self._db is not None:
@@ -986,8 +1000,19 @@ class ScalingGroup:
         return True
 
     def try_acquire_scale_up(self, timestamp: Timestamp | None = None) -> bool:
-        """Acquire a scale-up token from the detector's health-modulated bucket."""
-        return self._detector.try_acquire_scale_up(timestamp or Timestamp.now())
+        """Acquire a scale-up token from the detector's health-modulated bucket.
+
+        Also consumes a token from the shared global create limiter when one is
+        attached, so a single call answers both the per-group and global caps.
+        The global token is taken after the per-group one, so a saturated global
+        budget never burns a per-group token on a launch that won't happen.
+        """
+        timestamp = timestamp or Timestamp.now()
+        if not self._detector.try_acquire_scale_up(timestamp):
+            return False
+        if self._create_limiter is not None and not self._create_limiter.try_acquire(now=timestamp):
+            return False
+        return True
 
     def acquire_scale_down_token(self, timestamp: Timestamp | None = None) -> bool:
         """Try to acquire a scale-down rate limit token. Returns False if rate-limited."""

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -1002,8 +1002,8 @@ class ScalingGroup:
 
         Also consumes a token from the shared global create limiter when one is
         attached, so a single call answers both the per-group and global caps.
-        The global token is taken after the per-group one, so a saturated global
-        budget never burns a per-group token on a launch that won't happen.
+        The per-group token is taken first, so a group already at its regional
+        rate limit never burns a global token on a launch that won't happen.
         """
         timestamp = timestamp or Timestamp.now()
         if not self._detector.try_acquire_scale_up(timestamp):

--- a/lib/iris/src/iris/cluster/controller/autoscaler_factory.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler_factory.py
@@ -13,6 +13,8 @@ from __future__ import annotations
 
 import logging
 
+from rigging.timing import Duration, TokenBucket
+
 from iris.cluster.config import (
     _scale_groups_to_config,
     _validate_autoscaler_config,
@@ -20,6 +22,7 @@ from iris.cluster.config import (
 )
 from iris.cluster.controller.autoscaler import Autoscaler
 from iris.cluster.controller.autoscaler.scaling_group import (
+    DEFAULT_CREATE_RATE_LIMIT_PER_MINUTE,
     DEFAULT_SCALE_DOWN_RATE_LIMIT,
     DEFAULT_SCALE_UP_RATE_LIMIT,
     ScalingGroup,
@@ -67,6 +70,11 @@ def create_autoscaler(
 
     scale_down_delay = duration_from_proto(autoscaler_config.scale_down_delay)
 
+    # One global create limiter shared across every group bounds the aggregate
+    # CreateNode rate against the cloud API quota; per-group buckets only bound
+    # a single group.
+    create_limiter = TokenBucket(capacity=DEFAULT_CREATE_RATE_LIMIT_PER_MINUTE, refill_period=Duration.from_minutes(1))
+
     scaling_groups: dict[str, ScalingGroup] = {}
     for name, group_config in scale_groups.items():
         scaling_groups[name] = ScalingGroup(
@@ -76,6 +84,7 @@ def create_autoscaler(
             idle_threshold=scale_down_delay,
             scale_up_rate_limit=group_config.scale_up_rate_limit or DEFAULT_SCALE_UP_RATE_LIMIT,
             scale_down_rate_limit=group_config.scale_down_rate_limit or DEFAULT_SCALE_DOWN_RATE_LIMIT,
+            create_limiter=create_limiter,
             db=db,
         )
         resources = group_config.resources

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -28,7 +28,7 @@ from iris.cluster.providers.types import (
 from iris.cluster.types import WorkerStatus
 from iris.rpc import config_pb2, vm_pb2
 from iris.time_proto import duration_to_proto
-from rigging.timing import Duration, Timestamp
+from rigging.timing import Duration, Timestamp, TokenBucket
 
 from tests.cluster.providers.conftest import (
     FakeSliceHandle,
@@ -455,6 +455,30 @@ class TestAutoscalerExecution:
         autoscaler.execute(decisions, timestamp=Timestamp.from_ms(1000))
 
         assert group.slice_count() == 0
+
+    def test_global_create_rate_limit_defers_excess_launches(self):
+        """A saturated global create limiter defers launches beyond its capacity.
+
+        Each group's own scale-up bucket has headroom, so only the shared global
+        cap (1/min here) bounds the cycle: one launch proceeds, the rest defer.
+        """
+        create_limiter = TokenBucket(capacity=1, refill_period=Duration.from_minutes(1))
+        groups = {
+            f"group-{i}": ScalingGroup(
+                make_scale_group_config(name=f"group-{i}", buffer_slices=0, max_slices=5),
+                make_mock_platform(),
+                create_limiter=create_limiter,
+            )
+            for i in range(3)
+        }
+        autoscaler = make_autoscaler(groups)
+
+        decisions = [ScalingDecision(scale_group=name, action=ScalingAction.SCALE_UP, reason="test") for name in groups]
+        autoscaler.execute(decisions, timestamp=Timestamp.from_ms(1000))
+        autoscaler._wait_for_inflight()
+
+        assert sum(group.slice_count() for group in groups.values()) == 1
+        autoscaler.shutdown()
 
 
 class TestAutoscalerWorkerFailure:


### PR DESCRIPTION
Add a shared token-bucket limiter set to GCP's 91 CreateNode/min project quota, consulted in ScalingGroup.try_acquire_scale_up so the autoscaler's aggregate node-create rate stays within quota. Per-group scale-up buckets only bound a single group, letting many groups burst past the quota on cold start. The limiter is created once in create_autoscaler and shared across all groups. Adds a regression test.