### PR TITLE
[iris] Validate non-positive GPU counts at the submit boundary

### DIFF
--- a/lib/iris/src/iris/cluster/constraints.py
+++ b/lib/iris/src/iris/cluster/constraints.py
@@ -795,6 +795,28 @@ def validate_tpu_request(
     return None
 
 
+def validate_gpu_request(resources: job_pb2.ResourceSpecProto) -> str | None:
+    """Reject GPU requests with a non-positive device count.
+
+    The scheduler subtracts the requested GPU count from a worker's advertised
+    capacity. A negative count would be *added* back, inflating advertised
+    capacity and bypassing the positive fit check; a zero count is requested
+    inconsistently across readers. Reject both at the submit trust boundary
+    (the controller deserializes the wire proto directly and never calls the
+    client-side ``gpu_device`` construction guard).
+
+    Returns ``None`` if the request is valid, or a human-readable error message
+    suitable for returning as ``INVALID_ARGUMENT``.
+    """
+    if not resources.HasField("device") or not resources.device.HasField("gpu"):
+        return None
+
+    count = resources.device.gpu.count
+    if count < 1:
+        return f"GPU count must be >= 1, got {count}."
+    return None
+
+
 # ---------------------------------------------------------------------------
 # Executor heuristic: auto-tag small CPU-only jobs as non-preemptible
 # ---------------------------------------------------------------------------

--- a/lib/iris/src/iris/cluster/controller/autoscaler/status.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/status.py
@@ -9,7 +9,7 @@ from dataclasses import dataclass
 
 from iris.cluster.controller.autoscaler.models import DemandEntry, RoutingDecision
 from iris.cluster.controller.autoscaler.routing import format_variants
-from iris.cluster.types import JobName
+from iris.cluster.types import JobName, get_gpu_count, get_tpu_count
 from iris.rpc import job_pb2, vm_pb2
 
 
@@ -22,19 +22,12 @@ class PendingHint:
 
 
 def _resource_spec_proto(resources: job_pb2.ResourceSpecProto) -> vm_pb2.ResourceSpec:
-    gpu_count = 0
-    tpu_count = 0
-    if resources.HasField("device"):
-        if resources.device.HasField("gpu"):
-            gpu_count = resources.device.gpu.count or 1
-        if resources.device.HasField("tpu"):
-            tpu_count = resources.device.tpu.count or 0
     return vm_pb2.ResourceSpec(
         cpu_millicores=resources.cpu_millicores,
         memory_bytes=resources.memory_bytes,
         disk_bytes=resources.disk_bytes,
-        gpu_count=gpu_count,
-        tpu_count=tpu_count,
+        gpu_count=get_gpu_count(resources.device),
+        tpu_count=get_tpu_count(resources.device),
     )
 
 

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -24,7 +24,13 @@ from rigging.timing import Duration, ExponentialBackoff, Timer, Timestamp
 from sqlalchemy import bindparam, case, func, select, text, tuple_
 
 from iris.cluster.bundle import BundleStore
-from iris.cluster.constraints import Constraint, constraints_from_resources, merge_constraints, validate_tpu_request
+from iris.cluster.constraints import (
+    Constraint,
+    constraints_from_resources,
+    merge_constraints,
+    validate_gpu_request,
+    validate_tpu_request,
+)
 from iris.cluster.controller import ops, reads, writes
 from iris.cluster.controller.auth import (
     DEFAULT_JWT_TTL_SECONDS,
@@ -1182,6 +1188,13 @@ class ControllerServiceImpl:
         tpu_error = validate_tpu_request(request.resources, [Constraint.from_proto(c) for c in request.constraints])
         if tpu_error:
             raise ConnectError(Code.INVALID_ARGUMENT, tpu_error)
+
+        # Reject non-positive GPU counts at the trust boundary: a negative count
+        # would inflate the scheduler's advertised capacity and bypass its fit
+        # check, since the controller deserializes the wire proto directly.
+        gpu_error = validate_gpu_request(request.resources)
+        if gpu_error:
+            raise ConnectError(Code.INVALID_ARGUMENT, gpu_error)
 
         # Reject jobs that can never be scheduled so they fail fast instead
         # of sitting in the pending queue. For coscheduled jobs this also

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -313,10 +313,20 @@ class TaskAttempt:
 
 
 def get_gpu_count(device: job_pb2.DeviceConfig) -> int:
-    """Extract GPU count from DeviceConfig."""
-    if device.HasField("gpu"):
-        return device.gpu.count or 1
-    return 0
+    """Extract GPU count from DeviceConfig.
+
+    Raises ``ValueError`` on a non-positive count: the scheduler subtracts this
+    from a worker's advertised GPU capacity, so a zero or negative value would
+    corrupt capacity accounting. Valid requests are guarded at construction
+    (``gpu_device``) and at submit (``validate_gpu_request``), so reaching here
+    with ``count < 1`` means a corrupt or hand-crafted proto.
+    """
+    if not device.HasField("gpu"):
+        return 0
+    count = device.gpu.count
+    if count < 1:
+        raise ValueError(f"GPU device count must be >= 1, got {count}")
+    return count
 
 
 def get_tpu_count(device: job_pb2.DeviceConfig) -> int:

--- a/lib/iris/tests/cluster/test_constraints.py
+++ b/lib/iris/tests/cluster/test_constraints.py
@@ -23,6 +23,7 @@ from iris.cluster.constraints import (
     routing_constraints,
     soft_constraint_score,
     split_hard_soft,
+    validate_gpu_request,
 )
 from iris.rpc import job_pb2
 
@@ -188,6 +189,30 @@ def test_looks_like_executor_false_with_tpu():
 
 def test_looks_like_executor_false_with_gpu():
     assert not looks_like_executor(_make_resources(device="gpu"), replicas=1)
+
+
+def _gpu_resources(count: int) -> job_pb2.ResourceSpecProto:
+    r = job_pb2.ResourceSpecProto(cpu_millicores=500)
+    r.device.gpu.variant = "h100"
+    r.device.gpu.count = count
+    return r
+
+
+def test_validate_gpu_request_accepts_positive_count():
+    assert validate_gpu_request(_gpu_resources(8)) is None
+
+
+@pytest.mark.parametrize("count", [0, -1])
+def test_validate_gpu_request_rejects_non_positive_count(count):
+    error = validate_gpu_request(_gpu_resources(count))
+    assert error is not None
+    assert str(count) in error
+
+
+def test_validate_gpu_request_ignores_non_gpu_requests():
+    assert validate_gpu_request(_make_resources()) is None
+    assert validate_gpu_request(_make_resources(device="cpu")) is None
+    assert validate_gpu_request(_make_resources(device="tpu")) is None
 
 
 def test_looks_like_executor_one_full_cpu():

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -17,7 +17,15 @@ from iris.cluster.constraints import (
     preemptible_constraint,
     region_constraint,
 )
-from iris.cluster.types import Entrypoint, JobName, TaskAttempt, adjust_tpu_replicas, gpu_device, tpu_device
+from iris.cluster.types import (
+    Entrypoint,
+    JobName,
+    TaskAttempt,
+    adjust_tpu_replicas,
+    get_gpu_count,
+    gpu_device,
+    tpu_device,
+)
 from iris.rpc import job_pb2
 
 
@@ -612,3 +620,21 @@ def test_merge_auto_constraints_with_user_variant_override():
     assert len(dv) == 1
     assert dv[0].op == ConstraintOp.IN
     assert tuple(v.value for v in dv[0].values) == ("v5litepod-16", "v6e-16")
+
+
+def test_get_gpu_count_returns_positive_count():
+    assert get_gpu_count(gpu_device("h100", count=4)) == 4
+
+
+def test_get_gpu_count_zero_without_gpu_field():
+    assert get_gpu_count(tpu_device("v5litepod-16")) == 0
+    assert get_gpu_count(job_pb2.DeviceConfig()) == 0
+
+
+@pytest.mark.parametrize("count", [0, -1])
+def test_get_gpu_count_rejects_non_positive_count(count):
+    # gpu_device() guards count < 1, so build the proto directly to mimic a
+    # corrupt or hand-crafted wire message reaching the reader.
+    device = job_pb2.DeviceConfig(gpu=job_pb2.GpuDevice(variant="h100", count=count))
+    with pytest.raises(ValueError, match="GPU device count"):
+        get_gpu_count(device)


### PR DESCRIPTION
Fixes #6478.

A non-positive GPU count in a `DeviceConfig` wasn't validated at job submit. A negative count is *subtracted* from the scheduler's `available_gpus`, which inflates advertised capacity and bypasses the positive fit check; a zero count is read inconsistently (`1` by `get_gpu_count`, `0` by the raw readers). TPU requests already had submit-time validation, but GPU had none — and the controller deserializes the wire proto directly, so the client-side `gpu_device()` guard from #6473 doesn't cover it.

**Changes:**
- Add `validate_gpu_request()` in `cluster/constraints.py` (mirrors `validate_tpu_request`) and reject `count < 1` at submit in the controller (`INVALID_ARGUMENT`).
- `get_gpu_count()` now raises `ValueError` on a non-positive count instead of the `or 1` idiom that coerced `0`→`1` and let negatives pass through.
- Dedupe the autoscaler status reader onto `get_gpu_count`/`get_tpu_count`.

Self-report/diagnostic raw reads (`env_resources.py`, `env_probe.py`, `proto_display.py`) are left as-is — they're not the scheduler trust boundary.

**Testing:** new unit tests for `validate_gpu_request` and `get_gpu_count` (reject 0/-1, accept ≥1/no-GPU); `test_constraints.py` + `test_types.py` 112 passed; controller/scheduler/autoscaler suites 1013 passed; pre-commit clean.
