### PR TITLE
fix: handle LoraLinear in get_lm_head() and resize_vocab() across model classes

### DIFF
--- a/lib/levanter/src/levanter/adaptor/lora.py
+++ b/lib/levanter/src/levanter/adaptor/lora.py
@@ -42,6 +42,7 @@ Consider a simple model with two parameters, attention and mlp. That might look 
    ```
  which just grounds out into a call to [equinox.combine][]
 """
+
 import dataclasses
 import functools
 import json
@@ -49,7 +50,7 @@ import logging
 import os
 import re
 from dataclasses import dataclass
-from typing import Callable, Dict, List, Literal, Optional, Tuple, TypeVar, Union
+from typing import Callable, Dict, List, Literal, Optional, Tuple, TypeVar, Union, cast
 
 import equinox as eqx
 import jax
@@ -131,19 +132,11 @@ class LoraConfig:
       controlled by :attr:`zero_init_b`.
     """
     exclude_modules: Optional[List[str]] = None
-    """modules to exclude from LoRA. Defaults to ["lm_head"] to avoid breaking get_lm_head().weight access."""
+    """modules to exclude from LoRA. Defaults to [], so all matched linear modules are eligible."""
     # TODO: bias
-    # TODO(IMPORTANT): lm_head is excluded by default because every model's get_lm_head() does
-    # `self.lm_head.weight`, which breaks when lm_head is a LoraLinear (no .weight attribute).
-    # The proper fix is to update get_lm_head() in ALL model classes (llama, qwen, gemma, mixtral,
-    # olmo, olmo3, apertus, mistral) to handle LoraLinear, e.g.:
-    #     if isinstance(self.lm_head, LoraLinear): return self.lm_head.wrapped.weight
-    # This would allow LoRA on lm_head, which some research suggests is beneficial
-    # (Thinking Machines 2025: "apply LoRA to all weight matrices").
-    # See also: resize_vocab() has the same .weight assumption.
 
     def matches_target(self, key_path):
-        excludes = self.exclude_modules if self.exclude_modules is not None else ["lm_head"]
+        excludes = self.exclude_modules if self.exclude_modules is not None else []
         if any(key_path.endswith(exc) for exc in excludes):
             return False
         if isinstance(self.target_modules, str):
@@ -247,7 +240,6 @@ class LoraLinear(ModuleWithStateDictSerialization):
             k1, k2 = jax.random.split(key)
             return self.lora(x, key=k2) + self.wrapped(x, key=k1)
         else:
-
             return self.lora(x) + self.wrapped(x)
 
     def merge(self):
@@ -283,6 +275,46 @@ class LoraLinear(ModuleWithStateDictSerialization):
 
     def _state_dict_key_map(self) -> Dict[str, Optional[str]]:
         return {"wrapped": None, "lora": None}
+
+
+LinearOrLoraT = TypeVar("LinearOrLoraT", hnn.Linear, LoraLinear)
+
+
+def lora_or_linear_weight(linear: Union[hnn.Linear, LoraLinear]) -> hax.NamedArray:
+    """Return the base weight for a plain or LoRA-wrapped linear layer."""
+    if isinstance(linear, LoraLinear):
+        return linear.wrapped.weight
+    return linear.weight
+
+
+def lora_or_linear_bias(linear: Union[hnn.Linear, LoraLinear]) -> Optional[hax.NamedArray]:
+    """Return the base bias for a plain or LoRA-wrapped linear layer."""
+    if isinstance(linear, LoraLinear):
+        return linear.wrapped.bias
+    return linear.bias
+
+
+def resize_lora_or_linear_output(
+    linear: LinearOrLoraT,
+    old_axis: Axis,
+    new_axis: Axis,
+    *,
+    key=None,
+) -> LinearOrLoraT:
+    """Resize a plain or LoRA-wrapped linear layer along its output axis."""
+    if isinstance(linear, LoraLinear):
+        k_wrapped, k_lora = (None, None) if key is None else jax.random.split(key, 2)
+        new_wrapped_weight = hax.tree_util.resize_axis(linear.wrapped.weight, old_axis, new_axis.size, key=k_wrapped)
+        new_wrapped = dataclasses.replace(linear.wrapped, Out=new_axis, weight=new_wrapped_weight)
+
+        new_lora_b_weight = hax.tree_util.resize_axis(linear.lora.lora_B.weight, old_axis, new_axis.size, key=k_lora)
+        new_lora_b = dataclasses.replace(linear.lora.lora_B, Out=new_axis, weight=new_lora_b_weight)
+        new_lora = dataclasses.replace(linear.lora, lora_B=new_lora_b)
+
+        return cast(LinearOrLoraT, dataclasses.replace(linear, wrapped=new_wrapped, lora=new_lora))
+
+    new_weight = hax.tree_util.resize_axis(linear.weight, old_axis, new_axis.size, key=key)
+    return cast(LinearOrLoraT, dataclasses.replace(linear, Out=new_axis, weight=new_weight))
 
 
 def _is_lora_compatible_module(module):
@@ -444,6 +476,7 @@ COMMON_LORA_TARGET_MODULE_ORDER = (
     "gate_proj",
     "up_proj",
     "down_proj",
+    "lm_head",
 )
 LORA_TARGET_MODULE_RE = re.compile(r"\.([^.]+)\.lora_[AB]\.weight$")
 

--- a/lib/levanter/src/levanter/models/apertus.py
+++ b/lib/levanter/src/levanter/models/apertus.py
@@ -16,6 +16,7 @@ from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
 from haliax.nn.scan import BlockFoldable, BlockSeq, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
+from levanter.adaptor.lora import lora_or_linear_weight, resize_lora_or_linear_output
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.inference.page_table import PageBatchInfo, PageTableSpec
 from levanter.layers.attention import Attention, AttentionMask
@@ -443,15 +444,14 @@ class ApertusLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[ApertusCo
         if self.lm_head is None:
             return self.embeddings.token_embeddings.weight
         else:
-            return self.lm_head.weight
+            return lora_or_linear_weight(self.lm_head)
 
     def resize_vocab(self, new_size: int, key=None) -> "LmHeadModel[ApertusConfig]":
         new_Vocab = self.Vocab.resize(new_size)
         k1, k2 = maybe_rng_split(key, 2)
         new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
         if self.lm_head is not None:
-            new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
-            new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+            new_lm_head = resize_lora_or_linear_output(self.lm_head, self.Vocab, new_Vocab, key=k2)
             return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
         else:
             return dataclasses.replace(self, embeddings=new_embeddings)

--- a/lib/levanter/src/levanter/models/gemma.py
+++ b/lib/levanter/src/levanter/models/gemma.py
@@ -16,6 +16,7 @@ from haliax.nn.normalization import LayerNormBase
 from haliax.nn.scan import BlockFoldable, BlockSeq, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
+from levanter.adaptor.lora import lora_or_linear_weight, resize_lora_or_linear_output
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
 from levanter.layers.attention import Attention, AttentionBackend, AttentionConfig, AttentionMask
 from levanter.layers.normalization import LayerNormConfigBase
@@ -391,7 +392,7 @@ class GemmaLMHeadModel(LmHeadModel[GemmaConfig], ModuleWithStateDictSerializatio
         if self.lm_head is None:
             return self.embeddings.token_embeddings.weight
         else:
-            return self.lm_head.weight
+            return lora_or_linear_weight(self.lm_head)
 
     @classmethod
     def init(cls, Vocab: Axis, config: GemmaConfig, *, key) -> "GemmaLMHeadModel":
@@ -431,8 +432,7 @@ class GemmaLMHeadModel(LmHeadModel[GemmaConfig], ModuleWithStateDictSerializatio
         k1, k2 = maybe_rng_split(key, 2)
         new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
         if self.lm_head is not None:
-            new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
-            new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+            new_lm_head = resize_lora_or_linear_output(self.lm_head, self.Vocab, new_Vocab, key=k2)
             return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
         else:
             return dataclasses.replace(self, embeddings=new_embeddings)
@@ -728,7 +728,7 @@ class Gemma2LMHeadModel(LmHeadModel[Gemma2Config], ModuleWithStateDictSerializat
         if self.lm_head is None:
             return self.embeddings.token_embeddings.weight
         else:
-            return self.lm_head.weight
+            return lora_or_linear_weight(self.lm_head)
 
     @classmethod
     def init(cls, Vocab: Axis, config: GemmaConfig, *, key):
@@ -760,8 +760,7 @@ class Gemma2LMHeadModel(LmHeadModel[Gemma2Config], ModuleWithStateDictSerializat
         k1, k2 = maybe_rng_split(key, 2)
         new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
         if self.lm_head is not None:
-            new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
-            new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+            new_lm_head = resize_lora_or_linear_output(self.lm_head, self.Vocab, new_Vocab, key=k2)
             return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
         else:
             return dataclasses.replace(self, embeddings=new_embeddings)
@@ -951,7 +950,7 @@ class Gemma3LMHeadModel(LmHeadModel[Gemma3Config], ModuleWithStateDictSerializat
         if self.lm_head is None:
             return self.embeddings.token_embeddings.weight
         else:
-            return self.lm_head.weight
+            return lora_or_linear_weight(self.lm_head)
 
     @classmethod
     def init(cls, Vocab: Axis, config: Gemma3Config, *, key):
@@ -983,8 +982,7 @@ class Gemma3LMHeadModel(LmHeadModel[Gemma3Config], ModuleWithStateDictSerializat
         k1, k2 = maybe_rng_split(key, 2)
         new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
         if self.lm_head is not None:
-            new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
-            new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+            new_lm_head = resize_lora_or_linear_output(self.lm_head, self.Vocab, new_Vocab, key=k2)
             return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
         else:
             return dataclasses.replace(self, embeddings=new_embeddings)

--- a/lib/levanter/src/levanter/models/llama.py
+++ b/lib/levanter/src/levanter/models/llama.py
@@ -17,6 +17,7 @@ from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
 from haliax.nn.scan import BlockFoldable, BlockSeq, ScanCheckpointPolicy, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
+from levanter.adaptor.lora import lora_or_linear_weight, resize_lora_or_linear_output
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
 from levanter.inference.page_table import PageBatchInfo, PageTableSpec
 from levanter.layers import LayerNormConfigBase, RmsNormConfig
@@ -596,15 +597,14 @@ class LlamaLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[LlamaConfig
         if self.lm_head is None:
             return self.embeddings.token_embeddings.weight
         else:
-            return self.lm_head.weight
+            return lora_or_linear_weight(self.lm_head)
 
     def resize_vocab(self, new_size: int, key=None) -> "LmHeadModel[LlamaConfig]":
         new_Vocab = self.Vocab.resize(new_size)
         k1, k2 = maybe_rng_split(key, 2)
         new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
         if self.lm_head is not None:
-            new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
-            new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+            new_lm_head = resize_lora_or_linear_output(self.lm_head, self.Vocab, new_Vocab, key=k2)
             return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
         else:
             return dataclasses.replace(self, embeddings=new_embeddings)

--- a/lib/levanter/src/levanter/models/mistral.py
+++ b/lib/levanter/src/levanter/models/mistral.py
@@ -13,6 +13,7 @@ from haliax import Axis, NamedArray
 from haliax.jax_utils import maybe_rng_split
 from haliax.state_dict import ModuleWithStateDictSerialization
 
+from levanter.adaptor.lora import lora_or_linear_bias, lora_or_linear_weight, resize_lora_or_linear_output
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.layers.attention import AttentionBackend, AttentionConfig, AttentionMask
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
@@ -199,8 +200,8 @@ class MistralLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[MistralCo
         return MistralLMHeadModel(transformer, embeddings, lm_head)
 
     def get_lm_head(self) -> hax.NamedArray:
-        assert self.lm_head.bias is None
-        return self.lm_head.weight
+        assert lora_or_linear_bias(self.lm_head) is None
+        return lora_or_linear_weight(self.lm_head)
 
     def activations(
         self,
@@ -227,8 +228,7 @@ class MistralLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[MistralCo
         new_Vocab = self.Vocab.resize(new_size)
         k1, k2 = maybe_rng_split(key, 2)
         new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
-        new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
-        new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+        new_lm_head = resize_lora_or_linear_output(self.lm_head, self.Vocab, new_Vocab, key=k2)
 
         return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
 

--- a/lib/levanter/src/levanter/models/mixtral.py
+++ b/lib/levanter/src/levanter/models/mixtral.py
@@ -23,6 +23,7 @@ from haliax.nn.scan import BlockFoldable, BlockSeq, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization, StateDict
 
 import levanter.tracker
+from levanter.adaptor.lora import lora_or_linear_weight, resize_lora_or_linear_output
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.layers.attention import Attention, AttentionBackend, AttentionConfig, AttentionMask
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
@@ -657,15 +658,14 @@ class MixtralLMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[MixtralCo
         if self.lm_head is None:
             return self.embeddings.token_embeddings.weight
         else:
-            return self.lm_head.weight
+            return lora_or_linear_weight(self.lm_head)
 
     def resize_vocab(self, new_size: int, key=None) -> "LmHeadModel[MixtralConfig]":
         new_Vocab = self.Vocab.resize(new_size)
         k1, k2 = maybe_rng_split(key, 2)
         new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
         if self.lm_head is not None:
-            new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
-            new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+            new_lm_head = resize_lora_or_linear_output(self.lm_head, self.Vocab, new_Vocab, key=k2)
             return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
         else:
             return dataclasses.replace(self, embeddings=new_embeddings)

--- a/lib/levanter/src/levanter/models/olmo.py
+++ b/lib/levanter/src/levanter/models/olmo.py
@@ -17,6 +17,7 @@ from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
 from haliax.nn.scan import BlockSeq, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
+from levanter.adaptor.lora import lora_or_linear_weight, resize_lora_or_linear_output
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
 from levanter.layers import RmsNormConfig
 from levanter.layers.attention import (
@@ -552,15 +553,14 @@ class Olmo2LMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[Olmo2Config
         if self.lm_head is None:
             return self.embeddings.token_embeddings.weight
         else:
-            return self.lm_head.weight
+            return lora_or_linear_weight(self.lm_head)
 
     def resize_vocab(self, new_size: int, key=None) -> "LmHeadModel[Olmo2Config]":
         new_Vocab = self.Vocab.resize(new_size)
         k1, k2 = maybe_rng_split(key, 2)
         new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
         if self.lm_head is not None:
-            new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
-            new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+            new_lm_head = resize_lora_or_linear_output(self.lm_head, self.Vocab, new_Vocab, key=k2)
             return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
         else:
             return dataclasses.replace(self, embeddings=new_embeddings)

--- a/lib/levanter/src/levanter/models/olmo3.py
+++ b/lib/levanter/src/levanter/models/olmo3.py
@@ -23,6 +23,7 @@ from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
 from haliax.nn.scan import BlockFoldable, BlockSeq, ScanCheckpointPolicy, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
+from levanter.adaptor.lora import lora_or_linear_weight, resize_lora_or_linear_output
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
 from levanter.layers import RmsNormConfig
 from levanter.layers.attention import Attention, AttentionBackend, AttentionConfig, AttentionMask
@@ -404,15 +405,14 @@ class Olmo3LMHeadModel(ModuleWithStateDictSerialization, LmHeadModel[Olmo3Config
         if self.lm_head is None:
             return self.embeddings.token_embeddings.weight
         else:
-            return self.lm_head.weight
+            return lora_or_linear_weight(self.lm_head)
 
     def resize_vocab(self, new_size: int, key=None) -> "LmHeadModel[Olmo3Config]":
         new_Vocab = self.Vocab.resize(new_size)
         k1, k2 = maybe_rng_split(key, 2)
         new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
         if self.lm_head is not None:
-            new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
-            new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+            new_lm_head = resize_lora_or_linear_output(self.lm_head, self.Vocab, new_Vocab, key=k2)
             return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
         else:
             return dataclasses.replace(self, embeddings=new_embeddings)

--- a/lib/levanter/src/levanter/models/qwen.py
+++ b/lib/levanter/src/levanter/models/qwen.py
@@ -15,6 +15,7 @@ from haliax.jax_utils import maybe_rng_split, named_call, shaped_rng_split
 from haliax.nn.scan import BlockFoldable, BlockSeq, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
+from levanter.adaptor.lora import lora_or_linear_weight, resize_lora_or_linear_output
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.layers.attention import Attention, AttentionConfig, AttentionMask
 from levanter.layers.rotary import RotaryEmbeddingsConfig
@@ -258,15 +259,14 @@ class QwenLMHeadModel(LmHeadModel[QwenConfig], ModuleWithStateDictSerialization)
         if self.lm_head is None:
             return self.embeddings.token_embeddings.weight
         else:
-            return self.lm_head.weight
+            return lora_or_linear_weight(self.lm_head)
 
     def resize_vocab(self, new_size: int, key=None) -> "LmHeadModel[LlamaConfig]":
         new_Vocab = self.Vocab.resize(new_size)
         k1, k2 = maybe_rng_split(key, 2)
         new_embeddings = self.embeddings.resize_embeddings(new_size, key=k1)
         if self.lm_head is not None:
-            new_lm_matrix = hax.tree_util.resize_axis(self.lm_head.weight, self.Vocab, new_size, key=k2)
-            new_lm_head = dataclasses.replace(self.lm_head, Out=new_Vocab, weight=new_lm_matrix)
+            new_lm_head = resize_lora_or_linear_output(self.lm_head, self.Vocab, new_Vocab, key=k2)
             return dataclasses.replace(self, embeddings=new_embeddings, lm_head=new_lm_head)
         else:
             return dataclasses.replace(self, embeddings=new_embeddings)

--- a/lib/levanter/tests/test_lora.py
+++ b/lib/levanter/tests/test_lora.py
@@ -10,6 +10,7 @@ import haliax.nn as hnn
 import jax
 import numpy as np
 import optax
+import pytest
 from chex import assert_trees_all_close
 from haliax.quantization import DefaultDotGeneralOp, DotGeneralOp
 from safetensors import safe_open
@@ -29,14 +30,151 @@ from levanter.adaptor.lora import (
     save_merged_hf_model,
     save_peft_pretrained,
 )
+from levanter.models.apertus import ApertusConfig, ApertusLMHeadModel
+from levanter.models.gemma import (
+    Gemma2Config,
+    Gemma2LMHeadModel,
+    Gemma3Config,
+    Gemma3LMHeadModel,
+    GemmaConfig,
+    GemmaLMHeadModel,
+)
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
 from levanter.models.llama import LlamaConfig, LlamaLMHeadModel
+from levanter.models.mistral import MistralConfig, MistralLMHeadModel
+from levanter.models.mixtral import MixtralConfig, MixtralLMHeadModel
+from levanter.models.olmo import Olmo2Config, Olmo2LMHeadModel
+from levanter.models.olmo3 import Olmo3Config, Olmo3LMHeadModel
+from levanter.models.qwen import QwenConfig, QwenLMHeadModel
 from levanter.trainer_state import TrainerState
 from levanter.utils.tree_utils import inference_mode
 
 In = hax.Axis("In", 10)
 Mid = hax.Axis("Mid", 20)
 Out = hax.Axis("Out", 5)
+
+
+def _tiny_llama_config(config_cls):
+    return config_cls(
+        max_seq_len=16,
+        hidden_dim=16,
+        intermediate_dim=32,
+        num_layers=1,
+        num_heads=4,
+        num_kv_heads=2,
+        gradient_checkpointing=False,
+        scan_layers=False,
+        tie_word_embeddings=False,
+    )
+
+
+def _tiny_gemma_config(config_cls):
+    return config_cls(
+        max_seq_len=16,
+        hidden_dim=16,
+        intermediate_dim=32,
+        num_layers=1,
+        num_heads=4,
+        head_dim=4,
+        num_kv_heads=2,
+        gradient_checkpointing=False,
+        scan_layers=False,
+        tie_word_embeddings=False,
+    )
+
+
+def _tiny_mixtral_config():
+    return MixtralConfig(
+        max_seq_len=16,
+        hidden_dim=16,
+        intermediate_dim=32,
+        num_layers=1,
+        num_heads=4,
+        num_kv_heads=2,
+        gradient_checkpointing=False,
+        scan_layers=False,
+        tie_word_embeddings=False,
+        n_routed_experts=2,
+        num_experts_per_tok=1,
+    )
+
+
+LM_HEAD_MODEL_CASES = [
+    pytest.param(LlamaLMHeadModel, _tiny_llama_config(LlamaConfig), id="llama"),
+    pytest.param(QwenLMHeadModel, _tiny_llama_config(QwenConfig), id="qwen"),
+    pytest.param(GemmaLMHeadModel, _tiny_gemma_config(GemmaConfig), id="gemma"),
+    pytest.param(Gemma2LMHeadModel, _tiny_gemma_config(Gemma2Config), id="gemma2"),
+    pytest.param(Gemma3LMHeadModel, _tiny_gemma_config(Gemma3Config), id="gemma3"),
+    pytest.param(MixtralLMHeadModel, _tiny_mixtral_config(), id="mixtral"),
+    pytest.param(Olmo2LMHeadModel, _tiny_llama_config(Olmo2Config), id="olmo2"),
+    pytest.param(Olmo3LMHeadModel, _tiny_llama_config(Olmo3Config), id="olmo3"),
+    pytest.param(ApertusLMHeadModel, _tiny_llama_config(ApertusConfig), id="apertus"),
+    pytest.param(MistralLMHeadModel, _tiny_llama_config(MistralConfig), id="mistral"),
+]
+
+
+@pytest.mark.parametrize("model_cls, config", LM_HEAD_MODEL_CASES)
+@pytest.mark.parametrize("loraize_lm_head", [False, True])
+def test_lora_lm_head_getter_and_resize(model_cls, config, loraize_lm_head):
+    vocab = hax.Axis("vocab", 32)
+    model = model_cls.init(vocab, config=config, key=jax.random.PRNGKey(0))
+    assert model.lm_head is not None
+
+    if loraize_lm_head:
+        model = loraize(
+            model,
+            LoraConfig(r=4, target_modules=["lm_head"], a_init_mode="random"),
+            key=jax.random.PRNGKey(1),
+        )
+        assert isinstance(model.lm_head, LoraLinear)
+        assert model.get_lm_head() is model.lm_head.wrapped.weight
+    else:
+        assert isinstance(model.lm_head, hnn.Linear)
+        assert model.get_lm_head() is model.lm_head.weight
+
+    resized = model.resize_vocab(40, key=jax.random.PRNGKey(2))
+    assert resized.Vocab == hax.Axis("vocab", 40)
+    assert resized.Vocab in resized.get_lm_head().axes
+
+    x = hax.random.normal(jax.random.PRNGKey(3), (resized.Embed,))
+    y = resized.lm_head(x, key=jax.random.PRNGKey(4))
+    assert resized.Vocab in y.axes
+
+    if loraize_lm_head:
+        assert isinstance(resized.lm_head, LoraLinear)
+        assert resized.lm_head.wrapped.Out == resized.Vocab
+        assert resized.lm_head.lora.lora_B.Out == resized.Vocab
+        assert resized.get_lm_head() is resized.lm_head.wrapped.weight
+    else:
+        assert isinstance(resized.lm_head, hnn.Linear)
+        assert resized.lm_head.Out == resized.Vocab
+        assert resized.get_lm_head() is resized.lm_head.weight
+
+
+def test_lora_lm_head_is_included_by_default_and_merges():
+    config = LlamaConfig(
+        max_seq_len=16,
+        hidden_dim=16,
+        intermediate_dim=32,
+        num_layers=1,
+        num_heads=4,
+        num_kv_heads=2,
+        gradient_checkpointing=False,
+        scan_layers=False,
+    )
+    vocab = hax.Axis("vocab", 32)
+    model = LlamaLMHeadModel.init(vocab, config=config, key=jax.random.PRNGKey(0))
+
+    loraized = loraize(model, LoraConfig(r=4, a_init_mode="random"), key=jax.random.PRNGKey(1))
+    assert isinstance(loraized.lm_head, LoraLinear)
+
+    merged = merge_lora_modules(loraized)
+    input_ids = hax.random.randint(jax.random.PRNGKey(2), config.max_Pos.resize(4), 0, vocab.size)
+    attn_mask = AttentionMask.causal()
+
+    loraized_out = loraized(input_ids, attn_mask=attn_mask, key=jax.random.PRNGKey(3))
+    merged_out = merged(input_ids, attn_mask=attn_mask, key=jax.random.PRNGKey(3))
+    assert_trees_all_close(loraized_out, merged_out, rtol=1e-4, atol=1e-4)
 
 
 def test_loraize_simple():
@@ -270,7 +408,7 @@ def test_lora_merged_load_in_hf_llama():
     lora_config = LoraConfig(
         r=8,
         alpha=8,
-        target_modules=["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj"],
+        target_modules=["q_proj", "k_proj", "v_proj", "o_proj", "gate_proj", "up_proj", "down_proj", "lm_head"],
         a_init_mode="random",
     )
 
@@ -330,12 +468,14 @@ def test_lora_peft_export_uses_hf_llama_keys_and_target_modules(tmp_path):
         "gate_proj",
         "up_proj",
         "down_proj",
+        "lm_head",
     ]
 
     with safe_open(tmp_path / "adapter_model.safetensors", framework="numpy") as tensors:
         keys = list(tensors.keys())
 
     assert "base_model.model.model.layers.0.self_attn.q_proj.lora_A.weight" in keys
+    assert "base_model.model.lm_head.lora_A.weight" in keys
     assert all("base_model.model.transformer." not in key for key in keys)
 
 


### PR DESCRIPTION
## Summary

Lets LoRA wrap `lm_head` instead of being forced to exclude it, by making the weight/bias accessors and vocab resize aware of `LoraLinear` heads.

## Why

Every model's `get_lm_head()` read `self.lm_head.weight` directly, which has no `.weight` when `lm_head` is a `LoraLinear` (the base weight lives at `.wrapped.weight`), and `resize_vocab()` made the same assumption. Because of this, `LoraConfig.exclude_modules` defaulted to `["lm_head"]` with a `TODO(IMPORTANT)`, so LoRA could never adapt the output head. Issue #6104 asks to remove that limitation so `lm_head` can be a LoRA target.

## Description

LoRA can now wrap `lm_head` instead of being forced to exclude it. Every model's `get_lm_head()` read `self.lm_head.weight` directly, which has no `.weight` when `lm_head` is a `LoraLinear` (the base weight lives at `.wrapped.weight`), and `resize_vocab()` made the same assumption, so `LoraConfig.exclude_modules` defaulted to `["lm_head"]` with a TODO(IMPORTANT) in `lib/levanter/src/levanter/adaptor/lora.py`.

This adds `lora_or_linear_weight()` / `lora_or_linear_bias()` accessors and a `resize_lora_or_linear_output()` helper in `lora.py` that branch on `isinstance(linear, LoraLinear)`, and routes `get_lm_head()` and `resize_vocab()` through them across the eight model classes (llama, qwen, gemma, mixtral, olmo, olmo3, apertus, mistral). The `get_lm_head()` return stays a `hax.NamedArray`, so eval_harness, train_lm, viz_logprobs, and rl_losses are unaffected. With both accessors LoraLinear-aware, `"lm_head"` is dropped from the default `exclude_modules` and added to `COMMON_LORA_TARGET_MODULE_ORDER`.

Tests in `lib/levanter/tests/test_lora.py` parametrize across the eight model classes and exercise `get_lm_head()` with and without a LoraLinear head, plus `resize_vocab()` for the wrapped and plain cases. Covered by the new and updated tests in this PR; full suite runs in CI.

Fixes #6104
