### PR TITLE
[levanter] Record vLLM startup runtime snapshot

### DIFF
--- a/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
+++ b/lib/levanter/scripts/bench/bench_qwen3_tpu_inference_parity.py
@@ -74,6 +74,20 @@ REFERENCE_LOGIT_ARTIFACT_MD = "levanter_reference_logits.md"
 REFERENCE_LOGIT_TOP_KS = (1, 10, 100, 1000, 4096)
 REFERENCE_LOGIT_HISTOGRAM_BOUNDS = (0.0, 1e-4, 3e-4, 1e-3, 3e-3, 1e-2, 3e-2, 1e-1, 3e-1, 1.0)
 REFERENCE_LOGIT_CACHE_DTYPE_POLICIES = ("auto", "default", "bfloat16", "float32")
+VLLM_STARTUP_ENV_KEYS = (
+    "JAX_COMPILATION_CACHE_DIR",
+    "JAX_ENABLE_COMPILATION_CACHE",
+    "JAX_PLATFORMS",
+    "LIBTPU_INIT_ARGS",
+    "MODEL_IMPL_TYPE",
+    "TPU_CHIPS_PER_HOST_BOUNDS",
+    "TPU_HOST_BOUNDS",
+    "TPU_MIN_LOG_LEVEL",
+    "TPU_STDERR_LOG_LEVEL",
+    "TPU_VISIBLE_DEVICES",
+    "VLLM_XLA_CACHE_PATH",
+    "XLA_FLAGS",
+)
 
 
 @dataclass(frozen=True, slots=True)
@@ -320,6 +334,7 @@ def _vllm_startup_error_message(
     cmd: list[str],
     process_return_code: int | None,
     cause: Exception,
+    startup_snapshot: dict[str, Any] | None = None,
 ) -> str:
     process_state = (
         f"vLLM process exited with code {process_return_code}"
@@ -330,6 +345,8 @@ def _vllm_startup_error_message(
         f"vLLM failed to start. Logs: {log_dir}. Command: {' '.join(cmd)}",
         f"{process_state}. Startup error: {cause}",
     ]
+    if startup_snapshot is not None:
+        parts.append(f"startup snapshot:\n{json.dumps(startup_snapshot, indent=2, sort_keys=True)}")
     stderr_tail = _tail_text_file(log_dir / "stderr.log")
     if stderr_tail:
         parts.append(f"stderr tail:\n{stderr_tail}")
@@ -337,6 +354,13 @@ def _vllm_startup_error_message(
     if stdout_tail:
         parts.append(f"stdout tail:\n{stdout_tail}")
     return "\n\n".join(parts)
+
+
+def _vllm_startup_snapshot(env: dict[str, str]) -> dict[str, Any]:
+    return {
+        "runtime": _runtime_env_snapshot(include_jax_devices=False),
+        "env": {key: env.get(key) for key in VLLM_STARTUP_ENV_KEYS},
+    }
 
 
 def _prompt_for_token_count(tokenizer, target_tokens: int) -> tuple[str, int]:
@@ -1441,6 +1465,7 @@ def start_vllm_server(
     env.setdefault("JAX_ENABLE_COMPILATION_CACHE", "1")
     env.setdefault("TPU_MIN_LOG_LEVEL", "3")
     env.setdefault("TPU_STDERR_LOG_LEVEL", "3")
+    startup_snapshot = _vllm_startup_snapshot(env)
 
     if log_dir is None:
         log_dir = Path(tempfile.mkdtemp(prefix="qwen3_vllm_bench_"))
@@ -1472,6 +1497,7 @@ def start_vllm_server(
                 cmd=cmd,
                 process_return_code=process_return_code,
                 cause=exc,
+                startup_snapshot=startup_snapshot,
             )
         ) from exc
 

--- a/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
+++ b/lib/levanter/tests/test_qwen3_tpu_inference_parity_bench.py
@@ -1038,6 +1038,53 @@ def test_vllm_startup_error_includes_log_tails(tmp_path):
     assert "loading model" in message
 
 
+def test_vllm_startup_snapshot_records_versions_and_selected_env(monkeypatch):
+    def runtime_snapshot(*, include_jax_devices):
+        assert include_jax_devices is False
+        return {
+            "jax_version": "0.0.test",
+            "vllm_tpu_version": "0.20.0",
+            "devices": None,
+            "device_kind": None,
+        }
+
+    monkeypatch.setattr(bench, "_runtime_env_snapshot", runtime_snapshot)
+
+    snapshot = bench._vllm_startup_snapshot(
+        {
+            "LIBTPU_INIT_ARGS": "--xla_tpu_scoped_vmem_limit_kib=50000",
+            "MODEL_IMPL_TYPE": "vllm",
+            "UNRELATED_SECRET": "do-not-report",
+        }
+    )
+
+    assert snapshot["runtime"]["vllm_tpu_version"] == "0.20.0"
+    assert snapshot["env"]["LIBTPU_INIT_ARGS"] == "--xla_tpu_scoped_vmem_limit_kib=50000"
+    assert snapshot["env"]["MODEL_IMPL_TYPE"] == "vllm"
+    assert "UNRELATED_SECRET" not in snapshot["env"]
+
+
+def test_vllm_startup_error_includes_startup_snapshot(tmp_path):
+    log_dir = tmp_path / "vllm_profiles"
+    log_dir.mkdir()
+
+    message = bench._vllm_startup_error_message(
+        log_dir=log_dir,
+        cmd=["vllm", "serve", "Qwen/Qwen3-8B"],
+        process_return_code=None,
+        cause=TimeoutError("models endpoint timed out"),
+        startup_snapshot={
+            "runtime": {"vllm_tpu_version": "0.20.0", "jax_version": "0.0.test"},
+            "env": {"LIBTPU_INIT_ARGS": "--xla_tpu_scoped_vmem_limit_kib=50000"},
+        },
+    )
+
+    assert "vLLM process was still running when startup timed out" in message
+    assert "startup snapshot:" in message
+    assert '"vllm_tpu_version": "0.20.0"' in message
+    assert '"LIBTPU_INIT_ARGS": "--xla_tpu_scoped_vmem_limit_kib=50000"' in message
+
+
 def test_main_rejects_vllm_greedy_multi_generation_cases():
     with pytest.raises(ValueError, match="n > 1 with greedy sampling"):
         bench.main(


### PR DESCRIPTION
Add a bounded vLLM startup snapshot to parity benchmark startup failures. Future v5p startup timeouts will include package versions plus an allowlist of TPU/XLA/vLLM environment keys alongside the existing command and log tails, without dumping the full environment or initializing JAX devices while vLLM may own libtpu.

Part of #6230; parent epic #6227.