### PR TITLE
Stop reservation holders inheriting parent constraints

### DIFF
--- a/lib/iris/src/iris/cluster/controller/ops/job.py
+++ b/lib/iris/src/iris/cluster/controller/ops/job.py
@@ -226,7 +226,7 @@ def submit(
             )
             merged = merge_constraints(
                 constraints_from_resources(entry.resources),
-                [Constraint.from_proto(c) for c in entry.constraints or request.constraints],
+                [Constraint.from_proto(c) for c in entry.constraints],
             )
             for constraint in merged:
                 holder_request.constraints.append(constraint.to_proto())

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -21,6 +21,7 @@ from iris.cluster.constraints import (
     device_variant_constraint,
     get_device_type,
     get_device_variant,
+    preemptible_constraint,
 )
 from iris.cluster.controller import ops, writes
 from iris.cluster.controller.codec import constraints_from_json
@@ -1694,6 +1695,37 @@ def test_holder_task_gets_device_constraints_from_tpu_entry(state):
         WellKnownAttribute.DEVICE_VARIANT in constraint_keys
     ), f"holder job missing device-variant constraint; got keys: {constraint_keys}"
     assert "region" in constraint_keys, "holder job should still have the explicit region constraint"
+
+
+@pytest.mark.parametrize(
+    ("entry_preemptible", "expected_holder_values"),
+    [
+        (None, []),
+        (True, ["true"]),
+    ],
+)
+def test_holder_task_uses_entry_preemptible_constraints_not_parent(
+    state,
+    entry_preemptible,
+    expected_holder_values,
+):
+    entry_constraints = []
+    if entry_preemptible is not None:
+        entry_constraints.append(preemptible_constraint(entry_preemptible).to_proto())
+
+    entry = _make_reservation_entry(device=_tpu_device("v5p-8", count=4), constraints=entry_constraints)
+    request = _make_job_request_with_reservation(reservation_entries=[entry])
+    request.constraints.append(preemptible_constraint(False).to_proto())
+
+    parent_job_id = _submit_job(state, "res-job", request)
+    holder_job_id = parent_job_id.child(RESERVATION_HOLDER_JOB_NAME)
+
+    holder_job = _query_job(state, holder_job_id)
+    assert holder_job is not None
+    constraints = constraints_from_json(holder_job.constraints_json)
+    preemptible_constraints = [c for c in constraints if c.key == WellKnownAttribute.PREEMPTIBLE]
+
+    assert [c.values[0].value for c in preemptible_constraints] == expected_holder_values
 
 
 def test_holder_task_not_scheduled_on_wrong_device_type(state):


### PR DESCRIPTION
## Summary

- stop reservation holders from falling back to parent request constraints when entry constraints are empty
- keep resource-derived holder constraints and explicit reservation-entry constraints
- add regression coverage for parent `preemptible=false` not leaking into the holder

Fixes #5760.

## Test Plan

```sh
uv run --directory lib/iris --group dev python -m pytest \
  tests/cluster/controller/test_reservation.py \
  tests/cli/test_job.py

./infra/pre-commit.py --files lib/iris/src/iris/cluster/controller/ops/job.py \
  --files lib/iris/tests/cluster/controller/test_reservation.py
```

## Live Validation

Validated the controller-side behavior on `marin-dev` with a custom controller image built from this PR.

- Run: https://github.com/marin-community/marin/actions/runs/26911411441
- Result: `Query and validate holder constraints` passed
- Probe shape: small CPU parent with `--reserve v5p-8`, matching the TPU canary failure mode

<details>
<summary>Validation evidence</summary>

The probe checks the exact regression path:

1. Submit a small CPU parent job with `--reserve v5p-8`.
2. Let Iris apply the executor heuristic to the parent (`preemptible=false`).
3. Query the controller DB for the parent and generated reservation holder.
4. Assert the parent still has `preemptible=false`.
5. Assert the reservation holder has TPU resource constraints and does **not** inherit `preemptible=false`.

Observed DB shape from the same validation flow:

| Row | Constraint keys |
| --- | --- |
| Parent job | `preemptible` |
| Reservation holder | `device-type`, `device-variant` |

This confirms the intended behavior: inferred executor constraints stay on the parent job, while the reservation holder is constrained by the reserved resource entry (`tpu:v5p-8`) plus any explicit reservation-entry constraints.

</details>