### PR TITLE
[iris] Fix controller crash on protobuf 7.x: use FieldDescriptor.is_repeated

### DIFF
--- a/lib/iris/src/iris/cli/rpc.py
+++ b/lib/iris/src/iris/cli/rpc.py
@@ -221,7 +221,7 @@ def kebab_to_pascal(name: str) -> str:
 
 def _is_simple_field(field: FieldDescriptor) -> bool:
     """Check if a protobuf field is a simple scalar type that maps to Click."""
-    if field.label == FieldDescriptor.LABEL_REPEATED:
+    if field.is_repeated:
         return False
     if field.message_type is not None:
         return False

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -444,7 +444,7 @@ def _deep_merge_defaults(target: config_pb2.DefaultsConfig, source: config_pb2.D
     for field_desc in source.DESCRIPTOR.fields:
         if field_desc.message_type is not None:
             continue
-        if field_desc.label == field_desc.LABEL_REPEATED:
+        if field_desc.is_repeated:
             continue
         if source.HasField(field_desc.name):
             setattr(target, field_desc.name, getattr(source, field_desc.name))


### PR DESCRIPTION
## Problem

The CoreWeave smoke CI (`cw-ci-test`) started failing on every PR after ~06:00 UTC today. The controller pod crash-loops at startup ([example run](https://github.com/marin-community/marin/actions/runs/27621022889/job/81669624284)):

```
File ".../iris/cluster/config.py", line 447, in _deep_merge_defaults
    if field_desc.label == field_desc.LABEL_REPEATED:
AttributeError: 'google._upb._message.FieldDescriptor' object has no attribute 'label'
```

## Root cause — the "recent version change"

**protobuf 7.x removed the `.label` attribute from the upb `FieldDescriptor`.** (7.34 shipped 2026-02-27; latest 7.35.1 on 2026-06-11.)

The repo `uv.lock` pins `protobuf==6.33.6`, where `.label` still works — which is why this passes locally and in the rest of CI. But the **iris `Dockerfile` `deps` stage resolves dependencies fresh from PyPI**: it writes a reduced `pyproject.toml` and runs `uv sync` *without copying the repo `uv.lock`*, so the controller image picks up **protobuf 7.x**. The `.label` usage introduced in #6380 (merged ~06:05 today) worked locally but crash-loops in the container — the first CoreWeave run after that merge was the first failure.

## Fix

Replace `field.label == FieldDescriptor.LABEL_REPEATED` with `field.is_repeated` at both protobuf-descriptor call sites:

- `lib/iris/src/iris/cluster/config.py` (`_deep_merge_defaults` — the crash site)
- `lib/iris/src/iris/cli/rpc.py` (`_is_simple_field` — same pattern, would crash the CLI on 7.x too)

`is_repeated` is the modern boolean property and works on **both** 6.33.6 and 7.35.1, so the code is version-robust regardless of which protobuf the environment resolves. `.type` usages are untouched — `.type` is still present in 7.x.

## Verification

- `load_config(config/coreweave-ci.yaml)` succeeds under **both** protobuf 6.33.6 and 7.35.1 (previously crashed on 7.x).
- Confirmed the other descriptor-reflection predicate in the same hot path (`GetOptions().map_entry`) also works on 7.x.
- iris config + rpc test suites: **253 passed, 1 skipped**.