### PR TITLE
[reentrant] Re-entrant (self-looping) MoE: design + E0–E5 empirical study (d512)

### DIFF
--- a/.agents/projects/reentrant-model-testing.md
+++ b/.agents/projects/reentrant-model-testing.md
@@ -1,0 +1,357 @@
+# Re-entrant (self-looping) models: research findings & first-model recommendation
+
+**Status:** research complete, implementation not started.
+**Author:** weaver session `weaver/re-entrant-model-testing` (issue #139).
+**Date:** 2026-06-15.
+
+## TL;DR
+
+A "re-entrant" model that re-applies its own layers is not a fringe idea — it is a
+well-studied family usually called **recurrent-depth**, **looped**, or **recursive**
+transformers. The thesis you are after — *latent recurrence can substitute for explicit
+"thinking" tokens* — is supported both theoretically (a stack looped `T` times can
+simulate `T` steps of chain-of-thought) and empirically (a `k`-layer block looped `L`
+times nearly matches a `kL`-layer model on reasoning, at a fraction of the parameters).
+
+Your three design questions all have established answers:
+
+1. **How to train it?** Weight-tie the looped block; train with a *randomized* number of
+   loop iterations per step (so the model learns to be correct at many depths); use
+   *truncated* backprop through only the last few iterations to bound memory. This is
+   the Huginn recipe. Alternatively, solve for the fixed point directly and use implicit
+   gradients (the Deep Equilibrium Model recipe).
+2. **How does it signal "more time"?** Three options of increasing cost: (a) a *training-free*
+   inference heuristic — stop looping when consecutive latent states stop changing (KL
+   convergence); (b) a learned *halting head* (ACT / PonderNet) with a "ponder cost"
+   regularizer; (c) a *per-token recursion router* (Mixture-of-Recursions) that routes
+   each token to its own loop depth.
+3. **The "input/output consistency" soft constraint** is exactly the **fixed-point /
+   equilibrium** framing (DEQ): the looped block `f` is trained so `z* ≈ f(z*; x)`.
+   Note: the strongest modern result (Huginn) deliberately does *not* enforce strict
+   convergence — convergence *emerges* from random-depth training. Treat an explicit
+   consistency penalty as an ablation, not the default.
+
+**Recommendation:** build a `experiments/grug/reentrant/` variant (copy-first, per the
+`change-grug` skill) using a **prelude → shared recurrent block → coda** structure on the
+small 130M dense Grug config. Phase 1 is fixed-depth (validate plumbing + match a dense
+baseline at equal effective depth). Phase 2 adds randomized-depth training with truncated
+BPTT for test-time depth scaling. Phase 3 adds a KL-convergence early-exit (training-free).
+Phase 4, only if 1–3 win, adds a learned router/halting head. Start dense, not MoE — keep
+the number of moving variables minimal. Details in [§5](#5-recommendation-a-first-re-entrant-grug)
+and [§6](#6-phased-plan--issues).
+
+---
+
+## 1. The concept and why it is interesting
+
+Standard test-time scaling spends extra compute by emitting more *tokens* (chain-of-thought).
+A re-entrant model instead spends extra compute by re-applying *layers* to the same
+positions — extra computation in latent space, with no extra tokens emitted. The appeal:
+
+- **Decouple compute from parameter count.** A small weight-tied block looped many times
+  has the FLOPs of a deep model with the parameter footprint of a shallow one.
+- **Reason in latent space.** Some computations ("types of reasoning not easily represented
+  in words", per Huginn) may be awkward to serialize into discrete tokens.
+- **Adaptive per-input/per-token compute.** Hard inputs can loop more; easy ones exit early.
+
+The flip side of your "skip layers" intuition (early-exit / layer-drop) is precisely this:
+instead of *removing* depth for easy inputs, you *add* depth (by re-entry) for hard ones.
+
+---
+
+## 2. Literature survey
+
+All claims below were adversarially fact-checked against primary sources (arXiv abstracts/PDFs)
+in a 3-vote verification pass; citations are in [§7](#7-references). Empirical numbers are
+self-reported by the originating papers in controlled/synthetic settings unless noted.
+
+### 2.1 Foundations (adaptive compute + weight sharing + equilibrium)
+
+- **Adaptive Computation Time (ACT)** — Graves 2016 (arXiv:1603.08983). Lets an RNN *learn
+  how many iterations* of the same recurrent step to run per input, via a halting unit that
+  accumulates a halting probability until it crosses a threshold; a "ponder cost" penalizes
+  extra steps. Established the core idea: **the model decides its own compute budget.**
+
+- **Universal Transformer (UT)** — Dehghani et al. 2018 (arXiv:1807.03819, ICLR 2019).
+  Applies the *same* transformer transition function recurrently across depth (**weight
+  sharing across recurrent depth**) and adds a **dynamic per-position ACT halting** so
+  different token positions stop after different numbers of steps. The direct ancestor of
+  every model here: depth-via-recurrence + per-token adaptive compute.
+
+- **PonderNet** — Banino, Balaguer, Blundell 2021 (arXiv:2107.05407). Reframes halting
+  probabilistically: a per-step scalar halting probability `λ_n` induces a (generalized)
+  geometric distribution `p_n = λ_n ∏_{j<n}(1−λ_j)` over which step to stop at; the
+  prediction is taken at the sampled halting step (vs ACT's weighted average). Trained with
+  a two-term loss — reconstruction `Σ_n p_n L(y, y_n)` + `β·KL(p_n ‖ geometric prior)`. The
+  KL term biases toward an expected step count `1/λ_p` and *incentivizes exploration* rather
+  than bluntly penalizing steps. Empirically solved all 20 bAbI tasks (0.15 vs UT's 0.29 avg
+  error) with ~6× fewer steps, and **extrapolated** parity to 96-element inputs (trained on
+  ≤48) where ACT stayed at chance — by spending more thinking steps. Strong evidence that
+  *learned latent pondering substitutes for fixed compute*.
+
+- **ALBERT** — Lan et al. 2019 (arXiv:1909.11942, ICLR 2020). Introduced **cross-layer
+  parameter sharing** (layer tying) as a parameter-reduction technique (plus factorized
+  embeddings). Not framed as "reasoning", but it is the canonical proof that tying weights
+  across all transformer layers is trainable and competitive — the structural prerequisite
+  for looping.
+
+- **Deep Equilibrium Models (DEQ)** — Bai, Kolter, Koltun 2019 (arXiv:1909.01377, NeurIPS).
+  The **fixed-point / equilibrium framing** you asked about. Instead of stacking discrete
+  layers, represent an infinite-depth weight-tied network by *directly solving* for its
+  fixed point `z* = f(z*; x)` via root-finding. Crucially, training uses **implicit
+  differentiation** to backprop analytically through the equilibrium point, so memory is
+  **constant regardless of effective depth**. This is the "input/output consistency" soft
+  constraint made into the whole architecture.
+
+### 2.2 The modern reasoning-focused wave (2023–2025)
+
+- **CoTFormer** — Mohtashami, Pagliardini, Jaggi 2023 (arXiv:2310.10845). Explicitly frames
+  CoT as "employing a deeper transformer by re-applying the model multiple times" and builds
+  an architecture that mimics CoT at the token level by reusing/looping layers, with
+  **budget-adaptive compute at inference**. Reaches accuracies close to much larger models.
+
+- **Recursive & Relaxed Recursive Transformers** — Bae et al. 2024 (arXiv:2410.20672,
+  ICLR 2025). A **training recipe to convert existing pretrained LLMs into looped form**:
+  reuse a single block of unique layers repeated `L` times in a loop, *initialized from a
+  standard pretrained transformer* (not from scratch) with minimal performance loss.
+  **Relaxed** Recursive Transformers loosen strict weight-tying with depth-wise **LoRA**
+  modules so each loop iteration can differ slightly while staying compact. Directly relevant
+  if we ever want to "loop-ify" an existing Grug checkpoint instead of training fresh.
+
+- **Reasoning with Latent Thoughts: On the Power of Looped Transformers** — Saunshi, Dikkala,
+  Li, Kumar, Reddi 2025 (arXiv:2502.17416, ICLR 2025). The key **theoretical + empirical**
+  case: looped models "implicitly generate latent thoughts and can simulate `T` steps of CoT
+  with `T` loops" (their Theorem 5.4). Empirically, a `k`-layer transformer looped `L` times
+  **nearly matches a `kL`-layer non-looped model** on reasoning (addition, p-hop induction,
+  math) despite far fewer parameters — i.e. *effective depth, not parameter count, drives
+  reasoning*. Looped and non-looped models scale with effective depth analogously to
+  inference-time CoT scaling. (Follow-up arXiv:2509.25239 corroborates "looped transformers
+  subsume deterministic CoT" but flags an open gap under stochastic decoding.)
+
+- **Scaling up Test-Time Compute with Latent Reasoning: A Recurrent Depth Approach ("Huginn")**
+  — Geiping, McLeish, Jain, Kirchenbauer, Singh, Bartoldson, Kailkhura, Bhatele, Goldstein
+  2025 (arXiv:2502.05171). **The closest existing model to what you want** and the template
+  for my recommendation. A 3.5B-param model with a **prelude → recurrent block → coda**
+  ("sandwich") structure: a few non-looped layers embed the input, a core block is **looped a
+  variable number of times**, and a few non-looped layers decode. Key properties:
+  - **No specialized (CoT) training data required** — it learns latent reasoning from
+    ordinary pretraining (trained to 800B tokens).
+  - Trained with a **randomly sampled number of recurrent iterations per step** (a
+    log-normal-Poisson schedule), so the model is simultaneously trained to produce good
+    outputs at many depths. Backprop is **truncated** to the last few iterations to bound
+    memory (truncated BPTT), and the recurrent state is randomly initialized with the
+    embedded input **injected at every iteration**.
+  - At **test time it can scale compute by looping more** — up to a compute load
+    "equivalent to 50B parameters" — improving reasoning benchmarks, "sometimes dramatically".
+  - Exhibits **emergent per-token convergence**: the latent state's change between
+    consecutive iterations shrinks, enabling a training-free per-token early-exit (stop when
+    the KL/Δ between steps is small). Claims latent recurrence captures reasoning "not easily
+    represented in words".
+
+- **Mixture-of-Recursions (MoR)** — Bae, Kim, et al. 2025 (arXiv:2507.10524, NeurIPS 2025).
+  Unifies parameter sharing + **per-token adaptive compute** in one recursive transformer:
+  a shared stack is reused across recursion steps, while **lightweight routers dynamically
+  assign different recursion depths to individual tokens** — the cleanest answer to "how does
+  a token get *more time*". At equal training FLOPs and smaller sizes, MoR lowers validation
+  perplexity, raises few-shot accuracy, and improves throughput vs vanilla and recursive
+  baselines (e.g. 43.1% vs 42.3% avg few-shot at 16.5e18 FLOPs with ~50% fewer params).
+  Public code exists (github.com/raymin0223/mixture_of_recursions).
+
+### 2.3 How the pieces map to your three questions
+
+| Your question | Established mechanisms |
+|---|---|
+| **How to train a self-looping model?** | Weight-tie the looped block (ALBERT/UT). Train with **randomized loop count** + **truncated BPTT** (Huginn) so the model is good at many depths and memory is bounded. *Or* solve for the fixed point and use **implicit/equilibrium gradients** (DEQ). *Or* convert a pretrained model with layer-tying + LoRA (Relaxed Recursive). |
+| **How does it ask for "more time"?** | (a) **Training-free**: early-exit when consecutive latent states converge (Huginn KL/Δ heuristic). (b) **Learned halting head**: ACT threshold or PonderNet geometric halting + ponder-cost KL. (c) **Per-token router**: MoR assigns each token a recursion depth. |
+| **Soft input/output consistency constraint?** | This is the **fixed-point / equilibrium** idea (DEQ): train so `z ≈ f(z; x)`. Can be added as an auxiliary penalty `‖f(z)−z‖`. **Caveat:** Huginn shows you may not *want* to force this — convergence emerges from random-depth training, and over-constraining can cap expressivity. Recommend it as an ablation. |
+
+---
+
+## 3. Where Grug stands today (codebase map)
+
+Grug is **template-first** (per `.agents/skills/change-grug`): the canonical edit surface is
+`experiments/grug/base/` (`model.py`, `train.py`, `launch.py`); variants are copied from `base`
+and edited locally (this is how `experiments/grug/moe/` exists). Plain JAX arrays + Equinox
+modules with `init`/`__call__`, explicit sharding, minimal config knobs, legibility first.
+
+The layer stack is a **plain Python `for`-loop over a tuple of blocks** — there is no
+weight-tying, scan-over-shared-params, or adaptive compute anywhere yet. The dense base
+forward pass (`experiments/grug/base/model.py:197-200`):
+
+```python
+for i, block in enumerate(self.blocks):
+    with jax.named_scope(f"block_{i}"):
+        block_fn = block if is_backward_flow_active() else eqx.filter_checkpoint(block)
+        hidden = block_fn(hidden, mask)
+```
+
+`Block` is a standard pre-norm residual unit (`model.py:136-158`): `x = x + attn(norm(x));
+x = x + mlp(norm(x))`. Blocks are built as `tuple(Block.init(cfg, key=k) for k in block_keys)`
+(`model.py:175`). The MoE variant (`experiments/grug/moe/model.py:544-547`) is the same loop
+but collects per-layer router stats and alternates sliding-window masks every 4th layer.
+
+**Implications for a re-entrant variant — all favorable:**
+
+- Converting the for-loop into "prelude loop → looped core → coda loop" is a *local* edit to
+  `Transformer.__call__` plus a few config knobs. No framework surface needed.
+- Weight-tying = build *one* core block and apply it `R` times instead of building `N`
+  distinct blocks. Trivial in Equinox.
+- `eqx.filter_checkpoint` is already used per-block; truncated BPTT can reuse the same remat
+  machinery (`jax.lax.stop_gradient` on the carry for all but the last `k` iterations).
+- `haliax.nn.Stacked` (`lib/haliax/src/haliax/nn/scan.py`) provides `scan`/`fold` over layers
+  with checkpointing, *but it's for distinct per-layer params*. For tied params the simplest
+  primitive is `jax.lax.scan(step, init=hidden, xs=None, length=R)` where `step` closes over
+  the single shared block — keep it inline and grug-style rather than reaching for Stacked.
+- A small tiny config already exists — `GRUG_130M_MODEL` (`experiments/grug/base/launch.py:62`,
+  6 layers / hidden 512) — ideal for the first experiments.
+- MoE's existing per-layer router-stats plumbing is a ready template if we later add a
+  MoR-style per-token recursion router.
+
+---
+
+## 4. Design space & recommended choices
+
+| Axis | Options | Recommendation for v1 |
+|---|---|---|
+| **What is looped** | single block (pure UT) · a small stack · whole model | **Prelude/coda + a small shared core** (Huginn). Pure single-block looping is the simplest sanity check but empirically weaker; prelude/coda is the proven sweet spot. |
+| **Weight tying** | strict tie · tie + per-iteration LoRA (Relaxed Recursive) | **Strict tie** for v1. LoRA-per-iteration is a later expressivity lever. |
+| **Loop count at train time** | fixed `R` · randomized per step | **Fixed `R`** in phase 1 (clean baseline), **randomized** in phase 2 (enables test-time scaling). |
+| **Gradient** | full BPTT · truncated BPTT · implicit/DEQ | **Truncated BPTT** (last `k≈2` iters) once depth is randomized. DEQ implicit-grad is a heavier, higher-risk alternative — defer. |
+| **State init / input injection** | zero/random init · inject embedded input each iter | **Random init + input injection every iteration** (Huginn) — improves robustness to variable depth. |
+| **Adaptive compute** | none · KL-convergence exit · ACT/PonderNet head · MoR router | **None → KL-exit (training-free) → learned router**, in that order across phases. |
+| **Consistency penalty** | none · `‖f(z)−z‖` aux loss | **None by default**; add as an ablation only. |
+| **Dense vs MoE** | dense · MoE | **Dense first.** MoE adds routing variance that confounds the looping signal; combine only after looping is validated. |
+
+---
+
+## 5. Recommendation: a first re-entrant Grug
+
+Build **`experiments/grug/reentrant/`** by copying `experiments/grug/base/` and making the
+forward pass re-entrant. Concrete shape, starting from `GRUG_130M_MODEL`:
+
+```
+tokens → embed
+       → PRELUDE  : P unique blocks            (e.g. P = 1)
+       → CORE     : C shared blocks, looped R× (e.g. C = 1, R ∈ {2,4,8})   ← the re-entry
+       → CODA     : K unique blocks            (e.g. K = 1)
+       → final norm → logits
+```
+
+So "effective depth" = `P + C·R + K`. With `P=K=1, C=1`, looping `R=4` gives effective depth
+6 — matching the 6-layer dense baseline at **~1/3 the transformer-block parameters** (3 unique
+blocks vs 6). That equal-effective-depth, unequal-params comparison is the headline experiment.
+
+Config additions (new frozen dataclass `ReentrantGrugModelConfig`, or fields on a copied
+`GrugModelConfig`):
+
+```python
+num_prelude_layers: int = 1
+num_core_layers: int = 1          # unique layers in the shared, looped block
+num_coda_layers: int = 1
+recurrence_steps: int = 4         # R: loop count (fixed in phase 1)
+randomize_recurrence: bool = False        # phase 2: sample R per microbatch
+recurrence_dist: str = "lognormal_poisson"  # Huginn-style schedule (phase 2)
+backprop_steps: int = 2           # truncated BPTT window (phase 2)
+inject_input_each_step: bool = True       # add prelude output into core input every iter
+# adaptive compute lives in a later phase; keep it out of v1
+```
+
+Forward-pass sketch (dense, inline, grug-style — replaces the `for` loop):
+
+```python
+hidden = embed(token_ids)
+for block in self.prelude:                      # P unique blocks
+    hidden = block(hidden, mask)
+prelude_out = hidden
+
+def core_step(state, _):
+    x = state + prelude_out if cfg.inject_input_each_step else state
+    for block in self.core:                     # C shared blocks, reused every iteration
+        x = block(x, mask)
+    return x, None
+
+# phase 1: fixed R. phase 2: R sampled; stop_gradient on carry except last `backprop_steps`.
+hidden, _ = jax.lax.scan(core_step, init=hidden, xs=None, length=R)
+
+for block in self.coda:                         # K unique blocks
+    hidden = block(hidden, mask)
+hidden = self.final_norm(hidden)
+```
+
+(For phase-2 truncated BPTT, run the first `R−k` iterations under `jax.lax.stop_gradient` and
+the last `k` with gradients — a small wrapper around the scan, or two scans.)
+
+### Headline experiments (small, cheap, on 130M-scale configs)
+
+1. **Equal effective depth, fewer params.** Looped (`P=K=1, C=1, R=4`, effective depth 6,
+   3 unique blocks) vs dense 6-layer baseline. Question: how much val-loss / reasoning gap
+   does parameter-sharing cost? (Saunshi predicts: small, on reasoning.)
+2. **Effective-depth scaling at fixed params.** Same looped model, evaluate at `R ∈ {2,4,8,16}`.
+   Question: does looping more at *test time* (phase 2, randomized-depth training) keep
+   improving reasoning, à la Huginn?
+3. **Reasoning vs memorization split.** Track loss separately on a reasoning probe (arithmetic
+   / multi-hop) vs a memorization-heavy slice. Saunshi's claim is the benefit concentrates on
+   reasoning — worth confirming on Marin data/evals.
+4. **Adaptive-compute (phase 3):** add the training-free KL-convergence early-exit; measure
+   accuracy vs average loop count. Does it cut compute on easy tokens without hurting hard ones?
+
+### Validation / checks
+
+- `./infra/pre-commit.py --all-files` and `uv run pytest tests/test_grug_variant_contracts.py`
+  (the contract test the `change-grug` skill mandates for variants).
+- Record the variant in `docs/reports/grug-archive.md` (path, origin=`base`, purpose, status).
+- Add a focused test that the re-entrant forward at `R=1, P+C+K=N` is numerically equivalent
+  to the dense baseline (a clean plumbing regression).
+
+---
+
+## 6. Phased plan & issues
+
+Issues filed under this branch (see `weaver issue ls --mine`):
+
+- **#158 Phase 1 — fixed-depth plumbing.** Copy `base` → `reentrant`, add prelude/core/coda
+  config, weight-tied fixed-`R` scan, equivalence test, train 130M, compare to dense baseline
+  at equal effective depth.
+- **#159 Phase 2 — randomized depth + truncated BPTT.** Sample `R` per step
+  (log-normal-Poisson), truncate backprop to last `k`, input injection + random state init.
+  Demonstrate test-time depth scaling (experiment 2).
+- **#160 Phase 3 — training-free adaptive compute.** KL/Δ-convergence per-token early-exit at
+  inference; compute-vs-accuracy curve (experiment 4).
+- **#161 Phase 4 (stretch, only if 1–3 win) — learned adaptive compute.** Either a
+  PonderNet-style halting head + ponder-cost loss, or a MoR-style per-token recursion router
+  reusing the MoE router-stats plumbing. Optionally combine with MoE.
+
+This document is the `plan` artifact; the dashboard projects live issue state — keep the issue
+list and this section reconciled as work moves.
+
+---
+
+## 7. References
+
+| # | Title | Authors / year | arXiv |
+|---|---|---|---|
+| 1 | Adaptive Computation Time for Recurrent Neural Networks | Graves 2016 | [1603.08983](https://arxiv.org/abs/1603.08983) |
+| 2 | Universal Transformers | Dehghani, Gouws, Vinyals, Uszkoreit, Kaiser 2018 (ICLR'19) | [1807.03819](https://arxiv.org/abs/1807.03819) |
+| 3 | ALBERT: A Lite BERT for Self-supervised Learning of Language Representations | Lan, Chen, Goodman, Gimpel, Sharma, Soricut 2019 (ICLR'20) | [1909.11942](https://arxiv.org/abs/1909.11942) |
+| 4 | Deep Equilibrium Models | Bai, Kolter, Koltun 2019 (NeurIPS) | [1909.01377](https://arxiv.org/abs/1909.01377) |
+| 5 | PonderNet: Learning to Ponder | Banino, Balaguer, Blundell 2021 | [2107.05407](https://arxiv.org/abs/2107.05407) |
+| 6 | CoTFormer: A Chain-of-Thought Driven Architecture with Budget-Adaptive Computation Cost at Inference | Mohtashami, Pagliardini, Jaggi 2023 | [2310.10845](https://arxiv.org/abs/2310.10845) |
+| 7 | Relaxed Recursive Transformers: Effective Parameter Sharing with Layer-wise LoRA | Bae, Fisch, Harutyunyan, Ji, Kim, Schuster 2024 (ICLR'25) | [2410.20672](https://arxiv.org/abs/2410.20672) |
+| 8 | Scaling up Test-Time Compute with Latent Reasoning: A Recurrent Depth Approach (Huginn) | Geiping, McLeish, Jain, Kirchenbauer, Singh, Bartoldson, Kailkhura, Bhatele, Goldstein 2025 | [2502.05171](https://arxiv.org/abs/2502.05171) |
+| 9 | Reasoning with Latent Thoughts: On the Power of Looped Transformers | Saunshi, Dikkala, Li, Kumar, Reddi 2025 (ICLR'25) | [2502.17416](https://arxiv.org/abs/2502.17416) |
+| 10 | Mixture-of-Recursions: Learning Dynamic Recursive Depths for Adaptive Token-Level Computation | Bae, Kim, Bayat, Kim, Ha, Schuster, Fisch, Harutyunyan, Ji, Courville, Yun 2025 (NeurIPS'25) | [2507.10524](https://arxiv.org/abs/2507.10524) |
+| 11 | (follow-up) Looped transformers subsume deterministic CoT — stochastic-decoding gap | 2025 | [2509.25239](https://arxiv.org/abs/2509.25239) |
+
+## 8. Caveats & open questions
+
+- Most empirical numbers are **self-reported** by the originating papers in controlled/synthetic
+  settings; independent replication at Marin scale is exactly what these experiments would
+  provide.
+- Saunshi's "looped simulates CoT" is proven for **deterministic decoding**; the stochastic
+  case is open (arXiv:2509.25239).
+- The looped-substitutes-for-CoT benefit appears to concentrate on **reasoning**, not
+  memorization — our eval split should separate the two.
+- DEQ-style implicit gradients are elegant but add solver complexity and can be unstable;
+  truncated-BPTT-over-random-depth (Huginn) is the lower-risk first bet.
+- Strict input/output consistency may **cap expressivity**; do not enforce it by default.
+- MoE + looping together multiplies routing variance — validate looping on a dense model first.

--- a/.agents/projects/reentrant-model-testing.md
+++ b/.agents/projects/reentrant-model-testing.md
@@ -326,7 +326,80 @@ list and this section reconciled as work moves.
 
 ---
 
-## 7. References
+## 7. Novel directions beyond existing work
+
+The published work is almost entirely "loop a **dense** tied block + decide when to stop." That
+leaves real space, and several gaps line up with what makes Grug Grug (MoE + a hackable block).
+
+- **A. MoE-native recurrence (Grug's home turf).** Every looped model (MoR included) loops a
+  *dense* block. Instead: re-enter the *same shared MoE block* each loop but let the router pick
+  **different experts per pass**, conditioned on iteration index / convergence — experts
+  specialize into *roles along a reasoning trajectory* (parse → manipulate → refine), not roles
+  across fixed depths. Can be unified into Grug's existing top-k router (one router emits "which
+  experts" *and* "loop again?"). Highest ceiling, highest variance; later phase.
+- **B. Iteration-conditioned shared block (adaLN/FiLM on the loop index).** One shared block that
+  *knows what step it is on* via a cheap additive/scale modulation from an embedding of the
+  iteration count (+ optional convergence signal). Diffusion does this with timestep embeddings;
+  not cleanly ported to LM latent recurrence (Huginn injects the input but the block is
+  step-agnostic). Almost free in params; a coarse-to-fine schedule from one block. **Top cheap
+  win.**
+- **C. Anytime-decodable + self-distillation.** Attach the coda/LM head at *every* iteration and
+  train each step's output to be valid (PonderNet-style per-step outputs, but for an
+  autoregressive LM), then **distill late-iteration logits into early iterations**. Early-exit
+  becomes free and *calibrated*, and you get the refinement curve that says whether looping
+  actually helps. Plus a **learned value-of-compute critic** (predict marginal loss reduction of
+  one more loop; halt when gain < cost) — more principled than a KL threshold.
+- **D. New training framings.** *Latent denoising* — treat each loop as a denoising step on the
+  latent (perturb the recurrent state, train the loop to denoise toward consistency); inherits
+  diffusion's compute-for-quality knob and reframes the consistency constraint. *Stability-
+  regularized consistency* — rather than a blunt `‖f(z)−z‖` penalty, regularize the **Jacobian
+  spectral radius of the loop map toward <1** to *guarantee* a unique fixed point while dialing
+  how settled the representation must be.
+- **E. Latent-trajectory measurement (the de-risker).** Apply a **logit lens at every iteration**
+  and watch what the model "says" as it loops: stepwise refinement (genuine latent CoT) or smooth
+  capacity add? Directly attacks the open question of whether recurrence *substitutes* for CoT.
+  Cheap, analysis-only — run it from the first looped model onward.
+- **F. Inference/serving.** *Recurrent KV scratchpad* — persistent KV slots carried across
+  iterations so re-entry attends to its own prior latent passes (memory in KV space, no emitted
+  tokens). *SLA-elastic depth* — loop count as a per-request knob; map the accuracy/latency
+  Pareto frontier from one checkpoint.
+- **G. Interpretable hybrid.** A **"loop-more" control token**: the model emits a discrete token
+  that triggers N latent loops before resuming generation — interpretable trigger, latent compute;
+  a middle ground between CoTFormer (token-level) and Huginn (pure latent).
+
+**Order of bets (EV/risk):** B (nearly free) → C (principled adaptive compute + the refinement
+curve) → E (run from day one) → then A (high-ceiling, Grug-native) once the basics are stable.
+D/F/G are follow-ups.
+
+---
+
+## 8. Experimental rollout (live)
+
+Runs train **130M Grug MoE** variants on the `lib/iris/config/marin.yaml` Iris cluster, smallest
+slice that fits (target v6e-4/v6e-8), parallelizing independent experiments. Progress is logged
+in the GH tracking issue (and mirrored to this PR); babysitter sub-agents (`babysit-job`) watch
+each run. Each experiment changes **one** thing vs the prior best (per `change-grug`).
+
+| ID | Experiment | New idea | Compares against |
+|----|-----------|----------|------------------|
+| **E0** | Baseline 130M Grug MoE, unchanged | — (reference) | itself / dense scaling |
+| **E1** | Basic re-entrant: prelude/shared-core/coda, **fixed** loop `R`, strict weight-tie | the core mechanism | E0 at equal effective depth, fewer unique params |
+| **E2** | + **iteration-conditioned block** (adaLN on loop index) | §7 B | E1 |
+| **E3** | + **randomized depth** train + **truncated BPTT** | Huginn recipe | E1/E2; enables test-time depth scaling |
+| **E4** | + **anytime-decodable head** + self-distillation | §7 C | E3; calibrated early-exit |
+| **E5** | **logit-lens trajectory** analysis (no training change) | §7 E | run on E1+ checkpoints |
+| **E6** | **KL-convergence early-exit** at inference (training-free) | Phase 3 / §2 | E3/E4 compute-vs-accuracy |
+| **E7** | **per-iteration MoE re-routing** | §7 A | best of E1–E4 |
+
+Later swings: learned value-of-compute critic, latent-denoising training, spectral-stability
+consistency, recurrent KV scratchpad, "loop-more" control token.
+
+The phase issues (#158–#161) map onto this: #158→E1, #159→E3, #160→E6, #161→E7; E2/E4/E5 are
+the new §7 directions folded into the early rollout.
+
+---
+
+## 9. References
 
 | # | Title | Authors / year | arXiv |
 |---|---|---|---|
@@ -342,7 +415,7 @@ list and this section reconciled as work moves.
 | 10 | Mixture-of-Recursions: Learning Dynamic Recursive Depths for Adaptive Token-Level Computation | Bae, Kim, Bayat, Kim, Ha, Schuster, Fisch, Harutyunyan, Ji, Courville, Yun 2025 (NeurIPS'25) | [2507.10524](https://arxiv.org/abs/2507.10524) |
 | 11 | (follow-up) Looped transformers subsume deterministic CoT — stochastic-decoding gap | 2025 | [2509.25239](https://arxiv.org/abs/2509.25239) |
 
-## 8. Caveats & open questions
+## 10. Caveats & open questions
 
 - Most empirical numbers are **self-reported** by the originating papers in controlled/synthetic
   settings; independent replication at Marin scale is exactly what these experiments would

--- a/experiments/grug/reentrant/README.md
+++ b/experiments/grug/reentrant/README.md
@@ -1,0 +1,168 @@
+# grug-moe
+
+Current best recipe for training Mixture-of-Experts models in the grug
+template. Model, optimizer, train loop, and launch wiring all live in
+`experiments/grug/moe/` so the MoE variant can iterate independently from
+the dense base template.
+
+## Architecture
+
+All layers are MoE. No dense initial layers, no load-balancing loss (router
+z-loss only). The architecture choices are hardcoded in
+[`model.py`](./model.py); only shape/size knobs live in `GrugModelConfig`.
+
+- **Router**: linear projection (fp32) of `hidden_dim → num_experts`. Routing
+  uses a `stop_gradient` bias term that is updated each step from the previous
+  step's QB-β statistics (see `train.py::_apply_qb_betas`).
+- **QB load balancing**: at each step, the router computes per-expert β from
+  the top-k logit threshold and stores it on `GrugTrainState.pending_qb_betas`.
+  On the next step, `router_bias := -β` to push rarely-selected experts up and
+  over-selected experts down. This replaces a traditional aux load-balancing
+  loss — the bias mechanism does the balancing and is invisible to gradients.
+  The full QB computation lives in [`model.py#L350-L385`](./model.py#L350).
+- **Top-k**: `num_experts_per_token = 4` active experts out of `num_experts = 64`.
+- **Combine weights**: sigmoid on unbiased router logits for the selected
+  experts (not softmax).
+- **Shared expert**: one always-on dense MLP per block in parallel with the
+  routed experts (contributes to every token).
+- **GatedNorm**: rank-128 low-rank gating on RMS-normalized input pre-attention
+  and pre-MLP. Acts as a learned per-token gate over the hidden dimension.
+- **XSA (Exclusive Self-Attention)**: after attention, subtract the component
+  of each head's output that is parallel to its `aligned_v`. `z = y − (yᵀv / ‖v‖²)·v`
+  per head. Followed by a headwise sigmoid gate.
+- **RoPE**: standard rotary embeddings (no scaling by default).
+- **GQA**: grouped-query attention. Default ratio in the heuristic is 4:1
+  (`num_kv_heads = num_heads / 4`).
+- **Sliding-window attention**: every 4th layer uses full `sliding_window`;
+  others use half. Specifically, layer `i` uses the long mask iff `i % 4 == 3`.
+- **Fp32 router path**: router logits cast to fp32 before top-k, softmax, and
+  QB statistics.
+- **Expert parallelism**: `ragged_all_to_all` or ring-based via
+  `levanter.grug.grug_moe.moe_mlp` (default: ring). Default capacity factor 1.0.
+
+## Scaling heuristic
+
+The [`MoeAdamHHeuristic`](./heuristic.py) in `heuristic.py` turns a compute
+budget and a `hidden_dim` into a full `(model_config, optimizer_config,
+batch_size, num_steps)` tuple. Formulas were fit on the v16 LR sweep (186 runs,
+R²=0.995) and are all anchored at **seq_len = 4096**.
+
+- **Adam LR**: `adam_lr = 1.63 · tokens^(-0.2813) · dim^(-0.3678) · sqrt(B)`
+- **AdamH LR**: `lr = (13/3) · adam_lr`
+- **Compute budget**: `C = 3 · flops_per_token(no_lm_head) · tokens`
+- **Epsilon**: `epsilon_base · sqrt(r0/r)` where `r = (B·T0)/(B0·T)`
+- **Beta1**: fixed at 0.9062
+- **Beta2**: `clip(0.999^(B/B0), 0.95, 0.9999)` (constant-token half-life)
+- **Layer count**: `num_layers ≈ dim / (64 + 4·log2(dim) − 9)` (rounded)
+- **GQA**: largest divisor of `num_heads ≤ num_heads / 4`
+
+`build_from_heuristic(budget, hidden_dim, target_steps=2**14)` is the main
+entry point — `launch.py` uses it to produce the baseline step. Callers that
+want full manual control pass `GrugModelConfig` and `GrugMoeAdamHConfig`
+directly to `GrugMoeLaunchConfig`.
+
+## v16 isoflop sweep
+
+From the v16 sweep (`group=isoflop-moe-v16` on wandb, project `dial_moe`).
+See [issue #4447](https://github.com/marin-community/marin/issues/4447) for
+the full sweep context, per-cell results, and extrapolation tables. All runs
+use the architecture described above, QB routing, shared expert, GQA 4:1,
+seq_len 4096. The sweep tested multiple hidden dims at each compute budget
+(1e18–3e20) to find the optimal model size per budget.
+
+Scaling laws fit on the v16 sweep optima:
+
+- `N*(C) = 1.09e-2 · C^0.535`
+- `T*(C) = 1.60e+1 · C^0.464`
+- Paloma macro: `1.6 + 95.18 · C^(-0.0941)` (L∞ pinned at 1.6)
+
+Projections:
+
+| Budget | Projected macro |
+|--------|-----------------|
+| 1e21   | 2.606           |
+| 1e23   | 2.252           |
+
+The **measured** 1e21 d2560-v2 run came in at macro **2.599**.
+
+## Compute-optimal baseline
+
+Using `N*(C)` from the isoflop sweep, we inverted to find the optimal compute
+budget for each hidden dim, then ran each at its predicted optimal budget. These
+are the baseline runs that ablation experiments compare against.
+
+| Budget   | Dim      | Layers | Paloma macro | Tokens  | v5p-8 avg tok/s | v5p-8 runtime | Run |
+|----------|----------|--------|-------------|---------|-----------------|---------------|-----|
+| 2.19e17  | d512     | 6      | **3.8104**  | 8.37e8  | 405,630         | 0.6h          | [moe-v16-compute-opt-d512-2.19e+17](https://wandb.ai/marin-community/dial_moe/runs/moe-v16-compute-opt-d512-2.19e+17) |
+| 1.70e18  | d768     | 8      | **3.4339**  | 2.71e9  | 273,532         | 2.8h          | [moe-v16-compute-opt-d768-1.70e+18](https://wandb.ai/marin-community/dial_moe/runs/moe-v16-compute-opt-d768-1.70e+18) |
+| 9.00e18  | d1024    | 11     | **3.1605**  | 6.63e9  | 175,165         | 10.5h         | [moe-v16-compute-opt-d1024-9.00e+18](https://wandb.ai/marin-community/dial_moe/runs/moe-v16-compute-opt-d1024-9.00e+18) |
+| 2.83e19  | d1280    | 13     | **3.0065**  | 1.24e10 | 128,277         | 26.8h         | [moe-v16-compute-opt-d1280-2.83e+19](https://wandb.ai/marin-community/dial_moe/runs/moe-v16-compute-opt-d1280-2.83e+19) |
+
+## Promotion criteria
+
+Changes can be promoted to this recipe when they demonstrate some combination
+of the following. Typically point 1 is sufficient.
+
+1. **Passes gate 1 and gate 2** as defined in [`agent.md`](./agent.md) —
+   effective speedup > 1 at all compute-optimal baseline points, and lower
+   projected macro_loss at 1e21 and 1e23.
+2. **Low curvature around the minimum of each isoflop curve** — stable
+   behavior across under- and over-trained regimes, in particular the
+   overtrained regime.
+3. **Stability and scaling improvements** — better routing balance, controlled
+   norm growth, fewer activation outliers. Anything that makes the recipe more
+   robust to scaling, even if loss is neutral at small scale.
+
+Most promotable changes will land in one of three files:
+
+- [`model.py`](./model.py) — architecture tweaks (routing, norms, attention,
+  activation functions, expert layout, etc.).
+- [`heuristic.py`](./heuristic.py) — scaling heuristics (LR formula coefficients,
+  depth/width formula, GQA ratio, per-batch-size epsilon/beta2 scaling).
+- [`optimizer.py`](./optimizer.py) — optimizer internals (AdamH components,
+  parameter-group partitioning, per-group learning rates, weight decay).
+
+Some discretionary factors may influence the promotion decision even when the
+loss criteria are met — for example, impact on training memory footprint,
+inference latency / KV-cache size, serving compatibility, or interaction effects with other promotable changes.
+
+## Large run model sizing
+
+Conservative sizing for large runs using equal compute allocation between
+parameters and tokens (exponent fixed to 0.5):
+
+```
+N*(C) = 0.0543 · C^0.5    (active params, no lm_head)
+T*(C) = 3.290  · C^0.5    (tokens)
+token:active_param ratio = 60.6 (constant across all scales)
+total_params ≈ 8 × active_params  (for E=64, K=4 with shared expert)
+```
+
+These formulas fix the exponent to 0.5 for both N and T (equal scaling),
+fit on v16 isoflop sweep parabola optima. The free-fit exponents
+(N: 0.546, T: 0.464) are slightly param-heavy, but the fixed 0.5 is more
+conservative and easier to reason about.
+
+| Budget | Active params | Total params | Tokens  | Predicted macro | Approx dim | Layers |
+|--------|--------------|-------------|---------|-----------------|------------|--------|
+| 1e21   | 1.7B         | ~14B        | 104B    | 2.606           | d2400      | 24     |
+| 1e22   | 5.4B         | ~43B        | 329B    | 2.410           | d3520      | 35     |
+| 1e23   | 17.2B        | ~137B       | 1.0T    | 2.252           | d5170      | 50     |
+| 1e24   | 54.3B        | ~434B       | 3.3T    | 2.125           | d7590      | 71     |
+| 1e25   | 171.7B       | ~1.4T       | 10.4T   | 2.023           | d11150     | 102    |
+
+Predicted macro uses `loss(C) = 1.6 + 95.18 · C^(-0.0941)`.
+
+## Files
+
+- [`model.py`](./model.py) — `GrugModelConfig` + transformer implementation.
+- [`optimizer.py`](./optimizer.py) — `GrugMoeAdamHConfig` wrapper on top of
+  `AdamHConfig` with expert-param-group awareness.
+- [`train.py`](./train.py) — `GrugTrainState`, `train_step`, `_apply_qb_betas`,
+  `run_grug` (dispatches a Fray job).
+- [`heuristic.py`](./heuristic.py) — `MoeAdamHHeuristic` and
+  `build_from_heuristic` entry point.
+- [`launch.py`](./launch.py) — `GrugMoeLaunchConfig`, baseline `ExecutorStep`,
+  and `executor_main` wiring.
+- [`adamh.py`](./adamh.py) — shared AdamH utilities.
+- [`agent.md`](./agent.md) — agent guide for running ablation experiments on Iris.

--- a/experiments/grug/reentrant/__init__.py
+++ b/experiments/grug/reentrant/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/grug/reentrant/adamh.py
+++ b/experiments/grug/reentrant/adamh.py
@@ -1,0 +1,78 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+#
+# Local copy of AdamH for iteration without modifying Levanter.
+# Adapted from levanter.optim.adamh.
+
+from typing import Any, NamedTuple
+
+import chex
+import jax
+import jax.numpy as jnp
+import optax
+from optax import tree_utils as otu
+
+
+class ScaleByAdamHState(NamedTuple):
+    count: chex.Array
+    mu: optax.Updates
+    nu: optax.Updates
+
+
+def scale_by_adamh(
+    b1: float = 0.9,
+    b2: float = 0.999,
+    eps: float = 1e-8,
+    learning_rate: float = 0.02,
+    mu_dtype: Any | None = None,
+) -> optax.GradientTransformation:
+    mu_dtype = jax.dtypes.canonicalize_dtype(mu_dtype)
+
+    def init_fn(params):
+        mu = otu.tree_zeros_like(params, dtype=mu_dtype)
+        nu = otu.tree_zeros_like(params)
+        return ScaleByAdamHState(count=jnp.zeros([], jnp.int32), mu=mu, nu=nu)
+
+    def update_fn(updates, state, params):
+        mu = otu.tree_update_moment(updates, state.mu, b1, 1)
+        nu = otu.tree_update_moment_per_elem_norm(updates, state.nu, b2, 2)
+        count_inc = optax.safe_increment(state.count)
+        mu_hat = otu.tree_bias_correction(mu, b1, count_inc)
+        nu_hat = otu.tree_bias_correction(nu, b2, count_inc)
+
+        adam_updates = jax.tree.map(
+            lambda m, v: None if m is None else m / (jnp.sqrt(v) + eps),
+            mu_hat,
+            nu_hat,
+            is_leaf=lambda x: x is None,
+        )
+        mu = otu.tree_cast(mu, mu_dtype)
+
+        def _scale_invariant_2d(p, u):
+            """Core update for a 2-D (matrix) parameter."""
+            p_norm = jnp.linalg.norm(p)
+            u_norm = jnp.linalg.norm(u)
+            new_p = p - learning_rate * u * p_norm / jnp.maximum(u_norm, 1e-10)
+            return new_p / jnp.linalg.norm(new_p) * p_norm - p
+
+        def scale_invariant_update(p, u):
+            if p is None:
+                return None
+            if p.ndim <= 2:
+                return _scale_invariant_2d(p, u)
+            # For higher-rank tensors, vmap the 2-D logic over the leading axis.
+            return jax.vmap(_scale_invariant_2d)(p, u)
+
+        adamh_updates = jax.tree_util.tree_map(
+            scale_invariant_update,
+            params,
+            adam_updates,
+            is_leaf=lambda x: x is None,
+        )
+
+        return adamh_updates, ScaleByAdamHState(count=count_inc, mu=mu, nu=nu)
+
+    return optax.GradientTransformation(init_fn, update_fn)
+
+
+__all__ = ["ScaleByAdamHState", "scale_by_adamh"]

--- a/experiments/grug/reentrant/agent.md
+++ b/experiments/grug/reentrant/agent.md
@@ -1,0 +1,200 @@
+# Agent Guide: experiments/grug/moe
+
+## Autonomy
+
+This workflow is designed to run end-to-end without human confirmation. The
+agent is authorized to:
+
+- Create branches, commit, and push without asking
+- Create GitHub experiment issues and post comments
+- Submit Iris jobs and kill only jobs submitted by self
+- Run experiments through both gates autonomously
+
+Do not stop to ask for confirmation at any step. If something fails, diagnose
+and retry or report the failure — do not block waiting for input.
+
+## Objective
+
+Determine whether a proposed change outperforms the baseline. Baseline results
+are in `experiments/grug/moe/README.md` — compare against the table there.
+
+**Metrics (from wandb):**
+- `eval/paloma/macro_loss` (final value)
+- `throughput/tokens_per_second` (averaged over the last 100 steps)
+- `throughput/total_tokens` (final value)
+- `run.state` must be `finished` before pulling final metrics
+
+**Baseline scaling law** (L∞ pinned at 1.6):
+
+```
+loss(C) = 1.6 + 95.18 · C^(-0.0941)
+```
+
+### Gate 1: effective speedup at two small scales
+
+Run the variant at `d512` (2.19e17 FLOPs) and `d768` (1.70e18 FLOPs).
+
+For each scale, compute the **effective speedup** at a fixed macro_loss target
+(use the baseline's final macro_loss at that scale as the target). The variant
+passes gate 1 if it shows an effective speedup at **both** scales.
+
+### Gate 2: scaling law projection
+
+Run the variant at the two larger scales: `d1024` (9.00e18) and `d1280`
+(2.83e19). Combine with the gate 1 results (d512, d768) for four total points.
+
+The variant passes gate 2 if:
+1. It shows an effective speedup at **all four** scales.
+2. Fit a new scaling law `loss(C) = 1.6 + A · C^(-alpha)` (asymptote pinned
+   at 1.6) on the variant's four optima. Project to 1e21 and 1e23 FLOPs.
+   The variant's projected loss must be lower than the baseline's at both
+   budgets (baseline: 2.606 at 1e21, 2.252 at 1e23).
+
+### Effective speedup calculation
+
+The question: how much faster (in wall-clock time) does the variant reach
+its final loss compared to how long the baseline would need to reach that
+same loss?
+
+The scaling law `loss(C) = 1.6 + A · C^(-0.0941)` has a fixed exponent but
+the coefficient A varies. We recenter A to pass through the baseline's
+actual (budget, loss) point, then invert to find how much compute the
+baseline would need to match the variant's loss. Finally, compare wall-clock
+times.
+
+```python
+def effective_speedup(baseline_loss, baseline_tps, variant_loss, variant_tps, budget):
+    """Wall-clock speedup of the variant over the baseline.
+
+    Returns > 1 if the variant reaches its loss faster in real time.
+    """
+    L_inf = 1.6
+    alpha = 0.0941
+
+    # 1. Fit the scaling law coefficient through the baseline's data point.
+    #    loss = L_inf + A_bl * C^(-alpha)  =>  A_bl = (loss - L_inf) * C^alpha
+    A_bl = (baseline_loss - L_inf) * budget ** alpha
+
+    # 2. How much compute would the baseline need to reach variant's loss?
+    C_needed = (A_bl / (variant_loss - L_inf)) ** (1 / alpha)
+
+    # 3. Compare wall-clock times:
+    #    baseline_time = C_needed / baseline_tps
+    #    variant_time  = budget / variant_tps
+    return (C_needed / baseline_tps) / (budget / variant_tps)
+```
+
+### Example
+
+Suppose at d512 / 2.19e17 FLOPs:
+- **Baseline**: macro_loss = 3.81, tok/s = 405,000
+- **Variant**: macro_loss = 3.79, tok/s = 380,000 (better loss, 6% slower)
+
+```python
+# 1. Fit A through baseline point
+A_bl = (3.81 - 1.6) * (2.19e17) ** 0.0941  # ≈ 94.7
+
+# 2. Compute baseline needs to reach 3.79
+C_needed = (94.7 / (3.79 - 1.6)) ** (1 / 0.0941)  # > 2.19e17
+
+# 3. Wall-clock comparison
+baseline_time = C_needed / 405_000
+variant_time  = 2.19e17 / 380_000
+speedup = baseline_time / variant_time
+```
+
+If the quality improvement (needing more baseline compute to match) outweighs
+the throughput cost (variant taking longer per FLOP), speedup > 1.
+
+## Implementation
+
+Most promotable changes will land in one of three files:
+
+- `model.py` — architecture tweaks (routing, norms, attention, activation functions, expert layout, etc.).
+- `heuristic.py` — scaling heuristics (LR formula coefficients, depth/width formula, GQA ratio, per-batch-size epsilon/beta2 scaling).
+- `optimizer.py` — optimizer internals (AdamH components, parameter-group partitioning, per-group learning rates, weight decay).
+
+## Documentation & GitHub Issues
+
+Create a new branch for each experiment issue. Branch off `main`.
+
+Follow `.agents/skills/run-research/SKILL.md` for all documentation, logbooks,
+W&B tracking, and GitHub experiment issue management tied to work in this
+directory. Pay attention to this file carefully.
+
+Experiment issues should be titled `Agent MoE Experiment: [description]`.
+Include the exact prompt from the user that initiated the experiment in the
+issue body.
+
+After creating the issue, **add it as a sub-issue of #4281** (April 2026 MoE
+scaling tracking issue) using the GitHub GraphQL API. This is required — do not skip it. First get the node IDs, then
+call `addSubIssue`:
+
+```bash
+# 1. Get node IDs for the parent and the new issue
+gh api graphql -f query='
+query {
+  repository(owner: "marin-community", name: "marin") {
+    parent: issue(number: 4281) { id }
+    child: issue(number: <NEW_ISSUE_NUMBER>) { id }
+  }
+}'
+
+# 2. Add the sub-issue relationship
+gh api graphql -f query='
+mutation {
+  addSubIssue(input: {issueId: "<PARENT_ID>", subIssueId: "<CHILD_ID>"}) {
+    issue { number }
+    subIssue { number }
+  }
+}'
+```
+
+## Authentication
+
+Assume the user has already completed these before job submission:
+- `WANDB_API_KEY` set in the environment
+- `gcloud auth login` and `gcloud auth application-default login`
+
+## Job Submission
+
+Jobs in this directory are submitted to **Iris** on a **v5p-8**.
+
+### Submission command
+
+```bash
+.venv/bin/iris --cluster=marin job run \
+  --no-wait \
+  --reserve v5p-8 \
+  -e WANDB_API_KEY "$WANDB_API_KEY" \
+  -- python -m experiments.grug.moe.launch
+```
+
+Swap the module path (`experiments.grug.moe.launch`) for whichever launch
+script in this directory you are running.
+
+### Monitoring
+
+Runs may take time to find a TPU, and 5–10 minutes to start once scheduled.
+After confirming the run is progressing on wandb, jobs typically take over an
+hour to complete. Sleep at reasonable intervals (e.g. 15 minutes) before
+checking status — do not poll in a tight loop.
+
+Reconnect to logs:
+```bash
+.venv/bin/iris --cluster=marin job logs -f JOB_ID
+```
+
+List your jobs:
+```bash
+.venv/bin/iris --cluster=marin job list | grep "$(whoami)"
+```
+
+Check runs in wandb (match `<PREFIX>` to the run_id pattern in `launch.py`):
+```python
+import wandb
+api = wandb.Api()
+runs = api.runs('marin-community/marin_moe', filters={'displayName': {'$regex': '^<PREFIX>'}}, order='-created_at')
+for r in runs:
+    print(f'{r.name:<50} state={r.state:<10} step={r.summary.get("global_step", "n/a")}')
+```

--- a/experiments/grug/reentrant/eval_sweep.py
+++ b/experiments/grug/reentrant/eval_sweep.py
@@ -1,0 +1,383 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Test-time depth-scaling eval harness for the re-entrant grug experiments.
+
+E3 trains one weight-tied core whose loop count is sampled per step from a small
+set (e.g. {2, 4, 8}). The headline question is whether looping the SAME trained
+checkpoint MORE times at eval time keeps lowering loss. Because the parameters
+are weight-tied and independent of the loop count, we restore the checkpoint
+once and re-evaluate it at several recurrence depths R by swapping only the
+(static) ``recurrence_steps`` on the model config -- ``Transformer.__call__``
+applies the shared core that many times.
+
+This file is eval-only: it loads a checkpoint, builds the evaluator once, sweeps
+R, and records the validation/paloma loss at each R. It does not train and does
+not modify the model.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+import logging
+import os
+from dataclasses import dataclass, field
+from datetime import timedelta
+
+import jax
+import jmp
+import levanter.tracker
+from fray.cluster import ResourceConfig
+from haliax.partitioning import set_mesh
+from levanter.checkpoint import CheckpointerConfig
+from levanter.data.text import LmDataConfig
+from levanter.eval import EvalResult, TaggedEvaluator
+from levanter.grug.sharding import compact_grug_mesh
+from levanter.optim import OptimizerConfig
+from levanter.tracker import TrackerConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from marin.execution.executor import executor_main
+from marin.execution.types import ExecutorStep, this_output_path, versioned
+from marin.training.training import temporary_checkpoint_base_path
+
+from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
+from experiments.grug.dispatch import dispatch_grug_training_run
+from experiments.grug.reentrant.launch import (
+    _E3_MODEL,
+    _REENTRANT_RESOURCES,
+    NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+    _baseline_optimizer,
+    _resolve_run_id,
+    env_int,
+)
+from experiments.grug.reentrant.model import GrugModelConfig, Transformer
+from experiments.grug.reentrant.train import (
+    GrugEvalConfig,
+    GrugRunConfig,
+    GrugTrainerConfig,
+    build_tagged_evaluator,
+    initial_state,
+)
+
+logger = logging.getLogger(__name__)
+
+# wandb x-axis / per-R metric prefixes for the depth sweep.
+_SWEEP_PREFIX = "sweep"
+_DEFAULT_RECURRENCE_VALUES: tuple[int, ...] = (2, 4, 8, 16, 32)
+# A per-tag macro loss whose tag name contains this substring is surfaced as the
+# headline paloma loss. The default validation sets carry a "paloma" parent tag.
+_PALOMA_TAG_SUBSTRING = "paloma"
+
+
+def _model_at_depth(model: Transformer, recurrence_steps: int) -> Transformer:
+    """Return a copy of ``model`` whose forward loops the core ``recurrence_steps`` times.
+
+    The params are weight-tied and independent of the loop count, so we only swap
+    the static config. ``randomize_recurrence`` is forced off (eval is a single
+    fixed depth, not a per-step sample) and ``recurrence_choices`` cleared so the
+    config is a valid plain re-entrant model at depth R.
+    """
+    eval_cfg = dataclasses.replace(
+        model.config,
+        recurrence_steps=recurrence_steps,
+        randomize_recurrence=False,
+        recurrence_choices=(),
+    )
+    return dataclasses.replace(model, config=eval_cfg)
+
+
+def evaluate_at_depths(
+    model: Transformer,
+    evaluator: TaggedEvaluator,
+    recurrence_values: tuple[int, ...],
+) -> dict[int, EvalResult]:
+    """Evaluate one weight-tied model at several recurrence depths.
+
+    For each R in ``recurrence_values`` we build a model variant that loops its
+    shared core R times (swapping only the static config) and run the SAME
+    evaluator. Returns R -> the evaluator's ``EvalResult`` (macro/micro losses and
+    per-tag breakdown). Pure: no logging or I/O, so the multi-R plumbing is
+    testable on a tiny model without a checkpoint.
+    """
+    results: dict[int, EvalResult] = {}
+    for recurrence_steps in recurrence_values:
+        model_at_r = _model_at_depth(model, recurrence_steps)
+        results[recurrence_steps] = evaluator.evaluate(model_at_r)
+    return results
+
+
+def _paloma_macro_loss(result: EvalResult) -> float | None:
+    """Extract the paloma parent-tag macro loss from an eval result, if present."""
+    for tag, loss in result.tag_macro_losses.items():
+        if _PALOMA_TAG_SUBSTRING in tag.lower():
+            return loss
+    return None
+
+
+def _log_sweep_result(recurrence_steps: int, result: EvalResult) -> None:
+    """Log one depth's losses to wandb, keyed both by step=R and by an explicit per-R key."""
+    metrics: dict[str, float] = {
+        f"{_SWEEP_PREFIX}/recurrence_steps": float(recurrence_steps),
+        f"{_SWEEP_PREFIX}/macro_loss": result.macro_avg_loss,
+        f"{_SWEEP_PREFIX}/micro_loss": result.micro_avg_loss,
+    }
+    if result.macro_bpb is not None:
+        metrics[f"{_SWEEP_PREFIX}/macro_bpb"] = result.macro_bpb
+    paloma_loss = _paloma_macro_loss(result)
+    if paloma_loss is not None:
+        metrics[f"{_SWEEP_PREFIX}/paloma_macro_loss"] = paloma_loss
+    for tag, loss in result.tag_macro_losses.items():
+        metrics[f"{_SWEEP_PREFIX}/tag/{tag}/macro_loss"] = loss
+
+    # step=R gives a wandb x-axis of recurrence depth for sweep/* line plots.
+    levanter.tracker.log(metrics, step=recurrence_steps)
+    # Also pin each depth's headline loss under a flat key so the run summary keeps
+    # the whole curve even though successive log() calls share no monotonic step.
+    summary: dict[str, float] = {f"{_SWEEP_PREFIX}/macro_loss_at_R{recurrence_steps}": result.macro_avg_loss}
+    if paloma_loss is not None:
+        summary[f"{_SWEEP_PREFIX}/paloma_macro_loss_at_R{recurrence_steps}"] = paloma_loss
+    levanter.tracker.log_summary(summary)
+
+
+def _print_sweep_table(results: dict[int, EvalResult]) -> None:
+    """Print a clean stdout table of R vs macro loss (and paloma if present)."""
+    lines = ["", "depth-scaling eval sweep", f"{'R':>6}  {'macro_loss':>12}  {'paloma_loss':>12}"]
+    for recurrence_steps in sorted(results):
+        result = results[recurrence_steps]
+        paloma_loss = _paloma_macro_loss(result)
+        paloma_str = f"{paloma_loss:>12.4f}" if paloma_loss is not None else f"{'n/a':>12}"
+        lines.append(f"{recurrence_steps:>6}  {result.macro_avg_loss:>12.4f}  {paloma_str}")
+    print("\n".join(lines))
+
+
+def _run_eval_sweep_local(
+    config: GrugRunConfig,
+    *,
+    checkpoint_path: str,
+    recurrence_values: tuple[int, ...],
+) -> None:
+    """Eval-only entrypoint: restore one checkpoint, sweep recurrence depth.
+
+    Mirrors the mesh/optimizer/initial_state/restore setup of
+    ``experiments.grug.reentrant.train._run_grug_local`` but runs no training: it
+    builds the evaluator once and evaluates the restored params at each depth in
+    ``recurrence_values``.
+    """
+    trainer = config.trainer.trainer
+    trainer.initialize()
+    levanter.tracker.log_configuration(config)
+
+    # An optimizer is needed only to shape the train state for the checkpoint
+    # restore (the same GrugTrainState layout was saved during training); it is
+    # never stepped here.
+    optimizer = config.optimizer.build(trainer.num_train_steps)
+
+    model_key = jax.random.split(jax.random.PRNGKey(trainer.seed), 2)[1]
+
+    mesh = compact_grug_mesh(
+        expert_axis_size=config.trainer.expert_axis_size,
+        replica_axis_size=config.trainer.replica_axis_size,
+    )
+    with set_mesh(mesh):
+
+        @jax.jit
+        def _init_state(model_rng):
+            return initial_state(
+                config.model,
+                optimizer=optimizer,
+                mp=trainer.mp,
+                key=model_rng,
+                ema_beta=config.trainer.ema_beta,
+            )
+
+        state = _init_state(model_key)
+        state = restore_grug_state_from_checkpoint(
+            state,
+            checkpoint_search_paths=[checkpoint_path],
+            load_checkpoint_setting=True,
+            mesh=mesh,
+            allow_partial=False,
+        )
+
+        eval_cfg = config.eval
+        if eval_cfg is None:
+            raise ValueError("eval config is required for the depth-scaling sweep")
+        evaluator = build_tagged_evaluator(
+            data_config=config.data,
+            max_seq_len=config.model.max_seq_len,
+            mesh=mesh,
+            eval_cfg=eval_cfg,
+        )
+        if evaluator is None:
+            raise ValueError("no evaluation datasets configured; cannot run the depth sweep")
+
+        logger.info("Running depth-scaling eval sweep over R=%s", recurrence_values)
+        results = evaluate_at_depths(state.params, evaluator, recurrence_values)
+        for recurrence_steps in recurrence_values:
+            _log_sweep_result(recurrence_steps, results[recurrence_steps])
+        _print_sweep_table(results)
+
+    levanter.tracker.current_tracker().finish()
+
+
+def run_eval_sweep(
+    config: GrugRunConfig,
+    *,
+    checkpoint_path: str,
+    recurrence_values: tuple[int, ...],
+) -> None:
+    """Dispatch the depth-scaling eval sweep through Fray jobs.
+
+    Mirrors ``experiments.grug.reentrant.train.run_grug`` but binds the checkpoint
+    path and recurrence values into the entrypoint, since
+    ``dispatch_grug_training_run`` calls ``local_entrypoint(config)``.
+    """
+    trainer = config.trainer.trainer
+    if trainer.id is None:
+        raise ValueError("trainer.id must be set before dispatching the eval sweep.")
+
+    entrypoint = functools.partial(
+        _run_eval_sweep_local,
+        checkpoint_path=checkpoint_path,
+        recurrence_values=recurrence_values,
+    )
+    dispatch_grug_training_run(
+        run_id=trainer.id,
+        config=config,
+        local_entrypoint=entrypoint,
+        resources=config.resources,
+    )
+
+
+@dataclass(frozen=True)
+class GrugEvalSweepLaunchConfig:
+    """Last-mile config for the re-entrant depth-scaling eval sweep."""
+
+    model: GrugModelConfig
+    data: LmDataConfig
+    output_path: str
+    run_id: str
+    resources: ResourceConfig
+    batch_size: int
+    seed: int
+    mp: str  # jmp policy string, e.g. "params=float32,compute=bfloat16,output=bfloat16".
+    tracker: TrackerConfig
+    optimizer: OptimizerConfig
+    checkpoint_path: str
+    recurrence_values: tuple[int, ...]
+    grug_trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
+    eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
+
+
+def run_grug_eval_sweep(config: GrugEvalSweepLaunchConfig) -> None:
+    """Map launch knobs onto a GrugRunConfig and dispatch the sweep.
+
+    ``num_train_steps=1`` keeps the LR-schedule build valid; no training runs.
+    The checkpointer points at a temporary path because the sweep never saves.
+    """
+    tracker = config.tracker
+    if isinstance(tracker, WandbConfig):
+        tracker = dataclasses.replace(tracker, name=config.run_id)
+
+    trainer = TrainerConfig(
+        id=config.run_id,
+        seed=config.seed,
+        train_batch_size=config.batch_size,
+        num_train_steps=1,
+        mp=jmp.get_policy(config.mp),
+        tracker=tracker,
+        use_explicit_mesh_axes=True,
+        require_accelerator=True,
+        allow_nondivisible_batch_size=False,
+        checkpointer=CheckpointerConfig(
+            base_path=os.path.join(config.output_path, "checkpoints"),
+            temporary_base_path=temporary_checkpoint_base_path(config.output_path),
+            append_run_id_to_base_path=False,
+            save_interval=timedelta(days=365),
+            keep=None,
+        ),
+    )
+
+    grug_trainer = dataclasses.replace(config.grug_trainer, trainer=trainer)
+    run_config = GrugRunConfig(
+        model=config.model,
+        data=config.data,
+        resources=config.resources,
+        optimizer=config.optimizer,
+        trainer=grug_trainer,
+        eval=config.eval,
+    )
+    run_eval_sweep(
+        run_config,
+        checkpoint_path=config.checkpoint_path,
+        recurrence_values=config.recurrence_values,
+    )
+
+
+def _parse_recurrence_values(raw: str) -> tuple[int, ...]:
+    values = tuple(int(part.strip()) for part in raw.split(",") if part.strip())
+    if not values:
+        raise ValueError(f"RECURRENCE_VALUES must list at least one integer, got {raw!r}")
+    if any(v < 1 for v in values):
+        raise ValueError(f"RECURRENCE_VALUES must all be >= 1, got {values}")
+    return values
+
+
+def _build_eval_sweep_step() -> ExecutorStep:
+    """Build the ExecutorStep for the E3 depth-scaling eval sweep from env config.
+
+    The eval reuses the exact E3 model/data/resources so the restored checkpoint
+    matches its train-time train-state layout. CHECKPOINT_PATH (the gs:// E3
+    checkpoint dir) is required; RECURRENCE_VALUES defaults to "2,4,8,16,32".
+    """
+    checkpoint_path = os.environ.get("CHECKPOINT_PATH", "")
+    if not checkpoint_path:
+        raise ValueError("CHECKPOINT_PATH must be set to the gs:// E3 checkpoint dir.")
+    recurrence_values = _parse_recurrence_values(
+        os.environ.get("RECURRENCE_VALUES", ",".join(str(v) for v in _DEFAULT_RECURRENCE_VALUES))
+    )
+
+    # Match the E3 train eval knobs but evaluate every batch (no train-time
+    # max_eval_batches throttle) so the depth comparison is over the full set.
+    eval_cfg = GrugEvalConfig(
+        eval_batch_size=512,
+        steps_per_eval=None,
+        max_eval_batches=None,
+        eval_current=True,
+        eval_ema=False,
+    )
+
+    return ExecutorStep(
+        name="grug/reentrant_e3_eval_sweep",
+        fn=run_grug_eval_sweep,
+        config=GrugEvalSweepLaunchConfig(
+            model=versioned(_E3_MODEL),
+            data=NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+            output_path=this_output_path(),
+            run_id=_resolve_run_id("reentrant_e3_eval_sweep"),
+            resources=versioned(_REENTRANT_RESOURCES),
+            batch_size=versioned(env_int("EVAL_BATCH_SIZE", 512)),
+            seed=versioned(0),
+            mp=versioned("params=float32,compute=bfloat16,output=bfloat16"),
+            tracker=WandbConfig(
+                project="marin_moe",
+                tags=["moe", "reentrant", "e3-randdepth", "depth-sweep"],
+                group="reentrant-eval-sweep",
+                name=None,
+            ),
+            optimizer=versioned(_baseline_optimizer),
+            checkpoint_path=versioned(checkpoint_path),
+            recurrence_values=versioned(recurrence_values),
+            grug_trainer=versioned(GrugTrainerConfig(z_loss_weight=1e-4, ema_beta=None, log_every=1)),
+            eval=versioned(eval_cfg),
+        ),
+    )
+
+
+if __name__ == "__main__":
+    executor_main(
+        steps=[_build_eval_sweep_step()],
+        description="Re-entrant grug E3 test-time depth-scaling eval sweep (d512).",
+    )

--- a/experiments/grug/reentrant/eval_sweep.py
+++ b/experiments/grug/reentrant/eval_sweep.py
@@ -46,6 +46,7 @@ from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
 from experiments.grug.reentrant.launch import (
     _E3_MODEL,
+    _E6_MODEL,
     _REENTRANT_RESOURCES,
     NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
     _baseline_optimizer,
@@ -66,6 +67,21 @@ logger = logging.getLogger(__name__)
 # wandb x-axis / per-R metric prefixes for the depth sweep.
 _SWEEP_PREFIX = "sweep"
 _DEFAULT_RECURRENCE_VALUES: tuple[int, ...] = (2, 4, 8, 16, 32)
+
+# Which model config to restore the checkpoint with. E4's anytime supervision adds
+# no params, so its checkpoint shares E3's param tree (restore with E3, no readout
+# overhead). E64 shares E6's tree (depth-conditioned router bias present, anytime
+# off for eval). Keyed by SWEEP_MODEL (default e3).
+_SWEEP_MODELS = {"e3": _E3_MODEL, "e4": _E3_MODEL, "e6": _E6_MODEL, "e64": _E6_MODEL}
+
+
+def _resolve_sweep_model() -> GrugModelConfig:
+    name = os.environ.get("SWEEP_MODEL", "e3").strip()
+    if name not in _SWEEP_MODELS:
+        raise ValueError(f"SWEEP_MODEL must be one of {sorted(_SWEEP_MODELS)}, got {name!r}")
+    return _SWEEP_MODELS[name]
+
+
 # A per-tag macro loss whose tag name contains this substring is surfaced as the
 # headline paloma loss. The default validation sets carry a "paloma" parent tag.
 _PALOMA_TAG_SUBSTRING = "paloma"
@@ -326,15 +342,18 @@ def _parse_recurrence_values(raw: str) -> tuple[int, ...]:
 
 
 def _build_eval_sweep_step() -> ExecutorStep:
-    """Build the ExecutorStep for the E3 depth-scaling eval sweep from env config.
+    """Build the ExecutorStep for a depth-scaling eval sweep from env config.
 
-    The eval reuses the exact E3 model/data/resources so the restored checkpoint
-    matches its train-time train-state layout. CHECKPOINT_PATH (the gs:// E3
+    The eval reuses the exact train-time model/data/resources so the restored
+    checkpoint matches its train-state layout. SWEEP_MODEL (default e3) selects
+    which variant's model config to restore with; CHECKPOINT_PATH (the gs://
     checkpoint dir) is required; RECURRENCE_VALUES defaults to "2,4,8,16,32".
     """
     checkpoint_path = os.environ.get("CHECKPOINT_PATH", "")
     if not checkpoint_path:
-        raise ValueError("CHECKPOINT_PATH must be set to the gs:// E3 checkpoint dir.")
+        raise ValueError("CHECKPOINT_PATH must be set to the gs:// checkpoint dir.")
+    sweep_model_name = os.environ.get("SWEEP_MODEL", "e3").strip()
+    sweep_model = _resolve_sweep_model()
     recurrence_values = _parse_recurrence_values(
         os.environ.get("RECURRENCE_VALUES", ",".join(str(v) for v in _DEFAULT_RECURRENCE_VALUES))
     )
@@ -350,20 +369,20 @@ def _build_eval_sweep_step() -> ExecutorStep:
     )
 
     return ExecutorStep(
-        name="grug/reentrant_e3_eval_sweep",
+        name=f"grug/reentrant_{sweep_model_name}_eval_sweep",
         fn=run_grug_eval_sweep,
         config=GrugEvalSweepLaunchConfig(
-            model=versioned(_E3_MODEL),
+            model=versioned(sweep_model),
             data=NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
             output_path=this_output_path(),
-            run_id=_resolve_run_id("reentrant_e3_eval_sweep"),
+            run_id=_resolve_run_id(f"reentrant_{sweep_model_name}_eval_sweep"),
             resources=versioned(_REENTRANT_RESOURCES),
             batch_size=versioned(env_int("EVAL_BATCH_SIZE", 512)),
             seed=versioned(0),
             mp=versioned("params=float32,compute=bfloat16,output=bfloat16"),
             tracker=WandbConfig(
                 project="marin_moe",
-                tags=["moe", "reentrant", "e3-randdepth", "depth-sweep"],
+                tags=["moe", "reentrant", sweep_model_name, "depth-sweep"],
                 group="reentrant-eval-sweep",
                 name=None,
             ),

--- a/experiments/grug/reentrant/eval_sweep.py
+++ b/experiments/grug/reentrant/eval_sweep.py
@@ -40,7 +40,7 @@ from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 from marin.execution.executor import executor_main
 from marin.execution.types import ExecutorStep, this_output_path, versioned
-from marin.training.training import temporary_checkpoint_base_path
+from marin.training.training import resolve_training_env, temporary_checkpoint_base_path
 
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
@@ -259,6 +259,16 @@ def run_eval_sweep(
         checkpoint_path=checkpoint_path,
         recurrence_values=recurrence_values,
     )
+    # GRUG_DIRECT: run the sweep inline on the current accelerator task (submitted
+    # directly with `iris job run --tpu ...`) instead of dispatching a nested job.
+    # Mirrors experiments.grug.reentrant.train.run_grug; applies the same training
+    # env before the entrypoint touches JAX.
+    if os.environ.get("GRUG_DIRECT"):
+        env = resolve_training_env(base_env=None, resources=config.resources)
+        for key, value in env.items():
+            os.environ.setdefault(key, value)
+        entrypoint(config)
+        return
     dispatch_grug_training_run(
         run_id=trainer.id,
         config=config,

--- a/experiments/grug/reentrant/eval_sweep.py
+++ b/experiments/grug/reentrant/eval_sweep.py
@@ -47,6 +47,7 @@ from experiments.grug.dispatch import dispatch_grug_training_run
 from experiments.grug.reentrant.launch import (
     _E3_MODEL,
     _E6_MODEL,
+    _E7_MODEL,
     _REENTRANT_RESOURCES,
     NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
     _baseline_optimizer,
@@ -71,8 +72,16 @@ _DEFAULT_RECURRENCE_VALUES: tuple[int, ...] = (2, 4, 8, 16, 32)
 # Which model config to restore the checkpoint with. E4's anytime supervision adds
 # no params, so its checkpoint shares E3's param tree (restore with E3, no readout
 # overhead). E64 shares E6's tree (depth-conditioned router bias present, anytime
-# off for eval). Keyed by SWEEP_MODEL (default e3).
-_SWEEP_MODELS = {"e3": _E3_MODEL, "e4": _E3_MODEL, "e6": _E6_MODEL, "e64": _E6_MODEL}
+# off for eval). E7 adds a halt_head (PonderNet), so it must restore with the E7
+# config; ponder is training-only, so the eval forward is identical to E3's. Keyed
+# by SWEEP_MODEL (default e3).
+_SWEEP_MODELS = {
+    "e3": _E3_MODEL,
+    "e4": _E3_MODEL,
+    "e6": _E6_MODEL,
+    "e64": _E6_MODEL,
+    "e7": _E7_MODEL,
+}
 
 
 def _resolve_sweep_model() -> GrugModelConfig:

--- a/experiments/grug/reentrant/heuristic.py
+++ b/experiments/grug/reentrant/heuristic.py
@@ -1,0 +1,255 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Compute-scaling AdamH heuristic for MoE ISOFlop sweeps.
+
+All empirical fits below were measured on runs with seq_len=4096. The formulas
+use tokens_per_batch (= batch_size * seq_len) so they generalize to other
+sequence lengths, though the coefficients are an extrapolation beyond 4096.
+
+Formulas (fit on v16 LR sweep, 186 runs, R²=0.995):
+- Adam LR: adam_lr = lr_coeff * tokens^lr_tokens_exp * dim^lr_dim_exp * sqrt(B)
+  (with lr_coeff=1.63, lr_tokens_exp=-0.2813, lr_dim_exp=-0.3678)
+- AdamH LR: lr = (13/3) * adam_lr
+- Compute budget convention: C = 3 * flops_per_token(no_lm_head) * tokens
+- Epsilon: epsilon = epsilon_base * sqrt(r0/r), where r = (B*T0)/(B0*T)
+- Beta1: fixed at 0.9062
+- Beta2: beta2 = clip(beta2_base^(B/B0), min_beta2, max_beta2)
+"""
+
+import math
+from dataclasses import dataclass
+
+from levanter.utils.flop_utils import lm_flops_per_token
+
+from experiments.grug.reentrant.model import GrugModelConfig
+from experiments.grug.reentrant.optimizer import GrugMoeAdamHConfig
+
+SEQ_LEN: int = 4096
+MIN_BATCH_SIZE: int = 32
+DEFAULT_TARGET_STEPS: int = 2**14
+
+
+def _round_to_power_of_two(x: float) -> int:
+    if x <= 1:
+        return 1
+    return 2 ** math.ceil(math.log2(x))
+
+
+def compute_flops_per_token(cfg: GrugModelConfig) -> float:
+    """Non-embedding FLOPs per token (excludes lm_head)."""
+    fpt_with_lm_head = lm_flops_per_token(
+        hidden_dim=cfg.hidden_dim,
+        intermediate_dim=cfg.intermediate_dim,
+        num_layers=cfg.num_layers,
+        num_kv_heads=cfg.num_kv_heads,
+        num_heads=cfg.num_heads,
+        seq_len=cfg.max_seq_len,
+        vocab_size=cfg.vocab_size,
+        glu=True,
+        num_experts=cfg.num_experts,
+        num_shared_experts=1 if cfg.shared_expert_intermediate_dim > 0 else 0,
+        num_experts_per_tok=cfg.num_experts_per_token,
+        shared_intermediate_dim=cfg.shared_expert_intermediate_dim,
+    )
+    return fpt_with_lm_head - 2 * cfg.hidden_dim * cfg.vocab_size
+
+
+def compute_tokens_and_batch(
+    budget: float,
+    flops_per_token: float,
+    target_steps: int = DEFAULT_TARGET_STEPS,
+    min_batch_size: int = MIN_BATCH_SIZE,
+    seq_len: int = SEQ_LEN,
+) -> tuple[float, int, int]:
+    """Derive (tokens, batch_size, num_steps) from a compute budget and FLOPs-per-token.
+
+    ``seq_len`` controls the sequence length used to convert between batch_size
+    (sequences) and tokens_per_batch (tokens per step). All downstream formulas
+    that depend on batch size use ``tokens_per_batch = batch_size * seq_len``
+    so they work correctly at any sequence length.
+    """
+    tokens = budget / (3 * flops_per_token)
+    batch_exact = tokens / (target_steps * seq_len)
+    batch_size = max(min_batch_size, _round_to_power_of_two(batch_exact))
+    train_steps = max(1, round(tokens / (batch_size * seq_len)))
+    return tokens, batch_size, train_steps
+
+
+@dataclass(frozen=True)
+class MoeAdamHHeuristic:
+    """Compute-scaling AdamH heuristic for MoE models.
+
+    adam_lr = lr_coeff * tokens^lr_tokens_exp * dim^lr_dim_exp * sqrt(batch_size)
+    adamh_lr = adamh_ratio * adam_lr
+    C = 3 * flops_per_token * tokens  (flops_per_token excludes lm_head)
+    """
+
+    # --- LR scaling ---
+    # adam_lr = lr_coeff * tokens^lr_tokens_exp * dim^lr_dim_exp * sqrt(tokens_per_batch)
+    # Original (186 runs, R²=0.995) — used for v16 sweep:
+    lr_coeff: float = 0.025469  # 1.63 / sqrt(4096)
+    lr_tokens_exp: float = -0.2813
+    lr_dim_exp: float = -0.3678
+    adamh_ratio: float = 13 / 3
+
+    # --- Base hyperparameters ---
+    epsilon_coeff: float = 9.676e-18
+    beta1: float = 0.9062
+    beta2_base: float = 0.999
+    beta2_reference_tpb: int = 131_072  # beta2 = beta2_base^(tpb / beta2_reference_tpb)
+
+    # --- Fixed hyperparameters ---
+    max_grad_norm: float = 1.0
+    z_loss_weight: float = 0.0001
+
+    # --- Schedule ---
+    min_lr_ratio: float = 0.0
+    warmup: float = 0.1
+    lr_schedule: str = "linear"
+    decay: float | None = None
+
+    # --- Architecture ---
+    vocab_size: int = 128_256
+    hidden_head_ratio: int = 128
+    gqa_ratio: int | None = 4  # None = MHA, 4 = 4:1 GQA, etc.
+    base_hidden_layer_ratio: int = 64
+    layer_scaling_factor: float = 4.0
+    layer_formula_offset: int = 9
+
+    # --- Constraints ---
+    max_learning_rate: float = 0.05
+    min_beta2: float = 0.95
+    max_beta2: float = 0.9999
+
+    def _compute_adam_lr(self, tokens_per_batch: int, tokens: float, hidden_dim: int) -> float:
+        """adam_lr = lr_coeff * tokens^lr_tokens_exp * dim^lr_dim_exp * sqrt(tokens_per_batch)"""
+        adam_lr = (
+            self.lr_coeff * (tokens**self.lr_tokens_exp) * (hidden_dim**self.lr_dim_exp) * math.sqrt(tokens_per_batch)
+        )
+        return min(self.max_learning_rate, adam_lr)
+
+    def _compute_learning_rate(self, tokens_per_batch: int, tokens: float, hidden_dim: int) -> float:
+        """adamh_lr = (13/3) * adam_lr"""
+        adam_lr = self._compute_adam_lr(tokens_per_batch, tokens, hidden_dim)
+        return min(self.max_learning_rate, self.adamh_ratio * adam_lr)
+
+    def _compute_epsilon(self, tokens_per_batch: int, tokens: float) -> float:
+        """epsilon = epsilon_coeff * sqrt(tokens / tokens_per_batch)"""
+        return self.epsilon_coeff * math.sqrt(tokens / tokens_per_batch)
+
+    def _compute_beta2(self, tokens_per_batch: int) -> float:
+        """beta2 = clip(beta2_0^(tpb/tpb0), min_beta2, max_beta2). Constant token half-life."""
+        exponent = tokens_per_batch / self.beta2_reference_tpb
+        return max(self.min_beta2, min(self.max_beta2, self.beta2_base**exponent))
+
+    def build_optimizer_config(
+        self, batch_size: int, tokens: float, hidden_dim: int, seq_len: int = SEQ_LEN
+    ) -> GrugMoeAdamHConfig:
+        tokens_per_batch = batch_size * seq_len
+        lr = self._compute_learning_rate(tokens_per_batch, tokens, hidden_dim)
+        adam_lr = self._compute_adam_lr(tokens_per_batch, tokens, hidden_dim)
+        epsilon = self._compute_epsilon(tokens_per_batch, tokens)
+        beta2 = self._compute_beta2(tokens_per_batch)
+        return GrugMoeAdamHConfig(
+            learning_rate=lr,
+            adam_lr=adam_lr,
+            min_lr_ratio=self.min_lr_ratio,
+            warmup=self.warmup,
+            beta1=self.beta1,
+            beta2=beta2,
+            epsilon=epsilon,
+            max_grad_norm=self.max_grad_norm,
+            lr_schedule=self.lr_schedule,
+            decay=self.decay,
+        )
+
+    def _compute_num_layers(self, hidden_size: int) -> int:
+        hs_pow = math.log2(hidden_size)
+        return round(
+            hidden_size
+            / (self.base_hidden_layer_ratio + (hs_pow * self.layer_scaling_factor) - self.layer_formula_offset)
+        )
+
+    def _get_step_size(self, budget: float) -> int:
+        if budget > self.budget_step_threshold:
+            return self.large_budget_step_size
+        return self.small_budget_step_size
+
+    def _max_params_for_budget(self, budget: float) -> float:
+        scaling = self.base_max_params * math.sqrt(budget / self.base_max_params_budget)
+        return min(max(self.base_max_params, scaling), self.global_max_params)
+
+    @staticmethod
+    def _compute_kv_heads(num_heads: int, gqa_ratio: int | None) -> int:
+        """Compute num_kv_heads for a given GQA ratio.
+
+        If gqa_ratio is None, returns num_heads (MHA).
+        Otherwise returns the largest divisor of num_heads <= num_heads // gqa_ratio.
+        """
+        if gqa_ratio is None:
+            return num_heads
+        target = num_heads // gqa_ratio
+        for k in range(target, 0, -1):
+            if num_heads % k == 0:
+                return k
+        return 1
+
+    def build_model_config(self, hidden_size: int, seq_len: int = SEQ_LEN) -> GrugModelConfig:
+        if hidden_size % self.hidden_head_ratio != 0:
+            raise ValueError(
+                f"hidden_size ({hidden_size}) must be divisible by hidden_head_ratio ({self.hidden_head_ratio})."
+            )
+        num_layers = self._compute_num_layers(hidden_size)
+        num_heads = max(1, hidden_size // self.hidden_head_ratio)
+        num_kv_heads = self._compute_kv_heads(num_heads, self.gqa_ratio)
+
+        return GrugModelConfig(
+            vocab_size=self.vocab_size,
+            hidden_dim=hidden_size,
+            # Round up to nearest 128 for Pallas TPU MoE kernel compatibility
+            intermediate_dim=math.ceil(hidden_size / 2 / 128) * 128,
+            shared_expert_intermediate_dim=hidden_size,
+            num_experts=64,
+            num_experts_per_token=4,
+            num_layers=num_layers,
+            num_heads=num_heads,
+            num_kv_heads=num_kv_heads,
+            max_seq_len=seq_len,
+            sliding_window=seq_len,
+            initializer_std=0.5 / math.sqrt(hidden_size),
+            qk_mult=1.3,
+        )
+
+
+moe_adamh_heuristic = MoeAdamHHeuristic()
+
+
+def build_from_heuristic(
+    *,
+    budget: float,
+    hidden_dim: int,
+    heuristic: MoeAdamHHeuristic | None = None,
+    target_steps: int = DEFAULT_TARGET_STEPS,
+    min_batch_size: int = MIN_BATCH_SIZE,
+    seq_len: int = SEQ_LEN,
+) -> tuple[GrugModelConfig, GrugMoeAdamHConfig, int, int]:
+    """Construct (model, optimizer, batch_size, num_steps) for a compute budget.
+
+    Uses `MoeAdamHHeuristic` to size the model (from `hidden_dim`) and to set
+    the AdamH hyperparameters (scaled by tokens_per_batch = batch_size * seq_len).
+    Callers who want manual control should continue passing `GrugModelConfig` /
+    `GrugMoeAdamHConfig` directly to `GrugMoeLaunchConfig`.
+    """
+    h = heuristic or MoeAdamHHeuristic()
+    model_cfg = h.build_model_config(hidden_dim, seq_len=seq_len)
+    fpt = compute_flops_per_token(model_cfg)
+    tokens, batch_size, num_steps = compute_tokens_and_batch(
+        budget,
+        fpt,
+        target_steps=target_steps,
+        min_batch_size=min_batch_size,
+        seq_len=seq_len,
+    )
+    optimizer_cfg = h.build_optimizer_config(batch_size, tokens, hidden_dim, seq_len=seq_len)
+    return model_cfg, optimizer_cfg, batch_size, num_steps

--- a/experiments/grug/reentrant/launch.py
+++ b/experiments/grug/reentrant/launch.py
@@ -286,8 +286,63 @@ e5_reentrant = reentrant_step(
     tags=["moe", "reentrant", "e5-consistency"],
 )
 
+# E6 — depth-conditioned MoE routing: E3 plus a learned per-(iteration, core-layer)
+# additive router-logit bias, so each core traversal activates a DIFFERENT expert
+# mixture. Directly targets the E0-E5 structural failure (a single residual core
+# re-applied in place can't both keep computing and converge): depth-varying expert
+# selection makes each loop a genuinely different transformation while staying
+# weight-tied. Zero-init bias => numerically identical to E3 at step 0.
+_E6_MODEL = dataclasses.replace(_E3_MODEL, depth_conditioned_routing=True)
+e6_reentrant = reentrant_step(
+    name="grug/reentrant_e6_depthroute",
+    run_id=_resolve_run_id("reentrant_e6_depthroute"),
+    model=_E6_MODEL,
+    tags=["moe", "reentrant", "e6-depthroute"],
+)
+
+# E4 — anytime deep-supervision: E3 plus a training-only CE term read off the shared
+# output head after EACH core iteration (averaged). Rewards USEFUL refinement at
+# every depth (the direct fix for E5's freeze, which suppressed refinement) and makes
+# every depth anytime-decodable. ANYTIME_WEIGHT tunes the term. No new params, so the
+# checkpoint is depth-sweepable with the E3 model config.
+_E4_MODEL = dataclasses.replace(
+    _E3_MODEL,
+    anytime_supervision=True,
+    anytime_supervision_weight=env_float("ANYTIME_WEIGHT", 1.0),
+)
+e4_reentrant = reentrant_step(
+    name="grug/reentrant_e4_anytime",
+    run_id=_resolve_run_id("reentrant_e4_anytime"),
+    model=_E4_MODEL,
+    tags=["moe", "reentrant", "e4-anytime"],
+)
+
+# E64 — combined: depth-conditioned routing (E6) AND anytime deep-supervision (E4).
+# Tests whether genuinely depth-varying computation plus a per-depth usefulness
+# signal together beat each alone.
+_E64_MODEL = dataclasses.replace(
+    _E6_MODEL,
+    anytime_supervision=True,
+    anytime_supervision_weight=env_float("ANYTIME_WEIGHT", 1.0),
+)
+e64_reentrant = reentrant_step(
+    name="grug/reentrant_e64_depthroute_anytime",
+    run_id=_resolve_run_id("reentrant_e64_depthroute_anytime"),
+    model=_E64_MODEL,
+    tags=["moe", "reentrant", "e64-combined"],
+)
+
 # Experiment registry. Select with GRUG_EXPERIMENT (comma-separated names); default E0.
-_STEPS = {"e0": e0_baseline, "e1": e1_reentrant, "e2": e2_reentrant, "e3": e3_reentrant, "e5": e5_reentrant}
+_STEPS = {
+    "e0": e0_baseline,
+    "e1": e1_reentrant,
+    "e2": e2_reentrant,
+    "e3": e3_reentrant,
+    "e5": e5_reentrant,
+    "e6": e6_reentrant,
+    "e4": e4_reentrant,
+    "e64": e64_reentrant,
+}
 
 
 if __name__ == "__main__":

--- a/experiments/grug/reentrant/launch.py
+++ b/experiments/grug/reentrant/launch.py
@@ -1,0 +1,232 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Re-entrant (self-looping) grug MoE experiment series.
+
+A copy-first variant of `experiments/grug/moe` (per the change-grug skill) used to
+prototype recurrent-depth / looped transformers. Model, train loop, and launch
+wiring are all self-contained in `experiments/grug/reentrant` so each experiment
+(E0 baseline, E1 re-entrant, ...) can be iterated independently. See
+`.agents/projects/reentrant-model-testing.md` for the design and rollout.
+"""
+
+import dataclasses
+import os
+from dataclasses import dataclass, field
+from datetime import timedelta
+
+import jmp
+from fray.cluster import ResourceConfig
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.data.text import BlockShuffleConfig, LmDataConfig, TextLmDatasetFormat
+from levanter.optim import OptimizerConfig
+from levanter.tracker import TrackerConfig
+from levanter.tracker.wandb import WandbConfig
+from levanter.trainer import TrainerConfig
+from marin.execution.executor import executor_main
+from marin.execution.types import ExecutorStep, this_output_path, versioned
+from marin.processing.tokenize import add_validation_sets_to_mixture
+from marin.processing.tokenize.data_configs import lm_data_config
+from marin.training.training import temporary_checkpoint_base_path
+
+from experiments.defaults import default_validation_sets
+from experiments.grug.reentrant.heuristic import build_from_heuristic
+from experiments.grug.reentrant.model import GrugModelConfig
+from experiments.grug.reentrant.train import GrugEvalConfig, GrugRunConfig, GrugTrainerConfig, run_grug
+from experiments.llama import llama3_tokenizer
+from experiments.pretraining_datasets import nemotron_mix
+from experiments.tokenization import default_tokenize
+
+
+@dataclass(frozen=True)
+class GrugMoeLaunchConfig:
+    """Last-mile run config for the MoE grug template.
+
+    Keep this as the main entry point for day-to-day edits (model/data/optimizer/trainer/eval knobs).
+    """
+
+    model: GrugModelConfig
+    data: LmDataConfig
+    output_path: str
+    run_id: str
+    resources: ResourceConfig
+    steps: int
+    batch_size: int
+    seed: int
+    mp: str  # jmp policy string, e.g. "params=float32,compute=bfloat16,output=bfloat16".
+    tracker: TrackerConfig
+    optimizer: OptimizerConfig
+    profiler: ProfilerConfig = field(default_factory=ProfilerConfig)
+    grug_trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
+    eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
+    checkpointer: CheckpointerConfig | None = None
+    """Override the checkpointer. None builds the default (periodic + final saves
+    under output_path). Throughput experiments point this at node-local disk so a
+    slow object-store commit can't wedge the end-of-run barrier."""
+
+
+NEMOTRON_MIX_WITH_DEFAULT_VALIDATION = add_validation_sets_to_mixture(
+    nemotron_mix,
+    default_validation_sets(tokenizer=nemotron_mix.tokenizer),
+)
+
+
+def env_int(key: str, default: int) -> int:
+    """Read an int from ``os.environ[key]``, falling back to ``default`` when unset/empty."""
+    raw = os.environ.get(key, "")
+    return int(raw) if raw else default
+
+
+def slimpajama_6b_data() -> LmDataConfig:
+    """SlimPajama-6B, llama3-tokenized with block-shuffle, re-tokenized on first run.
+
+    A small, R2-local corpus for GPU smoke/scale runs; returns a ready-to-train
+    ``LmDataConfig``. A production pretraining mixture would instead need its
+    tokenized cache already materialized to avoid a cross-region tokenize.
+    """
+    tokenize_step = default_tokenize(
+        name="slimpajama-6b-cw",
+        dataset="DKYoon/SlimPajama-6B",
+        tokenizer=llama3_tokenizer,
+        format=TextLmDatasetFormat(),
+    )
+    tokenize_step = dataclasses.replace(
+        tokenize_step,
+        config=dataclasses.replace(
+            tokenize_step.config,
+            # SlimPajama-6B tokenization OOMs at the default 10g worker_resources.
+            worker_resources=ResourceConfig(ram="64g", disk="64g"),
+        ),
+    )
+    return lm_data_config(
+        training_set=tokenize_step,
+        shuffle=BlockShuffleConfig(io_block_size=256, window_blocks=256, perm_type="feistel"),
+    )
+
+
+def _resolve_run_id(default_run_id: str) -> str:
+    """Resolve run id and append `FERRY_DATE` when launching from ferry workflows."""
+    run_id = os.environ.get("GRUG_RUN_ID", default_run_id)
+    ferry_date = os.environ.get("FERRY_DATE")
+    if ferry_date:
+        run_id = f"{run_id}-{ferry_date}"
+    return run_id
+
+
+def _resolve_tracker(tracker: TrackerConfig, run_id: str) -> TrackerConfig:
+    if isinstance(tracker, WandbConfig):
+        return dataclasses.replace(tracker, name=run_id)
+    return tracker
+
+
+def run_grug_moe_trial(config: GrugMoeLaunchConfig) -> None:
+    # Map template launch knobs onto full Levanter TrainerConfig.
+    trainer = TrainerConfig(
+        id=config.run_id,
+        seed=config.seed,
+        train_batch_size=config.batch_size,
+        num_train_steps=config.steps,
+        profiler=config.profiler,
+        mp=jmp.get_policy(config.mp),
+        tracker=_resolve_tracker(config.tracker, config.run_id),
+        use_explicit_mesh_axes=True,
+        require_accelerator=True,
+        allow_nondivisible_batch_size=False,
+        checkpointer=config.checkpointer
+        or CheckpointerConfig(
+            base_path=os.path.join(config.output_path, "checkpoints"),
+            temporary_base_path=temporary_checkpoint_base_path(config.output_path),
+            append_run_id_to_base_path=False,
+            save_interval=timedelta(minutes=10),
+            keep=None,
+        ),
+    )
+
+    grug_trainer = dataclasses.replace(config.grug_trainer, trainer=trainer)
+
+    run_config = GrugRunConfig(
+        model=config.model,
+        data=config.data,
+        resources=config.resources,
+        optimizer=config.optimizer,
+        trainer=grug_trainer,
+        eval=config.eval,
+    )
+    run_grug(run_config)
+
+
+# Re-entrant experiment series. All runs share one compute budget / model size
+# (the d512 ~130M-class MoE point) so re-entrant variants are directly comparable
+# to the E0 baseline. Only the model architecture changes between experiments.
+_BUDGET: float = 2.19e17
+_HIDDEN_DIM: int = 512
+_TARGET_STEPS: int = 2**14
+_baseline_model, _baseline_optimizer, _baseline_batch, _baseline_steps = build_from_heuristic(
+    budget=_BUDGET,
+    hidden_dim=_HIDDEN_DIM,
+    target_steps=_TARGET_STEPS,
+)
+
+# Public alias for the heuristic-derived baseline GrugModelConfig. Kept because
+# consumers (e.g. experiments/ferries/canary_ferry.py) import it by name.
+GRUG_MOE_TRIAL_MODEL: GrugModelConfig = _baseline_model
+
+# Smallest slice that comfortably fits the d512 MoE (4 chips, ~128 GiB HBM).
+_REENTRANT_RESOURCES = ResourceConfig.with_tpu("v6e-4")
+
+
+def reentrant_step(*, name: str, run_id: str, model: GrugModelConfig, tags: list[str]) -> ExecutorStep:
+    """Build an ExecutorStep for one re-entrant experiment.
+
+    Every experiment shares optimizer / batch / steps / data / trainer / eval with
+    the E0 baseline; only ``model`` (and the run metadata) changes, so curves are
+    directly comparable.
+    """
+    return ExecutorStep(
+        name=name,
+        fn=run_grug_moe_trial,
+        config=GrugMoeLaunchConfig(
+            model=versioned(model),
+            data=NEMOTRON_MIX_WITH_DEFAULT_VALIDATION,
+            output_path=this_output_path(),
+            run_id=run_id,
+            resources=versioned(_REENTRANT_RESOURCES),
+            steps=versioned(_baseline_steps),
+            batch_size=versioned(_baseline_batch),
+            seed=versioned(0),
+            mp=versioned("params=float32,compute=bfloat16,output=bfloat16"),
+            tracker=WandbConfig(project="marin_moe", tags=tags, group="reentrant", name=None),
+            optimizer=versioned(_baseline_optimizer),
+            grug_trainer=versioned(GrugTrainerConfig(z_loss_weight=1e-4, ema_beta=None, log_every=1)),
+            eval=versioned(
+                GrugEvalConfig(
+                    eval_batch_size=512,
+                    steps_per_eval=1000,
+                    max_eval_batches=8,
+                    eval_current=True,
+                    eval_ema=False,
+                )
+            ),
+        ),
+    )
+
+
+# E0 — baseline: unchanged d512 Grug MoE. Reference curve for all re-entrant variants.
+e0_baseline = reentrant_step(
+    name="grug/reentrant_e0_d512",
+    run_id=_resolve_run_id("reentrant_e0_d512"),
+    model=_baseline_model,
+    tags=["moe", "reentrant", "e0-baseline"],
+)
+
+# Experiment registry. Select with GRUG_EXPERIMENT (comma-separated names); default E0.
+_STEPS = {"e0": e0_baseline}
+
+
+if __name__ == "__main__":
+    _selected = os.environ.get("GRUG_EXPERIMENT", "e0").split(",")
+    executor_main(
+        steps=[_STEPS[name.strip()] for name in _selected],
+        description="Re-entrant grug MoE experiments (d512).",
+    )

--- a/experiments/grug/reentrant/launch.py
+++ b/experiments/grug/reentrant/launch.py
@@ -251,8 +251,24 @@ e2_reentrant = reentrant_step(
     tags=["moe", "reentrant", "e2-film-loop4"],
 )
 
+# E3 — randomized-depth re-entrant: E1 with the core loop count sampled per step
+# from {2,4,8} during training. Trains one weight-tied core to be correct at many
+# depths so the SAME checkpoint can be evaluated at higher loop counts at test time
+# (the depth-scaling experiment). recurrence_steps=4 stays the default/eval depth.
+_E3_MODEL = dataclasses.replace(
+    _E1_MODEL,
+    randomize_recurrence=True,
+    recurrence_choices=(2, 4, 8),
+)
+e3_reentrant = reentrant_step(
+    name="grug/reentrant_e3_randdepth",
+    run_id=_resolve_run_id("reentrant_e3_randdepth"),
+    model=_E3_MODEL,
+    tags=["moe", "reentrant", "e3-randdepth"],
+)
+
 # Experiment registry. Select with GRUG_EXPERIMENT (comma-separated names); default E0.
-_STEPS = {"e0": e0_baseline, "e1": e1_reentrant, "e2": e2_reentrant}
+_STEPS = {"e0": e0_baseline, "e1": e1_reentrant, "e2": e2_reentrant, "e3": e3_reentrant}
 
 
 if __name__ == "__main__":

--- a/experiments/grug/reentrant/launch.py
+++ b/experiments/grug/reentrant/launch.py
@@ -220,8 +220,25 @@ e0_baseline = reentrant_step(
     tags=["moe", "reentrant", "e0-baseline"],
 )
 
+# E1 — basic re-entrant: 1 prelude + 1 weight-tied core looped 4x + 1 coda.
+# Effective depth 6 (compute-matched to E0) with 3 unique blocks (~half the block
+# params). Tests Saunshi's "looped k-layer ~= kL-layer" at fixed compute.
+_E1_MODEL = dataclasses.replace(
+    _baseline_model,
+    num_layers=3,
+    num_prelude_layers=1,
+    num_coda_layers=1,
+    recurrence_steps=4,
+)
+e1_reentrant = reentrant_step(
+    name="grug/reentrant_e1_loop4",
+    run_id=_resolve_run_id("reentrant_e1_loop4"),
+    model=_E1_MODEL,
+    tags=["moe", "reentrant", "e1-loop4"],
+)
+
 # Experiment registry. Select with GRUG_EXPERIMENT (comma-separated names); default E0.
-_STEPS = {"e0": e0_baseline}
+_STEPS = {"e0": e0_baseline, "e1": e1_reentrant}
 
 
 if __name__ == "__main__":

--- a/experiments/grug/reentrant/launch.py
+++ b/experiments/grug/reentrant/launch.py
@@ -332,6 +332,23 @@ e64_reentrant = reentrant_step(
     tags=["moe", "reentrant", "e64-combined"],
 )
 
+# E7 — PonderNet: E3 plus a learned per-token halting head + expected-over-halting CE
+# and a KL-to-geometric-prior regularizer (added on top of the standard final CE, so
+# the eval metric stays comparable). Adaptive test-time compute. PONDER_KL / PONDER_PRIOR
+# env knobs. No effect on the eval path; checkpoint depth-sweepable with the E3 config.
+_E7_MODEL = dataclasses.replace(
+    _E3_MODEL,
+    ponder_halting=True,
+    ponder_kl_weight=env_float("PONDER_KL", 0.01),
+    ponder_prior_lambda=env_float("PONDER_PRIOR", 0.2),
+)
+e7_reentrant = reentrant_step(
+    name="grug/reentrant_e7_ponder",
+    run_id=_resolve_run_id("reentrant_e7_ponder"),
+    model=_E7_MODEL,
+    tags=["moe", "reentrant", "e7-ponder"],
+)
+
 # Experiment registry. Select with GRUG_EXPERIMENT (comma-separated names); default E0.
 _STEPS = {
     "e0": e0_baseline,
@@ -342,6 +359,7 @@ _STEPS = {
     "e6": e6_reentrant,
     "e4": e4_reentrant,
     "e64": e64_reentrant,
+    "e7": e7_reentrant,
 }
 
 

--- a/experiments/grug/reentrant/launch.py
+++ b/experiments/grug/reentrant/launch.py
@@ -172,8 +172,11 @@ _baseline_model, _baseline_optimizer, _baseline_batch, _baseline_steps = build_f
 # consumers (e.g. experiments/ferries/canary_ferry.py) import it by name.
 GRUG_MOE_TRIAL_MODEL: GrugModelConfig = _baseline_model
 
-# Smallest slice that comfortably fits the d512 MoE (4 chips, ~128 GiB HBM).
-_REENTRANT_RESOURCES = ResourceConfig.with_tpu("v6e-4")
+# v5p-8 in us-central1-a: region-local to the gs://marin-us-central1 data and
+# checkpoint bucket and to the cluster controller. The marin v6e pool lives only
+# in us-east/europe, which would force cross-region I/O. This matches the README
+# d512 baseline hardware (the v5p pool's smallest slice is 8 chips).
+_REENTRANT_RESOURCES = ResourceConfig.with_tpu("v5p-8", regions=["us-central1"])
 
 
 def reentrant_step(*, name: str, run_id: str, model: GrugModelConfig, tags: list[str]) -> ExecutorStep:

--- a/experiments/grug/reentrant/launch.py
+++ b/experiments/grug/reentrant/launch.py
@@ -78,6 +78,12 @@ def env_int(key: str, default: int) -> int:
     return int(raw) if raw else default
 
 
+def env_float(key: str, default: float) -> float:
+    """Read a float from ``os.environ[key]``, falling back to ``default`` when unset/empty."""
+    raw = os.environ.get(key, "")
+    return float(raw) if raw else default
+
+
 def slimpajama_6b_data() -> LmDataConfig:
     """SlimPajama-6B, llama3-tokenized with block-shuffle, re-tokenized on first run.
 
@@ -267,8 +273,21 @@ e3_reentrant = reentrant_step(
     tags=["moe", "reentrant", "e3-randdepth"],
 )
 
+# E5 — convergence-regularized re-entrant: E3 plus a training-only core-consistency
+# penalty (mean normalized squared delta between consecutive core-loop states). Pulls
+# the weight-tied core toward a contractive/fixed-point map so deeper-than-trained
+# test-time loops stop drifting. CONSISTENCY_WEIGHT tunes lambda; eval metric is
+# unchanged (penalty is training-only).
+_E5_MODEL = dataclasses.replace(_E3_MODEL, core_consistency_weight=env_float("CONSISTENCY_WEIGHT", 1.0))
+e5_reentrant = reentrant_step(
+    name="grug/reentrant_e5_consistency",
+    run_id=_resolve_run_id("reentrant_e5_consistency"),
+    model=_E5_MODEL,
+    tags=["moe", "reentrant", "e5-consistency"],
+)
+
 # Experiment registry. Select with GRUG_EXPERIMENT (comma-separated names); default E0.
-_STEPS = {"e0": e0_baseline, "e1": e1_reentrant, "e2": e2_reentrant, "e3": e3_reentrant}
+_STEPS = {"e0": e0_baseline, "e1": e1_reentrant, "e2": e2_reentrant, "e3": e3_reentrant, "e5": e5_reentrant}
 
 
 if __name__ == "__main__":

--- a/experiments/grug/reentrant/launch.py
+++ b/experiments/grug/reentrant/launch.py
@@ -240,8 +240,19 @@ e1_reentrant = reentrant_step(
     tags=["moe", "reentrant", "e1-loop4"],
 )
 
+# E2 — iteration-conditioned re-entrant: E1 + per-iteration FiLM (adaLN) on the
+# shared core block. Tests whether telling the looped block which step it is on
+# (coarse-to-fine) helps, at ~free parameter cost. Identity at init == E1.
+_E2_MODEL = dataclasses.replace(_E1_MODEL, iteration_film=True)
+e2_reentrant = reentrant_step(
+    name="grug/reentrant_e2_filmloop4",
+    run_id=_resolve_run_id("reentrant_e2_filmloop4"),
+    model=_E2_MODEL,
+    tags=["moe", "reentrant", "e2-film-loop4"],
+)
+
 # Experiment registry. Select with GRUG_EXPERIMENT (comma-separated names); default E0.
-_STEPS = {"e0": e0_baseline, "e1": e1_reentrant}
+_STEPS = {"e0": e0_baseline, "e1": e1_reentrant, "e2": e2_reentrant}
 
 
 if __name__ == "__main__":

--- a/experiments/grug/reentrant/launch_cw_scale.py
+++ b/experiments/grug/reentrant/launch_cw_scale.py
@@ -1,0 +1,210 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Large sparse-MoE scale run for the CoreWeave cw-us-east-02a H100 cluster.
+
+Launches a ~90B-total / ~5B-active Grug MoE (hidden 3072, 48 layers, 128 experts,
+top-4 -> ~17x sparsity) across all 32 nodes / 256 H100s. Parameters are fully
+sharded over the cross-node ``data`` axis (FSDP) while the 128 routed experts are
+sharded 8-way over the intra-node NVLink ``expert`` axis (expert parallelism).
+
+This is the size class the cluster can train as a *single* model. The canary
+(``experiments/ferries/canary_ferry.py``) replicates parameters per node, so it
+caps at the ~9.5B that fits on one node's 8 GPUs; here ``replica_axis_size=1``
+shards one model across every device instead.
+
+Env knobs (all optional; defaults give the full 90B run on 256 H100):
+
+    SCALE_GPU_REPLICAS  number of 8xH100 nodes (default 32 -> 256 GPUs)
+    SCALE_EXPERT_AXIS   expert-parallel axis size, intra-node (default 8)
+    SCALE_REPLICA_AXIS  cross-node replication; 1 = pure FSDP (default 1)
+    SCALE_BATCH         global batch in sequences (default 256)
+    SCALE_SEQ_LEN       sequence length (default 2048)
+    SCALE_STEPS         training steps (default 50)
+    SCALE_HIDDEN_DIM / SCALE_NUM_LAYERS / SCALE_NUM_EXPERTS / SCALE_TOP_K
+                        model-shape overrides (e.g. a smaller FSDP smoke test)
+    SCALE_REMAT         recompute_all (default) | save_moe -- save_moe keeps the
+                        tagged MoE dispatch tensors for backward so the EP
+                        collectives are not re-run during recompute
+    SCALE_MP            jmp policy (default params=float32,compute=bfloat16,
+                        output=bfloat16); params=bfloat16 halves FSDP gather bytes
+    SCALE_TRACKER       wandb | json_logger (default json_logger)
+    SCALE_PROFILER_STEPS  >0 enables a jax_profile capture window of N steps
+                          (use SCALE_TRACKER=wandb so the artifact uploads)
+    SCALE_PROFILER_START  profiler start step (default 8, past compile/warmup)
+    SCALE_CHECKPOINTS   s3 (default) | local. local writes checkpoints to
+                        node-local disk with no periodic saves -- for throughput
+                        experiments where the checkpoint is disposable and a
+                        slow S3 commit must not wedge the end-of-run barrier
+    RUN_ID              unique run identifier
+"""
+
+import datetime
+import os
+from typing import cast
+
+from fray.cluster import ResourceConfig
+from levanter.callbacks.profiler import ProfilerConfig
+from levanter.checkpoint import CheckpointerConfig
+from levanter.optim import AdamConfig
+from levanter.tracker.json_logger import JsonLoggerConfig
+from levanter.tracker.wandb import WandbConfig
+from marin.execution.executor import executor_main
+from marin.execution.types import ExecutorStep, this_output_path, versioned
+
+from experiments.grug.reentrant.launch import GrugMoeLaunchConfig, env_int, run_grug_moe_trial, slimpajama_6b_data
+from experiments.grug.reentrant.model import GrugModelConfig, RematMode
+from experiments.grug.reentrant.train import GrugTrainerConfig
+from experiments.llama import llama3_tokenizer_vocab_size
+
+# head_dim is fixed at 128; hidden_dim must be a multiple of it.
+HEAD_DIM = 128
+VOCAB_SIZE = llama3_tokenizer_vocab_size
+GPUS_PER_NODE = 8  # H100s per gd-8xh100ib node; the batch-shard math and with_gpu(count=...) must track
+# Default seq for the 90B run. FSDP reshards the [batch, seq, hidden] activation
+# through a fully-replicated intermediate (an XLA SPMD limitation, pending Shardy),
+# so peak memory scales with batch*seq; at the default 89.7B model, batch 256 x
+# seq 2048 fits in 80GB while 512 x 4096 OOMs (~58GiB replicated tile).
+DEFAULT_SEQ_LEN = 2048
+DEFAULT_BATCH = 256
+
+# Modest, schedule-stable Adam for a short scale/throughput run (not trained to
+# convergence). expert weights share the schedule; the goal is to exercise the
+# FSDP+expert-parallel mesh at scale, not to produce a checkpoint.
+SCALE_OPTIMIZER = AdamConfig(
+    learning_rate=6e-4,
+    weight_decay=0.1,
+    lr_schedule="cosine",
+    warmup=10,
+    min_lr_ratio=0.1,
+)
+
+SCALE_TRAINER_DEFAULTS = dict(z_loss_weight=1e-4, ema_beta=None, log_every=1)
+
+
+def build_scale_model() -> GrugModelConfig:
+    """~90B-total / ~5B-active sparse MoE (overridable via SCALE_* env vars)."""
+    hidden_dim = env_int("SCALE_HIDDEN_DIM", 3072)
+    if hidden_dim % HEAD_DIM != 0:
+        raise ValueError(f"SCALE_HIDDEN_DIM={hidden_dim} must be a multiple of head_dim={HEAD_DIM}")
+    num_heads = hidden_dim // HEAD_DIM
+    # ~4:1 grouped-query attention; back off to the nearest divisor of num_heads.
+    num_kv_heads = max(1, num_heads // 4)
+    while num_heads % num_kv_heads != 0:
+        num_kv_heads -= 1
+    intermediate_dim = hidden_dim // 2  # expert FFN inner width (~d/2)
+    seq_len = env_int("SCALE_SEQ_LEN", DEFAULT_SEQ_LEN)
+    remat_mode = os.environ.get("SCALE_REMAT", "recompute_all")
+    if remat_mode not in ("recompute_all", "save_moe"):
+        raise ValueError(f"SCALE_REMAT={remat_mode!r} must be 'recompute_all' or 'save_moe'")
+    return GrugModelConfig(
+        vocab_size=VOCAB_SIZE,
+        hidden_dim=hidden_dim,
+        num_layers=env_int("SCALE_NUM_LAYERS", 48),
+        num_heads=num_heads,
+        num_kv_heads=num_kv_heads,
+        head_dim=HEAD_DIM,
+        intermediate_dim=intermediate_dim,
+        shared_expert_intermediate_dim=intermediate_dim,
+        num_experts=env_int("SCALE_NUM_EXPERTS", 128),
+        num_experts_per_token=env_int("SCALE_TOP_K", 4),
+        max_seq_len=seq_len,
+        sliding_window=seq_len,
+        remat_mode=cast(RematMode, remat_mode),
+    )
+
+
+def build_scale_step() -> ExecutorStep:
+    run_id = os.environ.get("RUN_ID") or datetime.datetime.now(datetime.timezone.utc).strftime("%Y%m%d-%H%M%S")
+
+    replicas = env_int("SCALE_GPU_REPLICAS", 32)
+    expert_axis = env_int("SCALE_EXPERT_AXIS", 8)
+    replica_axis = env_int("SCALE_REPLICA_AXIS", 1)
+    batch_size = env_int("SCALE_BATCH", DEFAULT_BATCH)
+    steps = env_int("SCALE_STEPS", 50)
+    # SCALE_PROFILER_STEPS > 0 captures a jax_profile window of that many steps
+    # (uploaded via the tracker, so pair with SCALE_TRACKER=wandb to retrieve it).
+    profiler_steps = env_int("SCALE_PROFILER_STEPS", 0)
+    profiler = ProfilerConfig(
+        enabled=profiler_steps > 0,
+        start_step=env_int("SCALE_PROFILER_START", 8),
+        num_steps=profiler_steps,
+    )
+
+    checkpoint_mode = os.environ.get("SCALE_CHECKPOINTS", "s3").lower()
+    if checkpoint_mode == "local":
+        checkpointer = CheckpointerConfig(
+            base_path=f"/tmp/grug-scale-ckpt/{run_id}",
+            append_run_id_to_base_path=False,
+            save_interval=None,
+            keep=None,
+        )
+    elif checkpoint_mode == "s3":
+        checkpointer = None
+    else:
+        raise ValueError(f"SCALE_CHECKPOINTS={checkpoint_mode!r} must be 's3' or 'local'")
+
+    model = build_scale_model()
+    if model.num_experts % expert_axis != 0:
+        raise ValueError(f"num_experts={model.num_experts} must be divisible by SCALE_EXPERT_AXIS={expert_axis}")
+
+    # Batch is sharded over the (replica_dcn, data, expert) axes; data absorbs the
+    # rest of the 8*replicas devices. Require the global batch to cover every shard.
+    data_axis = (replicas * GPUS_PER_NODE) // (replica_axis * expert_axis)
+    batch_shards = replica_axis * data_axis * expert_axis
+    if batch_size % batch_shards != 0:
+        raise ValueError(f"SCALE_BATCH={batch_size} must be divisible by batch shards={batch_shards}")
+
+    resources = ResourceConfig.with_gpu("H100", count=GPUS_PER_NODE, cpu=32, ram="256g", disk="256g", replicas=replicas)
+
+    if os.environ.get("SCALE_TRACKER", "json_logger").lower() == "wandb":
+        tracker = WandbConfig(
+            entity=os.environ.get("WANDB_ENTITY") or None,
+            project=os.environ.get("WANDB_PROJECT", "marin_moe"),
+            tags=["grug", "moe", "cw", "h100", "scale"],
+            group="grug-moe-cw-scale",
+            name=None,
+            replicate_path=this_output_path(),
+        )
+    else:
+        tracker = JsonLoggerConfig(logger_name=os.environ.get("SCALE_JSON_LOGGER", "grug_moe_scale.metrics"))
+
+    grug_trainer = GrugTrainerConfig(
+        expert_axis_size=expert_axis,
+        replica_axis_size=replica_axis,
+        **SCALE_TRAINER_DEFAULTS,
+    )
+
+    name = f"grug-moe-cw-d{model.hidden_dim}-L{model.num_layers}-e{model.num_experts}-r{replicas}"
+    return ExecutorStep(
+        name=f"{name}-{run_id}",
+        fn=run_grug_moe_trial,
+        config=GrugMoeLaunchConfig(
+            model=versioned(model),
+            data=slimpajama_6b_data(),
+            output_path=this_output_path(),
+            run_id=run_id,
+            resources=versioned(resources),
+            steps=versioned(steps),
+            batch_size=versioned(batch_size),
+            seed=versioned(0),
+            mp=versioned(os.environ.get("SCALE_MP", "params=float32,compute=bfloat16,output=bfloat16")),
+            tracker=tracker,
+            optimizer=versioned(SCALE_OPTIMIZER),
+            grug_trainer=versioned(grug_trainer),
+            eval=None,
+            profiler=profiler,
+            checkpointer=checkpointer,
+        ),
+    )
+
+
+scale_moe_step = build_scale_step()
+
+
+def main():
+    executor_main(steps=[scale_moe_step])
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/grug/reentrant/model.py
+++ b/experiments/grug/reentrant/model.py
@@ -1,0 +1,640 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""MoE grug variant model.
+
+Architecture: QB-routed MoE with GatedNorm, XSA, sigmoid combine weights.
+No load-balancing loss; router z-loss only. All layers are MoE (no dense layers).
+"""
+
+import dataclasses
+from dataclasses import dataclass
+from typing import Literal
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jax.scipy as jsp
+from einops import rearrange
+from haliax.jax_utils import named_call
+from jax import random
+from jax.sharding import PartitionSpec as P
+from jax.sharding import get_abstract_mesh, reshard
+
+try:
+    from jax.shard_map import shard_map
+except ModuleNotFoundError:
+    from jax.experimental.shard_map import shard_map
+from jaxtyping import Array, Float, Int, PRNGKeyArray
+from levanter.grug.attention import (
+    AttentionMask,
+    GrugAttentionImplementation,
+    RotaryConfig,
+    align_kv_heads,
+    apply_rotary_embedding,
+    attention,
+)
+from levanter.grug.grug_moe import (
+    MOE_REMAT_SAVE_NAMES,
+    MoeActivation,
+    MoEExpertMlp,
+    MoeImplementation,
+    resolve_moe_implementation,
+)
+from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
+from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
+from levanter.tracker.histogram import Histogram, SummaryStats
+from levanter.utils.activation import ActivationFunctionEnum
+
+_DEFAULT_EP_CAPACITY_FACTOR = 1.0
+_GATED_NORM_RANK = 128
+
+
+_BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
+
+
+def _mesh_axis_size(mesh: jax.sharding.AbstractMesh | None, axis_name: str) -> int:
+    if mesh is None or mesh.empty:
+        raise ValueError("grug/moe requires a non-empty abstract mesh")
+    if axis_name not in mesh.shape:
+        # compact_grug_mesh standardizes on (replica_dcn, data, expert, model) with length-1
+        # axes kept, so any missing axis is a caller bug rather than a "size 1" shortcut.
+        raise ValueError(f"grug/moe requires an abstract mesh with axis '{axis_name}'")
+    return int(mesh.shape[axis_name])
+
+
+RematMode = Literal["recompute_all", "save_moe"]
+
+
+def _batch_spec() -> P:
+    return P(_BATCH_AXES)
+
+
+def _batch_reshard(x: jax.Array) -> jax.Array:
+    return reshard(x, _batch_spec())
+
+
+def _layer_attention_masks(mask: AttentionMask, *, sliding_window: int) -> tuple[AttentionMask, AttentionMask]:
+    return mask.with_sliding_window(sliding_window // 2), mask.with_sliding_window(sliding_window)
+
+
+@dataclass(frozen=True)
+class GrugModelConfig:
+    """Hyperparameters for the grug MoE transformer.
+
+    Architecture choices (GatedNorm, XSA, QB routing) are hardcoded.
+    Only shape/size knobs live here. All layers are MoE.
+    """
+
+    vocab_size: int
+    hidden_dim: int = 2048
+    intermediate_dim: int = 5632
+    shared_expert_intermediate_dim: int = 5632
+    num_experts: int = 8
+    num_experts_per_token: int = 2
+    num_layers: int = 24
+    num_heads: int = 16
+    num_kv_heads: int = 16
+    head_dim: int | None = None
+    max_seq_len: int = 4096
+    sliding_window: int = 4096
+    layer_norm_eps: float = 1e-5
+    initializer_std: float = 0.02
+    qk_mult: float = 1.0
+    router_z_loss_coef: float = 0.001
+    attention_implementation: GrugAttentionImplementation | None = None
+    moe_implementation: MoeImplementation | None = None
+    remat_mode: RematMode = "recompute_all"
+    """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
+    backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
+    backward skips re-running expert dispatch and its EP collectives."""
+    rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
+
+    def __post_init__(self) -> None:
+        _ = self.inferred_head_dim
+        if self.num_heads % self.num_kv_heads != 0:
+            raise ValueError("num_heads must be divisible by num_kv_heads for grouped-query attention")
+        if self.vocab_size <= 0:
+            raise ValueError("vocab_size must be positive")
+        if self.max_seq_len <= 0:
+            raise ValueError("max_seq_len must be positive")
+        if self.num_experts <= 0:
+            raise ValueError("num_experts must be positive")
+        if self.num_experts_per_token <= 0:
+            raise ValueError("num_experts_per_token must be positive")
+        if self.num_experts_per_token > self.num_experts:
+            raise ValueError("num_experts_per_token must be <= num_experts")
+        if self.shared_expert_intermediate_dim < 0:
+            raise ValueError("shared_expert_intermediate_dim must be non-negative")
+        resolve_moe_implementation(self.moe_implementation)
+
+    @property
+    def inferred_head_dim(self) -> int:
+        if self.head_dim is not None:
+            return self.head_dim
+        if self.hidden_dim % self.num_heads != 0:
+            raise ValueError(
+                f"hidden_dim={self.hidden_dim} is not divisible by num_heads={self.num_heads}; set head_dim explicitly"
+            )
+        return self.hidden_dim // self.num_heads
+
+
+def rms_norm(x: jax.Array, eps: float = 1e-6) -> jax.Array:
+    """Non-parametric RMS norm over the last dimension."""
+    variance = jnp.mean(jnp.square(x.astype(jnp.float32)), axis=-1, keepdims=True)
+    return (x * jax.lax.rsqrt(variance + eps)).astype(x.dtype)
+
+
+class CausalSelfAttention(eqx.Module):
+    w_q: Float[Array, "D NH"]
+    w_k: Float[Array, "D MH"]
+    w_v: Float[Array, "D MH"]
+    w_o: Float[Array, "NH D"]
+    attn_gate: Float[Array, "D N"]
+    cfg: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "CausalSelfAttention":
+        k_q, k_k, k_v, k_o = random.split(key, 4)
+        d, n, m, h = cfg.hidden_dim, cfg.num_heads, cfg.num_kv_heads, cfg.inferred_head_dim
+        return CausalSelfAttention(
+            w_q=reshard(_init_weight(k_q, (d, n * h), cfg.initializer_std), P("data", "model")),
+            w_k=reshard(_init_weight(k_k, (d, m * h), cfg.initializer_std), P("data", "model")),
+            w_v=reshard(_init_weight(k_v, (d, m * h), cfg.initializer_std), P("data", "model")),
+            w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", "data")),
+            attn_gate=reshard(jnp.zeros((d, n)), P(None, None)),
+            cfg=cfg,
+        )
+
+    @named_call
+    def __call__(self, x: Float[Array, "B S D"], mask: AttentionMask | jax.Array) -> Float[Array, "B S D"]:
+        head_dim = self.cfg.inferred_head_dim
+        seq_len = x.shape[1]
+        batch_spec = _batch_spec()
+
+        q = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_q), "... (n d) -> ... n d", d=head_dim)
+        k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (m d) -> ... m d", d=head_dim)
+        v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (m d) -> ... m d", d=head_dim)
+        q = rms_norm(q)
+        k = rms_norm(k)
+        q, k = apply_rotary_embedding(q, k, seq_len=seq_len, head_dim=head_dim, rope=self.cfg.rope)
+        q = q * self.cfg.qk_mult
+        attn_out = attention(q, k, v, mask, implementation=self.cfg.attention_implementation)
+        aligned_v = align_kv_heads(v, num_q_heads=attn_out.shape[2])
+        aligned_v = reshard(aligned_v, P(_BATCH_AXES, None, "model", None))
+        # Exclusive Self Attention: subtract the component of yᵢ parallel to vᵢ.
+        # zᵢ = yᵢ - (yᵢᵀvᵢ / ‖vᵢ‖²) vᵢ, per head.
+        dot = jnp.sum(attn_out * aligned_v, axis=-1, keepdims=True)
+        v_norm_sq = jnp.sum(aligned_v * aligned_v, axis=-1, keepdims=True)
+        attn_out = attn_out - (dot / (v_norm_sq + 1e-6)) * aligned_v
+        # Headwise gating: sigmoid(x @ attn_gate) produces one scalar per head.
+        gate = 2 * jax.nn.sigmoid(jnp.einsum("bsd,dn->bsn", x, self.attn_gate))[..., None]
+        attn_out = gate * attn_out
+        attn_out = rearrange(attn_out, "... n d -> ... (n d)")
+        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=batch_spec)
+
+
+class RMSNorm(eqx.Module):
+    weight: jax.Array
+    eps: float = eqx.field(static=True)
+
+    @staticmethod
+    def init(dim: int, eps: float) -> "RMSNorm":
+        return RMSNorm(weight=jnp.ones((dim,), dtype=jnp.float32), eps=eps)
+
+    @named_call
+    def __call__(self, x: Float[Array, "... D"]) -> Float[Array, "... D"]:
+        weight = unshard(self.weight)
+        dtype = x.dtype
+        x = x.astype(jnp.float32)
+        variance = jnp.mean(jnp.square(x), axis=-1, keepdims=True)
+        normed = x * jax.lax.rsqrt(variance + self.eps)
+        return (normed * weight).astype(dtype)
+
+
+class GatedNorm(eqx.Module):
+    """Learnable per-dimension gating. Compensates for AdamH's bounded activation norms.
+    See https://arxiv.org/abs/2601.22966v1"""
+
+    w_down: jax.Array
+    w_up: jax.Array
+
+    @staticmethod
+    def init(hidden_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "GatedNorm":
+        k_down, k_up = random.split(key)
+        return GatedNorm(
+            w_down=reshard(_init_weight(k_down, (hidden_dim, _GATED_NORM_RANK), initializer_std), P(None, None)),
+            w_up=reshard(_init_weight(k_up, (_GATED_NORM_RANK, hidden_dim), initializer_std), P(None, None)),
+        )
+
+    @named_call
+    def __call__(self, x: Float[Array, "... D"]) -> Float[Array, "... D"]:
+        gate_hidden = jnp.einsum("...d,dr->...r", x, self.w_down)
+        # TODO: silu activation here isn't explored, just cargo-culted from Qwen. Likely low-hanging ablation fruit
+        # (e.g. compare no activation, relu, etc.).
+        gate_hidden = jax.nn.silu(gate_hidden)
+        gate = jax.nn.sigmoid(jnp.einsum("...r,rd->...d", gate_hidden, self.w_up))
+        return x * gate.astype(x.dtype)
+
+
+class DenseMLP(eqx.Module):
+    w_gate: jax.Array
+    w_up: jax.Array
+    w_down: jax.Array
+
+    @staticmethod
+    def init(hidden_dim: int, intermediate_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "DenseMLP":
+        k_gate, k_up, k_down = random.split(key, 3)
+        return DenseMLP(
+            w_gate=reshard(_init_weight(k_gate, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
+            w_up=reshard(_init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
+            w_down=reshard(_init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), P("model", "data")),
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        *,
+        activation: MoeActivation = ActivationFunctionEnum.silu,
+    ) -> Float[Array, "B S D"]:
+        if isinstance(activation, ActivationFunctionEnum):
+            activation_fn = activation.to_jax_fn()
+        else:
+            activation_fn = activation
+
+        b, s, _ = x.shape
+        x_flat = rearrange(x, "b s d -> (b s) d")
+        gate = jnp.einsum("td,dm->tm", x_flat, self.w_gate)
+        up = jnp.einsum("td,dm->tm", x_flat, self.w_up)
+        out_flat = jnp.einsum("tm,md->td", activation_fn(gate) * up, self.w_down, out_sharding=_batch_spec())
+        # Reshard after the reshape so the shared-expert output carries the same
+        # canonical batch sharding as the routed MoE output (MoEMLP reshards its
+        # routed result identically). Splitting the fused
+        # ("replica_dcn", "data", "expert") token axis back into (b, s) otherwise
+        # leaks the `expert` mesh axis onto the seq dim, so the shared+routed
+        # residual add fails with a ShardingTypeError on a multi-node mesh.
+        return _batch_reshard(rearrange(out_flat, "(b s) d -> b s d", b=b, s=s))
+
+
+def _routing_stats(
+    selected_experts: Int[Array, "T K"],
+    router_probs: Float[Array, "T E"],
+    router_logits: Float[Array, "T E"],
+    *,
+    num_experts: int,
+    num_experts_per_token: int,
+) -> dict[str, jax.Array]:
+    router_probs_f = router_probs.astype(jnp.float32)
+    router_logits_f = router_logits.astype(jnp.float32)
+    expert_counts = jnp.sum(jax.nn.one_hot(selected_experts, num_experts, dtype=jnp.float32), axis=(0, 1))
+    total_assignments = jnp.maximum(jnp.sum(expert_counts), 1.0)
+    assignment_fraction = expert_counts / total_assignments
+    routing_entropy = -jnp.sum(assignment_fraction * jnp.log(assignment_fraction + 1e-6))
+    token_fraction = assignment_fraction * num_experts_per_token
+    p = jnp.mean(router_probs_f, axis=0)
+    load_balancing_loss = num_experts * jnp.sum(token_fraction * p)
+    z = jsp.special.logsumexp(router_logits_f, axis=-1)
+    router_z_loss = jnp.mean(z**2)
+
+    return {
+        "routing_counts": expert_counts,
+        "routing_entropy": routing_entropy,
+        "load_balancing_loss": load_balancing_loss,
+        "router_z_loss": router_z_loss,
+    }
+
+
+def _summarize_router_metrics(router_metrics: dict[str, jax.Array]) -> dict[str, jax.Array | SummaryStats]:
+    routing_entropy = router_metrics["routing_entropy_per_layer"]
+    routing_counts = router_metrics["routing_counts_per_layer"]
+    load_balancing_loss = router_metrics["load_balancing_loss_per_layer"]
+    router_z_loss = router_metrics["router_z_loss_per_layer"]
+    num_layers = int(routing_entropy.shape[0])
+
+    out: dict[str, jax.Array | SummaryStats] = {
+        "train/router/routing_entropy_mean": jnp.mean(routing_entropy),
+        "train/router/load_balancing_loss": jnp.mean(load_balancing_loss),
+        "train/router/router_z_loss": jnp.mean(router_z_loss),
+        "train/router/routing_counts_per_layer": routing_counts,
+        "qb_beta_per_layer": router_metrics.get("qb_beta_per_layer"),
+    }
+    for i in range(num_layers):
+        out[f"train/router/layer_{i}/routing_entropy"] = routing_entropy[i]
+        out[f"train/router/layer_{i}/load_balancing_loss"] = load_balancing_loss[i]
+        out[f"train/router/layer_{i}/router_z_loss"] = router_z_loss[i]
+        out[f"train/router/layer_{i}/routing_hist"] = _histogram_from_expert_counts(routing_counts[i])
+    return out
+
+
+def _histogram_from_expert_counts(expert_counts: jax.Array) -> SummaryStats:
+    counts = jnp.asarray(expert_counts, dtype=jnp.float32)
+    num_experts = counts.shape[0]
+    expert_ids = jnp.arange(num_experts, dtype=jnp.float32)
+    num = jnp.sum(counts)
+    sum_values = jnp.sum(counts * expert_ids)
+    sum_squares = jnp.sum(counts * expert_ids * expert_ids)
+    nonzero = counts > 0
+    min_value = jnp.where(nonzero, expert_ids, jnp.inf).min()
+    max_value = jnp.where(nonzero, expert_ids, -jnp.inf).max()
+    min_value = jnp.where(num > 0, min_value, 0.0)
+    max_value = jnp.where(num > 0, max_value, 0.0)
+    bucket_limits = jnp.arange(num_experts + 1, dtype=jnp.float32)
+    histogram = Histogram(bucket_limits=bucket_limits, bucket_counts=counts)
+    return SummaryStats.from_reduced_values(
+        min=min_value,
+        max=max_value,
+        num=num,
+        nonzero_count=jnp.sum(nonzero),
+        sum=sum_values,
+        sum_squares=sum_squares,
+        histogram=histogram,
+    )
+
+
+class MoEMLP(eqx.Module):
+    """QB-routed MoE with sigmoid combine weights."""
+
+    router: jax.Array
+    router_bias: jax.Array
+    expert_mlp: MoEExpertMlp
+    cfg: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "MoEMLP":
+        k_router, k_expert_mlp = random.split(key, 2)
+        mesh = get_abstract_mesh()
+
+        expert_axis_size = _mesh_axis_size(mesh, "expert")
+        if cfg.num_experts % expert_axis_size != 0:
+            raise ValueError(f"num_experts={cfg.num_experts} must be divisible by expert axis size={expert_axis_size}")
+
+        d, e, i = cfg.hidden_dim, cfg.num_experts, cfg.intermediate_dim
+
+        return MoEMLP(
+            router=reshard(_init_weight(k_router, (d, e), cfg.initializer_std), P(None, None)),
+            router_bias=jnp.zeros((e,)),
+            expert_mlp=MoEExpertMlp.init(
+                num_experts=e,
+                hidden_dim=d,
+                intermediate_dim=i,
+                initializer_std=cfg.initializer_std,
+                key=k_expert_mlp,
+                implementation=cfg.moe_implementation,
+                activation=ActivationFunctionEnum.silu,
+                capacity_factor=_DEFAULT_EP_CAPACITY_FACTOR,
+            ),
+            cfg=cfg,
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        b, s, _ = x.shape
+        x_flat = rearrange(x, "b s d -> (b s) d")
+        # Keep the router path in fp32 before top-k, softmax, and QB statistics.
+        router_logits = jnp.einsum("td,de->te", x_flat, reshard(self.router, P(None, None))).astype(jnp.float32)
+        biased_logits = router_logits + jax.lax.stop_gradient(self.router_bias)
+        router_probs = jax.nn.softmax(router_logits, axis=-1)
+        # Select top-(K+1) on biased logits; the (K+1)-th is the QB threshold alpha.
+        _topk_logits, selected_experts = jax.lax.top_k(biased_logits, self.cfg.num_experts_per_token + 1)
+        qb_alpha = _topk_logits[:, -1:]
+        selected_experts = selected_experts[:, :-1]
+        # Sigmoid combine weights on unbiased logits for selected experts.
+        unbiased_topk = jnp.take_along_axis(router_logits, selected_experts, axis=-1)
+        combine_weights = jax.nn.sigmoid(unbiased_topk).astype(x.dtype)
+        router_stats = _routing_stats(
+            selected_experts,
+            router_probs,
+            router_logits,
+            num_experts=self.cfg.num_experts,
+            num_experts_per_token=self.cfg.num_experts_per_token,
+        )
+        # Sharded QB: compute beta locally per device, then average.
+        mesh = get_abstract_mesh()
+        s_minus_alpha = reshard(router_logits - qb_alpha, P(_BATCH_AXES, None))
+        num_devices = 1
+        for a in _BATCH_AXES:
+            num_devices *= mesh.shape[a]
+        local_tokens = s_minus_alpha.shape[0] // num_devices
+        qb_count = max(1, local_tokens * self.cfg.num_experts_per_token // self.cfg.num_experts)
+
+        def _local_qb_beta(s_ma):
+            topk_vals, _ = jax.lax.top_k(s_ma.T, qb_count)
+            beta = topk_vals[:, -1]
+            return jax.lax.pmean(beta, axis_name=_BATCH_AXES)
+
+        router_stats["qb_beta"] = shard_map(
+            _local_qb_beta,
+            mesh=mesh,
+            in_specs=(P(_BATCH_AXES, None),),
+            out_specs=P(),
+        )(s_minus_alpha)
+
+        routed_flat = self.expert_mlp(
+            x_flat,
+            selected_experts.astype(jnp.int32),
+            combine_weights,
+            mesh=get_abstract_mesh(),
+        )
+
+        routed = rearrange(routed_flat, "(b s) d -> b s d", b=b, s=s)
+        routed = reshard(routed, _batch_spec())
+        return routed, router_stats
+
+
+class Block(eqx.Module):
+    rms_attn: RMSNorm
+    attn_gated_norm: GatedNorm
+    attn: CausalSelfAttention
+    rms_mlp: RMSNorm
+    mlp_gated_norm: GatedNorm
+    mlp: MoEMLP
+    shared: DenseMLP | None
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "Block":
+        attn_key, mlp_key, shared_key, gn_attn_key, gn_mlp_key = random.split(key, 5)
+        shared = None
+        if cfg.shared_expert_intermediate_dim > 0:
+            shared = DenseMLP.init(
+                cfg.hidden_dim, cfg.shared_expert_intermediate_dim, cfg.initializer_std, key=shared_key
+            )
+        return Block(
+            rms_attn=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            attn_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=gn_attn_key),
+            attn=CausalSelfAttention.init(cfg, key=attn_key),
+            rms_mlp=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            mlp_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=gn_mlp_key),
+            mlp=MoEMLP.init(cfg, key=mlp_key),
+            shared=shared,
+        )
+
+    @named_call
+    def __call__(
+        self,
+        x: Float[Array, "B S D"],
+        mask: AttentionMask | jax.Array,
+    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        attn_in = self.attn_gated_norm(self.rms_attn(x))
+        x = _batch_reshard(x + self.attn(attn_in, mask))
+        mlp_in = _batch_reshard(self.mlp_gated_norm(self.rms_mlp(x)))
+        mlp_out, router_stats = self.mlp(mlp_in)
+        if self.shared is not None:
+            mlp_out = mlp_out + self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
+        x = x + mlp_out
+        return x, router_stats
+
+
+class Transformer(eqx.Module):
+    token_embed: jax.Array
+    embed_norm: RMSNorm
+    embed_gated_norm: GatedNorm
+    output_proj: jax.Array
+    blocks: tuple[Block, ...]
+    final_norm: RMSNorm
+    final_gated_norm: GatedNorm
+    config: GrugModelConfig = eqx.field(static=True)
+
+    @staticmethod
+    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "Transformer":
+        embed_key, out_key, embed_gn_key, final_gn_key, *block_keys = random.split(key, cfg.num_layers + 4)
+        token_embed = reshard(
+            _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
+        )
+        output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head)
+        blocks = tuple(Block.init(cfg, key=block_keys[i]) for i in range(cfg.num_layers))
+        return Transformer(
+            token_embed=token_embed,
+            embed_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            embed_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=embed_gn_key),
+            output_proj=output_proj,
+            blocks=blocks,
+            final_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
+            final_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=final_gn_key),
+            config=cfg,
+        )
+
+    @named_call
+    def __call__(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        if mask is None:
+            mask = AttentionMask.causal()
+
+        batch_spec = _batch_spec()
+        cfg = self.config
+        hidden = self.token_embed.at[token_ids].get(out_sharding=batch_spec)
+        hidden = self.embed_gated_norm(self.embed_norm(hidden))
+
+        if not isinstance(mask, AttentionMask):
+            mask = AttentionMask.causal()
+        short_mask, long_mask = _layer_attention_masks(mask, sliding_window=cfg.sliding_window)
+
+        if cfg.remat_mode == "save_moe":
+            remat_policy = jax.checkpoint_policies.save_only_these_names(*MOE_REMAT_SAVE_NAMES)
+        else:
+            remat_policy = None
+
+        moe_router_stats: list[dict[str, jax.Array]] = []
+        for i, block in enumerate(self.blocks):
+            layer_mask = long_mask if i % 4 == 3 else short_mask
+            hidden, router_stats = eqx.filter_checkpoint(block, policy=remat_policy)(hidden, layer_mask)
+            moe_router_stats.append(router_stats)
+
+        router_metrics = {
+            "routing_entropy_per_layer": jnp.stack([s["routing_entropy"] for s in moe_router_stats], axis=0),
+            "routing_counts_per_layer": jnp.stack([s["routing_counts"] for s in moe_router_stats], axis=0),
+            "load_balancing_loss_per_layer": jnp.stack([s["load_balancing_loss"] for s in moe_router_stats], axis=0),
+            "router_z_loss_per_layer": jnp.stack([s["router_z_loss"] for s in moe_router_stats], axis=0),
+            "qb_beta_per_layer": jnp.stack([s["qb_beta"] for s in moe_router_stats], axis=0),
+        }
+        hidden = self.final_gated_norm(self.final_norm(hidden))
+        return hidden, router_metrics
+
+    @named_call
+    def logits(
+        self,
+        token_ids: Int[Array, "B S"],
+        mask: AttentionMask | jax.Array | None = None,
+    ) -> Float[Array, "B S V"]:
+        batch_spec = _batch_spec()
+        hidden, _ = self(token_ids, mask=mask)
+        return jnp.einsum("bsh,hd->bsd", hidden, self.output_proj, out_sharding=batch_spec)
+
+    def next_token_loss(
+        self,
+        token_ids: Int[Array, "B S"],
+        loss_weight: Float[Array, "B S"],
+        *,
+        mask: AttentionMask | jax.Array | None = None,
+        reduction: str = "mean",
+        logsumexp_weight: float | None = None,
+        loss_dtype: jnp.dtype = jnp.float32,
+        return_router_metrics: bool = False,
+    ) -> jax.Array | tuple[jax.Array, dict[str, jax.Array | SummaryStats]]:
+        hidden, router_metrics = self(token_ids, mask=mask)
+        labels = jnp.concatenate([token_ids[:, 1:], token_ids[:, :1] * 0], axis=1).astype(jnp.int32)
+        loss_weight = loss_weight.astype(loss_dtype)
+
+        cross_entropy_loss = fused_linear_softmax_cross_entropy_loss(
+            hidden,
+            self.output_proj,
+            labels,
+            weight=loss_weight,
+            reduction=reduction,
+            logsumexp_weight=logsumexp_weight,
+            dtype=loss_dtype,
+        )
+        # No load-balancing loss; router z-loss only.
+        num_moe_layers = router_metrics["router_z_loss_per_layer"].shape[0]
+        rzl = jnp.sum(router_metrics["router_z_loss_per_layer"]) / num_moe_layers
+        aux_loss = self.config.router_z_loss_coef * rzl
+        loss = cross_entropy_loss + aux_loss if reduction != "none" else cross_entropy_loss
+        if return_router_metrics:
+            summarized_metrics = _summarize_router_metrics(router_metrics)
+            summarized_metrics["train/cross_entropy_loss"] = cross_entropy_loss
+            summarized_metrics["train/router/aux_loss_weighted"] = aux_loss
+            return loss, summarized_metrics
+        return loss
+
+
+def _init_weight(key: PRNGKeyArray, shape: tuple[int, ...], std: float) -> Float[Array, "..."]:
+    return std * random.truncated_normal(key, -3, 3, shape)
+
+
+def debug_mesh_and_token_pspec(num_devices: int) -> tuple[jax.sharding.AbstractMesh, P]:
+    """Return a small abstract mesh and token sharding for lowering contract tests."""
+    if num_devices <= 0:
+        raise ValueError(f"num_devices must be positive, got {num_devices}")
+    expert = 2 if num_devices % 2 == 0 else 1
+    data = max(1, num_devices // expert)
+    mesh = jax.sharding.AbstractMesh(
+        axis_sizes=(1, data, expert, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(
+            jax.sharding.AxisType.Explicit,
+            jax.sharding.AxisType.Explicit,
+            jax.sharding.AxisType.Explicit,
+            jax.sharding.AxisType.Explicit,
+        ),
+    )
+    return mesh, P(("replica_dcn", "data", "expert"), None)
+
+
+__all__ = [
+    "Block",
+    "CausalSelfAttention",
+    "DenseMLP",
+    "GatedNorm",
+    "GrugModelConfig",
+    "MoEMLP",
+    "MoeActivation",
+    "RMSNorm",
+    "Transformer",
+    "debug_mesh_and_token_pspec",
+]

--- a/experiments/grug/reentrant/model.py
+++ b/experiments/grug/reentrant/model.py
@@ -122,6 +122,14 @@ class GrugModelConfig:
     the iteration step and core-layer index. Gives one weight-tied block a
     coarse-to-fine schedule at ~free parameter cost. Initialized to identity, so at
     step 0 the model is numerically identical to the iteration_film=False variant."""
+    randomize_recurrence: bool = False
+    """E3: when True, training samples the core loop count per step from
+    recurrence_choices (the model forward is called with a per-step recurrence
+    override). Trains one weight-tied core to be correct at many depths, enabling
+    test-time depth scaling. recurrence_steps stays the default/eval loop count."""
+    recurrence_choices: tuple[int, ...] = ()
+    """E3: the set of loop counts to sample among when randomize_recurrence is True
+    (e.g. (2, 4, 8)). Empty unless randomize_recurrence."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
@@ -134,6 +142,13 @@ class GrugModelConfig:
             raise ValueError("recurrence_steps must be >= 1")
         if self.recurrence_steps > 1 and self.num_core_layers <= 0:
             raise ValueError("recurrence_steps > 1 requires at least one core layer")
+        if self.randomize_recurrence:
+            if not self.recurrence_choices:
+                raise ValueError("randomize_recurrence requires a non-empty recurrence_choices")
+            if any(choice < 1 for choice in self.recurrence_choices):
+                raise ValueError("recurrence_choices must all be >= 1")
+            if self.num_core_layers < 1:
+                raise ValueError("randomize_recurrence requires at least one core layer")
         if self.num_heads % self.num_kv_heads != 0:
             raise ValueError("num_heads must be divisible by num_kv_heads for grouped-query attention")
         if self.vocab_size <= 0:
@@ -590,6 +605,7 @@ class Transformer(eqx.Module):
         self,
         token_ids: Int[Array, "B S"],
         mask: AttentionMask | jax.Array | None = None,
+        recurrence_steps: int | None = None,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         if mask is None:
             mask = AttentionMask.causal()
@@ -640,12 +656,19 @@ class Transformer(eqx.Module):
             per_block_stats.append(stats)
             eff_idx += 1
 
+        # E3: a per-call override of the core loop count (randomized depth during
+        # training; deeper-than-trained eval at test time). None reproduces the
+        # config default exactly, so E0/E1/E2 are unchanged.
+        n_recurrence = recurrence_steps if recurrence_steps is not None else cfg.recurrence_steps
         core_iter_stats: list[list[dict[str, jax.Array]]] = [[] for _ in core_blocks]
-        for t in range(cfg.recurrence_steps):
+        for t in range(n_recurrence):
             for c, block in enumerate(core_blocks):
                 film = None
                 if self.core_film_scale is not None:
-                    film = (self.core_film_scale[t, c], self.core_film_shift[t, c])
+                    # The FiLM tables are sized for cfg.recurrence_steps; for an
+                    # override deeper than trained, reuse the last iteration's FiLM.
+                    film_t = min(t, cfg.recurrence_steps - 1)
+                    film = (self.core_film_scale[film_t, c], self.core_film_shift[film_t, c])
                 hidden, stats = apply_block(block, hidden, eff_idx, film)
                 core_iter_stats[c].append(stats)
                 eff_idx += 1
@@ -671,9 +694,10 @@ class Transformer(eqx.Module):
         self,
         token_ids: Int[Array, "B S"],
         mask: AttentionMask | jax.Array | None = None,
+        recurrence_steps: int | None = None,
     ) -> Float[Array, "B S V"]:
         batch_spec = _batch_spec()
-        hidden, _ = self(token_ids, mask=mask)
+        hidden, _ = self(token_ids, mask=mask, recurrence_steps=recurrence_steps)
         return jnp.einsum("bsh,hd->bsd", hidden, self.output_proj, out_sharding=batch_spec)
 
     def next_token_loss(
@@ -686,8 +710,9 @@ class Transformer(eqx.Module):
         logsumexp_weight: float | None = None,
         loss_dtype: jnp.dtype = jnp.float32,
         return_router_metrics: bool = False,
+        recurrence_steps: int | None = None,
     ) -> jax.Array | tuple[jax.Array, dict[str, jax.Array | SummaryStats]]:
-        hidden, router_metrics = self(token_ids, mask=mask)
+        hidden, router_metrics = self(token_ids, mask=mask, recurrence_steps=recurrence_steps)
         labels = jnp.concatenate([token_ids[:, 1:], token_ids[:, :1] * 0], axis=1).astype(jnp.int32)
         loss_weight = loss_weight.astype(loss_dtype)
 

--- a/experiments/grug/reentrant/model.py
+++ b/experiments/grug/reentrant/model.py
@@ -108,10 +108,26 @@ class GrugModelConfig:
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
     backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
     backward skips re-running expert dispatch and its EP collectives."""
+    num_prelude_layers: int = 0
+    """Re-entrant structure: leading unique (non-looped) layers. 0 = no prelude."""
+    num_coda_layers: int = 0
+    """Re-entrant structure: trailing unique (non-looped) layers. 0 = no coda."""
+    recurrence_steps: int = 1
+    """Times the shared core stack (layers between prelude and coda) is applied per
+    forward. 1 = plain stack (no recurrence); >1 = weight-tied re-entrant looping.
+    Effective depth = num_prelude_layers + num_core_layers * recurrence_steps + num_coda_layers."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
         _ = self.inferred_head_dim
+        if self.num_prelude_layers < 0 or self.num_coda_layers < 0:
+            raise ValueError("num_prelude_layers and num_coda_layers must be non-negative")
+        if self.num_prelude_layers + self.num_coda_layers > self.num_layers:
+            raise ValueError("num_prelude_layers + num_coda_layers must be <= num_layers")
+        if self.recurrence_steps < 1:
+            raise ValueError("recurrence_steps must be >= 1")
+        if self.recurrence_steps > 1 and self.num_core_layers <= 0:
+            raise ValueError("recurrence_steps > 1 requires at least one core layer")
         if self.num_heads % self.num_kv_heads != 0:
             raise ValueError("num_heads must be divisible by num_kv_heads for grouped-query attention")
         if self.vocab_size <= 0:
@@ -137,6 +153,16 @@ class GrugModelConfig:
                 f"hidden_dim={self.hidden_dim} is not divisible by num_heads={self.num_heads}; set head_dim explicitly"
             )
         return self.hidden_dim // self.num_heads
+
+    @property
+    def num_core_layers(self) -> int:
+        """Unique layers in the shared, looped core (everything between prelude and coda)."""
+        return self.num_layers - self.num_prelude_layers - self.num_coda_layers
+
+    @property
+    def effective_depth(self) -> int:
+        """Number of block applications per forward (compute depth)."""
+        return self.num_prelude_layers + self.num_core_layers * self.recurrence_steps + self.num_coda_layers
 
 
 def rms_norm(x: jax.Array, eps: float = 1e-6) -> jax.Array:
@@ -488,6 +514,19 @@ class Block(eqx.Module):
         return x, router_stats
 
 
+def _mean_router_stats(stats_per_iter: list[dict[str, jax.Array]]) -> dict[str, jax.Array]:
+    """Mean-aggregate a shared core block's per-iteration router stats into one entry.
+
+    A weight-tied core block is applied ``recurrence_steps`` times per forward but has a
+    single set of router params; collapsing its per-iteration stats to one keeps
+    ``qb_beta_per_layer`` (and the rest of ``router_metrics``) 1:1 with the unique blocks
+    that ``_apply_qb_betas`` nudges. With a single iteration this is the identity.
+    """
+    if len(stats_per_iter) == 1:
+        return stats_per_iter[0]
+    return {k: jnp.mean(jnp.stack([s[k] for s in stats_per_iter], axis=0), axis=0) for k in stats_per_iter[0]}
+
+
 class Transformer(eqx.Module):
     token_embed: jax.Array
     embed_norm: RMSNorm
@@ -540,18 +579,52 @@ class Transformer(eqx.Module):
         else:
             remat_policy = None
 
-        moe_router_stats: list[dict[str, jax.Array]] = []
-        for i, block in enumerate(self.blocks):
-            layer_mask = long_mask if i % 4 == 3 else short_mask
-            hidden, router_stats = eqx.filter_checkpoint(block, policy=remat_policy)(hidden, layer_mask)
-            moe_router_stats.append(router_stats)
+        # Re-entrant structure: prelude blocks (once) -> shared core stack (looped
+        # recurrence_steps times, weight-tied) -> coda blocks (once). With the
+        # default config (prelude=coda=0, recurrence_steps=1) this is exactly the
+        # plain stack over self.blocks. `self.blocks` stays a flat tuple of the
+        # unique blocks, so per-block router stats (and the QB bias update in
+        # _apply_qb_betas) remain 1:1 with the unique blocks: a looped core block's
+        # per-iteration stats are mean-aggregated back to a single entry below.
+        prelude = cfg.num_prelude_layers
+        core = cfg.num_core_layers
+        prelude_blocks = self.blocks[:prelude]
+        core_blocks = self.blocks[prelude : prelude + core]
+        coda_blocks = self.blocks[prelude + core :]
+
+        # `eff_idx` counts block applications (effective depth) so the every-4th-layer
+        # long-attention pattern is preserved across the unrolled core.
+        eff_idx = 0
+
+        def apply_block(block: "Block", h: jax.Array, idx: int) -> tuple[jax.Array, dict[str, jax.Array]]:
+            layer_mask = long_mask if idx % 4 == 3 else short_mask
+            return eqx.filter_checkpoint(block, policy=remat_policy)(h, layer_mask)
+
+        per_block_stats: list[dict[str, jax.Array]] = []
+        for block in prelude_blocks:
+            hidden, stats = apply_block(block, hidden, eff_idx)
+            per_block_stats.append(stats)
+            eff_idx += 1
+
+        core_iter_stats: list[list[dict[str, jax.Array]]] = [[] for _ in core_blocks]
+        for _ in range(cfg.recurrence_steps):
+            for c, block in enumerate(core_blocks):
+                hidden, stats = apply_block(block, hidden, eff_idx)
+                core_iter_stats[c].append(stats)
+                eff_idx += 1
+        per_block_stats.extend(_mean_router_stats(s) for s in core_iter_stats)
+
+        for block in coda_blocks:
+            hidden, stats = apply_block(block, hidden, eff_idx)
+            per_block_stats.append(stats)
+            eff_idx += 1
 
         router_metrics = {
-            "routing_entropy_per_layer": jnp.stack([s["routing_entropy"] for s in moe_router_stats], axis=0),
-            "routing_counts_per_layer": jnp.stack([s["routing_counts"] for s in moe_router_stats], axis=0),
-            "load_balancing_loss_per_layer": jnp.stack([s["load_balancing_loss"] for s in moe_router_stats], axis=0),
-            "router_z_loss_per_layer": jnp.stack([s["router_z_loss"] for s in moe_router_stats], axis=0),
-            "qb_beta_per_layer": jnp.stack([s["qb_beta"] for s in moe_router_stats], axis=0),
+            "routing_entropy_per_layer": jnp.stack([s["routing_entropy"] for s in per_block_stats], axis=0),
+            "routing_counts_per_layer": jnp.stack([s["routing_counts"] for s in per_block_stats], axis=0),
+            "load_balancing_loss_per_layer": jnp.stack([s["load_balancing_loss"] for s in per_block_stats], axis=0),
+            "router_z_loss_per_layer": jnp.stack([s["router_z_loss"] for s in per_block_stats], axis=0),
+            "qb_beta_per_layer": jnp.stack([s["qb_beta"] for s in per_block_stats], axis=0),
         }
         hidden = self.final_gated_norm(self.final_norm(hidden))
         return hidden, router_metrics

--- a/experiments/grug/reentrant/model.py
+++ b/experiments/grug/reentrant/model.py
@@ -154,6 +154,20 @@ class GrugModelConfig:
     anytime_supervision_weight: float = 1.0
     """E4: relative weight on the averaged per-iteration deep-supervision CE term.
     Only used when anytime_supervision is True."""
+    ponder_halting: bool = False
+    """E7 (PonderNet): when True and the core is looped, a learned per-token halting
+    head reads each per-iteration readout to predict a halting probability; training
+    adds an expected-over-halting CE term plus a KL-to-geometric-prior regularizer.
+    This is ADDED to the standard final CE (not a replacement), so the eval path and
+    the comparable paloma metric are unchanged. Training-only; adds one (hidden_dim,)
+    halt-head vector (routes to plain Adam). Builds on the same per-iteration readout
+    plumbing as anytime_supervision (E4)."""
+    ponder_loss_weight: float = 1.0
+    """E7: weight on the expected-over-halting reconstruction CE term."""
+    ponder_kl_weight: float = 0.01
+    """E7: weight (beta) on the KL(halting-dist || geometric-prior) regularizer."""
+    ponder_prior_lambda: float = 0.2
+    """E7: geometric-prior halting rate (expected halting step ~ 1/lambda)."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
@@ -615,6 +629,7 @@ class Transformer(eqx.Module):
     core_film_scale: jax.Array | None
     core_film_shift: jax.Array | None
     core_router_bias: jax.Array | None
+    halt_head: jax.Array | None
     config: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
@@ -645,6 +660,13 @@ class Transformer(eqx.Module):
         if cfg.depth_conditioned_routing and cfg.max_trained_recurrence > 1:
             bias_shape = (cfg.max_trained_recurrence, cfg.num_core_layers, cfg.num_experts)
             core_router_bias = reshard(jnp.zeros(bias_shape, dtype=jnp.float32), P(None, None, None))
+        # E7 (PonderNet): per-token halting head read off each per-iteration readout.
+        # Zero-init and consumes no PRNG key, so every other param stays bit-identical
+        # to the ponder_halting=False model. Shape (hidden_dim,) so ndim==1 routes it
+        # to plain Adam (AdamH divides by the param norm -> 0/0 NaN on a zero init).
+        halt_head = None
+        if cfg.ponder_halting and cfg.max_trained_recurrence > 1:
+            halt_head = reshard(jnp.zeros((cfg.hidden_dim,), dtype=jnp.float32), P(None))
         return Transformer(
             token_embed=token_embed,
             embed_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
@@ -656,6 +678,7 @@ class Transformer(eqx.Module):
             core_film_scale=core_film_scale,
             core_film_shift=core_film_shift,
             core_router_bias=core_router_bias,
+            halt_head=halt_head,
             config=cfg,
         )
 
@@ -734,7 +757,12 @@ class Transformer(eqx.Module):
         # coda (cheap), so they regularize the core to be decodable at every depth;
         # the final output still flows through the coda below.
         track_anytime = cfg.anytime_supervision and cfg.max_trained_recurrence > 1
+        # E7 (PonderNet): collect a per-iteration halting logit (readout . halt_head)
+        # alongside the readouts. Needs the same per-iteration readout plumbing as E4.
+        track_ponder = cfg.ponder_halting and cfg.max_trained_recurrence > 1
+        collect_readouts = track_anytime or track_ponder
         anytime_readouts: list[jax.Array] = []
+        ponder_halt_logits: list[jax.Array] = []
         for t in range(n_recurrence):
             for c, block in enumerate(core_blocks):
                 film = None
@@ -758,8 +786,11 @@ class Transformer(eqx.Module):
                 den = jnp.sum(jnp.square(x_prev.astype(jnp.float32)), axis=-1) + cfg.layer_norm_eps
                 consistency_accum = consistency_accum + jnp.mean(num / den)
                 x_prev = hidden
-            if track_anytime:
-                anytime_readouts.append(self.final_gated_norm(self.final_norm(hidden)))
+            if collect_readouts:
+                readout = self.final_gated_norm(self.final_norm(hidden))
+                anytime_readouts.append(readout)
+                if track_ponder:
+                    ponder_halt_logits.append(jnp.einsum("bsd,d->bs", readout, self.halt_head))
         per_block_stats.extend(_mean_router_stats(s) for s in core_iter_stats)
 
         for block in coda_blocks:
@@ -776,11 +807,15 @@ class Transformer(eqx.Module):
         }
         if track_consistency:
             router_metrics["core_consistency"] = consistency_accum / n_recurrence
-        if track_anytime:
+        if collect_readouts:
             # (n_recurrence, B, S, D). Consumed by next_token_loss (training only)
             # and dropped before _summarize_router_metrics, so it never escapes the
-            # train_step metrics dict.
+            # train_step metrics dict. Present whenever ponder is on too, since the
+            # PonderNet recon term reads each per-iteration readout's CE.
             router_metrics["anytime_readouts"] = jnp.stack(anytime_readouts, axis=0)
+        if track_ponder:
+            # (n_recurrence, B, S). Per-iteration halting logits for the PonderNet loss.
+            router_metrics["ponder_halt_logits"] = jnp.stack(ponder_halt_logits, axis=0)
         hidden = self.final_gated_norm(self.final_norm(hidden))
         return hidden, router_metrics
 
@@ -855,6 +890,61 @@ class Transformer(eqx.Module):
             anytime_ce = ce_sum / n_iter
             anytime_ce_weighted = self.config.anytime_supervision_weight * anytime_ce
             loss = loss + anytime_ce_weighted
+        # E7 (PonderNet): training-only halting loss. Builds a per-token halting
+        # distribution p_t over the R core iterations from the learned halting head,
+        # then adds an expected-over-halting CE (recon) plus a KL-to-geometric-prior
+        # regularizer. ADDED to the standard final CE (not a replacement), so the eval
+        # (reduction="none") path and the comparable metric stay byte-identical.
+        ponder_recon = None
+        ponder_kl = None
+        expected_halt_step = None
+        if reduction != "none" and self.config.ponder_halting and "ponder_halt_logits" in router_metrics:
+            readouts = router_metrics["anytime_readouts"]  # (R, B, S, D)
+            halt_logits = router_metrics["ponder_halt_logits"]  # (R, B, S)
+            n_recurrence = readouts.shape[0]
+            # Halting distribution p_t (R, B, S), Sum_t p_t == 1 exactly: the last
+            # step absorbs all remaining mass (forced halt). remain_t is the exclusive
+            # cumulative product of (1 - lam) so remain_0 == 1.
+            lam = jax.nn.sigmoid(halt_logits.astype(loss_dtype))
+            one_minus = 1.0 - lam
+            incl = jnp.cumprod(one_minus, axis=0)
+            # remain_t = exclusive cumprod of (1 - lam) (remain_0 = 1). Build it by
+            # shifting `incl` down one step and seeding step 0 with ones; `ones_like`
+            # inherits incl's batch sharding so the concatenate stays well-sharded.
+            ones = jnp.ones_like(incl[:1])
+            remain = jnp.concatenate([ones, incl[:-1]], axis=0)
+            p = lam * remain
+            p = p.at[-1].set(remain[-1])
+            # Raw (unweighted) per-position CE for each per-iteration readout (R, B, S).
+            ce_list = [
+                fused_linear_softmax_cross_entropy_loss(
+                    readouts[t],
+                    self.output_proj,
+                    labels,
+                    weight=None,
+                    reduction="none",
+                    dtype=loss_dtype,
+                )
+                for t in range(n_recurrence)
+            ]
+            ce = jnp.stack(ce_list, axis=0)  # (R, B, S)
+            recon_per_pos = jnp.sum(p * ce, axis=0)  # (B, S)
+            denom = jnp.sum(loss_weight)
+            ponder_recon = jnp.sum(loss_weight * recon_per_pos) / denom
+            # Geometric prior g_t = lp*(1-lp)^t for t<R-1, g_{R-1}=(1-lp)^{R-1}; Sum_t g_t == 1.
+            lp = jnp.asarray(self.config.ponder_prior_lambda, dtype=loss_dtype)
+            t_idx = jnp.arange(n_recurrence, dtype=loss_dtype)
+            prior = lp * (1.0 - lp) ** t_idx
+            prior = prior.at[-1].set((1.0 - lp) ** (n_recurrence - 1))
+            eps = 1e-8
+            g = prior.reshape((n_recurrence, 1, 1))
+            kl_per_pos = jnp.sum(p * (jnp.log(p + eps) - jnp.log(g + eps)), axis=0)  # (B, S)
+            ponder_kl = jnp.sum(loss_weight * kl_per_pos) / denom
+            # Diagnostic: loss_weight-weighted mean of E_t[t] = Sum_t p_t * t over positions.
+            steps = jnp.arange(n_recurrence, dtype=p.dtype).reshape((n_recurrence, 1, 1))
+            expected_halt_per_pos = jnp.sum(p * steps, axis=0)  # (B, S)
+            expected_halt_step = jnp.sum(loss_weight * expected_halt_per_pos) / denom
+            loss = loss + self.config.ponder_loss_weight * ponder_recon + self.config.ponder_kl_weight * ponder_kl
         if return_router_metrics:
             summarized_metrics = _summarize_router_metrics(router_metrics)
             summarized_metrics["train/cross_entropy_loss"] = cross_entropy_loss
@@ -865,6 +955,10 @@ class Transformer(eqx.Module):
             if anytime_ce is not None:
                 summarized_metrics["train/anytime_ce"] = anytime_ce
                 summarized_metrics["train/anytime_ce_weighted"] = anytime_ce_weighted
+            if ponder_recon is not None:
+                summarized_metrics["train/ponder_recon"] = ponder_recon
+                summarized_metrics["train/ponder_kl"] = ponder_kl
+                summarized_metrics["train/ponder_expected_halt_step"] = expected_halt_step
             return loss, summarized_metrics
         return loss
 

--- a/experiments/grug/reentrant/model.py
+++ b/experiments/grug/reentrant/model.py
@@ -130,6 +130,11 @@ class GrugModelConfig:
     recurrence_choices: tuple[int, ...] = ()
     """E3: the set of loop counts to sample among when randomize_recurrence is True
     (e.g. (2, 4, 8)). Empty unless randomize_recurrence."""
+    core_consistency_weight: float = 0.0
+    """E5: weight on the core-consistency penalty (mean normalized squared delta
+    between consecutive core-loop hidden states). 0 disables it (E0-E3 unchanged).
+    >0 pulls the weight-tied core toward a contractive/fixed-point map so extra
+    test-time loops stop drifting."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
@@ -661,6 +666,12 @@ class Transformer(eqx.Module):
         # config default exactly, so E0/E1/E2 are unchanged.
         n_recurrence = recurrence_steps if recurrence_steps is not None else cfg.recurrence_steps
         core_iter_stats: list[list[dict[str, jax.Array]]] = [[] for _ in core_blocks]
+        # E5: accumulate the per-iteration normalized squared delta between
+        # consecutive core-loop states. Gated on the static config so E0-E3 trace
+        # to the identical jaxpr (no penalty op, no extra metric key).
+        track_consistency = cfg.core_consistency_weight > 0
+        consistency_accum = jnp.zeros((), dtype=jnp.float32)
+        x_prev = hidden
         for t in range(n_recurrence):
             for c, block in enumerate(core_blocks):
                 film = None
@@ -672,6 +683,12 @@ class Transformer(eqx.Module):
                 hidden, stats = apply_block(block, hidden, eff_idx, film)
                 core_iter_stats[c].append(stats)
                 eff_idx += 1
+            if track_consistency:
+                delta = hidden - x_prev
+                num = jnp.sum(jnp.square(delta.astype(jnp.float32)), axis=-1)
+                den = jnp.sum(jnp.square(x_prev.astype(jnp.float32)), axis=-1) + cfg.layer_norm_eps
+                consistency_accum = consistency_accum + jnp.mean(num / den)
+                x_prev = hidden
         per_block_stats.extend(_mean_router_stats(s) for s in core_iter_stats)
 
         for block in coda_blocks:
@@ -686,6 +703,8 @@ class Transformer(eqx.Module):
             "router_z_loss_per_layer": jnp.stack([s["router_z_loss"] for s in per_block_stats], axis=0),
             "qb_beta_per_layer": jnp.stack([s["qb_beta"] for s in per_block_stats], axis=0),
         }
+        if track_consistency:
+            router_metrics["core_consistency"] = consistency_accum / n_recurrence
         hidden = self.final_gated_norm(self.final_norm(hidden))
         return hidden, router_metrics
 
@@ -730,10 +749,20 @@ class Transformer(eqx.Module):
         rzl = jnp.sum(router_metrics["router_z_loss_per_layer"]) / num_moe_layers
         aux_loss = self.config.router_z_loss_coef * rzl
         loss = cross_entropy_loss + aux_loss if reduction != "none" else cross_entropy_loss
+        # E5: training-only core-consistency penalty. Gated on the static config so
+        # weight==0 (E0-E3) leaves the eval (reduction="none") path untouched.
+        consistency_weighted = None
+        if reduction != "none" and self.config.core_consistency_weight > 0:
+            consistency = router_metrics["core_consistency"]
+            consistency_weighted = self.config.core_consistency_weight * consistency
+            loss = loss + consistency_weighted
         if return_router_metrics:
             summarized_metrics = _summarize_router_metrics(router_metrics)
             summarized_metrics["train/cross_entropy_loss"] = cross_entropy_loss
             summarized_metrics["train/router/aux_loss_weighted"] = aux_loss
+            if "core_consistency" in router_metrics:
+                summarized_metrics["train/core_consistency"] = router_metrics["core_consistency"]
+                summarized_metrics["train/core_consistency_weighted"] = consistency_weighted
             return loss, summarized_metrics
         return loss
 

--- a/experiments/grug/reentrant/model.py
+++ b/experiments/grug/reentrant/model.py
@@ -116,6 +116,12 @@ class GrugModelConfig:
     """Times the shared core stack (layers between prelude and coda) is applied per
     forward. 1 = plain stack (no recurrence); >1 = weight-tied re-entrant looping.
     Effective depth = num_prelude_layers + num_core_layers * recurrence_steps + num_coda_layers."""
+    iteration_film: bool = False
+    """When True and recurrence_steps > 1, modulate the shared core block per loop
+    iteration with a learned FiLM (adaLN-style per-feature scale+shift) indexed by
+    the iteration step and core-layer index. Gives one weight-tied block a
+    coarse-to-fine schedule at ~free parameter cost. Initialized to identity, so at
+    step 0 the model is numerically identical to the iteration_film=False variant."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
@@ -503,10 +509,19 @@ class Block(eqx.Module):
         self,
         x: Float[Array, "B S D"],
         mask: AttentionMask | jax.Array,
+        film: tuple[jax.Array, jax.Array] | None = None,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        # `film` is an optional (scale, shift) pair, each shape (D,), broadcast over
+        # (B, S, D). The same modulation is applied after both gated-norms so a
+        # weight-tied core block can be told which loop iteration it is on (E2).
         attn_in = self.attn_gated_norm(self.rms_attn(x))
+        if film is not None:
+            scale, shift = film
+            attn_in = attn_in * (1.0 + scale) + shift
         x = _batch_reshard(x + self.attn(attn_in, mask))
         mlp_in = _batch_reshard(self.mlp_gated_norm(self.rms_mlp(x)))
+        if film is not None:
+            mlp_in = mlp_in * (1.0 + scale) + shift
         mlp_out, router_stats = self.mlp(mlp_in)
         if self.shared is not None:
             mlp_out = mlp_out + self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
@@ -535,6 +550,8 @@ class Transformer(eqx.Module):
     blocks: tuple[Block, ...]
     final_norm: RMSNorm
     final_gated_norm: GatedNorm
+    core_film_scale: jax.Array | None
+    core_film_shift: jax.Array | None
     config: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
@@ -545,6 +562,16 @@ class Transformer(eqx.Module):
         )
         output_proj = reshard(_init_weight(out_key, (cfg.hidden_dim, cfg.vocab_size), cfg.initializer_std), Plm_head)
         blocks = tuple(Block.init(cfg, key=block_keys[i]) for i in range(cfg.num_layers))
+        # Per-iteration FiLM tables for the shared core block. Zeros => identity
+        # (Block applies x*(1+scale)+shift), so consuming no PRNG key keeps every
+        # other param bit-identical to the iteration_film=False model. Replicated
+        # like RMSNorm weights: tiny per-feature params, no sharding.
+        core_film_scale = None
+        core_film_shift = None
+        if cfg.iteration_film and cfg.recurrence_steps > 1:
+            film_shape = (cfg.recurrence_steps, cfg.num_core_layers, cfg.hidden_dim)
+            core_film_scale = reshard(jnp.zeros(film_shape, dtype=jnp.float32), P(None, None, None))
+            core_film_shift = reshard(jnp.zeros(film_shape, dtype=jnp.float32), P(None, None, None))
         return Transformer(
             token_embed=token_embed,
             embed_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
@@ -553,6 +580,8 @@ class Transformer(eqx.Module):
             blocks=blocks,
             final_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
             final_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=final_gn_key),
+            core_film_scale=core_film_scale,
+            core_film_shift=core_film_shift,
             config=cfg,
         )
 
@@ -596,9 +625,14 @@ class Transformer(eqx.Module):
         # long-attention pattern is preserved across the unrolled core.
         eff_idx = 0
 
-        def apply_block(block: "Block", h: jax.Array, idx: int) -> tuple[jax.Array, dict[str, jax.Array]]:
+        def apply_block(
+            block: "Block",
+            h: jax.Array,
+            idx: int,
+            film: tuple[jax.Array, jax.Array] | None = None,
+        ) -> tuple[jax.Array, dict[str, jax.Array]]:
             layer_mask = long_mask if idx % 4 == 3 else short_mask
-            return eqx.filter_checkpoint(block, policy=remat_policy)(h, layer_mask)
+            return eqx.filter_checkpoint(block, policy=remat_policy)(h, layer_mask, film)
 
         per_block_stats: list[dict[str, jax.Array]] = []
         for block in prelude_blocks:
@@ -607,9 +641,12 @@ class Transformer(eqx.Module):
             eff_idx += 1
 
         core_iter_stats: list[list[dict[str, jax.Array]]] = [[] for _ in core_blocks]
-        for _ in range(cfg.recurrence_steps):
+        for t in range(cfg.recurrence_steps):
             for c, block in enumerate(core_blocks):
-                hidden, stats = apply_block(block, hidden, eff_idx)
+                film = None
+                if self.core_film_scale is not None:
+                    film = (self.core_film_scale[t, c], self.core_film_shift[t, c])
+                hidden, stats = apply_block(block, hidden, eff_idx, film)
                 core_iter_stats[c].append(stats)
                 eff_idx += 1
         per_block_stats.extend(_mean_router_stats(s) for s in core_iter_stats)

--- a/experiments/grug/reentrant/model.py
+++ b/experiments/grug/reentrant/model.py
@@ -135,6 +135,25 @@ class GrugModelConfig:
     between consecutive core-loop hidden states). 0 disables it (E0-E3 unchanged).
     >0 pulls the weight-tied core toward a contractive/fixed-point map so extra
     test-time loops stop drifting."""
+    depth_conditioned_routing: bool = False
+    """E6: when True and the core is looped, the MoE router gets a learned
+    per-(iteration, core-layer) additive logit bias, so each core traversal
+    activates a DIFFERENT expert mixture (depth-conditioned routing). This makes
+    the weight-tied loop a genuinely depth-varying map (f_t != f) instead of one
+    fixed residual map re-applied in place -- the structural failure E0-E5 hit.
+    Sized to max_trained_recurrence; eval at deeper R reuses the last entry.
+    Zero-init, so step 0 is numerically identical to the routing=False variant."""
+    anytime_supervision: bool = False
+    """E4: when True and the core is looped, training adds a deep-supervision CE
+    term read off the shared output head (final_norm + output_proj) after EACH
+    core iteration, averaged over iterations and weighted by
+    anytime_supervision_weight. Rewards monotonically-USEFUL refinement at every
+    depth (the fix for E5's freeze, which suppressed refinement) and makes every
+    depth anytime-decodable. Training-only: the eval (reduction='none') path and
+    the parameter tree are unchanged (no new params)."""
+    anytime_supervision_weight: float = 1.0
+    """E4: relative weight on the averaged per-iteration deep-supervision CE term.
+    Only used when anytime_supervision is True."""
     rope: RotaryConfig = dataclasses.field(default_factory=RotaryConfig)
 
     def __post_init__(self) -> None:
@@ -189,6 +208,18 @@ class GrugModelConfig:
     def effective_depth(self) -> int:
         """Number of block applications per forward (compute depth)."""
         return self.num_prelude_layers + self.num_core_layers * self.recurrence_steps + self.num_coda_layers
+
+    @property
+    def max_trained_recurrence(self) -> int:
+        """Deepest core-loop count the model is trained at.
+
+        Sizes the per-depth tables (FiLM, depth-conditioned router bias). With
+        randomized recurrence this is max(recurrence_choices); otherwise the
+        static recurrence_steps. Eval at a deeper R reuses the last table entry.
+        """
+        if self.randomize_recurrence and self.recurrence_choices:
+            return max(self.recurrence_choices)
+        return self.recurrence_steps
 
 
 def rms_norm(x: jax.Array, eps: float = 1e-6) -> jax.Array:
@@ -443,11 +474,19 @@ class MoEMLP(eqx.Module):
     def __call__(
         self,
         x: Float[Array, "B S D"],
+        router_logit_bias: jax.Array | None = None,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
+        # `router_logit_bias` (E6) is an optional learned per-expert (E,) additive bias,
+        # added to the router logits with gradient so it shapes BOTH expert
+        # selection and the sigmoid combine weights. Distinct from `router_bias`,
+        # the stop-gradient QB load-balancing threshold. None reproduces the
+        # depth_conditioned_routing=False path exactly (E0-E5 unchanged).
         b, s, _ = x.shape
         x_flat = rearrange(x, "b s d -> (b s) d")
         # Keep the router path in fp32 before top-k, softmax, and QB statistics.
         router_logits = jnp.einsum("td,de->te", x_flat, reshard(self.router, P(None, None))).astype(jnp.float32)
+        if router_logit_bias is not None:
+            router_logits = router_logits + router_logit_bias.astype(jnp.float32)
         biased_logits = router_logits + jax.lax.stop_gradient(self.router_bias)
         router_probs = jax.nn.softmax(router_logits, axis=-1)
         # Select top-(K+1) on biased logits; the (K+1)-th is the QB threshold alpha.
@@ -530,10 +569,13 @@ class Block(eqx.Module):
         x: Float[Array, "B S D"],
         mask: AttentionMask | jax.Array,
         film: tuple[jax.Array, jax.Array] | None = None,
+        router_logit_bias: jax.Array | None = None,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         # `film` is an optional (scale, shift) pair, each shape (D,), broadcast over
         # (B, S, D). The same modulation is applied after both gated-norms so a
         # weight-tied core block can be told which loop iteration it is on (E2).
+        # `router_logit_bias` (E6) is an optional per-expert (E,) additive bias on
+        # the MoE router logits for depth-conditioned expert selection.
         attn_in = self.attn_gated_norm(self.rms_attn(x))
         if film is not None:
             scale, shift = film
@@ -542,7 +584,7 @@ class Block(eqx.Module):
         mlp_in = _batch_reshard(self.mlp_gated_norm(self.rms_mlp(x)))
         if film is not None:
             mlp_in = mlp_in * (1.0 + scale) + shift
-        mlp_out, router_stats = self.mlp(mlp_in)
+        mlp_out, router_stats = self.mlp(mlp_in, router_logit_bias=router_logit_bias)
         if self.shared is not None:
             mlp_out = mlp_out + self.shared(mlp_in, activation=ActivationFunctionEnum.silu)
         x = x + mlp_out
@@ -572,6 +614,7 @@ class Transformer(eqx.Module):
     final_gated_norm: GatedNorm
     core_film_scale: jax.Array | None
     core_film_shift: jax.Array | None
+    core_router_bias: jax.Array | None
     config: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
@@ -592,6 +635,16 @@ class Transformer(eqx.Module):
             film_shape = (cfg.recurrence_steps, cfg.num_core_layers, cfg.hidden_dim)
             core_film_scale = reshard(jnp.zeros(film_shape, dtype=jnp.float32), P(None, None, None))
             core_film_shift = reshard(jnp.zeros(film_shape, dtype=jnp.float32), P(None, None, None))
+        # E6: per-(iteration, core-layer, expert) additive router-logit bias for
+        # depth-conditioned routing. Zeros => identity at init and consumes no PRNG
+        # key, so every other param stays bit-identical to the routing=False model.
+        # Sized to the deepest trained core depth; the matching name substring
+        # "router_bias" routes it to plain Adam (not AdamH), so the zero init can't
+        # trigger the AdamH 0/0 NaN that bit E2's FiLM.
+        core_router_bias = None
+        if cfg.depth_conditioned_routing and cfg.max_trained_recurrence > 1:
+            bias_shape = (cfg.max_trained_recurrence, cfg.num_core_layers, cfg.num_experts)
+            core_router_bias = reshard(jnp.zeros(bias_shape, dtype=jnp.float32), P(None, None, None))
         return Transformer(
             token_embed=token_embed,
             embed_norm=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),
@@ -602,6 +655,7 @@ class Transformer(eqx.Module):
             final_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=final_gn_key),
             core_film_scale=core_film_scale,
             core_film_shift=core_film_shift,
+            core_router_bias=core_router_bias,
             config=cfg,
         )
 
@@ -651,9 +705,10 @@ class Transformer(eqx.Module):
             h: jax.Array,
             idx: int,
             film: tuple[jax.Array, jax.Array] | None = None,
+            router_logit_bias: jax.Array | None = None,
         ) -> tuple[jax.Array, dict[str, jax.Array]]:
             layer_mask = long_mask if idx % 4 == 3 else short_mask
-            return eqx.filter_checkpoint(block, policy=remat_policy)(h, layer_mask, film)
+            return eqx.filter_checkpoint(block, policy=remat_policy)(h, layer_mask, film, router_logit_bias)
 
         per_block_stats: list[dict[str, jax.Array]] = []
         for block in prelude_blocks:
@@ -672,6 +727,14 @@ class Transformer(eqx.Module):
         track_consistency = cfg.core_consistency_weight > 0
         consistency_accum = jnp.zeros((), dtype=jnp.float32)
         x_prev = hidden
+        # E4: collect a readout (shared head: final_norm + final_gated_norm) after
+        # each core iteration so next_token_loss can deep-supervise every depth.
+        # Gated on the static config so E0/E1/E2/E3/E5/E6 trace to the identical
+        # jaxpr (no readout op, no extra metric key). The intermediates skip the
+        # coda (cheap), so they regularize the core to be decodable at every depth;
+        # the final output still flows through the coda below.
+        track_anytime = cfg.anytime_supervision and cfg.max_trained_recurrence > 1
+        anytime_readouts: list[jax.Array] = []
         for t in range(n_recurrence):
             for c, block in enumerate(core_blocks):
                 film = None
@@ -680,7 +743,13 @@ class Transformer(eqx.Module):
                     # override deeper than trained, reuse the last iteration's FiLM.
                     film_t = min(t, cfg.recurrence_steps - 1)
                     film = (self.core_film_scale[film_t, c], self.core_film_shift[film_t, c])
-                hidden, stats = apply_block(block, hidden, eff_idx, film)
+                router_logit_bias = None
+                if self.core_router_bias is not None:
+                    # E6: depth-conditioned router bias. Sized to max_trained_recurrence;
+                    # eval deeper than trained reuses the last iteration's bias.
+                    bias_t = min(t, cfg.max_trained_recurrence - 1)
+                    router_logit_bias = self.core_router_bias[bias_t, c]
+                hidden, stats = apply_block(block, hidden, eff_idx, film, router_logit_bias)
                 core_iter_stats[c].append(stats)
                 eff_idx += 1
             if track_consistency:
@@ -689,6 +758,8 @@ class Transformer(eqx.Module):
                 den = jnp.sum(jnp.square(x_prev.astype(jnp.float32)), axis=-1) + cfg.layer_norm_eps
                 consistency_accum = consistency_accum + jnp.mean(num / den)
                 x_prev = hidden
+            if track_anytime:
+                anytime_readouts.append(self.final_gated_norm(self.final_norm(hidden)))
         per_block_stats.extend(_mean_router_stats(s) for s in core_iter_stats)
 
         for block in coda_blocks:
@@ -705,6 +776,11 @@ class Transformer(eqx.Module):
         }
         if track_consistency:
             router_metrics["core_consistency"] = consistency_accum / n_recurrence
+        if track_anytime:
+            # (n_recurrence, B, S, D). Consumed by next_token_loss (training only)
+            # and dropped before _summarize_router_metrics, so it never escapes the
+            # train_step metrics dict.
+            router_metrics["anytime_readouts"] = jnp.stack(anytime_readouts, axis=0)
         hidden = self.final_gated_norm(self.final_norm(hidden))
         return hidden, router_metrics
 
@@ -756,6 +832,29 @@ class Transformer(eqx.Module):
             consistency = router_metrics["core_consistency"]
             consistency_weighted = self.config.core_consistency_weight * consistency
             loss = loss + consistency_weighted
+        # E4: training-only anytime deep-supervision. For each per-iteration readout
+        # collected in the forward, compute CE against the same labels through the
+        # shared output head, average over iterations, and add a weighted term.
+        # Gated on reduction so the eval (reduction="none") path is byte-identical.
+        anytime_ce = None
+        anytime_ce_weighted = None
+        if reduction != "none" and self.config.anytime_supervision and "anytime_readouts" in router_metrics:
+            readouts = router_metrics["anytime_readouts"]
+            n_iter = readouts.shape[0]
+            ce_sum = jnp.zeros((), dtype=loss_dtype)
+            for t in range(n_iter):
+                ce_sum = ce_sum + fused_linear_softmax_cross_entropy_loss(
+                    readouts[t],
+                    self.output_proj,
+                    labels,
+                    weight=loss_weight,
+                    reduction=reduction,
+                    logsumexp_weight=logsumexp_weight,
+                    dtype=loss_dtype,
+                )
+            anytime_ce = ce_sum / n_iter
+            anytime_ce_weighted = self.config.anytime_supervision_weight * anytime_ce
+            loss = loss + anytime_ce_weighted
         if return_router_metrics:
             summarized_metrics = _summarize_router_metrics(router_metrics)
             summarized_metrics["train/cross_entropy_loss"] = cross_entropy_loss
@@ -763,6 +862,9 @@ class Transformer(eqx.Module):
             if "core_consistency" in router_metrics:
                 summarized_metrics["train/core_consistency"] = router_metrics["core_consistency"]
                 summarized_metrics["train/core_consistency_weighted"] = consistency_weighted
+            if anytime_ce is not None:
+                summarized_metrics["train/anytime_ce"] = anytime_ce
+                summarized_metrics["train/anytime_ce_weighted"] = anytime_ce_weighted
             return loss, summarized_metrics
         return loss
 

--- a/experiments/grug/reentrant/optimizer.py
+++ b/experiments/grug/reentrant/optimizer.py
@@ -1,0 +1,95 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from dataclasses import dataclass
+
+import jax
+import optax
+from levanter.optim import OptimizerConfig
+from levanter.utils.jax_utils import leaf_key_paths
+
+from experiments.grug.reentrant.adamh import scale_by_adamh
+
+
+@OptimizerConfig.register_subclass("grug_moe_adamh_v2")
+@dataclass(frozen=True)
+class GrugMoeAdamHConfig(OptimizerConfig):
+    """AdamH for Grug MoE. Four optimizer groups, no flags.
+
+    - adamh: attention weights, dense MLP weights (2D matrices)
+    - adamh_expert: expert MLP weights (mlp.expert_mlp.w_gate_up,
+      mlp.expert_mlp.w_down, shared.w_*)
+    - adam: norms, biases, router, embeddings, attention gates (1D / small params)
+    """
+
+    beta1: float = 0.9
+    beta2: float = 0.95
+    epsilon: float = 1e-8
+    max_grad_norm: float | None = 1.0
+    adam_lr: float = 6e-4
+    expert_lr: float | None = None
+
+    def build(self, num_train_steps):
+        learning_rate_schedule = self.lr_scheduler(num_train_steps)
+        adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
+        expert_lr_val = self.expert_lr if self.expert_lr is not None else self.learning_rate
+        expert_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=expert_lr_val)
+
+        def optimizer(learning_rate, adam_lr, expert_lr):
+            def adamh_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, learning_rate))
+                return optax.chain(*components)
+
+            def adamh_expert_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, expert_lr))
+                return optax.chain(*components)
+
+            def adam_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
+                components.append(optax.scale(-adam_lr))
+                return optax.chain(*components)
+
+            return optax.multi_transform(
+                {
+                    "adamh": adamh_transform(),
+                    "adamh_expert": adamh_expert_transform(),
+                    "adam": adam_transform(),
+                },
+                self.create_mask,
+            )
+
+        return optax.inject_hyperparams(optimizer)(
+            learning_rate=learning_rate_schedule,
+            adam_lr=adam_lr_schedule,
+            expert_lr=expert_lr_schedule,
+        )
+
+    def create_mask(self, params):
+        paths = leaf_key_paths(params)
+
+        def mask_fn(param, path):
+            path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
+            path_lower = path_str.lower()
+            if "token_embed" in path_lower:
+                return "adam"
+            if "router_bias" in path_lower or "attn_gate" in path_lower or ".router" in path_lower:
+                return "adam"
+            if ".mlp.expert_mlp.w_" in path_lower or ".mlp.w_" in path_lower or ".shared.w_" in path_lower:
+                return "adamh_expert"
+            if hasattr(param, "ndim") and param.ndim >= 2:
+                return "adamh"
+            return "adam"
+
+        return jax.tree.map(mask_fn, params, paths)
+
+
+__all__ = ["GrugMoeAdamHConfig"]

--- a/experiments/grug/reentrant/optimizer.py
+++ b/experiments/grug/reentrant/optimizer.py
@@ -83,6 +83,12 @@ class GrugMoeAdamHConfig(OptimizerConfig):
                 return "adam"
             if "router_bias" in path_lower or "attn_gate" in path_lower or ".router" in path_lower:
                 return "adam"
+            if "core_film" in path_lower:
+                # Per-iteration FiLM scale/shift are per-feature affine params (like
+                # norms/biases), not weight matrices. They must use plain Adam: AdamH's
+                # norm-preserving update divides by the parameter norm, which is zero at
+                # their identity (zero) init -> 0/0 NaN that poisons the whole tree.
+                return "adam"
             if ".mlp.expert_mlp.w_" in path_lower or ".mlp.w_" in path_lower or ".shared.w_" in path_lower:
                 return "adamh_expert"
             if hasattr(param, "ndim") and param.ndim >= 2:

--- a/experiments/grug/reentrant/test_eval_sweep.py
+++ b/experiments/grug/reentrant/test_eval_sweep.py
@@ -1,0 +1,142 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU smoke test for the re-entrant depth-scaling eval plumbing.
+
+No checkpoint is involved: a tiny randomly-initialized re-entrant model is
+evaluated at several recurrence depths through the real ``evaluate_at_depths``
+helper, asserting one finite macro loss per depth and that different depths
+generally produce different losses (i.e. the loop count really does change the
+forward). This proves the multi-R eval sweep works without a real E3 checkpoint.
+"""
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+from haliax.partitioning import set_mesh
+from jax.sharding import PartitionSpec as P
+from levanter.data.dataset import ListAsyncDataset
+from levanter.data.text.examples import GrugLmExample
+from levanter.eval import TaggedEvaluator
+from levanter.grug.sharding import compact_grug_mesh
+
+from experiments.grug.reentrant.eval_sweep import evaluate_at_depths
+from experiments.grug.reentrant.model import GrugModelConfig, Transformer
+
+_BATCH_AXES = ("replica_dcn", "data", "expert")
+
+
+def _tiny_reentrant_config() -> GrugModelConfig:
+    """A minimal re-entrant MoE config: 1 prelude + 1 core + 1 coda, loopable core."""
+    return GrugModelConfig(
+        vocab_size=64,
+        hidden_dim=32,
+        intermediate_dim=32,
+        shared_expert_intermediate_dim=32,
+        num_experts=4,
+        num_experts_per_token=2,
+        num_layers=3,
+        num_prelude_layers=1,
+        num_coda_layers=1,
+        recurrence_steps=2,
+        num_heads=2,
+        num_kv_heads=2,
+        max_seq_len=16,
+        sliding_window=16,
+    )
+
+
+def _make_grug_dataset(cfg: GrugModelConfig, *, num_examples: int, seed: int) -> ListAsyncDataset:
+    """Deterministic synthetic GrugLmExamples with host (numpy) token arrays.
+
+    Built outside any explicit grug mesh so the example arrays carry no committed
+    sharding; the DataLoader then places them onto the grug mesh at stack time.
+    """
+    rng = np.random.default_rng(seed)
+    examples = [
+        GrugLmExample.causal(np.asarray(rng.integers(0, cfg.vocab_size, size=cfg.max_seq_len), dtype=np.int32))
+        for _ in range(num_examples)
+    ]
+    return ListAsyncDataset(examples)
+
+
+def _tiny_evaluator(cfg: GrugModelConfig, mesh, datasets: list[ListAsyncDataset]) -> TaggedEvaluator:
+    """A 2-tag grug evaluator over pre-built synthetic datasets."""
+    eval_batch_size = jax.device_count()
+    eval_array_sharding = jax.sharding.NamedSharding(mesh, P(_BATCH_AXES, None))
+
+    def eval_loss_fn(model: Transformer, batch: GrugLmExample):
+        per_pos_loss = model.next_token_loss(
+            batch.tokens,
+            batch.loss_weight,
+            mask=batch.attn_mask,
+            reduction="none",
+            logsumexp_weight=None,
+        )
+        per_pos_loss = jax.sharding.reshard(per_pos_loss, eval_array_sharding)
+        per_pos_weight = jax.sharding.reshard(batch.loss_weight, eval_array_sharding)
+        per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
+        return per_pos_loss, per_pos_weight, per_pos_token_id
+
+    return TaggedEvaluator(
+        EvalBatch=eval_batch_size,
+        tagged_eval_sets=[(datasets[0], ["a"]), (datasets[1], ["b"])],
+        loss_fn=eval_loss_fn,
+        tokenizer=None,
+        device_mesh=mesh,
+        axis_mapping={"batch": _BATCH_AXES},
+    )
+
+
+def test_evaluate_at_depths_returns_finite_loss_per_depth():
+    cfg = _tiny_reentrant_config()
+    recurrence_values = (1, 2, 4, 8)
+    num_examples = 2 * jax.device_count()
+
+    # Build datasets outside the grug mesh so their example arrays carry the
+    # default (Auto) mesh aval that the DataLoader uses when it stacks them.
+    datasets = [
+        _make_grug_dataset(cfg, num_examples=num_examples, seed=0),
+        _make_grug_dataset(cfg, num_examples=num_examples, seed=1),
+    ]
+
+    mesh = compact_grug_mesh()
+    with set_mesh(mesh):
+        model = Transformer.init(cfg, key=jax.random.PRNGKey(0))
+        evaluator = _tiny_evaluator(cfg, mesh, datasets)
+        results = evaluate_at_depths(model, evaluator, recurrence_values)
+
+    assert set(results) == set(recurrence_values)
+    macro_losses = {}
+    for recurrence_steps, result in results.items():
+        assert np.isfinite(result.macro_avg_loss), f"non-finite macro loss at R={recurrence_steps}"
+        assert np.isfinite(result.micro_avg_loss), f"non-finite micro loss at R={recurrence_steps}"
+        macro_losses[recurrence_steps] = result.macro_avg_loss
+
+    # Looping the core a different number of times must change the forward, so the
+    # depths should not all collapse onto a single loss value.
+    distinct = {round(loss, 5) for loss in macro_losses.values()}
+    assert len(distinct) > 1, f"all depths gave the same loss {macro_losses}; loop count had no effect"
+
+
+def test_evaluate_at_depths_does_not_mutate_input_model():
+    cfg = _tiny_reentrant_config()
+    num_examples = 2 * jax.device_count()
+    datasets = [
+        _make_grug_dataset(cfg, num_examples=num_examples, seed=0),
+        _make_grug_dataset(cfg, num_examples=num_examples, seed=1),
+    ]
+    mesh = compact_grug_mesh()
+    with set_mesh(mesh):
+        model = Transformer.init(cfg, key=jax.random.PRNGKey(1))
+        evaluator = _tiny_evaluator(cfg, mesh, datasets)
+        evaluate_at_depths(model, evaluator, (2, 4))
+
+    # The depth swap is per-variant (dataclasses.replace), so the passed-in model
+    # keeps its original config recurrence_steps.
+    assert model.config.recurrence_steps == cfg.recurrence_steps
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-x", "-q"])

--- a/experiments/grug/reentrant/test_optimizer.py
+++ b/experiments/grug/reentrant/test_optimizer.py
@@ -1,0 +1,35 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import jax.numpy as jnp
+
+from experiments.grug.reentrant.optimizer import GrugMoeAdamHConfig
+
+
+def test_grug_moe_adamh_mask_routes_expert_mlp_weights_to_expert_group():
+    params = {
+        "blocks": {
+            "0": {
+                "mlp": {
+                    "router": jnp.ones((8, 4), dtype=jnp.float32),
+                    "expert_mlp": {
+                        "w_gate_up": jnp.ones((4, 8, 16), dtype=jnp.float32),
+                        "w_down": jnp.ones((4, 16, 8), dtype=jnp.float32),
+                    },
+                },
+                "shared": {
+                    "w_gate": jnp.ones((8, 16), dtype=jnp.float32),
+                },
+            },
+        },
+        "token_embed": jnp.ones((128, 8), dtype=jnp.float32),
+    }
+
+    mask = GrugMoeAdamHConfig().create_mask(params)
+
+    block_mask = mask["blocks"]["0"]
+    assert block_mask["mlp"]["router"] == "adam"
+    assert block_mask["mlp"]["expert_mlp"]["w_gate_up"] == "adamh_expert"
+    assert block_mask["mlp"]["expert_mlp"]["w_down"] == "adamh_expert"
+    assert block_mask["shared"]["w_gate"] == "adamh_expert"
+    assert mask["token_embed"] == "adam"

--- a/experiments/grug/reentrant/train.py
+++ b/experiments/grug/reentrant/train.py
@@ -552,6 +552,9 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                         "train/core_consistency_weighted",
                         "train/anytime_ce",
                         "train/anytime_ce_weighted",
+                        "train/ponder_recon",
+                        "train/ponder_kl",
+                        "train/ponder_expected_halt_step",
                     )
                     extra_scalars = {key: metrics[key] for key in extra_scalar_keys if key in metrics}
                     if extra_scalars:

--- a/experiments/grug/reentrant/train.py
+++ b/experiments/grug/reentrant/train.py
@@ -1,0 +1,583 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import dataclasses
+import functools
+import logging
+import time
+from dataclasses import dataclass, field
+
+import equinox as eqx
+import jax
+import jax.numpy as jnp
+import jmp
+import levanter.callbacks as callbacks
+import levanter.tracker
+import optax
+from fray.cluster import ResourceConfig
+from haliax import Axis
+from haliax.partitioning import set_mesh
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from jax.tree_util import register_dataclass
+from jaxtyping import PRNGKeyArray
+from levanter.callbacks.state_adapter import StateCallbackRunner
+from levanter.callbacks.watch import WatchConfig, compute_watch_stats
+from levanter.data import AsyncDataset, DataLoader
+from levanter.data.mixture import MixtureDataset, rescale_mixture_schedule_for_batch_schedule
+from levanter.data.text import GrugLmExample, LmDataConfig
+from levanter.data.text.examples import grug_lm_example_from_named
+from levanter.eval import TaggedEvaluator, cb_tagged_evaluate
+from levanter.grug.sharding import compact_grug_mesh
+from levanter.models.lm_model import LmExample
+from levanter.optim import AdamConfig, OptimizerConfig
+from levanter.schedule import BatchSchedule
+from levanter.trainer import TrainerConfig
+from levanter.utils.flop_utils import lm_flops_per_token
+from levanter.utils.jax_utils import parameter_count
+from levanter.utils.logging import LoadingTimeTrackerIterator
+
+from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
+from experiments.grug.dispatch import dispatch_grug_training_run
+from experiments.grug.reentrant.model import GrugModelConfig, Transformer
+
+# This file intentionally mirrors `experiments/grug/base/train.py` with
+# variant-specific model/loss/FLOP wiring, per the grug copy-first workflow in
+# `.agents/skills/change-grug/`.
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class GrugTrainerConfig:
+    """Runtime knobs for grug training."""
+
+    trainer: TrainerConfig = field(default_factory=lambda: TrainerConfig(use_explicit_mesh_axes=True))
+    data_seed: int | None = None
+    log_every: int = 1
+    ema_beta: float | None = None  # EMA coefficient for eval/checkpoint model; None disables EMA.
+    z_loss_weight: float = 0.0  # Weight on logsumexp (z-loss) stabilization term.
+
+    # Grug builds its own compact (replica_dcn, data, expert, model) mesh instead of using
+    # the Trainer's logical axis mapping; `data` absorbs whatever these two leave free.
+    # Defaults reproduce the historical layout: no expert parallelism and full replication
+    # across slices (replica_axis_size=None -> jax.process_count()), i.e. parameters
+    # replicated per slice and sharded only over the intra-slice `data` axis. For a model
+    # too large to replicate within one slice, set replica_axis_size=1 (FSDP across every
+    # slice) and expert_axis_size>1 (expert parallelism over the intra-slice devices).
+    expert_axis_size: int = 1
+    replica_axis_size: int | None = None
+
+
+@dataclass(frozen=True)
+class GrugEvalConfig:
+    """Perplexity eval settings for grug training."""
+
+    eval_batch_size: int = 512
+    steps_per_eval: int | None = 1000
+    max_eval_batches: int | None = None
+    prefix: str = "eval"
+    eval_current: bool = True
+    eval_ema: bool = True
+    compute_bpb: bool = True
+
+
+@dataclass(frozen=True)
+class GrugRunConfig:
+    """Top-level config for grug training."""
+
+    model: GrugModelConfig
+    data: LmDataConfig
+    resources: ResourceConfig
+    optimizer: OptimizerConfig = field(default_factory=AdamConfig)
+    trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
+    eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
+
+
+def build_train_dataset(
+    data_config: LmDataConfig,
+    *,
+    max_seq_len: int,
+    batch_schedule: BatchSchedule,
+    key: PRNGKeyArray,
+) -> MixtureDataset[GrugLmExample]:
+    pos = Axis("position", max_seq_len)
+    mix_key, shuffle_key = jax.random.split(key)
+    weights = data_config.train_weights
+    if isinstance(weights, list):
+        weights = rescale_mixture_schedule_for_batch_schedule(weights, batch_schedule)
+
+    initial_batch_size = batch_schedule.batch_size_at_step(0)
+    datasets = data_config.train_sets(pos, key=shuffle_key, initial_batch_size=initial_batch_size)
+    return MixtureDataset(
+        datasets=datasets,
+        weights=weights,
+        stop_strategy=data_config.stop_strategy,
+        key=mix_key,
+        block_size=data_config.mixture_block_size,
+    )
+
+
+_BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
+
+
+def build_train_loader(
+    dataset: AsyncDataset[GrugLmExample],
+    *,
+    batch_schedule: BatchSchedule,
+    mesh: Mesh,
+) -> DataLoader[GrugLmExample]:
+    # DataLoader uses this batch axis mapping to shard batches across the distributed mesh.
+    # `compact_grug_mesh` always carries (replica_dcn, data, expert, model); length-1 axes
+    # are kept so we can name "expert" unconditionally.
+    return DataLoader(
+        dataset,
+        batch_schedule.schedule,
+        mesh=mesh,
+        axis_resources={"__BATCH__": _BATCH_AXES},
+        batch_axis_name="__BATCH__",
+        allow_nondivisible_batch_size=False,
+    )
+
+
+def build_tagged_evaluator(
+    *,
+    data_config: LmDataConfig,
+    max_seq_len: int,
+    mesh: Mesh,
+    eval_cfg: GrugEvalConfig,
+) -> TaggedEvaluator[LmExample | GrugLmExample, Transformer] | None:
+    pos = Axis("position", max_seq_len)
+    tagged_eval_sets = data_config.tagged_eval_sets(pos)
+    if len(tagged_eval_sets) == 0:
+        logger.warning("No evaluation datasets provided.")
+        return None
+
+    max_examples_per_dataset = None
+    if eval_cfg.max_eval_batches is not None:
+        max_examples_per_dataset = eval_cfg.max_eval_batches * eval_cfg.eval_batch_size
+
+    tokenizer = data_config.the_tokenizer if eval_cfg.compute_bpb else None
+    # `compact_grug_mesh` always carries (replica_dcn, data, expert, model); length-1 axes
+    # are kept so we can name "expert" unconditionally.
+    eval_axis_mapping = {"batch": _BATCH_AXES}
+    eval_batch = Axis("batch", eval_cfg.eval_batch_size)
+    eval_array_sharding = NamedSharding(mesh, P(_BATCH_AXES, None))
+
+    def eval_loss_fn(model: Transformer, batch: LmExample | GrugLmExample) -> tuple[jax.Array, jax.Array, jax.Array]:
+        if isinstance(batch, LmExample):
+            batch = grug_lm_example_from_named(batch)
+        per_pos_loss = model.next_token_loss(
+            batch.tokens,
+            batch.loss_weight,
+            mask=batch.attn_mask,
+            reduction="none",
+            logsumexp_weight=None,
+        )
+        per_pos_loss = jax.sharding.reshard(per_pos_loss, eval_array_sharding)
+        per_pos_weight = jax.sharding.reshard(batch.loss_weight, eval_array_sharding)
+        per_pos_token_id = jnp.roll(batch.tokens, -1, axis=-1)
+        return per_pos_loss, per_pos_weight, per_pos_token_id
+
+    return TaggedEvaluator(
+        EvalBatch=eval_batch,
+        tagged_eval_sets=tagged_eval_sets,
+        loss_fn=eval_loss_fn,
+        tokenizer=tokenizer,
+        device_mesh=mesh,
+        axis_mapping=eval_axis_mapping,
+        max_examples_per_dataset=max_examples_per_dataset,
+    )
+
+
+def _compute_flops(
+    *,
+    model_config: GrugModelConfig,
+) -> tuple[float, dict[str, float]]:
+    flops_per_token = lm_flops_per_token(
+        hidden_dim=model_config.hidden_dim,
+        intermediate_dim=model_config.intermediate_dim,
+        shared_intermediate_dim=model_config.shared_expert_intermediate_dim,
+        num_layers=model_config.num_layers,
+        num_kv_heads=model_config.num_kv_heads,
+        num_heads=model_config.num_heads,
+        seq_len=model_config.max_seq_len,
+        vocab_size=model_config.vocab_size,
+        glu=True,
+        num_experts=model_config.num_experts,
+        num_shared_experts=1 if model_config.shared_expert_intermediate_dim > 0 else 0,
+        num_experts_per_tok=model_config.num_experts_per_token,
+    )
+    flops_per_example = 3 * flops_per_token * model_config.max_seq_len
+
+    flops_summary: dict[str, float] = {
+        "throughput/flops_per_token_analytic": flops_per_token,
+        "throughput/flops_per_example_analytic": flops_per_example,
+    }
+
+    return flops_per_example, flops_summary
+
+
+def _make_mixture_stage_callback(train_dataset: MixtureDataset, batch_schedule: BatchSchedule):
+    last_mixture_stage = -1
+
+    def log_mixture_stage(step_info):
+        nonlocal last_mixture_stage
+        seq_index = batch_schedule.global_data_offset_by_step(step_info.step)
+        block_id = seq_index // train_dataset.block_size
+        stage = train_dataset._get_stage_for_block(block_id)
+        if stage == last_mixture_stage:
+            return
+
+        weights = train_dataset.weight_stages[stage][1]
+        mixture_log = {f"mixture/weight/{name}": weight for name, weight in weights.items()}
+        mixture_log["mixture/stage"] = stage
+        levanter.tracker.log(mixture_log, step=step_info.step)
+        last_mixture_stage = stage
+
+    return log_mixture_stage
+
+
+@register_dataclass
+@dataclass(frozen=True)
+class GrugTrainState:
+    step: jax.Array
+    params: Transformer
+    opt_state: optax.OptState
+    ema_params: Transformer | None
+    pending_qb_betas: jax.Array
+
+
+def _apply_qb_betas(model: Transformer, qb_betas: jax.Array) -> Transformer:
+    """Set router biases from QB betas (computed on previous step)."""
+    new_blocks = list(model.blocks)
+    moe_idx = 0
+    for i, block in enumerate(model.blocks):
+        if block.mlp is None:
+            continue
+        new_bias = -qb_betas[moe_idx]
+        new_bias = new_bias - jnp.mean(new_bias)
+        new_mlp = eqx.tree_at(lambda m: m.router_bias, block.mlp, new_bias)
+        new_blocks[i] = eqx.tree_at(lambda b: b.mlp, block, new_mlp)
+        moe_idx += 1
+    return eqx.tree_at(lambda t: t.blocks, model, tuple(new_blocks))
+
+
+def initial_state(
+    model_config: GrugModelConfig,
+    *,
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    key: PRNGKeyArray,
+    ema_beta: float | None,
+) -> GrugTrainState:
+    params = mp.cast_to_param(Transformer.init(model_config, key=key))
+    num_moe_layers = sum(1 for b in params.blocks if b.mlp is not None)
+    return GrugTrainState(
+        step=jnp.array(0, dtype=jnp.int32),
+        params=params,
+        opt_state=optimizer.init(params),
+        ema_params=params if ema_beta is not None else None,
+        pending_qb_betas=jnp.zeros((num_moe_layers, model_config.num_experts)),
+    )
+
+
+def _make_train_step(
+    optimizer: optax.GradientTransformation,
+    mp: jmp.Policy,
+    *,
+    z_loss_weight: float,
+    ema_beta: float | None,
+    watch_config: WatchConfig | None = None,
+):
+    one = jnp.array(1, dtype=jnp.int32)
+    z_loss = z_loss_weight if z_loss_weight > 0 else None
+    if watch_config is not None:
+        if isinstance(watch_config.watch_targets, str):
+            watch_targets = tuple(t.strip() for t in watch_config.watch_targets.split(","))
+        else:
+            watch_targets = tuple(watch_config.watch_targets)
+    else:
+        watch_targets = ()
+
+    @functools.partial(jax.jit, donate_argnums=(0,), static_argnames=("compute_watch",))
+    def train_step(state: GrugTrainState, batch, *, compute_watch: bool = False):
+        # Apply pending QB betas to router biases inside JIT (avoids eager
+        # host-side TPU kernel launches that can cause SPMD sync issues).
+        qb_params = _apply_qb_betas(state.params, state.pending_qb_betas)
+        if ema_beta is not None:
+            qb_ema_params = _apply_qb_betas(state.ema_params, state.pending_qb_betas)
+        else:
+            qb_ema_params = None
+
+        def loss_fn(params):
+            compute_params = mp.cast_to_compute(params)
+            return compute_params.next_token_loss(
+                batch.tokens,
+                batch.loss_weight,
+                mask=batch.attn_mask,
+                reduction="mean",
+                logsumexp_weight=z_loss,
+                return_router_metrics=True,
+            )
+
+        (loss, summarized_metrics), grads = jax.value_and_grad(loss_fn, has_aux=True)(qb_params)
+        metrics = {"train/loss": loss, **summarized_metrics}
+        updates, opt_state = optimizer.update(grads, state.opt_state, qb_params)
+        params = optax.apply_updates(qb_params, updates)
+
+        if ema_beta is None:
+            ema_params = None
+        else:
+            if qb_ema_params is None:
+                raise ValueError("ema_params must be initialized when ema_beta is set.")
+            ema_params = jax.tree_util.tree_map(
+                lambda old, new: ema_beta * old + (1.0 - ema_beta) * new,
+                qb_ema_params,
+                params,
+            )
+
+        watch_stats = None
+        if watch_config is not None and compute_watch:
+            watch_stats = compute_watch_stats(
+                watch_targets=watch_targets,
+                include_norms=watch_config.include_norms,
+                include_per_parameter_norms=watch_config.include_per_parameter_norms,
+                include_histogram=watch_config.include_histograms,
+                split_scan_layers=watch_config.split_scan_layers,
+                params=qb_params,
+                grads=grads,
+                updates=updates,
+                opt_state=state.opt_state,
+                model_tree_type=type(state.params),
+            )
+
+        next_state = dataclasses.replace(
+            state,
+            step=state.step + one,
+            params=params,
+            opt_state=opt_state,
+            ema_params=ema_params,
+            pending_qb_betas=metrics["qb_beta_per_layer"],
+        )
+
+        return next_state, metrics, watch_stats
+
+    return train_step
+
+
+def _run_grug_local(config: GrugRunConfig) -> None:
+    """Entry point for the grug template training loop."""
+    trainer = config.trainer.trainer
+    trainer.initialize()
+    levanter.tracker.log_configuration(config)
+
+    run_id = trainer.id
+    if run_id is None:
+        raise ValueError("trainer.id was not initialized")
+
+    optimizer = config.optimizer.build(trainer.num_train_steps)
+    watch_config = trainer.watch
+    train_step = _make_train_step(
+        optimizer,
+        trainer.mp,
+        z_loss_weight=config.trainer.z_loss_weight,
+        ema_beta=config.trainer.ema_beta,
+        watch_config=watch_config if watch_config.is_enabled else None,
+    )
+
+    data_key, model_key = jax.random.split(jax.random.PRNGKey(trainer.seed), 2)
+    if config.trainer.data_seed is not None:
+        data_key = jax.random.PRNGKey(config.trainer.data_seed)
+
+    # Grug uses raw PartitionSpecs rather than Trainer's logical axis mapping.
+    # Keep the mesh compact so the batch pspec derived by `_batch_spec(mesh)` spans slices directly.
+    # replica_axis_size=None lets compact_grug_mesh default to jax.process_count() (full
+    # cross-slice replication); set it to 1 on GrugTrainerConfig for cross-slice FSDP.
+    mesh = compact_grug_mesh(
+        expert_axis_size=config.trainer.expert_axis_size,
+        replica_axis_size=config.trainer.replica_axis_size,
+    )
+    with set_mesh(mesh):
+        batch_schedule = trainer.batch_schedule
+
+        train_dataset = build_train_dataset(
+            config.data,
+            max_seq_len=config.model.max_seq_len,
+            batch_schedule=batch_schedule,
+            key=data_key,
+        )
+        train_loader = build_train_loader(
+            train_dataset,
+            batch_schedule=batch_schedule,
+            mesh=mesh,
+        )
+
+        @jax.jit
+        def _init_state(model_rng):
+            return initial_state(
+                config.model,
+                optimizer=optimizer,
+                mp=trainer.mp,
+                key=model_rng,
+                ema_beta=config.trainer.ema_beta,
+            )
+
+        state = _init_state(model_key)
+
+        checkpointer = trainer.checkpointer.create(run_id)
+        state = restore_grug_state_from_checkpoint(
+            state,
+            checkpoint_search_paths=trainer.checkpoint_search_paths(run_id),
+            load_checkpoint_setting=trainer.load_checkpoint,
+            mesh=mesh,
+            allow_partial=trainer.allow_partial_checkpoint,
+        )
+
+        levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
+
+        flops_per_example, flops_summary = _compute_flops(model_config=config.model)
+        levanter.tracker.log_summary(flops_summary)
+
+        eval_cfg = config.eval
+        evaluator = None
+        if eval_cfg is not None:
+            evaluator = build_tagged_evaluator(
+                data_config=config.data,
+                max_seq_len=config.model.max_seq_len,
+                mesh=mesh,
+                eval_cfg=eval_cfg,
+            )
+
+        profiler_cfg = trainer.profiler
+        profiler_num_steps = profiler_cfg.resolve_num_profile_steps(num_train_steps=trainer.num_train_steps)
+        profiler_enabled = profiler_cfg.is_enabled and profiler_num_steps > 0
+
+        log_every = max(1, config.trainer.log_every)
+        iterator = LoadingTimeTrackerIterator(train_loader.iter_from_step(int(state.step)))
+
+        state_callbacks = StateCallbackRunner[GrugTrainState](
+            step_getter=lambda s: s.step,
+            model_getter=lambda s: s.params,
+            eval_model_getter=lambda s: s.ema_params if s.ema_params is not None else s.params,
+            opt_state_getter=lambda s: s.opt_state,
+        )
+        state_callbacks.add_hook(
+            callbacks.log_performance_stats(config.model.max_seq_len, batch_schedule, flops_per_example),
+            every=log_every,
+        )
+        state_callbacks.add_hook(callbacks.pbar_logger(total=trainer.num_train_steps), every=log_every)
+        state_callbacks.add_hook(callbacks.log_step_info(trainer.num_train_steps), every=log_every)
+        if profiler_enabled:
+            state_callbacks.add_hook(
+                callbacks.profile(
+                    str(trainer.log_dir / run_id / "profiler"),
+                    profiler_cfg.start_step,
+                    profiler_num_steps,
+                    profiler_cfg.perfetto_link,
+                ),
+                every=1,
+            )
+        state_callbacks.add_hook(_make_mixture_stage_callback(train_dataset, batch_schedule), every=1)
+        if evaluator is not None and eval_cfg is not None:
+            interval = eval_cfg.steps_per_eval
+            eval_ema = eval_cfg.eval_ema and config.trainer.ema_beta is not None
+            if interval is not None and interval > 0 and (eval_cfg.eval_current or eval_ema):
+                state_callbacks.add_hook(
+                    cb_tagged_evaluate(
+                        evaluator,
+                        prefix=eval_cfg.prefix,
+                        eval_current=eval_cfg.eval_current,
+                        eval_ema=eval_ema,
+                    ),
+                    every=interval,
+                )
+
+        last_loss: float | jax.Array = 0.0
+        last_step_duration = 0.0
+
+        # Main optimization loop.
+        try:
+            while int(state.step) < trainer.num_train_steps:
+                with jax.profiler.TraceAnnotation("load_batch"):
+                    batch = next(iterator)
+                step_start = time.perf_counter()
+                current_step = int(state.step)
+                # grad_watch runs only on its configured interval.
+                compute_watch = (
+                    watch_config.is_enabled and watch_config.interval > 0 and current_step % watch_config.interval == 0
+                )
+                state, metrics, watch_stats = train_step(state, batch, compute_watch=compute_watch)
+                step = int(state.step) - 1
+
+                jax.block_until_ready(metrics["train/loss"])
+
+                if jnp.isnan(metrics["train/loss"]):
+                    logger.error(f"NaN loss at step {int(state.step)}. Stopping training.")
+                    break
+                duration = time.perf_counter() - step_start
+                hook_start = time.perf_counter()
+                with jax.profiler.TraceAnnotation("callbacks"):
+                    state_callbacks.run(state, loss=metrics["train/loss"], step_duration=duration)
+                    last_loss = metrics["train/loss"]
+                    last_step_duration = duration
+                    levanter.tracker.log({"throughput/hook_time": time.perf_counter() - hook_start}, step=step)
+                    levanter.tracker.log({"throughput/loading_time": iterator.this_load_time}, step=step)
+                    router_metrics = {
+                        key: value
+                        for key, value in metrics.items()
+                        if (key.startswith("train/router/") or key.startswith("moe_bias/"))
+                        and key not in ("train/router/routing_counts_per_layer", "qb_beta_per_layer")
+                    }
+                    if router_metrics:
+                        levanter.tracker.log(router_metrics, step=step)
+                    if "train/cross_entropy_loss" in metrics:
+                        levanter.tracker.log(
+                            {"train/cross_entropy_loss": metrics["train/cross_entropy_loss"]},
+                            step=step,
+                        )
+
+                    if watch_stats is not None:
+                        levanter.tracker.log(watch_stats, step=step)
+
+                if checkpointer is not None:
+                    checkpointer.on_step(tree=state, step=int(state.step))
+        except BaseException:
+            logger.exception(
+                "Fatal error in grug training loop; skipping final callbacks/checkpoint to preserve root cause"
+            )
+            raise
+        else:
+            # Mirror classic trainer behavior: force callbacks on the last completed step.
+            state_callbacks.run(state, loss=last_loss, step_duration=last_step_duration, force=True)
+            if checkpointer is not None:
+                checkpointer.on_step(tree=state, step=int(state.step), force=True)
+                checkpointer.wait_until_finished()
+
+    levanter.tracker.current_tracker().finish()
+
+
+def run_grug(config: GrugRunConfig) -> None:
+    """Dispatch grug training through Fray jobs."""
+    trainer = config.trainer.trainer
+    if trainer.id is None:
+        raise ValueError("trainer.id must be set before dispatching grug training.")
+
+    dispatch_grug_training_run(
+        run_id=trainer.id,
+        config=config,
+        local_entrypoint=_run_grug_local,
+        resources=config.resources,
+    )
+
+
+__all__ = [
+    "GrugEvalConfig",
+    "GrugRunConfig",
+    "GrugTrainState",
+    "GrugTrainerConfig",
+    "initial_state",
+    "run_grug",
+]

--- a/experiments/grug/reentrant/train.py
+++ b/experiments/grug/reentrant/train.py
@@ -15,6 +15,7 @@ import jax.numpy as jnp
 import jmp
 import levanter.callbacks as callbacks
 import levanter.tracker
+import numpy as np
 import optax
 from fray.cluster import ResourceConfig
 from haliax import Axis
@@ -302,8 +303,8 @@ def _make_train_step(
     else:
         watch_targets = ()
 
-    @functools.partial(jax.jit, donate_argnums=(0,), static_argnames=("compute_watch",))
-    def train_step(state: GrugTrainState, batch, *, compute_watch: bool = False):
+    @functools.partial(jax.jit, donate_argnums=(0,), static_argnames=("compute_watch", "recurrence_steps"))
+    def train_step(state: GrugTrainState, batch, *, compute_watch: bool = False, recurrence_steps: int | None = None):
         # Apply pending QB betas to router biases inside JIT (avoids eager
         # host-side TPU kernel launches that can cause SPMD sync issues).
         qb_params = _apply_qb_betas(state.params, state.pending_qb_betas)
@@ -321,6 +322,7 @@ def _make_train_step(
                 reduction="mean",
                 logsumexp_weight=z_loss,
                 return_router_metrics=True,
+                recurrence_steps=recurrence_steps,
             )
 
         (loss, summarized_metrics), grads = jax.value_and_grad(loss_fn, has_aux=True)(qb_params)
@@ -509,7 +511,14 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                 compute_watch = (
                     watch_config.is_enabled and watch_config.interval > 0 and current_step % watch_config.interval == 0
                 )
-                state, metrics, watch_stats = train_step(state, batch, compute_watch=compute_watch)
+                recurrence_override = None
+                if config.model.randomize_recurrence:
+                    # Deterministic per-step sample (reproducible across resumes): seed by (seed, step).
+                    rng = np.random.default_rng([trainer.seed, current_step])
+                    recurrence_override = int(rng.choice(config.model.recurrence_choices))
+                state, metrics, watch_stats = train_step(
+                    state, batch, compute_watch=compute_watch, recurrence_steps=recurrence_override
+                )
                 step = int(state.step) - 1
 
                 jax.block_until_ready(metrics["train/loss"])

--- a/experiments/grug/reentrant/train.py
+++ b/experiments/grug/reentrant/train.py
@@ -6,6 +6,7 @@ from __future__ import annotations
 import dataclasses
 import functools
 import logging
+import os
 import time
 from dataclasses import dataclass, field
 
@@ -39,6 +40,7 @@ from levanter.trainer import TrainerConfig
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
+from marin.training.training import resolve_training_env
 
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
@@ -581,10 +583,26 @@ def _run_grug_local(config: GrugRunConfig) -> None:
 
 
 def run_grug(config: GrugRunConfig) -> None:
-    """Dispatch grug training through Fray jobs."""
+    """Run grug training: dispatch a nested Fray job, or run inline when GRUG_DIRECT is set.
+
+    Default: submit a nested Fray training job (the CPU launcher pattern). When
+    GRUG_DIRECT is set the training runs inline on the *current* task instead. Use
+    that when the job is submitted directly to an accelerator (`iris job run --tpu
+    ...`), which attaches the devices to this task — no CPU launcher, no nested
+    dispatch, and no `--reserve` reservation (which does not attach devices). We
+    apply the same training env the dispatch path would have set before
+    `_run_grug_local` touches JAX, so the inline run matches the dispatched one.
+    """
     trainer = config.trainer.trainer
     if trainer.id is None:
         raise ValueError("trainer.id must be set before dispatching grug training.")
+
+    if os.environ.get("GRUG_DIRECT"):
+        env = resolve_training_env(base_env=None, resources=config.resources)
+        for key, value in env.items():
+            os.environ.setdefault(key, value)
+        _run_grug_local(config)
+        return
 
     dispatch_grug_training_run(
         run_id=trainer.id,

--- a/experiments/grug/reentrant/train.py
+++ b/experiments/grug/reentrant/train.py
@@ -547,6 +547,15 @@ def _run_grug_local(config: GrugRunConfig) -> None:
                             {"train/cross_entropy_loss": metrics["train/cross_entropy_loss"]},
                             step=step,
                         )
+                    extra_scalar_keys = (
+                        "train/core_consistency",
+                        "train/core_consistency_weighted",
+                        "train/anytime_ce",
+                        "train/anytime_ce_weighted",
+                    )
+                    extra_scalars = {key: metrics[key] for key in extra_scalar_keys if key in metrics}
+                    if extra_scalars:
+                        levanter.tracker.log(extra_scalars, step=step)
 
                     if watch_stats is not None:
                         levanter.tracker.log(watch_stats, step=step)

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -593,6 +593,125 @@ def test_reentrant_recurrence_override_changes_effective_depth():
         assert not jnp.array_equal(logits, logits_r4)
 
 
+def _small_reentrant_consistency_config(model_module, *, core_consistency_weight: float):
+    """1 prelude + 1 core looped 4x + 1 coda re-entrant config (FiLM off, E3/E5 path)."""
+    return model_module.GrugModelConfig(
+        vocab_size=128,
+        hidden_dim=32,
+        intermediate_dim=64,
+        num_layers=3,
+        num_prelude_layers=1,
+        num_coda_layers=1,
+        recurrence_steps=4,
+        iteration_film=False,
+        num_heads=2,
+        num_kv_heads=2,
+        num_experts=4,
+        num_experts_per_token=2,
+        shared_expert_intermediate_dim=64,
+        max_seq_len=8,
+        core_consistency_weight=core_consistency_weight,
+    )
+
+
+def test_reentrant_core_consistency_does_not_touch_eval_loss():
+    """E5's core-consistency penalty must be training-only: with reduction="none"
+    (the eval path), a model with core_consistency_weight>0 returns the exact same
+    per-position loss as the identical model with weight=0. Comparability of the eval
+    cross-entropy across E5 and the baselines depends on this.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg_off = _small_reentrant_consistency_config(model_module, core_consistency_weight=0.0)
+    cfg_on = _small_reentrant_consistency_config(model_module, core_consistency_weight=1.0)
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg_off.vocab_size
+    weights = jnp.ones((2, 8), dtype=jnp.float32)
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    def eval_loss(cfg, sharded_tokens, sharded_weights):
+        # Both configs only differ in core_consistency_weight (a static field), so the
+        # same PRNG key gives bit-identical params; the only possible divergence is the
+        # penalty leaking into the eval path.
+        model = model_module.Transformer.init(cfg, key=key)
+        return jax.jit(lambda m, t, w: m.next_token_loss(t, w, reduction="none", logsumexp_weight=None))(
+            model, sharded_tokens, sharded_weights
+        )
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        sharded_weights = jax.sharding.reshard(weights, token_pspec)
+        loss_off = eval_loss(cfg_off, sharded_tokens, sharded_weights)
+        loss_on = eval_loss(cfg_on, sharded_tokens, sharded_weights)
+
+    assert loss_off.shape == (2, 8)
+    assert jnp.array_equal(loss_off, loss_on)
+
+
+def test_reentrant_core_consistency_adds_positive_term_to_training_loss():
+    """With weight>0 and reduction="mean", the scalar training loss is strictly greater
+    than the weight=0 loss (the penalty is positive), and the raw ``train/core_consistency``
+    metric is surfaced, finite, and >= 0.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg_off = _small_reentrant_consistency_config(model_module, core_consistency_weight=0.0)
+    cfg_on = _small_reentrant_consistency_config(model_module, core_consistency_weight=1.0)
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg_off.vocab_size
+    weights = jnp.ones((2, 8), dtype=jnp.float32)
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    def train_loss(cfg, sharded_tokens, sharded_weights):
+        model = model_module.Transformer.init(cfg, key=key)
+        return jax.jit(
+            lambda m, t, w: m.next_token_loss(t, w, reduction="mean", logsumexp_weight=None, return_router_metrics=True)
+        )(model, sharded_tokens, sharded_weights)
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        sharded_weights = jax.sharding.reshard(weights, token_pspec)
+        loss_off, metrics_off = train_loss(cfg_off, sharded_tokens, sharded_weights)
+        loss_on, metrics_on = train_loss(cfg_on, sharded_tokens, sharded_weights)
+
+    raw = metrics_on["train/core_consistency"]
+    assert jnp.isfinite(raw)
+    assert float(raw) >= 0.0
+    assert float(raw) > 0.0  # random init produces a nonzero per-loop delta
+    # weight==1.0 adds the raw penalty; the training loss must grow by exactly that.
+    assert float(loss_on) > float(loss_off)
+    assert jnp.allclose(loss_on, loss_off + raw, atol=1e-5)
+    assert jnp.allclose(metrics_on["train/core_consistency_weighted"], raw, atol=1e-6)
+    # The weight=0 model never computes the penalty, so it has no such metric.
+    assert "train/core_consistency" not in metrics_off
+
+
+def test_reentrant_core_consistency_absent_when_disabled():
+    """With weight=0 (the E0-E3 default) the forward never adds a ``core_consistency``
+    key to router_metrics, so the static gate in next_token_loss stays clean and the
+    baseline traces are unchanged.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg = _small_reentrant_consistency_config(model_module, core_consistency_weight=0.0)
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg.vocab_size
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        model = model_module.Transformer.init(cfg, key=key)
+        _, router_metrics = jax.jit(lambda m, t: m(t))(model, sharded_tokens)
+
+    assert "core_consistency" not in router_metrics
+
+
 def test_reentrant_film_params_use_plain_adam_not_adamh():
     """E2's FiLM tables must be optimized by plain Adam, not AdamH.
 

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -419,3 +419,54 @@ def test_grug_base_run_emits_expected_metrics_with_json_tracker(tmp_path: Path):
     ]
     for key in required_keys:
         assert key in summary
+
+
+def test_reentrant_recurrent_config_lowers_and_keeps_router_stats_per_unique_block():
+    """The re-entrant variant must lower a full train step with recurrence enabled,
+    and (the load-bearing invariant) keep ``qb_beta_per_layer`` 1:1 with the unique
+    blocks even though the weight-tied core is applied multiple times per forward.
+
+    A mismatch here would break ``_apply_qb_betas`` (which maps betas positionally
+    onto ``model.blocks``) and silently corrupt the QB load-balancing bias update.
+    """
+    train_module = importlib.import_module("experiments.grug.reentrant.train")
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    # 1 prelude + 1 weight-tied core looped 4x + 1 coda => 3 unique blocks, effective depth 6.
+    cfg = model_module.GrugModelConfig(
+        vocab_size=1024,
+        num_layers=3,
+        num_prelude_layers=1,
+        num_coda_layers=1,
+        recurrence_steps=4,
+    )
+    assert cfg.num_core_layers == 1
+    assert cfg.effective_depth == 6
+
+    optimizer = optax.adam(1e-2)
+    mp = jmp.get_policy("f32")
+    train_step = train_module._make_train_step(optimizer, mp, z_loss_weight=0.0, ema_beta=None)
+    mesh, token_pspec = model_module.debug_mesh_and_token_pspec(num_devices=4)
+    batch = GrugLmExample(
+        tokens=jnp.zeros((8, 4), dtype=jnp.int32),
+        loss_weight=jnp.ones((8, 4), dtype=jnp.float32),
+        attn_mask=GrugAttentionMask.causal(),
+    )
+
+    def one_step():
+        sharded_batch = dataclasses.replace(
+            batch,
+            tokens=jax.sharding.reshard(batch.tokens, token_pspec),
+            loss_weight=jax.sharding.reshard(batch.loss_weight, token_pspec),
+        )
+        state = train_module.initial_state(cfg, optimizer=optimizer, mp=mp, key=jax.random.PRNGKey(0), ema_beta=None)
+        return train_step(state, sharded_batch, compute_watch=False)
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        out_state_shape, out_metrics_shape, _ = eqx.filter_eval_shape(one_step)
+
+    assert out_metrics_shape["train/loss"].shape == ()
+    # One QB beta row per unique block (3), NOT per block application (6).
+    assert out_metrics_shape["qb_beta_per_layer"].shape[0] == cfg.num_layers
+    # pending_qb_betas in the next state must match the unique-block router biases.
+    assert out_state_shape.pending_qb_betas.shape[0] == cfg.num_layers

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -532,3 +532,62 @@ def test_reentrant_iteration_film_is_identity_at_init():
 
     # Identity FiLM => bit-identical forward outputs from the same key.
     assert jnp.array_equal(logits_e1, logits_e2)
+
+
+def test_reentrant_recurrence_override_changes_effective_depth():
+    """E3's per-call recurrence override must change the effective loop depth:
+
+    - Passing the config default (recurrence_steps=4) is a no-op (numerically
+      identical to passing nothing), so E0/E1/E2 paths are unchanged.
+    - Passing a smaller/larger count (2 or 8) changes the computation: the SAME
+      weights run through fewer/more core-loop iterations, producing finite outputs
+      of the right shape that differ from the R=4 output. This is the mechanism the
+      depth-scaling experiment relies on.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    # 1 prelude + 1 core looped 4x + 1 coda => 3 unique blocks. FiLM off (E3 path).
+    cfg = model_module.GrugModelConfig(
+        vocab_size=128,
+        hidden_dim=32,
+        intermediate_dim=64,
+        num_layers=3,
+        num_prelude_layers=1,
+        num_coda_layers=1,
+        recurrence_steps=4,
+        iteration_film=False,
+        num_heads=2,
+        num_kv_heads=2,
+        num_experts=4,
+        num_experts_per_token=2,
+        shared_expert_intermediate_dim=64,
+        max_seq_len=8,
+    )
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg.vocab_size
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    def logits_at(model, sharded_tokens, recurrence_steps):
+        return jax.jit(lambda m, t: m.logits(t, recurrence_steps=recurrence_steps))(model, sharded_tokens)
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        model = model_module.Transformer.init(cfg, key=key)
+        logits_default = jax.jit(lambda m, t: m.logits(t))(model, sharded_tokens)
+        logits_r4 = logits_at(model, sharded_tokens, 4)
+        logits_r2 = logits_at(model, sharded_tokens, 2)
+        logits_r8 = logits_at(model, sharded_tokens, 8)
+
+    expected_shape = (2, 8, cfg.vocab_size)
+    assert logits_default.shape == expected_shape
+
+    # Overriding with the config default is a numerical no-op.
+    assert jnp.array_equal(logits_default, logits_r4)
+
+    # Fewer / more loops change the computation but stay finite and correctly shaped.
+    for logits in (logits_r2, logits_r8):
+        assert logits.shape == expected_shape
+        assert jnp.all(jnp.isfinite(logits))
+        assert not jnp.array_equal(logits, logits_r4)

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -591,3 +591,48 @@ def test_reentrant_recurrence_override_changes_effective_depth():
         assert logits.shape == expected_shape
         assert jnp.all(jnp.isfinite(logits))
         assert not jnp.array_equal(logits, logits_r4)
+
+
+def test_reentrant_film_params_use_plain_adam_not_adamh():
+    """E2's FiLM tables must be optimized by plain Adam, not AdamH.
+
+    AdamH is a norm-preserving update for weight matrices: it divides by the
+    parameter norm, which is zero at the FiLM tables' identity (zero) init, giving
+    0/0 = NaN that poisons the whole parameter tree on the second step. The mask in
+    GrugMoeAdamHConfig must route ``core_film_*`` to the ``adam`` group (where norms
+    and biases live), not fall through the ``ndim >= 2`` rule into ``adamh``.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+    optimizer_module = importlib.import_module("experiments.grug.reentrant.optimizer")
+    leaf_key_paths = importlib.import_module("levanter.utils.jax_utils").leaf_key_paths
+
+    cfg = model_module.GrugModelConfig(
+        vocab_size=128,
+        hidden_dim=32,
+        intermediate_dim=64,
+        num_layers=3,
+        num_prelude_layers=1,
+        num_coda_layers=1,
+        recurrence_steps=4,
+        iteration_film=True,
+        num_heads=2,
+        num_kv_heads=2,
+        num_experts=4,
+        num_experts_per_token=2,
+        shared_expert_intermediate_dim=64,
+        max_seq_len=8,
+    )
+
+    with _reset_abstract_mesh(), set_mesh(compact_grug_mesh()):
+        model = model_module.Transformer.init(cfg, key=jax.random.PRNGKey(0))
+
+    def path_str(p):
+        return ".".join(p) if isinstance(p, (list, tuple)) else str(p)
+
+    mask = optimizer_module.GrugMoeAdamHConfig().create_mask(model)
+    paths = [path_str(p) for p in jax.tree.leaves(leaf_key_paths(model))]
+    groups = jax.tree.leaves(mask)
+
+    film_groups = [g for path, g in zip(paths, groups, strict=True) if "core_film" in path.lower()]
+    assert film_groups, "expected FiLM params in the tree when iteration_film=True"
+    assert all(g == "adam" for g in film_groups), f"FiLM must use plain adam, got {set(film_groups)}"

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -720,8 +720,10 @@ def test_reentrant_core_consistency_absent_when_disabled():
         {"depth_conditioned_routing": True, "anytime_supervision": True},
         {"randomize_recurrence": True, "recurrence_choices": (2, 4, 8), "depth_conditioned_routing": True},
         {"randomize_recurrence": True, "recurrence_choices": (2, 4, 8), "anytime_supervision": True},
+        {"ponder_halting": True},
+        {"randomize_recurrence": True, "recurrence_choices": (2, 4, 8), "ponder_halting": True},
     ],
-    ids=["e6", "e4", "e64", "e6_randdepth", "e4_randdepth"],
+    ids=["e6", "e4", "e64", "e6_randdepth", "e4_randdepth", "e7", "e7_randdepth"],
 )
 def test_reentrant_e4_e6_full_train_step_lowers(overrides):
     """A full re-entrant train step (value_and_grad through the deep-supervision /
@@ -770,6 +772,8 @@ def test_reentrant_e4_e6_full_train_step_lowers(overrides):
     assert out_metrics_shape["train/loss"].shape == ()
     if overrides.get("anytime_supervision"):
         assert "train/anytime_ce" in out_metrics_shape
+    if overrides.get("ponder_halting"):
+        assert out_metrics_shape["train/ponder_recon"].shape == ()
     assert out_state_shape.pending_qb_betas.shape[0] == cfg.num_layers
 
 
@@ -950,6 +954,177 @@ def test_reentrant_anytime_readouts_absent_when_disabled():
         _, router_metrics = jax.jit(lambda m, t: m(t))(model, sharded_tokens)
 
     assert "anytime_readouts" not in router_metrics
+
+
+def _ponder_halting_distribution(halt_logits):
+    """Recompute the PonderNet halting distribution p_t (R, B, S) from halt logits.
+
+    Mirrors the exact formula in Transformer.next_token_loss: lam=sigmoid(logit),
+    remain_t = exclusive cumprod of (1-lam) (remain_0=1), p_t = lam*remain_t, and the
+    last step absorbs all remaining mass so Sum_t p_t == 1.
+    """
+    lam = jax.nn.sigmoid(halt_logits)
+    one_minus = 1.0 - lam
+    incl = jnp.cumprod(one_minus, axis=0)
+    ones = jnp.ones((1, *lam.shape[1:]), dtype=lam.dtype)
+    remain = jnp.concatenate([ones, incl[:-1]], axis=0)
+    p = lam * remain
+    return p.at[-1].set(remain[-1])
+
+
+def test_reentrant_ponder_does_not_touch_eval_loss():
+    """E7's PonderNet halting loss must be training-only: with reduction="none"
+    (the eval path), a model with ponder_halting=True returns the exact same
+    per-position loss as the identical model with it off. PonderNet adds the halt_head
+    param, but it is zero-init and never feeds back into the residual stream, so the
+    post-coda hidden and thus the eval CE are byte-identical.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg_off = _small_reentrant_config(model_module, ponder_halting=False)
+    cfg_on = _small_reentrant_config(model_module, ponder_halting=True)
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg_off.vocab_size
+    weights = jnp.ones((2, 8), dtype=jnp.float32)
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    def eval_loss(cfg, sharded_tokens, sharded_weights):
+        model = model_module.Transformer.init(cfg, key=key)
+        return jax.jit(lambda m, t, w: m.next_token_loss(t, w, reduction="none", logsumexp_weight=None))(
+            model, sharded_tokens, sharded_weights
+        )
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        sharded_weights = jax.sharding.reshard(weights, token_pspec)
+        loss_off = eval_loss(cfg_off, sharded_tokens, sharded_weights)
+        loss_on = eval_loss(cfg_on, sharded_tokens, sharded_weights)
+
+    assert loss_off.shape == (2, 8)
+    assert jnp.array_equal(loss_off, loss_on)
+
+
+def test_reentrant_ponder_adds_positive_terms_to_training_loss():
+    """With ponder_halting and reduction="mean", the recon/KL metrics are surfaced,
+    finite, and recon is positive; the training loss grows relative to ponder off.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg_off = _small_reentrant_config(model_module, ponder_halting=False)
+    cfg_on = _small_reentrant_config(model_module, ponder_halting=True)
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg_off.vocab_size
+    weights = jnp.ones((2, 8), dtype=jnp.float32)
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    def train_loss(cfg, sharded_tokens, sharded_weights):
+        model = model_module.Transformer.init(cfg, key=key)
+        return jax.jit(
+            lambda m, t, w: m.next_token_loss(t, w, reduction="mean", logsumexp_weight=None, return_router_metrics=True)
+        )(model, sharded_tokens, sharded_weights)
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        sharded_weights = jax.sharding.reshard(weights, token_pspec)
+        loss_off, metrics_off = train_loss(cfg_off, sharded_tokens, sharded_weights)
+        loss_on, metrics_on = train_loss(cfg_on, sharded_tokens, sharded_weights)
+
+    recon = metrics_on["train/ponder_recon"]
+    kl = metrics_on["train/ponder_kl"]
+    assert jnp.isfinite(recon)
+    assert jnp.isfinite(kl)
+    assert float(recon) > 0.0
+    assert float(loss_on) > float(loss_off)
+    # The ponder-off model never computes the terms, so it has no such metrics.
+    assert "train/ponder_recon" not in metrics_off
+    assert "train/ponder_kl" not in metrics_off
+
+
+def test_reentrant_ponder_halting_distribution_sums_to_one():
+    """The PonderNet halting distribution recomputed from the per-iteration halt
+    logits in router_metrics must sum to 1 across iterations for every (B, S) token,
+    and the reported expected-halt-step diagnostic must be finite and in [0, R-1].
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg = _small_reentrant_config(model_module, ponder_halting=True)
+    r = cfg.recurrence_steps
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg.vocab_size
+    weights = jnp.ones((2, 8), dtype=jnp.float32)
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        sharded_weights = jax.sharding.reshard(weights, token_pspec)
+        model = model_module.Transformer.init(cfg, key=key)
+        _, router_metrics = jax.jit(lambda m, t: m(t))(model, sharded_tokens)
+        _, metrics = jax.jit(
+            lambda m, t, w: m.next_token_loss(t, w, reduction="mean", logsumexp_weight=None, return_router_metrics=True)
+        )(model, sharded_tokens, sharded_weights)
+
+    halt_logits = router_metrics["ponder_halt_logits"]
+    assert halt_logits.shape == (r, 2, 8)
+    p = _ponder_halting_distribution(halt_logits)
+    assert jnp.allclose(jnp.sum(p, axis=0), 1.0, atol=1e-5)
+
+    expected_halt_step = metrics["train/ponder_expected_halt_step"]
+    assert jnp.isfinite(expected_halt_step)
+    assert 0.0 <= float(expected_halt_step) <= r - 1
+
+
+def test_reentrant_ponder_readouts_absent_when_disabled():
+    """With ponder_halting off (the default) the forward never adds a
+    ``ponder_halt_logits`` key to router_metrics, so E0-E6 traces are unchanged.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg = _small_reentrant_config(model_module, ponder_halting=False)
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg.vocab_size
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        model = model_module.Transformer.init(cfg, key=key)
+        _, router_metrics = jax.jit(lambda m, t: m(t))(model, sharded_tokens)
+
+    assert "ponder_halt_logits" not in router_metrics
+
+
+def test_reentrant_ponder_halt_head_uses_plain_adam_not_adamh():
+    """E7's halt head must be optimized by plain Adam, not AdamH. It is a 1-D
+    (hidden_dim,) zero-init vector; AdamH divides by the parameter norm, giving
+    0/0 = NaN at init. The mask routes it to ``adam`` because it doesn't match an
+    AdamH name rule and falls through the ndim==1 case.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+    optimizer_module = importlib.import_module("experiments.grug.reentrant.optimizer")
+    leaf_key_paths = importlib.import_module("levanter.utils.jax_utils").leaf_key_paths
+
+    cfg = _small_reentrant_config(model_module, ponder_halting=True)
+
+    with _reset_abstract_mesh(), set_mesh(compact_grug_mesh()):
+        model = model_module.Transformer.init(cfg, key=jax.random.PRNGKey(0))
+
+    def path_str(p):
+        return ".".join(p) if isinstance(p, (list, tuple)) else str(p)
+
+    mask = optimizer_module.GrugMoeAdamHConfig().create_mask(model)
+    paths = [path_str(p) for p in jax.tree.leaves(leaf_key_paths(model))]
+    groups = jax.tree.leaves(mask)
+
+    halt_groups = [g for path, g in zip(paths, groups, strict=True) if "halt_head" in path.lower()]
+    assert halt_groups, "expected halt_head in the tree when ponder_halting=True"
+    assert all(g == "adam" for g in halt_groups), f"halt head must use plain adam, got {set(halt_groups)}"
 
 
 def test_reentrant_depth_router_bias_uses_plain_adam_not_adamh():

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -712,6 +712,274 @@ def test_reentrant_core_consistency_absent_when_disabled():
     assert "core_consistency" not in router_metrics
 
 
+@pytest.mark.parametrize(
+    "overrides",
+    [
+        {"depth_conditioned_routing": True},
+        {"anytime_supervision": True},
+        {"depth_conditioned_routing": True, "anytime_supervision": True},
+        {"randomize_recurrence": True, "recurrence_choices": (2, 4, 8), "depth_conditioned_routing": True},
+        {"randomize_recurrence": True, "recurrence_choices": (2, 4, 8), "anytime_supervision": True},
+    ],
+    ids=["e6", "e4", "e64", "e6_randdepth", "e4_randdepth"],
+)
+def test_reentrant_e4_e6_full_train_step_lowers(overrides):
+    """A full re-entrant train step (value_and_grad through the deep-supervision /
+    depth-router terms, the AdamH param-group mask over the new params, and the
+    sharded forward) must lower for the E4/E6/E64 variants. This is the cheap
+    guarantee that the new code paths trace before any cluster spend -- it would
+    catch an AdamH-on-zeros NaN-by-construction, a bad shard spec on the new param,
+    or a tracing error in the per-iteration CE loop.
+    """
+    train_module = importlib.import_module("experiments.grug.reentrant.train")
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+    optimizer_module = importlib.import_module("experiments.grug.reentrant.optimizer")
+
+    cfg = model_module.GrugModelConfig(
+        vocab_size=1024,
+        num_layers=3,
+        num_prelude_layers=1,
+        num_coda_layers=1,
+        recurrence_steps=4,
+        **overrides,
+    )
+    # Use the real AdamH (not plain adam) so the param-group mask over the new
+    # tables is exercised -- a zero-init table landing in adamh would NaN here.
+    optimizer = optimizer_module.GrugMoeAdamHConfig().build(num_train_steps=2)
+    mp = jmp.get_policy("f32")
+    train_step = train_module._make_train_step(optimizer, mp, z_loss_weight=1e-4, ema_beta=None)
+    mesh, token_pspec = model_module.debug_mesh_and_token_pspec(num_devices=4)
+    batch = GrugLmExample(
+        tokens=jnp.zeros((8, 4), dtype=jnp.int32),
+        loss_weight=jnp.ones((8, 4), dtype=jnp.float32),
+        attn_mask=GrugAttentionMask.causal(),
+    )
+
+    def one_step():
+        sharded_batch = dataclasses.replace(
+            batch,
+            tokens=jax.sharding.reshard(batch.tokens, token_pspec),
+            loss_weight=jax.sharding.reshard(batch.loss_weight, token_pspec),
+        )
+        state = train_module.initial_state(cfg, optimizer=optimizer, mp=mp, key=jax.random.PRNGKey(0), ema_beta=None)
+        return train_step(state, sharded_batch, compute_watch=False)
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        out_state_shape, out_metrics_shape, _ = eqx.filter_eval_shape(one_step)
+
+    assert out_metrics_shape["train/loss"].shape == ()
+    if overrides.get("anytime_supervision"):
+        assert "train/anytime_ce" in out_metrics_shape
+    assert out_state_shape.pending_qb_betas.shape[0] == cfg.num_layers
+
+
+def _small_reentrant_config(model_module, **overrides):
+    """1 prelude + 1 core looped 4x + 1 coda re-entrant config (FiLM off), with
+    arbitrary field overrides for the E4/E6 variants."""
+    kwargs = dict(
+        vocab_size=128,
+        hidden_dim=32,
+        intermediate_dim=64,
+        num_layers=3,
+        num_prelude_layers=1,
+        num_coda_layers=1,
+        recurrence_steps=4,
+        iteration_film=False,
+        num_heads=2,
+        num_kv_heads=2,
+        num_experts=4,
+        num_experts_per_token=2,
+        shared_expert_intermediate_dim=64,
+        max_seq_len=8,
+    )
+    kwargs.update(overrides)
+    return model_module.GrugModelConfig(**kwargs)
+
+
+def test_reentrant_depth_conditioned_routing_is_identity_at_init():
+    """E6's depth-conditioned router bias must be identity at init: a model built
+    with ``depth_conditioned_routing=True`` and one without, from the SAME PRNG
+    key, must produce numerically identical forward outputs.
+
+    The bias table is zero-initialized and consumes no PRNG key, so every other
+    param is bit-identical and ``router_logits + 0 == router_logits``. This is the
+    contract that lets E6 be a strict superset of E3 (it can only diverge once the
+    per-depth router bias learns).
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg_e3 = _small_reentrant_config(model_module, depth_conditioned_routing=False)
+    cfg_e6 = _small_reentrant_config(model_module, depth_conditioned_routing=True)
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg_e3.vocab_size
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    def forward(cfg):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        model = model_module.Transformer.init(cfg, key=key)
+        return model, jax.jit(lambda m, t: m.logits(t))(model, sharded_tokens)
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        model_e3, logits_e3 = forward(cfg_e3)
+        model_e6, logits_e6 = forward(cfg_e6)
+
+    assert model_e3.core_router_bias is None
+    assert model_e6.core_router_bias is not None
+    expected_shape = (cfg_e6.max_trained_recurrence, cfg_e6.num_core_layers, cfg_e6.num_experts)
+    assert model_e6.core_router_bias.shape == expected_shape
+    # Zero bias => bit-identical forward outputs from the same key.
+    assert jnp.array_equal(logits_e3, logits_e6)
+
+
+def test_reentrant_depth_router_bias_changes_routing_once_learned():
+    """A nonzero per-depth router bias must actually move the forward output: it is
+    the mechanism by which each core traversal can activate a different expert
+    mixture. Setting one depth-slice's bias strongly toward one expert changes the
+    logits relative to the zero-init model.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg = _small_reentrant_config(model_module, depth_conditioned_routing=True)
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg.vocab_size
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        model = model_module.Transformer.init(cfg, key=key)
+        logits_zero = jax.jit(lambda m, t: m.logits(t))(model, sharded_tokens)
+        # Push iteration 0's first core layer hard toward expert 0.
+        biased = model.core_router_bias.at[0, 0, 0].set(50.0)
+        model_biased = eqx.tree_at(lambda m: m.core_router_bias, model, biased)
+        logits_biased = jax.jit(lambda m, t: m.logits(t))(model_biased, sharded_tokens)
+
+    assert jnp.all(jnp.isfinite(logits_biased))
+    assert not jnp.array_equal(logits_zero, logits_biased)
+
+
+def test_reentrant_anytime_does_not_touch_eval_loss():
+    """E4's anytime deep-supervision must be training-only: with reduction="none"
+    (the eval path), a model with anytime_supervision=True returns the exact same
+    per-position loss as the identical model with it off. E4's checkpoint shares
+    E3's param tree, so the only possible divergence is the term leaking into eval.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg_off = _small_reentrant_config(model_module, anytime_supervision=False)
+    cfg_on = _small_reentrant_config(model_module, anytime_supervision=True)
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg_off.vocab_size
+    weights = jnp.ones((2, 8), dtype=jnp.float32)
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    def eval_loss(cfg, sharded_tokens, sharded_weights):
+        model = model_module.Transformer.init(cfg, key=key)
+        return jax.jit(lambda m, t, w: m.next_token_loss(t, w, reduction="none", logsumexp_weight=None))(
+            model, sharded_tokens, sharded_weights
+        )
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        sharded_weights = jax.sharding.reshard(weights, token_pspec)
+        loss_off = eval_loss(cfg_off, sharded_tokens, sharded_weights)
+        loss_on = eval_loss(cfg_on, sharded_tokens, sharded_weights)
+
+    assert loss_off.shape == (2, 8)
+    assert jnp.array_equal(loss_off, loss_on)
+
+
+def test_reentrant_anytime_adds_positive_term_to_training_loss():
+    """With anytime_supervision and reduction="mean", the scalar training loss is
+    strictly greater than with it off (the averaged deep-supervision CE is
+    positive), and the raw ``train/anytime_ce`` metric is surfaced and finite.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg_off = _small_reentrant_config(model_module, anytime_supervision=False)
+    cfg_on = _small_reentrant_config(model_module, anytime_supervision=True, anytime_supervision_weight=1.0)
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg_off.vocab_size
+    weights = jnp.ones((2, 8), dtype=jnp.float32)
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    def train_loss(cfg, sharded_tokens, sharded_weights):
+        model = model_module.Transformer.init(cfg, key=key)
+        return jax.jit(
+            lambda m, t, w: m.next_token_loss(t, w, reduction="mean", logsumexp_weight=None, return_router_metrics=True)
+        )(model, sharded_tokens, sharded_weights)
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        sharded_weights = jax.sharding.reshard(weights, token_pspec)
+        loss_off, metrics_off = train_loss(cfg_off, sharded_tokens, sharded_weights)
+        loss_on, metrics_on = train_loss(cfg_on, sharded_tokens, sharded_weights)
+
+    raw = metrics_on["train/anytime_ce"]
+    assert jnp.isfinite(raw)
+    assert float(raw) > 0.0
+    assert float(loss_on) > float(loss_off)
+    assert jnp.allclose(loss_on, loss_off + raw, atol=1e-5)
+    assert jnp.allclose(metrics_on["train/anytime_ce_weighted"], raw, atol=1e-6)
+    # The anytime-off model never computes the term, so it has no such metric.
+    assert "train/anytime_ce" not in metrics_off
+
+
+def test_reentrant_anytime_readouts_absent_when_disabled():
+    """With anytime_supervision off (the default) the forward never adds an
+    ``anytime_readouts`` key to router_metrics, so E0-E3/E5/E6 traces are unchanged.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    cfg = _small_reentrant_config(model_module, anytime_supervision=False)
+
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % cfg.vocab_size
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        model = model_module.Transformer.init(cfg, key=key)
+        _, router_metrics = jax.jit(lambda m, t: m(t))(model, sharded_tokens)
+
+    assert "anytime_readouts" not in router_metrics
+
+
+def test_reentrant_depth_router_bias_uses_plain_adam_not_adamh():
+    """E6's depth-conditioned router bias must be optimized by plain Adam, not
+    AdamH. The table is zero-initialized; AdamH divides by the parameter norm,
+    giving 0/0 = NaN at init (the failure that bit E2's FiLM). The mask routes
+    ``core_router_bias`` to the ``adam`` group via the ``router_bias`` substring
+    rule rather than falling through ``ndim >= 2`` into ``adamh``.
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+    optimizer_module = importlib.import_module("experiments.grug.reentrant.optimizer")
+    leaf_key_paths = importlib.import_module("levanter.utils.jax_utils").leaf_key_paths
+
+    cfg = _small_reentrant_config(model_module, depth_conditioned_routing=True)
+
+    with _reset_abstract_mesh(), set_mesh(compact_grug_mesh()):
+        model = model_module.Transformer.init(cfg, key=jax.random.PRNGKey(0))
+
+    def path_str(p):
+        return ".".join(p) if isinstance(p, (list, tuple)) else str(p)
+
+    mask = optimizer_module.GrugMoeAdamHConfig().create_mask(model)
+    paths = [path_str(p) for p in jax.tree.leaves(leaf_key_paths(model))]
+    groups = jax.tree.leaves(mask)
+
+    bias_groups = [g for path, g in zip(paths, groups, strict=True) if "core_router_bias" in path.lower()]
+    assert bias_groups, "expected core_router_bias in the tree when depth_conditioned_routing=True"
+    assert all(g == "adam" for g in bias_groups), f"depth router bias must use plain adam, got {set(bias_groups)}"
+
+
 def test_reentrant_film_params_use_plain_adam_not_adamh():
     """E2's FiLM tables must be optimized by plain Adam, not AdamH.
 

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -23,6 +23,7 @@ import jmp
 import optax
 import pytest
 from fray.cluster import ResourceConfig
+from haliax.partitioning import set_mesh
 from jax._src import config as jax_config
 from jax.sharding import use_abstract_mesh
 from levanter.checkpoint import CheckpointerConfig
@@ -31,7 +32,7 @@ from levanter.data.text import DatasetComponent, DirectDatasetComponent, LmDataC
 from levanter.data.text.examples import GrugLmExample
 from levanter.distributed import DistributedConfig
 from levanter.grug.attention import AttentionMask as GrugAttentionMask
-from levanter.grug.sharding import _compact_grug_mesh_shape
+from levanter.grug.sharding import _compact_grug_mesh_shape, compact_grug_mesh
 from levanter.schedule import BatchSchedule
 from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.trainer import TrainerConfig
@@ -470,3 +471,64 @@ def test_reentrant_recurrent_config_lowers_and_keeps_router_stats_per_unique_blo
     assert out_metrics_shape["qb_beta_per_layer"].shape[0] == cfg.num_layers
     # pending_qb_betas in the next state must match the unique-block router biases.
     assert out_state_shape.pending_qb_betas.shape[0] == cfg.num_layers
+
+
+def test_reentrant_iteration_film_is_identity_at_init():
+    """E2's per-iteration FiLM must be identity at init: a model built with
+    ``iteration_film=True`` and one with ``iteration_film=False`` from the SAME
+    PRNG key must produce numerically identical forward outputs.
+
+    FiLM is initialized to zeros and consumes no PRNG key, so every other param is
+    bit-identical and ``x * (1 + 0) + 0 == x``. This is the contract that lets E2 be
+    a strict superset of E1 (it can only diverge once the FiLM tables learn).
+    """
+    model_module = importlib.import_module("experiments.grug.reentrant.model")
+
+    # Same small re-entrant config as the recurrence test: 1 prelude + 1 core looped
+    # 4x + 1 coda => 3 unique blocks, effective depth 6.
+    base_kwargs = dict(
+        vocab_size=128,
+        hidden_dim=32,
+        intermediate_dim=64,
+        num_layers=3,
+        num_prelude_layers=1,
+        num_coda_layers=1,
+        recurrence_steps=4,
+        num_heads=2,
+        num_kv_heads=2,
+        num_experts=4,
+        num_experts_per_token=2,
+        shared_expert_intermediate_dim=64,
+        max_seq_len=8,
+    )
+    cfg_e1 = model_module.GrugModelConfig(iteration_film=False, **base_kwargs)
+    cfg_e2 = model_module.GrugModelConfig(iteration_film=True, **base_kwargs)
+
+    # Concrete mesh so we can compare actual forward values (not just shapes). The
+    # default expert_axis_size=1 mesh works on a single CPU device; FiLM identity
+    # holds independent of mesh shape.
+    mesh = compact_grug_mesh()
+    key = jax.random.PRNGKey(0)
+    tokens = jnp.arange(2 * 8, dtype=jnp.int32).reshape(2, 8) % base_kwargs["vocab_size"]
+    token_pspec = jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None)
+
+    def forward(cfg):
+        sharded_tokens = jax.sharding.reshard(tokens, token_pspec)
+        model = model_module.Transformer.init(cfg, key=key)
+        return model, jax.jit(lambda m, t: m.logits(t))(model, sharded_tokens)
+
+    with _reset_abstract_mesh(), set_mesh(mesh):
+        model_e1, logits_e1 = forward(cfg_e1)
+        model_e2, logits_e2 = forward(cfg_e2)
+
+    # E1 carries no FiLM tables; E2 carries zero-initialized ones of the expected shape.
+    assert model_e1.core_film_scale is None
+    assert model_e1.core_film_shift is None
+    assert model_e2.core_film_scale is not None
+    assert model_e2.core_film_shift is not None
+    expected_film_shape = (cfg_e2.recurrence_steps, cfg_e2.num_core_layers, cfg_e2.hidden_dim)
+    assert model_e2.core_film_scale.shape == expected_film_shape
+    assert model_e2.core_film_shift.shape == expected_film_shape
+
+    # Identity FiLM => bit-identical forward outputs from the same key.
+    assert jnp.array_equal(logits_e1, logits_e2)


### PR DESCRIPTION
## Re-entrant (self-looping) transformers: design + empirical study on Grug MoE

Can a model "think longer" by **looping its own layers** instead of emitting more tokens?
This branch researches the idea and tests it end-to-end on the Marin/Grug d512 MoE at the
compute-optimal point (2.19e17 FLOPs, ~8.4e8 tokens), holding budget/optimizer/data fixed and
varying **only architecture**. Primary metric: `eval/paloma/macro_loss` (lower is better).

Live results ledger (weaver artifact): `reentrant-results`. Design doc: `reentrant-models-research`.

### What's here
- `experiments/grug/reentrant/` — a copy-first Grug variant: weight-tied **prelude → core-loop → coda**
  forward (`model.py`), randomized recurrence depth + per-iteration FiLM, a training-only
  **core-consistency penalty**, the dispatch/launch wiring (`launch.py`), and a **test-time
  depth-scaling eval harness** (`eval_sweep.py`) that restores one checkpoint and evaluates it at
  many loop counts R by swapping only the static config.
- Optimizer fix + tests for an AdamH NaN (zero-init FiLM tables must use plain Adam, not AdamH's
  norm-preserving update — `optimizer.py`, regression test).
- Contract tests in `tests/test_grug_variant_contracts.py`.

### Results (paloma macro, d512; all at effective depth ~6 unless swept)
| Exp | Variant | macro | vs E0 |
|-----|---------|-------|-------|
| **E0** | dense baseline (6 distinct blocks) | **3.818** | — (reproduces README 3.81 ✓) |
| **E1** | weight-tied loop4 (3 blocks, ½ params) | 3.905 | +0.087 |
| **E2** | E1 + per-iteration FiLM/adaLN | 3.908 | +0.090 (null) |
| **E3** | randomized depth R∈{2,4,8} | 3.937 @R8 | +0.119 |
| **E5** | E3 + core-consistency penalty | 4.085 best (λ300,R16) | +0.267 |

### Findings
1. **Weight-tied looping is parameter-efficient but lossy** — E1 costs +0.087 vs the dense E0 for
   half the unique-block params.
2. **Per-iteration conditioning (FiLM, E2) is a null result** at this scale.
3. **Naive test-time depth scaling (E3) is weak and does not extrapolate.** Sweeping one checkpoint
   over R=1..32: loss bottoms at the *max trained depth* (R=8) and **drifts upward beyond it** (R32
   worse than R8) — the looped map isn't contractive. "More loops = more thinking" holds only weakly
   and only inside the trained range.
4. **A consistency/convergence penalty (E5) fixes the drift but only by freezing the core.** As λ
   rises the depth curve flattens (λ=3000 is dead flat 4.114 from R1→R32 — a degenerate fixed point)
   and the usable-depth window extends, but the whole curve shifts *up* ~0.15–0.18: the penalty drives
   the per-iteration update to ~0, so looping becomes a no-op. The cure costs ~0.15 to remove ~0.02
   of drift — a net loss. A naive "input≈output" penalty conflates *converged* with *did-nothing*.

**Bottom line:** at d512, none of the simple "loop the same layers" variants beats the plain dense
baseline. The failure is structural — a single residual core re-applied in place either drifts (no
constraint) or freezes (with a contraction constraint), with no way to both keep computing *and*
converge.

### Recommended next direction (future work)
Decouple "keep computing" from "converge": **E4 — an anytime-decodable head with deep supervision /
self-distillation** (apply the LM head at every iteration, train all depths, distill deep→shallow) so
depth becomes a smooth quality knob and the core is rewarded for *useful* refinement rather than mere
consistency. A DEQ-style non-trivial learned fixed point, or a scratchpad the core writes to, are the
other candidates. The training-free per-token KL early-exit (#160) is deprioritized — its premise
(convergence ⇒ a good stop) is undercut by E3 (the convergent direction drifts) and E5 (models that do
converge are worse).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
