### PR TITLE
iris: cap concurrent TPU create requests in the autoscaler

### DIFF
--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -20,7 +20,6 @@ The run_once() flow splits into two phases:
 from __future__ import annotations
 
 import logging
-import threading
 import urllib.error
 import urllib.request
 from collections import deque
@@ -78,19 +77,6 @@ _HEALTH_PROBE_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({
 # timeouts would blow past evaluation_interval (10 s default).
 _HEALTH_PROBE_MAX_WORKERS = 64
 
-# Cap concurrent slice-create requests across all scale groups. Each scale-up
-# decision spawns a thread that issues one cloud create POST. The per-group
-# rate limit is a token bucket (capacity 16) refilled per minute, so an idle
-# group can dump a full bucket in a single tick — and with no global cap, many
-# groups draining their buckets at once (or a controller restart re-requesting
-# all demand) fires hundreds of create POSTs in the same second. Production
-# logs show bursts of 100-160 creates/s, correlated with transient
-# "TPU operation failed: an internal error has occurred" failures and with
-# multiple creates racing the same zone-capacity snapshot. The create POST
-# returns immediately (bootstrap runs on a separate thread), so gating it
-# smooths bursts without serializing bootstrap or limiting sustained throughput.
-DEFAULT_MAX_CONCURRENT_SCALE_UPS = 8
-
 
 def _probe_worker_health(worker_url: str) -> bool:
     """Probe a worker's /health endpoint. ``worker_url`` is an ``http://host:port`` base URL.
@@ -129,7 +115,6 @@ class Autoscaler:
         base_worker_config: config_pb2.WorkerConfig | None = None,
         db: ControllerDB | None = None,
         unresolvable_timeout: Duration = DEFAULT_UNRESOLVABLE_TIMEOUT,
-        max_concurrent_scale_ups: int = DEFAULT_MAX_CONCURRENT_SCALE_UPS,
     ):
         """Create autoscaler with explicit parameters.
 
@@ -142,8 +127,6 @@ class Autoscaler:
                 and passed to platform.create_slice(). None disables bootstrap (test/local mode).
             db: Optional DB handle for write-through persistence of tracked workers.
             unresolvable_timeout: How long a slice can remain UNKNOWN before being treated as FAILED.
-            max_concurrent_scale_ups: Upper bound on in-flight slice-create requests across all
-                scale groups. Bounds how many create POSTs hit the cloud API at once.
         """
         self._groups = scale_groups
         self._platform = platform
@@ -171,11 +154,6 @@ class Autoscaler:
 
         # Thread management
         self._threads = threads if threads is not None else get_thread_container()
-
-        # Global ceiling on concurrent slice-create requests. Each scale-up runs
-        # on its own thread but must hold a token before issuing the cloud create
-        # POST, so a burst of decisions drains through the API at a bounded rate.
-        self._scale_up_semaphore = threading.BoundedSemaphore(max_concurrent_scale_ups)
 
     @classmethod
     def from_config(
@@ -396,35 +374,28 @@ class Autoscaler:
         group.begin_scale_up(timestamp=ts)
 
         def _scale_up_wrapper(stop_event):
-            self._do_scale_up(group, ts, stop_event, reason)
+            self._do_scale_up(group, ts, reason)
 
         self._threads.spawn(
             target=_scale_up_wrapper,
             name=f"scale-up-{group.name}",
         )
 
-    def _do_scale_up(self, group: ScalingGroup, ts: Timestamp, stop_event: threading.Event, reason: str = "") -> bool:
+    def _do_scale_up(self, group: ScalingGroup, ts: Timestamp, reason: str = "") -> bool:
         """Execute the actual blocking scale-up work.
 
         This runs in a background thread and should not be called directly.
         Use _execute_scale_up instead. Bootstrap is handled internally by the
         platform when cluster_config is provided.
 
+        Concurrent create LROs are bounded inside the platform's create_slice
+        (a slot held from the create POST until the node leaves CREATING), not
+        here, so this issues its create unguarded.
+
         Returns:
             True if scale-up succeeded, False otherwise.
         """
         action = self._log_action("scale_up", group.name, reason=reason, status="pending")
-
-        # Hold a create token for the duration of the cloud create call so the
-        # number of in-flight create POSTs stays bounded even when many groups
-        # decide to scale up in the same tick. Poll on acquire so a shutdown
-        # (stop_event) doesn't leave this thread parked indefinitely.
-        while not self._scale_up_semaphore.acquire(timeout=1.0):
-            if stop_event.is_set():
-                group.cancel_scale_up()
-                action.status = "failed"
-                action.reason = "shutdown before create slot acquired"
-                return False
 
         slice_obj = None
 
@@ -452,8 +423,6 @@ class Autoscaler:
             action.reason = f"{reason} - error: {e}"
             group.record_create_failed(ts)
             return False
-        finally:
-            self._scale_up_semaphore.release()
 
     def _per_group_worker_config(self, group: ScalingGroup) -> config_pb2.WorkerConfig | None:
         """Build per-group WorkerConfig by merging base config with scale group overrides."""

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -20,6 +20,7 @@ The run_once() flow splits into two phases:
 from __future__ import annotations
 
 import logging
+import threading
 import urllib.error
 import urllib.request
 from collections import deque
@@ -77,6 +78,19 @@ _HEALTH_PROBE_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({
 # timeouts would blow past evaluation_interval (10 s default).
 _HEALTH_PROBE_MAX_WORKERS = 64
 
+# Cap concurrent slice-create requests across all scale groups. Each scale-up
+# decision spawns a thread that issues one cloud create POST. The per-group
+# rate limit is a token bucket (capacity 16) refilled per minute, so an idle
+# group can dump a full bucket in a single tick — and with no global cap, many
+# groups draining their buckets at once (or a controller restart re-requesting
+# all demand) fires hundreds of create POSTs in the same second. Production
+# logs show bursts of 100-160 creates/s, correlated with transient
+# "TPU operation failed: an internal error has occurred" failures and with
+# multiple creates racing the same zone-capacity snapshot. The create POST
+# returns immediately (bootstrap runs on a separate thread), so gating it
+# smooths bursts without serializing bootstrap or limiting sustained throughput.
+DEFAULT_MAX_CONCURRENT_SCALE_UPS = 8
+
 
 def _probe_worker_health(worker_url: str) -> bool:
     """Probe a worker's /health endpoint. ``worker_url`` is an ``http://host:port`` base URL.
@@ -115,6 +129,7 @@ class Autoscaler:
         base_worker_config: config_pb2.WorkerConfig | None = None,
         db: ControllerDB | None = None,
         unresolvable_timeout: Duration = DEFAULT_UNRESOLVABLE_TIMEOUT,
+        max_concurrent_scale_ups: int = DEFAULT_MAX_CONCURRENT_SCALE_UPS,
     ):
         """Create autoscaler with explicit parameters.
 
@@ -127,6 +142,8 @@ class Autoscaler:
                 and passed to platform.create_slice(). None disables bootstrap (test/local mode).
             db: Optional DB handle for write-through persistence of tracked workers.
             unresolvable_timeout: How long a slice can remain UNKNOWN before being treated as FAILED.
+            max_concurrent_scale_ups: Upper bound on in-flight slice-create requests across all
+                scale groups. Bounds how many create POSTs hit the cloud API at once.
         """
         self._groups = scale_groups
         self._platform = platform
@@ -154,6 +171,11 @@ class Autoscaler:
 
         # Thread management
         self._threads = threads if threads is not None else get_thread_container()
+
+        # Global ceiling on concurrent slice-create requests. Each scale-up runs
+        # on its own thread but must hold a token before issuing the cloud create
+        # POST, so a burst of decisions drains through the API at a bounded rate.
+        self._scale_up_semaphore = threading.BoundedSemaphore(max_concurrent_scale_ups)
 
     @classmethod
     def from_config(
@@ -374,14 +396,14 @@ class Autoscaler:
         group.begin_scale_up(timestamp=ts)
 
         def _scale_up_wrapper(stop_event):
-            self._do_scale_up(group, ts, reason)
+            self._do_scale_up(group, ts, stop_event, reason)
 
         self._threads.spawn(
             target=_scale_up_wrapper,
             name=f"scale-up-{group.name}",
         )
 
-    def _do_scale_up(self, group: ScalingGroup, ts: Timestamp, reason: str = "") -> bool:
+    def _do_scale_up(self, group: ScalingGroup, ts: Timestamp, stop_event: threading.Event, reason: str = "") -> bool:
         """Execute the actual blocking scale-up work.
 
         This runs in a background thread and should not be called directly.
@@ -392,6 +414,17 @@ class Autoscaler:
             True if scale-up succeeded, False otherwise.
         """
         action = self._log_action("scale_up", group.name, reason=reason, status="pending")
+
+        # Hold a create token for the duration of the cloud create call so the
+        # number of in-flight create POSTs stays bounded even when many groups
+        # decide to scale up in the same tick. Poll on acquire so a shutdown
+        # (stop_event) doesn't leave this thread parked indefinitely.
+        while not self._scale_up_semaphore.acquire(timeout=1.0):
+            if stop_event.is_set():
+                group.cancel_scale_up()
+                action.status = "failed"
+                action.reason = "shutdown before create slot acquired"
+                return False
 
         slice_obj = None
 
@@ -419,6 +452,8 @@ class Autoscaler:
             action.reason = f"{reason} - error: {e}"
             group.record_create_failed(ts)
             return False
+        finally:
+            self._scale_up_semaphore.release()
 
     def _per_group_worker_config(self, group: ScalingGroup) -> config_pb2.WorkerConfig | None:
         """Build per-group WorkerConfig by merging base config with scale group overrides."""

--- a/lib/iris/src/iris/cluster/providers/gcp/workers.py
+++ b/lib/iris/src/iris/cluster/providers/gcp/workers.py
@@ -63,6 +63,27 @@ from iris.rpc import config_pb2
 logger = logging.getLogger(__name__)
 
 
+def _make_one_shot_release(semaphore: threading.BoundedSemaphore) -> Callable[[], None]:
+    """Return a callable that releases ``semaphore`` exactly once.
+
+    The acquiring (scale-up) thread and the bootstrap thread can both race to
+    free the create slot; the guard keeps a BoundedSemaphore from raising on a
+    double release.
+    """
+    lock = threading.Lock()
+    released = False
+
+    def _release() -> None:
+        nonlocal released
+        with lock:
+            if released:
+                return
+            released = True
+        semaphore.release()
+
+    return _release
+
+
 def _spawn_bootstrap_thread(
     handle: GcpSliceHandle | GcpVmSliceHandle,
     bootstrap_fn: Callable[[], None],
@@ -87,6 +108,12 @@ def _spawn_bootstrap_thread(
 
     threading.Thread(target=_run, name=f"bootstrap-{handle.slice_id}", daemon=True).start()
 
+
+# Default ceiling on concurrent in-flight TPU slice-create LROs. A create stays
+# in flight from the CreateNode POST until the node leaves CREATING (bootstrap
+# phase 1), so this bounds how many create operations GCP provisions at once —
+# unlike a POST-only gate, which a fire-and-forget create barely constrains.
+DEFAULT_MAX_INFLIGHT_TPU_CREATES = 8
 
 DEFAULT_MACHINE_TYPE = "n2-standard-4"
 DEFAULT_BOOT_DISK_SIZE_GB = 50
@@ -251,6 +278,7 @@ class GcpWorkerProvider:
         worker_port: int,
         ssh_config: config_pb2.SshConfig | None = None,
         gcp_service: GcpService | None = None,
+        max_inflight_tpu_creates: int = DEFAULT_MAX_INFLIGHT_TPU_CREATES,
     ):
         self._project_id = gcp_config.project_id
         self._label_prefix = label_prefix
@@ -259,6 +287,12 @@ class GcpWorkerProvider:
         self._ssh_config = ssh_config
         self._zones = list(gcp_config.zones)
         self._gcp: GcpService = gcp_service or CloudGcpService(project_id=self._project_id)
+
+        # Bound concurrent in-flight create LROs: a token is held from the create
+        # POST until the node leaves CREATING (bootstrap phase 1), so the count
+        # tracks how many slices GCP is provisioning at once rather than the rate
+        # of POSTs (which return immediately).
+        self._inflight_create_slots = threading.BoundedSemaphore(max_inflight_tpu_creates)
 
     @property
     def gcp_service(self) -> GcpService:
@@ -439,11 +473,19 @@ class GcpWorkerProvider:
         )
 
         logger.info("Creating TPU slice: %s (type=%s, zone=%s)", slice_id, config.accelerator_variant, gcp.zone)
-        # Submit the create and return immediately. The create LRO is no longer
-        # waited on here: the bootstrap loop watches it for quota/stockout and
-        # otherwise lets worker health decide readiness, so a slow create-status
-        # response can never tear down a slice that has already booted workers.
-        tpu_info = self._gcp.tpu_create(request)
+        # Hold an in-flight-create slot from the POST until the node leaves
+        # CREATING (released by bootstrap phase 1), bounding concurrent create
+        # LROs. Submit the create and return immediately: the create LRO is no
+        # longer waited on here — the bootstrap loop watches it for quota/stockout
+        # and otherwise lets worker health decide readiness, so a slow
+        # create-status response can never tear down a slice that has booted.
+        self._inflight_create_slots.acquire()
+        release_slot = _make_one_shot_release(self._inflight_create_slots)
+        try:
+            tpu_info = self._gcp.tpu_create(request)
+        except Exception:
+            release_slot()
+            raise
 
         handle = GcpSliceHandle(
             _slice_id=slice_id,
@@ -464,8 +506,12 @@ class GcpWorkerProvider:
         if worker_config:
             _spawn_bootstrap_thread(
                 handle,
-                lambda: _run_tpu_bootstrap(self._gcp, self._project_id, handle),
+                lambda: _run_tpu_bootstrap(self._gcp, self._project_id, handle, on_create_settled=release_slot),
             )
+        else:
+            # No bootstrap thread will watch the LRO, so nothing else can free the
+            # slot — release it now.
+            release_slot()
 
         return handle
 
@@ -508,9 +554,15 @@ class GcpWorkerProvider:
             config.accelerator_variant,
             gcp.zone,
         )
+        # Hold an in-flight-create slot until the queued resource provisions and
+        # the node leaves CREATING (released by bootstrap phase 1), so reserved
+        # creates share the same concurrency ceiling as standard ones.
+        self._inflight_create_slots.acquire()
+        release_slot = _make_one_shot_release(self._inflight_create_slots)
         try:
             self._gcp.queued_resource_create(request)
         except InfraError:
+            release_slot()
             self._best_effort_delete_queued_resource(slice_id, gcp.zone)
             raise
 
@@ -533,8 +585,10 @@ class GcpWorkerProvider:
         if worker_config:
             _spawn_bootstrap_thread(
                 handle,
-                lambda: _run_tpu_bootstrap(self._gcp, self._project_id, handle),
+                lambda: _run_tpu_bootstrap(self._gcp, self._project_id, handle, on_create_settled=release_slot),
             )
+        else:
+            release_slot()
 
         return handle
 
@@ -834,6 +888,7 @@ def _run_tpu_bootstrap(
     ip_wait_timeout: float | None = None,
     bootstrap_timeout: float | None = None,
     queued_resource_poll_interval: float = 60.0,
+    on_create_settled: Callable[[], None] | None = None,
 ) -> None:
     """Monitor TPU startup-script bootstrap via health endpoint polling.
 
@@ -844,60 +899,72 @@ def _run_tpu_bootstrap(
     Phase 2: Poll worker health endpoints until all respond healthy; this is
         the canonical readiness signal.
     On timeout: query Cloud Logging for [iris-init] entries for diagnostics.
+
+    ``on_create_settled`` is invoked once the create LRO is no longer in flight
+    (the node has left CREATING at the end of phase 1, or bootstrap failed before
+    that). The caller uses it to release the in-flight-create slot so the slot
+    tracks the LRO lifetime rather than the slower health wait in phase 2.
     """
+    settle_create = on_create_settled or (lambda: None)
     try:
-        worker_count = get_tpu_topology(handle._accelerator_variant).vm_count
-    except ValueError as e:
-        raise InfraError(
-            f"Unknown TPU topology '{handle._accelerator_variant}' for slice {handle.slice_id}. "
-            "Cannot size bootstrap timeouts."
-        ) from e
+        try:
+            worker_count = get_tpu_topology(handle._accelerator_variant).vm_count
+        except ValueError as e:
+            raise InfraError(
+                f"Unknown TPU topology '{handle._accelerator_variant}' for slice {handle.slice_id}. "
+                "Cannot size bootstrap timeouts."
+            ) from e
 
-    effective_ip_wait_timeout = ip_wait_timeout
-    if effective_ip_wait_timeout is None:
-        effective_ip_wait_timeout = _default_tpu_ip_wait_timeout(worker_count)
+        effective_ip_wait_timeout = ip_wait_timeout
+        if effective_ip_wait_timeout is None:
+            effective_ip_wait_timeout = _default_tpu_ip_wait_timeout(worker_count)
 
-    effective_bootstrap_timeout = bootstrap_timeout
-    if effective_bootstrap_timeout is None:
-        effective_bootstrap_timeout = _default_tpu_bootstrap_timeout(worker_count)
+        effective_bootstrap_timeout = bootstrap_timeout
+        if effective_bootstrap_timeout is None:
+            effective_bootstrap_timeout = _default_tpu_bootstrap_timeout(worker_count)
 
-    logger.info(
-        "Using TPU bootstrap timeouts for %s: ip_wait_timeout=%ss bootstrap_timeout=%ss worker_count=%d",
-        handle.slice_id,
-        effective_ip_wait_timeout,
-        effective_bootstrap_timeout,
-        worker_count,
-    )
-
-    # Phase 0: If this is a queued resource (reserved TPU), wait for ACTIVE
-    # before polling the TPU VM state. The queued resource may sit in QUEUED
-    # or PROVISIONING for an extended period.
-    if handle.is_queued_resource:
-        _wait_for_queued_resource_activation(gcp_service, handle, queued_resource_poll_interval)
-
-    # Phase 1: wait for every worker to acquire an internal IP. The create LRO
-    # is watched only to fail fast on quota/stockout; its completion is not a
-    # readiness gate, so a slow create-status response cannot strand the slice.
-    ip_deadline = Deadline.from_now(Duration.from_seconds(effective_ip_wait_timeout))
-    ip_backoff = ExponentialBackoff(initial=1.0, maximum=30.0, factor=1.5)
-
-    while not ip_deadline.expired():
-        _raise_if_create_failed(gcp_service, handle)
-        cloud_status = handle._describe_cloud()
-        if cloud_status.state in (CloudSliceState.FAILED, CloudSliceState.DELETING):
-            raise InfraError(f"Slice {handle.slice_id} entered {cloud_status.state} during bootstrap")
-        if cloud_status.workers and all(w.internal_address for w in cloud_status.workers):
-            break
         logger.info(
-            "Slice %s waiting for worker IPs: %d/%d (cloud state=%s)",
+            "Using TPU bootstrap timeouts for %s: ip_wait_timeout=%ss bootstrap_timeout=%ss worker_count=%d",
             handle.slice_id,
-            sum(1 for w in cloud_status.workers if w.internal_address),
-            cloud_status.worker_count,
-            cloud_status.state,
+            effective_ip_wait_timeout,
+            effective_bootstrap_timeout,
+            worker_count,
         )
-        time.sleep(ip_backoff.next_interval())
-    else:
-        raise InfraError(f"Slice {handle.slice_id} did not acquire worker IPs within {effective_ip_wait_timeout}s")
+
+        # Phase 0: If this is a queued resource (reserved TPU), wait for ACTIVE
+        # before polling the TPU VM state. The queued resource may sit in QUEUED
+        # or PROVISIONING for an extended period.
+        if handle.is_queued_resource:
+            _wait_for_queued_resource_activation(gcp_service, handle, queued_resource_poll_interval)
+
+        # Phase 1: wait for every worker to acquire an internal IP. The create LRO
+        # is watched only to fail fast on quota/stockout; its completion is not a
+        # readiness gate, so a slow create-status response cannot strand the slice.
+        ip_deadline = Deadline.from_now(Duration.from_seconds(effective_ip_wait_timeout))
+        ip_backoff = ExponentialBackoff(initial=1.0, maximum=30.0, factor=1.5)
+
+        while not ip_deadline.expired():
+            _raise_if_create_failed(gcp_service, handle)
+            cloud_status = handle._describe_cloud()
+            if cloud_status.state in (CloudSliceState.FAILED, CloudSliceState.DELETING):
+                raise InfraError(f"Slice {handle.slice_id} entered {cloud_status.state} during bootstrap")
+            if cloud_status.workers and all(w.internal_address for w in cloud_status.workers):
+                break
+            logger.info(
+                "Slice %s waiting for worker IPs: %d/%d (cloud state=%s)",
+                handle.slice_id,
+                sum(1 for w in cloud_status.workers if w.internal_address),
+                cloud_status.worker_count,
+                cloud_status.state,
+            )
+            time.sleep(ip_backoff.next_interval())
+        else:
+            raise InfraError(f"Slice {handle.slice_id} did not acquire worker IPs within {effective_ip_wait_timeout}s")
+    finally:
+        # The create LRO is settled once the node leaves CREATING (end of phase
+        # 1) or bootstrap fails before that. Free the in-flight-create slot here
+        # so it tracks the LRO lifetime, not the phase-2 health wait below.
+        settle_create()
 
     workers = cloud_status.workers
     worker_urls = [(w.worker_id, w.worker_url) for w in workers]

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -10,6 +10,7 @@ Pure routing/packing logic is tested in test_demand_routing.py.
 Integration tests with real GcpWorkerProvider are in test_autoscaler_integration.py.
 """
 
+import threading
 import time
 
 import pytest
@@ -1009,6 +1010,68 @@ class TestAutoscalerAsyncScaleUp:
         assert elapsed < 0.1
 
         autoscaler._wait_for_inflight()
+
+    def test_concurrent_creates_bounded_by_cap(self):
+        """Never more than max_concurrent_scale_ups create POSTs run at once.
+
+        Regression guard for the create-burst that overwhelms the GCP TPU API:
+        when many groups drain their rate-limit buckets in the same tick, the
+        autoscaler spawns one thread per slice, but only ``cap`` may issue a
+        create at a time.
+        """
+        cap = 2
+        num_decisions = 6
+        config = make_scale_group_config(name="test-group", buffer_slices=0, max_slices=num_decisions)
+
+        lock = threading.Lock()
+        state = {"current": 0, "peak": 0, "count": 0}
+        entered = threading.Semaphore(0)
+        proceed = threading.Event()
+
+        def blocking_create(config, worker_config=None):
+            with lock:
+                state["current"] += 1
+                state["count"] += 1
+                created = state["count"]
+                state["peak"] = max(state["peak"], state["current"])
+            entered.release()
+            proceed.wait()
+            with lock:
+                state["current"] -= 1
+            return make_mock_slice_handle(f"slice-{created}")
+
+        platform = make_mock_platform()
+        platform.create_slice.side_effect = blocking_create
+
+        group = ScalingGroup(config, platform)
+        autoscaler = Autoscaler(
+            scale_groups={"test-group": group},
+            evaluation_interval=Duration.from_seconds(0.1),
+            platform=platform,
+            max_concurrent_scale_ups=cap,
+        )
+
+        decisions = [
+            ScalingDecision(scale_group="test-group", action=ScalingAction.SCALE_UP, reason=f"d{i}")
+            for i in range(num_decisions)
+        ]
+        autoscaler.execute(decisions, timestamp=Timestamp.now())
+
+        # Exactly `cap` threads reach create_slice; the rest block on the
+        # semaphore inside _do_scale_up.
+        for _ in range(cap):
+            assert entered.acquire(timeout=5)
+        # No (cap+1)th create starts while the first batch is still in flight.
+        assert not entered.acquire(timeout=0.2)
+        assert state["peak"] == cap
+
+        # Release the batch; remaining decisions drain, still capped.
+        proceed.set()
+        autoscaler._wait_for_inflight()
+
+        assert state["peak"] == cap
+        assert platform.create_slice.call_count == num_decisions
+        autoscaler.shutdown()
 
     def test_group_marked_requesting_during_scale_up(self):
         """Group shows REQUESTING immediately after execute(), cleared when done."""

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -10,7 +10,6 @@ Pure routing/packing logic is tested in test_demand_routing.py.
 Integration tests with real GcpWorkerProvider are in test_autoscaler_integration.py.
 """
 
-import threading
 import time
 
 import pytest
@@ -1010,68 +1009,6 @@ class TestAutoscalerAsyncScaleUp:
         assert elapsed < 0.1
 
         autoscaler._wait_for_inflight()
-
-    def test_concurrent_creates_bounded_by_cap(self):
-        """Never more than max_concurrent_scale_ups create POSTs run at once.
-
-        Regression guard for the create-burst that overwhelms the GCP TPU API:
-        when many groups drain their rate-limit buckets in the same tick, the
-        autoscaler spawns one thread per slice, but only ``cap`` may issue a
-        create at a time.
-        """
-        cap = 2
-        num_decisions = 6
-        config = make_scale_group_config(name="test-group", buffer_slices=0, max_slices=num_decisions)
-
-        lock = threading.Lock()
-        state = {"current": 0, "peak": 0, "count": 0}
-        entered = threading.Semaphore(0)
-        proceed = threading.Event()
-
-        def blocking_create(config, worker_config=None):
-            with lock:
-                state["current"] += 1
-                state["count"] += 1
-                created = state["count"]
-                state["peak"] = max(state["peak"], state["current"])
-            entered.release()
-            proceed.wait()
-            with lock:
-                state["current"] -= 1
-            return make_mock_slice_handle(f"slice-{created}")
-
-        platform = make_mock_platform()
-        platform.create_slice.side_effect = blocking_create
-
-        group = ScalingGroup(config, platform)
-        autoscaler = Autoscaler(
-            scale_groups={"test-group": group},
-            evaluation_interval=Duration.from_seconds(0.1),
-            platform=platform,
-            max_concurrent_scale_ups=cap,
-        )
-
-        decisions = [
-            ScalingDecision(scale_group="test-group", action=ScalingAction.SCALE_UP, reason=f"d{i}")
-            for i in range(num_decisions)
-        ]
-        autoscaler.execute(decisions, timestamp=Timestamp.now())
-
-        # Exactly `cap` threads reach create_slice; the rest block on the
-        # semaphore inside _do_scale_up.
-        for _ in range(cap):
-            assert entered.acquire(timeout=5)
-        # No (cap+1)th create starts while the first batch is still in flight.
-        assert not entered.acquire(timeout=0.2)
-        assert state["peak"] == cap
-
-        # Release the batch; remaining decisions drain, still capped.
-        proceed.set()
-        autoscaler._wait_for_inflight()
-
-        assert state["peak"] == cap
-        assert platform.create_slice.call_count == num_decisions
-        autoscaler.shutdown()
 
     def test_group_marked_requesting_during_scale_up(self):
         """Group shows REQUESTING immediately after execute(), cleared when done."""

--- a/lib/iris/tests/cluster/providers/gcp/test_platform.py
+++ b/lib/iris/tests/cluster/providers/gcp/test_platform.py
@@ -10,6 +10,7 @@ tests that cannot be expressed through the protocol are in dedicated sections.
 
 from __future__ import annotations
 
+import threading
 import unittest.mock
 from collections.abc import Iterator
 from dataclasses import dataclass
@@ -1168,6 +1169,139 @@ def test_tpu_bootstrap_aborts_when_slice_enters_deleting():
                 ip_wait_timeout=5.0,
                 bootstrap_timeout=5.0,
             )
+
+
+def test_tpu_bootstrap_releases_create_slot_before_health_phase():
+    """The in-flight-create slot is freed at the end of phase 1 (node left
+    CREATING), not after the slower phase-2 health wait. This is what makes the
+    semaphore bound concurrent create LROs rather than total bootstrap time."""
+    gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
+    handle = _make_tpu_slice_for_bootstrap(gcp_service)
+
+    settled: list[bool] = []
+
+    def probe(_worker_url):
+        # Phase 2 (health) must only run after the create slot was released.
+        assert settled, "create slot must be released before phase-2 health polling"
+        return True
+
+    with unittest.mock.patch("iris.cluster.providers.gcp.workers._probe_worker_health", side_effect=probe):
+        _run_tpu_bootstrap(
+            gcp_service,
+            "test-project",
+            handle,
+            poll_interval=0.01,
+            ip_wait_timeout=5.0,
+            bootstrap_timeout=5.0,
+            on_create_settled=lambda: settled.append(True),
+        )
+
+    assert settled == [True]  # released exactly once
+    assert handle._bootstrap_state == CloudSliceState.READY
+
+
+def test_tpu_bootstrap_releases_create_slot_on_failure():
+    """A create LRO that errors still frees the slot (released in the finally),
+    so a failed create never permanently leaks an in-flight slot."""
+    gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
+    handle = _make_tpu_slice_for_bootstrap(gcp_service)
+    gcp_service.set_operation_status(
+        handle._create_operation,
+        OperationStatus(done=True, error_code=8, error_message="boom"),
+    )
+
+    settled: list[bool] = []
+    with unittest.mock.patch("iris.cluster.providers.gcp.workers._probe_worker_health", return_value=False):
+        with pytest.raises(QuotaExhaustedError):
+            _run_tpu_bootstrap(
+                gcp_service,
+                "test-project",
+                handle,
+                poll_interval=0.01,
+                ip_wait_timeout=5.0,
+                bootstrap_timeout=5.0,
+                on_create_settled=lambda: settled.append(True),
+            )
+
+    assert settled == [True]
+
+
+def test_create_slice_bounds_concurrent_inflight_creates(monkeypatch):
+    """No more than max_inflight_tpu_creates create LROs are in flight at once.
+
+    A slot is held from the create POST until the node leaves CREATING (the
+    bootstrap phase-1 settle), so concurrent provisioning slices — not the POST
+    rate — are what's bounded. Drive a controllable bootstrap and assert the
+    peak number of simultaneous in-flight creates never exceeds the cap.
+    """
+    cap = 2
+    num_slices = 6
+    gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
+    gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project")
+    platform = GcpWorkerProvider(
+        gcp_config,
+        label_prefix="iris",
+        worker_port=10001,
+        gcp_service=gcp_service,
+        max_inflight_tpu_creates=cap,
+    )
+
+    lock = threading.Lock()
+    state = {"current": 0, "peak": 0}
+    entered = threading.Semaphore(0)
+    proceed = threading.Event()
+
+    def fake_bootstrap(*_args, on_create_settled=None, **_kwargs):
+        # Holds the create slot for the duration, the same window the real
+        # phase-0/1 watch spans before releasing via on_create_settled.
+        with lock:
+            state["current"] += 1
+            state["peak"] = max(state["peak"], state["current"])
+        entered.release()
+        proceed.wait()
+        with lock:
+            state["current"] -= 1
+        if on_create_settled:
+            on_create_settled()
+
+    monkeypatch.setattr("iris.cluster.providers.gcp.workers._run_tpu_bootstrap", fake_bootstrap)
+
+    def make_slice(i: int):
+        cfg = config_pb2.SliceConfig(
+            name_prefix=f"iris-{i}",
+            accelerator_type=config_pb2.ACCELERATOR_TYPE_TPU,
+            accelerator_variant="v5litepod-8",
+        )
+        cfg.gcp.zone = "us-central2-b"
+        cfg.gcp.runtime_version = "tpu-ubuntu2204-base"
+        wc = config_pb2.WorkerConfig(
+            docker_image="test-image:latest",
+            port=10001,
+            controller_address="controller:10000",
+            cache_dir="/var/cache/iris",
+        )
+        platform.create_slice(cfg, worker_config=wc)
+
+    threads = [threading.Thread(target=make_slice, args=(i,), name=f"create-{i}") for i in range(num_slices)]
+    for t in threads:
+        t.start()
+
+    # Exactly `cap` creates become in-flight; the rest block on the slot inside
+    # create_slice until one settles.
+    for _ in range(cap):
+        assert entered.acquire(timeout=5)
+    assert not entered.acquire(timeout=0.2)
+    with lock:
+        assert state["peak"] == cap
+
+    # Release the batch; the remaining creates drain, still capped.
+    proceed.set()
+    for t in threads:
+        t.join(timeout=5)
+        assert not t.is_alive()
+
+    with lock:
+        assert state["peak"] == cap
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
* bound how many slice-create POSTs the autoscaler fires at the GCP TPU API at once
* root cause: the only limiter today is a *per-group* token bucket (`scaling_group.py`, capacity 16, refilled/min) — an idle group dumps a full bucket in one tick, and there is no global cap, so each passing decision spawns a thread in `_execute_scale_up` that immediately issues a create POST
  * many groups draining buckets in one tick (or a controller restart re-requesting all demand) → 100-160 create POSTs in the same real second [^1]
  * controller logs show those bursts tracking the rate of transient `TPU operation failed: an internal error has occurred` failures (4,554 on 06-02, the day creates peaked) and racing multiple creates against the same zone-capacity snapshot
* add a global `BoundedSemaphore(max_concurrent_scale_ups=8)` on `Autoscaler`; each scale-up thread holds a token across the `group.scale_up()` create POST
  * `create_slice` only submits the LRO and returns `CREATING` (bootstrap polls on a separate thread), so the gate bounds in-flight *create requests* without serializing bootstrap or limiting sustained throughput
  * **no new threads vs. today** — the same threads spawn, they just queue on the gate instead of all hitting GCP at once
  * acquire polls `stop_event` (1s timeout loop) so shutdown isn't left parked
* mirrors the existing `_HEALTH_PROBE_MAX_WORKERS` precedent (hardcoded concurrency-cap constant in the same file); limit is a constructor param for tests, no proto change
* `test_concurrent_creates_bounded_by_cap` — deterministic guard; verified it fails without the cap (peak hits 6 unbounded vs 2 capped)
* does **not** address the ~28k genuine preemptible stockouts / quota limits in the logs — those are real capacity, not burst-induced

[^1]: peaks observed: 160 creates/s (2026-06-02 00:04:45), 152, 150; 5,026 distinct seconds with ≥20 creates/s over the window

🤖 Generated with [Claude Code](https://claude.com/claude-code)