### PR TITLE
[iris] Stamp attempt_uid on the stop-intent reconcile path so adopted attempts finalize

### DIFF
--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -661,10 +661,29 @@ class Worker:
 
         This is the routing order the controller itself uses. The composite
         fallback covers label-less adopted attempts created by a pre-UID-label
-        worker — they enter the local task list with an empty UID and are
-        stamped by the first reconcile tick that composite-matches them.
+        worker — they enter the local task list with an empty UID. On a
+        composite match the controller UID is stamped onto the attempt so every
+        later observation it emits is keyed by that UID. Without the stamp those
+        observations carry an empty UID and the controller drops them
+        (``filter_observations_to_plan``); an attempt the worker only ever sees
+        via stop intents — a controller-terminated attempt — would then never
+        finalize and the stop intent would re-fire every reconcile tick.
+
+        Mutates the resolved attempt, so callers must hold ``self._lock``.
         """
-        return self.task_by_uid(uid) or self.task_by_attempt(task_id, attempt_id)
+        task = self.task_by_uid(uid)
+        if task is not None:
+            return task
+        task = self.task_by_attempt(task_id, attempt_id)
+        if task is not None and uid and not task.attempt_uid:
+            logger.info(
+                "Reconcile: stamping attempt_uid %s onto attempt %s/%d (composite match)",
+                uid,
+                task_id,
+                attempt_id,
+            )
+            task.attempt_uid = uid
+        return task
 
     def submit_task(self, request: job_pb2.RunTaskRequest) -> str:
         """Submit a new task for execution.
@@ -962,17 +981,7 @@ class Worker:
         so the observation loop reports MISSING.
         """
         with self._lock:
-            task = self.task_by_uid(attempt_uid)
-            if task is None:
-                task = self.task_by_attempt(task_id, attempt_id)
-                if task is not None and attempt_uid and not task.attempt_uid:
-                    logger.info(
-                        "Reconcile: stamping attempt_uid %s onto attempt %s/%d (composite match)",
-                        attempt_uid,
-                        task_id,
-                        attempt_id,
-                    )
-                    task.attempt_uid = attempt_uid
+            task = self.resolve_attempt(attempt_uid, task_id, attempt_id)
 
         if task is not None:
             return

--- a/lib/iris/tests/cluster/worker/test_reconcile.py
+++ b/lib/iris/tests/cluster/worker/test_reconcile.py
@@ -597,6 +597,31 @@ def test_stop_intent_via_composite_kills_labelless_attempt(worker):
     assert attempt.should_stop is True
 
 
+def test_stop_intent_stamps_uid_on_labelless_adopted_attempt(worker):
+    """A stop intent stamps the controller UID onto a label-less adopted attempt.
+
+    Regression: the stop path resolved the attempt by composite but never
+    stamped the UID, so the attempt's observation went out keyed by an empty
+    UID and the controller dropped it (``filter_observations_to_plan``). A
+    controller-terminated attempt the worker only ever saw via stop intents
+    then never finalized — the stop intent re-fired every reconcile tick.
+    """
+    task_id = _task_id("rollover-stop-stamp")
+    attempt = _adopt_labelless(worker, task_id, attempt_id=0)
+    assert attempt.attempt_uid == ""
+
+    response = _reconcile(worker, [_stop_desired("uid-rollover-stop-stamp", task_id=task_id, attempt_id=0)])
+
+    # UID stamped → every later observation is keyed by it, not an empty UID.
+    assert attempt.attempt_uid == "uid-rollover-stop-stamp"
+    # This tick's observation already carries the real UID, so the controller
+    # keeps it (it is in the plan) and can finalize the attempt.
+    obs = _observations_by_uid(response)
+    assert "uid-rollover-stop-stamp" in obs
+    assert obs["uid-rollover-stop-stamp"].task_id == task_id
+    assert obs["uid-rollover-stop-stamp"].attempt_id == 0
+
+
 def test_labelless_attempt_observation_carries_composite(worker):
     """Observations from a label-less adopted attempt carry the composite key."""
     task_id = _task_id("rollover-obs")


### PR DESCRIPTION
Centralize the rollover UID stamp in resolve_attempt so a label-less adopted attempt gets the controller UID whether it is reached by a run or a stop intent. Previously only run intents stamped it, so a controller-terminated attempt seen only via stop intents emitted observations keyed by an empty UID that the controller dropped (filter_observations_to_plan), leaving it unfinalized and re-polled every reconcile tick. Adds a regression test.