### PR TITLE
[iris] Throttle slice creation project-wide to respect GCP CreateNode quota

### DIFF
--- a/lib/iris/config/marin.yaml
+++ b/lib/iris/config/marin.yaml
@@ -47,6 +47,7 @@ controller:
 tpu_pools:
   # v5e (v5litepod) — europe-west4-b, us-west4-a
   # Per-VM: ct5lp-hightpu-4t — 112 vCPU, 192 GiB RAM
+  # max_slices capped to the v5e serving quota (us-west4-a: 128 cores).
   v5e-serving:
     family: v5e
     zones: [europe-west4-b, us-west4-a]
@@ -57,8 +58,8 @@ tpu_pools:
         service_account: iris-worker@hai-gcp-models.iam.gserviceaccount.com
         runtime_version: v2-alpha-tpuv5-lite
     sizes:
-      4:   { buffer_slices: 2, max_slices: 1024 }
-      8:   { buffer_slices: 2, max_slices: 512 }
+      4:   { buffer_slices: 2, max_slices: 32 }
+      8:   { buffer_slices: 2, max_slices: 16 }
 
   v5e-preemptible:
     family: v5e

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -24,7 +24,7 @@ from collections import deque
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 
-from rigging.timing import Duration, Timestamp
+from rigging.timing import Duration, Timestamp, TokenBucket
 
 from iris.cluster.constraints import Constraint
 from iris.cluster.controller.autoscaler.models import (
@@ -63,6 +63,11 @@ logger = logging.getLogger(__name__)
 
 # After this long in UNKNOWN state, treat the slice as FAILED (quota timeout is 5 min, so this is conservative)
 DEFAULT_UNRESOLVABLE_TIMEOUT = Duration.from_minutes(15)
+
+# Project-wide cap on slice creates per minute, shared across all scale groups.
+# Per-group limits don't coordinate, so a fan-out across groups in one cycle can
+# burst past GCP's per-project create quota (tpu.googleapis.com/qps/create, ~91/min).
+DEFAULT_CREATE_RATE_LIMIT = 60
 
 # How long the autoscaler waits for a worker /health response per probe.
 _HEALTH_PROBE_TIMEOUT_SECONDS = 3.0
@@ -113,6 +118,7 @@ class Autoscaler:
         base_worker_config: config_pb2.WorkerConfig | None = None,
         db: ControllerDB | None = None,
         unresolvable_timeout: Duration = DEFAULT_UNRESOLVABLE_TIMEOUT,
+        create_rate_limit: int = DEFAULT_CREATE_RATE_LIMIT,
     ):
         """Create autoscaler with explicit parameters.
 
@@ -125,6 +131,8 @@ class Autoscaler:
                 and passed to platform.create_slice(). None disables bootstrap (test/local mode).
             db: Optional DB handle for write-through persistence of tracked workers.
             unresolvable_timeout: How long a slice can remain UNKNOWN before being treated as FAILED.
+            create_rate_limit: Project-wide ceiling on slice-creation requests per minute,
+                shared across all scale groups. See ``DEFAULT_CREATE_RATE_LIMIT``.
         """
         self._groups = scale_groups
         self._platform = platform
@@ -132,6 +140,11 @@ class Autoscaler:
         self.evaluation_interval = evaluation_interval
         self._base_worker_config = base_worker_config
         self._unresolvable_timeout = unresolvable_timeout
+
+        # Project-wide slice-creation throttle, shared across all groups. Deferred
+        # scale-ups are retried on the next evaluation cycle.
+        self._create_rate_limit = create_rate_limit
+        self._create_bucket = TokenBucket(capacity=create_rate_limit, refill_period=Duration.from_minutes(1))
 
         # Centralized per-worker state indexed by worker_id
         self._worker_registry = WorkerRegistry()
@@ -329,6 +342,10 @@ class Autoscaler:
         # Aggregate rate-limited decisions per group so we emit a single summary
         # line per group per cycle instead of one per deferred slice (#5580).
         rate_limited: dict[str, list[ScalingDecision]] = {}
+        # Scale-ups deferred by the project-wide create budget (not a per-group
+        # limit), summarized once per cycle so a global throttle doesn't spam a
+        # line per group.
+        create_throttled = 0
         for decision in decisions:
             group = self._groups.get(decision.scale_group)
             if not group:
@@ -336,10 +353,28 @@ class Autoscaler:
                 continue
 
             if decision.action == ScalingAction.SCALE_UP:
+                # Per-group gate first: it honors the group's health/quota block,
+                # so we never spend the scarce global create budget on a group
+                # that couldn't scale anyway.
                 if not group.try_acquire_scale_up(timestamp):
                     rate_limited.setdefault(decision.scale_group, []).append(decision)
                     continue
+                if not self._create_bucket.try_acquire(now=timestamp):
+                    create_throttled += 1
+                    continue
                 self._execute_scale_up(group, timestamp, reason=decision.reason)
+
+        if create_throttled:
+            logger.info(
+                "Throttled %d scale-up(s) to stay under the global create limit (%d/min)",
+                create_throttled,
+                self._create_rate_limit,
+            )
+            self._log_action(
+                "create_throttled",
+                "",
+                reason=f"deferred={create_throttled} limit={self._create_rate_limit}/min",
+            )
 
         for scale_group, deferred in rate_limited.items():
             # All decisions in a cycle share the same target/demand snapshot;

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -456,52 +456,6 @@ class TestAutoscalerExecution:
 
         assert group.slice_count() == 0
 
-    def test_execute_throttles_global_create_rate(self):
-        """A multi-slice fan-out in one cycle is capped by the project-wide create budget.
-
-        The per-group rate limit (16/min) does not coordinate across groups, so the
-        global throttle is what keeps the aggregate CreateNode rate under the cloud's
-        per-project quota. Deferred scale-ups are retried once the budget refills.
-        """
-        platform = make_mock_platform()
-        # Large per-group cap so the global create throttle -- not max_slices or the
-        # per-group limit -- is the binding constraint.
-        config = make_scale_group_config(
-            name="test-group",
-            buffer_slices=0,
-            max_slices=10,
-            runtime_version="v2-alpha-tpuv5",
-            zones=["us-central1-a"],
-        )
-        group = ScalingGroup(config, platform)
-        # 2 creates/min, so one cycle can only create 2 regardless of demand.
-        autoscaler = Autoscaler(
-            scale_groups={"test-group": group},
-            evaluation_interval=Duration.from_seconds(0.1),
-            platform=platform,
-            create_rate_limit=2,
-        )
-        decisions = [
-            ScalingDecision(scale_group="test-group", action=ScalingAction.SCALE_UP, reason="demand") for _ in range(5)
-        ]
-
-        # First cycle: only 2 of the 5 proceed; the other 3 are deferred.
-        autoscaler.execute(decisions, timestamp=Timestamp.from_ms(1000))
-        autoscaler._wait_for_inflight()
-        assert group.slice_count() == 2
-
-        # Same instant, budget still empty: nothing more is created.
-        autoscaler.execute(decisions, timestamp=Timestamp.from_ms(1000))
-        autoscaler._wait_for_inflight()
-        assert group.slice_count() == 2
-
-        # A minute later the budget has refilled, so 2 more proceed.
-        autoscaler.execute(decisions, timestamp=Timestamp.from_ms(1000 + 60_000))
-        autoscaler._wait_for_inflight()
-        assert group.slice_count() == 4
-
-        autoscaler.shutdown()
-
 
 class TestAutoscalerWorkerFailure:
     """Tests for worker failure handling."""

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -456,6 +456,52 @@ class TestAutoscalerExecution:
 
         assert group.slice_count() == 0
 
+    def test_execute_throttles_global_create_rate(self):
+        """A multi-slice fan-out in one cycle is capped by the project-wide create budget.
+
+        The per-group rate limit (16/min) does not coordinate across groups, so the
+        global throttle is what keeps the aggregate CreateNode rate under the cloud's
+        per-project quota. Deferred scale-ups are retried once the budget refills.
+        """
+        platform = make_mock_platform()
+        # Large per-group cap so the global create throttle -- not max_slices or the
+        # per-group limit -- is the binding constraint.
+        config = make_scale_group_config(
+            name="test-group",
+            buffer_slices=0,
+            max_slices=10,
+            runtime_version="v2-alpha-tpuv5",
+            zones=["us-central1-a"],
+        )
+        group = ScalingGroup(config, platform)
+        # 2 creates/min, so one cycle can only create 2 regardless of demand.
+        autoscaler = Autoscaler(
+            scale_groups={"test-group": group},
+            evaluation_interval=Duration.from_seconds(0.1),
+            platform=platform,
+            create_rate_limit=2,
+        )
+        decisions = [
+            ScalingDecision(scale_group="test-group", action=ScalingAction.SCALE_UP, reason="demand") for _ in range(5)
+        ]
+
+        # First cycle: only 2 of the 5 proceed; the other 3 are deferred.
+        autoscaler.execute(decisions, timestamp=Timestamp.from_ms(1000))
+        autoscaler._wait_for_inflight()
+        assert group.slice_count() == 2
+
+        # Same instant, budget still empty: nothing more is created.
+        autoscaler.execute(decisions, timestamp=Timestamp.from_ms(1000))
+        autoscaler._wait_for_inflight()
+        assert group.slice_count() == 2
+
+        # A minute later the budget has refilled, so 2 more proceed.
+        autoscaler.execute(decisions, timestamp=Timestamp.from_ms(1000 + 60_000))
+        autoscaler._wait_for_inflight()
+        assert group.slice_count() == 4
+
+        autoscaler.shutdown()
+
 
 class TestAutoscalerWorkerFailure:
     """Tests for worker failure handling."""


### PR DESCRIPTION
The autoscaler's only create-rate limit was per scale group (16/min). With dozens of (size, zone) TPU groups all scaling in the same evaluation cycle, the aggregate CreateNode rate blew past GCP's project-wide tpu.googleapis.com/qps/create quota (91/min), producing bursts of "Maximum number of CreateNode requests per minute" errors.

Add a global, cross-group create throttle on the Autoscaler: a shared 60/min token bucket checked in execute() after the per-group gate, so the scarce global budget is never spent on a group that is already health- or quota-blocked. Deferred scale-ups are retried on the next cycle and summarized in one log line instead of one error per group.

Also fix the v5e-serving pool, which draws on the much smaller serving quota bucket (tpu-v5s-litepod-serving-preemptible: us-west4-a 128 cores, europe-west4-b 48) rather than the 10000-core training litepod bucket used by v5e-preemptible. Its max_slices of 1024/512 let the autoscaler perpetually request nodes the serving quota can never grant; the caps are now sized to the us-west4-a serving quota (size 4 to 32, size 8 to 16, i.e. 128 chips). europe-west4-b's 48-core serving quota is smaller still, so that zone's cap stays loose pending a per-zone pool split.