### PR TITLE
[canary] Add nightly agentic canary

### DIFF
--- a/.github/workflows/marin-canary-agentic.yaml
+++ b/.github/workflows/marin-canary-agentic.yaml
@@ -92,6 +92,12 @@ jobs:
           echo "module=$MODULE" >> "$GITHUB_OUTPUT"
           echo "Authored module: $MODULE"
 
+      # Gate A, part 1 (credential-free): import + statically validate the agent's module
+      # BEFORE any cloud creds exist in the runner, so its import-time code can't read them.
+      - name: Gate A — validate (credential-free)
+        shell: bash -l {0}
+        run: .venv/bin/python -m experiments.ferries.agentic.agentic_canary check --module "${{ steps.mod.outputs.module }}"
+
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
         with:
@@ -113,10 +119,11 @@ jobs:
           chmod 600 ~/.ssh/google_compute_engine
           chmod 644 ~/.ssh/google_compute_engine.pub
 
-      # Gate A (CPU, pre-launch): module imports + exposes a valid launch; pinned dataset is in-region.
-      - name: Gate A (validate + data preflight)
+      # Gate A, part 2: confirm the pinned dataset is present in-region. This does NOT import
+      # the agent module (it only checks the pinned mixture), so running it post-auth is safe.
+      - name: Gate A — data preflight
         shell: bash -l {0}
-        run: .venv/bin/python -m experiments.ferries.agentic.agentic_canary gate-a --module "${{ steps.mod.outputs.module }}" --region us-east5
+        run: .venv/bin/python -m experiments.ferries.agentic.agentic_canary preflight --region us-east5
 
       # CI owns the launch. The worker entrypoint clamps consumption (resources/data/steps)
       # before submitting the child; --priority batch yields to interactive/production.

--- a/.github/workflows/marin-canary-agentic.yaml
+++ b/.github/workflows/marin-canary-agentic.yaml
@@ -1,0 +1,242 @@
+name: Marin - Canary Agentic
+
+# Nightly agentic canary: a cold-prompt agent authors a tiny grug-base experiment; CI
+# clamps its consumption (accelerator / dataset / steps), launches it on a single v6e in
+# us-east5, and grades that it trained. See experiments/ferries/agentic/agentic_canary.py.
+
+on:
+  schedule:
+    - cron: '0 3 * * *'  # Daily at 03:00 UTC, staggered clear of the other canaries
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  issues: write    # claude triage files issues
+  id-token: write  # claude-code-action OIDC
+
+jobs:
+  agentic-canary:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+    concurrency:
+      group: canary-agentic
+      cancel-in-progress: true
+    env:
+      RUN_ID: canary-agentic-${{ github.run_id }}-${{ github.run_attempt }}
+      WANDB_ENTITY: marin-community
+      WANDB_PROJECT: marin
+      IRIS_CONFIG: lib/iris/config/marin.yaml
+      MARIN_PREFIX: gs://marin-us-east5  # pin every region-resolved path (data, output, compile cache) in-region
+      CANARY_STEPS: "500"
+      CANARY_CHILD_WAIT_TIMEOUT: "12600"
+      IRIS_CONTROLLER_SERVICE_ACCOUNT: iris-controller@hai-gcp-models.iam.gserviceaccount.com
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Install dependencies
+        run: uv sync --all-packages --extra=cpu --no-default-groups
+
+      # Agent authoring runs BEFORE any cloud credentials exist in the runner: its scoped
+      # `.venv/bin/python` (used only to self-validate its module) cannot reach the cluster
+      # or read cloud secrets. The allowlist still excludes iris/gcloud/git/gh. CI
+      # authenticates and launches (with the clamp) only after Gate A.
+      - name: Agent authors experiment
+        uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1  # v1.0.140
+        with:
+          claude_code_oauth_token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
+          prompt: |
+            Set up a tiny language-model pretraining smoke experiment in this Marin repo,
+            to run on a single TPU for a few hundred steps. Use the repo and its skills to
+            figure out the conventions.
+
+            Author a NEW module at experiments/ferries/agentic/run_<short_slug>.py that defines
+            a module-level variable `launch` of type
+            experiments.grug.base.launch.GrugBaseLaunchConfig — a small grug-base model with an
+            optimizer and trainer. Base it on the grug-base template. Focus on the MODEL,
+            OPTIMIZER, and TRAINER. You do NOT need to choose the accelerator, dataset, or step
+            count: CI pins those for safety, so whatever you set for resources/data/steps is
+            overridden at launch.
+
+            Validate before finishing: run
+            `.venv/bin/python -m experiments.ferries.agentic.agentic_canary check --module experiments.ferries.agentic.run_<slug>`
+            and fix any import/type errors it reports. Then write ONLY the dotted module path
+            (e.g. experiments.ferries.agentic.run_<slug>) to `agentic_module.txt` at the repo root.
+
+            Constraints: only create files under experiments/ferries/agentic/. You MAY use
+            `.venv/bin/python` to import-check your module; do NOT commit, push, or launch
+            anything, and do NOT use git, gh, iris, or gcloud.
+          claude_args: |
+            --model claude-opus-4-8
+            --max-turns 40
+            --allowedTools "Read,Write,Edit,Bash(grep:*),Bash(cat:*),Bash(ls:*),Bash(find:*),Bash(.venv/bin/python:*)"
+
+      - name: Resolve authored module
+        id: mod
+        run: |
+          test -s agentic_module.txt || { echo "::error::agent did not write agentic_module.txt"; exit 1; }
+          MODULE="$(tr -d '[:space:]' < agentic_module.txt)"
+          echo "$MODULE" | grep -qE '^experiments\.ferries\.agentic\.[A-Za-z0-9_.]+$' \
+            || { echo "::error::unexpected module path: $MODULE"; exit 1; }
+          echo "module=$MODULE" >> "$GITHUB_OUTPUT"
+          echo "Authored module: $MODULE"
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Install SSH key
+        env:
+          SSH_KEY: ${{ secrets.IRIS_CI_GCP_SSH_KEY }}
+          SSH_KEY_PUB: ${{ secrets.IRIS_CI_GCP_SSH_KEY_PUB }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/google_compute_engine
+          printf '%s\n' "$SSH_KEY_PUB" > ~/.ssh/google_compute_engine.pub
+          chmod 600 ~/.ssh/google_compute_engine
+          chmod 644 ~/.ssh/google_compute_engine.pub
+
+      # Gate A (CPU, pre-launch): module imports + exposes a valid launch; pinned dataset is in-region.
+      - name: Gate A (validate + data preflight)
+        shell: bash -l {0}
+        run: .venv/bin/python -m experiments.ferries.agentic.agentic_canary gate-a --module "${{ steps.mod.outputs.module }}" --region us-east5
+
+      # CI owns the launch. The worker entrypoint clamps consumption (resources/data/steps)
+      # before submitting the child; --priority batch yields to interactive/production.
+      - name: Submit agentic canary
+        id: submit
+        shell: bash -l {0}
+        run: |
+          JOB_ID=$(.venv/bin/iris --config=${{ env.IRIS_CONFIG }} \
+            job run --no-wait \
+            --memory=2G --disk=4G --cpu=1 --extra=cpu \
+            --priority batch \
+            -e RUN_ID "$RUN_ID" \
+            -e MARIN_PREFIX "$MARIN_PREFIX" \
+            -e WANDB_ENTITY "$WANDB_ENTITY" \
+            -e WANDB_PROJECT "$WANDB_PROJECT" \
+            -e WANDB_API_KEY "$WANDB_API_KEY" \
+            -e HF_TOKEN "$HF_TOKEN" \
+            -e CANARY_STEPS "$CANARY_STEPS" \
+            -- python -m experiments.ferries.agentic.agentic_canary launch --module "${{ steps.mod.outputs.module }}")
+          echo "job_id=$JOB_ID" >> "$GITHUB_OUTPUT"
+          echo "Submitted job: $JOB_ID"
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+          HF_TOKEN: ${{ secrets.HF_TOKEN }}
+
+      # Bound the wait below the job timeout so a hung run fails this step (keeps the runner
+      # alive for triage), not the job. See marin-canary-ferry.yaml for the rationale.
+      - name: Wait for agentic canary
+        timeout-minutes: 300
+        shell: bash -l {0}
+        run: |
+          uv run python scripts/workflows/iris_monitor.py wait \
+            --job-id "${{ steps.submit.outputs.job_id }}" \
+            --iris-config "${{ env.IRIS_CONFIG }}" \
+            --poll-interval 30 \
+            --child-wait-timeout "${{ env.CANARY_CHILD_WAIT_TIMEOUT }}" \
+            --github-output
+
+      # Gate B (post-run): the run produced enough finite loss steps. Fails closed.
+      - name: Gate B (loss health)
+        shell: bash -l {0}
+        env:
+          WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
+        run: .venv/bin/python -m experiments.ferries.agentic.agentic_canary gate-b --run-id "$RUN_ID"
+
+      - name: Capture failure diagnostics
+        if: failure() || cancelled()
+        continue-on-error: true
+        shell: bash -l {0}
+        env:
+          JOB_ID: ${{ steps.submit.outputs.job_id }}
+          DIAG_DIR: ${{ github.workspace }}/canary-diagnostics
+        run: |
+          mkdir -p "$DIAG_DIR"
+          uv run python scripts/workflows/iris_monitor.py collect \
+            --job-id "$JOB_ID" \
+            --iris-config "${{ env.IRIS_CONFIG }}" \
+            --provider gcp \
+            --output-dir "$DIAG_DIR" \
+            --project "${{ secrets.GCP_PROJECT_ID }}" \
+            --controller-label iris-marin-controller \
+            --service-account "$IRIS_CONTROLLER_SERVICE_ACCOUNT" \
+            --ssh-key ~/.ssh/google_compute_engine
+
+      - name: Upload diagnostics
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentic-canary-diagnostics
+          path: canary-diagnostics/
+          retention-days: 14
+          if-no-files-found: ignore
+
+      # Capture what the agent produced so triage can tell a Gate-A (ergonomics) failure
+      # from a Gate-B (infra/stability) failure.
+      - name: Upload agent artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: agentic-canary-authored
+          path: |
+            agentic_module.txt
+            experiments/ferries/agentic/
+          retention-days: 14
+          if-no-files-found: ignore
+
+      - name: Claude triage
+        if: (failure() || cancelled()) && github.event_name == 'schedule'
+        uses: ./.github/actions/claude-triage
+        timeout-minutes: 30
+        with:
+          oauth-token: ${{ secrets.CLAUDE_CODE_OAUTH_TOKEN || secrets.CLAUDE_MAX_OAUTH_TOKEN }}
+          lane: agentic
+          job-id: ${{ steps.submit.outputs.job_id }}
+          run-id: ${{ env.RUN_ID }}
+          iris-config: ${{ env.IRIS_CONFIG }}
+          wandb-entity: ${{ env.WANDB_ENTITY }}
+          wandb-project: ${{ env.WANDB_PROJECT }}
+          wandb-api-key: ${{ secrets.WANDB_API_KEY }}
+          gha-run-url: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}
+
+      - name: Upload Slack message
+        if: failure() || cancelled()
+        uses: actions/upload-artifact@v4
+        with:
+          name: slack-message
+          path: slack_message.md
+          retention-days: 1
+          if-no-files-found: ignore
+
+  # Separate job so Slack always fires even if the main job is force-killed past its grace window.
+  notify-slack:
+    needs: agentic-canary
+    if: always() && (needs.agentic-canary.result == 'failure' || needs.agentic-canary.result == 'cancelled') && github.event_name == 'schedule'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+      - name: Notify Slack
+        uses: ./.github/actions/notify-slack
+        with:
+          webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
+          fallback-text: ":red_circle: *Agentic Canary failed*\nRun: ${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"

--- a/experiments/ferries/agentic/agentic_canary.py
+++ b/experiments/ferries/agentic/agentic_canary.py
@@ -26,11 +26,14 @@ region, and step count are CI's.
 """
 
 import argparse
+import ast
 import dataclasses
 import importlib
+import importlib.util
 import math
 import os
 import subprocess
+from pathlib import Path
 
 import wandb
 from fray.cluster import ResourceConfig
@@ -75,8 +78,77 @@ WANDB_GROUP = "agentic-canary"
 CHILD_ENV_KEYS = ("WANDB_API_KEY", "WANDB_ENTITY", "WANDB_PROJECT", "HF_TOKEN", "MARIN_PREFIX")
 
 
+# --- Gate A static guard: reject import-time side effects before executing agent code ---
+# Importing runs the module's top level (in `_load_launch`), which on a credentialed host
+# or an Iris worker could read secrets or submit jobs before the clamp applies. We parse —
+# never execute — the source and require it to only declare (imports / assignments / defs /
+# a docstring), with no process/network imports and no exec/eval or job-submitting calls.
+# Best-effort: an obfuscated module can still evade it; full containment is a sandboxed
+# import (tracked separately).
+_FORBIDDEN_IMPORTS = frozenset(
+    {"subprocess", "socket", "requests", "urllib", "http", "ftplib", "smtplib", "ctypes", "pty", "shutil"}
+)
+_FORBIDDEN_CALLS = frozenset(
+    {
+        "eval",
+        "exec",
+        "compile",
+        "__import__",
+        "system",
+        "popen",
+        "run",
+        "Popen",
+        "call",
+        "check_output",
+        "check_call",
+        "train_grug",
+        "executor_main",
+        "run_grug",
+        "_submit_train_job",
+    }
+)
+
+
+def _assert_no_import_side_effects(module_path: str) -> None:
+    """Statically reject an agent module that would do work at import time."""
+    spec = importlib.util.find_spec(module_path)  # resolves parent packages only, not the target
+    if spec is None or not spec.origin:
+        raise SystemExit(f"GATE A FAILED: cannot locate source for {module_path}.")
+    tree = ast.parse(Path(spec.origin).read_text(), filename=spec.origin)
+
+    allowed = (
+        ast.Import,
+        ast.ImportFrom,
+        ast.Assign,
+        ast.AnnAssign,
+        ast.FunctionDef,
+        ast.AsyncFunctionDef,
+        ast.ClassDef,
+    )
+    for node in tree.body:
+        if isinstance(node, allowed) or (isinstance(node, ast.Expr) and isinstance(node.value, ast.Constant)):
+            continue
+        raise SystemExit(
+            f"GATE A FAILED: {module_path} has a disallowed top-level {type(node).__name__} at "
+            f"line {node.lineno}; a config module may only import, assign, and define."
+        )
+
+    for node in ast.walk(tree):
+        if isinstance(node, ast.Import):
+            bad = next((a.name for a in node.names if a.name.split(".")[0] in _FORBIDDEN_IMPORTS), None)
+            if bad:
+                raise SystemExit(f"GATE A FAILED: {module_path} imports {bad!r} (process/network not allowed).")
+        elif isinstance(node, ast.ImportFrom) and node.module and node.module.split(".")[0] in _FORBIDDEN_IMPORTS:
+            raise SystemExit(f"GATE A FAILED: {module_path} imports from {node.module!r} (process/network not allowed).")
+        elif isinstance(node, ast.Call):
+            name = node.func.attr if isinstance(node.func, ast.Attribute) else getattr(node.func, "id", None)
+            if name in _FORBIDDEN_CALLS:
+                raise SystemExit(f"GATE A FAILED: {module_path} calls {name!r}, not allowed at import.")
+
+
 def _load_launch(module_path: str) -> GrugBaseLaunchConfig:
-    """Import the agent's module and return its `launch`, asserting the contract."""
+    """Statically guard against import-time side effects, then import and return `launch`."""
+    _assert_no_import_side_effects(module_path)
     module = importlib.import_module(module_path)
     launch = getattr(module, "launch", None)
     if launch is None:
@@ -170,10 +242,19 @@ def check(module_path: str) -> None:
     print("CHECK PASSED.")
 
 
-def gate_a(module_path: str, region: str) -> None:
-    validate_module(module_path)
-    print(f"GATE A: data preflight for the pinned mixture in {region}:")
+def preflight(region: str) -> None:
+    """Assert the pinned dataset is present in-region. Does not import the agent module
+    (it only checks the pinned mixture), so it is safe to run after cloud creds exist."""
+    print(f"data preflight for the pinned mixture in {region}:")
     _data_preflight(region)
+    print("PREFLIGHT PASSED.")
+
+
+def gate_a(module_path: str, region: str) -> None:
+    """Local convenience: validate the module and run the preflight together. In CI these
+    run as two steps so the import stays credential-free (see the workflow)."""
+    validate_module(module_path)
+    preflight(region)
     print("GATE A PASSED.")
 
 
@@ -241,6 +322,9 @@ def main() -> None:
     p_a.add_argument("--module", required=True, help="Dotted path to the agent's module.")
     p_a.add_argument("--region", default=CLAMP_REGION)
 
+    p_p = sub.add_parser("preflight", help="Assert the pinned dataset is in-region (no agent import; post-auth).")
+    p_p.add_argument("--region", default=CLAMP_REGION)
+
     p_l = sub.add_parser("launch", help="Clamp consumption and submit the run (Iris worker entrypoint).")
     p_l.add_argument("--module", required=True, help="Dotted path to the agent's module.")
 
@@ -252,6 +336,8 @@ def main() -> None:
         check(args.module)
     elif args.command == "gate-a":
         gate_a(args.module, args.region)
+    elif args.command == "preflight":
+        preflight(args.region)
     elif args.command == "launch":
         launch_cmd(args.module)
     elif args.command == "gate-b":

--- a/experiments/ferries/agentic/agentic_canary.py
+++ b/experiments/ferries/agentic/agentic_canary.py
@@ -1,0 +1,262 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Agentic canary driver: validate the agent's experiment, launch it under a clamped
+consumption envelope, and check that it trained.
+
+An agent authors a grug-base experiment from the repo + its skills; CI runs it, but never
+trusts the agent's consumption choices. Two gates bracket the run:
+
+  Gate A (pre-launch, CPU, no accelerator) — "is the authored experiment usable and safe to
+    launch?" It must import and expose a valid `launch`, and the pinned dataset must be present
+    in-region. A Gate-A failure is an ergonomics/safety problem, so no accelerator is spent.
+  Gate B (post-run) — "did the launched run actually train?" It must have produced enough
+    finite loss steps. A Gate-B failure points at infra/training, not the agent.
+
+Subcommands:
+  check  --module M   Gate A's code half (agent self-check, no cloud): M imports + exposes a valid `launch`.
+  gate-a --module M   check + assert the pinned dataset exists in-region. Fails closed.
+  launch --module M   (Iris worker) import M's `launch`, REPLACE consumption (resources/data/steps)
+                      with the clamp, assert it held, submit via train_grug. Agent's picks are recorded, not used.
+  gate-b --run-id R   read R's train/loss from W&B; assert it reached enough finite steps. Fails closed.
+
+Safety (cost + egress) comes from the clamp + preflight here — never from trusting the agent.
+The agent's freedom is the authoring (model / optimizer / trainer); the accelerator, dataset,
+region, and step count are CI's.
+"""
+
+import argparse
+import dataclasses
+import importlib
+import math
+import os
+import subprocess
+
+import wandb
+from fray.cluster import ResourceConfig
+from levanter.tracker.wandb import WandbConfig
+from marin.execution.executor import unwrap_versioned_value
+from marin.execution.types import this_output_path, versioned
+
+from experiments.grug.base.launch import GrugBaseLaunchConfig, train_grug
+from experiments.pretraining_datasets import nemotron_mix
+
+# --- The clamp: the fixed run envelope CI forces, ignoring whatever the agent wrote —
+# one small TPU slice in a pinned region, plus a pinned dataset and a step cap (below). ---
+ALLOWED_TPU_VARIANTS = ("v6e-8", "v5p-8", "v4-8")  # single-VM TPU variants (1 slice == 1 replica)
+CLAMP_TPU_VARIANT = "v6e-8"
+CLAMP_REGION = "us-east5"
+CLAMP_SLICE_COUNT = 1
+STEP_CAP = 500  # hard ceiling on steps, even if env asks for more
+
+# Pinned, region-local training mixture (verified present in gs://marin-us-east5).
+# The agent's `data` choice is recorded but never used — this is what actually runs,
+# so reads stay in-region (no egress). Relative paths resolve under gs://marin-<region>.
+PINNED_DATA = nemotron_mix
+PINNED_DATA_COMPONENT_PATHS = (
+    "tokenized/nemotron_cc/hq_actual-5af4cc",
+    "tokenized/nemotron_cc/hq_synth-3525e2",
+    "tokenized/nemotron_cc/low_actual-cb3f2c",
+    "tokenized/nemotron_cc/low_synth-3c57b3",
+    "tokenized/nemotron_cc/medium-d86506",
+    "tokenized/nemotron_cc/medium_high-d21701",
+    "tokenized/nemotron_cc/medium_low-0fdb07",
+    "tokenized/starcoderdata-12f018",
+    "tokenized/proofpile_2-4a35c7",
+)
+
+# --- Gate B: post-run health check (did it train at all — not how well) ---
+TRAIN_LOSS_KEY = "train/loss"
+MIN_STEPS = 100  # must reach this many logged steps
+
+CANARY_NAME = "grug/agentic-canary"
+WANDB_GROUP = "agentic-canary"
+# Training env forwarded from the launcher into the worker.
+CHILD_ENV_KEYS = ("WANDB_API_KEY", "WANDB_ENTITY", "WANDB_PROJECT", "HF_TOKEN", "MARIN_PREFIX")
+
+
+def _load_launch(module_path: str) -> GrugBaseLaunchConfig:
+    """Import the agent's module and return its `launch`, asserting the contract."""
+    module = importlib.import_module(module_path)
+    launch = getattr(module, "launch", None)
+    if launch is None:
+        raise SystemExit(f"GATE A FAILED: {module_path} has no module-level `launch`.")
+    if not isinstance(launch, GrugBaseLaunchConfig):
+        raise SystemExit(
+            f"GATE A FAILED: {module_path}.launch is {type(launch).__name__}, "
+            "expected experiments.grug.base.launch.GrugBaseLaunchConfig."
+        )
+    return launch
+
+
+def _clamped_resources() -> ResourceConfig:
+    return ResourceConfig.with_tpu(CLAMP_TPU_VARIANT, slice_count=CLAMP_SLICE_COUNT, regions=[CLAMP_REGION])
+
+
+def _assert_in_envelope(resources: ResourceConfig) -> None:
+    """Defense-in-depth: verify the clamped resources match the envelope — an allowed
+    single-VM variant, one slice, pinned region."""
+    variant = resources.device.variant
+    if variant not in ALLOWED_TPU_VARIANTS:
+        raise SystemExit(f"CLAMP FAILED: variant {variant!r} not in {ALLOWED_TPU_VARIANTS}.")
+    if resources.device_alternatives:
+        raise SystemExit(f"CLAMP FAILED: unexpected device_alternatives {resources.device_alternatives}.")
+    if resources.regions != [CLAMP_REGION]:
+        raise SystemExit(f"CLAMP FAILED: regions {resources.regions} != [{CLAMP_REGION!r}].")
+    if resources.replicas > CLAMP_SLICE_COUNT:
+        raise SystemExit(f"CLAMP FAILED: replicas {resources.replicas} > {CLAMP_SLICE_COUNT}.")
+
+
+def _data_preflight(region: str) -> None:
+    """Assert every pinned data component exists in the target region (no egress / no miss)."""
+    missing = []
+    for path in PINNED_DATA_COMPONENT_PATHS:
+        url = f"gs://marin-{region}/{path}/"
+        result = subprocess.run(
+            ["gcloud", "storage", "ls", url],
+            capture_output=True,
+            text=True,
+        )
+        status = "ok" if result.returncode == 0 else "MISSING"
+        print(f"  [{status}] {url}")
+        if result.returncode != 0:
+            missing.append(url)
+    if missing:
+        raise SystemExit(f"GATE A FAILED: {len(missing)} pinned data component(s) absent in {region}: {missing}")
+
+
+def _wandb_target() -> tuple[str | None, str]:
+    """(entity, project) for W&B reads and writes, from the environment."""
+    return os.environ.get("WANDB_ENTITY") or None, os.environ.get("WANDB_PROJECT", "marin")
+
+
+def _tracker() -> WandbConfig:
+    entity, project = _wandb_target()
+    return WandbConfig(
+        entity=entity,
+        project=project,
+        tags=["grug", "agentic-canary"],
+        group=WANDB_GROUP,
+        name=None,  # the grug launcher sets the W&B run name from the launch run_id
+        replicate_path=this_output_path(),
+    )
+
+
+def validate_module(module_path: str) -> GrugBaseLaunchConfig:
+    """Import the agent's module, assert the contract, report its (untrusted) picks.
+
+    The code half of Gate A — no cloud access — so the authoring agent can run it
+    itself (`check`) to validate before CI does.
+    """
+    launch = _load_launch(module_path)
+    print(f"OK: {module_path}.launch is a valid GrugBaseLaunchConfig.")
+
+    # Record (do not trust) what the agent chose for the clamped dimensions. Best-effort:
+    # the values are overridden at launch, so a weird shape must not fail validation.
+    chosen = unwrap_versioned_value(launch.resources)
+    variant = getattr(getattr(chosen, "device", None), "variant", "?")
+    components = getattr(getattr(launch, "data", None), "components", {})
+    print(
+        f"  agent chose: accelerator={variant} replicas={getattr(chosen, 'replicas', '?')} "
+        f"steps={unwrap_versioned_value(launch.steps)} data_components={len(components)} "
+        "(all overridden by the clamp at launch)"
+    )
+    return launch
+
+
+def check(module_path: str) -> None:
+    """Agent self-check: the module imports and exposes a valid launch (no cloud, no launch)."""
+    validate_module(module_path)
+    print("CHECK PASSED.")
+
+
+def gate_a(module_path: str, region: str) -> None:
+    validate_module(module_path)
+    print(f"GATE A: data preflight for the pinned mixture in {region}:")
+    _data_preflight(region)
+    print("GATE A PASSED.")
+
+
+def launch_cmd(module_path: str) -> None:
+    launch = _load_launch(module_path)
+    run_id = os.environ["RUN_ID"]
+    steps = min(int(os.environ.get("CANARY_STEPS", STEP_CAP)), STEP_CAP)
+
+    clamped = dataclasses.replace(
+        launch,
+        resources=versioned(_clamped_resources()),
+        data=PINNED_DATA,
+        steps=versioned(steps),
+        output_path=this_output_path(),
+        run_id=run_id,
+        tracker=_tracker(),
+        eval=None,
+    )
+    _assert_in_envelope(unwrap_versioned_value(clamped.resources))
+    if clamped.data is not PINNED_DATA:
+        raise SystemExit("CLAMP FAILED: data is not the pinned in-region mixture.")
+
+    env_vars = {key: os.environ[key] for key in CHILD_ENV_KEYS if os.environ.get(key)}
+    print(f"LAUNCH: run_id={run_id} steps={steps} variant={CLAMP_TPU_VARIANT} region={CLAMP_REGION}")
+    train_grug(name=CANARY_NAME, launch=clamped, env_vars=env_vars)
+
+
+def _loss_points(run_id: str) -> list[tuple[int, float]]:
+    entity, project = _wandb_target()
+    run_path = f"{entity}/{project}/{run_id}" if entity else f"{project}/{run_id}"
+    run = wandb.Api(timeout=60).run(run_path)
+    points: list[tuple[int, float]] = []
+    for row in run.scan_history(keys=["_step", TRAIN_LOSS_KEY]):
+        step, loss = row.get("_step"), row.get(TRAIN_LOSS_KEY)
+        if not isinstance(loss, (int, float)):
+            continue
+        if not math.isfinite(loss):
+            raise SystemExit(f"GATE B FAILED: non-finite {TRAIN_LOSS_KEY}={loss} at step {step}.")
+        if isinstance(step, (int, float)):
+            points.append((int(step), float(loss)))
+    return points
+
+
+def gate_b(run_id: str) -> None:
+    # _loss_points already fails closed on any non-finite loss (NaN/Inf = divergence/crash).
+    points = _loss_points(run_id)
+    if not points:
+        raise SystemExit(f"GATE B FAILED: no {TRAIN_LOSS_KEY} points for run {run_id}.")
+
+    max_step = max(s for s, _ in points)
+    print(f"GATE B: {len(points)} finite loss points, max_step={max_step}, final={points[-1][1]:.3f}")
+    if max_step < MIN_STEPS:
+        raise SystemExit(f"GATE B FAILED: only reached step {max_step} (< {MIN_STEPS}).")
+    print("GATE B PASSED.")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description=__doc__)
+    sub = parser.add_subparsers(dest="command", required=True)
+
+    p_c = sub.add_parser("check", help="Import + type-check the agent's module (no cloud; agent self-check).")
+    p_c.add_argument("--module", required=True, help="Dotted path to the agent's module.")
+
+    p_a = sub.add_parser("gate-a", help="Validate the agent's module + pinned-data preflight (pre-launch).")
+    p_a.add_argument("--module", required=True, help="Dotted path to the agent's module.")
+    p_a.add_argument("--region", default=CLAMP_REGION)
+
+    p_l = sub.add_parser("launch", help="Clamp consumption and submit the run (Iris worker entrypoint).")
+    p_l.add_argument("--module", required=True, help="Dotted path to the agent's module.")
+
+    p_b = sub.add_parser("gate-b", help="Check loss health from W&B (post-run).")
+    p_b.add_argument("--run-id", required=True)
+
+    args = parser.parse_args()
+    if args.command == "check":
+        check(args.module)
+    elif args.command == "gate-a":
+        gate_a(args.module, args.region)
+    elif args.command == "launch":
+        launch_cmd(args.module)
+    elif args.command == "gate-b":
+        gate_b(args.run_id)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
Adds a nightly canary that tests whether the repo and its skills still let an agent stand up a working training run. The existing canaries fix the config and test infra/training health; this one holds the infra constant and varies the agent, giving an ergonomics regression signal for an agent-first codebase.

Problem: nothing continuously checks that a naive agent can still produce a launchable experiment from the repo, its skills, and conventions. Doc/skill/API drift stays invisible until someone hits it.

Approach: a cold-prompt agent authors a tiny grug-base experiment exposing a module-level `launch: GrugBaseLaunchConfig`. CI never trusts the agent's consumption choices; two gates bracket the run:

- Gate A (pre-launch, CPU): the module imports and exposes a valid `launch`, and the pinned dataset is present in the compute region. Fails closed, so no accelerator is spent on a broken artifact.
- Launch: CI clamps the agent's resources, data, and steps to a fixed envelope (one v6e-8 in us-east5, a pinned in-region dataset, a step cap, batch priority) and submits via train_grug. The agent's choices are recorded but never used, so cost and egress safety come from the clamp, not from trusting the agent.
- Gate B (post-run): the run produced enough finite loss steps.

On a scheduled failure it reuses the existing claude-triage action (lane agentic) and Slack notification.

The driver (experiments/ferries/agentic/agentic_canary.py) exposes check/gate-a/launch/gate-b plus the clamp and in-region data preflight; the workflow (.github/workflows/marin-canary-agentic.yaml) runs authoring credential-free, then the gates and the clamped launch.
