### PR TITLE
[iris] Fix benchmark_controller demand benchmark after Tx-snapshot API change

### DIFF
--- a/lib/iris/scripts/benchmark_controller.py
+++ b/lib/iris/scripts/benchmark_controller.py
@@ -1201,8 +1201,11 @@ def benchmark_scheduling(db: ControllerDB) -> None:
     # ---- Autoscaler demand path (compute_demand_entries) ----
     # Demand is now a pure function over the per-tick scheduling context; build it
     # once (as the scheduling pass does) and benchmark only the demand computation.
+    # SchedulingContext carries plain data built eagerly, so it is safe to use after
+    # the snapshot closes.
     sched = Scheduler()
-    demand_ctx = build_scheduling_context(db, health, _NoAttrs(), UserBudgetDefaults(), {})
+    with db.read_snapshot() as _sched_snap:
+        demand_ctx = build_scheduling_context(_sched_snap, health, _NoAttrs(), UserBudgetDefaults(), {})
 
     def _demand():
         compute_demand_entries(demand_ctx, sched, {})


### PR DESCRIPTION
## Summary

- PR #6344 changed `build_scheduling_context` to take a caller-owned `Tx` (read snapshot) as its first argument rather than a `ControllerDB`.
- `lib/iris/scripts/` is outside pyrefly coverage, so the stale call site (`benchmark_controller.py:1205`) was not caught statically and would crash at runtime when the scheduling benchmark group runs with `AttributeError: 'ControllerDB' object has no attribute 'execute'`.
- Found by post-merge adversarial review of the PR #6344 API change.

## Fix

Wrap the `build_scheduling_context` call in `db.read_snapshot()` following the pattern used throughout the same file (e.g. lines 1167, 1195). `SchedulingContext` holds plain data built eagerly inside the snapshot, so it is safe to keep and pass to `compute_demand_entries` after the snapshot closes — confirmed by reading the dataclass definition and `build_scheduling_context` implementation.

Grepped the full repo (`lib/`, `scripts/`, `infra/`) for all callers of `build_scheduling_context`, `refresh_reservation_claims`, `cleanup_stale_claims`, and `claim_workers_for_reservations` — no other stale call sites found.

## Validation

- Wrote and executed a minimal in-process test against a synthetic SQLite DB: the fixed pattern (`db.read_snapshot()` → `build_scheduling_context(snap, ...)`) succeeds and `compute_demand_entries` returns cleanly; the old pattern (`build_scheduling_context(db, ...)`) raises `AttributeError: 'ControllerDB' object has no attribute 'execute'` as expected.
- `./infra/pre-commit.py --fix lib/iris/scripts/benchmark_controller.py` → OK (ruff, black, license all pass).
- `./infra/pre-commit.py --all-files --fix` → OK (pyrefly neutral — scripts dir uncovered as noted).

🤖 Generated with [Claude Code](https://claude.com/claude-code)