### PR TITLE
[status-page] Show all three datakit ferry tiers as stacked strips

### DIFF
--- a/infra/status-page/README.md
+++ b/infra/status-page/README.md
@@ -145,20 +145,31 @@ if it's unreachable.
 
 ### Ferry workflows
 
-Ferry workflows live in `server/sources/githubActions.ts`:
+Ferries live in `server/sources/githubActions.ts`. Each ferry is one card
+and groups one or more tiers; a tier maps to a single workflow file. Most
+ferries have a single tier; the datakit ferry stacks three (tier1/2/3) as
+separate strips under one card:
 
 ```ts
-export const FERRY_WORKFLOWS = [
-  { name: "Canary ferry", file: "marin-canary-ferry.yaml" },
-  { name: "CW ferry", file: "marin-canary-ferry-coreweave.yaml" },
-  { name: "Datakit ferry", file: "marin-canary-datakit-tier1.yaml" },
-] as const;
+export const FERRY_GROUPS: FerryGroupConfig[] = [
+  { name: "Canary ferry", tiers: [{ label: null, file: "marin-canary-ferry.yaml" }] },
+  { name: "CW ferry", tiers: [{ label: null, file: "marin-canary-ferry-coreweave.yaml" }] },
+  {
+    name: "Datakit ferry",
+    tiers: [
+      { label: "tier1", file: "marin-canary-datakit-tier1.yaml" },
+      { label: "tier2", file: "marin-canary-datakit-tier2.yaml" },
+      { label: "tier3", file: "marin-canary-datakit-tier3.yaml" },
+    ],
+  },
+];
 ```
 
-Add more by appending to the array. `file` is the workflow filename
-under `.github/workflows/`. The `main`-branch filter is hardcoded in
-`fetchWorkflowStatus`; the 10-day history window is set in
-`server/main.ts`.
+Add ferries or tiers by appending to the array. `file` is the workflow
+filename under `.github/workflows/`; `label` captions the strip in a
+multi-tier card (use `null` for single-tier ferries, where the file is
+shown as the subtitle). The `main`-branch filter is hardcoded in
+`fetchTierStatus`; the 10-day history window is set in `server/main.ts`.
 
 ### Build panel
 

--- a/infra/status-page/server/main.ts
+++ b/infra/status-page/server/main.ts
@@ -22,6 +22,7 @@ import { IrisPingHistory, ServiceHealthHistory, WorkerHistory } from "./history.
 import {
   FERRY_GROUPS,
   fetchTierStatus,
+  type FerryGroupStatus,
   type FerryTierStatus,
 } from "./sources/githubActions.js";
 import { fetchBuildsOnMain, type BuildsResponse } from "./sources/githubCommits.js";
@@ -137,7 +138,7 @@ const app = new Hono();
 app.get("/api/health", (c) => c.json({ status: "ok" }));
 
 app.get("/api/ferry", async (c) => {
-  const groups = await Promise.all(
+  const groups: FerryGroupStatus[] = await Promise.all(
     FERRY_GROUPS.map(async (group) => ({
       name: group.name,
       tiers: await Promise.all(

--- a/infra/status-page/server/main.ts
+++ b/infra/status-page/server/main.ts
@@ -20,9 +20,9 @@ import { Hono } from "hono";
 import { TTLCache } from "./cache.js";
 import { IrisPingHistory, ServiceHealthHistory, WorkerHistory } from "./history.js";
 import {
-  FERRY_WORKFLOWS,
-  fetchWorkflowStatus,
-  type FerryWorkflowStatus,
+  FERRY_GROUPS,
+  fetchTierStatus,
+  type FerryTierStatus,
 } from "./sources/githubActions.js";
 import { fetchBuildsOnMain, type BuildsResponse } from "./sources/githubCommits.js";
 import { irisStatus, pingIris, type IrisPingResult } from "./sources/iris.js";
@@ -38,7 +38,9 @@ import { workerSnapshot, type WorkersSnapshot } from "./sources/workers.js";
 const FERRY_WINDOW_DAYS = 10;
 const BUILD_HISTORY = 100;
 
-const ferryCache = new TTLCache<FerryWorkflowStatus>(60_000);
+// Cache is keyed per tier workflow file so the three datakit tiers share
+// the same shield as the single-workflow ferries.
+const ferryCache = new TTLCache<FerryTierStatus>(60_000);
 const buildCache = new TTLCache<BuildsResponse>(60_000);
 const workersCache = new TTLCache<WorkersSnapshot>(15_000);
 const jobsCache = new TTLCache<JobsSnapshot>(60_000);
@@ -135,12 +137,17 @@ const app = new Hono();
 app.get("/api/health", (c) => c.json({ status: "ok" }));
 
 app.get("/api/ferry", async (c) => {
-  const results = await Promise.all(
-    FERRY_WORKFLOWS.map((wf) =>
-      ferryCache.get(wf.file, () => fetchWorkflowStatus(wf, FERRY_WINDOW_DAYS)),
-    ),
+  const groups = await Promise.all(
+    FERRY_GROUPS.map(async (group) => ({
+      name: group.name,
+      tiers: await Promise.all(
+        group.tiers.map((tier) =>
+          ferryCache.get(tier.file, () => fetchTierStatus(tier, FERRY_WINDOW_DAYS)),
+        ),
+      ),
+    })),
   );
-  return c.json({ windowDays: FERRY_WINDOW_DAYS, workflows: results });
+  return c.json({ windowDays: FERRY_WINDOW_DAYS, groups });
 });
 
 app.get("/api/builds", async (c) => {

--- a/infra/status-page/server/sources/githubActions.ts
+++ b/infra/status-page/server/sources/githubActions.ts
@@ -12,13 +12,32 @@ import { githubAuthHeaders, REPO } from "./github.js";
 const MAX_WORKFLOW_RUNS_PER_REQUEST = 100;
 const MS_PER_DAY = 24 * 60 * 60 * 1000;
 
-export const FERRY_WORKFLOWS = [
-  { name: "Canary ferry", file: "marin-canary-ferry.yaml" },
-  { name: "CW ferry", file: "marin-canary-ferry-coreweave.yaml" },
-  { name: "Datakit ferry", file: "marin-canary-datakit-tier1.yaml" },
-] as const;
+// A ferry is one card on the dashboard. Most map to a single workflow file;
+// the datakit ferry runs three tiers (tier1/2/3) we surface as three strips
+// under one card. `label` is the per-tier caption (null for single-tier
+// ferries, where the file subtitle identifies the workflow).
+export interface FerryTier {
+  label: string | null;
+  file: string;
+}
 
-export type WorkflowConfig = (typeof FERRY_WORKFLOWS)[number];
+export interface FerryGroupConfig {
+  name: string;
+  tiers: FerryTier[];
+}
+
+export const FERRY_GROUPS: FerryGroupConfig[] = [
+  { name: "Canary ferry", tiers: [{ label: null, file: "marin-canary-ferry.yaml" }] },
+  { name: "CW ferry", tiers: [{ label: null, file: "marin-canary-ferry-coreweave.yaml" }] },
+  {
+    name: "Datakit ferry",
+    tiers: [
+      { label: "tier1", file: "marin-canary-datakit-tier1.yaml" },
+      { label: "tier2", file: "marin-canary-datakit-tier2.yaml" },
+      { label: "tier3", file: "marin-canary-datakit-tier3.yaml" },
+    ],
+  },
+];
 
 export interface FerryRun {
   id: number;
@@ -33,14 +52,19 @@ export interface FerryRun {
   actor: string;
 }
 
-export interface FerryWorkflowStatus {
-  name: string;
+export interface FerryTierStatus {
+  label: string | null;
   file: string;
   latest: FerryRun | null;
   history: FerryRun[];
   successRate: number | null; // [0, 1] over completed runs in the window; null if no completed runs
   fetchedAt: string;
   error?: string;
+}
+
+export interface FerryGroupStatus {
+  name: string;
+  tiers: FerryTierStatus[];
 }
 
 // GitHub's API response shape for the subset of fields we read. Keeping
@@ -91,10 +115,10 @@ function computeSuccessRate(runs: FerryRun[]): number | null {
   return successes / completed.length;
 }
 
-export async function fetchWorkflowStatus(
-  workflow: WorkflowConfig,
+export async function fetchTierStatus(
+  tier: FerryTier,
   windowDays: number,
-): Promise<FerryWorkflowStatus> {
+): Promise<FerryTierStatus> {
   const fetchedAt = new Date().toISOString();
   const cutoff = new Date(Date.now() - windowDays * MS_PER_DAY);
   const params = new URLSearchParams({
@@ -103,20 +127,20 @@ export async function fetchWorkflowStatus(
     created: `>=${cutoff.toISOString()}`,
   });
   const url =
-    `https://api.github.com/repos/${REPO}/actions/workflows/${workflow.file}` +
+    `https://api.github.com/repos/${REPO}/actions/workflows/${tier.file}` +
     `/runs?${params.toString()}`;
 
   // Every failure path returns a snapshot with `error` set instead of
-  // throwing, so callers that aggregate multiple workflows with
-  // Promise.all can surface one-workflow failures in the UI without
-  // turning /api/ferry into a 500.
+  // throwing, so callers that aggregate multiple tiers with Promise.all
+  // can surface one-tier failures in the UI without turning /api/ferry
+  // into a 500.
   try {
     const res = await fetch(url, { headers: githubAuthHeaders() });
     if (!res.ok) {
       const body = await res.text().catch(() => "");
       return {
-        name: workflow.name,
-        file: workflow.file,
+        label: tier.label,
+        file: tier.file,
         latest: null,
         history: [],
         successRate: null,
@@ -131,8 +155,8 @@ export async function fetchWorkflowStatus(
       .map(toFerryRun)
       .filter((run) => Date.parse(run.startedAt) >= cutoffMs);
     return {
-      name: workflow.name,
-      file: workflow.file,
+      label: tier.label,
+      file: tier.file,
       latest: history[0] ?? null,
       history,
       successRate: computeSuccessRate(history),
@@ -140,8 +164,8 @@ export async function fetchWorkflowStatus(
     };
   } catch (err) {
     return {
-      name: workflow.name,
-      file: workflow.file,
+      label: tier.label,
+      file: tier.file,
       latest: null,
       history: [],
       successRate: null,

--- a/infra/status-page/web/src/api.ts
+++ b/infra/status-page/web/src/api.ts
@@ -18,8 +18,10 @@ export interface FerryRun {
   actor: string;
 }
 
-export interface FerryWorkflowStatus {
-  name: string;
+// One strip within a ferry card. `label` is the tier caption (e.g. "tier1");
+// null for single-workflow ferries, where `file` is shown as the subtitle.
+export interface FerryTierStatus {
+  label: string | null;
   file: string;
   latest: FerryRun | null;
   history: FerryRun[];
@@ -28,9 +30,14 @@ export interface FerryWorkflowStatus {
   error?: string;
 }
 
+export interface FerryGroupStatus {
+  name: string;
+  tiers: FerryTierStatus[];
+}
+
 export interface FerryResponse {
   windowDays: number;
-  workflows: FerryWorkflowStatus[];
+  groups: FerryGroupStatus[];
 }
 
 // Per-commit aggregate check-run status for the last N commits on main.

--- a/infra/status-page/web/src/components/FerryPanel.tsx
+++ b/infra/status-page/web/src/components/FerryPanel.tsx
@@ -1,6 +1,6 @@
 import type { CSSProperties } from "react";
 import { useFerry } from "../hooks/useFerry";
-import type { FerryRun, FerryWorkflowStatus } from "../api";
+import type { FerryGroupStatus, FerryRun, FerryTierStatus } from "../api";
 
 // Diagonal gray/red stripe marks cancelled runs — they count as failures
 // for success-rate math but carry a distinct cause worth surfacing.
@@ -91,99 +91,121 @@ function formatRelative(iso: string): string {
   return `${days}d ago`;
 }
 
-function WorkflowCard({ wf }: { wf: FerryWorkflowStatus }) {
-  const latest = wf.latest;
-  const successRate = wf.successRate;
+// One tier's run strip: latest-run line, success rate, and the 10-day
+// history dots. A single-workflow ferry renders exactly one of these; the
+// datakit ferry stacks three (tier1/2/3) under one card.
+function TierStrip({ tier, showLabel }: { tier: FerryTierStatus; showLabel: boolean }) {
+  const latest = tier.latest;
+  const successRate = tier.successRate;
   // The API keeps history newest-first for latest-run math. The strip reads
   // more naturally oldest-to-newest, with the most recent run on the right.
-  const visualHistory = wf.history.map((run, index) => ({ run, index })).reverse();
+  const visualHistory = tier.history.map((run, index) => ({ run, index })).reverse();
   // Match the denominator the server uses for `successRate`
   // (githubActions.ts:computeSuccessRate) — completed runs only, not
   // the raw history length which can include queued/in-progress runs.
-  const completedCount = wf.history.filter(
+  const completedCount = tier.history.filter(
     (r) => r.status === "completed" && r.conclusion !== null,
   ).length;
+
+  if (tier.error) {
+    return (
+      <div>
+        {showLabel && <div className="font-mono text-xs text-slate-400">{tier.label}</div>}
+        <div className="text-sm text-rose-400">{tier.error}</div>
+      </div>
+    );
+  }
+
+  return (
+    <div>
+      <div className="flex flex-wrap items-center gap-3 text-sm">
+        {showLabel && <span className="font-mono text-xs text-slate-400">{tier.label}</span>}
+        {latest ? (
+          <a
+            href={latest.url}
+            target="_blank"
+            rel="noreferrer"
+            className="inline-flex items-center gap-2 text-slate-200 hover:text-emerald-300"
+          >
+            {(() => {
+              const a = runAppearance(latest);
+              return <span className={`h-3 w-3 rounded-full ${a.className}`} style={a.style} />;
+            })()}
+            <span className="font-mono text-xs">{latest.shaShort}</span>
+            <span className="text-slate-400">{formatRelative(latest.startedAt)}</span>
+            <span className="text-slate-500">({formatDuration(latest.durationSeconds)})</span>
+          </a>
+        ) : (
+          <span className="text-slate-400">no runs yet</span>
+        )}
+        <span className="ml-auto text-slate-400">
+          {successRate === null
+            ? "—"
+            : `${Math.round(successRate * 100)}% success over ${completedCount}`}
+        </span>
+      </div>
+
+      {/* Single-row strip — dots and inter-dot gap shrink on mobile
+          so the visible window fits without wrapping to a second row. */}
+      <div className="mt-2 flex gap-px sm:gap-1">
+        {visualHistory.map(({ run, index }) => {
+          const a = runAppearance(run);
+          const slow = isSlowRun(tier.history, index);
+          const baseline = slow ? slowRunBaseline(tier.history, index) : null;
+          return (
+            <a
+              key={run.id}
+              href={run.url}
+              target="_blank"
+              rel="noreferrer"
+              className={`group relative h-5 w-2 rounded-sm sm:w-2.5 ${a.className} hover:ring-2 hover:ring-slate-400`}
+              style={a.style}
+            >
+              {slow && (
+                <span
+                  aria-label="slow run"
+                  className="pointer-events-none absolute -right-0.5 -top-1 font-bold leading-none text-amber-300"
+                  style={{ fontSize: "10px", textShadow: "0 0 2px #0f172a, 0 0 2px #0f172a" }}
+                >
+                  !
+                </span>
+              )}
+              <div className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 hidden -translate-x-1/2 whitespace-nowrap rounded border border-slate-700 bg-slate-950/95 px-2 py-1 text-xs text-slate-200 shadow-lg group-hover:block">
+                <div className="font-mono text-slate-300">{run.shaShort}</div>
+                <div className="text-slate-400">
+                  {run.conclusion ?? run.status} · {formatRelative(run.startedAt)}
+                </div>
+                <div>wall time: {formatDuration(run.durationSeconds)}</div>
+                {slow && baseline !== null && (
+                  <div className="text-amber-300">
+                    slow · prior {baseline.sampleSize} successful runs mean+1σ ≈{" "}
+                    {formatDuration(Math.round(baseline.threshold))}
+                  </div>
+                )}
+              </div>
+            </a>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function FerryCard({ group }: { group: FerryGroupStatus }) {
+  // Single-workflow ferries show their file as the subtitle; multi-tier
+  // ferries (datakit) caption each strip with its tier label instead.
+  const single = group.tiers.length === 1;
   return (
     <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-3">
       <div className="min-w-0">
-        <h3 className="truncate text-base font-semibold text-slate-100">{wf.name}</h3>
-        <div className="truncate text-xs text-slate-500">{wf.file}</div>
+        <h3 className="truncate text-base font-semibold text-slate-100">{group.name}</h3>
+        {single && <div className="truncate text-xs text-slate-500">{group.tiers[0].file}</div>}
       </div>
-
-      {wf.error ? (
-        <div className="mt-3 text-sm text-rose-400">{wf.error}</div>
-      ) : (
-        <>
-          <div className="mt-3 flex flex-wrap items-center gap-3 text-sm">
-            {latest ? (
-              <a
-                href={latest.url}
-                target="_blank"
-                rel="noreferrer"
-                className="inline-flex items-center gap-2 text-slate-200 hover:text-emerald-300"
-              >
-                {(() => {
-                  const a = runAppearance(latest);
-                  return <span className={`h-3 w-3 rounded-full ${a.className}`} style={a.style} />;
-                })()}
-                <span className="font-mono text-xs">{latest.shaShort}</span>
-                <span className="text-slate-400">{formatRelative(latest.startedAt)}</span>
-                <span className="text-slate-500">({formatDuration(latest.durationSeconds)})</span>
-              </a>
-            ) : (
-              <span className="text-slate-400">no runs yet</span>
-            )}
-            <span className="ml-auto text-slate-400">
-              {successRate === null
-                ? "—"
-                : `${Math.round(successRate * 100)}% success over ${completedCount}`}
-            </span>
-          </div>
-
-          {/* Single-row strip — dots and inter-dot gap shrink on mobile
-              so the visible window fits without wrapping to a second row. */}
-          <div className="mt-3 flex gap-px sm:gap-1">
-            {visualHistory.map(({ run, index }) => {
-              const a = runAppearance(run);
-              const slow = isSlowRun(wf.history, index);
-              const baseline = slow ? slowRunBaseline(wf.history, index) : null;
-              return (
-                <a
-                  key={run.id}
-                  href={run.url}
-                  target="_blank"
-                  rel="noreferrer"
-                  className={`group relative h-5 w-2 rounded-sm sm:w-2.5 ${a.className} hover:ring-2 hover:ring-slate-400`}
-                  style={a.style}
-                >
-                  {slow && (
-                    <span
-                      aria-label="slow run"
-                      className="pointer-events-none absolute -right-0.5 -top-1 font-bold leading-none text-amber-300"
-                      style={{ fontSize: "10px", textShadow: "0 0 2px #0f172a, 0 0 2px #0f172a" }}
-                    >
-                      !
-                    </span>
-                  )}
-                  <div className="pointer-events-none absolute bottom-full left-1/2 z-10 mb-2 hidden -translate-x-1/2 whitespace-nowrap rounded border border-slate-700 bg-slate-950/95 px-2 py-1 text-xs text-slate-200 shadow-lg group-hover:block">
-                    <div className="font-mono text-slate-300">{run.shaShort}</div>
-                    <div className="text-slate-400">
-                      {run.conclusion ?? run.status} · {formatRelative(run.startedAt)}
-                    </div>
-                    <div>wall time: {formatDuration(run.durationSeconds)}</div>
-                    {slow && baseline !== null && (
-                      <div className="text-amber-300">
-                        slow · prior {baseline.sampleSize} successful runs mean+1σ ≈{" "}
-                        {formatDuration(Math.round(baseline.threshold))}
-                      </div>
-                    )}
-                  </div>
-                </a>
-              );
-            })}
-          </div>
-        </>
-      )}
+      <div className="mt-3 space-y-3">
+        {group.tiers.map((tier) => (
+          <TierStrip key={tier.file} tier={tier} showLabel={!single} />
+        ))}
+      </div>
     </div>
   );
 }
@@ -209,8 +231,8 @@ export function FerryPanel() {
       {error && <div className="text-rose-400">failed to load: {(error as Error).message}</div>}
       {data && (
         <div className="grid gap-3 md:grid-cols-3">
-          {data.workflows.map((wf) => (
-            <WorkflowCard key={wf.file} wf={wf} />
+          {data.groups.map((group) => (
+            <FerryCard key={group.name} group={group} />
           ))}
         </div>
       )}


### PR DESCRIPTION
The datakit canary runs three tiers (tier1/2/3) but the ferry panel only surfaced tier1. Model a ferry as a group of one or more tiers, each mapping to a workflow file: single-workflow ferries (Canary, CW) render one strip as before, while the datakit ferry stacks three 10-day strips under one card, captioned tier1/tier2/tier3.