### PR TITLE
[zephyr] Fix slow test annotation

### DIFF
--- a/lib/zephyr/pyproject.toml
+++ b/lib/zephyr/pyproject.toml
@@ -51,3 +51,7 @@ log_level = "INFO"
 log_format = "%(asctime)s %(levelname)s %(message)s"
 log_date_format = "%Y-%m-%d %H:%M:%S"
 log_cli_level = "INFO"
+markers = [
+    "slow: marks tests as slow (deselect with '-m \"not slow\"')",
+]
+addopts = "-m 'not slow'"


### PR DESCRIPTION
I incorrectly assumed this was inherited from the top-level `pyproject.toml` in https://github.com/marin-community/marin/pull/5857
