### PR TITLE
Fix served Qwen3 HumanEval priority import

### DIFF
--- a/experiments/evals/served_qwen3_humaneval.py
+++ b/experiments/evals/served_qwen3_humaneval.py
@@ -32,7 +32,7 @@ from iris.cluster.config import IrisConfig
 from iris.cluster.constraints import preemptible_constraint, region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec
 from iris.rpc import job_pb2
-from iris.rpc.proto_utils import PRIORITY_BAND_NAMES, priority_band_value
+from iris.rpc.proto_display import PRIORITY_BAND_NAMES, priority_band_value
 from marin.inference.types import RunningModel
 from marin.inference.vllm import (
     DEFAULT_BROKERED_MAX_IN_FLIGHT_PER_WORKER,


### PR DESCRIPTION
## Summary

- Update `experiments/evals/served_qwen3_humaneval.py` to import Iris priority-band helpers from `iris.rpc.proto_display`.

## Root Cause

`iris.rpc.proto_utils` no longer exists in the current tree. The priority-band helpers used by the `--priority` option live in `iris.rpc.proto_display`, so importing the eval script from `main` fails before the CLI can run.

## Validation

- `PYTHONDONTWRITEBYTECODE=1 uv run python -c "import experiments.evals.served_qwen3_humaneval"`
- `./infra/pre-commit.py --files experiments/evals/served_qwen3_humaneval.py`
- `./infra/pre-commit.py --review --no-lint-compose --agent-command 'codex exec'`