### PR TITLE
[iris] Bound the reconcile round so stragglers don't stall worker liveness

### DIFF
--- a/lib/iris/src/iris/cluster/backends/rpc/backend.py
+++ b/lib/iris/src/iris/cluster/backends/rpc/backend.py
@@ -48,11 +48,14 @@ from iris.rpc.worker_connect import WorkerServiceClient
 
 logger = logging.getLogger(__name__)
 
-# Per-worker RPC deadline applied to every fanned-out worker reconcile call.
-# Combined with the fan-out semaphore this bounds a full reconcile round at
-# ~DEFAULT_WORKER_RPC_TIMEOUT * ceil(num_workers / parallelism), so the control
-# thread is never blocked indefinitely even if the whole fleet is hung.
+# Per-worker RPC deadline for on-demand worker RPCs (profile_task, exec_in_container,
+# get_process_status) and the cached stub's fallback timeout.
 DEFAULT_WORKER_RPC_TIMEOUT = Duration.from_seconds(10.0)
+
+# Tighter per-worker deadline for the reconcile fan-out: a hung worker can't gate
+# the gather-joined round on the slow straggler, and a missed round never reaps a
+# worker (the reconcile-failure threshold is dozens of rounds).
+RECONCILE_RPC_TIMEOUT = Duration.from_seconds(3.0)
 
 # Max concurrent in-flight per-worker RPCs in a fan-out (asyncio.Semaphore width).
 # Kept >= fleet size so the whole fleet reconciles in one wave and a slow worker
@@ -313,7 +316,9 @@ class RpcTaskBackend:
                     await asyncio.sleep(rule.delay_seconds)
                     raise ProviderError("chaos: controller.reconcile")
                 stub = self.stub_factory.get_stub(address)
-                response = await stub.reconcile(plan.request)
+                response = await asyncio.wait_for(
+                    stub.reconcile(plan.request), timeout=RECONCILE_RPC_TIMEOUT.to_seconds()
+                )
                 return WorkerReconcileResult(
                     worker_id=plan.worker_id,
                     observations=list(response.observed),
@@ -322,7 +327,7 @@ class RpcTaskBackend:
                     responder_worker_id=response.worker_id or None,
                 )
             except Exception as e:
-                return WorkerReconcileResult(worker_id=plan.worker_id, observations=[], error=str(e))
+                return WorkerReconcileResult(worker_id=plan.worker_id, observations=[], error=str(e) or type(e).__name__)
 
     def close(self) -> None:
         if self.autoscaler is not None:


### PR DESCRIPTION
## Problem

Workers on the `marin` dashboard show ~30s in "time since last ping" despite the recent loop-perf pass. There is no ping loop — "since last ping" is just *time since the last successful Reconcile RPC folded a worker's heartbeat*.

The control loop runs `schedule → reconcile → autoscale` serially on **one thread**. The reconcile fan-out joins every worker under one `asyncio.gather`, so the round only returns once the **slowest** worker does. With the 10s per-RPC `DEFAULT_WORKER_RPC_TIMEOUT`, as few as a handful of dead-but-IP-reachable workers (GCP recycles a deleted VM's internal IP — the stale address accepts a TCP connection then hangs, cf. #6445) drag **every** round out to ~10s, while all healthy workers answered sub-second.

## Evidence (live `marin` controller, profile/read-only)

- Controller CPU **0.055 cores** → I/O-bound, not CPU-bound.
- Thread-dump sampling of the `control-loop` thread: **~71% reconcile fan-out (blocked in `select`), ~21% autoscale cloud I/O, ~8% idle.** Schedule never showed up (<1s).
- `list-workers`: **347 of 352 workers shared an identical ping age**, oscillating in a sawtooth **~20s (floor = tick wall-time) → ~31s**, never fresh. The 5 outliers were genuinely dead (`consecutive_failures` 31–43, threshold 50). Fleet: 350 workers, 307 ready + 101 booting slices, 372 running tasks.

## Fix (this PR)

Bound each reconcile RPC with a dedicated **3s** deadline via `asyncio.wait_for`, separate from the 10s deadline the on-demand RPCs (`profile`/`exec`/`status`) still use. A timeout surfaces as an `UNREACHABLE` event exactly like any RPC failure; the reconcile-failure threshold is dozens of rounds, so a momentarily-slow worker is never falsely reaped. The round now finishes in ~3s regardless of how many workers hang (sub-second when none do).

This removes the dominant ~71% cost. Reconcile rounds drop from ~10s → ≤3s; the ping-age floor drops from ~20s to a few seconds.

`handle_reconcile` on the worker only records desired state (`submit_task`/`_kill_async`) and returns observations — no blocking container work — so 3s is ample headroom.

## Follow-up (designed, not in this PR)

To take the **peak** under 5s during scale-up churn, the autoscale phase (~21%, and the every-tick `should_run`-at-tick-start feedback loop) must come off the reconcile thread, plus drop the redundant `/health` probe from the hot path. Concrete design + expected impact in the investigation note.

## Test

`test_reconcile_straggler_does_not_gate_the_round`: with the deadline patched to 50ms and one worker sleeping 5s, the round returns in <1s, the straggler is `UNREACHABLE`, and the healthy worker is still `REACHED`.

## Report

Full investigation, profiles, per-phase breakdown, and the two-lever fix analysis: `.agents/ops/2026-06-17-iris-reconcile-loop-30s-ping-latency.md`.

> ⚠️ Deploying this requires rebuilding `iris-controller:latest` (`gh workflow run "Ops - Docker Images"`) **then** restarting the controller — a bare restart re-pulls the stale `:latest`.

Tracked as weaver #212.

🤖 Generated with [Claude Code](https://claude.com/claude-code)