### PR TITLE
[ci] write coreweave smoke-test data under ttl'd r2 temp prefix

### DIFF
--- a/.github/workflows/iris-smoke-coreweave.yaml
+++ b/.github/workflows/iris-smoke-coreweave.yaml
@@ -109,7 +109,7 @@ jobs:
           JAX_TRACEBACK_FILTERING: off
           # When set, the marin-on-iris test uploads fixtures and writes
           # intermediate data to S3 (R2) so remote Zephyr pods can access them.
-          MARIN_CI_S3_PREFIX: s3://marin-na/temp/ci
+          MARIN_CI_S3_PREFIX: s3://marin-na/tmp/ttl=3d/ci
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com
@@ -127,7 +127,7 @@ jobs:
           WANDB_MODE: disabled
           WANDB_API_KEY: ""
           JAX_TRACEBACK_FILTERING: off
-          MARIN_CI_S3_PREFIX: s3://marin-na/temp/ci
+          MARIN_CI_S3_PREFIX: s3://marin-na/tmp/ttl=3d/ci
           AWS_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
           AWS_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           AWS_ENDPOINT_URL: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com

--- a/scripts/iris/run_smoke_cw.sh
+++ b/scripts/iris/run_smoke_cw.sh
@@ -55,7 +55,7 @@ if [ -n "${R2_ACCESS_KEY_ID:-}" ] && [ -n "${R2_SECRET_ACCESS_KEY:-}" ]; then
     export AWS_SECRET_ACCESS_KEY="$R2_SECRET_ACCESS_KEY"
     export AWS_ENDPOINT_URL="https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com"
     export FSSPEC_S3="{\"endpoint_url\": \"${AWS_ENDPOINT_URL}\"}"
-    export MARIN_CI_S3_PREFIX="s3://marin-na/temp/ci"
+    export MARIN_CI_S3_PREFIX="s3://marin-na/tmp/ttl=3d/ci"
 fi
 
 export WANDB_MODE=disabled


### PR DESCRIPTION
* point `MARIN_CI_S3_PREFIX` at the lifecycle-managed `s3://marin-na/tmp/ttl=3d/ci` instead of the unmanaged `s3://marin-na/temp/ci`
* the coreweave integration/smoke test is the only writer of that path — it uploads fixtures and child-job pipeline output under it
* the test already self-cleans via `_rm_s3` on exit, so the 3-day TTL is just a backstop for crashed or `--no-cleanup` runs[^1]
* lands under the `tmp/ttl=Nd/` R2 lifecycle rules installed by `infra/configure_buckets.py`, so orphaned data auto-deletes
* updated both env occurrences in `.github/workflows/iris-smoke-coreweave.yaml` and the local runner `scripts/iris/run_smoke_cw.sh`

[^1]: `3` is a valid `ALLOWED_TTL_DAYS` value — short, since this is disposable CI data, but long enough to inspect a failed run's artifacts
