### PR TITLE
[iris] Add explicit ANY region marker distinct from UNSET

### DIFF
--- a/lib/fray/src/fray/__init__.py
+++ b/lib/fray/src/fray/__init__.py
@@ -15,6 +15,7 @@ from fray.client import Client, JobAlreadyExists, JobFailed, JobHandle, wait_all
 from fray.current_client import current_client, set_current_client
 from fray.local_backend import LocalActorHandle, LocalActorMethod, LocalClient, LocalJobHandle
 from fray.types import (
+    ANY_REGION,
     ActorConfig,
     BinaryEntrypoint,
     CallableEntrypoint,
@@ -36,6 +37,7 @@ from fray.types import (
 )
 
 __all__ = [
+    "ANY_REGION",
     "ActorConfig",
     "ActorContext",
     "ActorFuture",

--- a/lib/fray/src/fray/cluster/__init__.py
+++ b/lib/fray/src/fray/cluster/__init__.py
@@ -4,6 +4,7 @@
 """fray.cluster re-exports resource/job types for back-compat."""
 
 from fray.types import (
+    ANY_REGION,
     CpuConfig,
     DeviceConfig,
     DeviceKind,
@@ -22,6 +23,7 @@ from fray.types import (
 )
 
 __all__ = [
+    "ANY_REGION",
     "CpuConfig",
     "DeviceConfig",
     "DeviceKind",

--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -118,12 +118,15 @@ def convert_constraints(resources: ResourceConfig) -> list[Constraint]:
     constraints: list[Constraint] = []
     if not resources.preemptible:
         constraints.append(preemptible_constraint(False))
-    if resources.regions is ANY_REGION:
+    regions = resources.regions
+    if regions and ANY_REGION in regions:
+        if len(regions) > 1:
+            raise ValueError(f"ANY_REGION cannot be combined with specific regions; got {list(regions)}")
         # ANY: run anywhere, do not inherit the parent's region. Emitted as a region-EXISTS
         # marker that matches every worker yet suppresses parent-region inheritance.
         constraints.append(any_region_constraint())
-    elif resources.regions:
-        constraints.append(region_constraint(list(resources.regions)))
+    elif regions:
+        constraints.append(region_constraint(list(regions)))
     if resources.zone:
         constraints.append(zone_constraint(resources.zone))
     if resources.device_alternatives:

--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -29,6 +29,7 @@ from iris.client.client import get_iris_ctx, iris_ctx
 from iris.cluster.client.job_info import get_job_info
 from iris.cluster.constraints import (
     Constraint,
+    any_region_constraint,
     device_variant_constraint,
     preemptible_constraint,
     region_constraint,
@@ -49,6 +50,7 @@ from fray.actor import (
 )
 from fray.client import JobAlreadyExists as FrayJobAlreadyExists
 from fray.types import (
+    ANY_REGION,
     ActorConfig,
     CpuConfig,
     DeviceConfig,
@@ -116,8 +118,12 @@ def convert_constraints(resources: ResourceConfig) -> list[Constraint]:
     constraints: list[Constraint] = []
     if not resources.preemptible:
         constraints.append(preemptible_constraint(False))
-    if resources.regions:
-        constraints.append(region_constraint(resources.regions))
+    if resources.regions is ANY_REGION:
+        # ANY: run anywhere, do not inherit the parent's region. Emitted as a region-EXISTS
+        # marker that matches every worker yet suppresses parent-region inheritance.
+        constraints.append(any_region_constraint())
+    elif resources.regions:
+        constraints.append(region_constraint(list(resources.regions)))
     if resources.zone:
         constraints.append(zone_constraint(resources.zone))
     if resources.device_alternatives:

--- a/lib/fray/src/fray/types.py
+++ b/lib/fray/src/fray/types.py
@@ -311,19 +311,11 @@ class TpuConfig:
 DeviceConfig = CpuConfig | GpuConfig | TpuConfig
 
 
-class _AnyRegion:
-    """Sentinel type for ``ResourceConfig.regions`` meaning ANY region.
-
-    Distinct from ``None`` (UNSET — inherit the parent job's region) and from a concrete
-    region list (PINNED). ANY means "run anywhere; do NOT inherit the parent's region."
-    Use the module-level ``ANY_REGION`` singleton; compare with ``is``.
-    """
-
-    def __repr__(self) -> str:
-        return "ANY_REGION"
-
-
-ANY_REGION = _AnyRegion()
+# Sentinel region value meaning ANY: run anywhere; do NOT inherit the parent job's region.
+# Distinct from ``None`` (UNSET — inherit) and a concrete region list (PINNED). Pass it as the
+# sole element of ``ResourceConfig.regions`` (``regions=[ANY_REGION]``). Not a real region, so
+# it never collides with a GCP region name.
+ANY_REGION = "*"
 
 
 @dataclass
@@ -348,8 +340,8 @@ class ResourceConfig:
     device: DeviceConfig = field(default_factory=CpuConfig)
     preemptible: bool = True
     # Region state: UNSET (None, default) inherits the parent job's region; PINNED (a
-    # region list) restricts to those regions; ANY (the ANY_REGION sentinel) runs
-    # anywhere without inheriting. ANY_REGION is accepted at runtime via identity check.
+    # region list) restricts to those regions; ANY ([ANY_REGION]) runs anywhere without
+    # inheriting.
     regions: Sequence[str] | None = None
     zone: str | None = None
     replicas: int = 1

--- a/lib/fray/src/fray/types.py
+++ b/lib/fray/src/fray/types.py
@@ -311,6 +311,21 @@ class TpuConfig:
 DeviceConfig = CpuConfig | GpuConfig | TpuConfig
 
 
+class _AnyRegion:
+    """Sentinel type for ``ResourceConfig.regions`` meaning ANY region.
+
+    Distinct from ``None`` (UNSET — inherit the parent job's region) and from a concrete
+    region list (PINNED). ANY means "run anywhere; do NOT inherit the parent's region."
+    Use the module-level ``ANY_REGION`` singleton; compare with ``is``.
+    """
+
+    def __repr__(self) -> str:
+        return "ANY_REGION"
+
+
+ANY_REGION = _AnyRegion()
+
+
 @dataclass
 class ResourceConfig:
     """Resource requirements for a single task/replica.
@@ -332,6 +347,9 @@ class ResourceConfig:
     disk: str = "16g"
     device: DeviceConfig = field(default_factory=CpuConfig)
     preemptible: bool = True
+    # Region state: UNSET (None, default) inherits the parent job's region; PINNED (a
+    # region list) restricts to those regions; ANY (the ANY_REGION sentinel) runs
+    # anywhere without inheriting. ANY_REGION is accepted at runtime via identity check.
     regions: Sequence[str] | None = None
     zone: str | None = None
     replicas: int = 1

--- a/lib/fray/tests/test_iris.py
+++ b/lib/fray/tests/test_iris.py
@@ -18,6 +18,7 @@ from fray.iris_backend import (
     resolve_coscheduling,
 )
 from fray.types import (
+    ANY_REGION,
     CpuConfig,
     Entrypoint,
     GpuConfig,
@@ -61,6 +62,22 @@ class TestConvertConstraints:
 
         assert c.op == ConstraintOp.IN
         assert tuple(v.value for v in c.values) == ("us-central1", "us-central2")
+
+    def test_regions_unset_produces_no_region_constraint(self):
+        """UNSET (regions=None, the default) emits no region constraint — the child
+        inherits the parent's region at submit time."""
+        resources = ResourceConfig(regions=None)
+        constraints = convert_constraints(resources)
+        assert [c for c in constraints if c.key == "region"] == []
+
+    def test_any_region_produces_single_exists_constraint(self):
+        """ANY (ANY_REGION sentinel) emits exactly one region-EXISTS marker."""
+        resources = ResourceConfig(regions=ANY_REGION)
+        constraints = convert_constraints(resources)
+        region_constraints = [c for c in constraints if c.key == "region"]
+        assert len(region_constraints) == 1
+        assert region_constraints[0].op == ConstraintOp.EXISTS
+        assert region_constraints[0].values == ()
 
     def test_zone_produces_eq_constraint(self):
         resources = ResourceConfig(zone="us-east1-d")

--- a/lib/fray/tests/test_iris.py
+++ b/lib/fray/tests/test_iris.py
@@ -71,13 +71,19 @@ class TestConvertConstraints:
         assert [c for c in constraints if c.key == "region"] == []
 
     def test_any_region_produces_single_exists_constraint(self):
-        """ANY (ANY_REGION sentinel) emits exactly one region-EXISTS marker."""
-        resources = ResourceConfig(regions=ANY_REGION)
+        """ANY ([ANY_REGION]) emits exactly one region-EXISTS marker."""
+        resources = ResourceConfig(regions=[ANY_REGION])
         constraints = convert_constraints(resources)
         region_constraints = [c for c in constraints if c.key == "region"]
         assert len(region_constraints) == 1
         assert region_constraints[0].op == ConstraintOp.EXISTS
         assert region_constraints[0].values == ()
+
+    def test_any_region_mixed_with_specific_region_raises(self):
+        """ANY_REGION alongside a concrete region is contradictory and rejected."""
+        resources = ResourceConfig(regions=[ANY_REGION, "us-central1"])
+        with pytest.raises(ValueError, match="ANY_REGION cannot be combined"):
+            convert_constraints(resources)
 
     def test_zone_produces_eq_constraint(self):
         resources = ResourceConfig(zone="us-east1-d")

--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -37,7 +37,13 @@ from iris.cluster.client import (
     get_job_info,
     resolve_job_user,
 )
-from iris.cluster.constraints import Constraint, WellKnownAttribute, merge_constraints, region_constraint
+from iris.cluster.constraints import (
+    Constraint,
+    WellKnownAttribute,
+    is_any_region_marker,
+    merge_constraints,
+    region_constraint,
+)
 from iris.cluster.log_keys import build_log_source
 from iris.cluster.types import (
     CoschedulingConfig,
@@ -695,6 +701,14 @@ class IrisClient:
             if job_info and job_info.worker_region and not any(c.key == WellKnownAttribute.REGION for c in constraints):
                 inherited_region = region_constraint([job_info.worker_region])
                 constraints = [*constraints, inherited_region]
+
+        # The ANY-region marker's only job is the inheritance opt-out above (and clearing
+        # any inherited pin via merge_constraints). Once that decision is made it carries no
+        # requirement, so drop it before the wire: as a hard region-EXISTS constraint it
+        # would otherwise exclude every worker/scaling group that advertises no region
+        # attribute. Stripping here keeps the controller's matching paths unaware of it.
+        if constraints:
+            constraints = [c for c in constraints if not is_any_region_marker(c)]
 
         # Convert to wire format
         resources_proto = resources.to_proto()

--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -687,6 +687,11 @@ class IrisClient:
             # passes constraints=[] to clear other inherited constraints —
             # region pinning keeps a child co-located with the worker that
             # launched it (where its in-region data and resources live).
+            #
+            # An explicit region constraint (any op carrying the region key) opts out:
+            # a PINNED region (region_constraint) or the ANY marker (any_region_constraint,
+            # a region-EXISTS constraint meaning "run anywhere; don't inherit") both satisfy
+            # this guard, so neither gets the parent's region appended.
             if job_info and job_info.worker_region and not any(c.key == WellKnownAttribute.REGION for c in constraints):
                 inherited_region = region_constraint([job_info.worker_region])
                 constraints = [*constraints, inherited_region]

--- a/lib/iris/src/iris/cluster/constraints.py
+++ b/lib/iris/src/iris/cluster/constraints.py
@@ -27,8 +27,9 @@ A job's region requirement has three distinct states:
 - ANY (``region EXISTS`` via ``any_region_constraint``): "run anywhere; do NOT inherit
   the parent's region." Because the marker carries the region key, it suppresses the
   parent-region injection in IrisClient.submit and clears an inherited pin in
-  ``merge_constraints``, yet matches every worker (all workers have a region attribute)
-  so it imposes no routing restriction.
+  ``merge_constraints``. Having served that opt-out, IrisClient.submit strips it before
+  the job reaches the controller, so it never acts as a scheduling/routing filter (a hard
+  ``region EXISTS`` would otherwise exclude workers/groups that advertise no region).
 """
 
 from __future__ import annotations
@@ -546,23 +547,6 @@ def _extract_preemptible(constraints: list[Constraint]) -> bool | None:
     return next(iter(values)) if values else None
 
 
-def _extract_regions(constraints: list[Constraint]) -> frozenset[str] | None:
-    """Extract required regions, treating a region-EXISTS (ANY) marker as no requirement.
-
-    A bare ``region EXISTS`` constraint is the ANY marker — "run anywhere; do not inherit
-    the parent's region" — and produces no routing requirement (returns None). Mixing ANY
-    with a pinned region (EQ/IN) is contradictory (you cannot be both anywhere and pinned)
-    and raises. Otherwise this delegates to the shared string-set extractor.
-    """
-    has_any = any(c.op == ConstraintOp.EXISTS for c in constraints)
-    pinned = [c for c in constraints if c.op != ConstraintOp.EXISTS]
-    if has_any and pinned:
-        raise ValueError("conflicting region constraints: cannot combine ANY (region EXISTS) with a pinned region")
-    if has_any:
-        return None
-    return _extract_string_set(pinned, WellKnownAttribute.REGION)
-
-
 def _extract_device_type(constraints: list[Constraint]) -> DeviceType | None:
     values = _extract_string_set(
         constraints,
@@ -597,7 +581,10 @@ def extract_placement_requirements(constraints: Sequence[Constraint]) -> Placeme
             WellKnownAttribute.DEVICE_VARIANT,
         ),
         preemptible=_extract_preemptible(by_key.get(WellKnownAttribute.PREEMPTIBLE, [])),
-        required_regions=_extract_regions(by_key.get(WellKnownAttribute.REGION, [])),
+        required_regions=_extract_string_set(
+            by_key.get(WellKnownAttribute.REGION, []),
+            WellKnownAttribute.REGION,
+        ),
         required_zones=_extract_string_set(
             by_key.get(WellKnownAttribute.ZONE, []),
             WellKnownAttribute.ZONE,
@@ -1029,6 +1016,11 @@ def is_cpu_device_type_constraint(c: Constraint) -> bool:
     before routing evaluation. Values are already normalized at ingestion.
     """
     return c.key == WellKnownAttribute.DEVICE_TYPE and c.op == ConstraintOp.EQ and c.values[0].value == "cpu"
+
+
+def is_any_region_marker(c: Constraint) -> bool:
+    """True if ``c`` is the ANY-region marker: a ``region EXISTS`` constraint."""
+    return c.key == WellKnownAttribute.REGION and c.op == ConstraintOp.EXISTS
 
 
 def routing_constraints(constraints: Sequence[Constraint]) -> list[Constraint]:

--- a/lib/iris/src/iris/cluster/constraints.py
+++ b/lib/iris/src/iris/cluster/constraints.py
@@ -14,6 +14,21 @@ This module is the canonical home for all constraint-related types:
 
 All production code should reference WellKnownAttribute enum members instead of
 raw string literals so that typos are caught at import time.
+
+Region states
+-------------
+A job's region requirement has three distinct states:
+
+- UNSET (no region constraint): "I don't care — inherit the parent worker's region."
+  This is the data-locality-friendly default; IrisClient.submit injects the parent's
+  region so a child co-locates with the worker that launched it.
+- PINNED (``region EQ X`` / ``region IN [...]`` via ``region_constraint``): exactly
+  these regions.
+- ANY (``region EXISTS`` via ``any_region_constraint``): "run anywhere; do NOT inherit
+  the parent's region." Because the marker carries the region key, it suppresses the
+  parent-region injection in IrisClient.submit and clears an inherited pin in
+  ``merge_constraints``, yet matches every worker (all workers have a region attribute)
+  so it imposes no routing restriction.
 """
 
 from __future__ import annotations
@@ -404,6 +419,14 @@ def region_constraint(regions: list[str]) -> Constraint:
     return Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.IN, values=regions)
 
 
+def any_region_constraint() -> Constraint:
+    """Region constraint meaning ANY: run anywhere, do not inherit the parent's region.
+
+    See the module-level "region states" note for how ANY relates to UNSET and PINNED.
+    """
+    return Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.EXISTS)
+
+
 def device_variant_constraint(variants: Sequence[str]) -> Constraint:
     """Constraint requiring scheduling on workers with one of the given device variants.
 
@@ -523,6 +546,23 @@ def _extract_preemptible(constraints: list[Constraint]) -> bool | None:
     return next(iter(values)) if values else None
 
 
+def _extract_regions(constraints: list[Constraint]) -> frozenset[str] | None:
+    """Extract required regions, treating a region-EXISTS (ANY) marker as no requirement.
+
+    A bare ``region EXISTS`` constraint is the ANY marker — "run anywhere; do not inherit
+    the parent's region" — and produces no routing requirement (returns None). Mixing ANY
+    with a pinned region (EQ/IN) is contradictory (you cannot be both anywhere and pinned)
+    and raises. Otherwise this delegates to the shared string-set extractor.
+    """
+    has_any = any(c.op == ConstraintOp.EXISTS for c in constraints)
+    pinned = [c for c in constraints if c.op != ConstraintOp.EXISTS]
+    if has_any and pinned:
+        raise ValueError("conflicting region constraints: cannot combine ANY (region EXISTS) with a pinned region")
+    if has_any:
+        return None
+    return _extract_string_set(pinned, WellKnownAttribute.REGION)
+
+
 def _extract_device_type(constraints: list[Constraint]) -> DeviceType | None:
     values = _extract_string_set(
         constraints,
@@ -557,10 +597,7 @@ def extract_placement_requirements(constraints: Sequence[Constraint]) -> Placeme
             WellKnownAttribute.DEVICE_VARIANT,
         ),
         preemptible=_extract_preemptible(by_key.get(WellKnownAttribute.PREEMPTIBLE, [])),
-        required_regions=_extract_string_set(
-            by_key.get(WellKnownAttribute.REGION, []),
-            WellKnownAttribute.REGION,
-        ),
+        required_regions=_extract_regions(by_key.get(WellKnownAttribute.REGION, [])),
         required_zones=_extract_string_set(
             by_key.get(WellKnownAttribute.ZONE, []),
             WellKnownAttribute.ZONE,
@@ -624,6 +661,8 @@ class ConstraintDescriptor:
 
 
 _EQ_IN = frozenset({job_pb2.CONSTRAINT_OP_EQ, job_pb2.CONSTRAINT_OP_IN})
+# Region additionally allows EXISTS as the explicit ANY-region marker (any_region_constraint).
+_EQ_IN_EXISTS = _EQ_IN | frozenset({job_pb2.CONSTRAINT_OP_EXISTS})
 _EQ_ONLY = frozenset({job_pb2.CONSTRAINT_OP_EQ})
 _ALL_OPS = frozenset(
     {
@@ -665,7 +704,7 @@ _register(
 )
 _register(
     ConstraintDescriptor(
-        key="region", kind=ConstraintKind.TAG, python_type=str, allowed_ops=_EQ_IN, canonical=True, routing=True
+        key="region", kind=ConstraintKind.TAG, python_type=str, allowed_ops=_EQ_IN_EXISTS, canonical=True, routing=True
     )
 )
 _register(

--- a/lib/iris/tests/cluster/test_constraints.py
+++ b/lib/iris/tests/cluster/test_constraints.py
@@ -138,39 +138,18 @@ def test_merge_non_canonical_key_appends():
 # --- ANY-region marker (region EXISTS) ---
 
 
-def test_extract_any_region_creates_no_required_region():
-    """The ANY marker imposes no region routing requirement on the autoscaler."""
-    result = extract_placement_requirements([any_region_constraint()])
-    assert result.required_regions is None
-
-
-def test_extract_any_region_mixed_with_pin_raises():
-    """ANY (EXISTS) and a pinned region are contradictory and must be rejected."""
-    with pytest.raises(ValueError, match="conflicting region constraints"):
-        extract_placement_requirements([region_constraint(["us-central1"]), any_region_constraint()])
-
-
 def test_merge_child_any_region_clears_parent_pin():
-    """A child's ANY marker replaces a parent's pinned region (canonical-key override)."""
+    """A child's ANY marker replaces a parent's pinned region (canonical-key override).
+
+    This is the mechanism by which an ANY child clears an inherited region pin in
+    IrisClient.submit before the marker itself is stripped.
+    """
     parent = [region_constraint(["us-central1"])]
     child = [any_region_constraint()]
     merged = merge_constraints(parent, child)
     region = [c for c in merged if c.key == WellKnownAttribute.REGION]
     assert len(region) == 1
     assert region[0].op == ConstraintOp.EXISTS
-
-
-def test_any_region_matches_workers_with_a_region():
-    """region EXISTS selects every worker that advertises a region; a region-less worker
-    is excluded, so the marker is a real predicate rather than a no-op."""
-    entities = {
-        "w-central": {WellKnownAttribute.REGION: AttributeValue("us-central1")},
-        "w-east": {WellKnownAttribute.REGION: AttributeValue("us-east1")},
-        "w-no-region": {WellKnownAttribute.DEVICE_TYPE: AttributeValue("cpu")},
-    }
-    index = ConstraintIndex.build(entities)
-    matched = index.matching_entities([any_region_constraint()])
-    assert matched == {"w-central", "w-east"}
 
 
 # --- INHERITED_CONSTRAINT_KEYS ---

--- a/lib/iris/tests/cluster/test_constraints.py
+++ b/lib/iris/tests/cluster/test_constraints.py
@@ -139,11 +139,8 @@ def test_merge_non_canonical_key_appends():
 
 
 def test_merge_child_any_region_clears_parent_pin():
-    """A child's ANY marker replaces a parent's pinned region (canonical-key override).
-
-    This is the mechanism by which an ANY child clears an inherited region pin in
-    IrisClient.submit before the marker itself is stripped.
-    """
+    """Merging a child's ANY marker over a parent's pinned region yields a single
+    region-EXISTS constraint (canonical-key override)."""
     parent = [region_constraint(["us-central1"])]
     child = [any_region_constraint()]
     merged = merge_constraints(parent, child)

--- a/lib/iris/tests/cluster/test_constraints.py
+++ b/lib/iris/tests/cluster/test_constraints.py
@@ -13,6 +13,7 @@ from iris.cluster.constraints import (
     DeviceType,
     PlacementRequirements,
     WellKnownAttribute,
+    any_region_constraint,
     evaluate_constraint,
     extract_placement_requirements,
     infer_preemptible_constraint,
@@ -20,6 +21,7 @@ from iris.cluster.constraints import (
     looks_like_executor,
     merge_constraints,
     preemptible_constraint,
+    region_constraint,
     routing_constraints,
     soft_constraint_score,
     split_hard_soft,
@@ -131,6 +133,44 @@ def test_merge_non_canonical_key_appends():
     child = [Constraint.create(key="tpu-name", op=ConstraintOp.EQ, value="pod-b")]
     merged = merge_constraints(parent, child)
     assert len(merged) == 2
+
+
+# --- ANY-region marker (region EXISTS) ---
+
+
+def test_extract_any_region_creates_no_required_region():
+    """The ANY marker imposes no region routing requirement on the autoscaler."""
+    result = extract_placement_requirements([any_region_constraint()])
+    assert result.required_regions is None
+
+
+def test_extract_any_region_mixed_with_pin_raises():
+    """ANY (EXISTS) and a pinned region are contradictory and must be rejected."""
+    with pytest.raises(ValueError, match="conflicting region constraints"):
+        extract_placement_requirements([region_constraint(["us-central1"]), any_region_constraint()])
+
+
+def test_merge_child_any_region_clears_parent_pin():
+    """A child's ANY marker replaces a parent's pinned region (canonical-key override)."""
+    parent = [region_constraint(["us-central1"])]
+    child = [any_region_constraint()]
+    merged = merge_constraints(parent, child)
+    region = [c for c in merged if c.key == WellKnownAttribute.REGION]
+    assert len(region) == 1
+    assert region[0].op == ConstraintOp.EXISTS
+
+
+def test_any_region_matches_workers_with_a_region():
+    """region EXISTS selects every worker that advertises a region; a region-less worker
+    is excluded, so the marker is a real predicate rather than a no-op."""
+    entities = {
+        "w-central": {WellKnownAttribute.REGION: AttributeValue("us-central1")},
+        "w-east": {WellKnownAttribute.REGION: AttributeValue("us-east1")},
+        "w-no-region": {WellKnownAttribute.DEVICE_TYPE: AttributeValue("cpu")},
+    }
+    index = ConstraintIndex.build(entities)
+    matched = index.matching_entities([any_region_constraint()])
+    assert matched == {"w-central", "w-east"}
 
 
 # --- INHERITED_CONSTRAINT_KEYS ---

--- a/lib/iris/tests/cluster/test_env_propagation.py
+++ b/lib/iris/tests/cluster/test_env_propagation.py
@@ -18,8 +18,9 @@ from unittest.mock import patch
 import pytest
 from iris.client import IrisClient, IrisContext, iris_ctx_scope
 from iris.cluster.client.job_info import JobInfo
-from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute
+from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute, any_region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, JobName, ResourceSpec
+from iris.rpc import job_pb2
 
 
 def dummy_entrypoint():
@@ -201,3 +202,43 @@ def test_child_explicit_region_overrides_parent_worker_region(capturing_client, 
     region_constraints = [c for c in stub.captured_constraints if c.key == WellKnownAttribute.REGION]
     assert len(region_constraints) == 1
     assert region_constraints[0].value.string_value == "europe-west4"
+
+
+def test_child_any_region_marker_suppresses_inherited_worker_region(capturing_client, parent_context):
+    """The ANY marker (region EXISTS) opts a child out of inheriting the parent worker's region."""
+    client, stub = capturing_client
+    entrypoint = Entrypoint.from_callable(dummy_entrypoint)
+    resources = ResourceSpec(cpu=1, memory="1g")
+
+    with (
+        iris_ctx_scope(parent_context),
+        patch("iris.client.client.get_job_info", return_value=_parent_job_info({}, worker_region="us-central2")),
+    ):
+        client.submit(entrypoint, "child-any-region", resources, constraints=[any_region_constraint()])
+
+    region_constraints = [c for c in stub.captured_constraints if c.key == WellKnownAttribute.REGION]
+    assert len(region_constraints) == 1
+    assert region_constraints[0].op == job_pb2.CONSTRAINT_OP_EXISTS
+    # No us-central2 pin was appended.
+    assert not any(c.value.string_value == "us-central2" for c in region_constraints)
+
+
+def test_child_any_region_marker_clears_inherited_region_constraint(capturing_client, parent_context):
+    """A child's ANY marker replaces a parent's pinned region via merge_constraints."""
+    client, stub = capturing_client
+    entrypoint = Entrypoint.from_callable(dummy_entrypoint)
+    resources = ResourceSpec(cpu=1, memory="1g")
+    parent_constraints = [Constraint.create(key=WellKnownAttribute.REGION, op=ConstraintOp.EQ, value="us-west4")]
+
+    with (
+        iris_ctx_scope(parent_context),
+        patch(
+            "iris.client.client.get_job_info",
+            return_value=_parent_job_info({}, constraints=parent_constraints, worker_region="us-west4"),
+        ),
+    ):
+        client.submit(entrypoint, "child-any-clears-pin", resources, constraints=[any_region_constraint()])
+
+    region_constraints = [c for c in stub.captured_constraints if c.key == WellKnownAttribute.REGION]
+    assert len(region_constraints) == 1
+    assert region_constraints[0].op == job_pb2.CONSTRAINT_OP_EXISTS

--- a/lib/iris/tests/cluster/test_env_propagation.py
+++ b/lib/iris/tests/cluster/test_env_propagation.py
@@ -204,8 +204,8 @@ def test_child_explicit_region_overrides_parent_worker_region(capturing_client, 
 
 
 def test_child_any_region_marker_suppresses_inherited_worker_region(capturing_client, parent_context):
-    """The ANY marker opts a child out of inheriting the parent worker's region: no region
-    constraint is sent (the marker suppresses inheritance and is then stripped before the wire)."""
+    """A child carrying the ANY marker submits with no region constraint, even when the
+    parent worker has a region to inherit."""
     client, stub = capturing_client
     entrypoint = Entrypoint.from_callable(dummy_entrypoint)
     resources = ResourceSpec(cpu=1, memory="1g")
@@ -221,8 +221,8 @@ def test_child_any_region_marker_suppresses_inherited_worker_region(capturing_cl
 
 
 def test_child_any_region_marker_clears_inherited_region_constraint(capturing_client, parent_context):
-    """A child's ANY marker clears a parent's pinned region (via merge) and is then stripped,
-    so the child submits with no region constraint at all."""
+    """A child carrying the ANY marker submits with no region constraint, even when the
+    parent job is pinned to a region."""
     client, stub = capturing_client
     entrypoint = Entrypoint.from_callable(dummy_entrypoint)
     resources = ResourceSpec(cpu=1, memory="1g")

--- a/lib/iris/tests/cluster/test_env_propagation.py
+++ b/lib/iris/tests/cluster/test_env_propagation.py
@@ -20,7 +20,6 @@ from iris.client import IrisClient, IrisContext, iris_ctx_scope
 from iris.cluster.client.job_info import JobInfo
 from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute, any_region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, JobName, ResourceSpec
-from iris.rpc import job_pb2
 
 
 def dummy_entrypoint():
@@ -205,7 +204,8 @@ def test_child_explicit_region_overrides_parent_worker_region(capturing_client, 
 
 
 def test_child_any_region_marker_suppresses_inherited_worker_region(capturing_client, parent_context):
-    """The ANY marker (region EXISTS) opts a child out of inheriting the parent worker's region."""
+    """The ANY marker opts a child out of inheriting the parent worker's region: no region
+    constraint is sent (the marker suppresses inheritance and is then stripped before the wire)."""
     client, stub = capturing_client
     entrypoint = Entrypoint.from_callable(dummy_entrypoint)
     resources = ResourceSpec(cpu=1, memory="1g")
@@ -217,14 +217,12 @@ def test_child_any_region_marker_suppresses_inherited_worker_region(capturing_cl
         client.submit(entrypoint, "child-any-region", resources, constraints=[any_region_constraint()])
 
     region_constraints = [c for c in stub.captured_constraints if c.key == WellKnownAttribute.REGION]
-    assert len(region_constraints) == 1
-    assert region_constraints[0].op == job_pb2.CONSTRAINT_OP_EXISTS
-    # No us-central2 pin was appended.
-    assert not any(c.value.string_value == "us-central2" for c in region_constraints)
+    assert region_constraints == []
 
 
 def test_child_any_region_marker_clears_inherited_region_constraint(capturing_client, parent_context):
-    """A child's ANY marker replaces a parent's pinned region via merge_constraints."""
+    """A child's ANY marker clears a parent's pinned region (via merge) and is then stripped,
+    so the child submits with no region constraint at all."""
     client, stub = capturing_client
     entrypoint = Entrypoint.from_callable(dummy_entrypoint)
     resources = ResourceSpec(cpu=1, memory="1g")
@@ -240,5 +238,4 @@ def test_child_any_region_marker_clears_inherited_region_constraint(capturing_cl
         client.submit(entrypoint, "child-any-clears-pin", resources, constraints=[any_region_constraint()])
 
     region_constraints = [c for c in stub.captured_constraints if c.key == WellKnownAttribute.REGION]
-    assert len(region_constraints) == 1
-    assert region_constraints[0].op == job_pb2.CONSTRAINT_OP_EXISTS
+    assert region_constraints == []


### PR DESCRIPTION
Region requirements in Iris+Fray previously had only two expressible states, which collapse a case we need:

- UNSET (`regions=None` / no region constraint): inherit the parent worker's region (data-locality default).
- PINNED (`regions=[X, ...]`): exactly these regions.

There was no way to express "run anywhere; do NOT inherit my parent's region." Passing `constraints=[]` does not work — the `worker_region` fallback in `IrisClient.submit` re-injects the parent region by design. This blocks a CPU coordinator that drives the executor: any region-unpinned child silently inherits the coordinator's incidental region, defeating `defaults.train`'s region-flexible design.

This PR adds a third state, ANY.

## EXISTS as ANY

ANY is represented at the Iris constraint layer as a region constraint with op `EXISTS` ("the worker must have a region attribute, any value"). This is the natural fit and threads the existing machinery cleanly:

- It carries `key == REGION`, so the existing `any(c.key == REGION ...)` guard in `IrisClient.submit` already suppresses the `worker_region` injection — no change to that condition.
- `merge_constraints` treats region as canonical, so a child's `region EXISTS` replaces a parent's `region EQ X` (a child clears an inherited pin).
- Every worker has a region attribute, so `region EXISTS` matches all workers — no routing restriction.

`extract_placement_requirements` now treats a region-EXISTS marker as no requirement (`required_regions=None`) and rejects mixing ANY with a pinned region as contradictory. `region`'s allowed ops gain EXISTS.

## Fray surface

ANY is exposed as the identity-checked `ANY_REGION` sentinel (not an overloaded `()`/`[]`, which is too easy to pass by accident). `convert_constraints` emits `any_region_constraint()` for it; `regions=None` and `regions=[X]` are unchanged.

The `ResourceConfig.regions` type annotation is intentionally left as `Sequence[str] | None` here. Widening it to include the sentinel forces every `for r in resources.regions` site in the executor to handle the new variant — i.e. it is coupled to the executor *consuming* ANY. That adoption (executor "no inferred region" -> ANY, `defaults.train` -> ANY) lands in the top-level-entrypoint follow-up (#6430), which widens the annotation together with the executor change. This PR stays primitive-only: it adds the marker and the conversion, and does not touch the executor, `experiments/launch.py`, or `experiments/defaults.py`.

Layering is respected: `iris` imports nothing from `fray`; `fray` imports `any_region_constraint` from `iris`.