### PR TITLE
[lint] Fix pyrefly errors on main

### DIFF
--- a/lib/levanter/src/levanter/callbacks/labeled_eval.py
+++ b/lib/levanter/src/levanter/callbacks/labeled_eval.py
@@ -129,7 +129,7 @@ def cb_labeled_lm_evaluate(
     prefix: str = "labeled_eval",
     eval_current: bool = True,
     eval_model: bool = True,
-    mp: jmp.Policy = None,
+    mp: jmp.Policy | None = None,
 ) -> Callable[[StepInfo], None]:
     """Build a training callback for periodic labeled LM loss evaluation."""
     evaluator = LabeledEvaluator.for_labeled_examples(

--- a/lib/levanter/src/levanter/main/train_lm.py
+++ b/lib/levanter/src/levanter/main/train_lm.py
@@ -4,6 +4,7 @@
 import dataclasses
 import gc
 import logging
+import os
 from dataclasses import dataclass, field
 from typing import Optional
 

--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -25,7 +25,7 @@ import shutil
 import tempfile
 import time
 from enum import StrEnum
-from typing import Any, Protocol, runtime_checkable
+from typing import Any, Protocol, cast, runtime_checkable
 
 import fsspec
 import jinja2
@@ -198,8 +198,9 @@ def _make_jinja_env(extensions: list[type]) -> jinja2.Environment:
         lstrip_blocks=True,
         extensions=extensions,
     )
-    env.globals["raise_exception"] = _raise_chat_template_exception
-    env.globals["strftime_now"] = lambda fmt: time.strftime(fmt)
+    env_globals = cast(dict[str, Any], env.globals)
+    env_globals["raise_exception"] = _raise_chat_template_exception
+    env_globals["strftime_now"] = lambda fmt: time.strftime(fmt)
     return env
 
 

--- a/lib/marin/src/marin/evaluation/trace_labeled_eval.py
+++ b/lib/marin/src/marin/evaluation/trace_labeled_eval.py
@@ -431,10 +431,11 @@ def _completed_dataset_count(results: dict[str, object]) -> int:
 def _completed_dataset_metrics(results: dict[str, object]) -> dict[str, float]:
     metrics: dict[str, float] = {}
     for dataset_result in _dataset_results(results).values():
-        if not _is_completed_dataset_result(dataset_result):
+        if not isinstance(dataset_result, Mapping):
             continue
-        dataset_metrics = dataset_result["metrics"]
-        assert isinstance(dataset_metrics, Mapping)
+        dataset_metrics = dataset_result.get("metrics")
+        if not isinstance(dataset_metrics, Mapping):
+            continue
         for metric_name, metric_value in dataset_metrics.items():
             if not isinstance(metric_name, str):
                 raise ValueError(f"Trace labeled eval metric names must be strings, got {metric_name!r}")


### PR DESCRIPTION
Repair the pyrefly failures currently blocking the main lint workflow. The fix restores the missing import in LM training, makes the labeled eval mixed-precision policy explicitly nullable, gives Jinja global mutation a type pyrefly accepts, and narrows completed trace eval metrics without relying on helper-predicate inference.