### PR TITLE
[iris] Drop the dead api_keys.key_hash column

### DIFF
--- a/lib/iris/src/iris/cluster/controller/auth.py
+++ b/lib/iris/src/iris/cluster/controller/auth.py
@@ -27,7 +27,6 @@ from iris.rpc.auth import (
     StaticTokenVerifier,
     TokenVerifier,
     VerifiedIdentity,
-    hash_token,
 )
 
 logger = logging.getLogger(__name__)
@@ -44,19 +43,17 @@ DEFAULT_JWT_TTL_SECONDS = 86400 * 30  # 30 days
 def create_api_key(
     db: ControllerDB,
     key_id: str,
-    key_hash: str | None,
     key_prefix: str,
     user_id: str,
     name: str,
     now: Timestamp,
     expires_at: Timestamp | None = None,
 ) -> None:
-    """Insert a new API key row. ``key_hash`` is ``None`` for JWT-backed keys, which carry no stored hash."""
+    """Insert a new API key row."""
     with db.transaction() as tx:
         tx.execute(
             insert(auth_api_keys_table).values(
                 key_id=key_id,
-                key_hash=key_hash,
                 key_prefix=key_prefix,
                 user_id=user_id,
                 name=name,
@@ -380,8 +377,8 @@ def _preload_static_tokens(
 ) -> None:
     """Insert static config tokens into the api_keys table for audit.
 
-    The raw token hashes are stored so that the Login RPC can verify
-    static tokens during the login exchange flow.
+    Verification of static tokens happens in-memory via ``StaticTokenVerifier``;
+    these rows exist only so configured tokens surface in ``iris key list``.
     """
     tokens = dict(static_config.tokens)
     if not tokens:
@@ -397,7 +394,6 @@ def _preload_static_tokens(
         create_api_key(
             db,
             key_id=key_id,
-            key_hash=hash_token(raw_token),
             key_prefix=raw_token[:8],
             user_id=username,
             name=f"static-config-{username}",
@@ -418,7 +414,6 @@ def _create_worker_jwt(db: ControllerDB, jwt_mgr: JwtTokenManager, now: Timestam
     create_api_key(
         db,
         key_id=key_id,
-        key_hash=None,
         key_prefix="jwt",
         user_id=WORKER_USER,
         name="worker-token",

--- a/lib/iris/src/iris/cluster/controller/migrations/0028_drop_api_keys_key_hash.py
+++ b/lib/iris/src/iris/cluster/controller/migrations/0028_drop_api_keys_key_hash.py
@@ -1,0 +1,67 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Drop the dead ``api_keys.key_hash`` column.
+
+``key_hash`` was scaffolding for DB-backed API-key verification that was never
+wired up: it is written but never read — all token verification happens
+in-memory (``StaticTokenVerifier``) or via JWT crypto. It also carried an old
+``NOT NULL`` constraint that rejected the worker token (which has no hash),
+crashing controller startup on DBs created before the column was meant to go
+nullable. Rather than relax the constraint, drop the column outright.
+
+``api_keys`` lives in the attached ``auth`` database (``auth.sqlite3``), so every
+statement is schema-qualified. SQLite cannot drop a column referenced by an
+index in place across all supported versions, so this rebuilds the table to
+match ``schema.py``'s ``auth_api_keys_table`` (no ``key_hash``, no unique
+constraint, just ``idx_api_keys_user``). Idempotent: if ``key_hash`` is already
+gone it is a no-op, so a crash mid-run is safe to retry.
+"""
+
+
+def _has_key_hash(raw_conn) -> bool:
+    # PRAGMA table_info columns: (cid, name, type, notnull, dflt_value, pk)
+    return any(row[1] == "key_hash" for row in raw_conn.execute("PRAGMA auth.table_info(api_keys)").fetchall())
+
+
+def migrate(raw_conn) -> None:
+    if not _has_key_hash(raw_conn):
+        return
+
+    raw_conn.commit()
+    raw_conn.execute("BEGIN IMMEDIATE")
+    try:
+        raw_conn.execute(
+            """
+            CREATE TABLE auth.api_keys_new (
+                key_id VARCHAR NOT NULL,
+                key_prefix VARCHAR NOT NULL,
+                user_id VARCHAR NOT NULL,
+                name VARCHAR NOT NULL,
+                created_at_ms INTEGER NOT NULL,
+                last_used_at_ms INTEGER,
+                expires_at_ms INTEGER,
+                revoked_at_ms INTEGER,
+                PRIMARY KEY (key_id)
+            )
+            """
+        )
+        raw_conn.execute(
+            """
+            INSERT INTO auth.api_keys_new (
+                key_id, key_prefix, user_id, name,
+                created_at_ms, last_used_at_ms, expires_at_ms, revoked_at_ms
+            )
+            SELECT
+                key_id, key_prefix, user_id, name,
+                created_at_ms, last_used_at_ms, expires_at_ms, revoked_at_ms
+            FROM auth.api_keys
+            """
+        )
+        raw_conn.execute("DROP TABLE auth.api_keys")
+        raw_conn.execute("ALTER TABLE auth.api_keys_new RENAME TO api_keys")
+        raw_conn.execute("CREATE INDEX auth.idx_api_keys_user ON api_keys (user_id)")
+        raw_conn.commit()
+    except Exception:
+        raw_conn.execute("ROLLBACK")
+        raise

--- a/lib/iris/src/iris/cluster/controller/schema.py
+++ b/lib/iris/src/iris/cluster/controller/schema.py
@@ -547,9 +547,8 @@ auth_api_keys_table = Table(
     "api_keys",
     auth_metadata,
     Column("key_id", String, primary_key=True),
-    # NULL for JWT-backed keys (validated via signed JWT, not a stored hash);
-    # the SHA-256 token hash for static/hash-backed keys.
-    Column("key_hash", String, nullable=True, unique=True),
+    # Human-readable key prefix surfaced in `iris key list` / CreateApiKey
+    # responses ("jwt" for JWT-backed keys, the token's first 8 chars otherwise).
     Column("key_prefix", String, nullable=False),
     Column("user_id", String, nullable=False),
     Column("name", String, nullable=False),
@@ -557,7 +556,6 @@ auth_api_keys_table = Table(
     Column("last_used_at_ms", TimestampMsType),
     Column("expires_at_ms", TimestampMsType),
     Column("revoked_at_ms", TimestampMsType),
-    Index("idx_api_keys_hash", "key_hash"),
     Index("idx_api_keys_user", "user_id"),
 )
 

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -2105,7 +2105,6 @@ class ControllerServiceImpl:
         create_api_key(
             self._db,
             key_id=key_id,
-            key_hash=None,
             key_prefix="jwt",
             user_id=username,
             name=f"login-{now.epoch_ms()}",
@@ -2145,7 +2144,6 @@ class ControllerServiceImpl:
         create_api_key(
             self._db,
             key_id=key_id,
-            key_hash=None,
             key_prefix="jwt",
             user_id=target_user,
             name=request.name or f"key-{now.epoch_ms()}",

--- a/lib/iris/src/iris/cluster/providers/local/cluster.py
+++ b/lib/iris/src/iris/cluster/providers/local/cluster.py
@@ -47,7 +47,6 @@ from iris.cluster.token_store import store_token
 from iris.cluster.worker.port_allocator import PortAllocator
 from iris.managed_thread import ThreadContainer
 from iris.rpc import config_pb2
-from iris.rpc.auth import hash_token
 
 
 def create_local_autoscaler(
@@ -235,7 +234,6 @@ class LocalCluster:
             create_api_key(
                 db,
                 key_id=key_id,
-                key_hash=None,
                 key_prefix="jwt",
                 user_id="local-admin",
                 name="local-auto-login",
@@ -248,7 +246,6 @@ class LocalCluster:
             create_api_key(
                 db,
                 key_id=key_id,
-                key_hash=hash_token(jwt_token),
                 key_prefix=jwt_token[:8],
                 user_id="local-admin",
                 name="local-auto-login",

--- a/lib/iris/src/iris/rpc/auth.py
+++ b/lib/iris/src/iris/rpc/auth.py
@@ -13,7 +13,6 @@ pass through as the anonymous admin user.
 """
 
 import contextlib
-import hashlib
 import logging
 import time
 from contextvars import ContextVar
@@ -60,11 +59,6 @@ def extract_bearer_token(headers: dict) -> str | None:
         return auth_header[len("Bearer ") :]
     cookie_header = headers.get("cookie", "")
     return _extract_cookie(cookie_header, SESSION_COOKIE)
-
-
-def hash_token(raw_token: str) -> str:
-    """SHA-256 hex digest of a raw API key. Used for storage and lookup."""
-    return hashlib.sha256(raw_token.encode()).hexdigest()
 
 
 # Per-request identity set by AuthInterceptor, read by service handlers.

--- a/lib/iris/tests/cluster/controller/test_api_keys.py
+++ b/lib/iris/tests/cluster/controller/test_api_keys.py
@@ -26,7 +26,7 @@ from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjecti
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.controller.worker_health import WorkerHealthTracker
 from iris.rpc import config_pb2, job_pb2
-from iris.rpc.auth import VerifiedIdentity, _verified_identity, hash_token
+from iris.rpc.auth import VerifiedIdentity, _verified_identity
 from rigging.timing import Timestamp
 
 from tests.cluster.conftest import fake_log_client_from_service
@@ -452,7 +452,6 @@ def test_null_auth_rpcs_work_with_anonymous_token(db):
     create_api_key(
         db,
         key_id=f"iris_k_test_{secrets.token_hex(4)}",
-        key_hash=hash_token(anonymous_token),
         key_prefix=anonymous_token[:8],
         user_id="anonymous",
         name="test-null-auth",

--- a/lib/iris/tests/cluster/controller/test_auth.py
+++ b/lib/iris/tests/cluster/controller/test_auth.py
@@ -31,7 +31,7 @@ from iris.cluster.controller.projections.endpoints import EndpointsProjection
 from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.controller.worker_health import WorkerHealthTracker
-from iris.rpc.auth import SESSION_COOKIE, StaticTokenVerifier, hash_token, resolve_auth
+from iris.rpc.auth import SESSION_COOKIE, StaticTokenVerifier, resolve_auth
 from rigging.timing import Timestamp
 from sqlalchemy import text
 from starlette.responses import JSONResponse
@@ -260,7 +260,7 @@ def test_read_snapshot_cannot_access_auth_tables(db: ControllerDB):
     with db.transaction() as _tx:
         writes.ensure_user(_tx, "test-user", now)
     _get_or_create_signing_key(db)
-    create_api_key(db, key_id="k1", key_hash="hash1", key_prefix="pfx", user_id="test-user", name="test", now=now)
+    create_api_key(db, key_id="k1", key_prefix="pfx", user_id="test-user", name="test", now=now)
 
     with db.read_snapshot() as q:
         for table in ["api_keys", "controller_secrets", "auth.api_keys"]:
@@ -273,7 +273,7 @@ def test_write_connection_can_access_auth_tables(db: ControllerDB):
     with db.transaction() as _tx:
         writes.ensure_user(_tx, "test-user", now)
     _get_or_create_signing_key(db)
-    create_api_key(db, key_id="k1", key_hash="hash1", key_prefix="pfx", user_id="test-user", name="test", now=now)
+    create_api_key(db, key_id="k1", key_prefix="pfx", user_id="test-user", name="test", now=now)
 
     with db.transaction() as q:
         rows = q.execute(text("SELECT key_id FROM auth.api_keys")).all()
@@ -300,14 +300,12 @@ def test_api_key_create_lookup_revoke(db: ControllerDB):
     with db.read_snapshot() as _snap:
         assert reads.get_user_role(_snap, "alice") == "admin"
 
-    create_api_key(
-        db, key_id="k1", key_hash=hash_token("secret1"), key_prefix="sec", user_id="alice", name="my-key", now=now
-    )
+    create_api_key(db, key_id="k1", key_prefix="sec", user_id="alice", name="my-key", now=now)
 
     found = lookup_api_key_by_id(db, "k1")
     assert found is not None
     assert found.key_id == "k1"
-    assert found.key_hash == hash_token("secret1")
+    assert found.key_prefix == "sec"
 
     keys = list_api_keys(db, user_id="alice")
     assert len(keys) == 1
@@ -323,7 +321,7 @@ def test_jwt_create_and_verify(db: ControllerDB):
     signing_key = _get_or_create_signing_key(db)
     mgr = JwtTokenManager(signing_key, db=db)
 
-    create_api_key(db, key_id="k-bob", key_hash=None, key_prefix="jwt", user_id="bob", name="test", now=now)
+    create_api_key(db, key_id="k-bob", key_prefix="jwt", user_id="bob", name="test", now=now)
 
     token = mgr.create_token("bob", "user", "k-bob")
     identity = mgr.verify(token)
@@ -340,7 +338,6 @@ def test_revoke_login_keys(db: ControllerDB):
         create_api_key(
             db,
             key_id=f"k-login-{i}",
-            key_hash=None,
             key_prefix="jwt",
             user_id="carol",
             name=f"login-{i}",

--- a/lib/iris/tests/cluster/controller/test_budgets.py
+++ b/lib/iris/tests/cluster/controller/test_budgets.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for budget migration and DB accessors."""
+"""Tests for budget DB accessors and tier reconciliation."""
 
 from pathlib import Path
 
@@ -38,43 +38,6 @@ def _get_user_budget(db: ControllerDB, user_id: str) -> UserBudget | None:
 def _list_user_budgets(db: ControllerDB) -> list[UserBudget]:
     with db.read_snapshot() as snap:
         return reads.list_user_budgets(snap)
-
-
-def test_migration_creates_user_budgets_table(db: ControllerDB) -> None:
-    """The 0013 migration creates the user_budgets table."""
-    with db.read_snapshot() as q:
-        row = q.execute(text("SELECT name FROM sqlite_master WHERE type='table' AND name='user_budgets'")).first()
-    assert row is not None
-
-
-def test_migration_adds_priority_band_column(db: ControllerDB) -> None:
-    """The 0013 migration adds priority_band column to tasks."""
-    with db.read_snapshot() as q:
-        columns = {row[1] for row in q.execute(text("PRAGMA table_info(tasks)")).all()}
-    assert "priority_band" in columns
-
-
-def test_migration_seeds_budgets_for_existing_users(tmp_path: Path) -> None:
-    """Users created before the migration get seeded budget rows."""
-    # Create a DB, add a user, then verify the migration seeded a budget row.
-    # ControllerDB.__init__ applies all migrations including 0013, but users
-    # table is empty at that point. We test the INSERT OR IGNORE path by
-    # adding a user and re-running the seed SQL.
-    db = ControllerDB(db_dir=tmp_path)
-    _create_user(db, "alice", created_at_ms=5000)
-    # Re-run the seed statement (idempotent)
-    with db.transaction() as tx:
-        tx.execute(
-            text(
-                "INSERT OR IGNORE INTO user_budgets(user_id, budget_limit, max_band, updated_at_ms) "
-                "SELECT user_id, 0, 2, created_at_ms FROM users"
-            )
-        )
-    budget = _get_user_budget(db, "alice")
-    assert budget is not None
-    assert budget.budget_limit == 0
-    assert budget.max_band == 2
-    db.close()
 
 
 def test_pending_index_includes_priority_band(db: ControllerDB) -> None:

--- a/lib/iris/tests/cluster/controller/test_db.py
+++ b/lib/iris/tests/cluster/controller/test_db.py
@@ -1,9 +1,8 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for ControllerDB transaction, read snapshot, and migration helpers."""
+"""Tests for ControllerDB transaction, read snapshot, and replace_from behavior."""
 
-import importlib.util
 from pathlib import Path
 
 import pytest
@@ -14,236 +13,6 @@ from sqlalchemy import text
 @pytest.fixture
 def db(tmp_path: Path) -> ControllerDB:
     return ControllerDB(db_dir=tmp_path)
-
-
-# =============================================================================
-# Migration 0027_attempt_uid
-# =============================================================================
-
-# task_attempts before 0027 added attempt_uid: same columns, PK, FKs, and
-# non-unique indexes as schema.py, minus the attempt_uid column and its index.
-_PRE_0027_TASK_ATTEMPTS = """
-CREATE TABLE task_attempts (
-    task_id VARCHAR NOT NULL,
-    attempt_id INTEGER NOT NULL,
-    worker_id VARCHAR,
-    state INTEGER NOT NULL,
-    created_at_ms INTEGER NOT NULL,
-    started_at_ms INTEGER,
-    finished_at_ms INTEGER,
-    exit_code INTEGER,
-    error VARCHAR,
-    PRIMARY KEY (task_id, attempt_id),
-    FOREIGN KEY(task_id) REFERENCES tasks (task_id) ON DELETE CASCADE,
-    FOREIGN KEY(worker_id) REFERENCES workers (worker_id) ON DELETE SET NULL
-)
-"""
-
-
-def _table_info(raw_conn, table: str) -> list[tuple]:
-    return raw_conn.execute(f"PRAGMA table_info({table})").fetchall()
-
-
-def _index_list(raw_conn, table: str) -> list[tuple]:
-    return raw_conn.execute(f"PRAGMA index_list({table})").fetchall()
-
-
-def _revert_to_pre_0027(db: ControllerDB) -> None:
-    """Rewind ``task_attempts`` to its pre-0027 shape and unrecord the migration.
-
-    A fresh DB is built from ``schema.py``, which already declares
-    ``attempt_uid``. To exercise the real backfill path we rebuild the table
-    without that column, then drop the ``0027`` marker so ``apply_migrations``
-    treats the migration as pending.
-    """
-    raw_conn = db._sa_write_engine.raw_connection()
-    try:
-        raw_conn.execute("PRAGMA foreign_keys=OFF")
-        raw_conn.execute("DROP TABLE task_attempts")
-        raw_conn.execute(_PRE_0027_TASK_ATTEMPTS)
-        raw_conn.execute("PRAGMA foreign_keys=ON")
-        raw_conn.execute("DELETE FROM schema_migrations WHERE name = '0027_attempt_uid.py'")
-        raw_conn.commit()
-    finally:
-        raw_conn.close()
-
-
-def _insert_task_attempt_rows(db: ControllerDB, count: int) -> None:
-    """Insert ``count`` task_attempt rows directly (one attempt per synthetic task).
-
-    Migration 0027 only ever reads/writes ``task_attempts``, so the parent
-    ``tasks`` / ``jobs`` rows are irrelevant to it. Inserting with foreign keys
-    disabled keeps the fixture focused on the migration under test rather than
-    on materializing the whole job graph.
-    """
-    raw_conn = db._sa_write_engine.raw_connection()
-    try:
-        raw_conn.execute("PRAGMA foreign_keys=OFF")
-        for i in range(count):
-            raw_conn.execute(
-                "INSERT INTO task_attempts (task_id, attempt_id, state, created_at_ms) VALUES (?, ?, ?, ?)",
-                (f"/test-user/job-{i}/0", 0, 0, 1000),
-            )
-        raw_conn.commit()
-        raw_conn.execute("PRAGMA foreign_keys=ON")
-    finally:
-        raw_conn.close()
-
-
-def _attempt_uids(db: ControllerDB) -> list[str]:
-    raw_conn = db._sa_write_engine.raw_connection()
-    try:
-        return [row[0] for row in raw_conn.execute("SELECT attempt_uid FROM task_attempts").fetchall()]
-    finally:
-        raw_conn.close()
-
-
-def test_migration_0027_backfills_unique_uids(tmp_path: Path) -> None:
-    """0027 backfills every pre-existing row with a distinct 16-hex attempt_uid."""
-    db = ControllerDB(db_dir=tmp_path)
-    _revert_to_pre_0027(db)
-    _insert_task_attempt_rows(db, count=5)
-
-    db.apply_migrations()
-
-    uids = _attempt_uids(db)
-    assert len(uids) == 5
-    assert all(uid is not None for uid in uids)
-    assert all(len(uid) == 16 for uid in uids)
-    assert all(all(c in "0123456789abcdef" for c in uid) for uid in uids)
-    assert len(set(uids)) == 5, "every backfilled attempt_uid must be distinct"
-    db.close()
-
-
-def test_migration_0027_backfills_across_chunks(tmp_path: Path) -> None:
-    """The chunked backfill loop covers every row when there are more rows than one chunk."""
-    db = ControllerDB(db_dir=tmp_path)
-    _revert_to_pre_0027(db)
-    # BACKFILL_CHUNK is 1000; exceed it so the loop must iterate more than once.
-    _insert_task_attempt_rows(db, count=1500)
-
-    db.apply_migrations()
-
-    uids = _attempt_uids(db)
-    assert len(uids) == 1500
-    assert all(uid is not None and len(uid) == 16 for uid in uids)
-    assert len(set(uids)) == 1500, "no row may be left NULL or share a uid across chunks"
-    db.close()
-
-
-def test_migration_0027_promotes_not_null_and_unique_index(tmp_path: Path) -> None:
-    """After 0027, attempt_uid is NOT NULL and idx_task_attempts_uid is a unique index."""
-    db = ControllerDB(db_dir=tmp_path)
-    _revert_to_pre_0027(db)
-    _insert_task_attempt_rows(db, count=3)
-
-    db.apply_migrations()
-
-    raw_conn = db._sa_write_engine.raw_connection()
-    try:
-        # PRAGMA table_info columns: (cid, name, type, notnull, dflt_value, pk)
-        cols = {row[1]: row for row in _table_info(raw_conn, "task_attempts")}
-        assert "attempt_uid" in cols
-        assert cols["attempt_uid"][3] == 1, "attempt_uid must be NOT NULL after the rebuild"
-
-        # PRAGMA index_list columns: (seq, name, unique, origin, partial)
-        indexes = {row[1]: row for row in _index_list(raw_conn, "task_attempts")}
-        assert "idx_task_attempts_uid" in indexes
-        assert indexes["idx_task_attempts_uid"][2] == 1, "idx_task_attempts_uid must be UNIQUE"
-
-        # The rebuild must preserve the other two indexes from schema.py.
-        assert "idx_task_attempts_worker_task" in indexes
-        assert "idx_task_attempts_live_workerbound" in indexes
-
-        # The unique index is real: a duplicate attempt_uid is rejected.
-        existing = raw_conn.execute("SELECT attempt_uid FROM task_attempts LIMIT 1").fetchone()[0]
-        raw_conn.execute("PRAGMA foreign_keys=OFF")
-        with pytest.raises(Exception, match="UNIQUE"):
-            raw_conn.execute(
-                "INSERT INTO task_attempts (task_id, attempt_id, state, created_at_ms, attempt_uid) "
-                "VALUES (?, ?, ?, ?, ?)",
-                ("/test-user/dup-job/0", 0, 0, 1000, existing),
-            )
-        raw_conn.rollback()
-    finally:
-        raw_conn.close()
-    db.close()
-
-
-def test_migration_0027_is_idempotent(tmp_path: Path) -> None:
-    """Re-running apply_migrations on an already-migrated DB is a clean no-op."""
-    db = ControllerDB(db_dir=tmp_path)
-    _revert_to_pre_0027(db)
-    _insert_task_attempt_rows(db, count=4)
-
-    db.apply_migrations()
-    uids_first = sorted(_attempt_uids(db))
-
-    # Second run: 0027 is already recorded, so the runner skips it entirely;
-    # even if it ran again, every step is guarded and would not mutate data.
-    db.apply_migrations()
-    uids_second = sorted(_attempt_uids(db))
-
-    assert uids_first == uids_second, "a second migration pass must not change attempt_uid values"
-    db.close()
-
-
-def test_migration_0027_runs_unconditionally_idempotent(tmp_path: Path) -> None:
-    """0027.migrate() applied directly to an already-migrated DB does not error or mutate.
-
-    The runner skips recorded migrations, but the migration's own guards
-    (_has_column / _column_is_notnull / IF NOT EXISTS) must also make a direct
-    re-invocation a no-op — that is what makes a crash-and-retry safe.
-    """
-
-    db = ControllerDB(db_dir=tmp_path)
-    _revert_to_pre_0027(db)
-    _insert_task_attempt_rows(db, count=3)
-    db.apply_migrations()
-    uids_before = sorted(_attempt_uids(db))
-
-    migration_path = Path(__file__).parents[3] / "src/iris/cluster/controller/migrations/0027_attempt_uid.py"
-    spec = importlib.util.spec_from_file_location("m0027", migration_path)
-    assert spec is not None and spec.loader is not None
-    module = importlib.util.module_from_spec(spec)
-    spec.loader.exec_module(module)
-
-    raw_conn = db._sa_write_engine.raw_connection()
-    try:
-        module.migrate(raw_conn)
-        raw_conn.commit()
-    finally:
-        raw_conn.close()
-
-    assert sorted(_attempt_uids(db)) == uids_before
-    db.close()
-
-
-def test_fresh_db_schema_matches_0027_end_state(tmp_path: Path) -> None:
-    """A DB built fresh from schema.py agrees with 0027's end state.
-
-    schema.py declares attempt_uid NOT NULL with a unique index; the migration
-    promotes the same. A fresh DB exercises both (schema create_all, then 0027
-    runs as a no-op) and must land on the identical shape.
-    """
-    db = ControllerDB(db_dir=tmp_path)
-    raw_conn = db._sa_write_engine.raw_connection()
-    try:
-        cols = {row[1]: row for row in _table_info(raw_conn, "task_attempts")}
-        assert "attempt_uid" in cols
-        assert cols["attempt_uid"][3] == 1, "fresh schema must declare attempt_uid NOT NULL"
-
-        indexes = {row[1]: row for row in _index_list(raw_conn, "task_attempts")}
-        assert "idx_task_attempts_uid" in indexes
-        assert indexes["idx_task_attempts_uid"][2] == 1, "fresh schema must make idx_task_attempts_uid UNIQUE"
-
-        # 0027 is recorded on a fresh DB — create_all already produced the
-        # end state, so the runner ran the (no-op) migration and marked it.
-        recorded = {row[0] for row in raw_conn.execute("SELECT name FROM schema_migrations").fetchall()}
-        assert "0027_attempt_uid.py" in recorded
-    finally:
-        raw_conn.close()
-    db.close()
 
 
 def _create_simple_table(db: ControllerDB) -> None:
@@ -308,12 +77,11 @@ def test_replace_from_reattaches_auth_db(tmp_path: Path) -> None:
     with db.transaction() as cur:
         cur.execute(
             text(
-                "INSERT INTO auth.api_keys (key_id, key_hash, key_prefix, name, user_id, created_at_ms) "
-                "VALUES (:key_id, :key_hash, :key_prefix, :name, :user_id, :created_at_ms)"
+                "INSERT INTO auth.api_keys (key_id, key_prefix, name, user_id, created_at_ms) "
+                "VALUES (:key_id, :key_prefix, :name, :user_id, :created_at_ms)"
             ),
             {
                 "key_id": "id1",
-                "key_hash": "hash1",
                 "key_prefix": "pfx",
                 "name": "test-key",
                 "user_id": "user1",
@@ -330,7 +98,7 @@ def test_replace_from_reattaches_auth_db(tmp_path: Path) -> None:
 
     # Auth tables should still be accessible after replace_from via the write connection.
     with db.transaction() as q:
-        rows = q.execute(text("SELECT name FROM auth.api_keys WHERE key_hash = 'hash1'")).all()
+        rows = q.execute(text("SELECT name FROM auth.api_keys WHERE key_id = 'id1'")).all()
     assert len(rows) == 1
     assert rows[0][0] == "test-key"
     db.close()

--- a/lib/iris/tests/rpc/test_auth.py
+++ b/lib/iris/tests/rpc/test_auth.py
@@ -31,7 +31,6 @@ from iris.rpc.auth import (
     authorize_resource_owner,
     get_verified_identity,
     get_verified_user,
-    hash_token,
     require_identity,
 )
 from iris.rpc.config_pb2 import AuthConfig
@@ -426,22 +425,6 @@ def test_create_client_token_provider_none_when_no_provider(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# hash_token utility
-# ---------------------------------------------------------------------------
-
-
-def test_hash_token_deterministic():
-    assert hash_token("test-token") == hash_token("test-token")
-    assert hash_token("a") != hash_token("b")
-
-
-def test_hash_token_is_sha256_hex():
-    result = hash_token("test")
-    assert len(result) == 64  # SHA-256 hex digest
-    assert all(c in "0123456789abcdef" for c in result)
-
-
-# ---------------------------------------------------------------------------
 # JwtTokenManager (replaces DbTokenVerifier)
 # ---------------------------------------------------------------------------
 
@@ -491,7 +474,6 @@ def test_jwt_token_manager_load_revocations(tmp_path):
     create_api_key(
         db,
         key_id="k-revoked",
-        key_hash=None,
         key_prefix="jwt",
         user_id="alice",
         name="test-key",
@@ -503,7 +485,6 @@ def test_jwt_token_manager_load_revocations(tmp_path):
     create_api_key(
         db,
         key_id="k-active",
-        key_hash=None,
         key_prefix="jwt",
         user_id="alice",
         name="active-key",


### PR DESCRIPTION
key_hash was scaffolding for DB-backed API-key verification that was never
wired up: it is written but never read, since all token verification happens
in-memory via StaticTokenVerifier or JWT crypto. It also carried a NOT NULL
constraint that the worker token (which has no hash) could not satisfy, so
controllers whose auth DB predates the column going nullable crashed on startup
with "NOT NULL constraint failed: api_keys.key_hash".

Remove the column outright rather than relaxing the constraint: drop it from
schema.py along with its unique constraint and idx_api_keys_hash, drop the
key_hash parameter from create_api_key and every call site, and delete the
now-callerless hash_token helper. Migration 0028 rebuilds the attached
auth.api_keys table without the column; it is idempotent and self-heals each
controller on its next restart.

key_prefix is unaffected and stays — it is surfaced by ListApiKeys and
CreateApiKey responses and printed by `iris key list`.