### PR TITLE
[iris] Stop recycled-IP zombie kill loop and repair DEGRADED adopted slices

### DIFF
--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -537,11 +537,13 @@ class Autoscaler:
         """
         timestamp = timestamp or Timestamp.now()
 
-        # Phase 1: snapshot every non-READY slice across all groups.
+        # Phase 1: snapshot every slice that needs a describe() — not-yet-ready
+        # slices, plus READY slices the autoscaler tracks no workers for (so an
+        # adopted READY-but-empty slice repopulates instead of staying DEGRADED).
         targets = [
             (group, slice_id, handle)
             for group in self._groups.values()
-            for slice_id, handle in group.non_ready_slice_handles()
+            for slice_id, handle in group.slices_needing_describe()
         ]
 
         # Phase 2: fan out the blocking describe() over a bounded pool.

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -671,13 +671,21 @@ class ScalingGroup:
         with self._slices_lock:
             return [s.handle for s in self._slices.values()]
 
-    def non_ready_slice_handles(self) -> list[tuple[str, SliceHandle]]:
-        """Snapshot non-READY slice handles for background lifecycle polling."""
+    def slices_needing_describe(self) -> list[tuple[str, SliceHandle]]:
+        """Snapshot slice handles the caller must ``describe()`` this tick.
+
+        Returns not-yet-ready slices (BOOTING/INITIALIZING), plus READY slices
+        the autoscaler tracks no workers for. A READY slice with empty
+        ``worker_ids`` never resolved its membership (e.g. adopted from a
+        checkpoint that recorded none); re-describing lets ``refresh`` repopulate
+        or reap it instead of leaving it stuck DEGRADED.
+        """
         with self._slices_lock:
             return [
                 (slice_id, state.handle)
                 for slice_id, state in self._slices.items()
                 if state.lifecycle in (SliceLifecycleState.BOOTING, SliceLifecycleState.INITIALIZING)
+                or (state.lifecycle == SliceLifecycleState.READY and not state.worker_ids)
             ]
 
     def slice_count(self) -> int:

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -402,10 +402,8 @@ class Controller:
         # Set after a tick commits new ASSIGNED rows so the next tick reconciles
         # immediately (dispatching them) instead of waiting a full poll interval.
         self._force_reconcile = False
-        # Worker rows queued for fail-and-teardown by an off-loop caller (the
-        # Register RPC, on recycled-IP detection). The teardown touches the
-        # autoscaler, which is only safe on the control-loop thread, so it is
-        # drained into _fail_and_teardown there rather than run inline.
+        # Workers queued off the control loop for teardown on the next tick; see
+        # request_worker_eviction / _drain_pending_evictions.
         self._pending_evictions: set[WorkerId] = set()
         self._pending_evictions_lock = threading.Lock()
         self._server: uvicorn.Server | None = None
@@ -1273,12 +1271,11 @@ class Controller:
         self._health.forget_many(set(removed_ids) | set(auto.removed_workers))
 
     def _drain_pending_evictions(self) -> None:
-        """Fail-and-teardown workers queued by ``request_worker_eviction``.
+        """Fail-and-teardown the workers queued by :meth:`request_worker_eviction`.
 
-        Runs on the control-loop thread, so the autoscaler-side slice teardown in
-        ``_fail_and_teardown`` is safe. The snapshot carries only the queued
-        workers' addresses (for cached-stub eviction); their rows are still
-        present because eviction is queued before any failure.
+        The snapshot carries only the queued workers' addresses (for cached-stub
+        eviction); their rows still exist because eviction is queued before any
+        failure.
         """
         with self._pending_evictions_lock:
             if not self._pending_evictions:

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -402,6 +402,12 @@ class Controller:
         # Set after a tick commits new ASSIGNED rows so the next tick reconciles
         # immediately (dispatching them) instead of waiting a full poll interval.
         self._force_reconcile = False
+        # Worker rows queued for fail-and-teardown by an off-loop caller (the
+        # Register RPC, on recycled-IP detection). The teardown touches the
+        # autoscaler, which is only safe on the control-loop thread, so it is
+        # drained into _fail_and_teardown there rather than run inline.
+        self._pending_evictions: set[WorkerId] = set()
+        self._pending_evictions_lock = threading.Lock()
         self._server: uvicorn.Server | None = None
         self._control_thread: ManagedThread | None = None
         self._prune_thread: ManagedThread | None = None
@@ -452,6 +458,20 @@ class Controller:
         of waiting a full poll interval.
         """
         self._tick_wake.set()
+
+    def request_worker_eviction(self, worker_ids: Sequence[WorkerId]) -> None:
+        """Queue workers for fail-and-teardown on the next control tick.
+
+        Called off the control-loop thread (the Register RPC, when a worker claims
+        an address still held by a stale row — a recycled internal IP). The
+        teardown reaps the worker's slice through the autoscaler, which is only
+        safe on the control-loop thread, so the work is deferred to the tick drain.
+        """
+        if not worker_ids:
+            return
+        with self._pending_evictions_lock:
+            self._pending_evictions.update(worker_ids)
+        self.wake()
 
     def _seed_liveness_from_workers(self) -> None:
         """Seed every persisted worker as healthy so the scheduler sees them at startup.
@@ -736,6 +756,8 @@ class Controller:
         if self._config.dry_run:
             self._run_scheduling()
             return
+
+        self._drain_pending_evictions()
 
         run_autoscale = autoscale_limiter.should_run()
         run_schedule = woken or run_autoscale or schedule_limiter.should_run()
@@ -1197,7 +1219,13 @@ class Controller:
         if dead_workers:
             self._fail_and_teardown(dead_workers, snapshot)
 
-    def _fail_and_teardown(self, dead_workers: list[WorkerId], snapshot: reads.ControlSnapshot) -> None:
+    def _fail_and_teardown(
+        self,
+        dead_workers: list[WorkerId],
+        snapshot: reads.ControlSnapshot,
+        *,
+        reason: str = "worker reconcile failure threshold exceeded",
+    ) -> None:
         """Serialize worker failure, tear down slices + siblings, forget the lot.
 
         Fail the dead workers (``ops.worker.fail``), hand them to
@@ -1206,7 +1234,6 @@ class Controller:
         the autoscaler state, and forget every removed worker from the tracker.
         The only health-driven write is removal.
         """
-        reason = "worker reconcile failure threshold exceeded"
         sibling_reason = "unhealthy worker failed, slice terminated"
         for wid in dead_workers:
             log_event("worker_failing", str(wid), trigger=reason)
@@ -1244,6 +1271,24 @@ class Controller:
                 worker_attrs=self._worker_attrs,
             )
         self._health.forget_many(set(removed_ids) | set(auto.removed_workers))
+
+    def _drain_pending_evictions(self) -> None:
+        """Fail-and-teardown workers queued by ``request_worker_eviction``.
+
+        Runs on the control-loop thread, so the autoscaler-side slice teardown in
+        ``_fail_and_teardown`` is safe. The snapshot carries only the queued
+        workers' addresses (for cached-stub eviction); their rows are still
+        present because eviction is queued before any failure.
+        """
+        with self._pending_evictions_lock:
+            if not self._pending_evictions:
+                return
+            drained = sorted(self._pending_evictions)
+            self._pending_evictions.clear()
+        with self._db.read_snapshot() as snap:
+            addresses = reads.bulk_get_worker_addresses(snap, drained)
+        snapshot = reads.ControlSnapshot(worker_addresses=addresses, reconcile_rows=[], timeout_rows=[])
+        self._fail_and_teardown(drained, snapshot, reason="address reused by newly-registered worker (recycled IP)")
 
     def _worker_status_map_from_tx(self, tx: Tx) -> WorkerStatusMap:
         """Per-worker idle/running status for the autoscale phase, read from ``tx``.

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -1377,6 +1377,24 @@ def bulk_get_worker_addresses(tx: Tx, worker_ids: Iterable[WorkerId]) -> dict[Wo
     return {row.worker_id: str(row.address) for row in rows}
 
 
+def worker_ids_at_address(tx: Tx, address: str, *, exclude: WorkerId) -> list[WorkerId]:
+    """Return worker ids whose row holds ``address``, excluding ``exclude``.
+
+    Detects a recycled internal IP: when GCP deletes a worker VM and reuses its
+    IP for a new VM, the dead worker's row keeps the address, so two rows end up
+    sharing one ``address``. The reconcile dial is by address, so the stale row
+    misroutes its plan to the live worker now at that IP. The new registrant owns
+    the address, so any other holder is a stale prior owner to evict.
+    """
+    rows = tx.execute(
+        select(workers_table.c.worker_id).where(
+            workers_table.c.address == address,
+            workers_table.c.worker_id != exclude,
+        )
+    ).all()
+    return [WorkerId(str(row.worker_id)) for row in rows]
+
+
 @dataclass(frozen=True, slots=True)
 class SchedulableWorker:
     """Worker shape consumed by the scheduler.

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -1380,11 +1380,9 @@ def bulk_get_worker_addresses(tx: Tx, worker_ids: Iterable[WorkerId]) -> dict[Wo
 def worker_ids_at_address(tx: Tx, address: str, *, exclude: WorkerId) -> list[WorkerId]:
     """Return worker ids whose row holds ``address``, excluding ``exclude``.
 
-    Detects a recycled internal IP: when GCP deletes a worker VM and reuses its
-    IP for a new VM, the dead worker's row keeps the address, so two rows end up
-    sharing one ``address``. The reconcile dial is by address, so the stale row
-    misroutes its plan to the live worker now at that IP. The new registrant owns
-    the address, so any other holder is a stale prior owner to evict.
+    Detects a recycled internal IP: when GCP reuses a deleted VM's IP for a new
+    one, two rows end up sharing one ``address``. Passing the new registrant as
+    ``exclude`` yields the stale prior owners.
     """
     rows = tx.execute(
         select(workers_table.c.worker_id).where(

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1611,10 +1611,43 @@ class ControllerServiceImpl:
                 slice_id=request.slice_id,
                 scale_group=request.scale_group,
             )
+        self._evict_recycled_address_owners(worker_id, request.address)
         logger.info("Worker registered: %s at %s", worker_id, request.address)
         return controller_pb2.Controller.RegisterResponse(
             worker_id=str(worker_id),
             accepted=True,
+        )
+
+    def _evict_recycled_address_owners(self, worker_id: WorkerId, address: str) -> None:
+        """Fail any other worker still holding ``address`` after ``worker_id`` claims it.
+
+        GCP recycles a deleted worker's internal IP onto a new VM, so the dead
+        worker's row keeps the stale address. The controller reconciles by
+        address, so the RPC reaches the live worker now at that IP, which --
+        routing by attempt_uid -- zombie-kills its own tasks; the reconcile-time
+        identity check misses this when the responder runs an older image that
+        echoes no worker_id. The new registrant owns the address, so the prior
+        holder is stale: fail it through the standard reap path so its tasks
+        reschedule and its row is removed.
+        """
+        with self._db.read_snapshot() as snap:
+            stale = reads.worker_ids_at_address(snap, address, exclude=worker_id)
+        if not stale:
+            return
+        logger.warning(
+            "Worker %s registered at %s held by %d stale row(s) (recycled IP); failing: %s",
+            worker_id,
+            address,
+            len(stale),
+            [str(wid) for wid in stale],
+        )
+        ops.worker.fail(
+            self._db,
+            worker_ids=[str(wid) for wid in stale],
+            reason="address reused by newly-registered worker (recycled IP)",
+            health=self._health,
+            endpoints=self._endpoints,
+            worker_attrs=self._worker_attrs,
         )
 
     def list_workers(

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -12,6 +12,7 @@ import json
 import logging
 import secrets
 import uuid
+from collections.abc import Sequence
 from dataclasses import dataclass, field
 from datetime import date, timedelta
 from typing import Any, Protocol
@@ -859,6 +860,8 @@ class ControllerProtocol(Protocol):
 
     def wake(self) -> None: ...
 
+    def request_worker_eviction(self, worker_ids: Sequence[WorkerId]) -> None: ...
+
     def get_job_scheduling_diagnostics(self, job_wire_id: str) -> str | None: ...
 
     def begin_checkpoint(self) -> tuple[str, Any]: ...
@@ -1611,15 +1614,15 @@ class ControllerServiceImpl:
                 slice_id=request.slice_id,
                 scale_group=request.scale_group,
             )
-        self._evict_recycled_address_owners(worker_id, request.address)
+        self._request_recycled_address_eviction(worker_id, request.address)
         logger.info("Worker registered: %s at %s", worker_id, request.address)
         return controller_pb2.Controller.RegisterResponse(
             worker_id=str(worker_id),
             accepted=True,
         )
 
-    def _evict_recycled_address_owners(self, worker_id: WorkerId, address: str) -> None:
-        """Fail any other worker still holding ``address`` after ``worker_id`` claims it.
+    def _request_recycled_address_eviction(self, worker_id: WorkerId, address: str) -> None:
+        """Queue any other worker still holding ``address`` for eviction.
 
         GCP recycles a deleted worker's internal IP onto a new VM, so the dead
         worker's row keeps the stale address. The controller reconciles by
@@ -1627,28 +1630,21 @@ class ControllerServiceImpl:
         routing by attempt_uid -- zombie-kills its own tasks; the reconcile-time
         identity check misses this when the responder runs an older image that
         echoes no worker_id. The new registrant owns the address, so the prior
-        holder is stale: fail it through the standard reap path so its tasks
-        reschedule and its row is removed.
+        holder is stale and is handed to the controller for fail-and-teardown
+        (deferred to the control-loop thread, where reaping its slice is safe).
         """
         with self._db.read_snapshot() as snap:
             stale = reads.worker_ids_at_address(snap, address, exclude=worker_id)
         if not stale:
             return
         logger.warning(
-            "Worker %s registered at %s held by %d stale row(s) (recycled IP); failing: %s",
+            "Worker %s registered at %s held by %d stale row(s) (recycled IP); evicting: %s",
             worker_id,
             address,
             len(stale),
             [str(wid) for wid in stale],
         )
-        ops.worker.fail(
-            self._db,
-            worker_ids=[str(wid) for wid in stale],
-            reason="address reused by newly-registered worker (recycled IP)",
-            health=self._health,
-            endpoints=self._endpoints,
-            worker_attrs=self._worker_attrs,
-        )
+        self._controller.request_worker_eviction(stale)
 
     def list_workers(
         self,

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1622,16 +1622,10 @@ class ControllerServiceImpl:
         )
 
     def _request_recycled_address_eviction(self, worker_id: WorkerId, address: str) -> None:
-        """Queue any other worker still holding ``address`` for eviction.
+        """Hand any stale prior owner of ``address`` to the controller for teardown.
 
-        GCP recycles a deleted worker's internal IP onto a new VM, so the dead
-        worker's row keeps the stale address. The controller reconciles by
-        address, so the RPC reaches the live worker now at that IP, which --
-        routing by attempt_uid -- zombie-kills its own tasks; the reconcile-time
-        identity check misses this when the responder runs an older image that
-        echoes no worker_id. The new registrant owns the address, so the prior
-        holder is stale and is handed to the controller for fail-and-teardown
-        (deferred to the control-loop thread, where reaping its slice is safe).
+        Detects a recycled internal IP (see :func:`reads.worker_ids_at_address`)
+        and defers the reap to :meth:`Controller.request_worker_eviction`.
         """
         with self._db.read_snapshot() as snap:
             stale = reads.worker_ids_at_address(snap, address, exclude=worker_id)

--- a/lib/iris/tests/cluster/backends/test_scaling_group.py
+++ b/lib/iris/tests/cluster/backends/test_scaling_group.py
@@ -261,6 +261,29 @@ class TestScalingGroupVmGroupOwnership:
         assert group.slice_count() == 3
         assert group.ready_slice_count() == 2
 
+    def test_slices_needing_describe_includes_ready_without_workers(
+        self, scale_group_config: config_pb2.ScaleGroupConfig
+    ):
+        """A READY slice with no tracked workers is re-described, not left DEGRADED.
+
+        An adopted slice can come back READY with empty worker_ids; without
+        re-describing it the autoscaler would never repopulate membership (so it
+        stays "no hosts registered") nor reap it.
+        """
+        discovered = [
+            make_fake_slice_handle("ready-with-workers", all_ready=True),
+            make_fake_slice_handle("still-booting", all_ready=False, vm_states=[vm_pb2.VM_STATE_BOOTING]),
+            make_fake_slice_handle("ready-no-workers", all_ready=True),
+        ]
+        platform = make_mock_platform(slices_to_discover=discovered)
+        group = ScalingGroup(scale_group_config, platform)
+        group.reconcile()
+        _mark_discovered_ready(group, [discovered[0]])
+        group.mark_slice_ready("ready-no-workers", [])  # READY but membership never resolved
+
+        needing = {slice_id for slice_id, _ in group.slices_needing_describe()}
+        assert needing == {"still-booting", "ready-no-workers"}
+
 
 class TestScalingGroupScalingPolicy:
     """Tests for scaling policy decisions (can_scale_up, rate limiting)."""

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -158,6 +158,7 @@ class MockController:
 
     def __init__(self):
         self.wake = Mock()
+        self.request_worker_eviction = Mock()
         self.get_job_scheduling_diagnostics = Mock(return_value=None)
         self.last_scheduling_context = None
         self.autoscaler = None

--- a/lib/iris/tests/cluster/controller/test_reconcile.py
+++ b/lib/iris/tests/cluster/controller/test_reconcile.py
@@ -1412,6 +1412,35 @@ def test_reconcile_failure_reaps_slice_siblings(make_controller):
     assert ctrl._health.all() == {}, "whole slice should be forgotten from the tracker"
 
 
+def test_request_worker_eviction_tears_down_on_next_tick(make_controller):
+    """A queued eviction fails the worker and reaps its slice on the next tick.
+
+    The Register RPC queues a recycled-IP prior owner off the control-loop thread,
+    where reaping a slice via the autoscaler is unsafe. The tick drains it through
+    the same fail-and-teardown path as a reconcile failure --
+    ``backend.autoscale(dead_workers=...)`` -- even though the worker answers every
+    reconcile: eviction is driven by the queue, not by liveness.
+    """
+    provider = _UnreachableProvider()  # the worker stays reachable every tick
+    ctrl = make_controller(provider=provider, worker_unreachable_grace=_SHORT_GRACE)
+    state = ControllerTestState(
+        ctrl._db,
+        health=ctrl._health,
+        endpoints=ctrl._endpoints,
+        worker_attrs=ctrl._worker_attrs,
+        run_template_cache=ctrl._run_template_cache,
+    )
+
+    wid = register_worker(state, _W1, _W1_ADDR, make_worker_metadata())
+
+    ctrl.request_worker_eviction([wid])
+    reconcile_once(ctrl)
+
+    assert provider.autoscale_calls == [[wid]], "drain must drive teardown via backend.autoscale"
+    assert query_worker(state, wid) is None, "evicted worker row should be removed"
+    assert wid not in ctrl._health.all(), "evicted worker should be forgotten from the tracker"
+
+
 # ===========================================================================
 # Section 6: same-batch coscheduling split-slice corruption (#2 / #3)
 # ===========================================================================

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -1576,13 +1576,14 @@ def test_register_allows_worker_role(state, mock_controller, tmp_path, log_clien
         _verified_identity.reset(token)
 
 
-def test_register_evicts_recycled_address_owner(service, state):
+def test_register_requests_eviction_of_recycled_address_owner(service, state, mock_controller):
     """Registering at an address still held by another row evicts the stale owner.
 
     GCP recycles a deleted worker's internal IP onto a new VM. Left in place, the
     dead row makes the controller misroute its address-keyed reconcile to the live
-    worker, which then zombie-kills its own tasks (the #6445 cross-talk). The new
-    registrant owns the address, so the prior holder must be failed.
+    worker, which then zombie-kills its own tasks (the recycled-IP cross-talk). The
+    new registrant owns the address, so the prior holder is handed to the
+    controller for fail-and-teardown (deferred to the control-loop thread).
     """
     addr = "10.0.0.7:10001"
     dead, live = WorkerId("dead-worker-0"), WorkerId("live-worker-0")
@@ -1594,20 +1595,19 @@ def test_register_evicts_recycled_address_owner(service, state):
     )
     with state._db.read_snapshot() as tx:
         assert reads.worker_ids_at_address(tx, addr, exclude=sentinel) == [dead]
+    mock_controller.request_worker_eviction.assert_not_called()
 
     service.register(
         controller_pb2.Controller.RegisterRequest(worker_id=str(live), address=addr, metadata=make_worker_metadata()),
         None,
     )
 
-    # The recycled address now belongs to `live`; the stale `dead` row is gone.
-    with state._db.read_snapshot() as tx:
-        assert reads.worker_ids_at_address(tx, addr, exclude=sentinel) == [live]
-    assert not state._health.liveness(dead).active
-    assert state._health.liveness(live).active
+    # The live registrant now shares the address with the stale `dead` row, which
+    # is queued for eviction; the actual teardown rides the control tick.
+    mock_controller.request_worker_eviction.assert_called_once_with([dead])
 
 
-def test_register_distinct_addresses_evicts_nothing(service, state):
+def test_register_distinct_addresses_requests_no_eviction(service, state, mock_controller):
     """Registering at a fresh address leaves workers at other addresses untouched."""
     meta = make_worker_metadata()
     a, b = WorkerId("worker-a"), WorkerId("worker-b")
@@ -1619,6 +1619,7 @@ def test_register_distinct_addresses_evicts_nothing(service, state):
     )
     assert state._health.liveness(a).active
     assert state._health.liveness(b).active
+    mock_controller.request_worker_eviction.assert_not_called()
 
 
 def test_get_scheduler_state_with_running_task(controller_service, state):

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -1576,6 +1576,51 @@ def test_register_allows_worker_role(state, mock_controller, tmp_path, log_clien
         _verified_identity.reset(token)
 
 
+def test_register_evicts_recycled_address_owner(service, state):
+    """Registering at an address still held by another row evicts the stale owner.
+
+    GCP recycles a deleted worker's internal IP onto a new VM. Left in place, the
+    dead row makes the controller misroute its address-keyed reconcile to the live
+    worker, which then zombie-kills its own tasks (the #6445 cross-talk). The new
+    registrant owns the address, so the prior holder must be failed.
+    """
+    addr = "10.0.0.7:10001"
+    dead, live = WorkerId("dead-worker-0"), WorkerId("live-worker-0")
+    sentinel = WorkerId("__no_match__")
+
+    service.register(
+        controller_pb2.Controller.RegisterRequest(worker_id=str(dead), address=addr, metadata=make_worker_metadata()),
+        None,
+    )
+    with state._db.read_snapshot() as tx:
+        assert reads.worker_ids_at_address(tx, addr, exclude=sentinel) == [dead]
+
+    service.register(
+        controller_pb2.Controller.RegisterRequest(worker_id=str(live), address=addr, metadata=make_worker_metadata()),
+        None,
+    )
+
+    # The recycled address now belongs to `live`; the stale `dead` row is gone.
+    with state._db.read_snapshot() as tx:
+        assert reads.worker_ids_at_address(tx, addr, exclude=sentinel) == [live]
+    assert not state._health.liveness(dead).active
+    assert state._health.liveness(live).active
+
+
+def test_register_distinct_addresses_evicts_nothing(service, state):
+    """Registering at a fresh address leaves workers at other addresses untouched."""
+    meta = make_worker_metadata()
+    a, b = WorkerId("worker-a"), WorkerId("worker-b")
+    service.register(
+        controller_pb2.Controller.RegisterRequest(worker_id=str(a), address="10.0.0.1:10001", metadata=meta), None
+    )
+    service.register(
+        controller_pb2.Controller.RegisterRequest(worker_id=str(b), address="10.0.0.2:10001", metadata=meta), None
+    )
+    assert state._health.liveness(a).active
+    assert state._health.liveness(b).active
+
+
 def test_get_scheduler_state_with_running_task(controller_service, state):
     """get_scheduler_state aggregates a running task into a (band, user, worker, job) bucket."""
     # Submit a job and move a task to RUNNING


### PR DESCRIPTION
## Problem

A v4-reserved TPU's worker ran an infinite kill loop: `/michaelryan/cascade-w5/0` was enqueued, built, ran ~12s, then killed as a "zombie attempt (not in desired set)" and re-assigned every ~60s, forever (attempts 116→123+, all `state=6 KILLED`). The slice could not be reaped, and 13 sibling reserved v4-8 slices sat permanently DEGRADED ("no hosts registered — not schedulable") despite having live workers. The controller already had #6445, yet nothing cleaned this up.

Two independent controller bugs:

### Bug 1 — recycled-IP cross-talk (the kill loop)

```mermaid
flowchart TD
    A[Worker VM deleted] --> B[GCP recycles its internal IP onto a new VM]
    B --> C[Dead worker row keeps the stale address —<br/>two workers rows now share one IP]
    C --> D[Controller reconcile dials by ADDRESS]
    D --> E[RPC reaches the LIVE worker now at that IP]
    E --> F[Live worker routes by attempt_uid →<br/>kills its own task as a zombie<br/>state=6 KILLED · ~12s · forever]
    E -. "#6445 identity check" .-> G{Responder echoes worker_id?}
    G -->|"pre-#6445 worker image: no"| H[check skipped → folded REACHED →<br/>never accrues failures → NEVER REAPED]
    G -->|"fixed image: yes"| I[mismatch → evict stub]
```

#6445's controller-side identity check only fires when the **responder** echoes its `worker_id`. The live workers run a pre-#6445 image that echoes none, so the stale row is folded `REACHED`, never accrues failures, and is never reaped — the loop persists regardless of #6445.

### Bug 2 — adopted READY slices never repopulate membership (the DEGRADED slices)

```mermaid
flowchart TD
    P[Slice adopted READY with worker_ids = empty] --> Q[refresh only describes BOOTING/INITIALIZING slices]
    Q --> R[A READY slice is never re-described]
    R --> S[worker_ids stays empty → host_count 0 → DEGRADED]
    S --> T1{idle-scaledown reaper}
    T1 -->|"has a live worker → not idle-empty"| R
    S --> T2{no-worker-probe reaper}
    T2 -->|"describe returns the live worker → not empty"| R
```

`mark_slice_ready` is the only writer of `worker_ids`, and `refresh()` only describes not-yet-ready slices. A slice adopted READY-but-empty is therefore never re-described: membership is never repopulated, and neither reaper fires (it *has* a live worker). It stays DEGRADED forever — unschedulable but un-reaped.

## Fixes

- **Eviction at registration** (`service.py`, `reads.py`, `controller.py`): when a worker registers, any other row still holding that address (the recycled-IP prior owner) is queued for fail-and-teardown. The Register RPC runs off the control-loop thread where reaping a slice via the autoscaler is unsafe, so it calls `Controller.request_worker_eviction`; the control tick drains the queue through the same `_fail_and_teardown` path used for reconcile-failed workers. That fails the stale row, terminates its slice and healthy siblings, and evicts the cached stub — so the zombie is reaped *and* no leaked slice keeps counting against `max_slices`. Controller-only, independent of worker image version.
- **Re-describe READY-but-empty slices** (`scaling_group.py`, `runtime.py`): `refresh()` now also describes READY slices the autoscaler tracks no workers for. A live slice repopulates via `mark_slice_ready` and becomes schedulable; a genuinely-gone one is reaped by the existing FAILED/UNKNOWN and no-worker-probe paths.

## Testing

- New regression tests: `test_register_requests_eviction_of_recycled_address_owner`, `test_register_distinct_addresses_requests_no_eviction`, `test_request_worker_eviction_tears_down_on_next_tick` (control-tick drain → teardown), `test_slices_needing_describe_includes_ready_without_workers`.
- `pytest` controller + scaling-group suites green (320 passed); `pyrefly` 0 errors; `pre-commit.py --review` clean.

## Residual cleanup (separate)

A sweep of the live cluster found **0 current duplicate IPs** but **~215 orphan READY slice rows in retired scale groups** (old `tpu_v5e_16-…` naming, VMs gone since Mar/Apr) that `restore_scaling_group` skips because the group is absent from config, so they never get discarded. Harmless (no VMs/cost) but stale. Not addressed here; a startup purge for config-absent groups is a candidate follow-up.

