### PR TITLE
[iris] Autoscaler cloud ops: functional issue → serial fold (T6)

### DIFF
--- a/lib/iris/src/iris/cluster/backends/local/cluster.py
+++ b/lib/iris/src/iris/cluster/backends/local/cluster.py
@@ -143,7 +143,6 @@ def create_local_autoscaler(
         scale_groups=scale_groups,
         config=config.defaults.autoscaler,
         platform=platform,
-        threads=threads,
         base_worker_config=base_worker_config,
     )
     return autoscaler, temp_dir

--- a/lib/iris/src/iris/cluster/controller/autoscaler/recovery.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/recovery.py
@@ -4,7 +4,6 @@
 """Autoscaler checkpoint restore helpers."""
 
 import logging
-import threading
 from dataclasses import dataclass
 
 from sqlalchemy import select
@@ -145,18 +144,15 @@ def restore_autoscaler_state(
 
 
 def _reclaim_dead_slice(handle: SliceHandle, state: CloudSliceState) -> None:
-    """Best-effort terminate of a dead slice in a daemon thread.
+    """Best-effort terminate of a dead slice during boot recovery.
 
-    Boot recovery must not block on or fail because of a stale cloud resource:
-    terminate() can hit transient API errors and is not guaranteed to be fast.
-    Errors are logged; on the next restart the slice will surface again.
+    ``terminate()`` is a bounded cloud request (an async delete that returns
+    immediately), issued in line here. Boot recovery must not fail because of a
+    stale cloud resource, so transient API errors are logged and swallowed; on
+    the next restart the slice will surface again.
     """
     logger.info("Reclaiming dead slice %s (state=%s, zone=%s)", handle.slice_id, state, handle.zone)
-
-    def _run() -> None:
-        try:
-            handle.terminate()
-        except Exception as e:
-            logger.warning("Failed to terminate dead slice %s: %s", handle.slice_id, e)
-
-    threading.Thread(target=_run, name=f"reclaim-{handle.slice_id}", daemon=True).start()
+    try:
+        handle.terminate()
+    except Exception as e:
+        logger.warning("Failed to terminate dead slice %s: %s", handle.slice_id, e)

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -21,8 +21,10 @@ import logging
 import urllib.error
 import urllib.request
 from collections import deque
-from collections.abc import Sequence
+from collections.abc import Callable, Sequence
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass
+from typing import TypeVar
 
 from rigging.timing import Duration, Timestamp, TokenBucket
 
@@ -55,7 +57,6 @@ from iris.cluster.controller.autoscaler.worker_registry import TrackedWorker, Wo
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.worker_health import CONSECUTIVE_FAILURE_THRESHOLD
 from iris.cluster.types import WorkerStatusMap
-from iris.managed_thread import ThreadContainer, get_thread_container
 from iris.rpc import config_pb2, vm_pb2
 from iris.time_proto import duration_from_proto, timestamp_to_proto
 
@@ -81,6 +82,35 @@ _HEALTH_PROBE_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({
 # timeouts would blow past evaluation_interval (10 s default).
 _HEALTH_PROBE_MAX_WORKERS = 64
 
+# Cap concurrent slice create/terminate cloud requests issued in one phase. The
+# fan-out keeps a burst (cold-start scale-up, mass-preemption teardown) within
+# the phase budget instead of serializing one bounded HTTP round-trip at a time.
+_CLOUD_OP_MAX_WORKERS = 16
+
+_T = TypeVar("_T")
+_R = TypeVar("_R")
+
+
+def _run_io_batch(
+    items: Sequence[_T],
+    issue: Callable[[_T], _R],
+    *,
+    max_workers: int,
+    thread_name_prefix: str,
+) -> list[_R]:
+    """Run a pure-I/O ``issue`` over ``items`` on a bounded, joined thread pool.
+
+    The pool only performs cloud/network I/O and *returns* its results; callers
+    fold those results into autoscaler state serially afterward. Because no
+    shared state is touched inside the pool, the fan-out is race-free regardless
+    of its width, and it joins before returning so the phase stays bounded.
+    """
+    if not items:
+        return []
+    workers = min(max_workers, len(items))
+    with ThreadPoolExecutor(max_workers=workers, thread_name_prefix=thread_name_prefix) as pool:
+        return list(pool.map(issue, items))
+
 
 def _probe_worker_health(worker_url: str) -> bool:
     """Probe a worker's /health endpoint. ``worker_url`` is an ``http://host:port`` base URL.
@@ -95,6 +125,28 @@ def _probe_worker_health(worker_url: str) -> bool:
         return 200 <= resp.status < 300
     except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
         return False
+
+
+@dataclass
+class _ScaleUpRequest:
+    """One scale-up to issue this phase: a group, its reason, and the pending action."""
+
+    group: ScalingGroup
+    reason: str
+    action: vm_pb2.AutoscalerAction
+
+
+@dataclass
+class _ScaleUpOutcome:
+    """Result of issuing one create: the slice handle on success, else the error.
+
+    Captured as plain data so the issuing fan-out touches no shared state; the
+    outcome is classified and folded into autoscaler state serially.
+    """
+
+    request: _ScaleUpRequest
+    handle: SliceHandle | None = None
+    error: Exception | None = None
 
 
 class Autoscaler:
@@ -115,7 +167,6 @@ class Autoscaler:
         scale_groups: dict[str, ScalingGroup],
         evaluation_interval: Duration,
         platform: WorkerInfraProvider,
-        threads: ThreadContainer | None = None,
         base_worker_config: config_pb2.WorkerConfig | None = None,
         unresolvable_timeout: Duration = DEFAULT_UNRESOLVABLE_TIMEOUT,
         create_rate_limit: int = DEFAULT_CREATE_RATE_LIMIT,
@@ -126,7 +177,6 @@ class Autoscaler:
             scale_groups: Map of scale group name to ScalingGroup instance
             evaluation_interval: How often to evaluate scaling decisions
             platform: WorkerInfraProvider instance for shutdown lifecycle
-            threads: Optional thread container for testing
             base_worker_config: Base worker config merged with per-group overrides
                 and passed to platform.create_slice(). None disables bootstrap (test/local mode).
             unresolvable_timeout: How long a slice can remain UNKNOWN before being treated as FAILED.
@@ -158,16 +208,12 @@ class Autoscaler:
         self._last_routing_decision_proto: vm_pb2.RoutingDecision | None = None
         self._last_pending_hints: dict[str, PendingHint] | None = None
 
-        # Thread management
-        self._threads = threads if threads is not None else get_thread_container()
-
     @classmethod
     def from_config(
         cls,
         scale_groups: dict[str, ScalingGroup],
         config: config_pb2.AutoscalerConfig,
         platform: WorkerInfraProvider,
-        threads: ThreadContainer | None = None,
         base_worker_config: config_pb2.WorkerConfig | None = None,
     ) -> "Autoscaler":
         """Create autoscaler from proto config.
@@ -176,7 +222,6 @@ class Autoscaler:
             scale_groups: Map of scale group name to ScalingGroup instance
             config: Autoscaler configuration proto (with defaults already applied)
             platform: WorkerInfraProvider instance for shutdown lifecycle
-            threads: Optional thread container for testing
             base_worker_config: Base worker config merged with per-group overrides
 
         Returns:
@@ -186,38 +231,18 @@ class Autoscaler:
             scale_groups=scale_groups,
             evaluation_interval=duration_from_proto(config.evaluation_interval),
             platform=platform,
-            threads=threads,
             base_worker_config=base_worker_config,
         )
-
-    def _wait_for_inflight(self) -> None:
-        """Wait for in-flight scale-ups to complete without terminating anything.
-
-        Test-only: Waits for all scale-up threads to complete.
-        """
-        self._threads.wait()
 
     def shutdown(self) -> None:
         """Shutdown the autoscaler, terminate all VM groups, and clean up platform.
 
-        Shutdown ordering:
-        1. Stop all threads in the autoscaler's ThreadContainer. This signals
-           stop_events for both in-flight scale-up threads AND worker lifecycle
-           threads (via child containers), then joins with timeout.
-        2. Terminate all VM groups — calls Worker.stop() for final cleanup
-           of any workers that didn't exit in step 1.
-        3. Shutdown platform — clears local tracking state.
+        Cloud operations (scale-up, terminate) run synchronously inside the
+        autoscale phase — there are no background threads to join — so shutdown
+        is just: terminate all tracked slices, then release platform resources.
         """
-        # Stop all threads (scale-ups + workers) via ThreadContainer.
-        # Using stop() rather than wait() because wait() doesn't signal
-        # stop_events and would block forever on worker-lifecycle threads.
-        self._threads.stop()
-
-        # Step 2: Terminate VMs and cleanup (idempotent with step 1)
         for group in self._groups.values():
             group.terminate_all()
-
-        # Step 3: Shutdown platform (cleanup remaining threads)
         self._platform.shutdown()
 
     def __enter__(self) -> "Autoscaler":
@@ -330,6 +355,11 @@ class Autoscaler:
     ) -> None:
         """Execute scale-up decisions.
 
+        Runs in three steps so the cloud I/O never races autoscaler state:
+        plan (serial: apply rate limits, mark pending, build the issue list),
+        issue (bounded parallel: submit the creates, capturing handle-or-error
+        as data), then fold (serial: record each outcome into group state).
+
         Args:
             decisions: List of scaling decisions to execute.
             timestamp: Current timestamp.
@@ -341,6 +371,8 @@ class Autoscaler:
         # limit), summarized once per cycle so a global throttle doesn't spam a
         # line per group.
         create_throttled = 0
+        # Plan: gate each decision and mark it pending before any I/O.
+        to_issue: list[_ScaleUpRequest] = []
         for decision in decisions:
             group = self._groups.get(decision.scale_group)
             if not group:
@@ -357,7 +389,20 @@ class Autoscaler:
                 if not self._create_bucket.try_acquire(now=timestamp):
                     create_throttled += 1
                     continue
-                self._execute_scale_up(group, timestamp, reason=decision.reason)
+                group.begin_scale_up(timestamp=timestamp)
+                action = self._log_action("scale_up", group.name, reason=decision.reason, status="pending")
+                to_issue.append(_ScaleUpRequest(group=group, reason=decision.reason, action=action))
+
+        # Issue the creates in a bounded parallel fan-out (pure I/O), then fold
+        # each outcome into state serially.
+        outcomes = _run_io_batch(
+            to_issue,
+            lambda req: self._issue_scale_up(req, timestamp),
+            max_workers=_CLOUD_OP_MAX_WORKERS,
+            thread_name_prefix="scale-up",
+        )
+        for outcome in outcomes:
+            self._fold_scale_up(outcome, timestamp)
 
         if create_throttled:
             logger.info(
@@ -388,61 +433,62 @@ class Autoscaler:
                 reason=summary,
             )
 
-    def _execute_scale_up(self, group: ScalingGroup, ts: Timestamp, reason: str = "") -> None:
-        """Initiate async scale-up for a scale group.
+    def _issue_scale_up(self, request: _ScaleUpRequest, ts: Timestamp) -> _ScaleUpOutcome:
+        """Submit one create and return the handle-or-error as data. Pure I/O.
 
-        Increments the group's pending scale-up counter and spawns a background
-        thread for the actual scale-up work. The counter is included in
-        slice_count(), preventing double scale-up.
+        Runs inside the bounded issue fan-out, so it must not touch shared
+        autoscaler/group state: ``group.scale_up`` only submits the create LRO
+        (bounded; it does not wait) and returns a handle. The exception is
+        captured rather than raised so a single failed create can't abort the
+        whole batch; classification and state changes happen in
+        :meth:`_fold_scale_up`.
         """
-        group.begin_scale_up(timestamp=ts)
-
-        def _scale_up_wrapper(stop_event):
-            self._do_scale_up(group, ts, reason)
-
-        self._threads.spawn(
-            target=_scale_up_wrapper,
-            name=f"scale-up-{group.name}",
-        )
-
-    def _do_scale_up(self, group: ScalingGroup, ts: Timestamp, reason: str = "") -> bool:
-        """Execute the actual blocking scale-up work.
-
-        This runs in a background thread and should not be called directly.
-        Use _execute_scale_up instead. Bootstrap is handled internally by the
-        platform when cluster_config is provided.
-
-        Returns:
-            True if scale-up succeeded, False otherwise.
-        """
-        action = self._log_action("scale_up", group.name, reason=reason, status="pending")
-
-        slice_obj = None
-
+        group = request.group
         try:
-            logger.info("Scaling up %s: %s", group.name, reason)
+            logger.info("Scaling up %s: %s", group.name, request.reason)
             wc = self._per_group_worker_config(group)
-            slice_obj = group.scale_up(worker_config=wc, timestamp=ts)
-            group.complete_scale_up(slice_obj, ts)
-            logger.info("Created slice %s for group %s", slice_obj.slice_id, group.name)
-            action.slice_id = slice_obj.slice_id
+            handle = group.scale_up(worker_config=wc, timestamp=ts)
+            return _ScaleUpOutcome(request=request, handle=handle)
+        except Exception as e:
+            # Captured as data (not swallowed): _fold_scale_up classifies it,
+            # records the failure on the group, and logs with a stack trace.
+            return _ScaleUpOutcome(request=request, error=e)
+
+    def _fold_scale_up(self, outcome: _ScaleUpOutcome, ts: Timestamp) -> None:
+        """Fold one create outcome into group state. Serial; mutates shared state.
+
+        Success records the slice as BOOTING (it then advances BOOTING→READY/
+        FAILED via the describe() poll in :meth:`refresh`). Quota/error failures
+        clear the pending scale-up and feed the group's detector so the freed
+        demand re-plans on the next cycle.
+        """
+        request = outcome.request
+        group, action = request.group, request.action
+
+        if outcome.error is None:
+            handle = outcome.handle
+            assert handle is not None, "a successful scale-up must carry a slice handle"
+            group.complete_scale_up(handle, ts)
+            logger.info("Created slice %s for group %s", handle.slice_id, group.name)
+            action.slice_id = handle.slice_id
             action.status = "completed"
-            return True
-        except QuotaExhaustedError as e:
+            return
+
+        error = outcome.error
+        if isinstance(error, QuotaExhaustedError):
             group.cancel_scale_up()
-            group.record_quota_exceeded(str(e), ts)
-            logger.warning("Quota exceeded for %s: %s", group.name, e)
+            group.record_quota_exceeded(str(error), ts)
+            logger.warning("Quota exceeded for %s: %s", group.name, error)
             action.action_type = "quota_exceeded"
             action.status = "failed"
-            action.reason = str(e)
-            return False
-        except Exception as e:
-            group.cancel_scale_up()
-            logger.exception("Failed to create slice for %s: %s", group.name, e)
-            action.status = "failed"
-            action.reason = f"{reason} - error: {e}"
-            group.record_create_failed(ts)
-            return False
+            action.reason = str(error)
+            return
+
+        group.cancel_scale_up()
+        logger.error("Failed to create slice for %s: %s", group.name, error, exc_info=error)
+        action.status = "failed"
+        action.reason = f"{request.reason} - error: {error}"
+        group.record_create_failed(ts)
 
     def _per_group_worker_config(self, group: ScalingGroup) -> config_pb2.WorkerConfig | None:
         """Build per-group WorkerConfig by merging base config with scale group overrides."""
@@ -552,9 +598,9 @@ class Autoscaler:
         tracker uses for its reconcile-failure threshold. Worker URLs
         come from the slice handle, refreshed lazily via ``handle.describe()``
         when SliceState has none cached (e.g. after a controller restart).
-        Probes are fanned out across a thread pool so a partitioned AZ
-        doesn't burn the entire evaluation interval at the 3s per-probe
-        timeout. Slice teardown runs serially after all probes complete.
+        Probes are fanned out over a bounded thread pool so a partitioned AZ
+        doesn't burn the entire evaluation interval at the 3s per-probe timeout.
+        The pool returns results; slice teardown is folded in serially after.
         """
         timestamp = timestamp or Timestamp.now()
 
@@ -582,11 +628,14 @@ class Autoscaler:
                 for worker_id, worker_url in worker_urls.items():
                     probes.append((group, slice_id, worker_id, worker_url))
 
-        # Phase 2: fan out probes. Bound the pool so we don't melt the controller.
+        # Phase 2: fan out probes over a bounded thread pool, returning results.
         if probes:
-            workers = min(_HEALTH_PROBE_MAX_WORKERS, len(probes))
-            with ThreadPoolExecutor(max_workers=workers, thread_name_prefix="health-probe") as pool:
-                results = list(pool.map(lambda p: _probe_worker_health(p[3]), probes))
+            results = _run_io_batch(
+                probes,
+                lambda p: _probe_worker_health(p[3]),
+                max_workers=_HEALTH_PROBE_MAX_WORKERS,
+                thread_name_prefix="health-probe",
+            )
 
             # Phase 3: record results and collect slices that tripped the threshold.
             for (group, slice_id, worker_id, _url), healthy in zip(probes, results, strict=True):
@@ -776,7 +825,12 @@ class Autoscaler:
         """Terminate the unique slices containing the given workers.
 
         Returns sibling worker IDs that should be failed immediately because
-        their slices are being torn down.
+        their slices are being torn down. The operation detaches the slices from
+        tracking serially (the state mutation), then issues the deletes in a
+        bounded parallel fan-out: each ``terminate_slice_handle`` is a bounded
+        cloud request that catches and logs its own errors and touches no shared
+        state, so the fan-out stays within the phase budget under a mass
+        preemption without racing.
         """
         result = terminate_slices_for_workers_operation(
             groups=self._groups,
@@ -785,23 +839,10 @@ class Autoscaler:
             log_action=self._log_action,
             timestamp=Timestamp.now(),
         )
-        for request in result.termination_requests:
-
-            def _terminate(
-                stop_event,
-                target_group: ScalingGroup = request.group,
-                target_slice_id: str = request.slice_id,
-                target_handle: SliceHandle = request.handle,
-            ) -> None:
-                del stop_event
-                self._terminate_slice_handle(target_group, target_slice_id, target_handle)
-
-            self._threads.spawn(
-                target=_terminate,
-                name=f"slice-terminate-{request.slice_id}",
-            )
-
+        _run_io_batch(
+            result.termination_requests,
+            lambda req: req.group.terminate_slice_handle(req.handle, context="cleaning up anyway"),
+            max_workers=_CLOUD_OP_MAX_WORKERS,
+            thread_name_prefix="slice-terminate",
+        )
         return result.sibling_worker_ids
-
-    def _terminate_slice_handle(self, group: ScalingGroup, slice_id: str, handle: SliceHandle) -> None:
-        group.terminate_slice_handle(handle, context="cleaning up anyway")

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -10,8 +10,6 @@ Pure routing/packing logic is tested in test_demand_routing.py.
 Integration tests with real GcpWorkerProvider are in test_autoscaler_integration.py.
 """
 
-import time
-
 import pytest
 from iris.cluster.backends.types import (
     CloudSliceState,
@@ -399,7 +397,6 @@ class TestAutoscalerExecution:
         )
 
         empty_autoscaler.execute([decision], timestamp=Timestamp.from_ms(1000))
-        empty_autoscaler._wait_for_inflight()
 
         group = empty_autoscaler.groups["test-group"]
         assert group.slice_count() == 1
@@ -418,7 +415,6 @@ class TestAutoscalerExecution:
         )
 
         autoscaler.execute([decision], timestamp=Timestamp.from_ms(1000))
-        autoscaler._wait_for_inflight()
 
         # The create-failure decays the detector's health score below 1.0.
         # One failure at decay=0.7 → health ~0.7 (and recovery over 2 ms is negligible).
@@ -429,7 +425,6 @@ class TestAutoscalerExecution:
         demand = make_demand_entries(2, device_type=DeviceType.CPU, device_variant=None)
         vm_status_map = {}
         decisions = empty_autoscaler.run_once(demand, vm_status_map)
-        empty_autoscaler._wait_for_inflight()
 
         assert len(decisions) == 1
         assert decisions[0].action == ScalingAction.SCALE_UP
@@ -722,7 +717,6 @@ class TestAutoscalerQuotaHandling:
 
         demand = make_demand_entries(1, device_type=DeviceType.TPU, device_variant="v5p-8")
         autoscaler.run_once(demand, {}, timestamp=Timestamp.from_ms(1000))
-        autoscaler._wait_for_inflight()
 
         state = group.availability(timestamp=Timestamp.from_ms(2000))
         assert state.status == GroupAvailability.QUOTA_EXCEEDED
@@ -748,7 +742,6 @@ class TestAutoscalerQuotaHandling:
 
         demand = make_demand_entries(1, device_type=DeviceType.TPU, device_variant="v5p-8")
         autoscaler.run_once(demand, {}, timestamp=Timestamp.from_ms(1000))
-        autoscaler._wait_for_inflight()
 
         decisions = autoscaler.evaluate(demand, timestamp=Timestamp.from_ms(2000))
 
@@ -790,7 +783,6 @@ class TestAutoscalerQuotaHandling:
         demand = make_demand_entries(1, device_type=DeviceType.TPU, device_variant="v5p-8")
         for i in range(5):
             autoscaler.run_once(demand, {}, timestamp=Timestamp.from_ms(1000 + i))
-            autoscaler._wait_for_inflight()
 
         state = group.availability(timestamp=Timestamp.from_ms(2000))
         assert state.status == GroupAvailability.BACKOFF
@@ -804,7 +796,6 @@ class TestAutoscalerActionLogging:
         """Verify scale-up actions are logged."""
         demand = make_demand_entries(2, device_type=DeviceType.TPU, device_variant="v5p-8")
         empty_autoscaler.run_once(demand, {})
-        empty_autoscaler._wait_for_inflight()
 
         status = empty_autoscaler.get_status()
         assert len(status.recent_actions) >= 1
@@ -823,7 +814,6 @@ class TestAutoscalerActionLogging:
 
         demand = make_demand_entries(1, device_type=DeviceType.TPU, device_variant="v5p-8")
         autoscaler.run_once(demand, {})
-        autoscaler._wait_for_inflight()
 
         status = autoscaler.get_status()
         assert len(status.recent_actions) == 1
@@ -866,7 +856,6 @@ class TestAutoscalerActionLogging:
         """Verify get_status returns recent actions."""
         demand = make_demand_entries(1, device_type=DeviceType.TPU, device_variant="v5p-8")
         empty_autoscaler.run_once(demand, {})
-        empty_autoscaler._wait_for_inflight()
 
         status = empty_autoscaler.get_status()
 
@@ -882,7 +871,6 @@ class TestAutoscalerActionLogging:
         before = Timestamp.now().epoch_ms()
         demand = make_demand_entries(1, device_type=DeviceType.TPU, device_variant="v5p-8")
         empty_autoscaler.run_once(demand, {})
-        empty_autoscaler._wait_for_inflight()
         after = Timestamp.now().epoch_ms()
 
         status = empty_autoscaler.get_status()
@@ -977,52 +965,31 @@ class TestScalingGroupRequestingState:
         assert status_by_group["group-2"].decision == "idle"
 
 
-class TestAutoscalerAsyncScaleUp:
-    """Tests for async scale-up behavior."""
+class TestAutoscalerSynchronousScaleUp:
+    """Tests for scale-up issuance: creates land before execute() returns (no detached threads)."""
 
-    def test_execute_scale_up_returns_immediately(self):
-        """_execute_scale_up returns immediately without blocking."""
+    def test_execute_scale_up_issues_create_synchronously(self):
+        """execute() issues the create in line and tracks the slice before returning."""
         config = make_scale_group_config(name="test-group", buffer_slices=0, max_slices=5)
-
         platform = make_mock_platform()
-        original_create = platform.create_slice.side_effect
-
-        def slow_create(config, worker_config=None):
-            time.sleep(0.5)
-            return original_create(config, worker_config)
-
-        platform.create_slice.side_effect = slow_create
-
         group = ScalingGroup(config, platform)
         autoscaler = make_autoscaler({"test-group": group})
 
         decision = ScalingDecision(
             scale_group="test-group",
             action=ScalingAction.SCALE_UP,
-            reason="test async",
+            reason="test sync",
         )
 
-        start = time.time()
         autoscaler.execute([decision], timestamp=Timestamp.now())
-        elapsed = time.time() - start
 
-        assert elapsed < 0.1
+        platform.create_slice.assert_called_once()
+        assert group.slice_count() == 1
 
-        autoscaler._wait_for_inflight()
-
-    def test_group_marked_requesting_during_scale_up(self):
-        """Group shows REQUESTING immediately after execute(), cleared when done."""
-
+    def test_group_available_after_scale_up(self):
+        """The slice is tracked and the pending counter cleared once execute() returns."""
         config = make_scale_group_config(name="test-group", buffer_slices=0, max_slices=5)
         platform = make_mock_platform()
-        original_create = platform.create_slice.side_effect
-
-        def slow_create(config, worker_config=None):
-            time.sleep(0.2)
-            return original_create(config, worker_config)
-
-        platform.create_slice.side_effect = slow_create
-
         group = ScalingGroup(config, platform)
         autoscaler = make_autoscaler({"test-group": group})
 
@@ -1035,33 +1002,16 @@ class TestAutoscalerAsyncScaleUp:
 
         autoscaler.execute([decision], timestamp=Timestamp.from_ms(ts))
 
-        # Pending counter is incremented, so availability shows REQUESTING
+        # The create is issued synchronously, so by the time execute() returns the
+        # pending counter is already resolved into a tracked slice.
         availability = group.availability(Timestamp.from_ms(ts))
-        assert availability.status == GroupAvailability.REQUESTING
-
-        autoscaler._wait_for_inflight()
-
-        # After completion, pending counter is decremented and slice is added
-        availability = group.availability(Timestamp.from_ms(ts + 300))
         assert availability.status == GroupAvailability.AVAILABLE
         assert group.slice_count() == 1
 
-    def test_autoscaler_shutdown_waits_for_scale_up(self):
-        """shutdown() waits for in-flight scale-ups to complete."""
+    def test_shutdown_after_scale_up_terminates_created_slice(self):
+        """The synchronously-created slice is terminated on shutdown."""
         config = make_scale_group_config(name="test-group", buffer_slices=0, max_slices=5)
-
         platform = make_mock_platform()
-        original_create = platform.create_slice.side_effect
-        create_completed = []
-
-        def slow_create(config, worker_config=None):
-            time.sleep(0.2)
-            result = original_create(config, worker_config)
-            create_completed.append(True)
-            return result
-
-        platform.create_slice.side_effect = slow_create
-
         group = ScalingGroup(config, platform)
         autoscaler = make_autoscaler({"test-group": group})
 
@@ -1072,10 +1022,32 @@ class TestAutoscalerAsyncScaleUp:
         )
 
         autoscaler.execute([decision], timestamp=Timestamp.now())
+        assert group.slice_count() == 1
 
         autoscaler.shutdown()
+        assert group.slice_count() == 0
 
-        assert len(create_completed) == 1
+    def test_booting_slice_prevents_double_scale_up(self, scale_group_config):
+        """A slice issued in one cycle is tracked (BOOTING) before the next, so steady
+        demand does not double-provision."""
+        platform = make_mock_platform()
+        group = ScalingGroup(scale_group_config, platform)
+        autoscaler = make_autoscaler({"test-group": group})
+
+        demand = make_demand_entries(1, device_type=DeviceType.TPU, device_variant="v5p-8")
+
+        decisions1 = autoscaler.update(demand, Timestamp.from_ms(1_000))
+        assert len(decisions1) == 1
+        assert group.slice_count() == 1
+
+        # The created slice describes as BOOTING and counts toward capacity, so a
+        # second cycle with the same demand issues no further scale-up.
+        decisions2 = autoscaler.update(demand, Timestamp.from_ms(2_000))
+        assert len(decisions2) == 0, "BOOTING slice should satisfy demand and block re-scale"
+        assert group.slice_count() == 1
+        platform.create_slice.assert_called_once()
+
+        autoscaler.shutdown()
 
     def test_autoscaler_shutdown_terminates_all_slices(self):
         """shutdown() terminates all slices."""

--- a/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
@@ -8,17 +8,14 @@ quota handling, backoff, and multi-tier scaling -- using real provider implement
 backed by in-memory fakes rather than MagicMock.
 """
 
-import threading
 import unittest.mock
 
 from iris.cluster.backends.gcp.fake import InMemoryGcpService
-from iris.cluster.backends.gcp.workers import GcpWorkerProvider
 from iris.cluster.backends.types import CloudSliceState
 from iris.cluster.constraints import DeviceType, PlacementRequirements
 from iris.cluster.controller.autoscaler import Autoscaler
 from iris.cluster.controller.autoscaler.models import DemandEntry, ScalingAction
 from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup
-from iris.cluster.service_mode import ServiceMode
 from iris.rpc import config_pb2, job_pb2
 from iris.time_proto import duration_to_proto
 from rigging.timing import Duration, Timestamp
@@ -67,14 +64,12 @@ class TestAutoscalerWaterfallEndToEnd:
         demand = make_demand_entries(2, device_type=DeviceType.TPU, device_variant="v5p-8")
 
         autoscaler.run_once(demand, {})
-        autoscaler._wait_for_inflight()
 
         assert group_primary.availability().status == GroupAvailability.QUOTA_EXCEEDED
         assert group_fallback.slice_count() == 0
 
         # 2 TPU entries are VM-exclusive -> 2 slices on fallback
         autoscaler.run_once(demand, {})
-        autoscaler._wait_for_inflight()
         assert group_fallback.slice_count() == 2
 
     def test_quota_recovery_restores_primary_routing(self):
@@ -99,13 +94,11 @@ class TestAutoscalerWaterfallEndToEnd:
         demand = make_demand_entries(1, device_type=DeviceType.CPU, device_variant=None)
 
         autoscaler.run_once(demand, {})
-        autoscaler._wait_for_inflight()
         ts_after_fail = Timestamp.now()
         assert group_primary.availability(ts_after_fail).status == GroupAvailability.QUOTA_EXCEEDED
         assert group_fallback.slice_count() == 0
 
         autoscaler.run_once(demand, {})
-        autoscaler._wait_for_inflight()
         assert group_fallback.slice_count() == 1
 
         # Restore quota so primary can create slices again
@@ -144,7 +137,6 @@ class TestAutoscalerWaterfallEndToEnd:
 
         demand = make_demand_entries(1, device_type=DeviceType.CPU, device_variant=None)
         autoscaler.run_once(demand, {})
-        autoscaler._wait_for_inflight()
         assert group_primary.slice_count() == 1
 
         # Mark the primary slice as READY so it enters AT_MAX_SLICES (rejecting)
@@ -153,7 +145,6 @@ class TestAutoscalerWaterfallEndToEnd:
 
         demand = make_demand_entries(2, device_type=DeviceType.CPU, device_variant=None)
         autoscaler.run_once(demand, {})
-        autoscaler._wait_for_inflight()
         assert group_primary.slice_count() == 1
         assert group_fallback.slice_count() == 1
 
@@ -183,7 +174,6 @@ class TestAutoscalerWaterfallEndToEnd:
         ]
 
         autoscaler.run_once(demand, {})
-        autoscaler._wait_for_inflight()
 
         assert group_v5p.slice_count() == 2
         assert group_v5lite.slice_count() == 1
@@ -227,7 +217,6 @@ class TestAutoscalerWaterfallEndToEnd:
         ]
 
         autoscaler.run_once(demand, {})
-        autoscaler._wait_for_inflight()
         assert group_primary.slice_count() == 1
         assert group_fallback.slice_count() == 2
 
@@ -263,13 +252,11 @@ class TestAutoscalerWaterfallEndToEnd:
         # past the HOSTILE display threshold (>=80% of failures_at_probe_floor=10).
         for _ in range(8):
             autoscaler.run_once(demand, {})
-            autoscaler._wait_for_inflight()
         assert group_primary.availability().status == GroupAvailability.BACKOFF
         assert group_primary.slice_count() == 0
 
         # Next run: primary in BACKOFF -> demand cascades to fallback
         autoscaler.run_once(demand, {})
-        autoscaler._wait_for_inflight()
         assert group_fallback.slice_count() >= 1
 
 
@@ -309,7 +296,6 @@ def test_bootstrap_state_with_worker_config():
 
     decisions = autoscaler.run_once(demand, {}, t0)
     assert len(decisions) == 1
-    autoscaler._wait_for_inflight()
 
     assert group.slice_count() == 1
 
@@ -347,7 +333,6 @@ def test_no_bootstrap_without_worker_config():
     t0 = Timestamp.from_ms(1_000_000)
 
     autoscaler.run_once(demand, {}, t0)
-    autoscaler._wait_for_inflight()
 
     # Advance TPUs to READY and refresh
     advance_all_tpus(service, "READY")
@@ -360,67 +345,6 @@ def test_no_bootstrap_without_worker_config():
     slice_handle = group.slice_handles()[0]
     status = slice_handle.describe()
     assert status.state == CloudSliceState.READY
-
-    autoscaler.shutdown()
-
-
-# ---------------------------------------------------------------------------
-# Pending counter prevents double scale-up (real GcpWorkerProvider with slow create)
-# ---------------------------------------------------------------------------
-
-
-def test_pending_counter_prevents_double_scaleup():
-    """Verify that the pending scale-up counter prevents double scale-up when
-    create_slice takes longer than expected."""
-    create_barrier = threading.Event()
-
-    class SlowGcpWorkerProvider(GcpWorkerProvider):
-        """GcpWorkerProvider where create_slice blocks until barrier is released."""
-
-        def create_slice(self, config, worker_config=None):
-            create_barrier.wait(timeout=10)
-            return super().create_slice(config, worker_config)
-
-    sg_config = make_scale_group_config(
-        name="test-group",
-        buffer_slices=0,
-        max_slices=4,
-        zones=["us-central1-a"],
-    )
-    service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project", label_prefix="iris")
-    gcp_config = config_pb2.GcpPlatformConfig(project_id="test-project", zones=["us-central1-a"])
-    platform = SlowGcpWorkerProvider(gcp_config=gcp_config, label_prefix="iris", worker_port=10001, gcp_service=service)
-    group = ScalingGroup(
-        sg_config,
-        platform,
-    )
-    autoscaler = Autoscaler(
-        scale_groups={"test-group": group},
-        evaluation_interval=Duration.from_ms(100),
-        platform=platform,
-    )
-
-    demand = make_demand_entries(1)
-    t0 = Timestamp.from_ms(1_000_000)
-
-    # First run_once: demand=1, current=0 -> scale up.
-    decisions1 = autoscaler.run_once(demand, {}, t0)
-    assert len(decisions1) == 1
-    assert decisions1[0].action == ScalingAction.SCALE_UP
-
-    # Advance time arbitrarily far
-    t1 = Timestamp.from_ms(t0.epoch_ms() + 600)
-
-    # Second run_once: pending counter prevents double scale-up
-    decisions2 = autoscaler.run_once(demand, {}, t1)
-    assert len(decisions2) == 0, "Pending counter should prevent second scale-up"
-
-    # Release the barrier so threads complete
-    create_barrier.set()
-    autoscaler._wait_for_inflight()
-
-    # Only 1 slice was created
-    assert group.slice_count() == 1
 
     autoscaler.shutdown()
 
@@ -450,7 +374,6 @@ def test_incremental_demand_growth_triggers_scale_up():
         task_prefix="phase1",
     )
     autoscaler.run_once(demand_4, {})
-    autoscaler._wait_for_inflight()
     assert group.slice_count() == 4
 
     # Mark all slices ready
@@ -473,7 +396,6 @@ def test_incremental_demand_growth_triggers_scale_up():
 
     # Execute and verify
     autoscaler.execute(decisions, Timestamp.now())
-    autoscaler._wait_for_inflight()
     assert group.slice_count() == 10
 
 
@@ -533,7 +455,6 @@ def test_marin_style_lifecycle():
 
     t = Timestamp.from_ms(10_000)
     autoscaler.run_once(make_demand(4), {}, timestamp=t)
-    autoscaler._wait_for_inflight()
     assert groups["tpu-1vm"].slice_count() == 4, "tpu-1vm filled to max"
     assert_no_load_on_last()
 
@@ -542,7 +463,6 @@ def test_marin_style_lifecycle():
     t = Timestamp.from_ms(11_000)
     advance(t)
     autoscaler.run_once(make_demand(8), {}, timestamp=t)
-    autoscaler._wait_for_inflight()
     assert groups["tpu-1vm"].slice_count() == 4, "tpu-1vm unchanged"
     assert routed("tpu-2vm") == 8, "all demand cascades to tpu-2vm"
     assert groups["tpu-2vm"].slice_count() == 4, "tpu-2vm filled to max"
@@ -553,7 +473,6 @@ def test_marin_style_lifecycle():
     t = Timestamp.from_ms(12_000)
     advance(t)
     autoscaler.run_once(make_demand(16), {}, timestamp=t)
-    autoscaler._wait_for_inflight()
     assert groups["tpu-4vm"].slice_count() == 4, "tpu-4vm at max_slices"
     assert routed("tpu-4vm") == 16, "demand routed to tpu-4vm"
     assert_no_load_on_last()
@@ -563,7 +482,6 @@ def test_marin_style_lifecycle():
     t = Timestamp.from_ms(13_000)
     advance(t)
     autoscaler.run_once(make_demand(28), {}, timestamp=t)
-    autoscaler._wait_for_inflight()
     assert routed("tpu-8vm") == 28
     assert groups["tpu-8vm"].slice_count() == 4, "tpu-8vm at max_slices"
     assert_no_load_on_last()
@@ -612,7 +530,6 @@ class TestScaleUpRateLimiting:
         assert len(decisions) == 5
 
         autoscaler.execute(decisions, ts)
-        autoscaler._wait_for_inflight()
 
         # Only 1 should have actually executed (rate_limit=1)
         assert group.slice_count() == 1
@@ -648,7 +565,6 @@ class TestScaleUpRateLimiting:
         decisions = autoscaler.evaluate(demand, timestamp=ts)
         assert len(decisions) == 6
         autoscaler.execute(decisions, ts)
-        autoscaler._wait_for_inflight()
         assert group.slice_count() == 2
 
         # Advance time by 1 minute so rate-limit tokens refill
@@ -658,7 +574,6 @@ class TestScaleUpRateLimiting:
         decisions2 = autoscaler.evaluate(demand, timestamp=ts2)
         assert len(decisions2) == 4
         autoscaler.execute(decisions2, ts2)
-        autoscaler._wait_for_inflight()
         assert group.slice_count() == 4
 
     def test_high_rate_limit_allows_all_decisions(self):
@@ -682,5 +597,4 @@ class TestScaleUpRateLimiting:
         decisions = autoscaler.evaluate(demand, timestamp=ts)
         assert len(decisions) == 10
         autoscaler.execute(decisions, ts)
-        autoscaler._wait_for_inflight()
         assert group.slice_count() == 10


### PR DESCRIPTION
## Summary

T6 of the *tighten-iris-control-boundaries* plan. `Autoscaler.update()` (scale-up) and `terminate_slices_for_workers` spawned **detached fire-and-forget threads** that blocked inside cloud calls *and mutated shared `Autoscaler`/`ScalingGroup` state on completion*. The hazard is the combination — untracked work mutating shared state after a blocking call.

This fixes it at the root by **separating I/O from state** instead of forbidding concurrency. Each cloud op now **returns its result as data**, and the autoscale phase runs in three steps:

| step | concurrency | touches shared state? |
|------|-------------|------------------------|
| **plan** | serial | yes — gate decisions, mark pending, build the work list |
| **issue** | bounded parallel | **no** — submit the cloud requests, capture handle-or-error |
| **fold** | serial | yes — record each outcome into group state |

Because the **issue** step touches no shared state, the fan-out is race-free at any width and joins before the phase returns — so a burst (cold-start scale-up, mass-preemption teardown) stays within the phase budget instead of serializing one bounded HTTP round-trip at a time. One small bounded-pool helper (`_run_io_batch`) backs all three I/O fan-outs: scale-up, terminate, and the `/health` probe (which was already a joined pool returning results on `main`).

### Changes

- **`runtime.py`** — `_do_scale_up` splits into `_issue_scale_up` (pure I/O → `_ScaleUpOutcome`) and `_fold_scale_up` (serial state mutation). `execute` now **plans → issues a bounded fan-out → folds**. `terminate_slices_for_workers` detaches slices serially (the state mutation) then issues the deletes through the same bounded fan-out (`terminate_slice_handle` catches+logs its own errors and touches no shared state). The detached `ThreadContainer` plumbing (`threads=` kwarg, `_wait_for_inflight`, the thread-stopping `shutdown` step) is removed.
- **`recovery.py`** — dead-slice reclaim on boot terminates in line (bounded delete, off the per-tick path) instead of a daemon thread.
- **`local/cluster.py`** — stop forwarding the removed `threads=` kwarg to the Autoscaler (the LOCAL fake service keeps its own thread container).

### Why this is better than the original create thread

The scale-up thread was dangerous because it blocked up to the 600 s GCP operation timeout *and then* called `complete_scale_up` / `cancel_scale_up` / `record_quota_exceeded` — mutating `_slices` and the detector from an untracked thread. Now the create is a bounded submit (it returns a slice handle without waiting on the create LRO), the slice advances `BOOTING→READY/FAILED` via the existing `describe()` poll in `refresh()`, and an in-flight create survives a controller restart through the existing **slice-adoption** path (persisted `SlicePersist` reconciled against `list_all_slices`) — no second recovery mechanism.

### Note vs the plan's "no `threading.Thread`/executor spawn"

This deliberately keeps **bounded, joined** thread pools for the I/O. The plan's grep was a proxy for *"no untracked work mutating shared state"*; the functional issue→fold split satisfies that intent directly — the pools do pure I/O and return results, and the only **detached, state-mutating** threads (the per-decision create/terminate spawns) are gone. Flagging for the plan author in case the literal acceptance line should be updated to reflect the issue→fold framing.

(Earlier revision of this PR removed threads entirely / went sequential; per review feedback this was reworked into the functional issue→fold design so concurrency is safe by construction rather than avoided.)

## Tests

Full `lib/iris` suite green (**2285 passed, 1 skipped**), pyrefly clean, `pre-commit.py` clean.

## Scope / coordination

Confined to the autoscaler runtime plus trivial `local/cluster.py` constructor plumbing. No `controller.py` loop restructuring, no change to `Autoscaler.update()` signature or `AutoscalerState`, to minimize conflicts with the parallel T5 (single-tick) work. K8s/cluster-view backends have no Iris autoscaler ops and are untouched.

🤖 Generated for weaver issue #99.