### PR TITLE
[docs] Bump marin-docs CI uv pin to 0.11.7 for extra-build-variables

### DIFF
--- a/.github/workflows/marin-docs.yaml
+++ b/.github/workflows/marin-docs.yaml
@@ -43,7 +43,7 @@ jobs:
       - name: Install uv and Python
         uses: astral-sh/setup-uv@v6
         with:
-          version: "0.7.20"
+          version: "0.11.7"
           python-version: "3.11"
           enable-cache: true
 


### PR DESCRIPTION
#6453 added `[tool.uv.extra-build-variables]` (`vllm = { VLLM_TARGET_DEVICE = "tpu" }`) to `pyproject.toml` so vllm builds for TPU without CUDA. The `marin-docs` workflow pins `uv 0.7.20`, which does not understand that field: it fails to parse `[tool.uv]`, silently drops `prerelease = "explicit"`, ignores the lockfile, re-resolves, and builds vllm from git without `VLLM_TARGET_DEVICE` — so the build asserts `CUDA_HOME is not set` and the job fails.

main has not surfaced this because the `marin-docs` paths-filter only runs the job when `docs/**`, `mkdocs.yml`, or the workflow itself change, and no main commit since #6453 touched those. So `marin-docs` is latently broken for every docs-touching PR (e.g. #6430).

Bump the pin to `0.11.7` (the version in use locally, which supports `extra-build-variables` and honors the lockfile). This PR edits the workflow, so its own `marin-docs` run exercises the fix.

The same `0.7.20` pin is also in `marin-unit`, `marin-lint`, `levanter-unit`, `zephyr-unit`, and `levanter-integration`; those jobs don't build vllm so they're unaffected for now, but a maintainer may want to bump them for consistency.