### PR TITLE
[datakit] Add AutoMathText-V2 math_web and reasoning_qa sources

### DIFF
--- a/lib/marin/src/marin/datakit/download/automathtext_v2.py
+++ b/lib/marin/src/marin/datakit/download/automathtext_v2.py
@@ -1,0 +1,66 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""AutoMathText-V2 math and reasoning midtraining sources."""
+
+from dataclasses import dataclass
+from functools import cache
+
+from marin.datakit.download.hf_simple_util import hf_normalize_steps
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "OpenSQZ/AutoMathText-V2"
+HF_REVISION = "2a8d19c8edff7eeab35ffaa36f7845e86e2b3417"
+HF_REVISION_SHORT = HF_REVISION[:7]
+
+
+@dataclass(frozen=True)
+class AutoMathTextV2Subset:
+    """One AutoMathText-V2 domain exposed as a separate Datakit source."""
+
+    marin_name: str
+    hf_urls_glob: tuple[str, ...]
+    data_subdir: str
+    rough_token_count_b: float
+
+
+AUTOMATHTEXT_V2_SUBSETS: dict[str, AutoMathTextV2Subset] = {
+    "math_web": AutoMathTextV2Subset(
+        marin_name="automathtext_v2/math_web",
+        hf_urls_glob=("math_web/*/*.parquet",),
+        data_subdir="math_web",
+        rough_token_count_b=68.3,
+    ),
+    "reasoning_qa": AutoMathTextV2Subset(
+        marin_name="automathtext_v2/reasoning_qa",
+        hf_urls_glob=("reasoning_qa/*/*.parquet",),
+        data_subdir="reasoning_qa",
+        rough_token_count_b=86.2,
+    ),
+}
+# The globs intentionally select every quality-percentile shard under each
+# domain. Keep aggregate ``automathtext-v2-*`` configs and per-percentile splits
+# out of this first registration.
+
+AUTOMATHTEXT_V2_ROUGH_TOKENS_B = {
+    subset.marin_name: subset.rough_token_count_b for subset in AUTOMATHTEXT_V2_SUBSETS.values()
+}
+
+
+@cache
+def automathtext_v2_normalize_steps() -> dict[str, tuple[StepSpec, ...]]:
+    """Return independent ``(download, normalize)`` chains for selected domains."""
+    return {
+        subset.marin_name: hf_normalize_steps(
+            marin_name=subset.marin_name,
+            hf_dataset_id=HF_DATASET_ID,
+            revision=HF_REVISION,
+            staged_path=f"raw/automathtext_v2/{subset_name}-{HF_REVISION_SHORT}",
+            hf_urls_glob=subset.hf_urls_glob,
+            data_subdir=subset.data_subdir,
+            id_field="id",
+            text_field="text",
+            file_extensions=(".parquet",),
+        )
+        for subset_name, subset in AUTOMATHTEXT_V2_SUBSETS.items()
+    }

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -18,6 +18,10 @@ from dataclasses import dataclass
 from functools import cache
 
 from marin.datakit.canonical.safety_pretraining import safety_pretraining_normalize_steps
+from marin.datakit.download.automathtext_v2 import (
+    AUTOMATHTEXT_V2_ROUGH_TOKENS_B,
+    automathtext_v2_normalize_steps,
+)
 from marin.datakit.download.biodiversity import biodiversity_normalize_steps
 from marin.datakit.download.climblab_ja import climblab_ja_normalize_steps
 from marin.datakit.download.coderforge import coderforge_normalize_steps
@@ -158,6 +162,14 @@ def all_sources() -> dict[str, DatakitSource]:
         ("swe-rebench-openhands", swe_rebench_openhands_normalize_steps, 2.47),
         ("swe-zero-12m", swe_zero_12m_normalize_steps, 106.91),
         ("synthetic-1", synthetic1_normalize_steps, 7.32),
+    )
+
+    # AutoMathText-V2: keep the math/science web and reasoning-QA domains as
+    # separate mixture components. Do not register the aggregate quality buckets
+    # here; they include domains outside the selected math/reasoning slice.
+    automathtext_v2 = _rows_flat(
+        automathtext_v2_normalize_steps,
+        AUTOMATHTEXT_V2_ROUGH_TOKENS_B,
     )
 
     # StarCoder2-Extras: 5 of 6 subsets advertised (ir_low_resource isn't in
@@ -342,6 +354,7 @@ def all_sources() -> dict[str, DatakitSource]:
 
     all_rows: tuple[_SourceRow, ...] = (
         *single_sources,
+        *automathtext_v2,
         *starcoder2_extras,
         *common_pile,
         *finepdfs,

--- a/tests/datakit/download/test_automathtext_v2.py
+++ b/tests/datakit/download/test_automathtext_v2.py
@@ -1,0 +1,32 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from marin.datakit.download.automathtext_v2 import automathtext_v2_normalize_steps
+
+EXPECTED_HF_DATASET_ID = "OpenSQZ/AutoMathText-V2"
+EXPECTED_HF_REVISION = "2a8d19c8edff7eeab35ffaa36f7845e86e2b3417"
+
+EXPECTED_SOURCES: dict[str, tuple[str, tuple[str, ...], str]] = {
+    "automathtext_v2/math_web": ("math_web", ("math_web/*/*.parquet",), "math_web"),
+    "automathtext_v2/reasoning_qa": ("reasoning_qa", ("reasoning_qa/*/*.parquet",), "reasoning_qa"),
+}
+
+
+def test_automathtext_v2_steps_download_only_selected_domains():
+    steps_by_name = automathtext_v2_normalize_steps()
+
+    assert set(steps_by_name) == set(EXPECTED_SOURCES)
+
+    for marin_name, (subset_name, hf_urls_glob, data_subdir) in EXPECTED_SOURCES.items():
+        steps = steps_by_name[marin_name]
+        assert len(steps) == 2
+        download = steps[0]
+        normalized = steps[1]
+
+        assert download.override_output_path == f"raw/automathtext_v2/{subset_name}-{EXPECTED_HF_REVISION[:7]}"
+        assert download.hash_attrs["hf_dataset_id"] == EXPECTED_HF_DATASET_ID
+        assert download.hash_attrs["revision"] == EXPECTED_HF_REVISION
+        assert download.hash_attrs["hf_urls_glob"] == list(hf_urls_glob)
+        assert normalized.name == f"normalized/{marin_name}"
+        assert normalized.deps == [download]
+        assert normalized.hash_attrs["relative_input_path"] == data_subdir


### PR DESCRIPTION
Add AutoMathText-V2 math_web and reasoning_qa to the Datakit source catalog as separate mixture components for midtraining. The new downloader module pins the Hugging Face revision, downloads only the selected domain parquet shards, and normalizes each domain from its own subdirectory so math web text and QA-shaped reasoning text can be capped or ablated independently.

Register the sources under automathtext_v2/math_web and automathtext_v2/reasoning_qa with upstream-reported rough token counts. The implementation intentionally skips the aggregate automathtext-v2-* quality buckets and per-percentile source expansion because those would mix unrelated domains or add registry noise before the first ablations.

Add a focused Datakit test for the materialization contract: selected source keys, pinned Hugging Face repo and revision, scoped globs, distinct staging paths, and matching normalize subdirectories.