### PR TITLE
[levanter] Share Splash Attention mask lowering

### DIFF
--- a/lib/levanter/src/levanter/grug/attention/_core.py
+++ b/lib/levanter/src/levanter/grug/attention/_core.py
@@ -362,14 +362,7 @@ def _tpu_splash_attention(
 
     if mask is None:
         mask_spec = None
-        segment_id_lowering = lower_splash_segment_ids(
-            q_segment_ids=None,
-            kv_segment_ids=None,
-            q_segment_ids_axes=None,
-            kv_segment_ids_axes=None,
-            q_segment_batch_axis=None,
-            kv_segment_batch_axis=None,
-        )
+        segment_id_lowering = lower_splash_segment_ids()
     elif isinstance(mask, AttentionMask):
         if mask.sliding_window is not None:
             if mask.sliding_window <= 0:
@@ -393,14 +386,7 @@ def _tpu_splash_attention(
                 kv_segment_batch_axis=0 if kv_segment_ids.ndim == 2 else None,
             )
         else:
-            segment_id_lowering = lower_splash_segment_ids(
-                q_segment_ids=None,
-                kv_segment_ids=None,
-                q_segment_ids_axes=None,
-                kv_segment_ids_axes=None,
-                q_segment_batch_axis=None,
-                kv_segment_batch_axis=None,
-            )
+            segment_id_lowering = lower_splash_segment_ids()
     else:
         raise NotImplementedError("Dense masks are not supported for splash attention.")
 

--- a/lib/levanter/src/levanter/grug/attention/_core.py
+++ b/lib/levanter/src/levanter/grug/attention/_core.py
@@ -12,10 +12,18 @@ from haliax.jax_utils import named_call
 from haliax.partitioning import _get_mesh
 from jax import numpy as jnp
 from jax import shard_map
-from jax.experimental.pallas.ops.tpu.splash_attention import SegmentIds as SplashSegmentIds
-from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel, splash_attention_mask
+from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel
 from jax.sharding import NamedSharding
 from jaxtyping import Array, Bool, Float, Int
+
+from levanter.kernels.pallas.splash_attention import (
+    DEFAULT_SPLASH_BLOCK_SIZE,
+    SplashAttentionMaskSpec,
+    lower_splash_attention_mask,
+    lower_splash_segment_ids,
+    splash_attention_block_sizes,
+    splash_partition_spec_shard_factor,
+)
 
 _SHARD_MAP_CHECK_KWARG = "check_vma" if "check_vma" in inspect.signature(shard_map).parameters else "check_rep"
 _SHARD_MAP_CHECK_KWARGS = {_SHARD_MAP_CHECK_KWARG: False}
@@ -282,24 +290,6 @@ def reference_attention(
     return ctx.astype(v.dtype)
 
 
-def _spec_shard_factor(entry: str | tuple[str, ...] | None, mesh) -> int:
-    """
-    Compute the size of the mesh axes associated with a PartitionSpec entry.
-
-    Splash attention can handle various kinds of sequence parallelism but needs this to function
-    """
-    if entry is None or mesh is None:
-        return 1
-    if isinstance(entry, str):
-        return mesh.shape[entry]
-    if isinstance(entry, tuple):
-        factor = 1
-        for name in entry:
-            factor *= mesh.shape[name]
-        return factor
-    raise TypeError(f"Unsupported PartitionSpec entry: {entry!r}")
-
-
 def _tpu_splash_attention(
     q: Float[Array, "B Q Hq D"],
     k: Float[Array, "B K Hkv D"],
@@ -358,94 +348,72 @@ def _tpu_splash_attention(
             f"Got KV sequence spec: {k_pspec[2]}"
         )
 
-    head_shards = _spec_shard_factor(q_pspec[1], mesh)
-    q_seq_shards = _spec_shard_factor(q_pspec[2], mesh)
-    kv_seq_shards = _spec_shard_factor(k_pspec[2], mesh)
+    head_shards = splash_partition_spec_shard_factor(q_pspec[1], mesh)
+    q_seq_shards = splash_partition_spec_shard_factor(q_pspec[2], mesh)
+    kv_seq_shards = splash_partition_spec_shard_factor(k_pspec[2], mesh)
 
-    # MaxText uses a block size of 512. Pick per-shard blocks that evenly divide each shard length,
-    # preferring multiples of 128 when possible.
-    block_size = 512
-
-    shard_Sq = max(1, Sq // max(1, q_seq_shards))
-    shard_Sk = max(1, Sk // max(1, kv_seq_shards))
-
-    def _compatible_block(shard_len: int, max_block: int) -> int:
-        """Pick largest block <= max_block that divides shard_len; prefer multiples of 128."""
-        if shard_len <= 0:
-            return max_block
-        cap = min(max_block, shard_len)
-        for step in (128, 1):
-            candidate = cap - (cap % step)
-            while candidate >= step:
-                if shard_len % candidate == 0:
-                    return candidate
-                candidate -= step
-        return 1
-
-    block_q = _compatible_block(shard_Sq, block_size)
-    block_kv = _compatible_block(shard_Sk, block_size)
-
-    block_sizes = splash_attention_kernel.BlockSizes(
-        block_q=block_q,
-        block_kv_compute=block_kv,
-        block_kv=block_kv,
-        block_q_dkv=block_q,
-        block_kv_dkv=block_kv,
-        block_kv_dkv_compute=block_q,
-        block_q_dq=block_q,
-        block_kv_dq=block_kv,
+    block_sizes = splash_attention_block_sizes(
+        q_seq_len=Sq,
+        kv_seq_len=Sk,
+        q_seq_shards=q_seq_shards,
+        kv_seq_shards=kv_seq_shards,
+        max_block_size=DEFAULT_SPLASH_BLOCK_SIZE,
     )
 
     if mask is None:
-        base_mask = splash_attention_mask.FullMask(_shape=(Sq, Sk))
-        segment_ids = None
-        segment_ids_axes = None
-        segment_batch_axis = None
+        mask_spec = None
+        segment_id_lowering = lower_splash_segment_ids(
+            q_segment_ids=None,
+            kv_segment_ids=None,
+            q_segment_ids_axes=None,
+            kv_segment_ids_axes=None,
+            q_segment_batch_axis=None,
+            kv_segment_batch_axis=None,
+        )
     elif isinstance(mask, AttentionMask):
-        if mask.is_causal:
-            base_mask = splash_attention_mask.CausalMask((Sq, Sk), offset=0, shard_count=q_seq_shards)
-        else:
-            base_mask = splash_attention_mask.FullMask(_shape=(Sq, Sk))
-
         if mask.sliding_window is not None:
             if mask.sliding_window <= 0:
                 raise ValueError(f"sliding_window must be positive, got {mask.sliding_window}")
-            local_mask = splash_attention_mask.LocalMask(
-                shape=(Sq, Sk),
-                # Grug's `sliding_window` matches the "lookback" semantics used in the
-                # reference mask materialization: allow attending to keys with
-                #   k >= q - (sliding_window - 1)
-                # (and optionally combine with causal).
-                window_size=(mask.sliding_window - 1, None),
-                offset=0,
-                shard_count=q_seq_shards,
-            )
-            base_mask = splash_attention_mask.LogicalAnd(base_mask, local_mask)
+
+        mask_spec = SplashAttentionMaskSpec(
+            is_causal=mask.is_causal,
+            sliding_window=mask.sliding_window,
+        )
 
         if mask.segment_ids is not None:
             q_segment_ids, kv_segment_ids = mask.segment_ids
             q_seg_sharding = _named_sharding_of(q_segment_ids, label="segment_ids.q")
             kv_seg_sharding = _named_sharding_of(kv_segment_ids, label="segment_ids.kv")
-            segment_ids = SplashSegmentIds(q_segment_ids, kv_segment_ids)
-            segment_ids_axes = SplashSegmentIds(
-                q_seg_sharding.spec,
-                kv_seg_sharding.spec,
-            )
-            segment_batch_axis = SplashSegmentIds(
-                0 if q_segment_ids.ndim == 2 else None,
-                0 if kv_segment_ids.ndim == 2 else None,
+            segment_id_lowering = lower_splash_segment_ids(
+                q_segment_ids=q_segment_ids,
+                kv_segment_ids=kv_segment_ids,
+                q_segment_ids_axes=q_seg_sharding.spec,
+                kv_segment_ids_axes=kv_seg_sharding.spec,
+                q_segment_batch_axis=0 if q_segment_ids.ndim == 2 else None,
+                kv_segment_batch_axis=0 if kv_segment_ids.ndim == 2 else None,
             )
         else:
-            segment_ids = None
-            segment_ids_axes = None
-            segment_batch_axis = None
+            segment_id_lowering = lower_splash_segment_ids(
+                q_segment_ids=None,
+                kv_segment_ids=None,
+                q_segment_ids_axes=None,
+                kv_segment_ids_axes=None,
+                q_segment_batch_axis=None,
+                kv_segment_batch_axis=None,
+            )
     else:
         raise NotImplementedError("Dense masks are not supported for splash attention.")
 
-    kernel_mask = splash_attention_mask.MultiHeadMask(masks=[base_mask for _ in range(Hq)])
+    mask_lowering = lower_splash_attention_mask(
+        mask=mask_spec,
+        q_seq_len=Sq,
+        kv_seq_len=Sk,
+        num_heads=Hq,
+        q_seq_shards=q_seq_shards,
+    )
 
     splash_kernel = splash_attention_kernel.make_splash_mha(
-        mask=kernel_mask,
+        mask=mask_lowering.kernel_mask,
         block_sizes=block_sizes,
         head_shards=head_shards,
         q_seq_shards=q_seq_shards,
@@ -454,15 +422,20 @@ def _tpu_splash_attention(
     @functools.partial(
         shard_map,
         mesh=mesh,
-        in_specs=(q_pspec, k_pspec, v_pspec, segment_ids_axes, None),
+        in_specs=(q_pspec, k_pspec, v_pspec, segment_id_lowering.segment_ids_axes, None),
         out_specs=q_pspec,
         **_SHARD_MAP_CHECK_KWARGS,
     )
     def wrap(q_bhsd, k_bhsd, v_bhsd, seg_ids, kernel):
-        return jax.vmap(kernel, in_axes=(0, 0, 0, segment_batch_axis))(q_bhsd, k_bhsd, v_bhsd, seg_ids)
+        return jax.vmap(kernel, in_axes=(0, 0, 0, segment_id_lowering.segment_batch_axis))(
+            q_bhsd,
+            k_bhsd,
+            v_bhsd,
+            seg_ids,
+        )
 
     # pyrefly: ignore[bad-specialization, bad-argument-count]  # jax.shard_map decorator erases wrap's real signature
-    out = wrap(q_, k_, v_, segment_ids, splash_kernel)
+    out = wrap(q_, k_, v_, segment_id_lowering.segment_ids, splash_kernel)
     return jnp.transpose(out, (0, 2, 1, 3)).astype(v.dtype)
 
 

--- a/lib/levanter/src/levanter/kernels/pallas/splash_attention.py
+++ b/lib/levanter/src/levanter/kernels/pallas/splash_attention.py
@@ -1,0 +1,163 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared lowering helpers for JAX Splash Attention."""
+
+from dataclasses import dataclass
+from typing import Any
+
+import jax
+from jax.experimental.pallas.ops.tpu.splash_attention import SegmentIds as SplashSegmentIds
+from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel, splash_attention_mask
+from jax.sharding import PartitionSpec
+
+
+DEFAULT_SPLASH_BLOCK_SIZE = 512
+
+
+@dataclass(frozen=True)
+class SplashAttentionMaskSpec:
+    """Static mask fields supported by Splash Attention lowering."""
+
+    is_causal: bool = False
+    causal_offset: Any | None = None
+    sliding_window: int | None = None
+    has_explicit_mask: bool = False
+
+
+@dataclass(frozen=True)
+class SplashAttentionMaskLowering:
+    """JAX Splash masks lowered from a structured mask spec."""
+
+    base_mask: Any
+    kernel_mask: Any
+
+
+@dataclass(frozen=True)
+class SplashSegmentIdsLowering:
+    """Segment ID arrays and sharding metadata for Splash Attention."""
+
+    segment_ids: SplashSegmentIds | None
+    segment_ids_axes: SplashSegmentIds | None
+    segment_batch_axis: SplashSegmentIds | None
+
+
+def lower_splash_attention_mask(
+    *,
+    mask: SplashAttentionMaskSpec | None,
+    q_seq_len: int,
+    kv_seq_len: int,
+    num_heads: int,
+    q_seq_shards: int,
+) -> SplashAttentionMaskLowering:
+    """Lower static structured mask fields to JAX Splash mask objects."""
+    if mask is None:
+        base_mask = splash_attention_mask.FullMask(_shape=(q_seq_len, kv_seq_len))
+    else:
+        if mask.is_causal:
+            if mask.causal_offset is not None:
+                raise NotImplementedError(
+                    "Causal offsets are not supported for splash attention. Please use a standard causal mask."
+                )
+            base_mask = splash_attention_mask.CausalMask(
+                (q_seq_len, kv_seq_len),
+                offset=0,
+                shard_count=q_seq_shards,
+            )
+        else:
+            base_mask = splash_attention_mask.FullMask(_shape=(q_seq_len, kv_seq_len))
+
+        if mask.sliding_window is not None:
+            local_mask = splash_attention_mask.LocalMask(
+                shape=(q_seq_len, kv_seq_len),
+                window_size=(mask.sliding_window - 1, None),
+                offset=0,
+                shard_count=q_seq_shards,
+            )
+            base_mask = splash_attention_mask.LogicalAnd(base_mask, local_mask)
+
+        if mask.has_explicit_mask:
+            raise NotImplementedError("Explicit masks are not yet supported for splash attention")
+
+    kernel_mask = splash_attention_mask.MultiHeadMask(masks=[base_mask for _ in range(num_heads)])
+    return SplashAttentionMaskLowering(base_mask=base_mask, kernel_mask=kernel_mask)
+
+
+def lower_splash_segment_ids(
+    *,
+    q_segment_ids: jax.Array | None,
+    kv_segment_ids: jax.Array | None,
+    q_segment_ids_axes: Any | None,
+    kv_segment_ids_axes: Any | None,
+    q_segment_batch_axis: int | None,
+    kv_segment_batch_axis: int | None,
+) -> SplashSegmentIdsLowering:
+    """Package segment ID arrays, input specs, and vmap axes for Splash."""
+    if q_segment_ids is None and kv_segment_ids is None:
+        return SplashSegmentIdsLowering(segment_ids=None, segment_ids_axes=None, segment_batch_axis=None)
+    if q_segment_ids is None or kv_segment_ids is None:
+        raise ValueError("Both q_segment_ids and kv_segment_ids must be provided.")
+
+    return SplashSegmentIdsLowering(
+        segment_ids=SplashSegmentIds(q_segment_ids, kv_segment_ids),
+        segment_ids_axes=SplashSegmentIds(q_segment_ids_axes, kv_segment_ids_axes),
+        segment_batch_axis=SplashSegmentIds(q_segment_batch_axis, kv_segment_batch_axis),
+    )
+
+
+def splash_attention_block_sizes(
+    *,
+    q_seq_len: int,
+    kv_seq_len: int,
+    q_seq_shards: int,
+    kv_seq_shards: int,
+    max_block_size: int = DEFAULT_SPLASH_BLOCK_SIZE,
+) -> splash_attention_kernel.BlockSizes:
+    """Choose Splash Attention block sizes compatible with per-shard sequence lengths."""
+    shard_q_seq_len = max(1, q_seq_len // max(1, q_seq_shards))
+    shard_kv_seq_len = max(1, kv_seq_len // max(1, kv_seq_shards))
+
+    block_q = _compatible_splash_block(shard_q_seq_len, max_block_size)
+    block_kv = _compatible_splash_block(shard_kv_seq_len, max_block_size)
+
+    return splash_attention_kernel.BlockSizes(
+        block_q=block_q,
+        block_kv_compute=block_kv,
+        block_kv=block_kv,
+        block_q_dkv=block_q,
+        block_kv_dkv=block_kv,
+        block_kv_dkv_compute=block_q,
+        block_q_dq=block_q,
+        block_kv_dq=block_kv,
+    )
+
+
+def splash_partition_spec_shard_factor(entry: Any, mesh: Any) -> int:
+    """Compute product of mesh axis sizes referenced by a PartitionSpec entry."""
+    if mesh is None:
+        return 1
+    if entry is None or entry is PartitionSpec.UNCONSTRAINED:
+        return 1
+    if isinstance(entry, str):
+        return int(mesh.shape.get(entry, 1))
+
+    product = 1
+    for axis_name in entry:
+        if axis_name is None or axis_name is PartitionSpec.UNCONSTRAINED:
+            continue
+        product *= int(mesh.shape.get(axis_name, 1))
+    return product
+
+
+def _compatible_splash_block(shard_len: int, max_block: int) -> int:
+    """Pick largest block <= max_block that divides shard_len; prefer multiples of 128."""
+    if shard_len <= 0:
+        return max_block
+    cap = min(max_block, shard_len)
+    for step in (128, 1):
+        candidate = cap - (cap % step)
+        while candidate >= step:
+            if shard_len % candidate == 0:
+                return candidate
+            candidate -= step
+    return 1

--- a/lib/levanter/src/levanter/kernels/pallas/splash_attention.py
+++ b/lib/levanter/src/levanter/kernels/pallas/splash_attention.py
@@ -3,24 +3,26 @@
 
 """Shared lowering helpers for JAX Splash Attention."""
 
+from collections.abc import Sequence
 from dataclasses import dataclass
-from typing import Any
 
 import jax
 from jax.experimental.pallas.ops.tpu.splash_attention import SegmentIds as SplashSegmentIds
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel, splash_attention_mask
-from jax.sharding import PartitionSpec
+from jax.sharding import Mesh, PartitionSpec
 
 
+SPLASH_BLOCK_GRANULARITY = 128
 DEFAULT_SPLASH_BLOCK_SIZE = 512
+PartitionSpecEntry = str | Sequence[str | None] | None
 
 
 @dataclass(frozen=True)
 class SplashAttentionMaskSpec:
-    """Static mask fields supported by Splash Attention lowering."""
+    """Static mask fields consumed by Splash Attention lowering."""
 
     is_causal: bool = False
-    causal_offset: Any | None = None
+    causal_offset: int | None = None
     sliding_window: int | None = None
     has_explicit_mask: bool = False
 
@@ -29,8 +31,8 @@ class SplashAttentionMaskSpec:
 class SplashAttentionMaskLowering:
     """JAX Splash masks lowered from a structured mask spec."""
 
-    base_mask: Any
-    kernel_mask: Any
+    base_mask: splash_attention_mask.Mask
+    kernel_mask: splash_attention_mask.MultiHeadMask
 
 
 @dataclass(frozen=True)
@@ -85,12 +87,12 @@ def lower_splash_attention_mask(
 
 def lower_splash_segment_ids(
     *,
-    q_segment_ids: jax.Array | None,
-    kv_segment_ids: jax.Array | None,
-    q_segment_ids_axes: Any | None,
-    kv_segment_ids_axes: Any | None,
-    q_segment_batch_axis: int | None,
-    kv_segment_batch_axis: int | None,
+    q_segment_ids: jax.Array | None = None,
+    kv_segment_ids: jax.Array | None = None,
+    q_segment_ids_axes: PartitionSpec | None = None,
+    kv_segment_ids_axes: PartitionSpec | None = None,
+    q_segment_batch_axis: int | None = None,
+    kv_segment_batch_axis: int | None = None,
 ) -> SplashSegmentIdsLowering:
     """Package segment ID arrays, input specs, and vmap axes for Splash."""
     if q_segment_ids is None and kv_segment_ids is None:
@@ -132,7 +134,7 @@ def splash_attention_block_sizes(
     )
 
 
-def splash_partition_spec_shard_factor(entry: Any, mesh: Any) -> int:
+def splash_partition_spec_shard_factor(entry: PartitionSpecEntry, mesh: Mesh | None) -> int:
     """Compute product of mesh axis sizes referenced by a PartitionSpec entry."""
     if mesh is None:
         return 1
@@ -150,11 +152,11 @@ def splash_partition_spec_shard_factor(entry: Any, mesh: Any) -> int:
 
 
 def _compatible_splash_block(shard_len: int, max_block: int) -> int:
-    """Pick largest block <= max_block that divides shard_len; prefer multiples of 128."""
+    """Pick largest block <= max_block that divides shard_len; prefer Splash's granularity."""
     if shard_len <= 0:
         return max_block
     cap = min(max_block, shard_len)
-    for step in (128, 1):
+    for step in (SPLASH_BLOCK_GRANULARITY, 1):
         candidate = cap - (cap % step)
         while candidate >= step:
             if shard_len % candidate == 0:

--- a/lib/levanter/src/levanter/layers/attention.py
+++ b/lib/levanter/src/levanter/layers/attention.py
@@ -14,9 +14,16 @@ import equinox as eqx
 import jax
 import jax.random as jrandom
 from jax import numpy as jnp
-from jax.experimental.pallas.ops.tpu.splash_attention import SegmentIds as SplashSegmentIds
-from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel, splash_attention_mask
+from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_kernel
 
+from levanter.kernels.pallas.splash_attention import (
+    DEFAULT_SPLASH_BLOCK_SIZE,
+    SplashAttentionMaskSpec,
+    lower_splash_attention_mask,
+    lower_splash_segment_ids,
+    splash_attention_block_sizes,
+    splash_partition_spec_shard_factor,
+)
 from levanter.inference.utils import is_valid
 
 try:
@@ -62,7 +69,6 @@ class AttentionBackend(StrEnum):
     VANILLA = "vanilla"  # regular dot product attention
 
 
-DEFAULT_SPLASH_BLOCK_SIZE = 512
 _SPLASH_FALLBACK_WARNINGS_EMITTED: set[str] = set()
 
 
@@ -1006,19 +1012,26 @@ def _tpu_splash_attention(
         q_segment_ids, kv_segment_ids = segment_ids
         kv_segment_ids = kv_segment_ids.rename({QPos.name: KPos.name})
 
-        segment_ids = SplashSegmentIds(q_segment_ids.array, kv_segment_ids.array)
-        segment_ids_axes = SplashSegmentIds(pspec_for_axis(q_segment_ids.axes), pspec_for_axis(kv_segment_ids.axes))
-
         q_segment_batch_axis = _find_batch_axis_for_segment_ids(QPos, q_segment_ids)
         kv_segment_batch_axis = _find_batch_axis_for_segment_ids(KPos, kv_segment_ids)
 
-        if q_segment_batch_axis is not None or kv_segment_batch_axis is not None:
-            segment_batch_axis = SplashSegmentIds(q_segment_batch_axis, kv_segment_batch_axis)  # type: ignore[arg-type]
-        else:
-            segment_batch_axis = None
+        segment_id_lowering = lower_splash_segment_ids(
+            q_segment_ids=q_segment_ids.array,
+            kv_segment_ids=kv_segment_ids.array,
+            q_segment_ids_axes=pspec_for_axis(q_segment_ids.axes),
+            kv_segment_ids_axes=pspec_for_axis(kv_segment_ids.axes),
+            q_segment_batch_axis=q_segment_batch_axis,
+            kv_segment_batch_axis=kv_segment_batch_axis,
+        )
     else:
-        segment_batch_axis = None
-        segment_ids_axes = None
+        segment_id_lowering = lower_splash_segment_ids(
+            q_segment_ids=None,
+            kv_segment_ids=None,
+            q_segment_ids_axes=None,
+            kv_segment_ids_axes=None,
+            q_segment_batch_axis=None,
+            kv_segment_batch_axis=None,
+        )
 
     # MaxText uses a block size of 512
     block_size = block_size or DEFAULT_SPLASH_BLOCK_SIZE
@@ -1027,9 +1040,9 @@ def _tpu_splash_attention(
     mesh = hax.partitioning._get_mesh()
     if mesh is None or mesh.empty:
         raise NotImplementedError("Splash attention requires a non-empty mesh")
-    head_shards = _spec_shard_factor(physical_axes_q[1], mesh)
-    q_seq_shards = _spec_shard_factor(physical_axes_q[2], mesh)
-    kv_seq_shards = _spec_shard_factor(physical_axes_k[2], mesh)
+    head_shards = splash_partition_spec_shard_factor(physical_axes_q[1], mesh)
+    q_seq_shards = splash_partition_spec_shard_factor(physical_axes_q[2], mesh)
+    kv_seq_shards = splash_partition_spec_shard_factor(physical_axes_k[2], mesh)
 
     # K should not be sharded for splash attention
     if physical_axes_k[2] is not None:
@@ -1038,69 +1051,40 @@ def _tpu_splash_attention(
             f"Got KV sequence spec: {physical_axes_k[2]}"
         )
 
-    # Compute block sizes based on per-shard sequence lengths
-    shard_Sq = max(1, Sq // max(1, q_seq_shards))
-    shard_Sk = max(1, Sk // max(1, kv_seq_shards))
-
-    def _compatible_block(shard_len: int, max_block: int) -> int:
-        """Pick largest block <= max_block that divides shard_len; prefer multiples of 128."""
-        if shard_len <= 0:
-            return max_block
-        cap = min(max_block, shard_len)
-        for step in (128, 1):
-            candidate = cap - (cap % step)
-            while candidate >= step:
-                if shard_len % candidate == 0:
-                    return candidate
-                candidate -= step
-        return 1
-
-    block_q = _compatible_block(shard_Sq, block_size)
-    block_kv = _compatible_block(shard_Sk, block_size)
-
-    block_sizes = splash_attention_kernel.BlockSizes(
-        block_q=block_q,
-        block_kv_compute=block_kv,
-        block_kv=block_kv,
-        block_q_dkv=block_q,
-        block_kv_dkv=block_kv,
-        block_kv_dkv_compute=block_q,
-        block_q_dq=block_q,
-        block_kv_dq=block_kv,
+    block_sizes = splash_attention_block_sizes(
+        q_seq_len=Sq,
+        kv_seq_len=Sk,
+        q_seq_shards=q_seq_shards,
+        kv_seq_shards=kv_seq_shards,
+        max_block_size=block_size,
     )
 
     # Create mask with GLOBAL shapes (outside shard_map)
     if mask is None:
-        base_mask = splash_attention_mask.FullMask(_shape=(Sq, Sk))
+        mask_spec = None
     elif isinstance(mask, AttentionMask):
-        if mask.is_causal:
-            if mask.causal_offset is not None:
-                raise NotImplementedError(
-                    "Causal offsets are not supported for splash attention. Please use a standard causal mask."
-                )
-            base_mask = splash_attention_mask.CausalMask((Sq, Sk), offset=0, shard_count=q_seq_shards)
-        else:
-            base_mask = splash_attention_mask.FullMask(_shape=(Sq, Sk))
-        if mask.sliding_window is not None:
-            local_mask = splash_attention_mask.LocalMask(
-                shape=(Sq, Sk),
-                window_size=(mask.sliding_window - 1, None),
-                offset=0,
-                shard_count=q_seq_shards,
-            )
-            base_mask = splash_attention_mask.LogicalAnd(base_mask, local_mask)
-        if mask.explicit_mask is not None:
-            raise NotImplementedError("Explicit masks are not yet supported for splash attention")
+        mask_spec = SplashAttentionMaskSpec(
+            is_causal=mask.is_causal,
+            causal_offset=mask.causal_offset,
+            sliding_window=mask.sliding_window,
+            has_explicit_mask=mask.explicit_mask is not None,
+        )
     elif isinstance(mask, NamedArray):
         raise NotImplementedError("NamedArray masks are not yet supported for splash attention")
     else:
         raise ValueError(f"Unknown mask type: {mask}")
 
-    kernel_mask = splash_attention_mask.MultiHeadMask(masks=[base_mask for _ in range(Hq)])
+    mask_lowering = lower_splash_attention_mask(
+        mask=mask_spec,
+        q_seq_len=Sq,
+        kv_seq_len=Sk,
+        num_heads=Hq,
+        q_seq_shards=q_seq_shards,
+    )
 
     # Create kernel with GLOBAL shapes and q_seq_shards (outside shard_map)
     splash_kernel = splash_attention_kernel.make_splash_mha(
-        mask=kernel_mask,
+        mask=mask_lowering.kernel_mask,
         head_shards=head_shards,
         q_seq_shards=q_seq_shards,
         block_sizes=block_sizes,
@@ -1118,7 +1102,7 @@ def _tpu_splash_attention(
             physical_axes_q,
             physical_axes_k,
             physical_axes_v,
-            segment_ids_axes,
+            segment_id_lowering.segment_ids_axes,
             physical_axes_sink,
             kernel_specs,
         ),
@@ -1138,10 +1122,10 @@ def _tpu_splash_attention(
 
         return jax.vmap(
             call_kernel,
-            in_axes=(0, 0, 0, segment_batch_axis, sink_in_axes),
+            in_axes=(0, 0, 0, segment_id_lowering.segment_batch_axis, sink_in_axes),
         )(q, k, v, segment_ids, sinks)
 
-    attn_output = wrap_flash_attention(q_, k_, v_, segment_ids, sinks, splash_kernel)
+    attn_output = wrap_flash_attention(q_, k_, v_, segment_id_lowering.segment_ids, sinks, splash_kernel)
 
     attn_output = haliax.named(attn_output, ("B", "H", "S", "D"))
     # the output shape is B, S_q, H_q, D_v. Right now we're requiring D_k == D_v
@@ -1184,22 +1168,6 @@ def _find_batch_axis_for_segment_ids(Pos, segment_ids) -> Optional[int]:
         segment_batch_axis = None
 
     return segment_batch_axis
-
-
-def _spec_shard_factor(entry, mesh) -> int:
-    """Compute product of mesh axis sizes referenced by a PartitionSpec entry."""
-    if mesh is None:
-        return 1
-    if entry is None or entry is PartitionSpec.UNCONSTRAINED:
-        return 1
-    if isinstance(entry, str):
-        return int(mesh.shape.get(entry, 1))
-    prod = 1
-    for e in entry:
-        if e is None or e is PartitionSpec.UNCONSTRAINED:
-            continue
-        prod *= int(mesh.shape.get(e, 1))
-    return prod
 
 
 @dataclass(frozen=True)

--- a/lib/levanter/src/levanter/layers/attention.py
+++ b/lib/levanter/src/levanter/layers/attention.py
@@ -1024,14 +1024,7 @@ def _tpu_splash_attention(
             kv_segment_batch_axis=kv_segment_batch_axis,
         )
     else:
-        segment_id_lowering = lower_splash_segment_ids(
-            q_segment_ids=None,
-            kv_segment_ids=None,
-            q_segment_ids_axes=None,
-            kv_segment_ids_axes=None,
-            q_segment_batch_axis=None,
-            kv_segment_batch_axis=None,
-        )
+        segment_id_lowering = lower_splash_segment_ids()
 
     # MaxText uses a block size of 512
     block_size = block_size or DEFAULT_SPLASH_BLOCK_SIZE

--- a/lib/levanter/tests/kernels/test_splash_attention.py
+++ b/lib/levanter/tests/kernels/test_splash_attention.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import jax.numpy as jnp
+import numpy as np
 import pytest
 from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask
 from jax.sharding import PartitionSpec as P
@@ -23,11 +24,11 @@ def test_lower_splash_attention_mask_builds_multi_head_mask():
         q_seq_shards=1,
     )
 
-    assert lowering.base_mask.shape == (256, 256)
-    assert isinstance(lowering.base_mask, splash_attention_mask.LogicalAnd)
     assert len(lowering.kernel_mask.masks) == 3
-    assert all(mask.shape == (256, 256) for mask in lowering.kernel_mask.masks)
-    assert all(isinstance(mask, splash_attention_mask.LogicalAnd) for mask in lowering.kernel_mask.masks)
+    expected = np.tril(np.ones((256, 256), dtype=bool))
+    expected &= np.arange(256)[None, :] >= np.arange(256)[:, None] - 127
+    np.testing.assert_array_equal(_materialize_splash_mask(lowering.kernel_mask.masks[0]), expected)
+    np.testing.assert_array_equal(_materialize_splash_mask(lowering.kernel_mask.masks[1]), expected)
 
 
 def test_lower_splash_attention_mask_rejects_unsupported_structured_fields():
@@ -83,3 +84,12 @@ def test_splash_attention_block_sizes_match_existing_defaults():
     assert block_sizes.block_q == 512
     assert block_sizes.block_kv == 512
     assert block_sizes.block_kv_compute == 512
+
+
+def _materialize_splash_mask(mask):
+    if isinstance(mask, splash_attention_mask.LogicalAnd):
+        return _materialize_splash_mask(mask.left) & _materialize_splash_mask(mask.right)
+
+    q_indices = jnp.arange(mask.shape[0])[:, None]
+    kv_indices = jnp.arange(mask.shape[1])[None, :]
+    return np.asarray(mask.mask_function(q_indices, kv_indices))

--- a/lib/levanter/tests/kernels/test_splash_attention.py
+++ b/lib/levanter/tests/kernels/test_splash_attention.py
@@ -26,7 +26,8 @@ def test_lower_splash_attention_mask_builds_multi_head_mask():
     assert lowering.base_mask.shape == (256, 256)
     assert isinstance(lowering.base_mask, splash_attention_mask.LogicalAnd)
     assert len(lowering.kernel_mask.masks) == 3
-    assert all(mask is lowering.base_mask for mask in lowering.kernel_mask.masks)
+    assert all(mask.shape == (256, 256) for mask in lowering.kernel_mask.masks)
+    assert all(isinstance(mask, splash_attention_mask.LogicalAnd) for mask in lowering.kernel_mask.masks)
 
 
 def test_lower_splash_attention_mask_rejects_unsupported_structured_fields():

--- a/lib/levanter/tests/kernels/test_splash_attention.py
+++ b/lib/levanter/tests/kernels/test_splash_attention.py
@@ -1,0 +1,84 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import jax.numpy as jnp
+import pytest
+from jax.experimental.pallas.ops.tpu.splash_attention import splash_attention_mask
+from jax.sharding import PartitionSpec as P
+
+from levanter.kernels.pallas.splash_attention import (
+    SplashAttentionMaskSpec,
+    lower_splash_attention_mask,
+    lower_splash_segment_ids,
+    splash_attention_block_sizes,
+)
+
+
+def test_lower_splash_attention_mask_builds_multi_head_mask():
+    lowering = lower_splash_attention_mask(
+        mask=SplashAttentionMaskSpec(is_causal=True, sliding_window=128),
+        q_seq_len=256,
+        kv_seq_len=256,
+        num_heads=3,
+        q_seq_shards=1,
+    )
+
+    assert lowering.base_mask.shape == (256, 256)
+    assert isinstance(lowering.base_mask, splash_attention_mask.LogicalAnd)
+    assert len(lowering.kernel_mask.masks) == 3
+    assert all(mask is lowering.base_mask for mask in lowering.kernel_mask.masks)
+
+
+def test_lower_splash_attention_mask_rejects_unsupported_structured_fields():
+    with pytest.raises(NotImplementedError):
+        lower_splash_attention_mask(
+            mask=SplashAttentionMaskSpec(is_causal=True, causal_offset=1),
+            q_seq_len=128,
+            kv_seq_len=128,
+            num_heads=1,
+            q_seq_shards=1,
+        )
+
+    with pytest.raises(NotImplementedError):
+        lower_splash_attention_mask(
+            mask=SplashAttentionMaskSpec(has_explicit_mask=True),
+            q_seq_len=128,
+            kv_seq_len=128,
+            num_heads=1,
+            q_seq_shards=1,
+        )
+
+
+def test_lower_splash_segment_ids_packages_arrays_specs_and_batch_axes():
+    q_segment_ids = jnp.array([[0, 0, 1, 1]], dtype=jnp.int32)
+    kv_segment_ids = jnp.array([[0, 0, 1, 1]], dtype=jnp.int32)
+
+    lowering = lower_splash_segment_ids(
+        q_segment_ids=q_segment_ids,
+        kv_segment_ids=kv_segment_ids,
+        q_segment_ids_axes=P("data", None),
+        kv_segment_ids_axes=P("data", None),
+        q_segment_batch_axis=0,
+        kv_segment_batch_axis=0,
+    )
+
+    assert lowering.segment_ids is not None
+    assert lowering.segment_ids.q is q_segment_ids
+    assert lowering.segment_ids.kv is kv_segment_ids
+    assert lowering.segment_ids_axes is not None
+    assert lowering.segment_ids_axes.q == P("data", None)
+    assert lowering.segment_batch_axis is not None
+    assert lowering.segment_batch_axis.q == 0
+
+
+def test_splash_attention_block_sizes_match_existing_defaults():
+    block_sizes = splash_attention_block_sizes(
+        q_seq_len=1024,
+        kv_seq_len=1024,
+        q_seq_shards=2,
+        kv_seq_shards=1,
+    )
+
+    assert block_sizes.block_q == 512
+    assert block_sizes.block_kv == 512
+    assert block_sizes.block_kv_compute == 512

--- a/lib/marin/src/marin/rl/train_worker.py
+++ b/lib/marin/src/marin/rl/train_worker.py
@@ -28,7 +28,8 @@ from levanter.checkpoint import (
     register_debug_checkpointer_state_provider,
     unregister_debug_checkpointer_state_provider,
 )
-from levanter.layers.attention import DEFAULT_SPLASH_BLOCK_SIZE, AttentionBackend
+from levanter.kernels.pallas.splash_attention import DEFAULT_SPLASH_BLOCK_SIZE
+from levanter.layers.attention import AttentionBackend
 from levanter.models.flash_attention import BLOCK_SIZE as DEFAULT_FLASH_BLOCK_SIZE
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.optim import OptimizerConfig


### PR DESCRIPTION
Factor the duplicated TPU Splash Attention mask, segment-id, sharding, and block-size lowering into levanter.kernels.pallas.splash_attention. The named-tensor attention path and Grug attention path now call the same helper, keeping existing static causal, sliding-window, and segment-id behavior aligned before adding structured dynamic masks.

Update Marin's RL worker to import the Splash block-size default from the new helper module, and add focused tests for the shared lowering behavior.