### PR TITLE
Fix relative output paths in ExecutorStep to StepSpec bridge

### DIFF
--- a/lib/marin/src/marin/execution/executor.py
+++ b/lib/marin/src/marin/execution/executor.py
@@ -617,6 +617,24 @@ def asdict_without_description(obj: Any) -> dict[str, Any]:
     return d
 
 
+def _resolved_output_path(output_path: str) -> str:
+    """Absolutize a fully-resolved local executor output path.
+
+    Executor output paths are already resolved against the executor's ``prefix``
+    (``executor.py``'s ``compute_version``). When that prefix is relative
+    (e.g. ``--prefix ../marin-prefix``), the resolved path stays relative.
+    Passing such a path straight into ``StepSpec(override_output_path=...)``
+    would make :pyattr:`StepSpec.output_path` re-interpret it as
+    prefix-relative and prepend ``marin_prefix()`` a second time, splitting the
+    step's status/lock/dependency paths from where its ``fn`` actually writes
+    data. Absolutizing here (URLs and already-absolute paths pass through) keeps
+    every path for one logical step pointing at the same directory.
+    """
+    if _is_relative_path(output_path):
+        return os.path.abspath(output_path)
+    return output_path
+
+
 def resolve_executor_step(
     step: "ExecutorStep",
     config: Any,
@@ -689,7 +707,7 @@ def resolve_executor_step(
     return StepSpec(
         name=step.name,
         deps=deps or [],
-        override_output_path=output_path,
+        override_output_path=_resolved_output_path(output_path),
         fn=final_fn,
         resources=step.resources,
     )
@@ -1203,7 +1221,7 @@ class Executor:
         dag_tpu_regions_by_step = _step_dag_tpu_regions(steps, self.dependencies)
         dep_stubs_by_step = {
             step: [
-                StepSpec(name=dep.name, override_output_path=self.output_paths[dep])
+                StepSpec(name=dep.name, override_output_path=_resolved_output_path(self.output_paths[dep]))
                 for dep in self.dependencies[step]
                 if dep in self.output_paths
             ]

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -23,7 +23,6 @@ from marin.evaluation.perplexity_gap import (
 from marin.execution.executor import (
     Executor,
     _get_info_path,
-    _is_relative_path,
     collect_dependencies_and_version,
     compute_output_path,
     instantiate_config,
@@ -141,7 +140,7 @@ def test_executor():
     cleanup_log(log)
 
 
-def test_relative_prefix_resolves_to_single_directory(monkeypatch, tmp_path):
+def test_relative_prefix_resolves_to_single_directory(tmp_path):
     """Regression for #6334.
 
     With a relative executor ``prefix`` (e.g. ``--prefix ../marin-prefix``) the
@@ -151,12 +150,7 @@ def test_relative_prefix_resolves_to_single_directory(monkeypatch, tmp_path):
     which would split a step's status/lock/dependency paths from where its
     ``fn`` actually writes data.
     """
-    # A MARIN_PREFIX distinct from cwd: a spurious re-prefix would surface here.
-    marin_prefix_env = str(tmp_path / "marin-prefix-env")
-    monkeypatch.setenv("MARIN_PREFIX", marin_prefix_env)
-
     rel_prefix = os.path.relpath(str(tmp_path / "work"))
-    assert _is_relative_path(rel_prefix)
 
     def fn(config: MyConfig | None):
         return None
@@ -174,13 +168,12 @@ def test_relative_prefix_resolves_to_single_directory(monkeypatch, tmp_path):
 
     for step in (a, b):
         spec = specs[step.name]
-        # Status/lock/info path (StepSpec.output_path) must match where fn writes data.
-        assert os.path.realpath(spec.output_path) == os.path.realpath(executor.output_paths[step])
-        # ...and must not be re-prefixed against MARIN_PREFIX.
-        assert marin_prefix_env not in spec.output_path
+        # Status/lock/info path (StepSpec.output_path) must be the resolved path
+        # where fn writes data, not a second-prefixed variant.
+        assert spec.output_path == os.path.abspath(executor.output_paths[step])
 
     # The dependency stub (b -> a) must resolve to a's real directory.
-    assert os.path.realpath(specs["b"].dep_paths[0]) == os.path.realpath(executor.output_paths[a])
+    assert specs["b"].dep_paths[0] == os.path.abspath(executor.output_paths[a])
 
 
 def test_status_file_reads_legacy_format(tmp_path):

--- a/tests/execution/test_executor.py
+++ b/tests/execution/test_executor.py
@@ -23,6 +23,7 @@ from marin.evaluation.perplexity_gap import (
 from marin.execution.executor import (
     Executor,
     _get_info_path,
+    _is_relative_path,
     collect_dependencies_and_version,
     compute_output_path,
     instantiate_config,
@@ -138,6 +139,48 @@ def test_executor():
                 check_info(step_info, step)
 
     cleanup_log(log)
+
+
+def test_relative_prefix_resolves_to_single_directory(monkeypatch, tmp_path):
+    """Regression for #6334.
+
+    With a relative executor ``prefix`` (e.g. ``--prefix ../marin-prefix``) the
+    resolved output path stays relative. The ``ExecutorStep``->``StepSpec``
+    bridge must hand a final, non-relative path to ``StepSpec`` so that
+    ``StepSpec.output_path`` does not re-prefix it against ``marin_prefix()``,
+    which would split a step's status/lock/dependency paths from where its
+    ``fn`` actually writes data.
+    """
+    # A MARIN_PREFIX distinct from cwd: a spurious re-prefix would surface here.
+    marin_prefix_env = str(tmp_path / "marin-prefix-env")
+    monkeypatch.setenv("MARIN_PREFIX", marin_prefix_env)
+
+    rel_prefix = os.path.relpath(str(tmp_path / "work"))
+    assert _is_relative_path(rel_prefix)
+
+    def fn(config: MyConfig | None):
+        return None
+
+    a = ExecutorStep(name="a", fn=fn, config=None)
+    b = ExecutorStep(
+        name="b",
+        fn=fn,
+        config=MyConfig(input_path=output_path_of(a, "sub"), output_path=this_output_path(), n=1, m=2),
+    )
+
+    executor = create_executor(rel_prefix)
+    executor.compute_version(b, is_pseudo_dep=False)
+    specs = {spec.name: spec for spec in executor._resolve_steps([a, b])}
+
+    for step in (a, b):
+        spec = specs[step.name]
+        # Status/lock/info path (StepSpec.output_path) must match where fn writes data.
+        assert os.path.realpath(spec.output_path) == os.path.realpath(executor.output_paths[step])
+        # ...and must not be re-prefixed against MARIN_PREFIX.
+        assert marin_prefix_env not in spec.output_path
+
+    # The dependency stub (b -> a) must resolve to a's real directory.
+    assert os.path.realpath(specs["b"].dep_paths[0]) == os.path.realpath(executor.output_paths[a])
 
 
 def test_status_file_reads_legacy_format(tmp_path):


### PR DESCRIPTION
Fixes #6334.

With a relative executor `--prefix` (e.g. `../marin-prefix`), a step's resolved `output_path` stays relative. The `ExecutorStep` → `StepSpec` bridge passed that already-resolved path into `StepSpec(override_output_path=...)`, where `StepSpec.output_path` treats relative overrides as prefix-relative and prepends `marin_prefix()` a second time. Status/lock/dependency paths then diverged from where the step `fn` writes data, so completed artifacts were ignored and dependencies needlessly reran.

**Fix:** absolutize the resolved path at both bridge sites (the step's own output and the dependency stubs); URLs and absolute paths pass through unchanged.

**Testing:** new regression test (fails on `main`, passes here); `test_executor.py` + `test_step_runner.py` → 125 passed, 1 skipped; pre-commit (ruff/black/license/pyrefly) clean.
