### PR TITLE
Read profiler traces from run dir

### DIFF
--- a/.agents/skills/profile-training/SKILL.md
+++ b/.agents/skills/profile-training/SKILL.md
@@ -6,8 +6,8 @@ description: Profile JAX training and analyze hotspots. Use when profiling or op
 # Skill: Agent-Driven Profiling (XPlane/xprof/TensorBoard/Perfetto)
 
 ## Overview
-Turn a `jax_profile` artifact into a deterministic, agent-consumable summary and
-a concrete optimization workflow:
+Turn a Levanter profile directory into a deterministic, agent-consumable
+summary and a concrete optimization workflow:
 1. capture a representative profile,
 2. ingest to `profile_summary.v1`,
 3. query hotspots and bottlenecks,
@@ -16,13 +16,13 @@ a concrete optimization workflow:
 
 ## Scope
 Ingestion sources:
-- XPlane protobufs inside Levanter `jax_profile` artifacts (source of truth):
+- XPlane protobufs inside Levanter profile directories (source of truth):
   - `plugins/profile/<timestamp>/*.xplane.pb`
   - explicit local `*.xplane.pb` files via `--xplane-file`
 - xprof aggregate tables exported from the same XPlane protobuf when the
   optional `xprof` package is available: step overview timing, kernel stats,
   collective breakdowns, xprof bottleneck statements.
-- Perfetto trace JSON as an explicit/fallback source for old artifacts:
+- Perfetto trace JSON as an explicit/fallback source for older profiles:
   - `plugins/profile/<timestamp>/perfetto_trace.json.gz`
   - `plugins/profile/<timestamp>/*.trace.json.gz`
 
@@ -30,11 +30,11 @@ Prefer XPlane protobuf for new work. Perfetto trace JSON commonly hits the trace
 event cap; XPlane contains the uncapped timeline events needed for named-scope
 regions, pre-op gaps, gap context, process/thread metadata, and xprof aggregate
 tables. Use `--trace-file` only for a specific Perfetto JSON trace or an older
-artifact with no XPlane protobuf.
+profile with no XPlane protobuf.
 
 ## Capture Profiles
-Use Levanter profiler flags so profiles upload consistently as `jax_profile`
-artifacts:
+Use Levanter profiler flags so profiles land under
+`<trainer.log_dir>/<run_id>/profiler`:
 
 ```bash
 uv run ... \
@@ -99,24 +99,24 @@ uv run python lib/marin/tools/profile_summary.py summarize \
   --output /tmp/profile_summary.json
 ```
 
-### Option B: From a W&B run target (auto-pick latest profile artifact)
+### Option B: From a W&B run target
 
 ```bash
 uv run python lib/marin/tools/profile_summary.py summarize \
   --run-target marin-community/marin/grug-125m-profile-apples-pallas_tpu-20260217-225239-055ab2 \
-  --alias latest \
   --download-root /tmp/marin-profiles \
   --output /tmp/profile_summary.json
 ```
 
 `--run-target` accepts: a bare run id (requires `--entity` and `--project`),
-`entity/project/run_id`, or a full W&B run URL.
+`entity/project/run_id`, or a full W&B run URL. The profiler directory is
+resolved from `trainer.log_dir` in the run config.
 
 ### Option C: From a local artifact directory
 
 ```bash
 uv run python lib/marin/tools/profile_summary.py summarize \
-  --profile-dir /path/to/jax_profile_artifact_dir \
+  --profile-dir /path/to/profiler_dir \
   --output /tmp/profile_summary.json
 ```
 

--- a/lib/levanter/docs/Performance-Guide.md
+++ b/lib/levanter/docs/Performance-Guide.md
@@ -14,7 +14,7 @@ See also the [JAX Profiling Guide](https://jax.readthedocs.io/en/latest/profilin
 Levanter uses JAX's built-in profiler. You can enable it by adding the `--trainer.profiler.enabled true` flag
 to the command line. This will generate a trace file in the `./logs` directory, under `./logs/<run_id>/profiler/plugins/profile/<datetime>`.
 (Yeah, it's a mess, but it's what JAX wants to do.)
-It will also upload the information to the relevant tracker (such as Weights & Biases or TensorBoard).
+The trace stays on disk in the run directory, so you can inspect it from whatever durable storage backs `log_dir`.
 
 Install profiling dependencies (TensorBoard) with one of:
 
@@ -32,8 +32,8 @@ Here are the full list of profiling related options:
 
 As usual, these can be specified in the yaml configuration file as well.
 
-In a multi-process setup, each node will save a profile, but only the first node will upload it to the tracker.
-All of them will be available in the `./logs` directory (on each node).
+In a multi-process setup, each node will save a profile. All of them will be available in the `./logs` directory (on each node),
+or in the remote storage configured for `log_dir`.
 
 
 ### Examining a Profile
@@ -46,10 +46,8 @@ JAX offers two main ways to examine a profile: Perfetto and TensorBoard.
 
 [Perfetto](https://ui.perfetto.dev/) is a web-based tool for examining profiles.
 
-We automatically save Perfetto traces and log them to WandB as artifacts. You can download the trace from WandB and use Perfetto to examine it.
-To find the trace, go to the run's page on WandB and click on the "Artifacts" tab. Then click on the `jax_profile` artifact, and navigate to the "Files" tab.
-Click `plugins` then `profile` then a date, then download `perfetto_trace.json.gz`.
-You can then go to https://ui.perfetto.dev/ and upload the file.
+Open the trace from the run directory, then go to https://ui.perfetto.dev/ and upload `perfetto_trace.json.gz`.
+The file lives under `plugins/profile/<datetime>/` inside the profiler output directory.
 
 Alternatively, you can enable the `--trainer.profiler.perfetto_link` flag.
 This will generate a link that will automatically upload the `perfetto_trace.json.gz` file in the same directory as the TensorBoard profile.
@@ -63,23 +61,15 @@ You want to download the trace files (e.g. `plugins/profile/2024_03_16_07_26_24`
 and run `tensorboard --logdir <dir>` where `<dir>` is the *directory containing plugins* (not the plugins directory itself).
 Then you can navigate to http://localhost:6006/#profile in your browser and see the profile.
 
-#### Fetching traces from Weights & Biases
+#### Fetching traces
 
-When you log profiles to WandB, the easiest way to grab the latest trace and open it locally is the helper script in
-`scripts/wandb_tensorboard_profile.py`. It understands bare run ids, `entity/project/run` paths, or full WandB URLs and
-downloads the most recent `jax_profile` artifact by default.
+If your run directory is on durable remote storage, download or sync the profiler output directory locally and point
+TensorBoard at the directory containing `plugins/`.
 
 ```bash
-# Example: launch TensorBoard for a specific run by URL
-uv run scripts/wandb_tensorboard_profile.py https://wandb.ai/my-entity/my-project/runs/abc123 --port 6007
-
-# Example: run by id with explicit entity/project, but just print the command it would run
-uv run scripts/wandb_tensorboard_profile.py abc123 --entity my-entity --project my-project --dry-run
+# Example: launch TensorBoard from a local copy of a profiler output directory
+tensorboard --logdir /path/to/run/profiler
 ```
-
-The script creates a temporary download directory unless `--download-root` is provided, prints the resolved aliases, and
-launches TensorBoard (or exits once the command is printed when `--dry-run` is passed). Use `Ctrl+C` to stop TensorBoard
-after inspecting the profile.
 
 TensorBoard install tips:
 

--- a/lib/levanter/docs/Performance-Guide.md
+++ b/lib/levanter/docs/Performance-Guide.md
@@ -32,8 +32,9 @@ Here are the full list of profiling related options:
 
 As usual, these can be specified in the yaml configuration file as well.
 
-In a multi-process setup, each node will save a profile. All of them will be available in the `./logs` directory (on each node),
-or in the remote storage configured for `log_dir`.
+In a multi-process setup, each node saves its own profile under that node's `log_dir` tree. JAX does not merge or align
+those traces automatically, so compare the per-host `plugins/profile/<datetime>/` directories directly if you need a
+cross-host view.
 
 
 ### Examining a Profile
@@ -48,6 +49,9 @@ JAX offers two main ways to examine a profile: Perfetto and TensorBoard.
 
 Open the trace from the run directory, then go to https://ui.perfetto.dev/ and upload `perfetto_trace.json.gz`.
 The file lives under `plugins/profile/<datetime>/` inside the profiler output directory.
+
+If you enabled host profiling, the companion `host_profile.pstats` and `host_profile.txt` files are written alongside the
+JAX trace files in that same profiler directory.
 
 Alternatively, you can enable the `--trainer.profiler.perfetto_link` flag.
 This will generate a link that will automatically upload the `perfetto_trace.json.gz` file in the same directory as the TensorBoard profile.

--- a/lib/levanter/scripts/wandb_tensorboard_profile.py
+++ b/lib/levanter/scripts/wandb_tensorboard_profile.py
@@ -80,12 +80,12 @@ def main() -> None:
     args = parse_args()
 
     try:
-        entity, project, run_id = normalize_run_target(args.target, args.entity, args.project)
+        run_target = normalize_run_target(args.target, args.entity, args.project)
     except ValueError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)
 
-    run_path = f"{entity}/{project}/{run_id}"
+    run_path = f"{run_target.entity}/{run_target.project}/{run_target.run_id}"
     api = wandb.Api()
     try:
         run = api.run(run_path)

--- a/lib/levanter/scripts/wandb_tensorboard_profile.py
+++ b/lib/levanter/scripts/wandb_tensorboard_profile.py
@@ -2,7 +2,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Download the latest JAX profile artifact for a W&B run and launch TensorBoard."""
+"""Download the JAX profile directory for a W&B run and launch TensorBoard."""
 
 from __future__ import annotations
 
@@ -13,20 +13,20 @@ import subprocess
 import sys
 import tempfile
 from pathlib import Path
-from typing import Iterable, Optional, Tuple
+from typing import Optional, Tuple
 from urllib.parse import urlparse
+
+from rigging.filesystem import url_to_fs
 
 import wandb
 import wandb.errors as wandb_errors
 
-
-ARTIFACT_TYPE = "jax_profile"
-DEFAULT_ALIAS = "latest"
+from levanter.utils.fsspec_utils import join_path
 
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
-        description="Download the latest JAX profile artifact for a W&B run and launch TensorBoard on it."
+        description="Download the JAX profile directory for a W&B run and launch TensorBoard on it."
     )
     parser.add_argument(
         "target",
@@ -38,14 +38,9 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument("--entity", help="W&B entity (team or username) if target is a bare run id.")
     parser.add_argument("--project", help="W&B project if target is a bare run id.")
     parser.add_argument(
-        "--alias",
-        default=DEFAULT_ALIAS,
-        help="Artifact alias to use. Defaults to 'latest'. If not found, the freshest artifact is used.",
-    )
-    parser.add_argument(
         "--download-root",
         type=Path,
-        help="Optional directory where the artifact will be downloaded. Defaults to a new temp directory.",
+        help="Optional directory where the profile tree will be mirrored. Defaults to a new temp directory.",
     )
     parser.add_argument(
         "--tensorboard",
@@ -93,42 +88,47 @@ def normalize_run_path(target: str, entity: Optional[str], project: Optional[str
     raise ValueError(f"Unrecognized run target: {target}")
 
 
-def iter_profile_artifacts(run: "wandb.apis.public.Run") -> Iterable["wandb.sdk.Artifact"]:
-    for artifact in run.logged_artifacts():
-        if artifact.type == ARTIFACT_TYPE:
-            yield artifact
+def resolve_profile_dir(run: "wandb.apis.public.Run") -> str:
+    trainer_config = run.config.get("trainer")
+    if not isinstance(trainer_config, dict):
+        raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
+
+    log_dir = trainer_config.get("log_dir")
+    if not log_dir:
+        raise RuntimeError(f"Run {run.path} does not expose trainer.log_dir.")
+
+    run_id = run.path[-1]
+    return join_path(join_path(str(log_dir), run_id), "profiler")
 
 
-def _alias_names(artifact: "wandb.sdk.Artifact") -> set[str]:  # type: ignore[name-defined]
-    names: set[str] = set()
-    for alias in artifact.aliases or []:
-        name = getattr(alias, "name", alias)
-        if name is not None:
-            names.add(str(name))
-    return names
+def _is_local_fs(fs) -> bool:
+    protocol = fs.protocol[0] if isinstance(fs.protocol, tuple) else fs.protocol
+    return protocol in (None, "", "file")
 
 
-def select_profile_artifact(run: "wandb.apis.public.Run", alias: Optional[str]) -> "wandb.sdk.Artifact":
-    candidates = list(iter_profile_artifacts(run))
-    if not candidates:
-        raise RuntimeError(f"No artifacts of type '{ARTIFACT_TYPE}' were found for run {run.path}.")
-
-    if alias:
-        for artifact in candidates:
-            alias_names = _alias_names(artifact)
-            if alias in alias_names:
-                return artifact
-
-    candidates.sort(key=lambda art: art.updated_at or art.created_at, reverse=True)
-    return candidates[0]
-
-
-def download_artifact(artifact: "wandb.sdk.Artifact", root: Optional[Path]) -> Path:
+def mirror_profile_dir(profile_dir: str, root: Optional[Path], *, run_id: str) -> Path:
+    fs, fs_path = url_to_fs(profile_dir)
     if root is None:
+        if _is_local_fs(fs):
+            path = Path(fs_path)
+            if not path.exists():
+                raise FileNotFoundError(f"Profile directory '{profile_dir}' does not exist.")
+            return path
         root = Path(tempfile.mkdtemp(prefix="wandb-profile-"))
     else:
         root.mkdir(parents=True, exist_ok=True)
-    download_path = Path(artifact.download(root=str(root)))
+
+    download_path = root / run_id / "profiler"
+    if download_path.exists():
+        shutil.rmtree(download_path)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if _is_local_fs(fs):
+        if not Path(fs_path).exists():
+            raise FileNotFoundError(f"Profile directory '{profile_dir}' does not exist.")
+        shutil.copytree(fs_path, download_path)
+    else:
+        fs.get(fs_path, str(download_path), recursive=True)
     return download_path
 
 
@@ -175,11 +175,14 @@ def main() -> None:
         print(f"Failed to load run '{run_path}': {exc}", file=sys.stderr)
         sys.exit(1)
 
-    artifact = select_profile_artifact(run, args.alias)
-    download_path = download_artifact(artifact, args.download_root)
+    try:
+        profile_dir = resolve_profile_dir(run)
+        download_path = mirror_profile_dir(profile_dir, args.download_root, run_id=run_id)
+    except (RuntimeError, FileNotFoundError) as exc:
+        print(f"Failed to resolve profile directory for '{run_path}': {exc}", file=sys.stderr)
+        sys.exit(1)
 
-    alias_list = sorted(_alias_names(artifact))
-    print(f"Downloaded artifact '{artifact.name}' (aliases: {alias_list}) to {download_path}")
+    print(f"Resolved profile directory '{profile_dir}' to {download_path}")
     print("Press Ctrl+C to stop TensorBoard when finished.")
 
     ensure_tensorboard_available(args.tensorboard)

--- a/lib/levanter/scripts/wandb_tensorboard_profile.py
+++ b/lib/levanter/scripts/wandb_tensorboard_profile.py
@@ -12,15 +12,17 @@ import shutil
 import subprocess
 import sys
 from pathlib import Path
-from typing import Optional, Tuple
-from urllib.parse import urlparse
+from typing import Optional
 
 import wandb
 import wandb.errors as wandb_errors
 
-from levanter.utils.fsspec_utils import join_path, mirror_directory
-
-PROFILER_DIR_NAME = "profiler"
+from levanter.utils.profile_dirs import (
+    mirror_profile_dir,
+    normalize_run_target,
+    resolve_profile_dir,
+    resolve_profile_run_id,
+)
 
 
 def parse_args() -> argparse.Namespace:
@@ -55,73 +57,6 @@ def parse_args() -> argparse.Namespace:
     return parser.parse_args()
 
 
-def normalize_run_path(target: str, entity: Optional[str], project: Optional[str]) -> Tuple[str, str, str]:
-    if target.startswith(("http://", "https://")):
-        parsed = urlparse(target)
-        parts = [p for p in parsed.path.split("/") if p]
-        if len(parts) < 3:
-            raise ValueError(f"Could not parse run information from URL: {target}")
-        entity = parts[0]
-        project = parts[1]
-        if parts[2] == "runs" and len(parts) >= 4:
-            run_id = parts[3]
-        else:
-            run_id = parts[2]
-        return entity, project, run_id
-
-    parts = [p for p in target.split("/") if p]
-    if len(parts) == 1:
-        if not entity or not project:
-            raise ValueError("Bare run ids require --entity and --project.")
-        return entity, project, parts[0]
-
-    if len(parts) >= 3:
-        entity = parts[0]
-        project = parts[1]
-        if parts[2] == "runs" and len(parts) >= 4:
-            run_id = parts[3]
-        else:
-            run_id = parts[2]
-        return entity, project, run_id
-
-    raise ValueError(f"Unrecognized run target: {target}")
-
-
-def resolve_profile_dir(run: "wandb.apis.public.Run") -> str:
-    run_id = resolve_profile_run_id(run)
-    trainer_config = run.config.get("trainer")
-    if not isinstance(trainer_config, dict):
-        raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
-
-    log_dir = trainer_config.get("log_dir")
-    if not log_dir:
-        raise RuntimeError(f"Run {run.path} does not expose trainer.log_dir.")
-
-    return join_path(join_path(str(log_dir), run_id), PROFILER_DIR_NAME)
-
-
-def resolve_profile_run_id(run: "wandb.apis.public.Run") -> str:
-    trainer_config = run.config.get("trainer")
-    if not isinstance(trainer_config, dict):
-        raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
-
-    run_id = trainer_config.get("id")
-    if isinstance(run_id, str) and run_id:
-        return run_id
-
-    return run.path[-1]
-
-
-def mirror_profile_dir(profile_dir: str, root: Path | None, *, run_id: str) -> Path:
-    return mirror_directory(
-        profile_dir,
-        root,
-        run_id=run_id,
-        leaf_dirname=PROFILER_DIR_NAME,
-        temp_dir_prefix="wandb-profile-",
-    )
-
-
 def build_tensorboard_command(executable: str, logdir: Path, port: Optional[int]) -> list[str]:
     command = [executable, f"--logdir={logdir}"]
     if port is not None:
@@ -145,7 +80,7 @@ def main() -> None:
     args = parse_args()
 
     try:
-        entity, project, run_id = normalize_run_path(args.target, args.entity, args.project)
+        entity, project, run_id = normalize_run_target(args.target, args.entity, args.project)
     except ValueError as exc:
         print(f"Error: {exc}", file=sys.stderr)
         sys.exit(1)

--- a/lib/levanter/scripts/wandb_tensorboard_profile.py
+++ b/lib/levanter/scripts/wandb_tensorboard_profile.py
@@ -91,6 +91,7 @@ def normalize_run_path(target: str, entity: Optional[str], project: Optional[str
 
 
 def resolve_profile_dir(run: "wandb.apis.public.Run") -> str:
+    run_id = resolve_profile_run_id(run)
     trainer_config = run.config.get("trainer")
     if not isinstance(trainer_config, dict):
         raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
@@ -99,8 +100,19 @@ def resolve_profile_dir(run: "wandb.apis.public.Run") -> str:
     if not log_dir:
         raise RuntimeError(f"Run {run.path} does not expose trainer.log_dir.")
 
-    run_id = run.path[-1]
     return join_path(join_path(str(log_dir), run_id), PROFILER_DIR_NAME)
+
+
+def resolve_profile_run_id(run: "wandb.apis.public.Run") -> str:
+    trainer_config = run.config.get("trainer")
+    if not isinstance(trainer_config, dict):
+        raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
+
+    run_id = trainer_config.get("id")
+    if isinstance(run_id, str) and run_id:
+        return run_id
+
+    return run.path[-1]
 
 
 def _is_local_fs(fs) -> bool:
@@ -121,14 +133,20 @@ def mirror_profile_dir(profile_dir: str, root: Optional[Path], *, run_id: str) -
         root.mkdir(parents=True, exist_ok=True)
 
     download_path = root / run_id / PROFILER_DIR_NAME
+    source_path = Path(fs_path)
+    if _is_local_fs(fs) and download_path.resolve() == source_path.resolve():
+        if not source_path.exists():
+            raise FileNotFoundError(f"Profile directory '{profile_dir}' does not exist.")
+        return source_path
+
     if download_path.exists():
         shutil.rmtree(download_path)
     download_path.parent.mkdir(parents=True, exist_ok=True)
 
     if _is_local_fs(fs):
-        if not Path(fs_path).exists():
+        if not source_path.exists():
             raise FileNotFoundError(f"Profile directory '{profile_dir}' does not exist.")
-        shutil.copytree(fs_path, download_path)
+        shutil.copytree(source_path, download_path)
     else:
         fs.get(fs_path, str(download_path), recursive=True)
     return download_path
@@ -179,7 +197,8 @@ def main() -> None:
 
     try:
         profile_dir = resolve_profile_dir(run)
-        download_path = mirror_profile_dir(profile_dir, args.download_root, run_id=run_id)
+        profile_run_id = resolve_profile_run_id(run)
+        download_path = mirror_profile_dir(profile_dir, args.download_root, run_id=profile_run_id)
     except (RuntimeError, FileNotFoundError) as exc:
         print(f"Failed to resolve profile directory for '{run_path}': {exc}", file=sys.stderr)
         sys.exit(1)

--- a/lib/levanter/scripts/wandb_tensorboard_profile.py
+++ b/lib/levanter/scripts/wandb_tensorboard_profile.py
@@ -23,6 +23,8 @@ import wandb.errors as wandb_errors
 
 from levanter.utils.fsspec_utils import join_path
 
+PROFILER_DIR_NAME = "profiler"
+
 
 def parse_args() -> argparse.Namespace:
     parser = argparse.ArgumentParser(
@@ -51,7 +53,7 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--dry-run",
         action="store_true",
-        help="Download the artifact and print the TensorBoard command without launching it.",
+        help="Mirror the profile directory and print the TensorBoard command without launching it.",
     )
     return parser.parse_args()
 
@@ -98,7 +100,7 @@ def resolve_profile_dir(run: "wandb.apis.public.Run") -> str:
         raise RuntimeError(f"Run {run.path} does not expose trainer.log_dir.")
 
     run_id = run.path[-1]
-    return join_path(join_path(str(log_dir), run_id), "profiler")
+    return join_path(join_path(str(log_dir), run_id), PROFILER_DIR_NAME)
 
 
 def _is_local_fs(fs) -> bool:
@@ -118,7 +120,7 @@ def mirror_profile_dir(profile_dir: str, root: Optional[Path], *, run_id: str) -
     else:
         root.mkdir(parents=True, exist_ok=True)
 
-    download_path = root / run_id / "profiler"
+    download_path = root / run_id / PROFILER_DIR_NAME
     if download_path.exists():
         shutil.rmtree(download_path)
     download_path.parent.mkdir(parents=True, exist_ok=True)

--- a/lib/levanter/scripts/wandb_tensorboard_profile.py
+++ b/lib/levanter/scripts/wandb_tensorboard_profile.py
@@ -11,17 +11,14 @@ import os
 import shutil
 import subprocess
 import sys
-import tempfile
 from pathlib import Path
 from typing import Optional, Tuple
 from urllib.parse import urlparse
 
-from rigging.filesystem import url_to_fs
-
 import wandb
 import wandb.errors as wandb_errors
 
-from levanter.utils.fsspec_utils import join_path
+from levanter.utils.fsspec_utils import join_path, mirror_directory
 
 PROFILER_DIR_NAME = "profiler"
 
@@ -115,41 +112,14 @@ def resolve_profile_run_id(run: "wandb.apis.public.Run") -> str:
     return run.path[-1]
 
 
-def _is_local_fs(fs) -> bool:
-    protocol = fs.protocol[0] if isinstance(fs.protocol, tuple) else fs.protocol
-    return protocol in (None, "", "file")
-
-
-def mirror_profile_dir(profile_dir: str, root: Optional[Path], *, run_id: str) -> Path:
-    fs, fs_path = url_to_fs(profile_dir)
-    if root is None:
-        if _is_local_fs(fs):
-            path = Path(fs_path)
-            if not path.exists():
-                raise FileNotFoundError(f"Profile directory '{profile_dir}' does not exist.")
-            return path
-        root = Path(tempfile.mkdtemp(prefix="wandb-profile-"))
-    else:
-        root.mkdir(parents=True, exist_ok=True)
-
-    download_path = root / run_id / PROFILER_DIR_NAME
-    source_path = Path(fs_path)
-    if _is_local_fs(fs) and download_path.resolve() == source_path.resolve():
-        if not source_path.exists():
-            raise FileNotFoundError(f"Profile directory '{profile_dir}' does not exist.")
-        return source_path
-
-    if download_path.exists():
-        shutil.rmtree(download_path)
-    download_path.parent.mkdir(parents=True, exist_ok=True)
-
-    if _is_local_fs(fs):
-        if not source_path.exists():
-            raise FileNotFoundError(f"Profile directory '{profile_dir}' does not exist.")
-        shutil.copytree(source_path, download_path)
-    else:
-        fs.get(fs_path, str(download_path), recursive=True)
-    return download_path
+def mirror_profile_dir(profile_dir: str, root: Path | None, *, run_id: str) -> Path:
+    return mirror_directory(
+        profile_dir,
+        root,
+        run_id=run_id,
+        leaf_dirname=PROFILER_DIR_NAME,
+        temp_dir_prefix="wandb-profile-",
+    )
 
 
 def build_tensorboard_command(executable: str, logdir: Path, port: Optional[int]) -> list[str]:

--- a/lib/levanter/src/levanter/callbacks/__init__.py
+++ b/lib/levanter/src/levanter/callbacks/__init__.py
@@ -163,6 +163,8 @@ def profile_ctx(
         - Only process 0 creates the Perfetto link when ``create_perfetto_link`` is True.
         - After exiting the context, the profile remains in ``path`` and the context
           manager performs a cross-process barrier.
+        - When ``host_profile`` is enabled, the cProfile outputs are written into the
+          same directory as the JAX trace files.
     """
     _create_perfetto_link = create_perfetto_link and jax.process_index() == 0
     logger.info("Starting profiler.")

--- a/lib/levanter/src/levanter/callbacks/__init__.py
+++ b/lib/levanter/src/levanter/callbacks/__init__.py
@@ -161,8 +161,8 @@ def profile_ctx(
 
     Notes:
         - Only process 0 creates the Perfetto link when ``create_perfetto_link`` is True.
-        - After stopping the trace, logs the artifact to the current tracker as type
-          "jax_profile" and performs a cross-process barrier.
+        - After stopping the trace, the profile remains in ``path`` and the callback
+          performs a cross-process barrier.
     """
     _create_perfetto_link = create_perfetto_link and jax.process_index() == 0
     logger.info("Starting profiler.")
@@ -192,16 +192,10 @@ def profile_ctx(
         except Exception as e:  # pragma: no cover - optional/diagnostic path
             logger.warning(f"Failed to start cProfile host profiler: {e}")
 
-    def _try_log_host_artifact(artifact_path: str, description: str) -> None:
-        try:
-            levanter.tracker.current_tracker().log_artifact(artifact_path, type="host_profile")
-        except Exception:
-            logger.warning(f"Failed to log host profile {description}", exc_info=True)
-
     try:
         yield
     finally:
-        # Stop host profiler and write artifacts
+        # Stop host profiler and write the profile outputs into the run directory.
         # Do this first because jax.profiler can be very slow to finish
         if pr is not None and stats_path is not None:
             try:
@@ -232,11 +226,6 @@ def profile_ctx(
         if event is not None:
             event.set()
 
-        levanter.tracker.current_tracker().log_artifact(path, type="jax_profile")
-        if stats_path is not None and os.path.exists(stats_path):
-            _try_log_host_artifact(stats_path, "stats")
-        if txt_summary_path is not None and os.path.exists(txt_summary_path):
-            _try_log_host_artifact(txt_summary_path, "summary")
         barrier_sync()
 
 

--- a/lib/levanter/src/levanter/callbacks/__init__.py
+++ b/lib/levanter/src/levanter/callbacks/__init__.py
@@ -161,8 +161,8 @@ def profile_ctx(
 
     Notes:
         - Only process 0 creates the Perfetto link when ``create_perfetto_link`` is True.
-        - After stopping the trace, the profile remains in ``path`` and the callback
-          performs a cross-process barrier.
+        - After exiting the context, the profile remains in ``path`` and the context
+          manager performs a cross-process barrier.
     """
     _create_perfetto_link = create_perfetto_link and jax.process_index() == 0
     logger.info("Starting profiler.")

--- a/lib/levanter/src/levanter/callbacks/profiler.py
+++ b/lib/levanter/src/levanter/callbacks/profiler.py
@@ -10,8 +10,8 @@ from typing import Callable
 
 import jax
 
-import levanter.tracker
 from levanter.callbacks._core import StepInfo
+from levanter.utils.fsspec_utils import mkdirs
 from levanter.utils.jax_utils import barrier_sync
 
 logger = logging.getLogger(__name__)
@@ -99,8 +99,8 @@ def profile(
     create_perfetto_link: bool,
     profiler_options: jax.profiler.ProfileOptions | None = None,
 ) -> Callable[[StepInfo], None]:
-    artifact_name = f"jax-profile-step-{start_step}-{start_step + num_steps}"
     trace_started = False
+    mkdirs(path)
 
     def profiler_callback_fn(step: StepInfo, *, force: bool = False):
         nonlocal trace_started
@@ -144,12 +144,6 @@ def profile(
 
         if create_perfetto_link and jax.process_index() == 0:
             event.set()
-
-        levanter.tracker.current_tracker().log_artifact(
-            path,
-            name=artifact_name,
-            type="jax_profile",
-        )
         barrier_sync()
 
     return profiler_callback_fn

--- a/lib/levanter/src/levanter/eval_harness.py
+++ b/lib/levanter/src/levanter/eval_harness.py
@@ -554,10 +554,6 @@ class LevanterHarnessLM(TemplateLM):
 
         return None
 
-    def _log_profiler_artifact(self):
-        """Log profiler artifact to the tracker."""
-        levanter.tracker.current_tracker().log_artifact(self.profiler_config.profile_path, type="jax_profile")
-
     def _handle_profiler_step(self):
         """Check if we should start or stop the profiler at this step."""
         if not self.profiler_config.enabled:
@@ -586,7 +582,6 @@ class LevanterHarnessLM(TemplateLM):
             logger.info(f"Stopping profiler at step {self._current_step}")
             jax.profiler.stop_trace()
             self._profiler_started = False
-            self._log_profiler_artifact()
 
     def _stop_profiler_if_needed(self):
         """Ensure profiler is stopped if it was started."""
@@ -594,7 +589,6 @@ class LevanterHarnessLM(TemplateLM):
             logger.info("Stopping profiler (end of evaluation).")
             jax.profiler.stop_trace()
             self._profiler_started = False
-            self._log_profiler_artifact()
 
     def _loglikelihood_tokens(self, requests, disable_tqdm: bool = False):
         raise NotImplementedError("_loglikelihood_tokens is not yet supported")

--- a/lib/levanter/src/levanter/utils/fsspec_utils.py
+++ b/lib/levanter/src/levanter/utils/fsspec_utils.py
@@ -3,9 +3,6 @@
 
 import glob
 import os
-import shutil
-import tempfile
-from pathlib import Path
 
 import braceexpand
 import fsspec
@@ -69,41 +66,3 @@ def join_path(lhs, rhs):
         return rhs
     else:
         return os.path.join(lhs, rhs)
-
-
-def mirror_directory(source: str, root: Path | None, *, run_id: str, leaf_dirname: str, temp_dir_prefix: str) -> Path:
-    """Mirror a local or remote directory into `root/run_id/leaf_dirname`."""
-    fs, source_path = url_to_fs(source)
-    source_local_path = Path(source_path)
-
-    if root is None:
-        if _is_local_fs(fs):
-            if not source_local_path.exists():
-                raise FileNotFoundError(f"Directory '{source}' does not exist.")
-            return source_local_path
-        root = Path(tempfile.mkdtemp(prefix=temp_dir_prefix))
-    else:
-        root.mkdir(parents=True, exist_ok=True)
-
-    download_path = root / run_id / leaf_dirname
-    if _is_local_fs(fs) and download_path.resolve() == source_local_path.resolve():
-        if not source_local_path.exists():
-            raise FileNotFoundError(f"Directory '{source}' does not exist.")
-        return source_local_path
-
-    if download_path.exists():
-        shutil.rmtree(download_path)
-    download_path.parent.mkdir(parents=True, exist_ok=True)
-
-    if _is_local_fs(fs):
-        if not source_local_path.exists():
-            raise FileNotFoundError(f"Directory '{source}' does not exist.")
-        shutil.copytree(source_local_path, download_path)
-    else:
-        fs.get(source_path, str(download_path), recursive=True)
-    return download_path
-
-
-def _is_local_fs(fs) -> bool:
-    protocol = fs.protocol[0] if isinstance(fs.protocol, tuple) else fs.protocol
-    return protocol in (None, "", "file")

--- a/lib/levanter/src/levanter/utils/fsspec_utils.py
+++ b/lib/levanter/src/levanter/utils/fsspec_utils.py
@@ -3,6 +3,9 @@
 
 import glob
 import os
+import shutil
+import tempfile
+from pathlib import Path
 
 import braceexpand
 import fsspec
@@ -66,3 +69,41 @@ def join_path(lhs, rhs):
         return rhs
     else:
         return os.path.join(lhs, rhs)
+
+
+def mirror_directory(source: str, root: Path | None, *, run_id: str, leaf_dirname: str, temp_dir_prefix: str) -> Path:
+    """Mirror a local or remote directory into `root/run_id/leaf_dirname`."""
+    fs, source_path = url_to_fs(source)
+    source_local_path = Path(source_path)
+
+    if root is None:
+        if _is_local_fs(fs):
+            if not source_local_path.exists():
+                raise FileNotFoundError(f"Directory '{source}' does not exist.")
+            return source_local_path
+        root = Path(tempfile.mkdtemp(prefix=temp_dir_prefix))
+    else:
+        root.mkdir(parents=True, exist_ok=True)
+
+    download_path = root / run_id / leaf_dirname
+    if _is_local_fs(fs) and download_path.resolve() == source_local_path.resolve():
+        if not source_local_path.exists():
+            raise FileNotFoundError(f"Directory '{source}' does not exist.")
+        return source_local_path
+
+    if download_path.exists():
+        shutil.rmtree(download_path)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if _is_local_fs(fs):
+        if not source_local_path.exists():
+            raise FileNotFoundError(f"Directory '{source}' does not exist.")
+        shutil.copytree(source_local_path, download_path)
+    else:
+        fs.get(source_path, str(download_path), recursive=True)
+    return download_path
+
+
+def _is_local_fs(fs) -> bool:
+    protocol = fs.protocol[0] if isinstance(fs.protocol, tuple) else fs.protocol
+    return protocol in (None, "", "file")

--- a/lib/levanter/src/levanter/utils/profile_dirs.py
+++ b/lib/levanter/src/levanter/utils/profile_dirs.py
@@ -15,6 +15,7 @@ from levanter.utils.fsspec_utils import join_path
 from rigging.filesystem import url_to_fs
 
 PROFILER_DIR_NAME = "profiler"
+WANDB_RUNS_SEGMENT = "runs"
 TRAINER_CONFIG_KEY = "trainer"
 
 
@@ -40,7 +41,7 @@ def normalize_run_target(target: str, entity: Optional[str], project: Optional[s
             raise ValueError(f"Could not parse run information from URL: {target}")
         entity = parts[0]
         project = parts[1]
-        if parts[2] == "runs" and len(parts) >= 4:
+        if parts[2] == WANDB_RUNS_SEGMENT and len(parts) >= 4:
             run_id = parts[3]
         else:
             run_id = parts[2]
@@ -55,7 +56,7 @@ def normalize_run_target(target: str, entity: Optional[str], project: Optional[s
     if len(parts) >= 3:
         entity = parts[0]
         project = parts[1]
-        if parts[2] == "runs" and len(parts) >= 4:
+        if parts[2] == WANDB_RUNS_SEGMENT and len(parts) >= 4:
             run_id = parts[3]
         else:
             run_id = parts[2]

--- a/lib/levanter/src/levanter/utils/profile_dirs.py
+++ b/lib/levanter/src/levanter/utils/profile_dirs.py
@@ -5,15 +5,24 @@ from __future__ import annotations
 
 import shutil
 import tempfile
+from dataclasses import dataclass
 from collections.abc import Mapping, Sequence
 from pathlib import Path
-from typing import Any, Optional, Protocol, Tuple
+from typing import Any, Optional, Protocol
 from urllib.parse import urlparse
 
 from levanter.utils.fsspec_utils import join_path
 from rigging.filesystem import url_to_fs
 
 PROFILER_DIR_NAME = "profiler"
+TRAINER_CONFIG_KEY = "trainer"
+
+
+@dataclass(frozen=True)
+class RunTarget:
+    entity: str
+    project: str
+    run_id: str
 
 
 class WandbRunLike(Protocol):
@@ -23,7 +32,7 @@ class WandbRunLike(Protocol):
     summary: Mapping[str, Any]
 
 
-def normalize_run_target(target: str, entity: Optional[str], project: Optional[str]) -> Tuple[str, str, str]:
+def normalize_run_target(target: str, entity: Optional[str], project: Optional[str]) -> RunTarget:
     if target.startswith(("http://", "https://")):
         parsed = urlparse(target)
         parts = [p for p in parsed.path.split("/") if p]
@@ -35,13 +44,13 @@ def normalize_run_target(target: str, entity: Optional[str], project: Optional[s
             run_id = parts[3]
         else:
             run_id = parts[2]
-        return entity, project, run_id
+        return RunTarget(entity=entity, project=project, run_id=run_id)
 
     parts = [p for p in target.split("/") if p]
     if len(parts) == 1:
         if not entity or not project:
             raise ValueError("Bare run ids require --entity and --project.")
-        return entity, project, parts[0]
+        return RunTarget(entity=entity, project=project, run_id=parts[0])
 
     if len(parts) >= 3:
         entity = parts[0]
@@ -50,13 +59,13 @@ def normalize_run_target(target: str, entity: Optional[str], project: Optional[s
             run_id = parts[3]
         else:
             run_id = parts[2]
-        return entity, project, run_id
+        return RunTarget(entity=entity, project=project, run_id=run_id)
 
     raise ValueError(f"Unrecognized run target: {target}")
 
 
 def resolve_profile_run_id(run: WandbRunLike) -> str:
-    trainer_config = run.config.get("trainer")
+    trainer_config = run.config.get(TRAINER_CONFIG_KEY)
     if not isinstance(trainer_config, dict):
         raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
 
@@ -68,7 +77,7 @@ def resolve_profile_run_id(run: WandbRunLike) -> str:
 
 
 def resolve_profile_dir(run: WandbRunLike) -> str:
-    trainer_config = run.config.get("trainer")
+    trainer_config = run.config.get(TRAINER_CONFIG_KEY)
     if not isinstance(trainer_config, dict):
         raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
 

--- a/lib/levanter/src/levanter/utils/profile_dirs.py
+++ b/lib/levanter/src/levanter/utils/profile_dirs.py
@@ -1,0 +1,116 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from __future__ import annotations
+
+import shutil
+import tempfile
+from collections.abc import Mapping, Sequence
+from pathlib import Path
+from typing import Any, Optional, Protocol, Tuple
+from urllib.parse import urlparse
+
+from levanter.utils.fsspec_utils import join_path
+from rigging.filesystem import url_to_fs
+
+PROFILER_DIR_NAME = "profiler"
+
+
+class WandbRunLike(Protocol):
+    config: Mapping[str, Any]
+    path: Sequence[str]
+    id: str
+    summary: Mapping[str, Any]
+
+
+def normalize_run_target(target: str, entity: Optional[str], project: Optional[str]) -> Tuple[str, str, str]:
+    if target.startswith(("http://", "https://")):
+        parsed = urlparse(target)
+        parts = [p for p in parsed.path.split("/") if p]
+        if len(parts) < 3:
+            raise ValueError(f"Could not parse run information from URL: {target}")
+        entity = parts[0]
+        project = parts[1]
+        if parts[2] == "runs" and len(parts) >= 4:
+            run_id = parts[3]
+        else:
+            run_id = parts[2]
+        return entity, project, run_id
+
+    parts = [p for p in target.split("/") if p]
+    if len(parts) == 1:
+        if not entity or not project:
+            raise ValueError("Bare run ids require --entity and --project.")
+        return entity, project, parts[0]
+
+    if len(parts) >= 3:
+        entity = parts[0]
+        project = parts[1]
+        if parts[2] == "runs" and len(parts) >= 4:
+            run_id = parts[3]
+        else:
+            run_id = parts[2]
+        return entity, project, run_id
+
+    raise ValueError(f"Unrecognized run target: {target}")
+
+
+def resolve_profile_run_id(run: WandbRunLike) -> str:
+    trainer_config = run.config.get("trainer")
+    if not isinstance(trainer_config, dict):
+        raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
+
+    run_id = trainer_config.get("id")
+    if isinstance(run_id, str) and run_id:
+        return run_id
+
+    return run.path[-1]
+
+
+def resolve_profile_dir(run: WandbRunLike) -> str:
+    trainer_config = run.config.get("trainer")
+    if not isinstance(trainer_config, dict):
+        raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
+
+    log_dir = trainer_config.get("log_dir")
+    if not isinstance(log_dir, str) or not log_dir:
+        raise RuntimeError(f"Run {run.path} does not expose trainer.log_dir.")
+
+    return join_path(join_path(log_dir, resolve_profile_run_id(run)), PROFILER_DIR_NAME)
+
+
+def mirror_profile_dir(profile_dir: str, root: Path | None, *, run_id: str) -> Path:
+    fs, fs_path = url_to_fs(profile_dir)
+    source_path = Path(fs_path)
+
+    if root is None:
+        if _is_local_fs(fs):
+            if not source_path.exists():
+                raise FileNotFoundError(f"Profile directory '{profile_dir}' does not exist.")
+            return source_path
+        root = Path(tempfile.mkdtemp(prefix="wandb-profile-"))
+    else:
+        root.mkdir(parents=True, exist_ok=True)
+
+    download_path = root / run_id / PROFILER_DIR_NAME
+    if _is_local_fs(fs) and download_path.resolve() == source_path.resolve():
+        if not source_path.exists():
+            raise FileNotFoundError(f"Profile directory '{profile_dir}' does not exist.")
+        return source_path
+
+    if download_path.exists():
+        shutil.rmtree(download_path)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if _is_local_fs(fs):
+        if not source_path.exists():
+            raise FileNotFoundError(f"Profile directory '{profile_dir}' does not exist.")
+        shutil.copytree(source_path, download_path)
+    else:
+        fs.get(fs_path, str(download_path), recursive=True)
+    return download_path
+
+
+def _is_local_fs(fs: Any) -> bool:
+    protocol = fs.protocol[0] if isinstance(fs.protocol, tuple) else fs.protocol
+    return protocol in (None, "", "file")

--- a/lib/levanter/tests/test_profiler.py
+++ b/lib/levanter/tests/test_profiler.py
@@ -1,7 +1,6 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from pathlib import Path
 from types import SimpleNamespace
 
 import levanter.callbacks as callbacks_module
@@ -16,9 +15,6 @@ def test_profile_writes_trace_to_run_dir_and_ignores_duplicate_forced_stop(monke
 
     def start_trace(path: str, *, create_perfetto_link: bool, create_perfetto_trace: bool, profiler_options) -> None:
         calls.append(("start", path, create_perfetto_link, create_perfetto_trace, profiler_options))
-        trace_dir = Path(path) / "plugins" / "profile" / "2024_01_01_00_00_00"
-        trace_dir.mkdir(parents=True, exist_ok=True)
-        (trace_dir / "perfetto_trace.json.gz").write_bytes(b"trace")
 
     def stop_trace() -> None:
         calls.append(("stop",))
@@ -51,7 +47,7 @@ def test_profile_writes_trace_to_run_dir_and_ignores_duplicate_forced_stop(monke
         ("stop",),
         ("barrier",),
     ]
-    assert (profile_dir / "plugins" / "profile" / "2024_01_01_00_00_00" / "perfetto_trace.json.gz").exists()
+    assert profile_dir.exists()
 
 
 def test_profile_callback_stress_repeated_start_stop_finalization(monkeypatch, tmp_path):

--- a/lib/levanter/tests/test_profiler.py
+++ b/lib/levanter/tests/test_profiler.py
@@ -1,23 +1,24 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from pathlib import Path
 from types import SimpleNamespace
 
+import levanter.callbacks as callbacks_module
 from levanter.callbacks import LambdaCallback
+from levanter.callbacks import profile_ctx
 from levanter.callbacks import profiler as profiler_module
 from levanter.callbacks.profiler import ProfileOptionsConfig, ProfilerConfig, profile
 
 
-def test_profile_passes_profile_options_and_ignores_duplicate_forced_stop(monkeypatch):
+def test_profile_writes_trace_to_run_dir_and_ignores_duplicate_forced_stop(monkeypatch, tmp_path):
     calls = []
-    artifacts = []
-
-    class FakeTracker:
-        def log_artifact(self, artifact_path: str, *, name: str | None = None, type: str | None = None) -> None:
-            artifacts.append((artifact_path, name, type))
 
     def start_trace(path: str, *, create_perfetto_link: bool, create_perfetto_trace: bool, profiler_options) -> None:
         calls.append(("start", path, create_perfetto_link, create_perfetto_trace, profiler_options))
+        trace_dir = Path(path) / "plugins" / "profile" / "2024_01_01_00_00_00"
+        trace_dir.mkdir(parents=True, exist_ok=True)
+        (trace_dir / "perfetto_trace.json.gz").write_bytes(b"trace")
 
     def stop_trace() -> None:
         calls.append(("stop",))
@@ -25,13 +26,13 @@ def test_profile_passes_profile_options_and_ignores_duplicate_forced_stop(monkey
     monkeypatch.setattr(profiler_module.jax, "process_index", lambda: 0)
     monkeypatch.setattr(profiler_module.jax.profiler, "start_trace", start_trace)
     monkeypatch.setattr(profiler_module.jax.profiler, "stop_trace", stop_trace)
-    monkeypatch.setattr(profiler_module.levanter.tracker, "current_tracker", lambda: FakeTracker())
     monkeypatch.setattr(profiler_module, "barrier_sync", lambda: calls.append(("barrier",)))
 
     options = ProfilerConfig(profile_options=ProfileOptionsConfig(host_tracer_level=1)).build_jax_profile_options()
+    profile_dir = tmp_path / "run" / "profiler"
     callback = LambdaCallback(
         profile(
-            "/tmp/profiler",
+            str(profile_dir),
             start_step=5,
             num_steps=1,
             create_perfetto_link=False,
@@ -39,41 +40,52 @@ def test_profile_passes_profile_options_and_ignores_duplicate_forced_stop(monkey
         )
     )
 
+    assert profile_dir.exists()
+
     callback.on_step(SimpleNamespace(step=4))
     callback.on_step(SimpleNamespace(step=4), force=True)
     callback.on_step(SimpleNamespace(step=4), force=True)
 
     assert calls == [
-        ("start", "/tmp/profiler", False, True, options),
+        ("start", str(profile_dir), False, True, options),
         ("stop",),
         ("barrier",),
     ]
-    assert artifacts == [("/tmp/profiler", "jax-profile-step-5-6", "jax_profile")]
+    assert (profile_dir / "plugins" / "profile" / "2024_01_01_00_00_00" / "perfetto_trace.json.gz").exists()
 
 
-def test_profile_callback_stress_repeated_start_stop_finalization(monkeypatch):
+def test_profile_callback_stress_repeated_start_stop_finalization(monkeypatch, tmp_path):
     calls = []
-
-    class FakeTracker:
-        def log_artifact(self, artifact_path: str, *, name: str | None = None, type: str | None = None) -> None:
-            calls.append(("artifact", artifact_path, name, type))
 
     monkeypatch.setattr(
         profiler_module.jax.profiler,
         "start_trace",
-        lambda *_args, **_kwargs: calls.append(("start",)),
+        lambda path, *_args, **_kwargs: calls.append(("start", path)),
     )
     monkeypatch.setattr(profiler_module.jax.profiler, "stop_trace", lambda: calls.append(("stop",)))
-    monkeypatch.setattr(profiler_module.levanter.tracker, "current_tracker", lambda: FakeTracker())
     monkeypatch.setattr(profiler_module, "barrier_sync", lambda: calls.append(("barrier",)))
 
-    callback = LambdaCallback(profile("profile-dir", start_step=10, num_steps=2, create_perfetto_link=False))
+    profile_dir = tmp_path / "stress" / "profiler"
+    callback = LambdaCallback(profile(str(profile_dir), start_step=10, num_steps=2, create_perfetto_link=False))
     for _ in range(50):
         callback.on_step(SimpleNamespace(step=9))
         callback.on_step(SimpleNamespace(step=10))
         callback.on_step(SimpleNamespace(step=10), force=True)
 
-    assert calls.count(("start",)) == 50
+    assert calls.count(("start", str(profile_dir))) == 50
     assert calls.count(("stop",)) == 50
     assert calls.count(("barrier",)) == 50
-    assert calls.count(("artifact", "profile-dir", "jax-profile-step-10-12", "jax_profile")) == 50
+    assert profile_dir.exists()
+
+
+def test_profile_ctx_writes_host_profile_files_without_tracker_upload(monkeypatch, tmp_path):
+    calls = []
+    monkeypatch.setattr(callbacks_module, "barrier_sync", lambda: calls.append(("barrier",)))
+
+    profile_dir = tmp_path / "ctx" / "profiler"
+    with profile_ctx(str(profile_dir), device_profile=False, host_profile=True, host_profile_topn=10):
+        sum(range(1000))
+
+    assert (profile_dir / "host_profile.pstats").exists()
+    assert (profile_dir / "host_profile.txt").exists()
+    assert calls == [("barrier",)]

--- a/lib/levanter/tests/test_wandb_tensorboard_profile.py
+++ b/lib/levanter/tests/test_wandb_tensorboard_profile.py
@@ -56,15 +56,3 @@ def test_mirror_profile_dir_copies_remote_directory_to_download_root(tmp_path):
 
     assert mirrored == tmp_path / "download" / "run-123" / "profiler"
     assert (mirrored / "plugins" / "profile" / "2024_01_01_00_00_00" / "perfetto_trace.json.gz").exists()
-
-
-def test_mirror_profile_dir_noops_when_root_matches_local_source(tmp_path):
-    source = tmp_path / "logs" / "run-123" / "profiler"
-    trace_dir = source / "plugins" / "profile" / "2024_01_01_00_00_00"
-    trace_dir.mkdir(parents=True)
-    (trace_dir / "perfetto_trace.json.gz").write_bytes(b"trace")
-
-    mirrored = mirror_profile_dir(str(source), tmp_path / "logs", run_id="run-123")
-
-    assert mirrored == source
-    assert (mirrored / "plugins" / "profile" / "2024_01_01_00_00_00" / "perfetto_trace.json.gz").exists()

--- a/lib/levanter/tests/test_wandb_tensorboard_profile.py
+++ b/lib/levanter/tests/test_wandb_tensorboard_profile.py
@@ -30,7 +30,7 @@ def test_resolve_profile_dir_uses_logged_trainer_log_dir():
     assert resolve_profile_dir(run) == "gs://bucket/logs/trainer-456/profiler"
 
 
-@pytest.mark.parametrize("root_factory", [lambda tmp_path: None, lambda tmp_path: tmp_path / "logs"])
+@pytest.mark.parametrize("root_factory", [lambda _: None, lambda tmp_path: tmp_path / "logs"])
 def test_mirror_profile_dir_returns_existing_local_directory(tmp_path, root_factory):
     source = tmp_path / "logs" / "run-123" / "profiler"
     trace_dir = source / "plugins" / "profile" / "2024_01_01_00_00_00"

--- a/lib/levanter/tests/test_wandb_tensorboard_profile.py
+++ b/lib/levanter/tests/test_wandb_tensorboard_profile.py
@@ -16,15 +16,17 @@ SCRIPT_SPEC.loader.exec_module(SCRIPT_MODULE)
 
 mirror_profile_dir = SCRIPT_MODULE.mirror_profile_dir
 resolve_profile_dir = SCRIPT_MODULE.resolve_profile_dir
+resolve_profile_run_id = SCRIPT_MODULE.resolve_profile_run_id
 
 
 def test_resolve_profile_dir_uses_logged_trainer_log_dir():
     run = SimpleNamespace(
-        config={"trainer": {"log_dir": "gs://bucket/logs"}},
+        config={"trainer": {"id": "trainer-456", "log_dir": "gs://bucket/logs"}},
         path=["entity", "project", "run-123"],
     )
 
-    assert resolve_profile_dir(run) == "gs://bucket/logs/run-123/profiler"
+    assert resolve_profile_run_id(run) == "trainer-456"
+    assert resolve_profile_dir(run) == "gs://bucket/logs/trainer-456/profiler"
 
 
 def test_mirror_profile_dir_returns_existing_local_directory(tmp_path):
@@ -50,4 +52,16 @@ def test_mirror_profile_dir_copies_remote_directory_to_download_root(tmp_path):
     mirrored = mirror_profile_dir(source, tmp_path / "download", run_id="run-123")
 
     assert mirrored == tmp_path / "download" / "run-123" / "profiler"
+    assert (mirrored / "plugins" / "profile" / "2024_01_01_00_00_00" / "perfetto_trace.json.gz").exists()
+
+
+def test_mirror_profile_dir_noops_when_root_matches_local_source(tmp_path):
+    source = tmp_path / "logs" / "run-123" / "profiler"
+    trace_dir = source / "plugins" / "profile" / "2024_01_01_00_00_00"
+    trace_dir.mkdir(parents=True)
+    (trace_dir / "perfetto_trace.json.gz").write_bytes(b"trace")
+
+    mirrored = mirror_profile_dir(str(source), tmp_path / "logs", run_id="run-123")
+
+    assert mirrored == source
     assert (mirrored / "plugins" / "profile" / "2024_01_01_00_00_00" / "perfetto_trace.json.gz").exists()

--- a/lib/levanter/tests/test_wandb_tensorboard_profile.py
+++ b/lib/levanter/tests/test_wandb_tensorboard_profile.py
@@ -1,0 +1,53 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import importlib.util
+from pathlib import Path
+from types import SimpleNamespace
+
+from rigging.filesystem import url_to_fs
+
+SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "wandb_tensorboard_profile.py"
+SCRIPT_SPEC = importlib.util.spec_from_file_location("wandb_tensorboard_profile", SCRIPT_PATH)
+assert SCRIPT_SPEC is not None
+SCRIPT_MODULE = importlib.util.module_from_spec(SCRIPT_SPEC)
+assert SCRIPT_SPEC.loader is not None
+SCRIPT_SPEC.loader.exec_module(SCRIPT_MODULE)
+
+mirror_profile_dir = SCRIPT_MODULE.mirror_profile_dir
+resolve_profile_dir = SCRIPT_MODULE.resolve_profile_dir
+
+
+def test_resolve_profile_dir_uses_logged_trainer_log_dir():
+    run = SimpleNamespace(
+        config={"trainer": {"log_dir": "gs://bucket/logs"}},
+        path=["entity", "project", "run-123"],
+    )
+
+    assert resolve_profile_dir(run) == "gs://bucket/logs/run-123/profiler"
+
+
+def test_mirror_profile_dir_returns_existing_local_directory(tmp_path):
+    source = tmp_path / "logs" / "run-123" / "profiler"
+    trace_dir = source / "plugins" / "profile" / "2024_01_01_00_00_00"
+    trace_dir.mkdir(parents=True)
+    (trace_dir / "perfetto_trace.json.gz").write_bytes(b"trace")
+
+    mirrored = mirror_profile_dir(str(source), None, run_id="run-123")
+
+    assert mirrored == source
+    assert (mirrored / "plugins" / "profile" / "2024_01_01_00_00_00" / "perfetto_trace.json.gz").exists()
+
+
+def test_mirror_profile_dir_copies_remote_directory_to_download_root(tmp_path):
+    source = "memory://wandb/runs/run-123/profiler"
+    fs, fs_path = url_to_fs(source)
+    fs.makedirs(fs_path, exist_ok=True)
+    fs.makedirs(f"{fs_path}/plugins/profile/2024_01_01_00_00_00", exist_ok=True)
+    with fs.open(f"{fs_path}/plugins/profile/2024_01_01_00_00_00/perfetto_trace.json.gz", "wb") as f:
+        f.write(b"trace")
+
+    mirrored = mirror_profile_dir(source, tmp_path / "download", run_id="run-123")
+
+    assert mirrored == tmp_path / "download" / "run-123" / "profiler"
+    assert (mirrored / "plugins" / "profile" / "2024_01_01_00_00_00" / "perfetto_trace.json.gz").exists()

--- a/lib/levanter/tests/test_wandb_tensorboard_profile.py
+++ b/lib/levanter/tests/test_wandb_tensorboard_profile.py
@@ -5,6 +5,7 @@ import importlib.util
 from pathlib import Path
 from types import SimpleNamespace
 
+import pytest
 from rigging.filesystem import url_to_fs
 
 SCRIPT_PATH = Path(__file__).resolve().parents[1] / "scripts" / "wandb_tensorboard_profile.py"
@@ -29,13 +30,15 @@ def test_resolve_profile_dir_uses_logged_trainer_log_dir():
     assert resolve_profile_dir(run) == "gs://bucket/logs/trainer-456/profiler"
 
 
-def test_mirror_profile_dir_returns_existing_local_directory(tmp_path):
+@pytest.mark.parametrize("root_factory", [lambda tmp_path: None, lambda tmp_path: tmp_path / "logs"])
+def test_mirror_profile_dir_returns_existing_local_directory(tmp_path, root_factory):
     source = tmp_path / "logs" / "run-123" / "profiler"
     trace_dir = source / "plugins" / "profile" / "2024_01_01_00_00_00"
     trace_dir.mkdir(parents=True)
     (trace_dir / "perfetto_trace.json.gz").write_bytes(b"trace")
 
-    mirrored = mirror_profile_dir(str(source), None, run_id="run-123")
+    resolved_root = root_factory(tmp_path)
+    mirrored = mirror_profile_dir(str(source), resolved_root, run_id="run-123")
 
     assert mirrored == source
     assert (mirrored / "plugins" / "profile" / "2024_01_01_00_00_00" / "perfetto_trace.json.gz").exists()

--- a/lib/marin/src/marin/profiling/__init__.py
+++ b/lib/marin/src/marin/profiling/__init__.py
@@ -5,7 +5,6 @@
 
 from marin.profiling.compare_bundle import ComparisonBundleResult, run_profile_comparison_bundle
 from marin.profiling.ingest import (
-    DEFAULT_ARTIFACT_ALIAS,
     download_latest_profile_artifact_for_run,
     download_wandb_profile_artifact,
     summarize_profile_artifact,
@@ -26,7 +25,6 @@ from marin.profiling.tracking import (
 from marin.profiling.xplane import summarize_xplane, summarize_xplane_tables
 
 __all__ = [
-    "DEFAULT_ARTIFACT_ALIAS",
     "PROFILE_SUMMARY_ARTIFACT_TYPE",
     "ComparisonBundleResult",
     "ProfileSummary",

--- a/lib/marin/src/marin/profiling/__init__.py
+++ b/lib/marin/src/marin/profiling/__init__.py
@@ -5,7 +5,7 @@
 
 from marin.profiling.compare_bundle import ComparisonBundleResult, run_profile_comparison_bundle
 from marin.profiling.ingest import (
-    download_latest_profile_artifact_for_run,
+    download_profile_dir_for_run,
     download_wandb_profile_artifact,
     summarize_profile_artifact,
     summarize_trace,
@@ -32,7 +32,7 @@ __all__ = [
     "assess_profile_regression",
     "build_markdown_report",
     "compare_profile_summaries",
-    "download_latest_profile_artifact_for_run",
+    "download_profile_dir_for_run",
     "download_wandb_profile_artifact",
     "profile_summary_from_dict",
     "publish_profile_summary_artifact",

--- a/lib/marin/src/marin/profiling/__init__.py
+++ b/lib/marin/src/marin/profiling/__init__.py
@@ -23,24 +23,3 @@ from marin.profiling.tracking import (
     summarize_regression_history,
 )
 from marin.profiling.xplane import summarize_xplane, summarize_xplane_tables
-
-__all__ = [
-    "PROFILE_SUMMARY_ARTIFACT_TYPE",
-    "ComparisonBundleResult",
-    "ProfileSummary",
-    "RegressionThresholds",
-    "assess_profile_regression",
-    "build_markdown_report",
-    "compare_profile_summaries",
-    "download_profile_dir_for_run",
-    "download_wandb_profile_artifact",
-    "profile_summary_from_dict",
-    "publish_profile_summary_artifact",
-    "query_profile_summary",
-    "run_profile_comparison_bundle",
-    "summarize_profile_artifact",
-    "summarize_regression_history",
-    "summarize_trace",
-    "summarize_xplane",
-    "summarize_xplane_tables",
-]

--- a/lib/marin/src/marin/profiling/cli.py
+++ b/lib/marin/src/marin/profiling/cli.py
@@ -11,7 +11,6 @@ from pathlib import Path
 
 from marin.profiling.compare_bundle import run_profile_comparison_bundle
 from marin.profiling.ingest import (
-    DEFAULT_ARTIFACT_ALIAS,
     download_latest_profile_artifact_for_run,
     download_wandb_profile_artifact,
     summarize_profile_artifact,
@@ -46,16 +45,11 @@ def parse_args() -> argparse.Namespace:
         "--run-target",
         help=(
             "Optional W&B run target (run id, entity/project/run_id, or run URL). "
-            "Downloads the selected jax_profile artifact for that run."
+            "Downloads the profiler directory for that run."
         ),
     )
     summarize.add_argument("--entity", help="W&B entity when --run-target is a bare run id.")
     summarize.add_argument("--project", help="W&B project when --run-target is a bare run id.")
-    summarize.add_argument(
-        "--alias",
-        default=DEFAULT_ARTIFACT_ALIAS,
-        help=f"Artifact alias preference when using --run-target. Defaults to '{DEFAULT_ARTIFACT_ALIAS}'.",
-    )
     summarize.add_argument("--download-root", type=Path, help="Optional root directory for downloaded artifacts.")
     summarize.add_argument("--profile-dir", type=Path, help="Path to a downloaded jax_profile artifact directory.")
     summarize.add_argument("--trace-file", type=Path, help="Path to an explicit trace JSON(.gz) file.")
@@ -159,11 +153,6 @@ def parse_args() -> argparse.Namespace:
     bundle.add_argument("--after-run-target", help="Optional candidate run target for auto summarization.")
     bundle.add_argument("--entity", help="W&B entity when run targets are bare run ids.")
     bundle.add_argument("--project", help="W&B project when run targets are bare run ids.")
-    bundle.add_argument(
-        "--alias",
-        default=DEFAULT_ARTIFACT_ALIAS,
-        help=f"Artifact alias preference when summarizing from run targets. Defaults to '{DEFAULT_ARTIFACT_ALIAS}'.",
-    )
     bundle.add_argument("--download-root", type=Path, help="Optional root directory for downloaded artifacts.")
     bundle.add_argument("--warmup-steps", type=int, default=5, help="Warmup steps ignored in summary generation.")
     bundle.add_argument("--hot-op-limit", type=int, default=25, help="Maximum hot ops in generated summaries.")
@@ -311,7 +300,6 @@ def main() -> None:
             run_target=args.before_run_target,
             entity=args.entity,
             project=args.project,
-            alias=args.alias,
             download_root=args.download_root,
             warmup_steps=args.warmup_steps,
             hot_op_limit=args.hot_op_limit,
@@ -322,7 +310,6 @@ def main() -> None:
             run_target=args.after_run_target,
             entity=args.entity,
             project=args.project,
-            alias=args.alias,
             download_root=args.download_root,
             warmup_steps=args.warmup_steps,
             hot_op_limit=args.hot_op_limit,
@@ -415,11 +402,10 @@ def _handle_summarize(args: argparse.Namespace):
             args.run_target,
             entity=args.entity,
             project=args.project,
-            alias=args.alias,
             download_root=args.download_root,
         )
         return summarize_profile_artifact(
-            downloaded.artifact_dir,
+            downloaded.profile_dir,
             run_metadata=downloaded.run_metadata,
             warmup_steps=args.warmup_steps,
             hot_op_limit=args.hot_op_limit,
@@ -450,7 +436,6 @@ def _resolve_bundle_summary(
     run_target: str | None,
     entity: str | None,
     project: str | None,
-    alias: str,
     download_root: Path | None,
     warmup_steps: int,
     hot_op_limit: int,
@@ -463,11 +448,10 @@ def _resolve_bundle_summary(
             run_target,
             entity=entity,
             project=project,
-            alias=alias,
             download_root=download_root,
         )
         return summarize_profile_artifact(
-            downloaded.artifact_dir,
+            downloaded.profile_dir,
             run_metadata=downloaded.run_metadata,
             warmup_steps=warmup_steps,
             hot_op_limit=hot_op_limit,

--- a/lib/marin/src/marin/profiling/cli.py
+++ b/lib/marin/src/marin/profiling/cli.py
@@ -11,7 +11,7 @@ from pathlib import Path
 
 from marin.profiling.compare_bundle import run_profile_comparison_bundle
 from marin.profiling.ingest import (
-    download_latest_profile_artifact_for_run,
+    download_profile_dir_for_run,
     download_wandb_profile_artifact,
     summarize_profile_artifact,
     summarize_trace,
@@ -398,7 +398,7 @@ def _handle_summarize(args: argparse.Namespace):
         )
 
     if args.run_target:
-        downloaded = download_latest_profile_artifact_for_run(
+        downloaded = download_profile_dir_for_run(
             args.run_target,
             entity=args.entity,
             project=args.project,
@@ -444,7 +444,7 @@ def _resolve_bundle_summary(
     if summary_path is not None:
         return _load_summary(summary_path)
     if run_target is not None:
-        downloaded = download_latest_profile_artifact_for_run(
+        downloaded = download_profile_dir_for_run(
             run_target,
             entity=entity,
             project=project,

--- a/lib/marin/src/marin/profiling/ingest.py
+++ b/lib/marin/src/marin/profiling/ingest.py
@@ -49,8 +49,6 @@ class DownloadedProfileArtifact:
 
 @dataclass(frozen=True)
 class DownloadedProfileDir:
-    """Downloaded profiler directory and associated metadata."""
-
     profile_dir: Path
     run_metadata: RunMetadata
 

--- a/lib/marin/src/marin/profiling/ingest.py
+++ b/lib/marin/src/marin/profiling/ingest.py
@@ -8,18 +8,15 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-import os
-import shutil
-import tempfile
+from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 from urllib.parse import urlparse
 
-import fsspec
 import wandb
 from google.protobuf.message import DecodeError
-from rigging.filesystem import url_to_fs
+from levanter.utils.fsspec_utils import join_path, mirror_directory
 
 from marin.profiling.schema import ProfileSummary, RunMetadata
 from marin.profiling.trace_summary import (
@@ -34,6 +31,13 @@ logger = logging.getLogger(__name__)
 
 PROFILE_ARTIFACT_TYPE = "jax_profile"
 PROFILE_DIR_NAME = "profiler"
+
+
+class WandbRunLike(Protocol):
+    config: Mapping[str, Any]
+    path: Sequence[str]
+    id: str
+    summary: Mapping[str, Any]
 
 
 @dataclass(frozen=True)
@@ -82,7 +86,7 @@ def download_wandb_profile_artifact(
     )
 
 
-def download_latest_profile_artifact_for_run(
+def download_profile_dir_for_run(
     run_target: str,
     *,
     entity: str | None = None,
@@ -141,8 +145,9 @@ def find_profile_trace(profile_dir: Path) -> Path:
     )
 
 
-def resolve_profile_dir_from_run(run: Any) -> str:
+def resolve_profile_dir_from_run(run: WandbRunLike) -> str:
     """Resolve the profiler directory for a W&B run from trainer config."""
+    run_id = resolve_profile_run_id_from_run(run)
     trainer_config = run.config.get("trainer")
     if not isinstance(trainer_config, dict):
         raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
@@ -151,7 +156,19 @@ def resolve_profile_dir_from_run(run: Any) -> str:
     if not isinstance(log_dir, str) or not log_dir:
         raise RuntimeError(f"Run {run.path} does not expose trainer.log_dir.")
 
-    return _join_path(_join_path(log_dir, run.path[-1]), PROFILE_DIR_NAME)
+    return join_path(join_path(log_dir, run_id), PROFILE_DIR_NAME)
+
+
+def resolve_profile_run_id_from_run(run: WandbRunLike) -> str:
+    trainer_config = run.config.get("trainer")
+    if not isinstance(trainer_config, dict):
+        raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
+
+    run_id = trainer_config.get("id")
+    if isinstance(run_id, str) and run_id:
+        return run_id
+
+    return run.path[-1]
 
 
 def summarize_profile_artifact(
@@ -315,10 +332,17 @@ def _download_artifact_with_metadata(
 def _download_profile_dir_with_metadata(
     *,
     profile_dir: str,
-    run: Any,
+    run: WandbRunLike,
     download_root: Path | None,
 ) -> DownloadedProfileDir:
-    local_profile_dir = _mirror_profile_dir(profile_dir, download_root=download_root, run_id=run.path[-1])
+    run_id = resolve_profile_run_id_from_run(run)
+    local_profile_dir = mirror_directory(
+        profile_dir,
+        download_root,
+        run_id=run_id,
+        leaf_dirname=PROFILE_DIR_NAME,
+        temp_dir_prefix="marin-profile-",
+    )
     metadata = _run_metadata_from_run(run, artifact_ref=profile_dir, artifact_name=PROFILE_DIR_NAME)
     return DownloadedProfileDir(profile_dir=local_profile_dir, run_metadata=metadata)
 
@@ -362,7 +386,7 @@ def _int_or_none(value: Any) -> int | None:
     return None
 
 
-def _run_metadata_from_run(run: Any, *, artifact_ref: str, artifact_name: str) -> RunMetadata:
+def _run_metadata_from_run(run: WandbRunLike, *, artifact_ref: str, artifact_name: str) -> RunMetadata:
     summary = dict(run.summary)
     config = dict(run.config)
     return RunMetadata(
@@ -377,45 +401,3 @@ def _run_metadata_from_run(run: Any, *, artifact_ref: str, artifact_name: str) -
         num_devices=_int_or_none(summary.get("num_devices") or config.get("num_devices")),
         num_hosts=_int_or_none(summary.get("num_hosts") or config.get("num_hosts")),
     )
-
-
-def _mirror_profile_dir(profile_dir: str, *, download_root: Path | None, run_id: str) -> Path:
-    fs, fs_path = url_to_fs(profile_dir)
-    if download_root is None:
-        if _is_local_fs(fs):
-            local_path = Path(fs_path)
-            if not local_path.exists():
-                raise FileNotFoundError(f"Profile directory does not exist: {profile_dir}")
-            return local_path
-        download_root = Path(tempfile.mkdtemp(prefix="marin-profile-"))
-    else:
-        download_root.mkdir(parents=True, exist_ok=True)
-
-    download_path = download_root / run_id / PROFILE_DIR_NAME
-    if download_path.exists():
-        shutil.rmtree(download_path)
-    download_path.parent.mkdir(parents=True, exist_ok=True)
-
-    if _is_local_fs(fs):
-        source_path = Path(fs_path)
-        if not source_path.exists():
-            raise FileNotFoundError(f"Profile directory does not exist: {profile_dir}")
-        shutil.copytree(source_path, download_path)
-    else:
-        fs.get(fs_path, str(download_path), recursive=True)
-    return download_path
-
-
-def _is_local_fs(fs: Any) -> bool:
-    protocol = fs.protocol[0] if isinstance(fs.protocol, tuple) else fs.protocol
-    return protocol in (None, "", "file")
-
-
-def _join_path(lhs: str, rhs: str) -> str:
-    lhs_protocol, lhs_rest = fsspec.core.split_protocol(lhs)
-    rhs_protocol, _ = fsspec.core.split_protocol(rhs)
-    if rhs_protocol is not None:
-        return rhs
-    if lhs_protocol is not None:
-        return f"{lhs_protocol}://{os.path.join(lhs_rest, rhs)}"
-    return os.path.join(lhs, rhs)

--- a/lib/marin/src/marin/profiling/ingest.py
+++ b/lib/marin/src/marin/profiling/ingest.py
@@ -99,8 +99,8 @@ def download_profile_dir_for_run(
         project: W&B project when `run_target` is a bare run id.
         download_root: Optional output directory where the profiler tree will be mirrored.
     """
-    run_entity, run_project, run_id = normalize_run_target(run_target, entity=entity, project=project)
-    run_path = f"{run_entity}/{run_project}/{run_id}"
+    run_target_info = normalize_run_target(run_target, entity=entity, project=project)
+    run_path = f"{run_target_info.entity}/{run_target_info.project}/{run_target_info.run_id}"
 
     api = wandb.Api()
     run = api.run(run_path)

--- a/lib/marin/src/marin/profiling/ingest.py
+++ b/lib/marin/src/marin/profiling/ingest.py
@@ -89,7 +89,7 @@ def download_profile_dir_for_run(
     download_root: Path | None = None,
 ) -> DownloadedProfileDir:
     """
-    Download the profiler directory for a W&B run.
+    Mirror a run's profiler directory from `trainer.log_dir` and attach metadata.
 
     Args:
         run_target: Bare run id, `entity/project/run_id`, or W&B run URL.
@@ -149,7 +149,7 @@ def summarize_profile_artifact(
     breakdown_mode: str = "exclusive_per_track",
 ) -> ProfileSummary:
     """
-    Summarize a downloaded profile artifact into the normalized schema.
+    Summarize a downloaded profile directory into the normalized schema.
 
     Args:
         profile_dir: Local path to a `jax_profile` artifact directory.

--- a/lib/marin/src/marin/profiling/ingest.py
+++ b/lib/marin/src/marin/profiling/ingest.py
@@ -15,6 +15,7 @@ from typing import Any
 import wandb
 from google.protobuf.message import DecodeError
 from levanter.utils.profile_dirs import (
+    PROFILER_DIR_NAME,
     WandbRunLike,
     mirror_profile_dir,
     normalize_run_target,
@@ -34,7 +35,6 @@ from marin.profiling.xplane import MultipleXPlaneFilesError, find_xplane_file, s
 logger = logging.getLogger(__name__)
 
 PROFILE_ARTIFACT_TYPE = "jax_profile"
-PROFILE_DIR_NAME = "profiler"
 
 
 @dataclass(frozen=True)
@@ -282,7 +282,7 @@ def _download_profile_dir_with_metadata(
 ) -> DownloadedProfileDir:
     run_id = resolve_profile_run_id(run)
     local_profile_dir = mirror_profile_dir(profile_dir, download_root, run_id=run_id)
-    metadata = _run_metadata_from_run(run, artifact_ref=profile_dir, artifact_name=PROFILE_DIR_NAME)
+    metadata = _run_metadata_from_run(run, artifact_ref=profile_dir, artifact_name=PROFILER_DIR_NAME)
     return DownloadedProfileDir(profile_dir=local_profile_dir, run_metadata=metadata)
 
 

--- a/lib/marin/src/marin/profiling/ingest.py
+++ b/lib/marin/src/marin/profiling/ingest.py
@@ -8,15 +8,19 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
-from collections.abc import Mapping, Sequence
 from dataclasses import dataclass
 from pathlib import Path
-from typing import Any, Protocol
-from urllib.parse import urlparse
+from typing import Any
 
 import wandb
 from google.protobuf.message import DecodeError
-from levanter.utils.fsspec_utils import join_path, mirror_directory
+from levanter.utils.profile_dirs import (
+    WandbRunLike,
+    mirror_profile_dir,
+    normalize_run_target,
+    resolve_profile_dir,
+    resolve_profile_run_id,
+)
 
 from marin.profiling.schema import ProfileSummary, RunMetadata
 from marin.profiling.trace_summary import (
@@ -31,13 +35,6 @@ logger = logging.getLogger(__name__)
 
 PROFILE_ARTIFACT_TYPE = "jax_profile"
 PROFILE_DIR_NAME = "profiler"
-
-
-class WandbRunLike(Protocol):
-    config: Mapping[str, Any]
-    path: Sequence[str]
-    id: str
-    summary: Mapping[str, Any]
 
 
 @dataclass(frozen=True)
@@ -107,7 +104,7 @@ def download_profile_dir_for_run(
 
     api = wandb.Api()
     run = api.run(run_path)
-    profile_dir = resolve_profile_dir_from_run(run)
+    profile_dir = resolve_profile_dir(run)
 
     return _download_profile_dir_with_metadata(
         profile_dir=profile_dir,
@@ -143,32 +140,6 @@ def find_profile_trace(profile_dir: Path) -> Path:
     raise FileNotFoundError(
         f"No profile trace JSON found under '{profile_dir}'. Expected perfetto_trace.json.gz or *.trace.json(.gz)."
     )
-
-
-def resolve_profile_dir_from_run(run: WandbRunLike) -> str:
-    """Resolve the profiler directory for a W&B run from trainer config."""
-    run_id = resolve_profile_run_id_from_run(run)
-    trainer_config = run.config.get("trainer")
-    if not isinstance(trainer_config, dict):
-        raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
-
-    log_dir = trainer_config.get("log_dir")
-    if not isinstance(log_dir, str) or not log_dir:
-        raise RuntimeError(f"Run {run.path} does not expose trainer.log_dir.")
-
-    return join_path(join_path(log_dir, run_id), PROFILE_DIR_NAME)
-
-
-def resolve_profile_run_id_from_run(run: WandbRunLike) -> str:
-    trainer_config = run.config.get("trainer")
-    if not isinstance(trainer_config, dict):
-        raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
-
-    run_id = trainer_config.get("id")
-    if isinstance(run_id, str) and run_id:
-        return run_id
-
-    return run.path[-1]
 
 
 def summarize_profile_artifact(
@@ -271,32 +242,6 @@ def summarize_trace(
     )
 
 
-def normalize_run_target(target: str, *, entity: str | None, project: str | None) -> tuple[str, str, str]:
-    """
-    Normalize run target into `(entity, project, run_id)`.
-
-    Accepted target forms:
-    - bare run id (`abc123`) with explicit `entity` and `project`
-    - `entity/project/run_id`
-    - W&B run URL (`https://wandb.ai/entity/project/runs/run_id`)
-    """
-    if target.startswith(("http://", "https://")):
-        parts = [part for part in urlparse(target).path.split("/") if part]
-        if len(parts) < 3:
-            raise ValueError(f"Could not parse run information from URL: {target}")
-    else:
-        parts = [part for part in target.split("/") if part]
-        if len(parts) == 1:
-            if entity is None or project is None:
-                raise ValueError("Bare run ids require --entity and --project.")
-            return entity, project, parts[0]
-        if len(parts) < 3:
-            raise ValueError(f"Unrecognized run target: {target}")
-
-    run_id = parts[3] if parts[2] == "runs" and len(parts) >= 4 else parts[2]
-    return parts[0], parts[1], run_id
-
-
 def _download_artifact_with_metadata(
     *,
     artifact: Any,
@@ -335,14 +280,8 @@ def _download_profile_dir_with_metadata(
     run: WandbRunLike,
     download_root: Path | None,
 ) -> DownloadedProfileDir:
-    run_id = resolve_profile_run_id_from_run(run)
-    local_profile_dir = mirror_directory(
-        profile_dir,
-        download_root,
-        run_id=run_id,
-        leaf_dirname=PROFILE_DIR_NAME,
-        temp_dir_prefix="marin-profile-",
-    )
+    run_id = resolve_profile_run_id(run)
+    local_profile_dir = mirror_profile_dir(profile_dir, download_root, run_id=run_id)
     metadata = _run_metadata_from_run(run, artifact_ref=profile_dir, artifact_name=PROFILE_DIR_NAME)
     return DownloadedProfileDir(profile_dir=local_profile_dir, run_metadata=metadata)
 

--- a/lib/marin/src/marin/profiling/ingest.py
+++ b/lib/marin/src/marin/profiling/ingest.py
@@ -8,13 +8,18 @@ from __future__ import annotations
 import hashlib
 import json
 import logging
+import os
+import shutil
+import tempfile
 from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 from urllib.parse import urlparse
 
+import fsspec
 import wandb
 from google.protobuf.message import DecodeError
+from rigging.filesystem import url_to_fs
 
 from marin.profiling.schema import ProfileSummary, RunMetadata
 from marin.profiling.trace_summary import (
@@ -28,7 +33,7 @@ from marin.profiling.xplane import MultipleXPlaneFilesError, find_xplane_file, s
 logger = logging.getLogger(__name__)
 
 PROFILE_ARTIFACT_TYPE = "jax_profile"
-DEFAULT_ARTIFACT_ALIAS = "latest"
+PROFILE_DIR_NAME = "profiler"
 
 
 @dataclass(frozen=True)
@@ -38,6 +43,14 @@ class DownloadedProfileArtifact:
     artifact_ref: str
     artifact_name: str
     artifact_dir: Path
+    run_metadata: RunMetadata
+
+
+@dataclass(frozen=True)
+class DownloadedProfileDir:
+    """Downloaded profiler directory and associated metadata."""
+
+    profile_dir: Path
     run_metadata: RunMetadata
 
 
@@ -74,30 +87,26 @@ def download_latest_profile_artifact_for_run(
     *,
     entity: str | None = None,
     project: str | None = None,
-    alias: str = DEFAULT_ARTIFACT_ALIAS,
     download_root: Path | None = None,
-) -> DownloadedProfileArtifact:
+) -> DownloadedProfileDir:
     """
-    Download the latest (or alias-selected) `jax_profile` artifact for a W&B run.
+    Download the profiler directory for a W&B run.
 
     Args:
         run_target: Bare run id, `entity/project/run_id`, or W&B run URL.
         entity: W&B entity when `run_target` is a bare run id.
         project: W&B project when `run_target` is a bare run id.
-        alias: Artifact alias preference (defaults to `latest`).
-        download_root: Optional output directory for artifact download.
+        download_root: Optional output directory where the profiler tree will be mirrored.
     """
     run_entity, run_project, run_id = normalize_run_target(run_target, entity=entity, project=project)
     run_path = f"{run_entity}/{run_project}/{run_id}"
 
     api = wandb.Api()
     run = api.run(run_path)
-    artifact = select_profile_artifact(run, alias=alias)
-    artifact_ref = f"{run_entity}/{run_project}/{artifact.name}"
+    profile_dir = resolve_profile_dir_from_run(run)
 
-    return _download_artifact_with_metadata(
-        artifact=artifact,
-        artifact_ref=artifact_ref,
+    return _download_profile_dir_with_metadata(
+        profile_dir=profile_dir,
         run=run,
         download_root=download_root,
     )
@@ -130,6 +139,19 @@ def find_profile_trace(profile_dir: Path) -> Path:
     raise FileNotFoundError(
         f"No profile trace JSON found under '{profile_dir}'. Expected perfetto_trace.json.gz or *.trace.json(.gz)."
     )
+
+
+def resolve_profile_dir_from_run(run: Any) -> str:
+    """Resolve the profiler directory for a W&B run from trainer config."""
+    trainer_config = run.config.get("trainer")
+    if not isinstance(trainer_config, dict):
+        raise RuntimeError(f"Run {run.path} does not expose a trainer config.")
+
+    log_dir = trainer_config.get("log_dir")
+    if not isinstance(log_dir, str) or not log_dir:
+        raise RuntimeError(f"Run {run.path} does not expose trainer.log_dir.")
+
+    return _join_path(_join_path(log_dir, run.path[-1]), PROFILE_DIR_NAME)
 
 
 def summarize_profile_artifact(
@@ -258,39 +280,6 @@ def normalize_run_target(target: str, *, entity: str | None, project: str | None
     return parts[0], parts[1], run_id
 
 
-def select_profile_artifact(run: Any, *, alias: str | None) -> Any:
-    """
-    Select a `jax_profile` artifact from a W&B run.
-
-    If `alias` matches no artifact, falls back to the most recently updated one.
-    """
-    candidates = [
-        artifact for artifact in run.logged_artifacts() if getattr(artifact, "type", None) == PROFILE_ARTIFACT_TYPE
-    ]
-    if not candidates:
-        raise RuntimeError(f"No artifacts of type '{PROFILE_ARTIFACT_TYPE}' were found for run {run.path}.")
-
-    if alias:
-        for artifact in candidates:
-            if alias in _alias_names(artifact):
-                return artifact
-
-    candidates.sort(
-        key=lambda artifact: getattr(artifact, "updated_at", None) or getattr(artifact, "created_at", None),
-        reverse=True,
-    )
-    return candidates[0]
-
-
-def _alias_names(artifact: Any) -> set[str]:
-    names: set[str] = set()
-    for alias in getattr(artifact, "aliases", None) or []:
-        name = getattr(alias, "name", alias)
-        if name is not None:
-            names.add(str(name))
-    return names
-
-
 def _download_artifact_with_metadata(
     *,
     artifact: Any,
@@ -321,6 +310,17 @@ def _download_artifact_with_metadata(
         artifact_dir=artifact_dir,
         run_metadata=metadata,
     )
+
+
+def _download_profile_dir_with_metadata(
+    *,
+    profile_dir: str,
+    run: Any,
+    download_root: Path | None,
+) -> DownloadedProfileDir:
+    local_profile_dir = _mirror_profile_dir(profile_dir, download_root=download_root, run_id=run.path[-1])
+    metadata = _run_metadata_from_run(run, artifact_ref=profile_dir, artifact_name=PROFILE_DIR_NAME)
+    return DownloadedProfileDir(profile_dir=local_profile_dir, run_metadata=metadata)
 
 
 def _pick_first(mapping: dict[str, Any], *keys: str) -> str | None:
@@ -377,3 +377,45 @@ def _run_metadata_from_run(run: Any, *, artifact_ref: str, artifact_name: str) -
         num_devices=_int_or_none(summary.get("num_devices") or config.get("num_devices")),
         num_hosts=_int_or_none(summary.get("num_hosts") or config.get("num_hosts")),
     )
+
+
+def _mirror_profile_dir(profile_dir: str, *, download_root: Path | None, run_id: str) -> Path:
+    fs, fs_path = url_to_fs(profile_dir)
+    if download_root is None:
+        if _is_local_fs(fs):
+            local_path = Path(fs_path)
+            if not local_path.exists():
+                raise FileNotFoundError(f"Profile directory does not exist: {profile_dir}")
+            return local_path
+        download_root = Path(tempfile.mkdtemp(prefix="marin-profile-"))
+    else:
+        download_root.mkdir(parents=True, exist_ok=True)
+
+    download_path = download_root / run_id / PROFILE_DIR_NAME
+    if download_path.exists():
+        shutil.rmtree(download_path)
+    download_path.parent.mkdir(parents=True, exist_ok=True)
+
+    if _is_local_fs(fs):
+        source_path = Path(fs_path)
+        if not source_path.exists():
+            raise FileNotFoundError(f"Profile directory does not exist: {profile_dir}")
+        shutil.copytree(source_path, download_path)
+    else:
+        fs.get(fs_path, str(download_path), recursive=True)
+    return download_path
+
+
+def _is_local_fs(fs: Any) -> bool:
+    protocol = fs.protocol[0] if isinstance(fs.protocol, tuple) else fs.protocol
+    return protocol in (None, "", "file")
+
+
+def _join_path(lhs: str, rhs: str) -> str:
+    lhs_protocol, lhs_rest = fsspec.core.split_protocol(lhs)
+    rhs_protocol, _ = fsspec.core.split_protocol(rhs)
+    if rhs_protocol is not None:
+        return rhs
+    if lhs_protocol is not None:
+        return f"{lhs_protocol}://{os.path.join(lhs_rest, rhs)}"
+    return os.path.join(lhs, rhs)

--- a/lib/marin/src/marin/profiling/ingest.py
+++ b/lib/marin/src/marin/profiling/ingest.py
@@ -152,7 +152,7 @@ def summarize_profile_artifact(
     Summarize a downloaded profile directory into the normalized schema.
 
     Args:
-        profile_dir: Local path to a `jax_profile` artifact directory.
+        profile_dir: Local path to a profiler directory.
         run_metadata: Optional run metadata to attach.
         warmup_steps: Number of initial steps to exclude from steady-state stats.
         hot_op_limit: Maximum number of hot ops to include.

--- a/tests/profiling/test_profile_summary.py
+++ b/tests/profiling/test_profile_summary.py
@@ -606,7 +606,7 @@ def test_summarize_cli_run_target_honors_download_root(tmp_path: Path, monkeypat
         _write_trace(trace_path, step_durations=[100], softmax_duration=10)
         return summarize_trace(trace_path, warmup_steps=0)
 
-    monkeypatch.setattr(cli_module, "download_latest_profile_artifact_for_run", download_profile_dir)
+    monkeypatch.setattr(cli_module, "download_profile_dir_for_run", download_profile_dir)
     monkeypatch.setattr(cli_module, "summarize_profile_artifact", summarize_artifact)
     monkeypatch.setattr(
         sys,
@@ -630,8 +630,8 @@ def test_summarize_cli_run_target_honors_download_root(tmp_path: Path, monkeypat
     assert seen_run_target == [("entity/project/run", None, None)]
 
 
-def test_download_latest_profile_artifact_for_run_mirrors_remote_log_dir(tmp_path: Path, monkeypatch) -> None:
-    source = "memory://wandb/logs/run-123/profiler"
+def test_download_profile_dir_for_run_mirrors_remote_log_dir(tmp_path: Path, monkeypatch) -> None:
+    source = "memory://wandb/logs/trainer-456/profiler"
     fs, fs_path = url_to_fs(source)
     fs.makedirs(f"{fs_path}/plugins/profile/2026_05_11_12_00_00", exist_ok=True)
     with fs.open(f"{fs_path}/plugins/profile/2026_05_11_12_00_00/perfetto_trace.json.gz", "wb") as handle:
@@ -640,7 +640,7 @@ def test_download_latest_profile_artifact_for_run_mirrors_remote_log_dir(tmp_pat
     fake_run = SimpleNamespace(
         path=["entity", "project", "run-123"],
         id="run-123",
-        config={"trainer": {"log_dir": "memory://wandb/logs"}},
+        config={"trainer": {"id": "trainer-456", "log_dir": "memory://wandb/logs"}},
         summary={},
     )
 
@@ -651,12 +651,12 @@ def test_download_latest_profile_artifact_for_run_mirrors_remote_log_dir(tmp_pat
 
     monkeypatch.setattr(ingest_module.wandb, "Api", lambda: FakeApi())
 
-    downloaded = ingest_module.download_latest_profile_artifact_for_run(
+    downloaded = ingest_module.download_profile_dir_for_run(
         "entity/project/run-123",
         download_root=tmp_path / "downloads",
     )
 
-    assert downloaded.profile_dir == tmp_path / "downloads" / "run-123" / "profiler"
+    assert downloaded.profile_dir == tmp_path / "downloads" / "trainer-456" / "profiler"
     assert downloaded.run_metadata.run_id == "run-123"
     assert (downloaded.profile_dir / "plugins" / "profile" / "2026_05_11_12_00_00" / "perfetto_trace.json.gz").exists()
 

--- a/tests/profiling/test_profile_summary.py
+++ b/tests/profiling/test_profile_summary.py
@@ -10,6 +10,7 @@ from pathlib import Path
 from types import ModuleType, SimpleNamespace
 
 import marin.profiling.cli as cli_module
+import marin.profiling.ingest as ingest_module
 import marin.profiling.xplane as xplane_module
 import pytest
 from marin.profiling.ingest import summarize_profile_artifact, summarize_trace
@@ -24,6 +25,7 @@ from marin.profiling.xplane import (
     summarize_xplane,
     summarize_xplane_tables,
 )
+from rigging.filesystem import url_to_fs
 
 
 def test_summarize_trace_produces_deterministic_breakdown_and_hot_ops(tmp_path: Path) -> None:
@@ -582,21 +584,29 @@ def test_summarize_cli_xplane_file_honors_breakdown_mode(tmp_path: Path, monkeyp
     assert summary.time_breakdown.duration_basis == "exclusive_duration_global_timeline"
 
 
-def test_summarize_cli_artifact_honors_download_root(tmp_path: Path, monkeypatch, capsys) -> None:
+def test_summarize_cli_run_target_honors_download_root(tmp_path: Path, monkeypatch, capsys) -> None:
     seen_download_root = []
+    seen_run_target = []
     output_path = tmp_path / "summary.json"
     download_root = tmp_path / "downloads"
 
-    def download_artifact(artifact_ref: str, *, download_root: Path | None = None):
+    def download_profile_dir(
+        run_target: str,
+        *,
+        entity: str | None = None,
+        project: str | None = None,
+        download_root: Path | None = None,
+    ):
         seen_download_root.append(download_root)
-        return SimpleNamespace(artifact_dir=tmp_path / "artifact", run_metadata=None)
+        seen_run_target.append((run_target, entity, project))
+        return SimpleNamespace(profile_dir=tmp_path / "artifact", run_metadata=None)
 
     def summarize_artifact(*args, **kwargs):
         trace_path = tmp_path / "trace.json.gz"
         _write_trace(trace_path, step_durations=[100], softmax_duration=10)
         return summarize_trace(trace_path, warmup_steps=0)
 
-    monkeypatch.setattr(cli_module, "download_wandb_profile_artifact", download_artifact)
+    monkeypatch.setattr(cli_module, "download_latest_profile_artifact_for_run", download_profile_dir)
     monkeypatch.setattr(cli_module, "summarize_profile_artifact", summarize_artifact)
     monkeypatch.setattr(
         sys,
@@ -604,8 +614,8 @@ def test_summarize_cli_artifact_honors_download_root(tmp_path: Path, monkeypatch
         [
             "profile_summary.py",
             "summarize",
-            "--artifact",
-            "entity/project/artifact:v0",
+            "--run-target",
+            "entity/project/run",
             "--download-root",
             str(download_root),
             "--output",
@@ -617,6 +627,38 @@ def test_summarize_cli_artifact_honors_download_root(tmp_path: Path, monkeypatch
 
     assert capsys.readouterr().out.strip() == str(output_path)
     assert seen_download_root == [download_root]
+    assert seen_run_target == [("entity/project/run", None, None)]
+
+
+def test_download_latest_profile_artifact_for_run_mirrors_remote_log_dir(tmp_path: Path, monkeypatch) -> None:
+    source = "memory://wandb/logs/run-123/profiler"
+    fs, fs_path = url_to_fs(source)
+    fs.makedirs(f"{fs_path}/plugins/profile/2026_05_11_12_00_00", exist_ok=True)
+    with fs.open(f"{fs_path}/plugins/profile/2026_05_11_12_00_00/perfetto_trace.json.gz", "wb") as handle:
+        handle.write(b"trace")
+
+    fake_run = SimpleNamespace(
+        path=["entity", "project", "run-123"],
+        id="run-123",
+        config={"trainer": {"log_dir": "memory://wandb/logs"}},
+        summary={},
+    )
+
+    class FakeApi:
+        def run(self, run_path: str):
+            assert run_path == "entity/project/run-123"
+            return fake_run
+
+    monkeypatch.setattr(ingest_module.wandb, "Api", lambda: FakeApi())
+
+    downloaded = ingest_module.download_latest_profile_artifact_for_run(
+        "entity/project/run-123",
+        download_root=tmp_path / "downloads",
+    )
+
+    assert downloaded.profile_dir == tmp_path / "downloads" / "run-123" / "profiler"
+    assert downloaded.run_metadata.run_id == "run-123"
+    assert (downloaded.profile_dir / "plugins" / "profile" / "2026_05_11_12_00_00" / "perfetto_trace.json.gz").exists()
 
 
 def test_summarize_xplane_with_installed_xprof_exports_tables(tmp_path: Path) -> None:

--- a/tests/profiling/test_tracking.py
+++ b/tests/profiling/test_tracking.py
@@ -7,6 +7,7 @@ import gzip
 import json
 from pathlib import Path
 
+from levanter.utils.profile_dirs import RunTarget
 from marin.profiling.ingest import normalize_run_target, summarize_trace
 from marin.profiling.tracking import (
     RegressionThresholds,
@@ -23,16 +24,16 @@ def test_normalize_run_target_variants() -> None:
         "https://wandb.ai/marin-community/marin/runs/abc123",
         entity=None,
         project=None,
-    ) == ("marin-community", "marin", "abc123")
-    assert normalize_run_target("marin-community/marin/abc123", entity=None, project=None) == (
-        "marin-community",
-        "marin",
-        "abc123",
+    ) == RunTarget(entity="marin-community", project="marin", run_id="abc123")
+    assert normalize_run_target("marin-community/marin/abc123", entity=None, project=None) == RunTarget(
+        entity="marin-community",
+        project="marin",
+        run_id="abc123",
     )
-    assert normalize_run_target("abc123", entity="marin-community", project="marin") == (
-        "marin-community",
-        "marin",
-        "abc123",
+    assert normalize_run_target("abc123", entity="marin-community", project="marin") == RunTarget(
+        entity="marin-community",
+        project="marin",
+        run_id="abc123",
     )
 
 

--- a/tests/profiling/test_tracking.py
+++ b/tests/profiling/test_tracking.py
@@ -7,8 +7,8 @@ import gzip
 import json
 from pathlib import Path
 
-from levanter.utils.profile_dirs import RunTarget
-from marin.profiling.ingest import normalize_run_target, summarize_trace
+from levanter.utils.profile_dirs import RunTarget, normalize_run_target
+from marin.profiling.ingest import summarize_trace
 from marin.profiling.tracking import (
     RegressionThresholds,
     append_regression_record,


### PR DESCRIPTION
Levanter's profiling flow now keeps traces on disk under the run directory instead of uploading jax_profile artifacts. The training callback, profile context manager, eval harness, and TensorBoard helper now resolve the profile tree from the run config and mirror it locally when needed.

This keeps profiler inspection aligned with the filesystem layout of the run itself and makes the helper work against durable storage directly.