### PR TITLE
[status-page] Show last 14 ferry runs per tier instead of a 10-day window

### DIFF
--- a/infra/status-page/server/main.ts
+++ b/infra/status-page/server/main.ts
@@ -1,7 +1,7 @@
 // Hono entrypoint for the Marin status page.
 //
 // Serves:
-//   GET /api/ferry           — GitHub Actions ferry status (60s cache, last 10 days)
+//   GET /api/ferry           — GitHub Actions ferry status (60s cache, last 14 runs per tier)
 //   GET /api/builds          — GitHub per-commit CI rollup on main (60s cache, last 100 commits)
 //   GET /api/iris            — iris controller reachability (15s cache)
 //   GET /api/control-plane/health — active env Iris + finelog health history
@@ -36,7 +36,7 @@ import {
 } from "./sources/serviceHealth.js";
 import { workerSnapshot, type WorkersSnapshot } from "./sources/workers.js";
 
-const FERRY_WINDOW_DAYS = 10;
+const FERRY_RUN_LIMIT = 14;
 const BUILD_HISTORY = 100;
 
 // Cache is keyed per tier workflow file so the three datakit tiers share
@@ -143,12 +143,12 @@ app.get("/api/ferry", async (c) => {
       name: group.name,
       tiers: await Promise.all(
         group.tiers.map((tier) =>
-          ferryCache.get(tier.file, () => fetchTierStatus(tier, FERRY_WINDOW_DAYS)),
+          ferryCache.get(tier.file, () => fetchTierStatus(tier, FERRY_RUN_LIMIT)),
         ),
       ),
     })),
   );
-  return c.json({ windowDays: FERRY_WINDOW_DAYS, groups });
+  return c.json({ runLimit: FERRY_RUN_LIMIT, groups });
 });
 
 app.get("/api/builds", async (c) => {

--- a/infra/status-page/server/sources/githubActions.ts
+++ b/infra/status-page/server/sources/githubActions.ts
@@ -9,9 +9,6 @@
 
 import { githubAuthHeaders, REPO } from "./github.js";
 
-const MAX_WORKFLOW_RUNS_PER_REQUEST = 100;
-const MS_PER_DAY = 24 * 60 * 60 * 1000;
-
 // A ferry is one card on the dashboard. Most map to a single workflow file;
 // the datakit ferry runs three tiers (tier1/2/3) we surface as three strips
 // under one card. `label` is the per-tier caption (null for single-tier
@@ -57,7 +54,7 @@ export interface FerryTierStatus {
   file: string;
   latest: FerryRun | null;
   history: FerryRun[];
-  successRate: number | null; // [0, 1] over completed runs in the window; null if no completed runs
+  successRate: number | null; // [0, 1] over completed runs in the strip; null if no completed runs
   fetchedAt: string;
   error?: string;
 }
@@ -117,14 +114,16 @@ function computeSuccessRate(runs: FerryRun[]): number | null {
 
 export async function fetchTierStatus(
   tier: FerryTier,
-  windowDays: number,
+  runLimit: number,
 ): Promise<FerryTierStatus> {
   const fetchedAt = new Date().toISOString();
-  const cutoff = new Date(Date.now() - windowDays * MS_PER_DAY);
+  // Fetch a fixed number of most-recent runs rather than a time window: the
+  // datakit tiers run on different cadences (tier1/2 daily, tier3 weekly), so
+  // a shared time window leaves the weekly strip nearly empty. A per-tier run
+  // count gives every strip the same number of bars regardless of cadence.
   const params = new URLSearchParams({
-    per_page: String(MAX_WORKFLOW_RUNS_PER_REQUEST),
+    per_page: String(runLimit),
     branch: "main",
-    created: `>=${cutoff.toISOString()}`,
   });
   const url =
     `https://api.github.com/repos/${REPO}/actions/workflows/${tier.file}` +
@@ -150,10 +149,7 @@ export async function fetchTierStatus(
     }
 
     const data = (await res.json()) as GhRunsResponse;
-    const cutoffMs = cutoff.getTime();
-    const history = (data.workflow_runs ?? [])
-      .map(toFerryRun)
-      .filter((run) => Date.parse(run.startedAt) >= cutoffMs);
+    const history = (data.workflow_runs ?? []).slice(0, runLimit).map(toFerryRun);
     return {
       label: tier.label,
       file: tier.file,

--- a/infra/status-page/web/src/api.ts
+++ b/infra/status-page/web/src/api.ts
@@ -36,7 +36,7 @@ export interface FerryGroupStatus {
 }
 
 export interface FerryResponse {
-  windowDays: number;
+  runLimit: number;
   groups: FerryGroupStatus[];
 }
 

--- a/infra/status-page/web/src/components/FerryPanel.tsx
+++ b/infra/status-page/web/src/components/FerryPanel.tsx
@@ -91,7 +91,7 @@ function formatRelative(iso: string): string {
   return `${days}d ago`;
 }
 
-// One tier's run strip: latest-run line, success rate, and the 10-day
+// One tier's run strip: latest-run line, success rate, and the last-N-runs
 // history dots. A single-workflow ferry renders exactly one of these; the
 // datakit ferry stacks three (tier1/2/3) under one card.
 function TierStrip({ tier, showLabel }: { tier: FerryTierStatus; showLabel: boolean }) {
@@ -218,7 +218,7 @@ export function FerryPanel() {
       <div className="mb-3 flex items-baseline justify-between">
         <h2 className="text-xl font-semibold text-slate-200">Ferries</h2>
         <div className="text-right text-xs text-slate-500">
-          {data && <span>last {data.windowDays}d</span>}
+          {data && <span>last {data.runLimit} runs</span>}
           {dataUpdatedAt && (
             <span>
               {data ? " · " : ""}


### PR DESCRIPTION
The datakit ferry tiers run on different cadences: tier1 and tier2 fire daily, tier3 fires weekly (Mondays). The Ferry panel filtered runs to a fixed 10-day window, so the tier3 strip showed only ~2 bars while plenty more runs existed — they just fell outside the window.

Switch the ferry source from a time window to a fixed count of most-recent runs per tier (14). `fetchTierStatus` now takes a `runLimit` instead of `windowDays`: it requests `per_page=14` and drops the `created>=cutoff` query param and the post-fetch cutoff filter. The API field `windowDays` becomes `runLimit`, and the panel footer reads "last 14 runs" instead of "last 10d".

This applies to all three ferries (Canary, CW, Datakit), so every tier strip now shows the same number of bars regardless of cadence.