### PR TITLE
[ci] Trigger dupekit/finelog Rust builds only on files that affect them

### DIFF
--- a/.github/workflows/dupekit-release-wheels.yaml
+++ b/.github/workflows/dupekit-release-wheels.yaml
@@ -22,8 +22,15 @@ on:
     tags:
       - "dupekit-v*"
   pull_request:
+    # PR build smoke only needs the wheel-build inputs (Rust crate compiled by
+    # maturin + maturin config + build driver). Pure-Python edits under src/ are
+    # bundled into the wheel but cannot break the cross-compile, and dupekit-unit
+    # already covers them. Nightly/tag/dispatch are unaffected by this filter
+    # (the stale check below scopes broadly to all of lib/dupekit/).
     paths:
-      - "lib/dupekit/**"
+      - "lib/dupekit/rust/**"
+      - "lib/dupekit/pyproject.toml"
+      - "lib/dupekit/build_package.py"
       - ".github/workflows/dupekit-release-wheels.yaml"
 
 concurrency:

--- a/.github/workflows/dupekit-unit.yaml
+++ b/.github/workflows/dupekit-unit.yaml
@@ -17,6 +17,7 @@ jobs:
       pull-requests: read
     outputs:
       should_run: ${{ steps.filter.outputs.relevant }}
+      check_user_mode: ${{ steps.filter.outputs.user_mode }}
     steps:
       - uses: actions/checkout@v5
       - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
@@ -24,13 +25,26 @@ jobs:
         with:
           filters: |
             relevant:
+              # dupekit is a standalone uv project, NOT a root workspace member
+              # (see [tool.uv.workspace] in the root pyproject.toml). Its tests
+              # run `uv run --frozen` against lib/dupekit/uv.lock — already
+              # covered by lib/dupekit/** below — so the root uv.lock does not
+              # affect this suite and must not gate it. The other unit workflows
+              # (iris/zephyr/marin/...) DO resolve against the root lock, which
+              # is why they keep 'uv.lock' here and dupekit does not.
               - 'lib/dupekit/**'
-              - 'uv.lock'
               - '.github/workflows/dupekit-unit.yaml'
+            # The dev-mode guard below inspects the root pyproject.toml, where a
+            # leaked editable rust source (written by scripts/rust_mode.py dev)
+            # lands — it never rewrites uv.lock. Gate the guard on that file
+            # directly so it runs whenever its target changes, without dragging
+            # the expensive test/cargo jobs onto every root-pyproject edit.
+            user_mode:
+              - 'pyproject.toml'
 
   check-user-mode:
     needs: changes
-    if: needs.changes.outputs.should_run == 'true'
+    if: needs.changes.outputs.should_run == 'true' || needs.changes.outputs.check_user_mode == 'true'
     runs-on: ubuntu-latest
     timeout-minutes: 1
     steps:

--- a/.github/workflows/finelog-release-wheels.yaml
+++ b/.github/workflows/finelog-release-wheels.yaml
@@ -7,8 +7,13 @@ name: "Finelog - Release Wheels"
 #
 # marin-finelog is a native package: the wheel bundles the pure-Python
 # client/deploy/proto AND the native in-process server ext (finelog._native),
-# built by maturin from lib/finelog (manifest-path -> rust/pyext). So
-# both trees gate the build.
+# built by maturin from lib/finelog (manifest-path -> rust/pyext). The nightly
+# and tag builds publish a wheel covering both trees, so the stale-nightly check
+# below scopes broadly to all of lib/finelog/. The pull_request leg, by
+# contrast, is only a build smoke ("does the wheel still compile?"), so its
+# paths filter is scoped to the inputs that can actually break the build (Rust
+# crate + maturin config + build driver) — not pure-Python edits under src/,
+# which the cross-compile bundles but cannot fail on.
 on:
   workflow_dispatch:
     inputs:
@@ -26,8 +31,12 @@ on:
     tags:
       - "finelog-v*"
   pull_request:
+    # Only the wheel-build inputs gate this expensive (4-target, zig-cross)
+    # smoke. See the header comment for why src/** is intentionally excluded.
     paths:
-      - "lib/finelog/**"
+      - "lib/finelog/rust/**"
+      - "lib/finelog/pyproject.toml"
+      - "lib/finelog/build_package.py"
       - ".github/workflows/finelog-release-wheels.yaml"
 
 concurrency:


### PR DESCRIPTION
Two unrelated PRs were kicking off the expensive dupekit/finelog Rust builds. An iris-only change (#6209) ran dupekit-unit's full suite — three pytest matrices plus cargo fmt/clippy/test — because the workflow's paths-filter included the root uv.lock. dupekit is a standalone uv project, not a root workspace member, and its tests run `uv run --frozen` against lib/dupekit/uv.lock, so the root lock never affects them. Drop uv.lock from the filter; lib/dupekit/uv.lock is already covered by lib/dupekit/**. The check-user-mode guard greps the root pyproject.toml for a leaked dev-mode source, which is what the root lock was loosely standing in for, so give it its own filter keyed on pyproject.toml — the file scripts/rust_mode.py dev actually writes (it never rewrites uv.lock) — letting the guard run without dragging the expensive jobs onto every root-pyproject edit.

The same PR also ran the finelog 4-target zig-cross maturin wheel build because it edited lib/finelog/src/finelog/deploy/_gcp.py, a pure-Python file the wheel bundles but that cannot break the compile. Narrow the pull_request build-smoke paths for both release-wheels workflows to the inputs that can break the build: rust/**, pyproject.toml, build_package.py, and the workflow file. Nightly, tag, and dispatch builds are unaffected — their stale check still scopes to all of lib/<pkg>/ — so published wheels still rebuild on Python changes.