### PR TITLE
[iris] Fix and broaden the dashboard ProfileHistory pane

### DIFF
--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -163,7 +163,7 @@ Namespaces:
 
 - `iris.worker` — per-tick host utilization (cpu, mem, disk, running task count, net bps), keyed by `ts`.
 - `iris.task` — per-attempt task resource snapshots, keyed by `ts`.
-- `iris.profile` — per-capture profile blobs (cpu/memory/thread, periodic or on-demand), keyed by `captured_at`. Filter on `source` (a task path like `/user/job/.../<index>`, `/system/worker/<id>`, or `/system/controller`) and `type` (`cpu`/`memory`/`thread`). `format` is the blob encoding — periodic CPU captures are py-spy **speedscope** JSON. `vm_id` is the writer VM (worker id, `controller-self`, or `k8s/<node-or-pod>`).
+- `iris.profile` — per-capture profile blobs (cpu/memory/thread, periodic or on-demand), keyed by `source` so the dashboard's per-source list query prunes via parquet row-group min/max. Filter on `source` (a task path like `/user/job/.../<index>`, `/system/worker/<id>`, or `/system/controller`) and `type` (`cpu`/`memory`/`thread`). `format` is the blob encoding — periodic CPU captures are py-spy **speedscope** JSON. `vm_id` is the writer VM (worker id, `controller-self`, or `k8s/<node-or-pod>`).
 
 Retention is finelog segment-based. Target for `iris.profile` is 7 days.
 

--- a/lib/iris/dashboard/rsbuild.config.ts
+++ b/lib/iris/dashboard/rsbuild.config.ts
@@ -27,6 +27,7 @@ export default defineConfig({
       '/iris.cluster.ControllerService': 'http://localhost:8080',
       '/finelog.logging.LogService': 'http://localhost:8080',
       '/iris.cluster.WorkerService': 'http://localhost:8081',
+      '/proxy': 'http://localhost:8080',
       '/bundles': 'http://localhost:8080',
       '/blobs': 'http://localhost:8080',
       '/health': 'http://localhost:8080',

--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -19,6 +19,7 @@ import InfoRow from '@/components/shared/InfoRow.vue'
 import EmptyState from '@/components/shared/EmptyState.vue'
 import LogViewer from '@/components/shared/LogViewer.vue'
 import MarkdownRenderer from '@/components/shared/MarkdownRenderer.vue'
+import ProfileHistory from '@/components/shared/ProfileHistory.vue'
 import { useMediaQuery } from '@/composables/useMediaQuery'
 
 // Tailwind's `sm` breakpoint is 640px. Cards on mobile, table on desktop.
@@ -1337,6 +1338,9 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
         </div>
       </div>
       </template>
+
+      <!-- Profile history (last 10 captures across this job's tasks; self-hides when empty) -->
+      <ProfileHistory :source="jobId" class="mt-6 mb-6" />
 
       <!-- Job logs -->
       <div class="mt-6 mb-6">

--- a/lib/iris/dashboard/src/components/shared/ProfileHistory.vue
+++ b/lib/iris/dashboard/src/components/shared/ProfileHistory.vue
@@ -2,34 +2,36 @@
 /**
  * Profile history panel sourced from the iris.profile finelog namespace.
  *
- * Lists the last 50 captures for `source` (a task wire ID, /system/worker/<id>,
- * or /system/controller). Click a row to download the captured bytes.
+ * Lists the last 10 captures for `source` and anything nested under it: pass a
+ * task wire ID, /system/worker/<id>, or /system/controller to scope to one
+ * source, or a job ID to cover every task under that job. Click a row to
+ * download its captured bytes. The list never reads the profile_data blob — the
+ * bytes are fetched on click — so it stays cheap on the log server.
  */
 import { computed, onMounted, ref, watch } from 'vue'
 import { useLogServerStatsRpc } from '@/composables/useRpc'
 import { useAutoRefresh } from '@/composables/useAutoRefresh'
 import { decodeArrowIpc } from '@/utils/arrow'
-import { formatBytes } from '@/utils/formatting'
 
 interface Props {
   source: string
-  downloadLabel?: string
   refreshIntervalMs?: number
 }
 const props = withDefaults(defineProps<Props>(), {
-  downloadLabel: '',
   refreshIntervalMs: 30_000,
 })
 
 interface ProfileHistoryRow {
-  captured_at?: string
+  // Epoch milliseconds: the stats server returns captured_at as a TIMESTAMP,
+  // which apache-arrow decodes to a number (ms since epoch), not a string.
+  captured_at?: number
+  source?: string
   type?: string
   attempt_id?: number | null
   vm_id?: string
   duration_seconds?: number
   format?: string
   trigger?: string
-  size_bytes?: number
 }
 
 interface QueryResponse {
@@ -40,13 +42,23 @@ function escape(value: string): string {
   return value.replace(/'/g, "''")
 }
 
-const { data, refresh } = useLogServerStatsRpc<QueryResponse>('Query', () => ({
-  sql: `SELECT captured_at, type, attempt_id, vm_id, duration_seconds, format, trigger, length(profile_data) AS size_bytes
+function formatCaptured(capturedAt: number | undefined): string {
+  return capturedAt == null ? '-' : new Date(capturedAt).toLocaleString()
+}
+
+// Match the source itself plus anything nested under it (a job → its tasks). The
+// '/' delimiter keeps '/task/1' from also matching '/task/10'. Only small
+// metadata columns are selected — never profile_data — so the list stays cheap.
+const { data, refresh } = useLogServerStatsRpc<QueryResponse>('Query', () => {
+  const src = escape(props.source)
+  return {
+    sql: `SELECT captured_at, source, type, attempt_id, vm_id, duration_seconds, format, trigger
 FROM "iris.profile"
-WHERE source = '${escape(props.source)}'
+WHERE source = '${src}' OR starts_with(source, '${src}/')
 ORDER BY captured_at DESC
-LIMIT 50`,
-}))
+LIMIT 10`,
+  }
+})
 
 useAutoRefresh(refresh, props.refreshIntervalMs)
 onMounted(refresh)
@@ -78,10 +90,12 @@ function defaultLabel(source: string): string {
 }
 
 async function downloadProfile(row: ProfileHistoryRow) {
-  if (downloading.value || !row.captured_at) return
+  if (downloading.value || row.captured_at == null || !row.source) return
   downloading.value = true
   try {
-    const sql = `SELECT profile_data, type, format FROM "iris.profile" WHERE source = '${escape(props.source)}' AND captured_at = '${escape(row.captured_at)}' LIMIT 1`
+    // captured_at arrives as epoch ms; match the TIMESTAMP column via epoch_ms()
+    // rather than a string literal (the server rejects a raw ms string).
+    const sql = `SELECT profile_data, type, format FROM "iris.profile" WHERE source = '${escape(row.source)}' AND epoch_ms(captured_at) = ${row.captured_at} LIMIT 1`
     const resp = await fetch('/proxy/system.log-server/finelog.stats.StatsService/Query', {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
@@ -95,8 +109,8 @@ async function downloadProfile(row: ProfileHistoryRow) {
     if (!fetched.length || !fetched[0].profile_data) return
     const bytes = fetched[0].profile_data
     const ext = profileExtension(fetched[0].format)
-    const ts = row.captured_at.replace(/[T]/g, '_').replace(/:/g, '-').replace(/\.\d+/, '')
-    const label = props.downloadLabel || defaultLabel(props.source)
+    const ts = new Date(row.captured_at).toISOString().replace(/T/g, '_').replace(/:/g, '-').replace(/\.\d+Z$/, '')
+    const label = defaultLabel(row.source)
     const blob = new Blob([bytes], { type: 'application/octet-stream' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
@@ -125,22 +139,20 @@ defineExpose({ refresh })
             <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Type</th>
             <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Format</th>
             <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Trigger</th>
-            <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-right">Size</th>
             <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-right">Duration</th>
           </tr>
         </thead>
         <tbody>
           <tr
             v-for="row in rows"
-            :key="row.captured_at ?? ''"
+            :key="`${row.source ?? ''}@${row.captured_at ?? ''}`"
             class="border-b border-surface-border-subtle hover:bg-surface-raised transition-colors cursor-pointer"
             @click="downloadProfile(row)"
           >
-            <td class="px-3 py-2 text-[13px] font-mono">{{ row.captured_at ?? '-' }}</td>
+            <td class="px-3 py-2 text-[13px] font-mono">{{ formatCaptured(row.captured_at) }}</td>
             <td class="px-3 py-2 text-[13px] font-mono">{{ row.type ?? '-' }}</td>
             <td class="px-3 py-2 text-[13px] font-mono">{{ row.format ?? '-' }}</td>
             <td class="px-3 py-2 text-[13px] font-mono">{{ row.trigger ?? '-' }}</td>
-            <td class="px-3 py-2 text-[13px] font-mono text-right">{{ row.size_bytes !== undefined ? formatBytes(Number(row.size_bytes)) : '-' }}</td>
             <td class="px-3 py-2 text-[13px] font-mono text-right">{{ row.duration_seconds !== undefined ? `${row.duration_seconds}s` : '-' }}</td>
           </tr>
         </tbody>

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -707,6 +707,7 @@ class ProxyControllerDashboard:
             Route("/auth/{path:path}", self._proxy_auth),
             Route("/iris.cluster.ControllerService/{method}", self._proxy_rpc, methods=["POST"]),
             Route("/finelog.logging.LogService/{method}", self._proxy_log_rpc, methods=["POST"]),
+            Route("/proxy/{path:path}", self._proxy_endpoint, methods=list(endpoint_proxy.ALLOWED_METHODS)),
             static_files_mount(),
         ]
 
@@ -760,6 +761,29 @@ class ProxyControllerDashboard:
         upstream_resp = await self._client.post(
             f"/finelog.logging.LogService/{method}",
             content=body,
+            headers={"content-type": request.headers.get("content-type", "application/json")},
+        )
+        return Response(
+            content=upstream_resp.content,
+            status_code=upstream_resp.status_code,
+            media_type=upstream_resp.headers.get("content-type"),
+        )
+
+    async def _proxy_endpoint(self, request: Request) -> Response:
+        """Forward generic ``/proxy/<endpoint>/<sub_path>`` requests upstream.
+
+        The dashboard's stats panels (live resource usage, status text, profile
+        history) reach the bundled log server through
+        ``/proxy/system.log-server/finelog.stats.StatsService/...``. The upstream
+        controller already exposes the endpoint proxy at the same path, so we pass
+        the request through verbatim (method, body, query, content-type).
+        """
+        path = request.path_params["path"]
+        query = f"?{request.url.query}" if request.url.query else ""
+        upstream_resp = await self._client.request(
+            request.method,
+            f"/proxy/{path}{query}",
+            content=await request.body(),
             headers={"content-type": request.headers.get("content-type", "application/json")},
         )
         return Response(

--- a/lib/iris/src/iris/cluster/runtime/profile.py
+++ b/lib/iris/src/iris/cluster/runtime/profile.py
@@ -66,7 +66,11 @@ class ProfileTrigger(StrEnum):
 class IrisProfile:
     """One row per profile capture. Written by worker / k8s provider / controller; read by dashboard."""
 
-    key_column: ClassVar[str] = "captured_at"
+    # The dashboard lists captures per source (a task, a worker, or every task
+    # under a job via a source prefix) ordered by captured_at. Clustering segments
+    # by source lets parquet row-group min/max prune to the few segments holding
+    # that source instead of scanning the whole namespace.
+    key_column: ClassVar[str] = "source"
 
     source: str
     attempt_id: int | None


### PR DESCRIPTION
ProfileHistory selected length(profile_data), which the log server rejects (no length(BLOB)), so the pane never rendered. Drop it, scope by source prefix (a task or a whole job), and cap at 10. Render captured_at (epoch ms) as a date and match downloads via epoch_ms(). Add a job-scoped pane to JobDetail, cluster iris.profile by source, and forward /proxy through dashboard-proxy so its stats panels work.