### PR TITLE
[lint] Strip trailing whitespace in lint-review SKILL.md

### DIFF
--- a/.agents/skills/lint-review/SKILL.md
+++ b/.agents/skills/lint-review/SKILL.md
@@ -7,8 +7,8 @@ allowed-tools: Bash(./infra/pre-commit.py:*), Bash(gh pr comment:*), Bash(gh pr 
 # Skill: Lint-catalog review on a PR
 
 Run the `infra/lint/` catalog review (`./infra/pre-commit.py --review`)
-over a pull request's branch diff and surface every finding — as `file:line` 
-inline review comments where the finding's line is available, and as a 
+over a pull request's branch diff and surface every finding — as `file:line`
+inline review comments where the finding's line is available, and as a
 single fallback comment for the rest.
 
 ## Your contract


### PR DESCRIPTION
The marin-lint --all-files job fails on trailing whitespace at lines 10-11 of .agents/skills/lint-review/SKILL.md (introduced in #6268), which blocks every PR branched off current main. Strip the trailing whitespace so CI is green again.