### PR TITLE
probes: fix gcs rollup iam, finelog sink, stale deps

### DIFF
--- a/infra/probes/README.md
+++ b/infra/probes/README.md
@@ -59,7 +59,7 @@ Single COS VM `infra-probes` (us-central1-b), one container, `restart=always`.
 ```bash
 cd infra/probes
 uv run deploy/deploy.py build    # build + push :sha and :latest
-uv run deploy/deploy.py apply    # roll the VM to :latest
+uv run deploy/deploy.py apply    # roll the VM to this HEAD's :sha image
 uv run deploy/deploy.py status   # VM state + recent logs
 ```
 

--- a/infra/probes/deploy/Dockerfile
+++ b/infra/probes/deploy/Dockerfile
@@ -3,9 +3,9 @@
 # Build context is THIS directory's parent (infra/probes/):
 #   docker build -f deploy/Dockerfile -t probes:dev infra/probes
 #
-# marin-iris, marin-finelog, marin-rigging come from the per-package rolling
-# GitHub releases (see pyproject.toml [tool.uv] find-links). No marin source
-# is required in the build context.
+# marin-iris, marin-finelog, marin-rigging are installed from PyPI per the
+# lockfile (their nightly dev wheels). No marin source is required in the
+# build context.
 
 FROM python:3.12-slim AS base
 

--- a/infra/probes/deploy/deploy.py
+++ b/infra/probes/deploy/deploy.py
@@ -68,14 +68,18 @@ def cli(ctx: click.Context, project: str, region: str, zone: str, vm_name: str, 
     }
 
 
+def _git_sha() -> str:
+    return _run(
+        ["git", "-C", str(PROBES_DIR), "rev-parse", "--short", "HEAD"],
+        capture_output=True,
+    ).stdout.strip()
+
+
 @cli.command()
 @click.pass_obj
 def build(cfg: dict[str, str]) -> None:
     """Build the image, tag with git sha and 'latest', push to Artifact Registry."""
-    sha = _run(
-        ["git", "-C", str(PROBES_DIR), "rev-parse", "--short", "HEAD"],
-        capture_output=True,
-    ).stdout.strip()
+    sha = _git_sha()
     image_sha = f"{cfg['registry']}:{sha}"
     image_latest = f"{cfg['registry']}:latest"
 
@@ -102,9 +106,15 @@ def build(cfg: dict[str, str]) -> None:
 @cli.command()
 @click.pass_obj
 def apply(cfg: dict[str, str]) -> None:
-    """Roll the prod VM to the 'latest' image."""
-    image_latest = f"{cfg['registry']}:latest"
-    logger.info("Rolling VM %s (%s) to %s", cfg["vm_name"], cfg["zone"], image_latest)
+    """Roll the prod VM to the current git sha's image.
+
+    Deploys the immutable ``:<sha>`` tag, not ``:latest``: konlet keeps running a
+    locally-cached ``:latest`` when update-container is handed the same mutable
+    ref, so a same-tag roll silently runs the old image. A distinct ``:<sha>``
+    ref forces the pull. Build the matching image first (``build`` at this HEAD).
+    """
+    image_sha = f"{cfg['registry']}:{_git_sha()}"
+    logger.info("Rolling VM %s (%s) to %s", cfg["vm_name"], cfg["zone"], image_sha)
     _run(
         [
             "gcloud",
@@ -114,7 +124,7 @@ def apply(cfg: dict[str, str]) -> None:
             cfg["vm_name"],
             f"--project={cfg['project']}",
             f"--zone={cfg['zone']}",
-            f"--container-image={image_latest}",
+            f"--container-image={image_sha}",
         ]
     )
 

--- a/infra/probes/deploy/deploy.py
+++ b/infra/probes/deploy/deploy.py
@@ -26,9 +26,13 @@ from rigging.filesystem import REGION_TO_DATA_BUCKET
 logger = logging.getLogger("deploy")
 
 IMAGE_NAME = "infra-probes"
-# The probes daemon writes its JSONL roll-ups here; the SA needs object-create on
-# this bucket and the canary's GCS prefix lives under it (see infra_probes.py).
+# The probes daemon writes its JSONL roll-ups under this bucket+prefix (see
+# infra_probes.py). Rolling a day up overwrites a deterministic per-day object
+# when a stranded local file is re-uploaded after a restart, so the SA needs
+# create+get+delete — granted via objectUser, scoped by IAM condition to the
+# prefix so the canary can't touch the rest of this shared data bucket.
 RESULTS_BUCKET = REGION_TO_DATA_BUCKET["us-central1"]
+RESULTS_GCS_PREFIX = "infra/probes"
 RESULTS_HOST_PATH = "/var/lib/probes"
 # Build context / git repo root for `build`: this script lives in deploy/.
 PROBES_DIR = Path(__file__).resolve().parent.parent
@@ -170,7 +174,7 @@ def create(cfg: dict[str, str], iris_endpoint: str, machine_type: str) -> None:
     logger.info("Creating service account %s", sa)
     _run(["gcloud", "iam", "service-accounts", "create", IMAGE_NAME, f"--project={project}"])
 
-    # SA needs: pull image, ship stdout to Cloud Logging, write GCS roll-ups.
+    # SA needs: pull image, ship stdout to Cloud Logging, manage GCS roll-ups.
     logger.info("Granting IAM roles to %s", sa)
     _run(
         [
@@ -196,6 +200,15 @@ def create(cfg: dict[str, str], iris_endpoint: str, machine_type: str) -> None:
             "--condition=None",
         ]
     )
+    # objectUser (create/get/delete) restricted to the roll-up prefix. The
+    # bucket-scoped objects.list it implies is intentionally not covered by the
+    # object-name condition; gcsfs only uses list to sniff bucket type and falls
+    # back gracefully, so the upload still succeeds.
+    prefix_condition = (
+        f'expression=resource.name.startsWith("projects/_/buckets/{RESULTS_BUCKET}'
+        f'/objects/{RESULTS_GCS_PREFIX}/"),title=infra-probes-prefix,'
+        "description=Limit infra-probes SA object access to its rollup prefix"
+    )
     _run(
         [
             "gcloud",
@@ -204,7 +217,8 @@ def create(cfg: dict[str, str], iris_endpoint: str, machine_type: str) -> None:
             "add-iam-policy-binding",
             f"gs://{RESULTS_BUCKET}",
             f"--member={member}",
-            "--role=roles/storage.objectCreator",
+            "--role=roles/storage.objectUser",
+            f"--condition={prefix_condition}",
         ]
     )
 

--- a/infra/probes/pyproject.toml
+++ b/infra/probes/pyproject.toml
@@ -8,14 +8,18 @@ version = "0.1.0"
 description = "Synthetic infra monitoring: continuously exercises Iris and Finelog, records latency and error samples."
 requires-python = ">=3.12,<3.14"
 # marin-* libs ship to PyPI nightly (marin-release-libs-wheels.yaml for
-# iris/rigging, finelog-release-wheels.yaml for finelog). prerelease=allow lets
-# the `0.2.x.devYYYYMMDDhhmm` nightlies resolve; `uv lock -U` picks up the
-# latest. (The old GH `*-latest` rolling releases are abandoned/frozen.)
+# iris/rigging, finelog-release-wheels.yaml for finelog), only as
+# `0.2.x.devYYYYMMDDhhmm` prereleases; `uv lock -U` picks up the latest. (The
+# old GH `*-latest` rolling releases are abandoned/frozen.)
 dependencies = [
     "marin-iris    >= 0.2.0",
     "marin-finelog >= 0.2.0",
     "marin-rigging >= 0.2.0",
     "click >= 8.0",
+    # marin-iris pulls s3fs -> aiobotocore, which breaks at import under the
+    # httpx 1.0 prereleases (no httpx.TimeoutException). Pin to the 0.28 stable
+    # line; marin-iris only needs httpx >= 0.28.1.
+    "httpx >= 0.28.1, < 1",
 ]
 
 [project.scripts]
@@ -25,7 +29,10 @@ probes = "infra_probes:main"
 dev = ["pytest >= 8.4"]
 
 [tool.uv]
-prerelease = "allow"
+# if-necessary (not allow): take prereleases only for packages with no stable
+# release — the marin-* dev wheels — while pinning httpx/pydantic/etc to stable.
+# Global "allow" dragged in httpx 1.0.dev3, which broke aiobotocore at import.
+prerelease = "if-necessary"
 
 [tool.hatch.build.targets.wheel]
 # Ship the whole package; an explicit per-file list silently drops new modules

--- a/infra/probes/pyproject.toml
+++ b/infra/probes/pyproject.toml
@@ -7,13 +7,14 @@ name = "marin-infra-probes"
 version = "0.1.0"
 description = "Synthetic infra monitoring: continuously exercises Iris and Finelog, records latency and error samples."
 requires-python = ">=3.12,<3.14"
-# marin-* libs are not published to PyPI past a one-time bootstrap; the real
-# distribution channel is the per-package rolling GH release. Pinning the
-# floor at 0.99.dev0 + prerelease=allow + find-links picks up today's nightly.
+# marin-* libs ship to PyPI nightly (marin-release-libs-wheels.yaml for
+# iris/rigging, finelog-release-wheels.yaml for finelog). prerelease=allow lets
+# the `0.2.x.devYYYYMMDDhhmm` nightlies resolve; `uv lock -U` picks up the
+# latest. (The old GH `*-latest` rolling releases are abandoned/frozen.)
 dependencies = [
-    "marin-iris    >= 0.99.dev0",
-    "marin-finelog >= 0.99.dev0",
-    "marin-rigging >= 0.99.dev0",
+    "marin-iris    >= 0.2.0",
+    "marin-finelog >= 0.2.0",
+    "marin-rigging >= 0.2.0",
     "click >= 8.0",
 ]
 
@@ -25,11 +26,6 @@ dev = ["pytest >= 8.4"]
 
 [tool.uv]
 prerelease = "allow"
-find-links = [
-    "https://github.com/marin-community/marin/releases/expanded_assets/marin-iris-latest",
-    "https://github.com/marin-community/marin/releases/expanded_assets/marin-finelog-latest",
-    "https://github.com/marin-community/marin/releases/expanded_assets/marin-rigging-latest",
-]
 
 [tool.hatch.build.targets.wheel]
 # Ship the whole package; an explicit per-file list silently drops new modules

--- a/infra/probes/src/sample.py
+++ b/infra/probes/src/sample.py
@@ -17,10 +17,18 @@ from __future__ import annotations
 import json
 from dataclasses import dataclass
 from datetime import datetime
+from typing import ClassVar
 
 
 @dataclass(frozen=True)
 class Sample:
+    # The finelog ordering key. register_table requires the schema to declare a
+    # key_column naming an existing column (or carry an implicit `timestamp_ms`
+    # column). Our time axis is collected_at, so name it explicitly — the server
+    # checks presence, not type, and accepts a TIMESTAMP_MS column. Without this
+    # the metrics table never registers and FinelogTableSink drops every row.
+    key_column: ClassVar[str] = "collected_at"
+
     # labels is a JSON object string (e.g. '{"zone":"us-east5-a"}') rather than a
     # dict so the finelog schema is a flat STRING column and the JSONL stays one
     # line per sample; DuckDB's json_extract slices it at query time.

--- a/infra/probes/tests/test_sample.py
+++ b/infra/probes/tests/test_sample.py
@@ -1,0 +1,18 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Sample doubles as the finelog table schema, so it must satisfy finelog's
+register_table contract: a declared key_column that names an existing column
+(or an implicit `timestamp_ms` column). Without it the metrics table never
+registers and FinelogTableSink drops every row."""
+
+from __future__ import annotations
+
+from finelog.client.log_client import schema_from_dataclass
+from sample import Sample
+
+
+def test_sample_schema_has_resolvable_finelog_key():
+    schema = schema_from_dataclass(Sample)
+    assert schema.key_column == "collected_at"
+    assert any(column.name == schema.key_column for column in schema.columns)

--- a/infra/probes/uv.lock
+++ b/infra/probes/uv.lock
@@ -738,8 +738,8 @@ wheels = [
 
 [[package]]
 name = "marin-finelog"
-version = "0.99.dev20260529"
-source = { registry = "https://github.com/marin-community/marin/releases/expanded_assets/marin-finelog-latest" }
+version = "0.2.12.dev202606221149"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "connect-python" },
@@ -747,16 +747,26 @@ dependencies = [
     { name = "fsspec" },
     { name = "gcsfs" },
     { name = "marin-rigging" },
-    { name = "numpy" },
     { name = "protobuf" },
     { name = "pyarrow" },
     { name = "pyyaml" },
-    { name = "starlette" },
-    { name = "uvicorn", extra = ["standard"] },
     { name = "zstandard" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/13/11596597aa04e03411057d3834d6270b588da9d4143bcac54445ecfc342a/marin_finelog-0.2.12.dev202606221149.tar.gz", hash = "sha256:70d2aab9182cb79e38411360f48c7844ae12b644fda7772d7b520a5835b37848", size = 53501, upload-time = "2026-06-22T12:20:57.765Z" }
 wheels = [
-    { url = "https://github.com/marin-community/marin/releases/download/marin-finelog-latest/marin_finelog-0.99.dev20260529-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/ef/ad/7fbea0212f4944ba6497e34e46142eee4c201d60a57e1aabdd7c6250ae53/marin_finelog-0.2.12.dev202606221149-py3-none-any.whl", hash = "sha256:1ce7df20cd52567e1291a33d07bee7144028791d68594b68415d070d068ea376", size = 54857, upload-time = "2026-06-22T12:20:41.005Z" },
+]
+
+[[package]]
+name = "marin-finelog-server"
+version = "0.2.12.dev202606221149"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2f/54/faa56969daa3964263dd862c7bfacc465bcc0712750b802018455f85b83c/marin_finelog_server-0.2.12.dev202606221149.tar.gz", hash = "sha256:4ce7c67aa9f3a6eaf7c1777383aa4b49b5714476aa794a8190b9599e904985b8", size = 203466, upload-time = "2026-06-22T12:20:58.831Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/bc/13/44a7196f7ca35f543017198aae433b5d2b350cbe0798abe9733a5f0a6eab/marin_finelog_server-0.2.12.dev202606221149-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:a5a90bed267bc945ca2ca70bbc1631fa960d2a1de756a689af4fc6fb442b48c8", size = 41542754, upload-time = "2026-06-22T12:20:43.473Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/5a/03c87e808f8ee8bbddaa725b6164f717cf43c4a8f7185754617608dd2a30/marin_finelog_server-0.2.12.dev202606221149-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:ac990bc50f689c004845e8be192bcce53707904fa74f7160e3feacf386899f35", size = 39139419, upload-time = "2026-06-22T12:20:46.915Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/02/75ee1413dea54440d41f1397cd831054c01e4017842792b0f64704010c04/marin_finelog_server-0.2.12.dev202606221149-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:93150da09f776c5b56db74d230edb0d5bcdec6ce75d6f30ac15e49d724cb51a5", size = 40509490, upload-time = "2026-06-22T12:20:50.924Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/83/1c9ab0e2830bd3e7c123f29ff3f9e78666426e3a6c15972c3e956cc2d130/marin_finelog_server-0.2.12.dev202606221149-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:e89d4fda9cfca9ccb6fd3173d2a40e4e6b11a701e73cd29e164bbfe6b9700ab2", size = 43050993, upload-time = "2026-06-22T12:20:55.263Z" },
 ]
 
 [[package]]
@@ -778,9 +788,9 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0" },
-    { name = "marin-finelog", specifier = ">=0.99.dev0" },
-    { name = "marin-iris", specifier = ">=0.99.dev0" },
-    { name = "marin-rigging", specifier = ">=0.99.dev0" },
+    { name = "marin-finelog", specifier = ">=0.2.0" },
+    { name = "marin-iris", specifier = ">=0.2.0" },
+    { name = "marin-rigging", specifier = ">=0.2.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -788,8 +798,8 @@ dev = [{ name = "pytest", specifier = ">=8.4" }]
 
 [[package]]
 name = "marin-iris"
-version = "0.99.dev20260529"
-source = { registry = "https://github.com/marin-community/marin/releases/expanded_assets/marin-iris-latest" }
+version = "0.2.24.dev202606221125"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "cloudpickle" },
@@ -802,6 +812,7 @@ dependencies = [
     { name = "httpx" },
     { name = "humanfriendly" },
     { name = "marin-finelog" },
+    { name = "marin-finelog-server" },
     { name = "marin-rigging" },
     { name = "pydantic" },
     { name = "pyjwt" },
@@ -814,22 +825,26 @@ dependencies = [
     { name = "uvicorn", extra = ["standard"] },
     { name = "zstandard" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/8b/a9/5a1b35eb49cd4c0d00a22900ed3192eb78a952a8d57b226ab2d6932bbd9a/marin_iris-0.2.24.dev202606221125.tar.gz", hash = "sha256:2100b8ec4907fcafdfe376d1c9f9258057e6b5debf39e4af3fb3622d3860418b", size = 681095, upload-time = "2026-06-22T11:26:46.113Z" }
 wheels = [
-    { url = "https://github.com/marin-community/marin/releases/download/marin-iris-latest/marin_iris-0.99.dev20260529-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/ef/b6/982e1d02c83453cdff050a1f92ee6433c1db0ec854f5a7aa1a8881fa8eba/marin_iris-0.2.24.dev202606221125-py3-none-any.whl", hash = "sha256:94aceb0f874ea7f0633a18f56cdf273bcd9fb3fdd1b0e9078bd93d0be1417d69", size = 807947, upload-time = "2026-06-22T11:26:35.982Z" },
 ]
 
 [[package]]
 name = "marin-rigging"
-version = "0.99.dev20260529"
-source = { registry = "https://github.com/marin-community/marin/releases/expanded_assets/marin-rigging-latest" }
+version = "0.2.24.dev202606221125"
+source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "click" },
     { name = "connect-python" },
     { name = "fsspec" },
     { name = "gcsfs" },
+    { name = "google-auth" },
     { name = "s3fs" },
 ]
+sdist = { url = "https://files.pythonhosted.org/packages/b2/34/e68ce66f129e5a1aae6009829022a055481149d389c02f6e889940a89019/marin_rigging-0.2.24.dev202606221125.tar.gz", hash = "sha256:c7a54bd179e8d2a47340cd8f8c0424420a53066f930d9f0913e6b55327ce8e94", size = 62490, upload-time = "2026-06-22T11:26:48.616Z" }
 wheels = [
-    { url = "https://github.com/marin-community/marin/releases/download/marin-rigging-latest/marin_rigging-0.99.dev20260529-py3-none-any.whl" },
+    { url = "https://files.pythonhosted.org/packages/30/97/b952ff16f2a2cd4d6438792040d0b7e3267ec2552e2af7ad93f3af555493/marin_rigging-0.2.24.dev202606221125-py3-none-any.whl", hash = "sha256:b3d84c8cf6fd2a0ea7a9634c5b1ca9320af3a5056417e4574e8c3b6aed705598", size = 51210, upload-time = "2026-06-22T11:26:39.291Z" },
 ]
 
 [[package]]
@@ -893,46 +908,6 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/ac/5b/2d2d1d522e51285bd61b1e20df8f47ae1a9d80839db0b24ea783b3832832/multidict-6.7.1-cp313-cp313t-win_amd64.whl", hash = "sha256:d54ecf9f301853f2c5e802da559604b3e95bb7a3b01a9c295c6ee591b9882de8", size = 53109, upload-time = "2026-01-26T02:45:08.044Z" },
     { url = "https://files.pythonhosted.org/packages/3d/a3/cc409ba012c83ca024a308516703cf339bdc4b696195644a7215a5164a24/multidict-6.7.1-cp313-cp313t-win_arm64.whl", hash = "sha256:5a37ca18e360377cfda1d62f5f382ff41f2b8c4ccb329ed974cc2e1643440118", size = 45573, upload-time = "2026-01-26T02:45:09.349Z" },
     { url = "https://files.pythonhosted.org/packages/81/08/7036c080d7117f28a4af526d794aab6a84463126db031b007717c1a6676e/multidict-6.7.1-py3-none-any.whl", hash = "sha256:55d97cc6dae627efa6a6e548885712d4864b81110ac76fa4e534c03819fa4a56", size = 12319, upload-time = "2026-01-26T02:46:44.004Z" },
-]
-
-[[package]]
-name = "numpy"
-version = "2.4.6"
-source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/d0/ad/fed0499ce6a338d2a03ebae59cd15093910c8875328855781952abf6c2fe/numpy-2.4.6.tar.gz", hash = "sha256:f3a3570c4a2a16746ac2c31a7c7c7b0c186b95ce902e33db6f28094ed7387dda", size = 20735807, upload-time = "2026-05-18T23:37:14.07Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/95/2a/3d7b5ac8aac24feaf9ad7ed58f45b0bbc06d37e4338ae84c9f2298b570f9/numpy-2.4.6-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:001fbb8e08d942dd57599e781f2472269ee7f2755fae407b4f67b2f0b17da3f1", size = 16689119, upload-time = "2026-05-18T23:33:54.065Z" },
-    { url = "https://files.pythonhosted.org/packages/ea/12/92c4c131527599e8288d6918e888d88726f84d805d784b771f32408aeaef/numpy-2.4.6-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ebfb099f8dcf083deef3ac1ca4c1503f387cf76296fcb3816b66f5ecb5f54fdb", size = 14699246, upload-time = "2026-05-18T23:33:57.621Z" },
-    { url = "https://files.pythonhosted.org/packages/ad/fe/c0a6b7b2ca128a8fb228575147073b660656734b8ebe4d76c8fd748dcc79/numpy-2.4.6-cp312-cp312-macosx_14_0_arm64.whl", hash = "sha256:3213d622a0283a39a93d188f3cf72b26862df52fbb4ca3697f51705016523d41", size = 5204410, upload-time = "2026-05-18T23:34:00.302Z" },
-    { url = "https://files.pythonhosted.org/packages/f3/d4/9770d14ba719432bb90a421bfd443872ed0f70f7264b64bec12ea363d5fd/numpy-2.4.6-cp312-cp312-macosx_14_0_x86_64.whl", hash = "sha256:357cc07a6d7b0b182ff02249616a03742827ebb1277546b5c7cd7f7620a45698", size = 6551240, upload-time = "2026-05-18T23:34:02.852Z" },
-    { url = "https://files.pythonhosted.org/packages/c9/c6/50a46a6205feba2343f1d6d17438107c5dc491ed1c736e6ea68689fd906b/numpy-2.4.6-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5f9fb9157b4ce2971008323afe46053787b526ef624fea915b261468a8421a0f", size = 15671012, upload-time = "2026-05-18T23:34:05.485Z" },
-    { url = "https://files.pythonhosted.org/packages/99/60/14115e6364fa676c5397c2ad3004e527e9aa487abf5d0706ec81bbd08529/numpy-2.4.6-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:90f9849678c75fe7afa2d348ac842c168b0a4d3d61919687216dfc547976d853", size = 16645538, upload-time = "2026-05-18T23:34:09.265Z" },
-    { url = "https://files.pythonhosted.org/packages/ae/c5/693cbe59e57db94d2231fa519ca3978dc9e19da5a8f088588f5c6e947ff2/numpy-2.4.6-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c1a2af6c6ef86344a6b0db6b97834208bf598db514f2b155042439b62605601a", size = 17020706, upload-time = "2026-05-18T23:34:13.053Z" },
-    { url = "https://files.pythonhosted.org/packages/ef/fc/85b7c4eff9b4966ade25c2273cf7e7012e92366c032058653934b37de044/numpy-2.4.6-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e5805d5a22fd19c8ccff10a9561f9df94436b0545619ea579db2d3c35294bce2", size = 18368541, upload-time = "2026-05-18T23:34:17.024Z" },
-    { url = "https://files.pythonhosted.org/packages/f6/81/e1b27545deedce7f4a0b348618c6b62d74e36a4dc9ccd42f3eb2f85eee32/numpy-2.4.6-cp312-cp312-win32.whl", hash = "sha256:e3eeb0aabd6bd5ce64faae67e9935203a6991b4bc2a485a767fbafb2c5125f45", size = 5962825, upload-time = "2026-05-18T23:34:20.3Z" },
-    { url = "https://files.pythonhosted.org/packages/ab/ca/feab00bd44aa5fe1ad2c18f08b4d3bb92e26484b0b1d1443897809ed528c/numpy-2.4.6-cp312-cp312-win_amd64.whl", hash = "sha256:d8e8286dd7cea7895157318d1b91cdacac64c479f3cbc8dce548331728484751", size = 12321687, upload-time = "2026-05-18T23:34:23.095Z" },
-    { url = "https://files.pythonhosted.org/packages/63/cf/5a6d34850a39d1093558564f77ee8e8e0bee5061151b8f05a55711001ec7/numpy-2.4.6-cp312-cp312-win_arm64.whl", hash = "sha256:4081eb135ac24158bd51cdfbef16f1c64df7063b1143f24731387137c092bec8", size = 10221482, upload-time = "2026-05-18T23:34:25.876Z" },
-    { url = "https://files.pythonhosted.org/packages/fb/82/bdab26d7438c6791ca31b7c024ca37c1eab8b726ba236129005cd4a06e45/numpy-2.4.6-cp313-cp313-macosx_10_13_x86_64.whl", hash = "sha256:511dbaf848decaaaf4b4ca48032619fb3138710c4bf7da7617765edad1ef96b0", size = 16684648, upload-time = "2026-05-18T23:34:29.41Z" },
-    { url = "https://files.pythonhosted.org/packages/1b/30/a80189bcc7f5e4258b3fbc3968d909d1756f54d023299ecc39ad6fdb9ef8/numpy-2.4.6-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:bf162abab1c1a736333192707cef898e735a5ca00f38f27eeedf44b39d9e85eb", size = 14693902, upload-time = "2026-05-18T23:34:33.013Z" },
-    { url = "https://files.pythonhosted.org/packages/97/12/70b5d0d7c15e1ebb8a6a84a8caa1d19e181d84fb58bb6d70aca29099dec1/numpy-2.4.6-cp313-cp313-macosx_14_0_arm64.whl", hash = "sha256:043191bfa8eab18c776647b62723ac9dddece59743b13f49b2016094129c2b3f", size = 5198992, upload-time = "2026-05-18T23:34:36.132Z" },
-    { url = "https://files.pythonhosted.org/packages/ba/8c/ebd2a8f8a83541f8d38cc5667e8c2b69cecfd30da6e45693e8158857d44b/numpy-2.4.6-cp313-cp313-macosx_14_0_x86_64.whl", hash = "sha256:6180d8b35af935aed8ece3a85e0a43f87393ae0ac87c8d2c8bd2c993f7270ef3", size = 6546944, upload-time = "2026-05-18T23:34:38.484Z" },
-    { url = "https://files.pythonhosted.org/packages/bb/c5/7b863a97a91671a0338f4253bd3b5a3d3852f0692dae91711c9f4a10e787/numpy-2.4.6-cp313-cp313-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:72fbe16c6fac95aedf5937fa873445cec2110be35d8a4e9433d7501fd98dae6b", size = 15669392, upload-time = "2026-05-18T23:34:41.257Z" },
-    { url = "https://files.pythonhosted.org/packages/a5/9d/3584b9984ca4c047aea75214ce1a4c4c73d849bd71b604264b7f5653f8a8/numpy-2.4.6-cp313-cp313-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a7830bab239b79cda9c08c2da014761cafb48da6150e1da17ac06283f43b6089", size = 16633220, upload-time = "2026-05-18T23:34:45.075Z" },
-    { url = "https://files.pythonhosted.org/packages/05/ae/7c67fba23bd98caec7c99261f3a16072ade14813486b0282cb29846de832/numpy-2.4.6-cp313-cp313-musllinux_1_2_aarch64.whl", hash = "sha256:ef4aea96ce4d3b074422cb4f2f64e216bf9e213004bb58ecfdf50ea02ea8eb9a", size = 17020800, upload-time = "2026-05-18T23:34:49.065Z" },
-    { url = "https://files.pythonhosted.org/packages/d9/5d/3b6725cb31d983c5e66916f5d36f6d7e5521129e4c4404d64f918292a5b6/numpy-2.4.6-cp313-cp313-musllinux_1_2_x86_64.whl", hash = "sha256:dfa20cc6ca228e6b155b11da03825975ce66aea520985dbbddf0f2a5a495c605", size = 18357600, upload-time = "2026-05-18T23:34:52.709Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/da/2ccc6c2fe8898dee01d90c75c5f5f914a23daf99e3e0f59516a08760c8b5/numpy-2.4.6-cp313-cp313-win32.whl", hash = "sha256:56b39e5e0622a09a25bf5baf62f4bcf0cb8a41ae6e2819cf49bbc5a74c083f91", size = 5961134, upload-time = "2026-05-18T23:34:55.618Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/cd/9cc4dc876fb065d5c220aae4d5e14826b2715331bb7618ce1fb07a679d99/numpy-2.4.6-cp313-cp313-win_amd64.whl", hash = "sha256:c4fc99836233ea196540b17ab0983aff60ed07941751930f5f4d05bc3b3b7359", size = 12318598, upload-time = "2026-05-18T23:34:58.928Z" },
-    { url = "https://files.pythonhosted.org/packages/39/1e/c0bcba1f8694116485fe28fd1be698c278fcda4141c5b0e53a2aed8b12a8/numpy-2.4.6-cp313-cp313-win_arm64.whl", hash = "sha256:a7c711e21628b52034bb5ab8d1bce291f752fcc5e92accc615778acee1ff4778", size = 10222272, upload-time = "2026-05-18T23:35:02.167Z" },
-    { url = "https://files.pythonhosted.org/packages/63/6d/cc5619247c8f4204e507f5883528372e4ac4bb189e579fb859a12e480b1f/numpy-2.4.6-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:112b06a867b235ef466ed3508ddf0238050df9c727cafb5301ac385b899189a1", size = 14821197, upload-time = "2026-05-18T23:35:05.468Z" },
-    { url = "https://files.pythonhosted.org/packages/00/58/f1c39161c87d9e9bed660f1ed4bafc0e403d5ec9650b6dd77aead07d489b/numpy-2.4.6-cp313-cp313t-macosx_14_0_arm64.whl", hash = "sha256:eaf7fa2de5c0be8ae6ff8e9bea2ccd725e980541244521d8d4b5f3354a27babe", size = 5326287, upload-time = "2026-05-18T23:35:08.693Z" },
-    { url = "https://files.pythonhosted.org/packages/af/57/3917ab0fd97f271a8694513581b8a36c655f111c446852c302f04ccdb6fc/numpy-2.4.6-cp313-cp313t-macosx_14_0_x86_64.whl", hash = "sha256:7265a2f3d436e54ef9f2b52b5c937e6be778781bd97a590319d7348f1c1ca997", size = 6646763, upload-time = "2026-05-18T23:35:11.459Z" },
-    { url = "https://files.pythonhosted.org/packages/eb/0f/037e64c494b67581ae18193d770adef354c41f3f2c8ebf865602d949bf8f/numpy-2.4.6-cp313-cp313t-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:f74a575920ab21fe304421a3fc28793d82e299cae9eccb37084e9fc7f3617c20", size = 15728070, upload-time = "2026-05-18T23:35:14.79Z" },
-    { url = "https://files.pythonhosted.org/packages/21/a6/5d2bae9c9542eb4df16dc9c46dc79c186e9bad53805dfa5399a6023c6db0/numpy-2.4.6-cp313-cp313t-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:ede83e07a75dd06bc501566c1eca2afc0d61677c1472ac9ad93fdee6e638a48d", size = 16681752, upload-time = "2026-05-18T23:35:18.836Z" },
-    { url = "https://files.pythonhosted.org/packages/92/14/23d1dfb410ae362cd59ce53e936b1513d545eb40db3949ced632e19a459e/numpy-2.4.6-cp313-cp313t-musllinux_1_2_aarch64.whl", hash = "sha256:68bb27509ac1b9a3443094260f6326150663b06abe40b73a2f81160623da5b67", size = 17086024, upload-time = "2026-05-18T23:35:22.52Z" },
-    { url = "https://files.pythonhosted.org/packages/4b/6e/23595a2c642cdf3bc567877064bdd7f91c8b0038a4453cf2daf7248eafe9/numpy-2.4.6-cp313-cp313t-musllinux_1_2_x86_64.whl", hash = "sha256:a0df0043bdb289bde1f62da130d20df23d58b45429f752bc7a8fc5325a225ecd", size = 18403398, upload-time = "2026-05-18T23:35:26.398Z" },
-    { url = "https://files.pythonhosted.org/packages/8a/90/0ac3bc947217e66dec77e7cbc6a1979d1af70b6461b82f620d3bccd5e4c8/numpy-2.4.6-cp313-cp313t-win32.whl", hash = "sha256:29a287e0cf63ff528da061de6b9f64a4618da591ca1046aafc54062e40ca7eab", size = 6084971, upload-time = "2026-05-18T23:35:29.387Z" },
-    { url = "https://files.pythonhosted.org/packages/77/71/5673e351671a1d2bd6063b91b44f70c0affea7d1516fa7a6572941ba4aa1/numpy-2.4.6-cp313-cp313t-win_amd64.whl", hash = "sha256:25c692919ac5a01f170a3bfcd62d745b24fd095c353d50812637d6fcab442e75", size = 12458532, upload-time = "2026-05-18T23:35:32.175Z" },
-    { url = "https://files.pythonhosted.org/packages/3f/88/19d3503c5046e688f049274b27a3ef3d771152fa80d3ba3d01a3dff61abe/numpy-2.4.6-cp313-cp313t-win_arm64.whl", hash = "sha256:1e978ec1e8bd0e0e4de6bb75de9d30cbb74db6b6a2bb727618613703ca0167dd", size = 10291881, upload-time = "2026-05-18T23:35:35.465Z" },
 ]
 
 [[package]]

--- a/infra/probes/uv.lock
+++ b/infra/probes/uv.lock
@@ -7,7 +7,7 @@ resolution-markers = [
 ]
 
 [options]
-prerelease-mode = "allow"
+prerelease-mode = "if-necessary"
 
 [[package]]
 name = "aiobotocore"
@@ -664,6 +664,19 @@ wheels = [
 ]
 
 [[package]]
+name = "httpcore"
+version = "1.0.9"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "certifi" },
+    { name = "h11" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/06/94/82699a10bca87a5556c9c59b5963f2d039dbd239f25bc2a63907a05a14cb/httpcore-1.0.9.tar.gz", hash = "sha256:6e34463af53fd2ab5d807f399a9b45ea31c3dfa2276f15a2c3f00afff6e176e8", size = 85484, upload-time = "2025-04-24T22:06:22.219Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/7e/f5/f66802a942d491edb555dd61e3a9961140fd64c90bce1eafd741609d334d/httpcore-1.0.9-py3-none-any.whl", hash = "sha256:2d400746a40668fc9dec9810239072b40b4484b640a8c38fd654a024c7a1bf55", size = 78784, upload-time = "2025-04-24T22:06:20.566Z" },
+]
+
+[[package]]
 name = "httptools"
 version = "0.7.1"
 source = { registry = "https://pypi.org/simple" }
@@ -687,14 +700,17 @@ wheels = [
 
 [[package]]
 name = "httpx"
-version = "1.0.dev3"
+version = "0.28.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
+    { name = "anyio" },
     { name = "certifi" },
+    { name = "httpcore" },
+    { name = "idna" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/25/40/b6f25020eeafd822fc473394a5db45a5964a64c88788eb5dc49ffabb64e7/httpx-1.0.dev3.tar.gz", hash = "sha256:e95700e4f9cf6430295f4c195f9cb0ca0549bab4294927f8002bf196851d40db", size = 761377, upload-time = "2025-09-15T16:15:12.087Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/b1/df/48c586a5fe32a0f01324ee087459e112ebb7224f646c0b5023f5e79e9956/httpx-0.28.1.tar.gz", hash = "sha256:75e98c5f16b0f35b567856f597f06ff2270a374470a5c2392242528e3e3e42fc", size = 141406, upload-time = "2024-12-06T15:37:23.222Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/97/8d/ff4f018c9a813994e28fabb998f8d76542fc2b46c1210d4c1b2c615eea7f/httpx-1.0.dev3-py3-none-any.whl", hash = "sha256:80b33db1bc8e1fac2a15f419839e324d472d528822608ea6b7a93fed2011722d", size = 34319, upload-time = "2025-09-15T16:15:10.458Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/39/e50c7c3a983047577ee07d2a9e53faf5a69493943ec3f6a384bdc792deb2/httpx-0.28.1-py3-none-any.whl", hash = "sha256:d909fcccc110f8c7faf814ca82a9a4d816bc5a6dbfea25d6591d6985b8ba59ad", size = 73517, upload-time = "2024-12-06T15:37:21.509Z" },
 ]
 
 [[package]]
@@ -775,6 +791,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "click" },
+    { name = "httpx" },
     { name = "marin-finelog" },
     { name = "marin-iris" },
     { name = "marin-rigging" },
@@ -788,6 +805,7 @@ dev = [
 [package.metadata]
 requires-dist = [
     { name = "click", specifier = ">=8.0" },
+    { name = "httpx", specifier = ">=0.28.1,<1" },
     { name = "marin-finelog", specifier = ">=0.2.0" },
     { name = "marin-iris", specifier = ">=0.2.0" },
     { name = "marin-rigging", specifier = ">=0.2.0" },


### PR DESCRIPTION
* fixes the probes canary: 5/7 → all 7 probes green (incl. `iris-job-submit`, now submits + waits for `SUCCEEDED`)
* roll-up SA had `objectCreator` only; re-uploading a stranded daily file overwrites an existing object → needs `objects.delete`, so stale files looped on retry-fail [^1]
  * grant prefix-scoped `objectUser` (create/get/delete) on `infra/probes/`; applied live to the SA too
* `FinelogTableSink` never wrote: `Sample` schema had no `key_column` and no implicit `timestamp_ms`, so `register_table` was rejected and the sink ran disabled — every sample dropped
  * declare existing `collected_at` as the `key_column`; add `test_sample.py` asserting the schema resolves
* deps came from the abandoned GH `*-latest` rolling releases via `find-links`, frozen at `0.99.dev20260529` — bundled iris client was 3 weeks stale, controller rejected submits (build `2026-05-29` < min `2026-06-08`)
  * drop `find-links`, resolve marin-iris/finelog/rigging from PyPI, lower floors to `>= 0.2.0` (PyPI version scheme)
* pin `httpx < 1` + `prerelease = "if-necessary"` — global `prerelease=allow` dragged in `httpx 1.0.dev3`, which broke `aiobotocore` (via `s3fs`) at import and crash-looped the daemon [^2]
* `apply` now rolls the immutable `:sha`, not `:latest` — konlet keeps running a cached `:latest` on a same-tag roll, silently serving the old image

[^1]: the daily roll-up writes a deterministic per-day object; a restart strands the local JSONL, and the re-upload overwrites the already-uploaded object.
[^2]: `aiobotocore` references `httpx.TimeoutException` at import, which `httpx` 1.0 removed; marin-iris only needs `httpx >= 0.28.1`, so the 0.28 stable line satisfies everything.