### PR TITLE
[iris] Plan record: tighten control boundaries for multi-backend readiness (complete)

### DIFF
--- a/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
+++ b/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
@@ -5,6 +5,13 @@ status: draft
 
 # Tighten Iris control boundaries (multi-backend readiness)
 
+> Revised after maintainer review. The chosen direction is sharper than the first
+> draft: **push placement/capacity logic into the backend** behind one uniform
+> interface (don't have the controller dispatch capabilities), **fold the autoscaler
+> and ping loops into a single control tick**, and **bound every call the controller
+> *dispatches into* a backend** (not the inbound service handlers). `cluster=` is a
+> **hard** constraint. The single-tick model is the target.
+
 ## Problem & goal
 
 The recent `TaskBackend` work pulled most backend specifics behind a contract, but
@@ -18,77 +25,71 @@ the control plane is still **loose** in five concrete ways:
 2. **Demand is computed twice.** The autoscaler does not consume the scheduler's
    output; it re-derives demand by running the scheduler a *second* time as a dry-run
    (`compute_demand_entries` → `scheduler.find_assignments`) against the shared mutable
-   `self._scheduler` on a *separate* snapshot. There is no synchronization boundary
-   between scheduler and autoscaler — they are two readers of the DB that happen to
-   agree most of the time.
-3. The `TaskBackend` contract is **one fat 13-method interface**. `K8sTaskProvider`
-   stubs out six of them (`schedule`/`manage_capacity`/`on_workers_failed`/`ping_workers`
-   return empty, `attach_autoscaler` raises `AssertionError`, `get_process_status`
-   raises `ProviderUnsupportedError`). Capability is tracked by two side-channel flags
-   (`placement`, `manages_capacity`) that can drift from which methods actually do work.
+   `self._scheduler` on a *separate* snapshot. No synchronization boundary exists between
+   scheduler and autoscaler — they are two readers of the DB that happen to agree most of
+   the time.
+3. The controller **dispatches on backend type/capability**. It branches on `placement`
+   (`controller.py:761/1092`) and `manages_capacity` (`1234`) to pick between a dispatch
+   loop and a reconcile loop, and `K8sTaskProvider` stubs six contract methods
+   (`tasks.py:1255-1269,1395,1404`). The controller "knows" how each backend works.
 4. The reconcile **result shape is backend-specific**: `BackendReconcileResult` carries
    *both* `updates` (K8s) and `worker_results` (RPC); the controller picks the field by
-   `placement` and runs different apply paths. The controller "knows" each backend's
-   encoding.
-5. RPCs are bounded by **thread count** (a 1024-thread executor) but **not by latency**.
-   The timing interceptor only *measures*; nothing enforces a deadline. `launch_job`
-   blocks a handler thread for up to 120 s; the three on-demand one-offs each
-   re-implement controller→backend→worker fan-out with three different timeout
-   conventions; `get_autoscaler_status` fans out to all workers with no cap;
-   `execute_raw_query` has no row/time limit.
+   `placement` and runs different apply paths.
+5. **Calls the controller dispatches into a backend are not uniformly bounded.** Reconcile
+   and ping fan out with a 10 s per-worker timeout and 128-way semaphore (good), but
+   `RpcTaskBackend.reconcile` runs `asyncio.run(...)` on the *caller* thread, so a slow
+   batch stalls whatever loop called it; and `exec_in_container` permits an RPC deadline
+   of **up to one hour** (`backend.py:232-237`). There is no single place that guarantees
+   "any call into a backend completes within a bound."
 
 **Long-term goal:** a *multi-backend* Iris — e.g. a GCP TPU cluster and a Slurm GPU
-cluster live simultaneously, jobs dispatched by a `cluster=` constraint. That future
-needs sharp boundaries *now*: the controller as a pure state/serialization layer, each
-backend exposing only the capabilities it actually has, a single demand artifact handed
-scheduler→autoscaler, and one bounded path for every RPC.
+cluster live simultaneously, jobs dispatched by a **hard `cluster=<name>` constraint**.
+That future needs the controller to be a pure state/serialization layer that calls **one
+uniform interface** on every backend and persists whatever DB-shaped deltas come back —
+never branching on which backend it is talking to.
 
 **What "done" looks like for this plan:** this document — a verified map of the current
-control flow, five targeted, independently-shippable improvements with concrete code
-shapes, and a feasibility analysis with a recommended landing sequence. Implementation
-is tracked as the task breakdown below.
+control flow, a target control flow, and five targeted improvements with concrete code
+shapes and a feasibility analysis with a recommended landing sequence. Implementation is
+tracked as the task breakdown below.
 
 ### What is already good (don't regress it)
-
-The audit confirmed the design is *decent*, not broken — these properties hold today and
-every improvement below must preserve them:
 
 - `Scheduler.find_assignments(context) -> SchedulingResult` is a **pure function**, zero
   runtime imports of controller state (`scheduling/scheduler.py`).
 - Both backends are **DB-clean**: neither `RpcTaskBackend` nor `K8sTaskProvider` imports
-  `db`/`reads`/`writes`/`schema`/`sqlalchemy`. Their imports of `controller.scheduling`/
-  `autoscaler`/`reconcile` are **types and pure logic only**.
-- Capability dispatch is **flag-based, never `isinstance`** (`placement`,
-  `manages_capacity` — `controller.py:761/1092/1234`).
+  `db`/`reads`/`writes`/`schema`/`sqlalchemy`. The `RpcTaskBackend` *already owns* its
+  `Scheduler` (`backend.py:141`) and `Autoscaler` (`backend.py:136`) — Improvement 3 just
+  finishes the job of making the controller stop orchestrating them.
+- Capability dispatch is **flag-based, never `isinstance`** today — but the goal is to
+  delete the flags entirely (Improvement 3).
 - The reconcile *kernel* (`reconcile/overlay|task|job|worker|effects`) is a **pure state
-  machine**; `reconcile/loader` → `snapshot` → kernel → `commit` is a clean
-  load→pure→write pipeline, and `writes.validate()` enforces projection-table ownership.
-- A single write `RLock` + `BEGIN IMMEDIATE` serializes all mutations; reads use a
-  separate `query_only` pool. Correctness is sound; the issue is *looseness and
-  duplication*, not races that corrupt state.
+  machine**; `loader → snapshot → kernel → commit` is a clean load→pure→write pipeline,
+  and `writes.validate()` enforces projection-table ownership.
+- Reconcile already fans out to **every active healthy worker**
+  (`reads.list_active_healthy_workers`, `controller.py:1017`); idle workers get an
+  empty-rows heartbeat reconcile — which is *why* the separate ping loop is now vestigial
+  (Improvement 1).
 
 ### Static dependency-graph findings (the coupling smells)
 
 Package-level import graph over `cluster/controller`, `cluster/backends`, `rpc`
 (edge = "imports", verified against code):
 
-- `controller.scheduling → {db, reads, projections, budget, worker_health}` — these are
-  all in `policy.py` (the DB **context-builder**), *not* `scheduler.py`. The boundary is
-  in the right place but lives in the same package as the pure scheduler, which obscures
-  it.
-- `controller.autoscaler → {db, schema, worker_health}` — the autoscaler reads the DB at
-  startup (`restore_from_db`) and re-derives demand per-cycle (see Improvement 2).
+- `controller.backend → {autoscaler, scheduling, reconcile, ops}` — the *contract* module
+  pulls in the scheduler and autoscaler, so "the backend abstraction" and "the
+  Iris-specific scheduling/capacity implementation" are tangled. Improvement 3 moves that
+  logic fully *inside* `RpcTaskBackend` so the contract carries only the uniform interface.
 - `backends.rpc → {controller.scheduling, controller.autoscaler, controller.reconcile}`
-  and `backends.k8s → {controller.backend, controller.reconcile, controller.autoscaler}`
-  — backends reach *up* into controller modules. Confirmed to be types/pure-logic only,
-  but it means the contract type (`controller/backend.py`) itself imports
-  `autoscaler`/`scheduling`/`reconcile` (fan-in: 7 modules depend on `controller.backend`).
-- `controller.backend → {autoscaler, scheduling, reconcile, ops}` — the *contract*
-  module pulls in the scheduler and autoscaler, so "the backend abstraction" and "the
-  Iris-specific scheduling/capacity implementation" are not cleanly separable. This is
-  what Improvement 3 untangles.
+  — backends reach *up* into controller modules; confirmed types/pure-logic only. After
+  Improvement 3 these become the backend's *own* internals, not shared contract surface.
+- `controller.scheduling → {db, reads, projections, budget}` — all in `policy.py` (the DB
+  context-builder), not `scheduler.py`. Improvement 4 routes the remaining raw queries
+  through `reads.py` so the controller's snapshot build is the single DB fan-out point.
+- `controller.autoscaler → {db, schema, worker_health}` — startup `restore_from_db` +
+  per-cycle re-derivation; the latter is deleted by Improvement 2.
 
-## Architecture (current control flow)
+## Architecture — current control flow
 
 ```mermaid
 flowchart TB
@@ -96,13 +97,10 @@ flowchart TB
     classDef pure fill:#e1f0ff,stroke:#2980b9,color:#000;
     classDef store fill:#f5f0d8,stroke:#7f8c8d,color:#000;
 
-    subgraph SVC["Service RPCs — 1024-thread executor, NO per-call deadline"]
+    subgraph DISP["Controller -> backend calls (NOT uniformly bounded)"]
         direction TB
-        R1["launch_job<br/>blocks a handler thread up to 120s<br/>draining the predecessor job"]:::problem
-        R2["get_/list_ status reads<br/>(bounded, via reads.py)"]
-        R3["profile_task / exec_in_container / get_process_status<br/>3 near-identical backend fan-outs, 3 timeout conventions"]:::problem
-        R4["get_autoscaler_status<br/>unbounded worker liveness fan-out"]:::problem
-        R5["execute_raw_query<br/>no row / statement-time limit"]:::problem
+        R3["profile_task / exec_in_container / get_process_status<br/>3 fan-outs, 3 timeout conventions; exec allows ~1h deadline"]:::problem
+        R4["reconcile / ping fan-out<br/>10s/worker + 128 sem, but asyncio.run blocks the caller loop"]:::problem
     end
 
     subgraph CTRL["Controller — owns SQLite + single write RLock; 7 independent ManagedThreads"]
@@ -110,7 +108,7 @@ flowchart TB
         L1["scheduling loop<br/>~10s adaptive backoff + wake"]
         L2["polling / reconcile loop<br/>5s + wake (IRIS placement)"]
         L3["dispatch loop<br/>5s (TASK_BACKEND only)"]
-        L4["ping loop — 5s"]
+        L4["ping loop — 5s (vestigial: reconcile already reaches all workers)"]:::problem
         L5["autoscaler loop<br/>10s (only if !manages_capacity)"]
         L6["prune — 600s WAL / 3600s full"]
         L7["checkpoint — optional"]
@@ -124,101 +122,144 @@ flowchart TB
         ASP["Autoscaler<br/>evaluate/route/plan = PURE · execute = cloud ops"]:::pure
     end
 
-    subgraph BK["TaskBackend — single 13-method contract"]
-        RPCB["RpcTaskBackend<br/>placement=IRIS_CONTROLLER"]
-        K8S["K8sTaskProvider<br/>placement=TASK_BACKEND<br/>stubs 6 methods (empty / raise)"]:::problem
+    subgraph BK["TaskBackend — single 13-method contract; controller branches on type"]
+        RPCB["RpcTaskBackend (IRIS)<br/>owns Scheduler + Autoscaler"]
+        K8S["K8sTaskProvider (TASK_BACKEND)<br/>stubs 6 methods (empty / raise)"]:::problem
     end
 
     L1 -->|"snapshot #1"| DB
     L1 --> SCH
     SCH -->|"assignments"| L1
-    L1 -->|"commit assignments / preemptions"| DB
+    L1 -->|"commit"| DB
 
     L5 -->|"snapshot #2"| DB
     L5 --> DEM
     DEM -.->|"dry-run find_assignments"| SCH
     L5 --> ASP
     ASP -->|"AutoscalerState"| L5
-    L5 -->|"commit slices / scaling_groups"| DB
+    L5 -->|"commit"| DB
 
     L2 -->|"snapshot"| DB
-    L2 --> RPCB
+    L2 --> R4
+    R4 --> RPCB
     RPCB -.->|"worker_results"| L2
-    L3 --> K8S
+    L3 --> R4
+    R4 --> K8S
     K8S -.->|"updates"| L3
     L2 -->|"commit"| DB
     L3 -->|"commit"| DB
-    L4 --> RPCB
+    L4 --> R4
 
     L6 --> DB
     L7 --> DB
-
-    R2 --> DB
-    R4 --> DB
     R3 --> BK
 
     L1 -.->|"⚠ demand skew (separate snapshot)"| L5
     L1 -.->|"⚠ snapshot skew"| L2
 ```
 
-Legend: **red** = looseness/duplication this plan targets; **blue** = already-pure
-components to preserve; the two dashed ⚠ edges are the cross-loop snapshot races.
+## Architecture — target control flow
+
+```mermaid
+flowchart TB
+    classDef good fill:#e1ffe1,stroke:#27ae60,color:#000;
+    classDef store fill:#f5f0d8,stroke:#7f8c8d,color:#000;
+
+    subgraph TICK["Control tick — ONE thread, ONE snapshot/tick"]
+        direction TB
+        S0["build snapshot (reads.py, one read txn)"]
+        S1["schedule phase (due ~10s)<br/>→ backend.schedule(snapshot)"]
+        S2["reconcile phase (every tick)<br/>→ backend.reconcile(desired+observed)"]
+        S3["commit uniform deltas (one write txn)"]
+        S0 --> S1 --> S2 --> S3
+    end
+
+    subgraph HK["Housekeeping threads (genuinely independent)"]
+        P["prune"]
+        C["checkpoint"]
+    end
+
+    DB[("Controller DB")]:::store
+
+    subgraph BD["BackendDispatch — every controller→backend call<br/>threadpool + hard per-call deadline"]
+        D["submit(call, deadline)"]
+    end
+
+    subgraph BK["Backends — UNIFORM interface; own their placement + capacity"]
+        RPCB["RpcTaskBackend<br/>schedule() = find_assignments → residual_demand<br/>→ autoscaler.update(residual) → DB-shaped deltas"]:::good
+        K8S["K8sTaskProvider<br/>Kueue places; pod diff → DB-shaped deltas"]:::good
+    end
+
+    S0 --> DB
+    S1 --> BD
+    S2 --> BD
+    BD --> RPCB
+    BD --> K8S
+    RPCB -->|"uniform deltas"| S3
+    K8S -->|"uniform deltas"| S3
+    S3 --> DB
+    P --> DB
+    C --> DB
+```
+
+Net thread count: **7 → 3** (one control tick + prune + checkpoint). The controller never
+branches on backend type; it builds a snapshot, calls the same interface on every backend,
+and persists whatever uniform deltas come back through one apply path.
 
 ## The five targeted improvements
 
-### I1 — Collapse the fast control loops into one phased "control tick"
+### I1 — One phased control tick; delete the autoscaler, ping, and dispatch threads
 
-**Problem.** Five fast loops (`scheduling`, `polling/reconcile`, `dispatch`, `ping`,
-`autoscaler`) each open an independent DB snapshot and commit independently
-(`controller.py:_run_scheduling`, `_reconcile_tick`, `_sync_dispatch`, `_run_ping_loop`,
-`_run_autoscaler_once`). This is the "loose threading" the goal calls out: the scheduler
-commits assignments that the reconciler's just-captured snapshot can't see, and the
-autoscaler snapshots demand *after* the scheduler already placed it.
+**Problem.** Five fast loops each open an independent snapshot and commit independently
+(`_run_scheduling`, `_reconcile_tick`, `_sync_dispatch`, `_run_ping_loop`,
+`_run_autoscaler_once`). The ping loop is vestigial — reconcile already reaches every
+active healthy worker (verified above). The dispatch loop is just "reconcile for
+TASK_BACKEND placement." The autoscaler loop re-snapshots state the scheduler just read.
 
-**Change.** One driver thread runs a fixed-order tick over **one snapshot per tick**:
+**Change.** One driver thread, one snapshot per tick, fixed phase order:
 
 ```
 control_tick(now):
-    snap = build_control_snapshot(db)          # ONE read txn -> typed snapshot
-    effects = Effects()
-    if schedule_phase.due(now):                 # IRIS placement only
-        effects += run_schedule(snap)           # pure
-    if capacity_phase.due(now):                 # !manages_capacity only
-        effects += run_capacity(snap, effects.residual_demand)   # consumes I2 output
-    effects += run_reconcile(snap)              # backend I/O (bounded, I5)
-    if health_phase.due(now):
-        effects += run_health(snap)             # ping / liveness (backend I/O)
+    snap = build_control_snapshot(db)          # ONE read txn via reads.py (I4)
+    deltas = Deltas()
+    if schedule_phase.due(now):                 # autoscaler folded in here (I2/I3)
+        deltas += backend.schedule(snap)        # backend owns placement + capacity
+    deltas += backend.reconcile(snap, deltas)   # bounded dispatch (I5); reaches all workers
+    deltas += derive_liveness(deltas)           # over-threshold terminations off reconcile errors
     with db.transaction() as tx:                # ONE write txn
-        commit(tx, effects)
+        commit(tx, deltas)                      # one uniform apply path (I3/I4)
 ```
 
-Per-phase `due(now)` predicates (a `RateLimiter` each) preserve the existing cadences
-(autoscale every ~10 s, ping every ~5 s) **without** a separate snapshot per phase. Wake
-events stop targeting individual loops; they just shorten the next tick deadline.
-`prune` and `checkpoint` stay as separate slow housekeeping threads — they are genuinely
-independent and must not block the control tick.
+Per-phase `due(now)` predicates (one `RateLimiter` each) preserve cadences (schedule/
+autoscale ~10 s, reconcile every tick ~5 s) **without** a separate snapshot per phase.
+Wake events just shorten the next tick deadline.
 
-**Serves:** poll-over-threading (#3); one snapshot fans out to DB-free abstractions (#1);
-and it is the structural enabler for the scheduler↔autoscaler sync boundary (#6).
+- **Drop the ping loop.** Reconcile contacts every active worker; fold ping's only unique
+  job — terminating workers past the failure threshold — onto reconcile-RPC errors
+  (`ReconcileResult.error` already exists; bump `WorkerHealthTracker`, terminate
+  over-threshold in the same tick). No idle-worker liveness gap.
+- **Drop the dispatch loop.** Unify it into the single reconcile phase (I3 makes the
+  reconcile input uniform across placements).
+- **Drop the autoscaler loop.** Folded into the schedule phase (I2).
+- **Keep** prune + checkpoint as separate slow housekeeping threads.
 
-**Risk:** highest blast radius of the five — it rewrites the loop architecture in
-`controller.py`. Mitigation: land it *after* I2 and I4 so each phase is already a clean
-`(snapshot) -> effects` function; the tick is then just an ordering shell over functions
-that already exist. The backend I/O phases (reconcile, ping) must be bounded (I5) so one
-slow backend can't stall the whole tick.
+**Serves:** poll over loose threading (#3); one snapshot fans out to DB-free abstractions
+(#1); strong scheduler↔autoscaler sync (#6).
 
-### I2 — Scheduler emits the demand model; autoscaler consumes it (delete the dry-run)
+**Risk:** highest blast radius. Land it *after* I2/I3/I4 so each phase is already a clean
+`(snapshot) -> deltas` call; the tick is then an ordering shell. Backend I/O must be
+bounded (I5) so a slow backend never stalls the tick. Ship behind a flag; bake on
+`marin-dev`. **Never bounce the live controller without explicit OK** (AGENTS.md).
 
-**Problem.** `compute_demand_entries` (`scheduling/policy.py:181`) runs a **full dry-run**
-`scheduler.find_assignments(context)` (`policy.py:283`) on a *second* read snapshot
-(`policy.py:221,255`), with building/assignment limits disabled, against the shared
-mutable `self._scheduler` — *unlocked* (`controller.py:1240-1245`). So placement logic
-runs twice per cycle through two code paths, and the autoscaler's demand can diverge from
-what the scheduler actually did. This is precisely the missing "strong synchronization
-boundary between scheduler & autoscaler."
+### I2 — Scheduler emits residual demand; autoscaler runs off it (one phase, no dry-run, no thread)
 
-**Change.** Make the **real** scheduling pass emit residual demand as a first-class
-output, so demand is computed exactly once and handed across a typed boundary:
+**Problem.** `compute_demand_entries` (`policy.py:181`) runs a **full dry-run**
+`scheduler.find_assignments` (`policy.py:283`) on a *second* snapshot, limits disabled,
+against the shared mutable `self._scheduler` — *unlocked* (`controller.py:1240-1245`). So
+placement runs twice per cycle through two paths on two snapshots.
+
+**Change.** The real scheduling pass emits residual demand as a first-class output, and
+the autoscaler consumes it **in the same phase** — no separate loop, no dry-run:
 
 ```python
 @dataclass(frozen=True)
@@ -226,254 +267,243 @@ class ScheduleResult:
     assignments: list[Assignment] = field(default_factory=list)
     preemptions: list[TerminalDecision] = field(default_factory=list)
     unschedulable: list[PendingTask] = field(default_factory=list)
-    # NEW: tasks that did not fit on existing capacity this tick, bucketed by
-    # requirement — the single source of truth for the autoscaler.
-    residual_demand: list[DemandEntry] = field(default_factory=list)
+    residual_demand: list[DemandEntry] = field(default_factory=list)   # NEW: single demand source
+    autoscaler_state: AutoscalerState | None = None                    # NEW: capacity delta, same call
     diagnostics: dict[str, str] = field(default_factory=dict)
     post_taint_context: SchedulingContext | None = None
 ```
 
 `find_assignments` already walks the per-worker capacity model; it computes
-`residual_demand` from the same traversal using **capacity-fit** semantics (what doesn't
-fit on existing/known capacity) while ignoring per-cycle *promotion* caps — so demand
-reflects saturation, not "what we declined to promote this tick." `compute_demand_entries`
-and its dry-run are **deleted**; `CapacityInput.demand_entries` is populated from
-`ScheduleResult.residual_demand` produced earlier in the same control tick (I1).
+`residual_demand` from the same traversal (capacity-fit, ignoring per-cycle *promotion*
+caps, matching today's `_UNLIMITED` dry-run). Inside `RpcTaskBackend.schedule` (I3) the
+flow becomes `find_assignments → residual_demand → autoscaler.refresh/probe/update(residual)
+→ persistable_state()`, returned as one delta set. `compute_demand_entries` and the
+autoscaler thread are **deleted**.
 
 **Serves:** one demand artifact across a typed boundary (#6); one way to compute demand
-(#5); removes a DB snapshot and the unlocked shared-scheduler access (#1).
+(#5); removes a snapshot and the unlocked shared-scheduler access (#1).
 
-**Risk:** medium — must reproduce the dry-run's reservation-taint and holder-task
-behavior (`inject_reservation_taints`, holder demand) inside the real pass. Ships
-independently of I1 (immediate win: kills the double-compute), but the *full* sync
-guarantee only lands once I1 makes the two phases share a snapshot.
+**Risk:** medium — must reproduce the dry-run's reservation-taint / holder-task demand in
+the real pass. Guard with a golden-fixture parity test before deleting the dry-run.
 
-### I3 — Segment the `TaskBackend` contract by capability (kill the stubs; ready multi-backend)
+### I3 — One uniform backend interface; push placement/capacity into the backend; controller dispatches only on returned deltas
 
-**Problem.** One 13-method contract forces `K8sTaskProvider` to stub six methods
-(`tasks.py:1255-1269,1395,1404` — empty results, `AssertionError`,
-`ProviderUnsupportedError`). Capability lives in two side-channel flags that can drift
-from which methods actually do work.
+**Problem.** The controller orchestrates backend specifics — it branches on `placement`
+and `manages_capacity`, calls `schedule`/`manage_capacity`/`reconcile`/`ping_workers` in a
+type-specific sequence, and reads a type-specific result field (`updates` vs
+`worker_results`). K8s stubs six methods.
 
-**Change.** Split the contract into composed capability protocols exposed as **optional
-sub-objects**, so capability is *structural* — a backend physically cannot offer an
-operation it doesn't implement:
+**Change.** Make the contract a single uniform interface that **every** backend
+implements, push all placement/capacity logic *inside* the backend, and have the
+controller persist whatever DB-shaped deltas come back — dispatching on the **delta type**,
+never the backend type:
 
 ```python
-class TaskBackend(Protocol):              # core — every backend
+class TaskBackend(Protocol):
     name: str
-    def reconcile(self, inp: BackendReconcileInput) -> BackendReconcileResult: ...
+    # Decide: place tasks + manage capacity for this cluster, over a DB-less snapshot.
+    # RpcTaskBackend runs the Iris scheduler + autoscaler internally; K8s lets Kueue place.
+    def schedule(self, snap: ControlSnapshot) -> BackendDeltas: ...
+    # Operate: drive the cluster toward desired state, observe actual state.
+    def reconcile(self, snap: ControlSnapshot, scheduled: BackendDeltas) -> BackendDeltas: ...
     def set_log_sink(self, ...) -> None: ...
     def close(self) -> None: ...
-    # Capability handles (None == not offered):
-    placement: "PlacementBackend | None"  # exposes schedule(...)
-    capacity:  "CapacityBackend | None"   # exposes manage_capacity / on_workers_failed
-                                          #         / ping_workers / attach_autoscaler
-    oneoffs:   "OneOffOps"                # status / profile / exec (I5)
 
-class PlacementBackend(Protocol):
-    def schedule(self, inp: ScheduleInput) -> ScheduleResult: ...
-
-class CapacityBackend(Protocol):
-    def manage_capacity(self, inp: CapacityInput) -> CapacityResult: ...
-    def on_workers_failed(self, ids: list[WorkerId]) -> WorkersFailedResult: ...
-    def ping_workers(self, w: list[tuple[WorkerId, str | None]]) -> list[PingResult]: ...
-```
-
-Controller dispatch becomes presence checks, not flags:
-`if backend.placement is not None: ...`, `if backend.capacity is not None: ...`. The
-`backend_descriptor` capability strings (`backend.py:101`) derive from sub-object
-presence. Every stub and `raise` is deleted. This is also the shape the multi-backend
-future needs: a `BackendRegistry` holding N heterogeneous backends, the controller
-iterating those exposing `placement`/`capacity`, routed by a `cluster=` constraint. It
-also lets the contract module stop importing the Iris `Scheduler`/`Autoscaler` (those
-move behind `PlacementBackend`/`CapacityBackend` implementations).
-
-**Serves:** controller stops "knowing" backend specifics (#2); structural single-way
-dispatch (#5); the direct enabler of multi-backend.
-
-**Risk:** large but mechanical — touches the contract type, both backends, and ~6
-controller call sites. Highest *churn*, lowest *conceptual* risk. Sequence: define
-protocols → adapt both backends → migrate call sites → delete `manages_capacity`/
-`placement`-flag branches.
-
-### I4 — One reconcile result shape + route the reconcile-input through `reads.py`
-
-**Problem (a).** `BackendReconcileResult` carries both `updates` (K8s) and
-`worker_results` (RPC); the controller picks the field by placement
-(`controller.py:778` vs `1104`) and runs different apply paths. The controller knows each
-backend's encoding.
-**Problem (b).** The reconcile-input snapshot (`_snapshot_reconcile_inputs`, the raw
-`task_attempts ⋈ tasks` join around `controller.py:1038-1059`) bypasses `reads.py`, the
-single DB chokepoint. (Same class of violation in `policy.py`, `budget.py`,
-`checkpoint.py`.)
-
-**Change (a).** Unify on the **raw-observation** shape (`worker_results`) as the single
-result type, and run **one** apply path. The controller already holds the DB snapshot, so
-uid-resolution / worker-loss interpretation stays controller-side (preserving backend
-DB-purity); K8s wraps its `TaskUpdate`s as already-resolved observations that flow through
-the *same* `apply_reconcile`. Collapse `BackendReconcileResult` to one field and delete
-the placement branch at apply time.
-
-```python
 @dataclass(frozen=True)
-class BackendReconcileResult:
-    observations: list[ReconcileObservation]   # ONE shape; controller resolves+applies uniformly
+class BackendDeltas:
+    """Everything the controller writes back to the DB this tick — a tagged union of
+    row-level changes the controller applies through one writes.py path. The controller
+    does not interpret backend internals: assignments, task-state observations, slice /
+    scaling-group state, endpoint changes. Empty fields = 'this backend has nothing here'
+    (e.g. K8s emits no autoscaler_state)."""
+    assignments: list[Assignment] = field(default_factory=list)
+    observations: list[ReconcileObservation] = field(default_factory=list)
+    preemptions: list[TerminalDecision] = field(default_factory=list)
+    autoscaler_state: AutoscalerState | None = None
+    ...
 ```
 
-**Change (b).** Move the reconcile-input join into a `reads.py` helper (or reuse
-`reconcile/loader.load_closed_snapshot`), and sweep the other raw-select sites behind
-`reads.py`, so `reads.py`/`writes.py` are the *only* modules issuing schema queries.
+- The controller stops importing/owning `Scheduler`/`Autoscaler`; they become
+  `RpcTaskBackend` internals (it already holds both — `backend.py:136,141`).
+- `placement` / `manages_capacity` flags and every branch on them are **deleted**. K8s
+  simply returns empty `assignments`/`autoscaler_state` from `schedule` because Kueue
+  places and the cluster autoscaler provisions — a real "nothing to add," not a stub/raise.
+- `BackendReconcileResult`'s two fields collapse into the one `observations` shape. The
+  small amount of uid-resolution that needs the snapshot is done by a **shared pure
+  resolver** the controller runs on `deltas.observations` before writing — so the backend
+  stays DB-less and the apply path is uniform (K8s observations pass through; RPC
+  observations resolve identically).
+- This is the multi-backend keystone: a `BackendRegistry` holds N backends; the controller
+  iterates them, calling the same `schedule`/`reconcile`, routed by the hard
+  `cluster=<name>` constraint (which backend a task is eligible for); deltas merge into one
+  commit.
 
-**Serves:** controller = state, backend = operation (#2); one way to apply reconcile
-results (#5); central DB queries fan out from a single chokepoint (#1).
+**Serves:** controller = state, backend = operation (#2); one interface, one result shape,
+one apply path (#5); the direct enabler of multi-backend.
 
-**Risk:** medium. (a) and (b) are independent and individually shippable. The subtlety in
-(a) is that worker-loss interpretation needs the snapshot — keep it controller-side; the
-backend returns observations, never resolved DB rows.
+**Risk:** largest churn (contract type + both backends + ~6 call sites), low conceptual
+risk. Sequence: define `BackendDeltas` + uniform `ControlSnapshot` input → move
+scheduler/autoscaler ownership into `RpcTaskBackend.schedule` → unify reconcile input/
+result → migrate controller call sites to the uniform calls → delete the flags.
 
-### I5 — Centralized RPC bounding: deadline interceptor + one bounded one-off path
+**Design decision (flag in open questions):** does the backend return *raw* observations
+(controller resolves — recommended, keeps resolution centralized near the DB) or
+*pre-resolved* deltas (backend resolves against the in-memory snapshot)? Recommend raw +
+shared resolver.
 
-**Problem.** The 1024-thread executor bounds *thread count*, not *latency*. The
-`RequestTimingInterceptor` only logs (`interceptors.py` — no `raise` on overrun).
-`launch_job` blocks ≤120 s inline (`service.py:1122`). The three on-demand one-offs
-(`get_process_status`/`profile_task`/`exec_in_container`) each re-implement
-controller→backend→worker fan-out with three timeout conventions (client-driven, none,
-K8s-only 60 s default). `get_autoscaler_status` fans out to all workers uncapped;
-`execute_raw_query` has no row/time limit.
+### I4 — `reads.py` is the single DB fan-out point feeding the uniform snapshot
 
-**Change.**
-1. **Server-side deadline interceptor** — every RPC runs under a hard wall-clock cap
-   (default e.g. 30 s, per-method override) by submitting the handler to the bounded
-   executor with a `future.result(timeout=...)` and returning `DEADLINE_EXCEEDED` on
-   overrun. One chokepoint where latency is capped.
-2. **De-block `launch_job`** — don't hold a handler thread for 120 s. Record the
-   drain/replace intent and return; the control tick (I1) completes the replacement and
-   the client polls job status. (Interim: cap the wait at the RPC deadline.)
-3. **One bounded one-off path** — fold the three one-offs into a single
-   `OneOffOps.run(target, op, deadline)` on the backend handle (I3), dispatched through a
-   dedicated **bounded** `ThreadPoolExecutor` with a hard per-call timeout — one timeout
-   convention, one fan-out pool, one `ProviderUnsupportedError`. `get_autoscaler_status`'s
-   liveness fan-out uses the same bounded pool.
-4. **Cap `execute_raw_query`** with a row limit + statement timeout.
+**Problem.** The reconcile-input snapshot (`_snapshot_reconcile_inputs`, raw
+`task_attempts ⋈ tasks` join, `controller.py:1038-1059`) bypasses `reads.py`, the intended
+DB chokepoint. Same class of violation in `policy.py`, `budget.py`, `checkpoint.py`. With
+I3, the controller's snapshot build becomes *the* place central DB queries fan out to the
+DB-free backends — so it must go through one chokepoint.
 
-**Serves:** all RPCs bounded + threadpool-dispatched + latency-capped (#4); one way for
-the on-demand one-offs (#5).
+**Change.** Build one typed `ControlSnapshot` per tick via `reads.py` helpers (reuse
+`reconcile/loader.load_closed_snapshot` where it fits), hand it to `backend.schedule` /
+`backend.reconcile`. Move the reconcile-input join and the other raw selects behind
+`reads.py` so `reads.py`/`writes.py`/projections are the **only** modules issuing schema
+queries.
 
-**Risk:** low–medium. (1) and (4) are small, high-value, and ship immediately. (3) pairs
-naturally with I3's `oneoffs` handle. (2) interacts with I1 (the tick finishes the
-drain) — until I1 lands, cap-the-wait is the safe interim.
+**Serves:** central DB queries fan out to DB-free abstractions from a single chokepoint
+(#1); supports the controller-as-serialization-layer goal.
+
+**Risk:** medium; independent of the others and individually shippable. Pairs naturally
+with I3 (the `ControlSnapshot` type is the backends' uniform input).
+
+### I5 — Bound every call the controller *dispatches into* a backend
+
+**Problem.** This is about the controller's **outbound** calls into backends, not inbound
+service handlers. Today reconcile/ping fan-out is per-call bounded (10 s/worker, 128-way
+semaphore) but `RpcTaskBackend.reconcile` runs `asyncio.run(...)` on the **caller** thread,
+so a slow batch blocks the whole tick; and `exec_in_container` allows an RPC deadline of
+**up to one hour** (`backend.py:232-237`). No single place guarantees a bound.
+
+**Change.** Route **every** controller→backend call through one `BackendDispatch`: a
+bounded `ThreadPoolExecutor` where each submission carries a **hard wall-clock deadline**
+(`future.result(timeout=cap)`), so:
+
+1. The **reconcile phase** gets a bounded result regardless of fleet size — workers that
+   don't answer by the deadline are surfaced as reconcile errors (which now drive liveness,
+   per I1), so a hung worker can never stall the tick.
+2. The **on-demand one-offs** (`profile_task` / `exec_in_container` / `get_process_status`)
+   go through the same dispatch with one timeout convention and one error path — the 1-hour
+   `exec` deadline is replaced by a hard cap (long-running exec/profile get an explicit,
+   bounded override, not "unlimited").
+3. `schedule`/`autoscale` (now in-process, in the backend) also run under the dispatch so a
+   pathological scheduling pass can't wedge the tick.
+
+**Serves:** any call into a backend completes in bounded time, threadpool-dispatched (#4);
+one bounded dispatch path for all backend ops (#5).
+
+**Risk:** low–medium. The deadline wrapper + executor is small; the care item is choosing
+caps (reconcile-phase cap vs per-worker timeout; explicit long caps for profile/exec).
 
 ## Constraint → improvement coverage
 
 | Constraint | Addressed by |
 |---|---|
-| Central DB queries fan out to DB-free abstractions | I1 (one snapshot/tick), I2 (single demand artifact), I4b (reads.py chokepoint) |
-| Controller handles state, backends handle operation | I3 (capability segregation), I4a (uniform result + apply) |
-| Prefer poll workflows vs loose threading | I1 (phased control tick) |
-| All RPCs bounded, threadpool-dispatched, latency-capped | I5 (deadline interceptor + bounded one-off pool) |
-| Only one way to do something | I2 (one demand path), I4 (one result shape), I5 (one one-off path) |
-| Strong sync boundary scheduler ↔ autoscaler | I1 (shared snapshot, phase order) + I2 (typed handoff) |
+| Central DB queries fan out to DB-free abstractions | I4 (one `reads.py` snapshot), I3 (backend takes snapshot, returns deltas), I2 (single demand artifact) |
+| Controller handles state, backends handle operation | I3 (uniform interface, logic pushed into backend, controller persists deltas) |
+| Prefer poll workflows vs loose threading | I1 (one control tick; drop autoscaler/ping/dispatch threads) |
+| Any controller→backend call completes in bounded time, threadpool-dispatched | I5 (BackendDispatch: pool + hard deadline) |
+| Only one way to do something | I3 (one interface + one result shape), I2 (one demand path), I5 (one dispatch path) |
+| Strong sync boundary scheduler ↔ autoscaler | I2 (autoscaler consumes scheduler's residual_demand in one phase) + I1 (shared snapshot) |
 
 ## Tasks
 
 Each task has a stable id. `exec: session` tasks become weaver issues on
-`weaver plan sync … --apply`. Ordered by the recommended landing sequence (see
-Feasibility), not by id.
+`weaver plan sync … --apply`. Ordered by recommended landing sequence.
 
-### T1 — I5a: server-side RPC deadline interceptor + cap raw query  `exec: session`  `value: high`  `deps: —`
-Add a deadline-enforcing interceptor (per-method cap, default ~30 s) that returns
-`DEADLINE_EXCEEDED` on overrun; add row limit + statement timeout to `execute_raw_query`.
-Smallest, safest, immediately caps tail latency. Acceptance: a handler that sleeps past
-its cap returns `DEADLINE_EXCEEDED`; raw query truncates at the row limit.
+### T1 — I5: BackendDispatch — bound every controller→backend call  `exec: session`  `value: high`  `deps: —`
+Introduce a bounded `ThreadPoolExecutor` dispatch with a hard per-call deadline; route
+reconcile/ping fan-out and the three one-offs through it; replace the 1-hour `exec`
+deadline with an explicit bounded cap. Acceptance: a hung worker RPC is surfaced as a
+reconcile error within the cap and never blocks the caller; `exec`/`profile` run under an
+explicit bounded deadline; no backend call path lacks a timeout.
 
-### T2 — I2: scheduler emits residual demand, delete the dry-run  `exec: session`  `value: high`  `deps: —`
-Add `residual_demand` to `ScheduleResult`, compute it in `find_assignments`, delete
-`compute_demand_entries`' dry-run, feed the autoscaler from the scheduler's output.
-Acceptance: autoscaler provisions identically on representative fixtures with the
-scheduler invoked once per cycle; no `scheduler.find_assignments` call remains in the
-autoscaler path.
+### T2 — I2: scheduler emits residual demand; autoscaler runs off it  `exec: session`  `value: high`  `deps: —`
+Add `residual_demand` (+ `autoscaler_state`) to the schedule output, compute residual in
+`find_assignments`, run the autoscaler off it in the schedule path, delete
+`compute_demand_entries`' dry-run. Acceptance: golden-fixture parity (same demand in/out)
+with the scheduler invoked once per cycle; no dry-run `find_assignments` remains.
 
-### T3 — I4: unify reconcile result shape + route reconcile-input via reads.py  `exec: session`  `value: medium`  `deps: —`
-Collapse `BackendReconcileResult` to one observation list with one apply path; move the
-reconcile-input join (and the policy/budget/checkpoint raw selects) behind `reads.py`.
-Acceptance: controller has a single apply path independent of placement; no schema query
-outside `reads.py`/`writes.py`/projections.
+### T3 — I4: one reads.py-built ControlSnapshot  `exec: session`  `value: medium`  `deps: —`
+Build a typed per-tick snapshot via `reads.py`; move the reconcile-input join and the
+policy/budget/checkpoint raw selects behind `reads.py`. Acceptance: no schema query
+outside `reads.py`/`writes.py`/projections; backends receive one snapshot type.
 
-### T4 — I3: segment TaskBackend into capability protocols  `exec: session`  `value: high`  `deps: T3`
-Define `PlacementBackend`/`CapacityBackend`/`OneOffOps`, expose as optional sub-objects,
-migrate controller call sites to presence checks, delete all K8s stubs and the
-`placement`/`manages_capacity` flag branches. Acceptance: no stub/`raise`-`NotImplemented`
-methods on any backend; `grep` finds no `manages_capacity`/`placement ==` branches in the
-controller; `backend_descriptor` derives capabilities from sub-object presence.
+### T4 — I3: uniform backend interface + BackendDeltas  `exec: session`  `value: high`  `deps: T2, T3`
+Define `BackendDeltas` + the uniform `schedule`/`reconcile(snapshot)` interface; move
+`Scheduler`/`Autoscaler` ownership into `RpcTaskBackend`; collapse the two reconcile-result
+fields via a shared pure resolver; migrate controller call sites to the uniform calls;
+delete `placement`/`manages_capacity` and every branch on them. Acceptance: `grep` finds no
+`placement ==`/`manages_capacity` branch in the controller and no stub/`raise`-Unsupported
+in any backend; controller commits via one apply path that dispatches on delta type only.
 
-### T5 — I5c: consolidate the three on-demand one-offs onto OneOffOps  `exec: session`  `value: medium`  `deps: T4`
-Fold `get_process_status`/`profile_task`/`exec_in_container` into one bounded
-`OneOffOps.run(target, op, deadline)` over a dedicated bounded pool; route
-`get_autoscaler_status` liveness through the same pool. Acceptance: one timeout
-convention, one `ProviderUnsupportedError` path; all three RPCs delegate to the shared op.
-
-### T6 — I1: collapse fast loops into one phased control tick  `exec: session`  `value: high`  `deps: T2, T3`
-Replace the five fast `ManagedThread` loops with one driver running
-snapshot → schedule → capacity → reconcile → health → commit, per-phase `due()` cadence,
-one snapshot/tick; keep prune/checkpoint separate. Acceptance: one control thread; one
-read snapshot + one write txn per tick (verified by a counter/test); cadences preserved;
-chaos/integration suite green.
+### T5 — I1: collapse the fast loops into one phased control tick  `exec: session`  `value: high`  `deps: T1, T2, T4`
+Replace the five fast loops with one driver: snapshot → schedule → reconcile → commit,
+per-phase `due()` cadence, one snapshot/tick; fold ping's over-threshold termination onto
+reconcile errors; keep prune/checkpoint separate. Acceptance: one control thread; one read
+snapshot + one write txn per tick (counter/test); no idle-worker liveness gap; cadences
+preserved; chaos/integration suite green; behind a fallback flag.
 
 ## Feasibility analysis
 
-**Overall: feasible and incremental.** None of the five requires a data-model change or a
-migration; all are refactors over an already-sound state layer. The pure scheduler,
-DB-clean backends, and flag-based (non-`isinstance`) dispatch that exist today are the
-foundation each improvement builds on.
+**Overall: feasible and incremental.** No data-model change or migration; all refactors
+over a sound state layer. The `RpcTaskBackend` already owns the scheduler and autoscaler,
+so I3 *relocates ownership* rather than rewriting logic, and I2 mostly deletes a duplicate
+path. The aggressive simplification the maintainer asked for (uniform interface, 3 threads)
+makes the end state *smaller* than today's.
 
-**Recommended landing sequence** (dependencies in parentheses):
+**Recommended landing sequence** (deps in parentheses):
 
-1. **T1 (I5a)** — independent, ~1 session, immediate tail-latency safety. No design risk.
-2. **T2 (I2)** — independent, high value (deletes a whole duplicate scheduling pass and an
-   unlocked shared-object access). The only care item is reproducing reservation-taint /
-   holder-task demand in the real pass.
-3. **T3 (I4)** — independent; unifies the reconcile boundary and closes the `reads.py`
-   chokepoint. Prereq for clean phase functions in T6.
-4. **T4 (I3)** — depends on T3 (so the reconcile sub-object is already clean). Large churn,
-   low conceptual risk; this is the multi-backend keystone.
-5. **T5 (I5c)** — depends on T4's `oneoffs` handle. Small once T4 lands.
-6. **T6 (I1)** — depends on T2 + T3 so every phase is already a `(snapshot) -> effects`
-   function; the tick is then an ordering shell, not a rewrite. Highest blast radius —
-   land last, behind the chaos/integration suite, ideally with a feature flag to fall
-   back to the legacy loops during bake.
+1. **T1 (I5)** — independent, high value, immediately removes the 1-hour `exec` foot-gun
+   and makes backend calls non-blocking. Prereq for a safe single tick.
+2. **T2 (I2)** — independent; deletes the duplicate scheduling pass and the unlocked
+   shared-scheduler access. Care item: reservation/holder demand parity.
+3. **T3 (I4)** — independent; produces the typed `ControlSnapshot` that T4's uniform
+   interface consumes.
+4. **T4 (I3)** — depends on T2 + T3 (needs the residual-demand output and the snapshot
+   type). Largest churn; the multi-backend keystone. Protocol-first, then relocate
+   ownership, then delete flags.
+5. **T5 (I1)** — last; depends on T1 (bounded dispatch so no phase stalls the tick), T2
+   (autoscaler folded in), T4 (uniform calls). The tick is then an ordering shell over
+   functions that already exist. Behind a fallback flag, baked on `marin-dev`.
 
 **Risk register:**
 
-- *T6 is the one to fear.* Folding five cadences into one tick can starve a phase or
-  change effective latency under load. Mitigation: per-phase `due()` predicates preserve
-  cadence; keep the bounded backend I/O (T1/T5) so no phase stalls the tick; ship behind a
-  flag and bake on `marin-dev` before `marin`. **Never bounce the live controller without
-  the user's explicit OK** (AGENTS.md).
-- *T2 correctness:* demand semantics must match today's dry-run on reservation/holder
-  jobs. Mitigation: golden-fixture parity test (same demand entries in/out) before
-  deleting the dry-run.
-- *T4 churn:* mechanical but wide. Mitigation: protocol-first, adapt backends, then migrate
-  call sites in one pass; pyrefly + the existing capability tests catch drift.
-- *Cross-region / cost:* none of these move data across regions; pure control-plane code.
-- *Multi-backend itself is out of scope here* — these five make it *tractable* (capability
-  registry, `cluster=` routing, per-backend ticks) but the registry/routing work is a
-  follow-on plan once T4 + T6 land.
+- *T5 is the one to fear* — folding cadences into one tick can starve a phase or change
+  effective latency. Mitigation: per-phase `due()` predicates; bounded dispatch (T1) so no
+  phase blocks; fallback flag; `marin-dev` bake. Never bounce the live controller without
+  explicit OK.
+- *Dropping ping (T5):* verified reconcile reaches all active workers, but the
+  over-threshold *termination* path must move onto reconcile errors in the same change, or
+  unhealthy workers linger. Covered in T5's acceptance.
+- *Commit ordering (T5):* schedule and reconcile in one tick means assignments may be acted
+  on before they're committed. The worker daemon is the source of truth (reconcile observes
+  actual state), so a crash between RPC and commit self-heals on the next tick — but confirm
+  this is acceptable vs. a commit-after-schedule boundary (open question).
+- *T2 correctness:* golden-fixture parity before deleting the dry-run.
+- *T4 churn:* wide but mechanical; pyrefly + capability tests catch drift.
+- *Cross-region / cost:* none; pure control-plane code.
+- *Multi-backend itself is out of scope here* — these five make it tractable; the
+  `BackendRegistry` + `cluster=` routing is a follow-on plan once T4 + T5 land.
 
-**Independently shippable now (no deps):** T1, T2, T3. **Sequenced:** T4 → T5; T6 last.
-Estimated ~6 focused sessions; T1–T3 can run in parallel.
+**Independently shippable now (no deps):** T1, T2, T3. **Sequenced:** T4 (after T2+T3) → T5
+(after T1+T2+T4). Estimated ~6 focused sessions; T1–T3 parallelizable.
 
 ## Open questions
 
-- **I1 cadence:** keep per-phase `RateLimiter`s inside one tick (recommended), or run the
-  autoscaler on its own slower tick that still consumes the scheduler's published
-  `residual_demand`? The former gives the strongest sync boundary; the latter is a smaller
-  diff.
-- **I2 residual semantics:** confirm "capacity-fit, promotion-cap-free" is the demand the
-  autoscaler wants (matches today's `_UNLIMITED` dry-run) — verify against a cold-start
-  fixture with reservations.
-- **I5 default deadline:** what is the right global RPC cap (30 s?) and which methods need
-  explicit overrides (profile/exec are inherently long)?
-- **Multi-backend routing:** is `cluster=<name>` a hard constraint resolved at submit
-  time, or a soft preference the scheduler can override? Affects whether routing lives in
-  the scheduler or a pre-scheduler dispatcher. (Follow-on plan.)
+- **Commit boundary in the tick (I1):** single end-of-tick write txn (schedule + reconcile
+  commit together; faster convergence, relies on reconcile self-heal after a crash), or
+  commit assignments after the schedule phase then reconcile (preserves persist-before-act
+  at the cost of an extra txn)? Recommend single commit + self-heal; confirm.
+- **Observation resolution (I3):** backend returns raw observations and the controller
+  resolves (recommended), vs. backend returns pre-resolved deltas against the in-memory
+  snapshot. Affects where uid-resolution lives.
+- **I5 caps:** reconcile-phase wall-clock cap vs per-worker timeout; explicit long caps for
+  `profile`/`exec` (what values?).
+- **`cluster=` routing (follow-on):** as a hard constraint, where is it resolved — a
+  pre-scheduler dispatcher that partitions tasks per backend, or inside each backend's
+  eligibility filter? Affects the `BackendRegistry` shape.

--- a/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
+++ b/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
@@ -30,7 +30,7 @@ from the post-merge audit.
 | T1 / I5 | #6291 | **Scope reduced in review** — see I5 below. exec deadline 1 h → 15 min; fan-out bounds documented as named constants. The watchdog pool was rolled back: reconcile/ping fan-outs were *already* bounded (10 s/RPC × 128-way semaphore), and a tripped watchdog would leave a hung pool thread still mutating the shared `Autoscaler` while the next cycle dispatched — two unsynchronized writers. |
 | T2 / I2 | #6295 | As specced. One `Scheduler` (backend-owned, `rpc/backend.py:152`); residual demand computed in the scheduling pass (`backend.py:283`) and returned on `ScheduleResult`; autoscaler loop consumes the cached `_last_residual_demand`; dry-run + second snapshot + controller `Scheduler` deleted. Demand-parity tests pin holder/taint/absorption semantics. Validated live on `marin-dev` (fineweb 10BT dedup end-to-end). |
 | T3 / I4 | #6294 | As specced. `reads.py` is the DB fan-out point; `ControlSnapshot{worker_addresses, reconcile_rows, timeout_rows, health}` built by `load_control_snapshot` in one read txn (`reads.py:1612`), health tracker attached by the controller. |
-| T4 / I3 | #6311 (open, review-complete) | Uniform `schedule`/`reconcile`/`autoscale`; ping + dispatch loops deleted (7→5 threads); health observed by backend, folded via one `WorkerHealthTracker.apply`; `placement`/`manages_capacity` deleted in favor of a `BackendCapability` descriptor consulted once at construction (+ service-RPC guards). **Design deltas:** results are three *method-specific* types (`ScheduleResult`/`ReconcileResult`/`AutoscaleResult`), each uniform across backends — better than the planned single fat `BackendResult`; `schedule` keeps `ScheduleInput` (genuinely different shape); the dispatch drain stays controller-side (it is a *write*). **Review caught a blocker the 1900-test suite couldn't:** the ping RPC was also the *workers'* keep-alive — reconcile now resets the worker heartbeat deadline. Detection latency is grace-based (`worker_unreachable_grace`=50s ÷ `poll_interval`); placement excludes failing workers while reconcile keeps probing them. **Rollout:** no churn-free deploy order (old workers decode `health` unset → reaped; old controller pings → gone on new workers); controller-first one-time churn recommended on marin-dev, optional one-release shim for prod. |
+| T4 / I3 | #6311 | Uniform `schedule`/`reconcile`/`autoscale`; ping + dispatch loops deleted (7→5 threads); health observed by backend, folded via one `WorkerHealthTracker.apply`; `placement`/`manages_capacity` deleted in favor of a `BackendCapability` descriptor consulted once at construction (+ service-RPC guards). **Design deltas:** results are three *method-specific* types (`ScheduleResult`/`ReconcileResult`/`AutoscaleResult`), each uniform across backends — better than the planned single fat `BackendResult`; `schedule` keeps `ScheduleInput` (genuinely different shape); the dispatch drain stays controller-side (it is a *write*). **Review caught a blocker the 1900-test suite couldn't:** the ping RPC was also the *workers'* keep-alive — reconcile now resets the worker heartbeat deadline. Detection latency is grace-based (`worker_unreachable_grace`=50s ÷ `poll_interval`); placement excludes failing workers while reconcile keeps probing them. **Rollout:** no churn-free deploy order (old workers decode `health` unset → reaped; old controller pings → gone on new workers); controller-first one-time churn recommended on marin-dev, optional one-release shim for prod. |
 
 **Verified post-merge state (audit of `main`):**
 
@@ -455,7 +455,9 @@ moved behind `reads.py`. (Remaining acceptable locals: `dispatch.py:_dispatch_qu
 when T4 unifies dispatch into reconcile — and service-RPC detail-view queries.)
 
 ### T4 — I3: uniform backend interface + backend-observed health  `exec: session`  `value: high`  `deps: T2, T3`
-**Done — PR #6311 (awaiting merge).** See the status table for outcome + design deltas. Doc
+**Done — #6311 (merged 2026-06-12).** See the status table for outcome + design deltas. A final
+review round fixed a CoreWeave smoke flake: k8s `_apply_pod` is now create-if-absent (the old
+delete-then-create raced the 1 s redrive against pod deletion → 409 → attempt churn). Doc
 nits deferred to T5: AGENTS.md/architecture.md still claim capabilities "never gate the
 per-tick loops" (the `_backend_drains_dispatch` exception exists and is documented in
 `backend.py`) and call BUILD_FAILED backend-emitted (it is controller-synthesized);
@@ -522,9 +524,9 @@ apply path.
 1. ~~**T1 (I5)**~~ — done (#6291, reduced scope; capacity-path boundedness → T6).
 2. ~~**T2 (I2)**~~ — done (#6295; demand parity pinned by tests, validated on `marin-dev`).
 3. ~~**T3 (I4)**~~ — done (#6294; `ControlSnapshot` with health view is now T4's input).
-4. ~~**T4 (I3)**~~ — done (PR #6311, awaiting merge; two review rounds — the adversarial pass
+4. ~~**T4 (I3)**~~ — done (#6311, merged 2026-06-12; two review rounds — the adversarial pass
    caught the worker-keep-alive blocker).
-5. **T5 (I1)** — next, after #6311 merges. The tick is then an ordering shell over functions
+5. **T5 (I1)** — next. The tick is then an ordering shell over functions
    that already exist; also folds the remaining snapshot builders, kills the
    `_last_residual_demand` cross-thread handoff, and absorbs T4's deferred doc nits.
    Fallback flag; `marin-dev` bake (which doubles as T4's rollout churn validation).

--- a/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
+++ b/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
@@ -1,6 +1,6 @@
 ---
 plan: tighten-iris-control-boundaries-multi-backend-readiness
-status: draft
+status: in-progress
 ---
 
 # Tighten Iris control boundaries (multi-backend readiness)
@@ -19,6 +19,47 @@ status: draft
 > end of tick**. `cluster=` is a **hard** constraint; the single-tick model is the target; the
 > `BackendResult` name stays (the `*Result` swarm collapses, so the earlier naming concern is
 > moot).
+
+## Status — independent layer landed (2026-06-10)
+
+T1–T3 are merged to `main`; T4/T5 are the remaining sequenced work, plus one new task (T6)
+from the post-merge audit.
+
+| Task | PR | Outcome |
+|---|---|---|
+| T1 / I5 | #6291 | **Scope reduced in review** — see I5 below. exec deadline 1 h → 15 min; fan-out bounds documented as named constants. The watchdog pool was rolled back: reconcile/ping fan-outs were *already* bounded (10 s/RPC × 128-way semaphore), and a tripped watchdog would leave a hung pool thread still mutating the shared `Autoscaler` while the next cycle dispatched — two unsynchronized writers. |
+| T2 / I2 | #6295 | As specced. One `Scheduler` (backend-owned, `rpc/backend.py:152`); residual demand computed in the scheduling pass (`backend.py:283`) and returned on `ScheduleResult`; autoscaler loop consumes the cached `_last_residual_demand`; dry-run + second snapshot + controller `Scheduler` deleted. Demand-parity tests pin holder/taint/absorption semantics. Validated live on `marin-dev` (fineweb 10BT dedup end-to-end). |
+| T3 / I4 | #6294 | As specced. `reads.py` is the DB fan-out point; `ControlSnapshot{worker_addresses, reconcile_rows, timeout_rows, health}` built by `load_control_snapshot` in one read txn (`reads.py:1612`), health tracker attached by the controller. |
+
+**Verified post-merge state (audit of `main`):**
+
+- **Still 7 `ManagedThread` loops** + uvicorn (`controller.py:493-541`): scheduling, polling/
+  reconcile, ping, dispatch, prune, autoscaler, checkpoint. T4 deletes ping; T5 collapses
+  scheduling/polling/dispatch/autoscaler into the tick.
+- **Health is mutated from two loops**: the ping loop (`ping`/`bump_heartbeat`/
+  `workers_over_threshold` → `_terminate_workers`, `controller.py:1075-1160`) and the reconcile
+  commit path (`heartbeat`/`build_failed`/`mark_unhealthy` via effects, `reconcile/commit.py:236-240`).
+  Ping and reconcile are two RPCs probing the same liveness fact — T4's deletion target stands.
+- **The uniform interface is closer than the plan assumed**: `K8sTaskProvider.schedule()`,
+  `manage_capacity()`, and `on_workers_failed()` are already no-ops returning empty results
+  (`k8s/tasks.py:1271-1283`), so the controller's three `placement`/`manages_capacity` branches
+  (`controller.py:757, 1029, 1174`) are largely redundant guards. The real remaining asymmetry
+  is the **input shape**: the controller builds dispatch-drain inputs for TASK_BACKEND and
+  reconcile-plan inputs for IRIS placement. T4's churn is mostly input/result unification, not
+  behavior change — risk lower than originally estimated.
+- **New finding — the autoscaler trades boundedness for loose threading** (violates
+  constraint #3): `Autoscaler.update()` spawns detached threads for scale-up
+  (`platform.create_slice()` blocks up to the 600 s GCP operation timeout inside the spawned
+  thread) and `terminate_slices_for_workers` spawns a thread per slice handle. The control
+  thread never blocks, but the work is untracked fire-and-forget. → **T6**.
+- **Cross-thread handoff without a sync boundary**: `_last_residual_demand` is written by the
+  scheduling loop (`controller.py:822, 844`) and read by the autoscaler loop
+  (`controller.py:1179`) with no ordering guarantee — benign under the GIL, but exactly the
+  skew constraint #6 targets. Resolved structurally by T5 (autoscale phase consumes the same
+  tick's result).
+- **Three snapshot builders remain on control paths**: `load_control_snapshot` (reconcile),
+  `build_scheduling_context` (`policy.py:932`), `refresh_reservation_claims` (`policy.py:661`).
+  Each is internally consistent; T5's "one snapshot per tick" folds them.
 
 ## Problem & goal
 
@@ -100,9 +141,8 @@ flowchart TB
     HT["WorkerHealthTracker (in-memory; reseeded from worker rows at startup)"]
 
     subgraph PURE["DB-free decision components"]
-        SCH["Scheduler.find_assignments (PURE) — TWO instances"]:::pure
-        DEM["compute_demand_entries — DRY-RUN on a 2nd snapshot"]:::problem
-        ASP["Autoscaler — owns slices + sibling logic"]
+        SCH["Scheduler.find_assignments (PURE) — one instance, backend-owned (T2 ✅)"]:::pure
+        ASP["Autoscaler — owns slices + sibling logic; spawns detached threads for cloud ops"]:::problem
     end
 
     subgraph BK["TaskBackend — 13-method contract; controller branches on type"]
@@ -112,8 +152,7 @@ flowchart TB
 
     L1 --> SCH
     L1 -->|"snapshot/commit"| DB
-    L5 -->|"2nd snapshot"| DB
-    L5 --> DEM -.->|"dry-run"| SCH
+    L1 -.->|"residual_demand via _last_residual_demand (no sync boundary)"| L5
     L5 --> ASP --> DB
     L2 -->|"snapshot/commit"| DB
     L2 -->|"reconcile"| RPCB
@@ -126,7 +165,6 @@ flowchart TB
     L6 --> DB
     L7 --> DB
 
-    L1 -.->|"⚠ demand skew"| L5
     L4 -.->|"⚠ backend-specific data through controller"| RPCB
 ```
 
@@ -371,6 +409,18 @@ reconcile to take ~5 s; no constant-time target, no global pool.
 dispatch policy (#5).
 **Risk:** low. Care item: choosing the reconcile/autoscale watchdog caps and the exec/profile caps.
 
+**Outcome (#6291, merged):** item 1 landed (exec deadline 1 h → 15 min via
+`EXEC_IN_CONTAINER_MAX_TIMEOUT`); item 2 — the watchdog pool — was **rolled back in review**.
+Two reasons: (a) the fan-outs are already bounded without it — every per-worker RPC carries
+`DEFAULT_WORKER_RPC_TIMEOUT` (10 s) under a 128-way semaphore, so a full reconcile completes in
+~`10s × ceil(workers/128)` even with the whole fleet hung; (b) a tripped watchdog abandons a
+pool thread that may still be mutating the shared `Autoscaler` while the next cycle dispatches
+a fresh call — two unsynchronized writers on `refresh`/`update` state, strictly worse than
+blocking. The constants and bound documentation were kept. **Residual gap:** the autoscaler's
+cloud operations are "bounded" only by being fire-and-forget in detached threads — that is
+constraint #3's loose threading, now tracked as **T6** (polled operations), which supersedes
+the watchdog idea for the capacity path.
+
 ## Constraint → improvement coverage
 
 | Constraint | Addressed by |
@@ -388,24 +438,20 @@ dispatch policy (#5).
 recommended landing sequence.
 
 ### T1 — I5: bound controller→backend RPCs  `exec: session`  `value: high`  `deps: —`
-Give the backend a small pool; run `reconcile`/`autoscale` ops under a fleet-size-aware
-watchdog deadline; replace the ~1-hour `exec` deadline with an explicit generous cap; leave
-the already-pooled one-offs bounded-in-place. Acceptance: a hung worker is surfaced as a
-reconcile error within the cap without blocking the caller; no backend call path lacks a timeout.
+**Done — #6291** (scope reduced in review; see I5 outcome). exec deadline 1 h → 15 min; fan-out
+bounds named + documented; watchdog pool rolled back (fan-outs already bounded; tripped watchdog
+risks overlapping autoscaler writers). Capacity-path boundedness moved to T6.
 
 ### T2 — I2: single scheduler + co-located residual demand  `exec: session`  `value: high`  `deps: —`
-Make the scheduling pass compute residual demand alongside assignments via one shared pure path
-on one `Scheduler` instance; have the autoscaler consume that same path instead of its own
-dry-run; delete `compute_demand_entries`' dry-run, the second snapshot, and the duplicate
-`Scheduler`. The autoscaler keeps its own thread for now (the thread collapse into the tick is
-T5). Acceptance: golden-fixture parity (same demand in/out incl. reservation/holder), exactly
-one `Scheduler` instance, one demand code path.
+**Done — #6295.** One backend-owned `Scheduler`; residual demand computed in the scheduling
+pass and returned on `ScheduleResult`; dry-run/second-snapshot/duplicate-`Scheduler` deleted;
+demand-parity tests pin reservation/holder/taint semantics; validated live on `marin-dev`.
 
 ### T3 — I4: one reads.py-built ControlSnapshot  `exec: session`  `value: medium`  `deps: —`
-Build a typed per-tick snapshot via `reads.py`, with the controller attaching a health view from
-the in-memory tracker; move the reconcile-input join + policy/budget/checkpoint raw selects
-behind `reads.py`. Acceptance: no schema query outside `reads.py`/`writes.py`/projections;
-snapshot carries the health view.
+**Done — #6294.** `ControlSnapshot` built by `load_control_snapshot` in one read txn; health
+tracker attached by the controller; reconcile-input join + policy/budget/checkpoint selects
+moved behind `reads.py`. (Remaining acceptable locals: `dispatch.py:_dispatch_query` — dissolves
+when T4 unifies dispatch into reconcile — and service-RPC detail-view queries.)
 
 ### T4 — I3: uniform backend interface + backend-observed health  `exec: session`  `value: high`  `deps: T2, T3`
 Define `BackendResult` + the uniform `schedule`/`reconcile`/`autoscale(snapshot)` interface;
@@ -422,13 +468,37 @@ branch and no `on_workers_failed`/`ping_workers`; backend imports no `db`/`reads
 per-tick path; the health tracker is mutated in exactly one place; a worker whose reconcile RPC
 fails the threshold is failed and its slice torn down with no ping loop.
 
+Post-merge audit notes (lowers risk): K8s `schedule`/`manage_capacity`/`on_workers_failed` are
+already no-ops, so the controller's capability branches are redundant guards — the real work is
+unifying the **input shape** (dispatch-drain vs reconcile-plan inputs both become
+`ControlSnapshot`) and the health-event flow. The Scheduler merge is already done (T2); strike
+it from this task's scope.
+
 ### T5 — I1: collapse the fast loops into one phased control tick  `exec: session`  `value: high`  `deps: T1, T2, T4`
 One driver: snapshot → schedule → reconcile(+health events) → apply-thresholds → autoscale →
 **single end-of-tick commit**; per-phase `due()`; wake → schedule-only mini-tick; drop
 ping/dispatch/autoscaler loops; keep prune/checkpoint + the in-memory tracker. Acceptance: one
 control thread; one read snapshot + one write txn per tick (counter/test); submit→assign latency
 = schedule time; reconcile cadence ≈ old ping interval (no liveness regression); chaos/integration
-suite green; behind a fallback flag.
+suite green; behind a fallback flag. Also fold the remaining control-path snapshot builders
+(`build_scheduling_context`, `refresh_reservation_claims`) into the per-tick snapshot, and
+replace the `_last_residual_demand` cross-thread field with same-tick dataflow.
+
+### T6 — autoscaler cloud ops become polled operations  `exec: session`  `value: medium`  `deps: T4`
+Today `Autoscaler.update()` and `terminate_slices_for_workers` spawn detached fire-and-forget
+threads that block inside cloud calls (GCP `create_slice`/`terminate` wait up to the 600 s
+operation timeout). Replace with the poll workflow: the autoscale phase *issues* the cloud
+request and records an operation handle in `AutoscalerState`; subsequent autoscale phases poll
+operation status (a fast bounded call) and fold completion/failure into state. No detached
+threads; every autoscale phase completes in bounded time; in-flight operations survive in
+`AutoscalerState` and are re-adopted after a controller restart the same way slices are.
+Acceptance: no `threading.Thread`/executor spawn inside the autoscaler runtime; an autoscale
+phase with a slow cloud API returns within its poll budget; an operation outcome lands in state
+within one poll interval of completion; restart with an in-flight create adopts or reconciles it.
+
+**Why this supersedes T1's watchdog for the capacity path:** the watchdog bounded the *wait*
+but left the work untracked on a hung thread; polled operations make the work itself a
+state-machine entry — bounded, observable, restart-safe, and aligned with constraint #3.
 
 ## Feasibility analysis
 
@@ -440,19 +510,20 @@ the autoscaler. **No data-model change at all** — health stays in-memory (rese
 today); only worker removal is serialized, as today. End state: 3 threads, one interface, one
 apply path.
 
-**Recommended landing sequence:**
+**Landing sequence (T1–T3 merged 2026-06-09):**
 
-1. **T1 (I5)** — independent; removes the 1-hour `exec` foot-gun and the inline-blocking
-   reconcile. Prereq for a safe single tick.
-2. **T2 (I2)** — independent; deletes the duplicate scheduling pass, the second snapshot, the
-   second `Scheduler`. Care item: demand parity.
-3. **T3 (I4)** — independent; produces the `ControlSnapshot` (with health view) T4 consumes.
-4. **T4 (I3)** — after T2 + T3; largest churn (uniform interface, health-events-into-backend,
-   autoscaler restore decoupling, dual-scheduler merge, flag deletion). Land
-   health-events-into-backend with the ping loop still present as belt-and-suspenders, then
+1. ~~**T1 (I5)**~~ — done (#6291, reduced scope; capacity-path boundedness → T6).
+2. ~~**T2 (I2)**~~ — done (#6295; demand parity pinned by tests, validated on `marin-dev`).
+3. ~~**T3 (I4)**~~ — done (#6294; `ControlSnapshot` with health view is now T4's input).
+4. **T4 (I3)** — next; largest churn (uniform interface, health-events-into-backend, autoscaler
+   restore decoupling, input-shape unification). The Scheduler merge already happened in T2.
+   Land health-events-into-backend with the ping loop still present as belt-and-suspenders, then
    remove ping in the same task once the backend events match the ping-derived liveness.
-5. **T5 (I1)** — last; after T1, T2, T4. The tick is then an ordering shell over functions that
-   already exist. Fallback flag; `marin-dev` bake.
+5. **T5 (I1)** — after T1, T2, T4. The tick is then an ordering shell over functions that
+   already exist; also folds the remaining snapshot builders and kills the
+   `_last_residual_demand` cross-thread handoff. Fallback flag; `marin-dev` bake.
+6. **T6** — after T4 (the autoscale phase is the natural home for issue-then-poll); independent
+   of T5 and can land in parallel with it.
 
 **Risk register:**
 
@@ -463,17 +534,20 @@ apply path.
 - *T5 (single tick)* — phase starvation/latency. Mitigation: per-phase `due()`; wake →
   schedule-only mini-tick; bounded reconcile (T1); single end-of-tick commit + reconcile
   self-heal; fallback flag. Never bounce the live controller without explicit OK.
-- *T2 (demand parity)* — golden-fixture test gates the dry-run deletion.
+- *T2 (demand parity)* — ~~golden-fixture test gates the dry-run deletion~~ landed; parity tests
+  in `test_reservation.py` are the regression gate.
 - *T4 (autoscaler DB-decoupling)* — `restore_from_db`/`recovery`/`persistence` touch the DB;
   keep restore controller-driven, off the per-tick path.
+- *T6 (operation adoption)* — an in-flight cloud operation must survive controller restart;
+  reuse the slice-adoption pattern rather than inventing a second recovery mechanism.
 - *K8s health* — events must come from pod status, not a daemon ping; verify the pod-diff
   reconcile already exposes enough to emit a pod-worker-unreachable event.
 - *Cross-region / cost* — none; pure control-plane code.
 - *Multi-backend itself is out of scope* — these five make it tractable; `BackendRegistry` +
   `cluster=` routing is a follow-on once T4 + T5 land.
 
-**Independently shippable now:** T1, T2, T3. **Sequenced:** T4 (after T2+T3) → T5 (after T1, T2,
-T4). Estimated ~6–7 focused sessions.
+**Shipped:** T1, T2, T3. **Sequenced:** T4 (after T2+T3) → T5 (after T1, T2, T4) ∥ T6 (after
+T4). Estimated ~3–4 remaining focused sessions.
 
 ## Decisions & open questions
 
@@ -484,9 +558,15 @@ T4). Estimated ~6–7 focused sessions.
   controller-owned, fed by backend health events; only worker removal is serialized (as today).
 - **`cluster=`:** a hard constraint.
 
+**Decided since (T1 review):**
+- **No watchdog pool over backend calls.** Fan-outs are bounded by per-RPC deadline × semaphore;
+  abandoning a hung pool thread that mutates shared autoscaler state is worse than blocking.
+  Capacity-path boundedness comes from T6's polled operations instead.
+
 **Open:**
 - **Observation resolution (I3):** backend returns raw observations and the controller resolves
   in the pure kernel (recommended), vs backend pre-resolves against the in-memory snapshot.
-- **I5 caps:** the reconcile/autoscale watchdog caps and the exec/profile caps (values?).
 - **`cluster=` routing (follow-on):** hard constraint resolved by a pre-scheduler dispatcher
   that partitions tasks per backend, or inside each backend's eligibility filter?
+- **T6 poll budget:** the per-phase cap on operation-status polls (the issue call itself can be
+  bounded at the HTTP layer, e.g. GCP's 30 s POST timeout).

--- a/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
+++ b/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
@@ -394,9 +394,12 @@ the already-pooled one-offs bounded-in-place. Acceptance: a hung worker is surfa
 reconcile error within the cap without blocking the caller; no backend call path lacks a timeout.
 
 ### T2 — I2: single scheduler + co-located residual demand  `exec: session`  `value: high`  `deps: —`
-Compute residual demand once on the schedule snapshot with one `Scheduler`; feed the autoscaler
-off it; delete the dry-run + the separate autoscaler thread. Acceptance: golden-fixture parity
-(same demand in/out incl. reservation/holder), one `Scheduler`, one scheduling snapshot/cycle.
+Make the scheduling pass compute residual demand alongside assignments via one shared pure path
+on one `Scheduler` instance; have the autoscaler consume that same path instead of its own
+dry-run; delete `compute_demand_entries`' dry-run, the second snapshot, and the duplicate
+`Scheduler`. The autoscaler keeps its own thread for now (the thread collapse into the tick is
+T5). Acceptance: golden-fixture parity (same demand in/out incl. reservation/holder), exactly
+one `Scheduler` instance, one demand code path.
 
 ### T3 — I4: one reads.py-built ControlSnapshot  `exec: session`  `value: medium`  `deps: —`
 Build a typed per-tick snapshot via `reads.py`, with the controller attaching a health view from

--- a/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
+++ b/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
@@ -5,15 +5,20 @@ status: draft
 
 # Tighten Iris control boundaries (multi-backend readiness)
 
-> Revised three times. The decisive simplification (this round): **worker health is a
-> backend concern.** The backend tracks health from its own I/O (RPC backend: reconcile-RPC
-> + build failures; K8s: pod status) and returns per-worker verdicts in `BackendResult`; the
-> controller just **stores** them. That deletes `on_workers_failed` / `on_worker_failed` /
-> `ping_workers`, the ping loop, and the controller-side `WorkerHealthTracker` logic — and
-> removes the last place backend-specific data flowed through the controller. Phase order is
-> **schedule → reconcile → autoscale** (each as-needed). `cluster=` is a **hard** constraint;
-> the single-tick model is the target; the `BackendResult` name stays (the `*Result` swarm
-> collapses, so the earlier naming concern is moot).
+> Revised through several rounds. The settled model: **worker health is observed by the
+> backend but owned by the controller.** Each backend tracks health from its own I/O (RPC
+> backend: reconcile-RPC + build failures; K8s: pod status) and returns generic per-worker
+> **health events** in `BackendResult`; the controller folds them into its **in-memory**
+> `WorkerHealthTracker`, applies the thresholds, and serializes **only the hard decision** —
+> a worker crossing the threshold and being torn down. Health is **not** persisted (the
+> tracker is reseeded from worker rows at startup, as today). That still deletes
+> `on_workers_failed` / `on_worker_failed` / `ping_workers`, the ping loop, and the scattered
+> in-reconcile tracker mutations — and removes the last place backend-specific data flowed
+> through the controller (the dead set is now controller-derived and passed via the uniform
+> `autoscale(...)`). Phase order is **schedule → reconcile → autoscale**, committed **once at
+> end of tick**. `cluster=` is a **hard** constraint; the single-tick model is the target; the
+> `BackendResult` name stays (the `*Result` swarm collapses, so the earlier naming concern is
+> moot).
 
 ## Problem & goal
 
@@ -61,10 +66,13 @@ with concrete code shapes + an honest feasibility analysis. Implementation = the
   `mark_unhealthy` on the fail cascade `batches.py:226`). Read by scheduling-context filtering
   (`policy.py:1063` → `reads.py:1097`) and the read-only RPCs (`ListWorkers` `service.py:1578`,
   `GetWorkerStatus` `:1985`, `GetAutoscalerStatus` `:1766`). **Health is not in the scheduling
-  snapshot today** — it's a separate post-filter.
+  snapshot today** — it's a separate post-filter. We **keep** this in-memory model; we change
+  only *what feeds it* (one stream of backend health events instead of a ping loop + scattered
+  in-reconcile mutations).
 - **K8s has no daemon-ping health model** — workers are pods, health is pod status
   (`backends/k8s/tasks.py`); it stubs `on_workers_failed`/`ping_workers`. This asymmetry is the
-  reason health belongs *in* the backend, not in one controller-side tracker.
+  reason health must be *observed in* the backend (each backend knows its own liveness source),
+  even though the threshold decision stays controller-side.
 - The reconcile *kernel* (`reconcile/overlay|task|job|worker|effects`) is a **pure state
   machine**; `loader → snapshot → kernel → commit` is clean; `writes.validate()` enforces
   projection-table ownership.
@@ -89,7 +97,7 @@ flowchart TB
     end
 
     DB[("Controller DB")]:::store
-    HT["WorkerHealthTracker (in-memory, lost on restart)"]:::problem
+    HT["WorkerHealthTracker (in-memory; reseeded from worker rows at startup)"]
 
     subgraph PURE["DB-free decision components"]
         SCH["Scheduler.find_assignments (PURE) — TWO instances"]:::pure
@@ -129,14 +137,15 @@ flowchart TB
     classDef good fill:#e1ffe1,stroke:#27ae60,color:#000;
     classDef store fill:#f5f0d8,stroke:#7f8c8d,color:#000;
 
-    subgraph TICK["Control tick — ONE thread, ONE snapshot/tick"]
+    subgraph TICK["Control tick — ONE thread, ONE snapshot, ONE end-of-tick commit"]
         direction TB
-        S0["build ControlSnapshot (reads.py, one read txn) — incl. stored worker health"]
+        S0["build ControlSnapshot — reads.py (DB state) + health view from in-memory tracker"]
         S1["schedule (due ~10s / on wake): DECISION → assignments + residual_demand"]
-        S2["reconcile (every tick): OPERATION → task observations + WORKER-HEALTH VERDICTS"]
-        S3["autoscale (due): OPERATION → provision + tear down dead slices/siblings → AutoscalerState + verdicts"]
-        S4["commit BackendResult (one write txn): pure kernel applies observations+health → store"]
-        S0 --> S1 --> S2 --> S3 --> S4
+        S2["reconcile (every tick): OPERATION → task observations + per-worker HEALTH EVENTS"]
+        SH["controller folds health events → in-memory tracker, applies thresholds → newly_dead"]
+        S3["autoscale (due): OPERATION → provision + tear down newly_dead slices/siblings → AutoscalerState + removed_workers"]
+        S4["commit BackendResult (one write txn): pure kernel applies observations → task state; serialize hard decisions (worker removal, slices)"]
+        S0 --> S1 --> S2 --> SH --> S3 --> S4
     end
 
     subgraph HK["Housekeeping threads"]
@@ -144,70 +153,84 @@ flowchart TB
         C["checkpoint"]
     end
 
-    DB[("Controller DB — stores task state, worker health, slices")]:::store
+    DB[("Controller DB — stores task state + slices; worker removal is the only health-driven write")]:::store
+    HT["WorkerHealthTracker (in-memory, controller-owned)"]
 
     subgraph BD["per-backend bounded dispatch (threadpool + generous timeout) — I/O calls only"]
         D["submit(io_call, deadline)"]
     end
 
-    subgraph BK["Backends — UNIFORM interface; OWN placement, capacity, AND health"]
-        RPCB["RpcTaskBackend — 1 Scheduler + Autoscaler + health from reconcile-RPC/build"]:::good
-        K8S["K8sTaskProvider — Kueue places; health from pod status"]:::good
+    subgraph BK["Backends — UNIFORM interface; OWN placement, capacity, AND health OBSERVATION"]
+        RPCB["RpcTaskBackend — 1 Scheduler + Autoscaler + health events from reconcile-RPC/build"]:::good
+        K8S["K8sTaskProvider — Kueue places; health events from pod status"]:::good
     end
 
     S0 --> DB
+    S0 -.->|"health view"| HT
     S1 -->|"in-process decision"| RPCB
     S2 --> BD
+    SH --> HT
     S3 --> BD
     BD --> RPCB
     BD --> K8S
-    RPCB -->|"BackendResult"| S4
-    K8S -->|"BackendResult"| S4
+    RPCB -->|"BackendResult"| S2
+    RPCB -->|"BackendResult"| S3
+    K8S -->|"BackendResult"| S2
+    S3 --> S4
     S4 --> DB
     P --> DB
     C --> DB
 ```
 
-Net threads: **7 → 3**. No ping loop, no `on_workers_failed`, no controller-side health
-tracker. The controller builds a snapshot (incl. stored health), calls one interface, and
-persists `BackendResult` through one pure-kernel apply path — dispatching on result shape,
-never backend type. `schedule` is an in-process decision; only the actual **I/O** (reconcile,
-autoscale ops, one-offs) goes through the bounded dispatch.
+Net threads: **7 → 3**. No ping loop, no `on_workers_failed`, no scattered tracker mutations.
+The controller builds a snapshot (DB state + in-memory health view), calls one interface, folds
+the returned health events into its tracker, and persists `BackendResult` through one pure-kernel
+apply path — dispatching on result shape, never backend type. `schedule` is an in-process
+decision; only the actual **I/O** (reconcile, autoscale ops, one-offs) goes through the bounded
+dispatch. Health stays in-memory; only worker **removal** is serialized.
 
 ## The five targeted improvements
 
-### I1 — One phased control tick (schedule → reconcile → autoscale); drop the ping, dispatch & autoscaler loops
+### I1 — One phased control tick (schedule → reconcile → autoscale), one end-of-tick commit; drop the ping, dispatch & autoscaler loops
 
 **Problem.** Five fast loops re-snapshot/commit independently; the dispatch loop is "reconcile
 for TASK_BACKEND"; the autoscaler loop re-snapshots; the ping loop derives liveness and
 couriers failures into the backend.
 
-**Change.** One driver thread, one snapshot per tick, fixed order:
+**Change.** One driver thread, one snapshot per tick, fixed order, **one write txn at the end
+of the tick**:
 
 ```
 control_tick(now):
-    snap = build_control_snapshot(db)              # ONE read txn via reads.py (I4); incl. stored health
+    snap = build_control_snapshot(db, health_tracker)   # ONE read txn via reads.py (I4) + in-memory health view
     r = BackendResult()
+    newly_dead = []
     if schedule_phase.due(now) or woken:
-        r += backend.schedule(snap)                # pure decision: assignments + residual_demand
+        r += backend.schedule(snap)                      # pure decision: assignments + residual_demand
     if reconcile_phase.due(now):
-        r += backend.reconcile(snap)               # bounded I/O (I5): observations + health verdicts
+        r += backend.reconcile(snap)                     # bounded I/O (I5): observations + health events
+        newly_dead = health_tracker.apply(r.health_events)   # in-memory; PING/BUILD thresholds → who crossed
     if autoscale_phase.due(now):
-        r += backend.autoscale(snap, r.residual_demand, r.health)  # bounded I/O: scale + dead-slice teardown
-    with db.transaction() as tx:                   # ONE write txn, one apply path
-        commit(tx, r)                              # pure kernel: observations+health → task state; store health/slices
+        r += backend.autoscale(snap, r.residual_demand, newly_dead)  # bounded I/O: scale + dead-slice/sibling teardown
+    with db.transaction() as tx:                         # ONE end-of-tick write txn (decided)
+        commit(tx, r)                                    # pure kernel: observations → task state; serialize removals/slices
 ```
 
+- **Commit boundary (decided):** a **single end-of-tick write** covering schedule + reconcile +
+  autoscale. A mid-tick crash leaves no partial commit; the next tick's reconcile self-heals
+  from observed state. No commit-after-schedule.
 - **Drop the ping loop.** Reconcile already reaches every active worker (idle ones get an
-  empty-rows heartbeat); liveness now comes from the backend tracking its own reconcile-RPC
-  outcomes (I3). Keep the reconcile cadence ≈ the old ping interval so detection isn't slower.
+  empty-rows heartbeat); liveness now comes from the backend reporting its own reconcile-RPC
+  outcomes as health events (I3), folded into the in-memory tracker. Keep the reconcile cadence
+  ≈ the old ping interval so detection isn't slower.
 - **Drop the dispatch loop** (it is reconcile for TASK_BACKEND placement; uniform after I3).
-- **Drop the autoscaler loop** (now the autoscale phase, off `residual_demand` + reconcile's
-  health verdicts).
+- **Drop the autoscaler loop** (now the autoscale phase, off `residual_demand` + the
+  controller-derived `newly_dead` set).
 - **Scheduling latency:** an RPC wake triggers a **schedule-only mini-tick** (reconcile/
   autoscale skipped unless due), so submit→assign = schedule time, not gated on in-flight
   reconcile.
-- **Keep** prune + checkpoint as separate housekeeping threads.
+- **Keep** prune + checkpoint as separate housekeeping threads, and the in-memory
+  `WorkerHealthTracker` (now mutated in exactly one place: `apply(health_events)`).
 
 **Serves:** poll over loose threading (#3); one snapshot fans out to DB-free abstractions (#1);
 strong scheduler↔autoscaler sync (#6).
@@ -238,22 +261,23 @@ parity test is load-bearing** (same demand entries in/out, incl. reservation/hol
 removes a snapshot + the unlocked dual-scheduler access (#1).
 **Risk:** medium-high — reproduce reservation-taint / holder-task demand semantics exactly.
 
-### I3 — One uniform backend interface; the backend owns placement, capacity, AND health; controller stores `BackendResult`
+### I3 — One uniform backend interface; the backend observes placement, capacity, AND health; the controller owns health state and stores `BackendResult`
 
 **Problem.** The controller orchestrates backend specifics: branches on `placement`/
-`manages_capacity`; derives health itself; couriers failures via `on_workers_failed`; reads
-type-specific result fields; K8s stubs methods.
+`manages_capacity`; derives health itself via a ping loop; couriers failures via
+`on_workers_failed`; reads type-specific result fields; K8s stubs methods.
 
 **Change.** One uniform interface every backend implements; the Iris scheduler, autoscaler,
-**and worker-health tracking** live inside `RpcTaskBackend`; the controller persists the
-returned `BackendResult` through one pure-kernel apply path, dispatching on result shape only:
+**and worker-health observation** live inside `RpcTaskBackend`; the controller keeps the
+in-memory health *state* and persists the returned `BackendResult` through one pure-kernel
+apply path, dispatching on result shape only:
 
 ```python
 class TaskBackend(Protocol):
     name: str
-    def schedule(self, snap: ControlSnapshot) -> BackendResult: ...        # DECISION: assignments + residual_demand
-    def reconcile(self, snap: ControlSnapshot) -> BackendResult: ...       # OPERATION: observations + worker-health verdicts
-    def autoscale(self, snap, residual_demand, health) -> BackendResult: ...# OPERATION: scale + dead-slice/sibling teardown
+    def schedule(self, snap: ControlSnapshot) -> BackendResult: ...          # DECISION: assignments + residual_demand (filters on snap health view)
+    def reconcile(self, snap: ControlSnapshot) -> BackendResult: ...         # OPERATION: observations + per-worker health events
+    def autoscale(self, snap, residual_demand, dead_workers) -> BackendResult: ...# OPERATION: scale + tear down dead slices/siblings
     def set_log_sink(self, ...) -> None: ...
     def close(self) -> None: ...
 
@@ -264,28 +288,36 @@ class BackendResult:
     assignments: list[Assignment] = field(default_factory=list)
     residual_demand: list[DemandEntry] = field(default_factory=list)
     observations: list[ReconcileObservation] = field(default_factory=list)   # task-state observed
-    worker_health: list[WorkerHealthVerdict] = field(default_factory=list)   # healthy/active + counts, per worker
+    health_events: list[WorkerHealthEvent] = field(default_factory=list)     # generic per-worker: reached / unreachable / build-failed
+    removed_workers: list[WorkerId] = field(default_factory=list)            # autoscale teardown result (dead slices + siblings)
     autoscaler_state: AutoscalerState | None = None
     ...
 ```
 
-**Worker health moves into the backend (the heart of this revision):**
-- `RpcTaskBackend` owns the health tracker; `reconcile` counts its own reconcile-RPC outcomes
-  (success → heartbeat; error → `consecutive_failures`++) plus build failures, applies the
-  threshold, and returns per-worker `WorkerHealthVerdict`s. When it deems a worker dead it
-  evicts its own cached stub (today's `on_worker_failed`) internally — no controller call.
-- `autoscale`, given the dead-worker verdicts, tears down their slices **and** their healthy
-  siblings (logic already in `autoscaler/operations.py`) and returns the siblings as further
-  dead verdicts — so the controller never couriers IDs back in.
-- `K8sTaskProvider.reconcile` derives verdicts from pod status — its native health source.
-- The controller **stores** verdicts on the worker rows (persist + restore on restart, like
-  autoscaler state — fixing the in-memory-only gap) and feeds them back via the next
-  `ControlSnapshot` (so `schedule` can filter on health, and read-only RPCs serve stored
-  health). The pure reconcile kernel still runs in `commit`, consuming
-  `observations + dead-worker set` to compute task transitions (WORKER_FAILED cascades).
+**Worker health — observed in the backend, owned by the controller (the heart of this revision):**
+- `RpcTaskBackend.reconcile` counts its own reconcile-RPC outcomes (reached → heartbeat event;
+  RPC error/timeout → unreachable event) plus build failures, and returns generic per-worker
+  **health events**. It may evict its own cached stub on an RPC failure (I/O hygiene) — but it
+  does **not** decide dead/alive.
+- The **controller** keeps the in-memory `WorkerHealthTracker` (unchanged, reseeded from worker
+  rows at startup) and folds the events in via a single `apply(health_events)` — accumulating
+  `consecutive_failures`/`build_failures` and applying `PING_FAILURE_THRESHOLD`/
+  `BUILD_FAILURE_THRESHOLD`. Crossing the threshold yields the `newly_dead` set.
+- `autoscale(snap, residual_demand, dead_workers)` receives that controller-derived `newly_dead`
+  set (db values — worker ids, not backend-specific data), tears down their slices **and** their
+  healthy siblings (logic already in `autoscaler/operations.py`), and returns the full set as
+  `removed_workers` — so the controller never couriers IDs back in via a dedicated RPC.
+- `K8sTaskProvider.reconcile` derives health events from pod status — its native liveness source.
+- **Health is not persisted.** The tracker stays in-memory; the snapshot's health view is read
+  from it (I4). The pure reconcile kernel still runs in `commit`, consuming
+  `observations + newly_dead` to compute task transitions (WORKER_FAILED cascades). **Only the
+  hard decision** — a removed worker — is serialized (worker row + slice teardown), exactly as
+  today.
 
-**Deleted:** `on_workers_failed`, `on_worker_failed`, `ping_workers`, the controller
-`WorkerHealthTracker` mutation logic, and `placement`/`manages_capacity` + every branch.
+**Deleted:** `on_workers_failed`, `on_worker_failed`, `ping_workers`, the ping loop, the
+scattered in-reconcile tracker mutations (`batches.py:182/226`, `task.py:441` → one
+`apply(health_events)` site), and `placement`/`manages_capacity` + every branch. **Kept:** the
+controller's in-memory `WorkerHealthTracker` and its threshold logic.
 
 Also in scope: reconcile the two `Scheduler` instances → one (backend-owned; building cap
 sources from it); keep autoscaler startup-restore controller-driven so the backend stays
@@ -299,7 +331,7 @@ backend-internal — so there is no remaining collision.
 **Serves:** controller = state/storage, backend = operation, **no backend-specific data in the
 controller** (#2); one interface + one result shape + one apply path (#5); the multi-backend
 keystone (`BackendRegistry` over N backends, routed by the hard `cluster=` constraint).
-**Risk:** largest churn; the genuine sub-projects are health-into-backend, autoscaler
+**Risk:** largest churn; the genuine sub-projects are health-events-into-backend, autoscaler
 DB-decoupling, and the dual-scheduler merge.
 
 ### I4 — `reads.py` is the single DB fan-out point feeding the typed `ControlSnapshot`
@@ -307,10 +339,11 @@ DB-decoupling, and the dual-scheduler merge.
 **Problem.** `_snapshot_reconcile_inputs`' raw join (`controller.py:1038-1059`) bypasses
 `reads.py`; same in `policy.py`/`budget.py`/`checkpoint.py`.
 
-**Change.** Build one typed `ControlSnapshot` per tick via `reads.py` (reuse
-`reconcile/loader.load_closed_snapshot` where it fits), **including stored worker health** so
-the backend can filter/track from it; move the raw selects behind `reads.py`. `reads.py`/
-`writes.py`/projections become the only modules issuing schema queries.
+**Change.** Build one typed `ControlSnapshot` per tick: `reads.py` fans out the DB state (reuse
+`reconcile/loader.load_closed_snapshot` where it fits) and the controller attaches a **health
+view from the in-memory tracker** so the backend can filter/observe from a uniform input. Move
+the raw selects behind `reads.py`. `reads.py`/`writes.py`/projections become the only modules
+issuing schema queries; the health view is the one non-DB field, composed in by the controller.
 
 **Serves:** central DB queries fan out to DB-free abstractions from one chokepoint (#1).
 **Risk:** medium; independent; the `ControlSnapshot` is the backends' uniform input.
@@ -343,7 +376,7 @@ dispatch policy (#5).
 | Constraint | Addressed by |
 |---|---|
 | Central DB queries fan out to DB-free abstractions | I4 (one `reads.py` snapshot), I3 (snapshot in → `BackendResult` out), I2 (single demand artifact) |
-| Controller handles state, backends handle operation | I3 (backend owns placement/capacity/**health**; controller only stores; **no backend-specific data in the controller**) |
+| Controller handles state, backends handle operation | I3 (backend observes placement/capacity/**health**; controller owns the in-memory health model + applies thresholds; **no backend-specific data in the controller**; only worker removal serialized) |
 | Prefer poll workflows vs loose threading | I1 (one control tick; drop ping/dispatch/autoscaler loops) |
 | Any controller→backend call is threadpool-dispatched + bounded | I5 (per-backend pool + generous deadline; fix the 1h exec) |
 | Only one way to do something | I3 (one interface + one result shape; delete `on_workers_failed`/`ping_workers`), I2 (one demand path) |
@@ -366,38 +399,43 @@ off it; delete the dry-run + the separate autoscaler thread. Acceptance: golden-
 (same demand in/out incl. reservation/holder), one `Scheduler`, one scheduling snapshot/cycle.
 
 ### T3 — I4: one reads.py-built ControlSnapshot  `exec: session`  `value: medium`  `deps: —`
-Build a typed per-tick snapshot via `reads.py`, carrying stored worker health; move the
-reconcile-input join + policy/budget/checkpoint raw selects behind `reads.py`. Acceptance: no
-schema query outside `reads.py`/`writes.py`/projections; snapshot includes health.
+Build a typed per-tick snapshot via `reads.py`, with the controller attaching a health view from
+the in-memory tracker; move the reconcile-input join + policy/budget/checkpoint raw selects
+behind `reads.py`. Acceptance: no schema query outside `reads.py`/`writes.py`/projections;
+snapshot carries the health view.
 
-### T4 — I3: uniform backend interface + backend-owned health  `exec: session`  `value: high`  `deps: T2, T3`
+### T4 — I3: uniform backend interface + backend-observed health  `exec: session`  `value: high`  `deps: T2, T3`
 Define `BackendResult` + the uniform `schedule`/`reconcile`/`autoscale(snapshot)` interface;
-**move worker-health tracking into the backend** (RPC: reconcile-RPC + build failures + threshold;
-K8s: pod status), returning per-worker verdicts; **persist health to worker rows** (+ restore on
-restart) and feed it back via the snapshot; **delete `on_workers_failed`/`on_worker_failed`/
-`ping_workers` + the controller health tracker**; backend tears down dead slices + siblings in
-`autoscale`, returning sibling verdicts; reconcile the two `Scheduler` instances → one; keep
-autoscaler startup-restore controller-driven; collapse the result fields via a shared resolver;
-delete `placement`/`manages_capacity` + branches. Acceptance: `grep` finds no
-`placement ==`/`manages_capacity` branch and no `on_workers_failed`/`ping_workers`; backend
-imports no `db`/`reads`/`schema` on the per-tick path; a worker whose reconcile RPC fails the
-threshold is failed and its slice torn down with no ping loop.
+**move worker-health observation into the backend** (RPC: reconcile-RPC + build failures emitted
+as generic events; K8s: pod status), returning per-worker health events; **keep the in-memory
+`WorkerHealthTracker` controller-side**, folding events in via one `apply(...)` that applies the
+thresholds (no persistence, no new columns); **delete `on_workers_failed`/`on_worker_failed`/
+`ping_workers` + the ping loop + the scattered in-reconcile mutations**; backend tears down dead
+slices + siblings in `autoscale` off the controller-derived `newly_dead` set, returning
+`removed_workers`; reconcile the two `Scheduler` instances → one; keep autoscaler startup-restore
+controller-driven; collapse the result fields via a shared resolver; delete `placement`/
+`manages_capacity` + branches. Acceptance: `grep` finds no `placement ==`/`manages_capacity`
+branch and no `on_workers_failed`/`ping_workers`; backend imports no `db`/`reads`/`schema` on the
+per-tick path; the health tracker is mutated in exactly one place; a worker whose reconcile RPC
+fails the threshold is failed and its slice torn down with no ping loop.
 
 ### T5 — I1: collapse the fast loops into one phased control tick  `exec: session`  `value: high`  `deps: T1, T2, T4`
-One driver: snapshot → schedule → reconcile(+health) → autoscale → commit; per-phase `due()`;
-wake → schedule-only mini-tick; drop ping/dispatch/autoscaler loops; keep prune/checkpoint.
-Acceptance: one control thread; one read snapshot + one write txn per tick (counter/test);
-submit→assign latency = schedule time; reconcile cadence ≈ old ping interval (no liveness
-regression); chaos/integration suite green; behind a fallback flag.
+One driver: snapshot → schedule → reconcile(+health events) → apply-thresholds → autoscale →
+**single end-of-tick commit**; per-phase `due()`; wake → schedule-only mini-tick; drop
+ping/dispatch/autoscaler loops; keep prune/checkpoint + the in-memory tracker. Acceptance: one
+control thread; one read snapshot + one write txn per tick (counter/test); submit→assign latency
+= schedule time; reconcile cadence ≈ old ping interval (no liveness regression); chaos/integration
+suite green; behind a fallback flag.
 
 ## Feasibility analysis
 
-**Overall: feasible, incremental, and now genuinely simplifying.** Moving health into the
-backend *removes* code (ping loop, `on_workers_failed`/`on_worker_failed`/`ping_workers`,
-controller `WorkerHealthTracker` mutation logic, the courier-and-loop sibling dance) rather than
-adding it, and the sibling/slice logic it relies on already lives in the autoscaler. No
-data-model change except adding stored health to the worker rows (a small, beneficial migration
-that also fixes restart durability). End state: 3 threads, one interface, one apply path.
+**Overall: feasible, incremental, and genuinely simplifying.** Observing health in the backend
+while keeping the tracker controller-side *removes* code (ping loop, `on_workers_failed`/
+`on_worker_failed`/`ping_workers`, the scattered tracker-mutation sites, the courier-and-loop
+sibling dance) rather than adding it, and the sibling/slice logic it relies on already lives in
+the autoscaler. **No data-model change at all** — health stays in-memory (reseeded at startup as
+today); only worker removal is serialized, as today. End state: 3 threads, one interface, one
+apply path.
 
 **Recommended landing sequence:**
 
@@ -405,28 +443,28 @@ that also fixes restart durability). End state: 3 threads, one interface, one ap
    reconcile. Prereq for a safe single tick.
 2. **T2 (I2)** — independent; deletes the duplicate scheduling pass, the second snapshot, the
    second `Scheduler`. Care item: demand parity.
-3. **T3 (I4)** — independent; produces the `ControlSnapshot` (with health) T4 consumes.
-4. **T4 (I3)** — after T2 + T3; largest churn (uniform interface, health-into-backend, autoscaler
-   restore decoupling, dual-scheduler merge, flag deletion). Land health-into-backend with the
-   ping loop still present as belt-and-suspenders, then remove ping in the same task once the
-   backend verdicts are proven.
+3. **T3 (I4)** — independent; produces the `ControlSnapshot` (with health view) T4 consumes.
+4. **T4 (I3)** — after T2 + T3; largest churn (uniform interface, health-events-into-backend,
+   autoscaler restore decoupling, dual-scheduler merge, flag deletion). Land
+   health-events-into-backend with the ping loop still present as belt-and-suspenders, then
+   remove ping in the same task once the backend events match the ping-derived liveness.
 5. **T5 (I1)** — last; after T1, T2, T4. The tick is then an ordering shell over functions that
    already exist. Fallback flag; `marin-dev` bake.
 
 **Risk register:**
 
-- *T4 (health-into-backend)* — health is mutated from several sites today (ping + reconcile +
-  build + cascade); consolidating onto the backend's reconcile must preserve the threshold
-  semantics (`PING_FAILURE_THRESHOLD`/`BUILD_FAILURE_THRESHOLD`). Mitigation: keep ping running
-  until backend verdicts match it on `marin-dev`, then delete.
+- *T4 (health-events-into-backend)* — health is mutated from several sites today (ping +
+  reconcile + build + cascade); consolidating onto one `apply(health_events)` must preserve the
+  threshold semantics (`PING_FAILURE_THRESHOLD`/`BUILD_FAILURE_THRESHOLD`). Mitigation: keep ping
+  running until backend events match its liveness on `marin-dev`, then delete.
 - *T5 (single tick)* — phase starvation/latency. Mitigation: per-phase `due()`; wake →
-  schedule-only mini-tick; bounded reconcile (T1); fallback flag. Never bounce the live
-  controller without explicit OK.
+  schedule-only mini-tick; bounded reconcile (T1); single end-of-tick commit + reconcile
+  self-heal; fallback flag. Never bounce the live controller without explicit OK.
 - *T2 (demand parity)* — golden-fixture test gates the dry-run deletion.
 - *T4 (autoscaler DB-decoupling)* — `restore_from_db`/`recovery`/`persistence` touch the DB;
   keep restore controller-driven, off the per-tick path.
-- *K8s health* — verdicts must come from pod status, not a daemon ping; verify the pod-diff
-  reconcile already exposes enough to mark a pod-worker dead.
+- *K8s health* — events must come from pod status, not a daemon ping; verify the pod-diff
+  reconcile already exposes enough to emit a pod-worker-unreachable event.
 - *Cross-region / cost* — none; pure control-plane code.
 - *Multi-backend itself is out of scope* — these five make it tractable; `BackendRegistry` +
   `cluster=` routing is a follow-on once T4 + T5 land.
@@ -434,16 +472,18 @@ that also fixes restart durability). End state: 3 threads, one interface, one ap
 **Independently shippable now:** T1, T2, T3. **Sequenced:** T4 (after T2+T3) → T5 (after T1, T2,
 T4). Estimated ~6–7 focused sessions.
 
-## Open questions
+## Decisions & open questions
 
-- **Health persistence shape:** add `healthy`/`active`/`consecutive_failures`/`build_failures`/
-  `last_heartbeat_ms` columns to the worker rows, or a small dedicated health table? Either way
-  it feeds the snapshot and survives restart.
-- **Commit boundary in the tick (I1):** single end-of-tick write (schedule+reconcile+autoscale
-  commit together; relies on reconcile self-heal after a crash) vs commit-after-schedule.
-  Recommend single commit + self-heal; confirm.
+**Decided:**
+- **Commit boundary (I1):** single end-of-tick write (schedule+reconcile+autoscale commit
+  together; relies on reconcile self-heal after a crash). Not commit-after-schedule.
+- **Health persistence (I3):** none. The `WorkerHealthTracker` stays in-memory and
+  controller-owned, fed by backend health events; only worker removal is serialized (as today).
+- **`cluster=`:** a hard constraint.
+
+**Open:**
 - **Observation resolution (I3):** backend returns raw observations and the controller resolves
-  (recommended), vs backend pre-resolves against the in-memory snapshot.
+  in the pure kernel (recommended), vs backend pre-resolves against the in-memory snapshot.
 - **I5 caps:** the reconcile/autoscale watchdog caps and the exec/profile caps (values?).
 - **`cluster=` routing (follow-on):** hard constraint resolved by a pre-scheduler dispatcher
   that partitions tasks per backend, or inside each backend's eligibility filter?

--- a/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
+++ b/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
@@ -1,0 +1,479 @@
+---
+plan: tighten-iris-control-boundaries-multi-backend-readiness
+status: draft
+---
+
+# Tighten Iris control boundaries (multi-backend readiness)
+
+## Problem & goal
+
+The recent `TaskBackend` work pulled most backend specifics behind a contract, but
+the control plane is still **loose** in five concrete ways:
+
+1. The controller drives **seven independent `ManagedThread` loops**, each opening its
+   *own* DB snapshot on its *own* cadence and committing on its *own* schedule.
+   Coordination is only a single write `RLock` plus best-effort wake events — so the
+   scheduler, autoscaler and reconciler routinely act on **skewed snapshots** of the
+   same state.
+2. **Demand is computed twice.** The autoscaler does not consume the scheduler's
+   output; it re-derives demand by running the scheduler a *second* time as a dry-run
+   (`compute_demand_entries` → `scheduler.find_assignments`) against the shared mutable
+   `self._scheduler` on a *separate* snapshot. There is no synchronization boundary
+   between scheduler and autoscaler — they are two readers of the DB that happen to
+   agree most of the time.
+3. The `TaskBackend` contract is **one fat 13-method interface**. `K8sTaskProvider`
+   stubs out six of them (`schedule`/`manage_capacity`/`on_workers_failed`/`ping_workers`
+   return empty, `attach_autoscaler` raises `AssertionError`, `get_process_status`
+   raises `ProviderUnsupportedError`). Capability is tracked by two side-channel flags
+   (`placement`, `manages_capacity`) that can drift from which methods actually do work.
+4. The reconcile **result shape is backend-specific**: `BackendReconcileResult` carries
+   *both* `updates` (K8s) and `worker_results` (RPC); the controller picks the field by
+   `placement` and runs different apply paths. The controller "knows" each backend's
+   encoding.
+5. RPCs are bounded by **thread count** (a 1024-thread executor) but **not by latency**.
+   The timing interceptor only *measures*; nothing enforces a deadline. `launch_job`
+   blocks a handler thread for up to 120 s; the three on-demand one-offs each
+   re-implement controller→backend→worker fan-out with three different timeout
+   conventions; `get_autoscaler_status` fans out to all workers with no cap;
+   `execute_raw_query` has no row/time limit.
+
+**Long-term goal:** a *multi-backend* Iris — e.g. a GCP TPU cluster and a Slurm GPU
+cluster live simultaneously, jobs dispatched by a `cluster=` constraint. That future
+needs sharp boundaries *now*: the controller as a pure state/serialization layer, each
+backend exposing only the capabilities it actually has, a single demand artifact handed
+scheduler→autoscaler, and one bounded path for every RPC.
+
+**What "done" looks like for this plan:** this document — a verified map of the current
+control flow, five targeted, independently-shippable improvements with concrete code
+shapes, and a feasibility analysis with a recommended landing sequence. Implementation
+is tracked as the task breakdown below.
+
+### What is already good (don't regress it)
+
+The audit confirmed the design is *decent*, not broken — these properties hold today and
+every improvement below must preserve them:
+
+- `Scheduler.find_assignments(context) -> SchedulingResult` is a **pure function**, zero
+  runtime imports of controller state (`scheduling/scheduler.py`).
+- Both backends are **DB-clean**: neither `RpcTaskBackend` nor `K8sTaskProvider` imports
+  `db`/`reads`/`writes`/`schema`/`sqlalchemy`. Their imports of `controller.scheduling`/
+  `autoscaler`/`reconcile` are **types and pure logic only**.
+- Capability dispatch is **flag-based, never `isinstance`** (`placement`,
+  `manages_capacity` — `controller.py:761/1092/1234`).
+- The reconcile *kernel* (`reconcile/overlay|task|job|worker|effects`) is a **pure state
+  machine**; `reconcile/loader` → `snapshot` → kernel → `commit` is a clean
+  load→pure→write pipeline, and `writes.validate()` enforces projection-table ownership.
+- A single write `RLock` + `BEGIN IMMEDIATE` serializes all mutations; reads use a
+  separate `query_only` pool. Correctness is sound; the issue is *looseness and
+  duplication*, not races that corrupt state.
+
+### Static dependency-graph findings (the coupling smells)
+
+Package-level import graph over `cluster/controller`, `cluster/backends`, `rpc`
+(edge = "imports", verified against code):
+
+- `controller.scheduling → {db, reads, projections, budget, worker_health}` — these are
+  all in `policy.py` (the DB **context-builder**), *not* `scheduler.py`. The boundary is
+  in the right place but lives in the same package as the pure scheduler, which obscures
+  it.
+- `controller.autoscaler → {db, schema, worker_health}` — the autoscaler reads the DB at
+  startup (`restore_from_db`) and re-derives demand per-cycle (see Improvement 2).
+- `backends.rpc → {controller.scheduling, controller.autoscaler, controller.reconcile}`
+  and `backends.k8s → {controller.backend, controller.reconcile, controller.autoscaler}`
+  — backends reach *up* into controller modules. Confirmed to be types/pure-logic only,
+  but it means the contract type (`controller/backend.py`) itself imports
+  `autoscaler`/`scheduling`/`reconcile` (fan-in: 7 modules depend on `controller.backend`).
+- `controller.backend → {autoscaler, scheduling, reconcile, ops}` — the *contract*
+  module pulls in the scheduler and autoscaler, so "the backend abstraction" and "the
+  Iris-specific scheduling/capacity implementation" are not cleanly separable. This is
+  what Improvement 3 untangles.
+
+## Architecture (current control flow)
+
+```mermaid
+flowchart TB
+    classDef problem fill:#ffe1e1,stroke:#c0392b,stroke-width:2px,color:#000;
+    classDef pure fill:#e1f0ff,stroke:#2980b9,color:#000;
+    classDef store fill:#f5f0d8,stroke:#7f8c8d,color:#000;
+
+    subgraph SVC["Service RPCs — 1024-thread executor, NO per-call deadline"]
+        direction TB
+        R1["launch_job<br/>blocks a handler thread up to 120s<br/>draining the predecessor job"]:::problem
+        R2["get_/list_ status reads<br/>(bounded, via reads.py)"]
+        R3["profile_task / exec_in_container / get_process_status<br/>3 near-identical backend fan-outs, 3 timeout conventions"]:::problem
+        R4["get_autoscaler_status<br/>unbounded worker liveness fan-out"]:::problem
+        R5["execute_raw_query<br/>no row / statement-time limit"]:::problem
+    end
+
+    subgraph CTRL["Controller — owns SQLite + single write RLock; 7 independent ManagedThreads"]
+        direction TB
+        L1["scheduling loop<br/>~10s adaptive backoff + wake"]
+        L2["polling / reconcile loop<br/>5s + wake (IRIS placement)"]
+        L3["dispatch loop<br/>5s (TASK_BACKEND only)"]
+        L4["ping loop — 5s"]
+        L5["autoscaler loop<br/>10s (only if !manages_capacity)"]
+        L6["prune — 600s WAL / 3600s full"]
+        L7["checkpoint — optional"]
+    end
+
+    DB[("Controller DB<br/>state + decisions")]:::store
+
+    subgraph PURE["DB-free decision components"]
+        SCH["Scheduler.find_assignments(ctx)<br/>PURE"]:::pure
+        DEM["compute_demand_entries<br/>re-runs the scheduler as a DRY-RUN<br/>on a 2nd snapshot, limits disabled"]:::problem
+        ASP["Autoscaler<br/>evaluate/route/plan = PURE · execute = cloud ops"]:::pure
+    end
+
+    subgraph BK["TaskBackend — single 13-method contract"]
+        RPCB["RpcTaskBackend<br/>placement=IRIS_CONTROLLER"]
+        K8S["K8sTaskProvider<br/>placement=TASK_BACKEND<br/>stubs 6 methods (empty / raise)"]:::problem
+    end
+
+    L1 -->|"snapshot #1"| DB
+    L1 --> SCH
+    SCH -->|"assignments"| L1
+    L1 -->|"commit assignments / preemptions"| DB
+
+    L5 -->|"snapshot #2"| DB
+    L5 --> DEM
+    DEM -.->|"dry-run find_assignments"| SCH
+    L5 --> ASP
+    ASP -->|"AutoscalerState"| L5
+    L5 -->|"commit slices / scaling_groups"| DB
+
+    L2 -->|"snapshot"| DB
+    L2 --> RPCB
+    RPCB -.->|"worker_results"| L2
+    L3 --> K8S
+    K8S -.->|"updates"| L3
+    L2 -->|"commit"| DB
+    L3 -->|"commit"| DB
+    L4 --> RPCB
+
+    L6 --> DB
+    L7 --> DB
+
+    R2 --> DB
+    R4 --> DB
+    R3 --> BK
+
+    L1 -.->|"⚠ demand skew (separate snapshot)"| L5
+    L1 -.->|"⚠ snapshot skew"| L2
+```
+
+Legend: **red** = looseness/duplication this plan targets; **blue** = already-pure
+components to preserve; the two dashed ⚠ edges are the cross-loop snapshot races.
+
+## The five targeted improvements
+
+### I1 — Collapse the fast control loops into one phased "control tick"
+
+**Problem.** Five fast loops (`scheduling`, `polling/reconcile`, `dispatch`, `ping`,
+`autoscaler`) each open an independent DB snapshot and commit independently
+(`controller.py:_run_scheduling`, `_reconcile_tick`, `_sync_dispatch`, `_run_ping_loop`,
+`_run_autoscaler_once`). This is the "loose threading" the goal calls out: the scheduler
+commits assignments that the reconciler's just-captured snapshot can't see, and the
+autoscaler snapshots demand *after* the scheduler already placed it.
+
+**Change.** One driver thread runs a fixed-order tick over **one snapshot per tick**:
+
+```
+control_tick(now):
+    snap = build_control_snapshot(db)          # ONE read txn -> typed snapshot
+    effects = Effects()
+    if schedule_phase.due(now):                 # IRIS placement only
+        effects += run_schedule(snap)           # pure
+    if capacity_phase.due(now):                 # !manages_capacity only
+        effects += run_capacity(snap, effects.residual_demand)   # consumes I2 output
+    effects += run_reconcile(snap)              # backend I/O (bounded, I5)
+    if health_phase.due(now):
+        effects += run_health(snap)             # ping / liveness (backend I/O)
+    with db.transaction() as tx:                # ONE write txn
+        commit(tx, effects)
+```
+
+Per-phase `due(now)` predicates (a `RateLimiter` each) preserve the existing cadences
+(autoscale every ~10 s, ping every ~5 s) **without** a separate snapshot per phase. Wake
+events stop targeting individual loops; they just shorten the next tick deadline.
+`prune` and `checkpoint` stay as separate slow housekeeping threads — they are genuinely
+independent and must not block the control tick.
+
+**Serves:** poll-over-threading (#3); one snapshot fans out to DB-free abstractions (#1);
+and it is the structural enabler for the scheduler↔autoscaler sync boundary (#6).
+
+**Risk:** highest blast radius of the five — it rewrites the loop architecture in
+`controller.py`. Mitigation: land it *after* I2 and I4 so each phase is already a clean
+`(snapshot) -> effects` function; the tick is then just an ordering shell over functions
+that already exist. The backend I/O phases (reconcile, ping) must be bounded (I5) so one
+slow backend can't stall the whole tick.
+
+### I2 — Scheduler emits the demand model; autoscaler consumes it (delete the dry-run)
+
+**Problem.** `compute_demand_entries` (`scheduling/policy.py:181`) runs a **full dry-run**
+`scheduler.find_assignments(context)` (`policy.py:283`) on a *second* read snapshot
+(`policy.py:221,255`), with building/assignment limits disabled, against the shared
+mutable `self._scheduler` — *unlocked* (`controller.py:1240-1245`). So placement logic
+runs twice per cycle through two code paths, and the autoscaler's demand can diverge from
+what the scheduler actually did. This is precisely the missing "strong synchronization
+boundary between scheduler & autoscaler."
+
+**Change.** Make the **real** scheduling pass emit residual demand as a first-class
+output, so demand is computed exactly once and handed across a typed boundary:
+
+```python
+@dataclass(frozen=True)
+class ScheduleResult:
+    assignments: list[Assignment] = field(default_factory=list)
+    preemptions: list[TerminalDecision] = field(default_factory=list)
+    unschedulable: list[PendingTask] = field(default_factory=list)
+    # NEW: tasks that did not fit on existing capacity this tick, bucketed by
+    # requirement — the single source of truth for the autoscaler.
+    residual_demand: list[DemandEntry] = field(default_factory=list)
+    diagnostics: dict[str, str] = field(default_factory=dict)
+    post_taint_context: SchedulingContext | None = None
+```
+
+`find_assignments` already walks the per-worker capacity model; it computes
+`residual_demand` from the same traversal using **capacity-fit** semantics (what doesn't
+fit on existing/known capacity) while ignoring per-cycle *promotion* caps — so demand
+reflects saturation, not "what we declined to promote this tick." `compute_demand_entries`
+and its dry-run are **deleted**; `CapacityInput.demand_entries` is populated from
+`ScheduleResult.residual_demand` produced earlier in the same control tick (I1).
+
+**Serves:** one demand artifact across a typed boundary (#6); one way to compute demand
+(#5); removes a DB snapshot and the unlocked shared-scheduler access (#1).
+
+**Risk:** medium — must reproduce the dry-run's reservation-taint and holder-task
+behavior (`inject_reservation_taints`, holder demand) inside the real pass. Ships
+independently of I1 (immediate win: kills the double-compute), but the *full* sync
+guarantee only lands once I1 makes the two phases share a snapshot.
+
+### I3 — Segment the `TaskBackend` contract by capability (kill the stubs; ready multi-backend)
+
+**Problem.** One 13-method contract forces `K8sTaskProvider` to stub six methods
+(`tasks.py:1255-1269,1395,1404` — empty results, `AssertionError`,
+`ProviderUnsupportedError`). Capability lives in two side-channel flags that can drift
+from which methods actually do work.
+
+**Change.** Split the contract into composed capability protocols exposed as **optional
+sub-objects**, so capability is *structural* — a backend physically cannot offer an
+operation it doesn't implement:
+
+```python
+class TaskBackend(Protocol):              # core — every backend
+    name: str
+    def reconcile(self, inp: BackendReconcileInput) -> BackendReconcileResult: ...
+    def set_log_sink(self, ...) -> None: ...
+    def close(self) -> None: ...
+    # Capability handles (None == not offered):
+    placement: "PlacementBackend | None"  # exposes schedule(...)
+    capacity:  "CapacityBackend | None"   # exposes manage_capacity / on_workers_failed
+                                          #         / ping_workers / attach_autoscaler
+    oneoffs:   "OneOffOps"                # status / profile / exec (I5)
+
+class PlacementBackend(Protocol):
+    def schedule(self, inp: ScheduleInput) -> ScheduleResult: ...
+
+class CapacityBackend(Protocol):
+    def manage_capacity(self, inp: CapacityInput) -> CapacityResult: ...
+    def on_workers_failed(self, ids: list[WorkerId]) -> WorkersFailedResult: ...
+    def ping_workers(self, w: list[tuple[WorkerId, str | None]]) -> list[PingResult]: ...
+```
+
+Controller dispatch becomes presence checks, not flags:
+`if backend.placement is not None: ...`, `if backend.capacity is not None: ...`. The
+`backend_descriptor` capability strings (`backend.py:101`) derive from sub-object
+presence. Every stub and `raise` is deleted. This is also the shape the multi-backend
+future needs: a `BackendRegistry` holding N heterogeneous backends, the controller
+iterating those exposing `placement`/`capacity`, routed by a `cluster=` constraint. It
+also lets the contract module stop importing the Iris `Scheduler`/`Autoscaler` (those
+move behind `PlacementBackend`/`CapacityBackend` implementations).
+
+**Serves:** controller stops "knowing" backend specifics (#2); structural single-way
+dispatch (#5); the direct enabler of multi-backend.
+
+**Risk:** large but mechanical — touches the contract type, both backends, and ~6
+controller call sites. Highest *churn*, lowest *conceptual* risk. Sequence: define
+protocols → adapt both backends → migrate call sites → delete `manages_capacity`/
+`placement`-flag branches.
+
+### I4 — One reconcile result shape + route the reconcile-input through `reads.py`
+
+**Problem (a).** `BackendReconcileResult` carries both `updates` (K8s) and
+`worker_results` (RPC); the controller picks the field by placement
+(`controller.py:778` vs `1104`) and runs different apply paths. The controller knows each
+backend's encoding.
+**Problem (b).** The reconcile-input snapshot (`_snapshot_reconcile_inputs`, the raw
+`task_attempts ⋈ tasks` join around `controller.py:1038-1059`) bypasses `reads.py`, the
+single DB chokepoint. (Same class of violation in `policy.py`, `budget.py`,
+`checkpoint.py`.)
+
+**Change (a).** Unify on the **raw-observation** shape (`worker_results`) as the single
+result type, and run **one** apply path. The controller already holds the DB snapshot, so
+uid-resolution / worker-loss interpretation stays controller-side (preserving backend
+DB-purity); K8s wraps its `TaskUpdate`s as already-resolved observations that flow through
+the *same* `apply_reconcile`. Collapse `BackendReconcileResult` to one field and delete
+the placement branch at apply time.
+
+```python
+@dataclass(frozen=True)
+class BackendReconcileResult:
+    observations: list[ReconcileObservation]   # ONE shape; controller resolves+applies uniformly
+```
+
+**Change (b).** Move the reconcile-input join into a `reads.py` helper (or reuse
+`reconcile/loader.load_closed_snapshot`), and sweep the other raw-select sites behind
+`reads.py`, so `reads.py`/`writes.py` are the *only* modules issuing schema queries.
+
+**Serves:** controller = state, backend = operation (#2); one way to apply reconcile
+results (#5); central DB queries fan out from a single chokepoint (#1).
+
+**Risk:** medium. (a) and (b) are independent and individually shippable. The subtlety in
+(a) is that worker-loss interpretation needs the snapshot — keep it controller-side; the
+backend returns observations, never resolved DB rows.
+
+### I5 — Centralized RPC bounding: deadline interceptor + one bounded one-off path
+
+**Problem.** The 1024-thread executor bounds *thread count*, not *latency*. The
+`RequestTimingInterceptor` only logs (`interceptors.py` — no `raise` on overrun).
+`launch_job` blocks ≤120 s inline (`service.py:1122`). The three on-demand one-offs
+(`get_process_status`/`profile_task`/`exec_in_container`) each re-implement
+controller→backend→worker fan-out with three timeout conventions (client-driven, none,
+K8s-only 60 s default). `get_autoscaler_status` fans out to all workers uncapped;
+`execute_raw_query` has no row/time limit.
+
+**Change.**
+1. **Server-side deadline interceptor** — every RPC runs under a hard wall-clock cap
+   (default e.g. 30 s, per-method override) by submitting the handler to the bounded
+   executor with a `future.result(timeout=...)` and returning `DEADLINE_EXCEEDED` on
+   overrun. One chokepoint where latency is capped.
+2. **De-block `launch_job`** — don't hold a handler thread for 120 s. Record the
+   drain/replace intent and return; the control tick (I1) completes the replacement and
+   the client polls job status. (Interim: cap the wait at the RPC deadline.)
+3. **One bounded one-off path** — fold the three one-offs into a single
+   `OneOffOps.run(target, op, deadline)` on the backend handle (I3), dispatched through a
+   dedicated **bounded** `ThreadPoolExecutor` with a hard per-call timeout — one timeout
+   convention, one fan-out pool, one `ProviderUnsupportedError`. `get_autoscaler_status`'s
+   liveness fan-out uses the same bounded pool.
+4. **Cap `execute_raw_query`** with a row limit + statement timeout.
+
+**Serves:** all RPCs bounded + threadpool-dispatched + latency-capped (#4); one way for
+the on-demand one-offs (#5).
+
+**Risk:** low–medium. (1) and (4) are small, high-value, and ship immediately. (3) pairs
+naturally with I3's `oneoffs` handle. (2) interacts with I1 (the tick finishes the
+drain) — until I1 lands, cap-the-wait is the safe interim.
+
+## Constraint → improvement coverage
+
+| Constraint | Addressed by |
+|---|---|
+| Central DB queries fan out to DB-free abstractions | I1 (one snapshot/tick), I2 (single demand artifact), I4b (reads.py chokepoint) |
+| Controller handles state, backends handle operation | I3 (capability segregation), I4a (uniform result + apply) |
+| Prefer poll workflows vs loose threading | I1 (phased control tick) |
+| All RPCs bounded, threadpool-dispatched, latency-capped | I5 (deadline interceptor + bounded one-off pool) |
+| Only one way to do something | I2 (one demand path), I4 (one result shape), I5 (one one-off path) |
+| Strong sync boundary scheduler ↔ autoscaler | I1 (shared snapshot, phase order) + I2 (typed handoff) |
+
+## Tasks
+
+Each task has a stable id. `exec: session` tasks become weaver issues on
+`weaver plan sync … --apply`. Ordered by the recommended landing sequence (see
+Feasibility), not by id.
+
+### T1 — I5a: server-side RPC deadline interceptor + cap raw query  `exec: session`  `value: high`  `deps: —`
+Add a deadline-enforcing interceptor (per-method cap, default ~30 s) that returns
+`DEADLINE_EXCEEDED` on overrun; add row limit + statement timeout to `execute_raw_query`.
+Smallest, safest, immediately caps tail latency. Acceptance: a handler that sleeps past
+its cap returns `DEADLINE_EXCEEDED`; raw query truncates at the row limit.
+
+### T2 — I2: scheduler emits residual demand, delete the dry-run  `exec: session`  `value: high`  `deps: —`
+Add `residual_demand` to `ScheduleResult`, compute it in `find_assignments`, delete
+`compute_demand_entries`' dry-run, feed the autoscaler from the scheduler's output.
+Acceptance: autoscaler provisions identically on representative fixtures with the
+scheduler invoked once per cycle; no `scheduler.find_assignments` call remains in the
+autoscaler path.
+
+### T3 — I4: unify reconcile result shape + route reconcile-input via reads.py  `exec: session`  `value: medium`  `deps: —`
+Collapse `BackendReconcileResult` to one observation list with one apply path; move the
+reconcile-input join (and the policy/budget/checkpoint raw selects) behind `reads.py`.
+Acceptance: controller has a single apply path independent of placement; no schema query
+outside `reads.py`/`writes.py`/projections.
+
+### T4 — I3: segment TaskBackend into capability protocols  `exec: session`  `value: high`  `deps: T3`
+Define `PlacementBackend`/`CapacityBackend`/`OneOffOps`, expose as optional sub-objects,
+migrate controller call sites to presence checks, delete all K8s stubs and the
+`placement`/`manages_capacity` flag branches. Acceptance: no stub/`raise`-`NotImplemented`
+methods on any backend; `grep` finds no `manages_capacity`/`placement ==` branches in the
+controller; `backend_descriptor` derives capabilities from sub-object presence.
+
+### T5 — I5c: consolidate the three on-demand one-offs onto OneOffOps  `exec: session`  `value: medium`  `deps: T4`
+Fold `get_process_status`/`profile_task`/`exec_in_container` into one bounded
+`OneOffOps.run(target, op, deadline)` over a dedicated bounded pool; route
+`get_autoscaler_status` liveness through the same pool. Acceptance: one timeout
+convention, one `ProviderUnsupportedError` path; all three RPCs delegate to the shared op.
+
+### T6 — I1: collapse fast loops into one phased control tick  `exec: session`  `value: high`  `deps: T2, T3`
+Replace the five fast `ManagedThread` loops with one driver running
+snapshot → schedule → capacity → reconcile → health → commit, per-phase `due()` cadence,
+one snapshot/tick; keep prune/checkpoint separate. Acceptance: one control thread; one
+read snapshot + one write txn per tick (verified by a counter/test); cadences preserved;
+chaos/integration suite green.
+
+## Feasibility analysis
+
+**Overall: feasible and incremental.** None of the five requires a data-model change or a
+migration; all are refactors over an already-sound state layer. The pure scheduler,
+DB-clean backends, and flag-based (non-`isinstance`) dispatch that exist today are the
+foundation each improvement builds on.
+
+**Recommended landing sequence** (dependencies in parentheses):
+
+1. **T1 (I5a)** — independent, ~1 session, immediate tail-latency safety. No design risk.
+2. **T2 (I2)** — independent, high value (deletes a whole duplicate scheduling pass and an
+   unlocked shared-object access). The only care item is reproducing reservation-taint /
+   holder-task demand in the real pass.
+3. **T3 (I4)** — independent; unifies the reconcile boundary and closes the `reads.py`
+   chokepoint. Prereq for clean phase functions in T6.
+4. **T4 (I3)** — depends on T3 (so the reconcile sub-object is already clean). Large churn,
+   low conceptual risk; this is the multi-backend keystone.
+5. **T5 (I5c)** — depends on T4's `oneoffs` handle. Small once T4 lands.
+6. **T6 (I1)** — depends on T2 + T3 so every phase is already a `(snapshot) -> effects`
+   function; the tick is then an ordering shell, not a rewrite. Highest blast radius —
+   land last, behind the chaos/integration suite, ideally with a feature flag to fall
+   back to the legacy loops during bake.
+
+**Risk register:**
+
+- *T6 is the one to fear.* Folding five cadences into one tick can starve a phase or
+  change effective latency under load. Mitigation: per-phase `due()` predicates preserve
+  cadence; keep the bounded backend I/O (T1/T5) so no phase stalls the tick; ship behind a
+  flag and bake on `marin-dev` before `marin`. **Never bounce the live controller without
+  the user's explicit OK** (AGENTS.md).
+- *T2 correctness:* demand semantics must match today's dry-run on reservation/holder
+  jobs. Mitigation: golden-fixture parity test (same demand entries in/out) before
+  deleting the dry-run.
+- *T4 churn:* mechanical but wide. Mitigation: protocol-first, adapt backends, then migrate
+  call sites in one pass; pyrefly + the existing capability tests catch drift.
+- *Cross-region / cost:* none of these move data across regions; pure control-plane code.
+- *Multi-backend itself is out of scope here* — these five make it *tractable* (capability
+  registry, `cluster=` routing, per-backend ticks) but the registry/routing work is a
+  follow-on plan once T4 + T6 land.
+
+**Independently shippable now (no deps):** T1, T2, T3. **Sequenced:** T4 → T5; T6 last.
+Estimated ~6 focused sessions; T1–T3 can run in parallel.
+
+## Open questions
+
+- **I1 cadence:** keep per-phase `RateLimiter`s inside one tick (recommended), or run the
+  autoscaler on its own slower tick that still consumes the scheduler's published
+  `residual_demand`? The former gives the strongest sync boundary; the latter is a smaller
+  diff.
+- **I2 residual semantics:** confirm "capacity-fit, promotion-cap-free" is the demand the
+  autoscaler wants (matches today's `_UNLIMITED` dry-run) — verify against a cold-start
+  fixture with reservations.
+- **I5 default deadline:** what is the right global RPC cap (30 s?) and which methods need
+  explicit overrides (profile/exec are inherently long)?
+- **Multi-backend routing:** is `cluster=<name>` a hard constraint resolved at submit
+  time, or a soft preference the scheduler can override? Affects whether routing lives in
+  the scheduler or a pre-scheduler dispatcher. (Follow-on plan.)

--- a/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
+++ b/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
@@ -5,89 +5,70 @@ status: draft
 
 # Tighten Iris control boundaries (multi-backend readiness)
 
-> Revised after maintainer review. The chosen direction is sharper than the first
-> draft: **push placement/capacity logic into the backend** behind one uniform
-> interface (don't have the controller dispatch capabilities), **fold the autoscaler
-> and ping loops into a single control tick**, and **bound every call the controller
-> *dispatches into* a backend** (not the inbound service handlers). `cluster=` is a
-> **hard** constraint. The single-tick model is the target.
+> Revised twice: once for the maintainer's direction (uniform backend interface, single
+> control tick, bounded backend dispatch), then again after an **adversarial review** that
+> caught four things the earlier draft oversold as "already true / free." Those are now
+> scoped as explicit work: (E1) reconcile-error → liveness, (E2) residual demand is a real
+> capacity-fit, (E4) the autoscaler is not DB-clean, (B2) the failure→slice-teardown path.
+> `cluster=` is a **hard** constraint; the single-tick model is the target.
 
 ## Problem & goal
 
-The recent `TaskBackend` work pulled most backend specifics behind a contract, but
-the control plane is still **loose** in five concrete ways:
+The recent `TaskBackend` work pulled most backend specifics behind a contract, but the
+control plane is still **loose**:
 
-1. The controller drives **seven independent `ManagedThread` loops**, each opening its
-   *own* DB snapshot on its *own* cadence and committing on its *own* schedule.
-   Coordination is only a single write `RLock` plus best-effort wake events — so the
-   scheduler, autoscaler and reconciler routinely act on **skewed snapshots** of the
-   same state.
-2. **Demand is computed twice.** The autoscaler does not consume the scheduler's
-   output; it re-derives demand by running the scheduler a *second* time as a dry-run
-   (`compute_demand_entries` → `scheduler.find_assignments`) against the shared mutable
-   `self._scheduler` on a *separate* snapshot. No synchronization boundary exists between
-   scheduler and autoscaler — they are two readers of the DB that happen to agree most of
-   the time.
-3. The controller **dispatches on backend type/capability**. It branches on `placement`
-   (`controller.py:761/1092`) and `manages_capacity` (`1234`) to pick between a dispatch
-   loop and a reconcile loop, and `K8sTaskProvider` stubs six contract methods
-   (`tasks.py:1255-1269,1395,1404`). The controller "knows" how each backend works.
-4. The reconcile **result shape is backend-specific**: `BackendReconcileResult` carries
-   *both* `updates` (K8s) and `worker_results` (RPC); the controller picks the field by
-   `placement` and runs different apply paths.
-5. **Calls the controller dispatches into a backend are not uniformly bounded.** Reconcile
-   and ping fan out with a 10 s per-worker timeout and 128-way semaphore (good), but
-   `RpcTaskBackend.reconcile` runs `asyncio.run(...)` on the *caller* thread, so a slow
-   batch stalls whatever loop called it; and `exec_in_container` permits an RPC deadline
-   of **up to one hour** (`backend.py:232-237`). There is no single place that guarantees
-   "any call into a backend completes within a bound."
+1. The controller drives **seven independent `ManagedThread` loops**, each opening its own
+   DB snapshot on its own cadence and committing on its own schedule. Coordination is a
+   single write `RLock` plus wake events — so scheduler, autoscaler and reconciler act on
+   **skewed snapshots**.
+2. **Demand is computed twice.** The autoscaler re-derives demand by running the scheduler
+   a *second* time as a dry-run (`compute_demand_entries` → `scheduler.find_assignments`,
+   `policy.py:283`) on a *separate* snapshot, against a *separate* `Scheduler` instance
+   (`controller.py:350`) from the one the backend schedules with (`backend.py:141`).
+3. The controller **dispatches on backend type**: it branches on `placement`
+   (`controller.py:761/1092`) and `manages_capacity` (`1234`); `K8sTaskProvider` stubs six
+   contract methods.
+4. The reconcile **result shape is backend-specific** — `BackendReconcileResult` carries
+   both `updates` (K8s) and `worker_results` (RPC); the controller picks by `placement`.
+5. **Calls the controller dispatches into a backend are not uniformly bounded.**
+   `RpcTaskBackend.reconcile` runs `asyncio.run(...)` on the *caller* thread
+   (`backend.py:153`), and `exec_in_container` permits an RPC deadline of **up to one hour**
+   (`backend.py:232-237`).
 
-**Long-term goal:** a *multi-backend* Iris — e.g. a GCP TPU cluster and a Slurm GPU
-cluster live simultaneously, jobs dispatched by a **hard `cluster=<name>` constraint**.
-That future needs the controller to be a pure state/serialization layer that calls **one
-uniform interface** on every backend and persists whatever DB-shaped deltas come back —
-never branching on which backend it is talking to.
+**Long-term goal:** a *multi-backend* Iris (e.g. GCP TPU + Slurm GPU clusters), jobs routed
+by a **hard `cluster=<name>` constraint**. The controller must be a pure state/serialization
+layer that calls **one uniform interface** on every backend and persists the DB-shaped
+results — never branching on which backend it is.
 
-**What "done" looks like for this plan:** this document — a verified map of the current
-control flow, a target control flow, and five targeted improvements with concrete code
-shapes and a feasibility analysis with a recommended landing sequence. Implementation is
-tracked as the task breakdown below.
+**What "done" looks like for this plan:** a verified map of the current control flow, a
+target flow, and five improvements with concrete code shapes and an honest feasibility
+analysis. Implementation is the task breakdown below.
 
-### What is already good (don't regress it)
+### What is already good — and the precise caveats (post-review)
 
-- `Scheduler.find_assignments(context) -> SchedulingResult` is a **pure function**, zero
-  runtime imports of controller state (`scheduling/scheduler.py`).
-- Both backends are **DB-clean**: neither `RpcTaskBackend` nor `K8sTaskProvider` imports
-  `db`/`reads`/`writes`/`schema`/`sqlalchemy`. The `RpcTaskBackend` *already owns* its
-  `Scheduler` (`backend.py:141`) and `Autoscaler` (`backend.py:136`) — Improvement 3 just
-  finishes the job of making the controller stop orchestrating them.
-- Capability dispatch is **flag-based, never `isinstance`** today — but the goal is to
-  delete the flags entirely (Improvement 3).
+- `Scheduler.find_assignments(context) -> SchedulingResult` is a **pure function**
+  (`scheduling/scheduler.py`). But it returns only `assignments` and marks a job
+  `exhausted` on the first capacity miss without recording *why* — so residual demand does
+  **not** fall out of it for free (see I2). And there are **two** `Scheduler` instances —
+  the controller's (`controller.py:350`, feeds the building cap at `814` and the dry-run at
+  `1242`) and the backend's (`backend.py:141`) — which I2/I3 must reconcile.
+- The backend **classes** are DB-clean (no `db`/`reads`/`schema`/`sqlalchemy` imports). The
+  `Autoscaler` they own is **not**: `runtime.restore_from_db(db)` (`autoscaler/runtime.py:682`)
+  and `autoscaler/recovery.py`/`persistence.py` import `schema` and issue SQL. Its per-cycle
+  `evaluate/update` is pure and capacity **persist is already controller-side**
+  (`persist_autoscaler_state`, `controller.py:1249`), but **startup-restore touches the DB**.
+  I3 must keep restore controller-driven so the backend stays DB-less per-tick.
+- Reconcile already **reaches** every active healthy worker
+  (`reads.list_active_healthy_workers`, `controller.py:1017`; idle workers get an empty-rows
+  heartbeat). But reconcile RPC errors today only `logger.debug` (`controller.py:1109-1111`)
+  — they do **not** feed `WorkerHealthTracker`. The failure signal (`consecutive_failures`)
+  is produced **only** by the ping loop's `_health.ping(healthy=False)`
+  (`controller.py:1156-1160`, `worker_health.py`). So the ping loop is vestigial for
+  *reaching* workers but is the **sole producer of the liveness-failure signal** — dropping
+  it is real new work (I1 / task T5).
 - The reconcile *kernel* (`reconcile/overlay|task|job|worker|effects`) is a **pure state
-  machine**; `loader → snapshot → kernel → commit` is a clean load→pure→write pipeline,
-  and `writes.validate()` enforces projection-table ownership.
-- Reconcile already fans out to **every active healthy worker**
-  (`reads.list_active_healthy_workers`, `controller.py:1017`); idle workers get an
-  empty-rows heartbeat reconcile — which is *why* the separate ping loop is now vestigial
-  (Improvement 1).
-
-### Static dependency-graph findings (the coupling smells)
-
-Package-level import graph over `cluster/controller`, `cluster/backends`, `rpc`
-(edge = "imports", verified against code):
-
-- `controller.backend → {autoscaler, scheduling, reconcile, ops}` — the *contract* module
-  pulls in the scheduler and autoscaler, so "the backend abstraction" and "the
-  Iris-specific scheduling/capacity implementation" are tangled. Improvement 3 moves that
-  logic fully *inside* `RpcTaskBackend` so the contract carries only the uniform interface.
-- `backends.rpc → {controller.scheduling, controller.autoscaler, controller.reconcile}`
-  — backends reach *up* into controller modules; confirmed types/pure-logic only. After
-  Improvement 3 these become the backend's *own* internals, not shared contract surface.
-- `controller.scheduling → {db, reads, projections, budget}` — all in `policy.py` (the DB
-  context-builder), not `scheduler.py`. Improvement 4 routes the remaining raw queries
-  through `reads.py` so the controller's snapshot build is the single DB fan-out point.
-- `controller.autoscaler → {db, schema, worker_health}` — startup `restore_from_db` +
-  per-cycle re-derivation; the latter is deleted by Improvement 2.
+  machine**; `loader → snapshot → kernel → commit` is clean; `writes.validate()` enforces
+  projection-table ownership.
 
 ## Architecture — current control flow
 
@@ -99,62 +80,57 @@ flowchart TB
 
     subgraph DISP["Controller -> backend calls (NOT uniformly bounded)"]
         direction TB
-        R3["profile_task / exec_in_container / get_process_status<br/>3 fan-outs, 3 timeout conventions; exec allows ~1h deadline"]:::problem
-        R4["reconcile / ping fan-out<br/>10s/worker + 128 sem, but asyncio.run blocks the caller loop"]:::problem
+        R3["profile / exec / get_process_status<br/>already on the rpc-handler pool, but exec allows ~1h deadline"]:::problem
+        R4["reconcile fan-out<br/>10s/worker + 128 sem, but asyncio.run blocks the CALLER loop"]:::problem
     end
 
-    subgraph CTRL["Controller — owns SQLite + single write RLock; 7 independent ManagedThreads"]
+    subgraph CTRL["Controller — owns SQLite + single write RLock; 7 ManagedThreads"]
         direction TB
-        L1["scheduling loop<br/>~10s adaptive backoff + wake"]
-        L2["polling / reconcile loop<br/>5s + wake (IRIS placement)"]
-        L3["dispatch loop<br/>5s (TASK_BACKEND only)"]
-        L4["ping loop — 5s (vestigial: reconcile already reaches all workers)"]:::problem
-        L5["autoscaler loop<br/>10s (only if !manages_capacity)"]
-        L6["prune — 600s WAL / 3600s full"]
-        L7["checkpoint — optional"]
+        L1["scheduling loop (~10s backoff + RPC wake)"]
+        L2["polling / reconcile loop (5s + wake)"]
+        L3["dispatch loop (5s, TASK_BACKEND only)"]
+        L4["ping loop (5s) — SOLE producer of the worker-failure signal"]:::problem
+        L5["autoscaler loop (10s) — runs for every non-K8s backend"]
+        L6["prune (600s / 3600s)"]
+        L7["checkpoint (optional)"]
     end
 
-    DB[("Controller DB<br/>state + decisions")]:::store
+    DB[("Controller DB")]:::store
 
     subgraph PURE["DB-free decision components"]
-        SCH["Scheduler.find_assignments(ctx)<br/>PURE"]:::pure
-        DEM["compute_demand_entries<br/>re-runs the scheduler as a DRY-RUN<br/>on a 2nd snapshot, limits disabled"]:::problem
-        ASP["Autoscaler<br/>evaluate/route/plan = PURE · execute = cloud ops"]:::pure
+        SCH["Scheduler.find_assignments (PURE) — TWO instances"]:::pure
+        DEM["compute_demand_entries<br/>DRY-RUN re-run on a 2nd snapshot, limits disabled"]:::problem
+        ASP["Autoscaler — evaluate PURE; restore_from_db + execute touch DB/cloud"]
     end
 
-    subgraph BK["TaskBackend — single 13-method contract; controller branches on type"]
-        RPCB["RpcTaskBackend (IRIS)<br/>owns Scheduler + Autoscaler"]
-        K8S["K8sTaskProvider (TASK_BACKEND)<br/>stubs 6 methods (empty / raise)"]:::problem
+    subgraph BK["TaskBackend — 13-method contract; controller branches on type"]
+        RPCB["RpcTaskBackend (IRIS) — owns Scheduler + Autoscaler"]
+        K8S["K8sTaskProvider (TASK_BACKEND) — stubs 6 methods"]:::problem
     end
 
     L1 -->|"snapshot #1"| DB
     L1 --> SCH
     SCH -->|"assignments"| L1
     L1 -->|"commit"| DB
-
     L5 -->|"snapshot #2"| DB
     L5 --> DEM
-    DEM -.->|"dry-run find_assignments"| SCH
+    DEM -.->|"dry-run"| SCH
     L5 --> ASP
     ASP -->|"AutoscalerState"| L5
     L5 -->|"commit"| DB
-
     L2 -->|"snapshot"| DB
-    L2 --> R4
-    R4 --> RPCB
+    L2 --> R4 --> RPCB
     RPCB -.->|"worker_results"| L2
-    L3 --> R4
-    R4 --> K8S
+    L3 --> R4 --> K8S
     K8S -.->|"updates"| L3
     L2 -->|"commit"| DB
     L3 -->|"commit"| DB
     L4 --> R4
-
     L6 --> DB
     L7 --> DB
     R3 --> BK
 
-    L1 -.->|"⚠ demand skew (separate snapshot)"| L5
+    L1 -.->|"⚠ demand skew (2nd snapshot, 2nd scheduler)"| L5
     L1 -.->|"⚠ snapshot skew"| L2
 ```
 
@@ -167,99 +143,106 @@ flowchart TB
 
     subgraph TICK["Control tick — ONE thread, ONE snapshot/tick"]
         direction TB
-        S0["build snapshot (reads.py, one read txn)"]
-        S1["schedule phase (due ~10s)<br/>→ backend.schedule(snapshot)"]
-        S2["reconcile phase (every tick)<br/>→ backend.reconcile(desired+observed)"]
-        S3["commit uniform deltas (one write txn)"]
+        S0["build ControlSnapshot (reads.py, one read txn)"]
+        S1["schedule phase (due ~10s, or on RPC wake)<br/>backend.schedule() = DECISION → assignments + residual_demand<br/>backend.manage_capacity(residual) = OPERATION → AutoscalerState"]
+        S2["reconcile phase (every tick) → backend.reconcile()<br/>+ liveness: reconcile errors bump health, terminate over-threshold"]
+        S3["commit BackendResult (one write txn, one apply path)"]
         S0 --> S1 --> S2 --> S3
     end
 
-    subgraph HK["Housekeeping threads (genuinely independent)"]
+    subgraph HK["Housekeeping threads"]
         P["prune"]
         C["checkpoint"]
     end
 
     DB[("Controller DB")]:::store
 
-    subgraph BD["BackendDispatch — every controller→backend call<br/>threadpool + hard per-call deadline"]
-        D["submit(call, deadline)"]
+    subgraph BD["per-backend bounded dispatch (threadpool + generous timeout)<br/>wraps the I/O calls only: reconcile fan-out, capacity ops, one-offs"]
+        D["submit(io_call, deadline)"]
     end
 
-    subgraph BK["Backends — UNIFORM interface; own their placement + capacity"]
-        RPCB["RpcTaskBackend<br/>schedule() = find_assignments → residual_demand<br/>→ autoscaler.update(residual) → DB-shaped deltas"]:::good
-        K8S["K8sTaskProvider<br/>Kueue places; pod diff → DB-shaped deltas"]:::good
+    subgraph BK["Backends — UNIFORM interface; own placement + capacity"]
+        RPCB["RpcTaskBackend — owns ONE Scheduler + Autoscaler"]:::good
+        K8S["K8sTaskProvider — Kueue places; pod diff"]:::good
     end
 
     S0 --> DB
+    S1 -->|"schedule = in-process decision (no dispatch)"| RPCB
     S1 --> BD
     S2 --> BD
     BD --> RPCB
     BD --> K8S
-    RPCB -->|"uniform deltas"| S3
-    K8S -->|"uniform deltas"| S3
+    RPCB -->|"BackendResult"| S3
+    K8S -->|"BackendResult"| S3
     S3 --> DB
     P --> DB
     C --> DB
 ```
 
-Net thread count: **7 → 3** (one control tick + prune + checkpoint). The controller never
-branches on backend type; it builds a snapshot, calls the same interface on every backend,
-and persists whatever uniform deltas come back through one apply path.
+Net threads: **7 → 3** (control tick + prune + checkpoint). The controller builds a
+snapshot, calls one interface, and persists `BackendResult` through one apply path —
+dispatching on the **result shape**, never the backend type. `schedule` stays a pure
+in-process decision; only the actual **I/O** (reconcile fan-out, capacity cloud ops,
+one-offs) goes through the bounded dispatch.
 
 ## The five targeted improvements
 
-### I1 — One phased control tick; delete the autoscaler, ping, and dispatch threads
+### I1 — One phased control tick; drop the autoscaler & dispatch loops; **migrate** ping's liveness signal
 
-**Problem.** Five fast loops each open an independent snapshot and commit independently
-(`_run_scheduling`, `_reconcile_tick`, `_sync_dispatch`, `_run_ping_loop`,
-`_run_autoscaler_once`). The ping loop is vestigial — reconcile already reaches every
-active healthy worker (verified above). The dispatch loop is just "reconcile for
-TASK_BACKEND placement." The autoscaler loop re-snapshots state the scheduler just read.
+**Problem.** Five fast loops each re-snapshot and commit independently. The dispatch loop is
+just "reconcile for TASK_BACKEND." The autoscaler loop re-snapshots state the scheduler just
+read. The ping loop reaches workers reconcile already reaches — **but it is the only thing
+that produces the worker-failure signal** (verified: reconcile errors only log,
+`controller.py:1109-1111`; `consecutive_failures` is bumped only by `_health.ping`).
 
 **Change.** One driver thread, one snapshot per tick, fixed phase order:
 
 ```
 control_tick(now):
-    snap = build_control_snapshot(db)          # ONE read txn via reads.py (I4)
-    deltas = Deltas()
-    if schedule_phase.due(now):                 # autoscaler folded in here (I2/I3)
-        deltas += backend.schedule(snap)        # backend owns placement + capacity
-    deltas += backend.reconcile(snap, deltas)   # bounded dispatch (I5); reaches all workers
-    deltas += derive_liveness(deltas)           # over-threshold terminations off reconcile errors
-    with db.transaction() as tx:                # ONE write txn
-        commit(tx, deltas)                      # one uniform apply path (I3/I4)
+    snap = build_control_snapshot(db)              # ONE read txn via reads.py (I4)
+    result = BackendResult()
+    if schedule_phase.due(now) or woken:
+        result += backend.schedule(snap)           # pure decision: assignments + residual_demand
+        result += backend.manage_capacity(snap, result.residual_demand)   # capacity OPERATION (I5-bounded)
+    if reconcile_phase.due(now):
+        rec = backend.reconcile(snap, result)      # bounded dispatch (I5); reaches all workers
+        result += rec
+        result += liveness_from(rec)               # NEW: bump health on RPC errors, terminate over-threshold
+    with db.transaction() as tx:                   # ONE write txn, one apply path
+        commit(tx, result)
 ```
 
-Per-phase `due(now)` predicates (one `RateLimiter` each) preserve cadences (schedule/
-autoscale ~10 s, reconcile every tick ~5 s) **without** a separate snapshot per phase.
-Wake events just shorten the next tick deadline.
-
-- **Drop the ping loop.** Reconcile contacts every active worker; fold ping's only unique
-  job — terminating workers past the failure threshold — onto reconcile-RPC errors
-  (`ReconcileResult.error` already exists; bump `WorkerHealthTracker`, terminate
-  over-threshold in the same tick). No idle-worker liveness gap.
-- **Drop the dispatch loop.** Unify it into the single reconcile phase (I3 makes the
-  reconcile input uniform across placements).
-- **Drop the autoscaler loop.** Folded into the schedule phase (I2).
-- **Keep** prune + checkpoint as separate slow housekeeping threads.
+- **Migrate ping's liveness signal (new work, task T5).** Translate `ReconcileResult.error`
+  → `WorkerHealthTracker` failure bumps → over-threshold termination, plus the
+  failure→sibling-slice-teardown path (today `backend.on_workers_failed`,
+  `controller.py:1182-1222`) folded into the tick. This is *not* "for free"; it has its own
+  test (a worker whose reconcile RPC fails N times is failed and its slice torn down).
+- **Drop the dispatch loop** — it is the reconcile phase for TASK_BACKEND placement (uniform
+  after I3).
+- **Drop the autoscaler loop** — folded into the schedule phase (I2).
+- **Scheduling latency:** today RPC handlers wake the scheduler thread directly. In one tick,
+  a submit-wake must not be gated on an in-flight reconcile — a wake triggers a
+  **schedule-only mini-tick** (reconcile skipped unless due), so worst-case submit→assign =
+  schedule time, not (reconcile cap + schedule). State and confirm this bound.
+- **Keep** prune + checkpoint as separate housekeeping threads.
 
 **Serves:** poll over loose threading (#3); one snapshot fans out to DB-free abstractions
 (#1); strong scheduler↔autoscaler sync (#6).
 
-**Risk:** highest blast radius. Land it *after* I2/I3/I4 so each phase is already a clean
-`(snapshot) -> deltas` call; the tick is then an ordering shell. Backend I/O must be
-bounded (I5) so a slow backend never stalls the tick. Ship behind a flag; bake on
-`marin-dev`. **Never bounce the live controller without explicit OK** (AGENTS.md).
+**Risk:** highest blast radius; land last. Ship behind a fallback flag; bake on `marin-dev`.
+Never bounce the live controller without explicit OK (AGENTS.md).
 
-### I2 — Scheduler emits residual demand; autoscaler runs off it (one phase, no dry-run, no thread)
+### I2 — One scheduler, one snapshot: co-locate residual demand; autoscaler off it (no dry-run, no thread)
 
-**Problem.** `compute_demand_entries` (`policy.py:181`) runs a **full dry-run**
-`scheduler.find_assignments` (`policy.py:283`) on a *second* snapshot, limits disabled,
-against the shared mutable `self._scheduler` — *unlocked* (`controller.py:1240-1245`). So
-placement runs twice per cycle through two paths on two snapshots.
+**Problem.** Demand is a **second** `find_assignments` dry-run on a **second** snapshot with
+limits disabled (`policy.py:268-285`), against a **second** `Scheduler` instance. The real
+pass runs with `max_assignments_per_worker`/`max_building_tasks` caps and marks jobs
+exhausted without recording cap-vs-capacity — so the residual genuinely needs a
+**limits-free capacity fit**, not a by-product of the capped pass.
 
-**Change.** The real scheduling pass emits residual demand as a first-class output, and
-the autoscaler consumes it **in the same phase** — no separate loop, no dry-run:
+**Change.** Keep the capacity-fit computation (it is real), but compute it **once, on the
+same snapshot, with a single `Scheduler` instance**, and hand the result to the autoscaler
+in-memory in the same phase:
 
 ```python
 @dataclass(frozen=True)
@@ -267,243 +250,241 @@ class ScheduleResult:
     assignments: list[Assignment] = field(default_factory=list)
     preemptions: list[TerminalDecision] = field(default_factory=list)
     unschedulable: list[PendingTask] = field(default_factory=list)
-    residual_demand: list[DemandEntry] = field(default_factory=list)   # NEW: single demand source
-    autoscaler_state: AutoscalerState | None = None                    # NEW: capacity delta, same call
+    residual_demand: list[DemandEntry] = field(default_factory=list)   # NEW: limits-free capacity-fit residual
     diagnostics: dict[str, str] = field(default_factory=dict)
     post_taint_context: SchedulingContext | None = None
 ```
 
-`find_assignments` already walks the per-worker capacity model; it computes
-`residual_demand` from the same traversal (capacity-fit, ignoring per-cycle *promotion*
-caps, matching today's `_UNLIMITED` dry-run). Inside `RpcTaskBackend.schedule` (I3) the
-flow becomes `find_assignments → residual_demand → autoscaler.refresh/probe/update(residual)
-→ persistable_state()`, returned as one delta set. `compute_demand_entries` and the
-autoscaler thread are **deleted**.
+The win is **not** "free demand" — it is: one snapshot (not two), one `Scheduler` (reconcile
+`controller.py:350` and `backend.py:141`), demand handed across a typed in-memory boundary,
+and the separate autoscaler thread + `compute_demand_entries` plumbing deleted. The residual
+is still a deliberate limits-free fit co-located in the schedule path. The **golden-fixture
+parity test is load-bearing** (same demand entries in/out, incl. reservation/holder cases),
+not just a refactor guard.
 
-**Serves:** one demand artifact across a typed boundary (#6); one way to compute demand
-(#5); removes a snapshot and the unlocked shared-scheduler access (#1).
+**Serves:** one demand artifact across a typed boundary (#6); one way to compute demand (#5);
+removes a snapshot + the unlocked dual-scheduler access (#1).
 
-**Risk:** medium — must reproduce the dry-run's reservation-taint / holder-task demand in
-the real pass. Guard with a golden-fixture parity test before deleting the dry-run.
+**Risk:** medium-high — reproducing reservation-taint / holder-task demand semantics exactly.
 
-### I3 — One uniform backend interface; push placement/capacity into the backend; controller dispatches only on returned deltas
+### I3 — One uniform backend interface; controller persists `BackendResult`, never branches on type — but keep decision separate from operation
 
-**Problem.** The controller orchestrates backend specifics — it branches on `placement`
-and `manages_capacity`, calls `schedule`/`manage_capacity`/`reconcile`/`ping_workers` in a
-type-specific sequence, and reads a type-specific result field (`updates` vs
-`worker_results`). K8s stubs six methods.
+**Problem.** The controller orchestrates backend specifics (branches on `placement`/
+`manages_capacity`; type-specific result fields; K8s stubs).
 
-**Change.** Make the contract a single uniform interface that **every** backend
-implements, push all placement/capacity logic *inside* the backend, and have the
-controller persist whatever DB-shaped deltas come back — dispatching on the **delta type**,
-never the backend type:
+**Change.** A single uniform interface every backend implements, with the Iris scheduler/
+autoscaler living *inside* `RpcTaskBackend`. The controller persists the returned
+`BackendResult` through one apply path, dispatching on **result shape**, never backend type:
 
 ```python
 class TaskBackend(Protocol):
     name: str
-    # Decide: place tasks + manage capacity for this cluster, over a DB-less snapshot.
-    # RpcTaskBackend runs the Iris scheduler + autoscaler internally; K8s lets Kueue place.
-    def schedule(self, snap: ControlSnapshot) -> BackendDeltas: ...
-    # Operate: drive the cluster toward desired state, observe actual state.
-    def reconcile(self, snap: ControlSnapshot, scheduled: BackendDeltas) -> BackendDeltas: ...
+    def schedule(self, snap: ControlSnapshot) -> BackendResult: ...        # DECISION (pure): assignments + residual_demand
+    def manage_capacity(self, snap, residual_demand) -> BackendResult: ...  # OPERATION: scale up/down, AutoscalerState delta
+    def reconcile(self, snap, scheduled: BackendResult) -> BackendResult: ...# OPERATION: drive cluster, observe state
+    def on_workers_failed(self, ids) -> BackendResult: ...                   # OPERATION: slice teardown + AutoscalerState
     def set_log_sink(self, ...) -> None: ...
     def close(self) -> None: ...
 
 @dataclass(frozen=True)
-class BackendDeltas:
-    """Everything the controller writes back to the DB this tick — a tagged union of
-    row-level changes the controller applies through one writes.py path. The controller
-    does not interpret backend internals: assignments, task-state observations, slice /
-    scaling-group state, endpoint changes. Empty fields = 'this backend has nothing here'
-    (e.g. K8s emits no autoscaler_state)."""
+class BackendResult:
+    """The DB-shaped write-back the controller commits this tick — a tagged union of
+    row-level changes applied through one writes.py path: assignments, task-state
+    observations, preemptions, capacity (slice / scaling-group) state, endpoint changes.
+    Empty fields = 'this backend has nothing here' (K8s emits no AutoscalerState)."""
     assignments: list[Assignment] = field(default_factory=list)
     observations: list[ReconcileObservation] = field(default_factory=list)
     preemptions: list[TerminalDecision] = field(default_factory=list)
+    residual_demand: list[DemandEntry] = field(default_factory=list)
     autoscaler_state: AutoscalerState | None = None
     ...
 ```
 
-- The controller stops importing/owning `Scheduler`/`Autoscaler`; they become
-  `RpcTaskBackend` internals (it already holds both — `backend.py:136,141`).
-- `placement` / `manages_capacity` flags and every branch on them are **deleted**. K8s
-  simply returns empty `assignments`/`autoscaler_state` from `schedule` because Kueue
-  places and the cluster autoscaler provisions — a real "nothing to add," not a stub/raise.
-- `BackendReconcileResult`'s two fields collapse into the one `observations` shape. The
-  small amount of uid-resolution that needs the snapshot is done by a **shared pure
-  resolver** the controller runs on `deltas.observations` before writing — so the backend
-  stays DB-less and the apply path is uniform (K8s observations pass through; RPC
-  observations resolve identically).
-- This is the multi-backend keystone: a `BackendRegistry` holds N backends; the controller
-  iterates them, calling the same `schedule`/`reconcile`, routed by the hard
-  `cluster=<name>` constraint (which backend a task is eligible for); deltas merge into one
-  commit.
+**Critical: do NOT fold capacity into `schedule()`.** `autoscaler.update` is an *operation*
+with side effects (mutates slice/group state; `execute` calls cloud APIs, `runtime.py:662`).
+Keeping `schedule()` a pure decision and `manage_capacity()` a separate (bounded, I5)
+operation preserves "controller=state, backend=operation, decision separable from operation"
+(#2) — while still running both in the one schedule phase off `residual_demand` (the
+maintainer's "autoscaler off the scheduler output, same loop"). Same for `on_workers_failed`
+(the failure→teardown operation) — it stays an explicit method, invoked from the liveness
+step (I1/T5).
 
-**Serves:** controller = state, backend = operation (#2); one interface, one result shape,
-one apply path (#5); the direct enabler of multi-backend.
+Also in scope (the review caught these as prerequisites, not free):
+- **Reconcile the two `Scheduler` instances** → one, owned by the backend; the building cap
+  (`controller.py:814`) sources from it.
+- **Keep autoscaler startup-restore controller-driven** (`restore_from_db` stays at the
+  controller boundary, handing restored state to the backend) so the backend stays DB-less
+  per-tick; per-cycle `evaluate/update` is already pure and persist is already controller-side.
+- Collapse the two reconcile-result fields into `observations` via a **shared pure resolver**
+  the controller runs before writing (RPC observations resolve; K8s pass through).
+- Delete `placement`/`manages_capacity` and every branch on them.
 
-**Risk:** largest churn (contract type + both backends + ~6 call sites), low conceptual
-risk. Sequence: define `BackendDeltas` + uniform `ControlSnapshot` input → move
-scheduler/autoscaler ownership into `RpcTaskBackend.schedule` → unify reconcile input/
-result → migrate controller call sites to the uniform calls → delete the flags.
+**Naming:** the maintainer proposed `BackendResult` (used above). Caveat from review: it
+collides with the existing `*Result` swarm (`ScheduleResult`, `CapacityResult`,
+`BackendReconcileResult`, `SchedulingResult`, `PingResult`) and reads vaguer than the
+write-back delta-set it is; alternatives `BackendDeltas` / `ControlDeltas`. **Open question.**
 
-**Design decision (flag in open questions):** does the backend return *raw* observations
-(controller resolves — recommended, keeps resolution centralized near the DB) or
-*pre-resolved* deltas (backend resolves against the in-memory snapshot)? Recommend raw +
-shared resolver.
+**Serves:** controller = state, backend = operation (#2); one interface + one result shape +
+one apply path (#5); the multi-backend keystone (a `BackendRegistry` over N backends, routed
+by the hard `cluster=` constraint).
 
-### I4 — `reads.py` is the single DB fan-out point feeding the uniform snapshot
+**Risk:** largest churn; conceptually low *except* the autoscaler DB-decoupling and
+dual-scheduler reconciliation, which are genuine sub-projects.
 
-**Problem.** The reconcile-input snapshot (`_snapshot_reconcile_inputs`, raw
-`task_attempts ⋈ tasks` join, `controller.py:1038-1059`) bypasses `reads.py`, the intended
-DB chokepoint. Same class of violation in `policy.py`, `budget.py`, `checkpoint.py`. With
-I3, the controller's snapshot build becomes *the* place central DB queries fan out to the
-DB-free backends — so it must go through one chokepoint.
+### I4 — `reads.py` is the single DB fan-out point feeding the typed `ControlSnapshot`
 
-**Change.** Build one typed `ControlSnapshot` per tick via `reads.py` helpers (reuse
-`reconcile/loader.load_closed_snapshot` where it fits), hand it to `backend.schedule` /
-`backend.reconcile`. Move the reconcile-input join and the other raw selects behind
-`reads.py` so `reads.py`/`writes.py`/projections are the **only** modules issuing schema
-queries.
+**Problem.** `_snapshot_reconcile_inputs`' raw `task_attempts ⋈ tasks` join
+(`controller.py:1038-1059`) bypasses `reads.py`; same in `policy.py`, `budget.py`,
+`checkpoint.py`. With I3, the controller's snapshot build *is* the central DB fan-out to the
+DB-free backends, so it must go through one chokepoint.
 
-**Serves:** central DB queries fan out to DB-free abstractions from a single chokepoint
-(#1); supports the controller-as-serialization-layer goal.
+**Change.** Build one typed `ControlSnapshot` per tick via `reads.py` (reuse
+`reconcile/loader.load_closed_snapshot` where it fits); move the reconcile-input join and the
+other raw selects behind `reads.py`. `reads.py`/`writes.py`/projections become the only
+modules issuing schema queries.
 
-**Risk:** medium; independent of the others and individually shippable. Pairs naturally
-with I3 (the `ControlSnapshot` type is the backends' uniform input).
+**Serves:** central DB queries fan out to DB-free abstractions from a single chokepoint (#1).
+**Risk:** medium; independent; the `ControlSnapshot` type is the backends' uniform input.
 
-### I5 — Bound every call the controller *dispatches into* a backend
+### I5 — Policy: every controller→backend RPC is threadpool-dispatched with a bounded (generous) timeout
 
-**Problem.** This is about the controller's **outbound** calls into backends, not inbound
-service handlers. Today reconcile/ping fan-out is per-call bounded (10 s/worker, 128-way
-semaphore) but `RpcTaskBackend.reconcile` runs `asyncio.run(...)` on the **caller** thread,
-so a slow batch blocks the whole tick; and `exec_in_container` allows an RPC deadline of
-**up to one hour** (`backend.py:232-237`). No single place guarantees a bound.
+**Problem.** Not all controller→backend calls are bounded. `RpcTaskBackend.reconcile` runs
+`asyncio.run(...)` on the **caller** thread (`backend.py:153`); `exec_in_container` allows a
+**~1-hour** RPC deadline (`backend.py:232-237`).
 
-**Change.** Route **every** controller→backend call through one `BackendDispatch`: a
-bounded `ThreadPoolExecutor` where each submission carries a **hard wall-clock deadline**
-(`future.result(timeout=cap)`), so:
+**Change — keep the policy, drop the ceremony.** The policy is: *every call the controller
+dispatches into a backend runs on a threadpool and has a hard, generous timeout.* It is fine
+for reconcile to take ~5 s; we are **not** chasing constant-time-regardless-of-fleet and we
+do **not** need a single global pool (per-backend pools are fine).
 
-1. The **reconcile phase** gets a bounded result regardless of fleet size — workers that
-   don't answer by the deadline are surfaced as reconcile errors (which now drive liveness,
-   per I1), so a hung worker can never stall the tick.
-2. The **on-demand one-offs** (`profile_task` / `exec_in_container` / `get_process_status`)
-   go through the same dispatch with one timeout convention and one error path — the 1-hour
-   `exec` deadline is replaced by a hard cap (long-running exec/profile get an explicit,
-   bounded override, not "unlimited").
-3. `schedule`/`autoscale` (now in-process, in the backend) also run under the dispatch so a
-   pathological scheduling pass can't wedge the tick.
+1. **One-offs are already pooled — just bound them.** `profile_task` / `exec_in_container` /
+   `get_process_status` already run on the uvicorn `rpc-handler` pool (invoked from
+   `service.py`, off the tick thread). They are small one-offs; the only fix is replacing the
+   ~1-hour `exec` deadline with an explicit generous cap (e.g. 10–15 min for exec/profile).
+   **Do not re-route them through a new pool** — that double-pools an already-pooled call.
+2. **Wrap the one inline call.** `RpcTaskBackend.reconcile` is the call that blocks its
+   caller; give the backend a small pool and run the fan-out under `future.result(timeout=cap)`.
+   The inner per-worker RPCs already have a 10 s timeout + 128-way semaphore, so the outer cap
+   is a **fleet-size-aware watchdog** (`cap ≈ per_worker_timeout × ceil(workers/128) + slack`),
+   not a fixed 5 s.
+3. **Do not wrap in-process decisions.** `schedule`/`manage_capacity`-decision are in-process;
+   a watchdog over an uncancellable Python thread is ceremony — bound only the actual I/O.
 
-**Serves:** any call into a backend completes in bounded time, threadpool-dispatched (#4);
-one bounded dispatch path for all backend ops (#5).
-
-**Risk:** low–medium. The deadline wrapper + executor is small; the care item is choosing
-caps (reconcile-phase cap vs per-worker timeout; explicit long caps for profile/exec).
+**Serves:** any backend call completes in bounded time, threadpool-dispatched (#4); no second
+way to dispatch (#5).
+**Risk:** low. Care item: choosing the reconcile watchdog cap and the exec/profile caps.
 
 ## Constraint → improvement coverage
 
 | Constraint | Addressed by |
 |---|---|
-| Central DB queries fan out to DB-free abstractions | I4 (one `reads.py` snapshot), I3 (backend takes snapshot, returns deltas), I2 (single demand artifact) |
-| Controller handles state, backends handle operation | I3 (uniform interface, logic pushed into backend, controller persists deltas) |
+| Central DB queries fan out to DB-free abstractions | I4 (one `reads.py` snapshot), I3 (backend takes snapshot, returns `BackendResult`), I2 (single demand artifact) |
+| Controller handles state, backends handle operation | I3 (uniform interface; **schedule=decision, capacity/reconcile/teardown=operation, kept separable**) |
 | Prefer poll workflows vs loose threading | I1 (one control tick; drop autoscaler/ping/dispatch threads) |
-| Any controller→backend call completes in bounded time, threadpool-dispatched | I5 (BackendDispatch: pool + hard deadline) |
-| Only one way to do something | I3 (one interface + one result shape), I2 (one demand path), I5 (one dispatch path) |
-| Strong sync boundary scheduler ↔ autoscaler | I2 (autoscaler consumes scheduler's residual_demand in one phase) + I1 (shared snapshot) |
+| Any controller→backend call is threadpool-dispatched + bounded timeout | I5 (per-backend pool + generous deadline; fix the 1h exec) |
+| Only one way to do something | I3 (one interface + one result shape), I2 (one demand path), I5 (one dispatch policy) |
+| Strong sync boundary scheduler ↔ autoscaler | I2 (autoscaler consumes the scheduler's `residual_demand`, one scheduler, one snapshot) + I1 |
 
 ## Tasks
 
-Each task has a stable id. `exec: session` tasks become weaver issues on
-`weaver plan sync … --apply`. Ordered by recommended landing sequence.
+`exec: session` tasks become weaver issues on `weaver plan sync … --apply`. Ordered by
+recommended landing sequence.
 
-### T1 — I5: BackendDispatch — bound every controller→backend call  `exec: session`  `value: high`  `deps: —`
-Introduce a bounded `ThreadPoolExecutor` dispatch with a hard per-call deadline; route
-reconcile/ping fan-out and the three one-offs through it; replace the 1-hour `exec`
-deadline with an explicit bounded cap. Acceptance: a hung worker RPC is surfaced as a
-reconcile error within the cap and never blocks the caller; `exec`/`profile` run under an
+### T1 — I5: bound controller→backend RPCs  `exec: session`  `value: high`  `deps: —`
+Give the backend a small pool; run `reconcile` fan-out under a fleet-size-aware watchdog
+deadline; replace the ~1-hour `exec` deadline with an explicit generous cap. Leave the
+already-pooled one-offs in place (just bounded). Acceptance: a hung worker is surfaced as a
+reconcile error within the cap without blocking the caller; `exec`/`profile` run under an
 explicit bounded deadline; no backend call path lacks a timeout.
 
-### T2 — I2: scheduler emits residual demand; autoscaler runs off it  `exec: session`  `value: high`  `deps: —`
-Add `residual_demand` (+ `autoscaler_state`) to the schedule output, compute residual in
-`find_assignments`, run the autoscaler off it in the schedule path, delete
-`compute_demand_entries`' dry-run. Acceptance: golden-fixture parity (same demand in/out)
-with the scheduler invoked once per cycle; no dry-run `find_assignments` remains.
+### T2 — I2: single scheduler + co-located residual demand  `exec: session`  `value: high`  `deps: —`
+Compute residual demand once on the schedule snapshot with one `Scheduler` instance; feed the
+autoscaler off it in the schedule path; delete the dry-run + the separate autoscaler thread.
+Acceptance: golden-fixture parity (same demand in/out, incl. reservation/holder), one
+`Scheduler` instance, one scheduling snapshot per cycle, no `compute_demand_entries` dry-run.
 
 ### T3 — I4: one reads.py-built ControlSnapshot  `exec: session`  `value: medium`  `deps: —`
 Build a typed per-tick snapshot via `reads.py`; move the reconcile-input join and the
-policy/budget/checkpoint raw selects behind `reads.py`. Acceptance: no schema query
-outside `reads.py`/`writes.py`/projections; backends receive one snapshot type.
+policy/budget/checkpoint raw selects behind `reads.py`. Acceptance: no schema query outside
+`reads.py`/`writes.py`/projections.
 
-### T4 — I3: uniform backend interface + BackendDeltas  `exec: session`  `value: high`  `deps: T2, T3`
-Define `BackendDeltas` + the uniform `schedule`/`reconcile(snapshot)` interface; move
-`Scheduler`/`Autoscaler` ownership into `RpcTaskBackend`; collapse the two reconcile-result
-fields via a shared pure resolver; migrate controller call sites to the uniform calls;
-delete `placement`/`manages_capacity` and every branch on them. Acceptance: `grep` finds no
-`placement ==`/`manages_capacity` branch in the controller and no stub/`raise`-Unsupported
-in any backend; controller commits via one apply path that dispatches on delta type only.
+### T4 — I3: uniform backend interface + BackendResult  `exec: session`  `value: high`  `deps: T2, T3`
+Define `BackendResult` + the uniform `schedule`/`manage_capacity`/`reconcile`/
+`on_workers_failed(snapshot)` interface, **keeping decision separate from operation**; move
+the single `Scheduler` + `Autoscaler` ownership into `RpcTaskBackend` while keeping
+autoscaler startup-restore controller-driven (backend stays DB-less per-tick); collapse the
+two reconcile-result fields via a shared resolver; migrate call sites; delete
+`placement`/`manages_capacity` and every branch. Acceptance: `grep` finds no
+`placement ==`/`manages_capacity` branch in the controller and no stub/Unsupported in any
+backend; controller commits via one apply path on result shape only; backend imports no
+`db`/`reads`/`schema` on the per-tick path.
 
-### T5 — I1: collapse the fast loops into one phased control tick  `exec: session`  `value: high`  `deps: T1, T2, T4`
-Replace the five fast loops with one driver: snapshot → schedule → reconcile → commit,
-per-phase `due()` cadence, one snapshot/tick; fold ping's over-threshold termination onto
-reconcile errors; keep prune/checkpoint separate. Acceptance: one control thread; one read
-snapshot + one write txn per tick (counter/test); no idle-worker liveness gap; cadences
-preserved; chaos/integration suite green; behind a fallback flag.
+### T5 — Migrate ping's liveness signal onto reconcile + teardown  `exec: session`  `value: high`  `deps: T1`
+Translate `ReconcileResult.error` → `WorkerHealthTracker` failure bumps → over-threshold
+termination; fold the failure→sibling-slice-teardown (`on_workers_failed`) into the tick.
+Acceptance: a worker whose reconcile RPC fails the threshold count is failed and its slice
+torn down — *without* the ping loop; no idle-worker liveness gap. (Prereq for dropping ping
+in T6.)
+
+### T6 — I1: collapse the fast loops into one phased control tick  `exec: session`  `value: high`  `deps: T1, T2, T4, T5`
+One driver: snapshot → schedule(+capacity off residual) → reconcile(+liveness) → commit;
+per-phase `due()`; wake → schedule-only mini-tick; drop autoscaler/ping/dispatch loops; keep
+prune/checkpoint. Acceptance: one control thread; one read snapshot + one write txn per tick
+(counter/test); submit→assign latency = schedule time (not gated on reconcile); chaos/
+integration suite green; behind a fallback flag.
 
 ## Feasibility analysis
 
-**Overall: feasible and incremental.** No data-model change or migration; all refactors
-over a sound state layer. The `RpcTaskBackend` already owns the scheduler and autoscaler,
-so I3 *relocates ownership* rather than rewriting logic, and I2 mostly deletes a duplicate
-path. The aggressive simplification the maintainer asked for (uniform interface, 3 threads)
-makes the end state *smaller* than today's.
+**Overall: feasible and incremental — but bigger than the first draft implied.** The
+adversarial pass converted three "already true" claims into real tasks (T2's parity work,
+T4's autoscaler DB-decoupling + dual-scheduler merge, T5's liveness migration). None needs a
+data-model change or migration. The end state is still *smaller* than today (3 threads, one
+interface, one apply path).
 
-**Recommended landing sequence** (deps in parentheses):
+**Recommended landing sequence:**
 
-1. **T1 (I5)** — independent, high value, immediately removes the 1-hour `exec` foot-gun
-   and makes backend calls non-blocking. Prereq for a safe single tick.
-2. **T2 (I2)** — independent; deletes the duplicate scheduling pass and the unlocked
-   shared-scheduler access. Care item: reservation/holder demand parity.
-3. **T3 (I4)** — independent; produces the typed `ControlSnapshot` that T4's uniform
-   interface consumes.
-4. **T4 (I3)** — depends on T2 + T3 (needs the residual-demand output and the snapshot
-   type). Largest churn; the multi-backend keystone. Protocol-first, then relocate
-   ownership, then delete flags.
-5. **T5 (I1)** — last; depends on T1 (bounded dispatch so no phase stalls the tick), T2
-   (autoscaler folded in), T4 (uniform calls). The tick is then an ordering shell over
-   functions that already exist. Behind a fallback flag, baked on `marin-dev`.
+1. **T1 (I5)** — independent; removes the 1-hour `exec` foot-gun and the inline-blocking
+   reconcile. Prereq for a safe single tick and for T5.
+2. **T2 (I2)** — independent; deletes the duplicate scheduling pass, the second snapshot, and
+   the second `Scheduler`. Care item: demand parity.
+3. **T3 (I4)** — independent; produces the `ControlSnapshot` T4 consumes.
+4. **T5 (liveness)** — after T1; can land *before* the tick (reconcile errors start driving
+   health while the ping loop still exists as belt-and-suspenders), de-risking T6.
+5. **T4 (I3)** — after T2 + T3; largest churn (uniform interface, single scheduler/autoscaler
+   ownership, autoscaler restore decoupling, flag deletion).
+6. **T6 (I1)** — last; after T1, T2, T4, T5. The tick is then an ordering shell over functions
+   that already exist. Fallback flag; `marin-dev` bake.
 
 **Risk register:**
 
-- *T5 is the one to fear* — folding cadences into one tick can starve a phase or change
-  effective latency. Mitigation: per-phase `due()` predicates; bounded dispatch (T1) so no
-  phase blocks; fallback flag; `marin-dev` bake. Never bounce the live controller without
-  explicit OK.
-- *Dropping ping (T5):* verified reconcile reaches all active workers, but the
-  over-threshold *termination* path must move onto reconcile errors in the same change, or
-  unhealthy workers linger. Covered in T5's acceptance.
-- *Commit ordering (T5):* schedule and reconcile in one tick means assignments may be acted
-  on before they're committed. The worker daemon is the source of truth (reconcile observes
-  actual state), so a crash between RPC and commit self-heals on the next tick — but confirm
-  this is acceptable vs. a commit-after-schedule boundary (open question).
-- *T2 correctness:* golden-fixture parity before deleting the dry-run.
-- *T4 churn:* wide but mechanical; pyrefly + capability tests catch drift.
-- *Cross-region / cost:* none; pure control-plane code.
-- *Multi-backend itself is out of scope here* — these five make it tractable; the
-  `BackendRegistry` + `cluster=` routing is a follow-on plan once T4 + T5 land.
+- *T6 (single tick)* — phase starvation / latency. Mitigation: per-phase `due()`; wake →
+  schedule-only mini-tick (submit→assign not gated on reconcile); bounded reconcile (T1);
+  fallback flag. Never bounce the live controller without explicit OK.
+- *T5 (drop ping)* — verified the failure signal is ping-only today; the migration must land
+  and be tested *before* ping is removed, or unhealthy workers linger. Sequenced before T6.
+- *T2 (demand parity)* — limits-free residual must match the old dry-run on reservation/holder
+  jobs; golden-fixture test gates the deletion.
+- *T4 (autoscaler DB-decoupling)* — `restore_from_db`/`recovery`/`persistence` touch the DB;
+  keep restore controller-driven, do not drag it into the backend per-tick path.
+- *B1 avoided* — capacity stays a separate operation from the schedule decision (not a
+  god-method).
+- *Cross-region / cost* — none; pure control-plane code.
+- *Multi-backend itself is out of scope* — these five make it tractable; `BackendRegistry` +
+  `cluster=` routing is a follow-on once T4 + T6 land.
 
-**Independently shippable now (no deps):** T1, T2, T3. **Sequenced:** T4 (after T2+T3) → T5
-(after T1+T2+T4). Estimated ~6 focused sessions; T1–T3 parallelizable.
+**Independently shippable now:** T1, T2, T3 (and T5 after T1). **Sequenced:** T4 (after
+T2+T3) → T6 (after T1, T2, T4, T5). Estimated ~7 focused sessions.
 
 ## Open questions
 
-- **Commit boundary in the tick (I1):** single end-of-tick write txn (schedule + reconcile
-  commit together; faster convergence, relies on reconcile self-heal after a crash), or
-  commit assignments after the schedule phase then reconcile (preserves persist-before-act
-  at the cost of an extra txn)? Recommend single commit + self-heal; confirm.
+- **`BackendResult` vs `BackendDeltas`/`ControlDeltas`** — the review flagged a collision with
+  the existing `*Result` swarm and that "Result" reads vaguer than the write-back delta-set.
+  Maintainer proposed `BackendResult`; confirm or pick `BackendDeltas`.
+- **Commit boundary in the tick (I1):** single end-of-tick write (schedule + reconcile commit
+  together; relies on reconcile self-heal after a crash) vs commit-after-schedule. Recommend
+  single commit + self-heal; confirm.
 - **Observation resolution (I3):** backend returns raw observations and the controller
-  resolves (recommended), vs. backend returns pre-resolved deltas against the in-memory
-  snapshot. Affects where uid-resolution lives.
-- **I5 caps:** reconcile-phase wall-clock cap vs per-worker timeout; explicit long caps for
-  `profile`/`exec` (what values?).
-- **`cluster=` routing (follow-on):** as a hard constraint, where is it resolved — a
-  pre-scheduler dispatcher that partitions tasks per backend, or inside each backend's
-  eligibility filter? Affects the `BackendRegistry` shape.
+  resolves (recommended), vs backend pre-resolves against the in-memory snapshot.
+- **I5 caps:** the reconcile watchdog cap (fleet-size-aware) and the exec/profile caps (values?).
+- **`cluster=` routing (follow-on):** hard constraint resolved by a pre-scheduler dispatcher
+  that partitions tasks per backend, or inside each backend's eligibility filter?

--- a/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
+++ b/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
@@ -1,6 +1,6 @@
 ---
 plan: tighten-iris-control-boundaries-multi-backend-readiness
-status: in-progress
+status: complete
 ---
 
 # Tighten Iris control boundaries (multi-backend readiness)
@@ -20,10 +20,11 @@ status: in-progress
 > `BackendResult` name stays (the `*Result` swarm collapses, so the earlier naming concern is
 > moot).
 
-## Status — independent layer landed (2026-06-10)
+## Status — all tasks landed (2026-06-12)
 
-T1–T3 are merged to `main`; T4/T5 are the remaining sequenced work, plus one new task (T6)
-from the post-merge audit.
+T1–T6 are merged to `main`, plus two post-merge fixes (#6349, #6352) from the adversarial
+review of the T5×T6 composition. The remaining step is operational: restart `marin-dev` onto
+the new controller (user decision; see Open questions).
 
 | Task | PR | Outcome |
 |---|---|---|
@@ -31,8 +32,10 @@ from the post-merge audit.
 | T2 / I2 | #6295 | As specced. One `Scheduler` (backend-owned, `rpc/backend.py:152`); residual demand computed in the scheduling pass (`backend.py:283`) and returned on `ScheduleResult`; autoscaler loop consumes the cached `_last_residual_demand`; dry-run + second snapshot + controller `Scheduler` deleted. Demand-parity tests pin holder/taint/absorption semantics. Validated live on `marin-dev` (fineweb 10BT dedup end-to-end). |
 | T3 / I4 | #6294 | As specced. `reads.py` is the DB fan-out point; `ControlSnapshot{worker_addresses, reconcile_rows, timeout_rows, health}` built by `load_control_snapshot` in one read txn (`reads.py:1612`), health tracker attached by the controller. |
 | T4 / I3 | #6311 | Uniform `schedule`/`reconcile`/`autoscale`; ping + dispatch loops deleted (7→5 threads); health observed by backend, folded via one `WorkerHealthTracker.apply`; `placement`/`manages_capacity` deleted in favor of a `BackendCapability` descriptor consulted once at construction (+ service-RPC guards). **Design deltas:** results are three *method-specific* types (`ScheduleResult`/`ReconcileResult`/`AutoscaleResult`), each uniform across backends — better than the planned single fat `BackendResult`; `schedule` keeps `ScheduleInput` (genuinely different shape); the dispatch drain stays controller-side (it is a *write*). **Review caught a blocker the 1900-test suite couldn't:** the ping RPC was also the *workers'* keep-alive — reconcile now resets the worker heartbeat deadline. Detection latency is grace-based (`worker_unreachable_grace`=50s ÷ `poll_interval`); placement excludes failing workers while reconcile keeps probing them. **Rollout:** no churn-free deploy order (old workers decode `health` unset → reaped; old controller pings → gone on new workers); controller-first one-time churn recommended on marin-dev, optional one-release shim for prod. |
+| T5 / I1 | #6344 | As specced. One `control-loop` thread: snapshot → schedule → reconcile → fold health → autoscale → **single end-of-tick write txn** (`_commit_tick`); per-phase `due()`; wake → schedule-only mini-tick; `run_autoscale → run_schedule` invariant guarantees fresh same-tick residual demand (no cached handoff on the new path); legacy loops retained behind `single_control_tick` (default on). Honest exceptions to one-txn: CLUSTER_VIEW drains in a pre-read txn (documented); dead-worker teardown rides post-commit writes (matches legacy). **Post-merge review found** a stale `build_scheduling_context(db, ...)` call in `lib/iris/scripts/benchmark_controller.py` (pyrefly-uncovered; the same gap as T4's round) — fixed in #6349; structural fix tracked in #6348. |
+| T6 | #6343 | **Design delta — simpler than planned:** no operation-handle state machine. The detached threads were never necessary: TPU `create_slice` submits the LRO and returns, the persisted slice row *is* the operation handle, and the existing `BOOTING→READY/FAILED` `describe()` poll in `refresh()` is the polling mechanism. Shipped as plan → bounded parallel issue (`_run_io_batch`, joined in-phase) → serial fold; restart adoption reuses slice adoption unchanged. **Post-merge review refuted the boundedness claim for VM slices:** `vm_create` still blocked in `_wait_zone_operation` (600 s) — composed with T5's single tick this could stall reconcile (now the worker keep-alive) for 10 min on `GCP_SLICE_MODE_VM`. Fixed in #6352 (`wait: bool = False`, synthesized PROVISIONING `VmInfo`, token-refresh lock); tests sharpened to HTTP-boundary assertions in #6355. |
 
-**Verified post-merge state (audit of `main`):**
+**Verified post-merge state (audit of `main`, 2026-06-10 — after T1–T3, before T4–T6):**
 
 - **Still 7 `ManagedThread` loops** + uvicorn (`controller.py:493-541`): scheduling, polling/
   reconcile, ping, dispatch, prune, autoscaler, checkpoint. T4 deletes ping; T5 collapses
@@ -484,6 +487,8 @@ unifying the **input shape** (dispatch-drain vs reconcile-plan inputs both becom
 it from this task's scope.
 
 ### T5 — I1: collapse the fast loops into one phased control tick  `exec: session`  `value: high`  `deps: T1, T2, T4`
+**Done — #6344 (merged 2026-06-12).** See the status table for outcome + post-merge fix (#6349).
+
 One driver: snapshot → schedule → reconcile(+health events) → apply-thresholds → autoscale →
 **single end-of-tick commit**; per-phase `due()`; wake → schedule-only mini-tick; drop
 ping/dispatch/autoscaler loops; keep prune/checkpoint + the in-memory tracker. Acceptance: one
@@ -494,6 +499,12 @@ suite green; behind a fallback flag. Also fold the remaining control-path snapsh
 replace the `_last_residual_demand` cross-thread field with same-tick dataflow.
 
 ### T6 — autoscaler cloud ops become polled operations  `exec: session`  `value: medium`  `deps: T4`
+**Done — #6343 (merged 2026-06-12), simpler than specced.** No `AutoscalerState` operation
+handles: the slice row is the handle and `refresh()`'s `describe()` poll is the poller; the
+spec below survives as the *constraint* (every autoscale phase bounded, no detached threads,
+restart-adopted in-flight work) rather than the mechanism. VM-create boundedness completed by
+#6352. See the status table.
+
 Today `Autoscaler.update()` and `terminate_slices_for_workers` spawn detached fire-and-forget
 threads that block inside cloud calls (GCP `create_slice`/`terminate` wait up to the 600 s
 operation timeout). Replace with the poll workflow: the autoscale phase *issues* the cloud
@@ -526,12 +537,10 @@ apply path.
 3. ~~**T3 (I4)**~~ — done (#6294; `ControlSnapshot` with health view is now T4's input).
 4. ~~**T4 (I3)**~~ — done (#6311, merged 2026-06-12; two review rounds — the adversarial pass
    caught the worker-keep-alive blocker).
-5. **T5 (I1)** — next. The tick is then an ordering shell over functions
-   that already exist; also folds the remaining snapshot builders, kills the
-   `_last_residual_demand` cross-thread handoff, and absorbs T4's deferred doc nits.
-   Fallback flag; `marin-dev` bake (which doubles as T4's rollout churn validation).
-6. **T6** — after T4 (the autoscale phase is the natural home for issue-then-poll); independent
-   of T5 and can land in parallel with it.
+5. ~~**T5 (I1)**~~ — done (#6344, merged 2026-06-12; post-merge fix #6349). The `marin-dev`
+   bake is still pending and doubles as the T4/T5 rollout churn validation.
+6. ~~**T6**~~ — done (#6343, merged 2026-06-12 in parallel with T5; post-merge fix #6352,
+   test sharpening #6355).
 
 **Risk register:**
 
@@ -554,8 +563,11 @@ apply path.
 - *Multi-backend itself is out of scope* — these five make it tractable; `BackendRegistry` +
   `cluster=` routing is a follow-on once T4 + T5 land.
 
-**Shipped:** T1, T2, T3. **Sequenced:** T4 (after T2+T3) → T5 (after T1, T2, T4) ∥ T6 (after
-T4). Estimated ~3–4 remaining focused sessions.
+**Shipped:** all of T1–T6 (+ post-merge fixes #6349/#6352). End state vs the six constraints:
+3 control threads (tick + prune + checkpoint); DB touched only at snapshot/commit boundaries;
+backends operate, controller serializes; every per-tick cloud call is a single bounded
+submission polled by `refresh()`; one RPC per idea (Ping deleted — reconcile is the
+keep-alive); scheduler↔autoscaler synchronized by same-tick dataflow.
 
 ## Decisions & open questions
 
@@ -582,12 +594,22 @@ T4). Estimated ~3–4 remaining focused sessions.
 - **Placement vs probing filters split**: scheduling excludes `consecutive_failures > 0`;
   reconcile targets all active workers.
 
+**Decided since (T5/T6 review):**
+- **Observation resolution (I3) settled as a hybrid:** the backend emits liveness events
+  (REACHED/UNREACHABLE from its own I/O) while BUILD_FAILED is controller-synthesized in
+  `_fold_health` from kernel effects; thresholds resolve controller-side in one
+  `WorkerHealthTracker.apply`.
+- **No poll budget needed (T6):** with no operation-handle machinery, the only per-phase cloud
+  calls are single bounded HTTP submissions plus one `describe()` per non-ready slice; the
+  in-phase `_run_io_batch` join makes phase duration = slowest single call. This puts a hard
+  contract on platform methods — `create_slice`/`terminate` must submit-and-return (the
+  `vm_create` violation was the one post-merge blocker, #6352).
+- **The tick has no per-phase watchdog by design** (consistent with the T1 decision): its
+  liveness leans on the bounded-submission contract above, not on timeouts around phases.
+
 **Open:**
-- **T4 rollout order** (one-time controller-first churn vs one-release Ping/health-unset shim) —
-  user decision at deploy time; analysis on PR #6311.
-- **Observation resolution (I3):** backend returns raw observations and the controller resolves
-  in the pure kernel (recommended), vs backend pre-resolves against the in-memory snapshot.
+- **Rollout** (now covers T4+T5+T6 together — one `marin-dev` restart validates all of it):
+  one-time controller-first churn vs one-release Ping/health-unset shim — user decision at
+  deploy time; analysis on PR #6311.
 - **`cluster=` routing (follow-on):** hard constraint resolved by a pre-scheduler dispatcher
   that partitions tasks per backend, or inside each backend's eligibility filter?
-- **T6 poll budget:** the per-phase cap on operation-status polls (the issue call itself can be
-  bounded at the HTTP layer, e.g. GCP's 30 s POST timeout).

--- a/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
+++ b/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
@@ -5,67 +5,66 @@ status: draft
 
 # Tighten Iris control boundaries (multi-backend readiness)
 
-> Revised twice: once for the maintainer's direction (uniform backend interface, single
-> control tick, bounded backend dispatch), then again after an **adversarial review** that
-> caught four things the earlier draft oversold as "already true / free." Those are now
-> scoped as explicit work: (E1) reconcile-error → liveness, (E2) residual demand is a real
-> capacity-fit, (E4) the autoscaler is not DB-clean, (B2) the failure→slice-teardown path.
-> `cluster=` is a **hard** constraint; the single-tick model is the target.
+> Revised three times. The decisive simplification (this round): **worker health is a
+> backend concern.** The backend tracks health from its own I/O (RPC backend: reconcile-RPC
+> + build failures; K8s: pod status) and returns per-worker verdicts in `BackendResult`; the
+> controller just **stores** them. That deletes `on_workers_failed` / `on_worker_failed` /
+> `ping_workers`, the ping loop, and the controller-side `WorkerHealthTracker` logic — and
+> removes the last place backend-specific data flowed through the controller. Phase order is
+> **schedule → reconcile → autoscale** (each as-needed). `cluster=` is a **hard** constraint;
+> the single-tick model is the target; the `BackendResult` name stays (the `*Result` swarm
+> collapses, so the earlier naming concern is moot).
 
 ## Problem & goal
 
 The recent `TaskBackend` work pulled most backend specifics behind a contract, but the
 control plane is still **loose**:
 
-1. The controller drives **seven independent `ManagedThread` loops**, each opening its own
-   DB snapshot on its own cadence and committing on its own schedule. Coordination is a
-   single write `RLock` plus wake events — so scheduler, autoscaler and reconciler act on
-   **skewed snapshots**.
-2. **Demand is computed twice.** The autoscaler re-derives demand by running the scheduler
-   a *second* time as a dry-run (`compute_demand_entries` → `scheduler.find_assignments`,
-   `policy.py:283`) on a *separate* snapshot, against a *separate* `Scheduler` instance
-   (`controller.py:350`) from the one the backend schedules with (`backend.py:141`).
-3. The controller **dispatches on backend type**: it branches on `placement`
-   (`controller.py:761/1092`) and `manages_capacity` (`1234`); `K8sTaskProvider` stubs six
-   contract methods.
-4. The reconcile **result shape is backend-specific** — `BackendReconcileResult` carries
-   both `updates` (K8s) and `worker_results` (RPC); the controller picks by `placement`.
-5. **Calls the controller dispatches into a backend are not uniformly bounded.**
-   `RpcTaskBackend.reconcile` runs `asyncio.run(...)` on the *caller* thread
-   (`backend.py:153`), and `exec_in_container` permits an RPC deadline of **up to one hour**
-   (`backend.py:232-237`).
+1. **Seven independent `ManagedThread` loops**, each on its own snapshot/cadence, coordinated
+   only by a write `RLock` + wake events → scheduler, autoscaler and reconciler act on skewed
+   snapshots.
+2. **Demand is computed twice** — a dry-run `find_assignments` (`policy.py:283`) on a second
+   snapshot against a second `Scheduler` instance (`controller.py:350` vs `backend.py:141`).
+3. **Backend-specific data flows through the controller.** The controller derives worker
+   liveness (ping loop), then *couriers* failed worker IDs into the backend
+   (`on_workers_failed`, `controller.py:1202`) and loops over backend-returned siblings — even
+   though the sibling/slice logic already lives in the autoscaler (`operations.py:36-102`). It
+   also branches on `placement`/`manages_capacity` and reads type-specific result fields.
+4. The reconcile **result shape is backend-specific** (`updates` vs `worker_results`).
+5. **Calls the controller dispatches into a backend are not uniformly bounded** —
+   `RpcTaskBackend.reconcile` runs `asyncio.run(...)` on the caller thread (`backend.py:153`);
+   `exec_in_container` permits a ~1-hour RPC deadline (`backend.py:232-237`).
 
-**Long-term goal:** a *multi-backend* Iris (e.g. GCP TPU + Slurm GPU clusters), jobs routed
-by a **hard `cluster=<name>` constraint**. The controller must be a pure state/serialization
-layer that calls **one uniform interface** on every backend and persists the DB-shaped
-results — never branching on which backend it is.
+**Long-term goal:** a *multi-backend* Iris (GCP TPU + Slurm GPU, …), jobs routed by a **hard
+`cluster=<name>` constraint**. The controller must build a snapshot, call **one uniform
+interface** on every backend, and persist the DB-shaped `BackendResult` — never branching on
+backend type, never holding backend-specific data.
 
-**What "done" looks like for this plan:** a verified map of the current control flow, a
-target flow, and five improvements with concrete code shapes and an honest feasibility
-analysis. Implementation is the task breakdown below.
+**What "done" looks like:** a verified current-flow map, a target flow, and five improvements
+with concrete code shapes + an honest feasibility analysis. Implementation = the tasks below.
 
-### What is already good — and the precise caveats (post-review)
+### What is already good — and the precise caveats (verified)
 
-- `Scheduler.find_assignments(context) -> SchedulingResult` is a **pure function**
-  (`scheduling/scheduler.py`). But it returns only `assignments` and marks a job
-  `exhausted` on the first capacity miss without recording *why* — so residual demand does
-  **not** fall out of it for free (see I2). And there are **two** `Scheduler` instances —
-  the controller's (`controller.py:350`, feeds the building cap at `814` and the dry-run at
-  `1242`) and the backend's (`backend.py:141`) — which I2/I3 must reconcile.
-- The backend **classes** are DB-clean (no `db`/`reads`/`schema`/`sqlalchemy` imports). The
-  `Autoscaler` they own is **not**: `runtime.restore_from_db(db)` (`autoscaler/runtime.py:682`)
-  and `autoscaler/recovery.py`/`persistence.py` import `schema` and issue SQL. Its per-cycle
-  `evaluate/update` is pure and capacity **persist is already controller-side**
-  (`persist_autoscaler_state`, `controller.py:1249`), but **startup-restore touches the DB**.
-  I3 must keep restore controller-driven so the backend stays DB-less per-tick.
-- Reconcile already **reaches** every active healthy worker
-  (`reads.list_active_healthy_workers`, `controller.py:1017`; idle workers get an empty-rows
-  heartbeat). But reconcile RPC errors today only `logger.debug` (`controller.py:1109-1111`)
-  — they do **not** feed `WorkerHealthTracker`. The failure signal (`consecutive_failures`)
-  is produced **only** by the ping loop's `_health.ping(healthy=False)`
-  (`controller.py:1156-1160`, `worker_health.py`). So the ping loop is vestigial for
-  *reaching* workers but is the **sole producer of the liveness-failure signal** — dropping
-  it is real new work (I1 / task T5).
+- `Scheduler.find_assignments` is **pure** (`scheduling/scheduler.py`) but returns only
+  `assignments` and marks a job `exhausted` on the first capacity miss without recording *why*
+  — so residual demand is a deliberate limits-free fit, **not** a by-product (I2). And there
+  are **two** `Scheduler` instances (`controller.py:350` feeds the building cap `:814` and the
+  dry-run `:1242`; `backend.py:141` is the one the backend schedules with) — I2/I3 reconcile
+  them to one.
+- **Sibling-teardown already lives in the autoscaler** (`autoscaler/operations.py:36-102`,
+  `runtime.py:774-802`): given dead workers, it finds the slice, derives siblings, detaches.
+  The controller's `on_workers_failed` is a courier (`controller.py:1199-1217`) — deletable.
+- **Worker health is purely in-memory in the controller** (`worker_health.py`; no DB
+  persistence; reseeded from the workers table at startup, `controller.py:447-458`). Mutated
+  by the ping loop (`consecutive_failures`, `:1157-1163`) **and** the reconcile path
+  (heartbeat on success `batches.py:182`; `build_failed` on BUILDING→FAILED `task.py:441`;
+  `mark_unhealthy` on the fail cascade `batches.py:226`). Read by scheduling-context filtering
+  (`policy.py:1063` → `reads.py:1097`) and the read-only RPCs (`ListWorkers` `service.py:1578`,
+  `GetWorkerStatus` `:1985`, `GetAutoscalerStatus` `:1766`). **Health is not in the scheduling
+  snapshot today** — it's a separate post-filter.
+- **K8s has no daemon-ping health model** — workers are pods, health is pod status
+  (`backends/k8s/tasks.py`); it stubs `on_workers_failed`/`ping_workers`. This asymmetry is the
+  reason health belongs *in* the backend, not in one controller-side tracker.
 - The reconcile *kernel* (`reconcile/overlay|task|job|worker|effects`) is a **pure state
   machine**; `loader → snapshot → kernel → commit` is clean; `writes.validate()` enforces
   projection-table ownership.
@@ -78,60 +77,49 @@ flowchart TB
     classDef pure fill:#e1f0ff,stroke:#2980b9,color:#000;
     classDef store fill:#f5f0d8,stroke:#7f8c8d,color:#000;
 
-    subgraph DISP["Controller -> backend calls (NOT uniformly bounded)"]
+    subgraph CTRL["Controller — owns SQLite + write RLock + in-memory WorkerHealthTracker; 7 ManagedThreads"]
         direction TB
-        R3["profile / exec / get_process_status<br/>already on the rpc-handler pool, but exec allows ~1h deadline"]:::problem
-        R4["reconcile fan-out<br/>10s/worker + 128 sem, but asyncio.run blocks the CALLER loop"]:::problem
-    end
-
-    subgraph CTRL["Controller — owns SQLite + single write RLock; 7 ManagedThreads"]
-        direction TB
-        L1["scheduling loop (~10s backoff + RPC wake)"]
+        L1["scheduling loop (~10s + RPC wake)"]
         L2["polling / reconcile loop (5s + wake)"]
         L3["dispatch loop (5s, TASK_BACKEND only)"]
-        L4["ping loop (5s) — SOLE producer of the worker-failure signal"]:::problem
-        L5["autoscaler loop (10s) — runs for every non-K8s backend"]
+        L4["ping loop (5s) — derives liveness, then couriers IDs to backend"]:::problem
+        L5["autoscaler loop (10s)"]
         L6["prune (600s / 3600s)"]
         L7["checkpoint (optional)"]
     end
 
     DB[("Controller DB")]:::store
+    HT["WorkerHealthTracker (in-memory, lost on restart)"]:::problem
 
     subgraph PURE["DB-free decision components"]
         SCH["Scheduler.find_assignments (PURE) — TWO instances"]:::pure
-        DEM["compute_demand_entries<br/>DRY-RUN re-run on a 2nd snapshot, limits disabled"]:::problem
-        ASP["Autoscaler — evaluate PURE; restore_from_db + execute touch DB/cloud"]
+        DEM["compute_demand_entries — DRY-RUN on a 2nd snapshot"]:::problem
+        ASP["Autoscaler — owns slices + sibling logic"]
     end
 
     subgraph BK["TaskBackend — 13-method contract; controller branches on type"]
-        RPCB["RpcTaskBackend (IRIS) — owns Scheduler + Autoscaler"]
-        K8S["K8sTaskProvider (TASK_BACKEND) — stubs 6 methods"]:::problem
+        RPCB["RpcTaskBackend (IRIS)"]
+        K8S["K8sTaskProvider (TASK_BACKEND) — stubs on_workers_failed / ping"]:::problem
     end
 
-    L1 -->|"snapshot #1"| DB
     L1 --> SCH
-    SCH -->|"assignments"| L1
-    L1 -->|"commit"| DB
-    L5 -->|"snapshot #2"| DB
-    L5 --> DEM
-    DEM -.->|"dry-run"| SCH
-    L5 --> ASP
-    ASP -->|"AutoscalerState"| L5
-    L5 -->|"commit"| DB
-    L2 -->|"snapshot"| DB
-    L2 --> R4 --> RPCB
-    RPCB -.->|"worker_results"| L2
-    L3 --> R4 --> K8S
-    K8S -.->|"updates"| L3
-    L2 -->|"commit"| DB
-    L3 -->|"commit"| DB
-    L4 --> R4
+    L1 -->|"snapshot/commit"| DB
+    L5 -->|"2nd snapshot"| DB
+    L5 --> DEM -.->|"dry-run"| SCH
+    L5 --> ASP --> DB
+    L2 -->|"snapshot/commit"| DB
+    L2 -->|"reconcile"| RPCB
+    L3 --> K8S
+    L4 -->|"ping"| RPCB
+    L4 --> HT
+    L4 -->|"on_workers_failed(ids)"| RPCB
+    RPCB -.->|"siblings + AutoscalerState"| L4
+    HT -.->|"health filter"| SCH
     L6 --> DB
     L7 --> DB
-    R3 --> BK
 
-    L1 -.->|"⚠ demand skew (2nd snapshot, 2nd scheduler)"| L5
-    L1 -.->|"⚠ snapshot skew"| L2
+    L1 -.->|"⚠ demand skew"| L5
+    L4 -.->|"⚠ backend-specific data through controller"| RPCB
 ```
 
 ## Architecture — target control flow
@@ -143,11 +131,12 @@ flowchart TB
 
     subgraph TICK["Control tick — ONE thread, ONE snapshot/tick"]
         direction TB
-        S0["build ControlSnapshot (reads.py, one read txn)"]
-        S1["schedule phase (due ~10s, or on RPC wake)<br/>backend.schedule() = DECISION → assignments + residual_demand<br/>backend.manage_capacity(residual) = OPERATION → AutoscalerState"]
-        S2["reconcile phase (every tick) → backend.reconcile()<br/>+ liveness: reconcile errors bump health, terminate over-threshold"]
-        S3["commit BackendResult (one write txn, one apply path)"]
-        S0 --> S1 --> S2 --> S3
+        S0["build ControlSnapshot (reads.py, one read txn) — incl. stored worker health"]
+        S1["schedule (due ~10s / on wake): DECISION → assignments + residual_demand"]
+        S2["reconcile (every tick): OPERATION → task observations + WORKER-HEALTH VERDICTS"]
+        S3["autoscale (due): OPERATION → provision + tear down dead slices/siblings → AutoscalerState + verdicts"]
+        S4["commit BackendResult (one write txn): pure kernel applies observations+health → store"]
+        S0 --> S1 --> S2 --> S3 --> S4
     end
 
     subgraph HK["Housekeeping threads"]
@@ -155,235 +144,210 @@ flowchart TB
         C["checkpoint"]
     end
 
-    DB[("Controller DB")]:::store
+    DB[("Controller DB — stores task state, worker health, slices")]:::store
 
-    subgraph BD["per-backend bounded dispatch (threadpool + generous timeout)<br/>wraps the I/O calls only: reconcile fan-out, capacity ops, one-offs"]
+    subgraph BD["per-backend bounded dispatch (threadpool + generous timeout) — I/O calls only"]
         D["submit(io_call, deadline)"]
     end
 
-    subgraph BK["Backends — UNIFORM interface; own placement + capacity"]
-        RPCB["RpcTaskBackend — owns ONE Scheduler + Autoscaler"]:::good
-        K8S["K8sTaskProvider — Kueue places; pod diff"]:::good
+    subgraph BK["Backends — UNIFORM interface; OWN placement, capacity, AND health"]
+        RPCB["RpcTaskBackend — 1 Scheduler + Autoscaler + health from reconcile-RPC/build"]:::good
+        K8S["K8sTaskProvider — Kueue places; health from pod status"]:::good
     end
 
     S0 --> DB
-    S1 -->|"schedule = in-process decision (no dispatch)"| RPCB
-    S1 --> BD
+    S1 -->|"in-process decision"| RPCB
     S2 --> BD
+    S3 --> BD
     BD --> RPCB
     BD --> K8S
-    RPCB -->|"BackendResult"| S3
-    K8S -->|"BackendResult"| S3
-    S3 --> DB
+    RPCB -->|"BackendResult"| S4
+    K8S -->|"BackendResult"| S4
+    S4 --> DB
     P --> DB
     C --> DB
 ```
 
-Net threads: **7 → 3** (control tick + prune + checkpoint). The controller builds a
-snapshot, calls one interface, and persists `BackendResult` through one apply path —
-dispatching on the **result shape**, never the backend type. `schedule` stays a pure
-in-process decision; only the actual **I/O** (reconcile fan-out, capacity cloud ops,
-one-offs) goes through the bounded dispatch.
+Net threads: **7 → 3**. No ping loop, no `on_workers_failed`, no controller-side health
+tracker. The controller builds a snapshot (incl. stored health), calls one interface, and
+persists `BackendResult` through one pure-kernel apply path — dispatching on result shape,
+never backend type. `schedule` is an in-process decision; only the actual **I/O** (reconcile,
+autoscale ops, one-offs) goes through the bounded dispatch.
 
 ## The five targeted improvements
 
-### I1 — One phased control tick; drop the autoscaler & dispatch loops; **migrate** ping's liveness signal
+### I1 — One phased control tick (schedule → reconcile → autoscale); drop the ping, dispatch & autoscaler loops
 
-**Problem.** Five fast loops each re-snapshot and commit independently. The dispatch loop is
-just "reconcile for TASK_BACKEND." The autoscaler loop re-snapshots state the scheduler just
-read. The ping loop reaches workers reconcile already reaches — **but it is the only thing
-that produces the worker-failure signal** (verified: reconcile errors only log,
-`controller.py:1109-1111`; `consecutive_failures` is bumped only by `_health.ping`).
+**Problem.** Five fast loops re-snapshot/commit independently; the dispatch loop is "reconcile
+for TASK_BACKEND"; the autoscaler loop re-snapshots; the ping loop derives liveness and
+couriers failures into the backend.
 
-**Change.** One driver thread, one snapshot per tick, fixed phase order:
+**Change.** One driver thread, one snapshot per tick, fixed order:
 
 ```
 control_tick(now):
-    snap = build_control_snapshot(db)              # ONE read txn via reads.py (I4)
-    result = BackendResult()
+    snap = build_control_snapshot(db)              # ONE read txn via reads.py (I4); incl. stored health
+    r = BackendResult()
     if schedule_phase.due(now) or woken:
-        result += backend.schedule(snap)           # pure decision: assignments + residual_demand
-        result += backend.manage_capacity(snap, result.residual_demand)   # capacity OPERATION (I5-bounded)
+        r += backend.schedule(snap)                # pure decision: assignments + residual_demand
     if reconcile_phase.due(now):
-        rec = backend.reconcile(snap, result)      # bounded dispatch (I5); reaches all workers
-        result += rec
-        result += liveness_from(rec)               # NEW: bump health on RPC errors, terminate over-threshold
+        r += backend.reconcile(snap)               # bounded I/O (I5): observations + health verdicts
+    if autoscale_phase.due(now):
+        r += backend.autoscale(snap, r.residual_demand, r.health)  # bounded I/O: scale + dead-slice teardown
     with db.transaction() as tx:                   # ONE write txn, one apply path
-        commit(tx, result)
+        commit(tx, r)                              # pure kernel: observations+health → task state; store health/slices
 ```
 
-- **Migrate ping's liveness signal (new work, task T5).** Translate `ReconcileResult.error`
-  → `WorkerHealthTracker` failure bumps → over-threshold termination, plus the
-  failure→sibling-slice-teardown path (today `backend.on_workers_failed`,
-  `controller.py:1182-1222`) folded into the tick. This is *not* "for free"; it has its own
-  test (a worker whose reconcile RPC fails N times is failed and its slice torn down).
-- **Drop the dispatch loop** — it is the reconcile phase for TASK_BACKEND placement (uniform
-  after I3).
-- **Drop the autoscaler loop** — folded into the schedule phase (I2).
-- **Scheduling latency:** today RPC handlers wake the scheduler thread directly. In one tick,
-  a submit-wake must not be gated on an in-flight reconcile — a wake triggers a
-  **schedule-only mini-tick** (reconcile skipped unless due), so worst-case submit→assign =
-  schedule time, not (reconcile cap + schedule). State and confirm this bound.
+- **Drop the ping loop.** Reconcile already reaches every active worker (idle ones get an
+  empty-rows heartbeat); liveness now comes from the backend tracking its own reconcile-RPC
+  outcomes (I3). Keep the reconcile cadence ≈ the old ping interval so detection isn't slower.
+- **Drop the dispatch loop** (it is reconcile for TASK_BACKEND placement; uniform after I3).
+- **Drop the autoscaler loop** (now the autoscale phase, off `residual_demand` + reconcile's
+  health verdicts).
+- **Scheduling latency:** an RPC wake triggers a **schedule-only mini-tick** (reconcile/
+  autoscale skipped unless due), so submit→assign = schedule time, not gated on in-flight
+  reconcile.
 - **Keep** prune + checkpoint as separate housekeeping threads.
 
-**Serves:** poll over loose threading (#3); one snapshot fans out to DB-free abstractions
-(#1); strong scheduler↔autoscaler sync (#6).
+**Serves:** poll over loose threading (#3); one snapshot fans out to DB-free abstractions (#1);
+strong scheduler↔autoscaler sync (#6).
+**Risk:** highest blast radius; land last; fallback flag; `marin-dev` bake. Never bounce the
+live controller without explicit OK (AGENTS.md).
 
-**Risk:** highest blast radius; land last. Ship behind a fallback flag; bake on `marin-dev`.
-Never bounce the live controller without explicit OK (AGENTS.md).
+### I2 — One scheduler, one snapshot: co-locate residual demand; autoscaler off it
 
-### I2 — One scheduler, one snapshot: co-locate residual demand; autoscaler off it (no dry-run, no thread)
+**Problem.** Demand is a second `find_assignments` dry-run on a second snapshot, limits
+disabled (`policy.py:268-285`), against a second `Scheduler`.
 
-**Problem.** Demand is a **second** `find_assignments` dry-run on a **second** snapshot with
-limits disabled (`policy.py:268-285`), against a **second** `Scheduler` instance. The real
-pass runs with `max_assignments_per_worker`/`max_building_tasks` caps and marks jobs
-exhausted without recording cap-vs-capacity — so the residual genuinely needs a
-**limits-free capacity fit**, not a by-product of the capped pass.
-
-**Change.** Keep the capacity-fit computation (it is real), but compute it **once, on the
-same snapshot, with a single `Scheduler` instance**, and hand the result to the autoscaler
-in-memory in the same phase:
+**Change.** Keep the limits-free capacity fit (it is real work), but compute it **once, on the
+schedule snapshot, with one `Scheduler` instance**, returning it on `BackendResult`:
 
 ```python
 @dataclass(frozen=True)
-class ScheduleResult:
+class BackendResult:
     assignments: list[Assignment] = field(default_factory=list)
-    preemptions: list[TerminalDecision] = field(default_factory=list)
-    unschedulable: list[PendingTask] = field(default_factory=list)
-    residual_demand: list[DemandEntry] = field(default_factory=list)   # NEW: limits-free capacity-fit residual
-    diagnostics: dict[str, str] = field(default_factory=dict)
-    post_taint_context: SchedulingContext | None = None
+    residual_demand: list[DemandEntry] = field(default_factory=list)   # limits-free capacity-fit residual
+    ...                                                                # (other fields below in I3)
 ```
 
-The win is **not** "free demand" — it is: one snapshot (not two), one `Scheduler` (reconcile
-`controller.py:350` and `backend.py:141`), demand handed across a typed in-memory boundary,
-and the separate autoscaler thread + `compute_demand_entries` plumbing deleted. The residual
-is still a deliberate limits-free fit co-located in the schedule path. The **golden-fixture
-parity test is load-bearing** (same demand entries in/out, incl. reservation/holder cases),
-not just a refactor guard.
+The autoscale phase consumes `residual_demand` in the same tick. Delete the dry-run, the
+second snapshot, the second `Scheduler`, and `compute_demand_entries`. The **golden-fixture
+parity test is load-bearing** (same demand entries in/out, incl. reservation/holder cases).
 
 **Serves:** one demand artifact across a typed boundary (#6); one way to compute demand (#5);
 removes a snapshot + the unlocked dual-scheduler access (#1).
+**Risk:** medium-high — reproduce reservation-taint / holder-task demand semantics exactly.
 
-**Risk:** medium-high — reproducing reservation-taint / holder-task demand semantics exactly.
+### I3 — One uniform backend interface; the backend owns placement, capacity, AND health; controller stores `BackendResult`
 
-### I3 — One uniform backend interface; controller persists `BackendResult`, never branches on type — but keep decision separate from operation
+**Problem.** The controller orchestrates backend specifics: branches on `placement`/
+`manages_capacity`; derives health itself; couriers failures via `on_workers_failed`; reads
+type-specific result fields; K8s stubs methods.
 
-**Problem.** The controller orchestrates backend specifics (branches on `placement`/
-`manages_capacity`; type-specific result fields; K8s stubs).
-
-**Change.** A single uniform interface every backend implements, with the Iris scheduler/
-autoscaler living *inside* `RpcTaskBackend`. The controller persists the returned
-`BackendResult` through one apply path, dispatching on **result shape**, never backend type:
+**Change.** One uniform interface every backend implements; the Iris scheduler, autoscaler,
+**and worker-health tracking** live inside `RpcTaskBackend`; the controller persists the
+returned `BackendResult` through one pure-kernel apply path, dispatching on result shape only:
 
 ```python
 class TaskBackend(Protocol):
     name: str
-    def schedule(self, snap: ControlSnapshot) -> BackendResult: ...        # DECISION (pure): assignments + residual_demand
-    def manage_capacity(self, snap, residual_demand) -> BackendResult: ...  # OPERATION: scale up/down, AutoscalerState delta
-    def reconcile(self, snap, scheduled: BackendResult) -> BackendResult: ...# OPERATION: drive cluster, observe state
-    def on_workers_failed(self, ids) -> BackendResult: ...                   # OPERATION: slice teardown + AutoscalerState
+    def schedule(self, snap: ControlSnapshot) -> BackendResult: ...        # DECISION: assignments + residual_demand
+    def reconcile(self, snap: ControlSnapshot) -> BackendResult: ...       # OPERATION: observations + worker-health verdicts
+    def autoscale(self, snap, residual_demand, health) -> BackendResult: ...# OPERATION: scale + dead-slice/sibling teardown
     def set_log_sink(self, ...) -> None: ...
     def close(self) -> None: ...
 
 @dataclass(frozen=True)
 class BackendResult:
-    """The DB-shaped write-back the controller commits this tick — a tagged union of
-    row-level changes applied through one writes.py path: assignments, task-state
-    observations, preemptions, capacity (slice / scaling-group) state, endpoint changes.
-    Empty fields = 'this backend has nothing here' (K8s emits no AutoscalerState)."""
+    """The DB-shaped write-back the controller commits this tick — applied through one
+    writes.py / reconcile-kernel path. Empty fields = 'this backend has nothing here'."""
     assignments: list[Assignment] = field(default_factory=list)
-    observations: list[ReconcileObservation] = field(default_factory=list)
-    preemptions: list[TerminalDecision] = field(default_factory=list)
     residual_demand: list[DemandEntry] = field(default_factory=list)
+    observations: list[ReconcileObservation] = field(default_factory=list)   # task-state observed
+    worker_health: list[WorkerHealthVerdict] = field(default_factory=list)   # healthy/active + counts, per worker
     autoscaler_state: AutoscalerState | None = None
     ...
 ```
 
-**Critical: do NOT fold capacity into `schedule()`.** `autoscaler.update` is an *operation*
-with side effects (mutates slice/group state; `execute` calls cloud APIs, `runtime.py:662`).
-Keeping `schedule()` a pure decision and `manage_capacity()` a separate (bounded, I5)
-operation preserves "controller=state, backend=operation, decision separable from operation"
-(#2) — while still running both in the one schedule phase off `residual_demand` (the
-maintainer's "autoscaler off the scheduler output, same loop"). Same for `on_workers_failed`
-(the failure→teardown operation) — it stays an explicit method, invoked from the liveness
-step (I1/T5).
+**Worker health moves into the backend (the heart of this revision):**
+- `RpcTaskBackend` owns the health tracker; `reconcile` counts its own reconcile-RPC outcomes
+  (success → heartbeat; error → `consecutive_failures`++) plus build failures, applies the
+  threshold, and returns per-worker `WorkerHealthVerdict`s. When it deems a worker dead it
+  evicts its own cached stub (today's `on_worker_failed`) internally — no controller call.
+- `autoscale`, given the dead-worker verdicts, tears down their slices **and** their healthy
+  siblings (logic already in `autoscaler/operations.py`) and returns the siblings as further
+  dead verdicts — so the controller never couriers IDs back in.
+- `K8sTaskProvider.reconcile` derives verdicts from pod status — its native health source.
+- The controller **stores** verdicts on the worker rows (persist + restore on restart, like
+  autoscaler state — fixing the in-memory-only gap) and feeds them back via the next
+  `ControlSnapshot` (so `schedule` can filter on health, and read-only RPCs serve stored
+  health). The pure reconcile kernel still runs in `commit`, consuming
+  `observations + dead-worker set` to compute task transitions (WORKER_FAILED cascades).
 
-Also in scope (the review caught these as prerequisites, not free):
-- **Reconcile the two `Scheduler` instances** → one, owned by the backend; the building cap
-  (`controller.py:814`) sources from it.
-- **Keep autoscaler startup-restore controller-driven** (`restore_from_db` stays at the
-  controller boundary, handing restored state to the backend) so the backend stays DB-less
-  per-tick; per-cycle `evaluate/update` is already pure and persist is already controller-side.
-- Collapse the two reconcile-result fields into `observations` via a **shared pure resolver**
-  the controller runs before writing (RPC observations resolve; K8s pass through).
-- Delete `placement`/`manages_capacity` and every branch on them.
+**Deleted:** `on_workers_failed`, `on_worker_failed`, `ping_workers`, the controller
+`WorkerHealthTracker` mutation logic, and `placement`/`manages_capacity` + every branch.
 
-**Naming:** the maintainer proposed `BackendResult` (used above). Caveat from review: it
-collides with the existing `*Result` swarm (`ScheduleResult`, `CapacityResult`,
-`BackendReconcileResult`, `SchedulingResult`, `PingResult`) and reads vaguer than the
-write-back delta-set it is; alternatives `BackendDeltas` / `ControlDeltas`. **Open question.**
+Also in scope: reconcile the two `Scheduler` instances → one (backend-owned; building cap
+sources from it); keep autoscaler startup-restore controller-driven so the backend stays
+DB-less per-tick; collapse the two reconcile-result fields via a shared pure resolver.
 
-**Serves:** controller = state, backend = operation (#2); one interface + one result shape +
-one apply path (#5); the multi-backend keystone (a `BackendRegistry` over N backends, routed
-by the hard `cluster=` constraint).
+**Naming (resolved):** keep `BackendResult`. The `*Result` swarm collapses — `PingResult`
+deleted (ping gone), `BackendReconcileResult`/`CapacityResult`/`WorkersFailedResult` subsumed
+by `BackendResult`, the per-worker `ReconcileResult` (`reconcile/worker.py`) becomes
+backend-internal — so there is no remaining collision.
 
-**Risk:** largest churn; conceptually low *except* the autoscaler DB-decoupling and
-dual-scheduler reconciliation, which are genuine sub-projects.
+**Serves:** controller = state/storage, backend = operation, **no backend-specific data in the
+controller** (#2); one interface + one result shape + one apply path (#5); the multi-backend
+keystone (`BackendRegistry` over N backends, routed by the hard `cluster=` constraint).
+**Risk:** largest churn; the genuine sub-projects are health-into-backend, autoscaler
+DB-decoupling, and the dual-scheduler merge.
 
 ### I4 — `reads.py` is the single DB fan-out point feeding the typed `ControlSnapshot`
 
-**Problem.** `_snapshot_reconcile_inputs`' raw `task_attempts ⋈ tasks` join
-(`controller.py:1038-1059`) bypasses `reads.py`; same in `policy.py`, `budget.py`,
-`checkpoint.py`. With I3, the controller's snapshot build *is* the central DB fan-out to the
-DB-free backends, so it must go through one chokepoint.
+**Problem.** `_snapshot_reconcile_inputs`' raw join (`controller.py:1038-1059`) bypasses
+`reads.py`; same in `policy.py`/`budget.py`/`checkpoint.py`.
 
 **Change.** Build one typed `ControlSnapshot` per tick via `reads.py` (reuse
-`reconcile/loader.load_closed_snapshot` where it fits); move the reconcile-input join and the
-other raw selects behind `reads.py`. `reads.py`/`writes.py`/projections become the only
-modules issuing schema queries.
+`reconcile/loader.load_closed_snapshot` where it fits), **including stored worker health** so
+the backend can filter/track from it; move the raw selects behind `reads.py`. `reads.py`/
+`writes.py`/projections become the only modules issuing schema queries.
 
-**Serves:** central DB queries fan out to DB-free abstractions from a single chokepoint (#1).
-**Risk:** medium; independent; the `ControlSnapshot` type is the backends' uniform input.
+**Serves:** central DB queries fan out to DB-free abstractions from one chokepoint (#1).
+**Risk:** medium; independent; the `ControlSnapshot` is the backends' uniform input.
 
 ### I5 — Policy: every controller→backend RPC is threadpool-dispatched with a bounded (generous) timeout
 
-**Problem.** Not all controller→backend calls are bounded. `RpcTaskBackend.reconcile` runs
-`asyncio.run(...)` on the **caller** thread (`backend.py:153`); `exec_in_container` allows a
-**~1-hour** RPC deadline (`backend.py:232-237`).
+**Problem.** `RpcTaskBackend.reconcile` runs `asyncio.run(...)` on the caller thread
+(`backend.py:153`); `exec_in_container` allows a ~1-hour deadline (`backend.py:232-237`).
 
-**Change — keep the policy, drop the ceremony.** The policy is: *every call the controller
-dispatches into a backend runs on a threadpool and has a hard, generous timeout.* It is fine
-for reconcile to take ~5 s; we are **not** chasing constant-time-regardless-of-fleet and we
-do **not** need a single global pool (per-backend pools are fine).
+**Change — keep the policy, drop the ceremony.** Every call the controller dispatches into a
+backend runs on a (per-backend) threadpool with a hard, generous timeout. It is fine for
+reconcile to take ~5 s; no constant-time target, no global pool.
 
-1. **One-offs are already pooled — just bound them.** `profile_task` / `exec_in_container` /
-   `get_process_status` already run on the uvicorn `rpc-handler` pool (invoked from
-   `service.py`, off the tick thread). They are small one-offs; the only fix is replacing the
-   ~1-hour `exec` deadline with an explicit generous cap (e.g. 10–15 min for exec/profile).
-   **Do not re-route them through a new pool** — that double-pools an already-pooled call.
-2. **Wrap the one inline call.** `RpcTaskBackend.reconcile` is the call that blocks its
-   caller; give the backend a small pool and run the fan-out under `future.result(timeout=cap)`.
-   The inner per-worker RPCs already have a 10 s timeout + 128-way semaphore, so the outer cap
-   is a **fleet-size-aware watchdog** (`cap ≈ per_worker_timeout × ceil(workers/128) + slack`),
-   not a fixed 5 s.
-3. **Do not wrap in-process decisions.** `schedule`/`manage_capacity`-decision are in-process;
-   a watchdog over an uncancellable Python thread is ceremony — bound only the actual I/O.
+1. **One-offs are already pooled** (`profile`/`exec`/`get_process_status` run on the uvicorn
+   `rpc-handler` pool, off the tick) — just replace the ~1-hour `exec` deadline with an
+   explicit generous cap (e.g. 10–15 min). Do not re-route them.
+2. **Wrap the inline calls** — `reconcile` and `autoscale` ops run under
+   `future.result(timeout=cap)`. The inner per-worker RPCs already have a 10 s timeout +
+   128-way semaphore, so the outer cap is a **fleet-size-aware watchdog**
+   (`per_worker_timeout × ceil(workers/128) + slack`), not a fixed constant.
+3. **Do not wrap in-process decisions** (`schedule`) — a watchdog over an uncancellable Python
+   thread is ceremony; bound only real I/O.
 
-**Serves:** any backend call completes in bounded time, threadpool-dispatched (#4); no second
-way to dispatch (#5).
-**Risk:** low. Care item: choosing the reconcile watchdog cap and the exec/profile caps.
+**Serves:** any backend call completes in bounded time, threadpool-dispatched (#4); one
+dispatch policy (#5).
+**Risk:** low. Care item: choosing the reconcile/autoscale watchdog caps and the exec/profile caps.
 
 ## Constraint → improvement coverage
 
 | Constraint | Addressed by |
 |---|---|
-| Central DB queries fan out to DB-free abstractions | I4 (one `reads.py` snapshot), I3 (backend takes snapshot, returns `BackendResult`), I2 (single demand artifact) |
-| Controller handles state, backends handle operation | I3 (uniform interface; **schedule=decision, capacity/reconcile/teardown=operation, kept separable**) |
-| Prefer poll workflows vs loose threading | I1 (one control tick; drop autoscaler/ping/dispatch threads) |
-| Any controller→backend call is threadpool-dispatched + bounded timeout | I5 (per-backend pool + generous deadline; fix the 1h exec) |
-| Only one way to do something | I3 (one interface + one result shape), I2 (one demand path), I5 (one dispatch policy) |
-| Strong sync boundary scheduler ↔ autoscaler | I2 (autoscaler consumes the scheduler's `residual_demand`, one scheduler, one snapshot) + I1 |
+| Central DB queries fan out to DB-free abstractions | I4 (one `reads.py` snapshot), I3 (snapshot in → `BackendResult` out), I2 (single demand artifact) |
+| Controller handles state, backends handle operation | I3 (backend owns placement/capacity/**health**; controller only stores; **no backend-specific data in the controller**) |
+| Prefer poll workflows vs loose threading | I1 (one control tick; drop ping/dispatch/autoscaler loops) |
+| Any controller→backend call is threadpool-dispatched + bounded | I5 (per-backend pool + generous deadline; fix the 1h exec) |
+| Only one way to do something | I3 (one interface + one result shape; delete `on_workers_failed`/`ping_workers`), I2 (one demand path) |
+| Strong sync boundary scheduler ↔ autoscaler | I2 (autoscaler consumes the scheduler's `residual_demand`; one scheduler, one snapshot) + I1 |
 
 ## Tasks
 
@@ -391,100 +355,95 @@ way to dispatch (#5).
 recommended landing sequence.
 
 ### T1 — I5: bound controller→backend RPCs  `exec: session`  `value: high`  `deps: —`
-Give the backend a small pool; run `reconcile` fan-out under a fleet-size-aware watchdog
-deadline; replace the ~1-hour `exec` deadline with an explicit generous cap. Leave the
-already-pooled one-offs in place (just bounded). Acceptance: a hung worker is surfaced as a
-reconcile error within the cap without blocking the caller; `exec`/`profile` run under an
-explicit bounded deadline; no backend call path lacks a timeout.
+Give the backend a small pool; run `reconcile`/`autoscale` ops under a fleet-size-aware
+watchdog deadline; replace the ~1-hour `exec` deadline with an explicit generous cap; leave
+the already-pooled one-offs bounded-in-place. Acceptance: a hung worker is surfaced as a
+reconcile error within the cap without blocking the caller; no backend call path lacks a timeout.
 
 ### T2 — I2: single scheduler + co-located residual demand  `exec: session`  `value: high`  `deps: —`
-Compute residual demand once on the schedule snapshot with one `Scheduler` instance; feed the
-autoscaler off it in the schedule path; delete the dry-run + the separate autoscaler thread.
-Acceptance: golden-fixture parity (same demand in/out, incl. reservation/holder), one
-`Scheduler` instance, one scheduling snapshot per cycle, no `compute_demand_entries` dry-run.
+Compute residual demand once on the schedule snapshot with one `Scheduler`; feed the autoscaler
+off it; delete the dry-run + the separate autoscaler thread. Acceptance: golden-fixture parity
+(same demand in/out incl. reservation/holder), one `Scheduler`, one scheduling snapshot/cycle.
 
 ### T3 — I4: one reads.py-built ControlSnapshot  `exec: session`  `value: medium`  `deps: —`
-Build a typed per-tick snapshot via `reads.py`; move the reconcile-input join and the
-policy/budget/checkpoint raw selects behind `reads.py`. Acceptance: no schema query outside
-`reads.py`/`writes.py`/projections.
+Build a typed per-tick snapshot via `reads.py`, carrying stored worker health; move the
+reconcile-input join + policy/budget/checkpoint raw selects behind `reads.py`. Acceptance: no
+schema query outside `reads.py`/`writes.py`/projections; snapshot includes health.
 
-### T4 — I3: uniform backend interface + BackendResult  `exec: session`  `value: high`  `deps: T2, T3`
-Define `BackendResult` + the uniform `schedule`/`manage_capacity`/`reconcile`/
-`on_workers_failed(snapshot)` interface, **keeping decision separate from operation**; move
-the single `Scheduler` + `Autoscaler` ownership into `RpcTaskBackend` while keeping
-autoscaler startup-restore controller-driven (backend stays DB-less per-tick); collapse the
-two reconcile-result fields via a shared resolver; migrate call sites; delete
-`placement`/`manages_capacity` and every branch. Acceptance: `grep` finds no
-`placement ==`/`manages_capacity` branch in the controller and no stub/Unsupported in any
-backend; controller commits via one apply path on result shape only; backend imports no
-`db`/`reads`/`schema` on the per-tick path.
+### T4 — I3: uniform backend interface + backend-owned health  `exec: session`  `value: high`  `deps: T2, T3`
+Define `BackendResult` + the uniform `schedule`/`reconcile`/`autoscale(snapshot)` interface;
+**move worker-health tracking into the backend** (RPC: reconcile-RPC + build failures + threshold;
+K8s: pod status), returning per-worker verdicts; **persist health to worker rows** (+ restore on
+restart) and feed it back via the snapshot; **delete `on_workers_failed`/`on_worker_failed`/
+`ping_workers` + the controller health tracker**; backend tears down dead slices + siblings in
+`autoscale`, returning sibling verdicts; reconcile the two `Scheduler` instances → one; keep
+autoscaler startup-restore controller-driven; collapse the result fields via a shared resolver;
+delete `placement`/`manages_capacity` + branches. Acceptance: `grep` finds no
+`placement ==`/`manages_capacity` branch and no `on_workers_failed`/`ping_workers`; backend
+imports no `db`/`reads`/`schema` on the per-tick path; a worker whose reconcile RPC fails the
+threshold is failed and its slice torn down with no ping loop.
 
-### T5 — Migrate ping's liveness signal onto reconcile + teardown  `exec: session`  `value: high`  `deps: T1`
-Translate `ReconcileResult.error` → `WorkerHealthTracker` failure bumps → over-threshold
-termination; fold the failure→sibling-slice-teardown (`on_workers_failed`) into the tick.
-Acceptance: a worker whose reconcile RPC fails the threshold count is failed and its slice
-torn down — *without* the ping loop; no idle-worker liveness gap. (Prereq for dropping ping
-in T6.)
-
-### T6 — I1: collapse the fast loops into one phased control tick  `exec: session`  `value: high`  `deps: T1, T2, T4, T5`
-One driver: snapshot → schedule(+capacity off residual) → reconcile(+liveness) → commit;
-per-phase `due()`; wake → schedule-only mini-tick; drop autoscaler/ping/dispatch loops; keep
-prune/checkpoint. Acceptance: one control thread; one read snapshot + one write txn per tick
-(counter/test); submit→assign latency = schedule time (not gated on reconcile); chaos/
-integration suite green; behind a fallback flag.
+### T5 — I1: collapse the fast loops into one phased control tick  `exec: session`  `value: high`  `deps: T1, T2, T4`
+One driver: snapshot → schedule → reconcile(+health) → autoscale → commit; per-phase `due()`;
+wake → schedule-only mini-tick; drop ping/dispatch/autoscaler loops; keep prune/checkpoint.
+Acceptance: one control thread; one read snapshot + one write txn per tick (counter/test);
+submit→assign latency = schedule time; reconcile cadence ≈ old ping interval (no liveness
+regression); chaos/integration suite green; behind a fallback flag.
 
 ## Feasibility analysis
 
-**Overall: feasible and incremental — but bigger than the first draft implied.** The
-adversarial pass converted three "already true" claims into real tasks (T2's parity work,
-T4's autoscaler DB-decoupling + dual-scheduler merge, T5's liveness migration). None needs a
-data-model change or migration. The end state is still *smaller* than today (3 threads, one
-interface, one apply path).
+**Overall: feasible, incremental, and now genuinely simplifying.** Moving health into the
+backend *removes* code (ping loop, `on_workers_failed`/`on_worker_failed`/`ping_workers`,
+controller `WorkerHealthTracker` mutation logic, the courier-and-loop sibling dance) rather than
+adding it, and the sibling/slice logic it relies on already lives in the autoscaler. No
+data-model change except adding stored health to the worker rows (a small, beneficial migration
+that also fixes restart durability). End state: 3 threads, one interface, one apply path.
 
 **Recommended landing sequence:**
 
 1. **T1 (I5)** — independent; removes the 1-hour `exec` foot-gun and the inline-blocking
-   reconcile. Prereq for a safe single tick and for T5.
-2. **T2 (I2)** — independent; deletes the duplicate scheduling pass, the second snapshot, and
-   the second `Scheduler`. Care item: demand parity.
-3. **T3 (I4)** — independent; produces the `ControlSnapshot` T4 consumes.
-4. **T5 (liveness)** — after T1; can land *before* the tick (reconcile errors start driving
-   health while the ping loop still exists as belt-and-suspenders), de-risking T6.
-5. **T4 (I3)** — after T2 + T3; largest churn (uniform interface, single scheduler/autoscaler
-   ownership, autoscaler restore decoupling, flag deletion).
-6. **T6 (I1)** — last; after T1, T2, T4, T5. The tick is then an ordering shell over functions
-   that already exist. Fallback flag; `marin-dev` bake.
+   reconcile. Prereq for a safe single tick.
+2. **T2 (I2)** — independent; deletes the duplicate scheduling pass, the second snapshot, the
+   second `Scheduler`. Care item: demand parity.
+3. **T3 (I4)** — independent; produces the `ControlSnapshot` (with health) T4 consumes.
+4. **T4 (I3)** — after T2 + T3; largest churn (uniform interface, health-into-backend, autoscaler
+   restore decoupling, dual-scheduler merge, flag deletion). Land health-into-backend with the
+   ping loop still present as belt-and-suspenders, then remove ping in the same task once the
+   backend verdicts are proven.
+5. **T5 (I1)** — last; after T1, T2, T4. The tick is then an ordering shell over functions that
+   already exist. Fallback flag; `marin-dev` bake.
 
 **Risk register:**
 
-- *T6 (single tick)* — phase starvation / latency. Mitigation: per-phase `due()`; wake →
-  schedule-only mini-tick (submit→assign not gated on reconcile); bounded reconcile (T1);
-  fallback flag. Never bounce the live controller without explicit OK.
-- *T5 (drop ping)* — verified the failure signal is ping-only today; the migration must land
-  and be tested *before* ping is removed, or unhealthy workers linger. Sequenced before T6.
-- *T2 (demand parity)* — limits-free residual must match the old dry-run on reservation/holder
-  jobs; golden-fixture test gates the deletion.
+- *T4 (health-into-backend)* — health is mutated from several sites today (ping + reconcile +
+  build + cascade); consolidating onto the backend's reconcile must preserve the threshold
+  semantics (`PING_FAILURE_THRESHOLD`/`BUILD_FAILURE_THRESHOLD`). Mitigation: keep ping running
+  until backend verdicts match it on `marin-dev`, then delete.
+- *T5 (single tick)* — phase starvation/latency. Mitigation: per-phase `due()`; wake →
+  schedule-only mini-tick; bounded reconcile (T1); fallback flag. Never bounce the live
+  controller without explicit OK.
+- *T2 (demand parity)* — golden-fixture test gates the dry-run deletion.
 - *T4 (autoscaler DB-decoupling)* — `restore_from_db`/`recovery`/`persistence` touch the DB;
-  keep restore controller-driven, do not drag it into the backend per-tick path.
-- *B1 avoided* — capacity stays a separate operation from the schedule decision (not a
-  god-method).
+  keep restore controller-driven, off the per-tick path.
+- *K8s health* — verdicts must come from pod status, not a daemon ping; verify the pod-diff
+  reconcile already exposes enough to mark a pod-worker dead.
 - *Cross-region / cost* — none; pure control-plane code.
 - *Multi-backend itself is out of scope* — these five make it tractable; `BackendRegistry` +
-  `cluster=` routing is a follow-on once T4 + T6 land.
+  `cluster=` routing is a follow-on once T4 + T5 land.
 
-**Independently shippable now:** T1, T2, T3 (and T5 after T1). **Sequenced:** T4 (after
-T2+T3) → T6 (after T1, T2, T4, T5). Estimated ~7 focused sessions.
+**Independently shippable now:** T1, T2, T3. **Sequenced:** T4 (after T2+T3) → T5 (after T1, T2,
+T4). Estimated ~6–7 focused sessions.
 
 ## Open questions
 
-- **`BackendResult` vs `BackendDeltas`/`ControlDeltas`** — the review flagged a collision with
-  the existing `*Result` swarm and that "Result" reads vaguer than the write-back delta-set.
-  Maintainer proposed `BackendResult`; confirm or pick `BackendDeltas`.
-- **Commit boundary in the tick (I1):** single end-of-tick write (schedule + reconcile commit
-  together; relies on reconcile self-heal after a crash) vs commit-after-schedule. Recommend
-  single commit + self-heal; confirm.
-- **Observation resolution (I3):** backend returns raw observations and the controller
-  resolves (recommended), vs backend pre-resolves against the in-memory snapshot.
-- **I5 caps:** the reconcile watchdog cap (fleet-size-aware) and the exec/profile caps (values?).
+- **Health persistence shape:** add `healthy`/`active`/`consecutive_failures`/`build_failures`/
+  `last_heartbeat_ms` columns to the worker rows, or a small dedicated health table? Either way
+  it feeds the snapshot and survives restart.
+- **Commit boundary in the tick (I1):** single end-of-tick write (schedule+reconcile+autoscale
+  commit together; relies on reconcile self-heal after a crash) vs commit-after-schedule.
+  Recommend single commit + self-heal; confirm.
+- **Observation resolution (I3):** backend returns raw observations and the controller resolves
+  (recommended), vs backend pre-resolves against the in-memory snapshot.
+- **I5 caps:** the reconcile/autoscale watchdog caps and the exec/profile caps (values?).
 - **`cluster=` routing (follow-on):** hard constraint resolved by a pre-scheduler dispatcher
   that partitions tasks per backend, or inside each backend's eligibility filter?

--- a/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
+++ b/docs/plans/tighten-iris-control-boundaries-multi-backend-readiness.md
@@ -30,6 +30,7 @@ from the post-merge audit.
 | T1 / I5 | #6291 | **Scope reduced in review** — see I5 below. exec deadline 1 h → 15 min; fan-out bounds documented as named constants. The watchdog pool was rolled back: reconcile/ping fan-outs were *already* bounded (10 s/RPC × 128-way semaphore), and a tripped watchdog would leave a hung pool thread still mutating the shared `Autoscaler` while the next cycle dispatched — two unsynchronized writers. |
 | T2 / I2 | #6295 | As specced. One `Scheduler` (backend-owned, `rpc/backend.py:152`); residual demand computed in the scheduling pass (`backend.py:283`) and returned on `ScheduleResult`; autoscaler loop consumes the cached `_last_residual_demand`; dry-run + second snapshot + controller `Scheduler` deleted. Demand-parity tests pin holder/taint/absorption semantics. Validated live on `marin-dev` (fineweb 10BT dedup end-to-end). |
 | T3 / I4 | #6294 | As specced. `reads.py` is the DB fan-out point; `ControlSnapshot{worker_addresses, reconcile_rows, timeout_rows, health}` built by `load_control_snapshot` in one read txn (`reads.py:1612`), health tracker attached by the controller. |
+| T4 / I3 | #6311 (open, review-complete) | Uniform `schedule`/`reconcile`/`autoscale`; ping + dispatch loops deleted (7→5 threads); health observed by backend, folded via one `WorkerHealthTracker.apply`; `placement`/`manages_capacity` deleted in favor of a `BackendCapability` descriptor consulted once at construction (+ service-RPC guards). **Design deltas:** results are three *method-specific* types (`ScheduleResult`/`ReconcileResult`/`AutoscaleResult`), each uniform across backends — better than the planned single fat `BackendResult`; `schedule` keeps `ScheduleInput` (genuinely different shape); the dispatch drain stays controller-side (it is a *write*). **Review caught a blocker the 1900-test suite couldn't:** the ping RPC was also the *workers'* keep-alive — reconcile now resets the worker heartbeat deadline. Detection latency is grace-based (`worker_unreachable_grace`=50s ÷ `poll_interval`); placement excludes failing workers while reconcile keeps probing them. **Rollout:** no churn-free deploy order (old workers decode `health` unset → reaped; old controller pings → gone on new workers); controller-first one-time churn recommended on marin-dev, optional one-release shim for prod. |
 
 **Verified post-merge state (audit of `main`):**
 
@@ -454,6 +455,12 @@ moved behind `reads.py`. (Remaining acceptable locals: `dispatch.py:_dispatch_qu
 when T4 unifies dispatch into reconcile — and service-RPC detail-view queries.)
 
 ### T4 — I3: uniform backend interface + backend-observed health  `exec: session`  `value: high`  `deps: T2, T3`
+**Done — PR #6311 (awaiting merge).** See the status table for outcome + design deltas. Doc
+nits deferred to T5: AGENTS.md/architecture.md still claim capabilities "never gate the
+per-tick loops" (the `_backend_drains_dispatch` exception exists and is documented in
+`backend.py`) and call BUILD_FAILED backend-emitted (it is controller-synthesized);
+`set_worker_consecutive_failures_for_test` is unused.
+
 Define `BackendResult` + the uniform `schedule`/`reconcile`/`autoscale(snapshot)` interface;
 **move worker-health observation into the backend** (RPC: reconcile-RPC + build failures emitted
 as generic events; K8s: pod status), returning per-worker health events; **keep the in-memory
@@ -515,13 +522,12 @@ apply path.
 1. ~~**T1 (I5)**~~ — done (#6291, reduced scope; capacity-path boundedness → T6).
 2. ~~**T2 (I2)**~~ — done (#6295; demand parity pinned by tests, validated on `marin-dev`).
 3. ~~**T3 (I4)**~~ — done (#6294; `ControlSnapshot` with health view is now T4's input).
-4. **T4 (I3)** — next; largest churn (uniform interface, health-events-into-backend, autoscaler
-   restore decoupling, input-shape unification). The Scheduler merge already happened in T2.
-   Land health-events-into-backend with the ping loop still present as belt-and-suspenders, then
-   remove ping in the same task once the backend events match the ping-derived liveness.
-5. **T5 (I1)** — after T1, T2, T4. The tick is then an ordering shell over functions that
-   already exist; also folds the remaining snapshot builders and kills the
-   `_last_residual_demand` cross-thread handoff. Fallback flag; `marin-dev` bake.
+4. ~~**T4 (I3)**~~ — done (PR #6311, awaiting merge; two review rounds — the adversarial pass
+   caught the worker-keep-alive blocker).
+5. **T5 (I1)** — next, after #6311 merges. The tick is then an ordering shell over functions
+   that already exist; also folds the remaining snapshot builders, kills the
+   `_last_residual_demand` cross-thread handoff, and absorbs T4's deferred doc nits.
+   Fallback flag; `marin-dev` bake (which doubles as T4's rollout churn validation).
 6. **T6** — after T4 (the autoscale phase is the natural home for issue-then-poll); independent
    of T5 and can land in parallel with it.
 
@@ -563,7 +569,20 @@ T4). Estimated ~3–4 remaining focused sessions.
   abandoning a hung pool thread that mutates shared autoscaler state is worse than blocking.
   Capacity-path boundedness comes from T6's polled operations instead.
 
+**Decided since (T4 review):**
+- **Method-specific results, uniform across backends** (`ScheduleResult`/`ReconcileResult`/
+  `AutoscaleResult`) instead of one fat `BackendResult`. The constraint that matters is *no
+  backend-type branching in the apply paths* — verified held.
+- **Reconcile is the worker keep-alive** (deadline reset + stats + self-health bit ride the
+  reconcile RPC); the worker Ping RPC is deleted end-to-end.
+- **Detection thresholds are time-based** (`worker_unreachable_grace`, default 50s, divided by
+  `poll_interval`) so cadence changes can't silently change reap latency again.
+- **Placement vs probing filters split**: scheduling excludes `consecutive_failures > 0`;
+  reconcile targets all active workers.
+
 **Open:**
+- **T4 rollout order** (one-time controller-first churn vs one-release Ping/health-unset shim) —
+  user decision at deploy time; analysis on PR #6311.
 - **Observation resolution (I3):** backend returns raw observations and the controller resolves
   in the pure kernel (recommended), vs backend pre-resolves against the in-memory snapshot.
 - **`cluster=` routing (follow-on):** hard constraint resolved by a pre-scheduler dispatcher


### PR DESCRIPTION
Plan document for the control-boundaries effort, now marked complete: all six tasks merged (#6291, #6295, #6294, #6311, #6344, #6343) plus post-merge fixes #6349 and #6352.

The document records the settled architecture (backend-observed / controller-owned health, single phased control tick with one end-of-tick commit, method-specific results uniform across backends, reconcile as the worker keep-alive, bounded-submission contract for platform cloud calls), the design deltas made during review, the per-task outcomes, and the one remaining operational step (marin-dev restart; rollout analysis on #6311).

Kept as the durable design record under docs/plans/.

Part of #75 (weaver tracking).

🤖 Generated with [Claude Code](https://claude.com/claude-code)