### PR TITLE
[levanter] Sandbox chat template rendering

### DIFF
--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -30,6 +30,7 @@ from typing import Any, Protocol, runtime_checkable
 import fsspec
 import jinja2
 import jinja2.ext
+import jinja2.sandbox
 from huggingface_hub import __version__ as _hf_hub_version
 from huggingface_hub import hf_hub_download, snapshot_download
 from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError
@@ -192,7 +193,7 @@ class _GenerationStripExtension(jinja2.ext.Extension):
 
 def _make_jinja_env(extensions: list[type]) -> jinja2.Environment:
     """Create a jinja2 environment matching HF's template rendering settings."""
-    env = jinja2.Environment(
+    env = jinja2.sandbox.SandboxedEnvironment(
         undefined=jinja2.StrictUndefined,
         trim_blocks=True,
         lstrip_blocks=True,

--- a/lib/levanter/tests/test_tokenizers.py
+++ b/lib/levanter/tests/test_tokenizers.py
@@ -13,15 +13,19 @@ import os
 import pathlib
 import re
 import shutil
+from typing import cast
 from unittest.mock import patch
 
+import jinja2.exceptions
 import pytest
 from huggingface_hub import __version__ as _hf_hub_version
+from tokenizers import Tokenizer as HfBaseTokenizer
 
 import levanter.tokenizers as tk
 from levanter.data.text._batch_tokenizer import BatchTokenizer
 from levanter.data.text.formats import ChatProcessor
 from levanter.tokenizers import (
+    HfMarinTokenizer,
     MarinTokenizer,
     TokenizerBackend,
     _load_tokenizer_config,
@@ -1016,6 +1020,24 @@ def test_chat_template_add_generation_prompt(chat_tokenizer):
     with_prompt = chat_tokenizer.apply_chat_template(conversation, tokenize=False, add_generation_prompt=True)
     # With generation prompt should be at least as long
     assert len(with_prompt) >= len(without)
+
+
+def test_chat_template_blocks_python_internal_attribute_access():
+    tokenizer = HfMarinTokenizer(
+        _tokenizer=cast(HfBaseTokenizer, object()),
+        _name_or_path="malicious-tokenizer",
+        _bos_id=None,
+        _eos_id=None,
+        _pad_id=None,
+        _bos_token=None,
+        _eos_token=None,
+        _chat_template="{{ ''.__class__.__mro__[1].__subclasses__() }}",
+        _vocab_size=0,
+        _all_special_ids=[],
+    )
+
+    with pytest.raises(jinja2.exceptions.SecurityError):
+        tokenizer.apply_chat_template([{"role": "user", "content": "hi"}], tokenize=False)
 
 
 @requires_model


### PR DESCRIPTION
Switch Levanter chat-template rendering to Jinja2's sandboxed environment so tokenizer-provided templates cannot traverse Python internals during render. The shared environment construction keeps the existing strict undefined behavior, whitespace settings, and custom generation extensions for both direct rendering and mask rendering.

Adds a regression test for a malicious tokenizer chat_template that attempts Python internal attribute traversal.