### PR TITLE
[levanter] Add Qwen3 MoE perplexity support

### DIFF
--- a/lib/levanter/src/levanter/models/qwen3_moe.py
+++ b/lib/levanter/src/levanter/models/qwen3_moe.py
@@ -38,6 +38,13 @@ from transformers import Qwen3MoeConfig as HfQwen3MoeConfig  # noqa: E402
 _SHARD_MAP_CHECK_KWARG = "check_vma" if "check_vma" in inspect.signature(shard_map).parameters else "check_rep"
 
 
+def _expert_state_dict_key(prefix: str | None, expert_index: int, projection_name: str) -> str:
+    key = f"{expert_index}.{projection_name}.weight"
+    if prefix is None:
+        return key
+    return f"{prefix}.{key}"
+
+
 @LmConfig.register_subclass("qwen3_moe")
 @dataclass(frozen=True)
 class Qwen3MoeConfig(LlamaConfig):
@@ -257,7 +264,7 @@ class Qwen3MoeExperts(ModuleWithStateDictSerialization):
         out = {}
         for i in range(self.gate_proj.Experts.size):
             for name, weight in projections.items():
-                out[f"{prefix}.{i}.{name}.weight"] = jnp.swapaxes(weight["experts", i].array, -1, -2)
+                out[_expert_state_dict_key(prefix, i, name)] = jnp.swapaxes(weight["experts", i].array, -1, -2)
         return out
 
     def from_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None) -> "Qwen3MoeExperts":
@@ -266,7 +273,7 @@ class Qwen3MoeExperts(ModuleWithStateDictSerialization):
         for name in ("gate_proj", "up_proj", "down_proj"):
             weights = []
             for i in range(self.gate_proj.Experts.size):
-                key = f"{prefix}.{i}.{name}.weight"
+                key = _expert_state_dict_key(prefix, i, name)
                 weights.append(jnp.swapaxes(state_dict[key], -1, -2))
             values[name] = jnp.stack(weights, axis=expert_axis_index)
 

--- a/lib/levanter/src/levanter/models/qwen3_moe.py
+++ b/lib/levanter/src/levanter/models/qwen3_moe.py
@@ -1,0 +1,533 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import dataclasses
+import inspect
+from dataclasses import dataclass
+from functools import partial
+from typing import Callable, Dict, Optional, Type, Union
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.random as jrandom
+from jax import shard_map
+
+import haliax as hax
+import haliax.nn as hnn
+from haliax import Axis, NamedArray
+from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
+from haliax.nn.scan import BlockFoldable, BlockSeq, Stacked
+from haliax.state_dict import ModuleWithStateDictSerialization, StateDict
+
+from levanter.compat.hf_checkpoints import HFCheckpointConverter
+from levanter.layers.attention import Attention, AttentionBackend, AttentionMask
+from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
+from levanter.models.llama import LlamaConfig, LlamaEmbedding
+from levanter.models.lm_model import LmConfig, LmHeadModel
+from levanter.utils.activation import ActivationFunctionEnum
+from levanter.utils.flop_utils import lm_flops_per_token
+from levanter.utils.logging import silence_transformer_nag
+
+
+silence_transformer_nag()
+from transformers import PretrainedConfig as HfConfig  # noqa: E402
+from transformers import Qwen3MoeConfig as HfQwen3MoeConfig  # noqa: E402
+
+
+_SHARD_MAP_CHECK_KWARG = "check_vma" if "check_vma" in inspect.signature(shard_map).parameters else "check_rep"
+
+
+@LmConfig.register_subclass("qwen3_moe")
+@dataclass(frozen=True)
+class Qwen3MoeConfig(LlamaConfig):
+    """Qwen3 MoE config for HF checkpoint loading and loss evaluation."""
+
+    max_seq_len: int = 40960
+    hidden_dim: int = 2048
+    intermediate_dim: int = 6144
+    moe_intermediate_dim: int = 768
+    num_layers: int = 48
+    num_heads: int = 32
+    head_dim: int | None = 128
+    num_kv_heads: int = 4
+    activation_function: ActivationFunctionEnum = ActivationFunctionEnum.silu
+    initializer_range: float = 0.02
+    layer_norm_epsilon: float = 1e-6
+    tie_word_embeddings: bool = False
+    use_qk_norm: bool = True
+
+    num_experts: int = 128
+    num_experts_per_tok: int = 8
+    norm_topk_prob: bool = True
+    router_aux_loss_coef: float | None = 0.001
+    decoder_sparse_step: int = 1
+    mlp_only_layers: tuple[int, ...] = ()
+
+    sliding_window: int | None = None
+    max_window_layers: int = 48
+    use_sliding_window: bool = False
+
+    upcast_attn: bool = False
+    attn_backend: Optional[AttentionBackend] = None
+    flash_attention_block_size: Optional[int] = None
+
+    gradient_checkpointing: bool = True
+    scan_layers: bool = True
+
+    use_bias: bool = False
+    use_layer_norm_weight: bool = True
+    rope: RotaryEmbeddingsConfig = dataclasses.field(
+        default_factory=lambda: DefaultRotaryEmbeddingsConfig(theta=1_000_000.0)
+    )
+
+    reference_checkpoint: str = "Qwen/Qwen3-30B-A3B"
+    tokenizer: Optional[str] = None
+
+    @property
+    def Experts(self) -> Axis:
+        return Axis(name="experts", size=self.num_experts)
+
+    @property
+    def TopExperts(self) -> Axis:
+        return Axis(name="top_experts", size=self.num_experts_per_tok)
+
+    @property
+    def MoeMlp(self) -> Axis:
+        return Axis(name="mlp", size=self.moe_intermediate_dim)
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.num_experts_per_tok > self.num_experts:
+            raise ValueError(
+                f"num_experts_per_tok={self.num_experts_per_tok} greater than num_experts={self.num_experts}."
+            )
+        if self.mlp_only_layers:
+            raise NotImplementedError("Qwen3 MoE dense-only layers are not supported in Levanter yet.")
+        if self.decoder_sparse_step != 1:
+            raise NotImplementedError("Qwen3 MoE decoder_sparse_step values other than 1 are not supported yet.")
+
+    def hf_checkpoint_converter(
+        self, ref_checkpoint: Optional[str] = None
+    ) -> HFCheckpointConverter["Qwen3MoeConfig"]:  # type: ignore
+        return HFCheckpointConverter(
+            self.__class__,
+            reference_checkpoint=self.reference_checkpoint if ref_checkpoint is None else ref_checkpoint,
+            trust_remote_code=True,
+            tokenizer=ref_checkpoint if self.tokenizer is None else self.tokenizer,
+            HfConfigClass=HfQwen3MoeConfig,
+        )
+
+    @classmethod
+    def from_hf_config(cls, hf_config: HfConfig):
+        rope_config = RotaryEmbeddingsConfig.from_hf_config(
+            hf_config.rope_theta,
+            getattr(hf_config, "rope_scaling", None),
+        )
+        return Qwen3MoeConfig(
+            max_seq_len=hf_config.max_position_embeddings,
+            hidden_dim=hf_config.hidden_size,
+            intermediate_dim=hf_config.intermediate_size,
+            moe_intermediate_dim=hf_config.moe_intermediate_size,
+            num_layers=hf_config.num_hidden_layers,
+            num_heads=hf_config.num_attention_heads,
+            head_dim=getattr(hf_config, "head_dim", None),
+            num_kv_heads=hf_config.num_key_value_heads,
+            activation_function=ActivationFunctionEnum(hf_config.hidden_act),
+            initializer_range=hf_config.initializer_range,
+            layer_norm_epsilon=hf_config.rms_norm_eps,
+            tie_word_embeddings=hf_config.tie_word_embeddings,
+            use_qk_norm=True,
+            num_experts=hf_config.num_experts,
+            num_experts_per_tok=hf_config.num_experts_per_tok,
+            norm_topk_prob=hf_config.norm_topk_prob,
+            router_aux_loss_coef=hf_config.router_aux_loss_coef,
+            decoder_sparse_step=hf_config.decoder_sparse_step,
+            mlp_only_layers=tuple(hf_config.mlp_only_layers),
+            sliding_window=getattr(hf_config, "sliding_window", None),
+            max_window_layers=getattr(hf_config, "max_window_layers", hf_config.num_hidden_layers),
+            use_sliding_window=getattr(hf_config, "use_sliding_window", False),
+            use_bias=getattr(hf_config, "attention_bias", False),
+            rope=rope_config,
+        )
+
+    def to_hf_config(self, vocab_size: int, config_overrides: Optional[Dict] = None) -> HfQwen3MoeConfig:
+        if config_overrides is None:
+            config_overrides = {}
+
+        rope_theta, rope_scaling = self.rope.to_hf_config()
+
+        return HfQwen3MoeConfig(
+            vocab_size=vocab_size,
+            max_position_embeddings=self.max_seq_len,
+            hidden_size=self.hidden_dim,
+            intermediate_size=self.intermediate_dim,
+            moe_intermediate_size=self.moe_intermediate_dim,
+            num_hidden_layers=self.num_layers,
+            num_attention_heads=self.num_heads,
+            head_dim=self.head_dim,
+            num_key_value_heads=self.num_kv_heads,
+            hidden_act=self.activation_function.name,
+            initializer_range=self.initializer_range,
+            rms_norm_eps=self.layer_norm_epsilon,
+            tie_word_embeddings=self.tie_word_embeddings,
+            attention_bias=self.use_bias,
+            num_experts=self.num_experts,
+            num_experts_per_tok=self.num_experts_per_tok,
+            norm_topk_prob=self.norm_topk_prob,
+            router_aux_loss_coef=self.router_aux_loss_coef,
+            decoder_sparse_step=self.decoder_sparse_step,
+            mlp_only_layers=list(self.mlp_only_layers),
+            sliding_window=self.sliding_window,
+            max_window_layers=self.max_window_layers,
+            use_sliding_window=self.use_sliding_window,
+            rope_theta=rope_theta,
+            rope_scaling=rope_scaling,
+            **config_overrides,
+        )
+
+    @property
+    def model_type(self) -> Type["Qwen3MoeLMHeadModel"]:
+        return Qwen3MoeLMHeadModel
+
+    def flops_per_token(self, vocab_size: int, context_length: int):
+        return lm_flops_per_token(
+            hidden_dim=self.hidden_dim,
+            intermediate_dim=self.moe_intermediate_dim,
+            num_layers=self.num_layers,
+            num_kv_heads=self.num_kv_heads,
+            num_heads=self.num_heads,
+            seq_len=context_length,
+            vocab_size=vocab_size,
+            glu=True,
+            num_experts=self.num_experts,
+            num_experts_per_tok=self.num_experts_per_tok,
+        )
+
+    def total_trainable_params(self, vocab_size):
+        token_embedding = vocab_size * self.hidden_dim
+        head_size = self.actual_head_size
+        q_proj = self.hidden_dim * head_size * self.num_heads
+        kv_proj = 2 * self.hidden_dim * head_size * self.num_kv_heads
+        o_proj = head_size * self.num_heads * self.hidden_dim
+        qk_norm = 2 * head_size
+        attn = q_proj + kv_proj + o_proj + qk_norm
+        router = self.hidden_dim * self.num_experts
+        mlps = 3 * self.num_experts * self.hidden_dim * self.moe_intermediate_dim
+        transformer_layer = attn + router + mlps + 2 * self.hidden_dim
+        transformer = self.num_layers * transformer_layer + self.hidden_dim
+        lm_head = 0 if self.tie_word_embeddings else token_embedding
+        return transformer + token_embedding + lm_head
+
+
+class Qwen3MoeExperts(ModuleWithStateDictSerialization):
+    gate_proj: hnn.MoELinear
+    up_proj: hnn.MoELinear
+    down_proj: hnn.MoELinear
+    act: Callable = eqx.field(static=True)
+
+    @staticmethod
+    def init(
+        Experts: Axis,
+        Embed: Axis,
+        Mlp: Axis,
+        activation_fn: Union[ActivationFunctionEnum, Callable],
+        *,
+        key,
+        use_bias: bool = False,
+    ) -> "Qwen3MoeExperts":
+        k_gate, k_up, k_down = jrandom.split(key, 3)
+        gate_proj = hnn.MoELinear.init(Experts=Experts, Out=Mlp, In=Embed, key=k_gate, use_bias=use_bias)
+        up_proj = hnn.MoELinear.init(Experts=Experts, Out=Mlp, In=Embed, key=k_up, use_bias=use_bias)
+        down_proj = hnn.MoELinear.init(Experts=Experts, Out=Embed, In=Mlp, key=k_down, use_bias=use_bias)
+        if isinstance(activation_fn, ActivationFunctionEnum):
+            activation_fn = activation_fn.to_fn()
+        return Qwen3MoeExperts(gate_proj, up_proj, down_proj, activation_fn)
+
+    @named_call
+    def __call__(self, x: NamedArray, group_sizes: NamedArray, *, key=None) -> NamedArray:
+        k_gate, k_up, k_down = maybe_rng_split(key, 3)
+        hidden_states = self.act(self.gate_proj(x, group_sizes, key=k_gate))
+        hidden_states = hidden_states * self.up_proj(x, group_sizes, key=k_up)
+        return self.down_proj(hidden_states, group_sizes, key=k_down)
+
+    def to_state_dict(self, prefix: Optional[str] = None) -> StateDict:
+        projections = {
+            "gate_proj": self.gate_proj.weight,
+            "up_proj": self.up_proj.weight,
+            "down_proj": self.down_proj.weight,
+        }
+        out = {}
+        for i in range(self.gate_proj.Experts.size):
+            for name, weight in projections.items():
+                out[f"{prefix}.{i}.{name}.weight"] = jnp.swapaxes(weight["experts", i].array, -1, -2)
+        return out
+
+    def from_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None) -> "Qwen3MoeExperts":
+        expert_axis_index = self.gate_proj.weight.axes.index(self.gate_proj.Experts)
+        values = {}
+        for name in ("gate_proj", "up_proj", "down_proj"):
+            weights = []
+            for i in range(self.gate_proj.Experts.size):
+                key = f"{prefix}.{i}.{name}.weight"
+                weights.append(jnp.swapaxes(state_dict[key], -1, -2))
+            values[name] = jnp.stack(weights, axis=expert_axis_index)
+
+        return eqx.tree_at(
+            lambda m: [m.gate_proj.weight.array, m.up_proj.weight.array, m.down_proj.weight.array],
+            self,
+            [values["gate_proj"], values["up_proj"], values["down_proj"]],
+        )
+
+
+class Qwen3MoeSparseMoeBlock(eqx.Module):
+    config: Qwen3MoeConfig = eqx.field(static=True)
+    gate: hnn.Linear
+    experts: Qwen3MoeExperts
+
+    @staticmethod
+    def init(config: Qwen3MoeConfig, *, key) -> "Qwen3MoeSparseMoeBlock":
+        k_gate, k_experts = jrandom.split(key, 2)
+        gate = hnn.Linear.init(config.Embed, config.Experts, key=k_gate, use_bias=False)
+        experts = Qwen3MoeExperts.init(
+            Experts=config.Experts,
+            Embed=config.Embed,
+            Mlp=config.MoeMlp,
+            activation_fn=config.activation_function,
+            key=k_experts,
+            use_bias=False,
+        )
+        return Qwen3MoeSparseMoeBlock(config, gate, experts)
+
+    def _route(self, router_logits: NamedArray, Token: Axis, TopExperts: Axis):
+        Experts = self.config.Experts
+
+        @partial(
+            shard_map,
+            mesh=hax.partitioning._get_mesh(),
+            in_specs=hax.partitioning.pspec_for_axis(router_logits.axes),
+            out_specs=(
+                hax.partitioning.pspec_for_axis((Token, TopExperts)),
+                hax.partitioning.pspec_for_axis((Token, TopExperts)),
+                hax.partitioning.pspec_for_axis((Experts,)),
+            ),
+            **{_SHARD_MAP_CHECK_KWARG: False},
+        )
+        def sharded_route(router_logits_):
+            router_probs_ = jax.nn.softmax(router_logits_, axis=-1)
+            selected_weights_, selected_experts_ = jax.lax.top_k(router_probs_, TopExperts.size)
+            if self.config.norm_topk_prob:
+                selected_weights_ = selected_weights_ / selected_weights_.sum(-1, keepdims=True)
+            expert_loads_ = jnp.bincount(selected_experts_.reshape(-1), length=self.config.num_experts)
+            return selected_weights_, selected_experts_, expert_loads_
+
+        with jax.named_scope("route"):
+            selected_weights, selected_experts, expert_loads = sharded_route(router_logits.array)
+            return (
+                hax.named(selected_weights, (Token, TopExperts)),
+                hax.named(selected_experts, (Token, TopExperts)),
+                hax.named(expert_loads, (Experts,)),
+            )
+
+    def _permute(self, x_flat: NamedArray, topk_idx_flat: NamedArray, TokenRepeat: Axis):
+        Experts = self.config.Experts
+
+        @partial(
+            shard_map,
+            mesh=hax.partitioning._get_mesh(),
+            in_specs=(
+                hax.partitioning.pspec_for_axis(x_flat.axes),
+                hax.partitioning.pspec_for_axis(topk_idx_flat.axes),
+            ),
+            out_specs=(
+                hax.partitioning.pspec_for_axis((TokenRepeat, self.config.Embed)),
+                hax.partitioning.pspec_for_axis((Experts,)),
+                hax.partitioning.pspec_for_axis((TokenRepeat,)),
+            ),
+            **{_SHARD_MAP_CHECK_KWARG: False},
+        )
+        def permute_sharded(x_flat_, topk_idx_flat_):
+            sort_idx_ = jnp.argsort(topk_idx_flat_, axis=-1)
+            x_repeat_sort_ = jnp.take(x_flat_, sort_idx_ // self.config.num_experts_per_tok, axis=0)
+            group_sizes_ = jnp.bincount(topk_idx_flat_, length=self.config.num_experts)
+            return x_repeat_sort_, group_sizes_, sort_idx_
+
+        with jax.named_scope("permute"):
+            x_repeat_sort, group_sizes, sort_idx = permute_sharded(x_flat.array, topk_idx_flat.array)
+            return (
+                hax.named(x_repeat_sort, (TokenRepeat, self.config.Embed)),
+                hax.named(group_sizes, (Experts,)),
+                hax.named(sort_idx, (TokenRepeat,)),
+            )
+
+    def _unpermute(
+        self,
+        out_repeat_sort: NamedArray,
+        sort_idx: NamedArray,
+        Token: Axis,
+        TopExperts: Axis,
+    ):
+        @partial(
+            shard_map,
+            mesh=hax.partitioning._get_mesh(),
+            in_specs=(
+                hax.partitioning.pspec_for_axis(out_repeat_sort.axes),
+                hax.partitioning.pspec_for_axis(sort_idx.axes),
+            ),
+            out_specs=hax.partitioning.pspec_for_axis((Token, TopExperts, self.config.Embed)),
+            **{_SHARD_MAP_CHECK_KWARG: False},
+        )
+        def unpermute_sharded(out_repeat_sort_, sort_idx_):
+            inv_sort_idx_ = jnp.argsort(sort_idx_)
+            out_repeat_ = jnp.take(out_repeat_sort_, inv_sort_idx_, axis=0)
+            return jnp.reshape(out_repeat_, (-1, self.config.num_experts_per_tok, self.config.hidden_dim))
+
+        with jax.named_scope("unpermute"):
+            return hax.named(
+                unpermute_sharded(out_repeat_sort.array, sort_idx.array), (Token, TopExperts, self.config.Embed)
+            )
+
+    @named_call
+    def __call__(self, x: NamedArray, *, key=None) -> NamedArray:
+        if x.has_axis("batch"):
+            squash_axes = [x.resolve_axis("batch"), x.resolve_axis(self.config.max_Pos.name)]
+        else:
+            squash_axes = [x.resolve_axis(self.config.max_Pos.name)]
+
+        TopExperts = self.config.TopExperts
+        k_gate, k_experts = maybe_rng_split(key, 2)
+
+        x_flat = hax.flatten_axes(x, old_axes=squash_axes, new_axis="token")
+        Token = x_flat.resolve_axis("token")
+        router_logits = self.gate(x_flat, key=k_gate)
+        topk_weights, topk_idx, _ = self._route(router_logits.astype(jnp.float32), Token, TopExperts)
+        topk_weights = topk_weights.astype(x.dtype)
+
+        topk_idx_flat = hax.flatten_axes(topk_idx, old_axes=[Token, TopExperts], new_axis="token_repeat")
+        TokenRepeat = topk_idx_flat.resolve_axis("token_repeat")
+        x_repeat_sort, group_sizes, sort_idx = self._permute(x_flat, topk_idx_flat, TokenRepeat)
+        out_repeat_sort = self.experts(x_repeat_sort, group_sizes, key=k_experts)
+        out_repeat_unflat = self._unpermute(out_repeat_sort, sort_idx, Token, TopExperts)
+        out = out_repeat_unflat.dot(topk_weights, axis=TopExperts)
+        return hax.unflatten_axis(out, axis=Token, new_axes=squash_axes)
+
+
+class Qwen3MoeDecoderLayer(eqx.Module):
+    config: Qwen3MoeConfig = eqx.field(static=True)
+    self_attn: Attention
+    mlp: Qwen3MoeSparseMoeBlock
+    input_layernorm: hnn.RmsNorm
+    post_attention_layernorm: hnn.RmsNorm
+
+    @staticmethod
+    def init(config: Qwen3MoeConfig, *, key) -> "Qwen3MoeDecoderLayer":
+        k_attn, k_mlp = jrandom.split(key, 2)
+        attn = Attention.init(config.attention_config(), key=k_attn)
+        mlp = Qwen3MoeSparseMoeBlock.init(config, key=k_mlp)
+        ln_1 = config.mk_LayerNorm(config.Embed)
+        ln_2 = config.mk_LayerNorm(config.Embed)
+        return Qwen3MoeDecoderLayer(config, attn, mlp, ln_1, ln_2)
+
+    @named_call
+    def __call__(
+        self, x: NamedArray, mask: Optional[NamedArray | AttentionMask], *, key=None, pos_ids: NamedArray | None = None
+    ) -> NamedArray:
+        k_attn, k_mlp = maybe_rng_split(key, 2)
+        residual = x
+        x = self.input_layernorm(x)
+        x = residual + self.self_attn(x=x, mask=mask, key=k_attn, pos_ids=pos_ids)
+
+        residual = x
+        x = self.post_attention_layernorm(x)
+        return residual + self.mlp(x, key=k_mlp)
+
+
+class Qwen3MoeTransformer(eqx.Module):
+    config: Qwen3MoeConfig = eqx.field(static=True)
+    layers: BlockFoldable[Qwen3MoeDecoderLayer]
+    norm: hnn.RmsNorm
+
+    @staticmethod
+    def init(config: Qwen3MoeConfig, *, key) -> "Qwen3MoeTransformer":
+        S = Stacked if config.scan_layers else BlockSeq
+        layers = S.init(config.Layers, Qwen3MoeDecoderLayer, gradient_checkpointing=config.gradient_checkpointing)(
+            config,
+            key=shaped_rng_split(key, config.num_layers),
+        )
+        return Qwen3MoeTransformer(config, layers, config.mk_LayerNorm(config.Embed))
+
+    @named_call
+    def __call__(
+        self, x: NamedArray, attn_mask: Optional[NamedArray | AttentionMask], *, key, pos_ids: NamedArray | None = None
+    ) -> NamedArray:
+        keys = maybe_rng_split(key, self.config.num_layers) if key is not None else None
+        x = self.layers.fold(x, mask=attn_mask, key=keys, pos_ids=pos_ids)
+        return self.norm(x)
+
+
+class Qwen3MoeLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[Qwen3MoeConfig]):
+    transformer: Qwen3MoeTransformer
+    embeddings: LlamaEmbedding
+    lm_head: Optional[hnn.Linear]
+
+    @property
+    def config(self):
+        return self.transformer.config
+
+    @property
+    def Vocab(self) -> Axis:
+        return self.embeddings.Vocab
+
+    @classmethod
+    def init(cls, Vocab: Axis, config: Qwen3MoeConfig, *, key) -> "Qwen3MoeLMHeadModel":
+        k_t, k_emb = jrandom.split(key, 2)
+        transformer = Qwen3MoeTransformer.init(config, key=k_t)
+        embeddings = LlamaEmbedding.init(Vocab, config, key=k_emb)
+        lm_head = None
+        if not config.tie_word_embeddings:
+            lm_head = hnn.Linear.init(In=config.Embed, Out=Vocab, key=k_emb, use_bias=False, out_first=True)
+        return Qwen3MoeLMHeadModel(transformer, embeddings, lm_head)
+
+    def __call__(
+        self,
+        input_ids: NamedArray,
+        attn_mask: Optional[Union[NamedArray, AttentionMask]] = None,
+        pos_ids: NamedArray | None = None,
+        *,
+        key=None,
+    ) -> NamedArray:
+        k_t, k_head = maybe_rng_split(key, 2)
+        x = self.activations(input_ids, attn_mask=attn_mask, key=k_t, pos_ids=pos_ids)
+        if self.lm_head is not None:
+            return self.lm_head(x, key=k_head)
+        return self.embeddings.unembed(x)
+
+    def activations(
+        self,
+        input_ids: NamedArray,
+        attn_mask: Optional[AttentionMask | NamedArray] = None,
+        *,
+        key=None,
+        pos_ids: NamedArray | None = None,
+    ) -> NamedArray:
+        x = self.embeddings.embed(input_ids)
+        return self.transformer(x, attn_mask=attn_mask, key=key, pos_ids=pos_ids)
+
+    def get_lm_head(self) -> hax.NamedArray:
+        if self.lm_head is None:
+            return self.embeddings.token_embeddings.weight
+        return self.lm_head.weight
+
+    def resize_vocab(self, new_size: int, key=None) -> "LmHeadModel[Qwen3MoeConfig]":
+        new_Vocab = self.Vocab.resize(new_size)
+        k1, k2 = maybe_rng_split(key, 2)
+        new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
+        if self.lm_head is None:
+            return eqx.tree_at(lambda m: m.embeddings, self, new_embeddings)
+
+        new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
+        new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+        return eqx.tree_at(lambda m: (m.embeddings, m.lm_head), self, (new_embeddings, new_lm_head))
+
+    def _state_dict_key_map(self) -> Dict[str, Optional[str]]:
+        return {"transformer": "model", "embeddings": None}

--- a/lib/levanter/src/levanter/models/qwen3_moe.py
+++ b/lib/levanter/src/levanter/models/qwen3_moe.py
@@ -5,7 +5,7 @@ import dataclasses
 import inspect
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable, Dict, Optional, Type, Union
+from typing import Callable, Dict, Optional, Type
 
 import equinox as eqx
 import jax
@@ -73,7 +73,6 @@ class Qwen3MoeConfig(LlamaConfig):
     flash_attention_block_size: Optional[int] = None
 
     gradient_checkpointing: bool = True
-    scan_layers: bool = True
 
     use_bias: bool = False
     use_layer_norm_weight: bool = True
@@ -231,7 +230,7 @@ class Qwen3MoeExperts(ModuleWithStateDictSerialization):
         Experts: Axis,
         Embed: Axis,
         Mlp: Axis,
-        activation_fn: Union[ActivationFunctionEnum, Callable],
+        activation_fn: Callable,
         *,
         key,
         use_bias: bool = False,
@@ -240,8 +239,6 @@ class Qwen3MoeExperts(ModuleWithStateDictSerialization):
         gate_proj = hnn.MoELinear.init(Experts=Experts, Out=Mlp, In=Embed, key=k_gate, use_bias=use_bias)
         up_proj = hnn.MoELinear.init(Experts=Experts, Out=Mlp, In=Embed, key=k_up, use_bias=use_bias)
         down_proj = hnn.MoELinear.init(Experts=Experts, Out=Embed, In=Mlp, key=k_down, use_bias=use_bias)
-        if isinstance(activation_fn, ActivationFunctionEnum):
-            activation_fn = activation_fn.to_fn()
         return Qwen3MoeExperts(gate_proj, up_proj, down_proj, activation_fn)
 
     @named_call
@@ -293,7 +290,7 @@ class Qwen3MoeSparseMoeBlock(eqx.Module):
             Experts=config.Experts,
             Embed=config.Embed,
             Mlp=config.MoeMlp,
-            activation_fn=config.activation_function,
+            activation_fn=config.activation_function.to_fn(),
             key=k_experts,
             use_bias=False,
         )
@@ -449,7 +446,9 @@ class Qwen3MoeTransformer(eqx.Module):
 
     @staticmethod
     def init(config: Qwen3MoeConfig, *, key) -> "Qwen3MoeTransformer":
-        S = Stacked if config.scan_layers else BlockSeq
+        S = Stacked
+        if not config.scan_layers:
+            S = BlockSeq
         layers = S.init(config.Layers, Qwen3MoeDecoderLayer, gradient_checkpointing=config.gradient_checkpointing)(
             config,
             key=shaped_rng_split(key, config.num_layers),
@@ -458,7 +457,7 @@ class Qwen3MoeTransformer(eqx.Module):
 
     @named_call
     def __call__(
-        self, x: NamedArray, attn_mask: Optional[NamedArray | AttentionMask], *, key, pos_ids: NamedArray | None = None
+        self, x: NamedArray, attn_mask: AttentionMask | None, *, key, pos_ids: NamedArray | None = None
     ) -> NamedArray:
         keys = maybe_rng_split(key, self.config.num_layers) if key is not None else None
         x = self.layers.fold(x, mask=attn_mask, key=keys, pos_ids=pos_ids)
@@ -491,7 +490,7 @@ class Qwen3MoeLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[Qwen3Moe
     def __call__(
         self,
         input_ids: NamedArray,
-        attn_mask: Optional[Union[NamedArray, AttentionMask]] = None,
+        attn_mask: AttentionMask | None = None,
         pos_ids: NamedArray | None = None,
         *,
         key=None,
@@ -505,7 +504,7 @@ class Qwen3MoeLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[Qwen3Moe
     def activations(
         self,
         input_ids: NamedArray,
-        attn_mask: Optional[AttentionMask | NamedArray] = None,
+        attn_mask: AttentionMask | None = None,
         *,
         key=None,
         pos_ids: NamedArray | None = None,

--- a/lib/levanter/tests/test_qwen3_moe.py
+++ b/lib/levanter/tests/test_qwen3_moe.py
@@ -79,6 +79,7 @@ def test_qwen3_moe_state_dict_keys_match_hf_qwen_layout():
     assert state_dict["lm_head.weight"].shape == (128, 32)
 
 
+@skip_if_no_torch
 def test_qwen3_moe_loads_torch_compatible_state_dict():
     config = Qwen3MoeConfig.from_hf_config(_tiny_hf_config())
     with local_cpu_mesh():

--- a/lib/levanter/tests/test_qwen3_moe.py
+++ b/lib/levanter/tests/test_qwen3_moe.py
@@ -15,6 +15,7 @@ from haliax.state_dict import from_torch_compatible_state_dict, to_torch_compati
 from levanter.layers.attention import AttentionMask
 from levanter.models.lm_model import LmExample
 from levanter.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeLMHeadModel
+from levanter.utils.jax_utils import local_cpu_mesh
 from test_utils import skip_if_no_torch, use_test_mesh
 
 
@@ -80,7 +81,7 @@ def test_qwen3_moe_state_dict_keys_match_hf_qwen_layout():
 
 def test_qwen3_moe_loads_torch_compatible_state_dict():
     config = Qwen3MoeConfig.from_hf_config(_tiny_hf_config())
-    with use_test_mesh():
+    with local_cpu_mesh():
         model = Qwen3MoeLMHeadModel.init(hax.Axis("vocab", 128), config, key=random.PRNGKey(0))
         state_dict = to_torch_compatible_state_dict(model)
 

--- a/lib/levanter/tests/test_qwen3_moe.py
+++ b/lib/levanter/tests/test_qwen3_moe.py
@@ -1,0 +1,169 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import tempfile
+from jax import random
+from transformers import Qwen3MoeConfig as HfQwen3MoeConfig
+
+import haliax as hax
+from haliax.state_dict import from_torch_compatible_state_dict, to_torch_compatible_state_dict
+
+from levanter.layers.attention import AttentionMask
+from levanter.models.lm_model import LmExample
+from levanter.models.qwen3_moe import Qwen3MoeConfig, Qwen3MoeLMHeadModel
+from test_utils import skip_if_no_torch, use_test_mesh
+
+
+def _tiny_hf_config() -> HfQwen3MoeConfig:
+    return HfQwen3MoeConfig(
+        vocab_size=128,
+        max_position_embeddings=16,
+        hidden_size=32,
+        intermediate_size=64,
+        moe_intermediate_size=8,
+        num_hidden_layers=2,
+        num_attention_heads=4,
+        head_dim=8,
+        num_key_value_heads=2,
+        num_experts=4,
+        num_experts_per_tok=2,
+        norm_topk_prob=True,
+        router_aux_loss_coef=0.001,
+        decoder_sparse_step=1,
+        mlp_only_layers=[],
+        rope_theta=1_000_000.0,
+        attention_bias=False,
+        tie_word_embeddings=False,
+    )
+
+
+def test_qwen3_moe_config_roundtrip():
+    hf_config = _tiny_hf_config()
+    config = Qwen3MoeConfig.from_hf_config(hf_config)
+
+    assert config.max_seq_len == hf_config.max_position_embeddings
+    assert config.hidden_dim == hf_config.hidden_size
+    assert config.moe_intermediate_dim == hf_config.moe_intermediate_size
+    assert config.num_experts == hf_config.num_experts
+    assert config.num_experts_per_tok == hf_config.num_experts_per_tok
+    assert config.head_dim == hf_config.head_dim
+    assert config.use_qk_norm
+
+    roundtripped = config.to_hf_config(hf_config.vocab_size)
+    assert roundtripped.model_type == "qwen3_moe"
+    assert roundtripped.hidden_size == hf_config.hidden_size
+    assert roundtripped.moe_intermediate_size == hf_config.moe_intermediate_size
+    assert roundtripped.num_experts == hf_config.num_experts
+    assert roundtripped.num_experts_per_tok == hf_config.num_experts_per_tok
+    assert roundtripped.head_dim == hf_config.head_dim
+
+
+def test_qwen3_moe_hf_converter_uses_qwen3_moe_config_class():
+    converter = Qwen3MoeConfig().hf_checkpoint_converter()
+    assert converter.HfConfigClass.__name__ == "Qwen3MoeConfig"
+
+
+def test_qwen3_moe_state_dict_keys_match_hf_qwen_layout():
+    config = Qwen3MoeConfig.from_hf_config(_tiny_hf_config())
+    model = Qwen3MoeLMHeadModel.init(hax.Axis("vocab", 128), config, key=random.PRNGKey(0))
+
+    state_dict = to_torch_compatible_state_dict(model)
+
+    assert state_dict["model.layers.0.self_attn.q_norm.weight"].shape == (8,)
+    assert state_dict["model.layers.0.self_attn.k_norm.weight"].shape == (8,)
+    assert state_dict["model.layers.0.self_attn.q_proj.weight"].shape == (32, 32)
+    assert state_dict["model.layers.0.mlp.gate.weight"].shape == (4, 32)
+    assert state_dict["model.layers.0.mlp.experts.0.gate_proj.weight"].shape == (8, 32)
+    assert state_dict["model.layers.0.mlp.experts.0.up_proj.weight"].shape == (8, 32)
+    assert state_dict["model.layers.0.mlp.experts.0.down_proj.weight"].shape == (32, 8)
+    assert state_dict["lm_head.weight"].shape == (128, 32)
+
+
+def test_qwen3_moe_loads_torch_compatible_state_dict():
+    config = Qwen3MoeConfig.from_hf_config(_tiny_hf_config())
+    model = Qwen3MoeLMHeadModel.init(hax.Axis("vocab", 128), config, key=random.PRNGKey(0))
+    state_dict = to_torch_compatible_state_dict(model)
+
+    loaded = from_torch_compatible_state_dict(model, state_dict)
+
+    loaded_state_dict = to_torch_compatible_state_dict(loaded)
+    assert state_dict.keys() == loaded_state_dict.keys()
+    for key, value in state_dict.items():
+        np.testing.assert_allclose(np.asarray(loaded_state_dict[key]), np.asarray(value))
+
+
+def test_qwen3_moe_forward_and_next_token_loss():
+    config = Qwen3MoeConfig.from_hf_config(_tiny_hf_config())
+    Batch = hax.Axis("batch", 2)
+    Pos = config.max_Pos
+    Vocab = hax.Axis("vocab", 128)
+    input_ids = hax.random.randint(random.PRNGKey(1), (Batch, Pos), 0, Vocab.size)
+
+    with use_test_mesh():
+        model = Qwen3MoeLMHeadModel.init(Vocab, config, key=random.PRNGKey(0))
+
+        @jax.jit
+        def compute_loss(model, input_ids):
+            loss_weight = hax.ones((Batch, Pos), dtype=jnp.float32)
+            example = LmExample(tokens=input_ids, loss_weight=loss_weight, attn_mask=AttentionMask.causal())
+            return model.compute_next_token_loss(example, reduction=None, reduction_axis=()).array
+
+        losses = compute_loss(model, input_ids)
+
+    assert losses.shape == (Batch.size, Pos.size)
+    assert np.isfinite(np.asarray(losses)).all()
+
+
+@skip_if_no_torch
+def test_qwen3_moe_hf_logits_and_loss_match_torch():
+    import torch  # noqa: PLC0415
+    import torch.nn.functional as F  # noqa: PLC0415
+    from transformers import Qwen3MoeForCausalLM  # noqa: PLC0415
+
+    hf_config = _tiny_hf_config()
+    config = Qwen3MoeConfig.from_hf_config(hf_config)
+    converter = config.hf_checkpoint_converter()
+    Batch = hax.Axis("batch", 2)
+    Pos = config.max_Pos
+    Vocab = hax.Axis("vocab", hf_config.vocab_size)
+    input_ids = hax.random.randint(random.PRNGKey(1), (Batch, Pos), 0, Vocab.size)
+    input_torch = torch.from_numpy(np.array(input_ids.array)).to(torch.long)
+
+    torch.random.manual_seed(0)
+    torch_model = Qwen3MoeForCausalLM(hf_config)
+    torch_model.eval()
+
+    with torch.no_grad():
+        torch_logits = torch_model(input_torch).logits.detach().cpu().numpy()
+        torch_loss = F.cross_entropy(
+            torch.from_numpy(torch_logits[:, :-1]).reshape(-1, Vocab.size),
+            input_torch[:, 1:].reshape(-1),
+            reduction="none",
+        ).reshape(Batch.size, Pos.size - 1)
+
+    with tempfile.TemporaryDirectory() as tmpdir, use_test_mesh():
+        torch_model.save_pretrained(f"{tmpdir}/torch_model")
+        model = converter.load_pretrained(
+            Qwen3MoeLMHeadModel,
+            ref=f"{tmpdir}/torch_model",
+            resize_vocab_to_match_tokenizer=False,
+        )
+
+        @hax.named_jit
+        def compute_logits(model, input_ids):
+            return model(input_ids, attn_mask=AttentionMask.causal()).array
+
+        @hax.named_jit
+        def compute_loss(model, input_ids):
+            loss_weight = hax.ones((Batch, Pos), dtype=jnp.float32)
+            example = LmExample(tokens=input_ids, loss_weight=loss_weight, attn_mask=AttentionMask.causal())
+            return model.compute_next_token_loss(example, reduction=None, reduction_axis=()).array
+
+        jax_logits = compute_logits(model, input_ids)
+        jax_loss = compute_loss(model, input_ids)
+
+    np.testing.assert_allclose(np.asarray(jax_logits), torch_logits, rtol=1e-4, atol=1e-4)
+    np.testing.assert_allclose(np.asarray(jax_loss[:, :-1]), torch_loss.numpy(), rtol=1e-4, atol=1e-4)

--- a/lib/levanter/tests/test_qwen3_moe.py
+++ b/lib/levanter/tests/test_qwen3_moe.py
@@ -1,10 +1,11 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import tempfile
+
 import jax
 import jax.numpy as jnp
 import numpy as np
-import tempfile
 from jax import random
 from transformers import Qwen3MoeConfig as HfQwen3MoeConfig
 
@@ -61,11 +62,6 @@ def test_qwen3_moe_config_roundtrip():
     assert roundtripped.head_dim == hf_config.head_dim
 
 
-def test_qwen3_moe_hf_converter_uses_qwen3_moe_config_class():
-    converter = Qwen3MoeConfig().hf_checkpoint_converter()
-    assert converter.HfConfigClass.__name__ == "Qwen3MoeConfig"
-
-
 def test_qwen3_moe_state_dict_keys_match_hf_qwen_layout():
     config = Qwen3MoeConfig.from_hf_config(_tiny_hf_config())
     model = Qwen3MoeLMHeadModel.init(hax.Axis("vocab", 128), config, key=random.PRNGKey(0))
@@ -84,12 +80,13 @@ def test_qwen3_moe_state_dict_keys_match_hf_qwen_layout():
 
 def test_qwen3_moe_loads_torch_compatible_state_dict():
     config = Qwen3MoeConfig.from_hf_config(_tiny_hf_config())
-    model = Qwen3MoeLMHeadModel.init(hax.Axis("vocab", 128), config, key=random.PRNGKey(0))
-    state_dict = to_torch_compatible_state_dict(model)
+    with use_test_mesh():
+        model = Qwen3MoeLMHeadModel.init(hax.Axis("vocab", 128), config, key=random.PRNGKey(0))
+        state_dict = to_torch_compatible_state_dict(model)
 
-    loaded = from_torch_compatible_state_dict(model, state_dict)
+        loaded = from_torch_compatible_state_dict(model, state_dict)
 
-    loaded_state_dict = to_torch_compatible_state_dict(loaded)
+        loaded_state_dict = to_torch_compatible_state_dict(loaded)
     assert state_dict.keys() == loaded_state_dict.keys()
     for key, value in state_dict.items():
         np.testing.assert_allclose(np.asarray(loaded_state_dict[key]), np.asarray(value))

--- a/scripts/qwen3_moe_iris_smoke.py
+++ b/scripts/qwen3_moe_iris_smoke.py
@@ -1,0 +1,71 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+import time
+
+import jax
+import jmp
+import levanter
+from levanter.main.perplexity_gap import GapFinderModelConfig, _load_model_runner, _resolved_model_spec
+from levanter.tracker import NoopConfig
+from levanter.trainer import TrainerConfig
+
+MODEL_ID = "Qwen/Qwen3-30B-A3B"
+
+
+def main() -> None:
+    trainer = TrainerConfig(
+        id="qwen3-moe-iris-smoke",
+        mp=jmp.get_policy("bf16"),
+        tracker=NoopConfig(),
+        train_batch_size=8,
+        per_device_parallelism=1,
+        per_device_eval_parallelism=1,
+        require_accelerator=True,
+        log_jaxprs=False,
+        log_xla_hlo=False,
+    )
+    levanter.initialize(trainer)
+
+    spec = _resolved_model_spec(
+        GapFinderModelConfig(
+            checkpoint_path=MODEL_ID,
+            checkpoint_is_hf=True,
+            tokenizer=MODEL_ID,
+            trust_remote_code=True,
+        )
+    )
+
+    started = time.perf_counter()
+    with trainer.use_device_mesh():
+        runner = _load_model_runner(
+            spec=spec,
+            trainer=trainer,
+            max_eval_length=64,
+            compute_axis_mapping=trainer.compute_axis_mapping,
+            parameter_axis_mapping=trainer.parameter_axis_mapping,
+        )
+        tokenized, per_byte_losses = runner.score_texts(
+            [
+                "Qwen3 MoE smoke test for Levanter perplexity scoring on Iris. "
+                "This should produce finite next-token losses."
+            ]
+        )
+
+    elapsed = time.perf_counter() - started
+    result = {
+        "model": MODEL_ID,
+        "devices": [str(device) for device in jax.devices()],
+        "token_count": len(tokenized[0].token_ids),
+        "num_bytes": int(tokenized[0].num_bytes),
+        "loss_sum": float(per_byte_losses[0].sum()),
+        "loss_min": float(per_byte_losses[0].min()),
+        "loss_max": float(per_byte_losses[0].max()),
+        "elapsed_seconds": elapsed,
+    }
+    print("QWEN3_MOE_IRIS_SMOKE_RESULT", json.dumps(result, sort_keys=True))
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Add Qwen3 MoE model support in Levanter so Hugging Face Qwen/Qwen3-30B-A3B can load through the perplexity scoring path. Includes HF conversion, MoE expert serialization, Torch parity coverage for logits and next-token loss, and an Iris smoke script for v6e-8 validation.