### PR TITLE
[iris] Sweep terminal Kueue gang pods promptly so TAS reservations release

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/fake.py
@@ -701,10 +701,10 @@ class InMemoryK8sService:
         if resource is K8sResource.PODS:
             self._release_pod_resources(name)
 
-    def delete_many(self, resource: K8sResource, names: list[str], *, wait: bool = False) -> None:
+    def delete_many(self, resource: K8sResource, names: list[str], *, force: bool = False, wait: bool = False) -> None:
         """Delete multiple resources by name."""
         for name in names:
-            self.delete(resource, name)
+            self.delete(resource, name, force=force)
 
     def delete_by_labels(self, resource: K8sResource, labels: dict[str, str], *, wait: bool = False) -> None:
         """Delete all resources matching the given label selector."""

--- a/lib/iris/src/iris/cluster/backends/k8s/service.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/service.py
@@ -82,7 +82,7 @@ class K8sService(Protocol):
 
     def delete(self, resource: K8sResource, name: str, *, force: bool = False, wait: bool = True) -> None: ...
 
-    def delete_many(self, resource: K8sResource, names: list[str], *, wait: bool = False) -> None:
+    def delete_many(self, resource: K8sResource, names: list[str], *, force: bool = False, wait: bool = False) -> None:
         """Delete multiple resources by name."""
         ...
 
@@ -332,14 +332,14 @@ class CloudK8sService:
             except ApiException as e:
                 raise KubectlError(f"delete {resource.plural}/{name} failed ({e.status}): {e.reason}") from e
 
-    def delete_many(self, resource: K8sResource, names: list[str], *, wait: bool = False) -> None:
+    def delete_many(self, resource: K8sResource, names: list[str], *, force: bool = False, wait: bool = False) -> None:
         """Delete multiple resources by name."""
         if not names:
             return
-        logger.info("k8s: DELETE_MANY %s count=%d", resource.plural, len(names))
+        logger.info("k8s: DELETE_MANY %s count=%d force=%s", resource.plural, len(names), force)
         with slow_log(logger, f"delete_many {resource.plural} ({len(names)})", threshold_ms=_SLOW_THRESHOLD_MS):
             for name in names:
-                self.delete(resource, name, wait=wait)
+                self.delete(resource, name, force=force, wait=wait)
 
     def delete_by_labels(self, resource: K8sResource, labels: dict[str, str], *, wait: bool = False) -> None:
         """Delete all resources matching the given label selector."""

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -129,11 +129,10 @@ _KUEUE_PREFERRED_TOPOLOGY = "kueue.x-k8s.io/podset-preferred-topology"
 # but stamping it is harmless and required once a podset-topology annotation is
 # present. Sourced from the task ordinal (JobName.task_index).
 _KUEUE_POD_GROUP_POD_INDEX = "kueue.x-k8s.io/pod-group-pod-index"
-# Finalizer Kueue's pod integration stamps on admitted gang pods. It blocks pod
-# removal until Kueue reconciles the Workload; if a gang is torn down while pods
-# are wedged (containers exited, deletionTimestamp set), the finalizer keeps the
-# labeled pods alive, Kueue recreates the Workload from them, and the TAS
-# reservation leaks. Teardown and GC strip it to let the pods actually drain.
+# Pod finalizer Kueue's webhook stamps on admitted gang pods. Kueue only
+# strips it for pods it considers accounted for; on teardown Iris removes it
+# itself so the pod objects actually disappear instead of pinning the
+# pod-group Workload (Kueue rebuilds it from surviving labeled pods).
 _KUEUE_MANAGED_FINALIZER = "kueue.x-k8s.io/managed"
 
 # CoreWeave-convention fallback for KueueConfig.topologies: group_by -> (node
@@ -782,10 +781,21 @@ _ACTIVE_PODS_FIELD_SELECTOR = "status.phase!=Succeeded,status.phase!=Failed"
 _MANAGED_POD_LABELS = {_LABEL_MANAGED: "true", _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE}
 
 # Garbage collection: how often to run the terminal-pod cleanup pass (seconds).
-_GC_INTERVAL_SECONDS = 300  # 5 minutes
+# 1 minute bounds how long a wedged gang can pin idle GPU nodes (the pass is two
+# field-selector list calls, so the cadence is cheap).
+_GC_INTERVAL_SECONDS = 60
 
 # Garbage collection: delete terminal pods and orphaned configmaps/PDBs older than this (seconds).
 _GC_MAX_AGE_SECONDS = 3600  # 1 hour
+
+# Garbage collection: shorter retention for terminal gang (Kueue pod-group)
+# pods. Gang pods pin Kueue quota and the TAS topology reservation for as long
+# as they exist — Kueue rebuilds the pod-group Workload from surviving labeled
+# pods — so they cannot get the 1h debugging window plain pods do: every held
+# slot is an idle GPU node. 1 minute is still far above pod-status poll
+# latency (the reconcile loop runs every few seconds), so prompt deletion
+# cannot race exit-status collection.
+_GANG_GC_MAX_AGE_SECONDS = 60
 
 
 def _build_pod_statuses(pods: list[dict]) -> list[controller_pb2.Controller.KubernetesPodStatus]:
@@ -1558,19 +1568,9 @@ class K8sTaskProvider:
         if not stray_pod_names:
             return
 
-        # Strip Kueue's managed finalizer first so the delete actually drains the
-        # pod. Otherwise a wedged pod lingers, Kueue rebuilds the Workload from
-        # the still-labeled pod, and the TAS reservation never frees.
-        for pod_name in stray_gang_pod_names:
-            self.kubectl.remove_finalizer(K8sResource.PODS, pod_name, _KUEUE_MANAGED_FINALIZER)
         self.kubectl.delete_many(K8sResource.PODS, stray_pod_names, wait=False)
-        # Release the Kueue gang reservation for every torn-down generation.
-        # Kueue parks a coscheduled Workload in WaitingForReplacementPods when
-        # its pods are deleted, holding the quota until the Workload itself is
-        # removed; without this, a gang requeue (which bumps to a new
-        # pod-group generation) would deadlock behind the old generation's
-        # still-reserved quota.
-        self._delete_kueue_workloads(stray_pod_groups)
+        # The GC pass re-drives any gang pods that survive this teardown.
+        self._release_gang_reservations(stray_gang_pod_names, stray_pod_groups)
         # Enqueue task hashes for deferred configmap/PDB cleanup by the GC pass.
         self._pending_gc_hashes.update(stray_hashes)
 
@@ -1580,6 +1580,21 @@ class K8sTaskProvider:
             len(stray_hashes),
             len(stray_pod_groups),
         )
+
+    def _release_gang_reservations(self, gang_pod_names: list[str], pod_groups: set[str]) -> None:
+        """Release the Kueue gang reservation for torn-down pod-group generations.
+
+        Kueue parks a coscheduled Workload in WaitingForReplacementPods when its
+        pods are deleted, holding the quota until the Workload itself is removed;
+        a gang requeue (which bumps to a new pod-group generation) would deadlock
+        behind the old generation's still-reserved quota. Stripping Kueue's pod
+        finalizer is what guarantees the labeled pods actually disappear —
+        otherwise Kueue rebuilds the Workload from the surviving pods and
+        re-holds the quota/TAS slots.
+        """
+        for pod_name in gang_pod_names:
+            self.kubectl.remove_finalizer(K8sResource.PODS, pod_name, _KUEUE_MANAGED_FINALIZER)
+        self._delete_kueue_workloads(pod_groups)
 
     def _delete_kueue_workloads(self, pod_group_names: set[str]) -> None:
         """Delete the Kueue Workload backing each coscheduled pod-group generation.
@@ -1594,7 +1609,8 @@ class K8sTaskProvider:
 
     def _maybe_gc_terminal_resources(self, active_pods: list[dict]) -> None:
         """Periodically delete terminal (Succeeded/Failed) pods and their associated
-        configmaps/PDBs that are older than _GC_MAX_AGE_SECONDS.
+        configmaps/PDBs that are older than _GC_MAX_AGE_SECONDS, and sweep terminal
+        gang pods (with their Kueue Workloads) on the shorter gang retention.
 
         Without this, completed pods and their configmaps accumulate in etcd indefinitely
         since the sync loop's field selector excludes terminal pods from its queries.
@@ -1613,16 +1629,30 @@ class K8sTaskProvider:
             logger.exception("GC pass failed; will retry next interval")
 
     def _gc_terminal_resources(self, active_pods: list[dict]) -> None:
-        cutoff = datetime.now(timezone.utc).timestamp() - _GC_MAX_AGE_SECONDS
+        """One GC pass: deferred CM/PDB cleanup, the 1h terminal-pod sweep, and a
+        short-retention sweep of terminal gang pods that strips the Kueue pod
+        finalizer and deletes the pod-group Workloads they would otherwise pin.
+        """
+        now = datetime.now(timezone.utc).timestamp()
+        cutoff = now - _GC_MAX_AGE_SECONDS
+        gang_cutoff = now - _GANG_GC_MAX_AGE_SECONDS
 
         # Collect task hashes that still have active (Pending/Running) pods.
         # These must NOT have their configmaps/PDBs deleted, even if an older
         # attempt of the same task is terminal — task_hash is shared across attempts.
         active_hashes: set[str] = set()
+        # Pod-groups with live (Pending/Running) members share one Kueue
+        # Workload across the gang; releasing it would evict the running
+        # siblings, so the gang sweep must skip those groups entirely.
+        active_gang_groups: set[str] = set()
         for pod in active_pods:
-            h = pod.get("metadata", {}).get("labels", {}).get(_LABEL_TASK_HASH)
+            labels = pod.get("metadata", {}).get("labels", {})
+            h = labels.get(_LABEL_TASK_HASH)
             if h:
                 active_hashes.add(h)
+            g = labels.get(_KUEUE_POD_GROUP_NAME)
+            if g:
+                active_gang_groups.add(g)
 
         # 1. Targeted cleanup: delete configmaps/PDBs for tasks that were killed
         #    since last GC. Uses label-selector deletes (one kubectl call per hash)
@@ -1643,13 +1673,9 @@ class K8sTaskProvider:
         #    Skip hashes that still have active pods to avoid deleting live resources.
         old_pod_names: list[str] = []
         old_task_hashes: set[str] = set()
-        # Wedged gang pods: terminal, already deletion-requested, but held alive
-        # by Kueue's managed finalizer. The active-pod field selector hides them
-        # from _delete_stray_pods, so GC is the only place that re-drives them.
-        # Strip the finalizer, delete promptly (no age gate), and re-delete the
-        # Workload — once the labeled pods drain, Kueue stops rebuilding it.
-        wedged_gang_pod_names: list[str] = []
-        wedged_pod_groups: set[str] = set()
+        gang_pod_names: list[str] = []
+        gang_pod_groups: set[str] = set()
+        gang_task_hashes: set[str] = set()
         for phase in ("Succeeded", "Failed"):
             pods = self.kubectl.list_json(
                 K8sResource.PODS,
@@ -1658,30 +1684,45 @@ class K8sTaskProvider:
             )
             for pod in pods:
                 meta = pod.get("metadata", {})
-                labels = meta.get("labels", {})
-                pod_group = labels.get(_KUEUE_POD_GROUP_NAME)
-                if pod_group and meta.get("deletionTimestamp"):
-                    self.kubectl.remove_finalizer(K8sResource.PODS, meta["name"], _KUEUE_MANAGED_FINALIZER)
-                    wedged_gang_pod_names.append(meta["name"])
-                    wedged_pod_groups.add(pod_group)
-                    continue
                 created = meta.get("creationTimestamp", "")
                 if not created:
                     continue
                 ts = datetime.fromisoformat(created.replace("Z", "+00:00")).timestamp()
+                task_hash = meta.get("labels", {}).get(_LABEL_TASK_HASH)
+                pod_group = meta.get("labels", {}).get(_KUEUE_POD_GROUP_NAME)
+                # Gang sweep: a deletionTimestamp means a prior delete is
+                # wedged on the Kueue finalizer; otherwise the shorter gang
+                # retention applies. Handled pods are excluded from the 1h
+                # sweep below. Pods whose group still has live members are
+                # deferred wholesale (not even age-swept): a partial delete
+                # would wedge on the finalizer, and releasing the shared
+                # Workload would evict the running siblings.
+                if pod_group and pod_group in active_gang_groups:
+                    continue
+                if pod_group and (meta.get("deletionTimestamp") or ts < gang_cutoff):
+                    gang_pod_names.append(meta["name"])
+                    gang_pod_groups.add(pod_group)
+                    if task_hash:
+                        gang_task_hashes.add(task_hash)
+                    continue
                 if ts < cutoff:
                     old_pod_names.append(meta["name"])
-                    task_hash = labels.get(_LABEL_TASK_HASH)
                     if task_hash:
                         old_task_hashes.add(task_hash)
 
-        if wedged_gang_pod_names:
-            self.kubectl.delete_many(K8sResource.PODS, wedged_gang_pod_names, wait=False)
-            self._delete_kueue_workloads(wedged_pod_groups)
+        if gang_pod_names:
+            # force (gracePeriodSeconds=0): these pods are already terminal, so
+            # there is nothing to terminate gracefully, and force unsticks
+            # deletion when the node's kubelet is gone (node failure).
+            self.kubectl.delete_many(K8sResource.PODS, gang_pod_names, force=True, wait=False)
+            self._release_gang_reservations(gang_pod_names, gang_pod_groups)
+            # CM/PDB cleanup follows the deferred path so active retry
+            # attempts sharing the task hash keep their resources.
+            self._pending_gc_hashes.update(gang_task_hashes)
             logger.info(
-                "GC: drained %d wedged gang pods (%d Kueue workloads re-deleted)",
-                len(wedged_gang_pod_names),
-                len(wedged_pod_groups),
+                "GC: swept %d terminal gang pods, released %d Kueue workloads",
+                len(gang_pod_names),
+                len(gang_pod_groups),
             )
 
         if old_pod_names:

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -13,6 +13,7 @@ import pytest
 from finelog.client.proxy import LogServiceProxy
 from finelog.rpc import logging_pb2
 from iris.cluster.backends.k8s.tasks import (
+    _GANG_GC_MAX_AGE_SECONDS,
     _GC_MAX_AGE_SECONDS,
     _KUEUE_MANAGED_FINALIZER,
     _KUEUE_POD_GROUP_NAME,
@@ -1222,57 +1223,132 @@ def test_gang_teardown_deletes_kueue_workload(kueue_provider, k8s):
     assert k8s.get_json(K8sResource.WORKLOADS, group_name) is None, "stray-pod teardown must release the Kueue Workload"
 
 
-def test_stray_gang_teardown_strips_kueue_finalizer(kueue_provider, k8s):
-    """A stray gang pod held by Kueue's managed finalizer must be drained, not
-    left terminating. Without stripping the finalizer the pod lingers, Kueue
-    rebuilds the Workload from it, and the TAS reservation leaks."""
+def test_gang_teardown_strips_kueue_finalizer(kueue_provider, k8s):
+    """Tearing down a gang whose pods hold the Kueue pod finalizer removes the
+    finalizer so the pod objects actually disappear.
+
+    The fake honors finalizers: a plain delete leaves a finalizer-held pod
+    parked with a deletionTimestamp. The pods being fully gone after teardown
+    proves the provider stripped the finalizer; without that, Kueue rebuilds
+    the pod-group Workload from the surviving labeled pods and re-holds the
+    quota/TAS reservation.
+    """
     reqs = [
         make_run_req(f"/gang/task/{i}", attempt_id=0, num_tasks=2, coscheduling_group_by="leafgroup") for i in range(2)
     ]
     kueue_provider.reconcile(make_batch(tasks_to_run=reqs))
 
     pods = k8s.list_json(K8sResource.PODS, labels=_MANAGED_POD_LABELS)
+    assert len(pods) == 2
+    pod_names = [p["metadata"]["name"] for p in pods]
     group_name = pods[0]["metadata"]["labels"][_KUEUE_POD_GROUP_NAME]
-    # Kueue admits the gang: it stamps the managed finalizer on every pod and
-    # creates the backing Workload.
+    # Kueue's webhook stamps its finalizer on every admitted gang pod.
     for pod in pods:
         pod["metadata"]["finalizers"] = [_KUEUE_MANAGED_FINALIZER]
     k8s.seed_resource(K8sResource.WORKLOADS, group_name, {"kind": "Workload", "metadata": {"name": group_name}})
 
-    # Empty desired set: the whole gang is now stray and gets torn down.
+    # Empty desired set: the whole gang is stray.
     kueue_provider.reconcile(make_batch())
 
-    assert k8s.list_json(K8sResource.PODS, labels=_MANAGED_POD_LABELS) == [], "finalizer-held gang pods must drain"
+    for name in pod_names:
+        assert k8s.get_json(K8sResource.PODS, name) is None, "finalizer-held pod must be fully removed"
     assert k8s.get_json(K8sResource.WORKLOADS, group_name) is None
 
 
-def test_gc_drains_wedged_terminal_gang_pod(kueue_provider, k8s):
-    """GC re-drives a gang pod that wedged Failed under the managed finalizer
-    after a delete request: strip the finalizer, delete it, and re-delete the
-    Workload. The active-pod field selector hides such pods from the stray-pod
-    teardown, so GC is the only path that retries — promptly, not after 1h."""
-    group_name = "gang-wedged-grp"
-    recent = (datetime.now(timezone.utc) - timedelta(seconds=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
-    pod = {
+def _seed_gang_pod(
+    k8s,
+    name: str,
+    pod_group: str,
+    created: str,
+    *,
+    task_hash: str = "feedfacecafebeef",
+    finalizers: list[str] | None = None,
+    deletion_timestamp: str | None = None,
+) -> None:
+    """Insert a Failed gang pod (Kueue pod-group label) into the fake k8s store."""
+    metadata: dict = {
+        "name": name,
+        "creationTimestamp": created,
+        "labels": {
+            _LABEL_MANAGED: "true",
+            _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE,
+            _LABEL_TASK_HASH: task_hash,
+            _KUEUE_POD_GROUP_NAME: pod_group,
+        },
+    }
+    if finalizers:
+        metadata["finalizers"] = finalizers
+    if deletion_timestamp:
+        metadata["deletionTimestamp"] = deletion_timestamp
+    k8s.seed_resource(K8sResource.PODS, name, {"kind": "Pod", "metadata": metadata, "status": {"phase": "Failed"}})
+
+
+def test_gc_sweeps_finalizer_wedged_gang_pod(provider, k8s):
+    """A Failed gang pod wedged in deletion on the Kueue finalizer is swept by GC
+    (finalizer stripped, pod removed, Workload deleted) regardless of age."""
+    now = datetime.now(timezone.utc)
+    recent_ts = (now - timedelta(seconds=60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    group = "wedged-gang-group"
+    _seed_gang_pod(
+        k8s,
+        "wedged-gang-pod",
+        group,
+        recent_ts,
+        finalizers=[_KUEUE_MANAGED_FINALIZER],
+        deletion_timestamp=now.strftime("%Y-%m-%dT%H:%M:%SZ"),
+    )
+    k8s.seed_resource(K8sResource.WORKLOADS, group, {"kind": "Workload", "metadata": {"name": group}})
+
+    provider._last_gc_time = 0.0
+    provider._maybe_gc_terminal_resources(active_pods=[])
+
+    assert k8s.get_json(K8sResource.PODS, "wedged-gang-pod") is None
+    assert k8s.get_json(K8sResource.WORKLOADS, group) is None
+
+
+def test_gc_sweeps_crashed_gang_pods_on_short_retention(provider, k8s):
+    """A Failed gang pod older than the gang retention (but younger than the 1h
+    plain-pod retention) is swept along with its Workload; a non-gang Failed pod
+    of the same age keeps the 1h debugging window."""
+    now = datetime.now(timezone.utc)
+    age_ts = (now - timedelta(seconds=_GANG_GC_MAX_AGE_SECONDS + 60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    group = "crashed-gang-group"
+    _seed_gang_pod(k8s, "crashed-gang-pod", group, age_ts)
+    k8s.seed_resource(K8sResource.WORKLOADS, group, {"kind": "Workload", "metadata": {"name": group}})
+    _seed_terminal_pod(k8s, "plain-failed-pod", "Failed", "1122334455667788", age_ts)
+
+    provider._gc_terminal_resources(active_pods=[])
+
+    assert k8s.get_json(K8sResource.PODS, "crashed-gang-pod") is None
+    assert k8s.get_json(K8sResource.WORKLOADS, group) is None
+    assert k8s.get_json(K8sResource.PODS, "plain-failed-pod") is not None, "1h retention for plain pods must hold"
+
+
+def test_gc_skips_gang_with_active_sibling(provider, k8s):
+    """A terminal gang pod past the gang retention is NOT swept while a
+    Pending/Running sibling of the same pod group exists: releasing the shared
+    Workload would evict the live siblings. Once the gang has no live members,
+    the next GC pass sweeps it."""
+    now = datetime.now(timezone.utc)
+    age_ts = (now - timedelta(seconds=_GANG_GC_MAX_AGE_SECONDS + 60)).strftime("%Y-%m-%dT%H:%M:%SZ")
+    group = "skewed-gang-group"
+    _seed_gang_pod(k8s, "early-failed-gang-pod", group, age_ts, finalizers=[_KUEUE_MANAGED_FINALIZER])
+    k8s.seed_resource(K8sResource.WORKLOADS, group, {"kind": "Workload", "metadata": {"name": group}})
+    running_sibling = {
         "kind": "Pod",
         "metadata": {
-            "name": "iris-wedged-pod",
-            "creationTimestamp": recent,
-            "deletionTimestamp": recent,  # delete already requested, finalizer holds it
-            "finalizers": [_KUEUE_MANAGED_FINALIZER],
-            "labels": {
-                _LABEL_MANAGED: "true",
-                _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE,
-                _LABEL_TASK_HASH: "deadbeefdeadbeef",
-                _KUEUE_POD_GROUP_NAME: group_name,
-            },
+            "name": "running-gang-pod",
+            "labels": {_LABEL_TASK_HASH: "feedfacecafebeef", _KUEUE_POD_GROUP_NAME: group},
         },
-        "status": {"phase": "Failed"},
+        "status": {"phase": "Running"},
     }
-    k8s.seed_resource(K8sResource.PODS, "iris-wedged-pod", pod)
-    k8s.seed_resource(K8sResource.WORKLOADS, group_name, {"kind": "Workload", "metadata": {"name": group_name}})
 
-    kueue_provider._gc_terminal_resources(active_pods=[])
+    provider._gc_terminal_resources(active_pods=[running_sibling])
 
-    assert k8s.get_json(K8sResource.PODS, "iris-wedged-pod") is None, "wedged gang pod must be drained promptly"
-    assert k8s.get_json(K8sResource.WORKLOADS, group_name) is None, "wedged gang Workload must be re-deleted"
+    assert k8s.get_json(K8sResource.PODS, "early-failed-gang-pod") is not None, "gang with live sibling must be kept"
+    assert k8s.get_json(K8sResource.WORKLOADS, group) is not None, "shared Workload must survive while gang is live"
+
+    provider._gc_terminal_resources(active_pods=[])
+
+    assert k8s.get_json(K8sResource.PODS, "early-failed-gang-pod") is None
+    assert k8s.get_json(K8sResource.WORKLOADS, group) is None

--- a/lib/iris/tests/e2e/gpu_gang_smoke.py
+++ b/lib/iris/tests/e2e/gpu_gang_smoke.py
@@ -248,16 +248,28 @@ class ControllerTarget:
         logger.info("controller ready (in-cluster: %s)", addr)
         return addr
 
-    def open_tunnel(self, local_port: int = 10000) -> str:
+    def open_tunnel(self, local_port: int = 0) -> str:
         port = self.cfg.controller.coreweave.port or 10000
         svc = self.cfg.controller.coreweave.service_name or "iris-controller-svc"
+        # Random free port, pinned to 127.0.0.1. A fixed port silently
+        # cross-wires the client: with something else (e.g. a production
+        # controller tunnel) on 127.0.0.1:<port>, kubectl binds only [::1] and
+        # "localhost" resolves to the OTHER listener — the smoke then submits
+        # its gang to that cluster. --address makes a genuine conflict fail
+        # loudly instead.
+        if local_port == 0:
+            with socket.socket() as s:
+                s.bind(("127.0.0.1", 0))
+                local_port = s.getsockname()[1]
         self._tunnel = subprocess.Popen(
-            self._kc("port-forward", "-n", self.namespace, f"svc/{svc}", f"{local_port}:{port}"),
+            self._kc(
+                "port-forward", "--address", "127.0.0.1", "-n", self.namespace, f"svc/{svc}", f"{local_port}:{port}"
+            ),
             stdout=subprocess.DEVNULL,
             stderr=subprocess.DEVNULL,
         )
-        _wait_port("localhost", local_port, timeout=60)
-        url = f"http://localhost:{local_port}"
+        _wait_port("127.0.0.1", local_port, timeout=60)
+        url = f"http://127.0.0.1:{local_port}"
         logger.info("controller tunnel open: %s", url)
         return url
 

--- a/lib/iris/tests/e2e/gpu_gang_smoke.py
+++ b/lib/iris/tests/e2e/gpu_gang_smoke.py
@@ -63,7 +63,7 @@ from iris.cluster.backends.k8s.coreweave_topology import (
     CW_LABEL_SUPERPOD,
 )
 from iris.cluster.backends.k8s.service import CloudK8sService
-from iris.cluster.backends.types import Labels
+from iris.cluster.backends.types import Labels, find_free_port
 from iris.cluster.config import load_config
 from iris.cluster.types import CoschedulingConfig, Entrypoint, EnvironmentSpec, ResourceSpec, gpu_device
 from iris.rpc import config_pb2, job_pb2
@@ -258,9 +258,7 @@ class ControllerTarget:
         # its gang to that cluster. --address makes a genuine conflict fail
         # loudly instead.
         if local_port == 0:
-            with socket.socket() as s:
-                s.bind(("127.0.0.1", 0))
-                local_port = s.getsockname()[1]
+            local_port = find_free_port()
         self._tunnel = subprocess.Popen(
             self._kc(
                 "port-forward", "--address", "127.0.0.1", "-n", self.namespace, f"svc/{svc}", f"{local_port}:{port}"


### PR DESCRIPTION
Follow-up to #6303, which landed the core fix for the TAS-reservation leak (the remove_finalizer primitive, the finalizer-honoring fake, stripping Kueue's pod finalizer on stray-gang teardown, and a GC re-drive for pods already wedged in deletion). Rebased onto main; this PR carries the remaining hardening:

- Sweep all terminal gang pods on a 60-second retention, not only ones already wedged in deletion. Plain pods keep their 1h debugging window, but a terminal gang pod pins the pod-group Workload — Kueue rebuilds it from surviving labeled pods — and with it the gang's quota and TAS topology reservation, so every held slot is an idle GPU node. The GC pass now runs every 60s and force-deletes swept gang pods (gracePeriodSeconds=0: they are already terminal, and force unsticks deletion when the node's kubelet is gone) before re-driving Workload deletion.
- Skip pod-groups that still have live (Pending/Running) members: the gang shares one Workload, and releasing it would evict the running siblings. The next pass sweeps the group once it has no live members.
- Extract _release_gang_reservations so teardown and GC release a gang identically: strip the kueue.x-k8s.io/managed pod finalizer, then delete the pod-group Workload. These are the only two call sites that touch Kueue finalization.
- delete_many grows a force flag (CloudK8sService and the fake) for the terminal-pod force delete.
- The gang e2e smoke's controller tunnel now uses a free local port pinned to 127.0.0.1: with another listener (e.g. a production controller tunnel) on 127.0.0.1:10000, kubectl port-forward silently bound only [::1], "localhost" resolved to the other listener, and the smoke submitted its gang to the wrong cluster.

Why Iris strips the finalizer itself: upstream documents three release paths for kueue.x-k8s.io/managed (the group meets its termination criteria, Kueue observes a replacement for a Failed pod, or you delete the Workload object) and advises against modifying finalizers manually. None of them holds for a deliberately torn-down gang. No replacement pods will ever come; deleting the Workload races the pod-group controller, which rebuilds it from the surviving finalizer-held pods (the production wedge in #6302; kubernetes-sigs/kueue#6149 tracks pod groups being undeletable before completion); and the retriable-in-group=false finish annotation is asynchronous and still wedges when the kubelet is gone (kubernetes-sigs/kueue#6757) — exactly the node-failure mode that bit cw-us-east-02a. Deterministically stripping the finalizer, as the operator did by hand during the incident, through one idempotent helper re-driven by the GC sweep, is the simplest mechanism that cannot itself wedge.

Part of #6302
