### PR TITLE
[datakit] Add finetranslations source

### DIFF
--- a/lib/marin/src/marin/datakit/download/finetranslations.py
+++ b/lib/marin/src/marin/datakit/download/finetranslations.py
@@ -1,0 +1,95 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""HuggingFaceFW/finetranslations download + parallel-text transform + normalize.
+
+FineTranslations is a parallel corpus: each row pairs ``og_full_text`` (the
+original web text in its native language) with ``translated_text`` (a machine
+English translation). For pretraining we fold both sides into a single document
+so the model sees the same content in both languages.
+
+The transform concatenates the two with a blank-line separator in a per-document
+random order — in expectation half the documents read original→English and half
+read English→original. The order is chosen deterministically from a content hash
+so the step is reproducible across re-runs.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator
+
+import dupekit
+from fray import ResourceConfig
+from zephyr import Dataset, ZephyrContext, counters, load_parquet
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+FINETRANSLATIONS_HF_ID = "HuggingFaceFW/finetranslations"
+FINETRANSLATIONS_REVISION = "af3f4ca"
+
+SEPARATOR = "\n\n"
+
+
+def fold_parallel_text(record: dict) -> Iterator[dict]:
+    """Concatenate the English translation and the original text into one document.
+
+    Yields a single ``{"text": ...}`` record. When both sides are present the
+    English/original order is a deterministic per-document coin flip on a content
+    hash, so in expectation half the corpus reads original→English and half
+    English→original while staying reproducible. A row with only one side present
+    is kept with just that side. Records with neither side present are dropped.
+    """
+    original = record.get("og_full_text") or ""
+    english = record.get("translated_text") or ""
+    if not original and not english:
+        counters.increment("finetranslations/empty")
+        return
+
+    # Coin flip from the row id (falls back to the original text) so the chosen
+    # order is stable across re-runs rather than depending on shard order. Empty
+    # sides are dropped from the join, so single-sided rows pass through as-is.
+    coin = record.get("id") or original
+    if dupekit.hash_xxh3_128(coin.encode("utf-8")) & 1:
+        counters.increment("finetranslations/english_first")
+        parts = (english, original)
+    else:
+        counters.increment("finetranslations/original_first")
+        parts = (original, english)
+
+    counters.increment("finetranslations/kept")
+    yield {"text": SEPARATOR.join(p for p in parts if p)}
+
+
+def transform(input_path: str, output_path: str) -> None:
+    """Fold each parallel row into a single-text-column parquet document."""
+    pipeline = (
+        Dataset.from_files(f"{input_path}/data/**/*.parquet")
+        .flat_map(load_parquet)
+        .flat_map(fold_parallel_text)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="finetranslations-parallel", resources=ResourceConfig(cpu=2, ram="16g"))
+    ctx.execute(pipeline)
+
+
+def finetranslations_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the ``(download, fold, normalize)`` chain for finetranslations."""
+    download = download_hf_step(
+        "raw/finetranslations",
+        hf_dataset_id=FINETRANSLATIONS_HF_ID,
+        revision=FINETRANSLATIONS_REVISION,
+        hf_urls_glob=["data/**/*.parquet"],
+    )
+    processed = StepSpec(
+        name="processed/finetranslations",
+        deps=[download],
+        fn=lambda output_path: transform(input_path=download.output_path, output_path=output_path),
+        hash_attrs={"version": "v1", "separator": SEPARATOR},
+    )
+    normalize = normalize_step(
+        name="normalized/finetranslations",
+        download=processed,
+    )
+    return (download, processed, normalize)

--- a/lib/marin/src/marin/datakit/download/finetranslations.py
+++ b/lib/marin/src/marin/datakit/download/finetranslations.py
@@ -20,7 +20,7 @@ from collections.abc import Iterator
 
 import dupekit
 from fray import ResourceConfig
-from zephyr import Dataset, ZephyrContext, counters, load_parquet
+from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.download.huggingface import download_hf_step
 from marin.datakit.normalize import normalize_step
@@ -30,6 +30,10 @@ FINETRANSLATIONS_HF_ID = "HuggingFaceFW/finetranslations"
 FINETRANSLATIONS_REVISION = "af3f4ca"
 
 SEPARATOR = "\n\n"
+
+# Only the columns the fold needs; projected at read time so the upstream's
+# heavy chunk/score/warc columns never leave parquet.
+COLUMNS = ["id", "og_full_text", "translated_text"]
 
 
 def fold_parallel_text(record: dict) -> Iterator[dict]:
@@ -66,7 +70,7 @@ def transform(input_path: str, output_path: str) -> None:
     """Fold each parallel row into a single-text-column parquet document."""
     pipeline = (
         Dataset.from_files(f"{input_path}/data/**/*.parquet")
-        .flat_map(load_parquet)
+        .load_parquet(columns=COLUMNS)
         .flat_map(fold_parallel_text)
         .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
     )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -28,6 +28,7 @@ from marin.datakit.download.davinci_dev import (
 )
 from marin.datakit.download.diagnostic_logs import GHALOGS_ROUGH_TOKENS_B, ghalogs_public_normalize_steps
 from marin.datakit.download.finepdfs import finepdfs_normalize_steps
+from marin.datakit.download.finetranslations import finetranslations_normalize_steps
 from marin.datakit.download.gpt_oss_rollouts import gpt_oss_rollouts_normalize_steps
 from marin.datakit.download.hplt import hplt_v3_normalize_steps
 from marin.datakit.download.institutional_books import institutional_books_normalize_steps
@@ -122,13 +123,6 @@ def _rows_nemotron(
 # .executor_status marker, so we can't confirm the staging run completed
 # cleanly. Re-enable once the staging is re-verified.
 #
-# TODO: confirm there's a download module for HuggingFaceFW/finetranslations.
-# Staging at ``raw/finetranslations_d17a789b`` is still in progress — no
-# provenance.json, no .executor_status=SUCCESS yet. The upstream is a parallel
-# corpus of original multilingual text + machine-translated English; splitting
-# into /multilingual and /web needs different text_field, hf_urls_glob, or
-# data_subdir so the two accounting slices don't normalize to identical rows.
-#
 @cache
 def all_sources() -> dict[str, DatakitSource]:
     """Return the canonical active source set as ``{name: DatakitSource}``.
@@ -148,6 +142,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("coderforge", coderforge_normalize_steps, 10.29),
         ("davinci-dev/ctx-native", davinci_dev_ctx_native_normalize_steps, 57.57),
         ("davinci-dev/env-native", davinci_dev_env_native_normalize_steps, 2.58),
+        ("finetranslations", finetranslations_normalize_steps, 3040.0),
         ("ghalogs/public", ghalogs_public_normalize_steps, GHALOGS_ROUGH_TOKENS_B),
         ("gpt-oss-rollouts", gpt_oss_rollouts_normalize_steps, 3.20),
         ("hplt_v3", hplt_v3_normalize_steps, 612.7),


### PR DESCRIPTION
Registers `HuggingFaceFW/finetranslations` as a single datakit source (`finetranslations`), replacing the stale TODO in `sources.py`. Same shape as closed PR #4328, ported to the datakit `(download → transform → normalize)` chain.

- New `download/finetranslations.py`: download (`af3f4ca`, `data/**/*.parquet`) → fold → normalize.
- Fold transform pairs each row's `og_full_text` (original language) with `translated_text` (English MT) into one `text` column, blank-line separated.
- Order is a deterministic per-doc coin flip on `xxh3(id)`: ~50% original→English, ~50% English→original. Verified ≈50/50 over 20k ids; stable across re-runs.
- Keeps a row if either side is non-empty (drops only fully-empty); no stray separators. Counters: `finetranslations/{kept,english_first,original_first,empty}`.
- Wired into `sources.py` at 3040B rough tokens.

🤖 Generated with [Claude Code](https://claude.com/claude-code)