### PR TITLE
Restrict dependabot to grouped security updates only

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,11 @@
-# Dependabot version updates.
+# Dependabot configuration.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# All version bumps (major, minor, patch) are grouped into a single PR per
-# ecosystem per directory to cut review noise.
+# Proactive version updates are disabled (open-pull-requests-limit: 0). We only
+# want Dependabot to open PRs for security advisories. Security-update PRs are
+# grouped into a single PR per ecosystem per directory to cut review noise.
+# (Security updates are enabled in repo settings and are unaffected by the
+# open-pull-requests-limit: 0 setting.)
 
 version: 2
 updates:
@@ -12,12 +15,12 @@ updates:
       - "/rust/dupekit"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
-      uv-all:
-        update-types:
-          - "major"
-          - "minor"
-          - "patch"
+      uv-security:
+        applies-to: security-updates
+        patterns:
+          - "*"
 
   - package-ecosystem: "npm"
     directories:
@@ -28,9 +31,9 @@ updates:
       - "/lib/finelog/dashboard"
     schedule:
       interval: "weekly"
+    open-pull-requests-limit: 0
     groups:
-      npm-all:
-        update-types:
-          - "major"
-          - "minor"
-          - "patch"
+      npm-security:
+        applies-to: security-updates
+        patterns:
+          - "*"

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,8 +1,8 @@
 # Dependabot version updates.
 # https://docs.github.com/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file
 #
-# Minor and patch bumps are grouped into a single PR per ecosystem per
-# directory to cut review noise; major bumps stay as individual PRs.
+# All version bumps (major, minor, patch) are grouped into a single PR per
+# ecosystem per directory to cut review noise.
 
 version: 2
 updates:
@@ -13,8 +13,9 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      uv-minor-patch:
+      uv-all:
         update-types:
+          - "major"
           - "minor"
           - "patch"
 
@@ -28,7 +29,8 @@ updates:
     schedule:
       interval: "weekly"
     groups:
-      npm-minor-patch:
+      npm-all:
         update-types:
+          - "major"
           - "minor"
           - "patch"


### PR DESCRIPTION
Disable proactive version-update PRs by setting open-pull-requests-limit to 0 on the uv and npm ecosystems, and re-target the groups to security-updates. Dependabot now only opens PRs for security advisories, grouped into one PR per ecosystem per directory. Security updates are already enabled in repo settings.