### PR TITLE
[iris] Remove vestigial legacy 3-thread control loop

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -933,10 +933,9 @@ class Controller:
     def _run_scheduling(self) -> SchedulingOutcome:
         """Run one self-contained scheduling cycle (its own snapshot + commits).
 
-        Drives the dry-run schedule-only mini-tick (``_control_tick`` short-circuits
-        here when side effects are suppressed); the live control tick instead runs
-        the schedule decision via ``_schedule_phase`` and commits it inside the
-        shared end-of-tick transaction.
+        This is the dry-run scheduling path; the live control tick computes its
+        schedule via ``_schedule_phase`` and commits it in the shared end-of-tick
+        transaction instead.
 
         The controller owns only the I/O: it refreshes reservation claims and
         builds the scheduling context in a single DB snapshot (which folds in the

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -31,7 +31,6 @@ from iris.cluster.controller import ops, reads, writes
 from iris.cluster.controller.audit_logging import log_event
 from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.autoscaler import Autoscaler
-from iris.cluster.controller.autoscaler.models import DemandEntry
 from iris.cluster.controller.autoscaler.persistence import persist_autoscaler_state
 from iris.cluster.controller.backend import (
     AutoscaleResult,
@@ -171,33 +170,20 @@ class ControllerConfig:
     """Remote URI for controller checkpoints and worker profiles (e.g. gs://bucket/iris/state)."""
 
     scheduler_min_interval: Duration = field(default_factory=lambda: Duration.from_seconds(10.0))
-    """Minimum scheduling loop interval (used when cluster is active)."""
-
-    scheduler_max_interval: Duration = field(default_factory=lambda: Duration.from_seconds(10.0))
-    """Maximum scheduling loop interval (reached via exponential backoff when idle)."""
+    """Schedule-phase cadence: the control tick runs its schedule phase at most
+    this often (a submit wake still forces an immediate schedule-only mini-tick)."""
 
     autoscaler_evaluation_interval: Duration = field(default_factory=lambda: Duration.from_seconds(10.0))
     """How often the controller runs an autoscale provisioning cycle
     (``backend.autoscale``). A capacity-managing backend (k8s) no-ops."""
 
-    single_control_tick: bool = True
-    """When True (default), scheduling, reconcile, and autoscale run as phases of
-    one driver thread: each tick builds a single read snapshot, runs the phases
-    that are due (or, on a wake, a schedule-only mini-tick), and commits through a
-    single end-of-tick write transaction. When False, the legacy structure runs —
-    scheduling, polling/reconcile, and autoscale on three independent loop threads
-    with their own snapshots and commits. The legacy path is a runtime fallback;
-    remove it (and this flag) once the single-tick path has run one release in
-    production without regression. The per-phase cadences are identical either way."""
-
     poll_interval: Duration = field(default_factory=lambda: Duration.from_seconds(1.0))
-    """Reconcile cadence — the sole reconcile + liveness channel. The polling
-    thread wakes every ``poll_interval`` (or sooner if ``_polling_wake`` is set)
-    and runs ``_reconcile_tick`` against every active worker. The reconcile RPC
-    outcome is the only liveness signal; ``worker_unreachable_grace`` sets how
-    long a worker may stay unreachable before teardown. The Reconcile RPC is also
-    the sole channel that dispatches new ASSIGNED rows and observes worker
-    state."""
+    """Reconcile cadence — the sole reconcile + liveness channel. The control
+    tick runs its reconcile phase every ``poll_interval`` (or sooner when a fresh
+    assignment forces one) against every active worker. The reconcile RPC outcome
+    is the only liveness signal; ``worker_unreachable_grace`` sets how long a
+    worker may stay unreachable before teardown. The Reconcile RPC is also the
+    sole channel that dispatches new ASSIGNED rows and observes worker state."""
 
     worker_unreachable_grace: Duration = field(default_factory=lambda: Duration.from_seconds(50.0))
     """How long a worker may be continuously unreachable (or self-report
@@ -215,7 +201,7 @@ class ControllerConfig:
 
     checkpoint_interval: Duration | None = None
     """If set, take a periodic best-effort snapshot this often.
-    Runs in the autoscaler loop thread; does not pause scheduling."""
+    Runs on its own checkpoint thread; does not pause the control tick."""
 
     prune_interval: Duration = field(default_factory=lambda: Duration.from_seconds(3600))
     """How often to run the data pruning sweep (default: 1 hour)."""
@@ -275,12 +261,9 @@ def _log_client_interceptors(config: "ControllerConfig") -> tuple:
 class Controller:
     """Unified controller managing all components and lifecycle.
 
-    By default (``single_control_tick=True``) one driver thread runs the control
-    tick — schedule -> reconcile -> autoscale as phases over a single read
-    snapshot, committed through one end-of-tick write transaction — alongside the
-    prune and checkpoint housekeeping threads. Setting ``single_control_tick=False``
-    restores the legacy structure (scheduling, polling/reconcile, and autoscale on
-    three independent loop threads) as a one-release runtime fallback.
+    One driver thread runs the control tick — schedule -> reconcile -> autoscale
+    as phases over a single read snapshot, committed through one end-of-tick write
+    transaction — alongside the prune and checkpoint housekeeping threads.
 
     Example:
         ```python
@@ -412,35 +395,20 @@ class Controller:
             finelog_stats_service=self._remote_stats_service,
         )
 
-        # Background loop state. Two wake events drive two threads:
-        #   * ``_scheduling_wake`` — producers that may free capacity (terminal
-        #     heartbeats, attempt finalization). Scheduling tick re-evaluates
-        #     pending tasks.
-        #   * ``_polling_wake`` — producers that change ``tasks.state`` such
-        #     that the per-worker reconcile snapshot differs (new ASSIGNED,
-        #     bulk cancel). Polling tick re-fans-out the next worker batch.
-        #
-        # Most write paths set both: over-waking is cheaper than missing a
-        # capacity-return or a fresh ASSIGNED row.
-        self._scheduling_wake = threading.Event()
-        self._polling_wake = threading.Event()
-        # Wakes the unified control-tick driver (single_control_tick=True). A
-        # submit triggers a schedule-only mini-tick so submit->assign latency is
-        # the schedule time, not gated on the next reconcile cadence.
+        # Wakes the control-tick driver. A submit triggers a schedule-only
+        # mini-tick so submit->assign latency is the schedule time, not gated on
+        # the next reconcile cadence.
         self._tick_wake = threading.Event()
         # Set after a tick commits new ASSIGNED rows so the next tick reconciles
         # immediately (dispatching them) instead of waiting a full poll interval.
         self._force_reconcile = False
         self._server: uvicorn.Server | None = None
-        self._scheduling_thread: ManagedThread | None = None
-        self._polling_thread: ManagedThread | None = None
-        self._autoscaler_thread: ManagedThread | None = None
         self._control_thread: ManagedThread | None = None
         self._prune_thread: ManagedThread | None = None
         self._checkpoint_thread: ManagedThread | None = None
 
-        # Throttles the execution-timeout deadline scan in _reconcile_tick.
-        # The reconcile tick runs frequently (poll cadence); the timeout query
+        # Throttles the execution-timeout deadline scan in the reconcile phase.
+        # The reconcile phase runs frequently (poll cadence); the timeout query
         # only needs minute-granularity, so we gate it behind a 60s limiter.
         self._timeout_rate_limiter: RateLimiter = RateLimiter(interval_seconds=60.0)
 
@@ -456,11 +424,6 @@ class Controller:
         # the DB. This is the only ``| None`` attribute on Controller: it is
         # genuinely None before the first scheduling tick has run.
         self._last_scheduling_context: SchedulingContext | None = None
-
-        # Residual demand from the most recent scheduling tick, computed by the
-        # scheduling pass alongside assignments and read by the autoscaler loop.
-        # Empty until the first tick with pending work runs.
-        self._last_residual_demand: list[DemandEntry] = []
 
         # Set to True once start() is called. Used to gate operations that
         # are only valid before the controller loops begin (e.g. LoadCheckpoint).
@@ -482,15 +445,12 @@ class Controller:
             self._periodic_checkpoint_limiter.mark_run()
 
     def wake(self) -> None:
-        """Signal both the scheduling and polling loops to run immediately.
+        """Wake the control tick to run a schedule-only mini-tick immediately.
 
-        Called on new job submission. The scheduling tick picks up the new
-        pending tasks, and the polling tick re-fans-out the next worker batch
-        so any ASSIGNED rows the scheduler writes land on the worker without
-        waiting for a full polling rotation.
+        Called on new job submission so the next tick picks up the new pending
+        tasks (and a fresh assignment then forces the following reconcile) instead
+        of waiting a full poll interval.
         """
-        self._scheduling_wake.set()
-        self._polling_wake.set()
         self._tick_wake.set()
 
     def _seed_liveness_from_workers(self) -> None:
@@ -539,21 +499,16 @@ class Controller:
         """Start the dashboard server and the control + housekeeping threads.
 
         Every backend gets the same threads; each phase no-ops where it does not
-        apply. By default the unified control tick drives schedule -> reconcile ->
-        autoscale (``single_control_tick=True``); the reconcile phase is the sole
-        reconcile + liveness channel — it reconciles every active worker
-        (worker-daemon backends) or drains + syncs pods (cluster backends), folds
-        the backend's observed health events, and tears down workers that cross the
-        failure threshold. With ``single_control_tick=False`` the legacy
-        scheduling/polling/autoscaler loop threads run instead.
+        apply. The unified control tick drives schedule -> reconcile -> autoscale;
+        the reconcile phase is the sole reconcile + liveness channel — it
+        reconciles every active worker (worker-daemon backends) or drains + syncs
+        pods (cluster backends), folds the backend's observed health events, and
+        tears down workers that cross the failure threshold.
         """
         self._started = True
         if self._config.dry_run:
             logger.info("[DRY-RUN] Controller started in dry-run mode — all side effects suppressed")
 
-        if not self._config.single_control_tick:
-            self._scheduling_thread = self._threads.spawn(self._run_scheduling_loop, name="scheduling-loop")
-            self._polling_thread = self._threads.spawn(self._run_polling_loop, name="polling-loop")
         if not self._config.dry_run:
             self._prune_thread = self._threads.spawn(self._run_prune_loop, name="prune-loop")
 
@@ -584,25 +539,23 @@ class Controller:
         _install_rpc_executor(self._server, max_workers=_RPC_HANDLER_THREADS)
         self._threads.spawn_server(self._server, name="controller-server")
 
-        # Register cluster endpoints BEFORE spawning the autoscaler. Otherwise the
-        # autoscaler's first tick can create buffer slices whose workers query the
-        # controller for /system/log-server before this dict is populated, returning
-        # an empty result. The slice creation fails, the group enters backoff, and
-        # any task constrained to that group hangs until the backoff expires.
+        # Register cluster endpoints BEFORE spawning the control loop. Otherwise
+        # the autoscale phase's first tick can create buffer slices whose workers
+        # query the controller for /system/log-server before this dict is
+        # populated, returning an empty result. The slice creation fails, the
+        # group enters backoff, and any task constrained to that group hangs until
+        # the backoff expires.
         for name, url in self._config.endpoints.items():
             self._service._system_endpoints[name] = url
             logger.info("Registered system endpoint %s -> %s", name, url)
         self._service._system_endpoints["/system/log-server"] = self._log_service_address
 
-        if self._config.single_control_tick:
-            # One driver runs schedule -> reconcile -> autoscale as phases of a
-            # single tick (one read snapshot + one end-of-tick commit). Spawned
-            # after endpoint registration for the same reason the autoscaler loop
-            # was: its first tick may provision buffer slices whose workers query
-            # /system/log-server. In dry-run it runs the schedule phase only.
-            self._control_thread = self._threads.spawn(self._run_control_loop, name="control-loop")
-        elif not self._config.dry_run:
-            self._autoscaler_thread = self._threads.spawn(self._run_autoscaler_loop, name="autoscaler-loop")
+        # One driver runs schedule -> reconcile -> autoscale as phases of a single
+        # tick (one read snapshot + one end-of-tick commit). Spawned after endpoint
+        # registration because its first autoscale phase may provision buffer slices
+        # whose workers query /system/log-server. In dry-run it runs the schedule
+        # phase only.
+        self._control_thread = self._threads.spawn(self._run_control_loop, name="control-loop")
 
         if self._periodic_checkpoint_limiter is not None and not self._config.dry_run:
             self._checkpoint_thread = self._threads.spawn(self._run_checkpoint_loop, name="checkpoint-loop")
@@ -623,7 +576,7 @@ class Controller:
 
         Shutdown ordering:
         1. Unregister atexit hook so it doesn't fire against a closed DB.
-        2. Stop scheduling/provider/autoscaler loops so no new work is triggered.
+        2. Stop the control loop so no new work is triggered.
         3. Shut down the autoscaler (stops monitors, terminates VMs, stops platform).
         4. Stop remaining threads (server) and executors.
         """
@@ -634,25 +587,14 @@ class Controller:
         if self._atexit_registered:
             atexit.unregister(self._atexit_checkpoint)
             self._atexit_registered = False
-        self._scheduling_wake.set()
-        self._polling_wake.set()
         self._tick_wake.set()
         join_timeout = Duration.from_seconds(5.0)
         if self._control_thread:
             self._control_thread.stop()
             self._control_thread.join(timeout=join_timeout)
-        if self._scheduling_thread:
-            self._scheduling_thread.stop()
-            self._scheduling_thread.join(timeout=join_timeout)
-        if self._polling_thread:
-            self._polling_thread.stop()
-            self._polling_thread.join(timeout=join_timeout)
         if self._prune_thread:
             self._prune_thread.stop()
             self._prune_thread.join(timeout=join_timeout)
-        if self._autoscaler_thread:
-            self._autoscaler_thread.stop()
-            self._autoscaler_thread.join(timeout=join_timeout)
         if self._checkpoint_thread:
             self._checkpoint_thread.stop()
             self._checkpoint_thread.join(timeout=join_timeout)
@@ -683,66 +625,6 @@ class Controller:
             logger.info("atexit checkpoint written: %s", path)
         except Exception:
             logger.exception("atexit checkpoint failed")
-
-    def _run_scheduling_loop(self, stop_event: threading.Event) -> None:
-        """Scheduling loop with adaptive backoff.
-
-        Backs off from min to max interval when idle (no pending tasks or no
-        assignments possible). Resets to min interval when woken by a producer
-        that may free capacity or by a new job submission.
-
-        Reconciliation runs on the separate polling thread
-        (``_run_polling_loop``) on its own cadence via the Reconcile RPC.
-        Sharing the
-        same write transaction is no longer required: producers write
-        ``tasks.state = ASSIGNED`` and the polling thread reads that state via
-        a snapshot query, so dispatch never crosses a transaction boundary.
-        """
-        backoff = ExponentialBackoff(
-            initial=self._config.scheduler_min_interval.to_seconds(),
-            maximum=self._config.scheduler_max_interval.to_seconds(),
-            factor=2.0,
-            jitter=0.1,
-        )
-        while not stop_event.is_set():
-            interval = backoff.next_interval()
-            woken = self._scheduling_wake.wait(timeout=interval)
-            self._scheduling_wake.clear()
-
-            if stop_event.is_set():
-                break
-
-            if woken:
-                backoff.reset()
-
-            outcome = self._run_scheduling()
-            if outcome == SchedulingOutcome.ASSIGNMENTS_MADE:
-                backoff.reset()
-
-    def _run_polling_loop(self, stop_event: threading.Event) -> None:
-        """Per-worker reconcile loop on the configured ``poll_interval`` cadence.
-
-        Each tick:
-          1. Snapshot every healthy active worker.
-          2. Fan out the Reconcile RPC carrying the desired-attempt set per
-             worker (ASSIGNED rows to start, BUILDING/RUNNING rows to keep
-             alive, and stops for everything else).
-          3. Apply observation-driven results in one write txn.
-
-        The polling thread is the sole path that pushes work to a worker.
-        Worker auto-kill is implicit: any attempt absent from the desired
-        set on the next reconcile is killed locally by the worker.
-        """
-        tick_seconds = self._config.poll_interval.to_seconds()
-        while not stop_event.is_set():
-            self._polling_wake.wait(timeout=tick_seconds)
-            self._polling_wake.clear()
-            if stop_event.is_set():
-                break
-            try:
-                self._reconcile_tick()
-            except Exception:
-                logger.exception("Polling reconcile tick failed")
 
     def _run_prune_loop(self, stop_event: threading.Event) -> None:
         """Background maintenance: WAL checkpoint every 10 min, full data prune on the configured interval."""
@@ -782,21 +664,9 @@ class Controller:
                 except Exception:
                     logger.exception("Data pruning failed")
 
-    def _run_autoscaler_loop(self, stop_event: threading.Event) -> None:
-        """Autoscaler loop: runs on its own thread so blocking cloud API calls
-        don't stall scheduling or heartbeats."""
-        limiter = RateLimiter(interval_seconds=self._config.autoscaler_evaluation_interval.to_seconds())
-        while not stop_event.is_set():
-            if not limiter.wait(cancel=stop_event):
-                break
-            try:
-                self._run_autoscaler_once()
-            except Exception:
-                logger.exception("Autoscaler loop iteration failed")
-
     def _run_checkpoint_loop(self, stop_event: threading.Event) -> None:
         """Periodic checkpoint loop: runs on its own thread so the multi-second
-        backup+upload doesn't stall the autoscaler cadence."""
+        backup+upload doesn't stall the control tick cadence."""
         limiter = self._periodic_checkpoint_limiter
         assert limiter is not None, "checkpoint loop spawned without configured limiter"
         while not stop_event.is_set():
@@ -808,7 +678,7 @@ class Controller:
                 logger.exception("Periodic checkpoint failed")
 
     # =========================================================================
-    # Unified control tick (single_control_tick=True)
+    # Unified control tick
     # =========================================================================
 
     def _run_control_loop(self, stop_event: threading.Event) -> None:
@@ -1061,7 +931,12 @@ class Controller:
             logger.info("Preemption pass: %d tasks preempted", len(result.preemptions))
 
     def _run_scheduling(self) -> SchedulingOutcome:
-        """Run one scheduling cycle.
+        """Run one self-contained scheduling cycle (its own snapshot + commits).
+
+        Drives the dry-run schedule-only mini-tick (``_control_tick`` short-circuits
+        here when side effects are suppressed); the live control tick instead runs
+        the schedule decision via ``_schedule_phase`` and commits it inside the
+        shared end-of-tick transaction.
 
         The controller owns only the I/O: it refreshes reservation claims and
         builds the scheduling context in a single DB snapshot (which folds in the
@@ -1072,7 +947,7 @@ class Controller:
         gates → order → taints → preference → find_assignments → preemption
         pipeline; a cluster backend returns an empty result (Kueue schedules).
 
-        No lock is needed since only one scheduling thread exists. Every DB
+        No lock is needed since the control driver is single-threaded. Every DB
         access is serialized by ControllerDB._lock with multi-statement
         mutations wrapped in BEGIN IMMEDIATE transactions.
         """
@@ -1101,7 +976,6 @@ class Controller:
         if not ctx.pending_task_rows:
             self._scheduling_diagnostics = {}
             self._last_scheduling_context = ctx
-            self._last_residual_demand = []
             return SchedulingOutcome.NO_PENDING_TASKS
 
         result = self._task_backend.schedule(
@@ -1123,7 +997,6 @@ class Controller:
 
         self._scheduling_diagnostics = result.diagnostics
         self._last_scheduling_context = result.post_taint_context
-        self._last_residual_demand = result.residual_demand
 
         if result.assignments or result.preemptions:
             log_event(
@@ -1154,8 +1027,8 @@ class Controller:
         onto ``tasks.priority_band``. The preemption pass then trusts that
         stamped value instead of recomputing from current spend every tick.
 
-        The polling reconcile thread reads ASSIGNED rows on its next tick
-        (woken via ``_polling_wake``) and fans out the Reconcile RPCs.
+        The next control tick's reconcile phase reads the ASSIGNED rows and fans
+        out the Reconcile RPCs.
         """
         if self._config.dry_run:
             for assignment in assignments:
@@ -1163,9 +1036,6 @@ class Controller:
             return
         with self._db.transaction() as cur:
             ops.task.assign(cur, assignments, health=self._health)
-        # Wake the polling thread; every tick reconciles every healthy worker,
-        # so the new ASSIGNED rows turn into Reconcile RPCs on the next tick.
-        self._polling_wake.set()
 
     def _apply_preemptions(self, preemptions: list[TerminalDecision]) -> None:
         """Finalize the backend's PREEMPT decisions.
@@ -1280,25 +1150,6 @@ class Controller:
                 templates_by_job[row.job_id] = dispatch.run_request_template(self._run_template_cache, snap, row.job_id)
         return {jid: spec for jid, spec in templates_by_job.items() if spec is not None}
 
-    def _build_reconcile_snapshot(self, scan_timeouts: bool) -> reads.ControlSnapshot:
-        """Compose the DB-less :class:`ControlSnapshot` the backend reconciles against.
-
-        Worker-daemon backends get the live worker set, their worker-bound
-        attempt rows, the per-job run templates (so the backend builds its own
-        plans), and — when ``scan_timeouts`` — the execution-timeout rows, all
-        from one read transaction. A cluster backend that owns placement instead
-        gets the dispatch drain (``tasks_to_run`` / ``running_tasks``): the
-        controller promotes PENDING→ASSIGNED in a write transaction (the drain is
-        the only write here) and rides the result on the snapshot.
-        """
-        if self._backend_drains_dispatch:
-            return self._drain_dispatch_snapshot()
-
-        with self._db.control_read_snapshot() as snap:
-            control = reads.load_control_snapshot(snap, self._health, scan_timeouts=scan_timeouts)
-            job_specs = self._build_run_templates(snap, control.reconcile_rows)
-        return dataclasses.replace(control, job_specs=job_specs)
-
     def _drain_dispatch_snapshot(self) -> reads.ControlSnapshot:
         """Promote PENDING->ASSIGNED for a placement-owning backend and ride the drain.
 
@@ -1319,46 +1170,6 @@ class Controller:
             tasks_to_run=batch.tasks_to_run,
             running_tasks=batch.running_tasks,
         )
-
-    def _reconcile_tick(self) -> None:
-        """One polling-tick reconcile pass: snapshot, drive the backend, apply.
-
-        The sole reconcile + liveness channel. It composes the snapshot, calls
-        ``backend.reconcile`` (uniform across backends), commits the observed
-        task-state changes, folds the backend's observed health events plus any
-        kernel-derived build failures through the single ``health.apply`` site,
-        and tears down workers that crossed the failure threshold. The
-        execution-timeout deadline scan is folded in (gated by
-        ``_timeout_rate_limiter``) for worker-daemon backends.
-        """
-        if self._config.dry_run:
-            return
-
-        now = Timestamp.now()
-        scan_timeouts = self._timeout_rate_limiter.should_run()
-        snapshot = self._build_reconcile_snapshot(scan_timeouts)
-        timeout_decisions = self._timeout_decisions(snapshot.timeout_rows, now.epoch_ms())
-        # A cluster-view backend always reconciles: its reconcile does cluster-wide
-        # GC (stray-pod deletion, terminal-resource cleanup, node refresh) that must
-        # run even on an idle DB. Worker-daemon backends skip a tick with no work.
-        has_work = bool(
-            snapshot.worker_addresses or snapshot.tasks_to_run or snapshot.running_tasks or timeout_decisions
-        )
-        if not self._backend_drains_dispatch and not has_work:
-            return
-
-        result = self._task_backend.reconcile(snapshot)
-
-        reconcile_effects: ControllerEffects | None = None
-        with self._db.transaction() as cur:
-            if result.worker_results:
-                reconcile_effects = apply_reconcile(cur, result.worker_results, endpoints=self._endpoints, now=now)
-            if result.updates:
-                apply_dispatch_updates(cur, result.updates, endpoints=self._endpoints, now=now)
-            if timeout_decisions:
-                finalize(cur, timeout_decisions, endpoints=self._endpoints, now=now)
-
-        self._fold_health(result.health_events, reconcile_effects, snapshot, now)
 
     def _fold_health(
         self,
@@ -1434,36 +1245,6 @@ class Controller:
                 worker_attrs=self._worker_attrs,
             )
         self._health.forget_many(set(removed_ids) | set(auto.removed_workers))
-
-    def _run_autoscaler_once(self) -> None:
-        """Run one provisioning cycle: build the worker-status snapshot, drive
-        ``backend.autoscale`` with the cached residual demand, persist the state.
-
-        Called from the autoscaler loop thread with no ``dead_workers`` (teardown
-        rides the reconcile tick's health detection). Demand comes from the
-        scheduling pass via ``_last_residual_demand``. A capacity-managing backend
-        (k8s) no-ops and returns no state. The controller owns every DB read and
-        write; the backend never touches the database.
-        """
-        if self._config.dry_run:
-            logger.info("[DRY-RUN] Skipping autoscaler cycle")
-            return
-
-        snapshot = reads.ControlSnapshot(
-            worker_addresses={},
-            reconcile_rows=[],
-            timeout_rows=[],
-            worker_status_map=self._build_worker_status_map(),
-        )
-        result = self._task_backend.autoscale(snapshot, self._last_residual_demand, dead_workers=[])
-        if result.autoscaler_state is not None:
-            with self._db.transaction() as cur:
-                persist_autoscaler_state(cur, result.autoscaler_state)
-
-    def _build_worker_status_map(self) -> WorkerStatusMap:
-        """Build a map of worker_id to worker status for autoscaler idle tracking."""
-        with self._db.control_read_snapshot() as tx:
-            return self._worker_status_map_from_tx(tx)
 
     def _worker_status_map_from_tx(self, tx: Tx) -> WorkerStatusMap:
         """Per-worker idle/running status for the autoscale phase, read from ``tx``.

--- a/lib/iris/src/iris/cluster/controller/ops/task.py
+++ b/lib/iris/src/iris/cluster/controller/ops/task.py
@@ -64,11 +64,10 @@ def assign(
 ) -> None:
     """Commit assignments to ``tasks.state = ASSIGNED`` + ``task_attempts``.
 
-    Worker-bound dispatch is driven by the polling reconcile loop, which
-    reads ``tasks.state = ASSIGNED`` rows from a snapshot and fans out
-    Reconcile RPCs. This method does not enqueue or fan out anything;
-    callers are responsible for waking ``_polling_wake`` after commit so
-    the reconcile loop sees the new ASSIGNED rows on its next tick.
+    Worker-bound dispatch is driven by the control tick's reconcile phase, which
+    reads ``tasks.state = ASSIGNED`` rows from a snapshot and fans out Reconcile
+    RPCs. This method does not enqueue or fan out anything; the next reconcile
+    phase picks up the new ASSIGNED rows (a fresh assignment forces one).
 
     Reservation-holder assignments are admitted (they anchor the worker
     for taint-injection) but never produce a worker-bound RunTaskRequest.

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -286,10 +286,9 @@ def _spent_limiter() -> RateLimiter:
 def reconcile_once(ctrl: Controller) -> None:
     """Drive exactly one reconcile pass through the production control tick.
 
-    The standalone polling loop is gone; reconcile now runs only as a phase of
-    ``Controller._control_tick``. This forces a single reconcile-only tick:
-    ``_force_reconcile`` drives the reconcile phase while the schedule and
-    autoscale limiters never fire.
+    Reconcile runs only as a phase of ``Controller._control_tick``, so this forces
+    a reconcile-only tick: the reconcile phase fires while the schedule and
+    autoscale phases are held off.
     """
     ctrl._force_reconcile = True
     ctrl._control_tick(
@@ -303,10 +302,9 @@ def reconcile_once(ctrl: Controller) -> None:
 def autoscale_once(ctrl: Controller) -> None:
     """Drive one autoscale pass through the production control tick.
 
-    The standalone autoscaler loop is gone; autoscale now runs only as a phase of
-    ``Controller._control_tick`` (always paired with a fresh schedule). In dry-run
-    the tick short-circuits to the schedule-only path, so the autoscale backend
-    call is suppressed — exactly what the dry-run test asserts.
+    Autoscale runs only as a phase of ``Controller._control_tick``, always paired
+    with a fresh schedule. In dry-run the tick short-circuits to the schedule-only
+    path, so the autoscale backend call is suppressed.
     """
     ctrl._force_reconcile = False
     ctrl._control_tick(

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -67,7 +67,7 @@ from iris.cluster.service_mode import ServiceMode
 from iris.cluster.types import TERMINAL_TASK_STATES, JobName, WorkerId, is_job_finished
 from iris.rpc import config_pb2, controller_pb2, job_pb2
 from iris.time_proto import duration_to_proto
-from rigging.timing import Duration, Timestamp
+from rigging.timing import Duration, RateLimiter, Timestamp
 from sqlalchemy import func, select
 from sqlalchemy import update as sa_update
 
@@ -274,6 +274,47 @@ def make_controller(tmp_path):
             errors.append(exc)
     if errors:
         raise errors[0]
+
+
+def _spent_limiter() -> RateLimiter:
+    """A ``RateLimiter`` whose ``should_run()`` returns False (already ran, long interval)."""
+    limiter = RateLimiter(interval_seconds=1e9)
+    limiter.mark_run()
+    return limiter
+
+
+def reconcile_once(ctrl: Controller) -> None:
+    """Drive exactly one reconcile pass through the production control tick.
+
+    The standalone polling loop is gone; reconcile now runs only as a phase of
+    ``Controller._control_tick``. This forces a single reconcile-only tick:
+    ``_force_reconcile`` drives the reconcile phase while the schedule and
+    autoscale limiters never fire.
+    """
+    ctrl._force_reconcile = True
+    ctrl._control_tick(
+        woken=False,
+        schedule_limiter=_spent_limiter(),
+        reconcile_limiter=_spent_limiter(),
+        autoscale_limiter=_spent_limiter(),
+    )
+
+
+def autoscale_once(ctrl: Controller) -> None:
+    """Drive one autoscale pass through the production control tick.
+
+    The standalone autoscaler loop is gone; autoscale now runs only as a phase of
+    ``Controller._control_tick`` (always paired with a fresh schedule). In dry-run
+    the tick short-circuits to the schedule-only path, so the autoscale backend
+    call is suppressed — exactly what the dry-run test asserts.
+    """
+    ctrl._force_reconcile = False
+    ctrl._control_tick(
+        woken=False,
+        schedule_limiter=_spent_limiter(),
+        reconcile_limiter=_spent_limiter(),
+        autoscale_limiter=RateLimiter(interval_seconds=0.0),
+    )
 
 
 def make_test_entrypoint() -> job_pb2.RuntimeEntrypoint:

--- a/lib/iris/tests/cluster/controller/test_dry_run.py
+++ b/lib/iris/tests/cluster/controller/test_dry_run.py
@@ -11,6 +11,7 @@ from iris.rpc import job_pb2
 
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.conftest import (
+    autoscale_once,
     make_job_request,
     make_worker_metadata,
     query_tasks_for_job,
@@ -58,7 +59,9 @@ def test_dry_run_autoscaler_skipped_entirely(dry_run_controller):
     controller = dry_run_controller
     controller._task_backend.autoscale = MagicMock()
 
-    controller._run_autoscaler_once()
+    # In dry-run the control tick short-circuits to the schedule-only path, so
+    # the autoscale phase never reaches the backend even when forced.
+    autoscale_once(controller)
 
     controller._task_backend.autoscale.assert_not_called()
 

--- a/lib/iris/tests/cluster/controller/test_reconcile.py
+++ b/lib/iris/tests/cluster/controller/test_reconcile.py
@@ -10,8 +10,8 @@ Three layers, exercised in order:
 2. **Wire & dispatch** — ``RpcTaskBackend.reconcile`` fans out via a
    fake stub factory and synthesizes ``WorkerReconcileResult.observations``.
 3. **Apply + e2e** — ``apply_reconcile`` against real SQLite DB state, plus a
-   handful of end-to-end convergence ticks driven through
-   ``Controller._reconcile_tick``.
+   handful of end-to-end convergence ticks driven through the production control
+   tick's reconcile phase (``reconcile_once``).
 """
 
 from __future__ import annotations
@@ -70,6 +70,7 @@ from .conftest import (
     query_job,
     query_task,
     query_worker,
+    reconcile_once,
     register_worker,
     submit_job,
 )
@@ -1151,7 +1152,7 @@ def test_e2e_converges_to_succeeded(make_controller):
         ops.task.assign(cur, [Assignment(task_id=task_id, worker_id=wid)], health=state._health)
 
     # Tick 1: ASSIGNED — controller dispatches the inline spec.
-    ctrl._reconcile_tick()
+    reconcile_once(ctrl)
     tick1_desired = list(provider.calls[0][0][0].request.desired)
     assert len(tick1_desired) == 1
     assert tick1_desired[0].HasField("run") and tick1_desired[0].run.HasField(
@@ -1160,11 +1161,11 @@ def test_e2e_converges_to_succeeded(make_controller):
     assert tick1_desired[0].attempt_uid, "controller must emit a non-empty attempt_uid"
 
     # Tick 2: worker reports RUNNING.
-    ctrl._reconcile_tick()
+    reconcile_once(ctrl)
     assert query_task(state, task_id).state == job_pb2.TASK_STATE_RUNNING
 
     # Tick 3: subsequent run intents must not carry inline spec (cache-hit invariant).
-    ctrl._reconcile_tick()
+    reconcile_once(ctrl)
     tick3_desired = list(provider.calls[2][0][0].request.desired)
     assert tick3_desired and tick3_desired[0].HasField("run")
     assert not tick3_desired[0].run.HasField("request"), "subsequent ticks must not carry inline spec"
@@ -1202,8 +1203,8 @@ def test_e2e_missing_observation_on_assigned_task_retries_to_pending(make_contro
     with state._db.transaction() as cur:
         ops.task.assign(cur, [Assignment(task_id=task_id, worker_id=wid)], health=state._health)
 
-    ctrl._reconcile_tick()
-    ctrl._reconcile_tick()
+    reconcile_once(ctrl)
+    reconcile_once(ctrl)
 
     task = query_task(state, task_id)
     assert task.state == job_pb2.TASK_STATE_PENDING
@@ -1327,13 +1328,13 @@ def test_reconcile_failure_tears_down_worker_without_ping_loop(make_controller, 
 
     # One failure short of the threshold: still present, still tracked, no teardown.
     for _ in range(_THRESHOLD - 1):
-        ctrl._reconcile_tick()
+        reconcile_once(ctrl)
     assert query_worker(state, wid) is not None
     assert ctrl._health.liveness(wid).consecutive_failures == _THRESHOLD - 1
     assert provider.autoscale_calls == []
 
     # The threshold-crossing tick fails and tears the worker down.
-    ctrl._reconcile_tick()
+    reconcile_once(ctrl)
     assert provider.autoscale_calls == [[wid]]
     assert query_worker(state, wid) is None, "failed worker row should be removed"
     assert wid not in ctrl._health.all(), "failed worker should be forgotten from the tracker"
@@ -1360,7 +1361,7 @@ def test_reconcile_failure_reaps_slice_siblings(make_controller):
     sibling = register_worker(state, _W2, f"{_W2}:8080", make_worker_metadata())
 
     for _ in range(_THRESHOLD):
-        ctrl._reconcile_tick()
+        reconcile_once(ctrl)
 
     assert provider.autoscale_calls == [[dead]]
     assert query_worker(state, dead) is None


### PR DESCRIPTION
The controller's single_control_tick flag gated two structures: the unified
single-driver control tick (default True since #6344) and a legacy fallback that
ran scheduling, polling/reconcile, and autoscale on three independent loop
threads. The flag was a plain dataclass default, never a wire/config field, and
nothing set it False — the legacy path was unreachable outside editing source and
has shipped a release in production without regression.

This deletes the flag and the entire three-thread path:

- the _run_scheduling_loop / _run_polling_loop / _run_autoscaler_loop methods and
  their _scheduling_thread / _polling_thread / _autoscaler_thread fields
- the cross-thread _last_residual_demand handoff (the single tick passes
  sched_result.residual_demand inline)
- the now-vestigial _scheduling_wake / _polling_wake events (the single tick uses
  _tick_wake only) and scheduler_max_interval (used only by the deleted adaptive
  backoff)

_reconcile_tick / _build_reconcile_snapshot / _run_autoscaler_once /
_build_worker_status_map existed only to drive the legacy loops and as test entry
points. Tests now drive the production _control_tick directly through new
reconcile_once / autoscale_once conftest helpers, so reconcile and autoscale are
exercised through the same code path that runs in production rather than a
parallel test-only one.

Net -175 lines. The full controller suite (1030 tests), the lifecycle/integration
tests, and a non-dry-run live control-loop start/stop check all pass.

Fixes #6434