### PR TITLE
[CI] Make marin integration test independent of HF Hub

### DIFF
--- a/.github/workflows/marin-integration.yaml
+++ b/.github/workflows/marin-integration.yaml
@@ -85,7 +85,11 @@ jobs:
           timeout 600 uv run pytest tests/test_integration_test.py \
             -m integration -o "addopts=" --timeout=600 -v -s
         env:
-          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+          # The pipeline uses a vendored tokenizer fixture and degrades gracefully
+          # when the reference HF config is unreachable, so it must not touch HF Hub.
+          # HF_HUB_OFFLINE makes any accidental Hub access fail fast instead of
+          # reintroducing a flaky network dependency.
+          HF_HUB_OFFLINE: "1"
           WANDB_MODE: disabled
           WANDB_API_KEY: ""
           JAX_TRACEBACK_FILTERING: off

--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -314,6 +314,22 @@ KEYS_TO_COPY_FROM_BASE_CONFIG = {
 }
 
 
+def _causal_lm_architecture_name(hf_config_class: type) -> Optional[str]:
+    """Return the HF causal-LM architecture class name for *hf_config_class*, or None.
+
+    Uses the transformers name mapping (model_type -> architecture class name), which is a plain
+    string table that does not require torch — unlike ``AutoModelForCausalLM._model_mapping``. This
+    lets us record ``architectures`` in a saved config even when the reference checkpoint can't be
+    fetched (gated repo or HF outage) and torch isn't installed.
+    """
+    from transformers.models.auto.modeling_auto import MODEL_FOR_CAUSAL_LM_MAPPING_NAMES
+
+    model_type = getattr(hf_config_class, "model_type", None)
+    if model_type is None:
+        return None
+    return MODEL_FOR_CAUSAL_LM_MAPPING_NAMES.get(model_type)
+
+
 def _load_torch(path, dtype, fs: AbstractFileSystem | None = None):
     import torch  # noqa: F401
 
@@ -920,17 +936,20 @@ class HFCheckpointConverter(Generic[LevConfig]):
             # sufficient for most built-in architectures.
             base_config = None
             logger.warning("No reference checkpoint set; skipping base HF config metadata copy.")
-        except Exception as e:  # noqa: BLE001
-            if isinstance(e, GatedRepoError) or isinstance(e.__cause__, GatedRepoError):
-                warnings.warn("Could not copy keys from base config because the repo is gated. Making assumptions.")
-                dict_config["auto_map"] = {
-                    "AutoModelForCausalLM": self.HFAutoModelClass(AutoModelForCausalLM).__qualname__,
-                    "AutoConfig": self.HfConfigClass.__qualname__,
-                }
-                dict_config["architectures"] = [self.HFAutoModelClass(AutoModelForCausalLM).__name__]
-                base_config = None
-            else:
-                raise
+        except OSError as e:
+            # The reference config could not be read: the repo is gated, or the Hub is unreachable
+            # (HF outage, or HF_HUB_OFFLINE in CI). Every HF/transformers "can't fetch" error is an
+            # OSError subclass. We can still save: `to_hf_config()` already produced a complete config,
+            # so an HF outage never blocks a save. Record `architectures` from the model type (torch-free)
+            # so the checkpoint stays loadable.
+            warnings.warn(
+                f"Could not load reference HF config from {self.reference_checkpoint!r} ({type(e).__name__});"
+                " saving with architecture metadata derived from the model type."
+            )
+            base_config = None
+            architecture = _causal_lm_architecture_name(self.HfConfigClass)
+            if architecture is not None:
+                dict_config["architectures"] = [architecture]
 
         if base_config is not None:
             for k in KEYS_TO_COPY_FROM_BASE_CONFIG:

--- a/lib/levanter/src/levanter/models/gpt2.py
+++ b/lib/levanter/src/levanter/models/gpt2.py
@@ -62,6 +62,11 @@ class Gpt2Config(HFCompatConfig):
     attn_backend: Optional[AttentionBackend] = None
     flash_attention_block_size: Optional[int] = None
 
+    # Tokenizer for the HF checkpoint converter. When set (e.g. to a local directory), the converter
+    # loads it instead of fetching the reference tokenizer from HF Hub — mirrors the other model
+    # configs and lets from-scratch training/export run without Hub access.
+    tokenizer: Optional[str] = None
+
     # Axes
     @property
     def Embed(self) -> Axis:
@@ -77,8 +82,17 @@ class Gpt2Config(HFCompatConfig):
         return Gpt2LMHeadModel
 
     def hf_checkpoint_converter(self, ref_checkpoint: Optional[str] = None) -> HFCheckpointConverter["Gpt2Config"]:  # type: ignore
-        # We trust this code because it's in our hub repo
-        return HFCheckpointConverter(self.__class__, reference_checkpoint="gpt2", ignore_prefix="transformer")
+        # Pass HfConfigClass explicitly: GPT2 maps to a built-in transformers config, so there is no
+        # need to infer it by fetching the reference checkpoint from HF Hub. Honor a configured
+        # tokenizer (e.g. a local directory) like the other configs so from-scratch training/export
+        # never requires Hub access.
+        return HFCheckpointConverter(
+            self.__class__,
+            reference_checkpoint=ref_checkpoint or "gpt2",
+            HfConfigClass=HfGpt2Config,
+            tokenizer=ref_checkpoint if self.tokenizer is None else self.tokenizer,
+            ignore_prefix="transformer",
+        )
 
     def to_hf_config(self, vocab_size, config_overrides=None) -> HfGpt2Config:
         if config_overrides is None:

--- a/lib/levanter/tests/test_hf_checkpoints.py
+++ b/lib/levanter/tests/test_hf_checkpoints.py
@@ -23,6 +23,7 @@ from levanter.compat.hf_checkpoints import (
     SAFE_TENSORS_INDEX_NAME,
     SAFE_TENSORS_MODEL,
     ModelWithHfSerializationMixin,
+    _causal_lm_architecture_name,
     _convert_to_jnp,
 )
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
@@ -262,3 +263,54 @@ def test_save_pretrained_to_memory_fs():
             assert_trees_all_close(original_value, reloaded_value)
 
     fs.rm(base_path, recursive=True)
+
+
+def test_causal_lm_architecture_name_is_torch_free():
+    """The degrade path derives `architectures` from the model type without importing torch."""
+    from transformers import GPT2Config as HfGpt2Config
+
+    assert _causal_lm_architecture_name(HfGpt2Config) == "GPT2LMHeadModel"
+
+
+def _simulate_hub_offline(monkeypatch):
+    """Make ``AutoConfig.from_pretrained`` fail for Hub ids but still work for local directories,
+    mirroring a real HF outage (local files remain readable)."""
+    import transformers
+
+    real = transformers.AutoConfig.from_pretrained
+
+    def _offline(pretrained_model_name_or_path, *args, **kwargs):
+        if os.path.isdir(str(pretrained_model_name_or_path)):
+            return real(pretrained_model_name_or_path, *args, **kwargs)
+        raise OSError("We couldn't connect to 'https://huggingface.co' to load the files")
+
+    monkeypatch.setattr(transformers.AutoConfig, "from_pretrained", _offline)
+
+
+def test_gpt2_converter_uses_configured_tokenizer_without_hub(local_gpt2_tokenizer_path, monkeypatch):
+    """A configured tokenizer lets the GPT2 converter build without any HF Hub access: the config
+    class is known statically and the tokenizer is loaded from the local directory."""
+    _simulate_hub_offline(monkeypatch)
+
+    converter = Gpt2Config(
+        hidden_dim=32, num_heads=2, num_layers=2, tokenizer=local_gpt2_tokenizer_path
+    ).hf_checkpoint_converter()
+
+    assert converter.HfConfigClass.__name__ == "GPT2Config"
+    assert converter.tokenizer is not None  # loaded from the local directory, not the Hub
+
+
+def test_build_hf_config_dict_degrades_when_reference_unreachable(local_gpt2_tokenizer_path, monkeypatch):
+    """An HF outage must not block a checkpoint save: with a local tokenizer the config is still
+    produced and `architectures` is derived from the model type rather than the reference."""
+    _simulate_hub_offline(monkeypatch)
+
+    config = Gpt2Config(hidden_dim=32, num_heads=2, num_layers=2, max_seq_len=64, tokenizer=local_gpt2_tokenizer_path)
+    converter = config.hf_checkpoint_converter()
+
+    with use_test_mesh():
+        model = Gpt2LMHeadModel.init(converter.Vocab, config, key=PRNGKey(0))
+        dict_config = converter._build_hf_config_dict(model)
+
+    assert dict_config["model_type"] == "gpt2"
+    assert dict_config["architectures"] == ["GPT2LMHeadModel"]

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -15,6 +15,7 @@ Otherwise runs in-process against local filesystem.
 """
 
 import argparse
+import json
 import logging
 import os
 import shutil
@@ -50,11 +51,40 @@ logger = logging.getLogger(__name__)
 REPO_ROOT = Path(__file__).resolve().parents[1]
 LOCAL_SYNTH_DATA = REPO_ROOT / "tests" / "quickstart-data"
 
+# Reduced GPT-2 tokenizer already vendored in the repo for offline tests. Reused here so the
+# local-mode pipeline never touches HF Hub (frequently unavailable in CI). `load_tokenizer`
+# short-circuits a local directory, so pointing the tokenize step at it skips Hub staging.
+LOCAL_TOKENIZER_FILE = REPO_ROOT / "lib" / "levanter" / "tests" / "gpt2_tokenizer_config.json"
+# Vocab size of the reduced fixture above (matches lib/levanter/tests/conftest.py).
+LOCAL_TOKENIZER_VOCAB_SIZE = 5027
+
 _S3_ENV_KEYS = ["AWS_ACCESS_KEY_ID", "AWS_SECRET_ACCESS_KEY", "AWS_ENDPOINT_URL", "FSSPEC_S3"]
 
 
-def create_steps(prefix: str, synth_data: str) -> list[ExecutorStep]:
-    """Build the full marin data pipeline as executor steps."""
+def _materialize_local_tokenizer(dest_dir: Path) -> str:
+    """Lay out the reduced GPT-2 tokenizer fixture as a loadable tokenizer directory.
+
+    ``config.json`` gives ``AutoTokenizer`` the ``model_type`` it needs to resolve the
+    GPT-2 class offline; ``tokenizer_config.json`` is a minimal, well-formed config so the
+    train step's ``save_pretrained`` round-trip succeeds. Copying the raw ``tokenizer.json``
+    into ``tokenizer_config.json`` would load fine but fail to re-serialize on save.
+    """
+    dest_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy(LOCAL_TOKENIZER_FILE, dest_dir / "tokenizer.json")
+    (dest_dir / "config.json").write_text(json.dumps({"model_type": "gpt2", "vocab_size": LOCAL_TOKENIZER_VOCAB_SIZE}))
+    (dest_dir / "tokenizer_config.json").write_text(
+        json.dumps({"model_max_length": 1024, "tokenizer_class": "GPT2Tokenizer"})
+    )
+    return str(dest_dir)
+
+
+def create_steps(prefix: str, synth_data: str, tokenizer: str) -> list[ExecutorStep]:
+    """Build the full marin data pipeline as executor steps.
+
+    ``tokenizer`` is an HF model name or a local directory of tokenizer files.
+    The local-mode runner passes a vendored fixture directory so the pipeline
+    does not depend on HF Hub.
+    """
 
     # Transform HTML to markdown
     transform_hq_data_spec = StepSpec(
@@ -122,7 +152,7 @@ def create_steps(prefix: str, synth_data: str) -> list[ExecutorStep]:
             train_paths=[consolidate_step],
             validation_paths=[],
             cache_path=this_output_path(),
-            tokenizer="gpt2",
+            tokenizer=tokenizer,
         ),
     )
 
@@ -149,6 +179,9 @@ def create_steps(prefix: str, synth_data: str) -> list[ExecutorStep]:
                     num_heads=2,
                     max_seq_len=64,
                     hidden_dim=32,
+                    # Load the converter's tokenizer from the same source as the data so the
+                    # train step's HF-checkpoint save never reaches HF Hub in local mode.
+                    tokenizer=tokenizer,
                 ),
                 trainer=TrainerConfig(
                     train_batch_size=8, num_train_steps=2, max_eval_batches=1, require_accelerator=False
@@ -198,12 +231,12 @@ def _s3_env_vars() -> dict[str, str]:
 # ---------------------------------------------------------------------------
 
 
-def _run_executor(prefix: str, synth_data: str) -> None:
+def _run_executor(prefix: str, synth_data: str, tokenizer: str) -> None:
     config = ExecutorMainConfig(
         prefix=prefix,
         executor_info_base_path=f"{prefix}/experiments",
     )
-    steps = create_steps("quickstart-tests", synth_data)
+    steps = create_steps("quickstart-tests", synth_data, tokenizer)
     executor_main(config, steps=steps)
 
 
@@ -231,10 +264,14 @@ def main():
         logger.info("Uploading test fixtures to %s", synth_data)
         _upload_tree(LOCAL_SYNTH_DATA, synth_data)
         cleanup = lambda: _rm_s3(prefix)  # noqa: E731
+        # The vendored tokenizer fixture lives on the submitting host's filesystem,
+        # which remote Zephyr pods cannot see, so S3 mode stages "gpt2" from HF Hub.
+        tokenizer = "gpt2"
     else:
         prefix = tempfile.mkdtemp(prefix="iris-marin-itest-")
         synth_data = str(LOCAL_SYNTH_DATA)
         cleanup = lambda: shutil.rmtree(prefix, ignore_errors=True)  # noqa: E731
+        tokenizer = _materialize_local_tokenizer(Path(prefix) / "gpt2-tokenizer")
 
     os.environ["MARIN_PREFIX"] = prefix
     os.environ["WANDB_MODE"] = "disabled"
@@ -263,7 +300,7 @@ def main():
                         name=f"marin-itest-{uuid.uuid4().hex[:8]}",
                         entrypoint=Entrypoint.from_callable(
                             _run_executor,
-                            args=(prefix, synth_data),
+                            args=(prefix, synth_data, tokenizer),
                         ),
                         resources=ResourceConfig.with_cpu(),
                         environment=create_environment(env_vars=env_vars),
@@ -276,7 +313,7 @@ def main():
                 prefix=prefix,
                 executor_info_base_path=f"{prefix}/experiments",
             )
-            steps = create_steps("quickstart-tests", synth_data)
+            steps = create_steps("quickstart-tests", synth_data, tokenizer)
             with set_current_client(iris_client):
                 executor_main(config, steps=steps)
 


### PR DESCRIPTION
The marin integration test failed whenever HF Hub was unavailable: it pulled the
gpt2 tokenizer and reference config from the Hub on every run, so an outage failed
CI with LocalEntryNotFoundError during the tokenize step.

Local-mode runs now stage the reduced gpt2 tokenizer fixture already vendored at
lib/levanter/tests/gpt2_tokenizer_config.json into a loadable directory and point
both the tokenize step and the train step's HF-checkpoint converter at it, so the
pipeline never reaches the Hub. The CI step sets HF_HUB_OFFLINE=1 so any accidental
Hub access fails fast rather than reintroducing the flake. S3 mode still stages
"gpt2" from the Hub because remote Zephyr pods cannot see the submitting host's
filesystem.

Gpt2Config gains a tokenizer field, mirroring the other model configs, so the
converter loads a configured tokenizer instead of fetching the reference from the
Hub. HFCheckpointConverter now degrades gracefully when the reference config is
unreachable: every HF/transformers "can't fetch" error is an OSError subclass, so
_build_hf_config_dict catches OSError and records architectures derived from the
model type via the torch-free transformers name mapping, instead of failing the
save.