### PR TITLE
[zephyr/rigging] Make cross-process exceptions survive pickle so deterministic failures fail fast

### DIFF
--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -448,12 +448,22 @@ class TransferBudgetExceeded(Exception):
         self.attempted = attempted
         self.limit = limit
         self.path = path
-        super().__init__(
-            f"Cross-region transfer budget exceeded: {path} "
-            f"({attempted / (1024**2):.1f}MB) would bring total to "
-            f"{(bytes_used + attempted) / (1024**3):.2f}GB, "
-            f"exceeding the {limit / (1024**3):.0f}GB limit "
-            f"(already transferred {bytes_used / (1024**3):.2f}GB). "
+        # Pass the constructor arguments — not the rendered message — to
+        # BaseException. The default exception reduce reconstructs via
+        # ``TransferBudgetExceeded(*self.args)`` on unpickle, so ``args`` must
+        # match this signature; storing the single message string instead made
+        # the exception un-revivable (``TypeError: missing 3 required positional
+        # arguments``) whenever it crossed a process boundary. The human-readable
+        # message is rendered lazily by ``__str__``.
+        super().__init__(bytes_used, attempted, limit, path)
+
+    def __str__(self) -> str:
+        return (
+            f"Cross-region transfer budget exceeded: {self.path} "
+            f"({self.attempted / (1024**2):.1f}MB) would bring total to "
+            f"{(self.bytes_used + self.attempted) / (1024**3):.2f}GB, "
+            f"exceeding the {self.limit / (1024**3):.0f}GB limit "
+            f"(already transferred {self.bytes_used / (1024**3):.2f}GB). "
             f"Consider running in the source region instead."
         )
 

--- a/lib/rigging/tests/test_record_transfer.py
+++ b/lib/rigging/tests/test_record_transfer.py
@@ -1,6 +1,8 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import pickle
+
 import pytest
 from rigging import filesystem as rfs
 from rigging.filesystem import TransferBudget, TransferBudgetExceeded, record_transfer
@@ -37,3 +39,18 @@ def test_record_transfer_raises_when_budget_exceeded(patched_regions):
     budget = TransferBudget(limit_bytes=500)
     with pytest.raises(TransferBudgetExceeded):
         record_transfer(1000, "gs://marin-us-central2/checkpoint", budget=budget)
+
+
+def test_transfer_budget_exceeded_round_trips_through_pickle():
+    # The exception crosses process boundaries (Zephyr ships shard/coordinator
+    # errors via cloudpickle). It must revive without a constructor TypeError.
+    original = TransferBudgetExceeded(bytes_used=9_960, attempted=400, limit=10_000, path="gs://marin-us-east5/x")
+    revived = pickle.loads(pickle.dumps(original))
+    assert (revived.bytes_used, revived.attempted, revived.limit, revived.path) == (
+        9_960,
+        400,
+        10_000,
+        "gs://marin-us-east5/x",
+    )
+    assert str(revived) == str(original)
+    assert "Cross-region transfer budget exceeded" in str(revived)

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -41,7 +41,13 @@ from fray.local_backend import LocalClient
 from fray.types import Entrypoint, JobRequest
 from iris.client import get_iris_ctx
 from iris.cluster.client.job_info import get_job_info
-from rigging.filesystem import marin_temp_bucket, open_url, unique_temp_path, url_to_fs
+from rigging.filesystem import (
+    TransferBudgetExceeded,
+    marin_temp_bucket,
+    open_url,
+    unique_temp_path,
+    url_to_fs,
+)
 from rigging.timing import ExponentialBackoff, RateLimiter, log_time
 
 from zephyr.dataset import Dataset
@@ -414,8 +420,41 @@ class CoordinatorUnreachable(RuntimeError):
 # These are deterministic errors (bad plan, invalid config, programming bugs)
 # that would fail identically on every attempt. Infrastructure errors (OSError,
 # RuntimeError from dead actors, backend actor errors) are NOT listed here so they
-# remain retryable.
-_NON_RETRYABLE_ERRORS = (ZephyrWorkerError, ValueError, TypeError, KeyError, AttributeError, MemoryError)
+# remain retryable. TransferBudgetExceeded is deterministic: the cross-region
+# budget is global and persists for the life of the process, so every retry hits
+# the same wall while re-transferring data across regions.
+_NON_RETRYABLE_ERRORS = (
+    ZephyrWorkerError,
+    ValueError,
+    TypeError,
+    KeyError,
+    AttributeError,
+    MemoryError,
+    TransferBudgetExceeded,
+)
+
+
+def _ensure_picklable_exception(error: BaseException) -> BaseException:
+    """Return *error*, or a picklable stand-in if it cannot survive pickling.
+
+    Exceptions cross process boundaries (shard subprocess → worker, coordinator
+    job → driver) by cloudpickle. A subclass whose ``__init__`` signature is
+    incompatible with the ``args`` the default reduce replays revives into a
+    ``TypeError`` at *unpickle* time — which would crash the process that is only
+    trying to re-raise a child's failure, and mask the real error behind an
+    unrelated ``TypeError``. We detect that here and substitute a
+    ``ZephyrWorkerError`` carrying the original type and message, preserving any
+    traceback notes. ``ZephyrWorkerError`` is non-retryable on purpose: an error
+    we cannot even deserialize must not be retried blindly.
+    """
+    try:
+        cloudpickle.loads(cloudpickle.dumps(error))
+        return error
+    except Exception:
+        wrapped = ZephyrWorkerError(f"{type(error).__module__}.{type(error).__qualname__}: {error}")
+        for note in getattr(error, "__notes__", ()):
+            wrapped.add_note(note)
+        return wrapped
 
 
 # ---------------------------------------------------------------------------
@@ -1850,11 +1889,13 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
                 f.write(cloudpickle.dumps(payload))
         except Exception as e:
             # Persist the exception so the caller can recover the original type
-            # (important for non-retryable error detection).
+            # (important for non-retryable error detection). Normalize first so a
+            # subclass that cannot round-trip through pickle does not make the
+            # caller's revival crash and mask the real failure.
             with suppress(Exception):
                 ensure_parent_dir(result_path)
                 with open_url(result_path, "wb") as f:
-                    f.write(cloudpickle.dumps(e))
+                    f.write(cloudpickle.dumps(_ensure_picklable_exception(e)))
             raise
     finally:
         # Signal coordinator shutdown first so workers receive SHUTDOWN from
@@ -1889,7 +1930,15 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
 def _read_coordinator_result(result_path: str) -> Any:
     """Read the coordinator job's result file. Returns the deserialized object."""
     with open_url(result_path, "rb") as f:
-        return cloudpickle.loads(f.read())
+        data = f.read()
+    try:
+        return cloudpickle.loads(data)
+    except Exception as e:
+        # The coordinator normalizes exceptions before persisting, so a revival
+        # failure here means a genuinely corrupt or version-incompatible payload.
+        # Surface a clear non-retryable error instead of letting an opaque
+        # unpickle error crash the driver mid-recovery.
+        raise ZephyrWorkerError(f"Could not deserialize coordinator result at {result_path}: {e!r}") from e
 
 
 def _try_read_coordinator_result(result_path: str) -> Any:

--- a/lib/zephyr/src/zephyr/runners.py
+++ b/lib/zephyr/src/zephyr/runners.py
@@ -46,6 +46,7 @@ from zephyr.execution import (
     ShardTask,
     StageRunner,
     TaskResult,
+    _ensure_picklable_exception,
     _shared_data_path,
     _stage_throughput,
     _worker_ctx_var,
@@ -399,7 +400,11 @@ def _execute_shard_subprocess(task_file: str, result_file: str, num_workers: int
         # it inline when the exception eventually propagates.
         logger.exception("Subprocess shard execution failed")
         e.add_note(f"--- subprocess traceback ---\n{traceback.format_exc().rstrip()}")
-        result_or_error = e
+        # Normalize before handing the error to the parent: a subclass that
+        # cannot round-trip through pickle (e.g. an __init__ whose signature
+        # does not match its args) would otherwise revive into a TypeError when
+        # the parent loads the result file, masking the real failure.
+        result_or_error = _ensure_picklable_exception(e)
     finally:
         stop_event.set()
         if flusher is not None and flusher.is_alive():

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -22,6 +22,7 @@ from fray.local_backend import LocalClient
 from zephyr import counters
 from zephyr.dataset import Dataset
 from zephyr.execution import (
+    _NON_RETRYABLE_ERRORS,
     MAX_SHARD_FAILURES,
     MAX_SHARD_INFRA_FAILURES,
     ZEPHYR_STAGE_BYTES_PROCESSED_KEY,
@@ -38,9 +39,39 @@ from zephyr.execution import (
     ZephyrCoordinator,
     ZephyrWorker,
     ZephyrWorkerError,
+    _ensure_picklable_exception,
     zephyr_worker_ctx,
 )
 from zephyr.plan import PhysicalStage, StageType, compute_plan
+
+
+class _UnpicklableError(Exception):
+    """Mimics rigging's old TransferBudgetExceeded: __init__ args don't match self.args."""
+
+    def __init__(self, a, b, c):
+        self.a, self.b, self.c = a, b, c
+        super().__init__(f"boom {a}/{b}/{c}")  # self.args = (message,) -> revive needs 3 args
+
+
+def test_ensure_picklable_exception_passes_through_picklable():
+    err = ValueError("plain and picklable")
+    assert _ensure_picklable_exception(err) is err
+
+
+def test_ensure_picklable_exception_wraps_unrevivable_and_preserves_message():
+    import cloudpickle
+
+    err = _UnpicklableError(1, 2, 3)
+    err.add_note("--- subprocess traceback ---\nsomewhere")
+    with pytest.raises(TypeError):
+        cloudpickle.loads(cloudpickle.dumps(err))  # confirms the hazard
+
+    safe = _ensure_picklable_exception(err)
+    revived = cloudpickle.loads(cloudpickle.dumps(safe))  # must not raise
+    assert isinstance(revived, ZephyrWorkerError)
+    assert isinstance(revived, _NON_RETRYABLE_ERRORS)  # un-revivable -> fail fast, never retry
+    assert "_UnpicklableError" in str(revived) and "boom 1/2/3" in str(revived)
+    assert any("subprocess traceback" in n for n in revived.__notes__)
 
 
 def test_simple_map(zephyr_ctx):


### PR DESCRIPTION
rigging's TransferBudgetExceeded overrode __init__ with four required positional args but passed only the rendered message string to BaseException, so self.args held one element. The default exception reduce reconstructs via TransferBudgetExceeded(*self.args), so reviving a pickled instance raised "TypeError: __init__() missing 3 required positional arguments".

Zephyr ships shard- and coordinator-level errors across process boundaries with cloudpickle (shard subprocess to worker in runners.py, coordinator job to driver in execution.py). So the deterministic cross-region budget error was destroyed on unpickle and surfaced as an unrelated TypeError, masking the real failure and misdirecting debugging.

Changes:

- rigging: pass the four constructor args through to BaseException and render the message in __str__, so TransferBudgetExceeded round-trips through pickle. Existing fields and message text are unchanged.
- zephyr: add _ensure_picklable_exception() and apply it at the two sites that persist an error for another process to revive (subprocess result file, coordinator result file). Any exception that cannot round-trip is normalized to a ZephyrWorkerError that preserves the original type name, message, and traceback notes. Harden _read_coordinator_result so a revival failure raises a clear non-retryable error instead of letting an opaque unpickle error crash the driver mid-recovery.
- Classify TransferBudgetExceeded as non-retryable. The cross-region budget is process-global and persists for the life of the process, so retrying only re-transfers data across regions and hits the same wall.

Part of #6264