### PR TITLE
[infra] Enable Ruff TID252 and ICN001 local-import lints

### DIFF
--- a/lib/haliax/pyproject.toml
+++ b/lib/haliax/pyproject.toml
@@ -86,6 +86,10 @@ src_paths = ["src", "tests"]
 "Documentation" = "https://haliax.readthedocs.io/en/latest/"
 
 [tool.ruff.lint]
+# Local-import hygiene (issue #6219), mirrored from the root config so these
+# rules apply repo-wide: TID252 (absolute over parent-relative imports) and
+# ICN001 (conventional import aliases, e.g. `import numpy as np`).
+extend-select = ["TID252", "ICN001"]
 ignore = [ "E203", "E501", "W605", "F821", "E266", "F722", "E731", "E741" ]
 
 [tool.setuptools.package-data]

--- a/lib/haliax/src/haliax/_src/einsum.py
+++ b/lib/haliax/src/haliax/_src/einsum.py
@@ -10,12 +10,12 @@ import jax.lax
 import haliax
 
 from .dot import _infer_out_sharding
-from ..axis import Axis, AxisSelector, axis_name, eliminate_axes, rearrange_for_partial_order, union_axes
-from ..core import NamedArray
-from ..jax_utils import _jittable_dg_einsum
-from ..quantization import DotGeneralOp
-from ..types import DTypeLike, PrecisionLike
-from ..util import ensure_tuple
+from haliax.axis import Axis, AxisSelector, axis_name, eliminate_axes, rearrange_for_partial_order, union_axes
+from haliax.core import NamedArray
+from haliax.jax_utils import _jittable_dg_einsum
+from haliax.quantization import DotGeneralOp
+from haliax.types import DTypeLike, PrecisionLike
+from haliax.util import ensure_tuple
 from .parsing import AliasTable, parse_einsum, raise_parse_error
 
 

--- a/lib/haliax/src/haliax/_src/rearrange.py
+++ b/lib/haliax/src/haliax/_src/rearrange.py
@@ -11,9 +11,9 @@ from typing import Mapping, Sequence
 import jax.lax
 import jax.numpy as jnp
 
-from ..axis import Axis, AxisSelector, PartialAxisSpec, axis_name, rearrange_for_partial_order
-from ..core import NamedArray
-from ..partitioning import auto_sharded
+from haliax.axis import Axis, AxisSelector, PartialAxisSpec, axis_name, rearrange_for_partial_order
+from haliax.core import NamedArray
+from haliax.partitioning import auto_sharded
 from .parsing import AliasTable, Expression, _resolve_bindings, parse_rearrangement, raise_parse_error
 
 

--- a/lib/haliax/src/haliax/nn/__init__.py
+++ b/lib/haliax/src/haliax/nn/__init__.py
@@ -13,8 +13,8 @@ import haliax.nn.activations
 import haliax.nn.attention as attention
 import haliax.nn.normalization
 
-from ..axis import Axis
-from ..core import NamedArray
+from haliax.axis import Axis
+from haliax.core import NamedArray
 from .activations import (
     celu,
     elu,

--- a/lib/haliax/src/haliax/nn/activations.py
+++ b/lib/haliax/src/haliax/nn/activations.py
@@ -7,10 +7,10 @@ import typing
 from jax import nn as jnn
 from jax import numpy as jnp
 
-from ..axis import Axis
-from ..core import NamedArray
-from ..types import Scalar
-from ..wrap import wrap_elemwise_unary
+from haliax.axis import Axis
+from haliax.core import NamedArray
+from haliax.types import Scalar
+from haliax.wrap import wrap_elemwise_unary
 
 A = typing.TypeVar("A", Scalar, NamedArray, jnp.ndarray)
 

--- a/lib/haliax/src/haliax/nn/array_stacked.py
+++ b/lib/haliax/src/haliax/nn/array_stacked.py
@@ -9,10 +9,10 @@ import equinox as eqx
 import jax
 import jax.numpy as jnp
 
-from .._src.scan import ScanCheckpointPolicy, ScanCheckpointSpec, find_closest_divisible_int_to_sqrt
-from .._src.state_dict import ModuleWithStateDictSerialization, StateDict
-from ..jax_utils import is_jax_array_like, multilevel_scan, tree_checkpoint_name
-from ..util import is_named_array
+from haliax._src.scan import ScanCheckpointPolicy, ScanCheckpointSpec, find_closest_divisible_int_to_sqrt
+from haliax._src.state_dict import ModuleWithStateDictSerialization, StateDict
+from haliax.jax_utils import is_jax_array_like, multilevel_scan, tree_checkpoint_name
+from haliax.util import is_named_array
 from .scan import ModuleInit, _stack_state_dict, _unstack_state_dict
 
 M = TypeVar("M", bound=eqx.Module)

--- a/lib/haliax/src/haliax/nn/conv.py
+++ b/lib/haliax/src/haliax/nn/conv.py
@@ -13,7 +13,7 @@ from jaxtyping import PRNGKeyArray
 
 import haliax.partitioning
 
-from ..axis import (
+from haliax.axis import (
     Axis,
     AxisSelection,
     axis_name,
@@ -23,10 +23,10 @@ from ..axis import (
     unsize_axes,
     without_axes,
 )
-from ..core import NamedArray, named
-from ..jax_utils import named_call
-from ..random import uniform
-from ..util import ensure_tuple
+from haliax.core import NamedArray, named
+from haliax.jax_utils import named_call
+from haliax.random import uniform
+from haliax.util import ensure_tuple
 
 T = TypeVar("T")
 

--- a/lib/haliax/src/haliax/nn/embedding.py
+++ b/lib/haliax/src/haliax/nn/embedding.py
@@ -11,10 +11,10 @@ from jaxtyping import PRNGKeyArray
 import haliax as hax
 
 from .mup import AbstractEmbeddingReparam, ReparamEnabled, EmbeddingStandardParam
-from ..axis import Axis, AxisSpec, concat_axes
-from ..core import NamedArray
-from ..jax_utils import named_call
-from ..tree_util import resize_axis
+from haliax.axis import Axis, AxisSpec, concat_axes
+from haliax.core import NamedArray
+from haliax.jax_utils import named_call
+from haliax.tree_util import resize_axis
 
 
 class Embedding(eqx.Module, ReparamEnabled):

--- a/lib/haliax/src/haliax/nn/linear.py
+++ b/lib/haliax/src/haliax/nn/linear.py
@@ -17,19 +17,19 @@ import haliax as hax
 from . import mup
 from .ragged_dot import ragged_dot
 from .mup import AbstractLinearReparam, ReparamEnabled, LinearStandardParam
-from .._src.state_dict import (
+from haliax._src.state_dict import (
     Mod,
     ModuleWithStateDictSerialization,
     StateDict,
     default_eqx_module_from_state_dict,
     default_eqx_module_to_state_dict,
 )
-from ..axis import Axis, AxisSpec
-from ..core import NamedArray
-from ..jax_utils import named_call
-from ..partitioning import ResourceAxis, shard_map
-from ..quantization import DotGeneralOp
-from ..util import ensure_tuple
+from haliax.axis import Axis, AxisSpec
+from haliax.core import NamedArray
+from haliax.jax_utils import named_call
+from haliax.partitioning import ResourceAxis, shard_map
+from haliax.quantization import DotGeneralOp
+from haliax.util import ensure_tuple
 
 
 class Linear(ModuleWithStateDictSerialization, ReparamEnabled):

--- a/lib/haliax/src/haliax/nn/mlp.py
+++ b/lib/haliax/src/haliax/nn/mlp.py
@@ -8,10 +8,10 @@ import equinox as eqx
 import jax
 from jaxtyping import PRNGKeyArray
 
-from ..axis import Axis, AxisSpec
-from ..core import NamedArray
-from ..jax_utils import maybe_rng_split
-from ..quantization import DotGeneralOp
+from haliax.axis import Axis, AxisSpec
+from haliax.core import NamedArray
+from haliax.jax_utils import maybe_rng_split
+from haliax.quantization import DotGeneralOp
 from .activations import relu
 from .linear import Linear
 

--- a/lib/haliax/src/haliax/nn/mup.py
+++ b/lib/haliax/src/haliax/nn/mup.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 import haliax as hax
 import equinox as eqx
 
-from ..axis import AxisSpec
+from haliax.axis import AxisSpec
 
 
 class AbstractReparam(ABC):

--- a/lib/haliax/src/haliax/nn/normalization.py
+++ b/lib/haliax/src/haliax/nn/normalization.py
@@ -13,11 +13,11 @@ from jax import numpy as jnp
 import haliax
 import haliax as hax
 
-from .._src.state_dict import Mod, ModuleWithStateDictSerialization
-from ..axis import AxisSelection, AxisSpec
-from ..core import NamedArray
-from ..types import Scalar
-from ..wrap import unwrap_namedarrays, wrap_axiswise_call, wrap_reduction_call
+from haliax._src.state_dict import Mod, ModuleWithStateDictSerialization
+from haliax.axis import AxisSelection, AxisSpec
+from haliax.core import NamedArray
+from haliax.types import Scalar
+from haliax.wrap import unwrap_namedarrays, wrap_axiswise_call, wrap_reduction_call
 
 A = TypeVar("A", Scalar, NamedArray, jnp.ndarray)
 

--- a/lib/haliax/src/haliax/nn/pool.py
+++ b/lib/haliax/src/haliax/nn/pool.py
@@ -10,11 +10,11 @@ import jax
 
 import haliax
 
-from ..axis import AxisSpec, axis_spec_to_shape_dict, unsize_axes
-from ..core import NamedArray
-from ..partitioning import auto_sharded
-from ..types import Scalar
-from ..util import ensure_tuple
+from haliax.axis import AxisSpec, axis_spec_to_shape_dict, unsize_axes
+from haliax.core import NamedArray
+from haliax.partitioning import auto_sharded
+from haliax.types import Scalar
+from haliax.util import ensure_tuple
 
 Padding = Literal["SAME", "VALID"] | int | tuple[tuple[int, int], ...]
 

--- a/lib/haliax/src/haliax/nn/ragged_dot.py
+++ b/lib/haliax/src/haliax/nn/ragged_dot.py
@@ -11,7 +11,7 @@ from typing import Literal, TypeAlias
 import jax
 import jax.numpy as jnp
 
-from ..partitioning import ResourceAxis
+from haliax.partitioning import ResourceAxis
 
 logger = logging.getLogger(__name__)
 

--- a/lib/haliax/src/haliax/nn/scan.py
+++ b/lib/haliax/src/haliax/nn/scan.py
@@ -29,9 +29,9 @@ import haliax.util
 from haliax.jax_utils import tree_checkpoint_name
 from haliax.util import is_jax_or_hax_array_like
 
-from .._src.scan import ScanCheckpointPolicy, ScanCheckpointSpec
-from .._src.state_dict import ModuleWithStateDictSerialization, StateDict, with_prefix
-from ..axis import Axis
+from haliax._src.scan import ScanCheckpointPolicy, ScanCheckpointSpec
+from haliax._src.state_dict import ModuleWithStateDictSerialization, StateDict, with_prefix
+from haliax.axis import Axis
 
 M = TypeVar("M", bound=eqx.Module)
 M_co = TypeVar("M_co", bound=eqx.Module, covariant=True)

--- a/lib/levanter/pyproject.toml
+++ b/lib/levanter/pyproject.toml
@@ -183,6 +183,10 @@ target-version = "py311"
 extend-exclude = ["scripts/"]
 
 [tool.ruff.lint]
+# Local-import hygiene (issue #6219), mirrored from the root config so these
+# rules apply repo-wide: TID252 (absolute over parent-relative imports) and
+# ICN001 (conventional import aliases, e.g. `import numpy as np`).
+extend-select = ["TID252", "ICN001"]
 ignore = [
   "E203", "E501", "W605", "F821", "E266", "F722", "E731", "E741"
 ]

--- a/lib/levanter/src/levanter/analysis/entropy.py
+++ b/lib/levanter/src/levanter/analysis/entropy.py
@@ -18,8 +18,8 @@ from haliax.jax_utils import named_call
 import levanter.tracker
 from levanter.callbacks import StepInfo
 
-from ..data import DataLoader
-from ..tracker.histogram import SummaryStats
+from levanter.data import DataLoader
+from levanter.tracker.histogram import SummaryStats
 
 
 B = TypeVar("B")

--- a/lib/levanter/src/levanter/data/loader.py
+++ b/lib/levanter/src/levanter/data/loader.py
@@ -15,7 +15,7 @@ from typing import Generic, TypeVar
 
 import haliax.partitioning
 import jax
-import numpy
+import numpy as np
 from jax import Array
 from jax import numpy as jnp
 from jax import tree_util as jtu
@@ -616,7 +616,7 @@ def check_sharded_consistency(tree: PyTree, check_disjoint_indices_are_different
             replica_0_array = replica_0_arrays[_to_tuple(shard.index)]
             assert shard.data is not None
 
-            if not numpy.array_equal(shard.data, replica_0_array, equal_nan=True):
+            if not np.array_equal(shard.data, replica_0_array, equal_nan=True):
                 raise ValueError("Shard data does not match replica 0 data", shard, replica_0_array)
 
             if check_disjoint_indices_are_different:

--- a/lib/levanter/src/levanter/data/sharded_datasource.py
+++ b/lib/levanter/src/levanter/data/sharded_datasource.py
@@ -17,8 +17,8 @@ import pyarrow.parquet as pq
 
 from levanter.utils import fsspec_utils
 
-from ..data import AsyncDataset
-from ..utils.fsspec_utils import expand_glob
+from levanter.data import AsyncDataset
+from levanter.utils.fsspec_utils import expand_glob
 from ._preprocessor import (
     BatchResult,
     _BatchMapTransform,
@@ -88,7 +88,7 @@ class ShardedDataSource(Generic[T_co]):
         """
 
         source, processor = _construct_composite_batch_processor(self)
-        from ..store.cache import build_or_load_cache  # lazy: store.cache imports levanter.data modules
+        from levanter.store.cache import build_or_load_cache  # lazy: store.cache imports levanter.data modules
 
         cache = build_or_load_cache(
             path,

--- a/lib/levanter/src/levanter/kernels/__init__.py
+++ b/lib/levanter/src/levanter/kernels/__init__.py
@@ -1,0 +1,4 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Custom JAX kernels for Levanter (Pallas TPU kernels and DeepEP helpers)."""

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_tpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_tpu.py
@@ -20,7 +20,7 @@ from jaxtyping import Array, Float, Int
 
 from .config import BlockSizes
 from .tuned_block_sizes import infer_xla_v_block_size
-from ..cost_estimate_utils import with_io_bytes_accessed
+from levanter.kernels.pallas.cost_estimate_utils import with_io_bytes_accessed
 from .xla import _linear_softmax_cross_entropy_loss_streaming_bwd
 
 

--- a/lib/levanter/src/levanter/kernels/pallas/mamba3/config.py
+++ b/lib/levanter/src/levanter/kernels/pallas/mamba3/config.py
@@ -6,7 +6,7 @@ from __future__ import annotations
 from dataclasses import dataclass
 from typing import Literal, TypeAlias
 
-from ..ssd.config import BlockSizes
+from levanter.kernels.pallas.ssd.config import BlockSizes
 
 
 Mamba3Mode: TypeAlias = Literal["siso", "mimo"]

--- a/lib/levanter/src/levanter/kernels/pallas/mamba3/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/mamba3/reference.py
@@ -9,7 +9,7 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float
 
-from ..ssd.reference import (
+from levanter.kernels.pallas.ssd.reference import (
     intra_chunk_log_alpha_cumsum,
     local_log_alpha,
     ssd_chunk_state_reference_batched,

--- a/lib/levanter/src/levanter/kernels/pallas/mamba3/xla.py
+++ b/lib/levanter/src/levanter/kernels/pallas/mamba3/xla.py
@@ -8,12 +8,12 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float
 
-from ..ssd.reference import (
+from levanter.kernels.pallas.ssd.reference import (
     intra_chunk_log_alpha_cumsum,
     local_log_alpha,
     ssd_scan_chunk_states_reference_batched,
 )
-from ..ssd.xla import (
+from levanter.kernels.pallas.ssd.xla import (
     LOCAL_OUTPUT_AUTO,
     LocalOutputVariant,
     PREFIX_EMIT_AUTO,

--- a/lib/levanter/src/levanter/layers/attention.py
+++ b/lib/levanter/src/levanter/layers/attention.py
@@ -16,7 +16,7 @@ import jax
 import jax.random as jrandom
 from jax import numpy as jnp
 
-from ..inference.utils import is_valid
+from levanter.inference.utils import is_valid
 
 try:
     from jax.experimental.pallas.ops.tpu.ragged_paged_attention import (
@@ -45,7 +45,7 @@ except Exception:
 else:
     _SPLASH_KERNEL_SUPPORTS_SINKS = "sinks" in inspect.signature(_splash_attention).parameters
 
-from ..inference.page_table import PageBatchInfo, PageTableSpec
+from levanter.inference.page_table import PageBatchInfo, PageTableSpec
 from .kv_cache import KvPageCache
 from .normalization import LayerNormConfigBase
 from .rotary import RotaryEmbeddings, RotaryEmbeddingsConfig

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -36,8 +36,8 @@ from levanter.data.dataset import AsyncDataset
 from levanter.utils.jax_utils import broadcast_one_to_all
 from levanter.utils.thread_utils import blocking_wait
 
-from ..data._preprocessor import BatchProcessor, BatchResult, dict_from_record_batch
-from ..data.sharded_datasource import ShardedDataSource
+from levanter.data._preprocessor import BatchProcessor, BatchResult, dict_from_record_batch
+from levanter.data.sharded_datasource import ShardedDataSource
 from .jagged_array import JaggedArrayStore, _no_cache_read_context
 from .tree_store import TreeStore
 

--- a/lib/levanter/tests/test_hf_gpt2_serialize.py
+++ b/lib/levanter/tests/test_hf_gpt2_serialize.py
@@ -10,7 +10,7 @@ from typing import Optional, cast
 import equinox
 import fsspec
 import jax
-import numpy as onp
+import numpy as np
 import pytest
 from fsspec import AbstractFileSystem
 from jax.random import PRNGKey
@@ -74,7 +74,7 @@ def _roundtrip_compare_gpt2_checkpoint(model_id, revision, config: Optional[Gpt2
         model = inference_mode(model, True)
 
         lm_head = model.embeddings.token_embeddings
-        jax_lm_head = onp.array(lm_head.weight.array)
+        jax_lm_head = np.array(lm_head.weight.array)
         torch_lm_head = torch_model.transformer.wte.weight.detach().cpu().numpy()
         assert torch_lm_head.shape == jax_lm_head.shape
         assert_allclose(jax_lm_head, torch_lm_head, rtol=1e-4, atol=1e-4)
@@ -83,7 +83,7 @@ def _roundtrip_compare_gpt2_checkpoint(model_id, revision, config: Optional[Gpt2
         attn_mask = AttentionMask.causal()
 
         # we compare softmaxes because the numerics are wonky and we usually just care about the softmax
-        torch_out = torch_model(torch.from_numpy(onp.array(input.array)).to(torch.int32).unsqueeze(0))
+        torch_out = torch_model(torch.from_numpy(np.array(input.array)).to(torch.int32).unsqueeze(0))
         torch_out = torch_out.logits[0].detach().cpu().numpy()
         torch_out = jax.nn.softmax(torch_out, axis=-1)
 
@@ -94,7 +94,7 @@ def _roundtrip_compare_gpt2_checkpoint(model_id, revision, config: Optional[Gpt2
         jax_out = compute(input).array
         assert torch_out.shape == jax_out.shape, f"{torch_out.shape} != {jax_out.shape}"
         # get the argmaxes for the two models
-        assert_allclose(torch_out, onp.array(jax_out), rtol=1e-2, atol=1e-2)
+        assert_allclose(torch_out, np.array(jax_out), rtol=1e-2, atol=1e-2)
 
         with tempfile.TemporaryDirectory() as tmpdir:
             converter.save_pretrained(model, tmpdir)
@@ -102,13 +102,11 @@ def _roundtrip_compare_gpt2_checkpoint(model_id, revision, config: Optional[Gpt2
             torch_model2: HfGpt2LMHeadModel = AutoModelForCausalLM.from_pretrained(tmpdir)
             torch_model2.eval()
 
-            torch_out2 = torch_model2(torch.from_numpy(onp.array(input.array)).to(torch.int32).unsqueeze(0))
+            torch_out2 = torch_model2(torch.from_numpy(np.array(input.array)).to(torch.int32).unsqueeze(0))
             torch_out2 = torch_out2.logits[0].detach().cpu().numpy()
             torch_out2 = jax.nn.softmax(torch_out2, axis=-1)
 
-            assert onp.isclose(
-                torch_out2, onp.array(jax_out), rtol=1e-2, atol=1e-2
-            ).all(), f"{torch_out2} != {jax_out}"
+            assert np.isclose(torch_out2, np.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out2} != {jax_out}"
 
 
 # Gradient tests
@@ -151,7 +149,7 @@ def _compare_gpt2_checkpoint_gradients(model_id, revision, config: Optional[Gpt2
         def torch_loss(model, input_ids) -> torch.Tensor:
             return model(input_ids, labels=input_ids)[0]
 
-        torch_out = torch_loss(torch_model, torch.from_numpy(onp.array(input.array)).to(torch.int64).unsqueeze(0))
+        torch_out = torch_loss(torch_model, torch.from_numpy(np.array(input.array)).to(torch.int64).unsqueeze(0))
 
         def compute_loss(model: LmHeadModel, input_ids):
             example = LmExample.causal(input_ids, eos_id=converter.tokenizer.eos_token_id)
@@ -174,7 +172,7 @@ def _compare_gpt2_checkpoint_gradients(model_id, revision, config: Optional[Gpt2
             continue
 
         torch_g = state_dict[jax_key]
-        assert onp.isclose(jax_g, torch_g.detach().cpu().numpy(), rtol=1e-2, atol=1e-2).all(), f"{jax_g} != {torch_g}"
+        assert np.isclose(jax_g, torch_g.detach().cpu().numpy(), rtol=1e-2, atol=1e-2).all(), f"{jax_g} != {torch_g}"
 
     # now we also want to check that the optimizers do similar things
     optimizer_config = AdamConfig(weight_decay=0.0, learning_rate=1e-3, warmup=0.0, lr_schedule="constant")
@@ -205,9 +203,9 @@ def _compare_gpt2_checkpoint_gradients(model_id, revision, config: Optional[Gpt2
             assert key == "token_out_embeddings"
             continue
         torch_p = state_dict[key]
-        assert onp.isclose(
+        assert np.isclose(
             jax_p, torch_p.detach().cpu().numpy(), rtol=1e-3, atol=2e-3
-        ).all(), f"{key}: {onp.linalg.norm(jax_p - torch_p.detach().cpu().numpy(), ord=onp.inf)}"
+        ).all(), f"{key}: {np.linalg.norm(jax_p - torch_p.detach().cpu().numpy(), ord=np.inf)}"
 
 
 def test_hf_save_to_fs_spec():
@@ -233,7 +231,7 @@ def test_hf_save_to_fs_spec():
 
             for key, simple_p in simple_dict.items():
                 loaded_p = loaded_dict[key]
-                assert onp.allclose(simple_p, loaded_p), f"{key}: {onp.linalg.norm(simple_p - loaded_p, ord=onp.inf)}"
+                assert np.allclose(simple_p, loaded_p), f"{key}: {np.linalg.norm(simple_p - loaded_p, ord=np.inf)}"
 
 
 @pytest.mark.slow
@@ -276,9 +274,9 @@ def test_hf_save_to_gcs_roundtrip():
 
             for key, simple_param in simple_dict.items():
                 loaded_param = loaded_dict[key]
-                assert onp.allclose(
+                assert np.allclose(
                     simple_param, loaded_param
-                ), f"{key}: {onp.linalg.norm(simple_param - loaded_param, ord=onp.inf)}"
+                ), f"{key}: {np.linalg.norm(simple_param - loaded_param, ord=np.inf)}"
     finally:
         with contextlib.suppress(Exception):
             fs.rm(remote_path, recursive=True)

--- a/lib/levanter/tests/test_llama.py
+++ b/lib/levanter/tests/test_llama.py
@@ -7,7 +7,6 @@ import chex
 import equinox as eqx
 import haliax as hax
 import haliax.nn as hnn
-import numpy
 import numpy as np
 import pytest
 import transformers
@@ -277,7 +276,7 @@ def test_llama_roundtrip(scan_layers, num_kv_heads):
         torch_out2 = torch_model2(input_torch)
         torch_out2 = torch_out2.logits[0].detach().cpu().numpy()
         assert torch_out2.shape == jax_out.shape, f"{torch_out2.shape} != {jax_out.shape}"
-        numpy.testing.assert_allclose(torch_out2, jax_out, rtol=1e-5, atol=1e-5)
+        np.testing.assert_allclose(torch_out2, jax_out, rtol=1e-5, atol=1e-5)
 
 
 def _get_llama_config(use_flash=False, num_kv_heads=4, seq_len=64) -> LlamaConfig:

--- a/lib/levanter/tests/test_prp.py
+++ b/lib/levanter/tests/test_prp.py
@@ -3,7 +3,6 @@
 
 import jax.numpy as jnp
 import jax.random as jrandom
-import numpy
 import numpy as np
 import pytest
 
@@ -37,7 +36,7 @@ def test_permutation_with_array_returns_correct_values(PermutationClass):
     permutation = PermutationClass(length, prng_key)
     indices = jnp.arange(length)
     results = permutation(indices)
-    assert isinstance(results, numpy.ndarray)
+    assert isinstance(results, np.ndarray)
     assert len(results) == length
     assert jnp.sum(results == indices) <= 2
 

--- a/lib/levanter/tests/whisper_test.py
+++ b/lib/levanter/tests/whisper_test.py
@@ -6,7 +6,7 @@ from typing import cast
 
 import jax
 import jax.numpy as jnp
-import numpy as onp
+import numpy as np
 import pytest
 from datasets import load_dataset
 from jax.random import PRNGKey
@@ -183,7 +183,7 @@ def test_hf_roundtrip():
     jax_out = compute(na, inp).array[0]
 
     assert torch_out.shape == jax_out.shape, f"{torch_out.shape} != {jax_out.shape}"
-    assert onp.isclose(torch_out, onp.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out} != {jax_out}"
+    assert np.isclose(torch_out, np.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out} != {jax_out}"
 
     with tempfile.TemporaryDirectory() as tmpdir:
         converter.save_pretrained(model, tmpdir)
@@ -194,4 +194,4 @@ def test_hf_roundtrip():
         torch_out2 = torch_model2(input_features, decoder_input_ids=decoder_input_ids)
         torch_out2 = torch_out2.logits[0].detach().cpu().numpy()
         torch_out2 = jax.nn.softmax(torch_out2, axis=-1)
-        assert onp.isclose(torch_out2, onp.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out2} != {jax_out}"
+        assert np.isclose(torch_out2, np.array(jax_out), rtol=1e-2, atol=1e-2).all(), f"{torch_out2} != {jax_out}"

--- a/lib/marin/src/marin/processing/tokenize/data_configs.py
+++ b/lib/marin/src/marin/processing/tokenize/data_configs.py
@@ -6,7 +6,7 @@ import logging
 import os
 from functools import lru_cache
 
-import numpy
+import numpy as np
 from levanter.data.text import DEFAULT_LM_DATA_SHUFFLE, BlockShuffleConfig, DatasetComponent, LmDataConfig
 from levanter.tokenizers import load_tokenizer
 
@@ -173,7 +173,7 @@ def interpolate_mixture_weights(mixture_weights: list[dict[str, float]], weights
     if not all(isinstance(w, int | float) for w in weights):
         raise TypeError("All items in weights must be numeric")
 
-    if not numpy.isclose(sum(weights), 1.0):
+    if not np.isclose(sum(weights), 1.0):
         raise ValueError("Weights must sum to 1.0")
 
     combined_weights = {}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -169,6 +169,12 @@ extend-include = ["scripts/workflows/**/*.py"]
 select = [
     "A", "B", "E", "F", "I", "NPY", "RUF", "UP", "W",
     "N805", "PLR0124", "PLR1722", "RET502", "RET503", "SIM115",
+    # Local-import hygiene (issue #6219):
+    #   TID252 -> "relative-imports" (prefer absolute over parent-relative imports)
+    #   ICN001 -> "unconventional-import-alias" (e.g. `import numpy as np`)
+    # lib/haliax and lib/levanter carry their own [tool.ruff.lint] configs; these
+    # two rules are mirrored there via extend-select so they apply repo-wide.
+    "TID252", "ICN001",
 ]
 ignore = ["F722", "B008", "UP015", "A005", "E741"]
 


### PR DESCRIPTION
Add TID252 (relative-imports) and ICN001 (unconventional-import-alias) to the ruff select so parent-relative imports and off-convention import aliases are caught at pre-commit. lib/haliax and lib/levanter carry their own [tool.ruff.lint] configs that do not inherit the root select, so the two rules are mirrored there via extend-select to apply repo-wide.

Convert the 128 parent-relative imports across haliax and levanter to absolute, and fix all six ICN001 sites (numpy imported unaliased or as onp, now np). The marin-native packages were already clean.

Add lib/levanter/src/levanter/kernels/__init__.py. kernels/ was a PEP 420 namespace package with no __init__.py, so ruff resolved the pallas kernel imports against a non-existent top-level pallas package (from pallas.ssd.config) rather than levanter.kernels.pallas. Making it a regular package, consistent with its deepep/ and pallas/ siblings, lets those imports resolve correctly. The mamba3 kernel tests and a runtime import smoke confirm the kernels package imports cleanly.

Part of #6219