### PR TITLE
Use collections.abc.Iterable for type hints

### DIFF
--- a/lib/dupekit/src/dupekit/__init__.pyi
+++ b/lib/dupekit/src/dupekit/__init__.pyi
@@ -25,7 +25,8 @@
 
 import os
 from enum import Enum
-from typing import Any, BinaryIO, Iterable, Optional, Union, final
+from typing import Any, BinaryIO, Optional, Union, final
+from collections.abc import Iterable
 
 import pyarrow as pa
 


### PR DESCRIPTION
## Problem Background
In Python, `typing.Iterable` has been deprecated since Python 3.9. The recommended practice is to use `collections.abc.Iterable` for type hints, as it aligns with the standard library's evolution and ensures better compatibility with modern Python versions.

## Changes Made
Updated the import in `lib/dupekit/src/dupekit/__init__.pyi` to import `Iterable` from `collections.abc` instead of `typing`. This change is purely stylistic and does not affect runtime behavior or API.

## Verification
- Ensure no functional changes: The type hints remain identical, so all static type checks (e.g., with mypy) should pass without issues.
- Review code style: The modification follows Python best practices for type hints, improving code clarity and maintainability.
- Note: Since this is a `.pyi` stub file, it only affects type checking, not runtime execution.