### PR TITLE
Add behavior assertions to Levanter entrypoint smoke tests

### DIFF
--- a/lib/levanter/tests/test_export_to_hf.py
+++ b/lib/levanter/tests/test_export_to_hf.py
@@ -2,6 +2,8 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import contextlib
+import glob
+import json
 import os
 import tempfile
 from types import SimpleNamespace
@@ -21,7 +23,6 @@ from test_utils import has_torch
 
 
 def test_export_lm_to_hf():
-    # just testing if train_lm has a pulse
     model_config = Gpt2Config(
         num_layers=2,
         num_heads=2,
@@ -40,25 +41,33 @@ def test_export_lm_to_hf():
 
         save_checkpoint({"model": trainable}, 0, f"{tmpdir}/ckpt")
 
-        try:
-            trainer = SimpleNamespace(
-                device_mesh=contextlib.nullcontext(),
-                parameter_axis_mapping={},
-            )
-            config = export_lm_to_hf.ConvertLmConfig(
-                trainer=trainer,
-                checkpoint_path=f"{tmpdir}/ckpt",
-                output_dir=f"{tmpdir}/output",
-                model=model_config,
-                use_cpu=True,
-            )
-            export_lm_to_hf.main(config)
+        trainer = SimpleNamespace(
+            device_mesh=contextlib.nullcontext(),
+            parameter_axis_mapping={},
+        )
+        output_dir = f"{tmpdir}/output"
+        config = export_lm_to_hf.ConvertLmConfig(
+            trainer=trainer,
+            checkpoint_path=f"{tmpdir}/ckpt",
+            output_dir=output_dir,
+            model=model_config,
+            use_cpu=True,
+        )
+        export_lm_to_hf.main(config)
 
-            if has_torch():
-                AutoModelForCausalLM.from_pretrained(f"{tmpdir}/output")
+        # save_pretrained must persist a loadable HF config plus a weights shard.
+        config_path = os.path.join(output_dir, "config.json")
+        assert os.path.exists(config_path)
+        weights = glob.glob(os.path.join(output_dir, "*.safetensors")) + glob.glob(os.path.join(output_dir, "*.bin"))
+        assert weights, f"no weights file written under {output_dir}"
 
-        finally:
-            try:
-                os.unlink("wandb")
-            except Exception:
-                pass
+        with open(config_path) as f:
+            hf_config = json.load(f)
+        # the exported config must round-trip our model shape, not just be present
+        assert hf_config["n_layer"] == 2
+        assert hf_config["n_head"] == 2
+
+        if has_torch():
+            reloaded = AutoModelForCausalLM.from_pretrained(output_dir)
+            assert reloaded.config.n_layer == 2
+            assert reloaded.config.vocab_size == len(tok)

--- a/lib/levanter/tests/test_trackio.py
+++ b/lib/levanter/tests/test_trackio.py
@@ -12,25 +12,94 @@ from levanter.tracker.trackio import TrackioTracker
 trackio = pytest.importorskip("trackio")
 
 
-def test_log_summary(monkeypatch):
-    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
-    run = trackio.init(project="test-log-summary", embed=False)
-    tracker = TrackioTracker(run)
-    tracker.log_summary({"float": 2.0})
-    tracker.log_summary({"str": "test"})
-    tracker.log_summary({"scalar_jax_array": jnp.array(3.0)})
-    tracker.log_summary({"scalar_np_array": np.array(3.0)})
-    trackio.finish()
+def _capture_logs(monkeypatch):
+    """Patch ``trackio.log`` to record forwarded payloads instead of persisting them."""
+    calls = []
+    monkeypatch.setattr(trackio, "log", lambda payload, step=None: calls.append((payload, step)))
+    return calls
 
 
-def test_log(monkeypatch):
+def _assert_json_native(value):
+    """Trackio persists to SQLite, so every forwarded leaf must be a Python scalar/container."""
+    if isinstance(value, dict):
+        for v in value.values():
+            _assert_json_native(v)
+    elif isinstance(value, (list, tuple)):
+        for v in value:
+            _assert_json_native(v)
+    else:
+        assert isinstance(value, (int, float, str, bool, type(None))), f"un-coerced leaf {value!r}: {type(value)}"
+
+
+def test_log_coerces_values_and_preserves_step(monkeypatch):
     monkeypatch.setenv("HF_HUB_OFFLINE", "1")
     run = trackio.init(project="test-log", embed=False)
     tracker = TrackioTracker(run)
+    calls = _capture_logs(monkeypatch)
+
     tracker.log({"float": 2.0}, step=0)
-    tracker.log({"str": "test"}, step=0)
-    tracker.log({"scalar_jax_array": jnp.array(3.0)}, step=0)
-    tracker.log({"scalar_np_array": np.array(3.0)}, step=0)
+    tracker.log({"str": "test"}, step=1)
+    tracker.log({"scalar_jax_array": jnp.array(3.0)}, step=2)
+    tracker.log({"scalar_np_array": np.array(4.0)}, step=3)
+
+    by_step = {step: payload for payload, step in calls}
+    assert by_step[0] == {"float": 2.0}
+    assert isinstance(by_step[1]["str"], str)
+    # jax/np scalars must be coerced to native Python floats, not left as arrays
+    assert by_step[2] == {"scalar_jax_array": 3.0}
+    assert isinstance(by_step[2]["scalar_jax_array"], float)
+    assert by_step[3] == {"scalar_np_array": 4.0}
+    assert isinstance(by_step[3]["scalar_np_array"], float)
+    for payload, _ in calls:
+        _assert_json_native(payload)
+
+    trackio.finish()
+
+
+def test_log_expands_summary_stats(monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    run = trackio.init(project="test-log-hist", embed=False)
+    tracker = TrackioTracker(run)
+    calls = _capture_logs(monkeypatch)
+
     tracker.log({"histogram": SummaryStats.from_array(jnp.array([1.0, 2.0, 3.0]))}, step=0)
-    tracker.log({"summary_only": SummaryStats.from_array(jnp.array([1.0, 2.0, 3.0]), include_histogram=False)}, step=0)
+    tracker.log(
+        {"summary_only": SummaryStats.from_array(jnp.array([1.0, 2.0, 3.0]), include_histogram=False)},
+        step=1,
+    )
+
+    hist = calls[0][0]["histogram"]
+    assert hist["min"] == 1.0
+    assert hist["max"] == 3.0
+    assert hist["mean"] == pytest.approx(2.0)
+    assert hist["num"] == 3
+    # histogram bucket payload survives the numpy -> list coercion
+    assert isinstance(hist["histogram"]["counts"], list)
+    assert isinstance(hist["histogram"]["limits"], list)
+    assert sum(hist["histogram"]["counts"]) == 3
+
+    summary_only = calls[1][0]["summary_only"]
+    assert "histogram" not in summary_only
+    assert summary_only["mean"] == pytest.approx(2.0)
+
+    for payload, _ in calls:
+        _assert_json_native(payload)
+
+    trackio.finish()
+
+
+def test_log_summary_prefixes_keys(monkeypatch):
+    monkeypatch.setenv("HF_HUB_OFFLINE", "1")
+    run = trackio.init(project="test-log-summary", embed=False)
+    tracker = TrackioTracker(run)
+    calls = _capture_logs(monkeypatch)
+
+    tracker.log_summary({"float": 2.0})
+    tracker.log_summary({"scalar_jax_array": jnp.array(3.0)})
+
+    # log_summary namespaces metrics under "summary/" and forwards without a step
+    assert calls[0] == ({"summary/float": 2.0}, None)
+    assert calls[1][0] == {"summary/scalar_jax_array": 3.0}
+    assert isinstance(calls[1][0]["summary/scalar_jax_array"], float)
+
     trackio.finish()

--- a/lib/levanter/tests/test_train_lm.py
+++ b/lib/levanter/tests/test_train_lm.py
@@ -1,6 +1,8 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
+import math
 import os
 import tempfile
 
@@ -19,8 +21,8 @@ from levanter.adaptor import LoraAdaptorConfig
 from levanter.data.dataset import ListAsyncDataset
 from levanter.data.text import DirectDatasetComponent, GrugLmExample, LmDataConfig
 from levanter.distributed import DistributedConfig
+from levanter.tracker.json_file import JsonFileTrackerConfig
 from levanter.trainer_state import trainables_only
-from levanter.tracker import NoopConfig
 from test_utils import arrays_only
 
 
@@ -28,101 +30,99 @@ def _array_leaves(tree):
     return jax.tree_util.tree_leaves(arrays_only(tree))
 
 
+def _assert_training_recorded(output_path: str) -> dict:
+    """Load the JsonFileTracker record and assert training produced finite metrics.
+
+    The smoke tests run ``train_lm.main`` end to end; the only stable observable
+    effect is the metrics persisted by the tracker on ``finish()``. Asserting on
+    them catches silent no-ops (no step ever logged) and NaN/inf loss blowups.
+    """
+    with open(os.path.join(output_path, "eval_results.json")) as f:
+        metrics = json.load(f)
+    assert metrics["parameter_count"] > 0
+    assert "train/loss" in metrics, "per-step logging hook never fired"
+    assert math.isfinite(metrics["train/loss"])
+    return metrics
+
+
 def test_train_lm():
-    # just testing if train_lm has a pulse
     with tempfile.TemporaryDirectory() as tmpdir:
         data_config, _ = tiny_test_corpus.construct_small_data_cache(tmpdir)
-        try:
-            config = train_lm.TrainLmConfig(
-                data=data_config,
-                model=train_lm.LlamaConfig(
-                    num_layers=2,
-                    num_heads=2,
-                    num_kv_heads=2,
-                    max_seq_len=64,
-                    hidden_dim=32,
-                    attn_backend=None,  # use default for platform
-                ),
-                trainer=train_lm.TrainerConfig(
-                    num_train_steps=2,
-                    train_batch_size=len(jax.devices()),
-                    max_eval_batches=1,
-                    tracker=NoopConfig(),
-                    require_accelerator=False,
-                    distributed=DistributedConfig(initialize_jax_distributed=False),
-                ),
-            )
-            train_lm.main(config)
-        finally:
-            try:
-                os.unlink("wandb")
-            except Exception:
-                pass
+        config = train_lm.TrainLmConfig(
+            data=data_config,
+            model=train_lm.LlamaConfig(
+                num_layers=2,
+                num_heads=2,
+                num_kv_heads=2,
+                max_seq_len=64,
+                hidden_dim=32,
+                attn_backend=None,  # use default for platform
+            ),
+            trainer=train_lm.TrainerConfig(
+                num_train_steps=2,
+                train_batch_size=len(jax.devices()),
+                max_eval_batches=1,
+                tracker=JsonFileTrackerConfig(output_path=tmpdir),
+                require_accelerator=False,
+                distributed=DistributedConfig(initialize_jax_distributed=False),
+            ),
+        )
+        train_lm.main(config)
+        _assert_training_recorded(tmpdir)
 
 
 def test_train_lm_fp8():
-    # just testing if train_lm has a pulse
     with tempfile.TemporaryDirectory() as tmpdir:
         data_config, _ = tiny_test_corpus.construct_small_data_cache(tmpdir)
-        try:
-            config = train_lm.TrainLmConfig(
-                data=data_config,
-                model=train_lm.LlamaConfig(
-                    num_layers=2,
-                    num_heads=2,
-                    num_kv_heads=2,
-                    max_seq_len=64,
-                    hidden_dim=32,
-                    attn_backend=None,  # use default for platform
-                ),
-                trainer=train_lm.TrainerConfig(
-                    quantization=QuantizationConfig(fp8=True),
-                    num_train_steps=2,
-                    train_batch_size=len(jax.devices()),
-                    max_eval_batches=1,
-                    tracker=NoopConfig(),
-                    require_accelerator=False,
-                    distributed=DistributedConfig(initialize_jax_distributed=False),
-                ),
-            )
-            train_lm.main(config)
-        finally:
-            try:
-                os.unlink("wandb")
-            except Exception:
-                pass
+        config = train_lm.TrainLmConfig(
+            data=data_config,
+            model=train_lm.LlamaConfig(
+                num_layers=2,
+                num_heads=2,
+                num_kv_heads=2,
+                max_seq_len=64,
+                hidden_dim=32,
+                attn_backend=None,  # use default for platform
+            ),
+            trainer=train_lm.TrainerConfig(
+                quantization=QuantizationConfig(fp8=True),
+                num_train_steps=2,
+                train_batch_size=len(jax.devices()),
+                max_eval_batches=1,
+                tracker=JsonFileTrackerConfig(output_path=tmpdir),
+                require_accelerator=False,
+                distributed=DistributedConfig(initialize_jax_distributed=False),
+            ),
+        )
+        train_lm.main(config)
+        _assert_training_recorded(tmpdir)
 
 
 def test_train_lm_with_lora_adapter():
     with tempfile.TemporaryDirectory() as tmpdir:
         data_config, _ = tiny_test_corpus.construct_small_data_cache(tmpdir)
-        try:
-            config = train_lm.TrainLmConfig(
-                data=data_config,
-                model=train_lm.LlamaConfig(
-                    num_layers=2,
-                    num_heads=2,
-                    num_kv_heads=2,
-                    max_seq_len=64,
-                    hidden_dim=32,
-                    attn_backend=None,
-                ),
-                trainer=train_lm.TrainerConfig(
-                    num_train_steps=2,
-                    train_batch_size=len(jax.devices()),
-                    max_eval_batches=1,
-                    tracker=NoopConfig(),
-                    require_accelerator=False,
-                    distributed=DistributedConfig(initialize_jax_distributed=False),
-                ),
-                adapter=LoraAdaptorConfig(r=4),
-            )
-            train_lm.main(config)
-        finally:
-            try:
-                os.unlink("wandb")
-            except Exception:
-                pass
+        config = train_lm.TrainLmConfig(
+            data=data_config,
+            model=train_lm.LlamaConfig(
+                num_layers=2,
+                num_heads=2,
+                num_kv_heads=2,
+                max_seq_len=64,
+                hidden_dim=32,
+                attn_backend=None,
+            ),
+            trainer=train_lm.TrainerConfig(
+                num_train_steps=2,
+                train_batch_size=len(jax.devices()),
+                max_eval_batches=1,
+                tracker=JsonFileTrackerConfig(output_path=tmpdir),
+                require_accelerator=False,
+                distributed=DistributedConfig(initialize_jax_distributed=False),
+            ),
+            adapter=LoraAdaptorConfig(r=4),
+        )
+        train_lm.main(config)
+        _assert_training_recorded(tmpdir)
 
 
 def test_restore_lm_model_from_partial_checkpoint_recovers_base_model():
@@ -155,43 +155,36 @@ def test_restore_lm_model_from_partial_checkpoint_recovers_base_model():
 
 
 def test_train_lm_direct_dataset():
-    with tempfile.TemporaryDirectory():
-        try:
-            vocab_size = 128
-            seq_len = 64
-            data = []
-            for i in range(8):
-                tokens = jnp.full((seq_len,), i % vocab_size, dtype=jnp.int32)
-                data.append(GrugLmExample.causal(tokens))
-            dataset = ListAsyncDataset(data)
+    with tempfile.TemporaryDirectory() as tmpdir:
+        vocab_size = 128
+        seq_len = 64
+        data = []
+        for i in range(8):
+            tokens = jnp.full((seq_len,), i % vocab_size, dtype=jnp.int32)
+            data.append(GrugLmExample.causal(tokens))
+        dataset = ListAsyncDataset(data)
 
-            component = DirectDatasetComponent(datasets={"train": dataset})
-            data_config = LmDataConfig(
-                components={"direct": component}, vocab_size=vocab_size, tokenizer="passthrough"
-            )
+        component = DirectDatasetComponent(datasets={"train": dataset})
+        data_config = LmDataConfig(components={"direct": component}, vocab_size=vocab_size, tokenizer="passthrough")
 
-            config = train_lm.TrainLmConfig(
-                data=data_config,
-                model=train_lm.LlamaConfig(
-                    num_layers=2,
-                    num_heads=2,
-                    num_kv_heads=2,
-                    max_seq_len=seq_len,
-                    hidden_dim=32,
-                    attn_backend=None,
-                ),
-                trainer=train_lm.TrainerConfig(
-                    num_train_steps=2,
-                    train_batch_size=len(jax.devices()),
-                    max_eval_batches=1,
-                    tracker=NoopConfig(),
-                    require_accelerator=False,
-                    distributed=DistributedConfig(initialize_jax_distributed=False),
-                ),
-            )
-            train_lm.main(config)
-        finally:
-            try:
-                os.unlink("wandb")
-            except Exception:
-                pass
+        config = train_lm.TrainLmConfig(
+            data=data_config,
+            model=train_lm.LlamaConfig(
+                num_layers=2,
+                num_heads=2,
+                num_kv_heads=2,
+                max_seq_len=seq_len,
+                hidden_dim=32,
+                attn_backend=None,
+            ),
+            trainer=train_lm.TrainerConfig(
+                num_train_steps=2,
+                train_batch_size=len(jax.devices()),
+                max_eval_batches=1,
+                tracker=JsonFileTrackerConfig(output_path=tmpdir),
+                require_accelerator=False,
+                distributed=DistributedConfig(initialize_jax_distributed=False),
+            ),
+        )
+        train_lm.main(config)
+        _assert_training_recorded(tmpdir)

--- a/lib/levanter/tests/test_viz_lm.py
+++ b/lib/levanter/tests/test_viz_lm.py
@@ -1,6 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import glob
 import os
 import tempfile
 
@@ -17,8 +18,6 @@ from levanter.tracker import NoopConfig
 
 
 def test_viz_lm():
-    # just testing if eval_lm has a pulse
-    # save a checkpoint
     model_config = LlamaConfig(
         num_layers=2,
         num_heads=2,
@@ -28,31 +27,32 @@ def test_viz_lm():
     )
 
     with tempfile.TemporaryDirectory() as f:
-        try:
-            data_config, _ = tiny_test_corpus.construct_small_data_cache(f)
-            tok = data_config.the_tokenizer
-            Vocab = haliax.Axis("vocab", len(tok))
-            model = LlamaLMHeadModel.init(Vocab, model_config, key=jax.random.PRNGKey(0))
+        data_config, _ = tiny_test_corpus.construct_small_data_cache(f)
+        tok = data_config.the_tokenizer
+        Vocab = haliax.Axis("vocab", len(tok))
+        model = LlamaLMHeadModel.init(Vocab, model_config, key=jax.random.PRNGKey(0))
 
-            save_checkpoint({"model": model}, 0, f"{f}/ckpt")
+        save_checkpoint({"model": model}, 0, f"{f}/ckpt")
 
-            config = viz_logprobs.VizLmConfig(
-                data=data_config,
-                model=model_config,
-                trainer=viz_logprobs.TrainerConfig(
-                    per_device_eval_parallelism=len(jax.devices()),
-                    max_eval_batches=1,
-                    tracker=NoopConfig(),
-                    require_accelerator=False,
-                    distributed=DistributedConfig(initialize_jax_distributed=False),
-                ),
-                checkpoint_path=f"{f}/ckpt",
-                num_docs=len(jax.devices()),
-                path=f"{f}/viz",
-            )
-            viz_logprobs.main(config)
-        finally:
-            try:
-                os.unlink("wandb")
-            except Exception:
-                pass
+        viz_path = f"{f}/viz"
+        config = viz_logprobs.VizLmConfig(
+            data=data_config,
+            model=model_config,
+            trainer=viz_logprobs.TrainerConfig(
+                per_device_eval_parallelism=len(jax.devices()),
+                max_eval_batches=1,
+                tracker=NoopConfig(),
+                require_accelerator=False,
+                distributed=DistributedConfig(initialize_jax_distributed=False),
+            ),
+            checkpoint_path=f"{f}/ckpt",
+            num_docs=len(jax.devices()),
+            path=viz_path,
+        )
+        viz_logprobs.main(config)
+
+        # main() writes one HTML log-prob visualization per validation set; assert at
+        # least one non-empty artifact landed so a silently-empty render is caught.
+        html_files = glob.glob(f"{viz_path}*.html") + glob.glob(os.path.join(viz_path, "*.html"))
+        assert html_files, f"no viz HTML written under {viz_path}"
+        assert all(os.path.getsize(p) > 0 for p in html_files)

--- a/tests/vllm/test_llm_inference.py
+++ b/tests/vllm/test_llm_inference.py
@@ -39,4 +39,10 @@ def test_local_llm_inference():
         generation_params={"max_tokens": 16},
     )
     model_name_or_path, config = resolve_model_name_or_path(config)
-    run_vllm_inference(model_name_or_path, **config.engine_kwargs)
+    generated_texts = run_vllm_inference(model_name_or_path, **config.engine_kwargs)
+
+    # vLLM returns one RequestOutput for the single prompt; assert it actually
+    # decoded a non-empty completion rather than silently returning nothing.
+    assert len(generated_texts) == 1
+    assert generated_texts[0].outputs
+    assert generated_texts[0].outputs[0].text.strip()


### PR DESCRIPTION
Closes #6426.

Replaces behaviorless smoke tests with assertions on stable outputs and persisted effects across train_lm, viz_lm, export_to_hf, trackio, and vllm inference tests. Drops the dead os.unlink("wandb") cleanup.

Testing: uv run --group test pytest on the four levanter tests (all pass); pre-commit OK. The tpu_ci vllm test needs TPU CI to validate.