### PR TITLE
[iris] Fix flaky 500s proxying dashboard assets through the endpoint proxy

### DIFF
--- a/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
+++ b/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
@@ -104,7 +104,14 @@ _LOCATION_HEADERS: frozenset[str] = frozenset({"location", "content-location"})
 
 # Bound the connection pool explicitly so httpx default drift cannot silently
 # change resource usage on the controller.
-_HTTPX_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=20)
+#
+# max_keepalive_connections=0 disables connection reuse to upstreams. Reuse
+# races with upstream keepalive lifecycle — the browser fires a burst of asset
+# requests and cancels in-flight ones on refresh, leaving a pooled connection
+# half-read; the next request on it fails mid-stream with httpx.ReadError, which
+# surfaces as an uncaught 500. Dashboard-proxy traffic is low, so a fresh
+# connection per request is a fine trade for eliminating that flakiness.
+_HTTPX_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=0)
 
 
 def _build_forwarded_headers(request: Request, *, proxy_prefix: str) -> dict[str, str]:
@@ -171,6 +178,21 @@ def _rewrite_location(loc: str, *, upstream_base: str, proxy_prefix: str) -> str
         return urlunsplit(("", "", new_path, parsed.query, parsed.fragment))
 
     return loc
+
+
+def _request_has_body(request: Request) -> bool:
+    """Whether the inbound request carries a body to forward upstream.
+
+    A body is present when Content-Length is non-zero or Transfer-Encoding is
+    set. Bodyless requests (typically GET/HEAD) must NOT be forwarded with a
+    streamed body: ``content=request.stream()`` makes httpx frame an empty
+    chunked body, which some upstreams (e.g. hyper) answer by closing the
+    connection — poisoning a reused keepalive connection for the next request.
+    """
+    content_length = request.headers.get("content-length")
+    if content_length is not None and content_length != "0":
+        return True
+    return "transfer-encoding" in request.headers
 
 
 class EndpointProxy:
@@ -250,11 +272,15 @@ class EndpointProxy:
         forward_headers = {k: v for k, v in request.headers.items() if k.lower() not in _HOP_BY_HOP}
         forward_headers.update(_build_forwarded_headers(request, proxy_prefix=proxy_prefix))
 
+        # Only forward a body when the request has one; a bodyless GET sent with
+        # content=request.stream() becomes a chunked empty body (see
+        # _request_has_body). content=None is httpx's "no body".
+        body = request.stream() if _request_has_body(request) else None
         upstream_req = self._client.build_request(
             request.method,
             upstream_url,
             headers=forward_headers,
-            content=request.stream(),
+            content=body,
         )
         try:
             upstream_resp = await self._client.send(upstream_req, stream=True)

--- a/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
@@ -294,6 +294,24 @@ def test_round_trip_post_body(proxy: ProxyHandle) -> None:
     assert proxy.upstream.received_bodies[-1] == payload
 
 
+def test_bodyless_get_forwards_no_chunked_body(proxy: ProxyHandle) -> None:
+    """A bodyless GET must reach the upstream with no request body.
+
+    Forwarding ``content=request.stream()`` for a bodyless GET made httpx frame
+    an empty *chunked* body (``Transfer-Encoding: chunked``), which some
+    upstreams answer by closing the connection — poisoning a reused keepalive
+    connection so the next request fails mid-stream. The proxy must forward no
+    body for a request that has none.
+    """
+    with httpx.Client() as client:
+        resp = client.get(f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/echo")
+    assert resp.status_code == 200
+    assert resp.json()["body_len"] == 0
+    upstream_headers = proxy.upstream.received_headers[-1]
+    assert "transfer-encoding" not in upstream_headers
+    assert upstream_headers.get("content-length", "0") == "0"
+
+
 def test_streams_large_response(proxy: ProxyHandle) -> None:
     # Stream-read; assert we can pull bytes incrementally and that the total
     # equals the upstream's 9 MiB without tripping any internal cap.


### PR DESCRIPTION
The dashboard endpoint proxy forwarded a streamed body on every request, including bodyless GETs, which httpx frames as a chunked empty body. Upstreams that close the connection afterward poisoned the proxy's keepalive pool, so the next response read failed mid-stream with httpx.ReadError and surfaced as an uncaught 500 under the browser's concurrent asset burst. Forward a body only when one is present and disable upstream keepalive. Adds a regression test.
