### PR TITLE
[levanter] Keep HF-dependent torch tests off the Hub

### DIFF
--- a/lib/levanter/src/levanter/models/mistral.py
+++ b/lib/levanter/src/levanter/models/mistral.py
@@ -68,6 +68,8 @@ class MistralConfig(LlamaConfig):
     use_bias: bool = False
     rope: RotaryEmbeddingsConfig = dataclasses.field(default_factory=DefaultRotaryEmbeddingsConfig)
 
+    reference_checkpoint: str = "mistralai/Mistral-7B-v0.1"
+
     # Axis
     @property
     def Embed(self) -> Axis:
@@ -82,13 +84,11 @@ class MistralConfig(LlamaConfig):
     def hf_checkpoint_converter(
         self, ref_checkpoint: Optional[str] = None
     ) -> HFCheckpointConverter["MistralConfig"]:  # type: ignore
-        hf_model_path = "mistralai/Mistral-7B-v0.1" if ref_checkpoint is None else ref_checkpoint
-
         return HFCheckpointConverter(
             self,
-            reference_checkpoint=hf_model_path,
+            reference_checkpoint=self.reference_checkpoint if ref_checkpoint is None else ref_checkpoint,
             trust_remote_code=True,
-            tokenizer=hf_model_path,
+            tokenizer=ref_checkpoint if self.tokenizer is None else self.tokenizer,
             HfConfigClass=HfMistralConfig,
         )
 

--- a/lib/levanter/tests/test_apertus.py
+++ b/lib/levanter/tests/test_apertus.py
@@ -121,7 +121,7 @@ def _make_hf_apertus_config(vocab_size: int, num_kv_heads: int):
     return config
 
 
-def _make_levanter_apertus_config(scan_layers: bool, num_kv_heads: int) -> ApertusConfig:
+def _make_levanter_apertus_config(scan_layers: bool, num_kv_heads: int, tokenizer: str) -> ApertusConfig:
     max_position_embeddings = 256
     rope = Llama3RotaryEmbeddingsConfig(
         theta=12000000.0,
@@ -144,21 +144,23 @@ def _make_levanter_apertus_config(scan_layers: bool, num_kv_heads: int) -> Apert
         rope=rope,
         gradient_checkpointing=False,
         scan_layers=scan_layers,
-        tokenizer="swiss-ai/Apertus-8B-2509",
+        tokenizer=tokenizer,
     )
 
 
 @skip_if_no_torch
 @pytest.mark.parametrize("scan_layers", [True, False])
 @pytest.mark.parametrize("num_kv_heads", [2])
-def test_apertus_roundtrip(scan_layers, num_kv_heads):
+def test_apertus_roundtrip(scan_layers, num_kv_heads, local_gpt2_tokenizer_path):
     import torch
     from transformers import AutoModelForCausalLM
     from transformers.models.apertus.modeling_apertus import ApertusForCausalLM
 
     Vocab = hax.Axis("vocab", 4096)
     hf_config = _make_hf_apertus_config(Vocab.size, num_kv_heads)
-    lev_config = _make_levanter_apertus_config(scan_layers, num_kv_heads)
+    # Local tokenizer keeps the converter off the Hub; the roundtrip uses random
+    # inputs and only asserts logit-equivalence, so the tokenizer is incidental.
+    lev_config = _make_levanter_apertus_config(scan_layers, num_kv_heads, tokenizer=local_gpt2_tokenizer_path)
     input_ids = hax.random.randint(random.PRNGKey(0), lev_config.max_Pos, 0, Vocab.size)
     attn_mask = AttentionMask.causal()
     input_torch = torch.from_numpy(np.array(input_ids.array)).to(torch.int32).unsqueeze(0)
@@ -194,7 +196,7 @@ def test_apertus_roundtrip(scan_layers, num_kv_heads):
 
         assert np.isclose(torch_out, np.array(jax_out), rtol=1e-4, atol=1e-4).all(), f"{torch_out} != {jax_out}"
 
-        converter.save_pretrained(model, f"{tmpdir}/lev_model", save_reference_code=False)
+        converter.save_pretrained(model, f"{tmpdir}/lev_model", save_reference_code=False, save_tokenizer=False)
 
         torch_model2 = AutoModelForCausalLM.from_pretrained(f"{tmpdir}/lev_model")
         torch_model2.eval()
@@ -203,7 +205,7 @@ def test_apertus_roundtrip(scan_layers, num_kv_heads):
 
 
 @skip_if_no_torch
-def test_xielu_parameters_loaded_from_checkpoint():
+def test_xielu_parameters_loaded_from_checkpoint(local_gpt2_tokenizer_path):
     """Test that xIELU learnable parameters (alpha_p, alpha_n) are correctly loaded from HF checkpoint.
 
     This test modifies the xIELU parameters to non-default values before saving,
@@ -216,7 +218,9 @@ def test_xielu_parameters_loaded_from_checkpoint():
     Vocab = hax.Axis("vocab", 4096)
     num_kv_heads = 2
     hf_config = _make_hf_apertus_config(Vocab.size, num_kv_heads)
-    lev_config = _make_levanter_apertus_config(scan_layers=True, num_kv_heads=num_kv_heads)
+    lev_config = _make_levanter_apertus_config(
+        scan_layers=True, num_kv_heads=num_kv_heads, tokenizer=local_gpt2_tokenizer_path
+    )
 
     torch.random.manual_seed(42)
     torch_model = ApertusForCausalLM(hf_config)

--- a/lib/levanter/tests/test_eval_lm.py
+++ b/lib/levanter/tests/test_eval_lm.py
@@ -61,7 +61,7 @@ def test_eval_lm():
 
 
 @skip_if_no_torch
-def test_eval_lm_from_hf():
+def test_eval_lm_from_hf(local_gpt2_tokenizer_path):
     # just testing if eval_lm has a pulse
     # save a checkpoint
     model_config = LlamaConfig(
@@ -74,7 +74,9 @@ def test_eval_lm_from_hf():
 
     with tempfile.TemporaryDirectory() as f:
         try:
-            data_config, _ = tiny_test_corpus.construct_small_data_cache(f)
+            # Local tokenizer keeps the data config off the Hub (the cache holds
+            # random ids, so the tokenizer is only used for vocab sizing).
+            data_config, _ = tiny_test_corpus.construct_small_data_cache(f, tokenizer=local_gpt2_tokenizer_path)
             tok = data_config.the_tokenizer
             Vocab = haliax.Axis("vocab", len(tok))
             model = LlamaLMHeadModel.init(Vocab, model_config, key=jax.random.PRNGKey(0))

--- a/lib/levanter/tests/test_llama.py
+++ b/lib/levanter/tests/test_llama.py
@@ -218,11 +218,13 @@ def test_llama_lm_head_model_bwd(use_flash, num_kv_heads):
 @skip_if_no_torch
 @pytest.mark.parametrize("scan_layers", [True, False])
 @pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
-def test_llama_roundtrip(scan_layers, num_kv_heads):
+def test_llama_roundtrip(scan_layers, num_kv_heads, local_gpt2_tokenizer_path):
     import torch
     from transformers import AutoModelForCausalLM, LlamaForCausalLM
 
-    converter = LlamaConfig().hf_checkpoint_converter()
+    # Local tokenizer + no remote reference keeps the roundtrip off the Hub; the
+    # tokenizer is incidental (random inputs, logit-equivalence only).
+    converter = LlamaConfig(reference_checkpoint=None, tokenizer=local_gpt2_tokenizer_path).hf_checkpoint_converter()
 
     config = LlamaConfig(
         max_seq_len=128,
@@ -269,7 +271,7 @@ def test_llama_roundtrip(scan_layers, num_kv_heads):
         # now we're going to magnify the model parameters enough that differences should actualy show up
         jax_out = compute(model, input).array
 
-        converter.save_pretrained(model, f"{tmpdir}/lev_model", save_reference_code=False)
+        converter.save_pretrained(model, f"{tmpdir}/lev_model", save_reference_code=False, save_tokenizer=False)
         torch_model2 = AutoModelForCausalLM.from_pretrained(f"{tmpdir}/lev_model")
         torch_model2.eval()
 

--- a/lib/levanter/tests/test_llama3.py
+++ b/lib/levanter/tests/test_llama3.py
@@ -70,14 +70,16 @@ def get_config(vocab_size=1000):
 
 @skip_if_no_torch
 @pytest.mark.parametrize("test_seq_len", [128, 256, 512])
-def test_llama3_roundtrip(test_seq_len):
+def test_llama3_roundtrip(test_seq_len, local_gpt2_tokenizer_path):
     import torch
     from transformers import AutoModelForCausalLM, LlamaForCausalLM
 
     Vocab = hax.Axis("vocab", 1000)
     hf_config = get_config(Vocab.size)
 
-    converter = LlamaConfig().hf_checkpoint_converter()
+    # Local tokenizer + no remote reference keeps the roundtrip off the Hub; the
+    # tokenizer is incidental (random inputs, logit-equivalence only).
+    converter = LlamaConfig(reference_checkpoint=None, tokenizer=local_gpt2_tokenizer_path).hf_checkpoint_converter()
 
     config = LlamaConfig.from_hf_config(hf_config)
 
@@ -116,7 +118,7 @@ def test_llama3_roundtrip(test_seq_len):
         # now we're going to magnify the model parameters enough that differences should actualy show up
         jax_out = compute(model, input).array
 
-        converter.save_pretrained(model, f"{tmpdir}/lev_model", save_reference_code=False)
+        converter.save_pretrained(model, f"{tmpdir}/lev_model", save_reference_code=False, save_tokenizer=False)
         torch_model2 = AutoModelForCausalLM.from_pretrained(f"{tmpdir}/lev_model")
         torch_model2.eval()
 

--- a/lib/levanter/tests/test_lora.py
+++ b/lib/levanter/tests/test_lora.py
@@ -152,10 +152,12 @@ def test_merge_lora():
 
 @skip_if_module_missing("peft")
 @skip_if_no_torch
-def test_lora_load_in_peft():
+def test_lora_load_in_peft(local_gpt2_tokenizer_path):
     import torch
 
-    converter: HFCheckpointConverter = Gpt2Config().hf_checkpoint_converter()
+    # Local tokenizer keeps converter construction off the Hub; the base model is
+    # saved/reloaded from a temp dir so the tokenizer is incidental here.
+    converter: HFCheckpointConverter = Gpt2Config(tokenizer=local_gpt2_tokenizer_path).hf_checkpoint_converter()
     config = Gpt2Config(max_seq_len=128, hidden_dim=128, num_layers=2, num_heads=2)
     Vocab = converter.Vocab
 
@@ -170,7 +172,7 @@ def test_lora_load_in_peft():
     with tempfile.TemporaryDirectory() as tmpdir, use_test_mesh():
         from peft import PeftConfig, PeftModel
 
-        converter.save_pretrained(model, f"{tmpdir}/model")
+        converter.save_pretrained(model, f"{tmpdir}/model", save_tokenizer=False)
 
         lora_config = LoraConfig(r=8, target_modules=["c_attn"], a_init_mode="random")
         loraized = loraize(model, lora_config, key=jax.random.PRNGKey(0))
@@ -202,10 +204,12 @@ def test_lora_load_in_peft():
 
 @skip_if_module_missing("peft")
 @skip_if_no_torch
-def test_lora_merged_load_in_hf():
+def test_lora_merged_load_in_hf(local_gpt2_tokenizer_path):
     import torch
 
-    converter: HFCheckpointConverter = Gpt2Config().hf_checkpoint_converter()
+    # Local tokenizer keeps converter construction off the Hub; the base model is
+    # saved/reloaded from a temp dir so the tokenizer is incidental here.
+    converter: HFCheckpointConverter = Gpt2Config(tokenizer=local_gpt2_tokenizer_path).hf_checkpoint_converter()
     config = Gpt2Config(max_seq_len=128, hidden_dim=128, num_layers=2, num_heads=2)
     Vocab = converter.Vocab
 
@@ -218,11 +222,11 @@ def test_lora_merged_load_in_hf():
     causal_mask = AttentionMask.causal()
 
     with tempfile.TemporaryDirectory() as tmpdir, use_test_mesh():
-        converter.save_pretrained(model, f"{tmpdir}/model")
+        converter.save_pretrained(model, f"{tmpdir}/model", save_tokenizer=False)
 
         lora_config = LoraConfig(r=8, target_modules=["c_attn"], a_init_mode="random")
         loraized = loraize(model, lora_config, key=jax.random.PRNGKey(0))
-        save_merged_hf_model(loraized, converter, f"{tmpdir}/loraized")
+        save_merged_hf_model(loraized, converter, f"{tmpdir}/loraized", save_tokenizer=False)
 
         hf_model = AutoModelForCausalLM.from_pretrained(f"{tmpdir}/model").cpu()
         hf_model.eval()

--- a/lib/levanter/tests/test_mistral.py
+++ b/lib/levanter/tests/test_mistral.py
@@ -14,6 +14,7 @@ from test_utils import (
     check_load_config,
     check_model_works_with_seqlen,
     parameterize_with_configs,
+    skip_if_hf_model_not_accessible,
     skip_if_no_torch,
     use_test_mesh,
 )
@@ -24,6 +25,7 @@ from levanter.models.mistral import MistralConfig, MistralLMHeadModel
 
 
 @skip_if_no_torch
+@skip_if_hf_model_not_accessible("mistralai/Mistral-7B-v0.1")
 def test_mistral_config():
     # load HF config and convert to levanter config
     hf_config = transformers.MistralConfig.from_pretrained("mistralai/Mistral-7B-v0.1")
@@ -86,16 +88,20 @@ def test_mistral_lm_head_model_bwd(use_flash, num_kv_heads):
 
 @skip_if_no_torch
 @pytest.mark.parametrize("num_kv_heads", [1, 2, 4])
-def test_mistral_roundtrip(num_kv_heads):
+def test_mistral_roundtrip(num_kv_heads, local_gpt2_tokenizer_path):
     import torch
     from transformers import AutoModelForCausalLM, MistralForCausalLM
 
+    # Local tokenizer + no remote reference keeps the roundtrip off the Hub; the
+    # tokenizer is incidental (random inputs, logit-equivalence only).
     config = MistralConfig(
         max_seq_len=128,
         hidden_dim=16,
         num_heads=4,
         num_kv_heads=num_kv_heads,
         gradient_checkpointing=False,
+        reference_checkpoint=None,
+        tokenizer=local_gpt2_tokenizer_path,
     )
     converter = config.hf_checkpoint_converter()
 
@@ -120,7 +126,7 @@ def test_mistral_roundtrip(num_kv_heads):
         torch_model.save_pretrained(f"{tmpdir}/torch_model")
 
         model = converter.load_pretrained(
-            converter.default_config.model_type, ref=f"{tmpdir}/torch_model", resize_vocab_to_match_tokenizer=False
+            MistralLMHeadModel, ref=f"{tmpdir}/torch_model", resize_vocab_to_match_tokenizer=False
         )
 
         def compute(input):
@@ -133,7 +139,7 @@ def test_mistral_roundtrip(num_kv_heads):
         assert torch_out.shape == jax_out.shape, f"{torch_out.shape} != {jax_out.shape}"
         assert np.isclose(torch_out, np.array(jax_out), rtol=1e-4, atol=1e-4).all(), f"{torch_out} != {jax_out}"
 
-        converter.save_pretrained(model, f"{tmpdir}/lev_model", save_reference_code=False)
+        converter.save_pretrained(model, f"{tmpdir}/lev_model", save_reference_code=False, save_tokenizer=False)
         torch_model2 = AutoModelForCausalLM.from_pretrained(f"{tmpdir}/lev_model")
         torch_model2.eval()
 

--- a/lib/levanter/tests/test_qwen3_moe.py
+++ b/lib/levanter/tests/test_qwen3_moe.py
@@ -1,6 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
 import tempfile
 
 import jax
@@ -117,14 +118,18 @@ def test_qwen3_moe_forward_and_next_token_loss():
 
 
 @skip_if_no_torch
-def test_qwen3_moe_hf_logits_and_loss_match_torch():
+def test_qwen3_moe_hf_logits_and_loss_match_torch(local_gpt2_tokenizer_path):
     import torch  # noqa: PLC0415
     import torch.nn.functional as F  # noqa: PLC0415
     from transformers import Qwen3MoeForCausalLM  # noqa: PLC0415
 
     hf_config = _tiny_hf_config()
     config = Qwen3MoeConfig.from_hf_config(hf_config)
-    converter = config.hf_checkpoint_converter()
+    # Local tokenizer + no remote reference keeps the conversion off the Hub; the
+    # tokenizer is incidental (random inputs, logit-equivalence only).
+    converter = dataclasses.replace(
+        config, reference_checkpoint=None, tokenizer=local_gpt2_tokenizer_path
+    ).hf_checkpoint_converter()
     Batch = hax.Axis("batch", 2)
     Pos = config.max_Pos
     Vocab = hax.Axis("vocab", hf_config.vocab_size)

--- a/lib/levanter/tests/tiny_test_corpus.py
+++ b/lib/levanter/tests/tiny_test_corpus.py
@@ -48,7 +48,7 @@ def tiny_asr_corpus_config(path):
 
 
 def construct_small_data_cache(
-    path, num_shards=8, chunk_size=512, doc_len=128, vocab_size=1024
+    path, num_shards=8, chunk_size=512, doc_len=128, vocab_size=1024, tokenizer="gpt2"
 ) -> tuple[LmDataConfig, dict[str, TreeCache]]:
     rng = np.random.default_rng(0)
 
@@ -67,6 +67,6 @@ def construct_small_data_cache(
         caches[split] = writer.result()
 
     component = DatasetComponent(source=None, cache_dir=f"{path}/cache")
-    config = LmDataConfig(components={"tiny": component}, vocab_size=vocab_size, tokenizer="gpt2")
+    config = LmDataConfig(components={"tiny": component}, vocab_size=vocab_size, tokenizer=tokenizer)
 
     return config, caches


### PR DESCRIPTION
The torch test lane fails whenever huggingface.co is briefly unreachable: each HF roundtrip/config test builds its HFCheckpointConverter from a default config, which eagerly downloads the reference checkpoint's tokenizer at construction time. The roundtrips use random input ids and only assert logit-equivalence across save/load, so the real tokenizer is incidental.

Build these converters against a local GPT-2 tokenizer with no remote reference checkpoint, and pass save_tokenizer=False on save, so test_apertus, test_eval_lm, test_llama, test_llama3, test_lora, test_mistral, and test_qwen3_moe run fully offline. test_mistral_config genuinely compares against the upstream config, so gate it with skip_if_hf_model_not_accessible like test_llama_config. MistralConfig.hf_checkpoint_converter now honors its reference_checkpoint/tokenizer fields like the sibling configs instead of hardcoding the Hub path, which is what lets the roundtrip point at a local tokenizer.

Extends the same fix from #6189 to the remaining HF-dependent torch tests.