### PR TITLE
[levanter] Loosen test_entropy TPU tolerance for f32 reduction precision

### DIFF
--- a/lib/levanter/tests/test_entropy.py
+++ b/lib/levanter/tests/test_entropy.py
@@ -51,4 +51,7 @@ def test_entropy_matches_softmax_reference():
     probs = np.exp(log_probs)
     expected = -np.sum(probs * log_probs, axis=-1)
 
-    np.testing.assert_allclose(np.asarray(entropy), expected, atol=1e-5)
+    # entropy_from_logits reduces over the vocab axis in f32 on TPU, so it differs
+    # from the f64 numpy reference by ~1e-4 — a reduction-precision gap, not a bug.
+    # (top2_gap above is an exact subtraction, so it keeps the tighter 1e-5.)
+    np.testing.assert_allclose(np.asarray(entropy), expected, rtol=1e-3, atol=1e-4)


### PR DESCRIPTION
test_entropy_matches_softmax_reference compared entropy_from_logits against an f64 numpy reference at atol=1e-5. On TPU the entropy reduction runs in f32, so it differs from the reference by ~1.5e-4 — a precision gap, not a bug — and the assertion fails.

The test landed in #6419, whose levanter-tpu-tests run was cancelled, so it merged without ever passing on TPU. It now fails every levanter-touching PR (e.g. #6430) once CI runs the branch-merged-with-main.

Compare at rtol=1e-3 / atol=1e-4, which reflects TPU reduction precision. The sibling top2_gap test is an exact subtraction and keeps the tighter 1e-5.