### PR TITLE
[codehealth] Batch, parallelize, and cache PR comment classification; add a gist report mode

### DIFF
--- a/infra/codehealth/review.py
+++ b/infra/codehealth/review.py
@@ -17,8 +17,11 @@
 For each PR merged in the last N days:
   1. Pull review/inline/issue comments via the `gh` CLI.
   2. Drop bot comments (only humans should be in the denominator).
-  3. Classify each human comment with Gemini 3.5 Flash. Two independent
-     "could automation have caught this?" signals:
+  3. Classify each human comment with a pluggable classifier (Gemini 3.5 Flash
+     by default). Comments from all PRs are pooled, batched, and the batches
+     classified in parallel so a many-PR run is not a long serial trickle of
+     one request per comment. Two independent "could automation have caught
+     this?" signals:
        - catchable_strict   — a deterministic linter / type checker / ml-*
                               catalog rule could mechanically flag it.
        - catchable_generous — a modern LLM running on the diff alone would
@@ -46,6 +49,8 @@ import logging
 import os
 import subprocess
 import sys
+from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from typing import Literal
 
@@ -53,7 +58,7 @@ import click
 import wandb
 from google import genai
 from google.genai import types
-from pydantic import BaseModel, Field
+from pydantic import BaseModel, Field, TypeAdapter
 
 logger = logging.getLogger("codehealth.review")
 
@@ -61,6 +66,8 @@ WANDB_PROJECT = "marin-review-stats"
 WANDB_RUN_ID = "review-stats"
 DEFAULT_REPO = "marin-community/marin"
 DEFAULT_MODEL = "gemini-3.5-flash"
+DEFAULT_BATCH_SIZE = 20
+DEFAULT_CONCURRENCY = 16
 
 HUMAN_COMMENT_COLUMNS = [
     "ts",
@@ -115,11 +122,41 @@ class CommentClassification(BaseModel):
     model_config = {"populate_by_name": True}
 
 
+@dataclass
+class CommentToClassify:
+    """One comment handed to a classifier. `id` is a caller-assigned marker the
+    classifier echoes back so batched results can be matched to their input."""
+
+    id: int
+    file: str | None
+    line: int | None
+    body: str
+
+
+class BatchedClassification(CommentClassification):
+    """A `CommentClassification` plus the `id` marker echoed back in a batch."""
+
+    id: int
+
+
+# A classifier turns a batch of comments into classifications keyed by their
+# `id` marker. Comments it cannot classify are simply absent from the result.
+# Pluggable so the Gemini backend can be swapped (e.g. for `claude -p`) without
+# touching the batching/parallelism orchestration.
+Classifier = Callable[[list[CommentToClassify]], dict[int, CommentClassification]]
+
+
 CLASSIFIER_SYSTEM = """\
 You triage human PR review comments to measure how much reviewer effort our
-review automation is missing. For each comment, emit a single JSON object.
+review automation is missing. You receive a batch of comments, each delimited
+by a `=== COMMENT id=N ===` marker. Classify each comment independently and
+return a JSON array holding exactly one object per comment — never merge,
+split, drop, or reorder comments.
 
 Fields:
+
+  id — echo back, unchanged, the integer N from this comment's
+       `=== COMMENT id=N ===` marker so the result can be matched to its input.
 
   class — what is the comment about? Pick exactly one:
     bug       — flags a logic error, missing await, wrong type, null deref
@@ -166,6 +203,7 @@ Fields:
            a human would need.
 
 Hard rules:
+  - Return one object per input comment, each echoing the comment's `id`.
   - If catchable_strict is TRUE, catchable_generous must be TRUE.
   - approval / ack comments are never catchable.
   - When a comment is multi-issue, classify by the most material issue.
@@ -173,35 +211,81 @@ Hard rules:
 """
 
 
-def classify_comment(
-    client: genai.Client, model: str, file: str | None, line: int | None, body: str
-) -> CommentClassification | None:
-    """Return classification, or None if the API call fails."""
-    where = f"File: {file}\nLine: {line}\n" if file else "Comment scope: top-level PR comment\n"
-    prompt = f"{where}Body:\n{body.strip()}"
-    try:
-        resp = client.models.generate_content(
-            model=model,
-            contents=prompt,
-            config=types.GenerateContentConfig(
-                system_instruction=CLASSIFIER_SYSTEM,
-                response_mime_type="application/json",
-                response_schema=CommentClassification,
-                temperature=0.0,
-            ),
-        )
-    except Exception as e:
-        logger.warning("Gemini call failed: %s", e)
-        return None
-    try:
-        c = CommentClassification.model_validate_json(resp.text)
-    except Exception as e:
-        logger.warning("Gemini returned unparseable JSON: %s | text=%r", e, resp.text[:200])
-        return None
-    # Enforce the strict ⊆ generous invariant even if the model slipped.
-    if c.catchable_strict and not c.catchable_generous:
-        c.catchable_generous = True
-    return c
+_BATCH_ADAPTER = TypeAdapter(list[BatchedClassification])
+
+
+def _format_batch(items: list[CommentToClassify]) -> str:
+    """Render a batch as marker-delimited blocks the classifier can split."""
+    blocks = []
+    for it in items:
+        where = f"File: {it.file}\nLine: {it.line}" if it.file else "Comment scope: top-level PR comment"
+        blocks.append(f"=== COMMENT id={it.id} ===\n{where}\nBody:\n{it.body.strip()}")
+    return "\n\n".join(blocks)
+
+
+def make_gemini_classifier(client: genai.Client, model: str) -> Classifier:
+    """Build a `Classifier` backed by Gemini structured output.
+
+    One API call per batch: the prompt carries every comment's `id` marker and
+    the response is a JSON array of `BatchedClassification`. A failed call (or
+    unparseable response) yields no classifications for that batch; those
+    comments are dropped from the metric, same as the previous behavior.
+    """
+
+    def classify(items: list[CommentToClassify]) -> dict[int, CommentClassification]:
+        if not items:
+            return {}
+        try:
+            resp = client.models.generate_content(
+                model=model,
+                contents=_format_batch(items),
+                config=types.GenerateContentConfig(
+                    system_instruction=CLASSIFIER_SYSTEM,
+                    response_mime_type="application/json",
+                    response_schema=list[BatchedClassification],
+                    temperature=0.0,
+                ),
+            )
+        except Exception as e:
+            logger.warning("Gemini call failed for batch of %d: %s", len(items), e)
+            return {}
+        try:
+            parsed = _BATCH_ADAPTER.validate_json(resp.text)
+        except Exception as e:
+            logger.warning("Gemini returned unparseable JSON: %s | text=%r", e, (resp.text or "")[:200])
+            return {}
+        wanted = {it.id for it in items}
+        out: dict[int, CommentClassification] = {}
+        for c in parsed:
+            if c.id not in wanted:
+                continue
+            # Enforce the strict ⊆ generous invariant even if the model slipped.
+            if c.catchable_strict and not c.catchable_generous:
+                c.catchable_generous = True
+            out[c.id] = c
+        missing = len(wanted) - len(out)
+        if missing:
+            logger.warning("Gemini omitted %d of %d comments in a batch", missing, len(items))
+        return out
+
+    return classify
+
+
+def classify_comments(
+    classifier: Classifier, items: list[CommentToClassify], batch_size: int, concurrency: int
+) -> dict[int, CommentClassification]:
+    """Classify every comment, batched into groups of `batch_size` and run
+    `concurrency` batches at a time. Returns a map from comment `id` to its
+    classification; ids absent from the map could not be classified."""
+    if not items:
+        return {}
+    batches = [items[i : i + batch_size] for i in range(0, len(items), batch_size)]
+    results: dict[int, CommentClassification] = {}
+    with ThreadPoolExecutor(max_workers=concurrency) as pool:
+        futures = [pool.submit(classifier, batch) for batch in batches]
+        for fut in as_completed(futures):
+            results.update(fut.result())
+    return results
 
 
 # ---------------------------------------------------------------------------
@@ -424,13 +508,36 @@ def overlap_count(bot_findings: list[dict], human_comments: list[Comment], windo
 @click.option("--limit", type=int, default=100, show_default=True, help="Max PRs to process")
 @click.option("--model", default=DEFAULT_MODEL, show_default=True)
 @click.option(
+    "--batch-size",
+    type=int,
+    default=DEFAULT_BATCH_SIZE,
+    show_default=True,
+    help="Comments classified per model request",
+)
+@click.option(
+    "--concurrency",
+    type=int,
+    default=DEFAULT_CONCURRENCY,
+    show_default=True,
+    help="Batches classified in parallel",
+)
+@click.option(
     "--bot-logins",
     default="github-actions,dependabot,claude,claude-review,renovate",
     show_default=True,
     help="Comma-separated bot logins to skip (lowercase)",
 )
 @click.option("--dry-run", is_flag=True, help="Skip W&B upload; print rollup")
-def main(repo: str, days: int, limit: int, model: str, bot_logins: str, dry_run: bool) -> None:
+def main(
+    repo: str,
+    days: int,
+    limit: int,
+    model: str,
+    batch_size: int,
+    concurrency: int,
+    bot_logins: str,
+    dry_run: bool,
+) -> None:
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     bot_login_set = {x.strip().lower() for x in bot_logins.split(",") if x.strip()}
 
@@ -439,6 +546,7 @@ def main(repo: str, days: int, limit: int, model: str, bot_logins: str, dry_run:
         sys.exit(2)
 
     client = genai.Client()
+    classifier = make_gemini_classifier(client, model)
 
     logger.info("Listing PRs merged in last %d day(s) in %s", days, repo)
     prs = list_merged_prs(repo, days, limit)
@@ -472,16 +580,33 @@ def main(repo: str, days: int, limit: int, model: str, bot_logins: str, dry_run:
         )
         findings_by_sha = load_findings_for_shas(wandb, all_shas)
 
-    # Classify + build rows.
+    # Flatten every human comment across all PRs into one list, assign each a
+    # stable marker (its index), classify the whole set in parallel batches,
+    # then map results back to comments. Batching across PRs keeps requests
+    # full even when most PRs have only a comment or two.
+    human_by_pr = {pr["number"]: [c for c in per_pr_comments.get(pr["number"], []) if not c.is_bot] for pr in prs}
+    flat_comments = [c for pr in prs for c in human_by_pr[pr["number"]]]
+    items = [CommentToClassify(id=i, file=c.file, line=c.line, body=c.body) for i, c in enumerate(flat_comments)]
+    logger.info("Classifying %d human comments in batches of %d, %d in parallel", len(items), batch_size, concurrency)
+    classifications = classify_comments(classifier, items, batch_size, concurrency)
+    # Regroup classifications by PR, preserving flat-list ordering for markers.
+    marker = 0
+    classified_by_pr: dict[int, list[tuple[Comment, CommentClassification | None]]] = {}
+    for pr in prs:
+        pairs: list[tuple[Comment, CommentClassification | None]] = []
+        for c in human_by_pr[pr["number"]]:
+            pairs.append((c, classifications.get(marker)))
+            marker += 1
+        classified_by_pr[pr["number"]] = pairs
+
+    # Build rows.
     for pr in prs:
         n = pr["number"]
-        comments = per_pr_comments.get(n, [])
-        human = [c for c in comments if not c.is_bot]
+        human = human_by_pr[n]
         by_class: dict[str, int] = {}
         strict_cnt = generous_cnt = 0
 
-        for c in human:
-            cls = classify_comment(client, model, c.file, c.line, c.body)
+        for c, cls in classified_by_pr[n]:
             if cls is None:
                 continue
             by_class[cls.klass] = by_class.get(cls.klass, 0) + 1

--- a/infra/codehealth/review.py
+++ b/infra/codehealth/review.py
@@ -471,6 +471,66 @@ def _load_existing_rows(wandb, log_key: str) -> list[list]:
         return []
 
 
+def _rows_to_dicts(columns: list[str], rows: list[list]) -> list[dict]:
+    """Zip the flat W&B table rows back into dicts keyed by column name."""
+    return [dict(zip(columns, r, strict=False)) for r in rows]
+
+
+def build_classification_cache(human_rows: list[list]) -> dict[tuple[str, int], tuple[str, CommentClassification]]:
+    """Index already-classified comments so unchanged comments can skip
+    re-classification. Keyed on (comment_type, comment_id) — GitHub's inline /
+    review / issue comment ids live in separate spaces, so the type disambiguates
+    them. Maps to (stored body, classification); the body is kept so an edited
+    comment (same id, new text) is re-classified rather than served stale. The
+    cache is model-agnostic — re-run with `--refresh` after changing `--model`,
+    since the table does not record it."""
+    cache: dict[tuple[str, int], tuple[str, CommentClassification]] = {}
+    for row in _rows_to_dicts(HUMAN_COMMENT_COLUMNS, human_rows):
+        cls = CommentClassification(
+            **{"class": row["class"]},
+            catchable_strict=bool(row["catchable_strict"]),
+            catchable_generous=bool(row["catchable_generous"]),
+            confidence=float(row["confidence"]),
+            reason=row["reason"] or "",
+        )
+        cache[(row["comment_type"], int(row["comment_id"]))] = (row["body"] or "", cls)
+    return cache
+
+
+def resolve_classifications(
+    comments: list[Comment],
+    cache: dict[tuple[str, int], tuple[str, CommentClassification]],
+    classifier: Classifier,
+    batch_size: int,
+    concurrency: int,
+) -> list[CommentClassification | None]:
+    """Classify `comments`, returning one verdict per comment aligned with the
+    input. A comment is reused from `cache` when the same (comment_type,
+    comment_id) was seen before with identical (truncated) text; the rest are
+    sent to `classifier` in parallel batches."""
+    final: list[CommentClassification | None] = [None] * len(comments)
+    pending: list[tuple[int, Comment]] = []
+    for i, c in enumerate(comments):
+        cached = cache.get((c.comment_type, c.comment_id))
+        if cached and cached[0] == c.body[:500]:
+            final[i] = cached[1]
+        else:
+            pending.append((i, c))
+    logger.info(
+        "%d human comments: %d cached, %d to classify in batches of %d, %d in parallel",
+        len(comments),
+        len(comments) - len(pending),
+        len(pending),
+        batch_size,
+        concurrency,
+    )
+    items = [CommentToClassify(id=j, file=c.file, line=c.line, body=c.body) for j, (_, c) in enumerate(pending)]
+    fresh = classify_comments(classifier, items, batch_size, concurrency)
+    for j, (i, _) in enumerate(pending):
+        final[i] = fresh.get(j)
+    return final
+
+
 def load_findings_for_shas(wandb, shas: set[str]) -> dict[str, list[dict]]:
     """Fetch bot findings rows for the given head_shas from the shared run.
 
@@ -509,11 +569,6 @@ def overlap_count(bot_findings: list[dict], human_comments: list[Comment], windo
 # ---------------------------------------------------------------------------
 # Report: render the accumulated W&B tables into a shareable markdown digest
 # ---------------------------------------------------------------------------
-
-
-def _rows_to_dicts(columns: list[str], rows: list[list]) -> list[dict]:
-    """Zip the flat W&B table rows back into dicts keyed by column name."""
-    return [dict(zip(columns, r, strict=False)) for r in rows]
 
 
 def _parse_ts(s: str) -> dt.datetime:
@@ -746,6 +801,11 @@ def cli() -> None:
     show_default=True,
     help="Comma-separated bot logins to skip (lowercase)",
 )
+@click.option(
+    "--refresh",
+    is_flag=True,
+    help="Re-classify every comment, ignoring the cache (use after changing --model)",
+)
 @click.option("--dry-run", is_flag=True, help="Skip W&B upload; print rollup")
 def aggregate(
     repo: str,
@@ -755,9 +815,15 @@ def aggregate(
     batch_size: int,
     concurrency: int,
     bot_logins: str,
+    refresh: bool,
     dry_run: bool,
 ) -> None:
-    """Classify reviewer comments on recently-merged PRs and append to W&B."""
+    """Classify reviewer comments on recently-merged PRs and append to W&B.
+
+    Comments already classified in the W&B `human_comments` table are reused by
+    `comment_id` (unless their text changed), so a daily run over a rolling
+    window only sends genuinely-new comments to the model. Pass `--refresh` to
+    re-classify everything."""
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     bot_login_set = {x.strip().lower() for x in bot_logins.split(",") if x.strip()}
 
@@ -788,9 +854,12 @@ def aggregate(
         per_pr_comments[pr["number"]] = comments
         all_shas.add(pr["headRefOid"])
 
-    # Pull bot findings for these shas from the shared run (skip in dry-run).
+    # Pull bot findings + the existing human_comments table from the shared run
+    # (skip in dry-run). The human_comments rows serve double duty: the
+    # classification cache below, and the replace-by-PR merge at the end.
     if dry_run:
         findings_by_sha = {sha: [] for sha in all_shas}
+        existing_human_rows: list[list] = []
     else:
         wandb.init(
             project=WANDB_PROJECT,
@@ -799,24 +868,25 @@ def aggregate(
             settings=wandb.Settings(silent=True, _disable_stats=True, _disable_meta=True),
         )
         findings_by_sha = load_findings_for_shas(wandb, all_shas)
+        existing_human_rows = _load_existing_rows(wandb, "human_comments")
+    cache = {} if refresh else build_classification_cache(existing_human_rows)
 
-    # Flatten every human comment across all PRs into one list, assign each a
-    # stable marker (its index), classify the whole set in parallel batches,
-    # then map results back to comments. Batching across PRs keeps requests
-    # full even when most PRs have only a comment or two.
+    # Flatten every human comment across all PRs. Reuse a cached classification
+    # when the same comment_id was classified before with identical text;
+    # otherwise queue it for the model. Only the queued ones are batched and
+    # classified in parallel, so an overlapping daily window stays cheap.
     human_by_pr = {pr["number"]: [c for c in per_pr_comments.get(pr["number"], []) if not c.is_bot] for pr in prs}
     flat_comments = [c for pr in prs for c in human_by_pr[pr["number"]]]
-    items = [CommentToClassify(id=i, file=c.file, line=c.line, body=c.body) for i, c in enumerate(flat_comments)]
-    logger.info("Classifying %d human comments in batches of %d, %d in parallel", len(items), batch_size, concurrency)
-    classifications = classify_comments(classifier, items, batch_size, concurrency)
-    # Regroup classifications by PR, preserving flat-list ordering for markers.
-    marker = 0
+    final_cls = resolve_classifications(flat_comments, cache, classifier, batch_size, concurrency)
+
+    # Regroup by PR, preserving flat-list ordering.
+    idx = 0
     classified_by_pr: dict[int, list[tuple[Comment, CommentClassification | None]]] = {}
     for pr in prs:
         pairs: list[tuple[Comment, CommentClassification | None]] = []
         for c in human_by_pr[pr["number"]]:
-            pairs.append((c, classifications.get(marker)))
-            marker += 1
+            pairs.append((c, final_cls[idx]))
+            idx += 1
         classified_by_pr[pr["number"]] = pairs
 
     # Build rows.
@@ -885,14 +955,16 @@ def aggregate(
         click.echo(json.dumps({"pr_rollups": pr_rows, "human_comments": human_rows[:20]}, default=str, indent=2))
         return
 
-    # Replace-by-PR: a daily cron over a rolling window re-classifies PRs we've
-    # seen before. Drop existing rows whose pr_number is in this batch, then
-    # append the fresh ones — the new rows are the source of truth for those PRs.
+    # Replace-by-PR: a daily cron over a rolling window re-emits rows for PRs
+    # we've seen before. Drop existing rows whose pr_number is in this batch,
+    # then append the fresh ones — the new rows are the source of truth for
+    # those PRs. (Cached comments are re-emitted with their stored verdict, so
+    # the dropped rows are reconstructed identically unless the text changed.)
     refreshed_prs = {pr["number"] for pr in prs}
     pr_col_idx = HUMAN_COMMENT_COLUMNS.index("pr_number")
     out_pr_col_idx = PR_OUTCOME_COLUMNS.index("pr_number")
 
-    existing_humans = [r for r in _load_existing_rows(wandb, "human_comments") if r[pr_col_idx] not in refreshed_prs]
+    existing_humans = [r for r in existing_human_rows if r[pr_col_idx] not in refreshed_prs]
     existing_humans.extend(human_rows)
     wandb.log({"human_comments": wandb.Table(columns=HUMAN_COMMENT_COLUMNS, data=existing_humans)})
 

--- a/infra/codehealth/review.py
+++ b/infra/codehealth/review.py
@@ -12,9 +12,16 @@
 # ]
 # ///
 
-"""Daily aggregator for the code-health stats dashboard.
+"""Aggregator and reporter for the code-health stats dashboard.
 
-For each PR merged in the last N days:
+Two subcommands:
+  - `aggregate` (designed to run as a daily GHA cron) classifies reviewer
+    comments and appends them to the shared `review-stats` W&B run.
+  - `report` reads those accumulated tables back and renders a markdown digest
+    (summary table, by-class breakdown, weekly trend, top PRs, examples),
+    published as a gist by default.
+
+`aggregate`, for each PR merged in the last N days:
   1. Pull review/inline/issue comments via the `gh` CLI.
   2. Drop bot comments (only humans should be in the denominator).
   3. Classify each human comment with a pluggable classifier (Gemini 3.5 Flash
@@ -49,9 +56,11 @@ import logging
 import os
 import subprocess
 import sys
+import tempfile
 from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
+from pathlib import Path
 from typing import Literal
 
 import click
@@ -498,11 +507,221 @@ def overlap_count(bot_findings: list[dict], human_comments: list[Comment], windo
 
 
 # ---------------------------------------------------------------------------
-# Main
+# Report: render the accumulated W&B tables into a shareable markdown digest
 # ---------------------------------------------------------------------------
 
 
-@click.command(context_settings={"help_option_names": ["-h", "--help"]})
+def _rows_to_dicts(columns: list[str], rows: list[list]) -> list[dict]:
+    """Zip the flat W&B table rows back into dicts keyed by column name."""
+    return [dict(zip(columns, r, strict=False)) for r in rows]
+
+
+def _parse_ts(s: str) -> dt.datetime:
+    return dt.datetime.fromisoformat(s.replace("Z", "+00:00"))
+
+
+def _pct(n: int, d: int) -> str:
+    return f"{round(100 * n / d)}%" if d else "—"
+
+
+def _cell(value: object, maxlen: int | None = None) -> str:
+    """Render a value as a single safe markdown table cell."""
+    text = " ".join(str(value).split()).replace("|", "\\|")
+    if maxlen and len(text) > maxlen:
+        text = text[: maxlen - 1] + "…"
+    return text
+
+
+def _md_table(headers: list[str], aligns: list[str], rows: list[list]) -> str:
+    lines = ["| " + " | ".join(headers) + " |", "| " + " | ".join(aligns) + " |"]
+    lines += ["| " + " | ".join(str(c) for c in r) + " |" for r in rows]
+    return "\n".join(lines)
+
+
+def _pr_link(repo: str, number: object) -> str:
+    return f"[#{number}](https://github.com/{repo}/pull/{number})"
+
+
+def build_report(
+    outcomes: list[dict], comments: list[dict], repo: str, start: dt.datetime, now: dt.datetime, days: int
+) -> str:
+    """Render the per-PR outcome rows and classified comments into a markdown
+    digest. Pure: takes already-loaded rows, returns markdown. Rows are filtered
+    to PRs merged on/after `start`."""
+
+    def in_window(row: dict) -> bool:
+        merged = row.get("merged_at")
+        if not merged:
+            return False
+        try:
+            return _parse_ts(merged) >= start
+        except ValueError:
+            return False
+
+    outcomes = [d for d in outcomes if in_window(d)]
+    comments = [d for d in comments if in_window(d)]
+
+    header = (
+        f"# Marin code-health review report\n\n"
+        f"**Window:** {start.date()} → {now.date()} ({days} days)  \n"
+        f"**Generated:** {now.replace(microsecond=0).isoformat()}"
+    )
+
+    if not outcomes:
+        return f"{header}\n\nNo PRs merged in the last {days} days were found in the review-stats tables."
+
+    n_prs = len(outcomes)
+    reviewed = sum(1 for d in outcomes if int(d["total_human_comments"]) > 0)
+    total = sum(int(d["total_human_comments"]) for d in outcomes)
+    strict = sum(int(d["catchable_strict_count"]) for d in outcomes)
+    generous = sum(int(d["catchable_generous_count"]) for d in outcomes)
+    bot_findings = sum(int(d["bot_findings_count"]) for d in outcomes)
+    overlap = sum(int(d["overlap_count"]) for d in outcomes)
+
+    narrative = (
+        f"Over the last {days} days, **{n_prs}** PRs merged; **{reviewed}** ({_pct(reviewed, n_prs)}) drew human "
+        f"review comments. Of **{total}** human comments, **{strict}** ({_pct(strict, total)}) were strictly "
+        f"catchable by a deterministic tool and **{generous}** ({_pct(generous, total)}) generously catchable by an "
+        f"LLM reading the diff alone. The review bot emitted **{bot_findings}** findings and independently flagged "
+        f"**{overlap}** of the spots humans commented on."
+    )
+
+    summary = "## Summary\n\n" + _md_table(
+        ["Metric", "Value"],
+        ["---", "---:"],
+        [
+            ["PRs merged", n_prs],
+            ["PRs with human review comments", f"{reviewed} ({_pct(reviewed, n_prs)})"],
+            ["Human review comments", total],
+            ["— strictly catchable", f"{strict} ({_pct(strict, total)})"],
+            ["— generously catchable", f"{generous} ({_pct(generous, total)})"],
+            ["Bot findings", bot_findings],
+            ["Human comments overlapping a bot finding", overlap],
+        ],
+    )
+
+    # By-class breakdown comes from the per-comment table, which carries the
+    # per-comment class + catchable flags the per-PR rollup does not.
+    by_class: dict[str, list[int]] = {}
+    for c in comments:
+        e = by_class.setdefault(str(c["class"]), [0, 0, 0])
+        e[0] += 1
+        e[1] += 1 if c["catchable_strict"] else 0
+        e[2] += 1 if c["catchable_generous"] else 0
+    class_rows = [
+        [cls, n, _pct(n, total), f"{s} ({_pct(s, n)})", f"{g} ({_pct(g, n)})"]
+        for cls, (n, s, g) in sorted(by_class.items(), key=lambda kv: kv[1][0], reverse=True)
+    ]
+    by_class_section = "## By comment class\n\n" + (
+        _md_table(
+            ["Class", "Comments", "% of all", "Strict", "Generous"], ["---", "---:", "---:", "---:", "---:"], class_rows
+        )
+        if class_rows
+        else "_No classified human comments in this window._"
+    )
+
+    # Weekly trend, keyed by ISO week of the merge date.
+    weeks: dict[tuple[int, int], list[int]] = {}
+    for d in outcomes:
+        try:
+            y, w, _ = _parse_ts(d["merged_at"]).isocalendar()
+        except ValueError:
+            continue
+        e = weeks.setdefault((y, w), [0, 0, 0, 0])
+        e[0] += 1
+        e[1] += int(d["total_human_comments"])
+        e[2] += int(d["catchable_strict_count"])
+        e[3] += int(d["catchable_generous_count"])
+    week_rows = [
+        [f"{y}-W{w:02d}", prs, cmts, st, gen, _pct(gen, cmts)] for (y, w), (prs, cmts, st, gen) in sorted(weeks.items())
+    ]
+    trend_section = "## Weekly trend\n\n" + _md_table(
+        ["Week", "PRs", "Comments", "Strict", "Generous", "Generous %"],
+        ["---", "---:", "---:", "---:", "---:", "---:"],
+        week_rows,
+    )
+
+    # Top PRs by how much catchable feedback they drew — where automation would
+    # have helped reviewers most.
+    top = sorted(
+        (d for d in outcomes if int(d["total_human_comments"]) > 0),
+        key=lambda d: (int(d["catchable_generous_count"]), int(d["total_human_comments"])),
+        reverse=True,
+    )[:10]
+    top_rows = [
+        [
+            _pr_link(repo, d["pr_number"]),
+            _cell(d["pr_title"], 60),
+            int(d["total_human_comments"]),
+            int(d["catchable_strict_count"]),
+            int(d["catchable_generous_count"]),
+            int(d["bot_findings_count"]),
+            int(d["overlap_count"]),
+        ]
+        for d in top
+    ]
+    top_section = "## PRs with the most catchable feedback\n\n" + (
+        _md_table(
+            ["PR", "Title", "Comments", "Strict", "Generous", "Bot findings", "Overlap"],
+            ["---", "---", "---:", "---:", "---:", "---:", "---:"],
+            top_rows,
+        )
+        if top_rows
+        else "_No human review comments in this window._"
+    )
+
+    # A few concrete, high-confidence strictly-catchable comments: the clearest
+    # "automation should have caught this" evidence.
+    examples = sorted(
+        (c for c in comments if c["catchable_strict"] and float(c["confidence"]) >= 0.7),
+        key=lambda c: float(c["confidence"]),
+        reverse=True,
+    )[:8]
+    example_rows = [
+        [
+            _pr_link(repo, c["pr_number"]),
+            _cell(c["class"]),
+            f"{float(c['confidence']):.2f}",
+            _cell(c["reason"], 80),
+            _cell(c["body"], 80),
+        ]
+        for c in examples
+    ]
+    examples_section = "## Sample strictly-catchable comments\n\n" + (
+        _md_table(
+            ["PR", "Class", "Conf.", "Why catchable", "Comment"], ["---", "---", "---:", "---", "---"], example_rows
+        )
+        if example_rows
+        else "_No strictly-catchable comments above the confidence threshold in this window._"
+    )
+
+    return "\n\n".join([header, narrative, summary, by_class_section, trend_section, top_section, examples_section])
+
+
+def publish_gist(markdown: str, desc: str, public: bool, filename: str) -> str:
+    """Write `markdown` to a temp file and create a gist via `gh`. Returns the
+    gist URL `gh` prints. Gists default to secret unless `public` is set."""
+    with tempfile.TemporaryDirectory() as d:
+        path = Path(d) / filename
+        path.write_text(markdown)
+        args = ["gist", "create", str(path), "--desc", desc]
+        if public:
+            args.append("--public")
+        result = subprocess.run(["gh", *args], capture_output=True, text=True, check=True)
+        return result.stdout.strip()
+
+
+# ---------------------------------------------------------------------------
+# CLI
+# ---------------------------------------------------------------------------
+
+
+@click.group(context_settings={"help_option_names": ["-h", "--help"]})
+def cli() -> None:
+    """Code-health review stats: classify reviewer comments, and report on them."""
+
+
+@cli.command()
 @click.option("--repo", default=DEFAULT_REPO, show_default=True)
 @click.option("--days", type=int, default=1, show_default=True, help="Look back N days of merged PRs")
 @click.option("--limit", type=int, default=100, show_default=True, help="Max PRs to process")
@@ -528,7 +747,7 @@ def overlap_count(bot_findings: list[dict], human_comments: list[Comment], windo
     help="Comma-separated bot logins to skip (lowercase)",
 )
 @click.option("--dry-run", is_flag=True, help="Skip W&B upload; print rollup")
-def main(
+def aggregate(
     repo: str,
     days: int,
     limit: int,
@@ -538,6 +757,7 @@ def main(
     bot_logins: str,
     dry_run: bool,
 ) -> None:
+    """Classify reviewer comments on recently-merged PRs and append to W&B."""
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     bot_login_set = {x.strip().lower() for x in bot_logins.split(",") if x.strip()}
 
@@ -692,5 +912,47 @@ def main(
     )
 
 
+@cli.command()
+@click.option("--repo", default=DEFAULT_REPO, show_default=True, help="Repo used to build PR links")
+@click.option("--days", type=int, default=30, show_default=True, help="Report window: PRs merged in last N days")
+@click.option("--out", type=click.Path(dir_okay=False), default=None, help="Also write the markdown report here")
+@click.option("--public", is_flag=True, help="Create a public gist (default: secret)")
+@click.option("--no-gist", is_flag=True, help="Print the report to stdout instead of creating a gist")
+def report(repo: str, days: int, out: str | None, public: bool, no_gist: bool) -> None:
+    """Render the accumulated review stats into a markdown digest and gist it."""
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
+    now = dt.datetime.now(dt.timezone.utc)
+    start = now - dt.timedelta(days=days)
+
+    wandb.init(
+        project=WANDB_PROJECT,
+        id=WANDB_RUN_ID,
+        resume="allow",
+        settings=wandb.Settings(silent=True, _disable_stats=True, _disable_meta=True),
+    )
+    outcomes = _rows_to_dicts(PR_OUTCOME_COLUMNS, _load_existing_rows(wandb, "pr_review_outcomes"))
+    comments = _rows_to_dicts(HUMAN_COMMENT_COLUMNS, _load_existing_rows(wandb, "human_comments"))
+    wandb.finish(quiet=True)
+
+    markdown = build_report(outcomes, comments, repo=repo, start=start, now=now, days=days)
+
+    if out:
+        Path(out).write_text(markdown)
+        logger.info("Wrote report to %s", out)
+
+    if no_gist:
+        click.echo(markdown)
+        return
+
+    url = publish_gist(
+        markdown,
+        desc=f"Marin code-health review — last {days} days ({now.date()})",
+        public=public,
+        filename="marin-code-health-report.md",
+    )
+    logger.info("Published gist: %s", url)
+    click.echo(url)
+
+
 if __name__ == "__main__":
-    main()
+    cli()

--- a/infra/codehealth/review.py
+++ b/infra/codehealth/review.py
@@ -597,6 +597,13 @@ def _pr_link(repo: str, number: object) -> str:
     return f"[#{number}](https://github.com/{repo}/pull/{number})"
 
 
+def _where(file: object, line: object) -> str:
+    """`file:line` for an inline comment, the file alone if unlocated, else —."""
+    if not file:
+        return "—"
+    return f"{file}:{line}" if line not in (None, "") else str(file)
+
+
 def build_report(
     outcomes: list[dict], comments: list[dict], repo: str, start: dt.datetime, now: dt.datetime, days: int
 ) -> str:
@@ -725,32 +732,40 @@ def build_report(
         else "_No human review comments in this window._"
     )
 
-    # A few concrete, high-confidence strictly-catchable comments: the clearest
-    # "automation should have caught this" evidence.
-    examples = sorted(
-        (c for c in comments if c["catchable_strict"] and float(c["confidence"]) >= 0.7),
-        key=lambda c: float(c["confidence"]),
-        reverse=True,
-    )[:8]
-    example_rows = [
+    # Every comment an automated check could have caught — the full "automation
+    # should have caught this" list, not a sample (strict ⊆ generous, so the
+    # catchable_strict/generous flags together cover all flagged comments).
+    # Volume is low (~tens/month), so it is intentionally not truncated.
+    flagged = sorted(
+        (c for c in comments if c["catchable_strict"] or c["catchable_generous"]),
+        key=lambda c: (not c["catchable_strict"], -float(c["confidence"])),
+    )
+    flagged_rows = [
         [
             _pr_link(repo, c["pr_number"]),
+            _cell(_where(c.get("file"), c.get("line"))),
+            "strict" if c["catchable_strict"] else "generous",
             _cell(c["class"]),
             f"{float(c['confidence']):.2f}",
+            _cell(c["body"], 120),
             _cell(c["reason"], 80),
-            _cell(c["body"], 80),
         ]
-        for c in examples
+        for c in flagged
     ]
-    examples_section = "## Sample strictly-catchable comments\n\n" + (
-        _md_table(
-            ["PR", "Class", "Conf.", "Why catchable", "Comment"], ["---", "---", "---:", "---", "---"], example_rows
+    flagged_section = f"## Catchable comments ({len(flagged_rows)})\n\n" + (
+        "Every human comment an automated check could plausibly have caught, "
+        "strict (deterministic) first. **strict** = a linter/type-check could "
+        "flag it; **generous** = an LLM reading the diff could.\n\n"
+        + _md_table(
+            ["PR", "Where", "Tier", "Class", "Conf.", "Comment", "Why catchable"],
+            ["---", "---", "---", "---", "---:", "---", "---"],
+            flagged_rows,
         )
-        if example_rows
-        else "_No strictly-catchable comments above the confidence threshold in this window._"
+        if flagged_rows
+        else "_No catchable comments in this window._"
     )
 
-    return "\n\n".join([header, narrative, summary, by_class_section, trend_section, top_section, examples_section])
+    return "\n\n".join([header, narrative, summary, by_class_section, trend_section, top_section, flagged_section])
 
 
 def publish_gist(markdown: str, desc: str, public: bool, filename: str) -> str:

--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -101,6 +101,13 @@ class FlushResult(StrEnum):
 
 def _format_exc_summary(exc: BaseException) -> str:
     if isinstance(exc, ConnectError):
+        # The server detail (e.g. "column \"ts\": nullable mismatch
+        # registered=true requested=false") is the whole point of the log —
+        # without it a FAILED_PRECONDITION is undiagnosable. Keep the code too
+        # so the retryable classification stays legible.
+        detail = exc.message.strip()
+        if detail:
+            return f"{type(exc).__name__}({exc.code.name}: {detail})"
         return f"{type(exc).__name__}({exc.code.name})"
     return f"{type(exc).__name__}: {exc}"
 
@@ -153,14 +160,20 @@ def schema_from_dataclass(cls: type) -> Schema:
                 f"dataclass {cls.__name__}: field {field.name!r} is reserved " f"(server-assigned implicit column)"
             )
         annotation = type_hints.get(field.name, field.type)
-        inner, nullable = _strip_optional(annotation)
+        # Every column is registered nullable regardless of whether the field is
+        # declared Optional. Finelog adopts compacted segments as all-nullable
+        # (DuckDB's COPY drops Arrow non-nullability), so a column registered
+        # non-nullable would conflict with its own adopted schema after a catalog
+        # rebuild and wedge all writes. _strip_optional still runs to unwrap the
+        # inner type of ``T | None`` fields and to reject unsupported unions.
+        inner, _nullable = _strip_optional(annotation)
         col_type = _PRIMITIVE_TYPE_MAP.get(inner)
         if col_type is None:
             raise SchemaValidationError(
                 f"dataclass {cls.__name__}: field {field.name!r} has unsupported "
                 f"type {annotation!r} (supported: str, int, float, bool, bytes, datetime)"
             )
-        columns.append(Column(name=field.name, type=col_type, nullable=nullable))
+        columns.append(Column(name=field.name, type=col_type, nullable=True))
     key_column = getattr(cls, "key_column", "")
     if not isinstance(key_column, str):
         raise SchemaValidationError(

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -423,6 +423,19 @@ def test_get_table_registration_conflict_drops_batch(tracked_clients, monkeypatc
         client.close()
 
 
+def test_format_exc_summary_surfaces_connect_detail():
+    """A ConnectError's server detail must survive into the log summary.
+
+    A bare ``FAILED_PRECONDITION`` is undiagnosable; the schema-conflict detail
+    it carries (which column, which mismatch) is the actionable part.
+    """
+    summary = log_client_mod._format_exc_summary(
+        ConnectError(Code.FAILED_PRECONDITION, 'column "mem_bytes": type mismatch registered=int64 requested=float64')
+    )
+    assert "FAILED_PRECONDITION" in summary
+    assert 'column "mem_bytes": type mismatch registered=int64 requested=float64' in summary
+
+
 def test_get_table_retries_transient_registration_failure(tracked_clients, monkeypatch):
     """A retryable registration failure is retried on the flush thread.
 
@@ -578,7 +591,7 @@ def test_table_overflow_drops_oldest(tracked_clients, caplog):
         client.close()
 
 
-def test_schema_from_dataclass_basic():
+def test_schema_from_dataclass_all_columns_nullable():
     @dataclass
     class Stat:
         worker_id: str
@@ -590,8 +603,10 @@ def test_schema_from_dataclass_basic():
     assert s.key_column == ""
     names = [c.name for c in s.columns]
     assert names == ["worker_id", "timestamp_ms", "mem_bytes", "note"]
-    note_col = next(c for c in s.columns if c.name == "note")
-    assert note_col.nullable is True
+    # Every column is nullable regardless of whether the field is Optional:
+    # finelog adopts compacted segments as all-nullable, so a non-nullable
+    # registration would conflict with its own adopted schema and wedge writes.
+    assert all(c.nullable for c in s.columns)
 
 
 def test_schema_from_dataclass_classvar_key():

--- a/rust/finelog/src/store/adopt.rs
+++ b/rust/finelog/src/store/adopt.rs
@@ -68,8 +68,11 @@
 //!    registered non-nullable but lives only in a compacted segment is adopted
 //!    as nullable. This is benign: a nullable-superset never changes queryable
 //!    contents (the cutover gate asserts Query Arrow + the data are identical),
-//!    and deploy's startup RegisterTable re-establishes the exact registered
-//!    nullability.
+//!    and a later RegisterTable with the original non-nullable schema is
+//!    accepted as a no-op (`merge_schemas` treats a nullability difference on
+//!    an existing column as compatible, keeping the adopted nullable form). The
+//!    column stays nullable rather than narrowing back, which is harmless for
+//!    every read and write path.
 //!
 //! Additive-merge history is likewise collapsed: the recovered schema is the
 //! newest segment's columns (which already reflect every additive evolution

--- a/rust/finelog/src/store/schema.rs
+++ b/rust/finelog/src/store/schema.rs
@@ -312,8 +312,12 @@ pub fn resolve_key_column(schema: &Schema) -> Result<String, StatsError> {
 ///
 /// - identical / requested ⊆ registered -> `registered` unchanged.
 /// - requested adds nullable columns -> the union (registered then new).
-/// - any conflicting column (type or nullability change) -> `SchemaConflict`.
+/// - a conflicting column *type* -> `SchemaConflict`.
 /// - a new non-nullable column -> `SchemaConflict`.
+/// - a nullability difference on an existing column is *not* a conflict: warn
+///   and keep the registered nullability (adopt-from-disk widens compacted
+///   columns to nullable, and re-registration with the original schema must be
+///   accepted, not rejected).
 /// - a differing `key_column` is a *hint*: warn and keep the registered value.
 pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, StatsError> {
     if registered.key_column != requested.key_column {
@@ -345,11 +349,22 @@ pub fn merge_schemas(registered: &Schema, requested: &Schema) -> Result<Schema, 
                         column_type_name(rc.r#type),
                     )));
                 }
+                // A nullability difference on an existing column is NOT a conflict.
+                // Adopt-from-disk widens every compacted column to nullable
+                // (DuckDB's COPY drops Arrow non-nullability), and the adopt
+                // design relies on a later RegisterTable with the original
+                // non-nullable schema being accepted rather than rejected. Keep
+                // the registered nullability (the per-batch align path enforces
+                // column presence against it); treating this as a conflict would
+                // permanently wedge every namespace with non-nullable columns
+                // once a compacted segment is adopted.
                 if existing.nullable != rc.nullable {
-                    return Err(StatsError::SchemaConflict(format!(
-                        "column {:?}: nullable mismatch registered={} requested={}",
-                        rc.name, existing.nullable, rc.nullable,
-                    )));
+                    tracing::warn!(
+                        column = %rc.name,
+                        registered = existing.nullable,
+                        requested = rc.nullable,
+                        "register: nullability differs — keeping registered",
+                    );
                 }
             }
         }
@@ -755,16 +770,36 @@ mod tests {
     }
 
     #[test]
-    fn merge_nullable_change_rejects() {
+    fn merge_nullability_difference_keeps_registered() {
+        // A re-register that flips an existing column's nullability is accepted
+        // (not a conflict) and keeps the registered nullability. This is the
+        // path that un-wedges a namespace whose compacted segments were adopted
+        // as all-nullable: the client re-registers with the original
+        // non-nullable schema and the merge succeeds as a no-op.
         let reg = with_implicit_seq(worker_schema());
-        let req = Schema::new(
+        let widened = Schema::new(
             vec![col("mem_bytes", ColumnType::COLUMN_TYPE_INT64, true)],
             "",
         );
-        assert!(matches!(
-            merge_schemas(&reg, &req),
-            Err(StatsError::SchemaConflict(_))
-        ));
+        assert_eq!(merge_schemas(&reg, &widened).unwrap(), reg);
+
+        let narrowed = Schema::new(
+            vec![col("mem_bytes", ColumnType::COLUMN_TYPE_INT64, false)],
+            "",
+        );
+        let reg_nullable = Schema::new(
+            vec![
+                col("seq", ColumnType::COLUMN_TYPE_INT64, false),
+                col("worker_id", ColumnType::COLUMN_TYPE_STRING, true),
+                col("mem_bytes", ColumnType::COLUMN_TYPE_INT64, true),
+                col("timestamp_ms", ColumnType::COLUMN_TYPE_INT64, true),
+            ],
+            "",
+        );
+        assert_eq!(
+            merge_schemas(&reg_nullable, &narrowed).unwrap(),
+            reg_nullable
+        );
     }
 
     #[test]


### PR DESCRIPTION
The review aggregator classified every human PR comment with a separate, serial Gemini call, so a run over dozens of merged PRs was a long trickle of one request per comment (infra/codehealth/review.py).

Pool all human comments across PRs, batch them (default 20 per request) behind `=== COMMENT id=N ===` markers with a structured JSON-array response, and run the batches through a thread pool (default 16 concurrent). Each comment carries a stable id marker, so batched results map back to the right PR before rollups are built. Classification is pluggable: `Classifier` is a callable taking a batch and returning {id: classification}, with `make_gemini_classifier` as the default Gemini backend, so a future `claude -p` backend can drop in without touching the batching or parallelism.

Cache results across runs. The aggregator re-classified every comment in the window on every run, so an overlapping daily cron did fully redundant model work. Load the existing `human_comments` table once at the start and reuse a comment's stored verdict when the same (comment_type, comment_id) reappears with identical text; only new or edited comments reach the model. `--refresh` re-classifies everything (use after changing `--model`, which the table does not record).

Turn the script into a click group. The classify-and-upload flow becomes `aggregate`; a new `report` reads the accumulated review-stats W&B tables and renders a markdown digest — headline summary table, by-class breakdown, weekly trend, top PRs by catchable feedback, and concrete strictly-catchable example comments — over a configurable window (default 30 days), published as a secret gist via `gh gist create` by default (`--public` to list it, `--no-gist` to print, `--out` to also save locally). Rendering is a pure `build_report` over already-loaded rows, separate from W&B load and gist I/O.

New flags: `aggregate --batch-size/--concurrency/--refresh`; `report --days/--repo/--out/--public/--no-gist`.