### PR TITLE
[grug] Use remat policy for DeepEP transport

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -16,7 +16,7 @@ import jax
 import jax.numpy as jnp
 import jax.scipy as jsp
 from einops import rearrange
-from haliax.jax_utils import named_call
+from haliax.jax_utils import named_call, tree_checkpoint_name
 from jax import random
 from jax.sharding import PartitionSpec as P
 from jax.sharding import get_abstract_mesh, reshard
@@ -36,6 +36,7 @@ from levanter.grug.attention import (
     with_fa4_cute_metadata,
 )
 from levanter.grug.grug_moe import (
+    DEEPEP_REMAT_SAVE_NAMES,
     MOE_REMAT_SAVE_NAMES,
     MoeActivation,
     MoEExpertMlp,
@@ -50,6 +51,7 @@ from levanter.utils.activation import ActivationFunctionEnum
 _DEFAULT_EP_CAPACITY_FACTOR = 1.0
 _GATED_NORM_RANK = 128
 _CROSS_ENTROPY_IMPLEMENTATIONS = ("pallas_gpu", "pallas_tpu", "xla", "reference")
+_CHECKPOINT_BLOCK_ATTENTION_OUTPUT = "grug_block_attention_output"
 
 
 _BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
@@ -634,7 +636,10 @@ class Block(eqx.Module):
         pko_doc_starts: Bool[Array, "B S"] | None,
     ) -> Float[Array, "B S D"]:
         attn_in = self.attn_gated_norm(self.rms_attn(x))
-        return _batch_reshard(x + self.attn(attn_in, mask, use_pko=use_pko, pko_doc_starts=pko_doc_starts))
+        return tree_checkpoint_name(
+            _batch_reshard(x + self.attn(attn_in, mask, use_pko=use_pko, pko_doc_starts=pko_doc_starts)),
+            _CHECKPOINT_BLOCK_ATTENTION_OUTPUT,
+        )
 
     @named_call
     def _mlp_update(self, x: Float[Array, "B S D"]) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
@@ -654,24 +659,6 @@ class Block(eqx.Module):
         pko_doc_starts: Bool[Array, "B S"] | None = None,
     ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
         x = self._attention_update(x, mask, use_pko=use_pko, pko_doc_starts=pko_doc_starts)
-        return self._mlp_update(x)
-
-    @named_call
-    def call_with_transport_safe_remat(
-        self,
-        x: Float[Array, "B S D"],
-        mask: AttentionMask | jax.Array,
-        *,
-        remat_policy,
-        use_pko: bool = False,
-        pko_doc_starts: Bool[Array, "B S"] | None = None,
-    ) -> tuple[Float[Array, "B S D"], dict[str, jax.Array]]:
-        x = eqx.filter_checkpoint(self._attention_update, policy=remat_policy)(
-            x,
-            mask,
-            use_pko=use_pko,
-            pko_doc_starts=pko_doc_starts,
-        )
         return self._mlp_update(x)
 
 
@@ -734,11 +721,23 @@ class Transformer(eqx.Module):
             batch_size, seq_len = hidden.shape[:2]
             pko_doc_starts = _segment_start_mask(mask, batch_size=batch_size, seq_len=seq_len)
 
+        uses_effectful_moe = resolve_moe_implementation(cfg.moe_implementation) == "deepep"
         if cfg.remat_mode == "save_moe":
-            remat_policy = jax.checkpoint_policies.save_only_these_names(*MOE_REMAT_SAVE_NAMES)
+            remat_save_names = MOE_REMAT_SAVE_NAMES
+            if uses_effectful_moe:
+                remat_save_names = (
+                    _CHECKPOINT_BLOCK_ATTENTION_OUTPUT,
+                    *DEEPEP_REMAT_SAVE_NAMES,
+                    *MOE_REMAT_SAVE_NAMES,
+                )
+            remat_policy = jax.checkpoint_policies.save_only_these_names(*remat_save_names)
+        elif uses_effectful_moe and cfg.remat_mode == "recompute_all":
+            remat_policy = jax.checkpoint_policies.save_only_these_names(
+                _CHECKPOINT_BLOCK_ATTENTION_OUTPUT,
+                *DEEPEP_REMAT_SAVE_NAMES,
+            )
         else:
             remat_policy = None
-        uses_effectful_moe = resolve_moe_implementation(cfg.moe_implementation) == "deepep"
 
         moe_router_stats: list[dict[str, jax.Array]] = []
         num_blocks = len(self.blocks)
@@ -749,13 +748,6 @@ class Transformer(eqx.Module):
             block_kwargs = {"use_pko": use_pko, "pko_doc_starts": pko_doc_starts if use_pko else None}
             if cfg.remat_mode == "none":
                 hidden, router_stats = block(hidden, layer_mask, **block_kwargs)
-            elif uses_effectful_moe:
-                hidden, router_stats = block.call_with_transport_safe_remat(
-                    hidden,
-                    layer_mask,
-                    remat_policy=remat_policy,
-                    **block_kwargs,
-                )
             else:
                 hidden, router_stats = eqx.filter_checkpoint(block, policy=remat_policy)(
                     hidden,

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -42,6 +42,19 @@ _CHECKPOINT_DISPATCH_INPUT = "grug_moe_dispatch_input"
 _CHECKPOINT_EXPERT_HIDDEN = "grug_moe_expert_hidden"
 _CHECKPOINT_DISPATCH_OUTPUT = "grug_moe_dispatch_output"
 _CHECKPOINT_MOE_OUTPUT = "grug_moe_output"
+_CHECKPOINT_DEEPEP_RECV_X = "grug_moe_deepep_recv_x"
+_CHECKPOINT_DEEPEP_RECV_TOPK_IDX = "grug_moe_deepep_recv_topk_idx"
+_CHECKPOINT_DEEPEP_RECV_TOPK_WEIGHTS = "grug_moe_deepep_recv_topk_weights"
+_CHECKPOINT_DEEPEP_RECV_SRC_IDX = "grug_moe_deepep_recv_src_idx"
+_CHECKPOINT_DEEPEP_RANK_PREFIX_MATRIX = "grug_moe_deepep_rank_prefix_matrix"
+_CHECKPOINT_DEEPEP_CHANNEL_PREFIX_MATRIX = "grug_moe_deepep_channel_prefix_matrix"
+_CHECKPOINT_DEEPEP_RECV_CHANNEL_PREFIX_MATRIX = "grug_moe_deepep_recv_channel_prefix_matrix"
+_CHECKPOINT_DEEPEP_SEND_HEAD = "grug_moe_deepep_send_head"
+_CHECKPOINT_DEEPEP_NUM_RECV_TOKENS = "grug_moe_deepep_num_recv_tokens"
+_CHECKPOINT_DEEPEP_IS_TOKEN_IN_RANK = "grug_moe_deepep_is_token_in_rank"
+_CHECKPOINT_DEEPEP_ASSIGNMENT_WEIGHTS = "grug_moe_deepep_assignment_weights"
+_CHECKPOINT_DEEPEP_RECV_TOKEN_INDICES = "grug_moe_deepep_recv_token_indices"
+_CHECKPOINT_DEEPEP_LOCAL_GROUP_SIZES = "grug_moe_deepep_local_group_sizes"
 
 # Checkpoint names every MoE backend tags on its dispatch tensors. A remat
 # policy of jax.checkpoint_policies.save_only_these_names(*MOE_REMAT_SAVE_NAMES)
@@ -52,6 +65,25 @@ MOE_REMAT_SAVE_NAMES = (
     _CHECKPOINT_EXPERT_HIDDEN,
     _CHECKPOINT_DISPATCH_OUTPUT,
     _CHECKPOINT_MOE_OUTPUT,
+)
+
+# DeepEP transport FFI calls are effectful and expensive. Saving these residuals
+# lets a normal block-level remat policy keep dispatch/combine handles live
+# without structurally moving DeepEP outside the block checkpoint.
+DEEPEP_REMAT_SAVE_NAMES = (
+    _CHECKPOINT_DEEPEP_RECV_X,
+    _CHECKPOINT_DEEPEP_RECV_TOPK_IDX,
+    _CHECKPOINT_DEEPEP_RECV_TOPK_WEIGHTS,
+    _CHECKPOINT_DEEPEP_RECV_SRC_IDX,
+    _CHECKPOINT_DEEPEP_RANK_PREFIX_MATRIX,
+    _CHECKPOINT_DEEPEP_CHANNEL_PREFIX_MATRIX,
+    _CHECKPOINT_DEEPEP_RECV_CHANNEL_PREFIX_MATRIX,
+    _CHECKPOINT_DEEPEP_SEND_HEAD,
+    _CHECKPOINT_DEEPEP_NUM_RECV_TOKENS,
+    _CHECKPOINT_DEEPEP_IS_TOKEN_IN_RANK,
+    _CHECKPOINT_DEEPEP_ASSIGNMENT_WEIGHTS,
+    _CHECKPOINT_DEEPEP_RECV_TOKEN_INDICES,
+    _CHECKPOINT_DEEPEP_LOCAL_GROUP_SIZES,
 )
 
 

--- a/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
@@ -18,6 +18,19 @@ from jaxtyping import Array, Float, Int
 from levanter.grug._moe.common import (
     _CHECKPOINT_DISPATCH_INPUT,
     _CHECKPOINT_DISPATCH_OUTPUT,
+    _CHECKPOINT_DEEPEP_ASSIGNMENT_WEIGHTS,
+    _CHECKPOINT_DEEPEP_CHANNEL_PREFIX_MATRIX,
+    _CHECKPOINT_DEEPEP_IS_TOKEN_IN_RANK,
+    _CHECKPOINT_DEEPEP_LOCAL_GROUP_SIZES,
+    _CHECKPOINT_DEEPEP_NUM_RECV_TOKENS,
+    _CHECKPOINT_DEEPEP_RANK_PREFIX_MATRIX,
+    _CHECKPOINT_DEEPEP_RECV_CHANNEL_PREFIX_MATRIX,
+    _CHECKPOINT_DEEPEP_RECV_SRC_IDX,
+    _CHECKPOINT_DEEPEP_RECV_TOKEN_INDICES,
+    _CHECKPOINT_DEEPEP_RECV_TOPK_IDX,
+    _CHECKPOINT_DEEPEP_RECV_TOPK_WEIGHTS,
+    _CHECKPOINT_DEEPEP_RECV_X,
+    _CHECKPOINT_DEEPEP_SEND_HEAD,
     _CHECKPOINT_EXPERT_HIDDEN,
     MOE_REMAT_SAVE_NAMES,
     MoERematMode,
@@ -136,6 +149,9 @@ def _pack_deepep_local_assignments(
         valid_sorted = jnp.arange(total_assignments, dtype=jnp.int32) < total_valid
         x_dispatch = jnp.where(valid_sorted[:, None], x_dispatch, 0)
         assignment_weights = jnp.where(valid_sorted, assignment_weights, 0)
+        assignment_weights = tree_checkpoint_name(assignment_weights, _CHECKPOINT_DEEPEP_ASSIGNMENT_WEIGHTS)
+        recv_token_indices = tree_checkpoint_name(recv_token_indices, _CHECKPOINT_DEEPEP_RECV_TOKEN_INDICES)
+        local_group_sizes = tree_checkpoint_name(local_group_sizes, _CHECKPOINT_DEEPEP_LOCAL_GROUP_SIZES)
         return DeepEPLocalAssignments(x_dispatch, assignment_weights, recv_token_indices, local_group_sizes)
 
 
@@ -212,6 +228,19 @@ def _moe_mlp_ep_deepep_local(
                 num_experts=num_experts,
                 max_recv_tokens=max_recv_tokens,
             )
+        recv_x = tree_checkpoint_name(recv_x, _CHECKPOINT_DEEPEP_RECV_X)
+        recv_topk_idx = tree_checkpoint_name(recv_topk_idx, _CHECKPOINT_DEEPEP_RECV_TOPK_IDX)
+        recv_topk_weights = tree_checkpoint_name(recv_topk_weights, _CHECKPOINT_DEEPEP_RECV_TOPK_WEIGHTS)
+        recv_src_idx = tree_checkpoint_name(recv_src_idx, _CHECKPOINT_DEEPEP_RECV_SRC_IDX)
+        rank_prefix_matrix = tree_checkpoint_name(rank_prefix_matrix, _CHECKPOINT_DEEPEP_RANK_PREFIX_MATRIX)
+        channel_prefix_matrix = tree_checkpoint_name(channel_prefix_matrix, _CHECKPOINT_DEEPEP_CHANNEL_PREFIX_MATRIX)
+        recv_channel_prefix_matrix = tree_checkpoint_name(
+            recv_channel_prefix_matrix,
+            _CHECKPOINT_DEEPEP_RECV_CHANNEL_PREFIX_MATRIX,
+        )
+        send_head = tree_checkpoint_name(send_head, _CHECKPOINT_DEEPEP_SEND_HEAD)
+        num_recv_tokens = tree_checkpoint_name(num_recv_tokens, _CHECKPOINT_DEEPEP_NUM_RECV_TOKENS)
+        is_token_in_rank = tree_checkpoint_name(is_token_in_rank, _CHECKPOINT_DEEPEP_IS_TOKEN_IN_RANK)
         num_recv_tokens_scalar = jnp.squeeze(num_recv_tokens, axis=0)
         local_assignments = _pack_deepep_local_assignments(
             recv_x,

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -29,6 +29,7 @@ from levanter.grug._moe.common import (
     _DEFAULT_EP_CAPACITY_FACTOR,
     _EP_MOE_IMPLEMENTATIONS,
     _init_weight,
+    DEEPEP_REMAT_SAVE_NAMES as DEEPEP_REMAT_SAVE_NAMES,
     MOE_REMAT_SAVE_NAMES as MOE_REMAT_SAVE_NAMES,
     MoEExpertMlpPspecs,
     MoeActivation,


### PR DESCRIPTION
Replace the DeepEP-specific block call path with a normal block-level checkpoint policy. The policy now saves the post-attention residual plus named DeepEP transport residuals, so dispatch/combine handles stay live without moving DeepEP outside the block remat boundary.

This keeps DeepEP remat behavior expressed through checkpoint names while preserving the existing MoE save-name policy for non-DeepEP backends.