### PR TITLE
[levanter] Read personal Marin launch config

### DIFF
--- a/docs/tutorials/storage-bucket.md
+++ b/docs/tutorials/storage-bucket.md
@@ -126,7 +126,16 @@ trainer:
     base_path: "$BUCKET/your-run"
 ```
 
-Commit these defaults in `.levanter.yaml` or `.envrc` so every launch script uses the same location.
+Put personal launch defaults in `~/.config/marin/config.yaml` so every launch script uses the same location:
+
+```yaml
+env:
+  MARIN_PREFIX: "gs://your-bucket"
+  WANDB_PROJECT: marin
+  WANDB_ENTITY: your-entity
+```
+
+Use a checkout-local `.levanter.yaml` only for values that should override your personal defaults for that repository.
 
 ## Ongoing Hygiene Checklist
 

--- a/lib/levanter/docs/Getting-Started-TPU-VM.md
+++ b/lib/levanter/docs/Getting-Started-TPU-VM.md
@@ -77,10 +77,11 @@ to set up ssh keys and [using `ssh-agent`](https://kb.iu.edu/d/aeww) to make exe
 You will need a [Docker installation](https://docs.docker.com/engine/install/)
 on your development machine to build and run images on TPUs.
 
-First create a configuration file for future launches in your Levanter directory:
+First create a personal configuration file for future launches:
 
 ```bash
-cat > .levanter.yaml <<EOF
+mkdir -p ~/.config/marin
+cat > ~/.config/marin/config.yaml <<EOF
 env:
     WANDB_API_KEY:
     WANDB_ENTITY:
@@ -103,6 +104,9 @@ capacity_type: "preemptible"
 subnetwork: "default"  # default
 EOF
 ```
+
+Levanter also reads `.levanter.yaml` from the current checkout. Use it for repository-specific values that should
+override your personal defaults in `~/.config/marin/config.yaml`.
 
 If you want to customize the docker image that is created and uploaded to Artifact Registry, you can add config `image_name: "YOUR-DOCKER-NAME"`.
 

--- a/lib/levanter/docs/reference/Configuration.md
+++ b/lib/levanter/docs/reference/Configuration.md
@@ -183,10 +183,11 @@ trainer:
 ```
 
 Alternatively, JAX's compilation cache directory can be set using the `JAX_COMPILATION_CACHE_DIR` environment variable.
-This method is particularly useful for workflows involving `launch.py` on TPUs, as environment variables can be specified in the `.levanter.yaml` configuration file used by `launch.py`.
+This method is particularly useful for workflows involving `launch.py` on TPUs, as environment variables can be specified in the `~/.config/marin/config.yaml` configuration file used by `launch.py`.
+Checkout-local `.levanter.yaml` files are also read and override matching values from `~/.config/marin/config.yaml`.
 For more details on using `launch.py`, see the [Using launch.py](../Getting-Started-TPU-VM.md#using-launchpy) section in the TPU VM guide.
 
-Example `.levanter.yaml` snippet:
+Example `~/.config/marin/config.yaml` snippet:
 ```yaml
 env:
   JAX_COMPILATION_CACHE_DIR: "gs://your-compile-cache-bucket/path"

--- a/lib/levanter/src/levanter/infra/cli_helpers.py
+++ b/lib/levanter/src/levanter/infra/cli_helpers.py
@@ -19,21 +19,35 @@ from google.cloud import storage
 
 USER_CONFIG_PATH = Path(".config/marin/config.yaml")
 LOCAL_CONFIG_PATH = Path(".levanter.yaml")
+# Legacy checkout-local file, distinct from the XDG user config directory.
 DEPRECATED_LOCAL_CONFIG_PATH = Path(".config")
 
 
 @dataclass(frozen=True)
 class CliConfig:
+    autodelete: bool | None = None
+    capacity_type: str | None = None
     project: str | None = None
+    region: str | None = None
     zone: str | None = None
     tpu: str | None = None
+    tpu_name: str | None = None
+    tpu_type: str | None = None
+    node_count: int | None = None
+    version: str | None = None
+    retries: int | None = None
+    run_id: str | None = None
     repository: str | None = None
     image: str | None = None
+    image_name: str | None = None
     tag: str | None = None
     github_user: str | None = None
     github_token: str | None = None
+    docker_base_image: str | None = None
     docker_file: str | None = None
+    docker_registry: str | None = None
     extra_context: str | None = None
+    foreground: bool | None = None
     docker_target: str | None = None
     docker_repository: str | None = None
     subnetwork: str | None = None

--- a/lib/levanter/src/levanter/infra/cli_helpers.py
+++ b/lib/levanter/src/levanter/infra/cli_helpers.py
@@ -10,11 +10,14 @@ import warnings
 from dataclasses import dataclass
 from functools import cached_property
 from pathlib import Path
-from typing import Optional
+from typing import Any, Optional
 
 import draccus
 import yaml
 from google.cloud import storage
+
+
+USER_CONFIG_PATH = Path(".config/marin/config.yaml")
 
 
 @dataclass(frozen=True)
@@ -101,15 +104,41 @@ def add_arg(parser: argparse.ArgumentParser, config: CliConfig, flags: list[str]
 
 
 def load_config() -> CliConfig:
+    d = _load_yaml_mapping(Path.home() / USER_CONFIG_PATH)
+
     if os.path.exists(".levanter.yaml"):
-        d = yaml.load(open(".levanter.yaml", "r"), Loader=yaml.SafeLoader)
+        d = _merge_config_dicts(d, _load_yaml_mapping(Path(".levanter.yaml")))
     elif os.path.exists(".config"):
         warnings.warn("Using deprecated .config file. Please rename to .levanter.yaml")
-        d = yaml.load(open(".config", "r"), Loader=yaml.SafeLoader)
-    else:
-        d = {}
+        d = _merge_config_dicts(d, _load_yaml_mapping(Path(".config")))
 
     return draccus.decode(CliConfig, d)
+
+
+def _load_yaml_mapping(path: Path) -> dict[str, Any]:
+    if not path.exists():
+        return {}
+
+    with path.open("r") as f:
+        data = yaml.load(f, Loader=yaml.SafeLoader)
+
+    if data is None:
+        return {}
+
+    if not isinstance(data, dict):
+        raise ValueError(f"Expected YAML mapping in {path}")
+
+    return data
+
+
+def _merge_config_dicts(base: dict[str, Any], override: dict[str, Any]) -> dict[str, Any]:
+    merged = base.copy()
+    for key, value in override.items():
+        if isinstance(value, dict) and isinstance(merged.get(key), dict):
+            merged[key] = _merge_config_dicts(merged[key], value)
+        else:
+            merged[key] = value
+    return merged
 
 
 def get_git_commit():

--- a/lib/levanter/src/levanter/infra/cli_helpers.py
+++ b/lib/levanter/src/levanter/infra/cli_helpers.py
@@ -18,6 +18,8 @@ from google.cloud import storage
 
 
 USER_CONFIG_PATH = Path(".config/marin/config.yaml")
+LOCAL_CONFIG_PATH = Path(".levanter.yaml")
+DEPRECATED_LOCAL_CONFIG_PATH = Path(".config")
 
 
 @dataclass(frozen=True)
@@ -104,15 +106,15 @@ def add_arg(parser: argparse.ArgumentParser, config: CliConfig, flags: list[str]
 
 
 def load_config() -> CliConfig:
-    d = _load_yaml_mapping(Path.home() / USER_CONFIG_PATH)
+    config_dict = _load_yaml_mapping(Path.home() / USER_CONFIG_PATH)
 
-    if os.path.exists(".levanter.yaml"):
-        d = _merge_config_dicts(d, _load_yaml_mapping(Path(".levanter.yaml")))
-    elif os.path.exists(".config"):
+    if LOCAL_CONFIG_PATH.exists():
+        config_dict = _merge_config_dicts(config_dict, _load_yaml_mapping(LOCAL_CONFIG_PATH))
+    elif DEPRECATED_LOCAL_CONFIG_PATH.exists():
         warnings.warn("Using deprecated .config file. Please rename to .levanter.yaml")
-        d = _merge_config_dicts(d, _load_yaml_mapping(Path(".config")))
+        config_dict = _merge_config_dicts(config_dict, _load_yaml_mapping(DEPRECATED_LOCAL_CONFIG_PATH))
 
-    return draccus.decode(CliConfig, d)
+    return draccus.decode(CliConfig, config_dict)
 
 
 def _load_yaml_mapping(path: Path) -> dict[str, Any]:


### PR DESCRIPTION
Read personal Levanter launch defaults from ~/.config/marin/config.yaml before applying checkout-local overrides. This gives users a normal XDG-style place for project, zone, Docker, and environment defaults while preserving .levanter.yaml for repository-specific values.

Update the Marin and Levanter docs to point personal launch defaults at ~/.config/marin/config.yaml and describe .levanter.yaml as the local override.