### PR TITLE
[Iris] Gate reservation demand to match the scheduler

### DIFF
--- a/lib/iris/src/iris/cluster/controller/scheduling_policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling_policy.py
@@ -154,6 +154,39 @@ def job_requirements_from_job(job: PendingTask) -> JobRequirements:
     )
 
 
+def reservation_unsatisfied(
+    task: PendingTask,
+    claims_by_job: dict[str, int],
+    reservation_entry_counts: dict[JobName, int],
+) -> bool:
+    """Whether a real task must wait for its job's reservation to be claimed.
+
+    A non-holder task of a directly-reserved job is *unsatisfied* until the
+    number of workers claimed for its reservation reaches the reservation's
+    entry count. Such a task must neither be scheduled nor generate autoscaler
+    demand: the reservation's holder task provisions the reserved capacity, and
+    the real task runs only once that capacity exists.
+
+    Both the scheduling gate (:func:`apply_scheduling_gates`) and the demand
+    path (:func:`compute_demand_entries`) consult this predicate so they agree.
+    If they disagree — demand emitting for a task the gate blocks — the
+    autoscaler provisions generic capacity the task can never occupy and
+    thrashes, booting workers that are reaped as idle every cycle.
+    """
+    if task.is_reservation_holder or not task.has_reservation:
+        return False
+    required = reservation_entry_counts.get(task.job_id, 0)
+    return claims_by_job.get(task.job_id.to_wire(), 0) < required
+
+
+def _claims_by_job(claims: dict[WorkerId, ReservationClaim] | None) -> dict[str, int]:
+    """Count reservation claims per claiming job (wire id) for the reservation gate."""
+    counts: dict[str, int] = defaultdict(int)
+    for claim in (claims or {}).values():
+        counts[claim.job_id] += 1
+    return counts
+
+
 def compute_demand_entries(
     queries: ControllerDB,
     scheduler: Scheduler | None = None,
@@ -196,9 +229,15 @@ def compute_demand_entries(
     all_schedulable: list[PendingTask] = []
     with queries.read_snapshot() as tx:
         pending = _pending_tasks_with_jobs(tx)
+        reservation_entry_counts = _reservation_entry_counts_for_pending(tx, pending)
     for task in pending:
         tasks_by_job[task.job_id].append(task)
         all_schedulable.append(task)
+
+    # Index reservation claims by job so the reservation gate below can compare
+    # claimed workers against required entries, exactly as apply_scheduling_gates
+    # does for the real scheduling pass.
+    claims_by_job = _claims_by_job(reservation_claims)
 
     # Build job requirements once, shared between dry-run and demand emission.
     # Also track which jobs have reservations so we can apply taint injection.
@@ -261,6 +300,15 @@ def compute_demand_entries(
         # Use the first task to source job-level columns.
         job_row = tasks[0]
         if is_job_finished(job_row.job_state):
+            continue
+
+        # Reservation gate (mirrors apply_scheduling_gates): a real task of a
+        # directly-reserved job emits no demand until its reservation is
+        # claimed. The holder task (a separate job) provisions the reserved
+        # capacity; emitting demand for the real task here would provision
+        # generic capacity the scheduler gate will never let it occupy, so the
+        # autoscaler would boot workers that idle out and get reaped forever.
+        if reservation_unsatisfied(job_row, claims_by_job, reservation_entry_counts):
             continue
 
         job_constraints = constraints_from_json(job_row.constraints_json)
@@ -1092,9 +1140,7 @@ def apply_scheduling_gates(
     filter_counts: dict[str, int] = defaultdict(int)
 
     # Index claims by wire id so reservation-satisfaction is O(1) per check.
-    claims_by_job: dict[str, int] = defaultdict(int)
-    for claim in claims.values():
-        claims_by_job[claim.job_id] += 1
+    claims_by_job = _claims_by_job(claims)
 
     for task in ctx.pending_task_rows:
         if not task_row_can_be_scheduled(task):
@@ -1107,12 +1153,9 @@ def apply_scheduling_gates(
             continue
         # Gate: skip real tasks whose job has an unsatisfied reservation.
         # Holder tasks are always schedulable (they ARE the reservation).
-        if not task.is_reservation_holder and task.has_reservation:
-            wire_id = task.job_id.to_wire()
-            required = ctx.reservation_entry_counts.get(task.job_id, 0)
-            if claims_by_job.get(wire_id, 0) < required:
-                filter_counts["reservation_unsatisfied"] += 1
-                continue
+        if reservation_unsatisfied(task, claims_by_job, ctx.reservation_entry_counts):
+            filter_counts["reservation_unsatisfied"] += 1
+            continue
         if (
             max_tasks_per_job_per_cycle > 0
             and not task.has_coscheduling

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -49,6 +49,7 @@ from iris.cluster.controller.scheduling_policy import (
     build_scheduling_context,
     claim_workers_for_reservations,
     cleanup_stale_claims,
+    compute_demand_entries,
     inject_reservation_taints,
     inject_taint_constraints,
     job_requirements_from_job,
@@ -587,6 +588,59 @@ def test_gate_satisfied_for_jobs_without_reservation(ctrl):
     ctx = build_scheduling_context(ctrl._db, ctrl._health, ctrl._worker_attrs, ctrl._config.user_budget_defaults)
     gated = apply_scheduling_gates(ctx, claims, max_tasks_per_job_per_cycle=0)
     assert jid.task(0) in gated.schedulable_task_ids
+
+
+# =============================================================================
+# Reservation gate parity: the demand path must match the scheduling gate
+# =============================================================================
+
+
+def _holder_demand(demand):
+    return [d for d in demand if any(RESERVATION_HOLDER_JOB_NAME in t for t in d.task_ids)]
+
+
+def _real_demand(demand):
+    return [d for d in demand if not any(RESERVATION_HOLDER_JOB_NAME in t for t in d.task_ids)]
+
+
+def test_demand_gates_real_task_until_reservation_claimed(ctrl):
+    """A reserved job's real task must not emit demand until its reservation is claimed.
+
+    Regression for the europe-west4-a autoscaler thrash: an ``iris run`` job's
+    parent task is a tiny CPU driver that holds a GPU/TPU reservation. While the
+    reservation is unclaimed the scheduler gate (``apply_scheduling_gates``)
+    blocks the parent task, but ``compute_demand_entries`` used to emit CPU
+    demand for it anyway. The autoscaler then booted CPU workers the scheduler
+    would never let the task occupy; they idled out and were reaped every cycle,
+    forever. The demand path must apply the same reservation gate: only the
+    holder task generates demand (to provision the reserved capacity) until the
+    reservation is satisfied.
+    """
+    # Parent task is a CPU driver; the reservation is for a GPU no CPU worker can
+    # satisfy, so it stays unclaimed even though a CPU worker is available.
+    _register_worker(ctrl, "cpu1", _cpu_metadata())
+    req = _make_job_request_with_reservation(reservation_entries=[_make_reservation_entry(_gpu_device("H100"))])
+    jid = _submit_job(ctrl, "j1", req)
+
+    _claim_for_reservations(ctrl)
+    claims = read_reservation_claims(ctrl._db)
+    assert claims == {}  # no GPU worker, reservation unfulfilled
+
+    demand = compute_demand_entries(ctrl._db, reservation_claims=claims)
+    # Holder provisions the reserved GPU; the parent's real task is gated.
+    assert len(_holder_demand(demand)) == 1
+    assert _real_demand(demand) == [], "real task must not emit demand while reservation is unclaimed"
+
+    # Once a matching worker is claimed, the gate opens and the real task may
+    # emit demand again.
+    _register_worker(ctrl, "gpu1", _gpu_metadata("H100"))
+    _claim_for_reservations(ctrl)
+    claims = read_reservation_claims(ctrl._db)
+    assert len(claims) == 1
+
+    demand = compute_demand_entries(ctrl._db, reservation_claims=claims)
+    real_ids = {t for d in _real_demand(demand) for t in d.task_ids}
+    assert jid.task(0).to_wire() in real_ids
 
 
 # =============================================================================

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -2377,12 +2377,14 @@ def _is_synthetic_demand(state: ControllerTestState, demand_entry: DemandEntry) 
     return False
 
 
-def test_demand_reservation_all_tasks_generate_demand(state):
-    """2 H100 reservation + 2 H100 tasks = 4 total demand (no budget dedup).
+def test_demand_reservation_gates_real_tasks_until_claimed(state):
+    """Until the reservation is claimed, only the holder tasks generate demand.
 
-    All tasks generate demand through a unified path. Holder tasks and real
-    tasks are independent demand sources — preemption during scheduling
-    (not demand) handles the dedup.
+    The holder tasks provision the reserved capacity; the real tasks are gated
+    (mirroring ``apply_scheduling_gates``) so the autoscaler never provisions
+    generic capacity the scheduler will refuse to let them occupy. The claimed
+    case — real tasks resume generating demand — is covered by
+    test_reservation.test_demand_gates_real_task_until_reservation_claimed.
     """
     req = _make_reservation_make_job_request(
         task_device=_h100_device(),
@@ -2391,16 +2393,16 @@ def test_demand_reservation_all_tasks_generate_demand(state):
     )
     submit_job(state, "j1", req)
 
-    demand = compute_demand_entries(state._db)
+    demand = compute_demand_entries(state._db)  # reservation unclaimed
     synthetic_demand = [d for d in demand if _is_synthetic_demand(state, d)]
     real_demand = [d for d in demand if not _is_synthetic_demand(state, d)]
 
     assert len(synthetic_demand) == 2
-    assert len(real_demand) == 2
+    assert real_demand == []
 
 
 def test_demand_reservation_excess_tasks(state):
-    """2 H100 reservation + 5 H100 tasks = 2 synthetic + 5 real task demand."""
+    """2 H100 reservation + 5 H100 tasks: 2 holder demand; real tasks gated until claimed."""
     req = _make_reservation_make_job_request(
         task_device=_h100_device(),
         reservation_devices=[_h100_device(), _h100_device()],
@@ -2413,7 +2415,7 @@ def test_demand_reservation_excess_tasks(state):
     real_demand = [d for d in demand if not _is_synthetic_demand(state, d)]
 
     assert len(synthetic_demand) == 2
-    assert len(real_demand) == 5
+    assert real_demand == []
 
 
 def test_demand_reservation_holder_uses_entry_resources(state):
@@ -2437,7 +2439,7 @@ def test_demand_reservation_holder_uses_entry_resources(state):
     real_demand = [d for d in demand if not _is_synthetic_demand(state, d)]
 
     assert len(synthetic_demand) == 2
-    assert len(real_demand) == 2
+    assert real_demand == []  # real tasks gated until the reservation is claimed
     # Holder demand uses entry's H100 device, not parent's A100
     for d in synthetic_demand:
         assert d.normalized.device_variants == frozenset({"h100"})
@@ -2474,8 +2476,9 @@ def test_demand_reservation_mixed_jobs(state):
     # 3 synthetic holder tasks from h100-job's reservation
     assert len(synthetic_demand) == 3
 
-    # h100-job: 3 real tasks + a100-job: 2 tasks = 5 real demand
-    assert len(real_demand) == 5
+    # h100-job's real tasks are gated (reservation unclaimed); only a100-job
+    # (no reservation) emits real demand.
+    assert len(real_demand) == 2
     a100_demand = [d for d in real_demand if d.normalized.device_variants == frozenset({"a100"})]
     assert len(a100_demand) == 2
 
@@ -2532,8 +2535,9 @@ def test_demand_reservation_independent_per_job(state):
 
     # Job A's 2 synthetic holder tasks
     assert len(synthetic_demand) == 2
-    # Job A's 2 real tasks + Job B's 2 tasks = 4 real demand
-    assert len(real_demand) == 4
+    # Job A's real tasks are gated (reservation unclaimed); only Job B (no
+    # reservation) emits real demand.
+    assert len(real_demand) == 2
 
 
 # =============================================================================
@@ -3175,15 +3179,17 @@ def test_demand_holders_absorbed_by_dry_run(state):
 
     Unlike the old design where holders always generated demand, they now
     participate in the dry-run like normal tasks and are absorbed when matching
-    workers have available capacity.
+    workers have available capacity. The job's real tasks are gated until the
+    reservation is claimed, so only holder tasks contribute demand here.
     """
     scheduler = Scheduler()
 
     # Register a large GPU worker with capacity for 1 task
     register_worker(state, "w1", "10.0.0.1:8080", _gpu_make_worker_metadata(cpu=2, memory_gb=4))
 
-    # Submit a job with reservation (2 entries) and 2 tasks.
-    # Worker can fit 1 task — so 1 task absorbed, 3 remain as demand.
+    # Submit a job with reservation (2 entries) and 2 tasks. The reservation is
+    # unclaimed, so the 2 real tasks are gated and only the 2 holder tasks are
+    # live demand. The worker absorbs 1 holder; the other remains as demand.
     req = _make_reservation_make_job_request(
         task_device=_h100_device(),
         reservation_devices=[_h100_device(), _h100_device()],
@@ -3193,8 +3199,8 @@ def test_demand_holders_absorbed_by_dry_run(state):
 
     workers = healthy_active_workers(state)
     demand = compute_demand_entries(state._db, scheduler, workers)
-    # Worker fits 1 task (holder or real). 3 remaining generate demand.
-    assert len(demand) == 3
+    assert len(demand) == 1
+    assert _is_synthetic_demand(state, demand[0])  # the remaining unabsorbed holder
 
 
 def test_demand_absorbs_capacity_before_emitting(state):


### PR DESCRIPTION
A real task of a job with an unfulfilled reservation was gated by the scheduler but still emitted autoscaler demand, so the autoscaler booted generic workers the scheduler would never let it use; they idled out and were reaped every cycle. Share one reservation_unsatisfied predicate (and claim-indexing helper) between the scheduler gate and the demand path so they cannot disagree. Adds a reproduction test.