### PR TITLE
[rigging] Add IAP token output for command-line clients

### DIFF
--- a/lib/finelog/OPS.md
+++ b/lib/finelog/OPS.md
@@ -1,0 +1,39 @@
+# Finelog Operations
+
+## Access through the Iris IAP endpoint
+
+The Iris controller exposes its finelog server as the `/system/log-server`
+endpoint. For `iris-marin.oa.dev`, the public path prefix is
+`https://iris-marin.oa.dev/proxy/system.log-server/`.
+
+Authenticate once with the desktop OAuth client registered as an IAP
+programmatic client:
+
+```bash
+uv run marin-login login marin --client-secrets /path/to/desktop.json
+```
+
+The command stores a refresh token in `~/.config/marin/iap/marin.json`.
+`print-token` uses that refresh token to mint a short-lived ID token without
+opening the browser again:
+
+```bash
+IAP_TOKEN="$(uv run marin-login print-token marin)"
+curl --fail-with-body \
+  --header "Proxy-Authorization: Bearer ${IAP_TOKEN}" \
+  https://iris-marin.oa.dev/proxy/system.log-server/health
+```
+
+IAP consumes `Proxy-Authorization`. Use `Authorization` separately if the
+target Iris route also requires an Iris JWT.
+
+The endpoint proxy replaces `/` in endpoint names with `.`. Use
+`system.log-server` for `/system/log-server`; `/proxy/system/finelog` addresses
+a different endpoint and does not reach finelog.
+
+The finelog CLI uses the same cached credentials when its deployment config
+sets `client_url`:
+
+```bash
+uv run finelog query marin 'SELECT * FROM "iris.profile" LIMIT 10'
+```

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -203,6 +203,36 @@ iris key create --name ci-bot         # create API key
 iris key list / iris key revoke       # manage API keys
 ```
 
+### Calling the IAP endpoint with `curl`
+
+Use the desktop OAuth client configured as an IAP programmatic client. The
+first command opens a browser and stores a long-lived refresh token in
+`~/.config/marin/iap/marin.json`:
+
+```bash
+uv run marin-login login marin --client-secrets /path/to/desktop.json
+```
+
+Mint a short-lived IAP ID token from the cached credentials and send it in
+`Proxy-Authorization`:
+
+```bash
+IAP_TOKEN="$(uv run marin-login print-token marin)"
+curl --fail-with-body \
+  --header "Proxy-Authorization: Bearer ${IAP_TOKEN}" \
+  https://iris-marin.oa.dev/proxy/system.log-server/health
+```
+
+`Proxy-Authorization` is reserved for IAP. Keep `Authorization` available for
+an Iris JWT when a controller route requires one. When
+`auth.iap.signed_header_audience` is configured, the controller accepts the
+identity assertion added by IAP and resolves the caller's Iris role by email.
+
+The path proxy encodes `/` in an endpoint name as `.`. The finelog endpoint
+`/system/log-server` is therefore `system.log-server` in the public URL.
+`/proxy/system/finelog` addresses an endpoint named `/system` with a `finelog`
+subpath and does not reach the controller's finelog server.
+
 ## Troubleshooting
 
 | Symptom | Diagnostic |

--- a/lib/rigging/src/rigging/iap_login.py
+++ b/lib/rigging/src/rigging/iap_login.py
@@ -78,7 +78,7 @@ def desktop_login(name: str, client_secrets_path: str, *, headless: bool = False
 
 def _login_hint(name: str) -> str:
     """The canonical 'run marin-login' remedy for endpoint ``name``."""
-    return f"run `marin-login {name} --client-secrets <desktop.json>` to authenticate"
+    return f"run `marin-login login {name} --client-secrets <desktop.json>` to authenticate"
 
 
 def provider_for(name: str) -> IapRefreshTokenProvider:

--- a/lib/rigging/src/rigging/iap_login_cli.py
+++ b/lib/rigging/src/rigging/iap_login_cli.py
@@ -1,22 +1,27 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""``marin-login`` — one IAP desktop-OAuth login, shared across Marin client tools.
+"""Manage IAP desktop-OAuth credentials shared across Marin client tools.
 
-Runs the browser consent flow (or a headless URL-paste flow when no browser is
-available) for an IAP-fronted cluster and caches the refresh token so any tool —
-``finelog query``, the iris CLI, a one-off script — can silently re-mint the
-OIDC ID token IAP requires.
+The login command runs the browser consent flow (or a headless URL-paste flow
+when no browser is available) and caches the refresh token. The print-token
+command silently mints an OIDC ID token for command-line HTTP clients.
 """
 
 import webbrowser
 
 import click
 
-from rigging.iap_login import credentials_path, desktop_login
+from rigging.auth import IapLoginRequired
+from rigging.iap_login import credentials_path, desktop_login, provider_for
 
 
-@click.command("marin-login")
+@click.group("marin-login")
+def main() -> None:
+    """Manage cached credentials for IAP-fronted Marin endpoints."""
+
+
+@main.command("login")
 @click.argument("name")
 @click.option(
     "--client-secrets",
@@ -25,7 +30,7 @@ from rigging.iap_login import credentials_path, desktop_login
     type=click.Path(exists=True, dir_okay=False),
     help="Path to the Google desktop OAuth client secret JSON.",
 )
-def main(name: str, client_secrets: str) -> None:
+def login(name: str, client_secrets: str) -> None:
     """Authenticate to an IAP-fronted Marin cluster and cache the refresh token.
 
     NAME is the logical cluster/endpoint that tools look up (e.g. 'marin').
@@ -42,6 +47,19 @@ def main(name: str, client_secrets: str) -> None:
 
     desktop_login(name, client_secrets, headless=headless)
     click.echo(f"Cached IAP credentials for '{name}' at {credentials_path(name)}")
+
+
+@main.command("print-token")
+@click.argument("name")
+def print_token(name: str) -> None:
+    """Print an IAP ID token minted from cached credentials for NAME."""
+    try:
+        token = provider_for(name).get_token()
+    except IapLoginRequired as exc:
+        raise click.ClickException(str(exc)) from exc
+    if token is None:
+        raise click.ClickException(f"IAP token provider returned no token for {name!r}")
+    click.echo(token)
 
 
 if __name__ == "__main__":

--- a/lib/rigging/tests/test_auth.py
+++ b/lib/rigging/tests/test_auth.py
@@ -200,9 +200,12 @@ def test_iap_refresh_token_provider_raises_login_required_when_refresh_fails(mon
     monkeypatch.setattr("google.auth.transport.requests.Request", lambda: object())
 
     provider = IapRefreshTokenProvider(
-        "client-id", "secret", "refresh-tok", login_hint="run `marin-login marin --client-secrets <desktop.json>`"
+        "client-id",
+        "secret",
+        "refresh-tok",
+        login_hint="run `marin-login login marin --client-secrets <desktop.json>`",
     )
 
     # The raw google-auth error becomes an actionable, self-contained IapLoginRequired.
-    with pytest.raises(IapLoginRequired, match="marin-login marin"):
+    with pytest.raises(IapLoginRequired, match="marin-login login marin"):
         provider.get_token()

--- a/lib/rigging/tests/test_iap_login.py
+++ b/lib/rigging/tests/test_iap_login.py
@@ -8,7 +8,7 @@ import webbrowser
 import pytest
 from click.testing import CliRunner
 from rigging import iap_login_cli
-from rigging.auth import IapLoginRequired
+from rigging.auth import IapLoginRequired, StaticTokenProvider
 from rigging.iap_login import (
     IapCredentials,
     credentials_path,
@@ -43,7 +43,7 @@ def test_load_missing_returns_none(home):
 
 
 def test_provider_for_missing_raises_with_login_hint(home):
-    with pytest.raises(IapLoginRequired, match="marin-login never-logged-in"):
+    with pytest.raises(IapLoginRequired, match="marin-login login never-logged-in"):
         provider_for("never-logged-in")
 
 
@@ -64,7 +64,7 @@ def test_provider_for_threads_cached_credentials_and_login_hint(home, monkeypatc
     assert captured["client_secret"] == "secret"
     assert captured["refresh_token"] == "rtok"
     # The provider carries a name-specific remedy for the refresh-failure path.
-    assert "marin-login marin" in captured["login_hint"]
+    assert "marin-login login marin" in captured["login_hint"]
 
 
 def test_desktop_login_caches_refresh_token(home, tmp_path, monkeypatch):
@@ -95,7 +95,7 @@ def test_desktop_login_rejects_web_client_secret(home, tmp_path):
         desktop_login("marin", str(secret_file))
 
 
-def test_cli_threads_args_and_detects_headless(home, tmp_path, monkeypatch):
+def test_cli_login_threads_args_and_detects_headless(home, tmp_path, monkeypatch):
     secret_file = tmp_path / "desktop.json"
     secret_file.write_text("{}")
 
@@ -109,7 +109,27 @@ def test_cli_threads_args_and_detects_headless(home, tmp_path, monkeypatch):
     # No browser on the box -> the CLI should pick the headless paste flow.
     monkeypatch.setattr("rigging.iap_login_cli.webbrowser.get", lambda *a: (_ for _ in ()).throw(webbrowser.Error()))
 
-    result = CliRunner().invoke(iap_login_cli.main, ["marin", "--client-secrets", str(secret_file)])
+    result = CliRunner().invoke(iap_login_cli.main, ["login", "marin", "--client-secrets", str(secret_file)])
 
     assert result.exit_code == 0, result.output
     assert captured == {"name": "marin", "client_secrets": str(secret_file), "headless": True}
+
+
+def test_cli_print_token_writes_only_token(monkeypatch):
+    def fake_provider(name: str) -> StaticTokenProvider:
+        assert name == "marin"
+        return StaticTokenProvider("iap-id-token")
+
+    monkeypatch.setattr("rigging.iap_login_cli.provider_for", fake_provider)
+
+    result = CliRunner().invoke(iap_login_cli.main, ["print-token", "marin"])
+
+    assert result.exit_code == 0, result.output
+    assert result.output == "iap-id-token\n"
+
+
+def test_cli_print_token_without_login_reports_login_command(home):
+    result = CliRunner().invoke(iap_login_cli.main, ["print-token", "marin"])
+
+    assert result.exit_code == 1
+    assert "marin-login login marin --client-secrets <desktop.json>" in result.output


### PR DESCRIPTION
Turn marin-login into a command group with login and print-token operations. print-token silently refreshes the cached desktop OAuth credentials and emits only the IAP ID token, making it safe to use in command substitution for curl and other HTTP clients.

Document the one-time login and Proxy-Authorization flow in the Iris and finelog operations guides, including the system.log-server endpoint encoding.