### PR TITLE
[codehealth] Report linter metrics; split human/bot lenses; classify with Claude

### DIFF
--- a/infra/codehealth/review.py
+++ b/infra/codehealth/review.py
@@ -588,11 +588,24 @@ def _parse_ts(s: str) -> dt.datetime:
     return dt.datetime.fromisoformat(s.replace("Z", "+00:00"))
 
 
+def _in_window(row: dict, key: str, start: dt.datetime) -> bool:
+    """True when the timestamp at `row[key]` is on/after `start`. Rows with a
+    missing or unparseable timestamp fall outside the window. Shared by the
+    merged-PR tables (keyed on `merged_at`) and the automation tables (`ts`)."""
+    ts = row.get(key)
+    if not ts:
+        return False
+    try:
+        return _parse_ts(ts) >= start
+    except ValueError:
+        return False
+
+
 def _pct(n: int, d: int) -> str:
     return f"{round(100 * n / d)}%" if d else "—"
 
 
-def _ival(value: object) -> int:
+def _to_int(value: object) -> int:
     """Coerce a possibly-null W&B cell to int; missing/garbage counts as 0."""
     try:
         return int(value)  # type: ignore[arg-type]
@@ -600,7 +613,7 @@ def _ival(value: object) -> int:
         return 0
 
 
-def _fval(value: object) -> float | None:
+def _to_float(value: object) -> float | None:
     """Coerce a possibly-null W&B cell to float, or None when absent/garbage."""
     try:
         return float(value)  # type: ignore[arg-type]
@@ -644,17 +657,8 @@ def build_automation_section(invocations: list[dict], findings: list[dict], star
     rules it fired — distinct from the human-comment catchability analysis,
     which measures what reviewers caught that the bot could have."""
 
-    def in_window(row: dict) -> bool:
-        ts = row.get("ts")
-        if not ts:
-            return False
-        try:
-            return _parse_ts(ts) >= start
-        except ValueError:
-            return False
-
-    runs = [r for r in invocations if in_window(r)]
-    finds = [f for f in findings if in_window(f)]
+    runs = [r for r in invocations if _in_window(r, "ts", start)]
+    finds = [f for f in findings if _in_window(f, "ts", start)]
 
     heading = "## Review automation activity"
     blurb = (
@@ -667,10 +671,10 @@ def build_automation_section(invocations: list[dict], findings: list[dict], star
         return f"{heading}\n\n{blurb}\n\n_No review-bot runs recorded in the last {days} days._"
 
     n_runs = len(runs)
-    with_findings = sum(1 for r in runs if _ival(r.get("finding_count")) > 0)
-    failed = sum(1 for r in runs if _ival(r.get("agent_exit_code")) != 0 or bool(r.get("timed_out")))
-    total_findings = sum(_ival(r.get("finding_count")) for r in runs)
-    elapsed = sorted(v for r in runs if (v := _fval(r.get("elapsed"))) is not None)
+    with_findings = sum(1 for r in runs if _to_int(r.get("finding_count")) > 0)
+    failed = sum(1 for r in runs if _to_int(r.get("agent_exit_code")) != 0 or bool(r.get("timed_out")))
+    total_findings = sum(_to_int(r.get("finding_count")) for r in runs)
+    elapsed = sorted(v for r in runs if (v := _to_float(r.get("elapsed"))) is not None)
     median_elapsed = elapsed[len(elapsed) // 2] if elapsed else None
 
     summary = "### Activity\n\n" + _md_table(
@@ -694,7 +698,7 @@ def build_automation_section(invocations: list[dict], findings: list[dict], star
         code = str(f.get("code") or "(uncoded)")
         e = by_code.setdefault(code, [0, 0.0, ""])
         e[0] += 1
-        conf = _fval(f.get("confidence"))
+        conf = _to_float(f.get("confidence"))
         if conf is not None:
             e[1] += conf
         if not e[2]:
@@ -722,8 +726,8 @@ def build_automation_section(invocations: list[dict], findings: list[dict], star
             continue
         e = weeks.setdefault((y, w), [0, 0, 0])
         e[0] += 1
-        e[1] += 1 if _ival(r.get("finding_count")) > 0 else 0
-        e[2] += _ival(r.get("finding_count"))
+        e[1] += 1 if _to_int(r.get("finding_count")) > 0 else 0
+        e[2] += _to_int(r.get("finding_count"))
     week_rows = [[f"{y}-W{w:02d}", n, wf, fnd] for (y, w), (n, wf, fnd) in sorted(weeks.items())]
     trend = "### Weekly trend\n\n" + _md_table(
         ["Week", "Runs", "With findings", "Findings"],
@@ -748,17 +752,8 @@ def build_report(
     digest. Pure: takes already-loaded rows, returns markdown. Rows are filtered
     to PRs merged on/after `start`."""
 
-    def in_window(row: dict) -> bool:
-        merged = row.get("merged_at")
-        if not merged:
-            return False
-        try:
-            return _parse_ts(merged) >= start
-        except ValueError:
-            return False
-
-    outcomes = [d for d in outcomes if in_window(d)]
-    comments = [d for d in comments if in_window(d)]
+    outcomes = [d for d in outcomes if _in_window(d, "merged_at", start)]
+    comments = [d for d in comments if _in_window(d, "merged_at", start)]
 
     header = (
         f"# Marin code-health review report\n\n"

--- a/infra/codehealth/review.py
+++ b/infra/codehealth/review.py
@@ -18,8 +18,11 @@ Two subcommands:
   - `aggregate` (designed to run as a daily GHA cron) classifies reviewer
     comments and appends them to the shared `review-stats` W&B run.
   - `report` reads those accumulated tables back and renders a markdown digest
-    (summary table, by-class breakdown, weekly trend, top PRs, examples),
-    published as a gist by default.
+    (summary table, by-class breakdown, weekly trend, top PRs, examples). It
+    also folds in the linter-fed `invocations`/`findings` tables (written by
+    `infra/codehealth/log_stats.py` on every review-bot run) as a "Review
+    automation activity" section — runs, runtime, and the catalog rules fired.
+    Published as a gist by default.
 
 `aggregate`, for each PR merged in the last N days:
   1. Pull review/inline/issue comments via the `gh` CLI.
@@ -67,6 +70,11 @@ import click
 import wandb
 from google import genai
 from google.genai import types
+
+# Sibling standalone script: the canonical schema for the linter-fed tables this
+# report reads back. Importing keeps the column layouts in one place rather than
+# re-declaring them here and risking drift.
+from log_stats import FINDING_COLUMNS, INVOCATION_COLUMNS
 from pydantic import BaseModel, Field, TypeAdapter
 
 logger = logging.getLogger("codehealth.review")
@@ -537,13 +545,18 @@ def load_findings_for_shas(wandb, shas: set[str]) -> dict[str, list[dict]]:
     Returns sha -> list of finding dicts (file, line, code, confidence, message).
     """
     by_sha: dict[str, list[dict]] = {sha: [] for sha in shas}
-    # FINDING_COLUMNS layout from log_stats.py:
-    #   ts, invocation_id, tool, pr_number, git_branch, head_sha, marin_user,
-    #   file, line, code, confidence, message
-    for r in _load_existing_rows(wandb, "findings"):
-        sha = r[5]
+    for r in _rows_to_dicts(FINDING_COLUMNS, _load_existing_rows(wandb, "findings")):
+        sha = r["head_sha"]
         if sha in by_sha:
-            by_sha[sha].append({"file": r[7], "line": r[8], "code": r[9], "confidence": r[10], "message": r[11]})
+            by_sha[sha].append(
+                {
+                    "file": r["file"],
+                    "line": r["line"],
+                    "code": r["code"],
+                    "confidence": r["confidence"],
+                    "message": r["message"],
+                }
+            )
     return by_sha
 
 
@@ -579,6 +592,22 @@ def _pct(n: int, d: int) -> str:
     return f"{round(100 * n / d)}%" if d else "—"
 
 
+def _ival(value: object) -> int:
+    """Coerce a possibly-null W&B cell to int; missing/garbage counts as 0."""
+    try:
+        return int(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return 0
+
+
+def _fval(value: object) -> float | None:
+    """Coerce a possibly-null W&B cell to float, or None when absent/garbage."""
+    try:
+        return float(value)  # type: ignore[arg-type]
+    except (TypeError, ValueError):
+        return None
+
+
 def _cell(value: object, maxlen: int | None = None) -> str:
     """Render a value as a single safe markdown table cell."""
     text = " ".join(str(value).split()).replace("|", "\\|")
@@ -604,8 +633,116 @@ def _where(file: object, line: object) -> str:
     return f"{file}:{line}" if line not in (None, "") else str(file)
 
 
+def build_automation_section(invocations: list[dict], findings: list[dict], start: dt.datetime, days: int) -> str:
+    """Render review-automation activity from the linter-fed `invocations` and
+    `findings` tables (written by `infra/codehealth/log_stats.py` on every
+    `pre-commit.py --review` / `/code-review` / `/review-pr` run). Pure: takes
+    already-loaded rows, returns markdown, filtered to runs whose `ts` falls
+    on/after `start`.
+
+    This is what the review bot itself did — runs, runtime, and the catalog
+    rules it fired — distinct from the human-comment catchability analysis,
+    which measures what reviewers caught that the bot could have."""
+
+    def in_window(row: dict) -> bool:
+        ts = row.get("ts")
+        if not ts:
+            return False
+        try:
+            return _parse_ts(ts) >= start
+        except ValueError:
+            return False
+
+    runs = [r for r in invocations if in_window(r)]
+    finds = [f for f in findings if in_window(f)]
+
+    heading = "## Review automation activity"
+    blurb = (
+        "What the review bot itself did over the window — every "
+        "`pre-commit.py --review`, `/code-review`, and `/review-pr` run logs to "
+        "W&B. Distinct from the catchability analysis above: that measures human "
+        "comments the bot could have caught; this is the bot's own output."
+    )
+    if not runs:
+        return f"{heading}\n\n{blurb}\n\n_No review-bot runs recorded in the last {days} days._"
+
+    n_runs = len(runs)
+    with_findings = sum(1 for r in runs if _ival(r.get("finding_count")) > 0)
+    failed = sum(1 for r in runs if _ival(r.get("agent_exit_code")) != 0 or bool(r.get("timed_out")))
+    total_findings = sum(_ival(r.get("finding_count")) for r in runs)
+    elapsed = sorted(v for r in runs if (v := _fval(r.get("elapsed"))) is not None)
+    median_elapsed = elapsed[len(elapsed) // 2] if elapsed else None
+
+    summary = "### Activity\n\n" + _md_table(
+        ["Metric", "Value"],
+        ["---", "---:"],
+        [
+            ["Review runs", n_runs],
+            ["— produced findings", f"{with_findings} ({_pct(with_findings, n_runs)})"],
+            ["— silent (no findings)", f"{n_runs - with_findings} ({_pct(n_runs - with_findings, n_runs)})"],
+            ["— failed or timed out", failed],
+            ["Findings emitted", total_findings],
+            ["Findings per run (mean)", f"{total_findings / n_runs:.1f}"],
+            ["Median runtime", f"{median_elapsed:.0f}s" if median_elapsed is not None else "—"],
+        ],
+    )
+
+    # Most-fired catalog rules: the `code` on each finding (e.g.
+    # `ml-exception-swallow`). Answers "what does the reviewer flag most?"
+    by_code: dict[str, list] = {}
+    for f in finds:
+        code = str(f.get("code") or "(uncoded)")
+        e = by_code.setdefault(code, [0, 0.0, ""])
+        e[0] += 1
+        conf = _fval(f.get("confidence"))
+        if conf is not None:
+            e[1] += conf
+        if not e[2]:
+            e[2] = str(f.get("message") or "")
+    code_rows = [
+        [_cell(code), n, _pct(n, len(finds)), f"{conf_sum / n:.2f}", _cell(example, 80)]
+        for code, (n, conf_sum, example) in sorted(by_code.items(), key=lambda kv: kv[1][0], reverse=True)[:15]
+    ]
+    codes_section = "### Most frequent findings\n\n" + (
+        _md_table(
+            ["Catalog code", "Count", "% of findings", "Mean conf.", "Example"],
+            ["---", "---:", "---:", "---:", "---"],
+            code_rows,
+        )
+        if code_rows
+        else "_No findings emitted in this window._"
+    )
+
+    # Weekly adoption: runs + findings keyed by ISO week of the run timestamp.
+    weeks: dict[tuple[int, int], list[int]] = {}
+    for r in runs:
+        try:
+            y, w, _ = _parse_ts(r["ts"]).isocalendar()
+        except (ValueError, KeyError):
+            continue
+        e = weeks.setdefault((y, w), [0, 0, 0])
+        e[0] += 1
+        e[1] += 1 if _ival(r.get("finding_count")) > 0 else 0
+        e[2] += _ival(r.get("finding_count"))
+    week_rows = [[f"{y}-W{w:02d}", n, wf, fnd] for (y, w), (n, wf, fnd) in sorted(weeks.items())]
+    trend = "### Weekly trend\n\n" + _md_table(
+        ["Week", "Runs", "With findings", "Findings"],
+        ["---", "---:", "---:", "---:"],
+        week_rows,
+    )
+
+    return "\n\n".join([heading, blurb, summary, codes_section, trend])
+
+
 def build_report(
-    outcomes: list[dict], comments: list[dict], repo: str, start: dt.datetime, now: dt.datetime, days: int
+    outcomes: list[dict],
+    comments: list[dict],
+    invocations: list[dict],
+    findings: list[dict],
+    repo: str,
+    start: dt.datetime,
+    now: dt.datetime,
+    days: int,
 ) -> str:
     """Render the per-PR outcome rows and classified comments into a markdown
     digest. Pure: takes already-loaded rows, returns markdown. Rows are filtered
@@ -629,8 +766,13 @@ def build_report(
         f"**Generated:** {now.replace(microsecond=0).isoformat()}"
     )
 
+    # The automation section reads its own (`invocations`/`findings`) tables and
+    # filters by run timestamp, so it is independent of whether any PR merged.
+    automation_section = build_automation_section(invocations, findings, start, days)
+
     if not outcomes:
-        return f"{header}\n\nNo PRs merged in the last {days} days were found in the review-stats tables."
+        note = f"No PRs merged in the last {days} days were found in the review-stats tables."
+        return "\n\n".join([header, note, automation_section])
 
     n_prs = len(outcomes)
     reviewed = sum(1 for d in outcomes if int(d["total_human_comments"]) > 0)
@@ -765,7 +907,9 @@ def build_report(
         else "_No catchable comments in this window._"
     )
 
-    return "\n\n".join([header, narrative, summary, by_class_section, trend_section, top_section, flagged_section])
+    return "\n\n".join(
+        [header, narrative, summary, automation_section, by_class_section, trend_section, top_section, flagged_section]
+    )
 
 
 def publish_gist(markdown: str, desc: str, public: bool, filename: str) -> str:
@@ -1006,7 +1150,11 @@ def aggregate(
 @click.option("--public", is_flag=True, help="Create a public gist (default: secret)")
 @click.option("--no-gist", is_flag=True, help="Print the report to stdout instead of creating a gist")
 def report(repo: str, days: int, out: str | None, public: bool, no_gist: bool) -> None:
-    """Render the accumulated review stats into a markdown digest and gist it."""
+    """Render the accumulated review stats into a markdown digest and gist it.
+
+    Reads four tables from the shared `review-stats` run: `pr_review_outcomes`
+    and `human_comments` (the catchability analysis) plus the linter-fed
+    `invocations` and `findings` (the review bot's own activity)."""
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     now = dt.datetime.now(dt.timezone.utc)
     start = now - dt.timedelta(days=days)
@@ -1019,9 +1167,11 @@ def report(repo: str, days: int, out: str | None, public: bool, no_gist: bool) -
     )
     outcomes = _rows_to_dicts(PR_OUTCOME_COLUMNS, _load_existing_rows(wandb, "pr_review_outcomes"))
     comments = _rows_to_dicts(HUMAN_COMMENT_COLUMNS, _load_existing_rows(wandb, "human_comments"))
+    invocations = _rows_to_dicts(INVOCATION_COLUMNS, _load_existing_rows(wandb, "invocations"))
+    findings = _rows_to_dicts(FINDING_COLUMNS, _load_existing_rows(wandb, "findings"))
     wandb.finish(quiet=True)
 
-    markdown = build_report(outcomes, comments, repo=repo, start=start, now=now, days=days)
+    markdown = build_report(outcomes, comments, invocations, findings, repo=repo, start=start, now=now, days=days)
 
     if out:
         Path(out).write_text(markdown)

--- a/infra/codehealth/review.py
+++ b/infra/codehealth/review.py
@@ -313,15 +313,11 @@ def _parse_claude_batch(stdout: str) -> list[BatchedClassification] | None:
 
 
 def make_claude_classifier(model: str, agent_command: str = "claude -p") -> Classifier:
-    """Build a `Classifier` that shells out to a headless Claude Code session.
-
-    One `claude -p` subprocess per batch — the same agent the lint review uses.
-    Each call is a fresh, isolated session (`_headless_env` strips the parent's
-    session/API-key markers so it runs on subscription auth), with tools
-    disabled and `--json-schema` forcing a structured-output array the API
-    validates against `_classification_schema`. The prompt carries every
-    comment's `id` marker on stdin. A failed or malformed call yields no
-    classifications for that batch; those comments are dropped from the metric.
+    """Build a `Classifier` that shells out to a headless Claude Code session
+    per batch — the same agent the lint review uses, run as a fresh isolated
+    session on Claude subscription auth. A failed or malformed call yields no
+    classifications for that batch; those comments are dropped from the metric,
+    the same degradation as any classifier backend.
     """
     env = _headless_env()
     cmd = [
@@ -684,6 +680,22 @@ def _in_window(row: dict, key: str, start: dt.datetime) -> bool:
         return False
 
 
+def _group_by_isoweek(rows: list[dict], ts_key: str) -> dict[tuple[int, int], list[dict]]:
+    """Bucket rows by the ISO (year, week) of `row[ts_key]`. Rows with a missing
+    or unparseable timestamp are dropped; callers sort the keys for display."""
+    weeks: dict[tuple[int, int], list[dict]] = {}
+    for row in rows:
+        ts = row.get(ts_key)
+        if not ts:
+            continue
+        try:
+            y, w, _ = _parse_ts(ts).isocalendar()
+        except ValueError:
+            continue
+        weeks.setdefault((y, w), []).append(row)
+    return weeks
+
+
 def _pct(n: int, d: int) -> str:
     return f"{round(100 * n / d)}%" if d else "—"
 
@@ -801,17 +813,11 @@ def build_automation_section(invocations: list[dict], findings: list[dict], star
     )
 
     # Weekly adoption: runs + findings keyed by ISO week of the run timestamp.
-    weeks: dict[tuple[int, int], list[int]] = {}
-    for r in runs:
-        try:
-            y, w, _ = _parse_ts(r["ts"]).isocalendar()
-        except (ValueError, KeyError):
-            continue
-        e = weeks.setdefault((y, w), [0, 0, 0])
-        e[0] += 1
-        e[1] += 1 if _to_int(r.get("finding_count")) > 0 else 0
-        e[2] += _to_int(r.get("finding_count"))
-    week_rows = [[f"{y}-W{w:02d}", n, wf, fnd] for (y, w), (n, wf, fnd) in sorted(weeks.items())]
+    week_rows = []
+    for (y, w), group in sorted(_group_by_isoweek(runs, "ts").items()):
+        found = sum(_to_int(r.get("finding_count")) for r in group)
+        with_finds = sum(1 for r in group if _to_int(r.get("finding_count")) > 0)
+        week_rows.append([f"{y}-W{w:02d}", len(group), with_finds, found])
     trend = "### Weekly trend\n\n" + _md_table(
         ["Week", "Runs", "With findings", "Findings"],
         ["---", "---:", "---:", "---:"],
@@ -917,20 +923,12 @@ def build_report(
     )
 
     # Weekly trend, keyed by ISO week of the merge date.
-    weeks: dict[tuple[int, int], list[int]] = {}
-    for d in outcomes:
-        try:
-            y, w, _ = _parse_ts(d["merged_at"]).isocalendar()
-        except ValueError:
-            continue
-        e = weeks.setdefault((y, w), [0, 0, 0, 0])
-        e[0] += 1
-        e[1] += int(d["total_human_comments"])
-        e[2] += int(d["catchable_strict_count"])
-        e[3] += int(d["catchable_generous_count"])
-    week_rows = [
-        [f"{y}-W{w:02d}", prs, cmts, st, gen, _pct(gen, cmts)] for (y, w), (prs, cmts, st, gen) in sorted(weeks.items())
-    ]
+    week_rows = []
+    for (y, w), group in sorted(_group_by_isoweek(outcomes, "merged_at").items()):
+        cmts = sum(int(d["total_human_comments"]) for d in group)
+        st = sum(int(d["catchable_strict_count"]) for d in group)
+        gen = sum(int(d["catchable_generous_count"]) for d in group)
+        week_rows.append([f"{y}-W{w:02d}", len(group), cmts, st, gen, _pct(gen, cmts)])
     trend_section = "### Weekly trend\n\n" + _md_table(
         ["Week", "PRs", "Comments", "Strict", "Generous", "Generous %"],
         ["---", "---:", "---:", "---:", "---:", "---:"],

--- a/infra/codehealth/review.py
+++ b/infra/codehealth/review.py
@@ -6,7 +6,6 @@
 # requires-python = ">=3.11"
 # dependencies = [
 #     "click>=8.0",
-#     "google-genai>=1.0",
 #     "pydantic>=2.0",
 #     "wandb>=0.18",
 # ]
@@ -27,8 +26,9 @@ Two subcommands:
 `aggregate`, for each PR merged in the last N days:
   1. Pull review/inline/issue comments via the `gh` CLI.
   2. Drop bot comments (only humans should be in the denominator).
-  3. Classify each human comment with a pluggable classifier (Gemini 3.5 Flash
-     by default). Comments from all PRs are pooled, batched, and the batches
+  3. Classify each human comment with a pluggable classifier — a headless
+     Claude Code session (`claude -p`) by default, the same agent that runs the
+     lint review. Comments from all PRs are pooled, batched, and the batches
      classified in parallel so a many-PR run is not a long serial trickle of
      one request per comment. Two independent "could automation have caught
      this?" signals:
@@ -47,8 +47,8 @@ Two subcommands:
 Same append-to-artifact pattern as `infra/codehealth/log_stats.py`. Concurrent
 writers race; loser's row is dropped (acceptable at our scale).
 
-Requires GEMINI_API_KEY and W&B auth. Invoke via `gh auth login` for the
-GitHub side. Designed to run as a daily GHA cron.
+Requires a logged-in `claude` CLI (subscription auth) and W&B auth, plus
+`gh auth login` for the GitHub side. Designed to run as a daily GHA cron.
 """
 
 from __future__ import annotations
@@ -57,6 +57,7 @@ import datetime as dt
 import json
 import logging
 import os
+import shutil
 import subprocess
 import sys
 import tempfile
@@ -64,12 +65,10 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Literal
+from typing import Literal, get_args
 
 import click
 import wandb
-from google import genai
-from google.genai import types
 
 # Sibling standalone script: the canonical schema for the linter-fed tables this
 # report reads back. Importing keeps the column layouts in one place rather than
@@ -82,9 +81,14 @@ logger = logging.getLogger("codehealth.review")
 WANDB_PROJECT = "marin-review-stats"
 WANDB_RUN_ID = "review-stats"
 DEFAULT_REPO = "marin-community/marin"
-DEFAULT_MODEL = "gemini-3.5-flash"
+# Classifier backend: a headless Claude Code session (`claude -p`). The model is
+# a CLI alias (`sonnet`, `opus`, `haiku`) or a full model id. `sonnet` balances
+# classification quality against cost for the per-comment judgment calls.
+DEFAULT_MODEL = "sonnet"
 DEFAULT_BATCH_SIZE = 20
-DEFAULT_CONCURRENCY = 16
+# One headless `claude` subprocess per batch, so concurrency caps simultaneous
+# processes (and subscription rate pressure) — lower than an HTTP-API backend.
+DEFAULT_CONCURRENCY = 4
 
 HUMAN_COMMENT_COLUMNS = [
     "ts",
@@ -122,7 +126,7 @@ PR_OUTCOME_COLUMNS = [
 
 
 # ---------------------------------------------------------------------------
-# Gemini classifier schema + prompt
+# Comment classifier: schema + prompt
 # ---------------------------------------------------------------------------
 
 
@@ -158,8 +162,8 @@ class BatchedClassification(CommentClassification):
 
 # A classifier turns a batch of comments into classifications keyed by their
 # `id` marker. Comments it cannot classify are simply absent from the result.
-# Pluggable so the Gemini backend can be swapped (e.g. for `claude -p`) without
-# touching the batching/parallelism orchestration.
+# Pluggable so the backend (currently a headless `claude -p` session) can be
+# swapped without touching the batching/parallelism orchestration.
 Classifier = Callable[[list[CommentToClassify]], dict[int, CommentClassification]]
 
 
@@ -240,36 +244,115 @@ def _format_batch(items: list[CommentToClassify]) -> str:
     return "\n\n".join(blocks)
 
 
-def make_gemini_classifier(client: genai.Client, model: str) -> Classifier:
-    """Build a `Classifier` backed by Gemini structured output.
+# Env markers that would bind a spawned `claude` to its parent Claude Code
+# session or to metered API billing. Stripped before exec (mirrors the lint
+# review in infra/linter.py) so each batch runs as a fresh, isolated session on
+# Claude subscription auth rather than nesting under the caller's transcript.
+CLAUDE_STRIPPED_ENV = (
+    "ANTHROPIC_API_KEY",
+    "CLAUDECODE",
+    "CLAUDE_CODE_ENTRYPOINT",
+    "CLAUDE_CODE_EXECPATH",
+    "CLAUDE_CODE_SESSION_ID",
+    "CLAUDE_CODE_SSE_PORT",
+)
 
-    One API call per batch: the prompt carries every comment's `id` marker and
-    the response is a JSON array of `BatchedClassification`. A failed call (or
-    unparseable response) yields no classifications for that batch; those
-    comments are dropped from the metric, same as the previous behavior.
+# Per-batch wall-clock ceiling for one headless classification call.
+CLAUDE_TIMEOUT = 300
+
+
+def _headless_env() -> dict[str, str]:
+    return {k: v for k, v in os.environ.items() if k not in CLAUDE_STRIPPED_ENV}
+
+
+def _classification_schema() -> dict:
+    """Anthropic structured-output JSON schema for one batch result.
+
+    The API uses this schema as a tool `input_schema`, whose root must be an
+    object (a top-level array is rejected), so the per-comment classifications
+    are wrapped in a `results` array. Field set mirrors `BatchedClassification`.
     """
+    item = {
+        "type": "object",
+        "properties": {
+            "id": {"type": "integer"},
+            "class": {"type": "string", "enum": list(get_args(CommentClass))},
+            "catchable_strict": {"type": "boolean"},
+            "catchable_generous": {"type": "boolean"},
+            "confidence": {"type": "number", "minimum": 0.0, "maximum": 1.0},
+            "reason": {"type": "string"},
+        },
+        "required": ["id", "class", "catchable_strict", "catchable_generous", "confidence", "reason"],
+    }
+    return {
+        "type": "object",
+        "properties": {"results": {"type": "array", "items": item}},
+        "required": ["results"],
+    }
+
+
+def _parse_claude_batch(stdout: str) -> list[BatchedClassification] | None:
+    """Extract the classifications from a `claude -p --output-format json`
+    envelope. Schema-validated structured output lands in the top-level
+    `structured_output` field (`result` carries only the model's prose).
+    Returns None on any error so the caller drops the batch.
+    """
+    try:
+        envelope = json.loads(stdout)
+    except (json.JSONDecodeError, ValueError):
+        return None
+    if not isinstance(envelope, dict) or envelope.get("is_error"):
+        return None
+    structured = envelope.get("structured_output")
+    if not isinstance(structured, dict) or "results" not in structured:
+        return None
+    try:
+        return _BATCH_ADAPTER.validate_python(structured["results"])
+    except ValueError:
+        return None
+
+
+def make_claude_classifier(model: str, agent_command: str = "claude -p") -> Classifier:
+    """Build a `Classifier` that shells out to a headless Claude Code session.
+
+    One `claude -p` subprocess per batch — the same agent the lint review uses.
+    Each call is a fresh, isolated session (`_headless_env` strips the parent's
+    session/API-key markers so it runs on subscription auth), with tools
+    disabled and `--json-schema` forcing a structured-output array the API
+    validates against `_classification_schema`. The prompt carries every
+    comment's `id` marker on stdin. A failed or malformed call yields no
+    classifications for that batch; those comments are dropped from the metric.
+    """
+    env = _headless_env()
+    cmd = [
+        *agent_command.split(),
+        "--output-format",
+        "json",
+        "--tools",
+        "",
+        "--model",
+        model,
+        "--json-schema",
+        json.dumps(_classification_schema()),
+    ]
 
     def classify(items: list[CommentToClassify]) -> dict[int, CommentClassification]:
         if not items:
             return {}
+        prompt = f"{CLASSIFIER_SYSTEM}\n\n{_format_batch(items)}"
         try:
-            resp = client.models.generate_content(
-                model=model,
-                contents=_format_batch(items),
-                config=types.GenerateContentConfig(
-                    system_instruction=CLASSIFIER_SYSTEM,
-                    response_mime_type="application/json",
-                    response_schema=list[BatchedClassification],
-                    temperature=0.0,
-                ),
-            )
-        except Exception as e:
-            logger.warning("Gemini call failed for batch of %d: %s", len(items), e)
+            proc = subprocess.run(cmd, input=prompt, capture_output=True, text=True, env=env, timeout=CLAUDE_TIMEOUT)
+        except subprocess.TimeoutExpired:
+            logger.warning("claude classify timed out for batch of %d", len(items))
             return {}
-        try:
-            parsed = _BATCH_ADAPTER.validate_json(resp.text)
-        except Exception as e:
-            logger.warning("Gemini returned unparseable JSON: %s | text=%r", e, (resp.text or "")[:200])
+        parsed = _parse_claude_batch(proc.stdout)
+        if parsed is None:
+            logger.warning(
+                "claude classify failed for batch of %d (exit=%s): %s",
+                len(items),
+                proc.returncode,
+                (proc.stderr or proc.stdout or "").strip()[:200],
+            )
             return {}
         wanted = {it.id for it in items}
         out: dict[int, CommentClassification] = {}
@@ -282,7 +365,7 @@ def make_gemini_classifier(client: genai.Client, model: str) -> Classifier:
             out[c.id] = c
         missing = len(wanted) - len(out)
         if missing:
-            logger.warning("Gemini omitted %d of %d comments in a batch", missing, len(items))
+            logger.warning("claude omitted %d of %d comments in a batch", missing, len(items))
         return out
 
     return classify
@@ -761,41 +844,55 @@ def build_report(
         f"**Generated:** {now.replace(microsecond=0).isoformat()}"
     )
 
+    # Two distinct lenses, kept in separate sections below so they are not
+    # conflated: what humans flagged (and whether a bot could have), versus what
+    # the bot itself flagged.
+    overview = (
+        "Two lenses on review quality:\n\n"
+        "- **Human review feedback** — comments people left on merged PRs, each classified by "
+        "whether an automated review *could* have caught it (**strict** = a deterministic "
+        "linter/type-checker would; **generous** = an LLM reading the diff would). This is the "
+        "gap automation still leaves.\n"
+        "- **Review automation activity** — what the review bot actually flagged when it ran. "
+        "This is what automation already does."
+    )
+
     # The automation section reads its own (`invocations`/`findings`) tables and
     # filters by run timestamp, so it is independent of whether any PR merged.
     automation_section = build_automation_section(invocations, findings, start, days)
 
     if not outcomes:
         note = f"No PRs merged in the last {days} days were found in the review-stats tables."
-        return "\n\n".join([header, note, automation_section])
+        return "\n\n".join([header, overview, note, automation_section])
 
     n_prs = len(outcomes)
     reviewed = sum(1 for d in outcomes if int(d["total_human_comments"]) > 0)
     total = sum(int(d["total_human_comments"]) for d in outcomes)
     strict = sum(int(d["catchable_strict_count"]) for d in outcomes)
     generous = sum(int(d["catchable_generous_count"]) for d in outcomes)
-    bot_findings = sum(int(d["bot_findings_count"]) for d in outcomes)
     overlap = sum(int(d["overlap_count"]) for d in outcomes)
 
     narrative = (
+        "## Human review feedback\n\n"
+        "What human reviewers flagged on merged PRs, and how much of it an automated review could "
+        "have caught.\n\n"
         f"Over the last {days} days, **{n_prs}** PRs merged; **{reviewed}** ({_pct(reviewed, n_prs)}) drew human "
         f"review comments. Of **{total}** human comments, **{strict}** ({_pct(strict, total)}) were strictly "
         f"catchable by a deterministic tool and **{generous}** ({_pct(generous, total)}) generously catchable by an "
-        f"LLM reading the diff alone. The review bot emitted **{bot_findings}** findings and independently flagged "
-        f"**{overlap}** of the spots humans commented on."
+        f"LLM reading the diff alone. Our review bot independently flagged **{overlap}** of the spots humans "
+        "commented on — see *Review automation activity* below for everything it caught."
     )
 
-    summary = "## Summary\n\n" + _md_table(
+    summary = "### Summary\n\n" + _md_table(
         ["Metric", "Value"],
         ["---", "---:"],
         [
             ["PRs merged", n_prs],
             ["PRs with human review comments", f"{reviewed} ({_pct(reviewed, n_prs)})"],
             ["Human review comments", total],
-            ["— strictly catchable", f"{strict} ({_pct(strict, total)})"],
-            ["— generously catchable", f"{generous} ({_pct(generous, total)})"],
-            ["Bot findings", bot_findings],
-            ["Human comments overlapping a bot finding", overlap],
+            ["— strictly catchable (deterministic tool)", f"{strict} ({_pct(strict, total)})"],
+            ["— generously catchable (LLM on the diff)", f"{generous} ({_pct(generous, total)})"],
+            ["— independently flagged by the bot", f"{overlap} ({_pct(overlap, total)})"],
         ],
     )
 
@@ -811,7 +908,7 @@ def build_report(
         [cls, n, _pct(n, total), f"{s} ({_pct(s, n)})", f"{g} ({_pct(g, n)})"]
         for cls, (n, s, g) in sorted(by_class.items(), key=lambda kv: kv[1][0], reverse=True)
     ]
-    by_class_section = "## By comment class\n\n" + (
+    by_class_section = "### By comment class\n\n" + (
         _md_table(
             ["Class", "Comments", "% of all", "Strict", "Generous"], ["---", "---:", "---:", "---:", "---:"], class_rows
         )
@@ -834,7 +931,7 @@ def build_report(
     week_rows = [
         [f"{y}-W{w:02d}", prs, cmts, st, gen, _pct(gen, cmts)] for (y, w), (prs, cmts, st, gen) in sorted(weeks.items())
     ]
-    trend_section = "## Weekly trend\n\n" + _md_table(
+    trend_section = "### Weekly trend\n\n" + _md_table(
         ["Week", "PRs", "Comments", "Strict", "Generous", "Generous %"],
         ["---", "---:", "---:", "---:", "---:", "---:"],
         week_rows,
@@ -859,7 +956,7 @@ def build_report(
         ]
         for d in top
     ]
-    top_section = "## PRs with the most catchable feedback\n\n" + (
+    top_section = "### PRs with the most catchable feedback\n\n" + (
         _md_table(
             ["PR", "Title", "Comments", "Strict", "Generous", "Bot findings", "Overlap"],
             ["---", "---", "---:", "---:", "---:", "---:", "---:"],
@@ -889,7 +986,7 @@ def build_report(
         ]
         for c in flagged
     ]
-    flagged_section = f"## Catchable comments ({len(flagged_rows)})\n\n" + (
+    flagged_section = f"### Catchable comments ({len(flagged_rows)})\n\n" + (
         "Every human comment an automated check could plausibly have caught, "
         "strict (deterministic) first. **strict** = a linter/type-check could "
         "flag it; **generous** = an LLM reading the diff could.\n\n"
@@ -903,7 +1000,20 @@ def build_report(
     )
 
     return "\n\n".join(
-        [header, narrative, summary, automation_section, by_class_section, trend_section, top_section, flagged_section]
+        [
+            header,
+            overview,
+            # Lens 1 — human review feedback (narrative carries the "## Human
+            # review feedback" banner; the rest are its ### subsections).
+            narrative,
+            summary,
+            by_class_section,
+            trend_section,
+            top_section,
+            flagged_section,
+            # Lens 2 — what the review bot itself did.
+            automation_section,
+        ]
     )
 
 
@@ -934,7 +1044,13 @@ def cli() -> None:
 @click.option("--repo", default=DEFAULT_REPO, show_default=True)
 @click.option("--days", type=int, default=1, show_default=True, help="Look back N days of merged PRs")
 @click.option("--limit", type=int, default=100, show_default=True, help="Max PRs to process")
-@click.option("--model", default=DEFAULT_MODEL, show_default=True)
+@click.option("--model", default=DEFAULT_MODEL, show_default=True, help="Claude model alias or id for the classifier")
+@click.option(
+    "--agent-command",
+    default="claude -p",
+    show_default=True,
+    help="Headless agent invocation for classification (reads its prompt on stdin)",
+)
 @click.option(
     "--batch-size",
     type=int,
@@ -966,6 +1082,7 @@ def aggregate(
     days: int,
     limit: int,
     model: str,
+    agent_command: str,
     batch_size: int,
     concurrency: int,
     bot_logins: str,
@@ -981,12 +1098,12 @@ def aggregate(
     logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(message)s")
     bot_login_set = {x.strip().lower() for x in bot_logins.split(",") if x.strip()}
 
-    if not os.environ.get("GEMINI_API_KEY"):
-        logger.error("GEMINI_API_KEY not set")
+    agent_binary = agent_command.split()[0]
+    if not shutil.which(agent_binary):
+        logger.error("classifier agent %r not found on PATH (need a logged-in `claude` CLI)", agent_binary)
         sys.exit(2)
 
-    client = genai.Client()
-    classifier = make_gemini_classifier(client, model)
+    classifier = make_claude_classifier(model, agent_command)
 
     logger.info("Listing PRs merged in last %d day(s) in %s", days, repo)
     prs = list_merged_prs(repo, days, limit)


### PR DESCRIPTION
The code-health review report never surfaced the linter-fed metrics the
`pre-commit --review` step writes to W&B (the `invocations` and `findings`
tables): it only showed the per-PR rollup, which attributes a bot finding
only when its head_sha matches a merged PR. Over the last 30 days that hid
~85% of the bot’s output — 177 findings emitted across 92 runs, but only
26 attributed to merged PRs.

What this changes in `infra/codehealth/review.py`:

- Add a "Review automation activity" section to `report`, read straight
  from the linter-fed `invocations`/`findings` tables: an activity summary
  (runs, silent vs with-findings, failures, mean findings/run, median
  runtime), the most-fired `ml-*` catalog rules, and a weekly adoption
  trend. Filtered by run timestamp, independent of PR merges. Schemas are
  imported from `log_stats.py` rather than re-declared.

- Split the report into two clearly-labeled lenses so they are not
  conflated: "Human review feedback" (comments people left, each
  classified by whether an automated review could have caught it) and
  "Review automation activity" (what the bot actually flagged). A top
  overview names both.