### PR TITLE
[iris] CoreWeave cw-us-east-02a bringup: scale to 256 H100 + FSDP/EP sparse MoE

### DIFF
--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -42,6 +42,7 @@ from experiments.grug.moe.launch import (
     GRUG_MOE_TRIAL_MODEL,
     NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
     GrugMoeLaunchConfig,
+    env_int,
     run_grug_moe_trial,
     slimpajama_6b_data,
 )
@@ -66,11 +67,6 @@ CANARY_TRAINER = GrugTrainerConfig(
 # Only the model *shape* (from hidden_dim) is used here; the budget-derived batch
 # size, step count, and optimizer are all overridden by CANARY_* settings below.
 _HEURISTIC_BUDGET = 1e18
-
-
-def _env_int(key: str, default: int) -> int:
-    raw = os.environ.get(key, "")
-    return int(raw) if raw else default
 
 
 def _env_bool(key: str, default: bool) -> bool:
@@ -105,8 +101,8 @@ def _build_step_from_env() -> ExecutorStep:
 
     if accelerator == "tpu":
         model = GRUG_MOE_TRIAL_MODEL
-        batch_size = _env_int("CANARY_BATCH_SIZE", 512)
-        target_tokens = _env_int("CANARY_TARGET_TOKENS", 1_000_000_000)
+        batch_size = env_int("CANARY_BATCH_SIZE", 512)
+        target_tokens = env_int("CANARY_TARGET_TOKENS", 1_000_000_000)
         name = "canary-ferry-moe"
         data = NEMOTRON_MIX_WITH_DEFAULT_VALIDATION
         resources = ResourceConfig.with_tpu(_tpu_types_from_env())
@@ -121,21 +117,21 @@ def _build_step_from_env() -> ExecutorStep:
         wandb_tags = ["canary", "ferry", "grug", "moe"]
     else:
         gpu_type = os.environ.get("CANARY_GPU_TYPE", "H100")
-        gpu_count = _env_int("CANARY_GPU_COUNT", 8)
-        gpu_replicas = _env_int("CANARY_GPU_REPLICAS", 1)
+        gpu_count = env_int("CANARY_GPU_COUNT", 8)
+        gpu_replicas = env_int("CANARY_GPU_REPLICAS", 1)
 
         # Model-size knob: scale the MoE by hidden_dim; the heuristic auto-scales
         # depth/heads/intermediate. Defaults to the ~1.1B trial model. Step up
         # CANARY_HIDDEN_DIM (1024 -> 2048 -> 3072 -> 4096) to grow the model across
         # more H100 nodes (pair with CANARY_GPU_REPLICAS).
-        hidden_dim = _env_int("CANARY_HIDDEN_DIM", GRUG_MOE_TRIAL_MODEL.hidden_dim)
+        hidden_dim = env_int("CANARY_HIDDEN_DIM", GRUG_MOE_TRIAL_MODEL.hidden_dim)
         if hidden_dim == GRUG_MOE_TRIAL_MODEL.hidden_dim:
             model = GRUG_MOE_TRIAL_MODEL
         else:
             model, _, _, _ = build_from_heuristic(budget=_HEURISTIC_BUDGET, hidden_dim=hidden_dim)
 
-        batch_size = _env_int("CANARY_BATCH_SIZE", 32)
-        target_tokens = _env_int("CANARY_TARGET_TOKENS", batch_size * model.max_seq_len * 50)
+        batch_size = env_int("CANARY_BATCH_SIZE", 32)
+        target_tokens = env_int("CANARY_TARGET_TOKENS", batch_size * model.max_seq_len * 50)
 
         data = slimpajama_6b_data()
         resources = ResourceConfig.with_gpu(
@@ -151,7 +147,7 @@ def _build_step_from_env() -> ExecutorStep:
         wandb_tags = ["canary", "ferry", "grug", "moe", "gpu", gpu_type.lower()]
         eval_config = None
 
-    num_steps = _env_int("CANARY_STEPS", target_tokens // (batch_size * model.max_seq_len))
+    num_steps = env_int("CANARY_STEPS", target_tokens // (batch_size * model.max_seq_len))
     if num_steps <= 0:
         raise ValueError(
             f"CANARY_STEPS={num_steps} invalid; set CANARY_STEPS or CANARY_TARGET_TOKENS high enough for "
@@ -171,8 +167,8 @@ def _build_step_from_env() -> ExecutorStep:
         )
 
     profiler_enabled = _env_bool("CANARY_PROFILER_ENABLED", True)
-    profiler_start_step = _env_int("CANARY_PROFILER_START_STEP", 5)
-    profiler_num_steps = _env_int("CANARY_PROFILER_NUM_STEPS", 25)
+    profiler_start_step = env_int("CANARY_PROFILER_START_STEP", 5)
+    profiler_num_steps = env_int("CANARY_PROFILER_NUM_STEPS", 25)
 
     return ExecutorStep(
         name=f"{name}-{run_id}",

--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -26,19 +26,16 @@ to the Iris container. workflow_dispatch inputs override CANARY_TARGET_TOKENS.
     RUN_ID               unique run identifier
 """
 
-import dataclasses
 import datetime
 import os
 
 from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
-from levanter.data.text import BlockShuffleConfig, TextLmDatasetFormat
 from levanter.optim import AdamConfig
 from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.tracker.wandb import WandbConfig
 from marin.execution.executor import executor_main
 from marin.execution.types import ExecutorStep, this_output_path, versioned
-from marin.processing.tokenize.data_configs import lm_data_config
 
 from experiments.grug.moe.heuristic import build_from_heuristic
 from experiments.grug.moe.launch import (
@@ -46,10 +43,9 @@ from experiments.grug.moe.launch import (
     NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
     GrugMoeLaunchConfig,
     run_grug_moe_trial,
+    slimpajama_6b_data,
 )
 from experiments.grug.moe.train import GrugEvalConfig, GrugTrainerConfig
-from experiments.llama import llama3_tokenizer
-from experiments.tokenization import default_tokenize
 
 CANARY_OPTIMIZER = AdamConfig(
     learning_rate=3e-3,
@@ -141,25 +137,7 @@ def _build_step_from_env() -> ExecutorStep:
         batch_size = _env_int("CANARY_BATCH_SIZE", 32)
         target_tokens = _env_int("CANARY_TARGET_TOKENS", batch_size * model.max_seq_len * 50)
 
-        # SlimPajama-6B with block-shuffle — small dataset, re-tokenized on first run.
-        tokenize_step = default_tokenize(
-            name="slimpajama-6b-cw",
-            dataset="DKYoon/SlimPajama-6B",
-            tokenizer=llama3_tokenizer,
-            format=TextLmDatasetFormat(),
-        )
-        tokenize_step = dataclasses.replace(
-            tokenize_step,
-            config=dataclasses.replace(
-                tokenize_step.config,
-                # SlimPajama-6B tokenization OOMs at the default 10g worker_resources.
-                worker_resources=ResourceConfig(ram="64g", disk="64g"),
-            ),
-        )
-        data = lm_data_config(
-            training_set=tokenize_step,
-            shuffle=BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel"),
-        )
+        data = slimpajama_6b_data()
         resources = ResourceConfig.with_gpu(
             gpu_type,
             count=gpu_count,

--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -14,6 +14,8 @@ to the Iris container. workflow_dispatch inputs override CANARY_TARGET_TOKENS.
     CANARY_GPU_TYPE      gpu-only accelerator type, e.g. H100, GH200, B200
     CANARY_GPU_COUNT     gpu-only accelerator count per replica
     CANARY_GPU_REPLICAS  gpu-only replica count
+    CANARY_HIDDEN_DIM    gpu-only model hidden dim; scales the MoE via the heuristic
+                         (1024 trial default -> 2048 -> 3072 -> 4096)
     CANARY_PROFILER_ENABLED true | false
     CANARY_PROFILER_NUM_STEPS profiler duration in steps
     CANARY_PROFILER_START_STEP profiler start step
@@ -38,6 +40,7 @@ from marin.execution.executor import executor_main
 from marin.execution.types import ExecutorStep, this_output_path, versioned
 from marin.processing.tokenize.data_configs import lm_data_config
 
+from experiments.grug.moe.heuristic import build_from_heuristic
 from experiments.grug.moe.launch import (
     GRUG_MOE_TRIAL_MODEL,
     NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
@@ -62,6 +65,11 @@ CANARY_TRAINER = GrugTrainerConfig(
     ema_beta=None,
     log_every=1,
 )
+
+# Compute budget passed to the heuristic when CANARY_HIDDEN_DIM scales the model.
+# Only the model *shape* (from hidden_dim) is used here; the budget-derived batch
+# size, step count, and optimizer are all overridden by CANARY_* settings below.
+_HEURISTIC_BUDGET = 1e18
 
 
 def _env_int(key: str, default: int) -> int:
@@ -100,6 +108,7 @@ def _build_step_from_env() -> ExecutorStep:
     run_id = os.environ.get("RUN_ID") or datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
 
     if accelerator == "tpu":
+        model = GRUG_MOE_TRIAL_MODEL
         batch_size = _env_int("CANARY_BATCH_SIZE", 512)
         target_tokens = _env_int("CANARY_TARGET_TOKENS", 1_000_000_000)
         name = "canary-ferry-moe"
@@ -115,11 +124,22 @@ def _build_step_from_env() -> ExecutorStep:
         wandb_group = "canary-ferry-moe"
         wandb_tags = ["canary", "ferry", "grug", "moe"]
     else:
-        batch_size = _env_int("CANARY_BATCH_SIZE", 32)
-        target_tokens = _env_int("CANARY_TARGET_TOKENS", batch_size * GRUG_MOE_TRIAL_MODEL.max_seq_len * 50)
         gpu_type = os.environ.get("CANARY_GPU_TYPE", "H100")
         gpu_count = _env_int("CANARY_GPU_COUNT", 8)
         gpu_replicas = _env_int("CANARY_GPU_REPLICAS", 1)
+
+        # Model-size knob: scale the MoE by hidden_dim; the heuristic auto-scales
+        # depth/heads/intermediate. Defaults to the ~1.1B trial model. Step up
+        # CANARY_HIDDEN_DIM (1024 -> 2048 -> 3072 -> 4096) to grow the model across
+        # more H100 nodes (pair with CANARY_GPU_REPLICAS).
+        hidden_dim = _env_int("CANARY_HIDDEN_DIM", GRUG_MOE_TRIAL_MODEL.hidden_dim)
+        if hidden_dim == GRUG_MOE_TRIAL_MODEL.hidden_dim:
+            model = GRUG_MOE_TRIAL_MODEL
+        else:
+            model, _, _, _ = build_from_heuristic(budget=_HEURISTIC_BUDGET, hidden_dim=hidden_dim)
+
+        batch_size = _env_int("CANARY_BATCH_SIZE", 32)
+        target_tokens = _env_int("CANARY_TARGET_TOKENS", batch_size * model.max_seq_len * 50)
 
         # SlimPajama-6B with block-shuffle — small dataset, re-tokenized on first run.
         tokenize_step = default_tokenize(
@@ -148,12 +168,12 @@ def _build_step_from_env() -> ExecutorStep:
             disk="256g",
             replicas=gpu_replicas,
         )
-        name = f"canary-ferry-cw-{gpu_type.lower()}x{gpu_count}-r{gpu_replicas}"
+        name = f"canary-ferry-cw-{gpu_type.lower()}x{gpu_count}-r{gpu_replicas}-d{hidden_dim}"
         wandb_group = f"canary-ferry-moe-gpu-{gpu_type.lower()}-r{gpu_replicas}"
         wandb_tags = ["canary", "ferry", "grug", "moe", "gpu", gpu_type.lower()]
         eval_config = None
 
-    num_steps = _env_int("CANARY_STEPS", target_tokens // (batch_size * GRUG_MOE_TRIAL_MODEL.max_seq_len))
+    num_steps = _env_int("CANARY_STEPS", target_tokens // (batch_size * model.max_seq_len))
     if num_steps <= 0:
         raise ValueError(
             f"CANARY_STEPS={num_steps} invalid; set CANARY_STEPS or CANARY_TARGET_TOKENS high enough for "
@@ -180,7 +200,7 @@ def _build_step_from_env() -> ExecutorStep:
         name=f"{name}-{run_id}",
         fn=run_grug_moe_trial,
         config=GrugMoeLaunchConfig(
-            model=versioned(GRUG_MOE_TRIAL_MODEL),
+            model=versioned(model),
             data=data,
             output_path=this_output_path(),
             run_id=run_id,

--- a/experiments/grug/moe/launch.py
+++ b/experiments/grug/moe/launch.py
@@ -65,12 +65,18 @@ NEMOTRON_MIX_WITH_DEFAULT_VALIDATION = add_validation_sets_to_mixture(
 )
 
 
+def env_int(key: str, default: int) -> int:
+    """Read an int from ``os.environ[key]``, falling back to ``default`` when unset/empty."""
+    raw = os.environ.get(key, "")
+    return int(raw) if raw else default
+
+
 def slimpajama_6b_data() -> LmDataConfig:
     """SlimPajama-6B, llama3-tokenized with block-shuffle, re-tokenized on first run.
 
-    Small and R2-local — the lightweight corpus shared by the GPU canary and the
-    CoreWeave scale launcher (a real pretraining mixture would need its tokenized
-    cache already materialized to avoid a cross-region tokenize).
+    A small, R2-local corpus for GPU smoke/scale runs; returns a ready-to-train
+    ``LmDataConfig``. A production pretraining mixture would instead need its
+    tokenized cache already materialized to avoid a cross-region tokenize.
     """
     tokenize_step = default_tokenize(
         name="slimpajama-6b-cw",

--- a/experiments/grug/moe/launch.py
+++ b/experiments/grug/moe/launch.py
@@ -16,7 +16,7 @@ import jmp
 from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
 from levanter.checkpoint import CheckpointerConfig
-from levanter.data.text import LmDataConfig
+from levanter.data.text import BlockShuffleConfig, LmDataConfig, TextLmDatasetFormat
 from levanter.optim import OptimizerConfig
 from levanter.tracker import TrackerConfig
 from levanter.tracker.wandb import WandbConfig
@@ -24,13 +24,16 @@ from levanter.trainer import TrainerConfig
 from marin.execution.executor import executor_main
 from marin.execution.types import ExecutorStep, this_output_path, versioned
 from marin.processing.tokenize import add_validation_sets_to_mixture
+from marin.processing.tokenize.data_configs import lm_data_config
 from marin.training.training import temporary_checkpoint_base_path
 
 from experiments.defaults import default_validation_sets
 from experiments.grug.moe.heuristic import build_from_heuristic
 from experiments.grug.moe.model import GrugModelConfig
 from experiments.grug.moe.train import GrugEvalConfig, GrugRunConfig, GrugTrainerConfig, run_grug
+from experiments.llama import llama3_tokenizer
 from experiments.pretraining_datasets import nemotron_mix
+from experiments.tokenization import default_tokenize
 
 
 @dataclass(frozen=True)
@@ -60,6 +63,33 @@ NEMOTRON_MIX_WITH_DEFAULT_VALIDATION = add_validation_sets_to_mixture(
     nemotron_mix,
     default_validation_sets(tokenizer=nemotron_mix.tokenizer),
 )
+
+
+def slimpajama_6b_data() -> LmDataConfig:
+    """SlimPajama-6B, llama3-tokenized with block-shuffle, re-tokenized on first run.
+
+    Small and R2-local — the lightweight corpus shared by the GPU canary and the
+    CoreWeave scale launcher (a real pretraining mixture would need its tokenized
+    cache already materialized to avoid a cross-region tokenize).
+    """
+    tokenize_step = default_tokenize(
+        name="slimpajama-6b-cw",
+        dataset="DKYoon/SlimPajama-6B",
+        tokenizer=llama3_tokenizer,
+        format=TextLmDatasetFormat(),
+    )
+    tokenize_step = dataclasses.replace(
+        tokenize_step,
+        config=dataclasses.replace(
+            tokenize_step.config,
+            # SlimPajama-6B tokenization OOMs at the default 10g worker_resources.
+            worker_resources=ResourceConfig(ram="64g", disk="64g"),
+        ),
+    )
+    return lm_data_config(
+        training_set=tokenize_step,
+        shuffle=BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel"),
+    )
 
 
 def _resolve_run_id(default_run_id: str) -> str:

--- a/experiments/grug/moe/launch_cw_scale.py
+++ b/experiments/grug/moe/launch_cw_scale.py
@@ -18,7 +18,8 @@ Env knobs (all optional; defaults give the full 90B run on 256 H100):
     SCALE_GPU_REPLICAS  number of 8xH100 nodes (default 32 -> 256 GPUs)
     SCALE_EXPERT_AXIS   expert-parallel axis size, intra-node (default 8)
     SCALE_REPLICA_AXIS  cross-node replication; 1 = pure FSDP (default 1)
-    SCALE_BATCH         global batch in sequences (default 512)
+    SCALE_BATCH         global batch in sequences (default 256)
+    SCALE_SEQ_LEN       sequence length (default 2048)
     SCALE_STEPS         training steps (default 50)
     SCALE_HIDDEN_DIM / SCALE_NUM_LAYERS / SCALE_NUM_EXPERTS / SCALE_TOP_K
                         model-shape overrides (e.g. a smaller FSDP smoke test)
@@ -49,7 +50,12 @@ from experiments.tokenization import default_tokenize
 # head_dim is fixed at 128; hidden_dim must be a multiple of it.
 HEAD_DIM = 128
 VOCAB_SIZE = 128_256
-SEQ_LEN = 4096
+# Default seq for the 90B run. FSDP reshards the [batch, seq, hidden] activation
+# through a fully-replicated intermediate (an XLA SPMD limitation, pending Shardy),
+# so peak memory scales with batch*seq; at the default 89.7B model, batch 256 x
+# seq 2048 fits in 80GB while 512 x 4096 OOMs (~58GiB replicated tile).
+DEFAULT_SEQ_LEN = 2048
+DEFAULT_BATCH = 256
 
 # Modest, schedule-stable Adam for a short scale/throughput run (not trained to
 # convergence). expert weights share the schedule; the goal is to exercise the
@@ -81,6 +87,7 @@ def build_scale_model() -> GrugModelConfig:
     while num_heads % num_kv_heads != 0:
         num_kv_heads -= 1
     intermediate_dim = hidden_dim // 2  # expert FFN inner width (~d/2)
+    seq_len = _env_int("SCALE_SEQ_LEN", DEFAULT_SEQ_LEN)
     return GrugModelConfig(
         vocab_size=VOCAB_SIZE,
         hidden_dim=hidden_dim,
@@ -92,8 +99,8 @@ def build_scale_model() -> GrugModelConfig:
         shared_expert_intermediate_dim=intermediate_dim,
         num_experts=_env_int("SCALE_NUM_EXPERTS", 128),
         num_experts_per_token=_env_int("SCALE_TOP_K", 4),
-        max_seq_len=SEQ_LEN,
-        sliding_window=SEQ_LEN,
+        max_seq_len=seq_len,
+        sliding_window=seq_len,
     )
 
 
@@ -126,7 +133,7 @@ def build_scale_step() -> ExecutorStep:
     replicas = _env_int("SCALE_GPU_REPLICAS", 32)
     expert_axis = _env_int("SCALE_EXPERT_AXIS", 8)
     replica_axis = _env_int("SCALE_REPLICA_AXIS", 1)
-    batch_size = _env_int("SCALE_BATCH", 512)
+    batch_size = _env_int("SCALE_BATCH", DEFAULT_BATCH)
     steps = _env_int("SCALE_STEPS", 50)
 
     model = build_scale_model()

--- a/experiments/grug/moe/launch_cw_scale.py
+++ b/experiments/grug/moe/launch_cw_scale.py
@@ -27,29 +27,26 @@ Env knobs (all optional; defaults give the full 90B run on 256 H100):
     RUN_ID              unique run identifier
 """
 
-import dataclasses
 import datetime
 import os
 
 from fray.cluster import ResourceConfig
 from levanter.callbacks.profiler import ProfilerConfig
-from levanter.data.text import BlockShuffleConfig, TextLmDatasetFormat
 from levanter.optim import AdamConfig
 from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.tracker.wandb import WandbConfig
 from marin.execution.executor import executor_main
 from marin.execution.types import ExecutorStep, this_output_path, versioned
-from marin.processing.tokenize.data_configs import lm_data_config
 
-from experiments.grug.moe.launch import GrugMoeLaunchConfig, run_grug_moe_trial
+from experiments.grug.moe.launch import GrugMoeLaunchConfig, run_grug_moe_trial, slimpajama_6b_data
 from experiments.grug.moe.model import GrugModelConfig
 from experiments.grug.moe.train import GrugTrainerConfig
-from experiments.llama import llama3_tokenizer
-from experiments.tokenization import default_tokenize
+from experiments.llama import llama3_tokenizer_vocab_size
 
 # head_dim is fixed at 128; hidden_dim must be a multiple of it.
 HEAD_DIM = 128
-VOCAB_SIZE = 128_256
+VOCAB_SIZE = llama3_tokenizer_vocab_size
+GPUS_PER_NODE = 8  # H100s per gd-8xh100ib node; the batch-shard math and with_gpu(count=...) must track
 # Default seq for the 90B run. FSDP reshards the [batch, seq, hidden] activation
 # through a fully-replicated intermediate (an XLA SPMD limitation, pending Shardy),
 # so peak memory scales with batch*seq; at the default 89.7B model, batch 256 x
@@ -104,29 +101,6 @@ def build_scale_model() -> GrugModelConfig:
     )
 
 
-def _slimpajama_data():
-    # SlimPajama-6B with block-shuffle, re-tokenized on first run. Small and
-    # R2-local; a real pretraining mixture (Nemotron) would require its tokenized
-    # cache to already exist on marin-na to avoid a cross-region tokenize.
-    tokenize_step = default_tokenize(
-        name="slimpajama-6b-cw",
-        dataset="DKYoon/SlimPajama-6B",
-        tokenizer=llama3_tokenizer,
-        format=TextLmDatasetFormat(),
-    )
-    tokenize_step = dataclasses.replace(
-        tokenize_step,
-        config=dataclasses.replace(
-            tokenize_step.config,
-            worker_resources=ResourceConfig(ram="64g", disk="64g"),
-        ),
-    )
-    return lm_data_config(
-        training_set=tokenize_step,
-        shuffle=BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel"),
-    )
-
-
 def build_scale_step() -> ExecutorStep:
     run_id = os.environ.get("RUN_ID") or datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
 
@@ -142,12 +116,12 @@ def build_scale_step() -> ExecutorStep:
 
     # Batch is sharded over the (replica_dcn, data, expert) axes; data absorbs the
     # rest of the 8*replicas devices. Require the global batch to cover every shard.
-    data_axis = (replicas * 8) // (replica_axis * expert_axis)
+    data_axis = (replicas * GPUS_PER_NODE) // (replica_axis * expert_axis)
     batch_shards = replica_axis * data_axis * expert_axis
     if batch_size % batch_shards != 0:
         raise ValueError(f"SCALE_BATCH={batch_size} must be divisible by batch shards={batch_shards}")
 
-    resources = ResourceConfig.with_gpu("H100", count=8, cpu=32, ram="256g", disk="256g", replicas=replicas)
+    resources = ResourceConfig.with_gpu("H100", count=GPUS_PER_NODE, cpu=32, ram="256g", disk="256g", replicas=replicas)
 
     if os.environ.get("SCALE_TRACKER", "json_logger").lower() == "wandb":
         tracker = WandbConfig(
@@ -173,7 +147,7 @@ def build_scale_step() -> ExecutorStep:
         fn=run_grug_moe_trial,
         config=GrugMoeLaunchConfig(
             model=versioned(model),
-            data=_slimpajama_data(),
+            data=slimpajama_6b_data(),
             output_path=this_output_path(),
             run_id=run_id,
             resources=versioned(resources),

--- a/experiments/grug/moe/launch_cw_scale.py
+++ b/experiments/grug/moe/launch_cw_scale.py
@@ -38,7 +38,7 @@ from levanter.tracker.wandb import WandbConfig
 from marin.execution.executor import executor_main
 from marin.execution.types import ExecutorStep, this_output_path, versioned
 
-from experiments.grug.moe.launch import GrugMoeLaunchConfig, run_grug_moe_trial, slimpajama_6b_data
+from experiments.grug.moe.launch import GrugMoeLaunchConfig, env_int, run_grug_moe_trial, slimpajama_6b_data
 from experiments.grug.moe.model import GrugModelConfig
 from experiments.grug.moe.train import GrugTrainerConfig
 from experiments.llama import llama3_tokenizer_vocab_size
@@ -68,14 +68,9 @@ SCALE_OPTIMIZER = AdamConfig(
 SCALE_TRAINER_DEFAULTS = dict(z_loss_weight=1e-4, ema_beta=None, log_every=1)
 
 
-def _env_int(key: str, default: int) -> int:
-    raw = os.environ.get(key, "")
-    return int(raw) if raw else default
-
-
 def build_scale_model() -> GrugModelConfig:
     """~90B-total / ~5B-active sparse MoE (overridable via SCALE_* env vars)."""
-    hidden_dim = _env_int("SCALE_HIDDEN_DIM", 3072)
+    hidden_dim = env_int("SCALE_HIDDEN_DIM", 3072)
     if hidden_dim % HEAD_DIM != 0:
         raise ValueError(f"SCALE_HIDDEN_DIM={hidden_dim} must be a multiple of head_dim={HEAD_DIM}")
     num_heads = hidden_dim // HEAD_DIM
@@ -84,18 +79,18 @@ def build_scale_model() -> GrugModelConfig:
     while num_heads % num_kv_heads != 0:
         num_kv_heads -= 1
     intermediate_dim = hidden_dim // 2  # expert FFN inner width (~d/2)
-    seq_len = _env_int("SCALE_SEQ_LEN", DEFAULT_SEQ_LEN)
+    seq_len = env_int("SCALE_SEQ_LEN", DEFAULT_SEQ_LEN)
     return GrugModelConfig(
         vocab_size=VOCAB_SIZE,
         hidden_dim=hidden_dim,
-        num_layers=_env_int("SCALE_NUM_LAYERS", 48),
+        num_layers=env_int("SCALE_NUM_LAYERS", 48),
         num_heads=num_heads,
         num_kv_heads=num_kv_heads,
         head_dim=HEAD_DIM,
         intermediate_dim=intermediate_dim,
         shared_expert_intermediate_dim=intermediate_dim,
-        num_experts=_env_int("SCALE_NUM_EXPERTS", 128),
-        num_experts_per_token=_env_int("SCALE_TOP_K", 4),
+        num_experts=env_int("SCALE_NUM_EXPERTS", 128),
+        num_experts_per_token=env_int("SCALE_TOP_K", 4),
         max_seq_len=seq_len,
         sliding_window=seq_len,
     )
@@ -104,11 +99,11 @@ def build_scale_model() -> GrugModelConfig:
 def build_scale_step() -> ExecutorStep:
     run_id = os.environ.get("RUN_ID") or datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
 
-    replicas = _env_int("SCALE_GPU_REPLICAS", 32)
-    expert_axis = _env_int("SCALE_EXPERT_AXIS", 8)
-    replica_axis = _env_int("SCALE_REPLICA_AXIS", 1)
-    batch_size = _env_int("SCALE_BATCH", DEFAULT_BATCH)
-    steps = _env_int("SCALE_STEPS", 50)
+    replicas = env_int("SCALE_GPU_REPLICAS", 32)
+    expert_axis = env_int("SCALE_EXPERT_AXIS", 8)
+    replica_axis = env_int("SCALE_REPLICA_AXIS", 1)
+    batch_size = env_int("SCALE_BATCH", DEFAULT_BATCH)
+    steps = env_int("SCALE_STEPS", 50)
 
     model = build_scale_model()
     if model.num_experts % expert_axis != 0:

--- a/experiments/grug/moe/launch_cw_scale.py
+++ b/experiments/grug/moe/launch_cw_scale.py
@@ -1,0 +1,194 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Large sparse-MoE scale run for the CoreWeave cw-us-east-02a H100 cluster.
+
+Launches a ~90B-total / ~5B-active Grug MoE (hidden 3072, 48 layers, 128 experts,
+top-4 -> ~17x sparsity) across all 32 nodes / 256 H100s. Parameters are fully
+sharded over the cross-node ``data`` axis (FSDP) while the 128 routed experts are
+sharded 8-way over the intra-node NVLink ``expert`` axis (expert parallelism).
+
+This is the size class the cluster can train as a *single* model. The canary
+(``experiments/ferries/canary_ferry.py``) replicates parameters per node, so it
+caps at the ~9.5B that fits on one node's 8 GPUs; here ``replica_axis_size=1``
+shards one model across every device instead.
+
+Env knobs (all optional; defaults give the full 90B run on 256 H100):
+
+    SCALE_GPU_REPLICAS  number of 8xH100 nodes (default 32 -> 256 GPUs)
+    SCALE_EXPERT_AXIS   expert-parallel axis size, intra-node (default 8)
+    SCALE_REPLICA_AXIS  cross-node replication; 1 = pure FSDP (default 1)
+    SCALE_BATCH         global batch in sequences (default 512)
+    SCALE_STEPS         training steps (default 50)
+    SCALE_HIDDEN_DIM / SCALE_NUM_LAYERS / SCALE_NUM_EXPERTS / SCALE_TOP_K
+                        model-shape overrides (e.g. a smaller FSDP smoke test)
+    SCALE_TRACKER       wandb | json_logger (default json_logger)
+    RUN_ID              unique run identifier
+"""
+
+import dataclasses
+import datetime
+import os
+
+from fray.cluster import ResourceConfig
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.data.text import BlockShuffleConfig, TextLmDatasetFormat
+from levanter.optim import AdamConfig
+from levanter.tracker.json_logger import JsonLoggerConfig
+from levanter.tracker.wandb import WandbConfig
+from marin.execution.executor import executor_main
+from marin.execution.types import ExecutorStep, this_output_path, versioned
+from marin.processing.tokenize.data_configs import lm_data_config
+
+from experiments.grug.moe.launch import GrugMoeLaunchConfig, run_grug_moe_trial
+from experiments.grug.moe.model import GrugModelConfig
+from experiments.grug.moe.train import GrugTrainerConfig
+from experiments.llama import llama3_tokenizer
+from experiments.tokenization import default_tokenize
+
+# head_dim is fixed at 128; hidden_dim must be a multiple of it.
+HEAD_DIM = 128
+VOCAB_SIZE = 128_256
+SEQ_LEN = 4096
+
+# Modest, schedule-stable Adam for a short scale/throughput run (not trained to
+# convergence). expert weights share the schedule; the goal is to exercise the
+# FSDP+expert-parallel mesh at scale, not to produce a checkpoint.
+SCALE_OPTIMIZER = AdamConfig(
+    learning_rate=6e-4,
+    weight_decay=0.1,
+    lr_schedule="cosine",
+    warmup=10,
+    min_lr_ratio=0.1,
+)
+
+SCALE_TRAINER_DEFAULTS = dict(z_loss_weight=1e-4, ema_beta=None, log_every=1)
+
+
+def _env_int(key: str, default: int) -> int:
+    raw = os.environ.get(key, "")
+    return int(raw) if raw else default
+
+
+def build_scale_model() -> GrugModelConfig:
+    """~90B-total / ~5B-active sparse MoE (overridable via SCALE_* env vars)."""
+    hidden_dim = _env_int("SCALE_HIDDEN_DIM", 3072)
+    if hidden_dim % HEAD_DIM != 0:
+        raise ValueError(f"SCALE_HIDDEN_DIM={hidden_dim} must be a multiple of head_dim={HEAD_DIM}")
+    num_heads = hidden_dim // HEAD_DIM
+    # ~4:1 grouped-query attention; back off to the nearest divisor of num_heads.
+    num_kv_heads = max(1, num_heads // 4)
+    while num_heads % num_kv_heads != 0:
+        num_kv_heads -= 1
+    intermediate_dim = hidden_dim // 2  # expert FFN inner width (~d/2)
+    return GrugModelConfig(
+        vocab_size=VOCAB_SIZE,
+        hidden_dim=hidden_dim,
+        num_layers=_env_int("SCALE_NUM_LAYERS", 48),
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=HEAD_DIM,
+        intermediate_dim=intermediate_dim,
+        shared_expert_intermediate_dim=intermediate_dim,
+        num_experts=_env_int("SCALE_NUM_EXPERTS", 128),
+        num_experts_per_token=_env_int("SCALE_TOP_K", 4),
+        max_seq_len=SEQ_LEN,
+        sliding_window=SEQ_LEN,
+    )
+
+
+def _slimpajama_data():
+    # SlimPajama-6B with block-shuffle, re-tokenized on first run. Small and
+    # R2-local; a real pretraining mixture (Nemotron) would require its tokenized
+    # cache to already exist on marin-na to avoid a cross-region tokenize.
+    tokenize_step = default_tokenize(
+        name="slimpajama-6b-cw",
+        dataset="DKYoon/SlimPajama-6B",
+        tokenizer=llama3_tokenizer,
+        format=TextLmDatasetFormat(),
+    )
+    tokenize_step = dataclasses.replace(
+        tokenize_step,
+        config=dataclasses.replace(
+            tokenize_step.config,
+            worker_resources=ResourceConfig(ram="64g", disk="64g"),
+        ),
+    )
+    return lm_data_config(
+        training_set=tokenize_step,
+        shuffle=BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel"),
+    )
+
+
+def build_scale_step() -> ExecutorStep:
+    run_id = os.environ.get("RUN_ID") or datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+    replicas = _env_int("SCALE_GPU_REPLICAS", 32)
+    expert_axis = _env_int("SCALE_EXPERT_AXIS", 8)
+    replica_axis = _env_int("SCALE_REPLICA_AXIS", 1)
+    batch_size = _env_int("SCALE_BATCH", 512)
+    steps = _env_int("SCALE_STEPS", 50)
+
+    model = build_scale_model()
+    if model.num_experts % expert_axis != 0:
+        raise ValueError(f"num_experts={model.num_experts} must be divisible by SCALE_EXPERT_AXIS={expert_axis}")
+
+    # Batch is sharded over the (replica_dcn, data, expert) axes; data absorbs the
+    # rest of the 8*replicas devices. Require the global batch to cover every shard.
+    data_axis = (replicas * 8) // (replica_axis * expert_axis)
+    batch_shards = replica_axis * data_axis * expert_axis
+    if batch_size % batch_shards != 0:
+        raise ValueError(f"SCALE_BATCH={batch_size} must be divisible by batch shards={batch_shards}")
+
+    resources = ResourceConfig.with_gpu("H100", count=8, cpu=32, ram="256g", disk="256g", replicas=replicas)
+
+    if os.environ.get("SCALE_TRACKER", "json_logger").lower() == "wandb":
+        tracker = WandbConfig(
+            entity=os.environ.get("WANDB_ENTITY") or None,
+            project=os.environ.get("WANDB_PROJECT", "marin_moe"),
+            tags=["grug", "moe", "cw", "h100", "scale"],
+            group="grug-moe-cw-scale",
+            name=None,
+            replicate_path=this_output_path(),
+        )
+    else:
+        tracker = JsonLoggerConfig(logger_name=os.environ.get("SCALE_JSON_LOGGER", "grug_moe_scale.metrics"))
+
+    grug_trainer = GrugTrainerConfig(
+        expert_axis_size=expert_axis,
+        replica_axis_size=replica_axis,
+        **SCALE_TRAINER_DEFAULTS,
+    )
+
+    name = f"grug-moe-cw-d{model.hidden_dim}-L{model.num_layers}-e{model.num_experts}-r{replicas}"
+    return ExecutorStep(
+        name=f"{name}-{run_id}",
+        fn=run_grug_moe_trial,
+        config=GrugMoeLaunchConfig(
+            model=versioned(model),
+            data=_slimpajama_data(),
+            output_path=this_output_path(),
+            run_id=run_id,
+            resources=versioned(resources),
+            steps=versioned(steps),
+            batch_size=versioned(batch_size),
+            seed=versioned(0),
+            mp=versioned("params=float32,compute=bfloat16,output=bfloat16"),
+            tracker=tracker,
+            optimizer=versioned(SCALE_OPTIMIZER),
+            grug_trainer=versioned(grug_trainer),
+            eval=None,
+            profiler=ProfilerConfig(enabled=False),
+        ),
+    )
+
+
+scale_moe_step = build_scale_step()
+
+
+def main():
+    executor_main(steps=[scale_moe_step])
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -255,7 +255,13 @@ class DenseMLP(eqx.Module):
         gate = jnp.einsum("td,dm->tm", x_flat, self.w_gate)
         up = jnp.einsum("td,dm->tm", x_flat, self.w_up)
         out_flat = jnp.einsum("tm,md->td", activation_fn(gate) * up, self.w_down, out_sharding=_batch_spec())
-        return rearrange(out_flat, "(b s) d -> b s d", b=b, s=s)
+        # Reshard after the reshape so the shared-expert output carries the same
+        # canonical batch sharding as the routed MoE output (MoEMLP reshards its
+        # routed result identically). Splitting the fused
+        # ("replica_dcn", "data", "expert") token axis back into (b, s) otherwise
+        # leaks the `expert` mesh axis onto the seq dim, so the shared+routed
+        # residual add fails with a ShardingTypeError on a multi-node mesh.
+        return _batch_reshard(rearrange(out_flat, "(b s) d -> b s d", b=b, s=s))
 
 
 def _routing_stats(

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -60,6 +60,16 @@ class GrugTrainerConfig:
     ema_beta: float | None = None  # EMA coefficient for eval/checkpoint model; None disables EMA.
     z_loss_weight: float = 0.0  # Weight on logsumexp (z-loss) stabilization term.
 
+    # Grug builds its own compact (replica_dcn, data, expert, model) mesh instead of using
+    # the Trainer's logical axis mapping; `data` absorbs whatever these two leave free.
+    # Defaults reproduce the historical layout: no expert parallelism and full replication
+    # across slices (replica_axis_size=None -> jax.process_count()), i.e. parameters
+    # replicated per slice and sharded only over the intra-slice `data` axis. For a model
+    # too large to replicate within one slice, set replica_axis_size=1 (FSDP across every
+    # slice) and expert_axis_size>1 (expert parallelism over the intra-slice devices).
+    expert_axis_size: int = 1
+    replica_axis_size: int | None = None
+
 
 @dataclass(frozen=True)
 class GrugEvalConfig:
@@ -382,12 +392,14 @@ def _run_grug_local(config: GrugRunConfig) -> None:
     if config.trainer.data_seed is not None:
         data_key = jax.random.PRNGKey(config.trainer.data_seed)
 
-    mesh_axes = config.trainer.trainer.mesh.axes
-    expert_axis_size = int(mesh_axes.get("expert", 1))
-    replica_axis_size = int(mesh_axes.get("replica_dcn", jax.process_count()))
     # Grug uses raw PartitionSpecs rather than Trainer's logical axis mapping.
     # Keep the mesh compact so the batch pspec derived by `_batch_spec(mesh)` spans slices directly.
-    mesh = compact_grug_mesh(expert_axis_size=expert_axis_size, replica_axis_size=replica_axis_size)
+    # replica_axis_size=None lets compact_grug_mesh default to jax.process_count() (full
+    # cross-slice replication); set it to 1 on GrugTrainerConfig for cross-slice FSDP.
+    mesh = compact_grug_mesh(
+        expert_axis_size=config.trainer.expert_axis_size,
+        replica_axis_size=config.trainer.replica_axis_size,
+    )
     with set_mesh(mesh):
         batch_schedule = trainer.batch_schedule
 

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -1,11 +1,10 @@
-# CoreWeave US-EAST-02A cluster (cluster name: cw-us-east-o2a).
+# CoreWeave US-EAST-02A cluster (cluster name: cw-us-east-02a).
 #
 # These are fixed, reserved resources, so both pools are pinned ALWAYS WARM
 # rather than autoscaled: each scale group sets buffer_slices == max_slices, so
 # the backing NodePool gets minNodes == maxNodes (a static node count that never
-# scales to zero). Starting fleet: 2x CPU (Genoa) + 8x H100 (8 GPU each).
-# Account quota in this region is 4x cd-gp-a192-genoa and 32x gd-8xh100ib-i128;
-# bump buffer_slices/max_slices toward those caps to scale up.
+# scales to zero). Fleet: 4x CPU (Genoa) + 32x H100 (8 GPU each, 256 GPUs total) —
+# the full region quota of 4x cd-gp-a192-genoa and 32x gd-8xh100ib-i128.
 #
 # Architecture: KubernetesProvider dispatches task pods directly to the k8s API
 # (Pod-per-task); there are no worker daemons and no Iris autoscaler. Capacity is
@@ -19,8 +18,8 @@
 #   2. Point kubectl/iris at the region kubeconfig:
 #        export KUBECONFIG=~/.kube/coreweave-iris-gpu   # context marin-gpu_US-EAST-02A
 #   3. Start / inspect the cluster:
-#        uv run iris --cluster=cw-us-east-o2a cluster start
-#        uv run iris --cluster=cw-us-east-o2a cluster status
+#        uv run iris --cluster=cw-us-east-02a cluster start
+#        uv run iris --cluster=cw-us-east-02a cluster status
 
 platform:
   label_prefix: cw-use02a
@@ -31,7 +30,7 @@ platform:
     object_storage_endpoint: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com
 
 storage:
-  remote_state_dir: s3://marin-na/iris/cw-us-east-o2a/state
+  remote_state_dir: s3://marin-na/iris/cw-us-east-02a/state
 
 kubernetes_provider:
   namespace: iris
@@ -86,8 +85,8 @@ scale_groups:
     worker:
       attributes:
         pool: cpu-genoa
-    buffer_slices: 2     # pinned: 2 CPU nodes always warm (controller + CPU tasks)
-    max_slices: 2
+    buffer_slices: 4     # pinned: 4 CPU nodes always warm (controller + CPU tasks)
+    max_slices: 4
     priority: 50
     slice_template:
       num_vms: 1
@@ -108,8 +107,8 @@ scale_groups:
     worker:
       attributes:
         pool: h100-8x
-    buffer_slices: 8     # pinned: 8 H100 nodes (64 GPUs) always warm
-    max_slices: 8
+    buffer_slices: 32    # pinned: 32 H100 nodes (256 GPUs) always warm — full quota
+    max_slices: 32
     priority: 100
     slice_template:
       num_vms: 1

--- a/lib/iris/config/cw-us-east-o2a.yaml
+++ b/lib/iris/config/cw-us-east-o2a.yaml
@@ -1,0 +1,112 @@
+# CoreWeave US-EAST-02A cluster (cluster name: cw-us-east-o2a).
+#
+# These are fixed, reserved resources, so both pools are pinned ALWAYS WARM
+# rather than autoscaled: each scale group sets buffer_slices == max_slices, so
+# the backing NodePool gets minNodes == maxNodes (a static node count that never
+# scales to zero). Starting fleet: 2x CPU (Genoa) + 8x H100 (8 GPU each).
+# Account quota in this region is 4x cd-gp-a192-genoa and 32x gd-8xh100ib-i128;
+# bump buffer_slices/max_slices toward those caps to scale up.
+#
+# Architecture: KubernetesProvider dispatches task pods directly to the k8s API
+# (Pod-per-task); there are no worker daemons and no Iris autoscaler. Capacity is
+# whatever the NodePools hold. See lib/iris/docs/coreweave.md.
+#
+# Workflow:
+#   1. Set R2 object storage credentials (required for s3:// storage URIs):
+#        export R2_ACCESS_KEY_ID=<your-r2-access-key-id>
+#        export R2_SECRET_ACCESS_KEY=<your-r2-secret-access-key>
+#      `iris cluster start` turns these into the iris-s3-credentials Secret.
+#   2. Point kubectl/iris at the region kubeconfig:
+#        export KUBECONFIG=~/.kube/coreweave-iris-gpu   # context marin-gpu_US-EAST-02A
+#   3. Start / inspect the cluster:
+#        uv run iris --cluster=cw-us-east-o2a cluster start
+#        uv run iris --cluster=cw-us-east-o2a cluster status
+
+platform:
+  label_prefix: cw-use02a
+  coreweave:
+    region: US-EAST-02A
+    namespace: iris
+    kubeconfig_path: ~/.kube/coreweave-iris-gpu
+    object_storage_endpoint: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com
+
+storage:
+  remote_state_dir: s3://marin-na/iris/cw-us-east-o2a/state
+
+kubernetes_provider:
+  namespace: iris
+  default_image: ghcr.io/marin-community/iris-task:latest
+  host_network: true                # Required for NCCL/IB multi-host traffic
+  cache_dir: /mnt/local/iris-cache  # NVMe; default /cache hits the 15GB ramdisk on bare-metal nodes
+  controller_address: http://iris-controller-svc.iris.svc.cluster.local:10000
+
+controller:
+  image: ghcr.io/marin-community/iris-controller:latest
+  coreweave:
+    port: 10000
+    service_name: iris-controller-svc
+    scale_group: cpu-genoa
+
+defaults:
+  autoscaler:
+    evaluation_interval:
+      milliseconds: 10000
+    scale_up_delay:
+      milliseconds: 60000
+    scale_down_delay:
+      milliseconds: 300000
+    startup_grace_period:
+      milliseconds: 2400000    # 40 min — covers cold bare-metal provisioning + Pod startup
+  task_env:
+    MARIN_PREFIX: s3://marin-na/marin
+    # H100 hostNetwork pods also see IB and SR-IOV link-local interfaces.
+    NCCL_SOCKET_IFNAME: =enp157s0np0
+  worker:
+    docker_image: ghcr.io/marin-community/iris-worker:latest
+    port: 10001
+    cache_dir: /mnt/local/iris-cache
+    runtime: kubernetes
+    default_task_image: ghcr.io/marin-community/iris-task:latest
+
+scale_groups:
+  cpu-genoa:
+    num_vms: 1
+    resources:
+      cpu: 192
+      ram: 768GB
+      disk: 1TB
+      device_type: cpu
+      capacity_type: on-demand
+    worker:
+      attributes:
+        pool: cpu-genoa
+    buffer_slices: 2     # pinned: 2 CPU nodes always warm (controller + CPU tasks)
+    max_slices: 2
+    priority: 50
+    slice_template:
+      num_vms: 1
+      coreweave:
+        region: US-EAST-02A
+        instance_type: cd-gp-a192-genoa
+
+  h100-8x:
+    num_vms: 1
+    resources:
+      cpu: 128
+      ram: 2048GB
+      disk: 1TB
+      device_type: gpu
+      device_variant: H100
+      device_count: 8
+      capacity_type: on-demand
+    worker:
+      attributes:
+        pool: h100-8x
+    buffer_slices: 8     # pinned: 8 H100 nodes (64 GPUs) always warm
+    max_slices: 8
+    priority: 100
+    slice_template:
+      num_vms: 1
+      coreweave:
+        region: US-EAST-02A
+        instance_type: gd-8xh100ib-i128

--- a/lib/iris/config/cw-us-east-o2a.yaml
+++ b/lib/iris/config/cw-us-east-o2a.yaml
@@ -39,6 +39,12 @@ kubernetes_provider:
   host_network: true                # Required for NCCL/IB multi-host traffic
   cache_dir: /mnt/local/iris-cache  # NVMe; default /cache hits the 15GB ramdisk on bare-metal nodes
   controller_address: http://iris-controller-svc.iris.svc.cluster.local:10000
+  kueue:
+    # Enables Kueue gang admission for multi-host GPU jobs. The ClusterQueue
+    # (cluster-scoped) and ResourceFlavor cw-ib are created out-of-band by
+    # lib/iris/scripts/install_kueue.py --with-queues; Iris reconciles the
+    # namespaced LocalQueue (cw-use02a-lq) bound to it at controller start.
+    cluster_queue: iris-cq
 
 controller:
   image: ghcr.io/marin-community/iris-controller:latest


### PR DESCRIPTION
Bring up the CoreWeave US-EAST-02A H100 cluster (cw-us-east-02a) for Iris and
validate it end-to-end with a Grug MoE stress test, scaling up to a real sparse
MoE at full cluster size.

Cluster config (lib/iris/config/cw-us-east-02a.yaml): KubernetesProvider
(Pod-per-task, no Iris autoscaler), Kueue gang admission with Topology-Aware
Scheduling over the InfiniBand fabric, R2 (marin-na) for state/data/checkpoints.
Both pools are pinned always-warm (buffer_slices == max_slices) at the full
region quota: 4x Genoa CPU and 32x H100 (256 GPUs).

Enable a real sparse MoE at scale. The canary replicates parameters per node, so
it caps at the ~9.5B that fits on one node's 8 GPUs. Add explicit
expert_axis_size/replica_axis_size knobs to GrugTrainerConfig and build the
compact grug mesh from them, so a single model can shard across all 256 GPUs:
FSDP over the cross-node data axis plus expert parallelism over the intra-node
NVLink devices. Defaults reproduce the existing per-slice-replicated layout, so
the canary and TPU paths are unchanged. experiments/grug/moe/launch_cw_scale.py
is a ~90B-total / 5.3B-active run (hidden 3072, 48 layers, 128 experts, top-4)
for this cluster.

Validation on the live cluster (all 256 H100):
- hello-world CPU job; single-node and multi-host MoE smokes
- canary d2048 at replicas=32: 20/20 steps, 1.39M tok/s, zero sharding errors
- 4-node FSDP+expert-parallel smoke: 5 steps, zero sharding errors
- 90B run (d3072/L48/E128, parameter_count 89,672,822,784): 50/50 steps, loss
  decreasing, zero OOM/sharding errors

Also fixes the multi-host shared-expert sharding bug in the Grug MoE
(experiments/grug/moe/model.py) that crashed any model spanning more than one
node at compile time.

Fixes #6296
Part of #6292
