### PR TITLE
Fix BackgroundTracker log_artifact race that dropped W&B config.yaml uploads

### DIFF
--- a/lib/levanter/src/levanter/tracker/background.py
+++ b/lib/levanter/src/levanter/tracker/background.py
@@ -34,6 +34,7 @@ should refuse to start.
 
 from __future__ import annotations
 
+import dataclasses
 import logging
 import os
 import queue
@@ -48,6 +49,41 @@ from levanter.tracker.tracker import Tracker
 
 
 logger = logging.getLogger(__name__)
+
+
+@dataclasses.dataclass(frozen=True)
+class _StagedArtifact:
+    """A producer-thread copy of an artifact, living in its own temp dir.
+
+    Callers routinely build an artifact inside a ``tempfile.TemporaryDirectory``
+    and delete it as soon as ``log_artifact`` returns. Staging copies the bytes
+    synchronously so the source can vanish immediately; the worker uploads
+    :attr:`path`, then calls :meth:`cleanup` to remove the temp dir.
+    """
+
+    path: str
+
+    @classmethod
+    def stage(cls, source) -> Optional["_StagedArtifact"]:
+        """Copy ``source`` into a fresh temp dir, or return ``None`` if it is missing.
+
+        The basename is preserved so the artifact's contents and W&B's default
+        artifact name are unchanged. Raises ``OSError`` if the copy itself fails.
+        """
+        src = os.fspath(source)
+        if not os.path.exists(src):
+            return None
+        staging_dir = tempfile.mkdtemp(prefix="levanter-artifact-")
+        dst = os.path.join(staging_dir, os.path.basename(src.rstrip("/\\")) or "artifact")
+        try:
+            (shutil.copytree if os.path.isdir(src) else shutil.copy2)(src, dst)
+        except OSError:
+            shutil.rmtree(staging_dir, ignore_errors=True)
+            raise
+        return cls(dst)
+
+    def cleanup(self) -> None:
+        shutil.rmtree(os.path.dirname(self.path), ignore_errors=True)
 
 
 class _Shutdown:
@@ -181,54 +217,29 @@ class BackgroundTracker(Tracker):
         name: Optional[str] = None,
         type: Optional[str] = None,
     ) -> None:
-        # Stage the artifact synchronously so the caller may delete the source the
-        # moment this returns (callers often build it inside a TemporaryDirectory).
-        # The worker uploads the staged copy and then removes it.
-        staged_path = self._stage_artifact(artifact_path)
-        if staged_path is None:
-            return
-        if not self._enqueue(self._upload_staged_artifact, staged_path, name=name, type=type):
-            shutil.rmtree(os.path.dirname(staged_path), ignore_errors=True)
-
-    def _upload_staged_artifact(self, staged_path, *, name: Optional[str], type: Optional[str]) -> None:
-        """Worker-side: upload a staged artifact, then remove its staging dir."""
+        # Stage the bytes on the producer thread so the caller may delete the source
+        # the moment this returns (callers often build it in a TemporaryDirectory).
         try:
-            self.wrapped.log_artifact(staged_path, name=name, type=type)
-        finally:
-            shutil.rmtree(os.path.dirname(staged_path), ignore_errors=True)
-
-    def _stage_artifact(self, artifact_path) -> Optional[str]:
-        """Copy ``artifact_path`` into a tracker-owned temp dir on the calling thread.
-
-        Returns the staged path (preserving the original basename so the artifact's
-        contents and default name are unchanged), or ``None`` if the source is
-        missing or cannot be copied — in which case the update is dropped.
-        """
-        src = os.fspath(artifact_path)
-        if not os.path.exists(src):
-            logger.warning(
-                "Background tracker '%s': artifact path %s does not exist; dropping log_artifact.",
-                self.name,
-                src,
-            )
-            return None
-
-        staging_dir = tempfile.mkdtemp(prefix="levanter-artifact-")
-        dst = os.path.join(staging_dir, os.path.basename(src.rstrip("/\\")) or "artifact")
-        try:
-            if os.path.isdir(src):
-                shutil.copytree(src, dst)
-            else:
-                shutil.copy2(src, dst)
+            staged = _StagedArtifact.stage(artifact_path)
         except OSError:
             logger.exception(
-                "Background tracker '%s': failed to stage artifact %s; dropping log_artifact.",
-                self.name,
-                src,
+                "Background tracker '%s': failed to stage artifact %s; dropping it.", self.name, artifact_path
             )
-            shutil.rmtree(staging_dir, ignore_errors=True)
-            return None
-        return dst
+            return
+        if staged is None:
+            logger.warning(
+                "Background tracker '%s': artifact %s does not exist; dropping it.", self.name, artifact_path
+            )
+            return
+        if not self._enqueue(self._upload_staged_artifact, staged, name=name, type=type):
+            staged.cleanup()
+
+    def _upload_staged_artifact(self, staged: _StagedArtifact, *, name: Optional[str], type: Optional[str]) -> None:
+        """Worker-side: upload a staged artifact, then remove its staging dir."""
+        try:
+            self.wrapped.log_artifact(staged.path, name=name, type=type)
+        finally:
+            staged.cleanup()
 
     def finish(self) -> None:
         with self._lock:

--- a/lib/levanter/src/levanter/tracker/background.py
+++ b/lib/levanter/src/levanter/tracker/background.py
@@ -20,6 +20,12 @@ both guarantees:
   Keeping the ``jax.device_get`` there also matters for multi-host runs, where
   that transfer is a collective that must stay in program order on the main
   thread.
+* Artifacts are staged (copied to a tracker-owned temp dir) on the calling
+  thread before they cross the queue. Callers routinely build an artifact inside
+  a ``tempfile.TemporaryDirectory`` and delete it as soon as ``log_artifact``
+  returns; because the worker uploads asynchronously, the source would be gone by
+  the time it runs. Staging captures the bytes synchronously; the worker uploads
+  the staged copy and removes it.
 
 Tracker initialization is *not* wrapped. If e.g. ``wandb.init()`` fails
 because of bad auth, that's a fatal configuration problem and the run
@@ -29,7 +35,10 @@ should refuse to start.
 from __future__ import annotations
 
 import logging
+import os
 import queue
+import shutil
+import tempfile
 import threading
 import time
 import typing
@@ -107,12 +116,14 @@ class BackgroundTracker(Tracker):
             finally:
                 self._queue.task_done()
 
-    def _enqueue(self, method, *args, **kwargs) -> None:
+    def _enqueue(self, method, *args, **kwargs) -> bool:
+        """Push a deferred call onto the worker queue. Returns whether it was accepted."""
         if self._stopped:
             logger.debug("Background tracker '%s' already stopped; dropping %s", self.name, method.__name__)
-            return
+            return False
         try:
             self._queue.put_nowait((method, args, kwargs))
+            return True
         except queue.Full:
             with self._lock:
                 self._dropped += 1
@@ -123,6 +134,7 @@ class BackgroundTracker(Tracker):
                     self.name,
                     dropped,
                 )
+            return False
 
     def _defer(self, prepare, method, payload, **kwargs) -> None:
         """Prepare ``payload`` on the calling thread, then enqueue ``method``.
@@ -169,7 +181,54 @@ class BackgroundTracker(Tracker):
         name: Optional[str] = None,
         type: Optional[str] = None,
     ) -> None:
-        self._enqueue(self.wrapped.log_artifact, artifact_path, name=name, type=type)
+        # Stage the artifact synchronously so the caller may delete the source the
+        # moment this returns (callers often build it inside a TemporaryDirectory).
+        # The worker uploads the staged copy and then removes it.
+        staged_path = self._stage_artifact(artifact_path)
+        if staged_path is None:
+            return
+        if not self._enqueue(self._upload_staged_artifact, staged_path, name=name, type=type):
+            shutil.rmtree(os.path.dirname(staged_path), ignore_errors=True)
+
+    def _upload_staged_artifact(self, staged_path, *, name: Optional[str], type: Optional[str]) -> None:
+        """Worker-side: upload a staged artifact, then remove its staging dir."""
+        try:
+            self.wrapped.log_artifact(staged_path, name=name, type=type)
+        finally:
+            shutil.rmtree(os.path.dirname(staged_path), ignore_errors=True)
+
+    def _stage_artifact(self, artifact_path) -> Optional[str]:
+        """Copy ``artifact_path`` into a tracker-owned temp dir on the calling thread.
+
+        Returns the staged path (preserving the original basename so the artifact's
+        contents and default name are unchanged), or ``None`` if the source is
+        missing or cannot be copied — in which case the update is dropped.
+        """
+        src = os.fspath(artifact_path)
+        if not os.path.exists(src):
+            logger.warning(
+                "Background tracker '%s': artifact path %s does not exist; dropping log_artifact.",
+                self.name,
+                src,
+            )
+            return None
+
+        staging_dir = tempfile.mkdtemp(prefix="levanter-artifact-")
+        dst = os.path.join(staging_dir, os.path.basename(src.rstrip("/\\")) or "artifact")
+        try:
+            if os.path.isdir(src):
+                shutil.copytree(src, dst)
+            else:
+                shutil.copy2(src, dst)
+        except OSError:
+            logger.exception(
+                "Background tracker '%s': failed to stage artifact %s; dropping log_artifact.",
+                self.name,
+                src,
+            )
+            shutil.rmtree(staging_dir, ignore_errors=True)
+            return None
+        return dst
 
     def finish(self) -> None:
         with self._lock:
@@ -184,8 +243,7 @@ class BackgroundTracker(Tracker):
             self._queue.put_nowait((self.wrapped.finish, (), {}))
         except queue.Full:
             logger.warning(
-                "Background tracker '%s' queue full at shutdown; finish() may "
-                "not be called on the wrapped tracker.",
+                "Background tracker '%s' queue full at shutdown; finish() may not be called on the wrapped tracker.",
                 self.name,
             )
 

--- a/lib/levanter/src/levanter/tracker/wandb.py
+++ b/lib/levanter/src/levanter/tracker/wandb.py
@@ -405,7 +405,10 @@ class WandbConfig(TrackerConfig):
                 suppress_logging=not is_primary_process,
                 minimum_log_step=minimum_log_step,
             ),
-            enabled=self.background,
+            # Only the primary process actually logs; a suppressed tracker no-ops every
+            # call, so wrapping it in a background thread is pure overhead — and would
+            # make non-primary hosts stage (copy) large profile artifacts they discard.
+            enabled=self.background and is_primary_process,
             max_queue_size=self.background_max_queue_size,
             finish_timeout=self.background_finish_timeout,
         )

--- a/lib/levanter/tests/test_background_tracker.py
+++ b/lib/levanter/tests/test_background_tracker.py
@@ -15,6 +15,8 @@ These tests cover the behavior we want for robustness against W&B failures:
 
 from __future__ import annotations
 
+import os
+import shutil
 import threading
 import time
 from typing import Any
@@ -92,7 +94,10 @@ class AlwaysRaisingTracker(Tracker):
         self._boom()
 
 
-def test_background_tracker_forwards_calls():
+def test_background_tracker_forwards_calls(tmp_path):
+    artifact = tmp_path / "model.bin"
+    artifact.write_text("weights")
+
     inner = RecordingTracker()
     bt = BackgroundTracker(inner)
     try:
@@ -100,7 +105,7 @@ def test_background_tracker_forwards_calls():
         bt.log({"loss": 1.0}, step=0)
         bt.log({"loss": 0.5}, step=1, commit=True)
         bt.log_summary({"final_loss": 0.5})
-        bt.log_artifact("/tmp/x", name="x", type="model")
+        bt.log_artifact(str(artifact), name="x", type="model")
         assert bt._wait_until_idle(timeout=5)
     finally:
         bt.finish()
@@ -108,8 +113,122 @@ def test_background_tracker_forwards_calls():
     assert inner.hparams == [{"lr": 0.1}]
     assert inner.logs == [({"loss": 1.0}, 0, None), ({"loss": 0.5}, 1, True)]
     assert inner.summary == [{"final_loss": 0.5}]
-    assert inner.artifacts == [("/tmp/x", "x", "model")]
+    # The artifact is forwarded with its name/type preserved. The path is a staged
+    # copy (so the source can be deleted immediately), not the original path.
+    assert len(inner.artifacts) == 1
+    _, art_name, art_type = inner.artifacts[0]
+    assert (art_name, art_type) == ("x", "model")
     assert inner.finished is True
+
+
+class _GatedContentTracker(Tracker):
+    """Records each artifact's contents, with a gate that holds the worker thread.
+
+    The first ``log`` call blocks until ``release`` is set. That lets a test pin
+    the worker *before* it reaches the queued artifact, so it can delete the
+    source first and prove the bytes were captured on the producer thread.
+    """
+
+    name = "gated-content"
+
+    def __init__(self) -> None:
+        self.artifacts: list[dict[str, Any]] = []
+        self.worker_blocked = threading.Event()
+        self.release = threading.Event()
+
+    def log_hyperparameters(self, hparams):
+        pass
+
+    def log(self, metrics, *, step, commit=None):
+        self.worker_blocked.set()
+        self.release.wait(timeout=5)
+
+    def log_summary(self, metrics):
+        pass
+
+    def log_artifact(self, artifact_path, *, name=None, type=None):
+        if os.path.isdir(artifact_path):
+            contents: Any = sorted(os.listdir(artifact_path))
+        else:
+            with open(artifact_path) as f:
+                contents = f.read()
+        self.artifacts.append({"name": name, "type": type, "contents": contents})
+
+    def finish(self):
+        pass
+
+
+def test_background_tracker_stages_artifact_before_source_deleted(tmp_path):
+    """log_artifact must capture the file before the producer deletes the source.
+
+    Regression for the config.yaml FileNotFoundError: log_configuration builds the
+    artifact inside a TemporaryDirectory and deletes it as soon as log_artifact
+    returns, so the async worker would otherwise read a path that no longer exists.
+    The worker is pinned on a blocking log() so the delete is guaranteed to happen
+    before it processes the artifact — making the race deterministic.
+    """
+    inner = _GatedContentTracker()
+    bt = BackgroundTracker(inner)
+    try:
+        # Pin the worker so the queued artifact can't be processed until we release.
+        bt.log({"x": 1}, step=0)
+        assert inner.worker_blocked.wait(timeout=5)
+
+        ephemeral = tmp_path / "ephemeral"
+        ephemeral.mkdir()
+        config = ephemeral / "config.yaml"
+        config.write_text("hello: world\n")
+
+        bt.log_artifact(str(config), name="config.yaml", type="config")
+        # Producer deletes the source immediately, exactly like the TemporaryDirectory
+        # context manager in log_configuration — while the worker is still blocked.
+        shutil.rmtree(ephemeral)
+
+        inner.release.set()
+        assert bt._wait_until_idle(timeout=5)
+    finally:
+        inner.release.set()
+        bt.finish()
+
+    assert inner.artifacts == [{"name": "config.yaml", "type": "config", "contents": "hello: world\n"}]
+
+
+def test_background_tracker_stages_directory_artifact_before_source_deleted(tmp_path):
+    """Directory artifacts (e.g. perplexity-gap reports, profiles) are staged too."""
+    inner = _GatedContentTracker()
+    bt = BackgroundTracker(inner)
+    try:
+        bt.log({"x": 1}, step=0)
+        assert inner.worker_blocked.wait(timeout=5)
+
+        ephemeral = tmp_path / "report"
+        ephemeral.mkdir()
+        (ephemeral / "a.txt").write_text("a")
+        (ephemeral / "b.txt").write_text("b")
+
+        bt.log_artifact(str(ephemeral), name="report", type="report")
+        shutil.rmtree(ephemeral)
+
+        inner.release.set()
+        assert bt._wait_until_idle(timeout=5)
+    finally:
+        inner.release.set()
+        bt.finish()
+
+    assert inner.artifacts == [{"name": "report", "type": "report", "contents": ["a.txt", "b.txt"]}]
+
+
+def test_background_tracker_drops_missing_artifact(tmp_path):
+    """A source that does not exist at call time is dropped, not enqueued."""
+    inner = RecordingTracker()
+    bt = BackgroundTracker(inner)
+    try:
+        bt.log_artifact(str(tmp_path / "does-not-exist"), name="x", type="model")
+        assert bt._wait_until_idle(timeout=5)
+    finally:
+        bt.finish()
+
+    assert inner.artifacts == []
 
 
 def test_background_tracker_runs_off_caller_thread():

--- a/lib/levanter/tests/test_background_tracker.py
+++ b/lib/levanter/tests/test_background_tracker.py
@@ -15,8 +15,6 @@ These tests cover the behavior we want for robustness against W&B failures:
 
 from __future__ import annotations
 
-import os
-import shutil
 import threading
 import time
 from typing import Any
@@ -121,114 +119,41 @@ def test_background_tracker_forwards_calls(tmp_path):
     assert inner.finished is True
 
 
-class _GatedContentTracker(Tracker):
-    """Records each artifact's contents, with a gate that holds the worker thread.
+def test_background_tracker_stages_artifact_so_source_can_be_deleted(tmp_path):
+    """log_artifact must capture the bytes before the producer deletes the source.
 
-    The first ``log`` call blocks until ``release`` is set. That lets a test pin
-    the worker *before* it reaches the queued artifact, so it can delete the
-    source first and prove the bytes were captured on the producer thread.
+    Regression for the config.yaml FileNotFoundError: log_configuration writes the
+    artifact into a TemporaryDirectory and deletes it as soon as log_artifact
+    returns, so the deferred upload must read a staged copy, not the gone source.
+    A blocking log() pins the worker until after the delete, making the race
+    deterministic.
     """
+    gate = threading.Event()
+    uploaded: list[str] = []
 
-    name = "gated-content"
+    class ReadingTracker(RecordingTracker):
+        def log(self, metrics, *, step, commit=None):
+            gate.wait(timeout=5)  # hold the worker until the source is deleted
 
-    def __init__(self) -> None:
-        self.artifacts: list[dict[str, Any]] = []
-        self.worker_blocked = threading.Event()
-        self.release = threading.Event()
-
-    def log_hyperparameters(self, hparams):
-        pass
-
-    def log(self, metrics, *, step, commit=None):
-        self.worker_blocked.set()
-        self.release.wait(timeout=5)
-
-    def log_summary(self, metrics):
-        pass
-
-    def log_artifact(self, artifact_path, *, name=None, type=None):
-        if os.path.isdir(artifact_path):
-            contents: Any = sorted(os.listdir(artifact_path))
-        else:
+        def log_artifact(self, artifact_path, *, name=None, type=None):
             with open(artifact_path) as f:
-                contents = f.read()
-        self.artifacts.append({"name": name, "type": type, "contents": contents})
+                uploaded.append(f.read())
 
-    def finish(self):
-        pass
+    source = tmp_path / "config.yaml"
+    source.write_text("hello: world\n")
 
-
-def test_background_tracker_stages_artifact_before_source_deleted(tmp_path):
-    """log_artifact must capture the file before the producer deletes the source.
-
-    Regression for the config.yaml FileNotFoundError: log_configuration builds the
-    artifact inside a TemporaryDirectory and deletes it as soon as log_artifact
-    returns, so the async worker would otherwise read a path that no longer exists.
-    The worker is pinned on a blocking log() so the delete is guaranteed to happen
-    before it processes the artifact — making the race deterministic.
-    """
-    inner = _GatedContentTracker()
-    bt = BackgroundTracker(inner)
+    bt = BackgroundTracker(ReadingTracker())
     try:
-        # Pin the worker so the queued artifact can't be processed until we release.
-        bt.log({"x": 1}, step=0)
-        assert inner.worker_blocked.wait(timeout=5)
-
-        ephemeral = tmp_path / "ephemeral"
-        ephemeral.mkdir()
-        config = ephemeral / "config.yaml"
-        config.write_text("hello: world\n")
-
-        bt.log_artifact(str(config), name="config.yaml", type="config")
-        # Producer deletes the source immediately, exactly like the TemporaryDirectory
-        # context manager in log_configuration — while the worker is still blocked.
-        shutil.rmtree(ephemeral)
-
-        inner.release.set()
+        bt.log({}, step=0)  # occupy the worker so the artifact stays queued
+        bt.log_artifact(str(source), name="config.yaml", type="config")
+        source.unlink()  # source gone before the worker can read it
+        gate.set()
         assert bt._wait_until_idle(timeout=5)
     finally:
-        inner.release.set()
+        gate.set()
         bt.finish()
 
-    assert inner.artifacts == [{"name": "config.yaml", "type": "config", "contents": "hello: world\n"}]
-
-
-def test_background_tracker_stages_directory_artifact_before_source_deleted(tmp_path):
-    """Directory artifacts (e.g. perplexity-gap reports, profiles) are staged too."""
-    inner = _GatedContentTracker()
-    bt = BackgroundTracker(inner)
-    try:
-        bt.log({"x": 1}, step=0)
-        assert inner.worker_blocked.wait(timeout=5)
-
-        ephemeral = tmp_path / "report"
-        ephemeral.mkdir()
-        (ephemeral / "a.txt").write_text("a")
-        (ephemeral / "b.txt").write_text("b")
-
-        bt.log_artifact(str(ephemeral), name="report", type="report")
-        shutil.rmtree(ephemeral)
-
-        inner.release.set()
-        assert bt._wait_until_idle(timeout=5)
-    finally:
-        inner.release.set()
-        bt.finish()
-
-    assert inner.artifacts == [{"name": "report", "type": "report", "contents": ["a.txt", "b.txt"]}]
-
-
-def test_background_tracker_drops_missing_artifact(tmp_path):
-    """A source that does not exist at call time is dropped, not enqueued."""
-    inner = RecordingTracker()
-    bt = BackgroundTracker(inner)
-    try:
-        bt.log_artifact(str(tmp_path / "does-not-exist"), name="x", type="model")
-        assert bt._wait_until_idle(timeout=5)
-    finally:
-        bt.finish()
-
-    assert inner.artifacts == []
+    assert uploaded == ["hello: world\n"]
 
 
 def test_background_tracker_runs_off_caller_thread():

--- a/lib/levanter/tests/test_tracker.py
+++ b/lib/levanter/tests/test_tracker.py
@@ -15,8 +15,8 @@ import yaml
 import levanter.tracker
 import levanter.tracker.tracker_fns as tracker_fns
 import levanter.tracker.wandb as wandb_tracker_mod
-from levanter.tracker import BackgroundTracker, CompositeTracker, NoopTracker, TrackerConfig
-from levanter.tracker.tracker import NoopConfig, Tracker
+from levanter.tracker import CompositeTracker, NoopTracker, TrackerConfig
+from levanter.tracker.tracker import NoopConfig
 from levanter.tracker.wandb import WandbTracker, _truncate_wandb_artifact_name, truncate_wandb_run_name
 
 
@@ -97,54 +97,6 @@ def test_tracker_logging_without_global_tracker_emits_no_warning(monkeypatch):
         tracker_fns.log_configuration({"metric": 1.0})
 
     assert not caught
-
-
-def test_log_configuration_through_background_tracker_survives_tempdir_cleanup():
-    """log_configuration must hand the config artifact off before its tempdir is gone.
-
-    log_configuration dumps the dataclass into a tempfile.TemporaryDirectory and
-    deletes it as soon as log_artifact returns. Behind a BackgroundTracker the
-    upload happens on a worker thread, so without producer-side staging the worker
-    would hit FileNotFoundError on the deleted config.yaml (the reported bug).
-    """
-
-    @dataclasses.dataclass
-    class MyConfig:
-        lr: float = 0.1
-        name: str = "demo"
-
-    captured: dict[str, object] = {}
-
-    class ContentReadingTracker(Tracker):
-        name = "content-reading"
-
-        def log_hyperparameters(self, hparams):
-            pass
-
-        def log(self, metrics, *, step, commit=None):
-            pass
-
-        def log_summary(self, metrics):
-            pass
-
-        def log_artifact(self, artifact_path, *, name=None, type=None):
-            with open(artifact_path) as f:
-                captured["yaml"] = f.read()
-            captured["name"] = name
-            captured["type"] = type
-
-        def finish(self):
-            pass
-
-    bt = BackgroundTracker(ContentReadingTracker())
-    with levanter.tracker.current_tracker(bt):
-        tracker_fns.log_configuration(MyConfig(), config_name="config.yaml")
-        # finish() drains the queue and joins the worker, so the staged upload has run.
-        bt.finish()
-
-    assert captured["name"] == "config.yaml"
-    assert captured["type"] == "config"
-    assert captured["yaml"] == draccus.dump(MyConfig())
 
 
 def test_wandb_artifact_name_defaults_to_basename_and_truncates(monkeypatch):

--- a/lib/levanter/tests/test_tracker.py
+++ b/lib/levanter/tests/test_tracker.py
@@ -15,8 +15,8 @@ import yaml
 import levanter.tracker
 import levanter.tracker.tracker_fns as tracker_fns
 import levanter.tracker.wandb as wandb_tracker_mod
-from levanter.tracker import CompositeTracker, NoopTracker, TrackerConfig
-from levanter.tracker.tracker import NoopConfig
+from levanter.tracker import BackgroundTracker, CompositeTracker, NoopTracker, TrackerConfig
+from levanter.tracker.tracker import NoopConfig, Tracker
 from levanter.tracker.wandb import WandbTracker, _truncate_wandb_artifact_name, truncate_wandb_run_name
 
 
@@ -97,6 +97,54 @@ def test_tracker_logging_without_global_tracker_emits_no_warning(monkeypatch):
         tracker_fns.log_configuration({"metric": 1.0})
 
     assert not caught
+
+
+def test_log_configuration_through_background_tracker_survives_tempdir_cleanup():
+    """log_configuration must hand the config artifact off before its tempdir is gone.
+
+    log_configuration dumps the dataclass into a tempfile.TemporaryDirectory and
+    deletes it as soon as log_artifact returns. Behind a BackgroundTracker the
+    upload happens on a worker thread, so without producer-side staging the worker
+    would hit FileNotFoundError on the deleted config.yaml (the reported bug).
+    """
+
+    @dataclasses.dataclass
+    class MyConfig:
+        lr: float = 0.1
+        name: str = "demo"
+
+    captured: dict[str, object] = {}
+
+    class ContentReadingTracker(Tracker):
+        name = "content-reading"
+
+        def log_hyperparameters(self, hparams):
+            pass
+
+        def log(self, metrics, *, step, commit=None):
+            pass
+
+        def log_summary(self, metrics):
+            pass
+
+        def log_artifact(self, artifact_path, *, name=None, type=None):
+            with open(artifact_path) as f:
+                captured["yaml"] = f.read()
+            captured["name"] = name
+            captured["type"] = type
+
+        def finish(self):
+            pass
+
+    bt = BackgroundTracker(ContentReadingTracker())
+    with levanter.tracker.current_tracker(bt):
+        tracker_fns.log_configuration(MyConfig(), config_name="config.yaml")
+        # finish() drains the queue and joins the worker, so the staged upload has run.
+        bt.finish()
+
+    assert captured["name"] == "config.yaml"
+    assert captured["type"] == "config"
+    assert captured["yaml"] == draccus.dump(MyConfig())
 
 
 def test_wandb_artifact_name_defaults_to_basename_and_truncates(monkeypatch):


### PR DESCRIPTION
## Problem

Training runs were dropping W&B artifact uploads with a `FileNotFoundError`:

```
Background tracker 'wandb' raised while processing log_artifact; dropping update and continuing.
...
  File ".../wandb/sdk/artifacts/artifact.py", line 1771, in _add_local_file
    shutil.copyfile(path, staging_path)
FileNotFoundError: [Errno 2] No such file or directory: '/tmp/tmpiacb45gw/config.yaml'
```

(observed on `iris-run-job-20260615-220502/grug-train-reentrant_e0_d512`)

## Root cause

A time-of-check/time-of-use race introduced by the background tracker. `log_configuration` (`tracker/tracker_fns.py`) dumps the run config into a `tempfile.TemporaryDirectory`, calls `log_artifact()`, then exits the `with` block — **deleting the temp dir**:

```python
with tempfile.TemporaryDirectory() as tmpdir:
    config_path = os.path.join(tmpdir, "config.yaml")
    ...
    _global_tracker.log_artifact(config_path, name=name, type="config")
# tmpdir (and config.yaml) deleted here
```

Behind a `BackgroundTracker`, `log_artifact()` only **enqueues** the path and returns immediately. The actual upload runs later on the worker thread — by which point `config.yaml` is gone, so wandb's `shutil.copyfile(src, ...)` raises `FileNotFoundError`. The artifact is silently dropped (the run continues, but config/requirements/eval artifacts go missing). `levanter/main/perplexity_gap.py` had the same latent race.

## Fix

Every other deferred `BackgroundTracker` method already "prepares its payload on the calling thread before it crosses the queue" (per the module docstring); `log_artifact` was the one exception. An artifact's payload is the file's bytes, so stage it synchronously:

- A small `_StagedArtifact` value object copies the source into its own temp dir **on the producer thread** (preserving the basename so the artifact's contents and default name are unchanged) and owns the cleanup, so `shutil.rmtree` isn't scattered across call sites. `log_artifact` enqueues the staged copy; the worker uploads it then calls `staged.cleanup()`.
- Callers may now delete the source the instant `log_artifact()` returns — exactly what the `TemporaryDirectory` callers do. No call-site or API changes needed; the fix is generic across all artifact loggers (config, requirements, profiles, eval results, perplexity-gap reports).

### Suppressed (non-primary) hosts

In multi-host runs only process 0 logs to W&B; the others get a `suppress_logging=True` tracker that no-ops every call. The W&B init now skips background-wrapping those (`enabled=self.background and is_primary_process`), so non-primary hosts never stage — otherwise every host would synchronously copy large profile directories into `/tmp` that W&B then discards. Wrapping a suppressed tracker was pure overhead regardless.

Producer-side staging is still strictly cheaper than the pre-background-tracker behavior, which blocked the trainer thread on the entire synchronous upload (local copy **and** network).

## Tests

`test_background_tracker_stages_artifact_so_source_can_be_deleted` reproduces the reported failure: it logs a `config.yaml`, deletes the source, and asserts the bytes still reach the wrapped tracker. A blocking `log()` pins the worker until after the delete, so the race is **deterministic** — the test reproduces the exact `FileNotFoundError` when the fix is reverted, and passes with it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)