### PR TITLE
[ops] Add cost_manager: daily provider-cost pull into finelog

### DIFF
--- a/.github/workflows/ops-cost-report.yaml
+++ b/.github/workflows/ops-cost-report.yaml
@@ -1,0 +1,89 @@
+name: "Ops - Cost Report"
+
+# Daily provider-cost pull. Fetches a trailing window of API/cloud spend from
+# the configured backends (OpenAI, Anthropic, ... see scripts/cost_manager/
+# config.yaml) and writes one CostEvent row per (day, provider, category,
+# detail) into the finelog `cost.events` namespace.
+#
+# Writing to the marin finelog server requires reaching it; like the storage
+# report, this runner authenticates to GCP with the CI service account and
+# opens a gcloud SSH tunnel to the finelog VM (scripts/cost_manager opens the
+# tunnel internally from the `marin` finelog deploy config).
+
+on:
+  schedule:
+    - cron: '0 15 * * *'  # daily 15:00 UTC (after the egress report at 14:00)
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: 'Fetch and print only; do not write to finelog'
+        type: boolean
+        default: false
+      lookback_days:
+        description: 'Trailing UTC days to fetch (overrides config)'
+        type: number
+        required: false
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ops-cost-report
+  cancel-in-progress: false
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v5
+
+      - name: Set up Python
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+          cache-dependency-glob: "uv.lock"
+
+      - name: Sync uv environment
+        run: uv sync --all-packages --extra=cpu --no-default-groups
+
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
+
+      - name: Set up Google Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+        with:
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      # Required for the finelog SSH tunnel (gcloud compute ssh) — same as the
+      # storage report's controller tunnel.
+      - name: Install SSH key
+        env:
+          SSH_KEY: ${{ secrets.IRIS_CI_GCP_SSH_KEY }}
+          SSH_KEY_PUB: ${{ secrets.IRIS_CI_GCP_SSH_KEY_PUB }}
+        run: |
+          mkdir -p ~/.ssh
+          printf '%s\n' "$SSH_KEY" > ~/.ssh/google_compute_engine
+          printf '%s\n' "$SSH_KEY_PUB" > ~/.ssh/google_compute_engine.pub
+          chmod 600 ~/.ssh/google_compute_engine
+          chmod 644 ~/.ssh/google_compute_engine.pub
+
+      - name: Fetch and record costs
+        env:
+          # Provider credentials (see scripts/cost_manager/README.md). Missing
+          # keys fail only their own provider; the rest still record.
+          OPENAI_ADMIN_KEY: ${{ secrets.OPENAI_ADMIN_KEY }}
+          ANTHROPIC_ADMIN_KEY: ${{ secrets.ANTHROPIC_ADMIN_KEY }}
+          COREWEAVE_API_TOKEN: ${{ secrets.COREWEAVE_API_TOKEN }}
+        run: |
+          uv run python -m scripts.cost_manager.run \
+            ${{ inputs.dry_run && '--dry-run' || '' }} \
+            ${{ inputs.lookback_days && format('--lookback-days {0}', inputs.lookback_days) || '' }}

--- a/.github/workflows/ops-cost-report.yaml
+++ b/.github/workflows/ops-cost-report.yaml
@@ -83,6 +83,10 @@ jobs:
           OPENAI_ADMIN_KEY: ${{ secrets.OPENAI_ADMIN_KEY }}
           ANTHROPIC_ADMIN_KEY: ${{ secrets.ANTHROPIC_ADMIN_KEY }}
           COREWEAVE_API_TOKEN: ${{ secrets.COREWEAVE_API_TOKEN }}
+          # Optional: when a configured threshold (config.yaml `alerts`) is
+          # exceeded, the run posts to this webhook. Unset -> breach is logged
+          # only. Same secret the notify-slack action uses.
+          SLACK_WEBHOOK_URL: ${{ secrets.SLACK_WEBHOOK_URL }}
         run: |
           uv run python -m scripts.cost_manager.run \
             ${{ inputs.dry_run && '--dry-run' || '' }} \

--- a/lib/finelog/src/finelog/deploy/cli.py
+++ b/lib/finelog/src/finelog/deploy/cli.py
@@ -31,36 +31,14 @@ from rigging.auth import IapLoginRequired
 from rigging.connect import IapAuth, connect, disconnect
 from rigging.iap_login import provider_for
 from rigging.log_setup import configure_logging
-from rigging.tunnel import GcpSshForwardTarget, K8sPortForwardTarget, TunnelTarget, open_tunnel
+from rigging.tunnel import open_tunnel
 
 from finelog.client.log_client import LogClient
 from finelog.deploy import _gcp, _k8s
 from finelog.deploy.build import build_image as build_finelog_image
-from finelog.deploy.config import FinelogConfig, load_finelog_config
+from finelog.deploy.config import FinelogConfig, load_finelog_config, tunnel_target_for
 
 _SEGMENT_FILENAME_RE = re.compile(r"seg_L\d+_\d+\.parquet$")
-
-
-def _tunnel_target(cfg: FinelogConfig) -> TunnelTarget:
-    """Translate a finelog deployment block into a rigging tunnel target.
-
-    The GCP path forwards ``deployment.gcp.service_account`` as the SSH
-    impersonation principal — matching the deploy CLI's own SSH calls
-    (see ``_gcp._ssh_args``), so this command works wherever
-    ``finelog deploy status`` does.
-    """
-    if cfg.deployment.gcp is not None:
-        gcp = cfg.deployment.gcp
-        return GcpSshForwardTarget(
-            project=gcp.project,
-            zone=gcp.zone,
-            instance=cfg.name,
-            port=cfg.port,
-            impersonate_service_account=gcp.service_account,
-        )
-    assert cfg.deployment.k8s is not None
-    k8s = cfg.deployment.k8s
-    return K8sPortForwardTarget(namespace=k8s.namespace, service=cfg.name, port=cfg.port)
 
 
 @contextmanager
@@ -79,7 +57,7 @@ def _log_client(cfg: FinelogConfig, name: str, tunnel_timeout: float) -> Generat
             client.close()
             disconnect(client)
     else:
-        target = _tunnel_target(cfg)
+        target = tunnel_target_for(cfg)
         with open_tunnel(target, timeout=tunnel_timeout) as url:
             client = LogClient.connect(url)
             try:

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -17,6 +17,7 @@ from importlib.resources import files
 from pathlib import Path
 
 import yaml
+from rigging.tunnel import GcpSshForwardTarget, K8sPortForwardTarget, TunnelTarget
 
 USER_CONFIG_DIR = Path.home() / ".config" / "marin" / "finelog"
 
@@ -181,3 +182,24 @@ def derive_endpoint_uri(cfg: FinelogConfig) -> tuple[str, dict[str, str]]:
         f"k8s://{cfg.name}.{k8s.namespace}",
         {"port": str(cfg.port)},
     )
+
+
+def tunnel_target_for(cfg: FinelogConfig) -> TunnelTarget:
+    """Build a rigging tunnel target from a finelog deployment block.
+
+    The GCP path forwards ``deployment.gcp.service_account`` as the SSH
+    impersonation principal, matching the deploy CLI's own SSH calls, so this
+    target works wherever ``finelog deploy status`` does.
+    """
+    if cfg.deployment.gcp is not None:
+        gcp = cfg.deployment.gcp
+        return GcpSshForwardTarget(
+            project=gcp.project,
+            zone=gcp.zone,
+            instance=cfg.name,
+            port=cfg.port,
+            impersonate_service_account=gcp.service_account,
+        )
+    assert cfg.deployment.k8s is not None  # guaranteed by Deployment.__post_init__
+    k8s = cfg.deployment.k8s
+    return K8sPortForwardTarget(namespace=k8s.namespace, service=cfg.name, port=cfg.port)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -188,10 +188,11 @@ line-length = 121
 target-version = "py312"
 
 # Note :: Grow more strict over time!
-# Most of `scripts/**` is excluded until cleaned up, but `scripts/ci/**` holds
-# the scripts invoked directly by `.github/workflows` and stays under ruff.
+# Most of `scripts/**` is excluded until cleaned up, but `scripts/ci/**` and
+# `scripts/cost_manager/**` hold scripts invoked directly by `.github/workflows`
+# and stay under ruff.
 extend-exclude = ["scripts/"]
-extend-include = ["scripts/ci/**/*.py"]
+extend-include = ["scripts/ci/**/*.py", "scripts/cost_manager/**/*.py"]
 
 [tool.ruff.lint]
 # A,B,E,F,I,NPY,RUF,UP,W are the established families. The individually-listed
@@ -263,6 +264,7 @@ project-includes = [
     "lib/rigging/src/**/*.py",
     "lib/zephyr/src/**/*.py",
     "scripts/ci",
+    "scripts/cost_manager",
 ]
 
 # Explicitly tell Pyrefly where our editable packages live so it resolves imports

--- a/scripts/cost_manager/README.md
+++ b/scripts/cost_manager/README.md
@@ -1,0 +1,98 @@
+# cost_manager
+
+A daily job that pulls spend from our cost/billing providers and records it to
+finelog, so budget burn is visible next to job/throughput stats instead of in
+side services on personal VMs. It is the data-collection half of the
+"SREbots / cost-management" idea ([#6550], [#6464]): a follow-up agent reads the
+`cost.events` table (and can re-run this script) to flag unusual spend.
+
+## What it does
+
+For each enabled provider it fetches a trailing window of daily cost, normalizes
+every line item into a `CostEvent`, and appends the rows to the finelog
+`cost.events` namespace.
+
+```
+CostEvent:
+  ts            UTC midnight of the usage day (finelog ordering timestamp)
+  usage_date    "YYYY-MM-DD" UTC usage day
+  provider      openai | anthropic | gcp | coreweave
+  category      provider-natural grouping (api / a GCP service / compute / storage / ...)
+  detail        finer grain: model, line item, SKU, region, instance type
+  cost          amount in `currency`
+  currency      ISO code, e.g. USD
+  amount_kind   "billed" (from a cost API) or "estimated" (usage × rate card)
+  collected_ts  when this row was produced (one value per run)
+```
+
+### Re-runs and the "latest snapshot" read
+
+finelog is append-only and the current UTC day is always partial, so each run
+re-fetches a trailing window (`lookback_days`) and writes **fresh** rows;
+earlier partial days get corrected by later runs. Readers therefore take the
+newest row per logical key. The canonical query (also what the agent should
+use):
+
+```sql
+SELECT usage_date, provider, category, detail, cost, currency, amount_kind
+FROM (
+  SELECT *, ROW_NUMBER() OVER (
+    PARTITION BY usage_date, provider, category, detail ORDER BY seq DESC
+  ) AS rn
+  FROM "cost.events"
+)
+WHERE rn = 1
+ORDER BY usage_date DESC, provider, cost DESC;
+```
+
+## Providers and required secrets
+
+Secrets are passed via the environment only — `config.yaml` holds the env-var
+*names* (`*_env`), never values.
+
+| Provider | Source | Secret (env var) | Status |
+|----------|--------|------------------|--------|
+| **openai** | Costs API `GET /v1/organization/costs` | `OPENAI_ADMIN_KEY` | Works. Needs an **org Admin key** with the dashboard "Usage" permission — a project `sk-proj-…` key is rejected. |
+| **anthropic** | Admin Cost Report `GET /v1/organizations/cost_report` | `ANTHROPIC_ADMIN_KEY` | Works. Needs an **Admin key** (`sk-ant-admin01-…`). Amounts arrive in cents → converted to USD. |
+| **gcp** | BigQuery billing export (`bq query`) | none (ADC / runner SA) | Disabled by default. The Cloud Billing API exposes no spend; detailed cost lives only in the BigQuery export. The `hai-gcp-models` billing account is Stanford-managed, so its export dataset may be unreadable from CI — point `billing_export_table` at a readable dataset and set `enabled: true`. |
+| **coreweave** | Prometheus usage API (`observe.coreweave.com`) × rate card | `COREWEAVE_API_TOKEN` | Disabled by default, **estimate only**. CoreWeave has no dollar API; cost is `usage × rate_card` and tagged `amount_kind=estimated`. Fill in real `unit_rate`s and a token with the Observability Viewer role. |
+
+Adding a provider: drop a `fetch(config, window) -> list[CostEvent]` module in
+`backends/`, register it in `backends/__init__.py`, and add a block to
+`config.yaml`.
+
+## Running it
+
+```bash
+# Local smoke — fetch and print, never connect to finelog. Providers without a
+# key fail loudly (and only for themselves); the process exits non-zero.
+uv run python -m scripts.cost_manager.run --dry-run
+
+# One provider, custom window, against a finelog server you already tunneled to:
+uv run python -m scripts.cost_manager.run \
+  --provider openai --lookback-days 7 \
+  --finelog-url http://127.0.0.1:10001
+
+# Production shape — open the SSH/k8s tunnel from the 'marin' finelog config:
+OPENAI_ADMIN_KEY=… ANTHROPIC_ADMIN_KEY=… \
+  uv run python -m scripts.cost_manager.run
+```
+
+A single provider failing (missing key, auth/permission error) does not abort
+the run: the other backends still record, and the process exits non-zero so CI
+surfaces the failure.
+
+## In CI
+
+`.github/workflows/ops-cost-report.yaml` runs this daily at 15:00 UTC. It
+authenticates to GCP with the CI service account and opens a `gcloud` SSH tunnel
+to the finelog VM (the same mechanism as the storage report), then writes to
+`cost.events`. Required GitHub Actions secrets:
+
+- Tunnel (already configured for other ops jobs): `IRIS_CI_GCP_SA_KEY`,
+  `GCP_PROJECT_ID`, `IRIS_CI_GCP_SSH_KEY`, `IRIS_CI_GCP_SSH_KEY_PUB`.
+- Provider keys (add these): `OPENAI_ADMIN_KEY`, `ANTHROPIC_ADMIN_KEY`,
+  `COREWEAVE_API_TOKEN`.
+
+[#6550]: https://github.com/marin-community/marin/issues/6550
+[#6464]: https://github.com/marin-community/marin/issues/6464

--- a/scripts/cost_manager/README.md
+++ b/scripts/cost_manager/README.md
@@ -45,6 +45,34 @@ WHERE rn = 1
 ORDER BY usage_date DESC, provider, cost DESC;
 ```
 
+## Slack threshold alerts (optional)
+
+The `alerts` block in `config.yaml` defines spend ceilings. Each rule sums a
+cost slice — an optional `provider`/`category` filter — over a `window`
+(`latest_day`, the most recent complete UTC day, or `window_total`, the whole
+fetch window) and fires when that sum exceeds `max_usd`:
+
+```yaml
+alerts:
+  webhook_url_env: SLACK_WEBHOOK_URL   # env var holding the incoming-webhook URL
+  rules:
+    - name: total-daily          # no provider -> all providers combined
+      window: latest_day
+      max_usd: 500
+    - name: openai-daily
+      provider: openai
+      window: latest_day
+      max_usd: 200
+```
+
+Alerting is best-effort and fully optional: a breach is always logged at
+WARNING, but the Slack POST is skipped on `--dry-run` and when the webhook env
+var is unset, so local runs and environments without the secret stay silent. A
+POST failure is logged and never fails the run. The webhook (a standard Slack
+incoming webhook, same `{"text": …}` contract as the repo's `notify-slack`
+action) determines the channel — point `webhook_url_env` at a webhook bound to
+`#marin-eng`. Remove the `alerts` block (or its `rules`) to disable.
+
 ## Providers and required secrets
 
 Secrets are passed via the environment only — `config.yaml` holds the env-var
@@ -93,6 +121,8 @@ to the finelog VM (the same mechanism as the storage report), then writes to
   `GCP_PROJECT_ID`, `IRIS_CI_GCP_SSH_KEY`, `IRIS_CI_GCP_SSH_KEY_PUB`.
 - Provider keys (add these): `OPENAI_ADMIN_KEY`, `ANTHROPIC_ADMIN_KEY`,
   `COREWEAVE_API_TOKEN`.
+- Optional, for threshold alerts: `SLACK_WEBHOOK_URL` (already configured for
+  other ops jobs). Unset → threshold breaches are logged but not posted.
 
 [#6550]: https://github.com/marin-community/marin/issues/6550
 [#6464]: https://github.com/marin-community/marin/issues/6464

--- a/scripts/cost_manager/README.md
+++ b/scripts/cost_manager/README.md
@@ -54,7 +54,7 @@ Secrets are passed via the environment only — `config.yaml` holds the env-var
 |----------|--------|------------------|--------|
 | **openai** | Costs API `GET /v1/organization/costs` | `OPENAI_ADMIN_KEY` | Works. Needs an **org Admin key** with the dashboard "Usage" permission — a project `sk-proj-…` key is rejected. |
 | **anthropic** | Admin Cost Report `GET /v1/organizations/cost_report` | `ANTHROPIC_ADMIN_KEY` | Works. Needs an **Admin key** (`sk-ant-admin01-…`). Amounts arrive in cents → converted to USD. |
-| **gcp** | BigQuery billing export (`bq query`) | none (ADC / runner SA) | Disabled by default. The Cloud Billing API exposes no spend; detailed cost lives only in the BigQuery export. The `hai-gcp-models` billing account is Stanford-managed, so its export dataset may be unreadable from CI — point `billing_export_table` at a readable dataset and set `enabled: true`. |
+| **gcp** | BigQuery billing export (`bq query`) | none (ADC / runner SA) | Disabled by default. The Cloud Billing API exposes no actual spend; detailed cost lives only in the BigQuery export. Enable once `billing_export_table` points at an export dataset the runner's service account can read. |
 | **coreweave** | Prometheus usage API (`observe.coreweave.com`) × rate card | `COREWEAVE_API_TOKEN` | Disabled by default, **estimate only**. CoreWeave has no dollar API; cost is `usage × rate_card` and tagged `amount_kind=estimated`. Fill in real `unit_rate`s and a token with the Observability Viewer role. |
 
 Adding a provider: drop a `fetch(config, window) -> list[CostEvent]` module in

--- a/scripts/cost_manager/__init__.py
+++ b/scripts/cost_manager/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/scripts/cost_manager/backends/__init__.py
+++ b/scripts/cost_manager/backends/__init__.py
@@ -1,0 +1,25 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cost backends: one fetcher per provider, keyed by provider name.
+
+Each backend exposes ``fetch(config, window) -> list[CostEvent]`` where
+``config`` is the provider's block from ``config.yaml`` and secrets are read
+from the environment. Register a new provider by adding its module and an entry
+to :data:`BACKENDS`.
+"""
+
+from collections.abc import Callable, Mapping
+from typing import Any
+
+from scripts.cost_manager.backends import anthropic, coreweave, gcp, openai
+from scripts.cost_manager.cost_event import CostEvent, DateWindow
+
+ProviderFetcher = Callable[[Mapping[str, Any], DateWindow], list[CostEvent]]
+
+BACKENDS: dict[str, ProviderFetcher] = {
+    "openai": openai.fetch,
+    "anthropic": anthropic.fetch,
+    "gcp": gcp.fetch,
+    "coreweave": coreweave.fetch,
+}

--- a/scripts/cost_manager/backends/anthropic.py
+++ b/scripts/cost_manager/backends/anthropic.py
@@ -1,0 +1,116 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Anthropic organization costs.
+
+Reads the Anthropic Admin Cost Report API
+(``GET /v1/organizations/cost_report``). Requires an **Admin API key**
+(``sk-ant-admin01-...``); a standard key is rejected.
+
+Two gotchas baked in here:
+
+- ``amount`` is a decimal **string in the lowest currency unit** (USD cents),
+  so it is divided by 100 to get dollars.
+- bucket boundaries live on the bucket (``starting_at``), not inside each
+  result.
+
+Priority-tier spend is excluded from this endpoint (it is reported via the
+usage endpoint), so totals here track on-demand cost.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections.abc import Mapping
+from decimal import Decimal
+from typing import Any
+
+import requests
+
+from scripts.cost_manager.cost_event import CostEvent, CostFetchError, DateWindow, cost_event, require_env
+
+logger = logging.getLogger(__name__)
+
+COST_REPORT_URL = "https://api.anthropic.com/v1/organizations/cost_report"
+ANTHROPIC_VERSION = "2023-06-01"
+PROVIDER = "anthropic"
+# The cost endpoint caps a single page at 31 daily buckets.
+MAX_BUCKETS = 31
+# Amounts are reported in cents; convert to dollars.
+CENTS_PER_DOLLAR = Decimal(100)
+REQUEST_TIMEOUT = 30.0
+
+
+def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
+    api_key = require_env(
+        config.get("api_key_env", "ANTHROPIC_ADMIN_KEY"),
+        provider=PROVIDER,
+        purpose="organization Admin API key (sk-ant-admin01-...)",
+    )
+    base_url = config.get("base_url", COST_REPORT_URL)
+    group_by = list(config.get("group_by", ["description"]))
+
+    params: dict[str, Any] = {
+        "starting_at": _rfc3339(window.start_dt),
+        "ending_at": _rfc3339(window.end_exclusive_dt),
+        "bucket_width": "1d",
+        "limit": min(len(window.days()), MAX_BUCKETS),
+    }
+    if group_by:
+        params["group_by[]"] = group_by
+
+    headers = {"x-api-key": api_key, "anthropic-version": ANTHROPIC_VERSION}
+    session = requests.Session()
+    events: list[CostEvent] = []
+    page: str | None = None
+    while True:
+        if page:
+            params["page"] = page
+        payload = _get(session, base_url, headers, params)
+        events.extend(_buckets_to_events(payload.get("data", []) or []))
+        if not payload.get("has_more"):
+            break
+        page = payload.get("next_page")
+        if not page:
+            break
+    logger.info("anthropic: fetched %d cost rows for %s..%s", len(events), window.start, window.end)
+    return events
+
+
+def _rfc3339(when: dt.datetime) -> str:
+    return when.strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def _get(session: requests.Session, url: str, headers: dict[str, str], params: dict[str, Any]) -> dict[str, Any]:
+    response = session.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT)
+    if response.status_code in (401, 403):
+        raise CostFetchError(
+            f"anthropic: {response.status_code} from Cost Report API — the key is likely "
+            f"not an org Admin key: {response.text[:200]}"
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+def _buckets_to_events(buckets: list[dict[str, Any]]) -> list[CostEvent]:
+    events: list[CostEvent] = []
+    for bucket in buckets:
+        day = dt.datetime.fromisoformat(bucket["starting_at"]).astimezone(dt.UTC).date()
+        for result in bucket.get("results", []) or []:
+            raw_amount = result.get("amount")
+            if raw_amount is None:
+                continue
+            dollars = float(Decimal(str(raw_amount)) / CENTS_PER_DOLLAR)
+            detail = result.get("description") or result.get("model") or result.get("workspace_id") or "total"
+            events.append(
+                cost_event(
+                    provider=PROVIDER,
+                    day=day,
+                    category="api",
+                    detail=str(detail),
+                    cost=dollars,
+                    currency=str(result.get("currency", "USD")).upper(),
+                )
+            )
+    return events

--- a/scripts/cost_manager/backends/anthropic.py
+++ b/scripts/cost_manager/backends/anthropic.py
@@ -28,7 +28,8 @@ from typing import Any
 
 import requests
 
-from scripts.cost_manager.cost_event import CostEvent, CostFetchError, DateWindow, cost_event, require_env
+from scripts.cost_manager.backends import cost_api
+from scripts.cost_manager.cost_event import CostEvent, DateWindow, cost_event, require_env
 
 logger = logging.getLogger(__name__)
 
@@ -39,7 +40,6 @@ PROVIDER = "anthropic"
 MAX_BUCKETS = 31
 # Amounts are reported in cents; convert to dollars.
 CENTS_PER_DOLLAR = Decimal(100)
-REQUEST_TIMEOUT = 30.0
 
 
 def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
@@ -63,34 +63,22 @@ def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
     headers = {"x-api-key": api_key, "anthropic-version": ANTHROPIC_VERSION}
     session = requests.Session()
     events: list[CostEvent] = []
-    page: str | None = None
-    while True:
-        if page:
-            params["page"] = page
-        payload = _get(session, base_url, headers, params)
+    for payload in cost_api.paginate(
+        session,
+        base_url,
+        headers,
+        params,
+        provider=PROVIDER,
+        api_label="Cost Report API",
+        permission_hint="the key is likely not an org Admin key",
+    ):
         events.extend(_buckets_to_events(payload.get("data", []) or []))
-        if not payload.get("has_more"):
-            break
-        page = payload.get("next_page")
-        if not page:
-            break
     logger.info("anthropic: fetched %d cost rows for %s..%s", len(events), window.start, window.end)
     return events
 
 
 def _rfc3339(when: dt.datetime) -> str:
     return when.strftime("%Y-%m-%dT%H:%M:%SZ")
-
-
-def _get(session: requests.Session, url: str, headers: dict[str, str], params: dict[str, Any]) -> dict[str, Any]:
-    response = session.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT)
-    if response.status_code in (401, 403):
-        raise CostFetchError(
-            f"anthropic: {response.status_code} from Cost Report API — the key is likely "
-            f"not an org Admin key: {response.text[:200]}"
-        )
-    response.raise_for_status()
-    return response.json()
 
 
 def _buckets_to_events(buckets: list[dict[str, Any]]) -> list[CostEvent]:

--- a/scripts/cost_manager/backends/coreweave.py
+++ b/scripts/cost_manager/backends/coreweave.py
@@ -42,7 +42,7 @@ DEFAULT_STEP_SECONDS = 3600
 REQUEST_TIMEOUT = 60.0
 # observe.coreweave.com sits behind Cloudflare, which rejects non-browser
 # clients; present a browser User-Agent to get past the bot challenge.
-_BROWSER_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+_BROWSER_USER_AGENT = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
 
 
 def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
@@ -61,7 +61,7 @@ def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
         )
 
     session = requests.Session()
-    session.headers.update({"Authorization": f"Bearer {token}", "User-Agent": _BROWSER_UA})
+    session.headers.update({"Authorization": f"Bearer {token}", "User-Agent": _BROWSER_USER_AGENT})
     step_hours = step_seconds / 3600.0
 
     events: list[CostEvent] = []

--- a/scripts/cost_manager/backends/coreweave.py
+++ b/scripts/cost_manager/backends/coreweave.py
@@ -1,0 +1,120 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""CoreWeave costs — usage-based estimate.
+
+CoreWeave exposes **no dollar-denominated billing API**; billed amounts live
+only in the Billing Insights console. What is available programmatically is a
+Prometheus-compatible usage API at ``observe.coreweave.com`` exposing
+``billing:*`` metrics (instance counts, object-storage bytes, ...). This
+backend reads those usage series over the window and multiplies them by an
+operator-supplied **rate card** to produce *estimated* costs. Rows are tagged
+``amount_kind="estimated"`` and will not reconcile exactly with the invoice
+(contracts, discounts, taxes, billing-cycle effects).
+
+Each rate-card entry is::
+
+    {category, query, unit_rate, detail_label}
+
+``query`` is PromQL returning an instantaneous usage quantity (e.g. instance
+count). Sampling at ``step_seconds`` and summing ``value * step_hours`` over a
+UTC day approximates resource-hours, which times ``unit_rate`` ($/unit/hour)
+gives the estimated daily cost. Series are grouped by ``detail_label``.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections import defaultdict
+from collections.abc import Mapping
+from typing import Any
+
+import requests
+
+from scripts.cost_manager.cost_event import AmountKind, CostEvent, CostFetchError, DateWindow, cost_event, require_env
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = "coreweave"
+DEFAULT_PROMETHEUS_URL = "https://observe.coreweave.com"
+DEFAULT_STEP_SECONDS = 3600
+REQUEST_TIMEOUT = 60.0
+# observe.coreweave.com sits behind Cloudflare, which rejects non-browser
+# clients; present a browser User-Agent to get past the bot challenge.
+_BROWSER_UA = "Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/124.0 Safari/537.36"
+
+
+def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
+    token = require_env(
+        config.get("api_token_env", "COREWEAVE_API_TOKEN"),
+        provider=PROVIDER,
+        purpose="CoreWeave token with the Observability Viewer role",
+    )
+    base_url = str(config.get("prometheus_url", DEFAULT_PROMETHEUS_URL)).rstrip("/")
+    step_seconds = int(config.get("step_seconds", DEFAULT_STEP_SECONDS))
+    rate_card = list(config.get("rate_card", []))
+    if not rate_card:
+        raise CostFetchError(
+            "coreweave: config.rate_card is empty — CoreWeave has no dollar API, so a "
+            "{category, query, unit_rate, detail_label} rate card is required to estimate cost"
+        )
+
+    session = requests.Session()
+    session.headers.update({"Authorization": f"Bearer {token}", "User-Agent": _BROWSER_UA})
+    step_hours = step_seconds / 3600.0
+
+    events: list[CostEvent] = []
+    for entry in rate_card:
+        series = _query_range(session, base_url, entry["query"], window, step_seconds)
+        unit_hours = _accumulate_unit_hours(series, detail_label=entry.get("detail_label"), step_hours=step_hours)
+        unit_rate = float(entry["unit_rate"])
+        for (day, detail), hours in sorted(unit_hours.items()):
+            events.append(
+                cost_event(
+                    provider=PROVIDER,
+                    day=day,
+                    category=str(entry["category"]),
+                    detail=detail,
+                    cost=hours * unit_rate,
+                    amount_kind=AmountKind.ESTIMATED,
+                )
+            )
+    logger.info("coreweave: estimated %d cost rows for %s..%s", len(events), window.start, window.end)
+    return events
+
+
+def _query_range(
+    session: requests.Session, base_url: str, query: str, window: DateWindow, step_seconds: int
+) -> list[dict[str, Any]]:
+    params = {
+        "query": query,
+        "start": int(window.start_dt.timestamp()),
+        "end": int(window.end_exclusive_dt.timestamp()),
+        "step": step_seconds,
+    }
+    response = session.get(f"{base_url}/api/v1/query_range", params=params, timeout=REQUEST_TIMEOUT)
+    if response.status_code in (401, 403):
+        raise CostFetchError(
+            f"coreweave: {response.status_code} from {base_url} — the token may lack the "
+            f"Observability Viewer role, or Cloudflare blocked the request: {response.text[:200]}"
+        )
+    response.raise_for_status()
+    payload = response.json()
+    if payload.get("status") != "success":
+        raise CostFetchError(f"coreweave: query_range returned status {payload.get('status')!r} for {query!r}")
+    return payload.get("data", {}).get("result", []) or []
+
+
+def _accumulate_unit_hours(
+    series: list[dict[str, Any]], *, detail_label: str | None, step_hours: float
+) -> dict[tuple[dt.date, str], float]:
+    """Sum ``value * step_hours`` per (UTC day, detail) across all series samples."""
+    totals: dict[tuple[dt.date, str], float] = defaultdict(float)
+    for item in series:
+        labels = item.get("metric", {})
+        detail = str(labels.get(detail_label, "total")) if detail_label else "total"
+        for sample_ts, raw_value in item.get("values", []) or []:
+            day = dt.datetime.fromtimestamp(float(sample_ts), tz=dt.UTC).date()
+            totals[(day, detail)] += float(raw_value) * step_hours
+    return dict(totals)

--- a/scripts/cost_manager/backends/coreweave.py
+++ b/scripts/cost_manager/backends/coreweave.py
@@ -64,10 +64,13 @@ def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
     session.headers.update({"Authorization": f"Bearer {token}", "User-Agent": _BROWSER_USER_AGENT})
     step_hours = step_seconds / 3600.0
 
+    window_days = set(window.days())
     events: list[CostEvent] = []
     for entry in rate_card:
         series = _query_range(session, base_url, entry["query"], window, step_seconds)
-        unit_hours = _accumulate_unit_hours(series, detail_label=entry.get("detail_label"), step_hours=step_hours)
+        unit_hours = _accumulate_unit_hours(
+            series, window_days=window_days, detail_label=entry.get("detail_label"), step_hours=step_hours
+        )
         unit_rate = float(entry["unit_rate"])
         for (day, detail), hours in sorted(unit_hours.items()):
             events.append(
@@ -107,14 +110,22 @@ def _query_range(
 
 
 def _accumulate_unit_hours(
-    series: list[dict[str, Any]], *, detail_label: str | None, step_hours: float
+    series: list[dict[str, Any]], *, window_days: set[dt.date], detail_label: str | None, step_hours: float
 ) -> dict[tuple[dt.date, str], float]:
-    """Sum ``value * step_hours`` per (UTC day, detail) across all series samples."""
+    """Sum ``value * step_hours`` per (UTC day, detail) over samples in the window.
+
+    Prometheus ``query_range`` treats both range endpoints as inclusive, so a
+    window ending at midnight returns the next day's first sample; samples whose
+    day falls outside ``window_days`` are dropped so no out-of-window row is
+    emitted.
+    """
     totals: dict[tuple[dt.date, str], float] = defaultdict(float)
     for item in series:
         labels = item.get("metric", {})
         detail = str(labels.get(detail_label, "total")) if detail_label else "total"
         for sample_ts, raw_value in item.get("values", []) or []:
             day = dt.datetime.fromtimestamp(float(sample_ts), tz=dt.UTC).date()
+            if day not in window_days:
+                continue
             totals[(day, detail)] += float(raw_value) * step_hours
     return dict(totals)

--- a/scripts/cost_manager/backends/cost_api.py
+++ b/scripts/cost_manager/backends/cost_api.py
@@ -1,0 +1,78 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared client for the cursor-paginated provider cost APIs.
+
+OpenAI's Costs API and Anthropic's Cost Report share the same wire contract: a
+GET returns a page of daily buckets plus ``has_more`` / ``next_page``, and the
+prior ``next_page`` is passed back as ``page``. This module owns the GET (with a
+clear error on auth/permission failures) and the page loop, so each backend
+only maps its buckets to :class:`CostEvent`.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterator, Mapping
+from typing import Any
+
+import requests
+
+from scripts.cost_manager.cost_event import CostFetchError
+
+DEFAULT_TIMEOUT = 30.0
+
+
+def get_json(
+    session: requests.Session,
+    url: str,
+    headers: Mapping[str, str],
+    params: Mapping[str, Any],
+    *,
+    provider: str,
+    api_label: str,
+    permission_hint: str,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> dict[str, Any]:
+    """GET ``url`` and return JSON; raise :class:`CostFetchError` on 401/403."""
+    response = session.get(url, headers=dict(headers), params=dict(params), timeout=timeout)
+    if response.status_code in (401, 403):
+        raise CostFetchError(
+            f"{provider}: {response.status_code} from {api_label} — {permission_hint}: {response.text[:200]}"
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+def paginate(
+    session: requests.Session,
+    url: str,
+    headers: Mapping[str, str],
+    params: Mapping[str, Any],
+    *,
+    provider: str,
+    api_label: str,
+    permission_hint: str,
+    timeout: float = DEFAULT_TIMEOUT,
+) -> Iterator[dict[str, Any]]:
+    """Yield each response page, following the ``page`` cursor to exhaustion."""
+    page_params = dict(params)
+    page: str | None = None
+    while True:
+        if page:
+            page_params["page"] = page
+        payload = get_json(
+            session,
+            url,
+            headers,
+            page_params,
+            provider=provider,
+            api_label=api_label,
+            permission_hint=permission_hint,
+            timeout=timeout,
+        )
+        yield payload
+        if not payload.get("has_more"):
+            return
+        page = payload.get("next_page")
+        if not page:
+            return

--- a/scripts/cost_manager/backends/gcp.py
+++ b/scripts/cost_manager/backends/gcp.py
@@ -12,9 +12,8 @@ configured to write. This backend runs a daily-cost query via the ``bq`` CLI
 Net cost adds the (negative) credits to gross ``cost``; both are cast to
 ``NUMERIC`` before summing to avoid float rounding.
 
-Note: the ``hai-gcp-models`` billing account is Stanford-managed, so its export
-dataset may be inaccessible from CI. Point ``billing_export_table`` at a
-dataset the runner's service account can read.
+The billing export must be enabled and readable by the runner's service
+account; point ``billing_export_table`` at that dataset.
 """
 
 from __future__ import annotations

--- a/scripts/cost_manager/backends/gcp.py
+++ b/scripts/cost_manager/backends/gcp.py
@@ -1,0 +1,100 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""GCP costs from the BigQuery billing export.
+
+The Cloud Billing API exposes no actual spend, so detailed GCP cost lives only
+in the **BigQuery billing export** table that the billing account must be
+configured to write. This backend runs a daily-cost query via the ``bq`` CLI
+(already on the GitHub runner via the Cloud SDK) and emits one
+:class:`CostEvent` per (day, service, region).
+
+Net cost adds the (negative) credits to gross ``cost``; both are cast to
+``NUMERIC`` before summing to avoid float rounding.
+
+Note: the ``hai-gcp-models`` billing account is Stanford-managed, so its export
+dataset may be inaccessible from CI. Point ``billing_export_table`` at a
+dataset the runner's service account can read.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import json
+import logging
+import subprocess
+from collections.abc import Mapping
+from typing import Any
+
+from scripts.cost_manager.cost_event import CostEvent, CostFetchError, DateWindow, cost_event
+
+logger = logging.getLogger(__name__)
+
+PROVIDER = "gcp"
+BQ_TIMEOUT = 180.0
+MAX_ROWS = 100_000
+
+# One row per (UTC day, service, region) with credit-adjusted net cost. The
+# table name is interpolated (it is operator-controlled config, not user input)
+# because BigQuery does not parameterize table identifiers.
+_QUERY_TEMPLATE = """
+SELECT
+  FORMAT_DATE('%Y-%m-%d', DATE(usage_start_time, 'UTC')) AS day,
+  service.description AS service,
+  COALESCE(NULLIF(location.region, ''), NULLIF(location.location, ''), 'global') AS region,
+  currency AS currency,
+  SUM(
+    CAST(cost AS NUMERIC)
+    + IFNULL((SELECT SUM(CAST(c.amount AS NUMERIC)) FROM UNNEST(credits) c), 0)
+  ) AS net_cost
+FROM `{table}`
+WHERE usage_start_time >= TIMESTAMP('{start}') AND usage_start_time < TIMESTAMP('{end}')
+GROUP BY day, service, region, currency
+HAVING ABS(net_cost) > 1e-9
+ORDER BY day, net_cost DESC
+"""
+
+
+def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
+    table = config.get("billing_export_table")
+    if not table:
+        raise CostFetchError("gcp: config.billing_export_table is required (the BigQuery billing export table)")
+    location = config.get("location", "US")
+    project = config.get("project")
+
+    sql = _QUERY_TEMPLATE.format(
+        table=table,
+        start=window.start_dt.strftime("%Y-%m-%d %H:%M:%S+00"),
+        end=window.end_exclusive_dt.strftime("%Y-%m-%d %H:%M:%S+00"),
+    )
+    rows = _run_bq(sql, location=location, project=project)
+    events = [
+        cost_event(
+            provider=PROVIDER,
+            day=dt.date.fromisoformat(row["day"]),
+            category=row.get("service") or "unknown",
+            detail=row.get("region") or "global",
+            cost=float(row["net_cost"]),
+            currency=str(row.get("currency", "USD")).upper(),
+        )
+        for row in rows
+    ]
+    logger.info("gcp: fetched %d cost rows for %s..%s", len(events), window.start, window.end)
+    return events
+
+
+def _run_bq(sql: str, *, location: str, project: str | None) -> list[dict[str, Any]]:
+    cmd = ["bq", "query", "--use_legacy_sql=false", "--format=json", f"--max_rows={MAX_ROWS}", f"--location={location}"]
+    if project:
+        cmd.append(f"--project_id={project}")
+    cmd.append(sql)
+    try:
+        result = subprocess.run(cmd, capture_output=True, text=True, timeout=BQ_TIMEOUT, check=True)
+    except subprocess.CalledProcessError as exc:
+        raise CostFetchError(f"gcp: bq query failed: {(exc.stderr or exc.stdout or str(exc)).strip()[:400]}") from exc
+    except subprocess.TimeoutExpired as exc:
+        raise CostFetchError(f"gcp: bq query timed out after {BQ_TIMEOUT:.0f}s") from exc
+    stdout = result.stdout.strip()
+    if not stdout:
+        return []
+    return json.loads(stdout)

--- a/scripts/cost_manager/backends/openai.py
+++ b/scripts/cost_manager/backends/openai.py
@@ -22,7 +22,8 @@ from typing import Any
 
 import requests
 
-from scripts.cost_manager.cost_event import CostEvent, CostFetchError, DateWindow, cost_event, require_env
+from scripts.cost_manager.backends import cost_api
+from scripts.cost_manager.cost_event import CostEvent, DateWindow, cost_event, require_env
 
 logger = logging.getLogger(__name__)
 
@@ -30,7 +31,6 @@ COSTS_URL = "https://api.openai.com/v1/organization/costs"
 PROVIDER = "openai"
 # The API caps a single page at 180 daily buckets.
 MAX_BUCKETS = 180
-REQUEST_TIMEOUT = 30.0
 
 
 def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
@@ -54,30 +54,18 @@ def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
     headers = {"Authorization": f"Bearer {api_key}"}
     session = requests.Session()
     events: list[CostEvent] = []
-    page: str | None = None
-    while True:
-        if page:
-            params["page"] = page
-        payload = _get(session, base_url, headers, params)
+    for payload in cost_api.paginate(
+        session,
+        base_url,
+        headers,
+        params,
+        provider=PROVIDER,
+        api_label="Costs API",
+        permission_hint="the key likely lacks org Admin/Usage access",
+    ):
         events.extend(_buckets_to_events(payload.get("data", []) or []))
-        if not payload.get("has_more"):
-            break
-        page = payload.get("next_page")
-        if not page:
-            break
     logger.info("openai: fetched %d cost rows for %s..%s", len(events), window.start, window.end)
     return events
-
-
-def _get(session: requests.Session, url: str, headers: dict[str, str], params: dict[str, Any]) -> dict[str, Any]:
-    response = session.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT)
-    if response.status_code in (401, 403):
-        raise CostFetchError(
-            f"openai: {response.status_code} from Costs API — the key likely lacks org "
-            f"Admin/Usage access: {response.text[:200]}"
-        )
-    response.raise_for_status()
-    return response.json()
 
 
 def _buckets_to_events(buckets: list[dict[str, Any]]) -> list[CostEvent]:

--- a/scripts/cost_manager/backends/openai.py
+++ b/scripts/cost_manager/backends/openai.py
@@ -1,0 +1,103 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""OpenAI organization costs.
+
+Reads the OpenAI Costs API (``GET /v1/organization/costs``), which returns
+daily cost buckets for the whole organization. Requires an **organization
+Admin API key** (a project ``sk-proj-...`` key is rejected); the key's owner
+needs the dashboard "Usage" permission.
+
+Each daily bucket carries one or more results; grouping by ``line_item`` splits
+a day into per-feature rows (e.g. a model's input/output tokens), which become
+the :class:`CostEvent` ``detail``. Amounts are already in dollars.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections.abc import Mapping
+from typing import Any
+
+import requests
+
+from scripts.cost_manager.cost_event import CostEvent, CostFetchError, DateWindow, cost_event, require_env
+
+logger = logging.getLogger(__name__)
+
+COSTS_URL = "https://api.openai.com/v1/organization/costs"
+PROVIDER = "openai"
+# The API caps a single page at 180 daily buckets.
+MAX_BUCKETS = 180
+REQUEST_TIMEOUT = 30.0
+
+
+def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
+    api_key = require_env(
+        config.get("api_key_env", "OPENAI_ADMIN_KEY"),
+        provider=PROVIDER,
+        purpose="organization Admin API key with the 'Usage' permission",
+    )
+    base_url = config.get("base_url", COSTS_URL)
+    group_by = list(config.get("group_by", ["line_item"]))
+
+    params: dict[str, Any] = {
+        "start_time": int(window.start_dt.timestamp()),
+        "end_time": int(window.end_exclusive_dt.timestamp()),
+        "bucket_width": "1d",
+        "limit": min(len(window.days()), MAX_BUCKETS),
+    }
+    if group_by:
+        params["group_by"] = group_by
+
+    headers = {"Authorization": f"Bearer {api_key}"}
+    session = requests.Session()
+    events: list[CostEvent] = []
+    page: str | None = None
+    while True:
+        if page:
+            params["page"] = page
+        payload = _get(session, base_url, headers, params)
+        events.extend(_buckets_to_events(payload.get("data", []) or []))
+        if not payload.get("has_more"):
+            break
+        page = payload.get("next_page")
+        if not page:
+            break
+    logger.info("openai: fetched %d cost rows for %s..%s", len(events), window.start, window.end)
+    return events
+
+
+def _get(session: requests.Session, url: str, headers: dict[str, str], params: dict[str, Any]) -> dict[str, Any]:
+    response = session.get(url, headers=headers, params=params, timeout=REQUEST_TIMEOUT)
+    if response.status_code in (401, 403):
+        raise CostFetchError(
+            f"openai: {response.status_code} from Costs API — the key likely lacks org "
+            f"Admin/Usage access: {response.text[:200]}"
+        )
+    response.raise_for_status()
+    return response.json()
+
+
+def _buckets_to_events(buckets: list[dict[str, Any]]) -> list[CostEvent]:
+    events: list[CostEvent] = []
+    for bucket in buckets:
+        day = dt.datetime.fromtimestamp(int(bucket["start_time"]), tz=dt.UTC).date()
+        for result in bucket.get("results", []) or []:
+            amount = result.get("amount", {})
+            value = amount.get("value")
+            if value is None:
+                continue
+            detail = result.get("line_item") or result.get("project_id") or "total"
+            events.append(
+                cost_event(
+                    provider=PROVIDER,
+                    day=day,
+                    category="api",
+                    detail=str(detail),
+                    cost=float(value),
+                    currency=str(amount.get("currency", "usd")).upper(),
+                )
+            )
+    return events

--- a/scripts/cost_manager/config.yaml
+++ b/scripts/cost_manager/config.yaml
@@ -33,10 +33,10 @@ providers:
     api_key_env: ANTHROPIC_ADMIN_KEY
     group_by: [description]
 
-  # GCP costs from the BigQuery billing export. Disabled by default: the
-  # hai-gcp-models billing account is Stanford-managed, so its export dataset
-  # may be unreadable from CI. Enable once `billing_export_table` points at a
-  # dataset the runner's service account can query.
+  # GCP costs from the BigQuery billing export. Disabled by default: the Cloud
+  # Billing API exposes no actual spend, so detailed cost requires the BigQuery
+  # billing export to be enabled. Enable once `billing_export_table` points at
+  # an export dataset the runner's service account can query.
   - name: gcp
     enabled: false
     project: hai-gcp-models

--- a/scripts/cost_manager/config.yaml
+++ b/scripts/cost_manager/config.yaml
@@ -18,6 +18,28 @@ finelog:
 # (readers take the latest snapshot per day — see README).
 lookback_days: 3
 
+# Optional Slack threshold alerts. Each rule sums a cost slice (an optional
+# provider/category filter) over `window` and pings Slack when it exceeds
+# max_usd. Pinging is best-effort: a breach is always logged, but the POST is
+# skipped on --dry-run and when `webhook_url_env` is unset, so local runs and
+# environments without the secret stay silent. The webhook decides the channel
+# (the repo's SLACK_WEBHOOK_URL); point webhook_url_env at a #marin-eng webhook.
+alerts:
+  webhook_url_env: SLACK_WEBHOOK_URL
+  rules:
+    # window: latest_day (most recent complete UTC day) | window_total (whole window).
+    - name: total-daily
+      window: latest_day  # no provider -> all providers combined
+      max_usd: 500
+    - name: openai-daily
+      provider: openai
+      window: latest_day
+      max_usd: 200
+    - name: anthropic-daily
+      provider: anthropic
+      window: latest_day
+      max_usd: 200
+
 providers:
   # OpenAI organization costs (Costs API). Needs an ORG ADMIN key with the
   # "Usage" permission — a project `sk-proj-...` key is rejected.

--- a/scripts/cost_manager/config.yaml
+++ b/scripts/cost_manager/config.yaml
@@ -1,0 +1,65 @@
+# Cost-manager configuration: which providers to probe and where to write.
+#
+# Secrets are NEVER stored here — only the NAMES of the env vars that hold them
+# (`*_env`). Inject the real values via the environment (GitHub Actions secrets
+# in CI). See README.md for the full list of required secrets per provider.
+
+# Destination for the cost events.
+finelog:
+  # A finelog deploy-config name (lib/finelog/config/<name>.yaml). The runner
+  # opens an SSH/k8s tunnel to that server — works headlessly in CI with a
+  # service-account + SSH key. Alternatively set `url: http://host:port` for a
+  # direct connection (e.g. a tunnel opened by an earlier workflow step).
+  config: marin
+  namespace: cost.events
+
+# Trailing UTC days to (re)fetch each run. The current day is always partial;
+# re-fetching a few trailing days lets later runs correct earlier partial days
+# (readers take the latest snapshot per day — see README).
+lookback_days: 3
+
+providers:
+  # OpenAI organization costs (Costs API). Needs an ORG ADMIN key with the
+  # "Usage" permission — a project `sk-proj-...` key is rejected.
+  - name: openai
+    enabled: true
+    api_key_env: OPENAI_ADMIN_KEY
+    group_by: [line_item]  # split each day into per-feature rows -> CostEvent.detail
+
+  # Anthropic organization costs (Admin Cost Report). Needs an Admin key
+  # (`sk-ant-admin01-...`). Amounts arrive in cents and are converted to USD.
+  - name: anthropic
+    enabled: true
+    api_key_env: ANTHROPIC_ADMIN_KEY
+    group_by: [description]
+
+  # GCP costs from the BigQuery billing export. Disabled by default: the
+  # hai-gcp-models billing account is Stanford-managed, so its export dataset
+  # may be unreadable from CI. Enable once `billing_export_table` points at a
+  # dataset the runner's service account can query.
+  - name: gcp
+    enabled: false
+    project: hai-gcp-models
+    location: US
+    billing_export_table: "hai-gcp-models.billing_export.gcp_billing_export_v1_XXXXXX_XXXXXX_XXXXXX"
+
+  # CoreWeave costs. CoreWeave has NO dollar-denominated API, so this estimates
+  # cost from Prometheus usage metrics times a rate card (rows are tagged
+  # amount_kind=estimated). Disabled until a real rate card is filled in.
+  - name: coreweave
+    enabled: false
+    prometheus_url: https://observe.coreweave.com
+    api_token_env: COREWEAVE_API_TOKEN
+    step_seconds: 3600
+    rate_card:
+      # Estimated $/instance-hour, grouped by instance type. Replace unit_rate
+      # values with the cluster's contracted rates.
+      - category: compute
+        query: "billing:instance:total"
+        detail_label: label_node_kubernetes_io_instance_type
+        unit_rate: 0.0
+      # Estimated $/GiB-hour of object storage.
+      - category: storage
+        query: "billing:object_storage_used_bytes:total / (1024*1024*1024)"
+        detail_label: region
+        unit_rate: 0.0

--- a/scripts/cost_manager/cost_event.py
+++ b/scripts/cost_manager/cost_event.py
@@ -1,0 +1,160 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The cost-event schema written to finelog and the fetch window.
+
+A :class:`CostEvent` is one provider cost line item for a single UTC usage
+day. Every backend normalizes its provider's billing data into a list of
+these, the runner stamps each with a shared ``collected_ts``, and the sink
+appends them to the finelog ``cost.events`` namespace.
+
+finelog is append-only: a daily job that re-fetches a trailing window writes a
+fresh row for each ``(usage_date, provider, category, detail)`` on every run.
+Readers take the latest snapshot by keeping the row with the greatest
+``collected_ts`` (equivalently the greatest implicit ``seq``) per key. See the
+README for the canonical "latest snapshot" SQL.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import os
+from dataclasses import dataclass, replace
+from enum import StrEnum
+from typing import ClassVar
+
+
+class CostFetchError(RuntimeError):
+    """A backend could not fetch costs for an actionable, expected reason.
+
+    Raised for missing credentials, provider auth/permission errors, and other
+    misconfigurations the operator can fix. The runner reports these per
+    provider and continues with the remaining backends rather than aborting.
+    """
+
+
+def require_env(var_name: str, *, provider: str, purpose: str) -> str:
+    """Return the value of env var ``var_name`` or raise :class:`CostFetchError`."""
+    value = os.environ.get(var_name)
+    if not value:
+        raise CostFetchError(f"{provider}: required env var {var_name!r} is unset ({purpose})")
+    return value
+
+
+# finelog namespace holding daily cost line items.
+COST_EVENTS_NAMESPACE = "cost.events"
+
+# Cost data is tiny (hundreds of rows/day) but valuable over a long horizon, so
+# the namespace gets a generous byte cap to keep years of history rather than
+# inheriting the server's high-volume eviction default.
+COST_EVENTS_MAX_BYTES = 2 * 1024 * 1024 * 1024
+
+
+class AmountKind(StrEnum):
+    """Whether ``CostEvent.cost`` is an authoritative bill or an estimate.
+
+    ``BILLED`` rows come from a provider cost/billing API and reconcile with an
+    invoice. ``ESTIMATED`` rows are derived from usage metrics times a local
+    rate card (CoreWeave has no dollar-denominated API) and will not match an
+    invoice exactly.
+    """
+
+    BILLED = "billed"
+    ESTIMATED = "estimated"
+
+
+@dataclass
+class CostEvent:
+    """One provider cost line item for a single UTC usage day."""
+
+    # Same-provider rows colocate for row-group pruning; the dominant query is
+    # a per-provider time range.
+    key_column: ClassVar[str] = "provider"
+
+    # UTC midnight of the usage day; finelog's per-key ordering timestamp.
+    ts: dt.datetime
+    # The usage day as an ISO ``YYYY-MM-DD`` string for human-facing grouping.
+    usage_date: str
+    provider: str
+    # Provider-natural coarse grouping: an OpenAI/Anthropic line item is "api";
+    # a GCP row carries the service ("Compute Engine"); a CoreWeave row carries
+    # the resource class ("compute"/"storage"/"network").
+    category: str
+    # Finer sub-detail within the category: model, SKU, region, or line item.
+    detail: str
+    cost: float
+    currency: str
+    # AmountKind value; str because finelog cannot serialize a StrEnum directly.
+    amount_kind: str
+    # When this row was produced. The runner stamps every row of a run with one
+    # value so a single fetch is one atomic snapshot for latest-wins reads.
+    collected_ts: dt.datetime | None = None
+
+
+@dataclass(frozen=True)
+class DateWindow:
+    """An inclusive range of UTC usage days ``[start, end]`` to fetch."""
+
+    start: dt.date
+    end: dt.date
+
+    def __post_init__(self) -> None:
+        if self.end < self.start:
+            raise ValueError(f"DateWindow end {self.end} precedes start {self.start}")
+
+    @staticmethod
+    def trailing(days: int, *, today: dt.date) -> DateWindow:
+        """The window of the last ``days`` UTC days ending at ``today``."""
+        if days < 1:
+            raise ValueError(f"lookback days must be >= 1, got {days}")
+        return DateWindow(start=today - dt.timedelta(days=days - 1), end=today)
+
+    @property
+    def start_dt(self) -> dt.datetime:
+        """UTC midnight at the start of the first day (inclusive)."""
+        return _day_start(self.start)
+
+    @property
+    def end_exclusive_dt(self) -> dt.datetime:
+        """UTC midnight after the last day, i.e. the exclusive upper bound."""
+        return _day_start(self.end + dt.timedelta(days=1))
+
+    def days(self) -> list[dt.date]:
+        out: list[dt.date] = []
+        day = self.start
+        while day <= self.end:
+            out.append(day)
+            day += dt.timedelta(days=1)
+        return out
+
+
+def _day_start(day: dt.date) -> dt.datetime:
+    return dt.datetime.combine(day, dt.time.min, tzinfo=dt.UTC)
+
+
+def cost_event(
+    *,
+    provider: str,
+    day: dt.date,
+    category: str,
+    detail: str,
+    cost: float,
+    currency: str = "USD",
+    amount_kind: AmountKind = AmountKind.BILLED,
+) -> CostEvent:
+    """Build a :class:`CostEvent` for ``day``; ``collected_ts`` is stamped later."""
+    return CostEvent(
+        ts=_day_start(day),
+        usage_date=day.isoformat(),
+        provider=provider,
+        category=category,
+        detail=detail,
+        cost=float(cost),
+        currency=currency,
+        amount_kind=str(amount_kind),
+    )
+
+
+def stamp_collected(events: list[CostEvent], collected_at: dt.datetime) -> list[CostEvent]:
+    """Return ``events`` with ``collected_ts`` set to one shared run timestamp."""
+    return [replace(e, collected_ts=collected_at) for e in events]

--- a/scripts/cost_manager/finelog_sink.py
+++ b/scripts/cost_manager/finelog_sink.py
@@ -24,8 +24,8 @@ from contextlib import closing, contextmanager
 from typing import Any, Protocol
 
 from finelog.client import FlushResult, LogClient, StoragePolicy
-from finelog.deploy.config import FinelogConfig, load_finelog_config
-from rigging.tunnel import GcpSshForwardTarget, K8sPortForwardTarget, TunnelTarget, open_tunnel
+from finelog.deploy.config import load_finelog_config, tunnel_target_for
+from rigging.tunnel import open_tunnel
 
 from scripts.cost_manager.cost_event import COST_EVENTS_MAX_BYTES, COST_EVENTS_NAMESPACE, CostEvent
 
@@ -101,23 +101,7 @@ def open_sink(finelog_cfg: Mapping[str, Any], *, dry_run: bool, tunnel_timeout: 
     if not config_name:
         raise ValueError("finelog config must set 'config' or 'url' (or pass --dry-run)")
     cfg = load_finelog_config(config_name)
-    target = _tunnel_target(cfg)
+    target = tunnel_target_for(cfg)
     logger.info("Opening tunnel to finelog '%s' (%s)", cfg.name, type(target).__name__)
     with open_tunnel(target, timeout=tunnel_timeout) as tunnel_url, closing(LogClient.connect(tunnel_url)) as client:
         yield FinelogSink(client, namespace)
-
-
-def _tunnel_target(cfg: FinelogConfig) -> TunnelTarget:
-    """Build a rigging tunnel target from a finelog deployment block."""
-    if cfg.deployment.gcp is not None:
-        gcp = cfg.deployment.gcp
-        return GcpSshForwardTarget(
-            project=gcp.project,
-            zone=gcp.zone,
-            instance=cfg.name,
-            port=cfg.port,
-            impersonate_service_account=gcp.service_account,
-        )
-    assert cfg.deployment.k8s is not None
-    k8s = cfg.deployment.k8s
-    return K8sPortForwardTarget(namespace=k8s.namespace, service=cfg.name, port=cfg.port)

--- a/scripts/cost_manager/finelog_sink.py
+++ b/scripts/cost_manager/finelog_sink.py
@@ -1,0 +1,123 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Where cost events go: stdout for dry runs, or the finelog ``cost.events`` table.
+
+:func:`open_sink` is a context manager that yields a :class:`Sink` for the
+configured destination:
+
+- ``--dry-run`` → :class:`StdoutSink` (prints a table; never connects).
+- ``finelog.url`` set → connect a ``LogClient`` directly (e.g. a tunnel a
+  caller already opened, or a local server).
+- ``finelog.config`` set → load the finelog deploy config and open an SSH
+  (GCE) or ``kubectl port-forward`` (k8s) tunnel to the server. This is the CI
+  default: it works headlessly with a service-account + SSH key, with no
+  interactive IAP login.
+"""
+
+from __future__ import annotations
+
+import logging
+from collections import defaultdict
+from collections.abc import Iterator, Mapping
+from contextlib import closing, contextmanager
+from typing import Any, Protocol
+
+from finelog.client import FlushResult, LogClient, StoragePolicy
+from finelog.deploy.config import FinelogConfig, load_finelog_config
+from rigging.tunnel import GcpSshForwardTarget, K8sPortForwardTarget, TunnelTarget, open_tunnel
+
+from scripts.cost_manager.cost_event import COST_EVENTS_MAX_BYTES, COST_EVENTS_NAMESPACE, CostEvent
+
+logger = logging.getLogger(__name__)
+
+FLUSH_TIMEOUT = 30.0
+
+
+class Sink(Protocol):
+    def write(self, events: list[CostEvent]) -> None: ...
+
+    def flush(self) -> None: ...
+
+
+class StdoutSink:
+    """Prints events as a table plus per-provider totals; writes nowhere."""
+
+    def write(self, events: list[CostEvent]) -> None:
+        if not events:
+            print("(no cost events)")
+            return
+        print(f"{'usage_date':<12} {'provider':<10} {'category':<22} {'detail':<40} {'cost':>12} kind")
+        for e in sorted(events, key=lambda x: (x.usage_date, x.provider, x.category, x.detail)):
+            print(
+                f"{e.usage_date:<12} {e.provider:<10} {e.category[:22]:<22} "
+                f"{e.detail[:40]:<40} {e.cost:>12.4f} {e.currency} {e.amount_kind}"
+            )
+        totals: dict[str, float] = defaultdict(float)
+        for e in events:
+            totals[e.provider] += e.cost
+        print("\n-- totals by provider --")
+        for provider, total in sorted(totals.items()):
+            print(f"{provider:<10} {total:>12.2f}")
+
+    def flush(self) -> None:
+        pass
+
+
+class FinelogSink:
+    """Appends events to the finelog ``cost.events`` namespace."""
+
+    def __init__(self, client: LogClient, namespace: str) -> None:
+        self._table = client.get_table(
+            namespace,
+            CostEvent,
+            storage_policy=StoragePolicy(max_bytes=COST_EVENTS_MAX_BYTES),
+        )
+
+    def write(self, events: list[CostEvent]) -> None:
+        self._table.write(events)
+
+    def flush(self) -> None:
+        result = self._table.flush(timeout=FLUSH_TIMEOUT)
+        if result is not FlushResult.SUCCEEDED:
+            raise RuntimeError(f"finelog flush did not complete within {FLUSH_TIMEOUT:.0f}s (result={result})")
+
+
+@contextmanager
+def open_sink(finelog_cfg: Mapping[str, Any], *, dry_run: bool, tunnel_timeout: float = 60.0) -> Iterator[Sink]:
+    if dry_run:
+        yield StdoutSink()
+        return
+
+    namespace = finelog_cfg.get("namespace", COST_EVENTS_NAMESPACE)
+    url = finelog_cfg.get("url")
+    if url:
+        logger.info("Connecting to finelog at %s", url)
+        with closing(LogClient.connect(url)) as client:
+            yield FinelogSink(client, namespace)
+        return
+
+    config_name = finelog_cfg.get("config")
+    if not config_name:
+        raise ValueError("finelog config must set 'config' or 'url' (or pass --dry-run)")
+    cfg = load_finelog_config(config_name)
+    target = _tunnel_target(cfg)
+    logger.info("Opening tunnel to finelog '%s' (%s)", cfg.name, type(target).__name__)
+    with open_tunnel(target, timeout=tunnel_timeout) as tunnel_url, closing(LogClient.connect(tunnel_url)) as client:
+        yield FinelogSink(client, namespace)
+
+
+def _tunnel_target(cfg: FinelogConfig) -> TunnelTarget:
+    """Build a rigging tunnel target from a finelog deployment block."""
+    if cfg.deployment.gcp is not None:
+        gcp = cfg.deployment.gcp
+        return GcpSshForwardTarget(
+            project=gcp.project,
+            zone=gcp.zone,
+            instance=cfg.name,
+            port=cfg.port,
+            impersonate_service_account=gcp.service_account,
+        )
+    assert cfg.deployment.k8s is not None
+    k8s = cfg.deployment.k8s
+    return K8sPortForwardTarget(namespace=k8s.namespace, service=cfg.name, port=cfg.port)

--- a/scripts/cost_manager/run.py
+++ b/scripts/cost_manager/run.py
@@ -24,6 +24,7 @@ from __future__ import annotations
 
 import datetime as dt
 import logging
+import os
 from pathlib import Path
 from typing import Any
 
@@ -33,6 +34,12 @@ import yaml
 from scripts.cost_manager.backends import BACKENDS
 from scripts.cost_manager.cost_event import CostEvent, CostFetchError, DateWindow, stamp_collected
 from scripts.cost_manager.finelog_sink import open_sink
+from scripts.cost_manager.slack_alert import (
+    evaluate_alerts,
+    format_slack_message,
+    parse_alert_rules,
+    post_slack_message,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -46,6 +53,53 @@ def _load_config(path: Path) -> dict[str, Any]:
     if not isinstance(raw, dict):
         raise ValueError(f"{path}: expected a yaml mapping at top level")
     return raw
+
+
+def _handle_alerts(
+    config: dict[str, Any], events: list[CostEvent], window: DateWindow, today: dt.date, *, dry_run: bool
+) -> None:
+    """Evaluate threshold rules and ping Slack on any breach (best-effort).
+
+    No-op when no ``alerts.rules`` are configured. A breach is always logged at
+    WARNING so it shows in CI even without a webhook; the Slack POST is skipped
+    on a dry run, when the webhook env var is unset, and a POST failure never
+    fails the run.
+    """
+    alerts_cfg = config.get("alerts") or {}
+    rules = parse_alert_rules(alerts_cfg.get("rules", []))
+    if not rules:
+        return
+
+    breaches = evaluate_alerts(events, rules, window=window, today=today)
+    if not breaches:
+        logger.info("Cost alerts: %d rule(s) checked, none exceeded", len(rules))
+        return
+    for breach in breaches:
+        logger.warning(
+            "Cost threshold exceeded [%s]: %s (%s) $%.2f > $%.2f",
+            breach.rule_name,
+            breach.scope,
+            breach.window_label,
+            breach.observed_usd,
+            breach.threshold_usd,
+        )
+
+    message = format_slack_message(breaches)
+    if dry_run:
+        print("\n-- slack alert (dry-run, not posted) --")
+        print(message)
+        return
+
+    webhook_env = alerts_cfg.get("webhook_url_env", "SLACK_WEBHOOK_URL")
+    webhook_url = os.environ.get(webhook_env)
+    if not webhook_url:
+        logger.warning("Cost threshold exceeded but %s is unset — not posting to Slack", webhook_env)
+        return
+    try:
+        post_slack_message(webhook_url, message)
+        logger.info("Posted cost alert to Slack (%d breach(es))", len(breaches))
+    except Exception:
+        logger.exception("Failed to post cost alert to Slack")
 
 
 def _run_backends(
@@ -122,6 +176,8 @@ def main(
         sink.write(events)
         sink.flush()
     logger.info("Wrote %d cost events (dry_run=%s)", len(events), dry_run)
+
+    _handle_alerts(config, events, window, today, dry_run=dry_run)
 
     if failed:
         raise SystemExit(f"providers failed: {', '.join(failed)}")

--- a/scripts/cost_manager/run.py
+++ b/scripts/cost_manager/run.py
@@ -1,0 +1,131 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fetch provider costs and write them to finelog.
+
+Loads ``config.yaml``, runs each enabled provider backend over a trailing UTC
+window, and appends the resulting :class:`CostEvent` rows to the finelog
+``cost.events`` namespace (or prints them with ``--dry-run``).
+
+One provider failing (missing key, API/permission error) does not abort the
+run: the remaining backends still write, and the process exits non-zero so CI
+surfaces the failure.
+
+Examples::
+
+    # Local smoke: fetch + print, never connect to finelog.
+    uv run python -m scripts.cost_manager.run --dry-run
+
+    # Production daily run (CI): tunnel to the 'marin' finelog server.
+    uv run python -m scripts.cost_manager.run
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from pathlib import Path
+from typing import Any
+
+import click
+import yaml
+
+from scripts.cost_manager.backends import BACKENDS
+from scripts.cost_manager.cost_event import CostEvent, CostFetchError, DateWindow, stamp_collected
+from scripts.cost_manager.finelog_sink import open_sink
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_CONFIG = Path(__file__).resolve().parent / "config.yaml"
+DEFAULT_LOOKBACK_DAYS = 3
+
+
+def _load_config(path: Path) -> dict[str, Any]:
+    with path.open() as f:
+        raw = yaml.safe_load(f)
+    if not isinstance(raw, dict):
+        raise ValueError(f"{path}: expected a yaml mapping at top level")
+    return raw
+
+
+def _run_backends(
+    providers: list[dict[str, Any]], window: DateWindow, only: set[str]
+) -> tuple[list[CostEvent], list[str]]:
+    """Run each enabled (and selected) backend; return (events, failed_providers)."""
+    events: list[CostEvent] = []
+    failed: list[str] = []
+    for provider_cfg in providers:
+        name = provider_cfg["name"]
+        if only and name not in only:
+            continue
+        if not provider_cfg.get("enabled", False):
+            logger.info("Skipping disabled provider %s", name)
+            continue
+        fetcher = BACKENDS.get(name)
+        if fetcher is None:
+            logger.error("Unknown provider %r (known: %s)", name, ", ".join(sorted(BACKENDS)))
+            failed.append(name)
+            continue
+        try:
+            provider_events = fetcher(provider_cfg, window)
+        except CostFetchError as exc:
+            logger.error("Provider %s failed: %s", name, exc)
+            failed.append(name)
+            continue
+        except Exception:
+            logger.exception("Provider %s raised an unexpected error", name)
+            failed.append(name)
+            continue
+        logger.info("Provider %s: %d events, $%.2f", name, len(provider_events), sum(e.cost for e in provider_events))
+        events.extend(provider_events)
+    return events, failed
+
+
+@click.command(help=__doc__)
+@click.option("--config", "config_path", type=click.Path(path_type=Path), default=DEFAULT_CONFIG, show_default=True)
+@click.option("--lookback-days", type=int, default=None, help="Override config lookback_days (trailing UTC days).")
+@click.option("--provider", "providers_filter", multiple=True, help="Restrict to these providers (repeatable).")
+@click.option("--today", "today_override", default=None, help="UTC 'today' as YYYY-MM-DD (default: now). For backfill.")
+@click.option("--finelog-url", default=None, help="Override finelog.url (direct connect, e.g. a pre-opened tunnel).")
+@click.option("--finelog-config", default=None, help="Override finelog.config (deploy config name to tunnel to).")
+@click.option("--dry-run/--no-dry-run", default=False, help="Fetch and print; never connect to finelog.")
+def main(
+    config_path: Path,
+    lookback_days: int | None,
+    providers_filter: tuple[str, ...],
+    today_override: str | None,
+    finelog_url: str | None,
+    finelog_config: str | None,
+    dry_run: bool,
+) -> None:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s - %(levelname)s - %(message)s")
+    config = _load_config(config_path)
+
+    today = dt.date.fromisoformat(today_override) if today_override else dt.datetime.now(dt.UTC).date()
+    days = lookback_days if lookback_days is not None else config.get("lookback_days", DEFAULT_LOOKBACK_DAYS)
+    window = DateWindow.trailing(days, today=today)
+    logger.info("Fetching costs for UTC window %s..%s", window.start, window.end)
+
+    providers = config.get("providers", [])
+    events, failed = _run_backends(providers, window, set(providers_filter))
+
+    collected_at = dt.datetime.now(dt.UTC)
+    events = stamp_collected(events, collected_at)
+
+    finelog_cfg = dict(config.get("finelog", {}))
+    if finelog_url:
+        finelog_cfg["url"] = finelog_url
+    if finelog_config:
+        finelog_cfg["config"] = finelog_config
+
+    with open_sink(finelog_cfg, dry_run=dry_run) as sink:
+        sink.write(events)
+        sink.flush()
+    logger.info("Wrote %d cost events (dry_run=%s)", len(events), dry_run)
+
+    if failed:
+        raise SystemExit(f"providers failed: {', '.join(failed)}")
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/cost_manager/slack_alert.py
+++ b/scripts/cost_manager/slack_alert.py
@@ -1,0 +1,151 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Threshold alerts: ping Slack when a cost slice exceeds a configured limit.
+
+A run evaluates a list of :class:`AlertRule`s against the fetched
+:class:`~scripts.cost_manager.cost_event.CostEvent`s. Each rule sums the cost of
+a slice (an optional provider/category filter) over either the most recent
+complete UTC day or the whole fetch window, and fires an :class:`AlertBreach`
+when that sum exceeds ``max_usd``. Breaches are formatted into one message and
+POSTed to a Slack incoming webhook — the same ``{"text": ...}`` contract as the
+repo's ``notify-slack`` GitHub action.
+
+Computation (:func:`evaluate_alerts`, :func:`format_slack_message`) is separate
+from I/O (:func:`post_slack_message`) so the threshold logic is testable without
+the network and the runner can print-instead-of-post on a dry run.
+"""
+
+from __future__ import annotations
+
+import datetime as dt
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+from enum import StrEnum
+from typing import Any
+
+import requests
+
+from scripts.cost_manager.cost_event import CostEvent, DateWindow
+
+logger = logging.getLogger(__name__)
+
+POST_TIMEOUT = 10.0
+
+
+class AlertWindow(StrEnum):
+    """Which span a rule's threshold is measured over."""
+
+    # The most recent fully-elapsed UTC day (today is always partial).
+    LATEST_DAY = "latest_day"
+    # The entire trailing fetch window.
+    WINDOW_TOTAL = "window_total"
+
+
+@dataclass(frozen=True)
+class AlertRule:
+    """A spend ceiling over a cost slice.
+
+    ``provider``/``category`` are optional filters; ``None`` matches every value
+    for that field, so a rule with neither set covers total spend.
+    """
+
+    name: str
+    max_usd: float
+    provider: str | None = None
+    category: str | None = None
+    window: AlertWindow = AlertWindow.LATEST_DAY
+
+
+@dataclass(frozen=True)
+class AlertBreach:
+    """A rule whose measured spend exceeded its threshold."""
+
+    rule_name: str
+    scope: str
+    window_label: str
+    observed_usd: float
+    threshold_usd: float
+
+
+def parse_alert_rules(raw_rules: Iterable[dict[str, Any]]) -> list[AlertRule]:
+    """Build :class:`AlertRule`s from the ``alerts.rules`` config list."""
+    rules: list[AlertRule] = []
+    for raw in raw_rules:
+        name = raw.get("name")
+        if not name:
+            raise ValueError(f"alert rule is missing 'name': {raw!r}")
+        if "max_usd" not in raw:
+            raise ValueError(f"alert rule {name!r} is missing 'max_usd'")
+        window = AlertWindow(raw.get("window", AlertWindow.LATEST_DAY))
+        rules.append(
+            AlertRule(
+                name=str(name),
+                max_usd=float(raw["max_usd"]),
+                provider=raw.get("provider"),
+                category=raw.get("category"),
+                window=window,
+            )
+        )
+    return rules
+
+
+def _scope_label(rule: AlertRule) -> str:
+    parts = [rule.provider or "all providers"]
+    if rule.category is not None:
+        parts.append(rule.category)
+    return " / ".join(parts)
+
+
+def _matches(event: CostEvent, rule: AlertRule) -> bool:
+    if rule.provider is not None and event.provider != rule.provider:
+        return False
+    return rule.category is None or event.category == rule.category
+
+
+def evaluate_alerts(
+    events: list[CostEvent], rules: list[AlertRule], *, window: DateWindow, today: dt.date
+) -> list[AlertBreach]:
+    """Return one :class:`AlertBreach` per rule whose slice exceeds its threshold."""
+    latest_complete_day = today - dt.timedelta(days=1)
+    window_label_total = f"{window.start.isoformat()}..{window.end.isoformat()}"
+
+    breaches: list[AlertBreach] = []
+    for rule in rules:
+        if rule.window is AlertWindow.LATEST_DAY:
+            target = latest_complete_day.isoformat()
+            observed = sum(e.cost for e in events if _matches(e, rule) and e.usage_date == target)
+            window_label = target
+        else:
+            observed = sum(e.cost for e in events if _matches(e, rule))
+            window_label = window_label_total
+
+        if observed > rule.max_usd:
+            breaches.append(
+                AlertBreach(
+                    rule_name=rule.name,
+                    scope=_scope_label(rule),
+                    window_label=window_label,
+                    observed_usd=observed,
+                    threshold_usd=rule.max_usd,
+                )
+            )
+    return breaches
+
+
+def format_slack_message(breaches: list[AlertBreach]) -> str:
+    """Render breaches as a Slack mrkdwn message body."""
+    lines = [":rotating_light: *Cost alert* — spend exceeded a configured threshold"]
+    for b in breaches:
+        lines.append(
+            f"• {b.scope} ({b.window_label}): ${b.observed_usd:,.2f} > ${b.threshold_usd:,.2f} [`{b.rule_name}`]"
+        )
+    lines.append("Source: finelog `cost.events` (scripts/cost_manager).")
+    return "\n".join(lines)
+
+
+def post_slack_message(webhook_url: str, text: str, *, timeout: float = POST_TIMEOUT) -> None:
+    """POST ``{"text": text}`` to a Slack incoming webhook; raise on a non-2xx reply."""
+    response = requests.post(webhook_url, json={"text": text}, timeout=timeout)
+    response.raise_for_status()


### PR DESCRIPTION
Adds `scripts/cost_manager`, a config-driven daily job that fetches spend from our cost/billing providers and appends it to the finelog `cost.events` namespace, so budget burn is queryable next to job/throughput stats instead of living in side bots on personal VMs. This is the data-collection half of the cost-management bot; a follow-up agent reads the table (and can re-run the script) to flag unusual spend.

## Shape

Each backend normalizes its provider into `CostEvent` rows — `{ts, usage_date, provider, category, detail, cost, currency, amount_kind, collected_ts}` — and `run.py` appends them to finelog. The table is append-only and the current UTC day is partial, so each run re-fetches a trailing window and writes fresh rows; readers take the newest row per `(usage_date, provider, category, detail)` via `ROW_NUMBER() OVER (... ORDER BY seq DESC)` (the README gives the canonical query).

The runner writes through an SSH/k8s tunnel opened from the finelog deploy config (headless in CI, no interactive IAP login), via `--finelog-url` for a pre-opened tunnel, or to stdout with `--dry-run`. One provider failing (missing key, auth error) does not abort the run; the process exits non-zero so CI surfaces it.

## Backends and the keys they need

- `openai` — Costs API. Needs an org **Admin** key with the "Usage" permission (`OPENAI_ADMIN_KEY`); a project `sk-proj-` key is rejected.
- `anthropic` — Admin Cost Report (`ANTHROPIC_ADMIN_KEY`, `sk-ant-admin01-`); amounts arrive in cents and are converted to USD.
- `gcp` — BigQuery billing export via `bq`. Disabled by default: the Cloud Billing API exposes no actual spend, so detailed cost requires the BigQuery export to be enabled and readable by the runner's service account.
- `coreweave` — usage-based **estimate**. CoreWeave has no dollar API, so cost is Prometheus usage × a config rate card, tagged `amount_kind=estimated`. Disabled until a real rate card is filled in.

## Slack threshold alerts (optional)

A `config.yaml` `alerts` block defines spend ceilings. Each rule sums a cost slice (optional provider/category filter) over the latest complete UTC day or the whole window and pings Slack when it exceeds `max_usd`. A breach is always logged at WARNING; the POST is skipped on `--dry-run` and when the webhook env var is unset, and a POST failure never fails the run. It reuses the existing `SLACK_WEBHOOK_URL` secret and the `notify-slack` action's `{"text": …}` contract — point it at a `#marin-eng` webhook. Remove the block to disable.

`ops-cost-report.yaml` runs it daily, reusing the storage report's GCP/SSH-tunnel auth. New GitHub Actions secrets to add: `OPENAI_ADMIN_KEY`, `ANTHROPIC_ADMIN_KEY`, `COREWEAVE_API_TOKEN`, and optionally `SLACK_WEBHOOK_URL` for alerts.

The package is added to ruff `extend-include` and pyrefly `project-includes` (matching `scripts/ci/**`) so it is linted and type-checked. To avoid duplicating the tunnel-target logic, finelog's private `_tunnel_target` is promoted to a public `finelog.deploy.config.tunnel_target_for`, used by both the deploy CLI and the cost sink.

Verified by round-tripping `CostEvent`s through an embedded finelog server (schema registration, tz-aware timestamps, latest-snapshot dedup), by exercising the live OpenAI HTTP path and the CLI exit codes, and by checking the threshold-alert evaluation (latest-day vs window-total, provider/total scopes) and the dry-run / webhook-unset branches.

A follow-up issue (#6580) tracks a CLI to onboard a service account for headless IAP access, which would let this job reach finelog over the controller IAP proxy instead of the SSH tunnel.

Fixes #6550
Part of #6464