### PR TITLE
[Iris] Default marin SSH to impersonate iris-controller SA

### DIFF
--- a/lib/iris/config/marin.yaml
+++ b/lib/iris/config/marin.yaml
@@ -9,6 +9,8 @@ platform:
     project_id: hai-gcp-models
 
 defaults:
+  ssh:
+    impersonate_service_account: iris-controller@hai-gcp-models.iam.gserviceaccount.com
   autoscaler:
     evaluation_interval:
       milliseconds: 10000


### PR DESCRIPTION
Set the marin cluster SSH default to impersonate iris-controller@hai-gcp-models.iam.gserviceaccount.com so gcloud SSH operations use the controller service account instead of the caller's own credentials.