### PR TITLE
[infra] Enable 7 pyrefly error codes by driving them to zero

### DIFF
--- a/lib/haliax/src/haliax/nn/conv.py
+++ b/lib/haliax/src/haliax/nn/conv.py
@@ -4,7 +4,7 @@
 
 import string
 from functools import cached_property
-from typing import Sequence, TypeVar
+from typing import Sequence, TypeVar, cast
 
 import equinox as eqx
 import jax
@@ -426,4 +426,5 @@ def _compute_output_axes(inputs, batch_dims, In, Out):
     2. turn spatial dims (non-batch, non-In, non-Out) into raw names b/c they change size in convolutions
     """
     unchanging_dims = [Out, *batch_dims]
-    return [ax.name if ax not in unchanging_dims else ax for ax in replace_axis(inputs.axes, In, Out)]
+    new_axes = cast(Sequence[Axis], replace_axis(inputs.axes, In, Out))
+    return [ax.name if ax not in unchanging_dims else ax for ax in new_axes]

--- a/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
@@ -78,7 +78,7 @@ def terminate_slices_for_workers(
         )
         group.record_slice_preempted(slice_id, timestamp)
         handle = group.detach_slice(slice_id)
-        unregister_slice_workers(slice_id, worker_ids=slice_worker_ids)
+        unregister_slice_workers(slice_id, slice_worker_ids)
         if handle is not None:
             termination_requests.append(SliceTerminationRequest(slice_id=slice_id, group=group, handle=handle))
 

--- a/lib/iris/src/iris/cluster/controller/reconcile/batches.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/batches.py
@@ -443,8 +443,9 @@ class ReconcileState:
         rows_by_worker: dict[WorkerId, list[ActiveTaskRow]] = {wid: [] for wid in failed_worker_ids}
         for rows in self._snapshot.active_tasks_by_job.values():
             for row in rows:
-                if row.current_worker_id in failed_worker_ids:
-                    rows_by_worker[row.current_worker_id].append(row)
+                wid = row.current_worker_id
+                if wid is not None and wid in failed_worker_ids:
+                    rows_by_worker[wid].append(row)
         return rows_by_worker
 
     def _fail_one_task(

--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -503,7 +503,11 @@ class HFCheckpointConverter(Generic[LevConfig]):
         # TODO: hacky hacky
         for k, v in LmConfig.get_known_choices().items():
             if issubclass(v, HFCompatConfig):
-                if v().hf_checkpoint_converter().HfConfigClass.__name__ == config_class.__name__:
+                # `v` is typed as the abstract LmConfig base (registry value), whose __init__
+                # requires max_seq_len; at runtime every registered choice is a concrete config
+                # that supplies a default, so the no-arg construction is safe.
+                instance = v()  # pyrefly: ignore[missing-argument]
+                if instance.hf_checkpoint_converter().HfConfigClass.__name__ == config_class.__name__:
                     LevConfigClass = v
                     break
         else:

--- a/lib/levanter/src/levanter/config.py
+++ b/lib/levanter/src/levanter/config.py
@@ -142,7 +142,7 @@ def _maybe_get_config_path_and_cmdline_args(args: List[str]):
                 temp_file = tempfile.NamedTemporaryFile(prefix="config", suffix=".yaml", delete=False)
                 temp_config_path = temp_file.name
                 temp_file.close()
-                atexit.register(lambda path=temp_config_path: os.unlink(path))
+                atexit.register(lambda path=temp_config_path: os.unlink(path))  # pyrefly: ignore[missing-argument]
                 fs.get(fs_path, temp_config_path)
                 config_path = temp_config_path
 
@@ -158,7 +158,7 @@ def _maybe_get_config_path_and_cmdline_args(args: List[str]):
             temp_merged_config_path = tempfile.NamedTemporaryFile(prefix="config_merged", suffix=".yaml", delete=False)
             merged_config_path = temp_merged_config_path.name
             temp_merged_config_path.close()
-            atexit.register(lambda path=merged_config_path: os.unlink(path))
+            atexit.register(lambda path=merged_config_path: os.unlink(path))  # pyrefly: ignore[missing-argument]
             with open(merged_config_path, "w") as f:
                 for config_path in config_paths:
                     with open(config_path) as config_file:

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -1052,4 +1052,4 @@ if __name__ == "__main__":
                 metric = key.split("/")[4]
                 print(f"{name} {metric}: {value}")
 
-    main()
+    main()  # pyrefly: ignore[missing-argument]

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -53,6 +53,7 @@ from levanter.inference.engine import InferenceEngine, InferenceEngineConfig
 from levanter.inference.engine import Request as GenRequest
 from levanter.inference.jit_scheduler import SeqDecodingParams
 from levanter.inference.utils import INVALID
+from levanter.layers.attention import AttentionMask
 from levanter.models.gpt2 import Gpt2Config
 from levanter.models.loss import fused_cross_entropy_loss_and_logsumexp_penalty
 from levanter.utils.background_iterable import BackgroundIterator
@@ -392,10 +393,12 @@ def get_segment_ids_from_batch(batch: LmExample, max_segments_per_ex: int) -> li
     """
     Extract unique segment IDs from a batch (on host).
     """
-    if batch.attn_mask.segment_ids is None:
+    attn_mask = batch.attn_mask
+    assert isinstance(attn_mask, AttentionMask), "expected a structured AttentionMask with segment ids"
+    if attn_mask.segment_ids is None:
         segment_ids = []
     else:
-        segment_ids = jax.device_get(batch.attn_mask.segment_ids[0].array)
+        segment_ids = jax.device_get(attn_mask.segment_ids[0].array)
 
     unique_segs = np.unique(segment_ids).tolist()
 

--- a/lib/levanter/src/levanter/grad_accum.py
+++ b/lib/levanter/src/levanter/grad_accum.py
@@ -3,7 +3,7 @@
 
 import enum
 import functools
-from typing import Callable, Optional, ParamSpec, TypeVar
+from typing import Any, Callable, Optional, ParamSpec, TypeVar, cast
 
 import equinox as eqx
 import haliax as hax
@@ -125,7 +125,7 @@ def microbatched(
                 microbatch_kwargs = microbatch_kwargs.copy()
                 if key is not None:
                     microbatch_kwargs[patch_in_rng_key] = key
-                this_r = fn(*microbatch, **microbatch_kwargs)
+                this_r = cast(tuple[tuple[Any, Any], Any], fn(*microbatch, **microbatch_kwargs))
 
             with jax.named_scope("accum"):
                 # Unpack structure: ((loss, metrics_dict), grads)

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_tpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_tpu.py
@@ -647,6 +647,7 @@ def _make_custom_vjp(
                 dout_lse,
                 block_size=xla_block_size,
                 dtype=dtype,
+                batch_block_size=block_sizes.b_block_size,
                 logit_soft_cap=logit_soft_cap,
                 precision=precision,
             )

--- a/lib/levanter/src/levanter/kernels/pallas/ssd/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/ssd/api.py
@@ -3,7 +3,7 @@
 
 from __future__ import annotations
 
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 import math
 from typing import Literal, TypeAlias, cast
 import warnings
@@ -127,7 +127,7 @@ def ssd_intra_chunk(
 
     errors: list[Exception] = []
     for impl in impls:
-        fn = IMPLEMENTATIONS[impl]
+        fn = cast(Callable[..., Array], IMPLEMENTATIONS[impl])
         try:
             if impl == "pallas_tpu":
                 y = fn(*flat_inputs, block_sizes=block_sizes, interpret=interpret, backend=backend)

--- a/lib/levanter/src/levanter/models/mixtral.py
+++ b/lib/levanter/src/levanter/models/mixtral.py
@@ -5,7 +5,7 @@ import dataclasses
 import inspect
 from dataclasses import dataclass
 from functools import partial
-from typing import Callable, Dict, List, Optional, Type, Union
+from typing import Callable, Dict, List, Optional, Type, Union, cast
 
 import equinox as eqx
 import jax
@@ -545,7 +545,7 @@ class MixtralTransformer(eqx.Module):
         self, x: NamedArray, attn_mask: Optional[NamedArray], *, key, pos_ids: NamedArray | None = None
     ) -> tuple[NamedArray, dict]:
         keys = maybe_rng_split(key, self.config.num_layers) if key is not None else None
-        x, extras = self.layers.scan(x, mask=attn_mask, key=keys)
+        x, extras = cast(tuple[NamedArray, dict], self.layers.scan(x, mask=attn_mask, key=keys))
         x = self.norm(x)
 
         # moe logging

--- a/lib/levanter/src/levanter/models/whisper.py
+++ b/lib/levanter/src/levanter/models/whisper.py
@@ -46,6 +46,10 @@ class WhisperConfig(HFCompatConfig, ASRConfig):
 
     max_source_positions: int = 1500
     max_length: int = 448
+    # Decoder sequence length for the generic LmConfig interface. WhisperConfig overrides
+    # max_Pos to derive the position axis from max_length, so this value only feeds code
+    # that reads LmConfig.max_seq_len directly; keep it in sync with max_length.
+    max_seq_len: int = 448
 
     activation_function: ActivationFunctionEnum = ActivationFunctionEnum.gelu
     layer_norm_epsilon: float = 1e-5

--- a/lib/levanter/src/levanter/schedule.py
+++ b/lib/levanter/src/levanter/schedule.py
@@ -46,7 +46,7 @@ def value_at_step(schedule_or_t: Sequence[ScheduleStep[T]] | T, step: int) -> T:
 def distinct_values(schedule: Sequence[ScheduleStep[T]] | T) -> set[T]:
     if _is_scalar(schedule):
         return {schedule}  # type: ignore
-    return set(step.value for step in schedule)
+    return set(step.value for step in typing.cast("Sequence[ScheduleStep[T]]", schedule))
 
 
 @dataclass

--- a/lib/marin/src/marin/datakit/download/wikipedia.py
+++ b/lib/marin/src/marin/datakit/download/wikipedia.py
@@ -59,7 +59,11 @@ def process_file(input_file: str, output_path: str) -> Iterable[str]:
         with open_url(input_file) as f:
             with tarfile.open(fileobj=f, mode="r:gz") as tr:
                 for info in tr:
-                    with tr.extractfile(info) as file:
+                    file = tr.extractfile(info)
+                    if file is None:
+                        # Non-regular members (e.g. directories) have no extractable content.
+                        continue
+                    with file:
                         file_content = file.read()
                         file_path = os.path.join(output_path, info.name + ".gz")
 

--- a/lib/marin/src/marin/rl/scripts/replay_completions.py
+++ b/lib/marin/src/marin/rl/scripts/replay_completions.py
@@ -28,10 +28,17 @@ import time
 from dataclasses import dataclass, field
 from typing import Any
 
-from levanter.compat.hf_checkpoints import RepoRef
+import equinox as eqx
+import jax.random as jrandom
+from haliax import Axis
+from haliax.partitioning import round_axis_for_partitioning
+from levanter.checkpoint import latest_checkpoint_path, load_checkpoint
+from levanter.compat.hf_checkpoints import HFCheckpointConverter, load_tokenizer
 from levanter.inference.engine import InferenceEngineConfig
 from levanter.inference.openai import InferenceServer, InferenceServerConfig
 from levanter.models.llama import LlamaConfig
+from levanter.models.lm_model import LmHeadModel
+from levanter.tokenizers import MarinTokenizer
 from levanter.trainer import TrainerConfig
 from openai import AsyncOpenAI
 from rigging.log_setup import configure_logging
@@ -85,35 +92,66 @@ def load_requests(requests_file: str) -> list[dict[str, Any]]:
     return requests
 
 
+def _load_model_and_tokenizer(config: ReplayConfig) -> tuple[LmHeadModel, MarinTokenizer]:
+    """Load the inference model and tokenizer from the configured checkpoint.
+
+    Mirrors levanter's inference REPL loader: HF repos are materialized through the
+    HF checkpoint converter, while local Levanter checkpoints are restored with
+    ``load_checkpoint``. The tokenizer is always loaded so the server receives a
+    concrete tokenizer regardless of checkpoint kind.
+    """
+    if not config.checkpoint:
+        raise ValueError("Must specify --checkpoint to load a model")
+
+    tokenizer = load_tokenizer(config.tokenizer or config.checkpoint)
+    is_hf_model = "/" in config.checkpoint and not config.checkpoint.startswith(("/", "./"))
+
+    with config.trainer.use_device_mesh():
+        if is_hf_model:
+            converter = HFCheckpointConverter(
+                type(config.model),
+                reference_checkpoint=config.checkpoint,
+                tokenizer=tokenizer,
+            )
+            model = converter.load_pretrained(
+                config.model.model_type,
+                ref=config.checkpoint,
+                dtype=config.trainer.mp.compute_dtype,
+                axis_mapping=config.trainer.parameter_axis_mapping,
+            )
+        else:
+            Vocab = round_axis_for_partitioning(Axis("vocab", tokenizer.vocab_size), config.trainer.compute_axis_mapping)
+            model = eqx.filter_eval_shape(config.model.build, Vocab, key=jrandom.PRNGKey(0))
+            model = load_checkpoint(
+                model,
+                latest_checkpoint_path(config.checkpoint),
+                subpath="model",
+                axis_mapping=config.trainer.parameter_axis_mapping,
+            )
+            model = config.trainer.mp.cast_to_compute(model)
+
+    return model, tokenizer
+
+
 def create_inference_server(config: ReplayConfig) -> tuple[InferenceServer, AsyncOpenAI, int]:
     """Create and start inference server with client."""
     logger.info(f"Starting inference server with checkpoint: {config.checkpoint}")
 
-    # Determine tokenizer
-    tokenizer_path = config.tokenizer or config.checkpoint
-    if not tokenizer_path:
-        raise ValueError("Must specify either --checkpoint or --tokenizer")
+    model, tokenizer = _load_model_and_tokenizer(config)
 
     # Configure server
     port = find_open_port()
     server_config = InferenceServerConfig(
         host="localhost",
         port=port,
-        tokenizer=tokenizer_path,
+        tokenizer=config.tokenizer or config.checkpoint,
         trainer=config.trainer,
         service=config.service,
     )
 
-    # Set checkpoint path
-    if config.checkpoint:
-        if "/" in config.checkpoint and not config.checkpoint.startswith(("/", "./")):
-            # Looks like an HF model
-            server_config.hf_checkpoint = RepoRef.from_string(config.checkpoint)
-        else:
-            server_config.checkpoint_path = config.checkpoint
-
     # Create and start server
-    server = InferenceServer.create(server_config)
+    with config.trainer.use_device_mesh():
+        server = InferenceServer.create(server_config, model=model, tokenizer=tokenizer)
 
     # run serving in background
     threading.Thread(target=server.serve, daemon=True).start()

--- a/lib/marin/src/marin/rl/weight_transfer/arrow_flight.py
+++ b/lib/marin/src/marin/rl/weight_transfer/arrow_flight.py
@@ -305,6 +305,7 @@ class MarinFlightServer(flight.FlightServerBase):
                     logger.debug(f"Requested weight_id {weight_id} stale, returning {self._latest_weight_id}")
                     weight_id = self._latest_weight_id
 
+                assert weight_id is not None, "No weights have been published yet"
                 (schema, batches) = self._weights_store[weight_id][param_name]
 
             return flight.RecordBatchStream(pa.RecordBatchReader.from_batches(schema, batches))

--- a/lib/marin/src/marin/transform/ar5iv/transform.py
+++ b/lib/marin/src/marin/transform/ar5iv/transform.py
@@ -14,6 +14,7 @@ from html import escape, unescape
 import draccus
 from bs4 import BeautifulSoup
 from marin import markdown
+from marin.schemas.web.convert import HtmlToMarkdownConfig
 from zephyr import Dataset, ZephyrContext, load_jsonl
 
 logger = logging.getLogger(__name__)
@@ -228,7 +229,7 @@ def markdownify_ar5iv_record(html_blob: dict) -> dict:
     """
     content = BeautifulSoup(html_blob["text"], "html.parser")
     try:
-        content = markdown.MyMarkdownConverter().convert_soup(content)
+        content = markdown.MyMarkdownConverter(HtmlToMarkdownConfig()).convert_soup(content)
     except Exception:
         logger.exception("Error converting to markdown; content was: %s", content)
         raise

--- a/lib/marin/src/marin/transform/huggingface/dataset_to_eval.py
+++ b/lib/marin/src/marin/transform/huggingface/dataset_to_eval.py
@@ -312,7 +312,7 @@ def standardize_options(options: list | dict) -> list:
 
 
 def format_prompt_response(
-    question_text: str, options: list[str], labels: list[str], answer_idx: str, answer_text: str
+    question_text: str, options: list[str], labels: list[str], answer_idx: int, answer_text: str
 ) -> tuple[str, str]:
     """
     Produce a fully formatted input string from a question, set of options, and labels
@@ -321,7 +321,7 @@ def format_prompt_response(
         question_text (str): The text of the question
         options (list[str]): The list of options for the multiple choice question
         labels (list[str]): The list of labels
-        answer_idx (str): The index of the correct answer
+        answer_idx (int): The index of the correct answer
         answer_text (str): The text of the correct answer
 
     Returns:

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -92,7 +92,7 @@ class Map:
         needs_shard_context: True if fn expects (stream, shard_info: ShardInfo).
     """
 
-    fn: Callable[[Iterator], Iterator]
+    fn: Callable[..., Iterator]
     needs_shard_context: bool = False
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -263,42 +263,21 @@ project-excludes = [
 # Missing imports (824 occurrences) - third-party libs without stubs
 missing-import = false
 
-# Unexpected keyword arguments (47 occurrences) - dynamic configs from transformers, dataclasses
-unexpected-keyword = false
-
 # Missing attributes (315 occurrences) - often from untyped libraries like JAX, etc.
 # These are mostly false positives from libraries without complete type stubs
 missing-attribute = false
 
-# Additional error types with >10 occurrences that are hard to fix systematically:
-
-# Deprecated APIs (19 occurrences) - would require code changes across multiple files
-deprecated = false
-
 # Unknown name errors (17 occurrences) - often from dynamic code or missing stubs
 unknown-name = false
 
-# Not iterable errors (17 occurrences) - complex type inference issues with JAX/numpy
-not-iterable = false
-
 # No matching overload (16 occurrences) - complex overload resolution issues
 no-matching-overload = false
-
-# Bad index (12 occurrences) - complex dict/list type inference
-bad-index = false
 
 # Library/stub-related noise - disable to focus on real issues:
 
 # Bad argument type (638 occurrences) - mostly third-party library stub issues
 # Common culprits: smart_open, Flax API, JAX/numpy arrays
 bad-argument-type = false
-
-# Bad context manager (30 occurrences) - tqdm and similar libraries
-bad-context-manager = false
-
-# Missing/bad argument count (99 occurrences) - Flax API positional/keyword confusion
-missing-argument = false
-bad-argument-count = false
 
 # Unbound name (64 occurrences) - pyrefly's control flow analysis doesn't understand
 # patterns where variables are guaranteed to be initialized by program logic


### PR DESCRIPTION
Enable seven previously-disabled pyrefly error codes — unexpected-keyword, missing-argument, not-iterable, bad-index, bad-context-manager, bad-argument-count, and deprecated — and remove their disable lines and stale count comments from [tool.pyrefly.errors]. On pyrefly 0.61.0 these codes amounted to 29 instances across 14 sites, not the hundreds the old inline comments claimed.

Five of the fixes are genuine latent runtime bugs, not type noise:

- replay_completions called InferenceServer.create() without the now-required model and tokenizer arguments and set hf_checkpoint/checkpoint_path attributes that no longer exist on InferenceServerConfig; it now loads the model and tokenizer from the checkpoint (mirroring the inference REPL loader) and passes them.
- The pallas fused-cross-entropy backward path under use_bwd_xla_streaming called the streaming bwd without its required batch_block_size; it now passes the forward block_sizes.b_block_size.
- WhisperConfig omitted the no-default max_seq_len it inherits from LmConfig, which made HFCheckpointConverter.from_hf raise while scanning the config registry; it now defaults max_seq_len to max_length. Whisper overrides max_Pos to size the position axis from max_length, so the default cannot change axis sizing.
- ar5iv transform constructed MyMarkdownConverter() without its required config; it now passes HtmlToMarkdownConfig().
- The wikipedia downloader used tarfile.extractfile() as a context manager, but it returns None for non-regular members; it now skips those.

The remaining changes are annotation and narrowing fixes plus four category-scoped pyrefly suppressions for genuine tool limitations (atexit default-parameter lambdas, a draccus-decorated main(), and constructing a concrete config through its abstract registry type).

lib/levanter and lib/haliax are kept in sync with their upstream repos and use separate pre-commit/black configs; the edits there are deliberately minimal (one batch-block-size argument, one WhisperConfig field, casts/asserts, and suppression comments) and should be routed through the upstream-sync workflow.

Part of #6219