### PR TITLE
[iris] Parallelize autoscaler refresh() describes to unblock the control loop

### DIFF
--- a/.agents/ops/2026-06-16-iris-slow-reconcile-autoscaler-refresh.md
+++ b/.agents/ops/2026-06-16-iris-slow-reconcile-autoscaler-refresh.md
@@ -3,7 +3,7 @@ date: 2026-06-16
 system: iris
 severity: degraded
 resolution: fixed
-pr: pending
+pr: "#6435"
 issue: weaver #202
 ---
 

--- a/.agents/ops/2026-06-16-iris-slow-reconcile-autoscaler-refresh.md
+++ b/.agents/ops/2026-06-16-iris-slow-reconcile-autoscaler-refresh.md
@@ -1,0 +1,231 @@
+---
+date: 2026-06-16
+system: iris
+severity: degraded
+resolution: fixed
+pr: pending
+issue: weaver #202
+---
+
+# Iris control loop stalls ~60s/pass: autoscaler refresh() serializes blocking GCP describes
+
+## TL;DR
+
+- **Symptom:** a full control-loop pass (schedule → reconcile → autoscale) on the
+  `marin` controller takes up to ~60s, so worker heartbeat/reconcile state goes
+  stale and the autoscaler logs confusing demand against data that is tens of
+  seconds old.
+- **Root cause:** the control loop is a *single thread* (`single_control_tick=True`)
+  that runs schedule → reconcile → autoscale **inline**. The autoscale phase calls
+  `Autoscaler.refresh()`, which walks **every non-READY slice serially** and calls
+  `handle.describe()` on each — a blocking GCP round-trip. For a reserved
+  (queued-resource) slice `describe()` is **two** serial calls (`tpu_describe`
+  miss → `queued_resource_describe`). On this cluster there were **64 reserved
+  queued resources stuck `WAITING_FOR_RESOURCES`**, so one `refresh()` serializes
+  ~130–140 blocking GCP calls. At GCP API latency that is tens of seconds, and it
+  blocks reconcile the entire time.
+- **Evidence:** live py-spy thread dumps of the `control-loop` thread caught it
+  in `refresh → describe → tpu_describe`/`queued_resource_describe` in 2 of 5
+  samples; `cluster status` showed `tpu_v4-reserved_8-us-central2-b` with **66
+  booting**; `gcloud` confirmed **64 `WAITING_FOR_RESOURCES`** queued resources;
+  controller logs showed concurrent `reconcile_rpc_failed ... Request timed out`
+  (the stale-state symptom).
+- **Fix (this PR):** parallelize the `refresh()` describes over a bounded thread
+  pool (`_REFRESH_DESCRIBE_MAX_WORKERS = 64`) using the existing `_run_io_batch`
+  find-then-fold pattern (`probe_health()` and `execute()` already do this). State
+  folding stays single-threaded, so scale-group mutation is unchanged and
+  race-free. This turns ~140 serial round-trips into ~3 bounded waves
+  (≈seconds).
+- **Secondary fix (this PR):** bump the reconcile fan-out semaphore
+  `RECONCILE_FANOUT_PARALLELISM` 128 → 512 so the ~350-worker fleet reconciles in
+  one wave; a single slow/timing-out worker then costs one 10s timeout window for
+  the round instead of one-per-wave.
+- **Not in this PR (follow-up):** the ~63 long-lived per-slice `bootstrap-*`
+  threads. They are a *secondary* factor (redundant cloud polling + GCP API load
+  + thread churn — ~10k threads created over the controller's life), not the
+  direct cause. Removing them is an architectural change tracked separately.
+
+## Original problem report
+
+> It's taking up to ~60 seconds for [the marin controller] to complete a full
+> reconcile pass. This leads to stale information on the worker & confusing
+> autoscaler messages. Why is the loop taking so long?
+>
+> Open questions:
+> * I thought we got rid of long lived threads in favor of polling TPU state, but
+>   I see lots of threads like `bootstrap-marin-tpu-v4-preemptible-8-...`
+>   (`_run_tpu_bootstrap`) — is that a factor?
+> * what's the timeout/parallelism of the reconcile loop, the performance, how
+>   can we make it faster (control-loop thread seen in `_fan_out` →
+>   `reconcile`)?
+> * what's a reasonable value for the parallelism semaphore, does it make sense
+>   to go up to 1024?
+
+## Architecture recap
+
+`single_control_tick=True` (the production default,
+`controller.py:183`) runs ONE driver thread, `_run_control_loop` →
+`_control_tick` (`controller.py:814`, `:842`), executing the phases inline:
+
+```
+schedule (pure, in-memory)         every scheduler_min_interval / on wake
+  -> reconcile (fan-out RPC, I/O)  every poll_interval (1.0s)
+  -> autoscale (cloud I/O)         every autoscaler_evaluation_interval (10s)
+  -> one end-of-tick write txn
+```
+
+The legacy separate `_run_autoscaler_loop` thread (`controller.py:785`) only
+spawns when `single_control_tick=False`; in production it is dead. So **any time
+the autoscale phase blocks, reconcile cannot run** — the two share the thread.
+
+Relevant cadences/limits (marin config + code defaults):
+
+| Knob | Value | Source |
+|------|-------|--------|
+| `poll_interval` (reconcile cadence) | 1.0s | `controller.py:193` |
+| `autoscaler.evaluation_interval` | 10s | `config/marin.yaml:17` |
+| `RECONCILE_FANOUT_PARALLELISM` | 128 → **512** | `rpc/backend.py:58` |
+| `DEFAULT_WORKER_RPC_TIMEOUT` | 10s | `rpc/backend.py:55` |
+| `_HEALTH_PROBE_MAX_WORKERS` | 64 | `autoscaler/runtime.py:83` |
+| `_RPC_HANDLER_THREADS` | 1024 | `controller.py:108` |
+
+## Investigation path
+
+1. **`cluster status`** — controller healthy, git `b80b973b72`, **351/351 workers
+   healthy**. Autoscaler table showed `tpu_v4-reserved_8-us-central2-b`:
+   **66 booting / 102 ready / demand 256**. So the fleet was fine but a reserved
+   group had a large non-ready backlog.
+
+2. **`iris process profile threads`** (py-spy dump, repeated). The `control-loop`
+   thread (Thread 45) across 5 samples:
+   - **2/5** blocked in autoscale `refresh()`:
+     ```
+     read (ssl.py) ... get (httpx) -> _tpu_get (service.py:635)
+     tpu_describe (service.py:641) -> _describe_cloud (handles.py:314)
+     describe (handles.py:298) -> refresh (autoscaler/runtime.py:519)
+     autoscale (rpc/backend.py:226) -> _control_tick (controller.py:909)
+     ```
+     and (queued-resource variant):
+     ```
+     _blocking (grpc/_channel.py) ... get_queued_resource (tpu client)
+     queued_resource_describe (service.py:730) -> _describe_queued_resource (handles.py:368)
+     _describe_cloud (handles.py:317) -> describe -> refresh (runtime.py:519)
+     ```
+   - **1/5** in autoscale `update()` → `_run_io_batch` (already parallel).
+   - **2/5** in reconcile `_fan_out` (`rpc/backend.py:85`).
+
+   The `refresh → describe` frames are the serial blocking I/O. (A CPU profile is
+   uninformative here — the thread is GIL-released in a socket read, so the thread
+   *dump* is the right tool.)
+
+3. **Thread census** (full dump): **1100 live threads** = **1024 `rpc-handler`**
+   (the RPC server executor pool) + **63 `bootstrap-*`** + control/housekeeping.
+   Highest thread id ≈ **10,869** → ~10k threads created over the controller's
+   life (heavy bootstrap-thread churn). The 63 live bootstrap threads are mostly
+   `v4-reserved-8` (52 of 63).
+
+4. **gcloud + logs** — `gcloud compute tpus queued-resources list
+   --zone=us-central2-b`: **106 ACTIVE, 64 WAITING_FOR_RESOURCES**. Controller
+   logs were a steady stream of `Queued resource ... is WAITING_FOR_RESOURCES,
+   waiting...` (emitted by the bootstrap threads' `_wait_for_queued_resource_activation`)
+   interleaved with `reconcile_rpc_failed ... Request timed out`.
+
+## Root cause
+
+`Autoscaler.refresh()` (`autoscaler/runtime.py`) before the fix:
+
+```python
+for group in self._groups.values():
+    for slice_id, handle in group.non_ready_slice_handles():
+        status = handle.describe()   # <-- blocking GCP round-trip, SERIAL
+        ... fold status into group state ...
+```
+
+`non_ready_slice_handles()` returns every BOOTING/INITIALIZING slice. With 64
+reserved queued resources stuck in `WAITING_FOR_RESOURCES` (+ a handful of other
+booting slices), the loop issues ~140 serial blocking GCP calls per pass
+(reserved slices cost two: `tpu_describe` returns None → `queued_resource_describe`).
+Because autoscale is inline on the single control thread, reconcile is starved
+for the whole duration — exactly the ~60s stalls and stale worker state reported.
+
+This was a latent cost that only became visible once the reserved backlog grew:
+at 2–3 non-ready slices the serial loop is sub-second; at 64+ it is a minute.
+
+## The fix
+
+### 1. Parallelize `refresh()` describes (primary)
+
+Restructure `refresh()` into the same **find → fan-out I/O → fold serially**
+shape `probe_health()` already uses:
+
+- **Phase 1:** snapshot all `(group, slice_id, handle)` non-READY targets.
+- **Phase 2:** `_run_io_batch(targets, _safe_describe, max_workers=64,
+  thread_name_prefix="slice-describe")` — pure I/O on a bounded, joined pool that
+  touches no autoscaler state, so it is race-free regardless of width.
+  `_safe_describe` returns `SliceStatus | None` (None on exception, logged,
+  retried next tick — same as the old per-iteration `try/except: continue`).
+- **Phase 3:** fold the results into group state **serially** (unchanged logic),
+  so all scale-group mutation stays single-threaded.
+
+~140 serial round-trips → ~⌈140/64⌉ ≈ 3 bounded waves (seconds). 64 matches the
+existing `_HEALTH_PROBE_MAX_WORKERS` precedent and is well within GCP TPU read
+quota.
+
+### 2. Reconcile fan-out width 128 → 512 (secondary)
+
+A reconcile round costs `~RPC_TIMEOUT * ceil(num_workers / parallelism)`. At 128
+with 351 workers that is 3 waves; a straggler/timeout (we observed several
+`Request timed out`) in each wave adds another 10s. Setting the width ≥ fleet
+size makes the fleet reconcile in one wave, so a straggler costs one timeout
+window for the whole round, not one per wave. The RPCs are async coroutines over
+per-worker pyqwest pools, so real concurrency is still bounded by the worker
+count — a wider semaphore is cheap.
+
+## Answers to the open questions
+
+**Q: Are the long-lived `bootstrap-*` threads a factor?**
+Secondary, not primary. Each non-ready slice still spawns a daemon thread
+(`_spawn_bootstrap_thread` → `_run_tpu_bootstrap`) that polls cloud state to
+drive create→READY. With 64 reserved slices queued they pile up (63 live, ~10k
+created over the controller's life). They are mostly sleeping (GIL released on
+I/O) so they do not directly burn the control loop, but they (a) **redundantly
+poll the same cloud state** that `refresh()` also polls, doubling GCP load, and
+(b) add thread/memory churn. The intended direction — *let the autoscaler's
+polling be the lifecycle driver and drop the per-slice threads* — is the right
+cleanup but is a larger, riskier change. Filed as a follow-up; not bundled here.
+Note: the `refresh()` parallelization narrows, but does not remove, the
+double-poll, so the follow-up still matters.
+
+**Q: What is the reconcile loop's timeout/parallelism and how to make it faster?**
+Per-worker RPC deadline 10s (`DEFAULT_WORKER_RPC_TIMEOUT`), fan-out width 128
+(now 512). The fan-out itself was *not* the dominant cost (it appeared in 2/5
+samples and completes in seconds when workers are responsive); the autoscale
+`refresh()` was. Widening the semaphore removes the per-wave straggler tax; the
+big win is the `refresh()` parallelization.
+
+**Q: Is 1024 a reasonable semaphore value?**
+It is *safe* (asyncio handles thousands of concurrent coroutines; concurrency is
+capped by worker count anyway), but the meaningful threshold is "≥ fleet size."
+512 already makes the current ~350-worker fleet a single wave with headroom.
+Going to 1024 buys nothing today and only matters once the fleet grows past 512;
+bump it then. Distinct from `_RPC_HANDLER_THREADS = 1024` (the inbound RPC server
+pool), which is a separate knob.
+
+## Verification
+
+- `uv run --group dev pytest lib/iris/tests/cluster/controller/test_autoscaler.py
+  test_autoscaler_integration.py -m "not requires_cluster"` → **90 passed**.
+- `ruff@0.14.3 check` / `format --check` clean on the changed file.
+- Behaviour preserved: describe failures still fold as "skip, retry next tick";
+  READY/FAILED/UNKNOWN transitions and `scale_down_if_idle` logic unchanged;
+  ordering preserved via `zip(targets, statuses, strict=True)`.
+
+## Follow-ups
+
+- Retire the per-slice `bootstrap-*` threads in favor of autoscaler-driven
+  polling (the user's stated intent), eliminating the redundant cloud poll and
+  the thread churn.
+- Consider revisiting `_RPC_HANDLER_THREADS = 1024` (1024 idle threads × stack ≈
+  real memory on `e2-highmem-4`) — separate from this issue.
+- Consider a per-phase tick-duration log/metric so a slow phase is visible
+  without a live thread dump.

--- a/lib/iris/src/iris/cluster/backends/gcp/service.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/service.py
@@ -417,11 +417,17 @@ class CloudGcpService:
         self._valid_zones: set[str] = set(KNOWN_GCP_ZONES)
         self._valid_accelerator_types: set[str] = set(KNOWN_TPU_TYPES)
         self._tpu_alpha_client_cached: tpu_v2alpha1.TpuClient | None = None
+        self._tpu_alpha_client_lock = threading.Lock()
 
     @property
     def _tpu_alpha_client(self) -> tpu_v2alpha1.TpuClient:
+        # Double-checked under a lock: the describe/create/terminate fan-outs reach
+        # the queued-resource path concurrently, so an unguarded check-then-set
+        # could build (and leak the channel of) a redundant TpuClient per thread.
         if self._tpu_alpha_client_cached is None:
-            self._tpu_alpha_client_cached = tpu_v2alpha1.TpuClient()
+            with self._tpu_alpha_client_lock:
+                if self._tpu_alpha_client_cached is None:
+                    self._tpu_alpha_client_cached = tpu_v2alpha1.TpuClient()
         return self._tpu_alpha_client_cached
 
     @property

--- a/lib/iris/src/iris/cluster/backends/rpc/backend.py
+++ b/lib/iris/src/iris/cluster/backends/rpc/backend.py
@@ -55,15 +55,8 @@ logger = logging.getLogger(__name__)
 DEFAULT_WORKER_RPC_TIMEOUT = Duration.from_seconds(10.0)
 
 # Max concurrent in-flight per-worker RPCs in a fan-out (asyncio.Semaphore width).
-# A full reconcile round costs ~DEFAULT_WORKER_RPC_TIMEOUT * ceil(num_workers /
-# parallelism): once num_workers exceeds the width, a single slow/timing-out
-# worker in each wave adds another timeout window to the round. Keep the width at
-# or above the fleet size so the whole fleet reconciles in one wave and a
-# straggler costs one timeout, not one-per-wave. The RPCs are async coroutines
-# sharing per-worker pyqwest connection pools, so a wider semaphore is cheap (the
-# real concurrency is still bounded by the worker count). 512 covers the current
-# fleet (~350) with headroom; raising it further is safe but only matters as the
-# fleet grows past this width.
+# Kept >= fleet size so the whole fleet reconciles in one wave and a slow worker
+# costs one RPC-timeout window per round, not one per wave.
 RECONCILE_FANOUT_PARALLELISM = 512
 
 # Generous deadline for an "unlimited" exec_in_container (negative timeout). Long

--- a/lib/iris/src/iris/cluster/backends/rpc/backend.py
+++ b/lib/iris/src/iris/cluster/backends/rpc/backend.py
@@ -55,7 +55,16 @@ logger = logging.getLogger(__name__)
 DEFAULT_WORKER_RPC_TIMEOUT = Duration.from_seconds(10.0)
 
 # Max concurrent in-flight per-worker RPCs in a fan-out (asyncio.Semaphore width).
-RECONCILE_FANOUT_PARALLELISM = 128
+# A full reconcile round costs ~DEFAULT_WORKER_RPC_TIMEOUT * ceil(num_workers /
+# parallelism): once num_workers exceeds the width, a single slow/timing-out
+# worker in each wave adds another timeout window to the round. Keep the width at
+# or above the fleet size so the whole fleet reconciles in one wave and a
+# straggler costs one timeout, not one-per-wave. The RPCs are async coroutines
+# sharing per-worker pyqwest connection pools, so a wider semaphore is cheap (the
+# real concurrency is still bounded by the worker count). 512 covers the current
+# fleet (~350) with headroom; raising it further is safe but only matters as the
+# fleet grows past this width.
+RECONCILE_FANOUT_PARALLELISM = 512
 
 # Generous deadline for an "unlimited" exec_in_container (negative timeout). Long
 # enough for real interactive/debug commands, but not the old ~1-hour stall.

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -136,12 +136,10 @@ def _probe_worker_health(worker_url: str) -> bool:
 
 
 def _safe_describe(slice_id: str, handle: SliceHandle) -> SliceStatus | None:
-    """Run a slice's blocking ``describe()``, returning None on failure.
+    """Describe a slice, returning None (and logging) when the call raises.
 
-    Pure I/O helper for the refresh() fan-out: it touches no autoscaler state,
-    so it is safe to run on the bounded describe pool. A describe that raises is
-    logged and folded as None — the slice is left untouched and retried next
-    tick, matching the original serial behaviour.
+    Touches no autoscaler state, so it is safe to run concurrently on the
+    describe pool. A None result means "skip this slice this tick".
     """
     try:
         return handle.describe()
@@ -533,17 +531,13 @@ class Autoscaler:
         self._worker_registry.unregister_slice_workers(slice_id, worker_ids)
 
     def refresh(self, worker_status_map: WorkerStatusMap, timestamp: Timestamp | None = None) -> None:
-        """State-read phase: scale down idle slices from currently tracked state.
+        """Poll non-READY slices and scale down idle ones.
 
-        Each non-READY slice's cloud state is read via ``handle.describe()`` — a
-        blocking GCP round-trip (two, for a still-queued reserved slice). A large
-        reserved backlog (dozens of WAITING_FOR_RESOURCES queued resources) would
-        serialize into tens of seconds and, because this runs inline on the
-        shared control loop, starve reconcile. So the describes are fanned out
-        over a bounded pool (pure I/O, no shared state) and their results folded
-        into group state serially afterward — the same find-then-fold structure
-        :meth:`probe_health` uses for /health probes. Folding stays single-
-        threaded so scale-group mutation remains race-free.
+        Reading a slice's cloud state is a blocking GCP round-trip (two for a
+        still-queued reserved slice). A large reserved backlog would serialize
+        into tens of seconds and, since this runs inline on the shared control
+        loop, starve reconcile — so the reads are fanned out over a bounded pool
+        and folded serially (see the phase comments below).
         """
         timestamp = timestamp or Timestamp.now()
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -83,11 +83,9 @@ _HEALTH_PROBE_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({
 # timeouts would blow past evaluation_interval (10 s default).
 _HEALTH_PROBE_MAX_WORKERS = 64
 
-# Cap concurrent slice describe() calls in refresh(). Each describe is a blocking
-# GCP round-trip (two, for a still-queued reserved slice), so a large reserved
-# backlog (dozens of WAITING_FOR_RESOURCES queued resources) would otherwise
-# serialize into tens of seconds and starve the shared control loop. Mirrors
-# _HEALTH_PROBE_MAX_WORKERS.
+# Cap concurrent describe() calls in refresh(). Each is a blocking GCP round-trip
+# (two for a still-queued reserved slice), so a large reserved backlog would
+# otherwise serialize into tens of seconds and starve the shared control loop.
 _REFRESH_DESCRIBE_MAX_WORKERS = 64
 
 # Cap concurrent slice create/terminate cloud requests issued in one phase. The
@@ -136,14 +134,12 @@ def _probe_worker_health(worker_url: str) -> bool:
 
 
 def _safe_describe(slice_id: str, handle: SliceHandle) -> SliceStatus | None:
-    """Describe a slice, returning None (and logging) when the call raises.
-
-    Touches no autoscaler state, so it is safe to run concurrently on the
-    describe pool. A None result means "skip this slice this tick".
-    """
+    """Describe a slice on the fan-out pool, returning None (logged) if it raises."""
     try:
         return handle.describe()
     except Exception as e:
+        # A failed poll is transient: skip this slice this tick and retry. A slice
+        # that stays unresolvable is failed via the UNKNOWN/unresolvable-timeout path.
         logger.warning("Failed to poll slice %s: %s", slice_id, e)
         return None
 
@@ -548,8 +544,7 @@ class Autoscaler:
             for slice_id, handle in group.non_ready_slice_handles()
         ]
 
-        # Phase 2: fan out the blocking describe() over a bounded pool. A describe
-        # that raises is folded as None and the slice retried next tick.
+        # Phase 2: fan out the blocking describe() over a bounded pool.
         statuses = _run_io_batch(
             targets,
             lambda t: _safe_describe(t[1], t[2]),

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -34,6 +34,7 @@ from iris.cluster.backends.types import (
     QuotaExhaustedError,
     RemoteWorkerHandle,
     SliceHandle,
+    SliceStatus,
 )
 from iris.cluster.constraints import Constraint
 from iris.cluster.controller.autoscaler.models import (
@@ -82,6 +83,13 @@ _HEALTH_PROBE_OPENER = urllib.request.build_opener(urllib.request.ProxyHandler({
 # timeouts would blow past evaluation_interval (10 s default).
 _HEALTH_PROBE_MAX_WORKERS = 64
 
+# Cap concurrent slice describe() calls in refresh(). Each describe is a blocking
+# GCP round-trip (two, for a still-queued reserved slice), so a large reserved
+# backlog (dozens of WAITING_FOR_RESOURCES queued resources) would otherwise
+# serialize into tens of seconds and starve the shared control loop. Mirrors
+# _HEALTH_PROBE_MAX_WORKERS.
+_REFRESH_DESCRIBE_MAX_WORKERS = 64
+
 # Cap concurrent slice create/terminate cloud requests issued in one phase. The
 # fan-out keeps a burst (cold-start scale-up, mass-preemption teardown) within
 # the phase budget instead of serializing one bounded HTTP round-trip at a time.
@@ -125,6 +133,21 @@ def _probe_worker_health(worker_url: str) -> bool:
         return 200 <= resp.status < 300
     except (urllib.error.URLError, urllib.error.HTTPError, OSError, TimeoutError):
         return False
+
+
+def _safe_describe(slice_id: str, handle: SliceHandle) -> SliceStatus | None:
+    """Run a slice's blocking ``describe()``, returning None on failure.
+
+    Pure I/O helper for the refresh() fan-out: it touches no autoscaler state,
+    so it is safe to run on the bounded describe pool. A describe that raises is
+    logged and folded as None — the slice is left untouched and retried next
+    tick, matching the original serial behaviour.
+    """
+    try:
+        return handle.describe()
+    except Exception as e:
+        logger.warning("Failed to poll slice %s: %s", slice_id, e)
+        return None
 
 
 @dataclass
@@ -510,62 +533,85 @@ class Autoscaler:
         self._worker_registry.unregister_slice_workers(slice_id, worker_ids)
 
     def refresh(self, worker_status_map: WorkerStatusMap, timestamp: Timestamp | None = None) -> None:
-        """State-read phase: scale down idle slices from currently tracked state."""
+        """State-read phase: scale down idle slices from currently tracked state.
+
+        Each non-READY slice's cloud state is read via ``handle.describe()`` — a
+        blocking GCP round-trip (two, for a still-queued reserved slice). A large
+        reserved backlog (dozens of WAITING_FOR_RESOURCES queued resources) would
+        serialize into tens of seconds and, because this runs inline on the
+        shared control loop, starve reconcile. So the describes are fanned out
+        over a bounded pool (pure I/O, no shared state) and their results folded
+        into group state serially afterward — the same find-then-fold structure
+        :meth:`probe_health` uses for /health probes. Folding stays single-
+        threaded so scale-group mutation remains race-free.
+        """
         timestamp = timestamp or Timestamp.now()
 
-        for group in self._groups.values():
-            for slice_id, handle in group.non_ready_slice_handles():
-                try:
-                    status = handle.describe()
-                except Exception as e:
-                    logger.warning("Failed to poll slice %s: %s", slice_id, e)
-                    continue
+        # Phase 1: snapshot every non-READY slice across all groups.
+        targets = [
+            (group, slice_id, handle)
+            for group in self._groups.values()
+            for slice_id, handle in group.non_ready_slice_handles()
+        ]
 
-                if status.state == CloudSliceState.READY:
-                    worker_ids = [w.worker_id for w in status.workers]
-                    worker_urls = self._worker_urls(status.workers)
-                    group.mark_slice_ready(slice_id, worker_ids, worker_urls=worker_urls)
-                    self._register_slice_workers(status.workers, slice_id, group.name)
-                    self._log_action(
-                        "slice_ready",
-                        group.name,
-                        slice_id,
-                        reason=f"bootstrap completed ({len(worker_ids)} workers)",
-                    )
-                elif status.state == CloudSliceState.FAILED:
-                    group.mark_slice_failed(slice_id, error_message=status.error_message)
+        # Phase 2: fan out the blocking describe() over a bounded pool. A describe
+        # that raises is folded as None and the slice retried next tick.
+        statuses = _run_io_batch(
+            targets,
+            lambda t: _safe_describe(t[1], t[2]),
+            max_workers=_REFRESH_DESCRIBE_MAX_WORKERS,
+            thread_name_prefix="slice-describe",
+        )
+
+        # Phase 3: fold describe results into group state serially.
+        for (group, slice_id, handle), status in zip(targets, statuses, strict=True):
+            if status is None:
+                continue
+            if status.state == CloudSliceState.READY:
+                worker_ids = [w.worker_id for w in status.workers]
+                worker_urls = self._worker_urls(status.workers)
+                group.mark_slice_ready(slice_id, worker_ids, worker_urls=worker_urls)
+                self._register_slice_workers(status.workers, slice_id, group.name)
+                self._log_action(
+                    "slice_ready",
+                    group.name,
+                    slice_id,
+                    reason=f"bootstrap completed ({len(worker_ids)} workers)",
+                )
+            elif status.state == CloudSliceState.FAILED:
+                group.mark_slice_failed(slice_id, error_message=status.error_message)
+                group.scale_down(slice_id)
+                self._unregister_slice_workers(slice_id)
+                group.record_slice_boot_failed(slice_id, timestamp)
+                reason = status.error_message if status.error_message else "bootstrap failed"
+                self._log_action(
+                    "slice_failed",
+                    group.name,
+                    slice_id,
+                    reason=reason,
+                    status="failed",
+                )
+            elif status.state == CloudSliceState.UNKNOWN:
+                age = Duration.from_ms(timestamp.epoch_ms() - handle.created_at.epoch_ms())
+                if age >= self._unresolvable_timeout:
+                    group.mark_slice_failed(slice_id, error_message="unresolvable after timeout")
                     group.scale_down(slice_id)
                     self._unregister_slice_workers(slice_id)
                     group.record_slice_boot_failed(slice_id, timestamp)
-                    reason = status.error_message if status.error_message else "bootstrap failed"
                     self._log_action(
                         "slice_failed",
                         group.name,
                         slice_id,
-                        reason=reason,
+                        reason=f"TPU unresolvable for {age}",
                         status="failed",
                     )
-                elif status.state == CloudSliceState.UNKNOWN:
-                    age = Duration.from_ms(timestamp.epoch_ms() - handle.created_at.epoch_ms())
-                    if age >= self._unresolvable_timeout:
-                        group.mark_slice_failed(slice_id, error_message="unresolvable after timeout")
-                        group.scale_down(slice_id)
-                        self._unregister_slice_workers(slice_id)
-                        group.record_slice_boot_failed(slice_id, timestamp)
-                        self._log_action(
-                            "slice_failed",
-                            group.name,
-                            slice_id,
-                            reason=f"TPU unresolvable for {age}",
-                            status="failed",
-                        )
-                    else:
-                        logger.debug(
-                            "Slice %s UNKNOWN (age %s < timeout %s); will retry",
-                            slice_id,
-                            age,
-                            self._unresolvable_timeout,
-                        )
+                else:
+                    logger.debug(
+                        "Slice %s UNKNOWN (age %s < timeout %s); will retry",
+                        slice_id,
+                        age,
+                        self._unresolvable_timeout,
+                    )
 
         for group in self._groups.values():
             target_capacity = min(group.current_demand + group.buffer_slices, group.max_slices)

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -1541,12 +1541,10 @@ class TestAutoscalerUnresolvableTimeout:
         autoscaler.shutdown()
 
     def test_describe_failure_isolated_across_slices(self, scale_group_config: config_pb2.ScaleGroupConfig):
-        """A describe() that raises folds as skip-and-retry without aborting peers.
+        """A describe() that raises leaves its slice tracked without aborting peers.
 
-        refresh() fans the per-slice describes out over a bounded pool and folds
-        the results serially. A single slice whose describe() raises must leave
-        that slice tracked for retry while every other slice is still processed —
-        the resilience the old serial ``try/except: continue`` provided.
+        One slice failing to describe must not prevent the others from being
+        processed; the failed slice stays tracked for retry next tick.
         """
         ok_handle = make_mock_slice_handle("slice-ok", created_at_ms=0)
         bad_handle = make_mock_slice_handle("slice-bad", created_at_ms=0)

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -1540,6 +1540,43 @@ class TestAutoscalerUnresolvableTimeout:
         assert group.ready_slice_count() == 1
         autoscaler.shutdown()
 
+    def test_describe_failure_isolated_across_slices(self, scale_group_config: config_pb2.ScaleGroupConfig):
+        """A describe() that raises folds as skip-and-retry without aborting peers.
+
+        refresh() fans the per-slice describes out over a bounded pool and folds
+        the results serially. A single slice whose describe() raises must leave
+        that slice tracked for retry while every other slice is still processed —
+        the resilience the old serial ``try/except: continue`` provided.
+        """
+        ok_handle = make_mock_slice_handle("slice-ok", created_at_ms=0)
+        bad_handle = make_mock_slice_handle("slice-bad", created_at_ms=0)
+        platform = make_mock_platform(slices_to_discover=[ok_handle, bad_handle])
+        group = ScalingGroup(scale_group_config, platform)
+        group.reconcile()
+
+        autoscaler = Autoscaler(
+            scale_groups={"test-group": group},
+            evaluation_interval=Duration.from_seconds(0.1),
+            platform=platform,
+            unresolvable_timeout=DEFAULT_UNRESOLVABLE_TIMEOUT,
+        )
+
+        # The healthy peer transitions to READY; the other peer's describe raises.
+        worker = make_mock_worker_handle("slice-ok-vm-0", "10.0.2.0", vm_pb2.VM_STATE_READY)
+        ok_handle._status = SliceStatus(state=CloudSliceState.READY, worker_count=1, workers=[worker])
+
+        def _raise() -> SliceStatus:
+            raise RuntimeError("transient GCP describe error")
+
+        bad_handle.describe = _raise
+
+        autoscaler.refresh({}, timestamp=Timestamp.from_ms(60 * 1000))
+
+        # Healthy peer processed despite the failure; failing peer left tracked.
+        assert group.ready_slice_count() == 1
+        assert group.slice_count() == 2
+        autoscaler.shutdown()
+
 
 class TestAutoscalerHealthProbe:
     """Tests for probe_health(): terminate slices whose /health endpoint dies."""


### PR DESCRIPTION
The unified control loop runs schedule -> reconcile -> autoscale inline on one
thread (single_control_tick=True), so a slow autoscale phase starves reconcile
and worker heartbeat/reconcile state goes stale.

Autoscaler.refresh() walked every non-READY slice serially, calling the blocking
handle.describe() on each — two GCP round-trips for a still-queued reserved slice
(tpu_describe miss -> queued_resource_describe). On the marin cluster there were
64 reserved queued resources stuck WAITING_FOR_RESOURCES, so one refresh pass
serialized ~140 blocking GCP calls, taking up to ~60s and blocking the whole
control tick the entire time. Live py-spy dumps caught the control-loop thread in
refresh -> describe -> tpu_describe / queued_resource_describe.

Fix: fan the describes out over a bounded thread pool (64-wide, mirroring the
existing probe_health and execute fan-outs) and fold results into group state
serially, so scale-group mutation stays single-threaded and race-free. ~140
serial round-trips become ~3 bounded waves (seconds). Folding logic and slice
state transitions are unchanged.

Also bump the reconcile fan-out semaphore 128 -> 512 so the ~350-worker fleet
reconciles in one wave: a single slow/timing-out worker then costs one
RPC-timeout window for the round instead of one per wave.

Full investigation (thread dumps, gcloud queued-resource counts, the
bootstrap-thread question, and the parallelism-semaphore sizing answer) is in
.agents/ops/2026-06-16-iris-slow-reconcile-autoscaler-refresh.md.