### PR TITLE
Document contribution scope and AI-generated PR policy

### DIFF
--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -1,5 +1,22 @@
 # Contributing to Marin
 
+We welcome contributions that add missing features or fix serious issues. If you
+are unsure whether a change is wanted, open an issue or ask in the
+[Marin Discord](https://discord.gg/J9CTk7pqcM) before sending a PR. We are
+unlikely to merge typo fixes, stylistic rewrites, or speculative refactors that
+are not tied to an issue.
+
+## AI-generated contributions
+
+We use coding agents ourselves and accept contributions made with them. We do
+not accept drive-by PRs that an agent produced in one shot.
+
+The rule of thumb: if your agent can do it in one shot, so can ours, so please
+do not burden us with the PR. A throwaway agent-generated change costs us more to
+review than it cost you to file. If you do contribute agent-assisted work, hold
+it to the same bar as the rest of this guide: confirm the change is needed, that
+it is correct, and that you can explain why it matters.
+
 ## Setup
 
 1. Clone the repository


### PR DESCRIPTION
We are seeing a rise in low-value, agent-generated drive-by PRs. This adds a
short acceptance-scope note and an AI-contributions section to the canonical
contributing guide (docs/dev-guide/contributing.md, which the root
CONTRIBUTING.md points to) so the expectations are stated up front.

The policy: we welcome contributions for missing features or serious fixes and
accept agent-assisted work, but not one-shot drive-by PRs. The rule of thumb is
that if an agent can produce it in one shot, so can ours, so it is not worth the
review burden.

Folded into the existing single-sourced contributing doc rather than a new
top-level file to avoid fragmenting the contribution guidance.

Validated with infra/check_docs_source_links.py and infra/pre-commit.py.