### PR TITLE
[datakit] Add PlanetMath pretraining source

### DIFF
--- a/lib/marin/src/marin/datakit/download/planetmath.py
+++ b/lib/marin/src/marin/datakit/download/planetmath.py
@@ -1,0 +1,285 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""PlanetMath pretraining source.
+
+PlanetMath is a compact CC-BY-SA-4.0 encyclopedia of math articles exported on
+Hugging Face as one CSV file with HTML article bodies. The transform keeps the
+raw download intact, converts the article HTML to Markdown, preserves MathML
+``alttext`` as inline/display LaTeX, and writes one Parquet shard for Datakit
+normalization.
+"""
+
+import csv
+import hashlib
+import os
+import re
+import sys
+from collections.abc import Iterable
+from typing import Any
+
+import fsspec
+import pyarrow as pa
+from bs4 import BeautifulSoup, NavigableString, Tag
+from rigging.filesystem import url_to_fs
+from zephyr import counters
+from zephyr.writers import write_parquet_file
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+from marin.markdown import to_markdown
+from marin.schemas.web.convert import HtmlToMarkdownConfig
+from marin.utils import fsspec_url
+
+HF_DATASET_ID = "aarjaneiro/planetmath"
+HF_REVISION = "e4006c4172da7d737a7bb0b24dfd47cc87054728"
+PLANETMATH_CSV_NAME = "planet_math.csv"
+PLANETMATH_ROUGH_TOKENS_B = 0.008
+
+MIN_CLEAN_CHARS = 200
+OUTPUT_FILE_NAME = "data-00000-of-00001.parquet"
+
+_HTML_NOISE_TAGS = frozenset({"base", "footer", "head", "script", "style", "template"})
+_MATH_PLACEHOLDER_PREFIX = "MARINPLANETMATHMATH"
+_MARKDOWN_CONFIG = HtmlToMarkdownConfig(include_images=False, include_links=False)
+_METADATA_LABELS = frozenset(
+    {
+        "canonical name",
+        "classification",
+        "date of creation",
+        "entry type",
+        "owner",
+        "title",
+    }
+)
+_REQUIRED_RAW_COLUMNS = frozenset({"name", "url", "content"})
+_OUTPUT_SCHEMA = pa.schema(
+    [
+        pa.field("id", pa.string()),
+        pa.field("text", pa.string()),
+        pa.field("source", pa.string()),
+        pa.field("planetmath_name", pa.string()),
+        pa.field("source_url", pa.string()),
+    ]
+)
+
+
+def _is_display_math(math_element: Tag) -> bool:
+    display = str(math_element.get("display", "")).lower()
+    if display == "block":
+        return True
+
+    parent = math_element.parent
+    while isinstance(parent, Tag):
+        class_attr = parent.get("class")
+        if isinstance(class_attr, str):
+            classes = (class_attr,)
+        elif isinstance(class_attr, list):
+            classes = tuple(str(class_name) for class_name in class_attr)
+        else:
+            classes = ()
+        if any(class_name.startswith("ltx_equation") for class_name in classes):
+            return True
+        parent = parent.parent
+
+    return False
+
+
+def _replace_math_alttext(root: BeautifulSoup | Tag) -> dict[str, str]:
+    """Replace MathML nodes with placeholders and return exact Markdown math replacements."""
+    replacements: dict[str, str] = {}
+    for math_element in root.find_all("math"):
+        alttext = math_element.get("alttext")
+        if not isinstance(alttext, str) or not alttext.strip():
+            continue
+
+        latex = alttext.strip()
+        if _is_display_math(math_element):
+            replacement = f"\n\n$${latex}$$\n\n"
+        else:
+            replacement = f"${latex}$"
+        placeholder = f"{_MATH_PLACEHOLDER_PREFIX}{len(replacements):08d}"
+        replacements[placeholder] = replacement
+        math_element.replace_with(NavigableString(placeholder))
+
+    return replacements
+
+
+def _remove_noise(root: BeautifulSoup | Tag) -> None:
+    for tag_name in _HTML_NOISE_TAGS:
+        for tag in root.find_all(tag_name):
+            tag.decompose()
+
+    for image in root.find_all("img"):
+        src = image.get("src")
+        if isinstance(src, str) and src.lower().startswith("data:"):
+            image.decompose()
+
+    for element in root.select("[style]"):
+        style = str(element.get("style", "")).lower().replace(" ", "")
+        if "display:none" in style or "visibility:hidden" in style:
+            element.decompose()
+
+
+def _metadata_labels(table: Tag) -> set[str]:
+    labels: set[str] = set()
+    for cell in table.find_all(["th", "td"]):
+        text = re.sub(r"\s+", " ", cell.get_text(" ", strip=True)).strip().lower()
+        if text:
+            labels.add(text)
+    return labels
+
+
+def _is_metadata_table(table: Tag) -> bool:
+    labels = _metadata_labels(table)
+    return len(labels & _METADATA_LABELS) >= 3 and bool({"canonical name", "entry type"} & labels)
+
+
+def _remove_metadata_tables(root: BeautifulSoup | Tag) -> None:
+    for table in root.find_all("table"):
+        if _is_metadata_table(table):
+            table.decompose()
+
+
+def _content_root(soup: BeautifulSoup) -> BeautifulSoup | Tag:
+    article = soup.select_one("article.ltx_document")
+    if article is not None:
+        return article
+
+    fallback_article = soup.find("article")
+    if isinstance(fallback_article, Tag):
+        return fallback_article
+
+    if soup.body is not None:
+        return soup.body
+
+    return soup
+
+
+def _normalize_markdown(text: str) -> str:
+    text = text.replace("\xa0", " ")
+    text = re.sub(r"[ \t]+\n", "\n", text)
+    text = re.sub(r"\n{3,}", "\n\n", text)
+    return text.strip()
+
+
+def clean_planetmath_html(html: str) -> str:
+    """Convert one PlanetMath HTML article to Markdown text."""
+    soup = BeautifulSoup(html, "html.parser")
+    _remove_noise(soup)
+    math_replacements = _replace_math_alttext(soup)
+
+    root = _content_root(soup)
+    _remove_metadata_tables(root)
+    text = to_markdown(root, _MARKDOWN_CONFIG)
+    for placeholder, replacement in math_replacements.items():
+        text = text.replace(placeholder, replacement)
+    return _normalize_markdown(text)
+
+
+def _required_text(row: dict[str, Any], key: str) -> str | None:
+    value = row.get(key)
+    if not isinstance(value, str):
+        return None
+
+    text = value.strip()
+    if not text:
+        return None
+
+    return text
+
+
+def row_to_doc(row: dict[str, Any]) -> list[dict[str, Any]]:
+    """Convert one raw PlanetMath CSV row into zero or one Datakit document."""
+    counters.increment("planetmath/rows_total")
+
+    name = _required_text(row, "name")
+    source_url = _required_text(row, "url")
+    content = _required_text(row, "content")
+    if name is None or source_url is None or content is None:
+        counters.increment("planetmath/dropped_missing_field")
+        return []
+
+    text = clean_planetmath_html(content)
+    if not text:
+        counters.increment("planetmath/dropped_empty_after_clean")
+        return []
+
+    if len(text) < MIN_CLEAN_CHARS:
+        counters.increment("planetmath/dropped_short_after_clean")
+        return []
+
+    counters.increment("planetmath/rows_kept")
+    return [
+        {
+            "id": hashlib.sha256(source_url.encode("utf-8")).hexdigest(),
+            "text": text,
+            "source": HF_DATASET_ID,
+            "planetmath_name": name,
+            "source_url": source_url,
+        }
+    ]
+
+
+def _find_planetmath_csv(input_path: str) -> str:
+    fs, root = url_to_fs(input_path)
+    matches: list[str] = []
+
+    for walk_root, _dirs, files in fs.walk(root):
+        for filename in files:
+            if filename == PLANETMATH_CSV_NAME:
+                matches.append(fsspec_url(fs, os.path.join(walk_root, filename)))
+
+    matches.sort()
+    if len(matches) != 1:
+        raise ValueError(f"Expected exactly one {PLANETMATH_CSV_NAME!r} under {input_path}, found {len(matches)}")
+
+    return matches[0]
+
+
+def _records_from_csv(csv_path: str) -> Iterable[dict[str, Any]]:
+    csv.field_size_limit(sys.maxsize)
+
+    with fsspec.open(csv_path, "rt", encoding="utf-8", newline="") as text_file:
+        reader = csv.DictReader(text_file)
+        missing = _REQUIRED_RAW_COLUMNS - set(reader.fieldnames or [])
+        if missing:
+            missing_columns = ", ".join(sorted(missing))
+            raise ValueError(f"PlanetMath CSV {csv_path} is missing required columns: {missing_columns}")
+
+        for row in reader:
+            yield from row_to_doc(row)
+
+
+def transform(input_path: str, output_path: str) -> dict:
+    """Clean the downloaded PlanetMath CSV and write one Parquet file."""
+    csv_path = _find_planetmath_csv(input_path)
+    output_file = os.path.join(output_path, OUTPUT_FILE_NAME)
+    return write_parquet_file(_records_from_csv(csv_path), output_file, schema=_OUTPUT_SCHEMA)
+
+
+def download_planetmath_step() -> StepSpec:
+    """Create the raw-download plus CSV-cleaning StepSpec for PlanetMath."""
+    raw = download_hf_step(
+        "raw/planetmath",
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[PLANETMATH_CSV_NAME],
+    )
+
+    return StepSpec(
+        name="processed/planetmath",
+        deps=[raw],
+        fn=lambda output_path: transform(raw.output_path, output_path),
+        hash_attrs={"version": "v1"},
+    )
+
+
+def planetmath_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the full ``(download+transform, normalize)`` chain for PlanetMath."""
+    processed = download_planetmath_step()
+    return (
+        processed,
+        normalize_step(name="normalized/planetmath", download=processed, file_extensions=(".parquet",)),
+    )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -39,6 +39,7 @@ from marin.datakit.download.nemotron_v2 import nemotron_v2_normalize_steps
 from marin.datakit.download.nsf_awards import nsf_awards_normalize_steps
 from marin.datakit.download.numinamath_tir import numinamath_tir_normalize_steps
 from marin.datakit.download.numinamath_v1_5 import numinamath_v1_5_normalize_steps
+from marin.datakit.download.planetmath import PLANETMATH_ROUGH_TOKENS_B, planetmath_normalize_steps
 from marin.datakit.download.starcoder2_extras import starcoder2_extras_normalize_steps
 from marin.datakit.download.superior_reasoning import superior_reasoning_normalize_steps
 from marin.datakit.download.svgfind import svgfind_creativecommons_normalize_steps
@@ -153,6 +154,7 @@ def all_sources() -> dict[str, DatakitSource]:
         ("nsf_awards", nsf_awards_normalize_steps, 0.17),
         ("numinamath-1.5", numinamath_v1_5_normalize_steps, 0.40),
         ("numinamath-tir", numinamath_tir_normalize_steps, 0.08),
+        ("planetmath", planetmath_normalize_steps, PLANETMATH_ROUGH_TOKENS_B),
         ("superior-reasoning", superior_reasoning_normalize_steps, 7.08),
         ("svg", svgfind_creativecommons_normalize_steps, 8.95),
         ("swe-rebench-openhands", swe_rebench_openhands_normalize_steps, 2.47),

--- a/tests/datakit/download/test_planetmath.py
+++ b/tests/datakit/download/test_planetmath.py
@@ -1,0 +1,188 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import csv
+import hashlib
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+from marin.datakit.download.planetmath import (
+    HF_DATASET_ID,
+    HF_REVISION,
+    PLANETMATH_CSV_NAME,
+    clean_planetmath_html,
+    planetmath_normalize_steps,
+    row_to_doc,
+    transform,
+)
+
+
+def _long_sentence() -> str:
+    return (
+        "This PlanetMath article explains a mathematical construction with definitions, "
+        "examples, relationships to neighboring concepts, and enough expository detail "
+        "to represent the source as useful pretraining text."
+    )
+
+
+def _article_html(body: str | None = None) -> str:
+    text = body or " ".join([_long_sentence()] * 3)
+    return f"""
+    <html>
+      <head>
+        <style>.hidden {{ display: none; }}</style>
+        <script>window.noisy = true;</script>
+      </head>
+      <body>
+        <article class="ltx_document">
+          <table>
+            <tr><th>Title</th><td>Ring</td></tr>
+            <tr><th>Canonical name</th><td>Ring</td></tr>
+            <tr><th>Entry type</th><td>Definition</td></tr>
+          </table>
+          <p>
+            Let <math alttext="x_1^2 + y_2"><mi>x</mi></math> be the motivating polynomial.
+            <sup style="display: none;">hidden concept expansion</sup>
+          </p>
+          <div class="ltx_equation">
+            <math alttext="\\sum_{{i=1}}^n i = \\frac{{n(n+1)}}{{2}}">
+              <mi>x</mi>
+            </math>
+          </div>
+          <p>{text}</p>
+          <p><a href="https://planetmath.org/ring">visible reference</a></p>
+          <img src="data:image/png;base64,abc" alt="encoded image">
+        </article>
+        <footer>download boilerplate footer</footer>
+      </body>
+    </html>
+    """
+
+
+def _row(**overrides) -> dict:
+    row = {
+        "Unnamed: 0": "0",
+        "name": "Ring",
+        "url": "https://planetmath.org/ring",
+        "content": _article_html(),
+    }
+    row.update(overrides)
+    return row
+
+
+def _write_csv(path: Path, rows: list[dict]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as file:
+        writer = csv.DictWriter(file, fieldnames=["Unnamed: 0", "name", "url", "content"])
+        writer.writeheader()
+        writer.writerows(rows)
+
+
+def test_clean_planetmath_html_preserves_math_and_removes_boilerplate():
+    text = clean_planetmath_html(_article_html())
+
+    assert "$x_1^2 + y_2$" in text
+    assert "$$\\sum_{i=1}^n i = \\frac{n(n+1)}{2}$$" in text
+    assert "This PlanetMath article explains" in text
+    assert "visible reference" in text
+    assert "https://planetmath.org/ring" not in text
+    assert "Canonical name" not in text
+    assert "Entry type" not in text
+    assert "hidden concept expansion" not in text
+    assert "encoded image" not in text
+    assert "download boilerplate footer" not in text
+    assert "window.noisy" not in text
+
+
+def test_row_to_doc_preserves_stable_provenance_fields():
+    [doc] = row_to_doc(_row())
+
+    assert doc["id"] == hashlib.sha256(b"https://planetmath.org/ring").hexdigest()
+    assert doc["source"] == HF_DATASET_ID
+    assert doc["planetmath_name"] == "Ring"
+    assert doc["source_url"] == "https://planetmath.org/ring"
+    assert "$x_1^2 + y_2$" in doc["text"]
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"name": ""},
+        {"name": "   "},
+        {"name": None},
+        {"url": ""},
+        {"url": "   "},
+        {"url": None},
+        {"content": ""},
+        {"content": "   "},
+        {"content": None},
+        {"content": "<article>short after cleaning</article>"},
+    ],
+)
+def test_row_to_doc_drops_missing_or_too_short_rows(overrides):
+    assert row_to_doc(_row(**overrides)) == []
+
+
+def test_transform_requires_exactly_one_raw_csv(tmp_path: Path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+
+    with pytest.raises(ValueError, match="Expected exactly one"):
+        transform(str(raw_dir), str(tmp_path / "processed-empty"))
+
+    first = raw_dir / PLANETMATH_CSV_NAME
+    first.write_text("name,url,content\n", encoding="utf-8")
+    nested = raw_dir / "nested"
+    nested.mkdir()
+    second = nested / PLANETMATH_CSV_NAME
+    second.write_text("name,url,content\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="Expected exactly one"):
+        transform(str(raw_dir), str(tmp_path / "processed-duplicate"))
+
+
+def test_transform_reads_raw_csv_and_writes_clean_parquet(tmp_path: Path):
+    raw_dir = tmp_path / "raw" / "planetmath"
+    raw_dir.mkdir(parents=True)
+    _write_csv(
+        raw_dir / PLANETMATH_CSV_NAME,
+        [
+            _row(),
+            _row(name="Too Short", url="https://planetmath.org/too-short", content="<article>short</article>"),
+        ],
+    )
+
+    output_dir = tmp_path / "processed"
+    result = transform(str(tmp_path / "raw"), str(output_dir))
+
+    assert result["count"] == 1
+    rows = [row for path in output_dir.rglob("*.parquet") for row in pq.read_table(path).to_pylist()]
+    assert len(rows) == 1
+    assert rows[0]["source"] == HF_DATASET_ID
+    assert rows[0]["planetmath_name"] == "Ring"
+    assert rows[0]["source_url"] == "https://planetmath.org/ring"
+    assert "Canonical name" not in rows[0]["text"]
+    assert "$x_1^2 + y_2$" in rows[0]["text"]
+
+
+def test_transform_rejects_csv_missing_required_columns(tmp_path: Path):
+    raw_dir = tmp_path / "raw"
+    raw_dir.mkdir()
+    (raw_dir / PLANETMATH_CSV_NAME).write_text("name,url\nRing,https://planetmath.org/ring\n", encoding="utf-8")
+
+    with pytest.raises(ValueError, match="missing required columns: content"):
+        transform(str(raw_dir), str(tmp_path / "processed"))
+
+
+def test_planetmath_normalize_steps_use_pinned_csv_download_and_stable_names():
+    processed, normalized = planetmath_normalize_steps()
+    download = processed.deps[0]
+
+    assert download.name == "raw/planetmath"
+    assert download.hash_attrs["hf_dataset_id"] == HF_DATASET_ID
+    assert download.hash_attrs["revision"] == HF_REVISION
+    assert download.hash_attrs["hf_urls_glob"] == [PLANETMATH_CSV_NAME]
+    assert processed.name == "processed/planetmath"
+    assert processed.deps == [download]
+    assert normalized.name == "normalized/planetmath"
+    assert normalized.deps == [processed]


### PR DESCRIPTION
Add PlanetMath as a compact pretraining Datakit source. The dataset is a CC-BY-SA math encyclopedia exported as a single Hugging Face CSV, so the source downloads the pinned CSV, cleans LaTeXML/HTML article bodies to Markdown, preserves MathML alttext as exact inline/display LaTeX, and emits provenance-rich Parquet rows for normal Datakit normalization.

The transform drops rows missing name, URL, or content; filters very short cleaned articles; removes PlanetMath metadata and boilerplate; disables link and image emission; and fails fast if the staged raw directory does not contain exactly one planet_math.csv or if required columns drift. The source is registered with a conservative rough token count for mixture planning and no default mixture inclusion.
