### PR TITLE
[SFT] Add Nemotron competitive code datasets

### DIFF
--- a/experiments/posttrain/instruction_datasets.py
+++ b/experiments/posttrain/instruction_datasets.py
@@ -38,6 +38,7 @@ Current datasets:
 23. open-thoughts/OpenThoughts3-1.2M  # Original OT3 dataset; smoltalk2 uses a slightly different version
 24. lm-provers/FineProofs-SFT
 25. lm-provers/FineProofs-SFT/proof-only
+26. nvidia/Nemotron-SFT-Competitive-Programming-v2
 """
 
 import dataclasses
@@ -104,6 +105,52 @@ NEMOTRON_V2_SPLITS = [
 
 NEMOTRON_V1_SPLITS = ["chat", "code", "math", "stem", "tool_calling"]
 
+NEMOTRON_COMPETITIVE_V2_DATASET_ID = "nvidia/Nemotron-SFT-Competitive-Programming-v2"
+NEMOTRON_COMPETITIVE_V2_REVISION = "778afc98a9e027e10b3cd78020c120e93e142ef2"
+NEMOTRON_COMPETITIVE_V2_SOURCE_FILES_BY_SPLIT = {
+    "competitive_coding_python": [
+        "data/competitive_programming_python_00.jsonl",
+        "data/competitive_programming_python_01.jsonl",
+    ],
+    "competitive_coding_cpp": [
+        "data/competitive_programming_cpp_00.jsonl",
+        "data/competitive_programming_cpp_01.jsonl",
+    ],
+    "exercism": ["data/exercism.jsonl"],
+    "text_to_sql": ["data/text_to_sql.jsonl"],
+}
+NEMOTRON_COMPETITIVE_V2_METADATA_COLUMNS = {
+    "competitive_coding_python": [
+        "uuid",
+        "used_in",
+        "license",
+        "dataset",
+        "split",
+        "index",
+        "source",
+        "difficulty",
+        "question_id",
+    ],
+    "competitive_coding_cpp": [
+        "uuid",
+        "used_in",
+        "license",
+        "dataset",
+        "split",
+        "index",
+        "source",
+        "difficulty",
+        "question_id",
+    ],
+    "exercism": ["uuid", "used_in", "license"],
+    "text_to_sql": ["uuid", "used_in", "license", "complexity", "dialect"],
+}
+NEMOTRON_COMPETITIVE_V2_REASONING_SPLITS = {
+    "competitive_coding_python",
+    "competitive_coding_cpp",
+    "text_to_sql",
+}
+
 
 @dataclass(frozen=True)
 class InstructionDatasetConfig:
@@ -118,6 +165,9 @@ class InstructionDatasetConfig:
         splits: Data splits (e.g., `train`, `validation`) to use. Empty list indicates to use all splits.
                 Defaults to `train` only
         name: Optional friendly name for the dataset; defaults to `hf_dataset_id`.
+        source_files_by_split: Optional raw JSONL files keyed by split. Use this when a Hugging Face dataset
+            builder has unreliable inferred schema for the raw files.
+        raw_shard_size: Number of transformed records per output shard when using `source_files_by_split`.
         max_parallelism: Max number of parallel data processing tasks. Reduce if needed to avoid HF rate limits.
     """
 
@@ -128,6 +178,8 @@ class InstructionDatasetConfig:
     name: str | None = None
     subsets: list[str] = field(default_factory=lambda: [])
     splits: list[str] = field(default_factory=lambda: ["train"])
+    source_files_by_split: dict[str, list[str]] | None = None
+    raw_shard_size: int = 50_000
     max_parallelism: int | None = 32  # 32 works for free users; set to None to use default behavior (full parallelism)
 
 
@@ -138,6 +190,7 @@ def multi_turn_adapter(
     assistant_value: str = "assistant",
     system_value: str = "system",
     content_key: str = "content",
+    message_keys_to_copy: tuple[str, ...] = (),
     metadata_remap: dict[str, str] | None = None,
     replacements: dict[str, str] | None = None,
     extra_metadata_fn=None,
@@ -150,6 +203,7 @@ def multi_turn_adapter(
         assistant_value=assistant_value,
         system_value=system_value,
         content_key=content_key,
+        message_keys_to_copy=message_keys_to_copy,
         metadata_remap=metadata_remap or {},
         replacements=replacements,
         extra_metadata_fn=extra_metadata_fn,
@@ -595,6 +649,20 @@ for split_name in NEMOTRON_V1_SPLITS:
         splits=[split_name],
     )
 
+for split_name, metadata_columns in NEMOTRON_COMPETITIVE_V2_METADATA_COLUMNS.items():
+    dataset_key = f"{NEMOTRON_COMPETITIVE_V2_DATASET_ID}/{split_name}"
+    message_keys_to_copy = ("reasoning_content",) if split_name in NEMOTRON_COMPETITIVE_V2_REASONING_SPLITS else ()
+    INSTRUCTION_DATASET_NAME_TO_CONFIG[dataset_key] = InstructionDatasetConfig(
+        name=dataset_key,
+        hf_dataset_id=NEMOTRON_COMPETITIVE_V2_DATASET_ID,
+        revision=NEMOTRON_COMPETITIVE_V2_REVISION,
+        adapter=multi_turn_adapter(message_keys_to_copy=message_keys_to_copy),
+        metadata_columns=metadata_columns,
+        subsets=["default"],
+        splits=[split_name],
+        source_files_by_split={split_name: NEMOTRON_COMPETITIVE_V2_SOURCE_FILES_BY_SPLIT[split_name]},
+    )
+
 
 def get_directory_friendly_dataset_name(hf_dataset_id: str) -> str:
     dataset_name = hf_dataset_id.replace("/", "--")
@@ -611,6 +679,8 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
 
     adapter_dict = dataclasses.asdict(adapter)
     adapter_dict["dataset_format"] = adapter_dict["dataset_format"].value
+    if not adapter_dict["message_keys_to_copy"]:
+        del adapter_dict["message_keys_to_copy"]
 
     def canonicalize(value):
         if isinstance(value, dict):
@@ -623,11 +693,16 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
 
     adapter_signature = canonicalize(adapter_dict)
     adapter_signature_str = json.dumps(adapter_signature, sort_keys=True)
+    source_files_signature = canonicalize(dataset_cfg.source_files_by_split or {})
+    source_files_signature_str = json.dumps(source_files_signature, sort_keys=True)
+    source_files_config_str = (
+        f"-{source_files_signature_str}-{dataset_cfg.raw_shard_size}" if dataset_cfg.source_files_by_split else ""
+    )
 
     config_str = f"{dataset_name}-\
         {dataset_cfg.revision}\
         -{sorted(dataset_cfg.subsets)}\
-        -{sorted(dataset_cfg.splits)}\
+        -{sorted(dataset_cfg.splits)}{source_files_config_str}\
         -{adapter_signature_str}"
     hashed_config_str = hashlib.md5(config_str.encode()).hexdigest()[:6]
 
@@ -642,6 +717,8 @@ def transform_dataset_step(dataset_cfg: InstructionDatasetConfig) -> ExecutorSte
             adapter=versioned(adapter),
             subsets=versioned(dataset_cfg.subsets),
             splits=versioned(dataset_cfg.splits),
+            source_files_by_split=versioned(dataset_cfg.source_files_by_split),
+            raw_shard_size=versioned(dataset_cfg.raw_shard_size),
             max_parallelism=dataset_cfg.max_parallelism,
         ),
         override_output_path=f"documents/{dataset_name}-{dataset_cfg.revision}-{hashed_config_str}",

--- a/lib/marin/src/marin/transform/conversation/adapters.py
+++ b/lib/marin/src/marin/transform/conversation/adapters.py
@@ -86,6 +86,7 @@ class TransformAdapter:
     filter_on_key: str = ""
     metadata_remap: dict[str, str] = field(default_factory=dict)
     replacements: dict[str, str] | None = None
+    message_keys_to_copy: tuple[str, ...] = ()
     extra_metadata_fn: Callable[[dict[str, Any]], dict[str, Any]] | None = None
 
     def transform_conversation_to_openai_format(
@@ -128,7 +129,10 @@ class TransformAdapter:
             conversation = row[self.conversation_column]
             for conv in conversation:
                 role = role_to_openai_role[conv[self.role_key]]
-                messages.append(OpenAIChatMessage(role=role, content=conv[self.content_key]))
+                message_kwargs = {
+                    key: conv[key] for key in self.message_keys_to_copy if key in conv and conv[key] is not None
+                }
+                messages.append(OpenAIChatMessage(role=role, content=conv[self.content_key], **message_kwargs))
             return messages
         elif self.dataset_format == InputDatasetFormat.INSTRUCT_COLUMN_RESPONSE:
             messages = []

--- a/lib/marin/src/marin/transform/conversation/transform_conversation.py
+++ b/lib/marin/src/marin/transform/conversation/transform_conversation.py
@@ -51,6 +51,9 @@ class TransformSFTDatasetConfig:
         adapter (TransformAdapter): Adapter responsible for mapping raw rows into OpenAI chat format.
         subsets (list[str]): Data subsets (from HuggingFace config) to use. Empty list indicates all/default subset(s).
         splits (list[str]): Data splits (e.g., `train`, `validation`) to use. Empty list indicates all splits.
+        source_files_by_split: Optional raw JSONL files keyed by split, used when HF dataset builder schemas are not
+            reliable. Relative files are resolved as hf://datasets/{source}@{revision}/{path}.
+        raw_shard_size: Number of transformed records per output shard when reading source_files_by_split.
         max_parallelism (int | None): Maximum number of concurrent shard processing tasks.
             Set to lower values to avoid HF rate limits. Set to None for default behavior (full concurrency).
     """
@@ -62,6 +65,8 @@ class TransformSFTDatasetConfig:
     adapter: TransformAdapter
     subsets: list[str] = field(default_factory=lambda: [])  # Default behavior is to use all subsets
     splits: list[str] = field(default_factory=lambda: ["train"])  # Set to train; empty set means everything
+    source_files_by_split: dict[str, list[str]] | None = None
+    raw_shard_size: int = 50_000
     max_parallelism: int | None = None  # None means use default behavior (full concurrency)
 
 
@@ -75,6 +80,20 @@ class ShardTask:
     split: str
     shard_idx: int
     num_shards: int
+    output_path: str
+    cfg: TransformSFTDatasetConfig
+
+
+@dataclass(frozen=True)
+class RawFileTask:
+    """Task for processing one raw JSONL file for a dataset split."""
+
+    source: str
+    revision: str
+    subset: str | None
+    split: str
+    source_file: str
+    source_file_idx: int
     output_path: str
     cfg: TransformSFTDatasetConfig
 
@@ -242,6 +261,16 @@ def _streaming_dataset_kwargs(source: str, split: str, revision: str, subset: st
     return kwargs
 
 
+def _raw_shard_filename(output_path: str, source_file_idx: int, shard_idx: int) -> str:
+    return os.path.join(output_path, f"file_{source_file_idx:05d}_shard_{shard_idx:05d}.jsonl.gz")
+
+
+def _raw_source_url(source: str, revision: str, source_file: str) -> str:
+    if "://" in source_file or os.path.isabs(source_file):
+        return source_file
+    return f"hf://datasets/{source}@{revision}/{source_file.lstrip('/')}"
+
+
 def get_shard_dir(dir_name: os.PathLike, subset_name: str | None, split: str) -> os.PathLike | str:
     """Creates a new path with the subset and split names.
     e.g., create_subset_name('gs://thisserver/testfolder-a982374', 'subset', 'train') -> 'gs://thisserver/testfolder-a982374/subset/train'
@@ -261,6 +290,36 @@ def get_dataset_tasks(cfg: TransformSFTDatasetConfig):
         raise ValueError("Transform configuration must include `source` pointing to the HF dataset id.")
     revision = unwrap_versioned_value(cfg.revision)
     configured_splits = unwrap_versioned_value(cfg.splits)
+    source_files_by_split = unwrap_versioned_value(cfg.source_files_by_split) or {}
+
+    if source_files_by_split:
+        configured_subsets = unwrap_versioned_value(cfg.subsets)
+        subsets = configured_subsets or [None]
+        if len(subsets) != 1 or subsets[0] not in (None, "default"):
+            raise ValueError("source_files_by_split only supports a single default subset.")
+
+        splits = list(configured_splits) if configured_splits else sorted(source_files_by_split)
+        missing = sorted(set(splits) - set(source_files_by_split))
+        if missing:
+            raise ValueError(f"No source files configured for split(s) {missing} in dataset {source}.")
+
+        subset = subsets[0]
+        subset_name = subset or "default"
+        for split in splits:
+            subset_output_path = get_shard_dir(cfg.output_path, subset_name, split)
+            output_path = create_shard_output_directory(subset_output_path)
+            for source_file_idx, source_file in enumerate(source_files_by_split[split]):
+                yield RawFileTask(
+                    source=source,
+                    revision=revision,
+                    subset=subset,
+                    split=split,
+                    source_file=source_file,
+                    source_file_idx=source_file_idx,
+                    output_path=output_path,
+                    cfg=cfg,
+                )
+        return
 
     # 1. Get available subsets
     subsets = _get_available_subsets(cfg)
@@ -363,6 +422,69 @@ def process_shard_task(task: ShardTask) -> dict:
     }
 
 
+def process_raw_file_task(task: RawFileTask) -> dict:
+    """Process one raw JSONL source file into batched transformed shards."""
+    adapter = unwrap_versioned_value(task.cfg.adapter).copy()
+
+    subset_name = task.subset or "default"
+    source_url = _raw_source_url(task.source, task.revision, task.source_file)
+    raw_shard_size = unwrap_versioned_value(task.cfg.raw_shard_size)
+    if raw_shard_size <= 0:
+        raise ValueError("raw_shard_size must be positive.")
+
+    input_count = 0
+    output_count = 0
+    filtered_count = 0
+    shard_idx = 0
+    shard_files: list[dict[str, Any]] = []
+    batch: list[dict[str, Any]] = []
+
+    def flush_batch() -> None:
+        nonlocal batch, output_count, shard_idx
+        if not batch:
+            return
+        output_filename = _raw_shard_filename(task.output_path, task.source_file_idx, shard_idx)
+        result = write_jsonl_file(batch, output_filename)
+        shard_files.append(result)
+        output_count += result["count"]
+        shard_idx += 1
+        batch = []
+
+    for raw_row in load_jsonl(source_url):
+        input_count += 1
+        transformed_row = transform_row(raw_row, task.cfg, adapter)
+        if transformed_row is None:
+            filtered_count += 1
+            continue
+        batch.append(transformed_row.model_dump())
+        if len(batch) >= raw_shard_size:
+            flush_batch()
+    flush_batch()
+
+    logger.info(
+        f"Wrote {output_count} rows from {source_url} into {len(shard_files)} shard(s) "
+        f"for subset={subset_name} split={task.split}"
+    )
+
+    return {
+        "subset": subset_name,
+        "split": task.split,
+        "source_file": task.source_file,
+        "source_file_idx": task.source_file_idx,
+        "paths": [file_info["path"] for file_info in shard_files],
+        "count": output_count,
+        "input_count": input_count,
+        "filtered_count": filtered_count,
+        "num_output_shards": len(shard_files),
+    }
+
+
+def process_dataset_task(task: ShardTask | RawFileTask) -> dict:
+    if isinstance(task, RawFileTask):
+        return process_raw_file_task(task)
+    return process_shard_task(task)
+
+
 @draccus.wrap()
 def transform_hf_dataset(cfg: TransformSFTDatasetConfig):
     """Transform HuggingFace conversation dataset using shard-level parallelism.
@@ -386,7 +508,7 @@ def transform_hf_dataset(cfg: TransformSFTDatasetConfig):
     metrics_path = os.path.join(cfg.output_path, "metrics")
     pipeline = (
         Dataset.from_list(all_tasks)
-        .map(process_shard_task)
+        .map(process_dataset_task)
         .write_jsonl(f"{metrics_path}/{{shard:05d}}-transform.jsonl", skip_existing=True)
     )
     ctx = ZephyrContext(name="transform-conversation")
@@ -402,9 +524,17 @@ def transform_hf_dataset(cfg: TransformSFTDatasetConfig):
     for (subset, split), shard_results in sorted(by_subset_split.items()):
         total_count = sum(r["count"] for r in shard_results)
         logger.info(f"Wrote {total_count} records to {len(shard_results)} shards ({subset}/{split})")
-        for shard in sorted(shard_results, key=lambda x: x["shard_idx"]):
-            skipped_suffix = " (skipped)" if shard.get("skipped") else ""
-            logger.info(f"  - {shard['path']}: {shard['count']} records (shard {shard['shard_idx']}){skipped_suffix}")
+        for shard in sorted(shard_results, key=lambda x: (x.get("source_file_idx", -1), x.get("shard_idx", -1))):
+            if "paths" in shard:
+                logger.info(
+                    f"  - {shard['source_file']}: {shard['count']} records "
+                    f"across {shard['num_output_shards']} output shard(s)"
+                )
+            else:
+                skipped_suffix = " (skipped)" if shard.get("skipped") else ""
+                logger.info(
+                    f"  - {shard['path']}: {shard['count']} records " f"(shard {shard['shard_idx']}){skipped_suffix}"
+                )
 
     return cfg.output_path
 

--- a/tests/test_instruction_datasets.py
+++ b/tests/test_instruction_datasets.py
@@ -1,9 +1,11 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import dataclasses
+
 from marin.execution.executor import unwrap_versioned_value
 from marin.transform.conversation.adapters import InputDatasetFormat
-from marin.transform.conversation.transform_conversation import transform_row
+from marin.transform.conversation.transform_conversation import RawFileTask, get_dataset_tasks, transform_row
 
 from experiments.posttrain.instruction_datasets import (
     FINEPROOFS_SFT_METADATA_COLUMNS,
@@ -22,6 +24,74 @@ SYNTHETIC2_SFT_VERIFIED_SAMPLE = {
     "messages": [
         {"role": "user", "content": "Write Python code to count the intersection of two sets."},
         {"role": "assistant", "content": "<think>Use set intersection.</think>\n```python\nprint(len(a & b))\n```"},
+    ],
+}
+
+NEMOTRON_COMPETITIVE_PYTHON_SAMPLE = {
+    "uuid": "python-1",
+    "used_in": ["sft"],
+    "license": "cc-by-4.0",
+    "dataset": "open-r1/codeforces",
+    "split": "train",
+    "index": 123,
+    "source": "codeforces",
+    "difficulty": "1800",
+    "question_id": "cf-1",
+    "messages": [
+        {"role": "user", "content": "Solve the programming problem in Python."},
+        {
+            "role": "assistant",
+            "content": "print('accepted')",
+            "reasoning_content": "We need an O(n log n) implementation.",
+        },
+    ],
+}
+
+NEMOTRON_COMPETITIVE_CPP_SAMPLE = {
+    "uuid": "cpp-1",
+    "used_in": ["sft"],
+    "license": "cc-by-4.0",
+    "dataset": "open-r1/codeforces",
+    "split": "train",
+    "index": 456,
+    "source": "codeforces",
+    "difficulty": "2200",
+    "question_id": "cf-2",
+    "messages": [
+        {"role": "user", "content": "Solve the programming problem in C++."},
+        {
+            "role": "assistant",
+            "content": "#include <bits/stdc++.h>\nint main() {}",
+            "reasoning_content": "Use sorting and binary search.",
+        },
+    ],
+}
+
+NEMOTRON_EXERCISM_SAMPLE = {
+    "uuid": "exercism-1",
+    "used_in": ["sft"],
+    "license": "mit",
+    "messages": [
+        {"role": "system", "content": "You are editing a repository."},
+        {"role": "user", "content": "Implement the exercise."},
+        {"role": "assistant", "content": "Updated the solution files."},
+    ],
+}
+
+NEMOTRON_TEXT_TO_SQL_SAMPLE = {
+    "uuid": "sql-1",
+    "used_in": ["sft"],
+    "license": "cc-by-4.0",
+    "complexity": "hard",
+    "dialect": "postgresql",
+    "messages": [
+        {"role": "system", "content": "You write SQL."},
+        {"role": "user", "content": "Count paid invoices by customer."},
+        {
+            "role": "assistant",
+            "content": "SELECT customer_id, count(*) FROM invoices WHERE paid GROUP BY customer_id;",
+            "reasoning_content": "Filter paid invoices before grouping by customer.",
+        },
     ],
 }
 
@@ -69,6 +139,97 @@ def test_get_instruction_dataset_preserves_fineproofs_config():
     assert unwrap_versioned_value(proof_only_cfg.metadata_columns) == FINEPROOFS_SFT_METADATA_COLUMNS
     assert unwrap_versioned_value(proof_only_cfg.adapter).dataset_format == InputDatasetFormat.INSTRUCTION_RESPONSE
     assert proof_only_step.name == "documents/lm-provers/FineProofs-SFT/proof-only"
+
+
+def test_nemotron_competitive_v2_steps_plan_raw_jsonl_and_transform_samples(tmp_path):
+    cases = {
+        "competitive_coding_python": {
+            "sample": NEMOTRON_COMPETITIVE_PYTHON_SAMPLE,
+            "source_files": [
+                "data/competitive_programming_python_00.jsonl",
+                "data/competitive_programming_python_01.jsonl",
+            ],
+            "expected_metadata": {
+                "uuid": "python-1",
+                "used_in": ["sft"],
+                "license": "cc-by-4.0",
+                "dataset": "open-r1/codeforces",
+                "split": "train",
+                "index": 123,
+                "source": "codeforces",
+                "difficulty": "1800",
+                "question_id": "cf-1",
+            },
+            "expected_reasoning": "We need an O(n log n) implementation.",
+        },
+        "competitive_coding_cpp": {
+            "sample": NEMOTRON_COMPETITIVE_CPP_SAMPLE,
+            "source_files": [
+                "data/competitive_programming_cpp_00.jsonl",
+                "data/competitive_programming_cpp_01.jsonl",
+            ],
+            "expected_metadata": {
+                "uuid": "cpp-1",
+                "used_in": ["sft"],
+                "license": "cc-by-4.0",
+                "dataset": "open-r1/codeforces",
+                "split": "train",
+                "index": 456,
+                "source": "codeforces",
+                "difficulty": "2200",
+                "question_id": "cf-2",
+            },
+            "expected_reasoning": "Use sorting and binary search.",
+        },
+        "exercism": {
+            "sample": NEMOTRON_EXERCISM_SAMPLE,
+            "source_files": ["data/exercism.jsonl"],
+            "expected_metadata": {
+                "uuid": "exercism-1",
+                "used_in": ["sft"],
+                "license": "mit",
+            },
+            "expected_reasoning": None,
+        },
+        "text_to_sql": {
+            "sample": NEMOTRON_TEXT_TO_SQL_SAMPLE,
+            "source_files": ["data/text_to_sql.jsonl"],
+            "expected_metadata": {
+                "uuid": "sql-1",
+                "used_in": ["sft"],
+                "license": "cc-by-4.0",
+                "complexity": "hard",
+                "dialect": "postgresql",
+            },
+            "expected_reasoning": "Filter paid invoices before grouping by customer.",
+        },
+    }
+
+    for split_name, case in cases.items():
+        dataset_key = f"nvidia/Nemotron-SFT-Competitive-Programming-v2/{split_name}"
+        step = get_instruction_dataset(dataset_key)
+        cfg = dataclasses.replace(step.config, output_path=str(tmp_path / split_name))
+        adapter = unwrap_versioned_value(cfg.adapter)
+
+        tasks = list(get_dataset_tasks(cfg))
+        assert len(tasks) == len(case["source_files"])
+        assert all(isinstance(task, RawFileTask) for task in tasks)
+        assert all(task.split == split_name for task in tasks)
+        assert [task.source_file for task in tasks] == case["source_files"]
+
+        result = transform_row(case["sample"], cfg, adapter)
+
+        assert result is not None
+        assert result.source == "nvidia/Nemotron-SFT-Competitive-Programming-v2"
+        assert result.metadata == case["expected_metadata"]
+        assert [message.role for message in result.messages] == [
+            message["role"] for message in case["sample"]["messages"]
+        ]
+        assistant_message = result.messages[-1].model_dump()
+        if case["expected_reasoning"] is None:
+            assert "reasoning_content" not in assistant_message
+        else:
+            assert assistant_message["reasoning_content"] == case["expected_reasoning"]
 
 
 def test_synthetic2_sft_verified_step_transforms_chat_rows():

--- a/tests/transform/test_conversation.py
+++ b/tests/transform/test_conversation.py
@@ -3,15 +3,20 @@
 
 """Tests for conversation data transformation scripts."""
 
+import json
 from pathlib import Path
 
 from marin.transform.conversation.adapters import InputDatasetFormat, TransformAdapter
 from marin.transform.conversation.conversation_to_dolma import transform_conversation_to_dolma
 from marin.transform.conversation.preference_data_adapters import PreferenceTransformAdapter
 from marin.transform.conversation.transform_conversation import (
+    RawFileTask,
     TransformSFTDatasetConfig,
+    create_shard_output_directory,
+    process_raw_file_task,
     transform_row,
 )
+from zephyr import load_jsonl
 
 OPENAI_FORMAT_SAMPLE = {
     "messages": [
@@ -121,6 +126,51 @@ class TestTransformAdapters:
         assert messages[0].content == "Explain quantum computing"
         assert messages[1].role == "assistant"
         assert messages[2].role == "system"
+
+    def test_multi_turn_adapter_copies_selected_message_keys(self):
+        """Test preserving opt-in extra message fields."""
+        row = {
+            "messages": [
+                {"role": "user", "content": "Solve this."},
+                {
+                    "role": "assistant",
+                    "content": "Final answer.",
+                    "reasoning_content": "Think through the cases.",
+                    "unlisted": "drop me",
+                },
+            ]
+        }
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+            message_keys_to_copy=("reasoning_content",),
+        )
+
+        messages = adapter.transform_conversation_to_openai_format(row)
+
+        assert messages is not None
+        assert "reasoning_content" not in messages[0].model_dump()
+        assistant_message = messages[1].model_dump()
+        assert assistant_message["reasoning_content"] == "Think through the cases."
+        assert "unlisted" not in assistant_message
+
+    def test_multi_turn_adapter_drops_unlisted_message_keys_by_default(self):
+        """Test current default behavior remains unchanged."""
+        row = {
+            "messages": [
+                {"role": "user", "content": "Solve this."},
+                {
+                    "role": "assistant",
+                    "content": "Final answer.",
+                    "reasoning_content": "Think through the cases.",
+                },
+            ]
+        }
+        adapter = TransformAdapter(dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN)
+
+        messages = adapter.transform_conversation_to_openai_format(row)
+
+        assert messages is not None
+        assert "reasoning_content" not in messages[1].model_dump()
 
 
 class TestTransformRow:
@@ -243,6 +293,64 @@ class TestTransformRow:
         }
 
         assert transform_row(row, cfg, adapter) is None
+
+    def test_raw_file_task_batches_jsonl_rows_and_preserves_reasoning_content(self, tmp_path):
+        """Test raw JSONL fallback processing without using the HF dataset builder."""
+        raw_file = tmp_path / "input.jsonl"
+        rows = [
+            {
+                "uuid": "row-1",
+                "messages": [
+                    {"role": "user", "content": "Write Python."},
+                    {"role": "assistant", "content": "print(1)", "reasoning_content": "Need to print one."},
+                ],
+            },
+            {
+                "uuid": "row-2",
+                "messages": [
+                    {"role": "user", "content": "Write C++."},
+                    {"role": "assistant", "content": "int main() {}", "reasoning_content": "Need a main."},
+                ],
+            },
+        ]
+        raw_file.write_text("\n".join(json.dumps(row) for row in rows) + "\n")
+
+        adapter = TransformAdapter(
+            dataset_format=InputDatasetFormat.SINGLE_COLUMN_MULTI_TURN,
+            message_keys_to_copy=("reasoning_content",),
+        )
+        cfg = TransformSFTDatasetConfig(
+            source="test/raw",
+            revision="main",
+            output_path=str(tmp_path / "output"),
+            metadata_columns=["uuid"],
+            adapter=adapter,
+            splits=["train"],
+            source_files_by_split={"train": [str(raw_file)]},
+            raw_shard_size=1,
+        )
+        output_path = create_shard_output_directory(str(tmp_path / "output" / "train"))
+        task = RawFileTask(
+            source="test/raw",
+            revision="main",
+            subset=None,
+            split="train",
+            source_file=str(raw_file),
+            source_file_idx=0,
+            output_path=output_path,
+            cfg=cfg,
+        )
+
+        result = process_raw_file_task(task)
+
+        assert result["input_count"] == 2
+        assert result["count"] == 2
+        assert result["filtered_count"] == 0
+        assert result["num_output_shards"] == 2
+        records = [record for output_file in result["paths"] for record in load_jsonl(output_file)]
+        assert [record["metadata"]["uuid"] for record in records] == ["row-1", "row-2"]
+        assert records[0]["messages"][1]["reasoning_content"] == "Need to print one."
+        assert records[1]["messages"][1]["reasoning_content"] == "Need a main."
 
 
 class TestPreferenceDataTransform:


### PR DESCRIPTION
Register Nemotron Competitive v2 as split-specific SFT sources for Python competitive programming, C++ competitive programming, Exercism, and Text-to-SQL. The dataset ships raw JSONL files whose inferred Hugging Face builder schema can drop fields such as reasoning_content, so the conversation transform now has an explicit raw JSONL file-list path that streams through Zephyr and writes batched transformed shards.

Add opt-in message-key preservation to the multi-turn adapter so reasoning_content survives for code and SQL reasoning traces without changing existing datasets by default. Existing output-path hashes continue to ignore the empty default adapter option, while raw-file datasets include their source file mapping in the transform hash.