### PR TITLE
[ops] Keep Claude canary triage alive and pin opus-4.8

### DIFF
--- a/.github/actions/claude-triage/action.yaml
+++ b/.github/actions/claude-triage/action.yaml
@@ -47,13 +47,13 @@ runs:
   using: composite
   steps:
     - name: Run claude-code-action
-      uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
+      uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1  # v1.0.140
       with:
         claude_code_oauth_token: ${{ inputs.oauth-token }}
         prompt: |
           Read .agents/skills/triage-canary/SKILL.md and follow it.
         claude_args: |
-          --model opus
+          --model claude-opus-4-8
           --max-turns ${{ inputs.max-turns }}
           --allowedTools "${{ inputs.allowed-tools }}"
       env:

--- a/.github/workflows/marin-canary-ferry-coreweave.yaml
+++ b/.github/workflows/marin-canary-ferry-coreweave.yaml
@@ -144,14 +144,21 @@ jobs:
           R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           CANARY_TARGET_TOKENS: ${{ inputs.target_tokens || env.CANARY_TARGET_TOKENS }}
 
+      # Keep the wait below the job timeout (180) so a hung ferry fails this
+      # *step* (failure(), runner stays alive for Claude triage) rather than
+      # tripping the job timeout (cancelled(), which force-kills triage after
+      # GitHub's short grace — exit 143). The monitor --timeout (120m) exits
+      # gracefully; timeout-minutes is a hard backstop if the monitor wedges
+      # between polls. Healthy runs finish in ~35m, leaving ~55m for triage.
       - name: Wait for canary ferry
+        timeout-minutes: 125
         shell: bash -l {0}
         run: |
           uv run python scripts/workflows/iris_monitor.py wait \
             --job-id "${{ steps.submit.outputs.job_id }}" \
             --iris-config "$IRIS_CONFIG" \
             --poll-interval 30 \
-            --timeout 10500 \
+            --timeout 7200 \
             --github-output
 
       - name: Validate canary metrics

--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -98,7 +98,16 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           CANARY_TARGET_TOKENS: ${{ inputs.target_tokens || env.CANARY_TARGET_TOKENS }}
 
+      # Bound the wait below the job timeout (360) so a hung ferry fails this
+      # *step* rather than tripping the job timeout. A step timeout is failure(),
+      # which keeps the runner alive and lets Claude triage run with its full
+      # budget; a job timeout is cancelled(), which force-kills triage after
+      # GitHub's short cancellation grace (exit 143). --child-wait-timeout only
+      # bounds the queue wait — once a child is RUNNING the monitor relies on
+      # this wall clock. Healthy runs finish in ~2h, so 300 leaves 60m for
+      # diagnostics + triage.
       - name: Wait for canary ferry
+        timeout-minutes: 300
         shell: bash -l {0}
         run: |
           uv run python scripts/workflows/iris_monitor.py wait \

--- a/.github/workflows/marin-canary-grug-multislice.yaml
+++ b/.github/workflows/marin-canary-grug-multislice.yaml
@@ -105,7 +105,13 @@ jobs:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
           GRUG_MULTISLICE_STEPS: ${{ inputs.steps || env.GRUG_MULTISLICE_STEPS }}
 
+      # Bound the wait below the job timeout (180) so a hung ferry fails this
+      # *step* (failure(), runner stays alive for Claude triage) instead of
+      # tripping the job timeout (cancelled(), which force-kills triage). See the
+      # same note in marin-canary-ferry.yaml. Healthy runs finish in ~20m, so 135
+      # leaves 45m for diagnostics + triage.
       - name: Wait for Grug multislice smoke
+        timeout-minutes: 135
         shell: bash -l {0}
         run: |
           uv run python scripts/workflows/iris_monitor.py wait \

--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -32,14 +32,14 @@ jobs:
           fetch-depth: 1
 
       - name: Run Claude Review
-        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1  # v1.0.140
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           track_progress: true
           prompt: |
             /review-pr --comment ${{ github.event.pull_request.number }}
           claude_args: |
-            --model opus
+            --model claude-opus-4-8
             --max-turns 200
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(gh issue view:*),Bash(gh search:*),Bash(gh issue list:*),Bash(gh pr comment:*),Bash(gh pr diff:*),Bash(gh pr view:*),Bash(gh pr list:*),Bash(gh pr review:*)"
           allowed_bots: 'claude[bot]'
@@ -94,13 +94,13 @@ jobs:
           enable-cache: true
 
       - name: Run Lint Review
-        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1  # v1.0.140
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           prompt: |
             /lint-review --comment ${{ github.event.pull_request.number }}
           claude_args: |
-            --model opus
+            --model claude-opus-4-8
             --max-turns 150
             --allowedTools "mcp__github_inline_comment__create_inline_comment,Bash(./infra/pre-commit.py:*),Bash(gh pr comment:*),Bash(gh pr view:*),Bash(gh pr diff:*),Bash(gh api:*),Bash(git diff:*),Bash(git log:*),Bash(git show:*),Bash(git merge-base:*),Bash(git rev-parse:*),Bash(git status:*)"
           allowed_bots: 'claude[bot]'

--- a/.github/workflows/ops-claude.yaml
+++ b/.github/workflows/ops-claude.yaml
@@ -58,7 +58,7 @@ jobs:
 
       - name: Run Claude Code
         id: claude
-        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1  # v1.0.140
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'
@@ -72,7 +72,7 @@ jobs:
             actions: read
 
           claude_args: |
-            --model opus
+            --model claude-opus-4-8
             --max-turns 250
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"
             --system-prompt "Read and follow AGENTS.md (especially its Testing section) and .agents/skills/commit/SKILL.md before starting work. You always have the ability to commit and push your changes. Use your MCP tools if available, falling back to git and gh (which you have authorization for) if needed. NEVER credit yourself: no 'Co-Authored-By: Claude' or 'Generated with Claude Code' trailer in commits, and no self-attribution in PR descriptions. NEVER write tautological, trivial, or slop tests: a test must fail when behavior is wrong, not merely when the code changes; never add a test for a thin wrapper, a one-off script, or just to have one; if a change does not warrant a meaningful test, add none. Before submitting any changes: 1) Run ./infra/pre-commit.py --all-files --fix and fix any issues. 2) Run uv run pytest on tests relevant to your changes. Report on the test status when you provide an update. Always commit and push changes, even if you couldn't get the tests to pass. In any follow-up comments on issues or PRs, state how you tested your changes (which tests you ran and their results)."
@@ -109,7 +109,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Triage Issue
-        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1  # v1.0.140
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'
@@ -185,7 +185,7 @@ jobs:
 
             Always produce output — either a PR or an analysis comment. Never silently exit.
           claude_args: |
-            --model opus
+            --model claude-opus-4-8
             --max-turns 250
             --permission-mode acceptEdits
             --allowedTools "Bash(git:*),Bash(./infra/pre-commit.py:*),Bash(uv:*),Bash(pytest:*),Bash(gh:*),Bash(python:*)"
@@ -223,7 +223,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
 
       - name: Apply Autofix
-        uses: anthropics/claude-code-action@fefa07e9c665b7320f08c3b525980457f22f58aa  # v1
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1  # v1.0.140
         with:
           claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
           allowed_bots: 'claude[bot]'


### PR DESCRIPTION
The canary-ferry "Claude triage" step has been failing with exit 143 (SIGTERM). When a ferry hangs, the "Wait for ferry" step is not bounded below the job timeout, so it consumes the whole job budget. GitHub then cancels the job rather than failing it, and triage — which runs as a post-failure step — gets only GitHub's short cancellation grace before the runner is torn down. The last four nightly TPU runs all died this way at the 360-minute mark (healthy runs finish in ~2h).

The fix bounds each "Wait for ferry" step below its job timeout. A step timeout is failure(), which keeps the runner alive so the triage step runs with its full 30-minute budget; only a job timeout is cancelled(). Per workflow: TPU ferry gets a step timeout-minutes 300 (job 360); grug 135 (job 180); coreweave tightens the monitor --timeout to 120m with a 125-minute step backstop (job 180). datakit already had headroom and is unchanged.

Separately, the claude-code-action pin was stale (v1.0.111, which installs Claude Code 2.1.126, where "--model opus" resolves to claude-opus-4-7). Bump to v1.0.140 (Claude Code 2.1.168) and pin --model claude-opus-4-8 explicitly across every Claude workflow (triage action, ops-claude, ops-claude-review), so the model is reviewable rather than silently tracking an alias. The autofix job keeps its intentional claude-sonnet-4-6.

Note: the Ops - Claude Review check on this PR is expected to fail with "App token exchange failed: 401 Workflow validation failed" — GitHub's guard on PRs that edit a claude-code-action workflow file. It clears once merged.

Fixes #76