### PR TITLE
[iris] Harden Playwright browser cache in e2e smoke workflows

### DIFF
--- a/.github/workflows/iris-smoke-gcp.yaml
+++ b/.github/workflows/iris-smoke-gcp.yaml
@@ -49,20 +49,24 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "lib/iris/pyproject.toml"
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(awk '/^name = "playwright"$/{getline; print}' uv.lock | sed -E 's/version = "(.*)"/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Cache Playwright browsers
-        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('lib/iris/pyproject.toml') }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        # Always run: `playwright install` only downloads browsers it does not already
+        # have, so a warm cache stays fast, while a partial or stale cache self-heals
+        # instead of leaving a missing browser binary. `--with-deps` reinstalls the system
+        # libraries that the browser cache cannot hold.
         run: cd lib/iris && uv run playwright install --with-deps chromium
-
-      - name: Install Playwright system deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx --yes playwright@1.57.0 install-deps chromium
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2

--- a/.github/workflows/iris-unit.yaml
+++ b/.github/workflows/iris-unit.yaml
@@ -87,20 +87,24 @@ jobs:
           enable-cache: true
           cache-dependency-glob: "lib/iris/pyproject.toml"
 
+      - name: Resolve Playwright version
+        id: playwright-version
+        run: |
+          version=$(awk '/^name = "playwright"$/{getline; print}' uv.lock | sed -E 's/version = "(.*)"/\1/')
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
       - name: Cache Playwright browsers
-        id: playwright-cache
         uses: actions/cache@v4
         with:
           path: ~/.cache/ms-playwright
-          key: playwright-${{ runner.os }}-${{ hashFiles('lib/iris/pyproject.toml') }}
+          key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
 
       - name: Install Playwright browsers
-        if: steps.playwright-cache.outputs.cache-hit != 'true'
+        # Always run: `playwright install` only downloads browsers it does not already
+        # have, so a warm cache stays fast, while a partial or stale cache self-heals
+        # instead of leaving a missing browser binary. `--with-deps` reinstalls the system
+        # libraries that the browser cache cannot hold.
         run: cd lib/iris && uv run playwright install --with-deps chromium
-
-      - name: Install Playwright system deps
-        if: steps.playwright-cache.outputs.cache-hit == 'true'
-        run: npx --yes playwright@1.57.0 install-deps chromium
 
       - name: Run E2E smoke tests
         env:


### PR DESCRIPTION
The Playwright browser cache in iris-unit.yaml and iris-smoke-gcp.yaml was keyed on the lib/iris/pyproject.toml hash and skipped `playwright install` on a cache hit. Any unrelated edit to that pyproject (e.g. a dependency floor bump) rotated the key, and because both workflows share the key, a concurrent job could populate a partial cache that the other job restored as a hit. On a hit the browser-install step was skipped, leaving the runner without the `chrome-headless-shell` build that playwright expects — the e2e smoke tests then failed with `Executable doesn't exist`.

Key the cache on the resolved playwright version read from uv.lock, so it only rotates when playwright itself changes (which is exactly when the browser binary set changes). Replace the two cache-hit-gated install steps with a single unconditional `playwright install --with-deps chromium`: it skips the download on a warm cache but self-heals a partial or stale cache, and `--with-deps` reinstalls the system libraries the cache cannot hold. The cache is now a pure optimization rather than a correctness dependency.

Follow-up to the investigation in marin-community/marin#6245.