### PR TITLE
[levanter] Support vocab-sharded fused CE loss

### DIFF
--- a/lib/levanter/src/levanter/grug/loss.py
+++ b/lib/levanter/src/levanter/grug/loss.py
@@ -7,14 +7,20 @@ This wraps the shared fused kernel API for TPU and falls back to a full-logits
 reference implementation on non-TPU backends.
 """
 
+from typing import cast
+
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding, PartitionSpec as P, get_abstract_mesh, get_mesh, reshard
 
 from haliax.jax_utils import named_call
 from levanter.kernels.pallas.fused_cross_entropy_loss import (
+    IMPLEMENTATIONS,
+    default_implementations,
     fused_cross_entropy_loss_and_logsumexp_penalty,
 )
+from levanter.kernels.pallas.fused_cross_entropy_loss.tuned_block_sizes import infer_block_sizes_with_tuned_match
+from levanter.kernels.pallas.fused_cross_entropy_loss.xla import linear_softmax_cross_entropy_loss_xla
 
 
 def _batch_axis_spec(x: jax.Array):
@@ -46,6 +52,21 @@ def _psum_over_axes(x: jax.Array, axis_names: tuple[str, ...]) -> jax.Array:
     return jax.lax.psum(x, axis_names)
 
 
+def _pmax_over_axes(x: jax.Array, axis_names: tuple[str, ...]) -> jax.Array:
+    if len(axis_names) == 0:
+        return x
+    if len(axis_names) == 1:
+        return jax.lax.pmax(x, axis_names[0])
+    return jax.lax.pmax(x, axis_names)
+
+
+def _logsumexp_over_axes(x: jax.Array, axis_names: tuple[str, ...]) -> jax.Array:
+    if len(axis_names) == 0:
+        return x
+    x_max = _pmax_over_axes(jax.lax.stop_gradient(x), axis_names)
+    return x_max + jnp.log(_psum_over_axes(jnp.exp(x - x_max), axis_names))
+
+
 def _current_mesh() -> Mesh | jax.sharding.AbstractMesh:
     try:
         mesh = get_mesh()
@@ -64,6 +85,107 @@ def _reshard_for_shard_map(
     if mesh is not None and not mesh.empty:
         return reshard(x, NamedSharding(mesh, spec))
     return x
+
+
+def _mesh_axis_size(mesh: Mesh | jax.sharding.AbstractMesh | None, axis_name: str) -> int:
+    if mesh is None or mesh.empty:
+        return 1
+    return int(mesh.shape.get(axis_name, 1))
+
+
+def _first_ce_implementation(implementation: str | tuple[str, ...] | None) -> str | None:
+    if implementation is None:
+        implementation = default_implementations()
+    if isinstance(implementation, str):
+        return implementation
+    if isinstance(implementation, tuple):
+        if len(implementation) == 0:
+            return None
+        return implementation[0]
+    return None
+
+
+def _uses_vocab_sharded_ce(implementation: str | tuple[str, ...] | None) -> bool:
+    return _first_ce_implementation(implementation) in ("xla", "pallas_gpu")
+
+
+def _local_linear_softmax_cross_entropy_loss(
+    flat_hidden: jax.Array,
+    safe_labels: jax.Array,
+    shard_lm_head: jax.Array,
+    *,
+    dtype: jnp.dtype,
+    precision: jax.lax.PrecisionLike,
+    implementation: str | tuple[str, ...] | None,
+) -> tuple[jax.Array, jax.Array]:
+    impl = _first_ce_implementation(implementation)
+    if impl == "pallas_gpu":
+        pallas_gpu_impl = IMPLEMENTATIONS.get("pallas_gpu")
+        if pallas_gpu_impl is None:
+            raise ValueError("pallas_gpu fused cross-entropy is not available")
+        block_sizes, _ = infer_block_sizes_with_tuned_match(
+            flat_hidden.shape[0],
+            flat_hidden.shape[1],
+            shard_lm_head.shape[1],
+            dtype=dtype,
+            x_dtype=flat_hidden.dtype,
+            w_dtype=shard_lm_head.dtype,
+        )
+        pallas_result = pallas_gpu_impl(
+            flat_hidden,
+            safe_labels,
+            shard_lm_head,
+            block_sizes=block_sizes,
+            dtype=dtype,
+            logit_soft_cap=None,
+            precision=precision,
+        )
+        local_loss = pallas_result[0]
+        local_lse = pallas_result[1]
+        return local_loss, local_lse
+
+    if impl == "xla":
+        return cast(
+            tuple[jax.Array, jax.Array],
+            linear_softmax_cross_entropy_loss_xla(
+                flat_hidden,
+                safe_labels,
+                shard_lm_head,
+                dtype=dtype,
+                logit_soft_cap=None,
+                precision=precision,
+            ),
+        )
+
+    raise ValueError(f"Vocab-sharded fused CE requires xla or pallas_gpu, got {impl!r}")
+
+
+def _lm_head_spec_for_ce(
+    lm_head: jax.Array,
+    mesh: Mesh | jax.sharding.AbstractMesh | None,
+    implementation: str | tuple[str, ...] | None,
+) -> P:
+    if _uses_vocab_sharded_ce(implementation) and lm_head.shape[1] % _mesh_axis_size(mesh, "model") == 0:
+        if _mesh_axis_size(mesh, "model") > 1:
+            return P(None, "model")
+    return P(None, None)
+
+
+def _lm_head_spec_for_xla_ce(
+    lm_head: jax.Array,
+    mesh: Mesh | jax.sharding.AbstractMesh | None,
+    implementation: str | tuple[str, ...] | None,
+) -> P:
+    return _lm_head_spec_for_ce(lm_head, mesh, implementation)
+
+
+def _vocab_axis_for_lm_head_spec(lm_head_spec: P) -> str | None:
+    if len(lm_head_spec) < 2:
+        return None
+    vocab_spec = lm_head_spec[1]
+    if isinstance(vocab_spec, str):
+        return vocab_spec
+    return None
 
 
 @named_call
@@ -115,6 +237,7 @@ def fused_linear_softmax_cross_entropy_loss(
     weight_array = weight if weight is not None else jnp.ones_like(labels, dtype=dtype)
     batch_axis_spec = _batch_axis_spec(hidden) if has_mesh else None
     batch_axis_names = _axis_names_from_spec(batch_axis_spec) if has_mesh else ()
+    lm_head_spec = P(None, None)
 
     def _loss_shard(
         shard_hidden: jax.Array,
@@ -126,18 +249,42 @@ def fused_linear_softmax_cross_entropy_loss(
         flat_labels = shard_labels.reshape((-1,)).astype(jnp.int32)
         flat_weight = shard_weight.reshape((-1,))
 
-        loss = fused_cross_entropy_loss_and_logsumexp_penalty(
-            flat_hidden,
-            flat_labels,
-            shard_lm_head,
-            reduction=None,
-            weight=flat_weight,
-            logsumexp_weight=logsumexp_weight,
-            dtype=dtype,
-            logit_soft_cap=None,
-            precision=precision,
-            implementation=implementation,
-        )
+        vocab_axis = _vocab_axis_for_lm_head_spec(lm_head_spec)
+        if vocab_axis is None:
+            loss = fused_cross_entropy_loss_and_logsumexp_penalty(
+                flat_hidden,
+                flat_labels,
+                shard_lm_head,
+                reduction=None,
+                weight=flat_weight,
+                logsumexp_weight=logsumexp_weight,
+                dtype=dtype,
+                logit_soft_cap=None,
+                precision=precision,
+                implementation=implementation,
+            )
+        else:
+            local_vocab_size = shard_lm_head.shape[1]
+            vocab_start = jax.lax.axis_index(vocab_axis) * local_vocab_size
+            local_labels = flat_labels - vocab_start
+            in_vocab_shard = (0 <= local_labels) & (local_labels < local_vocab_size)
+            safe_labels = jnp.clip(local_labels, 0, local_vocab_size - 1)
+            local_loss, local_lse = _local_linear_softmax_cross_entropy_loss(
+                flat_hidden,
+                safe_labels,
+                shard_lm_head,
+                dtype=dtype,
+                precision=precision,
+                implementation=implementation,
+            )
+            local_label_logit = local_lse - local_loss
+            vocab_axis_names = (vocab_axis,)
+            global_lse = _logsumexp_over_axes(local_lse, vocab_axis_names)
+            global_label_logit = _psum_over_axes(jnp.where(in_vocab_shard, local_label_logit, 0.0), vocab_axis_names)
+            loss = global_lse - global_label_logit
+            if logsumexp_weight is not None and logsumexp_weight != 0.0:
+                loss = loss + logsumexp_weight * (global_lse**2)
+            loss = loss * flat_weight.astype(loss.dtype)
 
         if reduction_mode is None:
             return loss.reshape(shard_labels.shape)
@@ -154,7 +301,7 @@ def fused_linear_softmax_cross_entropy_loss(
         return _loss_shard(hidden, lm_head, labels, weight_array)
 
     hidden_spec = P(batch_axis_spec)
-    lm_head_spec = P(None, None)
+    lm_head_spec = _lm_head_spec_for_xla_ce(lm_head, mesh, implementation)
     label_spec = P(batch_axis_spec)
     hidden = _reshard_for_shard_map(hidden, mesh, hidden_spec)
     lm_head = _reshard_for_shard_map(lm_head, mesh, lm_head_spec)

--- a/lib/levanter/src/levanter/grug/loss.py
+++ b/lib/levanter/src/levanter/grug/loss.py
@@ -14,6 +14,7 @@ import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding, PartitionSpec as P, get_abstract_mesh, get_mesh, reshard
 
 from haliax.jax_utils import named_call
+from levanter.grug.sharding import _mesh_axis_size
 from levanter.kernels.pallas.fused_cross_entropy_loss import (
     IMPLEMENTATIONS,
     fused_cross_entropy_loss_and_logsumexp_penalty,
@@ -87,26 +88,18 @@ def _reshard_for_shard_map(
     return x
 
 
-def _mesh_axis_size(mesh: Mesh | jax.sharding.AbstractMesh | None, axis_name: str) -> int:
-    if mesh is None or mesh.empty:
-        return 1
-    return int(mesh.shape.get(axis_name, 1))
-
-
-def _first_ce_implementation(implementation: str | tuple[str, ...] | None) -> str | None:
+def _ce_implementation_order(implementation: str | tuple[str, ...] | None) -> tuple[str, ...]:
     if implementation is None:
         implementation = default_implementations()
     if isinstance(implementation, str):
-        return implementation
+        return (implementation,)
     if isinstance(implementation, tuple):
-        if len(implementation) == 0:
-            return None
-        return implementation[0]
-    return None
+        return implementation
+    return ()
 
 
 def _uses_vocab_sharded_ce(implementation: str | tuple[str, ...] | None) -> bool:
-    return _first_ce_implementation(implementation) in ("xla", "pallas_gpu")
+    return any(impl in ("xla", "pallas_gpu") for impl in _ce_implementation_order(implementation))
 
 
 def _local_linear_softmax_cross_entropy_loss(
@@ -118,46 +111,56 @@ def _local_linear_softmax_cross_entropy_loss(
     precision: jax.lax.PrecisionLike,
     implementation: str | tuple[str, ...] | None,
 ) -> tuple[jax.Array, jax.Array]:
-    impl = _first_ce_implementation(implementation)
-    if impl == "pallas_gpu":
-        pallas_gpu_impl = IMPLEMENTATIONS.get("pallas_gpu")
-        if pallas_gpu_impl is None:
-            raise ValueError("pallas_gpu fused cross-entropy is not available")
-        block_sizes, _ = infer_block_sizes_with_tuned_match(
-            flat_hidden.shape[0],
-            flat_hidden.shape[1],
-            shard_lm_head.shape[1],
-            dtype=dtype,
-            x_dtype=flat_hidden.dtype,
-            w_dtype=shard_lm_head.dtype,
-        )
-        pallas_result = pallas_gpu_impl(
-            flat_hidden,
-            safe_labels,
-            shard_lm_head,
-            block_sizes=block_sizes,
-            dtype=dtype,
-            logit_soft_cap=None,
-            precision=precision,
-        )
-        local_loss = pallas_result[0]
-        local_lse = pallas_result[1]
-        return local_loss, local_lse
-
-    if impl == "xla":
-        return cast(
-            tuple[jax.Array, jax.Array],
-            linear_softmax_cross_entropy_loss_xla(
-                flat_hidden,
-                safe_labels,
-                shard_lm_head,
+    errors: list[Exception] = []
+    for impl in _ce_implementation_order(implementation):
+        if impl == "pallas_gpu":
+            pallas_gpu_impl = IMPLEMENTATIONS.get("pallas_gpu")
+            if pallas_gpu_impl is None:
+                errors.append(ValueError("pallas_gpu fused cross-entropy is not available"))
+                continue
+            block_sizes, _ = infer_block_sizes_with_tuned_match(
+                flat_hidden.shape[0],
+                flat_hidden.shape[1],
+                shard_lm_head.shape[1],
                 dtype=dtype,
-                logit_soft_cap=None,
-                precision=precision,
-            ),
-        )
+                x_dtype=flat_hidden.dtype,
+                w_dtype=shard_lm_head.dtype,
+            )
+            try:
+                pallas_result = pallas_gpu_impl(
+                    flat_hidden,
+                    safe_labels,
+                    shard_lm_head,
+                    block_sizes=block_sizes,
+                    dtype=dtype,
+                    logit_soft_cap=None,
+                    precision=precision,
+                )
+            except Exception as exc:
+                errors.append(exc)
+                continue
+            local_loss = pallas_result[0]
+            local_lse = pallas_result[1]
+            return local_loss, local_lse
 
-    raise ValueError(f"Vocab-sharded fused CE requires xla or pallas_gpu, got {impl!r}")
+        if impl == "xla":
+            return cast(
+                tuple[jax.Array, jax.Array],
+                linear_softmax_cross_entropy_loss_xla(
+                    flat_hidden,
+                    safe_labels,
+                    shard_lm_head,
+                    dtype=dtype,
+                    logit_soft_cap=None,
+                    precision=precision,
+                ),
+            )
+
+    if errors:
+        raise ValueError("No vocab-sharded fused CE implementation succeeded") from errors[-1]
+    raise ValueError(
+        "Vocab-sharded fused CE requires xla or pallas_gpu, " f"got {_ce_implementation_order(implementation)!r}"
+    )
 
 
 def _lm_head_spec_for_ce(

--- a/lib/levanter/src/levanter/grug/loss.py
+++ b/lib/levanter/src/levanter/grug/loss.py
@@ -8,6 +8,7 @@ reference implementation on non-TPU backends.
 """
 
 from typing import cast
+import warnings
 
 import jax
 import jax.numpy as jnp
@@ -111,7 +112,8 @@ def _local_linear_softmax_cross_entropy_loss(
     precision: jax.lax.PrecisionLike,
     implementation: str | tuple[str, ...] | None,
 ) -> tuple[jax.Array, jax.Array]:
-    for impl in _ce_implementation_order(implementation):
+    implementation_order = _ce_implementation_order(implementation)
+    for index, impl in enumerate(implementation_order):
         if impl == "pallas_gpu":
             pallas_gpu_impl = IMPLEMENTATIONS.get("pallas_gpu")
             if pallas_gpu_impl is None:
@@ -124,15 +126,25 @@ def _local_linear_softmax_cross_entropy_loss(
                 x_dtype=flat_hidden.dtype,
                 w_dtype=shard_lm_head.dtype,
             )
-            pallas_result = pallas_gpu_impl(
-                flat_hidden,
-                safe_labels,
-                shard_lm_head,
-                block_sizes=block_sizes,
-                dtype=dtype,
-                logit_soft_cap=None,
-                precision=precision,
-            )
+            try:
+                pallas_result = pallas_gpu_impl(
+                    flat_hidden,
+                    safe_labels,
+                    shard_lm_head,
+                    block_sizes=block_sizes,
+                    dtype=dtype,
+                    logit_soft_cap=None,
+                    precision=precision,
+                )
+            except Exception as exc:
+                if "xla" not in implementation_order[index + 1 :]:
+                    raise
+                warnings.warn(
+                    "pallas_gpu vocab-sharded fused CE failed; falling back to xla. " f"Error: {exc}",
+                    RuntimeWarning,
+                    stacklevel=2,
+                )
+                continue
             local_loss = pallas_result[0]
             local_lse = pallas_result[1]
             return local_loss, local_lse

--- a/lib/levanter/src/levanter/grug/loss.py
+++ b/lib/levanter/src/levanter/grug/loss.py
@@ -7,22 +7,14 @@ This wraps the shared fused kernel API for TPU and falls back to a full-logits
 reference implementation on non-TPU backends.
 """
 
-from typing import cast
-import warnings
-
 import jax
 import jax.numpy as jnp
 from jax.sharding import Mesh, NamedSharding, PartitionSpec as P, get_abstract_mesh, get_mesh, reshard
 
 from haliax.jax_utils import named_call
 from levanter.grug.sharding import _mesh_axis_size
-from levanter.kernels.pallas.fused_cross_entropy_loss import (
-    IMPLEMENTATIONS,
-    fused_cross_entropy_loss_and_logsumexp_penalty,
-)
+from levanter.kernels.pallas.fused_cross_entropy_loss import fused_cross_entropy_loss_and_logsumexp_penalty
 from levanter.kernels.pallas.fused_cross_entropy_loss.api import default_implementations
-from levanter.kernels.pallas.fused_cross_entropy_loss.tuned_block_sizes import infer_block_sizes_with_tuned_match
-from levanter.kernels.pallas.fused_cross_entropy_loss.xla import linear_softmax_cross_entropy_loss_xla
 
 
 def _batch_axis_spec(x: jax.Array):
@@ -36,37 +28,6 @@ def _batch_axis_spec(x: jax.Array):
     if spec is not None and len(spec) > 0 and spec[0] is not None:
         return spec[0]
     return ("data",)
-
-
-def _axis_names_from_spec(axis_spec) -> tuple[str, ...]:
-    if axis_spec is None:
-        return ()
-    if isinstance(axis_spec, tuple):
-        return tuple(str(name) for name in axis_spec)
-    return (str(axis_spec),)
-
-
-def _psum_over_axes(x: jax.Array, axis_names: tuple[str, ...]) -> jax.Array:
-    if len(axis_names) == 0:
-        return x
-    if len(axis_names) == 1:
-        return jax.lax.psum(x, axis_names[0])
-    return jax.lax.psum(x, axis_names)
-
-
-def _pmax_over_axes(x: jax.Array, axis_names: tuple[str, ...]) -> jax.Array:
-    if len(axis_names) == 0:
-        return x
-    if len(axis_names) == 1:
-        return jax.lax.pmax(x, axis_names[0])
-    return jax.lax.pmax(x, axis_names)
-
-
-def _logsumexp_over_axes(x: jax.Array, axis_names: tuple[str, ...]) -> jax.Array:
-    if len(axis_names) == 0:
-        return x
-    x_max = _pmax_over_axes(jax.lax.stop_gradient(x), axis_names)
-    return x_max + jnp.log(_psum_over_axes(jnp.exp(x - x_max), axis_names))
 
 
 def _current_mesh() -> Mesh | jax.sharding.AbstractMesh:
@@ -103,67 +64,6 @@ def _uses_vocab_sharded_ce(implementation_order: tuple[str, ...]) -> bool:
     return any(impl in ("xla", "pallas_gpu") for impl in implementation_order)
 
 
-def _local_linear_softmax_cross_entropy_loss(
-    flat_hidden: jax.Array,
-    safe_labels: jax.Array,
-    shard_lm_head: jax.Array,
-    *,
-    dtype: jnp.dtype,
-    precision: jax.lax.PrecisionLike,
-    implementation_order: tuple[str, ...],
-) -> tuple[jax.Array, jax.Array]:
-    for index, impl in enumerate(implementation_order):
-        if impl == "pallas_gpu":
-            pallas_gpu_impl = IMPLEMENTATIONS.get("pallas_gpu")
-            if pallas_gpu_impl is None:
-                continue
-            block_sizes, _ = infer_block_sizes_with_tuned_match(
-                flat_hidden.shape[0],
-                flat_hidden.shape[1],
-                shard_lm_head.shape[1],
-                dtype=dtype,
-                x_dtype=flat_hidden.dtype,
-                w_dtype=shard_lm_head.dtype,
-            )
-            try:
-                pallas_result = pallas_gpu_impl(
-                    flat_hidden,
-                    safe_labels,
-                    shard_lm_head,
-                    block_sizes=block_sizes,
-                    dtype=dtype,
-                    logit_soft_cap=None,
-                    precision=precision,
-                )
-            except Exception as exc:
-                if "xla" not in implementation_order[index + 1 :]:
-                    raise
-                warnings.warn(
-                    "pallas_gpu vocab-sharded fused CE failed; falling back to xla. " f"Error: {exc}",
-                    RuntimeWarning,
-                    stacklevel=2,
-                )
-                continue
-            local_loss = pallas_result[0]
-            local_lse = pallas_result[1]
-            return local_loss, local_lse
-
-        if impl == "xla":
-            return cast(
-                tuple[jax.Array, jax.Array],
-                linear_softmax_cross_entropy_loss_xla(
-                    flat_hidden,
-                    safe_labels,
-                    shard_lm_head,
-                    dtype=dtype,
-                    logit_soft_cap=None,
-                    precision=precision,
-                ),
-            )
-
-    raise ValueError("Vocab-sharded fused CE requires xla or pallas_gpu, " f"got {implementation_order!r}")
-
-
 def _lm_head_spec_for_ce(
     lm_head: jax.Array,
     mesh: Mesh | jax.sharding.AbstractMesh | None,
@@ -173,15 +73,6 @@ def _lm_head_spec_for_ce(
         if _mesh_axis_size(mesh, "model") > 1:
             return P(None, "model")
     return P(None, None)
-
-
-def _vocab_axis_for_lm_head_spec(lm_head_spec: P) -> str | None:
-    if len(lm_head_spec) < 2:
-        return None
-    vocab_spec = lm_head_spec[1]
-    if isinstance(vocab_spec, str):
-        return vocab_spec
-    return None
 
 
 @named_call
@@ -233,86 +124,35 @@ def fused_linear_softmax_cross_entropy_loss(
     has_mesh = mesh is not None and not mesh.empty
     weight_array = weight if weight is not None else jnp.ones_like(labels, dtype=dtype)
     batch_axis_spec = _batch_axis_spec(hidden) if has_mesh else None
-    batch_axis_names = _axis_names_from_spec(batch_axis_spec) if has_mesh else ()
-    lm_head_spec = P(None, None)
 
-    def _loss_shard(
-        shard_hidden: jax.Array,
-        shard_lm_head: jax.Array,
-        shard_labels: jax.Array,
-        shard_weight: jax.Array,
-    ) -> jax.Array:
-        flat_hidden = shard_hidden.reshape((-1, hidden_dim))
-        flat_labels = shard_labels.reshape((-1,)).astype(jnp.int32)
-        flat_weight = shard_weight.reshape((-1,))
+    flat_hidden = hidden.reshape((-1, hidden_dim))
+    flat_labels = labels.reshape((-1,)).astype(jnp.int32)
+    flat_weight = weight_array.reshape((-1,))
 
-        vocab_axis = _vocab_axis_for_lm_head_spec(lm_head_spec)
-        if vocab_axis is None:
-            loss = fused_cross_entropy_loss_and_logsumexp_penalty(
-                flat_hidden,
-                flat_labels,
-                shard_lm_head,
-                reduction=None,
-                weight=flat_weight,
-                logsumexp_weight=logsumexp_weight,
-                dtype=dtype,
-                logit_soft_cap=None,
-                precision=precision,
-                implementation=implementation,
-            )
-        else:
-            local_vocab_size = shard_lm_head.shape[1]
-            vocab_start = jax.lax.axis_index(vocab_axis) * local_vocab_size
-            local_labels = flat_labels - vocab_start
-            in_vocab_shard = (0 <= local_labels) & (local_labels < local_vocab_size)
-            safe_labels = jnp.clip(local_labels, 0, local_vocab_size - 1)
-            local_loss, local_lse = _local_linear_softmax_cross_entropy_loss(
-                flat_hidden,
-                safe_labels,
-                shard_lm_head,
-                dtype=dtype,
-                precision=precision,
-                implementation_order=implementation_order,
-            )
-            local_label_logit = local_lse - local_loss
-            vocab_axis_names = (vocab_axis,)
-            global_lse = _logsumexp_over_axes(local_lse, vocab_axis_names)
-            global_label_logit = _psum_over_axes(jnp.where(in_vocab_shard, local_label_logit, 0.0), vocab_axis_names)
-            loss = global_lse - global_label_logit
-            if logsumexp_weight is not None and logsumexp_weight != 0.0:
-                loss = loss + logsumexp_weight * (global_lse**2)
-            loss = loss * flat_weight.astype(loss.dtype)
+    if has_mesh:
+        hidden_spec = P(batch_axis_spec, None)
+        lm_head_spec = _lm_head_spec_for_ce(lm_head, mesh, implementation_order)
+        label_spec = P(batch_axis_spec)
+        flat_hidden = _reshard_for_shard_map(flat_hidden, mesh, hidden_spec)
+        lm_head = _reshard_for_shard_map(lm_head, mesh, lm_head_spec)
+        flat_labels = _reshard_for_shard_map(flat_labels, mesh, label_spec)
+        flat_weight = _reshard_for_shard_map(flat_weight, mesh, label_spec)
 
-        if reduction_mode is None:
-            return loss.reshape(shard_labels.shape)
-
-        local_sum = jnp.sum(loss)
-        local_denom = jnp.sum(flat_weight)
-        total_sum = _psum_over_axes(local_sum, batch_axis_names)
-        if reduction_mode == "sum":
-            return total_sum
-        total_denom = _psum_over_axes(local_denom, batch_axis_names)
-        return jnp.where(total_denom != 0, total_sum / total_denom, jnp.zeros_like(total_denom))
-
-    if not has_mesh:
-        return _loss_shard(hidden, lm_head, labels, weight_array)
-
-    hidden_spec = P(batch_axis_spec)
-    lm_head_spec = _lm_head_spec_for_ce(lm_head, mesh, implementation_order)
-    label_spec = P(batch_axis_spec)
-    hidden = _reshard_for_shard_map(hidden, mesh, hidden_spec)
-    lm_head = _reshard_for_shard_map(lm_head, mesh, lm_head_spec)
-    labels = _reshard_for_shard_map(labels, mesh, label_spec)
-    weight_array = _reshard_for_shard_map(weight_array, mesh, label_spec)
-
-    out_specs = hidden_spec if reduction_mode is None else P()
-    return jax.shard_map(
-        _loss_shard,
-        mesh=mesh,
-        in_specs=(hidden_spec, lm_head_spec, label_spec, label_spec),
-        out_specs=out_specs,
-        check_vma=False,
-    )(hidden, lm_head, labels, weight_array)
+    loss = fused_cross_entropy_loss_and_logsumexp_penalty(
+        flat_hidden,
+        flat_labels,
+        lm_head,
+        reduction=reduction_mode,
+        weight=flat_weight,
+        logsumexp_weight=logsumexp_weight,
+        dtype=dtype,
+        logit_soft_cap=None,
+        precision=precision,
+        implementation=implementation,
+    )
+    if reduction_mode is None:
+        return loss.reshape(labels.shape)
+    return loss
 
 
 __all__ = [

--- a/lib/levanter/src/levanter/grug/loss.py
+++ b/lib/levanter/src/levanter/grug/loss.py
@@ -16,9 +16,9 @@ from jax.sharding import Mesh, NamedSharding, PartitionSpec as P, get_abstract_m
 from haliax.jax_utils import named_call
 from levanter.kernels.pallas.fused_cross_entropy_loss import (
     IMPLEMENTATIONS,
-    default_implementations,
     fused_cross_entropy_loss_and_logsumexp_penalty,
 )
+from levanter.kernels.pallas.fused_cross_entropy_loss.api import default_implementations
 from levanter.kernels.pallas.fused_cross_entropy_loss.tuned_block_sizes import infer_block_sizes_with_tuned_match
 from levanter.kernels.pallas.fused_cross_entropy_loss.xla import linear_softmax_cross_entropy_loss_xla
 
@@ -171,14 +171,6 @@ def _lm_head_spec_for_ce(
     return P(None, None)
 
 
-def _lm_head_spec_for_xla_ce(
-    lm_head: jax.Array,
-    mesh: Mesh | jax.sharding.AbstractMesh | None,
-    implementation: str | tuple[str, ...] | None,
-) -> P:
-    return _lm_head_spec_for_ce(lm_head, mesh, implementation)
-
-
 def _vocab_axis_for_lm_head_spec(lm_head_spec: P) -> str | None:
     if len(lm_head_spec) < 2:
         return None
@@ -301,7 +293,7 @@ def fused_linear_softmax_cross_entropy_loss(
         return _loss_shard(hidden, lm_head, labels, weight_array)
 
     hidden_spec = P(batch_axis_spec)
-    lm_head_spec = _lm_head_spec_for_xla_ce(lm_head, mesh, implementation)
+    lm_head_spec = _lm_head_spec_for_ce(lm_head, mesh, implementation)
     label_spec = P(batch_axis_spec)
     hidden = _reshard_for_shard_map(hidden, mesh, hidden_spec)
     lm_head = _reshard_for_shard_map(lm_head, mesh, lm_head_spec)

--- a/lib/levanter/src/levanter/grug/loss.py
+++ b/lib/levanter/src/levanter/grug/loss.py
@@ -99,8 +99,8 @@ def _ce_implementation_order(implementation: str | tuple[str, ...] | None) -> tu
     return ()
 
 
-def _uses_vocab_sharded_ce(implementation: str | tuple[str, ...] | None) -> bool:
-    return any(impl in ("xla", "pallas_gpu") for impl in _ce_implementation_order(implementation))
+def _uses_vocab_sharded_ce(implementation_order: tuple[str, ...]) -> bool:
+    return any(impl in ("xla", "pallas_gpu") for impl in implementation_order)
 
 
 def _local_linear_softmax_cross_entropy_loss(
@@ -110,9 +110,8 @@ def _local_linear_softmax_cross_entropy_loss(
     *,
     dtype: jnp.dtype,
     precision: jax.lax.PrecisionLike,
-    implementation: str | tuple[str, ...] | None,
+    implementation_order: tuple[str, ...],
 ) -> tuple[jax.Array, jax.Array]:
-    implementation_order = _ce_implementation_order(implementation)
     for index, impl in enumerate(implementation_order):
         if impl == "pallas_gpu":
             pallas_gpu_impl = IMPLEMENTATIONS.get("pallas_gpu")
@@ -162,17 +161,15 @@ def _local_linear_softmax_cross_entropy_loss(
                 ),
             )
 
-    raise ValueError(
-        "Vocab-sharded fused CE requires xla or pallas_gpu, " f"got {_ce_implementation_order(implementation)!r}"
-    )
+    raise ValueError("Vocab-sharded fused CE requires xla or pallas_gpu, " f"got {implementation_order!r}")
 
 
 def _lm_head_spec_for_ce(
     lm_head: jax.Array,
     mesh: Mesh | jax.sharding.AbstractMesh | None,
-    implementation: str | tuple[str, ...] | None,
+    implementation_order: tuple[str, ...],
 ) -> P:
-    if _uses_vocab_sharded_ce(implementation) and lm_head.shape[1] % _mesh_axis_size(mesh, "model") == 0:
+    if _uses_vocab_sharded_ce(implementation_order) and lm_head.shape[1] % _mesh_axis_size(mesh, "model") == 0:
         if _mesh_axis_size(mesh, "model") > 1:
             return P(None, "model")
     return P(None, None)
@@ -230,6 +227,7 @@ def fused_linear_softmax_cross_entropy_loss(
         reduction_mode = reduction
     else:
         raise ValueError(f"Unknown reduction: {reduction}")
+    implementation_order = _ce_implementation_order(implementation)
 
     mesh = _current_mesh()
     has_mesh = mesh is not None and not mesh.empty
@@ -274,7 +272,7 @@ def fused_linear_softmax_cross_entropy_loss(
                 shard_lm_head,
                 dtype=dtype,
                 precision=precision,
-                implementation=implementation,
+                implementation_order=implementation_order,
             )
             local_label_logit = local_lse - local_loss
             vocab_axis_names = (vocab_axis,)
@@ -300,7 +298,7 @@ def fused_linear_softmax_cross_entropy_loss(
         return _loss_shard(hidden, lm_head, labels, weight_array)
 
     hidden_spec = P(batch_axis_spec)
-    lm_head_spec = _lm_head_spec_for_ce(lm_head, mesh, implementation)
+    lm_head_spec = _lm_head_spec_for_ce(lm_head, mesh, implementation_order)
     label_spec = P(batch_axis_spec)
     hidden = _reshard_for_shard_map(hidden, mesh, hidden_spec)
     lm_head = _reshard_for_shard_map(lm_head, mesh, lm_head_spec)

--- a/lib/levanter/src/levanter/grug/loss.py
+++ b/lib/levanter/src/levanter/grug/loss.py
@@ -111,12 +111,10 @@ def _local_linear_softmax_cross_entropy_loss(
     precision: jax.lax.PrecisionLike,
     implementation: str | tuple[str, ...] | None,
 ) -> tuple[jax.Array, jax.Array]:
-    errors: list[Exception] = []
     for impl in _ce_implementation_order(implementation):
         if impl == "pallas_gpu":
             pallas_gpu_impl = IMPLEMENTATIONS.get("pallas_gpu")
             if pallas_gpu_impl is None:
-                errors.append(ValueError("pallas_gpu fused cross-entropy is not available"))
                 continue
             block_sizes, _ = infer_block_sizes_with_tuned_match(
                 flat_hidden.shape[0],
@@ -126,19 +124,15 @@ def _local_linear_softmax_cross_entropy_loss(
                 x_dtype=flat_hidden.dtype,
                 w_dtype=shard_lm_head.dtype,
             )
-            try:
-                pallas_result = pallas_gpu_impl(
-                    flat_hidden,
-                    safe_labels,
-                    shard_lm_head,
-                    block_sizes=block_sizes,
-                    dtype=dtype,
-                    logit_soft_cap=None,
-                    precision=precision,
-                )
-            except Exception as exc:
-                errors.append(exc)
-                continue
+            pallas_result = pallas_gpu_impl(
+                flat_hidden,
+                safe_labels,
+                shard_lm_head,
+                block_sizes=block_sizes,
+                dtype=dtype,
+                logit_soft_cap=None,
+                precision=precision,
+            )
             local_loss = pallas_result[0]
             local_lse = pallas_result[1]
             return local_loss, local_lse
@@ -156,8 +150,6 @@ def _local_linear_softmax_cross_entropy_loss(
                 ),
             )
 
-    if errors:
-        raise ValueError("No vocab-sharded fused CE implementation succeeded") from errors[-1]
     raise ValueError(
         "Vocab-sharded fused CE requires xla or pallas_gpu, " f"got {_ce_implementation_order(implementation)!r}"
     )

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/__init__.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/__init__.py
@@ -5,6 +5,7 @@ from .api import (
     BlockSizes,
     IMPLEMENTATIONS,
     Implementation,
+    default_implementations,
     fused_cross_entropy_loss_and_logsumexp_penalty,
 )
 from .tuned_block_sizes import (
@@ -23,6 +24,7 @@ __all__ = [
     "SHAPE_BUCKETS",
     "ShapeBucket",
     "TUNED_BLOCK_SIZES",
+    "default_implementations",
     "fused_cross_entropy_loss_and_logsumexp_penalty",
     "infer_block_sizes",
 ]

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/__init__.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/__init__.py
@@ -5,7 +5,6 @@ from .api import (
     BlockSizes,
     IMPLEMENTATIONS,
     Implementation,
-    default_implementations,
     fused_cross_entropy_loss_and_logsumexp_penalty,
 )
 from .tuned_block_sizes import (
@@ -24,7 +23,6 @@ __all__ = [
     "SHAPE_BUCKETS",
     "ShapeBucket",
     "TUNED_BLOCK_SIZES",
-    "default_implementations",
     "fused_cross_entropy_loss_and_logsumexp_penalty",
     "infer_block_sizes",
 ]

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -510,82 +510,126 @@ def _apply_reduction(loss: jax.Array, reduction: Reduction, weight: Optional[jax
     raise ValueError(f"Unsupported reduction: {reduction}")
 
 
-@overload
-def fused_cross_entropy_loss_and_logsumexp_penalty(
+def _axis_names_from_spec(axis_spec) -> tuple[str, ...]:
+    if axis_spec is None:
+        return ()
+    if isinstance(axis_spec, tuple):
+        return tuple(str(name) for name in axis_spec)
+    return (str(axis_spec),)
+
+
+def _axis_names_from_partition_spec(spec: jax.sharding.PartitionSpec) -> tuple[str, ...]:
+    axis_names: list[str] = []
+    for axis_spec in spec:
+        axis_names.extend(_axis_names_from_spec(axis_spec))
+    return tuple(axis_names)
+
+
+def _psum_over_axes(x: jax.Array, axis_names: tuple[str, ...]) -> jax.Array:
+    if len(axis_names) == 0:
+        return x
+    if len(axis_names) == 1:
+        return jax.lax.psum(x, axis_names[0])
+    return jax.lax.psum(x, axis_names)
+
+
+def _pmax_over_axes(x: jax.Array, axis_names: tuple[str, ...]) -> jax.Array:
+    if len(axis_names) == 0:
+        return x
+    if len(axis_names) == 1:
+        return jax.lax.pmax(x, axis_names[0])
+    return jax.lax.pmax(x, axis_names)
+
+
+def _pmin_over_axes(x: jax.Array, axis_names: tuple[str, ...]) -> jax.Array:
+    if len(axis_names) == 0:
+        return x
+    if len(axis_names) == 1:
+        return jax.lax.pmin(x, axis_names[0])
+    return jax.lax.pmin(x, axis_names)
+
+
+def _axis_index(axis_names: tuple[str, ...]) -> jax.Array:
+    if len(axis_names) == 1:
+        return jax.lax.axis_index(axis_names[0])
+    return jax.lax.axis_index(axis_names)
+
+
+def _logsumexp_over_axes(x: jax.Array, axis_names: tuple[str, ...]) -> jax.Array:
+    if len(axis_names) == 0:
+        return x
+    x_max = _pmax_over_axes(jax.lax.stop_gradient(x), axis_names)
+    return x_max + jnp.log(_psum_over_axes(jnp.exp(x - x_max), axis_names))
+
+
+def _partition_spec_for_array(x: jax.Array) -> jax.sharding.PartitionSpec:
+    sharding = getattr(x, "sharding", None)
+    spec = getattr(sharding, "spec", None)
+    if spec is not None:
+        return spec
+    sharding = getattr(jax.typeof(x), "sharding", None)
+    spec = getattr(sharding, "spec", None)
+    if spec is not None:
+        return spec
+    return jax.sharding.PartitionSpec(*(None for _ in range(x.ndim)))
+
+
+def _vocab_axis_names_from_sharding(w: jax.Array) -> tuple[str, ...]:
+    spec = _partition_spec_for_array(w)
+    if len(spec) < 2:
+        return ()
+    return _axis_names_from_spec(spec[1])
+
+
+def _mesh_from_sharding(x: jax.Array) -> jax.sharding.Mesh | None:
+    sharding = getattr(x, "sharding", None)
+    mesh = getattr(sharding, "mesh", None)
+    if mesh is None or getattr(mesh, "empty", False):
+        sharding = getattr(jax.typeof(x), "sharding", None)
+        mesh = getattr(sharding, "mesh", None)
+    if mesh is None or getattr(mesh, "empty", False):
+        return None
+    return mesh
+
+
+def _apply_reduction_sharded(
+    loss: jax.Array,
+    reduction: Reduction,
+    weight: Optional[jax.Array],
+    reduction_axis_names: tuple[str, ...],
+) -> jax.Array:
+    if weight is not None:
+        weight = weight.astype(loss.dtype)
+        loss = loss * weight
+
+    if reduction is None:
+        return loss
+    if reduction == "sum":
+        return _psum_over_axes(jnp.sum(loss), reduction_axis_names)
+    if reduction == "mean":
+        total = _psum_over_axes(jnp.sum(loss), reduction_axis_names)
+        if weight is None:
+            count = jnp.asarray(loss.size, dtype=loss.dtype)
+            denom = _psum_over_axes(count, reduction_axis_names)
+        else:
+            denom = _psum_over_axes(jnp.sum(weight), reduction_axis_names)
+        return jnp.where(denom != 0, total / denom, jnp.zeros_like(denom))
+    raise ValueError(f"Unsupported reduction: {reduction}")
+
+
+def _call_fused_cross_entropy_impls(
     x: Float[Array, "B H"],
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
     *,
-    reduction: Reduction = "mean",
-    weight: Optional[Float[Array, "B"]] = None,
-    logsumexp_weight: Optional[float] = 0.0,
-    block_size: Optional[int] = None,
-    block_sizes: Optional[BlockSizes] = None,
-    dtype: Optional[jnp.dtype] = jnp.float32,
-    logit_soft_cap: Optional[float] = None,
-    precision: jax.lax.PrecisionLike = None,
-    implementation: Implementation | Sequence[Implementation | ArrayImpl] | None = None,
-    return_argmax: Literal[False] = False,
-) -> jax.Array: ...
-
-
-@overload
-def fused_cross_entropy_loss_and_logsumexp_penalty(
-    x: Float[Array, "B H"],
-    labels: Int[Array, "B"],
-    w: Float[Array, "H V"],
-    *,
-    reduction: Reduction = "mean",
-    weight: Optional[Float[Array, "B"]] = None,
-    logsumexp_weight: Optional[float] = 0.0,
-    block_size: Optional[int] = None,
-    block_sizes: Optional[BlockSizes] = None,
-    dtype: Optional[jnp.dtype] = jnp.float32,
-    logit_soft_cap: Optional[float] = None,
-    precision: jax.lax.PrecisionLike = None,
-    implementation: Implementation | Sequence[Implementation | ArrayImpl] | None = None,
-    return_argmax: Literal[True] = True,
-) -> tuple[jax.Array, jax.Array]: ...
-
-
-def fused_cross_entropy_loss_and_logsumexp_penalty(
-    x: Float[Array, "B H"],
-    labels: Int[Array, "B"],
-    w: Float[Array, "H V"],
-    *,
-    reduction: Reduction = "mean",
-    weight: Optional[Float[Array, "B"]] = None,
-    logsumexp_weight: Optional[float] = 0.0,
-    block_size: Optional[int] = None,
-    block_sizes: Optional[BlockSizes] = None,
-    dtype: Optional[jnp.dtype] = jnp.float32,
-    logit_soft_cap: Optional[float] = None,
-    precision: jax.lax.PrecisionLike = None,
-    implementation: Implementation | Sequence[Implementation | ArrayImpl] | None = None,
-    return_argmax: bool = False,
-) -> jax.Array | tuple[jax.Array, jax.Array]:
-    """Fused cross-entropy + logsumexp penalty on raw arrays.
-
-    Args:
-        x: [B, H] input activations.
-        labels: [B] integer labels.
-        w: [H, V] projection weights.
-        reduction: "sum", "mean", or None to return per-example loss.
-        weight: Optional per-example weights/mask, broadcastable to [B].
-        logsumexp_weight: Weight for the logsumexp (z-loss) penalty.
-        block_size: Optional convenience for setting block_sizes.v_block_size.
-        block_sizes: Block size configuration for the kernel.
-        dtype: Optional dtype for logits/softmax computations.
-        logit_soft_cap: Optional tanh soft cap for logits.
-        precision: Optional matmul precision override for XLA/reference paths.
-        implementation: Backend selector or override implementation list.
-        return_argmax: Whether to additionally return per-example argmax ids.
-
-    Returns:
-        If return_argmax=False: reduced loss (scalar) or per-example loss [B] if reduction is None.
-        If return_argmax=True: tuple of (loss, argmax_ids[B]).
-    """
-    _validate_inputs(x, labels, w)
+    block_size: Optional[int],
+    block_sizes: Optional[BlockSizes],
+    dtype: Optional[jnp.dtype],
+    logit_soft_cap: Optional[float],
+    precision: jax.lax.PrecisionLike,
+    implementation: Implementation | Sequence[Implementation | ArrayImpl] | None,
+    return_argmax: bool,
+) -> tuple[jax.Array, jax.Array, jax.Array | None]:
     explicit_block_sizes = block_size is not None or block_sizes is not None
     resolved_block_sizes = (
         _resolve_block_sizes(block_size, block_sizes, x=x, w=w, dtype=dtype) if explicit_block_sizes else None
@@ -734,7 +778,42 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
 
         if return_argmax and argmax is None:
             raise ValueError("Implementation does not support return_argmax=True")
+        return loss, lse, argmax
 
+    raise ExceptionGroup("all implementations failed", errors)
+
+
+def _fused_cross_entropy_loss_and_logsumexp_penalty_local(
+    x: Float[Array, "B H"],
+    labels: Int[Array, "B"],
+    w: Float[Array, "H V"],
+    *,
+    reduction: Reduction,
+    weight: Optional[Float[Array, "B"]],
+    logsumexp_weight: Optional[float],
+    block_size: Optional[int],
+    block_sizes: Optional[BlockSizes],
+    dtype: Optional[jnp.dtype],
+    logit_soft_cap: Optional[float],
+    precision: jax.lax.PrecisionLike,
+    implementation: Implementation | Sequence[Implementation | ArrayImpl] | None,
+    return_argmax: bool,
+    vocab_axis_names: tuple[str, ...] = (),
+    reduction_axis_names: tuple[str, ...] = (),
+) -> jax.Array | tuple[jax.Array, jax.Array]:
+    if len(vocab_axis_names) == 0:
+        loss, lse, argmax = _call_fused_cross_entropy_impls(
+            x,
+            labels,
+            w,
+            block_size=block_size,
+            block_sizes=block_sizes,
+            dtype=dtype,
+            logit_soft_cap=logit_soft_cap,
+            precision=precision,
+            implementation=implementation,
+            return_argmax=return_argmax,
+        )
         if logsumexp_weight is not None and logsumexp_weight != 0.0:
             loss = loss + logsumexp_weight * (lse**2)
         reduced_loss = _apply_reduction(loss, reduction, weight)
@@ -743,7 +822,224 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
             return reduced_loss, argmax
         return reduced_loss
 
-    raise ExceptionGroup("all implementations failed", errors)
+    local_vocab_size = w.shape[1]
+    vocab_start = _axis_index(vocab_axis_names) * local_vocab_size
+    local_labels = labels - vocab_start
+    in_vocab_shard = (0 <= local_labels) & (local_labels < local_vocab_size)
+    safe_labels = jnp.clip(local_labels, 0, local_vocab_size - 1)
+    local_loss, local_lse, local_argmax = _call_fused_cross_entropy_impls(
+        x,
+        safe_labels,
+        w,
+        block_size=block_size,
+        block_sizes=block_sizes,
+        dtype=dtype,
+        logit_soft_cap=logit_soft_cap,
+        precision=precision,
+        implementation=implementation,
+        return_argmax=return_argmax,
+    )
+    local_label_logit = local_lse - local_loss
+    global_lse = _logsumexp_over_axes(local_lse, vocab_axis_names)
+    global_label_logit = _psum_over_axes(jnp.where(in_vocab_shard, local_label_logit, 0.0), vocab_axis_names)
+    loss = global_lse - global_label_logit
+    if logsumexp_weight is not None and logsumexp_weight != 0.0:
+        loss = loss + logsumexp_weight * (global_lse**2)
+
+    reduced_loss = _apply_reduction_sharded(loss, reduction, weight, reduction_axis_names)
+    if not return_argmax:
+        return reduced_loss
+
+    assert local_argmax is not None
+    local_argmax_logit = jnp.einsum(
+        "bh,bh->b",
+        x,
+        jnp.swapaxes(w[:, local_argmax], 0, 1),
+        precision=precision,
+    )
+    global_argmax_logit = _pmax_over_axes(local_argmax_logit, vocab_axis_names)
+    global_argmax = _pmin_over_axes(
+        jnp.where(
+            local_argmax_logit == global_argmax_logit,
+            local_argmax + vocab_start,
+            jnp.iinfo(jnp.int32).max,
+        ),
+        vocab_axis_names,
+    ).astype(jnp.int32)
+    return reduced_loss, global_argmax
+
+
+@overload
+def fused_cross_entropy_loss_and_logsumexp_penalty(
+    x: Float[Array, "B H"],
+    labels: Int[Array, "B"],
+    w: Float[Array, "H V"],
+    *,
+    reduction: Reduction = "mean",
+    weight: Optional[Float[Array, "B"]] = None,
+    logsumexp_weight: Optional[float] = 0.0,
+    block_size: Optional[int] = None,
+    block_sizes: Optional[BlockSizes] = None,
+    dtype: Optional[jnp.dtype] = jnp.float32,
+    logit_soft_cap: Optional[float] = None,
+    precision: jax.lax.PrecisionLike = None,
+    implementation: Implementation | Sequence[Implementation | ArrayImpl] | None = None,
+    return_argmax: Literal[False] = False,
+) -> jax.Array: ...
+
+
+@overload
+def fused_cross_entropy_loss_and_logsumexp_penalty(
+    x: Float[Array, "B H"],
+    labels: Int[Array, "B"],
+    w: Float[Array, "H V"],
+    *,
+    reduction: Reduction = "mean",
+    weight: Optional[Float[Array, "B"]] = None,
+    logsumexp_weight: Optional[float] = 0.0,
+    block_size: Optional[int] = None,
+    block_sizes: Optional[BlockSizes] = None,
+    dtype: Optional[jnp.dtype] = jnp.float32,
+    logit_soft_cap: Optional[float] = None,
+    precision: jax.lax.PrecisionLike = None,
+    implementation: Implementation | Sequence[Implementation | ArrayImpl] | None = None,
+    return_argmax: Literal[True] = True,
+) -> tuple[jax.Array, jax.Array]: ...
+
+
+def fused_cross_entropy_loss_and_logsumexp_penalty(
+    x: Float[Array, "B H"],
+    labels: Int[Array, "B"],
+    w: Float[Array, "H V"],
+    *,
+    reduction: Reduction = "mean",
+    weight: Optional[Float[Array, "B"]] = None,
+    logsumexp_weight: Optional[float] = 0.0,
+    block_size: Optional[int] = None,
+    block_sizes: Optional[BlockSizes] = None,
+    dtype: Optional[jnp.dtype] = jnp.float32,
+    logit_soft_cap: Optional[float] = None,
+    precision: jax.lax.PrecisionLike = None,
+    implementation: Implementation | Sequence[Implementation | ArrayImpl] | None = None,
+    return_argmax: bool = False,
+) -> jax.Array | tuple[jax.Array, jax.Array]:
+    """Fused cross-entropy + logsumexp penalty on raw arrays.
+
+    Args:
+        x: [B, H] input activations.
+        labels: [B] integer labels.
+        w: [H, V] projection weights.
+        reduction: "sum", "mean", or None to return per-example loss.
+        weight: Optional per-example weights/mask, broadcastable to [B].
+        logsumexp_weight: Weight for the logsumexp (z-loss) penalty.
+        block_size: Optional convenience for setting block_sizes.v_block_size.
+        block_sizes: Block size configuration for the kernel.
+        dtype: Optional dtype for logits/softmax computations.
+        logit_soft_cap: Optional tanh soft cap for logits.
+        precision: Optional matmul precision override for XLA/reference paths.
+        implementation: Backend selector or override implementation list.
+        return_argmax: Whether to additionally return per-example argmax ids.
+
+    Returns:
+        If return_argmax=False: reduced loss (scalar) or per-example loss [B] if reduction is None.
+        If return_argmax=True: tuple of (loss, argmax_ids[B]).
+    """
+    _validate_inputs(x, labels, w)
+    vocab_axis_names = _vocab_axis_names_from_sharding(w)
+    mesh = _mesh_from_sharding(w)
+    if len(vocab_axis_names) == 0 or mesh is None:
+        return _fused_cross_entropy_loss_and_logsumexp_penalty_local(
+            x,
+            labels,
+            w,
+            reduction=reduction,
+            weight=weight,
+            logsumexp_weight=logsumexp_weight,
+            block_size=block_size,
+            block_sizes=block_sizes,
+            dtype=dtype,
+            logit_soft_cap=logit_soft_cap,
+            precision=precision,
+            implementation=implementation,
+            return_argmax=return_argmax,
+        )
+
+    x_spec = _partition_spec_for_array(x)
+    labels_spec = _partition_spec_for_array(labels)
+    w_spec = _partition_spec_for_array(w)
+    weight_spec = _partition_spec_for_array(weight) if weight is not None else None
+    reduction_axis_names = _axis_names_from_partition_spec(labels_spec)
+
+    if return_argmax:
+        out_specs = (
+            jax.sharding.PartitionSpec() if reduction is not None else labels_spec,
+            labels_spec,
+        )
+    else:
+        out_specs = jax.sharding.PartitionSpec() if reduction is not None else labels_spec
+
+    if weight is None:
+
+        def mapped(x_shard: jax.Array, labels_shard: jax.Array, w_shard: jax.Array):
+            return _fused_cross_entropy_loss_and_logsumexp_penalty_local(
+                x_shard,
+                labels_shard,
+                w_shard,
+                reduction=reduction,
+                weight=None,
+                logsumexp_weight=logsumexp_weight,
+                block_size=block_size,
+                block_sizes=block_sizes,
+                dtype=dtype,
+                logit_soft_cap=logit_soft_cap,
+                precision=precision,
+                implementation=implementation,
+                return_argmax=return_argmax,
+                vocab_axis_names=vocab_axis_names,
+                reduction_axis_names=reduction_axis_names,
+            )
+
+        return jax.shard_map(
+            mapped,
+            mesh=mesh,
+            in_specs=(x_spec, labels_spec, w_spec),
+            out_specs=out_specs,
+            check_vma=False,
+        )(x, labels, w)
+
+    assert weight_spec is not None
+
+    def mapped_with_weight(
+        x_shard: jax.Array,
+        labels_shard: jax.Array,
+        w_shard: jax.Array,
+        weight_shard: jax.Array,
+    ):
+        return _fused_cross_entropy_loss_and_logsumexp_penalty_local(
+            x_shard,
+            labels_shard,
+            w_shard,
+            reduction=reduction,
+            weight=weight_shard,
+            logsumexp_weight=logsumexp_weight,
+            block_size=block_size,
+            block_sizes=block_sizes,
+            dtype=dtype,
+            logit_soft_cap=logit_soft_cap,
+            precision=precision,
+            implementation=implementation,
+            return_argmax=return_argmax,
+            vocab_axis_names=vocab_axis_names,
+            reduction_axis_names=reduction_axis_names,
+        )
+
+    return jax.shard_map(
+        mapped_with_weight,
+        mesh=mesh,
+        in_specs=(x_spec, labels_spec, w_spec, weight_spec),
+        out_specs=out_specs,
+        check_vma=False,
+    )(x, labels, w, weight)
 
 
 __all__ = [

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -95,7 +95,6 @@ def _default_implementations() -> tuple[Implementation, ...]:
 
 
 def default_implementations() -> tuple[Implementation, ...]:
-    """Return the fused CE implementation order for the current backend."""
     return _default_implementations()
 
 

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -2,11 +2,12 @@
 # SPDX-License-Identifier: Apache-2.0
 
 from collections.abc import Callable, Sequence
+from dataclasses import dataclass
 from functools import lru_cache
 import hashlib
 import logging
 import time
-from typing import Literal, Optional, TypeAlias, cast, overload
+from typing import Literal, NamedTuple, Optional, TypeAlias, cast, overload
 import warnings
 
 import jax
@@ -37,6 +38,23 @@ Reduction: TypeAlias = Literal["sum", "mean"] | None
 
 KernelOutput: TypeAlias = tuple[jax.Array, jax.Array] | tuple[jax.Array, jax.Array, jax.Array]
 ArrayImpl = Callable[..., KernelOutput]
+
+
+@dataclass(frozen=True)
+class _FusedCrossEntropyCallOptions:
+    block_size: Optional[int]
+    block_sizes: Optional[BlockSizes]
+    dtype: Optional[jnp.dtype]
+    logit_soft_cap: Optional[float]
+    precision: jax.lax.PrecisionLike
+    implementation: Implementation | Sequence[Implementation | ArrayImpl] | None
+    return_argmax: bool
+
+
+class _FusedCrossEntropyImplOutput(NamedTuple):
+    loss: jax.Array
+    logsumexp: jax.Array
+    argmax: jax.Array | None
 
 
 IMPLEMENTATIONS: dict[str, ArrayImpl] = {
@@ -622,29 +640,25 @@ def _call_fused_cross_entropy_impls(
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
     *,
-    block_size: Optional[int],
-    block_sizes: Optional[BlockSizes],
-    dtype: Optional[jnp.dtype],
-    logit_soft_cap: Optional[float],
-    precision: jax.lax.PrecisionLike,
-    implementation: Implementation | Sequence[Implementation | ArrayImpl] | None,
-    return_argmax: bool,
-) -> tuple[jax.Array, jax.Array, jax.Array | None]:
-    explicit_block_sizes = block_size is not None or block_sizes is not None
+    options: _FusedCrossEntropyCallOptions,
+) -> _FusedCrossEntropyImplOutput:
+    explicit_block_sizes = options.block_size is not None or options.block_sizes is not None
     resolved_block_sizes = (
-        _resolve_block_sizes(block_size, block_sizes, x=x, w=w, dtype=dtype) if explicit_block_sizes else None
+        _resolve_block_sizes(options.block_size, options.block_sizes, x=x, w=w, dtype=options.dtype)
+        if explicit_block_sizes
+        else None
     )
 
-    if implementation is None:
+    if options.implementation is None:
         impls = cast(Sequence[Implementation | ArrayImpl], _default_implementations())
         explicit = False
         user_requested_impls = False
-    elif isinstance(implementation, Sequence) and not isinstance(implementation, (str, bytes)):
-        impls = cast(Sequence[Implementation | ArrayImpl], implementation)
+    elif isinstance(options.implementation, Sequence) and not isinstance(options.implementation, (str, bytes)):
+        impls = cast(Sequence[Implementation | ArrayImpl], options.implementation)
         explicit = len(impls) == 1
         user_requested_impls = True
     else:
-        impls = (cast(Implementation, implementation),)
+        impls = (cast(Implementation, options.implementation),)
         explicit = True
         user_requested_impls = True
 
@@ -660,7 +674,7 @@ def _call_fused_cross_entropy_impls(
                 x.shape[0],
                 x.shape[1],
                 w.shape[1],
-                dtype=dtype,
+                dtype=options.dtype,
                 x_dtype=x.dtype,
                 w_dtype=w.dtype,
             )
@@ -678,10 +692,10 @@ def _call_fused_cross_entropy_impls(
                         labels=labels,
                         w=w,
                         inferred=inferred,
-                        dtype=dtype,
-                        logit_soft_cap=logit_soft_cap,
-                        precision=precision,
-                        return_argmax=return_argmax,
+                        dtype=options.dtype,
+                        logit_soft_cap=options.logit_soft_cap,
+                        precision=options.precision,
+                        return_argmax=options.return_argmax,
                     )
                 except Exception as exc:
                     if explicit:
@@ -694,7 +708,7 @@ def _call_fused_cross_entropy_impls(
                 x.shape[0],
                 x.shape[1],
                 w.shape[1],
-                dtype=dtype,
+                dtype=options.dtype,
                 x_dtype=x.dtype,
                 w_dtype=w.dtype,
             )
@@ -702,11 +716,11 @@ def _call_fused_cross_entropy_impls(
             try:
                 kwargs = dict(
                     block_sizes=block_sizes_for_impl,
-                    dtype=dtype,
-                    logit_soft_cap=logit_soft_cap,
-                    precision=precision,
+                    dtype=options.dtype,
+                    logit_soft_cap=options.logit_soft_cap,
+                    precision=options.precision,
                 )
-                if return_argmax:
+                if options.return_argmax:
                     kwargs["return_argmax"] = True
                 result = impl_for_call(x, labels, w, **kwargs)
             except PallasUnsupportedError as e:
@@ -728,11 +742,11 @@ def _call_fused_cross_entropy_impls(
             try:
                 kwargs = dict(
                     block_sizes=block_sizes_for_impl,
-                    dtype=dtype,
-                    logit_soft_cap=logit_soft_cap,
-                    precision=precision,
+                    dtype=options.dtype,
+                    logit_soft_cap=options.logit_soft_cap,
+                    precision=options.precision,
                 )
-                if return_argmax:
+                if options.return_argmax:
                     kwargs["return_argmax"] = True
                 result = fn(x, labels, w, **kwargs)
             except PallasUnsupportedError as e:
@@ -776,9 +790,9 @@ def _call_fused_cross_entropy_impls(
         else:
             raise ValueError(f"Implementation returned unexpected output tuple length: {len(result)}")
 
-        if return_argmax and argmax is None:
+        if options.return_argmax and argmax is None:
             raise ValueError("Implementation does not support return_argmax=True")
-        return loss, lse, argmax
+        return _FusedCrossEntropyImplOutput(loss=loss, logsumexp=lse, argmax=argmax)
 
     raise ExceptionGroup("all implementations failed", errors)
 
@@ -791,35 +805,19 @@ def _fused_cross_entropy_loss_and_logsumexp_penalty_local(
     reduction: Reduction,
     weight: Optional[Float[Array, "B"]],
     logsumexp_weight: Optional[float],
-    block_size: Optional[int],
-    block_sizes: Optional[BlockSizes],
-    dtype: Optional[jnp.dtype],
-    logit_soft_cap: Optional[float],
-    precision: jax.lax.PrecisionLike,
-    implementation: Implementation | Sequence[Implementation | ArrayImpl] | None,
-    return_argmax: bool,
+    options: _FusedCrossEntropyCallOptions,
     vocab_axis_names: tuple[str, ...] = (),
     reduction_axis_names: tuple[str, ...] = (),
 ) -> jax.Array | tuple[jax.Array, jax.Array]:
     if len(vocab_axis_names) == 0:
-        loss, lse, argmax = _call_fused_cross_entropy_impls(
-            x,
-            labels,
-            w,
-            block_size=block_size,
-            block_sizes=block_sizes,
-            dtype=dtype,
-            logit_soft_cap=logit_soft_cap,
-            precision=precision,
-            implementation=implementation,
-            return_argmax=return_argmax,
-        )
+        output = _call_fused_cross_entropy_impls(x, labels, w, options=options)
+        loss = output.loss
         if logsumexp_weight is not None and logsumexp_weight != 0.0:
-            loss = loss + logsumexp_weight * (lse**2)
+            loss = loss + logsumexp_weight * (output.logsumexp**2)
         reduced_loss = _apply_reduction(loss, reduction, weight)
-        if return_argmax:
-            assert argmax is not None
-            return reduced_loss, argmax
+        if options.return_argmax:
+            assert output.argmax is not None
+            return reduced_loss, output.argmax
         return reduced_loss
 
     local_vocab_size = w.shape[1]
@@ -827,18 +825,9 @@ def _fused_cross_entropy_loss_and_logsumexp_penalty_local(
     local_labels = labels - vocab_start
     in_vocab_shard = (0 <= local_labels) & (local_labels < local_vocab_size)
     safe_labels = jnp.clip(local_labels, 0, local_vocab_size - 1)
-    local_loss, local_lse, local_argmax = _call_fused_cross_entropy_impls(
-        x,
-        safe_labels,
-        w,
-        block_size=block_size,
-        block_sizes=block_sizes,
-        dtype=dtype,
-        logit_soft_cap=logit_soft_cap,
-        precision=precision,
-        implementation=implementation,
-        return_argmax=return_argmax,
-    )
+    local_output = _call_fused_cross_entropy_impls(x, safe_labels, w, options=options)
+    local_loss = local_output.loss
+    local_lse = local_output.logsumexp
     local_label_logit = local_lse - local_loss
     global_lse = _logsumexp_over_axes(local_lse, vocab_axis_names)
     global_label_logit = _psum_over_axes(jnp.where(in_vocab_shard, local_label_logit, 0.0), vocab_axis_names)
@@ -847,21 +836,21 @@ def _fused_cross_entropy_loss_and_logsumexp_penalty_local(
         loss = loss + logsumexp_weight * (global_lse**2)
 
     reduced_loss = _apply_reduction_sharded(loss, reduction, weight, reduction_axis_names)
-    if not return_argmax:
+    if not options.return_argmax:
         return reduced_loss
 
-    assert local_argmax is not None
+    assert local_output.argmax is not None
     local_argmax_logit = jnp.einsum(
         "bh,bh->b",
         x,
-        jnp.swapaxes(w[:, local_argmax], 0, 1),
-        precision=precision,
+        jnp.swapaxes(w[:, local_output.argmax], 0, 1),
+        precision=options.precision,
     )
     global_argmax_logit = _pmax_over_axes(local_argmax_logit, vocab_axis_names)
     global_argmax = _pmin_over_axes(
         jnp.where(
             local_argmax_logit == global_argmax_logit,
-            local_argmax + vocab_start,
+            local_output.argmax + vocab_start,
             jnp.iinfo(jnp.int32).max,
         ),
         vocab_axis_names,
@@ -945,6 +934,15 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
         If return_argmax=True: tuple of (loss, argmax_ids[B]).
     """
     _validate_inputs(x, labels, w)
+    options = _FusedCrossEntropyCallOptions(
+        block_size=block_size,
+        block_sizes=block_sizes,
+        dtype=dtype,
+        logit_soft_cap=logit_soft_cap,
+        precision=precision,
+        implementation=implementation,
+        return_argmax=return_argmax,
+    )
     vocab_axis_names = _vocab_axis_names_from_sharding(w)
     mesh = _mesh_from_sharding(w)
     if len(vocab_axis_names) == 0 or mesh is None:
@@ -955,13 +953,7 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
             reduction=reduction,
             weight=weight,
             logsumexp_weight=logsumexp_weight,
-            block_size=block_size,
-            block_sizes=block_sizes,
-            dtype=dtype,
-            logit_soft_cap=logit_soft_cap,
-            precision=precision,
-            implementation=implementation,
-            return_argmax=return_argmax,
+            options=options,
         )
 
     x_spec = _partition_spec_for_array(x)
@@ -978,26 +970,28 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
     else:
         out_specs = jax.sharding.PartitionSpec() if reduction is not None else labels_spec
 
+    def mapped_local(
+        x_shard: jax.Array,
+        labels_shard: jax.Array,
+        w_shard: jax.Array,
+        weight_shard: jax.Array | None,
+    ):
+        return _fused_cross_entropy_loss_and_logsumexp_penalty_local(
+            x_shard,
+            labels_shard,
+            w_shard,
+            reduction=reduction,
+            weight=weight_shard,
+            logsumexp_weight=logsumexp_weight,
+            options=options,
+            vocab_axis_names=vocab_axis_names,
+            reduction_axis_names=reduction_axis_names,
+        )
+
     if weight is None:
 
         def mapped(x_shard: jax.Array, labels_shard: jax.Array, w_shard: jax.Array):
-            return _fused_cross_entropy_loss_and_logsumexp_penalty_local(
-                x_shard,
-                labels_shard,
-                w_shard,
-                reduction=reduction,
-                weight=None,
-                logsumexp_weight=logsumexp_weight,
-                block_size=block_size,
-                block_sizes=block_sizes,
-                dtype=dtype,
-                logit_soft_cap=logit_soft_cap,
-                precision=precision,
-                implementation=implementation,
-                return_argmax=return_argmax,
-                vocab_axis_names=vocab_axis_names,
-                reduction_axis_names=reduction_axis_names,
-            )
+            return mapped_local(x_shard, labels_shard, w_shard, None)
 
         return jax.shard_map(
             mapped,
@@ -1015,23 +1009,7 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
         w_shard: jax.Array,
         weight_shard: jax.Array,
     ):
-        return _fused_cross_entropy_loss_and_logsumexp_penalty_local(
-            x_shard,
-            labels_shard,
-            w_shard,
-            reduction=reduction,
-            weight=weight_shard,
-            logsumexp_weight=logsumexp_weight,
-            block_size=block_size,
-            block_sizes=block_sizes,
-            dtype=dtype,
-            logit_soft_cap=logit_soft_cap,
-            precision=precision,
-            implementation=implementation,
-            return_argmax=return_argmax,
-            vocab_axis_names=vocab_axis_names,
-            reduction_axis_names=reduction_axis_names,
-        )
+        return mapped_local(x_shard, labels_shard, w_shard, weight_shard)
 
     return jax.shard_map(
         mapped_with_weight,

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -94,6 +94,11 @@ def _default_implementations() -> tuple[Implementation, ...]:
     return implementations
 
 
+def default_implementations() -> tuple[Implementation, ...]:
+    """Return the fused CE implementation order for the current backend."""
+    return _default_implementations()
+
+
 def _warn_pallas_fallback_once(exc: Exception) -> None:
     message = str(exc)
     if "requires TPU backend" in message:
@@ -747,5 +752,6 @@ __all__ = [
     "Implementation",
     "IMPLEMENTATIONS",
     "Reduction",
+    "default_implementations",
     "fused_cross_entropy_loss_and_logsumexp_penalty",
 ]

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/gpu_launch_limits.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/gpu_launch_limits.py
@@ -16,6 +16,7 @@ def is_power_of_two(n: int) -> bool:
 
 
 def max_weight_tile_bytes_for_device(device_kind: str) -> Optional[int]:
+    """Return the device weight-tile byte limit, or None when no limit is known."""
     if "nvidia" in device_kind.lower():
         return NVIDIA_WEIGHT_TILE_BYTES_LIMIT
     return None

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/gpu_launch_limits.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/gpu_launch_limits.py
@@ -1,0 +1,21 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import Optional
+
+
+# Empirical launch guardrails from Triton shared-memory launch failures.
+# H100 has 232,448 bytes per-SM shared memory; kernel overhead (input tiles,
+# accumulators, Triton metadata) consumes ~131 KB, leaving 101,376 bytes for
+# the weight tile. The same limit applies to all NVIDIA GPUs including GB10.
+NVIDIA_WEIGHT_TILE_BYTES_LIMIT = 101_376
+
+
+def is_power_of_two(n: int) -> bool:
+    return n > 0 and (n & (n - 1)) == 0
+
+
+def max_weight_tile_bytes_for_device(device_kind: str) -> Optional[int]:
+    if "nvidia" in device_kind.lower():
+        return NVIDIA_WEIGHT_TILE_BYTES_LIMIT
+    return None

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
@@ -4,7 +4,6 @@
 from __future__ import annotations
 
 from functools import partial
-import os
 from typing import Optional
 
 import jax
@@ -12,15 +11,11 @@ import jax.numpy as jnp
 from jaxtyping import Array, Float, Int
 
 from .config import BlockSizes
+from .gpu_launch_limits import is_power_of_two, max_weight_tile_bytes_for_device
 from .reference import linear_softmax_cross_entropy_loss_reference
 from .xla import linear_softmax_cross_entropy_loss_xla
 
 
-# Empirical launch guardrails from Triton shared-memory launch failures.
-# H100 has 232,448 bytes per-SM shared memory; kernel overhead (input tiles,
-# accumulators, Triton metadata) consumes ~131 KB, leaving 101,376 bytes for
-# the weight tile.  Same limit applies to all NVIDIA GPUs including GB10.
-_NVIDIA_WEIGHT_TILE_BYTES_LIMIT = 101_376
 # Compile-time safety cap observed to avoid pathological GB10 H-tiling compile behavior.
 _GB10_MAX_H_TILES = 512
 _GB10_FULL_MATMUL_MAX_OUTPUT_ELEMENTS = 67_108_864
@@ -31,7 +26,6 @@ _GB10_CUSTOM_BWD_V_BLOCK_BATCH_1K = 6144
 _GB10_CUSTOM_BWD_V_BLOCK_BATCH_2K_PLUS = 7168
 _NVIDIA_CUSTOM_BWD_V_BLOCK_LARGE_VOCAB = 8192
 _GPU_MIN_B_BLOCK_SIZE = 128
-_CUSTOM_BWD_V_BLOCK_SIZE_ENV = "LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE"
 
 
 def _apply_logit_soft_cap(logits: jax.Array, logit_soft_cap: Optional[float]) -> jax.Array:
@@ -44,20 +38,10 @@ def _ceil_div(n: int, d: int) -> int:
     return (n + d - 1) // d
 
 
-def _is_power_of_two(n: int) -> bool:
-    return n > 0 and (n & (n - 1)) == 0
-
-
 def _device_kind() -> str:
     if not jax.devices():
         return ""
     return jax.devices()[0].device_kind.lower()
-
-
-def _max_weight_tile_bytes_for_device(device_kind: str) -> Optional[int]:
-    if "nvidia" in device_kind:
-        return _NVIDIA_WEIGHT_TILE_BYTES_LIMIT
-    return None
 
 
 def _max_h_tiles_for_device(device_kind: str) -> Optional[int]:
@@ -162,17 +146,17 @@ def _validate_launch_feasibility(
     v_block_size: int,
     num_h_blocks: int,
 ) -> None:
-    if not _is_power_of_two(h_block_size):
+    if not is_power_of_two(h_block_size):
         raise PallasUnsupportedError(
             "h_block_size must be a power of 2 for current GPU Triton lowering; " f"got h_block_size={h_block_size}."
         )
-    if not _is_power_of_two(v_block_size):
+    if not is_power_of_two(v_block_size):
         raise PallasUnsupportedError(
             "v_block_size must be a power of 2 for current GPU Triton lowering; " f"got v_block_size={v_block_size}."
         )
 
     device_kind = _device_kind()
-    max_weight_tile_bytes = _max_weight_tile_bytes_for_device(device_kind)
+    max_weight_tile_bytes = max_weight_tile_bytes_for_device(device_kind)
     if max_weight_tile_bytes is not None:
         requested = h_block_size * v_block_size * jnp.dtype(w_dtype).itemsize
         if requested > max_weight_tile_bytes:
@@ -453,11 +437,6 @@ def _custom_backward_v_block_size(
     w: Float[Array, "H V"],
     block_sizes: BlockSizes | None,
 ) -> int:
-    if raw_override := os.environ.get(_CUSTOM_BWD_V_BLOCK_SIZE_ENV):
-        override = int(raw_override)
-        if override <= 0:
-            raise ValueError(f"{_CUSTOM_BWD_V_BLOCK_SIZE_ENV} must be positive, got {override}.")
-        return override
     gb10_tuned = _gb10_custom_backward_v_block_size(x, w)
     if gb10_tuned is not None:
         return gb10_tuned

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
@@ -22,6 +22,7 @@ _GB10_FULL_MATMUL_MAX_OUTPUT_ELEMENTS = 67_108_864
 _GB10_XLA_STREAMING_V_BLOCK_BATCH_1K = 2048
 _GB10_XLA_STREAMING_V_BLOCK_BATCH_4K = 3072
 _GB10_XLA_STREAMING_V_BLOCK_BATCH_8K = 3072
+_LARGE_VOCAB_THRESHOLD = 65536
 _GB10_CUSTOM_BWD_V_BLOCK_BATCH_1K = 6144
 _GB10_CUSTOM_BWD_V_BLOCK_BATCH_2K_PLUS = 7168
 _NVIDIA_CUSTOM_BWD_V_BLOCK_LARGE_VOCAB = 8192
@@ -70,7 +71,7 @@ def _gb10_xla_fallback_block_sizes(
     b_dim: int,
     v_dim: int,
 ) -> BlockSizes | None:
-    if v_dim < 65536:
+    if v_dim < _LARGE_VOCAB_THRESHOLD:
         return None
     if b_dim >= 8192:
         return BlockSizes(v_block_size=_GB10_XLA_STREAMING_V_BLOCK_BATCH_8K)
@@ -404,7 +405,7 @@ def _gb10_custom_backward_v_block_size(
         return None
     if _should_use_gb10_full_matmul_fallback(x, w):
         return None
-    if w.shape[1] < 65536:
+    if w.shape[1] < _LARGE_VOCAB_THRESHOLD:
         return None
     if x.shape[0] >= 2048:
         return _GB10_CUSTOM_BWD_V_BLOCK_BATCH_2K_PLUS
@@ -413,7 +414,7 @@ def _gb10_custom_backward_v_block_size(
     return None
 
 
-def _nvidia_custom_backward_v_block_size(
+def _h100_custom_backward_v_block_size(
     x: Float[Array, "B H"],
     w: Float[Array, "H V"],
 ) -> int | None:
@@ -425,7 +426,7 @@ def _nvidia_custom_backward_v_block_size(
         return None
     if x.dtype != jnp.bfloat16 or w.dtype != jnp.bfloat16:
         return None
-    if w.shape[1] < 65536:
+    if w.shape[1] < _LARGE_VOCAB_THRESHOLD:
         return None
     if x.shape[0] < 1024:
         return None
@@ -440,9 +441,9 @@ def _custom_backward_v_block_size(
     gb10_tuned = _gb10_custom_backward_v_block_size(x, w)
     if gb10_tuned is not None:
         return gb10_tuned
-    nvidia_tuned = _nvidia_custom_backward_v_block_size(x, w)
-    if nvidia_tuned is not None:
-        return nvidia_tuned
+    h100_tuned = _h100_custom_backward_v_block_size(x, w)
+    if h100_tuned is not None:
+        return h100_tuned
     if block_sizes is not None:
         return block_sizes.v_block_size
     return BlockSizes.get_default().v_block_size

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
@@ -4,6 +4,7 @@
 from __future__ import annotations
 
 from functools import partial
+import os
 from typing import Optional
 
 import jax
@@ -28,7 +29,9 @@ _GB10_XLA_STREAMING_V_BLOCK_BATCH_4K = 3072
 _GB10_XLA_STREAMING_V_BLOCK_BATCH_8K = 3072
 _GB10_CUSTOM_BWD_V_BLOCK_BATCH_1K = 6144
 _GB10_CUSTOM_BWD_V_BLOCK_BATCH_2K_PLUS = 7168
+_NVIDIA_CUSTOM_BWD_V_BLOCK_LARGE_VOCAB = 8192
 _GPU_MIN_B_BLOCK_SIZE = 128
+_CUSTOM_BWD_V_BLOCK_SIZE_ENV = "LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE"
 
 
 def _apply_logit_soft_cap(logits: jax.Array, logit_soft_cap: Optional[float]) -> jax.Array:
@@ -426,14 +429,41 @@ def _gb10_custom_backward_v_block_size(
     return None
 
 
+def _nvidia_custom_backward_v_block_size(
+    x: Float[Array, "B H"],
+    w: Float[Array, "H V"],
+) -> int | None:
+    """Return the H100-style large-vocab custom-backward tile when applicable."""
+    device_kind = _device_kind()
+    if "h100" not in device_kind:
+        return None
+    if "gb10" in device_kind:
+        return None
+    if x.dtype != jnp.bfloat16 or w.dtype != jnp.bfloat16:
+        return None
+    if w.shape[1] < 65536:
+        return None
+    if x.shape[0] < 1024:
+        return None
+    return _NVIDIA_CUSTOM_BWD_V_BLOCK_LARGE_VOCAB
+
+
 def _custom_backward_v_block_size(
     x: Float[Array, "B H"],
     w: Float[Array, "H V"],
     block_sizes: BlockSizes | None,
 ) -> int:
+    if raw_override := os.environ.get(_CUSTOM_BWD_V_BLOCK_SIZE_ENV):
+        override = int(raw_override)
+        if override <= 0:
+            raise ValueError(f"{_CUSTOM_BWD_V_BLOCK_SIZE_ENV} must be positive, got {override}.")
+        return override
     gb10_tuned = _gb10_custom_backward_v_block_size(x, w)
     if gb10_tuned is not None:
         return gb10_tuned
+    nvidia_tuned = _nvidia_custom_backward_v_block_size(x, w)
+    if nvidia_tuned is not None:
+        return nvidia_tuned
     if block_sizes is not None:
         return block_sizes.v_block_size
     return BlockSizes.get_default().v_block_size
@@ -471,7 +501,6 @@ def _backward_streaming_from_lse(
     v_offsets = jnp.arange(v_block_size, dtype=jnp.int32)
 
     grad_x_init = jnp.zeros((b_dim, h_dim), dtype=jnp.float32)
-    v_indices = jnp.arange(num_v_blocks, dtype=jnp.int32)
 
     def body(grad_x, v_block_index):
         v_start = v_block_index * v_block_size
@@ -515,9 +544,13 @@ def _backward_streaming_from_lse(
         ).astype(jnp.float32)
 
         grad_x = grad_x + grad_x_block
-        return grad_x, grad_w_block
+        return grad_x, grad_w_block.astype(w.dtype)
 
-    grad_x, grad_w_blocks = jax.lax.scan(body, grad_x_init, v_indices)
+    grad_x, grad_w_blocks = jax.lax.scan(
+        body,
+        grad_x_init,
+        jnp.arange(num_v_blocks, dtype=jnp.int32),
+    )
     grad_w = jnp.transpose(grad_w_blocks, (1, 0, 2)).reshape((h_dim, v_pad))
     grad_w = grad_w[:, :v_dim]
     return grad_x.astype(x.dtype), grad_w.astype(w.dtype)

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
@@ -10,10 +10,10 @@ import jax
 import jax.numpy as jnp
 
 from .config import BlockSizes
+from .gpu_launch_limits import NVIDIA_WEIGHT_TILE_BYTES_LIMIT, is_power_of_two
 
 
 DEFAULT_DEVICE_KEY = "default"
-_NVIDIA_WEIGHT_TILE_BYTES_LIMIT = 101_376
 
 
 @dataclass(frozen=True, slots=True)
@@ -452,10 +452,6 @@ def _is_nvidia_device(device_key: Optional[str]) -> bool:
     return bool(device_key and device_key.startswith("NVIDIA"))
 
 
-def _is_power_of_two(n: int) -> bool:
-    return n > 0 and (n & (n - 1) == 0)
-
-
 def _dtype_itemsize(dtype: Optional[jnp.dtype]) -> int:
     if dtype is None:
         return 4
@@ -694,10 +690,10 @@ def _is_valid_for_pallas_shape(
             return False
         if block_sizes.b_block_size % 16 != 0 or block_sizes.h_block_size % 16 != 0:
             return False
-        if not _is_power_of_two(block_sizes.h_block_size) or not _is_power_of_two(block_sizes.v_block_size):
+        if not is_power_of_two(block_sizes.h_block_size) or not is_power_of_two(block_sizes.v_block_size):
             return False
         weight_tile_bytes = block_sizes.h_block_size * block_sizes.v_block_size * _dtype_itemsize(w_dtype)
-        if weight_tile_bytes > _NVIDIA_WEIGHT_TILE_BYTES_LIMIT:
+        if weight_tile_bytes > NVIDIA_WEIGHT_TILE_BYTES_LIMIT:
             return False
     return True
 
@@ -711,7 +707,7 @@ def _sanitize_for_pallas(
     device_kind: Optional[str],
     w_dtype: Optional[jnp.dtype] = None,
 ) -> BlockSizes:
-    """Adjust inferred block sizes so B/H blocks divide local shapes when possible."""
+    """Adjust inferred block sizes to satisfy backend launch constraints."""
     del device_kind
     if not _is_tpu_device(device_key):
         if not _is_nvidia_device(device_key):
@@ -722,7 +718,7 @@ def _sanitize_for_pallas(
             b_block_size = 128
 
         h_block_size = _largest_power_of_two_at_most(min(block_sizes.h_block_size, 64), minimum=16)
-        max_v_for_tile = _NVIDIA_WEIGHT_TILE_BYTES_LIMIT // (_dtype_itemsize(w_dtype) * h_block_size)
+        max_v_for_tile = NVIDIA_WEIGHT_TILE_BYTES_LIMIT // (_dtype_itemsize(w_dtype) * h_block_size)
         v_block_size = _largest_power_of_two_at_most(
             min(block_sizes.v_block_size, 256, max_v_for_tile),
             minimum=16,

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
@@ -452,7 +452,7 @@ def _dtype_itemsize(dtype: Optional[jnp.dtype]) -> int:
     return jnp.dtype(dtype).itemsize
 
 
-def _largest_power_of_two_at_most(value: int, *, minimum: int) -> int:
+def _power_of_two_at_most_or_minimum(value: int, *, minimum: int) -> int:
     if value < minimum:
         return minimum
     return 1 << value.bit_length() - 1
@@ -711,9 +711,9 @@ def _sanitize_for_pallas(
         if b_block_size < 128 or b_block_size % 16 != 0:
             b_block_size = 128
 
-        h_block_size = _largest_power_of_two_at_most(min(block_sizes.h_block_size, 64), minimum=16)
+        h_block_size = _power_of_two_at_most_or_minimum(min(block_sizes.h_block_size, 64), minimum=16)
         max_v_for_tile = NVIDIA_WEIGHT_TILE_BYTES_LIMIT // (_dtype_itemsize(w_dtype) * h_block_size)
-        v_block_size = _largest_power_of_two_at_most(
+        v_block_size = _power_of_two_at_most_or_minimum(
             min(block_sizes.v_block_size, 256, max_v_for_tile),
             minimum=16,
         )

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
@@ -37,6 +37,15 @@ class ShapeBucket:
 #   - shape_bucket
 # value:
 #   - BlockSizes
+_NVIDIA_MEDIUM_H_BLOCK_SIZES: dict[tuple[str, str], BlockSizes] = {
+    ("bfloat16", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+    ("float32", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+    ("bfloat16", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+    ("float32", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+    ("bfloat16", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+    ("float32", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+}
+
 TUNED_BLOCK_SIZES: dict[str, dict[tuple[str, str], BlockSizes]] = {
     DEFAULT_DEVICE_KEY: {
         ("bfloat16", "large-batch-small-h"): BlockSizes(b_block_size=1024, h_block_size=512, v_block_size=2048),
@@ -51,12 +60,7 @@ TUNED_BLOCK_SIZES: dict[str, dict[tuple[str, str], BlockSizes]] = {
         ("float32", "llama3-ish"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=1024),
         ("bfloat16", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
         ("float32", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
-        ("bfloat16", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("float32", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("bfloat16", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("float32", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("bfloat16", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("float32", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        **_NVIDIA_MEDIUM_H_BLOCK_SIZES,
     },
     "NVIDIA GB10": {
         ("bfloat16", "tiny"): BlockSizes(b_block_size=128, h_block_size=64, v_block_size=128),
@@ -79,12 +83,7 @@ TUNED_BLOCK_SIZES: dict[str, dict[tuple[str, str], BlockSizes]] = {
         ("float32", "llama3-ish"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=1024),
         ("bfloat16", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
         ("float32", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
-        ("bfloat16", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("float32", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("bfloat16", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("float32", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("bfloat16", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("float32", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        **_NVIDIA_MEDIUM_H_BLOCK_SIZES,
     },
     "NVIDIA A100": {
         ("bfloat16", "tiny"): BlockSizes(b_block_size=128, h_block_size=64, v_block_size=128),
@@ -95,12 +94,7 @@ TUNED_BLOCK_SIZES: dict[str, dict[tuple[str, str], BlockSizes]] = {
         ("float32", "llama3-ish"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=1024),
         ("bfloat16", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
         ("float32", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
-        ("bfloat16", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("float32", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("bfloat16", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("float32", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("bfloat16", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
-        ("float32", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        **_NVIDIA_MEDIUM_H_BLOCK_SIZES,
     },
     "TPU v5e": {
         ("bfloat16", "small-vocab"): BlockSizes(b_block_size=1024, h_block_size=256, v_block_size=1024),

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
@@ -755,7 +755,7 @@ def infer_block_sizes(
         device_kind: Optional `jax.Device.device_kind` string.
 
     Returns:
-        BlockSizes chosen from the tuned table, or the default if no match.
+        BlockSizes chosen from the tuned table, or a backend-safe fallback if no match exists.
     """
     block_sizes, _ = infer_block_sizes_with_tuned_match(
         b,

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/tuned_block_sizes.py
@@ -13,6 +13,7 @@ from .config import BlockSizes
 
 
 DEFAULT_DEVICE_KEY = "default"
+_NVIDIA_WEIGHT_TILE_BYTES_LIMIT = 101_376
 
 
 @dataclass(frozen=True, slots=True)
@@ -50,8 +51,12 @@ TUNED_BLOCK_SIZES: dict[str, dict[tuple[str, str], BlockSizes]] = {
         ("float32", "llama3-ish"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=1024),
         ("bfloat16", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
         ("float32", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
-        ("bfloat16", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
-        ("float32", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
+        ("bfloat16", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("float32", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("bfloat16", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("float32", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("bfloat16", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("float32", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
     },
     "NVIDIA GB10": {
         ("bfloat16", "tiny"): BlockSizes(b_block_size=128, h_block_size=64, v_block_size=128),
@@ -74,8 +79,12 @@ TUNED_BLOCK_SIZES: dict[str, dict[tuple[str, str], BlockSizes]] = {
         ("float32", "llama3-ish"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=1024),
         ("bfloat16", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
         ("float32", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
-        ("bfloat16", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
-        ("float32", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
+        ("bfloat16", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("float32", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("bfloat16", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("float32", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("bfloat16", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("float32", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
     },
     "NVIDIA A100": {
         ("bfloat16", "tiny"): BlockSizes(b_block_size=128, h_block_size=64, v_block_size=128),
@@ -86,8 +95,12 @@ TUNED_BLOCK_SIZES: dict[str, dict[tuple[str, str], BlockSizes]] = {
         ("float32", "llama3-ish"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=1024),
         ("bfloat16", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
         ("float32", "large-batch-small-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
-        ("bfloat16", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
-        ("float32", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=256, v_block_size=2048),
+        ("bfloat16", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("float32", "small-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("bfloat16", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("float32", "medium-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("bfloat16", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
+        ("float32", "large-batch-medium-h"): BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256),
     },
     "TPU v5e": {
         ("bfloat16", "small-vocab"): BlockSizes(b_block_size=1024, h_block_size=256, v_block_size=1024),
@@ -352,6 +365,15 @@ SHAPE_BUCKETS: list[ShapeBucket] = [
         v_max=262144,
     ),
     ShapeBucket(
+        name="small-batch-medium-h",
+        b_min=4096,
+        b_max=8191,
+        h_min=1537,
+        h_max=3072,
+        v_min=120000,
+        v_max=131072,
+    ),
+    ShapeBucket(
         name="mid-h-large-vocab",
         b_min=4096,
         b_max=32768,
@@ -424,6 +446,26 @@ _WARNED_HUGE_BATCH_SAFE_FALLBACK = False
 
 def _is_tpu_device(device_key: Optional[str]) -> bool:
     return bool(device_key and device_key.startswith("TPU"))
+
+
+def _is_nvidia_device(device_key: Optional[str]) -> bool:
+    return bool(device_key and device_key.startswith("NVIDIA"))
+
+
+def _is_power_of_two(n: int) -> bool:
+    return n > 0 and (n & (n - 1) == 0)
+
+
+def _dtype_itemsize(dtype: Optional[jnp.dtype]) -> int:
+    if dtype is None:
+        return 4
+    return jnp.dtype(dtype).itemsize
+
+
+def _largest_power_of_two_at_most(value: int, *, minimum: int) -> int:
+    if value < minimum:
+        return minimum
+    return 1 << value.bit_length() - 1
 
 
 def _normalized_device_kind(device_kind: Optional[str]) -> Optional[str]:
@@ -633,6 +675,7 @@ def _is_valid_for_pallas_shape(
     h: int,
     device_key: Optional[str],
     device_kind: Optional[str],
+    w_dtype: Optional[jnp.dtype] = None,
 ) -> bool:
     del device_kind
     if _is_tpu_device(device_key):
@@ -646,10 +689,15 @@ def _is_valid_for_pallas_shape(
 
     if block_sizes.b_block_size <= 0 or block_sizes.h_block_size <= 0 or block_sizes.v_block_size <= 0:
         return False
-    if device_key and device_key.startswith("NVIDIA"):
+    if _is_nvidia_device(device_key):
         if block_sizes.b_block_size < 16 or block_sizes.h_block_size < 16 or block_sizes.v_block_size < 16:
             return False
         if block_sizes.b_block_size % 16 != 0 or block_sizes.h_block_size % 16 != 0:
+            return False
+        if not _is_power_of_two(block_sizes.h_block_size) or not _is_power_of_two(block_sizes.v_block_size):
+            return False
+        weight_tile_bytes = block_sizes.h_block_size * block_sizes.v_block_size * _dtype_itemsize(w_dtype)
+        if weight_tile_bytes > _NVIDIA_WEIGHT_TILE_BYTES_LIMIT:
             return False
     return True
 
@@ -661,11 +709,30 @@ def _sanitize_for_pallas(
     h: int,
     device_key: Optional[str],
     device_kind: Optional[str],
+    w_dtype: Optional[jnp.dtype] = None,
 ) -> BlockSizes:
     """Adjust inferred block sizes so B/H blocks divide local shapes when possible."""
     del device_kind
     if not _is_tpu_device(device_key):
-        return block_sizes
+        if not _is_nvidia_device(device_key):
+            return block_sizes
+
+        b_block_size = block_sizes.b_block_size
+        if b_block_size < 128 or b_block_size % 16 != 0:
+            b_block_size = 128
+
+        h_block_size = _largest_power_of_two_at_most(min(block_sizes.h_block_size, 64), minimum=16)
+        max_v_for_tile = _NVIDIA_WEIGHT_TILE_BYTES_LIMIT // (_dtype_itemsize(w_dtype) * h_block_size)
+        v_block_size = _largest_power_of_two_at_most(
+            min(block_sizes.v_block_size, 256, max_v_for_tile),
+            minimum=16,
+        )
+        return BlockSizes(
+            b_block_size=b_block_size,
+            h_block_size=h_block_size,
+            v_block_size=v_block_size,
+        )
+
     if b >= 1024:
         b_block_size = _largest_divisor_multiple_of_1024(b, block_sizes.b_block_size)
     else:
@@ -746,6 +813,7 @@ def infer_block_sizes_with_tuned_match(
                     h=h,
                     device_key=device_key,
                     device_kind=normalized_device_kind,
+                    w_dtype=w_dtype,
                 ):
                     return entry, True
 
@@ -756,6 +824,7 @@ def infer_block_sizes_with_tuned_match(
         h=h,
         device_key=device_key,
         device_kind=normalized_device_kind,
+        w_dtype=w_dtype,
     ):
         return default_entry, False
     return (
@@ -765,6 +834,7 @@ def infer_block_sizes_with_tuned_match(
             h=h,
             device_key=device_key,
             device_kind=normalized_device_kind,
+            w_dtype=w_dtype,
         ),
         False,
     )

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/xla.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/xla.py
@@ -76,7 +76,7 @@ def _resolve_xla_batch_block_size(
     return _largest_divisor_at_most(b_dim, min(requested, inferred))
 
 
-def _infer_tuned_xla_batch_block_size(
+def _infer_preferred_xla_batch_block_size(
     b_dim: int,
     h_dim: int,
     v_dim: int,
@@ -85,7 +85,7 @@ def _infer_tuned_xla_batch_block_size(
     x_dtype: jnp.dtype,
     w_dtype: jnp.dtype,
 ) -> int | None:
-    tuned_block_sizes, has_tuned_match = infer_block_sizes_with_tuned_match(
+    block_sizes, _ = infer_block_sizes_with_tuned_match(
         b_dim,
         h_dim,
         v_dim,
@@ -93,9 +93,7 @@ def _infer_tuned_xla_batch_block_size(
         x_dtype=x_dtype,
         w_dtype=w_dtype,
     )
-    if not has_tuned_match:
-        return None
-    return tuned_block_sizes.b_block_size
+    return block_sizes.b_block_size
 
 
 def _linear_softmax_cross_entropy_loss_streaming_fwd(
@@ -450,7 +448,7 @@ def linear_softmax_cross_entropy_loss_xla(
         b_block_size = _resolve_xla_batch_block_size(
             x.shape[0],
             v_block_size,
-            _infer_tuned_xla_batch_block_size(
+            _infer_preferred_xla_batch_block_size(
                 x.shape[0],
                 x.shape[1],
                 w.shape[1],

--- a/lib/levanter/tests/grug/test_loss.py
+++ b/lib/levanter/tests/grug/test_loss.py
@@ -1,7 +1,7 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from typing import cast
+from contextlib import nullcontext
 
 import numpy as np
 import pytest
@@ -10,7 +10,6 @@ import jax
 import jax.numpy as jnp
 from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
 
-from levanter.grug import loss as grug_loss
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 
 
@@ -72,7 +71,8 @@ def test_fused_linear_softmax_cross_entropy_loss_matches_reference_without_mesh(
     np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
 
 
-def test_xla_cross_entropy_model_sharded_vocab_matches_reference_and_gradients():
+@pytest.mark.parametrize("implementation", ["xla", ("pallas_gpu", "xla")])
+def test_cross_entropy_model_sharded_vocab_matches_reference_and_gradients(implementation: str | tuple[str, ...]):
     devices = jax.devices()
     if len(devices) < 2:
         pytest.skip("requires at least two devices; run with XLA_FLAGS=--xla_force_host_platform_device_count=2")
@@ -96,7 +96,7 @@ def test_xla_cross_entropy_model_sharded_vocab_matches_reference_and_gradients()
             weight=weight_sharded,
             reduction="mean",
             logsumexp_weight=0.02,
-            implementation="xla",
+            implementation=implementation,
         )
 
     def reference_loss(hidden_value: jax.Array, lm_head_value: jax.Array) -> jax.Array:
@@ -115,9 +115,13 @@ def test_xla_cross_entropy_model_sharded_vocab_matches_reference_and_gradients()
         weight_sharded = jax.device_put(weight, NamedSharding(mesh, P("data", None)))
         lm_head_sharded = jax.device_put(lm_head, NamedSharding(mesh, P(None, "model")))
 
-        actual, (actual_hidden_grad, actual_lm_head_grad) = jax.jit(jax.value_and_grad(sharded_loss, argnums=(0, 1)))(
-            hidden_sharded, lm_head_sharded
-        )
+        warning_context = pytest.warns(RuntimeWarning, match="falling back to xla")
+        if implementation == "xla":
+            warning_context = nullcontext()
+        with warning_context:
+            actual, (actual_hidden_grad, actual_lm_head_grad) = jax.jit(
+                jax.value_and_grad(sharded_loss, argnums=(0, 1))
+            )(hidden_sharded, lm_head_sharded)
 
     expected, (expected_hidden_grad, expected_lm_head_grad) = jax.value_and_grad(reference_loss, argnums=(0, 1))(
         hidden,
@@ -127,67 +131,3 @@ def test_xla_cross_entropy_model_sharded_vocab_matches_reference_and_gradients()
     np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
     np.testing.assert_allclose(actual_hidden_grad, expected_hidden_grad, rtol=1e-5, atol=1e-5)
     np.testing.assert_allclose(actual_lm_head_grad, expected_lm_head_grad, rtol=1e-5, atol=1e-5)
-
-
-def test_vocab_sharded_ce_falls_back_to_xla_after_pallas_gpu_failure(monkeypatch: pytest.MonkeyPatch):
-    flat_hidden = jnp.linspace(-0.4, 0.5, 3 * 4, dtype=jnp.float32).reshape((3, 4))
-    lm_head = jnp.linspace(-0.3, 0.7, 4 * 5, dtype=jnp.float32).reshape((4, 5))
-    labels = jnp.array([0, 2, 4], dtype=jnp.int32)
-
-    def failing_pallas_gpu(*args, **kwargs):
-        del args, kwargs
-        raise RuntimeError("synthetic pallas failure")
-
-    monkeypatch.setitem(grug_loss.IMPLEMENTATIONS, "pallas_gpu", failing_pallas_gpu)
-
-    with pytest.warns(RuntimeWarning, match="falling back to xla"):
-        actual_loss, actual_lse = grug_loss._local_linear_softmax_cross_entropy_loss(
-            flat_hidden,
-            labels,
-            lm_head,
-            dtype=jnp.float32,
-            precision=None,
-            implementation=("pallas_gpu", "xla"),
-        )
-    expected_loss, expected_lse = grug_loss._local_linear_softmax_cross_entropy_loss(
-        flat_hidden,
-        labels,
-        lm_head,
-        dtype=jnp.float32,
-        precision=None,
-        implementation="xla",
-    )
-
-    np.testing.assert_allclose(actual_loss, expected_loss, rtol=1e-5, atol=1e-5)
-    np.testing.assert_allclose(actual_lse, expected_lse, rtol=1e-5, atol=1e-5)
-
-
-def test_lm_head_spec_tracks_effective_default_ce_backend(monkeypatch: pytest.MonkeyPatch):
-    class FakeMesh:
-        empty = False
-        shape = {"model": 2}
-
-    lm_head = jnp.zeros((4, 8), dtype=jnp.float32)
-
-    mesh = cast(jax.sharding.AbstractMesh, FakeMesh())
-
-    monkeypatch.setattr(grug_loss, "default_implementations", lambda: ("xla",))
-    assert grug_loss._lm_head_spec_for_ce(lm_head, mesh, None) == P(None, "model")
-
-    monkeypatch.setattr(grug_loss, "default_implementations", lambda: ("pallas_gpu", "xla"))
-    assert grug_loss._lm_head_spec_for_ce(lm_head, mesh, None) == P(None, "model")
-
-
-def test_lm_head_spec_does_not_vocab_shard_when_model_axis_is_one(monkeypatch: pytest.MonkeyPatch):
-    class FakeMesh:
-        empty = False
-        shape = {"model": 1}
-
-    lm_head = jnp.zeros((2560, 128_256), dtype=jnp.bfloat16)
-    mesh = cast(jax.sharding.AbstractMesh, FakeMesh())
-
-    assert grug_loss._lm_head_spec_for_ce(lm_head, mesh, "xla") == P(None, None)
-    assert grug_loss._lm_head_spec_for_ce(lm_head, mesh, "pallas_gpu") == P(None, None)
-
-    monkeypatch.setattr(grug_loss, "default_implementations", lambda: ("pallas_gpu", "xla"))
-    assert grug_loss._lm_head_spec_for_ce(lm_head, mesh, None) == P(None, None)

--- a/lib/levanter/tests/grug/test_loss.py
+++ b/lib/levanter/tests/grug/test_loss.py
@@ -115,7 +115,7 @@ def test_cross_entropy_model_sharded_vocab_matches_reference_and_gradients(imple
         weight_sharded = jax.device_put(weight, NamedSharding(mesh, P("data", None)))
         lm_head_sharded = jax.device_put(lm_head, NamedSharding(mesh, P(None, "model")))
 
-        warning_context = pytest.warns(RuntimeWarning, match="falling back to xla")
+        warning_context = pytest.warns(RuntimeWarning)
         if implementation == "xla":
             warning_context = nullcontext()
         with warning_context:

--- a/lib/levanter/tests/grug/test_loss.py
+++ b/lib/levanter/tests/grug/test_loss.py
@@ -1,0 +1,160 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from typing import cast
+
+import numpy as np
+import pytest
+
+import jax
+import jax.numpy as jnp
+from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+from levanter.grug import loss as grug_loss
+from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
+
+
+def _reference_linear_cross_entropy(
+    hidden: jax.Array,
+    lm_head: jax.Array,
+    labels: jax.Array,
+    weight: jax.Array,
+    *,
+    reduction: str,
+    logsumexp_weight: float | None = None,
+) -> jax.Array:
+    flat_hidden = hidden.reshape((-1, hidden.shape[-1]))
+    flat_labels = labels.reshape((-1,)).astype(jnp.int32)
+    flat_weight = weight.reshape((-1,))
+    logits = flat_hidden @ lm_head
+    logsumexp = jax.nn.logsumexp(logits, axis=-1)
+    label_logits = logits[jnp.arange(flat_labels.shape[0]), flat_labels]
+    loss = logsumexp - label_logits
+    if logsumexp_weight is not None and logsumexp_weight != 0.0:
+        loss = loss + logsumexp_weight * (logsumexp**2)
+    loss = loss * flat_weight.astype(loss.dtype)
+
+    if reduction == "none":
+        return loss.reshape(labels.shape)
+    if reduction == "sum":
+        return jnp.sum(loss)
+    if reduction == "mean":
+        denom = jnp.sum(flat_weight)
+        return jnp.where(denom != 0, jnp.sum(loss) / denom, jnp.zeros_like(denom))
+    raise ValueError(f"Unknown reduction: {reduction}")
+
+
+@pytest.mark.parametrize("reduction", ["none", "sum", "mean"])
+def test_fused_linear_softmax_cross_entropy_loss_matches_reference_without_mesh(reduction: str):
+    hidden = jnp.linspace(-0.7, 0.9, 2 * 3 * 4, dtype=jnp.float32).reshape((2, 3, 4))
+    lm_head = jnp.linspace(-0.4, 0.6, 4 * 7, dtype=jnp.float32).reshape((4, 7))
+    labels = jnp.array([[0, 2, 6], [4, 1, 3]], dtype=jnp.int32)
+    weight = jnp.array([[1.0, 0.5, 1.0], [0.25, 0.0, 1.0]], dtype=jnp.float32)
+
+    actual = fused_linear_softmax_cross_entropy_loss(
+        hidden,
+        lm_head,
+        labels,
+        weight=weight,
+        reduction=reduction,
+        logsumexp_weight=0.01,
+        implementation="xla",
+    )
+    expected = _reference_linear_cross_entropy(
+        hidden,
+        lm_head,
+        labels,
+        weight,
+        reduction=reduction,
+        logsumexp_weight=0.01,
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
+
+
+def test_xla_cross_entropy_model_sharded_vocab_matches_reference_and_gradients():
+    devices = jax.devices()
+    if len(devices) < 2:
+        pytest.skip("requires at least two devices; run with XLA_FLAGS=--xla_force_host_platform_device_count=2")
+
+    hidden = jnp.linspace(-0.8, 0.7, 2 * 3 * 4, dtype=jnp.float32).reshape((2, 3, 4))
+    lm_head = jnp.linspace(-0.5, 0.4, 4 * 8, dtype=jnp.float32).reshape((4, 8))
+    labels = jnp.array([[0, 3, 7], [6, 1, 4]], dtype=jnp.int32)
+    weight = jnp.array([[1.0, 0.25, 1.0], [0.5, 0.0, 1.0]], dtype=jnp.float32)
+
+    mesh = Mesh(
+        np.array(devices[:2], dtype=object).reshape((1, 2)),
+        ("data", "model"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit),
+    )
+
+    def sharded_loss(hidden_value: jax.Array, lm_head_value: jax.Array) -> jax.Array:
+        return fused_linear_softmax_cross_entropy_loss(
+            hidden_value,
+            lm_head_value,
+            labels_sharded,
+            weight=weight_sharded,
+            reduction="mean",
+            logsumexp_weight=0.02,
+            implementation="xla",
+        )
+
+    def reference_loss(hidden_value: jax.Array, lm_head_value: jax.Array) -> jax.Array:
+        return _reference_linear_cross_entropy(
+            hidden_value,
+            lm_head_value,
+            labels,
+            weight,
+            reduction="mean",
+            logsumexp_weight=0.02,
+        )
+
+    with jax.set_mesh(mesh):
+        hidden_sharded = jax.device_put(hidden, NamedSharding(mesh, P("data", None, None)))
+        labels_sharded = jax.device_put(labels, NamedSharding(mesh, P("data", None)))
+        weight_sharded = jax.device_put(weight, NamedSharding(mesh, P("data", None)))
+        lm_head_sharded = jax.device_put(lm_head, NamedSharding(mesh, P(None, "model")))
+
+        actual, (actual_hidden_grad, actual_lm_head_grad) = jax.jit(jax.value_and_grad(sharded_loss, argnums=(0, 1)))(
+            hidden_sharded, lm_head_sharded
+        )
+
+    expected, (expected_hidden_grad, expected_lm_head_grad) = jax.value_and_grad(reference_loss, argnums=(0, 1))(
+        hidden,
+        lm_head,
+    )
+
+    np.testing.assert_allclose(actual, expected, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(actual_hidden_grad, expected_hidden_grad, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(actual_lm_head_grad, expected_lm_head_grad, rtol=1e-5, atol=1e-5)
+
+
+def test_lm_head_spec_tracks_effective_default_xla_backend(monkeypatch: pytest.MonkeyPatch):
+    class FakeMesh:
+        empty = False
+        shape = {"model": 2}
+
+    lm_head = jnp.zeros((4, 8), dtype=jnp.float32)
+
+    mesh = cast(jax.sharding.AbstractMesh, FakeMesh())
+
+    monkeypatch.setattr(grug_loss, "default_implementations", lambda: ("xla",))
+    assert grug_loss._lm_head_spec_for_xla_ce(lm_head, mesh, None) == P(None, "model")
+
+    monkeypatch.setattr(grug_loss, "default_implementations", lambda: ("pallas_gpu", "xla"))
+    assert grug_loss._lm_head_spec_for_xla_ce(lm_head, mesh, None) == P(None, "model")
+
+
+def test_lm_head_spec_does_not_vocab_shard_when_model_axis_is_one(monkeypatch: pytest.MonkeyPatch):
+    class FakeMesh:
+        empty = False
+        shape = {"model": 1}
+
+    lm_head = jnp.zeros((2560, 128_256), dtype=jnp.bfloat16)
+    mesh = cast(jax.sharding.AbstractMesh, FakeMesh())
+
+    assert grug_loss._lm_head_spec_for_xla_ce(lm_head, mesh, "xla") == P(None, None)
+    assert grug_loss._lm_head_spec_for_xla_ce(lm_head, mesh, "pallas_gpu") == P(None, None)
+
+    monkeypatch.setattr(grug_loss, "default_implementations", lambda: ("pallas_gpu", "xla"))
+    assert grug_loss._lm_head_spec_for_xla_ce(lm_head, mesh, None) == P(None, None)

--- a/lib/levanter/tests/grug/test_loss.py
+++ b/lib/levanter/tests/grug/test_loss.py
@@ -129,6 +129,39 @@ def test_xla_cross_entropy_model_sharded_vocab_matches_reference_and_gradients()
     np.testing.assert_allclose(actual_lm_head_grad, expected_lm_head_grad, rtol=1e-5, atol=1e-5)
 
 
+def test_vocab_sharded_ce_falls_back_to_xla_after_pallas_gpu_failure(monkeypatch: pytest.MonkeyPatch):
+    flat_hidden = jnp.linspace(-0.4, 0.5, 3 * 4, dtype=jnp.float32).reshape((3, 4))
+    lm_head = jnp.linspace(-0.3, 0.7, 4 * 5, dtype=jnp.float32).reshape((4, 5))
+    labels = jnp.array([0, 2, 4], dtype=jnp.int32)
+
+    def failing_pallas_gpu(*args, **kwargs):
+        del args, kwargs
+        raise RuntimeError("synthetic pallas failure")
+
+    monkeypatch.setitem(grug_loss.IMPLEMENTATIONS, "pallas_gpu", failing_pallas_gpu)
+
+    with pytest.warns(RuntimeWarning, match="falling back to xla"):
+        actual_loss, actual_lse = grug_loss._local_linear_softmax_cross_entropy_loss(
+            flat_hidden,
+            labels,
+            lm_head,
+            dtype=jnp.float32,
+            precision=None,
+            implementation=("pallas_gpu", "xla"),
+        )
+    expected_loss, expected_lse = grug_loss._local_linear_softmax_cross_entropy_loss(
+        flat_hidden,
+        labels,
+        lm_head,
+        dtype=jnp.float32,
+        precision=None,
+        implementation="xla",
+    )
+
+    np.testing.assert_allclose(actual_loss, expected_loss, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(actual_lse, expected_lse, rtol=1e-5, atol=1e-5)
+
+
 def test_lm_head_spec_tracks_effective_default_ce_backend(monkeypatch: pytest.MonkeyPatch):
     class FakeMesh:
         empty = False

--- a/lib/levanter/tests/grug/test_loss.py
+++ b/lib/levanter/tests/grug/test_loss.py
@@ -129,7 +129,7 @@ def test_xla_cross_entropy_model_sharded_vocab_matches_reference_and_gradients()
     np.testing.assert_allclose(actual_lm_head_grad, expected_lm_head_grad, rtol=1e-5, atol=1e-5)
 
 
-def test_lm_head_spec_tracks_effective_default_xla_backend(monkeypatch: pytest.MonkeyPatch):
+def test_lm_head_spec_tracks_effective_default_ce_backend(monkeypatch: pytest.MonkeyPatch):
     class FakeMesh:
         empty = False
         shape = {"model": 2}
@@ -139,10 +139,10 @@ def test_lm_head_spec_tracks_effective_default_xla_backend(monkeypatch: pytest.M
     mesh = cast(jax.sharding.AbstractMesh, FakeMesh())
 
     monkeypatch.setattr(grug_loss, "default_implementations", lambda: ("xla",))
-    assert grug_loss._lm_head_spec_for_xla_ce(lm_head, mesh, None) == P(None, "model")
+    assert grug_loss._lm_head_spec_for_ce(lm_head, mesh, None) == P(None, "model")
 
     monkeypatch.setattr(grug_loss, "default_implementations", lambda: ("pallas_gpu", "xla"))
-    assert grug_loss._lm_head_spec_for_xla_ce(lm_head, mesh, None) == P(None, "model")
+    assert grug_loss._lm_head_spec_for_ce(lm_head, mesh, None) == P(None, "model")
 
 
 def test_lm_head_spec_does_not_vocab_shard_when_model_axis_is_one(monkeypatch: pytest.MonkeyPatch):
@@ -153,8 +153,8 @@ def test_lm_head_spec_does_not_vocab_shard_when_model_axis_is_one(monkeypatch: p
     lm_head = jnp.zeros((2560, 128_256), dtype=jnp.bfloat16)
     mesh = cast(jax.sharding.AbstractMesh, FakeMesh())
 
-    assert grug_loss._lm_head_spec_for_xla_ce(lm_head, mesh, "xla") == P(None, None)
-    assert grug_loss._lm_head_spec_for_xla_ce(lm_head, mesh, "pallas_gpu") == P(None, None)
+    assert grug_loss._lm_head_spec_for_ce(lm_head, mesh, "xla") == P(None, None)
+    assert grug_loss._lm_head_spec_for_ce(lm_head, mesh, "pallas_gpu") == P(None, None)
 
     monkeypatch.setattr(grug_loss, "default_implementations", lambda: ("pallas_gpu", "xla"))
-    assert grug_loss._lm_head_spec_for_xla_ce(lm_head, mesh, None) == P(None, None)
+    assert grug_loss._lm_head_spec_for_ce(lm_head, mesh, None) == P(None, None)

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -1006,58 +1006,6 @@ def test_pallas_gpu_h100_large_vocab_custom_backward_uses_large_v_block(
     assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 8192
 
 
-def test_pallas_gpu_h100_large_vocab_custom_backward_dispatches_large_v_block(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
-
-    captured_v_blocks: list[int] = []
-
-    def fake_forward_impl(x_arg, labels_arg, w_arg, **_kwargs):
-        del labels_arg, w_arg
-        return jnp.zeros((x_arg.shape[0],), dtype=jnp.float32), jnp.ones((x_arg.shape[0],), dtype=jnp.float32)
-
-    def fake_backward_from_lse(
-        x_arg,
-        labels_arg,
-        w_arg,
-        lse_arg,
-        g_loss_arg,
-        g_lse_arg,
-        *,
-        v_block_size,
-        logit_soft_cap,
-        precision,
-    ):
-        del labels_arg, lse_arg, g_loss_arg, g_lse_arg, logit_soft_cap, precision
-        captured_v_blocks.append(v_block_size)
-        return jnp.zeros_like(x_arg), jnp.zeros_like(w_arg)
-
-    monkeypatch.setattr(pallas_gpu, "_linear_softmax_cross_entropy_loss_pallas_gpu_impl", fake_forward_impl)
-    monkeypatch.setattr(pallas_gpu, "_backward_streaming_from_lse", fake_backward_from_lse)
-
-    x = jnp.ones((1024, 16), dtype=jnp.bfloat16)
-    y = jnp.zeros((1024,), dtype=jnp.int32)
-    w = jnp.ones((16, 65536), dtype=jnp.bfloat16)
-    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
-
-    def loss_fn(x_arg: jax.Array, w_arg: jax.Array) -> jax.Array:
-        loss, _ = pallas_gpu._linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward(
-            x_arg,
-            y,
-            w_arg,
-            block_sizes,
-            jnp.float32,
-            None,
-            None,
-        )
-        return loss.sum()
-
-    jax.grad(loss_fn, argnums=(0, 1))(x, w)
-
-    assert captured_v_blocks == [8192]
-
-
 @pytest.mark.parametrize(
     ("device_kind", "x_dtype", "w_dtype", "vocab_size"),
     [

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -10,6 +10,7 @@ import pytest
 
 from levanter.kernels.pallas import autotune_cache_utils
 from levanter.kernels.pallas.fused_cross_entropy_loss import api as fused_api
+from levanter.kernels.pallas.fused_cross_entropy_loss import gpu_launch_limits
 from levanter.kernels.pallas.fused_cross_entropy_loss import pallas_tpu
 from levanter.kernels.pallas.fused_cross_entropy_loss import pallas_gpu
 from levanter.kernels.pallas.fused_cross_entropy_loss import tuned_block_sizes
@@ -338,14 +339,7 @@ def test_fused_cross_entropy_xla_caps_requested_batch_block_size_to_legal_diviso
     assert captured == {"block_size": 4, "batch_block_size": 6}
 
 
-@pytest.mark.parametrize(
-    ("tuned_batch_block_size", "has_tuned_match", "expected_batch_block_size"),
-    [(3, True, 3), (2, False, 2)],
-)
-def test_fused_cross_entropy_xla_infer_uses_preferred_batch_block_size(
-    tuned_batch_block_size: int,
-    has_tuned_match: bool,
-    expected_batch_block_size: int,
+def test_fused_cross_entropy_xla_infer_uses_tuned_batch_block_size_when_available(
     monkeypatch: pytest.MonkeyPatch,
 ):
     x, w, y = _make_toy_inputs()
@@ -358,10 +352,7 @@ def test_fused_cross_entropy_xla_infer_uses_preferred_batch_block_size(
     monkeypatch.setattr(
         fused_xla,
         "infer_block_sizes_with_tuned_match",
-        lambda *args, **kwargs: (
-            fused_api.BlockSizes(b_block_size=tuned_batch_block_size, h_block_size=4, v_block_size=8),
-            has_tuned_match,
-        ),
+        lambda *args, **kwargs: (fused_api.BlockSizes(b_block_size=3, h_block_size=4, v_block_size=8), True),
     )
 
     def fake_custom_vjp(block_size, batch_block_size, dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg):
@@ -379,7 +370,7 @@ def test_fused_cross_entropy_xla_infer_uses_preferred_batch_block_size(
         dtype=jnp.float32,
     )
 
-    assert captured == {"block_size": 4, "batch_block_size": expected_batch_block_size}
+    assert captured == {"block_size": 4, "batch_block_size": 3}
 
 
 def test_fused_cross_entropy_xla_infer_falls_back_when_tuned_batch_block_size_is_unsafe(
@@ -523,8 +514,15 @@ def test_device_key_tpu_v5_lite_maps_to_v5e():
     assert tuned_block_sizes._device_key("TPU v5litepod") == "TPU v5e"
 
 
+def _assert_fits_nvidia_tile_budget(block_sizes: fused_api.BlockSizes, *, w_dtype: jnp.dtype) -> None:
+    weight_tile_bytes = block_sizes.h_block_size * block_sizes.v_block_size * jnp.dtype(w_dtype).itemsize
+    assert gpu_launch_limits.is_power_of_two(block_sizes.h_block_size)
+    assert gpu_launch_limits.is_power_of_two(block_sizes.v_block_size)
+    assert weight_tile_bytes <= gpu_launch_limits.NVIDIA_WEIGHT_TILE_BYTES_LIMIT
+
+
 @pytest.mark.parametrize("batch", [4096, 8192])
-def test_h100_d2560_pallas_gpu_block_sizes_fit_nvidia_tile_budget(batch: int, monkeypatch: pytest.MonkeyPatch):
+def test_h100_d2560_pallas_gpu_block_sizes_fit_nvidia_tile_budget(batch: int):
     block_sizes, has_tuned_match = tuned_block_sizes.infer_block_sizes_with_tuned_match(
         batch,
         2560,
@@ -535,19 +533,12 @@ def test_h100_d2560_pallas_gpu_block_sizes_fit_nvidia_tile_budget(batch: int, mo
         device_kind="NVIDIA H100",
     )
 
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
-
     assert has_tuned_match
     assert block_sizes.b_block_size == 256
-    pallas_gpu._validate_launch_feasibility(
-        w_dtype=jnp.float32,
-        h_block_size=block_sizes.h_block_size,
-        v_block_size=block_sizes.v_block_size,
-        num_h_blocks=2560 // block_sizes.h_block_size,
-    )
+    _assert_fits_nvidia_tile_budget(block_sizes, w_dtype=jnp.float32)
 
 
-def test_h100_d2560_model_sharded_vocab_block_sizes_fit_nvidia_tile_budget(monkeypatch: pytest.MonkeyPatch):
+def test_h100_d2560_model_sharded_vocab_block_sizes_fit_nvidia_tile_budget():
     block_sizes, has_tuned_match = tuned_block_sizes.infer_block_sizes_with_tuned_match(
         16_384,
         2560,
@@ -558,16 +549,9 @@ def test_h100_d2560_model_sharded_vocab_block_sizes_fit_nvidia_tile_budget(monke
         device_kind="NVIDIA H100",
     )
 
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
-
     assert not has_tuned_match
     assert block_sizes == fused_api.BlockSizes(b_block_size=1024, h_block_size=64, v_block_size=256)
-    pallas_gpu._validate_launch_feasibility(
-        w_dtype=jnp.bfloat16,
-        h_block_size=block_sizes.h_block_size,
-        v_block_size=block_sizes.v_block_size,
-        num_h_blocks=2560 // block_sizes.h_block_size,
-    )
+    _assert_fits_nvidia_tile_budget(block_sizes, w_dtype=jnp.bfloat16)
 
 
 def test_pallas_tpu_backward_uses_pallas_by_default(monkeypatch):
@@ -990,44 +974,6 @@ def test_fused_cross_entropy_pallas_gpu_grad_tracing_non_gb10_path(
         return loss.sum()
 
     jax.make_jaxpr(jax.grad(loss_fn, argnums=(0, 1)))(x, w)
-
-
-@pytest.mark.parametrize("batch", [4096, 32768])
-def test_pallas_gpu_h100_large_vocab_custom_backward_uses_large_v_block(
-    batch: int,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
-
-    x = jax.ShapeDtypeStruct((batch, 2560), dtype=jnp.bfloat16)
-    w = jax.ShapeDtypeStruct((2560, 128256), dtype=jnp.bfloat16)
-    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
-
-    assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 8192
-
-
-@pytest.mark.parametrize(
-    ("device_kind", "x_dtype", "w_dtype", "vocab_size"),
-    [
-        ("nvidia h100", jnp.bfloat16, jnp.bfloat16, 32000),
-        ("nvidia a100", jnp.bfloat16, jnp.bfloat16, 128256),
-        ("nvidia h100", jnp.float32, jnp.float32, 128256),
-    ],
-)
-def test_pallas_gpu_custom_backward_uses_block_size_when_large_h100_tile_does_not_apply(
-    device_kind: str,
-    x_dtype: jnp.dtype,
-    w_dtype: jnp.dtype,
-    vocab_size: int,
-    monkeypatch: pytest.MonkeyPatch,
-):
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: device_kind)
-
-    x = jax.ShapeDtypeStruct((4096, 2560), dtype=x_dtype)
-    w = jax.ShapeDtypeStruct((2560, vocab_size), dtype=w_dtype)
-    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
-
-    assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 256
 
 
 def test_pallas_autotune_used_when_tuned_match_missing(monkeypatch: pytest.MonkeyPatch):

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -372,6 +372,40 @@ def test_fused_cross_entropy_xla_infer_uses_tuned_batch_block_size_when_availabl
     assert captured == {"block_size": 4, "batch_block_size": 3}
 
 
+def test_fused_cross_entropy_xla_infer_uses_default_batch_block_size_without_tuned_match(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    x, w, y = _make_toy_inputs()
+    x = x.reshape(6, 4)
+    y = y.reshape(6)
+    captured: dict[str, int] = {}
+
+    monkeypatch.setattr(fused_xla, "infer_xla_v_block_size", lambda b, h, v, dtype: 4)
+    monkeypatch.setattr(fused_xla, "infer_xla_b_block_size", lambda b, v_block_size: 6)
+    monkeypatch.setattr(
+        fused_xla,
+        "infer_block_sizes_with_tuned_match",
+        lambda *args, **kwargs: (fused_api.BlockSizes(b_block_size=2, h_block_size=4, v_block_size=8), False),
+    )
+
+    def fake_custom_vjp(block_size, batch_block_size, dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg):
+        del dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg
+        captured["block_size"] = block_size
+        captured["batch_block_size"] = batch_block_size
+        return jnp.zeros((6,), dtype=jnp.float32), jnp.zeros((6,), dtype=jnp.float32)
+
+    monkeypatch.setattr(fused_xla, "_linear_softmax_cross_entropy_loss_streaming_custom_vjp", fake_custom_vjp)
+
+    fused_xla.linear_softmax_cross_entropy_loss_xla(
+        x,
+        y,
+        w,
+        dtype=jnp.float32,
+    )
+
+    assert captured == {"block_size": 4, "batch_block_size": 2}
+
+
 def test_fused_cross_entropy_xla_infer_falls_back_when_tuned_batch_block_size_is_unsafe(
     monkeypatch: pytest.MonkeyPatch,
 ):
@@ -511,6 +545,53 @@ def test_infer_num_tensorcores_uses_device_kind(monkeypatch):
 def test_device_key_tpu_v5_lite_maps_to_v5e():
     assert tuned_block_sizes._device_key("TPU v5 lite") == "TPU v5e"
     assert tuned_block_sizes._device_key("TPU v5litepod") == "TPU v5e"
+
+
+@pytest.mark.parametrize("batch", [4096, 8192])
+def test_h100_d2560_pallas_gpu_block_sizes_fit_nvidia_tile_budget(batch: int, monkeypatch: pytest.MonkeyPatch):
+    block_sizes, has_tuned_match = tuned_block_sizes.infer_block_sizes_with_tuned_match(
+        batch,
+        2560,
+        128256,
+        dtype=jnp.float32,
+        x_dtype=jnp.bfloat16,
+        w_dtype=jnp.bfloat16,
+        device_kind="NVIDIA H100",
+    )
+
+    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
+
+    assert has_tuned_match
+    assert block_sizes.b_block_size == 256
+    pallas_gpu._validate_launch_feasibility(
+        w_dtype=jnp.float32,
+        h_block_size=block_sizes.h_block_size,
+        v_block_size=block_sizes.v_block_size,
+        num_h_blocks=2560 // block_sizes.h_block_size,
+    )
+
+
+def test_h100_d2560_model_sharded_vocab_block_sizes_fit_nvidia_tile_budget(monkeypatch: pytest.MonkeyPatch):
+    block_sizes, has_tuned_match = tuned_block_sizes.infer_block_sizes_with_tuned_match(
+        16_384,
+        2560,
+        64_128,
+        dtype=jnp.float32,
+        x_dtype=jnp.bfloat16,
+        w_dtype=jnp.bfloat16,
+        device_kind="NVIDIA H100",
+    )
+
+    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
+
+    assert not has_tuned_match
+    assert block_sizes == fused_api.BlockSizes(b_block_size=1024, h_block_size=64, v_block_size=256)
+    pallas_gpu._validate_launch_feasibility(
+        w_dtype=jnp.bfloat16,
+        h_block_size=block_sizes.h_block_size,
+        v_block_size=block_sizes.v_block_size,
+        num_h_blocks=2560 // block_sizes.h_block_size,
+    )
 
 
 def test_pallas_tpu_backward_uses_pallas_by_default(monkeypatch):
@@ -822,6 +903,41 @@ def test_fused_cross_entropy_pallas_gpu_requires_gpu():
         )
 
 
+def test_pallas_gpu_backward_streaming_from_lse_matches_reference_gradients():
+    if jax.default_backend() == "tpu":
+        pytest.skip("pallas_gpu custom backward helper is covered by CPU/GPU precision paths")
+
+    key = jax.random.PRNGKey(17)
+    key_x, key_w, key_y, key_loss, key_lse = jax.random.split(key, 5)
+    x = jax.random.normal(key_x, (5, 3), dtype=jnp.float32)
+    w = jax.random.normal(key_w, (3, 10), dtype=jnp.float32)
+    y = jax.random.randint(key_y, (5,), 0, 10, dtype=jnp.int32)
+    g_loss = jax.random.normal(key_loss, (5,), dtype=jnp.float32)
+    g_lse = jax.random.normal(key_lse, (5,), dtype=jnp.float32)
+
+    _, lse = linear_softmax_cross_entropy_loss_reference(x, y, w, dtype=jnp.float32)
+
+    def reference_cotangent_loss(x_raw: jax.Array, w_raw: jax.Array) -> jax.Array:
+        loss, logsumexp = linear_softmax_cross_entropy_loss_reference(x_raw, y, w_raw, dtype=jnp.float32)
+        return jnp.sum(loss * g_loss + logsumexp * g_lse)
+
+    expected_x, expected_w = jax.grad(reference_cotangent_loss, argnums=(0, 1))(x, w)
+    actual_x, actual_w = pallas_gpu._backward_streaming_from_lse(
+        x,
+        y,
+        w,
+        lse,
+        g_loss,
+        g_lse,
+        v_block_size=4,
+        logit_soft_cap=None,
+        precision=None,
+    )
+
+    np.testing.assert_allclose(actual_x, expected_x, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(actual_w, expected_w, rtol=1e-5, atol=1e-5)
+
+
 def test_fused_cross_entropy_pallas_gpu_custom_backward_grad_matches_xla():
     if jax.default_backend() != "gpu":
         pytest.skip("requires GPU backend")
@@ -898,6 +1014,118 @@ def test_fused_cross_entropy_pallas_gpu_grad_tracing_non_gb10_path(
         return loss.sum()
 
     jax.make_jaxpr(jax.grad(loss_fn, argnums=(0, 1)))(x, w)
+
+
+@pytest.mark.parametrize("batch", [4096, 32768])
+def test_pallas_gpu_h100_large_vocab_custom_backward_uses_large_v_block(
+    batch: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", raising=False)
+    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
+
+    x = jax.ShapeDtypeStruct((batch, 2560), dtype=jnp.bfloat16)
+    w = jax.ShapeDtypeStruct((2560, 128256), dtype=jnp.bfloat16)
+    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
+
+    assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 8192
+
+
+def test_pallas_gpu_h100_large_vocab_custom_backward_dispatches_large_v_block(
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.delenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", raising=False)
+    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
+
+    captured_v_blocks: list[int] = []
+
+    def fake_forward_impl(x_arg, labels_arg, w_arg, **_kwargs):
+        del labels_arg, w_arg
+        return jnp.zeros((x_arg.shape[0],), dtype=jnp.float32), jnp.ones((x_arg.shape[0],), dtype=jnp.float32)
+
+    def fake_backward_from_lse(
+        x_arg,
+        labels_arg,
+        w_arg,
+        lse_arg,
+        g_loss_arg,
+        g_lse_arg,
+        *,
+        v_block_size,
+        logit_soft_cap,
+        precision,
+    ):
+        del labels_arg, lse_arg, g_loss_arg, g_lse_arg, logit_soft_cap, precision
+        captured_v_blocks.append(v_block_size)
+        return jnp.zeros_like(x_arg), jnp.zeros_like(w_arg)
+
+    monkeypatch.setattr(pallas_gpu, "_linear_softmax_cross_entropy_loss_pallas_gpu_impl", fake_forward_impl)
+    monkeypatch.setattr(pallas_gpu, "_backward_streaming_from_lse", fake_backward_from_lse)
+
+    x = jnp.ones((1024, 16), dtype=jnp.bfloat16)
+    y = jnp.zeros((1024,), dtype=jnp.int32)
+    w = jnp.ones((16, 65536), dtype=jnp.bfloat16)
+    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
+
+    def loss_fn(x_arg: jax.Array, w_arg: jax.Array) -> jax.Array:
+        loss, _ = pallas_gpu._linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward(
+            x_arg,
+            y,
+            w_arg,
+            block_sizes,
+            jnp.float32,
+            None,
+            None,
+        )
+        return loss.sum()
+
+    jax.grad(loss_fn, argnums=(0, 1))(x, w)
+
+    assert captured_v_blocks == [8192]
+
+
+def test_pallas_gpu_custom_backward_env_override_wins(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.setenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", "4096")
+    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
+
+    x = jax.ShapeDtypeStruct((4096, 2560), dtype=jnp.bfloat16)
+    w = jax.ShapeDtypeStruct((2560, 128256), dtype=jnp.bfloat16)
+    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
+
+    assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 4096
+
+
+def test_pallas_gpu_custom_backward_small_vocab_uses_block_size(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", raising=False)
+    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
+
+    x = jax.ShapeDtypeStruct((4096, 2560), dtype=jnp.bfloat16)
+    w = jax.ShapeDtypeStruct((2560, 32000), dtype=jnp.bfloat16)
+    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
+
+    assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 256
+
+
+def test_pallas_gpu_custom_backward_non_h100_nvidia_uses_block_size(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", raising=False)
+    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia a100")
+
+    x = jax.ShapeDtypeStruct((4096, 2560), dtype=jnp.bfloat16)
+    w = jax.ShapeDtypeStruct((2560, 128256), dtype=jnp.bfloat16)
+    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
+
+    assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 256
+
+
+def test_pallas_gpu_custom_backward_float32_uses_block_size(monkeypatch: pytest.MonkeyPatch):
+    monkeypatch.delenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", raising=False)
+    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
+
+    x = jax.ShapeDtypeStruct((4096, 2560), dtype=jnp.float32)
+    w = jax.ShapeDtypeStruct((2560, 128256), dtype=jnp.float32)
+    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
+
+    assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 256
 
 
 def test_pallas_autotune_used_when_tuned_match_missing(monkeypatch: pytest.MonkeyPatch):

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -1180,6 +1180,64 @@ def test_pallas_tpu_autotune_sweeps_for_real_shard_map_tracers(monkeypatch: pyte
     assert faster in seen_block_sizes
 
 
+def test_fused_cross_entropy_vocab_sharded_weight_matches_reference_on_generic_axis():
+    devices = jax.devices()
+    if len(devices) < 2:
+        pytest.skip("requires at least two devices to exercise a sharded vocab axis")
+
+    partition_spec = jax.sharding.PartitionSpec
+    mesh = jax.sharding.Mesh(
+        np.array(devices[:2]),
+        ("tensor",),
+        axis_types=(jax.sharding.AxisType.Explicit,),
+    )
+    batch, hidden, vocab = 6, 8, 10
+    key = jax.random.PRNGKey(49)
+    key_x, key_w = jax.random.split(key)
+    x = jax.random.normal(key_x, (batch, hidden), dtype=jnp.float32)
+    w = jax.random.normal(key_w, (hidden, vocab), dtype=jnp.float32)
+    labels = jnp.array([0, 1, 4, 5, 8, 9], dtype=jnp.int32)
+    weight = jnp.array([1.0, 0.25, 0.5, 1.0, 0.75, 1.0], dtype=jnp.float32)
+    logsumexp_weight = 0.03
+
+    x_sharded = jax.device_put(x, jax.sharding.NamedSharding(mesh, partition_spec(None, None)))
+    labels_sharded = jax.device_put(labels, jax.sharding.NamedSharding(mesh, partition_spec(None)))
+    weight_sharded = jax.device_put(weight, jax.sharding.NamedSharding(mesh, partition_spec(None)))
+    w_sharded = jax.device_put(w, jax.sharding.NamedSharding(mesh, partition_spec(None, "tensor")))
+
+    loss, argmax = fused_api.fused_cross_entropy_loss_and_logsumexp_penalty(
+        x_sharded,
+        labels_sharded,
+        w_sharded,
+        reduction=None,
+        logsumexp_weight=logsumexp_weight,
+        implementation="xla",
+        return_argmax=True,
+    )
+    mean_loss = fused_api.fused_cross_entropy_loss_and_logsumexp_penalty(
+        x_sharded,
+        labels_sharded,
+        w_sharded,
+        reduction="mean",
+        weight=weight_sharded,
+        logsumexp_weight=logsumexp_weight,
+        implementation="xla",
+    )
+
+    ref_loss, ref_lse, ref_argmax = linear_softmax_cross_entropy_loss_reference(
+        x,
+        labels,
+        w,
+        return_argmax=True,
+    )
+    ref_loss = ref_loss + logsumexp_weight * (ref_lse**2)
+    ref_mean = jnp.sum(ref_loss * weight) / jnp.sum(weight)
+
+    assert jnp.allclose(loss, ref_loss, atol=1e-5, rtol=1e-5)
+    assert jnp.array_equal(argmax, ref_argmax)
+    assert jnp.allclose(mean_loss, ref_mean, atol=1e-5, rtol=1e-5)
+
+
 def test_pallas_tpu_vmem_compile_error_falls_back_to_xla_when_requested(monkeypatch: pytest.MonkeyPatch):
     x = jnp.ones((4, 8), dtype=jnp.float32)
     w = jnp.ones((8, 16), dtype=jnp.float32)

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -338,7 +338,14 @@ def test_fused_cross_entropy_xla_caps_requested_batch_block_size_to_legal_diviso
     assert captured == {"block_size": 4, "batch_block_size": 6}
 
 
-def test_fused_cross_entropy_xla_infer_uses_tuned_batch_block_size_when_available(
+@pytest.mark.parametrize(
+    ("tuned_batch_block_size", "has_tuned_match", "expected_batch_block_size"),
+    [(3, True, 3), (2, False, 2)],
+)
+def test_fused_cross_entropy_xla_infer_uses_preferred_batch_block_size(
+    tuned_batch_block_size: int,
+    has_tuned_match: bool,
+    expected_batch_block_size: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
     x, w, y = _make_toy_inputs()
@@ -351,7 +358,10 @@ def test_fused_cross_entropy_xla_infer_uses_tuned_batch_block_size_when_availabl
     monkeypatch.setattr(
         fused_xla,
         "infer_block_sizes_with_tuned_match",
-        lambda *args, **kwargs: (fused_api.BlockSizes(b_block_size=3, h_block_size=4, v_block_size=8), True),
+        lambda *args, **kwargs: (
+            fused_api.BlockSizes(b_block_size=tuned_batch_block_size, h_block_size=4, v_block_size=8),
+            has_tuned_match,
+        ),
     )
 
     def fake_custom_vjp(block_size, batch_block_size, dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg):
@@ -369,41 +379,7 @@ def test_fused_cross_entropy_xla_infer_uses_tuned_batch_block_size_when_availabl
         dtype=jnp.float32,
     )
 
-    assert captured == {"block_size": 4, "batch_block_size": 3}
-
-
-def test_fused_cross_entropy_xla_infer_uses_default_batch_block_size_without_tuned_match(
-    monkeypatch: pytest.MonkeyPatch,
-):
-    x, w, y = _make_toy_inputs()
-    x = x.reshape(6, 4)
-    y = y.reshape(6)
-    captured: dict[str, int] = {}
-
-    monkeypatch.setattr(fused_xla, "infer_xla_v_block_size", lambda b, h, v, dtype: 4)
-    monkeypatch.setattr(fused_xla, "infer_xla_b_block_size", lambda b, v_block_size: 6)
-    monkeypatch.setattr(
-        fused_xla,
-        "infer_block_sizes_with_tuned_match",
-        lambda *args, **kwargs: (fused_api.BlockSizes(b_block_size=2, h_block_size=4, v_block_size=8), False),
-    )
-
-    def fake_custom_vjp(block_size, batch_block_size, dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg):
-        del dtype, logit_soft_cap, precision, x_arg, labels_arg, w_arg
-        captured["block_size"] = block_size
-        captured["batch_block_size"] = batch_block_size
-        return jnp.zeros((6,), dtype=jnp.float32), jnp.zeros((6,), dtype=jnp.float32)
-
-    monkeypatch.setattr(fused_xla, "_linear_softmax_cross_entropy_loss_streaming_custom_vjp", fake_custom_vjp)
-
-    fused_xla.linear_softmax_cross_entropy_loss_xla(
-        x,
-        y,
-        w,
-        dtype=jnp.float32,
-    )
-
-    assert captured == {"block_size": 4, "batch_block_size": 2}
+    assert captured == {"block_size": 4, "batch_block_size": expected_batch_block_size}
 
 
 def test_fused_cross_entropy_xla_infer_falls_back_when_tuned_batch_block_size_is_unsafe(
@@ -1021,7 +997,6 @@ def test_pallas_gpu_h100_large_vocab_custom_backward_uses_large_v_block(
     batch: int,
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.delenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", raising=False)
     monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
 
     x = jax.ShapeDtypeStruct((batch, 2560), dtype=jnp.bfloat16)
@@ -1034,7 +1009,6 @@ def test_pallas_gpu_h100_large_vocab_custom_backward_uses_large_v_block(
 def test_pallas_gpu_h100_large_vocab_custom_backward_dispatches_large_v_block(
     monkeypatch: pytest.MonkeyPatch,
 ):
-    monkeypatch.delenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", raising=False)
     monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
 
     captured_v_blocks: list[int] = []
@@ -1084,45 +1058,25 @@ def test_pallas_gpu_h100_large_vocab_custom_backward_dispatches_large_v_block(
     assert captured_v_blocks == [8192]
 
 
-def test_pallas_gpu_custom_backward_env_override_wins(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.setenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", "4096")
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
+@pytest.mark.parametrize(
+    ("device_kind", "x_dtype", "w_dtype", "vocab_size"),
+    [
+        ("nvidia h100", jnp.bfloat16, jnp.bfloat16, 32000),
+        ("nvidia a100", jnp.bfloat16, jnp.bfloat16, 128256),
+        ("nvidia h100", jnp.float32, jnp.float32, 128256),
+    ],
+)
+def test_pallas_gpu_custom_backward_uses_block_size_when_large_h100_tile_does_not_apply(
+    device_kind: str,
+    x_dtype: jnp.dtype,
+    w_dtype: jnp.dtype,
+    vocab_size: int,
+    monkeypatch: pytest.MonkeyPatch,
+):
+    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: device_kind)
 
-    x = jax.ShapeDtypeStruct((4096, 2560), dtype=jnp.bfloat16)
-    w = jax.ShapeDtypeStruct((2560, 128256), dtype=jnp.bfloat16)
-    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
-
-    assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 4096
-
-
-def test_pallas_gpu_custom_backward_small_vocab_uses_block_size(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", raising=False)
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
-
-    x = jax.ShapeDtypeStruct((4096, 2560), dtype=jnp.bfloat16)
-    w = jax.ShapeDtypeStruct((2560, 32000), dtype=jnp.bfloat16)
-    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
-
-    assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 256
-
-
-def test_pallas_gpu_custom_backward_non_h100_nvidia_uses_block_size(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", raising=False)
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia a100")
-
-    x = jax.ShapeDtypeStruct((4096, 2560), dtype=jnp.bfloat16)
-    w = jax.ShapeDtypeStruct((2560, 128256), dtype=jnp.bfloat16)
-    block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
-
-    assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 256
-
-
-def test_pallas_gpu_custom_backward_float32_uses_block_size(monkeypatch: pytest.MonkeyPatch):
-    monkeypatch.delenv("LEVANTER_PALLAS_GPU_CUSTOM_BWD_V_BLOCK_SIZE", raising=False)
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
-
-    x = jax.ShapeDtypeStruct((4096, 2560), dtype=jnp.float32)
-    w = jax.ShapeDtypeStruct((2560, 128256), dtype=jnp.float32)
+    x = jax.ShapeDtypeStruct((4096, 2560), dtype=x_dtype)
+    w = jax.ShapeDtypeStruct((2560, vocab_size), dtype=w_dtype)
     block_sizes = fused_api.BlockSizes(b_block_size=256, h_block_size=64, v_block_size=256)
 
     assert pallas_gpu._custom_backward_v_block_size(x, w, block_sizes) == 256

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -1233,9 +1233,9 @@ def test_fused_cross_entropy_vocab_sharded_weight_matches_reference_on_generic_a
     ref_loss = ref_loss + logsumexp_weight * (ref_lse**2)
     ref_mean = jnp.sum(ref_loss * weight) / jnp.sum(weight)
 
-    assert jnp.allclose(loss, ref_loss, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(loss, ref_loss, atol=3e-4, rtol=1e-4)
     assert jnp.array_equal(argmax, ref_argmax)
-    assert jnp.allclose(mean_loss, ref_mean, atol=1e-5, rtol=1e-5)
+    np.testing.assert_allclose(mean_loss, ref_mean, atol=3e-4, rtol=1e-4)
 
 
 def test_pallas_tpu_vmem_compile_error_falls_back_to_xla_when_requested(monkeypatch: pytest.MonkeyPatch):


### PR DESCRIPTION
Add vocab-sharded fused linear softmax cross-entropy support for Grug so the LM head can shard over the model axis when using the XLA or Pallas GPU fused CE backends.

This also carries the fused CE kernel tuning needed for the extracted path: backend-aware NVIDIA tile sanitization, H100 large-vocab custom-backward block sizing, shared GPU launch-limit helpers, and tuned-table coverage for D2560 medium-hidden large-vocab shapes.