### PR TITLE
[levanter] Add multi-prefill admission for serving

### DIFF
--- a/.agents/ops/2026-06-06-v6e-prefill-diagnostic.md
+++ b/.agents/ops/2026-06-06-v6e-prefill-diagnostic.md
@@ -1,10 +1,32 @@
-# Debugging log for v6e prefill-heavy diagnostics
+---
+date: 2026-06-06
+system: levanter
+severity: degraded
+resolution: mitigated
+pr: https://github.com/marin-community/marin/pull/6185
+issue: https://github.com/marin-community/marin/issues/6229
+---
 
-Investigate why the Levanter-only v6e diagnostic for
-`prefill_b8_i2048_o128_n1` reported slower `no_lm_head` and
-`lm_head_no_sampling` rows than the normal measured row.
+# V6e Prefill-Heavy Diagnostic
 
-## Initial status
+## TL;DR
+
+- The first Levanter-only diagnostic for `prefill_b8_i2048_o128_n1` was
+  confounded because diagnostic generation admitted one pending prefill per
+  outer iteration instead of draining all currently admissible prefills before
+  decode.
+- Updating `_generate_diagnostic()` to mirror production prefill-drain
+  scheduling made normal, `no_lm_head`, and `lm_head_no_sampling` rows use the
+  same `4096,4096,4096,4096` prefill chunks and `1022` decode iteration tokens.
+- Production `decode_submit_seconds_per_iteration` was also measuring from
+  before prefill drain; moving the submit timer to immediately before
+  `_run_generation_loop(...)` fixed that attribution.
+- The remaining ambiguity was that `decode_seconds_per_iteration` could still
+  include prefill-drain work in prefill-heavy cases, so #6185 now reports
+  separate `prefill_drain_*`, `generation_*`, and
+  `generation_tokens_per_second` fields.
+
+## Initial Status
 
 Iris job `/dlwh/qwen3-v6e8-prefilldiag-prefill-b8-i2048-o128-n1-20260606-1504`
 succeeded. The normal `levanter:auto` row decoded one `1022`-token iteration,
@@ -19,7 +41,7 @@ prefill admissions, that makes the diagnostic rows decode after each pending
 prefill admission instead of after all currently admissible prefill work is
 queued.
 
-## Changes to make
+## Changes To Make
 
 Update `_generate_diagnostic()` in `levanter.inference.engine` so it drains all
 pending prefill admissions before each diagnostic decode submission, matching
@@ -33,7 +55,7 @@ Focused validation passed:
 
 - `uv run --package marin-levanter --group test pytest lib/levanter/tests/inference/test_engine.py -q`
   passed with `12 passed`.
-- `./infra/pre-commit.py --files lib/levanter/src/levanter/inference/engine.py lib/levanter/tests/inference/test_engine.py docs/debug-log-v6e-prefill-diagnostic.md --fix`
+- `./infra/pre-commit.py --files lib/levanter/src/levanter/inference/engine.py lib/levanter/tests/inference/test_engine.py .agents/ops/2026-06-06-v6e-prefill-diagnostic.md --fix`
   passed.
 
 ## Hypothesis 2
@@ -46,14 +68,14 @@ before submitting the diagnostic decode loop. The production metric therefore
 included prefill admission work and was not directly comparable to the
 diagnostic submit field.
 
-## Changes to make
+## Changes To Make
 
 Start the production `decode_submit_seconds_per_iteration` timer immediately
 before `_run_generation_loop(...)`, after pending prefill admissions have been
 drained. This preserves serving behavior and fixes metric attribution for
 future benchmark rows.
 
-## Future work
+## Future Work
 
 - [ ] Rerun one corrected Levanter-only v6e diagnostic if clean LM-head and
       sampling attribution is still needed.
@@ -67,7 +89,7 @@ iteration, before pending prefill admissions are drained. For
 can include prefill-drain work, even when `decode_submit_seconds_per_iteration`
 is correctly measured around `_run_generation_loop(...)`.
 
-## Changes to make
+## Changes To Make
 
 Add per-iteration metric fields that separate prefill drain from the generation
 loop itself:

--- a/docs/debug-log-v6e-prefill-diagnostic.md
+++ b/docs/debug-log-v6e-prefill-diagnostic.md
@@ -1,0 +1,42 @@
+# Debugging log for v6e prefill-heavy diagnostics
+
+Investigate why the Levanter-only v6e diagnostic for
+`prefill_b8_i2048_o128_n1` reported slower `no_lm_head` and
+`lm_head_no_sampling` rows than the normal measured row.
+
+## Initial status
+
+Iris job `/dlwh/qwen3-v6e8-prefilldiag-prefill-b8-i2048-o128-n1-20260606-1504`
+succeeded. The normal `levanter:auto` row decoded one `1022`-token iteration,
+while the diagnostic rows decoded `510,256,256` token groups. This made the
+diagnostic rows unsuitable for direct LM-head or sampling attribution.
+
+## Hypothesis 1
+
+The diagnostic generation path uses a different prefill-drain schedule than
+the production `generate()` path. In long-prompt cases split across several
+prefill admissions, that makes the diagnostic rows decode after each pending
+prefill admission instead of after all currently admissible prefill work is
+queued.
+
+## Changes to make
+
+Update `_generate_diagnostic()` in `levanter.inference.engine` so it drains all
+pending prefill admissions before each diagnostic decode submission, matching
+the production `generate()` scheduling shape. Tighten the diagnostic
+multi-prefill engine test to require one decode-token iteration for the small
+logical batch.
+
+## Results
+
+Focused validation passed:
+
+- `uv run --package marin-levanter --group test pytest lib/levanter/tests/inference/test_engine.py -q`
+  passed with `12 passed`.
+- `./infra/pre-commit.py --files lib/levanter/src/levanter/inference/engine.py lib/levanter/tests/inference/test_engine.py docs/debug-log-v6e-prefill-diagnostic.md --fix`
+  passed.
+
+## Future work
+
+- [ ] Rerun one corrected Levanter-only v6e diagnostic if clean LM-head and
+      sampling attribution is still needed.

--- a/docs/debug-log-v6e-prefill-diagnostic.md
+++ b/docs/debug-log-v6e-prefill-diagnostic.md
@@ -36,6 +36,23 @@ Focused validation passed:
 - `./infra/pre-commit.py --files lib/levanter/src/levanter/inference/engine.py lib/levanter/tests/inference/test_engine.py docs/debug-log-v6e-prefill-diagnostic.md --fix`
   passed.
 
+## Hypothesis 2
+
+The corrected diagnostic run showed production `levanter:auto` with high
+`decode submit s` while `lm_head_no_sampling` had near-zero submit time. Code
+inspection found that production `generate()` started the submit timer before
+draining pending prefills, while `_generate_diagnostic()` started it immediately
+before submitting the diagnostic decode loop. The production metric therefore
+included prefill admission work and was not directly comparable to the
+diagnostic submit field.
+
+## Changes to make
+
+Start the production `decode_submit_seconds_per_iteration` timer immediately
+before `_run_generation_loop(...)`, after pending prefill admissions have been
+drained. This preserves serving behavior and fixes metric attribution for
+future benchmark rows.
+
 ## Future work
 
 - [ ] Rerun one corrected Levanter-only v6e diagnostic if clean LM-head and

--- a/docs/debug-log-v6e-prefill-diagnostic.md
+++ b/docs/debug-log-v6e-prefill-diagnostic.md
@@ -57,3 +57,36 @@ future benchmark rows.
 
 - [ ] Rerun one corrected Levanter-only v6e diagnostic if clean LM-head and
       sampling attribution is still needed.
+
+## Hypothesis 3
+
+The corrected backend=both rerun exposed one more attribution ambiguity:
+`decode_seconds_per_iteration` still measures from the start of a generation
+iteration, before pending prefill admissions are drained. For
+`prefill_b8_i2048_o128_n1`, that means the reported decode iteration wall time
+can include prefill-drain work, even when `decode_submit_seconds_per_iteration`
+is correctly measured around `_run_generation_loop(...)`.
+
+## Changes to make
+
+Add per-iteration metric fields that separate prefill drain from the generation
+loop itself:
+
+- `prefill_drain_seconds_per_iteration`
+- `prefill_drain_tokens_per_iteration`
+- `generation_seconds_per_iteration`
+- `generation_host_seconds_per_iteration`
+- `generation_tokens_per_iteration`
+
+Plumb these through the OpenAI server metrics snapshot and benchmark
+`CaseResult`, and emit a derived `generation_tokens_per_second` field in
+`summary.json` and `summary.md`.
+
+## Results
+
+Focused validation passed:
+
+- `uv run --package marin-levanter --group test pytest lib/levanter/tests/inference/test_engine.py lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py -q`
+  passed with `63 passed`.
+- `./infra/pre-commit.py --files lib/levanter/src/levanter/inference/engine.py lib/levanter/src/levanter/inference/openai.py lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py lib/levanter/tests/inference/test_engine.py lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py --fix`
+  passed.

--- a/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
+++ b/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
@@ -280,6 +280,60 @@ def _poll_json(url: str, *, timeout: float) -> dict[str, Any]:
     raise TimeoutError(f"{url} did not become ready within {timeout}s; last_error={last_error}")
 
 
+def _poll_json_while_process_alive(url: str, *, timeout: float, process: subprocess.Popen) -> dict[str, Any]:
+    deadline = time.time() + timeout
+    last_error: Exception | None = None
+    while time.time() < deadline:
+        return_code = process.poll()
+        if return_code is not None:
+            raise RuntimeError(
+                f"process exited with code {return_code} before {url} became ready; last_error={last_error}"
+            )
+        try:
+            response = requests.get(url, timeout=5)
+            if response.status_code == 200:
+                return response.json()
+        except Exception as exc:
+            last_error = exc
+        time.sleep(2)
+    raise TimeoutError(f"{url} did not become ready within {timeout}s; last_error={last_error}")
+
+
+def _tail_text_file(path: Path, *, max_bytes: int = 12000) -> str:
+    if not path.exists():
+        return ""
+    with open(path, "rb") as f:
+        f.seek(0, os.SEEK_END)
+        size = f.tell()
+        f.seek(max(0, size - max_bytes), os.SEEK_SET)
+        return f.read().decode("utf-8", errors="replace").strip()
+
+
+def _vllm_startup_error_message(
+    *,
+    log_dir: Path,
+    cmd: list[str],
+    process_return_code: int | None,
+    cause: Exception,
+) -> str:
+    process_state = (
+        f"vLLM process exited with code {process_return_code}"
+        if process_return_code is not None
+        else "vLLM process was still running when startup timed out"
+    )
+    parts = [
+        f"vLLM failed to start. Logs: {log_dir}. Command: {' '.join(cmd)}",
+        f"{process_state}. Startup error: {cause}",
+    ]
+    stderr_tail = _tail_text_file(log_dir / "stderr.log")
+    if stderr_tail:
+        parts.append(f"stderr tail:\n{stderr_tail}")
+    stdout_tail = _tail_text_file(log_dir / "stdout.log")
+    if stdout_tail:
+        parts.append(f"stdout tail:\n{stdout_tail}")
+    return "\n\n".join(parts)
+
+
 def _prompt_for_token_count(tokenizer, target_tokens: int) -> tuple[str, int]:
     if target_tokens <= 0:
         raise ValueError("target_tokens must be positive")
@@ -1378,11 +1432,19 @@ def start_vllm_server(
         stderr.close()
 
     try:
-        payload = _poll_json(f"{base_url}/models", timeout=timeout)
+        payload = _poll_json_while_process_alive(f"{base_url}/models", timeout=timeout, process=process)
         model_id = str(payload["data"][0]["id"])
-    except Exception:
+    except Exception as exc:
+        process_return_code = process.poll()
         close()
-        raise RuntimeError(f"vLLM failed to start. Logs: {log_dir}. Command: {' '.join(cmd)}")
+        raise RuntimeError(
+            _vllm_startup_error_message(
+                log_dir=log_dir,
+                cmd=cmd,
+                process_return_code=process_return_code,
+                cause=exc,
+            )
+        ) from exc
 
     logger.info("Started vLLM server at %s with logs in %s", base_url, log_dir)
     return ServerHandle("vllm-tpu", base_url, model_id, close, cmd, supports_seed=False)

--- a/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
+++ b/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
@@ -115,6 +115,12 @@ class CaseResult:
     prefill_admissions: int | None = None
     prefill_prompt_tokens_per_admission: list[int] | None = None
     prefill_seconds_per_admission: list[float] | None = None
+    decode_seconds_per_iteration: list[float] | None = None
+    decode_device_seconds_per_iteration: list[float] | None = None
+    decode_host_seconds_per_iteration: list[float] | None = None
+    decode_submit_seconds_per_iteration: list[float] | None = None
+    decode_extract_seconds_per_iteration: list[float] | None = None
+    decode_tokens_per_iteration: list[int] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1056,7 +1062,7 @@ def run_case(
 
     elapsed = time.perf_counter() - start
     total_tokens = prompt_total + completion_total
-    prefill_admissions, prefill_chunks, prefill_seconds = _case_admission_metrics(handle.metrics_snapshot)
+    runtime_metrics = _case_runtime_metrics(handle.metrics_snapshot)
     return CaseResult(
         case_name=case.name,
         backend=handle.name,
@@ -1077,9 +1083,15 @@ def run_case(
         total_tokens_per_second=total_tokens / elapsed if elapsed > 0 else 0.0,
         hbm_used_bytes=handle.hbm_used_bytes,
         compiled_shape_count=handle.compiled_shape_count,
-        prefill_admissions=prefill_admissions,
-        prefill_prompt_tokens_per_admission=prefill_chunks,
-        prefill_seconds_per_admission=prefill_seconds,
+        prefill_admissions=runtime_metrics.prefill_admissions,
+        prefill_prompt_tokens_per_admission=runtime_metrics.prefill_prompt_tokens_per_admission,
+        prefill_seconds_per_admission=runtime_metrics.prefill_seconds_per_admission,
+        decode_seconds_per_iteration=runtime_metrics.decode_seconds_per_iteration,
+        decode_device_seconds_per_iteration=runtime_metrics.decode_device_seconds_per_iteration,
+        decode_host_seconds_per_iteration=runtime_metrics.decode_host_seconds_per_iteration,
+        decode_submit_seconds_per_iteration=runtime_metrics.decode_submit_seconds_per_iteration,
+        decode_extract_seconds_per_iteration=runtime_metrics.decode_extract_seconds_per_iteration,
+        decode_tokens_per_iteration=runtime_metrics.decode_tokens_per_iteration,
     )
 
 
@@ -1112,19 +1124,60 @@ def _stress_service_static_metric(
     return None if value is None else int(value)
 
 
-def _case_admission_metrics(
-    metrics_snapshot: Callable[[], dict[str, Any]] | None,
-) -> tuple[int | None, list[int] | None, list[float] | None]:
+@dataclass(frozen=True, slots=True)
+class CaseRuntimeMetrics:
+    prefill_admissions: int | None
+    prefill_prompt_tokens_per_admission: list[int] | None
+    prefill_seconds_per_admission: list[float] | None
+    decode_seconds_per_iteration: list[float] | None
+    decode_device_seconds_per_iteration: list[float] | None
+    decode_host_seconds_per_iteration: list[float] | None
+    decode_submit_seconds_per_iteration: list[float] | None
+    decode_extract_seconds_per_iteration: list[float] | None
+    decode_tokens_per_iteration: list[int] | None
+
+
+def _optional_metric_float_list(metrics: dict[str, Any], key: str) -> list[float] | None:
+    value = metrics.get(key)
+    return None if value is None else [float(item) for item in value]
+
+
+def _optional_metric_int_list(metrics: dict[str, Any], key: str) -> list[int] | None:
+    value = metrics.get(key)
+    return None if value is None else [int(item) for item in value]
+
+
+def _case_runtime_metrics(metrics_snapshot: Callable[[], dict[str, Any]] | None) -> CaseRuntimeMetrics:
     if metrics_snapshot is None:
-        return None, None, None
+        return CaseRuntimeMetrics(
+            prefill_admissions=None,
+            prefill_prompt_tokens_per_admission=None,
+            prefill_seconds_per_admission=None,
+            decode_seconds_per_iteration=None,
+            decode_device_seconds_per_iteration=None,
+            decode_host_seconds_per_iteration=None,
+            decode_submit_seconds_per_iteration=None,
+            decode_extract_seconds_per_iteration=None,
+            decode_tokens_per_iteration=None,
+        )
     metrics = metrics_snapshot()
     admissions = metrics.get("prefill_admissions")
-    chunks = metrics.get("prefill_prompt_tokens_per_admission")
-    seconds = metrics.get("prefill_seconds_per_admission")
-    return (
-        None if admissions is None else int(admissions),
-        None if chunks is None else [int(chunk) for chunk in chunks],
-        None if seconds is None else [float(second) for second in seconds],
+    return CaseRuntimeMetrics(
+        prefill_admissions=None if admissions is None else int(admissions),
+        prefill_prompt_tokens_per_admission=_optional_metric_int_list(metrics, "prefill_prompt_tokens_per_admission"),
+        prefill_seconds_per_admission=_optional_metric_float_list(metrics, "prefill_seconds_per_admission"),
+        decode_seconds_per_iteration=_optional_metric_float_list(metrics, "decode_seconds_per_iteration"),
+        decode_device_seconds_per_iteration=_optional_metric_float_list(
+            metrics, "decode_device_seconds_per_iteration"
+        ),
+        decode_host_seconds_per_iteration=_optional_metric_float_list(metrics, "decode_host_seconds_per_iteration"),
+        decode_submit_seconds_per_iteration=_optional_metric_float_list(
+            metrics, "decode_submit_seconds_per_iteration"
+        ),
+        decode_extract_seconds_per_iteration=_optional_metric_float_list(
+            metrics, "decode_extract_seconds_per_iteration"
+        ),
+        decode_tokens_per_iteration=_optional_metric_int_list(metrics, "decode_tokens_per_iteration"),
     )
 
 
@@ -1437,6 +1490,12 @@ def run_levanter_without_lm_head_case(
         prefill_admissions=result.prefill_admissions,
         prefill_prompt_tokens_per_admission=result.prefill_prompt_tokens_per_admission,
         prefill_seconds_per_admission=result.prefill_seconds_per_admission,
+        decode_seconds_per_iteration=result.decode_seconds_per_iteration,
+        decode_device_seconds_per_iteration=result.decode_device_seconds_per_iteration,
+        decode_host_seconds_per_iteration=result.decode_host_seconds_per_iteration,
+        decode_submit_seconds_per_iteration=result.decode_submit_seconds_per_iteration,
+        decode_extract_seconds_per_iteration=result.decode_extract_seconds_per_iteration,
+        decode_tokens_per_iteration=result.decode_tokens_per_iteration,
     )
 
 
@@ -1685,6 +1744,18 @@ def start_levanter_server(
                 list(server.inference_context.last_prefill_prompt_tokens_per_admission)
             ),
             "prefill_seconds_per_admission": list(server.inference_context.last_prefill_seconds_per_admission),
+            "decode_seconds_per_iteration": list(server.inference_context.last_decode_seconds_per_iteration),
+            "decode_device_seconds_per_iteration": list(
+                server.inference_context.last_decode_device_seconds_per_iteration
+            ),
+            "decode_host_seconds_per_iteration": list(server.inference_context.last_decode_host_seconds_per_iteration),
+            "decode_submit_seconds_per_iteration": list(
+                server.inference_context.last_decode_submit_seconds_per_iteration
+            ),
+            "decode_extract_seconds_per_iteration": list(
+                server.inference_context.last_decode_extract_seconds_per_iteration
+            ),
+            "decode_tokens_per_iteration": list(server.inference_context.last_decode_tokens_per_iteration),
         }
 
     logger.info("Started Levanter server at %s", base_url)
@@ -1970,6 +2041,12 @@ def write_outputs(
         "prefill admissions",
         "prefill chunks",
         "prefill s",
+        "decode iter s",
+        "decode device s",
+        "decode host s",
+        "decode submit s",
+        "decode extract s",
+        "decode iter toks",
         "decode/vllm",
         "total/vllm",
         "target",
@@ -1993,6 +2070,12 @@ def write_outputs(
             _optional_int(result.prefill_admissions),
             _optional_int_list(result.prefill_prompt_tokens_per_admission),
             _optional_float_list(result.prefill_seconds_per_admission),
+            _optional_float_list(result.decode_seconds_per_iteration),
+            _optional_float_list(result.decode_device_seconds_per_iteration),
+            _optional_float_list(result.decode_host_seconds_per_iteration),
+            _optional_float_list(result.decode_submit_seconds_per_iteration),
+            _optional_float_list(result.decode_extract_seconds_per_iteration),
+            _optional_int_list(result.decode_tokens_per_iteration),
             (
                 _ratio(result.decode_tokens_per_second, vllm_by_case.get(result.case_name).decode_tokens_per_second)
                 if result.case_name in vllm_by_case

--- a/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
+++ b/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
@@ -1961,6 +1961,15 @@ def _optional_float_list(value: list[float] | None) -> str:
     return ",".join(f"{item:.3f}" for item in value)
 
 
+def _optional_tokens_per_second(tokens: list[int] | None, seconds: list[float] | None) -> float | None:
+    if not tokens or not seconds:
+        return None
+    elapsed = sum(seconds)
+    if elapsed <= 0.0:
+        return None
+    return sum(tokens) / elapsed
+
+
 def _parity_target_status(result: CaseResult, baseline: CaseResult | None) -> str:
     if baseline is None or result.backend == baseline.backend or baseline.decode_tokens_per_second == 0.0:
         return ""
@@ -2006,7 +2015,18 @@ def write_outputs(
     stress_results: list[StressResult] | None = None,
 ) -> None:
     output_dir.mkdir(parents=True, exist_ok=True)
-    result_dicts = [dataclasses.asdict(result) for result in results]
+    result_dicts = []
+    for result in results:
+        result_dict = dataclasses.asdict(result)
+        result_dict["decode_iteration_tokens_per_second"] = _optional_tokens_per_second(
+            result.decode_tokens_per_iteration,
+            result.decode_seconds_per_iteration,
+        )
+        result_dict["decode_device_tokens_per_second"] = _optional_tokens_per_second(
+            result.decode_tokens_per_iteration,
+            result.decode_device_seconds_per_iteration,
+        )
+        result_dicts.append(result_dict)
     stress_result_dicts = [dataclasses.asdict(result) for result in stress_results or []]
     comparisons = parity_comparisons(results)
     with open(output_dir / "summary.json", "w") as f:
@@ -2047,6 +2067,8 @@ def write_outputs(
         "decode submit s",
         "decode extract s",
         "decode iter toks",
+        "decode iter tok/s",
+        "decode device tok/s",
         "decode/vllm",
         "total/vllm",
         "target",
@@ -2076,6 +2098,14 @@ def write_outputs(
             _optional_float_list(result.decode_submit_seconds_per_iteration),
             _optional_float_list(result.decode_extract_seconds_per_iteration),
             _optional_int_list(result.decode_tokens_per_iteration),
+            _optional_float(
+                _optional_tokens_per_second(result.decode_tokens_per_iteration, result.decode_seconds_per_iteration)
+            ),
+            _optional_float(
+                _optional_tokens_per_second(
+                    result.decode_tokens_per_iteration, result.decode_device_seconds_per_iteration
+                )
+            ),
             (
                 _ratio(result.decode_tokens_per_second, vllm_by_case.get(result.case_name).decode_tokens_per_second)
                 if result.case_name in vllm_by_case

--- a/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
+++ b/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
@@ -114,6 +114,7 @@ class CaseResult:
     compiled_shape_count: int | None
     prefill_admissions: int | None = None
     prefill_prompt_tokens_per_admission: list[int] | None = None
+    prefill_seconds_per_admission: list[float] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1055,7 +1056,7 @@ def run_case(
 
     elapsed = time.perf_counter() - start
     total_tokens = prompt_total + completion_total
-    prefill_admissions, prefill_chunks = _case_admission_metrics(handle.metrics_snapshot)
+    prefill_admissions, prefill_chunks, prefill_seconds = _case_admission_metrics(handle.metrics_snapshot)
     return CaseResult(
         case_name=case.name,
         backend=handle.name,
@@ -1078,6 +1079,7 @@ def run_case(
         compiled_shape_count=handle.compiled_shape_count,
         prefill_admissions=prefill_admissions,
         prefill_prompt_tokens_per_admission=prefill_chunks,
+        prefill_seconds_per_admission=prefill_seconds,
     )
 
 
@@ -1112,15 +1114,17 @@ def _stress_service_static_metric(
 
 def _case_admission_metrics(
     metrics_snapshot: Callable[[], dict[str, Any]] | None,
-) -> tuple[int | None, list[int] | None]:
+) -> tuple[int | None, list[int] | None, list[float] | None]:
     if metrics_snapshot is None:
-        return None, None
+        return None, None, None
     metrics = metrics_snapshot()
     admissions = metrics.get("prefill_admissions")
     chunks = metrics.get("prefill_prompt_tokens_per_admission")
+    seconds = metrics.get("prefill_seconds_per_admission")
     return (
         None if admissions is None else int(admissions),
         None if chunks is None else [int(chunk) for chunk in chunks],
+        None if seconds is None else [float(second) for second in seconds],
     )
 
 
@@ -1432,6 +1436,7 @@ def run_levanter_without_lm_head_case(
         compiled_shape_count=compiled_shape_count,
         prefill_admissions=result.prefill_admissions,
         prefill_prompt_tokens_per_admission=result.prefill_prompt_tokens_per_admission,
+        prefill_seconds_per_admission=result.prefill_seconds_per_admission,
     )
 
 
@@ -1679,6 +1684,7 @@ def start_levanter_server(
             "prefill_prompt_tokens_per_admission": (
                 list(server.inference_context.last_prefill_prompt_tokens_per_admission)
             ),
+            "prefill_seconds_per_admission": list(server.inference_context.last_prefill_seconds_per_admission),
         }
 
     logger.info("Started Levanter server at %s", base_url)
@@ -1878,6 +1884,12 @@ def _optional_int_list(value: list[int] | None) -> str:
     return ",".join(str(item) for item in value)
 
 
+def _optional_float_list(value: list[float] | None) -> str:
+    if value is None:
+        return ""
+    return ",".join(f"{item:.3f}" for item in value)
+
+
 def _parity_target_status(result: CaseResult, baseline: CaseResult | None) -> str:
     if baseline is None or result.backend == baseline.backend or baseline.decode_tokens_per_second == 0.0:
         return ""
@@ -1957,6 +1969,7 @@ def write_outputs(
         "shape buckets",
         "prefill admissions",
         "prefill chunks",
+        "prefill s",
         "decode/vllm",
         "total/vllm",
         "target",
@@ -1979,6 +1992,7 @@ def write_outputs(
             _optional_int(result.compiled_shape_count),
             _optional_int(result.prefill_admissions),
             _optional_int_list(result.prefill_prompt_tokens_per_admission),
+            _optional_float_list(result.prefill_seconds_per_admission),
             (
                 _ratio(result.decode_tokens_per_second, vllm_by_case.get(result.case_name).decode_tokens_per_second)
                 if result.case_name in vllm_by_case

--- a/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
+++ b/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
@@ -112,6 +112,8 @@ class CaseResult:
     total_tokens_per_second: float
     hbm_used_bytes: int | None
     compiled_shape_count: int | None
+    prefill_admissions: int | None = None
+    prefill_prompt_tokens_per_admission: list[int] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -159,7 +161,7 @@ class ServerHandle:
     hbm_used_bytes: int | None = None
     compiled_shape_count: int | None = None
     supports_seed: bool = True
-    metrics_snapshot: Callable[[], dict[str, int | None]] | None = None
+    metrics_snapshot: Callable[[], dict[str, Any]] | None = None
     diagnose_without_lm_head: (
         Callable[
             [BenchmarkCase, str, int, bool, int, float, float, float],
@@ -1053,6 +1055,7 @@ def run_case(
 
     elapsed = time.perf_counter() - start
     total_tokens = prompt_total + completion_total
+    prefill_admissions, prefill_chunks = _case_admission_metrics(handle.metrics_snapshot)
     return CaseResult(
         case_name=case.name,
         backend=handle.name,
@@ -1073,6 +1076,8 @@ def run_case(
         total_tokens_per_second=total_tokens / elapsed if elapsed > 0 else 0.0,
         hbm_used_bytes=handle.hbm_used_bytes,
         compiled_shape_count=handle.compiled_shape_count,
+        prefill_admissions=prefill_admissions,
+        prefill_prompt_tokens_per_admission=prefill_chunks,
     )
 
 
@@ -1084,7 +1089,7 @@ def _completion_error_key(exc: BaseException) -> str:
 
 def _update_stress_metric_maxima(
     maxima: dict[str, int],
-    metrics_snapshot: Callable[[], dict[str, int | None]] | None,
+    metrics_snapshot: Callable[[], dict[str, Any]] | None,
 ) -> None:
     if metrics_snapshot is None:
         return
@@ -1096,12 +1101,27 @@ def _update_stress_metric_maxima(
 
 
 def _stress_service_static_metric(
-    metrics_snapshot: Callable[[], dict[str, int | None]] | None,
+    metrics_snapshot: Callable[[], dict[str, Any]] | None,
     key: str,
 ) -> int | None:
     if metrics_snapshot is None:
         return None
-    return metrics_snapshot().get(key)
+    value = metrics_snapshot().get(key)
+    return None if value is None else int(value)
+
+
+def _case_admission_metrics(
+    metrics_snapshot: Callable[[], dict[str, Any]] | None,
+) -> tuple[int | None, list[int] | None]:
+    if metrics_snapshot is None:
+        return None, None
+    metrics = metrics_snapshot()
+    admissions = metrics.get("prefill_admissions")
+    chunks = metrics.get("prefill_prompt_tokens_per_admission")
+    return (
+        None if admissions is None else int(admissions),
+        None if chunks is None else [int(chunk) for chunk in chunks],
+    )
 
 
 def run_stress_case(
@@ -1410,6 +1430,8 @@ def run_levanter_without_lm_head_case(
         total_tokens_per_second=total_tokens / elapsed if elapsed > 0 else 0.0,
         hbm_used_bytes=hbm_used_bytes,
         compiled_shape_count=compiled_shape_count,
+        prefill_admissions=result.prefill_admissions,
+        prefill_prompt_tokens_per_admission=result.prefill_prompt_tokens_per_admission,
     )
 
 
@@ -1646,13 +1668,17 @@ def start_levanter_server(
             top_k=None,
         )
 
-    def metrics_snapshot() -> dict[str, int | None]:
+    def metrics_snapshot() -> dict[str, Any]:
         engine = server.inference_context.engine
         return {
             "request_queue_depth": server.inference_context.request_queue.qsize(),
             "batch_queue_depth": server.inference_context.batch_queue.qsize(),
             "page_size": engine.config.page_size if engine is not None else None,
             "max_pages": engine.config.max_pages if engine is not None else None,
+            "prefill_admissions": server.inference_context.last_prefill_admissions,
+            "prefill_prompt_tokens_per_admission": (
+                list(server.inference_context.last_prefill_prompt_tokens_per_admission)
+            ),
         }
 
     logger.info("Started Levanter server at %s", base_url)
@@ -1846,6 +1872,12 @@ def _optional_int(value: int | None) -> str:
     return str(value)
 
 
+def _optional_int_list(value: list[int] | None) -> str:
+    if value is None:
+        return ""
+    return ",".join(str(item) for item in value)
+
+
 def _parity_target_status(result: CaseResult, baseline: CaseResult | None) -> str:
     if baseline is None or result.backend == baseline.backend or baseline.decode_tokens_per_second == 0.0:
         return ""
@@ -1923,6 +1955,8 @@ def write_outputs(
         "p90 ms",
         "hbm bytes",
         "shape buckets",
+        "prefill admissions",
+        "prefill chunks",
         "decode/vllm",
         "total/vllm",
         "target",
@@ -1943,6 +1977,8 @@ def write_outputs(
             f"{result.request_latency_ms_p90:.1f}",
             _optional_int(result.hbm_used_bytes),
             _optional_int(result.compiled_shape_count),
+            _optional_int(result.prefill_admissions),
+            _optional_int_list(result.prefill_prompt_tokens_per_admission),
             (
                 _ratio(result.decode_tokens_per_second, vllm_by_case.get(result.case_name).decode_tokens_per_second)
                 if result.case_name in vllm_by_case

--- a/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
+++ b/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
@@ -121,6 +121,11 @@ class CaseResult:
     decode_submit_seconds_per_iteration: list[float] | None = None
     decode_extract_seconds_per_iteration: list[float] | None = None
     decode_tokens_per_iteration: list[int] | None = None
+    prefill_drain_seconds_per_iteration: list[float] | None = None
+    prefill_drain_tokens_per_iteration: list[int] | None = None
+    generation_seconds_per_iteration: list[float] | None = None
+    generation_host_seconds_per_iteration: list[float] | None = None
+    generation_tokens_per_iteration: list[int] | None = None
 
 
 @dataclass(frozen=True, slots=True)
@@ -1146,6 +1151,11 @@ def run_case(
         decode_submit_seconds_per_iteration=runtime_metrics.decode_submit_seconds_per_iteration,
         decode_extract_seconds_per_iteration=runtime_metrics.decode_extract_seconds_per_iteration,
         decode_tokens_per_iteration=runtime_metrics.decode_tokens_per_iteration,
+        prefill_drain_seconds_per_iteration=runtime_metrics.prefill_drain_seconds_per_iteration,
+        prefill_drain_tokens_per_iteration=runtime_metrics.prefill_drain_tokens_per_iteration,
+        generation_seconds_per_iteration=runtime_metrics.generation_seconds_per_iteration,
+        generation_host_seconds_per_iteration=runtime_metrics.generation_host_seconds_per_iteration,
+        generation_tokens_per_iteration=runtime_metrics.generation_tokens_per_iteration,
     )
 
 
@@ -1189,6 +1199,11 @@ class CaseRuntimeMetrics:
     decode_submit_seconds_per_iteration: list[float] | None
     decode_extract_seconds_per_iteration: list[float] | None
     decode_tokens_per_iteration: list[int] | None
+    prefill_drain_seconds_per_iteration: list[float] | None
+    prefill_drain_tokens_per_iteration: list[int] | None
+    generation_seconds_per_iteration: list[float] | None
+    generation_host_seconds_per_iteration: list[float] | None
+    generation_tokens_per_iteration: list[int] | None
 
 
 def _optional_metric_float_list(metrics: dict[str, Any], key: str) -> list[float] | None:
@@ -1213,6 +1228,11 @@ def _case_runtime_metrics(metrics_snapshot: Callable[[], dict[str, Any]] | None)
             decode_submit_seconds_per_iteration=None,
             decode_extract_seconds_per_iteration=None,
             decode_tokens_per_iteration=None,
+            prefill_drain_seconds_per_iteration=None,
+            prefill_drain_tokens_per_iteration=None,
+            generation_seconds_per_iteration=None,
+            generation_host_seconds_per_iteration=None,
+            generation_tokens_per_iteration=None,
         )
     metrics = metrics_snapshot()
     admissions = metrics.get("prefill_admissions")
@@ -1232,6 +1252,15 @@ def _case_runtime_metrics(metrics_snapshot: Callable[[], dict[str, Any]] | None)
             metrics, "decode_extract_seconds_per_iteration"
         ),
         decode_tokens_per_iteration=_optional_metric_int_list(metrics, "decode_tokens_per_iteration"),
+        prefill_drain_seconds_per_iteration=_optional_metric_float_list(
+            metrics, "prefill_drain_seconds_per_iteration"
+        ),
+        prefill_drain_tokens_per_iteration=_optional_metric_int_list(metrics, "prefill_drain_tokens_per_iteration"),
+        generation_seconds_per_iteration=_optional_metric_float_list(metrics, "generation_seconds_per_iteration"),
+        generation_host_seconds_per_iteration=_optional_metric_float_list(
+            metrics, "generation_host_seconds_per_iteration"
+        ),
+        generation_tokens_per_iteration=_optional_metric_int_list(metrics, "generation_tokens_per_iteration"),
     )
 
 
@@ -1558,6 +1587,11 @@ def run_levanter_without_lm_head_case(
         decode_submit_seconds_per_iteration=result.decode_submit_seconds_per_iteration,
         decode_extract_seconds_per_iteration=result.decode_extract_seconds_per_iteration,
         decode_tokens_per_iteration=result.decode_tokens_per_iteration,
+        prefill_drain_seconds_per_iteration=result.prefill_drain_seconds_per_iteration,
+        prefill_drain_tokens_per_iteration=result.prefill_drain_tokens_per_iteration,
+        generation_seconds_per_iteration=result.generation_seconds_per_iteration,
+        generation_host_seconds_per_iteration=result.generation_host_seconds_per_iteration,
+        generation_tokens_per_iteration=result.generation_tokens_per_iteration,
     )
 
 
@@ -1818,6 +1852,17 @@ def start_levanter_server(
                 server.inference_context.last_decode_extract_seconds_per_iteration
             ),
             "decode_tokens_per_iteration": list(server.inference_context.last_decode_tokens_per_iteration),
+            "prefill_drain_seconds_per_iteration": list(
+                server.inference_context.last_prefill_drain_seconds_per_iteration
+            ),
+            "prefill_drain_tokens_per_iteration": list(
+                server.inference_context.last_prefill_drain_tokens_per_iteration
+            ),
+            "generation_seconds_per_iteration": list(server.inference_context.last_generation_seconds_per_iteration),
+            "generation_host_seconds_per_iteration": list(
+                server.inference_context.last_generation_host_seconds_per_iteration
+            ),
+            "generation_tokens_per_iteration": list(server.inference_context.last_generation_tokens_per_iteration),
         }
 
     logger.info("Started Levanter server at %s", base_url)
@@ -2088,6 +2133,10 @@ def write_outputs(
             result.decode_tokens_per_iteration,
             result.decode_device_seconds_per_iteration,
         )
+        result_dict["generation_tokens_per_second"] = _optional_tokens_per_second(
+            result.generation_tokens_per_iteration,
+            result.generation_seconds_per_iteration,
+        )
         result_dicts.append(result_dict)
     stress_result_dicts = [dataclasses.asdict(result) for result in stress_results or []]
     comparisons = parity_comparisons(results)
@@ -2129,8 +2178,14 @@ def write_outputs(
         "decode submit s",
         "decode extract s",
         "decode iter toks",
+        "prefill drain s",
+        "prefill drain toks",
+        "generation s",
+        "generation host s",
+        "generation toks",
         "decode iter tok/s",
         "decode device tok/s",
+        "generation tok/s",
         "decode/vllm",
         "total/vllm",
         "target",
@@ -2160,12 +2215,22 @@ def write_outputs(
             _optional_float_list(result.decode_submit_seconds_per_iteration),
             _optional_float_list(result.decode_extract_seconds_per_iteration),
             _optional_int_list(result.decode_tokens_per_iteration),
+            _optional_float_list(result.prefill_drain_seconds_per_iteration),
+            _optional_int_list(result.prefill_drain_tokens_per_iteration),
+            _optional_float_list(result.generation_seconds_per_iteration),
+            _optional_float_list(result.generation_host_seconds_per_iteration),
+            _optional_int_list(result.generation_tokens_per_iteration),
             _optional_float(
                 _optional_tokens_per_second(result.decode_tokens_per_iteration, result.decode_seconds_per_iteration)
             ),
             _optional_float(
                 _optional_tokens_per_second(
                     result.decode_tokens_per_iteration, result.decode_device_seconds_per_iteration
+                )
+            ),
+            _optional_float(
+                _optional_tokens_per_second(
+                    result.generation_tokens_per_iteration, result.generation_seconds_per_iteration
                 )
             ),
             (

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -1763,10 +1763,11 @@ class InferenceEngine:
                 k: DecodeResult(id=rid, choice=k, token_list=[]) for k in range(expected_children[rid])
             }
 
-        def _admit_pending_prefill() -> int:
+        def _admit_pending_prefill() -> tuple[int, bool]:
             nonlocal pending_requests, prefill_admissions
             if not pending_requests:
-                return 0
+                return 0, False
+            before_request_count = len(pending_requests)
             prefill_start = time.time()
             prefill_admission = self._prefill_batch(pending_requests, apply_top_p=apply_top_p, return_logprobs=False)
             _block_until_ready_optional(
@@ -1774,12 +1775,21 @@ class InferenceEngine:
             )
             prefill_done = time.time()
             if prefill_admission is None:
-                return 0
+                return 0, False
             prefill_admissions += 1
             prefill_prompt_tokens_per_admission.append(prefill_admission.plan.prompt_tokens)
             prefill_seconds_per_admission.append(prefill_done - prefill_start)
             pending_requests = pending_requests[prefill_admission.plan.request_count :]
-            return self._ingest_outputs(prefill_admission.outputs)
+            return self._ingest_outputs(prefill_admission.outputs), len(pending_requests) < before_request_count
+
+        def _admit_all_pending_prefill() -> int:
+            new_tokens = 0
+            while pending_requests:
+                prefill_tokens, admitted_requests = _admit_pending_prefill()
+                new_tokens += prefill_tokens
+                if not admitted_requests:
+                    break
+            return new_tokens
 
         def _all_done() -> bool:
             for rid, n_kids in expected_children.items():
@@ -1796,7 +1806,7 @@ class InferenceEngine:
             if _all_done():
                 break
             iter_start = time.time()
-            iter_new_tokens = _admit_pending_prefill()
+            iter_new_tokens = _admit_all_pending_prefill()
 
             submit_start = time.time()
             future_state, decode_outputs = decode_loop(

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -8,7 +8,7 @@ import os
 import time
 import warnings
 from dataclasses import dataclass, field
-from typing import Any, Optional, Sequence, cast
+from typing import Any, Callable, Optional, Sequence, cast
 
 import equinox as eqx
 import haliax as hax
@@ -1287,15 +1287,6 @@ class InferenceEngine:
         self.gen_state, outputs = new_state
         return PrefillAdmissionResult(outputs=outputs, plan=plan)
 
-    def _reject_diagnostic_multi_prefill(self, requests: Sequence[Request], diagnostic_name: str) -> None:
-        max_prefill_size = self.config.max_prefill_size or self.model.Pos.size
-        prompt_tokens = sum(len(request.prompt_tokens) for request in requests)
-        if prompt_tokens > max_prefill_size:
-            raise ValueError(
-                f"{diagnostic_name} does not support multi-prefill admission: aggregate prompt tokens "
-                f"{prompt_tokens} exceed max_prefill_size={max_prefill_size}. Use generate() for multi-prefill batches."
-            )
-
     def _prefill_prompts(
         self,
         requests: Sequence[Request],
@@ -1743,32 +1734,53 @@ class InferenceEngine:
             decode_tokens_per_iteration=decode_tokens_per_iteration,
         )
 
-    def generate_without_lm_head(self, requests: Sequence[Request]) -> GenerationResult:
-        """Diagnostic generation path that skips LM-head projection and sampling after prefill.
-
-        This is for performance attribution only. Prefill still uses normal logits and sampling so the decode queue
-        is seeded in the usual way; subsequent decode rounds run the transformer and cache update, then enqueue dummy
-        token IDs.
-        """
-        self._reject_diagnostic_multi_prefill(requests, "generate_without_lm_head")
+    def _generate_diagnostic(
+        self,
+        requests: Sequence[Request],
+        *,
+        decode_loop: Callable[
+            [GenState, LmHeadModel, int, int, TpuPagedAttentionConfig],
+            tuple[GenState, _DecodeOutputs],
+        ],
+        diagnostic_name: str,
+    ) -> GenerationResult:
         self.reset()
 
+        pending_requests = list(requests)
         call_rids = [int(r.request_id) for r in requests]
         expected_children: dict[int, int] = {rid: int(r.n_generations) for rid, r in zip(call_rids, requests)}
         apply_top_p = self._requests_need_top_p(requests)
+        prefill_admissions = 0
+        prefill_prompt_tokens_per_admission: list[int] = []
+        prefill_seconds_per_admission: list[float] = []
+        decode_seconds_per_iteration: list[float] = []
+        decode_device_seconds_per_iteration: list[float] = []
+        decode_host_seconds_per_iteration: list[float] = []
+        decode_submit_seconds_per_iteration: list[float] = []
+        decode_extract_seconds_per_iteration: list[float] = []
+        decode_tokens_per_iteration: list[int] = []
         for rid in call_rids:
             self.results[rid] = {
                 k: DecodeResult(id=rid, choice=k, token_list=[]) for k in range(expected_children[rid])
             }
 
-        prefill_start = time.time()
-        prefill_admission = self._prefill_batch(requests, apply_top_p=apply_top_p, return_logprobs=False)
-        _block_until_ready_optional((self.gen_state, None if prefill_admission is None else prefill_admission.outputs))
-        self._ingest_outputs(None if prefill_admission is None else prefill_admission.outputs)
-        prefill_seconds = time.time() - prefill_start
-        prefill_prompt_tokens_per_admission = (
-            [] if prefill_admission is None else [prefill_admission.plan.prompt_tokens]
-        )
+        def _admit_pending_prefill() -> int:
+            nonlocal pending_requests, prefill_admissions
+            if not pending_requests:
+                return 0
+            prefill_start = time.time()
+            prefill_admission = self._prefill_batch(pending_requests, apply_top_p=apply_top_p, return_logprobs=False)
+            _block_until_ready_optional(
+                (self.gen_state, None if prefill_admission is None else prefill_admission.outputs)
+            )
+            prefill_done = time.time()
+            if prefill_admission is None:
+                return 0
+            prefill_admissions += 1
+            prefill_prompt_tokens_per_admission.append(prefill_admission.plan.prompt_tokens)
+            prefill_seconds_per_admission.append(prefill_done - prefill_start)
+            pending_requests = pending_requests[prefill_admission.plan.request_count :]
+            return self._ingest_outputs(prefill_admission.outputs)
 
         def _all_done() -> bool:
             for rid, n_kids in expected_children.items():
@@ -1779,27 +1791,47 @@ class InferenceEngine:
                         return False
             return True
 
+        _admit_pending_prefill()
         stagnant_iters = 0
         for _ in range(self.config.max_seq_len // self.config.max_rounds):
             if _all_done():
                 break
+            iter_start = time.time()
+            iter_new_tokens = _admit_pending_prefill()
 
-            future_state, decode_outputs = _run_generation_loop_without_lm_head(
+            submit_start = time.time()
+            future_state, decode_outputs = decode_loop(
                 self.gen_state,
-                self.model,
+                self.model,  # type: ignore[arg-type]
                 self.config.imputed_max_tokens_per_round,
                 self.config.max_rounds,
                 self.config.tpu_paged_attention,
             )
+            submit_done = time.time()
+
+            device_start = time.time()
             _block_until_ready_optional((future_state, decode_outputs))
+            device_time = time.time() - device_start
             self.gen_state = future_state
-            new_tokens = self._ingest_outputs(decode_outputs)
+
+            extract_start = time.time()
+            decode_new_tokens = self._ingest_outputs(decode_outputs)
+            extract_time = time.time() - extract_start
+            new_tokens = iter_new_tokens + decode_new_tokens
+            iter_time = time.time() - iter_start
+            host_time = max(iter_time - device_time, 0.0)
+            decode_seconds_per_iteration.append(iter_time)
+            decode_device_seconds_per_iteration.append(device_time)
+            decode_host_seconds_per_iteration.append(host_time)
+            decode_submit_seconds_per_iteration.append(submit_done - submit_start)
+            decode_extract_seconds_per_iteration.append(extract_time)
+            decode_tokens_per_iteration.append(new_tokens)
             if new_tokens == 0 and int(jax.device_get(self.gen_state.decode_state.num_queued_tokens)) == 0:
                 stagnant_iters += 1
             else:
                 stagnant_iters = 0
             if stagnant_iters >= 2:
-                logger.warning("No progress in no-LM-head decoding for 2 consecutive iterations; breaking.")
+                logger.warning("No progress in %s decoding for 2 consecutive iterations; breaking.", diagnostic_name)
                 break
 
         outputs_list: list[list[int]] = []
@@ -1821,9 +1853,28 @@ class InferenceEngine:
             tokens=outputs_list,
             logprobs=None,
             total_generated=total_generated,
-            prefill_admissions=0 if prefill_admission is None else 1,
+            prefill_admissions=prefill_admissions,
             prefill_prompt_tokens_per_admission=prefill_prompt_tokens_per_admission,
-            prefill_seconds_per_admission=[] if prefill_admission is None else [prefill_seconds],
+            prefill_seconds_per_admission=prefill_seconds_per_admission,
+            decode_seconds_per_iteration=decode_seconds_per_iteration,
+            decode_device_seconds_per_iteration=decode_device_seconds_per_iteration,
+            decode_host_seconds_per_iteration=decode_host_seconds_per_iteration,
+            decode_submit_seconds_per_iteration=decode_submit_seconds_per_iteration,
+            decode_extract_seconds_per_iteration=decode_extract_seconds_per_iteration,
+            decode_tokens_per_iteration=decode_tokens_per_iteration,
+        )
+
+    def generate_without_lm_head(self, requests: Sequence[Request]) -> GenerationResult:
+        """Diagnostic generation path that skips LM-head projection and sampling after prefill.
+
+        This is for performance attribution only. Prefill still uses normal logits and sampling so the decode queue
+        is seeded in the usual way; subsequent decode rounds run the transformer and cache update, then enqueue dummy
+        token IDs.
+        """
+        return self._generate_diagnostic(
+            requests,
+            decode_loop=_run_generation_loop_without_lm_head,
+            diagnostic_name="no-LM-head",
         )
 
     def generate_with_lm_head_no_sampling(self, requests: Sequence[Request]) -> GenerationResult:
@@ -1832,80 +1883,10 @@ class InferenceEngine:
         This is for performance attribution only. It keeps the transformer, cache update, and LM-head projection live,
         then enqueues dummy token IDs without argmax/top-p/logprob work.
         """
-        self._reject_diagnostic_multi_prefill(requests, "generate_with_lm_head_no_sampling")
-        self.reset()
-
-        call_rids = [int(r.request_id) for r in requests]
-        expected_children: dict[int, int] = {rid: int(r.n_generations) for rid, r in zip(call_rids, requests)}
-        apply_top_p = self._requests_need_top_p(requests)
-        for rid in call_rids:
-            self.results[rid] = {
-                k: DecodeResult(id=rid, choice=k, token_list=[]) for k in range(expected_children[rid])
-            }
-
-        prefill_start = time.time()
-        prefill_admission = self._prefill_batch(requests, apply_top_p=apply_top_p, return_logprobs=False)
-        _block_until_ready_optional((self.gen_state, None if prefill_admission is None else prefill_admission.outputs))
-        self._ingest_outputs(None if prefill_admission is None else prefill_admission.outputs)
-        prefill_seconds = time.time() - prefill_start
-        prefill_prompt_tokens_per_admission = (
-            [] if prefill_admission is None else [prefill_admission.plan.prompt_tokens]
-        )
-
-        def _all_done() -> bool:
-            for rid, n_kids in expected_children.items():
-                kid_map = self.results.get(rid, {})
-                for cid in range(n_kids):
-                    dr = kid_map.get(cid)
-                    if dr is None or not dr.done:
-                        return False
-            return True
-
-        stagnant_iters = 0
-        for _ in range(self.config.max_seq_len // self.config.max_rounds):
-            if _all_done():
-                break
-
-            future_state, decode_outputs = _run_generation_loop_with_lm_head_no_sampling(
-                self.gen_state,
-                self.model,
-                self.config.imputed_max_tokens_per_round,
-                self.config.max_rounds,
-                self.config.tpu_paged_attention,
-            )
-            _block_until_ready_optional((future_state, decode_outputs))
-            self.gen_state = future_state
-            new_tokens = self._ingest_outputs(decode_outputs)
-            if new_tokens == 0 and int(jax.device_get(self.gen_state.decode_state.num_queued_tokens)) == 0:
-                stagnant_iters += 1
-            else:
-                stagnant_iters = 0
-            if stagnant_iters >= 2:
-                logger.warning("No progress in LM-head/no-sampling decoding for 2 consecutive iterations; breaking.")
-                break
-
-        outputs_list: list[list[int]] = []
-        for r in requests:
-            rid = int(r.request_id)
-            kid_map = self.results.get(rid, {})
-            for k in range(int(r.n_generations)):
-                dr = kid_map.get(k)
-                if dr is None:
-                    kid_map[k] = DecodeResult(id=rid, choice=k, token_list=[])
-                    dr = kid_map[k]
-                outputs_list.append(dr.token_list)
-            self.results[rid] = kid_map
-        total_generated = sum(len(seq_outputs) for seq_outputs in outputs_list)
-
-        for rid in call_rids:
-            self.results.pop(rid, None)
-        return GenerationResult(
-            tokens=outputs_list,
-            logprobs=None,
-            total_generated=total_generated,
-            prefill_admissions=0 if prefill_admission is None else 1,
-            prefill_prompt_tokens_per_admission=prefill_prompt_tokens_per_admission,
-            prefill_seconds_per_admission=[] if prefill_admission is None else [prefill_seconds],
+        return self._generate_diagnostic(
+            requests,
+            decode_loop=_run_generation_loop_with_lm_head_no_sampling,
+            diagnostic_name="LM-head/no-sampling",
         )
 
     def write_kernel_jaxprs(

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -1633,7 +1633,7 @@ class InferenceEngine:
             )
             fake_submit_done = time.time()
 
-            submit_start = iter_start
+            submit_start = time.time()
             future_state, decode_outputs = _run_generation_loop(
                 self.gen_state,
                 self.model,

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -958,15 +958,15 @@ def _run_generation_loop_without_lm_head(
 @functools.partial(jax.jit, static_argnums=(2, 3, 4), donate_argnames=("gen_state",))
 def _run_generation_loop_with_lm_head_no_sampling(
     gen_state: GenState,
-    model: Any,
+    model: LmHeadModel,
     max_tokens_per_round: int,
     max_rounds: int,
     tpu_paged_attention: TpuPagedAttentionConfig,
 ) -> tuple[GenState, _DecodeOutputs]:
     """Run decode through the LM head, then enqueue dummy tokens without sampling.
 
-    This is a performance-attribution path. The logits checksum keeps the LM-head computation live while avoiding the
-    argmax/top-p/logprob work from the normal sampler path.
+    This is a performance-attribution path. It keeps the same streaming greedy LM-head computation as the production
+    greedy path while avoiding top-p/top-k sampling and logprob work from the normal sampler path.
     """
 
     def cond(state: tuple[GenState, _DecodeOutputs, jax.Array]):
@@ -997,12 +997,13 @@ def _run_generation_loop_with_lm_head_no_sampling(
             pos_ids,
             tpu_paged_attention=tpu_paged_attention,
         )
-        logits = model.lm_head_logits(hidden)
-        logits_checksum = hax.sum(logits).scalar()
 
         num_new_tokens = hax.sum(sample_indices != INVALID).scalar().astype(jnp.int32)
         new_slot_ids = slot_ids["position", sample_indices]
-        dummy_token = jnp.where(jnp.isfinite(logits_checksum), 0, 1).astype(jnp.int32)
+        hidden_at_samples = hidden["position", sample_indices]
+        greedy_tokens, _ = _streaming_greedy_lm_head(model, hidden_at_samples, return_logprobs=False)
+        token_checksum = hax.sum(greedy_tokens).scalar()
+        dummy_token = jnp.where(token_checksum >= 0, 0, 1).astype(jnp.int32)
         new_tokens = hax.zeros(new_slot_ids.axes, dtype=jnp.int32) + dummy_token
         log_probs = hax.zeros(new_slot_ids.axes, dtype=jnp.float32)
 

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -1552,28 +1552,46 @@ class InferenceEngine:
             pending_requests = pending_requests[admission.plan.request_count :]
             return self._ingest_outputs(admission.outputs)
 
+        def _admit_pending_prefill() -> tuple[int, bool]:
+            if not pending_requests:
+                return 0, False
+
+            before_request_count = len(pending_requests)
+            prefill_start = time.time()
+            prefill_admission = self._prefill_batch(
+                pending_requests,
+                apply_top_p=apply_top_p,
+                return_logprobs=return_logprobs,
+            )
+            prefill_submit_done = time.time()
+            prefill_device_start = time.time()
+            _block_until_ready_optional(
+                (self.gen_state, None if prefill_admission is None else prefill_admission.outputs)
+            )
+            prefill_device_done = time.time()
+            new_tokens = _record_prefill(prefill_admission)
+            prefill_out = time.time()
+
+            if prefill_admission is not None:
+                prefill_seconds_per_admission.append(prefill_out - prefill_start)
+                logger.info(
+                    "Prefill admission %d: %d requests, %d seqs, %d prompt tokens, "
+                    "submit %.3fs, device %.3fs, extraction %.3fs, total %.3fs",
+                    prefill_admissions,
+                    prefill_admission.plan.request_count,
+                    prefill_admission.plan.sequence_count,
+                    prefill_admission.plan.prompt_tokens,
+                    prefill_submit_done - prefill_start,
+                    prefill_device_done - prefill_device_start,
+                    prefill_out - prefill_device_done,
+                    prefill_out - prefill_start,
+                )
+
+            return new_tokens, len(pending_requests) < before_request_count
+
         time_in = time.time()
-        # Initial admission from queue and extract prompt tokens
-        prefill_admission = self._prefill_batch(
-            pending_requests,
-            apply_top_p=apply_top_p,
-            return_logprobs=return_logprobs,
-        )
-        prefill_submit_done = time.time()
-        prefill_device_start = time.time()
-        _block_until_ready_optional((self.gen_state, None if prefill_admission is None else prefill_admission.outputs))
-        prefill_device_done = time.time()
-        _record_prefill(prefill_admission)
-        initial_prefill_out = time.time()
-        if prefill_admission is not None:
-            prefill_seconds_per_admission.append(initial_prefill_out - time_in)
-        logger.info(
-            "Initial prefill: submit %.3fs, device %.3fs, extraction %.3fs, total %.3fs",
-            prefill_submit_done - time_in,
-            prefill_device_done - prefill_device_start,
-            initial_prefill_out - prefill_device_done,
-            initial_prefill_out - time_in,
-        )
+        # Initial admission from queue and extraction of prompt outputs.
+        _admit_pending_prefill()
 
         def _all_done() -> bool:
             for rid, n_kids in expected_children.items():
@@ -1596,31 +1614,11 @@ class InferenceEngine:
             iter_start = time.time()
             iter_new_tokens = 0
 
-            if pending_requests:
-                prefill_start = time.time()
-                prefill_admission = self._prefill_batch(
-                    pending_requests,
-                    apply_top_p=apply_top_p,
-                    return_logprobs=return_logprobs,
-                )
-                prefill_submit_done = time.time()
-                _block_until_ready_optional(
-                    (self.gen_state, None if prefill_admission is None else prefill_admission.outputs)
-                )
-                prefill_device_done = time.time()
-                iter_new_tokens += _record_prefill(prefill_admission)
-                prefill_out = time.time()
-                if prefill_admission is not None:
-                    prefill_seconds_per_admission.append(prefill_out - prefill_start)
-                    logger.info(
-                        "Prefill admission %d: %d requests, %d seqs, %d prompt tokens, %.3fs",
-                        prefill_admissions,
-                        prefill_admission.plan.request_count,
-                        prefill_admission.plan.sequence_count,
-                        prefill_admission.plan.prompt_tokens,
-                        prefill_out - prefill_start,
-                    )
-                logger.debug("Prefill submit overhead %.3fs", prefill_submit_done - prefill_start)
+            while pending_requests:
+                prefill_tokens, admitted_requests = _admit_pending_prefill()
+                iter_new_tokens += prefill_tokens
+                if not admitted_requests:
+                    break
 
             fake_submit_start = time.time()
             # future_state, decode_outputs = _run_generation_loop(

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -1028,6 +1028,7 @@ class GenerationResult:
     total_generated: int
     prefill_admissions: int = 0
     prefill_prompt_tokens_per_admission: list[int] = field(default_factory=list)
+    prefill_seconds_per_admission: list[float] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -1488,6 +1489,7 @@ class InferenceEngine:
         pending_requests = list(requests)
         prefill_admissions = 0
         prefill_prompt_tokens_per_admission: list[int] = []
+        prefill_seconds_per_admission: list[float] = []
         # Initialize fresh result buckets for this call
         for rid in call_rids:
             self.results[rid] = {
@@ -1559,6 +1561,8 @@ class InferenceEngine:
         prefill_device_done = time.time()
         _record_prefill(prefill_admission)
         initial_prefill_out = time.time()
+        if prefill_admission is not None:
+            prefill_seconds_per_admission.append(initial_prefill_out - time_in)
         logger.info(
             "Initial prefill: submit %.3fs, device %.3fs, extraction %.3fs, total %.3fs",
             prefill_submit_done - time_in,
@@ -1601,14 +1605,16 @@ class InferenceEngine:
                 )
                 prefill_device_done = time.time()
                 iter_new_tokens += _record_prefill(prefill_admission)
+                prefill_out = time.time()
                 if prefill_admission is not None:
+                    prefill_seconds_per_admission.append(prefill_out - prefill_start)
                     logger.info(
                         "Prefill admission %d: %d requests, %d seqs, %d prompt tokens, %.3fs",
                         prefill_admissions,
                         prefill_admission.plan.request_count,
                         prefill_admission.plan.sequence_count,
                         prefill_admission.plan.prompt_tokens,
-                        prefill_device_done - prefill_start,
+                        prefill_out - prefill_start,
                     )
                 logger.debug("Prefill submit overhead %.3fs", prefill_submit_done - prefill_start)
 
@@ -1710,6 +1716,7 @@ class InferenceEngine:
             total_generated=total_generated,
             prefill_admissions=prefill_admissions,
             prefill_prompt_tokens_per_admission=prefill_prompt_tokens_per_admission,
+            prefill_seconds_per_admission=prefill_seconds_per_admission,
         )
 
     def generate_without_lm_head(self, requests: Sequence[Request]) -> GenerationResult:
@@ -1730,9 +1737,11 @@ class InferenceEngine:
                 k: DecodeResult(id=rid, choice=k, token_list=[]) for k in range(expected_children[rid])
             }
 
+        prefill_start = time.time()
         prefill_admission = self._prefill_batch(requests, apply_top_p=apply_top_p, return_logprobs=False)
         _block_until_ready_optional((self.gen_state, None if prefill_admission is None else prefill_admission.outputs))
         self._ingest_outputs(None if prefill_admission is None else prefill_admission.outputs)
+        prefill_seconds = time.time() - prefill_start
         prefill_prompt_tokens_per_admission = (
             [] if prefill_admission is None else [prefill_admission.plan.prompt_tokens]
         )
@@ -1790,6 +1799,7 @@ class InferenceEngine:
             total_generated=total_generated,
             prefill_admissions=0 if prefill_admission is None else 1,
             prefill_prompt_tokens_per_admission=prefill_prompt_tokens_per_admission,
+            prefill_seconds_per_admission=[] if prefill_admission is None else [prefill_seconds],
         )
 
     def generate_with_lm_head_no_sampling(self, requests: Sequence[Request]) -> GenerationResult:
@@ -1809,9 +1819,11 @@ class InferenceEngine:
                 k: DecodeResult(id=rid, choice=k, token_list=[]) for k in range(expected_children[rid])
             }
 
+        prefill_start = time.time()
         prefill_admission = self._prefill_batch(requests, apply_top_p=apply_top_p, return_logprobs=False)
         _block_until_ready_optional((self.gen_state, None if prefill_admission is None else prefill_admission.outputs))
         self._ingest_outputs(None if prefill_admission is None else prefill_admission.outputs)
+        prefill_seconds = time.time() - prefill_start
         prefill_prompt_tokens_per_admission = (
             [] if prefill_admission is None else [prefill_admission.plan.prompt_tokens]
         )
@@ -1869,6 +1881,7 @@ class InferenceEngine:
             total_generated=total_generated,
             prefill_admissions=0 if prefill_admission is None else 1,
             prefill_prompt_tokens_per_admission=prefill_prompt_tokens_per_admission,
+            prefill_seconds_per_admission=[] if prefill_admission is None else [prefill_seconds],
         )
 
     def write_kernel_jaxprs(

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -1036,6 +1036,11 @@ class GenerationResult:
     decode_submit_seconds_per_iteration: list[float] = field(default_factory=list)
     decode_extract_seconds_per_iteration: list[float] = field(default_factory=list)
     decode_tokens_per_iteration: list[int] = field(default_factory=list)
+    prefill_drain_seconds_per_iteration: list[float] = field(default_factory=list)
+    prefill_drain_tokens_per_iteration: list[int] = field(default_factory=list)
+    generation_seconds_per_iteration: list[float] = field(default_factory=list)
+    generation_host_seconds_per_iteration: list[float] = field(default_factory=list)
+    generation_tokens_per_iteration: list[int] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -1494,6 +1499,11 @@ class InferenceEngine:
         decode_submit_seconds_per_iteration: list[float] = []
         decode_extract_seconds_per_iteration: list[float] = []
         decode_tokens_per_iteration: list[int] = []
+        prefill_drain_seconds_per_iteration: list[float] = []
+        prefill_drain_tokens_per_iteration: list[int] = []
+        generation_seconds_per_iteration: list[float] = []
+        generation_host_seconds_per_iteration: list[float] = []
+        generation_tokens_per_iteration: list[int] = []
         # Initialize fresh result buckets for this call
         for rid in call_rids:
             self.results[rid] = {
@@ -1613,6 +1623,7 @@ class InferenceEngine:
 
             iter_start = time.time()
             iter_new_tokens = 0
+            prefill_drain_start = iter_start
 
             while pending_requests:
                 prefill_tokens, admitted_requests = _admit_pending_prefill()
@@ -1620,6 +1631,8 @@ class InferenceEngine:
                 if not admitted_requests:
                     break
 
+            prefill_drain_done = time.time()
+            prefill_drain_time = prefill_drain_done - prefill_drain_start
             fake_submit_start = time.time()
             # future_state, decode_outputs = _run_generation_loop(
             jax.tree.flatten(
@@ -1661,8 +1674,10 @@ class InferenceEngine:
 
             iter_end = time.time()
             iter_time = iter_end - iter_start
+            generation_time = iter_end - prefill_drain_done
             # Host time is everything except the device execution wait
             host_time = max(iter_time - device_time, 0.0)
+            generation_host_time = max(generation_time - device_time, 0.0)
             submit_time = submit_done - submit_start
             decode_seconds_per_iteration.append(iter_time)
             decode_device_seconds_per_iteration.append(device_time)
@@ -1670,11 +1685,17 @@ class InferenceEngine:
             decode_submit_seconds_per_iteration.append(submit_time)
             decode_extract_seconds_per_iteration.append(extract_time)
             decode_tokens_per_iteration.append(new_tokens)
+            prefill_drain_seconds_per_iteration.append(prefill_drain_time)
+            prefill_drain_tokens_per_iteration.append(iter_new_tokens)
+            generation_seconds_per_iteration.append(generation_time)
+            generation_host_seconds_per_iteration.append(generation_host_time)
+            generation_tokens_per_iteration.append(decode_new_tokens)
             if iter_time > 0:
                 tps_total = new_tokens / iter_time
                 logger.info(
                     f"Decode iter: total {iter_time:.3f}s (device {device_time:.3f}s, host {host_time:.3f}s, "
-                    f"submit {submit_time:.3f}s), "
+                    f"submit {submit_time:.3f}s, prefill_drain {prefill_drain_time:.3f}s, "
+                    f"generation {generation_time:.3f}s), "
                     f"fake_submit {fake_submit_done - fake_submit_start:.3f}s, "
                     f"{tps_total:.2f} tok/s, {new_tokens} new"
                     f" (extract {extract_time:.3f}s"
@@ -1731,6 +1752,11 @@ class InferenceEngine:
             decode_submit_seconds_per_iteration=decode_submit_seconds_per_iteration,
             decode_extract_seconds_per_iteration=decode_extract_seconds_per_iteration,
             decode_tokens_per_iteration=decode_tokens_per_iteration,
+            prefill_drain_seconds_per_iteration=prefill_drain_seconds_per_iteration,
+            prefill_drain_tokens_per_iteration=prefill_drain_tokens_per_iteration,
+            generation_seconds_per_iteration=generation_seconds_per_iteration,
+            generation_host_seconds_per_iteration=generation_host_seconds_per_iteration,
+            generation_tokens_per_iteration=generation_tokens_per_iteration,
         )
 
     def _generate_diagnostic(

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -1026,6 +1026,21 @@ class GenerationResult:
     tokens: list[list[int]]
     logprobs: list[list[float]] | None
     total_generated: int
+    prefill_admissions: int = 0
+    prefill_prompt_tokens_per_admission: list[int] = field(default_factory=list)
+
+
+@dataclass(frozen=True)
+class PrefillAdmissionPlan:
+    request_count: int
+    prompt_tokens: int
+    sequence_count: int
+
+
+@dataclass(frozen=True)
+class PrefillAdmissionResult:
+    outputs: _DecodeOutputs
+    plan: PrefillAdmissionPlan
 
 
 FIRST_TOKEN_LOGPROB = 0.0
@@ -1195,15 +1210,58 @@ class InferenceEngine:
             float(np.asarray(request.decode_params.top_p, dtype=np.float32).item()) < 1.0 for request in requests
         )
 
+    def _prefill_admission_plan(self, requests: Sequence[Request]) -> PrefillAdmissionPlan | None:
+        """Return the leading request prefix that fits in the next prefill call."""
+
+        max_seqs_in_prefill = self.config.max_seqs_in_prefill
+        max_prefill_size = self.config.max_prefill_size or self.model.Pos.size
+        available_slots = len(self.free_slots)
+
+        request_count = 0
+        prompt_tokens = 0
+        sequence_count = 0
+        primary_sequences = 0
+
+        for request in requests:
+            if len(request.prompt_tokens) + prompt_tokens > max_prefill_size:
+                break
+            if primary_sequences >= max_seqs_in_prefill:
+                break
+            if available_slots < request.n_generations:
+                if max_seqs_in_prefill < request.n_generations:
+                    raise RuntimeError(
+                        f"Request {request.request_id} asked for {request.n_generations} generations, "
+                        f"but max_seqs_in_prefill={max_seqs_in_prefill} is too small to accommodate. "
+                        "Increase max_seqs_in_prefill or reduce n_generations."
+                    )
+                break
+
+            request_count += 1
+            prompt_tokens += len(request.prompt_tokens)
+            sequence_count += request.n_generations
+            primary_sequences += 1
+            available_slots -= request.n_generations
+
+        if request_count == 0:
+            return None
+        return PrefillAdmissionPlan(
+            request_count=request_count,
+            prompt_tokens=prompt_tokens,
+            sequence_count=sequence_count,
+        )
+
     def _prefill_batch(
         self, batch: Sequence[Request], *, apply_top_p: bool, return_logprobs: bool
-    ) -> _DecodeOutputs | None:
+    ) -> PrefillAdmissionResult | None:
         """Admit a batch from the head of the queue that fits in free slots/pages.
 
         Returns the decode outputs for the admitted prefill batch, or None if no work was admitted.
         """
+        plan = self._prefill_admission_plan(batch)
+        if plan is None:
+            return None
         # Build a single PrefillWork description and run prefill exactly once
-        prefill_work = self._prefill_prompts(batch)
+        prefill_work = self._prefill_prompts(batch[: plan.request_count])
         if prefill_work is None:
             return None
         new_state = _run_prefill(
@@ -1220,7 +1278,16 @@ class InferenceEngine:
 
         # _run_prefill returns (GenState, _DecodeOutputs)
         self.gen_state, outputs = new_state
-        return outputs
+        return PrefillAdmissionResult(outputs=outputs, plan=plan)
+
+    def _reject_diagnostic_multi_prefill(self, requests: Sequence[Request], diagnostic_name: str) -> None:
+        max_prefill_size = self.config.max_prefill_size or self.model.Pos.size
+        prompt_tokens = sum(len(request.prompt_tokens) for request in requests)
+        if prompt_tokens > max_prefill_size:
+            raise ValueError(
+                f"{diagnostic_name} does not support multi-prefill admission: aggregate prompt tokens "
+                f"{prompt_tokens} exceed max_prefill_size={max_prefill_size}. Use generate() for multi-prefill batches."
+            )
 
     def _prefill_prompts(
         self,
@@ -1393,13 +1460,21 @@ class InferenceEngine:
             requests: Sequence of generation requests
             step_callback: Optional callback function called at each decode iteration with iteration number
         """
-        # validate we don't have any sequences with n_generations exceeding max_seqs
-        max_needed = max(int(r.n_generations) for r in requests)
-        if max_needed > int(self.gen_state.decode_state.page_table.max_seqs):
+        max_seqs = int(self.gen_state.decode_state.page_table.max_seqs)
+        total_needed = sum(int(r.n_generations) for r in requests)
+        if total_needed > max_seqs:
             raise ValueError(
-                f"Total sequences needed ({max_needed}) exceeds max_seqs ({self.gen_state.decode_state.page_table.max_seqs})."
+                f"Total sequences needed ({total_needed}) exceeds max_seqs ({max_seqs}). "
                 "Decompose your request into smaller batches or increase max_seqs when building the service."
             )
+
+        max_prefill_size = self.config.max_prefill_size or self.model.Pos.size
+        for request in requests:
+            if len(request.prompt_tokens) > max_prefill_size:
+                raise ValueError(
+                    f"Request {request.request_id} prompt has {len(request.prompt_tokens)} tokens, "
+                    f"which exceeds max_prefill_size={max_prefill_size}."
+                )
 
         # for now, reset the engine state between each batch - the engine cannot be called with
         # parallel batches.
@@ -1410,6 +1485,9 @@ class InferenceEngine:
         expected_children: dict[int, int] = {rid: int(r.n_generations) for rid, r in zip(call_rids, requests)}
         return_logprobs = any(r.return_logprobs for r in requests)
         apply_top_p = self._requests_need_top_p(requests)
+        pending_requests = list(requests)
+        prefill_admissions = 0
+        prefill_prompt_tokens_per_admission: list[int] = []
         # Initialize fresh result buckets for this call
         for rid in call_rids:
             self.results[rid] = {
@@ -1459,14 +1537,27 @@ class InferenceEngine:
                     "Increase max_stop_seqs/max_stop_tokens when constructing the service."
                 )
 
+        def _record_prefill(admission: PrefillAdmissionResult | None) -> int:
+            nonlocal pending_requests, prefill_admissions
+            if admission is None:
+                return 0
+            prefill_admissions += 1
+            prefill_prompt_tokens_per_admission.append(admission.plan.prompt_tokens)
+            pending_requests = pending_requests[admission.plan.request_count :]
+            return self._ingest_outputs(admission.outputs)
+
         time_in = time.time()
         # Initial admission from queue and extract prompt tokens
-        decode_outputs = self._prefill_batch(requests, apply_top_p=apply_top_p, return_logprobs=return_logprobs)
+        prefill_admission = self._prefill_batch(
+            pending_requests,
+            apply_top_p=apply_top_p,
+            return_logprobs=return_logprobs,
+        )
         prefill_submit_done = time.time()
         prefill_device_start = time.time()
-        _block_until_ready_optional((self.gen_state, decode_outputs))
+        _block_until_ready_optional((self.gen_state, None if prefill_admission is None else prefill_admission.outputs))
         prefill_device_done = time.time()
-        self._ingest_outputs(decode_outputs)
+        _record_prefill(prefill_admission)
         initial_prefill_out = time.time()
         logger.info(
             "Initial prefill: submit %.3fs, device %.3fs, extraction %.3fs, total %.3fs",
@@ -1495,6 +1586,31 @@ class InferenceEngine:
                 step_callback(decode_iteration)
 
             iter_start = time.time()
+            iter_new_tokens = 0
+
+            if pending_requests:
+                prefill_start = time.time()
+                prefill_admission = self._prefill_batch(
+                    pending_requests,
+                    apply_top_p=apply_top_p,
+                    return_logprobs=return_logprobs,
+                )
+                prefill_submit_done = time.time()
+                _block_until_ready_optional(
+                    (self.gen_state, None if prefill_admission is None else prefill_admission.outputs)
+                )
+                prefill_device_done = time.time()
+                iter_new_tokens += _record_prefill(prefill_admission)
+                if prefill_admission is not None:
+                    logger.info(
+                        "Prefill admission %d: %d requests, %d seqs, %d prompt tokens, %.3fs",
+                        prefill_admissions,
+                        prefill_admission.plan.request_count,
+                        prefill_admission.plan.sequence_count,
+                        prefill_admission.plan.prompt_tokens,
+                        prefill_device_done - prefill_start,
+                    )
+                logger.debug("Prefill submit overhead %.3fs", prefill_submit_done - prefill_start)
 
             fake_submit_start = time.time()
             # future_state, decode_outputs = _run_generation_loop(
@@ -1531,7 +1647,8 @@ class InferenceEngine:
             self.gen_state = future_state
 
             extract_start = time.time()
-            new_tokens = self._ingest_outputs(decode_outputs)
+            decode_new_tokens = self._ingest_outputs(decode_outputs)
+            new_tokens = iter_new_tokens + decode_new_tokens
             extract_time = time.time() - extract_start
 
             iter_end = time.time()
@@ -1587,7 +1704,13 @@ class InferenceEngine:
         for rid in call_rids:
             if rid in self.results:
                 self.results.pop(rid, None)
-        return GenerationResult(tokens=outputs_list, logprobs=logprobs_list, total_generated=total_generated)
+        return GenerationResult(
+            tokens=outputs_list,
+            logprobs=logprobs_list,
+            total_generated=total_generated,
+            prefill_admissions=prefill_admissions,
+            prefill_prompt_tokens_per_admission=prefill_prompt_tokens_per_admission,
+        )
 
     def generate_without_lm_head(self, requests: Sequence[Request]) -> GenerationResult:
         """Diagnostic generation path that skips LM-head projection and sampling after prefill.
@@ -1596,6 +1719,7 @@ class InferenceEngine:
         is seeded in the usual way; subsequent decode rounds run the transformer and cache update, then enqueue dummy
         token IDs.
         """
+        self._reject_diagnostic_multi_prefill(requests, "generate_without_lm_head")
         self.reset()
 
         call_rids = [int(r.request_id) for r in requests]
@@ -1606,9 +1730,12 @@ class InferenceEngine:
                 k: DecodeResult(id=rid, choice=k, token_list=[]) for k in range(expected_children[rid])
             }
 
-        decode_outputs = self._prefill_batch(requests, apply_top_p=apply_top_p, return_logprobs=False)
-        _block_until_ready_optional((self.gen_state, decode_outputs))
-        self._ingest_outputs(decode_outputs)
+        prefill_admission = self._prefill_batch(requests, apply_top_p=apply_top_p, return_logprobs=False)
+        _block_until_ready_optional((self.gen_state, None if prefill_admission is None else prefill_admission.outputs))
+        self._ingest_outputs(None if prefill_admission is None else prefill_admission.outputs)
+        prefill_prompt_tokens_per_admission = (
+            [] if prefill_admission is None else [prefill_admission.plan.prompt_tokens]
+        )
 
         def _all_done() -> bool:
             for rid, n_kids in expected_children.items():
@@ -1657,7 +1784,13 @@ class InferenceEngine:
 
         for rid in call_rids:
             self.results.pop(rid, None)
-        return GenerationResult(tokens=outputs_list, logprobs=None, total_generated=total_generated)
+        return GenerationResult(
+            tokens=outputs_list,
+            logprobs=None,
+            total_generated=total_generated,
+            prefill_admissions=0 if prefill_admission is None else 1,
+            prefill_prompt_tokens_per_admission=prefill_prompt_tokens_per_admission,
+        )
 
     def generate_with_lm_head_no_sampling(self, requests: Sequence[Request]) -> GenerationResult:
         """Diagnostic generation path that computes LM-head logits but skips sampling after prefill.
@@ -1665,6 +1798,7 @@ class InferenceEngine:
         This is for performance attribution only. It keeps the transformer, cache update, and LM-head projection live,
         then enqueues dummy token IDs without argmax/top-p/logprob work.
         """
+        self._reject_diagnostic_multi_prefill(requests, "generate_with_lm_head_no_sampling")
         self.reset()
 
         call_rids = [int(r.request_id) for r in requests]
@@ -1675,9 +1809,12 @@ class InferenceEngine:
                 k: DecodeResult(id=rid, choice=k, token_list=[]) for k in range(expected_children[rid])
             }
 
-        decode_outputs = self._prefill_batch(requests, apply_top_p=apply_top_p, return_logprobs=False)
-        _block_until_ready_optional((self.gen_state, decode_outputs))
-        self._ingest_outputs(decode_outputs)
+        prefill_admission = self._prefill_batch(requests, apply_top_p=apply_top_p, return_logprobs=False)
+        _block_until_ready_optional((self.gen_state, None if prefill_admission is None else prefill_admission.outputs))
+        self._ingest_outputs(None if prefill_admission is None else prefill_admission.outputs)
+        prefill_prompt_tokens_per_admission = (
+            [] if prefill_admission is None else [prefill_admission.plan.prompt_tokens]
+        )
 
         def _all_done() -> bool:
             for rid, n_kids in expected_children.items():
@@ -1726,7 +1863,13 @@ class InferenceEngine:
 
         for rid in call_rids:
             self.results.pop(rid, None)
-        return GenerationResult(tokens=outputs_list, logprobs=None, total_generated=total_generated)
+        return GenerationResult(
+            tokens=outputs_list,
+            logprobs=None,
+            total_generated=total_generated,
+            prefill_admissions=0 if prefill_admission is None else 1,
+            prefill_prompt_tokens_per_admission=prefill_prompt_tokens_per_admission,
+        )
 
     def write_kernel_jaxprs(
         self,

--- a/lib/levanter/src/levanter/inference/engine.py
+++ b/lib/levanter/src/levanter/inference/engine.py
@@ -1029,6 +1029,12 @@ class GenerationResult:
     prefill_admissions: int = 0
     prefill_prompt_tokens_per_admission: list[int] = field(default_factory=list)
     prefill_seconds_per_admission: list[float] = field(default_factory=list)
+    decode_seconds_per_iteration: list[float] = field(default_factory=list)
+    decode_device_seconds_per_iteration: list[float] = field(default_factory=list)
+    decode_host_seconds_per_iteration: list[float] = field(default_factory=list)
+    decode_submit_seconds_per_iteration: list[float] = field(default_factory=list)
+    decode_extract_seconds_per_iteration: list[float] = field(default_factory=list)
+    decode_tokens_per_iteration: list[int] = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -1490,6 +1496,12 @@ class InferenceEngine:
         prefill_admissions = 0
         prefill_prompt_tokens_per_admission: list[int] = []
         prefill_seconds_per_admission: list[float] = []
+        decode_seconds_per_iteration: list[float] = []
+        decode_device_seconds_per_iteration: list[float] = []
+        decode_host_seconds_per_iteration: list[float] = []
+        decode_submit_seconds_per_iteration: list[float] = []
+        decode_extract_seconds_per_iteration: list[float] = []
+        decode_tokens_per_iteration: list[int] = []
         # Initialize fresh result buckets for this call
         for rid in call_rids:
             self.results[rid] = {
@@ -1662,6 +1674,12 @@ class InferenceEngine:
             # Host time is everything except the device execution wait
             host_time = max(iter_time - device_time, 0.0)
             submit_time = submit_done - submit_start
+            decode_seconds_per_iteration.append(iter_time)
+            decode_device_seconds_per_iteration.append(device_time)
+            decode_host_seconds_per_iteration.append(host_time)
+            decode_submit_seconds_per_iteration.append(submit_time)
+            decode_extract_seconds_per_iteration.append(extract_time)
+            decode_tokens_per_iteration.append(new_tokens)
             if iter_time > 0:
                 tps_total = new_tokens / iter_time
                 logger.info(
@@ -1717,6 +1735,12 @@ class InferenceEngine:
             prefill_admissions=prefill_admissions,
             prefill_prompt_tokens_per_admission=prefill_prompt_tokens_per_admission,
             prefill_seconds_per_admission=prefill_seconds_per_admission,
+            decode_seconds_per_iteration=decode_seconds_per_iteration,
+            decode_device_seconds_per_iteration=decode_device_seconds_per_iteration,
+            decode_host_seconds_per_iteration=decode_host_seconds_per_iteration,
+            decode_submit_seconds_per_iteration=decode_submit_seconds_per_iteration,
+            decode_extract_seconds_per_iteration=decode_extract_seconds_per_iteration,
+            decode_tokens_per_iteration=decode_tokens_per_iteration,
         )
 
     def generate_without_lm_head(self, requests: Sequence[Request]) -> GenerationResult:

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -254,6 +254,11 @@ class InferenceContext:
         self.last_decode_submit_seconds_per_iteration: list[float] = []
         self.last_decode_extract_seconds_per_iteration: list[float] = []
         self.last_decode_tokens_per_iteration: list[int] = []
+        self.last_prefill_drain_seconds_per_iteration: list[float] = []
+        self.last_prefill_drain_tokens_per_iteration: list[int] = []
+        self.last_generation_seconds_per_iteration: list[float] = []
+        self.last_generation_host_seconds_per_iteration: list[float] = []
+        self.last_generation_tokens_per_iteration: list[int] = []
 
     def start(self):
         """Start the inference and batch processing threads"""
@@ -511,10 +516,16 @@ class InferenceContext:
         self.last_decode_submit_seconds_per_iteration = list(result.decode_submit_seconds_per_iteration)
         self.last_decode_extract_seconds_per_iteration = list(result.decode_extract_seconds_per_iteration)
         self.last_decode_tokens_per_iteration = list(result.decode_tokens_per_iteration)
+        self.last_prefill_drain_seconds_per_iteration = list(result.prefill_drain_seconds_per_iteration)
+        self.last_prefill_drain_tokens_per_iteration = list(result.prefill_drain_tokens_per_iteration)
+        self.last_generation_seconds_per_iteration = list(result.generation_seconds_per_iteration)
+        self.last_generation_host_seconds_per_iteration = list(result.generation_host_seconds_per_iteration)
+        self.last_generation_tokens_per_iteration = list(result.generation_tokens_per_iteration)
         duration = time.time() - start_time
         logger.info(
             "Batch completed in %.2fs, generated %d tokens, prefill admissions=%d chunks=%s seconds=%s "
-            "decode_seconds=%s decode_device_seconds=%s decode_tokens=%s",
+            "decode_seconds=%s decode_device_seconds=%s decode_tokens=%s "
+            "prefill_drain_seconds=%s generation_seconds=%s",
             duration,
             result.total_generated,
             result.prefill_admissions,
@@ -523,6 +534,8 @@ class InferenceContext:
             result.decode_seconds_per_iteration,
             result.decode_device_seconds_per_iteration,
             result.decode_tokens_per_iteration,
+            result.prefill_drain_seconds_per_iteration,
+            result.generation_seconds_per_iteration,
         )
 
         # Return results to futures

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -123,12 +123,10 @@ def _request_fits_batch(
     request: InferenceRequest,
     *,
     max_seqs: int,
-    max_prompt_tokens_per_batch: int,
     max_tokens_per_batch: int,
 ) -> bool:
     return (
         batch.num_seqs() + request.n_generations <= max_seqs
-        and batch.prompt_tokens() + len(request.prompt_tokens) <= max_prompt_tokens_per_batch
         and batch.total_tokens() + len(request.prompt_tokens) + request.max_tokens <= max_tokens_per_batch
     )
 
@@ -138,7 +136,6 @@ def _merge_ready_batches(
     ready_batches: list[InferenceBatch],
     *,
     max_seqs: int,
-    max_prompt_tokens_per_batch: int,
     max_tokens_per_batch: int,
 ) -> tuple[InferenceBatch, list[InferenceBatch]]:
     """Merge already-queued inference batches while preserving request order."""
@@ -153,7 +150,6 @@ def _merge_ready_batches(
                 merged,
                 request,
                 max_seqs=max_seqs,
-                max_prompt_tokens_per_batch=max_prompt_tokens_per_batch,
                 max_tokens_per_batch=max_tokens_per_batch,
             ):
                 merged.append(request)
@@ -235,6 +231,8 @@ class InferenceContext:
         self.inference_thread = threading.Thread(target=self._inference_loop, daemon=True)
         self.batch_thread = threading.Thread(target=self._batch_processing_loop, daemon=True)
         self._next_request_id = 0
+        self.last_prefill_admissions: int | None = None
+        self.last_prefill_prompt_tokens_per_admission: list[int] = []
 
     def start(self):
         """Start the inference and batch processing threads"""
@@ -376,7 +374,6 @@ class InferenceContext:
                     batch,
                     r,
                     max_seqs=self.engine.config.max_seqs,
-                    max_prompt_tokens_per_batch=max_prompt_tokens_per_batch,
                     max_tokens_per_batch=max_tokens_per_batch,
                 ):
                     batch.append(r)
@@ -403,7 +400,6 @@ class InferenceContext:
                         batch,
                         ready_batches,
                         max_seqs=self.engine.config.max_seqs,
-                        max_prompt_tokens_per_batch=_max_prompt_tokens_per_batch(self.engine),
                         max_tokens_per_batch=_max_tokens_per_batch(self.engine),
                     )
                     for leftover in leftovers:
@@ -474,8 +470,16 @@ class InferenceContext:
         # Generate responses
         start_time = time.time()
         result = self.engine.generate(service_requests)
+        self.last_prefill_admissions = result.prefill_admissions
+        self.last_prefill_prompt_tokens_per_admission = list(result.prefill_prompt_tokens_per_admission)
         duration = time.time() - start_time
-        logger.info(f"Batch completed in {duration:.2f}s, generated {result.total_generated} tokens")
+        logger.info(
+            "Batch completed in %.2fs, generated %d tokens, prefill admissions=%d chunks=%s",
+            duration,
+            result.total_generated,
+            result.prefill_admissions,
+            result.prefill_prompt_tokens_per_admission,
+        )
 
         # Return results to futures
         output_idx = 0

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -247,6 +247,7 @@ class InferenceContext:
         self._next_request_id = 0
         self.last_prefill_admissions: int | None = None
         self.last_prefill_prompt_tokens_per_admission: list[int] = []
+        self.last_prefill_seconds_per_admission: list[float] = []
 
     def start(self):
         """Start the inference and batch processing threads"""
@@ -489,13 +490,15 @@ class InferenceContext:
         result = self.engine.generate(service_requests)
         self.last_prefill_admissions = result.prefill_admissions
         self.last_prefill_prompt_tokens_per_admission = list(result.prefill_prompt_tokens_per_admission)
+        self.last_prefill_seconds_per_admission = list(result.prefill_seconds_per_admission)
         duration = time.time() - start_time
         logger.info(
-            "Batch completed in %.2fs, generated %d tokens, prefill admissions=%d chunks=%s",
+            "Batch completed in %.2fs, generated %d tokens, prefill admissions=%d chunks=%s seconds=%s",
             duration,
             result.total_generated,
             result.prefill_admissions,
             result.prefill_prompt_tokens_per_admission,
+            result.prefill_seconds_per_admission,
         )
 
         # Return results to futures

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -337,7 +337,15 @@ class InferenceContext:
             return_logprobs=return_logprobs,
         )
 
-        logger.info("Enqueuing request %s", request)
+        logger.info(
+            "Enqueuing request %s: prompt_tokens=%d max_tokens=%d n=%d return_logprobs=%s echo_logprobs_top_k=%s",
+            request_id,
+            len(prompt_tokens),
+            max_tokens,
+            n_generations,
+            return_logprobs,
+            echo_logprobs_top_k,
+        )
         self.request_queue.put(request)
         return request_id
 

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -248,6 +248,12 @@ class InferenceContext:
         self.last_prefill_admissions: int | None = None
         self.last_prefill_prompt_tokens_per_admission: list[int] = []
         self.last_prefill_seconds_per_admission: list[float] = []
+        self.last_decode_seconds_per_iteration: list[float] = []
+        self.last_decode_device_seconds_per_iteration: list[float] = []
+        self.last_decode_host_seconds_per_iteration: list[float] = []
+        self.last_decode_submit_seconds_per_iteration: list[float] = []
+        self.last_decode_extract_seconds_per_iteration: list[float] = []
+        self.last_decode_tokens_per_iteration: list[int] = []
 
     def start(self):
         """Start the inference and batch processing threads"""
@@ -491,14 +497,24 @@ class InferenceContext:
         self.last_prefill_admissions = result.prefill_admissions
         self.last_prefill_prompt_tokens_per_admission = list(result.prefill_prompt_tokens_per_admission)
         self.last_prefill_seconds_per_admission = list(result.prefill_seconds_per_admission)
+        self.last_decode_seconds_per_iteration = list(result.decode_seconds_per_iteration)
+        self.last_decode_device_seconds_per_iteration = list(result.decode_device_seconds_per_iteration)
+        self.last_decode_host_seconds_per_iteration = list(result.decode_host_seconds_per_iteration)
+        self.last_decode_submit_seconds_per_iteration = list(result.decode_submit_seconds_per_iteration)
+        self.last_decode_extract_seconds_per_iteration = list(result.decode_extract_seconds_per_iteration)
+        self.last_decode_tokens_per_iteration = list(result.decode_tokens_per_iteration)
         duration = time.time() - start_time
         logger.info(
-            "Batch completed in %.2fs, generated %d tokens, prefill admissions=%d chunks=%s seconds=%s",
+            "Batch completed in %.2fs, generated %d tokens, prefill admissions=%d chunks=%s seconds=%s "
+            "decode_seconds=%s decode_device_seconds=%s decode_tokens=%s",
             duration,
             result.total_generated,
             result.prefill_admissions,
             result.prefill_prompt_tokens_per_admission,
             result.prefill_seconds_per_admission,
+            result.decode_seconds_per_iteration,
+            result.decode_device_seconds_per_iteration,
+            result.decode_tokens_per_iteration,
         )
 
         # Return results to futures

--- a/lib/levanter/src/levanter/inference/openai.py
+++ b/lib/levanter/src/levanter/inference/openai.py
@@ -161,10 +161,24 @@ def _merge_ready_batches(
     return merged, leftovers
 
 
-def _drain_ready_batches(batch_queue: queue.Queue) -> list[InferenceBatch]:
-    """Return batches already waiting behind the next executable batch."""
+def _drain_ready_batches(batch_queue: queue.Queue, *, coalesce_timeout: float = 0.0) -> list[InferenceBatch]:
+    """Return batches waiting behind the next executable batch.
+
+    If no batch is immediately ready, wait briefly for a batch that is still
+    being assembled by the request-collection thread.
+    """
 
     batches = []
+    try:
+        batches.append(batch_queue.get_nowait())
+    except queue.Empty:
+        if coalesce_timeout <= 0:
+            return batches
+        try:
+            batches.append(batch_queue.get(timeout=coalesce_timeout))
+        except queue.Empty:
+            return batches
+
     while True:
         try:
             batches.append(batch_queue.get_nowait())
@@ -394,7 +408,10 @@ class InferenceContext:
         while not self.shutdown_event.is_set():
             try:
                 batch = self.batch_queue.get(timeout=1)
-                ready_batches = _drain_ready_batches(self.batch_queue)
+                ready_batches = _drain_ready_batches(
+                    self.batch_queue,
+                    coalesce_timeout=self.config.batch_timeout,
+                )
                 if ready_batches:
                     batch, leftovers = _merge_ready_batches(
                         batch,

--- a/lib/levanter/tests/inference/test_engine.py
+++ b/lib/levanter/tests/inference/test_engine.py
@@ -362,6 +362,7 @@ def test_generate_admits_multiple_prefill_chunks_for_one_logical_batch():
     assert len(result.decode_seconds_per_iteration) == len(result.decode_host_seconds_per_iteration)
     assert len(result.decode_seconds_per_iteration) == len(result.decode_submit_seconds_per_iteration)
     assert len(result.decode_seconds_per_iteration) == len(result.decode_extract_seconds_per_iteration)
+    assert len(result.decode_tokens_per_iteration) == 1
     assert 0 < sum(result.decode_tokens_per_iteration) <= result.total_generated
     assert all(seconds >= 0.0 for seconds in result.decode_device_seconds_per_iteration)
 

--- a/lib/levanter/tests/inference/test_engine.py
+++ b/lib/levanter/tests/inference/test_engine.py
@@ -355,6 +355,8 @@ def test_generate_admits_multiple_prefill_chunks_for_one_logical_batch():
     assert result.total_generated == 8
     assert result.prefill_admissions == 2
     assert result.prefill_prompt_tokens_per_admission == [4, 4]
+    assert len(result.prefill_seconds_per_admission) == 2
+    assert all(seconds >= 0.0 for seconds in result.prefill_seconds_per_admission)
 
 
 @pytest.mark.parametrize("method_name", ["generate_without_lm_head", "generate_with_lm_head_no_sampling"])

--- a/lib/levanter/tests/inference/test_engine.py
+++ b/lib/levanter/tests/inference/test_engine.py
@@ -357,6 +357,13 @@ def test_generate_admits_multiple_prefill_chunks_for_one_logical_batch():
     assert result.prefill_prompt_tokens_per_admission == [4, 4]
     assert len(result.prefill_seconds_per_admission) == 2
     assert all(seconds >= 0.0 for seconds in result.prefill_seconds_per_admission)
+    assert result.decode_seconds_per_iteration
+    assert len(result.decode_seconds_per_iteration) == len(result.decode_device_seconds_per_iteration)
+    assert len(result.decode_seconds_per_iteration) == len(result.decode_host_seconds_per_iteration)
+    assert len(result.decode_seconds_per_iteration) == len(result.decode_submit_seconds_per_iteration)
+    assert len(result.decode_seconds_per_iteration) == len(result.decode_extract_seconds_per_iteration)
+    assert 0 < sum(result.decode_tokens_per_iteration) <= result.total_generated
+    assert all(seconds >= 0.0 for seconds in result.decode_device_seconds_per_iteration)
 
 
 @pytest.mark.parametrize("method_name", ["generate_without_lm_head", "generate_with_lm_head_no_sampling"])

--- a/lib/levanter/tests/inference/test_engine.py
+++ b/lib/levanter/tests/inference/test_engine.py
@@ -314,6 +314,87 @@ def test_generate_streaming_greedy_lm_head_emits_argmax_tokens_after_prefill():
     assert result.tokens == [[3, 3, 3]]
 
 
+def test_generate_admits_multiple_prefill_chunks_for_one_logical_batch():
+    model = DummyModel(vocab_size=10, eos_id=3)
+    service = InferenceEngine.from_model_with_config(
+        model=model,  # type: ignore
+        tokenizer=None,
+        config=InferenceEngineConfig(
+            max_seq_len=32,
+            max_pages=64,
+            max_seqs=4,
+            page_size=8,
+            compute_dtype=jnp.float32,
+            max_queued_tokens=16,
+            max_rounds=1,
+            max_prefill_size=4,
+            max_seqs_in_prefill=4,
+            use_streaming_greedy_lm_head=True,
+        ),
+    )
+    requests = [
+        Request(
+            prompt_tokens=[1, 2],
+            request_id=request_id,
+            decode_params=SeqDecodingParams(
+                max_num_tokens=jnp.asarray(4, dtype=jnp.int32),
+                stop_tokens=None,
+                temperature=jnp.asarray(0.0, dtype=jnp.float32),
+                top_p=jnp.asarray(1.0, dtype=jnp.float32),
+                top_k=jnp.asarray(0, dtype=jnp.int32),
+                key=jax.random.PRNGKey(request_id),
+            ),
+            n_generations=1,
+        )
+        for request_id in range(4)
+    ]
+
+    result = service.generate(requests)
+
+    assert result.tokens == [[3, 3], [3, 3], [3, 3], [3, 3]]
+    assert result.total_generated == 8
+    assert result.prefill_admissions == 2
+    assert result.prefill_prompt_tokens_per_admission == [4, 4]
+
+
+@pytest.mark.parametrize("method_name", ["generate_without_lm_head", "generate_with_lm_head_no_sampling"])
+def test_diagnostic_generation_rejects_aggregate_prefill_overflow(method_name):
+    model = DummyModel(vocab_size=10, eos_id=3)
+    service = InferenceEngine.from_model_with_config(
+        model=model,  # type: ignore
+        tokenizer=None,
+        config=InferenceEngineConfig(
+            max_seq_len=32,
+            max_pages=64,
+            max_seqs=4,
+            page_size=8,
+            compute_dtype=jnp.float32,
+            max_queued_tokens=16,
+            max_prefill_size=4,
+            max_seqs_in_prefill=4,
+        ),
+    )
+    requests = [
+        Request(
+            prompt_tokens=[1, 2],
+            request_id=request_id,
+            decode_params=SeqDecodingParams(
+                max_num_tokens=jnp.asarray(4, dtype=jnp.int32),
+                stop_tokens=None,
+                temperature=jnp.asarray(0.0, dtype=jnp.float32),
+                top_p=jnp.asarray(1.0, dtype=jnp.float32),
+                top_k=jnp.asarray(0, dtype=jnp.int32),
+                key=jax.random.PRNGKey(request_id),
+            ),
+            n_generations=1,
+        )
+        for request_id in range(3)
+    ]
+
+    with pytest.raises(ValueError, match="aggregate prompt tokens"):
+        getattr(service, method_name)(requests)
+
+
 def test_streaming_greedy_lm_head_returns_logprobs_without_materialized_logits():
     Pos = Axis("position", 2)
     Embed = Axis("embed", 2)

--- a/lib/levanter/tests/inference/test_engine.py
+++ b/lib/levanter/tests/inference/test_engine.py
@@ -367,7 +367,7 @@ def test_generate_admits_multiple_prefill_chunks_for_one_logical_batch():
 
 
 @pytest.mark.parametrize("method_name", ["generate_without_lm_head", "generate_with_lm_head_no_sampling"])
-def test_diagnostic_generation_rejects_aggregate_prefill_overflow(method_name):
+def test_diagnostic_generation_supports_multi_prefill(method_name):
     model = DummyModel(vocab_size=10, eos_id=3)
     service = InferenceEngine.from_model_with_config(
         model=model,  # type: ignore
@@ -400,8 +400,18 @@ def test_diagnostic_generation_rejects_aggregate_prefill_overflow(method_name):
         for request_id in range(3)
     ]
 
-    with pytest.raises(ValueError, match="aggregate prompt tokens"):
-        getattr(service, method_name)(requests)
+    result = getattr(service, method_name)(requests)
+
+    assert result.total_generated == 6
+    assert result.prefill_admissions == 2
+    assert result.prefill_prompt_tokens_per_admission == [4, 2]
+    assert len(result.prefill_seconds_per_admission) == 2
+    assert result.decode_seconds_per_iteration
+    assert len(result.decode_seconds_per_iteration) == len(result.decode_device_seconds_per_iteration)
+    assert len(result.decode_seconds_per_iteration) == len(result.decode_host_seconds_per_iteration)
+    assert len(result.decode_seconds_per_iteration) == len(result.decode_submit_seconds_per_iteration)
+    assert len(result.decode_seconds_per_iteration) == len(result.decode_extract_seconds_per_iteration)
+    assert 0 < sum(result.decode_tokens_per_iteration) <= result.total_generated
 
 
 def test_streaming_greedy_lm_head_returns_logprobs_without_materialized_logits():

--- a/lib/levanter/tests/inference/test_engine.py
+++ b/lib/levanter/tests/inference/test_engine.py
@@ -412,6 +412,7 @@ def test_diagnostic_generation_supports_multi_prefill(method_name):
     assert len(result.decode_seconds_per_iteration) == len(result.decode_host_seconds_per_iteration)
     assert len(result.decode_seconds_per_iteration) == len(result.decode_submit_seconds_per_iteration)
     assert len(result.decode_seconds_per_iteration) == len(result.decode_extract_seconds_per_iteration)
+    assert len(result.decode_tokens_per_iteration) == 1
     assert 0 < sum(result.decode_tokens_per_iteration) <= result.total_generated
 
 

--- a/lib/levanter/tests/inference/test_engine.py
+++ b/lib/levanter/tests/inference/test_engine.py
@@ -362,9 +362,17 @@ def test_generate_admits_multiple_prefill_chunks_for_one_logical_batch():
     assert len(result.decode_seconds_per_iteration) == len(result.decode_host_seconds_per_iteration)
     assert len(result.decode_seconds_per_iteration) == len(result.decode_submit_seconds_per_iteration)
     assert len(result.decode_seconds_per_iteration) == len(result.decode_extract_seconds_per_iteration)
+    assert len(result.decode_seconds_per_iteration) == len(result.prefill_drain_seconds_per_iteration)
+    assert len(result.decode_seconds_per_iteration) == len(result.prefill_drain_tokens_per_iteration)
+    assert len(result.decode_seconds_per_iteration) == len(result.generation_seconds_per_iteration)
+    assert len(result.decode_seconds_per_iteration) == len(result.generation_host_seconds_per_iteration)
+    assert len(result.decode_seconds_per_iteration) == len(result.generation_tokens_per_iteration)
     assert len(result.decode_tokens_per_iteration) == 1
     assert 0 < sum(result.decode_tokens_per_iteration) <= result.total_generated
+    assert 0 < sum(result.generation_tokens_per_iteration) <= sum(result.decode_tokens_per_iteration)
     assert all(seconds >= 0.0 for seconds in result.decode_device_seconds_per_iteration)
+    assert all(seconds >= 0.0 for seconds in result.prefill_drain_seconds_per_iteration)
+    assert all(seconds >= 0.0 for seconds in result.generation_seconds_per_iteration)
 
 
 @pytest.mark.parametrize("method_name", ["generate_without_lm_head", "generate_with_lm_head_no_sampling"])

--- a/lib/levanter/tests/inference/test_inference_server.py
+++ b/lib/levanter/tests/inference/test_inference_server.py
@@ -1,10 +1,12 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import asyncio
 import logging
 import queue
 import time
 from concurrent.futures import ThreadPoolExecutor
+from typing import Any, cast
 
 import equinox as eqx
 import haliax as hax
@@ -29,6 +31,7 @@ try:
     )
     from levanter.inference.openai import (
         InferenceBatch,
+        InferenceContext,
         InferenceRequest,
         InferenceResponse,
         InferenceServer,
@@ -41,6 +44,39 @@ except ImportError:
     pytest.skip("Serving imports not installed, use --extra=serve", allow_module_level=True)
 
 logger = logging.getLogger(__name__)
+
+
+def test_submit_request_log_does_not_dump_prompt_tokens(caplog):
+    context = InferenceContext(
+        model=cast(Any, object()),
+        tokenizer=object(),
+        engine=cast(Any, object()),
+        config=InferenceServerConfig(),
+    )
+    loop = asyncio.new_event_loop()
+    try:
+        future = loop.create_future()
+        prompt_tokens = list(range(2048))
+
+        with caplog.at_level(logging.INFO, logger="levanter.inference.openai"):
+            context.submit_request(
+                prompt_tokens=prompt_tokens,
+                max_tokens=128,
+                temperature=0.0,
+                top_p=1.0,
+                top_k=None,
+                stop_tokens=None,
+                seed=7,
+                future=future,
+                n_generations=1,
+            )
+    finally:
+        loop.close()
+
+    assert "prompt_tokens=2048" in caplog.text
+    assert "prompt_tokens=[0, 1, 2" not in caplog.text
+    request = context.request_queue.get_nowait()
+    assert request.prompt_tokens == prompt_tokens
 
 
 def _inference_request(

--- a/lib/levanter/tests/inference/test_inference_server.py
+++ b/lib/levanter/tests/inference/test_inference_server.py
@@ -73,7 +73,6 @@ def test_merge_ready_batches_coalesces_pending_work_up_to_sequence_limit():
         first_batch,
         ready_batches,
         max_seqs=16,
-        max_prompt_tokens_per_batch=4096,
         max_tokens_per_batch=4096,
     )
 
@@ -93,7 +92,6 @@ def test_merge_ready_batches_preserves_overflow_order():
         first_batch,
         ready_batches,
         max_seqs=16,
-        max_prompt_tokens_per_batch=4096,
         max_tokens_per_batch=4096,
     )
 
@@ -101,7 +99,7 @@ def test_merge_ready_batches_preserves_overflow_order():
     assert [[request.request_id for request in leftover] for leftover in leftovers] == [["req_2"], ["req_3"]]
 
 
-def test_merge_ready_batches_respects_prefill_prompt_budget():
+def test_merge_ready_batches_allows_aggregate_prompts_over_prefill_budget():
     first_batch = InferenceBatch([_inference_request("req_0", n_generations=1, prompt_tokens=512, max_tokens=1)])
     ready_batches = [
         InferenceBatch(
@@ -117,12 +115,11 @@ def test_merge_ready_batches_respects_prefill_prompt_budget():
         first_batch,
         ready_batches,
         max_seqs=16,
-        max_prompt_tokens_per_batch=1024,
         max_tokens_per_batch=4096,
     )
 
-    assert [request.request_id for request in merged] == ["req_0", "req_1"]
-    assert [[request.request_id for request in leftover] for leftover in leftovers] == [["req_2"], ["req_3"]]
+    assert [request.request_id for request in merged] == ["req_0", "req_1", "req_2", "req_3"]
+    assert leftovers == []
 
 
 @pytest.fixture(scope="module")

--- a/lib/levanter/tests/inference/test_inference_server.py
+++ b/lib/levanter/tests/inference/test_inference_server.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import logging
+import queue
 import time
 from concurrent.futures import ThreadPoolExecutor
 
@@ -32,6 +33,7 @@ try:
         InferenceResponse,
         InferenceServer,
         InferenceServerConfig,
+        _drain_ready_batches,
         _merge_ready_batches,
     )
 
@@ -120,6 +122,34 @@ def test_merge_ready_batches_allows_aggregate_prompts_over_prefill_budget():
 
     assert [request.request_id for request in merged] == ["req_0", "req_1", "req_2", "req_3"]
     assert leftovers == []
+
+
+def test_drain_ready_batches_uses_coalescing_window_for_trailing_work():
+    delayed_batch = InferenceBatch([_inference_request("req_1", n_generations=1)])
+    immediate_batch = InferenceBatch([_inference_request("req_2", n_generations=1)])
+
+    class DelayedBatchQueue:
+        def __init__(self):
+            self.timeout_seen: float | None = None
+            self.ready_batches = [immediate_batch]
+
+        def get_nowait(self):
+            if self.timeout_seen is None:
+                raise queue.Empty
+            if self.ready_batches:
+                return self.ready_batches.pop(0)
+            raise queue.Empty
+
+        def get(self, timeout: float):
+            self.timeout_seen = timeout
+            return delayed_batch
+
+    batch_queue = DelayedBatchQueue()
+
+    batches = _drain_ready_batches(batch_queue, coalesce_timeout=0.25)
+
+    assert batch_queue.timeout_seen == 0.25
+    assert [[request.request_id for request in batch] for batch in batches] == [["req_1"], ["req_2"]]
 
 
 @pytest.fixture(scope="module")

--- a/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
+++ b/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
@@ -722,6 +722,9 @@ def _case_result(
     compile_including_seconds: float | None = None,
     hbm_used_bytes: int | None = None,
     compiled_shape_count: int | None = None,
+    decode_seconds_per_iteration: list[float] | None = None,
+    decode_device_seconds_per_iteration: list[float] | None = None,
+    decode_tokens_per_iteration: list[int] | None = None,
 ) -> bench.CaseResult:
     return bench.CaseResult(
         case_name=case_name,
@@ -743,6 +746,9 @@ def _case_result(
         total_tokens_per_second=decode_tokens_per_second + 1.0,
         hbm_used_bytes=hbm_used_bytes,
         compiled_shape_count=compiled_shape_count,
+        decode_seconds_per_iteration=decode_seconds_per_iteration,
+        decode_device_seconds_per_iteration=decode_device_seconds_per_iteration,
+        decode_tokens_per_iteration=decode_tokens_per_iteration,
     )
 
 
@@ -758,6 +764,9 @@ def test_summary_markdown_includes_vllm_ratio_columns(tmp_path):
                 compile_including_seconds=12.3456,
                 hbm_used_bytes=123456,
                 compiled_shape_count=2,
+                decode_seconds_per_iteration=[0.5],
+                decode_device_seconds_per_iteration=[0.25],
+                decode_tokens_per_iteration=[100],
             ),
         ],
         {"backend": "both"},
@@ -777,7 +786,11 @@ def test_summary_markdown_includes_vllm_ratio_columns(tmp_path):
     assert "decode device s" in summary
     assert "decode host s" in summary
     assert "decode iter toks" in summary
+    assert "decode iter tok/s" in summary
+    assert "decode device tok/s" in summary
     assert "0.900" in summary
+    assert "200.000" in summary
+    assert "400.000" in summary
     assert "pass" in summary
     assert "12.346" in summary
     assert "123456" in summary
@@ -790,7 +803,14 @@ def test_summary_json_includes_machine_readable_parity_comparisons(tmp_path):
             _case_result("decode_b8_i1_o128_n1", "vllm-tpu", 100.0),
             _case_result("decode_b8_i1_o128_n1", "levanter:auto", 90.0),
             _case_result("decode_b32_i1_o128_n1", "vllm-tpu", 100.0),
-            _case_result("decode_b32_i1_o128_n1", "levanter:auto", 70.0),
+            _case_result(
+                "decode_b32_i1_o128_n1",
+                "levanter:auto",
+                70.0,
+                decode_seconds_per_iteration=[0.25, 0.25],
+                decode_device_seconds_per_iteration=[0.2, 0.2],
+                decode_tokens_per_iteration=[64, 64],
+            ),
         ],
         {"backend": "both"},
     )
@@ -803,6 +823,13 @@ def test_summary_json_includes_machine_readable_parity_comparisons(tmp_path):
     assert comparisons["decode_b8_i1_o128_n1"]["meets_decode_ratio_target"] is True
     assert comparisons["decode_b32_i1_o128_n1"]["decode_ratio"] == 0.7
     assert comparisons["decode_b32_i1_o128_n1"]["meets_decode_ratio_target"] is False
+    levanter_rows = [
+        result
+        for result in summary["results"]
+        if result["case_name"] == "decode_b32_i1_o128_n1" and result["backend"] == "levanter:auto"
+    ]
+    assert levanter_rows[0]["decode_iteration_tokens_per_second"] == pytest.approx(256.0)
+    assert levanter_rows[0]["decode_device_tokens_per_second"] == pytest.approx(320.0)
 
 
 def _stress_result() -> bench.StressResult:

--- a/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
+++ b/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
@@ -1436,6 +1436,8 @@ def test_run_levanter_without_lm_head_case_preserves_warmup_flag(monkeypatch):
 
             class Result:
                 total_generated = 2
+                prefill_admissions = 1
+                prefill_prompt_tokens_per_admission = [1]
 
             return Result()
 
@@ -1514,6 +1516,8 @@ def test_run_levanter_without_lm_head_case_preserves_warmup_flag(monkeypatch):
     assert lm_head_no_sampling.backend == "levanter:auto:lm_head_no_sampling"
     assert measured.hbm_used_bytes == 123
     assert measured.compiled_shape_count == 2
+    assert warmup.prefill_admissions == 1
+    assert warmup.prefill_prompt_tokens_per_admission == [1]
     assert events == [
         "enter:mesh",
         "enter:axis_mapping",

--- a/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
+++ b/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
@@ -725,6 +725,11 @@ def _case_result(
     decode_seconds_per_iteration: list[float] | None = None,
     decode_device_seconds_per_iteration: list[float] | None = None,
     decode_tokens_per_iteration: list[int] | None = None,
+    prefill_drain_seconds_per_iteration: list[float] | None = None,
+    prefill_drain_tokens_per_iteration: list[int] | None = None,
+    generation_seconds_per_iteration: list[float] | None = None,
+    generation_host_seconds_per_iteration: list[float] | None = None,
+    generation_tokens_per_iteration: list[int] | None = None,
 ) -> bench.CaseResult:
     return bench.CaseResult(
         case_name=case_name,
@@ -749,6 +754,11 @@ def _case_result(
         decode_seconds_per_iteration=decode_seconds_per_iteration,
         decode_device_seconds_per_iteration=decode_device_seconds_per_iteration,
         decode_tokens_per_iteration=decode_tokens_per_iteration,
+        prefill_drain_seconds_per_iteration=prefill_drain_seconds_per_iteration,
+        prefill_drain_tokens_per_iteration=prefill_drain_tokens_per_iteration,
+        generation_seconds_per_iteration=generation_seconds_per_iteration,
+        generation_host_seconds_per_iteration=generation_host_seconds_per_iteration,
+        generation_tokens_per_iteration=generation_tokens_per_iteration,
     )
 
 
@@ -767,6 +777,11 @@ def test_summary_markdown_includes_vllm_ratio_columns(tmp_path):
                 decode_seconds_per_iteration=[0.5],
                 decode_device_seconds_per_iteration=[0.25],
                 decode_tokens_per_iteration=[100],
+                prefill_drain_seconds_per_iteration=[0.1],
+                prefill_drain_tokens_per_iteration=[20],
+                generation_seconds_per_iteration=[0.4],
+                generation_host_seconds_per_iteration=[0.15],
+                generation_tokens_per_iteration=[80],
             ),
         ],
         {"backend": "both"},
@@ -786,11 +801,18 @@ def test_summary_markdown_includes_vllm_ratio_columns(tmp_path):
     assert "decode device s" in summary
     assert "decode host s" in summary
     assert "decode iter toks" in summary
+    assert "prefill drain s" in summary
+    assert "prefill drain toks" in summary
+    assert "generation s" in summary
+    assert "generation host s" in summary
+    assert "generation toks" in summary
     assert "decode iter tok/s" in summary
     assert "decode device tok/s" in summary
+    assert "generation tok/s" in summary
     assert "0.900" in summary
     assert "200.000" in summary
     assert "400.000" in summary
+    assert "200.000" in summary
     assert "pass" in summary
     assert "12.346" in summary
     assert "123456" in summary
@@ -810,6 +832,8 @@ def test_summary_json_includes_machine_readable_parity_comparisons(tmp_path):
                 decode_seconds_per_iteration=[0.25, 0.25],
                 decode_device_seconds_per_iteration=[0.2, 0.2],
                 decode_tokens_per_iteration=[64, 64],
+                generation_seconds_per_iteration=[0.24, 0.24],
+                generation_tokens_per_iteration=[60, 60],
             ),
         ],
         {"backend": "both"},
@@ -830,6 +854,7 @@ def test_summary_json_includes_machine_readable_parity_comparisons(tmp_path):
     ]
     assert levanter_rows[0]["decode_iteration_tokens_per_second"] == pytest.approx(256.0)
     assert levanter_rows[0]["decode_device_tokens_per_second"] == pytest.approx(320.0)
+    assert levanter_rows[0]["generation_tokens_per_second"] == pytest.approx(120 / 0.48)
 
 
 def _stress_result() -> bench.StressResult:
@@ -1156,6 +1181,11 @@ def test_run_case_propagates_backend_static_metrics(monkeypatch):
             "decode_submit_seconds_per_iteration": [0.01],
             "decode_extract_seconds_per_iteration": [0.02],
             "decode_tokens_per_iteration": [2],
+            "prefill_drain_seconds_per_iteration": [0.03],
+            "prefill_drain_tokens_per_iteration": [1],
+            "generation_seconds_per_iteration": [0.22],
+            "generation_host_seconds_per_iteration": [0.02],
+            "generation_tokens_per_iteration": [1],
         }
 
     monkeypatch.setattr(bench, "_send_completion", send_completion)
@@ -1192,6 +1222,11 @@ def test_run_case_propagates_backend_static_metrics(monkeypatch):
     assert result.decode_submit_seconds_per_iteration == [0.01]
     assert result.decode_extract_seconds_per_iteration == [0.02]
     assert result.decode_tokens_per_iteration == [2]
+    assert result.prefill_drain_seconds_per_iteration == [0.03]
+    assert result.prefill_drain_tokens_per_iteration == [1]
+    assert result.generation_seconds_per_iteration == [0.22]
+    assert result.generation_host_seconds_per_iteration == [0.02]
+    assert result.generation_tokens_per_iteration == [1]
 
 
 def test_run_stress_case_aggregates_success_failures_and_service_metrics(monkeypatch):
@@ -1530,6 +1565,11 @@ def test_run_levanter_without_lm_head_case_preserves_warmup_flag(monkeypatch):
                 decode_submit_seconds_per_iteration = [0.01]
                 decode_extract_seconds_per_iteration = [0.02]
                 decode_tokens_per_iteration = [2]
+                prefill_drain_seconds_per_iteration = [0.03]
+                prefill_drain_tokens_per_iteration = [1]
+                generation_seconds_per_iteration = [0.22]
+                generation_host_seconds_per_iteration = [0.02]
+                generation_tokens_per_iteration = [1]
 
             return Result()
 

--- a/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
+++ b/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
@@ -772,6 +772,7 @@ def test_summary_markdown_includes_vllm_ratio_columns(tmp_path):
     assert "ttft p50 ms" in summary
     assert "hbm bytes" in summary
     assert "shape buckets" in summary
+    assert "prefill s" in summary
     assert "0.900" in summary
     assert "pass" in summary
     assert "12.346" in summary
@@ -1438,6 +1439,7 @@ def test_run_levanter_without_lm_head_case_preserves_warmup_flag(monkeypatch):
                 total_generated = 2
                 prefill_admissions = 1
                 prefill_prompt_tokens_per_admission = [1]
+                prefill_seconds_per_admission = [0.5]
 
             return Result()
 
@@ -1518,6 +1520,7 @@ def test_run_levanter_without_lm_head_case_preserves_warmup_flag(monkeypatch):
     assert measured.compiled_shape_count == 2
     assert warmup.prefill_admissions == 1
     assert warmup.prefill_prompt_tokens_per_admission == [1]
+    assert warmup.prefill_seconds_per_admission == [0.5]
     assert events == [
         "enter:mesh",
         "enter:axis_mapping",

--- a/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
+++ b/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
@@ -983,6 +983,36 @@ def test_start_backend_places_vllm_logs_under_output_dir(monkeypatch, tmp_path):
     assert captured["log_dir"] == tmp_path / "vllm_profiles"
 
 
+def test_vllm_startup_poll_fails_when_process_exits():
+    class ExitedProcess:
+        def poll(self):
+            return 17
+
+    with pytest.raises(RuntimeError, match="process exited with code 17"):
+        bench._poll_json_while_process_alive("http://127.0.0.1:1234/v1/models", timeout=60, process=ExitedProcess())
+
+
+def test_vllm_startup_error_includes_log_tails(tmp_path):
+    log_dir = tmp_path / "vllm_profiles"
+    log_dir.mkdir()
+    (log_dir / "stderr.log").write_text("compile failed\nbad vmem allocation\n")
+    (log_dir / "stdout.log").write_text("loading model\n")
+
+    message = bench._vllm_startup_error_message(
+        log_dir=log_dir,
+        cmd=["vllm", "serve", "Qwen/Qwen3-8B"],
+        process_return_code=1,
+        cause=TimeoutError("models endpoint timed out"),
+    )
+
+    assert "vLLM process exited with code 1" in message
+    assert "models endpoint timed out" in message
+    assert "stderr tail:" in message
+    assert "bad vmem allocation" in message
+    assert "stdout tail:" in message
+    assert "loading model" in message
+
+
 def test_main_rejects_vllm_greedy_multi_generation_cases():
     with pytest.raises(ValueError, match="n > 1 with greedy sampling"):
         bench.main(

--- a/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
+++ b/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
@@ -773,6 +773,10 @@ def test_summary_markdown_includes_vllm_ratio_columns(tmp_path):
     assert "hbm bytes" in summary
     assert "shape buckets" in summary
     assert "prefill s" in summary
+    assert "decode iter s" in summary
+    assert "decode device s" in summary
+    assert "decode host s" in summary
+    assert "decode iter toks" in summary
     assert "0.900" in summary
     assert "pass" in summary
     assert "12.346" in summary
@@ -1084,6 +1088,19 @@ def test_run_case_propagates_backend_static_metrics(monkeypatch):
     def send_completion(**kwargs):
         return {"usage": {"prompt_tokens": 1, "completion_tokens": 2, "total_tokens": 3}, "choices": []}, 0.1
 
+    def metrics_snapshot():
+        return {
+            "prefill_admissions": 1,
+            "prefill_prompt_tokens_per_admission": [1],
+            "prefill_seconds_per_admission": [0.5],
+            "decode_seconds_per_iteration": [0.25],
+            "decode_device_seconds_per_iteration": [0.2],
+            "decode_host_seconds_per_iteration": [0.05],
+            "decode_submit_seconds_per_iteration": [0.01],
+            "decode_extract_seconds_per_iteration": [0.02],
+            "decode_tokens_per_iteration": [2],
+        }
+
     monkeypatch.setattr(bench, "_send_completion", send_completion)
 
     result = bench.run_case(
@@ -1094,6 +1111,7 @@ def test_run_case_propagates_backend_static_metrics(monkeypatch):
             close=lambda: None,
             hbm_used_bytes=1234,
             compiled_shape_count=2,
+            metrics_snapshot=metrics_snapshot,
         ),
         case=bench.BenchmarkCase("decode_b1_i1_o2_n1", active_sequences=1, input_tokens=1, output_tokens=2),
         prompt="x",
@@ -1108,6 +1126,15 @@ def test_run_case_propagates_backend_static_metrics(monkeypatch):
 
     assert result.hbm_used_bytes == 1234
     assert result.compiled_shape_count == 2
+    assert result.prefill_admissions == 1
+    assert result.prefill_prompt_tokens_per_admission == [1]
+    assert result.prefill_seconds_per_admission == [0.5]
+    assert result.decode_seconds_per_iteration == [0.25]
+    assert result.decode_device_seconds_per_iteration == [0.2]
+    assert result.decode_host_seconds_per_iteration == [0.05]
+    assert result.decode_submit_seconds_per_iteration == [0.01]
+    assert result.decode_extract_seconds_per_iteration == [0.02]
+    assert result.decode_tokens_per_iteration == [2]
 
 
 def test_run_stress_case_aggregates_success_failures_and_service_metrics(monkeypatch):
@@ -1440,6 +1467,12 @@ def test_run_levanter_without_lm_head_case_preserves_warmup_flag(monkeypatch):
                 prefill_admissions = 1
                 prefill_prompt_tokens_per_admission = [1]
                 prefill_seconds_per_admission = [0.5]
+                decode_seconds_per_iteration = [0.25]
+                decode_device_seconds_per_iteration = [0.2]
+                decode_host_seconds_per_iteration = [0.05]
+                decode_submit_seconds_per_iteration = [0.01]
+                decode_extract_seconds_per_iteration = [0.02]
+                decode_tokens_per_iteration = [2]
 
             return Result()
 
@@ -1521,6 +1554,12 @@ def test_run_levanter_without_lm_head_case_preserves_warmup_flag(monkeypatch):
     assert warmup.prefill_admissions == 1
     assert warmup.prefill_prompt_tokens_per_admission == [1]
     assert warmup.prefill_seconds_per_admission == [0.5]
+    assert warmup.decode_seconds_per_iteration == [0.25]
+    assert warmup.decode_device_seconds_per_iteration == [0.2]
+    assert warmup.decode_host_seconds_per_iteration == [0.05]
+    assert warmup.decode_submit_seconds_per_iteration == [0.01]
+    assert warmup.decode_extract_seconds_per_iteration == [0.02]
+    assert warmup.decode_tokens_per_iteration == [2]
     assert events == [
         "enter:mesh",
         "enter:axis_mapping",


### PR DESCRIPTION
Add engine-side chunked prefill admission so one logical Levanter serving batch can admit multiple prompt chunks under max_prefill_size, while OpenAI batching only preserves per-request prompt-cap rejection. Report prefill admission count and chunk prompt tokens in Qwen3 parity outputs, guard diagnostic benchmark modes against silent aggregate-prefill overflow, and expose corrected timing fields so prefill-heavy rows can separate prefill drain, generation-loop, device, host, submit, and extraction time.

Also keep inference request logs bounded by logging request metadata instead of serializing full prompt token lists. This removes a measured-path host overhead for long-prompt serving without changing scheduling or API behavior.

Part of #6184 and parent rollout epic #6227. v6e prefill-heavy follow-up: #6229; v5p startup follow-up: #6230.