### PR TITLE
[grug] Avoid AdamH hyperball materialization

### DIFF
--- a/experiments/grug/moe/adamh.py
+++ b/experiments/grug/moe/adamh.py
@@ -19,6 +19,29 @@ class ScaleByAdamHState(NamedTuple):
     nu: optax.Updates
 
 
+def _scale_invariant_hyperball_update(param: jax.Array, update: jax.Array, learning_rate: float) -> jax.Array:
+    """Return AdamH's norm-preserving update without materializing the new parameter."""
+    if param.ndim <= 2:
+        param_norm = jnp.linalg.norm(param)
+        update_norm = jnp.linalg.norm(update)
+        step_scale = learning_rate * param_norm / jnp.maximum(update_norm, 1e-10)
+        dot = jnp.sum(param * update)
+        new_param_norm_sq = param_norm**2 - 2 * step_scale * dot + step_scale**2 * update_norm**2
+        new_param_norm = jnp.sqrt(jnp.maximum(new_param_norm_sq, 1e-30))
+        rescale = param_norm / jnp.maximum(new_param_norm, 1e-10)
+        return (rescale - 1) * param - rescale * step_scale * update
+
+    axes = tuple(range(1, param.ndim))
+    param_norm = jnp.sqrt(jnp.sum(jnp.square(param), axis=axes, keepdims=True))
+    update_norm = jnp.sqrt(jnp.sum(jnp.square(update), axis=axes, keepdims=True))
+    step_scale = learning_rate * param_norm / jnp.maximum(update_norm, 1e-10)
+    dot = jnp.sum(param * update, axis=axes, keepdims=True)
+    new_param_norm_sq = param_norm**2 - 2 * step_scale * dot + step_scale**2 * update_norm**2
+    new_param_norm = jnp.sqrt(jnp.maximum(new_param_norm_sq, 1e-30))
+    rescale = param_norm / jnp.maximum(new_param_norm, 1e-10)
+    return (rescale - 1) * param - rescale * step_scale * update
+
+
 def scale_by_adamh(
     b1: float = 0.9,
     b2: float = 0.999,
@@ -48,20 +71,10 @@ def scale_by_adamh(
         )
         mu = otu.tree_cast(mu, mu_dtype)
 
-        def _scale_invariant_2d(p, u):
-            """Core update for a 2-D (matrix) parameter."""
-            p_norm = jnp.linalg.norm(p)
-            u_norm = jnp.linalg.norm(u)
-            new_p = p - learning_rate * u * p_norm / jnp.maximum(u_norm, 1e-10)
-            return new_p / jnp.linalg.norm(new_p) * p_norm - p
-
         def scale_invariant_update(p, u):
             if p is None:
                 return None
-            if p.ndim <= 2:
-                return _scale_invariant_2d(p, u)
-            # For higher-rank tensors, vmap the 2-D logic over the leading axis.
-            return jax.vmap(_scale_invariant_2d)(p, u)
+            return _scale_invariant_hyperball_update(p, u, learning_rate)
 
         adamh_updates = jax.tree_util.tree_map(
             scale_invariant_update,

--- a/experiments/grug/moe/test_optimizer.py
+++ b/experiments/grug/moe/test_optimizer.py
@@ -4,6 +4,7 @@
 import jax
 import jax.numpy as jnp
 
+from experiments.grug.moe.adamh import _scale_invariant_hyperball_update as _adamh_hyperball_update
 from experiments.grug.moe.optimizer import GrugMoeAdamHConfig, GrugMoeMuonHConfig, _scale_invariant_hyperball_updates
 
 
@@ -112,10 +113,12 @@ def test_grug_moe_muonh_can_route_routed_expert_weights_to_adamh():
 
 def test_scale_invariant_hyperball_updates_matches_materialized_formula():
     params = {
+        "vector": jnp.arange(6, dtype=jnp.float32) / 5 + 0.3,
         "matrix": jnp.arange(12, dtype=jnp.float32).reshape(3, 4) / 7 + 0.25,
         "stack": jnp.arange(40, dtype=jnp.float32).reshape(2, 4, 5) / 11 + 0.5,
     }
     updates = {
+        "vector": jnp.arange(6, dtype=jnp.float32) / 9 + 0.05,
         "matrix": jnp.arange(12, dtype=jnp.float32).reshape(3, 4) / 13 + 0.1,
         "stack": jnp.arange(40, dtype=jnp.float32).reshape(2, 4, 5) / 17 + 0.2,
     }
@@ -139,5 +142,42 @@ def test_scale_invariant_hyperball_updates_matches_materialized_formula():
     actual = _scale_invariant_hyperball_updates(params, updates, learning_rate)
     expected = jax.tree.map(materialized_update, params, updates)
 
+    assert jnp.allclose(actual["vector"], expected["vector"], rtol=1e-5, atol=1e-6).item()
+    assert jnp.allclose(actual["matrix"], expected["matrix"], rtol=1e-5, atol=1e-6).item()
+    assert jnp.allclose(actual["stack"], expected["stack"], rtol=1e-5, atol=1e-6).item()
+
+
+def test_adamh_hyperball_update_matches_materialized_formula():
+    params = {
+        "vector": jnp.arange(6, dtype=jnp.float32) / 5 + 0.3,
+        "matrix": jnp.arange(12, dtype=jnp.float32).reshape(3, 4) / 7 + 0.25,
+        "stack": jnp.arange(40, dtype=jnp.float32).reshape(2, 4, 5) / 11 + 0.5,
+    }
+    updates = {
+        "vector": jnp.arange(6, dtype=jnp.float32) / 9 + 0.05,
+        "matrix": jnp.arange(12, dtype=jnp.float32).reshape(3, 4) / 13 + 0.1,
+        "stack": jnp.arange(40, dtype=jnp.float32).reshape(2, 4, 5) / 17 + 0.2,
+    }
+    learning_rate = 0.03
+
+    def materialized_update(param, update):
+        def materialized_2d(p, u):
+            p_norm = jnp.linalg.norm(p)
+            u_norm = jnp.linalg.norm(u)
+            new_p = p - learning_rate * u * p_norm / jnp.maximum(u_norm, 1e-10)
+            return new_p / jnp.linalg.norm(new_p) * p_norm - p
+
+        if param.ndim <= 2:
+            return materialized_2d(param, update)
+        return jax.vmap(materialized_2d)(param, update)
+
+    actual = jax.tree.map(
+        lambda param, update: _adamh_hyperball_update(param, update, learning_rate),
+        params,
+        updates,
+    )
+    expected = jax.tree.map(materialized_update, params, updates)
+
+    assert jnp.allclose(actual["vector"], expected["vector"], rtol=1e-5, atol=1e-6).item()
     assert jnp.allclose(actual["matrix"], expected["matrix"], rtol=1e-5, atol=1e-6).item()
     assert jnp.allclose(actual["stack"], expected["stack"], rtol=1e-5, atol=1e-6).item()


### PR DESCRIPTION
Rewrite AdamH hyperball updates to compute the norm-preserving delta algebraically instead of materializing the full post-step parameter before subtracting the original value. This preserves the existing update formula and removes an avoidable source-level intermediate, with parity coverage against the materialized reference calculation.

The H100 diagnostic that followed still reproduced the same short-sequence first-step OOM, so this should be treated as a small cleanup rather than evidence of a measured GPU memory or throughput improvement.