### PR TITLE
[iris] Retry worker-reported KILLED under the preemption budget

### DIFF
--- a/lib/iris/src/iris/cluster/controller/reconcile/task.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/task.py
@@ -446,12 +446,22 @@ def apply_one_transition(
             if failure_count <= task.max_retries_failure:
                 task_state = job_pb2.TASK_STATE_PENDING
                 terminal_ms = None
-        elif update.new_state == job_pb2.TASK_STATE_WORKER_FAILED:
-            # Worker loss / infra -> preemption budget. ASSIGNED retries without
-            # charge (the worker never ran the process); EXECUTING (BUILDING/
-            # RUNNING) charges and gates on max_retries_preemption. A truly-dead
-            # worker also misses its next ping/heartbeat (bumped observer-side),
-            # so we don't double-count here.
+        elif update.new_state in (job_pb2.TASK_STATE_WORKER_FAILED, job_pb2.TASK_STATE_KILLED):
+            # Worker loss / infra (WORKER_FAILED) or an out-of-band container stop
+            # the worker reports as KILLED — a higher-priority job reclaiming the
+            # slice, a node drain, a spot/preemptible reclaim, or a stop directive
+            # the controller issued without recording a matching task transition.
+            # None of these are application failures, so both share the preemption
+            # budget. A genuine user/controller cancel never reaches here: cancel_job
+            # marks the task terminal first, so the worker's echoing KILLED lands on
+            # an already-finished row above and is dropped; a stale stop of an
+            # abandoned attempt arrives under an old attempt_id and is dropped too.
+            # A KILLED that survives to this branch is therefore always the *current*
+            # live attempt stopped out-of-band — which must retry, not fail the job.
+            # ASSIGNED retries without charge (the worker never ran the process);
+            # EXECUTING (BUILDING/RUNNING) charges and gates on max_retries_preemption.
+            # A truly-dead worker also misses its next ping/heartbeat (bumped
+            # observer-side), so we don't double-count here.
             task_state, preemption_count = resolve_task_failure_state(
                 prior_state,
                 preemption_count,

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -735,6 +735,92 @@ def test_batch_success_and_failure_is_order_independent(state, success_first):
     assert _query_job(state, job_id).state == job_pb2.JOB_STATE_FAILED
 
 
+def _report_worker_state(state, worker_id, task, new_state):
+    """Feed one worker-reported task observation for ``task``'s current attempt."""
+    with state._db.transaction() as cur:
+        apply_task_observations(
+            cur,
+            [
+                WorkerTaskUpdates(
+                    worker_id=worker_id,
+                    updates=[
+                        TaskUpdate(
+                            task_id=task.task_id,
+                            attempt_id=_query_task(state, task.task_id).current_attempt_id,
+                            new_state=new_state,
+                        )
+                    ],
+                )
+            ],
+            health=state._health,
+            endpoints=state._endpoints,
+            now=Timestamp.now(),
+        )
+
+
+def test_worker_reported_killed_on_live_attempt_retries_under_preemption_budget(state):
+    """A worker-reported KILLED for the current attempt retries; it does not fail the job.
+
+    A worker only reports KILLED when its container is stopped out-of-band — a
+    higher-priority job reclaiming the slice, a node drain, a spot/preemptible
+    reclaim, or a stop directive the controller issued without recording a task
+    transition. None of these are application failures, so the kill is charged to
+    the preemption budget (like WORKER_FAILED) and the task rolls back to PENDING.
+
+    Regression for a production incident: a v5p training task was preempted
+    (attempt 0), retried onto a fresh worker (attempt 1), and that worker reported
+    KILLED ~13s in. The controller terminated the whole job (JOB_STATE_KILLED) with
+    99 of 100 preemption retries unused, and the parent driver's wait() raised.
+    """
+    worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())
+    req = controller_pb2.Controller.LaunchJobRequest(
+        name="train",
+        entrypoint=_make_test_entrypoint(),
+        resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
+        environment=job_pb2.EnvironmentConfig(),
+        replicas=1,
+        max_retries_preemption=100,
+    )
+    [task] = submit_job(state, "train", req)
+    job_id = JobName.root("test-user", "train")
+
+    dispatch_task(state, task, worker_id)
+    # Run the attempt first so the kill is charged against the preemption budget
+    # (an EXECUTING task), exactly as in the incident.
+    _report_worker_state(state, worker_id, task, job_pb2.TASK_STATE_RUNNING)
+
+    _report_worker_state(state, worker_id, task, job_pb2.TASK_STATE_KILLED)
+
+    retried = _query_task(state, task.task_id)
+    assert retried.state == job_pb2.TASK_STATE_PENDING, "a live-attempt KILLED must roll the task back to PENDING"
+    assert retried.preemption_count == 1, "the kill must be charged to the preemption budget"
+    assert _query_job(state, job_id).state == job_pb2.JOB_STATE_RUNNING, "the job must stay alive across the retry"
+
+
+def test_worker_reported_killed_terminal_when_preemption_budget_exhausted(state):
+    """With the preemption budget exhausted, a worker-reported KILLED finalizes
+    the task (as WORKER_FAILED) and the job — the retry is bounded, not infinite."""
+    worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())
+    req = controller_pb2.Controller.LaunchJobRequest(
+        name="train",
+        entrypoint=_make_test_entrypoint(),
+        resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
+        environment=job_pb2.EnvironmentConfig(),
+        replicas=1,
+        max_retries_preemption=0,
+    )
+    [task] = submit_job(state, "train", req)
+    job_id = JobName.root("test-user", "train")
+
+    dispatch_task(state, task, worker_id)
+    _report_worker_state(state, worker_id, task, job_pb2.TASK_STATE_RUNNING)
+
+    _report_worker_state(state, worker_id, task, job_pb2.TASK_STATE_KILLED)
+
+    assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_WORKER_FAILED
+    assert _query_job(state, job_id).state == job_pb2.JOB_STATE_WORKER_FAILED
+
+
 def test_max_task_failures_tolerance(state):
     """E2E: Job tolerates max_task_failures, then fails on next failure."""
 


### PR DESCRIPTION
## Symptom

Job [`/eczech/prot-exp75-w4l-e4-lr5e-4-wd0p2`](https://iris.oa.dev/#/job/%2Feczech%2Fprot-exp75-w4l-e4-lr5e-4-wd0p2) failed with:

```
iris.client.client.JobFailedError: Job .../prot-exp75-e4-lr5e-4-wd0p2
  JOB_STATE_KILLED: Preempted by /larry/.../grug-train-moe_..._d768/0
```

The user's expectation is correct: **Iris should never *fail* a job just because it was preempted by a higher-priority job** — preemption should be retried transparently.

## What actually happened

The experiment is a two-level job tree:

- **driver** `prot-exp75-w4l-...` — a CPU task running `exp75_sweep.py`; it submits the training job via fray and blocks on `handle.wait(raise_on_failure=True)`.
- **training** `.../prot-exp75-e4-lr5e-4-wd0p2` — the v5p-8 child job.

Timeline reconstructed from the controller audit log + `task_attempts`:

| time | event |
|------|-------|
| 17:50 | training **attempt 0** assigned to a v5p-8 worker, runs ~42 min |
| 18:32:38 | `event=task_preempted` — larry (higher priority, reservation-backed) preempts attempt 0 → task rolls back to **PENDING** (`preemption_count` 0→1 of **100**) |
| 18:35:06 | `event=assignment_queued` — **attempt 1** assigned to a fresh v5p-8 worker `…c560e252` |
| 18:35:19 | attempt 1 reported **`TASK_STATE_KILLED`** (~13 s in); job → `JOB_STATE_KILLED` **with no audit event** |
| 18:35:46 | driver's `wait()` sees the terminal child → raises `JobFailedError` → driver task FAILED → experiment dies |

Was it a too-few-preemption-retries config issue? **No.** `max_retries_preemption=100`, only `1` used. The "Preempted by larry" string on the job is the *stale* attempt-0 error; the actual kill of attempt 1 was a separate, silent event.

## Root cause

`reconcile/task.py::apply_one_transition` is the worker-reconcile path. For terminal states reported by a worker it had asymmetric retry handling:

- `TASK_STATE_FAILED` → **failure budget** (`max_retries_failure`)
- `TASK_STATE_WORKER_FAILED` → **preemption budget** (`max_retries_preemption`)
- `TASK_STATE_KILLED` → **terminal, no retry budget at all**

A worker emits `TASK_STATE_KILLED` only when its container is stopped out-of-band (`task_attempt.py`: `TaskCancelled` during setup, or a `should_stop` directive during monitoring) — a higher-priority job reclaiming the slice, a node drain, a spot/preemptible reclaim, or a stop directive the controller issued without recording a matching task transition. None of those are application failures, yet any one of them permanently failed the job.

Why this is the path (not a parent/child cascade): `JOB_STATE_KILLED` was reached with **no** `task_killed` / `job_terminated` / `job_cancelled` audit event. The worker-reconcile path (`ReconcileState.reconcile`) is the only one that takes a job terminal *silently*. The audit log confirms the worker does report state 6 (a dropped late report for attempt 0 at 18:33:09).

## Fix

Treat a worker-reported `KILLED` exactly like `WORKER_FAILED` — charge it to the preemption budget:

- `ASSIGNED` retries for free (the worker never ran the process);
- `EXECUTING` (BUILDING/RUNNING) charges and gates on `max_retries_preemption`;
- budget exhaustion finalizes as `WORKER_FAILED` (so `JOB_STATE_KILLED` stays reserved for genuine cancellation).

**Genuine user/controller cancellation is unaffected.** `cancel_job` marks the task terminal *first*, so the worker's echoing `KILLED` lands on an already-finished row and is dropped (task.py:326-345) before reaching this branch; a stale stop of an abandoned attempt arrives under an old `attempt_id` and is dropped too (task.py:347). A `KILLED` that survives to this branch is therefore always the *current* live attempt stopped out-of-band, which must retry.

## Tests

Two regression tests in `test_transitions.py`:

1. `test_worker_reported_killed_on_live_attempt_retries_under_preemption_budget` — worker-reported KILLED on a RUNNING attempt rolls the task to PENDING, charges `preemption_count`, and keeps the job alive.
2. `test_worker_reported_killed_terminal_when_preemption_budget_exhausted` — with no budget left, the task finalizes as WORKER_FAILED and the job as JOB_STATE_WORKER_FAILED (retry is bounded).

Both tests fail on the pre-fix code (confirmed by reverting). Full `tests/cluster/controller` + `tests/cluster/worker` suites pass (1138), including the reservation/preemption capacity-release tests (`test_5470_*`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)