### PR TITLE
[iris] Honor explicit accelerator CPU requests

### DIFF
--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -527,7 +527,9 @@ class ResourceSpec:
     disk: str | int = 0
     device: job_pb2.DeviceConfig | None = None
 
-    # Accelerator tasks need enough CPU to avoid bottlenecking on data loading.
+    # Accelerator tasks default to enough CPU to avoid bottlenecking on data
+    # loading, but explicit CPU requests are preserved for quota-constrained
+    # queues and diagnostic runs.
     MIN_ACCELERATOR_CPU_MILLICORES = 32_000
 
     def to_proto(self) -> job_pb2.ResourceSpecProto:
@@ -535,7 +537,7 @@ class ResourceSpec:
         memory_bytes = self.memory if isinstance(self.memory, int) else parse_memory_string(self.memory)
         disk_bytes = self.disk if isinstance(self.disk, int) else parse_memory_string(self.disk)
         cpu_mc = int(self.cpu * 1000)
-        if self.device is not None and cpu_mc < self.MIN_ACCELERATOR_CPU_MILLICORES:
+        if self.device is not None and cpu_mc == 0:
             cpu_mc = self.MIN_ACCELERATOR_CPU_MILLICORES
         spec = job_pb2.ResourceSpecProto(
             cpu_millicores=cpu_mc,

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -530,14 +530,14 @@ class ResourceSpec:
     # Accelerator tasks default to enough CPU to avoid bottlenecking on data
     # loading, but explicit CPU requests are preserved for quota-constrained
     # queues and diagnostic runs.
-    MIN_ACCELERATOR_CPU_MILLICORES = 32_000
+    MIN_ACCELERATOR_CPU_MILLICORES = 4_000
 
     def to_proto(self) -> job_pb2.ResourceSpecProto:
         """Convert to wire format."""
         memory_bytes = self.memory if isinstance(self.memory, int) else parse_memory_string(self.memory)
         disk_bytes = self.disk if isinstance(self.disk, int) else parse_memory_string(self.disk)
         cpu_mc = int(self.cpu * 1000)
-        if self.device is not None and cpu_mc == 0:
+        if self.device is not None and cpu_mc < self.MIN_ACCELERATOR_CPU_MILLICORES:
             cpu_mc = self.MIN_ACCELERATOR_CPU_MILLICORES
         spec = job_pb2.ResourceSpecProto(
             cpu_millicores=cpu_mc,

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -17,15 +17,7 @@ from iris.cluster.constraints import (
     preemptible_constraint,
     region_constraint,
 )
-from iris.cluster.types import (
-    Entrypoint,
-    JobName,
-    ResourceSpec,
-    TaskAttempt,
-    adjust_tpu_replicas,
-    gpu_device,
-    tpu_device,
-)
+from iris.cluster.types import Entrypoint, JobName, TaskAttempt, adjust_tpu_replicas, gpu_device, tpu_device
 from iris.rpc import job_pb2
 
 
@@ -76,18 +68,6 @@ def test_entrypoint_callable_has_workdir_files():
     assert "_callable.pkl" in ep.workdir_files
     assert "_callable_runner.py" in ep.workdir_files
     assert ep.command is not None
-
-
-def test_resource_spec_accelerator_without_cpu_uses_default_cpu_request():
-    proto = ResourceSpec(device=gpu_device("H100", count=8)).to_proto()
-
-    assert proto.cpu_millicores == ResourceSpec.MIN_ACCELERATOR_CPU_MILLICORES
-
-
-def test_resource_spec_accelerator_honors_explicit_cpu_request():
-    proto = ResourceSpec(cpu=8, device=gpu_device("H100", count=8)).to_proto()
-
-    assert proto.cpu_millicores == 8000
 
 
 def test_job_name_roundtrip_and_hierarchy():

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -17,7 +17,15 @@ from iris.cluster.constraints import (
     preemptible_constraint,
     region_constraint,
 )
-from iris.cluster.types import Entrypoint, JobName, TaskAttempt, adjust_tpu_replicas, gpu_device, tpu_device
+from iris.cluster.types import (
+    Entrypoint,
+    JobName,
+    ResourceSpec,
+    TaskAttempt,
+    adjust_tpu_replicas,
+    gpu_device,
+    tpu_device,
+)
 from iris.rpc import job_pb2
 
 
@@ -68,6 +76,18 @@ def test_entrypoint_callable_has_workdir_files():
     assert "_callable.pkl" in ep.workdir_files
     assert "_callable_runner.py" in ep.workdir_files
     assert ep.command is not None
+
+
+def test_resource_spec_accelerator_without_cpu_uses_default_cpu_request():
+    proto = ResourceSpec(device=gpu_device("H100", count=8)).to_proto()
+
+    assert proto.cpu_millicores == ResourceSpec.MIN_ACCELERATOR_CPU_MILLICORES
+
+
+def test_resource_spec_accelerator_honors_explicit_cpu_request():
+    proto = ResourceSpec(cpu=8, device=gpu_device("H100", count=8)).to_proto()
+
+    assert proto.cpu_millicores == 8000
 
 
 def test_job_name_roundtrip_and_hierarchy():


### PR DESCRIPTION
Preserve explicit CPU requests on accelerator jobs instead of always raising them to the accelerator default. Jobs that omit CPU still get the existing accelerator CPU floor, while quota-constrained or diagnostic jobs can request a smaller explicit CPU count.