### PR TITLE
Add DCLM Core scoring helpers

### DIFF
--- a/experiments/evals/dclm_core.py
+++ b/experiments/evals/dclm_core.py
@@ -1,0 +1,308 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""DCLM Core v2 task inventory and centered-accuracy scoring helpers."""
+
+from __future__ import annotations
+
+import math
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+from marin.evaluation.evaluation_config import EvalTaskConfig
+
+
+class TaskStatus(StrEnum):
+    """Implementation status for one DCLM Core task."""
+
+    LAUNCHABLE = "launchable"
+    REQUIRES_CUSTOM_TASK = "requires_custom_task"
+    REQUIRES_FILTERED_GENERATION = "requires_filtered_generation"
+
+
+class TaskMode(StrEnum):
+    """Evaluation backend mode for one DCLM Core task."""
+
+    EXTRACTIVE = "extractive"
+    MCQ = "mcq"
+    GENERATION = "generation"
+
+
+BIGBENCH_FILTERED_EXACT_MATCH_METRICS = (
+    "exact_match,strip-then-match",
+    "exact_match,strict-match",
+    "exact_match,flexible-extract",
+    "em",
+    "f1",
+)
+
+EXACT_MATCH_METRICS = (
+    "exact_match",
+    "exact_match,none",
+    "exact_match,strip-then-match",
+    "exact_match,strict-match",
+    "exact_match,flexible-extract",
+    "em",
+    "f1",
+)
+
+
+@dataclass(frozen=True)
+class DCLMCoreTask:
+    """One DCLM Core v2 task and its DCLM-centered scoring metadata."""
+
+    name: str
+    alias: str
+    num_fewshot: int
+    mode: TaskMode
+    random_baseline: float
+    primary_metric: str
+    status: TaskStatus = TaskStatus.LAUNCHABLE
+    task_kwargs: dict[str, Any] | None = None
+    metric_candidates: tuple[str, ...] = ()
+    metric_task_names: tuple[str, ...] = ()
+
+    def eval_config(self) -> EvalTaskConfig:
+        """Return the Marin eval task config for launchable tasks."""
+        if self.status != TaskStatus.LAUNCHABLE:
+            raise ValueError(f"DCLM Core task {self.alias} is not launchable: {self.status}")
+        return EvalTaskConfig(
+            self.name,
+            self.num_fewshot,
+            task_alias=self.alias,
+            task_kwargs=self.task_kwargs,
+        )
+
+    def metric_paths(self) -> tuple[str, ...]:
+        """Return flattened lm-eval metric columns that can score this task."""
+        metrics = self.metric_candidates or (self.primary_metric,)
+        task_names = (self.alias, self.name, *self.metric_task_names)
+        paths: list[str] = []
+        seen: set[str] = set()
+        for task_name in task_names:
+            for metric in metrics:
+                path = f"lm_eval/{task_name}/{metric}"
+                if path in seen:
+                    continue
+                seen.add(path)
+                paths.append(path)
+        return tuple(paths)
+
+
+def _bigbench_generate_until_task_kwargs(dataset_name: str) -> dict[str, Any]:
+    return {
+        "dataset_path": "hails/bigbench",
+        "dataset_name": dataset_name,
+        "test_split": "default",
+        "output_type": "generate_until",
+        "doc_to_text": "inputs",
+        "doc_to_target": "{{targets[0]}}",
+        "metric_list": [
+            {
+                "metric": "exact_match",
+                "aggregation": "mean",
+                "higher_is_better": True,
+                "ignore_punctuation": True,
+            }
+        ],
+        "metadata": {
+            "version": 1.0,
+            "source": "lm-eval BigBench generate-until template adapted for DCLM Core scoring",
+        },
+    }
+
+
+def dclm_core_tasks() -> tuple[DCLMCoreTask, ...]:
+    """Return the 22-task DCLM Core v2 inventory from the DCLM paper."""
+    return (
+        DCLMCoreTask("agieval_lsat_ar", "agieval_lsat_ar_3shot", 3, TaskMode.MCQ, 0.25, "acc_norm"),
+        DCLMCoreTask("arc_easy", "arc_easy_10shot", 10, TaskMode.MCQ, 0.25, "acc_norm"),
+        DCLMCoreTask("arc_challenge", "arc_challenge_10shot", 10, TaskMode.MCQ, 0.25, "acc_norm"),
+        DCLMCoreTask(
+            "bigbench_qa_wikidata_generate_until",
+            "bb_qa_wikidata_10shot",
+            10,
+            TaskMode.GENERATION,
+            0.0,
+            "exact_match",
+            status=TaskStatus.REQUIRES_FILTERED_GENERATION,
+            task_kwargs=_bigbench_generate_until_task_kwargs("qa_wikidata_zero_shot"),
+            metric_candidates=BIGBENCH_FILTERED_EXACT_MATCH_METRICS,
+        ),
+        DCLMCoreTask(
+            "bigbench_dyck_languages_generate_until",
+            "bb_dyck_languages_10shot",
+            10,
+            TaskMode.GENERATION,
+            0.0,
+            "exact_match",
+            status=TaskStatus.REQUIRES_FILTERED_GENERATION,
+            task_kwargs=_bigbench_generate_until_task_kwargs("dyck_languages_zero_shot"),
+            metric_candidates=BIGBENCH_FILTERED_EXACT_MATCH_METRICS,
+        ),
+        DCLMCoreTask(
+            "bigbench_operators_generate_until",
+            "bb_operators_10shot",
+            10,
+            TaskMode.GENERATION,
+            0.0,
+            "exact_match",
+            status=TaskStatus.REQUIRES_FILTERED_GENERATION,
+            task_kwargs=_bigbench_generate_until_task_kwargs("operators_zero_shot"),
+            metric_candidates=BIGBENCH_FILTERED_EXACT_MATCH_METRICS,
+        ),
+        DCLMCoreTask(
+            "bigbench_repeat_copy_logic_generate_until",
+            "bb_repeat_copy_logic_10shot",
+            10,
+            TaskMode.GENERATION,
+            0.0,
+            "exact_match",
+            status=TaskStatus.REQUIRES_FILTERED_GENERATION,
+            task_kwargs=_bigbench_generate_until_task_kwargs("repeat_copy_logic_zero_shot"),
+            metric_candidates=BIGBENCH_FILTERED_EXACT_MATCH_METRICS,
+        ),
+        DCLMCoreTask(
+            "bigbench_cs_algorithms_generate_until",
+            "bb_cs_algorithms_10shot",
+            10,
+            TaskMode.GENERATION,
+            0.0,
+            "exact_match",
+            status=TaskStatus.REQUIRES_FILTERED_GENERATION,
+            task_kwargs=_bigbench_generate_until_task_kwargs("cs_algorithms_zero_shot"),
+            metric_candidates=BIGBENCH_FILTERED_EXACT_MATCH_METRICS,
+        ),
+        DCLMCoreTask(
+            "bigbench_language_identification_multiple_choice",
+            "bb_language_identification_10shot",
+            10,
+            TaskMode.MCQ,
+            0.25,
+            "acc",
+        ),
+        DCLMCoreTask("boolq", "boolq_10shot", 10, TaskMode.MCQ, 0.62, "acc"),
+        DCLMCoreTask("commonsense_qa", "commonsense_qa_10shot", 10, TaskMode.MCQ, 0.403, "acc"),
+        DCLMCoreTask("copa", "copa_0shot", 0, TaskMode.MCQ, 0.5, "acc"),
+        DCLMCoreTask(
+            "coqa",
+            "coqa_0shot",
+            0,
+            TaskMode.GENERATION,
+            0.0,
+            "f1",
+            metric_candidates=("f1", "em", *EXACT_MATCH_METRICS),
+        ),
+        # DCLM Core counts HellaSwag at both 0-shot and 10-shot.
+        DCLMCoreTask("hellaswag", "hellaswag_0shot", 0, TaskMode.MCQ, 0.25, "acc_norm"),
+        DCLMCoreTask("hellaswag", "hellaswag_10shot", 10, TaskMode.MCQ, 0.25, "acc_norm"),
+        DCLMCoreTask(
+            "jeopardy",
+            "jeopardy_10shot",
+            10,
+            TaskMode.GENERATION,
+            0.0,
+            "exact_match",
+            status=TaskStatus.REQUIRES_CUSTOM_TASK,
+            metric_candidates=EXACT_MATCH_METRICS,
+        ),
+        DCLMCoreTask("lambada_openai", "lambada_0shot", 0, TaskMode.MCQ, 0.0, "acc"),
+        DCLMCoreTask("openbookqa", "openbookqa_0shot", 0, TaskMode.MCQ, 0.25, "acc_norm"),
+        DCLMCoreTask("piqa", "piqa_10shot", 10, TaskMode.MCQ, 0.5, "acc_norm"),
+        DCLMCoreTask(
+            "squad_completion",
+            "squad_10shot",
+            10,
+            TaskMode.GENERATION,
+            0.0,
+            "contains",
+            metric_candidates=("contains", "exact", "exact_match", "f1"),
+        ),
+        DCLMCoreTask(
+            "winograd",
+            "winograd_0shot",
+            0,
+            TaskMode.MCQ,
+            0.5,
+            "acc",
+            status=TaskStatus.REQUIRES_CUSTOM_TASK,
+        ),
+        DCLMCoreTask("winogrande", "winogrande_0shot", 0, TaskMode.MCQ, 0.5, "acc"),
+    )
+
+
+def task_by_alias(alias: str) -> DCLMCoreTask:
+    """Return a DCLM Core task by alias."""
+    by_alias = {task.alias: task for task in dclm_core_tasks()}
+    try:
+        return by_alias[alias]
+    except KeyError as exc:
+        raise ValueError(f"Unknown DCLM Core task alias: {alias}") from exc
+
+
+def dclm_core_task_aliases() -> tuple[str, ...]:
+    """Return aliases for all DCLM Core v2 tasks, including custom-task gaps."""
+    return tuple(task.alias for task in dclm_core_tasks())
+
+
+def launchable_task_aliases() -> tuple[str, ...]:
+    """Return aliases for DCLM Core tasks with safe, currently supported launch configs."""
+    return tuple(task.alias for task in dclm_core_tasks() if task.status == TaskStatus.LAUNCHABLE)
+
+
+def task_aliases_for_mode(mode: TaskMode) -> tuple[str, ...]:
+    """Return launchable aliases for one evaluator mode."""
+    return tuple(task.alias for task in dclm_core_tasks() if task.status == TaskStatus.LAUNCHABLE and task.mode == mode)
+
+
+def eval_tasks_for_aliases(task_aliases: tuple[str, ...]) -> list[EvalTaskConfig]:
+    """Return EvalTaskConfig objects in the requested alias order."""
+    return [task_by_alias(alias).eval_config() for alias in task_aliases]
+
+
+def _metric_value_for_task(metrics: dict[str, Any], task: DCLMCoreTask) -> float | None:
+    for path in task.metric_paths():
+        value = metrics.get(path)
+        if value is None:
+            continue
+        try:
+            numeric = float(value)
+        except (TypeError, ValueError):
+            continue
+        if math.isfinite(numeric):
+            return numeric
+    return None
+
+
+def dclm_core_centered_accuracy(
+    metrics: dict[str, Any],
+    task_aliases: tuple[str, ...] | None = None,
+) -> dict[str, float]:
+    r"""Compute DCLM-centered task accuracies and their macro average.
+
+    Centered accuracy is \((a-r)/(1-r)\), where \(a\) is a task's hard
+    accuracy-like score and \(r\) is its DCLM random baseline. The macro average
+    uses observed tasks only and reports ``missing_task_count``; do not compare a
+    partial macro directly to a fully covered DCLM Core score.
+    """
+    aliases = task_aliases or dclm_core_task_aliases()
+    scores: dict[str, float] = {}
+    values: list[float] = []
+    for alias in aliases:
+        task = task_by_alias(alias)
+        raw_value = _metric_value_for_task(metrics, task)
+        if raw_value is None:
+            continue
+        denominator = 1.0 - task.random_baseline
+        if denominator <= 0.0:
+            raise ValueError(f"Invalid random baseline for {alias}: {task.random_baseline}")
+        centered = (raw_value - task.random_baseline) / denominator
+        scores[f"lm_eval/dclm_core/{alias}/centered_accuracy"] = centered
+        scores[f"lm_eval/dclm_core/{alias}/raw_score"] = raw_value
+        values.append(centered)
+
+    scores["lm_eval/dclm_core/task_count"] = float(len(values))
+    scores["lm_eval/dclm_core/missing_task_count"] = float(len(aliases) - len(values))
+    scores["lm_eval/dclm_core/centered_accuracy_macro"] = float(sum(values) / len(values)) if values else math.nan
+    return scores

--- a/experiments/evals/task_configs.py
+++ b/experiments/evals/task_configs.py
@@ -5,6 +5,8 @@ from collections.abc import Sequence
 
 from marin.evaluation.evaluation_config import EvalTaskConfig
 
+from experiments.evals import dclm_core
+
 # tasks to run (corresponding to lm_eval_harness tasks)
 # subset from from page 43 of the DCLM paper: https://arxiv.org/pdf/2406.11794
 # TODO: add more once supported in lm-eval-harness and/or tested on our end
@@ -24,6 +26,10 @@ CORE_TASKS = (
     # EvalTaskConfig("squadv2", 10),  # reading comprehension benchmark
     EvalTaskConfig("wsc273", 0),  # Winograd Schema Challenge
     EvalTaskConfig("winogrande", 0),  # Winograd challenge, extended to more domains
+)
+
+DCLM_CORE_V2_TASKS = tuple(
+    task.eval_config() for task in dclm_core.dclm_core_tasks() if task.status == dclm_core.TaskStatus.LAUNCHABLE
 )
 
 MMLU_0_SHOT = EvalTaskConfig("mmlu", 0, task_alias="mmlu_0shot")

--- a/tests/evals/test_dclm_core.py
+++ b/tests/evals/test_dclm_core.py
@@ -1,0 +1,136 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from marin.evaluation.evaluation_config import convert_to_levanter_task_config
+
+from experiments.evals import dclm_core
+from experiments.evals.task_configs import DCLM_CORE_V2_TASKS
+
+
+def test_dclm_core_inventory_accounts_for_all_paper_tasks() -> None:
+    tasks = dclm_core.dclm_core_tasks()
+
+    assert len(tasks) == 22
+    assert {task.alias for task in tasks} == {
+        "agieval_lsat_ar_3shot",
+        "arc_easy_10shot",
+        "arc_challenge_10shot",
+        "bb_qa_wikidata_10shot",
+        "bb_dyck_languages_10shot",
+        "bb_operators_10shot",
+        "bb_repeat_copy_logic_10shot",
+        "bb_cs_algorithms_10shot",
+        "bb_language_identification_10shot",
+        "boolq_10shot",
+        "commonsense_qa_10shot",
+        "copa_0shot",
+        "coqa_0shot",
+        "hellaswag_0shot",
+        "hellaswag_10shot",
+        "jeopardy_10shot",
+        "lambada_0shot",
+        "openbookqa_0shot",
+        "piqa_10shot",
+        "squad_10shot",
+        "winograd_0shot",
+        "winogrande_0shot",
+    }
+    assert dclm_core.task_by_alias("arc_easy_10shot").primary_metric == "acc_norm"
+    assert dclm_core.task_by_alias("boolq_10shot").random_baseline == 0.62
+    assert dclm_core.task_by_alias("commonsense_qa_10shot").random_baseline == 0.403
+
+
+def test_custom_data_tasks_are_not_launchable_until_provenance_is_resolved() -> None:
+    launchable_aliases = set(dclm_core.launchable_task_aliases())
+
+    assert "jeopardy_10shot" not in launchable_aliases
+    assert "winograd_0shot" not in launchable_aliases
+    assert dclm_core.task_by_alias("jeopardy_10shot").status == dclm_core.TaskStatus.REQUIRES_CUSTOM_TASK
+    assert dclm_core.task_by_alias("winograd_0shot").status == dclm_core.TaskStatus.REQUIRES_CUSTOM_TASK
+    with pytest.raises(ValueError, match="not launchable"):
+        dclm_core.task_by_alias("jeopardy_10shot").eval_config()
+
+
+def test_bigbench_generation_tasks_are_not_launchable_until_filtered_metrics_are_supported() -> None:
+    launchable_aliases = set(dclm_core.launchable_task_aliases())
+
+    assert "bb_qa_wikidata_10shot" not in launchable_aliases
+    assert dclm_core.task_by_alias("bb_qa_wikidata_10shot").status == dclm_core.TaskStatus.REQUIRES_FILTERED_GENERATION
+    with pytest.raises(ValueError, match="not launchable"):
+        dclm_core.task_by_alias("bb_qa_wikidata_10shot").eval_config()
+
+
+def test_task_configs_exports_only_launchable_dclm_core_v2_tasks() -> None:
+    aliases = {task.task_alias for task in DCLM_CORE_V2_TASKS}
+
+    assert len(DCLM_CORE_V2_TASKS) == 15
+    assert aliases == set(dclm_core.launchable_task_aliases())
+    assert "bb_qa_wikidata_10shot" not in aliases
+    assert "jeopardy_10shot" not in aliases
+    assert "winograd_0shot" not in aliases
+
+
+def test_launchable_eval_configs_convert_to_levanter_task_configs() -> None:
+    task = dclm_core.task_by_alias("boolq_10shot")
+
+    [config] = convert_to_levanter_task_config([task.eval_config()])
+
+    assert config.task == "boolq"
+    assert config.task_alias == "boolq_10shot"
+
+
+def test_centered_accuracy_uses_primary_hard_metric_and_counts_missing_tasks() -> None:
+    metrics = {
+        "lm_eval/boolq_10shot/acc": 0.75,
+        "lm_eval/hellaswag_0shot/acc_norm": 0.70,
+        "lm_eval/coqa_0shot/f1": 0.40,
+    }
+
+    centered = dclm_core.dclm_core_centered_accuracy(metrics)
+
+    assert centered["lm_eval/dclm_core/boolq_10shot/centered_accuracy"] == pytest.approx((0.75 - 0.62) / 0.38)
+    assert centered["lm_eval/dclm_core/hellaswag_0shot/centered_accuracy"] == 0.60
+    assert centered["lm_eval/dclm_core/coqa_0shot/centered_accuracy"] == 0.40
+    assert centered["lm_eval/dclm_core/task_count"] == 3.0
+    assert centered["lm_eval/dclm_core/missing_task_count"] == 19.0
+    assert centered["lm_eval/dclm_core/centered_accuracy_macro"] == pytest.approx(
+        ((0.75 - 0.62) / 0.38 + 0.60 + 0.40) / 3.0
+    )
+
+
+def test_bigbench_generation_scoring_prefers_filtered_exact_match() -> None:
+    metrics = {
+        "lm_eval/bigbench_qa_wikidata_generate_until/exact_match,none": 0.0,
+        "lm_eval/bigbench_qa_wikidata_generate_until/exact_match,strip-then-match": 0.30,
+    }
+
+    centered = dclm_core.dclm_core_centered_accuracy(metrics, task_aliases=("bb_qa_wikidata_10shot",))
+
+    assert centered["lm_eval/dclm_core/bb_qa_wikidata_10shot/raw_score"] == 0.30
+    assert centered["lm_eval/dclm_core/bb_qa_wikidata_10shot/centered_accuracy"] == 0.30
+    assert centered["lm_eval/dclm_core/task_count"] == 1.0
+
+
+def test_bigbench_generation_scoring_rejects_unfiltered_exact_match_none() -> None:
+    metrics = {
+        "lm_eval/bigbench_qa_wikidata_generate_until/exact_match,none": 0.0,
+    }
+
+    centered = dclm_core.dclm_core_centered_accuracy(metrics, task_aliases=("bb_qa_wikidata_10shot",))
+
+    assert "lm_eval/dclm_core/bb_qa_wikidata_10shot/raw_score" not in centered
+    assert centered["lm_eval/dclm_core/task_count"] == 0.0
+    assert centered["lm_eval/dclm_core/missing_task_count"] == 1.0
+
+
+def test_bigbench_generation_scoring_rejects_post_strip_unfiltered_exact_match() -> None:
+    metrics = {
+        "lm_eval/bigbench_qa_wikidata_generate_until/exact_match": 0.0,
+    }
+
+    centered = dclm_core.dclm_core_centered_accuracy(metrics, task_aliases=("bb_qa_wikidata_10shot",))
+
+    assert "lm_eval/dclm_core/bb_qa_wikidata_10shot/raw_score" not in centered
+    assert centered["lm_eval/dclm_core/task_count"] == 0.0
+    assert centered["lm_eval/dclm_core/missing_task_count"] == 1.0


### PR DESCRIPTION
Add a DCLM Core v2 task inventory and centered-accuracy scoring helper. The launchable task export excludes Winograd, Jeopardy, and BigBench generation tasks until their custom data or filtered-generation metric support is safe, while scoring still handles filtered BigBench metrics and rejects unfiltered exact-match values.
