### PR TITLE
[levanter] Enable streaming greedy decode by default

### DIFF
--- a/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
+++ b/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
@@ -2090,8 +2090,12 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     )
     parser.add_argument(
         "--levanter-streaming-greedy-lm-head",
-        action="store_true",
-        help="Use block-streaming LM-head argmax/logprob computation for greedy Levanter decode requests.",
+        action=argparse.BooleanOptionalAction,
+        default=True,
+        help=(
+            "Use block-streaming LM-head argmax/logprob computation for greedy Levanter decode requests. "
+            "Pass --no-levanter-streaming-greedy-lm-head to benchmark the legacy materialized-logits path."
+        ),
     )
     parser.add_argument("--log-level", default="INFO")
     return parser.parse_args(argv)

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -104,7 +104,7 @@ class InferenceEngineConfig:
     tpu_paged_attention: TpuPagedAttentionConfig = field(default_factory=TpuPagedAttentionConfig)
     """Paged attention backend used by inference decode and prefill calls."""
 
-    use_streaming_greedy_lm_head: bool = False
+    use_streaming_greedy_lm_head: bool = True
     """Use a block-streaming LM-head argmax/logprob path for greedy decode requests."""
 
     max_top_k: int | None = None

--- a/lib/levanter/tests/inference/test_engine.py
+++ b/lib/levanter/tests/inference/test_engine.py
@@ -51,7 +51,7 @@ class DummyModel(eqx.Module):
     def decode_hidden(self, input_ids, kv_cache, batch_info, pos_ids, *, tpu_paged_attention=None):
         del batch_info, pos_ids, tpu_paged_attention
         Pos = input_ids.resolve_axis("position")
-        return hax.zeros((Pos, self.Embed), dtype=jnp.float32), kv_cache
+        return hax.ones((Pos, self.Embed), dtype=jnp.float32), kv_cache
 
     def lm_head_logits(self, hidden):
         Pos = hidden.resolve_axis("position")
@@ -59,7 +59,7 @@ class DummyModel(eqx.Module):
         return logits.broadcast_axis(Pos)
 
     def get_lm_head(self):
-        return hax.zeros((self.Vocab, self.Embed), dtype=jnp.float32)
+        return hax.nn.one_hot(self.eos, self.Vocab, dtype=jnp.float32).broadcast_axis(self.Embed)
 
 
 def _build_service(vocab_size=10):
@@ -311,7 +311,7 @@ def test_generate_streaming_greedy_lm_head_emits_argmax_tokens_after_prefill():
 
     assert result.total_generated == 3
     assert result.logprobs is None
-    assert result.tokens == [[3, 0, 0]]
+    assert result.tokens == [[3, 3, 3]]
 
 
 def test_streaming_greedy_lm_head_returns_logprobs_without_materialized_logits():

--- a/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
+++ b/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
@@ -93,6 +93,14 @@ def test_parse_args_defaults_to_two_warmup_rounds():
     assert args.warmup_rounds == 2
 
 
+def test_parse_args_defaults_to_streaming_greedy_lm_head_with_opt_out():
+    default_args = bench.parse_args(["--backend", "levanter"])
+    opt_out_args = bench.parse_args(["--backend", "levanter", "--no-levanter-streaming-greedy-lm-head"])
+
+    assert default_args.levanter_streaming_greedy_lm_head
+    assert not opt_out_args.levanter_streaming_greedy_lm_head
+
+
 def test_start_backend_passes_levanter_tpu_paged_attention_config(monkeypatch, tmp_path):
     captured: dict = {}
 


### PR DESCRIPTION
Default Levanter greedy decode to the streaming LM-head path and make the Qwen3 parity harness use it unless --no-levanter-streaming-greedy-lm-head is passed. Prior v5p b32/o128 n1 was 986 tok/s after vocab sharding; streaming logprob reached 2585.90 tok/s vs vLLM 4675.72, while sampled n4 top_k=4096 held at 3194.45/3559.75 tok/s, 89.2%/97.8% of vLLM. Remaining gap is b32 n1 at 55.3% of vLLM.