### PR TITLE
finelog: s3:// remote archive + self-contained k8s deploy on cw-us-east-02a

### DIFF
--- a/lib/finelog/config/cw-us-east-02a.yaml
+++ b/lib/finelog/config/cw-us-east-02a.yaml
@@ -7,10 +7,12 @@
 # finelog-cw-use02a.iris.svc.cluster.local:10001.
 #
 # Archive: segments offload to Cloudflare R2 (s3://), the same object store the
-# cluster uses for controller state. The pod authenticates with the R2 creds the
-# controller injects via the iris-task-env Secret (see deploy/k8s/02-deployment).
+# cluster uses for controller state. `finelog deploy up` mints the
+# `finelog-cw-use02a-env` Secret from the operator's R2 creds + object_storage_endpoint
+# and projects it into the pod via envFrom (see deploy/k8s/02-deployment).
 #
-# Deploy: export KUBECONFIG=~/.kube/coreweave-iris-gpu, then
+# Deploy: export KUBECONFIG=~/.kube/coreweave-iris-gpu and the R2 creds, then
+#   export R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=...
 #   uv run finelog deploy up cw-us-east-02a
 name: finelog-cw-use02a
 port: 10001
@@ -19,6 +21,9 @@ remote_log_dir: s3://marin-na/finelog/cw-us-east-02a
 deployment:
   k8s:
     namespace: iris
-    # storage_class omitted -> the cluster's default StorageClass backs the PVC.
-    # Segments offload to R2, so the local cache PVC stays small.
-    storage_gb: 50
+    # storage_class omitted -> the cluster's default StorageClass (shared-vast,
+    # VAST CSI) backs the PVC. Segments offload to R2, but size the local cache
+    # generously to absorb ingest bursts + L0->L1 compaction before offload.
+    storage_gb: 250
+    # R2 endpoint for the s3:// archive; folded into the minted creds Secret.
+    object_storage_endpoint: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com

--- a/lib/finelog/config/cw-us-east-02a.yaml
+++ b/lib/finelog/config/cw-us-east-02a.yaml
@@ -1,0 +1,24 @@
+# finelog log server for the CoreWeave US-EAST-02A cluster (cw-us-east-02a).
+#
+# Deployed as an in-cluster k8s Deployment + ClusterIP Service in the `iris`
+# namespace, the same namespace as the iris controller. iris references it from
+# its cluster config via `log_server_config: cw-us-east-02a`, which resolves to
+# the endpoint `k8s://finelog-cw-use02a.iris` ->
+# finelog-cw-use02a.iris.svc.cluster.local:10001.
+#
+# Archive: segments offload to Cloudflare R2 (s3://), the same object store the
+# cluster uses for controller state. The pod authenticates with the R2 creds the
+# controller injects via the iris-task-env Secret (see deploy/k8s/02-deployment).
+#
+# Deploy: export KUBECONFIG=~/.kube/coreweave-iris-gpu, then
+#   uv run finelog deploy up cw-us-east-02a
+name: finelog-cw-use02a
+port: 10001
+image: ghcr.io/marin-community/finelog:latest
+remote_log_dir: s3://marin-na/finelog/cw-us-east-02a
+deployment:
+  k8s:
+    namespace: iris
+    # storage_class omitted -> the cluster's default StorageClass backs the PVC.
+    # Segments offload to R2, so the local cache PVC stays small.
+    storage_gb: 50

--- a/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
+++ b/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
@@ -44,6 +44,17 @@ spec:
             - name: rpc
               containerPort: {{ port }}
               protocol: TCP
+          # On iris-managed clusters the controller mints an iris-task-env Secret
+          # holding the object-store credentials (on CoreWeave: the R2 AWS_*
+          # vars + AWS_ENDPOINT_URL). Project it so an s3:// remote_log_dir can
+          # authenticate. optional=true keeps the pod schedulable on clusters
+          # without the Secret (e.g. a gs:// or local-only deployment), where
+          # GCS uses workload identity instead. The explicit env below wins on
+          # any key collision.
+          envFrom:
+            - secretRef:
+                name: iris-task-env
+                optional: true
           env:
             - name: FINELOG_PORT
               value: "{{ port }}"

--- a/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
+++ b/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
@@ -44,16 +44,14 @@ spec:
             - name: rpc
               containerPort: {{ port }}
               protocol: TCP
-          # On iris-managed clusters the controller mints an iris-task-env Secret
-          # holding the object-store credentials (on CoreWeave: the R2 AWS_*
-          # vars + AWS_ENDPOINT_URL). Project it so an s3:// remote_log_dir can
-          # authenticate. optional=true keeps the pod schedulable on clusters
-          # without the Secret (e.g. a gs:// or local-only deployment), where
-          # GCS uses workload identity instead. The explicit env below wins on
-          # any key collision.
+          # S3 credentials for an s3:// remote_log_dir. `finelog deploy up` mints
+          # the `{{ name }}-env` Secret (R2 AWS_* creds + AWS_ENDPOINT_URL) from
+          # the operator's env and projects it here. optional=true keeps the pod
+          # schedulable when no Secret exists (gs:// or local archives, where GCS
+          # uses workload identity). The explicit env below wins on key collision.
           envFrom:
             - secretRef:
-                name: iris-task-env
+                name: {{ name }}-env
                 optional: true
           env:
             - name: FINELOG_PORT

--- a/lib/finelog/rust/Cargo.lock
+++ b/lib/finelog/rust/Cargo.lock
@@ -2674,6 +2674,7 @@ dependencies = [
  "humantime",
  "hyper",
  "itertools",
+ "md-5",
  "parking_lot",
  "percent-encoding",
  "quick-xml",

--- a/lib/finelog/rust/Cargo.toml
+++ b/lib/finelog/rust/Cargo.toml
@@ -82,7 +82,7 @@ datafusion = "53"
 # `downcast_ref::<ParquetAccessPlan>()` silently miss).
 datafusion-datasource = "53"
 datafusion-datasource-parquet = "53"
-object_store = { version = "0.13", features = ["gcp"] }
+object_store = { version = "0.13", features = ["gcp", "aws"] }
 async-trait = "0.1"
 url = "2"
 # Rust-owned catalog sidecar; `bundled` keeps the build hermetic (no system

--- a/lib/finelog/rust/src/main.rs
+++ b/lib/finelog/rust/src/main.rs
@@ -38,8 +38,8 @@ struct Args {
     #[arg(long, env = "FINELOG_LOG_DIR")]
     log_dir: Option<String>,
 
-    /// Remote (e.g. gs://) directory for offloaded segments. Empty disables sync.
-    /// Read from `FINELOG_REMOTE_DIR`, set by the deploy environment.
+    /// Remote (gs:// or s3://) directory for offloaded segments. Empty disables
+    /// sync. Read from `FINELOG_REMOTE_DIR`, set by the deploy environment.
     #[arg(long, env = "FINELOG_REMOTE_DIR", default_value = "")]
     remote_log_dir: String,
 

--- a/lib/finelog/rust/src/store/remote.rs
+++ b/lib/finelog/rust/src/store/remote.rs
@@ -1,7 +1,9 @@
 //! object_store remote sync surface (LOCAL -> BOTH -> REMOTE).
 //!
 //! `build_remote_store` dispatches on the configured `remote_log_dir`:
-//! `gs://bucket/prefix` -> `GoogleCloudStorageBuilder` (prod); any other
+//! `gs://bucket/prefix` -> `GoogleCloudStorageBuilder` (GCP prod);
+//! `s3://bucket/prefix` -> `AmazonS3Builder` for any S3-compatible store
+//! (Cloudflare R2 / CoreWeave Object Storage on CoreWeave clusters); any other
 //! non-empty value -> `LocalFileSystem` rooted at that directory (tests pass a
 //! plain tmp path). An empty `remote_log_dir` disables sync (returns `None`).
 //!
@@ -32,6 +34,13 @@ pub struct RemoteStore {
 /// disabled (empty string).
 ///
 /// `gs://bucket/sub/dir` -> a GCS store on `bucket` with prefix `sub/dir`.
+/// `s3://bucket/sub/dir` -> an S3-compatible store on `bucket` with prefix
+/// `sub/dir`. Everything else about the connection comes from the standard
+/// `AWS_*` env the deploy environment injects (on CoreWeave: the `iris-task-env`
+/// Secret's R2 creds). `AmazonS3Builder::from_env` reads credentials, region,
+/// the custom `AWS_ENDPOINT_URL`, and `AWS_VIRTUAL_HOSTED_STYLE_REQUEST` — so
+/// iris owns the addressing-style decision (path-style for R2, virtual-hosted
+/// for CoreWeave Object Storage) and this server stays endpoint-agnostic.
 /// Any other value -> a `LocalFileSystem` rooted at that (created) directory,
 /// with an empty prefix, writing into `{remote_log_dir}/{namespace}/{basename}`.
 pub fn build_remote_store(remote_log_dir: &str) -> Result<Option<RemoteStore>, StatsError> {
@@ -48,6 +57,20 @@ pub fn build_remote_store(remote_log_dir: &str) -> Result<Option<RemoteStore>, S
             .with_bucket_name(bucket)
             .build()
             .map_err(|e| StatsError::Internal(format!("build gcs store {bucket:?}: {e}")))?;
+        return Ok(Some(RemoteStore {
+            store: Arc::new(store),
+            prefix: prefix.trim_matches('/').to_string(),
+        }));
+    }
+    if let Some(rest) = dir.strip_prefix("s3://") {
+        let (bucket, prefix) = match rest.split_once('/') {
+            Some((b, p)) => (b, p),
+            None => (rest, ""),
+        };
+        let store = object_store::aws::AmazonS3Builder::from_env()
+            .with_bucket_name(bucket)
+            .build()
+            .map_err(|e| StatsError::Internal(format!("build s3 store {bucket:?}: {e}")))?;
         return Ok(Some(RemoteStore {
             store: Arc::new(store),
             prefix: prefix.trim_matches('/').to_string(),
@@ -238,6 +261,22 @@ mod tests {
         assert_eq!(store.prefix, "logs/sub");
         let p = store.object_path("ns.a", "seg_L1_0001.parquet");
         assert_eq!(p.to_string(), "logs/sub/ns.a/seg_L1_0001.parquet");
+    }
+
+    #[test]
+    fn s3_url_parses_bucket_and_prefix() {
+        // from_env() builds without credentials; the parse + prefix split is the
+        // logic under test (no network — we never call put/list here). No
+        // AWS_ENDPOINT_URL is set, so the builder keeps its default endpoint.
+        let store = build_remote_store("s3://my-bucket/finelog/cw-us-east-02a")
+            .unwrap()
+            .unwrap();
+        assert_eq!(store.prefix, "finelog/cw-us-east-02a");
+        let p = store.object_path("iris.worker", "seg_L1_0001.parquet");
+        assert_eq!(
+            p.to_string(),
+            "finelog/cw-us-east-02a/iris.worker/seg_L1_0001.parquet"
+        );
     }
 
     #[tokio::test]

--- a/lib/finelog/src/finelog/deploy/_k8s.py
+++ b/lib/finelog/src/finelog/deploy/_k8s.py
@@ -10,6 +10,9 @@ list is small enough that subprocess is the right tool.
 
 from __future__ import annotations
 
+import base64
+import json
+import os
 import re
 import subprocess
 from pathlib import Path
@@ -20,6 +23,10 @@ from finelog.deploy.bootstrap import render_template
 from finelog.deploy.config import FinelogConfig
 
 _TEMPLATE_VAR_RE = re.compile(r"\{\{ (\w+) \}\}")
+
+# Suffix for the finelog-owned Secret that carries S3 credentials into the pod.
+# Distinct from iris's own task-env Secret so finelog manages its own lifecycle.
+_S3_SECRET_SUFFIX = "-env"
 
 # Manifests live at `lib/finelog/deploy/k8s/*.yaml` in the repo. We resolve
 # this once at import time; the directory is part of the source tree, not
@@ -56,6 +63,57 @@ def _render_manifest(template_path: Path, cfg: FinelogConfig) -> str:
     return render_template(template, **{k: v for k, v in all_vars.items() if k in referenced})
 
 
+def _s3_secret_name(cfg: FinelogConfig) -> str:
+    return f"{cfg.name}{_S3_SECRET_SUFFIX}"
+
+
+def _build_s3_secret_manifest(cfg: FinelogConfig) -> str | None:
+    """Build the S3-credentials Secret manifest, or ``None`` when none is needed.
+
+    A Secret is minted only for an ``s3://`` archive: it carries the operator's
+    R2 credentials (from ``R2_ACCESS_KEY_ID`` / ``R2_SECRET_ACCESS_KEY`` in the
+    deploy shell) plus the configured endpoint and ``region=auto``, mapped to the
+    ``AWS_*`` names ``AmazonS3Builder::from_env`` reads in the server. ``gs://``
+    and local archives need no Secret (GCS uses workload identity).
+
+    Raises if an ``s3://`` archive is configured without an endpoint or creds —
+    deploying then would silently start a server that cannot reach its archive.
+    """
+    assert cfg.deployment.k8s is not None
+    if not cfg.remote_log_dir.startswith("s3://"):
+        return None
+    k8s = cfg.deployment.k8s
+    if not k8s.object_storage_endpoint:
+        raise click.ClickException(
+            f"finelog config {cfg.name!r}: remote_log_dir is s3:// but "
+            "deployment.k8s.object_storage_endpoint is unset"
+        )
+    key_id = os.environ.get("R2_ACCESS_KEY_ID")
+    key_secret = os.environ.get("R2_SECRET_ACCESS_KEY")
+    if not key_id or not key_secret:
+        raise click.ClickException(
+            "R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY must be set in the deploy "
+            f"environment to deploy {cfg.name!r} with an s3:// archive"
+        )
+    env = {
+        "AWS_ACCESS_KEY_ID": key_id,
+        "AWS_SECRET_ACCESS_KEY": key_secret,
+        "AWS_ENDPOINT_URL": k8s.object_storage_endpoint,
+        # Non-AWS S3 endpoints (R2, CoreWeave) reject a real region in the v4
+        # signature; "auto" skips region validation.
+        "AWS_REGION": "auto",
+        "AWS_DEFAULT_REGION": "auto",
+    }
+    manifest = {
+        "apiVersion": "v1",
+        "kind": "Secret",
+        "metadata": {"name": _s3_secret_name(cfg), "namespace": k8s.namespace},
+        "type": "Opaque",
+        "data": {k: base64.b64encode(v.encode()).decode() for k, v in env.items()},
+    }
+    return json.dumps(manifest)
+
+
 def _kubectl(*args: str, stdin: str | None = None, check: bool = True) -> subprocess.CompletedProcess:
     return subprocess.run(["kubectl", *args], input=stdin, text=True, check=check)
 
@@ -68,6 +126,10 @@ def k8s_up(cfg: FinelogConfig) -> None:
     """Render manifests and apply them; wait for the deployment to roll out."""
     assert cfg.deployment.k8s is not None
     k8s = cfg.deployment.k8s
+    secret_manifest = _build_s3_secret_manifest(cfg)
+    if secret_manifest is not None:
+        click.echo(f"Applying Secret {_s3_secret_name(cfg)} (S3 credentials)...")
+        _kubectl_apply(secret_manifest)
     for manifest_name in _MANIFESTS:
         rendered = _render_manifest(_K8S_MANIFEST_DIR / manifest_name, cfg)
         click.echo(f"Applying {manifest_name}...")

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -56,6 +56,11 @@ class K8sDeployment:
     namespace: str
     storage_class: str | None = None
     storage_gb: int = 200
+    # S3-compatible endpoint (e.g. Cloudflare R2) for an `s3://` remote_log_dir.
+    # Required there: `finelog deploy up` mints a Secret holding this endpoint
+    # plus the operator's R2 creds, projected into the pod via envFrom so the
+    # server can authenticate. Unused for `gs://` (GCS uses workload identity).
+    object_storage_endpoint: str | None = None
 
 
 @dataclass(frozen=True)
@@ -115,6 +120,7 @@ def _build_k8s(raw: dict) -> K8sDeployment:
         namespace=raw["namespace"],
         storage_class=raw.get("storage_class"),
         storage_gb=int(raw.get("storage_gb", 200)),
+        object_storage_endpoint=raw.get("object_storage_endpoint"),
     )
 
 

--- a/lib/finelog/tests/test_deploy_k8s.py
+++ b/lib/finelog/tests/test_deploy_k8s.py
@@ -5,9 +5,34 @@
 
 from __future__ import annotations
 
+import base64
+import json
+
+import click
 import pytest
-from finelog.deploy._k8s import _K8S_MANIFEST_DIR, _MANIFESTS, _render_manifest
+from finelog.deploy._k8s import (
+    _K8S_MANIFEST_DIR,
+    _MANIFESTS,
+    _build_s3_secret_manifest,
+    _render_manifest,
+    _s3_secret_name,
+)
 from finelog.deploy.config import Deployment, FinelogConfig, K8sDeployment
+
+
+def _s3_cfg(**k8s_overrides) -> FinelogConfig:
+    k8s = {
+        "namespace": "iris",
+        "object_storage_endpoint": "https://acct.r2.cloudflarestorage.com",
+    }
+    k8s.update(k8s_overrides)
+    return FinelogConfig(
+        name="finelog-cw",
+        port=10001,
+        image="img",
+        remote_log_dir="s3://bucket/finelog/cw",
+        deployment=Deployment(gcp=None, k8s=K8sDeployment(**k8s)),
+    )
 
 
 @pytest.fixture
@@ -70,6 +95,59 @@ def test_render_pvc_omits_storage_class_when_unset() -> None:
     rendered = _render_manifest(_K8S_MANIFEST_DIR / "01-pvc.yaml.tmpl", cfg)
     assert "storageClassName" in rendered  # appears in the comment fallback
     assert "<cluster default>" in rendered
+
+
+def test_s3_secret_minted_from_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "AKID")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "SEKRIT")
+    cfg = _s3_cfg()
+    manifest = json.loads(_build_s3_secret_manifest(cfg))
+    data = {k: base64.b64decode(v).decode() for k, v in manifest["data"].items()}
+    # The R2->AWS name mapping + injected region are the actual logic the Rust
+    # server's from_env() depends on; the rest of the manifest is boilerplate.
+    assert data == {
+        "AWS_ACCESS_KEY_ID": "AKID",
+        "AWS_SECRET_ACCESS_KEY": "SEKRIT",
+        "AWS_ENDPOINT_URL": "https://acct.r2.cloudflarestorage.com",
+        "AWS_REGION": "auto",
+        "AWS_DEFAULT_REGION": "auto",
+    }
+
+
+def test_no_secret_for_non_s3_archive(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "AKID")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "SEKRIT")
+    cfg = FinelogConfig(
+        name="finelog",
+        port=10001,
+        image="img",
+        remote_log_dir="gs://bucket/logs",
+        deployment=Deployment(gcp=None, k8s=K8sDeployment(namespace="iris")),
+    )
+    assert _build_s3_secret_manifest(cfg) is None
+
+
+def test_s3_secret_requires_endpoint(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("R2_ACCESS_KEY_ID", "AKID")
+    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "SEKRIT")
+    with pytest.raises(click.ClickException, match="object_storage_endpoint"):
+        _build_s3_secret_manifest(_s3_cfg(object_storage_endpoint=None))
+
+
+def test_s3_secret_requires_credentials(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("R2_ACCESS_KEY_ID", raising=False)
+    monkeypatch.delenv("R2_SECRET_ACCESS_KEY", raising=False)
+    with pytest.raises(click.ClickException, match="R2_ACCESS_KEY_ID"):
+        _build_s3_secret_manifest(_s3_cfg())
+
+
+def test_deployment_envfrom_matches_minted_secret_name() -> None:
+    # The template's envFrom secret name is a hardcoded `{{ name }}-env` literal,
+    # independent of the `_s3_secret_name` helper that names the minted Secret —
+    # this guards the two from drifting (a mismatch silently breaks auth).
+    cfg = _s3_cfg()
+    rendered = _render_manifest(_K8S_MANIFEST_DIR / "02-deployment.yaml.tmpl", cfg)
+    assert f"name: {_s3_secret_name(cfg)}" in rendered
 
 
 def test_manifest_dir_exists() -> None:

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -21,6 +21,12 @@
 #        uv run iris --cluster=cw-us-east-02a cluster start
 #        uv run iris --cluster=cw-us-east-02a cluster status
 
+# External finelog log server (in-cluster k8s Deployment, namespace `iris`).
+# Resolves to k8s://finelog-cw-use02a.iris; see lib/finelog/config/cw-us-east-02a.yaml.
+# Without this the controller falls back to an in-process MemStore (logs lost on
+# restart). Deploy the server first: `uv run finelog deploy up cw-us-east-02a`.
+log_server_config: cw-us-east-02a
+
 platform:
   label_prefix: cw-use02a
   coreweave:


### PR DESCRIPTION
* finelog gains s3-compatible remote archive and a self-contained external k8s deployment, archiving to cloudflare r2 on the coreweave `cw-us-east-02a` cluster
* rust server: `build_remote_store` handles `s3://bucket/prefix` via `AmazonS3Builder::from_env`, mirroring the existing `gs://` branch
  * `from_env` reads creds, region, `AWS_ENDPOINT_URL`, and `AWS_VIRTUAL_HOSTED_STYLE_REQUEST`, so the deploy env owns the addressing-style decision (path-style for r2, virtual-hosted for coreweave object storage) and the server stays endpoint-agnostic
  * enables the `object_store` `aws` feature
* `finelog deploy up` mints its own `<name>-env` Secret from the operator's `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY` + `object_storage_endpoint`, projected into the pod via `envFrom` — no dependency on iris's `iris-task-env`/`iris-s3-credentials` [^1]
  * only minted for `s3://` archives; fails fast on missing endpoint/creds; left in place on `down` (idempotent re-apply); skipped for `gs://`/local where gcs uses workload identity
  * `K8sDeployment` gains `object_storage_endpoint`
* new `lib/finelog/config/cw-us-east-02a.yaml` — k8s deploy in namespace `iris`, archive to `s3://marin-na/finelog/cw-us-east-02a`, 250Gi cache pvc on `shared-vast`; resolves to endpoint `k8s://finelog-cw-use02a.iris`
* `lib/iris/config/cw-us-east-02a.yaml` — set `log_server_config: cw-us-east-02a`, replacing the in-process MemStore fallback [^2]
* verified live on `cw-us-east-02a`: writes ingest, query, and `fetch_logs` round-trip, and a forced `L0->L1` compaction uploaded `seg_L1_*.parquet` to r2

[^1]: the live `cw-us-east-02a` controller is an older build still using the `iris-s3-credentials` secret; minting finelog's own secret keeps the deploy independent of iris's (evolving) secret scheme
[^2]: committed but not yet live — the running controller predates `log_server_config` support, so finelog is deployed standalone for now and not yet wired into the controller
