### PR TITLE
storage report: drain-based early scan finish + larger CI timeout

### DIFF
--- a/.github/workflows/ops-storage-report.yaml
+++ b/.github/workflows/ops-storage-report.yaml
@@ -32,9 +32,11 @@ concurrency:
 jobs:
   report:
     runs-on: ubuntu-latest
-    # The scan alone can run up to MAX_SCAN_SECONDS (90 min); leave room for
-    # dedup, aggregation, gist, and the Discord post on top of that.
-    timeout-minutes: 150
+    # The scan usually finishes early once it drains to a few straggler tasks,
+    # but can run up to MAX_SCAN_SECONDS (90 min) plus Iris scheduling overhead;
+    # leave generous room for dedup, aggregation, gist, and the Discord post so
+    # the publish step is never the thing that gets guillotined.
+    timeout-minutes: 240
     env:
       IRIS_CONFIG: lib/iris/config/marin.yaml
     steps:

--- a/scripts/ops/storage/scan_gcs.py
+++ b/scripts/ops/storage/scan_gcs.py
@@ -82,6 +82,15 @@ STRAGGLER_GRACE_SECONDS = 300
 # and finalize whatever we have, even if some tasks are still in flight.
 MAX_SCAN_SECONDS = 90 * 60
 
+# Drain-based early finish. Once only a handful of tasks remain in flight
+# (queue + active workers) and stay there for DRAIN_GRACE_SECONDS, finalize
+# instead of waiting out MAX_SCAN_SECONDS. The straggler tail is a few huge
+# flat prefixes that keep streaming objects (so the no-progress timeout never
+# fires) but contribute marginally to a directory-level report. This mirrors
+# the manual "kill the scan when <100 tasks are left" operating practice.
+DRAIN_TASK_THRESHOLD = 100
+DRAIN_GRACE_SECONDS = 300
+
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -635,10 +644,14 @@ def run_distributed(
 
     # Monitor progress
     start_time = time.monotonic()
+    # Monotonic time when the in-flight task count first dropped to the drain
+    # threshold; reset whenever it climbs back above (new sub-prefixes queued).
+    drained_since: float | None = None
     try:
         while True:
             status = coordinator.get_status()
             elapsed = time.monotonic() - start_time
+            remaining = status["queue_size"] + status["active_workers"]
 
             print(
                 f"[{elapsed:6.0f}s] "
@@ -652,6 +665,15 @@ def run_distributed(
 
             if status["done"]:
                 break
+
+            if remaining <= DRAIN_TASK_THRESHOLD:
+                if drained_since is None:
+                    drained_since = time.monotonic()
+                elif time.monotonic() - drained_since >= DRAIN_GRACE_SECONDS:
+                    print(f"Only {remaining} tasks left for {DRAIN_GRACE_SECONDS}s; abandoning stragglers, finalizing")
+                    break
+            else:
+                drained_since = None
 
             if elapsed >= MAX_SCAN_SECONDS:
                 print(f"Wall-clock cap of {MAX_SCAN_SECONDS}s hit; abandoning stragglers and finalizing")

--- a/scripts/ops/storage/scan_gcs.py
+++ b/scripts/ops/storage/scan_gcs.py
@@ -91,6 +91,14 @@ MAX_SCAN_SECONDS = 90 * 60
 DRAIN_TASK_THRESHOLD = 100
 DRAIN_GRACE_SECONDS = 300
 
+# Lower bound on elapsed wall-clock before the drain-based early finish is even
+# considered. Early in a run the in-flight count can briefly dip to/below
+# DRAIN_TASK_THRESHOLD before adaptive splitting fans the queue back out, so
+# without a floor we could finalize prematurely and miss large swaths of the
+# namespace. Below this threshold we never take the early exit; the no-progress
+# straggler timeout and the MAX_SCAN_SECONDS cap still apply as backstops.
+DRAIN_MIN_SCAN_SECONDS = 45 * 60
+
 
 # ---------------------------------------------------------------------------
 # Data types
@@ -666,7 +674,11 @@ def run_distributed(
             if status["done"]:
                 break
 
-            if remaining <= DRAIN_TASK_THRESHOLD:
+            # Only consider the drain-based early finish after a minimum
+            # elapsed time, so a transient early dip in the in-flight count
+            # (before adaptive splitting fans the queue back out) can't finalize
+            # the scan prematurely.
+            if elapsed >= DRAIN_MIN_SCAN_SECONDS and remaining <= DRAIN_TASK_THRESHOLD:
                 if drained_since is None:
                     drained_since = time.monotonic()
                 elif time.monotonic() - drained_since >= DRAIN_GRACE_SECONDS:


### PR DESCRIPTION
## Why

The weekly storage-report run (#6144) overran its CI budget (See https://github.com/marin-community/marin/actions/runs/27568351075). Last run was killed at the 150-min GitHub Actions cap — but the scan/dedup/report Iris jobs had already finished on the cluster, so the only thing lost was the publish step (gist + Discord).

Two causes:

1. The distributed scan burns its full 90-min `MAX_SCAN_SECONDS` wall-clock cap on every run. The straggler tail is a handful of huge flat prefixes that keep streaming objects, so the existing no-progress straggler timeout never fires and the scan waits out the full cap.
2. With ~40 min of Iris scheduling/flush overhead plus ~18 min of dedup on top of the 90-min scan, the total exceeds the 150-min CI cap.

## What

- **`scan_gcs.py` — drain-based early finish.** Once in-flight tasks (queue + active workers) sit at <=100 for 5 minutes, the coordinator finalizes instead of waiting out `MAX_SCAN_SECONDS`. This mechanizes the manual "kill the scan when <100 tasks are left" operating practice, and logs the abandoned count so the (marginal, directory-level) undercount is visible. The 90-min hard cap and the no-progress straggler timeout remain as backstops, so this is strictly an *earlier* exit — it can never make a run slower.
- **`ops-storage-report.yaml` — `timeout-minutes` 150 → 240.** Headroom so the thin publish step is never the thing that gets guillotined.

## Notes

- No behavior change to the report contents, the week-over-week diff, or the publish path.
- Draft for now.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
