### PR TITLE
[datakit] Add Nemotron Code v3 materializer

### DIFF
--- a/lib/marin/src/marin/datakit/download/nemotron_code_v3.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_code_v3.py
@@ -31,6 +31,7 @@ from rigging.filesystem import atomic_rename, open_url, url_to_fs
 from zephyr import counters
 
 from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
 from marin.execution.step_spec import StepSpec
 from marin.utils import fsspec_mkdirs
 
@@ -325,6 +326,8 @@ def materialize_nemotron_code_v3_step(
             "allowed_languages": config.allowed_languages,
             "max_rows": config.max_rows,
             "max_file_bytes": config.max_file_bytes,
+            "request_timeout_seconds": config.request_timeout_seconds,
+            "retry_attempts": config.retry_attempts,
             "raw_base_url": config.raw_base_url,
             "batch_rows": config.batch_rows,
             "record_transient_failures": config.record_transient_failures,
@@ -336,8 +339,6 @@ def nemotron_code_v3_normalize_steps(
     config: NemotronCodeV3MaterializeConfig = PILOT_CONFIG,
 ) -> tuple[StepSpec, ...]:
     """Return the metadata -> materialize -> normalize chain for one v3 view."""
-    from marin.datakit.normalize import normalize_step
-
     metadata = download_nemotron_code_v3_metadata_step()
     materialized = materialize_nemotron_code_v3_step(metadata, config=config)
     return (

--- a/lib/marin/src/marin/datakit/download/nemotron_code_v3.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_code_v3.py
@@ -1,0 +1,491 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Nemotron-Pretraining-Code-v3 metadata download and bounded materialization.
+
+``nvidia/Nemotron-Pretraining-Code-v3`` is a GitHub source-code refresh, but
+the Hugging Face dataset stores metadata only. Each row points at a raw GitHub
+blob via ``repo``, ``commit_id``, and ``rel_path``. This module keeps that
+metadata download separate from materialization so Marin never normalizes the
+metadata as training text by accident.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import hashlib
+import json
+import logging
+import posixpath
+from collections.abc import Callable, Iterator, Mapping
+from dataclasses import dataclass
+from pathlib import PurePosixPath
+from typing import Any
+from urllib.parse import quote
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import requests
+from fray import ResourceConfig
+from rigging.filesystem import atomic_rename, open_url, url_to_fs
+from zephyr import counters
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.execution.step_spec import StepSpec
+from marin.utils import fsspec_mkdirs
+
+logger = logging.getLogger(__name__)
+
+HF_DATASET_ID = "nvidia/Nemotron-Pretraining-Code-v3"
+HF_REVISION = "9b42feaec991c69006452e6654d91a58a04d935a"
+METADATA_PARQUET_GLOB = "Nemotron-Code-Metadata/**/*.parquet"
+GITHUB_RAW_BASE_URL = "https://raw.githubusercontent.com"
+
+SUCCESS_DIR = "success"
+FAILURES_DIR = "failures"
+DEFAULT_BATCH_ROWS = 1024
+_READ_CHUNK_BYTES = 64 * 1024
+_PERMANENT_MISSING_STATUSES = frozenset({404, 410})
+_TRANSIENT_HTTP_STATUSES = frozenset({401, 403, 408, 409, 425, 429, 500, 502, 503, 504})
+_REQUEST_HEADERS = {"User-Agent": "marin-nemotron-code-v3-materializer"}
+
+
+@dataclass(frozen=True)
+class GitHubBlobRef:
+    """Pointer to one source file in a GitHub repository."""
+
+    repo: str
+    rel_path: str
+    language: str
+    commit_id: str
+
+
+@dataclass(frozen=True)
+class NemotronCodeV3MaterializeConfig:
+    """Configuration for a bounded Nemotron Code v3 materialization view."""
+
+    view_name: str
+    metadata_relative_glob: str
+    allowed_languages: tuple[str, ...]
+    max_rows: int | None
+    max_file_bytes: int
+    request_timeout_seconds: float
+    retry_attempts: int
+    raw_base_url: str = GITHUB_RAW_BASE_URL
+    batch_rows: int = DEFAULT_BATCH_ROWS
+    record_transient_failures: bool = False
+
+    def __post_init__(self) -> None:
+        if not self.view_name:
+            raise ValueError("view_name must be non-empty")
+        if not self.metadata_relative_glob:
+            raise ValueError("metadata_relative_glob must be non-empty")
+        if not self.allowed_languages:
+            raise ValueError("allowed_languages must be non-empty")
+        if self.max_rows is not None and self.max_rows <= 0:
+            raise ValueError("max_rows must be positive when set")
+        if self.max_file_bytes <= 0:
+            raise ValueError("max_file_bytes must be positive")
+        if self.request_timeout_seconds <= 0:
+            raise ValueError("request_timeout_seconds must be positive")
+        if self.retry_attempts <= 0:
+            raise ValueError("retry_attempts must be positive")
+        if self.batch_rows <= 0:
+            raise ValueError("batch_rows must be positive")
+
+
+PILOT_CONFIG = NemotronCodeV3MaterializeConfig(
+    view_name="pilot",
+    metadata_relative_glob="Nemotron-Code-Metadata/part_00000.parquet",
+    allowed_languages=("Python", "JavaScript", "TypeScript", "Go", "Rust", "Java", "C++", "C"),
+    max_rows=1_000_000,
+    max_file_bytes=1_000_000,
+    request_timeout_seconds=20.0,
+    retry_attempts=3,
+)
+
+
+@dataclass(frozen=True)
+class MaterializedBlob:
+    """Successful raw GitHub blob fetch."""
+
+    ref: GitHubBlobRef
+    source_url: str
+    text: str
+
+
+@dataclass(frozen=True)
+class MaterializationFailure:
+    """Permanent skip or diagnostics-only fetch failure."""
+
+    repo: str | None
+    rel_path: str | None
+    language: str | None
+    commit_id: str | None
+    source_url: str | None
+    status: str
+    http_status: int | None = None
+    error: str | None = None
+
+
+class TransientFetchError(RuntimeError):
+    """A fetch failed for reasons that should not silently change the dataset."""
+
+
+def download_nemotron_code_v3_metadata_step() -> StepSpec:
+    """Download the Nemotron Code v3 GitHub blob metadata from Hugging Face."""
+    return download_hf_step(
+        "raw/nemotron_pretraining_code_v3_metadata",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[METADATA_PARQUET_GLOB],
+    )
+
+
+def blob_ref_from_row(row: Mapping[str, Any]) -> GitHubBlobRef:
+    """Parse and validate one Nemotron Code v3 metadata row."""
+    repo = _required_str(row, "repo")
+    rel_path = _required_str(row, "rel_path")
+    language = _required_str(row, "language")
+    commit_id = _required_str(row, "commit_id")
+
+    repo_parts = repo.split("/")
+    if len(repo_parts) != 2 or not all(repo_parts):
+        raise ValueError(f"repo must be owner/repo, got {repo!r}")
+
+    path = PurePosixPath(rel_path)
+    if path.is_absolute():
+        raise ValueError(f"rel_path must be relative, got {rel_path!r}")
+    if ".." in path.parts:
+        raise ValueError(f"rel_path must not contain '..', got {rel_path!r}")
+    if not path.parts:
+        raise ValueError("rel_path must contain at least one path segment")
+
+    return GitHubBlobRef(repo=repo, rel_path=rel_path, language=language, commit_id=commit_id)
+
+
+def github_raw_url(ref: GitHubBlobRef, *, raw_base_url: str = GITHUB_RAW_BASE_URL) -> str:
+    """Return the raw GitHub URL for a validated blob reference."""
+    repo = quote(ref.repo.strip("/"), safe="/")
+    commit_id = quote(ref.commit_id, safe="")
+    rel_path = quote(ref.rel_path.lstrip("/"), safe="/")
+    return f"{raw_base_url.rstrip('/')}/{repo}/{commit_id}/{rel_path}"
+
+
+def materialize_blob(
+    ref: GitHubBlobRef,
+    *,
+    config: NemotronCodeV3MaterializeConfig,
+    session: requests.Session,
+) -> MaterializedBlob | MaterializationFailure:
+    """Fetch one GitHub blob or return a permanent skip diagnostic."""
+    url = github_raw_url(ref, raw_base_url=config.raw_base_url)
+    last_error: str | None = None
+    last_failure_status = "timeout"
+    last_http_status: int | None = None
+    for _attempt in range(config.retry_attempts):
+        try:
+            with session.get(
+                url,
+                headers=_REQUEST_HEADERS,
+                stream=True,
+                timeout=config.request_timeout_seconds,
+            ) as response:
+                status_code = response.status_code
+                if status_code in _PERMANENT_MISSING_STATUSES:
+                    counters.increment("nemotron_code_v3/fetch_not_found")
+                    return _failure(ref, url, "not_found", http_status=status_code)
+                if status_code in _TRANSIENT_HTTP_STATUSES or status_code >= 500:
+                    last_error = f"HTTP {status_code}"
+                    last_failure_status = "http_error"
+                    last_http_status = status_code
+                    continue
+                if status_code >= 400:
+                    counters.increment("nemotron_code_v3/fetch_http_error")
+                    return _failure(ref, url, "http_error", http_status=status_code)
+
+                length_header = response.headers.get("Content-Length")
+                if _content_length_exceeds_cap(length_header, max_file_bytes=config.max_file_bytes):
+                    counters.increment("nemotron_code_v3/dropped_too_large")
+                    return _failure(ref, url, "too_large", http_status=status_code)
+
+                raw = _read_bounded_response(response, max_file_bytes=config.max_file_bytes)
+                if raw is None:
+                    counters.increment("nemotron_code_v3/dropped_too_large")
+                    return _failure(ref, url, "too_large", http_status=status_code)
+
+                try:
+                    text = raw.decode("utf-8")
+                except UnicodeDecodeError as exc:
+                    counters.increment("nemotron_code_v3/decode_error")
+                    return _failure(ref, url, "decode_error", http_status=status_code, error=str(exc))
+
+                if not text.strip():
+                    counters.increment("nemotron_code_v3/dropped_empty")
+                    return _failure(ref, url, "empty", http_status=status_code)
+
+                counters.increment("nemotron_code_v3/kept")
+                return MaterializedBlob(ref=ref, source_url=url, text=text)
+        except (requests.ConnectionError, requests.Timeout) as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            last_failure_status = "timeout"
+            last_http_status = None
+            counters.increment("nemotron_code_v3/fetch_timeout")
+        except requests.RequestException as exc:
+            last_error = f"{type(exc).__name__}: {exc}"
+            last_failure_status = "http_error"
+            last_http_status = exc.response.status_code if exc.response is not None else None
+            counters.increment("nemotron_code_v3/fetch_http_error")
+
+    if config.record_transient_failures:
+        return _failure(ref, url, last_failure_status, http_status=last_http_status, error=last_error)
+
+    counters.increment("nemotron_code_v3/job_failed_transient_fetch")
+    raise TransientFetchError(f"Failed to fetch {url} after {config.retry_attempts} attempts: {last_error}")
+
+
+def materialize_nemotron_code_v3(
+    input_path: str,
+    output_path: str,
+    *,
+    config: NemotronCodeV3MaterializeConfig = PILOT_CONFIG,
+    session_factory: Callable[[], requests.Session] = requests.Session,
+) -> dict[str, int]:
+    """Materialize a bounded Nemotron Code v3 metadata slice into code documents.
+
+    Success rows are written under ``<output_path>/success`` so the downstream
+    normalize step can target that directory explicitly. Permanent skip
+    diagnostics are written under ``<output_path>/failures``.
+    """
+    success_writer = _ParquetBatchWriter(posixpath.join(output_path, SUCCESS_DIR), batch_rows=config.batch_rows)
+    failure_writer = _ParquetBatchWriter(posixpath.join(output_path, FAILURES_DIR), batch_rows=config.batch_rows)
+    counts = {"metadata_rows": 0, "fetch_attempts": 0, "successes": 0, "failures": 0}
+
+    try:
+        with session_factory() as session:
+            for row in _iter_metadata_rows(input_path, metadata_relative_glob=config.metadata_relative_glob):
+                counters.increment("nemotron_code_v3/metadata_rows")
+                counts["metadata_rows"] += 1
+                try:
+                    ref = blob_ref_from_row(row)
+                except ValueError as exc:
+                    counters.increment("nemotron_code_v3/dropped_missing_field")
+                    failure_writer.write(_row_failure(row, status="invalid_metadata", error=str(exc)))
+                    counts["failures"] += 1
+                    continue
+
+                if ref.language not in config.allowed_languages:
+                    counters.increment("nemotron_code_v3/dropped_language")
+                    failure_writer.write(
+                        dataclasses.asdict(
+                            _failure(ref, github_raw_url(ref, raw_base_url=config.raw_base_url), "language")
+                        )
+                    )
+                    counts["failures"] += 1
+                    continue
+
+                if config.max_rows is not None and counts["fetch_attempts"] >= config.max_rows:
+                    break
+
+                counts["fetch_attempts"] += 1
+                result = materialize_blob(ref, config=config, session=session)
+                if isinstance(result, MaterializedBlob):
+                    success_writer.write(_success_row(result))
+                    counts["successes"] += 1
+                else:
+                    failure_writer.write(dataclasses.asdict(result))
+                    counts["failures"] += 1
+    finally:
+        success_writer.close()
+        failure_writer.close()
+
+    _write_metadata(output_path, config=config, counts=counts)
+    logger.info("Materialized Nemotron Code v3 view %s: %s", config.view_name, counts)
+    return counts
+
+
+def materialize_nemotron_code_v3_step(
+    metadata: StepSpec,
+    *,
+    config: NemotronCodeV3MaterializeConfig = PILOT_CONFIG,
+) -> StepSpec:
+    """Create a StepSpec that materializes one bounded Nemotron Code v3 view."""
+    return StepSpec(
+        name=f"processed/nemotron_code_v3/{config.view_name}",
+        deps=[metadata],
+        fn=lambda output_path: materialize_nemotron_code_v3(
+            input_path=metadata.output_path,
+            output_path=output_path,
+            config=config,
+        ),
+        hash_attrs={
+            "version": "v1",
+            "view_name": config.view_name,
+            "metadata_relative_glob": config.metadata_relative_glob,
+            "allowed_languages": config.allowed_languages,
+            "max_rows": config.max_rows,
+            "max_file_bytes": config.max_file_bytes,
+            "raw_base_url": config.raw_base_url,
+            "batch_rows": config.batch_rows,
+            "record_transient_failures": config.record_transient_failures,
+        },
+    )
+
+
+def nemotron_code_v3_normalize_steps(
+    config: NemotronCodeV3MaterializeConfig = PILOT_CONFIG,
+) -> tuple[StepSpec, ...]:
+    """Return the metadata -> materialize -> normalize chain for one v3 view."""
+    from marin.datakit.normalize import normalize_step
+
+    metadata = download_nemotron_code_v3_metadata_step()
+    materialized = materialize_nemotron_code_v3_step(metadata, config=config)
+    return (
+        metadata,
+        materialized,
+        normalize_step(
+            name=f"normalized/nemotron_code_v3/{config.view_name}",
+            download=materialized,
+            relative_input_path=SUCCESS_DIR,
+            file_extensions=(".parquet",),
+            worker_resources=ResourceConfig(cpu=1, ram="8g"),
+        ),
+    )
+
+
+def _required_str(row: Mapping[str, Any], field: str) -> str:
+    value = row.get(field)
+    if not isinstance(value, str) or not value.strip():
+        raise ValueError(f"{field} must be a non-empty string")
+    return value.strip()
+
+
+def _content_length_exceeds_cap(length_header: str | None, *, max_file_bytes: int) -> bool:
+    if length_header is None:
+        return False
+    try:
+        return int(length_header) > max_file_bytes
+    except ValueError:
+        return False
+
+
+def _read_bounded_response(response: requests.Response, *, max_file_bytes: int) -> bytes | None:
+    chunks: list[bytes] = []
+    total = 0
+    for chunk in response.iter_content(chunk_size=_READ_CHUNK_BYTES):
+        if not chunk:
+            continue
+        total += len(chunk)
+        if total > max_file_bytes:
+            return None
+        chunks.append(chunk)
+    return b"".join(chunks)
+
+
+def _failure(
+    ref: GitHubBlobRef,
+    source_url: str,
+    status: str,
+    *,
+    http_status: int | None = None,
+    error: str | None = None,
+) -> MaterializationFailure:
+    return MaterializationFailure(
+        repo=ref.repo,
+        rel_path=ref.rel_path,
+        language=ref.language,
+        commit_id=ref.commit_id,
+        source_url=source_url,
+        status=status,
+        http_status=http_status,
+        error=error,
+    )
+
+
+def _row_failure(row: Mapping[str, Any], *, status: str, error: str) -> dict[str, Any]:
+    return {
+        "repo": row.get("repo"),
+        "rel_path": row.get("rel_path"),
+        "language": row.get("language"),
+        "commit_id": row.get("commit_id"),
+        "source_url": None,
+        "status": status,
+        "http_status": None,
+        "error": error,
+    }
+
+
+def _success_row(blob: MaterializedBlob) -> dict[str, Any]:
+    return {
+        "id": hashlib.sha256(blob.text.encode("utf-8")).hexdigest(),
+        "text": blob.text,
+        "source": HF_DATASET_ID,
+        "repo": blob.ref.repo,
+        "rel_path": blob.ref.rel_path,
+        "commit_id": blob.ref.commit_id,
+        "language": blob.ref.language,
+        "source_url": blob.source_url,
+    }
+
+
+def _iter_metadata_rows(input_path: str, *, metadata_relative_glob: str) -> Iterator[dict[str, Any]]:
+    for path in _metadata_file_paths(input_path, metadata_relative_glob=metadata_relative_glob):
+        with open_url(path, "rb") as handle:
+            parquet_file = pq.ParquetFile(handle)
+            for batch in parquet_file.iter_batches(batch_size=DEFAULT_BATCH_ROWS):
+                columns = batch.to_pydict()
+                row_count = len(next(iter(columns.values()), []))
+                for index in range(row_count):
+                    yield {name: values[index] for name, values in columns.items()}
+
+
+def _metadata_file_paths(input_path: str, *, metadata_relative_glob: str) -> list[str]:
+    fs, resolved = url_to_fs(input_path)
+    pattern = posixpath.join(resolved, metadata_relative_glob)
+    paths = sorted(fs.glob(pattern))
+    if not paths:
+        raise ValueError(f"No metadata parquet files matched {metadata_relative_glob!r} under {input_path!r}")
+
+    protocol = input_path.split("://", 1)[0] if "://" in input_path else ""
+    return [f"{protocol}://{path}" if protocol and "://" not in path else path for path in paths]
+
+
+class _ParquetBatchWriter:
+    def __init__(self, output_dir: str, *, batch_rows: int) -> None:
+        self.output_dir = output_dir
+        self.batch_rows = batch_rows
+        self.rows: list[dict[str, Any]] = []
+        self.shard = 0
+
+    def write(self, row: dict[str, Any]) -> None:
+        self.rows.append(row)
+        if len(self.rows) >= self.batch_rows:
+            self._flush()
+
+    def close(self) -> None:
+        self._flush()
+
+    def _flush(self) -> None:
+        if not self.rows:
+            return
+        fsspec_mkdirs(self.output_dir, exist_ok=True)
+        output_file = posixpath.join(self.output_dir, f"part-{self.shard:05d}.parquet")
+        with atomic_rename(output_file) as temp_path:
+            with open_url(temp_path, "wb") as handle:
+                pq.write_table(pa.Table.from_pylist(self.rows), handle)
+        self.rows = []
+        self.shard += 1
+
+
+def _write_metadata(output_path: str, *, config: NemotronCodeV3MaterializeConfig, counts: dict[str, int]) -> None:
+    metadata = {
+        "source": HF_DATASET_ID,
+        "hf_revision": HF_REVISION,
+        "config": dataclasses.asdict(config),
+        "counts": counts,
+    }
+    metadata_path = posixpath.join(output_path, "metadata.json")
+    fsspec_mkdirs(output_path, exist_ok=True)
+    with atomic_rename(metadata_path) as temp_path:
+        with open_url(temp_path, "w", encoding="utf-8") as handle:
+            json.dump(metadata, handle, indent=2, sort_keys=True)

--- a/tests/datakit/download/test_nemotron_code_v3.py
+++ b/tests/datakit/download/test_nemotron_code_v3.py
@@ -1,0 +1,285 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import hashlib
+import json
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+import requests
+from marin.datakit.download.nemotron_code_v3 import (
+    FAILURES_DIR,
+    HF_DATASET_ID,
+    SUCCESS_DIR,
+    GitHubBlobRef,
+    NemotronCodeV3MaterializeConfig,
+    TransientFetchError,
+    blob_ref_from_row,
+    github_raw_url,
+    materialize_blob,
+    materialize_nemotron_code_v3,
+)
+
+
+def _config(**overrides) -> NemotronCodeV3MaterializeConfig:
+    values = {
+        "view_name": "test",
+        "metadata_relative_glob": "Nemotron-Code-Metadata/part_00000.parquet",
+        "allowed_languages": ("Python",),
+        "max_rows": 10,
+        "max_file_bytes": 100,
+        "request_timeout_seconds": 5.0,
+        "retry_attempts": 2,
+        "raw_base_url": "http://example.test",
+        "batch_rows": 1,
+        "record_transient_failures": False,
+    }
+    values.update(overrides)
+    return NemotronCodeV3MaterializeConfig(**values)
+
+
+def _metadata_row(**overrides) -> dict:
+    row = {
+        "repo": "owner/repo",
+        "rel_path": "src/main.py",
+        "language": "Python",
+        "commit_id": "abc1234",
+    }
+    row.update(overrides)
+    return row
+
+
+def _write_metadata(root: Path, rows: list[dict]) -> None:
+    metadata_dir = root / "Nemotron-Code-Metadata"
+    metadata_dir.mkdir(parents=True)
+    pq.write_table(pa.Table.from_pylist(rows), metadata_dir / "part_00000.parquet")
+
+
+def _read_rows(root: Path, subdir: str) -> list[dict]:
+    directory = root / subdir
+    if not directory.exists():
+        return []
+    return [row for path in sorted(directory.glob("*.parquet")) for row in pq.read_table(path).to_pylist()]
+
+
+@pytest.fixture()
+def local_raw_server() -> Iterator[tuple[str, dict]]:
+    state = {
+        "payloads": {},
+        "requests": [],
+    }
+
+    class Handler(BaseHTTPRequestHandler):
+        def do_GET(self) -> None:  # stdlib signature
+            state["requests"].append(self.path)
+            status, body, headers = state["payloads"].get(self.path, (404, b"", {}))
+            self.send_response(status)
+            self.send_header("Content-Length", str(len(body)))
+            for name, value in headers.items():
+                self.send_header(name, value)
+            self.end_headers()
+            if body:
+                self.wfile.write(body)
+
+        def log_message(self, format, *args):  # noqa: A002  # stdlib signature
+            pass
+
+    httpd = ThreadingHTTPServer(("127.0.0.1", 0), Handler)
+    thread = threading.Thread(target=httpd.serve_forever, daemon=True)
+    thread.start()
+    try:
+        host = httpd.server_address[0]
+        port = httpd.server_address[1]
+        yield f"http://{host}:{port}", state
+    finally:
+        httpd.shutdown()
+        thread.join()
+
+
+def test_github_raw_url_encodes_path_segments():
+    ref = GitHubBlobRef(
+        repo="owner/repo",
+        rel_path="src/file name+#.py",
+        language="Python",
+        commit_id="abc/123",
+    )
+
+    assert github_raw_url(ref, raw_base_url="https://raw.example.test/") == (
+        "https://raw.example.test/owner/repo/abc%2F123/src/file%20name%2B%23.py"
+    )
+
+
+@pytest.mark.parametrize(
+    "row",
+    [
+        _metadata_row(repo=""),
+        _metadata_row(repo="owner/repo/extra"),
+        _metadata_row(rel_path="/src/main.py"),
+        _metadata_row(rel_path="../src/main.py"),
+        _metadata_row(language=None),
+        _metadata_row(commit_id=""),
+    ],
+    ids=["empty-repo", "invalid-repo", "absolute-path", "parent-path", "non-string-language", "empty-commit"],
+)
+def test_blob_ref_from_row_rejects_malformed_metadata(row):
+    with pytest.raises(ValueError):
+        blob_ref_from_row(row)
+
+
+def test_materializer_writes_success_rows_and_provenance(tmp_path: Path, local_raw_server):
+    base_url, state = local_raw_server
+    state["payloads"]["/owner/repo/abc1234/src/main.py"] = (200, b"print('hello')\n", {})
+    _write_metadata(tmp_path / "input", [_metadata_row()])
+
+    output_dir = tmp_path / "output"
+    counts = materialize_nemotron_code_v3(
+        str(tmp_path / "input"),
+        str(output_dir),
+        config=_config(raw_base_url=base_url),
+    )
+
+    rows = _read_rows(output_dir, SUCCESS_DIR)
+    assert counts == {"metadata_rows": 1, "fetch_attempts": 1, "successes": 1, "failures": 0}
+    assert rows == [
+        {
+            "id": hashlib.sha256(b"print('hello')\n").hexdigest(),
+            "text": "print('hello')\n",
+            "source": HF_DATASET_ID,
+            "repo": "owner/repo",
+            "rel_path": "src/main.py",
+            "commit_id": "abc1234",
+            "language": "Python",
+            "source_url": f"{base_url}/owner/repo/abc1234/src/main.py",
+        }
+    ]
+    assert _read_rows(output_dir, FAILURES_DIR) == []
+
+    metadata = json.loads((output_dir / "metadata.json").read_text())
+    assert metadata["source"] == HF_DATASET_ID
+    assert metadata["counts"] == counts
+
+
+def test_materializer_records_permanent_fetch_failures(tmp_path: Path, local_raw_server):
+    base_url, _state = local_raw_server
+    _write_metadata(tmp_path / "input", [_metadata_row()])
+
+    counts = materialize_nemotron_code_v3(
+        str(tmp_path / "input"),
+        str(tmp_path / "output"),
+        config=_config(raw_base_url=base_url),
+    )
+
+    assert counts == {"metadata_rows": 1, "fetch_attempts": 1, "successes": 0, "failures": 1}
+    assert _read_rows(tmp_path / "output", SUCCESS_DIR) == []
+    [failure] = _read_rows(tmp_path / "output", FAILURES_DIR)
+    assert failure["status"] == "not_found"
+    assert failure["http_status"] == 404
+    assert failure["source_url"] == f"{base_url}/owner/repo/abc1234/src/main.py"
+
+
+def test_materializer_records_invalid_metadata_without_fetching(tmp_path: Path, local_raw_server):
+    base_url, state = local_raw_server
+    _write_metadata(tmp_path / "input", [_metadata_row(repo="owner/repo/extra")])
+
+    counts = materialize_nemotron_code_v3(
+        str(tmp_path / "input"),
+        str(tmp_path / "output"),
+        config=_config(raw_base_url=base_url),
+    )
+
+    assert counts == {"metadata_rows": 1, "fetch_attempts": 0, "successes": 0, "failures": 1}
+    assert state["requests"] == []
+    [failure] = _read_rows(tmp_path / "output", FAILURES_DIR)
+    assert failure["status"] == "invalid_metadata"
+    assert failure["source_url"] is None
+
+
+def test_materializer_records_disallowed_language_without_fetching(tmp_path: Path, local_raw_server):
+    base_url, state = local_raw_server
+    _write_metadata(tmp_path / "input", [_metadata_row(language="CSS")])
+
+    counts = materialize_nemotron_code_v3(
+        str(tmp_path / "input"),
+        str(tmp_path / "output"),
+        config=_config(raw_base_url=base_url),
+    )
+
+    assert counts == {"metadata_rows": 1, "fetch_attempts": 0, "successes": 0, "failures": 1}
+    assert state["requests"] == []
+    [failure] = _read_rows(tmp_path / "output", FAILURES_DIR)
+    assert failure["status"] == "language"
+    assert failure["source_url"] == f"{base_url}/owner/repo/abc1234/src/main.py"
+
+
+def test_materializer_raises_on_transient_fetch_failures(local_raw_server):
+    base_url, state = local_raw_server
+    state["payloads"]["/owner/repo/abc1234/src/main.py"] = (500, b"unavailable", {})
+    ref = blob_ref_from_row(_metadata_row())
+
+    with requests.Session() as session:
+        with pytest.raises(TransientFetchError):
+            materialize_blob(ref, config=_config(raw_base_url=base_url), session=session)
+
+    assert state["requests"] == [
+        "/owner/repo/abc1234/src/main.py",
+        "/owner/repo/abc1234/src/main.py",
+    ]
+
+
+def test_diagnostics_mode_records_transient_http_failures(local_raw_server):
+    base_url, state = local_raw_server
+    state["payloads"]["/owner/repo/abc1234/src/main.py"] = (500, b"unavailable", {})
+    ref = blob_ref_from_row(_metadata_row())
+
+    with requests.Session() as session:
+        result = materialize_blob(
+            ref,
+            config=_config(raw_base_url=base_url, record_transient_failures=True),
+            session=session,
+        )
+
+    assert result.status == "http_error"
+    assert result.http_status == 500
+
+
+def test_materializer_respects_max_file_bytes(tmp_path: Path, local_raw_server):
+    base_url, state = local_raw_server
+    state["payloads"]["/owner/repo/abc1234/src/main.py"] = (200, b"this is too long", {})
+    _write_metadata(tmp_path / "input", [_metadata_row()])
+
+    counts = materialize_nemotron_code_v3(
+        str(tmp_path / "input"),
+        str(tmp_path / "output"),
+        config=_config(raw_base_url=base_url, max_file_bytes=4),
+    )
+
+    assert counts == {"metadata_rows": 1, "fetch_attempts": 1, "successes": 0, "failures": 1}
+    [failure] = _read_rows(tmp_path / "output", FAILURES_DIR)
+    assert failure["status"] == "too_large"
+
+
+def test_max_rows_caps_fetch_attempts_deterministically(tmp_path: Path, local_raw_server):
+    base_url, state = local_raw_server
+    rows = [
+        _metadata_row(rel_path="src/one.py"),
+        _metadata_row(rel_path="src/two.py"),
+        _metadata_row(rel_path="src/three.py"),
+    ]
+    for row in rows:
+        state["payloads"][f"/owner/repo/abc1234/{row['rel_path']}"] = (200, b"print('x')\n", {})
+    _write_metadata(tmp_path / "input", rows)
+
+    counts = materialize_nemotron_code_v3(
+        str(tmp_path / "input"),
+        str(tmp_path / "output"),
+        config=_config(raw_base_url=base_url, max_rows=2),
+    )
+
+    assert counts["fetch_attempts"] == 2
+    assert len(state["requests"]) == 2
+    assert [row["rel_path"] for row in _read_rows(tmp_path / "output", SUCCESS_DIR)] == ["src/one.py", "src/two.py"]

--- a/tests/datakit/download/test_nemotron_code_v3.py
+++ b/tests/datakit/download/test_nemotron_code_v3.py
@@ -23,7 +23,9 @@ from marin.datakit.download.nemotron_code_v3 import (
     github_raw_url,
     materialize_blob,
     materialize_nemotron_code_v3,
+    materialize_nemotron_code_v3_step,
 )
+from marin.execution.step_spec import StepSpec
 
 
 def _config(**overrides) -> NemotronCodeV3MaterializeConfig:
@@ -283,3 +285,18 @@ def test_max_rows_caps_fetch_attempts_deterministically(tmp_path: Path, local_ra
     assert counts["fetch_attempts"] == 2
     assert len(state["requests"]) == 2
     assert [row["rel_path"] for row in _read_rows(tmp_path / "output", SUCCESS_DIR)] == ["src/one.py", "src/two.py"]
+
+
+def test_materialization_cache_key_tracks_fetch_policy():
+    metadata = StepSpec(name="raw/test-metadata")
+    fast_retries = _config(request_timeout_seconds=5.0, retry_attempts=2)
+    slow_retries = _config(request_timeout_seconds=20.0, retry_attempts=4)
+
+    fast_step = materialize_nemotron_code_v3_step(metadata, config=fast_retries)
+    slow_step = materialize_nemotron_code_v3_step(metadata, config=slow_retries)
+
+    assert fast_step.hash_attrs["request_timeout_seconds"] == 5.0
+    assert fast_step.hash_attrs["retry_attempts"] == 2
+    assert slow_step.hash_attrs["request_timeout_seconds"] == 20.0
+    assert slow_step.hash_attrs["retry_attempts"] == 4
+    assert fast_step.hash_attrs != slow_step.hash_attrs


### PR DESCRIPTION
Add a dedicated Datakit path for nvidia/Nemotron-Pretraining-Code-v3, whose Hugging Face artifact is metadata pointing to GitHub blobs rather than directly consumable training text. The new materializer downloads pinned HF metadata, validates GitHub row references, fetches allowed-language raw blobs with byte caps and retry-aware failure handling, and writes successful code documents separately from diagnostic failure rows before normalization. Keeping materialization explicit prevents metadata-only rows from entering the pretraining corpus and gives pilots a deterministic, bounded slice for review before scaling.