### PR TITLE
PRISM optimizer update

### DIFF
--- a/experiments/speedrun/prism_berkeley_qwen3_scaling/prism_berkeley_optimizer.py
+++ b/experiments/speedrun/prism_berkeley_qwen3_scaling/prism_berkeley_optimizer.py
@@ -68,12 +68,16 @@ def _grid_search_quartic_argmin(
 
 
 def _trace_sketch_powers(residual: jax.Array, sketch: jax.Array, max_power: int) -> dict[int, jax.Array]:
-    sketch_t = sketch.T.astype(jnp.float32)
-    current = sketch_t
+    sketch = sketch.astype(residual.dtype)
+    sketches= {}
+    sketches[1] = residual @ sketch
+    for power in range(2, max_power + 1):
+        sketches[power] = residual @ sketches[power - 1]
     traces = {}
-    for power in range(1, max_power + 1):
-        current = residual @ current
-        traces[power] = jnp.sum(sketch_t * current)
+    for power in range(2, 2*max_power + 1):
+        i = power // 2
+        j = power // 2 + power % 2
+        traces[power] = jnp.sum(sketches[i] * sketches[j])
     return traces
 
 
@@ -84,7 +88,7 @@ def _prism_berkeley_alpha(
     order: PrismBerkeleyOrder,
     alpha_grid_points: int,
 ) -> jax.Array:
-    traces = _trace_sketch_powers(residual, sketch, 6 if order == 3 else 10)
+    traces = _trace_sketch_powers(residual, sketch, 3 if order == 3 else 5)
 
     if order == 3:
         c1 = 4.0 * traces[3] - 4.0 * traces[2]
@@ -109,7 +113,7 @@ def _prism_berkeley_alpha(
         alpha_min=alpha_min,
         alpha_max=alpha_max,
         grid_points=alpha_grid_points,
-    )
+    ).astype(residual.dtype)
 
 
 def _make_default_sketch(weight_shape: tuple[int, ...], sketch_size: int, key: jax.Array) -> jax.Array:
@@ -118,8 +122,8 @@ def _make_default_sketch(weight_shape: tuple[int, ...], sketch_size: int, key: j
 
     min_dim = min(weight_shape[-2:])
     effective_sketch = min(sketch_size, min_dim)
-    sketch_shape = (*weight_shape[:-2], effective_sketch, min_dim)
-    return jax.random.normal(key, sketch_shape, dtype=jnp.float32) / jnp.sqrt(effective_sketch)
+    sketch_shape = (*weight_shape[:-2], min_dim, effective_sketch)
+    return jax.random.normal(key, sketch_shape, dtype=jnp.bfloat16) / jnp.sqrt(effective_sketch)
 
 
 def _init_sketch_cache(params, *, sketch_size: int, seed: int):
@@ -139,6 +143,22 @@ def _init_sketch_cache(params, *, sketch_size: int, seed: int):
     return jax.tree_util.tree_unflatten(treedef, sketches)
 
 
+def _estimate_spectral_norm(
+    matrix: jax.Array,
+    sketch: jax.Array,
+    steps: int = 5
+) -> jax.Array:
+    """
+    Uses power iteration to estimate the spectral norm 
+    """
+    y = sketch[:,0]
+    for _ in range(steps):
+        y = matrix.T @ (matrix @ y)
+        y /= jnp.linalg.norm(y)
+    z = matrix @ y
+    return jnp.linalg.norm(z)
+    
+
 def _prism_berkeley_polar(
     matrix: jax.Array,
     sketch: jax.Array | None,
@@ -148,39 +168,45 @@ def _prism_berkeley_polar(
     eps: float,
     alpha_grid_points: int,
     fixed_alpha_steps: int,
+    use_spectral_norm: bool,
 ) -> jax.Array:
     chex.assert_rank(matrix, 2)
 
-    working = matrix.astype(jnp.float32)
-    working = working / (jnp.linalg.norm(working) + eps)
+    nrm1 = jnp.linalg.norm(matrix) + eps
+    working = matrix / nrm1
 
     transposed = False
     if working.shape[0] < working.shape[1]:
         working = working.T
         transposed = True
 
+    if use_spectral_norm:
+        nrm2 = _estimate_spectral_norm(working, sketch)
+        working = jnp.where(nrm2 < 0.66, working / (1.5 * nrm2), working)
+
     min_dim = working.shape[1]
     if sketch is None:
         raise ValueError("PRISM-Berkeley expected a cached sketch for a linear layer, but received None.")
     if sketch.ndim != 2:
         raise ValueError(f"PRISM-Berkeley expected a rank-2 sketch, got shape {sketch.shape}.")
-    if sketch.shape[1] != min_dim:
+    if sketch.shape[0] != min_dim:
         raise ValueError(f"PRISM-Berkeley sketch shape {sketch.shape} is incompatible with min_dim={min_dim}.")
-    sketch = sketch.astype(jnp.float32)
+    sketch = sketch.astype(working.dtype)
 
-    identity = jnp.eye(min_dim, dtype=jnp.float32)
+    identity = jnp.eye(min_dim, dtype=working.dtype)
     fixed_alpha = 1.0 if order == 3 else 29.0 / 20.0
 
     for step_idx in range(steps):
         residual = identity - working.T @ working
-        alpha = lax_cond_fixed_or_adaptive(
-            step_idx < fixed_alpha_steps,
-            fixed_alpha,
-            residual,
-            sketch,
-            order,
-            alpha_grid_points,
-        )
+        if step_idx < fixed_alpha_steps:
+            alpha = fixed_alpha
+        else:
+            alpha = _prism_berkeley_alpha(
+                residual,
+                sketch,
+                order=order,
+                alpha_grid_points=alpha_grid_points,
+            )
         if order == 3:
             transform = identity + alpha * residual
         else:
@@ -191,7 +217,7 @@ def _prism_berkeley_polar(
     if transposed:
         working = working.T
 
-    return working.astype(matrix.dtype)
+    return working
 
 
 def lax_cond_fixed_or_adaptive(
@@ -204,7 +230,7 @@ def lax_cond_fixed_or_adaptive(
 ) -> jax.Array:
     return jax.lax.cond(
         jnp.asarray(use_fixed),
-        lambda _: jnp.asarray(fixed_alpha, dtype=jnp.float32),
+        lambda _: jnp.asarray(fixed_alpha, dtype=residual.dtype),
         lambda _: _prism_berkeley_alpha(
             residual,
             sketch,
@@ -226,10 +252,11 @@ def scale_with_prism_berkeley(
     steps=5,
     muon_eps=1e-8,
     use_kimi_scaling=False,
-    order: PrismBerkeleyOrder = 3,
+    order: PrismBerkeleyOrder = 5,
     alpha_grid_points: int = 65,
     fixed_alpha_steps: int = 0,
-    sketch_size: int = 5,
+    use_spectral_norm: bool = True,
+    sketch_size: int = 8,
     sketch_seed: int = 0,
 ):
     steps = int(steps)
@@ -280,6 +307,7 @@ def scale_with_prism_berkeley(
                 eps=muon_eps,
                 alpha_grid_points=alpha_grid_points,
                 fixed_alpha_steps=fixed_alpha_steps,
+                use_spectral_norm=use_spectral_norm,
             )
             transformed_weight_array = normalize_2d_update_fro_norm(transformed_weight_array)
 
@@ -322,10 +350,11 @@ class PrismBerkeleyConfig(OptimizerConfig):
     adamc_weight_decay: bool = False
     max_grad_norm: float = 1.0
     use_kimi_scaling: bool = False
-    order: PrismBerkeleyOrder = 3
+    order: PrismBerkeleyOrder = 5
     alpha_grid_points: int = 65
     fixed_alpha_steps: int = 0
-    sketch_size: int = 5
+    use_spectral_norm: bool = True
+    sketch_size: int = 8
     sketch_seed: int = 0
 
     def build(self, num_train_steps):

--- a/experiments/speedrun/prism_berkeley_qwen3_scaling/prism_berkeley_optimizer.py
+++ b/experiments/speedrun/prism_berkeley_qwen3_scaling/prism_berkeley_optimizer.py
@@ -146,7 +146,7 @@ def _init_sketch_cache(params, *, sketch_size: int, seed: int):
 def _estimate_spectral_norm(
     matrix: jax.Array,
     sketch: jax.Array,
-    steps: int = 5
+    steps: int = 10
 ) -> jax.Array:
     """
     Uses power iteration to estimate the spectral norm 
@@ -220,27 +220,6 @@ def _prism_berkeley_polar(
     return working
 
 
-def lax_cond_fixed_or_adaptive(
-    use_fixed: bool,
-    fixed_alpha: float,
-    residual: jax.Array,
-    sketch: jax.Array,
-    order: PrismBerkeleyOrder,
-    alpha_grid_points: int,
-) -> jax.Array:
-    return jax.lax.cond(
-        jnp.asarray(use_fixed),
-        lambda _: jnp.asarray(fixed_alpha, dtype=residual.dtype),
-        lambda _: _prism_berkeley_alpha(
-            residual,
-            sketch,
-            order=order,
-            alpha_grid_points=alpha_grid_points,
-        ),
-        operand=None,
-    )
-
-
 class ScaleByPrismBerkeleyState(NamedTuple):
     momentum_buffer: optax.Updates
     sketch_cache: optax.Updates
@@ -250,12 +229,12 @@ def scale_with_prism_berkeley(
     momentum=0.95,
     nesterov=True,
     steps=5,
-    muon_eps=1e-8,
+    muon_eps=1e-7,
     use_kimi_scaling=False,
     order: PrismBerkeleyOrder = 5,
     alpha_grid_points: int = 65,
     fixed_alpha_steps: int = 0,
-    use_spectral_norm: bool = True,
+    use_spectral_norm: bool = False,
     sketch_size: int = 8,
     sketch_seed: int = 0,
 ):
@@ -333,6 +312,126 @@ def scale_with_prism_berkeley(
     return optax.GradientTransformation(init_fn, update_fn)
 
 
+def _prism_berkeley_approx_polar(
+    matrix: jax.Array,
+    *,
+    steps: int,
+    eps: float,
+    use_omega_scaling: bool,
+) -> jax.Array:
+
+    chex.assert_rank(matrix, 2)
+
+    if use_omega_scaling:
+        working = matrix / (jnp.linalg.norm(matrix, axis=0) + eps)
+        working = working / jnp.linalg.norm(working)
+    else:
+        working = matrix / (jnp.linalg.norm(matrix) + eps)
+    
+    transposed = False
+    if working.shape[0] < working.shape[1]:
+        working = working.T
+        transposed = True
+
+    working = working.astype(jnp.float32)
+    identity = jnp.eye(working.shape[1], dtype=working.dtype)
+    
+    # PRISM Newton step
+    working_t = working.T
+    working_sq = working_t @ working + 1e-5 * identity
+    cho_factor = jax.lax.linalg.cholesky(working_sq, symmetrize_input=False)
+    update = jax.lax.linalg.triangular_solve(
+        cho_factor, working_t, left_side=True, lower=True, transpose_a=False,
+    )
+    update = jax.lax.linalg.triangular_solve(
+        cho_factor, update, left_side=True, lower=True, transpose_a=True,
+    )
+    update = update.T
+    working = 0.66 * working + 0.006666 * update
+
+    # PRISM Newton-Schulz step
+    working = working.astype(jnp.bfloat16)
+    identity = identity.astype(jnp.bfloat16)
+    for _ in range(2):
+        residual = identity - working.T @ working
+        working = working + 0.5 * working @ residual + 1.45 * working @ (residual @ residual)
+
+    if transposed:
+        working = working.T
+
+    return working
+
+
+class ScaleByApproxPrismBerkeleyState(NamedTuple):
+    momentum_buffer: optax.Updates
+
+
+def scale_with_approx_prism_berkeley(
+    momentum=0.95,
+    nesterov=True,
+    steps=2,
+    muon_eps=1e-7,
+    use_omega_scaling=True,
+    use_kimi_scaling=False,
+):
+    steps = int(steps)
+
+    def init_fn(params):
+        return ScaleByApproxPrismBerkeleyState(
+            momentum_buffer=otu.tree_zeros_like(params),
+        )
+
+    def update_fn(updates, state, params=None):
+        del params
+
+        grad_coeff = 1.0 - momentum
+        momentum_buffer = jax.tree.map(
+            lambda m, g: None if g is None else momentum * m + grad_coeff * g,
+            state.momentum_buffer,
+            updates,
+            is_leaf=lambda x: x is None,
+        )
+        if nesterov:
+            updates = jax.tree.map(
+                lambda m, g: None if g is None else momentum * m + grad_coeff * g,
+                momentum_buffer,
+                updates,
+                is_leaf=lambda x: x is None,
+            )
+        else:
+            updates = momentum_buffer
+
+        def transform_linear_layer(layer: haliax.nn.Linear, sketch: jax.Array | None):
+            assert layer.weight.ndim == 2
+            transformed_weight_array = _prism_berkeley_approx_polar(
+                layer.weight.array,
+                steps=steps,
+                eps=muon_eps,
+                use_omega_scaling=use_omega_scaling,
+            )
+            transformed_weight_array = normalize_2d_update_fro_norm(transformed_weight_array)
+
+            if not use_kimi_scaling:
+                scale = jnp.sqrt(jnp.maximum(1, transformed_weight_array.shape[0] / transformed_weight_array.shape[1]))
+            else:
+                scale = 0.2 * jnp.sqrt(jnp.maximum(transformed_weight_array.shape[0], transformed_weight_array.shape[1]))
+            transformed_weight_array = transformed_weight_array * scale
+
+            return dataclasses.replace(
+                layer,
+                weight=dataclasses.replace(
+                    layer.weight, array=transformed_weight_array.astype(layer.weight.array.dtype)
+                ),
+            )
+
+        transformed_updates = map_flattened_linear_layers(transform_linear_layer, updates, state.sketch_cache)
+        return transformed_updates, ScaleByApproxPrismBerkeleyState(
+            momentum_buffer=momentum_buffer,
+        )
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
 @OptimizerConfig.register_subclass("prism_berkeley")
 @dataclass(frozen=True)
 class PrismBerkeleyConfig(OptimizerConfig):
@@ -340,20 +439,21 @@ class PrismBerkeleyConfig(OptimizerConfig):
     adam_lr: float = 6e-4
     momentum: float = 0.95
     nesterov: bool = True
-    backend_steps: int = 5
+    backend_steps: int = 2
     weight_decay: float = 0.0
     adam_weight_decay: float | None = None
     beta1: float = 0.9
     beta2: float = 0.95
     epsilon: float = 1e-8
-    muon_epsilon: float = 1e-8
+    muon_epsilon: float = 1e-7
     adamc_weight_decay: bool = False
     max_grad_norm: float = 1.0
     use_kimi_scaling: bool = False
     order: PrismBerkeleyOrder = 5
     alpha_grid_points: int = 65
     fixed_alpha_steps: int = 0
-    use_spectral_norm: bool = True
+    use_spectral_norm: bool = False
+    use_omega_scaling: bool = True
     sketch_size: int = 8
     sketch_seed: int = 0
 
@@ -384,19 +484,27 @@ class PrismBerkeleyConfig(OptimizerConfig):
         def optimizer(learning_rate, adam_lr, weight_decay, adam_weight_decay):
             def prism_berkeley_transform():
                 components = [
-                    scale_with_prism_berkeley(
+                    # scale_with_prism_berkeley(
+                    #     self.momentum,
+                    #     self.nesterov,
+                    #     self.backend_steps,
+                    #     self.muon_epsilon,
+                    #     self.use_kimi_scaling,
+                    #     self.order,
+                    #     self.alpha_grid_points,
+                    #     self.fixed_alpha_steps,
+                    #     self.use_spectral_norm,
+                    #     self.sketch_size,
+                    #     self.sketch_seed,
+                    # ),
+                    scale_with_approx_prism_berkeley(
                         self.momentum,
                         self.nesterov,
                         self.backend_steps,
                         self.muon_epsilon,
+                        self.use_omega_scaling,
                         self.use_kimi_scaling,
-                        self.order,
-                        self.alpha_grid_points,
-                        self.fixed_alpha_steps,
-                        self.use_spectral_norm,
-                        self.sketch_size,
-                        self.sketch_seed,
-                    ),
+                    )
                     optax.add_decayed_weights(weight_decay, self.build_weight_decay_mask()),
                     optax.scale(-learning_rate),
                 ]

--- a/experiments/speedrun/prism_berkeley_qwen3_scaling/prism_berkeley_optimizer.py
+++ b/experiments/speedrun/prism_berkeley_qwen3_scaling/prism_berkeley_optimizer.py
@@ -393,6 +393,7 @@ class PrismBerkeleyConfig(OptimizerConfig):
                         self.order,
                         self.alpha_grid_points,
                         self.fixed_alpha_steps,
+                        self.use_spectral_norm,
                         self.sketch_size,
                         self.sketch_seed,
                     ),

--- a/experiments/speedrun/prism_berkeley_qwen3_scaling/prism_berkeley_optimizer.py
+++ b/experiments/speedrun/prism_berkeley_qwen3_scaling/prism_berkeley_optimizer.py
@@ -401,7 +401,7 @@ def scale_with_approx_prism_berkeley(
         else:
             updates = momentum_buffer
 
-        def transform_linear_layer(layer: haliax.nn.Linear, sketch: jax.Array | None):
+        def transform_linear_layer(layer: haliax.nn.Linear):
             assert layer.weight.ndim == 2
             transformed_weight_array = _prism_berkeley_approx_polar(
                 layer.weight.array,
@@ -424,7 +424,7 @@ def scale_with_approx_prism_berkeley(
                 ),
             )
 
-        transformed_updates = map_flattened_linear_layers(transform_linear_layer, updates, state.sketch_cache)
+        transformed_updates = map_flattened_linear_layers(transform_linear_layer, updates)
         return transformed_updates, ScaleByApproxPrismBerkeleyState(
             momentum_buffer=momentum_buffer,
         )
@@ -504,7 +504,7 @@ class PrismBerkeleyConfig(OptimizerConfig):
                         self.muon_epsilon,
                         self.use_omega_scaling,
                         self.use_kimi_scaling,
-                    )
+                    ),
                     optax.add_decayed_weights(weight_decay, self.build_weight_decay_mask()),
                     optax.scale(-learning_rate),
                 ]

--- a/experiments/speedrun/prism_berkeley_qwen3_scaling/prism_berkeley_optimizer.py
+++ b/experiments/speedrun/prism_berkeley_qwen3_scaling/prism_berkeley_optimizer.py
@@ -352,7 +352,7 @@ def _prism_berkeley_approx_polar(
     # PRISM Newton-Schulz step
     working = working.astype(jnp.bfloat16)
     identity = identity.astype(jnp.bfloat16)
-    for _ in range(2):
+    for _ in range(steps):
         residual = identity - working.T @ working
         working = working + 0.5 * working @ residual + 1.45 * working @ (residual @ residual)
 


### PR DESCRIPTION
Update PRISM implementation in prism_berkeley_optimizer.py. Major changes are:

- Updated _trace_sketch_powers(…) to use fewer number of matrix-matrix multiplies
- Due to the new trace power computation, we no longer need to transpose the sketch matrix. Therefore, the last two dimensions of the sketch matrices are swapped from the previous version of _make_default_sketch(...)
- Removed conversion and matrix multiply in jnp.float32
- Implemented a spectral norm based initialization for polar decomposition
- Replaced jax.lax.cond(...) for fixed alphas with if-else. jax.lax.cond(...) seems to be up to 100x slower than if-else on A100 GPUs with respect to wall-clock time. Since we are not benchmarking with respect to wall-clock time, not sure if this will have any influence