### PR TITLE
[iris] Validate worker identity on reconcile to stop recycled-IP zombie workers

### DIFF
--- a/.agents/ops/2026-06-16-iris-recycled-ip-zombie-worker.md
+++ b/.agents/ops/2026-06-16-iris-recycled-ip-zombie-worker.md
@@ -1,0 +1,129 @@
+# Recycled-IP zombie worker black-holes and kills every task it is assigned
+
+**Date:** 2026-06-16
+**Cluster:** marin (GCP)
+**Symptom:** A TPU training task (`/eczech/prot-exp75-w4p-e4-lr5e-4-wd0p1/.../0`)
+was assigned to the *same* worker four times in a row, each attempt KILLED after
+10–15 s (exit code 0, no error), charged as a preemption, then it finally ran
+fine on a different worker.
+
+## TL;DR
+
+A v6e-8 slice (`...0508-46fde438`) was declared failed by the ping loop at
+**06:05** and its TPU was deleted. The controller's `workers` row + in-memory
+liveness for `...46fde438-worker-0` were **not** durably removed. At **10:38**
+GCP recycled that worker's internal IP `10.202.0.90` onto a brand-new, healthy
+v5p worker (`...1038-cfe7edf5-worker-6`). From then on, every control tick the
+controller reconciled the **dead** worker by dialing its stale address — which
+now reached the **live** v5p worker. The live worker answered "healthy", the
+controller folded that as **REACHED**, which **reset the dead worker's failure
+counter to zero and marked it HEALTHY again** — so the scheduler kept treating it
+as a valid placement target. Every task placed there was killed ~12 s later
+(misrouted reconcile cross-talk), charged as a preemption, retried, re-placed on
+the same zombie — a loop that only broke when the autoscaler happened to bring up
+a fresh slice the retry landed on.
+
+The zombie was a **scheduling black hole** for **16+ hours**, killing tasks
+across at least three jobs (`eczech/...wd0p05`, `eczech/...wd0p1`,
+`power/iris-run-job-...`).
+
+## Timeline (UTC, 2026-06-16)
+
+| Time | Event |
+|------|-------|
+| 05:08 | Slice `...0508-46fde438` (v6e-8, addr `10.202.0.90`) created. |
+| 05:15 → 06:05 | Repeated `reconcile_rpc_failed` (Request timed out) to `...46fde438-worker-0`. |
+| 06:05:07 | **Ping loop** fails it over the ping threshold → `worker_failing` → `worker_failed` → autoscaler `worker_failed` → **TPU deleted (async)**. (Worker row + liveness linger.) |
+| 10:38 | New v5p worker `...1038-cfe7edf5-worker-6` created; **GCP recycles IP `10.202.0.90` onto it.** |
+| 13:32 | `reconcile_rpc_failed` to the zombie now returns **Connection refused** (old VM gone). |
+| 13:32 → ~10:38+ | Reconciles to the zombie's address start reaching the **live** v5p worker → "healthy" → **REACHED** → zombie resurrected to HEALTHY/schedulable. |
+| ~21:45 → 22:13 | Zombie black-holes `eczech/prot-exp75-w4e-...wd0p05/0`: assigned ≈ every 50 s, each killed in ~12 s. Recurring log: `apply_reconcile: worker ...46fde438-worker-0 sent 1 observations outside the plan; dropping`. |
+| 22:19:26 | `prot-exp75-...wd0p1/0` attempt 0 assigned to the zombie → KILLED 22:19:41 (14.4 s). |
+| 22:20:10 | attempt 1 → KILLED (11.5 s). |
+| 22:20:50 | attempt 2 → KILLED (15.0 s). |
+| 22:21:28 | attempt 3 → KILLED (15.7 s). |
+| 22:22:20 | Zombie starts black-holing `power/iris-run-job-...` (attempts 3–10 all KILLED ~12–16 s). |
+| 22:22:39 | Autoscaler creates fresh slice `...2222-db160366` (v6e-8). |
+| 22:27:26 | `prot-exp75-...wd0p1/0` attempt 4 lands on `db160366` → **runs normally** (training resumes from step 3379). |
+
+Both `...46fde438-worker-0` (zombie) and `...cfe7edf5-worker-6` (live) carry
+address `10.202.0.90:10001` in the `workers` table — confirming the IP reuse.
+
+## Root cause
+
+The worker-daemon reconcile path **identifies workers only by stored address**,
+with no check that the daemon answering at that address is the worker we meant to
+reach:
+
+1. **Controller** (`backends/rpc/backend.py::RpcTaskBackend.reconcile`): any
+   non-error, self-healthy reconcile reply was folded as `REACHED`, regardless of
+   the responder's identity. `WorkerHealthTracker.apply` then re-creates/refreshes
+   the (dead) worker's liveness via `setdefault(...)` as `active=True,
+   healthy=True, consecutive_failures=0` → HEALTHY → schedulable. The zombie could
+   never accumulate enough failures to be reaped because the impostor kept
+   resetting them.
+2. **Worker** (`worker/worker.py::Worker.handle_reconcile`): "Routing is by
+   attempt_uid only" — the handler ignored `ReconcileRequest.worker_id`, so the
+   live v5p worker acted on the dead worker's plan (running its tasks /
+   zombie-killing its own attempts that were absent from the misrouted plan). This
+   cross-talk is what actually killed each task ~12 s in.
+
+## Fix
+
+Validate worker identity on both ends of the reconcile RPC:
+
+- **Worker** refuses a `ReconcileRequest` whose `worker_id` ≠ its own id
+  (logs a warning, returns its real id with empty observations, does not touch
+  its task set or heartbeat). A misrouted reconcile can no longer corrupt the
+  live worker.
+- **Controller** captures the responder's `worker_id` and, on mismatch, folds the
+  outcome as `UNREACHABLE` (not `REACHED`) and evicts the stale stub. The zombie
+  now accrues failures → crosses the threshold → is reaped and removed, and the
+  impostor's healthy reply can never resurrect it.
+
+Together these break the loop and let the stale worker get cleaned up.
+
+## Control-flow diagram
+
+```mermaid
+flowchart TD
+    subgraph GCP
+        OLDVM["Old TPU VM<br/>46fde438-worker-0<br/>IP 10.202.0.90<br/>(deleted 06:05)"]
+        NEWVM["Live v5p VM<br/>cfe7edf5-worker-6<br/>IP 10.202.0.90<br/>(created 10:38, IP recycled)"]
+    end
+
+    subgraph Controller
+        SCHED["Scheduler<br/>places on usability==HEALTHY"]
+        LIVE["WorkerHealthTracker<br/>apply(): REACHED resets<br/>active/healthy, failures:=0"]
+        RECON["RpcBackend.reconcile<br/>dials stored address"]
+        WROW["workers row: 46fde438 -> 10.202.0.90<br/>(never removed)"]
+    end
+
+    WROW -->|"address"| RECON
+    RECON -->|"Reconcile RPC to 10.202.0.90"| NEWVM
+    NEWVM -->|"'healthy' reply<br/>(worker_id=cfe7edf5)"| RECON
+    RECON -.->|"BUG: folds as REACHED<br/>(ignores responder id)"| LIVE
+    LIVE -->|"46fde438 = HEALTHY"| SCHED
+    SCHED -->|"assigns task to 46fde438"| RECON
+    RECON -->|"misrouted plan<br/>(BUG: worker_id ignored)"| NEWVM
+    NEWVM -->|"zombie-kills task ~12s<br/>-> KILLED -> preemption"| RETRY["task -> PENDING, retry"]
+    RETRY --> SCHED
+
+    OLDVM -. "VM gone; IP reassigned" .-> NEWVM
+
+    FIX1["FIX worker: reject reconcile<br/>whose worker_id != self"]:::fix -.-> NEWVM
+    FIX2["FIX controller: responder id mismatch<br/>-> UNREACHABLE + evict stub<br/>-> zombie reaped"]:::fix -.-> RECON
+
+    classDef fix fill:#d5f5d5,stroke:#2a8a2a,color:#000;
+```
+
+## Diagnostic recipe (for next time)
+
+- Two `workers` rows sharing one address ⇒ recycled IP:
+  `SELECT worker_id, address FROM workers WHERE address LIKE '<ip>%';`
+- A worker still in `workers` whose `slices` row is gone ⇒ orphan/zombie.
+- Recurring `apply_reconcile: worker <id> sent N observations outside the plan;
+  dropping` ⇒ the controller is reaching a *different* worker than intended.
+- `iris query "SELECT attempt_id,state,exit_code,worker_id,created_at_ms,finished_at_ms
+  FROM task_attempts WHERE task_id='<task>' ORDER BY created_at_ms"` — repeated
+  KILLED (state 6), null exit, on the same `worker_id`, ~10–15 s apart.

--- a/lib/iris/src/iris/cluster/backends/rpc/backend.py
+++ b/lib/iris/src/iris/cluster/backends/rpc/backend.py
@@ -191,9 +191,27 @@ class RpcTaskBackend:
         worker_results: list[tuple[WorkerReconcilePlan, WorkerReconcileResult]] = list(zip(plans, results, strict=True))
         health_events: list[WorkerHealthEvent] = []
         for plan, result in worker_results:
+            address = snapshot.worker_addresses[plan.worker_id]
             if result.error is not None:
                 health_events.append(WorkerHealthEvent(plan.worker_id, WorkerHealthEventKind.UNREACHABLE))
-                self.stub_factory.evict(snapshot.worker_addresses[plan.worker_id])
+                self.stub_factory.evict(address)
+            elif result.responder_worker_id is not None and result.responder_worker_id != str(plan.worker_id):
+                # Misrouted reconcile: a *different* live worker answered at this
+                # address. GCP recycles a deleted worker's internal IP onto a new
+                # VM, so the controller's stale address for the dead worker now
+                # points at someone else. Counting the impostor's healthy reply as
+                # REACHED would resurrect the dead worker (reset its failures to 0)
+                # and keep it schedulable — a black hole that accepts and kills
+                # every task. Treat it as UNREACHABLE so the stale worker accrues
+                # failures and is reaped, and drop the impostor's stub.
+                logger.warning(
+                    "Reconcile for worker %s at %s was answered by %s (recycled address); marking unreachable",
+                    plan.worker_id,
+                    address,
+                    result.responder_worker_id,
+                )
+                health_events.append(WorkerHealthEvent(plan.worker_id, WorkerHealthEventKind.UNREACHABLE))
+                self.stub_factory.evict(address)
             elif not result.self_healthy:
                 health_events.append(WorkerHealthEvent(plan.worker_id, WorkerHealthEventKind.UNREACHABLE))
             else:
@@ -301,6 +319,7 @@ class RpcTaskBackend:
                     observations=list(response.observed),
                     error=None,
                     self_healthy=response.health.healthy,
+                    responder_worker_id=response.worker_id or None,
                 )
             except Exception as e:
                 return WorkerReconcileResult(worker_id=plan.worker_id, observations=[], error=str(e))

--- a/lib/iris/src/iris/cluster/controller/reconcile/worker.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/worker.py
@@ -86,12 +86,20 @@ class WorkerReconcileResult:
     an RPC error, where it is meaningless): a worker that responds but reports
     unhealthy — e.g. a failed disk — is still counted as a liveness failure so
     it is eventually reaped.
+
+    ``responder_worker_id`` is the ``worker_id`` the responding daemon stamped on
+    its Reconcile response. It is the *answerer's* identity, which can differ
+    from the targeted :attr:`worker_id` if the controller dialed a stale address
+    that a different live worker now owns (GCP recycles a deleted worker's
+    internal IP onto a new VM). ``None`` on an RPC error or when the daemon did
+    not report an id.
     """
 
     worker_id: WorkerId
     observations: list[worker_pb2.Worker.AttemptObservation]
     error: str | None = None
     self_healthy: bool = True
+    responder_worker_id: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/src/iris/cluster/worker/worker.py
+++ b/lib/iris/src/iris/cluster/worker/worker.py
@@ -836,6 +836,27 @@ class Worker:
         Routing is by ``attempt_uid`` only: every DesiredAttempt and
         AttemptObservation is keyed by UID.
         """
+        # Identity guard: only act on reconciles addressed to *this* worker.
+        # After a worker's VM is deleted GCP can recycle its internal IP onto a
+        # new VM; the controller may still hold the dead worker's stale address
+        # and reconcile us under the dead worker's id. Because routing is by
+        # attempt_uid, processing it would run the dead worker's tasks and
+        # zombie-kill our own attempts (absent from the misrouted plan). Refuse,
+        # but report our real id so the controller detects the recycled address
+        # and reaps the stale worker (a wrong-worker reply is not a heartbeat, so
+        # we also skip the deadline reset and the host-metrics stat below).
+        if request.worker_id and self._worker_id and request.worker_id != self._worker_id:
+            logger.warning(
+                "Reconcile addressed to %s but this worker is %s; refusing (recycled address?)",
+                request.worker_id,
+                self._worker_id,
+            )
+            return worker_pb2.Worker.ReconcileResponse(
+                worker_id=self._worker_id,
+                observed=[],
+                health=worker_pb2.Worker.WorkerHealth(healthy=True),
+            )
+
         self._heartbeat_deadline = Deadline.from_seconds(self._config.heartbeat_timeout.to_seconds())
 
         for desired in request.desired:

--- a/lib/iris/tests/cluster/controller/test_reconcile.py
+++ b/lib/iris/tests/cluster/controller/test_reconcile.py
@@ -597,6 +597,49 @@ def test_reconcile_rpc_failure_returns_error_and_empty_observations():
     assert list(results[0].observations) == []
 
 
+def test_reconcile_matching_responder_id_is_reached():
+    """A healthy reply stamped with the targeted worker's id counts as REACHED."""
+    stub = _FakeWorkerStub(
+        address=_W1_ADDR,
+        reconcile_response=worker_pb2.Worker.ReconcileResponse(
+            worker_id=_W1, health=worker_pb2.Worker.WorkerHealth(healthy=True)
+        ),
+    )
+    factory = _FakeStubFactory(stubs={_W1_ADDR: stub})
+    provider = RpcTaskBackend(stub_factory=factory)
+
+    result = provider.reconcile(_reconcile_snapshot({WorkerId(_W1): _W1_ADDR}))
+
+    assert result.health_events == [WorkerHealthEvent(WorkerId(_W1), WorkerHealthEventKind.REACHED)]
+    assert _W1_ADDR in factory.stubs  # healthy worker's stub kept
+
+
+def test_reconcile_recycled_address_is_unreachable_not_reached():
+    """A healthy reply stamped with a DIFFERENT worker_id (recycled IP) is UNREACHABLE.
+
+    Regression: after a worker's VM is deleted GCP recycles its internal IP onto
+    a new VM. Reconciling the dead worker at its stale address then reaches the
+    *new* worker, which answers healthy. Folding that as REACHED would reset the
+    dead worker's failure count and keep it schedulable forever — a black hole
+    that accepts and kills every task assigned to it. The mismatched id must mark
+    the dead worker UNREACHABLE so it is reaped, and the impostor's stub dropped.
+    """
+    stub = _FakeWorkerStub(
+        address=_W1_ADDR,
+        reconcile_response=worker_pb2.Worker.ReconcileResponse(
+            worker_id=_W2, health=worker_pb2.Worker.WorkerHealth(healthy=True)
+        ),
+    )
+    factory = _FakeStubFactory(stubs={_W1_ADDR: stub})
+    provider = RpcTaskBackend(stub_factory=factory)
+
+    result = provider.reconcile(_reconcile_snapshot({WorkerId(_W1): _W1_ADDR}))
+
+    assert result.health_events == [WorkerHealthEvent(WorkerId(_W1), WorkerHealthEventKind.UNREACHABLE)]
+    # The stale stub is evicted so the next tick re-resolves the address.
+    assert _W1_ADDR not in factory.stubs
+
+
 # ===========================================================================
 # Section 3: apply (transitions) + e2e (controller tick)
 # ===========================================================================

--- a/lib/iris/tests/cluster/worker/test_reconcile.py
+++ b/lib/iris/tests/cluster/worker/test_reconcile.py
@@ -240,6 +240,49 @@ def test_zombie_attempt_is_killed(worker, mock_runtime):
     assert task.status == job_pb2.TASK_STATE_KILLED
 
 
+def test_reconcile_addressed_to_other_worker_is_refused(worker, mock_runtime):
+    """A reconcile addressed to a different worker (recycled-IP misroute) is refused.
+
+    Regression: after a worker's VM is deleted GCP can recycle its internal IP
+    onto this live VM, so the controller — still holding the dead worker's stale
+    address — dials us under the dead worker's id. Routing is by attempt_uid, so
+    acting on that (empty) plan would zombie-kill our own running attempt. We must
+    ignore it and report our real id so the controller detects the recycled
+    address and reaps the stale worker instead.
+    """
+    task_id = _task_id("not-a-zombie")
+    uid = "uid-not-a-zombie"
+    run_req = create_run_task_request(task_id=task_id, attempt_id=0, attempt_uid=uid)
+
+    mock_runtime.create_container = Mock(
+        return_value=create_mock_container_handle(
+            status_sequence=[ContainerStatus(phase=ContainerPhase.RUNNING)] * 100,
+        )
+    )
+
+    worker.submit_task(run_req)
+    task = worker.task_by_uid(uid)
+    assert task is not None
+    wait_for_condition(lambda: task.status == job_pb2.TASK_STATE_RUNNING)
+
+    # Misrouted reconcile: empty desired set addressed to a DIFFERENT worker.
+    # Without the identity guard the empty plan zombie-kills our running attempt.
+    response = worker.handle_reconcile(worker_pb2.Worker.ReconcileRequest(worker_id="some-other-worker", desired=[]))
+
+    # Refused: response carries OUR id, no observations, and our task survives.
+    assert response.worker_id == "w-reconcile-test"
+    assert list(response.observed) == []
+    assert task.should_stop is False
+    assert task.status == job_pb2.TASK_STATE_RUNNING
+
+    # A correctly-addressed reconcile with the same empty desired set still
+    # performs the zombie kill, proving the guard only blocks misroutes.
+    worker.handle_reconcile(worker_pb2.Worker.ReconcileRequest(worker_id="w-reconcile-test", desired=[]))
+    assert task.should_stop is True
+    task.thread.join(timeout=5.0)
+    assert task.status == job_pb2.TASK_STATE_KILLED
+
+
 def test_zombie_kill_skips_terminal_tasks(worker, mock_runtime):
     """Attempts already in a terminal state are not re-killed during zombie detection."""
     task_id = _task_id("zombie-terminal")


### PR DESCRIPTION
## What

A worker whose VM is deleted can have its internal IP **recycled by GCP onto a new, healthy worker VM**. The controller, still holding the dead worker's stale address, kept reconciling it *by address only*. The reconcile RPC reached the **live** worker now at that IP, which answered "healthy", and the controller folded that as `REACHED` — resetting the dead worker's failure counter to zero and marking it `HEALTHY` again. The scheduler therefore kept treating the dead worker as a valid placement target. Worker-side routing is by `attempt_uid` only, so the live worker also acted on the dead worker's plan, zombie-killing each assigned task ~12 s in.

The result: a **scheduling black hole** that accepted and **KILLED every task** assigned to it (exit 0, no error, each charged as a preemption), for **16+ hours**, across multiple jobs, until the autoscaler happened to bring up a fresh slice that a retry landed on.

This is the bug behind the reported run, where one task was assigned to the same worker 4× and killed every 10–15 s:

```
Attempt  State   Worker                                   Exit  Duration
0        Killed  ...0508-46fde438-worker-0                0     14s
1        Killed  ...0508-46fde438-worker-0                0     11s
2        Killed  ...0508-46fde438-worker-0                0     15s
3        Killed  ...0508-46fde438-worker-0                0     15s
4 (run)  Running ...2222-db160366-worker-0  (fresh slice) 0     10m+
```

## Root cause

The reconcile RPC identifies a worker only by its stored address, with no check that the daemon answering is the worker we meant to reach. Two `workers` rows ended up sharing address `10.202.0.90:10001` — the dead `...46fde438-worker-0` and the live `...cfe7edf5-worker-6` — confirming the IP reuse.

- **Controller** (`RpcTaskBackend.reconcile`): folded any non-error, self-healthy reply as `REACHED` regardless of responder identity; `WorkerHealthTracker.apply` then `setdefault`s the dead worker back to `active/healthy, failures=0`.
- **Worker** (`Worker.handle_reconcile`): ignored `ReconcileRequest.worker_id`, so a misrouted reconcile mutated the live worker's task set (the cross-talk that actually killed each task).

## Fix

Validate worker identity on **both ends** of the Reconcile RPC:

- **Worker** rejects a `ReconcileRequest` whose `worker_id` ≠ its own id (warns, returns its real id with empty observations, leaves its task set and heartbeat untouched).
- **Controller** captures the responder's `worker_id`; on mismatch it folds the outcome as `UNREACHABLE` (not `REACHED`) and evicts the stale stub. The zombie now accrues failures → crosses the threshold → is reaped and removed, and the impostor's healthy reply can never resurrect it.

## Control flow

```mermaid
flowchart TD
    subgraph GCP
        OLDVM["Old TPU VM 46fde438-worker-0<br/>IP 10.202.0.90 (deleted 06:05)"]
        NEWVM["Live v5p VM cfe7edf5-worker-6<br/>IP 10.202.0.90 (created 10:38, IP recycled)"]
    end
    subgraph Controller
        SCHED["Scheduler: places on usability==HEALTHY"]
        LIVE["WorkerHealthTracker.apply()<br/>REACHED resets active/healthy, failures:=0"]
        RECON["RpcBackend.reconcile: dials stored address"]
        WROW["workers row 46fde438 -> 10.202.0.90 (never removed)"]
    end
    WROW -->|address| RECON
    RECON -->|"Reconcile RPC to 10.202.0.90"| NEWVM
    NEWVM -->|"'healthy' reply (worker_id=cfe7edf5)"| RECON
    RECON -.->|"BUG: folds as REACHED (ignores responder id)"| LIVE
    LIVE -->|"46fde438 = HEALTHY"| SCHED
    SCHED -->|"assigns task to 46fde438"| RECON
    RECON -->|"misrouted plan (BUG: worker_id ignored)"| NEWVM
    NEWVM -->|"zombie-kills task ~12s -> KILLED -> preemption"| RETRY["task -> PENDING, retry"]
    RETRY --> SCHED
    OLDVM -. "VM gone; IP reassigned" .-> NEWVM
    FIX1["FIX worker: reject reconcile whose worker_id != self"]:::fix -.-> NEWVM
    FIX2["FIX controller: responder id mismatch -> UNREACHABLE + evict -> reaped"]:::fix -.-> RECON
    classDef fix fill:#d5f5d5,stroke:#2a8a2a,color:#000;
```

## Reproduction / tests

- `tests/cluster/worker/test_reconcile.py::test_reconcile_addressed_to_other_worker_is_refused` — a reconcile addressed to a different worker does **not** zombie-kill the live worker's running attempt and returns the live worker's real id; a correctly-addressed reconcile still performs the zombie kill.
- `tests/cluster/controller/test_reconcile.py::test_reconcile_recycled_address_is_unreachable_not_reached` — a healthy reply stamped with a different `worker_id` is folded as `UNREACHABLE` and the stale stub is evicted (vs `test_reconcile_matching_responder_id_is_reached`, which stays `REACHED`).

Full postmortem with timeline + diagram: `.agents/ops/2026-06-16-iris-recycled-ip-zombie-worker.md`.
