### PR TITLE
[iris] Raise default per-worker assignment cap to 4

### DIFF
--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -85,6 +85,13 @@ logger = logging.getLogger(__name__)
 # Sentinel for dry-run scheduling with per-worker limits disabled.
 _UNLIMITED = sys.maxsize
 
+# Reservation placements advance one claimed worker per cycle, independent of
+# the (higher) non-reservation packing cap. Each claim is one reserved slot, so
+# packing several reservation tasks onto the first claimed worker would anchor
+# reserved capacity on one worker while the other claimed workers sit tainted
+# but unused.
+_MAX_RESERVATION_PLACEMENTS_PER_WORKER_PER_CYCLE = 1
+
 
 # Taint attribute injected onto claimed workers to prevent non-reservation
 # jobs from landing on them.  Non-reservation jobs get a NOT_EXISTS constraint
@@ -1025,7 +1032,7 @@ def preference_pass(
             if parent is not None:
                 claim_key = parent.to_wire()
         for wid in claimed_by_job.get(claim_key, ()):
-            if context.assignment_counts.get(wid, 0) >= context.max_assignments_per_worker:
+            if context.assignment_counts.get(wid, 0) >= _MAX_RESERVATION_PLACEMENTS_PER_WORKER_PER_CYCLE:
                 continue
             capacity = context.capacities.get(wid)
             if capacity is None:

--- a/lib/iris/src/iris/cluster/controller/scheduling/scheduler.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/scheduler.py
@@ -44,12 +44,17 @@ can overwhelm the worker. This limit provides back-pressure by deferring new
 task assignments until existing tasks complete their build phase.
 """
 
-DEFAULT_MAX_ASSIGNMENTS_PER_WORKER = 1
+DEFAULT_MAX_ASSIGNMENTS_PER_WORKER = 4
 """Default limit for task assignments per worker per scheduling cycle.
 
-Set to 1 for normal scheduling (round-robin distribution). Dry-run demand
-estimation raises this to an effectively unlimited value so a big worker
-with spare CPU can absorb multiple tasks, preventing false demand signals.
+Caps how many new tasks a worker absorbs in a single cycle so load still
+spreads across fresh workers, but allows enough packing that small tasks
+co-locate instead of each triggering a new VM. A cap of 1 scattered tiny
+CPU tasks one-per-VM (a 2-vCPU VM took one 1-vCPU task per cycle, and the
+autoscaler added VMs for the rest), leaving VMs half-used and unreclaimable.
+Dry-run demand estimation raises this to an effectively unlimited value so a
+big worker with spare CPU can absorb multiple tasks, preventing false demand
+signals.
 """
 
 

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -1124,9 +1124,9 @@ def test_preference_pass_deducts_capacity():
     job_id = JobName.root("test-user", "res-job")
     task_id_0 = job_id.task(0)
     task_id_1 = job_id.task(1)
-    # Each task wants 4000m CPU; w1 has 8000m, so only one fits.
+    # Each task wants 5000m CPU; w1 has 8000m, so only one fits by capacity.
     req = JobRequirements(
-        req_cpu_millicores=4000,
+        req_cpu_millicores=5000,
         req_memory_bytes=1024**3,
         req_gpu_count=0,
         req_tpu_count=0,
@@ -1146,7 +1146,7 @@ def test_preference_pass_deducts_capacity():
 
     assignments = preference_pass(context, has_reservation, claims)
 
-    # First task assigned to w1; second stays pending (w1 already scheduled this cycle)
+    # First task consumes w1's capacity; the second no longer fits and stays pending.
     assert len(assignments) == 1
     assert assignments[0] == (task_id_0, WorkerId("w1"))
     assert task_id_0 not in context.pending_tasks

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -1153,6 +1153,39 @@ def test_preference_pass_deducts_capacity():
     assert task_id_1 in context.pending_tasks
 
 
+def test_preference_pass_advances_one_claimed_worker_per_cycle():
+    """Reservation placements spread one-per-claimed-worker, not packed onto the first.
+
+    Each claim is a reserved slot on a distinct worker. Even though both 1-CPU
+    tasks fit on a single 8-CPU worker by capacity (so the raised non-reservation
+    packing cap would allow stacking), preference_pass must advance one claimed
+    worker per cycle so reserved capacity is not anchored on one worker while
+    other claimed workers sit tainted but unused.
+    """
+    w1 = _make_worker("w1")
+    w2 = _make_worker("w2")
+    job_id = JobName.root("test-user", "res-job")
+    task_id_0 = job_id.task(0)
+    task_id_1 = job_id.task(1)
+    req = _make_job_requirements()
+    has_reservation = {job_id}
+    claims = {
+        WorkerId("w1"): ReservationClaim(job_id=job_id.to_wire(), entry_idx=0),
+        WorkerId("w2"): ReservationClaim(job_id=job_id.to_wire(), entry_idx=1),
+    }
+
+    context = _build_context_with_workers(
+        [w1, w2],
+        pending_tasks=[task_id_0, task_id_1],
+        jobs={job_id: req},
+    )
+
+    assignments = preference_pass(context, has_reservation, claims)
+
+    assert len(assignments) == 2
+    assert {wid for _, wid in assignments} == {WorkerId("w1"), WorkerId("w2")}
+
+
 # =============================================================================
 # _find_reservation_ancestor
 # =============================================================================

--- a/lib/iris/tests/cluster/controller/test_scheduler.py
+++ b/lib/iris/tests/cluster/controller/test_scheduler.py
@@ -8,6 +8,8 @@ job requirements) and returns outputs (assignments). It does not dispatch tasks,
 modify state, or run threads.
 """
 
+from collections import Counter
+
 import pytest
 from iris.cluster.constraints import AttributeValue, WellKnownAttribute
 from iris.cluster.controller import ops, reads
@@ -274,22 +276,28 @@ def test_scheduler_returns_empty_when_no_workers(scheduler, state):
     assert len(result.assignments) == 0
 
 
-def test_scheduler_round_robins_tasks_across_workers(scheduler, state):
-    """Verify scheduler distributes tasks across workers instead of packing one worker."""
+def test_scheduler_packs_up_to_assignment_cap_then_spills(scheduler, state):
+    """A worker absorbs up to max_assignments_per_worker new tasks per cycle, then spills.
+
+    With ``DEFAULT_MAX_ASSIGNMENTS_PER_WORKER`` > 1, small tasks co-locate on a
+    worker (so they don't each trigger a new VM) up to the cap, after which load
+    spills to the next worker. Here all six 1-CPU tasks fit on a single 10-CPU
+    worker by capacity, so only the per-cycle cap limits stacking.
+    """
     register_worker(state, "w1", "addr1", make_worker_metadata(cpu=10, memory_bytes=10 * 1024**3))
     register_worker(state, "w2", "addr2", make_worker_metadata(cpu=10, memory_bytes=10 * 1024**3))
-    register_worker(state, "w3", "addr3", make_worker_metadata(cpu=10, memory_bytes=10 * 1024**3))
 
-    submit_job(state, "j1", make_job_request(cpu=2))
-    submit_job(state, "j2", make_job_request(cpu=2))
-    submit_job(state, "j3", make_job_request(cpu=2))
+    for i in range(6):
+        submit_job(state, f"j{i}", make_job_request(cpu=1))
 
-    result = schedule_until_done(scheduler, state)
+    context = _build_context(scheduler, state)
+    result = scheduler.find_assignments(context)
 
-    # All 3 tasks assigned, each to a different worker (round-robin)
-    assert len(result.assignments) == 3
-    assigned_worker_ids = {worker_id for _, worker_id in result.assignments}
-    assert len(assigned_worker_ids) == 3
+    assert len(result.assignments) == 6
+    per_worker = Counter(worker_id for _, worker_id in result.assignments)
+    # One worker fills to the cap; the remainder spills to the second worker.
+    assert max(per_worker.values()) == DEFAULT_MAX_ASSIGNMENTS_PER_WORKER
+    assert len(per_worker) == 2
 
 
 def test_scheduler_assigns_multiple_tasks_to_single_worker(scheduler, state):
@@ -2070,10 +2078,10 @@ def test_dedup_many_tasks_of_one_job_schedule_in_one_cycle(state):
 
     result = sched.find_assignments(context)
 
-    # Default max_assignments_per_worker=1: each worker takes exactly one task.
+    # All replicas place in a single cycle; per-worker stacking is bounded by the cap.
     assert len(result.assignments) == num_workers
-    assigned_workers = {worker_id for _, worker_id in result.assignments}
-    assert len(assigned_workers) == num_workers, "each worker should receive exactly one task"
+    per_worker = Counter(worker_id for _, worker_id in result.assignments)
+    assert max(per_worker.values()) <= DEFAULT_MAX_ASSIGNMENTS_PER_WORKER
 
 
 def test_dedup_excess_tasks_remain_pending_when_workers_saturated(state):
@@ -2104,10 +2112,12 @@ def test_dedup_excess_tasks_remain_pending_when_workers_saturated(state):
 
     result = sched.find_assignments(context)
 
-    # Workers cap at one assignment/cycle, so we get num_workers placements.
-    assert len(result.assignments) == num_workers
-    # One placement per worker.
-    assert len({wid for _, wid in result.assignments}) == num_workers
+    # Workers cap at max_assignments_per_worker/cycle, so one cycle places
+    # num_workers * cap tasks and the rest stay pending.
+    assert len(result.assignments) == num_workers * DEFAULT_MAX_ASSIGNMENTS_PER_WORKER
+    per_worker = Counter(wid for _, wid in result.assignments)
+    assert len(per_worker) == num_workers
+    assert all(c == DEFAULT_MAX_ASSIGNMENTS_PER_WORKER for c in per_worker.values())
 
 
 def test_dedup_unfittable_job_does_not_block_other_jobs(state):
@@ -2176,17 +2186,21 @@ def test_dedup_reservation_pinned_worker_respected_for_later_tasks(scheduler, st
 
     context = _build_context(sched, state)
 
-    # Simulate a reservation pre-pass having pinned worker w0 to one assignment
-    # before find_assignments runs (this is what _run_scheduler_pass phase 4 does).
-    context.assignment_counts[WorkerId("w0")] = 1
-    context.capacities[WorkerId("w0")].deduct(next(iter(context.jobs.values())))
+    # Simulate a reservation pre-pass having pinned worker w0 up to its per-cycle
+    # cap before find_assignments runs (this is what _run_scheduler_pass phase 4
+    # does). w0 is now full for the cycle and must be skipped for later tasks.
+    req = next(iter(context.jobs.values()))
+    context.assignment_counts[WorkerId("w0")] = DEFAULT_MAX_ASSIGNMENTS_PER_WORKER
+    for _ in range(DEFAULT_MAX_ASSIGNMENTS_PER_WORKER):
+        context.capacities[WorkerId("w0")].deduct(req)
 
     result = sched.find_assignments(context)
 
-    # Of the 10 pending tasks, only w1 and w2 are still open this cycle.
-    assert len(result.assignments) == 2
-    assigned_workers = {worker_id for _, worker_id in result.assignments}
-    assert assigned_workers == {WorkerId("w1"), WorkerId("w2")}
+    # w0 is at its cap, so only w1 and w2 absorb tasks this cycle, each up to the cap.
+    assert len(result.assignments) == 2 * DEFAULT_MAX_ASSIGNMENTS_PER_WORKER
+    per_worker = Counter(worker_id for _, worker_id in result.assignments)
+    assert set(per_worker) == {WorkerId("w1"), WorkerId("w2")}
+    assert all(c == DEFAULT_MAX_ASSIGNMENTS_PER_WORKER for c in per_worker.values())
 
 
 def test_gpu_job_matches_worker_with_config_variant(scheduler, state):

--- a/lib/iris/tests/cluster/controller/test_scheduler.py
+++ b/lib/iris/tests/cluster/controller/test_scheduler.py
@@ -2056,7 +2056,11 @@ def test_mixed_variant_cluster_many_jobs_all_scheduled(state):
 
 
 def test_dedup_many_tasks_of_one_job_schedule_in_one_cycle(state):
-    """One job with many replicas places one task per worker in a single cycle."""
+    """One job with many replicas places all of them in a single cycle.
+
+    Per-worker stacking may go up to the per-cycle assignment cap; the invariant
+    under test is that the dedup fast-path schedules every replica in one cycle.
+    """
     sched = Scheduler(max_building_tasks_per_worker=1000)
     num_workers = 50
 

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -1212,11 +1212,11 @@ def test_worker_can_accept_new_task_after_previous_completes(state):
 
 
 def test_multiple_small_tasks_fill_worker_capacity(state):
-    """E2E: Multiple small tasks can fill a worker's capacity, blocking further assignments.
+    """E2E: cumulative resource usage across tasks fills a worker and blocks the rest.
 
-    This verifies that the scheduler correctly tracks cumulative resource usage across
-    multiple running tasks. With round-robin scheduling, each worker gets at most one
-    task per cycle, so we run multiple cycles to fill capacity.
+    Verifies the scheduler tracks committed CPU across tasks: a 4-CPU worker takes
+    two 2-CPU tasks (capacity-limited, within the per-cycle assignment cap), and the
+    third does not fit and stays pending.
     """
 
     # Worker with 4 CPUs
@@ -1228,23 +1228,15 @@ def test_multiple_small_tasks_fill_worker_capacity(state):
 
     scheduler = Scheduler()
 
-    # First scheduling cycle: 1 task assigned (round-robin: 1 per worker per cycle)
+    # One cycle fills the worker to capacity: two 2-CPU tasks on 4 CPUs.
     context = _build_scheduling_context(scheduler, state)
     result = scheduler.find_assignments(context)
-    assert len(result.assignments) == 1
+    assert len(result.assignments) == 2
     for task_id, worker_id in result.assignments:
         task = _query_task(state, task_id)
         dispatch_task(state, task, worker_id)
 
-    # Second scheduling cycle: 1 more task assigned (worker still has 2 CPUs)
-    context = _build_scheduling_context(scheduler, state)
-    result = scheduler.find_assignments(context)
-    assert len(result.assignments) == 1
-    for task_id, worker_id in result.assignments:
-        task = _query_task(state, task_id)
-        dispatch_task(state, task, worker_id)
-
-    # Third task should still be pending
+    # Third task remains pending: the worker is out of CPU.
     pending = _schedulable_tasks(state)
     assert len(pending) == 1
     assert pending[0].job_id == JobName.root("test-user", "j2")


### PR DESCRIPTION
The scheduler caps new task assignments per worker per cycle at DEFAULT_MAX_ASSIGNMENTS_PER_WORKER. With the cap at 1, small CPU tasks scattered one-per-VM: a 2-vCPU VM took a single 1-vCPU task per scheduling cycle, and between cycles the autoscaler spun up fresh VMs that first-fit then preferred over the half-used one. The result was a pile of underutilized, unreclaimable VMs in the cpu_vm_e2_highmem_2_ondemand group (e.g. lone 1-vCPU distill-driver tasks each sitting on their own 2-vCPU VM).

Raise the default to 4 so small tasks co-locate up to the cap before load spills to the next worker, while large fan-out jobs still spread across workers. Dry-run demand estimation is unaffected (it already uses an effectively unlimited cap).

Update the scheduler, reservation, and transition tests that encoded the old one-per-cycle behavior to assert the cap-bounded packing instead. The reservation and transition cases now make capacity the binding constraint so they stay deterministic regardless of the cap value.