### PR TITLE
[datakit] Add Olympiad Books midtraining source

### DIFF
--- a/experiments/midtraining_datasets.py
+++ b/experiments/midtraining_datasets.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from marin.datakit.download.huggingface import DownloadConfig, download_hf
+from marin.datakit.download.olympiad_books_open_source import olympiad_books_open_source_normalize_steps
 from marin.execution import versioned
 from marin.execution.types import ExecutorStep, this_output_path
 from marin.processing.tokenize import lm_mixture_data_config
@@ -51,6 +52,14 @@ stackv2_edu_filtered_python = ExecutorStep(
 stackv2_edu_filtered_python_tokenized = default_tokenize(
     name="common_pile_stackv2_edu_filtered_python",
     dataset=stackv2_edu_filtered_python,
+    tokenizer=llama3_tokenizer,
+)
+
+_olympiad_books_open_source_normalized = olympiad_books_open_source_normalize_steps()[-1].as_executor_step()
+
+olympiad_books_open_source_cc_by_sa_reviewed_tokenized = default_tokenize(
+    name="olympiad_books_open_source_cc_by_sa_reviewed",
+    dataset=_olympiad_books_open_source_normalized,
     tokenizer=llama3_tokenizer,
 )
 

--- a/lib/marin/src/marin/datakit/download/olympiad_books_open_source.py
+++ b/lib/marin/src/marin/datakit/download/olympiad_books_open_source.py
@@ -1,0 +1,222 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""yoonholee/olympiad-books-open-source download + cleanup helpers.
+
+The upstream dataset is a small chunked collection of math textbooks. This
+source keeps the CC BY / CC BY-SA reviewed book subset, repairs the observed
+row-local duplicated-half artifact, removes exact duplicate text after cleanup,
+and emits Dolma-shaped document rows for Datakit normalization.
+"""
+
+from __future__ import annotations
+
+import hashlib
+from typing import Any
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+from rigging.filesystem import url_to_fs
+from zephyr import counters
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "yoonholee/olympiad-books-open-source"
+HF_REVISION = "016c098"
+TRAIN_PARQUET_GLOB = "data/train-00000-of-00001.parquet"
+OLYMPIAD_BOOKS_OPEN_SOURCE_CC_BY_SA_REVIEWED_ROUGH_TOKENS_B = 0.002
+
+PROCESSED_NAME = "processed/olympiad-books-open-source/cc-by-sa-reviewed"
+NORMALIZED_NAME = "normalized/olympiad-books-open-source/cc-by-sa-reviewed"
+
+BOOK_LICENSES = {
+    "napkin": "CC BY-SA 4.0 text; GPL v3 source files",
+    "mathematical-reasoning": "CC BY-NC-SA 3.0",
+    "exploring-combinatorial-math": "GFDL",
+    "discrete-mathematics": "CC BY-SA 4.0",
+    "aata": "GFDL",
+    "applied-combinatorics": "CC BY-SA 4.0",
+    "bogart": "GFDL",
+    "fcla": "GFDL",
+    "ent": "Free under Springer agreement",
+    "ra": "CC BY-NC-SA 4.0 + CC BY-SA 4.0",
+    "ibl-intro-proof": "CC BY-SA 4.0",
+    "openlogic": "CC BY 4.0",
+}
+
+CC_BY_SA_REVIEWED_BOOK_KEYS = frozenset(
+    {
+        "napkin",
+        "discrete-mathematics",
+        "applied-combinatorics",
+        "ibl-intro-proof",
+        "openlogic",
+    }
+)
+
+REPEATED_HALF_SEARCH_RADIUS = 8
+
+
+def _clean_required_text(row: dict, key: str) -> str | None:
+    value = row.get(key)
+    if not isinstance(value, str):
+        return None
+
+    text = value.strip()
+    if not text:
+        return None
+
+    return text
+
+
+def _optional_text(row: dict, key: str) -> str:
+    value = row.get(key)
+    if not isinstance(value, str):
+        return ""
+
+    return value.strip()
+
+
+def _optional_int(row: dict, key: str) -> int | None:
+    value = row.get(key)
+    if isinstance(value, bool) or value is None:
+        return None
+    if isinstance(value, int):
+        return value
+
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return None
+
+
+def _normalized_text_for_hash(text: str) -> str:
+    return " ".join(text.split())
+
+
+def _text_hash(text: str) -> str:
+    return hashlib.sha256(_normalized_text_for_hash(text).encode("utf-8")).hexdigest()
+
+
+def _collapse_repeated_half(text: str) -> tuple[str, bool]:
+    stripped = text.strip()
+    midpoint = len(stripped) // 2
+    for delta in range(-REPEATED_HALF_SEARCH_RADIUS, REPEATED_HALF_SEARCH_RADIUS + 1):
+        split = midpoint + delta
+        if split <= 0 or split >= len(stripped):
+            continue
+
+        left = stripped[:split].strip()
+        right = stripped[split:].strip()
+        if not left:
+            continue
+        if _normalized_text_for_hash(left) == _normalized_text_for_hash(right):
+            return left, True
+
+    return stripped, False
+
+
+def row_to_doc(row: dict[str, Any]) -> list[dict[str, Any]]:
+    text = _clean_required_text(row, "text")
+    if text is None:
+        counters.increment("olympiad_books_open_source/dropped_empty")
+        return []
+
+    book_key = _optional_text(row, "book_key")
+    if book_key not in BOOK_LICENSES:
+        counters.increment("olympiad_books_open_source/dropped_unknown_book")
+        return []
+
+    if book_key not in CC_BY_SA_REVIEWED_BOOK_KEYS:
+        counters.increment("olympiad_books_open_source/dropped_license")
+        return []
+
+    text, collapsed = _collapse_repeated_half(text)
+    if collapsed:
+        counters.increment("olympiad_books_open_source/collapsed_repeated_half")
+
+    text_hash = _text_hash(text)
+    source_file = _optional_text(row, "source_file")
+    chunk_id = _optional_int(row, "chunk_id")
+    doc_id = hashlib.sha256(f"{book_key}:{source_file}:{chunk_id}:{text_hash}".encode()).hexdigest()
+
+    return [
+        {
+            "id": doc_id,
+            "text": text,
+            "source": HF_DATASET_ID,
+            "source_revision": HF_REVISION,
+            "book": _optional_text(row, "book"),
+            "book_key": book_key,
+            "book_license": BOOK_LICENSES[book_key],
+            "license_view": "cc-by-sa-reviewed",
+            "subject": _optional_text(row, "subject"),
+            "level": _optional_text(row, "level"),
+            "part": _optional_text(row, "part"),
+            "chapter": _optional_text(row, "chapter"),
+            "section": _optional_text(row, "section"),
+            "source_file": source_file,
+            "chunk_id": chunk_id,
+            "tokens_est": _optional_int(row, "tokens_est"),
+            "text_hash": text_hash,
+        }
+    ]
+
+
+def transform(input_path: str, output_path: str) -> None:
+    input_fs, input_base = url_to_fs(input_path)
+    parquet_paths = sorted(input_fs.glob(f"{input_base}/data/*.parquet"))
+
+    seen_text_hashes: set[str] = set()
+    docs: list[dict[str, Any]] = []
+    for parquet_path in parquet_paths:
+        with input_fs.open(parquet_path, "rb") as input_file:
+            for row in pq.read_table(input_file).to_pylist():
+                for doc in row_to_doc(row):
+                    text_hash = doc["text_hash"]
+                    if text_hash in seen_text_hashes:
+                        counters.increment("olympiad_books_open_source/dropped_exact_duplicate")
+                        continue
+                    seen_text_hashes.add(text_hash)
+                    counters.increment("olympiad_books_open_source/kept")
+                    docs.append(doc)
+
+    output_fs, output_base = url_to_fs(output_path)
+    output_fs.makedirs(output_base, exist_ok=True)
+    with output_fs.open(f"{output_base}/data-00000-of-00001.parquet", "wb") as output_file:
+        pq.write_table(pa.Table.from_pylist(docs), output_file)
+
+
+def download_olympiad_books_open_source_step() -> StepSpec:
+    """Download and transform the reviewed Olympiad Books subset into documents."""
+    dl = download_hf_step(
+        "raw/olympiad-books-open-source",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[TRAIN_PARQUET_GLOB],
+        override_output_path=f"raw/olympiad-books-open-source-{HF_REVISION}",
+    )
+
+    return StepSpec(
+        name=PROCESSED_NAME,
+        deps=[dl],
+        fn=lambda output_path: transform(input_path=dl.output_path, output_path=output_path),
+        hash_attrs={
+            "version": "v1",
+            "license_view": "cc-by-sa-reviewed",
+            "book_keys": sorted(CC_BY_SA_REVIEWED_BOOK_KEYS),
+            "drop_exact_duplicates": True,
+            "collapse_repeated_half_rows": True,
+        },
+    )
+
+
+def olympiad_books_open_source_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the ``(download+transform, normalize)`` chain for Olympiad Books."""
+    processed = download_olympiad_books_open_source_step()
+    return (
+        processed,
+        normalize_step(name=NORMALIZED_NAME, download=processed),
+    )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -39,6 +39,10 @@ from marin.datakit.download.nemotron_v2 import nemotron_v2_normalize_steps
 from marin.datakit.download.nsf_awards import nsf_awards_normalize_steps
 from marin.datakit.download.numinamath_tir import numinamath_tir_normalize_steps
 from marin.datakit.download.numinamath_v1_5 import numinamath_v1_5_normalize_steps
+from marin.datakit.download.olympiad_books_open_source import (
+    OLYMPIAD_BOOKS_OPEN_SOURCE_CC_BY_SA_REVIEWED_ROUGH_TOKENS_B,
+    olympiad_books_open_source_normalize_steps,
+)
 from marin.datakit.download.starcoder2_extras import starcoder2_extras_normalize_steps
 from marin.datakit.download.superior_reasoning import superior_reasoning_normalize_steps
 from marin.datakit.download.svgfind import svgfind_creativecommons_normalize_steps
@@ -153,6 +157,11 @@ def all_sources() -> dict[str, DatakitSource]:
         ("nsf_awards", nsf_awards_normalize_steps, 0.17),
         ("numinamath-1.5", numinamath_v1_5_normalize_steps, 0.40),
         ("numinamath-tir", numinamath_tir_normalize_steps, 0.08),
+        (
+            "olympiad-books-open-source/cc-by-sa-reviewed",
+            olympiad_books_open_source_normalize_steps,
+            OLYMPIAD_BOOKS_OPEN_SOURCE_CC_BY_SA_REVIEWED_ROUGH_TOKENS_B,
+        ),
         ("superior-reasoning", superior_reasoning_normalize_steps, 7.08),
         ("svg", svgfind_creativecommons_normalize_steps, 8.95),
         ("swe-rebench-openhands", swe_rebench_openhands_normalize_steps, 2.47),

--- a/tests/datakit/download/test_olympiad_books_open_source.py
+++ b/tests/datakit/download/test_olympiad_books_open_source.py
@@ -1,0 +1,146 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from pathlib import Path
+
+import pyarrow as pa
+import pyarrow.parquet as pq
+import pytest
+from marin.datakit.download.olympiad_books_open_source import (
+    olympiad_books_open_source_normalize_steps,
+    row_to_doc,
+    transform,
+)
+
+
+def _valid_row(**overrides) -> dict:
+    row = {
+        "text": "Let $n$ be an integer. If $n$ is even, then $n^2$ is even.",
+        "book": "Open Logic",
+        "book_key": "openlogic",
+        "subject": "logic",
+        "level": "intro",
+        "part": "Proofs",
+        "chapter": "Direct proofs",
+        "section": "Parity",
+        "source_file": "proofs/parity.md",
+        "chunk_id": 7,
+        "tokens_est": 17,
+    }
+    row.update(overrides)
+    return row
+
+
+def test_row_to_doc_preserves_textbook_metadata():
+    [doc] = row_to_doc(_valid_row())
+
+    assert doc["source"] == "yoonholee/olympiad-books-open-source"
+    assert doc["source_revision"] == "016c098"
+    assert doc["text"] == "Let $n$ be an integer. If $n$ is even, then $n^2$ is even."
+    assert doc["book"] == "Open Logic"
+    assert doc["book_key"] == "openlogic"
+    assert doc["book_license"] == "CC BY 4.0"
+    assert doc["license_view"] == "cc-by-sa-reviewed"
+    assert doc["subject"] == "logic"
+    assert doc["level"] == "intro"
+    assert doc["part"] == "Proofs"
+    assert doc["chapter"] == "Direct proofs"
+    assert doc["section"] == "Parity"
+    assert doc["source_file"] == "proofs/parity.md"
+    assert doc["chunk_id"] == 7
+    assert doc["tokens_est"] == 17
+    assert len(doc["id"]) == 64
+    assert len(doc["text_hash"]) == 64
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"text": ""},
+        {"text": "   "},
+        {"text": None},
+    ],
+)
+def test_row_to_doc_drops_empty_text(overrides):
+    assert row_to_doc(_valid_row(**overrides)) == []
+
+
+def test_row_to_doc_drops_unknown_book_key():
+    assert row_to_doc(_valid_row(book_key="unknown-book")) == []
+
+
+@pytest.mark.parametrize(
+    "book_key",
+    [
+        "mathematical-reasoning",
+        "exploring-combinatorial-math",
+        "aata",
+        "bogart",
+        "fcla",
+        "ent",
+        "ra",
+    ],
+)
+def test_row_to_doc_drops_books_outside_reviewed_license_view(book_key):
+    assert row_to_doc(_valid_row(book_key=book_key)) == []
+
+
+def test_row_to_doc_collapses_repeated_half_text():
+    [doc] = row_to_doc(
+        _valid_row(
+            text=("A group homomorphism preserves multiplication.\n\n" "A group homomorphism preserves multiplication.")
+        )
+    )
+
+    assert doc["text"] == "A group homomorphism preserves multiplication."
+
+
+def test_olympiad_books_open_source_normalize_steps_use_pinned_train_file():
+    processed, normalized = olympiad_books_open_source_normalize_steps()
+    download = processed.deps[0]
+
+    assert download.name == "raw/olympiad-books-open-source"
+    assert download.override_output_path == "raw/olympiad-books-open-source-016c098"
+    assert download.hash_attrs["hf_dataset_id"] == "yoonholee/olympiad-books-open-source"
+    assert download.hash_attrs["revision"] == "016c098"
+    assert download.hash_attrs["hf_urls_glob"] == ["data/train-00000-of-00001.parquet"]
+    assert processed.name == "processed/olympiad-books-open-source/cc-by-sa-reviewed"
+    assert processed.deps == [download]
+    assert processed.hash_attrs["license_view"] == "cc-by-sa-reviewed"
+    assert processed.hash_attrs["drop_exact_duplicates"] is True
+    assert processed.hash_attrs["collapse_repeated_half_rows"] is True
+    assert normalized.name == "normalized/olympiad-books-open-source/cc-by-sa-reviewed"
+    assert normalized.deps == [processed]
+
+
+def test_transform_writes_cleaned_reviewed_license_docs(tmp_path: Path):
+    raw_dir = tmp_path / "raw" / "data"
+    raw_dir.mkdir(parents=True)
+    table = pa.Table.from_pylist(
+        [
+            _valid_row(text="Unique proof text.", source_file="a.md", chunk_id=0),
+            _valid_row(text="Unique proof text.", source_file="a.md", chunk_id=1),
+            _valid_row(
+                text="Repeated lemma.\n\nRepeated lemma.",
+                source_file="b.md",
+                chunk_id=0,
+            ),
+            _valid_row(
+                text="Excluded license text.",
+                book_key="aata",
+                source_file="c.md",
+                chunk_id=0,
+            ),
+            _valid_row(text="   ", source_file="d.md", chunk_id=0),
+        ]
+    )
+    pq.write_table(table, raw_dir / "train-00000-of-00001.parquet")
+
+    output_dir = tmp_path / "processed"
+    transform(str(tmp_path / "raw"), str(output_dir))
+
+    rows = [row for path in output_dir.rglob("*.parquet") for row in pq.read_table(path).to_pylist()]
+    assert [row["text"] for row in rows] == ["Unique proof text.", "Repeated lemma."]
+    assert {row["license_view"] for row in rows} == {"cc-by-sa-reviewed"}
+    assert {row["book_key"] for row in rows} == {"openlogic"}
+    assert {row["source"] for row in rows} == {"yoonholee/olympiad-books-open-source"}


### PR DESCRIPTION
Add yoonholee/olympiad-books-open-source as a bounded midtraining Datakit source for math textbook continuation data. The source pins the current train parquet revision, keeps the reviewed CC BY / CC BY-SA book subset, repairs the repeated-half chunk artifact visible in the upstream data, and removes exact duplicate text after cleanup before normalization.

Expose the normalized source through the Datakit source registry with a small rough token-count weight, and add a Llama 3 tokenized midtraining step for experiments. Add behavior-focused coverage for metadata preservation, license filtering, repeated-half repair, pinned download wiring, and parquet transform output.