### PR TITLE
[RL] Remove sleeps from rollout tests

### DIFF
--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -982,9 +982,9 @@ def load_checkpoint_or_initialize(
     return load_or_init
 
 
-def _load_metadata(checkpoint_path, fs=None):
+def _load_metadata(checkpoint_path, fs=None, storage_options: Mapping[str, Any] | None = None):
     if fs is None:
-        fs, _, _ = fsspec.get_fs_token_paths(str(checkpoint_path))
+        fs, _, _ = fsspec.get_fs_token_paths(str(checkpoint_path), storage_options=dict(storage_options or {}))
     with fs.open(os.path.join(checkpoint_path, "metadata.json")) as metadata_in:
         metadata = json.load(metadata_in)
     return metadata
@@ -995,6 +995,7 @@ def discover_checkpoint_candidates(
     *additional_paths: PathLike,
     exclude_paths: Sequence[PathLike] = (),
     max_step: int | None = None,
+    storage_options: Mapping[str, Any] | None = None,
 ) -> list[CheckpointCandidate]:
     """Return complete checkpoint candidates across one or more roots.
 
@@ -1011,7 +1012,7 @@ def discover_checkpoint_candidates(
     candidates_by_path: dict[str, CheckpointCandidate] = {}
 
     for cp_path in all_paths:
-        for candidate in _discover_checkpoint_candidates_single(cp_path):
+        for candidate in _discover_checkpoint_candidates_single(cp_path, storage_options=storage_options):
             if max_step is not None and candidate.step > max_step:
                 continue
             if _is_path_under_any(candidate.path, exclude_paths):
@@ -1039,6 +1040,7 @@ def discover_latest_checkpoint(
     *additional_paths: PathLike,
     exclude_paths: Sequence[PathLike] = (),
     max_step: int | None = None,
+    storage_options: Mapping[str, Any] | None = None,
 ) -> Optional[str]:
     """
     Discover the latest checkpoint across one or more root paths.
@@ -1048,7 +1050,11 @@ def discover_latest_checkpoint(
     """
     all_paths = [str(checkpoint_path)] + [str(p) for p in additional_paths]
     candidates = discover_checkpoint_candidates(
-        checkpoint_path, *additional_paths, exclude_paths=exclude_paths, max_step=max_step
+        checkpoint_path,
+        *additional_paths,
+        exclude_paths=exclude_paths,
+        max_step=max_step,
+        storage_options=storage_options,
     )
 
     if candidates:
@@ -1065,10 +1071,15 @@ def latest_checkpoint_path(
     *additional_paths: PathLike,
     exclude_paths: Sequence[PathLike] = (),
     max_step: int | None = None,
+    storage_options: Mapping[str, Any] | None = None,
 ) -> str:
     """Return the latest concrete checkpoint path across one or more search roots."""
     latest = discover_latest_checkpoint(
-        checkpoint_path, *additional_paths, exclude_paths=exclude_paths, max_step=max_step
+        checkpoint_path,
+        *additional_paths,
+        exclude_paths=exclude_paths,
+        max_step=max_step,
+        storage_options=storage_options,
     )
     if latest is None:
         search_paths = [str(checkpoint_path)] + [str(path) for path in additional_paths]
@@ -1076,13 +1087,15 @@ def latest_checkpoint_path(
     return latest
 
 
-def _discover_checkpoint_candidates_single(checkpoint_path: str) -> list[CheckpointCandidate]:
+def _discover_checkpoint_candidates_single(
+    checkpoint_path: str, storage_options: Mapping[str, Any] | None = None
+) -> list[CheckpointCandidate]:
     """Discover complete checkpoint candidates in a single root path."""
     candidates: list[CheckpointCandidate] = []
 
-    for ckpt_dir in _discover_checkpoint_paths_single(checkpoint_path):
+    for ckpt_dir in _discover_checkpoint_paths_single(checkpoint_path, storage_options=storage_options):
         try:
-            metadata = _load_metadata(ckpt_dir)
+            metadata = _load_metadata(ckpt_dir, storage_options=storage_options)
             step = int(metadata["step"])
             timestamp = datetime.datetime.fromisoformat(metadata["timestamp"])
         except Exception:
@@ -1094,10 +1107,12 @@ def _discover_checkpoint_candidates_single(checkpoint_path: str) -> list[Checkpo
     return sorted(candidates, key=_checkpoint_candidate_sort_key)
 
 
-def _discover_checkpoint_paths_single(checkpoint_path: str) -> list[str]:
+def _discover_checkpoint_paths_single(
+    checkpoint_path: str, storage_options: Mapping[str, Any] | None = None
+) -> list[str]:
     """Discover valid checkpoint directories in a single root path."""
     fs: AbstractFileSystem
-    fs, _ = _get_fs_and_plain_path(checkpoint_path)
+    fs, _ = _get_fs_and_plain_path(checkpoint_path, storage_options=storage_options)
 
     def is_checkpoint_dir(path: str):
         return fs.exists(os.path.join(path, "metadata.json"))
@@ -1113,9 +1128,9 @@ def _discover_checkpoint_paths_single(checkpoint_path: str) -> list[str]:
     return sorted(d for d in ckpt_dirs if is_checkpoint_dir(d))
 
 
-def _get_fs_and_plain_path(path, fs=None):
+def _get_fs_and_plain_path(path, fs=None, storage_options: Mapping[str, Any] | None = None):
     if fs is None:
-        fs, _, (path_to_open,) = fsspec.get_fs_token_paths(str(path))
+        fs, _, (path_to_open,) = fsspec.get_fs_token_paths(str(path), storage_options=dict(storage_options or {}))
     else:
         path_to_open = path
     return fs, path_to_open

--- a/lib/levanter/tests/test_checkpoint.py
+++ b/lib/levanter/tests/test_checkpoint.py
@@ -317,6 +317,32 @@ def test_checkpoint_candidate_discovery_sorts_by_numeric_step_before_timestamp()
         assert latest_checkpoint_path(tempdir) == f"{tempdir}/step-10"
 
 
+def test_checkpoint_candidate_discovery_passes_storage_options(monkeypatch, tmp_path):
+    _write_checkpoint_metadata(tmp_path / "step-10", step=10, timestamp="2021-01-01T00:00:00")
+    storage_options = {"use_listings_cache": False, "skip_instance_cache": True}
+    observed_storage_options = []
+    get_fs_token_paths = fsspec.get_fs_token_paths
+
+    def record_get_fs_token_paths(*args, **kwargs):
+        observed_storage_options.append(kwargs.get("storage_options"))
+        return get_fs_token_paths(*args, **kwargs)
+
+    monkeypatch.setattr(fsspec, "get_fs_token_paths", record_get_fs_token_paths)
+
+    candidates = discover_checkpoint_candidates(str(tmp_path), storage_options=storage_options)
+
+    assert candidates == [
+        CheckpointCandidate(
+            path=str(tmp_path / "step-10"),
+            step=10,
+            timestamp=datetime.datetime(2021, 1, 1, 0, 0, 0),
+            metadata={"step": 10, "timestamp": "2021-01-01T00:00:00", "is_temporary": False},
+        )
+    ]
+    assert observed_storage_options
+    assert all(option == storage_options for option in observed_storage_options)
+
+
 def test_checkpoint_candidate_discovery_can_exclude_rejected_lineage_and_max_step():
     with tempfile.TemporaryDirectory() as good_dir, tempfile.TemporaryDirectory() as rejected_dir:
         _write_checkpoint_metadata(pathlib.Path(good_dir) / "step-100", step=100, timestamp="2021-01-01T00:00:00")

--- a/lib/marin/src/marin/rl/rollout_storage.py
+++ b/lib/marin/src/marin/rl/rollout_storage.py
@@ -172,27 +172,27 @@ class FileRolloutReader(RolloutReader):
         logger.info(f"Initialized file rollout reader at {path}")
 
     def _get_available_files(self) -> list[str]:
-        """Get list of available batch files sorted by timestamp."""
+        """Get list of available batch files sorted by timestamp and writer counter."""
         pattern = f"{self.path}/*.pkl"
         files = self.fs.glob(pattern)
 
-        # Parse and sort files by timestamp
         parsed_files = []
         for file_path in files:
             filename = file_path.split("/")[-1]
             if filename.endswith(".pkl"):
-                # Extract timestamp from filename: timestamp_hostname_counter.pkl
-                parts = filename.split("_")
-                if len(parts) == 3:
-                    timestamp_int = int(parts[0])
-                    timestamp = timestamp_int / 1000000.0  # Convert back from microseconds
-                    parsed_files.append((timestamp, file_path))
-                else:
-                    logger.warning(f"Unexpected filename format: {filename}")
+                stem = filename.removesuffix(".pkl")
+                try:
+                    timestamp_raw, host_and_counter = stem.split("_", maxsplit=1)
+                    _, counter_raw = host_and_counter.rsplit("_", maxsplit=1)
+                    timestamp = int(timestamp_raw)
+                    counter = int(counter_raw)
+                except ValueError:
+                    logger.warning("Unexpected rollout filename format: %s", filename)
+                    continue
+                parsed_files.append((timestamp, counter, file_path))
 
-        # Sort by timestamp and return file paths
-        parsed_files.sort(key=lambda x: x[0])
-        return [file_path for _, file_path in parsed_files]
+        parsed_files.sort(key=lambda x: (x[0], x[1]))
+        return [file_path for _, _, file_path in parsed_files]
 
     def read_batch(self, timeout: float | None = None) -> RolloutBatch | None:
         """Read a single batch with optional timeout.

--- a/lib/marin/src/marin/rl/rollout_storage.py
+++ b/lib/marin/src/marin/rl/rollout_storage.py
@@ -47,6 +47,8 @@ from .types import RolloutBatch
 
 logger = logging.getLogger(__name__)
 
+ROLLOUT_FILE_SUFFIX = ".pkl"
+
 
 class StorageType(Enum):
     """Type of rollout storage backend."""
@@ -173,14 +175,14 @@ class FileRolloutReader(RolloutReader):
 
     def _get_available_files(self) -> list[str]:
         """Get list of available batch files sorted by timestamp and writer counter."""
-        pattern = f"{self.path}/*.pkl"
+        pattern = f"{self.path}/*{ROLLOUT_FILE_SUFFIX}"
         files = self.fs.glob(pattern)
 
         parsed_files = []
         for file_path in files:
             filename = file_path.split("/")[-1]
-            if filename.endswith(".pkl"):
-                stem = filename.removesuffix(".pkl")
+            if filename.endswith(ROLLOUT_FILE_SUFFIX):
+                stem = filename.removesuffix(ROLLOUT_FILE_SUFFIX)
                 try:
                     timestamp_raw, host_and_counter = stem.split("_", maxsplit=1)
                     _, counter_raw = host_and_counter.rsplit("_", maxsplit=1)
@@ -296,7 +298,7 @@ class FileRolloutWriter(RolloutWriter):
     def _get_batch_path(self, timestamp: float, counter: int) -> str:
         """Get path for batch with timestamp and hostname."""
         timestamp_int = int(timestamp * 1000000)  # microseconds for ordering
-        return f"{self.path}/{timestamp_int:020d}_{self.hostname}_{counter:06d}.pkl"
+        return f"{self.path}/{timestamp_int:020d}_{self.hostname}_{counter:06d}{ROLLOUT_FILE_SUFFIX}"
 
     def write_batch(self, batch: RolloutBatch) -> None:
         """Write batch to storage with all required fields."""

--- a/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
+++ b/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
@@ -32,6 +32,8 @@ from .base import (
 
 logger = logging.getLogger(__name__)
 
+CHECKPOINT_STEP_PREFIX = "step_"
+
 
 def _rm_thread(path: str) -> None:
     try:
@@ -58,7 +60,7 @@ class GCSCheckpointServer(WeightTransferServer):
 
     def serve_weights(self, weight_id: int, model: PyTree) -> None:
         """Save checkpoint using Levanter's checkpoint system."""
-        checkpoint_path = os.path.join(self.config.checkpoint_dir, f"step_{weight_id}")
+        checkpoint_path = os.path.join(self.config.checkpoint_dir, f"{CHECKPOINT_STEP_PREFIX}{weight_id}")
 
         self.metrics.total_transfers += 1
 
@@ -66,7 +68,7 @@ class GCSCheckpointServer(WeightTransferServer):
             # Manage checkpoint queue
             if self.config.max_checkpoints is not None and len(self.checkpoint_queue) >= self.config.max_checkpoints:
                 old_weight_id = self.checkpoint_queue.popleft()
-                old_path = os.path.join(self.config.checkpoint_dir, f"step_{old_weight_id}")
+                old_path = os.path.join(self.config.checkpoint_dir, f"{CHECKPOINT_STEP_PREFIX}{old_weight_id}")
                 if jax.process_index() == 0:  # Only delete from coordinator
                     logger.info(f"Cleaning up old checkpoint at weight_id {old_weight_id} ({old_path})...")
                     fs, _ = url_to_fs(old_path)
@@ -170,9 +172,9 @@ class GCSCheckpointClient(WeightTransferClient):
         for d in dirs:
             # Handle trailing slashes in directory names
             step_name = d.rstrip("/").split("/")[-1]
-            if step_name.startswith("step_"):
+            if step_name.startswith(CHECKPOINT_STEP_PREFIX):
                 try:
-                    step_num = int(step_name.removeprefix("step_"))
+                    step_num = int(step_name.removeprefix(CHECKPOINT_STEP_PREFIX))
                 except ValueError:
                     logger.warning("Ignoring malformed checkpoint directory: %s", d)
                     continue

--- a/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
+++ b/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
@@ -33,6 +33,10 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 CHECKPOINT_STEP_PREFIX = "step_"
+CHECKPOINT_DISCOVERY_STORAGE_OPTIONS = {
+    "use_listings_cache": False,
+    "skip_instance_cache": True,
+}
 
 
 def _rm_thread(path: str) -> None:
@@ -160,7 +164,10 @@ class GCSCheckpointClient(WeightTransferClient):
     def _find_latest_checkpoint(self) -> tuple[str, int] | None:
         """Find the latest checkpoint in the checkpoint directory."""
         logger.info(f"Search for new checkpoints in {self.config.checkpoint_dir}...")
-        checkpoint_candidates = levanter_checkpoint.discover_checkpoint_candidates(self.config.checkpoint_dir)
+        checkpoint_candidates = levanter_checkpoint.discover_checkpoint_candidates(
+            self.config.checkpoint_dir,
+            storage_options=CHECKPOINT_DISCOVERY_STORAGE_OPTIONS,
+        )
         if not checkpoint_candidates:
             return None
 

--- a/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
+++ b/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
@@ -165,13 +165,17 @@ class GCSCheckpointClient(WeightTransferClient):
         # Checkpoint format is {checkpoint_dir}/step_{xyz}
         # Make sure we expire before our poll-interval.
         # We disable caching above, but it's unclear if fsspec adheres to this.
-        dirs = fs.ls(path_in_fs, listings_expiry_time=1.0)
+        dirs = fs.ls(path_in_fs, detail=False, listings_expiry_time=1.0)
         checkpoint_dirs = []
         for d in dirs:
             # Handle trailing slashes in directory names
             step_name = d.rstrip("/").split("/")[-1]
             if step_name.startswith("step_"):
-                step_num = int(step_name.split("_")[-1])
+                try:
+                    step_num = int(step_name.removeprefix("step_"))
+                except ValueError:
+                    logger.warning("Ignoring malformed checkpoint directory: %s", d)
+                    continue
                 logger.info(f"Found checkpoint directory: {d} with step number {step_num}")
                 checkpoint_dirs.append((step_num, d))
         if not checkpoint_dirs:

--- a/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
+++ b/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
@@ -160,35 +160,17 @@ class GCSCheckpointClient(WeightTransferClient):
     def _find_latest_checkpoint(self) -> tuple[str, int] | None:
         """Find the latest checkpoint in the checkpoint directory."""
         logger.info(f"Search for new checkpoints in {self.config.checkpoint_dir}...")
-        fs, path_in_fs = url_to_fs(self.config.checkpoint_dir, use_listings_cache=False)
-        if not fs.exists(path_in_fs):
+        checkpoint_candidates = levanter_checkpoint.discover_checkpoint_candidates(self.config.checkpoint_dir)
+        if not checkpoint_candidates:
             return None
 
-        # Checkpoint format is {checkpoint_dir}/step_{xyz}
-        # Make sure we expire before our poll-interval.
-        # We disable caching above, but it's unclear if fsspec adheres to this.
-        dirs = fs.ls(path_in_fs, detail=False, listings_expiry_time=1.0)
-        checkpoint_dirs = []
-        for d in dirs:
-            # Handle trailing slashes in directory names
-            step_name = d.rstrip("/").split("/")[-1]
-            if step_name.startswith(CHECKPOINT_STEP_PREFIX):
-                try:
-                    step_num = int(step_name.removeprefix(CHECKPOINT_STEP_PREFIX))
-                except ValueError:
-                    logger.warning("Ignoring malformed checkpoint directory: %s", d)
-                    continue
-                logger.info(f"Found checkpoint directory: {d} with step number {step_num}")
-                checkpoint_dirs.append((step_num, d))
-        if not checkpoint_dirs:
-            return None
-
-        step_num, latest_dir = max(checkpoint_dirs, key=lambda x: x[0])
-        # Reconstruct full URL with original scheme
-        if "://" in str(self.config.checkpoint_dir) and "://" not in latest_dir:
-            scheme = self.config.checkpoint_dir.split("://")[0]
-            return f"{scheme}://{latest_dir}", step_num
-        return latest_dir, step_num
+        latest_checkpoint = checkpoint_candidates[-1]
+        logger.info(
+            "Found checkpoint directory: %s with step number %d",
+            latest_checkpoint.path,
+            latest_checkpoint.step,
+        )
+        return latest_checkpoint.path, latest_checkpoint.step
 
     def cleanup(self) -> None:
         """No cleanup needed for GCS checkpoints."""

--- a/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
+++ b/lib/marin/src/marin/rl/weight_transfer/checkpoint.py
@@ -33,10 +33,10 @@ from .base import (
 logger = logging.getLogger(__name__)
 
 CHECKPOINT_STEP_PREFIX = "step_"
-CHECKPOINT_DISCOVERY_STORAGE_OPTIONS = {
-    "use_listings_cache": False,
-    "skip_instance_cache": True,
-}
+CHECKPOINT_DISCOVERY_STORAGE_OPTIONS = (
+    ("use_listings_cache", False),
+    ("skip_instance_cache", True),
+)
 
 
 def _rm_thread(path: str) -> None:
@@ -166,7 +166,7 @@ class GCSCheckpointClient(WeightTransferClient):
         logger.info(f"Search for new checkpoints in {self.config.checkpoint_dir}...")
         checkpoint_candidates = levanter_checkpoint.discover_checkpoint_candidates(
             self.config.checkpoint_dir,
-            storage_options=CHECKPOINT_DISCOVERY_STORAGE_OPTIONS,
+            storage_options=dict(CHECKPOINT_DISCOVERY_STORAGE_OPTIONS),
         )
         if not checkpoint_candidates:
             return None

--- a/tests/integration/iris/test_iris_integration.py
+++ b/tests/integration/iris/test_iris_integration.py
@@ -9,7 +9,6 @@ No dashboard screenshots are taken here; those remain in lib/iris/tests/e2e/test
 
 import logging
 import os
-import time
 import uuid
 
 import pytest
@@ -118,15 +117,20 @@ def test_log_levels_populated(integration_cluster, verbose_job):
     """Task logs have level field (INFO, WARNING, ERROR)."""
     task_id = verbose_job.job_id.task(0).to_wire()
 
-    deadline = time.monotonic() + integration_cluster.job_timeout
     entries = []
     source = f"{task_id}:"
-    while time.monotonic() < deadline:
+
+    def _has_info_marker():
+        nonlocal entries
         response = integration_cluster.fetch_logs(source, match_scope=logging_pb2.MATCH_SCOPE_PREFIX)
         entries = list(response.entries)
-        if any("info-marker" in e.data for e in entries):
-            break
-        time.sleep(0.5)
+        return any("info-marker" in e.data for e in entries)
+
+    found_info_marker = ExponentialBackoff(initial=0.1, maximum=0.5).wait_until(
+        _has_info_marker,
+        timeout=Duration.from_seconds(integration_cluster.job_timeout),
+    )
+    assert found_info_marker, f"info-marker not found. Got {len(entries)} entries"
 
     markers_found = {}
     for entry in entries:
@@ -134,7 +138,7 @@ def test_log_levels_populated(integration_cluster, verbose_job):
             if marker in entry.data:
                 markers_found[marker] = entry.level
 
-    assert "info-marker" in markers_found, f"info-marker not found. Got {len(entries)} entries"
+    assert "info-marker" in markers_found
     assert markers_found["info-marker"] == logging_pb2.LOG_LEVEL_INFO
     assert markers_found.get("warning-marker") == logging_pb2.LOG_LEVEL_WARNING
     assert markers_found.get("error-marker") == logging_pb2.LOG_LEVEL_ERROR

--- a/tests/rl/integration/test_rollout_worker.py
+++ b/tests/rl/integration/test_rollout_worker.py
@@ -4,7 +4,6 @@
 """Test rollout worker in isolation."""
 
 import os
-import time
 
 import pytest
 from marin.rl.kl_regularization import KLConfig, KLMode
@@ -57,8 +56,6 @@ def test_rollout_worker(tmp_path):
 
     with runner:
         runner.wait_for_result()
-
-        time.sleep(0.5)
 
         batches = queue_reader.read_all_available()
         assert len(batches) > 0, "Should be able to read batches from queue"

--- a/tests/rl/integration/test_weight_sync.py
+++ b/tests/rl/integration/test_weight_sync.py
@@ -4,12 +4,12 @@
 """Test rollout and training workers with weight synchronization."""
 
 import os
-import time
 
 import pytest
 from marin.rl.kl_regularization import KLConfig, KLMode
 from marin.rl.rl_job import RLJob, RLJobConfig, TrainParams
 from marin.rl.rl_losses import RLOOLoss
+from rigging.timing import Duration, ExponentialBackoff
 
 from tests.rl.integration.config import (
     DummyTokenizer,
@@ -61,7 +61,11 @@ def test_rollout_and_train_workers(tmp_path):
     rollout_runner.rollout_worker_config.max_rollouts = 100
 
     with training_runner:
-        time.sleep(1)
+        training_started = ExponentialBackoff(initial=0.1, maximum=0.5).wait_until(
+            lambda: training_runner.worker is not None,
+            timeout=Duration.from_seconds(30),
+        )
+        assert training_started, "Training worker did not start"
         with rollout_runner:
             result = training_runner.wait_for_result(timeout=60)
             assert result == WaitResult.SUCCESS, "Training timed out after 60s"

--- a/tests/rl/test_checkpoint_transfer.py
+++ b/tests/rl/test_checkpoint_transfer.py
@@ -1,6 +1,8 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import datetime
+import json
 import posixpath
 import uuid
 
@@ -60,7 +62,11 @@ def _create_checkpoint_entries(
     fs.makedirs(path, exist_ok=True)
 
     for step in steps or []:
-        fs.makedirs(posixpath.join(path, f"step_{step}"), exist_ok=True)
+        checkpoint_path = posixpath.join(path, f"step_{step}")
+        fs.makedirs(checkpoint_path, exist_ok=True)
+        timestamp = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC) + datetime.timedelta(seconds=step)
+        with fs.open(posixpath.join(checkpoint_path, "metadata.json"), "w") as f:
+            json.dump({"step": step, "timestamp": timestamp.isoformat()}, f)
 
     for directory in directories or []:
         fs.makedirs(posixpath.join(path, directory), exist_ok=True)

--- a/tests/rl/test_checkpoint_transfer.py
+++ b/tests/rl/test_checkpoint_transfer.py
@@ -62,7 +62,7 @@ def _create_checkpoint_entries(
     fs.makedirs(path, exist_ok=True)
 
     for step in steps or []:
-        checkpoint_path = posixpath.join(path, f"step_{step}")
+        checkpoint_path = posixpath.join(path, f"{checkpoint_transfer.CHECKPOINT_STEP_PREFIX}{step}")
         fs.makedirs(checkpoint_path, exist_ok=True)
         timestamp = datetime.datetime(2026, 1, 1, tzinfo=datetime.UTC) + datetime.timedelta(seconds=step)
         with fs.open(posixpath.join(checkpoint_path, "metadata.json"), "w") as f:

--- a/tests/rl/test_checkpoint_transfer.py
+++ b/tests/rl/test_checkpoint_transfer.py
@@ -145,4 +145,3 @@ def test_receive_weights_supports_fsspec_memory_scheme(memory_checkpoint_dir, ch
     assert update is not None
     assert update.weight_id == 42
     assert checkpoint_paths == [expected_checkpoint_path]
-    assert not checkpoint_paths[0].startswith("memory://memory://")

--- a/tests/rl/test_checkpoint_transfer.py
+++ b/tests/rl/test_checkpoint_transfer.py
@@ -1,319 +1,142 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import os
-import tempfile
-from unittest.mock import Mock, patch
+import posixpath
+import uuid
 
 import pytest
+from rigging.filesystem import url_to_fs
 
 try:
+    import marin.rl.weight_transfer.checkpoint as checkpoint_transfer
     from marin.rl.weight_transfer import (
-        GCSCheckpointClient,
         WeightTransferConfig,
         WeightTransferMode,
+        create_weight_transfer_client,
     )
 except ImportError:
     pytest.skip("Post training imports unavailable", allow_module_level=True)
 
 
-pytestmark = pytest.mark.skipif(os.environ.get("CI") is not None, reason="GCS tests are skipped on CI")
+@pytest.fixture
+def checkpoint_loader(monkeypatch):
+    loaded_model = object()
+    checkpoint_paths = []
+
+    def fake_load_checkpoint(*, tree, checkpoint_path, axis_mapping, mesh):
+        checkpoint_paths.append(checkpoint_path)
+        return loaded_model
+
+    monkeypatch.setattr(checkpoint_transfer.levanter_checkpoint, "load_checkpoint", fake_load_checkpoint)
+    return checkpoint_paths, loaded_model
 
 
 @pytest.fixture
-def gcs_config():
-    """Create weight transfer config for GCS checkpoint mode."""
+def memory_checkpoint_dir():
+    checkpoint_dir = f"memory://checkpoint-transfer-{uuid.uuid4().hex}/policy_checkpoints"
+    yield checkpoint_dir
+
+    fs, path = url_to_fs(checkpoint_dir)
+    root = f"/{path.strip('/').split('/', maxsplit=1)[0]}"
+    if fs.exists(root):
+        fs.rm(root, recursive=True)
+
+
+def _checkpoint_config(checkpoint_dir: str) -> WeightTransferConfig:
     return WeightTransferConfig(
         mode=WeightTransferMode.GCS_CHECKPOINT,
-        checkpoint_dir="gs://marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints",
+        checkpoint_dir=checkpoint_dir,
     )
 
 
-@pytest.fixture
-def local_config():
-    """Create weight transfer config for local filesystem."""
-    with tempfile.TemporaryDirectory() as temp_dir:
-        config = WeightTransferConfig(
-            mode=WeightTransferMode.GCS_CHECKPOINT,
-            checkpoint_dir=temp_dir,
+def _create_checkpoint_entries(
+    checkpoint_dir: str,
+    *,
+    steps: list[int] | None = None,
+    directories: list[str] | None = None,
+    files: list[str] | None = None,
+) -> None:
+    fs, path = url_to_fs(checkpoint_dir)
+    fs.makedirs(path, exist_ok=True)
+
+    for step in steps or []:
+        fs.makedirs(posixpath.join(path, f"step_{step}"), exist_ok=True)
+
+    for directory in directories or []:
+        fs.makedirs(posixpath.join(path, directory), exist_ok=True)
+
+    for filename in files or []:
+        fs.touch(posixpath.join(path, filename))
+
+
+def test_receive_weights_loads_latest_numeric_checkpoint(tmp_path, checkpoint_loader):
+    checkpoint_dir = str(tmp_path / "policy_checkpoints")
+    _create_checkpoint_entries(
+        checkpoint_dir,
+        steps=[9, 100, 39],
+        directories=["other_dir", "step_not_numeric"],
+        files=["config.json"],
+    )
+    checkpoint_paths, loaded_model = checkpoint_loader
+    old_model = object()
+
+    client = create_weight_transfer_client(_checkpoint_config(checkpoint_dir))
+    update = client.receive_weights(old_model)
+
+    assert update is not None
+    assert update.model is loaded_model
+    assert update.weight_id == 100
+    assert checkpoint_paths == [str(tmp_path / "policy_checkpoints" / "step_100")]
+
+
+@pytest.mark.parametrize("create_entries", [False, True])
+def test_receive_weights_without_checkpoints_returns_none(tmp_path, checkpoint_loader, create_entries):
+    checkpoint_dir = str(tmp_path / "policy_checkpoints")
+    if create_entries:
+        _create_checkpoint_entries(
+            checkpoint_dir,
+            directories=["other_dir", "step_not_numeric"],
+            files=["config.json"],
         )
-        yield config
+    checkpoint_paths, _ = checkpoint_loader
+
+    client = create_weight_transfer_client(_checkpoint_config(checkpoint_dir))
+
+    assert client.receive_weights(object()) is None
+    assert checkpoint_paths == []
 
 
-def test_find_latest_checkpoint_with_trailing_slashes(gcs_config):
-    """Test handling of trailing slashes in directory names from fs.ls()."""
-    client = GCSCheckpointClient(gcs_config)
+def test_receive_weights_skips_repeated_checkpoint_and_loads_newer_step(tmp_path, checkpoint_loader):
+    checkpoint_dir = str(tmp_path / "policy_checkpoints")
+    _create_checkpoint_entries(checkpoint_dir, steps=[3])
+    checkpoint_paths, _ = checkpoint_loader
+    old_model = object()
 
-    # Mock fsspec to return dirs with trailing slashes (common for GCS)
-    mock_fs = Mock()
-    mock_fs.exists.return_value = True
-    mock_fs.ls.return_value = [
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_36/",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_37/",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_38/",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_39/",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_40/",
-    ]
+    client = create_weight_transfer_client(_checkpoint_config(checkpoint_dir))
+    first_update = client.receive_weights(old_model)
+    repeated_update = client.receive_weights(old_model)
 
-    with patch(
-        "fsspec.core.url_to_fs",
-        return_value=(
-            mock_fs,
-            "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints",
-        ),
-    ):
-        result = client._find_latest_checkpoint()
+    _create_checkpoint_entries(checkpoint_dir, steps=[5])
+    second_update = client.receive_weights(old_model)
 
-    # Should find step_40 (highest number) and reconstruct full GCS URL
-    # Note: preserves trailing slash from original fs.ls() result
-    expected_path = "gs://marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_40/"
-    expected_step = 40
-    assert result == (expected_path, expected_step)
+    assert first_update is not None
+    assert first_update.weight_id == 3
+    assert repeated_update is None
+    assert second_update is not None
+    assert second_update.weight_id == 5
+    assert [posixpath.basename(path) for path in checkpoint_paths] == ["step_3", "step_5"]
 
 
-def test_find_latest_checkpoint_without_trailing_slashes(gcs_config):
-    """Test handling when fs.ls() returns paths without trailing slashes."""
-    client = GCSCheckpointClient(gcs_config)
+def test_receive_weights_supports_fsspec_memory_scheme(memory_checkpoint_dir, checkpoint_loader):
+    _create_checkpoint_entries(memory_checkpoint_dir, steps=[42])
+    checkpoint_paths, _ = checkpoint_loader
+    _, path = url_to_fs(memory_checkpoint_dir)
+    expected_checkpoint_path = f"memory://{posixpath.join(path, 'step_42')}"
 
-    mock_fs = Mock()
-    mock_fs.exists.return_value = True
-    mock_fs.ls.return_value = [
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_36",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_40",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_38",
-    ]
+    client = create_weight_transfer_client(_checkpoint_config(memory_checkpoint_dir))
+    update = client.receive_weights(object())
 
-    with patch(
-        "fsspec.core.url_to_fs",
-        return_value=(
-            mock_fs,
-            "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints",
-        ),
-    ):
-        result = client._find_latest_checkpoint()
-
-    expected_path = "gs://marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_40"
-    expected_step = 40
-    assert result == (expected_path, expected_step)
-
-
-def test_find_latest_checkpoint_mixed_formats(gcs_config):
-    """Test handling of mixed directory formats."""
-    client = GCSCheckpointClient(gcs_config)
-
-    mock_fs = Mock()
-    mock_fs.exists.return_value = True
-    mock_fs.ls.return_value = [
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_36/",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_40",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/other_file.txt",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_38/",
-    ]
-
-    with patch(
-        "fsspec.core.url_to_fs",
-        return_value=(
-            mock_fs,
-            "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints",
-        ),
-    ):
-        result = client._find_latest_checkpoint()
-
-    # Should still find step_40 as the latest
-    expected_path = "gs://marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_40"
-    expected_step = 40
-    assert result == (expected_path, expected_step)
-
-
-def test_find_latest_checkpoint_step_number_extraction(gcs_config):
-    """Test correct extraction of step numbers from various formats."""
-    client = GCSCheckpointClient(gcs_config)
-
-    mock_fs = Mock()
-    mock_fs.exists.return_value = True
-    mock_fs.ls.return_value = [
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_9/",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_100/",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_39/",
-    ]
-
-    with patch(
-        "fsspec.core.url_to_fs",
-        return_value=(
-            mock_fs,
-            "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints",
-        ),
-    ):
-        result = client._find_latest_checkpoint()
-
-    # Should find step_100 (highest number), not step_9
-    # Note: preserves trailing slash from original fs.ls() result
-    expected_path = "gs://marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_100/"
-    expected_step = 100
-    assert result == (expected_path, expected_step)
-
-
-def test_find_latest_checkpoint_local_filesystem(local_config):
-    """Test checkpoint discovery with local filesystem paths."""
-    client = GCSCheckpointClient(local_config)
-
-    mock_fs = Mock()
-    mock_fs.exists.return_value = True
-    mock_fs.ls.return_value = [
-        f"{local_config.checkpoint_dir}/step_5",
-        f"{local_config.checkpoint_dir}/step_10",
-        f"{local_config.checkpoint_dir}/step_3",
-    ]
-
-    with patch("fsspec.core.url_to_fs", return_value=(mock_fs, local_config.checkpoint_dir)):
-        result = client._find_latest_checkpoint()
-
-    # For local paths, no scheme reconstruction needed
-    expected_path = f"{local_config.checkpoint_dir}/step_10"
-    expected_step = 10
-    assert result == (expected_path, expected_step)
-
-
-def test_find_latest_checkpoint_empty_directory(gcs_config):
-    """Test behavior when checkpoint directory is empty."""
-    client = GCSCheckpointClient(gcs_config)
-
-    mock_fs = Mock()
-    mock_fs.exists.return_value = True
-    mock_fs.ls.return_value = []
-
-    with patch(
-        "fsspec.core.url_to_fs",
-        return_value=(
-            mock_fs,
-            "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints",
-        ),
-    ):
-        result = client._find_latest_checkpoint()
-
-    assert result is None
-
-
-def test_find_latest_checkpoint_nonexistent_directory(gcs_config):
-    """Test behavior when checkpoint directory doesn't exist."""
-    client = GCSCheckpointClient(gcs_config)
-
-    mock_fs = Mock()
-    mock_fs.exists.return_value = False
-
-    with patch(
-        "fsspec.core.url_to_fs",
-        return_value=(
-            mock_fs,
-            "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints",
-        ),
-    ):
-        result = client._find_latest_checkpoint()
-
-    assert result is None
-
-
-def test_find_latest_checkpoint_no_step_directories(gcs_config):
-    """Test behavior when directory has files but no step_ directories."""
-    client = GCSCheckpointClient(gcs_config)
-
-    mock_fs = Mock()
-    mock_fs.exists.return_value = True
-    mock_fs.ls.return_value = [
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/config.json",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/log.txt",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/other_dir/",
-    ]
-
-    with patch(
-        "fsspec.core.url_to_fs",
-        return_value=(
-            mock_fs,
-            "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints",
-        ),
-    ):
-        result = client._find_latest_checkpoint()
-
-    assert result is None
-
-
-def test_url_reconstruction_with_scheme(gcs_config):
-    """Test that URL reconstruction preserves the original scheme."""
-    client = GCSCheckpointClient(gcs_config)
-
-    mock_fs = Mock()
-    mock_fs.exists.return_value = True
-    mock_fs.ls.return_value = [
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_42",
-    ]
-
-    with patch(
-        "fsspec.core.url_to_fs",
-        return_value=(
-            mock_fs,
-            "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints",
-        ),
-    ):
-        result = client._find_latest_checkpoint()
-
-    # Should reconstruct with gs:// scheme
-    assert result is not None
-    checkpoint_path, step_num = result
-    assert checkpoint_path.startswith("gs://")
-    assert "step_42" in checkpoint_path
-    assert step_num == 42
-
-
-def test_url_reconstruction_already_has_scheme(gcs_config):
-    """Test that URL reconstruction doesn't double-add scheme."""
-    client = GCSCheckpointClient(gcs_config)
-
-    mock_fs = Mock()
-    mock_fs.exists.return_value = True
-    # Simulate fs.ls() returning full URLs (edge case)
-    mock_fs.ls.return_value = [
-        "gs://marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_42",
-    ]
-
-    with patch(
-        "fsspec.core.url_to_fs",
-        return_value=(
-            mock_fs,
-            "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints",
-        ),
-    ):
-        result = client._find_latest_checkpoint()
-
-    # Should not have double gs:// prefix
-    assert result is not None
-    checkpoint_path, step_num = result
-    assert checkpoint_path == "gs://marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_42"
-    assert not checkpoint_path.startswith("gs://gs://")
-    assert step_num == 42
-
-
-def test_step_parsing_with_very_large_numbers(gcs_config):
-    """Test parsing of very large step numbers."""
-    client = GCSCheckpointClient(gcs_config)
-
-    mock_fs = Mock()
-    mock_fs.exists.return_value = True
-    mock_fs.ls.return_value = [
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_999999/",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_1000000/",
-        "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints/step_1000001/",
-    ]
-
-    with patch(
-        "fsspec.core.url_to_fs",
-        return_value=(
-            mock_fs,
-            "marin-eu-west4/rl_testing/llama-1b-math-rl-test-0-35d621/policy_checkpoints",
-        ),
-    ):
-        result = client._find_latest_checkpoint()
-
-    assert result is not None
-    checkpoint_path, step_num = result
-    assert "step_1000001" in checkpoint_path
-    assert step_num == 1000001
+    assert update is not None
+    assert update.weight_id == 42
+    assert checkpoint_paths == [expected_checkpoint_path]
+    assert not checkpoint_paths[0].startswith("memory://memory://")

--- a/tests/rl/test_checkpoint_transfer.py
+++ b/tests/rl/test_checkpoint_transfer.py
@@ -23,8 +23,8 @@ def checkpoint_loader(monkeypatch):
     loaded_model = object()
     checkpoint_paths = []
 
-    def fake_load_checkpoint(*, tree, checkpoint_path, axis_mapping, mesh):
-        checkpoint_paths.append(checkpoint_path)
+    def fake_load_checkpoint(**kwargs):
+        checkpoint_paths.append(kwargs["checkpoint_path"])
         return loaded_model
 
     monkeypatch.setattr(checkpoint_transfer.levanter_checkpoint, "load_checkpoint", fake_load_checkpoint)

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -138,6 +138,9 @@ def test_replay_buffer():
     with data_loader:
         rollouts = data_loader.get_rollouts(timeout=5.0)
         assert rollouts is not None
+        assert len(rollouts) == 4
+        assert replay_buffer.get_stats()["total_batches_added"] == 15
+        assert replay_buffer.get_stats()["env_sizes"] == {"env1": 20, "env2": 10}
 
 
 def test_replay_buffer_recency_bias():

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -136,9 +136,7 @@ def test_replay_buffer():
         writer.write_batch(batch)
 
     with data_loader:
-
-        time.sleep(0.2)  # Let it collect some batches
-        rollouts = data_loader.get_rollouts(timeout=1.0)
+        rollouts = data_loader.get_rollouts(timeout=5.0)
         assert rollouts is not None
 
 

--- a/tests/rl/test_replay_buffer.py
+++ b/tests/rl/test_replay_buffer.py
@@ -7,6 +7,7 @@ import time
 
 import numpy as np
 import pytest
+from rigging.timing import Duration, ExponentialBackoff
 
 try:
     from marin.rl import train_batch
@@ -136,11 +137,17 @@ def test_replay_buffer():
         writer.write_batch(batch)
 
     with data_loader:
+        collected_new_batches = ExponentialBackoff(initial=0.01, maximum=0.1).wait_until(
+            lambda: replay_buffer.get_stats()["total_batches_added"] == 15,
+            timeout=Duration.from_seconds(5.0),
+        )
+        assert collected_new_batches
+        stats = replay_buffer.get_stats()
+        assert stats["env_sizes"] == {"env1": 20, "env2": 10}
+
         rollouts = data_loader.get_rollouts(timeout=5.0)
         assert rollouts is not None
         assert len(rollouts) == 4
-        assert replay_buffer.get_stats()["total_batches_added"] == 15
-        assert replay_buffer.get_stats()["env_sizes"] == {"env1": 20, "env2": 10}
 
 
 def test_replay_buffer_recency_bias():

--- a/tests/rl/test_rollout_storage.py
+++ b/tests/rl/test_rollout_storage.py
@@ -115,27 +115,25 @@ def test_storage_operations(storage_config):
 
 
 def test_file_storage_timestamp_ordering(tmp_path):
-    """Test that file storage maintains timestamp ordering."""
-    config = RolloutStorageConfig(storage_type=StorageType.FILE, path=str(tmp_path / "ordered_test"))
-
-    writer = config.create_writer()
+    """Test that file storage breaks same-timestamp ties by counter."""
+    storage_path = tmp_path / "ordered_test"
+    storage_path.mkdir()
+    config = RolloutStorageConfig(storage_type=StorageType.FILE, path=str(storage_path))
     reader = config.create_reader()
 
-    # Write batches with small delays to ensure different timestamps
-    batches = []
-    for i in range(3):
-        batch = create_test_rollout_batch(i)
-        writer.write_batch(batch)
-        batches.append(batch)
-        time.sleep(0.01)  # Small delay
+    timestamp = 123456789
+    first_batch = create_test_rollout_batch(1)
+    second_batch = create_test_rollout_batch(2)
+    files = [
+        (f"{timestamp:020d}_zhost_000001.pkl", first_batch),
+        (f"{timestamp:020d}_ahost_000002.pkl", second_batch),
+    ]
+    for filename, batch in files:
+        with (storage_path / filename).open("wb") as f:
+            pickle.dump(batch, f)
 
-    # Read back - should be in order
     read_batches = reader.read_all_available()
-    assert len(read_batches) == 3
-
-    # Verify ordering by checking worker IDs
-    for i, batch in enumerate(read_batches):
-        assert batch.metadata.worker_id == f"worker_{i}"
+    assert [batch.metadata.worker_id for batch in read_batches] == ["worker_1", "worker_2"]
 
 
 def test_large_rollout_batch():

--- a/tests/rl/test_rollout_storage.py
+++ b/tests/rl/test_rollout_storage.py
@@ -115,7 +115,7 @@ def test_storage_operations(storage_config):
         assert np.array_equal(read_rollout.prompt_tokens, orig_rollout.prompt_tokens)
 
 
-def test_file_storage_timestamp_ordering(tmp_path):
+def test_file_storage_same_timestamp_counter_ordering(tmp_path):
     """Test that file storage breaks same-timestamp ties by counter."""
     storage_path = tmp_path / "ordered_test"
     storage_path.mkdir()

--- a/tests/rl/test_rollout_storage.py
+++ b/tests/rl/test_rollout_storage.py
@@ -11,6 +11,7 @@ import numpy as np
 import pytest
 from marin.rl.decoding import DecodingConfig
 from marin.rl.rollout_storage import (
+    ROLLOUT_FILE_SUFFIX,
     RolloutStorageConfig,
     StorageType,
 )
@@ -125,8 +126,8 @@ def test_file_storage_timestamp_ordering(tmp_path):
     first_batch = create_test_rollout_batch(1)
     second_batch = create_test_rollout_batch(2)
     files = [
-        (f"{timestamp:020d}_zhost_000001.pkl", first_batch),
-        (f"{timestamp:020d}_ahost_000002.pkl", second_batch),
+        (f"{timestamp:020d}_zhost_000001{ROLLOUT_FILE_SUFFIX}", first_batch),
+        (f"{timestamp:020d}_ahost_000002{ROLLOUT_FILE_SUFFIX}", second_batch),
     ]
     for filename, batch in files:
         with (storage_path / filename).open("wb") as f:

--- a/tests/vllm/test_llm_inference.py
+++ b/tests/vllm/test_llm_inference.py
@@ -30,6 +30,7 @@ def run_vllm_inference(model_path, **model_init_kwargs):
     return generated_texts
 
 
+@pytest.mark.integration
 @pytest.mark.tpu_ci
 def test_local_llm_inference():
     config = ModelConfig(
@@ -39,4 +40,7 @@ def test_local_llm_inference():
         generation_params={"max_tokens": 16},
     )
     model_name_or_path, config = resolve_model_name_or_path(config)
-    run_vllm_inference(model_name_or_path, **config.engine_kwargs)
+    generated_texts = run_vllm_inference(model_name_or_path, **config.engine_kwargs)
+    assert generated_texts
+    assert generated_texts[0].outputs
+    assert generated_texts[0].outputs[0].text


### PR DESCRIPTION
Replace sleep-based waits in rollout, Iris log, and vLLM integration tests with deadline polling, direct completion boundaries, or marker isolation. File rollout storage now sorts same-microsecond files by writer counter, and checkpoint weight transfer delegates latest-checkpoint discovery to Levanter's complete checkpoint candidate scan.

Checkpoint-transfer tests now run against local and memory fsspec filesystems through `receive_weights()`, and the vLLM TPU smoke test is marked `integration` with a generated-text assertion.

Fixes #6429