### PR TITLE
iris: honor task_image override in the Kubernetes provider

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -490,6 +490,9 @@ def _build_pod_manifest(
 
     namespace = config.namespace
     default_image = config.default_image
+    # Per-task image override (RunTaskRequest.task_image). The init container
+    # keeps default_image since it runs iris's own bundle_fetch tooling.
+    task_image = run_req.task_image or default_image
     cache_dir = config.cache_dir
     service_account = config.service_account
     host_network = config.host_network
@@ -559,7 +562,7 @@ def _build_pod_manifest(
 
     container: dict = {
         "name": "task",
-        "image": default_image,
+        "image": task_image,
         "imagePullPolicy": "IfNotPresent",
         "env": env_list,
         "workingDir": "/app",

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -112,6 +112,22 @@ def test_build_pod_manifest_fields():
     assert container["resources"]["requests"]["memory"] == str(4 * 1024**3)
 
 
+def test_build_pod_manifest_defaults_image_when_no_override():
+    req = make_run_req("/test-job/0")
+    manifest = _build_pod_manifest(req, pod_config(default_image="myrepo/iris:latest"))
+    assert manifest["spec"]["containers"][0]["image"] == "myrepo/iris:latest"
+
+
+def test_build_pod_manifest_honors_task_image_override():
+    """RunTaskRequest.task_image overrides the task container image. The init
+    container keeps default_image (see _build_init_container_spec) since it runs
+    iris's own bundle_fetch tooling."""
+    req = make_run_req("/test-job/0")
+    req.task_image = "myrepo/custom:v9"
+    manifest = _build_pod_manifest(req, pod_config(default_image="myrepo/iris:latest"))
+    assert manifest["spec"]["containers"][0]["image"] == "myrepo/custom:v9"
+
+
 def test_build_pod_manifest_env_vars():
     req = make_run_req("/test-job/0")
     req.environment.env_vars["MY_VAR"] = "hello"


### PR DESCRIPTION
see https://github.com/marin-community/marin/pull/6394

* k8s `KubernetesProvider` built every task pod from the cluster-wide `default_image` and silently dropped `RunTaskRequest.task_image`, so the per-task `--task-image` override (added in #6394) had no effect on k8s clusters (e.g. `cw-us-east-02a`)[^1]
  * the GCP worker path already honors it (`request.task_image or default_task_image`)
* `_build_pod_manifest` now sets the **task** container image to `run_req.task_image or default_image`
* the **init** container (`stage-workdir`) deliberately stays on `default_image` — it runs iris's own `bundle_fetch.py` tooling, which a user-supplied image may not have; it stages into the shared `/app` volume so the task container runs on its own image regardless
* tests: task container honors the override; falls back to `default_image` when unset

[^1]: verified empirically on `cw-us-east-02a` before this fix: a job submitted with a bogus `--task-image` produced a pod whose task container carried the bogus tag and went `ErrImagePull`, confirming the field was already honored by the *deployed* controller — but that wiring lived only in an unmerged, off-`main` build. this PR lands the same two-line change on `main` so a redeploy from `main` does not silently regress it. caveats unchanged: no `imagePullSecrets` are configured (private custom images will not pull), and `imagePullPolicy: IfNotPresent` means mutable tags can serve stale on warm nodes.