### PR TITLE
[finelog] Register stat columns as nullable; stop wedging on adopted schemas

### DIFF
--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -101,6 +101,13 @@ class FlushResult(StrEnum):
 
 def _format_exc_summary(exc: BaseException) -> str:
     if isinstance(exc, ConnectError):
+        # The server detail (e.g. "column \"ts\": nullable mismatch
+        # registered=true requested=false") is the whole point of the log —
+        # without it a FAILED_PRECONDITION is undiagnosable. Keep the code too
+        # so the retryable classification stays legible.
+        detail = exc.message.strip()
+        if detail:
+            return f"{type(exc).__name__}({exc.code.name}: {detail})"
         return f"{type(exc).__name__}({exc.code.name})"
     return f"{type(exc).__name__}: {exc}"
 
@@ -153,14 +160,20 @@ def schema_from_dataclass(cls: type) -> Schema:
                 f"dataclass {cls.__name__}: field {field.name!r} is reserved " f"(server-assigned implicit column)"
             )
         annotation = type_hints.get(field.name, field.type)
-        inner, nullable = _strip_optional(annotation)
+        # Every column is registered nullable regardless of whether the field is
+        # declared Optional. Finelog adopts compacted segments as all-nullable
+        # (DuckDB's COPY drops Arrow non-nullability), so a column registered
+        # non-nullable would conflict with its own adopted schema after a catalog
+        # rebuild and wedge all writes. _strip_optional still runs to unwrap the
+        # inner type of ``T | None`` fields and to reject unsupported unions.
+        inner, _nullable = _strip_optional(annotation)
         col_type = _PRIMITIVE_TYPE_MAP.get(inner)
         if col_type is None:
             raise SchemaValidationError(
                 f"dataclass {cls.__name__}: field {field.name!r} has unsupported "
                 f"type {annotation!r} (supported: str, int, float, bool, bytes, datetime)"
             )
-        columns.append(Column(name=field.name, type=col_type, nullable=nullable))
+        columns.append(Column(name=field.name, type=col_type, nullable=True))
     key_column = getattr(cls, "key_column", "")
     if not isinstance(key_column, str):
         raise SchemaValidationError(

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -423,6 +423,19 @@ def test_get_table_registration_conflict_drops_batch(tracked_clients, monkeypatc
         client.close()
 
 
+def test_format_exc_summary_surfaces_connect_detail():
+    """A ConnectError's server detail must survive into the log summary.
+
+    A bare ``FAILED_PRECONDITION`` is undiagnosable; the schema-conflict detail
+    it carries (which column, which mismatch) is the actionable part.
+    """
+    summary = log_client_mod._format_exc_summary(
+        ConnectError(Code.FAILED_PRECONDITION, 'column "mem_bytes": type mismatch registered=int64 requested=float64')
+    )
+    assert "FAILED_PRECONDITION" in summary
+    assert 'column "mem_bytes": type mismatch registered=int64 requested=float64' in summary
+
+
 def test_get_table_retries_transient_registration_failure(tracked_clients, monkeypatch):
     """A retryable registration failure is retried on the flush thread.
 
@@ -578,7 +591,7 @@ def test_table_overflow_drops_oldest(tracked_clients, caplog):
         client.close()
 
 
-def test_schema_from_dataclass_basic():
+def test_schema_from_dataclass_all_columns_nullable():
     @dataclass
     class Stat:
         worker_id: str
@@ -590,8 +603,10 @@ def test_schema_from_dataclass_basic():
     assert s.key_column == ""
     names = [c.name for c in s.columns]
     assert names == ["worker_id", "timestamp_ms", "mem_bytes", "note"]
-    note_col = next(c for c in s.columns if c.name == "note")
-    assert note_col.nullable is True
+    # Every column is nullable regardless of whether the field is Optional:
+    # finelog adopts compacted segments as all-nullable, so a non-nullable
+    # registration would conflict with its own adopted schema and wedge writes.
+    assert all(c.nullable for c in s.columns)
 
 
 def test_schema_from_dataclass_classvar_key():

--- a/rust/finelog/src/store/adopt.rs
+++ b/rust/finelog/src/store/adopt.rs
@@ -68,8 +68,11 @@
 //!    registered non-nullable but lives only in a compacted segment is adopted
 //!    as nullable. This is benign: a nullable-superset never changes queryable
 //!    contents (the cutover gate asserts Query Arrow + the data are identical),
-//!    and deploy's startup RegisterTable re-establishes the exact registered
-//!    nullability.
+//!    and a later RegisterTable with the original non-nullable schema is
+//!    accepted as a no-op (`merge_schemas` treats a nullability difference on
+//!    an existing column as compatible, keeping the adopted nullable form). The
+//!    column stays nullable rather than narrowing back, which is harmless for
+//!    every read and write path.
 //!
 //! Additive-merge history is likewise collapsed: the recovered schema is the
 //! newest segment's columns (which already reflect every additive evolution

--- a/rust/finelog/src/store/schema.rs
+++ b/rust/finelog/src/store/schema.rs
@@ -312,8 +312,12 @@ pub fn resolve_key_column(schema: &Schema) -> Result<String, StatsError> {
 ///
 /// - identical / requested ⊆ registered -> `registered` unchanged.
 /// - requested adds nullable columns -> the union (registered then new).
-/// - any conflicting column (type or nullability change) -> `SchemaConflict`.
+/// - a conflicting column *type* -> `SchemaConflict`.
 /// - a new non-nullable column -> `SchemaConflict`.
+/// - a nullability difference on an existing column is *not* a conflict: warn
+///   and keep the registered nullability (adopt-from-disk widens compacted
+///   columns to nullable, and re-registration with the original schema must be
+///   accepted, not rejected).
 /// - a differing `key_column` is a *hint*: warn and keep the registered value.
 pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, StatsError> {
     if registered.key_column != requested.key_column {
@@ -345,11 +349,22 @@ pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, 
                         column_type_name(rc.r#type),
                     )));
                 }
+                // A nullability difference on an existing column is NOT a conflict.
+                // Adopt-from-disk widens every compacted column to nullable
+                // (DuckDB's COPY drops Arrow non-nullability), and the adopt
+                // design relies on a later RegisterTable with the original
+                // non-nullable schema being accepted rather than rejected. Keep
+                // the registered nullability (the per-batch align path enforces
+                // column presence against it); treating this as a conflict would
+                // permanently wedge every namespace with non-nullable columns
+                // once a compacted segment is adopted.
                 if existing.nullable != rc.nullable {
-                    return Err(StatsError::SchemaConflict(format!(
-                        "column {:?}: nullable mismatch registered={} requested={}",
-                        rc.name, existing.nullable, rc.nullable,
-                    )));
+                    tracing::warn!(
+                        column = %rc.name,
+                        registered = existing.nullable,
+                        requested = rc.nullable,
+                        "register: nullability differs — keeping registered",
+                    );
                 }
             }
         }
@@ -755,16 +770,36 @@ mod tests {
     }
 
     #[test]
-    fn merge_nullable_change_rejects() {
+    fn merge_nullability_difference_keeps_registered() {
+        // A re-register that flips an existing column's nullability is accepted
+        // (not a conflict) and keeps the registered nullability. This is the
+        // path that un-wedges a namespace whose compacted segments were adopted
+        // as all-nullable: the client re-registers with the original
+        // non-nullable schema and the merge succeeds as a no-op.
         let reg = with_implicit_seq(worker_schema());
-        let req = Schema::new(
+        let widened = Schema::new(
             vec![col("mem_bytes", ColumnType::COLUMN_TYPE_INT64, true)],
             "",
         );
-        assert!(matches!(
-            merge_schemas(&reg, &req),
-            Err(StatsError::SchemaConflict(_))
-        ));
+        assert_eq!(merge_schemas(&reg, &widened).unwrap(), reg);
+
+        let narrowed = Schema::new(
+            vec![col("mem_bytes", ColumnType::COLUMN_TYPE_INT64, false)],
+            "",
+        );
+        let reg_nullable = Schema::new(
+            vec![
+                col("seq", ColumnType::COLUMN_TYPE_INT64, false),
+                col("worker_id", ColumnType::COLUMN_TYPE_STRING, true),
+                col("mem_bytes", ColumnType::COLUMN_TYPE_INT64, true),
+                col("timestamp_ms", ColumnType::COLUMN_TYPE_INT64, true),
+            ],
+            "",
+        );
+        assert_eq!(
+            merge_schemas(&reg_nullable, &narrowed).unwrap(),
+            reg_nullable
+        );
     }
 
     #[test]


### PR DESCRIPTION
A finelog namespace whose compacted segments are adopted from disk comes back all-nullable (DuckDB's COPY drops Arrow non-nullability). merge_schemas then rejected the very next RegisterTable — which sends the original non-nullable dataclass schema — as a nullable mismatch (FAILED_PRECONDITION), permanently blocking every write to that namespace. iris.task_status hit this because each running task re-registers it lazily, so status pushes failed every few seconds with an undiagnosable ConnectError(FAILED_PRECONDITION).

schema_from_dataclass now registers every column nullable regardless of whether the field is declared Optional, matching the adopted form, and merge_schemas treats a nullability difference on an existing column as compatible (keep the registered nullability) rather than a conflict, so a re-register after adoption is a no-op instead of a wedge. This also covers iris.worker and iris.task, which share the same latent failure.

_format_exc_summary now includes the ConnectError detail so a send failure logs the actionable reason (which column, which mismatch) instead of a bare FAILED_PRECONDITION.