### PR TITLE
[finelog] Per-column trigram index + flush/retention tuning + bootstrap fixes

### DIFF
--- a/lib/finelog/pyproject.toml
+++ b/lib/finelog/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "marin-finelog"
-version = "0.2.0"
+version = "0.2.11"
 description = "Standalone log store + log service: structured-log ingest, query, and persistence."
 requires-python = ">=3.11,<3.13"
 # duckdb is used by the deploy CLI to query pulled parquet segments in-process

--- a/lib/finelog/rust/proto/finelog_stats.proto
+++ b/lib/finelog/rust/proto/finelog_stats.proto
@@ -29,10 +29,21 @@ enum ColumnType {
   COLUMN_TYPE_INT32 = 7;        // pa.int32()
 }
 
+// Secondary indexes a column carries to accelerate queries. Extensible: each
+// index type is its own field, so adding one is additive. All-unset means the
+// column is not indexed.
+message ColumnIndex {
+  // Per-row-group trigram (substring) index, stored in each segment's `.tgm`
+  // sidecar so `contains(col, …)` and `col LIKE '%…%'` queries prune row groups
+  // instead of full-scanning. Only meaningful for STRING columns.
+  bool trigram = 1;
+}
+
 message Column {
   string name = 1;
   ColumnType type = 2;
   bool nullable = 3;
+  ColumnIndex index = 4;
 }
 
 message Schema {

--- a/lib/finelog/rust/src/query/provider.rs
+++ b/lib/finelog/rust/src/query/provider.rs
@@ -124,9 +124,10 @@ impl TableProvider for NamespaceProvider {
                 // range / min-max / bloom row-group pruning), then layer the
                 // trigram prune on top by injecting per-file access plans.
                 let plan = t.scan(state, projection, filters, limit).await?;
-                // Hot path: a query with no `contains(data, …)` filter does only
-                // this cheap expr inspection (no I/O) and returns untouched.
-                let needles = crate::query::trigram_prune::indexed_column_needles(filters);
+                // Hot path: a query with no `contains(col, …)`/`LIKE` filter on any
+                // column does only this cheap expr inspection (no I/O) and returns
+                // untouched.
+                let needles = crate::query::trigram_prune::substring_needles_by_column(filters);
                 if needles.is_empty() {
                     return Ok(plan);
                 }
@@ -378,7 +379,7 @@ mod tests {
         let (path, _) = write_segment_to_dir(dir, 1, 1, &batch).unwrap();
         // Build the sidecar the way the compactor would.
         assert!(
-            crate::store::trigram::write_sidecar(&path, &[batch], "data", Some("key")).unwrap(),
+            crate::store::trigram::write_sidecar(&path, &[batch], &["data"], Some("key")).unwrap(),
             "sidecar should be written for a data column"
         );
         path.to_string_lossy().into_owned()

--- a/lib/finelog/rust/src/query/sidecar.rs
+++ b/lib/finelog/rust/src/query/sidecar.rs
@@ -315,7 +315,13 @@ mod tests {
         let parquet = dir.join(format!("seg_L1_{seq:019}.parquet"));
         // Write the sidecar directly (no parquet body needed for these unit
         // tests — the manager only ever reads `<parquet>.tgm`).
-        write_sidecar(&parquet, std::slice::from_ref(&batch), "data", Some("key")).unwrap();
+        write_sidecar(
+            &parquet,
+            std::slice::from_ref(&batch),
+            &["data"],
+            Some("key"),
+        )
+        .unwrap();
         parquet
     }
 
@@ -403,7 +409,13 @@ mod tests {
                 )
                 .unwrap();
                 let parquet = dir.join(format!("seg_L1_{:019}.parquet", i + 1));
-                write_sidecar(&parquet, std::slice::from_ref(&batch), "data", Some("key")).unwrap();
+                write_sidecar(
+                    &parquet,
+                    std::slice::from_ref(&batch),
+                    &["data"],
+                    Some("key"),
+                )
+                .unwrap();
                 parquet
             })
             .collect();

--- a/lib/finelog/rust/src/query/trigram_prune.rs
+++ b/lib/finelog/rust/src/query/trigram_prune.rs
@@ -35,7 +35,7 @@ use datafusion_datasource_parquet::ParquetAccessPlan;
 
 use crate::query::sidecar::SidecarManager;
 use crate::store::segment::segment_row_group_count;
-use crate::store::trigram::{needle_trigrams, sidecar_path, INDEXED_COLUMN, MIN_TRIGRAM_LEN};
+use crate::store::trigram::{needle_trigrams, sidecar_path, MIN_TRIGRAM_LEN};
 
 /// An inclusive key range constraining a single column, distilled from a query's
 /// top-level conjuncts. Used to scope which segments' sidecars are read: a
@@ -52,30 +52,16 @@ pub struct StringRange {
     pub hi: Option<Vec<u8>>,
 }
 
-/// Prunable substring needles from every top-level `contains(INDEXED_COLUMN, …)`
-/// or `INDEXED_COLUMN LIKE '%…%'` conjunct, filtered to those long enough to
-/// decompose into at least one trigram (`>= MIN_TRIGRAM_LEN`).
-///
-/// Pure expr inspection, no I/O — the provider calls this on the hot path to
-/// decide (cheaply) whether the substring prune applies at all before touching
-/// any sidecar. A too-short needle constrains no trigram, so dropping it here
-/// keeps the prune off the blocking path entirely for `contains(col, 'ab')`.
-pub fn indexed_column_needles(filters: &[Expr]) -> Vec<String> {
-    substring_needles(filters, INDEXED_COLUMN)
-        .into_iter()
-        .filter(|n| n.len() >= MIN_TRIGRAM_LEN)
-        .collect()
-}
-
-/// Inject access plans for already-extracted `needles`. Does the blocking
-/// sidecar + footer reads (routed through the [`SidecarManager`] cache), so the
-/// provider runs it under `spawn_blocking`. `key_ranges` (from
-/// [`string_column_ranges`]) scopes which segments are consulted by key band.
-/// Returns `plan` unchanged when `needles` is empty or nothing prunes.
+/// Inject access plans for already-extracted per-column `needles` (from
+/// [`substring_needles_by_column`]). Does the blocking sidecar + footer reads
+/// (routed through the [`SidecarManager`] cache), so the provider runs it under
+/// `spawn_blocking`. `key_ranges` (from [`string_column_ranges`]) scopes which
+/// segments are consulted by key band. Returns `plan` unchanged when `needles`
+/// is empty or nothing prunes.
 pub fn apply_with_needles(
     plan: Arc<dyn ExecutionPlan>,
     segment_paths: &[String],
-    needles: &[String],
+    needles: &HashMap<String, Vec<String>>,
     key_ranges: &HashMap<String, StringRange>,
 ) -> Arc<dyn ExecutionPlan> {
     if needles.is_empty() {
@@ -178,7 +164,11 @@ fn apply_bound(range: &mut StringRange, op: Operator, value: Vec<u8>) {
 }
 
 /// Substring needles from every top-level conjunct that constrains `column` to
-/// contain a literal — `contains(column, lit)` or `column LIKE '%lit%'`.
+/// contain a literal — `contains(column, lit)` or `column LIKE '%lit%'`. A
+/// single-column probe over [`substring_column_needle`], used by the extraction
+/// unit tests; production extracts every column at once via
+/// [`substring_needles_by_column`].
+#[cfg(test)]
 fn substring_needles(filters: &[Expr], column: &str) -> Vec<String> {
     filters
         .iter()
@@ -186,52 +176,75 @@ fn substring_needles(filters: &[Expr], column: &str) -> Vec<String> {
         .collect()
 }
 
-/// `Some(needle)` if `expr` constrains `column` to contain a literal substring:
-/// `contains(<column>, <utf8 literal>)`, or a `<column> LIKE` whose pattern is a
-/// single wildcard-framed substring (see [`like_substring`]).
+/// Substring needles grouped by the column each constrains, from every top-level
+/// `contains(col, lit)` / `col LIKE '%lit%'` conjunct whose literal is long
+/// enough to decompose into at least one trigram (`>= MIN_TRIGRAM_LEN`).
+///
+/// Pure expr inspection (no I/O) — the provider calls this on the hot path to
+/// decide (cheaply) whether the substring prune applies at all before touching
+/// any sidecar. A column the query constrains but a given segment's sidecar does
+/// not index is simply ignored when that segment is pruned.
+pub fn substring_needles_by_column(filters: &[Expr]) -> HashMap<String, Vec<String>> {
+    let mut out: HashMap<String, Vec<String>> = HashMap::new();
+    for f in filters {
+        if let Some((column, needle)) = substring_column_needle(f) {
+            if needle.len() >= MIN_TRIGRAM_LEN {
+                out.entry(column).or_default().push(needle);
+            }
+        }
+    }
+    out
+}
+
+/// `Some(needle)` if `expr` constrains `column` to contain a literal substring.
+#[cfg(test)]
 fn substring_needle(expr: &Expr, column: &str) -> Option<String> {
+    substring_column_needle(expr)
+        .filter(|(c, _)| c == column)
+        .map(|(_, needle)| needle)
+}
+
+/// `Some((column, needle))` if `expr` constrains some column to contain a literal
+/// substring: `contains(<col>, <utf8 literal>)`, or a `<col> LIKE` whose pattern
+/// is a single wildcard-framed substring (see [`like_column_substring`]).
+fn substring_column_needle(expr: &Expr) -> Option<(String, String)> {
     match expr {
-        Expr::ScalarFunction(sf) => contains_literal(sf, column),
-        Expr::Like(like) => like_substring(like, column),
+        Expr::ScalarFunction(sf) => contains_column_literal(sf),
+        Expr::Like(like) => like_column_substring(like),
         _ => None,
     }
 }
 
-/// `Some(needle)` if `sf` is exactly `contains(<column>, <utf8 literal>)`.
-fn contains_literal(
+/// `Some((column, needle))` if `sf` is exactly `contains(<column>, <utf8 literal>)`.
+fn contains_column_literal(
     sf: &datafusion::logical_expr::expr::ScalarFunction,
-    column: &str,
-) -> Option<String> {
+) -> Option<(String, String)> {
     if sf.func.name() != "contains" || sf.args.len() != 2 {
         return None;
     }
     let Expr::Column(col) = &sf.args[0] else {
         return None;
     };
-    if col.name != column {
-        return None;
-    }
-    utf8_literal(&sf.args[1])
+    let needle = utf8_literal(&sf.args[1])?;
+    Some((col.name.clone(), needle))
 }
 
-/// `Some(needle)` if `like` is `<column> LIKE '<pattern>'` where the pattern is a
-/// single literal substring framed by `%` wildcards and free of the `_`
-/// single-char wildcard and `\` escape — so a match provably contains `needle`.
+/// `Some((column, needle))` if `like` is `<column> LIKE '<pattern>'` where the
+/// pattern is a single literal substring framed by `%` wildcards and free of the
+/// `_` single-char wildcard and `\` escape — so a match provably contains
+/// `needle`.
 ///
 /// Conservative by construction: `NOT LIKE`, `ILIKE` (case-insensitive), an
 /// explicit escape char, or a pattern with `_`, `\`, or more than one
 /// `%`-separated fragment all return `None` (no prune), because none of those
 /// guarantee `needle` appears verbatim in a matching value.
-fn like_substring(like: &Like, column: &str) -> Option<String> {
+fn like_column_substring(like: &Like) -> Option<(String, String)> {
     if like.negated || like.case_insensitive || like.escape_char.is_some() {
         return None;
     }
     let Expr::Column(col) = like.expr.as_ref() else {
         return None;
     };
-    if col.name != column {
-        return None;
-    }
     let pattern = utf8_literal(&like.pattern)?;
     // `\` is LIKE's implicit escape even with no explicit escape char; `_` is the
     // single-char wildcard. A pattern carrying either has subtler semantics than
@@ -248,7 +261,7 @@ fn like_substring(like: &Like, column: &str) -> Option<String> {
     if fragments.next().is_some() {
         return None;
     }
-    Some(needle.to_string())
+    Some((col.name.clone(), needle.to_string()))
 }
 
 /// The string value of a Utf8 / LargeUtf8 / Utf8View literal, else `None`.
@@ -274,15 +287,21 @@ fn utf8_literal(expr: &Expr) -> Option<String> {
 /// them, and the resident bytes stay within the cache budget.
 fn build_access_plans(
     segment_paths: &[String],
-    needles: &[String],
+    needles: &HashMap<String, Vec<String>>,
     key_ranges: &HashMap<String, StringRange>,
 ) -> HashMap<String, ParquetAccessPlan> {
-    // Decompose each needle into trigrams ONCE, not once per segment — a single
-    // query commonly spans dozens of segments. Needles arrive pre-filtered to
-    // `>= MIN_TRIGRAM_LEN`, so each yields a non-empty trigram set.
-    let needle_trigrams: Vec<Vec<[u8; 3]>> =
-        needles.iter().filter_map(|n| needle_trigrams(n)).collect();
-    if needle_trigrams.is_empty() {
+    // Decompose each constrained column's needles into trigram sets ONCE, not
+    // once per segment — a single query commonly spans dozens of segments.
+    // Needles arrive pre-filtered to `>= MIN_TRIGRAM_LEN`, so each yields a
+    // non-empty set; a column whose needles all degrade is dropped here.
+    let trigrams_by_column: HashMap<&str, Vec<Vec<[u8; 3]>>> = needles
+        .iter()
+        .filter_map(|(col, ns)| {
+            let tg: Vec<Vec<[u8; 3]>> = ns.iter().filter_map(|n| needle_trigrams(n)).collect();
+            (!tg.is_empty()).then_some((col.as_str(), tg))
+        })
+        .collect();
+    if trigrams_by_column.is_empty() {
         return HashMap::new();
     }
 
@@ -332,17 +351,23 @@ fn build_access_plans(
             );
             continue;
         }
-        let Some(index) = manager.get_column(&sidecar, &header, INDEXED_COLUMN) else {
-            continue;
-        };
-        // A row group survives only if it survives EVERY needle's trigram test.
-        let mut keep = vec![true; index.len()];
-        for trigrams in &needle_trigrams {
-            for (k, m) in keep.iter_mut().zip(index.keep_mask_for(trigrams)) {
-                *k &= m;
+        // A row group survives only if it survives EVERY constrained column's
+        // needles. A column this segment's sidecar does not index can't prune, so
+        // it simply contributes no constraint here.
+        let mut keep = vec![true; rg_count];
+        let mut applied_any = false;
+        for (&col, needle_trigrams) in &trigrams_by_column {
+            let Some(index) = manager.get_column(&sidecar, &header, col) else {
+                continue;
+            };
+            applied_any = true;
+            for trigrams in needle_trigrams {
+                for (k, m) in keep.iter_mut().zip(index.keep_mask_for(trigrams)) {
+                    *k &= m;
+                }
             }
         }
-        if keep.iter().all(|&k| k) {
+        if !applied_any || keep.iter().all(|&k| k) {
             continue;
         }
         let mut access = ParquetAccessPlan::new_all(rg_count);
@@ -359,7 +384,7 @@ fn build_access_plans(
     }
     if !out.is_empty() || scoped_out > 0 {
         tracing::debug!(
-            needles = needle_trigrams.len(),
+            indexed_columns = trigrams_by_column.len(),
             segments_pruned = out.len(),
             segments_scoped_out = scoped_out,
             row_groups_skipped = skipped_row_groups,
@@ -506,13 +531,14 @@ mod tests {
 
     #[test]
     fn short_needles_are_dropped_before_the_blocking_path() {
-        // `indexed_column_needles` filters needles too short to form a trigram, so
-        // the provider returns on the hot path without touching a sidecar.
+        // `substring_needles_by_column` filters needles too short to form a
+        // trigram, so the provider returns on the hot path without touching a
+        // sidecar.
         let filters = vec![
             contains_expr("data", "ab"),             // 2 bytes: no trigram
             like_expr("data", "%xy%", false, false), // 2 bytes: no trigram
         ];
-        assert!(indexed_column_needles(&filters).is_empty());
+        assert!(substring_needles_by_column(&filters).is_empty());
     }
 
     #[test]
@@ -579,7 +605,7 @@ mod tests {
         crate::store::trigram::write_sidecar(
             &path,
             std::slice::from_ref(&batch),
-            "data",
+            &["data"],
             Some("key"),
         )
         .unwrap();
@@ -602,7 +628,10 @@ mod tests {
             "Bootstrap completed for TPU here",
         );
         let paths = vec![path];
-        let needles = vec!["Bootstrap completed for TPU".to_string()];
+        let needles = HashMap::from([(
+            "data".to_string(),
+            vec!["Bootstrap completed for TPU".to_string()],
+        )]);
 
         // No key constraint: the needle prunes row group 0, so a plan is produced.
         let unscoped = build_access_plans(&paths, &needles, &HashMap::new());

--- a/lib/finelog/rust/src/query/trigram_prune.rs
+++ b/lib/finelog/rust/src/query/trigram_prune.rs
@@ -165,9 +165,7 @@ fn apply_bound(range: &mut StringRange, op: Operator, value: Vec<u8>) {
 
 /// Substring needles from every top-level conjunct that constrains `column` to
 /// contain a literal — `contains(column, lit)` or `column LIKE '%lit%'`. A
-/// single-column probe over [`substring_column_needle`], used by the extraction
-/// unit tests; production extracts every column at once via
-/// [`substring_needles_by_column`].
+/// single-column probe over [`substring_column_needle`].
 #[cfg(test)]
 fn substring_needles(filters: &[Expr], column: &str) -> Vec<String> {
     filters

--- a/lib/finelog/rust/src/store/compaction/config.rs
+++ b/lib/finelog/rust/src/store/compaction/config.rs
@@ -25,7 +25,11 @@ pub struct CompactionConfig {
     pub max_segments_per_level: usize,
     /// Whole-namespace segment cap (eviction trigger).
     pub max_segments_per_namespace: usize,
-    /// Whole-namespace byte cap (eviction trigger).
+    /// Whole-namespace byte cap on locally-retained segments (eviction trigger).
+    /// Once a namespace's local L>=1 segments exceed this, the oldest already-
+    /// offloaded (BOTH) segments have their local copies unlinked; the remote
+    /// archive is kept. At current log volume 15 GiB is ~10 days of backwards
+    /// search.
     pub max_bytes_per_namespace: i64,
     /// Maintenance-loop cadence.
     pub check_interval: Duration,
@@ -37,7 +41,7 @@ impl Default for CompactionConfig {
             level_targets: vec![64 * MIB, 256 * MIB, 256 * MIB],
             max_segments_per_level: 32,
             max_segments_per_namespace: 1000,
-            max_bytes_per_namespace: 100 * 1024 * 1024 * 1024,
+            max_bytes_per_namespace: 15 * 1024 * 1024 * 1024,
             check_interval: Duration::from_secs(30),
         }
     }

--- a/lib/finelog/rust/src/store/compaction/executor.rs
+++ b/lib/finelog/rust/src/store/compaction/executor.rs
@@ -77,12 +77,20 @@ pub fn run_job(
     dir: &Path,
     arrow_schema: &SchemaRef,
     key_column: Option<&str>,
+    indexed_columns: &[&str],
     input_key_bounds: impl Fn(&str) -> (Option<i64>, Option<i64>),
 ) -> Result<PlannedSwap, StatsError> {
     if job.inputs.len() == 1 {
         apply_level_bump(job, dir, &input_key_bounds)
     } else {
-        apply_merge(job, dir, arrow_schema, key_column, &input_key_bounds)
+        apply_merge(
+            job,
+            dir,
+            arrow_schema,
+            key_column,
+            indexed_columns,
+            &input_key_bounds,
+        )
     }
 }
 
@@ -126,6 +134,7 @@ fn apply_merge(
     dir: &Path,
     arrow_schema: &SchemaRef,
     key_column: Option<&str>,
+    indexed_columns: &[&str],
     input_key_bounds: &impl Fn(&str) -> (Option<i64>, Option<i64>),
 ) -> Result<PlannedSwap, StatsError> {
     let merged_filename = seg_filename(job.output_level, job.output_min_seq);
@@ -159,6 +168,11 @@ fn apply_merge(
 
     let merged = kway_merge(&projected, &sort_cols)
         .map_err(|e| StatsError::Internal(format!("k-way merge: {e}")))?;
+    // `kway_merge` copied the rows it needs into `merged`; free the sorted inputs
+    // now so the segment isn't held in RAM twice through the parquet + sidecar
+    // writes below (each input plus the output is a fully materialized,
+    // uncompressed copy of the segment).
+    drop(projected);
     write_merged_segment(&staging_path, arrow_schema, &merged)?;
     std::fs::rename(&staging_path, &merged_path).map_err(|e| {
         StatsError::Internal(format!(
@@ -168,25 +182,24 @@ fn apply_merge(
         ))
     })?;
 
-    // Build the trigram substring-index sidecar next to the merged output (a
-    // no-op for namespaces without the indexed column). Best-effort: the index
-    // is optional, so a missing sidecar only disables row-group pruning for this
-    // segment, never correctness. Sidecars are built here, at the L0->L1+ merge
-    // (where the bulk of queryable data lands), and carried forward verbatim by
-    // single-input level bumps; L0 is intentionally left unindexed.
+    // Build the trigram substring-index sidecar next to the merged output, one
+    // bloom set per `indexed_columns` entry (a no-op for namespaces with no
+    // indexed columns). Best-effort: the index is optional, so a missing sidecar
+    // only disables row-group pruning for this segment, never correctness.
+    // Sidecars are built here, at the L0->L1+ merge (where the bulk of queryable
+    // data lands), and carried forward verbatim by single-input level bumps; L0
+    // is intentionally left unindexed.
     //
     // The parquet rename above already committed the segment, so a crash in the
     // gap before this write leaves the segment without a sidecar. That is the
     // same correct-but-unpruned state as any missing sidecar; a later compaction
-    // consuming this segment rebuilds it. Only a terminal-level segment that is
-    // never re-merged would stay unindexed — closing that fully needs a
-    // boot-adoption sweep that rebuilds missing sidecars, left as a follow-up.
-    if let Err(e) = crate::store::trigram::write_sidecar(
-        &merged_path,
-        &merged,
-        crate::store::trigram::INDEXED_COLUMN,
-        key_column,
-    ) {
+    // consuming this segment rebuilds it. A terminal-level segment that is never
+    // re-merged (or one written before sidecars existed) stays unindexed until
+    // the maintenance backfill (`Namespace::backfill_missing_sidecars`) rebuilds
+    // it a few segments per tick.
+    if let Err(e) =
+        crate::store::trigram::write_sidecar(&merged_path, &merged, indexed_columns, key_column)
+    {
         tracing::warn!(path = %merged_path.display(), error = %e, "trigram sidecar write failed");
     }
 
@@ -357,7 +370,7 @@ mod tests {
                 _ => (None, None),
             }
         };
-        let swap = run_job(&job, &dir, &schema(), Some("key"), bounds).unwrap();
+        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], bounds).unwrap();
         assert!(swap.bump_rename.is_none());
         assert!(swap.unlink_removed);
         assert_eq!(swap.removed.len(), 3);
@@ -405,7 +418,7 @@ mod tests {
             output_max_seq: 2,
         };
         let bounds = |_: &str| (Some(10), Some(20));
-        let swap = run_job(&job, &dir, &schema(), Some("key"), bounds).unwrap();
+        let swap = run_job(&job, &dir, &schema(), Some("key"), &[], bounds).unwrap();
 
         // It's a bump: a deferred rename, not a rewrite.
         let (from, to) = swap.bump_rename.clone().unwrap();
@@ -470,7 +483,7 @@ mod tests {
             output_min_seq: 1,
             output_max_seq: 2,
         };
-        let swap = run_job(&job, &dir, &log, Some("key"), |_| (None, None)).unwrap();
+        let swap = run_job(&job, &dir, &log, Some("key"), &["data"], |_| (None, None)).unwrap();
 
         // The merged output carries a sidecar whose mask prunes correctly.
         let out = PathBuf::from(&swap.added.path);
@@ -581,7 +594,7 @@ mod tests {
             output_min_seq: 1,
             output_max_seq: 2,
         };
-        let swap = run_job(&job, &dir, &wide, Some("key"), |_| (None, None)).unwrap();
+        let swap = run_job(&job, &dir, &wide, Some("key"), &[], |_| (None, None)).unwrap();
         let batches = read_segment_batches(Path::new(&swap.added.path)).unwrap();
         let total_rows: usize = batches.iter().map(|b| b.num_rows()).sum();
         assert_eq!(total_rows, 2);

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -11,6 +11,10 @@
 //!   (durability-before-ack).
 //! - `await_persisted(target)` subscribes to the watch and waits, bounded by a
 //!   caller-supplied timeout, nudging the flush task via a `Notify`.
+//! - The flush task seals one L0 per wake but then holds off for
+//!   `MIN_FLUSH_INTERVAL`, so the appends in that window coalesce into a single
+//!   L0 instead of one tiny segment per nudge; a full buffer
+//!   (`SEGMENT_TARGET_BYTES`) bypasses the cooldown via `force_flush`.
 //!
 //! `MemoryNamespace` (no `data_dir`) treats every append as immediately
 //! persisted: it stamps into a RAM buffer, advances `persisted_seq` to the
@@ -27,9 +31,10 @@ use arrow::datatypes::SchemaRef;
 use tokio::sync::{watch, Notify, RwLock};
 
 use crate::errors::StatsError;
+use crate::proto::finelog::stats::ColumnType;
 use crate::store::catalog::Catalog;
 use crate::store::compaction::config::{CompactionConfig, CompactionJob};
-use crate::store::compaction::executor::{run_job, PlannedSwap};
+use crate::store::compaction::executor::{read_segment_batches, run_job, PlannedSwap};
 use crate::store::compaction::planner::plan;
 use crate::store::policy::StoragePolicy;
 use crate::store::ram_buffer::{stamp_seq_and_build, RamBuffers, SealedBuffer};
@@ -39,7 +44,7 @@ use crate::store::schema::{schema_to_arrow, AlignedBatch, Schema};
 use crate::store::segment::{
     discover_segments, read_segment_footer, recover_next_seq, write_segment_to_dir,
 };
-use crate::store::trigram::sidecar_path;
+use crate::store::trigram::{sidecar_path, write_sidecar};
 use crate::store::types::{LocalSegment, NamespaceStats, SegmentLocation, SegmentRow};
 
 /// Best-effort removal of a segment's trigram sidecar (`<path>.tgm`), co-located
@@ -54,14 +59,30 @@ fn remove_sidecar(parquet_path: &str) {
     }
 }
 
-/// Target sealed-buffer byte size before a flush is forced.
+/// Buffered-byte size at which an append forces an early flush, short-circuiting
+/// the flush-rate cooldown so a write burst can't buffer unboundedly (and bounds
+/// a single L0's size).
 pub const SEGMENT_TARGET_BYTES: i64 = 100 * 1024 * 1024;
 
-/// Default flush-loop cadence.
+/// Maximum idle gap before the flush task wakes on its own. With steady writes
+/// the per-append nudge drives flushes; this is the ceiling for a quiet namespace.
 pub const DEFAULT_FLUSH_INTERVAL: Duration = Duration::from_secs(5);
+
+/// Minimum spacing between consecutive L0 flushes. Every append nudges the flush
+/// task, so without this floor a steadily-written namespace seals a fresh tiny L0
+/// on each wake (many per second). Holding off coalesces all appends in the
+/// window into ONE L0, capping L0 creation at one segment per interval.
+pub const MIN_FLUSH_INTERVAL: Duration = Duration::from_secs(1);
 
 /// Default durability-await budget when the RPC carries no deadline.
 pub const DEFAULT_PERSIST_TIMEOUT: Duration = Duration::from_secs(30);
+
+/// Trigram sidecars rebuilt per maintenance tick by the background backfill.
+/// Kept at one because a single index build over a terminal-level segment is
+/// itself heavy (the builder currently uses substantial CPU + RAM); rebuilding
+/// one per tick keeps the backfill the lowest-priority maintenance work and
+/// never starves compaction/sync/eviction. Raise once the builder is cheaper.
+pub const BACKFILL_SIDECARS_PER_TICK: usize = 1;
 
 fn now_ms() -> i64 {
     SystemTime::now()
@@ -117,7 +138,14 @@ pub struct Namespace {
     /// `sync_step` uploads L>=1 LOCAL segments here; eviction flips BOTH->REMOTE.
     remote: Option<RemoteStore>,
     persisted_seq: watch::Sender<i64>,
+    /// Nudged by every append (and a durability await): "there may be data to
+    /// flush". Drives the flush task's normal wake.
     flush_notify: Arc<Notify>,
+    /// Nudged only when a buffer crosses `SEGMENT_TARGET_BYTES`: "flush now,
+    /// don't wait out the rate cooldown". Lets a write burst bypass
+    /// `MIN_FLUSH_INTERVAL` so RAM and L0 size stay bounded, while normal
+    /// per-append nudges (which spam `flush_notify`) keep coalescing.
+    force_flush: Arc<Notify>,
     stop: Arc<Notify>,
     /// Latched stop flag the background tasks check at the TOP of each loop
     /// iteration, in addition to selecting on the `stop` Notify. `Notify`
@@ -221,6 +249,7 @@ impl Namespace {
             remote,
             persisted_seq: tx,
             flush_notify: Arc::new(Notify::new()),
+            force_flush: Arc::new(Notify::new()),
             stop: Arc::new(Notify::new()),
             stopped: AtomicBool::new(false),
             task_handles: Mutex::new(Vec::new()),
@@ -327,9 +356,15 @@ impl Namespace {
             // land in RAM, so advance the high-water mark under the lock.
             self.persisted_seq.send_replace(last_seq);
         }
+        let buffered_bytes = inner.buffers.ram_bytes();
         drop(inner);
         if self.data_dir.is_some() {
             self.flush_notify.notify_one();
+            // A burst that has already buffered a full segment shouldn't wait out
+            // the flush-rate cooldown — flush now to bound RAM and L0 size.
+            if buffered_bytes >= SEGMENT_TARGET_BYTES {
+                self.force_flush.notify_one();
+            }
         }
         last_seq
     }
@@ -363,9 +398,15 @@ impl Namespace {
         if self.data_dir.is_none() {
             self.persisted_seq.send_replace(last_seq);
         }
+        let buffered_bytes = inner.buffers.ram_bytes();
         drop(inner);
         if self.data_dir.is_some() {
             self.flush_notify.notify_one();
+            // A burst that has already buffered a full segment shouldn't wait out
+            // the flush-rate cooldown — flush now to bound RAM and L0 size.
+            if buffered_bytes >= SEGMENT_TARGET_BYTES {
+                self.force_flush.notify_one();
+            }
         }
         last_seq
     }
@@ -626,14 +667,28 @@ impl Namespace {
 
     /// Execute `job` (read+merge+write or rename) then commit the resulting swap.
     fn run_one_job(&self, dir: &std::path::Path, job: &CompactionJob) -> Result<(), StatsError> {
+        let indexed = self.indexed_columns();
         let swap = run_job(
             job,
             dir,
             &self.arrow_schema,
             self.key_column.as_deref(),
+            &indexed,
             |path| self.input_key_bounds(path),
         )?;
         self.commit_swap(swap)
+    }
+
+    /// Names of the schema's STRING columns carrying a trigram substring index
+    /// (see `ColumnIndex::trigram`). The merge + backfill paths build one bloom
+    /// set per returned column.
+    fn indexed_columns(&self) -> Vec<&str> {
+        self.schema
+            .columns
+            .iter()
+            .filter(|c| c.index.trigram && c.r#type == ColumnType::COLUMN_TYPE_STRING)
+            .map(|c| c.name.as_str())
+            .collect()
     }
 
     /// Recover the typed Int64 key bounds for an input segment from the in-memory
@@ -928,10 +983,75 @@ impl Namespace {
         removed_bytes
     }
 
+    // ----- trigram sidecar backfill -------------------------------------
+
+    /// Rebuild trigram sidecars for up to `max` local L>=1 segments missing one.
+    ///
+    /// Compaction only builds a sidecar for the segments it merges (see
+    /// `executor::run_job`); L0 is intentionally unindexed, and a terminal-level
+    /// segment that never re-merges — or any segment written before sidecars
+    /// existed — stays without a `.tgm` and so scans `contains()`/`LIKE`
+    /// unpruned. This background sweep closes that gap for already-durable data.
+    ///
+    /// Bounded per call and run as the lowest-priority maintenance step so the
+    /// parquet reads + index build can't delay compaction/sync/eviction. A no-op
+    /// for namespaces without the indexed string column. Best-effort per segment
+    /// (a read/build failure only leaves that segment unpruned, never wrong),
+    /// mirroring the compaction-time sidecar write. Returns the number rebuilt.
+    ///
+    /// Writes are atomic (`write_sidecar` renames into place), so a query that
+    /// races the backfill sees either the old (absent) or the complete sidecar,
+    /// never a partial one.
+    fn backfill_missing_sidecars(&self, max: usize) -> usize {
+        if self.data_dir.is_none() || max == 0 {
+            return 0;
+        }
+        // Only namespaces with at least one indexed column benefit; skip the
+        // parquet reads entirely otherwise.
+        let indexed = self.indexed_columns();
+        if indexed.is_empty() {
+            return 0;
+        }
+        let candidates: Vec<String> = {
+            let inner = self.inner.lock().unwrap();
+            inner
+                .local_segments
+                .iter()
+                .filter(|s| s.level >= 1)
+                .map(|s| s.path.clone())
+                .filter(|p| !sidecar_path(Path::new(p)).exists())
+                .take(max)
+                .collect()
+        };
+        let mut built = 0;
+        for path in candidates {
+            let p = Path::new(&path);
+            let batches = match read_segment_batches(p) {
+                Ok(batches) => batches,
+                Err(e) => {
+                    tracing::warn!(namespace = %self.name, path = %path, error = %e, "sidecar backfill: read failed");
+                    continue;
+                }
+            };
+            match write_sidecar(p, &batches, &indexed, self.key_column.as_deref()) {
+                Ok(true) => {
+                    built += 1;
+                    tracing::debug!(namespace = %self.name, path = %path, "backfilled trigram sidecar");
+                }
+                Ok(false) => {}
+                Err(e) => {
+                    tracing::warn!(namespace = %self.name, path = %path, error = %e, "sidecar backfill: write failed")
+                }
+            }
+        }
+        built
+    }
+
     // ----- maintenance orchestration ------------------------------------
 
-    /// Run one full maintenance cycle: `flush -> compact -> sync -> evict`,
-    /// serialized against other maintenance callers via `maint_lock`.
+    /// Run one full maintenance cycle: `flush -> compact -> sync -> evict ->
+    /// backfill sidecars`, serialized against other maintenance callers via
+    /// `maint_lock`.
     ///
     /// Supports an optional forced L0->L1 (the debug `force_compact_l0` flag).
     /// The blocking compaction (read/merge/write +
@@ -972,6 +1092,16 @@ impl Namespace {
         tokio::task::spawn_blocking(move || ns.eviction_step())
             .await
             .map_err(|e| StatsError::Internal(format!("maintenance evict task panicked: {e}")))??;
+
+        // Backfill (blocking parquet reads + index build). Last + bounded so it is
+        // the lowest-priority work: older/terminal segments compaction never
+        // indexed get their trigram sidecars rebuilt a few per tick.
+        let ns = Arc::clone(self);
+        tokio::task::spawn_blocking(move || {
+            ns.backfill_missing_sidecars(BACKFILL_SIDECARS_PER_TICK)
+        })
+        .await
+        .map_err(|e| StatsError::Internal(format!("maintenance backfill task panicked: {e}")))?;
         Ok(())
     }
 
@@ -1259,6 +1389,18 @@ fn spawn_flush_task(ns: Arc<Namespace>) -> tokio::task::JoinHandle<()> {
             let res = tokio::task::spawn_blocking(move || ns2.flush_once()).await;
             if let Ok(Err(e)) = res {
                 tracing::warn!(namespace = %ns.name, error = %e, "flush task: flush_once failed");
+            }
+            // Flush-rate cooldown: coalesce the appends that arrive during the
+            // window into the next single L0 (cap = one segment per
+            // MIN_FLUSH_INTERVAL) instead of sealing a tiny L0 per nudge. A burst
+            // that fills a whole segment cuts the wait short via `force_flush`.
+            tokio::select! {
+                _ = tokio::time::sleep(MIN_FLUSH_INTERVAL) => {}
+                _ = ns.force_flush.notified() => {}
+                _ = ns.stop.notified() => {
+                    let _ = ns.flush_once();
+                    return;
+                }
             }
         }
     })
@@ -1549,6 +1691,102 @@ mod tests {
         let segs = discover_segments(&ns_dir);
         assert_eq!(segs.len(), 1, "one flush coalesces buffered appends");
         assert_eq!(ns.stats().row_count, 10);
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    // --- trigram sidecar backfill ---------------------------------------
+
+    /// Log-form schema carrying the trigram-indexed `data` string column.
+    fn data_schema() -> Schema {
+        with_implicit_seq(Schema::new(
+            vec![
+                Column::new("data", ColumnType::COLUMN_TYPE_STRING, false).with_trigram_index(),
+                Column::new("timestamp_ms", ColumnType::COLUMN_TYPE_INT64, false),
+            ],
+            "timestamp_ms",
+        ))
+    }
+
+    /// `n` rows of searchable `data` + monotonic `timestamp_ms` (non-seq columns
+    /// in registered order, as `append_aligned_batch` expects).
+    fn data_aligned(n: i64, first: i64) -> AlignedBatch {
+        let data: Vec<String> = (0..n)
+            .map(|i| format!("log line {} searchable text", first + i))
+            .collect();
+        let ts: Vec<i64> = (0..n).map(|i| 1000 + first + i).collect();
+        AlignedBatch {
+            arrays: vec![
+                Arc::new(StringArray::from(data)),
+                Arc::new(Int64Array::from(ts)),
+            ],
+            fields: vec![
+                Field::new("data", DataType::Utf8, false),
+                Field::new("timestamp_ms", DataType::Int64, false),
+            ],
+            num_rows: n as usize,
+            byte_size: 48 * n,
+        }
+    }
+
+    #[tokio::test]
+    async fn backfill_rebuilds_missing_trigram_sidecar() {
+        let dir = tempdir();
+        let ns_dir = dir.join("log.test");
+        let catalog = Arc::new(Catalog::open(Some(&dir)).unwrap());
+        let ns = open_ns("log.test", data_schema(), Some(ns_dir.clone()), catalog);
+
+        // Two L0 flushes merged to one L1 — the merge builds the sidecar.
+        ns.append_aligned_batch(&data_aligned(5, 0));
+        ns.flush_once().unwrap();
+        let last = ns.append_aligned_batch(&data_aligned(5, 5));
+        ns.flush_once().unwrap();
+        ns.await_persisted(last, Duration::from_secs(10))
+            .await
+            .unwrap();
+        // run_maintenance wraps the merge in spawn_blocking (commit_swap takes the
+        // blocking query-visibility lock); a multi-input merge builds the sidecar.
+        ns.run_maintenance(true).await.unwrap();
+
+        let segs = discover_segments(&ns_dir);
+        assert_eq!(segs.len(), 1, "two L0 merged into one L1");
+        let sidecar = sidecar_path(&segs[0]);
+        assert!(sidecar.exists(), "the merge wrote a sidecar");
+
+        // Simulate a segment compaction never indexed (single-input bump, or one
+        // written before sidecars existed): drop the sidecar.
+        std::fs::remove_file(&sidecar).unwrap();
+        assert!(!sidecar.exists());
+
+        // The backfill rebuilds exactly the one missing sidecar, then idles.
+        assert_eq!(ns.backfill_missing_sidecars(10), 1);
+        assert!(sidecar.exists(), "backfill rebuilt the sidecar");
+        assert_eq!(ns.backfill_missing_sidecars(10), 0, "nothing left to do");
+
+        std::fs::remove_dir_all(&dir).ok();
+    }
+
+    #[tokio::test]
+    async fn backfill_is_a_noop_without_the_indexed_column() {
+        let dir = tempdir();
+        let ns_dir = dir.join("iris.worker");
+        let catalog = Arc::new(Catalog::open(Some(&dir)).unwrap());
+        // worker_schema has no `data` column, so there is nothing to index.
+        let ns = open_ns(
+            "iris.worker",
+            worker_schema(),
+            Some(ns_dir.clone()),
+            catalog,
+        );
+        ns.append_aligned_batch(&aligned(3));
+        ns.flush_once().unwrap();
+        let last = ns.append_aligned_batch(&aligned(3));
+        ns.flush_once().unwrap();
+        ns.await_persisted(last, Duration::from_secs(10))
+            .await
+            .unwrap();
+        ns.run_maintenance(true).await.unwrap();
+
+        assert_eq!(ns.backfill_missing_sidecars(10), 0);
         std::fs::remove_dir_all(&dir).ok();
     }
 

--- a/lib/finelog/rust/src/store/namespace.rs
+++ b/lib/finelog/rust/src/store/namespace.rs
@@ -337,6 +337,21 @@ impl Namespace {
             .collect()
     }
 
+    /// Wake the flush task after an append. Nudges the rate-limited flush loop;
+    /// a buffer that already holds a full segment (`>= SEGMENT_TARGET_BYTES`)
+    /// also trips `force_flush` to bypass the cooldown and bound RAM / L0 size.
+    /// No-op in memory mode, which has no flush task. Call after dropping the
+    /// inner lock.
+    fn notify_flush_after_append(&self, buffered_bytes: i64) {
+        if self.data_dir.is_none() {
+            return;
+        }
+        self.flush_notify.notify_one();
+        if buffered_bytes >= SEGMENT_TARGET_BYTES {
+            self.force_flush.notify_one();
+        }
+    }
+
     /// Stamp `seq` onto `aligned` and append it; returns the last seq allocated
     /// (or `-1` if empty). In memory mode the rows are immediately "persisted".
     pub fn append_aligned_batch(&self, aligned: &AlignedBatch) -> i64 {
@@ -358,14 +373,7 @@ impl Namespace {
         }
         let buffered_bytes = inner.buffers.ram_bytes();
         drop(inner);
-        if self.data_dir.is_some() {
-            self.flush_notify.notify_one();
-            // A burst that has already buffered a full segment shouldn't wait out
-            // the flush-rate cooldown — flush now to bound RAM and L0 size.
-            if buffered_bytes >= SEGMENT_TARGET_BYTES {
-                self.force_flush.notify_one();
-            }
-        }
+        self.notify_flush_after_append(buffered_bytes);
         last_seq
     }
 
@@ -400,14 +408,7 @@ impl Namespace {
         }
         let buffered_bytes = inner.buffers.ram_bytes();
         drop(inner);
-        if self.data_dir.is_some() {
-            self.flush_notify.notify_one();
-            // A burst that has already buffered a full segment shouldn't wait out
-            // the flush-rate cooldown — flush now to bound RAM and L0 size.
-            if buffered_bytes >= SEGMENT_TARGET_BYTES {
-                self.force_flush.notify_one();
-            }
-        }
+        self.notify_flush_after_append(buffered_bytes);
         last_seq
     }
 
@@ -680,8 +681,7 @@ impl Namespace {
     }
 
     /// Names of the schema's STRING columns carrying a trigram substring index
-    /// (see `ColumnIndex::trigram`). The merge + backfill paths build one bloom
-    /// set per returned column.
+    /// (`ColumnIndex::trigram`); one bloom set is built per returned column.
     fn indexed_columns(&self) -> Vec<&str> {
         self.schema
             .columns

--- a/lib/finelog/rust/src/store/schema.rs
+++ b/lib/finelog/rust/src/store/schema.rs
@@ -10,11 +10,13 @@ use std::sync::Arc;
 use arrow::array::{new_null_array, ArrayRef, RecordBatch};
 use arrow::compute::cast;
 use arrow::datatypes::{DataType, Field, Schema as ArrowSchema, SchemaRef, TimeUnit};
+use buffa::MessageField;
 use serde::{Deserialize, Serialize};
 
 use crate::errors::StatsError;
 use crate::proto::finelog::stats::{
-    Column as ProtoColumn, ColumnType, Schema as ProtoSchema, SchemaView,
+    Column as ProtoColumn, ColumnIndex as ProtoColumnIndex, ColumnType, Schema as ProtoSchema,
+    SchemaView,
 };
 
 /// Default implicit ordering-key column name when `Schema.key_column` is empty.
@@ -31,12 +33,22 @@ pub const MAX_WRITE_ROWS_BYTES: usize = 16 * 1024 * 1024;
 /// Max rows per RecordBatch. Exactly `1_000_000` (NOT `1 << 20`).
 pub const MAX_WRITE_ROWS_ROWS: usize = 1_000_000;
 
+/// Secondary indexes a column carries. Each index type is its own field so
+/// adding one is additive; `ColumnIndex::default()` (all-false) is unindexed.
+#[derive(Debug, Clone, Copy, Default, PartialEq, Eq)]
+pub struct ColumnIndex {
+    /// Per-row-group trigram substring index in each segment's `.tgm` sidecar.
+    /// Only meaningful for STRING columns.
+    pub trigram: bool,
+}
+
 /// One column in a registered schema.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Column {
     pub name: String,
     pub r#type: ColumnType,
     pub nullable: bool,
+    pub index: ColumnIndex,
 }
 
 impl Column {
@@ -45,7 +57,14 @@ impl Column {
             name: name.into(),
             r#type,
             nullable,
+            index: ColumnIndex::default(),
         }
+    }
+
+    /// Builder: maintain a trigram substring index for this column.
+    pub fn with_trigram_index(mut self) -> Self {
+        self.index.trigram = true;
+        self
     }
 }
 
@@ -147,7 +166,13 @@ pub fn schema_from_proto_view(view: &SchemaView) -> Result<Schema, StatsError> {
                 "column {IMPLICIT_SEQ_COLUMN:?} is reserved (server-assigned implicit column)"
             )));
         }
-        cols.push(Column::new(name, ctype, c.nullable.unwrap_or(false)));
+        let mut column = Column::new(name, ctype, c.nullable.unwrap_or(false));
+        column.index.trigram = c
+            .index
+            .as_option()
+            .and_then(|ix| ix.trigram)
+            .unwrap_or(false);
+        cols.push(column);
     }
     Ok(Schema::new(cols, view.key_column.unwrap_or("")))
 }
@@ -159,10 +184,15 @@ pub fn schema_to_proto_owned(schema: &Schema) -> ProtoSchema {
         .iter()
         .filter(|c| c.name != IMPLICIT_SEQ_COLUMN)
         .map(|c| {
-            ProtoColumn::default()
-                .with_name(&c.name)
-                .with_type(c.r#type)
-                .with_nullable(c.nullable)
+            ProtoColumn {
+                index: MessageField::some(
+                    ProtoColumnIndex::default().with_trigram(c.index.trigram),
+                ),
+                ..Default::default()
+            }
+            .with_name(&c.name)
+            .with_type(c.r#type)
+            .with_nullable(c.nullable)
         })
         .collect();
     ProtoSchema {
@@ -176,12 +206,22 @@ pub fn schema_to_proto_owned(schema: &Schema) -> ProtoSchema {
 // JSON conversions (catalog sidecar form).
 // ---------------------------------------------------------------------------
 
+#[derive(Serialize, Deserialize, Default)]
+struct JsonColumnIndex {
+    #[serde(default)]
+    trigram: bool,
+}
+
 #[derive(Serialize, Deserialize)]
 struct JsonColumn {
     name: String,
     /// Proto enum *name* (e.g. "COLUMN_TYPE_STRING"); stable across edits.
     r#type: String,
     nullable: bool,
+    /// Absent in catalog rows written before column indexes existed;
+    /// `serde(default)` decodes those as an empty (unindexed) `ColumnIndex`.
+    #[serde(default)]
+    index: JsonColumnIndex,
 }
 
 #[derive(Serialize, Deserialize)]
@@ -240,6 +280,9 @@ pub fn schema_to_json(schema: &Schema) -> String {
                 name: c.name.clone(),
                 r#type: column_type_name(c.r#type).to_string(),
                 nullable: c.nullable,
+                index: JsonColumnIndex {
+                    trigram: c.index.trigram,
+                },
             })
             .collect(),
     };
@@ -252,11 +295,9 @@ pub fn schema_from_json(text: &str) -> Result<Schema, StatsError> {
         .map_err(|e| StatsError::Internal(format!("catalog schema JSON parse: {e}")))?;
     let mut cols = Vec::with_capacity(payload.columns.len());
     for c in payload.columns {
-        cols.push(Column::new(
-            c.name,
-            column_type_from_json(&c.r#type)?,
-            c.nullable,
-        ));
+        let mut column = Column::new(c.name, column_type_from_json(&c.r#type)?, c.nullable);
+        column.index.trigram = c.index.trigram;
+        cols.push(column);
     }
     Ok(Schema::new(cols, payload.key_column))
 }

--- a/lib/finelog/rust/src/store/store.rs
+++ b/lib/finelog/rust/src/store/store.rs
@@ -49,7 +49,9 @@ fn log_registered_schema() -> Schema {
         vec![
             Column::new("key", ColumnType::COLUMN_TYPE_STRING, false),
             Column::new("source", ColumnType::COLUMN_TYPE_STRING, false),
-            Column::new("data", ColumnType::COLUMN_TYPE_STRING, false),
+            // The log message body — substring-searched via contains()/LIKE, so
+            // it carries the trigram index.
+            Column::new("data", ColumnType::COLUMN_TYPE_STRING, false).with_trigram_index(),
             Column::new("epoch_ms", ColumnType::COLUMN_TYPE_INT64, false),
             Column::new("level", ColumnType::COLUMN_TYPE_INT32, false),
         ],
@@ -460,7 +462,8 @@ impl Store {
     }
 
     /// Run one full maintenance cycle for `name`:
-    /// `flush -> compact (planner-drained, or forced L0->L1) -> sync -> evict`.
+    /// `flush -> compact (planner-drained, or forced L0->L1) -> sync -> evict ->
+    /// backfill missing trigram sidecars`.
     ///
     /// This is the body the per-namespace background maintenance task runs on its
     /// tick, and the entry point the `--debug-admin` `POST /debug/maintain` drives

--- a/lib/finelog/rust/src/store/trigram.rs
+++ b/lib/finelog/rust/src/store/trigram.rs
@@ -523,38 +523,61 @@ pub fn sidecar_path(parquet_path: &Path) -> PathBuf {
     PathBuf::from(s)
 }
 
-/// Build the trigram index over `data_column` across `batches` and write it as
-/// the sidecar for `parquet_path`. `key_column` (when string-typed in `batches`)
-/// supplies the segment's key band, stored in the header for query-time scoping.
+/// Build a trigram index over each of `data_columns` across `batches` and write
+/// them as the single multi-column sidecar for `parquet_path`. `key_column`
+/// (when string-typed in `batches`) supplies the segment's key band, stored in
+/// the header for query-time scoping.
 ///
-/// Returns `Ok(true)` when a non-empty sidecar was written, `Ok(false)` when
-/// there was nothing to index (no such string column, or zero row groups).
+/// Columns that are absent or not UTF-8 string-typed are skipped (each yields no
+/// index, which is safe). Returns `Ok(true)` when a non-empty sidecar was
+/// written, `Ok(false)` when nothing was indexable (no such columns, or zero row
+/// groups). All surviving column indexes share the same row-group count — they
+/// chunk the same `batches` at the same `ROW_GROUP_SIZE` stride.
 ///
 /// The index is optional — a write failure is non-fatal to the caller (the
 /// segment just scans unpruned), so callers log rather than propagate.
 pub fn write_sidecar(
     parquet_path: &Path,
     batches: &[RecordBatch],
-    data_column: &str,
+    data_columns: &[&str],
     key_column: Option<&str>,
 ) -> std::io::Result<bool> {
-    let Some(index) = TrigramIndex::build(batches, data_column) else {
-        return Ok(false);
-    };
-    if index.is_empty() {
+    let indexes: Vec<TrigramIndex> = data_columns
+        .iter()
+        .filter_map(|col| {
+            let index = TrigramIndex::build(batches, col)?;
+            (!index.is_empty()).then_some(index)
+        })
+        .collect();
+    if indexes.is_empty() {
         return Ok(false);
     }
+    debug_assert!(
+        indexes.iter().all(|i| i.len() == indexes[0].len()),
+        "all indexed columns chunk the same batches into the same row-group count"
+    );
+    let rg_count = indexes[0].len() as u32;
     let (key_min, key_max) = key_column
         .map(|kc| string_key_bounds(batches, kc))
         .unwrap_or((None, None));
     let bytes = serialize_sidecar(
-        index.len() as u32,
+        rg_count,
         key_column.unwrap_or(""),
         key_min.as_deref(),
         key_max.as_deref(),
-        std::slice::from_ref(&index),
+        &indexes,
     );
-    std::fs::write(sidecar_path(parquet_path), bytes)?;
+    // Write to a temp file and rename into place so a reader never observes a
+    // half-written sidecar. The compaction path writes before the segment is
+    // query-visible, but the background backfill rebuilds sidecars for segments
+    // that are ALREADY visible; a partial read there would parse as absent (scan
+    // unpruned) — safe, but the rename makes the transition atomic regardless.
+    let final_path = sidecar_path(parquet_path);
+    let mut tmp_os = final_path.as_os_str().to_os_string();
+    tmp_os.push(".tmp");
+    let tmp_path = PathBuf::from(tmp_os);
+    std::fs::write(&tmp_path, &bytes)?;
+    std::fs::rename(&tmp_path, &final_path)?;
     Ok(true)
 }
 
@@ -618,44 +641,69 @@ fn trigram_windows(bytes: &[u8]) -> impl Iterator<Item = [u8; 3]> + '_ {
     bytes.windows(3).map(|w| [w[0], w[1], w[2]])
 }
 
-/// A small dedup set over trigrams. Backed by a `HashSet` keyed on the packed
-/// 24-bit trigram value.
-#[derive(Default)]
+/// Number of `u64` words in the trigram bitset: one bit per possible 24-bit
+/// trigram (256^3 = 16,777,216 bits = exactly 2 MiB).
+const TRIGRAM_BITSET_WORDS: usize = (1 << 24) / 64;
+
+/// Dedup set over the 24-bit trigram universe, backed by a fixed 2 MiB bitset.
+///
+/// A log row group yields millions of trigram windows that are mostly
+/// duplicates; a `HashSet<u32>` pays a hash + probe (and periodic rehash growth)
+/// on every one. The bitset makes `insert` a single shift-and-or against a
+/// direct bit index, with no hashing and no allocation after construction, and
+/// turns the distinct count into a `popcount`. Memory is bounded at 2 MiB
+/// regardless of cardinality (vs. a `HashSet` that grows toward the 16.7M-entry
+/// universe for high-entropy text).
 struct TrigramSet {
-    seen: std::collections::HashSet<u32>,
+    // Boxed so the 2 MiB array lives on the heap, not the stack.
+    words: Box<[u64]>,
+}
+
+impl Default for TrigramSet {
+    fn default() -> Self {
+        TrigramSet {
+            words: vec![0u64; TRIGRAM_BITSET_WORDS].into_boxed_slice(),
+        }
+    }
 }
 
 impl TrigramSet {
     #[inline]
     fn insert(&mut self, t: [u8; 3]) {
-        let packed = (t[0] as u32) | ((t[1] as u32) << 8) | ((t[2] as u32) << 16);
-        self.seen.insert(packed);
+        let packed = (t[0] as usize) | ((t[1] as usize) << 8) | ((t[2] as usize) << 16);
+        self.words[packed >> 6] |= 1u64 << (packed & 63);
+    }
+
+    /// Number of distinct trigrams inserted.
+    fn len(&self) -> usize {
+        self.words.iter().map(|w| w.count_ones() as usize).sum()
+    }
+
+    /// Visit each set trigram once, unpacking its bit index back to bytes.
+    fn for_each(&self, mut f: impl FnMut([u8; 3])) {
+        for (word_index, &word) in self.words.iter().enumerate() {
+            let mut bits = word;
+            while bits != 0 {
+                let packed = (word_index << 6) | bits.trailing_zeros() as usize;
+                bits &= bits - 1; // clear the lowest set bit
+                f([
+                    (packed & 0xFF) as u8,
+                    ((packed >> 8) & 0xFF) as u8,
+                    ((packed >> 16) & 0xFF) as u8,
+                ]);
+            }
+        }
     }
 
     fn into_vec(self) -> Vec<[u8; 3]> {
-        self.seen
-            .into_iter()
-            .map(|p| {
-                [
-                    (p & 0xFF) as u8,
-                    ((p >> 8) & 0xFF) as u8,
-                    ((p >> 16) & 0xFF) as u8,
-                ]
-            })
-            .collect()
+        let mut out = Vec::with_capacity(self.len());
+        self.for_each(|t| out.push(t));
+        out
     }
 
     fn into_bloom(self, fpr: f64) -> RowGroupBloom {
-        let n = self.seen.len();
-        let mut bloom = RowGroupBloom::with_capacity(n, fpr);
-        for p in &self.seen {
-            let t = [
-                (*p & 0xFF) as u8,
-                ((*p >> 8) & 0xFF) as u8,
-                ((*p >> 16) & 0xFF) as u8,
-            ];
-            bloom.insert(t);
-        }
+        let mut bloom = RowGroupBloom::with_capacity(self.len(), fpr);
+        self.for_each(|t| bloom.insert(t));
         bloom
     }
 }
@@ -851,6 +899,31 @@ mod tests {
         for &t in &tris {
             assert!(bloom.contains(t), "false negative for {t:?}");
         }
+    }
+
+    #[test]
+    fn trigram_set_dedups_and_round_trips_bit_positions() {
+        // Values chosen to land in distinct bitset words and exercise the
+        // low/high byte unpacking: packed indices 0, 63 (word boundary), 64
+        // (next word), the maximum 2^24-1, and an arbitrary mid value.
+        let inputs = [
+            [0u8, 0, 0],
+            [63, 0, 0],
+            [64, 0, 0],
+            [255, 255, 255],
+            [1, 2, 3],
+        ];
+        let mut set = TrigramSet::default();
+        for &t in &inputs {
+            set.insert(t);
+            set.insert(t); // a repeated trigram must not change the distinct set
+        }
+        assert_eq!(set.len(), inputs.len());
+        let mut got = set.into_vec();
+        got.sort();
+        let mut want = inputs.to_vec();
+        want.sort();
+        assert_eq!(got, want, "every inserted trigram must round-trip exactly");
     }
 
     #[test]

--- a/lib/finelog/src/finelog/deploy/bootstrap.py
+++ b/lib/finelog/src/finelog/deploy/bootstrap.py
@@ -60,19 +60,24 @@ sudo systemctl start docker || true
 
 # Cache directory on the boot disk. Finelog copies parquet segments to GCS
 # via FINELOG_REMOTE_DIR, so the boot disk only needs working space.
-# Owned by UID/GID 1000 to match the in-container `finelog` user (the
-# Dockerfile's chown is shadowed by this bind mount).
 sudo mkdir -p {{ cache_dir }}
-# 1000 matches the finelog user **inside** the container
-sudo chown -R 1000:1000 {{ cache_dir }}
 
 echo "[finelog-init] Pulling image: {{ docker_image }}"
 sudo docker pull {{ docker_image }}
 
 # Gracefully stop any existing container so the server can flush RAM
-# buffers to L0 on disk, then remove it.
+# buffers to L0 on disk, then remove it. This MUST precede the chown below:
+# a running server constantly creates and renames transient files
+# (seg_L*.parquet.tmp, _finelog_catalog.sqlite-journal). One vanishing between
+# readdir and the chown syscall makes `chown -R` exit non-zero, and `set -e`
+# would then abort the whole bootstrap before the new image is ever started.
 sudo docker stop --timeout 5 {{ container_name }} 2>/dev/null || true
 sudo docker rm -f {{ container_name }} 2>/dev/null || true
+
+# Own the cache dir as UID/GID 1000 to match the in-container `finelog` user
+# (the Dockerfile's chown is shadowed by this bind mount). Safe to recurse now
+# that the writer is stopped.
+sudo chown -R 1000:1000 {{ cache_dir }}
 
 host_cpus=$(nproc)
 host_mem_mib=$(awk '/^MemTotal:/ {printf "%d", $2/1024}' /proc/meminfo)

--- a/lib/finelog/src/finelog/proto/finelog_stats.proto
+++ b/lib/finelog/src/finelog/proto/finelog_stats.proto
@@ -29,10 +29,21 @@ enum ColumnType {
   COLUMN_TYPE_INT32 = 7;        // pa.int32()
 }
 
+// Secondary indexes a column carries to accelerate queries. Extensible: each
+// index type is its own field, so adding one is additive. All-unset means the
+// column is not indexed.
+message ColumnIndex {
+  // Per-row-group trigram (substring) index, stored in each segment's `.tgm`
+  // sidecar so `contains(col, …)` and `col LIKE '%…%'` queries prune row groups
+  // instead of full-scanning. Only meaningful for STRING columns.
+  bool trigram = 1;
+}
+
 message Column {
   string name = 1;
   ColumnType type = 2;
   bool nullable = 3;
+  ColumnIndex index = 4;
 }
 
 message Schema {

--- a/lib/finelog/src/finelog/rpc/finelog_stats_pb2.py
+++ b/lib/finelog/src/finelog/rpc/finelog_stats_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13\x66inelog_stats.proto\x12\rfinelog.stats\"g\n\x06\x43olumn\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12-\n\x04type\x18\x02 \x01(\x0e\x32\x19.finelog.stats.ColumnTypeR\x04type\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\"X\n\x06Schema\x12/\n\x07\x63olumns\x18\x01 \x03(\x0b\x32\x15.finelog.stats.ColumnR\x07\x63olumns\x12\x1d\n\nkey_column\x18\x02 \x01(\tR\tkeyColumn\"w\n\rStoragePolicy\x12!\n\x0cmax_segments\x18\x01 \x01(\x05R\x0bmaxSegments\x12\x1b\n\tmax_bytes\x18\x02 \x01(\x03R\x08maxBytes\x12&\n\x0fmax_age_seconds\x18\x03 \x01(\x03R\rmaxAgeSeconds\"\xa8\x01\n\x14RegisterTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\x12\x43\n\x0estorage_policy\x18\x03 \x01(\x0b\x32\x1c.finelog.stats.StoragePolicyR\rstoragePolicy\"\xa2\x01\n\x15RegisterTableResponse\x12@\n\x10\x65\x66\x66\x65\x63tive_schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x0f\x65\x66\x66\x65\x63tiveSchema\x12G\n\x10\x65\x66\x66\x65\x63tive_policy\x18\x02 \x01(\x0b\x32\x1c.finelog.stats.StoragePolicyR\x0f\x65\x66\x66\x65\x63tivePolicy\"M\n\x10WriteRowsRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x1b\n\tarrow_ipc\x18\x02 \x01(\x0cR\x08\x61rrowIpc\"6\n\x11WriteRowsResponse\x12!\n\x0crows_written\x18\x01 \x01(\x03R\x0browsWritten\" \n\x0cQueryRequest\x12\x10\n\x03sql\x18\x01 \x01(\tR\x03sql\"I\n\rQueryResponse\x12\x1b\n\tarrow_ipc\x18\x01 \x01(\x0cR\x08\x61rrowIpc\x12\x1b\n\trow_count\x18\x02 \x01(\x03R\x08rowCount\"0\n\x10\x44ropTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"\x13\n\x11\x44ropTableResponse\"\xb2\x02\n\rNamespaceInfo\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\x12\x1b\n\trow_count\x18\x03 \x01(\x03R\x08rowCount\x12\x1b\n\tbyte_size\x18\x04 \x01(\x03R\x08\x62yteSize\x12\x17\n\x07min_seq\x18\x05 \x01(\x03R\x06minSeq\x12\x17\n\x07max_seq\x18\x06 \x01(\x03R\x06maxSeq\x12#\n\rsegment_count\x18\x07 \x01(\x05R\x0csegmentCount\x12\x43\n\x0estorage_policy\x18\x08 \x01(\x0b\x32\x1c.finelog.stats.StoragePolicyR\rstoragePolicy\"\x17\n\x15ListNamespacesRequest\"V\n\x16ListNamespacesResponse\x12<\n\nnamespaces\x18\x01 \x03(\x0b\x32\x1c.finelog.stats.NamespaceInfoR\nnamespaces\"5\n\x15GetTableSchemaRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"G\n\x16GetTableSchemaResponse\x12-\n\x06schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema*\xcf\x01\n\nColumnType\x12\x17\n\x13\x43OLUMN_TYPE_UNKNOWN\x10\x00\x12\x16\n\x12\x43OLUMN_TYPE_STRING\x10\x01\x12\x15\n\x11\x43OLUMN_TYPE_INT64\x10\x02\x12\x17\n\x13\x43OLUMN_TYPE_FLOAT64\x10\x03\x12\x14\n\x10\x43OLUMN_TYPE_BOOL\x10\x04\x12\x1c\n\x18\x43OLUMN_TYPE_TIMESTAMP_MS\x10\x05\x12\x15\n\x11\x43OLUMN_TYPE_BYTES\x10\x06\x12\x15\n\x11\x43OLUMN_TYPE_INT32\x10\x07\x32\x8c\x04\n\x0cStatsService\x12Z\n\rRegisterTable\x12#.finelog.stats.RegisterTableRequest\x1a$.finelog.stats.RegisterTableResponse\x12N\n\tWriteRows\x12\x1f.finelog.stats.WriteRowsRequest\x1a .finelog.stats.WriteRowsResponse\x12\x42\n\x05Query\x12\x1b.finelog.stats.QueryRequest\x1a\x1c.finelog.stats.QueryResponse\x12N\n\tDropTable\x12\x1f.finelog.stats.DropTableRequest\x1a .finelog.stats.DropTableResponse\x12]\n\x0eListNamespaces\x12$.finelog.stats.ListNamespacesRequest\x1a%.finelog.stats.ListNamespacesResponse\x12]\n\x0eGetTableSchema\x12$.finelog.stats.GetTableSchemaRequest\x1a%.finelog.stats.GetTableSchemaResponseB{\n\x11\x63om.finelog.statsB\x11\x46inelogStatsProtoP\x01\xa2\x02\x03\x46SX\xaa\x02\rFinelog.Stats\xca\x02\rFinelog\\Stats\xe2\x02\x19\x46inelog\\Stats\\GPBMetadata\xea\x02\x0e\x46inelog::Statsb\x08\x65\x64itionsp\xe8\x07')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x13\x66inelog_stats.proto\x12\rfinelog.stats\"\'\n\x0b\x43olumnIndex\x12\x18\n\x07trigram\x18\x01 \x01(\x08R\x07trigram\"\x99\x01\n\x06\x43olumn\x12\x12\n\x04name\x18\x01 \x01(\tR\x04name\x12-\n\x04type\x18\x02 \x01(\x0e\x32\x19.finelog.stats.ColumnTypeR\x04type\x12\x1a\n\x08nullable\x18\x03 \x01(\x08R\x08nullable\x12\x30\n\x05index\x18\x04 \x01(\x0b\x32\x1a.finelog.stats.ColumnIndexR\x05index\"X\n\x06Schema\x12/\n\x07\x63olumns\x18\x01 \x03(\x0b\x32\x15.finelog.stats.ColumnR\x07\x63olumns\x12\x1d\n\nkey_column\x18\x02 \x01(\tR\tkeyColumn\"w\n\rStoragePolicy\x12!\n\x0cmax_segments\x18\x01 \x01(\x05R\x0bmaxSegments\x12\x1b\n\tmax_bytes\x18\x02 \x01(\x03R\x08maxBytes\x12&\n\x0fmax_age_seconds\x18\x03 \x01(\x03R\rmaxAgeSeconds\"\xa8\x01\n\x14RegisterTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\x12\x43\n\x0estorage_policy\x18\x03 \x01(\x0b\x32\x1c.finelog.stats.StoragePolicyR\rstoragePolicy\"\xa2\x01\n\x15RegisterTableResponse\x12@\n\x10\x65\x66\x66\x65\x63tive_schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x0f\x65\x66\x66\x65\x63tiveSchema\x12G\n\x10\x65\x66\x66\x65\x63tive_policy\x18\x02 \x01(\x0b\x32\x1c.finelog.stats.StoragePolicyR\x0f\x65\x66\x66\x65\x63tivePolicy\"M\n\x10WriteRowsRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12\x1b\n\tarrow_ipc\x18\x02 \x01(\x0cR\x08\x61rrowIpc\"6\n\x11WriteRowsResponse\x12!\n\x0crows_written\x18\x01 \x01(\x03R\x0browsWritten\" \n\x0cQueryRequest\x12\x10\n\x03sql\x18\x01 \x01(\tR\x03sql\"I\n\rQueryResponse\x12\x1b\n\tarrow_ipc\x18\x01 \x01(\x0cR\x08\x61rrowIpc\x12\x1b\n\trow_count\x18\x02 \x01(\x03R\x08rowCount\"0\n\x10\x44ropTableRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"\x13\n\x11\x44ropTableResponse\"\xb2\x02\n\rNamespaceInfo\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\x12-\n\x06schema\x18\x02 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema\x12\x1b\n\trow_count\x18\x03 \x01(\x03R\x08rowCount\x12\x1b\n\tbyte_size\x18\x04 \x01(\x03R\x08\x62yteSize\x12\x17\n\x07min_seq\x18\x05 \x01(\x03R\x06minSeq\x12\x17\n\x07max_seq\x18\x06 \x01(\x03R\x06maxSeq\x12#\n\rsegment_count\x18\x07 \x01(\x05R\x0csegmentCount\x12\x43\n\x0estorage_policy\x18\x08 \x01(\x0b\x32\x1c.finelog.stats.StoragePolicyR\rstoragePolicy\"\x17\n\x15ListNamespacesRequest\"V\n\x16ListNamespacesResponse\x12<\n\nnamespaces\x18\x01 \x03(\x0b\x32\x1c.finelog.stats.NamespaceInfoR\nnamespaces\"5\n\x15GetTableSchemaRequest\x12\x1c\n\tnamespace\x18\x01 \x01(\tR\tnamespace\"G\n\x16GetTableSchemaResponse\x12-\n\x06schema\x18\x01 \x01(\x0b\x32\x15.finelog.stats.SchemaR\x06schema*\xcf\x01\n\nColumnType\x12\x17\n\x13\x43OLUMN_TYPE_UNKNOWN\x10\x00\x12\x16\n\x12\x43OLUMN_TYPE_STRING\x10\x01\x12\x15\n\x11\x43OLUMN_TYPE_INT64\x10\x02\x12\x17\n\x13\x43OLUMN_TYPE_FLOAT64\x10\x03\x12\x14\n\x10\x43OLUMN_TYPE_BOOL\x10\x04\x12\x1c\n\x18\x43OLUMN_TYPE_TIMESTAMP_MS\x10\x05\x12\x15\n\x11\x43OLUMN_TYPE_BYTES\x10\x06\x12\x15\n\x11\x43OLUMN_TYPE_INT32\x10\x07\x32\x8c\x04\n\x0cStatsService\x12Z\n\rRegisterTable\x12#.finelog.stats.RegisterTableRequest\x1a$.finelog.stats.RegisterTableResponse\x12N\n\tWriteRows\x12\x1f.finelog.stats.WriteRowsRequest\x1a .finelog.stats.WriteRowsResponse\x12\x42\n\x05Query\x12\x1b.finelog.stats.QueryRequest\x1a\x1c.finelog.stats.QueryResponse\x12N\n\tDropTable\x12\x1f.finelog.stats.DropTableRequest\x1a .finelog.stats.DropTableResponse\x12]\n\x0eListNamespaces\x12$.finelog.stats.ListNamespacesRequest\x1a%.finelog.stats.ListNamespacesResponse\x12]\n\x0eGetTableSchema\x12$.finelog.stats.GetTableSchemaRequest\x1a%.finelog.stats.GetTableSchemaResponseB{\n\x11\x63om.finelog.statsB\x11\x46inelogStatsProtoP\x01\xa2\x02\x03\x46SX\xaa\x02\rFinelog.Stats\xca\x02\rFinelog\\Stats\xe2\x02\x19\x46inelog\\Stats\\GPBMetadata\xea\x02\x0e\x46inelog::Statsb\x08\x65\x64itionsp\xe8\x07')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,40 +32,42 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'finelog_stats_pb2', _global
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\021com.finelog.statsB\021FinelogStatsProtoP\001\242\002\003FSX\252\002\rFinelog.Stats\312\002\rFinelog\\Stats\342\002\031Finelog\\Stats\\GPBMetadata\352\002\016Finelog::Stats'
-  _globals['_COLUMNTYPE']._serialized_start=1556
-  _globals['_COLUMNTYPE']._serialized_end=1763
-  _globals['_COLUMN']._serialized_start=38
-  _globals['_COLUMN']._serialized_end=141
-  _globals['_SCHEMA']._serialized_start=143
-  _globals['_SCHEMA']._serialized_end=231
-  _globals['_STORAGEPOLICY']._serialized_start=233
-  _globals['_STORAGEPOLICY']._serialized_end=352
-  _globals['_REGISTERTABLEREQUEST']._serialized_start=355
-  _globals['_REGISTERTABLEREQUEST']._serialized_end=523
-  _globals['_REGISTERTABLERESPONSE']._serialized_start=526
-  _globals['_REGISTERTABLERESPONSE']._serialized_end=688
-  _globals['_WRITEROWSREQUEST']._serialized_start=690
-  _globals['_WRITEROWSREQUEST']._serialized_end=767
-  _globals['_WRITEROWSRESPONSE']._serialized_start=769
-  _globals['_WRITEROWSRESPONSE']._serialized_end=823
-  _globals['_QUERYREQUEST']._serialized_start=825
-  _globals['_QUERYREQUEST']._serialized_end=857
-  _globals['_QUERYRESPONSE']._serialized_start=859
-  _globals['_QUERYRESPONSE']._serialized_end=932
-  _globals['_DROPTABLEREQUEST']._serialized_start=934
-  _globals['_DROPTABLEREQUEST']._serialized_end=982
-  _globals['_DROPTABLERESPONSE']._serialized_start=984
-  _globals['_DROPTABLERESPONSE']._serialized_end=1003
-  _globals['_NAMESPACEINFO']._serialized_start=1006
-  _globals['_NAMESPACEINFO']._serialized_end=1312
-  _globals['_LISTNAMESPACESREQUEST']._serialized_start=1314
-  _globals['_LISTNAMESPACESREQUEST']._serialized_end=1337
-  _globals['_LISTNAMESPACESRESPONSE']._serialized_start=1339
-  _globals['_LISTNAMESPACESRESPONSE']._serialized_end=1425
-  _globals['_GETTABLESCHEMAREQUEST']._serialized_start=1427
-  _globals['_GETTABLESCHEMAREQUEST']._serialized_end=1480
-  _globals['_GETTABLESCHEMARESPONSE']._serialized_start=1482
-  _globals['_GETTABLESCHEMARESPONSE']._serialized_end=1553
-  _globals['_STATSSERVICE']._serialized_start=1766
-  _globals['_STATSSERVICE']._serialized_end=2290
+  _globals['_COLUMNTYPE']._serialized_start=1648
+  _globals['_COLUMNTYPE']._serialized_end=1855
+  _globals['_COLUMNINDEX']._serialized_start=38
+  _globals['_COLUMNINDEX']._serialized_end=77
+  _globals['_COLUMN']._serialized_start=80
+  _globals['_COLUMN']._serialized_end=233
+  _globals['_SCHEMA']._serialized_start=235
+  _globals['_SCHEMA']._serialized_end=323
+  _globals['_STORAGEPOLICY']._serialized_start=325
+  _globals['_STORAGEPOLICY']._serialized_end=444
+  _globals['_REGISTERTABLEREQUEST']._serialized_start=447
+  _globals['_REGISTERTABLEREQUEST']._serialized_end=615
+  _globals['_REGISTERTABLERESPONSE']._serialized_start=618
+  _globals['_REGISTERTABLERESPONSE']._serialized_end=780
+  _globals['_WRITEROWSREQUEST']._serialized_start=782
+  _globals['_WRITEROWSREQUEST']._serialized_end=859
+  _globals['_WRITEROWSRESPONSE']._serialized_start=861
+  _globals['_WRITEROWSRESPONSE']._serialized_end=915
+  _globals['_QUERYREQUEST']._serialized_start=917
+  _globals['_QUERYREQUEST']._serialized_end=949
+  _globals['_QUERYRESPONSE']._serialized_start=951
+  _globals['_QUERYRESPONSE']._serialized_end=1024
+  _globals['_DROPTABLEREQUEST']._serialized_start=1026
+  _globals['_DROPTABLEREQUEST']._serialized_end=1074
+  _globals['_DROPTABLERESPONSE']._serialized_start=1076
+  _globals['_DROPTABLERESPONSE']._serialized_end=1095
+  _globals['_NAMESPACEINFO']._serialized_start=1098
+  _globals['_NAMESPACEINFO']._serialized_end=1404
+  _globals['_LISTNAMESPACESREQUEST']._serialized_start=1406
+  _globals['_LISTNAMESPACESREQUEST']._serialized_end=1429
+  _globals['_LISTNAMESPACESRESPONSE']._serialized_start=1431
+  _globals['_LISTNAMESPACESRESPONSE']._serialized_end=1517
+  _globals['_GETTABLESCHEMAREQUEST']._serialized_start=1519
+  _globals['_GETTABLESCHEMAREQUEST']._serialized_end=1572
+  _globals['_GETTABLESCHEMARESPONSE']._serialized_start=1574
+  _globals['_GETTABLESCHEMARESPONSE']._serialized_end=1645
+  _globals['_STATSSERVICE']._serialized_start=1858
+  _globals['_STATSSERVICE']._serialized_end=2382
 # @@protoc_insertion_point(module_scope)

--- a/lib/finelog/src/finelog/rpc/finelog_stats_pb2.pyi
+++ b/lib/finelog/src/finelog/rpc/finelog_stats_pb2.pyi
@@ -26,15 +26,23 @@ COLUMN_TYPE_TIMESTAMP_MS: ColumnType
 COLUMN_TYPE_BYTES: ColumnType
 COLUMN_TYPE_INT32: ColumnType
 
+class ColumnIndex(_message.Message):
+    __slots__ = ("trigram",)
+    TRIGRAM_FIELD_NUMBER: _ClassVar[int]
+    trigram: bool
+    def __init__(self, trigram: _Optional[bool] = ...) -> None: ...
+
 class Column(_message.Message):
-    __slots__ = ("name", "type", "nullable")
+    __slots__ = ("name", "type", "nullable", "index")
     NAME_FIELD_NUMBER: _ClassVar[int]
     TYPE_FIELD_NUMBER: _ClassVar[int]
     NULLABLE_FIELD_NUMBER: _ClassVar[int]
+    INDEX_FIELD_NUMBER: _ClassVar[int]
     name: str
     type: ColumnType
     nullable: bool
-    def __init__(self, name: _Optional[str] = ..., type: _Optional[_Union[ColumnType, str]] = ..., nullable: _Optional[bool] = ...) -> None: ...
+    index: ColumnIndex
+    def __init__(self, name: _Optional[str] = ..., type: _Optional[_Union[ColumnType, str]] = ..., nullable: _Optional[bool] = ..., index: _Optional[_Union[ColumnIndex, _Mapping]] = ...) -> None: ...
 
 class Schema(_message.Message):
     __slots__ = ("columns", "key_column")

--- a/lib/finelog/src/finelog/schema.py
+++ b/lib/finelog/src/finelog/schema.py
@@ -60,6 +60,10 @@ class Column:
     # initial creation of a column where the producer guarantees presence
     # (e.g. the implicit ``timestamp_ms`` key).
     nullable: bool = True
+    # Maintain a per-row-group trigram substring index for this column so
+    # ``contains(col, …)`` / ``col LIKE '%…%'`` queries prune row groups instead
+    # of full-scanning. Only meaningful for STRING columns; ignored otherwise.
+    trigram_index: bool = False
 
 
 @dataclass(frozen=True)
@@ -93,7 +97,9 @@ LOG_REGISTERED_SCHEMA = Schema(
     columns=(
         Column(name="key", type=stats_pb2.COLUMN_TYPE_STRING, nullable=False),
         Column(name="source", type=stats_pb2.COLUMN_TYPE_STRING, nullable=False),
-        Column(name="data", type=stats_pb2.COLUMN_TYPE_STRING, nullable=False),
+        # The log message body is substring-searched via contains()/LIKE, so it
+        # carries the trigram index (matches the server's log schema).
+        Column(name="data", type=stats_pb2.COLUMN_TYPE_STRING, nullable=False, trigram_index=True),
         Column(name="epoch_ms", type=stats_pb2.COLUMN_TYPE_INT64, nullable=False),
         Column(name="level", type=stats_pb2.COLUMN_TYPE_INT32, nullable=False),
     ),
@@ -122,7 +128,7 @@ def schema_from_proto(msg: stats_pb2.Schema) -> Schema:
             raise SchemaValidationError(f"column {c.name!r}: unknown column type {c.type!r}")
         if c.name == IMPLICIT_SEQ_COLUMN:
             raise SchemaValidationError(f"column {IMPLICIT_SEQ_COLUMN!r} is reserved (server-assigned implicit column)")
-        cols.append(Column(name=c.name, type=c.type, nullable=c.nullable))
+        cols.append(Column(name=c.name, type=c.type, nullable=c.nullable, trigram_index=c.index.trigram))
     return Schema(columns=tuple(cols), key_column=msg.key_column)
 
 
@@ -137,7 +143,14 @@ def schema_to_proto(schema: Schema) -> stats_pb2.Schema:
     for c in schema.columns:
         if c.name == IMPLICIT_SEQ_COLUMN:
             continue
-        msg.columns.append(stats_pb2.Column(name=c.name, type=c.type, nullable=c.nullable))
+        msg.columns.append(
+            stats_pb2.Column(
+                name=c.name,
+                type=c.type,
+                nullable=c.nullable,
+                index=stats_pb2.ColumnIndex(trigram=c.trigram_index),
+            )
+        )
     return msg
 
 

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -24,7 +24,7 @@ from finelog.errors import (
 )
 from finelog.rpc import finelog_stats_pb2 as stats_pb2
 from finelog.rpc import logging_pb2
-from finelog.schema import Column, Schema, schema_to_proto
+from finelog.schema import Column, Schema, schema_from_proto, schema_to_proto
 
 
 class FakeLogClient:
@@ -714,3 +714,20 @@ def test_schema_from_proto_consistency():
         assert proto_col.name == src_col.name
         assert proto_col.type == src_col.type
         assert proto_col.nullable == src_col.nullable
+        assert proto_col.index.trigram == src_col.trigram_index
+
+
+def test_trigram_index_round_trips_through_proto():
+    s = Schema(
+        columns=(
+            Column(name="data", type=stats_pb2.COLUMN_TYPE_STRING, nullable=False, trigram_index=True),
+            Column(name="level", type=stats_pb2.COLUMN_TYPE_INT32, nullable=False),
+            Column(name="timestamp_ms", type=stats_pb2.COLUMN_TYPE_INT64, nullable=False),
+        ),
+    )
+    back = schema_from_proto(schema_to_proto(s))
+    assert {c.name: c.trigram_index for c in back.columns} == {
+        "data": True,
+        "level": False,
+        "timestamp_ms": False,
+    }

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,24 +17,23 @@ dependencies = [
     "marin-core",
     "marin-rigging",
     "marin-zephyr",
+    # marin-finelog is the pure-Python finelog client + deploy/CLI tooling, a
+    # workspace member (editable source) so deploy/CLI fixes land without a wheel
+    # republish. Its native companion marin-finelog-server (the in-process
+    # log-server ext, module `finelog_server`, maturin lib/finelog/rust) is NOT a
+    # member: it ships as a pre-built wheel and reaches us transitively via
+    # marin-iris, which depends on it explicitly. `scripts/rust_mode.py dev` swaps
+    # marin-finelog-server to a local source build.
+    "marin-finelog",
     # top level deps. try to keep these small.
     "watchdog",
-    # marin-dupekit and marin-finelog are native (maturin) packages shipped as
-    # pre-built platform wheels (built by their *-release-wheels.yaml workflows)
-    # rather than pure-Python workspace members. A `>= X.Y.Z.dev0` floor opts uv
-    # into the daily nightly wheels (`X.Y.Z.dev<YYYYMMDDhhmm>`); a plain
-    # `>= X.Y.Z` floor pins to a stable tag (`dupekit-v<X.Y.Z>` /
-    # `finelog-v<X.Y.Z>`). uv prefers the higher version, so a stable supersedes
+    # marin-dupekit is a native (maturin) package shipped as pre-built platform
+    # wheels (built by dupekit-release-wheels.yaml) rather than a workspace
+    # member. A `>= X.Y.Z.dev0` floor opts uv into the daily nightly wheels
+    # (`X.Y.Z.dev<YYYYMMDDhhmm>`); a plain `>= X.Y.Z` floor pins to a stable tag
+    # (`dupekit-v<X.Y.Z>`). uv prefers the higher version, so a stable supersedes
     # any earlier dev of the same Z; bump the floor to whichever is newest.
-    # Published by .github/workflows/dupekit-release-wheels.yaml.
     "marin-dupekit >= 0.1.2.dev202606060824",
-    # marin-finelog is the pure-Python client. The iris controller also starts
-    # an in-process native log server (module `finelog_server`); that ships as
-    # the separate marin-finelog-server wheel (maturin, lib/finelog/rust), which
-    # the controller depends on explicitly (see lib/iris) and reaches us
-    # transitively via marin-iris — the pure client does not depend on it.
-    # `scripts/rust_mode.py dev` swaps both to local path sources.
-    "marin-finelog >= 0.2.10",
 ]
 
 [tool.uv]
@@ -117,23 +116,26 @@ conflicts = [
 ]
 
 [tool.uv.workspace]
-# lib/finelog is intentionally NOT a member: marin-finelog and its native
-# companion marin-finelog-server (maturin, lib/finelog/rust) are consumed as
-# published wheels (see [project] dependencies and the RUST-DEV SOURCES block
-# below), mirroring marin-dupekit.
 members = [
     "lib/iris",
     "lib/fray",
+    "lib/finelog",
     "lib/haliax",
     "lib/levanter",
     "lib/marin",
     "lib/rigging",
     "lib/zephyr",
 ]
+# lib/finelog/rust (marin-finelog-server, maturin) is NOT a member: the native
+# log-server ext is consumed as a pre-built wheel by default and only built from
+# source under `scripts/rust_mode.py dev`. Exclude it so workspace discovery
+# doesn't pull the nested package into the workspace.
+exclude = ["lib/finelog/rust"]
 
 [tool.uv.sources]
 marin-iris = { workspace = true }
 marin-fray = { workspace = true }
+marin-finelog = { workspace = true }
 marin-haliax = { workspace = true }
 marin-levanter = { workspace = true }
 marin-core = { workspace = true }

--- a/scripts/rust_mode.py
+++ b/scripts/rust_mode.py
@@ -5,9 +5,10 @@
 """Switch the native (maturin) packages between dev mode (source build) and
 user mode (pre-built wheel).
 
-Covers marin-dupekit and the finelog pair (pure marin-finelog + native
-marin-finelog-server). Operates on each target pyproject.toml by replacing the
-block between RUST-DEV markers:
+Covers the native packages marin-dupekit and marin-finelog-server. The
+pure-Python marin-finelog client is a permanent workspace member (always built
+from source, see the root pyproject), so it is not toggled here. Operates on
+each target pyproject.toml by replacing the block between RUST-DEV markers:
     # ### BEGIN RUST-DEV SOURCES ###
     ...
     # ### END RUST-DEV SOURCES ###
@@ -29,17 +30,17 @@ import sys
 BEGIN = "# ### BEGIN RUST-DEV SOURCES ###"
 END = "# ### END RUST-DEV SOURCES ###"
 
-# Path sources injected in dev mode, per pyproject. The Python packages are
-# editable so source edits land without reinstalling; marin-finelog-server is a
-# plain path source — its [tool.uv] cache-keys cover the Rust sources, so
-# `uv sync` rebuilds the extension when they change.
+# Path sources injected in dev mode, per pyproject. marin-dupekit is editable so
+# source edits land without reinstalling; marin-finelog-server is a plain path
+# source — its [tool.uv] cache-keys cover the Rust sources, so `uv sync` rebuilds
+# the extension when they change. The pure marin-finelog client is omitted: it is
+# a permanent workspace member and always resolves from source.
 TARGETS = [
     (
         pathlib.Path("pyproject.toml"),
         "\n".join(
             [
                 'marin-dupekit = { path = "lib/dupekit", editable = true }',
-                'marin-finelog = { path = "lib/finelog", editable = true }',
                 'marin-finelog-server = { path = "lib/finelog/rust" }',
             ]
         ),

--- a/uv.lock
+++ b/uv.lock
@@ -239,6 +239,7 @@ fork-strategy = "fewest"
 [manifest]
 members = [
     "marin-core",
+    "marin-finelog",
     "marin-fray",
     "marin-haliax",
     "marin-iris",
@@ -5406,8 +5407,8 @@ wheels = [
 
 [[package]]
 name = "marin-finelog"
-version = "0.2.10"
-source = { registry = "https://pypi.org/simple" }
+version = "0.2.11"
+source = { editable = "lib/finelog" }
 dependencies = [
     { name = "click" },
     { name = "connect-python" },
@@ -5420,9 +5421,35 @@ dependencies = [
     { name = "pyyaml" },
     { name = "zstandard" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/5f/ea/1e53cc39aeb66d747533f6e423f5f202ddd1be9a482406345f9b839217f8/marin_finelog-0.2.10.tar.gz", hash = "sha256:2881a021ad2ac5f0a9a75fada759a130d1533d0e87f97e2f5119de68753d4a0e", size = 52204, upload-time = "2026-06-16T15:21:07.603Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/b6/d4/cebe857527ff2703edc2def8748cbe9fd84315bfe24c6e01463a3bb83f58/marin_finelog-0.2.10-py3-none-any.whl", hash = "sha256:9b240454f1f997c0aede999f871051eb5349f7c1b0003c1d2653c69a9f2cefa0", size = 53400, upload-time = "2026-06-16T15:20:53.35Z" },
+
+[package.dev-dependencies]
+dev = [
+    { name = "marin-finelog-server" },
+    { name = "pytest" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.3.1" },
+    { name = "connect-python", specifier = ">=0.9.0" },
+    { name = "duckdb", specifier = ">=1.0.0" },
+    { name = "fsspec", specifier = ">=2024.0.0" },
+    { name = "gcsfs", specifier = ">=2024.0.0" },
+    { name = "marin-rigging", editable = "lib/rigging" },
+    { name = "protobuf", specifier = ">=5.0" },
+    { name = "pyarrow", specifier = ">=23.0.0" },
+    { name = "pyyaml", specifier = ">=6.0" },
+    { name = "zstandard", specifier = ">=0.22" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "marin-finelog-server", specifier = ">=0.2.0.dev0" },
+    { name = "pytest", specifier = ">=8.4" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 
 [[package]]
@@ -5653,7 +5680,7 @@ requires-dist = [
     { name = "httpx", specifier = ">=0.28.1" },
     { name = "humanfriendly", specifier = ">=10.0" },
     { name = "kubernetes", marker = "extra == 'controller'", specifier = ">=31.0.0,<36" },
-    { name = "marin-finelog", specifier = ">=0.2.10" },
+    { name = "marin-finelog", editable = "lib/finelog" },
     { name = "marin-finelog-server", specifier = ">=0.2.10" },
     { name = "marin-rigging", editable = "lib/rigging" },
     { name = "pyarrow", marker = "extra == 'controller'", specifier = ">=23.0.0" },
@@ -5973,7 +6000,7 @@ dependencies = [
 requires-dist = [
     { name = "marin-core", editable = "lib/marin" },
     { name = "marin-dupekit", specifier = ">=0.1.2.dev202606060824" },
-    { name = "marin-finelog", specifier = ">=0.2.10" },
+    { name = "marin-finelog", editable = "lib/finelog" },
     { name = "marin-fray", editable = "lib/fray" },
     { name = "marin-haliax", editable = "lib/haliax" },
     { name = "marin-iris", editable = "lib/iris" },


### PR DESCRIPTION
This PR bundles several finelog changes. The first group (trigram index, flush and retention tuning) is the substantive store work; the last two were the deploy/structural fixes that unblocked shipping it.

## Per-column trigram index, flush/retention tuning, and build perf

**L0 flush rate limiting.** Every append nudged the flush task, which sealed an L0 on every wake with no gate, so many ~1/s log producers each minted a tiny L0 (multiple per second). A 1s post-flush cooldown coalesces a window's appends into one L0 (~1 L0/s), with a full-buffer (`SEGMENT_TARGET_BYTES`) force-flush bypass so high-volume namespaces aren't throttled.

**Retention.** Default local retention drops from 100 GiB to 15 GiB (~10 days of backwards search), much closer to the working set.

**Per-column, configurable trigram index.** The `.tgm` substring index was hardcoded to the log `data` column. It is now declared per column via a nested, extensible `ColumnIndex { trigram }` proto message on `Column` (add a field per future index type). Rust selects indexed STRING columns via `Column.index.trigram`; Python exposes `Column(..., trigram_index=True)`. The write, compaction, query-prune, and backfill paths thread the indexed-column set, and the pruner intersects keep-masks across every indexed column a query constrains.

**Background sidecar backfill.** Terminal-level, single-input-bumped, and pre-sidecar segments never received an index. A bounded, off-reactor maintenance step now rebuilds one missing sidecar per tick. A missing sidecar is always correct-but-unpruned, never wrong.

**Build memory + speed.** Building a sidecar for one L3 (256 MiB) segment used >1 min and ~9 GB RAM. The merge held the sorted inputs live while materializing the merged output (2x the uncompressed segment); freeing the inputs first halves peak RAM. The trigram dedup set is now a fixed 2 MiB bitset over the 24-bit trigram universe (insert = shift-or, distinct = popcount) instead of a growing `HashSet`. The on-disk sidecar format is unchanged.

## 1. Stop the container before chowning the cache dir (`bootstrap.py`)

A `finelog deploy` of a new image failed with:

```
[finelog-init] Starting finelog bootstrap ...
chown: changing ownership of '.../seg_L0_...555082422.parquet.tmp': No such file or directory
chown: changing ownership of '.../_finelog_catalog.sqlite-journal': No such file or directory
FAIL — finelog did not become healthy on the new image.
```

The image was **never pulled or started** — there's no `Pulling image` / `Container started` line. The bootstrap died at `chown`:

- `chown -R 1000:1000 /var/cache/finelog` ran while the **old container was still running** and writing transient files (`seg_L*.parquet.tmp` segment flush, `_finelog_catalog.sqlite-journal` catalog txn).
- One vanished between `chown -R`'s directory scan and the per-file syscall, so `chown -R` exited non-zero.
- `set -e` then aborted the whole bootstrap before the new image was pulled. The auto-rollback that followed "succeeded" only because the race didn't recur.

Fix: reorder to `mkdir → pull → stop → rm → chown → run`. With the writer stopped, the recursive chown can't race a vanishing temp file. Verified by redeploying the same new digest with the reordered bootstrap — clean run, zero `chown` errors, healthy.

## 2. Make `marin-finelog` a workspace member (editable source)

Why this is in the same PR: the pure-Python finelog client + deploy/CLI tooling was consumed as a **published `marin-finelog` wheel** (`lib/finelog` was deliberately not a uv workspace member), so `uv run` imported the installed wheel, not `lib/finelog/src`. The bootstrap fix above — and any pure-Python finelog edit — would therefore **not reach `safe_deploy.py` or `iris cluster finelog ...` until a new wheel was published and synced**. That silent shadow is exactly what we hit while diagnosing the race.

`marin-finelog` is pure hatchling; the native ext is the separate `marin-finelog-server` (maturin, `lib/finelog/rust`). So the pure client can be a workspace member with **no Rust build on sync**:

- add `lib/finelog` to `[tool.uv.workspace] members` + `marin-finelog = { workspace = true }`; drop the `>= 0.2.10` floor (workspace members carry none in root deps)
- `exclude = ["lib/finelog/rust"]` so the native server is **not** pulled into the workspace — it stays a pre-built wheel by default (transitive via `marin-iris`), source-built only under `scripts/rust_mode.py dev`
- bump `lib/finelog` `0.2.0 → 0.2.11` so source satisfies the `>= 0.2.10` floor `lib/iris` still carries (publish version comes from git tags, not pyproject — resolution-only)
- drop the now-redundant `marin-finelog` editable line from `rust_mode.py` dev sources

Lock result: `marin-finelog` → `source = { editable = "lib/finelog" }` @ 0.2.11; `marin-finelog-server` stays `registry` @ 0.2.10. `uv lock` resolves 632 packages cleanly.

After this lands, the race fix reaches deploys via a plain `uv sync` from source — no `marin-finelog` wheel republish needed — and this class of "edited source but the deploy ran the wheel" bug is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
