### PR TITLE
fix: Write replicate tracker_metrics file even when wandb run.finish() hangs

### DIFF
--- a/lib/levanter/src/levanter/tracker/background.py
+++ b/lib/levanter/src/levanter/tracker/background.py
@@ -37,7 +37,6 @@ from typing import Any, Optional
 
 from levanter.tracker.tracker import Tracker
 
-
 logger = logging.getLogger(__name__)
 
 
@@ -96,14 +95,22 @@ class BackgroundTracker(Tracker):
                 if item is _SHUTDOWN:
                     return
                 method, args, kwargs = item
+                method_name = method.__name__
                 try:
                     method(*args, **kwargs)
                 except Exception:
-                    logger.exception(
-                        "Background tracker '%s' raised while processing %s; dropping update and continuing.",
-                        self.name,
-                        method.__name__,
-                    )
+                    if method_name == "finish":
+                        logger.warning(
+                            "Background tracker '%s' raised during finish(); continuing shutdown.",
+                            self.name,
+                            exc_info=True,
+                        )
+                    else:
+                        logger.exception(
+                            "Background tracker '%s' raised while processing %s; dropping update and continuing.",
+                            self.name,
+                            method_name,
+                        )
             finally:
                 self._queue.task_done()
 

--- a/lib/levanter/src/levanter/tracker/wandb.py
+++ b/lib/levanter/src/levanter/tracker/wandb.py
@@ -23,7 +23,6 @@ from levanter.tracker.histogram import SummaryStats
 from levanter.tracker.tracker import TrackerConfig
 from levanter.utils import jax_utils
 
-
 if typing.TYPE_CHECKING:
     import wandb.sdk.lib.disabled
 
@@ -152,10 +151,24 @@ class WandbTracker(Tracker):
             return
 
         logger.info("Finishing wandb run...")
-        # Finish wandb first to ensure all metrics are synced to the summary
-        self.run.finish()
-        # Then write the replicate file with the complete summary
-        self._write_replicate_file()
+        # Preserve the latest in-memory summary before W&B enters its upload
+        # path, which can block indefinitely during shutdown.
+        try:
+            self._write_replicate_file()
+        except Exception:
+            logger.exception("Failed to write preliminary replicate metrics file before wandb run.finish().")
+
+        try:
+            self.run.finish()
+        except Exception:
+            try:
+                self._write_replicate_file()
+            except Exception:
+                logger.exception("Failed to write replicate metrics file after wandb run.finish() raised.")
+            raise
+        else:
+            # Then write the replicate file with the complete summary
+            self._write_replicate_file()
 
     def _write_replicate_file(self):
         if self._replicate_path is None:

--- a/lib/levanter/tests/test_tracker.py
+++ b/lib/levanter/tests/test_tracker.py
@@ -3,8 +3,10 @@
 
 # NOTE: Do not explicitly import wandb/other trackers here, as this will cause the tests to trivially pass.
 import dataclasses
+import json
 import logging
 import re
+import threading
 import warnings
 from typing import Tuple
 
@@ -15,9 +17,45 @@ import yaml
 import levanter.tracker
 import levanter.tracker.tracker_fns as tracker_fns
 import levanter.tracker.wandb as wandb_tracker_mod
-from levanter.tracker import CompositeTracker, NoopTracker, TrackerConfig
+from levanter.tracker import BackgroundTracker, CompositeTracker, NoopTracker, TrackerConfig
 from levanter.tracker.tracker import NoopConfig
 from levanter.tracker.wandb import WandbTracker, _truncate_wandb_artifact_name, truncate_wandb_run_name
+
+
+class _HandleAbandonedError(Exception):
+    pass
+
+
+class _FakeWandbRun:
+    step = 0
+
+    def __init__(
+        self,
+        *,
+        finish_error: Exception | None = None,
+        finish_release: threading.Event | None = None,
+    ):
+        self.config = {"learning_rate": 1.0e-4, "model": {"layers": 2}}
+        self.summary = {"train/loss": 6.61, "_step": 99}
+        self.finish_error = finish_error
+        self.finish_release = finish_release
+        self.finish_started = threading.Event()
+        self.finish_calls = 0
+
+    def finish(self):
+        self.finish_calls += 1
+        self.finish_started.set()
+        if self.finish_release is not None:
+            self.finish_release.wait(timeout=5.0)
+        if self.finish_error is not None:
+            raise self.finish_error
+
+
+def _read_tracker_metrics(replicate_path):
+    metrics_path = replicate_path / "tracker_metrics.jsonl"
+    lines = metrics_path.read_text().splitlines()
+    assert len(lines) == 1
+    return json.loads(lines[0])
 
 
 def test_tracker_plugin_stuff_works():
@@ -189,6 +227,96 @@ def test_wandb_tracker_materializes_before_dynamic_stale_step_check(monkeypatch)
     tracker.log({"metric": 2.0}, step=10)
 
     assert converted == [2.0]
+
+
+def test_wandb_tracker_finish_writes_replicate_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("WANDB_ERROR_REPORTING", "false")
+
+    replicate_path = tmp_path / "replicate"
+    run = _FakeWandbRun()
+    tracker = WandbTracker(run, replicate_path=str(replicate_path))
+
+    tracker.finish()
+
+    assert run.finish_calls == 1
+    assert _read_tracker_metrics(replicate_path) == {
+        "config": run.config,
+        "summary": run.summary,
+    }
+
+
+def test_wandb_tracker_finish_writes_replicate_file_when_finish_raises(tmp_path, monkeypatch):
+    monkeypatch.setenv("WANDB_ERROR_REPORTING", "false")
+
+    replicate_path = tmp_path / "replicate"
+    run = _FakeWandbRun(finish_error=_HandleAbandonedError("wandb finish abandoned"))
+    tracker = WandbTracker(run, replicate_path=str(replicate_path))
+
+    with pytest.raises(_HandleAbandonedError):
+        tracker.finish()
+
+    assert _read_tracker_metrics(replicate_path) == {
+        "config": run.config,
+        "summary": run.summary,
+    }
+
+
+def test_wandb_tracker_finish_without_replicate_path_writes_no_file(tmp_path, monkeypatch):
+    monkeypatch.setenv("WANDB_ERROR_REPORTING", "false")
+
+    run = _FakeWandbRun()
+    tracker = WandbTracker(run)
+
+    tracker.finish()
+
+    assert run.finish_calls == 1
+    assert list(tmp_path.iterdir()) == []
+
+
+def test_background_tracker_warns_and_writes_replicate_file_when_wandb_finish_raises(tmp_path, caplog, monkeypatch):
+    monkeypatch.setenv("WANDB_ERROR_REPORTING", "false")
+
+    replicate_path = tmp_path / "replicate"
+    run = _FakeWandbRun(finish_error=_HandleAbandonedError("wandb finish abandoned"))
+    wrapped = WandbTracker(run, replicate_path=str(replicate_path))
+    tracker = BackgroundTracker(wrapped, finish_timeout=5.0)
+
+    with caplog.at_level(logging.WARNING, logger="levanter.tracker.background"):
+        tracker.finish()
+
+    assert _read_tracker_metrics(replicate_path) == {
+        "config": run.config,
+        "summary": run.summary,
+    }
+    assert any(
+        record.levelno == logging.WARNING and "raised during finish" in record.message for record in caplog.records
+    )
+
+
+def test_background_tracker_timeout_keeps_replicate_file_when_wandb_finish_hangs(tmp_path, caplog, monkeypatch):
+    monkeypatch.setenv("WANDB_ERROR_REPORTING", "false")
+
+    replicate_path = tmp_path / "replicate"
+    finish_release = threading.Event()
+    run = _FakeWandbRun(finish_release=finish_release)
+    wrapped = WandbTracker(run, replicate_path=str(replicate_path))
+    tracker = BackgroundTracker(wrapped, finish_timeout=0.2)
+
+    try:
+        with caplog.at_level(logging.WARNING, logger="levanter.tracker.background"):
+            tracker.finish()
+
+        assert run.finish_started.wait(timeout=1.0)
+        assert _read_tracker_metrics(replicate_path) == {
+            "config": run.config,
+            "summary": run.summary,
+        }
+        assert any(
+            record.levelno == logging.WARNING and "did not exit within" in record.message for record in caplog.records
+        )
+    finally:
+        finish_release.set()
+        tracker._thread.join(timeout=5.0)
 
 
 def test_truncate_wandb_run_name_preserves_scientific_notation_lr_suffix():


### PR DESCRIPTION
## Summary
A healthy CoreWeave H100 Grug MoE canary run passed all training thresholds (train/loss 6.61, _step 99, finished W&B state) but the 'Validate canary metrics' gate failed because tracker_metrics.jsonl was never written. Root cause: in WandbTracker.finish(), self.run.finish() is called first and _write_replicate_file() only runs after it returns.

## Changes
In WandbTracker.finish(), decouple the replicate-file write from run.finish() succeeding: write _write_replicate_file() in a finally (or wrap run.finish() so an abandoned/timed-out finish still triggers the replicate write), since the W&B summary needed for the file is available before upload completes. In background.py, narrow or restructure the worker's except handling so a hung/abandoned wrapped finish still attempts the replicate write rather than silently dropping it, and surface the abandonment as a warning.

Fixes #6364
