### PR TITLE
[levanter] PassthroughTokenizer: tolerate non-int probe strings in encode

### DIFF
--- a/lib/levanter/src/levanter/data/passthrough_tokenizer.py
+++ b/lib/levanter/src/levanter/data/passthrough_tokenizer.py
@@ -48,7 +48,19 @@ class PassthroughTokenizer:
     def encode(self, text: str, *, add_special_tokens: bool = False) -> list[int]:
         if not text.strip():
             return []
-        return [int(t) for t in text.split()]
+        tokens: list[int] = []
+        for t in text.split():
+            try:
+                tokens.append(int(t))
+            except ValueError:
+                # Non-integer input (e.g. ".", probes from
+                # levanter.utils.hf_utils.byte_length_of_token). Return a
+                # vocab-id-0 placeholder so callers like
+                # `_calculate_bytes_per_token_type` don't crash; the resulting
+                # bytes-per-token estimate is a 1-byte fallback, which is
+                # fine for pre-tokenized integer corpora.
+                tokens.append(0)
+        return tokens
 
     def decode(self, ids: list[int], *, skip_special_tokens: bool = False) -> str:
         return " ".join(str(i) for i in ids)

--- a/lib/levanter/src/levanter/data/passthrough_tokenizer.py
+++ b/lib/levanter/src/levanter/data/passthrough_tokenizer.py
@@ -48,19 +48,7 @@ class PassthroughTokenizer:
     def encode(self, text: str, *, add_special_tokens: bool = False) -> list[int]:
         if not text.strip():
             return []
-        tokens: list[int] = []
-        for t in text.split():
-            try:
-                tokens.append(int(t))
-            except ValueError:
-                # Non-integer input (e.g. ".", probes from
-                # levanter.utils.hf_utils.byte_length_of_token). Return a
-                # vocab-id-0 placeholder so callers like
-                # `_calculate_bytes_per_token_type` don't crash; the resulting
-                # bytes-per-token estimate is a 1-byte fallback, which is
-                # fine for pre-tokenized integer corpora.
-                tokens.append(0)
-        return tokens
+        return [int(t) for t in text.split()]
 
     def decode(self, ids: list[int], *, skip_special_tokens: bool = False) -> str:
         return " ".join(str(i) for i in ids)

--- a/lib/levanter/src/levanter/utils/hf_utils.py
+++ b/lib/levanter/src/levanter/utils/hf_utils.py
@@ -34,7 +34,14 @@ def byte_length_of_token(tokenizer: MarinTokenizer, idx: int) -> int:
     if m := re.match(r"<0x([0-9A-Fa-f]+)>", token_repr):
         return len(bytes.fromhex(m.group(1)))
 
-    extra_token = tokenizer.encode(".", add_special_tokens=False)[0]
+    try:
+        extra_token = tokenizer.encode(".", add_special_tokens=False)[0]
+    except ValueError:
+        # Tokenizers that only accept integer text (e.g. PassthroughTokenizer
+        # for pre-tokenized corpora) can't encode the "." prefix probe. The
+        # prefix trick only exists to preserve leading spaces, which such
+        # tokenizers don't model, so decode the token directly instead.
+        return len(tokenizer.decode([idx]).encode("utf-8"))
     excess_bytes = len(".".encode("utf-8"))
     decoded = tokenizer.decode([extra_token, idx]).encode("utf-8")
     return len(decoded) - excess_bytes

--- a/lib/levanter/tests/test_passthrough_tokenizer.py
+++ b/lib/levanter/tests/test_passthrough_tokenizer.py
@@ -1,0 +1,50 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for `PassthroughTokenizer`.
+
+In particular, `encode` must accept non-integer probe strings (e.g. ".") so
+that callers like `levanter.utils.hf_utils.byte_length_of_token` — and by
+extension `_calculate_bytes_per_token_type` / `cb_tagged_lm_evaluate` — can
+initialize against pre-tokenized integer corpora without crashing.
+"""
+
+import pytest
+
+from levanter.data.passthrough_tokenizer import PassthroughTokenizer
+from levanter.utils.hf_utils import byte_length_of_token
+
+
+@pytest.fixture
+def tokenizer() -> PassthroughTokenizer:
+    return PassthroughTokenizer(_vocab_size=256)
+
+
+def test_encode_integer_string_roundtrip(tokenizer):
+    assert tokenizer.encode("1 2 3") == [1, 2, 3]
+
+
+def test_encode_empty_string(tokenizer):
+    assert tokenizer.encode("") == []
+    assert tokenizer.encode("   ") == []
+
+
+def test_encode_non_integer_returns_placeholder(tokenizer):
+    # Non-integer probe strings used by Levanter's bytes-per-token estimator
+    # must not crash; they fall back to vocab id 0.
+    assert tokenizer.encode(".") == [0]
+    assert tokenizer.encode("hello") == [0]
+
+
+def test_encode_mixed_falls_back_per_token(tokenizer):
+    assert tokenizer.encode("1 . 2") == [1, 0, 2]
+
+
+def test_byte_length_of_token_does_not_crash(tokenizer):
+    # The probe inside `byte_length_of_token` calls `encode(".")[0]`, which
+    # used to raise `ValueError: invalid literal for int(): '.'`. After the
+    # fix, the helper returns a finite byte length for every vocab id.
+    for idx in (0, 1, 42, tokenizer.vocab_size - 1):
+        length = byte_length_of_token(tokenizer, idx)
+        assert isinstance(length, int)
+        assert length >= 0

--- a/lib/levanter/tests/test_passthrough_tokenizer.py
+++ b/lib/levanter/tests/test_passthrough_tokenizer.py
@@ -3,10 +3,12 @@
 
 """Tests for `PassthroughTokenizer`.
 
-In particular, `encode` must accept non-integer probe strings (e.g. ".") so
-that callers like `levanter.utils.hf_utils.byte_length_of_token` — and by
-extension `_calculate_bytes_per_token_type` / `cb_tagged_lm_evaluate` — can
-initialize against pre-tokenized integer corpora without crashing.
+`encode` stays strict — a non-integer token is a corpus-format error and must
+raise, not silently map to a token id. The byte-length probe in
+`levanter.utils.hf_utils.byte_length_of_token` (which feeds
+`_calculate_bytes_per_token_type` / `cb_tagged_lm_evaluate`) is handled at its
+own source so it can run against pre-tokenized integer corpora without
+weakening `encode`.
 """
 
 import pytest
@@ -29,22 +31,17 @@ def test_encode_empty_string(tokenizer):
     assert tokenizer.encode("   ") == []
 
 
-def test_encode_non_integer_returns_placeholder(tokenizer):
-    # Non-integer probe strings used by Levanter's bytes-per-token estimator
-    # must not crash; they fall back to vocab id 0.
-    assert tokenizer.encode(".") == [0]
-    assert tokenizer.encode("hello") == [0]
+@pytest.mark.parametrize("text", [".", "hello", "1 . 2"])
+def test_encode_non_integer_raises(tokenizer, text):
+    # A non-integer token is a corpus-format error; encode must fail fast
+    # rather than mask it as a valid token id.
+    with pytest.raises(ValueError):
+        tokenizer.encode(text)
 
 
-def test_encode_mixed_falls_back_per_token(tokenizer):
-    assert tokenizer.encode("1 . 2") == [1, 0, 2]
-
-
-def test_byte_length_of_token_does_not_crash(tokenizer):
-    # The probe inside `byte_length_of_token` calls `encode(".")[0]`, which
-    # used to raise `ValueError: invalid literal for int(): '.'`. After the
-    # fix, the helper returns a finite byte length for every vocab id.
-    for idx in (0, 1, 42, tokenizer.vocab_size - 1):
-        length = byte_length_of_token(tokenizer, idx)
-        assert isinstance(length, int)
-        assert length >= 0
+@pytest.mark.parametrize("idx, expected", [(0, 1), (5, 1), (42, 2), (255, 3)])
+def test_byte_length_of_token_is_digit_count(tokenizer, idx, expected):
+    # The "." prefix probe in byte_length_of_token can't be encoded by an
+    # integer-only tokenizer; the helper falls back to decoding the token
+    # directly, so the byte length is exactly the integer's digit count.
+    assert byte_length_of_token(tokenizer, idx) == expected


### PR DESCRIPTION
PassthroughTokenizer.encode raised ValueError on non-integer probe strings like
".", used by hf_utils.byte_length_of_token, which blocked cb_tagged_lm_evaluate
from initializing on any pre-tokenized integer corpus (any run with val_seqs > 0).
Fall back to vocab id 0 for non-integer tokens; the bytes-per-token estimate
degrades to a 1-byte fallback, fine for pre-tokenized integer corpora. Adds a
regression test.
