### PR TITLE
[iris] Delete vestigial worker Ping RPC

### DIFF
--- a/lib/iris/src/iris/cluster/worker/service.py
+++ b/lib/iris/src/iris/cluster/worker/service.py
@@ -30,7 +30,6 @@ class TaskProvider(Protocol):
     def get_task(self, task_id: str, attempt_id: int = -1) -> TaskInfo | None: ...
     def list_tasks(self) -> list[TaskInfo]: ...
     def kill_task(self, task_id: str, term_timeout_ms: int = 5000) -> bool: ...
-    def handle_ping(self, request: worker_pb2.Worker.PingRequest) -> worker_pb2.Worker.PingResponse: ...
     def handle_reconcile(self, request: worker_pb2.Worker.ReconcileRequest) -> worker_pb2.Worker.ReconcileResponse: ...
     def capture_and_log_profile(
         self,
@@ -140,10 +139,6 @@ class WorkerServiceImpl:
                 raise ConnectError(Code.INVALID_ARGUMENT, "command is required")
             timeout_seconds = request.timeout_seconds if request.timeout_seconds != 0 else 60
             return self._provider.exec_in_container(request.task_id, list(request.command), timeout_seconds)
-
-    def ping(self, request: worker_pb2.Worker.PingRequest, _ctx: RequestContext) -> worker_pb2.Worker.PingResponse:
-        with rpc_error_handler("ping"):
-            return self._provider.handle_ping(request)
 
     def reconcile(
         self, request: worker_pb2.Worker.ReconcileRequest, _ctx: RequestContext

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -823,33 +823,6 @@ class Worker:
         )
         table.write([stat])
 
-    def handle_ping(self, request: worker_pb2.Worker.PingRequest) -> worker_pb2.Worker.PingResponse:
-        """Vestigial keep-alive for rolling deploys.
-
-        The new controller never calls Ping — Reconcile is the keep-alive. This
-        handler exists only so a pre-upgrade controller's ping loop keeps
-        succeeding (heartbeat reset + truthful health bit) against an upgraded
-        worker until the controller itself is rolled. Remove once the fleet is
-        fully migrated.
-        """
-        if rule := chaos("worker.ping"):
-            if rule.delay_seconds > 0:
-                time.sleep(rule.delay_seconds)
-            if rule.error:
-                raise rule.error
-            if not rule.delay_seconds:
-                raise RuntimeError("chaos: worker.ping")
-        self._heartbeat_deadline = Deadline.from_seconds(self._config.heartbeat_timeout.to_seconds())
-        resource_snapshot = self._collect_resource_metrics()
-        health = check_worker_health(disk_path=str(self._cache_dir))
-        if not health.healthy:
-            logger.warning("Worker health check failed: %s", health.error)
-        self._emit_worker_stat(resource_snapshot)
-        return worker_pb2.Worker.PingResponse(
-            healthy=health.healthy,
-            health_error=health.error,
-        )
-
     def handle_reconcile(self, request: worker_pb2.Worker.ReconcileRequest) -> worker_pb2.Worker.ReconcileResponse:
         """Process desired state from the controller and return observed state.
 

--- a/lib/iris/src/iris/rpc/worker.proto
+++ b/lib/iris/src/iris/rpc/worker.proto
@@ -66,20 +66,6 @@ message Worker {
     string error = 4;               // Non-empty if exec setup failed
   }
 
-  // --- Worker lifecycle / task RPCs ---
-
-  // Vestigial keep-alive. The controller no longer pings — Reconcile is the
-  // sole controller->worker channel and keep-alive. This RPC remains only so a
-  // pre-upgrade controller's ping loop keeps succeeding against an upgraded
-  // worker during a rolling deploy (workers first, controller second). Delete
-  // once the whole fleet is on the new controller.
-  message PingRequest {}
-  message PingResponse {
-    reserved 1;  // was: WorkerResourceSnapshot resource_snapshot (now in iris.worker stats)
-    bool healthy = 2;
-    string health_error = 3;
-  }
-
   // ============================================================
   // RECONCILE RPC (controller -> worker, unary)
   // ============================================================
@@ -161,10 +147,6 @@ service WorkerService {
   rpc ExecInContainer(Worker.ExecInContainerRequest) returns (Worker.ExecInContainerResponse);
 
   // --- Worker lifecycle / task RPCs (controller -> worker) ---
-  // Vestigial: a pre-upgrade controller's ping loop calls this against an
-  // upgraded worker during a rolling deploy. The new controller never calls it.
-  // Delete once the fleet is fully migrated.
-  rpc Ping(Worker.PingRequest) returns (Worker.PingResponse);
   // Reconcile RPC: controller -> worker, unary. The sole controller->worker
   // channel and the worker's keep-alive. One request carries the controller's
   // complete desired attempt set for this worker; one response carries the

--- a/lib/iris/src/iris/rpc/worker_connect.py
+++ b/lib/iris/src/iris/rpc/worker_connect.py
@@ -36,9 +36,6 @@ class WorkerService(Protocol):
     async def exec_in_container(self, request: worker__pb2.Worker.ExecInContainerRequest, ctx: RequestContext) -> worker__pb2.Worker.ExecInContainerResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
 
-    async def ping(self, request: worker__pb2.Worker.PingRequest, ctx: RequestContext) -> worker__pb2.Worker.PingResponse:
-        raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
-
     async def reconcile(self, request: worker__pb2.Worker.ReconcileRequest, ctx: RequestContext) -> worker__pb2.Worker.ReconcileResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
 
@@ -107,16 +104,6 @@ class WorkerServiceASGIApplication(ConnectASGIApplication[WorkerService]):
                         idempotency_level=IdempotencyLevel.UNKNOWN,
                     ),
                     function=svc.exec_in_container,
-                ),
-                "/iris.cluster.WorkerService/Ping": Endpoint.unary(
-                    method=MethodInfo(
-                        name="Ping",
-                        service_name="iris.cluster.WorkerService",
-                        input=worker__pb2.Worker.PingRequest,
-                        output=worker__pb2.Worker.PingResponse,
-                        idempotency_level=IdempotencyLevel.UNKNOWN,
-                    ),
-                    function=svc.ping,
                 ),
                 "/iris.cluster.WorkerService/Reconcile": Endpoint.unary(
                     method=MethodInfo(
@@ -261,26 +248,6 @@ class WorkerServiceClient(ConnectClient):
             timeout_ms=timeout_ms,
         )
 
-    async def ping(
-        self,
-        request: worker__pb2.Worker.PingRequest,
-        *,
-        headers: Headers | Mapping[str, str] | None = None,
-        timeout_ms: int | None = None,
-    ) -> worker__pb2.Worker.PingResponse:
-        return await self.execute_unary(
-            request=request,
-            method=MethodInfo(
-                name="Ping",
-                service_name="iris.cluster.WorkerService",
-                input=worker__pb2.Worker.PingRequest,
-                output=worker__pb2.Worker.PingResponse,
-                idempotency_level=IdempotencyLevel.UNKNOWN,
-            ),
-            headers=headers,
-            timeout_ms=timeout_ms,
-        )
-
     async def reconcile(
         self,
         request: worker__pb2.Worker.ReconcileRequest,
@@ -314,8 +281,6 @@ class WorkerServiceSync(Protocol):
     def get_process_status(self, request: job__pb2.GetProcessStatusRequest, ctx: RequestContext) -> job__pb2.GetProcessStatusResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
     def exec_in_container(self, request: worker__pb2.Worker.ExecInContainerRequest, ctx: RequestContext) -> worker__pb2.Worker.ExecInContainerResponse:
-        raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
-    def ping(self, request: worker__pb2.Worker.PingRequest, ctx: RequestContext) -> worker__pb2.Worker.PingResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
     def reconcile(self, request: worker__pb2.Worker.ReconcileRequest, ctx: RequestContext) -> worker__pb2.Worker.ReconcileResponse:
         raise ConnectError(Code.UNIMPLEMENTED, "Not implemented")
@@ -384,16 +349,6 @@ class WorkerServiceWSGIApplication(ConnectWSGIApplication):
                         idempotency_level=IdempotencyLevel.UNKNOWN,
                     ),
                     function=service.exec_in_container,
-                ),
-                "/iris.cluster.WorkerService/Ping": EndpointSync.unary(
-                    method=MethodInfo(
-                        name="Ping",
-                        service_name="iris.cluster.WorkerService",
-                        input=worker__pb2.Worker.PingRequest,
-                        output=worker__pb2.Worker.PingResponse,
-                        idempotency_level=IdempotencyLevel.UNKNOWN,
-                    ),
-                    function=service.ping,
                 ),
                 "/iris.cluster.WorkerService/Reconcile": EndpointSync.unary(
                     method=MethodInfo(
@@ -532,26 +487,6 @@ class WorkerServiceClientSync(ConnectClientSync):
                 service_name="iris.cluster.WorkerService",
                 input=worker__pb2.Worker.ExecInContainerRequest,
                 output=worker__pb2.Worker.ExecInContainerResponse,
-                idempotency_level=IdempotencyLevel.UNKNOWN,
-            ),
-            headers=headers,
-            timeout_ms=timeout_ms,
-        )
-
-    def ping(
-        self,
-        request: worker__pb2.Worker.PingRequest,
-        *,
-        headers: Headers | Mapping[str, str] | None = None,
-        timeout_ms: int | None = None,
-    ) -> worker__pb2.Worker.PingResponse:
-        return self.execute_unary(
-            request=request,
-            method=MethodInfo(
-                name="Ping",
-                service_name="iris.cluster.WorkerService",
-                input=worker__pb2.Worker.PingRequest,
-                output=worker__pb2.Worker.PingResponse,
                 idempotency_level=IdempotencyLevel.UNKNOWN,
             ),
             headers=headers,

--- a/lib/iris/src/iris/rpc/worker_pb2.py
+++ b/lib/iris/src/iris/rpc/worker_pb2.py
@@ -26,7 +26,7 @@ from . import job_pb2 as job__pb2
 from . import time_pb2 as time__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cworker.proto\x12\x0ciris.cluster\x1a\tjob.proto\x1a\ntime.proto\"\x8d\x0f\n\x06Worker\x1a\x35\n\x14GetTaskStatusRequest\x12\x17\n\x07task_id\x18\x01 \x01(\tR\x06taskIdJ\x04\x08\x02\x10\x03\x1a\x12\n\x10ListTasksRequest\x1a?\n\x11ListTasksResponse\x12*\n\x05tasks\x18\x01 \x03(\x0b\x32\x14.iris.job.TaskStatusR\x05tasks\x1a\x62\n\x0fKillTaskRequest\x12\x17\n\x07task_id\x18\x01 \x01(\tR\x06taskId\x12\x36\n\x0cterm_timeout\x18\x02 \x01(\x0b\x32\x13.iris.time.DurationR\x0btermTimeout\x1a|\n\x0eHealthResponse\x12\x18\n\x07healthy\x18\x01 \x01(\x08R\x07healthy\x12+\n\x06uptime\x18\x02 \x01(\x0b\x32\x13.iris.time.DurationR\x06uptime\x12#\n\rrunning_tasks\x18\x03 \x01(\x05R\x0crunningTasks\x1at\n\x16\x45xecInContainerRequest\x12\x17\n\x07task_id\x18\x01 \x01(\tR\x06taskId\x12\x18\n\x07\x63ommand\x18\x02 \x03(\tR\x07\x63ommand\x12\'\n\x0ftimeout_seconds\x18\x03 \x01(\x05R\x0etimeoutSeconds\x1a|\n\x17\x45xecInContainerResponse\x12\x1b\n\texit_code\x18\x01 \x01(\x05R\x08\x65xitCode\x12\x16\n\x06stdout\x18\x02 \x01(\tR\x06stdout\x12\x16\n\x06stderr\x18\x03 \x01(\tR\x06stderr\x12\x14\n\x05\x65rror\x18\x04 \x01(\tR\x05\x65rror\x1a\r\n\x0bPingRequest\x1aQ\n\x0cPingResponse\x12\x18\n\x07healthy\x18\x02 \x01(\x08R\x07healthy\x12!\n\x0chealth_error\x18\x03 \x01(\tR\x0bhealthErrorJ\x04\x08\x01\x10\x02\x1an\n\x10ReconcileRequest\x12\x1b\n\tworker_id\x18\x01 \x01(\tR\x08workerId\x12=\n\x07\x64\x65sired\x18\x02 \x03(\x0b\x32#.iris.cluster.Worker.DesiredAttemptR\x07\x64\x65sired\x1a\xb0\x01\n\x11ReconcileResponse\x12\x1b\n\tworker_id\x18\x01 \x01(\tR\x08workerId\x12\x43\n\x08observed\x18\x02 \x03(\x0b\x32\'.iris.cluster.Worker.AttemptObservationR\x08observed\x12\x39\n\x06health\x18\x03 \x01(\x0b\x32!.iris.cluster.Worker.WorkerHealthR\x06health\x1a\xb4\x01\n\x0e\x44\x65siredAttempt\x12\x1f\n\x0b\x61ttempt_uid\x18\x01 \x01(\tR\nattemptUid\x12\x34\n\x03run\x18\n \x01(\x0b\x32 .iris.cluster.Worker.AttemptSpecH\x00R\x03run\x12\x35\n\x04stop\x18\x0b \x01(\x0e\x32\x1f.iris.cluster.Worker.StopReasonH\x00R\x04stopB\x08\n\x06intentJ\x04\x08\x64\x10\x65J\x04\x08\x65\x10\x66\x1a\x41\n\x0b\x41ttemptSpec\x12\x32\n\x07request\x18\x01 \x01(\x0b\x32\x18.iris.job.RunTaskRequestR\x07request\x1a\xb9\x02\n\x12\x41ttemptObservation\x12\x1f\n\x0b\x61ttempt_uid\x18\x01 \x01(\tR\nattemptUid\x12)\n\x05state\x18\x02 \x01(\x0e\x32\x13.iris.job.TaskStateR\x05state\x12\x1b\n\texit_code\x18\x03 \x01(\x05R\x08\x65xitCode\x12\x14\n\x05\x65rror\x18\x04 \x01(\tR\x05\x65rror\x12!\n\x0c\x63ontainer_id\x18\x05 \x01(\tR\x0b\x63ontainerId\x12\x35\n\x0b\x66inished_at\x18\x06 \x01(\x0b\x32\x14.iris.time.TimestampR\nfinishedAt\x12>\n\x0eresource_usage\x18\x07 \x01(\x0b\x32\x17.iris.job.ResourceUsageR\rresourceUsageJ\x04\x08\x64\x10\x65J\x04\x08\x65\x10\x66\x1a\x8b\x01\n\x0cWorkerHealth\x12\x18\n\x07healthy\x18\x01 \x01(\x08R\x07healthy\x12!\n\x0chealth_error\x18\x02 \x01(\tR\x0bhealthError\x12>\n\tresources\x18\x03 \x01(\x0b\x32 .iris.job.WorkerResourceSnapshotR\tresources\"\xd7\x01\n\nStopReason\x12\x1b\n\x17STOP_REASON_UNSPECIFIED\x10\x00\x12\x19\n\x15STOP_REASON_CANCELLED\x10\x01\x12\x19\n\x15STOP_REASON_PREEMPTED\x10\x02\x12\x1a\n\x16STOP_REASON_SUPERSEDED\x10\x03\x12\x1e\n\x1aSTOP_REASON_JOB_TERMINATED\x10\x04\x12\x1c\n\x18STOP_REASON_TASK_TIMEOUT\x10\x05\x12\x1c\n\x18STOP_REASON_WORKER_DRAIN\x10\x06\x32\xc0\x05\n\rWorkerService\x12P\n\rGetTaskStatus\x12).iris.cluster.Worker.GetTaskStatusRequest\x1a\x14.iris.job.TaskStatus\x12Z\n\tListTasks\x12%.iris.cluster.Worker.ListTasksRequest\x1a&.iris.cluster.Worker.ListTasksResponse\x12\x43\n\x0bHealthCheck\x12\x0f.iris.job.Empty\x1a#.iris.cluster.Worker.HealthResponse\x12J\n\x0bProfileTask\x12\x1c.iris.job.ProfileTaskRequest\x1a\x1d.iris.job.ProfileTaskResponse\x12Y\n\x10GetProcessStatus\x12!.iris.job.GetProcessStatusRequest\x1a\".iris.job.GetProcessStatusResponse\x12l\n\x0f\x45xecInContainer\x12+.iris.cluster.Worker.ExecInContainerRequest\x1a,.iris.cluster.Worker.ExecInContainerResponse\x12K\n\x04Ping\x12 .iris.cluster.Worker.PingRequest\x1a!.iris.cluster.Worker.PingResponse\x12Z\n\tReconcile\x12%.iris.cluster.Worker.ReconcileRequest\x1a&.iris.cluster.Worker.ReconcileResponseBp\n\x10\x63om.iris.clusterB\x0bWorkerProtoP\x01\xa2\x02\x03ICX\xaa\x02\x0cIris.Cluster\xca\x02\x0cIris\\Cluster\xe2\x02\x18Iris\\Cluster\\GPBMetadata\xea\x02\rIris::Clusterb\x08\x65\x64itionsp\xe8\x07')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x0cworker.proto\x12\x0ciris.cluster\x1a\tjob.proto\x1a\ntime.proto\"\xab\x0e\n\x06Worker\x1a\x35\n\x14GetTaskStatusRequest\x12\x17\n\x07task_id\x18\x01 \x01(\tR\x06taskIdJ\x04\x08\x02\x10\x03\x1a\x12\n\x10ListTasksRequest\x1a?\n\x11ListTasksResponse\x12*\n\x05tasks\x18\x01 \x03(\x0b\x32\x14.iris.job.TaskStatusR\x05tasks\x1a\x62\n\x0fKillTaskRequest\x12\x17\n\x07task_id\x18\x01 \x01(\tR\x06taskId\x12\x36\n\x0cterm_timeout\x18\x02 \x01(\x0b\x32\x13.iris.time.DurationR\x0btermTimeout\x1a|\n\x0eHealthResponse\x12\x18\n\x07healthy\x18\x01 \x01(\x08R\x07healthy\x12+\n\x06uptime\x18\x02 \x01(\x0b\x32\x13.iris.time.DurationR\x06uptime\x12#\n\rrunning_tasks\x18\x03 \x01(\x05R\x0crunningTasks\x1at\n\x16\x45xecInContainerRequest\x12\x17\n\x07task_id\x18\x01 \x01(\tR\x06taskId\x12\x18\n\x07\x63ommand\x18\x02 \x03(\tR\x07\x63ommand\x12\'\n\x0ftimeout_seconds\x18\x03 \x01(\x05R\x0etimeoutSeconds\x1a|\n\x17\x45xecInContainerResponse\x12\x1b\n\texit_code\x18\x01 \x01(\x05R\x08\x65xitCode\x12\x16\n\x06stdout\x18\x02 \x01(\tR\x06stdout\x12\x16\n\x06stderr\x18\x03 \x01(\tR\x06stderr\x12\x14\n\x05\x65rror\x18\x04 \x01(\tR\x05\x65rror\x1an\n\x10ReconcileRequest\x12\x1b\n\tworker_id\x18\x01 \x01(\tR\x08workerId\x12=\n\x07\x64\x65sired\x18\x02 \x03(\x0b\x32#.iris.cluster.Worker.DesiredAttemptR\x07\x64\x65sired\x1a\xb0\x01\n\x11ReconcileResponse\x12\x1b\n\tworker_id\x18\x01 \x01(\tR\x08workerId\x12\x43\n\x08observed\x18\x02 \x03(\x0b\x32\'.iris.cluster.Worker.AttemptObservationR\x08observed\x12\x39\n\x06health\x18\x03 \x01(\x0b\x32!.iris.cluster.Worker.WorkerHealthR\x06health\x1a\xb4\x01\n\x0e\x44\x65siredAttempt\x12\x1f\n\x0b\x61ttempt_uid\x18\x01 \x01(\tR\nattemptUid\x12\x34\n\x03run\x18\n \x01(\x0b\x32 .iris.cluster.Worker.AttemptSpecH\x00R\x03run\x12\x35\n\x04stop\x18\x0b \x01(\x0e\x32\x1f.iris.cluster.Worker.StopReasonH\x00R\x04stopB\x08\n\x06intentJ\x04\x08\x64\x10\x65J\x04\x08\x65\x10\x66\x1a\x41\n\x0b\x41ttemptSpec\x12\x32\n\x07request\x18\x01 \x01(\x0b\x32\x18.iris.job.RunTaskRequestR\x07request\x1a\xb9\x02\n\x12\x41ttemptObservation\x12\x1f\n\x0b\x61ttempt_uid\x18\x01 \x01(\tR\nattemptUid\x12)\n\x05state\x18\x02 \x01(\x0e\x32\x13.iris.job.TaskStateR\x05state\x12\x1b\n\texit_code\x18\x03 \x01(\x05R\x08\x65xitCode\x12\x14\n\x05\x65rror\x18\x04 \x01(\tR\x05\x65rror\x12!\n\x0c\x63ontainer_id\x18\x05 \x01(\tR\x0b\x63ontainerId\x12\x35\n\x0b\x66inished_at\x18\x06 \x01(\x0b\x32\x14.iris.time.TimestampR\nfinishedAt\x12>\n\x0eresource_usage\x18\x07 \x01(\x0b\x32\x17.iris.job.ResourceUsageR\rresourceUsageJ\x04\x08\x64\x10\x65J\x04\x08\x65\x10\x66\x1a\x8b\x01\n\x0cWorkerHealth\x12\x18\n\x07healthy\x18\x01 \x01(\x08R\x07healthy\x12!\n\x0chealth_error\x18\x02 \x01(\tR\x0bhealthError\x12>\n\tresources\x18\x03 \x01(\x0b\x32 .iris.job.WorkerResourceSnapshotR\tresources\"\xd7\x01\n\nStopReason\x12\x1b\n\x17STOP_REASON_UNSPECIFIED\x10\x00\x12\x19\n\x15STOP_REASON_CANCELLED\x10\x01\x12\x19\n\x15STOP_REASON_PREEMPTED\x10\x02\x12\x1a\n\x16STOP_REASON_SUPERSEDED\x10\x03\x12\x1e\n\x1aSTOP_REASON_JOB_TERMINATED\x10\x04\x12\x1c\n\x18STOP_REASON_TASK_TIMEOUT\x10\x05\x12\x1c\n\x18STOP_REASON_WORKER_DRAIN\x10\x06\x32\xf3\x04\n\rWorkerService\x12P\n\rGetTaskStatus\x12).iris.cluster.Worker.GetTaskStatusRequest\x1a\x14.iris.job.TaskStatus\x12Z\n\tListTasks\x12%.iris.cluster.Worker.ListTasksRequest\x1a&.iris.cluster.Worker.ListTasksResponse\x12\x43\n\x0bHealthCheck\x12\x0f.iris.job.Empty\x1a#.iris.cluster.Worker.HealthResponse\x12J\n\x0bProfileTask\x12\x1c.iris.job.ProfileTaskRequest\x1a\x1d.iris.job.ProfileTaskResponse\x12Y\n\x10GetProcessStatus\x12!.iris.job.GetProcessStatusRequest\x1a\".iris.job.GetProcessStatusResponse\x12l\n\x0f\x45xecInContainer\x12+.iris.cluster.Worker.ExecInContainerRequest\x1a,.iris.cluster.Worker.ExecInContainerResponse\x12Z\n\tReconcile\x12%.iris.cluster.Worker.ReconcileRequest\x1a&.iris.cluster.Worker.ReconcileResponseBp\n\x10\x63om.iris.clusterB\x0bWorkerProtoP\x01\xa2\x02\x03ICX\xaa\x02\x0cIris.Cluster\xca\x02\x0cIris\\Cluster\xe2\x02\x18Iris\\Cluster\\GPBMetadata\xea\x02\rIris::Clusterb\x08\x65\x64itionsp\xe8\x07')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -35,7 +35,7 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\020com.iris.clusterB\013WorkerProtoP\001\242\002\003ICX\252\002\014Iris.Cluster\312\002\014Iris\\Cluster\342\002\030Iris\\Cluster\\GPBMetadata\352\002\rIris::Cluster'
   _globals['_WORKER']._serialized_start=54
-  _globals['_WORKER']._serialized_end=1987
+  _globals['_WORKER']._serialized_end=1889
   _globals['_WORKER_GETTASKSTATUSREQUEST']._serialized_start=64
   _globals['_WORKER_GETTASKSTATUSREQUEST']._serialized_end=117
   _globals['_WORKER_LISTTASKSREQUEST']._serialized_start=119
@@ -50,24 +50,20 @@ if not _descriptor._USE_C_DESCRIPTORS:
   _globals['_WORKER_EXECINCONTAINERREQUEST']._serialized_end=546
   _globals['_WORKER_EXECINCONTAINERRESPONSE']._serialized_start=548
   _globals['_WORKER_EXECINCONTAINERRESPONSE']._serialized_end=672
-  _globals['_WORKER_PINGREQUEST']._serialized_start=674
-  _globals['_WORKER_PINGREQUEST']._serialized_end=687
-  _globals['_WORKER_PINGRESPONSE']._serialized_start=689
-  _globals['_WORKER_PINGRESPONSE']._serialized_end=770
-  _globals['_WORKER_RECONCILEREQUEST']._serialized_start=772
-  _globals['_WORKER_RECONCILEREQUEST']._serialized_end=882
-  _globals['_WORKER_RECONCILERESPONSE']._serialized_start=885
-  _globals['_WORKER_RECONCILERESPONSE']._serialized_end=1061
-  _globals['_WORKER_DESIREDATTEMPT']._serialized_start=1064
-  _globals['_WORKER_DESIREDATTEMPT']._serialized_end=1244
-  _globals['_WORKER_ATTEMPTSPEC']._serialized_start=1246
-  _globals['_WORKER_ATTEMPTSPEC']._serialized_end=1311
-  _globals['_WORKER_ATTEMPTOBSERVATION']._serialized_start=1314
-  _globals['_WORKER_ATTEMPTOBSERVATION']._serialized_end=1627
-  _globals['_WORKER_WORKERHEALTH']._serialized_start=1630
-  _globals['_WORKER_WORKERHEALTH']._serialized_end=1769
-  _globals['_WORKER_STOPREASON']._serialized_start=1772
-  _globals['_WORKER_STOPREASON']._serialized_end=1987
-  _globals['_WORKERSERVICE']._serialized_start=1990
-  _globals['_WORKERSERVICE']._serialized_end=2694
+  _globals['_WORKER_RECONCILEREQUEST']._serialized_start=674
+  _globals['_WORKER_RECONCILEREQUEST']._serialized_end=784
+  _globals['_WORKER_RECONCILERESPONSE']._serialized_start=787
+  _globals['_WORKER_RECONCILERESPONSE']._serialized_end=963
+  _globals['_WORKER_DESIREDATTEMPT']._serialized_start=966
+  _globals['_WORKER_DESIREDATTEMPT']._serialized_end=1146
+  _globals['_WORKER_ATTEMPTSPEC']._serialized_start=1148
+  _globals['_WORKER_ATTEMPTSPEC']._serialized_end=1213
+  _globals['_WORKER_ATTEMPTOBSERVATION']._serialized_start=1216
+  _globals['_WORKER_ATTEMPTOBSERVATION']._serialized_end=1529
+  _globals['_WORKER_WORKERHEALTH']._serialized_start=1532
+  _globals['_WORKER_WORKERHEALTH']._serialized_end=1671
+  _globals['_WORKER_STOPREASON']._serialized_start=1674
+  _globals['_WORKER_STOPREASON']._serialized_end=1889
+  _globals['_WORKERSERVICE']._serialized_start=1892
+  _globals['_WORKERSERVICE']._serialized_end=2519
 # @@protoc_insertion_point(module_scope)

--- a/lib/iris/src/iris/rpc/worker_pb2.pyi
+++ b/lib/iris/src/iris/rpc/worker_pb2.pyi
@@ -76,16 +76,6 @@ class Worker(_message.Message):
         stderr: str
         error: str
         def __init__(self, exit_code: _Optional[int] = ..., stdout: _Optional[str] = ..., stderr: _Optional[str] = ..., error: _Optional[str] = ...) -> None: ...
-    class PingRequest(_message.Message):
-        __slots__ = ()
-        def __init__(self) -> None: ...
-    class PingResponse(_message.Message):
-        __slots__ = ("healthy", "health_error")
-        HEALTHY_FIELD_NUMBER: _ClassVar[int]
-        HEALTH_ERROR_FIELD_NUMBER: _ClassVar[int]
-        healthy: bool
-        health_error: str
-        def __init__(self, healthy: _Optional[bool] = ..., health_error: _Optional[str] = ...) -> None: ...
     class ReconcileRequest(_message.Message):
         __slots__ = ("worker_id", "desired")
         WORKER_ID_FIELD_NUMBER: _ClassVar[int]

--- a/lib/iris/tests/e2e/test_chaos.py
+++ b/lib/iris/tests/e2e/test_chaos.py
@@ -203,14 +203,6 @@ def test_dispatch_permanent_failure(cluster):
     assert status.state in (job_pb2.JOB_STATE_FAILED, job_pb2.JOB_STATE_UNSCHEDULABLE)
 
 
-# The three `worker.ping` chaos tests (test_ping_temporary_failure,
-# test_ping_permanent_failure, test_ping_survives_transient_delay) were deleted:
-# `handle_ping` (their injection seam) no longer exists, and they were redundant
-# with the `controller.reconcile` threshold tests below, which cover the
-# below-threshold-recovers and at-threshold-kills paths via the live reconcile
-# keep-alive seam.
-
-
 # ---------------------------------------------------------------------------
 # Reconcile-RPC threshold: a worker whose Reconcile RPCs keep failing accrues
 # UNREACHABLE health events and is torn down once consecutive failures reach


### PR DESCRIPTION
The worker Ping RPC was kept only as a rolling-deploy shim so a not-yet-upgraded controller's ping loop kept succeeding against an already-upgraded worker (workers-first deploy). #6311 removed the controller ping loop — Reconcile is now the sole controller->worker keep-alive — and the whole fleet is on the post-#6311 build, so Ping has no remaining caller.

Remove Ping/PingRequest/PingResponse from worker.proto (regen pb2 + connect), drop handle_ping from the worker and its TaskProvider protocol, the ping dispatch in worker/service.py, and the now-stale worker.ping chaos tombstone in test_chaos.py.

Fixes #6339