### PR TITLE
[agents] Add shared testing policy

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -16,9 +16,10 @@ commit. The review is read-only: it never edits, commits, or pushes for you.
 
 ## Checklist
 
-Work top to bottom. For a quick work-in-progress checkpoint, do **1, 2, 4, 5, 7**
-(clean up, lint, stage, commit, push) and stop. Run the whole list before you
-open or update a PR.
+Work top to bottom. For a quick work-in-progress checkpoint, do **1, 2, 4, 5,
+7** (clean up, lint, stage, commit, push) and stop. The changed-test cleanup in
+step 1 is a PR-readiness gate, not required for disposable WIP checkpoints. Run
+the whole list before you open or update a PR.
 
 1. Clean up your own diff (self-review).
 2. Mechanical lint & format — `./infra/pre-commit.py --changed-files --fix`.
@@ -26,7 +27,7 @@ open or update a PR.
 4. Stage the specific files for this work.
 5. Commit. ← natural checkpoint; the working tree is now clean.
 6. Lint-catalog review — `./infra/pre-commit.py --review`; fix or answer every finding.
-7. Push.
+7. Push (maybe).
 8. Open or update the PR.
 
 ## 1. Clean up your own diff
@@ -35,6 +36,17 @@ Read your own `git diff` before anything else. Drop dead code, debugging
 leftovers, and stale comments; tighten names; make the change say only what it
 means to. The review in step 6 is advisory and read-only — it will not clean up
 for you.
+
+If the diff touches tests and this commit is intended for a PR or review, read
+root `TESTING.md` and the relevant module-specific `AGENTS.md` or testing docs
+as part of this self-review. Review every changed test for slop: tautological
+assertions, disposable smoke probes left as pytest tests, internal call-count
+assertions, incidental string or command-fragment assertions, over-mocking,
+weakened tolerances, sleeps, skipped tests, and local marker/fake/mock
+violations.
+
+Fix or delete low-value tests before a PR-ready commit. Scratch probes are fine
+during development and WIP checkpointing, but they must not survive into a PR.
 
 ## 2. Lint and format
 
@@ -102,7 +114,7 @@ read it when a lane is slow or a run looks wrong.
 
 ## 7. Push
 
-Push to the remote tracking branch (`git push -u origin HEAD` if no upstream is
+If asked, or if the branch has an upstream, push to the remote tracking branch (`git push -u origin HEAD` if no upstream is
 set). If the push is rejected (diverged history), stop and ask the user — do not
 force-push.
 
@@ -162,6 +174,7 @@ gh pr create --title "<title>" --body "<plain text body>" --label agent-generate
 - Always add the `agent-generated` label.
 - Never credit yourself in commits or PR descriptions.
 - Include `Fixes #NNNN` when addressing a pre-existing issue.
+- If you have a specific github tool, you may use it.
 
 ## 9. Monitor the PR — mandatory, in a loop
 

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -28,7 +28,7 @@ Follow these steps precisely:
 
 4. Launch 4 agents in parallel to independently review the changes. Each returns a list of issues; each issue includes a description and the reason it was flagged (e.g. "CLAUDE.md adherence", "bug").
 
-   Agents 1 + 2: CLAUDE.md/AGENTS.md compliance sonnet agents. Audit changes for compliance. When evaluating a file, only consider CLAUDE.md/AGENTS.md files that share its path or are parents.
+   Agents 1 + 2: CLAUDE.md/AGENTS.md compliance sonnet agents. Audit changes for compliance. When evaluating a file, only consider CLAUDE.md/AGENTS.md files that share its path or are parents. If the PR adds or changes tests, read root `TESTING.md` plus the relevant module-specific testing docs, and check for low-value/slop tests or local testing-policy violations.
 
    Agents 3 + 4: Opus bug agents (parallel). Scan for obvious bugs, security issues, and incorrect logic within the changed code. Focus only on the diff without reading extra context. Flag only significant bugs you can validate from the diff alone; ignore nitpicks and likely false positives.
 
@@ -114,7 +114,8 @@ Notes:
 
 - Use gh CLI to interact with GitHub (e.g., fetch pull requests, create comments). Do not use web fetch.
 - Create a todo list before starting.
-- You must cite and link each issue in inline comments (e.g., if referring to a CLAUDE.md, include a link to it).
+- You must cite and link each issue in inline comments (e.g., if referring to a CLAUDE.md, include a link to it ideally with line number).
+- For changed tests, use root `TESTING.md` and the relevant module-specific `AGENTS.md`/`TESTING.md`/testing docs as the review checklist. Flag only concrete violations; do not use them to request broad coverage improvements.
 - If no issues are found and `--comment` argument is provided, post a comment with the following format:
 
 ---

--- a/.agents/skills/write-tests/SKILL.md
+++ b/.agents/skills/write-tests/SKILL.md
@@ -1,0 +1,46 @@
+---
+name: write-tests
+description: Write or revise Marin tests with an emphasis on behavior, regression coverage, pytest style, and avoiding "slop tests." Use when adding tests, fixing failing tests, reviewing test quality, or deciding what test would catch a bug.
+---
+
+# Write Tests
+
+Use this skill when a change needs tests or when existing tests look too coupled
+to implementation details.
+
+Read root `TESTING.md` before writing or reviewing non-trivial tests. It is the
+shared project-wide testing policy used by `write-tests`, `review-pr`, and
+`commit`.
+
+Also read the relevant module-specific docs before choosing test style,
+fixtures, mocks, markers, or commands:
+
+- root `AGENTS.md`
+- root `TESTING.md`
+- the nearest subproject `AGENTS.md` for files under `lib/*`
+- package testing docs referenced from that `AGENTS.md`, such as
+  `lib/iris/TESTING.md`
+
+## Workflow
+
+1. Find existing tests for the touched behavior before creating a new file.
+2. Check module-specific testing rules for commands, markers, fakes, mocks, and
+   numerical tolerances.
+3. Name the behavior that should fail if the code is wrong.
+4. Write the smallest test that observes that behavior through a public API,
+   structured output, persisted state, or real side effect.
+5. Prefer a regression test before the fix when fixing a bug. Ensure the test fails before implementing the bug fix.
+6. Keep test setup realistic but small. Use fixtures and parameterization to
+   remove duplication.
+7. Run the narrow test first, then the relevant package test command. Before a
+   PR, run the repo lint entry point required by `AGENTS.md`.
+
+## Default Commands
+
+- Root or mixed changes: `uv run pytest -m 'not slow'` over touched test dirs.
+- For package-specific commands, use the relevant `lib/*/AGENTS.md` or testing
+  doc.
+
+For PR preparation, run `./infra/pre-commit.py --changed-files --fix` or
+`./infra/pre-commit.py --all-files --fix` as appropriate. Do not replace it
+with `uv run pre-commit`.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -148,20 +148,12 @@ Dependency direction: {`iris`, `haliax`} → {`levanter`, `zephyr`} → `marin`.
 
 ## Testing
 
-- Always fix tests you broke. Do not relax tolerances or hack around failures.
-- Prefer integration-style tests that validate externally-observable behavior.
-- Do not write tautological tests: tests must fail if behavior is wrong, not just if implementation changes.
-- Do not write "slop" tests that assert on incidental strings — the exact text of a log
-  message, or that a constructed command line contains a particular word or flag. These
-  couple the test to copy and to how a command is assembled, not to behavior: they break
-  on a harmless reword or flag-form change while a real regression slips through. They are
-  pure maintenance burden. Assert on the structured output or the effect instead. Assert on
-  a string only when that string *is* the contract (machine-readable output, a wire format,
-  a log line a downstream tool parses) — and then assert on the structured field, not the
-  rendered text.
-- Use pytest fixtures and parameterization to avoid duplication.
-- Prefer top-level `def test_*` with fixtures over test classes.
-- Search for existing test files before creating new ones. Extend existing files first.
-- No mocks unless testing I/O boundaries (network, filesystem). Test against real behavior.
-- No `time.sleep()` in tests — inject `now=time.time()` or mock time instead.
-- Mock at boundaries (e.g., wandb), not internal logger output.
+Read `TESTING.md` before writing or reviewing tests. It is the root testing
+policy for behavior-focused tests, slop-test rejection, mocks/fakes, timing,
+numerical tolerances, and pytest style.
+
+Before touching tests under `lib/*`, also read the nearest module `AGENTS.md`
+and any module `TESTING.md` it references. Module docs define local commands,
+markers, fakes, mocks, optional dependencies, and integration-test boundaries.
+
+Always fix tests you broke. Do not relax tolerances or hack around failures.

--- a/TESTING.md
+++ b/TESTING.md
@@ -1,0 +1,152 @@
+# Testing Guidelines
+
+This is Marin's project-wide testing policy. Module-specific `AGENTS.md` and
+`TESTING.md` files are authoritative for local commands, markers, fakes, mocks,
+numerical tolerances, and integration-test boundaries. Before writing or
+reviewing tests, read root `AGENTS.md`, this file, the nearest module
+`AGENTS.md`, and any testing docs referenced there.
+
+## Core Rule
+
+A test must fail when behavior is wrong. It should not fail only because an
+implementation detail, wording choice, helper call, or command assembly changed.
+
+Prefer integration-style tests that validate externally observable behavior:
+
+- public API return values
+- structured output or machine-readable fields
+- persisted state
+- real side effects in a temp directory or in-memory fake
+- state transitions visible through the public event/status API
+- numerical value and gradient parity against an independent reference
+
+It is better to not have a test than to have "slop" tests (tautological or other useless tests). See below.
+
+## Good Targets
+
+- A regression for a reported bug.
+- A boundary case where user-visible behavior changes: empty input, duplicate
+  names, incompatible shapes, quota or capacity limits, timeout behavior, failed
+  workers, bad files, or invalid configs.
+- A round trip through the public API: submit a job, observe status, write
+  chunks, read chunks, serialize, deserialize, reload.
+- A stable contract: wire format, schema field, CLI JSON output, checkpoint
+  layout, or public exception type.
+- For numerical code, parity against an obvious reference implementation across
+  a small shape/dtype grid.
+
+## Slop Tests To Reject
+
+Delete or rewrite tests with negative value:
+
+- Tautologies: constant equals itself, method exists, object constructor assigns
+  attributes, `len(list) >= 0`, type exists. This definition should be construed broadly.
+- Private state: assertions on private attributes or `_`-prefixed state.
+- Incidental strings: assertions on human log text, progress messages, command
+  fragments, or copied prose.
+- Internal helper dispatch: assertions on `assert_called_once_with`, call count,
+  or "helper X was invoked" for in-process helpers.
+- Reimplementation: Tests that reimplement the production logic and compare the implementation to
+  itself.
+- Obvious error-condition behavior: Obvious error-condition tests that only prove a type checker, dataclass
+  constructor, or standard library function works. Infrastructure failure modes
+  are valid when the failure is externally observable.
+- Tests for Python language semantics.
+- Registration tests: Tests that check that specific items are registered in global registries.
+- Permanently skipped tests or empty test files.
+- Screenshot-only tests without behavioral assertions.
+- "Does not raise" tests without a comment explaining why that is the contract.
+- "Does raise" tests if the exception type is not part of the contract or an important regression signal.
+
+Disposable smoke probes are different from checked-in tests. During development,
+use scratch scripts, REPL snippets, or temporary local assertions to confirm
+imports, object construction, or fixture wiring. Do not leave those as pytest
+tests. Before a PR-ready commit, replace them with behavior assertions or delete
+them.
+
+String assertions are allowed when the string is the contract: a wire format,
+machine-readable output, a downstream-parsed log line, or an exact user-facing
+error promised by the API. Assert on structured fields when possible.
+
+Command construction is rarely the contract. Prefer to run through the boundary
+and assert the effect. If the command line is the contract, assert the parsed
+argv or structured command object, not a substring in rendered shell text.
+
+## Mocks And Fakes
+
+Default to real behavior. Use mocks only at I/O boundaries:
+
+- subprocesses such as `gcloud` or `kubectl`
+- HTTP or remote APIs
+- GCS, W&B, or other external services
+- filesystem boundaries that would be slow, expensive, or destructive
+
+Prefer fakes over mocks when practical: in-memory services, temp directories,
+local clients, fake schedulers, and fake clocks. Check module-specific docs for
+existing fakes before adding a new one.
+
+Do not mock internal functions to prove wiring. If a side effect matters, expose
+or observe it through a public API or use a fake that records stable state.
+If this is difficult, it may be a sign that you shouldn't test that behavior or that the API needs to be redesigned to make it testable without mocks.
+
+## Timing
+
+Do not use `time.sleep()` in tests. Inject `now=time.time()`, use a fake clock,
+or use existing deadline/backoff helpers.
+
+Use module-specific deadline, backoff, polling, or fake-clock helpers when they
+exist. A single short sleep to let a background thread start is acceptable only
+with a comment that names the race being avoided.
+
+## Numerical Tests
+
+Do not relax tolerances without human agreement. Exact tolerance values may be
+module-specific; the global rule is that agents do not weaken them without
+explicit agreement from the user.
+
+Use module-specific slow-test markers and optional-dependency markers as
+appropriate.
+
+For kernels, start from an obvious reference: existing in-repo code, a PyTorch
+reference, Optax/JAX baseline, or clear pseudocode. Check:
+
+- value parity over a small shape/dtype grid
+- gradient parity on small shapes
+- CPU numerics and accelerator-aligned fast paths when applicable
+- pointwise deviation metrics such as max and mean absolute difference, not only
+  `allclose`
+- If sharding is relevant, check parallelization and shard-local numerics separately.
+
+Keep the reference independent and simple. A clever reference that shares the same bug as
+the implementation is not useful.
+
+## Pytest Style
+
+- Prefer top-level `def test_*` functions with fixtures over test classes.
+- Name tests as `test_<subject>_<scenario>_<expected_outcome>`.
+- Use parameterization for meaningful behavior variation.
+- Extend existing test files before creating new ones.
+- Every test must contain an assertion or `pytest.raises`.
+- Remove dead helpers, unused fakes, unused imports, and empty stubs.
+- Mark slow, Docker, and cluster-dependent tests with the package's established
+  markers.
+- For non-trivial public classes with protocols, test the protocol behavior
+  rather than concrete private state.
+
+## Review Checklist
+
+When reviewing tests, flag the test if the answer to any question is "yes":
+
+- Would this test pass if the behavior were wrong?
+- Would this test fail only because a helper was renamed or a log line changed?
+- Is it asserting on private state, call counts, or internal dispatch?
+- Does it duplicate the implementation instead of checking an independent
+  oracle or observable behavior?
+- Is the mock inside the system under test rather than at an external boundary?
+- Does it sleep, skip permanently, or lack a real assertion?
+- Did the change weaken a numerical tolerance or test expectation without justification?
+- Does it ignore local `AGENTS.md` or module `TESTING.md` rules for markers,
+  fakes, mocks, commands, optional dependencies, or integration boundaries?
+
+Ask for low-value tests to be deleted or rewritten. More tests are not better
+when they pin implementation details and miss real regressions.

--- a/docs/dev-guide/coding-standards.md
+++ b/docs/dev-guide/coding-standards.md
@@ -310,13 +310,12 @@ dependencies. Cleanup workflows should flag any violation.
 
 ## 11. Testing Standards
 
-- Use `pytest` with fixtures and parameterization. Top-level `def test_*`
-  functions, not test classes.
-- Prefer integration-style tests that validate observable behavior.
-- No tautological tests (asserting that a constructor sets an attribute).
-- No mocks except at I/O boundaries. Prefer fakes backed by in-memory state.
-- Every test function must contain at least one `assert` or `pytest.raises`.
-- Run relevant tests before submitting: `uv run pytest -m 'not slow' <paths>`.
+Root `TESTING.md` is the canonical project-wide testing policy. Read it before
+writing or reviewing tests.
+
+For tests under `lib/*`, also read the nearest module `AGENTS.md` and any module
+`TESTING.md` it references. Module docs define local commands, markers, fakes,
+mocks, optional dependencies, and integration-test boundaries.
 
 ---
 


### PR DESCRIPTION
Move Marin's project-wide testing guidance into root TESTING.md so agents and humans use the same source for behavior-focused tests, slop-test rejection, mocks/fakes, timing, and tolerance rules.

Add a write-tests skill that points agents at TESTING.md plus module-specific docs. Update commit and review-pr workflows to use the root policy when changed tests are PR-bound or under review.