### PR TITLE
[iris] Make reads.py the single DB fan-out point via ControlSnapshot

### DIFF
--- a/lib/iris/scripts/benchmark_controller.py
+++ b/lib/iris/scripts/benchmark_controller.py
@@ -80,9 +80,6 @@ from iris.cluster.controller.reconcile.worker import (
     WorkerReconcilePlan,
     build_reconcile_plans,
 )
-from iris.cluster.controller.scheduling.policy import (
-    _pending_tasks_with_jobs as _schedulable_tasks,
-)
 from iris.cluster.controller.scheduling.policy import compute_demand_entries
 from iris.cluster.controller.scheduling.scheduler import Scheduler
 from iris.cluster.controller.schema import (
@@ -1139,7 +1136,7 @@ def benchmark_scheduling(db: ControllerDB) -> None:
             )
             pending_count += int(_tx.execute(text("SELECT changes() AS c")).scalar() or 0)
     with db.read_snapshot() as _ptx:
-        pending_tasks = _schedulable_tasks(_ptx)
+        pending_tasks = reads.pending_tasks_with_jobs(_ptx)
     with db.read_snapshot() as _wtx:
         workers = reads.healthy_active_workers_with_attributes(_wtx, health, _NoAttrs())
     print(
@@ -1175,7 +1172,7 @@ def benchmark_scheduling(db: ControllerDB) -> None:
     # ---- Full tick: _read_scheduling_state-style aggregate ----
     def _state_read():
         with db.read_snapshot() as _ptx:
-            _schedulable_tasks(_ptx)
+            reads.pending_tasks_with_jobs(_ptx)
         with db.read_snapshot() as _rtx:
             ws = reads.healthy_active_workers_with_attributes(_rtx, health, _NoAttrs())
         with db_mod.read_snapshot(db.sa_read_engine) as snap:

--- a/lib/iris/src/iris/cluster/controller/budget.py
+++ b/lib/iris/src/iris/cluster/controller/budget.py
@@ -10,13 +10,10 @@ from dataclasses import dataclass
 from typing import Generic, TypeVar
 
 from rigging.timing import Timestamp
-from sqlalchemy import bindparam, func, select
 
-from iris.cluster.controller import writes
+from iris.cluster.controller import reads, writes
 from iris.cluster.controller.codec import device_counts_from_json
 from iris.cluster.controller.db import ControllerDB, Tx
-from iris.cluster.controller.schema import hint_rare_state, job_config_table, tasks_table
-from iris.cluster.controller.task_state import ACTIVE_TASK_STATES
 from iris.cluster.types import UserBudgetDefaults
 from iris.rpc import config_pb2, job_pb2
 
@@ -42,37 +39,15 @@ def resource_value(cpu_millicores: int, memory_bytes: int, accelerator_count: in
     return 1000 * accelerator_count + ram_gb + 5 * cpu_cores
 
 
-_USER_SPEND_QUERY = (
-    select(
-        tasks_table.c.job_id,
-        job_config_table.c.res_cpu_millicores,
-        job_config_table.c.res_memory_bytes,
-        job_config_table.c.res_device_json,
-        func.count().label("task_count"),
-    )
-    .select_from(tasks_table.join(job_config_table, job_config_table.c.job_id == tasks_table.c.job_id))
-    .where(hint_rare_state(tasks_table.c.state.in_(bindparam("states", expanding=True))))
-    .where(job_config_table.c.priority_band != job_pb2.PRIORITY_BAND_BATCH)
-    .group_by(tasks_table.c.job_id)
-)
-
-
 def compute_user_spend(tx: Tx) -> dict[str, int]:
     """Compute per-user budget spend from active tasks.
 
-    Joins tasks (in ASSIGNED/BUILDING/RUNNING states) with job_config to get
-    resource columns.  Groups by job, then sums resource_value * task_count per user.
-
-    Jobs whose requested band is ``PRIORITY_BAND_BATCH`` are excluded so users
-    aren't billed for opportunistic work they explicitly submitted as batch.
-    We key off ``job_config.priority_band`` (the user's requested band) rather
-    than the stamped ``tasks.priority_band`` so jobs the scheduler downgraded
-    to BATCH still count — otherwise a downgrade would drop the user under
-    budget on the next tick and the band would oscillate.
+    Sums ``resource_value * task_count`` per user over the active, non-BATCH
+    task rows returned by :func:`reads.user_spend_rows`.
 
     Returns ``{user_id: total_resource_value}`` for users with active tasks.
     """
-    rows = tx.execute(_USER_SPEND_QUERY, {"states": list(ACTIVE_TASK_STATES)}).all()
+    rows = reads.user_spend_rows(tx)
 
     spend: dict[str, int] = defaultdict(int)
     for row in rows:

--- a/lib/iris/src/iris/cluster/controller/checkpoint.py
+++ b/lib/iris/src/iris/cluster/controller/checkpoint.py
@@ -35,10 +35,9 @@ from pathlib import Path
 import fsspec.core
 import zstandard
 from rigging.timing import Duration, Timestamp
-from sqlalchemy import func, select
 
+from iris.cluster.controller import reads
 from iris.cluster.controller.db import ControllerDB
-from iris.cluster.controller.schema import jobs_table, tasks_table, workers_table
 
 logger = logging.getLogger(__name__)
 
@@ -223,14 +222,12 @@ def upload_checkpoint(
     # They may diverge slightly from the backup contents if writes occurred
     # between backup and upload, but this is acceptable for checkpoint metadata.
     with db.read_snapshot() as snapshot:
-        job_count = snapshot.execute(select(func.count()).select_from(jobs_table)).scalar()
-        task_count = snapshot.execute(select(func.count()).select_from(tasks_table)).scalar()
-        worker_count = snapshot.execute(select(func.count()).select_from(workers_table)).scalar()
+        counts = reads.row_counts(snapshot)
     result = CheckpointResult(
         created_at=backup.created_at,
-        job_count=job_count,
-        task_count=task_count,
-        worker_count=worker_count,
+        job_count=counts.jobs,
+        task_count=counts.tasks,
+        worker_count=counts.workers,
     )
 
     # Best-effort pruning of old checkpoints

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -910,8 +910,7 @@ class Controller:
         """Turn execution-timeout rows from the snapshot into TIMEOUT decisions.
 
         A row becomes a decision only once its attempt's
-        ``started_at_ms + timeout_ms`` is already in the past. Returned decisions
-        are applied inside the same write transaction as the reconcile results.
+        ``started_at_ms + timeout_ms`` is already in the past.
         """
         decisions: list[TerminalDecision] = []
         for row in timeout_rows:
@@ -981,8 +980,7 @@ class Controller:
         """Build per-job ``RunTaskRequest`` templates for the ASSIGNED reconcile rows.
 
         ``run_request_template`` can return ``None`` for jobs the scheduler hasn't
-        cached yet (e.g. reservation holders); those are dropped so the spec map
-        stays tight (``build_reconcile_plans`` skips a row whose job is absent).
+        cached yet (e.g. reservation holders); those are dropped from the map.
         """
         templates_by_job: dict[JobName, job_pb2.RunTaskRequest | None] = {}
         for row in reconcile_rows:

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -11,6 +11,7 @@ import socket
 import tempfile
 import threading
 import time
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from pathlib import Path
@@ -21,7 +22,7 @@ from finelog.client import LogClient, RemoteLogHandler
 from finelog.client.proxy import LogServiceProxy, StatsServiceProxy
 from finelog.embedded import require_embedded_server
 from rigging.timing import Duration, ExponentialBackoff, RateLimiter, Timestamp, TokenBucket
-from sqlalchemy import bindparam, select
+from sqlalchemy import Row
 
 from iris.cluster.backends.types import resolve_external_host
 from iris.cluster.bundle import BundleStore
@@ -44,7 +45,7 @@ from iris.cluster.controller.checkpoint import (
     write_checkpoint,
 )
 from iris.cluster.controller.dashboard import ControllerDashboard
-from iris.cluster.controller.db import ControllerDB
+from iris.cluster.controller.db import ControllerDB, Tx
 from iris.cluster.controller.ops.task import (
     Assignment,
     apply_dispatch_updates,
@@ -78,14 +79,7 @@ from iris.cluster.controller.scheduling.scheduler import (
     Scheduler,
     SchedulingContext,
 )
-from iris.cluster.controller.schema import (
-    ReservationClaim,
-    hint_rare_state,
-    job_config_table,
-    task_attempts_table,
-    tasks_table,
-    workers_table,
-)
+from iris.cluster.controller.schema import ReservationClaim
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.controller.worker_health import WorkerHealthTracker
 from iris.cluster.log_keys import CONTROLLER_LOG_KEY
@@ -452,8 +446,7 @@ class Controller:
         """
         now_ms = Timestamp.now().epoch_ms()
         with self._db.read_snapshot() as q:
-            rows = q.execute(select(workers_table.c.worker_id)).all()
-        worker_ids = [WorkerId(str(row.worker_id)) for row in rows]
+            worker_ids = reads.all_worker_ids(q)
         if worker_ids:
             self._health.heartbeat(worker_ids, now_ms)
 
@@ -913,37 +906,15 @@ class Controller:
         """Return cached scheduling diagnostic for a job, or None if unavailable."""
         return self._scheduling_diagnostics.get(job_wire_id)
 
-    def _scan_execution_timeouts(self, snap: Any, now_ms: int) -> list[TerminalDecision]:
-        """Find executing tasks past their deadline within an existing read snapshot.
+    def _timeout_decisions(self, timeout_rows: Sequence[Row], now_ms: int) -> list[TerminalDecision]:
+        """Turn execution-timeout rows from the snapshot into TIMEOUT decisions.
 
-        Issued inline with the reconcile snapshot so the timeout sweep adds one
-        query (not a fresh snapshot open) per reconcile tick where the limiter
-        fires. Returned decisions are applied by the caller inside the same
-        write transaction as the reconcile results.
+        A row becomes a decision only once its attempt's
+        ``started_at_ms + timeout_ms`` is already in the past. Returned decisions
+        are applied inside the same write transaction as the reconcile results.
         """
-        rows = snap.execute(
-            select(
-                tasks_table.c.task_id,
-                task_attempts_table.c.started_at_ms,
-                job_config_table.c.timeout_ms,
-            )
-            .select_from(
-                tasks_table.join(job_config_table, job_config_table.c.job_id == tasks_table.c.job_id).join(
-                    task_attempts_table,
-                    (task_attempts_table.c.task_id == tasks_table.c.task_id)
-                    & (task_attempts_table.c.attempt_id == tasks_table.c.current_attempt_id),
-                )
-            )
-            .where(
-                hint_rare_state(tasks_table.c.state.in_(bindparam("executing_states", expanding=True))),
-                job_config_table.c.timeout_ms.is_not(None),
-                job_config_table.c.timeout_ms > 0,
-                task_attempts_table.c.started_at_ms.is_not(None),
-            ),
-            {"executing_states": [int(job_pb2.TASK_STATE_BUILDING), int(job_pb2.TASK_STATE_RUNNING)]},
-        ).all()
         decisions: list[TerminalDecision] = []
-        for row in rows:
+        for row in timeout_rows:
             if row.started_at_ms.epoch_ms() + int(row.timeout_ms) > now_ms:
                 continue
             logger.warning("Task %s exceeded execution timeout, killing", row.task_id)
@@ -959,7 +930,7 @@ class Controller:
     def _mark_tasks_unschedulable(self, tasks: list[Any]) -> None:
         """Mark a batch of tasks as unschedulable due to scheduling timeout.
 
-        Each entry must be a row from ``_pending_tasks_with_jobs``; it carries
+        Each entry must be a row from ``reads.pending_tasks_with_jobs``; it carries
         ``scheduling_timeout_ms`` so no secondary DB fetch is needed.
         """
         if not tasks:
@@ -1004,80 +975,46 @@ class Controller:
     # Worker lifecycle RPC dispatch (Reconcile / Ping)
     # =========================================================================
 
-    def _snapshot_reconcile_inputs(
-        self, scan_timeouts: bool, now_ms: int
-    ) -> tuple[ReconcileInputs, dict[WorkerId, str], list[TerminalDecision]]:
-        """Snapshot the DB and assemble the reconcile inputs for one tick.
+    def _build_run_templates(
+        self, snap: Tx, reconcile_rows: list[ReconcileRow]
+    ) -> dict[JobName, job_pb2.RunTaskRequest]:
+        """Build per-job ``RunTaskRequest`` templates for the ASSIGNED reconcile rows.
 
-        When ``scan_timeouts`` is True, also issues the execution-timeout
-        deadline scan inside the same read snapshot so the sweep adds one
-        query (not a fresh snapshot open) per limiter tick.
+        ``run_request_template`` can return ``None`` for jobs the scheduler hasn't
+        cached yet (e.g. reservation holders); those are dropped so the spec map
+        stays tight (``build_reconcile_plans`` skips a row whose job is absent).
+        """
+        templates_by_job: dict[JobName, job_pb2.RunTaskRequest | None] = {}
+        for row in reconcile_rows:
+            if row.task_state != job_pb2.TASK_STATE_ASSIGNED:
+                continue
+            if row.job_id not in templates_by_job:
+                templates_by_job[row.job_id] = dispatch.run_request_template(self._run_template_cache, snap, row.job_id)
+        return {jid: spec for jid, spec in templates_by_job.items() if spec is not None}
+
+    def _snapshot_reconcile_inputs(self, scan_timeouts: bool) -> tuple[reads.ControlSnapshot, ReconcileInputs]:
+        """Build the per-cycle :class:`ControlSnapshot` and derive reconcile inputs.
+
+        The control snapshot — live worker set, worker-bound attempt rows, and
+        (when ``scan_timeouts``) the execution-timeout rows — is assembled by
+        ``reads.load_control_snapshot`` in one read transaction. The per-job run
+        templates need the same open snapshot, so they are built before it
+        closes. The returned ``ReconcileInputs`` is the backend call shape; the
+        snapshot carries worker addresses, timeout rows, and the health view.
         """
         with self._db.read_snapshot() as snap:
-            addresses = reads.list_active_healthy_workers(snap, self._health)
-            if not addresses:
-                timeout_decisions = self._scan_execution_timeouts(snap, now_ms) if scan_timeouts else []
-                return ReconcileInputs(job_specs={}, worker_ids=[], rows_by_worker={}), {}, timeout_decisions
-            worker_ids = list(addresses)
-            # Snapshot current attempts for ``worker_ids``. Workers not in
-            # ``worker_ids`` are filtered in Python so the partial index
-            # ``idx_task_attempts_live_workerbound`` remains active rather
-            # than falling back to a scan on a long IN list. We deliberately
-            # do NOT filter on task state: active rows (ASSIGNED/BUILDING/
-            # RUNNING) drive normal reconciliation; rows whose task has
-            # already moved to a terminal state but whose attempt is still
-            # worker-bound (worker_id set, finished_at_ms NULL) are stranded
-            # attempts whose terminal Reconcile observation was lost.
-            # Including them in the desired set gives the worker a second
-            # chance to report -- either with the real terminal status or
-            # via the MISSING synthesis in ``handle_reconcile`` -- so the
-            # reconcile-observation path can stamp finished_at_ms. Without this, a single
-            # lost RPC strands the attempt forever, since no other code path
-            # polls about it.
-            target_ids: set[WorkerId] = set(worker_ids)
-            raw_rows = snap.execute(
-                select(
-                    task_attempts_table.c.worker_id,
-                    tasks_table.c.task_id,
-                    task_attempts_table.c.attempt_id,
-                    tasks_table.c.state.label("task_state"),
-                    task_attempts_table.c.state.label("attempt_state"),
-                    tasks_table.c.job_id,
-                    task_attempts_table.c.attempt_uid,
-                )
-                .select_from(
-                    task_attempts_table.join(
-                        tasks_table,
-                        (tasks_table.c.task_id == task_attempts_table.c.task_id)
-                        & (tasks_table.c.current_attempt_id == task_attempts_table.c.attempt_id),
-                    )
-                )
-                .where(
-                    task_attempts_table.c.worker_id.is_not(None),
-                    task_attempts_table.c.finished_at_ms.is_(None),
-                ),
-            ).all()
-            rows = [row for row in raw_rows if row.worker_id in target_ids]
-            templates_by_job: dict[JobName, job_pb2.RunTaskRequest | None] = {}
-            for row in rows:
-                if row.task_state != job_pb2.TASK_STATE_ASSIGNED:
-                    continue
-                if row.job_id not in templates_by_job:
-                    templates_by_job[row.job_id] = dispatch.run_request_template(
-                        self._run_template_cache, snap, row.job_id
-                    )
-            timeout_decisions = self._scan_execution_timeouts(snap, now_ms) if scan_timeouts else []
+            control = reads.load_control_snapshot(snap, self._health, scan_timeouts=scan_timeouts)
+            job_specs = self._build_run_templates(snap, control.reconcile_rows)
 
-        rows_by_worker: dict[WorkerId, list[ReconcileRow]] = {wid: [] for wid in worker_ids}
-        for row in rows:
+        rows_by_worker: dict[WorkerId, list[ReconcileRow]] = {wid: [] for wid in control.worker_addresses}
+        for row in control.reconcile_rows:
             rows_by_worker[row.worker_id].append(row)
-
-        # ``templates_by_job`` can carry ``None`` for jobs the scheduler hasn't
-        # cached yet; reconcile_worker checks the dict membership so feeding it
-        # the raw map is harmless. Filter Nones to keep the type tight.
-        job_specs = {jid: spec for jid, spec in templates_by_job.items() if spec is not None}
-        inputs = ReconcileInputs(job_specs=job_specs, worker_ids=worker_ids, rows_by_worker=rows_by_worker)
-        return inputs, addresses, timeout_decisions
+        inputs = ReconcileInputs(
+            job_specs=job_specs,
+            worker_ids=list(control.worker_addresses),
+            rows_by_worker=rows_by_worker,
+        )
+        return control, inputs
 
     def _reconcile_tick(self) -> None:
         """One polling-tick reconcile pass: snapshot, fan out, apply.
@@ -1094,13 +1031,14 @@ class Controller:
 
         now = Timestamp.now()
         scan_timeouts = self._timeout_rate_limiter.should_run()
-        inputs, addresses, timeout_decisions = self._snapshot_reconcile_inputs(scan_timeouts, now.epoch_ms())
+        snapshot, inputs = self._snapshot_reconcile_inputs(scan_timeouts)
+        timeout_decisions = self._timeout_decisions(snapshot.timeout_rows, now.epoch_ms())
         if not inputs.worker_ids and not timeout_decisions:
             return
 
         plans = build_reconcile_plans(inputs) if inputs.worker_ids else []
         if plans:
-            reconcile_input = BackendReconcileInput(plans=plans, worker_addresses=addresses)
+            reconcile_input = BackendReconcileInput(plans=plans, worker_addresses=snapshot.worker_addresses)
             results = self._task_backend.reconcile(reconcile_input).worker_results
         else:
             results = []
@@ -1115,7 +1053,7 @@ class Controller:
                     cur,
                     plan_by_worker,
                     results,
-                    health=self._health,
+                    health=snapshot.health,
                     endpoints=self._endpoints,
                     now=now,
                 )
@@ -1123,7 +1061,7 @@ class Controller:
                 finalize(
                     cur,
                     timeout_decisions,
-                    health=self._health,
+                    health=snapshot.health,
                     endpoints=self._endpoints,
                     now=now,
                 )

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -22,14 +22,20 @@ from dataclasses import dataclass, field
 from typing import Protocol
 
 from rigging.timing import Timestamp
-from sqlalchemy import Integer, bindparam, case, cast, func, literal_column, select, tuple_
+from sqlalchemy import Integer, Row, bindparam, case, cast, func, literal_column, select, tuple_
 
 from iris.cluster.constraints import AttributeValue
-from iris.cluster.controller.codec import device_counts_from_json, resource_spec_from_scalars
+from iris.cluster.controller.codec import (
+    device_counts_from_json,
+    reservation_entries_from_json,
+    resource_spec_from_scalars,
+)
 from iris.cluster.controller.db import Tx
+from iris.cluster.controller.reconcile.worker import ReconcileRow
 from iris.cluster.controller.schema import (
     USER_ROLE_DEFAULT,
     ReservationClaim,
+    hint_rare_state,
     job_config_table,
     job_workdir_files_table,
     jobs_table,
@@ -40,8 +46,14 @@ from iris.cluster.controller.schema import (
     users_table,
     workers_table,
 )
-from iris.cluster.controller.task_state import ActiveTaskRow, TaskDetailRow
-from iris.cluster.types import AttemptUid, JobName, WorkerId
+from iris.cluster.controller.task_state import (
+    ACTIVE_TASK_STATES,
+    ActiveTaskRow,
+    TaskDetailRow,
+    task_row_can_be_scheduled,
+)
+from iris.cluster.controller.worker_health import WorkerHealthTracker
+from iris.cluster.types import AttemptUid, JobName, PendingTask, WorkerId
 from iris.rpc import controller_pb2, job_pb2
 
 # ---------------------------------------------------------------------------
@@ -740,6 +752,223 @@ def running_tasks_by_worker(tx: Tx, worker_ids: set[WorkerId]) -> dict[WorkerId,
 
 
 # ---------------------------------------------------------------------------
+# Scheduling-policy reads (pending tasks, reservations, running tasks, budgets)
+# ---------------------------------------------------------------------------
+
+# Task columns needed to evaluate scheduling priority and retry budget. Shared by
+# the scheduler's pending-task query (pending_tasks_with_jobs, which joins
+# additional job/job_config columns) and the dashboard scheduler-summary path
+# (service.GetSchedulerSummary), so the two stay aligned as priority columns evolve.
+PENDING_TASK_COLS = (
+    tasks_table.c.task_id,
+    tasks_table.c.job_id,
+    tasks_table.c.state,
+    tasks_table.c.current_attempt_id,
+    tasks_table.c.failure_count,
+    tasks_table.c.preemption_count,
+    tasks_table.c.max_retries_failure,
+    tasks_table.c.max_retries_preemption,
+    tasks_table.c.submitted_at_ms,
+    tasks_table.c.priority_band,
+    tasks_table.c.priority_neg_depth,
+    tasks_table.c.priority_root_submitted_ms,
+    tasks_table.c.priority_insertion,
+)
+
+
+def _row_to_pending_task(row) -> PendingTask:
+    return PendingTask(
+        task_id=row.task_id,
+        job_id=row.job_id,
+        state=int(row.state),
+        current_attempt_id=int(row.current_attempt_id),
+        failure_count=int(row.failure_count),
+        preemption_count=int(row.preemption_count),
+        max_retries_failure=int(row.max_retries_failure),
+        max_retries_preemption=int(row.max_retries_preemption),
+        submitted_at_ms=row.submitted_at_ms,
+        priority_band=int(row.priority_band),
+        priority_neg_depth=int(row.priority_neg_depth),
+        priority_root_submitted_ms=int(row.priority_root_submitted_ms),
+        priority_insertion=int(row.priority_insertion),
+        job_state=int(row.job_state),
+        scheduling_deadline_epoch_ms=row.scheduling_deadline_epoch_ms,
+        is_reservation_holder=bool(row.is_reservation_holder),
+        has_reservation=bool(row.has_reservation),
+        scheduling_timeout_ms=row.scheduling_timeout_ms,
+        has_coscheduling=bool(row.has_coscheduling),
+        coscheduling_group_by=row.coscheduling_group_by,
+        constraints_json=row.constraints_json,
+        res_cpu_millicores=int(row.res_cpu_millicores),
+        res_memory_bytes=int(row.res_memory_bytes),
+        res_disk_bytes=int(row.res_disk_bytes),
+        res_device_json=row.res_device_json,
+    )
+
+
+_PENDING_TASKS_STMT = (
+    select(
+        *PENDING_TASK_COLS,
+        # job columns (label job_state to avoid clash with tasks.state)
+        jobs_table.c.state.label("job_state"),
+        jobs_table.c.scheduling_deadline_epoch_ms,
+        jobs_table.c.is_reservation_holder,
+        jobs_table.c.has_reservation,
+        # job_config columns
+        job_config_table.c.scheduling_timeout_ms,
+        job_config_table.c.has_coscheduling,
+        job_config_table.c.coscheduling_group_by,
+        job_config_table.c.constraints_json,
+        job_config_table.c.res_cpu_millicores,
+        job_config_table.c.res_memory_bytes,
+        job_config_table.c.res_disk_bytes,
+        job_config_table.c.res_device_json,
+    )
+    .select_from(
+        tasks_table.join(jobs_table, jobs_table.c.job_id == tasks_table.c.job_id).join(
+            job_config_table, job_config_table.c.job_id == tasks_table.c.job_id
+        )
+    )
+    .where(tasks_table.c.state == bindparam("state"))
+    .order_by(
+        tasks_table.c.priority_neg_depth.asc(),
+        tasks_table.c.priority_root_submitted_ms.asc(),
+        tasks_table.c.submitted_at_ms.asc(),
+        tasks_table.c.priority_insertion.asc(),
+    )
+)
+
+
+def pending_tasks_with_jobs(tx: Tx) -> list[PendingTask]:
+    """Return scheduling inputs for PENDING tasks, joining task + job + job_config in one query.
+
+    Rows that cannot currently be scheduled (per :func:`task_row_can_be_scheduled`)
+    are filtered out, so callers receive only actionable pending work.
+    """
+    rows = tx.execute(_PENDING_TASKS_STMT, {"state": job_pb2.TASK_STATE_PENDING}).all()
+    pending_tasks = [_row_to_pending_task(row) for row in rows]
+    return [task for task in pending_tasks if task_row_can_be_scheduled(task)]
+
+
+def reserved_job_ids(tx: Tx) -> set[JobName]:
+    """Return the set of job_ids with ``has_reservation = 1`` on the jobs table."""
+    rows = tx.execute(select(jobs_table.c.job_id).where(jobs_table.c.has_reservation == 1)).all()
+    return {row.job_id for row in rows}
+
+
+def reservation_entry_counts(tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName, int]:
+    """Return ``{job_id: reservation entry count}`` for the requested jobs.
+
+    Jobs with no reservation JSON are omitted. Drives both the scheduling gate
+    and the demand path so they agree on how many workers a reservation needs.
+    """
+    ids = list(job_ids)
+    if not ids:
+        return {}
+    rows = tx.execute(
+        select(job_config_table.c.job_id, job_config_table.c.reservation_json).where(
+            job_config_table.c.job_id.in_(bindparam("job_ids", expanding=True))
+        ),
+        {"job_ids": ids},
+    ).all()
+    counts: dict[JobName, int] = {}
+    for row in rows:
+        if row.reservation_json is None:
+            continue
+        counts[row.job_id] = len(reservation_entries_from_json(row.reservation_json))
+    return counts
+
+
+def jobs_with_reservations(tx: Tx, states: Iterable[int]) -> Sequence[Row]:
+    """Fetch ``(job_id, reservation_json)`` for non-finished jobs that hold a reservation.
+
+    Filters via ``jobs.has_reservation`` (no scan of ``job_config``) and joins
+    ``job_config`` solely to pull ``reservation_json``.
+    """
+    return tx.execute(
+        select(jobs_table.c.job_id, job_config_table.c.reservation_json)
+        .select_from(jobs_table.join(job_config_table, jobs_table.c.job_id == job_config_table.c.job_id))
+        .where(
+            jobs_table.c.state.in_(bindparam("states", expanding=True)),
+            jobs_table.c.has_reservation == 1,
+        ),
+        {"states": list(states)},
+    ).all()
+
+
+def job_states_by_id(tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName, int]:
+    """Fetch only ``jobs.state`` for the given job IDs.
+
+    Intentionally narrow: callers that need just the job state (not resources or
+    config) use this to avoid over-fetching.
+    """
+    ids = list(job_ids)
+    if not ids:
+        return {}
+    rows = tx.execute(
+        select(jobs_table.c.job_id, jobs_table.c.state).where(
+            jobs_table.c.job_id.in_(bindparam("job_ids", expanding=True))
+        ),
+        {"job_ids": ids},
+    ).all()
+    return {row.job_id: int(row.state) for row in rows}
+
+
+_RUNNING_TASK_BAND_STMT = (
+    select(
+        tasks_table.c.task_id,
+        tasks_table.c.priority_band,
+        tasks_table.c.current_worker_id.label("worker_id"),
+        job_config_table.c.res_cpu_millicores,
+        job_config_table.c.res_memory_bytes,
+        job_config_table.c.res_disk_bytes,
+        job_config_table.c.res_device_json,
+        job_config_table.c.has_coscheduling,
+    )
+    .select_from(tasks_table.join(job_config_table, tasks_table.c.job_id == job_config_table.c.job_id))
+    .where(
+        tasks_table.c.state == bindparam("state"),
+        tasks_table.c.current_worker_id.is_not(None),
+    )
+)
+
+
+def running_task_band_rows(tx: Tx) -> Sequence[Row]:
+    """Return RUNNING worker-bound tasks with band + worker + resource columns.
+
+    The reported band is ``tasks.priority_band`` (stamped at assignment time);
+    callers derive resource value and skip reservation-claimed workers.
+    """
+    return tx.execute(_RUNNING_TASK_BAND_STMT, {"state": job_pb2.TASK_STATE_RUNNING}).all()
+
+
+_USER_SPEND_STMT = (
+    select(
+        tasks_table.c.job_id,
+        job_config_table.c.res_cpu_millicores,
+        job_config_table.c.res_memory_bytes,
+        job_config_table.c.res_device_json,
+        func.count().label("task_count"),
+    )
+    .select_from(tasks_table.join(job_config_table, job_config_table.c.job_id == tasks_table.c.job_id))
+    .where(hint_rare_state(tasks_table.c.state.in_(bindparam("states", expanding=True))))
+    .where(job_config_table.c.priority_band != job_pb2.PRIORITY_BAND_BATCH)
+    .group_by(tasks_table.c.job_id)
+)
+
+
+def user_spend_rows(tx: Tx) -> Sequence[Row]:
+    """Return per-job resource rows for active, non-BATCH tasks (budget spend basis).
+
+    Each row carries ``(job_id, res_cpu_millicores, res_memory_bytes,
+    res_device_json, task_count)``. ``job_config.priority_band`` (the user's
+    requested band) drives the BATCH exclusion, not the stamped
+    ``tasks.priority_band``, so scheduler-downgraded jobs still count.
+    """
+    return tx.execute(_USER_SPEND_STMT, {"states": list(ACTIVE_TASK_STATES)}).all()
+
+
+# ---------------------------------------------------------------------------
 # Task-attempt reads (previously reads/task_attempts.py)
 # ---------------------------------------------------------------------------
 
@@ -854,26 +1083,6 @@ TASK_DETAIL_COLS = (
     tasks_table.c.current_worker_id,
     tasks_table.c.current_worker_address,
     tasks_table.c.container_id,
-)
-
-# Task columns needed to evaluate scheduling priority and retry budget. Shared by
-# the scheduler's pending-task query (policy._pending_tasks_with_jobs, which joins
-# additional job/job_config columns) and the dashboard scheduler-summary path
-# (service.GetSchedulerSummary), so the two stay aligned as priority columns evolve.
-PENDING_TASK_COLS = (
-    tasks_table.c.task_id,
-    tasks_table.c.job_id,
-    tasks_table.c.state,
-    tasks_table.c.current_attempt_id,
-    tasks_table.c.failure_count,
-    tasks_table.c.preemption_count,
-    tasks_table.c.max_retries_failure,
-    tasks_table.c.max_retries_preemption,
-    tasks_table.c.submitted_at_ms,
-    tasks_table.c.priority_band,
-    tasks_table.c.priority_neg_depth,
-    tasks_table.c.priority_root_submitted_ms,
-    tasks_table.c.priority_insertion,
 )
 
 
@@ -1259,4 +1468,173 @@ def pending_dispatch_row(r) -> PendingDispatchRow:
         has_coscheduling=bool(r.has_coscheduling),
         coscheduling_group_by=str(r.coscheduling_group_by),
         priority_band=int(r.priority_band),
+    )
+
+
+# ---------------------------------------------------------------------------
+# Control-cycle snapshot (the reconcile control tick reads through here)
+# ---------------------------------------------------------------------------
+
+
+@dataclass(frozen=True, slots=True)
+class RowCounts:
+    """Aggregate registry sizes, used for checkpoint metadata."""
+
+    jobs: int
+    tasks: int
+    workers: int
+
+
+def row_counts(tx: Tx) -> RowCounts:
+    """Return total row counts for the jobs, tasks, and workers tables."""
+    return RowCounts(
+        jobs=int(tx.execute(select(func.count()).select_from(jobs_table)).scalar() or 0),
+        tasks=int(tx.execute(select(func.count()).select_from(tasks_table)).scalar() or 0),
+        workers=int(tx.execute(select(func.count()).select_from(workers_table)).scalar() or 0),
+    )
+
+
+def all_worker_ids(tx: Tx) -> list[WorkerId]:
+    """Return every persisted worker id (used to seed the liveness tracker)."""
+    rows = tx.execute(select(workers_table.c.worker_id)).all()
+    return [WorkerId(str(row.worker_id)) for row in rows]
+
+
+_EXECUTING_TASK_STATES = (int(job_pb2.TASK_STATE_BUILDING), int(job_pb2.TASK_STATE_RUNNING))
+
+_EXECUTION_TIMEOUT_STMT = (
+    select(
+        tasks_table.c.task_id,
+        task_attempts_table.c.started_at_ms,
+        job_config_table.c.timeout_ms,
+    )
+    .select_from(
+        tasks_table.join(job_config_table, job_config_table.c.job_id == tasks_table.c.job_id).join(
+            task_attempts_table,
+            (task_attempts_table.c.task_id == tasks_table.c.task_id)
+            & (task_attempts_table.c.attempt_id == tasks_table.c.current_attempt_id),
+        )
+    )
+    .where(
+        hint_rare_state(tasks_table.c.state.in_(bindparam("executing_states", expanding=True))),
+        job_config_table.c.timeout_ms.is_not(None),
+        job_config_table.c.timeout_ms > 0,
+        task_attempts_table.c.started_at_ms.is_not(None),
+    )
+)
+
+
+def scan_execution_timeout_rows(tx: Tx) -> Sequence[Row]:
+    """Return ``(task_id, started_at_ms, timeout_ms)`` for executing tasks that declare a timeout.
+
+    Pure read: the caller compares ``started_at_ms + timeout_ms`` against the
+    tick's clock to decide which tasks have actually exceeded their deadline.
+    """
+    return tx.execute(_EXECUTION_TIMEOUT_STMT, {"executing_states": list(_EXECUTING_TASK_STATES)}).all()
+
+
+_RECONCILE_ROWS_STMT = (
+    select(
+        task_attempts_table.c.worker_id,
+        tasks_table.c.task_id,
+        task_attempts_table.c.attempt_id,
+        tasks_table.c.state.label("task_state"),
+        task_attempts_table.c.state.label("attempt_state"),
+        tasks_table.c.job_id,
+        task_attempts_table.c.attempt_uid,
+    )
+    .select_from(
+        task_attempts_table.join(
+            tasks_table,
+            (tasks_table.c.task_id == task_attempts_table.c.task_id)
+            & (tasks_table.c.current_attempt_id == task_attempts_table.c.attempt_id),
+        )
+    )
+    .where(
+        task_attempts_table.c.worker_id.is_not(None),
+        task_attempts_table.c.finished_at_ms.is_(None),
+    )
+)
+
+
+def load_reconcile_rows(tx: Tx, worker_ids: Iterable[WorkerId]) -> list[ReconcileRow]:
+    """Return the live ``(task, attempt, worker)`` tuples driving one reconcile tick.
+
+    Workers not in ``worker_ids`` are filtered in Python so the partial index
+    ``idx_task_attempts_live_workerbound`` stays active rather than falling back
+    to a scan on a long IN list. Task state is deliberately NOT filtered: active
+    rows (ASSIGNED/BUILDING/RUNNING) drive normal reconciliation; rows whose task
+    has already moved to a terminal state but whose attempt is still worker-bound
+    (worker_id set, finished_at_ms NULL) are stranded attempts whose terminal
+    Reconcile observation was lost. Including them gives the worker a second
+    chance to report -- with the real terminal status or via the MISSING
+    synthesis in ``handle_reconcile`` -- so the reconcile path can stamp
+    finished_at_ms. Without this, a single lost RPC strands the attempt forever.
+    """
+    target_ids = set(worker_ids)
+    if not target_ids:
+        return []
+    rows = tx.execute(_RECONCILE_ROWS_STMT).all()
+    return [
+        ReconcileRow(
+            worker_id=row.worker_id,
+            task_id=row.task_id,
+            attempt_id=int(row.attempt_id),
+            task_state=int(row.task_state),
+            attempt_state=int(row.attempt_state),
+            job_id=row.job_id,
+            attempt_uid=AttemptUid(str(row.attempt_uid)),
+        )
+        for row in rows
+        if row.worker_id in target_ids
+    ]
+
+
+@dataclass(frozen=True, slots=True)
+class ControlSnapshot:
+    """Per-cycle control-path state, built once via :func:`load_control_snapshot`.
+
+    Carries the DB-sourced inputs the reconcile control tick consumes:
+
+    * ``worker_addresses`` — ``{worker_id: address}`` for active + healthy workers.
+    * ``reconcile_rows`` — live ``(task, attempt, worker)`` tuples across those
+      workers (see :func:`load_reconcile_rows`).
+    * ``timeout_rows`` — executing tasks past their declared deadline; empty
+      unless the caller requested the timeout sweep this tick.
+
+    ``health`` is the one non-DB field: the controller's in-memory
+    :class:`WorkerHealthTracker`. Worker liveness is never persisted, so the
+    controller supplies its tracker — which the loader also uses to select the
+    live worker set — and it rides along on the snapshot so the reconcile apply
+    path consumes the same liveness view that scoped the snapshot.
+    """
+
+    worker_addresses: dict[WorkerId, str]
+    reconcile_rows: list[ReconcileRow]
+    timeout_rows: Sequence[Row]
+    health: WorkerHealthTracker
+
+
+def load_control_snapshot(
+    tx: Tx,
+    health: WorkerHealthTracker,
+    *,
+    scan_timeouts: bool,
+) -> ControlSnapshot:
+    """Build the per-cycle :class:`ControlSnapshot` in one read transaction.
+
+    ``health`` selects the live worker set (see :func:`list_active_healthy_workers`)
+    and is attached verbatim to the result as the snapshot's non-DB health view.
+    When ``scan_timeouts`` is set, the execution-timeout deadline scan is folded
+    into the same snapshot so the sweep adds one query rather than opening a
+    fresh snapshot.
+    """
+    worker_addresses = list_active_healthy_workers(tx, health)
+    reconcile_rows = load_reconcile_rows(tx, worker_addresses.keys()) if worker_addresses else []
+    timeout_rows = scan_execution_timeout_rows(tx) if scan_timeouts else []
+    return ControlSnapshot(
+        worker_addresses=worker_addresses,
+        reconcile_rows=reconcile_rows,
+        timeout_rows=timeout_rows,
+        health=health,
     )

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -3,18 +3,21 @@
 
 """Read-side helpers: module-level functions taking ``tx: db.Tx`` as first argument.
 
-All public functions return SA ``Row`` objects (or ``Sequence[Row]`` / dicts of
-them).  Return shapes are documented per-function.
+Return shapes vary and are documented per-function: some return raw SA ``Row``
+objects (or ``Sequence[Row]`` / dicts of them), others return typed dataclasses
+(``ControlSnapshot``, ``RowCounts``, ``PendingTask``, ``ReconcileRow``, …) or
+plain sets/dicts of ids.
 
 Areas covered:
-  budgets        — user budgets and roles
-  dashboard      — job listing, task summaries, parent-child helpers
-  jobs           — job/job_config lookups and CTEs
-  reservations   — reservation_claims reads
-  scheduler      — per-worker resource usage, running-tasks map
-  task_attempts  — bulk attempt lookups
-  tasks          — task detail and active-task projections
-  workers        — worker detail, liveness helpers, schedulable workers
+  budgets         — user budgets and roles
+  dashboard       — job listing, task summaries, parent-child helpers
+  jobs            — job/job_config lookups and CTEs
+  reservations    — reservation_claims reads
+  scheduling      — pending tasks, reservations, running tasks, per-user spend
+  task_attempts   — bulk attempt lookups
+  tasks           — task detail and active-task projections
+  workers         — worker detail, liveness helpers, schedulable workers
+  control-cycle   — the per-tick ControlSnapshot built via load_control_snapshot
 """
 
 from collections.abc import Iterable, Sequence

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -776,7 +776,7 @@ PENDING_TASK_COLS = (
 )
 
 
-def _row_to_pending_task(row) -> PendingTask:
+def _row_to_pending_task(row: Row) -> PendingTask:
     return PendingTask(
         task_id=row.task_id,
         job_id=row.job_id,
@@ -859,8 +859,7 @@ def reserved_job_ids(tx: Tx) -> set[JobName]:
 def reservation_entry_counts(tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName, int]:
     """Return ``{job_id: reservation entry count}`` for the requested jobs.
 
-    Jobs with no reservation JSON are omitted. Drives both the scheduling gate
-    and the demand path so they agree on how many workers a reservation needs.
+    Jobs with no reservation JSON are omitted.
     """
     ids = list(job_ids)
     if not ids:
@@ -880,11 +879,7 @@ def reservation_entry_counts(tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName
 
 
 def jobs_with_reservations(tx: Tx, states: Iterable[int]) -> Sequence[Row]:
-    """Fetch ``(job_id, reservation_json)`` for non-finished jobs that hold a reservation.
-
-    Filters via ``jobs.has_reservation`` (no scan of ``job_config``) and joins
-    ``job_config`` solely to pull ``reservation_json``.
-    """
+    """Return ``(job_id, reservation_json)`` rows for jobs in ``states`` that hold a reservation."""
     return tx.execute(
         select(jobs_table.c.job_id, job_config_table.c.reservation_json)
         .select_from(jobs_table.join(job_config_table, jobs_table.c.job_id == job_config_table.c.job_id))
@@ -897,11 +892,7 @@ def jobs_with_reservations(tx: Tx, states: Iterable[int]) -> Sequence[Row]:
 
 
 def job_states_by_id(tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName, int]:
-    """Fetch only ``jobs.state`` for the given job IDs.
-
-    Intentionally narrow: callers that need just the job state (not resources or
-    config) use this to avoid over-fetching.
-    """
+    """Return ``{job_id: state}`` for the given job IDs (no resource or config columns)."""
     ids = list(job_ids)
     if not ids:
         return {}
@@ -934,10 +925,10 @@ _RUNNING_TASK_BAND_STMT = (
 
 
 def running_task_band_rows(tx: Tx) -> Sequence[Row]:
-    """Return RUNNING worker-bound tasks with band + worker + resource columns.
+    """Return RUNNING worker-bound tasks with band, worker, and resource columns.
 
-    The reported band is ``tasks.priority_band`` (stamped at assignment time);
-    callers derive resource value and skip reservation-claimed workers.
+    The band is ``tasks.priority_band`` (stamped at assignment time), not the
+    immutable requested band in ``job_config``.
     """
     return tx.execute(_RUNNING_TASK_BAND_STMT, {"state": job_pb2.TASK_STATE_RUNNING}).all()
 
@@ -1495,7 +1486,7 @@ def row_counts(tx: Tx) -> RowCounts:
 
 
 def all_worker_ids(tx: Tx) -> list[WorkerId]:
-    """Return every persisted worker id (used to seed the liveness tracker)."""
+    """Return every persisted worker id."""
     rows = tx.execute(select(workers_table.c.worker_id)).all()
     return [WorkerId(str(row.worker_id)) for row in rows]
 
@@ -1527,8 +1518,8 @@ _EXECUTION_TIMEOUT_STMT = (
 def scan_execution_timeout_rows(tx: Tx) -> Sequence[Row]:
     """Return ``(task_id, started_at_ms, timeout_ms)`` for executing tasks that declare a timeout.
 
-    Pure read: the caller compares ``started_at_ms + timeout_ms`` against the
-    tick's clock to decide which tasks have actually exceeded their deadline.
+    Whether a task has actually exceeded its deadline is left to the caller,
+    which holds the tick clock; this only returns the candidates.
     """
     return tx.execute(_EXECUTION_TIMEOUT_STMT, {"executing_states": list(_EXECUTING_TASK_STATES)}).all()
 
@@ -1625,9 +1616,7 @@ def load_control_snapshot(
 
     ``health`` selects the live worker set (see :func:`list_active_healthy_workers`)
     and is attached verbatim to the result as the snapshot's non-DB health view.
-    When ``scan_timeouts`` is set, the execution-timeout deadline scan is folded
-    into the same snapshot so the sweep adds one query rather than opening a
-    fresh snapshot.
+    ``scan_timeouts`` includes the execution-timeout rows in the same snapshot.
     """
     worker_addresses = list_active_healthy_workers(tx, health)
     reconcile_rows = load_reconcile_rows(tx, worker_addresses.keys()) if worker_addresses else []

--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -13,13 +13,10 @@ over an in-memory ``SchedulingContext``.
 import logging
 import sys
 from collections import defaultdict
-from collections.abc import Sequence
 from collections.abc import Set as AbstractSet
 from dataclasses import dataclass, replace
-from typing import Any
 
 from rigging.log_setup import slow_log
-from sqlalchemy import Row, bindparam, select
 
 from iris.cluster.constraints import (
     AttributeValue,
@@ -32,7 +29,7 @@ from iris.cluster.constraints import (
     merge_constraints,
     split_hard_soft,
 )
-from iris.cluster.controller import db, reads, writes
+from iris.cluster.controller import reads, writes
 from iris.cluster.controller.autoscaler.models import DemandEntry
 from iris.cluster.controller.budget import (
     UserTask,
@@ -63,12 +60,7 @@ from iris.cluster.controller.scheduling.scheduler import (
     WorkerSnapshot,
     worker_snapshot_from_row,
 )
-from iris.cluster.controller.schema import (
-    ReservationClaim,
-    job_config_table,
-    jobs_table,
-    tasks_table,
-)
+from iris.cluster.controller.schema import ReservationClaim
 from iris.cluster.controller.task_state import job_scheduling_deadline, task_row_can_be_scheduled
 from iris.cluster.controller.worker_health import WorkerHealthTracker
 from iris.cluster.types import (
@@ -215,12 +207,15 @@ def compute_demand_entries(
     demand_entries: list[DemandEntry] = []
 
     # Single combined query: each row carries task + job + job_config columns.
-    # task_row_can_be_scheduled() is already applied inside _pending_tasks_with_jobs.
+    # task_row_can_be_scheduled() is already applied inside reads.pending_tasks_with_jobs.
     tasks_by_job: dict[JobName, list[PendingTask]] = defaultdict(list)
     all_schedulable: list[PendingTask] = []
     with queries.read_snapshot() as tx:
-        pending = _pending_tasks_with_jobs(tx)
-        reservation_entry_counts = _reservation_entry_counts_for_pending(tx, pending)
+        pending = reads.pending_tasks_with_jobs(tx)
+        reservation_entry_counts = reads.reservation_entry_counts(tx, {t.job_id for t in pending if t.has_reservation})
+        # Pre-fetch the reserved-job set in the same snapshot so the per-task
+        # ancestor walk below is pure Python, not one SQL round trip per job.
+        reserved_jobs = reads.reserved_job_ids(tx)
     for task in pending:
         tasks_by_job[task.job_id].append(task)
         all_schedulable.append(task)
@@ -232,9 +227,6 @@ def compute_demand_entries(
 
     # Build job requirements once, shared between dry-run and demand emission.
     # Also track which jobs have reservations so we can apply taint injection.
-    # Pre-fetch the reserved-job set once so the per-task ancestor walk is
-    # pure Python instead of one SQL round trip per unique pending job.
-    reserved_jobs = _reserved_job_ids(queries)
     jobs: dict[JobName, JobRequirements] = {}
     has_reservation: set[JobName] = set()
     has_direct_reservation: set[JobName] = set()
@@ -363,93 +355,6 @@ def read_reservation_claims(db: ControllerDB) -> dict[WorkerId, ReservationClaim
         return reads.list_claims(tx)
 
 
-def _row_to_pending_task(row: Any) -> PendingTask:
-    return PendingTask(
-        task_id=row.task_id,
-        job_id=row.job_id,
-        state=int(row.state),
-        current_attempt_id=int(row.current_attempt_id),
-        failure_count=int(row.failure_count),
-        preemption_count=int(row.preemption_count),
-        max_retries_failure=int(row.max_retries_failure),
-        max_retries_preemption=int(row.max_retries_preemption),
-        submitted_at_ms=row.submitted_at_ms,
-        priority_band=int(row.priority_band),
-        priority_neg_depth=int(row.priority_neg_depth),
-        priority_root_submitted_ms=int(row.priority_root_submitted_ms),
-        priority_insertion=int(row.priority_insertion),
-        job_state=int(row.job_state),
-        scheduling_deadline_epoch_ms=row.scheduling_deadline_epoch_ms,
-        is_reservation_holder=bool(row.is_reservation_holder),
-        has_reservation=bool(row.has_reservation),
-        scheduling_timeout_ms=row.scheduling_timeout_ms,
-        has_coscheduling=bool(row.has_coscheduling),
-        coscheduling_group_by=row.coscheduling_group_by,
-        constraints_json=row.constraints_json,
-        res_cpu_millicores=int(row.res_cpu_millicores),
-        res_memory_bytes=int(row.res_memory_bytes),
-        res_disk_bytes=int(row.res_disk_bytes),
-        res_device_json=row.res_device_json,
-    )
-
-
-def _pending_tasks_with_jobs(tx: Tx) -> list[PendingTask]:
-    """Return scheduling inputs for pending tasks, joining task + job + job_config in one query."""
-    rows = tx.execute(
-        select(
-            *reads.PENDING_TASK_COLS,
-            # job columns (label job_state to avoid clash with tasks.state)
-            jobs_table.c.state.label("job_state"),
-            jobs_table.c.scheduling_deadline_epoch_ms,
-            jobs_table.c.is_reservation_holder,
-            jobs_table.c.has_reservation,
-            # job_config columns
-            job_config_table.c.scheduling_timeout_ms,
-            job_config_table.c.has_coscheduling,
-            job_config_table.c.coscheduling_group_by,
-            job_config_table.c.constraints_json,
-            job_config_table.c.res_cpu_millicores,
-            job_config_table.c.res_memory_bytes,
-            job_config_table.c.res_disk_bytes,
-            job_config_table.c.res_device_json,
-        )
-        .select_from(
-            tasks_table.join(jobs_table, jobs_table.c.job_id == tasks_table.c.job_id).join(
-                job_config_table, job_config_table.c.job_id == tasks_table.c.job_id
-            )
-        )
-        .where(tasks_table.c.state == bindparam("state"))
-        .order_by(
-            tasks_table.c.priority_neg_depth.asc(),
-            tasks_table.c.priority_root_submitted_ms.asc(),
-            tasks_table.c.submitted_at_ms.asc(),
-            tasks_table.c.priority_insertion.asc(),
-        ),
-        {"state": job_pb2.TASK_STATE_PENDING},
-    ).all()
-    pending_tasks = [_row_to_pending_task(row) for row in rows]
-    return [task for task in pending_tasks if task_row_can_be_scheduled(task)]
-
-
-def _jobs_with_reservations(queries: ControllerDB, states: tuple[int, ...]) -> Sequence[Row]:
-    """Fetch (job_id, reservation_json) for jobs that hold a reservation.
-
-    Per-tick hot path: only decode what the reservation-claim recomputation
-    reads. Filters via ``jobs.has_reservation`` (no scan of ``job_config``)
-    and joins ``job_config`` solely to pull ``reservation_json``.
-    """
-    with db.read_snapshot(queries.sa_read_engine) as tx:
-        return tx.execute(
-            select(jobs_table.c.job_id, job_config_table.c.reservation_json)
-            .select_from(jobs_table.join(job_config_table, jobs_table.c.job_id == job_config_table.c.job_id))
-            .where(
-                jobs_table.c.state.in_(bindparam("states", expanding=True)),
-                jobs_table.c.has_reservation == 1,
-            ),
-            {"states": list(states)},
-        ).all()
-
-
 def get_running_tasks_with_band_and_value(
     db: ControllerDB,
     claimed_workers: set[WorkerId],
@@ -471,25 +376,12 @@ def get_running_tasks_with_band_and_value(
 
 
 def _running_tasks_with_band_and_value(tx: Tx, claimed_workers: set[WorkerId]) -> list[RunningTaskInfo]:
-    """Read running-task band/value/resource info from an already-open snapshot."""
-    rows = tx.execute(
-        select(
-            tasks_table.c.task_id,
-            tasks_table.c.priority_band,
-            tasks_table.c.current_worker_id.label("worker_id"),
-            job_config_table.c.res_cpu_millicores,
-            job_config_table.c.res_memory_bytes,
-            job_config_table.c.res_disk_bytes,
-            job_config_table.c.res_device_json,
-            job_config_table.c.has_coscheduling,
-        )
-        .select_from(tasks_table.join(job_config_table, tasks_table.c.job_id == job_config_table.c.job_id))
-        .where(
-            tasks_table.c.state == bindparam("state"),
-            tasks_table.c.current_worker_id.is_not(None),
-        ),
-        {"state": job_pb2.TASK_STATE_RUNNING},
-    ).all()
+    """Map the running-task band/resource rows into :class:`RunningTaskInfo`.
+
+    Skips tasks on reservation-claimed workers, since those workers are spoken
+    for and must not be considered as preemption victims.
+    """
+    rows = reads.running_task_band_rows(tx)
     result: list[RunningTaskInfo] = []
     for row in rows:
         wid = row.worker_id
@@ -703,24 +595,6 @@ def run_preemption_pass(
     return preemptions
 
 
-def _job_state_by_id(queries: ControllerDB, job_ids: set[JobName]) -> dict[JobName, int]:
-    """Fetch only ``jobs.state`` for the given job IDs.
-
-    Intentionally narrow: only callers that need job state (not resources or
-    config) should use this to avoid over-fetching.
-    """
-    if not job_ids:
-        return {}
-    with queries.read_snapshot() as tx:
-        rows = tx.execute(
-            select(jobs_table.c.job_id, jobs_table.c.state).where(
-                jobs_table.c.job_id.in_(bindparam("job_ids", expanding=True))
-            ),
-            {"job_ids": list(job_ids)},
-        ).all()
-    return {row.job_id: int(row.state) for row in rows}
-
-
 def _sort_pending_tasks_by_resolved_band(
     pending_tasks: list[PendingTask], requested_bands: dict[JobName, int]
 ) -> list[PendingTask]:
@@ -772,7 +646,8 @@ def cleanup_stale_claims(
     """
     active_worker_ids = {wid for wid, lease in health.all().items() if lease.active}
     claimed_job_ids = {JobName.from_wire(claim.job_id) for claim in claims.values()}
-    job_states = _job_state_by_id(db, claimed_job_ids)
+    with db.read_snapshot() as tx:
+        job_states = reads.job_states_by_id(tx, claimed_job_ids)
     stale: list[WorkerId] = []
     for worker_id, claim in claims.items():
         if worker_id not in active_worker_ids:
@@ -800,16 +675,16 @@ def claim_workers_for_reservations(
     """
     claimed_entries: set[tuple[str, int]] = {(c.job_id, c.entry_idx) for c in claims.values()}
     claimed_worker_ids: set[WorkerId] = set(claims.keys())
-    with db.read_snapshot() as tx:
-        all_workers = reads.healthy_active_workers_with_attributes(tx, health, worker_attrs)
-    changed = False
-
     reservable_states = (
         job_pb2.JOB_STATE_PENDING,
         job_pb2.JOB_STATE_BUILDING,
         job_pb2.JOB_STATE_RUNNING,
     )
-    reservation_jobs = _jobs_with_reservations(db, reservable_states)
+    with db.read_snapshot() as tx:
+        all_workers = reads.healthy_active_workers_with_attributes(tx, health, worker_attrs)
+        reservation_jobs = reads.jobs_with_reservations(tx, reservable_states)
+    changed = False
+
     for job in reservation_jobs:
         job_wire = job.job_id.to_wire()
         for idx, res_entry in enumerate(reservation_entries_from_json(job.reservation_json)):
@@ -929,22 +804,6 @@ def inject_taint_constraints(
     return modified
 
 
-def _reserved_job_ids_in_tx(tx: Tx) -> set[JobName]:
-    """Job_ids with ``has_reservation = 1``, read from an open snapshot ``tx``."""
-    rows = tx.execute(select(jobs_table.c.job_id).where(jobs_table.c.has_reservation == 1)).all()
-    return {row.job_id for row in rows}
-
-
-def _reserved_job_ids(queries: ControllerDB) -> set[JobName]:
-    """Return the set of job_ids with ``has_reservation = 1`` on the jobs table.
-
-    Callers use this to drive :func:`_find_reservation_ancestor` purely in
-    Python instead of issuing one SQL chain-walk per pending job.
-    """
-    with queries.read_snapshot() as tx:
-        return _reserved_job_ids_in_tx(tx)
-
-
 def _find_reservation_ancestor(reserved_jobs: AbstractSet[JobName], job_id: JobName) -> JobName | None:
     """Walk up the job hierarchy to find the nearest ancestor with a reservation.
 
@@ -1059,14 +918,16 @@ def build_scheduling_context(
     """
     with slow_log(logger, "scheduling tick context", threshold_ms=50):
         with queries.read_snapshot() as snap:
-            pending = _pending_tasks_with_jobs(snap)
+            pending = reads.pending_tasks_with_jobs(snap)
             workers = reads.healthy_active_workers_with_attributes(snap, health, worker_attrs)
             usage_by_worker = reads.resource_usage_by_worker(snap)
             user_spend = compute_user_spend(snap)
             user_budget_limits = reads.get_all_user_budget_limits(snap)
             requested_bands = reads.get_priority_bands(snap, {t.job_id for t in pending})
-            reserved_jobs = _reserved_job_ids_in_tx(snap)
-            reservation_entry_counts = _reservation_entry_counts_for_pending(snap, pending)
+            reserved_jobs = reads.reserved_job_ids(snap)
+            reservation_entry_counts = reads.reservation_entry_counts(
+                snap, {t.job_id for t in pending if t.has_reservation}
+            )
             building_counts = reads.building_counts(snap, [w.worker_id for w in workers])
             running = _running_tasks_with_band_and_value(snap, set(claims.keys()))
 
@@ -1088,25 +949,6 @@ def build_scheduling_context(
         user_budget_defaults=defaults,
         running_for_preemption=running,
     )
-
-
-def _reservation_entry_counts_for_pending(tx: Tx, pending: list[PendingTask]) -> dict[JobName, int]:
-    """Return reservation entry counts for pending jobs that hold a reservation."""
-    job_ids = {t.job_id for t in pending if t.has_reservation}
-    if not job_ids:
-        return {}
-    rows = tx.execute(
-        select(job_config_table.c.job_id, job_config_table.c.reservation_json).where(
-            job_config_table.c.job_id.in_(bindparam("job_ids", expanding=True))
-        ),
-        {"job_ids": list(job_ids)},
-    ).all()
-    counts: dict[JobName, int] = {}
-    for row in rows:
-        if row.reservation_json is None:
-            continue
-        counts[row.job_id] = len(reservation_entries_from_json(row.reservation_json))
-    return counts
 
 
 def apply_scheduling_gates(

--- a/lib/iris/tests/cluster/controller/test_perf_baselines.py
+++ b/lib/iris/tests/cluster/controller/test_perf_baselines.py
@@ -3,7 +3,7 @@
 
 """Performance baselines for the SA Core data-layer migration.
 
-Gates the SA Core path of ``_jobs_with_reservations`` and the scheduler
+Gates the SA Core path of ``reads.jobs_with_reservations`` and the scheduler
 reads (``resource_usage_by_worker`` and the inline reconcile-rows query)
 against a fixed workload to catch regressions. The legacy comparison path
 has been deleted — only the SA Core timings are measured.
@@ -18,7 +18,6 @@ from time import perf_counter
 import pytest
 from iris.cluster.controller import db, ops, reads
 from iris.cluster.controller.db import ControllerDB
-from iris.cluster.controller.scheduling.policy import _jobs_with_reservations
 from iris.cluster.controller.schema import task_attempts_table, tasks_table
 from iris.cluster.types import JobName, WorkerId
 from iris.rpc import controller_pb2, job_pb2
@@ -107,11 +106,12 @@ def _measure(callable_, ticks: int) -> float:
 
 
 def test_jobs_with_reservations_perf(seeded_db: ControllerDB) -> None:
-    """Gate SA _jobs_with_reservations below a fixed µs ceiling."""
+    """Gate SA reads.jobs_with_reservations below a fixed µs ceiling."""
     states = (job_pb2.JOB_STATE_RUNNING,)
 
     def _sa_call() -> int:
-        return len(_jobs_with_reservations(seeded_db, states))
+        with seeded_db.read_snapshot() as tx:
+            return len(reads.jobs_with_reservations(tx, states))
 
     assert _sa_call() == _RESERVATION_JOB_COUNT
 
@@ -119,7 +119,7 @@ def test_jobs_with_reservations_perf(seeded_db: ControllerDB) -> None:
     max_us = _SA_JOBS_WITH_RESERVATIONS_MAX_US
 
     assert sa_per_call * 1e6 <= max_us, (
-        f"SA _jobs_with_reservations too slow: "
+        f"SA reads.jobs_with_reservations too slow: "
         f"sa={sa_per_call * 1e6:.1f} µs/call > {max_us} µs gate "
         f"(200 reservation-holders + 200 plain jobs; {_TICKS} iterations)."
     )

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -13,7 +13,6 @@ from iris.cluster.controller.reconcile.task import TerminalDecision, TerminalKin
 from iris.cluster.controller.reconcile.task import resolve_task_failure_state as _resolve_task_failure_state
 from iris.cluster.controller.scheduling.policy import (
     PreemptionCandidate,
-    _pending_tasks_with_jobs,
     _sort_pending_tasks_by_resolved_band,
     get_running_tasks_with_band_and_value,
     run_preemption_pass,
@@ -935,7 +934,7 @@ def test_pending_child_order_uses_parent_job_config_not_stamped_task_band():
         assert child_task.priority_band == job_pb2.PRIORITY_BAND_INTERACTIVE
 
         with state._db.read_snapshot() as tx:
-            pending = _pending_tasks_with_jobs(tx)
+            pending = reads.pending_tasks_with_jobs(tx)
             bands = reads.get_priority_bands(tx, {t.job_id for t in pending})
         ordered = _sort_pending_tasks_by_resolved_band(pending, bands)
         ordered_ids = [task.task_id for task in ordered]

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -23,7 +23,7 @@ from iris.cluster.constraints import (
     get_device_variant,
     preemptible_constraint,
 )
-from iris.cluster.controller import ops, writes
+from iris.cluster.controller import ops, reads, writes
 from iris.cluster.controller.codec import constraints_from_json
 from iris.cluster.controller.controller import (
     Controller,
@@ -36,7 +36,6 @@ from iris.cluster.controller.reconcile.snapshot import TaskUpdate
 from iris.cluster.controller.scheduling.policy import (
     RESERVATION_TAINT_KEY,
     _find_reservation_ancestor,
-    _reserved_job_ids,
     _worker_matches_reservation_entry,
     apply_scheduling_gates,
     build_scheduling_context,
@@ -96,6 +95,12 @@ from tests.cluster.controller.conftest import (
     worker_running_tasks as _worker_running_tasks,
 )
 from tests.cluster.controller.transition_driver import WorkerTaskUpdates, apply_task_observations
+
+
+def _reserved_job_ids(db) -> set[JobName]:
+    """Test helper: read the reserved-job set through reads in a fresh snapshot."""
+    with db.read_snapshot() as tx:
+        return reads.reserved_job_ids(tx)
 
 
 def _cpu_device() -> job_pb2.DeviceConfig:

--- a/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
+++ b/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
@@ -11,7 +11,6 @@ from iris.cluster.controller.controller import (
     SchedulingOutcome,
 )
 from iris.cluster.controller.scheduling.policy import (
-    _pending_tasks_with_jobs,
     _sort_pending_tasks_by_resolved_band,
 )
 from iris.cluster.controller.schema import user_budgets_table
@@ -40,13 +39,13 @@ def _submit_user_job(state, user: str, name: str, replicas: int = 1, band: int |
 def _pending(state):
     """Test helper: read pending tasks within a fresh snapshot."""
     with state._db.read_snapshot() as tx:
-        return _pending_tasks_with_jobs(tx)
+        return reads.pending_tasks_with_jobs(tx)
 
 
 def _pending_sorted(state):
     """Test helper: pending tasks resorted by resolved priority band."""
     with state._db.read_snapshot() as tx:
-        tasks = _pending_tasks_with_jobs(tx)
+        tasks = reads.pending_tasks_with_jobs(tx)
         bands = reads.get_priority_bands(tx, {t.job_id for t in tasks})
     return _sort_pending_tasks_by_resolved_band(tasks, bands)
 


### PR DESCRIPTION
Makes reads.py the single DB fan-out point for the controller's control cycle. The controller now builds one typed `ControlSnapshot` per reconcile cycle through reads.py, and no control-path module issues raw schema queries. This concentrates per-cycle DB access at a single auditable boundary instead of scattering raw SQLAlchemy across controller.py, scheduling/policy.py, budget.py, and checkpoint.py.

## ControlSnapshot

`reads.ControlSnapshot` carries the per-cycle DB state the reconcile tick consumes — active worker addresses, live `(task, attempt, worker)` reconcile rows, and the optional execution-timeout rows — built by `reads.load_control_snapshot` in one read transaction. The controller's in-memory `WorkerHealthTracker` is the one non-DB field: it scopes the live-worker set and rides along on the snapshot, so the reconcile apply path (`apply_reconcile` / `finalize`) consumes the same liveness view that scoped the snapshot rather than reading it from a side channel. Health is never persisted, so it is supplied by the controller, not the DB.

## Queries moved behind reads.py

- controller.py: the reconcile-input join, the execution-timeout deadline scan, and the seed-liveness scan move to `load_reconcile_rows`, `scan_execution_timeout_rows`, and `all_worker_ids`. `_reconcile_tick` derives `ReconcileInputs` and timeout decisions from the snapshot; the timeout-decision logic is now a pure helper.
- scheduling/policy.py: the six policy selects move to `pending_tasks_with_jobs`, `reserved_job_ids`, `reservation_entry_counts`, `jobs_with_reservations`, `job_states_by_id`, and `running_task_band_rows`. The scheduler/budget-typed mapping (`RunningTaskInfo`, `resource_value`) stays in policy so reads.py keeps no upward imports.
- budget.py / checkpoint.py: user-spend and row-count queries move to `reads.user_spend_rows` and `reads.row_counts`.

After this, controller.py, scheduling/policy.py, budget.py, and checkpoint.py issue no raw schema queries; reads.py, writes.py, and the projections are the only DB fan-out point on the control path. Call sites — including tests that imported the former policy privates — are updated with no compatibility shims.

## Out of scope

Only the control-cycle chokepoint changes. The uniform backend interface, Scheduler merge / demand path, single control tick, RPC timeout bounding, and relocating worker-health observation into the backend are untouched, as are query sites that are their own subsystems (service.py RPC handlers, auth, ops, autoscaler persistence, reconcile commit/dispatch).