### PR TITLE
[lint] Add torch/sympy to pyrefly ignore-missing-imports

### DIFF
--- a/infra/pre-commit.py
+++ b/infra/pre-commit.py
@@ -779,9 +779,47 @@ def _ensure_iris_protos() -> None:
         print(f"  ⚠ Proto generation failed: {result.stderr.strip()}")
 
 
+# pyrefly resolves third-party types from this interpreter (see
+# `python-interpreter-path` in pyproject.toml). `jax` is a base dependency of
+# levanter/haliax, so any lint-ready venv installs it; its absence means the
+# worktree venv is unsynced and pyrefly would emit a missing-import flood for
+# every dependency instead of a real type check. CI always syncs, so this never
+# trips there.
+PYREFLY_INTERPRETER = ROOT_DIR / ".venv" / "bin" / "python"
+PYREFLY_ENV_SENTINEL = "jax"
+PYREFLY_SYNC_HINT = "uv sync --all-packages --extra=cpu"
+
+
+def _pyrefly_env_ready() -> bool:
+    """Whether pyrefly's configured interpreter has the project dependencies installed."""
+    if not PYREFLY_INTERPRETER.exists():
+        return False
+    probe = subprocess.run(
+        [
+            str(PYREFLY_INTERPRETER),
+            "-c",
+            f"import importlib.util as u, sys; sys.exit(0 if u.find_spec({PYREFLY_ENV_SENTINEL!r}) else 1)",
+        ],
+        cwd=ROOT_DIR,
+        capture_output=True,
+        text=True,
+    )
+    return probe.returncode == 0
+
+
 def check_pyrefly(files: list[pathlib.Path], fix: bool) -> int:
     if not files:
         return 0
+
+    # An unsynced .venv makes pyrefly report every dependency as missing-import.
+    # That is an environment problem, not a code problem: skip with guidance
+    # rather than drowning the user in false errors. CI's venv is always synced.
+    if not _pyrefly_env_ready():
+        print(
+            f"  ⚠ Skipping pyrefly: .venv is missing project dependencies "
+            f"(run `{PYREFLY_SYNC_HINT}`). CI type-checks regardless."
+        )
+        return _record("Pyrefly type checker (skipped: venv unsynced)", 0)
 
     _ensure_iris_protos()
 

--- a/infra/pre-commit.py
+++ b/infra/pre-commit.py
@@ -779,47 +779,9 @@ def _ensure_iris_protos() -> None:
         print(f"  ⚠ Proto generation failed: {result.stderr.strip()}")
 
 
-# pyrefly resolves third-party types from this interpreter (see
-# `python-interpreter-path` in pyproject.toml). `jax` is a base dependency of
-# levanter/haliax, so any lint-ready venv installs it; its absence means the
-# worktree venv is unsynced and pyrefly would emit a missing-import flood for
-# every dependency instead of a real type check. CI always syncs, so this never
-# trips there.
-PYREFLY_INTERPRETER = ROOT_DIR / ".venv" / "bin" / "python"
-PYREFLY_ENV_SENTINEL = "jax"
-PYREFLY_SYNC_HINT = "uv sync --all-packages --extra=cpu"
-
-
-def _pyrefly_env_ready() -> bool:
-    """Whether pyrefly's configured interpreter has the project dependencies installed."""
-    if not PYREFLY_INTERPRETER.exists():
-        return False
-    probe = subprocess.run(
-        [
-            str(PYREFLY_INTERPRETER),
-            "-c",
-            f"import importlib.util as u, sys; sys.exit(0 if u.find_spec({PYREFLY_ENV_SENTINEL!r}) else 1)",
-        ],
-        cwd=ROOT_DIR,
-        capture_output=True,
-        text=True,
-    )
-    return probe.returncode == 0
-
-
 def check_pyrefly(files: list[pathlib.Path], fix: bool) -> int:
     if not files:
         return 0
-
-    # An unsynced .venv makes pyrefly report every dependency as missing-import.
-    # That is an environment problem, not a code problem: skip with guidance
-    # rather than drowning the user in false errors. CI's venv is always synced.
-    if not _pyrefly_env_ready():
-        print(
-            f"  ⚠ Skipping pyrefly: .venv is missing project dependencies "
-            f"(run `{PYREFLY_SYNC_HINT}`). CI type-checks regardless."
-        )
-        return _record("Pyrefly type checker (skipped: venv unsynced)", 0)
 
     _ensure_iris_protos()
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,10 +241,18 @@ use-ignore-files = false
 # levanter/grug and levanter/kernels. See docs/plans/pyrefly-tensor-shapes.md.
 tensor-shapes = true
 
-# Deps the cpu lint profile does not install (extras-only like vllm/lm_eval, or
-# compiled packages without stubs like resiliparse/jaxlib). Unlike
-# replace-imports-with-any, this substitutes Any only when the module is truly
-# absent on disk, so a deleted/misspelled internal module still trips missing-import.
+# Modules pyrefly may not find on disk, listed so it substitutes Any for them
+# instead of erroring. Unlike replace-imports-with-any (which is unconditional),
+# this substitutes Any ONLY when the module is truly absent, so a deleted or
+# misspelled internal module still trips missing-import, and a dep that *is*
+# installed is still type-checked against its real stubs. Two categories live here:
+#   1. Deps no lint profile installs: extras-only (vllm/lm_eval) or compiled
+#      packages without stubs (resiliparse/jaxlib). Always Any.
+#   2. Compute deps a worktree lacks when its venv was synced without a compute
+#      extra (torch, sympy). CI syncs `--extra=cpu`, so real types are used there;
+#      a base-only local venv degrades to Any instead of a missing-import flood.
+#      (torch is also in the tpu/gpu/vllm extras, which conflict with cpu, so the
+#      lint env can't just force-install it — graceful Any is the portable fix.)
 # HAND-MAINTAINED: a new uninstalled dep trips missing-import until added here
 # (list both `pkg` and `pkg.*`).
 ignore-missing-imports = [
@@ -270,8 +278,12 @@ ignore-missing-imports = [
     "pylatexenc.*",
     "resiliparse",
     "resiliparse.*",
+    "sympy",
+    "sympy.*",
     "tensorboardX",
     "tensorboardX.*",
+    "torch",
+    "torch.*",
     "tpu_inference",
     "tpu_inference.*",
     "trackio",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -241,20 +241,11 @@ use-ignore-files = false
 # levanter/grug and levanter/kernels. See docs/plans/pyrefly-tensor-shapes.md.
 tensor-shapes = true
 
-# Modules pyrefly may not find on disk, listed so it substitutes Any for them
-# instead of erroring. Unlike replace-imports-with-any (which is unconditional),
-# this substitutes Any ONLY when the module is truly absent, so a deleted or
-# misspelled internal module still trips missing-import, and a dep that *is*
-# installed is still type-checked against its real stubs. Two categories live here:
-#   1. Deps no lint profile installs: extras-only (vllm/lm_eval) or compiled
-#      packages without stubs (resiliparse/jaxlib). Always Any.
-#   2. Compute deps a worktree lacks when its venv was synced without a compute
-#      extra (torch, sympy). CI syncs `--extra=cpu`, so real types are used there;
-#      a base-only local venv degrades to Any instead of a missing-import flood.
-#      (torch is also in the tpu/gpu/vllm extras, which conflict with cpu, so the
-#      lint env can't just force-install it — graceful Any is the portable fix.)
-# HAND-MAINTAINED: a new uninstalled dep trips missing-import until added here
-# (list both `pkg` and `pkg.*`).
+# Modules treated as Any when absent on disk. Pyrefly still uses real stubs when
+# the dep is installed (so a deleted/misspelled internal module still trips
+# missing-import). Covers deps no lint profile installs (vllm/lm_eval, resiliparse)
+# and compute deps a local venv commonly skips (torch, sympy). List both `pkg` and
+# `pkg.*`.
 ignore-missing-imports = [
     "harbor",
     "harbor.*",


### PR DESCRIPTION
A worktree venv synced without a compute extra lacks torch and sympy (they live only in the cpu/tpu/gpu/vllm and math extras), so pyrefly floods the local run with missing-import errors for them. CI syncs `--extra=cpu` and is unaffected.

Add `torch`/`sympy` to pyrefly's `ignore-missing-imports`. Pyrefly substitutes `Any` only when a module is truly absent on disk, so wherever the deps are installed (CI, and any local venv with a compute extra) they are still type-checked against their real stubs; a base-only venv degrades to `Any` instead of erroring. torch also lives in the tpu/gpu/vllm extras, which conflict with cpu, so the lint env cannot simply force-install it — graceful `Any` is the portable fix.