### PR TITLE
[finelog] Bound parquet scans on log queries

### DIFF
--- a/lib/finelog/src/finelog/store/log_namespace.py
+++ b/lib/finelog/src/finelog/store/log_namespace.py
@@ -19,7 +19,6 @@ from __future__ import annotations
 import contextlib
 import logging
 import os
-import re
 import threading
 import time
 from collections import deque
@@ -101,8 +100,11 @@ _PERSIST_WAIT_BACKOFF_INITIAL_SEC = 0.001
 _PERSIST_WAIT_BACKOFF_MAX_SEC = 0.05
 
 # Hard ceiling on the per-read parquet working set; safety net for body-LIKE
-# queries that cannot be pruned by row-group statistics.
-_MAX_PARQUET_BYTES_PER_READ = 10 * 1024 * 1024 * 1024
+# queries that cannot be pruned by row-group statistics. Both the FetchLogs
+# read path and the stats Query path scan the newest segments up to this many
+# bytes, so this directly bounds query latency on large namespaces (e.g. `log`)
+# at the cost of not matching older rows.
+_MAX_PARQUET_BYTES_PER_READ = 2560 * 1024 * 1024  # 2.5 GiB
 
 
 class SegmentMetadata(NamedTuple):
@@ -1657,11 +1659,25 @@ class DiskLogNamespace:
             )
 
     def query_snapshot(self) -> list[LocalSegment]:
-        """Return queryable local segments. Queries see only flushed data;
-        the in-RAM buffer is not exposed (flush cadence is ≤1s).
+        """Return queryable local segments, newest-first and capped to
+        ``_MAX_PARQUET_BYTES_PER_READ``.
+
+        The cap matches the FetchLogs read path: a stats Query over a large
+        namespace would otherwise build a ``read_parquet(union_by_name=true)``
+        view over *every* segment, forcing DuckDB to open every file's footer
+        up front (seconds on the multi-GB ``log`` namespace). Capping bounds
+        that to the newest ``_MAX_PARQUET_BYTES_PER_READ`` per namespace.
+
+        Trade-off: a Query sees only the newest few GB, the same recency bound
+        FetchLogs already applies. Full-history aggregations are out of scope
+        until the query engine is replaced.
+
+        Queries see only flushed data; the in-RAM buffer is not exposed (flush
+        cadence is ≤1s).
         """
         with self._insertion_lock:
-            return list(self._local_segments)
+            segments = list(self._local_segments)
+        return _cap_segments(segments)
 
     def all_segments_unlocked(self) -> list[LocalSegment]:
         """Snapshot every locally-tracked segment. Caller MUST hold the insertion lock."""
@@ -2042,16 +2058,42 @@ def _cap_segments(segments: list[LocalSegment]) -> list[LocalSegment]:
     return capped
 
 
-# Characters that hint a regex was passed where PREFIX was intended; used
-# only for a friendlier error if a caller forgets to set match_scope=REGEX.
-_REGEX_HINT_RE = re.compile(r"[.*+?\[\](){}^$|\\]")
+# Regex metacharacters that terminate a literal prefix. Backslash is handled
+# separately in ``_regex_literal_prefix`` (an escaped punctuation char is a
+# literal and extends the prefix).
+_REGEX_METACHARS = frozenset(".*+?[](){}^$|")
 
 
-def _regex_literal_prefix(pattern: str) -> str:
-    match = _REGEX_HINT_RE.search(pattern)
-    if match is None:
-        return pattern
-    return pattern[: match.start()]
+def _regex_literal_prefix(pattern: str) -> tuple[str, int]:
+    """Return ``(literal_prefix, consumed)`` for a regex ``pattern``.
+
+    Walks the leading run of literal characters, decoding ``re.escape``-style
+    single-character escapes (``\\-`` -> ``-``) so an escaped-but-literal key
+    still yields a long, prunable prefix. Stops at the first true
+    metacharacter or character-class/anchor escape (``\\d``, ``\\w``, ``\\b`` …).
+
+    ``consumed`` is the number of *source* characters the literal spans — which
+    exceeds ``len(literal_prefix)`` when escapes were decoded — so the caller
+    can slice the remaining regex suffix as ``pattern[consumed:]``.
+    """
+    out: list[str] = []
+    i = 0
+    n = len(pattern)
+    while i < n:
+        c = pattern[i]
+        if c == "\\":
+            # A trailing backslash or an alphanumeric escape (\d, \w, \b, \1)
+            # is a class/anchor/backref, not a literal — stop before it.
+            if i + 1 >= n or pattern[i + 1].isalnum():
+                break
+            out.append(pattern[i + 1])
+            i += 2
+            continue
+        if c in _REGEX_METACHARS:
+            break
+        out.append(c)
+        i += 1
+    return "".join(out), i
 
 
 def _scope_query(
@@ -2089,8 +2131,8 @@ def _scope_query(
         # Pull off any leading literal prefix to keep row-group pruning even
         # for regex queries. `prefix(key, $p)` is monotone, so it remains
         # correct as long as the regex requires that prefix to match.
-        literal_prefix = _regex_literal_prefix(source)
-        suffix = source[len(literal_prefix) :]
+        literal_prefix, consumed = _regex_literal_prefix(source)
+        suffix = source[consumed:]
         # `^literal$`, `^literal`, `^literal.*` all reduce to the literal prefix
         # alone; we still need regexp_matches for any other suffix.
         is_pure_prefix = suffix in (".*", "")

--- a/lib/finelog/tests/test_duckdb_store.py
+++ b/lib/finelog/tests/test_duckdb_store.py
@@ -3,11 +3,13 @@
 
 from __future__ import annotations
 
+import re
 from pathlib import Path
 
 import pytest
 from finelog.rpc import logging_pb2
 from finelog.store.duckdb_store import DuckDBLogStore
+from finelog.store.log_namespace import _regex_literal_prefix
 
 KEY = "/job/test/0:0"
 
@@ -60,6 +62,39 @@ def test_regex_scope_query(store: DuckDBLogStore):
     result = store.get_logs("/job/test/.*", match_scope=logging_pb2.MATCH_SCOPE_REGEX)
     assert sorted(e.data for e in result.entries) == ["a", "b"]
     assert all(e.attempt_id == 0 for e in result.entries)
+
+
+@pytest.mark.parametrize(
+    ("pattern", "literal", "consumed"),
+    [
+        ("/job/test/", "/job/test/", 10),  # no metachars: whole string is literal
+        ("/job/test/.*", "/job/test/", 10),  # stops at the `.`
+        (r"/job/a\-b/0:.*", "/job/a-b/0:", 12),  # decode `\-`; consumed counts the backslash
+        (r"/job/9e\+20", "/job/9e+20", 11),  # re.escape'd literal key, no suffix
+        (r"/job/\d+", "/job/", 5),  # `\d` is a class, not a literal — stop before it
+        (r"a\\b.*", "a\\b", 4),  # `\\` decodes to a single backslash
+    ],
+)
+def test_regex_literal_prefix_decodes_escapes(pattern: str, literal: str, consumed: int):
+    """The literal-prefix extractor must decode ``re.escape``-style single-char
+    escapes so escaped-but-literal keys still yield a long, prunable prefix, and
+    must report how many source chars it consumed so the caller can slice the
+    remaining regex suffix."""
+    assert _regex_literal_prefix(pattern) == (literal, consumed)
+
+
+def test_regex_scope_query_with_escaped_literal(store: DuckDBLogStore):
+    """An old client (pre-explicit-MatchScope) tails a task by sending the
+    re.escape'd task key plus ``.*`` under REGEX scope, e.g.
+    ``/ryan/train\\-mg\\-tz\\-11/0:.*``. The escaped hyphens must not truncate
+    the prunable prefix, and the query must still pin to that one task."""
+    store.append("/job/train-mg-tz-11/0:0", [_entry("hit-11", epoch_ms=1)])
+    store.append("/job/train-mg-tz-12/0:0", [_entry("decoy-12", epoch_ms=2)])
+    store.append("/job/train-mg-tz-11-extra/0:0", [_entry("decoy-extra", epoch_ms=3)])
+
+    pattern = re.escape("/job/train-mg-tz-11/0") + ":.*"
+    result = store.get_logs(pattern, match_scope=logging_pb2.MATCH_SCOPE_REGEX)
+    assert [e.data for e in result.entries] == ["hit-11"]
 
 
 def test_prefix_scope_query(store: DuckDBLogStore):

--- a/lib/finelog/tests/test_query.py
+++ b/lib/finelog/tests/test_query.py
@@ -105,6 +105,30 @@ def test_query_unknown_namespace_in_sql_raises(store: DuckDBLogStore):
         store.query('SELECT * FROM "nope.unknown"')
 
 
+def test_query_caps_to_newest_segments_within_byte_budget(store: DuckDBLogStore, monkeypatch):
+    """A stats Query sees only the newest segments within
+    ``_MAX_PARQUET_BYTES_PER_READ`` — the same recency cap the FetchLogs path
+    applies. This bounds how many parquet footers the per-query
+    ``read_parquet(union_by_name=true)`` view must open on a large namespace.
+    """
+    store.register_table("iris.worker", _worker_schema())
+    # Three independently sealed segments (force_compact_l0 only merges L0,
+    # so each write+seal yields its own L1 segment).
+    for i in range(3):
+        store.write_rows("iris.worker", _ipc_bytes(_worker_batch([f"w-{i}"], [i], [i])))
+        _seal(store, "iris.worker")
+
+    # Default (large) budget: the query sees every segment.
+    full = store.query('SELECT worker_id FROM "iris.worker" ORDER BY worker_id')
+    assert full.column("worker_id").to_pylist() == ["w-0", "w-1", "w-2"]
+
+    # A 1-byte budget keeps only the newest segment (the cap always keeps at
+    # least the newest one, then stops once the next would exceed the budget).
+    monkeypatch.setattr("finelog.store.log_namespace._MAX_PARQUET_BYTES_PER_READ", 1)
+    capped = store.query('SELECT worker_id FROM "iris.worker"')
+    assert capped.column("worker_id").to_pylist() == ["w-2"]
+
+
 def test_compaction_commit_waits_for_active_readers(store: DuckDBLogStore):
     """Commit (rename + catalog swap + unlink) must drain readers first.
 


### PR DESCRIPTION
Stats Query built a union_by_name view over every segment of every namespace, reading all footers up front — seconds on the multi-GB log namespace. Cap query_snapshot to the newest 2.5 GB, the same _MAX_PARQUET_BYTES_PER_READ budget the FetchLogs read path uses. Also decode re.escape'd literals in regex prefix extraction so escaped-but-literal key tails (from older iris clients) prune as pure prefixes instead of full L3 scans.