### PR TITLE
finelog: pin k8s deploy image to its digest at apply time

### DIFF
--- a/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
+++ b/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
@@ -33,6 +33,10 @@ spec:
         fsGroup: 1000
       containers:
         - name: finelog
+          # `finelog deploy` resolves the configured tag (e.g. `:latest`) to an
+          # immutable `@sha256:` digest before rendering, so this is a pinned
+          # reference and IfNotPresent is cache-safe — no node-cache staleness,
+          # and the spec records exactly what is running.
           image: {{ image }}
           imagePullPolicy: IfNotPresent
           # SYS_PTRACE lets memray/py-spy attach to the running server for

--- a/lib/finelog/scripts/safe_deploy.py
+++ b/lib/finelog/scripts/safe_deploy.py
@@ -26,10 +26,11 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import click
-from finelog.deploy._gcp import _resolve_image_digest, _ssh_args, _wait_health_via_ssh
+from finelog.deploy._gcp import _ssh_args, _wait_health_via_ssh
 from finelog.deploy.bootstrap import CONTAINER_NAME, render_bootstrap
 from finelog.deploy.build import build_image as build_finelog_image
 from finelog.deploy.config import FinelogConfig, load_finelog_config
+from finelog.deploy.image import resolve_image_digest
 
 STATE_DIR = Path.home() / ".cache" / "finelog" / "deploy-state"
 
@@ -160,7 +161,7 @@ def rollout_cmd(name: str, auto_rollback: bool, force: bool, build: bool, fast: 
     else:
         click.echo(f"captured running digest: {old_digest}")
 
-    new_digest = _resolve_image_digest(cfg.image)
+    new_digest = resolve_image_digest(cfg.image)
     if "@sha256:" not in new_digest:
         raise click.ClickException(f"Could not pin {cfg.image} to a content digest; refusing to deploy a mutable tag.")
     click.echo(f"new pinned digest:       {new_digest}")

--- a/lib/finelog/src/finelog/deploy/_gcp.py
+++ b/lib/finelog/src/finelog/deploy/_gcp.py
@@ -21,65 +21,10 @@ import click
 
 from finelog.deploy.bootstrap import CONTAINER_NAME, render_bootstrap
 from finelog.deploy.config import FinelogConfig
+from finelog.deploy.image import resolve_image_digest
 
 LABEL_KEY = "finelog-name"
 LABEL_MARKER = "finelog"
-
-
-def _resolve_image_digest(image: str) -> str:
-    """Pin a tag to its content digest via `docker manifest inspect`.
-
-    Returns `ghcr.io/...@sha256:...` on success, or the original tag with a
-    warning on any failure (no docker CLI, no network, private registry, etc.).
-    """
-    if "@sha256:" in image:
-        return image
-    if ":" not in image.rsplit("/", 1)[-1]:
-        # No tag at all — leave it alone; gcloud bootstrap will resolve.
-        return image
-    repo, _, _ = image.rpartition(":")
-    try:
-        result = subprocess.run(
-            ["docker", "manifest", "inspect", "-v", image],
-            capture_output=True,
-            text=True,
-            timeout=30,
-        )
-    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
-        click.echo(f"warning: could not resolve digest for {image} ({e}); using tag", err=True)
-        return image
-    if result.returncode != 0:
-        stderr_msg = result.stderr.strip()[:200]
-        click.echo(
-            f"warning: `docker manifest inspect` failed for {image}: {stderr_msg}; using tag",
-            err=True,
-        )
-        return image
-    digest = _extract_digest(result.stdout)
-    if not digest:
-        click.echo(f"warning: could not parse digest from manifest of {image}; using tag", err=True)
-        return image
-    return f"{repo}@{digest}"
-
-
-def _extract_digest(manifest_json: str) -> str | None:
-    """Pull a top-level `Descriptor.digest` out of `docker manifest inspect -v` output."""
-    try:
-        parsed = json.loads(manifest_json)
-    except json.JSONDecodeError:
-        return None
-    if isinstance(parsed, list):
-        for entry in parsed:
-            desc = entry.get("Descriptor", {})
-            platform = desc.get("platform", {})
-            if platform.get("os") == "linux" and platform.get("architecture") == "amd64":
-                digest = desc.get("digest")
-                if digest:
-                    return digest
-        if parsed:
-            return parsed[0].get("Descriptor", {}).get("digest")
-        return None
-    return parsed.get("Descriptor", {}).get("digest")
 
 
 def _gcloud(*args: str, check: bool = True, capture: bool = False) -> subprocess.CompletedProcess:
@@ -165,7 +110,7 @@ def gcp_up(cfg: FinelogConfig) -> None:
         click.echo("Run `finelog deploy restart <name>` to refresh the container in place.")
         return
 
-    pinned = _resolve_image_digest(cfg.image)
+    pinned = resolve_image_digest(cfg.image)
     if pinned != cfg.image:
         click.echo(f"Pinned image: {cfg.image} -> {pinned}")
     else:
@@ -233,7 +178,7 @@ def gcp_restart(cfg: FinelogConfig) -> None:
     assert cfg.deployment.gcp is not None
     gcp = cfg.deployment.gcp
 
-    pinned = _resolve_image_digest(cfg.image)
+    pinned = resolve_image_digest(cfg.image)
     if pinned != cfg.image:
         click.echo(f"Pinned image: {cfg.image} -> {pinned}")
     else:

--- a/lib/finelog/src/finelog/deploy/_k8s.py
+++ b/lib/finelog/src/finelog/deploy/_k8s.py
@@ -15,12 +15,14 @@ import json
 import os
 import re
 import subprocess
+from dataclasses import replace
 from pathlib import Path
 
 import click
 
 from finelog.deploy.bootstrap import render_template
 from finelog.deploy.config import FinelogConfig
+from finelog.deploy.image import resolve_image_digest
 
 _TEMPLATE_VAR_RE = re.compile(r"\{\{ (\w+) \}\}")
 
@@ -123,8 +125,14 @@ def _kubectl_apply(manifest: str) -> None:
 
 
 def k8s_up(cfg: FinelogConfig) -> None:
-    """Render manifests and apply them; wait for the deployment to roll out."""
+    """Render manifests and apply them; wait for the deployment to roll out.
+
+    ``cfg.image`` is pinned to its content digest before rendering, so the
+    Deployment references an immutable image and a redeploy lands exactly what
+    the tag points to now (with ``imagePullPolicy: IfNotPresent``, cache-safe).
+    """
     assert cfg.deployment.k8s is not None
+    cfg = replace(cfg, image=resolve_image_digest(cfg.image))
     k8s = cfg.deployment.k8s
     secret_manifest = _build_s3_secret_manifest(cfg)
     if secret_manifest is not None:
@@ -175,7 +183,7 @@ def k8s_restart(cfg: FinelogConfig) -> None:
         "set",
         "image",
         f"deployment/{cfg.name}",
-        f"finelog={cfg.image}",
+        f"finelog={resolve_image_digest(cfg.image)}",
         "-n",
         k8s.namespace,
     )

--- a/lib/finelog/src/finelog/deploy/image.py
+++ b/lib/finelog/src/finelog/deploy/image.py
@@ -1,0 +1,73 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Resolve a container image tag to its immutable content digest.
+
+Deploy backends call ``resolve_image_digest`` to pin ``cfg.image`` (often a
+mutable ``:latest``) to a ``...@sha256:...`` reference at deploy time, so a
+redeploy lands the exact image the tag points to right now — no node-cache
+staleness, and the rendered manifest records precisely what is running.
+"""
+
+from __future__ import annotations
+
+import json
+import subprocess
+
+import click
+
+
+def resolve_image_digest(image: str) -> str:
+    """Pin a tag to its content digest via ``docker manifest inspect``.
+
+    Returns ``ghcr.io/...@sha256:...`` on success, or the original tag with a
+    warning on any failure (no docker CLI, no network, private registry, etc.).
+    """
+    if "@sha256:" in image:
+        return image
+    if ":" not in image.rsplit("/", 1)[-1]:
+        # No tag at all — leave it alone; the deploy bootstrap will resolve.
+        return image
+    repo, _, _ = image.rpartition(":")
+    try:
+        result = subprocess.run(
+            ["docker", "manifest", "inspect", "-v", image],
+            capture_output=True,
+            text=True,
+            timeout=30,
+        )
+    except (FileNotFoundError, subprocess.TimeoutExpired) as e:
+        click.echo(f"warning: could not resolve digest for {image} ({e}); using tag", err=True)
+        return image
+    if result.returncode != 0:
+        stderr_msg = result.stderr.strip()[:200]
+        click.echo(
+            f"warning: `docker manifest inspect` failed for {image}: {stderr_msg}; using tag",
+            err=True,
+        )
+        return image
+    digest = _extract_digest(result.stdout)
+    if not digest:
+        click.echo(f"warning: could not parse digest from manifest of {image}; using tag", err=True)
+        return image
+    return f"{repo}@{digest}"
+
+
+def _extract_digest(manifest_json: str) -> str | None:
+    """Pull a top-level ``Descriptor.digest`` out of ``docker manifest inspect -v`` output."""
+    try:
+        parsed = json.loads(manifest_json)
+    except json.JSONDecodeError:
+        return None
+    if isinstance(parsed, list):
+        for entry in parsed:
+            desc = entry.get("Descriptor", {})
+            platform = desc.get("platform", {})
+            if platform.get("os") == "linux" and platform.get("architecture") == "amd64":
+                digest = desc.get("digest")
+                if digest:
+                    return digest
+        if parsed:
+            return parsed[0].get("Descriptor", {}).get("digest")
+        return None
+    return parsed.get("Descriptor", {}).get("digest")


### PR DESCRIPTION
* `finelog deploy` pins the k8s Deployment to an immutable image digest, resolved from the configured tag at apply time — so the config keeps a readable `:latest` but the cluster always runs an exact, recorded image
* `k8s_up` / `k8s_restart` resolve `cfg.image` (e.g. `ghcr.io/...:latest`) → `ghcr.io/...@sha256:...` before rendering, via `docker manifest inspect`
  * falls back to the tag (with a warning) if docker/registry is unavailable
* extract `resolve_image_digest` (+ `_extract_digest`) out of `_gcp` into a shared `finelog.deploy.image` module; reuse it in both the k8s and gcp backends [^1]
* deployment template keeps `imagePullPolicy: IfNotPresent` — cache-safe once the image is a digest, matching how iris deploys **task pods** [^2]

[^1]: the GCP backend already pinned digests this way; this just shares the helper so the k8s path gets the same behavior instead of trusting a mutable tag + node cache
[^2]: only the iris **controller** uses `imagePullPolicy: Always`, because it does not resolve digests (its spec holds a tag); iris task pods use `IfNotPresent`. finelog is a long-lived singleton like the controller, but since we resolve to a digest the cleaner equivalent is `IfNotPresent`
