### PR TITLE
Add Dolma3 Mix 6T pretraining dataset

### DIFF
--- a/experiments/pretraining_datasets/simple.py
+++ b/experiments/pretraining_datasets/simple.py
@@ -97,6 +97,15 @@ def _build_downloads() -> dict[str, ExecutorStep | InputName]:
                 append_sha_to_path=True,
             ).cd("15d04ee")
         ),
+        "dolma3_mix_6t": (
+            _dl(
+                "raw/dolma3_mix-6T",
+                "allenai/dolma3_mix-6T",
+                "689a3ea",
+                "raw/dolma3_mix-6T-689a3ea",
+                append_sha_to_path=True,
+            ).cd("689a3ea")
+        ),
         "dclm_baseline_wrong": _dl(
             "raw/dclm-baseline-1.0", "mlfoundations/dclm-baseline-1.0", "a3b142c", "raw/dclm_WRONG_20250211/"
         ),
@@ -154,5 +163,11 @@ tokenized = {
         downloads["dolma3_mix_150b_1025"],
         tokenizer=llama3_tokenizer,
         override_path="tokenized/dolma3_mix-150B-1025-15d04ee/",
+    ),
+    "dolma3_mix_6t": _tokenize_simple(
+        "dolma3_mix-6T",
+        downloads["dolma3_mix_6t"],
+        tokenizer=llama3_tokenizer,
+        override_path="tokenized/dolma3_mix-6T-689a3ea/",
     ),
 }


### PR DESCRIPTION
Registers AllenAI's Dolma3 Mix 6T corpus as an opt-in pretraining dataset in `experiments/pretraining_datasets/simple.py`.

The new entry follows the existing Dolma3 150B sample wiring: it pins the Hugging Face dataset to revision `689a3ea`, downloads through `download_hf_step(..., append_sha_to_path=True)`, and exposes a Llama 3 tokenizer step rooted at `tokenized/dolma3_mix-6T-689a3ea/`.

This keeps the full 6T corpus available for deliberate base-pretraining and scaling-law experiments without changing default mixtures, adding Datakit source-registry entries, or launching materialization of the 4.4 TB dataset.
