### PR TITLE
[iris] Gate TPU worker start on node READY before registration

### DIFF
--- a/.github/workflows/iris-smoke-gcp.yaml
+++ b/.github/workflows/iris-smoke-gcp.yaml
@@ -136,7 +136,7 @@ jobs:
             --label-prefix "$LABEL_PREFIX" \
             --url-file /tmp/iris-controller-url \
             --wait-for-workers 1 \
-            --worker-timeout 1800 &
+            --worker-timeout 600 &
           START_PID=$!
           echo "START_PID=$START_PID" >> "$GITHUB_ENV"
           for i in $(seq 1 900); do

--- a/.github/workflows/iris-smoke-gcp.yaml
+++ b/.github/workflows/iris-smoke-gcp.yaml
@@ -136,7 +136,7 @@ jobs:
             --label-prefix "$LABEL_PREFIX" \
             --url-file /tmp/iris-controller-url \
             --wait-for-workers 1 \
-            --worker-timeout 600 &
+            --worker-timeout 1800 &
           START_PID=$!
           echo "START_PID=$START_PID" >> "$GITHUB_ENV"
           for i in $(seq 1 900); do

--- a/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
@@ -120,6 +120,54 @@ set -e
 
 echo "[iris-init] Starting Iris worker bootstrap"
 
+echo "[iris-init] Phase: tpu_ready_gate"
+
+# Gate the whole bootstrap -- and thus controller registration -- on the TPU
+# node reaching READY, before any Docker install/pull work. A host can boot and
+# run this script while sibling hosts in the same slice are still provisioning;
+# registering early would let the controller schedule a task before the slice is
+# up. The node's aggregate state flips to READY only once every host is healthy,
+# so it is the cleanest in-VM signal that the whole slice is Active.
+#
+# The gate applies only to TPU slices (accelerator-type metadata present); CPU
+# and standalone GCE VMs have no such attribute and skip it. It is fail-open: if
+# gcloud is unavailable, the describe never succeeds, or the node never reaches
+# READY within the window, bootstrap proceeds anyway and the autoscaler's slice
+# health probe owns give-up -- exactly as it does for the /health wait below.
+IRIS_META="http://metadata.google.internal/computeMetadata/v1/instance"
+IRIS_ACCEL_TYPE=$(curl -sf -H "Metadata-Flavor: Google" "$IRIS_META/attributes/accelerator-type" || true)
+if [ -n "$IRIS_ACCEL_TYPE" ]; then
+    export PATH="$PATH:/snap/bin:/opt/google-cloud-sdk/bin"
+    IRIS_TPU_NODE=$(curl -sf -H "Metadata-Flavor: Google" "$IRIS_META/attributes/instance-id" || true)
+    IRIS_TPU_ZONE=$(curl -sf -H "Metadata-Flavor: Google" "$IRIS_META/zone" | sed 's#.*/##')
+    if command -v gcloud &> /dev/null && [ -n "$IRIS_TPU_NODE" ]; then
+        echo "[iris-init] Gating bootstrap on TPU node $IRIS_TPU_NODE (zone=$IRIS_TPU_ZONE) reaching READY"
+        # Reserved/queued multi-host slices can take a long time to fully
+        # provision; wait up to an hour before failing open. SECONDS is a bash
+        # builtin reset to 0 here, so the deadline accounts for gcloud latency.
+        SECONDS=0
+        IRIS_TPU_GATE_TIMEOUT=3600
+        IRIS_TPU_GATE_INTERVAL=15
+        IRIS_TPU_GATE_ATTEMPT=0
+        while [ "$SECONDS" -lt "$IRIS_TPU_GATE_TIMEOUT" ]; do
+            IRIS_TPU_GATE_ATTEMPT=$((IRIS_TPU_GATE_ATTEMPT + 1))
+            IRIS_TPU_STATE=$(gcloud compute tpus tpu-vm describe "$IRIS_TPU_NODE" \
+                --zone="$IRIS_TPU_ZONE" --format='value(state)' 2>/dev/null || true)
+            if [ "$IRIS_TPU_STATE" = "READY" ]; then
+                echo "[iris-init] TPU node READY after ${SECONDS}s (${IRIS_TPU_GATE_ATTEMPT} check(s)); proceeding"
+                break
+            fi
+            echo "[iris-init] TPU node state=${IRIS_TPU_STATE:-<describe-failed>}; waited ${SECONDS}s"
+            sleep "$IRIS_TPU_GATE_INTERVAL"
+        done
+        if [ "$IRIS_TPU_STATE" != "READY" ]; then
+            echo "[iris-init] WARNING: TPU node not READY after ${IRIS_TPU_GATE_TIMEOUT}s; proceeding (fail-open)"
+        fi
+    else
+        echo "[iris-init] gcloud or node name unavailable; skipping TPU ready gate"
+    fi
+fi
+
 echo "[iris-init] Phase: prerequisites"
 
 # Install Docker if missing
@@ -179,54 +227,6 @@ cat > /tmp/iris_worker_config.json << 'IRIS_WORKER_CONFIG_EOF'
 {{ worker_config_json }}
 IRIS_WORKER_CONFIG_EOF
 sudo mv /tmp/iris_worker_config.json /etc/iris/worker_config.json
-
-echo "[iris-init] Phase: tpu_ready_gate"
-
-# Defer worker startup -- and thus controller registration -- until the TPU
-# node reports READY. A host can boot and run this script while sibling hosts in
-# the same slice are still provisioning; registering early would let the
-# controller schedule a task before the slice is up. The node's aggregate state
-# flips to READY only once every host is healthy, so it is the cleanest in-VM
-# signal that the whole slice is Active.
-#
-# The gate applies only to TPU slices (accelerator-type metadata present); CPU
-# and standalone GCE VMs have no such attribute and skip it. It is fail-open: if
-# gcloud is unavailable, the describe never succeeds, or the node never reaches
-# READY within the window, the worker starts anyway and the autoscaler's slice
-# health probe owns give-up -- exactly as it does for the /health wait below.
-IRIS_META="http://metadata.google.internal/computeMetadata/v1/instance"
-IRIS_ACCEL_TYPE=$(curl -sf -H "Metadata-Flavor: Google" "$IRIS_META/attributes/accelerator-type" || true)
-if [ -n "$IRIS_ACCEL_TYPE" ]; then
-    export PATH="$PATH:/snap/bin:/opt/google-cloud-sdk/bin"
-    IRIS_TPU_NODE=$(curl -sf -H "Metadata-Flavor: Google" "$IRIS_META/attributes/instance-id" || true)
-    IRIS_TPU_ZONE=$(curl -sf -H "Metadata-Flavor: Google" "$IRIS_META/zone" | sed 's#.*/##')
-    if command -v gcloud &> /dev/null && [ -n "$IRIS_TPU_NODE" ]; then
-        echo "[iris-init] Gating worker start on TPU node $IRIS_TPU_NODE (zone=$IRIS_TPU_ZONE) reaching READY"
-        # Reserved/queued multi-host slices can take a long time to fully
-        # provision; wait up to an hour before failing open. SECONDS is a bash
-        # builtin reset to 0 here, so the deadline accounts for gcloud latency.
-        SECONDS=0
-        IRIS_TPU_GATE_TIMEOUT=3600
-        IRIS_TPU_GATE_INTERVAL=15
-        IRIS_TPU_GATE_ATTEMPT=0
-        while [ "$SECONDS" -lt "$IRIS_TPU_GATE_TIMEOUT" ]; do
-            IRIS_TPU_GATE_ATTEMPT=$((IRIS_TPU_GATE_ATTEMPT + 1))
-            IRIS_TPU_STATE=$(gcloud compute tpus tpu-vm describe "$IRIS_TPU_NODE" \
-                --zone="$IRIS_TPU_ZONE" --format='value(state)' 2>/dev/null || true)
-            if [ "$IRIS_TPU_STATE" = "READY" ]; then
-                echo "[iris-init] TPU node READY after ${SECONDS}s (${IRIS_TPU_GATE_ATTEMPT} check(s)); starting worker"
-                break
-            fi
-            echo "[iris-init] TPU node state=${IRIS_TPU_STATE:-<describe-failed>}; waited ${SECONDS}s"
-            sleep "$IRIS_TPU_GATE_INTERVAL"
-        done
-        if [ "$IRIS_TPU_STATE" != "READY" ]; then
-            echo "[iris-init] WARNING: TPU node not READY after ${IRIS_TPU_GATE_TIMEOUT}s; starting worker (fail-open)"
-        fi
-    else
-        echo "[iris-init] gcloud or node name unavailable; skipping TPU ready gate"
-    fi
-fi
 
 echo "[iris-init] Phase: worker_start"
 

--- a/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/bootstrap.py
@@ -180,6 +180,54 @@ cat > /tmp/iris_worker_config.json << 'IRIS_WORKER_CONFIG_EOF'
 IRIS_WORKER_CONFIG_EOF
 sudo mv /tmp/iris_worker_config.json /etc/iris/worker_config.json
 
+echo "[iris-init] Phase: tpu_ready_gate"
+
+# Defer worker startup -- and thus controller registration -- until the TPU
+# node reports READY. A host can boot and run this script while sibling hosts in
+# the same slice are still provisioning; registering early would let the
+# controller schedule a task before the slice is up. The node's aggregate state
+# flips to READY only once every host is healthy, so it is the cleanest in-VM
+# signal that the whole slice is Active.
+#
+# The gate applies only to TPU slices (accelerator-type metadata present); CPU
+# and standalone GCE VMs have no such attribute and skip it. It is fail-open: if
+# gcloud is unavailable, the describe never succeeds, or the node never reaches
+# READY within the window, the worker starts anyway and the autoscaler's slice
+# health probe owns give-up -- exactly as it does for the /health wait below.
+IRIS_META="http://metadata.google.internal/computeMetadata/v1/instance"
+IRIS_ACCEL_TYPE=$(curl -sf -H "Metadata-Flavor: Google" "$IRIS_META/attributes/accelerator-type" || true)
+if [ -n "$IRIS_ACCEL_TYPE" ]; then
+    export PATH="$PATH:/snap/bin:/opt/google-cloud-sdk/bin"
+    IRIS_TPU_NODE=$(curl -sf -H "Metadata-Flavor: Google" "$IRIS_META/attributes/instance-id" || true)
+    IRIS_TPU_ZONE=$(curl -sf -H "Metadata-Flavor: Google" "$IRIS_META/zone" | sed 's#.*/##')
+    if command -v gcloud &> /dev/null && [ -n "$IRIS_TPU_NODE" ]; then
+        echo "[iris-init] Gating worker start on TPU node $IRIS_TPU_NODE (zone=$IRIS_TPU_ZONE) reaching READY"
+        # Reserved/queued multi-host slices can take a long time to fully
+        # provision; wait up to an hour before failing open. SECONDS is a bash
+        # builtin reset to 0 here, so the deadline accounts for gcloud latency.
+        SECONDS=0
+        IRIS_TPU_GATE_TIMEOUT=3600
+        IRIS_TPU_GATE_INTERVAL=15
+        IRIS_TPU_GATE_ATTEMPT=0
+        while [ "$SECONDS" -lt "$IRIS_TPU_GATE_TIMEOUT" ]; do
+            IRIS_TPU_GATE_ATTEMPT=$((IRIS_TPU_GATE_ATTEMPT + 1))
+            IRIS_TPU_STATE=$(gcloud compute tpus tpu-vm describe "$IRIS_TPU_NODE" \
+                --zone="$IRIS_TPU_ZONE" --format='value(state)' 2>/dev/null || true)
+            if [ "$IRIS_TPU_STATE" = "READY" ]; then
+                echo "[iris-init] TPU node READY after ${SECONDS}s (${IRIS_TPU_GATE_ATTEMPT} check(s)); starting worker"
+                break
+            fi
+            echo "[iris-init] TPU node state=${IRIS_TPU_STATE:-<describe-failed>}; waited ${SECONDS}s"
+            sleep "$IRIS_TPU_GATE_INTERVAL"
+        done
+        if [ "$IRIS_TPU_STATE" != "READY" ]; then
+            echo "[iris-init] WARNING: TPU node not READY after ${IRIS_TPU_GATE_TIMEOUT}s; starting worker (fail-open)"
+        fi
+    else
+        echo "[iris-init] gcloud or node name unavailable; skipping TPU ready gate"
+    fi
+fi
+
 echo "[iris-init] Phase: worker_start"
 
 # Force-remove existing worker (handles restart policy race).


### PR DESCRIPTION
* re #6098 

## What

For TPU slices, defer worker container start — and thus controller registration — until the TPU node reports `READY`.

- A TPU host runs its startup script as it boots, possibly while sibling hosts in the slice are still provisioning. The worker registers the instant its container starts, so an early host could be handed a task before the slice is up.
- New gate before `docker run` polls `gcloud compute tpus tpu-vm describe ... --format='value(state)'` and waits for `READY`. A slice is a single node resource with one slice-level `state`, so `READY` means the whole slice is provisioned.
- Fires only for TPU slices (`accelerator-type` metadata present); CPU / standalone GCE VMs skip it.
- Waits up to 1h (sized for reserved/queued multi-host provisioning), then **fails open**: if gcloud is unavailable, the describe never succeeds, or the node never reaches `READY`, the worker starts anyway and the autoscaler slice-health probe owns give-up — same philosophy as the existing `/health` wait.

## Notes

- Self-discovers node name + zone from the metadata server; no new template plumbing or IAM beyond `tpu.nodes.get` (already granted to the worker SA).
- GCE imposes no startup-script execution timeout, so the 1h wait is safe.
- `bash -n` clean on the rendered script; full `test_bootstrap.py` suite passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)