### PR TITLE
[iris] Group dashboard jobs by owner; tidy Scheduler/Autoscaler panels

### DIFF
--- a/lib/iris/dashboard/src/components/controller/AutoscalerTab.vue
+++ b/lib/iris/dashboard/src/components/controller/AutoscalerTab.vue
@@ -22,6 +22,7 @@ import StatusBadge from '@/components/shared/StatusBadge.vue'
 import MetricCard from '@/components/shared/MetricCard.vue'
 import EmptyState from '@/components/shared/EmptyState.vue'
 import LogViewer from '@/components/shared/LogViewer.vue'
+import LoadingSpinner from '@/components/shared/LoadingSpinner.vue'
 
 // -- RPC + auto-refresh --
 
@@ -743,9 +744,7 @@ function formatUptimeShort(ms: number | null): string {
 
 <template>
   <!-- Loading state -->
-  <div v-if="loading && !data" class="flex items-center justify-center py-12 text-text-muted text-sm">
-    Loading autoscaler status...
-  </div>
+  <LoadingSpinner v-if="loading && !data" label="Loading autoscaler status…" />
 
   <!-- Error state -->
   <div
@@ -879,28 +878,36 @@ function formatUptimeShort(ms: number | null): string {
         <table class="w-full border-collapse">
           <thead>
             <tr class="border-b border-surface-border bg-surface">
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left w-16">Priority</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Group</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Slices</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-right w-20">Demand</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-right w-20">Assigned</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-right w-20">Launch</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Decision</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Reason</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left w-16">Priority</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Group</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Slices</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-right w-20">Demand</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-right w-20">Assigned</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-right w-20">Launch</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Decision</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Reason</th>
             </tr>
           </thead>
           <tbody>
             <template v-for="section in poolSections" :key="section.pool || '__unpooled'">
               <!-- Pool header row -->
-              <tr class="bg-surface border-b border-surface-border cursor-pointer hover:bg-surface-raised" @click="togglePool(section.pool)">
+              <tr class="bg-surface border-b border-surface-border hover:bg-surface-raised">
                 <td colspan="8" class="px-3 py-1.5">
                   <div class="flex items-center gap-2">
-                    <span class="text-[10px] text-text-muted">
-                      {{ collapsedPools.has(section.pool) ? '▶' : '▼' }}
-                    </span>
-                    <span class="text-xs font-semibold uppercase tracking-wider text-text-secondary">
-                      {{ section.pool === '__unpooled' ? 'Unpooled' : `Pool: ${section.pool}` }}
-                    </span>
+                    <button
+                      type="button"
+                      class="inline-flex items-center gap-2 text-left cursor-pointer hover:opacity-80"
+                      :aria-expanded="!collapsedPools.has(section.pool)"
+                      :aria-label="(collapsedPools.has(section.pool) ? 'Expand ' : 'Collapse ') + (section.pool === '__unpooled' ? 'unpooled groups' : 'pool ' + section.pool)"
+                      @click="togglePool(section.pool)"
+                    >
+                      <span class="text-[10px] text-text-muted">
+                        {{ collapsedPools.has(section.pool) ? '▶' : '▼' }}
+                      </span>
+                      <span class="text-xs font-semibold uppercase tracking-wider text-text-secondary">
+                        {{ section.pool === '__unpooled' ? 'Unpooled' : `Pool: ${section.pool}` }}
+                      </span>
+                    </button>
                     <span
                       v-if="section.blockedAtTier"
                       class="inline-flex items-center px-1.5 py-0.5 rounded text-xs border
@@ -976,6 +983,8 @@ function formatUptimeShort(ms: number | null): string {
                   <button
                     v-if="groupHasSlices(gs.group)"
                     class="inline-flex items-center gap-1 cursor-pointer hover:opacity-80"
+                    :aria-expanded="expandedSlices.has(gs.group)"
+                    :aria-label="(expandedSlices.has(gs.group) ? 'Hide' : 'Show') + ' slices for ' + gs.group"
                     @click="toggleSlices(gs.group)"
                   >
                     <span class="text-[10px] text-text-muted">
@@ -1014,6 +1023,8 @@ function formatUptimeShort(ms: number | null): string {
                   <button
                     v-if="groupDemand(gs.group) > 0"
                     class="cursor-pointer hover:opacity-80"
+                    :aria-expanded="expandedDemand.has(gs.group)"
+                    :aria-label="(expandedDemand.has(gs.group) ? 'Hide' : 'Show') + ' demand for ' + gs.group"
                     @click="toggleDemand(gs.group)"
                   >
                     <span class="text-[10px] text-text-muted mr-1">
@@ -1148,11 +1159,11 @@ function formatUptimeShort(ms: number | null): string {
         <table class="w-full border-collapse">
           <thead>
             <tr class="border-b border-surface-border bg-surface">
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Job</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Reasons</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-right w-20">Entries</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Example Task</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Accelerator</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Job</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Reasons</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-right w-20">Entries</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Example Task</th>
+              <th scope="col" class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Accelerator</th>
             </tr>
           </thead>
           <tbody>

--- a/lib/iris/dashboard/src/components/controller/JobsTab.vue
+++ b/lib/iris/dashboard/src/components/controller/JobsTab.vue
@@ -1,15 +1,18 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
-import { controllerRpcCall, RpcError, useControllerRpc } from '@/composables/useRpc'
+import type { LocationQueryValue } from 'vue-router'
+import { controllerRpcCall, useControllerRpc } from '@/composables/useRpc'
 import { useAutoRefresh, DEFAULT_REFRESH_MS } from '@/composables/useAutoRefresh'
-import { SEGMENT_COLORS, stateToName, stateDisplayName } from '@/types/status'
+import { SEGMENT_COLORS, stateDisplayName } from '@/types/status'
 import type { JobState } from '@/types/status'
-import type { JobStatus, JobQuery, ListJobsResponse, GetJobStatusResponse } from '@/types/rpc'
+import type { JobStatus, JobQuery, ListJobsResponse } from '@/types/rpc'
 import { timestampMs, formatDuration, formatRelativeTime } from '@/utils/formatting'
 import { flattenLoadedJobTree, getLeafJobName } from '@/utils/jobTree'
 import StatusBadge from '@/components/shared/StatusBadge.vue'
 import EmptyState from '@/components/shared/EmptyState.vue'
+import LoadingSpinner from '@/components/shared/LoadingSpinner.vue'
+import UsersOverview from '@/components/controller/UsersOverview.vue'
 import { useMediaQuery } from '@/composables/useMediaQuery'
 
 // Tailwind's `sm` breakpoint is 640px. Below that we render mobile cards;
@@ -46,16 +49,24 @@ const route = useRoute()
 const router = useRouter()
 
 const EXPANDED_JOBS_KEY = 'iris.controller.expandedJobs'
-const STARRED_JOBS_KEY = 'iris.controller.starredJobs'
-const MAX_STARRED_JOBS = 10
 
-// -- State (hydrated from URL query params) --
+// -- Front-page mode --
+//
+// The landing page (`/`) groups jobs by their top-level owner via
+// UsersOverview. Drilling into a user (`/?user=<id>`) renders this jobs table
+// scoped to that owner; `/?all=1` shows the flat, cross-user root list for ops.
+// `selectedUser` / `showAll` are derived from the URL so back/forward and
+// shared links land on the same view.
 
-/** Safely extract a single string from a Vue Router query value (string | string[] | null). */
-function queryStr(v: string | string[] | null | undefined): string {
+/** Safely extract a single string from a Vue Router query value. */
+function queryStr(v: LocationQueryValue | LocationQueryValue[] | undefined): string {
   if (Array.isArray(v)) return v[0] ?? ''
   return v ?? ''
 }
+
+const selectedUser = computed(() => queryStr(route.query.user))
+const showAll = computed(() => queryStr(route.query.all) === '1')
+const inJobList = computed(() => !!selectedUser.value || showAll.value)
 
 function parseSort(v: string): SortField {
   return SORT_FIELDS.includes(v as SortField) ? (v as SortField) : 'date'
@@ -77,16 +88,14 @@ const stateFilter = ref(queryStr(route.query.state))
 const expandedJobs = ref<Set<string>>(loadExpandedJobs())
 const childJobsByParent = ref<Map<string, JobStatus[]>>(new Map())
 const loadingChildJobs = ref<Set<string>>(new Set())
-const starredJobIds = ref<Set<string>>(loadStarredJobs())
-const showStarredOnly = ref(queryStr(route.query.starred) === '1')
-const starredJobsData = ref<JobStatus[]>([])
-const starredLoading = ref(false)
-const starredError = ref<string | null>(null)
-const starLimitNotice = ref<string | null>(null)
 
 const JOB_STATES: JobState[] = [
   'pending', 'building', 'running', 'succeeded', 'failed', 'killed', 'worker_failed', 'unschedulable',
 ]
+
+// Anchored prefix that scopes the root list to one owner. Job ids are wire
+// names of the form `/<user>/<job>`, so the prefix is `/<user>/`.
+const jobIdPrefix = computed(() => (selectedUser.value ? `/${selectedUser.value}/` : undefined))
 
 const {
   data: listResponse,
@@ -102,6 +111,7 @@ const {
     sortDirection: sortDir.value === 'asc' ? 'SORT_DIRECTION_ASC' : 'SORT_DIRECTION_DESC',
     nameFilter: nameFilter.value || undefined,
     stateFilter: stateFilter.value || undefined,
+    jobIdPrefix: jobIdPrefix.value,
   } satisfies JobQuery,
 }))
 
@@ -125,85 +135,6 @@ function saveExpandedJobs() {
     sessionStorage.setItem(EXPANDED_JOBS_KEY, JSON.stringify([...expandedJobs.value]))
   } catch {
     // ignore
-  }
-}
-
-// -- Local storage for starred jobs (persists across sessions) --
-
-function loadStarredJobs(): Set<string> {
-  try {
-    const stored = localStorage.getItem(STARRED_JOBS_KEY)
-    return stored ? new Set(JSON.parse(stored) as string[]) : new Set()
-  } catch {
-    return new Set()
-  }
-}
-
-function saveStarredJobs() {
-  try {
-    localStorage.setItem(STARRED_JOBS_KEY, JSON.stringify([...starredJobIds.value]))
-  } catch {
-    // ignore
-  }
-}
-
-function toggleStar(job: JobStatus) {
-  const next = new Set(starredJobIds.value)
-  if (next.has(job.jobId)) {
-    next.delete(job.jobId)
-  } else {
-    if (next.size >= MAX_STARRED_JOBS) {
-      starLimitNotice.value = `You can star at most ${MAX_STARRED_JOBS} jobs — unstar one first.`
-      setTimeout(() => { starLimitNotice.value = null }, 4000)
-      return
-    }
-    next.add(job.jobId)
-  }
-  starredJobIds.value = next
-  saveStarredJobs()
-  if (showStarredOnly.value) {
-    void fetchStarredJobs()
-  }
-}
-
-// Fetch each starred job individually — the ListJobs RPC does not support
-// filtering by a set of job IDs, so this is the simplest correct way to
-// show only starred jobs without losing any due to pagination.
-async function fetchStarredJobs() {
-  const ids = [...starredJobIds.value]
-  if (ids.length === 0) {
-    starredJobsData.value = []
-    starredError.value = null
-    return
-  }
-  starredLoading.value = true
-  starredError.value = null
-  try {
-    const results = await Promise.allSettled(
-      ids.map(id => controllerRpcCall<GetJobStatusResponse>('GetJobStatus', { jobId: id })),
-    )
-    // Auto-prune stars the controller confirms it no longer knows about.
-    // A 404 from GetJobStatus is a definitive NOT_FOUND — the job has been
-    // evicted from controller state, so there's no row UI to unstar from.
-    // Other failure modes (5xx, network) are treated as transient.
-    const goneIds = results.flatMap((r, i) =>
-      r.status === 'rejected' && r.reason instanceof RpcError && r.reason.status === 404 ? [ids[i]] : [],
-    )
-    if (goneIds.length > 0) {
-      const next = new Set(starredJobIds.value)
-      for (const id of goneIds) next.delete(id)
-      starredJobIds.value = next
-      saveStarredJobs()
-    }
-    starredJobsData.value = results
-      .filter((r): r is PromiseFulfilledResult<GetJobStatusResponse> => r.status === 'fulfilled' && !!r.value?.job)
-      .map(r => r.value.job)
-    const transientFailures = results.length - starredJobsData.value.length - goneIds.length
-    if (transientFailures > 0 && starredJobsData.value.length === 0) {
-      starredError.value = `Failed to load ${transientFailures} starred job${transientFailures !== 1 ? 's' : ''}`
-    }
-  } finally {
-    starredLoading.value = false
   }
 }
 
@@ -236,11 +167,7 @@ async function refreshExpandedChildren() {
 }
 
 async function fetchAll() {
-  if (showStarredOnly.value) {
-    await fetchStarredJobs()
-    await refreshExpandedChildren()
-    return
-  }
+  if (!inJobList.value) return  // UsersOverview owns its own data
   await fetchJobs()
   await refreshExpandedChildren()
 }
@@ -248,27 +175,23 @@ async function fetchAll() {
 onMounted(fetchAll)
 useAutoRefresh(fetchAll, DEFAULT_REFRESH_MS)
 
-watch([page, sortField, sortDir, nameFilter, stateFilter], () => {
+// Re-fetch from scratch whenever the scope or any query knob changes.
+watch([page, sortField, sortDir, nameFilter, stateFilter, selectedUser, showAll], () => {
   childJobsByParent.value = new Map()
   expandedJobs.value = new Set()
   saveExpandedJobs()
-  if (!showStarredOnly.value) fetchJobs()
+  if (inJobList.value) fetchJobs()
 })
 
-watch(showStarredOnly, (on) => {
-  childJobsByParent.value = new Map()
-  expandedJobs.value = new Set()
-  saveExpandedJobs()
-  if (on) void fetchStarredJobs()
-  else void fetchJobs()
-})
-
-watch(stateFilter, () => {
+// A different owner (or the all-jobs view) is a different result set — start at
+// the first page so a stale offset can't land out of range.
+watch([stateFilter, selectedUser, showAll], () => {
   page.value = 0
 })
 
 // Sync filter/sort/page state into the URL so back-button and link sharing work.
-watch([page, sortField, sortDir, nameFilter, stateFilter, showStarredOnly], () => {
+// `user`/`all` are spread through from the current query untouched.
+watch([page, sortField, sortDir, nameFilter, stateFilter], () => {
   router.replace({
     query: {
       ...route.query,
@@ -277,62 +200,13 @@ watch([page, sortField, sortDir, nameFilter, stateFilter, showStarredOnly], () =
       page: page.value !== 0 ? String(page.value) : undefined,
       name: nameFilter.value || undefined,
       state: stateFilter.value || undefined,
-      starred: showStarredOnly.value ? '1' : undefined,
     },
   })
 })
 
-// -- Starred-only client-side filter + sort --
-
-function jobSortKey(job: JobStatus, field: SortField): number | string {
-  switch (field) {
-    case 'date': return timestampMs(job.submittedAt) || 0
-    case 'name': return job.name ?? ''
-    case 'state': return stateToName(job.state)
-    case 'failures': return job.failureCount ?? 0
-    case 'preemptions': return job.preemptionCount ?? 0
-  }
-}
-
-function compareJobs(a: JobStatus, b: JobStatus): number {
-  const av = jobSortKey(a, sortField.value)
-  const bv = jobSortKey(b, sortField.value)
-  const sign = sortDir.value === 'asc' ? 1 : -1
-  if (typeof av === 'number' && typeof bv === 'number') return (av - bv) * sign
-  return String(av).localeCompare(String(bv)) * sign
-}
-
-const filteredStarredJobs = computed(() => {
-  const ids = starredJobIds.value
-  const nameF = nameFilter.value.toLowerCase()
-  const stateF = stateFilter.value
-  return starredJobsData.value
-    .filter(j => ids.has(j.jobId))
-    .filter(j => !nameF || (j.name ?? '').toLowerCase().includes(nameF))
-    .filter(j => !stateF || stateToName(j.state) === stateF)
-    .slice()
-    .sort(compareJobs)
-})
-
-const effectiveJobs = computed(() => showStarredOnly.value ? filteredStarredJobs.value : jobs.value)
-const effectiveLoading = computed(() => showStarredOnly.value ? starredLoading.value : loading.value)
-const effectiveError = computed(() => showStarredOnly.value ? starredError.value : error.value)
-const effectiveTotalCount = computed(() => showStarredOnly.value ? filteredStarredJobs.value.length : totalCount.value)
-
 // -- Job tree (lazy-loaded children) --
 
-const flattenedJobs = computed(() => flattenLoadedJobTree(effectiveJobs.value, childJobsByParent.value, expandedJobs.value))
-
-// Whether a row should render the expand toggle. In starred-only mode we
-// may have fetched the job via GetJobStatus against an older controller
-// that doesn't populate `has_children`; show the toggle defensively for
-// top-level rows and let `loadChildJobs` reveal whether it actually has
-// children.
-function showExpandToggle(job: JobStatus, depth: number): boolean {
-  if (job.hasChildren) return true
-  if (showStarredOnly.value && depth === 0) return true
-  return false
-}
+const flattenedJobs = computed(() => flattenLoadedJobTree(jobs.value, childJobsByParent.value, expandedJobs.value))
 
 // -- Interactions --
 async function toggleExpanded(job: JobStatus) {
@@ -379,11 +253,10 @@ function handleFilterClear() {
   localFilter.value = ''
   nameFilter.value = ''
   stateFilter.value = ''
-  showStarredOnly.value = false
   page.value = 0
 }
 
-const hasActiveFilter = computed(() => !!nameFilter.value || !!stateFilter.value || showStarredOnly.value)
+const hasActiveFilter = computed(() => !!nameFilter.value || !!stateFilter.value)
 
 // -- Formatting --
 
@@ -477,12 +350,28 @@ function sortIndicator(field: SortField): string {
 }
 </script>
 
+
 <template>
+  <!-- Front page: group jobs by owner. The jobs table only renders once the
+       user has drilled into an owner or chosen the flat all-jobs view. -->
+  <UsersOverview v-if="!inJobList" />
+
+  <template v-else>
+  <!-- Breadcrumb back to the user overview -->
+  <nav class="mb-4 flex items-center gap-1.5 text-sm" aria-label="Breadcrumb">
+    <RouterLink :to="{ path: '/' }" class="text-accent hover:underline">Users</RouterLink>
+    <span class="text-text-muted" aria-hidden="true">/</span>
+    <span class="font-mono font-semibold text-text">
+      {{ selectedUser || 'All jobs' }}
+    </span>
+  </nav>
+
   <!-- Filter bar -->
   <div class="mb-4 flex flex-wrap items-center gap-2 sm:gap-3">
     <form class="flex flex-wrap flex-1 sm:flex-initial gap-2" @submit.prevent="handleFilterSubmit">
       <select
         v-model="stateFilter"
+        aria-label="Filter by state"
         class="px-3 py-1.5 text-sm border border-surface-border rounded
                bg-surface text-text
                focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent"
@@ -494,6 +383,7 @@ function sortIndicator(field: SortField): string {
         v-model="localFilter"
         type="text"
         placeholder="Filter by name..."
+        aria-label="Filter by job name"
         class="flex-1 sm:flex-initial sm:w-52 px-3 py-1.5 text-sm border border-surface-border rounded
                bg-surface placeholder:text-text-muted
                focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent"
@@ -513,64 +403,26 @@ function sortIndicator(field: SortField): string {
         Reset
       </button>
     </form>
-    <button
-      type="button"
-      :class="[
-        'inline-flex items-center gap-1.5 px-3 py-1.5 text-sm border rounded',
-        showStarredOnly
-          ? 'border-status-warning-border bg-status-warning-bg text-status-warning'
-          : 'border-surface-border hover:bg-surface-raised',
-      ]"
-      :title="showStarredOnly ? 'Show all jobs' : 'Show only starred jobs'"
-      @click="showStarredOnly = !showStarredOnly"
-    >
-      <svg v-if="showStarredOnly" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-        <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.966a1 1 0 00.95.69h4.17c.969 0 1.371 1.24.588 1.81l-3.37 2.45a1 1 0 00-.364 1.118l1.287 3.966c.3.922-.755 1.688-1.54 1.118l-3.37-2.45a1 1 0 00-1.176 0l-3.37 2.45c-.784.57-1.838-.196-1.539-1.118l1.287-3.966a1 1 0 00-.364-1.118L2.06 9.393c-.783-.57-.38-1.81.588-1.81h4.17a1 1 0 00.95-.69l1.286-3.966z" />
-      </svg>
-      <svg v-else class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-      </svg>
-      Starred
-      <span v-if="starredJobIds.size > 0" class="text-xs tabular-nums opacity-70">
-        ({{ starredJobIds.size }})
-      </span>
-    </button>
     <span class="text-[13px] text-text-secondary">
-      {{ effectiveTotalCount }} job{{ effectiveTotalCount !== 1 ? 's' : '' }}
+      {{ totalCount }} job{{ totalCount !== 1 ? 's' : '' }}
     </span>
   </div>
 
   <!-- Error -->
   <div
-    v-if="effectiveError"
+    v-if="error"
     class="mb-4 px-4 py-3 text-sm text-status-danger bg-status-danger-bg rounded-lg border border-status-danger-border"
   >
-    {{ effectiveError }}
-  </div>
-
-  <!-- Star-limit notice -->
-  <div
-    v-if="starLimitNotice"
-    class="mb-4 px-4 py-2 text-sm text-status-warning bg-status-warning-bg rounded-lg border border-status-warning-border"
-  >
-    {{ starLimitNotice }}
+    {{ error }}
   </div>
 
   <!-- Loading -->
-  <div v-if="effectiveLoading && effectiveJobs.length === 0" class="flex items-center justify-center py-12 text-text-muted text-sm">
-    <svg class="animate-spin -ml-1 mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-    </svg>
-    Loading...
-  </div>
+  <LoadingSpinner v-if="loading && jobs.length === 0" />
 
   <!-- Empty state -->
   <EmptyState
-    v-else-if="!effectiveLoading && effectiveJobs.length === 0"
-    :message="showStarredOnly && starredJobIds.size === 0
-      ? 'No starred jobs — click the star next to a top-level job to pin it here'
-      : (hasActiveFilter ? 'No jobs matching filter' : 'No jobs')"
+    v-else-if="!loading && jobs.length === 0"
+    :message="hasActiveFilter ? 'No jobs matching filter' : 'No jobs'"
   />
 
   <!-- Mobile/desktop split: cards on xs, table on sm+. Pagination is shared.
@@ -585,11 +437,13 @@ function sortIndicator(field: SortField): string {
       class="rounded-lg border border-surface-border bg-surface px-3 py-2"
       :style="node.depth > 0 ? { marginLeft: (Math.min(node.depth, 3) * 12) + 'px' } : undefined"
     >
-      <!-- Row 1: expand, name, star -->
+      <!-- Row 1: expand, name -->
       <div class="flex items-start gap-1.5">
         <button
-          v-if="showExpandToggle(node.job, node.depth)"
+          v-if="node.job.hasChildren"
           class="text-text-muted hover:text-text select-none w-4 text-center text-xs shrink-0 mt-0.5"
+          :aria-label="expandedJobs.has(node.job.jobId) ? 'Collapse children' : 'Expand children'"
+          :aria-expanded="expandedJobs.has(node.job.jobId)"
           @click.stop="toggleExpanded(node.job)"
         >
           {{ loadingChildJobs.has(node.job.jobId) ? '…' : (expandedJobs.has(node.job.jobId) ? '▼' : '▶') }}
@@ -601,24 +455,6 @@ function sortIndicator(field: SortField): string {
         >
           {{ node.depth > 0 ? getLeafJobName(node.job.name) : (node.job.name || 'unnamed') }}
         </RouterLink>
-        <button
-          v-if="node.depth === 0"
-          :class="[
-            'shrink-0 p-1 -m-1',
-            starredJobIds.has(node.job.jobId)
-              ? 'text-status-warning'
-              : 'text-text-muted hover:text-text',
-          ]"
-          :title="starredJobIds.has(node.job.jobId) ? 'Unstar job' : 'Star job'"
-          @click.stop="toggleStar(node.job)"
-        >
-          <svg v-if="starredJobIds.has(node.job.jobId)" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor">
-            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.966a1 1 0 00.95.69h4.17c.969 0 1.371 1.24.588 1.81l-3.37 2.45a1 1 0 00-.364 1.118l1.287 3.966c.3.922-.755 1.688-1.54 1.118l-3.37-2.45a1 1 0 00-1.176 0l-3.37 2.45c-.784.57-1.838-.196-1.539-1.118l1.287-3.966a1 1 0 00-.364-1.118L2.06 9.393c-.783-.57-.38-1.81.588-1.81h4.17a1 1 0 00.95-.69l1.286-3.966z" />
-          </svg>
-          <svg v-else class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-          </svg>
-        </button>
       </div>
       <!-- Row 2: state + counters -->
       <div class="mt-1.5 pl-5 flex items-center gap-2 flex-wrap">
@@ -667,6 +503,8 @@ function sortIndicator(field: SortField): string {
           <th
             v-for="col in SORTABLE_COLS"
             :key="col.field"
+            scope="col"
+            :aria-sort="sortField === col.field ? (sortDir === 'asc' ? 'ascending' : 'descending') : 'none'"
             :class="[
               'px-2 sm:px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary',
               'cursor-pointer select-none hover:text-text',
@@ -681,10 +519,10 @@ function sortIndicator(field: SortField): string {
               </span>
             </span>
           </th>
-          <th class="px-2 sm:px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">
+          <th scope="col" class="px-2 sm:px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">
             Tasks
           </th>
-          <th class="hidden lg:table-cell px-2 sm:px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">
+          <th scope="col" class="hidden lg:table-cell px-2 sm:px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">
             Diagnostic
           </th>
         </tr>
@@ -702,8 +540,10 @@ function sortIndicator(field: SortField): string {
           >
             <span class="inline-flex items-center gap-1 max-w-full">
               <button
-                v-if="showExpandToggle(node.job, node.depth)"
+                v-if="node.job.hasChildren"
                 class="text-text-muted hover:text-text select-none w-4 text-center text-xs shrink-0"
+                :aria-label="expandedJobs.has(node.job.jobId) ? 'Collapse children' : 'Expand children'"
+                :aria-expanded="expandedJobs.has(node.job.jobId)"
                 @click.stop="toggleExpanded(node.job)"
               >
                 {{ loadingChildJobs.has(node.job.jobId) ? '…' : (expandedJobs.has(node.job.jobId) ? '▼' : '▶') }}
@@ -718,33 +558,16 @@ function sortIndicator(field: SortField): string {
               <button
                 v-if="node.job.name"
                 class="ml-1 text-text-muted hover:text-text opacity-0 group-hover/row:opacity-100 transition-opacity shrink-0"
+                :aria-label="'Copy job name ' + node.job.name"
                 title="Copy job name"
                 @click.stop="copyJobName(node.job.name)"
               >
-                <svg v-if="copiedJob === node.job.name" class="w-3.5 h-3.5 text-status-success" viewBox="0 0 20 20" fill="currentColor">
+                <svg v-if="copiedJob === node.job.name" class="w-3.5 h-3.5 text-status-success" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
                   <path fill-rule="evenodd" d="M16.707 5.293a1 1 0 010 1.414l-8 8a1 1 0 01-1.414 0l-4-4a1 1 0 011.414-1.414L8 12.586l7.293-7.293a1 1 0 011.414 0z" clip-rule="evenodd" />
                 </svg>
-                <svg v-else class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+                <svg v-else class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" aria-hidden="true">
                   <rect x="9" y="9" width="13" height="13" rx="2" ry="2" />
                   <path d="M5 15H4a2 2 0 01-2-2V4a2 2 0 012-2h9a2 2 0 012 2v1" />
-                </svg>
-              </button>
-              <button
-                v-if="node.depth === 0"
-                :class="[
-                  'ml-1 transition-opacity shrink-0',
-                  starredJobIds.has(node.job.jobId)
-                    ? 'text-status-warning opacity-100'
-                    : 'text-text-muted hover:text-text opacity-0 group-hover/row:opacity-100',
-                ]"
-                :title="starredJobIds.has(node.job.jobId) ? 'Unstar job' : 'Star job'"
-                @click.stop="toggleStar(node.job)"
-              >
-                <svg v-if="starredJobIds.has(node.job.jobId)" class="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor">
-                  <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.966a1 1 0 00.95.69h4.17c.969 0 1.371 1.24.588 1.81l-3.37 2.45a1 1 0 00-.364 1.118l1.287 3.966c.3.922-.755 1.688-1.54 1.118l-3.37-2.45a1 1 0 00-1.176 0l-3.37 2.45c-.784.57-1.838-.196-1.539-1.118l1.287-3.966a1 1 0 00-.364-1.118L2.06 9.393c-.783-.57-.38-1.81.588-1.81h4.17a1 1 0 00.95-.69l1.286-3.966z" />
-                </svg>
-                <svg v-else class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                  <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
                 </svg>
               </button>
             </span>
@@ -813,7 +636,7 @@ function sortIndicator(field: SortField): string {
 
   <!-- Pagination (shared between mobile cards and desktop table) -->
   <div
-    v-if="!showStarredOnly && totalPages > 1"
+    v-if="totalPages > 1"
     class="mt-2 flex items-center justify-between px-2 sm:px-3 py-2 text-xs text-text-secondary border-t border-surface-border"
   >
     <span>
@@ -838,5 +661,6 @@ function sortIndicator(field: SortField): string {
       </button>
     </div>
   </div>
+  </template>
   </template>
 </template>

--- a/lib/iris/dashboard/src/components/controller/SchedulerTab.vue
+++ b/lib/iris/dashboard/src/components/controller/SchedulerTab.vue
@@ -18,6 +18,7 @@ import { timestampMs, formatRelativeTime, bandDisplayName, bandColor } from '@/u
 import { DIVERGING_COLORS } from '@/types/status'
 import EmptyState from '@/components/shared/EmptyState.vue'
 import StatusBadge from '@/components/shared/StatusBadge.vue'
+import LoadingSpinner from '@/components/shared/LoadingSpinner.vue'
 
 // -- Scheduler State --
 
@@ -242,34 +243,28 @@ const hasData = computed(() => schedulerData.value || usersData.value)
   </div>
 
   <!-- Loading -->
-  <div v-if="loading" class="flex items-center justify-center py-12 text-text-muted text-sm">
-    <svg class="animate-spin -ml-1 mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-    </svg>
-    Loading...
-  </div>
+  <LoadingSpinner v-if="loading" label="Loading scheduler state…" />
 
   <div v-else-if="hasData" class="space-y-8">
     <!-- User Overview (merged Users tab + Scheduler budgets) -->
     <section>
-      <h2 class="text-lg font-semibold mb-3">Users &amp; Quotas</h2>
+      <h3 class="text-sm font-semibold text-text-secondary uppercase tracking-wider mb-3">Users &amp; Quotas</h3>
       <EmptyState v-if="mergedUsers.length === 0" message="No users" />
       <div v-else class="overflow-x-auto">
         <table class="w-full border-collapse">
           <thead>
             <tr class="border-b border-surface-border">
-              <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">User</th>
-              <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Active Jobs</th>
-              <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Running</th>
-              <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Pending</th>
-              <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Running Tasks</th>
-              <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary" title="Running / pending tasks per effective priority band">By Band</th>
-              <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Total Tasks</th>
-              <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Spent</th>
-              <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Limit</th>
-              <th class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Utilization</th>
-              <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Band</th>
+              <th scope="col" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">User</th>
+              <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Active Jobs</th>
+              <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Running</th>
+              <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Pending</th>
+              <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Running Tasks</th>
+              <th scope="col" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary" title="Running / pending tasks per effective priority band">By Band</th>
+              <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Total Tasks</th>
+              <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Spent</th>
+              <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Limit</th>
+              <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Utilization</th>
+              <th scope="col" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Band</th>
             </tr>
           </thead>
           <tbody>
@@ -278,7 +273,14 @@ const hasData = computed(() => schedulerData.value || usersData.value)
               :key="user.userId"
               class="border-b border-surface-border-subtle hover:bg-surface-raised transition-colors"
             >
-              <td class="px-3 py-2 text-[13px] font-mono">{{ user.userId || '(unknown)' }}</td>
+              <td class="px-3 py-2 text-[13px] font-mono">
+                <RouterLink
+                  v-if="user.userId"
+                  :to="{ path: '/', query: { user: user.userId } }"
+                  class="text-accent hover:underline"
+                >{{ user.userId }}</RouterLink>
+                <span v-else class="text-text-muted">(unknown)</span>
+              </td>
               <td class="px-3 py-2 text-[13px] text-right tabular-nums">{{ user.activeJobs }}</td>
               <td class="px-3 py-2 text-[13px] text-right tabular-nums">
                 <span :class="user.runningJobs > 0 ? 'text-accent font-semibold' : ''">{{ user.runningJobs }}</span>
@@ -337,13 +339,14 @@ const hasData = computed(() => schedulerData.value || usersData.value)
 
     <!-- Pending Jobs -->
     <section>
-      <h2 class="text-lg font-semibold mb-3">Pending Jobs ({{ unscheduledTotal }})</h2>
+      <h3 class="text-sm font-semibold text-text-secondary uppercase tracking-wider mb-3">Pending Jobs ({{ unscheduledTotal }})</h3>
       <div class="flex items-center gap-3 mb-3">
         <form class="flex items-center gap-2" @submit.prevent="applyUnscheduledSearch">
           <input
             v-model="unscheduledSearchInput"
             type="text"
             placeholder="Search by job name..."
+            aria-label="Search pending jobs by name"
             class="w-64 px-3 py-1.5 bg-surface border border-surface-border rounded
                    text-sm font-mono placeholder:text-text-muted
                    focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent"
@@ -372,13 +375,7 @@ const hasData = computed(() => schedulerData.value || usersData.value)
         {{ unscheduledError }}
       </div>
 
-      <div v-if="unscheduledLoading && unscheduledJobs.length === 0" class="flex items-center justify-center py-8 text-text-muted text-sm">
-        <svg class="animate-spin -ml-1 mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
-          <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
-          <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
-        </svg>
-        Loading...
-      </div>
+      <LoadingSpinner v-if="unscheduledLoading && unscheduledJobs.length === 0" size="sm" />
 
       <EmptyState v-else-if="unscheduledJobs.length === 0" message="No pending jobs" />
 
@@ -386,12 +383,12 @@ const hasData = computed(() => schedulerData.value || usersData.value)
         <table class="w-full border-collapse">
           <thead>
             <tr class="border-b border-surface-border">
-              <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Job</th>
-              <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">User</th>
-              <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">State</th>
-              <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Priority</th>
-              <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Pending Reason</th>
-              <th class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Submitted</th>
+              <th scope="col" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Job</th>
+              <th scope="col" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">User</th>
+              <th scope="col" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">State</th>
+              <th scope="col" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Priority</th>
+              <th scope="col" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Pending Reason</th>
+              <th scope="col" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">Submitted</th>
             </tr>
           </thead>
           <tbody>

--- a/lib/iris/dashboard/src/components/controller/UsersOverview.vue
+++ b/lib/iris/dashboard/src/components/controller/UsersOverview.vue
@@ -1,0 +1,220 @@
+<script setup lang="ts">
+import { ref, computed, onMounted } from 'vue'
+import { RouterLink } from 'vue-router'
+import { useControllerRpc } from '@/composables/useRpc'
+import { useAutoRefresh, DEFAULT_REFRESH_MS } from '@/composables/useAutoRefresh'
+import type { ListUsersResponse, UserSummary } from '@/types/rpc'
+import EmptyState from '@/components/shared/EmptyState.vue'
+import LoadingSpinner from '@/components/shared/LoadingSpinner.vue'
+
+// The landing page groups jobs by their top-level owner (the user id, which is
+// the first path component of every job name). Each user drills into the jobs
+// table scoped to that owner (`/?user=<id>`). Stars pin a user to the top so
+// people can keep their own username one glance away.
+
+const STARRED_USERS_KEY = 'iris.controller.starredUsers'
+const MAX_STARRED_USERS = 10
+
+const TERMINAL_JOB_STATES = new Set(['succeeded', 'failed', 'killed', 'worker_failed', 'preempted'])
+
+const { data, loading, error, refresh } = useControllerRpc<ListUsersResponse>('ListUsers')
+
+onMounted(refresh)
+useAutoRefresh(refresh, DEFAULT_REFRESH_MS)
+
+const search = ref('')
+const starLimitNotice = ref<string | null>(null)
+const starredUsers = ref<Set<string>>(loadStarredUsers())
+
+function loadStarredUsers(): Set<string> {
+  try {
+    const stored = localStorage.getItem(STARRED_USERS_KEY)
+    return stored ? new Set(JSON.parse(stored) as string[]) : new Set()
+  } catch {
+    return new Set()
+  }
+}
+
+function saveStarredUsers() {
+  try {
+    localStorage.setItem(STARRED_USERS_KEY, JSON.stringify([...starredUsers.value]))
+  } catch {
+    // ignore
+  }
+}
+
+function toggleStar(user: string) {
+  const next = new Set(starredUsers.value)
+  if (next.has(user)) {
+    next.delete(user)
+  } else {
+    if (next.size >= MAX_STARRED_USERS) {
+      starLimitNotice.value = `You can star at most ${MAX_STARRED_USERS} users — unstar one first.`
+      setTimeout(() => { starLimitNotice.value = null }, 4000)
+      return
+    }
+    next.add(user)
+  }
+  starredUsers.value = next
+  saveStarredUsers()
+}
+
+interface UserRow {
+  user: string
+  activeJobs: number
+  runningJobs: number
+  pendingJobs: number
+  runningTasks: number
+  totalTasks: number
+  starred: boolean
+}
+
+function toRow(summary: UserSummary): UserRow {
+  const jobCounts = summary.jobStateCounts ?? {}
+  const taskCounts = summary.taskStateCounts ?? {}
+  const activeJobs = Object.entries(jobCounts)
+    .filter(([state]) => !TERMINAL_JOB_STATES.has(state))
+    .reduce((acc, [, count]) => acc + count, 0)
+  return {
+    user: summary.user,
+    activeJobs,
+    runningJobs: jobCounts['running'] ?? 0,
+    pendingJobs: (jobCounts['pending'] ?? 0) + (jobCounts['unschedulable'] ?? 0),
+    runningTasks: taskCounts['running'] ?? 0,
+    totalTasks: Object.values(taskCounts).reduce((a, b) => a + b, 0),
+    starred: starredUsers.value.has(summary.user),
+  }
+}
+
+const rows = computed<UserRow[]>(() => {
+  const term = search.value.trim().toLowerCase()
+  return (data.value?.users ?? [])
+    .map(toRow)
+    .filter(r => !term || r.user.toLowerCase().includes(term))
+    .sort((a, b) =>
+      Number(b.starred) - Number(a.starred) ||
+      b.activeJobs - a.activeJobs ||
+      b.runningTasks - a.runningTasks ||
+      a.user.localeCompare(b.user),
+    )
+})
+</script>
+
+<template>
+  <div>
+    <!-- Toolbar: search + escape hatch to the flat all-jobs view -->
+    <div class="mb-4 flex flex-wrap items-center gap-2 sm:gap-3">
+      <input
+        v-model="search"
+        type="text"
+        placeholder="Filter users…"
+        aria-label="Filter users by id"
+        class="flex-1 sm:flex-initial sm:w-64 px-3 py-1.5 text-sm border border-surface-border rounded
+               bg-surface placeholder:text-text-muted
+               focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent"
+      />
+      <span class="text-[13px] text-text-secondary">
+        {{ rows.length }} user{{ rows.length !== 1 ? 's' : '' }}
+      </span>
+      <RouterLink
+        :to="{ path: '/', query: { all: '1' } }"
+        class="ml-auto px-3 py-1.5 text-sm border border-surface-border rounded hover:bg-surface-raised text-text-secondary"
+      >
+        View all jobs &rarr;
+      </RouterLink>
+    </div>
+
+    <!-- Error -->
+    <div
+      v-if="error"
+      class="mb-4 px-4 py-3 text-sm text-status-danger bg-status-danger-bg rounded-lg border border-status-danger-border"
+    >
+      {{ error }}
+    </div>
+
+    <!-- Star-limit notice -->
+    <div
+      v-if="starLimitNotice"
+      class="mb-4 px-4 py-2 text-sm text-status-warning bg-status-warning-bg rounded-lg border border-status-warning-border"
+    >
+      {{ starLimitNotice }}
+    </div>
+
+    <LoadingSpinner v-if="loading && rows.length === 0" />
+
+    <EmptyState
+      v-else-if="rows.length === 0"
+      :message="search.trim() ? 'No users matching filter' : 'No users'"
+    />
+
+    <!-- User cards: starred first, then by activity. -->
+    <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
+      <div
+        v-for="row in rows"
+        :key="row.user"
+        class="group/card relative rounded-lg border bg-surface transition-colors hover:bg-surface-raised hover:border-accent/40"
+        :class="row.starred ? 'border-status-warning-border' : 'border-surface-border'"
+      >
+        <RouterLink
+          :to="{ path: '/', query: { user: row.user } }"
+          class="block px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/30 rounded-lg"
+          :aria-label="`View jobs for ${row.user || 'unknown user'}`"
+        >
+          <div class="flex items-center gap-2">
+            <span class="font-mono text-sm font-semibold text-accent truncate min-w-0 flex-1">
+              {{ row.user || '(unknown)' }}
+            </span>
+            <span class="text-text-muted text-xs shrink-0 opacity-0 group-hover/card:opacity-100 transition-opacity" aria-hidden="true">
+              &rarr;
+            </span>
+          </div>
+          <!-- Aggregate counts. Each metric is labelled in text, not encoded by
+               colour alone, so the card reads without relying on hue. -->
+          <dl class="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-[13px]">
+            <div class="flex items-center justify-between">
+              <dt class="text-text-secondary">Running</dt>
+              <dd class="tabular-nums" :class="row.runningJobs > 0 ? 'text-accent font-semibold' : 'text-text-muted'">
+                {{ row.runningJobs }}
+              </dd>
+            </div>
+            <div class="flex items-center justify-between">
+              <dt class="text-text-secondary">Pending</dt>
+              <dd class="tabular-nums" :class="row.pendingJobs > 0 ? 'text-status-warning font-semibold' : 'text-text-muted'">
+                {{ row.pendingJobs }}
+              </dd>
+            </div>
+            <div class="flex items-center justify-between">
+              <dt class="text-text-secondary">Active jobs</dt>
+              <dd class="tabular-nums text-text">{{ row.activeJobs }}</dd>
+            </div>
+            <div class="flex items-center justify-between">
+              <dt class="text-text-secondary">Running tasks</dt>
+              <dd class="tabular-nums" :class="row.runningTasks > 0 ? 'text-accent font-semibold' : 'text-text-muted'">
+                {{ row.runningTasks }}
+              </dd>
+            </div>
+          </dl>
+        </RouterLink>
+        <!-- Star toggle, overlaid top-right so it stays clear of the card link. -->
+        <button
+          type="button"
+          :aria-label="row.starred ? `Unstar ${row.user}` : `Star ${row.user}`"
+          :aria-pressed="row.starred"
+          :title="row.starred ? 'Unstar user' : 'Star user to pin it to the top'"
+          class="absolute top-2 right-2 p-1 rounded transition-colors"
+          :class="row.starred
+            ? 'text-status-warning'
+            : 'text-text-muted opacity-0 group-hover/card:opacity-100 focus:opacity-100 hover:text-text'"
+          @click="toggleStar(row.user)"
+        >
+          <svg v-if="row.starred" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.966a1 1 0 00.95.69h4.17c.969 0 1.371 1.24.588 1.81l-3.37 2.45a1 1 0 00-.364 1.118l1.287 3.966c.3.922-.755 1.688-1.54 1.118l-3.37-2.45a1 1 0 00-1.176 0l-3.37 2.45c-.784.57-1.838-.196-1.539-1.118l1.287-3.966a1 1 0 00-.364-1.118L2.06 9.393c-.783-.57-.38-1.81.588-1.81h4.17a1 1 0 00.95-.69l1.286-3.966z" />
+          </svg>
+          <svg v-else class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+          </svg>
+        </button>
+      </div>
+    </div>
+  </div>
+</template>

--- a/lib/iris/dashboard/src/components/controller/UsersOverview.vue
+++ b/lib/iris/dashboard/src/components/controller/UsersOverview.vue
@@ -86,6 +86,7 @@ function toRow(summary: UserSummary): UserRow {
   }
 }
 
+// Alphabetical by user id, with starred users pinned to the top.
 const rows = computed<UserRow[]>(() => {
   const term = search.value.trim().toLowerCase()
   return (data.value?.users ?? [])
@@ -93,8 +94,6 @@ const rows = computed<UserRow[]>(() => {
     .filter(r => !term || r.user.toLowerCase().includes(term))
     .sort((a, b) =>
       Number(b.starred) - Number(a.starred) ||
-      b.activeJobs - a.activeJobs ||
-      b.runningTasks - a.runningTasks ||
       a.user.localeCompare(b.user),
     )
 })
@@ -147,74 +146,65 @@ const rows = computed<UserRow[]>(() => {
       :message="search.trim() ? 'No users matching filter' : 'No users'"
     />
 
-    <!-- User cards: starred first, then by activity. -->
-    <div v-else class="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-3">
-      <div
-        v-for="row in rows"
-        :key="row.user"
-        class="group/card relative rounded-lg border bg-surface transition-colors hover:bg-surface-raised hover:border-accent/40"
-        :class="row.starred ? 'border-status-warning-border' : 'border-surface-border'"
-      >
-        <RouterLink
-          :to="{ path: '/', query: { user: row.user } }"
-          class="block px-4 py-3 focus:outline-none focus:ring-2 focus:ring-accent/30 rounded-lg"
-          :aria-label="`View jobs for ${row.user || 'unknown user'}`"
-        >
-          <div class="flex items-center gap-2">
-            <span class="font-mono text-sm font-semibold text-accent truncate min-w-0 flex-1">
-              {{ row.user || '(unknown)' }}
-            </span>
-            <span class="text-text-muted text-xs shrink-0 opacity-0 group-hover/card:opacity-100 transition-opacity" aria-hidden="true">
-              &rarr;
-            </span>
-          </div>
-          <!-- Aggregate counts. Each metric is labelled in text, not encoded by
-               colour alone, so the card reads without relying on hue. -->
-          <dl class="mt-2 grid grid-cols-2 gap-x-4 gap-y-1 text-[13px]">
-            <div class="flex items-center justify-between">
-              <dt class="text-text-secondary">Running</dt>
-              <dd class="tabular-nums" :class="row.runningJobs > 0 ? 'text-accent font-semibold' : 'text-text-muted'">
-                {{ row.runningJobs }}
-              </dd>
-            </div>
-            <div class="flex items-center justify-between">
-              <dt class="text-text-secondary">Pending</dt>
-              <dd class="tabular-nums" :class="row.pendingJobs > 0 ? 'text-status-warning font-semibold' : 'text-text-muted'">
-                {{ row.pendingJobs }}
-              </dd>
-            </div>
-            <div class="flex items-center justify-between">
-              <dt class="text-text-secondary">Active jobs</dt>
-              <dd class="tabular-nums text-text">{{ row.activeJobs }}</dd>
-            </div>
-            <div class="flex items-center justify-between">
-              <dt class="text-text-secondary">Running tasks</dt>
-              <dd class="tabular-nums" :class="row.runningTasks > 0 ? 'text-accent font-semibold' : 'text-text-muted'">
-                {{ row.runningTasks }}
-              </dd>
-            </div>
-          </dl>
-        </RouterLink>
-        <!-- Star toggle, overlaid top-right so it stays clear of the card link. -->
-        <button
-          type="button"
-          :aria-label="row.starred ? `Unstar ${row.user}` : `Star ${row.user}`"
-          :aria-pressed="row.starred"
-          :title="row.starred ? 'Unstar user' : 'Star user to pin it to the top'"
-          class="absolute top-2 right-2 p-1 rounded transition-colors"
-          :class="row.starred
-            ? 'text-status-warning'
-            : 'text-text-muted opacity-0 group-hover/card:opacity-100 focus:opacity-100 hover:text-text'"
-          @click="toggleStar(row.user)"
-        >
-          <svg v-if="row.starred" class="w-4 h-4" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
-            <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.966a1 1 0 00.95.69h4.17c.969 0 1.371 1.24.588 1.81l-3.37 2.45a1 1 0 00-.364 1.118l1.287 3.966c.3.922-.755 1.688-1.54 1.118l-3.37-2.45a1 1 0 00-1.176 0l-3.37 2.45c-.784.57-1.838-.196-1.539-1.118l1.287-3.966a1 1 0 00-.364-1.118L2.06 9.393c-.783-.57-.38-1.81.588-1.81h4.17a1 1 0 00.95-.69l1.286-3.966z" />
-          </svg>
-          <svg v-else class="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
-            <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
-          </svg>
-        </button>
-      </div>
+    <!-- Owner list: starred first, then alphabetical. -->
+    <div v-else class="overflow-x-auto">
+      <table class="w-full border-collapse">
+        <thead>
+          <tr class="border-b border-surface-border">
+            <th scope="col" class="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wider text-text-secondary">User</th>
+            <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Running</th>
+            <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Pending</th>
+            <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Active Jobs</th>
+            <th scope="col" class="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wider text-text-secondary">Running Tasks</th>
+          </tr>
+        </thead>
+        <tbody>
+          <tr
+            v-for="row in rows"
+            :key="row.user"
+            class="group/row border-b border-surface-border-subtle hover:bg-surface-raised transition-colors"
+          >
+            <td class="px-3 py-2 text-[13px]">
+              <span class="inline-flex items-center gap-1.5 max-w-full">
+                <button
+                  type="button"
+                  :aria-label="row.starred ? `Unstar ${row.user}` : `Star ${row.user}`"
+                  :aria-pressed="row.starred"
+                  :title="row.starred ? 'Unstar user' : 'Star user to pin it to the top'"
+                  class="shrink-0 transition-opacity"
+                  :class="row.starred
+                    ? 'text-status-warning opacity-100'
+                    : 'text-text-muted hover:text-text opacity-0 group-hover/row:opacity-100 focus:opacity-100'"
+                  @click="toggleStar(row.user)"
+                >
+                  <svg v-if="row.starred" class="w-3.5 h-3.5" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+                    <path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.286 3.966a1 1 0 00.95.69h4.17c.969 0 1.371 1.24.588 1.81l-3.37 2.45a1 1 0 00-.364 1.118l1.287 3.966c.3.922-.755 1.688-1.54 1.118l-3.37-2.45a1 1 0 00-1.176 0l-3.37 2.45c-.784.57-1.838-.196-1.539-1.118l1.287-3.966a1 1 0 00-.364-1.118L2.06 9.393c-.783-.57-.38-1.81.588-1.81h4.17a1 1 0 00.95-.69l1.286-3.966z" />
+                  </svg>
+                  <svg v-else class="w-3.5 h-3.5" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                    <polygon points="12 2 15.09 8.26 22 9.27 17 14.14 18.18 21.02 12 17.77 5.82 21.02 7 14.14 2 9.27 8.91 8.26 12 2" />
+                  </svg>
+                </button>
+                <RouterLink
+                  v-if="row.user"
+                  :to="{ path: '/', query: { user: row.user } }"
+                  class="text-accent hover:underline font-mono break-anywhere"
+                >{{ row.user }}</RouterLink>
+                <span v-else class="text-text-muted font-mono">(unknown)</span>
+              </span>
+            </td>
+            <td class="px-3 py-2 text-[13px] text-right tabular-nums">
+              <span :class="row.runningJobs > 0 ? 'text-accent font-semibold' : 'text-text-muted'">{{ row.runningJobs }}</span>
+            </td>
+            <td class="px-3 py-2 text-[13px] text-right tabular-nums">
+              <span :class="row.pendingJobs > 0 ? 'text-status-warning font-semibold' : 'text-text-muted'">{{ row.pendingJobs }}</span>
+            </td>
+            <td class="px-3 py-2 text-[13px] text-right tabular-nums text-text">{{ row.activeJobs }}</td>
+            <td class="px-3 py-2 text-[13px] text-right tabular-nums">
+              <span :class="row.runningTasks > 0 ? 'text-accent font-semibold' : 'text-text-muted'">{{ row.runningTasks }}</span>
+            </td>
+          </tr>
+        </tbody>
+      </table>
     </div>
   </div>
 </template>

--- a/lib/iris/dashboard/src/components/shared/LoadingSpinner.vue
+++ b/lib/iris/dashboard/src/components/shared/LoadingSpinner.vue
@@ -1,0 +1,30 @@
+<script setup lang="ts">
+withDefaults(
+  defineProps<{
+    label?: string
+    // Vertical padding of the centering wrapper. "lg" suits a full panel,
+    // "sm" a nested section.
+    size?: 'sm' | 'lg'
+  }>(),
+  {
+    label: 'Loading…',
+    size: 'lg',
+  },
+)
+</script>
+
+<template>
+  <div
+    role="status"
+    :class="[
+      'flex items-center justify-center text-text-muted text-sm',
+      size === 'lg' ? 'py-12' : 'py-8',
+    ]"
+  >
+    <svg class="animate-spin -ml-1 mr-2 h-4 w-4" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24" aria-hidden="true">
+      <circle class="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" stroke-width="4" />
+      <path class="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4z" />
+    </svg>
+    {{ label }}
+  </div>
+</template>

--- a/lib/iris/dashboard/src/types/rpc.ts
+++ b/lib/iris/dashboard/src/types/rpc.ts
@@ -135,6 +135,8 @@ export interface JobQuery {
   sortDirection?: string
   offset?: number
   limit?: number
+  // Anchored prefix match against the full wire job_id (e.g. "/alice/").
+  jobIdPrefix?: string
 }
 
 // -- Controller RPC Responses --

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -268,7 +268,7 @@ def capabilities(smoke_cluster) -> ClusterCapabilities:
 
 
 def test_dashboard_jobs_tab(smoke_cluster, smoke_page, smoke_screenshot):
-    """Jobs tab shows diverse states."""
+    """Landing page groups jobs by owner; drilling into the owner shows states."""
     quick = smoke_cluster.submit(TestJobs.quick, "smoke-simple")
     failed = smoke_cluster.submit(TestJobs.fail, "smoke-failed")
     running = smoke_cluster.submit(TestJobs.sleep, "smoke-running", 300)
@@ -277,12 +277,21 @@ def test_dashboard_jobs_tab(smoke_cluster, smoke_page, smoke_screenshot):
     smoke_cluster.wait(failed, timeout=smoke_cluster.job_timeout)
     smoke_cluster.wait_for_state(running, job_pb2.JOB_STATE_RUNNING, timeout=smoke_cluster.job_timeout)
 
+    user = quick.job_id.user
+
+    # Landing page is the per-owner overview, not a flat job list.
     dashboard_goto(smoke_page, f"{smoke_cluster.url}/")
+    wait_for_dashboard_ready(smoke_page)
+    assert_visible(smoke_page, f"text={user}")
+
+    # Drill into this owner to see their individual jobs and states.
+    dashboard_goto(smoke_page, f"{smoke_cluster.url}/#/?user={user}")
     wait_for_dashboard_ready(smoke_page)
     for name in ["smoke-simple", "smoke-failed", "smoke-running"]:
         assert_visible(smoke_page, f"text={name}")
     smoke_screenshot(
-        "jobs-tab", "Jobs tab listing smoke-simple (succeeded), smoke-failed (failed), and smoke-running (running)"
+        "jobs-tab",
+        f"Jobs for user {user}: smoke-simple (succeeded), smoke-failed (failed), and smoke-running (running)",
     )
 
     smoke_cluster.kill(running)
@@ -316,13 +325,14 @@ def test_dashboard_job_expand(smoke_cluster, smoke_page, smoke_screenshot):
     parent = smoke_cluster.submit(_parent_with_two_children, "smoke-expand-parent")
     smoke_cluster.wait(parent, timeout=smoke_cluster.job_timeout)
 
-    dashboard_goto(smoke_page, f"{smoke_cluster.url}/")
+    # Open the owner's scoped job list (the landing page groups by owner).
+    dashboard_goto(smoke_page, f"{smoke_cluster.url}/#/?user={parent.job_id.user}")
     wait_for_dashboard_ready(smoke_page)
     assert_visible(smoke_page, "text=smoke-expand-parent")
 
-    # The parent should have an expand arrow (▶)
+    # The parent row exposes a keyboard-accessible expand toggle.
     row = smoke_page.locator("tr", has_text="smoke-expand-parent")
-    expand_btn = row.get_by_role("button", name="▶")
+    expand_btn = row.get_by_role("button", name="Expand children")
     expand_btn.click()
 
     # After clicking, children should appear (wait for the child names to render)
@@ -331,8 +341,8 @@ def test_dashboard_job_expand(smoke_cluster, smoke_page, smoke_screenshot):
         timeout=10000,
     )
 
-    # Verify the arrow changed to ▼
-    row.get_by_role("button", name="▼").wait_for(timeout=5000)
+    # Once expanded, the toggle flips to a collapse affordance.
+    row.get_by_role("button", name="Collapse children").wait_for(timeout=5000)
 
     smoke_screenshot("job-expand", "Jobs tab with expanded parent showing child-a and child-b indented beneath")
 

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -325,6 +325,11 @@ def test_dashboard_job_expand(smoke_cluster, smoke_page, smoke_screenshot):
     parent = smoke_cluster.submit(_parent_with_two_children, "smoke-expand-parent")
     smoke_cluster.wait(parent, timeout=smoke_cluster.job_timeout)
 
+    # Route through the owner overview first so the subsequent drill-in is a
+    # genuine hash change (the smoke page is shared module-scope and may already
+    # be parked on this owner's view from an earlier test).
+    dashboard_goto(smoke_page, f"{smoke_cluster.url}/")
+    wait_for_dashboard_ready(smoke_page)
     # Open the owner's scoped job list (the landing page groups by owner).
     dashboard_goto(smoke_page, f"{smoke_cluster.url}/#/?user={parent.job_id.user}")
     wait_for_dashboard_ready(smoke_page)

--- a/lib/levanter/src/levanter/tracker/background.py
+++ b/lib/levanter/src/levanter/tracker/background.py
@@ -15,16 +15,15 @@ both guarantees:
   keeps running so subsequent updates still go through.
 * If the queue fills up (e.g. the wrapped tracker is wedged), additional
   updates are dropped with a rate-limited warning rather than blocking.
-* Payloads are fully prepared on the calling thread via the wrapped
-  tracker's :meth:`~levanter.tracker.tracker.Tracker._prepare_payload_async`
-  hook before they cross the queue. The default hook is ``jax.device_get`` —
-  for sharded arrays that transfer is a cross-host collective and must be
-  dispatched from the main thread in identical program order on every host
-  (otherwise multi-host launch IDs desync and the TPU slice halts). Trackers
-  that would otherwise dispatch JAX during their ``log_*`` methods (e.g. via
-  lazy properties on a pytree leaf, or by constructing backend-specific
-  objects like ``wandb.Histogram``) override the hook so that work also runs
-  on the producer thread. The worker thread does nothing but the upload.
+* Payloads are fully prepared on the calling thread via the wrapped tracker's
+  ``_prepare_log`` / ``_prepare_summary`` / ``_prepare_hyperparameters`` hooks
+  before they cross the queue. The default hooks call ``jax.device_get`` — for
+  sharded arrays that transfer is a cross-host collective and must be dispatched
+  from the main thread in identical program order on every host (otherwise
+  multi-host launch IDs desync and the TPU slice halts). Trackers that build
+  backend-specific objects (e.g. ``wandb.Histogram``) override the hooks so that
+  work runs on the producer thread too, leaving the worker to do nothing but the
+  upload.
 
 Tracker initialization is *not* wrapped. If e.g. ``wandb.init()`` fails
 because of bad auth, that's a fatal configuration problem and the run
@@ -129,27 +128,25 @@ class BackgroundTracker(Tracker):
                     dropped,
                 )
 
-    def _enqueue_data(self, method_name: str, payload, **kwargs) -> None:
-        """Fully prepare ``payload`` on the calling thread, then enqueue.
+    def _defer(self, prepare, method, payload, **kwargs) -> None:
+        """Prepare ``payload`` on the calling thread, then enqueue ``method``.
 
-        Delegates preparation to the wrapped tracker's
-        :meth:`~levanter.tracker.tracker.Tracker._prepare_payload_async` hook
-        (default: ``jax.device_get``). Trackers that build backend-specific
-        objects or access lazy JAX-y properties override the hook to fold that
-        work into the producer thread, so the queue only carries inert data
-        and the worker only does the upload.
+        ``prepare`` and ``method`` are bound methods of the wrapped tracker (e.g.
+        ``_prepare_log`` and ``log``). Preparation runs here, on the producer
+        thread, so the queue carries only inert data and the worker only does the
+        upload. A failure to prepare drops the update rather than crashing the
+        producer.
         """
-        method = getattr(self.wrapped, method_name)
         if self._stopped:
-            logger.debug("Background tracker '%s' already stopped; dropping %s", self.name, method_name)
+            logger.debug("Background tracker '%s' already stopped; dropping %s", self.name, method.__name__)
             return
         try:
-            payload = self.wrapped._prepare_payload_async(method_name, payload)
+            payload = prepare(payload)
         except Exception:
             logger.exception(
                 "Background tracker '%s' failed to prepare payload for %s; dropping update.",
                 self.name,
-                method_name,
+                method.__name__,
             )
             return
         self._enqueue(method, payload, **kwargs)
@@ -157,7 +154,7 @@ class BackgroundTracker(Tracker):
     # ---- Tracker API --------------------------------------------------------
 
     def log_hyperparameters(self, hparams: dict[str, Any]) -> None:
-        self._enqueue_data("log_hyperparameters", hparams)
+        self._defer(self.wrapped._prepare_hyperparameters, self.wrapped.log_hyperparameters, hparams)
 
     def log(
         self,
@@ -166,10 +163,10 @@ class BackgroundTracker(Tracker):
         step: Optional[int],
         commit: Optional[bool] = None,
     ) -> None:
-        self._enqueue_data("log", metrics, step=step, commit=commit)
+        self._defer(self.wrapped._prepare_log, self.wrapped.log, metrics, step=step, commit=commit)
 
     def log_summary(self, metrics: dict[str, Any]) -> None:
-        self._enqueue_data("log_summary", metrics)
+        self._defer(self.wrapped._prepare_summary, self.wrapped.log_summary, metrics)
 
     def log_artifact(
         self,

--- a/lib/levanter/src/levanter/tracker/background.py
+++ b/lib/levanter/src/levanter/tracker/background.py
@@ -15,15 +15,11 @@ both guarantees:
   keeps running so subsequent updates still go through.
 * If the queue fills up (e.g. the wrapped tracker is wedged), additional
   updates are dropped with a rate-limited warning rather than blocking.
-* Payloads are fully prepared on the calling thread via the wrapped tracker's
-  ``_prepare_log`` / ``_prepare_summary`` / ``_prepare_hyperparameters`` hooks
-  before they cross the queue. The default hooks call ``jax.device_get`` — for
-  sharded arrays that transfer is a cross-host collective and must be dispatched
-  from the main thread in identical program order on every host (otherwise
-  multi-host launch IDs desync and the TPU slice halts). Trackers that build
-  backend-specific objects (e.g. ``wandb.Histogram``) override the hooks so that
-  work runs on the producer thread too, leaving the worker to do nothing but the
-  upload.
+* Payloads are prepared on the calling thread via the wrapped tracker's
+  ``_prepare_*`` hooks before they cross the queue, so the worker only does I/O.
+  Keeping the ``jax.device_get`` there also matters for multi-host runs, where
+  that transfer is a collective that must stay in program order on the main
+  thread.
 
 Tracker initialization is *not* wrapped. If e.g. ``wandb.init()`` fails
 because of bad auth, that's a fatal configuration problem and the run
@@ -132,10 +128,8 @@ class BackgroundTracker(Tracker):
         """Prepare ``payload`` on the calling thread, then enqueue ``method``.
 
         ``prepare`` and ``method`` are bound methods of the wrapped tracker (e.g.
-        ``_prepare_log`` and ``log``). Preparation runs here, on the producer
-        thread, so the queue carries only inert data and the worker only does the
-        upload. A failure to prepare drops the update rather than crashing the
-        producer.
+        ``_prepare_log`` and ``log``). A failure to prepare drops the update
+        rather than crashing the producer.
         """
         if self._stopped:
             logger.debug("Background tracker '%s' already stopped; dropping %s", self.name, method.__name__)

--- a/lib/levanter/src/levanter/tracker/background.py
+++ b/lib/levanter/src/levanter/tracker/background.py
@@ -15,9 +15,16 @@ both guarantees:
   keeps running so subsequent updates still go through.
 * If the queue fills up (e.g. the wrapped tracker is wedged), additional
   updates are dropped with a rate-limited warning rather than blocking.
-* ``jax.Array`` metric values are materialized to host memory on the calling
-  thread before they cross the queue, so the worker never issues a JAX
-  device transfer / cross-host collective off the main thread.
+* Payloads are fully prepared on the calling thread via the wrapped
+  tracker's :meth:`~levanter.tracker.tracker.Tracker._prepare_payload_async`
+  hook before they cross the queue. The default hook is ``jax.device_get`` —
+  for sharded arrays that transfer is a cross-host collective and must be
+  dispatched from the main thread in identical program order on every host
+  (otherwise multi-host launch IDs desync and the TPU slice halts). Trackers
+  that would otherwise dispatch JAX during their ``log_*`` methods (e.g. via
+  lazy properties on a pytree leaf, or by constructing backend-specific
+  objects like ``wandb.Histogram``) override the hook so that work also runs
+  on the producer thread. The worker thread does nothing but the upload.
 
 Tracker initialization is *not* wrapped. If e.g. ``wandb.init()`` fails
 because of bad auth, that's a fatal configuration problem and the run
@@ -32,8 +39,6 @@ import threading
 import time
 import typing
 from typing import Any, Optional
-
-import jax
 
 from levanter.tracker.tracker import Tracker
 
@@ -124,25 +129,27 @@ class BackgroundTracker(Tracker):
                     dropped,
                 )
 
-    def _enqueue_data(self, method, payload, **kwargs) -> None:
-        """Materialize ``jax.Array`` leaves on the calling thread, then enqueue.
+    def _enqueue_data(self, method_name: str, payload, **kwargs) -> None:
+        """Fully prepare ``payload`` on the calling thread, then enqueue.
 
-        ``jax.device_get`` pulls every array leaf to host memory; for
-        sharded arrays that transfer is a cross-host collective and must be
-        dispatched from the main thread in identical program order on every
-        host (otherwise multi-host launch IDs desync and the TPU slice halts).
-        Doing it here keeps only inert numpy/Python data on the queue.
+        Delegates preparation to the wrapped tracker's
+        :meth:`~levanter.tracker.tracker.Tracker._prepare_payload_async` hook
+        (default: ``jax.device_get``). Trackers that build backend-specific
+        objects or access lazy JAX-y properties override the hook to fold that
+        work into the producer thread, so the queue only carries inert data
+        and the worker only does the upload.
         """
+        method = getattr(self.wrapped, method_name)
         if self._stopped:
-            logger.debug("Background tracker '%s' already stopped; dropping %s", self.name, method.__name__)
+            logger.debug("Background tracker '%s' already stopped; dropping %s", self.name, method_name)
             return
         try:
-            payload = jax.device_get(payload)
+            payload = self.wrapped._prepare_payload_async(method_name, payload)
         except Exception:
             logger.exception(
-                "Background tracker '%s' failed to materialize payload for %s; dropping update.",
+                "Background tracker '%s' failed to prepare payload for %s; dropping update.",
                 self.name,
-                method.__name__,
+                method_name,
             )
             return
         self._enqueue(method, payload, **kwargs)
@@ -150,7 +157,7 @@ class BackgroundTracker(Tracker):
     # ---- Tracker API --------------------------------------------------------
 
     def log_hyperparameters(self, hparams: dict[str, Any]) -> None:
-        self._enqueue_data(self.wrapped.log_hyperparameters, hparams)
+        self._enqueue_data("log_hyperparameters", hparams)
 
     def log(
         self,
@@ -159,10 +166,10 @@ class BackgroundTracker(Tracker):
         step: Optional[int],
         commit: Optional[bool] = None,
     ) -> None:
-        self._enqueue_data(self.wrapped.log, metrics, step=step, commit=commit)
+        self._enqueue_data("log", metrics, step=step, commit=commit)
 
     def log_summary(self, metrics: dict[str, Any]) -> None:
-        self._enqueue_data(self.wrapped.log_summary, metrics)
+        self._enqueue_data("log_summary", metrics)
 
     def log_artifact(
         self,

--- a/lib/levanter/src/levanter/tracker/histogram.py
+++ b/lib/levanter/src/levanter/tracker/histogram.py
@@ -33,7 +33,14 @@ class Histogram(equinox.Module):
 
 
 class SummaryStats(equinox.Module):
-    """Summary statistics for an array, optionally including a histogram."""
+    """Summary statistics for an array, optionally including a histogram.
+
+    Every statistic — including the derived ``mean``/``variance``/``rms`` — is
+    materialized eagerly at construction, inside the same trace that produced the
+    source array. Nothing is computed on attribute access, so a ``SummaryStats``
+    can be handed to another thread (e.g. a :class:`~levanter.tracker.background.BackgroundTracker`
+    worker) without ever dispatching JAX off the main thread.
+    """
 
     min: Scalar
     max: Scalar
@@ -41,7 +48,18 @@ class SummaryStats(equinox.Module):
     nonzero_count: Scalar
     sum: Scalar
     sum_squares: Scalar
+    mean: Scalar
+    variance: Scalar
+    rms: Scalar
     histogram: Histogram | None = None
+
+    @staticmethod
+    def _with_derived(min, max, num, nonzero_count, sum, sum_squares, histogram) -> "SummaryStats":
+        """Build a ``SummaryStats``, computing the derived moments eagerly."""
+        mean = sum / num
+        variance = (sum_squares / num) - (mean**2)
+        rms = jnp.sqrt(sum_squares / num)
+        return SummaryStats(min, max, num, nonzero_count, sum, sum_squares, mean, variance, rms, histogram)
 
     @staticmethod
     def from_array(
@@ -81,7 +99,7 @@ class SummaryStats(equinox.Module):
             edges = jnp.histogram_bin_edges(jnp.stack([min, max]), bins=num_bins)
             counts = sharded_histogram_array(array, edges)
             histogram = Histogram(edges, counts)
-        return SummaryStats(min, max, num, nonzero_count, sum, sum_squares, histogram)
+        return SummaryStats._with_derived(min, max, num, nonzero_count, sum, sum_squares, histogram)
 
     @staticmethod
     def from_named_array(
@@ -101,20 +119,7 @@ class SummaryStats(equinox.Module):
         if include_histogram:
             counts, edges = sharded_histogram(array, bins=num_bins)
             histogram = Histogram(edges, counts)
-        return SummaryStats(min, max, num, nonzero_count, sum, sum_squares, histogram)
-
-    @property
-    def mean(self) -> Scalar:
-        return self.sum / self.num
-
-    @property
-    def variance(self) -> Scalar:
-        """Calculate the variance as E[X^2] - (E[X])^2."""
-        return (self.sum_squares / self.num) - (self.mean**2)
-
-    @property
-    def rms(self) -> Scalar:
-        return jnp.sqrt(self.sum_squares / self.num)
+        return SummaryStats._with_derived(min, max, num, nonzero_count, sum, sum_squares, histogram)
 
     def to_numpy_histogram(self) -> tuple[np.ndarray, np.ndarray]:
         if self.histogram is None:

--- a/lib/levanter/src/levanter/tracker/histogram.py
+++ b/lib/levanter/src/levanter/tracker/histogram.py
@@ -35,11 +35,8 @@ class Histogram(equinox.Module):
 class SummaryStats(equinox.Module):
     """Summary statistics for an array, optionally including a histogram.
 
-    Every statistic — including the derived ``mean``/``variance``/``rms`` — is
-    materialized eagerly at construction, inside the same trace that produced the
-    source array. Nothing is computed on attribute access, so a ``SummaryStats``
-    can be handed to another thread (e.g. a :class:`~levanter.tracker.background.BackgroundTracker`
-    worker) without ever dispatching JAX off the main thread.
+    ``mean``/``variance``/``rms`` are computed at construction rather than on
+    access, so reading them from a background thread never calls JAX.
     """
 
     min: Scalar

--- a/lib/levanter/src/levanter/tracker/tracker.py
+++ b/lib/levanter/src/levanter/tracker/tracker.py
@@ -30,21 +30,27 @@ class Tracker(abc.ABC):
 
     name: str
 
-    def _prepare_payload_async(self, method_name: str, payload: Any) -> Any:
-        """Hook: materialize a method payload on the producer (caller) thread.
+    def _prepare_log(self, metrics: typing.Mapping[str, Any]) -> Any:
+        """Materialize a ``log`` payload on the producer (caller) thread.
 
-        Used by :class:`~levanter.tracker.background.BackgroundTracker` to keep all
-        JAX work on the producer thread, so the background worker only does I/O.
-        ``method_name`` is one of ``"log"``, ``"log_summary"``, or
-        ``"log_hyperparameters"``.
-
-        Default: ``jax.device_get(payload)`` — pulls every ``jax.Array`` leaf in the
-        pytree to host as numpy. Subclasses should override when their ``log_*``
-        methods would otherwise dispatch JAX on the worker thread (e.g. via lazy
-        properties on a pytree leaf), and instead fold that work into the prepared
-        payload here so the worker only does the upload.
+        :class:`~levanter.tracker.background.BackgroundTracker` calls this on the
+        producer thread so the background worker only does I/O. The default pulls
+        every ``jax.Array`` leaf to host with ``jax.device_get``; subclasses
+        override to fold backend-specific conversion (e.g. building
+        ``wandb.Histogram``) into the producer thread too. ``log`` calls it as
+        well, so direct (non-background) use takes the same path. Must be
+        idempotent: the background worker re-invokes ``log`` on the prepared
+        payload.
         """
-        return jax.device_get(payload)
+        return jax.device_get(metrics)
+
+    def _prepare_summary(self, metrics: typing.Mapping[str, Any]) -> Any:
+        """Producer-thread counterpart to :meth:`_prepare_log` for ``log_summary``."""
+        return jax.device_get(metrics)
+
+    def _prepare_hyperparameters(self, hparams: typing.Mapping[str, Any]) -> Any:
+        """Producer-thread counterpart to :meth:`_prepare_log` for ``log_hyperparameters``."""
+        return jax.device_get(hparams)
 
     @abc.abstractmethod
     def log_hyperparameters(self, hparams: dict[str, Any]):

--- a/lib/levanter/src/levanter/tracker/tracker.py
+++ b/lib/levanter/src/levanter/tracker/tracker.py
@@ -8,6 +8,7 @@ import typing
 from typing import Any, List, Optional
 
 import draccus
+import jax
 
 
 logger = logging.getLogger(__name__)
@@ -28,6 +29,22 @@ class Tracker(abc.ABC):
     """
 
     name: str
+
+    def _prepare_payload_async(self, method_name: str, payload: Any) -> Any:
+        """Hook: materialize a method payload on the producer (caller) thread.
+
+        Used by :class:`~levanter.tracker.background.BackgroundTracker` to keep all
+        JAX work on the producer thread, so the background worker only does I/O.
+        ``method_name`` is one of ``"log"``, ``"log_summary"``, or
+        ``"log_hyperparameters"``.
+
+        Default: ``jax.device_get(payload)`` — pulls every ``jax.Array`` leaf in the
+        pytree to host as numpy. Subclasses should override when their ``log_*``
+        methods would otherwise dispatch JAX on the worker thread (e.g. via lazy
+        properties on a pytree leaf), and instead fold that work into the prepared
+        payload here so the worker only does the upload.
+        """
+        return jax.device_get(payload)
 
     @abc.abstractmethod
     def log_hyperparameters(self, hparams: dict[str, Any]):

--- a/lib/levanter/src/levanter/tracker/tracker.py
+++ b/lib/levanter/src/levanter/tracker/tracker.py
@@ -31,16 +31,13 @@ class Tracker(abc.ABC):
     name: str
 
     def _prepare_log(self, metrics: typing.Mapping[str, Any]) -> Any:
-        """Materialize a ``log`` payload on the producer (caller) thread.
+        """Convert a ``log`` payload to host data, on the caller thread.
 
-        :class:`~levanter.tracker.background.BackgroundTracker` calls this on the
-        producer thread so the background worker only does I/O. The default pulls
-        every ``jax.Array`` leaf to host with ``jax.device_get``; subclasses
-        override to fold backend-specific conversion (e.g. building
-        ``wandb.Histogram``) into the producer thread too. ``log`` calls it as
-        well, so direct (non-background) use takes the same path. Must be
-        idempotent: the background worker re-invokes ``log`` on the prepared
-        payload.
+        Both ``log`` and :class:`~levanter.tracker.background.BackgroundTracker`
+        call this. The default pulls ``jax.Array`` leaves to host with
+        ``jax.device_get``; subclasses override to also fold in backend-specific
+        conversion. Must be idempotent — the background worker re-invokes ``log``
+        on the result.
         """
         return jax.device_get(metrics)
 

--- a/lib/levanter/src/levanter/tracker/wandb.py
+++ b/lib/levanter/src/levanter/tracker/wandb.py
@@ -68,6 +68,22 @@ class WandbTracker(Tracker):
         self._suppress_logging = suppress_logging
         self._minimum_log_step = minimum_log_step
 
+    def _prepare_payload_async(self, method_name: str, payload):
+        """Run the full wandb-side conversion on the producer thread.
+
+        The W&B ``log`` path constructs ``wandb.Histogram`` objects and accesses
+        lazy properties on :class:`~levanter.tracker.histogram.SummaryStats`
+        (``rms``/``mean``/``variance``) that use ``jnp.sqrt`` and division —
+        those would otherwise dispatch JAX from the background worker thread,
+        which segfaults during the W&B profiler upload on the H100 canary. We
+        do the entire conversion here so the worker only does I/O.
+        """
+        if method_name == "log":
+            return _convert_metrics_to_wandb_loggable(payload)
+        if method_name in ("log_summary", "log_hyperparameters"):
+            return _convert_value_to_loggable_rec(payload)
+        return super()._prepare_payload_async(method_name, payload)
+
     def log_hyperparameters(self, hparams: dict[str, Any]):
         if self._suppress_logging:
             return
@@ -88,15 +104,10 @@ class WandbTracker(Tracker):
 
         step = int(step)
 
-        # wandb histograms are pretty limited: they log only the counts and the bin edges.
-        # Our summary stats have the same scalar fields Tensorboard understands. We log those as separate values.
-        to_log = {}
-        for k, v in metrics.items():
-            if isinstance(v, SummaryStats):
-                to_log.update(_convert_summary_stats_to_loggable(k, v))
-            else:
-                # otherwise, just log the value normally
-                to_log[k] = _convert_value_to_loggable_rec(v)
+        # Conversion is idempotent: if metrics was already prepared on the producer
+        # thread (via ``_prepare_payload_async``), the dict has no SummaryStats and
+        # no jax.Arrays left, and this just re-wraps already-loggable values.
+        to_log = _convert_metrics_to_wandb_loggable(metrics)
 
         if self._suppress_logging:
             return
@@ -204,6 +215,27 @@ def _set_nested(target: dict[str, Any], path: list[str], value: Any) -> None:
             cur[key] = next_val
         cur = next_val
     cur[path[-1]] = value
+
+
+def _convert_metrics_to_wandb_loggable(metrics: typing.Mapping[str, Any]) -> dict[str, Any]:
+    """Flatten metrics into a wandb-ready dict.
+
+    Expands every :class:`SummaryStats` value into its individual loggable keys
+    (computing ``mean``/``variance``/``rms`` and building ``wandb.Histogram`` as
+    needed) and passes every other value through
+    :func:`_convert_value_to_loggable_rec`.
+
+    Pure conversion: no wandb run state is touched. Safe to call on the producer
+    thread before handing off to a :class:`BackgroundTracker` worker, and
+    idempotent when called a second time on an already-flat dict.
+    """
+    to_log: dict[str, Any] = {}
+    for k, v in metrics.items():
+        if isinstance(v, SummaryStats):
+            to_log.update(_convert_summary_stats_to_loggable(k, v))
+        else:
+            to_log[k] = _convert_value_to_loggable_rec(v)
+    return to_log
 
 
 def _convert_value_to_loggable_rec(value: Any):

--- a/lib/levanter/src/levanter/tracker/wandb.py
+++ b/lib/levanter/src/levanter/tracker/wandb.py
@@ -68,11 +68,9 @@ class WandbTracker(Tracker):
         self._suppress_logging = suppress_logging
         self._minimum_log_step = minimum_log_step
 
-    # The prepare hooks run the full wandb-side conversion (SummaryStats
-    # expansion and ``wandb.Histogram`` construction) on the producer thread, so
-    # the background worker only does the upload. They are pure and idempotent,
-    # so the worker re-invoking the corresponding ``log_*`` method on the already
-    # prepared payload is a cheap no-op.
+    # The prepare hooks do the full wandb-side conversion (SummaryStats expansion,
+    # wandb.Histogram construction) so the background worker only uploads. They are
+    # idempotent, so re-running them on an already-prepared payload is a no-op.
 
     def _prepare_log(self, metrics):
         return _convert_metrics_to_wandb_loggable(metrics)

--- a/lib/levanter/src/levanter/tracker/wandb.py
+++ b/lib/levanter/src/levanter/tracker/wandb.py
@@ -68,26 +68,25 @@ class WandbTracker(Tracker):
         self._suppress_logging = suppress_logging
         self._minimum_log_step = minimum_log_step
 
-    def _prepare_payload_async(self, method_name: str, payload):
-        """Run the full wandb-side conversion on the producer thread.
+    # The prepare hooks run the full wandb-side conversion (SummaryStats
+    # expansion and ``wandb.Histogram`` construction) on the producer thread, so
+    # the background worker only does the upload. They are pure and idempotent,
+    # so the worker re-invoking the corresponding ``log_*`` method on the already
+    # prepared payload is a cheap no-op.
 
-        The W&B ``log`` path constructs ``wandb.Histogram`` objects and accesses
-        lazy properties on :class:`~levanter.tracker.histogram.SummaryStats`
-        (``rms``/``mean``/``variance``) that use ``jnp.sqrt`` and division —
-        those would otherwise dispatch JAX from the background worker thread,
-        which segfaults during the W&B profiler upload on the H100 canary. We
-        do the entire conversion here so the worker only does I/O.
-        """
-        if method_name == "log":
-            return _convert_metrics_to_wandb_loggable(payload)
-        if method_name in ("log_summary", "log_hyperparameters"):
-            return _convert_value_to_loggable_rec(payload)
-        return super()._prepare_payload_async(method_name, payload)
+    def _prepare_log(self, metrics):
+        return _convert_metrics_to_wandb_loggable(metrics)
+
+    def _prepare_summary(self, metrics):
+        return _convert_value_to_loggable_rec(metrics)
+
+    def _prepare_hyperparameters(self, hparams):
+        return _convert_value_to_loggable_rec(hparams)
 
     def log_hyperparameters(self, hparams: dict[str, Any]):
         if self._suppress_logging:
             return
-        self.run.config.update(_convert_value_to_loggable_rec(hparams), allow_val_change=True)
+        self.run.config.update(self._prepare_hyperparameters(hparams), allow_val_change=True)
 
     def log(self, metrics: typing.Mapping[str, Any], *, step, commit=None):
         if step is None and not commit:
@@ -104,10 +103,7 @@ class WandbTracker(Tracker):
 
         step = int(step)
 
-        # Conversion is idempotent: if metrics was already prepared on the producer
-        # thread (via ``_prepare_payload_async``), the dict has no SummaryStats and
-        # no jax.Arrays left, and this just re-wraps already-loggable values.
-        to_log = _convert_metrics_to_wandb_loggable(metrics)
+        to_log = self._prepare_log(metrics)
 
         if self._suppress_logging:
             return
@@ -125,7 +121,7 @@ class WandbTracker(Tracker):
     def log_summary(self, metrics: typing.Mapping[str, Any]):
         if self._suppress_logging:
             return
-        self.run.summary.update(_convert_value_to_loggable_rec(metrics))
+        self.run.summary.update(self._prepare_summary(metrics))
 
     def log_artifact(self, artifact_path, *, name: Optional[str] = None, type: Optional[str] = None):
         if self._suppress_logging:

--- a/lib/levanter/tests/test_background_tracker.py
+++ b/lib/levanter/tests/test_background_tracker.py
@@ -19,14 +19,17 @@ import logging
 import threading
 import time
 from typing import Any
+from unittest.mock import MagicMock
 
 import jax
 import jax.numpy as jnp
 import pytest
+import wandb
 
 from levanter.tracker import BackgroundTracker, CompositeTracker
 from levanter.tracker.histogram import SummaryStats
 from levanter.tracker.tracker import Tracker
+from levanter.tracker.wandb import WandbTracker
 
 
 class RecordingTracker(Tracker):
@@ -126,11 +129,8 @@ def test_background_tracker_swallows_exceptions(caplog):
 
     # The first call raised before recording; the second succeeded.
     assert inner.logs == [({"loss": 0.5}, 1, None)]
-    # An ERROR log should have captured the wandb exception.
-    assert any(
-        "wandb storage exceeded" in r.getMessage() or "raised while processing" in r.getMessage()
-        for r in caplog.records
-    )
+    # The swallowed exception is surfaced as an ERROR rather than silently dropped.
+    assert any(r.levelno == logging.ERROR for r in caplog.records)
 
 
 def test_background_tracker_runs_off_caller_thread():
@@ -300,7 +300,8 @@ def test_composite_tracker_isolates_failures(caplog):
     assert good.artifacts == [("/tmp/x", "a", "model")]
     assert good.finished is True
     assert bad.call_count == 5  # one per method call
-    assert any("continuing with remaining trackers" in r.getMessage() for r in caplog.records)
+    # Each swallowed member failure is surfaced as an ERROR.
+    assert sum(r.levelno == logging.ERROR for r in caplog.records) >= 5
 
 
 def test_composite_tracker_finish_does_not_raise():
@@ -386,25 +387,28 @@ def test_background_tracker_materializes_summary_stats_leaves():
         assert not isinstance(leaf, jax.Array)
 
 
-def test_prepare_payload_async_hook_runs_on_producer_thread():
-    """Trackers that override the hook get conversion done on the producer thread.
+def test_prepare_hooks_run_on_producer_thread():
+    """Payload preparation runs on the caller thread, and its output is what crosses the queue.
 
-    Regression for the Grug H100 canary segfault (#6108): WandbTracker.log()
-    accesses lazy SummaryStats.rms/.mean/.variance properties that dispatch
-    JAX via jnp.sqrt. Running that on the BackgroundTracker worker thread
-    races with the in-flight profiler upload and SIGSEGVs. The fix routes all
-    such conversion through ``_prepare_payload_async``, which runs on the
-    caller. This test exercises that contract with a tracker that records
-    which thread did the preparation.
+    This is the contract that keeps JAX work off the background worker (the
+    H100 SIGSEGV in #6108): the wrapped tracker's ``_prepare_*`` hooks are
+    invoked on the producer thread, and the worker only ever sees their output.
     """
     caller_thread = threading.get_ident()
     prep_threads: list[int] = []
 
     class PrepRecordingTracker(RecordingTracker):
-        def _prepare_payload_async(self, method_name, payload):
+        def _prepare_log(self, metrics):
             prep_threads.append(threading.get_ident())
-            # Sentinel marker we can spot in the worker-side payload.
-            return {"_prepared_on_thread": threading.get_ident(), "method": method_name, "payload": payload}
+            return {"prepared": True}
+
+        def _prepare_summary(self, metrics):
+            prep_threads.append(threading.get_ident())
+            return metrics
+
+        def _prepare_hyperparameters(self, hparams):
+            prep_threads.append(threading.get_ident())
+            return hparams
 
     inner = PrepRecordingTracker()
     bt = BackgroundTracker(inner)
@@ -416,33 +420,21 @@ def test_prepare_payload_async_hook_runs_on_producer_thread():
     finally:
         bt.finish()
 
-    assert prep_threads, "hook never invoked"
-    for tid in prep_threads:
-        assert tid == caller_thread, "preparation must happen on the caller thread"
+    assert len(prep_threads) == 3, "every log method must invoke its prepare hook"
+    assert all(tid == caller_thread for tid in prep_threads), "preparation must happen on the caller thread"
 
-    # The inner tracker received the sentinel-wrapped payload, confirming the
-    # hook's return value (not the raw input) is what crosses the queue.
+    # The worker receives the hook's output, not the raw input.
     logged_metrics, _, _ = inner.logs[0]
-    assert logged_metrics["_prepared_on_thread"] == caller_thread
-    assert logged_metrics["method"] == "log"
+    assert logged_metrics == {"prepared": True}
 
 
-def test_wandb_tracker_prepare_payload_flattens_summary_stats():
-    """WandbTracker overrides the hook to flatten SummaryStats into a wandb-ready dict.
+def test_wandb_tracker_prepare_log_flattens_summary_stats():
+    """WandbTracker._prepare_log flattens SummaryStats into a device-free, wandb-ready dict.
 
-    After preparation, the dict must be:
-      * fully flat (no nested SummaryStats),
-      * device-free (no jax.Array leaves),
-      * carry no JAX-dispatching values — i.e. accessing each value must not
-        trigger ``jnp.*``.
-
-    This is the structural invariant that keeps the W&B background worker
-    from issuing JAX ops mid-profiler-upload on the H100 canary.
+    After preparation the dict must hold no nested SummaryStats and no jax.Array
+    leaves — that is what lets the W&B background worker upload without issuing
+    any JAX op mid-profiler-upload (the H100 SIGSEGV in #6108).
     """
-    from unittest.mock import MagicMock
-
-    from levanter.tracker.wandb import WandbTracker
-
     tracker = WandbTracker(run=MagicMock(), suppress_logging=True)
 
     metrics = {
@@ -450,45 +442,26 @@ def test_wandb_tracker_prepare_payload_flattens_summary_stats():
         "grads/hist": SummaryStats.from_array(jnp.arange(100.0)),
     }
 
-    prepped = tracker._prepare_payload_async("log", metrics)
+    prepped = tracker._prepare_log(metrics)
 
-    # SummaryStats has been expanded.
+    # SummaryStats has been expanded into its component scalar keys.
     assert "grads/hist" not in prepped
-    assert "grads/hist/min" in prepped
-    assert "grads/hist/rms" in prepped
-    assert "grads/hist/mean" in prepped
-    assert "grads/hist/variance" in prepped
-
-    # No jax.Array leaves anywhere.
-    import wandb as _wandb
+    assert {"grads/hist/min", "grads/hist/mean", "grads/hist/variance", "grads/hist/rms"} <= prepped.keys()
 
     for k, v in prepped.items():
-        if isinstance(v, _wandb.Histogram):
+        if isinstance(v, wandb.Histogram):
             continue
         assert not isinstance(v, jax.Array), f"{k} is still a jax.Array: {v!r}"
 
-    # And rms/mean/variance must be plain Python/numpy scalars — *not* lazy
-    # jax.Arrays that would dispatch JAX on the worker thread.
-    assert not isinstance(prepped["grads/hist/rms"], jax.Array)
-    assert not isinstance(prepped["grads/hist/mean"], jax.Array)
-    assert not isinstance(prepped["grads/hist/variance"], jax.Array)
-
 
 def test_background_tracker_no_jax_dispatch_on_worker_for_summary_stats():
-    """The wrapped tracker must never see a jax.Array, even via SummaryStats props.
+    """End-to-end: nothing handed to ``wandb.run.log`` on the worker is a jax.Array.
 
-    Direct regression for the H100 SIGSEGV: prior to the fix, the worker
-    thread accessed ``SummaryStats.rms`` (a property using ``jnp.sqrt``),
-    which returned a fresh jax.Array on the wrong thread. With the
-    ``_prepare_payload_async`` hook in place, the WandbTracker flattens
-    SummaryStats on the producer thread; for plain trackers, the default
-    hook keeps materializing jax.Array leaves. Either way, no jax.Array
-    reaches the worker.
+    Direct regression for the H100 SIGSEGV (#6108). Now that SummaryStats
+    derives mean/variance/rms eagerly and WandbTracker flattens it in
+    ``_prepare_log`` on the producer thread, the worker only does the upload —
+    every value it passes to ``run.log`` is device-free.
     """
-    from unittest.mock import MagicMock
-
-    from levanter.tracker.wandb import WandbTracker
-
     captured: list[dict] = []
     run = MagicMock()
     run.step = 0
@@ -508,11 +481,7 @@ def test_background_tracker_no_jax_dispatch_on_worker_for_summary_stats():
 
     assert captured, "wandb.run.log was never called"
     logged = captured[0]
-    # Every value handed to wandb must be jax-free, including the derived ones
-    # whose property paths previously dispatched jnp.sqrt on the worker thread.
-    import wandb as _wandb
-
     for k, v in logged.items():
-        if isinstance(v, _wandb.Histogram):
+        if isinstance(v, wandb.Histogram):
             continue
         assert not isinstance(v, jax.Array), f"{k} reached wandb.log() as a jax.Array: {v!r}"

--- a/lib/levanter/tests/test_background_tracker.py
+++ b/lib/levanter/tests/test_background_tracker.py
@@ -384,3 +384,135 @@ def test_background_tracker_materializes_summary_stats_leaves():
     assert isinstance(logged, SummaryStats)
     for leaf in jax.tree_util.tree_leaves(logged):
         assert not isinstance(leaf, jax.Array)
+
+
+def test_prepare_payload_async_hook_runs_on_producer_thread():
+    """Trackers that override the hook get conversion done on the producer thread.
+
+    Regression for the Grug H100 canary segfault (#6108): WandbTracker.log()
+    accesses lazy SummaryStats.rms/.mean/.variance properties that dispatch
+    JAX via jnp.sqrt. Running that on the BackgroundTracker worker thread
+    races with the in-flight profiler upload and SIGSEGVs. The fix routes all
+    such conversion through ``_prepare_payload_async``, which runs on the
+    caller. This test exercises that contract with a tracker that records
+    which thread did the preparation.
+    """
+    caller_thread = threading.get_ident()
+    prep_threads: list[int] = []
+
+    class PrepRecordingTracker(RecordingTracker):
+        def _prepare_payload_async(self, method_name, payload):
+            prep_threads.append(threading.get_ident())
+            # Sentinel marker we can spot in the worker-side payload.
+            return {"_prepared_on_thread": threading.get_ident(), "method": method_name, "payload": payload}
+
+    inner = PrepRecordingTracker()
+    bt = BackgroundTracker(inner)
+    try:
+        bt.log({"loss": jnp.asarray(1.0)}, step=0)
+        bt.log_summary({"final": jnp.asarray(0.5)})
+        bt.log_hyperparameters({"lr": 0.1})
+        assert bt._wait_until_idle(timeout=5)
+    finally:
+        bt.finish()
+
+    assert prep_threads, "hook never invoked"
+    for tid in prep_threads:
+        assert tid == caller_thread, "preparation must happen on the caller thread"
+
+    # The inner tracker received the sentinel-wrapped payload, confirming the
+    # hook's return value (not the raw input) is what crosses the queue.
+    logged_metrics, _, _ = inner.logs[0]
+    assert logged_metrics["_prepared_on_thread"] == caller_thread
+    assert logged_metrics["method"] == "log"
+
+
+def test_wandb_tracker_prepare_payload_flattens_summary_stats():
+    """WandbTracker overrides the hook to flatten SummaryStats into a wandb-ready dict.
+
+    After preparation, the dict must be:
+      * fully flat (no nested SummaryStats),
+      * device-free (no jax.Array leaves),
+      * carry no JAX-dispatching values — i.e. accessing each value must not
+        trigger ``jnp.*``.
+
+    This is the structural invariant that keeps the W&B background worker
+    from issuing JAX ops mid-profiler-upload on the H100 canary.
+    """
+    from unittest.mock import MagicMock
+
+    from levanter.tracker.wandb import WandbTracker
+
+    tracker = WandbTracker(run=MagicMock(), suppress_logging=True)
+
+    metrics = {
+        "loss": jnp.asarray(1.5),
+        "grads/hist": SummaryStats.from_array(jnp.arange(100.0)),
+    }
+
+    prepped = tracker._prepare_payload_async("log", metrics)
+
+    # SummaryStats has been expanded.
+    assert "grads/hist" not in prepped
+    assert "grads/hist/min" in prepped
+    assert "grads/hist/rms" in prepped
+    assert "grads/hist/mean" in prepped
+    assert "grads/hist/variance" in prepped
+
+    # No jax.Array leaves anywhere.
+    import wandb as _wandb
+
+    for k, v in prepped.items():
+        if isinstance(v, _wandb.Histogram):
+            continue
+        assert not isinstance(v, jax.Array), f"{k} is still a jax.Array: {v!r}"
+
+    # And rms/mean/variance must be plain Python/numpy scalars — *not* lazy
+    # jax.Arrays that would dispatch JAX on the worker thread.
+    assert not isinstance(prepped["grads/hist/rms"], jax.Array)
+    assert not isinstance(prepped["grads/hist/mean"], jax.Array)
+    assert not isinstance(prepped["grads/hist/variance"], jax.Array)
+
+
+def test_background_tracker_no_jax_dispatch_on_worker_for_summary_stats():
+    """The wrapped tracker must never see a jax.Array, even via SummaryStats props.
+
+    Direct regression for the H100 SIGSEGV: prior to the fix, the worker
+    thread accessed ``SummaryStats.rms`` (a property using ``jnp.sqrt``),
+    which returned a fresh jax.Array on the wrong thread. With the
+    ``_prepare_payload_async`` hook in place, the WandbTracker flattens
+    SummaryStats on the producer thread; for plain trackers, the default
+    hook keeps materializing jax.Array leaves. Either way, no jax.Array
+    reaches the worker.
+    """
+    from unittest.mock import MagicMock
+
+    from levanter.tracker.wandb import WandbTracker
+
+    captured: list[dict] = []
+    run = MagicMock()
+    run.step = 0
+
+    def _capture(to_log, *, step, commit):
+        captured.append(to_log)
+
+    run.log = _capture
+
+    wandb_tracker = WandbTracker(run=run)
+    bt = BackgroundTracker(wandb_tracker)
+    try:
+        bt.log({"grads/hist": SummaryStats.from_array(jnp.arange(100.0))}, step=0)
+        assert bt._wait_until_idle(timeout=5)
+    finally:
+        bt.finish()
+
+    assert captured, "wandb.run.log was never called"
+    logged = captured[0]
+    # Every value handed to wandb must be jax-free, including the derived ones
+    # whose property paths previously dispatched jnp.sqrt on the worker thread.
+    import wandb as _wandb
+
+    for k, v in logged.items():
+        if isinstance(v, _wandb.Histogram):
+            continue
+        assert not isinstance(v, jax.Array), f"{k} reached wandb.log() as a jax.Array: {v!r}"

--- a/lib/levanter/tests/test_background_tracker.py
+++ b/lib/levanter/tests/test_background_tracker.py
@@ -15,7 +15,6 @@ These tests cover the behavior we want for robustness against W&B failures:
 
 from __future__ import annotations
 
-import logging
 import threading
 import time
 from typing import Any
@@ -113,26 +112,6 @@ def test_background_tracker_forwards_calls():
     assert inner.finished is True
 
 
-def test_background_tracker_swallows_exceptions(caplog):
-    """Exceptions from the wrapped tracker must not crash the producer."""
-    inner = RecordingTracker(raise_on_log=RuntimeError("wandb storage exceeded"))
-    bt = BackgroundTracker(inner)
-    try:
-        with caplog.at_level(logging.ERROR, logger="levanter.tracker.background"):
-            # First log raises in worker -- producer thread must not see it.
-            bt.log({"loss": 1.0}, step=0)
-            # Subsequent logs should still be processed.
-            bt.log({"loss": 0.5}, step=1)
-            assert bt._wait_until_idle(timeout=5)
-    finally:
-        bt.finish()
-
-    # The first call raised before recording; the second succeeded.
-    assert inner.logs == [({"loss": 0.5}, 1, None)]
-    # The swallowed exception is surfaced as an ERROR rather than silently dropped.
-    assert any(r.levelno == logging.ERROR for r in caplog.records)
-
-
 def test_background_tracker_runs_off_caller_thread():
     """The wrapped tracker must not run on the calling thread."""
     caller_thread = threading.get_ident()
@@ -210,7 +189,7 @@ def test_background_tracker_does_not_block_producer():
         bt.finish()
 
 
-def test_background_tracker_drops_when_queue_full(caplog):
+def test_background_tracker_drops_when_queue_full():
     """When the queue is full, additional log calls are dropped, not blocked."""
     block_event = threading.Event()
     release_event = threading.Event()
@@ -236,20 +215,19 @@ def test_background_tracker_drops_when_queue_full(caplog):
 
     bt = BackgroundTracker(GatedTracker(), max_queue_size=2)
     try:
-        with caplog.at_level(logging.WARNING, logger="levanter.tracker.background"):
-            # Saturate worker.
-            bt.log({"i": 0}, step=0)
-            block_event.wait(timeout=5)
-            # Fill the queue (capacity 2).
-            bt.log({"i": 1}, step=1)
-            bt.log({"i": 2}, step=2)
-            # These should be dropped, not blocked.
-            start = time.monotonic()
-            for i in range(100):
-                bt.log({"i": i + 3}, step=i + 3)
-            elapsed = time.monotonic() - start
-            assert elapsed < 1.0
-            assert bt._dropped >= 50
+        # Saturate worker.
+        bt.log({"i": 0}, step=0)
+        block_event.wait(timeout=5)
+        # Fill the queue (capacity 2).
+        bt.log({"i": 1}, step=1)
+        bt.log({"i": 2}, step=2)
+        # These should be dropped, not blocked.
+        start = time.monotonic()
+        for i in range(100):
+            bt.log({"i": i + 3}, step=i + 3)
+        elapsed = time.monotonic() - start
+        assert elapsed < 1.0
+        assert bt._dropped >= 50
     finally:
         release_event.set()
         bt.finish()
@@ -281,18 +259,17 @@ def test_background_tracker_logs_after_finish_are_dropped():
     assert inner.logs == []
 
 
-def test_composite_tracker_isolates_failures(caplog):
+def test_composite_tracker_isolates_failures():
     """A failing member tracker must not prevent later members from being called."""
     bad = AlwaysRaisingTracker()
     good = RecordingTracker()
     composite = CompositeTracker([bad, good])
 
-    with caplog.at_level(logging.ERROR, logger="levanter.tracker.tracker"):
-        composite.log_hyperparameters({"lr": 0.1})
-        composite.log({"loss": 1.0}, step=0)
-        composite.log_summary({"final": 0.5})
-        composite.log_artifact("/tmp/x", name="a", type="model")
-        composite.finish()
+    composite.log_hyperparameters({"lr": 0.1})
+    composite.log({"loss": 1.0}, step=0)
+    composite.log_summary({"final": 0.5})
+    composite.log_artifact("/tmp/x", name="a", type="model")
+    composite.finish()
 
     assert good.hparams == [{"lr": 0.1}]
     assert good.logs == [({"loss": 1.0}, 0, None)]
@@ -300,8 +277,6 @@ def test_composite_tracker_isolates_failures(caplog):
     assert good.artifacts == [("/tmp/x", "a", "model")]
     assert good.finished is True
     assert bad.call_count == 5  # one per method call
-    # Each swallowed member failure is surfaced as an ERROR.
-    assert sum(r.levelno == logging.ERROR for r in caplog.records) >= 5
 
 
 def test_composite_tracker_finish_does_not_raise():
@@ -322,15 +297,14 @@ def test_composite_tracker_finish_does_not_raise():
         ValueError("storage quota exceeded"),
     ],
 )
-def test_background_tracker_swallows_various_exceptions(exc, caplog):
+def test_background_tracker_swallows_various_exceptions(exc):
     """Sample of error types we expect from W&B at runtime."""
     inner = RecordingTracker(raise_on_log=exc)
     bt = BackgroundTracker(inner)
     try:
-        with caplog.at_level(logging.ERROR, logger="levanter.tracker.background"):
-            bt.log({"loss": 1.0}, step=0)
-            bt.log({"loss": 0.5}, step=1)
-            assert bt._wait_until_idle(timeout=5)
+        bt.log({"loss": 1.0}, step=0)
+        bt.log({"loss": 0.5}, step=1)
+        assert bt._wait_until_idle(timeout=5)
     finally:
         bt.finish()
     # Second call (after the raise) should still have been recorded.
@@ -387,47 +361,6 @@ def test_background_tracker_materializes_summary_stats_leaves():
         assert not isinstance(leaf, jax.Array)
 
 
-def test_prepare_hooks_run_on_producer_thread():
-    """Payload preparation runs on the caller thread, and its output is what crosses the queue.
-
-    This is the contract that keeps JAX work off the background worker (the
-    H100 SIGSEGV in #6108): the wrapped tracker's ``_prepare_*`` hooks are
-    invoked on the producer thread, and the worker only ever sees their output.
-    """
-    caller_thread = threading.get_ident()
-    prep_threads: list[int] = []
-
-    class PrepRecordingTracker(RecordingTracker):
-        def _prepare_log(self, metrics):
-            prep_threads.append(threading.get_ident())
-            return {"prepared": True}
-
-        def _prepare_summary(self, metrics):
-            prep_threads.append(threading.get_ident())
-            return metrics
-
-        def _prepare_hyperparameters(self, hparams):
-            prep_threads.append(threading.get_ident())
-            return hparams
-
-    inner = PrepRecordingTracker()
-    bt = BackgroundTracker(inner)
-    try:
-        bt.log({"loss": jnp.asarray(1.0)}, step=0)
-        bt.log_summary({"final": jnp.asarray(0.5)})
-        bt.log_hyperparameters({"lr": 0.1})
-        assert bt._wait_until_idle(timeout=5)
-    finally:
-        bt.finish()
-
-    assert len(prep_threads) == 3, "every log method must invoke its prepare hook"
-    assert all(tid == caller_thread for tid in prep_threads), "preparation must happen on the caller thread"
-
-    # The worker receives the hook's output, not the raw input.
-    logged_metrics, _, _ = inner.logs[0]
-    assert logged_metrics == {"prepared": True}
-
-
 def test_wandb_tracker_prepare_log_flattens_summary_stats():
     """WandbTracker._prepare_log flattens SummaryStats into a device-free, wandb-ready dict.
 
@@ -452,36 +385,3 @@ def test_wandb_tracker_prepare_log_flattens_summary_stats():
         if isinstance(v, wandb.Histogram):
             continue
         assert not isinstance(v, jax.Array), f"{k} is still a jax.Array: {v!r}"
-
-
-def test_background_tracker_no_jax_dispatch_on_worker_for_summary_stats():
-    """End-to-end: nothing handed to ``wandb.run.log`` on the worker is a jax.Array.
-
-    Direct regression for the H100 SIGSEGV (#6108). Now that SummaryStats
-    derives mean/variance/rms eagerly and WandbTracker flattens it in
-    ``_prepare_log`` on the producer thread, the worker only does the upload —
-    every value it passes to ``run.log`` is device-free.
-    """
-    captured: list[dict] = []
-    run = MagicMock()
-    run.step = 0
-
-    def _capture(to_log, *, step, commit):
-        captured.append(to_log)
-
-    run.log = _capture
-
-    wandb_tracker = WandbTracker(run=run)
-    bt = BackgroundTracker(wandb_tracker)
-    try:
-        bt.log({"grads/hist": SummaryStats.from_array(jnp.arange(100.0))}, step=0)
-        assert bt._wait_until_idle(timeout=5)
-    finally:
-        bt.finish()
-
-    assert captured, "wandb.run.log was never called"
-    logged = captured[0]
-    for k, v in logged.items():
-        if isinstance(v, wandb.Histogram):
-            continue
-        assert not isinstance(v, jax.Array), f"{k} reached wandb.log() as a jax.Array: {v!r}"

--- a/lib/levanter/tests/test_histogram.py
+++ b/lib/levanter/tests/test_histogram.py
@@ -8,6 +8,7 @@ import haliax as hax
 from haliax.partitioning import ResourceAxis
 import jax
 import jax.numpy as jnp
+import pytest
 from jax.random import PRNGKey
 
 from levanter.tracker.histogram import SummaryStats, sharded_histogram_array
@@ -86,6 +87,25 @@ def test_histogram_counts_include_values_on_the_last_bin_edge():
     assert histogram.histogram is not None
     assert int(histogram.histogram.bucket_counts.sum()) == 3
     assert int(histogram.num) == 3
+
+
+def test_summary_stats_moments_are_eager_and_host_transferable():
+    """mean/variance/rms are materialized fields, not lazy properties.
+
+    Regression for #6108: lazy properties re-dispatched ``jnp`` whenever read,
+    which segfaulted when a SummaryStats was read on a background thread. The
+    moments are now concrete leaves, so ``jax.device_get`` pulls them to host
+    and reading them never touches JAX again.
+    """
+    values = jnp.array([0.0, 1.0, 2.0, 3.0], dtype=jnp.float32)
+    stats = jax.device_get(SummaryStats.from_array(values, include_histogram=False))
+
+    for leaf in jax.tree_util.tree_leaves(stats):
+        assert not isinstance(leaf, jax.Array)
+
+    assert stats.mean == pytest.approx(1.5)
+    assert stats.variance == pytest.approx(1.25)
+    assert stats.rms == pytest.approx((14.0 / 4.0) ** 0.5)
 
 
 def test_summary_stats_can_skip_histogram_bins():


### PR DESCRIPTION
The controller dashboard landing page now lists job owners (the user id) as cards you drill into, with a star to pin your own username to the top, replacing the flat per-job list and per-job stars. Also aligns the Scheduler and Autoscaler panels: shared loading spinner, consistent section headings, keyboard-accessible expand toggles, and table-header semantics.