### PR TITLE
[codex] Enable Transformers 5 TPU-vLLM stack

### DIFF
--- a/experiments/create_marin_tokenizer.py
+++ b/experiments/create_marin_tokenizer.py
@@ -13,6 +13,8 @@ The script uses temporary in-memory storage for intermediate operations.
 import json
 import os
 import tempfile
+from collections.abc import Mapping
+from typing import Any, cast
 
 import numpy as np
 from transformers import AutoTokenizer, PreTrainedTokenizer
@@ -25,7 +27,7 @@ from experiments.marin_models import marin_tokenizer as marin_tokenizer_hf_path
 def _inject_special_tokens(
     tokenizer: PreTrainedTokenizer,
     new_tokens: dict[int, str],
-):
+) -> PreTrainedTokenizer:
     """
     Inject special tokens into the tokenizer config.
 
@@ -45,8 +47,20 @@ def _inject_special_tokens(
         tokenizer_config_path = os.path.join(temp_path, "tokenizer_config.json")
         with open(tokenizer_config_path, "r") as f:
             tokenizer_config = json.load(f)
+        added_tokens_decoder = tokenizer_config.setdefault("added_tokens_decoder", {})
         for token_id, token_str in new_tokens.items():
-            tokenizer_config["added_tokens_decoder"][str(token_id)]["content"] = token_str
+            token_config = added_tokens_decoder.setdefault(
+                str(token_id),
+                {
+                    "content": token_str,
+                    "single_word": False,
+                    "lstrip": False,
+                    "rstrip": False,
+                    "normalized": False,
+                    "special": True,
+                },
+            )
+            token_config["content"] = token_str
         with open(tokenizer_config_path, "w") as f:
             json.dump(tokenizer_config, f)
 
@@ -57,16 +71,31 @@ def _inject_special_tokens(
                 tokenizer_json = json.load(f)
             # Update the added_tokens list (id -> content)
             if "added_tokens" in tokenizer_json:
+                seen_token_ids = set()
                 for at in tokenizer_json["added_tokens"]:
                     tid = at.get("id")
                     if tid in new_tokens:
+                        seen_token_ids.add(tid)
                         at["content"] = new_tokens[tid]
+                for tid, token_str in new_tokens.items():
+                    if tid not in seen_token_ids:
+                        tokenizer_json["added_tokens"].append(
+                            {
+                                "id": tid,
+                                "content": token_str,
+                                "single_word": False,
+                                "lstrip": False,
+                                "rstrip": False,
+                                "normalized": False,
+                                "special": True,
+                            }
+                        )
             # Persist the file back
             with open(tokenizer_json_path, "w") as f:
                 json.dump(tokenizer_json, f)
 
         # Load the modified tokenizer
-        return AutoTokenizer.from_pretrained(temp_path)
+        return cast(PreTrainedTokenizer, AutoTokenizer.from_pretrained(temp_path))
 
 
 def create_marin_tokenizer(
@@ -100,7 +129,19 @@ def load_llama3_tokenizer() -> PreTrainedTokenizer:
     Raises:
         OSError, GatedRepoError, HTTPError: If access to the tokenizer is not available
     """
-    return AutoTokenizer.from_pretrained(llama3_tokenizer_hf_path)
+    return cast(PreTrainedTokenizer, AutoTokenizer.from_pretrained(llama3_tokenizer_hf_path))
+
+
+def _apply_chat_template_dict(marin_tokenizer: PreTrainedTokenizer) -> Mapping[str, Any]:
+    return cast(
+        Mapping[str, Any],
+        marin_tokenizer.apply_chat_template(
+            TEST_CONVERSATION,
+            tokenize=True,
+            return_dict=True,
+            return_assistant_tokens_mask=True,
+        ),
+    )
 
 
 # ============ Test data and functions ============
@@ -130,18 +171,14 @@ def chat_template_checks(marin_tokenizer: PreTrainedTokenizer):
     assert marin_tokenizer.tokenize("Hello, how are you?") == llama3_tokenizer.tokenize("Hello, how are you?")
 
     """Test that special tokens are used in chat template."""
-    out = marin_tokenizer.apply_chat_template(
-        TEST_CONVERSATION, tokenize=True, return_dict=True, return_assistant_tokens_mask=True
+    out = _apply_chat_template_dict(marin_tokenizer)
+    special_token_ids = cast(
+        list[int], marin_tokenizer.convert_tokens_to_ids(["<|start_header_id|>", "<|end_header_id|>", "<|eot_id|>"])
     )
-    assert all(
-        token in out["input_ids"]
-        for token in marin_tokenizer.convert_tokens_to_ids(["<|start_header_id|>", "<|end_header_id|>", "<|eot_id|>"])
-    )
+    assert all(token in out["input_ids"] for token in special_token_ids)
 
     """Test that assistant tokens are masked correctly."""
-    out = marin_tokenizer.apply_chat_template(
-        TEST_CONVERSATION, tokenize=True, return_dict=True, return_assistant_tokens_mask=True
-    )
+    out = _apply_chat_template_dict(marin_tokenizer)
     expected_length = len(marin_tokenizer(REASONING_TRACE_EXAMPLE + "I'm doing well, thanks!")["input_ids"]) + len(
         marin_tokenizer("Great!")["input_ids"]
     )
@@ -150,9 +187,7 @@ def chat_template_checks(marin_tokenizer: PreTrainedTokenizer):
     ), f"Expected {expected_length} assistant tokens, got {np.sum(out['assistant_masks'])}"
 
     """Test that decoding of assistant tokens is correct."""
-    out = marin_tokenizer.apply_chat_template(
-        TEST_CONVERSATION, tokenize=True, return_dict=True, return_assistant_tokens_mask=True
-    )
+    out = _apply_chat_template_dict(marin_tokenizer)
     ids = np.array(out["input_ids"])
     expected_text = REASONING_TRACE_EXAMPLE + "I'm doing well, thanks!<|eot_id|>Great!<|eot_id|>"
     assert marin_tokenizer.decode(ids[np.array(out["assistant_masks"]).astype(bool)]) == expected_text

--- a/lib/fray/pyproject.toml
+++ b/lib/fray/pyproject.toml
@@ -30,6 +30,7 @@ fray_test = [
     "pytest-timeout",
     "pytest>=8.3.2",
 ]
+# Exact TPU pins mirror Marin core's TPU/vLLM extras and Levanter's TPU extra.
 fray_tpu_test = ["jax==0.10.0", "jaxlib==0.10.0", "libtpu==0.0.40", { include-group = "fray_test" }]
 
 dev = [{ include-group = "fray_test" }]

--- a/lib/levanter/pyproject.toml
+++ b/lib/levanter/pyproject.toml
@@ -43,7 +43,7 @@ dependencies = [
     "einops",
     "jaxtyping>=0.2.34",
     "tokenizers>=0.15.2",
-    "transformers>=4.57.1,<5.0",
+    "transformers>=4.57.1,<6.0",
     "chex>=0.1.86",
     "optax>=0.1.9,<0.2.7",
     "wandb>0.24.0",
@@ -99,6 +99,7 @@ deepep = [
   # The Levanter wheel ships the JAX FFI shim sources; CUDA toolchain dependencies
   # come from the host GPU environment.
 ]
+# Exact TPU pins mirror Marin core's TPU/vLLM extras and Fray's TPU test group.
 tpu = ["jax==0.10.0", "jaxlib==0.10.0", "libtpu==0.0.40"]
 torch_test = [
   "torch>=2.7.0",

--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -1354,11 +1354,17 @@ def _is_retryable_hf_exception(exc: Exception) -> bool:
 def load_tokenizer(model_name_or_path, revision=None, local_cache_dir=None, trust_remote_code=True) -> HfTokenizer:
     """Like AutoTokenizer.from_pretrained, but works with gs:// paths or anything on fsspec"""
     with _patch_hf_hub_download():
-        return _hf_hub_retry(
-            lambda: AutoTokenizer.from_pretrained(
-                model_name_or_path, revision=revision, cache_dir=local_cache_dir, trust_remote_code=trust_remote_code
+        return cast(
+            HfTokenizer,
+            _hf_hub_retry(
+                lambda: AutoTokenizer.from_pretrained(
+                    model_name_or_path,
+                    revision=revision,
+                    cache_dir=local_cache_dir,
+                    trust_remote_code=trust_remote_code,
+                ),
+                action=f"load tokenizer {model_name_or_path!r}",
             ),
-            action=f"load tokenizer {model_name_or_path!r}",
         )
 
 

--- a/lib/levanter/src/levanter/compat/hf_config.py
+++ b/lib/levanter/src/levanter/compat/hf_config.py
@@ -1,0 +1,62 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from collections.abc import Mapping
+from typing import Any, TypeVar, cast
+
+ConfigT = TypeVar("ConfigT")
+
+
+def hf_config_from_kwargs(config_cls: type[ConfigT], **kwargs: Any) -> ConfigT:
+    """Construct HF configs with runtime kwargs that generated stubs may omit."""
+    return cast(Any, config_cls)(**kwargs)
+
+
+def hf_rope_parameter_mapping(hf_config: Any, *, include_rope_scaling: bool = False) -> Mapping[str, Any] | None:
+    rope_parameters = getattr(hf_config, "rope_parameters", None)
+    if isinstance(rope_parameters, Mapping):
+        return rope_parameters
+
+    if include_rope_scaling:
+        rope_scaling = getattr(hf_config, "rope_scaling", None)
+        if isinstance(rope_scaling, Mapping):
+            return rope_scaling
+
+    return None
+
+
+def hf_rope_config(
+    hf_config: Any,
+    default_theta: float = 10_000.0,
+    *,
+    rope_parameter_keys: tuple[str, ...] = (),
+) -> tuple[float, Any | None]:
+    rope_theta = getattr(hf_config, "rope_theta", None)
+    rope_scaling = getattr(hf_config, "rope_scaling", None)
+    rope_parameters = hf_rope_parameter_mapping(hf_config)
+
+    if rope_parameter_keys and rope_theta is None and rope_parameters is not None:
+        rope_theta = rope_parameters.get("rope_theta")
+        selected_rope_config = None
+        for key in rope_parameter_keys:
+            if rope_theta is not None:
+                break
+            attention_rope = rope_parameters.get(key)
+            if isinstance(attention_rope, Mapping):
+                rope_theta = attention_rope.get("rope_theta")
+                selected_rope_config = attention_rope
+
+        if selected_rope_config is not None:
+            rope_scaling = selected_rope_config
+        elif rope_scaling is None:
+            rope_scaling = rope_parameters
+    elif rope_parameters is not None:
+        if rope_theta is None:
+            rope_theta = rope_parameters.get("rope_theta")
+        if rope_scaling is None:
+            rope_scaling = rope_parameters
+
+    if rope_theta is None:
+        rope_theta = default_theta
+
+    return float(rope_theta), rope_scaling

--- a/lib/levanter/src/levanter/models/apertus.py
+++ b/lib/levanter/src/levanter/models/apertus.py
@@ -17,6 +17,7 @@ from haliax.nn.scan import BlockFoldable, BlockSeq, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
+from levanter.compat.hf_config import hf_config_from_kwargs
 from levanter.inference.page_table import PageBatchInfo, PageTableSpec
 from levanter.layers.attention import Attention, AttentionMask
 from levanter.layers.kv_cache import KvPageCache, ListCache
@@ -161,7 +162,8 @@ class ApertusConfig(LlamaConfig):
         else:
             rope_parameters = {"rope_type": "default", "rope_theta": rope_theta}
 
-        hf_config = HfApertusConfig(
+        hf_config = hf_config_from_kwargs(
+            HfApertusConfig,
             vocab_size=vocab_size,
             hidden_size=self.hidden_dim,
             intermediate_size=self.intermediate_dim,

--- a/lib/levanter/src/levanter/models/gemma.py
+++ b/lib/levanter/src/levanter/models/gemma.py
@@ -17,6 +17,7 @@ from haliax.nn.scan import BlockFoldable, BlockSeq, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
+from levanter.compat.hf_config import hf_config_from_kwargs, hf_rope_config, hf_rope_parameter_mapping
 from levanter.layers.attention import Attention, AttentionBackend, AttentionConfig, AttentionMask
 from levanter.layers.normalization import LayerNormConfigBase
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
@@ -35,6 +36,63 @@ from transformers import Gemma3Config as HfGemma3Config  # noqa: E402
 from transformers import Gemma3TextConfig as _HFGemma3Config  # noqa: E402
 from transformers import GemmaConfig as HfGemmaConfig  # noqa: E402
 from transformers import PretrainedConfig as HfConfig  # noqa: E402
+
+
+def _gemma_rope_config_from_hf(hf_config: HfConfig) -> RotaryEmbeddingsConfig:
+    rope_theta, rope_scaling = hf_rope_config(
+        hf_config,
+        rope_parameter_keys=("full_attention", "sliding_attention"),
+    )
+    return RotaryEmbeddingsConfig.from_hf_config(rope_theta, rope_scaling)
+
+
+def _hf_query_pre_attn_scalar(value: float | int | None, head_dim: int) -> int:
+    scalar = head_dim if value is None else value
+    if int(scalar) != scalar:
+        raise ValueError(f"Gemma query_pre_attn_scalar must be an integer for HF compatibility, got {scalar}.")
+    return int(scalar)
+
+
+def _hf_optional_float(value: float | int | None) -> float | None:
+    return None if value is None else float(value)
+
+
+def _gemma3_hf_rope_parameters(
+    rope_theta: float, rope_scaling: dict | None, rope_local_base_freq: float, layer_types: list[str]
+) -> dict[str, dict[str, object]]:
+    full_attention: dict[str, object] = {"rope_type": "default", "rope_theta": rope_theta}
+    if rope_scaling is not None:
+        full_attention.update(rope_scaling)
+        full_attention["rope_type"] = str(full_attention.pop("type", full_attention.get("rope_type", "default")))
+
+    rope_parameters: dict[str, dict[str, object]] = {}
+    if "full_attention" in layer_types:
+        rope_parameters["full_attention"] = full_attention
+    if "sliding_attention" in layer_types:
+        rope_parameters["sliding_attention"] = {"rope_type": "default", "rope_theta": rope_local_base_freq}
+    return rope_parameters
+
+
+def _gemma3_hf_layer_types(num_layers: int, sliding_window_pattern: int | None) -> list[str]:
+    pattern = sliding_window_pattern if sliding_window_pattern is not None else 1
+    return [
+        "sliding_attention" if bool((layer_idx + 1) % pattern) else "full_attention" for layer_idx in range(num_layers)
+    ]
+
+
+def _gemma3_local_rope_theta_from_hf(hf_config: HfConfig) -> float:
+    rope_local_base_freq = getattr(hf_config, "rope_local_base_freq", None)
+    if rope_local_base_freq is not None:
+        return rope_local_base_freq
+
+    rope_parameters = hf_rope_parameter_mapping(hf_config, include_rope_scaling=True)
+    if rope_parameters is not None:
+        sliding_attention = rope_parameters.get("sliding_attention")
+        if isinstance(sliding_attention, dict):
+            return sliding_attention.get("rope_theta", 10_000.0)
+
+    return 10_000.0
+
 
 # Gemma is... very similar to Llama, so we use much of the same modeling code.
 #
@@ -121,9 +179,7 @@ class GemmaConfig(HFCompatConfig):
             self.num_heads % self.num_kv_heads == 0
         ), f"num_heads={self.num_heads} not divisible by num_kv_heads={self.num_kv_heads}."
 
-    def hf_checkpoint_converter(
-        self, ref_checkpoint: str = "google/gemma-2b"
-    ) -> HFCheckpointConverter["GemmaConfig"]:  # type: ignore
+    def hf_checkpoint_converter(self, ref_checkpoint: str = "google/gemma-2b") -> HFCheckpointConverter["GemmaConfig"]:  # type: ignore
         return HFCheckpointConverter(
             self,
             reference_checkpoint=ref_checkpoint,
@@ -191,7 +247,8 @@ class GemmaConfig(HFCompatConfig):
         ), "Only DefaultRotaryEmbeddingsConfig is supported for Gemma."
         rope_theta, rope_scaling = rope.to_hf_config()
 
-        config = HfGemmaConfig(
+        config = hf_config_from_kwargs(
+            HfGemmaConfig,
             max_position_embeddings=self.max_seq_len,
             hidden_size=self.hidden_dim,
             intermediate_size=self.intermediate_dim,
@@ -524,14 +581,15 @@ class Gemma2Config(GemmaConfig):
             rope_theta=rope_theta,
             rope_scaling=rope_scaling,
             # Gemma-2 additions
-            query_pre_attn_scalar=self.query_pre_attn_scalar or self.head_dim,
-            final_logit_softcapping=self.final_logit_softcapping,
-            attn_logit_softcapping=self.attn_logit_softcapping,
+            query_pre_attn_scalar=_hf_query_pre_attn_scalar(self.query_pre_attn_scalar, self.head_dim),
+            final_logit_softcapping=_hf_optional_float(self.final_logit_softcapping),
+            attn_logit_softcapping=_hf_optional_float(self.attn_logit_softcapping),
             sliding_window=self.sliding_window if self.sliding_window is not None else self.max_seq_len,
         )
 
         # Merge user-overrides last so callers can tweak anything.
-        cfg = HfGemma2Config(
+        cfg = hf_config_from_kwargs(
+            HfGemma2Config,
             **common_args,
             _attn_implementation="eager",
             **config_overrides,
@@ -553,8 +611,7 @@ class Gemma2Config(GemmaConfig):
         assert activation_function is not None, "No activation function found in HF configuration."
         activation_function_enum = getattr(ActivationFunctionEnum, activation_function)
 
-        rope_theta, rope_scaling = hf_config.rope_theta, getattr(hf_config, "rope_scaling", None)
-        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, rope_scaling)
+        rope_config = _gemma_rope_config_from_hf(hf_config)
 
         return Gemma2Config(
             max_seq_len=hf_config.max_position_embeddings,
@@ -825,6 +882,7 @@ class Gemma3Config(Gemma2Config):
         rope = self.rope
         assert isinstance(rope, DefaultRotaryEmbeddingsConfig)
         rope_theta, rope_scaling = rope.to_hf_config()
+        layer_types = _gemma3_hf_layer_types(self.num_layers, self.sliding_window_pattern)
 
         common_args = dict(
             max_position_embeddings=self.max_seq_len,
@@ -843,21 +901,25 @@ class Gemma3Config(Gemma2Config):
             vocab_size=vocab_size,
             rope_theta=rope_theta,
             rope_scaling=rope_scaling,
-            use_qk_norm=self.use_qk_norm,
             rope_local_base_freq=self.rope_local_base_freq,
-            query_pre_attn_scalar=self.query_pre_attn_scalar or self.head_dim,
+            rope_parameters=_gemma3_hf_rope_parameters(
+                rope_theta, rope_scaling, self.rope_local_base_freq, layer_types
+            ),
+            use_qk_norm=self.use_qk_norm,
+            query_pre_attn_scalar=_hf_query_pre_attn_scalar(self.query_pre_attn_scalar, self.head_dim),
             final_logit_softcapping=self.final_logit_softcapping,
             attn_logit_softcapping=self.attn_logit_softcapping,
             sliding_window=self.sliding_window if self.sliding_window is not None else self.max_seq_len,
-            # we don't currently suport alternating local/global attention, so every layer is global
-            sliding_window_pattern=self.sliding_window_pattern if self.sliding_window_pattern is not None else 1,
+            # we don't currently suport alternating local/global attention, so every layer is global by default
+            layer_types=layer_types,
             attention_dropout=0.0,
             attention_bias=self.use_bias,  # Gemma3 uses bias in attention
             # we have to set this for some reason even though it's default
             use_cache=True,
         )
 
-        cfg = _HFGemma3Config(
+        cfg = hf_config_from_kwargs(
+            _HFGemma3Config,
             **common_args,
             _attn_implementation="eager",
             **config_overrides,
@@ -878,8 +940,7 @@ class Gemma3Config(Gemma2Config):
         assert activation_function is not None, "No activation function found in HF configuration."
         activation_function_enum = getattr(ActivationFunctionEnum, activation_function)
 
-        rope_theta, rope_scaling = hf_config.rope_theta, getattr(hf_config, "rope_scaling", None)
-        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, rope_scaling)
+        rope_config = _gemma_rope_config_from_hf(hf_config)
 
         return Gemma3Config(
             max_seq_len=hf_config.max_position_embeddings,
@@ -896,7 +957,7 @@ class Gemma3Config(Gemma2Config):
             head_dim=hf_config.head_dim,
             query_pre_attn_scalar=getattr(hf_config, "query_pre_attn_scalar", hf_config.head_dim),
             use_qk_norm=getattr(hf_config, "use_qk_norm", True),
-            rope_local_base_freq=getattr(hf_config, "rope_local_base_freq", 10_000.0),
+            rope_local_base_freq=_gemma3_local_rope_theta_from_hf(hf_config),
         )
 
     def attention_config(self) -> AttentionConfig:  # type: ignore[override]

--- a/lib/levanter/src/levanter/models/llama.py
+++ b/lib/levanter/src/levanter/models/llama.py
@@ -18,6 +18,7 @@ from haliax.nn.scan import BlockFoldable, BlockSeq, ScanCheckpointPolicy, Stacke
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
+from levanter.compat.hf_config import hf_config_from_kwargs, hf_rope_config
 from levanter.inference.page_table import PageBatchInfo, PageTableSpec
 from levanter.layers import LayerNormConfigBase, RmsNormConfig
 from levanter.layers.attention import Attention, AttentionBackend, AttentionConfig, AttentionMask
@@ -114,8 +115,8 @@ class LlamaConfig(HFCompatConfig):
 
     @classmethod
     def from_hf_config(cls, hf_config: HfConfig):
-        rope_theta = hf_config.rope_theta
-        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, getattr(hf_config, "rope_scaling", None))
+        rope_theta, rope_scaling = hf_rope_config(hf_config)
+        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, rope_scaling)
         return LlamaConfig(
             max_seq_len=hf_config.max_position_embeddings,
             hidden_dim=hf_config.hidden_size,
@@ -160,7 +161,8 @@ class LlamaConfig(HFCompatConfig):
             rope_theta = None
             rope_scaling = None
 
-        return HfLlamaConfig(
+        return hf_config_from_kwargs(
+            HfLlamaConfig,
             max_position_embeddings=self.max_seq_len,
             hidden_size=self.hidden_dim,
             intermediate_size=self.intermediate_dim,

--- a/lib/levanter/src/levanter/models/mistral.py
+++ b/lib/levanter/src/levanter/models/mistral.py
@@ -14,6 +14,7 @@ from haliax.jax_utils import maybe_rng_split
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
+from levanter.compat.hf_config import hf_config_from_kwargs, hf_rope_config
 from levanter.layers.attention import AttentionBackend, AttentionConfig, AttentionMask
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaConfig, LlamaEmbedding, LlamaTransformer
@@ -95,7 +96,7 @@ class MistralConfig(LlamaConfig):
 
     @classmethod
     def from_hf_config(cls, hf_config: HfConfig):
-        rope_theta = hf_config.rope_theta
+        rope_theta, _ = hf_rope_config(hf_config)
         rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, None)
         return MistralConfig(
             max_seq_len=hf_config.max_position_embeddings,  # this might be too big...
@@ -128,7 +129,8 @@ class MistralConfig(LlamaConfig):
 
         rope_theta, rope_scaling = self.rope.to_hf_config()
 
-        return HfMistralConfig(
+        return hf_config_from_kwargs(
+            HfMistralConfig,
             max_position_embeddings=self.max_seq_len,
             hidden_size=self.hidden_dim,
             intermediate_size=self.intermediate_dim,

--- a/lib/levanter/src/levanter/models/mixtral.py
+++ b/lib/levanter/src/levanter/models/mixtral.py
@@ -24,6 +24,7 @@ from haliax.state_dict import ModuleWithStateDictSerialization, StateDict
 
 import levanter.tracker
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
+from levanter.compat.hf_config import hf_config_from_kwargs, hf_rope_config
 from levanter.layers.attention import Attention, AttentionBackend, AttentionConfig, AttentionMask
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaEmbedding, LlamaMlp
@@ -134,7 +135,7 @@ class MixtralConfig(MistralConfig):
 
     @classmethod
     def from_hf_config(cls, hf_config: HfConfig):
-        rope_theta = hf_config.rope_theta
+        rope_theta, _ = hf_rope_config(hf_config)
         rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, None)
         return MixtralConfig(
             max_seq_len=hf_config.max_position_embeddings,
@@ -170,7 +171,8 @@ class MixtralConfig(MistralConfig):
 
         rope_theta, rope_scaling = self.rope.to_hf_config()
 
-        return HfMixtralConfig(
+        return hf_config_from_kwargs(
+            HfMixtralConfig,
             max_position_embeddings=self.max_seq_len,
             hidden_size=self.hidden_dim,
             intermediate_size=self.intermediate_dim,
@@ -285,20 +287,28 @@ class MixtralMoEMlp(ModuleWithStateDictSerialization):
         return outputs
 
     def to_state_dict(self, prefix: Optional[str] = None) -> StateDict:
-        w = [self.w1.weight, self.w2.weight, self.w3.weight]
-        out = {}
-
-        num_experts = self.w1.Experts.size
-        for i in range(num_experts):
-            for j in range(3):
-                key = f"{prefix}.{i}.w{j + 1}.weight"
-                val = w[j]["experts", i].array
-                # out[key] = val
-                out[key] = jnp.swapaxes(val, -1, -2)
-
-        return out
+        gate_proj = jnp.swapaxes(self.w1.weight.array, -1, -2)
+        up_proj = jnp.swapaxes(self.w3.weight.array, -1, -2)
+        down_proj = jnp.swapaxes(self.w2.weight.array, -1, -2)
+        return {
+            f"{prefix}.gate_up_proj": jnp.concatenate([gate_proj, up_proj], axis=-2),
+            f"{prefix}.down_proj": down_proj,
+        }
 
     def from_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None) -> "MixtralMoEMlp":
+        gate_up_key = f"{prefix}.gate_up_proj"
+        down_key = f"{prefix}.down_proj"
+        if gate_up_key in state_dict and down_key in state_dict:
+            gate_up_proj = state_dict[gate_up_key]
+            gate_proj, up_proj = jnp.split(gate_up_proj, 2, axis=-2)
+            down_proj = state_dict[down_key]
+            values = [
+                jnp.swapaxes(gate_proj, -1, -2),
+                jnp.swapaxes(down_proj, -1, -2),
+                jnp.swapaxes(up_proj, -1, -2),
+            ]
+            return eqx.tree_at(lambda m: [m.w1.weight.array, m.w2.weight.array, m.w3.weight.array], self, values)
+
         w: List[List[Array]] = [[], [], []]
         num_experts = self.w1.Experts.size
         for i in range(num_experts):
@@ -335,6 +345,28 @@ class MixtralSparseMoeBlock(eqx.Module):
         )
 
         return MixtralSparseMoeBlock(config, gate, experts)
+
+    def _state_dict_key_map(self) -> Dict[str, Optional[str]]:
+        return {"gate": "gate", "experts": "experts"}
+
+    def to_state_dict(self, prefix: Optional[str] = None) -> StateDict:
+        gate_prefix = "gate" if prefix is None else f"{prefix}.gate"
+        experts_prefix = "experts" if prefix is None else f"{prefix}.experts"
+        state_dict = self.gate.to_state_dict(gate_prefix)
+        state_dict.update(self.experts.to_state_dict(experts_prefix))
+        return state_dict
+
+    def from_state_dict(self, state_dict: StateDict, prefix: Optional[str] = None) -> "MixtralSparseMoeBlock":
+        gate_prefix = "gate" if prefix is None else f"{prefix}.gate"
+        experts_prefix = "experts" if prefix is None else f"{prefix}.experts"
+        if f"{gate_prefix}.weight" not in state_dict and prefix is not None and prefix.endswith(".mlp"):
+            legacy_prefix = f"{prefix.removesuffix('.mlp')}.block_sparse_moe"
+            gate_prefix = f"{legacy_prefix}.gate"
+            experts_prefix = f"{legacy_prefix}.experts"
+
+        gate = self.gate.from_state_dict(state_dict, gate_prefix)
+        experts = self.experts.from_state_dict(state_dict, experts_prefix)
+        return dataclasses.replace(self, gate=gate, experts=experts)
 
     def _route(self, router_probs: NamedArray, Token: Axis, TopExperts: Axis):
         @partial(
@@ -531,6 +563,9 @@ class MixtralDecoderLayer(eqx.Module):
         moe_output, extras = self.block_sparse_moe(x, key=k_mlp)
         output = residual + mlp_output + moe_output
         return output, extras
+
+    def _state_dict_key_map(self) -> Dict[str, Optional[str]]:
+        return {"block_sparse_moe": "mlp"}
 
 
 class MixtralTransformer(eqx.Module):

--- a/lib/levanter/src/levanter/models/olmo.py
+++ b/lib/levanter/src/levanter/models/olmo.py
@@ -18,6 +18,7 @@ from haliax.nn.scan import BlockSeq, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
+from levanter.compat.hf_config import hf_config_from_kwargs, hf_rope_config
 from levanter.layers import RmsNormConfig
 from levanter.layers.attention import (
     Attention,
@@ -115,8 +116,8 @@ class Olmo2Config(HFCompatConfig):
 
     @classmethod
     def from_hf_config(cls, hf_config: HfConfig):
-        rope_theta = getattr(hf_config, "rope_theta", 500000)
-        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, hf_config.rope_scaling)
+        rope_theta, rope_scaling = hf_rope_config(hf_config, default_theta=500000.0)
+        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, rope_scaling)
         return Olmo2Config(
             max_seq_len=hf_config.max_position_embeddings,
             hidden_dim=hf_config.hidden_size,
@@ -148,7 +149,8 @@ class Olmo2Config(HFCompatConfig):
 
         rope_theta, rope_scaling = self.rope.to_hf_config()
 
-        return HfOlmo2Config(
+        return hf_config_from_kwargs(
+            HfOlmo2Config,
             max_position_embeddings=self.max_seq_len,
             hidden_size=self.hidden_dim,
             intermediate_size=self.intermediate_dim,

--- a/lib/levanter/src/levanter/models/olmo3.py
+++ b/lib/levanter/src/levanter/models/olmo3.py
@@ -24,6 +24,7 @@ from haliax.nn.scan import BlockFoldable, BlockSeq, ScanCheckpointPolicy, Stacke
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter, HFCompatConfig
+from levanter.compat.hf_config import hf_config_from_kwargs, hf_rope_config
 from levanter.layers import RmsNormConfig
 from levanter.layers.attention import Attention, AttentionBackend, AttentionConfig, AttentionMask
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
@@ -101,8 +102,8 @@ class Olmo3Config(HFCompatConfig):
 
     @classmethod
     def from_hf_config(cls, hf_config: HfConfig) -> "Olmo3Config":  # type: ignore[override]
-        rope_theta = getattr(hf_config, "rope_theta", 10000.0)
-        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, hf_config.rope_scaling)
+        rope_theta, rope_scaling = hf_rope_config(hf_config)
+        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, rope_scaling)
         return Olmo3Config(
             max_seq_len=hf_config.max_position_embeddings,
             hidden_dim=hf_config.hidden_size,
@@ -127,7 +128,8 @@ class Olmo3Config(HFCompatConfig):
 
         rope_theta, rope_scaling = self.rope.to_hf_config()
 
-        return HfOlmo3Config(
+        return hf_config_from_kwargs(
+            HfOlmo3Config,
             max_position_embeddings=self.max_seq_len,
             hidden_size=self.hidden_dim,
             intermediate_size=self.intermediate_dim,
@@ -207,22 +209,12 @@ class Olmo3Config(HFCompatConfig):
         )
 
     def attention_config_for_layer(self, layer_idx: int) -> AttentionConfig:
-        """Build attention config for a specific layer.
-
-        OLMo3 uses different RoPE configurations per layer type:
-        - sliding_attention: uses "default" (vanilla) RoPE + sliding window
-        - full_attention: uses the model's rope config (e.g., YARN)
-
-        This matches HuggingFace's implementation which creates separate rotary
-        embedding modules for each attention type.
-        """
+        """Build attention config for a specific layer."""
         attn_config = self.attention_config()
         layer_types = self.get_layer_types()
         attention_type = layer_types[layer_idx]
         if attention_type == "sliding_attention":
-            # Sliding attention uses vanilla RoPE (not YARN) + sliding window
-            vanilla_rope = DefaultRotaryEmbeddingsConfig(theta=self.rope.theta)
-            return dataclasses.replace(attn_config, sliding_window=self.sliding_window, rope=vanilla_rope)
+            return dataclasses.replace(attn_config, sliding_window=self.sliding_window)
         return attn_config
 
     def init_attention(self, layer_idx: int, *, key) -> Attention:

--- a/lib/levanter/src/levanter/models/qwen.py
+++ b/lib/levanter/src/levanter/models/qwen.py
@@ -16,6 +16,7 @@ from haliax.nn.scan import BlockFoldable, BlockSeq, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
+from levanter.compat.hf_config import hf_config_from_kwargs, hf_rope_config
 from levanter.layers.attention import Attention, AttentionConfig, AttentionMask
 from levanter.layers.rotary import RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaConfig, LlamaEmbedding, LlamaLMHeadModel, LlamaMlp, LlamaTransformer
@@ -56,8 +57,8 @@ class QwenConfig(LlamaConfig):
 
     @classmethod
     def from_hf_config(cls, hf_config: HfConfig):
-        rope_theta = hf_config.rope_theta
-        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, hf_config.rope_scaling)
+        rope_theta, rope_scaling = hf_rope_config(hf_config)
+        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, rope_scaling)
         return QwenConfig(
             max_seq_len=hf_config.max_position_embeddings,
             hidden_dim=hf_config.hidden_size,
@@ -85,7 +86,8 @@ class QwenConfig(LlamaConfig):
 
         rope_theta, rope_scaling = self.rope.to_hf_config()
 
-        return HfQwenConfig(
+        return hf_config_from_kwargs(
+            HfQwenConfig,
             max_position_embeddings=self.max_seq_len,
             hidden_size=self.hidden_dim,
             intermediate_size=self.intermediate_dim,
@@ -192,8 +194,8 @@ class QwenDecoderLayer(eqx.Module):
 class QwenTransformer(LlamaTransformer):
     # config-reuse: QwenTransformer reuses LlamaTransformer but narrows config/layers to its own
     # Qwen types (LSP narrowing; mypy flags the same)
-    config: QwenConfig = eqx.field(static=True)  # pyrefly: ignore[bad-override-mutable-attribute]
-    layers: BlockFoldable[QwenDecoderLayer]  # pyrefly: ignore[bad-override-mutable-attribute]
+    config: QwenConfig = eqx.field(static=True)  # pyrefly: ignore[bad-override]
+    layers: BlockFoldable[QwenDecoderLayer]  # pyrefly: ignore[bad-override]
     norm: hnn.RmsNorm
 
     @staticmethod
@@ -328,7 +330,8 @@ class Qwen3Config(LlamaConfig):
 
         rope_theta, rope_scaling = self.rope.to_hf_config()
 
-        return HfQwen3Config(
+        return hf_config_from_kwargs(
+            HfQwen3Config,
             max_position_embeddings=self.max_seq_len,
             hidden_size=self.hidden_dim,
             intermediate_size=self.intermediate_dim,
@@ -352,8 +355,8 @@ class Qwen3Config(LlamaConfig):
 
     @classmethod
     def from_hf_config(cls, hf_config: HfConfig) -> "Qwen3Config":  # type: ignore[override]
-        rope_theta = hf_config.rope_theta
-        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, hf_config.rope_scaling)
+        rope_theta, rope_scaling = hf_rope_config(hf_config)
+        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, rope_scaling)
 
         return Qwen3Config(
             max_seq_len=hf_config.max_position_embeddings,

--- a/lib/levanter/src/levanter/models/qwen3_moe.py
+++ b/lib/levanter/src/levanter/models/qwen3_moe.py
@@ -21,6 +21,7 @@ from haliax.nn.scan import BlockFoldable, BlockSeq, Stacked
 from haliax.state_dict import ModuleWithStateDictSerialization, StateDict
 
 from levanter.compat.hf_checkpoints import HFCheckpointConverter
+from levanter.compat.hf_config import hf_config_from_kwargs, hf_rope_config
 from levanter.layers.attention import Attention, AttentionBackend, AttentionMask
 from levanter.layers.rotary import DefaultRotaryEmbeddingsConfig, RotaryEmbeddingsConfig
 from levanter.models.llama import LlamaConfig, LlamaEmbedding
@@ -127,10 +128,8 @@ class Qwen3MoeConfig(LlamaConfig):
 
     @classmethod
     def from_hf_config(cls, hf_config: HfConfig):
-        rope_config = RotaryEmbeddingsConfig.from_hf_config(
-            hf_config.rope_theta,
-            getattr(hf_config, "rope_scaling", None),
-        )
+        rope_theta, rope_scaling = hf_rope_config(hf_config)
+        rope_config = RotaryEmbeddingsConfig.from_hf_config(rope_theta, rope_scaling)
         return Qwen3MoeConfig(
             max_seq_len=hf_config.max_position_embeddings,
             hidden_dim=hf_config.hidden_size,
@@ -166,7 +165,8 @@ class Qwen3MoeConfig(LlamaConfig):
 
         rope_theta, rope_scaling = self.rope.to_hf_config()
 
-        return HfQwen3MoeConfig(
+        return hf_config_from_kwargs(
+            HfQwen3MoeConfig,
             vocab_size=vocab_size,
             max_position_embeddings=self.max_seq_len,
             hidden_size=self.hidden_dim,

--- a/lib/levanter/tests/conftest.py
+++ b/lib/levanter/tests/conftest.py
@@ -20,7 +20,16 @@ def _gpt2_tokenizer_dir(tmp_path_factory):
     config_src = Path(__file__).parent / "gpt2_tokenizer_config.json"
     tmpdir = tmp_path_factory.mktemp("gpt2_tok")
     shutil.copy(config_src, tmpdir / "tokenizer.json")
-    shutil.copy(config_src, tmpdir / "tokenizer_config.json")
+    (tmpdir / "tokenizer_config.json").write_text(
+        json.dumps(
+            {
+                "tokenizer_class": "GPT2Tokenizer",
+                "bos_token": "<|endoftext|>",
+                "eos_token": "<|endoftext|>",
+                "unk_token": "<|endoftext|>",
+            }
+        )
+    )
     (tmpdir / "config.json").write_text(json.dumps({"model_type": "gpt2", "vocab_size": 5027}))
     return tmpdir
 
@@ -49,7 +58,7 @@ def local_gpt2_marin_tokenizer(tmp_path_factory) -> HfMarinTokenizer:
     config_src = Path(__file__).parent / "gpt2_tokenizer_config.json"
     tmpdir = tmp_path_factory.mktemp("gpt2_marin_tok")
     shutil.copy(config_src, tmpdir / "tokenizer.json")
-    shutil.copy(config_src, tmpdir / "tokenizer_config.json")
+    (tmpdir / "tokenizer_config.json").write_text(json.dumps({"tokenizer_class": "GPT2Tokenizer"}))
 
     tok = HfBaseTokenizer.from_file(str(tmpdir / "tokenizer.json"))
 

--- a/lib/levanter/tests/test_gdn_layer.py
+++ b/lib/levanter/tests/test_gdn_layer.py
@@ -293,7 +293,7 @@ def test_gdn_layer_decode_matches_hf_one_step():
     Ensures conv-state length K and S-state handoff are correct and parity holds.
     """
     import torch  # noqa: PLC0415  # optional dep: torch
-    from transformers.models.qwen3_next.modular_qwen3_next import Qwen3NextDynamicCache  # noqa: PLC0415
+    from transformers.models.qwen3_next.modular_qwen3_next import DynamicCache  # noqa: PLC0415
 
     hidden_size, nk, nv, dk, dv, ksz = 128, 4, 8, 8, 8, 4
     hf_cfg, hf_layer = _init_small_hf_layer_with_linear_only(hidden_size, nk, nv, dk, dv, ksz)
@@ -330,11 +330,11 @@ def test_gdn_layer_decode_matches_hf_one_step():
     assert new_state2 is not None, "expected state tuple for decode step"
 
     # ---------- HF prefill with cache ----------
-    cache = Qwen3NextDynamicCache(hf_cfg)
+    cache = DynamicCache(config=hf_cfg)
     with torch.no_grad():
         x_t = torch.from_numpy(np.array(x_full))
         _ = hf_layer(hidden_states=x_t, cache_params=cache, cache_position=torch.arange(L))
-        assert cache.conv_states[0] is not None and cache.recurrent_states[0] is not None
+        assert cache.layers[0].conv_states is not None and cache.layers[0].recurrent_states is not None
 
     # ---------- HF decode one token ----------
     with torch.no_grad():

--- a/lib/levanter/tests/test_gemma.py
+++ b/lib/levanter/tests/test_gemma.py
@@ -217,7 +217,8 @@ def test_gemma2_decoder_layer(num_kv_heads):
         cache_position=torch.zeros((batch,), dtype=torch.int32),  # HF expects a cache position
     )
 
-    chex.assert_trees_all_close(hf_out[0].detach().cpu().numpy(), lev_out.array, rtol=1e-4, atol=1e-4)
+    hf_array = hf_out if isinstance(hf_out, torch.Tensor) else hf_out[0]
+    chex.assert_trees_all_close(hf_array.detach().cpu().numpy(), lev_out.array, rtol=1e-4, atol=1e-4)
 
 
 @pytest.mark.parametrize("num_kv_heads", [1, 2])
@@ -459,6 +460,26 @@ def _get_random_inputs(config: GemmaConfig):
     return x, mask
 
 
+def _gemma3_hf_position_embeddings(rot, hf_config, x_torch, position_ids):
+    if hasattr(rot, "full_attention_inv_freq"):
+        cos, sin = rot(x_torch, position_ids, layer_type="full_attention")
+        if hasattr(rot, "sliding_attention_inv_freq"):
+            local_cos, local_sin = rot(x_torch, position_ids, layer_type="sliding_attention")
+        else:
+            local_cos, local_sin = cos, sin
+        return (cos, sin), (local_cos, local_sin)
+
+    # Older Transformers versions expose a single Gemma3 RoPE module. Rebuild it
+    # with the local RoPE theta for the sliding-attention comparison.
+    local_hf_config = copy.deepcopy(hf_config)
+    local_hf_config.rope_theta = local_hf_config.rope_local_base_freq
+    local_hf_config.rope_scaling = {"rope_type": "default"}
+    local_rot = type(rot)(config=local_hf_config)
+    cos, sin = rot(x_torch, position_ids)
+    local_cos, local_sin = local_rot(x_torch, position_ids)
+    return (cos, sin), (local_cos, local_sin)
+
+
 @parameterize_with_configs("gemma*.yaml")
 def test_gemma_configs(config_file):
     config_class = TrainLmConfig
@@ -504,26 +525,31 @@ def test_gemma3_decoder_layer(num_kv_heads):
 
     position_ids = torch.arange(gemma_config.max_Pos.size).unsqueeze(0)
     rot = HFGemmaRotaryEmbedding(config=hf_config)
-    cos, sin = rot(x_t, position_ids)
-
-    # HF does this hacky crap so we copy it
-    local_hf_config = copy.deepcopy(hf_config)
-    local_hf_config.rope_theta = local_hf_config.rope_local_base_freq
-    local_hf_config.rope_scaling = {"rope_type": "default"}
-    local_rot = HFGemmaRotaryEmbedding(config=local_hf_config)
-    local_cos, local_sin = local_rot(x_t, position_ids)
+    (cos, sin), (local_cos, local_sin) = _gemma3_hf_position_embeddings(rot, hf_config, x_t, position_ids)
 
     lev_out = decoder_layer(x, mask)
-    hf_out = hf_decoder(
-        x_t,
-        attention_mask=bias,
-        position_ids=position_ids,
-        position_embeddings_global=(cos, sin),
-        position_embeddings_local=(local_cos, local_sin),
-        cache_position=torch.zeros((batch,), dtype=torch.int32),
-    )
+    layer_type = getattr(hf_decoder.self_attn, "layer_type", None)
+    if layer_type is not None:
+        position_embeddings = (local_cos, local_sin) if layer_type == "sliding_attention" else (cos, sin)
+        hf_out = hf_decoder(
+            x_t,
+            attention_mask=bias,
+            position_ids=position_ids,
+            position_embeddings=position_embeddings,
+            cache_position=torch.zeros((batch,), dtype=torch.int32),
+        )
+    else:
+        hf_out = hf_decoder(
+            x_t,
+            attention_mask=bias,
+            position_ids=position_ids,
+            position_embeddings_global=(cos, sin),
+            position_embeddings_local=(local_cos, local_sin),
+            cache_position=torch.zeros((batch,), dtype=torch.int32),
+        )
 
-    chex.assert_trees_all_close(hf_out[0].detach().cpu().numpy(), lev_out.array, rtol=1e-4, atol=1e-4)
+    hf_array = hf_out if isinstance(hf_out, torch.Tensor) else hf_out[0]
+    chex.assert_trees_all_close(hf_array.detach().cpu().numpy(), lev_out.array, rtol=1e-4, atol=1e-4)
 
 
 def test_gemma3_config_from_hf_config_roundtrip():
@@ -653,7 +679,7 @@ def test_gemma3_attention(use_flash, num_kv_heads):
 
     out = attention(x, mask)
     position_ids = torch.arange(gemma_config.max_Pos.size).unsqueeze(0)  # [1, seq_len]
-    cos, sin = hf_rotary_emb(x_torch, position_ids)
+    (cos, sin), _ = _gemma3_hf_position_embeddings(hf_rotary_emb, hf_config, x_torch, position_ids)
     hf_out = hf_attention(
         x_torch, position_ids=position_ids, attention_mask=mask_torch, position_embeddings=(cos, sin)
     )

--- a/lib/levanter/tests/test_hf_utils.py
+++ b/lib/levanter/tests/test_hf_utils.py
@@ -1,6 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import json
 import os
 
 import fsspec
@@ -16,8 +17,9 @@ def test_load_tokenizer_in_memory_fs():
     # sort of like a gs:// path insasmuch as it uses fsspec machinery
     fs: AbstractFileSystem = fsspec.filesystem("memory")
     directory_of_this_test = os.path.dirname(os.path.abspath(__file__))
-    fs.put(f"{directory_of_this_test}/gpt2_tokenizer_config.json", "memory://foo/tokenizer_config.json")
     fs.put(f"{directory_of_this_test}/gpt2_tokenizer_config.json", "memory://foo/tokenizer.json")
+    with fsspec.open("memory://foo/tokenizer_config.json", "w") as f:
+        json.dump({"tokenizer_class": "GPT2Tokenizer"}, f)
 
     with fsspec.open("memory://foo/config.json", "w") as f:
         f.write(

--- a/lib/marin/pyproject.toml
+++ b/lib/marin/pyproject.toml
@@ -30,6 +30,9 @@ dependencies = [
     "jax>=0.9.2,<0.11",
     "jaxopt>=0.8.3",
     "marin-levanter[serve]",
+    # Keep Marin's direct tokenizer/chat-template uses explicit while allowing
+    # the workspace to validate the Transformers 5 / HF Hub 1.x stack.
+    "transformers>=4.57.1,<6.0",
     "lxml[html_clean]",
     "lxml-html-clean>=0.4.4",
     "markdownify>=0.14.1",
@@ -148,6 +151,8 @@ gpu = [
   "torch==2.11.0",
   "torchvision==0.26.0",
 ]
+# TPU stack pins are owned with the vLLM TPU extra below and must stay aligned
+# with Levanter's TPU extra and Fray's `fray_tpu_test` group.
 tpu = [
   "jax==0.10.0",
   "jaxlib==0.10.0",
@@ -202,6 +207,8 @@ vizier = [
     "google-vizier[jax]",
 ]
 
+# TPU-vLLM runtime stack. Keep these exact JAX/libtpu/Torch pins aligned with
+# the fork sources in the workspace root and root `extra-build-dependencies.vllm`.
 vllm = [
     "jax==0.10.0",
     "jaxlib==0.10.0",

--- a/lib/marin/src/marin/evaluation/evaluators/simple_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/simple_evaluator.py
@@ -157,7 +157,7 @@ class SimpleEvaluator(Evaluator):
 
             # Print the outputs for debugging
             for output in outputs:
-                prompt: str = output.prompt
+                prompt = output.prompt or ""
                 print(f"Prompt: {prompt!r}")
                 for i, generation in enumerate(output.outputs):
                     print(f"Generation (#{i + 1} of {test_plan.num_outputs}): {generation.text!r}")

--- a/lib/marin/src/marin/rl/environments/inference_ctx/async_vllm.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/async_vllm.py
@@ -4,9 +4,11 @@
 import logging
 import os
 from dataclasses import replace
+from typing import cast
 
 import numpy as np
 from levanter.models.lm_model import LmHeadModel
+from marin.rl.environments.inference_ctx.inflight.worker import SyncVLLMWrapper
 from marin.rl.environments.inference_ctx.vllm import InferenceMode, vLLMInferenceContext, vLLMInferenceContextConfig
 
 logger = logging.getLogger(__name__)
@@ -42,7 +44,8 @@ class AsyncvLLMInferenceContext(vLLMInferenceContext):
         # Serialize numpy arrays to (bytes, dtype, shape) tuples to survive RPC serialization.
         # vLLM's collective_rpc can corrupt numpy arrays during pickling.
         serialized_state_dict = serialize_state_dict_for_rpc(state_dict)
-        self.llm.update_weights(serialized_state_dict, self.canonical_model_name)
+        llm = cast(SyncVLLMWrapper, self.llm)
+        llm.update_weights(serialized_state_dict, self.canonical_model_name)
         self.llm.reset_prefix_cache()  # Reset prefix cache because of new weights
 
     def shutdown(self):

--- a/lib/marin/src/marin/rl/environments/inference_ctx/base.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/base.py
@@ -9,6 +9,7 @@ as well as methods for tokenization and logprob extraction from an OpenAI ChatCo
 """
 
 import logging
+from collections.abc import Mapping
 from typing import Any
 
 import numpy as np
@@ -19,6 +20,22 @@ from openai.types.chat import ChatCompletion
 from openai.types.chat.chat_completion import Choice
 
 logger = logging.getLogger(__name__)
+
+
+def _extract_input_ids(tokenizer_output: Any) -> list[int]:
+    """Return token IDs from HF/Levanter tokenizer outputs."""
+    if isinstance(tokenizer_output, Mapping):
+        tokenizer_output = tokenizer_output["input_ids"]
+
+    if hasattr(tokenizer_output, "tolist"):
+        tokenizer_output = tokenizer_output.tolist()
+
+    if tokenizer_output and isinstance(tokenizer_output[0], list):
+        if len(tokenizer_output) != 1:
+            raise ValueError(f"Expected one tokenized prompt, got {len(tokenizer_output)}")
+        tokenizer_output = tokenizer_output[0]
+
+    return list(tokenizer_output)
 
 
 class BaseInferenceContext:
@@ -60,7 +77,7 @@ class BaseInferenceContext:
             if not tokens:
                 raise ValueError(f"Failed to tokenize: {prompt[:100]}...") from None
 
-        return np.array(tokens, dtype=np.int32)
+        return np.array(_extract_input_ids(tokens), dtype=np.int32)
 
     def response_tokens_from_choice(self, choice: Choice) -> np.ndarray:
         """Extract token IDs with BPE round-trip."""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -137,6 +137,9 @@ exclude = ["lib/finelog/rust"]
 vllm = { VLLM_TARGET_DEVICE = "tpu" }
 
 [tool.uv.extra-build-dependencies]
+# vLLM is source-built for TPU before its runtime dependencies are installed,
+# so uv must seed the isolated build env with CPU Torch. Keep these wheel URLs
+# on the same Torch version as `lib/marin/pyproject.toml`'s CPU/TPU/vLLM pins.
 vllm = [
     "torch @ https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_x86_64.whl ; python_version == '3.12' and sys_platform == 'linux' and platform_machine == 'x86_64'",
     "torch @ https://download-r2.pytorch.org/whl/cpu/torch-2.11.0%2Bcpu-cp312-cp312-manylinux_2_28_aarch64.whl ; python_version == '3.12' and sys_platform == 'linux' and platform_machine == 'aarch64'",
@@ -158,10 +161,15 @@ nvidia-cutlass-dsl-libs-cu13 = { index = "nvidia" }
 # NOTE: harbor is a pinned git dependency (not a workspace member).
 # harbor lives in marin-community/harbor as a pinned git dependency.
 harbor = { git = "https://github.com/marin-community/harbor.git", rev = "354692d9c0eab497b05f266aa0dff30e2a238d2e" }
+# TPU-vLLM fork pair: select tpu-inference from an upstream release, then
+# select vLLM from that release's `.buildkite/vllm_lkg.version`. Keep these
+# source pins aligned with `marin-core[vllm]` and the stack pins below.
+# Clean fork branch: auto-refresh/20260616/lkg-7b98f49-r1.
 # https://github.com/marin-community/vllm/compare/7b98f498cdf0bf9cf0ecc37b5c0c994cb94513c3...04321f0f01b8e60d577a85a1b1af688e4433e7e0
 vllm = { git = "https://github.com/marin-community/vllm.git", rev = "04321f0f01b8e60d577a85a1b1af688e4433e7e0" }
-# https://github.com/marin-community/tpu-inference/compare/0045517c4ba75b1d624dba3be8b77e16c18b1a1e...4c38590e29d33451f2b4375a78ad8f70cacd7b98
-tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "4c38590e29d33451f2b4375a78ad8f70cacd7b98" }
+# Clean fork branch: auto-refresh/20260616/v0.22.1-0045517-r2.
+# https://github.com/marin-community/tpu-inference/compare/0045517c4ba75b1d624dba3be8b77e16c18b1a1e...a1b3be6ff521f2e926a79007eb2fb2d22a8d2c12
+tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "a1b3be6ff521f2e926a79007eb2fb2d22a8d2c12" }
 # ### BEGIN RUST-DEV SOURCES ###
 # ### END RUST-DEV SOURCES ###
 

--- a/tests/datakit/download/test_huggingface.py
+++ b/tests/datakit/download/test_huggingface.py
@@ -88,7 +88,9 @@ def test_relative_path_in_source_supports_revision_qualified_bucket_paths():
     assert _relative_path_in_source(file_path, source_path) == "train/file1.txt"
 
 
-def test_download_hf_bucket_requires_newer_huggingface_hub(tmp_path):
+def test_download_hf_bucket_requires_newer_huggingface_hub(tmp_path, monkeypatch):
+    monkeypatch.setattr(hf_download.huggingface_hub, "__version__", "1.5.0")
+
     cfg = DownloadConfig(
         hf_dataset_id="buckets/demo-user/demo-bucket/data",
         revision="main",

--- a/uv.lock
+++ b/uv.lock
@@ -3091,24 +3091,26 @@ wheels = [
 
 [[package]]
 name = "hf-xet"
-version = "1.2.0"
+version = "1.5.1"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/5e/6e/0f11bacf08a67f7fb5ee09740f2ca54163863b07b70d579356e9222ce5d8/hf_xet-1.2.0.tar.gz", hash = "sha256:a8c27070ca547293b6890c4bf389f713f80e8c478631432962bb7f4bc0bd7d7f", size = 506020, upload-time = "2025-10-24T19:04:32.129Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/4b/2d/57fd21d84d93efb4bd0b962383790e19dd1bc053501b4264c97903b4e83e/hf_xet-1.5.1.tar.gz", hash = "sha256:51ef4500dab3764b41135ee1381a4b62ce56fc54d4c92b719b59e597d6df5bf6", size = 876636, upload-time = "2026-06-08T23:02:53.897Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/9e/a5/85ef910a0aa034a2abcfadc360ab5ac6f6bc4e9112349bd40ca97551cff0/hf_xet-1.2.0-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:ceeefcd1b7aed4956ae8499e2199607765fbd1c60510752003b6cc0b8413b649", size = 2861870, upload-time = "2025-10-24T19:04:11.422Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/40/e2e0a7eb9a51fe8828ba2d47fe22a7e74914ea8a0db68a18c3aa7449c767/hf_xet-1.2.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:b70218dd548e9840224df5638fdc94bd033552963cfa97f9170829381179c813", size = 2717584, upload-time = "2025-10-24T19:04:09.586Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/7d/daf7f8bc4594fdd59a8a596f9e3886133fdc68e675292218a5e4c1b7e834/hf_xet-1.2.0-cp313-cp313t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7d40b18769bb9a8bc82a9ede575ce1a44c75eb80e7375a01d76259089529b5dc", size = 3315004, upload-time = "2025-10-24T19:04:00.314Z" },
-    { url = "https://files.pythonhosted.org/packages/b1/ba/45ea2f605fbf6d81c8b21e4d970b168b18a53515923010c312c06cd83164/hf_xet-1.2.0-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:cd3a6027d59cfb60177c12d6424e31f4b5ff13d8e3a1247b3a584bf8977e6df5", size = 3222636, upload-time = "2025-10-24T19:03:58.111Z" },
-    { url = "https://files.pythonhosted.org/packages/4a/1d/04513e3cab8f29ab8c109d309ddd21a2705afab9d52f2ba1151e0c14f086/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:6de1fc44f58f6dd937956c8d304d8c2dea264c80680bcfa61ca4a15e7b76780f", size = 3408448, upload-time = "2025-10-24T19:04:20.951Z" },
-    { url = "https://files.pythonhosted.org/packages/f0/7c/60a2756d7feec7387db3a1176c632357632fbe7849fce576c5559d4520c7/hf_xet-1.2.0-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f182f264ed2acd566c514e45da9f2119110e48a87a327ca271027904c70c5832", size = 3503401, upload-time = "2025-10-24T19:04:22.549Z" },
-    { url = "https://files.pythonhosted.org/packages/4e/64/48fffbd67fb418ab07451e4ce641a70de1c40c10a13e25325e24858ebe5a/hf_xet-1.2.0-cp313-cp313t-win_amd64.whl", hash = "sha256:293a7a3787e5c95d7be1857358a9130694a9c6021de3f27fa233f37267174382", size = 2900866, upload-time = "2025-10-24T19:04:33.461Z" },
-    { url = "https://files.pythonhosted.org/packages/96/2d/22338486473df5923a9ab7107d375dbef9173c338ebef5098ef593d2b560/hf_xet-1.2.0-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:46740d4ac024a7ca9b22bebf77460ff43332868b661186a8e46c227fdae01848", size = 2866099, upload-time = "2025-10-24T19:04:15.366Z" },
-    { url = "https://files.pythonhosted.org/packages/7f/8c/c5becfa53234299bc2210ba314eaaae36c2875e0045809b82e40a9544f0c/hf_xet-1.2.0-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:27df617a076420d8845bea087f59303da8be17ed7ec0cd7ee3b9b9f579dff0e4", size = 2722178, upload-time = "2025-10-24T19:04:13.695Z" },
-    { url = "https://files.pythonhosted.org/packages/9a/92/cf3ab0b652b082e66876d08da57fcc6fa2f0e6c70dfbbafbd470bb73eb47/hf_xet-1.2.0-cp37-abi3-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:3651fd5bfe0281951b988c0facbe726aa5e347b103a675f49a3fa8144c7968fd", size = 3320214, upload-time = "2025-10-24T19:04:03.596Z" },
-    { url = "https://files.pythonhosted.org/packages/46/92/3f7ec4a1b6a65bf45b059b6d4a5d38988f63e193056de2f420137e3c3244/hf_xet-1.2.0-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:d06fa97c8562fb3ee7a378dd9b51e343bc5bc8190254202c9771029152f5e08c", size = 3229054, upload-time = "2025-10-24T19:04:01.949Z" },
-    { url = "https://files.pythonhosted.org/packages/0b/dd/7ac658d54b9fb7999a0ccb07ad863b413cbaf5cf172f48ebcd9497ec7263/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:4c1428c9ae73ec0939410ec73023c4f842927f39db09b063b9482dac5a3bb737", size = 3413812, upload-time = "2025-10-24T19:04:24.585Z" },
-    { url = "https://files.pythonhosted.org/packages/92/68/89ac4e5b12a9ff6286a12174c8538a5930e2ed662091dd2572bbe0a18c8a/hf_xet-1.2.0-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:a55558084c16b09b5ed32ab9ed38421e2d87cf3f1f89815764d1177081b99865", size = 3508920, upload-time = "2025-10-24T19:04:26.927Z" },
-    { url = "https://files.pythonhosted.org/packages/cb/44/870d44b30e1dcfb6a65932e3e1506c103a8a5aea9103c337e7a53180322c/hf_xet-1.2.0-cp37-abi3-win_amd64.whl", hash = "sha256:e6584a52253f72c9f52f9e549d5895ca7a471608495c4ecaa6cc73dba2b24d69", size = 2905735, upload-time = "2025-10-24T19:04:35.928Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ee/dd9ba7beae1005e54131b7d45263cc74c8a066d47d354e6d58ae9445a388/hf_xet-1.5.1-cp313-cp313t-macosx_10_12_x86_64.whl", hash = "sha256:dbf48c0d02cf0b2e568944330c60d9120c272dabe013bd892d48e25bc6797577", size = 4069485, upload-time = "2026-06-08T23:02:13.193Z" },
+    { url = "https://files.pythonhosted.org/packages/b6/bc/9cae6cfeb4e03070874e73e5c97c66eb90369d3206b6a2b1ef5f96520888/hf_xet-1.5.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:e78e4e5192ad2b674c2e1160b651cb9134db974f8ae1835bdfbfb0166b894a43", size = 3838493, upload-time = "2026-06-08T23:02:15.282Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/b4/d5c01e0eb6d9f2ca2dacd84d0d1b71e6cfbb2ef3208c968528e010e9b3d7/hf_xet-1.5.1-cp313-cp313t-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:6f7a04a8ad962422e225bc49fbbac99dc1806764b1f3e54dbd154bffa7593947", size = 4505658, upload-time = "2026-06-08T23:02:17.196Z" },
+    { url = "https://files.pythonhosted.org/packages/76/c5/29a7598c0c6383c523dc22186d577f4e04267a626cd95ae60f67c00bfe66/hf_xet-1.5.1-cp313-cp313t-manylinux_2_28_aarch64.whl", hash = "sha256:d48199c2bf4f8df0adc55d31d1368b6ec0e4d4f45bc86b08038089c23db0bed8", size = 4292822, upload-time = "2026-06-08T23:02:18.608Z" },
+    { url = "https://files.pythonhosted.org/packages/04/9a/dceaf6ca69390126b86ea825fb354b93d01163199070b7bd849225de9468/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:97f212a88d14bbf573619a74b7fecb238de77d08fc702e54dec6f78276ca3283", size = 4491255, upload-time = "2026-06-08T23:02:20.124Z" },
+    { url = "https://files.pythonhosted.org/packages/48/a7/e5a7afaacf6c1791fdbeeac42951fb81c3d2bc482992b115dedcc86d963e/hf_xet-1.5.1-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:f61e3665892a6c8c5e765395838b8ddf36185da835253d4bc4509a81e49fb342", size = 4711062, upload-time = "2026-06-08T23:02:21.863Z" },
+    { url = "https://files.pythonhosted.org/packages/53/49/2802f8433c9742ce281bddc1e65c02c32268ca3098d66828b05e12e45ee2/hf_xet-1.5.1-cp313-cp313t-win_amd64.whl", hash = "sha256:f4ad3ebd4c32dd2b27099d69dc7b2df821e30767e46fb6ee6a0713778243b8ff", size = 4017205, upload-time = "2026-06-08T23:02:23.495Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/5a/50c71195b9fb883659f596e7252faf4c18c58e753a9013bdbf9bac5d2250/hf_xet-1.5.1-cp313-cp313t-win_arm64.whl", hash = "sha256:8298485c1e36e7e67cbd01eeb1376619b7af43d4f1ec245caae306f890a8a32d", size = 3845426, upload-time = "2026-06-08T23:02:25.124Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/d8/5e54cf37434759d1f4f2ba9b66077ff9d4c4e1f37b6bd7975da5c40d94ab/hf_xet-1.5.1-cp37-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6abd35c3221eff63836618ddfb954dcf84798603f71d8e33e3ed7b04acfdbe6e", size = 4077794, upload-time = "2026-06-08T23:02:40.656Z" },
+    { url = "https://files.pythonhosted.org/packages/35/94/4b2ecfbad8f8b04701a23aefb62f540b9137d058b7e1dbef16a32676f0e9/hf_xet-1.5.1-cp37-abi3-macosx_11_0_arm64.whl", hash = "sha256:94e761bbd266bf4c03cee73753916062665ce8365aa40ed321f45afcb934b41e", size = 3845354, upload-time = "2026-06-08T23:02:42.702Z" },
+    { url = "https://files.pythonhosted.org/packages/de/cc/f99f4bc7295023d7bd9ebbfd51f75cc530ca262c1227666268b8208f4b77/hf_xet-1.5.1-cp37-abi3-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:892e3a3a3aecc12aded8b93cf4f9cd059282c7de0732f7d55026f3abdf474350", size = 4514864, upload-time = "2026-06-08T23:02:44.497Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/6e/21f7e5a2381278bd3b7b7a5a4d90038518bb6308a0c1daf5d9f8268bb178/hf_xet-1.5.1-cp37-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a93df2039190502835b1db8cd7e178b0b7b889fe9ab51299d5ced26e0dd879a4", size = 4303784, upload-time = "2026-06-08T23:02:46.203Z" },
+    { url = "https://files.pythonhosted.org/packages/35/0e/f992bb6927ac1cb30ef74e62268f551f338bc32b2191f7c96a44c6f7283e/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_aarch64.whl", hash = "sha256:0c97106032ef70467b4f6bc2d0ccc266d7613ee076afc56516c502f87ce1c4a6", size = 4500703, upload-time = "2026-06-08T23:02:47.628Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/d1/90a498d05447980b977b1669246eeeeae4cfb0ea3e7a286eaba627f91bf9/hf_xet-1.5.1-cp37-abi3-musllinux_1_2_x86_64.whl", hash = "sha256:6208adb15d192b90e4c2ad2a27ed864359b2cb0f2494eb6d7c7f3699ac02e2bf", size = 4719498, upload-time = "2026-06-08T23:02:49.268Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/b6/20f99cfe97cc663a711f7b33cc21d4793e51968e9a26125b4afcd77315ba/hf_xet-1.5.1-cp37-abi3-win_amd64.whl", hash = "sha256:f7b3002f95d1c13e24bcb4537baa8f0eb3838957067c91bb4959bc004a6435f5", size = 4026419, upload-time = "2026-06-08T23:02:50.829Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/fa/77453694888f03e5a8c8852d1514a0894d8e81c622d39edbaf308ea0dcf4/hf_xet-1.5.1-cp37-abi3-win_arm64.whl", hash = "sha256:93d090b57b211133f6c0dab0205ef5cb6d89162979ba75a74845045cc3063b8e", size = 3855178, upload-time = "2026-06-08T23:02:52.452Z" },
 ]
 
 [[package]]
@@ -3215,21 +3217,23 @@ wheels = [
 
 [[package]]
 name = "huggingface-hub"
-version = "0.36.0"
+version = "1.20.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "filelock" },
     { name = "fsspec" },
-    { name = "hf-xet", marker = "platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-gpu') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-vllm') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-vllm') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'group-10-marin-fray-fray-tpu-test') or (extra == 'extra-10-marin-core-tpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-vllm' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'group-10-marin-fray-fray-tpu-test')" },
+    { name = "hf-xet", marker = "platform_machine == 'AMD64' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'arm64' or platform_machine == 'x86_64' or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-gpu') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-vllm') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-vllm') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'group-10-marin-fray-fray-tpu-test') or (extra == 'extra-10-marin-core-tpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-vllm' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'group-10-marin-fray-fray-tpu-test')" },
+    { name = "httpx" },
     { name = "packaging" },
     { name = "pyyaml" },
-    { name = "requests" },
     { name = "tqdm" },
+    { name = "typer" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/98/63/4910c5fa9128fdadf6a9c5ac138e8b1b6cee4ca44bf7915bbfbce4e355ee/huggingface_hub-0.36.0.tar.gz", hash = "sha256:47b3f0e2539c39bf5cde015d63b72ec49baff67b6931c3d97f3f84532e2b8d25", size = 463358, upload-time = "2025-10-23T12:12:01.413Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/7e/fad82ad491b226e832d2da90a1a59f36acd4526cda8c726f639834754aa4/huggingface_hub-1.20.1.tar.gz", hash = "sha256:9f6d63bfbeab2d2a8357200a9bc4f18cd2c8bfac9579f792f5922e77bf6471d0", size = 859910, upload-time = "2026-06-18T22:06:53.348Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/cb/bd/1a875e0d592d447cbc02805fd3fe0f497714d6a2583f59d14fa9ebad96eb/huggingface_hub-0.36.0-py3-none-any.whl", hash = "sha256:7bcc9ad17d5b3f07b57c78e79d527102d08313caa278a641993acddcb894548d", size = 566094, upload-time = "2025-10-23T12:11:59.557Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/b5/ff8516e74b459da3dce9567540c39f2d305ee7a2655109f6802873ff1588/huggingface_hub-1.20.1-py3-none-any.whl", hash = "sha256:274448a45c1ba6f112fe2fb168ead05574c654faa156904157a84085cfae14bd", size = 719837, upload-time = "2026-06-18T22:06:51.486Z" },
 ]
 
 [[package]]
@@ -4587,6 +4591,7 @@ dependencies = [
     { name = "toml" },
     { name = "tqdm" },
     { name = "tqdm-loggable" },
+    { name = "transformers" },
     { name = "wandb" },
     { name = "warcio" },
 ]
@@ -4827,9 +4832,10 @@ requires-dist = [
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'cpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "cpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'tpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "tpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'vllm'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "vllm" } },
-    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=4c38590e29d33451f2b4375a78ad8f70cacd7b98" },
+    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=a1b3be6ff521f2e926a79007eb2fb2d22a8d2c12" },
     { name = "tqdm" },
     { name = "tqdm-loggable" },
+    { name = "transformers", specifier = ">=4.57.1,<6.0" },
     { name = "triton", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=3.6.0,<3.7" },
     { name = "verifiers", marker = "extra == 'rl'", specifier = "==0.1.5" },
     { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=04321f0f01b8e60d577a85a1b1af688e4433e7e0" },
@@ -5415,7 +5421,7 @@ requires-dist = [
     { name = "tokenizers", specifier = ">=0.15.2" },
     { name = "torch", marker = "extra == 'torch-test'", specifier = ">=2.7.0" },
     { name = "tqdm-loggable", specifier = ">=0.2" },
-    { name = "transformers", specifier = ">=4.57.1,<5.0" },
+    { name = "transformers", specifier = ">=4.57.1,<6.0" },
     { name = "triton", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=3.6.0,<3.7" },
     { name = "uvicorn", extras = ["standard"], marker = "extra == 'serve'", specifier = ">=0.23.0" },
     { name = "wandb", specifier = ">0.24.0" },
@@ -10964,7 +10970,7 @@ wheels = [
 [[package]]
 name = "tpu-inference"
 version = "0.22.1"
-source = { git = "https://github.com/marin-community/tpu-inference.git?rev=4c38590e29d33451f2b4375a78ad8f70cacd7b98#4c38590e29d33451f2b4375a78ad8f70cacd7b98" }
+source = { git = "https://github.com/marin-community/tpu-inference.git?rev=a1b3be6ff521f2e926a79007eb2fb2d22a8d2c12#a1b3be6ff521f2e926a79007eb2fb2d22a8d2c12" }
 dependencies = [
     { name = "absl-py" },
     { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-10-marin-core-vllm' or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-gpu') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'group-10-marin-fray-fray-tpu-test') or (extra == 'extra-10-marin-core-tpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'group-10-marin-fray-fray-tpu-test')" },
@@ -11074,23 +11080,22 @@ wheels = [
 
 [[package]]
 name = "transformers"
-version = "4.57.5"
+version = "5.12.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
-    { name = "filelock" },
     { name = "huggingface-hub" },
     { name = "numpy" },
     { name = "packaging" },
     { name = "pyyaml" },
     { name = "regex" },
-    { name = "requests" },
     { name = "safetensors" },
     { name = "tokenizers" },
     { name = "tqdm" },
+    { name = "typer" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/35/3a/7c90ee739871495f1a5cb9bdb074b42fe69357d7ccc1a8818af858d8e63b/transformers-4.57.5.tar.gz", hash = "sha256:d631faea6bd32fc51962e482744afeaa70170c70e5e991cf8e355d7275631524", size = 10138171, upload-time = "2026-01-13T13:28:24.19Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/aa/7c/8240f612819718100a9346dc28dea6a11370c3ca9c8c6eabadd3dea4ef29/transformers-5.12.1.tar.gz", hash = "sha256:679ee731c8225347889ad4fb3b2c926a62e9da3b7d284e9d12c791da7272466b", size = 8924054, upload-time = "2026-06-15T17:27:50.604Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f8/de/4f95d22d9764659d2bd35065f383f3fe099699a9e6e89fa4728dbcd7244a/transformers-4.57.5-py3-none-any.whl", hash = "sha256:5a1e0deb989cd0b8f141b6d8c9b7c956fc029cd288d68844f57dc0acbaf2fe39", size = 11993481, upload-time = "2026-01-13T13:28:16.542Z" },
+    { url = "https://files.pythonhosted.org/packages/df/56/bbd60dd8668055803bf8ba55a81f9b8a8b31497f620109a9671d26a2076d/transformers-5.12.1-py3-none-any.whl", hash = "sha256:2a5e109d2021265df7098ffbb738295acaf5ad256f12cbc586db2ea4dcbb1a8a", size = 11150587, upload-time = "2026-06-15T17:27:46.679Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Rebased PR #6483 onto current `main` (`c1785e4f71b52e69b34bf28b86619933206e3588`), including #6484's Python 3.12 floor and lockfile baseline.
- Rewrote the branch into four conceptual commits:
  1. `9f3bcd720` `Pin TF5 TPU-vLLM dependency stack`
  2. `5097cf205` `Adapt Marin call sites for HF Hub 1.x`
  3. `ea0d529b5` `Centralize Levanter HF config compatibility`
  4. `4d542febc` `Align Levanter TF5 runtime model drift`
- Keeps Marin dependency sources pinned by exact Git `rev` SHAs, with source comments naming clean fork branches and overlay-only compare links.
- Re-locks the TPU-vLLM target to `transformers==5.12.1` and `huggingface-hub==1.20.1`.

## Fork Branches

- `marin-community/tpu-inference`: clean branch `auto-refresh/20260616/v0.22.1-0045517-r2` at exact pinned SHA `a1b3be6ff521f2e926a79007eb2fb2d22a8d2c12`.
- `marin-community/vllm`: clean branch `auto-refresh/20260616/lkg-7b98f49-r1` at exact pinned SHA `04321f0f01b8e60d577a85a1b1af688e4433e7e0`.
- No fork PR was opened for `tpu-inference`; the new clean branch was pushed directly and the older clean branches were left unchanged.

## Compatibility Cleanup

Removed or tightened:

- Removed the `tpu-inference` Gemma4 Transformers 4 registration guard/comment. Marin's locked target stack uses Transformers 5, where `transformers.models.gemma4` exists, so Gemma4 now imports/registers directly again.
- Removed the Qwen3-Next test fallback for the Transformers 4-era `Qwen3NextDynamicCache` shape; the TF5 target uses `DynamicCache(config=...)` with layer-local cache state.
- Centralized repeated Levanter HF config construction and RoPE parsing behind `levanter.compat.hf_config` helpers instead of duplicating per-model compatibility reads.

Intentionally kept:

- Top-level and nested RoPE config handling, because existing Marin configs/checkpoints and real HF model configs can expose either `rope_theta` / `rope_scaling` or TF5 `rope_parameters`.
- Gemma3 export of both old top-level RoPE fields and TF5 nested `rope_parameters`, because existing artifacts and HF config readers still differ in what they consume.
- Mixtral import support for both packed TF5 `mlp.*` keys and legacy `block_sparse_moe.*` saved-checkpoint keys, because existing saved checkpoints may use the legacy layout while TF5 runtime/export paths can expose packed keys.
- Tokenizer metadata and chat-template normalization fallbacks, because existing Marin tokenizer artifacts and HF tokenizer APIs vary in `added_tokens_decoder` presence and tokenized return shape.

## Validation

Local bounded checks passed:

- `VLLM_TARGET_DEVICE=tpu uv lock --check`
- Resolver dry-runs for `marin-core[cpu]`, `marin-core[tpu]`, `marin-core[vllm]`, and `marin-core[tpu,vllm]` under `VLLM_TARGET_DEVICE=tpu UV_PYTHON=3.12`.
- `VLLM_TARGET_DEVICE=tpu UV_PYTHON=3.12 uv tree --locked --invert --package transformers` shows `transformers==5.12.1`.
- `VLLM_TARGET_DEVICE=tpu UV_PYTHON=3.12 uv tree --locked --invert --package huggingface-hub` shows `huggingface-hub==1.20.1`.
- Targeted Marin tokenizer/inference/HF Hub tests: `46 passed, 4 skipped`.
- Targeted Levanter TF5 torch/model tests for Qwen3-Next GDN, Gemma, OLMo3, and Mixtral: `54 passed, 3 skipped`.
- Changed-file `black`, `ruff`, and `pyrefly` pre-commit lanes passed.
- `git diff --check` passed.
- `tpu-inference` fork edit syntax check: `python -m py_compile tpu_inference/models/common/model_loader.py`.

GitHub CI passed on final head `4d542febc08639ed1d6539c73dd2dfc6e386aa83`:

- `marin-lint`
- `marin-unit`
- `marin-integration`
- `levanter-unit`
- `levanter-torch`
- `levanter-tpu-tests`
- `iris-unit`
- `iris-e2e-smoke`
- `haliax-unit`
- `fray-unit`
- `zephyr-unit`
- Read the Docs / CodeQL / change-detection lanes are green or expected-skipped.