### PR TITLE
[levanter] Post-merge review follow-ups: regression tests + comment fix

### DIFF
--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -123,13 +123,15 @@ def initialize_jax(
     """
     import jax  # noqa: PLC0415  # optional dep: jax (iris does not depend on jax)
 
-    # Idempotent: if the caller already initialized jax.distributed (either by
-    # calling us explicitly first, or because user code touched JAX before our
-    # call site — JAX 0.9+ raises on a second `jax.distributed.initialize()`
-    # via the `xla_bridge.backends_are_initialized()` check), just return.
-    # Callers that touch JAX before levanter.initialize (e.g. via `hax.named`
-    # → `jnp.asarray` building loss-config args) can call `initialize_jax()`
-    # themselves first; levanter's later call lands here and is a no-op.
+    # Idempotent: skip if jax.distributed has already been initialized. This
+    # lets a caller that must touch JAX before levanter.initialize (e.g. via
+    # `hax.named` → `jnp.asarray` while building loss-config args) call
+    # `initialize_jax()` explicitly first; levanter's later call then lands
+    # here as a no-op instead of hitting JAX 0.9+'s
+    # `xla_bridge.backends_are_initialized()` guard, which raises on a second
+    # `jax.distributed.initialize()`. Note this only covers a prior *initialize*
+    # call — merely materializing a JAX array initializes the XLA backend, not
+    # jax.distributed, so `is_initialized()` stays False in that case.
     if jax.distributed.is_initialized():
         logger.info("jax.distributed already initialized; skipping")
         return

--- a/lib/levanter/tests/test_flash_attention.py
+++ b/lib/levanter/tests/test_flash_attention.py
@@ -202,3 +202,61 @@ def test_tpu_flash_attention(soft_cap):
 
         assert hax_out.axes == flash_out.axes
         assert_trees_all_close(hax_out.array, flash_out.array, atol=1e-3, rtol=1e-3)
+
+
+def test_flash_attention_noconstraint_mask_forward():
+    """`AttentionMask(is_causal=False)` materializes to None (full attention).
+
+    Regression: the inner loop guards `if mask is not None` on the AttentionMask
+    *object* (truthy), then materializes a per-block slice that is None for a
+    constraint-free mask — so `hax.where(None, ...)` raised TypeError. The fix
+    skips the mask op when the slice is None; the result must equal full
+    bidirectional attention.
+    """
+    Key = hax.Axis("Key", 8)
+    QPos = hax.Axis("QPos", BLOCK_SIZE * 2)
+    KPos = hax.Axis("KPos", BLOCK_SIZE * 2)
+
+    mask = AttentionMask(is_causal=False)
+    assert mask.materialize(QPos, KPos) is None  # precondition: this is the crashing case
+
+    q = hax.random.normal(jrandom.PRNGKey(0), (QPos, Key)) * 0.2
+    k = hax.random.normal(jrandom.PRNGKey(1), (KPos, Key)) * 0.2
+    v = hax.random.normal(jrandom.PRNGKey(2), (KPos, Key)) * 0.2
+
+    flash_out = flash_attention(QPos, KPos, Key, q, k, v, inference=True, mask=mask, block_size=BLOCK_SIZE)
+    hax_out = hnn.attention.dot_product_attention(KPos, Key, q, k, v)
+
+    assert hax_out.axes == flash_out.axes
+    assert_trees_all_close(hax_out.array, flash_out.array, atol=1e-3, rtol=1e-3)
+
+
+def test_flash_attention_noconstraint_mask_grad():
+    """Backward pass also re-materializes the mask, so the None-slice guard is
+    needed on the backward callsite too. Grad must match full attention."""
+    Key = hax.Axis("Key", 8)
+    QPos = hax.Axis("QPos", BLOCK_SIZE * 2)
+    KPos = hax.Axis("KPos", BLOCK_SIZE * 2)
+
+    mask = AttentionMask(is_causal=False)
+    assert mask.materialize(QPos, KPos) is None
+
+    q = hax.random.normal(jrandom.PRNGKey(0), (QPos, Key))
+    k = hax.random.normal(jrandom.PRNGKey(1), (KPos, Key))
+    v = hax.random.normal(jrandom.PRNGKey(2), (KPos, Key))
+
+    @equinox.filter_value_and_grad
+    def d_attn(qkv, fn):
+        q, k, v = qkv
+        x_out = fn(QPos, KPos, Key, q, k, v, mask=mask)
+        return (x_out * x_out).mean().scalar()
+
+    hax_val, (hax_dq, hax_dk, hax_dv) = d_attn((q, k, v), simple_attention_with_dropout)
+    fa_val, (fa_dq, fa_dk, fa_dv) = d_attn(
+        (q, k, v), functools.partial(flash_attention, inference=True, block_size=BLOCK_SIZE)
+    )
+
+    assert_trees_all_close(hax_val, fa_val, atol=1e-3, rtol=1e-3)
+    assert_trees_all_close(hax_dq.array, fa_dq.array, atol=1e-3, rtol=1e-3)
+    assert_trees_all_close(hax_dk.array, fa_dk.array, atol=1e-3, rtol=1e-3)
+    assert_trees_all_close(hax_dv.array, fa_dv.array, atol=1e-3, rtol=1e-3)

--- a/lib/levanter/tests/test_text.py
+++ b/lib/levanter/tests/test_text.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import shutil
 import tempfile
 from pathlib import Path
 
@@ -833,3 +834,43 @@ def test_build_caches_propagates_exception_from_one_component(tmp_path):
     )
     with pytest.raises(ValueError, match="No source and no cache"):
         config.build_caches("train")
+
+
+def test_build_caches_rebuilds_on_unloadable_cache(tmp_path):
+    """A cache dir that exists but won't load (no shard_ledger.json — the
+    leftover of a cache build killed before it finished) must not crash-loop:
+    with auto_build_caches on, build_caches catches the FileNotFoundError and
+    falls through to rebuild rather than propagating it.
+    """
+    records = [{"input_ids": [1, 2, 3, 4]}, {"input_ids": [5, 6, 7, 8]}]
+    data_path = tmp_path / "data.jsonl"
+    with data_path.open("w") as f:
+        for record in records:
+            f.write(json.dumps(record) + "\n")
+
+    component = DatasetComponent(
+        source=UrlDatasetSourceConfig(train_urls=[str(data_path)], validation_urls=[]),
+        format=PrebuiltLmDatasetFormat(),
+        cache_dir=str(tmp_path),
+    )
+    config = LmDataConfig(components={"c": component}, tokenizer="passthrough", vocab_size=16)
+    assert config.auto_build_caches  # precondition: rebuild path is enabled
+
+    config.build_caches("train")  # first build → complete cache
+
+    # Reduce the cache dir to "exists but unloadable": keep the directory so
+    # fsspec exists() is True, but empty it so load_lm_dataset_cache raises
+    # FileNotFoundError (no ledger). This is the partial state a killed build
+    # leaves behind.
+    cache_path = next(tmp_path.glob("**/shard_ledger.json")).parent
+    for child in cache_path.iterdir():
+        shutil.rmtree(child) if child.is_dir() else child.unlink()
+    assert cache_path.exists() and not any(cache_path.iterdir())
+
+    rebuilt = config.build_caches("train")["c"]
+    assert (cache_path / "shard_ledger.json").exists(), "rebuild should restore the ledger"
+    Pos = hax.Axis("position", 4)
+    ds = dataset_for_component(
+        component, Pos, rebuilt, eos_id=None, block_cross_document_attention=config.block_cross_document_attention
+    ).as_sync_dataset()
+    np.testing.assert_array_equal(np.asarray(ds[0].tokens), np.array(records[0]["input_ids"], dtype=np.int32))


### PR DESCRIPTION
Follow-ups to #6316, #6319, and #6320, which merged before their review fixes
landed. Adds flash_attention regression tests for the None-mask (full
bidirectional attention) path on both the forward and backward callsites; a
regression test asserting cache rebuild when a partial cache dir exists but
won't load (auto_build_caches on); and tightens the iris jax_init idempotency
comment, which had implied the is_initialized() guard also covers a JAX array
materialization (it only covers a prior initialize() call).
