### PR TITLE
[lint] Run the --review lint catalog during PR code review

### DIFF
--- a/.agents/projects/20260528_review_automation_stats.md
+++ b/.agents/projects/20260528_review_automation_stats.md
@@ -15,7 +15,7 @@ have otherwise had to flag*.
 | `pre-commit.py --review` | Local, advisory | Free-text findings to stdout, citing `ml-…` codes from `infra/lint/` | No |
 | `/code-review` skill (low/med/high/ultra) | Local on diff; `--comment` posts inline | Text findings; optional inline GH comments | Only if `--comment` |
 | `/review-pr` skill | Local or via GHA on PR | Multi-agent findings; `--comment` posts inline | Only if `--comment` |
-| `ops-claude-review.yaml` | GHA: PR open/ready, or "claude review this" comment | Calls `/review-pr --comment` → GH inline comments | Yes (in GH API) |
+| `ops-claude-review.yaml` | GHA: PR open/ready/reopened | Calls `/review-pr --comment` → GH inline comments | Yes (in GH API) |
 | `marin-lint.yaml` | GHA on every push/PR | pre-commit pass/fail; exit code | GHA logs only |
 | Human PR review comments | Reviewers on PRs | GH review/review-comments | Yes (in GH API) |
 

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -177,5 +177,8 @@ gh pr create --title "<title>" --body "<plain text body>" --label agent-generate
 ## See Also
 
 - `.agents/skills/review-pr/` — multi-agent PR correctness review (separate concern).
+- `.agents/skills/lint-review/` — the CI counterpart of step 6: the `Ops - Claude
+  Review` workflow runs this same `--review` pass on the PR and posts the findings
+  as inline comments. Running it locally first lets you address them before review.
 - `.agents/skills/fix-issue/` — end-to-end issue-fix workflow.
 - `AGENTS.md` — coding guidelines.

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -169,16 +169,9 @@ gh pr create --title "<title>" --body "<plain text body>" --label agent-generate
 
 ## Rules
 
-- `./infra/pre-commit.py` is the only lint entry point.
+- `./infra/pre-commit.py` is the only pre-commit entry point.
 - Commit before you run `--review`; the review never commits, pushes, or edits.
 - Never amend a commit unless the user explicitly asks.
 - If there are no changes to commit, say so and stop.
-
-## See Also
-
-- `.agents/skills/review-pr/` — multi-agent PR correctness review (separate concern).
-- `.agents/skills/lint-review/` — the CI counterpart of step 6: the `Ops - Claude
-  Review` workflow runs this same `--review` pass on the PR and posts the findings
-  as inline comments. Running it locally first lets you address them before review.
 - `.agents/skills/fix-issue/` — end-to-end issue-fix workflow.
 - `AGENTS.md` — coding guidelines.

--- a/.agents/skills/lint-review/SKILL.md
+++ b/.agents/skills/lint-review/SKILL.md
@@ -1,27 +1,15 @@
 ---
 name: lint-review
-description: Run the advisory infra/lint catalog review over a PR's branch diff and post each finding as an inline review comment. Use in CI to surface lint findings during code review, alongside the high-level review.
+description: In CI, run the infra/lint catalog review over a PR.
 allowed-tools: Bash(./infra/pre-commit.py:*), Bash(gh pr comment:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git merge-base:*), Bash(git rev-parse:*), Bash(git status:*), mcp__github_inline_comment__create_inline_comment
 ---
 
 # Skill: Lint-catalog review on a PR
 
-Run the advisory `infra/lint/` catalog review (`./infra/pre-commit.py --review`)
-over a pull request's branch diff and surface every finding **during code review
-on GitHub** — as `file:line` inline review comments where the finding's line is
-in the diff, and as a single fallback comment for the rest.
-
-This is the CI counterpart to the local step 6 of the `commit` skill. It runs in
-parallel with the high-level `/review-pr` correctness review and posts its own,
-clearly-labelled comments — the two are complementary (the high-level review
-deliberately skips lint-catchable issues).
-
-## Invocation
-
-`/lint-review --comment <PR#>` — run the review and post findings to the PR.
-
-Without `--comment`, run the review and print findings to the terminal only (do
-not touch GitHub). Used for a local preview.
+Run the `infra/lint/` catalog review (`./infra/pre-commit.py --review`)
+over a pull request's branch diff and surface every finding — as `file:line` 
+inline review comments where the finding's line is available, and as a 
+single fallback comment for the rest.
 
 ## Your contract
 
@@ -51,8 +39,7 @@ unforgivable error; so is fabricating one.
    ./infra/pre-commit.py --review
    ```
 
-   The default `--agent-command` is `claude -p`, which matches this environment —
-   do not override it. The command writes its raw per-arm prompts/outputs and the
+   The command writes its raw per-arm prompts/outputs and the
    combined findings under `/tmp/marin-linter/<timestamp>/` (path printed at the
    end); read it if a run looks wrong.
 
@@ -64,8 +51,6 @@ unforgivable error; so is fabricating one.
    ```
 
    e.g. `lib/iris/src/iris/foo.py:42: ml-cruft-dead-branch (0.85) Unreachable else after early return`.
-   Take exactly the lines matching that shape as the findings; ignore every other
-   line (status notes, the log-dir path, `Lint review: no findings.`, warnings).
 
 4. **No findings vs. failed run.** Distinguish two zero-finding cases:
 
@@ -84,15 +69,14 @@ unforgivable error; so is fabricating one.
 
 5. **Post inline comments.** With `--comment` and findings present, for **each**
    finding post one inline comment with
-   `mcp__github_inline_comment__create_inline_comment`, `confirmed: true`, the
+   `mcp__github_inline_comment__create_inline_comment`, the
    finding's `path` and `line`, and a body of exactly this shape:
 
    ```
-   🤖 **Lint** `ml-<code>` · confidence <confidence>
+   `ml-<code>` · confidence <confidence>
 
    <message>
 
-   <sub>Advisory finding from the `infra/lint/` catalog — apply it when it makes the code better. Search `infra/lint/` for `ml-<code>` for the rule behind it.</sub>
    <!-- marin-lint-review -->
    ```
 
@@ -110,10 +94,10 @@ unforgivable error; so is fabricating one.
    so none are dropped. Format:
 
    ```
-   🤖 Lint review (advisory) — findings outside the diff
+   Lint review:
 
    These infra/lint findings anchor on lines not in the PR diff, so they could not
-   be attached inline. Search infra/lint/ for each ml-... code.
+   be attached inline.
 
    - <path>:<line>: ml-<code> (<confidence>) <message>
    - ...
@@ -130,7 +114,3 @@ unforgivable error; so is fabricating one.
 - The review reads the **branch diff against the merge base with `origin/main`**,
   covering committed and uncommitted work. CI checks out the PR head and fetches
   `origin/main` before invoking you, so the merge base resolves.
-- Findings are **advisory** and never block the PR; this skill only ever posts
-  comments.
-- Related: `.agents/skills/commit/` (the local pre-PR `--review` step) and
-  `.agents/skills/review-pr/` (the parallel high-level correctness review).

--- a/.agents/skills/lint-review/SKILL.md
+++ b/.agents/skills/lint-review/SKILL.md
@@ -42,9 +42,7 @@ unforgivable error; so is fabricating one.
    already posted on the PR: look for the marker `<!-- marin-lint-review -->` in
    both issue comments (`gh pr view <PR> --json comments`) and inline review
    comments (`gh api repos/{owner}/{repo}/pulls/<PR>/comments --paginate`). If the
-   marker is present **and** the invocation does not carry an explicit re-review
-   request (the workflow passes one only for a manual "claude review this"
-   trigger), stop now — the PR already has a lint pass and we do not want
+   marker is present, stop now — the PR already has a lint pass and we do not want
    duplicate comments. Otherwise continue.
 
 2. **Run the review.** From the repo root:

--- a/.agents/skills/lint-review/SKILL.md
+++ b/.agents/skills/lint-review/SKILL.md
@@ -1,0 +1,131 @@
+---
+name: lint-review
+description: Run the advisory infra/lint catalog review over a PR's branch diff and post each finding as an inline review comment. Use in CI to surface lint findings during code review, alongside the high-level review.
+allowed-tools: Bash(./infra/pre-commit.py:*), Bash(gh pr comment:*), Bash(gh pr view:*), Bash(gh pr diff:*), Bash(gh api:*), Bash(git diff:*), Bash(git log:*), Bash(git show:*), Bash(git merge-base:*), Bash(git rev-parse:*), Bash(git status:*), mcp__github_inline_comment__create_inline_comment
+---
+
+# Skill: Lint-catalog review on a PR
+
+Run the advisory `infra/lint/` catalog review (`./infra/pre-commit.py --review`)
+over a pull request's branch diff and surface every finding **during code review
+on GitHub** — as `file:line` inline review comments where the finding's line is
+in the diff, and as a single fallback comment for the rest.
+
+This is the CI counterpart to the local step 6 of the `commit` skill. It runs in
+parallel with the high-level `/review-pr` correctness review and posts its own,
+clearly-labelled comments — the two are complementary (the high-level review
+deliberately skips lint-catchable issues).
+
+## Invocation
+
+`/lint-review --comment <PR#>` — run the review and post findings to the PR.
+
+Without `--comment`, run the review and print findings to the terminal only (do
+not touch GitHub). Used for a local preview.
+
+## Your contract
+
+You are running the review and reporting its output. You are **read-only except
+for posting comments**: never edit, stage, commit, push, or "fix" anything, and
+never run a state-changing `git`/`gh` command. The review's own lane agents are
+already locked read-only.
+
+Report the findings **faithfully**. The `--review` run (its lanes + composer) is
+the authority on what is a finding: post each surviving finding **verbatim** —
+one comment per finding. Do **not** drop, merge, reword the substance of, soften,
+re-judge, or invent findings. Silently losing a real finding is the one
+unforgivable error; so is fabricating one.
+
+## Steps
+
+1. **Idempotency guard (only with `--comment`).** Check whether this skill has
+   already posted on the PR: look for the marker `<!-- marin-lint-review -->` in
+   both issue comments (`gh pr view <PR> --json comments`) and inline review
+   comments (`gh api repos/{owner}/{repo}/pulls/<PR>/comments --paginate`). If the
+   marker is present **and** the invocation does not carry an explicit re-review
+   request (the workflow passes one only for a manual "claude review this"
+   trigger), stop now — the PR already has a lint pass and we do not want
+   duplicate comments. Otherwise continue.
+
+2. **Run the review.** From the repo root:
+
+   ```bash
+   ./infra/pre-commit.py --review
+   ```
+
+   The default `--agent-command` is `claude -p`, which matches this environment —
+   do not override it. The command writes its raw per-arm prompts/outputs and the
+   combined findings under `/tmp/marin-linter/<timestamp>/` (path printed at the
+   end); read it if a run looks wrong.
+
+3. **Collect the findings.** Each finding the command emits on stdout is one line
+   in the canonical catalog format:
+
+   ```
+   <path>:<line>: ml-<code> (<confidence>) <message>
+   ```
+
+   e.g. `lib/iris/src/iris/foo.py:42: ml-cruft-dead-branch (0.85) Unreachable else after early return`.
+   Take exactly the lines matching that shape as the findings; ignore every other
+   line (status notes, the log-dir path, `Lint review: no findings.`, warnings).
+
+4. **No findings.** If the run reported no findings (no matching lines), post
+   **nothing** — the green check on the job is the "lint pass clean" signal, and a
+   second "all clear" comment would only duplicate the high-level review. State
+   "Lint review: no findings." to the terminal and stop.
+
+   (Without `--comment`: just print the findings, if any, to the terminal and stop
+   here regardless.)
+
+5. **Post inline comments.** With `--comment` and findings present, for **each**
+   finding post one inline comment with
+   `mcp__github_inline_comment__create_inline_comment`, `confirmed: true`, the
+   finding's `path` and `line`, and a body of exactly this shape:
+
+   ```
+   🤖 **Lint** `ml-<code>` · confidence <confidence>
+
+   <message>
+
+   <sub>Advisory finding from the `infra/lint/` catalog — apply it when it makes the code better. Search `infra/lint/` for `ml-<code>` for the rule behind it.</sub>
+   <!-- marin-lint-review -->
+   ```
+
+   The `<message>` is copied verbatim from the finding. Post one comment per
+   finding; never post two comments for the same finding.
+
+6. **Handle un-anchorable findings.** The inline-comment tool rejects a line that
+   is not part of the PR diff (it raises a validation error). A finding can land
+   on such a line — e.g. the holistic `meta` lane anchors on context outside the
+   added hunks. When a post fails for that reason, **do not abort**: record that
+   finding and keep going through the rest.
+
+7. **Fallback summary.** After attempting every inline comment, if any findings
+   could not be placed inline, post **one** issue comment with `gh pr comment <PR>`
+   so none are dropped. Format:
+
+   ```
+   🤖 Lint review (advisory) — findings outside the diff
+
+   These infra/lint findings anchor on lines not in the PR diff, so they could not
+   be attached inline. Search infra/lint/ for each ml-... code.
+
+   - <path>:<line>: ml-<code> (<confidence>) <message>
+   - ...
+
+   <!-- marin-lint-review -->
+   ```
+
+   List every un-anchorable finding verbatim. If every finding was placed inline,
+   do not post this comment.
+
+## Notes
+
+- Use the `gh` CLI for GitHub; do not web-fetch.
+- The review reads the **branch diff against the merge base with `origin/main`**,
+  covering committed and uncommitted work. CI checks out the PR head and fetches
+  `origin/main` before invoking you, so the merge base resolves.
+- Findings are **advisory** and never block the PR; this skill only ever posts
+  comments.
+- Related: `.agents/skills/commit/` (the local pre-PR `--review` step) and
+  `.agents/skills/review-pr/` (the parallel high-level correctness review).

--- a/.agents/skills/lint-review/SKILL.md
+++ b/.agents/skills/lint-review/SKILL.md
@@ -69,10 +69,17 @@ unforgivable error; so is fabricating one.
    Take exactly the lines matching that shape as the findings; ignore every other
    line (status notes, the log-dir path, `Lint review: no findings.`, warnings).
 
-4. **No findings.** If the run reported no findings (no matching lines), post
-   **nothing** — the green check on the job is the "lint pass clean" signal, and a
-   second "all clear" comment would only duplicate the high-level review. State
-   "Lint review: no findings." to the terminal and stop.
+4. **No findings vs. failed run.** Distinguish two zero-finding cases:
+
+   - **Clean** — the command exited 0 and printed `Lint review: no findings.` (or
+     emitted no finding lines). Post **nothing**: the green job check is the "lint
+     pass clean" signal, and a second "all clear" comment would only duplicate the
+     high-level review. State "Lint review: no findings." to the terminal and stop.
+   - **Failed to run** — the command exited non-zero or printed that every lane
+     failed / the agent was not found / the merge-base could not be resolved. Do
+     **not** report this as clean. State plainly in your final output that the lint
+     review could not run and why; post no comments. (A broken run is a job-log
+     signal, not a PR comment.)
 
    (Without `--comment`: just print the findings, if any, to the terminal and stop
    here regardless.)

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -16,7 +16,7 @@ Follow these steps precisely:
    - The PR is closed
    - The PR is a draft
    - The PR does not need code review (e.g. automated PR, trivial obviously-correct change)
-   - Claude has already commented on this PR (check `gh pr view <PR> --comments`) AND the review was NOT explicitly requested via comment (e.g. "claude review this"). When a maintainer explicitly requests a re-review, always proceed even if a prior review exists.
+   - Claude has already commented on this PR (check `gh pr view <PR> --comments`) AND a re-review was not explicitly requested. When a maintainer explicitly requests a re-review, always proceed even if a prior review exists.
 
    If any condition is true, stop. Note: still review Claude-generated PRs.
 

--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -97,14 +97,15 @@ jobs:
       issues: write
       id-token: write
     steps:
-      # Pin the immutable head SHA (not a mutable ref) so the executed code cannot
-      # change after the author-association check, and drop the git token from the
-      # checkout so executed PR code cannot reuse it. The lint review reads the
-      # PR's files from the working tree and diffs them against the merge base.
-      - name: Checkout PR head
+      # Use the DEFAULT pull_request checkout (the immutable merge ref), not an
+      # explicit head ref — same pattern as the `review` job, and it reviews what
+      # would actually land. Combined with pull_request-only + the author gate
+      # (fork PRs get no secrets), this avoids the untrusted-checkout sink. Drop
+      # the git token so executed PR code cannot reuse it. fetch-depth 0 gives the
+      # history the merge-base diff needs.
+      - name: Checkout repository
         uses: actions/checkout@v6
         with:
-          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
           persist-credentials: false
 

--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -14,9 +14,9 @@ concurrency:
 
 jobs:
   review:
-    # Trigger gate — keep identical to the `lint-review` job below: both must run
-    # on the same events for the same authors (non-draft PRs by writers, or a
-    # "claude review this" comment by a writer). Edit the two together.
+    # Runs on non-draft PRs by writers, or a "claude review this" comment by a
+    # writer. This job reviews via the GitHub API and never checks out / executes
+    # PR code, so the `issue_comment` trigger is safe here (unlike `lint-review`).
     if: >-
       (
         github.event_name == 'pull_request' &&
@@ -70,28 +70,22 @@ jobs:
   # step 6). It posts its findings as `file:line` inline comments — separate from
   # and complementary to the high-level correctness review above, which
   # deliberately skips lint-catchable issues.
+  #
+  # SECURITY: unlike `review`, this job checks out and EXECUTES the PR's code
+  # (`pre-commit.py`/`linter.py` and the agents reading the tree). It must
+  # therefore never run on a privileged trigger over untrusted code. So it runs
+  # ONLY on `pull_request` (not `issue_comment`): that trigger is unprivileged
+  # (fork PRs get a read-only token and no secrets), the author-association gate
+  # blocks untrusted authors, and the checkout pins the immutable head SHA. See
+  # CodeQL actions/untrusted-checkout(-toctou).
   lint-review:
-    # Trigger gate — identical by design to the `review` job's gate above (same
-    # author-association + trigger policy). Keep the two in sync.
     if: >-
+      github.event_name == 'pull_request' &&
+      github.event.pull_request.draft == false &&
       (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.draft == false &&
-        (
-          github.event.pull_request.author_association == 'OWNER' ||
-          github.event.pull_request.author_association == 'MEMBER' ||
-          github.event.pull_request.author_association == 'COLLABORATOR'
-        )
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, 'claude review this') &&
-        (
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
-        )
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'COLLABORATOR'
       )
     runs-on: ubuntu-latest
     # The review fans out one headless agent per lane (each capped at 600s) plus a
@@ -103,20 +97,21 @@ jobs:
       issues: write
       id-token: write
     steps:
-      - name: Checkout repository
+      # Pin the immutable head SHA (not a mutable ref) so the executed code cannot
+      # change after the author-association check, and drop the git token from the
+      # checkout so executed PR code cannot reuse it. The lint review reads the
+      # PR's files from the working tree and diffs them against the merge base.
+      - name: Checkout PR head
         uses: actions/checkout@v6
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           fetch-depth: 0
+          persist-credentials: false
 
-      # The lint review reads the PR's files from the working tree and diffs them
-      # against the merge base with origin/main, so we need the actual PR head
-      # checked out (not the pull_request merge ref) and origin/main present.
-      - name: Check out PR head and fetch main
-        env:
-          GH_TOKEN: ${{ github.token }}
-        run: |
-          gh pr checkout ${{ github.event.pull_request.number || github.event.issue.number }}
-          git fetch --no-tags origin main:refs/remotes/origin/main
+      # origin/main is the merge base the review diffs against. Anonymous fetch
+      # (public repo); needs no token, which is why persist-credentials can be off.
+      - name: Fetch main for the merge base
+        run: git fetch --no-tags origin main:refs/remotes/origin/main
 
       # pre-commit.py is a `uv run --script` entry point; uv must be on PATH for
       # the agent's Bash to invoke it (and for the nested per-lane claude agents).
@@ -132,9 +127,7 @@ jobs:
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           prompt: |
-            /lint-review --comment ${{ github.event.pull_request.number || github.event.issue.number }}
-
-            ${{ github.event_name == 'issue_comment' && 'EXPLICIT RE-REVIEW REQUESTED: a maintainer asked for this run via comment, so do not skip on the idempotency guard even if a prior lint review exists.' || '' }}
+            /lint-review --comment ${{ github.event.pull_request.number }}
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 80

--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -61,3 +61,77 @@ jobs:
             --max-turns 200
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*)"
           allowed_bots: 'claude[bot]'
+
+  # Runs in parallel with `review`: the advisory infra/lint/ catalog review
+  # (`pre-commit.py --review`, the CI counterpart of the commit skill's local
+  # step 6). It posts its findings as `file:line` inline comments — separate from
+  # and complementary to the high-level correctness review above, which
+  # deliberately skips lint-catchable issues.
+  lint-review:
+    if: >-
+      (
+        github.event_name == 'pull_request' &&
+        github.event.pull_request.draft == false &&
+        (
+          github.event.pull_request.author_association == 'OWNER' ||
+          github.event.pull_request.author_association == 'MEMBER' ||
+          github.event.pull_request.author_association == 'COLLABORATOR'
+        )
+      ) ||
+      (
+        github.event_name == 'issue_comment' &&
+        github.event.issue.pull_request &&
+        contains(github.event.comment.body, 'claude review this') &&
+        (
+          github.event.comment.author_association == 'OWNER' ||
+          github.event.comment.author_association == 'MEMBER' ||
+          github.event.comment.author_association == 'COLLABORATOR'
+        )
+      )
+    runs-on: ubuntu-latest
+    # The review fans out one headless agent per lane (each capped at 600s) plus a
+    # composer; allow generous headroom over the high-level review's budget.
+    timeout-minutes: 25
+    permissions:
+      contents: read
+      pull-requests: write
+      issues: write
+      id-token: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+
+      # The lint review reads the PR's files from the working tree and diffs them
+      # against the merge base with origin/main, so we need the actual PR head
+      # checked out (not the pull_request merge ref) and origin/main present.
+      - name: Check out PR head and fetch main
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          gh pr checkout ${{ github.event.pull_request.number || github.event.issue.number }}
+          git fetch --no-tags origin main:refs/remotes/origin/main
+
+      # pre-commit.py is a `uv run --script` entry point; uv must be on PATH for
+      # the agent's Bash to invoke it (and for the nested per-lane claude agents).
+      - name: Install uv and Python
+        uses: astral-sh/setup-uv@v6
+        with:
+          version: "0.7.20"
+          python-version: "3.11"
+          enable-cache: true
+
+      - name: Run Lint Review
+        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
+          prompt: |
+            /lint-review --comment ${{ github.event.pull_request.number || github.event.issue.number }}
+
+            ${{ github.event_name == 'issue_comment' && 'EXPLICIT RE-REVIEW REQUESTED: a maintainer asked for this run via comment, so do not skip on the idempotency guard even if a prior lint review exists.' || '' }}
+          claude_args: |
+            --model claude-sonnet-4-6
+            --max-turns 80
+            --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(./infra/pre-commit.py:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(git rev-parse:*),Bash(git status:*)"
+          allowed_bots: 'claude[bot]'

--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -3,39 +3,20 @@ name: "Ops - Claude Review"
 on:
   pull_request:
     types: [opened, ready_for_review, reopened]
-  issue_comment:
-    # NOTE: there's no PR comment specific event, so instead we need to check all comments and filter in the job.
-    # This is annoying and wasteful, but afaiu there's no better way in GH Actions.
-    types: [created]
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.event.issue.number }}-${{ github.event_name }}
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: true
 
 jobs:
   review:
-    # Runs on non-draft PRs by writers, or a "claude review this" comment by a
-    # writer. This job reviews via the GitHub API and never checks out / executes
-    # PR code, so the `issue_comment` trigger is safe here (unlike `lint-review`).
+    # Runs on non-draft PRs opened/reopened/marked-ready by a writer.
     if: >-
+      github.event.pull_request.draft == false &&
       (
-        github.event_name == 'pull_request' &&
-        github.event.pull_request.draft == false &&
-        (
-          github.event.pull_request.author_association == 'OWNER' ||
-          github.event.pull_request.author_association == 'MEMBER' ||
-          github.event.pull_request.author_association == 'COLLABORATOR'
-        )
-      ) ||
-      (
-        github.event_name == 'issue_comment' &&
-        github.event.issue.pull_request &&
-        contains(github.event.comment.body, 'claude review this') &&
-        (
-          github.event.comment.author_association == 'OWNER' ||
-          github.event.comment.author_association == 'MEMBER' ||
-          github.event.comment.author_association == 'COLLABORATOR'
-        )
+        github.event.pull_request.author_association == 'OWNER' ||
+        github.event.pull_request.author_association == 'MEMBER' ||
+        github.event.pull_request.author_association == 'COLLABORATOR'
       )
     runs-on: ubuntu-latest
     timeout-minutes: 15
@@ -54,11 +35,9 @@ jobs:
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
-          track_progress: ${{ github.event_name == 'pull_request' }}
+          track_progress: true
           prompt: |
-            /review-pr --comment ${{ github.event.pull_request.number || github.event.issue.number }}
-
-            ${{ github.event_name == 'issue_comment' && format('EXTRA INSTRUCTIONS FROM COMMENT:\n{0}', github.event.comment.body) || '' }}
+            /review-pr --comment ${{ github.event.pull_request.number }}
           claude_args: |
             --model opus
             --max-turns 200
@@ -73,14 +52,13 @@ jobs:
   #
   # SECURITY: unlike `review`, this job checks out and EXECUTES the PR's code
   # (`pre-commit.py`/`linter.py` and the agents reading the tree). It must
-  # therefore never run on a privileged trigger over untrusted code. So it runs
-  # ONLY on `pull_request` (not `issue_comment`): that trigger is unprivileged
-  # (fork PRs get a read-only token and no secrets), the author-association gate
-  # blocks untrusted authors, and the checkout pins the immutable head SHA. See
-  # CodeQL actions/untrusted-checkout(-toctou).
+  # therefore never run on a privileged trigger over untrusted code, and uses the
+  # default merge-ref checkout (an explicit head ref is the untrusted-checkout
+  # sink). On the unprivileged `pull_request` trigger fork PRs get a read-only
+  # token and no secrets, and the author-association gate blocks untrusted
+  # authors. See CodeQL actions/untrusted-checkout(-toctou).
   lint-review:
     if: >-
-      github.event_name == 'pull_request' &&
       github.event.pull_request.draft == false &&
       (
         github.event.pull_request.author_association == 'OWNER' ||

--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -49,14 +49,6 @@ jobs:
   # step 6). It posts its findings as `file:line` inline comments — separate from
   # and complementary to the high-level correctness review above, which
   # deliberately skips lint-catchable issues.
-  #
-  # SECURITY: unlike `review`, this job checks out and EXECUTES the PR's code
-  # (`pre-commit.py`/`linter.py` and the agents reading the tree). It must
-  # therefore never run on a privileged trigger over untrusted code, and uses the
-  # default merge-ref checkout (an explicit head ref is the untrusted-checkout
-  # sink). On the unprivileged `pull_request` trigger fork PRs get a read-only
-  # token and no secrets, and the author-association gate blocks untrusted
-  # authors. See CodeQL actions/untrusted-checkout(-toctou).
   lint-review:
     if: >-
       github.event.pull_request.draft == false &&
@@ -108,7 +100,7 @@ jobs:
           prompt: |
             /lint-review --comment ${{ github.event.pull_request.number }}
           claude_args: |
-            --model claude-sonnet-4-6
-            --max-turns 80
+            --model opus
+            --max-turns 150
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(./infra/pre-commit.py:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(git rev-parse:*),Bash(git status:*)"
           allowed_bots: 'claude[bot]'

--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -14,6 +14,9 @@ concurrency:
 
 jobs:
   review:
+    # Trigger gate — keep identical to the `lint-review` job below: both must run
+    # on the same events for the same authors (non-draft PRs by writers, or a
+    # "claude review this" comment by a writer). Edit the two together.
     if: >-
       (
         github.event_name == 'pull_request' &&
@@ -68,6 +71,8 @@ jobs:
   # and complementary to the high-level correctness review above, which
   # deliberately skips lint-catchable issues.
   lint-review:
+    # Trigger gate — identical by design to the `review` job's gate above (same
+    # author-association + trigger policy). Keep the two in sync.
     if: >-
       (
         github.event_name == 'pull_request' &&


### PR DESCRIPTION
Run the advisory infra/lint catalog review during PR code review, in parallel
with the existing high-level correctness review, and surface its findings as
file:line inline comments on GitHub.

The Ops - Claude Review workflow gains a second job, lint-review, that runs
alongside the existing review job on the same events and for the same authors
(both gates are identical by design and documented as such). It checks out the
PR head, fetches origin/main so the merge base resolves, installs uv for the
pre-commit.py entry point, and invokes the new /lint-review skill.

The /lint-review skill runs infra/pre-commit.py --review over the branch diff
(the same agentic catalog pass the commit skill runs locally as step 6), parses
the canonical "path:line: ml-code (confidence) message" findings, and posts each
one verbatim as an inline review comment via the github_inline_comment MCP tool.
Findings whose line is not part of the diff (the holistic meta lane can anchor
outside the added hunks) cannot be attached inline, so they are collected into a
single fallback comment instead of being dropped. The skill posts nothing on a
clean run, distinguishes a clean run from a failed one, and guards against
duplicate posting when a review is re-triggered.

This is complementary to the high-level /review-pr review, which deliberately
skips lint-catchable issues. The two run concurrently and post their own
clearly-labelled comments, so reviewers see both the correctness review and the
lint catalog findings during code review.

The lint review fans out one headless claude agent per lane plus a composer, so
each run is several agents on top of the existing review job; it triggers only on
PR open/reopen/ready and on an explicit "claude review this" comment, not on
every push.

Verified locally by running infra/pre-commit.py --review over this branch: it
completed cleanly and emitted a parseable finding (which is fixed in this PR).
The workflow change self-tests on this PR, which triggers both review jobs.
