### PR TITLE
[zephyr] Don't return counters with mixed aggregations

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -792,8 +792,8 @@ class ZephyrCoordinator:
 
         If snapshots disagree on a counter's aggregation (only possible for
         user counters that reuse a name with different ``set_aggregation``
-        modes), the first-seen mode wins and a warning is logged — stats
-        collection never raises into the execution path.
+        modes), the counter is omitted from the result and a warning is
+        logged — stats collection never raises into the execution path.
         """
         with self._lock:
             if worker_id is not None:
@@ -806,25 +806,29 @@ class ZephyrCoordinator:
 
         aggregations: dict[str, Aggregation] = {}
         values: dict[str, list[int | float]] = {}
+        conflicted: set[str] = set()
         for snap in all_snaps:
             for k, entry in snap.counters.items():
                 if stage is not None and entry.stage != stage:
                     continue
                 if k in aggregations:
                     if aggregations[k] != entry.aggregation:
-                        logger.warning(
-                            "Counter %r has conflicting aggregations: %r vs %r; keeping %r",
-                            k,
-                            aggregations[k],
-                            entry.aggregation,
-                            aggregations[k],
-                        )
+                        if k not in conflicted:
+                            logger.warning(
+                                "Counter %r has conflicting aggregations: %r vs %r; dropping",
+                                k,
+                                aggregations[k],
+                                entry.aggregation,
+                            )
+                            conflicted.add(k)
                 else:
                     aggregations[k] = entry.aggregation
                 values.setdefault(k, []).append(entry.value)
 
         result: dict[str, int | float] = {}
         for k, vals in values.items():
+            if k in conflicted:
+                continue
             match aggregations.get(k, Aggregation.SUM):
                 case Aggregation.SUM:
                     result[k] = sum(vals)

--- a/lib/zephyr/tests/test_counters.py
+++ b/lib/zephyr/tests/test_counters.py
@@ -273,13 +273,13 @@ def test_aggregation_mixed():
     assert coord.get_counters() == {"total": 30, "peak": 100}
 
 
-def test_aggregation_conflict_keeps_first_and_warns(caplog):
-    """Conflicting aggregations keep the first-seen mode and warn, never raising.
+def test_aggregation_conflict_drops_counter_and_warns(caplog):
+    """Conflicting aggregations drop the counter and warn, never raising.
 
     Stats collection must not be able to fault the execution path, so a counter
     that disagrees on aggregation across snapshots (only possible via user
-    ``set_aggregation`` misuse) resolves to the first-seen mode rather than
-    raising.
+    ``set_aggregation`` misuse) is omitted from the result rather than
+    producing a semantically wrong value or raising.
     """
     coord = _make_coordinator(
         [
@@ -289,8 +289,8 @@ def test_aggregation_conflict_keeps_first_and_warns(caplog):
     )
     with caplog.at_level(logging.WARNING):
         result = coord.get_counters()
-    # First-seen aggregation (MAX) wins over the later MIN.
-    assert result == {"x": 2}
+    # Conflicting aggregations (MAX vs MIN) — drop x to avoid garbage.
+    assert "x" not in result
     assert any("conflicting aggregations" in r.message for r in caplog.records)
 
 


### PR DESCRIPTION
If the aggregations are mixed, the results are not going to be coherent, so along with the current warning log, let's not return them to users don't get confused by the results.

I think the ideal outcome would be to return them with some error sentinel or in a separate list of error counters, but that would require changing the return value which does not seem worth it.
