### PR TITLE
[iris] Controller cleanup Wave 3: resolve four behavior-risk findings

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -852,11 +852,15 @@ class Controller:
         claims = self._refresh_reservation_claims()
 
         timer = Timer()
+        # Source max_building_tasks from the scheduler so the no-claims fast path
+        # (reusing ctx) and the claims path (rebuilding via evolve_with_workers)
+        # use one cap, not two independently-defaulted ones.
         ctx = build_scheduling_context(
             self._db,
             self._health,
             self._worker_attrs,
             self._config.user_budget_defaults,
+            max_building_tasks=self._scheduler.max_building_tasks_per_worker,
         )
 
         if trace:
@@ -930,15 +934,12 @@ class Controller:
         timer: Timer,
         trace: bool = False,
     ) -> tuple[list[tuple[JobName, WorkerId]], SchedulingContext, dict[JobName, JobRequirements]]:
-        """Run preference + normal assignment passes.
-
-        Reservation taints are injected here so gates/order/diagnostics see
-        un-tainted workers. When there are no claims we reuse ``ctx`` directly
-        to avoid an index rebuild.
-        """
+        """Inject reservation taints, then run the preference + assignment passes."""
         modified_jobs = inject_taint_constraints(gated.jobs, gated.has_reservation, gated.has_direct_reservation)
 
         if claims:
+            # Taints reorder/relabel workers, so rebuild the capacity/constraint
+            # indexes over the tainted set.
             modified_workers = inject_reservation_taints(list(ctx.workers), claims)
             building_counts = {wid: cap.building_task_count for wid, cap in ctx.capacities.items()}
             ctx.pending_tasks = list(order.ordered_task_ids)
@@ -949,6 +950,9 @@ class Controller:
                 max_building_tasks=self._scheduler.max_building_tasks_per_worker,
             )
         else:
+            # No claims: taint injection is a no-op and ctx's per-pass state is
+            # still empty, so a rebuild would reproduce ctx exactly — reuse it and
+            # skip the index rebuild.
             ctx.pending_tasks = list(order.ordered_task_ids)
             ctx.jobs = modified_jobs
             context = ctx

--- a/lib/iris/src/iris/cluster/controller/projections/endpoints.py
+++ b/lib/iris/src/iris/cluster/controller/projections/endpoints.py
@@ -275,12 +275,12 @@ class EndpointsProjection:
         """Remove all endpoints owned by a task. Returns the removed endpoint_ids."""
         with self._lock:
             ids = list(self._by_task.get(task_id, ()))
-        # Issue the DELETE even if ids is empty: belt-and-suspenders for any
-        # rows the projection might not have observed yet (unlikely race with
-        # an in-flight concurrent writer).
-        cur.execute(delete(endpoints_table).where(endpoints_table.c.task_id == task_id))
+        # Empty index means no committed rows (the index mirrors committed state
+        # under the write lock), so the DELETE would be a no-op — skip it, as
+        # remove() does.
         if not ids:
             return []
+        cur.execute(delete(endpoints_table).where(endpoints_table.c.task_id == task_id))
 
         def apply() -> None:
             with self._lock:

--- a/lib/iris/src/iris/cluster/controller/reconcile/commit.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/commit.py
@@ -17,7 +17,6 @@ leaves no observable trace.
 
 from rigging.timing import Timestamp
 from sqlalchemy import bindparam, func
-from sqlalchemy import literal as sa_literal
 from sqlalchemy import update as sa_update
 
 from iris.cluster.controller.audit_logging import log_event
@@ -29,11 +28,9 @@ from iris.cluster.controller.reconcile.effects import (
     JobRowDelta,
     TaskRowDelta,
 )
-from iris.cluster.controller.reconcile.policy import CANCEL_GUARD_STATES
 from iris.cluster.controller.schema import jobs_table, task_attempts_table, tasks_table
 from iris.cluster.controller.task_state import ACTIVE_TASK_STATES
 from iris.cluster.controller.worker_health import WorkerHealthTracker
-from iris.cluster.types import TERMINAL_JOB_STATES
 from iris.rpc import job_pb2
 
 
@@ -148,12 +145,7 @@ def _flush_attempts(cur: Tx, deltas: list[AttemptRowDelta]) -> None:
 
 
 def _flush_jobs(cur: Tx, deltas: list[JobRowDelta]) -> None:
-    """Bulk-flush job deltas in two groups: recompute writes and cascade kills.
-
-    The kill group keeps the SQL ``WHERE state NOT IN guard`` guard for safety;
-    the in-memory merge already enforces it. Cancel kills (which widen the guard)
-    are issued separately so each executemany uses a single guard set.
-    """
+    """Bulk-flush job deltas: recompute writes, then cascade kills."""
     recompute = [d for d in deltas if not d.is_cascade_kill]
     if recompute:
         params = [
@@ -180,12 +172,11 @@ def _flush_jobs(cur: Tx, deltas: list[JobRowDelta]) -> None:
             params,
         )
 
-    # Cascade kills split by guard width so each executemany uses one guard set.
-    for allow_overwrite in (False, True):
-        kills = [d for d in deltas if d.is_cascade_kill and d.allow_overwrite_worker_failed == allow_overwrite]
-        if not kills:
-            continue
-        guard_states = CANCEL_GUARD_STATES if allow_overwrite else TERMINAL_JOB_STATES
+    # Cascade kills flush unconditionally: merge_cascade_kill already drops a kill
+    # onto an already-terminal job, and snapshot load and this flush share one write
+    # transaction, so the live row cannot diverge from the guarded basis.
+    kills = [d for d in deltas if d.is_cascade_kill]
+    if kills:
         params = [
             {
                 "b_job_id": d.job_id,
@@ -196,14 +187,9 @@ def _flush_jobs(cur: Tx, deltas: list[JobRowDelta]) -> None:
             for d in kills
         ]
         c = jobs_table.c
-        # Render the guard as inline literals (NOT an expanding ``IN``): expanding
-        # bind params are incompatible with executemany. The in-memory merge in
-        # ``merge_cascade_kill`` already enforces this guard; the SQL guard is a
-        # harmless safety net.
-        guard_clause = c.state.not_in([sa_literal(s) for s in sorted(guard_states)])
         cur.execute(
             sa_update(jobs_table)
-            .where(c.job_id == bindparam("b_job_id"), guard_clause)
+            .where(c.job_id == bindparam("b_job_id"))
             .values(
                 state=job_pb2.JOB_STATE_KILLED,
                 error=bindparam("b_error"),

--- a/lib/iris/tests/cluster/controller/test_reconcile.py
+++ b/lib/iris/tests/cluster/controller/test_reconcile.py
@@ -1018,6 +1018,25 @@ def test_observations_to_updates_routes_batch_by_uid():
         assert by_task[task_b].new_state == job_pb2.TASK_STATE_FAILED
 
 
+@pytest.mark.parametrize(
+    ("obs_state", "exit_code", "expected"),
+    [
+        # proto3 has no scalar presence, so a real exit 0 (wire-0) is collapsed to
+        # None to avoid clobbering a recorded code via the commit-time coalesce;
+        # success is conveyed by the SUCCEEDED state, not by exit 0.
+        (job_pb2.TASK_STATE_SUCCEEDED, 0, None),
+        # A genuine non-zero code must survive.
+        (job_pb2.TASK_STATE_FAILED, 137, 137),
+    ],
+)
+def test_exit_code_zero_coalesced_to_none(obs_state, exit_code, expected):
+    """exit_code 0 is intentionally collapsed to None."""
+    with make_controller_state() as state:
+        _, _, uid = _setup_running_task(state)
+        [update] = _observations_to_updates(state, [_obs(uid, obs_state, exit_code=exit_code)])
+    assert update.exit_code == expected
+
+
 # --- End-to-end: full controller tick over both wires ----------------------
 
 

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -51,6 +51,7 @@ from iris.cluster.controller.scheduling_policy import (
     claim_workers_for_reservations,
     cleanup_stale_claims,
     compute_demand_entries,
+    compute_scheduling_order,
     inject_reservation_taints,
     inject_taint_constraints,
     job_requirements_from_job,
@@ -589,6 +590,60 @@ def test_gate_satisfied_for_jobs_without_reservation(ctrl):
     ctx = build_scheduling_context(ctrl._db, ctrl._health, ctrl._worker_attrs, ctrl._config.user_budget_defaults)
     gated = apply_scheduling_gates(ctx, claims, max_tasks_per_job_per_cycle=0)
     assert jid.task(0) in gated.schedulable_task_ids
+
+
+# =============================================================================
+# No-claims fast-path equivalence
+# =============================================================================
+
+
+def _no_reservation_request(name: str) -> controller_pb2.Controller.LaunchJobRequest:
+    return controller_pb2.Controller.LaunchJobRequest(
+        name=name,
+        entrypoint=_entrypoint(),
+        resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
+        environment=job_pb2.EnvironmentConfig(),
+        replicas=1,
+    )
+
+
+def test_no_claims_fast_path_matches_evolve(ctrl):
+    """The no-claims fast path schedules identically to the evolve rebuild."""
+    _register_worker(ctrl, "w1")
+    _register_worker(ctrl, "w2")
+    for name in ("j1", "j2"):
+        _submit_job(ctrl, name, _no_reservation_request(name))
+
+    scheduler = ctrl._scheduler
+    no_claims: dict[WorkerId, ReservationClaim] = {}
+
+    def _assign(rebuild: bool) -> set[tuple[JobName, WorkerId]]:
+        ctx = build_scheduling_context(
+            ctrl._db,
+            ctrl._health,
+            ctrl._worker_attrs,
+            ctrl._config.user_budget_defaults,
+            max_building_tasks=scheduler.max_building_tasks_per_worker,
+        )
+        gated = apply_scheduling_gates(ctx, no_claims, max_tasks_per_job_per_cycle=0)
+        order = compute_scheduling_order(ctx, gated)
+        jobs = inject_taint_constraints(gated.jobs, gated.has_reservation, gated.has_direct_reservation)
+        ctx.pending_tasks = list(order.ordered_task_ids)
+        if rebuild:  # controller's claims branch
+            building_counts = {wid: cap.building_task_count for wid, cap in ctx.capacities.items()}
+            ctx = ctx.evolve_with_workers(
+                workers=inject_reservation_taints(list(ctx.workers), no_claims),
+                jobs=jobs,
+                building_counts=building_counts,
+                max_building_tasks=scheduler.max_building_tasks_per_worker,
+            )
+        else:  # controller's no-claims branch
+            ctx.jobs = jobs
+        return set(scheduler.find_assignments(ctx).assignments)
+
+    fast = _assign(rebuild=False)
+    assert len(fast) == 2  # two fitting tasks, two workers — non-vacuous
+    assert fast == _assign(rebuild=True)
 
 
 # =============================================================================


### PR DESCRIPTION
Wave 3 of the Iris controller cleanup series (after #6169 and #6172) resolves the four behavior-risk findings on the reconcile/scheduling correctness surface.

The no-claims scheduler branch reused the built SchedulingContext in place while the claims branch rebuilt it through evolve_with_workers, and the two drew max_building_tasks from independently defaulted sources (build_scheduling_context versus the scheduler). They agree today but could silently diverge. The build site now sources the cap from the scheduler so both paths share it, and a new test asserts both paths schedule identically for the same worker set.

remove_by_task issued an unconditional DELETE to guard an "unlikely race" with a concurrent writer. The single write lock serializes all writers and fires post-commit hooks before releasing, so the in-memory index reflects every committed row at transaction start and that race cannot occur. It now early-returns when the index holds no rows for the task, matching remove(). The change is behavior-preserving, so it adds no test.

The exit_code 0 to None coalescing in worker reconcile is kept. No consumer distinguishes "exited 0" from "no exit code": the RPC surface reports exit_code or 0, the commit-time coalesce preserves recorded values, and the has_new_data check only gates a same-state skip. Success is conveyed by the SUCCEEDED terminal state. A test locks in the behavior for the zero and non-zero cases.

The cascade-kill guard was duplicated in the overlay and the SQL flush. Snapshot load and the flush share one write transaction under the single write lock, so the live row cannot diverge from the basis merge_cascade_kill already guards against, making the SQL WHERE state NOT IN guard re-check dead code. It is removed, leaving the overlay as the single enforcement point, which the existing merge_cascade_kill tests cover.