### PR TITLE
[iris] Add task image override for jobs

### DIFF
--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -550,6 +550,7 @@ def run_iris_job(
     reserve: tuple[str, ...] | None = None,
     priority: str | None = None,
     preemptible: bool | None = None,
+    task_image: str | None = None,
     token_provider: TokenProvider | None = None,
     submit_argv: list[str] | None = None,
     dashboard_url: str | None = None,
@@ -567,6 +568,8 @@ def run_iris_job(
         reserve: Reservation specs (e.g., ("4:H100x8", "v5litepod-16")).
         preemptible: If True/False, force scheduling on (non-)preemptible workers
             and bypass the executor heuristic. If None (default), the heuristic runs.
+        task_image: Optional task container image override. When None, workers use
+            their cluster-configured default task image.
 
     Returns:
         Exit code: 0 for success, 1 for failure
@@ -631,6 +634,8 @@ def run_iris_job(
         logger.info(f"Preemptible constraint: {preemptible}")
     if reservation:
         logger.info(f"Reservation: {len(reservation)} entries")
+    if task_image:
+        logger.info(f"Task image: {task_image}")
 
     logger.info(f"Using controller: {controller_url}")
     priority_band = job_pb2.PRIORITY_BAND_UNSPECIFIED
@@ -658,6 +663,7 @@ def run_iris_job(
         token_provider=token_provider,
         submit_argv=submit_argv,
         dashboard_url=dashboard_url,
+        task_image=task_image,
     )
 
 
@@ -681,6 +687,7 @@ def _submit_and_wait_job(
     token_provider: TokenProvider | None = None,
     submit_argv: list[str] | None = None,
     dashboard_url: str | None = None,
+    task_image: str | None = None,
 ) -> int:
     """Submit job and optionally wait for completion.
 
@@ -704,6 +711,7 @@ def _submit_and_wait_job(
         reservation=reservation,
         priority_band=priority_band,
         submit_argv=submit_argv,
+        task_image=task_image,
     )
 
     logger.info(f"Job submitted: {job.job_id}")
@@ -843,6 +851,15 @@ Examples:
     ),
 )
 @click.option(
+    "--task-image",
+    type=str,
+    default=None,
+    help=(
+        "Override the task container image for this job. "
+        "The image must already exist in a registry visible to workers."
+    ),
+)
+@click.option(
     "--terminate-on-exit/--no-terminate-on-exit",
     default=True,
     help="Terminate the job on Ctrl+C (default: terminate). Tunnel failures never kill the job.",
@@ -870,6 +887,7 @@ def run(
     reserve: tuple[str, ...],
     priority: str | None,
     preemptible: bool | None,
+    task_image: str | None,
     terminate_on_exit: bool,
     cmd: tuple[str, ...],
 ):
@@ -922,6 +940,7 @@ def run(
             reserve=reserve or None,
             priority=priority,
             preemptible=preemptible,
+            task_image=task_image,
             token_provider=ctx.obj.get("token_provider"),
             submit_argv=submit_argv,
             dashboard_url=dashboard_url or None,

--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -5,6 +5,7 @@
 
 import click
 import pytest
+from click.testing import CliRunner
 from iris.cli.job import (
     _parse_tpu_alternatives,
     _render_job_summary_text,
@@ -12,7 +13,7 @@ from iris.cli.job import (
     build_job_summary,
     build_resources,
     build_tpu_alternatives,
-    run_iris_job,
+    run,
     validate_extra_resources,
     validate_region_zone,
 )
@@ -185,25 +186,32 @@ def test_build_job_constraints_preemptible_true_overrides_heuristic():
     assert _preemptible_values(constraints) == ["true"]
 
 
-def test_run_iris_job_passes_task_image_override(monkeypatch):
-    captured: dict[str, str | None] = {}
+def test_job_run_cli_accepts_task_image_override(monkeypatch):
+    captured: dict[str, object] = {}
 
     def fake_submit_and_wait_job(**kwargs):
-        captured["task_image"] = kwargs["task_image"]
+        captured.update(kwargs)
         return 0
 
     monkeypatch.setattr("iris.cli.job._submit_and_wait_job", fake_submit_and_wait_job)
 
-    exit_code = run_iris_job(
-        command=["python", "train.py"],
-        env_vars={},
-        controller_url="http://controller.test",
-        wait=False,
-        task_image="ghcr.io/marin-community/iris-task-cuda-devel:test",
+    result = CliRunner().invoke(
+        run,
+        [
+            "--task-image",
+            "ghcr.io/marin-community/iris-task-cuda-devel:test",
+            "--no-wait",
+            "--",
+            "python",
+            "train.py",
+        ],
+        obj={"controller_url": "http://controller.test", "config": None, "token_provider": None},
     )
 
-    assert exit_code == 0
-    assert captured == {"task_image": "ghcr.io/marin-community/iris-task-cuda-devel:test"}
+    assert result.exit_code == 0, result.output
+    assert captured["task_image"] == "ghcr.io/marin-community/iris-task-cuda-devel:test"
+    assert captured["command"] == ["python", "train.py"]
+    assert captured["wait"] is False
 
 
 # --tpu multi-variant parsing

--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -12,6 +12,7 @@ from iris.cli.job import (
     build_job_summary,
     build_resources,
     build_tpu_alternatives,
+    run_iris_job,
     validate_extra_resources,
     validate_region_zone,
 )
@@ -182,6 +183,27 @@ def test_build_job_constraints_preemptible_true_overrides_heuristic():
 
     # Exactly one preemptible constraint, and it reflects the user's choice.
     assert _preemptible_values(constraints) == ["true"]
+
+
+def test_run_iris_job_passes_task_image_override(monkeypatch):
+    captured: dict[str, str | None] = {}
+
+    def fake_submit_and_wait_job(**kwargs):
+        captured["task_image"] = kwargs["task_image"]
+        return 0
+
+    monkeypatch.setattr("iris.cli.job._submit_and_wait_job", fake_submit_and_wait_job)
+
+    exit_code = run_iris_job(
+        command=["python", "train.py"],
+        env_vars={},
+        controller_url="http://controller.test",
+        wait=False,
+        task_image="ghcr.io/marin-community/iris-task-cuda-devel:test",
+    )
+
+    assert exit_code == 0
+    assert captured == {"task_image": "ghcr.io/marin-community/iris-task-cuda-devel:test"}
 
 
 # --tpu multi-variant parsing

--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -189,11 +189,21 @@ def test_build_job_constraints_preemptible_true_overrides_heuristic():
 def test_job_run_cli_accepts_task_image_override(monkeypatch):
     captured: dict[str, object] = {}
 
-    def fake_submit_and_wait_job(**kwargs):
-        captured.update(kwargs)
-        return 0
+    class FakeJob:
+        job_id = "test-job"
 
-    monkeypatch.setattr("iris.cli.job._submit_and_wait_job", fake_submit_and_wait_job)
+    class FakeClient:
+        def submit(self, **kwargs):
+            captured.update(kwargs)
+            return FakeJob()
+
+    def fake_remote(controller_url, workspace, token_provider):
+        captured["controller_url"] = controller_url
+        captured["workspace"] = workspace
+        captured["token_provider"] = token_provider
+        return FakeClient()
+
+    monkeypatch.setattr("iris.cli.job.IrisClient.remote", fake_remote)
 
     result = CliRunner().invoke(
         run,
@@ -210,8 +220,8 @@ def test_job_run_cli_accepts_task_image_override(monkeypatch):
 
     assert result.exit_code == 0, result.output
     assert captured["task_image"] == "ghcr.io/marin-community/iris-task-cuda-devel:test"
-    assert captured["command"] == ["python", "train.py"]
-    assert captured["wait"] is False
+    assert captured["controller_url"] == "http://controller.test"
+    assert captured["entrypoint"].command == ["python", "train.py"]
 
 
 # --tpu multi-variant parsing


### PR DESCRIPTION
Thread an optional task-image override through iris job submission and the CLI. This lets GPU diagnostics use a known CUDA-devel worker image without changing the cluster default image.