### PR TITLE
[codehealth] Handle non-serializable artifacts gracefully instead of crashing

### DIFF
--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -165,8 +165,14 @@ class Artifact:
                 # avoiding non-serializable objects in `__dict__`.
                 fd.write(json.dumps(asdict(artifact)).encode("utf-8"))
             else:
-                # TODO: should the error to serialize be ignored/logged instead of raising an exception?
-                fd.write(json.dumps(artifact).encode("utf-8"))
+                try:
+                    fd.write(json.dumps(artifact).encode("utf-8"))
+                except TypeError:
+                    logger.warning(
+                        "Artifact of type %s at %s is not JSON-serializable; skipping save.",
+                        type(artifact).__qualname__,
+                        base_path,
+                    )
 
 
 class PathMetadata(BaseModel):

--- a/lib/marin/src/marin/transform/conversation/adapters.py
+++ b/lib/marin/src/marin/transform/conversation/adapters.py
@@ -106,7 +106,7 @@ class TransformAdapter:
                 return None  # Do not process rows with missing data
             if self.filter_on_key:
                 best_completion = None
-                best_metric = -float("inf")  # TODO: Make this a config
+                best_metric = float("-inf")
 
                 for completion in response:
                     if completion[self.filter_on_key] > best_metric:


### PR DESCRIPTION
🤖

## Summary

Two small code health improvements in the Marin execution and transform modules.

## Changes

### 1. Graceful handling of non-serializable artifacts (`execution/artifact.py`)

`Artifact.save()` previously called `json.dumps(artifact)` on non-BaseModel, non-dataclass objects without error handling. If the object was not JSON-serializable, this raised an unhandled `TypeError` that crashed the save path.

Now catches `TypeError` and logs a warning with the artifact type and path, allowing the pipeline to continue.

Addresses the TODO at the site: `# TODO: should the error to serialize be ignored/logged instead of raising an exception?`

### 2. Idiomatic sentinel value (`transform/conversation/adapters.py`)

Replaced `best_metric = -float("inf")` with the more idiomatic `float("-inf")` and removed the stale `# TODO: Make this a config` comment — using `-inf` as a sentinel for "no best value yet" is a standard Python pattern and doesn't need configuration.

## Type

`codehealth` — no behavioral changes beyond graceful error handling.