### PR TITLE
fix: Make Iris dashboard work behind path-based reverse proxies

### DIFF
--- a/lib/iris/dashboard/rsbuild.config.ts
+++ b/lib/iris/dashboard/rsbuild.config.ts
@@ -13,7 +13,7 @@ export default defineConfig({
     distPath: {
       root: 'dist',
     },
-    assetPrefix: '/',
+    assetPrefix: 'auto',
   },
   html: {
     template: './src/template.html',

--- a/lib/iris/dashboard/src/composables/useRpc.ts
+++ b/lib/iris/dashboard/src/composables/useRpc.ts
@@ -25,6 +25,10 @@ function handleUnauthorized(resp: Response): void {
   }
 }
 
+export function dashboardApiUrl(path: string): string {
+  return new URL(path.replace(/^\/+/, ''), document.baseURI).toString()
+}
+
 function useRpc<T>(service: string, method: string, body?: RpcBody): RpcState<T> {
   const data = ref<T | null>(null) as Ref<T | null>
   const loading = ref(false)
@@ -37,7 +41,7 @@ function useRpc<T>(service: string, method: string, body?: RpcBody): RpcState<T>
     error.value = null
     try {
       const resolvedBody = typeof body === 'function' ? body() : (body ?? {})
-      const resp = await fetch(`/${service}/${method}`, {
+      const resp = await fetch(dashboardApiUrl(`${service}/${method}`), {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
         body: JSON.stringify(resolvedBody),
@@ -92,7 +96,7 @@ export class RpcError extends Error {
 /** One-shot RPC call returning a Promise. For use in async functions that
  *  need to call multiple RPCs or handle the response imperatively. */
 export async function controllerRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
-  const resp = await fetch(`/iris.cluster.ControllerService/${method}`, {
+  const resp = await fetch(dashboardApiUrl(`iris.cluster.ControllerService/${method}`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body ?? {}),
@@ -120,7 +124,7 @@ export function useStatsRpc<T>(
 
 /**
  * RPC composable for the finelog StatsService routed via the controller's
- * endpoint proxy at /proxy/system.log-server/finelog.stats.StatsService/<Method>.
+ * endpoint proxy at proxy/system.log-server/finelog.stats.StatsService/<Method>.
  */
 export function useLogServerStatsRpc<T>(
   method: string,
@@ -131,7 +135,7 @@ export function useLogServerStatsRpc<T>(
 
 /** One-shot RPC call for LogService. */
 export async function logServiceRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
-  const resp = await fetch(`/finelog.logging.LogService/${method}`, {
+  const resp = await fetch(dashboardApiUrl(`finelog.logging.LogService/${method}`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body ?? {}),
@@ -142,7 +146,7 @@ export async function logServiceRpcCall<T>(method: string, body?: Record<string,
 }
 
 export async function workerRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
-  const resp = await fetch(`/iris.cluster.WorkerService/${method}`, {
+  const resp = await fetch(dashboardApiUrl(`iris.cluster.WorkerService/${method}`), {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body ?? {}),

--- a/lib/iris/dashboard/src/template.html
+++ b/lib/iris/dashboard/src/template.html
@@ -5,6 +5,25 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title><%= title %></title>
     <script>
+      (function () {
+        var routeMatch = window.location.pathname.match(/^(.*?)(?:\/(?:job|worker|task|status)(?:\/|$))/);
+        var basePath = routeMatch ? (routeMatch[1] || '/') : window.location.pathname;
+        if (!basePath.endsWith('/')) {
+          basePath += '/';
+        }
+        var base = document.createElement('base');
+        base.href = basePath;
+        document.head.appendChild(base);
+
+        var nativeFetch = window.fetch;
+        window.fetch = function (input, init) {
+          if (typeof input === 'string' && input.startsWith('/') && !input.startsWith('//')) {
+            return nativeFetch.call(this, new URL(input.slice(1), document.baseURI).toString(), init);
+          }
+          return nativeFetch.apply(this, arguments);
+        };
+      })();
+
       // Apply dark mode before first paint to prevent flash
       try {
         var stored = localStorage.getItem('iris-dark-mode');

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -7,10 +7,12 @@ Tests verify dashboard functionality through the Connect RPC endpoints.
 The dashboard serves a web UI that fetches data via RPC calls.
 """
 
+from pathlib import Path
 from unittest.mock import Mock
 
 import pytest
 from finelog.server import LogServiceImpl
+from iris.cluster import dashboard_common
 from iris.cluster.bundle import BundleStore
 from iris.cluster.constraints import WellKnownAttribute
 from iris.cluster.controller import ops, reads
@@ -57,6 +59,8 @@ from .conftest import (
 # =============================================================================
 # Test Helpers
 # =============================================================================
+
+DASHBOARD_DIR = Path(__file__).parents[3] / "dashboard"
 
 
 def submit_job(
@@ -1095,6 +1099,50 @@ def test_health_endpoint_returns_ok(client):
 
     assert resp.status_code == 200
     assert resp.json() == {"status": "ok"}
+
+
+def test_dashboard_shell_serves_prefix_safe_html(client, tmp_path, monkeypatch):
+    """Dashboard HTML keeps assets/API calls under the browser-visible prefix."""
+    dist = tmp_path / "dashboard-dist"
+    (dist / "static" / "js").mkdir(parents=True)
+    (dist / "static" / "css").mkdir(parents=True)
+    template = (DASHBOARD_DIR / "src" / "template.html").read_text()
+    html = template.replace("<%= title %>", "Iris Dashboard").replace(
+        '<div id="app"></div>',
+        '<div id="app"></div>\n'
+        '    <script src="static/js/controller.js"></script>\n'
+        '    <link rel="stylesheet" href="static/css/controller.css" />',
+    )
+    (dist / "controller.html").write_text(html)
+    monkeypatch.setattr(dashboard_common, "VUE_DIST_DIR", dist)
+    monkeypatch.setattr(dashboard_common, "DOCKER_VUE_DIST_DIR", tmp_path / "missing-dashboard-dist")
+
+    resp = client.get("/job/test-user/test-job")
+
+    assert resp.status_code == 200
+    assert "document.createElement('base')" in resp.text
+    assert "new URL(input.slice(1), document.baseURI).toString()" in resp.text
+    assert 'src="static/js/controller.js"' in resp.text
+    assert 'href="static/css/controller.css"' in resp.text
+    assert 'src="/static/' not in resp.text
+    assert 'href="/static/' not in resp.text
+
+
+def test_dashboard_frontend_paths_are_prefix_relative():
+    """Dashboard build and RPC helpers avoid root-absolute URLs."""
+    config = (DASHBOARD_DIR / "rsbuild.config.ts").read_text()
+    rpc = (DASHBOARD_DIR / "src" / "composables" / "useRpc.ts").read_text()
+    template = (DASHBOARD_DIR / "src" / "template.html").read_text()
+
+    assert "assetPrefix: 'auto'" in config
+    assert "assetPrefix: '/'" not in config
+    assert "document.baseURI" in rpc
+    assert "fetch(`/${service}/${method}`" not in rpc
+    assert "fetch(`/iris.cluster.ControllerService/" not in rpc
+    assert "fetch(`/finelog.logging.LogService/" not in rpc
+    assert "fetch(`/iris.cluster.WorkerService/" not in rpc
+    assert "window.fetch = function" in template
+    assert "input.startsWith('/')" in template
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
The Iris dashboard cannot be served behind a prefix-stripping reverse proxy (code-server /proxy/<port>/, jupyter-server-proxy, IAP-style proxies). rsbuild.config.ts sets output.assetPrefix: '/', baking root-absolute script/CSS references into the built HTML, so under a path prefix the browser fetches /static/js/...

## Changes
Set output.assetPrefix to 'auto' (Rspack publicPath: 'auto') in rsbuild.config.ts so emitted asset URLs resolve relative to the document base instead of origin root. In useRpc.ts, derive the RPC/API base from document.baseURI (or window.location pathname up to the dashboard root) rather than hardcoding leading-slash paths, so connect/fetch calls stay under the active prefix.

Fixes #6358
