### PR TITLE
[ops] stop Claude CI workflows self-crediting and writing trivial tests

### DIFF
--- a/.github/workflows/ops-claude.yaml
+++ b/.github/workflows/ops-claude.yaml
@@ -58,6 +58,14 @@ jobs:
 
       - name: Run Claude Code
         id: claude
+        # Author commits as the repo's canonical bot identity (see
+        # .github/workflows/README.md) rather than claude[bot]: these env vars
+        # take precedence over the action's git config for any git-driven commit.
+        env:
+          GIT_AUTHOR_NAME: "github-actions[bot]"
+          GIT_AUTHOR_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "github-actions[bot]"
+          GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
@@ -70,8 +78,9 @@ jobs:
           claude_args: |
             --model opus
             --max-turns 250
+            --settings '{"attribution":{"commit":"","pr":""}}'
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"
-            --system-prompt "Always read and follow the guidelines in AGENTS.md before starting work. You always have the ability to commit and push your changes. Use your MCP tools if available, falling back to git and gh (which you have authorization for) if needed. Before submitting any changes: 1) Run ./infra/pre-commit.py --all-files --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results)."
+            --system-prompt "Read and follow AGENTS.md (especially its Testing section) and .agents/skills/commit/SKILL.md before starting. Commit and push with git and gh (you are authorized); the github-actions[bot] commit identity is preset via git environment variables, so prefer git for commits and avoid the GitHub MCP commit tools, which attribute commits to claude[bot]. NEVER credit yourself: no 'Co-Authored-By: Claude' or 'Generated with Claude Code' trailer in commits, and no self-attribution in PR descriptions. NEVER write tautological, trivial, or slop tests: a test must fail when behavior is wrong, not merely when the code changes; never add a test for a thin wrapper, a one-off script, or just to have one; if a change does not warrant a meaningful test, add none. Before submitting any changes: 1) Run ./infra/pre-commit.py --all-files --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results)."
 
   triage:
     if: |
@@ -105,6 +114,14 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Triage Issue
+        # Author commits as the repo's canonical bot identity (see
+        # .github/workflows/README.md) rather than claude[bot]: these env vars
+        # take precedence over the action's git config for any git-driven commit.
+        env:
+          GIT_AUTHOR_NAME: "github-actions[bot]"
+          GIT_AUTHOR_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "github-actions[bot]"
+          GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
@@ -158,6 +175,21 @@ jobs:
               do NOT open a PR. Instead, update your comment with root cause analysis, relevant code links,
               and a proposed approach for a human to review before implementation begins.
 
+            ## Tests and attribution (critical)
+
+            Follow the Testing section of AGENTS.md. NEVER write tautological,
+            trivial, or slop tests: a test must fail when the behavior is wrong,
+            not merely when the implementation changes. Do not add a test for a
+            thin wrapper around a library call, for a one-off script, or just to
+            have a test. If a change does not warrant a meaningful test, add none.
+
+            NEVER credit yourself. Do not add a "Co-Authored-By: Claude" or
+            "Generated with Claude Code" trailer to commits, and do not
+            self-attribute in the PR description. Commit and push with git and gh
+            (the github-actions[bot] identity is preset via git environment
+            variables); avoid the GitHub MCP commit tools, which attribute commits
+            to claude[bot].
+
             ## PR format (critical)
 
             When opening a PR, you MUST follow .agents/skills/commit/SKILL.md exactly.
@@ -169,8 +201,9 @@ jobs:
             --model opus
             --max-turns 250
             --permission-mode acceptEdits
+            --settings '{"attribution":{"commit":"","pr":""}}'
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"
-            --system-prompt "You can commit and push changes. Use MCP tools if available, falling back to git and gh. Always commit and push, even if tests fail. Never post multiple comments — post one comment, then use --edit-last for all updates."
+            --system-prompt "Commit and push with git and gh (the github-actions[bot] identity is preset via git environment variables); avoid the GitHub MCP commit tools, which attribute commits to claude[bot]. NEVER credit yourself in commits or PRs (no 'Co-Authored-By: Claude' or 'Generated with Claude Code' trailer). NEVER write tautological or trivial tests — a test must fail when behavior is wrong; do not test thin wrappers or scripts just to have a test. Always commit and push, even if tests fail. Never post multiple comments — post one comment, then use --edit-last for all updates."
 
   autofix:
     if: |
@@ -204,6 +237,14 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Apply Autofix
+        # Author commits as the repo's canonical bot identity (see
+        # .github/workflows/README.md) rather than claude[bot]: these env vars
+        # take precedence over the action's git config for the git commit below.
+        env:
+          GIT_AUTHOR_NAME: "github-actions[bot]"
+          GIT_AUTHOR_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
+          GIT_COMMITTER_NAME: "github-actions[bot]"
+          GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
@@ -212,16 +253,26 @@ jobs:
             PR: #${{ github.event.pull_request.number }}
             REVIEW: ${{ github.event.review.body }}
 
-            A reviewer has requested autofix. Read AGENTS.md.
+            A reviewer has requested autofix. Read AGENTS.md (especially its
+            Testing section) and .agents/skills/commit/SKILL.md.
 
             1. Fetch the full review with inline comments: `gh pr view ${{ github.event.pull_request.number }} --json reviews,comments`
             2. Fetch inline PR review comments: `gh api repos/${{ github.repository }}/pulls/${{ github.event.pull_request.number }}/comments`
             3. Apply ALL actionable changes from the review comments to the code.
             4. Run ./infra/pre-commit.py --all-files --fix
             5. Run uv run pytest -m 'not slow' on affected tests
-            6. Commit and push changes to the PR branch
+            6. Commit and push changes to the PR branch with git (the
+               github-actions[bot] identity is preset via git environment
+               variables). NEVER credit yourself: no "Co-Authored-By: Claude" or
+               "Generated with Claude Code" trailer.
             7. Post a comment summarizing what was changed, prefixed with "🤖 Autofix:"
+
+            When a fix needs a regression test, write a meaningful one — never a
+            tautological, trivial, or slop test. A test must fail when the
+            behavior is wrong, not merely when the implementation changes; do not
+            test a thin wrapper or a script just to have a test.
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 100
+            --settings '{"attribution":{"commit":"","pr":""}}'
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"

--- a/.github/workflows/ops-claude.yaml
+++ b/.github/workflows/ops-claude.yaml
@@ -58,18 +58,14 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        # Author commits as the repo's canonical bot identity (see
-        # .github/workflows/README.md) rather than claude[bot]: these env vars
-        # take precedence over the action's git config for any git-driven commit.
-        env:
-          GIT_AUTHOR_NAME: "github-actions[bot]"
-          GIT_AUTHOR_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
-          GIT_COMMITTER_NAME: "github-actions[bot]"
-          GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'
+
+          # Empty attribution hides Claude Code's default "Co-Authored-By: Claude"
+          # / "Generated with Claude Code" trailers from commits and PR descriptions.
+          settings: '{"attribution":{"commit":"","pr":""}}'
 
           # This is an optional setting that allows Claude to read CI results on PRs
           additional_permissions: |
@@ -78,9 +74,8 @@ jobs:
           claude_args: |
             --model opus
             --max-turns 250
-            --settings '{"attribution":{"commit":"","pr":""}}'
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"
-            --system-prompt "Read and follow AGENTS.md (especially its Testing section) and .agents/skills/commit/SKILL.md before starting. Commit and push with git and gh (you are authorized); the github-actions[bot] commit identity is preset via git environment variables, so prefer git for commits and avoid the GitHub MCP commit tools, which attribute commits to claude[bot]. NEVER credit yourself: no 'Co-Authored-By: Claude' or 'Generated with Claude Code' trailer in commits, and no self-attribution in PR descriptions. NEVER write tautological, trivial, or slop tests: a test must fail when behavior is wrong, not merely when the code changes; never add a test for a thin wrapper, a one-off script, or just to have one; if a change does not warrant a meaningful test, add none. Before submitting any changes: 1) Run ./infra/pre-commit.py --all-files --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results)."
+            --system-prompt "Read and follow AGENTS.md (especially its Testing section) and .agents/skills/commit/SKILL.md before starting work. You always have the ability to commit and push your changes. Use your MCP tools if available, falling back to git and gh (which you have authorization for) if needed. NEVER credit yourself: no 'Co-Authored-By: Claude' or 'Generated with Claude Code' trailer in commits, and no self-attribution in PR descriptions. NEVER write tautological, trivial, or slop tests: a test must fail when behavior is wrong, not merely when the code changes; never add a test for a thin wrapper, a one-off script, or just to have one; if a change does not warrant a meaningful test, add none. Before submitting any changes: 1) Run ./infra/pre-commit.py --all-files --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results)."
 
   triage:
     if: |
@@ -114,18 +109,13 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Triage Issue
-        # Author commits as the repo's canonical bot identity (see
-        # .github/workflows/README.md) rather than claude[bot]: these env vars
-        # take precedence over the action's git config for any git-driven commit.
-        env:
-          GIT_AUTHOR_NAME: "github-actions[bot]"
-          GIT_AUTHOR_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
-          GIT_COMMITTER_NAME: "github-actions[bot]"
-          GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'
+          # Empty attribution hides Claude Code's default "Co-Authored-By: Claude"
+          # / "Generated with Claude Code" trailers from commits and PR descriptions.
+          settings: '{"attribution":{"commit":"","pr":""}}'
           additional_permissions: |
             actions: read
           prompt: |
@@ -185,10 +175,7 @@ jobs:
 
             NEVER credit yourself. Do not add a "Co-Authored-By: Claude" or
             "Generated with Claude Code" trailer to commits, and do not
-            self-attribute in the PR description. Commit and push with git and gh
-            (the github-actions[bot] identity is preset via git environment
-            variables); avoid the GitHub MCP commit tools, which attribute commits
-            to claude[bot].
+            self-attribute in the PR description.
 
             ## PR format (critical)
 
@@ -201,9 +188,8 @@ jobs:
             --model opus
             --max-turns 250
             --permission-mode acceptEdits
-            --settings '{"attribution":{"commit":"","pr":""}}'
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"
-            --system-prompt "Commit and push with git and gh (the github-actions[bot] identity is preset via git environment variables); avoid the GitHub MCP commit tools, which attribute commits to claude[bot]. NEVER credit yourself in commits or PRs (no 'Co-Authored-By: Claude' or 'Generated with Claude Code' trailer). NEVER write tautological or trivial tests — a test must fail when behavior is wrong; do not test thin wrappers or scripts just to have a test. Always commit and push, even if tests fail. Never post multiple comments — post one comment, then use --edit-last for all updates."
+            --system-prompt "You can commit and push changes. Use MCP tools if available, falling back to git and gh. NEVER credit yourself in commits or PRs (no 'Co-Authored-By: Claude' or 'Generated with Claude Code' trailer). NEVER write tautological or trivial tests — a test must fail when behavior is wrong; do not test thin wrappers or scripts just to have a test. Always commit and push, even if tests fail. Never post multiple comments — post one comment, then use --edit-last for all updates."
 
   autofix:
     if: |
@@ -237,18 +223,13 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Apply Autofix
-        # Author commits as the repo's canonical bot identity (see
-        # .github/workflows/README.md) rather than claude[bot]: these env vars
-        # take precedence over the action's git config for the git commit below.
-        env:
-          GIT_AUTHOR_NAME: "github-actions[bot]"
-          GIT_AUTHOR_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
-          GIT_COMMITTER_NAME: "github-actions[bot]"
-          GIT_COMMITTER_EMAIL: "41898282+github-actions[bot]@users.noreply.github.com"
         uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'
+          # Empty attribution hides Claude Code's default "Co-Authored-By: Claude"
+          # / "Generated with Claude Code" trailers from commits and PR descriptions.
+          settings: '{"attribution":{"commit":"","pr":""}}'
           prompt: |
             PR: #${{ github.event.pull_request.number }}
             REVIEW: ${{ github.event.review.body }}
@@ -261,10 +242,8 @@ jobs:
             3. Apply ALL actionable changes from the review comments to the code.
             4. Run ./infra/pre-commit.py --all-files --fix
             5. Run uv run pytest -m 'not slow' on affected tests
-            6. Commit and push changes to the PR branch with git (the
-               github-actions[bot] identity is preset via git environment
-               variables). NEVER credit yourself: no "Co-Authored-By: Claude" or
-               "Generated with Claude Code" trailer.
+            6. Commit and push changes to the PR branch. NEVER credit yourself:
+               no "Co-Authored-By: Claude" or "Generated with Claude Code" trailer.
             7. Post a comment summarizing what was changed, prefixed with "🤖 Autofix:"
 
             When a fix needs a regression test, write a meaningful one — never a
@@ -274,5 +253,4 @@ jobs:
           claude_args: |
             --model claude-sonnet-4-6
             --max-turns 100
-            --settings '{"attribution":{"commit":"","pr":""}}'
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"

--- a/infra/scripts/nightshift_ci_tests.py
+++ b/infra/scripts/nightshift_ci_tests.py
@@ -40,6 +40,12 @@ MIN_SLOW_SECONDS = 60.0
 # evidence of a real perf regression.
 MIN_SLOW_RUNS = 2
 
+# Suppress Claude Code's default "Co-Authored-By: Claude" / "Generated with
+# Claude Code" trailers on the commits and PRs the agent creates. AGENTS.md
+# forbids self-credit, and a prose instruction alone does not reliably override
+# the harness default — this setting does.
+NO_SELF_CREDIT_SETTINGS = ("--settings", '{"attribution":{"commit":"","pr":""}}')
+
 DURATION_RE = re.compile(r"(?P<seconds>\d+(?:\.\d+)?)s\s+(?:setup|call|teardown)\s+(?P<test>\S+::.+)$")
 FAILURE_RE = re.compile(r"(?:FAILED|ERROR)\s+(?P<test>\S+::.+?)(?:\s+-\s|$)")
 ANSI_RE = re.compile(r"\x1b\[[0-9;]*[A-Za-z]")
@@ -377,7 +383,8 @@ determine:
 Treat `unstable` as a hypothesis from log evidence, not a proven flake. Confirm
 against the code and test intent before changing behavior.
 
-Read `AGENTS.md` for project conventions.
+Read `AGENTS.md` (especially its Testing section) and
+`.agents/skills/commit/SKILL.md` for project conventions, and follow them.
 
 ## Rules of Engagement
 
@@ -393,6 +400,13 @@ Read `AGENTS.md` for project conventions.
 - Do not weaken assertions or mark a useful test `slow` just to hide a problem.
 - Do not remove a test unless you can defend why its coverage is redundant,
   invalid, or better expressed elsewhere.
+- Never write tautological, trivial, or "slop" tests. A test must fail when the
+  behavior is wrong, not merely when the implementation changes. Do not add a
+  test for a thin wrapper around a library call, for a one-off script, or just
+  to have a test. If a change does not warrant a meaningful test, add none.
+- Never credit yourself. Do not add a `Co-Authored-By: Claude` or "Generated
+  with Claude Code" trailer to commits, and do not self-attribute in the PR
+  description.
 - If you modify code or tests, run `./infra/pre-commit.py --all-files --fix`
   and run the relevant `uv run pytest ...` targets.
 
@@ -417,6 +431,7 @@ def run_agent(prompt: str, root: Path) -> None:
             "--model=opus",
             "--print",
             "--dangerously-skip-permissions",
+            *NO_SELF_CREDIT_SETTINGS,
             "--tools=Read,Write,Edit,Glob,Grep,Bash",
             "--max-turns",
             "400",

--- a/infra/scripts/nightshift_cleanup.py
+++ b/infra/scripts/nightshift_cleanup.py
@@ -17,6 +17,12 @@ logger = logging.getLogger(__name__)
 
 SUBPROJECTS = ["lib/marin/src/marin", "lib/iris/src/iris", "lib/zephyr/src/zephyr", "lib/levanter/src/levanter"]
 
+# Suppress Claude Code's default "Co-Authored-By: Claude" / "Generated with
+# Claude Code" trailers on the commits and PRs the agent creates. AGENTS.md
+# forbids self-credit, and a prose instruction alone does not reliably override
+# the harness default — this setting does.
+NO_SELF_CREDIT_SETTINGS = ("--settings", '{"attribution":{"commit":"","pr":""}}')
+
 SCOUT_PROMPT = """\
 You are a Nightshift Scout Agent assigned to: {subproject}
 
@@ -38,7 +44,8 @@ lint, not renaming, but a genuine code quality win. Look for things like:
 - Test issues: tests with no assertions, `time.sleep()` in tests, mocks of
   internal functions
 
-Read `AGENTS.md` for project conventions.
+Read `AGENTS.md` (especially its Testing section) and
+`.agents/skills/commit/SKILL.md` for project conventions, and follow them.
 
 ## Rules of Engagement
 
@@ -50,6 +57,12 @@ Read `AGENTS.md` for project conventions.
 - If you find issues but the fix is non-trivial, file a GitHub issue instead
   of making a risky change.
 - Keep changes focused: one coherent improvement per subproject.
+- Never write tautological, trivial, or "slop" tests. A test must fail when the
+  behavior is wrong, not merely when the implementation changes. Do not add a
+  test for a thin wrapper around a library call, for a one-off script, or just
+  to have a test. If a change does not warrant a meaningful test, add none.
+- Never credit yourself in commit messages: no `Co-Authored-By: Claude` or
+  "Generated with Claude Code" trailer.
 
 ## Output
 
@@ -97,6 +110,12 @@ Their results:
 
 The scout worktrees with their commits are at these paths:
 {worktree_info}
+
+## Conventions
+
+Read `AGENTS.md` and `.agents/skills/commit/SKILL.md`, and follow them for the
+PR. Never credit yourself: no `Co-Authored-By: Claude` or "Generated with Claude
+Code" trailer in commits, and no self-attribution in the PR description.
 
 ## Your Mission
 
@@ -175,6 +194,7 @@ def run_scout(subproject: str, worktree_path: Path) -> tuple[str, dict, str]:
             "--model=opus",
             "--print",
             "--dangerously-skip-permissions",
+            *NO_SELF_CREDIT_SETTINGS,
             "--tools=Read,Write,Edit,Glob,Grep,Bash",
             "--max-turns",
             "400",
@@ -216,6 +236,7 @@ def run_merge(date: str, haiku_seed: str, scout_results: list[dict], worktree_in
             "--model=opus",
             "--print",
             "--dangerously-skip-permissions",
+            *NO_SELF_CREDIT_SETTINGS,
             "--tools=Read,Write,Edit,Glob,Grep,Bash",
             "--max-turns",
             "200",

--- a/infra/scripts/nightshift_doc_drift.py
+++ b/infra/scripts/nightshift_doc_drift.py
@@ -6,6 +6,12 @@
 import argparse
 import subprocess
 
+# Suppress Claude Code's default "Co-Authored-By: Claude" / "Generated with
+# Claude Code" trailers on the commits and PRs the agent creates. AGENTS.md
+# forbids self-credit, and a prose instruction alone does not reliably override
+# the harness default — this setting does.
+NO_SELF_CREDIT_SETTINGS = ("--settings", '{"attribution":{"commit":"","pr":""}}')
+
 DOC_DRIFT_PROMPT = """\
 You are the Nightshift Doc Drift detector.
 
@@ -22,7 +28,10 @@ Sample a single subfolder of `docs/` to focus on. Use your random seed
 to pick one at random. If the chosen subfolder has fewer than 3 markdown
 files, expand to its parent.
 
-Read `AGENTS.md` for project conventions.
+Read `AGENTS.md` and `.agents/skills/commit/SKILL.md` for project conventions,
+and follow them. Never credit yourself: no `Co-Authored-By: Claude` or "Generated
+with Claude Code" trailer in commits, and no self-attribution in the PR or issue
+you open.
 
 ## Mission
 
@@ -74,7 +83,7 @@ If meaningful drift is found:
   4. Pick a reviewer by finding who has recently touched the files you changed.
      Use GitHub login names (NOT emails):
      ```
-     gh api '/repos/{owner}/{repo}/commits?path=<changed_file>&per_page=20' \
+     gh api '/repos/{{owner}}/{{repo}}/commits?path=<changed_file>&per_page=20' \
        --jq '.[].author.login' | grep -v '\\[bot\\]' | sort | uniq -c | sort -rn | head -5
      ```
      Pick the top human contributor and request their review:
@@ -103,6 +112,7 @@ def main() -> None:
             "--model=opus",
             "--print",
             "--dangerously-skip-permissions",
+            *NO_SELF_CREDIT_SETTINGS,
             "--tools=Read,Write,Edit,Glob,Grep,Bash",
             "--max-turns",
             "600",


### PR DESCRIPTION
PR #6283 (the @claude responder fixing a canary) shipped a tautological test for a one-line script wrapper and committed under a Claude self-credit, both against rules that AGENTS.md and the commit skill already state. The Claude CI workflows were enforcing those rules only through "read AGENTS.md" prose, which the model did not reliably follow. This moves enforcement to the workflow boundary, for the issue/PR comment workflow (ops-claude.yaml: the @claude responder, issue triage, and autofix jobs) and the three nightshift agents (CI-test audit, cleanup, doc drift).

Self-credit: every Claude invocation now disables attribution with {"attribution":{"commit":"","pr":""}}. An empty attribution string hides the byline in Claude Code, so this deterministically drops the default "Co-Authored-By: Claude" / "Generated with Claude Code" trailer the model adds on its own, in commit messages and in PR descriptions. The nightshift scripts pass it as --settings to the claude CLI; the ops-claude.yaml jobs pass it through the claude-code-action settings input, since the action is a composite action whose internal step shadows caller env and the settings input is the path that actually reaches the subprocess. Commit author identity is intentionally left alone — only the message and the description need to be clean.

Trivial tests: each prompt now points at .agents/skills/commit/SKILL.md alongside AGENTS.md and states the rule directly: never write tautological, trivial, or slop tests; a test must fail when behavior is wrong, not when the implementation changes; do not test a thin wrapper or a script just to have a test.

Latent bug: nightshift_doc_drift.py had single-braced {owner}/{repo} inside a str.format() template, so prompt construction raised KeyError('owner') on every run and the doc-drift agent never started. Escaped to {{owner}}/{{repo}}.

The write-capable ops-claude.yaml jobs only run on issue/comment/review events, so they cannot be exercised by this PR and must be validated on the next invocation after merge. The canary-failure triage action (.github/actions/claude-triage) can also write files and file issues; giving it the same treatment is a noted follow-up.