### PR TITLE
[iris] Build controller/worker images from the committed root uv.lock

### DIFF
--- a/.github/workflows/ops-docker-images.yaml
+++ b/.github/workflows/ops-docker-images.yaml
@@ -19,7 +19,9 @@ jobs:
   # Iris Images - Worker, controller, and task images pushed to GHCR
   # Uses a single multi-stage Dockerfile (lib/iris/Dockerfile) with --target.
   # Controller and worker share all layers up to Python deps; the worker adds
-  # only the Docker CLI. Task is an independent stage with marin root context.
+  # only the Docker CLI. All targets build from the marin repo root context:
+  # the deps stage COPYs the root uv.lock and every workspace member's
+  # pyproject.toml (plus lib/rigging source), all of which live above lib/iris.
   iris-images:
     # Run on: manual trigger OR weekly schedule (02:00 UTC on Sundays)
     if: |
@@ -31,13 +33,10 @@ jobs:
         include:
           - image: iris-worker
             target: worker
-            context: lib/iris
           - image: iris-controller
             target: controller
-            context: lib/iris
           - image: iris-task
             target: task
-            context: .
     steps:
       - name: Checkout repository
         uses: actions/checkout@v5
@@ -70,7 +69,7 @@ jobs:
             --tag ghcr.io/marin-community/${{ matrix.image }}:latest \
             --tag ghcr.io/marin-community/${{ matrix.image }}:${{ steps.set-tags.outputs.DATE_TAG }} \
             --tag ghcr.io/marin-community/${{ matrix.image }}:${{ steps.set-tags.outputs.HASH_TAG }} \
-            ${{ matrix.context }}
+            .
 
   # Finelog Image - Standalone log server (lib/finelog)
   finelog-image:

--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -80,6 +80,9 @@ ENV PATH="/app/.venv/bin:$PATH"
 # member's pyproject.toml (metadata only) — but only iris+rigging install. The
 # first sync uses `--no-install-workspace` to install just the external deps
 # (cached across source edits); the second builds iris+rigging from source.
+# Metadata alone suffices even for marin-haliax's `dynamic = ["version"]`
+# (sourced from src/haliax/__about__.py): under --frozen, uv takes the version
+# from the lock and never invokes a non-installed member's build backend.
 COPY uv.lock pyproject.toml ./
 COPY lib/iris/pyproject.toml ./lib/iris/pyproject.toml
 COPY lib/rigging/pyproject.toml ./lib/rigging/pyproject.toml

--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -69,28 +69,34 @@ FROM base AS deps
 WORKDIR /app
 ENV PATH="/app/.venv/bin:$PATH"
 
-# Rigging is a workspace-local dep not on PyPI. finelog is consumed as
-# pre-built wheels from the index — the pure marin-finelog plus the native
-# marin-finelog-server (the in-process server ext, finelog_server, the
-# controller starts and depends on explicitly) — so neither is a workspace
-# member here (slim base has no Rust toolchain). `prerelease = "explicit"`
-# allows a prerelease only when a specifier asks for one; with iris's finelog
-# floors at stable, none do. Plain `"allow"` also pulls unrelated prereleases —
-# it grabbed httpx 1.0.dev, which drops `httpx.Limits` and crashes the
-# controller — because this reduced workspace lacks the full lock's httpx<1
-# bound. Copy only metadata first so source changes don't bust the dep cache.
+# Build against the committed root `uv.lock` (`--frozen`) so the image ships the
+# same pinned, tested dependency set as local dev and the rest of CI — no fresh
+# PyPI resolve that can float a transitive (e.g. protobuf) to an untested major.
+# marin-iris's closure is only marin-rigging (workspace) plus external/registry
+# deps (marin-finelog and the native marin-finelog-server ship as published
+# wheels); it never pulls the Rust-built members (marin-core, levanter, …), so
+# `--package marin-iris` never asks the toolchain-free slim base to build them.
+# uv must still discover every workspace member to map the lock, so copy each
+# member's pyproject.toml (metadata only) — but only iris+rigging install. The
+# first sync uses `--no-install-workspace` to install just the external deps
+# (cached across source edits); the second builds iris+rigging from source.
+COPY uv.lock pyproject.toml ./
+COPY lib/iris/pyproject.toml ./lib/iris/pyproject.toml
 COPY lib/rigging/pyproject.toml ./lib/rigging/pyproject.toml
-COPY lib/iris/pyproject.toml ./lib/iris/
+COPY lib/fray/pyproject.toml ./lib/fray/pyproject.toml
+COPY lib/haliax/pyproject.toml ./lib/haliax/pyproject.toml
+COPY lib/levanter/pyproject.toml ./lib/levanter/pyproject.toml
+COPY lib/marin/pyproject.toml ./lib/marin/pyproject.toml
+COPY lib/zephyr/pyproject.toml ./lib/zephyr/pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
-    printf '[tool.uv]\nprerelease = "explicit"\n\n[tool.uv.workspace]\nmembers = ["lib/iris", "lib/rigging"]\n\n[tool.uv.sources]\nmarin-rigging = { workspace = true }\n' > pyproject.toml \
-    && uv sync --package marin-iris --no-install-project
+    uv sync --frozen --package marin-iris --no-install-workspace
 
 # Now copy full source for rigging and iris, then install.
 COPY lib/rigging/src/ ./lib/rigging/src/
 COPY lib/iris/src/ ./lib/iris/src/
 COPY lib/iris/config/ ./lib/iris/config/
 RUN --mount=type=cache,target=/root/.cache/uv \
-    uv sync --package marin-iris
+    uv sync --frozen --package marin-iris
 
 # Profiling tools — installed after uv sync so they aren't pruned by the exact sync.
 RUN --mount=type=cache,target=/root/.cache/uv \
@@ -125,8 +131,9 @@ RUN install -m 0755 -d /etc/apt/keyrings && \
 # ── Stage: controller ────────────────────────────────────────────────
 FROM deps AS controller
 
-# Controller-only deps: duckdb, pyarrow, zstandard.
-RUN uv sync --extra controller --inexact
+# Controller-only deps: duckdb, pyarrow, kubernetes (marin-iris's `controller`
+# extra). --inexact keeps the py-spy/memray installed above from being pruned.
+RUN uv sync --frozen --package marin-iris --extra controller --inexact
 
 LABEL org.opencontainers.image.description="Iris controller image"
 

--- a/lib/iris/Dockerfile.dockerignore
+++ b/lib/iris/Dockerfile.dockerignore
@@ -1,7 +1,24 @@
-# Only lib/iris/ and lib/rigging/ are needed in the build context. finelog is
-# pulled as a pre-built wheel from the index, not copied as source.
-# Exclude everything else, then selectively re-include.
+# The build context is the marin repo root, but the controller/worker images
+# only need lib/iris/, lib/rigging/, and the workspace metadata that lets the
+# deps stage resolve against the committed root uv.lock. finelog is pulled as a
+# pre-built wheel from the index, not copied as source. Exclude everything,
+# then selectively re-include.
+#
+# NOTE: this allowlist must stay in sync with the COPY paths in the deps stage
+# of Dockerfile — a path that is COPY'd but not re-included here fails the build
+# with "<path>: not found" during context transfer.
 *
+
+# Root lockfile + workspace member pyproject.toml metadata. uv discovers every
+# member listed in the root [tool.uv.workspace] when mapping the lock, so all
+# member manifests must be present even though only iris+rigging install.
+!uv.lock
+!pyproject.toml
+!lib/fray/pyproject.toml
+!lib/haliax/pyproject.toml
+!lib/levanter/pyproject.toml
+!lib/marin/pyproject.toml
+!lib/zephyr/pyproject.toml
 
 !lib/iris/pyproject.toml
 !lib/iris/src/


### PR DESCRIPTION
The iris Dockerfile deps stage wrote a synthetic reduced-workspace pyproject (iris + rigging) and ran `uv sync` with no lockfile, so every dependency resolved fresh from PyPI at build time. The image floated transitives off the pinned, tested stack: protobuf drifted to 7.x (which dropped `FieldDescriptor.label`) and crash-looped the controller — caught only by the CoreWeave smoke job, never by local repro or unit CI.

Now that `marin-finelog-server` ships as its own published wheel, iris's dependency closure is just `marin-rigging` (workspace) plus external/registry deps; it never pulls the Rust-built members (`marin-core`, `levanter`, …). So the deps stage now copies the root `uv.lock` plus every workspace member's `pyproject.toml` (metadata only) and runs `uv sync --frozen --package marin-iris`. Only iris and rigging install, the toolchain-free slim base is never asked to build a Rust member, and the image ships the same pins as local dev and the rest of CI. A from-scratch controller build on the docker-container driver (the CoreWeave/GCP CI path) resolves `protobuf 6.33.6` and `httpx 0.28.1`, matching the lock exactly; `finelog_server` and the controller import cleanly.

Three coordinated changes:

- `lib/iris/Dockerfile` — build the deps/controller layers from the committed root `uv.lock` with `uv sync --frozen --package marin-iris`.
- `lib/iris/Dockerfile.dockerignore` — this file is an allowlist (`*` then `!lib/iris`, `!lib/rigging`) that buildx applies for `-f lib/iris/Dockerfile` in preference to the repo-root `.dockerignore`. Re-include `uv.lock`, the root `pyproject.toml`, and each member's `pyproject.toml` so the new COPYs reach the context (otherwise the build fails transfer with `uv.lock: not found`). Member source stays excluded, keeping the context tight.
- `.github/workflows/ops-docker-images.yaml` — it passed `context: lib/iris` for the controller/worker builds, but those targets `COPY` repo-root paths. That build only succeeded on a `--cache-from` hit and failed on cache miss (e.g. the 2026-06-14 worker leg). All three targets now build from the repo root, so the per-target context knob is dropped.

Fixes #6414