### PR TITLE
[grug] Fall back from invalid DeepEP collapse layout

### DIFF
--- a/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
@@ -281,6 +281,11 @@ def _collapse_local_assignments_gather_jax(
     return jnp.sum(jnp.where(valid[:, :, None], weighted, 0), axis=1)
 
 
+def _assignment_destinations_have_recv_topk_layout(assignment_destinations: jax.Array, *, recv_capacity: int) -> bool:
+    """Return whether destination metadata can be viewed as per-received-token top-k rows."""
+    return recv_capacity > 0 and assignment_destinations.shape[0] % recv_capacity == 0
+
+
 def _deepep_moe_up_down(
     x_dispatch: Float[Array, "TK D"],
     local_group_sizes: Int[Array, "EL"],
@@ -640,7 +645,10 @@ def _moe_mlp_ep_deepep_internode_local(
 
     with jax.named_scope("moe_ep_deepep_internode/combine"):
         collapse_mode = _deepep_internode_collapse_mode()
-        if collapse_mode == _DEEPEP_INTERNODE_COLLAPSE_FUSED_COMBINE:
+        has_recv_topk_destination_layout = _assignment_destinations_have_recv_topk_layout(
+            assignment_destinations, recv_capacity=recv_x.shape[0]
+        )
+        if collapse_mode == _DEEPEP_INTERNODE_COLLAPSE_FUSED_COMBINE and has_recv_topk_destination_layout:
             if _deepep_internode_combine_x_only():
                 with jax.named_scope("deepep_combine_internode_x_only_with_local_collapse"):
                     out_local = deepep_combine_internode_x_only_with_local_collapse(
@@ -685,7 +693,7 @@ def _moe_mlp_ep_deepep_internode_local(
                         num_recv_tokens,
                         num_recv_rdma_tokens,
                     )
-        elif collapse_mode == _DEEPEP_INTERNODE_COLLAPSE_GATHER:
+        elif collapse_mode == _DEEPEP_INTERNODE_COLLAPSE_GATHER and has_recv_topk_destination_layout:
             with jax.named_scope("deepep_collapse_local_assignments_gather_jax"):
                 recv_out = _collapse_local_assignments_gather_jax(
                     out_dispatch,
@@ -712,7 +720,7 @@ def _moe_mlp_ep_deepep_internode_local(
                     num_recv_tokens,
                     num_recv_rdma_tokens,
                 )
-        elif collapse_mode == _DEEPEP_INTERNODE_COLLAPSE_FFI:
+        elif collapse_mode == _DEEPEP_INTERNODE_COLLAPSE_FFI and has_recv_topk_destination_layout:
             with jax.named_scope("deepep_collapse_local_assignments_ffi"):
                 recv_out = deepep_collapse_local_assignments(
                     out_dispatch,
@@ -742,7 +750,17 @@ def _moe_mlp_ep_deepep_internode_local(
                     num_recv_rdma_tokens,
                 )
         else:
-            with jax.named_scope("deepep_collapse_local_assignments_jax"):
+            fallback_scope = (
+                "deepep_collapse_local_assignments_shape_fallback_jax"
+                if collapse_mode
+                in {
+                    _DEEPEP_INTERNODE_COLLAPSE_FUSED_COMBINE,
+                    _DEEPEP_INTERNODE_COLLAPSE_GATHER,
+                    _DEEPEP_INTERNODE_COLLAPSE_FFI,
+                }
+                else "deepep_collapse_local_assignments_jax"
+            )
+            with jax.named_scope(fallback_scope):
                 recv_out = _collapse_local_assignments_jax(
                     out_dispatch,
                     assignment_weights,

--- a/lib/levanter/src/levanter/kernels/deepep/transport_ffi.py
+++ b/lib/levanter/src/levanter/kernels/deepep/transport_ffi.py
@@ -2194,7 +2194,8 @@ def _dispatch_internode_impl(
         assignment_capacity=np.int32(output_assignments),
         low_latency_mode=_internode_low_latency_mode(),
     )
-    return DeepEPInternodeDispatch(*results[:21])
+    dispatch_results = (*results[:20], results[22])
+    return DeepEPInternodeDispatch(*dispatch_results)
 
 
 @partial(jax.custom_vjp, nondiff_argnums=(7, 8, 9, 10, 11, 12, 13))

--- a/lib/levanter/tests/grug/test_grugformer_moe.py
+++ b/lib/levanter/tests/grug/test_grugformer_moe.py
@@ -15,6 +15,7 @@ from haliax.nn.ragged_dot import ragged_dot
 import levanter.grug.grug_moe as grug_moe
 from levanter.grug._moe.common import _prepare_moe_dispatch, _prepare_moe_dispatch_indices_with_assignment_ids
 from levanter.grug._moe.ep_deepep import (
+    _assignment_destinations_have_recv_topk_layout,
     _collapse_local_assignments_gather_jax,
     _collapse_local_assignments_jax,
     _tokens_per_rdma_rank,
@@ -530,6 +531,16 @@ def test_deepep_internode_gather_collapse_matches_scatter_collapse():
     )
 
     np.testing.assert_allclose(np.asarray(gather), np.asarray(scatter), rtol=0, atol=0)
+
+
+def test_deepep_internode_collapse_destination_layout_detects_invalid_shape():
+    recv_capacity = 4
+
+    assert _assignment_destinations_have_recv_topk_layout(jnp.arange(8, dtype=jnp.int32), recv_capacity=recv_capacity)
+    assert not _assignment_destinations_have_recv_topk_layout(
+        jnp.arange(5, dtype=jnp.int32),
+        recv_capacity=recv_capacity,
+    )
 
 
 def test_deepep_internode_gather_collapse_gradients_match_scatter_collapse():

--- a/lib/levanter/tests/kernels/test_deepep_availability.py
+++ b/lib/levanter/tests/kernels/test_deepep_availability.py
@@ -971,7 +971,7 @@ def test_deepep_dispatch_internode_exposes_static_jax_contract(monkeypatch: pyte
     assert dispatch.x_dispatch.shape == (24, 16)
     assert dispatch.assignment_weights.shape == (24,)
     assert dispatch.recv_token_indices.shape == (24,)
-    assert dispatch.assignment_destinations.shape == (2,)
+    assert dispatch.assignment_destinations.shape == (24,)
 
 
 def test_internode_dispatch_config_accepts_env_overrides(monkeypatch: pytest.MonkeyPatch) -> None:


### PR DESCRIPTION
Guard the DeepEP internode local-assignment collapse paths against destination layouts that are not shaped as recv-topk maps. When the static layout is incompatible with the FFI/gather/fused-combine collapse contract, use the token-index JAX scatter collapse instead of calling the invalid FFI path.

This keeps the hidden-offload EP16 runs from failing before the first step when DeepEP dispatch returns compact assignment destinations.

Part of #6539