### PR TITLE
[iris] reduce RPC handler pool from 1024 back to 64

### DIFF
--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -100,7 +100,7 @@ logger = logging.getLogger(__name__)
 # every other RPC, including the worker heartbeats that would unblock the
 # drain. Install a wider, named pool so a burst of slow handlers cannot
 # starve the rest.
-_RPC_HANDLER_THREADS = 1024
+_RPC_HANDLER_THREADS = 64
 
 
 def _install_rpc_executor(server: uvicorn.Server, *, max_workers: int) -> None:


### PR DESCRIPTION
* revert `_RPC_HANDLER_THREADS` 1024 → 64 in `controller.py`
  * the bump to 1024 was an over-correction; return the controller's default executor to the original 64 threads
* 64 is still wider than uvicorn's default executor, so the existing comment (a burst of slow sync handlers cannot starve worker heartbeats) still holds