### PR TITLE
[datakit] Add StackMathQA full-qalist source

### DIFF
--- a/lib/marin/src/marin/datakit/download/stackmathqa.py
+++ b/lib/marin/src/marin/datakit/download/stackmathqa.py
@@ -1,0 +1,172 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""math-ai/StackMathQA download and transform.
+
+StackMathQA is a Math StackExchange-style Q&A corpus with one canonical
+``stackmathqafull-qalist`` view containing one row per question and an
+``A_list`` of answers. This transform keeps that source-native grouping and
+renders one LM document per question for math midtraining.
+"""
+
+import hashlib
+
+from fray import ResourceConfig
+from zephyr import Dataset, ZephyrContext, counters, load_jsonl
+
+from marin.datakit.download.huggingface import download_hf_step
+from marin.datakit.normalize import normalize_step
+from marin.execution.step_spec import StepSpec
+
+HF_DATASET_ID = "math-ai/StackMathQA"
+HF_REVISION = "5a3e18f6fa122652e1959c3cc3e714758778fdad"
+
+FULL_QALIST_CONFIG = "stackmathqafull-qalist"
+FULL_QALIST_GLOB = "preprocessed/stackexchange-math/*.jsonl"
+
+RAW_STEP_NAME = "raw/stackmathqa/full-qalist"
+PROCESSED_STEP_NAME = "processed/stackmathqa/full-qalist"
+NORMALIZED_STEP_NAME = "normalized/stackmathqa/full-qalist"
+
+# Provisional until the normalized source is materialized and measured with the
+# canonical Marin tokenizer.
+STACKMATHQA_FULL_QALIST_ROUGH_TOKENS_B = 0.85
+
+
+def _clean_text(value: object) -> str | None:
+    if not isinstance(value, str):
+        return None
+
+    text = value.strip()
+    if not text:
+        return None
+
+    return text
+
+
+def _optional_text(metadata: dict, key: str) -> str:
+    value = metadata.get(key)
+    if not isinstance(value, str):
+        return ""
+
+    return value.strip()
+
+
+def _optional_int(value: object) -> int | None:
+    if isinstance(value, bool):
+        return None
+
+    if isinstance(value, int):
+        return value
+
+    if not isinstance(value, str):
+        return None
+
+    text = value.strip()
+    if text.lstrip("-").isdigit():
+        return int(text)
+
+    return None
+
+
+def _hash_text(text: str) -> str:
+    return hashlib.sha256(text.encode("utf-8")).hexdigest()
+
+
+def _render_text(question: str, answers: list[str]) -> str:
+    parts = [f"<question>\n{question}\n</question>"]
+    for index, answer in enumerate(answers):
+        parts.append(f'<answer index="{index}">\n{answer}\n</answer>')
+
+    return "\n\n".join(parts)
+
+
+def _metadata(row: dict) -> dict:
+    value = row.get("meta")
+    if isinstance(value, dict):
+        return value
+
+    return {}
+
+
+def row_to_doc(row: dict) -> list[dict]:
+    question = _clean_text(row.get("Q"))
+    if question is None:
+        counters.increment("stackmathqa/full_qalist/dropped_empty_question")
+        return []
+
+    answer_values = row.get("A_list")
+    if not isinstance(answer_values, list):
+        counters.increment("stackmathqa/full_qalist/dropped_missing_answer_list")
+        return []
+
+    answers = [answer for value in answer_values if (answer := _clean_text(value)) is not None]
+    if not answers:
+        counters.increment("stackmathqa/full_qalist/dropped_empty_answer_list")
+        return []
+
+    text = _render_text(question, answers)
+    metadata = _metadata(row)
+    url = _optional_text(metadata, "url")
+    question_score_raw = _optional_text(metadata, "question_score")
+
+    counters.increment("stackmathqa/full_qalist/kept")
+    counters.increment("stackmathqa/full_qalist/answers_kept", len(answers))
+
+    return [
+        {
+            "id": _hash_text(url or text),
+            "text": text,
+            "source": HF_DATASET_ID,
+            "stackmathqa_config": FULL_QALIST_CONFIG,
+            "url": url,
+            "language": _optional_text(metadata, "language"),
+            "timestamp": _optional_text(metadata, "timestamp"),
+            "stackmathqa_source": _optional_text(metadata, "source"),
+            "question_hash": _hash_text(question),
+            "num_answers_rendered": len(answers),
+            "answer_count": _optional_int(metadata.get("answer_count")),
+            "question_score": _optional_int(metadata.get("question_score")),
+            "question_score_raw": question_score_raw,
+        }
+    ]
+
+
+def transform(input_path: str, output_path: str) -> None:
+    pipeline = (
+        Dataset.from_files(f"{input_path}/{FULL_QALIST_GLOB}")
+        .flat_map(load_jsonl)
+        .flat_map(row_to_doc)
+        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
+    )
+    ctx = ZephyrContext(name="stackmathqa-full-qalist-transform", resources=ResourceConfig(cpu=2, ram="16g"))
+    ctx.execute(pipeline)
+
+
+def download_stackmathqa_full_qalist_step() -> StepSpec:
+    """Download and transform StackMathQA full qlist rows into question-grouped documents."""
+    dl = download_hf_step(
+        RAW_STEP_NAME,
+        hf_dataset_id=HF_DATASET_ID,
+        revision=HF_REVISION,
+        hf_urls_glob=[FULL_QALIST_GLOB],
+    )
+
+    return StepSpec(
+        name=PROCESSED_STEP_NAME,
+        deps=[dl],
+        fn=lambda output_path: transform(
+            input_path=dl.output_path,
+            output_path=output_path,
+        ),
+        hash_attrs={"version": "v1", "config": FULL_QALIST_CONFIG},
+    )
+
+
+def stackmathqa_full_qalist_normalize_steps() -> tuple[StepSpec, ...]:
+    """Return the ``(download+transform, normalize)`` chain for StackMathQA qlist."""
+    processed = download_stackmathqa_full_qalist_step()
+    return (
+        processed,
+        normalize_step(name=NORMALIZED_STEP_NAME, download=processed),
+    )

--- a/lib/marin/src/marin/datakit/sources.py
+++ b/lib/marin/src/marin/datakit/sources.py
@@ -39,6 +39,10 @@ from marin.datakit.download.nemotron_v2 import nemotron_v2_normalize_steps
 from marin.datakit.download.nsf_awards import nsf_awards_normalize_steps
 from marin.datakit.download.numinamath_tir import numinamath_tir_normalize_steps
 from marin.datakit.download.numinamath_v1_5 import numinamath_v1_5_normalize_steps
+from marin.datakit.download.stackmathqa import (
+    STACKMATHQA_FULL_QALIST_ROUGH_TOKENS_B,
+    stackmathqa_full_qalist_normalize_steps,
+)
 from marin.datakit.download.starcoder2_extras import starcoder2_extras_normalize_steps
 from marin.datakit.download.superior_reasoning import superior_reasoning_normalize_steps
 from marin.datakit.download.svgfind import svgfind_creativecommons_normalize_steps
@@ -153,6 +157,11 @@ def all_sources() -> dict[str, DatakitSource]:
         ("nsf_awards", nsf_awards_normalize_steps, 0.17),
         ("numinamath-1.5", numinamath_v1_5_normalize_steps, 0.40),
         ("numinamath-tir", numinamath_tir_normalize_steps, 0.08),
+        (
+            "stackmathqa/full-qalist",
+            stackmathqa_full_qalist_normalize_steps,
+            STACKMATHQA_FULL_QALIST_ROUGH_TOKENS_B,
+        ),
         ("superior-reasoning", superior_reasoning_normalize_steps, 7.08),
         ("svg", svgfind_creativecommons_normalize_steps, 8.95),
         ("swe-rebench-openhands", swe_rebench_openhands_normalize_steps, 2.47),

--- a/tests/datakit/download/test_stackmathqa.py
+++ b/tests/datakit/download/test_stackmathqa.py
@@ -1,0 +1,142 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+
+import pyarrow.parquet as pq
+import pytest
+from marin.datakit.download.stackmathqa import (
+    FULL_QALIST_CONFIG,
+    FULL_QALIST_GLOB,
+    HF_DATASET_ID,
+    HF_REVISION,
+    NORMALIZED_STEP_NAME,
+    PROCESSED_STEP_NAME,
+    RAW_STEP_NAME,
+    row_to_doc,
+    stackmathqa_full_qalist_normalize_steps,
+    transform,
+)
+
+
+def _valid_row(**overrides) -> dict:
+    row = {
+        "Q": "How can you prove that $\\sqrt{2}$ is irrational?",
+        "A_list": [
+            "Assume $\\sqrt{2} = p / q$ in lowest terms and derive a parity contradiction.",
+            "A geometric proof also works by infinite descent.",
+        ],
+        "meta": {
+            "language": "en",
+            "url": "https://math.stackexchange.com/questions/2",
+            "timestamp": "2023-03-29T00:00:00",
+            "source": "stackexchange",
+            "question_score": "42",
+            "answer_count": 2,
+        },
+    }
+    row.update(overrides)
+    return row
+
+
+def test_row_to_doc_renders_question_with_all_valid_answers():
+    [doc] = row_to_doc(_valid_row())
+
+    assert doc["source"] == HF_DATASET_ID
+    assert doc["stackmathqa_config"] == FULL_QALIST_CONFIG
+    assert doc["url"] == "https://math.stackexchange.com/questions/2"
+    assert doc["language"] == "en"
+    assert doc["timestamp"] == "2023-03-29T00:00:00"
+    assert doc["stackmathqa_source"] == "stackexchange"
+    assert doc["question_score"] == 42
+    assert doc["question_score_raw"] == "42"
+    assert doc["answer_count"] == 2
+    assert doc["num_answers_rendered"] == 2
+    assert len(doc["id"]) == 64
+    assert len(doc["question_hash"]) == 64
+    assert doc["text"] == (
+        "<question>\n"
+        "How can you prove that $\\sqrt{2}$ is irrational?\n"
+        "</question>\n\n"
+        '<answer index="0">\n'
+        "Assume $\\sqrt{2} = p / q$ in lowest terms and derive a parity contradiction.\n"
+        "</answer>\n\n"
+        '<answer index="1">\n'
+        "A geometric proof also works by infinite descent.\n"
+        "</answer>"
+    )
+
+
+@pytest.mark.parametrize("question", ["", "   ", None, ["not a question"]])
+def test_row_to_doc_filters_bad_questions(question):
+    assert row_to_doc(_valid_row(Q=question)) == []
+
+
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"A_list": None},
+        {"A_list": "answer"},
+        {"A_list": []},
+        {"A_list": ["", "   ", None, 3]},
+    ],
+)
+def test_row_to_doc_filters_missing_or_empty_answer_lists(overrides):
+    assert row_to_doc(_valid_row(**overrides)) == []
+
+
+def test_row_to_doc_keeps_only_non_empty_string_answers():
+    [doc] = row_to_doc(_valid_row(A_list=[" First answer. ", "", None, 7, "Second answer."]))
+
+    assert doc["num_answers_rendered"] == 2
+    assert '<answer index="0">\nFirst answer.\n</answer>' in doc["text"]
+    assert '<answer index="1">\nSecond answer.\n</answer>' in doc["text"]
+    assert "None" not in doc["text"]
+
+
+def test_row_to_doc_preserves_unparseable_question_score_as_raw_text():
+    [doc] = row_to_doc(_valid_row(meta={**_valid_row()["meta"], "question_score": "unknown"}))
+
+    assert doc["question_score"] is None
+    assert doc["question_score_raw"] == "unknown"
+
+
+def test_stackmathqa_full_qalist_normalize_steps_use_pinned_revision_and_stable_names():
+    processed, normalized = stackmathqa_full_qalist_normalize_steps()
+    download = processed.deps[0]
+
+    assert download.name == RAW_STEP_NAME
+    assert download.hash_attrs["hf_dataset_id"] == HF_DATASET_ID
+    assert download.hash_attrs["revision"] == HF_REVISION
+    assert download.hash_attrs["hf_urls_glob"] == [FULL_QALIST_GLOB]
+    assert processed.name == PROCESSED_STEP_NAME
+    assert processed.deps == [download]
+    assert normalized.name == NORMALIZED_STEP_NAME
+    assert normalized.deps == [processed]
+
+
+def test_transform_reads_jsonl_and_writes_valid_docs(tmp_path: Path):
+    raw_dir = tmp_path / "raw" / "preprocessed" / "stackexchange-math"
+    raw_dir.mkdir(parents=True)
+    rows = [
+        _valid_row(),
+        _valid_row(Q=""),
+    ]
+    (raw_dir / "math.stackexchange.com.jsonl").write_text(
+        "\n".join(json.dumps(row) for row in rows) + "\n",
+        encoding="utf-8",
+    )
+
+    output_dir = tmp_path / "processed"
+    transform(str(tmp_path / "raw"), str(output_dir))
+
+    written_rows = [row for path in output_dir.rglob("*.parquet") for row in pq.read_table(path).to_pylist()]
+    assert len(written_rows) == 1
+    assert written_rows[0]["source"] == HF_DATASET_ID
+    assert written_rows[0]["stackmathqa_config"] == FULL_QALIST_CONFIG
+    assert written_rows[0]["url"] == "https://math.stackexchange.com/questions/2"
+    assert written_rows[0]["answer_count"] == 2
+    assert written_rows[0]["num_answers_rendered"] == 2
+    assert "<question>\nHow can you prove that $\\sqrt{2}$ is irrational?\n</question>" in written_rows[0]["text"]
+    assert '<answer index="0">\nAssume $\\sqrt{2} = p / q$' in written_rows[0]["text"]


### PR DESCRIPTION
Add a Datakit download and transform module for `math-ai/StackMathQA` `stackmathqafull-qalist` and register it as `stackmathqa/full-qalist`. The transform stages the pinned Hugging Face revision, reads the canonical `preprocessed/stackexchange-math/*.jsonl` files, folds each question valid `A_list` entries into one LM document, and preserves provenance and audit metadata including URL, language, timestamp, source domain, question score, answer count, and rendered-answer count.

This keeps StackMathQA source-native for a bounded math continued-pretraining or midtraining ablation without treating its forum answers as SFT labels or adding it to any default broad pretraining or production midtraining mixture. The provisional 0.85B token weight is isolated behind a constant until the normalized source is materialized and measured with the canonical Marin tokenizer.