### PR TITLE
[zephyr] abort scatter upload on failure to stop R2 multipart-upload leak

### DIFF
--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -646,13 +646,12 @@ class ScatterWriter:
         return ListShard(refs=[MemChunk(items=[self._data_path])])
 
     def abort(self) -> None:
-        """Abort the in-flight upload without committing it.
+        """Discard the output instead of committing it.
 
-        fsspec only finalises an object-store multipart/resumable upload on a
-        clean ``close()``; on a failed or reassigned shard the upload is
-        otherwise left open and R2/S3 keeps billing the uploaded parts (#6488).
-        ``discard()`` aborts it (``s3fs.S3File.discard`` -> ``abort_multipart_upload``).
-        Local files write in place, so we close the handle and remove the
+        A clean ``close()`` is the only thing that finalises an object-store
+        upload; on a failed or reassigned shard the upload is otherwise left
+        open and keeps billing for uploaded parts (see #6488). On remote paths
+        ``discard()`` aborts the upload; on local paths we close and remove the
         partial file.
         """
         if self._out.closed:
@@ -713,6 +712,6 @@ def _write_scatter(
         return writer.close()
     except BaseException:
         # The write loop is not a context manager, so abort the in-flight
-        # upload here to avoid orphaning a multipart upload on R2 (#6488).
+        # upload here to avoid orphaning a multipart upload on R2.
         writer.abort()
         raise

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -536,6 +536,9 @@ class ScatterWriter:
         ensure_parent_dir(data_path)
         self._fs, self._fs_path = url_to_fs(data_path)
         self._out = self._fs.open(self._fs_path, "wb")
+        # Cached committed result; makes close() idempotent so the
+        # context-manager exit after an explicit close() is a no-op.
+        self._result: ListShard | None = None
 
     def _flush(self, target: int, buf: list) -> None:
         if self._combiner_fn is not None:
@@ -608,7 +611,13 @@ class ScatterWriter:
             self._mid_write_flushes += 1
 
     def close(self) -> ListShard:
-        """Flush remaining buffers, write sidecar, return ListShard."""
+        """Flush remaining buffers, write sidecar, return ListShard.
+
+        Idempotent: the committed result is cached, so a second call (e.g. the
+        context-manager exit after an explicit ``close()``) is a no-op.
+        """
+        if self._result is not None:
+            return self._result
         close_flushes = 0
         with log_time(f"Flushing remaining buffers for {self._data_path}"):
             for target, buf in sorted(self._buffers.items()):
@@ -643,21 +652,25 @@ class ScatterWriter:
         with log_time(f"Writing scatter meta for {self._data_path}"):
             _write_scatter_meta(self._data_path, sidecar)
 
-        return ListShard(refs=[MemChunk(items=[self._data_path])])
+        self._result = ListShard(refs=[MemChunk(items=[self._data_path])])
+        return self._result
 
-    def abort(self) -> None:
+    def cleanup(self) -> None:
         """Discard the output instead of committing it.
 
         A clean ``close()`` is the only thing that finalises an object-store
         upload; on a failed or reassigned shard the upload is otherwise left
         open and keeps billing for uploaded parts (see #6488).
         """
-        if self._out.closed:
-            return
         if is_remote_path(self._data_path):
+            # discard() aborts the multipart upload. Run it even after close()
+            # failed mid-commit: fsspec flips the file to closed in its finally
+            # block, but the upload stays open until aborted (a no-op if nothing
+            # was uploaded).
             self._out.discard()
             return
-        self._out.close()
+        if not self._out.closed:
+            self._out.close()
         if self._fs.exists(self._fs_path):
             self._fs.rm(self._fs_path)
 
@@ -666,14 +679,14 @@ class ScatterWriter:
 
     def __exit__(self, exc_type: type[BaseException] | None, *exc: Any) -> None:
         if exc_type is not None:
-            self.abort()
+            self.cleanup()
             return
         try:
             self.close()
         except BaseException:
             # A failure while committing (e.g. a dead R2 connection) would
-            # otherwise leave the multipart upload open. Abort, then re-raise.
-            self.abort()
+            # otherwise leave the multipart upload open. Discard, then re-raise.
+            self.cleanup()
             raise
 
 
@@ -695,7 +708,7 @@ def _write_scatter(
         A ListShard wrapping the data file path (as the existing scatter
         plumbing expects a list of paths).
     """
-    writer = ScatterWriter(
+    with ScatterWriter(
         data_path=data_path,
         key_fn=key_fn,
         num_output_shards=num_output_shards,
@@ -703,13 +716,8 @@ def _write_scatter(
         sort_fn=sort_fn,
         combiner_fn=combiner_fn,
         buffer_limit_bytes=buffer_limit_bytes,
-    )
-    try:
+    ) as writer:
         for item in items:
             writer.write(item)
+        # __exit__ discards the in-flight upload if anything above raises.
         return writer.close()
-    except BaseException:
-        # The write loop is not a context manager, so abort the in-flight
-        # upload here to avoid orphaning a multipart upload on R2.
-        writer.abort()
-        raise

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -650,9 +650,7 @@ class ScatterWriter:
 
         A clean ``close()`` is the only thing that finalises an object-store
         upload; on a failed or reassigned shard the upload is otherwise left
-        open and keeps billing for uploaded parts (see #6488). On remote paths
-        ``discard()`` aborts the upload; on local paths we close and remove the
-        partial file.
+        open and keeps billing for uploaded parts (see #6488).
         """
         if self._out.closed:
             return

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -48,7 +48,7 @@ import cloudpickle
 import msgspec
 import zstandard as zstd
 from iris.env_resources import TaskResources
-from rigging.filesystem import open_url, url_to_fs
+from rigging.filesystem import is_remote_path, open_url, url_to_fs
 from rigging.timing import RateLimiter, log_time
 
 from zephyr.shard_keys import composite_sort_key, deterministic_hash
@@ -534,8 +534,8 @@ class ScatterWriter:
         self._first_item_bytes: float = 0.0  # logged at close for comparison
 
         ensure_parent_dir(data_path)
-        fs, fs_path = url_to_fs(data_path)
-        self._out = fs.open(fs_path, "wb")
+        self._fs, self._fs_path = url_to_fs(data_path)
+        self._out = self._fs.open(self._fs_path, "wb")
 
     def _flush(self, target: int, buf: list) -> None:
         if self._combiner_fn is not None:
@@ -645,11 +645,39 @@ class ScatterWriter:
 
         return ListShard(refs=[MemChunk(items=[self._data_path])])
 
+    def abort(self) -> None:
+        """Abort the in-flight upload without committing it.
+
+        fsspec only finalises an object-store multipart/resumable upload on a
+        clean ``close()``; on a failed or reassigned shard the upload is
+        otherwise left open and R2/S3 keeps billing the uploaded parts (#6488).
+        ``discard()`` aborts it (``s3fs.S3File.discard`` -> ``abort_multipart_upload``).
+        Local files write in place, so we close the handle and remove the
+        partial file.
+        """
+        if self._out.closed:
+            return
+        if is_remote_path(self._data_path):
+            self._out.discard()
+            return
+        self._out.close()
+        if self._fs.exists(self._fs_path):
+            self._fs.rm(self._fs_path)
+
     def __enter__(self) -> ScatterWriter:
         return self
 
-    def __exit__(self, *exc: Any) -> None:
-        self.close()
+    def __exit__(self, exc_type: type[BaseException] | None, *exc: Any) -> None:
+        if exc_type is not None:
+            self.abort()
+            return
+        try:
+            self.close()
+        except BaseException:
+            # A failure while committing (e.g. a dead R2 connection) would
+            # otherwise leave the multipart upload open. Abort, then re-raise.
+            self.abort()
+            raise
 
 
 def _write_scatter(
@@ -679,6 +707,12 @@ def _write_scatter(
         combiner_fn=combiner_fn,
         buffer_limit_bytes=buffer_limit_bytes,
     )
-    for item in items:
-        writer.write(item)
-    return writer.close()
+    try:
+        for item in items:
+            writer.write(item)
+        return writer.close()
+    except BaseException:
+        # The write loop is not a context manager, so abort the in-flight
+        # upload here to avoid orphaning a multipart upload on R2 (#6488).
+        writer.abort()
+        raise

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -378,6 +378,11 @@ class _FakeUploadFile(io.BytesIO):
     def close(self):
         if self.closed:
             return
+        if self._path in self._fs.fail_close:
+            # fsspec marks the file closed in its finally block even when the
+            # commit (CompleteMultipartUpload) fails, leaving the MPU open.
+            super().close()
+            raise OSError("commit failed")
         self._fs.store[self._path] = self.getvalue()
         self._fs.open_uploads.discard(self._path)
         super().close()
@@ -398,6 +403,7 @@ class _FakeObjectStore(fsspec.AbstractFileSystem):
         self.store: dict[str, bytes] = {}
         self.open_uploads: set[str] = set()
         self.aborted: set[str] = set()
+        self.fail_close: set[str] = set()  # paths whose commit (close) raises
 
     def _open(self, path, mode="rb", **kwargs):
         if "w" in mode:
@@ -420,6 +426,7 @@ def fake_object_store():
     fs.store.clear()
     fs.open_uploads.clear()
     fs.aborted.clear()
+    fs.fail_close.clear()
     return fs
 
 
@@ -439,6 +446,22 @@ def test_scatter_aborts_multipart_upload_on_write_failure(fake_object_store):
     assert stripped in fs.aborted, "multipart upload was not aborted on failure"
     assert stripped not in fs.open_uploads, "in-flight upload left dangling"
     assert stripped not in fs.store, "failed shard committed an output object"
+
+
+def test_scatter_aborts_multipart_upload_when_commit_fails(fake_object_store):
+    """A close() that fails while committing (dead R2 connection) must still
+    abort the upload, even though fsspec has already marked the file closed."""
+    fs = fake_object_store
+    path = "fakempu://bucket/stage/shard-0002.shuffle"
+    stripped = fs._strip_protocol(path)
+    fs.fail_close.add(stripped)
+
+    with pytest.raises(OSError, match="commit failed"):
+        _write_scatter(iter([{"k": "a"}, {"k": "b"}]), source_shard=0, data_path=path, key_fn=_key, num_output_shards=2)
+
+    assert stripped in fs.aborted, "upload not aborted after a failed commit"
+    assert stripped not in fs.open_uploads, "in-flight upload left dangling"
+    assert stripped not in fs.store, "failed commit left a committed object"
 
 
 def test_scatter_commits_multipart_upload_on_success(fake_object_store):

--- a/lib/zephyr/tests/test_shuffle.py
+++ b/lib/zephyr/tests/test_shuffle.py
@@ -7,6 +7,10 @@ Covers the scatter write/read roundtrip, per-shard stats, and external sort —
 without spinning up a full coordinator.
 """
 
+import io
+import os
+
+import fsspec
 import pytest
 from zephyr.external_sort import EXTERNAL_SORT_FAN_IN, external_sort_merge
 from zephyr.runners import _InProcessWorkerContext
@@ -350,3 +354,114 @@ def test_external_sort_merge_cleans_up(tmp_path):
     iters = [iter([i]) for i in range(EXTERNAL_SORT_FAN_IN + 1)]
     list(external_sort_merge(iter(iters), merge_key=lambda x: x, external_sort_dir=str(tmp_path)))
     assert list(tmp_path.iterdir()) == [], "run files should be deleted after merge"
+
+
+# ---------------------------------------------------------------------------
+# Upload-abort on failure (#6488): a failed/retried shard must not orphan its
+# in-flight multipart upload (R2) or leave a partial output file (local).
+# ---------------------------------------------------------------------------
+
+
+class _FakeUploadFile(io.BytesIO):
+    """In-memory object-store upload: commits on close(), aborts on discard().
+
+    Models the s3fs/R2 multipart contract — the object only becomes visible on a
+    clean close(); discard() aborts the upload (s3fs.S3File.discard).
+    """
+
+    def __init__(self, fs, path):
+        super().__init__()
+        self._fs = fs
+        self._path = path
+        fs.open_uploads.add(path)
+
+    def close(self):
+        if self.closed:
+            return
+        self._fs.store[self._path] = self.getvalue()
+        self._fs.open_uploads.discard(self._path)
+        super().close()
+
+    def discard(self):
+        self._fs.open_uploads.discard(self._path)
+        self._fs.aborted.add(self._path)
+        super().close()
+
+
+class _FakeObjectStore(fsspec.AbstractFileSystem):
+    """Minimal non-local fsspec backend with multipart-upload semantics."""
+
+    protocol = "fakempu"
+
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        self.store: dict[str, bytes] = {}
+        self.open_uploads: set[str] = set()
+        self.aborted: set[str] = set()
+
+    def _open(self, path, mode="rb", **kwargs):
+        if "w" in mode:
+            return _FakeUploadFile(self, path)
+        return io.BytesIO(self.store[path])
+
+    def mkdirs(self, path, exist_ok=False):
+        pass
+
+    makedirs = mkdirs
+
+    def exists(self, path, **kwargs):
+        return path in self.store
+
+
+@pytest.fixture
+def fake_object_store():
+    fsspec.register_implementation("fakempu", _FakeObjectStore, clobber=True)
+    fs = fsspec.filesystem("fakempu")
+    fs.store.clear()
+    fs.open_uploads.clear()
+    fs.aborted.clear()
+    return fs
+
+
+def test_scatter_aborts_multipart_upload_on_write_failure(fake_object_store):
+    fs = fake_object_store
+    path = "fakempu://bucket/stage/shard-0000.shuffle"
+    stripped = fs._strip_protocol(path)
+
+    def failing_items():
+        yield {"k": "a"}
+        yield {"k": "b"}
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _write_scatter(failing_items(), source_shard=0, data_path=path, key_fn=_key, num_output_shards=2)
+
+    assert stripped in fs.aborted, "multipart upload was not aborted on failure"
+    assert stripped not in fs.open_uploads, "in-flight upload left dangling"
+    assert stripped not in fs.store, "failed shard committed an output object"
+
+
+def test_scatter_commits_multipart_upload_on_success(fake_object_store):
+    fs = fake_object_store
+    path = "fakempu://bucket/stage/shard-0001.shuffle"
+    stripped = fs._strip_protocol(path)
+
+    _write_scatter(iter([{"k": "a"}, {"k": "b"}]), source_shard=0, data_path=path, key_fn=_key, num_output_shards=2)
+
+    assert stripped in fs.store, "successful shard did not commit its output"
+    assert stripped not in fs.aborted
+    assert not fs.open_uploads, "upload left open after a successful write"
+
+
+def test_scatter_removes_partial_file_on_write_failure(tmp_path):
+    """A local shard whose item stream fails mid-write leaves no partial file."""
+    data_path = str(tmp_path / "shard-0000.shuffle")
+
+    def failing_items():
+        yield {"k": "a"}
+        raise RuntimeError("boom")
+
+    with pytest.raises(RuntimeError, match="boom"):
+        _write_scatter(failing_items(), source_shard=0, data_path=data_path, key_fn=_key, num_output_shards=2)
+
+    assert not os.path.exists(data_path), "failed shard left a partial scatter file"


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/6488
* abort the scatter output upload on failure so a failed/retried shard no longer orphans its in-flight multipart upload on R2
* `ScatterWriter` only ever committed via `close()`; on any failure before a clean close (exception mid-write, shard reassignment/retry, commit error on a dead connection) fsspec left the multipart upload open and R2 kept billing the uploaded parts [^1]
* add `ScatterWriter.abort()` — on remote paths calls `discard()` to abort the multipart/resumable upload; on local paths closes and removes the partial file
* `__exit__` now aborts on exception, and aborts + re-raises if `close()` itself fails
* `_write_scatter` (the production path — not a context manager) wraps its write loop + `close()` to `abort()` and re-raise on any error
* tests: failed write through a fake object-store backend leaves no committed object and records the upload as aborted; local failed write leaves no partial file; success path still commits

[^1]: process-death (OOM/SIGKILL) and the one-off cleanup of the ~50 already-orphaned MPUs from the reported run still need an R2 lifecycle rule / abort sweep as a backstop — out of scope for this code fix
