### PR TITLE
[iris] Cascade a worker-reported KILLED to coscheduled peers

### DIFF
--- a/lib/iris/src/iris/cluster/controller/reconcile/policy.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/policy.py
@@ -36,7 +36,9 @@ accidental collision with normal job names."""
 # Predicate sets
 # ---------------------------------------------------------------------------
 
-# Failure states that trigger coscheduled sibling cascades.
+# Failure states that trigger coscheduled sibling cascades. Also reused to pick
+# the cascade *direction* from a transition's resolved task state: a member here
+# tears the gang down, a non-member (PENDING) requeues it.
 FAILURE_TASK_STATES: frozenset[int] = frozenset(
     {
         job_pb2.TASK_STATE_FAILED,
@@ -44,6 +46,15 @@ FAILURE_TASK_STATES: frozenset[int] = frozenset(
         job_pb2.TASK_STATE_PREEMPTED,
     }
 )
+
+# Worker-reported states that, on a coscheduled task, must fan out to the gang.
+# KILLED joins the failure states because a worker only reports it on an
+# out-of-band container stop (slice reclaimed for a higher-priority job, node
+# drain, spot/preemptible reclaim) — an infra event the whole gang must react to,
+# exactly like WORKER_FAILED. This gates *whether* to cascade; the resolved task
+# state (via FAILURE_TASK_STATES) still decides requeue-vs-terminate downstream,
+# so KILLED is deliberately kept out of FAILURE_TASK_STATES itself.
+PEER_CASCADE_TRIGGER_STATES: frozenset[int] = FAILURE_TASK_STATES | {job_pb2.TASK_STATE_KILLED}
 
 # Non-terminal task states (ACTIVE plus PENDING). Used as the snapshot's
 # per-job ``active_tasks_by_job`` state filter so a single read covers both

--- a/lib/iris/src/iris/cluster/controller/reconcile/task.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/task.py
@@ -16,7 +16,7 @@ from rigging.timing import Timestamp
 
 from iris.cluster.controller.reconcile.effects import AttemptRowDelta, TaskRowDelta
 from iris.cluster.controller.reconcile.overlay import Overlay
-from iris.cluster.controller.reconcile.policy import FAILURE_TASK_STATES
+from iris.cluster.controller.reconcile.policy import PEER_CASCADE_TRIGGER_STATES
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate, TransitionSnapshot
 from iris.cluster.controller.task_state import (
     ACTIVE_TASK_STATES,
@@ -507,7 +507,7 @@ def apply_one_transition(
         state.emit_endpoint_deletion(update.task_id)
 
     jc = state.job_config(task.job_id)
-    has_cosched = bool(jc is not None and jc.has_coscheduling and update.new_state in FAILURE_TASK_STATES)
+    has_cosched = bool(jc is not None and jc.has_coscheduling and update.new_state in PEER_CASCADE_TRIGGER_STATES)
 
     return TransitionOutcome(
         task_id=update.task_id,

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -821,6 +821,48 @@ def test_worker_reported_killed_terminal_when_preemption_budget_exhausted(state)
     assert _query_job(state, job_id).state == job_pb2.JOB_STATE_WORKER_FAILED
 
 
+def test_worker_reported_killed_on_coscheduled_task_requeues_the_gang(state):
+    """A worker-reported KILLED on one coscheduled task bounces the whole gang.
+
+    The retry must preserve the coscheduling invariant: when one gang member is
+    stopped out-of-band, every sibling is requeued to PENDING so the job
+    re-coschedules atomically onto a single slice — not left half-running with
+    one member pending. (Mirrors the WORKER_FAILED peer cascade.)
+    """
+    for i in range(4):
+        meta = make_worker_metadata()
+        meta.attributes[WellKnownAttribute.TPU_NAME].string_value = "tpu-a"
+        meta.attributes[WellKnownAttribute.TPU_WORKER_ID].int_value = i
+        register_worker(state, f"w{i}", f"addr{i}:8080", meta)
+
+    req = controller_pb2.Controller.LaunchJobRequest(
+        name="coschedule-killed",
+        entrypoint=_make_test_entrypoint(),
+        resources=job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3),
+        replicas=4,
+        environment=job_pb2.EnvironmentConfig(),
+        max_retries_preemption=100,
+    )
+    req.coscheduling.group_by = WellKnownAttribute.TPU_NAME
+    tasks = submit_job(state, "j-cosched-killed", req)
+    job_id = JobName.root("test-user", "j-cosched-killed")
+
+    for i, task in enumerate(tasks):
+        dispatch_task(state, task, WorkerId(f"w{i}"))
+    # The coscheduled requeue cascade only fires from EXECUTING states.
+    for i, task in enumerate(tasks):
+        _report_worker_state(state, WorkerId(f"w{i}"), task, job_pb2.TASK_STATE_RUNNING)
+
+    # One member is stopped out-of-band -> reported KILLED with budget to spare.
+    _report_worker_state(state, WorkerId("w0"), tasks[0], job_pb2.TASK_STATE_KILLED)
+
+    # The whole gang bounces to PENDING for atomic re-scheduling; the job survives.
+    for task in tasks:
+        assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_PENDING
+    assert _query_task(state, tasks[0].task_id).preemption_count == 1
+    assert _query_job(state, job_id).state == job_pb2.JOB_STATE_RUNNING
+
+
 def test_max_task_failures_tolerance(state):
     """E2E: Job tolerates max_task_failures, then fails on next failure."""
 


### PR DESCRIPTION
Follow-up to #6432 (merged), addressing a P1 from automated review on that PR.

## Background

#6432 fixed a production incident where a preempted training task that retried onto a fresh worker was then reported `TASK_STATE_KILLED` (an out-of-band container stop) and the controller permanently failed the whole job — despite 99/100 preemption retries unused. The fix retries a worker-reported `KILLED` under the preemption budget, exactly like `WORKER_FAILED`.

## The gap

`apply_one_transition` decides whether to fan a transition out to coscheduled siblings via:

```python
has_cosched = bool(jc is not None and jc.has_coscheduling and update.new_state in FAILURE_TASK_STATES)
```

`FAILURE_TASK_STATES` is `{FAILED, WORKER_FAILED, PREEMPTED}` — **no `KILLED`**. So after #6432, a worker-reported `KILLED` on one member of a **coscheduled gang** rolled only that task back to `PENDING` while its siblings kept running on the old slice. That breaks the atomic-gang invariant for exactly the out-of-band stop/preemption case #6432 set out to handle: the whole gang should be requeued together (as `WORKER_FAILED` already does).

## Fix

Add a dedicated gate set `PEER_CASCADE_TRIGGER_STATES = FAILURE_TASK_STATES | {KILLED}` and use it for the coscheduled cascade gate.

`KILLED` is deliberately **not** added to `FAILURE_TASK_STATES` itself, because that set is reused downstream (`_cascade_to_peers`) to pick the cascade *direction* from the transition's **resolved** task state:
- resolved `PENDING` (retry, budget remains) → **requeue** the gang ✅
- resolved `WORKER_FAILED` (budget exhausted) → **terminate** the gang ✅

A retried `KILLED` resolves to `PENDING` or `WORKER_FAILED`, never to `KILLED`, so only the trigger gate needs widening; the direction logic is already correct.

## Test

`test_worker_reported_killed_on_coscheduled_task_requeues_the_gang`: a 4-task coscheduled gang, all RUNNING; one member reports `KILLED` with budget to spare; asserts **all four** tasks bounce to `PENDING` (atomic re-coschedule), the killed task charges `preemption_count`, and the job stays `RUNNING`.

Fails on the pre-fix gate (confirmed by reverting). Full `tests/cluster/controller` + `tests/cluster/worker` suites pass (1139), including the existing coscheduled cascade and reservation/preemption capacity-release tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)