### PR TITLE
[zephyr] Fix group_by reducer that returns an iterator

### DIFF
--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -11,7 +11,6 @@ knowledge of logical operation types.
 from __future__ import annotations
 
 import heapq
-import inspect
 import logging
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass, field
@@ -182,12 +181,19 @@ def _reduce_gen(
     sort_fn: Callable | None = None,
     external_sort_dir: str | None = None,
 ) -> Iterator:
-    is_gen = inspect.isgeneratorfunction(reducer_fn)
+    # The reducer contract is ``R | Iterator[R]``: it may return a single
+    # result or a stream of results. Discriminate on the actual return value,
+    # not ``inspect.isgeneratorfunction`` — that only recognises functions
+    # literally defined with ``yield`` and misses reducers that *return* an
+    # iterator (a generator expression, ``map``/``filter``, or a call to
+    # another generator function). Such a reducer would otherwise be emitted
+    # whole as one item and crash the downstream writer.
     for key, items_iter in _merge_sorted_chunks(shard, key_fn, sort_fn, external_sort_dir=external_sort_dir):
-        if is_gen:
-            yield from reducer_fn(key, items_iter)
+        result = reducer_fn(key, items_iter)
+        if isinstance(result, Iterator):
+            yield from result
         else:
-            yield reducer_fn(key, items_iter)
+            yield result
 
 
 def _select_gen(stream: Iterator, columns: tuple[str, ...]) -> Iterator:

--- a/lib/zephyr/tests/test_groupby.py
+++ b/lib/zephyr/tests/test_groupby.py
@@ -5,6 +5,7 @@
 import hashlib
 
 import pyarrow as pa
+import pyarrow.parquet as pq
 import pytest
 from zephyr import Dataset
 from zephyr.shuffle import ScatterFileIterator, _write_chunk_frame
@@ -273,6 +274,87 @@ def test_group_by_generator_reducer(zephyr_ctx):
     assert results[1] == {"cat": "A", "val": 3, "from_group": True}
     assert results[2] == {"cat": "B", "val": 2, "from_group": True}
     assert results[3] == {"cat": "B", "val": 5, "from_group": True}
+
+
+def test_group_by_reducer_returns_generator_expression(zephyr_ctx):
+    """Reducer that *returns* an iterator (not a generator function) is flattened.
+
+    The ``group_by`` contract documents ``reducer: ... -> R | Iterator[R]``, so a
+    reducer that returns a generator expression / ``map`` / ``filter`` is valid.
+    Regression for the ``'generator' object has no attribute 'keys'`` crash where
+    such a reducer's return value was emitted whole into the writer instead of
+    being flattened.
+    """
+    data = [
+        {"cat": "A", "val": 1},
+        {"cat": "B", "val": 2},
+        {"cat": "A", "val": 3},
+        {"cat": "B", "val": 5},
+    ]
+
+    # NOTE: returns a generator expression — deliberately NOT a generator
+    # function (no ``yield`` in the body), so ``inspect.isgeneratorfunction``
+    # would not detect it.
+    def explode_via_genexpr(key, items):
+        return ({"cat": key, "val": item["val"], "from_group": True} for item in items)
+
+    ds = Dataset.from_list(data).group_by(key=lambda x: x["cat"], reducer=explode_via_genexpr)
+
+    results = sorted(zephyr_ctx.execute(ds).results, key=lambda x: (x["cat"], x["val"]))
+    assert results == [
+        {"cat": "A", "val": 1, "from_group": True},
+        {"cat": "A", "val": 3, "from_group": True},
+        {"cat": "B", "val": 2, "from_group": True},
+        {"cat": "B", "val": 5, "from_group": True},
+    ]
+
+
+def test_group_by_reducer_returns_map_object(zephyr_ctx):
+    """A reducer returning a ``map`` object (also an iterator, not a generator function)."""
+    data = [
+        {"cat": "A", "val": 1},
+        {"cat": "A", "val": 3},
+        {"cat": "B", "val": 2},
+    ]
+
+    def explode_via_map(key, items):
+        return map(lambda item: {"cat": key, "doubled": item["val"] * 2}, items)
+
+    ds = Dataset.from_list(data).group_by(key=lambda x: x["cat"], reducer=explode_via_map)
+
+    results = sorted(zephyr_ctx.execute(ds).results, key=lambda x: (x["cat"], x["doubled"]))
+    assert results == [
+        {"cat": "A", "doubled": 2},
+        {"cat": "A", "doubled": 6},
+        {"cat": "B", "doubled": 4},
+    ]
+
+
+def test_group_by_reducer_returns_generator_then_parquet(zephyr_ctx, tmp_path):
+    """Reduce fused with a parquet Write — the exact production failure path.
+
+    Mirrors the trace where ``Reduce-Write`` sent the reducer's (un-flattened)
+    generator into ``write_parquet_file``, which crashed in ``_build_table``.
+    """
+    data = [{"cat": "A", "val": 1}, {"cat": "A", "val": 3}, {"cat": "B", "val": 2}]
+    output_pattern = str(tmp_path / "out" / "data-{shard:05d}-of-{total:05d}.parquet")
+
+    def explode_via_genexpr(key, items):
+        return ({"cat": key, "val": item["val"]} for item in items)
+
+    ds = (
+        Dataset.from_list(data)
+        .group_by(key=lambda x: x["cat"], reducer=explode_via_genexpr)
+        .write_parquet(output_pattern)
+    )
+
+    output_files = zephyr_ctx.execute(ds).results
+    rows = [row for path in output_files for row in pq.read_table(path).to_pylist()]
+    assert sorted(rows, key=lambda r: (r["cat"], r["val"])) == [
+        {"cat": "A", "val": 1},
+        {"cat": "A", "val": 3},
+        {"cat": "B", "val": 2},
+    ]
 
 
 def test_group_by_secondary_sort(zephyr_ctx):


### PR DESCRIPTION
A group_by/reduce job (val-scan-4plus-mind-keyjoin) crashed in the
Reduce-Write stage with "'generator' object has no attribute 'keys'" inside
the parquet writer's _build_table. The external-sort spill in the trace was
incidental — the fault is in how reduce dispatches the reducer's result.

_reduce_gen discriminated streaming reducers with
inspect.isgeneratorfunction, which only recognises functions literally
defined with `yield`. A reducer that *returns* an iterator — a generator
expression, map/filter, or a call to another generator function — is valid
under the documented `R | Iterator[R]` contract, but isgeneratorfunction
reports it as non-streaming, so its return value was yielded whole as one
item. That un-flattened generator then reached write_parquet_file, which
called .keys() on it and raised.

Discriminate on the actual return value with isinstance(result, Iterator)
instead, flattening when it is an iterator and emitting it directly
otherwise.

Adds regression tests covering a reducer returning a generator expression, a
reducer returning a map object, and the fused reduce-then-write_parquet path
that reproduced the production crash.