### PR TITLE
[canary] Shrink canary MoE to fit f32 eval gmm in VMEM

### DIFF
--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -80,6 +80,19 @@ _GPU_ATTENTION_IMPLEMENTATIONS: tuple[GrugAttentionImplementation, ...] = (
 # size, step count, and optimizer are all overridden by CANARY_* settings below.
 _HEURISTIC_BUDGET = 1e18
 
+# Canary MoE hidden dim. Deliberately smaller than the d1024 trial model so the
+# canary is a *representative* MoE that fits comfortably rather than one sized to
+# the HBM/VMEM ceiling. The binding constraint is the MoE grouped-matmul (gmm)
+# Pallas kernel's 16M VMEM scratchpad: it holds a double-buffered per-expert
+# weight window of shape [1, hidden_dim, 2*intermediate_dim]. Eval runs the gmm in
+# float32 (the eval loss fn does not cast to the bf16 compute dtype), so that
+# window is twice the size of the train step's. At d1024 the f32 window is 8.4M
+# and the whole kernel needs 16.44M -- 452K over budget, which crashed the first
+# eval deterministically (#6363). At d768 the f32 window is 4.7M, leaving the
+# eval gmm a comfortable VMEM margin on both v5p and v4 (VMEM is a fixed 16M on
+# both). 768 stays divisible by the heuristic's hidden_head_ratio (128).
+_CANARY_TPU_HIDDEN_DIM = 768
+
 
 def _env_bool(key: str, default: bool) -> bool:
     raw = os.environ.get(key, "")
@@ -114,13 +127,17 @@ def _build_step_from_env() -> ExecutorStep:
     run_id = os.environ.get("RUN_ID") or datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
 
     if accelerator == "tpu":
-        model = GRUG_MOE_TRIAL_MODEL
+        # Representative MoE shape sized to fit the f32 eval gmm in VMEM (see
+        # _CANARY_TPU_HIDDEN_DIM). Only the model *shape* is taken from the
+        # heuristic; batch size, step count, and optimizer are set below.
+        model, _, _, _ = build_from_heuristic(budget=_HEURISTIC_BUDGET, hidden_dim=_CANARY_TPU_HIDDEN_DIM)
         # Global batch is sized to fit the smallest pool in the fallback list. The
-        # dominant train_step allocation is the MoE expert grouped-matmul over
+        # dominant train_step HBM allocation is the MoE expert grouped-matmul over
         # batch_size * max_seq_len tokens, so per-device HBM scales with the global
-        # batch. At 512 the compiled train_step needs ~42.6 GiB and OOMs on the
-        # v4-8 fallback (~30.75 GiB usable); 128 leaves comfortable headroom on v4
-        # while staying valid on v5p, giving one config across both pools.
+        # batch. 128 leaves comfortable headroom on the v4-8 fallback (~30.75 GiB
+        # usable, ~1/3 of v5p) while staying valid on v5p, giving one config across
+        # both pools. With the smaller representative model above this is well
+        # within v4's budget.
         batch_size = env_int("CANARY_BATCH_SIZE", 128)
         # Hold the step count steady (~476) so wall-clock stays bounded after the
         # batch shrink: tokens = batch_size * max_seq_len * steps.

--- a/experiments/ferries/canary_ferry.py
+++ b/experiments/ferries/canary_ferry.py
@@ -88,9 +88,9 @@ _HEURISTIC_BUDGET = 1e18
 # float32 (the eval loss fn does not cast to the bf16 compute dtype), so that
 # window is twice the size of the train step's. At d1024 the f32 window is 8.4M
 # and the whole kernel needs 16.44M -- 452K over budget, which crashed the first
-# eval deterministically (#6363). At d768 the f32 window is 4.7M, leaving the
-# eval gmm a comfortable VMEM margin on both v5p and v4 (VMEM is a fixed 16M on
-# both). 768 stays divisible by the heuristic's hidden_head_ratio (128).
+# eval deterministically. At d768 the f32 window is 4.7M, leaving the eval gmm a
+# comfortable VMEM margin on both v5p and v4 (VMEM is a fixed 16M on both). 768
+# stays divisible by the heuristic's hidden_head_ratio (128).
 _CANARY_TPU_HIDDEN_DIM = 768
 
 


### PR DESCRIPTION
The MoE canary trained to the first eval (step 240) then crashed with a deterministic XLA:TPU compile OOM: the MoE grouped-matmul (gmm) Pallas kernel exceeded its 16M VMEM scratchpad by 452K, failing identically on every retry for three days running.

Root cause: eval runs the gmm in float32 (the grug eval loss fn does not cast to the bf16 compute dtype that the train step uses), so the double-buffered per-expert weight window is twice the size it is during training. At the d1024 trial model that f32 window is 8.4M and the whole kernel needs 16.44M -- exactly the register-spill amount over the 16M budget.

Rather than size the canary to the memory ceiling, size it as a smaller but still representative MoE: hidden_dim 768 via the existing heuristic. The f32 eval-gmm weight window drops to 4.7M, leaving comfortable VMEM margin on both v5p and v4 (VMEM is a fixed 16M on both). Experts (64), top-k (4), shared expert, and the rest of the MoE shape are unchanged; the model is now 8 layers / 6 heads. Batch size and step count are unchanged, so wall-clock stays bounded.

Fixes #6363