### PR TITLE
[levanter] Generalize paged attention config choices

### DIFF
--- a/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
+++ b/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
@@ -1,13 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Benchmark Qwen3 8B decode-heavy TPU inference against vLLM TPU.
-
-This is the phase-1 parity harness from
-`.agents/projects/levanter_tpu_inference_parity/design.md`. It intentionally
-uses the OpenAI completions endpoint for both engines so the first signal is
-decode throughput rather than chat-template rendering.
-"""
+"""Benchmark Qwen3 8B decode-heavy TPU inference against vLLM TPU."""
 
 from __future__ import annotations
 
@@ -43,7 +37,14 @@ from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.inference.engine import InferenceEngineConfig, Request
 from levanter.inference.jit_scheduler import SeqDecodingParams, SequenceTable
 from levanter.inference.page_table import PageTable
-from levanter.inference.tpu_kernels import TpuPagedAttentionBackend, TpuPagedAttentionConfig
+from levanter.inference.tpu_kernels import (
+    AutoPagedAttentionConfig,
+    JaxRpaPagedAttentionConfig,
+    PagedAttentionConfig,
+    ReferencePagedAttentionConfig,
+    TpuInferencePagedAttentionConfig,
+    paged_attention_config_name,
+)
 from levanter.layers.attention import AttentionMask
 from levanter.layers.sampler import SamplerTopKMode
 from levanter.models.qwen import Qwen3Config, Qwen3LMHeadModel
@@ -73,6 +74,8 @@ REFERENCE_LOGIT_ARTIFACT_MD = "levanter_reference_logits.md"
 REFERENCE_LOGIT_TOP_KS = (1, 10, 100, 1000, 4096)
 REFERENCE_LOGIT_HISTOGRAM_BOUNDS = (0.0, 1e-4, 3e-4, 1e-3, 3e-3, 1e-2, 3e-2, 1e-1, 3e-1, 1.0)
 REFERENCE_LOGIT_CACHE_DTYPE_POLICIES = ("auto", "default", "bfloat16", "float32")
+PAGED_ATTENTION_CHOICES = ("auto", "tpu-inference", "jax-rpa", "reference")
+CONCRETE_PAGED_ATTENTION_CHOICES = ("tpu-inference", "jax-rpa", "reference")
 
 
 @dataclass(frozen=True, slots=True)
@@ -118,7 +121,7 @@ class ServerHandle:
     name: str
     base_url: str
     model_id: str
-    close: Any
+    close: Callable[[], None]
     command: list[str] | None = None
     hbm_used_bytes: int | None = None
     compiled_shape_count: int | None = None
@@ -455,24 +458,19 @@ def _single_token_direct_attention_hidden(
     return model.transformer.norm(x)
 
 
-def _reference_logit_cache_dtype(tpu_paged_attention: TpuPagedAttentionConfig, default_dtype: jnp.dtype) -> jnp.dtype:
-    backend = tpu_paged_attention.backend
-    if isinstance(backend, TpuPagedAttentionBackend | str):
-        backends = (TpuPagedAttentionBackend(backend),)
-    else:
-        backends = tuple(TpuPagedAttentionBackend(item) for item in backend)
-    if TpuPagedAttentionBackend.AUTO in backends or TpuPagedAttentionBackend.TPU_INFERENCE in backends:
+def _reference_logit_cache_dtype(paged_attention: PagedAttentionConfig, default_dtype: jnp.dtype) -> jnp.dtype:
+    if isinstance(paged_attention, AutoPagedAttentionConfig | TpuInferencePagedAttentionConfig):
         return jnp.bfloat16
     return default_dtype
 
 
 def _reference_logit_cache_dtype_for_policy(
-    tpu_paged_attention: TpuPagedAttentionConfig,
+    paged_attention: PagedAttentionConfig,
     default_dtype: jnp.dtype,
     policy: str,
 ) -> jnp.dtype:
     if policy == "auto":
-        return _reference_logit_cache_dtype(tpu_paged_attention, default_dtype)
+        return _reference_logit_cache_dtype(paged_attention, default_dtype)
     if policy == "default":
         return default_dtype
     if policy == "bfloat16":
@@ -482,17 +480,59 @@ def _reference_logit_cache_dtype_for_policy(
     raise ValueError(f"Unknown reference-logit cache dtype policy: {policy}")
 
 
+def _paged_attention_config_from_choice(
+    choice: str,
+    *,
+    fail_on_reference_fallback: bool,
+    tpu_inference_out_dtype: str | None,
+    preserve_attention_output_dtype: bool,
+    rpa_num_kv_pages_per_block: int | None,
+    rpa_num_queries_per_block: int | None,
+    rpa_vmem_limit_bytes: int | None,
+) -> PagedAttentionConfig:
+    if choice == "auto":
+        return AutoPagedAttentionConfig(fail_on_reference_fallback=fail_on_reference_fallback)
+    if choice == "reference":
+        return ReferencePagedAttentionConfig(fail_on_reference_fallback=fail_on_reference_fallback)
+    if choice == "tpu-inference":
+        return TpuInferencePagedAttentionConfig(
+            fail_on_reference_fallback=fail_on_reference_fallback,
+            out_dtype=tpu_inference_out_dtype,
+            preserve_attention_output_dtype=preserve_attention_output_dtype,
+        )
+    if choice == "jax-rpa":
+        return JaxRpaPagedAttentionConfig(
+            fail_on_reference_fallback=fail_on_reference_fallback,
+            num_kv_pages_per_block=rpa_num_kv_pages_per_block,
+            num_queries_per_block=rpa_num_queries_per_block,
+            vmem_limit_bytes=rpa_vmem_limit_bytes,
+        )
+    raise ValueError(f"Unknown paged attention choice: {choice}")
+
+
 def _reference_logit_backend_config(
-    backend: TpuPagedAttentionBackend | str,
-    base_config: TpuPagedAttentionConfig,
-) -> TpuPagedAttentionConfig:
-    backend = TpuPagedAttentionBackend(backend)
-    return TpuPagedAttentionConfig(
-        backend=backend,
-        fail_on_reference_fallback=backend != TpuPagedAttentionBackend.REFERENCE,
-        tpu_inference_out_dtype=base_config.tpu_inference_out_dtype,
-        preserve_attention_output_dtype=base_config.preserve_attention_output_dtype,
-    )
+    choice: str,
+    base_config: PagedAttentionConfig,
+) -> PagedAttentionConfig:
+    if choice == "reference":
+        return ReferencePagedAttentionConfig(fail_on_reference_fallback=False)
+    if choice == "tpu-inference":
+        return TpuInferencePagedAttentionConfig(
+            out_dtype=base_config.out_dtype if isinstance(base_config, TpuInferencePagedAttentionConfig) else None,
+            preserve_attention_output_dtype=(
+                isinstance(base_config, TpuInferencePagedAttentionConfig)
+                and base_config.preserve_attention_output_dtype
+            ),
+        )
+    if choice == "jax-rpa":
+        if isinstance(base_config, JaxRpaPagedAttentionConfig):
+            return JaxRpaPagedAttentionConfig(
+                num_kv_pages_per_block=base_config.num_kv_pages_per_block,
+                num_queries_per_block=base_config.num_queries_per_block,
+                vmem_limit_bytes=base_config.vmem_limit_bytes,
+            )
+        return JaxRpaPagedAttentionConfig()
+    raise ValueError(f"Unknown reference-logit paged attention choice: {choice}")
 
 
 def check_levanter_reference_logits(
@@ -502,8 +542,8 @@ def check_levanter_reference_logits(
     tokenizer: Any,
     cases: list[BenchmarkCase],
     prompts: dict[str, tuple[str, int]],
-    tpu_paged_attention: TpuPagedAttentionConfig,
-    decode_backends: list[TpuPagedAttentionBackend] | None,
+    paged_attention: PagedAttentionConfig,
+    decode_backends: list[str] | None,
     cache_dtype_policies: list[str],
     default_cache_dtype: jnp.dtype,
     max_model_len: int,
@@ -517,11 +557,10 @@ def check_levanter_reference_logits(
     results: list[ReferenceLogitCheckResult] = []
     max_pages_per_seq = (max_model_len + 127) // 128
     if decode_backends is None:
-        backend_configs = [("configured", tpu_paged_attention)]
+        backend_configs = [("configured", paged_attention)]
     else:
         backend_configs = [
-            (backend.value, _reference_logit_backend_config(backend, tpu_paged_attention))
-            for backend in decode_backends
+            (backend, _reference_logit_backend_config(backend, paged_attention)) for backend in decode_backends
         ]
 
     with trainer.use_device_mesh(), hax.axis_mapping(trainer.compute_axis_mapping):
@@ -583,7 +622,7 @@ def check_levanter_reference_logits(
                         kv_cache,
                         batch_info,
                         pos_ids,
-                        tpu_paged_attention=backend_config,
+                        paged_attention=backend_config,
                     )
                     decode_logits = model.lm_head_logits(decode_hidden)
 
@@ -621,8 +660,15 @@ def check_levanter_reference_logits(
                             decode_hidden_dtype=hidden_metrics["candidate_dtype"],
                             reference_logits_dtype=error_metrics["reference_logits_dtype"],
                             decode_logits_dtype=error_metrics["decode_logits_dtype"],
-                            tpu_inference_out_dtype=backend_config.tpu_inference_out_dtype,
-                            preserve_attention_output_dtype=backend_config.preserve_attention_output_dtype,
+                            tpu_inference_out_dtype=(
+                                backend_config.out_dtype
+                                if isinstance(backend_config, TpuInferencePagedAttentionConfig)
+                                else None
+                            ),
+                            preserve_attention_output_dtype=(
+                                isinstance(backend_config, TpuInferencePagedAttentionConfig)
+                                and backend_config.preserve_attention_output_dtype
+                            ),
                             positions=len(prompt_token_ids),
                             vocab_size=reference_logits.axis_size("vocab"),
                             hidden_max_abs_error=hidden_metrics["max_abs_error"],
@@ -1194,15 +1240,9 @@ def start_levanter_server(
     max_top_k: int | None,
     tensor_parallel_size: int,
     hbm_utilization: float,
-    rpa_num_kv_pages_per_block: int | None,
-    rpa_num_queries_per_block: int | None,
-    rpa_vmem_limit_bytes: int | None,
-    tpu_paged_attention_backend: TpuPagedAttentionBackend,
-    allow_reference_fallback: bool,
+    paged_attention: PagedAttentionConfig,
     compute_dtype: str,
     trainer_mp_policy: str,
-    tpu_inference_out_dtype: str | None,
-    preserve_attention_output_dtype: bool,
     sampler_top_k_mode: SamplerTopKMode,
     use_streaming_greedy_lm_head: bool,
     batch_timeout: float,
@@ -1214,7 +1254,7 @@ def start_levanter_server(
     reference_logit_atol: float,
     reference_logit_rtol: float,
     reference_logit_max_prompts: int | None,
-    reference_logit_decode_backends: list[TpuPagedAttentionBackend] | None,
+    reference_logit_decode_backends: list[str] | None,
     reference_logit_cache_dtype_policies: list[str],
     reference_logit_only: bool,
 ) -> ServerHandle:
@@ -1239,12 +1279,7 @@ def start_levanter_server(
         sampler_top_k_mode=sampler_top_k_mode,
         max_seqs_in_prefill=max_seqs,
         max_prefill_size=max_prefill_size,
-        tpu_paged_attention=TpuPagedAttentionConfig(
-            backend=tpu_paged_attention_backend,
-            fail_on_reference_fallback=not allow_reference_fallback,
-            tpu_inference_out_dtype=tpu_inference_out_dtype,
-            preserve_attention_output_dtype=preserve_attention_output_dtype,
-        ),
+        paged_attention=paged_attention,
         use_streaming_greedy_lm_head=use_streaming_greedy_lm_head,
     )
     server_config = InferenceServerConfig(
@@ -1267,12 +1302,6 @@ def start_levanter_server(
             trust_remote_code=True,
         )
         model_config = converter.config_from_hf_checkpoint(ref=checkpoint)
-        model_config = dataclasses.replace(
-            model_config,
-            rpa_num_kv_pages_per_block=rpa_num_kv_pages_per_block,
-            rpa_num_queries_per_block=rpa_num_queries_per_block,
-            rpa_vmem_limit_bytes=rpa_vmem_limit_bytes,
-        )
         model_obj = converter.load_pretrained(
             Qwen3LMHeadModel,
             ref=checkpoint,
@@ -1294,7 +1323,7 @@ def start_levanter_server(
             tokenizer=tokenizer,
             cases=reference_logit_check_cases,
             prompts=reference_logit_check_prompts,
-            tpu_paged_attention=service_config.tpu_paged_attention,
+            paged_attention=service_config.paged_attention,
             decode_backends=reference_logit_decode_backends,
             cache_dtype_policies=reference_logit_cache_dtype_policies,
             default_cache_dtype=service_compute_dtype,
@@ -1314,7 +1343,7 @@ def start_levanter_server(
             logger.info("Benchmark reference-logit-only artifacts:")
             log_output_artifacts(reference_logit_check_dir)
             return ServerHandle(
-                name=f"levanter:{tpu_paged_attention_backend.value}:reference_logit_only",
+                name=f"levanter:{paged_attention_config_name(paged_attention)}:reference_logit_only",
                 base_url=f"http://127.0.0.1:{port}/v1",
                 model_id=model,
                 close=lambda: None,
@@ -1345,8 +1374,9 @@ def start_levanter_server(
         close()
         raise
 
-    diagnostic_backend_name = f"levanter:{tpu_paged_attention_backend.value}:no_lm_head"
-    lm_head_no_sampling_backend_name = f"levanter:{tpu_paged_attention_backend.value}:lm_head_no_sampling"
+    paged_attention_name = paged_attention_config_name(paged_attention)
+    diagnostic_backend_name = f"levanter:{paged_attention_name}:no_lm_head"
+    lm_head_no_sampling_backend_name = f"levanter:{paged_attention_name}:lm_head_no_sampling"
 
     def diagnose_without_lm_head(
         case: BenchmarkCase,
@@ -1406,7 +1436,7 @@ def start_levanter_server(
 
     logger.info("Started Levanter server at %s", base_url)
     return ServerHandle(
-        f"levanter:{tpu_paged_attention_backend.value}",
+        f"levanter:{paged_attention_name}",
         base_url,
         "levanter",
         close,
@@ -1757,6 +1787,15 @@ def start_backend(
             log_dir=output_dir / "vllm_profiles",
         )
     if backend == "levanter":
+        paged_attention = _paged_attention_config_from_choice(
+            args.levanter_paged_attention,
+            fail_on_reference_fallback=not args.levanter_allow_reference_fallback,
+            tpu_inference_out_dtype=args.levanter_tpu_inference_out_dtype,
+            preserve_attention_output_dtype=args.levanter_preserve_attention_output_dtype,
+            rpa_num_kv_pages_per_block=args.rpa_num_kv_pages_per_block,
+            rpa_num_queries_per_block=args.rpa_num_queries_per_block,
+            rpa_vmem_limit_bytes=args.rpa_vmem_limit_bytes,
+        )
         return start_levanter_server(
             model=args.model,
             checkpoint=checkpoint,
@@ -1772,15 +1811,9 @@ def start_backend(
             max_top_k=args.top_k,
             tensor_parallel_size=args.tensor_parallel_size,
             hbm_utilization=args.hbm_utilization,
-            rpa_num_kv_pages_per_block=args.rpa_num_kv_pages_per_block,
-            rpa_num_queries_per_block=args.rpa_num_queries_per_block,
-            rpa_vmem_limit_bytes=args.rpa_vmem_limit_bytes,
-            tpu_paged_attention_backend=TpuPagedAttentionBackend(args.levanter_tpu_paged_attention_backend),
-            allow_reference_fallback=args.levanter_allow_reference_fallback,
+            paged_attention=paged_attention,
             compute_dtype=args.levanter_compute_dtype,
             trainer_mp_policy=args.levanter_trainer_mp,
-            tpu_inference_out_dtype=args.levanter_tpu_inference_out_dtype,
-            preserve_attention_output_dtype=args.levanter_preserve_attention_output_dtype,
             sampler_top_k_mode=SamplerTopKMode(args.levanter_sampler_top_k_mode),
             use_streaming_greedy_lm_head=args.levanter_streaming_greedy_lm_head,
             batch_timeout=args.batch_timeout,
@@ -1793,9 +1826,7 @@ def start_backend(
             reference_logit_rtol=args.reference_logit_rtol,
             reference_logit_max_prompts=args.reference_logit_max_prompts,
             reference_logit_decode_backends=(
-                [TpuPagedAttentionBackend(backend) for backend in args.reference_logit_decode_backend]
-                if args.reference_logit_decode_backend
-                else None
+                list(args.reference_logit_decode_backend) if args.reference_logit_decode_backend else None
             ),
             reference_logit_cache_dtype_policies=args.reference_logit_cache_dtype,
             reference_logit_only=args.reference_logit_only,
@@ -1966,10 +1997,10 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("--rpa-num-queries-per-block", type=int, default=None)
     parser.add_argument("--rpa-vmem-limit-bytes", type=int, default=None)
     parser.add_argument(
-        "--levanter-tpu-paged-attention-backend",
-        choices=[backend.value for backend in TpuPagedAttentionBackend],
-        default=TpuPagedAttentionBackend.AUTO.value,
-        help="Paged attention backend used by Levanter. AUTO requires tpu-inference on TPU.",
+        "--levanter-paged-attention",
+        choices=PAGED_ATTENTION_CHOICES,
+        default="auto",
+        help="Paged attention implementation used by Levanter. auto prefers tpu-inference on TPU.",
     )
     parser.add_argument(
         "--levanter-allow-reference-fallback",
@@ -2046,11 +2077,7 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument(
         "--reference-logit-decode-backend",
         action="append",
-        choices=[
-            TpuPagedAttentionBackend.TPU_INFERENCE.value,
-            TpuPagedAttentionBackend.JAX_RPA.value,
-            TpuPagedAttentionBackend.REFERENCE.value,
-        ],
+        choices=CONCRETE_PAGED_ATTENTION_CHOICES,
         default=[],
         help=(
             "Concrete decode backend to check against full causal logits. Repeat to run a diagnostic matrix. "
@@ -2187,6 +2214,7 @@ def main(argv: list[str] | None = None) -> int:
         "temperature": args.temperature,
         "top_p": args.top_p,
         "top_k": args.top_k,
+        "levanter_paged_attention": args.levanter_paged_attention,
         "levanter_sampler_top_k_mode": args.levanter_sampler_top_k_mode,
         "levanter_compute_dtype": args.levanter_compute_dtype,
         "levanter_trainer_mp": args.levanter_trainer_mp,

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -30,7 +30,7 @@ from levanter.inference.jit_scheduler import (
     _DecodeOutputs,
 )
 from levanter.inference.page_table import PageTable
-from levanter.inference.tpu_kernels import TpuPagedAttentionConfig
+from levanter.inference.tpu_kernels import AutoPagedAttentionConfig, PagedAttentionConfig
 from levanter.inference.utils import INVALID, is_valid
 from levanter.layers.attention import AttentionMask
 from levanter.layers.kv_cache import PageCache
@@ -101,7 +101,7 @@ class InferenceEngineConfig:
     max_tokens_per_round: int | None = None
     """Pack size for each decode loop iteration. If None, set to max_seqs """
 
-    tpu_paged_attention: TpuPagedAttentionConfig = field(default_factory=TpuPagedAttentionConfig)
+    paged_attention: PagedAttentionConfig = field(default_factory=AutoPagedAttentionConfig)
     """Paged attention backend used by inference decode and prefill calls."""
 
     use_streaming_greedy_lm_head: bool = False
@@ -459,7 +459,7 @@ def _prefill_kernel(
     sampler: Sampler,
     queue: TokenQueue,
     max_seqs_in_prefill: int,  # static
-    tpu_paged_attention: TpuPagedAttentionConfig,  # static
+    paged_attention: PagedAttentionConfig,  # static
     max_top_k: int | None,  # static
     apply_top_p: bool,  # static
     return_logprobs: bool,  # static
@@ -483,7 +483,7 @@ def _prefill_kernel(
     #     pos=pos_ids.array,
     #     lens=decode_state.seq_lens.array,
     # )
-    logits, cache = model.decode(tokens, gen_state.cache, binfo, pos_ids, tpu_paged_attention=tpu_paged_attention)
+    logits, cache = model.decode(tokens, gen_state.cache, binfo, pos_ids, paged_attention=paged_attention)
     logits_at_samples = logits["position", sample_indices]
 
     num_new_tokens = hax.sum(sample_indices != INVALID).scalar().astype(jnp.int32)
@@ -612,7 +612,7 @@ def _apply_prefill_work(gen_state: GenState, work: PrefillWork) -> GenState:
 @functools.partial(
     jax.jit,
     donate_argnums=0,
-    static_argnames=("max_seqs_in_prefill", "tpu_paged_attention", "max_top_k", "apply_top_p", "return_logprobs"),
+    static_argnames=("max_seqs_in_prefill", "paged_attention", "max_top_k", "apply_top_p", "return_logprobs"),
 )
 def _run_prefill(
     gen_state: GenState,
@@ -620,7 +620,7 @@ def _run_prefill(
     sampler: Sampler,
     work: PrefillWork,
     max_seqs_in_prefill: int,
-    tpu_paged_attention: TpuPagedAttentionConfig,
+    paged_attention: PagedAttentionConfig,
     max_top_k: int | None,
     apply_top_p: bool,
     return_logprobs: bool,
@@ -632,7 +632,7 @@ def _run_prefill(
         sampler,
         work.queue,
         max_seqs_in_prefill,
-        tpu_paged_attention,
+        paged_attention,
         max_top_k,
         apply_top_p,
         return_logprobs,
@@ -770,7 +770,7 @@ def _run_generation_loop(
     sampler: Sampler,
     max_tokens_per_round: int,
     max_rounds: int,
-    tpu_paged_attention: TpuPagedAttentionConfig,
+    paged_attention: PagedAttentionConfig,
     max_top_k: int | None,
     apply_top_p: bool,
     return_logprobs: bool,
@@ -827,7 +827,7 @@ def _run_generation_loop(
                 gen_state.cache,
                 binfo,
                 pos_ids,
-                tpu_paged_attention=tpu_paged_attention,
+                paged_attention=paged_attention,
             )
             logits_at_samples = logits["position", sample_indices]
             new_tokens, log_probs = hax.vmap(sampler, "position")(
@@ -849,7 +849,7 @@ def _run_generation_loop(
                     gen_state.cache,
                     binfo,
                     pos_ids,
-                    tpu_paged_attention=tpu_paged_attention,
+                    paged_attention=paged_attention,
                 )
                 hidden_at_samples = hidden["position", sample_indices]
                 new_tokens, log_probs = _streaming_greedy_lm_head(
@@ -902,7 +902,7 @@ def _run_generation_loop_without_lm_head(
     model: Any,
     max_tokens_per_round: int,
     max_rounds: int,
-    tpu_paged_attention: TpuPagedAttentionConfig,
+    paged_attention: PagedAttentionConfig,
 ) -> tuple[GenState, _DecodeOutputs]:
     """Run decode through transformer/cache update, then enqueue dummy tokens without LM head or sampling."""
 
@@ -932,7 +932,7 @@ def _run_generation_loop_without_lm_head(
             gen_state.cache,
             binfo,
             pos_ids,
-            tpu_paged_attention=tpu_paged_attention,
+            paged_attention=paged_attention,
         )
 
         num_new_tokens = hax.sum(sample_indices != INVALID).scalar().astype(jnp.int32)
@@ -961,7 +961,7 @@ def _run_generation_loop_with_lm_head_no_sampling(
     model: Any,
     max_tokens_per_round: int,
     max_rounds: int,
-    tpu_paged_attention: TpuPagedAttentionConfig,
+    paged_attention: PagedAttentionConfig,
 ) -> tuple[GenState, _DecodeOutputs]:
     """Run decode through the LM head, then enqueue dummy tokens without sampling.
 
@@ -995,7 +995,7 @@ def _run_generation_loop_with_lm_head_no_sampling(
             gen_state.cache,
             binfo,
             pos_ids,
-            tpu_paged_attention=tpu_paged_attention,
+            paged_attention=paged_attention,
         )
         logits = model.lm_head_logits(hidden)
         logits_checksum = hax.sum(logits).scalar()
@@ -1212,7 +1212,7 @@ class InferenceEngine:
             self.sampler,
             prefill_work,
             self.config.max_seqs_in_prefill,
-            self.config.tpu_paged_attention,
+            self.config.paged_attention,
             self.config.max_top_k,
             apply_top_p,
             return_logprobs,
@@ -1517,7 +1517,7 @@ class InferenceEngine:
                 # TODO: tune max_tokens_per_round
                 self.config.imputed_max_tokens_per_round,
                 self.config.max_rounds,
-                self.config.tpu_paged_attention,
+                self.config.paged_attention,
                 self.config.max_top_k,
                 apply_top_p,
                 return_logprobs,
@@ -1629,7 +1629,7 @@ class InferenceEngine:
                 self.model,
                 self.config.imputed_max_tokens_per_round,
                 self.config.max_rounds,
-                self.config.tpu_paged_attention,
+                self.config.paged_attention,
             )
             _block_until_ready_optional((future_state, decode_outputs))
             self.gen_state = future_state
@@ -1698,7 +1698,7 @@ class InferenceEngine:
                 self.model,
                 self.config.imputed_max_tokens_per_round,
                 self.config.max_rounds,
-                self.config.tpu_paged_attention,
+                self.config.paged_attention,
             )
             _block_until_ready_optional((future_state, decode_outputs))
             self.gen_state = future_state
@@ -1749,7 +1749,7 @@ class InferenceEngine:
             # TODO: tune max_tokens_per_round
             self.config.imputed_max_tokens_per_round,
             self.config.max_rounds,
-            self.config.tpu_paged_attention,
+            self.config.paged_attention,
             self.config.max_top_k,
             False,
             return_logprobs,
@@ -1793,7 +1793,7 @@ class InferenceEngine:
             self.sampler,
             eqx.filter_eval_shape(_create_dummy_work),
             self.config.max_seqs_in_prefill,
-            self.config.tpu_paged_attention,
+            self.config.paged_attention,
             self.config.max_top_k,
             False,
             return_logprobs,

--- a/lib/levanter/src/levanter/inference/tpu_kernels.py
+++ b/lib/levanter/src/levanter/inference/tpu_kernels.py
@@ -1,16 +1,15 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Backend dispatch for paged TPU inference kernels."""
+"""Backend dispatch for paged attention inference kernels."""
 
 from __future__ import annotations
 
 import dataclasses
 import warnings
-from collections.abc import Sequence
-from enum import StrEnum
 from typing import Any
 
+from draccus import ChoiceRegistry
 import jax
 import jax.numpy as jnp
 import numpy as np
@@ -20,35 +19,62 @@ from levanter.inference.page_table import PageBatchInfo
 from levanter.layers.kv_cache import KvPageCache
 
 
-class TpuPagedAttentionBackend(StrEnum):
-    AUTO = "auto"
-    TPU_INFERENCE = "tpu_inference"
-    JAX_RPA = "jax_rpa"
-    REFERENCE = "reference"
+class PagedAttentionConfig(ChoiceRegistry):
+    """Execution policy for paged attention during decode."""
+
+    @classmethod
+    def default_choice_name(cls) -> str | None:
+        return "auto"
 
 
+@PagedAttentionConfig.register_subclass("auto")
 @dataclasses.dataclass(frozen=True, slots=True)
-class TpuPagedAttentionConfig:
-    backend: TpuPagedAttentionBackend | Sequence[TpuPagedAttentionBackend] = TpuPagedAttentionBackend.AUTO
-    allow_autotune: bool = False
+class AutoPagedAttentionConfig(PagedAttentionConfig):
+    """Pick the fastest supported backend for the current platform."""
+
     fail_on_reference_fallback: bool = True
-    tpu_inference_out_dtype: str | None = None
+
+
+@PagedAttentionConfig.register_subclass("reference")
+@dataclasses.dataclass(frozen=True, slots=True)
+class ReferencePagedAttentionConfig(PagedAttentionConfig):
+    """Use the pure JAX reference paged-attention path."""
+
+    fail_on_reference_fallback: bool = True
+
+
+@PagedAttentionConfig.register_subclass("tpu-inference")
+@dataclasses.dataclass(frozen=True, slots=True)
+class TpuInferencePagedAttentionConfig(PagedAttentionConfig):
+    """Use the tpu-inference paged-attention kernel."""
+
+    fail_on_reference_fallback: bool = True
+    out_dtype: str | None = None
     preserve_attention_output_dtype: bool = False
+    vmem_limit_bytes: int | None = None
+
+
+@PagedAttentionConfig.register_subclass("jax-rpa")
+@dataclasses.dataclass(frozen=True, slots=True)
+class JaxRpaPagedAttentionConfig(PagedAttentionConfig):
+    """Use Levanter's JAX/Pallas ragged paged-attention path."""
+
+    fail_on_reference_fallback: bool = True
     num_kv_pages_per_block: int | None = None
     num_queries_per_block: int | None = None
     vmem_limit_bytes: int | None = None
 
 
-class UnsupportedTpuPagedAttentionBackend(RuntimeError):
+class UnsupportedPagedAttentionBackend(RuntimeError):
     """Raised when a selected paged-attention backend cannot run for the current platform or shape."""
 
 
-class TpuPagedAttentionFallbackWarning(UserWarning):
+class PagedAttentionFallbackWarning(UserWarning):
     """Warning emitted when backend dispatch falls back from one configured backend to another."""
 
 
 @dataclasses.dataclass(frozen=True, slots=True)
-class TpuPagedAttentionShape:
+class PagedAttentionShape:
     platform: str
     device_kind: str
     dtype: jnp.dtype
@@ -65,7 +91,7 @@ def _current_platform() -> str:
     try:
         return jax.default_backend()
     except Exception as exc:
-        raise UnsupportedTpuPagedAttentionBackend(f"Could not determine JAX backend: {exc}") from exc
+        raise UnsupportedPagedAttentionBackend(f"Could not determine JAX backend: {exc}") from exc
 
 
 def _current_device_kind() -> str:
@@ -83,82 +109,78 @@ def _has_nonempty_mesh() -> bool:
     return not jax.sharding.get_abstract_mesh().empty
 
 
-def _normalize_backend(backend: TpuPagedAttentionBackend | str) -> TpuPagedAttentionBackend:
-    if isinstance(backend, TpuPagedAttentionBackend):
-        return backend
-    return TpuPagedAttentionBackend(backend)
+def _config_name(config: PagedAttentionConfig) -> str:
+    if isinstance(config, AutoPagedAttentionConfig):
+        return "auto"
+    if isinstance(config, ReferencePagedAttentionConfig):
+        return "reference"
+    if isinstance(config, TpuInferencePagedAttentionConfig):
+        return "tpu-inference"
+    if isinstance(config, JaxRpaPagedAttentionConfig):
+        return "jax-rpa"
+    raise TypeError(f"Unknown paged attention config type: {type(config)}")
 
 
-def _is_auto_backend(backend: TpuPagedAttentionBackend | Sequence[TpuPagedAttentionBackend]) -> bool:
-    return (
-        isinstance(backend, TpuPagedAttentionBackend | str)
-        and _normalize_backend(backend) == TpuPagedAttentionBackend.AUTO
-    )
+def paged_attention_config_name(config: PagedAttentionConfig) -> str:
+    """Return the draccus choice name for a paged-attention config."""
+
+    return _config_name(config)
 
 
-def _backend_order(config: TpuPagedAttentionConfig) -> tuple[TpuPagedAttentionBackend, ...]:
-    backend = config.backend
-    if isinstance(backend, TpuPagedAttentionBackend | str):
-        selected = (_normalize_backend(backend),)
+def _expand_config(config: PagedAttentionConfig) -> tuple[PagedAttentionConfig, ...]:
+    if not isinstance(config, AutoPagedAttentionConfig):
+        return (config,)
+
+    if not _is_tpu():
+        return (ReferencePagedAttentionConfig(fail_on_reference_fallback=config.fail_on_reference_fallback),)
+
+    configs: list[PagedAttentionConfig] = [
+        TpuInferencePagedAttentionConfig(fail_on_reference_fallback=config.fail_on_reference_fallback)
+    ]
+    if _has_nonempty_mesh():
+        configs.append(JaxRpaPagedAttentionConfig(fail_on_reference_fallback=config.fail_on_reference_fallback))
     else:
-        selected = tuple(_normalize_backend(item) for item in backend)
-        if len(selected) == 0:
-            raise ValueError("tpu_paged_attention backend sequence must not be empty")
-
-    expanded: list[TpuPagedAttentionBackend] = []
-    for item in selected:
-        if item == TpuPagedAttentionBackend.AUTO:
-            if _is_tpu():
-                expanded.append(TpuPagedAttentionBackend.TPU_INFERENCE)
-                if _has_nonempty_mesh():
-                    expanded.append(TpuPagedAttentionBackend.JAX_RPA)
-                else:
-                    expanded.append(TpuPagedAttentionBackend.REFERENCE)
-            else:
-                expanded.append(TpuPagedAttentionBackend.REFERENCE)
-        else:
-            expanded.append(item)
-    return tuple(expanded)
+        configs.append(ReferencePagedAttentionConfig(fail_on_reference_fallback=False))
+    return tuple(configs)
 
 
-def available_tpu_paged_attention_backends() -> tuple[TpuPagedAttentionBackend, ...]:
-    """Return backends importable and platform-supported in the current process, excluding `AUTO`."""
+def available_paged_attention_configs() -> tuple[PagedAttentionConfig, ...]:
+    """Return paged-attention configs importable and platform-supported in the current process, excluding `auto`."""
 
     platform = _current_platform()
     if platform != "tpu":
-        return (TpuPagedAttentionBackend.REFERENCE,)
+        return (ReferencePagedAttentionConfig(),)
 
-    backends: list[TpuPagedAttentionBackend] = []
-    from levanter.inference import tpu_inference_adapter
+    configs: list[PagedAttentionConfig] = []
+    from levanter.inference import tpu_inference_adapter  # noqa: PLC0415
 
     if tpu_inference_adapter.is_available():
-        backends.append(TpuPagedAttentionBackend.TPU_INFERENCE)
+        configs.append(TpuInferencePagedAttentionConfig())
 
-    from levanter.layers import attention as attention_module
+    from levanter.layers import attention as attention_module  # noqa: PLC0415
 
     if _has_nonempty_mesh() and attention_module.tpu_ragged_paged_attention is not None:
-        backends.append(TpuPagedAttentionBackend.JAX_RPA)
+        configs.append(JaxRpaPagedAttentionConfig())
 
-    return tuple(backends)
+    return tuple(configs)
 
 
-def tpu_paged_attention_supports_shape(
-    backend: TpuPagedAttentionBackend,
-    shape: TpuPagedAttentionShape,
+def paged_attention_supports_shape(
+    config: PagedAttentionConfig,
+    shape: PagedAttentionShape,
 ) -> tuple[bool, str | None]:
-    """Return whether `backend` supports `shape`, plus a rejection reason when unsupported."""
+    """Return whether `config` supports `shape`, plus a rejection reason when unsupported."""
 
-    backend = _normalize_backend(backend)
-    if backend == TpuPagedAttentionBackend.AUTO:
+    if isinstance(config, AutoPagedAttentionConfig):
         return False, "AUTO is a dispatch policy, not a concrete backend"
-    if backend == TpuPagedAttentionBackend.REFERENCE:
+    if isinstance(config, ReferencePagedAttentionConfig):
         return True, None
     if shape.platform != "tpu":
-        return False, f"{backend.value} only runs on TPU"
+        return False, f"{_config_name(config)} only runs on TPU"
     if "tpu v2" in shape.device_kind.lower() or "tpu v3" in shape.device_kind.lower():
-        return False, f"{backend.value} does not support {shape.device_kind}"
+        return False, f"{_config_name(config)} does not support {shape.device_kind}"
     if shape.dtype != jnp.bfloat16:
-        return False, f"initial {backend.value} target only supports bf16 KV cache"
+        return False, f"initial {_config_name(config)} target only supports bf16 KV cache"
     if shape.page_size != 128:
         return False, "initial Qwen3 8B target requires page_size=128"
     if shape.head_size != 128:
@@ -168,6 +190,12 @@ def tpu_paged_attention_supports_shape(
     if shape.max_model_len != 4096:
         return False, "initial Qwen3 8B target requires max_model_len=4096"
     return True, None
+
+
+def paged_attention_preserves_output_dtype(config: PagedAttentionConfig) -> bool:
+    """Return whether the attention output projection should see the backend output dtype."""
+
+    return isinstance(config, TpuInferencePagedAttentionConfig) and config.preserve_attention_output_dtype
 
 
 def _concrete_array(value: Any) -> np.ndarray | None:
@@ -190,8 +218,8 @@ def _validate_no_duplicate_token_dests(batch_info: PageBatchInfo) -> None:
         raise ValueError("batch_info.new_token_dests contains duplicate valid destinations")
 
 
-def _unsupported(backend: TpuPagedAttentionBackend, reason: str) -> UnsupportedTpuPagedAttentionBackend:
-    return UnsupportedTpuPagedAttentionBackend(f"{backend.value} paged attention backend is unsupported: {reason}")
+def _unsupported(config: PagedAttentionConfig, reason: str) -> UnsupportedPagedAttentionBackend:
+    return UnsupportedPagedAttentionBackend(f"{_config_name(config)} paged attention backend is unsupported: {reason}")
 
 
 def _run_reference_backend(
@@ -204,7 +232,7 @@ def _run_reference_backend(
     sm_scale: float | jax.Array,
     soft_cap: float | None,
 ) -> tuple[NamedArray, KvPageCache]:
-    from levanter.layers.attention import default_ragged_paged_attention
+    from levanter.layers.attention import default_ragged_paged_attention  # noqa: PLC0415
 
     kv_cache = kv_cache.update(batch_info, new_k, new_v)
     attn = default_ragged_paged_attention(
@@ -229,12 +257,12 @@ def _run_jax_rpa_backend(
     *,
     sm_scale: float | jax.Array,
     soft_cap: float | None,
-    config: TpuPagedAttentionConfig,
+    config: JaxRpaPagedAttentionConfig,
 ) -> tuple[NamedArray, KvPageCache]:
     if not _is_tpu():
-        raise _unsupported(TpuPagedAttentionBackend.JAX_RPA, "JAX RPA only runs on TPU")
+        raise _unsupported(config, "JAX RPA only runs on TPU")
 
-    from levanter.layers.attention import _do_tpu_ragged_paged_attention
+    from levanter.layers.attention import _do_tpu_ragged_paged_attention  # noqa: PLC0415
 
     kv_cache = kv_cache.update(batch_info, new_k, new_v)
     attn = _do_tpu_ragged_paged_attention(
@@ -262,22 +290,22 @@ def _run_tpu_inference_backend(
     *,
     sm_scale: float | jax.Array,
     soft_cap: float | None,
-    config: TpuPagedAttentionConfig,
+    config: TpuInferencePagedAttentionConfig,
 ) -> tuple[NamedArray, KvPageCache]:
     if not _is_tpu():
-        raise _unsupported(TpuPagedAttentionBackend.TPU_INFERENCE, "tpu-inference only runs on TPU")
+        raise _unsupported(config, "tpu-inference only runs on TPU")
 
-    from levanter.inference import tpu_inference_adapter
+    from levanter.inference import tpu_inference_adapter  # noqa: PLC0415
 
     if not tpu_inference_adapter.is_available():
         raise _unsupported(
-            TpuPagedAttentionBackend.TPU_INFERENCE,
+            config,
             "the tpu-inference package or one of its runtime dependencies is not importable",
         )
 
     out_dtype = None
-    if config.tpu_inference_out_dtype is not None:
-        out_dtype = jnp.dtype(config.tpu_inference_out_dtype)
+    if config.out_dtype is not None:
+        out_dtype = jnp.dtype(config.out_dtype)
 
     try:
         return tpu_inference_adapter.paged_attention_with_kv_update(
@@ -293,13 +321,13 @@ def _run_tpu_inference_backend(
         )
     except ImportError as exc:
         raise _unsupported(
-            TpuPagedAttentionBackend.TPU_INFERENCE,
+            config,
             f"the tpu-inference kernel import failed: {exc}",
         ) from exc
 
 
 def _run_backend(
-    backend: TpuPagedAttentionBackend,
+    backend_config: PagedAttentionConfig,
     q: NamedArray,
     new_k: NamedArray,
     new_v: NamedArray,
@@ -308,10 +336,9 @@ def _run_backend(
     *,
     sm_scale: float | jax.Array,
     soft_cap: float | None,
-    config: TpuPagedAttentionConfig,
 ) -> tuple[NamedArray, KvPageCache]:
-    if backend == TpuPagedAttentionBackend.REFERENCE:
-        if _is_tpu() and config.fail_on_reference_fallback:
+    if isinstance(backend_config, ReferencePagedAttentionConfig):
+        if _is_tpu() and backend_config.fail_on_reference_fallback:
             raise ValueError(
                 "REFERENCE paged attention backend was selected on TPU with fail_on_reference_fallback=True"
             )
@@ -324,7 +351,7 @@ def _run_backend(
             sm_scale=sm_scale,
             soft_cap=soft_cap,
         )
-    if backend == TpuPagedAttentionBackend.JAX_RPA:
+    if isinstance(backend_config, JaxRpaPagedAttentionConfig):
         return _run_jax_rpa_backend(
             q,
             new_k,
@@ -333,9 +360,9 @@ def _run_backend(
             batch_info,
             sm_scale=sm_scale,
             soft_cap=soft_cap,
-            config=config,
+            config=backend_config,
         )
-    if backend == TpuPagedAttentionBackend.TPU_INFERENCE:
+    if isinstance(backend_config, TpuInferencePagedAttentionConfig):
         return _run_tpu_inference_backend(
             q,
             new_k,
@@ -344,9 +371,11 @@ def _run_backend(
             batch_info,
             sm_scale=sm_scale,
             soft_cap=soft_cap,
-            config=config,
+            config=backend_config,
         )
-    raise ValueError(f"Unsupported paged attention backend: {backend}")
+    if isinstance(backend_config, AutoPagedAttentionConfig):
+        raise ValueError("AutoPagedAttentionConfig must be expanded before backend dispatch")
+    raise TypeError(f"Unknown paged attention config type: {type(backend_config)}")
 
 
 def paged_attention_with_kv_update(
@@ -358,22 +387,18 @@ def paged_attention_with_kv_update(
     *,
     sm_scale: float | jax.Array,
     soft_cap: float | None,
-    config: TpuPagedAttentionConfig,
+    config: PagedAttentionConfig,
 ) -> tuple[NamedArray, KvPageCache]:
     """Compute paged attention for packed tokens and return the updated KV cache."""
 
     _validate_no_duplicate_token_dests(batch_info)
-    backends = _backend_order(config)
+    backend_configs = _expand_config(config)
     failures: list[Exception] = []
 
-    for index, backend in enumerate(backends):
-        backend_config = config
-        if backend == TpuPagedAttentionBackend.REFERENCE and failures and _is_auto_backend(config.backend):
-            backend_config = dataclasses.replace(config, fail_on_reference_fallback=False)
-
+    for index, backend_config in enumerate(backend_configs):
         try:
             return _run_backend(
-                backend,
+                backend_config,
                 q,
                 new_k,
                 new_v,
@@ -381,15 +406,16 @@ def paged_attention_with_kv_update(
                 batch_info,
                 sm_scale=sm_scale,
                 soft_cap=soft_cap,
-                config=backend_config,
             )
-        except (UnsupportedTpuPagedAttentionBackend, ValueError) as exc:
+        except (UnsupportedPagedAttentionBackend, ValueError) as exc:
             failures.append(exc)
-            if index == len(backends) - 1:
+            if index == len(backend_configs) - 1:
                 raise
+            next_backend_config = backend_configs[index + 1]
             warnings.warn(
-                f"{backend.value} paged attention backend failed; trying {backends[index + 1].value}: {exc}",
-                TpuPagedAttentionFallbackWarning,
+                f"{_config_name(backend_config)} paged attention backend failed; "
+                f"trying {_config_name(next_backend_config)}: {exc}",
+                PagedAttentionFallbackWarning,
                 stacklevel=2,
             )
 

--- a/lib/levanter/src/levanter/layers/attention.py
+++ b/lib/levanter/src/levanter/layers/attention.py
@@ -46,7 +46,12 @@ else:
     _SPLASH_KERNEL_SUPPORTS_SINKS = "sinks" in inspect.signature(_splash_attention).parameters
 
 from ..inference.page_table import PageBatchInfo, PageTableSpec
-from ..inference.tpu_kernels import TpuPagedAttentionConfig, paged_attention_with_kv_update
+from ..inference.tpu_kernels import (
+    AutoPagedAttentionConfig,
+    PagedAttentionConfig,
+    paged_attention_preserves_output_dtype,
+    paged_attention_with_kv_update,
+)
 from .kv_cache import KvPageCache
 from .normalization import LayerNormConfigBase
 from .rotary import RotaryEmbeddings, RotaryEmbeddingsConfig
@@ -1774,7 +1779,7 @@ class Attention(eqx.Module):
         batch_info: PageBatchInfo,
         *,
         pos_ids: NamedArray,
-        tpu_paged_attention: TpuPagedAttentionConfig = TpuPagedAttentionConfig(),
+        paged_attention: PagedAttentionConfig = AutoPagedAttentionConfig(),
         key=None,
     ) -> tuple[NamedArray, "KvPageCache"]:
         """Decode-time forward pass using a paged KV cache.
@@ -1801,11 +1806,11 @@ class Attention(eqx.Module):
             batch_info,
             sm_scale=sm_scale,
             soft_cap=self.config.logits_soft_cap,
-            config=tpu_paged_attention,
+            config=paged_attention,
         )
 
         attn_output = attn_tokens.flatten_axes(("kv_head", "q_heads_per_group"), "heads")
-        if not tpu_paged_attention.preserve_attention_output_dtype:
+        if not paged_attention_preserves_output_dtype(paged_attention):
             attn_output = attn_output.astype(x.dtype)
         attn_output = self.o_proj(attn_output, key=key_o)
 
@@ -1958,7 +1963,7 @@ class GatedAttention(Attention):
         batch_info: PageBatchInfo,
         *,
         pos_ids: NamedArray,
-        tpu_paged_attention: TpuPagedAttentionConfig = TpuPagedAttentionConfig(),
+        paged_attention: PagedAttentionConfig = AutoPagedAttentionConfig(),
         key=None,
     ) -> tuple[NamedArray, "KvPageCache"]:
         key_proj, key_o = maybe_rng_split(key, 2)
@@ -1978,7 +1983,7 @@ class GatedAttention(Attention):
             batch_info,
             sm_scale=sm_scale,
             soft_cap=self.config.logits_soft_cap,
-            config=tpu_paged_attention,
+            config=paged_attention,
         )
 
         assert self.gate_proj is not None
@@ -1987,7 +1992,7 @@ class GatedAttention(Attention):
         attn_tokens = attn_tokens * gate
 
         attn_output = attn_tokens.flatten_axes(("kv_head", "q_heads_per_group"), "heads")
-        if not tpu_paged_attention.preserve_attention_output_dtype:
+        if not paged_attention_preserves_output_dtype(paged_attention):
             attn_output = attn_output.astype(x.dtype)
         return self.o_proj(attn_output, key=key_o), kv_cache
 

--- a/lib/levanter/src/levanter/models/apertus.py
+++ b/lib/levanter/src/levanter/models/apertus.py
@@ -18,7 +18,7 @@ from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.inference.page_table import PageBatchInfo, PageTableSpec
-from levanter.inference.tpu_kernels import TpuPagedAttentionConfig
+from levanter.inference.tpu_kernels import AutoPagedAttentionConfig, PagedAttentionConfig
 from levanter.layers.attention import Attention, AttentionMask
 from levanter.layers.kv_cache import KvPageCache, ListCache
 from levanter.layers.rotary import Llama3RotaryEmbeddingsConfig, RotaryEmbeddingsConfig
@@ -298,7 +298,7 @@ class ApertusDecoderLayer(ModuleWithStateDictSerialization):
         batch_info: PageBatchInfo,
         pos_ids: NamedArray,
         *,
-        tpu_paged_attention: TpuPagedAttentionConfig = TpuPagedAttentionConfig(),
+        paged_attention: PagedAttentionConfig = AutoPagedAttentionConfig(),
         key=None,
     ) -> tuple[NamedArray, KvPageCache]:
         k_attn, k_mlp = maybe_rng_split(key, 2)
@@ -309,7 +309,7 @@ class ApertusDecoderLayer(ModuleWithStateDictSerialization):
             kv_cache,
             batch_info,
             pos_ids=pos_ids,
-            tpu_paged_attention=tpu_paged_attention,
+            paged_attention=paged_attention,
             key=k_attn,
         )
         x = residual + attn_output
@@ -360,7 +360,7 @@ class ApertusTransformer(eqx.Module):
         batch_info: PageBatchInfo,
         pos_ids: NamedArray,
         *,
-        tpu_paged_attention: TpuPagedAttentionConfig = TpuPagedAttentionConfig(),
+        paged_attention: PagedAttentionConfig = AutoPagedAttentionConfig(),
         key=None,
     ) -> tuple[NamedArray, ListCache[KvPageCache]]:
         keys = maybe_rng_split(key, self.config.num_layers) if key is not None else None
@@ -378,7 +378,7 @@ class ApertusTransformer(eqx.Module):
                 this_cache,
                 batch_info,
                 pos_ids=pos_ids,
-                tpu_paged_attention=tpu_paged_attention,
+                paged_attention=paged_attention,
                 key=keys[i] if keys is not None else None,
             )
             with jax.named_scope("update cache"):
@@ -481,7 +481,7 @@ class ApertusLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[ApertusCo
         batch_info: PageBatchInfo,
         pos_ids: NamedArray,
         *,
-        tpu_paged_attention: TpuPagedAttentionConfig = TpuPagedAttentionConfig(),
+        paged_attention: PagedAttentionConfig = AutoPagedAttentionConfig(),
         key=None,
     ) -> tuple[NamedArray, ListCache[KvPageCache]]:
         x = self.embeddings.embed(input_ids)
@@ -491,7 +491,7 @@ class ApertusLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[ApertusCo
             x,
             batch_info,
             pos_ids=pos_ids,
-            tpu_paged_attention=tpu_paged_attention,
+            paged_attention=paged_attention,
             key=k_t,
         )
         if self.lm_head:

--- a/lib/levanter/src/levanter/models/llama.py
+++ b/lib/levanter/src/levanter/models/llama.py
@@ -19,7 +19,7 @@ from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
 from levanter.inference.page_table import PageBatchInfo, PageTableSpec
-from levanter.inference.tpu_kernels import TpuPagedAttentionConfig
+from levanter.inference.tpu_kernels import AutoPagedAttentionConfig, PagedAttentionConfig
 from levanter.layers import LayerNormConfigBase, RmsNormConfig
 from levanter.layers.attention import Attention, AttentionBackend, AttentionConfig, AttentionMask
 from levanter.layers.kv_cache import KvPageCache, ListCache
@@ -354,7 +354,7 @@ class LlamaDecoderLayer(eqx.Module):
         batch_info: PageBatchInfo,
         pos_ids: NamedArray,
         *,
-        tpu_paged_attention: TpuPagedAttentionConfig = TpuPagedAttentionConfig(),
+        paged_attention: PagedAttentionConfig = AutoPagedAttentionConfig(),
         key=None,
     ) -> tuple[NamedArray, KvPageCache]:
         k_attn, k_mlp = maybe_rng_split(key, 2)
@@ -366,7 +366,7 @@ class LlamaDecoderLayer(eqx.Module):
             kv_cache,
             batch_info,
             pos_ids=pos_ids,
-            tpu_paged_attention=tpu_paged_attention,
+            paged_attention=paged_attention,
             key=k_attn,
         )
 
@@ -428,7 +428,7 @@ class LlamaTransformer(eqx.Module):
         batch_info: PageBatchInfo,
         pos_ids: NamedArray,
         *,
-        tpu_paged_attention: TpuPagedAttentionConfig = TpuPagedAttentionConfig(),
+        paged_attention: PagedAttentionConfig = AutoPagedAttentionConfig(),
         key=None,
     ) -> tuple[NamedArray, ListCache[KvPageCache]]:
         keys = maybe_rng_split(key, self.config.num_layers) if key is not None else None
@@ -456,7 +456,7 @@ class LlamaTransformer(eqx.Module):
                 this_cache,
                 batch_info,
                 pos_ids=pos_ids,
-                tpu_paged_attention=tpu_paged_attention,
+                paged_attention=paged_attention,
                 key=keys[i] if keys is not None else None,
             )
             with jax.named_scope("update cache"):
@@ -638,7 +638,7 @@ class LlamaLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[LlamaConfig
         batch_info: PageBatchInfo,
         pos_ids: NamedArray,
         *,
-        tpu_paged_attention: TpuPagedAttentionConfig = TpuPagedAttentionConfig(),
+        paged_attention: PagedAttentionConfig = AutoPagedAttentionConfig(),
         key=None,
     ) -> tuple[NamedArray, ListCache[KvPageCache]]:
         """Run one decode / pre-fill step with an existing paged-KV *state*.
@@ -668,7 +668,7 @@ class LlamaLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[LlamaConfig
             kv_cache,
             batch_info,
             pos_ids,
-            tpu_paged_attention=tpu_paged_attention,
+            paged_attention=paged_attention,
             key=key,
         )
         logits = self.lm_head_logits(x)
@@ -682,7 +682,7 @@ class LlamaLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[LlamaConfig
         batch_info: PageBatchInfo,
         pos_ids: NamedArray,
         *,
-        tpu_paged_attention: TpuPagedAttentionConfig = TpuPagedAttentionConfig(),
+        paged_attention: PagedAttentionConfig = AutoPagedAttentionConfig(),
         key=None,
     ) -> tuple[NamedArray, ListCache[KvPageCache]]:
         """Run paged decode through the transformer and return hidden states before the LM head."""
@@ -694,7 +694,7 @@ class LlamaLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[LlamaConfig
             x,
             batch_info,
             pos_ids,
-            tpu_paged_attention=tpu_paged_attention,
+            paged_attention=paged_attention,
             key=k_t,
         )
 

--- a/lib/levanter/tests/inference/test_engine.py
+++ b/lib/levanter/tests/inference/test_engine.py
@@ -38,8 +38,8 @@ class DummyModel(eqx.Module):
         head_size = Axis("embed", 1)
         return KvPageCache.init(spec, kv_heads, head_size, dtype=dtype)
 
-    def decode(self, input_ids, kv_cache, batch_info, pos_ids, *, tpu_paged_attention=None):
-        del tpu_paged_attention
+    def decode(self, input_ids, kv_cache, batch_info, pos_ids, *, paged_attention=None):
+        del paged_attention
         # Produce logits that prefer `eos` for every sampled position
         Pos = input_ids.resolve_axis("position")
         Vocab = self.Vocab
@@ -48,8 +48,8 @@ class DummyModel(eqx.Module):
         logits = logits.broadcast_axis(Pos)
         return logits, kv_cache
 
-    def decode_hidden(self, input_ids, kv_cache, batch_info, pos_ids, *, tpu_paged_attention=None):
-        del batch_info, pos_ids, tpu_paged_attention
+    def decode_hidden(self, input_ids, kv_cache, batch_info, pos_ids, *, paged_attention=None):
+        del batch_info, pos_ids, paged_attention
         Pos = input_ids.resolve_axis("position")
         return hax.zeros((Pos, self.Embed), dtype=jnp.float32), kv_cache
 

--- a/lib/levanter/tests/inference/test_tpu_paged_attention_backends.py
+++ b/lib/levanter/tests/inference/test_tpu_paged_attention_backends.py
@@ -4,6 +4,7 @@
 import math
 import dataclasses
 
+import draccus
 import jax.numpy as jnp
 import jax.random as jr
 import pytest
@@ -15,14 +16,16 @@ from haliax import Axis
 import levanter.inference.tpu_kernels as tpu_kernels
 from levanter.inference.page_table import PageBatchInfo, PageTableSpec
 from levanter.inference.tpu_kernels import (
-    TpuPagedAttentionBackend,
-    TpuPagedAttentionConfig,
-    TpuPagedAttentionFallbackWarning,
-    TpuPagedAttentionShape,
-    UnsupportedTpuPagedAttentionBackend,
-    available_tpu_paged_attention_backends,
+    AutoPagedAttentionConfig,
+    PagedAttentionConfig,
+    PagedAttentionFallbackWarning,
+    PagedAttentionShape,
+    ReferencePagedAttentionConfig,
+    TpuInferencePagedAttentionConfig,
+    UnsupportedPagedAttentionBackend,
+    available_paged_attention_configs,
+    paged_attention_supports_shape,
     paged_attention_with_kv_update,
-    tpu_paged_attention_supports_shape,
 )
 from levanter.inference.utils import INVALID
 from levanter.layers.attention import default_ragged_paged_attention
@@ -32,6 +35,28 @@ from levanter.layers.kv_cache import KvPageCache
 PAGE_SIZE = 4
 HEAD_SIZE = 128
 SM_SCALE = 1.0 / math.sqrt(HEAD_SIZE)
+
+
+def test_paged_attention_config_is_draccus_choice_family():
+    @dataclasses.dataclass
+    class DecodeConfig:
+        paged_attention: PagedAttentionConfig
+
+    decoded = draccus.decode(
+        DecodeConfig,
+        {
+            "paged_attention": {
+                "type": "tpu-inference",
+                "out_dtype": "float32",
+                "preserve_attention_output_dtype": True,
+            }
+        },
+    )
+
+    assert decoded.paged_attention == TpuInferencePagedAttentionConfig(
+        out_dtype="float32",
+        preserve_attention_output_dtype=True,
+    )
 
 
 def _single_sequence_case():
@@ -112,7 +137,7 @@ def _expected_attention_after_update(q, new_k, new_v, kv_cache, batch_info, *, s
     return expected, expected_cache
 
 
-def _assert_backend_matches_reference(case_factory, *, backend: TpuPagedAttentionBackend, soft_cap: float | None):
+def _assert_backend_matches_reference(case_factory, *, config: PagedAttentionConfig, soft_cap: float | None):
     expected_q, expected_new_k, expected_new_v, expected_cache_input, expected_batch_info = case_factory()
     expected, expected_cache = _expected_attention_after_update(
         expected_q,
@@ -124,8 +149,7 @@ def _assert_backend_matches_reference(case_factory, *, backend: TpuPagedAttentio
     )
     q, new_k, new_v, kv_cache, batch_info = case_factory()
 
-    config = TpuPagedAttentionConfig(backend=backend)
-    if backend == TpuPagedAttentionBackend.REFERENCE:
+    if isinstance(config, ReferencePagedAttentionConfig):
         config = dataclasses.replace(config, fail_on_reference_fallback=False)
 
     attn, updated_cache = paged_attention_with_kv_update(
@@ -147,17 +171,20 @@ def _assert_backend_matches_reference(case_factory, *, backend: TpuPagedAttentio
 def test_auto_backend_updates_cache_and_matches_reference_on_cpu():
     _assert_backend_matches_reference(
         _single_sequence_case,
-        backend=TpuPagedAttentionBackend.AUTO,
+        config=AutoPagedAttentionConfig(),
         soft_cap=None,
     )
 
 
-@pytest.mark.parametrize("backend", [TpuPagedAttentionBackend.AUTO, TpuPagedAttentionBackend.REFERENCE])
+@pytest.mark.parametrize(
+    "config",
+    [AutoPagedAttentionConfig(), ReferencePagedAttentionConfig(fail_on_reference_fallback=False)],
+)
 @pytest.mark.parametrize("soft_cap", [None, 30.0])
-def test_backend_matches_reference_on_multi_sequence_page_boundary_grouped_heads(backend, soft_cap):
+def test_backend_matches_reference_on_multi_sequence_page_boundary_grouped_heads(config, soft_cap):
     _assert_backend_matches_reference(
         _multi_sequence_page_boundary_case,
-        backend=backend,
+        config=config,
         soft_cap=soft_cap,
     )
 
@@ -174,36 +201,13 @@ def test_explicit_tpu_inference_backend_fails_fast_on_cpu():
             batch_info,
             sm_scale=SM_SCALE,
             soft_cap=None,
-            config=TpuPagedAttentionConfig(backend=TpuPagedAttentionBackend.TPU_INFERENCE),
+            config=TpuInferencePagedAttentionConfig(),
         )
-    except UnsupportedTpuPagedAttentionBackend as exc:
+    except UnsupportedPagedAttentionBackend as exc:
         message = str(exc)
         assert "only runs on TPU" in message or "not importable" in message
     else:
         raise AssertionError("explicit tpu-inference backend should fail on CPU")
-
-
-def test_backend_sequence_warns_then_runs_reference_on_cpu():
-    q, new_k, new_v, kv_cache, batch_info = _single_sequence_case()
-    config = TpuPagedAttentionConfig(
-        backend=(TpuPagedAttentionBackend.TPU_INFERENCE, TpuPagedAttentionBackend.REFERENCE),
-        fail_on_reference_fallback=False,
-    )
-
-    with pytest.warns(TpuPagedAttentionFallbackWarning):
-        attn, updated_cache = paged_attention_with_kv_update(
-            q,
-            new_k,
-            new_v,
-            kv_cache,
-            batch_info,
-            sm_scale=SM_SCALE,
-            soft_cap=None,
-            config=config,
-        )
-
-    assert attn.axes == q.axes
-    assert updated_cache.kv_pages.array.shape == kv_cache.kv_pages.array.shape
 
 
 def test_auto_backend_warns_then_uses_reference_on_tpu_without_mesh_when_tpu_inference_is_unavailable(monkeypatch):
@@ -220,13 +224,13 @@ def test_auto_backend_warns_then_uses_reference_on_tpu_without_mesh_when_tpu_inf
 
     def unavailable_tpu_backend(*args, **kwargs):
         del args, kwargs
-        raise UnsupportedTpuPagedAttentionBackend("tpu-inference import failed")
+        raise UnsupportedPagedAttentionBackend("tpu-inference import failed")
 
     monkeypatch.setattr(tpu_kernels, "_current_platform", lambda: "tpu")
     monkeypatch.setattr(tpu_kernels, "_has_nonempty_mesh", lambda: False)
     monkeypatch.setattr(tpu_kernels, "_run_tpu_inference_backend", unavailable_tpu_backend)
 
-    with pytest.warns(TpuPagedAttentionFallbackWarning):
+    with pytest.warns(PagedAttentionFallbackWarning):
         attn, updated_cache = paged_attention_with_kv_update(
             q,
             new_k,
@@ -235,7 +239,7 @@ def test_auto_backend_warns_then_uses_reference_on_tpu_without_mesh_when_tpu_inf
             batch_info,
             sm_scale=SM_SCALE,
             soft_cap=None,
-            config=TpuPagedAttentionConfig(),
+            config=AutoPagedAttentionConfig(),
         )
 
     assert_trees_all_close(attn.array, expected.array, atol=1e-3, rtol=1e-3)
@@ -255,7 +259,7 @@ def test_reference_backend_is_not_a_silent_tpu_fallback(monkeypatch):
             batch_info,
             sm_scale=SM_SCALE,
             soft_cap=None,
-            config=TpuPagedAttentionConfig(backend=TpuPagedAttentionBackend.REFERENCE),
+            config=ReferencePagedAttentionConfig(),
         )
     except ValueError as exc:
         assert "fail_on_reference_fallback=True" in str(exc)
@@ -279,7 +283,7 @@ def test_duplicate_token_destinations_raise_before_backend_dispatch():
             duplicate_batch_info,
             sm_scale=SM_SCALE,
             soft_cap=None,
-            config=TpuPagedAttentionConfig(),
+            config=AutoPagedAttentionConfig(),
         )
     except ValueError as exc:
         assert "duplicate valid destinations" in str(exc)
@@ -288,15 +292,15 @@ def test_duplicate_token_destinations_raise_before_backend_dispatch():
 
 
 def test_available_backends_on_cpu_only_report_reference():
-    backends = available_tpu_paged_attention_backends()
+    configs = available_paged_attention_configs()
     if tpu_kernels._is_tpu():
-        assert TpuPagedAttentionBackend.REFERENCE not in backends
+        assert not any(isinstance(config, ReferencePagedAttentionConfig) for config in configs)
     else:
-        assert backends == (TpuPagedAttentionBackend.REFERENCE,)
+        assert configs == (ReferencePagedAttentionConfig(),)
 
 
 def test_initial_qwen3_shape_support_matches_target_tensor_parallelism():
-    target_shape = TpuPagedAttentionShape(
+    target_shape = PagedAttentionShape(
         platform="tpu",
         device_kind="TPU v5",
         dtype=jnp.bfloat16,
@@ -309,7 +313,7 @@ def test_initial_qwen3_shape_support_matches_target_tensor_parallelism():
         tensor_parallel_size=4,
     )
 
-    supported, reason = tpu_paged_attention_supports_shape(TpuPagedAttentionBackend.TPU_INFERENCE, target_shape)
+    supported, reason = paged_attention_supports_shape(TpuInferencePagedAttentionConfig(), target_shape)
 
     assert supported
     assert reason is None

--- a/lib/levanter/tests/test_qwen3.py
+++ b/lib/levanter/tests/test_qwen3.py
@@ -14,9 +14,9 @@ import haliax as hax
 from levanter.inference.jit_scheduler import SequenceTable
 from levanter.inference.page_table import PageTable
 from levanter.inference.tpu_kernels import (
-    TpuPagedAttentionBackend,
-    TpuPagedAttentionConfig,
-    available_tpu_paged_attention_backends,
+    AutoPagedAttentionConfig,
+    PagedAttentionConfig,
+    available_paged_attention_configs,
 )
 from levanter.layers.attention import AttentionMask
 from levanter.models.qwen import Qwen3Config, Qwen3LMHeadModel
@@ -57,9 +57,9 @@ def _tiny_qwen3_config() -> Qwen3Config:
     )
 
 
-def _qwen_decode_backends() -> tuple[TpuPagedAttentionBackend, ...]:
-    available = available_tpu_paged_attention_backends()
-    return (TpuPagedAttentionBackend.AUTO, *available)
+def _qwen_decode_configs() -> tuple[PagedAttentionConfig, ...]:
+    available = available_paged_attention_configs()
+    return (AutoPagedAttentionConfig(), *available)
 
 
 @skip_if_no_torch
@@ -115,8 +115,8 @@ def test_qwen3_roundtrip():
             np.testing.assert_allclose(hf_out, jax_out, rtol=1e-4, atol=1e-4)
 
 
-@pytest.mark.parametrize("backend", _qwen_decode_backends())
-def test_qwen3_paged_decode_matches_full_logits_for_available_backends(backend: TpuPagedAttentionBackend):
+@pytest.mark.parametrize("paged_attention", _qwen_decode_configs())
+def test_qwen3_paged_decode_matches_full_logits_for_available_backends(paged_attention: PagedAttentionConfig):
     Vocab = hax.Axis("vocab", 32)
     Pos = hax.Axis("position", 6)
     config = _tiny_qwen3_config()
@@ -145,7 +145,7 @@ def test_qwen3_paged_decode_matches_full_logits_for_available_backends(backend: 
                 kv_cache,
                 batch_info,
                 pos_ids,
-                tpu_paged_attention=TpuPagedAttentionConfig(backend=backend),
+                paged_attention=paged_attention,
             )
             logits_chunks.append(logits_chunk)
 

--- a/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
+++ b/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
@@ -79,10 +79,10 @@ def test_main_rejects_reference_logit_check_without_levanter():
         bench.main(["--backend", "levanter", "--reference-logit-only"])
 
 
-def test_parse_args_defaults_to_auto_tpu_paged_attention_backend():
+def test_parse_args_defaults_to_auto_paged_attention():
     args = bench.parse_args(["--backend", "levanter"])
 
-    assert args.levanter_tpu_paged_attention_backend == "auto"
+    assert args.levanter_paged_attention == "auto"
     assert not args.levanter_allow_reference_fallback
     assert args.levanter_sampler_top_k_mode == "candidate"
 
@@ -93,13 +93,13 @@ def test_parse_args_defaults_to_two_warmup_rounds():
     assert args.warmup_rounds == 2
 
 
-def test_start_backend_passes_levanter_tpu_paged_attention_config(monkeypatch, tmp_path):
+def test_start_backend_passes_levanter_paged_attention_config(monkeypatch, tmp_path):
     captured: dict = {}
 
     def start_levanter_server(**kwargs):
         captured.update(kwargs)
         return bench.ServerHandle(
-            name=f"levanter:{kwargs['tpu_paged_attention_backend'].value}",
+            name=f"levanter:{bench.paged_attention_config_name(kwargs['paged_attention'])}",
             base_url="http://127.0.0.1:8000/v1",
             model_id="levanter",
             close=lambda: None,
@@ -110,8 +110,8 @@ def test_start_backend_passes_levanter_tpu_paged_attention_config(monkeypatch, t
         [
             "--backend",
             "levanter",
-            "--levanter-tpu-paged-attention-backend",
-            "jax_rpa",
+            "--levanter-paged-attention",
+            "jax-rpa",
             "--levanter-allow-reference-fallback",
             "--levanter-compute-dtype",
             "float32",
@@ -126,7 +126,7 @@ def test_start_backend_passes_levanter_tpu_paged_attention_config(monkeypatch, t
             "--reference-logit-max-prompts",
             "1",
             "--reference-logit-decode-backend",
-            "tpu_inference",
+            "tpu-inference",
             "--reference-logit-cache-dtype",
             "auto",
             "--reference-logit-cache-dtype",
@@ -147,20 +147,22 @@ def test_start_backend_passes_levanter_tpu_paged_attention_config(monkeypatch, t
         prompts={},
     )
 
-    assert handle.name == "levanter:jax_rpa"
-    assert captured["tpu_paged_attention_backend"] == bench.TpuPagedAttentionBackend.JAX_RPA
-    assert captured["allow_reference_fallback"]
+    assert handle.name == "levanter:jax-rpa"
+    assert captured["paged_attention"] == bench.JaxRpaPagedAttentionConfig(
+        fail_on_reference_fallback=False,
+        num_kv_pages_per_block=None,
+        num_queries_per_block=None,
+        vmem_limit_bytes=None,
+    )
     assert captured["compute_dtype"] == "float32"
     assert captured["trainer_mp_policy"] == "bf16"
-    assert captured["tpu_inference_out_dtype"] == "float32"
-    assert captured["preserve_attention_output_dtype"]
     assert captured["sampler_top_k_mode"] == bench.SamplerTopKMode.THRESHOLD_MASK
     assert captured["tensor_parallel_size"] == 4
     assert captured["reference_logit_check_dir"] == tmp_path
     assert captured["reference_logit_check_cases"] == []
     assert captured["reference_logit_check_prompts"] == {}
     assert captured["reference_logit_max_prompts"] == 1
-    assert captured["reference_logit_decode_backends"] == [bench.TpuPagedAttentionBackend.TPU_INFERENCE]
+    assert captured["reference_logit_decode_backends"] == ["tpu-inference"]
     assert captured["reference_logit_cache_dtype_policies"] == ["auto", "bfloat16"]
     assert captured["reference_logit_only"]
 
@@ -499,21 +501,21 @@ def test_reference_logit_error_metrics_reports_distribution_and_topk():
 def test_reference_logit_cache_dtype_uses_bf16_for_tpu_inference_policy():
     assert (
         bench._reference_logit_cache_dtype(
-            bench.TpuPagedAttentionConfig(backend=bench.TpuPagedAttentionBackend.AUTO),
+            bench.AutoPagedAttentionConfig(),
             bench.jnp.float32,
         )
         == bench.jnp.bfloat16
     )
     assert (
         bench._reference_logit_cache_dtype(
-            bench.TpuPagedAttentionConfig(backend=bench.TpuPagedAttentionBackend.TPU_INFERENCE),
+            bench.TpuInferencePagedAttentionConfig(),
             bench.jnp.float32,
         )
         == bench.jnp.bfloat16
     )
     assert (
         bench._reference_logit_cache_dtype(
-            bench.TpuPagedAttentionConfig(backend=bench.TpuPagedAttentionBackend.REFERENCE),
+            bench.ReferencePagedAttentionConfig(),
             bench.jnp.float32,
         )
         == bench.jnp.float32
@@ -521,7 +523,7 @@ def test_reference_logit_cache_dtype_uses_bf16_for_tpu_inference_policy():
 
 
 def test_reference_logit_cache_dtype_policy_can_force_f32_for_tpu_inference():
-    config = bench.TpuPagedAttentionConfig(backend=bench.TpuPagedAttentionBackend.TPU_INFERENCE)
+    config = bench.TpuInferencePagedAttentionConfig()
 
     assert bench._reference_logit_cache_dtype_for_policy(config, bench.jnp.bfloat16, "auto") == bench.jnp.bfloat16
     assert bench._reference_logit_cache_dtype_for_policy(config, bench.jnp.bfloat16, "float32") == bench.jnp.float32


### PR DESCRIPTION
Replace the TPU-only paged-attention backend enum with a draccus PagedAttentionConfig choice family and pass paged_attention through decode. Moves TPU-specific knobs onto concrete TPU backend configs and updates Qwen decode and benchmark coverage.

Fixes #6112
References #6099