### PR TITLE
iris: retry transient gcp 5xx reads instead of swallowing them as empty lists

### DIFF
--- a/lib/iris/src/iris/cluster/providers/gcp/service.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/service.py
@@ -664,13 +664,7 @@ class CloudGcpService:
         zone_list = zones if zones else ["-"]
 
         for zone in zone_list:
-            try:
-                items = self._paginate(f"{_TPU_BASE}/{self._tpu_parent(zone)}/nodes", "nodes")
-            except InfraUnavailableError:
-                raise  # sustained outage must surface; reconcile reclaims live slices on an empty list
-            except InfraError:
-                logger.warning("Failed to list TPUs in zone %s", zone, exc_info=True)
-                continue
+            items = self._paginate(f"{_TPU_BASE}/{self._tpu_parent(zone)}/nodes", "nodes")
             for tpu_data in items:
                 if labels and not _labels_match(tpu_data.get("labels", {}), labels):
                     continue
@@ -895,30 +889,17 @@ class CloudGcpService:
             params: dict[str, str] = {}
             if filter_str:
                 params["filter"] = filter_str
-            try:
-                for page in self._paginate_raw(url, params):
-                    for scope in page.get("items", {}).values():
-                        for vm_data in scope.get("instances", []):
-                            results.append(_parse_vm_info(vm_data))
-            except InfraUnavailableError:
-                raise  # sustained outage must surface, not read as "no controller" to discovery
-            except InfraError:
-                logger.warning("Failed to list instances", exc_info=True)
-                return []
+            for page in self._paginate_raw(url, params):
+                for scope in page.get("items", {}).values():
+                    for vm_data in scope.get("instances", []):
+                        results.append(_parse_vm_info(vm_data))
             return results
 
         for zone in zones:
             params = {}
             if filter_str:
                 params["filter"] = filter_str
-            try:
-                items = self._paginate(self._instance_url(zone), "items", params)
-            except InfraUnavailableError:
-                raise  # don't drop a sustained outage to an empty per-zone result
-            except InfraError:
-                logger.warning("Failed to list instances in zone %s", zone, exc_info=True)
-                continue
-            for vm_data in items:
+            for vm_data in self._paginate(self._instance_url(zone), "items", params):
                 results.append(_parse_vm_info(vm_data, fallback_zone=zone))
 
         return results

--- a/lib/iris/src/iris/cluster/providers/gcp/service.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/service.py
@@ -17,11 +17,12 @@ import google.auth.credentials
 import google.auth.transport.requests
 import httpx
 from google.cloud import tpu_v2alpha1
-from rigging.timing import ExponentialBackoff, Timestamp
+from rigging.timing import ExponentialBackoff, Timestamp, retry_with_backoff
 
 from iris.cluster.providers.gcp.local import LocalSliceHandle
 from iris.cluster.providers.types import (
     InfraError,
+    InfraUnavailableError,
     QuotaExhaustedError,
     ResourceNotFoundError,
 )
@@ -78,6 +79,11 @@ _LOGGING_BASE = "https://logging.googleapis.com/v2"
 _REFRESH_MARGIN = 300  # seconds before expiry to refresh token
 _DEFAULT_TIMEOUT = 120  # seconds
 _OPERATION_TIMEOUT = 600  # seconds to wait for an operation to complete
+
+# GCP occasionally returns 503 "Internal error. Please try again" (and other 5xx)
+# on otherwise-valid reads; these are explicitly retryable. Bounded so a sustained
+# outage still surfaces as InfraUnavailableError rather than hanging forever.
+_TRANSIENT_GET_ATTEMPTS = 5
 
 # google.rpc.Code value for RESOURCE_EXHAUSTED. Used to classify LRO failures
 # where the initial HTTP response was 200 but the async operation ended with a
@@ -476,15 +482,31 @@ class CloudGcpService:
             raise ResourceNotFoundError(message)
         if code == 429 or status in ("RESOURCE_EXHAUSTED", "QUOTA_EXCEEDED"):
             raise QuotaExhaustedError(message)
+        if code >= 500:
+            raise InfraUnavailableError(f"GCP API error {code}: {message}")
         raise InfraError(f"GCP API error {code}: {message}")
+
+    def _get_retrying(self, url: str, params: dict[str, str] | None = None) -> dict:
+        """GET + classify, retrying only transient (5xx) GCP errors with backoff."""
+
+        def fetch() -> dict:
+            resp = self._client.get(url, headers=self._headers(), params=params)
+            self._classify_response(resp)
+            return resp.json()
+
+        return retry_with_backoff(
+            fetch,
+            retryable=lambda e: isinstance(e, InfraUnavailableError),
+            max_attempts=_TRANSIENT_GET_ATTEMPTS,
+            backoff=ExponentialBackoff(initial=1.0, maximum=15.0, factor=2.0),
+            operation=f"GET {url}",
+        )
 
     def _paginate(self, url: str, items_key: str, params: dict[str, str] | None = None) -> list[dict]:
         results: list[dict] = []
         p = dict(params or {})
         while True:
-            resp = self._client.get(url, headers=self._headers(), params=p)
-            self._classify_response(resp)
-            data = resp.json()
+            data = self._get_retrying(url, p)
             results.extend(data.get(items_key, []))
             token = data.get("nextPageToken")
             if not token:
@@ -496,9 +518,7 @@ class CloudGcpService:
         pages: list[dict] = []
         p = dict(params or {})
         while True:
-            resp = self._client.get(url, headers=self._headers(), params=p)
-            self._classify_response(resp)
-            data = resp.json()
+            data = self._get_retrying(url, p)
             pages.append(data)
             token = data.get("nextPageToken")
             if not token:
@@ -646,6 +666,8 @@ class CloudGcpService:
         for zone in zone_list:
             try:
                 items = self._paginate(f"{_TPU_BASE}/{self._tpu_parent(zone)}/nodes", "nodes")
+            except InfraUnavailableError:
+                raise  # sustained outage must surface; reconcile reclaims live slices on an empty list
             except InfraError:
                 logger.warning("Failed to list TPUs in zone %s", zone, exc_info=True)
                 continue
@@ -878,6 +900,8 @@ class CloudGcpService:
                     for scope in page.get("items", {}).values():
                         for vm_data in scope.get("instances", []):
                             results.append(_parse_vm_info(vm_data))
+            except InfraUnavailableError:
+                raise  # sustained outage must surface, not read as "no controller" to discovery
             except InfraError:
                 logger.warning("Failed to list instances", exc_info=True)
                 return []
@@ -889,6 +913,8 @@ class CloudGcpService:
                 params["filter"] = filter_str
             try:
                 items = self._paginate(self._instance_url(zone), "items", params)
+            except InfraUnavailableError:
+                raise  # don't drop a sustained outage to an empty per-zone result
             except InfraError:
                 logger.warning("Failed to list instances in zone %s", zone, exc_info=True)
                 continue

--- a/lib/iris/tests/cluster/providers/gcp/test_gcp_service.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_gcp_service.py
@@ -465,19 +465,20 @@ def test_vm_list_recovers_after_transient_blip(monkeypatch: pytest.MonkeyPatch) 
     assert calls["n"] == 2  # one retried failure, then success
 
 
-def test_vm_list_propagates_sustained_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
-    """A sustained 503 on the project-wide list must surface, not look like 'no VMs'.
+@pytest.mark.parametrize(
+    ("code", "expected"),
+    [
+        (503, InfraUnavailableError),  # transient: retried, then surfaces after exhaustion
+        (403, InfraError),  # non-transient: surfaces immediately
+    ],
+)
+def test_vm_list_propagates_api_errors(monkeypatch: pytest.MonkeyPatch, code: int, expected: type[InfraError]) -> None:
+    """vm_list never degrades an API error to []: a swallowed error reads as 'no VMs',
 
-    This is the controller-discovery path the canary ferry depends on; swallowing
-    it to [] is what turned a transient GCP 503 into a spurious "No controller VM".
+    which on the controller-discovery path the canary ferry depends on becomes a
+    spurious "No controller VM found".
     """
     monkeypatch.setattr("rigging.timing.time.sleep", lambda _: None)
-    svc = _mock_service(lambda _r: _gcp_error_response(503, message="Internal error. Please try again"))
-    with pytest.raises(InfraUnavailableError):
+    svc = _mock_service(lambda _r: _gcp_error_response(code, message="boom"))
+    with pytest.raises(expected):
         svc.vm_list(zones=[], labels={"iris-x-controller": "true"})
-
-
-def test_vm_list_swallows_non_transient_error() -> None:
-    """Non-transient errors keep the existing degrade-to-empty behavior for list callers."""
-    svc = _mock_service(lambda _r: _gcp_error_response(403, message="forbidden"))
-    assert svc.vm_list(zones=[], labels={"iris-x-controller": "true"}) == []

--- a/lib/iris/tests/cluster/providers/gcp/test_gcp_service.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_gcp_service.py
@@ -437,19 +437,32 @@ def _mock_service(handler: Callable[[httpx.Request], httpx.Response]) -> CloudGc
     return svc
 
 
-def test_get_retrying_retries_transient_5xx_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+def test_vm_list_recovers_after_transient_blip(monkeypatch: pytest.MonkeyPatch) -> None:
+    """The ferry discovery path: a one-off 503 is retried, then returns the controller VM.
+
+    Drives the full public path (classify -> retry -> paginate -> parse) so the
+    returned VM distinguishes genuine recovery from a swallow-to-[].
+    """
     monkeypatch.setattr("rigging.timing.time.sleep", lambda _: None)
     calls = {"n": 0}
+    vm = {
+        "name": "iris-controller",
+        "status": "RUNNING",
+        "zone": "https://www.googleapis.com/compute/v1/projects/p/zones/us-central1-a",
+        "networkInterfaces": [{"networkIP": "10.0.0.5"}],
+        "labels": {"iris-x-controller": "true"},
+    }
 
     def handler(_request: httpx.Request) -> httpx.Response:
         calls["n"] += 1
-        if calls["n"] < 3:
+        if calls["n"] == 1:
             return _gcp_error_response(503, message="Internal error. Please try again")
-        return httpx.Response(200, json={"ok": True})
+        return httpx.Response(200, json={"items": {"zones/us-central1-a": {"instances": [vm]}}})
 
     svc = _mock_service(handler)
-    assert svc._get_retrying("https://compute.googleapis.com/x") == {"ok": True}
-    assert calls["n"] == 3
+    result = svc.vm_list(zones=[], labels={"iris-x-controller": "true"})
+    assert [v.name for v in result] == ["iris-controller"]
+    assert calls["n"] == 2  # one retried failure, then success
 
 
 def test_vm_list_propagates_sustained_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:

--- a/lib/iris/tests/cluster/providers/gcp/test_gcp_service.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_gcp_service.py
@@ -13,8 +13,11 @@ These tests cover:
 
 from __future__ import annotations
 
+import time
+from collections.abc import Callable
 from unittest.mock import MagicMock, patch
 
+import httpx
 import pytest
 from iris.cluster.providers.gcp.fake import InMemoryGcpService
 from iris.cluster.providers.gcp.service import (
@@ -22,7 +25,12 @@ from iris.cluster.providers.gcp.service import (
     TpuCreateRequest,
     VmCreateRequest,
 )
-from iris.cluster.providers.types import InfraError, QuotaExhaustedError, ResourceNotFoundError
+from iris.cluster.providers.types import (
+    InfraError,
+    InfraUnavailableError,
+    QuotaExhaustedError,
+    ResourceNotFoundError,
+)
 from iris.cluster.service_mode import ServiceMode
 from iris.rpc import config_pb2
 
@@ -405,3 +413,58 @@ def test_tpu_list_extracts_zone_from_wildcard() -> None:
     assert len(results) == 1
     assert results[0].name == "my-tpu"
     assert results[0].zone == "us-central2-b"
+
+
+# ========================================================================
+# Transient-error retry and propagation (HTTP read path)
+# ========================================================================
+
+
+def _gcp_error_response(code: int, *, status: str = "", message: str = "boom") -> httpx.Response:
+    return httpx.Response(code, json={"error": {"code": code, "status": status, "message": message}})
+
+
+def _mock_service(handler: Callable[[httpx.Request], httpx.Response]) -> CloudGcpService:
+    """Build a CloudGcpService whose HTTP client is driven by ``handler``.
+
+    The token is pre-seeded so ``_headers`` never triggers a real google.auth
+    credential refresh.
+    """
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    svc = CloudGcpService(project_id="test-project", http_client=client)
+    svc._token = "fake-token"
+    svc._expires_at = time.monotonic() + 3600
+    return svc
+
+
+def test_get_retrying_retries_transient_5xx_then_succeeds(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setattr("rigging.timing.time.sleep", lambda _: None)
+    calls = {"n": 0}
+
+    def handler(_request: httpx.Request) -> httpx.Response:
+        calls["n"] += 1
+        if calls["n"] < 3:
+            return _gcp_error_response(503, message="Internal error. Please try again")
+        return httpx.Response(200, json={"ok": True})
+
+    svc = _mock_service(handler)
+    assert svc._get_retrying("https://compute.googleapis.com/x") == {"ok": True}
+    assert calls["n"] == 3
+
+
+def test_vm_list_propagates_sustained_unavailable(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A sustained 503 on the project-wide list must surface, not look like 'no VMs'.
+
+    This is the controller-discovery path the canary ferry depends on; swallowing
+    it to [] is what turned a transient GCP 503 into a spurious "No controller VM".
+    """
+    monkeypatch.setattr("rigging.timing.time.sleep", lambda _: None)
+    svc = _mock_service(lambda _r: _gcp_error_response(503, message="Internal error. Please try again"))
+    with pytest.raises(InfraUnavailableError):
+        svc.vm_list(zones=[], labels={"iris-x-controller": "true"})
+
+
+def test_vm_list_swallows_non_transient_error() -> None:
+    """Non-transient errors keep the existing degrade-to-empty behavior for list callers."""
+    svc = _mock_service(lambda _r: _gcp_error_response(403, message="forbidden"))
+    assert svc.vm_list(zones=[], labels={"iris-x-controller": "true"}) == []


### PR DESCRIPTION
* harden the canary ferry against transient gcp blips: a one-off `503 Internal error. Please try again` on controller discovery failed the whole `Wait for canary ferry` step (run [26816359276](https://github.com/marin-community/marin/actions/runs/26816359276))
* root cause: `vm_list` swallowed the `InfraError` into `[]`, so `_gcp_tunnel` read it as `No controller VM found` on an otherwise-retryable error
* `_classify_response` now raises the existing `InfraUnavailableError` for any 5xx [^1]
* new `_get_retrying` wraps paginated GETs in bounded backoff (`_TRANSIENT_GET_ATTEMPTS=5`), retrying only `InfraUnavailableError`; `_paginate`/`_paginate_raw` route through it
* `vm_list` and `tpu_list` re-raise `InfraUnavailableError` instead of degrading to `[]`
  * a sustained outage now surfaces rather than masquerading as "no controller" (discovery) or "no slices" (autoscaler reconcile, which reclaims live slices on an empty list)
  * non-transient `InfraError` keeps the existing degrade-to-empty behavior
* adds 3 tests: retry-then-succeed on 503, `vm_list` propagates a sustained outage, non-transient 403 still degrades to `[]`

[^1]: `InfraUnavailableError` ("Transient infrastructure failure. Retry with backoff.") already existed and was exported but never raised anywhere
