### PR TITLE
[iris] Pin a reservation's parent to the reservation's claimed zone

### DIFF
--- a/lib/iris/src/iris/cluster/controller/backend.py
+++ b/lib/iris/src/iris/cluster/controller/backend.py
@@ -310,7 +310,12 @@ def apply_placements(
     un-tainted workers. When there are no claims the un-tainted ``ctx`` is reused
     to avoid an index rebuild.
     """
-    modified_jobs = inject_taint_constraints(gated.jobs, gated.has_reservation, gated.has_direct_reservation)
+    modified_jobs = inject_taint_constraints(
+        gated.jobs,
+        gated.has_reservation,
+        gated.has_direct_reservation,
+        ctx.reservation_zones_by_job,
+    )
 
     if claims:
         modified_workers = inject_reservation_taints(list(ctx.workers), claims)

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -27,7 +27,7 @@ from typing import Protocol
 from rigging.timing import Timestamp
 from sqlalchemy import Integer, Row, bindparam, case, cast, func, literal_column, select, tuple_
 
-from iris.cluster.constraints import AttributeValue
+from iris.cluster.constraints import AttributeValue, DeviceType, get_device_type_enum
 from iris.cluster.controller.codec import (
     device_counts_from_json,
     reservation_entries_from_json,
@@ -881,6 +881,33 @@ def reservation_entry_counts(tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName
             continue
         counts[row.job_id] = len(reservation_entries_from_json(row.reservation_json))
     return counts
+
+
+def reservation_entry_device_types(tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName, frozenset[DeviceType]]:
+    """Return ``{job_id: device types across its reservation entries}`` for the requested jobs.
+
+    Used to decide whether a directly-reserved job *co-locates* on its reserved
+    workers: a ``--reserve`` job whose own task targets the reservation's device
+    class runs on the reserved workers, while one whose own task is CPU-only and
+    reserves an accelerator does not (see ``_colocating_reservation_job_ids``).
+    Jobs with no reservation JSON are omitted.
+    """
+    ids = list(job_ids)
+    if not ids:
+        return {}
+    rows = tx.execute(
+        select(job_config_table.c.job_id, job_config_table.c.reservation_json).where(
+            job_config_table.c.job_id.in_(bindparam("job_ids", expanding=True))
+        ),
+        {"job_ids": ids},
+    ).all()
+    result: dict[JobName, frozenset[DeviceType]] = {}
+    for row in rows:
+        if row.reservation_json is None:
+            continue
+        entries = reservation_entries_from_json(row.reservation_json)
+        result[row.job_id] = frozenset(get_device_type_enum(entry.resources.device) for entry in entries)
+    return result
 
 
 def jobs_with_reservations(tx: Tx, states: Iterable[int]) -> Sequence[Row]:

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -886,10 +886,6 @@ def reservation_entry_counts(tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName
 def reservation_entry_device_types(tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName, frozenset[DeviceType]]:
     """Return ``{job_id: device types across its reservation entries}`` for the requested jobs.
 
-    Used to decide whether a directly-reserved job *co-locates* on its reserved
-    workers: a ``--reserve`` job whose own task targets the reservation's device
-    class runs on the reserved workers, while one whose own task is CPU-only and
-    reserves an accelerator does not (see ``_colocating_reservation_job_ids``).
     Jobs with no reservation JSON are omitted.
     """
     ids = list(job_ids)

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -27,7 +27,7 @@ from typing import Protocol
 from rigging.timing import Timestamp
 from sqlalchemy import Integer, Row, bindparam, case, cast, func, literal_column, select, tuple_
 
-from iris.cluster.constraints import AttributeValue, DeviceType, get_device_type_enum
+from iris.cluster.constraints import AttributeValue
 from iris.cluster.controller.codec import (
     device_counts_from_json,
     reservation_entries_from_json,
@@ -881,29 +881,6 @@ def reservation_entry_counts(tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName
             continue
         counts[row.job_id] = len(reservation_entries_from_json(row.reservation_json))
     return counts
-
-
-def reservation_entry_device_types(tx: Tx, job_ids: Iterable[JobName]) -> dict[JobName, frozenset[DeviceType]]:
-    """Return ``{job_id: device types across its reservation entries}`` for the requested jobs.
-
-    Jobs with no reservation JSON are omitted.
-    """
-    ids = list(job_ids)
-    if not ids:
-        return {}
-    rows = tx.execute(
-        select(job_config_table.c.job_id, job_config_table.c.reservation_json).where(
-            job_config_table.c.job_id.in_(bindparam("job_ids", expanding=True))
-        ),
-        {"job_ids": ids},
-    ).all()
-    result: dict[JobName, frozenset[DeviceType]] = {}
-    for row in rows:
-        if row.reservation_json is None:
-            continue
-        entries = reservation_entries_from_json(row.reservation_json)
-        result[row.job_id] = frozenset(get_device_type_enum(entry.resources.device) for entry in entries)
-    return result
 
 
 def jobs_with_reservations(tx: Tx, states: Iterable[int]) -> Sequence[Row]:

--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -22,14 +22,14 @@ from iris.cluster.constraints import (
     AttributeValue,
     Constraint,
     ConstraintOp,
-    DeviceType,
     PlacementRequirements,
+    WellKnownAttribute,
     constraints_from_resources,
     evaluate_constraint,
     extract_placement_requirements,
-    get_device_type_enum,
     merge_constraints,
     split_hard_soft,
+    zone_constraint,
 )
 from iris.cluster.controller import reads, writes
 from iris.cluster.controller.autoscaler.models import DemandEntry
@@ -44,7 +44,6 @@ from iris.cluster.controller.codec import (
     constraints_from_json,
     device_counts_from_json,
     device_variant_from_json,
-    proto_from_json,
     reservation_entries_from_json,
     resource_spec_from_scalars,
 )
@@ -144,24 +143,17 @@ def reservation_unsatisfied(
     task: PendingTask,
     claims_by_job: dict[str, int],
     reservation_entry_counts: dict[JobName, int],
-    colocating_reservation_job_ids: AbstractSet[JobName],
 ) -> bool:
     """Whether a real task must wait for its job's reservation to be claimed.
 
-    A non-holder task of a *co-locating* directly-reserved job is *unsatisfied*
-    until the number of workers claimed for its reservation reaches the
-    reservation's entry count. Such a task must neither be scheduled nor
-    generate autoscaler demand: the reservation's holder task provisions the
-    reserved capacity, and the real task runs only once that capacity exists.
-
-    A directly-reserved job that does *not* co-locate (its own task targets a
-    different device class than the reservation — e.g. a CPU orchestrator that
-    reserves a TPU) is never gated here: it does not run on the reserved
-    workers, so it schedules on its own resources independent of the
-    reservation. Gating it would strand it whenever the reservation cannot be
-    claimed (device stockout), and EQ-pinning it (see
-    :func:`inject_taint_constraints`) would route phantom demand the scheduler
-    can never satisfy.
+    A non-holder task of a directly-reserved job is *unsatisfied* until the
+    number of workers claimed for its reservation reaches the reservation's
+    entry count. Such a task must neither be scheduled nor generate autoscaler
+    demand: the reservation's holder task provisions the reserved capacity, and
+    the real task runs only once that capacity exists. Waiting for the claim also
+    fixes the reservation's zone before the task is placed or routed, so the
+    autoscaler never boots capacity in the wrong zone (see
+    :func:`inject_taint_constraints` for the zone pin then applied to the parent).
 
     Both the scheduling gate (:func:`apply_scheduling_gates`) and the demand
     path (:func:`compute_demand_entries`) consult this predicate so they agree.
@@ -170,8 +162,6 @@ def reservation_unsatisfied(
     thrashes, booting workers that are reaped as idle every cycle.
     """
     if task.is_reservation_holder or not task.has_reservation:
-        return False
-    if task.job_id not in colocating_reservation_job_ids:
         return False
     required = reservation_entry_counts.get(task.job_id, 0)
     return claims_by_job.get(task.job_id.to_wire(), 0) < required
@@ -185,38 +175,37 @@ def _claims_by_job(claims: dict[WorkerId, ReservationClaim] | None) -> dict[str,
     return counts
 
 
-def _own_device_type(res_device_json: str | None) -> DeviceType:
-    """Device class a task's *own* resource request targets (CPU when no accelerator)."""
-    if not res_device_json:
-        return DeviceType.CPU
-    return get_device_type_enum(proto_from_json(res_device_json, job_pb2.DeviceConfig))
+def reservation_zones_from_claims(
+    claims: dict[WorkerId, ReservationClaim],
+    workers: list[WorkerSnapshot],
+) -> dict[JobName, frozenset[str]]:
+    """Zones in which each reserving job's workers were claimed, keyed by job.
 
-
-def _colocating_reservation_job_ids(
-    pending: list[PendingTask],
-    entry_device_types: dict[JobName, frozenset[DeviceType]],
-) -> frozenset[JobName]:
-    """Directly-reserved jobs whose own task co-locates on their reserved workers.
-
-    A ``--reserve`` job co-locates only when its own resource request targets the
-    same device class the reservation reserves (e.g. ``--reserve v5p-8`` with a
-    v5p-8 task). A reservation whose own task is CPU-only while it reserves an
-    accelerator (the common orchestrator/``dev_tpu`` pattern) does NOT co-locate:
-    the reserved workers exist for its holder and descendants, and the parent
-    task itself schedules on a worker matching its own request. Only co-locating
-    jobs are EQ-pinned to and gated on their claimed workers; see
-    :func:`inject_taint_constraints` and :func:`reservation_unsatisfied`.
+    A directly-reserved job is pinned to these zones (see
+    :func:`inject_taint_constraints`) so it runs beside its reservation. A job is
+    absent until at least one of its entries is claimed on a zone-reporting
+    worker.
     """
-    result: set[JobName] = set()
-    for task in pending:
-        if not task.has_reservation:
+    zones_by_wire: dict[str, set[str]] = defaultdict(set)
+    attrs_by_worker = {w.worker_id: w.attributes for w in workers}
+    for worker_id, claim in claims.items():
+        attrs = attrs_by_worker.get(worker_id)
+        if attrs is None:
             continue
-        entries = entry_device_types.get(task.job_id)
-        if not entries:
-            continue
-        if _own_device_type(task.res_device_json) in entries:
-            result.add(task.job_id)
-    return frozenset(result)
+        zone = attrs.get(WellKnownAttribute.ZONE)
+        if zone is not None:
+            zones_by_wire[claim.job_id].add(str(zone.value))
+    return {JobName.from_wire(wire): frozenset(zones) for wire, zones in zones_by_wire.items()}
+
+
+def _reservation_zone_constraints(zones: frozenset[str]) -> list[Constraint]:
+    """Constrain a task to a set of claimed reservation zones (empty → no constraint)."""
+    if not zones:
+        return []
+    ordered = sorted(zones)
+    if len(ordered) == 1:
+        return [zone_constraint(ordered[0])]
+    return [Constraint.create(key=WellKnownAttribute.ZONE, op=ConstraintOp.IN, values=ordered)]
 
 
 def compute_demand_entries(
@@ -297,23 +286,30 @@ def compute_demand_entries(
     jobs: dict[JobName, JobRequirements] = {}
     has_reservation: set[JobName] = set()
     has_direct_reservation: set[JobName] = set()
-    colocating = ctx.colocating_reservation_job_ids
     for task in pending:
         if task.job_id in jobs:
             continue
         jobs[task.job_id] = job_requirements_from_job(task)
-        if task.has_reservation and task.job_id in colocating:
+        if task.has_reservation:
             has_reservation.add(task.job_id)
             has_direct_reservation.add(task.job_id)
         elif _find_reservation_ancestor(reserved_jobs, task.job_id) is not None:
             has_reservation.add(task.job_id)
 
     # Dry-run scheduling with building/assignment limits disabled.
-    # All tasks participate — holders and real tasks alike.
+    # Reservation-gated tasks are excluded: the real scheduling pass
+    # (apply_scheduling_gates) does not place them, so letting them consume
+    # absorption capacity here would make the fleet look full and push other
+    # tasks into false demand.
     absorbed_task_ids: set[JobName] = set()
     if ctx.workers:
         dry_run_workers = inject_reservation_taints(ctx.workers, claims)
-        dry_run_jobs = inject_taint_constraints(jobs, has_reservation, has_direct_reservation)
+        dry_run_jobs = inject_taint_constraints(
+            jobs, has_reservation, has_direct_reservation, ctx.reservation_zones_by_job
+        )
+        dry_run_pending = [
+            t.task_id for t in pending if not reservation_unsatisfied(t, claims_by_job, reservation_entry_counts)
+        ]
 
         # Dry-run scheduling context — only the per-(task, worker) matching loop
         # consumes capacities/jobs/pending_tasks, so the raw-read fields stay
@@ -324,7 +320,7 @@ def compute_demand_entries(
             building_counts=ctx.building_counts,
             max_building_tasks=_UNLIMITED,
             max_assignments_per_worker=_UNLIMITED,
-            pending_tasks=[t.task_id for t in pending],
+            pending_tasks=dry_run_pending,
             jobs=dry_run_jobs,
             pending_task_rows=[],
             user_spend={},
@@ -353,10 +349,21 @@ def compute_demand_entries(
         # capacity; emitting demand for the real task here would provision
         # generic capacity the scheduler gate will never let it occupy, so the
         # autoscaler would boot workers that idle out and get reaped forever.
-        if reservation_unsatisfied(job_row, claims_by_job, reservation_entry_counts, ctx.colocating_reservation_job_ids):
+        if reservation_unsatisfied(job_row, claims_by_job, reservation_entry_counts):
             continue
 
         job_constraints = constraints_from_json(job_row.constraints_json)
+        # A directly-reserved parent routes its own demand to the reservation's
+        # claimed zone, matching the zone pin the scheduler applies in
+        # inject_taint_constraints. The reservation gate above ensures we only
+        # reach here once claimed, so the zone is known. Without this the
+        # autoscaler would route the parent's demand to an arbitrary zone the
+        # scheduler then rejects.
+        if job_id in has_direct_reservation:
+            job_constraints = [
+                *job_constraints,
+                *_reservation_zone_constraints(ctx.reservation_zones_by_job.get(job_id, frozenset())),
+            ]
         # Build the proto here — DemandEntry.resources is an autoscaler RPC field (legitimate boundary).
         job_resources = resource_spec_from_scalars(
             job_row.res_cpu_millicores, job_row.res_memory_bytes, job_row.res_disk_bytes, job_row.res_device_json
@@ -841,44 +848,42 @@ def inject_taint_constraints(
     jobs: dict[JobName, JobRequirements],
     has_reservation: set[JobName],
     has_direct_reservation: set[JobName] | None = None,
+    reservation_zones_by_job: dict[JobName, frozenset[str]] | None = None,
 ) -> dict[JobName, JobRequirements]:
-    """Add reservation taint constraints to jobs.
+    """Add reservation zone/taint constraints to jobs.
 
-    Three-way logic:
-    - Direct reservation jobs (has_direct_reservation): get an EQ constraint
-      forcing them onto their claimed workers only.
+    A reservation maps its job to the *zone* where its accelerators were claimed;
+    it never pins to a specific worker. The reserved workers are held by the
+    job's ``:reservation:`` holder child and protected from third parties by the
+    taint below.
+
+    - Directly-reserved jobs (the reservation's parent): the zone constraint.
+      The parent must run in the reserved zone; the scheduler's normal matching
+      then places it on the reserved worker if its own request fits, or on other
+      capacity in that zone otherwise. No taint — the parent may use the claimed
+      workers.
     - Descendants of reservation jobs (has_reservation minus direct): no
-      constraint — they can use both claimed and unclaimed workers.
-    - Non-reservation jobs: get a NOT_EXISTS constraint blocking them from
-      claimed workers.
+      constraint — they are *allowed* to use the claimed workers but are not
+      required to, and may run anywhere.
+    - Non-reservation jobs: a NOT_EXISTS constraint blocking claimed workers.
     """
     if not has_reservation and not jobs:
         return jobs
 
-    if has_direct_reservation is None:
-        has_direct_reservation = set()
+    has_direct_reservation = has_direct_reservation or set()
+    zones_by_job = reservation_zones_by_job or {}
 
     taint_constraint = Constraint(key=RESERVATION_TAINT_KEY, op=ConstraintOp.NOT_EXISTS)
 
     modified: dict[JobName, JobRequirements] = {}
     for job_id, req in jobs.items():
         if job_id in has_direct_reservation:
-            eq_constraint = Constraint.create(
-                key=RESERVATION_TAINT_KEY,
-                op=ConstraintOp.EQ,
-                value=job_id.to_wire(),
-            )
-            modified[job_id] = replace(
-                req,
-                constraints=[*list(req.constraints), eq_constraint],
-            )
+            extra = _reservation_zone_constraints(zones_by_job.get(job_id, frozenset()))
+            modified[job_id] = replace(req, constraints=[*list(req.constraints), *extra])
         elif job_id in has_reservation:
             modified[job_id] = req
         else:
-            modified[job_id] = replace(
-                req,
-                constraints=[*list(req.constraints), taint_constraint],
-            )
+            modified[job_id] = replace(req, constraints=[*list(req.constraints), taint_constraint])
     return modified
 
 
@@ -1004,13 +1009,12 @@ def build_scheduling_context(
         reserved_jobs = reads.reserved_job_ids(snap)
         reserved_pending_ids = {t.job_id for t in pending if t.has_reservation}
         reservation_entry_counts = reads.reservation_entry_counts(snap, reserved_pending_ids)
-        entry_device_types = reads.reservation_entry_device_types(snap, reserved_pending_ids)
         building_counts = reads.building_counts(snap, [w.worker_id for w in workers])
         running = _running_tasks_with_band_and_value(snap, set(claims.keys()))
 
     snapshots = [worker_snapshot_from_row(w, usage_by_worker.get(w.worker_id)) for w in workers]
     sorted_pending = _sort_pending_tasks_by_resolved_band(pending, requested_bands)
-    colocating_reservations = _colocating_reservation_job_ids(pending, entry_device_types)
+    reservation_zones = reservation_zones_from_claims(claims, snapshots)
     return SchedulingContext(
         workers=snapshots,
         building_counts=building_counts,
@@ -1026,7 +1030,7 @@ def build_scheduling_context(
         reservation_entry_counts=reservation_entry_counts,
         user_budget_defaults=defaults,
         running_for_preemption=running,
-        colocating_reservation_job_ids=colocating_reservations,
+        reservation_zones_by_job=reservation_zones,
     )
 
 
@@ -1064,9 +1068,7 @@ def apply_scheduling_gates(
             continue
         # Gate: skip real tasks whose job has an unsatisfied reservation.
         # Holder tasks are always schedulable (they ARE the reservation).
-        if reservation_unsatisfied(
-            task, claims_by_job, ctx.reservation_entry_counts, ctx.colocating_reservation_job_ids
-        ):
+        if reservation_unsatisfied(task, claims_by_job, ctx.reservation_entry_counts):
             filter_counts["reservation_unsatisfied"] += 1
             continue
         if (
@@ -1080,7 +1082,7 @@ def apply_scheduling_gates(
         schedulable_task_ids.append(task.task_id)
         if task.job_id not in jobs:
             jobs[task.job_id] = job_requirements_from_job(task)
-            if task.has_reservation and task.job_id in ctx.colocating_reservation_job_ids:
+            if task.has_reservation:
                 has_reservation.add(task.job_id)
                 has_direct_reservation.add(task.job_id)
             elif _find_reservation_ancestor(ctx.reserved_job_ids, task.job_id) is not None:

--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -27,6 +27,7 @@ from iris.cluster.constraints import (
     constraints_from_resources,
     evaluate_constraint,
     extract_placement_requirements,
+    get_device_type_enum,
     merge_constraints,
     split_hard_soft,
 )
@@ -43,6 +44,7 @@ from iris.cluster.controller.codec import (
     constraints_from_json,
     device_counts_from_json,
     device_variant_from_json,
+    proto_from_json,
     reservation_entries_from_json,
     resource_spec_from_scalars,
 )
@@ -158,8 +160,8 @@ def reservation_unsatisfied(
     workers, so it schedules on its own resources independent of the
     reservation. Gating it would strand it whenever the reservation cannot be
     claimed (device stockout), and EQ-pinning it (see
-    :func:`inject_taint_constraints`) would route phantom CPU demand the
-    scheduler can never satisfy (the 2026-06-08 canary thrash).
+    :func:`inject_taint_constraints`) would route phantom demand the scheduler
+    can never satisfy.
 
     Both the scheduling gate (:func:`apply_scheduling_gates`) and the demand
     path (:func:`compute_demand_entries`) consult this predicate so they agree.
@@ -185,12 +187,9 @@ def _claims_by_job(claims: dict[WorkerId, ReservationClaim] | None) -> dict[str,
 
 def _own_device_type(res_device_json: str | None) -> DeviceType:
     """Device class a task's *own* resource request targets (CPU when no accelerator)."""
-    dc = device_counts_from_json(res_device_json)
-    if dc.gpu > 0:
-        return DeviceType.GPU
-    if dc.tpu > 0:
-        return DeviceType.TPU
-    return DeviceType.CPU
+    if not res_device_json:
+        return DeviceType.CPU
+    return get_device_type_enum(proto_from_json(res_device_json, job_pb2.DeviceConfig))
 
 
 def _colocating_reservation_job_ids(

--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -22,6 +22,7 @@ from iris.cluster.constraints import (
     AttributeValue,
     Constraint,
     ConstraintOp,
+    DeviceType,
     PlacementRequirements,
     constraints_from_resources,
     evaluate_constraint,
@@ -141,14 +142,24 @@ def reservation_unsatisfied(
     task: PendingTask,
     claims_by_job: dict[str, int],
     reservation_entry_counts: dict[JobName, int],
+    colocating_reservation_job_ids: AbstractSet[JobName],
 ) -> bool:
     """Whether a real task must wait for its job's reservation to be claimed.
 
-    A non-holder task of a directly-reserved job is *unsatisfied* until the
-    number of workers claimed for its reservation reaches the reservation's
-    entry count. Such a task must neither be scheduled nor generate autoscaler
-    demand: the reservation's holder task provisions the reserved capacity, and
-    the real task runs only once that capacity exists.
+    A non-holder task of a *co-locating* directly-reserved job is *unsatisfied*
+    until the number of workers claimed for its reservation reaches the
+    reservation's entry count. Such a task must neither be scheduled nor
+    generate autoscaler demand: the reservation's holder task provisions the
+    reserved capacity, and the real task runs only once that capacity exists.
+
+    A directly-reserved job that does *not* co-locate (its own task targets a
+    different device class than the reservation — e.g. a CPU orchestrator that
+    reserves a TPU) is never gated here: it does not run on the reserved
+    workers, so it schedules on its own resources independent of the
+    reservation. Gating it would strand it whenever the reservation cannot be
+    claimed (device stockout), and EQ-pinning it (see
+    :func:`inject_taint_constraints`) would route phantom CPU demand the
+    scheduler can never satisfy (the 2026-06-08 canary thrash).
 
     Both the scheduling gate (:func:`apply_scheduling_gates`) and the demand
     path (:func:`compute_demand_entries`) consult this predicate so they agree.
@@ -157,6 +168,8 @@ def reservation_unsatisfied(
     thrashes, booting workers that are reaped as idle every cycle.
     """
     if task.is_reservation_holder or not task.has_reservation:
+        return False
+    if task.job_id not in colocating_reservation_job_ids:
         return False
     required = reservation_entry_counts.get(task.job_id, 0)
     return claims_by_job.get(task.job_id.to_wire(), 0) < required
@@ -168,6 +181,43 @@ def _claims_by_job(claims: dict[WorkerId, ReservationClaim] | None) -> dict[str,
     for claim in (claims or {}).values():
         counts[claim.job_id] += 1
     return counts
+
+
+def _own_device_type(res_device_json: str | None) -> DeviceType:
+    """Device class a task's *own* resource request targets (CPU when no accelerator)."""
+    dc = device_counts_from_json(res_device_json)
+    if dc.gpu > 0:
+        return DeviceType.GPU
+    if dc.tpu > 0:
+        return DeviceType.TPU
+    return DeviceType.CPU
+
+
+def _colocating_reservation_job_ids(
+    pending: list[PendingTask],
+    entry_device_types: dict[JobName, frozenset[DeviceType]],
+) -> frozenset[JobName]:
+    """Directly-reserved jobs whose own task co-locates on their reserved workers.
+
+    A ``--reserve`` job co-locates only when its own resource request targets the
+    same device class the reservation reserves (e.g. ``--reserve v5p-8`` with a
+    v5p-8 task). A reservation whose own task is CPU-only while it reserves an
+    accelerator (the common orchestrator/``dev_tpu`` pattern) does NOT co-locate:
+    the reserved workers exist for its holder and descendants, and the parent
+    task itself schedules on a worker matching its own request. Only co-locating
+    jobs are EQ-pinned to and gated on their claimed workers; see
+    :func:`inject_taint_constraints` and :func:`reservation_unsatisfied`.
+    """
+    result: set[JobName] = set()
+    for task in pending:
+        if not task.has_reservation:
+            continue
+        entries = entry_device_types.get(task.job_id)
+        if not entries:
+            continue
+        if _own_device_type(task.res_device_json) in entries:
+            result.add(task.job_id)
+    return frozenset(result)
 
 
 def compute_demand_entries(
@@ -248,11 +298,12 @@ def compute_demand_entries(
     jobs: dict[JobName, JobRequirements] = {}
     has_reservation: set[JobName] = set()
     has_direct_reservation: set[JobName] = set()
+    colocating = ctx.colocating_reservation_job_ids
     for task in pending:
         if task.job_id in jobs:
             continue
         jobs[task.job_id] = job_requirements_from_job(task)
-        if task.has_reservation:
+        if task.has_reservation and task.job_id in colocating:
             has_reservation.add(task.job_id)
             has_direct_reservation.add(task.job_id)
         elif _find_reservation_ancestor(reserved_jobs, task.job_id) is not None:
@@ -303,7 +354,7 @@ def compute_demand_entries(
         # capacity; emitting demand for the real task here would provision
         # generic capacity the scheduler gate will never let it occupy, so the
         # autoscaler would boot workers that idle out and get reaped forever.
-        if reservation_unsatisfied(job_row, claims_by_job, reservation_entry_counts):
+        if reservation_unsatisfied(job_row, claims_by_job, reservation_entry_counts, ctx.colocating_reservation_job_ids):
             continue
 
         job_constraints = constraints_from_json(job_row.constraints_json)
@@ -952,12 +1003,15 @@ def build_scheduling_context(
         user_budget_limits = reads.get_all_user_budget_limits(snap)
         requested_bands = reads.get_priority_bands(snap, {t.job_id for t in pending})
         reserved_jobs = reads.reserved_job_ids(snap)
-        reservation_entry_counts = reads.reservation_entry_counts(snap, {t.job_id for t in pending if t.has_reservation})
+        reserved_pending_ids = {t.job_id for t in pending if t.has_reservation}
+        reservation_entry_counts = reads.reservation_entry_counts(snap, reserved_pending_ids)
+        entry_device_types = reads.reservation_entry_device_types(snap, reserved_pending_ids)
         building_counts = reads.building_counts(snap, [w.worker_id for w in workers])
         running = _running_tasks_with_band_and_value(snap, set(claims.keys()))
 
     snapshots = [worker_snapshot_from_row(w, usage_by_worker.get(w.worker_id)) for w in workers]
     sorted_pending = _sort_pending_tasks_by_resolved_band(pending, requested_bands)
+    colocating_reservations = _colocating_reservation_job_ids(pending, entry_device_types)
     return SchedulingContext(
         workers=snapshots,
         building_counts=building_counts,
@@ -973,6 +1027,7 @@ def build_scheduling_context(
         reservation_entry_counts=reservation_entry_counts,
         user_budget_defaults=defaults,
         running_for_preemption=running,
+        colocating_reservation_job_ids=colocating_reservations,
     )
 
 
@@ -1010,7 +1065,9 @@ def apply_scheduling_gates(
             continue
         # Gate: skip real tasks whose job has an unsatisfied reservation.
         # Holder tasks are always schedulable (they ARE the reservation).
-        if reservation_unsatisfied(task, claims_by_job, ctx.reservation_entry_counts):
+        if reservation_unsatisfied(
+            task, claims_by_job, ctx.reservation_entry_counts, ctx.colocating_reservation_job_ids
+        ):
             filter_counts["reservation_unsatisfied"] += 1
             continue
         if (
@@ -1024,7 +1081,7 @@ def apply_scheduling_gates(
         schedulable_task_ids.append(task.task_id)
         if task.job_id not in jobs:
             jobs[task.job_id] = job_requirements_from_job(task)
-            if task.has_reservation:
+            if task.has_reservation and task.job_id in ctx.colocating_reservation_job_ids:
                 has_reservation.add(task.job_id)
                 has_direct_reservation.add(task.job_id)
             elif _find_reservation_ancestor(ctx.reserved_job_ids, task.job_id) is not None:

--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -152,8 +152,7 @@ def reservation_unsatisfied(
     demand: the reservation's holder task provisions the reserved capacity, and
     the real task runs only once that capacity exists. Waiting for the claim also
     fixes the reservation's zone before the task is placed or routed, so the
-    autoscaler never boots capacity in the wrong zone (see
-    :func:`inject_taint_constraints` for the zone pin then applied to the parent).
+    autoscaler never boots capacity in the wrong zone.
 
     Both the scheduling gate (:func:`apply_scheduling_gates`) and the demand
     path (:func:`compute_demand_entries`) consult this predicate so they agree.
@@ -181,10 +180,9 @@ def reservation_zones_from_claims(
 ) -> dict[JobName, frozenset[str]]:
     """Zones in which each reserving job's workers were claimed, keyed by job.
 
-    A directly-reserved job is pinned to these zones (see
-    :func:`inject_taint_constraints`) so it runs beside its reservation. A job is
-    absent until at least one of its entries is claimed on a zone-reporting
-    worker.
+    A directly-reserved job is constrained to these zones so it runs beside its
+    reservation. A job is absent until at least one of its entries is claimed on
+    a zone-reporting worker.
     """
     zones_by_wire: dict[str, set[str]] = defaultdict(set)
     attrs_by_worker = {w.worker_id: w.attributes for w in workers}

--- a/lib/iris/src/iris/cluster/controller/scheduling/scheduler.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/scheduler.py
@@ -370,6 +370,13 @@ class SchedulingContext:
     reservation_entry_counts: dict[JobName, int]
     user_budget_defaults: UserBudgetDefaults
     running_for_preemption: list[RunningTaskInfo] = field(default_factory=list)
+    # Directly-reserved jobs whose own task co-locates on their reservation's
+    # claimed workers — i.e. the job's own resource request targets the same
+    # device class the reservation reserves. Only these are EQ-pinned to (and
+    # gated on) their claimed workers; a reservation whose own task is CPU-only
+    # while it reserves an accelerator is NOT here and schedules like a normal
+    # job. Empty when there are no reservations.
+    colocating_reservation_job_ids: frozenset[JobName] = field(default_factory=frozenset)
 
     # Derived from ``workers`` in __post_init__.
     capacities: dict[WorkerId, WorkerCapacity] = field(init=False)
@@ -433,6 +440,7 @@ class SchedulingContext:
             reservation_entry_counts=self.reservation_entry_counts,
             user_budget_defaults=self.user_budget_defaults,
             running_for_preemption=self.running_for_preemption,
+            colocating_reservation_job_ids=self.colocating_reservation_job_ids,
         )
 
     def matching_workers(self, constraints: Sequence[Constraint]) -> set[WorkerId]:

--- a/lib/iris/src/iris/cluster/controller/scheduling/scheduler.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/scheduler.py
@@ -370,13 +370,10 @@ class SchedulingContext:
     reservation_entry_counts: dict[JobName, int]
     user_budget_defaults: UserBudgetDefaults
     running_for_preemption: list[RunningTaskInfo] = field(default_factory=list)
-    # Directly-reserved jobs whose own task co-locates on their reservation's
-    # claimed workers — i.e. the job's own resource request targets the same
-    # device class the reservation reserves. Only these are EQ-pinned to (and
-    # gated on) their claimed workers; a reservation whose own task is CPU-only
-    # while it reserves an accelerator is NOT here and schedules like a normal
-    # job. Empty when there are no reservations.
-    colocating_reservation_job_ids: frozenset[JobName] = field(default_factory=frozenset)
+    # Zones in which each directly-reserved job's workers were claimed, keyed by
+    # job. A reservation pins its parent (and routes its demand) to these zones;
+    # the parent never pins to a specific worker. Empty for a job until claimed.
+    reservation_zones_by_job: dict[JobName, frozenset[str]] = field(default_factory=dict)
 
     # Derived from ``workers`` in __post_init__.
     capacities: dict[WorkerId, WorkerCapacity] = field(init=False)
@@ -440,7 +437,7 @@ class SchedulingContext:
             reservation_entry_counts=self.reservation_entry_counts,
             user_budget_defaults=self.user_budget_defaults,
             running_for_preemption=self.running_for_preemption,
-            colocating_reservation_job_ids=self.colocating_reservation_job_ids,
+            reservation_zones_by_job=self.reservation_zones_by_job,
         )
 
     def matching_workers(self, constraints: Sequence[Constraint]) -> set[WorkerId]:

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -203,11 +203,12 @@ def _entrypoint() -> job_pb2.RuntimeEntrypoint:
 def _make_job_request_with_reservation(
     name: str = "res-job",
     reservation_entries: list[job_pb2.ReservationEntry] | None = None,
+    resources: job_pb2.ResourceSpecProto | None = None,
 ) -> controller_pb2.Controller.LaunchJobRequest:
     req = controller_pb2.Controller.LaunchJobRequest(
         name=name,
         entrypoint=_entrypoint(),
-        resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
+        resources=resources or job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
         environment=job_pb2.EnvironmentConfig(),
         replicas=1,
     )
@@ -689,23 +690,25 @@ def _real_demand(demand):
     return [d for d in demand if not any(RESERVATION_HOLDER_JOB_NAME in t for t in d.task_ids)]
 
 
-def test_demand_gates_real_task_until_reservation_claimed(ctrl):
-    """A reserved job's real task must not emit demand until its reservation is claimed.
+def test_demand_gates_colocating_real_task_until_reservation_claimed(ctrl):
+    """A *co-locating* reserved job's real task must not emit demand until claimed.
 
-    Regression for the europe-west4-a autoscaler thrash: an ``iris run`` job's
-    parent task is a tiny CPU driver that holds a GPU/TPU reservation. While the
-    reservation is unclaimed the scheduler gate (``apply_scheduling_gates``)
-    blocks the parent task, but ``compute_demand_entries`` used to emit CPU
-    demand for it anyway. The autoscaler then booted CPU workers the scheduler
-    would never let the task occupy; they idled out and were reaped every cycle,
-    forever. The demand path must apply the same reservation gate: only the
-    holder task generates demand (to provision the reserved capacity) until the
-    reservation is satisfied.
+    Regression for the europe-west4-a autoscaler thrash, restricted to the case
+    the gate is actually for: a job whose own task runs *on* the reserved worker
+    (here a GPU parent reserving a GPU). While the reservation is unclaimed the
+    scheduler gate (``apply_scheduling_gates``) blocks the parent task; the
+    demand path (``compute_demand_entries``) must apply the same gate so it does
+    not emit demand the scheduler would reject. Only the holder generates demand
+    (to provision the reserved capacity) until the reservation is satisfied.
     """
-    # Parent task is a CPU driver; the reservation is for a GPU no CPU worker can
-    # satisfy, so it stays unclaimed even though a CPU worker is available.
-    _register_worker(ctrl, "cpu1", _cpu_metadata())
-    req = _make_job_request_with_reservation(reservation_entries=[_make_reservation_entry(_gpu_device("H100"))])
+    # Parent's own task requests the same device the reservation reserves (GPU),
+    # so it co-locates on the reserved worker. No GPU worker exists yet, so the
+    # reservation stays unclaimed.
+    gpu_resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3, device=_gpu_device("H100"))
+    req = _make_job_request_with_reservation(
+        reservation_entries=[_make_reservation_entry(_gpu_device("H100"))],
+        resources=gpu_resources,
+    )
     jid = _submit_job(ctrl, "j1", req)
 
     _claim_for_reservations(ctrl)
@@ -715,7 +718,7 @@ def test_demand_gates_real_task_until_reservation_claimed(ctrl):
     demand = _demand_no_dry_run(ctrl, claims)
     # Holder provisions the reserved GPU; the parent's real task is gated.
     assert len(_holder_demand(demand)) == 1
-    assert _real_demand(demand) == [], "real task must not emit demand while reservation is unclaimed"
+    assert _real_demand(demand) == [], "co-locating real task must not emit demand while reservation is unclaimed"
 
     # Once a matching worker is claimed, the gate opens and the real task may
     # emit demand again.
@@ -727,6 +730,111 @@ def test_demand_gates_real_task_until_reservation_claimed(ctrl):
     demand = _demand_no_dry_run(ctrl, claims)
     real_ids = {t for d in _real_demand(demand) for t in d.task_ids}
     assert jid.task(0).to_wire() in real_ids
+
+
+def test_device_mismatched_reservation_parent_not_gated(ctrl):
+    """A reservation whose own task targets a different device is NOT gated.
+
+    Regression for the 2026-06-08 canary thrash (and the ``/power`` v5p reserve
+    job that motivated this fix): ``iris run --reserve <tpu> --cpu N`` makes the
+    *parent* a CPU orchestrator that reserves a TPU it never runs on. The parent
+    must not wait on (or be EQ-pinned to) the reserved TPU workers — its own CPU
+    task schedules independently. So its real task emits CPU demand even while
+    the TPU reservation is unclaimed; only the holder provisions the TPU.
+
+    Before the fix the parent was treated as a co-locating reservation: the
+    demand path gated it (no CPU demand) while the scheduler EQ-pinned it to the
+    TPU-only claim, so it could never run, and (once claimed on a preemptible
+    worker the non-preemptible parent could not use) routed phantom CPU demand
+    that booted CPU VMs which idled out and were reaped every cycle.
+    """
+    tpu_device = job_pb2.DeviceConfig(tpu=job_pb2.TpuDevice(variant="v5p-8", count=4))
+    req = _make_job_request_with_reservation(reservation_entries=[_make_reservation_entry(tpu_device)])
+    jid = _submit_job(ctrl, "j1", req)
+
+    _claim_for_reservations(ctrl)
+    claims = read_reservation_claims(ctrl._db)
+    assert claims == {}  # no TPU worker, reservation unfulfilled
+
+    demand = _demand_no_dry_run(ctrl, claims)
+    # Holder provisions the reserved TPU; the CPU parent emits its own real demand.
+    assert len(_holder_demand(demand)) == 1
+    real_ids = {t for d in _real_demand(demand) for t in d.task_ids}
+    assert jid.task(0).to_wire() in real_ids, "device-mismatched parent must emit its own (CPU) demand"
+
+
+def test_device_mismatched_reservation_parent_schedules_on_cpu_worker(ctrl):
+    """The CPU parent of a TPU reservation schedules on a plain CPU worker.
+
+    The end-to-end anti-thrash property: rather than suppressing demand (which
+    left the parent stranded forever), the device-mismatched parent is placed on
+    a CPU worker matching its own request — so the CPU capacity the autoscaler
+    boots for it is actually used, not reaped. The parent must NOT be EQ-pinned
+    to the reservation's claimed workers and must NOT squat on them either.
+    """
+    # A plain CPU worker for the parent, plus a TPU worker the reservation claims.
+    _register_worker(ctrl, "cpu1", _cpu_metadata())
+    tpu_meta = job_pb2.WorkerMetadata(
+        hostname="tpu",
+        ip_address="127.0.0.1",
+        cpu_count=200,
+        memory_bytes=512 * 1024**3,
+        disk_bytes=1000 * 1024**3,
+        tpu_name="tpu-host",
+    )
+    tpu_meta.attributes[WellKnownAttribute.DEVICE_TYPE].CopyFrom(job_pb2.AttributeValue(string_value="tpu"))
+    tpu_meta.attributes[WellKnownAttribute.DEVICE_VARIANT].CopyFrom(job_pb2.AttributeValue(string_value="v5p-8"))
+    _register_worker(ctrl, "tpu1", tpu_meta)
+
+    tpu_device = job_pb2.DeviceConfig(tpu=job_pb2.TpuDevice(variant="v5p-8", count=4))
+    tpu_entry = job_pb2.ReservationEntry(
+        resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3, device=tpu_device),
+        constraints=[device_variant_constraint(["v5p-8"]).to_proto()],
+    )
+    req = _make_job_request_with_reservation(reservation_entries=[tpu_entry])
+    jid = _submit_job(ctrl, "j1", req)
+
+    _claim_for_reservations(ctrl)
+    claims = read_reservation_claims(ctrl._db)
+    # The TPU worker is claimed for the reservation; the CPU worker is free.
+    assert WorkerId("tpu1") in claims
+
+    scheduler = Scheduler()
+    with ctrl._db.read_snapshot() as snap:
+        ctx = build_scheduling_context(
+            snap,
+            ctrl._health,
+            ctrl._worker_attrs,
+            ctrl._config.user_budget_defaults,
+            claims,
+            max_building_tasks=scheduler.max_building_tasks_per_worker,
+        )
+    # The parent is device-mismatched, so it is not a co-locating reservation.
+    assert jid not in ctx.colocating_reservation_job_ids
+
+    gated = apply_scheduling_gates(ctx, claims, max_tasks_per_job_per_cycle=0)
+    assert jid.task(0) in gated.schedulable_task_ids, "CPU parent must pass the gate without a claim for itself"
+
+    order = compute_scheduling_order(ctx, gated)
+    jobs = inject_taint_constraints(gated.jobs, gated.has_reservation, gated.has_direct_reservation)
+    # The parent gets the NOT_EXISTS taint of a normal job (keeps it off the
+    # reserved TPU worker), never the EQ pin that stranded it.
+    parent_taint = [c for c in jobs[jid].constraints if c.key == RESERVATION_TAINT_KEY]
+    assert len(parent_taint) == 1
+    assert parent_taint[0].op == ConstraintOp.NOT_EXISTS
+
+    ctx.pending_tasks = list(order.ordered_task_ids)
+    building_counts = {wid: cap.building_task_count for wid, cap in ctx.capacities.items()}
+    ctx = ctx.evolve_with_workers(
+        workers=inject_reservation_taints(list(ctx.workers), claims),
+        jobs=jobs,
+        building_counts=building_counts,
+        max_building_tasks=scheduler.max_building_tasks_per_worker,
+    )
+    preference = preference_pass(ctx, gated.has_reservation, claims)
+    assignments = dict(preference + scheduler.find_assignments(ctx).assignments)
+    # The CPU parent lands on the plain CPU worker, not the reserved TPU worker.
+    assert assignments.get(jid.task(0)) == WorkerId("cpu1")
 
 
 # =============================================================================

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -124,6 +124,33 @@ def _cpu_metadata() -> job_pb2.WorkerMetadata:
     return meta
 
 
+def _cpu_metadata_in_zone(zone: str, *, preemptible: bool = False) -> job_pb2.WorkerMetadata:
+    meta = _cpu_metadata()
+    meta.attributes[WellKnownAttribute.ZONE].CopyFrom(job_pb2.AttributeValue(string_value=zone))
+    meta.attributes[WellKnownAttribute.PREEMPTIBLE].CopyFrom(
+        job_pb2.AttributeValue(string_value=str(preemptible).lower())
+    )
+    return meta
+
+
+def _tpu_metadata_in_zone(variant: str, zone: str, *, preemptible: bool = True) -> job_pb2.WorkerMetadata:
+    meta = job_pb2.WorkerMetadata(
+        hostname="tpu",
+        ip_address="127.0.0.1",
+        cpu_count=200,
+        memory_bytes=512 * 1024**3,
+        disk_bytes=1000 * 1024**3,
+        tpu_name="tpu-host",
+    )
+    meta.attributes[WellKnownAttribute.DEVICE_TYPE].CopyFrom(job_pb2.AttributeValue(string_value="tpu"))
+    meta.attributes[WellKnownAttribute.DEVICE_VARIANT].CopyFrom(job_pb2.AttributeValue(string_value=variant))
+    meta.attributes[WellKnownAttribute.ZONE].CopyFrom(job_pb2.AttributeValue(string_value=zone))
+    meta.attributes[WellKnownAttribute.PREEMPTIBLE].CopyFrom(
+        job_pb2.AttributeValue(string_value=str(preemptible).lower())
+    )
+    return meta
+
+
 def _gpu_metadata(variant: str = "H100") -> job_pb2.WorkerMetadata:
     meta = job_pb2.WorkerMetadata(
         hostname="test-gpu",
@@ -690,20 +717,18 @@ def _real_demand(demand):
     return [d for d in demand if not any(RESERVATION_HOLDER_JOB_NAME in t for t in d.task_ids)]
 
 
-def test_demand_gates_colocating_real_task_until_reservation_claimed(ctrl):
-    """A *co-locating* reserved job's real task must not emit demand until claimed.
+def test_demand_gates_reserved_parent_until_reservation_claimed(ctrl):
+    """A reserved job's parent must not emit demand until its reservation is claimed.
 
-    Regression for the europe-west4-a autoscaler thrash, restricted to the case
-    the gate is actually for: a job whose own task runs *on* the reserved worker
-    (here a GPU parent reserving a GPU). While the reservation is unclaimed the
-    scheduler gate (``apply_scheduling_gates``) blocks the parent task; the
-    demand path (``compute_demand_entries``) must apply the same gate so it does
-    not emit demand the scheduler would reject. Only the holder generates demand
-    (to provision the reserved capacity) until the reservation is satisfied.
+    Regression for the europe-west4-a autoscaler thrash. While the reservation is
+    unclaimed the scheduler gate (``apply_scheduling_gates``) blocks the parent
+    task; the demand path (``compute_demand_entries``) must apply the same gate so
+    it does not emit demand the scheduler would reject. Only the holder generates
+    demand (to provision the reserved capacity) until the reservation is
+    satisfied. Gating the parent until the claim also fixes its zone before any of
+    its demand is routed.
     """
-    # Parent's own task requests the same device the reservation reserves (GPU),
-    # so it co-locates on the reserved worker. No GPU worker exists yet, so the
-    # reservation stays unclaimed.
+    # No GPU worker exists yet, so the reservation stays unclaimed.
     gpu_resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3, device=_gpu_device("H100"))
     req = _make_job_request_with_reservation(
         reservation_entries=[_make_reservation_entry(_gpu_device("H100"))],
@@ -732,59 +757,17 @@ def test_demand_gates_colocating_real_task_until_reservation_claimed(ctrl):
     assert jid.task(0).to_wire() in real_ids
 
 
-def test_device_mismatched_reservation_parent_not_gated(ctrl):
-    """A reservation whose own task targets a different device is NOT gated.
+def test_reservation_parent_gated_then_routes_demand_to_reserved_zone(ctrl):
+    """A CPU parent reserving a TPU is gated until claimed, then routes demand to the reserved zone.
 
-    ``iris run --reserve <tpu> --cpu N`` makes the *parent* a CPU orchestrator
-    that reserves a TPU it never runs on. The parent must not wait on (or be
-    EQ-pinned to) the reserved TPU workers — its own CPU task schedules
-    independently. So its real task emits CPU demand even while the TPU
-    reservation is unclaimed; only the holder provisions the TPU.
-
-    When the parent was instead treated as a co-locating reservation, the demand
-    path gated it (no CPU demand) while the scheduler EQ-pinned it to the
-    TPU-only claim, so it could never run, and — once claimed on a preemptible
-    worker the non-preemptible parent could not use — routed phantom CPU demand
-    that booted CPU VMs which idled out and were reaped every cycle.
+    ``iris run --reserve <tpu> --cpu N`` makes the parent a CPU orchestrator that
+    reserves a TPU it never runs on. While the reservation is unclaimed the parent
+    emits no demand (the holder provisions the TPU). Once the TPU is claimed in a
+    zone, the parent's own CPU demand carries that zone, so the autoscaler routes
+    it to CPU capacity in the reserved zone instead of booting CPU VMs in an
+    arbitrary zone that idle out and get reaped (the europe-west4-a /
+    us-central2-b thrash).
     """
-    tpu_device = job_pb2.DeviceConfig(tpu=job_pb2.TpuDevice(variant="v5p-8", count=4))
-    req = _make_job_request_with_reservation(reservation_entries=[_make_reservation_entry(tpu_device)])
-    jid = _submit_job(ctrl, "j1", req)
-
-    _claim_for_reservations(ctrl)
-    claims = read_reservation_claims(ctrl._db)
-    assert claims == {}  # no TPU worker, reservation unfulfilled
-
-    demand = _demand_no_dry_run(ctrl, claims)
-    # Holder provisions the reserved TPU; the CPU parent emits its own real demand.
-    assert len(_holder_demand(demand)) == 1
-    real_ids = {t for d in _real_demand(demand) for t in d.task_ids}
-    assert jid.task(0).to_wire() in real_ids, "device-mismatched parent must emit its own (CPU) demand"
-
-
-def test_device_mismatched_reservation_parent_schedules_on_cpu_worker(ctrl):
-    """The CPU parent of a TPU reservation schedules on a plain CPU worker.
-
-    The end-to-end anti-thrash property: rather than suppressing demand (which
-    left the parent stranded forever), the device-mismatched parent is placed on
-    a CPU worker matching its own request — so the CPU capacity the autoscaler
-    boots for it is actually used, not reaped. The parent must NOT be EQ-pinned
-    to the reservation's claimed workers and must NOT squat on them either.
-    """
-    # A plain CPU worker for the parent, plus a TPU worker the reservation claims.
-    _register_worker(ctrl, "cpu1", _cpu_metadata())
-    tpu_meta = job_pb2.WorkerMetadata(
-        hostname="tpu",
-        ip_address="127.0.0.1",
-        cpu_count=200,
-        memory_bytes=512 * 1024**3,
-        disk_bytes=1000 * 1024**3,
-        tpu_name="tpu-host",
-    )
-    tpu_meta.attributes[WellKnownAttribute.DEVICE_TYPE].CopyFrom(job_pb2.AttributeValue(string_value="tpu"))
-    tpu_meta.attributes[WellKnownAttribute.DEVICE_VARIANT].CopyFrom(job_pb2.AttributeValue(string_value="v5p-8"))
-    _register_worker(ctrl, "tpu1", tpu_meta)
-
     tpu_device = job_pb2.DeviceConfig(tpu=job_pb2.TpuDevice(variant="v5p-8", count=4))
     tpu_entry = job_pb2.ReservationEntry(
         resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3, device=tpu_device),
@@ -793,9 +776,56 @@ def test_device_mismatched_reservation_parent_schedules_on_cpu_worker(ctrl):
     req = _make_job_request_with_reservation(reservation_entries=[tpu_entry])
     jid = _submit_job(ctrl, "j1", req)
 
+    # Unclaimed (no TPU worker yet): the CPU parent is gated; only the holder demands.
     _claim_for_reservations(ctrl)
     claims = read_reservation_claims(ctrl._db)
-    # The TPU worker is claimed for the reservation; the CPU worker is free.
+    assert claims == {}
+    demand = _demand_no_dry_run(ctrl, claims)
+    assert len(_holder_demand(demand)) == 1
+    assert _real_demand(demand) == [], "parent is gated until its reservation is claimed"
+
+    # Claim a TPU worker in us-east5-a; the parent ungates and routes CPU demand there.
+    _register_worker(ctrl, "tpu1", _tpu_metadata_in_zone("v5p-8", "us-east5-a"))
+    _claim_for_reservations(ctrl)
+    claims = read_reservation_claims(ctrl._db)
+    assert WorkerId("tpu1") in claims
+
+    demand = _demand_no_dry_run(ctrl, claims)
+    parent_demand = [d for d in _real_demand(demand) if jid.task(0).to_wire() in d.task_ids]
+    assert len(parent_demand) == 1
+    zone_values = [c.values[0].value for c in parent_demand[0].constraints if c.key == WellKnownAttribute.ZONE]
+    assert zone_values == ["us-east5-a"], "parent demand must carry the reservation's claimed zone"
+
+
+def test_reservation_parent_schedules_in_reserved_zone(ctrl):
+    """The CPU parent of a TPU reservation schedules on in-zone CPU, never worker-pinned.
+
+    End-to-end regression for the stuck ``--reserve`` job: the parent is
+    zone-pinned to the zone where its TPU was claimed, then the scheduler places
+    it on plain CPU capacity in that zone — so the CPU the autoscaler boots is
+    actually used, not reaped. Reproduces the real condition: the reserved v5p is
+    preemptible and the parent is non-preemptible, so the parent cannot run on the
+    reserved worker and must land on in-zone on-demand CPU (it is never pinned to
+    the exact reserved worker, and never sent to an out-of-zone worker).
+    """
+    # On-demand CPU in the reserved zone (the target), on-demand CPU elsewhere
+    # (must be excluded by the zone pin), and the preemptible TPU the reservation
+    # claims.
+    _register_worker(ctrl, "cpu-in", _cpu_metadata_in_zone("us-east5-a"))
+    _register_worker(ctrl, "cpu-out", _cpu_metadata_in_zone("us-central2-b"))
+    _register_worker(ctrl, "tpu1", _tpu_metadata_in_zone("v5p-8", "us-east5-a", preemptible=True))
+
+    tpu_device = job_pb2.DeviceConfig(tpu=job_pb2.TpuDevice(variant="v5p-8", count=4))
+    tpu_entry = job_pb2.ReservationEntry(
+        resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3, device=tpu_device),
+        constraints=[device_variant_constraint(["v5p-8"]).to_proto()],
+    )
+    req = _make_job_request_with_reservation(reservation_entries=[tpu_entry])
+    req.constraints.append(preemptible_constraint(False).to_proto())
+    jid = _submit_job(ctrl, "j1", req)
+
+    _claim_for_reservations(ctrl)
+    claims = read_reservation_claims(ctrl._db)
     assert WorkerId("tpu1") in claims
 
     scheduler = Scheduler()
@@ -808,19 +838,20 @@ def test_device_mismatched_reservation_parent_schedules_on_cpu_worker(ctrl):
             claims,
             max_building_tasks=scheduler.max_building_tasks_per_worker,
         )
-    # The parent is device-mismatched, so it is not a co-locating reservation.
-    assert jid not in ctx.colocating_reservation_job_ids
+    # The reservation maps the parent to the zone where its TPU was claimed.
+    assert ctx.reservation_zones_by_job.get(jid) == frozenset({"us-east5-a"})
 
     gated = apply_scheduling_gates(ctx, claims, max_tasks_per_job_per_cycle=0)
-    assert jid.task(0) in gated.schedulable_task_ids, "CPU parent must pass the gate without a claim for itself"
+    assert jid.task(0) in gated.schedulable_task_ids, "parent must pass the gate once its reservation is claimed"
 
     order = compute_scheduling_order(ctx, gated)
-    jobs = inject_taint_constraints(gated.jobs, gated.has_reservation, gated.has_direct_reservation)
-    # The parent gets the NOT_EXISTS taint of a normal job (keeps it off the
-    # reserved TPU worker), never the EQ pin that stranded it.
-    parent_taint = [c for c in jobs[jid].constraints if c.key == RESERVATION_TAINT_KEY]
-    assert len(parent_taint) == 1
-    assert parent_taint[0].op == ConstraintOp.NOT_EXISTS
+    jobs = inject_taint_constraints(
+        gated.jobs, gated.has_reservation, gated.has_direct_reservation, ctx.reservation_zones_by_job
+    )
+    # Zone-pinned to the reserved zone, never worker-pinned (no reservation taint).
+    parent_zone = [c for c in jobs[jid].constraints if c.key == WellKnownAttribute.ZONE]
+    assert [c.values[0].value for c in parent_zone] == ["us-east5-a"]
+    assert [c for c in jobs[jid].constraints if c.key == RESERVATION_TAINT_KEY] == []
 
     ctx.pending_tasks = list(order.ordered_task_ids)
     building_counts = {wid: cap.building_task_count for wid, cap in ctx.capacities.items()}
@@ -832,8 +863,9 @@ def test_device_mismatched_reservation_parent_schedules_on_cpu_worker(ctrl):
     )
     preference = preference_pass(ctx, gated.has_reservation, claims)
     assignments = dict(preference + scheduler.find_assignments(ctx).assignments)
-    # The CPU parent lands on the plain CPU worker, not the reserved TPU worker.
-    assert assignments.get(jid.task(0)) == WorkerId("cpu1")
+    # Non-preemptible parent can't use the preemptible reserved TPU, so it lands on
+    # the in-zone on-demand CPU worker — not the out-of-zone one, not stranded.
+    assert assignments.get(jid.task(0)) == WorkerId("cpu-in")
 
 
 # =============================================================================
@@ -945,26 +977,54 @@ def test_taint_constraint_added_to_non_reservation_jobs():
     assert not_exists[0].op == ConstraintOp.NOT_EXISTS
 
 
-def test_taint_constraint_not_added_to_reservation_jobs():
-    """Direct reservation jobs get an EQ constraint forcing them onto claimed workers."""
+def test_reservation_parent_zone_pinned_not_worker_pinned():
+    """A directly-reserved parent is pinned to its reservation's claimed zone."""
     res_job = JobName.root("test-user", "reserved")
     jobs = {
         res_job: _make_job_requirements(),
     }
     has_reservation = {res_job}
     has_direct_reservation = {res_job}
+    zones = {res_job: frozenset({"us-east5-a"})}
 
-    result = inject_taint_constraints(jobs, has_reservation, has_direct_reservation)
+    result = inject_taint_constraints(jobs, has_reservation, has_direct_reservation, zones)
 
     constraints = result[res_job].constraints
-    eq = [c for c in constraints if c.key == RESERVATION_TAINT_KEY]
-    assert len(eq) == 1
-    assert eq[0].op == ConstraintOp.EQ
-    assert eq[0].values[0].value == res_job.to_wire()
+    zone = [c for c in constraints if c.key == WellKnownAttribute.ZONE]
+    assert len(zone) == 1
+    assert zone[0].op == ConstraintOp.EQ
+    assert zone[0].values[0].value == "us-east5-a"
+    # Zone-pinned, never worker-pinned: no reservation taint on the parent.
+    assert [c for c in constraints if c.key == RESERVATION_TAINT_KEY] == []
+
+
+def test_reservation_parent_zone_pin_spans_claimed_zones():
+    """A reservation claimed across two zones pins its parent to both (an IN set)."""
+    res_job = JobName.root("test-user", "reserved")
+    jobs = {res_job: _make_job_requirements()}
+    zones = {res_job: frozenset({"us-east5-a", "us-central1-a"})}
+
+    result = inject_taint_constraints(jobs, {res_job}, {res_job}, zones)
+
+    zone = [c for c in result[res_job].constraints if c.key == WellKnownAttribute.ZONE]
+    assert len(zone) == 1
+    assert zone[0].op == ConstraintOp.IN
+    assert {v.value for v in zone[0].values} == {"us-east5-a", "us-central1-a"}
+
+
+def test_reservation_parent_no_constraint_until_claimed():
+    """An unclaimed reservation parent gets no zone constraint (its zone is unknown)."""
+    res_job = JobName.root("test-user", "reserved")
+    jobs = {res_job: _make_job_requirements()}
+
+    result = inject_taint_constraints(jobs, {res_job}, {res_job}, reservation_zones_by_job={})
+
+    # No claimed zone yet: no zone pin, and no taint (the parent may use claimed workers).
+    assert result[res_job].constraints == []
 
 
 def test_taint_constraint_mixed_jobs():
-    """Direct reservation gets EQ, descendant gets nothing, regular gets NOT_EXISTS."""
+    """Direct reservation gets a zone pin, descendant gets nothing, regular gets NOT_EXISTS."""
     res_job = JobName.root("test-user", "reserved")
     descendant_job = JobName.from_string("/test-user/reserved/child")
     reg_job = JobName.root("test-user", "regular")
@@ -975,18 +1035,19 @@ def test_taint_constraint_mixed_jobs():
     }
     has_reservation = {res_job, descendant_job}
     has_direct_reservation = {res_job}
+    zones = {res_job: frozenset({"us-east5-a"})}
 
-    result = inject_taint_constraints(jobs, has_reservation, has_direct_reservation)
+    result = inject_taint_constraints(jobs, has_reservation, has_direct_reservation, zones)
 
-    # Direct reservation job: EQ constraint
-    res_constraints = [c for c in result[res_job].constraints if c.key == RESERVATION_TAINT_KEY]
-    assert len(res_constraints) == 1
-    assert res_constraints[0].op == ConstraintOp.EQ
-    assert res_constraints[0].values[0].value == res_job.to_wire()
+    # Direct reservation parent: zone pin, no reservation taint.
+    res_zone = [c for c in result[res_job].constraints if c.key == WellKnownAttribute.ZONE]
+    assert len(res_zone) == 1
+    assert res_zone[0].values[0].value == "us-east5-a"
+    assert [c for c in result[res_job].constraints if c.key == RESERVATION_TAINT_KEY] == []
 
-    # Descendant: no taint constraint
-    desc_constraints = [c for c in result[descendant_job].constraints if c.key == RESERVATION_TAINT_KEY]
-    assert len(desc_constraints) == 0
+    # Descendant: allowed anywhere — no zone pin and no taint.
+    assert [c for c in result[descendant_job].constraints if c.key == WellKnownAttribute.ZONE] == []
+    assert [c for c in result[descendant_job].constraints if c.key == RESERVATION_TAINT_KEY] == []
 
     # Regular job: NOT_EXISTS constraint
     reg_constraints = [c for c in result[reg_job].constraints if c.key == RESERVATION_TAINT_KEY]
@@ -1232,17 +1293,24 @@ def test_preference_pass_respects_matching_hard_constraint():
     assert task_id not in context.pending_tasks
 
 
-def test_preference_pass_accepts_claimed_worker_carrying_its_reservation_taint():
-    """The constraint gate must not reject a claimed worker for its own EQ
-    reservation taint. In production preference_pass runs on the tainted req: a
-    direct-reservation job carries an EQ reservation-job==<job> constraint and
-    the claimed worker carries the matching reservation-job attribute, so the
-    gate must still admit it (otherwise direct reservations would never place)."""
+def test_preference_pass_accepts_claimed_worker_in_reservation_zone():
+    """The constraint gate must admit a claimed worker for a zone-pinned parent.
+
+    In production preference_pass runs on the zone-pinned req: a direct-reservation
+    parent carries a ``zone==<claimed zone>`` constraint and its claimed worker is
+    in that zone, so the gate must admit it (otherwise direct reservations would
+    never land on their claimed workers)."""
     job_id = JobName.root("test-user", "res-job")
     job_wire = job_id.to_wire()
     task_id = job_id.task(0)
-    w1 = _make_worker("w1", attributes={RESERVATION_TAINT_KEY: AttributeValue(job_wire)})
-    req = _req_with_constraints([Constraint.create(key=RESERVATION_TAINT_KEY, op=ConstraintOp.EQ, value=job_wire)])
+    w1 = _make_worker(
+        "w1",
+        attributes={
+            RESERVATION_TAINT_KEY: AttributeValue(job_wire),
+            WellKnownAttribute.ZONE: AttributeValue("us-east5-a"),
+        },
+    )
+    req = _req_with_constraints([Constraint.create(key=WellKnownAttribute.ZONE, op=ConstraintOp.EQ, value="us-east5-a")])
     has_reservation = {job_id}
     claims = {WorkerId("w1"): ReservationClaim(job_id=job_wire, entry_idx=0)}
 
@@ -1515,12 +1583,11 @@ def test_taint_exemption_for_children_of_reservation_job(ctrl):
     taint = [c for c in child_constraints if c.key == RESERVATION_TAINT_KEY]
     assert len(taint) == 0
 
-    # Parent (direct reservation) gets EQ constraint
+    # Parent (direct reservation) is zone-pinned, never worker-pinned: no taint.
     parent_jid = JobName.root("test-user", "res-parent")
     if parent_jid in modified_jobs:
         parent_constraints = [c for c in modified_jobs[parent_jid].constraints if c.key == RESERVATION_TAINT_KEY]
-        assert len(parent_constraints) == 1
-        assert parent_constraints[0].op == job_pb2.CONSTRAINT_OP_EQ
+        assert parent_constraints == []
 
 
 def test_grandchildren_inherit_reservation_from_ancestor(ctrl):
@@ -1647,12 +1714,11 @@ def test_grandchildren_inherit_reservation_from_ancestor(ctrl):
         taint = [c for c in gc_constraints if c.key == RESERVATION_TAINT_KEY]
         assert len(taint) == 0
 
-    # Direct reservation jobs get EQ constraint
+    # Direct reservation jobs are zone-pinned, never worker-pinned: no taint.
     for direct_jid in [child_a_jid, child_b_jid]:
         if direct_jid in modified_jobs:
             direct_constraints = [c for c in modified_jobs[direct_jid].constraints if c.key == RESERVATION_TAINT_KEY]
-            assert len(direct_constraints) == 1
-            assert direct_constraints[0].op == job_pb2.CONSTRAINT_OP_EQ
+            assert direct_constraints == []
 
     # Unrelated job DOES get NOT_EXISTS constraint
     unrelated_jid = JobName.root("test-user", "unrelated")

--- a/lib/iris/tests/cluster/controller/test_reservation.py
+++ b/lib/iris/tests/cluster/controller/test_reservation.py
@@ -735,17 +735,16 @@ def test_demand_gates_colocating_real_task_until_reservation_claimed(ctrl):
 def test_device_mismatched_reservation_parent_not_gated(ctrl):
     """A reservation whose own task targets a different device is NOT gated.
 
-    Regression for the 2026-06-08 canary thrash (and the ``/power`` v5p reserve
-    job that motivated this fix): ``iris run --reserve <tpu> --cpu N`` makes the
-    *parent* a CPU orchestrator that reserves a TPU it never runs on. The parent
-    must not wait on (or be EQ-pinned to) the reserved TPU workers — its own CPU
-    task schedules independently. So its real task emits CPU demand even while
-    the TPU reservation is unclaimed; only the holder provisions the TPU.
+    ``iris run --reserve <tpu> --cpu N`` makes the *parent* a CPU orchestrator
+    that reserves a TPU it never runs on. The parent must not wait on (or be
+    EQ-pinned to) the reserved TPU workers — its own CPU task schedules
+    independently. So its real task emits CPU demand even while the TPU
+    reservation is unclaimed; only the holder provisions the TPU.
 
-    Before the fix the parent was treated as a co-locating reservation: the
-    demand path gated it (no CPU demand) while the scheduler EQ-pinned it to the
-    TPU-only claim, so it could never run, and (once claimed on a preemptible
-    worker the non-preemptible parent could not use) routed phantom CPU demand
+    When the parent was instead treated as a co-locating reservation, the demand
+    path gated it (no CPU demand) while the scheduler EQ-pinned it to the
+    TPU-only claim, so it could never run, and — once claimed on a preemptible
+    worker the non-preemptible parent could not use — routed phantom CPU demand
     that booted CPU VMs which idled out and were reaped every cycle.
     """
     tpu_device = job_pb2.DeviceConfig(tpu=job_pb2.TpuDevice(variant="v5p-8", count=4))


### PR DESCRIPTION
A reservation maps its job to the *zone* where its accelerators were claimed; it never pins to a specific worker. The directly-reserved parent is gated until its reservation is claimed (so the zone is known), then constrained to that zone on both the scheduler placement and the autoscaler demand entry, so the two agree. With no taint on the parent, the scheduler's normal matching places it on the reserved worker when its own request fits, or on other capacity in the zone otherwise. Descendants are unchanged: allowed to use the claimed workers but not required to, free to run anywhere.

This fixes the stuck `--reserve` job in #180: a non-preemptible CPU orchestrator reserving a preemptible v5p was EQ-pinned to the TPU worker it could not run on, stranding it while phantom CPU demand routed to an arbitrary zone (us-central2-b) booted VMs that idled out and were reaped every cycle. The parent now waits for the claim, then runs on on-demand CPU in the reserved zone, beside its reservation.

The reservation holder still holds the reserved workers, and the NOT_EXISTS taint still keeps non-reservation jobs off them. Replaces the per-job EQ worker-pin and the device-mismatch discriminator with a single uniform zone rule, removing the now-unused colocating/device-type machinery (`reservation_entry_device_types`, `colocating_reservation_job_ids`).

Fixes #180