### PR TITLE
[iris] Fix flaky autoscaler-tab smoke screenshot (stale-DOM false positive)

### DIFF
--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -197,6 +197,21 @@ def smoke_screenshot(smoke_page, tmp_path_factory):
     return capture
 
 
+def _await_stable_screenshot(page, check: str, *, arg=None) -> None:
+    """Wait for a screenshot-readiness predicate, settle briefly, then re-verify.
+
+    Dashboard pages render structural content only after their first RPC resolves,
+    and an SPA route swap (lazy-imported components) can leave the previous page's
+    DOM mounted while the next chunk loads. The settle + re-verify catches a
+    predicate that passes on such a transient state and then flips back, so the
+    screenshot lands on the stable loaded page. Timing lives here so both detail
+    pages share one cadence.
+    """
+    page.wait_for_function(check, arg=arg, timeout=15000)
+    page.wait_for_timeout(250)
+    page.wait_for_function(check, arg=arg, timeout=5000)
+
+
 def _wait_for_worker_detail_screenshot_ready(page, worker_id: str) -> None:
     # WorkerDetail.vue uniquely nulls `data` in its workerId watch, so a late
     # re-fire can flip the page back to the "Loading worker..." overlay after a
@@ -216,9 +231,7 @@ def _wait_for_worker_detail_screenshot_ready(page, worker_id: str) -> None:
                 && headings.includes("task history");
         }
     """
-    page.wait_for_function(check, arg=worker_id, timeout=15000)
-    page.wait_for_timeout(250)
-    page.wait_for_function(check, arg=worker_id, timeout=5000)
+    _await_stable_screenshot(page, check, arg=worker_id)
 
 
 def _wait_for_job_detail_screenshot_ready(page, job_id: str) -> None:
@@ -495,20 +508,36 @@ def test_dashboard_worker_detail(smoke_cluster, smoke_page, smoke_screenshot, ca
     )
 
 
+def _wait_for_autoscaler_screenshot_ready(page) -> None:
+    # AutoscalerTab.vue shows only a "Loading autoscaler status…" spinner until its
+    # first RPC resolves. Route components are lazy-imported, so during the SPA swap
+    # the previously-viewed page (e.g. worker detail, which renders "Scale Group" +
+    # the "local-cpu" group name) is still mounted while the autoscaler chunk loads.
+    # A body-text wait keyed on those strings false-positives on that stale DOM, so
+    # the screenshot then catches the autoscaler spinner. Anchor on the route hash
+    # plus the section headings that only render in the loaded (v-else) branch so the
+    # match can't be satisfied by another page.
+    check = """
+        () => {
+            const text = document.body.textContent || "";
+            const routeReady = decodeURIComponent(window.location.hash) === "#/autoscaler";
+            const headings = Array.from(document.querySelectorAll("h3"))
+                .map((heading) => (heading.textContent || "").trim().toLowerCase());
+            return routeReady
+                && !text.includes("Loading autoscaler status")
+                && headings.includes("waterfall routing")
+                && headings.includes("recent actions")
+                && headings.includes("autoscaler logs");
+        }
+    """
+    _await_stable_screenshot(page, check)
+
+
 def test_dashboard_autoscaler_tab(smoke_cluster, smoke_page, smoke_screenshot):
     """Autoscaler tab shows scale groups."""
     dashboard_goto(smoke_page, f"{smoke_cluster.url}/autoscaler")
     wait_for_dashboard_ready(smoke_page)
-    # Wait for actual scale group content. The strict !Loading-autoscaler-status check
-    # blocks on the AutoscalerTab.vue placeholder so the screenshot isn't taken
-    # during a refetch cycle.
-    smoke_page.wait_for_function(
-        "() => !document.body.textContent.includes('Loading autoscaler status') && "
-        "(document.body.textContent.includes('Scale Group') || "
-        "document.body.textContent.includes('scale group') || "
-        "document.body.textContent.includes('local-cpu'))",
-        timeout=15000,
-    )
+    _wait_for_autoscaler_screenshot_ready(smoke_page)
     smoke_screenshot("autoscaler-tab", "Autoscaler tab showing scale group configuration")
 
 


### PR DESCRIPTION
## Problem

The `iris-e2e-smoke` job's **Verify screenshots with Claude** step intermittently fails because `smoke-autoscaler-tab.png` captures the `Loading autoscaler status…` spinner instead of the loaded tab — e.g. [this run](https://github.com/marin-community/marin/actions/runs/27159062442/job/80169423531?pr=6249).

## Root cause

Dashboard route components are lazy-imported. During the SPA swap to `/autoscaler`, the previously-viewed page is still mounted while the autoscaler chunk loads. The worker-detail page (which runs right before the autoscaler test on the shared module-scoped page) renders both `Scale Group` and the `local-cpu` group name in its body text.

The old `wait_for_function` was keyed on those exact strings:

```python
"() => !document.body.textContent.includes('Loading autoscaler status') && "
"(... includes('Scale Group') || ... includes('scale group') || ... includes('local-cpu'))"
```

so it false-positived on the **stale worker-detail DOM** during the transition (which contains `Scale Group`/`local-cpu` and not the autoscaler spinner text). The wait returned immediately, and the screenshot was then taken while `AutoscalerTab.vue` was still showing its loading spinner.

`useRpc` never nulls `data` after a successful fetch, so the spinner cannot reappear once content has loaded — the only way to capture it is to shoot before the loaded content ever rendered, which is exactly what the stale-DOM match caused.

## Fix

Anchor the readiness check on the route hash (`#/autoscaler`) **plus** the section headings that only render in the loaded (`v-else`) branch — `Waterfall Routing`, `Recent Actions`, `Autoscaler Logs` — so the predicate cannot be satisfied by any other page's DOM. This mirrors the existing `_wait_for_worker_detail_screenshot_ready` approach.

The shared wait → settle → re-verify scaffold is extracted into `_await_stable_screenshot` so both detail pages share one cadence (resolving the lint-review duplicate-logic finding).

## Verification

Ran `worker_detail` + `autoscaler_tab` together (shared module-scoped page → reproduces the exact route-swap precondition) locally with Playwright; both pass and the captured `smoke-autoscaler-tab.png` now shows the fully loaded tab (Fleet Overview, Waterfall Routing with scale groups, Recent Actions, Autoscaler Logs). `./infra/pre-commit.py --review` reports no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)