### PR TITLE
[ci] Harden GitHub Actions: drop comment triggers, scope token perms

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -110,8 +110,8 @@ Fixes #1234
 (auto-closes on merge) or `Part of #NNNN` (partial work). Do not invent an issue
 just to satisfy this — omit the link when none exists.
 
-**Specifications (>500 LOC).** Large PRs must carry a spec. 
-This may be in the linked issue, or part of the PR description. 
+**Specifications (>500 LOC).** Large PRs must carry a spec.
+This may be in the linked issue, or part of the PR description.
 If a design doc exists, may also link to it instead.
 Specs cover: **Problem** (what is broken/missing, with file/line refs), **Approach**
 (which modules change, what is added/removed), and **Key code** (10–30 line
@@ -146,3 +146,4 @@ gh pr create --title "<title>" --body "<plain text body>" --label agent-generate
 - `.agents/skills/review-pr/` — multi-agent PR correctness review (separate concern).
 - `.agents/skills/fix-issue/` — end-to-end issue-fix workflow.
 - `AGENTS.md` — coding guidelines.
+

--- a/.github/workflows/dupekit-unit.yaml
+++ b/.github/workflows/dupekit-unit.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/fray-unit.yaml
+++ b/.github/workflows/fray-unit.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/haliax-unit.yaml
+++ b/.github/workflows/haliax-unit.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/iris-release-iap-proxy.yaml
+++ b/.github/workflows/iris-release-iap-proxy.yaml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/iris-smoke-coreweave.yaml
+++ b/.github/workflows/iris-smoke-coreweave.yaml
@@ -7,15 +7,12 @@ on:
       - "lib/iris/**"
       - ".github/workflows/iris-smoke-coreweave.yaml"
       - "scripts/workflows/iris_monitor.py"
-  issue_comment:
-    types: [created]
   workflow_dispatch:
 
 permissions:
   contents: read
   packages: write
-  pull-requests: read   # needed for issue_comment to access PR metadata
-  statuses: write       # post commit status from issue_comment trigger
+  statuses: write       # post commit status from workflow_dispatch trigger
 
 # Shared concurrency group with marin-canary-ferry-coreweave.yaml — both rebuild/roll
 # the shared iris-ci controller and submit against the shared H100 in
@@ -29,17 +26,7 @@ jobs:
   cw-ci-test:
     if: >-
       (github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name == github.repository) ||
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/iris-ci-cw') &&
-        (
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR' ||
-          github.event.comment.author_association == 'OWNER'
-        )
-      )
+      github.event_name == 'workflow_dispatch'
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -49,11 +36,9 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
 
       - name: Set commit status to pending
-        if: github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch'
+        if: github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |
@@ -191,7 +176,7 @@ jobs:
           pkill -f "kubectl.*port-forward.*$IRIS_NAMESPACE.*pod/iris-controller" 2>/dev/null || true
 
       - name: Set commit status to result
-        if: always() && (github.event_name == 'issue_comment' || github.event_name == 'workflow_dispatch')
+        if: always() && github.event_name == 'workflow_dispatch'
         env:
           GH_TOKEN: ${{ github.token }}
         run: |

--- a/.github/workflows/iris-smoke-gcp.yaml
+++ b/.github/workflows/iris-smoke-gcp.yaml
@@ -4,36 +4,20 @@ on:
   pull_request:
     paths:
       - "lib/iris/**"
-  issue_comment:
-    types: [created]
   workflow_dispatch:
 
 permissions:
   contents: read
   packages: write
-  statuses: write  # post commit status from issue_comment trigger
 
 concurrency:
-  group: iris-cloud-smoke-${{ github.event.pull_request.number || github.event.issue.number || github.run_id }}
+  group: iris-cloud-smoke-${{ github.event.pull_request.number || github.run_id }}
   # Never kill a running cloud test — would leak GCP resources.
   cancel-in-progress: false
 
 jobs:
   cloud-smoke-test:
-    # Run on: PRs touching lib/iris/**, /iris-smoke comment, or manual dispatch
-    if: >-
-      github.event_name == 'pull_request' ||
-      github.event_name == 'workflow_dispatch' ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, '/iris-smoke') &&
-        (
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR' ||
-          github.event.comment.author_association == 'OWNER'
-        )
-      )
+    # Run on: PRs touching lib/iris/**, or manual dispatch
     runs-on: ubuntu-latest
     timeout-minutes: 45
     env:
@@ -46,28 +30,13 @@ jobs:
         run: |
           if [ "${{ github.event_name }}" = "pull_request" ]; then
             echo "prefix=smoke-pr-${{ github.event.pull_request.number }}" >> "$GITHUB_OUTPUT"
-          elif [ "${{ github.event_name }}" = "issue_comment" ]; then
-            echo "prefix=smoke-pr-${{ github.event.issue.number }}" >> "$GITHUB_OUTPUT"
           else
             # workflow_dispatch: use short SHA
             echo "prefix=smoke-$(echo ${{ github.sha }} | head -c 8)" >> "$GITHUB_OUTPUT"
           fi
 
-      - name: Set commit status to pending
-        if: github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh api repos/${{ github.repository }}/statuses/${{ github.event.pull_request.head.sha || github.sha }} \
-            -f state=pending \
-            -f context="Iris Cloud Smoke Test" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}" || true
-
       - name: Checkout code
         uses: actions/checkout@v5
-        with:
-          # pull_request uses default merge ref; issue_comment needs explicit PR head
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -243,8 +212,6 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
-        with:
-          ref: ${{ github.event_name == 'issue_comment' && format('refs/pull/{0}/head', github.event.issue.number) || '' }}
 
       - name: Set up Python 3.12
         uses: actions/setup-python@v6
@@ -304,19 +271,3 @@ jobs:
               gcloud compute tpus tpu-vm delete "$tpu_name" \
                 --project="$PROJECT" --zone="$tpu_zone" --quiet --async || true
             done
-
-      - name: Set commit status to result
-        if: github.event_name == 'issue_comment'
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          sha=$(git rev-parse HEAD)
-          if [ "${{ needs.cloud-smoke-test.result }}" = "success" ]; then
-            state=success
-          else
-            state=failure
-          fi
-          gh api repos/${{ github.repository }}/statuses/"$sha" \
-            -f state="$state" \
-            -f context="Iris Cloud Smoke Test" \
-            -f target_url="${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/.github/workflows/levanter-dev-launch-small-fast.yaml
+++ b/.github/workflows/levanter-dev-launch-small-fast.yaml
@@ -9,6 +9,9 @@ on:
 #  pull_request:
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   test:
     if: (github.event.pull_request.head.repo.full_name == github.repository)

--- a/.github/workflows/levanter-integration-gpt2-small.yaml
+++ b/.github/workflows/levanter-integration-gpt2-small.yaml
@@ -8,6 +8,9 @@ on:
     branches: [main]
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   integration-test:
     runs-on: ubuntu-latest

--- a/.github/workflows/levanter-unit.yaml
+++ b/.github/workflows/levanter-unit.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/marin-docs.yaml
+++ b/.github/workflows/marin-docs.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/marin-integration.yaml
+++ b/.github/workflows/marin-integration.yaml
@@ -8,6 +8,9 @@ on:
   workflow_dispatch:
 
 
+permissions:
+  contents: read
+
 jobs:
   marin-integration:
     if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository

--- a/.github/workflows/marin-lint.yaml
+++ b/.github/workflows/marin-lint.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   marin-lint:
     runs-on: ubuntu-latest

--- a/.github/workflows/marin-unit.yaml
+++ b/.github/workflows/marin-unit.yaml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest

--- a/.github/workflows/ops-infra-dashboard.yaml
+++ b/.github/workflows/ops-infra-dashboard.yaml
@@ -16,6 +16,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/zephyr-unit.yaml
+++ b/.github/workflows/zephyr-unit.yaml
@@ -9,6 +9,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
   cancel-in-progress: true
 
+permissions:
+  contents: read
+
 jobs:
   changes:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Resolve open code-scanning alerts on the Actions workflows, leaving the socket-binding warnings for later.

Remove the issue_comment slash-command triggers (/iris-smoke, /iris-ci-cw) from iris-smoke-gcp and iris-smoke-coreweave. Those triggers made the workflows privileged and checked out untrusted PR-head code, which is what raised the untrusted-checkout, TOCTOU, and env-var-injection alerts. The pull_request (merge-ref) and workflow_dispatch paths stay; coreweave keeps its commit-status steps, now scoped to workflow_dispatch. These comment commands are not used in practice.

Add an explicit contents: read permissions block to 13 CI and build workflows that relied on the broad default GITHUB_TOKEN. None of them write through the token, and the two deploy jobs authenticate to GCP via service-account-key secrets, so read-only is safe.

The two incomplete-URL-substring-sanitization alerts (a startswith gate that rewrites operator-supplied Docker image refs to the AR mirror, not URL sanitization) and the @claude bot untrusted-checkout alert (accepted risk, gated to trusted author associations) are dismissed directly in code scanning rather than changed here.