### PR TITLE
[iris] Tune controller read pools: widen shared pool, isolate the control loop

### DIFF
--- a/lib/iris/scripts/benchmark_controller.py
+++ b/lib/iris/scripts/benchmark_controller.py
@@ -1675,8 +1675,7 @@ def _print_latency_distribution(name: str, latencies: list[float]) -> None:
     max_ms = latencies[-1]
     _results.append((name, p50, p95, len(latencies)))
     print(
-        f"  {name:64s}  n={len(latencies):3d}  "
-        f"p50={p50:7.1f}ms  p95={p95:8.1f}ms  p99={p99:8.1f}ms  max={max_ms:8.1f}ms"
+        f"  {name:64s}  n={len(latencies):3d}  p50={p50:7.1f}ms  p95={p95:8.1f}ms  p99={p99:8.1f}ms  max={max_ms:8.1f}ms"
     )
 
 
@@ -1864,6 +1863,143 @@ def benchmark_apply_contention(db: ControllerDB) -> None:
 
 
 # ---------------------------------------------------------------------------
+# Group: control_isolation (control-loop checkout wait under a dashboard storm)
+# ---------------------------------------------------------------------------
+
+
+def _measure_connection_checkout(engine) -> float:
+    """Check out a read connection and return the wait in ms.
+
+    This is exactly the ``QueuePool.get`` blocking seen in production controller
+    stacks: when every shared connection is busy, a thread needing a read blocks
+    here. The query cost after checkout is identical regardless of
+    which pool is used, so the checkout wait is the only quantity the dedicated
+    control pool changes. A trivial probe query keeps iterations cheap so the
+    distribution has enough samples.
+    """
+    t0 = time.perf_counter()
+    conn = engine.connect()
+    checkout_ms = (time.perf_counter() - t0) * 1000.0
+    try:
+        conn.execute(text("SELECT 1")).all()
+    finally:
+        conn.close()
+    return checkout_ms
+
+
+def _dashboard_storm_read(engine, slow: bool, sample_job_id: str | None) -> None:
+    """One RPC-shaped read against the shared pool.
+
+    ``slow`` runs the ``GetSchedulerState`` pending+running aggregation (seconds
+    on the prod DB — these are what occupy every shared connection and head-of-
+    line block the dashboard); otherwise a single-job ``GetJobState``-shape read.
+    """
+    with db_mod.read_snapshot(engine) as snap:
+        if slow:
+            snap.execute(
+                select(tasks_table.c.task_id, tasks_table.c.priority_band, tasks_table.c.submitted_at_ms).where(
+                    tasks_table.c.state == job_pb2.TASK_STATE_PENDING
+                )
+            ).all()
+            snap.execute(
+                select(tasks_table.c.task_id, tasks_table.c.current_worker_id).where(
+                    tasks_table.c.state == job_pb2.TASK_STATE_RUNNING,
+                    tasks_table.c.current_worker_id.is_not(None),
+                )
+            ).all()
+        elif sample_job_id is not None:
+            snap.execute(select(jobs_table.c.state).where(jobs_table.c.job_id == sample_job_id)).all()
+
+
+def _run_control_read_under_storm(
+    db: ControllerDB,
+    *,
+    victim_engine,
+    sample_job_id: str | None,
+    storm_threads: int,
+    slow_every: int,
+    duration_s: float,
+) -> list[float]:
+    """Sample the connection-checkout wait on a victim thread while ``storm_threads``
+    hammer the shared read pool with a fast/slow RPC mix. Returns checkout waits (ms).
+    """
+    stop = threading.Event()
+    victim_latencies: list[float] = []
+    errors: list[BaseException] = []
+
+    def _victim() -> None:
+        try:
+            while not stop.is_set():
+                victim_latencies.append(_measure_connection_checkout(victim_engine))
+                # Sample every 50ms: frequent enough for a tight distribution,
+                # but not a busy-loop that would itself contend for connections.
+                stop.wait(0.05)
+        except BaseException as e:
+            errors.append(e)
+
+    def _storm() -> None:
+        i = 0
+        try:
+            while not stop.is_set():
+                _dashboard_storm_read(db.sa_read_engine, slow=(i % slow_every == 0), sample_job_id=sample_job_id)
+                i += 1
+        except BaseException as e:
+            errors.append(e)
+
+    threads = [threading.Thread(target=_victim, name="control-victim")]
+    threads += [threading.Thread(target=_storm, name=f"dash-storm-{i}") for i in range(storm_threads)]
+    for t in threads:
+        t.start()
+    time.sleep(duration_s)
+    stop.set()
+    for t in threads:
+        t.join(timeout=30.0)
+    if errors:
+        print(f"    storm thread error: {errors[0]!r}")
+    return victim_latencies
+
+
+def benchmark_control_isolation(db: ControllerDB) -> None:
+    """Control-loop connection-checkout wait under a dashboard read storm.
+
+    The control loop's per-tick snapshot must not queue behind a slow dashboard
+    read for a connection. This contrasts the victim (a control-loop thread
+    needing a read connection) checking out from the **shared** RPC read pool vs
+    the **dedicated** control pool while concurrent RPC-shaped reads saturate the
+    shared pool — the before/after for the dedicated control read pool.
+    """
+    with db.read_snapshot() as tx:
+        row = tx.execute(select(jobs_table.c.job_id).limit(1)).first()
+    sample_job_id = str(row.job_id) if row else None
+
+    # Saturate the shared pool with readers, ~1 in 3 of them a slow aggregation.
+    storm_threads = 12
+    slow_every = 3
+    duration_s = 6.0
+    print(f"  (storm: {storm_threads} threads on the shared pool, every {slow_every}th read = slow aggregation)")
+
+    shared = _run_control_read_under_storm(
+        db,
+        victim_engine=db.sa_read_engine,
+        sample_job_id=sample_job_id,
+        storm_threads=storm_threads,
+        slow_every=slow_every,
+        duration_s=duration_s,
+    )
+    _print_latency_distribution("Control checkout: SHARED pool (contends w/ dashboard)", shared)
+
+    dedicated = _run_control_read_under_storm(
+        db,
+        victim_engine=db.sa_control_read_engine,
+        sample_job_id=sample_job_id,
+        storm_threads=storm_threads,
+        slow_every=slow_every,
+        duration_s=duration_s,
+    )
+    _print_latency_distribution("Control checkout: DEDICATED pool (isolated)", dedicated)
+
+
+# ---------------------------------------------------------------------------
 # Shared latency / scenario helpers (used by the rpcs and scenario groups)
 # ---------------------------------------------------------------------------
 
@@ -2037,6 +2173,7 @@ _GROUPS = (
     "dashboard",
     "endpoints",
     "apply_contention",
+    "control_isolation",
     "scenario",
 )
 
@@ -2101,6 +2238,7 @@ def run_cmd(db_path: Path | None, only_group: str | None, scenario_scale: float,
         ("dashboard", benchmark_dashboard),
         ("endpoints", benchmark_endpoints),
         ("apply_contention", benchmark_apply_contention),
+        ("control_isolation", benchmark_control_isolation),
         ("scenario", benchmark_scenario),
     ]
     for name, fn in groups:

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -949,7 +949,9 @@ class Controller:
             drained_control = self._drain_dispatch_snapshot()
 
         inputs = _TickInputs()
-        with self._db.read_snapshot() as snap:
+        # Dedicated control pool: the tick's snapshot must not queue behind a slow
+        # dashboard read for a connection.
+        with self._db.control_read_snapshot() as snap:
             if run_schedule:
                 claims, changed = refresh_reservation_claims_in_tx(snap, self._health, self._worker_attrs)
                 inputs.claims = claims
@@ -1077,7 +1079,7 @@ class Controller:
         trace = self._scheduling_round % _SCHEDULING_TRACE_INTERVAL == 0
 
         claims = self._refresh_reservation_claims()
-        with self._db.read_snapshot() as snap:
+        with self._db.control_read_snapshot() as snap:
             ctx = build_scheduling_context(
                 snap,
                 self._health,
@@ -1291,7 +1293,7 @@ class Controller:
         if self._backend_drains_dispatch:
             return self._drain_dispatch_snapshot()
 
-        with self._db.read_snapshot() as snap:
+        with self._db.control_read_snapshot() as snap:
             control = reads.load_control_snapshot(snap, self._health, scan_timeouts=scan_timeouts)
             job_specs = self._build_run_templates(snap, control.reconcile_rows)
         return dataclasses.replace(control, job_specs=job_specs)
@@ -1459,7 +1461,7 @@ class Controller:
 
     def _build_worker_status_map(self) -> WorkerStatusMap:
         """Build a map of worker_id to worker status for autoscaler idle tracking."""
-        with self._db.read_snapshot() as tx:
+        with self._db.control_read_snapshot() as tx:
             return self._worker_status_map_from_tx(tx)
 
     def _worker_status_map_from_tx(self, tx: Tx) -> WorkerStatusMap:

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -6,19 +6,31 @@
 Hosts the SA ``Engine`` factories, the ``Tx`` wrapper, and the two
 transaction context managers (``write_transaction`` / ``read_snapshot``).
 
-The engine is split into a **write engine** and a **read engine**:
+The engine is split into a **write engine** and two **read engines**:
 
 * The write engine uses pool size 1 so writes are funneled through a
   single connection. Serialization between writers is enforced by an
   external ``threading.RLock`` passed into ``write_transaction``.
-* The read engine uses ``QueuePool(pool_size=2, max_overflow=2)`` with
-  ``PRAGMA query_only = ON`` **pinned at connect time**. Pinning avoids
-  toggling the pragma on every ``read_snapshot`` call. A small pool keeps
-  tail latency low under concurrent reads — SQLite's WAL-index header lock
-  becomes contended once many readers each hold their own connection, so
-  queueing surplus readers at the SA pool (FIFO) beats spinning inside SQLite.
+* The shared read engine uses ``QueuePool(pool_size=4, max_overflow=4)``
+  with ``PRAGMA query_only = ON`` **pinned at connect time** and backs every
+  RPC-handler read (``read_snapshot``). Pinning avoids toggling the pragma on
+  every call. The pool caps in-flight readers: SQLite's WAL admits concurrent
+  readers but each contends on the WAL-index header lock when establishing a
+  snapshot, so queueing surplus readers at the SA pool (FIFO) beats spinning
+  inside SQLite. A total of 8 is the controller benchmark's measured knee — it
+  lets the high-volume fast reads (e.g. ``GetJobState``) bypass the handful of
+  slow ones (``ListJobs``, ``GetSchedulerState``) that would otherwise occupy
+  every connection and head-of-line block the dashboard; widening past 8 only
+  adds WAL-index/GIL contention with no throughput gain.
+* The control read engine is a **dedicated** ``QueuePool(pool_size=2,
+  max_overflow=2)`` used only by the single control-loop thread's per-tick
+  snapshot (``control_read_snapshot``). Isolating it guarantees the
+  schedule/reconcile/autoscale tick never waits behind a slow dashboard read
+  for a connection — the pool-checkout wait visible as ``QueuePool.get`` in
+  controller stacks. Its connections sit idle between ticks (~1 read/s), so
+  they add negligible WAL-index contention.
 
-Both engines use ``isolation_level="AUTOCOMMIT"`` so callers issue
+All engines use ``isolation_level="AUTOCOMMIT"`` so callers issue
 ``BEGIN`` / ``BEGIN IMMEDIATE`` / ``COMMIT`` / ``ROLLBACK`` explicitly.
 
 Post-commit hooks registered via ``Tx.register`` fire *under the write
@@ -96,12 +108,28 @@ def _make_engine(
     return engine
 
 
+# Read-pool sizing. See the module docstring for the rationale; the totals are
+# the controller benchmark's measured knee.
+SHARED_READ_POOL_SIZE = 4
+SHARED_READ_MAX_OVERFLOW = 4
+CONTROL_READ_POOL_SIZE = 2
+CONTROL_READ_MAX_OVERFLOW = 2
+
+
 def _make_write_engine(db_path: Path, auth_db_path: Path | None) -> Engine:
     return _make_engine(db_path, read_only=False, pool_size=1, max_overflow=0, auth_db_path=auth_db_path)
 
 
-def _make_read_engine(db_path: Path, auth_db_path: Path | None) -> Engine:
-    return _make_engine(db_path, read_only=True, pool_size=2, max_overflow=2, auth_db_path=auth_db_path)
+def _make_read_engine(
+    db_path: Path,
+    auth_db_path: Path | None,
+    *,
+    pool_size: int = SHARED_READ_POOL_SIZE,
+    max_overflow: int = SHARED_READ_MAX_OVERFLOW,
+) -> Engine:
+    return _make_engine(
+        db_path, read_only=True, pool_size=pool_size, max_overflow=max_overflow, auth_db_path=auth_db_path
+    )
 
 
 class Tx:
@@ -214,6 +242,11 @@ class ControllerDB:
         self._sa_write_engine: Engine = _make_write_engine(self._db_path, self._auth_db_path)
         # Read connections must not see auth tables — pass None so auth is not ATTACHed.
         self._sa_read_engine: Engine = _make_read_engine(self._db_path, None)
+        # Dedicated read engine for the control-loop tick, isolated from the
+        # shared RPC pool so scheduling never queues behind a slow dashboard read.
+        self._sa_control_read_engine: Engine = _make_read_engine(
+            self._db_path, None, pool_size=CONTROL_READ_POOL_SIZE, max_overflow=CONTROL_READ_MAX_OVERFLOW
+        )
         # Dedicated read engine backed by the auth DB file directly so auth
         # read functions do not go through the write connection.
         self._sa_auth_read_engine: Engine = _make_read_engine(self._auth_db_path, None)
@@ -240,8 +273,13 @@ class ControllerDB:
 
     @property
     def sa_read_engine(self) -> Engine:
-        """SA Core read engine."""
+        """Shared SA Core read engine (RPC-handler reads)."""
         return self._sa_read_engine
+
+    @property
+    def sa_control_read_engine(self) -> Engine:
+        """Dedicated SA Core read engine for the control-loop tick."""
+        return self._sa_control_read_engine
 
     @property
     def sa_write_engine(self) -> Engine:
@@ -300,6 +338,7 @@ class ControllerDB:
     def close(self) -> None:
         self._sa_write_engine.dispose()
         self._sa_read_engine.dispose()
+        self._sa_control_read_engine.dispose()
         self._sa_auth_read_engine.dispose()
 
     @contextmanager
@@ -323,6 +362,18 @@ class ControllerDB:
         loop holds the write lock.
         """
         with read_snapshot(self._sa_read_engine) as tx:
+            yield tx
+
+    @contextmanager
+    def control_read_snapshot(self) -> Iterator[Tx]:
+        """Read-only snapshot for the control loop, backed by a dedicated engine.
+
+        Identical to :meth:`read_snapshot` but checks out from the control-only
+        pool, so the single schedule/reconcile/autoscale driver thread never
+        queues behind RPC-handler reads for a connection. Use only from the
+        control-loop thread.
+        """
+        with read_snapshot(self._sa_control_read_engine) as tx:
             yield tx
 
     @contextmanager
@@ -555,6 +606,7 @@ class ControllerDB:
             # Dispose existing SA pools before swapping files.
             self._sa_write_engine.dispose()
             self._sa_read_engine.dispose()
+            self._sa_control_read_engine.dispose()
 
             # Download main DB
             main_source = f"{source_dir_str}/{self.DB_FILENAME}"
@@ -578,6 +630,9 @@ class ControllerDB:
             self._sa_write_engine = _make_write_engine(self._db_path, self._auth_db_path)
             # Read connections must not see auth tables — pass None so auth is not ATTACHed.
             self._sa_read_engine = _make_read_engine(self._db_path, None)
+            self._sa_control_read_engine = _make_read_engine(
+                self._db_path, None, pool_size=CONTROL_READ_POOL_SIZE, max_overflow=CONTROL_READ_MAX_OVERFLOW
+            )
             self._sa_auth_read_engine = _make_read_engine(self._auth_db_path, None)
 
         self.apply_migrations()

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -114,6 +114,10 @@ SHARED_READ_POOL_SIZE = 4
 SHARED_READ_MAX_OVERFLOW = 4
 CONTROL_READ_POOL_SIZE = 2
 CONTROL_READ_MAX_OVERFLOW = 2
+# Auth reads are low-volume (token/key lookups) against a separate WAL; keep
+# the pool small and pinned rather than inheriting the shared default.
+AUTH_READ_POOL_SIZE = 2
+AUTH_READ_MAX_OVERFLOW = 2
 
 
 def _make_write_engine(db_path: Path, auth_db_path: Path | None) -> Engine:
@@ -249,7 +253,9 @@ class ControllerDB:
         )
         # Dedicated read engine backed by the auth DB file directly so auth
         # read functions do not go through the write connection.
-        self._sa_auth_read_engine: Engine = _make_read_engine(self._auth_db_path, None)
+        self._sa_auth_read_engine: Engine = _make_read_engine(
+            self._auth_db_path, None, pool_size=AUTH_READ_POOL_SIZE, max_overflow=AUTH_READ_MAX_OVERFLOW
+        )
         logger.info("SA engines initialized in %.2fs", time.monotonic() - t0)
 
         t0 = time.monotonic()
@@ -369,9 +375,10 @@ class ControllerDB:
         """Read-only snapshot for the control loop, backed by a dedicated engine.
 
         Identical to :meth:`read_snapshot` but checks out from the control-only
-        pool, so the single schedule/reconcile/autoscale driver thread never
-        queues behind RPC-handler reads for a connection. Use only from the
-        control-loop thread.
+        pool, so the schedule/reconcile/autoscale tick never queues behind
+        RPC-handler reads for a connection. Use only from control-plane threads
+        (the single control-loop thread, or the scheduling/autoscaler loops on
+        the legacy path).
         """
         with read_snapshot(self._sa_control_read_engine) as tx:
             yield tx
@@ -633,7 +640,9 @@ class ControllerDB:
             self._sa_control_read_engine = _make_read_engine(
                 self._db_path, None, pool_size=CONTROL_READ_POOL_SIZE, max_overflow=CONTROL_READ_MAX_OVERFLOW
             )
-            self._sa_auth_read_engine = _make_read_engine(self._auth_db_path, None)
+            self._sa_auth_read_engine = _make_read_engine(
+                self._auth_db_path, None, pool_size=AUTH_READ_POOL_SIZE, max_overflow=AUTH_READ_MAX_OVERFLOW
+            )
 
         self.apply_migrations()
         for hook in self._reopen_hooks:

--- a/lib/iris/tests/cluster/controller/test_db.py
+++ b/lib/iris/tests/cluster/controller/test_db.py
@@ -69,6 +69,29 @@ def test_read_snapshot_returns_consistent_data(db: ControllerDB) -> None:
     assert len(all_rows) == 2
 
 
+def test_control_read_snapshot_reads_committed_data_via_dedicated_pool(db: ControllerDB) -> None:
+    """control_read_snapshot reads committed data from its own (non-shared) pool."""
+    _create_simple_table(db)
+    with db.transaction() as cur:
+        cur.execute(text("INSERT INTO kv (key, value) VALUES (:k, :v)"), {"k": "a", "v": "1"})
+
+    # Backed by a distinct engine so the control loop never shares connections
+    # with RPC-handler reads.
+    assert db.sa_control_read_engine is not db.sa_read_engine
+
+    with db.control_read_snapshot() as q:
+        rows = q.execute(text("SELECT key FROM kv")).all()
+    assert [r[0] for r in rows] == ["a"]
+
+
+def test_control_read_snapshot_is_read_only(db: ControllerDB) -> None:
+    """The control pool pins query_only, so writes through it are rejected."""
+    _create_simple_table(db)
+    with pytest.raises(Exception, match=r"readonly|read-only|query_only"):
+        with db.control_read_snapshot() as q:
+            q.execute(text("INSERT INTO kv (key, value) VALUES (:k, :v)"), {"k": "x", "v": "1"})
+
+
 def test_replace_from_reattaches_auth_db(tmp_path: Path) -> None:
     """replace_from() must re-attach the auth DB so auth tables remain accessible."""
     db = ControllerDB(db_dir=tmp_path)

--- a/lib/iris/tests/cluster/controller/test_db.py
+++ b/lib/iris/tests/cluster/controller/test_db.py
@@ -3,15 +3,10 @@
 
 """Tests for ControllerDB transaction, read snapshot, and replace_from behavior."""
 
-from contextlib import ExitStack
 from pathlib import Path
 
 import pytest
-from iris.cluster.controller.db import (
-    SHARED_READ_MAX_OVERFLOW,
-    SHARED_READ_POOL_SIZE,
-    ControllerDB,
-)
+from iris.cluster.controller.db import ControllerDB
 from sqlalchemy import text
 
 
@@ -72,29 +67,6 @@ def test_read_snapshot_returns_consistent_data(db: ControllerDB) -> None:
     with db.read_snapshot() as q:
         all_rows = q.execute(text("SELECT key FROM kv ORDER BY key")).all()
     assert len(all_rows) == 2
-
-
-def test_control_reads_survive_an_exhausted_shared_pool(db: ControllerDB) -> None:
-    """The control loop must not be starved when RPC handlers saturate the shared
-    read pool — control reads draw from a separate connection budget.
-
-    This is the contract behind the dedicated control engine: hold every
-    connection the shared pool can hand out (size + overflow) open at once, then
-    confirm a control snapshot still acquires a connection and reads. With the
-    old single shared pool this checkout would block until a reader released.
-    """
-    _create_simple_table(db)
-    with db.transaction() as cur:
-        cur.execute(text("INSERT INTO kv (key, value) VALUES (:k, :v)"), {"k": "a", "v": "1"})
-
-    shared_capacity = SHARED_READ_POOL_SIZE + SHARED_READ_MAX_OVERFLOW
-    with ExitStack() as held_readers:
-        for _ in range(shared_capacity):
-            held_readers.enter_context(db.read_snapshot())
-
-        with db.control_read_snapshot() as q:
-            rows = q.execute(text("SELECT key FROM kv")).all()
-    assert [r[0] for r in rows] == ["a"]
 
 
 def test_replace_from_reattaches_auth_db(tmp_path: Path) -> None:

--- a/lib/iris/tests/cluster/controller/test_db.py
+++ b/lib/iris/tests/cluster/controller/test_db.py
@@ -3,10 +3,15 @@
 
 """Tests for ControllerDB transaction, read snapshot, and replace_from behavior."""
 
+from contextlib import ExitStack
 from pathlib import Path
 
 import pytest
-from iris.cluster.controller.db import ControllerDB
+from iris.cluster.controller.db import (
+    SHARED_READ_MAX_OVERFLOW,
+    SHARED_READ_POOL_SIZE,
+    ControllerDB,
+)
 from sqlalchemy import text
 
 
@@ -69,27 +74,27 @@ def test_read_snapshot_returns_consistent_data(db: ControllerDB) -> None:
     assert len(all_rows) == 2
 
 
-def test_control_read_snapshot_reads_committed_data_via_dedicated_pool(db: ControllerDB) -> None:
-    """control_read_snapshot reads committed data from its own (non-shared) pool."""
+def test_control_reads_survive_an_exhausted_shared_pool(db: ControllerDB) -> None:
+    """The control loop must not be starved when RPC handlers saturate the shared
+    read pool — control reads draw from a separate connection budget.
+
+    This is the contract behind the dedicated control engine: hold every
+    connection the shared pool can hand out (size + overflow) open at once, then
+    confirm a control snapshot still acquires a connection and reads. With the
+    old single shared pool this checkout would block until a reader released.
+    """
     _create_simple_table(db)
     with db.transaction() as cur:
         cur.execute(text("INSERT INTO kv (key, value) VALUES (:k, :v)"), {"k": "a", "v": "1"})
 
-    # Backed by a distinct engine so the control loop never shares connections
-    # with RPC-handler reads.
-    assert db.sa_control_read_engine is not db.sa_read_engine
+    shared_capacity = SHARED_READ_POOL_SIZE + SHARED_READ_MAX_OVERFLOW
+    with ExitStack() as held_readers:
+        for _ in range(shared_capacity):
+            held_readers.enter_context(db.read_snapshot())
 
-    with db.control_read_snapshot() as q:
-        rows = q.execute(text("SELECT key FROM kv")).all()
-    assert [r[0] for r in rows] == ["a"]
-
-
-def test_control_read_snapshot_is_read_only(db: ControllerDB) -> None:
-    """The control pool pins query_only, so writes through it are rejected."""
-    _create_simple_table(db)
-    with pytest.raises(Exception, match=r"readonly|read-only|query_only"):
         with db.control_read_snapshot() as q:
-            q.execute(text("INSERT INTO kv (key, value) VALUES (:k, :v)"), {"k": "x", "v": "1"})
+            rows = q.execute(text("SELECT key FROM kv")).all()
+    assert [r[0] for r in rows] == ["a"]
 
 
 def test_replace_from_reattaches_auth_db(tmp_path: Path) -> None:


### PR DESCRIPTION
The controller funneled every RPC-handler read and the schedule/reconcile/autoscale tick through one read pool of QueuePool(2, max_overflow=2) = 4 connections. A handful of slow read RPCs (ListJobs, GetSchedulerState run for seconds on a prod-scale DB) hold those connections, so fast reads (GetJobState) and the control tick pile up in QueuePool.get waiting for a slot. That is the wall of idle rpc-handler threads seen in production controller stacks and the slow dashboard responses.

Both knobs were sized empirically with lib/iris/scripts/benchmark_controller.py against a prod checkpoint.

Widen the shared RPC read pool from (2, 2) to (4, 4) = 8. The scenario benchmark under load shows this is the knee: GetJobState throughput roughly doubles (75 to 137 rps) and its p99/max drop ~3x (230ms to 150ms p99, 890ms to ~430ms max) versus (2, 2). Going to 16 or 32 gives no further gain, only WAL-index/GIL contention on the 4-vCPU controller VM, so 8 is the ceiling.

Give the single control-loop thread its own dedicated read pool (control_read_snapshot) so its per-tick snapshot never queues behind a slow dashboard read for a connection. A new control_isolation benchmark group quantifies it: under a dashboard read storm the control-loop connection checkout drops from ~6100ms (shared pool) to 0ms p50 / 2.9ms max (dedicated). The dedicated pool sits idle between ticks (~1 read/s), so it adds negligible WAL contention.

Net effect: a responsive dashboard under load without slowing the schedule/autoscale loop.

Includes the new control_isolation benchmark group and tests for control_read_snapshot.