### PR TITLE
[grug] Nest cw-scale MoE outputs under experiments/grug-moe-cw/

### DIFF
--- a/experiments/grug/moe/launch_cw_scale.py
+++ b/experiments/grug/moe/launch_cw_scale.py
@@ -81,6 +81,10 @@ SCALE_OPTIMIZER = AdamConfig(
 
 SCALE_TRAINER_DEFAULTS = dict(z_loss_weight=1e-4, ema_beta=None, log_every=1)
 
+# Subdirectory of MARIN_PREFIX these scale runs write their per-run output dirs
+# into, so they stay grouped instead of cluttering the prefix root.
+OUTPUT_SUBDIR = "experiments/grug-moe-cw"
+
 
 def build_scale_model() -> GrugModelConfig:
     """~90B-total / ~5B-active sparse MoE (overridable via SCALE_* env vars)."""
@@ -177,7 +181,7 @@ def build_scale_step() -> ExecutorStep:
 
     name = f"grug-moe-cw-d{model.hidden_dim}-L{model.num_layers}-e{model.num_experts}-r{replicas}"
     return ExecutorStep(
-        name=f"{name}-{run_id}",
+        name=f"{OUTPUT_SUBDIR}/{name}-{run_id}",
         fn=run_grug_moe_trial,
         config=GrugMoeLaunchConfig(
             model=versioned(model),


### PR DESCRIPTION
launch_cw_scale.py wrote one output dir per manual scale run directly to the MARIN_PREFIX root, cluttering it alongside other experiment outputs. Nest these runs under a dedicated experiments/grug-moe-cw/ subdir so they stay grouped.

This only changes where future runs land; existing outputs at the root are untouched.