### PR TITLE
probes: fix README dep-source prose (pypi, not gh releases)

### DIFF
--- a/infra/probes/README.md
+++ b/infra/probes/README.md
@@ -40,8 +40,9 @@ labels with DuckDB `json_extract`), and appended to a daily JSONL that rolls up
 to `gs://<us-central1 data bucket>/infra/probes/dt=<date>/` at UTC rollover.
 
 Standalone package (own `pyproject.toml`/`uv.lock`): pulls `marin-iris`,
-`marin-finelog`, `marin-rigging` from the rolling GitHub releases via
-`find-links`. Bump to today's nightly with `uv lock -U` inside `infra/probes/`.
+`marin-finelog`, `marin-rigging` from PyPI as `0.2.x.dev` nightlies
+(`prerelease = "if-necessary"`). Bump to today's nightly with `uv lock -U`
+inside `infra/probes/`.
 
 ## Run
 


### PR DESCRIPTION
* #6562 moved the probes off the abandoned GH `*-latest` rolling releases to PyPI, but left the "Standalone package" paragraph describing the old `find-links` channel
* update it: pulls `marin-iris`/`marin-finelog`/`marin-rigging` from PyPI as `0.2.x.dev` nightlies (`prerelease = "if-necessary"`)
* docs-only