### PR TITLE
[levanter] Fall through to cache rebuild on partial-cache FileNotFoundError

### DIFF
--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -910,8 +910,15 @@ class LmDataConfig:
                 return name, cache, None
 
             if cache_exists:
-                cache = load_lm_dataset_cache(cache_path, component.format, self.the_tokenizer, self.enforce_eos)
-                return name, cache, None
+                try:
+                    cache = load_lm_dataset_cache(cache_path, component.format, self.the_tokenizer, self.enforce_eos)
+                    return name, cache, None
+                except FileNotFoundError:
+                    logger.warning(
+                        f"Cache dir at {cache_path} exists but is unloadable (likely a "
+                        "partial build from a killed prior cache-build job); auto_build_caches "
+                        "is on, so falling through to rebuild."
+                    )
             return name, None, (cache_path, shard_source, component.format)
 
         caches: dict[str, TreeCache[dict]] = {}


### PR DESCRIPTION
When auto_build_caches is set and a cache directory exists but lacks
shard_ledger.json (the leftover of a killed prior cache build),
load_lm_dataset_cache raised FileNotFoundError unguarded, so the trainer
crash-looped on the partial state instead of rebuilding. Catch it, log a warning,
and fall through to the build path. No-op on a healthy cache.
