### PR TITLE
[iris] Add blog-metrics pipeline (TPU usage, users, FLOPs over time)

### DIFF
--- a/lib/iris/scripts/blog_metrics/.gitignore
+++ b/lib/iris/scripts/blog_metrics/.gitignore
@@ -1,0 +1,6 @@
+# All pipeline outputs are reproducible from the scripts, so none are committed:
+#   data/raw/    bulk-copied finelog parquet + W&B cache (multi-GB) — `pipeline.py fetch`
+#   data/daily/  per-day rollup CSVs — `pipeline.py extract`
+#   data/charts/ rendered SVG/PNG — `pipeline.py charts`
+data/
+*.log

--- a/lib/iris/scripts/blog_metrics/README.md
+++ b/lib/iris/scripts/blog_metrics/README.md
@@ -110,7 +110,7 @@ headline and coverage separately, and the chart plots on-active MFU only.
 
 Run from `lib/iris`. `extract` uses the iris env (duckdb is already a dep);
 `fetch` additionally needs `wandb` (and `WANDB_API_KEY`), `charts` needs
-matplotlib.
+`seaborn` (which pulls in matplotlib).
 
 ```bash
 # 1. Mirror iris.worker + iris.task parquet (~10 GB) + pull W&B run history
@@ -121,10 +121,10 @@ uv run --with wandb python scripts/blog_metrics/pipeline.py fetch
 uv run python scripts/blog_metrics/pipeline.py extract
 
 # 3. Render charts.
-uv run --with matplotlib python scripts/blog_metrics/pipeline.py charts
+uv run --with seaborn python scripts/blog_metrics/pipeline.py charts
 
 # …or all three:
-uv run --with wandb --with matplotlib python scripts/blog_metrics/pipeline.py all
+uv run --with wandb --with seaborn python scripts/blog_metrics/pipeline.py all
 ```
 
 Pass `--no-wandb` to skip the W&B pull (Iris-only charts), or `--force` to
@@ -158,7 +158,8 @@ uv run python scripts/blog_metrics/pipeline.py fetch --with-controller
 `data/charts/` (`.svg` for the blog, `.png` for preview): `accelerators_chips`,
 `flops_pflops`, `users`, `tasks`, `fleet_utilization` (occupancy: busy vs idle
 chips), `preemptible` (preemptible non-v4 vs reserved v4 capacity), `accelerators_by_region`,
-`intraday_regions` (within-day cross-region migration for the candidate day),
+`intraday_regions` + `intraday_regions_share` (within-day cross-region migration
+for the candidate day, absolute and share-of-total),
 `overview`, `compute_history` (2024→now, + cumulative), `calibration`. Only the
 wide `compute_history` annotates the `config.MILESTONES`; the cramped
 Iris-window charts omit them.

--- a/lib/iris/scripts/blog_metrics/README.md
+++ b/lib/iris/scripts/blog_metrics/README.md
@@ -147,16 +147,18 @@ uv run python scripts/blog_metrics/pipeline.py fetch --with-controller
 - `accelerators_daily.csv` — total chips / workers / PFLOP/s / running tasks (mean + peak).
 - `accelerators_by_family_daily.csv` — mean chips / PFLOP/s / workers per TPU family.
 - `accelerators_by_region_daily.csv` — mean chips per GCP region.
+- `utilization_daily.csv` — fleet occupancy: mean busy vs idle chips and the busy fraction (chips running ≥1 task / chips provisioned). Allocation, not efficiency — the MFU side is `calibration_daily.csv`.
 - `users_daily.csv` — active users (raw + human), distinct tasks run.
 - `iris_capacity_daily.csv` — provisioned device-hours + peak-capacity FLOPs (calibration denominator).
 - `wandb_compute_daily.csv` / `..._by_backend_daily.csv` — realized device-hours + FLOPs back to 2024.
-- `calibration_daily.csv` — overlap-window coverage + effective MFU.
+- `calibration_daily.csv` — June-onward coverage + on-active MFU (all-on-iris window).
 - `submissions_daily.csv` — only with `--with-controller`.
 
 `data/charts/` (`.svg` for the blog, `.png` for preview): `accelerators_chips`,
-`flops_pflops`, `users`, `tasks`, `accelerators_by_region`, `overview`,
-`compute_history` (2024→now, + cumulative), `calibration`. Time-axis charts
-annotate the `config.MILESTONES` that fall inside the window.
+`flops_pflops`, `users`, `tasks`, `fleet_utilization` (occupancy: busy vs idle
+chips), `accelerators_by_region`, `overview`, `compute_history` (2024→now, +
+cumulative), `calibration`. Time-axis charts annotate the `config.MILESTONES`
+that fall inside the window.
 
 ## Editing
 

--- a/lib/iris/scripts/blog_metrics/README.md
+++ b/lib/iris/scripts/blog_metrics/README.md
@@ -156,9 +156,14 @@ uv run python scripts/blog_metrics/pipeline.py fetch --with-controller
 
 `data/charts/` (`.svg` for the blog, `.png` for preview): `accelerators_chips`,
 `flops_pflops`, `users`, `tasks`, `fleet_utilization` (occupancy: busy vs idle
-chips), `accelerators_by_region`, `overview`, `compute_history` (2024→now, +
-cumulative), `calibration`. Time-axis charts annotate the `config.MILESTONES`
-that fall inside the window.
+chips), `preemptible` (preemptible non-v4 vs reserved v4 capacity), `accelerators_by_region`,
+`overview`, `compute_history` (2024→now, + cumulative), `calibration`. Time-axis
+charts annotate the `config.MILESTONES` that fall inside the window.
+
+The `preemptible` chart needs the real per-device generation, which only the
+iris structured data carries (~May 6 on) — W&B logs `num_devices` but not the
+TPU type, so the v4-vs-non-v4 split **cannot** be reconstructed for the pre-iris
+(Jan–Apr) history.
 
 ## Editing
 

--- a/lib/iris/scripts/blog_metrics/README.md
+++ b/lib/iris/scripts/blog_metrics/README.md
@@ -57,12 +57,29 @@ export in this project, so neither extends the structured charts.
 
 The **W&B-derived** compute charts reach back to **~2024-04**, covering the
 pre-Iris (Ray-era) history. They measure *realized training compute* from runs
-that logged to W&B (`6 * parameter_count * total_tokens`), which:
+that logged to W&B as `6 * parameter_count * total_tokens`, **capped at each
+run's physical hardware capacity** (`num_devices * runtime * peak * mfu`,
+`config.REALIZED_FLOPS_CEILING_*`). The cap matters a lot:
 
-- covers training + eval runs but **misses non-W&B work** (data/crawl jobs), so
-  it is a compute-usage *proxy*, not the whole cluster;
-- over-counts eval/inference (they do ~2ND, not 6ND);
-- needs no device-type lookup (FLOPs come straight from N and D).
+- W&B's `throughput/total_tokens` (D) is a **cumulative counter that resumed and
+  cooldown runs inherit** from their parent. Uncapped, `6*N*D` counts a flagship
+  lineage many times over — a 1-hour 32B cooldown re-reports the parent's ~6T
+  tokens, so naive `6*N*D` charges it ~1e24 FLOPs (an implied **>1000x MFU**).
+  Summed over all runs that was ~47e24 FLOPs — physically impossible against a
+  fleet that peaked at 2048 chips.
+- Capping each run at the most its *own* `num_devices * runtime` could deliver
+  bounds the corrupted runs at hardware reality while leaving honest runs (whose
+  `6*N*D` is already below the ceiling) at their exact value. The corrected total
+  is **~3e24 FLOPs** — a few final-runs-worth. Because the bound uses each run's
+  own device count, it honors a fleet whose size varied over time.
+- It still **misses non-W&B work** (data/crawl jobs) and projects that don't log
+  token counts, so it is a compute-usage *proxy*, not the whole cluster.
+
+Projects pulled: the flagship `marin` project plus the device-bearing sibling
+projects that log N and D — the MoE training projects (`dial_moe`, `marin_moe`)
+and the two largest optimizer sweeps (`optimizer-scaling`, `Hyperball`). Eval /
+post-training projects log devices but no token counts, so they can't form
+`6*N*D` and are omitted (`config.WANDB_PROJECTS`).
 
 ### Calibration
 

--- a/lib/iris/scripts/blog_metrics/README.md
+++ b/lib/iris/scripts/blog_metrics/README.md
@@ -147,6 +147,7 @@ uv run python scripts/blog_metrics/pipeline.py fetch --with-controller
 - `accelerators_daily.csv` — total chips / workers / PFLOP/s / running tasks (mean + peak).
 - `accelerators_by_family_daily.csv` — mean chips / PFLOP/s / workers per TPU family.
 - `accelerators_by_region_daily.csv` — mean chips per GCP region.
+- `intraday_regions.csv` — concurrent chips per region at fine (30-min) buckets for `config.INTRADAY_CANDIDATE_DAY`, to show within-day cross-region migration.
 - `utilization_daily.csv` — fleet occupancy: mean busy vs idle chips and the busy fraction (chips running ≥1 task / chips provisioned). Allocation, not efficiency — the MFU side is `calibration_daily.csv`.
 - `users_daily.csv` — active users (raw + human), distinct tasks run.
 - `iris_capacity_daily.csv` — provisioned device-hours + peak-capacity FLOPs (calibration denominator).
@@ -157,8 +158,10 @@ uv run python scripts/blog_metrics/pipeline.py fetch --with-controller
 `data/charts/` (`.svg` for the blog, `.png` for preview): `accelerators_chips`,
 `flops_pflops`, `users`, `tasks`, `fleet_utilization` (occupancy: busy vs idle
 chips), `preemptible` (preemptible non-v4 vs reserved v4 capacity), `accelerators_by_region`,
-`overview`, `compute_history` (2024→now, + cumulative), `calibration`. Time-axis
-charts annotate the `config.MILESTONES` that fall inside the window.
+`intraday_regions` (within-day cross-region migration for the candidate day),
+`overview`, `compute_history` (2024→now, + cumulative), `calibration`. Only the
+wide `compute_history` annotates the `config.MILESTONES`; the cramped
+Iris-window charts omit them.
 
 The `preemptible` chart needs the real per-device generation, which only the
 iris structured data carries (~May 6 on) — W&B logs `num_devices` but not the

--- a/lib/iris/scripts/blog_metrics/README.md
+++ b/lib/iris/scripts/blog_metrics/README.md
@@ -1,0 +1,133 @@
+# Iris blog metrics pipeline
+
+Reconstructs **TPU usage, active users, running tasks, and aggregate FLOPS over
+time** from the Iris cluster's finelog archives, for the Marin blog post.
+
+It is a three-step pipeline with on-disk artifacts between steps, so you can
+re-run a later step (tweak a metric, restyle a chart) without redoing the
+expensive fetch.
+
+```
+fetch    ──>  data/raw/      (multi-GB parquet + W&B cache)
+extract  ──>  data/daily/    (small per-day CSVs)
+charts   ──>  data/charts/   (SVG + PNG)
+```
+
+All of `data/` is gitignored — every artifact is reproducible from the scripts,
+so nothing here is committed. Re-run the relevant step to regenerate.
+
+## Data sources
+
+Everything comes from the finelog `marin` deployment, archived at
+`gs://marin-us-central2/finelog/marin`:
+
+| Source | What we use it for |
+|---|---|
+| `iris.worker` | One row per worker heartbeat with `device_variant`, `running_task_count`, `zone`. Drives accelerators, FLOPS, concurrent tasks, regions. |
+| `iris.task` | One row per task-attempt resource update; `task_id` is `/<user>/<job>/.../<idx>`, so the first path component gives the **submitting user**. Drives active users + distinct tasks. |
+| `log` / `/system/controller` | The controller's audit lines (`event=job_submitted ...`). *Optional* — only needed for submission/demand series. The namespace is ~33 GB; fetching it is the slow path. |
+| **W&B** `marin-community/marin` | One row per run (`num_devices`, `_runtime`, `parameter_count`, `throughput/total_tokens`, `backend`). The **only source reaching before Iris** (back to ~2024-04). Drives the long-history compute charts + calibration. |
+
+**FLOPS** are computed from the slice `device_variant` (e.g. `v5p-32`):
+`get_tpu_topology(variant).chips_per_vm` gives chips per worker VM, multiplied by
+the peak bf16 FLOP/s per chip vendored from
+`lib/fray/src/fray/device_flops.py` into `config.FAMILY_FLOPS_BF16`. This is
+**provisioned (peak) capacity**, not realized utilization — `iris.task`'s
+`accelerator_util_pct` is null across this window, so realized MFU is not
+available here.
+
+### Concurrency model
+
+Heartbeats are dense and workers churn (preemption mints new worker ids), so raw
+"distinct worker ids per day" overcounts badly. Instead each heartbeat marks its
+VM **present in a 10-minute bucket**; one present worker contributes
+`chips_per_vm` chips. Per day we report:
+
+- **mean** = time-weighted average over the day's buckets (idle buckets count as
+  zero), additive across families/regions so stacks are honest;
+- **peak** = the single busiest bucket.
+
+## Data window & history
+
+The **Iris structured** charts (accelerators, users, tasks, regions) only exist
+from **~2026-05-06** onward — the finelog Rust store was bootstrapped then and
+earlier `iris.*` data was not carried over. The controller `log` namespace is
+retention-capped only ~1 week earlier (~2026-04-29), and GCP has no billing
+export in this project, so neither extends the structured charts.
+
+The **W&B-derived** compute charts reach back to **~2024-04**, covering the
+pre-Iris (Ray-era) history. They measure *realized training compute* from runs
+that logged to W&B (`6 * parameter_count * total_tokens`), which:
+
+- covers training + eval runs but **misses non-W&B work** (data/crawl jobs), so
+  it is a compute-usage *proxy*, not the whole cluster;
+- over-counts eval/inference (they do ~2ND, not 6ND);
+- needs no device-type lookup (FLOPs come straight from N and D).
+
+### Calibration
+
+In the **overlap** (from `CALIBRATION_START`), the W&B realized series is
+checked against the Iris-provisioned capacity (`calibration_daily.csv`):
+
+- **coverage** = W&B-TPU device-hours / Iris provisioned device-hours — what
+  fraction of the standing fleet the W&B-logged jobs occupied;
+- **effective MFU** = W&B realized FLOPs / Iris peak-capacity FLOPs — realized
+  vs theoretical peak. The extract step logs both headline ratios.
+
+## Running
+
+Run from `lib/iris`. `extract` uses the iris env (duckdb is already a dep);
+`fetch` additionally needs `wandb` (and `WANDB_API_KEY`), `charts` needs
+matplotlib.
+
+```bash
+# 1. Mirror iris.worker + iris.task parquet (~10 GB) + pull W&B run history
+#    (~tens of thousands of runs, minutes; cached, so re-runs skip it).
+uv run --with wandb python scripts/blog_metrics/pipeline.py fetch
+
+# 2. Roll up into per-day CSVs (fast; re-run freely while tweaking metrics).
+uv run python scripts/blog_metrics/pipeline.py extract
+
+# 3. Render charts.
+uv run --with matplotlib python scripts/blog_metrics/pipeline.py charts
+
+# …or all three:
+uv run --with wandb --with matplotlib python scripts/blog_metrics/pipeline.py all
+```
+
+Pass `--no-wandb` to skip the W&B pull (Iris-only charts), or `--force` to
+refresh both caches.
+
+Optional controller-log extraction (slow ~33 GB remote scan), which adds
+`submissions_daily.csv` (jobs/tasks submitted, distinct submitting users):
+
+```bash
+uv run python scripts/blog_metrics/pipeline.py fetch --with-controller
+```
+
+`--data-dir DIR` relocates all artifacts; `--force` makes `fetch` pass
+`rsync -d` to prune local segments dropped remotely.
+
+## Outputs
+
+`data/daily/`:
+
+- `accelerators_daily.csv` — total chips / workers / PFLOP/s / running tasks (mean + peak).
+- `accelerators_by_family_daily.csv` — mean chips / PFLOP/s / workers per TPU family.
+- `accelerators_by_region_daily.csv` — mean chips per GCP region.
+- `users_daily.csv` — active users (raw + human), distinct tasks run.
+- `iris_capacity_daily.csv` — provisioned device-hours + peak-capacity FLOPs (calibration denominator).
+- `wandb_compute_daily.csv` / `..._by_backend_daily.csv` — realized device-hours + FLOPs back to 2024.
+- `calibration_daily.csv` — overlap-window coverage + effective MFU.
+- `submissions_daily.csv` — only with `--with-controller`.
+
+`data/charts/` (`.svg` for the blog, `.png` for preview): `accelerators_chips`,
+`flops_pflops`, `users`, `tasks`, `accelerators_by_region`, `overview`,
+`compute_history` (2024→now, + cumulative), `calibration`. Time-axis charts
+annotate the `config.MILESTONES` that fall inside the window.
+
+## Editing
+
+- **Metrics / definitions** → `extract.py` (DuckDB SQL).
+- **FLOPS table, bucket size, milestones, bot-user filter** → `config.py`.
+- **Chart styling** → `charts.py`.

--- a/lib/iris/scripts/blog_metrics/README.md
+++ b/lib/iris/scripts/blog_metrics/README.md
@@ -83,13 +83,28 @@ post-training projects log devices but no token counts, so they can't form
 
 ### Calibration
 
-In the **overlap** (from `CALIBRATION_START`), the W&B realized series is
-checked against the Iris-provisioned capacity (`calibration_daily.csv`):
+The W&B realized series is checked against the Iris-provisioned capacity over
+the window where **all training actually ran on Iris** (`CALIBRATION_START`,
+June onward). Earlier is apples-to-oranges: April's v4 runs were still on Ray
+(no Iris logs), and in early-bootstrap May some runs ran elsewhere — W&B
+device-hours *exceed* Iris's on May 7–8 (an impossible >100% coverage), which is
+exactly why the window starts in June.
 
-- **coverage** = W&B-TPU device-hours / Iris provisioned device-hours — what
-  fraction of the standing fleet the W&B-logged jobs occupied;
-- **effective MFU** = W&B realized FLOPs / Iris peak-capacity FLOPs — realized
-  vs theoretical peak. The extract step logs both headline ratios.
+Two ratios, kept **separate** because their product is misleading
+(`calibration_daily.csv`):
+
+- **coverage** = W&B-logged-TPU device-hours / Iris device-hours — what fraction
+  of the standing fleet ran W&B-logged *training*. This is well under 100% (~16%
+  in June) because most fleet work is non-training / not-6ND-loggable (data
+  jobs, RL, evals);
+- **on-active MFU** = realized FLOPs per W&B device-hour ÷ fleet peak per
+  device-hour — the efficiency of the logged jobs *while they ran* (~32% in
+  June, steady).
+
+Their product, "effective MFU vs the whole fleet", craters whenever coverage
+dips (the big multi-day MoE runs ended ~May 19, so it falls ~30× into June) even
+though on-active MFU is steady — so we report on-active MFU as the efficiency
+headline and coverage separately, and the chart plots on-active MFU only.
 
 ## Running
 

--- a/lib/iris/scripts/blog_metrics/charts.py
+++ b/lib/iris/scripts/blog_metrics/charts.py
@@ -229,6 +229,42 @@ def chart_regions(daily_dir: str, charts_dir: str) -> None:
     _save(fig, charts_dir, "accelerators_by_region")
 
 
+def chart_fleet_utilization(daily_dir: str, charts_dir: str) -> None:
+    """Fleet occupancy: provisioned TPU chips running a task vs idle, over time.
+
+    The stacked area is the standing fleet split into busy (>=1 task scheduled)
+    and idle chips; the idle band is the "idle accelerator is a waste" gap. The
+    dotted line is occupancy %. This is allocation, not efficiency — a busy chip
+    may still run at low MFU (that is the calibration chart's job).
+    """
+    rows = _load_csv(os.path.join(daily_dir, "utilization_daily.csv"))
+    if not rows:
+        return
+    days = _dates(rows)
+    busy = _floats(rows, "mean_busy_chips")
+    idle = _floats(rows, "mean_idle_chips")
+    total = _floats(rows, "mean_total_chips")
+    occupancy = [100 * v for v in _floats(rows, "occupancy")]
+    overall = 100 * sum(busy) / sum(total) if sum(total) else 0.0
+
+    fig, ax = plt.subplots(figsize=(11, 5))
+    ax.stackplot(days, busy, idle, labels=["running a task", "idle"], colors=["#55A868", "#D9D9D9"], alpha=0.95)
+    ax.set_ylabel("TPU chips (mean concurrent)")
+    ax.set_title(f"Fleet occupancy: {overall:.0f}% of provisioned chip-time was running a task")
+    ax.set_ylim(bottom=0)
+    _style_time_axis(ax)
+    ax.legend(loc="upper left", fontsize=8, frameon=False)
+    _add_milestones(ax, min(days), max(days))
+
+    ax2 = ax.twinx()
+    ax2.plot(days, occupancy, color="0.25", linewidth=1.2, linestyle=":", label="occupancy %")
+    ax2.set_ylabel("occupancy (%)", color="0.25")
+    ax2.tick_params(axis="y", colors="0.25")
+    ax2.set_ylim(0, 100)
+    ax2.spines["top"].set_visible(False)
+    _save(fig, charts_dir, "fleet_utilization")
+
+
 def chart_compute_history(daily_dir: str, charts_dir: str) -> None:
     """Realized training compute over the full W&B history, back to 2024.
 
@@ -360,6 +396,7 @@ def run(paths: config.Paths) -> None:
     chart_flops(paths.daily_dir, paths.charts_dir)
     chart_users(paths.daily_dir, paths.charts_dir)
     chart_tasks(paths.daily_dir, paths.charts_dir)
+    chart_fleet_utilization(paths.daily_dir, paths.charts_dir)
     chart_regions(paths.daily_dir, paths.charts_dir)
     chart_overview(paths.daily_dir, paths.charts_dir)
     if os.path.exists(os.path.join(paths.daily_dir, "wandb_compute_daily.csv")):

--- a/lib/iris/scripts/blog_metrics/charts.py
+++ b/lib/iris/scripts/blog_metrics/charts.py
@@ -224,6 +224,44 @@ def chart_regions(daily_dir: str, charts_dir: str) -> None:
     _save(fig, charts_dir, "accelerators_by_region")
 
 
+def chart_intraday_regions(daily_dir: str, charts_dir: str) -> None:
+    """Within-day compute migration across regions for the candidate day.
+
+    Stacked concurrent chips per region at the fine intraday bucket. On the
+    chosen day preemptible capacity hands off between regions through the day
+    while the reserved pool stays flat — visible as the stack's composition
+    shifting even where its height is roughly steady.
+    """
+    rows = _load_csv(os.path.join(daily_dir, "intraday_regions.csv"))
+    if not rows:
+        return
+    times = sorted({r["bucket"] for r in rows})
+    parsed = [dt.datetime.fromisoformat(t) for t in times]
+    index = {t: i for i, t in enumerate(times)}
+    totals: dict[str, float] = {}
+    series: dict[str, list[float]] = {}
+    for r in rows:
+        region = r["region"] or "(unknown)"
+        series.setdefault(region, [0.0] * len(times))[index[r["bucket"]]] = float(r["chips"])
+        totals[region] = totals.get(region, 0.0) + float(r["chips"])
+    order = sorted(series, key=lambda reg: totals[reg], reverse=True)
+
+    fig, ax = plt.subplots(figsize=(11, 5))
+    ax.stackplot(parsed, *[series[reg] for reg in order], labels=order, alpha=0.9)
+    ax.set_title(f"Intraday compute migration across regions - {parsed[0].date().isoformat()} (UTC)")
+    ax.set_ylabel("TPU chips (concurrent)")
+    ax.set_xlabel("hour of day (UTC)")
+    ax.set_ylim(bottom=0)
+    ax.set_xlim(parsed[0], parsed[-1])
+    ax.xaxis.set_major_locator(mdates.HourLocator(interval=3))
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
+    ax.grid(True, axis="y", linewidth=0.4, alpha=0.4)
+    for spine in ("top", "right"):
+        ax.spines[spine].set_visible(False)
+    ax.legend(loc="upper right", fontsize=8, ncol=3, frameon=False)
+    _save(fig, charts_dir, "intraday_regions")
+
+
 def chart_fleet_utilization(daily_dir: str, charts_dir: str) -> None:
     """Fleet occupancy: provisioned TPU chips running a task vs idle, over time.
 
@@ -437,6 +475,7 @@ def run(paths: config.Paths) -> None:
     chart_fleet_utilization(paths.daily_dir, paths.charts_dir)
     chart_preemptible(paths.daily_dir, paths.charts_dir)
     chart_regions(paths.daily_dir, paths.charts_dir)
+    chart_intraday_regions(paths.daily_dir, paths.charts_dir)
     chart_overview(paths.daily_dir, paths.charts_dir)
     if os.path.exists(os.path.join(paths.daily_dir, "wandb_compute_daily.csv")):
         chart_compute_history(paths.daily_dir, paths.charts_dir)

--- a/lib/iris/scripts/blog_metrics/charts.py
+++ b/lib/iris/scripts/blog_metrics/charts.py
@@ -266,29 +266,46 @@ def chart_compute_history(daily_dir: str, charts_dir: str) -> None:
 
 
 def chart_calibration(daily_dir: str, charts_dir: str) -> None:
-    """Calibrate W&B realized compute vs iris provisioned capacity in the overlap."""
+    """Calibrate W&B realized compute vs iris provisioned capacity (all-on-iris window).
+
+    Primary axis: realized (W&B-logged training) vs provisioned (whole fleet)
+    FLOPs/day — the gap between the lines is the un-logged / non-training work.
+    Secondary axis: **on-active MFU**, the efficiency of the logged jobs while
+    they ran. We deliberately do *not* plot "effective MFU vs total fleet"
+    (realized/capacity): it is on-active MFU times coverage, so it craters
+    whenever coverage dips even though efficiency is steady.
+    """
     rows = _load_csv(os.path.join(daily_dir, "calibration_daily.csv"))
     if not rows:
         return
     days = _dates(rows)
     realized = _floats(rows, "wandb_tpu_realized_flops")
     capacity = _floats(rows, "iris_capacity_flops")
-    mfu = [100 * v for v in _floats(rows, "effective_mfu")]
+    on_active = [100 * v for v in _floats(rows, "on_active_mfu")]
+    # Coverage-weighted headline MFU + mean coverage over the window.
+    realized_sum, capacity_sum = sum(realized), sum(capacity)
+    devhrs = _floats(rows, "wandb_tpu_device_hours")
+    iris_devhrs = _floats(rows, "iris_device_hours")
+    cov_pct = 100 * sum(devhrs) / sum(iris_devhrs) if sum(iris_devhrs) else 0.0
+    mfu_pct = 100 * realized_sum * sum(iris_devhrs) / (capacity_sum * sum(devhrs)) if sum(devhrs) else 0.0
 
     fig, ax = plt.subplots(figsize=(11, 5))
-    ax.plot(days, capacity, color="#8172B3", linewidth=1.6, label="iris provisioned capacity")
-    ax.plot(days, realized, color="#C44E52", linewidth=1.6, label="W&B realized (6*N*D, TPU)")
+    ax.plot(days, capacity, color="#8172B3", linewidth=1.6, label="iris provisioned capacity (whole fleet)")
+    ax.plot(days, realized, color="#C44E52", linewidth=1.6, label="W&B-logged training (on iris)")
     ax.set_yscale("log")
     ax.set_ylabel("FLOPs / day")
-    ax.set_title("Realized vs provisioned compute (Iris x W&B overlap)")
+    ax.set_title(
+        f"Realized vs provisioned compute - W&B-logged training covered {cov_pct:.0f}% "
+        f"of fleet device-hours at {mfu_pct:.0f}% MFU"
+    )
     _style_time_axis(ax)
-    ax.legend(loc="upper left", fontsize=8, frameon=False)
+    ax.legend(loc="lower left", fontsize=8, frameon=False)
 
     ax2 = ax.twinx()
-    ax2.plot(days, mfu, color="0.4", linewidth=1.0, linestyle=":", label="effective MFU")
-    ax2.set_ylabel("effective MFU (%)", color="0.4")
+    ax2.plot(days, on_active, color="0.4", linewidth=1.2, marker="o", markersize=2.5, label="on-active MFU")
+    ax2.set_ylabel("on-active MFU (%)", color="0.4")
     ax2.tick_params(axis="y", colors="0.4")
-    ax2.set_ylim(bottom=0)
+    ax2.set_ylim(0, 100)
     ax2.spines["top"].set_visible(False)
     _save(fig, charts_dir, "calibration")
 

--- a/lib/iris/scripts/blog_metrics/charts.py
+++ b/lib/iris/scripts/blog_metrics/charts.py
@@ -1,0 +1,348 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pipeline step 3: render blog charts from the daily CSVs.
+
+Reads ``<data_dir>/daily/*.csv`` and writes SVG + PNG charts to
+``<data_dir>/charts``. Uses matplotlib only (no pandas); run with
+``uv run --with matplotlib``. Time-axis charts overlay the milestones from
+``config.MILESTONES`` that fall inside the data window.
+"""
+
+from __future__ import annotations
+
+import csv
+import datetime as dt
+import logging
+import os
+
+import matplotlib as mpl
+
+mpl.use("Agg")  # headless backend; must precede pyplot import
+import config
+import matplotlib.dates as mdates
+import matplotlib.pyplot as plt
+
+logger = logging.getLogger(__name__)
+
+# Generation-ordered family palette so stacks/legends stay stable across charts.
+FAMILY_ORDER = ["v4", "v5e", "v5p", "v6e", "v3"]
+FAMILY_COLOR = {
+    "v4": "#4C72B0",
+    "v5e": "#55A868",
+    "v5p": "#C44E52",
+    "v6e": "#8172B3",
+    "v3": "#CCB974",
+}
+
+
+def _load_csv(path: str) -> list[dict[str, str]]:
+    with open(path, newline="") as f:
+        return list(csv.DictReader(f))
+
+
+def _dates(rows: list[dict[str, str]]) -> list[dt.date]:
+    return [dt.date.fromisoformat(r["day"]) for r in rows]
+
+
+def _floats(rows: list[dict[str, str]], col: str) -> list[float]:
+    return [float(r[col]) if r[col] not in ("", None) else 0.0 for r in rows]
+
+
+def _save(fig: plt.Figure, charts_dir: str, name: str) -> None:
+    for ext in ("svg", "png"):
+        out = os.path.join(charts_dir, f"{name}.{ext}")
+        fig.savefig(out, bbox_inches="tight", dpi=150)
+    plt.close(fig)
+    logger.info("wrote %s.{svg,png}", os.path.join(charts_dir, name))
+
+
+def _add_milestones(ax: plt.Axes, day_min: dt.date, day_max: dt.date) -> None:
+    """Draw vertical markers for milestones inside [day_min, day_max].
+
+    Labels run vertically just inside the top of the plot so they never collide
+    with the title or each other.
+    """
+    top = ax.get_ylim()[1]
+    for iso, label in config.MILESTONES:
+        day = dt.date.fromisoformat(iso)
+        if not (day_min <= day <= day_max):
+            continue
+        ax.axvline(day, color="0.35", linestyle="--", linewidth=0.9, alpha=0.7, zorder=1)
+        ax.text(
+            day,
+            top * 0.98,
+            f" {label}",
+            rotation=90,
+            fontsize=6.5,
+            color="0.3",
+            ha="right",
+            va="top",
+            rotation_mode="anchor",
+            zorder=3,
+        )
+
+
+def _style_time_axis(ax: plt.Axes, *, long_range: bool = False) -> None:
+    if long_range:
+        ax.xaxis.set_major_locator(mdates.AutoDateLocator(minticks=6, maxticks=12))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %Y"))
+    else:
+        ax.xaxis.set_major_locator(mdates.WeekdayLocator(byweekday=mdates.MO))
+        ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %-d"))
+    ax.grid(True, axis="y", linewidth=0.4, alpha=0.4)
+    for spine in ("top", "right"):
+        ax.spines[spine].set_visible(False)
+
+
+def _cumulative(values: list[float]) -> list[float]:
+    out, acc = [], 0.0
+    for v in values:
+        acc += v
+        out.append(acc)
+    return out
+
+
+def _pivot_family(rows: list[dict[str, str]], value_col: str) -> tuple[list[dt.date], dict[str, list[float]]]:
+    """Pivot the long by-family CSV into per-family series aligned on a shared date axis."""
+    days = sorted({dt.date.fromisoformat(r["day"]) for r in rows})
+    index = {d: i for i, d in enumerate(days)}
+    series: dict[str, list[float]] = {}
+    for r in rows:
+        fam = r["family"]
+        series.setdefault(fam, [0.0] * len(days))[index[dt.date.fromisoformat(r["day"])]] = float(r[value_col])
+    ordered = {fam: series[fam] for fam in FAMILY_ORDER if fam in series}
+    for fam in series:  # any family not in FAMILY_ORDER, appended at the end
+        ordered.setdefault(fam, series[fam])
+    return days, ordered
+
+
+def _stacked_family(
+    ax: plt.Axes,
+    days: list[dt.date],
+    series: dict[str, list[float]],
+    peak_days: list[dt.date] | None = None,
+    peak_values: list[float] | None = None,
+) -> None:
+    labels = list(series.keys())
+    ax.stackplot(
+        days,
+        *[series[f] for f in labels],
+        labels=labels,
+        colors=[FAMILY_COLOR.get(f, "0.6") for f in labels],
+        alpha=0.9,
+    )
+    if peak_values is not None and peak_days is not None:
+        ax.plot(peak_days, peak_values, color="0.15", linewidth=1.0, label="peak (all families)")
+
+
+def chart_accelerators(daily_dir: str, charts_dir: str) -> None:
+    fam_rows = _load_csv(os.path.join(daily_dir, "accelerators_by_family_daily.csv"))
+    tot_rows = _load_csv(os.path.join(daily_dir, "accelerators_daily.csv"))
+    days, series = _pivot_family(fam_rows, "mean_chips")
+    tot_days, peak = _dates(tot_rows), _floats(tot_rows, "peak_chips")
+
+    fig, ax = plt.subplots(figsize=(11, 5))
+    _stacked_family(ax, days, series, tot_days, peak)
+    ax.set_title("Active TPU accelerators (chips) — Iris cluster")
+    ax.set_ylabel("chips (mean concurrent / day)")
+    _style_time_axis(ax)
+    ax.set_ylim(bottom=0)
+    _add_milestones(ax, min(days), max(days))
+    ax.legend(loc="upper left", fontsize=8, ncol=3, frameon=False)
+    _save(fig, charts_dir, "accelerators_chips")
+
+
+def chart_flops(daily_dir: str, charts_dir: str) -> None:
+    fam_rows = _load_csv(os.path.join(daily_dir, "accelerators_by_family_daily.csv"))
+    tot_rows = _load_csv(os.path.join(daily_dir, "accelerators_daily.csv"))
+    days, series = _pivot_family(fam_rows, "mean_pflops")
+    tot_days, peak = _dates(tot_rows), _floats(tot_rows, "peak_pflops")
+
+    fig, ax = plt.subplots(figsize=(11, 5))
+    _stacked_family(ax, days, series, tot_days, peak)
+    ax.set_title("Peak bf16 compute capacity (PFLOP/s) — Iris cluster")
+    ax.set_ylabel("PFLOP/s (mean concurrent / day)")
+    _style_time_axis(ax)
+    ax.set_ylim(bottom=0)
+    _add_milestones(ax, min(days), max(days))
+    ax.legend(loc="upper left", fontsize=8, ncol=3, frameon=False)
+    _save(fig, charts_dir, "flops_pflops")
+
+
+def chart_users(daily_dir: str, charts_dir: str) -> None:
+    rows = _load_csv(os.path.join(daily_dir, "users_daily.csv"))
+    days = _dates(rows)
+    fig, ax = plt.subplots(figsize=(11, 4.5))
+    ax.plot(days, _floats(rows, "active_users_human"), color="#4C72B0", linewidth=1.8, marker="o", markersize=3)
+    ax.set_title("Active users per day (ran >=1 task)")
+    ax.set_ylabel("distinct users")
+    _style_time_axis(ax)
+    ax.set_ylim(bottom=0)
+    _add_milestones(ax, min(days), max(days))
+    _save(fig, charts_dir, "users")
+
+
+def chart_tasks(daily_dir: str, charts_dir: str) -> None:
+    rows = _load_csv(os.path.join(daily_dir, "accelerators_daily.csv"))
+    user_rows = _load_csv(os.path.join(daily_dir, "users_daily.csv"))
+    days = _dates(rows)
+    fig, ax = plt.subplots(figsize=(11, 4.5))
+    ax.plot(days, _floats(rows, "mean_tasks"), color="#55A868", linewidth=1.8, label="mean concurrent")
+    ax.plot(days, _floats(rows, "peak_tasks"), color="#C44E52", linewidth=1.0, alpha=0.8, label="peak concurrent")
+    ax.set_title("Running tasks — Iris cluster")
+    ax.set_ylabel("concurrent tasks")
+    _style_time_axis(ax)
+    ax.set_ylim(bottom=0)
+    _add_milestones(ax, min(days), max(days))
+
+    ax2 = ax.twinx()
+    ax2.plot(_dates(user_rows), _floats(user_rows, "active_tasks_ran"), color="0.5", linewidth=1.0, linestyle=":")
+    ax2.set_ylabel("distinct tasks run / day (dotted)", color="0.4")
+    ax2.tick_params(axis="y", colors="0.4")
+    ax2.spines["top"].set_visible(False)
+    ax.legend(loc="upper left", fontsize=8, frameon=False)
+    _save(fig, charts_dir, "tasks")
+
+
+def chart_regions(daily_dir: str, charts_dir: str) -> None:
+    rows = _load_csv(os.path.join(daily_dir, "accelerators_by_region_daily.csv"))
+    days = sorted({dt.date.fromisoformat(r["day"]) for r in rows})
+    index = {d: i for i, d in enumerate(days)}
+    # Order regions by total footprint so the largest sit at the bottom of the stack.
+    totals: dict[str, float] = {}
+    series: dict[str, list[float]] = {}
+    for r in rows:
+        region = r["region"] or "(unknown)"
+        series.setdefault(region, [0.0] * len(days))[index[dt.date.fromisoformat(r["day"])]] = float(r["mean_chips"])
+        totals[region] = totals.get(region, 0.0) + float(r["mean_chips"])
+    order = sorted(series, key=lambda reg: totals[reg], reverse=True)
+
+    fig, ax = plt.subplots(figsize=(11, 5))
+    ax.stackplot(days, *[series[reg] for reg in order], labels=order, alpha=0.9)
+    ax.set_title("Active TPU chips by region — Iris cluster")
+    ax.set_ylabel("chips (mean concurrent / day)")
+    _style_time_axis(ax)
+    ax.set_ylim(bottom=0)
+    _add_milestones(ax, min(days), max(days))
+    ax.legend(loc="upper left", fontsize=8, ncol=3, frameon=False)
+    _save(fig, charts_dir, "accelerators_by_region")
+
+
+def chart_compute_history(daily_dir: str, charts_dir: str) -> None:
+    """Realized training compute (6*N*D) over the full W&B history, back to 2024.
+
+    Top: training FLOPs/day (log) with the Iris stats window shaded. Bottom:
+    cumulative FLOPs in units of 1e24 (the blog's final-run scale).
+    """
+    rows = _load_csv(os.path.join(daily_dir, "wandb_compute_daily.csv"))
+    days = _dates(rows)
+    flops = _floats(rows, "realized_flops")
+    flops_tpu = _floats(rows, "realized_flops_tpu")
+    cumulative = [c / 1e24 for c in _cumulative(flops)]
+    iris_start = dt.date.fromisoformat(config.CALIBRATION_START)
+
+    fig, (ax_top, ax_bot) = plt.subplots(2, 1, figsize=(12, 7), sharex=True)
+    ax_top.plot(days, flops, color="#4C72B0", linewidth=1.2, label="all backends")
+    ax_top.plot(days, flops_tpu, color="#C44E52", linewidth=1.0, alpha=0.8, label="TPU only")
+    ax_top.set_yscale("log")
+    ax_top.set_ylabel("training FLOPs / day (6*N*D)")
+    ax_top.set_title("Realized training compute over time - W&B run history")
+    ax_top.axvspan(iris_start, max(days), color="0.85", alpha=0.5, zorder=0, label="Iris stats window")
+    ax_top.legend(loc="upper left", fontsize=8, frameon=False)
+    _add_milestones(ax_top, min(days), max(days))
+
+    ax_bot.fill_between(days, cumulative, color="#55A868", alpha=0.85)
+    ax_bot.set_ylabel(r"cumulative FLOPs ($\times 10^{24}$)")
+    ax_bot.set_title(rf"Cumulative realized compute: {cumulative[-1]:.2f}$\times 10^{{24}}$ FLOPs to date")
+
+    for ax in (ax_top, ax_bot):
+        _style_time_axis(ax, long_range=True)
+    ax_bot.set_ylim(bottom=0)
+    fig.tight_layout()
+    _save(fig, charts_dir, "compute_history")
+
+
+def chart_calibration(daily_dir: str, charts_dir: str) -> None:
+    """Calibrate W&B realized compute vs iris provisioned capacity in the overlap."""
+    rows = _load_csv(os.path.join(daily_dir, "calibration_daily.csv"))
+    if not rows:
+        return
+    days = _dates(rows)
+    realized = _floats(rows, "wandb_tpu_realized_flops")
+    capacity = _floats(rows, "iris_capacity_flops")
+    mfu = [100 * v for v in _floats(rows, "effective_mfu")]
+
+    fig, ax = plt.subplots(figsize=(11, 5))
+    ax.plot(days, capacity, color="#8172B3", linewidth=1.6, label="iris provisioned capacity")
+    ax.plot(days, realized, color="#C44E52", linewidth=1.6, label="W&B realized (6*N*D, TPU)")
+    ax.set_yscale("log")
+    ax.set_ylabel("FLOPs / day")
+    ax.set_title("Realized vs provisioned compute (Iris x W&B overlap)")
+    _style_time_axis(ax)
+    ax.legend(loc="upper left", fontsize=8, frameon=False)
+
+    ax2 = ax.twinx()
+    ax2.plot(days, mfu, color="0.4", linewidth=1.0, linestyle=":", label="effective MFU")
+    ax2.set_ylabel("effective MFU (%)", color="0.4")
+    ax2.tick_params(axis="y", colors="0.4")
+    ax2.set_ylim(bottom=0)
+    ax2.spines["top"].set_visible(False)
+    _save(fig, charts_dir, "calibration")
+
+
+def chart_overview(daily_dir: str, charts_dir: str) -> None:
+    """One 2x2 figure tying the four series together for an at-a-glance summary."""
+    fam_rows = _load_csv(os.path.join(daily_dir, "accelerators_by_family_daily.csv"))
+    tot_rows = _load_csv(os.path.join(daily_dir, "accelerators_daily.csv"))
+    user_rows = _load_csv(os.path.join(daily_dir, "users_daily.csv"))
+    tot_days = _dates(tot_rows)
+    day_min, day_max = min(tot_days), max(tot_days)
+
+    fig, axes = plt.subplots(2, 2, figsize=(15, 8.5))
+
+    days, chips = _pivot_family(fam_rows, "mean_chips")
+    _stacked_family(axes[0][0], days, chips, tot_days, _floats(tot_rows, "peak_chips"))
+    axes[0][0].set_title("Active TPU chips")
+    axes[0][0].set_ylabel("chips (mean/day)")
+    axes[0][0].legend(loc="upper left", fontsize=7, ncol=3, frameon=False)
+
+    _, pflops = _pivot_family(fam_rows, "mean_pflops")
+    _stacked_family(axes[0][1], days, pflops, tot_days, _floats(tot_rows, "peak_pflops"))
+    axes[0][1].set_title("Peak bf16 capacity")
+    axes[0][1].set_ylabel("PFLOP/s (mean/day)")
+
+    axes[1][0].plot(
+        _dates(user_rows), _floats(user_rows, "active_users_human"), color="#4C72B0", marker="o", markersize=3
+    )
+    axes[1][0].set_title("Active users/day")
+    axes[1][0].set_ylabel("distinct users")
+
+    axes[1][1].plot(tot_days, _floats(tot_rows, "mean_tasks"), color="#55A868", label="mean")
+    axes[1][1].plot(tot_days, _floats(tot_rows, "peak_tasks"), color="#C44E52", alpha=0.8, linewidth=1.0, label="peak")
+    axes[1][1].set_title("Concurrent running tasks")
+    axes[1][1].set_ylabel("tasks")
+    axes[1][1].legend(loc="upper left", fontsize=7, frameon=False)
+
+    for ax in axes.flat:
+        _style_time_axis(ax)
+        ax.set_ylim(bottom=0)
+        _add_milestones(ax, day_min, day_max)
+
+    fig.suptitle("Iris cluster usage — Marin", fontsize=14, y=0.98)
+    fig.tight_layout(rect=(0, 0, 1, 0.96))
+    _save(fig, charts_dir, "overview")
+
+
+def run(paths: config.Paths) -> None:
+    """Render every chart from the daily CSVs."""
+    os.makedirs(paths.charts_dir, exist_ok=True)
+    chart_accelerators(paths.daily_dir, paths.charts_dir)
+    chart_flops(paths.daily_dir, paths.charts_dir)
+    chart_users(paths.daily_dir, paths.charts_dir)
+    chart_tasks(paths.daily_dir, paths.charts_dir)
+    chart_regions(paths.daily_dir, paths.charts_dir)
+    chart_overview(paths.daily_dir, paths.charts_dir)
+    if os.path.exists(os.path.join(paths.daily_dir, "wandb_compute_daily.csv")):
+        chart_compute_history(paths.daily_dir, paths.charts_dir)
+        chart_calibration(paths.daily_dir, paths.charts_dir)

--- a/lib/iris/scripts/blog_metrics/charts.py
+++ b/lib/iris/scripts/blog_metrics/charts.py
@@ -230,10 +230,12 @@ def chart_regions(daily_dir: str, charts_dir: str) -> None:
 
 
 def chart_compute_history(daily_dir: str, charts_dir: str) -> None:
-    """Realized training compute (6*N*D) over the full W&B history, back to 2024.
+    """Realized training compute over the full W&B history, back to 2024.
 
-    Top: training FLOPs/day (log) with the Iris stats window shaded. Bottom:
-    cumulative FLOPs in units of 1e24 (the blog's final-run scale).
+    FLOPs are ``6*N*D`` capped at each run's physical hardware capacity (see
+    ``config.REALIZED_FLOPS_CEILING_*``). Top: FLOPs/day (log) with the Iris
+    stats window shaded. Bottom: cumulative FLOPs in units of 1e24 (the blog's
+    final-run scale).
     """
     rows = _load_csv(os.path.join(daily_dir, "wandb_compute_daily.csv"))
     days = _dates(rows)
@@ -246,7 +248,7 @@ def chart_compute_history(daily_dir: str, charts_dir: str) -> None:
     ax_top.plot(days, flops, color="#4C72B0", linewidth=1.2, label="all backends")
     ax_top.plot(days, flops_tpu, color="#C44E52", linewidth=1.0, alpha=0.8, label="TPU only")
     ax_top.set_yscale("log")
-    ax_top.set_ylabel("training FLOPs / day (6*N*D)")
+    ax_top.set_ylabel("training FLOPs / day (capped 6*N*D)")
     ax_top.set_title("Realized training compute over time - W&B run history")
     ax_top.axvspan(iris_start, max(days), color="0.85", alpha=0.5, zorder=0, label="Iris stats window")
     ax_top.legend(loc="upper left", fontsize=8, frameon=False)

--- a/lib/iris/scripts/blog_metrics/charts.py
+++ b/lib/iris/scripts/blog_metrics/charts.py
@@ -148,7 +148,6 @@ def chart_accelerators(daily_dir: str, charts_dir: str) -> None:
     ax.set_ylabel("chips (mean concurrent / day)")
     _style_time_axis(ax)
     ax.set_ylim(bottom=0)
-    _add_milestones(ax, min(days), max(days))
     ax.legend(loc="upper left", fontsize=8, ncol=3, frameon=False)
     _save(fig, charts_dir, "accelerators_chips")
 
@@ -165,7 +164,6 @@ def chart_flops(daily_dir: str, charts_dir: str) -> None:
     ax.set_ylabel("PFLOP/s (mean concurrent / day)")
     _style_time_axis(ax)
     ax.set_ylim(bottom=0)
-    _add_milestones(ax, min(days), max(days))
     ax.legend(loc="upper left", fontsize=8, ncol=3, frameon=False)
     _save(fig, charts_dir, "flops_pflops")
 
@@ -179,7 +177,6 @@ def chart_users(daily_dir: str, charts_dir: str) -> None:
     ax.set_ylabel("distinct users")
     _style_time_axis(ax)
     ax.set_ylim(bottom=0)
-    _add_milestones(ax, min(days), max(days))
     _save(fig, charts_dir, "users")
 
 
@@ -194,7 +191,6 @@ def chart_tasks(daily_dir: str, charts_dir: str) -> None:
     ax.set_ylabel("concurrent tasks")
     _style_time_axis(ax)
     ax.set_ylim(bottom=0)
-    _add_milestones(ax, min(days), max(days))
 
     ax2 = ax.twinx()
     ax2.plot(_dates(user_rows), _floats(user_rows, "active_tasks_ran"), color="0.5", linewidth=1.0, linestyle=":")
@@ -224,7 +220,6 @@ def chart_regions(daily_dir: str, charts_dir: str) -> None:
     ax.set_ylabel("chips (mean concurrent / day)")
     _style_time_axis(ax)
     ax.set_ylim(bottom=0)
-    _add_milestones(ax, min(days), max(days))
     ax.legend(loc="upper left", fontsize=8, ncol=3, frameon=False)
     _save(fig, charts_dir, "accelerators_by_region")
 
@@ -254,7 +249,6 @@ def chart_fleet_utilization(daily_dir: str, charts_dir: str) -> None:
     ax.set_ylim(bottom=0)
     _style_time_axis(ax)
     ax.legend(loc="upper left", fontsize=8, frameon=False)
-    _add_milestones(ax, min(days), max(days))
 
     ax2 = ax.twinx()
     ax2.plot(days, occupancy, color="0.25", linewidth=1.2, linestyle=":", label="occupancy %")
@@ -301,7 +295,6 @@ def chart_preemptible(daily_dir: str, charts_dir: str) -> None:
     ax.set_ylim(bottom=0)
     _style_time_axis(ax)
     ax.legend(loc="upper left", fontsize=8, frameon=False)
-    _add_milestones(ax, min(days), max(days))
 
     ax2 = ax.twinx()
     ax2.plot(days, share, color="0.25", linewidth=1.2, linestyle=":", label="preemptible share")
@@ -399,7 +392,6 @@ def chart_overview(daily_dir: str, charts_dir: str) -> None:
     tot_rows = _load_csv(os.path.join(daily_dir, "accelerators_daily.csv"))
     user_rows = _load_csv(os.path.join(daily_dir, "users_daily.csv"))
     tot_days = _dates(tot_rows)
-    day_min, day_max = min(tot_days), max(tot_days)
 
     fig, axes = plt.subplots(2, 2, figsize=(15, 8.5))
 
@@ -429,7 +421,6 @@ def chart_overview(daily_dir: str, charts_dir: str) -> None:
     for ax in axes.flat:
         _style_time_axis(ax)
         ax.set_ylim(bottom=0)
-        _add_milestones(ax, day_min, day_max)
 
     fig.suptitle("Iris cluster usage — Marin", fontsize=14, y=0.98)
     fig.tight_layout(rect=(0, 0, 1, 0.96))

--- a/lib/iris/scripts/blog_metrics/charts.py
+++ b/lib/iris/scripts/blog_metrics/charts.py
@@ -265,6 +265,53 @@ def chart_fleet_utilization(daily_dir: str, charts_dir: str) -> None:
     _save(fig, charts_dir, "fleet_utilization")
 
 
+def chart_preemptible(daily_dir: str, charts_dir: str) -> None:
+    """Preemptible (non-v4) vs reserved (v4) TPU capacity over time.
+
+    v4 is the reserved (guaranteed) pool; everything else (v5e/v5p/v6e) is
+    preemptible. Built from the real per-device iris data, so it only spans the
+    structured window (~May 6 on); W&B carries no device generation, so this
+    split cannot be reconstructed for the pre-iris (Jan-Apr) history.
+    """
+    rows = _load_csv(os.path.join(daily_dir, "accelerators_by_family_daily.csv"))
+    if not rows:
+        return
+    days, by_family = _pivot_family(rows, "mean_pflops")
+    reserved = [0.0] * len(days)
+    preempt = [0.0] * len(days)
+    for family, values in by_family.items():
+        target = reserved if family == "v4" else preempt
+        for i, v in enumerate(values):
+            target[i] += v
+    total = sum(preempt) + sum(reserved)
+    overall = 100 * sum(preempt) / total if total else 0.0
+    share = [100 * p / (p + r) if (p + r) > 0 else 0.0 for p, r in zip(preempt, reserved, strict=True)]
+
+    fig, ax = plt.subplots(figsize=(11, 5))
+    ax.stackplot(
+        days,
+        preempt,
+        reserved,
+        labels=["preemptible (non-v4)", "reserved (v4)"],
+        colors=["#4C72B0", "#DD8452"],
+        alpha=0.9,
+    )
+    ax.set_ylabel("TPU capacity (mean PFLOP/s)")
+    ax.set_title(f"Preemptible vs reserved capacity - {overall:.0f}% of compute was preemptible (non-v4)")
+    ax.set_ylim(bottom=0)
+    _style_time_axis(ax)
+    ax.legend(loc="upper left", fontsize=8, frameon=False)
+    _add_milestones(ax, min(days), max(days))
+
+    ax2 = ax.twinx()
+    ax2.plot(days, share, color="0.25", linewidth=1.2, linestyle=":", label="preemptible share")
+    ax2.set_ylabel("preemptible share (%)", color="0.25")
+    ax2.tick_params(axis="y", colors="0.25")
+    ax2.set_ylim(0, 100)
+    ax2.spines["top"].set_visible(False)
+    _save(fig, charts_dir, "preemptible")
+
+
 def chart_compute_history(daily_dir: str, charts_dir: str) -> None:
     """Realized training compute over the full W&B history, back to 2024.
 
@@ -397,6 +444,7 @@ def run(paths: config.Paths) -> None:
     chart_users(paths.daily_dir, paths.charts_dir)
     chart_tasks(paths.daily_dir, paths.charts_dir)
     chart_fleet_utilization(paths.daily_dir, paths.charts_dir)
+    chart_preemptible(paths.daily_dir, paths.charts_dir)
     chart_regions(paths.daily_dir, paths.charts_dir)
     chart_overview(paths.daily_dir, paths.charts_dir)
     if os.path.exists(os.path.join(paths.daily_dir, "wandb_compute_daily.csv")):

--- a/lib/iris/scripts/blog_metrics/charts.py
+++ b/lib/iris/scripts/blog_metrics/charts.py
@@ -22,6 +22,12 @@ mpl.use("Agg")  # headless backend; must precede pyplot import
 import config
 import matplotlib.dates as mdates
 import matplotlib.pyplot as plt
+import seaborn as sns
+
+# One elegant, consistent theme for every figure. The "deep" palette is the
+# source of the hand-picked family/region hexes below, so explicitly-colored and
+# auto-colored charts stay visually coherent.
+sns.set_theme(style="whitegrid", context="notebook", palette="deep")
 
 logger = logging.getLogger(__name__)
 
@@ -90,9 +96,7 @@ def _style_time_axis(ax: plt.Axes, *, long_range: bool = False) -> None:
     else:
         ax.xaxis.set_major_locator(mdates.WeekdayLocator(byweekday=mdates.MO))
         ax.xaxis.set_major_formatter(mdates.DateFormatter("%b %-d"))
-    ax.grid(True, axis="y", linewidth=0.4, alpha=0.4)
-    for spine in ("top", "right"):
-        ax.spines[spine].set_visible(False)
+    sns.despine(ax=ax)
 
 
 def _cumulative(values: list[float]) -> list[float]:
@@ -193,6 +197,7 @@ def chart_tasks(daily_dir: str, charts_dir: str) -> None:
     ax.set_ylim(bottom=0)
 
     ax2 = ax.twinx()
+    ax2.grid(False)
     ax2.plot(_dates(user_rows), _floats(user_rows, "active_tasks_ran"), color="0.5", linewidth=1.0, linestyle=":")
     ax2.set_ylabel("distinct tasks run / day (dotted)", color="0.4")
     ax2.tick_params(axis="y", colors="0.4")
@@ -224,13 +229,50 @@ def chart_regions(daily_dir: str, charts_dir: str) -> None:
     _save(fig, charts_dir, "accelerators_by_region")
 
 
+def _intraday_figure(
+    parsed: list[dt.datetime],
+    order: list[str],
+    series: dict[str, list[float]],
+    charts_dir: str,
+    *,
+    normalize: bool,
+) -> None:
+    """Render one intraday cross-region stack: absolute chips, or share of total."""
+    stacks = [list(series[reg]) for reg in order]
+    if normalize:
+        column_total = [sum(stack[i] for stack in stacks) or 1.0 for i in range(len(parsed))]
+        stacks = [[100 * v / column_total[i] for i, v in enumerate(stack)] for stack in stacks]
+    day = parsed[0].date().isoformat()
+
+    fig, ax = plt.subplots(figsize=(11, 5))
+    ax.stackplot(parsed, *stacks, labels=order, alpha=0.9)
+    ax.set_xlabel("hour of day (UTC)")
+    ax.set_xlim(parsed[0], parsed[-1])
+    ax.xaxis.set_major_locator(mdates.HourLocator(interval=3))
+    ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
+    sns.despine(ax=ax)
+    if normalize:
+        ax.set_ylim(0, 100)
+        ax.set_ylabel("share of fleet chips (%)")
+        ax.set_title(f"Intraday region mix (share of total) — {day} (UTC)")
+        ax.legend(loc="upper left", bbox_to_anchor=(1.01, 1.0), fontsize=8, frameon=False)
+        _save(fig, charts_dir, "intraday_regions_share")
+    else:
+        ax.set_ylim(bottom=0)
+        ax.set_ylabel("TPU chips (concurrent)")
+        ax.set_title(f"Intraday compute migration across regions — {day} (UTC)")
+        ax.legend(loc="upper right", fontsize=8, ncol=3, frameon=False)
+        _save(fig, charts_dir, "intraday_regions")
+
+
 def chart_intraday_regions(daily_dir: str, charts_dir: str) -> None:
     """Within-day compute migration across regions for the candidate day.
 
-    Stacked concurrent chips per region at the fine intraday bucket. On the
-    chosen day preemptible capacity hands off between regions through the day
-    while the reserved pool stays flat — visible as the stack's composition
-    shifting even where its height is roughly steady.
+    Renders two views from the same fine-bucket series: absolute concurrent chips
+    per region, and the share-of-total mix. On the chosen day preemptible
+    capacity hands off between regions through the day while the reserved pool
+    stays flat — the share view makes the composition shift explicit even where
+    the absolute height is steady.
     """
     rows = _load_csv(os.path.join(daily_dir, "intraday_regions.csv"))
     if not rows:
@@ -246,20 +288,8 @@ def chart_intraday_regions(daily_dir: str, charts_dir: str) -> None:
         totals[region] = totals.get(region, 0.0) + float(r["chips"])
     order = sorted(series, key=lambda reg: totals[reg], reverse=True)
 
-    fig, ax = plt.subplots(figsize=(11, 5))
-    ax.stackplot(parsed, *[series[reg] for reg in order], labels=order, alpha=0.9)
-    ax.set_title(f"Intraday compute migration across regions - {parsed[0].date().isoformat()} (UTC)")
-    ax.set_ylabel("TPU chips (concurrent)")
-    ax.set_xlabel("hour of day (UTC)")
-    ax.set_ylim(bottom=0)
-    ax.set_xlim(parsed[0], parsed[-1])
-    ax.xaxis.set_major_locator(mdates.HourLocator(interval=3))
-    ax.xaxis.set_major_formatter(mdates.DateFormatter("%H:%M"))
-    ax.grid(True, axis="y", linewidth=0.4, alpha=0.4)
-    for spine in ("top", "right"):
-        ax.spines[spine].set_visible(False)
-    ax.legend(loc="upper right", fontsize=8, ncol=3, frameon=False)
-    _save(fig, charts_dir, "intraday_regions")
+    _intraday_figure(parsed, order, series, charts_dir, normalize=False)
+    _intraday_figure(parsed, order, series, charts_dir, normalize=True)
 
 
 def chart_fleet_utilization(daily_dir: str, charts_dir: str) -> None:
@@ -289,6 +319,7 @@ def chart_fleet_utilization(daily_dir: str, charts_dir: str) -> None:
     ax.legend(loc="upper left", fontsize=8, frameon=False)
 
     ax2 = ax.twinx()
+    ax2.grid(False)
     ax2.plot(days, occupancy, color="0.25", linewidth=1.2, linestyle=":", label="occupancy %")
     ax2.set_ylabel("occupancy (%)", color="0.25")
     ax2.tick_params(axis="y", colors="0.25")
@@ -335,6 +366,7 @@ def chart_preemptible(daily_dir: str, charts_dir: str) -> None:
     ax.legend(loc="upper left", fontsize=8, frameon=False)
 
     ax2 = ax.twinx()
+    ax2.grid(False)
     ax2.plot(days, share, color="0.25", linewidth=1.2, linestyle=":", label="preemptible share")
     ax2.set_ylabel("preemptible share (%)", color="0.25")
     ax2.tick_params(axis="y", colors="0.25")
@@ -416,6 +448,7 @@ def chart_calibration(daily_dir: str, charts_dir: str) -> None:
     ax.legend(loc="lower left", fontsize=8, frameon=False)
 
     ax2 = ax.twinx()
+    ax2.grid(False)
     ax2.plot(days, on_active, color="0.4", linewidth=1.2, marker="o", markersize=2.5, label="on-active MFU")
     ax2.set_ylabel("on-active MFU (%)", color="0.4")
     ax2.tick_params(axis="y", colors="0.4")

--- a/lib/iris/scripts/blog_metrics/config.py
+++ b/lib/iris/scripts/blog_metrics/config.py
@@ -1,0 +1,204 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared configuration for the Iris blog-metrics pipeline.
+
+Paths, finelog source coordinates, the TPU FLOPS table, the worker-variant ->
+chip/FLOPS mapping, and the milestone annotations all live here so the fetch /
+extract / chart steps agree on one source of truth.
+
+The peak-FLOPS numbers are vendored from ``lib/fray/src/fray/device_flops.py``
+(``DEVICE_FLOPS``) because ``fray`` is not importable from the iris
+environment. Keep them in sync with that file if the canonical table changes.
+"""
+
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+from iris.cluster.tpu_topology import TPU_TOPOLOGIES, get_tpu_topology
+
+# --------------------------------------------------------------------------- #
+# Paths
+# --------------------------------------------------------------------------- #
+PACKAGE_DIR = os.path.dirname(os.path.abspath(__file__))
+DEFAULT_DATA_DIR = os.path.join(PACKAGE_DIR, "data")
+
+
+@dataclass(frozen=True)
+class Paths:
+    """Resolved on-disk layout for one pipeline run, rooted at ``data_dir``."""
+
+    data_dir: str
+
+    @property
+    def raw_dir(self) -> str:
+        """Bulk-copied finelog parquet + extracted controller audit lines."""
+        return os.path.join(self.data_dir, "raw")
+
+    @property
+    def worker_parquet(self) -> str:
+        return os.path.join(self.raw_dir, "iris.worker")
+
+    @property
+    def task_parquet(self) -> str:
+        return os.path.join(self.raw_dir, "iris.task")
+
+    @property
+    def controller_audit_parquet(self) -> str:
+        return os.path.join(self.raw_dir, "controller_audit.parquet")
+
+    @property
+    def wandb_runs_parquet(self) -> str:
+        """Cached bulk pull of W&B run metadata (one row per run)."""
+        return os.path.join(self.raw_dir, "wandb_runs.parquet")
+
+    @property
+    def daily_dir(self) -> str:
+        """Small per-day CSV rollups — cheap to recompute (gitignored)."""
+        return os.path.join(self.data_dir, "daily")
+
+    @property
+    def charts_dir(self) -> str:
+        return os.path.join(self.data_dir, "charts")
+
+
+def resolve_paths(data_dir: str | None) -> Paths:
+    return Paths(data_dir=os.path.abspath(data_dir or DEFAULT_DATA_DIR))
+
+
+# --------------------------------------------------------------------------- #
+# Finelog source
+# --------------------------------------------------------------------------- #
+# The finelog deployment name (``finelog gcs-query <name> ...``) and the GCS
+# prefix it archives to. iris.worker / iris.task carry structured per-heartbeat
+# rows; the ``log`` namespace's ``/system/controller`` key holds the
+# controller's audit lines (see audit_logging.py).
+FINELOG_DEPLOYMENT = "marin"
+REMOTE_LOG_DIR = "gs://marin-us-central2/finelog/marin"
+WORKER_NAMESPACE = "iris.worker"
+TASK_NAMESPACE = "iris.task"
+CONTROLLER_LOG_KEY = "/system/controller"
+
+# Time bucket used to turn dense heartbeats into a concurrency estimate: a
+# worker present in a bucket (>= 1 heartbeat) counts once. Daily "mean" is the
+# time-weighted average over buckets; daily "peak" is the busiest bucket.
+CONCURRENCY_BUCKET_MINUTES = 10
+CONCURRENCY_BUCKET = f"{CONCURRENCY_BUCKET_MINUTES} minutes"
+
+# --------------------------------------------------------------------------- #
+# W&B long-history source
+# --------------------------------------------------------------------------- #
+# Iris structured logs only reach back to the finelog Rust migration
+# (~2026-05-06). W&B run history reaches back to the project's start (~2024-04)
+# and is the only source for pre-Iris compute. Each run's summary carries
+# num_devices, _runtime, parameter_count (N) and throughput/total_tokens (D), so
+# realized training FLOPs are estimated as 6*N*D with no device-type lookup.
+WANDB_ENTITY = "marin-community"
+WANDB_PROJECTS = ["marin"]
+# Multiplier in the standard transformer training-FLOPs estimate 6*N*D
+# (forward+backward MAC*2). Eval/inference runs over-count under this (they do
+# ~2ND), so realized FLOPs from W&B are an upper bound for non-training work.
+TRAINING_FLOPS_PER_PARAM_TOKEN = 6.0
+
+# The Iris stats window overlaps W&B from this date; used to calibrate the
+# W&B-derived series (realized) against the cluster's provisioned capacity.
+CALIBRATION_START = "2026-05-07"  # first full day of iris stats data
+
+# --------------------------------------------------------------------------- #
+# FLOPS table (peak bf16 FLOP/s per chip)
+# --------------------------------------------------------------------------- #
+# Vendored from lib/fray/src/fray/device_flops.py::DEVICE_FLOPS (TPU bf16
+# entries). Keyed by the family token produced by FAMILY_OF (variant.split("-")[0]).
+FAMILY_FLOPS_BF16: dict[str, float] = {
+    "v3": 123e12 / 2,  # per-chip halved: a JAX device is one core
+    "v4": 275e12,
+    "v5litepod": 197e12,  # v5e
+    "v5p": 459e12,
+    "v6e": 918e12,
+}
+
+# Human-facing family label for charts/legends.
+FAMILY_DISPLAY: dict[str, str] = {
+    "v3": "v3",
+    "v4": "v4",
+    "v5litepod": "v5e",
+    "v5p": "v5p",
+    "v6e": "v6e",
+}
+
+
+def family_of(variant: str) -> str:
+    """Family token for a worker ``device_variant`` (e.g. ``v5p-32`` -> ``v5p``)."""
+    return variant.split("-")[0]
+
+
+@dataclass(frozen=True)
+class VariantInfo:
+    """Per-worker (one VM) chip count and peak FLOPS for a TPU slice variant."""
+
+    variant: str
+    family: str
+    family_display: str
+    chips_per_vm: int
+    flops_per_chip: float
+
+
+def build_variant_table() -> list[VariantInfo]:
+    """Resolve every known TPU topology to its per-VM chip count and FLOPS.
+
+    Each ``iris.worker`` row reports the slice ``device_variant`` of the VM it
+    runs on; one worker == one VM, so its chip contribution is ``chips_per_vm``.
+    Variants whose family has no FLOPS entry are dropped (with the family token
+    left discoverable via the topology list).
+    """
+    rows: list[VariantInfo] = []
+    for topo in TPU_TOPOLOGIES:
+        variant = topo.name.lower()
+        family = family_of(variant)
+        flops = FAMILY_FLOPS_BF16.get(family)
+        if flops is None:
+            continue
+        rows.append(
+            VariantInfo(
+                variant=variant,
+                family=family,
+                family_display=FAMILY_DISPLAY.get(family, family),
+                chips_per_vm=topo.chips_per_vm,
+                flops_per_chip=flops,
+            )
+        )
+    return rows
+
+
+def variant_chips(variant: str) -> int:
+    """Per-VM chip count for a single ``device_variant`` (0 if unknown)."""
+    try:
+        return get_tpu_topology(variant).chips_per_vm
+    except ValueError:
+        return 0
+
+
+# --------------------------------------------------------------------------- #
+# Users
+# --------------------------------------------------------------------------- #
+# The first path component of a task id (``/<user>/<job>/.../<idx>``) is the
+# submitting user. These are automation namespaces, not people — excluded from
+# the "human active users" count but kept in the raw count.
+BOT_USERS: frozenset[str] = frozenset({"infra-probes", "runner", "canary"})
+
+# --------------------------------------------------------------------------- #
+# Milestones
+# --------------------------------------------------------------------------- #
+# (ISO date, short label) annotations drawn as vertical markers. Dates outside
+# the data window are dropped by the chart step. Sourced from git history of
+# lib/iris; edit freely.
+MILESTONES: list[tuple[str, str]] = [
+    ("2024-04-10", "First W&B-tracked runs"),
+    ("2026-04-01", "User budgets + priority bands (#4096)"),
+    ("2026-04-08", "v4-reserved pool (#4528)"),
+    ("2026-04-22", "Ray → Iris cutover (#5076)"),
+    ("2026-05-08", "Scheduling queue (#5563)"),
+    ("2026-06-16", "Empirical availability constraint (#6438)"),
+]

--- a/lib/iris/scripts/blog_metrics/config.py
+++ b/lib/iris/scripts/blog_metrics/config.py
@@ -121,9 +121,13 @@ TRAINING_FLOPS_PER_PARAM_TOKEN = 6.0
 REALIZED_FLOPS_CEILING_PEAK_BF16 = 459e12  # v5p per-chip bf16 FLOP/s
 REALIZED_FLOPS_CEILING_MFU = 0.6
 
-# The Iris stats window overlaps W&B from this date; used to calibrate the
-# W&B-derived series (realized) against the cluster's provisioned capacity.
-CALIBRATION_START = "2026-05-07"  # first full day of iris stats data
+# Calibration compares W&B realized compute against iris *provisioned* capacity,
+# so it is only valid where all training actually ran on iris. That holds from
+# early June: April's v4 runs were still on Ray (no iris logs), and May is mixed
+# — iris was bootstrapping (~May 6) and some runs ran elsewhere, so W&B
+# device-hours *exceed* iris's on May 7-8 (an impossible >100% coverage). Start
+# in June for an apples-to-apples window.
+CALIBRATION_START = "2026-06-01"
 
 # --------------------------------------------------------------------------- #
 # FLOPS table (peak bf16 FLOP/s per chip)

--- a/lib/iris/scripts/blog_metrics/config.py
+++ b/lib/iris/scripts/blog_metrics/config.py
@@ -94,13 +94,32 @@ CONCURRENCY_BUCKET = f"{CONCURRENCY_BUCKET_MINUTES} minutes"
 # (~2026-05-06). W&B run history reaches back to the project's start (~2024-04)
 # and is the only source for pre-Iris compute. Each run's summary carries
 # num_devices, _runtime, parameter_count (N) and throughput/total_tokens (D), so
-# realized training FLOPs are estimated as 6*N*D with no device-type lookup.
+# realized training FLOPs are estimated as 6*N*D, capped at physical capacity
+# (see REALIZED_FLOPS_CEILING_* below).
 WANDB_ENTITY = "marin-community"
-WANDB_PROJECTS = ["marin"]
+# The flagship pretraining lives in "marin"; the rest are the sibling projects
+# that log device-bearing runs *with* N and D (so they contribute FLOPs): the
+# MoE training projects and the two largest optimizer sweeps. Eval / post-train
+# projects log devices but no token counts, so they cannot form 6*N*D and are
+# omitted.
+WANDB_PROJECTS = ["marin", "dial_moe", "marin_moe", "optimizer-scaling", "Hyperball"]
 # Multiplier in the standard transformer training-FLOPs estimate 6*N*D
-# (forward+backward MAC*2). Eval/inference runs over-count under this (they do
-# ~2ND), so realized FLOPs from W&B are an upper bound for non-training work.
+# (forward+backward MAC*2).
 TRAINING_FLOPS_PER_PARAM_TOKEN = 6.0
+
+# W&B's throughput/total_tokens (D) is a CUMULATIVE counter that resumed and
+# cooldown runs inherit from their parent, so 6*N*D counts a flagship lineage
+# many times over: a 1-hour 32B cooldown re-reports the parent's ~6T tokens and
+# 6*N*D then attributes ~1e24 FLOPs to it -> an implied >1000x MFU. We therefore
+# cap each run's 6*N*D at the most its *own* hardware-time could physically
+# deliver, ``num_devices * runtime * peak * mfu``. Clean runs (6*N*D below the
+# ceiling) keep their exact estimate; only the cumulative-counter runs are
+# bounded, and the bound uses each run's own device count so it honors a fleet
+# whose size varied over time. The peak is the generous v5p per-chip rate so
+# genuine v5p/v6e runs are never wrongly capped; mfu is a hardware ceiling, not a
+# typical efficiency.
+REALIZED_FLOPS_CEILING_PEAK_BF16 = 459e12  # v5p per-chip bf16 FLOP/s
+REALIZED_FLOPS_CEILING_MFU = 0.6
 
 # The Iris stats window overlaps W&B from this date; used to calibrate the
 # W&B-derived series (realized) against the cluster's provisioned capacity.

--- a/lib/iris/scripts/blog_metrics/config.py
+++ b/lib/iris/scripts/blog_metrics/config.py
@@ -87,6 +87,14 @@ CONTROLLER_LOG_KEY = "/system/controller"
 CONCURRENCY_BUCKET_MINUTES = 10
 CONCURRENCY_BUCKET = f"{CONCURRENCY_BUCKET_MINUTES} minutes"
 
+# A single day chosen to illustrate *intraday* compute migration across regions:
+# preemptible capacity sloshes between regions over the day (on 2026-06-01,
+# us-east5 dominates the morning then hands off to europe-west4 in the
+# afternoon) while the reserved v4 pool (us-central2) holds flat. Bucketed finer
+# than the daily series so the within-day movement is visible.
+INTRADAY_CANDIDATE_DAY = "2026-06-01"
+INTRADAY_BUCKET = "30 minutes"
+
 # --------------------------------------------------------------------------- #
 # W&B long-history source
 # --------------------------------------------------------------------------- #

--- a/lib/iris/scripts/blog_metrics/extract.py
+++ b/lib/iris/scripts/blog_metrics/extract.py
@@ -328,7 +328,18 @@ def _write_calibration(con: duckdb.DuckDBPyConnection, daily_dir: str) -> None:
     """Calibrate W&B realized compute against iris provisioned capacity in the overlap.
 
     Requires the ``iris_capacity_daily`` and ``wandb_compute_daily`` temp tables.
-    Emits a per-day CSV and logs the headline coverage / effective-MFU ratios.
+    Two distinct ratios, kept separate because conflating them is misleading:
+
+    * **coverage** = W&B-logged-TPU device-hours / iris device-hours — what
+      fraction of the standing fleet ran W&B-logged *training* (the rest is
+      non-training / non-logged work, so this is well below 100%);
+    * **on-active MFU** = realized FLOPs per W&B device-hour / fleet peak FLOPs
+      per device-hour — the efficiency of the logged jobs *while they ran*,
+      independent of how much of the fleet they occupied.
+
+    Their product is the "effective MFU vs total fleet", which collapses whenever
+    coverage drops even though efficiency is steady — so we report on-active MFU
+    as the efficiency headline and coverage separately.
     """
     start = config.CALIBRATION_START
     con.execute(
@@ -340,7 +351,9 @@ def _write_calibration(con: duckdb.DuckDBPyConnection, daily_dir: str) -> None:
                w.device_hours_tpu / nullif(i.device_hours, 0) AS device_hours_coverage,
                w.realized_flops_tpu AS wandb_tpu_realized_flops,
                i.capacity_flops AS iris_capacity_flops,
-               w.realized_flops_tpu / nullif(i.capacity_flops, 0) AS effective_mfu
+               w.realized_flops_tpu / nullif(i.capacity_flops, 0) AS effective_mfu,
+               w.realized_flops_tpu * i.device_hours
+                 / nullif(i.capacity_flops * w.device_hours_tpu, 0) AS on_active_mfu
         FROM iris_capacity_daily i
         JOIN wandb_compute_daily w USING (day)
         WHERE i.day >= DATE '{start}'
@@ -354,14 +367,15 @@ def _write_calibration(con: duckdb.DuckDBPyConnection, daily_dir: str) -> None:
     summary = con.execute(
         """
         SELECT sum(wandb_tpu_device_hours) / nullif(sum(iris_device_hours), 0) AS coverage,
-               sum(wandb_tpu_realized_flops) / nullif(sum(iris_capacity_flops), 0) AS effective_mfu
+               sum(wandb_tpu_realized_flops) * sum(iris_device_hours)
+                 / nullif(sum(iris_capacity_flops) * sum(wandb_tpu_device_hours), 0) AS on_active_mfu
         FROM calibration_daily
         """
     ).fetchone()
     if summary and summary[0] is not None:
         logger.info(
-            "calibration (overlap >= %s): W&B-TPU device-hours = %.1f%% of iris provisioned; "
-            "realized FLOPs = %.1f%% of provisioned capacity (effective MFU)",
+            "calibration (all-on-iris window >= %s): W&B-logged training = %.1f%% of fleet device-hours "
+            "(coverage); those jobs ran at %.1f%% MFU while active (on-active MFU)",
             start,
             100 * summary[0],
             100 * (summary[1] or 0),

--- a/lib/iris/scripts/blog_metrics/extract.py
+++ b/lib/iris/scripts/blog_metrics/extract.py
@@ -258,13 +258,19 @@ def _write_iris_capacity(con: duckdb.DuckDBPyConnection, daily_dir: str) -> None
 
 
 def _write_wandb_compute(con: duckdb.DuckDBPyConnection, daily_dir: str, wandb_parquet: str) -> None:
-    """Daily *realized* compute from W&B runs: device-hours and 6*N*D training FLOPs.
+    """Daily *realized* compute from W&B runs: device-hours and capped 6*N*D FLOPs.
 
-    Each run's totals are spread uniformly across the wall-clock days it spans
-    (``created_at`` .. ``created_at + runtime``), so a multi-day run lands on
-    every day it touched. ``backend`` separates TPU from GPU/CPU work.
+    Each run's FLOPs are estimated as ``6*N*D`` but **capped at the most its own
+    hardware-time could deliver** (``num_devices * runtime * peak * mfu``),
+    because ``total_tokens`` is a cumulative counter that resumed/cooldown runs
+    inherit — see ``config.REALIZED_FLOPS_CEILING_*``. The capped run total and
+    the device-hours are then spread uniformly across the wall-clock days the run
+    spans, so a multi-day run lands on every day it touched. ``backend``
+    separates TPU from GPU/CPU work.
     """
     k = config.TRAINING_FLOPS_PER_PARAM_TOKEN
+    peak = config.REALIZED_FLOPS_CEILING_PEAK_BF16
+    mfu = config.REALIZED_FLOPS_CEILING_MFU
     con.execute(
         f"""
         CREATE TEMP TABLE wandb_exploded AS
@@ -273,15 +279,15 @@ def _write_wandb_compute(con: duckdb.DuckDBPyConnection, daily_dir: str, wandb_p
                    created_at + (greatest(coalesce(runtime_s, 0), 1) * INTERVAL '1 second') AS end_ts,
                    greatest(coalesce(runtime_s, 0), 1) AS dur,
                    num_devices,
-                   coalesce(parameter_count, 0) AS np,
-                   coalesce(total_tokens, 0) AS tok,
+                   least({k} * coalesce(parameter_count, 0) * coalesce(total_tokens, 0),
+                         num_devices * greatest(coalesce(runtime_s, 0), 1) * {peak} * {mfu}) AS run_flops,
                    lower(coalesce(backend, 'unknown')) AS backend
             FROM read_parquet('{wandb_parquet}')
             WHERE created_at IS NOT NULL AND num_devices > 0
         )
         SELECT r.backend, d::DATE AS day,
                num_devices * day_secs / 3600.0 AS device_hours,
-               {k} * np * tok * day_secs / dur AS realized_flops
+               run_flops * day_secs / dur AS realized_flops
         FROM r,
              unnest(generate_series(date_trunc('day', start_ts),
                                     date_trunc('day', end_ts),

--- a/lib/iris/scripts/blog_metrics/extract.py
+++ b/lib/iris/scripts/blog_metrics/extract.py
@@ -1,0 +1,389 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pipeline step 2: roll the raw parquet up into small per-day CSVs.
+
+All aggregation runs in DuckDB over the locally-mirrored parquet (no network),
+so this step is cheap to re-run while iterating on metric definitions. Outputs
+land in ``<data_dir>/daily`` as per-day CSVs:
+
+* ``accelerators_daily.csv`` — total concurrent chips / workers / PFLOP/s /
+  running tasks per day (mean = time-weighted over 10-min buckets, peak =
+  busiest bucket).
+* ``accelerators_by_family_daily.csv`` — the same mean concurrency split by TPU
+  family (additive across families -> stackable).
+* ``users_daily.csv`` — distinct active users and tasks that actually ran.
+* ``submissions_daily.csv`` — *only if* controller audit lines were fetched:
+  jobs/tasks submitted and distinct submitting users per day.
+
+Concurrency model: each ``iris.worker`` heartbeat marks its VM present in a
+10-min bucket; one worker contributes ``chips_per_vm`` chips. Summing distinct
+present workers per bucket and averaging over the day's buckets gives a
+time-weighted mean concurrent footprint that is robust to heartbeat cadence and
+to preemption churn within a day.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+
+import config
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+
+def _register_variant_info(con: duckdb.DuckDBPyConnection) -> None:
+    """Create the variant -> (family, chips_per_vm, flops_per_chip) lookup table."""
+    con.execute(
+        "CREATE TABLE variant_info ("
+        " variant VARCHAR, family VARCHAR, family_display VARCHAR,"
+        " chips_per_vm INTEGER, flops_per_chip DOUBLE)"
+    )
+    con.executemany(
+        "INSERT INTO variant_info VALUES (?, ?, ?, ?, ?)",
+        [
+            (vi.variant, vi.family, vi.family_display, vi.chips_per_vm, vi.flops_per_chip)
+            for vi in config.build_variant_table()
+        ],
+    )
+
+
+def _log_variant_coverage(con: duckdb.DuckDBPyConnection, worker_glob: str) -> None:
+    """Warn about TPU variants present in the data but missing from the FLOPS table."""
+    rows = con.execute(
+        f"""
+        SELECT lower(device_variant) AS variant, count(DISTINCT worker_id) AS workers
+        FROM read_parquet('{worker_glob}')
+        WHERE lower(device_type) = 'tpu' AND device_variant <> ''
+          AND lower(device_variant) NOT IN (SELECT variant FROM variant_info)
+        GROUP BY 1 ORDER BY 2 DESC
+        """
+    ).fetchall()
+    if rows:
+        logger.warning("dropping %d unmapped TPU variant(s): %s", len(rows), rows)
+
+
+def _build_bucket_tables(con: duckdb.DuckDBPyConnection, worker_glob: str) -> None:
+    """Materialize per-bucket concurrency tables shared by the accelerator rollups."""
+    bucket = config.CONCURRENCY_BUCKET
+    # Distinct (worker, variant) presence per time bucket. device_variant is
+    # static per worker, so this is "which VMs emitted a heartbeat this bucket".
+    con.execute(
+        f"""
+        CREATE TEMP TABLE hb AS
+        SELECT worker_id, lower(device_variant) AS variant,
+               time_bucket(INTERVAL '{bucket}', ts) AS bucket
+        FROM read_parquet('{worker_glob}')
+        WHERE lower(device_type) = 'tpu' AND device_variant <> ''
+        GROUP BY 1, 2, 3
+        """
+    )
+    # Per (bucket, family): concurrent workers, chips, PFLOP/s capacity.
+    con.execute(
+        """
+        CREATE TEMP TABLE bucket_family AS
+        SELECT h.bucket, vi.family_display AS family,
+               count(*) AS workers,
+               sum(vi.chips_per_vm) AS chips,
+               sum(vi.chips_per_vm * vi.flops_per_chip) / 1e15 AS pflops
+        FROM hb h JOIN variant_info vi ON h.variant = vi.variant
+        GROUP BY 1, 2
+        """
+    )
+    # Per-bucket totals across all families.
+    con.execute(
+        """
+        CREATE TEMP TABLE bucket_total AS
+        SELECT bucket, sum(workers) AS workers, sum(chips) AS chips, sum(pflops) AS pflops
+        FROM bucket_family GROUP BY 1
+        """
+    )
+    # Number of populated buckets per day -> denominator for time-weighted means.
+    con.execute(
+        """
+        CREATE TEMP TABLE day_buckets AS
+        SELECT bucket::DATE AS day, count(*) AS nb
+        FROM bucket_total GROUP BY 1
+        """
+    )
+    # Per-bucket concurrent running tasks, from the host-level running_task_count.
+    con.execute(
+        f"""
+        CREATE TEMP TABLE bucket_tasks AS
+        SELECT bucket, sum(rtc) AS tasks FROM (
+            SELECT time_bucket(INTERVAL '{bucket}', ts) AS bucket, worker_id,
+                   max(running_task_count) AS rtc
+            FROM read_parquet('{worker_glob}')
+            GROUP BY 1, 2
+        ) GROUP BY 1
+        """
+    )
+    # Per (bucket, region): concurrent chips, for the regional footprint chart.
+    # Region = zone with its trailing "-<letter>" stripped (us-east5-a -> us-east5).
+    con.execute(
+        """
+        CREATE TEMP TABLE bucket_region AS
+        SELECT h.bucket, regexp_replace(coalesce(w.zone, ''), '-[a-z]$', '') AS region,
+               sum(vi.chips_per_vm) AS chips
+        FROM hb h
+        JOIN variant_info vi ON h.variant = vi.variant
+        JOIN (SELECT DISTINCT worker_id, zone FROM read_parquet('{glob}')) w
+          ON h.worker_id = w.worker_id
+        GROUP BY 1, 2
+        """.replace(
+            "{glob}", worker_glob
+        )
+    )
+
+
+def _write_accelerators(con: duckdb.DuckDBPyConnection, daily_dir: str) -> None:
+    total_csv = os.path.join(daily_dir, "accelerators_daily.csv")
+    con.execute(
+        f"""
+        COPY (
+            SELECT bt.bucket::DATE AS day,
+                   avg(bt.chips) AS mean_chips, max(bt.chips) AS peak_chips,
+                   avg(bt.workers) AS mean_workers, max(bt.workers) AS peak_workers,
+                   avg(bt.pflops) AS mean_pflops, max(bt.pflops) AS peak_pflops,
+                   avg(coalesce(tk.tasks, 0)) AS mean_tasks,
+                   max(coalesce(tk.tasks, 0)) AS peak_tasks
+            FROM bucket_total bt
+            LEFT JOIN bucket_tasks tk USING (bucket)
+            GROUP BY 1 ORDER BY 1
+        ) TO '{total_csv}' (HEADER, DELIMITER ',')
+        """
+    )
+    logger.info("wrote %s", total_csv)
+
+    family_csv = os.path.join(daily_dir, "accelerators_by_family_daily.csv")
+    # Divide by the day's bucket count so an idle bucket counts as zero for a
+    # family (time-weighted mean, additive across families for stacking).
+    con.execute(
+        f"""
+        COPY (
+            SELECT bf.bucket::DATE AS day, bf.family,
+                   sum(bf.chips) / max(db.nb) AS mean_chips,
+                   sum(bf.pflops) / max(db.nb) AS mean_pflops,
+                   sum(bf.workers) / max(db.nb) AS mean_workers
+            FROM bucket_family bf
+            JOIN day_buckets db ON bf.bucket::DATE = db.day
+            GROUP BY 1, 2 ORDER BY 1, 2
+        ) TO '{family_csv}' (HEADER, DELIMITER ',')
+        """
+    )
+    logger.info("wrote %s", family_csv)
+
+    region_csv = os.path.join(daily_dir, "accelerators_by_region_daily.csv")
+    con.execute(
+        f"""
+        COPY (
+            SELECT br.bucket::DATE AS day, br.region,
+                   sum(br.chips) / max(db.nb) AS mean_chips
+            FROM bucket_region br
+            JOIN day_buckets db ON br.bucket::DATE = db.day
+            GROUP BY 1, 2 ORDER BY 1, 2
+        ) TO '{region_csv}' (HEADER, DELIMITER ',')
+        """
+    )
+    logger.info("wrote %s", region_csv)
+
+
+def _write_users(con: duckdb.DuckDBPyConnection, daily_dir: str, task_glob: str) -> None:
+    bots = ", ".join(f"'{u}'" for u in sorted(config.BOT_USERS))
+    users_csv = os.path.join(daily_dir, "users_daily.csv")
+    con.execute(
+        f"""
+        COPY (
+            SELECT ts::DATE AS day,
+                   count(DISTINCT u) AS active_users,
+                   count(DISTINCT CASE WHEN u NOT IN ({bots}) THEN u END) AS active_users_human,
+                   count(DISTINCT task_id) AS active_tasks_ran
+            FROM (
+                SELECT ts, task_id, split_part(ltrim(task_id, '/'), '/', 1) AS u
+                FROM read_parquet('{task_glob}')
+            )
+            GROUP BY 1 ORDER BY 1
+        ) TO '{users_csv}' (HEADER, DELIMITER ',')
+        """
+    )
+    logger.info("wrote %s", users_csv)
+
+
+def _write_submissions(con: duckdb.DuckDBPyConnection, daily_dir: str, audit_parquet: str) -> None:
+    bots = ", ".join(f"'{u}'" for u in sorted(config.BOT_USERS))
+    subs_csv = os.path.join(daily_dir, "submissions_daily.csv")
+    con.execute(
+        rf"""
+        COPY (
+            SELECT day,
+                   count(*) AS jobs_submitted,
+                   sum(num_tasks) AS tasks_submitted,
+                   count(DISTINCT u) AS submitting_users,
+                   count(DISTINCT CASE WHEN u NOT IN ({bots}) THEN u END) AS submitting_users_human
+            FROM (
+                SELECT to_timestamp(epoch_ms / 1000)::DATE AS day,
+                       split_part(ltrim(regexp_extract(data, 'entity=(\S+)', 1), '/'), '/', 1) AS u,
+                       TRY_CAST(regexp_extract(data, 'num_tasks=(\d+)', 1) AS INTEGER) AS num_tasks
+                FROM read_parquet('{audit_parquet}')
+                WHERE data LIKE '%event=job_submitted%'
+            )
+            GROUP BY 1 ORDER BY 1
+        ) TO '{subs_csv}' (HEADER, DELIMITER ',')
+        """
+    )
+    logger.info("wrote %s", subs_csv)
+
+
+def _write_iris_capacity(con: duckdb.DuckDBPyConnection, daily_dir: str) -> None:
+    """Daily *provisioned* footprint from iris: device-hours and peak-capacity FLOPs.
+
+    These are what the cluster could deliver (workers present x peak per chip),
+    the denominator the W&B realized series is calibrated against.
+    """
+    mins = config.CONCURRENCY_BUCKET_MINUTES
+    con.execute(
+        f"""
+        CREATE TEMP TABLE iris_capacity_daily AS
+        SELECT bucket::DATE AS day,
+               sum(chips) * ({mins} / 60.0) AS device_hours,
+               sum(pflops) * 1e15 * ({mins} * 60) AS capacity_flops
+        FROM bucket_total GROUP BY 1 ORDER BY 1
+        """
+    )
+    out = os.path.join(daily_dir, "iris_capacity_daily.csv")
+    con.execute(f"COPY iris_capacity_daily TO '{out}' (HEADER, DELIMITER ',')")
+    logger.info("wrote %s", out)
+
+
+def _write_wandb_compute(con: duckdb.DuckDBPyConnection, daily_dir: str, wandb_parquet: str) -> None:
+    """Daily *realized* compute from W&B runs: device-hours and 6*N*D training FLOPs.
+
+    Each run's totals are spread uniformly across the wall-clock days it spans
+    (``created_at`` .. ``created_at + runtime``), so a multi-day run lands on
+    every day it touched. ``backend`` separates TPU from GPU/CPU work.
+    """
+    k = config.TRAINING_FLOPS_PER_PARAM_TOKEN
+    con.execute(
+        f"""
+        CREATE TEMP TABLE wandb_exploded AS
+        WITH r AS (
+            SELECT created_at AS start_ts,
+                   created_at + (greatest(coalesce(runtime_s, 0), 1) * INTERVAL '1 second') AS end_ts,
+                   greatest(coalesce(runtime_s, 0), 1) AS dur,
+                   num_devices,
+                   coalesce(parameter_count, 0) AS np,
+                   coalesce(total_tokens, 0) AS tok,
+                   lower(coalesce(backend, 'unknown')) AS backend
+            FROM read_parquet('{wandb_parquet}')
+            WHERE created_at IS NOT NULL AND num_devices > 0
+        )
+        SELECT r.backend, d::DATE AS day,
+               num_devices * day_secs / 3600.0 AS device_hours,
+               {k} * np * tok * day_secs / dur AS realized_flops
+        FROM r,
+             unnest(generate_series(date_trunc('day', start_ts),
+                                    date_trunc('day', end_ts),
+                                    INTERVAL '1 day')) AS g(d),
+             LATERAL (SELECT greatest(0, date_diff('second', greatest(start_ts, d),
+                                      least(end_ts, d + INTERVAL '1 day'))) AS day_secs) o
+        WHERE day_secs > 0
+        """
+    )
+    con.execute(
+        """
+        CREATE TEMP TABLE wandb_compute_daily AS
+        SELECT day,
+               sum(device_hours) AS device_hours,
+               sum(realized_flops) AS realized_flops,
+               sum(CASE WHEN backend = 'tpu' THEN device_hours ELSE 0 END) AS device_hours_tpu,
+               sum(CASE WHEN backend = 'tpu' THEN realized_flops ELSE 0 END) AS realized_flops_tpu
+        FROM wandb_exploded GROUP BY 1 ORDER BY 1
+        """
+    )
+    out = os.path.join(daily_dir, "wandb_compute_daily.csv")
+    con.execute(f"COPY wandb_compute_daily TO '{out}' (HEADER, DELIMITER ',')")
+    logger.info("wrote %s", out)
+
+    by_backend = os.path.join(daily_dir, "wandb_compute_by_backend_daily.csv")
+    con.execute(
+        f"""
+        COPY (
+            SELECT day, backend, sum(device_hours) AS device_hours, sum(realized_flops) AS realized_flops
+            FROM wandb_exploded GROUP BY 1, 2 ORDER BY 1, 2
+        ) TO '{by_backend}' (HEADER, DELIMITER ',')
+        """
+    )
+    logger.info("wrote %s", by_backend)
+
+
+def _write_calibration(con: duckdb.DuckDBPyConnection, daily_dir: str) -> None:
+    """Calibrate W&B realized compute against iris provisioned capacity in the overlap.
+
+    Requires the ``iris_capacity_daily`` and ``wandb_compute_daily`` temp tables.
+    Emits a per-day CSV and logs the headline coverage / effective-MFU ratios.
+    """
+    start = config.CALIBRATION_START
+    con.execute(
+        f"""
+        CREATE TEMP TABLE calibration_daily AS
+        SELECT i.day,
+               w.device_hours_tpu AS wandb_tpu_device_hours,
+               i.device_hours AS iris_device_hours,
+               w.device_hours_tpu / nullif(i.device_hours, 0) AS device_hours_coverage,
+               w.realized_flops_tpu AS wandb_tpu_realized_flops,
+               i.capacity_flops AS iris_capacity_flops,
+               w.realized_flops_tpu / nullif(i.capacity_flops, 0) AS effective_mfu
+        FROM iris_capacity_daily i
+        JOIN wandb_compute_daily w USING (day)
+        WHERE i.day >= DATE '{start}'
+        ORDER BY i.day
+        """
+    )
+    out = os.path.join(daily_dir, "calibration_daily.csv")
+    con.execute(f"COPY calibration_daily TO '{out}' (HEADER, DELIMITER ',')")
+    logger.info("wrote %s", out)
+
+    summary = con.execute(
+        """
+        SELECT sum(wandb_tpu_device_hours) / nullif(sum(iris_device_hours), 0) AS coverage,
+               sum(wandb_tpu_realized_flops) / nullif(sum(iris_capacity_flops), 0) AS effective_mfu
+        FROM calibration_daily
+        """
+    ).fetchone()
+    if summary and summary[0] is not None:
+        logger.info(
+            "calibration (overlap >= %s): W&B-TPU device-hours = %.1f%% of iris provisioned; "
+            "realized FLOPs = %.1f%% of provisioned capacity (effective MFU)",
+            start,
+            100 * summary[0],
+            100 * (summary[1] or 0),
+        )
+
+
+def run(paths: config.Paths) -> None:
+    """Compute every daily rollup CSV from the locally-mirrored parquet."""
+    os.makedirs(paths.daily_dir, exist_ok=True)
+    worker_glob = os.path.join(paths.worker_parquet, "*.parquet")
+    task_glob = os.path.join(paths.task_parquet, "*.parquet")
+
+    con = duckdb.connect()
+    _register_variant_info(con)
+    _log_variant_coverage(con, worker_glob)
+    _build_bucket_tables(con, worker_glob)
+    _write_accelerators(con, paths.daily_dir)
+    _write_users(con, paths.daily_dir, task_glob)
+    _write_iris_capacity(con, paths.daily_dir)
+
+    if os.path.exists(paths.wandb_runs_parquet):
+        _write_wandb_compute(con, paths.daily_dir, paths.wandb_runs_parquet)
+        _write_calibration(con, paths.daily_dir)
+    else:
+        logger.info("no W&B run cache; skipping long-history compute + calibration")
+
+    if os.path.exists(paths.controller_audit_parquet):
+        _write_submissions(con, paths.daily_dir, paths.controller_audit_parquet)
+    else:
+        logger.info("no controller audit parquet; skipping submissions_daily.csv")
+    con.close()

--- a/lib/iris/scripts/blog_metrics/extract.py
+++ b/lib/iris/scripts/blog_metrics/extract.py
@@ -236,6 +236,37 @@ def _write_utilization(con: duckdb.DuckDBPyConnection, daily_dir: str) -> None:
         logger.info("fleet occupancy: %.1f%% of provisioned chip-time was running a task", 100 * summary[0])
 
 
+def _write_intraday_regions(con: duckdb.DuckDBPyConnection, daily_dir: str, worker_glob: str) -> None:
+    """Fine-grained per-region chips for one day, to show intraday cross-region movement.
+
+    Buckets ``config.INTRADAY_CANDIDATE_DAY`` at ``config.INTRADAY_BUCKET`` and
+    sums concurrent chips per region per bucket — the within-day analogue of the
+    daily regional footprint. Heartbeats are ~10s apart so even 30-min buckets
+    are densely populated.
+    """
+    day = config.INTRADAY_CANDIDATE_DAY
+    out = os.path.join(daily_dir, "intraday_regions.csv")
+    con.execute(
+        f"""
+        COPY (
+            WITH hb AS (
+                SELECT worker_id, lower(device_variant) AS variant,
+                       regexp_replace(coalesce(zone, ''), '-[a-z]$', '') AS region,
+                       time_bucket(INTERVAL '{config.INTRADAY_BUCKET}', ts) AS bucket
+                FROM read_parquet('{worker_glob}')
+                WHERE lower(device_type) = 'tpu' AND device_variant <> ''
+                  AND ts::DATE = DATE '{day}'
+                GROUP BY 1, 2, 3, 4
+            )
+            SELECT hb.bucket, hb.region, sum(vi.chips_per_vm) AS chips
+            FROM hb JOIN variant_info vi ON hb.variant = vi.variant
+            GROUP BY 1, 2 ORDER BY 1, 2
+        ) TO '{out}' (HEADER, DELIMITER ',')
+        """
+    )
+    logger.info("wrote %s (intraday regions for %s)", out, day)
+
+
 def _write_users(con: duckdb.DuckDBPyConnection, daily_dir: str, task_glob: str) -> None:
     bots = ", ".join(f"'{u}'" for u in sorted(config.BOT_USERS))
     users_csv = os.path.join(daily_dir, "users_daily.csv")
@@ -440,6 +471,7 @@ def run(paths: config.Paths) -> None:
     _build_bucket_tables(con, worker_glob)
     _write_accelerators(con, paths.daily_dir)
     _write_utilization(con, paths.daily_dir)
+    _write_intraday_regions(con, paths.daily_dir, worker_glob)
     _write_users(con, paths.daily_dir, task_glob)
     _write_iris_capacity(con, paths.daily_dir)
 

--- a/lib/iris/scripts/blog_metrics/extract.py
+++ b/lib/iris/scripts/blog_metrics/extract.py
@@ -120,6 +120,25 @@ def _build_bucket_tables(con: duckdb.DuckDBPyConnection, worker_glob: str) -> No
         ) GROUP BY 1
         """
     )
+    # Per bucket: provisioned chips split into busy (worker running >=1 task)
+    # vs idle (running_task_count == 0). Drives the fleet-occupancy chart — the
+    # real "are accelerators doing work" signal, independent of W&B.
+    con.execute(
+        f"""
+        CREATE TEMP TABLE bucket_occupancy AS
+        SELECT wr.bucket,
+               sum(vi.chips_per_vm) AS chips_total,
+               sum(CASE WHEN wr.rtc > 0 THEN vi.chips_per_vm ELSE 0 END) AS chips_busy
+        FROM (
+            SELECT time_bucket(INTERVAL '{bucket}', ts) AS bucket, worker_id,
+                   lower(device_variant) AS variant, max(running_task_count) AS rtc
+            FROM read_parquet('{worker_glob}')
+            WHERE lower(device_type) = 'tpu' AND device_variant <> ''
+            GROUP BY 1, 2, 3
+        ) wr JOIN variant_info vi ON wr.variant = vi.variant
+        GROUP BY 1
+        """
+    )
     # Per (bucket, region): concurrent chips, for the regional footprint chart.
     # Region = zone with its trailing "-<letter>" stripped (us-east5-a -> us-east5).
     con.execute(
@@ -188,6 +207,33 @@ def _write_accelerators(con: duckdb.DuckDBPyConnection, daily_dir: str) -> None:
         """
     )
     logger.info("wrote %s", region_csv)
+
+
+def _write_utilization(con: duckdb.DuckDBPyConnection, daily_dir: str) -> None:
+    """Daily fleet occupancy: provisioned chips that were running a task vs idle.
+
+    Occupancy (allocation) is distinct from efficiency (MFU): a chip with a task
+    assigned counts as busy even if that task runs at low MFU. The calibration
+    chart covers the MFU side; this covers the "is anything scheduled on it"
+    side. Requires the ``bucket_occupancy`` temp table.
+    """
+    out = os.path.join(daily_dir, "utilization_daily.csv")
+    con.execute(
+        f"""
+        COPY (
+            SELECT bucket::DATE AS day,
+                   avg(chips_busy) AS mean_busy_chips,
+                   avg(chips_total - chips_busy) AS mean_idle_chips,
+                   avg(chips_total) AS mean_total_chips,
+                   sum(chips_busy) / nullif(sum(chips_total), 0) AS occupancy
+            FROM bucket_occupancy GROUP BY 1 ORDER BY 1
+        ) TO '{out}' (HEADER, DELIMITER ',')
+        """
+    )
+    logger.info("wrote %s", out)
+    summary = con.execute("SELECT sum(chips_busy) / nullif(sum(chips_total), 0) FROM bucket_occupancy").fetchone()
+    if summary and summary[0] is not None:
+        logger.info("fleet occupancy: %.1f%% of provisioned chip-time was running a task", 100 * summary[0])
 
 
 def _write_users(con: duckdb.DuckDBPyConnection, daily_dir: str, task_glob: str) -> None:
@@ -393,6 +439,7 @@ def run(paths: config.Paths) -> None:
     _log_variant_coverage(con, worker_glob)
     _build_bucket_tables(con, worker_glob)
     _write_accelerators(con, paths.daily_dir)
+    _write_utilization(con, paths.daily_dir)
     _write_users(con, paths.daily_dir, task_glob)
     _write_iris_capacity(con, paths.daily_dir)
 

--- a/lib/iris/scripts/blog_metrics/fetch.py
+++ b/lib/iris/scripts/blog_metrics/fetch.py
@@ -1,0 +1,119 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pipeline step 1: pull raw finelog data to local disk.
+
+Two sources, both cached under ``<data_dir>/raw`` so re-running ``extract`` /
+``charts`` never re-fetches:
+
+* ``iris.worker`` + ``iris.task`` parquet — mirrored wholesale with ``gsutil
+  rsync`` (a few GB each). These structured namespaces carry everything the
+  core charts need (device variant -> chips/FLOPS, running task counts, task
+  ids -> users).
+* ``/system/controller`` audit lines — *optional*, off by default. The ``log``
+  namespace is ~33 GB and clustered by ``key``; filtering to the controller key
+  still streams the big ``data`` column, so this is the expensive path. Only
+  needed for submission/demand series and milestone cross-checks.
+
+This module shells out to ``gsutil`` and the ``finelog`` CLI rather than
+reimplementing GCS/DuckDB plumbing.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+import subprocess
+
+import config
+import wandb_history
+
+logger = logging.getLogger(__name__)
+
+
+def _run(cmd: list[str]) -> None:
+    logger.info("$ %s", " ".join(cmd))
+    subprocess.run(cmd, check=True)
+
+
+def mirror_stats_namespaces(paths: config.Paths, *, force: bool = False) -> None:
+    """Mirror the iris.worker / iris.task parquet archives to ``raw/``.
+
+    Uses ``gsutil -m rsync`` so a re-run only transfers changed/new segments.
+    ``force`` adds ``-d`` to delete local segments no longer present remotely.
+    """
+    for namespace, dest in (
+        (config.WORKER_NAMESPACE, paths.worker_parquet),
+        (config.TASK_NAMESPACE, paths.task_parquet),
+    ):
+        os.makedirs(dest, exist_ok=True)
+        src = f"{config.REMOTE_LOG_DIR}/{namespace}"
+        cmd = ["gsutil", "-m", "rsync"]
+        if force:
+            cmd.append("-d")
+        cmd += [src, dest]
+        logger.info("mirroring %s -> %s", src, dest)
+        _run(cmd)
+
+
+def extract_controller_audit(paths: config.Paths) -> None:
+    """Extract ``/system/controller`` audit lines to a local parquet file.
+
+    Runs a key-pruned DuckDB query against the GCS-archived ``log`` namespace
+    via ``finelog gcs-query`` and keeps only the structured ``event=`` audit
+    lines (job submissions, worker lifecycle, scheduling passes). The result is
+    tiny; the cost is the remote scan of the ``data`` column.
+    """
+    os.makedirs(paths.raw_dir, exist_ok=True)
+    out = paths.controller_audit_parquet
+    # COPY ... TO writes parquet directly from the DuckDB result. Keep only
+    # audit lines (``event=``) to drop the high-volume provider/slice chatter.
+    sql = (
+        f"COPY (SELECT epoch_ms, data FROM log "
+        f"WHERE key = '{config.CONTROLLER_LOG_KEY}' AND data LIKE '%event=%') "
+        f"TO '{out}' (FORMAT parquet)"
+    )
+    cmd = [
+        "uv",
+        "run",
+        "finelog",
+        "gcs-query",
+        config.FINELOG_DEPLOYMENT,
+        sql,
+        "--namespace",
+        "log",
+    ]
+    logger.info("extracting controller audit lines -> %s (slow remote scan)", out)
+    # finelog lives in its own workspace package; run from there.
+    finelog_dir = os.path.abspath(os.path.join(config.PACKAGE_DIR, "..", "..", "..", "finelog"))
+    logger.info("$ (cwd=%s) %s", finelog_dir, " ".join(cmd))
+    subprocess.run(cmd, check=True, cwd=finelog_dir)
+
+
+def fetch_wandb(paths: config.Paths, *, force: bool = False) -> None:
+    """Pull W&B run history to the local cache, unless it already exists.
+
+    The full pull walks tens of thousands of runs (minutes), so it is skipped
+    when the cache is present; pass ``force`` to refresh.
+    """
+    if os.path.exists(paths.wandb_runs_parquet) and not force:
+        logger.info("W&B cache present (%s); skipping pull (use --force to refresh)", paths.wandb_runs_parquet)
+        return
+    wandb_history.fetch_runs(paths)
+
+
+def run(
+    paths: config.Paths,
+    *,
+    with_controller: bool = False,
+    with_wandb: bool = True,
+    force: bool = False,
+) -> None:
+    """Fetch all raw inputs for the pipeline."""
+    mirror_stats_namespaces(paths, force=force)
+    if with_wandb:
+        fetch_wandb(paths, force=force)
+    if with_controller:
+        extract_controller_audit(paths)
+    else:
+        logger.info("skipping controller audit extraction (pass --with-controller to enable)")

--- a/lib/iris/scripts/blog_metrics/pipeline.py
+++ b/lib/iris/scripts/blog_metrics/pipeline.py
@@ -1,0 +1,84 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Iris blog-metrics pipeline: TPU usage / users / tasks / FLOPS over time.
+
+Three independently re-runnable steps, each reading/writing on-disk artifacts so
+you can iterate on a later step without redoing an earlier one:
+
+    fetch     mirror iris.worker/iris.task parquet (+ optional controller audit)
+              to <data_dir>/raw
+    extract   roll the raw parquet up into per-day CSVs in <data_dir>/daily
+    charts    render SVG/PNG charts from the CSVs into <data_dir>/charts
+
+Usage (run from lib/iris; matplotlib is only needed for `charts`):
+
+    uv run python scripts/blog_metrics/pipeline.py fetch
+    uv run python scripts/blog_metrics/pipeline.py extract
+    uv run --with matplotlib python scripts/blog_metrics/pipeline.py charts
+    uv run --with matplotlib python scripts/blog_metrics/pipeline.py all
+
+The data source is the finelog `marin` deployment archived at
+gs://marin-us-central2/finelog/marin. Structured rows only go back to the
+finelog Rust migration (~2026-05-06), so the window is ~6 weeks, not months.
+"""
+
+from __future__ import annotations
+
+import argparse
+import logging
+import os
+import sys
+
+# Make the sibling modules importable whether run as a script or with -m.
+sys.path.insert(0, os.path.dirname(os.path.abspath(__file__)))
+
+import config
+import extract
+import fetch
+
+logger = logging.getLogger("blog_metrics")
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = argparse.ArgumentParser(description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+    parser.add_argument("step", choices=["fetch", "extract", "charts", "all"])
+    parser.add_argument(
+        "--data-dir",
+        default=None,
+        help=f"Root for raw/daily/charts artifacts (default: {config.DEFAULT_DATA_DIR})",
+    )
+    parser.add_argument(
+        "--with-controller",
+        action="store_true",
+        help="In `fetch`, also extract /system/controller audit lines (slow ~33GB remote scan).",
+    )
+    parser.add_argument(
+        "--no-wandb",
+        dest="with_wandb",
+        action="store_false",
+        help="In `fetch`, skip the W&B long-history pull (needs `--with wandb` + WANDB_API_KEY).",
+    )
+    parser.add_argument(
+        "--force",
+        action="store_true",
+        help="In `fetch`, refresh caches: rsync -d for stats parquet and re-pull the W&B history.",
+    )
+    args = parser.parse_args(argv)
+
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    paths = config.resolve_paths(args.data_dir)
+    logger.info("data dir: %s", paths.data_dir)
+
+    if args.step in ("fetch", "all"):
+        fetch.run(paths, with_controller=args.with_controller, with_wandb=args.with_wandb, force=args.force)
+    if args.step in ("extract", "all"):
+        extract.run(paths)
+    if args.step in ("charts", "all"):
+        import charts  # noqa: PLC0415  # lazy: only `charts` needs matplotlib
+
+        charts.run(paths)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/iris/scripts/blog_metrics/wandb_history.py
+++ b/lib/iris/scripts/blog_metrics/wandb_history.py
@@ -1,0 +1,173 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Bulk-fetch W&B run metadata to a local parquet cache (long-history source).
+
+Iris structured logs only reach back to ~2026-05-06; W&B run history reaches
+back to the project's start (~2024-04) and is the only source for pre-Iris
+compute. This pulls one row per run with the few summary fields needed to
+reconstruct compute over time, and caches them so ``extract``/``charts`` iterate
+locally without re-hitting the API.
+
+The high-level ``Api.runs()`` iterator is unusably slow here (~5 runs/s) because
+it downloads and deserializes each run's *full* summary — and the runs we want
+are the big training runs with thousands of logged metrics. Instead we issue a
+raw GraphQL query that projects ``summaryMetrics(keys: ...)`` down to the seven
+fields we need and filters to device-bearing runs server-side, which is ~100x
+faster (hundreds of runs/s).
+
+Requires the ``wandb`` package (run the pipeline's ``fetch`` step with
+``uv run --with wandb``) and ``WANDB_API_KEY`` in the environment.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import os
+import time
+
+import config
+import duckdb
+
+logger = logging.getLogger(__name__)
+
+_RUNTIME_KEYS = ("_runtime", "_wandb.runtime")
+_TOKENS_KEY = "throughput/total_tokens"
+_MFU_KEY = "throughput/mfu"
+# Projected summary keys — only these are downloaded per run.
+_SUMMARY_KEYS = ["num_devices", "num_hosts", "parameter_count", _TOKENS_KEY, _MFU_KEY, "backend", *_RUNTIME_KEYS]
+_PAGE_SIZE = 500
+
+_PARQUET_COLUMNS = (
+    "run_path",
+    "project",
+    "name",
+    "state",
+    "created_at",
+    "runtime_s",
+    "num_devices",
+    "num_hosts",
+    "parameter_count",
+    "total_tokens",
+    "mfu",
+    "backend",
+)
+
+# Cursor-paginated runs query. ``summaryMetrics(keys:)`` returns a JSON string
+# with only the requested keys; ``filters`` drops runs lacking device info
+# server-side so their (often huge) summaries are never touched.
+_RUNS_QUERY = """
+query BlogMetricsRuns($entity: String!, $project: String!, $cursor: String,
+                     $first: Int!, $keys: [String!], $filters: JSONString) {
+  project(name: $project, entityName: $entity) {
+    runs(first: $first, after: $cursor, filters: $filters) {
+      edges {
+        cursor
+        node { name displayName state createdAt summaryMetrics(keys: $keys) }
+      }
+      pageInfo { hasNextPage endCursor }
+    }
+  }
+}
+"""
+
+_DEVICE_FILTER = json.dumps({"summary_metrics.num_devices": {"$gt": 0}})
+
+
+def _parse_created_at(value: str | None) -> dt.datetime | None:
+    if not value:
+        return None
+    return dt.datetime.fromisoformat(value.replace("Z", "+00:00")).replace(tzinfo=None)
+
+
+def _first_float(summary: dict, keys: tuple[str, ...]) -> float | None:
+    for key in keys:
+        if key in summary and summary[key] is not None:
+            return float(summary[key])
+    return None
+
+
+def _row_from_node(node: dict, entity: str, project: str) -> tuple | None:
+    """Build the cache row from one GraphQL run node, or None if it lacks devices."""
+    summary = json.loads(node.get("summaryMetrics") or "{}")
+    num_devices = summary.get("num_devices")
+    if not num_devices:
+        return None
+    return (
+        f"{entity}/{project}/{node['name']}",
+        project,
+        node.get("displayName") or node["name"],
+        node.get("state"),
+        _parse_created_at(node.get("createdAt")),
+        _first_float(summary, _RUNTIME_KEYS),
+        int(num_devices),
+        int(summary["num_hosts"]) if summary.get("num_hosts") is not None else None,
+        int(summary["parameter_count"]) if summary.get("parameter_count") is not None else None,
+        float(summary[_TOKENS_KEY]) if summary.get(_TOKENS_KEY) is not None else None,
+        float(summary[_MFU_KEY]) if summary.get(_MFU_KEY) is not None else None,
+        str(summary["backend"]) if summary.get("backend") is not None else None,
+    )
+
+
+def _fetch_project_rows(api, entity: str, project: str) -> list[tuple]:
+    from wandb_gql import gql  # noqa: PLC0415  # ships with wandb; resolved alongside it
+
+    query = gql(_RUNS_QUERY)
+    logger.info("pulling %s/%s via projected GraphQL…", entity, project)
+    rows: list[tuple] = []
+    cursor: str | None = None
+    pages = 0
+    start = time.monotonic()
+    while True:
+        result = api.client.execute(
+            query,
+            variable_values={
+                "entity": entity,
+                "project": project,
+                "cursor": cursor,
+                "first": _PAGE_SIZE,
+                "keys": _SUMMARY_KEYS,
+                "filters": _DEVICE_FILTER,
+            },
+        )
+        conn = result["project"]["runs"]
+        for edge in conn["edges"]:
+            row = _row_from_node(edge["node"], entity, project)
+            if row is not None:
+                rows.append(row)
+        pages += 1
+        if pages % 20 == 0:
+            logger.info("  %d pages, %d runs (%.0fs)", pages, len(rows), time.monotonic() - start)
+        if not conn["pageInfo"]["hasNextPage"]:
+            break
+        cursor = conn["pageInfo"]["endCursor"]
+    logger.info("  %s/%s done: %d device-bearing runs (%.0fs)", entity, project, len(rows), time.monotonic() - start)
+    return rows
+
+
+def fetch_runs(paths: config.Paths, *, entity: str | None = None, projects: list[str] | None = None) -> None:
+    """Pull run metadata for ``projects`` and cache it to ``wandb_runs.parquet``."""
+    import wandb  # noqa: PLC0415  # optional dep, only needed for the W&B pull
+
+    entity = entity or config.WANDB_ENTITY
+    projects = projects or config.WANDB_PROJECTS
+    api = wandb.Api(timeout=60)
+
+    rows: list[tuple] = []
+    for project in projects:
+        rows.extend(_fetch_project_rows(api, entity, project))
+
+    os.makedirs(paths.raw_dir, exist_ok=True)
+    con = duckdb.connect()
+    con.execute(
+        "CREATE TABLE runs ("
+        " run_path VARCHAR, project VARCHAR, name VARCHAR, state VARCHAR,"
+        " created_at TIMESTAMP, runtime_s DOUBLE, num_devices INTEGER, num_hosts INTEGER,"
+        " parameter_count BIGINT, total_tokens DOUBLE, mfu DOUBLE, backend VARCHAR)"
+    )
+    con.executemany(f"INSERT INTO runs ({', '.join(_PARQUET_COLUMNS)}) VALUES (?,?,?,?,?,?,?,?,?,?,?,?)", rows)
+    con.execute(f"COPY runs TO '{paths.wandb_runs_parquet}' (FORMAT parquet)")
+    con.close()
+    logger.info("wrote %d run rows -> %s", len(rows), paths.wandb_runs_parquet)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -307,6 +307,8 @@ ignore-missing-imports = [
     "pylatexenc.*",
     "resiliparse",
     "resiliparse.*",
+    "seaborn",
+    "seaborn.*",
     "sympy",
     "sympy.*",
     "tensorboardX",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -258,6 +258,9 @@ search-path = [
     # benchmark_controller.py imports controller test fixtures from lib/iris/tests
     # (`from tests.cluster.controller... import`), run with lib/iris on sys.path.
     "lib/iris",
+    # blog_metrics is a standalone multi-file script package; its modules import
+    # each other by bare name (pipeline.py adds its own dir to sys.path at runtime).
+    "lib/iris/scripts/blog_metrics",
 ]
 disable-search-path-heuristics = true
 
@@ -294,6 +297,8 @@ ignore-missing-imports = [
     "lm_eval.*",
     "math_verify",
     "math_verify.*",
+    "matplotlib",
+    "matplotlib.*",
     "memray",
     "memray.*",
     "prompt_toolkit",
@@ -318,6 +323,10 @@ ignore-missing-imports = [
     "verifiers.*",
     "vllm",
     "vllm.*",
+    "wandb",
+    "wandb.*",
+    "wandb_gql",
+    "wandb_gql.*",
     "xprof",
     "xprof.*",
 ]


### PR DESCRIPTION
## What

A standalone three-step pipeline under `lib/iris/scripts/blog_metrics` that reconstructs the cluster's **TPU usage, active users, running tasks, and aggregate FLOPs over time** for the Iris blog post, at day granularity. Steps write on-disk artifacts between them, so a later step can be re-run (tweak a metric, restyle a chart) without redoing the expensive fetch:

```
fetch    -> data/raw/      (multi-GB parquet + W&B cache)
extract  -> data/daily/    (per-day CSVs)
charts   -> data/charts/   (SVG + PNG)
```

## Data sources

- **`iris.worker` / `iris.task`** structured finelog namespaces (bulk-copied to local parquet, aggregated in DuckDB) drive the accelerator, user, task, and regional series. These exist from ~2026-05-06 on (finelog Rust migration).
- **W&B run history** (`marin-community/marin`) is the only source reaching before Iris (back to ~2024-04). Realized training compute is `6 * N * D` from each run's `parameter_count` and `total_tokens` — no device-type lookup needed.

The W&B pull uses a projected GraphQL query (`summaryMetrics(keys: ...)` + a server-side device filter) so the 46k device-bearing runs fetch in ~2 min; the high-level `Api.runs()` iterator took 2+ hours because it deserializes each run's full (thousands-of-keys) summary.

## Calibration

In the overlap window the W&B realized series is checked against iris provisioned capacity:
- **device-hours coverage** = W&B-TPU device-hours / iris provisioned device-hours;
- **effective MFU** = W&B realized FLOPs / iris peak-capacity FLOPs.

Cross-check: dividing effective MFU by coverage recovers ~30-40% on-active MFU, which matches W&B's own device-hour-weighted logged `throughput/mfu` (~42%), so the 6*N*D estimate and the provisioned-capacity denominator are mutually consistent.

## FLOPs model

Per-chip peak bf16 FLOP/s are vendored from `lib/fray/src/fray/device_flops.py` (fray isn't importable from the iris env); a worker's contribution is `chips_per_vm * flops_per_chip` from its slice `device_variant`. This is provisioned/peak capacity — `iris.task.accelerator_util_pct` is null across the window, so realized MFU only comes from the W&B calibration.

## Notes

- All of `data/` is gitignored (every artifact is reproducible from the scripts). Headline charts are attached as weaver artifacts on this branch.
- `pyproject.toml` adds the script dir to the pyrefly `search-path` (sibling modules import by bare name) and `matplotlib` / `wandb` / `wandb_gql` to `ignore-missing-imports` (optional deps pulled in via `uv run --with`).
- Charts annotate milestones (priority bands, Ray->Iris cutover, scheduling queue, ...).

Closes #220.