### PR TITLE
[iris] Build marin-finelog from source in the controller image

### DIFF
--- a/lib/iris/Dockerfile
+++ b/lib/iris/Dockerfile
@@ -72,20 +72,22 @@ ENV PATH="/app/.venv/bin:$PATH"
 # Build against the committed root `uv.lock` (`--frozen`) so the image ships the
 # same pinned, tested dependency set as local dev and the rest of CI — no fresh
 # PyPI resolve that can float a transitive (e.g. protobuf) to an untested major.
-# marin-iris's closure is only marin-rigging (workspace) plus external/registry
-# deps (marin-finelog and the native marin-finelog-server ship as published
-# wheels); it never pulls the Rust-built members (marin-core, levanter, …), so
-# `--package marin-iris` never asks the toolchain-free slim base to build them.
+# marin-iris's closure is two workspace members built from source — marin-rigging
+# and marin-finelog (the pure-Python finelog client) — plus external/registry
+# deps (the native marin-finelog-server ships as a published wheel). It never
+# pulls the Rust-built members (marin-core, levanter, …), so `--package
+# marin-iris` never asks the toolchain-free slim base to build them.
 # uv must still discover every workspace member to map the lock, so copy each
-# member's pyproject.toml (metadata only) — but only iris+rigging install. The
-# first sync uses `--no-install-workspace` to install just the external deps
-# (cached across source edits); the second builds iris+rigging from source.
+# member's pyproject.toml (metadata only) — but only iris+rigging+finelog install.
+# The first sync uses `--no-install-workspace` to install just the external deps
+# (cached across source edits); the second builds iris+rigging+finelog from source.
 # Metadata alone suffices even for marin-haliax's `dynamic = ["version"]`
 # (sourced from src/haliax/__about__.py): under --frozen, uv takes the version
 # from the lock and never invokes a non-installed member's build backend.
 COPY uv.lock pyproject.toml ./
 COPY lib/iris/pyproject.toml ./lib/iris/pyproject.toml
 COPY lib/rigging/pyproject.toml ./lib/rigging/pyproject.toml
+COPY lib/finelog/pyproject.toml ./lib/finelog/pyproject.toml
 COPY lib/fray/pyproject.toml ./lib/fray/pyproject.toml
 COPY lib/haliax/pyproject.toml ./lib/haliax/pyproject.toml
 COPY lib/levanter/pyproject.toml ./lib/levanter/pyproject.toml
@@ -94,8 +96,12 @@ COPY lib/zephyr/pyproject.toml ./lib/zephyr/pyproject.toml
 RUN --mount=type=cache,target=/root/.cache/uv \
     uv sync --frozen --package marin-iris --no-install-workspace
 
-# Now copy full source for rigging and iris, then install.
+# Now copy full source for rigging, finelog, and iris, then install. finelog's
+# wheel build force-includes its config/ dir, so copy that too (the editable
+# build reads it).
 COPY lib/rigging/src/ ./lib/rigging/src/
+COPY lib/finelog/src/ ./lib/finelog/src/
+COPY lib/finelog/config/ ./lib/finelog/config/
 COPY lib/iris/src/ ./lib/iris/src/
 COPY lib/iris/config/ ./lib/iris/config/
 RUN --mount=type=cache,target=/root/.cache/uv \

--- a/lib/iris/Dockerfile.dockerignore
+++ b/lib/iris/Dockerfile.dockerignore
@@ -1,8 +1,9 @@
 # The build context is the marin repo root, but the controller/worker images
-# only need lib/iris/, lib/rigging/, and the workspace metadata that lets the
-# deps stage resolve against the committed root uv.lock. finelog is pulled as a
-# pre-built wheel from the index, not copied as source. Exclude everything,
-# then selectively re-include.
+# only need lib/iris/, lib/rigging/, lib/finelog/, and the workspace metadata
+# that lets the deps stage resolve against the committed root uv.lock. The pure
+# marin-finelog client is a workspace member built from source here; its native
+# companion marin-finelog-server is pulled as a pre-built wheel from the index.
+# Exclude everything, then selectively re-include.
 #
 # NOTE: this allowlist must stay in sync with the COPY paths in the deps stage
 # of Dockerfile — a path that is COPY'd but not re-included here fails the build
@@ -11,7 +12,7 @@
 
 # Root lockfile + workspace member pyproject.toml metadata. uv discovers every
 # member listed in the root [tool.uv.workspace] when mapping the lock, so all
-# member manifests must be present even though only iris+rigging install.
+# member manifests must be present even though only iris+rigging+finelog install.
 !uv.lock
 !pyproject.toml
 !lib/fray/pyproject.toml
@@ -34,6 +35,12 @@
 !lib/iris/dashboard/src/
 
 !lib/rigging/
+
+# marin-finelog (pure-Python client) builds editable from source; the deps stage
+# copies its pyproject + the src/ and config/ inputs its wheel build needs.
+!lib/finelog/pyproject.toml
+!lib/finelog/src/
+!lib/finelog/config/
 
 # Exclude build artifacts within included paths
 **/__pycache__


### PR DESCRIPTION
PR #6455 made marin-finelog (the pure-Python finelog client) a workspace member again, so the root `uv.lock` now resolves it as an editable source build rather than a published wheel. The iris controller/worker image deps stage never copied `lib/finelog`, so `uv sync --frozen --package marin-iris` failed with "Distribution not found at: file:///app/lib/finelog", breaking the CoreWeave CI controller build (`cw-ci-test` / Start controller).

Copy `lib/finelog`'s pyproject (so uv can map it in the lock) plus its `src/` and `config/` (its hatchling wheel build force-includes `config/`) into the deps stage, and re-include those paths in `lib/iris/Dockerfile.dockerignore`, mirroring how `lib/rigging` is handled. The native `marin-finelog-server` stays a pre-built published wheel. Verified the deps stage builds clean locally (`marin-finelog==0.2.11 from file:///app/lib/finelog`).