### PR TITLE
[Grug] Fix MoE optimizer global clipping

### DIFF
--- a/experiments/grug/moe/optimizer.py
+++ b/experiments/grug/moe/optimizer.py
@@ -37,28 +37,18 @@ class GrugMoeAdamHConfig(OptimizerConfig):
 
         def optimizer(learning_rate, adam_lr, expert_lr):
             def adamh_transform():
-                components = []
-                if self.max_grad_norm:
-                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
-                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, learning_rate))
-                return optax.chain(*components)
+                return optax.chain(scale_by_adamh(self.beta1, self.beta2, self.epsilon, learning_rate))
 
             def adamh_expert_transform():
-                components = []
-                if self.max_grad_norm:
-                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
-                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, expert_lr))
-                return optax.chain(*components)
+                return optax.chain(scale_by_adamh(self.beta1, self.beta2, self.epsilon, expert_lr))
 
             def adam_transform():
-                components = []
-                if self.max_grad_norm:
-                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
-                components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
-                components.append(optax.scale(-adam_lr))
-                return optax.chain(*components)
+                return optax.chain(
+                    optax.scale_by_adam(self.beta1, self.beta2, self.epsilon),
+                    optax.scale(-adam_lr),
+                )
 
-            return optax.multi_transform(
+            grouped = optax.multi_transform(
                 {
                     "adamh": adamh_transform(),
                     "adamh_expert": adamh_expert_transform(),
@@ -66,6 +56,9 @@ class GrugMoeAdamHConfig(OptimizerConfig):
                 },
                 self.create_mask,
             )
+            if self.max_grad_norm is None:
+                return grouped
+            return optax.chain(optax.clip_by_global_norm(self.max_grad_norm), grouped)
 
         return optax.inject_hyperparams(optimizer)(
             learning_rate=learning_rate_schedule,

--- a/experiments/grug/moe/test_optimizer.py
+++ b/experiments/grug/moe/test_optimizer.py
@@ -7,7 +7,41 @@ from experiments.grug.moe.optimizer import GrugMoeAdamHConfig
 
 
 def test_grug_moe_adamh_mask_routes_expert_mlp_weights_to_expert_group():
-    params = {
+    mask = GrugMoeAdamHConfig().create_mask(_optimizer_test_params())
+
+    block_mask = mask["blocks"]["0"]
+    assert block_mask["mlp"]["router"] == "adam"
+    assert block_mask["mlp"]["expert_mlp"]["w_gate_up"] == "adamh_expert"
+    assert block_mask["mlp"]["expert_mlp"]["w_down"] == "adamh_expert"
+    assert block_mask["shared"]["w_gate"] == "adamh_expert"
+    assert mask["token_embed"] == "adam"
+
+
+def test_grug_moe_adamh_applies_one_outer_global_clip():
+    optimizer = GrugMoeAdamHConfig(max_grad_norm=1.0).build(num_train_steps=10)
+    state = optimizer.init(_optimizer_test_params())
+
+    clip_state, grouped_state = state.inner_state
+    assert type(clip_state).__name__ == "EmptyState"
+    assert type(grouped_state).__name__ == "PartitionState"
+    assert _inner_state_names(grouped_state, "adamh_expert") == ["ScaleByAdamHState"]
+
+
+def test_grug_moe_adamh_disables_outer_clip_when_unset():
+    optimizer = GrugMoeAdamHConfig(max_grad_norm=None).build(num_train_steps=10)
+    state = optimizer.init(_optimizer_test_params())
+
+    assert type(state.inner_state).__name__ == "PartitionState"
+    assert _inner_state_names(state.inner_state, "adamh_expert") == ["ScaleByAdamHState"]
+
+
+def _inner_state_names(partition_state, label):
+    masked_state = partition_state.inner_states[label]
+    return [type(inner_state).__name__ for inner_state in masked_state.inner_state]
+
+
+def _optimizer_test_params():
+    return {
         "blocks": {
             "0": {
                 "mlp": {
@@ -24,12 +58,3 @@ def test_grug_moe_adamh_mask_routes_expert_mlp_weights_to_expert_group():
         },
         "token_embed": jnp.ones((128, 8), dtype=jnp.float32),
     }
-
-    mask = GrugMoeAdamHConfig().create_mask(params)
-
-    block_mask = mask["blocks"]["0"]
-    assert block_mask["mlp"]["router"] == "adam"
-    assert block_mask["mlp"]["expert_mlp"]["w_gate_up"] == "adamh_expert"
-    assert block_mask["mlp"]["expert_mlp"]["w_down"] == "adamh_expert"
-    assert block_mask["shared"]["w_gate"] == "adamh_expert"
-    assert mask["token_embed"] == "adam"

--- a/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
@@ -48,33 +48,34 @@ def _pack_deepep_local_assignments(
     local_experts: int,
     num_recv_tokens: Int[Array, ""],
 ) -> DeepEPLocalAssignments:
-    max_recv_tokens, topk = recv_topk_idx.shape
-    total_assignments = max_recv_tokens * topk
+    with jax.named_scope("deepep_pack_local_assignments"):
+        max_recv_tokens, topk = recv_topk_idx.shape
+        total_assignments = max_recv_tokens * topk
 
-    recv_token_indices = jnp.repeat(jnp.arange(max_recv_tokens, dtype=jnp.int32), topk)
-    expert_flat = recv_topk_idx.reshape(-1).astype(jnp.int32)
-    recv_valid = jnp.arange(max_recv_tokens, dtype=jnp.int32) < num_recv_tokens
-    local_mask = recv_valid[:, None] & (recv_topk_idx >= 0) & (recv_topk_idx < local_experts)
-    local_mask_flat = local_mask.reshape(-1)
-    local_bucket = jnp.where(local_mask_flat, expert_flat, local_experts)
-    local_group_sizes = jnp.bincount(local_bucket, length=local_experts + 1).astype(jnp.int32)[:-1]
-    total_valid = jnp.sum(local_group_sizes, dtype=jnp.int32)
+        recv_token_indices = jnp.repeat(jnp.arange(max_recv_tokens, dtype=jnp.int32), topk)
+        expert_flat = recv_topk_idx.reshape(-1).astype(jnp.int32)
+        recv_valid = jnp.arange(max_recv_tokens, dtype=jnp.int32) < num_recv_tokens
+        local_mask = recv_valid[:, None] & (recv_topk_idx >= 0) & (recv_topk_idx < local_experts)
+        local_mask_flat = local_mask.reshape(-1)
+        local_bucket = jnp.where(local_mask_flat, expert_flat, local_experts)
+        local_group_sizes = jnp.bincount(local_bucket, length=local_experts + 1).astype(jnp.int32)[:-1]
+        total_valid = jnp.sum(local_group_sizes, dtype=jnp.int32)
 
-    flat_positions = jnp.arange(total_assignments, dtype=jnp.int32)
-    order_key = local_bucket * total_assignments + flat_positions
-    max_order_key = (local_experts + 1) * total_assignments
-    selection_key = jnp.where(local_mask_flat, max_order_key - order_key, -1)
-    _, sorted_assignment_indices = jax.lax.top_k(selection_key, total_assignments)
+        flat_positions = jnp.arange(total_assignments, dtype=jnp.int32)
+        order_key = local_bucket * total_assignments + flat_positions
+        max_order_key = (local_experts + 1) * total_assignments
+        selection_key = jnp.where(local_mask_flat, max_order_key - order_key, -1)
+        _, sorted_assignment_indices = jax.lax.top_k(selection_key, total_assignments)
 
-    recv_token_indices = jnp.take(recv_token_indices, sorted_assignment_indices, axis=0)
-    x_dispatch = jnp.take(recv_x, recv_token_indices, axis=0)
-    assignment_weights = jnp.take(recv_topk_weights.reshape(-1), sorted_assignment_indices, axis=0).astype(
-        recv_x.dtype
-    )
-    valid_sorted = jnp.arange(total_assignments, dtype=jnp.int32) < total_valid
-    x_dispatch = jnp.where(valid_sorted[:, None], x_dispatch, 0)
-    assignment_weights = jnp.where(valid_sorted, assignment_weights, 0)
-    return DeepEPLocalAssignments(x_dispatch, assignment_weights, recv_token_indices, local_group_sizes)
+        recv_token_indices = jnp.take(recv_token_indices, sorted_assignment_indices, axis=0)
+        x_dispatch = jnp.take(recv_x, recv_token_indices, axis=0)
+        assignment_weights = jnp.take(recv_topk_weights.reshape(-1), sorted_assignment_indices, axis=0).astype(
+            recv_x.dtype
+        )
+        valid_sorted = jnp.arange(total_assignments, dtype=jnp.int32) < total_valid
+        x_dispatch = jnp.where(valid_sorted[:, None], x_dispatch, 0)
+        assignment_weights = jnp.where(valid_sorted, assignment_weights, 0)
+        return DeepEPLocalAssignments(x_dispatch, assignment_weights, recv_token_indices, local_group_sizes)
 
 
 def _collapse_deepep_local_assignments(
@@ -85,14 +86,15 @@ def _collapse_deepep_local_assignments(
     recv_capacity: int,
     num_recv_tokens: Int[Array, ""],
 ) -> Float[Array, "TR D"]:
-    recv_out = jax.ops.segment_sum(
-        out_dispatch * assignment_weights[:, None],
-        recv_token_indices,
-        num_segments=recv_capacity,
-        indices_are_sorted=False,
-    )
-    recv_valid = jnp.arange(recv_capacity, dtype=jnp.int32) < num_recv_tokens
-    return jnp.where(recv_valid[:, None], recv_out, 0)
+    with jax.named_scope("deepep_collapse_local_assignments"):
+        recv_out = jax.ops.segment_sum(
+            out_dispatch * assignment_weights[:, None],
+            recv_token_indices,
+            num_segments=recv_capacity,
+            indices_are_sorted=False,
+        )
+        recv_valid = jnp.arange(recv_capacity, dtype=jnp.int32) < num_recv_tokens
+        return jnp.where(recv_valid[:, None], recv_out, 0)
 
 
 def _moe_mlp_ep_deepep_local(
@@ -120,32 +122,34 @@ def _moe_mlp_ep_deepep_local(
     max_recv_tokens = x_local.shape[0] * ep_size
 
     with jax.named_scope("dispatch"):
-        num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
-            selected_experts_local,
-            num_ranks=ep_size,
-            num_experts=num_experts,
-        )
-        (
-            recv_x,
-            recv_topk_idx,
-            recv_topk_weights,
-            recv_src_idx,
-            rank_prefix_matrix,
-            channel_prefix_matrix,
-            recv_channel_prefix_matrix,
-            send_head,
-            _local_expert_counts,
-            num_recv_tokens,
-        ) = deepep_dispatch_intranode(
-            x_local,
-            selected_experts_local,
-            combine_weights_local,
-            num_tokens_per_rank,
-            num_tokens_per_expert,
-            is_token_in_rank,
-            num_experts=num_experts,
-            max_recv_tokens=max_recv_tokens,
-        )
+        with jax.named_scope("deepep_layout"):
+            num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
+                selected_experts_local,
+                num_ranks=ep_size,
+                num_experts=num_experts,
+            )
+        with jax.named_scope("deepep_dispatch_transport"):
+            (
+                recv_x,
+                recv_topk_idx,
+                recv_topk_weights,
+                recv_src_idx,
+                rank_prefix_matrix,
+                channel_prefix_matrix,
+                recv_channel_prefix_matrix,
+                send_head,
+                _local_expert_counts,
+                num_recv_tokens,
+            ) = deepep_dispatch_intranode(
+                x_local,
+                selected_experts_local,
+                combine_weights_local,
+                num_tokens_per_rank,
+                num_tokens_per_expert,
+                is_token_in_rank,
+                num_experts=num_experts,
+                max_recv_tokens=max_recv_tokens,
+            )
         num_recv_tokens_scalar = jnp.squeeze(num_recv_tokens, axis=0)
         local_assignments = _pack_deepep_local_assignments(
             recv_x,
@@ -175,16 +179,17 @@ def _moe_mlp_ep_deepep_local(
             recv_capacity=recv_x.shape[0],
             num_recv_tokens=num_recv_tokens_scalar,
         )
-        out_local, _ = deepep_combine_intranode(
-            recv_out,
-            recv_topk_weights,
-            recv_src_idx,
-            rank_prefix_matrix,
-            channel_prefix_matrix,
-            recv_channel_prefix_matrix,
-            send_head,
-            num_recv_tokens,
-            is_token_in_rank,
-        )
+        with jax.named_scope("deepep_combine_transport"):
+            out_local, _ = deepep_combine_intranode(
+                recv_out,
+                recv_topk_weights,
+                recv_src_idx,
+                rank_prefix_matrix,
+                channel_prefix_matrix,
+                recv_channel_prefix_matrix,
+                send_head,
+                num_recv_tokens,
+                is_token_in_rank,
+            )
         dropped_total = jnp.array(0, dtype=jnp.int32)
     return out_local.astype(x_local.dtype), dropped_total

--- a/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
@@ -48,34 +48,33 @@ def _pack_deepep_local_assignments(
     local_experts: int,
     num_recv_tokens: Int[Array, ""],
 ) -> DeepEPLocalAssignments:
-    with jax.named_scope("deepep_pack_local_assignments"):
-        max_recv_tokens, topk = recv_topk_idx.shape
-        total_assignments = max_recv_tokens * topk
+    max_recv_tokens, topk = recv_topk_idx.shape
+    total_assignments = max_recv_tokens * topk
 
-        recv_token_indices = jnp.repeat(jnp.arange(max_recv_tokens, dtype=jnp.int32), topk)
-        expert_flat = recv_topk_idx.reshape(-1).astype(jnp.int32)
-        recv_valid = jnp.arange(max_recv_tokens, dtype=jnp.int32) < num_recv_tokens
-        local_mask = recv_valid[:, None] & (recv_topk_idx >= 0) & (recv_topk_idx < local_experts)
-        local_mask_flat = local_mask.reshape(-1)
-        local_bucket = jnp.where(local_mask_flat, expert_flat, local_experts)
-        local_group_sizes = jnp.bincount(local_bucket, length=local_experts + 1).astype(jnp.int32)[:-1]
-        total_valid = jnp.sum(local_group_sizes, dtype=jnp.int32)
+    recv_token_indices = jnp.repeat(jnp.arange(max_recv_tokens, dtype=jnp.int32), topk)
+    expert_flat = recv_topk_idx.reshape(-1).astype(jnp.int32)
+    recv_valid = jnp.arange(max_recv_tokens, dtype=jnp.int32) < num_recv_tokens
+    local_mask = recv_valid[:, None] & (recv_topk_idx >= 0) & (recv_topk_idx < local_experts)
+    local_mask_flat = local_mask.reshape(-1)
+    local_bucket = jnp.where(local_mask_flat, expert_flat, local_experts)
+    local_group_sizes = jnp.bincount(local_bucket, length=local_experts + 1).astype(jnp.int32)[:-1]
+    total_valid = jnp.sum(local_group_sizes, dtype=jnp.int32)
 
-        flat_positions = jnp.arange(total_assignments, dtype=jnp.int32)
-        order_key = local_bucket * total_assignments + flat_positions
-        max_order_key = (local_experts + 1) * total_assignments
-        selection_key = jnp.where(local_mask_flat, max_order_key - order_key, -1)
-        _, sorted_assignment_indices = jax.lax.top_k(selection_key, total_assignments)
+    flat_positions = jnp.arange(total_assignments, dtype=jnp.int32)
+    order_key = local_bucket * total_assignments + flat_positions
+    max_order_key = (local_experts + 1) * total_assignments
+    selection_key = jnp.where(local_mask_flat, max_order_key - order_key, -1)
+    _, sorted_assignment_indices = jax.lax.top_k(selection_key, total_assignments)
 
-        recv_token_indices = jnp.take(recv_token_indices, sorted_assignment_indices, axis=0)
-        x_dispatch = jnp.take(recv_x, recv_token_indices, axis=0)
-        assignment_weights = jnp.take(recv_topk_weights.reshape(-1), sorted_assignment_indices, axis=0).astype(
-            recv_x.dtype
-        )
-        valid_sorted = jnp.arange(total_assignments, dtype=jnp.int32) < total_valid
-        x_dispatch = jnp.where(valid_sorted[:, None], x_dispatch, 0)
-        assignment_weights = jnp.where(valid_sorted, assignment_weights, 0)
-        return DeepEPLocalAssignments(x_dispatch, assignment_weights, recv_token_indices, local_group_sizes)
+    recv_token_indices = jnp.take(recv_token_indices, sorted_assignment_indices, axis=0)
+    x_dispatch = jnp.take(recv_x, recv_token_indices, axis=0)
+    assignment_weights = jnp.take(recv_topk_weights.reshape(-1), sorted_assignment_indices, axis=0).astype(
+        recv_x.dtype
+    )
+    valid_sorted = jnp.arange(total_assignments, dtype=jnp.int32) < total_valid
+    x_dispatch = jnp.where(valid_sorted[:, None], x_dispatch, 0)
+    assignment_weights = jnp.where(valid_sorted, assignment_weights, 0)
+    return DeepEPLocalAssignments(x_dispatch, assignment_weights, recv_token_indices, local_group_sizes)
 
 
 def _collapse_deepep_local_assignments(
@@ -86,15 +85,14 @@ def _collapse_deepep_local_assignments(
     recv_capacity: int,
     num_recv_tokens: Int[Array, ""],
 ) -> Float[Array, "TR D"]:
-    with jax.named_scope("deepep_collapse_local_assignments"):
-        recv_out = jax.ops.segment_sum(
-            out_dispatch * assignment_weights[:, None],
-            recv_token_indices,
-            num_segments=recv_capacity,
-            indices_are_sorted=False,
-        )
-        recv_valid = jnp.arange(recv_capacity, dtype=jnp.int32) < num_recv_tokens
-        return jnp.where(recv_valid[:, None], recv_out, 0)
+    recv_out = jax.ops.segment_sum(
+        out_dispatch * assignment_weights[:, None],
+        recv_token_indices,
+        num_segments=recv_capacity,
+        indices_are_sorted=False,
+    )
+    recv_valid = jnp.arange(recv_capacity, dtype=jnp.int32) < num_recv_tokens
+    return jnp.where(recv_valid[:, None], recv_out, 0)
 
 
 def _moe_mlp_ep_deepep_local(
@@ -122,34 +120,32 @@ def _moe_mlp_ep_deepep_local(
     max_recv_tokens = x_local.shape[0] * ep_size
 
     with jax.named_scope("dispatch"):
-        with jax.named_scope("deepep_layout"):
-            num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
-                selected_experts_local,
-                num_ranks=ep_size,
-                num_experts=num_experts,
-            )
-        with jax.named_scope("deepep_dispatch_transport"):
-            (
-                recv_x,
-                recv_topk_idx,
-                recv_topk_weights,
-                recv_src_idx,
-                rank_prefix_matrix,
-                channel_prefix_matrix,
-                recv_channel_prefix_matrix,
-                send_head,
-                _local_expert_counts,
-                num_recv_tokens,
-            ) = deepep_dispatch_intranode(
-                x_local,
-                selected_experts_local,
-                combine_weights_local,
-                num_tokens_per_rank,
-                num_tokens_per_expert,
-                is_token_in_rank,
-                num_experts=num_experts,
-                max_recv_tokens=max_recv_tokens,
-            )
+        num_tokens_per_rank, num_tokens_per_expert, is_token_in_rank = deepep_get_dispatch_layout(
+            selected_experts_local,
+            num_ranks=ep_size,
+            num_experts=num_experts,
+        )
+        (
+            recv_x,
+            recv_topk_idx,
+            recv_topk_weights,
+            recv_src_idx,
+            rank_prefix_matrix,
+            channel_prefix_matrix,
+            recv_channel_prefix_matrix,
+            send_head,
+            _local_expert_counts,
+            num_recv_tokens,
+        ) = deepep_dispatch_intranode(
+            x_local,
+            selected_experts_local,
+            combine_weights_local,
+            num_tokens_per_rank,
+            num_tokens_per_expert,
+            is_token_in_rank,
+            num_experts=num_experts,
+            max_recv_tokens=max_recv_tokens,
+        )
         num_recv_tokens_scalar = jnp.squeeze(num_recv_tokens, axis=0)
         local_assignments = _pack_deepep_local_assignments(
             recv_x,
@@ -179,17 +175,16 @@ def _moe_mlp_ep_deepep_local(
             recv_capacity=recv_x.shape[0],
             num_recv_tokens=num_recv_tokens_scalar,
         )
-        with jax.named_scope("deepep_combine_transport"):
-            out_local, _ = deepep_combine_intranode(
-                recv_out,
-                recv_topk_weights,
-                recv_src_idx,
-                rank_prefix_matrix,
-                channel_prefix_matrix,
-                recv_channel_prefix_matrix,
-                send_head,
-                num_recv_tokens,
-                is_token_in_rank,
-            )
+        out_local, _ = deepep_combine_intranode(
+            recv_out,
+            recv_topk_weights,
+            recv_src_idx,
+            rank_prefix_matrix,
+            channel_prefix_matrix,
+            recv_channel_prefix_matrix,
+            send_head,
+            num_recv_tokens,
+            is_token_in_rank,
+        )
         dropped_total = jnp.array(0, dtype=jnp.int32)
     return out_local.astype(x_local.dtype), dropped_total


### PR DESCRIPTION
Apply global norm clipping once around the Grug MoE AdamH multi_transform instead of once per parameter group. This matches literal global norm behavior and avoids redundant grouped norm work in the d5120/L8 profile path. Adds focused optimizer composition tests.

Part of #6139