### PR TITLE
[iris] Route Finelog through endpoint proxy

### DIFF
--- a/lib/iris/dashboard/rsbuild.config.ts
+++ b/lib/iris/dashboard/rsbuild.config.ts
@@ -30,7 +30,6 @@ export default defineConfig({
   server: {
     proxy: {
       '/iris.cluster.ControllerService': 'http://localhost:8080',
-      '/finelog.logging.LogService': 'http://localhost:8080',
       '/iris.cluster.WorkerService': 'http://localhost:8081',
       '/proxy': 'http://localhost:8080',
       '/bundles': 'http://localhost:8080',

--- a/lib/iris/dashboard/src/composables/useRpc.ts
+++ b/lib/iris/dashboard/src/composables/useRpc.ts
@@ -107,7 +107,7 @@ export function useLogServiceRpc<T>(
   method: string,
   body?: RpcBody,
 ): RpcState<T> {
-  return useRpc<T>('finelog.logging.LogService', method, body)
+  return useRpc<T>('proxy/system.log-server/finelog.logging.LogService', method, body)
 }
 
 /** RPC composable for StatsService endpoints. */
@@ -131,7 +131,7 @@ export function useLogServerStatsRpc<T>(
 
 /** One-shot RPC call for LogService. */
 export async function logServiceRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
-  const resp = await fetch(`/finelog.logging.LogService/${method}`, {
+  const resp = await fetch(`/proxy/system.log-server/finelog.logging.LogService/${method}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body ?? {}),

--- a/lib/iris/dashboard/src/composables/useRpc.ts
+++ b/lib/iris/dashboard/src/composables/useRpc.ts
@@ -10,6 +10,8 @@
  */
 import { ref, type Ref } from 'vue'
 
+const LOG_SERVICE_PATH = 'proxy/system.log-server/finelog.logging.LogService'
+
 export type RpcBody = Record<string, unknown> | (() => Record<string, unknown>)
 
 export interface RpcState<T> {
@@ -107,7 +109,7 @@ export function useLogServiceRpc<T>(
   method: string,
   body?: RpcBody,
 ): RpcState<T> {
-  return useRpc<T>('proxy/system.log-server/finelog.logging.LogService', method, body)
+  return useRpc<T>(LOG_SERVICE_PATH, method, body)
 }
 
 /** RPC composable for StatsService endpoints. */
@@ -131,7 +133,7 @@ export function useLogServerStatsRpc<T>(
 
 /** One-shot RPC call for LogService. */
 export async function logServiceRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
-  const resp = await fetch(`/proxy/system.log-server/finelog.logging.LogService/${method}`, {
+  const resp = await fetch(`/${LOG_SERVICE_PATH}/${method}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body ?? {}),

--- a/lib/iris/src/iris/cli/bug_report.py
+++ b/lib/iris/src/iris/cli/bug_report.py
@@ -13,7 +13,9 @@ from dataclasses import dataclass, field
 
 from finelog.client import LogClient
 from finelog.rpc import logging_pb2
+from rigging.connect import proxy_path
 
+from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
 from iris.cluster.log_keys import build_log_source
 from iris.cluster.types import JobName
 from iris.rpc import controller_pb2, job_pb2
@@ -127,7 +129,11 @@ def gather_bug_report(
         accept_compression=IRIS_RPC_COMPRESSIONS,
         send_compression=None,
     )
-    log_client = LogClient.connect(controller_url, timeout_ms=30000, interceptors=interceptors)
+    log_client = LogClient.connect(
+        f"{controller_url.rstrip('/')}{proxy_path(LOG_SERVER_ENDPOINT_NAME)}",
+        timeout_ms=30000,
+        interceptors=interceptors,
+    )
     try:
         return _gather(client, log_client, job_id, tail=tail)
     finally:

--- a/lib/iris/src/iris/cli/process_status.py
+++ b/lib/iris/src/iris/cli/process_status.py
@@ -18,8 +18,10 @@ import humanfriendly
 from finelog.client import LogClient
 from finelog.rpc import logging_pb2
 from google.protobuf import json_format
+from rigging.connect import proxy_path
 
 from iris.cli.connect import require_controller_url, rpc_client_for_ctx
+from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
 from iris.cluster.runtime.profile import SYSTEM_PROCESS_TARGET
 from iris.rpc import job_pb2
 
@@ -90,8 +92,11 @@ def logs(ctx, target: str | None, level: str, follow: bool, max_lines: int, subs
     """Show process logs."""
     url = require_controller_url(ctx)
     source = target or _CONTROLLER_LOG_TARGET
+    credentials = ctx.obj.get("credentials") if ctx.obj else None
+    interceptors = credentials.interceptors() if credentials is not None else ()
 
-    with contextlib.closing(LogClient.connect(url)) as log_client:
+    log_server_url = f"{url.rstrip('/')}{proxy_path(LOG_SERVER_ENDPOINT_NAME)}"
+    with contextlib.closing(LogClient.connect(log_server_url, interceptors=interceptors)) as log_client:
         cursor = 0
         first = True
         while True:

--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -536,9 +536,9 @@ class IrisClient:
 
         Same as :meth:`remote`, except finelog logs/stats are written straight
         to the resolved finelog server instead of through the controller's
-        StatsServiceProxy — so high-frequency task-status pushes don't compete
-        for the controller's RPC thread pool. Only valid where the finelog
-        server's internal address is reachable (i.e. inside the cluster).
+        endpoint proxy — so high-frequency task-status pushes don't compete for
+        the controller's HTTP proxy. Only valid where the finelog server's
+        internal address is reachable (i.e. inside the cluster).
         """
         return cls._make(
             controller_address,
@@ -1108,7 +1108,7 @@ def get_iris_ctx() -> IrisContext | None:
     if job_info.controller_address:
         bundle_id = job_info.bundle_id
         # In-task code runs inside the cluster and can reach the finelog server
-        # directly, so task-status pushes bypass the controller's StatsServiceProxy.
+        # directly, so task-status pushes bypass the controller's endpoint proxy.
         client = IrisClient.in_cluster(
             controller_address=job_info.controller_address,
             bundle_id=bundle_id,

--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -15,6 +15,7 @@ from connectrpc.errors import ConnectError
 from connectrpc.interceptor import InterceptorSync
 from finelog.client import LogClient
 from finelog.rpc import logging_pb2
+from rigging.connect import proxy_path
 from rigging.timing import Deadline, Duration, ExponentialBackoff
 
 from iris.cluster.client.bundle import create_workspace_zip
@@ -406,12 +407,12 @@ class RemoteClusterClient:
         """Resolve ``endpoint_name`` to a service address.
 
         When ``use_controller_proxy`` is set (external clients), returns the
-        controller address so RPCs flow through its proxies; otherwise looks
+        endpoint's path under the controller's generic proxy; otherwise looks
         the name up in the controller's endpoint registry and returns the
         backing service's direct address.
         """
         if self._use_controller_proxy:
-            return self._address
+            return f"{self._address.rstrip('/')}{proxy_path(endpoint_name)}"
         endpoints = self.list_endpoints(endpoint_name, exact=True)
         if not endpoints:
             raise ConnectionError(f"No {endpoint_name!r} endpoint registered on controller")

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -20,7 +20,6 @@ from typing import Any
 
 import uvicorn
 from finelog.client import LogClient, RemoteLogHandler
-from finelog.client.proxy import LogServiceProxy, StatsServiceProxy
 from finelog.embedded import require_embedded_server
 from rigging.timing import Duration, ExponentialBackoff, RateLimiter, Timestamp, TokenBucket
 from sqlalchemy import Row
@@ -346,9 +345,6 @@ class Controller:
             self._log_service_address = self._start_local_log_server()
 
         log_client_interceptors = _log_client_interceptors(config)
-        self._remote_log_service = LogServiceProxy(self._log_service_address, interceptors=log_client_interceptors)
-        self._remote_stats_service = StatsServiceProxy(self._log_service_address, interceptors=log_client_interceptors)
-
         # A single log client serves both the controller's own logs and any backend
         # that collects logs out-of-process.
         self._log_client = LogClient.connect(self._log_service_address, interceptors=log_client_interceptors)
@@ -393,11 +389,9 @@ class Controller:
         )
         self._dashboard = ControllerDashboard(
             self._service,
-            log_service=self._remote_log_service,
             host=config.host,
             port=config.port,
             auth_provider=config.auth_provider,
-            finelog_stats_service=self._remote_stats_service,
             auth_policy=ControllerAuthPolicy.from_verifiers(
                 verifier=config.auth_verifier,
                 optional=config.auth.optional if config.auth else False,
@@ -637,8 +631,6 @@ class Controller:
         logging.getLogger("iris").removeHandler(self._log_handler)
         self._log_handler.close()
         self._log_client.close()
-        self._remote_log_service.close()
-        self._remote_stats_service.close()
         if self._log_server is not None:
             self._log_server.stop()
         self._db.close()

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -379,24 +379,8 @@ class _SubdomainProxyMiddleware:
         return headers.get("x-forwarded-host") or headers.get("host", "")
 
 
-_LEGACY_FETCH_LOGS_PATH = "/iris.cluster.ControllerService/FetchLogs"
 _CANONICAL_FETCH_LOGS_PATH = "/finelog.logging.LogService/FetchLogs"
 _CANONICAL_PUSH_LOGS_PATH = "/finelog.logging.LogService/PushLogs"
-
-
-class _LegacyFetchLogsRedirect:
-    """Rewrites the legacy ControllerService/FetchLogs path to the canonical
-    LogService path so old workers reach the LogService mount, where the
-    full auth + timing + concurrency interceptor chain handles the request.
-    """
-
-    def __init__(self, app: ASGIApp):
-        self._app = app
-
-    async def __call__(self, scope: Scope, receive: Receive, send: Send) -> None:
-        if scope.get("type") == "http" and scope.get("path") == _LEGACY_FETCH_LOGS_PATH:
-            scope = {**scope, "path": _CANONICAL_FETCH_LOGS_PATH}
-        await self._app(scope, receive, send)
 
 
 class ControllerDashboard:
@@ -577,9 +561,6 @@ class ControllerDashboard:
         wrapped: ASGIApp = app
         if self._auth_policy.request_auth_enabled and self._auth_provider is not None:
             wrapped = _RouteAuthMiddleware(app, self._auth_policy)
-        # Wrap auth so the legacy FetchLogs rewrite happens before route
-        # matching: auth and routing both see the canonical path.
-        wrapped = _LegacyFetchLogsRedirect(wrapped)
         # Subdomain dispatch wraps everything: subdomain requests don't match
         # any Starlette route, so _RouteAuthMiddleware would default-allow
         # them. This middleware enforces auth itself before forwarding.

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -31,12 +31,6 @@ from urllib.parse import urlparse
 import httpx
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
-from finelog.client.proxy import LogServiceProxy, StatsServiceProxy
-from finelog.rpc.finelog_stats_connect import (
-    StatsServiceASGIApplication as FinelogStatsServiceASGIApplication,
-)
-from finelog.rpc.logging_connect import LogServiceASGIApplication
-from rigging.rpc import ConcurrencyLimitInterceptor
 from starlette.applications import Starlette
 from starlette.middleware.wsgi import WSGIMiddleware
 from starlette.requests import Request
@@ -379,10 +373,6 @@ class _SubdomainProxyMiddleware:
         return headers.get("x-forwarded-host") or headers.get("host", "")
 
 
-_CANONICAL_FETCH_LOGS_PATH = "/finelog.logging.LogService/FetchLogs"
-_CANONICAL_PUSH_LOGS_PATH = "/finelog.logging.LogService/PushLogs"
-
-
 class ControllerDashboard:
     """HTTP dashboard with Connect RPC and web UI.
 
@@ -395,16 +385,12 @@ class ControllerDashboard:
     def __init__(
         self,
         service: ControllerServiceImpl,
-        log_service: LogServiceProxy,
         host: str = "0.0.0.0",
         port: int = 8080,
         auth_provider: str | None = None,
-        finelog_stats_service: StatsServiceProxy | None = None,
         auth_policy: ControllerAuthPolicy = ControllerAuthPolicy(),
     ):
         self._service = service
-        self._log_service = log_service
-        self._finelog_stats_service = finelog_stats_service
         self._host = host
         self._port = port
         self._auth_provider = auth_provider
@@ -424,14 +410,10 @@ class ControllerDashboard:
         return self._app
 
     def _create_app(self) -> ASGIApp:
-        # Two timing interceptors: only the controller chain feeds the stats
-        # collector, so the panel stays a clean view of ControllerService
-        # traffic. The log server runs in a subprocess and will gain its own
-        # collector separately; the controller-side LogService mount is a
-        # legacy proxy whose forwarded calls would just add noise here.
+        # Only the controller RPC chain feeds the stats collector. Finelog RPCs
+        # use the generic endpoint proxy and are measured by the log server.
         include_tb = bool(os.environ.get("IRIS_DEBUG"))
         controller_timing = RequestTimingInterceptor(include_traceback=include_tb, collector=self._stats_collector)
-        log_timing = RequestTimingInterceptor(include_traceback=include_tb)
         if self._auth_provider is not None and self._auth_policy.request_auth_enabled:
             auth_interceptor = _DashboardAuthInterceptor(self._auth_policy)
         else:
@@ -456,32 +438,6 @@ class ControllerDashboard:
             compressions=IRIS_RPC_COMPRESSIONS,
         )
         stats_app = WSGIMiddleware(stats_wsgi_app)
-
-        # PushLogs is kept on the controller as a forwarding proxy: older workers
-        # cached /system/log-server -> controller URL, so we must accept their
-        # pushes and forward them to the real log server. Forwarding happens
-        # transparently because self._log_service is a LogServiceProxy whose
-        # push_logs() calls the remote LogService over RPC.
-        # Cap concurrent FetchLogs RPCs to avoid evicting the page cache with
-        # parallel log-segment scans against the finelog store.
-        log_interceptors = [auth_interceptor, log_timing, ConcurrencyLimitInterceptor({"FetchLogs": 4})]
-        log_app = LogServiceASGIApplication(
-            service=self._log_service, interceptors=log_interceptors, compressions=IRIS_RPC_COMPRESSIONS
-        )
-
-        # Backward-compat: clients/workers built before the finelog lift call
-        # /iris.logging.LogService/{FetchLogs,PushLogs}. Wire bytes are identical
-        # to /finelog.logging.LogService/*, so mount the same ASGI app at the
-        # legacy prefix and register relative-path aliases.
-        # connectrpc dispatch (_server_async.py) first looks up scope["path"]
-        # directly; under the Starlette Mount the legacy prefix is stripped to
-        # a relative path. Adding relative keys lets that first lookup succeed
-        # regardless of which mount handled the request. We pre-resolve so the
-        # aliased dict survives lifespan/lazy resolution.
-        log_app._resolved_endpoints = dict(log_app._resolve_endpoints(self._log_service))
-        log_app._resolved_endpoints["/FetchLogs"] = log_app._resolved_endpoints[_CANONICAL_FETCH_LOGS_PATH]
-        log_app._resolved_endpoints["/PushLogs"] = log_app._resolved_endpoints[_CANONICAL_PUSH_LOGS_PATH]
-        _LEGACY_LOG_SERVICE_PATH = "/iris.logging.LogService"
 
         self._endpoint_proxy = EndpointProxy(self._service.resolve_endpoint)
 
@@ -530,18 +486,9 @@ class ControllerDashboard:
                 _proxy_endpoint,
                 methods=list(endpoint_proxy.ALLOWED_METHODS),
             ),
-            Mount(log_app.path, app=log_app),
-            Mount(_LEGACY_LOG_SERVICE_PATH, app=log_app),
             Mount(rpc_asgi_app.path, app=rpc_asgi_app),
             Mount(stats_wsgi_app.path, app=stats_app),
         ]
-        if self._finelog_stats_service is not None:
-            finelog_stats_asgi_app = FinelogStatsServiceASGIApplication(
-                service=self._finelog_stats_service,
-                interceptors=[auth_interceptor],
-                compressions=IRIS_RPC_COMPRESSIONS,
-            )
-            routes.append(Mount(finelog_stats_asgi_app.path, app=finelog_stats_asgi_app))
         routes.append(static_files_mount())
 
         app: Starlette | _RouteAuthMiddleware = Starlette(
@@ -716,11 +663,6 @@ class ProxyControllerDashboard:
             Route(
                 "/iris.cluster.ControllerService/{method}",
                 functools.partial(self._proxy_rpc_post, service="iris.cluster.ControllerService"),
-                methods=["POST"],
-            ),
-            Route(
-                "/finelog.logging.LogService/{method}",
-                functools.partial(self._proxy_rpc_post, service="finelog.logging.LogService"),
                 methods=["POST"],
             ),
             Route("/proxy/{path:path}", self._proxy_endpoint, methods=list(endpoint_proxy.ALLOWED_METHODS)),

--- a/lib/iris/tests/cluster/client/test_remote_client.py
+++ b/lib/iris/tests/cluster/client/test_remote_client.py
@@ -1,0 +1,15 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from iris.cluster.client.remote_client import RemoteClusterClient
+from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
+
+
+def test_external_endpoint_resolution_uses_controller_proxy_path():
+    client = RemoteClusterClient("http://controller.example:8080/")
+    try:
+        address = client.resolve_endpoint(LOG_SERVER_ENDPOINT_NAME)
+    finally:
+        client.shutdown()
+
+    assert address == "http://controller.example:8080/proxy/system.log-server"

--- a/lib/iris/tests/cluster/controller/test_auth.py
+++ b/lib/iris/tests/cluster/controller/test_auth.py
@@ -9,7 +9,6 @@ import pytest
 import sqlalchemy.exc
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
-from finelog.client.proxy import LogServiceProxy
 from iris.cluster.bundle import BundleStore
 from iris.cluster.controller import reads, writes
 from iris.cluster.controller.auth import (
@@ -76,11 +75,6 @@ def state(db, tmp_path):
 
 
 @pytest.fixture
-def log_service(embedded_log_server) -> LogServiceProxy:
-    return LogServiceProxy(embedded_log_server.address)
-
-
-@pytest.fixture
 def service(state, tmp_path, log_client):
     controller_mock = Mock()
     controller_mock.wake = Mock()
@@ -106,10 +100,9 @@ def verifier():
 
 
 @pytest.fixture
-def authed_client(service, log_service, verifier):
+def authed_client(service, verifier):
     dashboard = ControllerDashboard(
         service,
-        log_service=log_service,
         auth_provider="gcp",
         auth_policy=ControllerAuthPolicy.from_verifiers(verifier=verifier),
     )
@@ -117,8 +110,8 @@ def authed_client(service, log_service, verifier):
 
 
 @pytest.fixture
-def noauth_client(service, log_service):
-    dashboard = ControllerDashboard(service, log_service=log_service)
+def noauth_client(service):
+    dashboard = ControllerDashboard(service)
     return TestClient(dashboard.app)
 
 
@@ -364,11 +357,10 @@ def test_revoke_login_keys(db: ControllerDB):
 
 
 @pytest.fixture
-def optional_auth_client(service, log_service, verifier):
+def optional_auth_client(service, verifier):
     """Dashboard with auth configured but optional — tokens verified if present, anonymous fallback."""
     dashboard = ControllerDashboard(
         service,
-        log_service=log_service,
         auth_provider="static",
         auth_policy=ControllerAuthPolicy.from_verifiers(verifier=verifier, optional=True),
     )
@@ -480,7 +472,7 @@ def test_resolve_auth_policy(verifier, token, optional, should_succeed):
         "invalid-optional",
     ],
 )
-def test_route_auth_middleware_uses_resolve_auth(service, log_service, verifier, token, optional, should_allow):
+def test_route_auth_middleware_uses_resolve_auth(service, verifier, token, optional, should_allow):
     """_RouteAuthMiddleware applies the same resolve_auth policy as the gRPC interceptor.
 
     We build a dashboard with a @requires_auth route injected and verify it
@@ -493,7 +485,6 @@ def test_route_auth_middleware_uses_resolve_auth(service, log_service, verifier,
 
     dashboard = ControllerDashboard(
         service,
-        log_service=log_service,
         auth_provider="static",
         auth_policy=ControllerAuthPolicy.from_verifiers(verifier=verifier, optional=optional),
     )

--- a/lib/iris/tests/cluster/controller/test_auth.py
+++ b/lib/iris/tests/cluster/controller/test_auth.py
@@ -26,7 +26,6 @@ from iris.cluster.controller.backend import BackendCapability
 from iris.cluster.controller.dashboard import (
     ControllerDashboard,
     _DashboardAuthInterceptor,
-    _LegacyFetchLogsRedirect,
     _RouteAuthMiddleware,
     _SubdomainProxyMiddleware,
     requires_auth,
@@ -498,12 +497,10 @@ def test_route_auth_middleware_uses_resolve_auth(service, log_service, verifier,
         auth_provider="static",
         auth_policy=ControllerAuthPolicy.from_verifiers(verifier=verifier, optional=optional),
     )
-    # Inject a @requires_auth route. The app is wrapped in
-    # _SubdomainProxyMiddleware → _LegacyFetchLogsRedirect → _RouteAuthMiddleware
-    # → Starlette; walk down to the Starlette router so the new route
-    # participates in route matching.
+    # Inject a @requires_auth route. Walk down to the Starlette router so the
+    # new route participates in route matching.
     app = dashboard.app
-    while isinstance(app, _SubdomainProxyMiddleware | _LegacyFetchLogsRedirect | _RouteAuthMiddleware):
+    while isinstance(app, _SubdomainProxyMiddleware | _RouteAuthMiddleware):
         app = app._app
     app.router.routes.insert(0, Route("/test-protected", _protected))
 

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -11,7 +11,6 @@ from unittest.mock import Mock
 
 import pytest
 from finelog.client.proxy import LogServiceProxy
-from finelog.rpc import logging_pb2
 from iris.cluster.backends.k8s.fake import InMemoryK8sService
 from iris.cluster.backends.k8s.tasks import _LABEL_MANAGED, _LABEL_RUNTIME, _RUNTIME_LABEL_VALUE, K8sTaskProvider
 from iris.cluster.backends.k8s.types import K8sResource
@@ -1190,37 +1189,6 @@ def test_fetch_logs_for_missing_task_returns_empty_entries(client):
     assert resp.status_code == 200
     data = resp.json()
     assert data.get("entries", []) == []
-
-
-def test_fetch_logs_backward_compat_proxy(client):
-    """The old ControllerService/FetchLogs path proxies to LogService."""
-    task_id = JobName.root("test-user", "nonexistent").task(0).to_wire()
-    resp = client.post(
-        "/iris.cluster.ControllerService/FetchLogs",
-        json={"source": f"{task_id}:", "match_scope": "MATCH_SCOPE_PREFIX"},
-        headers={"Content-Type": "application/json"},
-    )
-    assert resp.status_code == 200
-    data = resp.json()
-    assert data.get("entries", []) == []
-
-
-def test_fetch_logs_backward_compat_proxy_proto_binary(client):
-    """Old clients using default Connect proto encoding hit the compat endpoint."""
-    task_id = JobName.root("test-user", "nonexistent").task(0).to_wire()
-    req = logging_pb2.FetchLogsRequest(
-        source=f"{task_id}:",
-        match_scope=logging_pb2.MATCH_SCOPE_PREFIX,
-    )
-    resp = client.post(
-        "/iris.cluster.ControllerService/FetchLogs",
-        content=req.SerializeToString(),
-        headers={"Content-Type": "application/proto"},
-    )
-    assert resp.status_code == 200
-    parsed = logging_pb2.FetchLogsResponse()
-    parsed.ParseFromString(resp.content)
-    assert list(parsed.entries) == []
 
 
 def test_fetch_logs_legacy_iris_logging_path(client):

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -10,7 +10,6 @@ The dashboard serves a web UI that fetches data via RPC calls.
 from unittest.mock import Mock
 
 import pytest
-from finelog.client.proxy import LogServiceProxy
 from iris.cluster.backends.k8s.fake import InMemoryK8sService
 from iris.cluster.backends.k8s.tasks import _LABEL_MANAGED, _LABEL_RUNTIME, _RUNTIME_LABEL_VALUE, K8sTaskProvider
 from iris.cluster.backends.k8s.types import K8sResource
@@ -197,12 +196,7 @@ def _make_controller_mock(state, scheduler, autoscaler=None):
 
 
 @pytest.fixture
-def log_service(embedded_log_server) -> LogServiceProxy:
-    return LogServiceProxy(embedded_log_server.address)
-
-
-@pytest.fixture
-def service(state, scheduler, tmp_path, log_client):
+def service(state, scheduler, tmp_path, embedded_log_server, log_client):
     controller_mock = _make_controller_mock(state, scheduler)
     return ControllerServiceImpl(
         controller=controller_mock,
@@ -212,12 +206,13 @@ def service(state, scheduler, tmp_path, log_client):
         health=state._health,
         endpoints=state._endpoints,
         worker_attrs=state._worker_attrs,
+        system_endpoints={"/system/log-server": embedded_log_server.address},
     )
 
 
 @pytest.fixture
-def client(service, log_service):
-    dashboard = ControllerDashboard(service, log_service=log_service)
+def client(service):
+    dashboard = ControllerDashboard(service)
     return TestClient(dashboard.app)
 
 
@@ -630,9 +625,9 @@ def mock_autoscaler():
 
 
 @pytest.fixture
-def client_with_autoscaler(service_with_autoscaler, log_service):
+def client_with_autoscaler(service_with_autoscaler):
     """Dashboard test client with autoscaler enabled."""
-    dashboard = ControllerDashboard(service_with_autoscaler, log_service=log_service)
+    dashboard = ControllerDashboard(service_with_autoscaler)
     return TestClient(dashboard.app)
 
 
@@ -1179,10 +1174,10 @@ def test_health_endpoint_returns_ok(client):
 
 
 def test_fetch_logs_for_missing_task_returns_empty_entries(client):
-    """FetchLogs on LogService returns empty entries for a nonexistent task."""
+    """The endpoint proxy forwards FetchLogs to the registered log server."""
     task_id = JobName.root("test-user", "nonexistent").task(0).to_wire()
     resp = client.post(
-        "/finelog.logging.LogService/FetchLogs",
+        "/proxy/system.log-server/finelog.logging.LogService/FetchLogs",
         json={"source": f"{task_id}:", "match_scope": "MATCH_SCOPE_PREFIX"},
         headers={"Content-Type": "application/json"},
     )
@@ -1191,16 +1186,18 @@ def test_fetch_logs_for_missing_task_returns_empty_entries(client):
     assert data.get("entries", []) == []
 
 
-def test_fetch_logs_legacy_iris_logging_path(client):
-    """Pre-finelog-lift clients call /iris.logging.LogService/FetchLogs."""
-    task_id = JobName.root("test-user", "nonexistent").task(0).to_wire()
-    resp = client.post(
+@pytest.mark.parametrize(
+    "path",
+    [
+        "/iris.cluster.ControllerService/FetchLogs",
         "/iris.logging.LogService/FetchLogs",
-        json={"source": f"{task_id}:", "match_scope": "MATCH_SCOPE_PREFIX"},
-        headers={"Content-Type": "application/json"},
-    )
-    assert resp.status_code == 200
-    assert resp.json().get("entries", []) == []
+        "/finelog.logging.LogService/FetchLogs",
+    ],
+)
+def test_fetch_logs_outside_endpoint_proxy_is_not_exposed(client, path):
+    resp = client.post(path, json={}, headers={"Content-Type": "application/json"})
+
+    assert resp.status_code == 404
 
 
 # =============================================================================
@@ -1340,12 +1337,11 @@ def test_auth_config_returns_disabled_by_default(client):
     assert data["provider"] is None
 
 
-def test_auth_config_returns_enabled_when_verifier_set(service, log_service):
+def test_auth_config_returns_enabled_when_verifier_set(service):
     """Auth config endpoint reports auth enabled with provider name."""
     verifier = StaticTokenVerifier({"test-token": "test-user"})
     dashboard = ControllerDashboard(
         service,
-        log_service=log_service,
         auth_provider="gcp",
         auth_policy=ControllerAuthPolicy.from_verifiers(verifier=verifier),
     )
@@ -1371,14 +1367,13 @@ def test_auth_config_worker_capabilities(client):
     assert "cluster" not in backend["capabilities"]
 
 
-def test_auth_config_kubernetes_capabilities(state, scheduler, tmp_path, embedded_log_server, log_client):
+def test_auth_config_kubernetes_capabilities(state, scheduler, tmp_path, log_client):
     """auth/config advertises the cluster capability for a backend-placed (k8s) backend."""
     controller_mock = _make_controller_mock(state, scheduler)
     cluster_caps = frozenset({BackendCapability.CLUSTER_VIEW})
     controller_mock.capabilities = cluster_caps
     controller_mock.provider = Mock(capabilities=cluster_caps)
     controller_mock.provider.name = "kubernetes"
-    log_service = LogServiceProxy(embedded_log_server.address)
     svc = ControllerServiceImpl(
         controller=controller_mock,
         bundle_store=BundleStore(storage_dir=str(tmp_path / "bundles")),
@@ -1388,7 +1383,7 @@ def test_auth_config_kubernetes_capabilities(state, scheduler, tmp_path, embedde
         endpoints=state._endpoints,
         worker_attrs=state._worker_attrs,
     )
-    dashboard = ControllerDashboard(svc, log_service=log_service)
+    dashboard = ControllerDashboard(svc)
     k8s_client = TestClient(dashboard.app)
 
     resp = k8s_client.get("/auth/config")
@@ -1407,14 +1402,13 @@ def test_auth_config_kubernetes_capabilities(state, scheduler, tmp_path, embedde
 # =============================================================================
 
 
-def _make_k8s_dashboard_client(state, scheduler, tmp_path, embedded_log_server, log_client):
+def _make_k8s_dashboard_client(state, scheduler, tmp_path, log_client):
     """Build a TestClient wired to a real K8sTaskProvider backed by InMemoryK8sService."""
     k8s = InMemoryK8sService(namespace="iris")
     provider = K8sTaskProvider(kubectl=k8s, namespace="iris", default_image="img:latest", cluster_scan_interval=0.0)
     controller_mock = _make_controller_mock(state, scheduler)
     controller_mock.capabilities = frozenset({BackendCapability.CLUSTER_VIEW})
     controller_mock.provider = provider
-    log_service = LogServiceProxy(embedded_log_server.address)
     svc = ControllerServiceImpl(
         controller=controller_mock,
         bundle_store=BundleStore(storage_dir=str(tmp_path / "bundles")),
@@ -1424,13 +1418,13 @@ def _make_k8s_dashboard_client(state, scheduler, tmp_path, embedded_log_server, 
         endpoints=state._endpoints,
         worker_attrs=state._worker_attrs,
     )
-    dashboard = ControllerDashboard(svc, log_service=log_service)
+    dashboard = ControllerDashboard(svc)
     return TestClient(dashboard.app), k8s, provider
 
 
-def test_k8s_cluster_status_returns_nodes_and_pods(state, scheduler, tmp_path, embedded_log_server, log_client):
+def test_k8s_cluster_status_returns_nodes_and_pods(state, scheduler, tmp_path, log_client):
     """GetKubernetesClusterStatus returns node capacity and pod statuses after sync."""
-    client, k8s, provider = _make_k8s_dashboard_client(state, scheduler, tmp_path, embedded_log_server, log_client)
+    client, k8s, provider = _make_k8s_dashboard_client(state, scheduler, tmp_path, log_client)
 
     # Seed nodes and a pod.
     k8s.seed_resource(
@@ -1487,9 +1481,9 @@ def test_k8s_cluster_status_returns_nodes_and_pods(state, scheduler, tmp_path, e
     provider.close()
 
 
-def test_k8s_cluster_status_empty_before_sync(state, scheduler, tmp_path, embedded_log_server, log_client):
+def test_k8s_cluster_status_empty_before_sync(state, scheduler, tmp_path, log_client):
     """GetKubernetesClusterStatus returns empty data when no sync has run yet."""
-    client, _k8s, provider = _make_k8s_dashboard_client(state, scheduler, tmp_path, embedded_log_server, log_client)
+    client, _k8s, provider = _make_k8s_dashboard_client(state, scheduler, tmp_path, log_client)
 
     resp = client.post(
         "/iris.cluster.ControllerService/GetKubernetesClusterStatus",

--- a/lib/iris/tests/e2e/conftest.py
+++ b/lib/iris/tests/e2e/conftest.py
@@ -30,6 +30,7 @@ from iris.chaos import reset_chaos
 from iris.client.client import IrisClient, Job
 from iris.cluster.config import load_config, make_local_config
 from iris.cluster.constraints import Constraint, WellKnownAttribute
+from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
 from iris.cluster.lifecycle import connect_cluster
 from iris.cluster.types import (
     CoschedulingConfig,
@@ -40,6 +41,7 @@ from iris.cluster.types import (
 )
 from iris.rpc import config_pb2, controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
+from rigging.connect import proxy_path
 from rigging.timing import Duration
 
 from .chronos import VirtualClock
@@ -357,7 +359,10 @@ def cluster():
     with connect_cluster(config) as url:
         client = IrisClient.remote(url, workspace=MARIN_ROOT)
         controller_client = ControllerServiceClientSync(address=url, timeout_ms=30000)
-        log_client = LogServiceClientSync(address=url, timeout_ms=30000)
+        log_client = LogServiceClientSync(
+            address=f"{url.rstrip('/')}{proxy_path(LOG_SERVER_ENDPOINT_NAME)}",
+            timeout_ms=30000,
+        )
         yield IrisTestCluster(url=url, client=client, controller_client=controller_client, log_client=log_client)
         log_client.close()
         controller_client.close()
@@ -393,7 +398,10 @@ def multi_worker_cluster():
     with connect_cluster(config) as url:
         client = IrisClient.remote(url, workspace=MARIN_ROOT)
         controller_client = ControllerServiceClientSync(address=url, timeout_ms=30000)
-        log_client = LogServiceClientSync(address=url, timeout_ms=30000)
+        log_client = LogServiceClientSync(
+            address=f"{url.rstrip('/')}{proxy_path(LOG_SERVER_ENDPOINT_NAME)}",
+            timeout_ms=30000,
+        )
         tc = IrisTestCluster(url=url, client=client, controller_client=controller_client, log_client=log_client)
         tc.wait_for_workers(num_workers, timeout=60)
         yield tc

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -23,12 +23,14 @@ from iris.client.client import IrisClient, iris_ctx
 from iris.cluster.backends.local.cluster import LocalCluster
 from iris.cluster.config import load_config, make_local_config
 from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute, region_constraint
+from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
 from iris.cluster.lifecycle import connect_cluster
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec
 from iris.rpc import config_pb2, controller_pb2, job_pb2
 from iris.rpc.auth import AuthTokenInjector, StaticTokenProvider
 from iris.rpc.controller_connect import ControllerServiceClientSync
 from iris.version import client_revision_date
+from rigging.connect import proxy_path
 from rigging.timing import Duration, ExponentialBackoff
 
 from .conftest import (
@@ -122,7 +124,10 @@ def smoke_cluster(request):
     if controller_url:
         client = IrisClient.remote(controller_url, workspace=MARIN_ROOT)
         controller_client = ControllerServiceClientSync(address=controller_url, timeout_ms=30000)
-        log_client = LogServiceClientSync(address=controller_url, timeout_ms=30000)
+        log_client = LogServiceClientSync(
+            address=f"{controller_url.rstrip('/')}{proxy_path(LOG_SERVER_ENDPOINT_NAME)}",
+            timeout_ms=30000,
+        )
         tc = IrisTestCluster(
             url=controller_url,
             client=client,
@@ -137,6 +142,7 @@ def smoke_cluster(request):
         if workers:
             tc.wait_for_workers(1, timeout=600)
         yield tc
+        log_client.close()
         controller_client.close()
         return
 
@@ -144,10 +150,14 @@ def smoke_cluster(request):
     with connect_cluster(config) as url:
         client = IrisClient.remote(url, workspace=MARIN_ROOT)
         controller_client = ControllerServiceClientSync(address=url, timeout_ms=30000)
-        log_client = LogServiceClientSync(address=url, timeout_ms=30000)
+        log_client = LogServiceClientSync(
+            address=f"{url.rstrip('/')}{proxy_path(LOG_SERVER_ENDPOINT_NAME)}",
+            timeout_ms=30000,
+        )
         tc = IrisTestCluster(url=url, client=client, controller_client=controller_client, log_client=log_client)
         tc.wait_for_workers(SMOKE_WORKER_COUNT, timeout=60)
         yield tc
+        log_client.close()
         controller_client.close()
 
 


### PR DESCRIPTION
Route dashboard and external Iris LogClient traffic through the generic /proxy/system.log-server endpoint introduced for Finelog connections. In-cluster clients continue resolving the Finelog service directly.

Remove the controller's typed LogService and Finelog StatsService forwarding mounts, including the obsolete ControllerService/FetchLogs and iris.logging compatibility paths. This leaves one authenticated proxy path for external Finelog RPCs and removes method-specific controller forwarding code.