### PR TITLE
[levanter] BackgroundIterator: propagate JAX mesh context into prefetch thread

### DIFF
--- a/lib/levanter/src/levanter/utils/background_iterable.py
+++ b/lib/levanter/src/levanter/utils/background_iterable.py
@@ -8,7 +8,9 @@ import sys
 import threading
 from typing import AsyncIterator, Callable, Iterable, Iterator, Optional, TypeVar, Union
 
+import haliax.partitioning as hpart
 import tblib
+from jax.sharding import Mesh
 
 from levanter.utils.thread_utils import AsyncIteratorWrapper
 
@@ -49,28 +51,18 @@ class BackgroundIterator(Iterator[Ex]):
         else:
             self._producer_fn = producer_fn
         self._stop_event = threading.Event()
-        # Capture the parent thread's ContextVars + JAX mesh stack so the
-        # prefetch thread runs under the same JAX mesh / sharding context.
-        # threading.Thread does NOT propagate either by default; without
-        # this, jits traced inside _fill_queue_with_batches see an empty
-        # mesh and fall back to CPU, causing "Received incompatible devices"
-        # when the resulting array meets TPU-resident data downstream.
-        #
-        # JAX stores its active-mesh stack in a `threading.local` subclass
-        # (`jax._src.mesh.thread_resources`), NOT a ContextVar — so
-        # `copy_context()` alone is insufficient. Snapshot the mesh stack
-        # manually here and restore it inside the prefetch thread.
+        # Capture the parent thread's ContextVars and active JAX mesh so the
+        # prefetch thread runs under the same sharding context. A fresh
+        # threading.Thread carries neither: jits traced inside the producer
+        # (e.g. stack_tree) would otherwise see an empty mesh, fall back to
+        # CPU, and raise "Received incompatible devices" when their output
+        # meets TPU-resident data downstream. On modern JAX the active mesh
+        # lives in the concrete-mesh config (set via jax.set_mesh), not in a
+        # ContextVar, so copy_context() does not carry it across the thread
+        # boundary — snapshot it here and re-enter it in the worker.
         self._captured_ctx = contextvars.copy_context()
-        self._captured_jax_mesh_stack: Optional[list] = None
-        self._captured_jax_mesh_env = None
-        try:
-            # Lazy import of a JAX private internal; guarded for version drift.
-            from jax._src.mesh import thread_resources as _jax_thread_resources  # noqa: PLC0415
-
-            self._captured_jax_mesh_stack = list(_jax_thread_resources.stack)
-            self._captured_jax_mesh_env = _jax_thread_resources.env
-        except Exception:
-            pass
+        mesh = hpart.get_concrete_mesh()
+        self._captured_mesh: Optional[Mesh] = None if mesh is None or mesh.empty else mesh
 
         if self.max_capacity is None or self.max_capacity >= 0:
             self.q: queue.Queue = queue.Queue(self.max_capacity or 0)
@@ -119,26 +111,18 @@ class BackgroundIterator(Iterator[Ex]):
             self.thread.join()
 
     def _fill_queue_with_batches(self):
-        # Restore JAX's thread-local mesh stack in this producer thread,
-        # since `threading.Thread` doesn't carry it across. This is the
-        # actual fix for the eval-mesh ValueError; `copy_context` below
-        # is belt-and-suspenders for any non-mesh ContextVars.
-        mesh_stack = getattr(self, "_captured_jax_mesh_stack", None)
-        mesh_env = getattr(self, "_captured_jax_mesh_env", None)
-        if mesh_stack is not None:
-            try:
-                from jax._src.mesh import thread_resources as _jax_thread_resources  # noqa: PLC0415
+        # Re-enter the parent thread's mesh and ContextVars in this producer
+        # thread (a fresh threading.Thread inherits neither). Re-entering the
+        # captured mesh is the actual fix for the eval-boundary "incompatible
+        # devices" error; copy_context carries any other ContextVars.
+        def run():
+            if self._captured_mesh is not None:
+                with hpart.set_mesh(self._captured_mesh):
+                    self._fill_queue_with_batches_inner()
+            else:
+                self._fill_queue_with_batches_inner()
 
-                _jax_thread_resources.stack = list(mesh_stack)
-                if mesh_env is not None:
-                    _jax_thread_resources.env = mesh_env
-            except Exception:
-                pass
-        ctx = getattr(self, "_captured_ctx", None)
-        if ctx is None:
-            self._fill_queue_with_batches_inner()
-        else:
-            ctx.run(self._fill_queue_with_batches_inner)
+        self._captured_ctx.run(run)
 
     def _fill_queue_with_batches_inner(self):
         try:

--- a/lib/levanter/src/levanter/utils/background_iterable.py
+++ b/lib/levanter/src/levanter/utils/background_iterable.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import asyncio
+import contextvars
 import queue
 import sys
 import threading
@@ -48,6 +49,14 @@ class BackgroundIterator(Iterator[Ex]):
         else:
             self._producer_fn = producer_fn
         self._stop_event = threading.Event()
+        # Capture the parent thread's ContextVars so the prefetch thread runs
+        # under the same JAX mesh / sharding context. threading.Thread does NOT
+        # propagate ContextVars by default; without this, jits traced inside
+        # _fill_queue_with_batches see an empty mesh context and fall back to
+        # CPU, causing "Received incompatible devices" when the resulting array
+        # meets TPU-resident data downstream. See tomat
+        # specs/done/31-tz11-postmortem.md for the full debugging story.
+        self._captured_ctx = contextvars.copy_context()
 
         if self.max_capacity is None or self.max_capacity >= 0:
             self.q: queue.Queue = queue.Queue(self.max_capacity or 0)
@@ -96,6 +105,13 @@ class BackgroundIterator(Iterator[Ex]):
             self.thread.join()
 
     def _fill_queue_with_batches(self):
+        ctx = getattr(self, "_captured_ctx", None)
+        if ctx is None:
+            self._fill_queue_with_batches_inner()
+        else:
+            ctx.run(self._fill_queue_with_batches_inner)
+
+    def _fill_queue_with_batches_inner(self):
         try:
             iterator = self._producer_fn()
         except Exception:

--- a/lib/levanter/src/levanter/utils/background_iterable.py
+++ b/lib/levanter/src/levanter/utils/background_iterable.py
@@ -49,14 +49,28 @@ class BackgroundIterator(Iterator[Ex]):
         else:
             self._producer_fn = producer_fn
         self._stop_event = threading.Event()
-        # Capture the parent thread's ContextVars so the prefetch thread runs
-        # under the same JAX mesh / sharding context. threading.Thread does NOT
-        # propagate ContextVars by default; without this, jits traced inside
-        # _fill_queue_with_batches see an empty mesh context and fall back to
-        # CPU, causing "Received incompatible devices" when the resulting array
-        # meets TPU-resident data downstream. See tomat
-        # specs/done/31-tz11-postmortem.md for the full debugging story.
+        # Capture the parent thread's ContextVars + JAX mesh stack so the
+        # prefetch thread runs under the same JAX mesh / sharding context.
+        # threading.Thread does NOT propagate either by default; without
+        # this, jits traced inside _fill_queue_with_batches see an empty
+        # mesh and fall back to CPU, causing "Received incompatible devices"
+        # when the resulting array meets TPU-resident data downstream.
+        #
+        # JAX stores its active-mesh stack in a `threading.local` subclass
+        # (`jax._src.mesh.thread_resources`), NOT a ContextVar — so
+        # `copy_context()` alone is insufficient. Snapshot the mesh stack
+        # manually here and restore it inside the prefetch thread.
         self._captured_ctx = contextvars.copy_context()
+        self._captured_jax_mesh_stack: Optional[list] = None
+        self._captured_jax_mesh_env = None
+        try:
+            # Lazy import of a JAX private internal; guarded for version drift.
+            from jax._src.mesh import thread_resources as _jax_thread_resources  # noqa: PLC0415
+
+            self._captured_jax_mesh_stack = list(_jax_thread_resources.stack)
+            self._captured_jax_mesh_env = _jax_thread_resources.env
+        except Exception:
+            pass
 
         if self.max_capacity is None or self.max_capacity >= 0:
             self.q: queue.Queue = queue.Queue(self.max_capacity or 0)
@@ -105,6 +119,21 @@ class BackgroundIterator(Iterator[Ex]):
             self.thread.join()
 
     def _fill_queue_with_batches(self):
+        # Restore JAX's thread-local mesh stack in this producer thread,
+        # since `threading.Thread` doesn't carry it across. This is the
+        # actual fix for the eval-mesh ValueError; `copy_context` below
+        # is belt-and-suspenders for any non-mesh ContextVars.
+        mesh_stack = getattr(self, "_captured_jax_mesh_stack", None)
+        mesh_env = getattr(self, "_captured_jax_mesh_env", None)
+        if mesh_stack is not None:
+            try:
+                from jax._src.mesh import thread_resources as _jax_thread_resources  # noqa: PLC0415
+
+                _jax_thread_resources.stack = list(mesh_stack)
+                if mesh_env is not None:
+                    _jax_thread_resources.env = mesh_env
+            except Exception:
+                pass
         ctx = getattr(self, "_captured_ctx", None)
         if ctx is None:
             self._fill_queue_with_batches_inner()

--- a/lib/levanter/tests/test_background_iterable.py
+++ b/lib/levanter/tests/test_background_iterable.py
@@ -3,7 +3,11 @@
 
 import asyncio
 
+import haliax.partitioning as hpart
+import jax
+import numpy as np
 import pytest
+from jax.sharding import Mesh
 
 from levanter.utils.background_iterable import BackgroundIterable
 
@@ -144,3 +148,28 @@ async def test_async_stop_event(max_capacity):
     with pytest.raises(StopIteration):
         next(iter1)
         next(iter1)
+
+
+@pytest.mark.parametrize("max_capacity", [None, 10])
+def test_producer_thread_runs_under_captured_mesh(max_capacity):
+    """The prefetch thread must run the producer under the parent's JAX mesh.
+
+    Regression for the eval-boundary "Received incompatible devices" crash: a
+    fresh threading.Thread inherits neither ContextVars nor JAX's active mesh,
+    so without an explicit re-entry the producer traces jits on an empty CPU
+    mesh. On modern JAX the mesh lives in the concrete-mesh config, which
+    copy_context() alone does not carry across the thread boundary.
+    """
+    mesh = Mesh(np.array(jax.devices()).reshape(1, 1), ("data", "model"))
+    seen_axis_names = []
+
+    def producer():
+        seen = hpart.get_concrete_mesh()
+        seen_axis_names.append(None if seen is None or seen.empty else tuple(seen.axis_names))
+        yield 1
+
+    with hpart.set_mesh(mesh):
+        result = list(BackgroundIterable(producer, max_capacity=max_capacity))
+
+    assert result == [1]
+    assert seen_axis_names == [("data", "model")]

--- a/lib/levanter/tests/test_background_iterable.py
+++ b/lib/levanter/tests/test_background_iterable.py
@@ -160,7 +160,8 @@ def test_producer_thread_runs_under_captured_mesh(max_capacity):
     mesh. On modern JAX the mesh lives in the concrete-mesh config, which
     copy_context() alone does not carry across the thread boundary.
     """
-    mesh = Mesh(np.array(jax.devices()).reshape(1, 1), ("data", "model"))
+    # N×1 so this works regardless of device count (1 on CPU, >1 on TPU CI).
+    mesh = Mesh(np.array(jax.devices()).reshape(-1, 1), ("data", "model"))
     seen_axis_names = []
 
     def producer():


### PR DESCRIPTION
The prefetch thread spawned in BackgroundIterator ran with an empty JAX context,
so jits traced inside the producer (e.g. stack_tree) fell back to a CPU mesh and
raised "Received incompatible devices" when their output met TPU data at the eval
boundary. Capture the parent's ContextVars and snapshot JAX's thread-local mesh
stack, reinstalling both in the prefetch thread. The mesh-stack snapshot touches
jax._src.mesh internals and is guarded for version drift.
