### PR TITLE
[iris] Make vm_create non-blocking; poll VM boot via describe

### DIFF
--- a/lib/iris/src/iris/cluster/backends/gcp/fake.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/fake.py
@@ -167,6 +167,21 @@ class InMemoryGcpService:
             raise ValueError(f"TPU {name!r} not found in {zone}")
         self._tpus[key] = dataclasses.replace(self._tpus[key], state=state)
 
+    def advance_vm_state(self, name: str, zone: str, status: str = "RUNNING") -> None:
+        """Transition a VM to a new status string (DRY_RUN/LOCAL only).
+
+        Also sets a plausible internal_ip when advancing to RUNNING so that
+        describe() tests can assert on the IP field.
+        """
+        key = (name, zone)
+        if key not in self._vms:
+            raise ValueError(f"VM {name!r} not found in {zone}")
+        vm = self._vms[key]
+        updated_ip = vm.internal_ip
+        if status == "RUNNING" and not updated_ip:
+            updated_ip = f"10.1.{len(self._vms)}.1"
+        self._vms[key] = dataclasses.replace(vm, status=status, internal_ip=updated_ip)
+
     def _check_injected_failure(self, operation: str) -> None:
         err = self._injected_failures.pop(operation, None)
         if err is not None:
@@ -310,7 +325,7 @@ class InMemoryGcpService:
     # VM operations
     # ========================================================================
 
-    def vm_create(self, request: VmCreateRequest) -> VmInfo:
+    def vm_create(self, request: VmCreateRequest, *, wait: bool = False) -> VmInfo:
         self._check_injected_failure("vm_create")
 
         if self._mode == ServiceMode.LOCAL:

--- a/lib/iris/src/iris/cluster/backends/gcp/service.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/service.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import json
 import logging
 import re
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -275,7 +276,7 @@ class GcpService(Protocol):
         self, zones: list[str], labels: dict[str, str] | None = None
     ) -> list[QueuedResourceInfo]: ...
 
-    def vm_create(self, request: VmCreateRequest) -> VmInfo: ...
+    def vm_create(self, request: VmCreateRequest, *, wait: bool = False) -> VmInfo: ...
     def vm_delete(self, name: str, zone: str, *, wait: bool = False) -> None: ...
     def vm_describe(self, name: str, zone: str) -> VmInfo | None: ...
     def vm_list(self, zones: list[str], labels: dict[str, str] | None = None) -> list[VmInfo]: ...
@@ -412,6 +413,7 @@ class CloudGcpService:
         self._creds: google.auth.credentials.Credentials | None = None
         self._token: str | None = None
         self._expires_at: float = 0.0
+        self._token_lock = threading.Lock()
         self._valid_zones: set[str] = set(KNOWN_GCP_ZONES)
         self._valid_accelerator_types: set[str] = set(KNOWN_TPU_TYPES)
         self._tpu_alpha_client_cached: tpu_v2alpha1.TpuClient | None = None
@@ -436,7 +438,10 @@ class CloudGcpService:
 
     def _headers(self) -> dict[str, str]:
         if self._token is None or time.monotonic() >= self._expires_at:
-            self._refresh_token()
+            with self._token_lock:
+                # Re-check under the lock: another thread may have refreshed already.
+                if self._token is None or time.monotonic() >= self._expires_at:
+                    self._refresh_token()
         return {
             "Authorization": f"Bearer {self._token}",
             "Content-Type": "application/json",
@@ -775,7 +780,16 @@ class CloudGcpService:
     # VM operations
     # ========================================================================
 
-    def vm_create(self, request: VmCreateRequest) -> VmInfo:
+    def vm_create(self, request: VmCreateRequest, *, wait: bool = False) -> VmInfo:
+        """POST the instance insert and return.
+
+        With wait=False (the default): returns a synthesized VmInfo in PROVISIONING
+        state immediately after the insert is accepted.  internal_ip is empty; callers
+        that need the instance running before proceeding must pass wait=True.
+
+        With wait=True: blocks until the insert zone operation completes, then describes
+        the instance so the returned VmInfo reflects the live state including internal_ip.
+        """
         validate_vm_create(request, self._valid_zones)
 
         all_metadata = dict(request.metadata)
@@ -811,22 +825,38 @@ class CloudGcpService:
 
         logger.info("Creating VM: %s (zone=%s, type=%s)", request.name, request.zone, request.machine_type)
         try:
-            # POST to insert, wait for zone operation
             url = self._instance_url(request.zone)
             resp = self._client.post(url, headers=self._headers(), json=body)
             self._classify_response(resp)
             data = resp.json()
             op_name = data.get("name", "")
-            if op_name:
+            if wait and op_name:
                 self._wait_zone_operation(request.zone, op_name)
         except InfraError as e:
             if "already exists" not in str(e).lower():
                 raise
 
-        info = self.vm_describe(request.name, request.zone)
-        if info is None:
-            raise InfraError(f"VM {request.name} created but could not be described")
-        return info
+        if wait:
+            info = self.vm_describe(request.name, request.zone)
+            if info is None:
+                raise InfraError(f"VM {request.name} created but could not be described")
+            return info
+
+        # Non-blocking path: synthesize a VmInfo in PROVISIONING state so the
+        # caller has the name and zone available immediately.  internal_ip is
+        # empty; the refresh loop's vm_describe() calls will supply it once the
+        # VM reaches RUNNING.
+        return VmInfo(
+            name=request.name,
+            status="PROVISIONING",
+            zone=request.zone,
+            internal_ip="",
+            external_ip=None,
+            labels=dict(request.labels),
+            metadata=dict(request.metadata),
+            service_account=request.service_account,
+            created_at=Timestamp.now(),
+        )
 
     def vm_delete(self, name: str, zone: str, *, wait: bool = False) -> None:
         logger.info("Deleting VM: %s", name)

--- a/lib/iris/src/iris/cluster/backends/gcp/workers.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/workers.py
@@ -344,7 +344,8 @@ class GcpWorkerProvider:
 
         logger.info("Creating GCE instance: %s (zone=%s, type=%s)", config.name, zone, machine_type)
         try:
-            vm_info = self._gcp.vm_create(request)
+            # wait=True: start_controller uses internal_ip immediately to build the RPC address.
+            vm_info = self._gcp.vm_create(request, wait=True)
         except InfraError:
             self._best_effort_delete_vm(config.name, zone)
             raise

--- a/lib/iris/tests/cluster/backends/gcp/test_cloud_service_integration.py
+++ b/lib/iris/tests/cluster/backends/gcp/test_cloud_service_integration.py
@@ -312,6 +312,8 @@ def _dump_http_log(log: list[HttpLog]) -> str:
 
 
 def test_vm_full_lifecycle(svc: CloudGcpService, backend: GcpFakeBackend):
+    # wait=True: this test exercises the controller-VM bootstrap path that needs
+    # the instance IP immediately after create.
     vm = svc.vm_create(
         VmCreateRequest(
             name="ctrl-vm",
@@ -320,7 +322,8 @@ def test_vm_full_lifecycle(svc: CloudGcpService, backend: GcpFakeBackend):
             labels={"iris-managed": "true"},
             startup_script="#!/bin/bash\necho hello",
             service_account="sa@test.iam.gserviceaccount.com",
-        )
+        ),
+        wait=True,
     )
 
     assert vm.name == "ctrl-vm", f"Expected ctrl-vm, got {vm.name}\n{_dump_http_log(backend.http_log)}"

--- a/lib/iris/tests/cluster/backends/gcp/test_gcp_service.py
+++ b/lib/iris/tests/cluster/backends/gcp/test_gcp_service.py
@@ -20,12 +20,15 @@ from unittest.mock import MagicMock, patch
 import httpx
 import pytest
 from iris.cluster.backends.gcp.fake import InMemoryGcpService
+from iris.cluster.backends.gcp.handles import GcpVmSliceHandle
 from iris.cluster.backends.gcp.service import (
     CloudGcpService,
     TpuCreateRequest,
     VmCreateRequest,
+    VmInfo,
 )
 from iris.cluster.backends.types import (
+    CloudSliceState,
     InfraError,
     InfraUnavailableError,
     QuotaExhaustedError,
@@ -33,6 +36,7 @@ from iris.cluster.backends.types import (
 )
 from iris.cluster.service_mode import ServiceMode
 from iris.rpc import config_pb2
+from rigging.timing import Timestamp
 
 
 @pytest.fixture
@@ -482,3 +486,196 @@ def test_vm_list_propagates_api_errors(monkeypatch: pytest.MonkeyPatch, code: in
     svc = _mock_service(lambda _r: _gcp_error_response(code, message="boom"))
     with pytest.raises(expected):
         svc.vm_list(zones=[], labels={"iris-x-controller": "true"})
+
+
+# ========================================================================
+# Non-blocking vm_create
+# ========================================================================
+
+# A long-running zone operation that should never be awaited on the autoscaler path.
+_OP_NAME = "operation-123"
+_VM_ZONE = "us-central1-a"
+_VM_NAME = "my-vm"
+
+
+def _mock_service_with_insert_op(op_name: str = _OP_NAME) -> CloudGcpService:
+    """Build a CloudGcpService whose POST /instances returns an operation name.
+
+    The token is pre-seeded so _headers() never triggers a real credential refresh.
+    Any GET request (for the operation poll or describe) returns 404 so that the
+    non-blocking path's describe-skipping is exercised without network calls.
+    """
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        if request.method == "POST":
+            return httpx.Response(200, json={"name": op_name, "status": "RUNNING"})
+        # GET for operation or describe: return 404 (VM not yet visible)
+        return httpx.Response(404, json={"error": {"code": 404, "status": "NOT_FOUND", "message": "not found"}})
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    svc = CloudGcpService(project_id="test-project", http_client=client)
+    svc._token = "fake-token"
+    svc._expires_at = time.monotonic() + 3600
+    return svc
+
+
+def test_vm_create_default_does_not_wait_for_zone_operation() -> None:
+    """vm_create(wait=False) submits the insert and returns without polling the operation.
+
+    Verifies the boundedness fix: blocking on the zone op (up to 600 s) inside
+    the single-threaded control tick would starve reconcile and worker keep-alive.
+    """
+    wait_called = False
+
+    def _fail_if_wait_called(zone: str, op: str, timeout: float = 600.0) -> dict:
+        nonlocal wait_called
+        wait_called = True
+        raise AssertionError("_wait_zone_operation must not be called on the non-blocking path")
+
+    svc = _mock_service_with_insert_op()
+    svc._wait_zone_operation = _fail_if_wait_called  # type: ignore[method-assign]
+
+    req = VmCreateRequest(
+        name=_VM_NAME,
+        zone=_VM_ZONE,
+        machine_type="n2-standard-4",
+    )
+    info = svc.vm_create(req)  # wait=False by default
+
+    assert not wait_called
+    assert info.name == _VM_NAME
+    assert info.status == "PROVISIONING"
+    assert info.internal_ip == ""  # IP not yet assigned
+
+
+def test_vm_create_wait_true_calls_wait_zone_operation() -> None:
+    """vm_create(wait=True) does poll the zone operation (controller-VM bootstrap path)."""
+    wait_called = False
+
+    def _record_wait(zone: str, op: str, timeout: float = 600.0) -> dict:
+        nonlocal wait_called
+        wait_called = True
+        return {}
+
+    # For wait=True the service also calls vm_describe after the wait.  Return
+    # a minimal running-instance response so describe() succeeds.
+    call_count = {"n": 0}
+
+    def handler(request: httpx.Request) -> httpx.Response:
+        call_count["n"] += 1
+        if request.method == "POST":
+            return httpx.Response(200, json={"name": _OP_NAME, "status": "RUNNING"})
+        # GET /instances/<name>: return a running instance
+        return httpx.Response(
+            200,
+            json={
+                "name": _VM_NAME,
+                "status": "RUNNING",
+                "zone": f"https://www.googleapis.com/compute/v1/projects/test-project/zones/{_VM_ZONE}",
+                "networkInterfaces": [{"networkIP": "10.0.0.1"}],
+                "labels": {},
+            },
+        )
+
+    client = httpx.Client(transport=httpx.MockTransport(handler))
+    svc = CloudGcpService(project_id="test-project", http_client=client)
+    svc._token = "fake-token"
+    svc._expires_at = time.monotonic() + 3600
+    svc._wait_zone_operation = _record_wait  # type: ignore[method-assign]
+
+    req = VmCreateRequest(name=_VM_NAME, zone=_VM_ZONE, machine_type="n2-standard-4")
+    info = svc.vm_create(req, wait=True)
+
+    assert wait_called
+    assert info.status == "RUNNING"
+    assert info.internal_ip == "10.0.0.1"
+
+
+# ========================================================================
+# GcpVmSliceHandle state machine: None-describe → CREATING → READY
+# ========================================================================
+
+
+def _make_vm_slice_handle(gcp_service: InMemoryGcpService, slice_id: str, vm_name: str, zone: str) -> GcpVmSliceHandle:
+    """Build a GcpVmSliceHandle in the bootstrapping state (bootstrap_state=None)."""
+    return GcpVmSliceHandle(
+        _slice_id=slice_id,
+        _vm_name=vm_name,
+        _zone=zone,
+        _project_id="test-project",
+        _labels={},
+        _created_at=Timestamp.now(),
+        _label_prefix="iris",
+        _worker_port=10001,
+        _gcp_service=gcp_service,
+        _bootstrapping=True,  # bootstrap_state=None → still booting
+    )
+
+
+def test_vm_slice_describe_unknown_when_vm_not_yet_visible() -> None:
+    """describe() returns UNKNOWN when vm_describe returns None immediately after insert.
+
+    The slice must NOT be treated as FAILED during the boot grace window: UNKNOWN
+    is the correct state for a VM that has been inserted but is not yet visible to
+    the describe API (a race that was always possible but is now more common with
+    the non-blocking insert path).
+    """
+    gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
+    handle = _make_vm_slice_handle(gcp_service, "slice-abc", "vm-abc", "us-central2-b")
+
+    # VM not in the service yet (as if the insert just returned but describe hasn't caught up)
+    status = handle.describe()
+    assert status.state == CloudSliceState.UNKNOWN, (
+        f"Expected UNKNOWN while VM is not visible, got {status.state}. "
+        "FAILED here would cause an immediate spurious boot failure."
+    )
+
+
+def test_vm_slice_advances_from_creating_to_ready() -> None:
+    """Slice state machine: not-visible → CREATING (PROVISIONING) → READY (RUNNING).
+
+    This is the normal boot path for the non-blocking create: the autoscaler's
+    refresh loop drives state advancement purely through vm_describe() calls.
+    No zone-operation wait is involved.
+    """
+    gcp_service = InMemoryGcpService(mode=ServiceMode.DRY_RUN, project_id="test-project")
+
+    # Create VM in PROVISIONING state by adding it directly to the service
+    zone = "us-central2-b"
+    vm_name = "vm-boot-test"
+    provisioning_info = VmInfo(
+        name=vm_name,
+        status="PROVISIONING",
+        zone=zone,
+        internal_ip="",
+        external_ip=None,
+        labels={},
+        metadata={},
+        service_account=None,
+        created_at=Timestamp.now(),
+    )
+    gcp_service._vms[(vm_name, zone)] = provisioning_info
+
+    handle = _make_vm_slice_handle(gcp_service, "slice-boot", vm_name, zone)
+
+    # PROVISIONING maps to CREATING in the state machine
+    status = handle.describe()
+    assert status.state == CloudSliceState.CREATING, f"Expected CREATING while VM is PROVISIONING, got {status.state}"
+
+    # Advance to RUNNING (as refresh() would see after a few seconds)
+    gcp_service.advance_vm_state(vm_name, zone, "RUNNING")
+
+    # Still BOOTSTRAPPING because the bootstrap thread hasn't completed yet
+    status = handle.describe()
+    assert (
+        status.state == CloudSliceState.BOOTSTRAPPING
+    ), f"Expected BOOTSTRAPPING after VM is RUNNING but before bootstrap completes, got {status.state}"
+
+    # Simulate bootstrap thread completing
+    with handle._bootstrap_lock:
+        handle._bootstrap_state = CloudSliceState.READY
+
+    status = handle.describe()
+    assert status.state == CloudSliceState.READY
+    assert status.worker_count == 1
+    assert status.workers[0].internal_address == gcp_service._vms[(vm_name, zone)].internal_ip


### PR DESCRIPTION
CloudGcpService.vm_create previously blocked up to 600 s waiting for the zone insert operation. After PR #6343 (inline cloud ops) composed with PR #6344 (single control-tick thread), this stall ran inline in the control tick — stopping reconcile, worker-failure detection, and worker keep-alive for all GCP_SLICE_MODE_VM slices for up to 10 minutes per create.

vm_create now defaults to wait=False: POST the insert, return a synthesized VmInfo(status=PROVISIONING) immediately. The existing GcpVmSliceHandle.describe() / refresh() loop polls the real VM state via vm_describe() exactly as it does for TPU slices.

GcpWorkerProvider.create_vm (controller-bootstrap path) passes wait=True because start_controller uses internal_ip immediately to build the controller RPC address; _create_vm_slice (autoscaler path) discards the return value and uses the non-blocking default.

Three new behavioral regression tests: no _wait_zone_operation call on the non-blocking path; the blocking path does poll; GcpVmSliceHandle advances UNKNOWN -> CREATING -> BOOTSTRAPPING -> READY purely through vm_describe() calls.

Rider: _headers() now holds _token_lock during the check-and-refresh to prevent concurrent fan-out threads from refreshing credentials in parallel.

Found by post-merge adversarial review of #6343 x #6344.

🤖 Generated with [Claude Code](https://claude.com/claude-code)