### PR TITLE
Fix Grug MoE router SummaryStats construction

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -315,7 +315,7 @@ def _histogram_from_expert_counts(expert_counts: jax.Array) -> SummaryStats:
     max_value = jnp.where(num > 0, max_value, 0.0)
     bucket_limits = jnp.arange(num_experts + 1, dtype=jnp.float32)
     histogram = Histogram(bucket_limits=bucket_limits, bucket_counts=counts)
-    return SummaryStats(
+    return SummaryStats.from_reduced_values(
         min=min_value,
         max=max_value,
         num=num,

--- a/lib/levanter/src/levanter/tracker/histogram.py
+++ b/lib/levanter/src/levanter/tracker/histogram.py
@@ -51,8 +51,16 @@ class SummaryStats(equinox.Module):
     histogram: Histogram | None = None
 
     @staticmethod
-    def _with_derived(min, max, num, nonzero_count, sum, sum_squares, histogram) -> "SummaryStats":
-        """Build a ``SummaryStats``, computing the derived moments eagerly."""
+    def from_reduced_values(
+        min: Scalar,
+        max: Scalar,
+        num: Scalar,
+        nonzero_count: Scalar,
+        sum: Scalar,
+        sum_squares: Scalar,
+        histogram: Histogram | None = None,
+    ) -> "SummaryStats":
+        """Build a ``SummaryStats`` from already-reduced summary values."""
         mean = sum / num
         variance = (sum_squares / num) - (mean**2)
         rms = jnp.sqrt(sum_squares / num)
@@ -96,7 +104,7 @@ class SummaryStats(equinox.Module):
             edges = jnp.histogram_bin_edges(jnp.stack([min, max]), bins=num_bins)
             counts = sharded_histogram_array(array, edges)
             histogram = Histogram(edges, counts)
-        return SummaryStats._with_derived(min, max, num, nonzero_count, sum, sum_squares, histogram)
+        return SummaryStats.from_reduced_values(min, max, num, nonzero_count, sum, sum_squares, histogram)
 
     @staticmethod
     def from_named_array(
@@ -116,7 +124,7 @@ class SummaryStats(equinox.Module):
         if include_histogram:
             counts, edges = sharded_histogram(array, bins=num_bins)
             histogram = Histogram(edges, counts)
-        return SummaryStats._with_derived(min, max, num, nonzero_count, sum, sum_squares, histogram)
+        return SummaryStats.from_reduced_values(min, max, num, nonzero_count, sum, sum_squares, histogram)
 
     def to_numpy_histogram(self) -> tuple[np.ndarray, np.ndarray]:
         if self.histogram is None:


### PR DESCRIPTION
## Summary

Fixes #6125.

`experiments/grug/moe/model.py::_histogram_from_expert_counts` directly constructed `SummaryStats` with the old reduced field set. After `SummaryStats` added eager `mean`, `variance`, and `rms` fields, that caller failed before the CoreWeave canary could reach the original profiler/artifact path.

This PR adds a public `SummaryStats.from_reduced_values(...)` constructor on the owning type, routes the existing Levanter constructors through it, and uses it from the Grug MoE router summary code.

The issue has the manual repro and failure details: #6125.

## Validation

```sh
git diff --check
uv run ruff check experiments/grug/moe/model.py lib/levanter/src/levanter/tracker/histogram.py lib/levanter/tests/test_histogram.py
cd lib/levanter && PYTHONPATH=tests:src:. uv run --group test pytest tests/test_histogram.py -q
```

Results:

- Levanter histogram tests: `8 passed, 9 warnings in 13.38s`
- Ruff: `All checks passed!`
- Commit hooks passed: ruff, black, license headers, pyrefly, large files, AST, merge conflicts, trailing whitespace, EOF newline

CoreWeave H100 validation:

- Direct k8s job: `cw-summary-stats-fix-20260602-225916`
- Cluster: `coreweave-ci`
- Namespace: `iris-ci`
- Node: `g12f55c`
- GPU: `1 x H100`
- Source commit: `1f85f48594319a5926695f41af3f951062e3276c`
- Result: `gpu_validation_success`

Note: the H100 validation commit differs from the current head only by removal of a test-only block in `lib/levanter/tests/test_histogram.py`.

Local artifacts:

- GPU manifest: `/tmp/cw-jun2-h100-repro/summary-stats-fix-gpu-20260602-225916.yaml`
- GPU log: `/tmp/cw-jun2-h100-repro/summary-stats-fix-gpu-20260602-225916.log`
- Investigation notes: `/tmp/cw-jun2-h100-repro/sharp-edges.md`