### PR TITLE
[iris] Reap a TPU slice whose bootstrap failed instead of waiting out UNKNOWN

### DIFF
--- a/lib/iris/src/iris/cluster/providers/gcp/handles.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/handles.py
@@ -112,14 +112,26 @@ def _composite_slice_state(
     bootstrap sentinel, so it too becomes READY and is validated by the
     autoscaler's health probe, which reaps it if the workers are in fact dead.
 
-    Cloud states that mean "gone or doomed" — FAILED, DELETING, and UNKNOWN (no
-    longer describable) — are authoritative and override the bootstrap verdict,
-    so a torn-down or vanished node never lingers as READY on a stale sentinel.
+    A bootstrap that definitively FAILED is authoritative — even when the cloud
+    is no longer describable (UNKNOWN). A stockout/quota create failure leaves no
+    TPU resource to describe, so describe() reports UNKNOWN; without surfacing the
+    FAILED bootstrap verdict the autoscaler would wait out the full
+    unresolvable-timeout grace period (and keep re-describing the dead TPU) before
+    reaping a slice it already knows never came up.
+
+    Cloud states that mean "gone or doomed" — FAILED and DELETING — are likewise
+    authoritative. A bare UNKNOWN (cloud no longer describable, bootstrap still in
+    progress or a stale READY sentinel) is reported as UNKNOWN so a vanished node
+    never lingers as READY and the unresolvable-timeout path can reap it.
     """
-    if cloud_state in (CloudSliceState.FAILED, CloudSliceState.DELETING, CloudSliceState.UNKNOWN):
+    if cloud_state in (CloudSliceState.FAILED, CloudSliceState.DELETING):
         return cloud_state
+    # A definitive bootstrap failure wins over UNKNOWN: the slice never came up,
+    # so reap it now instead of waiting out the unresolvable timeout.
     if bootstrap_state == CloudSliceState.FAILED:
         return CloudSliceState.FAILED
+    if cloud_state == CloudSliceState.UNKNOWN:
+        return CloudSliceState.UNKNOWN
     if bootstrap_state == CloudSliceState.READY:
         return CloudSliceState.READY
     # Bootstrap still in progress: surface BOOTSTRAPPING once cloud is READY,

--- a/lib/iris/tests/cluster/providers/gcp/test_platform.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_platform.py
@@ -1186,6 +1186,10 @@ def test_tpu_bootstrap_aborts_when_slice_enters_deleting():
         (CloudSliceState.UNKNOWN, CloudSliceState.READY, CloudSliceState.UNKNOWN),
         # Bootstrap failure surfaces as FAILED.
         (CloudSliceState.CREATING, CloudSliceState.FAILED, CloudSliceState.FAILED),
+        # A definitive bootstrap failure wins over an UNKNOWN cloud state: a
+        # stockout/quota create failure leaves no TPU to describe (UNKNOWN), but
+        # the slice must be reaped now, not after the unresolvable timeout.
+        (CloudSliceState.UNKNOWN, CloudSliceState.FAILED, CloudSliceState.FAILED),
     ],
 )
 def test_composite_slice_state(cloud_state, bootstrap_state, expected):


### PR DESCRIPTION
A stockout/quota create failure leaves no TPU to describe, so describe() reports UNKNOWN. _composite_slice_state gave cloud UNKNOWN priority over a FAILED bootstrap verdict, masking the failure: the autoscaler re-described the dead TPU every tick and held the phantom slice as BOOTING capacity until the 15-minute unresolvable timeout. Now a definitive bootstrap FAILED is surfaced over UNKNOWN so the slice is reaped at once. Adds a regression case.