### PR TITLE
[iris] Add morrisy to marin user budgets

### DIFF
--- a/lib/iris/config/marin.yaml
+++ b/lib/iris/config/marin.yaml
@@ -231,5 +231,6 @@ user_budgets:
       - ryan
       - marinazh
       - benjaminfeuer
+      - morrisy
     budget_limit: 75000
     max_band: PRIORITY_BAND_INTERACTIVE


### PR DESCRIPTION
Add morrisy to the researcher tier of marin user_budgets (budget_limit 75000,
  PRIORITY_BAND_INTERACTIVE) so the account has a budget entry on the marin
  controller and can submit jobs. The live controller currently has no budget
  for this user.
