### PR TITLE
[skills] Make commit skill PR-monitoring a mandatory loop

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -161,7 +161,7 @@ gh pr create --title "<title>" --body "<plain text body>" --label agent-generate
 - Never credit yourself in commits or PR descriptions.
 - Include `Fixes #NNNN` when addressing a pre-existing issue.
 
-### 9. Monitor the PR — mandatory, in a loop
+## 9. Monitor the PR — mandatory, in a loop
 
 Opening the PR does not end your turn. You MUST monitor until the PR is merged or
 closed, or the user tells you to stop. A summary message to the user is NOT a
@@ -173,9 +173,13 @@ CI duration (e.g. ~120–270s while checks run, longer once green and idle). Onl
 stop scheduling when an exit condition below is met.
 
 Each poll, check **both**:
-1. **CI status** — `gh pr checks <N>`. On failure, read the failing job log, fix,
-   commit, push. A failure in a file you did not touch is pre-existing — say so and
-   handle per the unrelated-changes rule; do not silently absorb it.
+1. **CI status** — `gh pr checks <N>`. On failure, read the failing job log and
+   fix it. A failure in a file you did not touch is NOT automatically pre-existing:
+   first check whether the same job fails on `main` without your change (or whether
+   your change altered an API, config, or behavior that breaks that caller/test). If
+   your change caused it — even in an untouched file — it is your regression; fix it.
+   Only call it pre-existing once you have confirmed it fails on `main` independently,
+   then handle per the unrelated-changes rule. Never silently absorb a failure.
 2. **New comments and reviews** — `gh api repos/<owner>/<repo>/pulls/<N>/comments`
    and `.../reviews`, plus `gh pr view <N> --json comments`. CI being green does
    NOT mean there is nothing to do — review bots and humans comment after CI

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -67,7 +67,9 @@ of this work.
   (`[iris]`, `[zephyr]`, `[docs]`, …).
 - **Body** (optional, blank-line separated): what changed and why — the context a
   reviewer needs. Keep it short and readable.
-- No emoji, no markdown, no bullets in the subject. Do not credit yourself.
+- No emoji, no markdown, no bullets in the subject. Do not credit yourself —
+  this includes any `Co-Authored-By: Claude`/`Generated with` trailer. Omit it
+  even if a harness default suggests adding one.
 
 Create the commit. If a pre-commit hook fails, fix the issue and make a **new**
 commit — never amend (unless the user asks) and never force-push.

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -167,10 +167,11 @@ Opening the PR does not end your turn. You MUST monitor until the PR is merged o
 closed, or the user tells you to stop. A summary message to the user is NOT a
 substitute for monitoring and is NOT an exit condition.
 
-Drive the loop yourself — do not just check once. After each poll, schedule the
-next one with `ScheduleWakeup` (or the `loop` skill), picking the delay to match
-CI duration (e.g. ~120–270s while checks run, longer once green and idle). Only
-stop scheduling when an exit condition below is met.
+Drive the loop yourself — do not just check once. While CI runs, block on it with
+`gh pr checks <N> --watch --fail-fast` instead of re-polling. Once CI is green,
+switch to `ScheduleWakeup` polling for comments/reviews/merge with exponential
+backoff (e.g. 270s, doubling, capped at the 1h `ScheduleWakeup` max), giving up
+after ~4h idle. Only stop early when an exit condition below is met.
 
 Each poll, check **both**:
 1. **CI status** — `gh pr checks <N>`. On failure, read the failing job log and

--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -160,12 +160,35 @@ gh pr create --title "<title>" --body "<plain text body>" --label agent-generate
 - Always add the `agent-generated` label.
 - Never credit yourself in commits or PR descriptions.
 - Include `Fixes #NNNN` when addressing a pre-existing issue.
-- You must monitor PR status after creation if you have the ability (via a monitor skill or automation update and the `gh` CLI).
-- Address CI failures, apply fixes, and repush. Continue monitoring.
-- Respond to both human and agent comments: address obvious comments directly and resolve
-  them. If you are unsure, prepare a report with your analysis of the remaining comments and
-  your proposed action and present it to the local user.
-- Continue monitoring until instructed otherwise, or the PR is merged.
+
+### 9. Monitor the PR — mandatory, in a loop
+
+Opening the PR does not end your turn. You MUST monitor until the PR is merged or
+closed, or the user tells you to stop. A summary message to the user is NOT a
+substitute for monitoring and is NOT an exit condition.
+
+Drive the loop yourself — do not just check once. After each poll, schedule the
+next one with `ScheduleWakeup` (or the `loop` skill), picking the delay to match
+CI duration (e.g. ~120–270s while checks run, longer once green and idle). Only
+stop scheduling when an exit condition below is met.
+
+Each poll, check **both**:
+1. **CI status** — `gh pr checks <N>`. On failure, read the failing job log, fix,
+   commit, push. A failure in a file you did not touch is pre-existing — say so and
+   handle per the unrelated-changes rule; do not silently absorb it.
+2. **New comments and reviews** — `gh api repos/<owner>/<repo>/pulls/<N>/comments`
+   and `.../reviews`, plus `gh pr view <N> --json comments`. CI being green does
+   NOT mean there is nothing to do — review bots and humans comment after CI
+   passes. Never declare the PR done on CI status alone.
+
+Respond to every human and agent comment: address obvious ones directly (commit
+the fix, then reply, prefixing agent replies with `🤖`) and resolve them. For
+comments you are unsure about, report your analysis and proposed action to the
+user — but keep monitoring while you wait.
+
+Exit conditions (the only ways to stop the loop): the PR is merged or closed, or
+the user explicitly tells you to stop. Blocking on a user question pauses for the
+answer; it does not end monitoring.
 
 ## Rules
 


### PR DESCRIPTION
The post-PR monitoring guidance in the commit skill was a passive standing instruction ("continue monitoring until merged"), with no mechanism. In practice agents check CI once, post a summary to the user, and stop — missing review comments that arrive after CI passes.

Rewrite it as an explicit step 9: opening the PR does not end the turn; drive a poll loop with ScheduleWakeup/loop; each poll check both CI status and new comments/reviews (green CI is not a done signal); respond to and resolve comments; only stop when the PR is merged/closed or the user says so.