### PR TITLE
status-page: probes panel — synthetic-canary health + provisioning from finelog

### DIFF
--- a/infra/status-page/README.md
+++ b/infra/status-page/README.md
@@ -2,18 +2,21 @@
 
 Internal dashboard for Marin: ferry workflow status from GitHub Actions,
 a GitHub Build panel showing aggregate CI status for the last 100
-commits on main (per-commit check-run rollup), and an Iris section
+commits on main (per-commit check-run rollup), an Iris section
 surfacing controller reachability, worker counts (current + 24h
 history), active-environment Iris + finelog health, and the 24h
-job-state breakdown. Deployed as Cloud Run + native IAP, following the
-`infra/iris-iap-proxy/` pattern.
+job-state breakdown, and a Probes section reading the synthetic-canary
+metrics that `infra/probes/` writes to finelog — health checks plus the
+accelerator-provisioning rollup. Deployed as Cloud Run + native IAP,
+following the `infra/iris-iap-proxy/` pattern.
 
 ## Stack
 
 - **Server** — Node 20 + TypeScript + [Hono](https://hono.dev). Exposes
   `/api/ferry`, `/api/builds`, `/api/iris`, `/api/workers`,
   `/api/control-plane/health`, `/api/workers/history`, `/api/jobs`,
-  `/api/health`, and serves the built web UI from `web/dist`.
+  `/api/probes`, `/api/health`, and serves the built web UI from
+  `web/dist`.
 - **Web** — Vite + React 18 + TypeScript + Jotai + `@tanstack/react-query`
   + Tailwind.
 - Single `package.json`, multi-stage Dockerfile, single service account,
@@ -31,9 +34,11 @@ server/
     githubActions.ts   Ferry workflow runs (REST API)
     githubCommits.ts   Build panel: per-commit CI rollup on main (GraphQL)
     iris.ts            iris controller /health caller
-    serviceHealth.ts   active env Iris + finelog /health probes
+    serviceHealth.ts   active env Iris + finelog /health probes (+ finelog URL)
     workers.ts         iris worker counts via the ListWorkers RPC
     jobs.ts            iris 24h job-state breakdown via ExecuteRawQuery
+    probes.ts          synthetic-canary checks + provisioning from finelog
+    finelogQuery.ts    finelog StatsService SQL query → Arrow IPC decode
     controllerQuery.ts helper for the raw-SQL Connect RPC
     discovery.ts       GCE label → controller internal URL
 web/
@@ -51,6 +56,7 @@ web/
       useWorkers.ts
       useWorkersHistory.ts
       useJobs.ts
+      useProbes.ts
     components/
       FerryPanel.tsx
       BuildPanel.tsx  GitHub CI, last 100 runs on main
@@ -58,6 +64,7 @@ web/
       ControlPlanePanel.tsx active env Iris + finelog latency chart
       WorkersPanel.tsx
       JobsPanel.tsx
+      ProbesPanel.tsx synthetic-canary health checks + provisioning rollup
     style.css       Tailwind entry
 Dockerfile          multi-stage build → node:20-slim runtime
 deploy.sh           Cloud Run + IAP deploy
@@ -188,6 +195,39 @@ pending, expected, and commits with no checks configured — so the
 number reflects actual CI pass/fail ratios rather than being dragged
 down by in-flight builds.
 
+### Probes panel
+
+The Probes panel renders the synthetic-canary telemetry the
+`infra/probes/` daemon writes to the finelog `infra.canary.metrics`
+namespace (one flat `{metric, value, labels, collected_at}` row per
+sample). Two bounded DuckDB queries run against the **active
+environment's** finelog log-server through its `StatsService.Query`
+Connect RPC — the same JSON-over-HTTP shape the controller's
+`ExecuteRawQuery` uses, except the result is an Arrow IPC stream, which
+`server/sources/finelogQuery.ts` decodes with `apache-arrow`. No
+controller hop is involved; the finelog URL is resolved by
+`activeFinelogUrl()` (same overrides + GCE discovery as the
+control-plane health probe). The two queries are:
+
+- **Health checks** — the latest `probe_up` (+ matching
+  `probe_latency_ms`) per synthetic check (`controller-ping`,
+  `finelog-write`, `iris-job-submit/<zone>`). Only checks that emit
+  `probe_up` appear; a gauge collector surfaces here only when it
+  fails.
+- **Provisioning** — the latest provisioning cycle's `provision_*`
+  gauges, which the probe rolls up from the controller's
+  `iris.provisioning` namespace over a trailing window (default 3h).
+  Rendered as a fleet summary (create success ratio = ready /
+  resolved attempts, create→ready latency p50/p95, ready / stockout /
+  error / preempted counts, pools placing vs. stuck) plus a per-pool
+  breakdown keyed by `(resource_type, scale_group, zone)`. Per-pool
+  success ratio is computed client-side; preemptions are runtime
+  deaths and excluded from the create-success rate. See
+  `infra/probes/src/provisioning.py` for the metric vocabulary.
+
+The panel surfaces a friendly empty state until the canary has written
+metrics (e.g. before first deploy, or if the namespace is missing).
+
 ## Deploy
 
 ```bash
@@ -219,6 +259,7 @@ plus the dev controller discovery settings.
 | Workers         | 15s         | 30s                        | current only        |
 | Workers history | in-memory   | 30s                        | 24h ring buffer     |
 | Jobs            | 60s         | 60s                        | 24h window          |
+| Probes          | 60s         | 60s                        | latest cycle        |
 
 Backend TTL is the authoritative shield against the GitHub rate limit —
 frontend polling can be tuned without affecting upstream. Concurrent

--- a/infra/status-page/package-lock.json
+++ b/infra/status-page/package-lock.json
@@ -11,6 +11,7 @@
         "@google-cloud/compute": "^4.9.0",
         "@hono/node-server": "^2.0.4",
         "@tanstack/react-query": "^5.101.0",
+        "apache-arrow": "^21.1.0",
         "hono": "^4.12.25",
         "jotai": "^2.20.0",
         "react": "^18.3.1",
@@ -1513,6 +1514,15 @@
       "integrity": "sha512-e7Mew686owMaPJVNNLs55PUvgz371nKgwsc4vxE49zsODpJEnxgxRo2y/OKrqueavXgZNMDVj3DdHFlaSAeU8g==",
       "license": "MIT"
     },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
     "node_modules/@tailwindcss/node": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.0.tgz",
@@ -1900,6 +1910,18 @@
       "version": "0.12.5",
       "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.5.tgz",
       "integrity": "sha512-hWtVTC2q7hc7xZ/RLbxapMvDMgUnDvKvMOpKal4DrMyfGBUfB1oKaZlIRr6mJL+If3bAP6sV/QneGzF6tJjZDg==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-args": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/command-line-args/-/command-line-args-5.2.3.tgz",
+      "integrity": "sha512-uv0aG6R0Y8WHZLTamZwtfsDLVRnOa+n+n5rEvFWL5Na5gZ8V2Teab/duDPFzIIIhs9qizDpcavCusCLJZu62Kw==",
+      "license": "MIT"
+    },
+    "node_modules/@types/command-line-usage": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/command-line-usage/-/command-line-usage-5.0.4.tgz",
+      "integrity": "sha512-BwR5KP3Es/CSht0xqBcUXS3qCAUVXwpRKsV2+arxeb65atasuXG9LykC9Ab10Cw3s2raH92ZqOeILaQbsB2ACg==",
       "license": "MIT"
     },
     "node_modules/@types/d3-array": {
@@ -2452,12 +2474,56 @@
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
       }
     },
+    "node_modules/apache-arrow": {
+      "version": "21.1.0",
+      "resolved": "https://registry.npmjs.org/apache-arrow/-/apache-arrow-21.1.0.tgz",
+      "integrity": "sha512-kQrYLxhC+NTVVZ4CCzGF6L/uPVOzJmD1T3XgbiUnP7oTeVFOFgEUu6IKNwCDkpFoBVqDKQivlX4RUFqqnWFlEA==",
+      "license": "Apache-2.0",
+      "dependencies": {
+        "@swc/helpers": "^0.5.11",
+        "@types/command-line-args": "^5.2.3",
+        "@types/command-line-usage": "^5.0.4",
+        "@types/node": "^24.0.3",
+        "command-line-args": "^6.0.1",
+        "command-line-usage": "^7.0.1",
+        "flatbuffers": "^25.1.24",
+        "json-bignum": "^0.0.3",
+        "tslib": "^2.6.2"
+      },
+      "bin": {
+        "arrow2csv": "bin/arrow2csv.js"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/@types/node": {
+      "version": "24.13.2",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.2.tgz",
+      "integrity": "sha512-fRa09kZTgu8o71KFcDjUFuc7F+dEbZYZmkI0mg5YBTRs0yMKjYHsq/c0urDKeDb+D5qVgXOdFcuu+DZPKOITwA==",
+      "license": "MIT",
+      "dependencies": {
+        "undici-types": "~7.18.0"
+      }
+    },
+    "node_modules/apache-arrow/node_modules/undici-types": {
+      "version": "7.18.2",
+      "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
+      "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
+      "license": "MIT"
+    },
     "node_modules/argparse": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/array-back": {
+      "version": "6.2.3",
+      "resolved": "https://registry.npmjs.org/array-back/-/array-back-6.2.3.tgz",
+      "integrity": "sha512-SGDvmg6QTYiTxCBkYVmThcoa67uLl35pyzRHdpCGBOcqFy6BtwnphoFPk7LhJshD+Yk1Kt35WGWeZPTgwR4Fhw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2650,7 +2716,6 @@
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
       "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ansi-styles": "^4.1.0",
@@ -2663,11 +2728,25 @@
         "url": "https://github.com/chalk/chalk?sponsor=1"
       }
     },
+    "node_modules/chalk-template": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/chalk-template/-/chalk-template-0.4.0.tgz",
+      "integrity": "sha512-/ghrgmhfY8RaSdeo43hNXxpoHAtxdbskUHjPpfqUWGttFgycUhYPGx3YZBCnUCvOa7Doivn1IZec3DEGFoMgLg==",
+      "license": "MIT",
+      "dependencies": {
+        "chalk": "^4.1.2"
+      },
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk-template?sponsor=1"
+      }
+    },
     "node_modules/chalk/node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
       "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-flag": "^4.0.0"
@@ -2727,6 +2806,44 @@
       },
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/command-line-args": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/command-line-args/-/command-line-args-6.0.2.tgz",
+      "integrity": "sha512-AIjYVxrV9X752LmPDLbVYv8aMCuHPSLZJXEo2qo/xJfv+NYhaZ4sMSF01rM+gHPaMgvPM0l5D/F+Qx+i2WfSmQ==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.3",
+        "find-replace": "^5.0.2",
+        "lodash.camelcase": "^4.3.0",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/command-line-usage": {
+      "version": "7.0.4",
+      "resolved": "https://registry.npmjs.org/command-line-usage/-/command-line-usage-7.0.4.tgz",
+      "integrity": "sha512-85UdvzTNx/+s5CkSgBm/0hzP80RFHAa7PsfeADE5ezZF3uHz3/Tqj9gIKGT9PTtpycc3Ua64T0oVulGfKxzfqg==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "chalk-template": "^0.4.0",
+        "table-layout": "^4.1.1",
+        "typical": "^7.3.0"
+      },
+      "engines": {
+        "node": ">=12.20.0"
       }
     },
     "node_modules/concat-map": {
@@ -3407,6 +3524,23 @@
         "node": ">=16.0.0"
       }
     },
+    "node_modules/find-replace": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/find-replace/-/find-replace-5.0.2.tgz",
+      "integrity": "sha512-Y45BAiE3mz2QsrN2fb5QEtO4qb44NcS7en/0y9PEVsg351HsLeVclP8QPMH79Le9sH3rs5RSwJu99W0WPZO43Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=14"
+      },
+      "peerDependencies": {
+        "@75lb/nature": "latest"
+      },
+      "peerDependenciesMeta": {
+        "@75lb/nature": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/find-up": {
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-5.0.0.tgz",
@@ -3437,6 +3571,12 @@
       "engines": {
         "node": ">=16"
       }
+    },
+    "node_modules/flatbuffers": {
+      "version": "25.9.23",
+      "resolved": "https://registry.npmjs.org/flatbuffers/-/flatbuffers-25.9.23.tgz",
+      "integrity": "sha512-MI1qs7Lo4Syw0EOzUl0xjs2lsoeqFku44KpngfIduHBYvzm8h2+7K8YMQh1JtVVVrUvhLpNwqVi4DERegUJhPQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/flatted": {
       "version": "3.4.2",
@@ -3697,7 +3837,6 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
       "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">=8"
@@ -4008,6 +4147,14 @@
       "license": "MIT",
       "dependencies": {
         "bignumber.js": "^9.0.0"
+      }
+    },
+    "node_modules/json-bignum": {
+      "version": "0.0.3",
+      "resolved": "https://registry.npmjs.org/json-bignum/-/json-bignum-0.0.3.tgz",
+      "integrity": "sha512-2WHyXj3OfHSgNyuzDbSxI1w2jgw5gkWSWhS7Qg4bWXx1nLk3jnbwfUeS0PSba3IzpTUWdHxBieELUzXRjQB2zg==",
+      "engines": {
+        "node": ">=0.8"
       }
     },
     "node_modules/json-buffer": {
@@ -5099,6 +5246,19 @@
         "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
+    "node_modules/table-layout": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/table-layout/-/table-layout-4.1.1.tgz",
+      "integrity": "sha512-iK5/YhZxq5GO5z8wb0bY1317uDF3Zjpha0QFFLA8/trAoiLbQD0HUbMesEaxyzUgDxi2QlcbM8IvqOlEjgoXBA==",
+      "license": "MIT",
+      "dependencies": {
+        "array-back": "^6.2.2",
+        "wordwrapjs": "^5.1.0"
+      },
+      "engines": {
+        "node": ">=12.17"
+      }
+    },
     "node_modules/tailwindcss": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.0.tgz",
@@ -5217,7 +5377,6 @@
       "version": "2.8.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
-      "dev": true,
       "license": "0BSD"
     },
     "node_modules/tsx": {
@@ -5288,6 +5447,15 @@
       "peerDependencies": {
         "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0",
         "typescript": ">=4.8.4 <6.1.0"
+      }
+    },
+    "node_modules/typical": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/typical/-/typical-7.3.0.tgz",
+      "integrity": "sha512-ya4mg/30vm+DOWfBg4YK3j2WD6TWtRkCbasOJr40CseYENzCUby/7rIvXA99JGsQHeNxLbnXdyLLxKSv3tauFw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/undici-types": {
@@ -5505,6 +5673,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/wordwrapjs": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/wordwrapjs/-/wordwrapjs-5.1.1.tgz",
+      "integrity": "sha512-0yweIbkINJodk27gX9LBGMzyQdBDan3s/dEAiwBOj+Mf0PPyWL6/rikalkv8EeD0E8jm4o5RXEOrFTP3NXbhJg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=12.17"
       }
     },
     "node_modules/wrap-ansi": {

--- a/infra/status-page/package.json
+++ b/infra/status-page/package.json
@@ -18,6 +18,7 @@
     "@google-cloud/compute": "^4.9.0",
     "@hono/node-server": "^2.0.4",
     "@tanstack/react-query": "^5.101.0",
+    "apache-arrow": "^21.1.0",
     "hono": "^4.12.25",
     "jotai": "^2.20.0",
     "react": "^18.3.1",

--- a/infra/status-page/server/main.ts
+++ b/infra/status-page/server/main.ts
@@ -8,6 +8,7 @@
 //   GET /api/workers         — current iris worker counts (15s cache)
 //   GET /api/workers/history — in-memory 24h worker count ring buffer
 //   GET /api/jobs            — iris job counts for last 24h by state (60s cache)
+//   GET /api/probes          — synthetic-canary checks + provisioning from finelog (60s cache)
 //   GET /api/health          — liveness probe, no upstream calls
 //   GET /*                   — static assets from web/dist (production only)
 //
@@ -28,6 +29,7 @@ import {
 import { fetchBuildsOnMain, type BuildsResponse } from "./sources/githubCommits.js";
 import { irisStatus, pingIris, type IrisPingResult } from "./sources/iris.js";
 import { jobsSnapshot, type JobsSnapshot } from "./sources/jobs.js";
+import { probesSnapshot, type ProbesSnapshot } from "./sources/probes.js";
 import {
   serviceHealthResponse,
   serviceHealthSample,
@@ -45,6 +47,9 @@ const ferryCache = new TTLCache<FerryTierStatus>(60_000);
 const buildCache = new TTLCache<BuildsResponse>(60_000);
 const workersCache = new TTLCache<WorkersSnapshot>(15_000);
 const jobsCache = new TTLCache<JobsSnapshot>(60_000);
+// Probe metrics turn over slowly — health checks every ≤5min, provisioning
+// every 15min — so a 60s shield is plenty and keeps finelog query load low.
+const probesCache = new TTLCache<ProbesSnapshot>(60_000);
 
 // Iris controller ping sampler. We probe /health on a fixed cadence and
 // keep a rolling 1h window of successful samples so /api/iris can report
@@ -181,6 +186,11 @@ app.get("/api/workers/history", (c) => {
 
 app.get("/api/jobs", async (c) => {
   const snapshot = await jobsCache.get("jobs", () => jobsSnapshot());
+  return c.json(snapshot);
+});
+
+app.get("/api/probes", async (c) => {
+  const snapshot = await probesCache.get("probes", () => probesSnapshot());
   return c.json(snapshot);
 });
 

--- a/infra/status-page/server/sources/finelogQuery.ts
+++ b/infra/status-page/server/sources/finelogQuery.ts
@@ -1,0 +1,83 @@
+// Helper for running a read-only SQL query against the finelog log-server.
+//
+// Finelog's StatsService exposes a DuckDB-backed query endpoint at
+// /finelog.stats.StatsService/Query. The server speaks the Connect protocol
+// over plain HTTP, so — exactly like the iris controller's ExecuteRawQuery
+// (see controllerQuery.ts) — a JSON POST works without a generated client:
+//
+//   request  { sql: string }
+//   response { arrowIpc: <base64 bytes>, rowCount: <int64 as string> }
+//
+// The result table is an Arrow IPC stream (proto3 JSON encodes the `bytes`
+// field as base64). We decode it with apache-arrow and hand callers plain
+// JS row objects, coercing Arrow's BigInt cells to numbers so the rows
+// survive JSON serialization back out of the dashboard API.
+
+import { tableFromIPC } from "apache-arrow";
+import { activeFinelogUrl } from "./serviceHealth.js";
+
+const QUERY_PATH = "/finelog.stats.StatsService/Query";
+const QUERY_TIMEOUT_MS = 10_000;
+
+interface QueryWireResponse {
+  // proto3 JSON lower-camel-cases field names; accept the proto names too in
+  // case a future codec emits them verbatim.
+  arrowIpc?: string;
+  arrow_ipc?: string;
+}
+
+// Format a Date as the tz-naive UTC literal DuckDB compares against finelog's
+// timestamp('ms') columns (which the probes stamp in UTC). Mirrors the
+// `TIMESTAMP 'YYYY-MM-DD HH:MM:SS'` literal infra/probes/src/provisioning.py
+// builds, sidestepping tz-aware-vs-naive comparison errors from now().
+export function sqlTimestampUtc(at: Date): string {
+  return at.toISOString().slice(0, 19).replace("T", " ");
+}
+
+export async function queryFinelog(sql: string): Promise<Record<string, unknown>[]> {
+  const base = await activeFinelogUrl();
+  // Hold a strong reference to the controller so the abort timer is not GC'd
+  // before it fires (same undici quirk controllerQuery.ts guards against).
+  const ac = new AbortController();
+  const timer = setTimeout(() => ac.abort(new Error("finelog query timed out after 10s")), QUERY_TIMEOUT_MS);
+  try {
+    const res = await fetch(`${base}${QUERY_PATH}`, {
+      method: "POST",
+      // connectrpc (the Rust server crate) follows the Connect spec, which
+      // requires this header on unary JSON calls to distinguish them from a
+      // stray POST; the iris controller's Python server is laxer but it's
+      // standard to send it.
+      headers: { "content-type": "application/json", "connect-protocol-version": "1" },
+      body: JSON.stringify({ sql }),
+      signal: ac.signal,
+    });
+    if (!res.ok) {
+      // Connect reports failures as non-2xx with a JSON { code, message } body.
+      const body = await res.text().catch(() => "");
+      throw new Error(`finelog Query ${res.status}: ${body.slice(0, 300)}`);
+    }
+    const body = (await res.json()) as QueryWireResponse;
+    const arrowB64 = body.arrowIpc ?? body.arrow_ipc;
+    if (!arrowB64) return [];
+    return decodeArrowRows(Buffer.from(arrowB64, "base64"));
+  } finally {
+    clearTimeout(timer);
+  }
+}
+
+function decodeArrowRows(ipc: Uint8Array): Record<string, unknown>[] {
+  const table = tableFromIPC(ipc);
+  const fields = table.schema.fields.map((f) => f.name);
+  const rows: Record<string, unknown>[] = [];
+  for (const row of table) {
+    const obj: Record<string, unknown> = {};
+    for (const name of fields) {
+      const value = (row as Record<string, unknown>)[name];
+      // Arrow returns int64/timestamp cells as BigInt, which JSON.stringify
+      // rejects; downgrade to number (safe for our ms timestamps and counts).
+      obj[name] = typeof value === "bigint" ? Number(value) : value;
+    }
+    rows.push(obj);
+  }
+  return rows;
+}

--- a/infra/status-page/server/sources/probes.ts
+++ b/infra/status-page/server/sources/probes.ts
@@ -1,0 +1,347 @@
+// Synthetic-canary view, read from the finelog metrics the infra/probes
+// daemon writes (namespace `infra.canary.metrics`).
+//
+// Every probe cycle emits flat `Sample` rows — { metric, value, labels (a
+// JSON object string), collected_at } — covering both up/down health checks
+// and numeric gauges (see infra/probes/src/sample.py). This module turns two
+// bounded DuckDB queries over that namespace into a typed snapshot:
+//
+//   - checks: the latest probe_up / probe_latency_ms per synthetic health
+//     check (controller-ping, finelog-write, iris-job-submit/<zone>).
+//   - provisioning: the latest accelerator-provisioning cycle the probes roll
+//     up from the controller's iris.provisioning namespace — fleet success
+//     ratio, create→ready latency, outcome counts, and a per-pool breakdown
+//     (see infra/probes/src/provisioning.py for the metric vocabulary).
+
+import { queryFinelog, sqlTimestampUtc } from "./finelogQuery.js";
+
+const METRICS_NAMESPACE = "infra.canary.metrics";
+
+// How far back each query scans for "latest" rows. The health checks run on a
+// ≤5min cadence and provisioning every 15min, so two hours comfortably covers
+// the freshest cycle while bounding the scan; a longer reach only matters
+// right after a canary restart, where MAX(collected_at) still wins.
+const CHECKS_LOOKBACK_MS = 2 * 60 * 60 * 1000;
+// Provisioning rolls a trailing 3h window forward every 15min; reach back far
+// enough that a brief canary outage doesn't blank the panel.
+const PROVISIONING_LOOKBACK_MS = 6 * 60 * 60 * 1000;
+
+// Metric names emitted by the probe collectors (infra/probes/src). Kept in
+// sync with runner.py (health meta-metrics) and provisioning.py (gauges).
+const METRIC_UP = "probe_up";
+const METRIC_LATENCY_MS = "probe_latency_ms";
+const PROVISION_PREFIX = "provision_";
+const METRIC_PROVISION_READY = "provision_ready";
+const METRIC_PROVISION_STOCKOUT = "provision_stockout";
+const METRIC_PROVISION_ERROR = "provision_error";
+const METRIC_PROVISION_PREEMPTED = "provision_preempted";
+const METRIC_PROVISION_OUTCOMES = "provision_outcomes";
+const METRIC_PROVISION_SUCCESS_RATIO = "provision_success_ratio";
+const METRIC_PROVISION_POOLS_PLACING = "provision_pools_placing";
+const METRIC_PROVISION_POOLS_STOCKOUT_DEAD = "provision_pools_stockout_dead";
+const METRIC_PROVISION_WINDOW_HOURS = "provision_window_hours";
+const METRIC_PROVISION_LATENCY_SECONDS = "provision_latency_seconds";
+
+const FLEET_SCOPE = "fleet";
+
+export interface ProbeCheck {
+  probe: string;
+  up: boolean;
+  latencyMs: number | null;
+  collectedAt: string; // ISO of the latest probe_up sample
+}
+
+export interface ProvisionPool {
+  resourceType: string;
+  scaleGroup: string;
+  zone: string;
+  ready: number;
+  stockout: number;
+  error: number;
+  preempted: number;
+  outcomes: number; // resolved create attempts = ready + stockout + error
+  successRatio: number | null; // ready / outcomes
+  latencyP50Seconds: number | null;
+  latencyP95Seconds: number | null;
+}
+
+export interface ProvisionFleet {
+  ready: number;
+  stockout: number;
+  error: number;
+  preempted: number;
+  outcomes: number;
+  successRatio: number | null;
+  poolsPlacing: number;
+  poolsStockoutDead: number;
+  latencyP50Seconds: number | null;
+  latencyP95Seconds: number | null;
+}
+
+export interface ProvisioningSnapshot {
+  windowHours: number | null;
+  collectedAt: string | null; // cycle timestamp shared by every row
+  fleet: ProvisionFleet | null;
+  pools: ProvisionPool[];
+}
+
+export interface ProbesSnapshot {
+  checks: ProbeCheck[];
+  provisioning: ProvisioningSnapshot;
+  fetchedAt: string;
+  error?: string;
+}
+
+// Provisioning rows: friendly types, with collected_at as epoch-ms so Arrow
+// hands us a plain number rather than a timestamp object, and the JSON label
+// object kept as a string for per-row decode.
+interface MetricRow {
+  metric: string;
+  value: number;
+  labels: string; // JSON object string
+  collected_ms: number;
+}
+
+// Health-check rows: the probe label is projected into its own column by
+// checksSql, so there is no labels blob to decode here.
+interface CheckRow {
+  probe: string;
+  metric: string;
+  value: number;
+  collected_ms: number;
+}
+
+function emptyProvisioning(): ProvisioningSnapshot {
+  return { windowHours: null, collectedAt: null, fleet: null, pools: [] };
+}
+
+const checksSql = (cutoff: string) => `
+  WITH recent AS (
+    SELECT
+      json_extract_string(labels, '$.probe') AS probe,
+      metric,
+      value,
+      collected_at,
+      ROW_NUMBER() OVER (
+        PARTITION BY json_extract_string(labels, '$.probe'), metric
+        ORDER BY collected_at DESC
+      ) AS rn
+    FROM "${METRICS_NAMESPACE}"
+    WHERE metric IN ('${METRIC_UP}', '${METRIC_LATENCY_MS}')
+      AND collected_at >= TIMESTAMP '${cutoff}'
+  )
+  SELECT probe, metric, value::DOUBLE AS value, epoch_ms(collected_at)::BIGINT AS collected_ms
+  FROM recent
+  WHERE rn = 1 AND probe IS NOT NULL
+`;
+
+const provisioningSql = (cutoff: string) => `
+  SELECT metric, value::DOUBLE AS value, labels, epoch_ms(collected_at)::BIGINT AS collected_ms
+  FROM "${METRICS_NAMESPACE}"
+  WHERE metric LIKE '${PROVISION_PREFIX}%'
+    AND collected_at >= TIMESTAMP '${cutoff}'
+    AND collected_at = (
+      SELECT MAX(collected_at) FROM "${METRICS_NAMESPACE}"
+      WHERE metric LIKE '${PROVISION_PREFIX}%' AND collected_at >= TIMESTAMP '${cutoff}'
+    )
+`;
+
+function asMetricRows(rows: Record<string, unknown>[]): MetricRow[] {
+  return rows.map((r) => ({
+    metric: String(r.metric),
+    value: Number(r.value),
+    labels: String(r.labels ?? "{}"),
+    collected_ms: Number(r.collected_ms),
+  }));
+}
+
+function asCheckRows(rows: Record<string, unknown>[]): CheckRow[] {
+  return rows.map((r) => ({
+    probe: String(r.probe),
+    metric: String(r.metric),
+    value: Number(r.value),
+    collected_ms: Number(r.collected_ms),
+  }));
+}
+
+// Latest probe_up (+ matching probe_latency_ms) per synthetic health check.
+// Only probes that emit probe_up appear — the gauge collectors
+// (provisioning/workers/jobs) emit probe_up solely when they fail, so a
+// failing gauge surfaces here too, but a healthy one stays out of the list.
+function parseChecks(rows: CheckRow[]): ProbeCheck[] {
+  const up = new Map<string, { value: number; collectedMs: number }>();
+  const latency = new Map<string, number>();
+  for (const row of rows) {
+    if (row.metric === METRIC_UP) up.set(row.probe, { value: row.value, collectedMs: row.collected_ms });
+    else if (row.metric === METRIC_LATENCY_MS) latency.set(row.probe, row.value);
+  }
+  return [...up.entries()]
+    .map(([probe, { value, collectedMs }]) => ({
+      probe,
+      up: value === 1,
+      latencyMs: latency.has(probe) ? Math.round(latency.get(probe)!) : null,
+      collectedAt: new Date(collectedMs).toISOString(),
+    }))
+    .sort((a, b) => a.probe.localeCompare(b.probe));
+}
+
+function safeLabels(raw: string): Record<string, string> {
+  try {
+    return JSON.parse(raw) as Record<string, string>;
+  } catch {
+    return {};
+  }
+}
+
+function blankFleet(): ProvisionFleet {
+  return {
+    ready: 0,
+    stockout: 0,
+    error: 0,
+    preempted: 0,
+    outcomes: 0,
+    successRatio: null,
+    poolsPlacing: 0,
+    poolsStockoutDead: 0,
+    latencyP50Seconds: null,
+    latencyP95Seconds: null,
+  };
+}
+
+function blankPool(resourceType: string, scaleGroup: string, zone: string): ProvisionPool {
+  return {
+    resourceType,
+    scaleGroup,
+    zone,
+    ready: 0,
+    stockout: 0,
+    error: 0,
+    preempted: 0,
+    outcomes: 0,
+    successRatio: null,
+    latencyP50Seconds: null,
+    latencyP95Seconds: null,
+  };
+}
+
+// Roll the latest provisioning cycle's rows into fleet + per-pool series.
+// Every row in the cycle shares one collected_at; fleet rows carry
+// scope=fleet, pool rows carry resource_type/scale_group/zone, and latency
+// rows additionally carry a quantile label (p50/p95).
+function parseProvisioning(rows: MetricRow[]): ProvisioningSnapshot {
+  if (rows.length === 0) return emptyProvisioning();
+
+  const fleet = blankFleet();
+  const pools = new Map<string, ProvisionPool>();
+  let windowHours: number | null = null;
+
+  for (const row of rows) {
+    const labels = safeLabels(row.labels);
+    const quantile = labels.quantile;
+    if (labels.scope === FLEET_SCOPE) {
+      applyFleetMetric(fleet, row.metric, row.value, quantile);
+      if (row.metric === METRIC_PROVISION_WINDOW_HOURS) windowHours = row.value;
+      continue;
+    }
+    if (labels.resource_type && labels.scale_group && labels.zone) {
+      const key = `${labels.resource_type} ${labels.scale_group} ${labels.zone}`;
+      const pool = pools.get(key) ?? blankPool(labels.resource_type, labels.scale_group, labels.zone);
+      applyCountMetric(pool, row.metric, row.value, quantile);
+      pools.set(key, pool);
+    }
+  }
+
+  for (const pool of pools.values()) {
+    pool.successRatio = pool.outcomes > 0 ? pool.ready / pool.outcomes : null;
+  }
+
+  return {
+    windowHours,
+    collectedAt: new Date(rows[0]!.collected_ms).toISOString(),
+    fleet,
+    pools: [...pools.values()].sort(
+      (a, b) =>
+        a.resourceType.localeCompare(b.resourceType) ||
+        a.scaleGroup.localeCompare(b.scaleGroup) ||
+        a.zone.localeCompare(b.zone),
+    ),
+  };
+}
+
+// The outcome counts + latency quantiles shared by the fleet and per-pool
+// series — both ProvisionFleet and ProvisionPool structurally satisfy this.
+interface ProvisionCounts {
+  ready: number;
+  stockout: number;
+  error: number;
+  preempted: number;
+  outcomes: number;
+  latencyP50Seconds: number | null;
+  latencyP95Seconds: number | null;
+}
+
+// Apply a count/latency metric common to both series; ignores fleet-only
+// metrics (success ratio, pool tallies, window) which applyFleetMetric owns.
+function applyCountMetric(target: ProvisionCounts, metric: string, value: number, quantile?: string): void {
+  switch (metric) {
+    case METRIC_PROVISION_READY:
+      target.ready = value;
+      break;
+    case METRIC_PROVISION_STOCKOUT:
+      target.stockout = value;
+      break;
+    case METRIC_PROVISION_ERROR:
+      target.error = value;
+      break;
+    case METRIC_PROVISION_PREEMPTED:
+      target.preempted = value;
+      break;
+    case METRIC_PROVISION_OUTCOMES:
+      target.outcomes = value;
+      break;
+    case METRIC_PROVISION_LATENCY_SECONDS:
+      if (quantile === "p50") target.latencyP50Seconds = value;
+      else if (quantile === "p95") target.latencyP95Seconds = value;
+      break;
+  }
+}
+
+function applyFleetMetric(fleet: ProvisionFleet, metric: string, value: number, quantile?: string): void {
+  applyCountMetric(fleet, metric, value, quantile);
+  switch (metric) {
+    case METRIC_PROVISION_SUCCESS_RATIO:
+      fleet.successRatio = value;
+      break;
+    case METRIC_PROVISION_POOLS_PLACING:
+      fleet.poolsPlacing = value;
+      break;
+    case METRIC_PROVISION_POOLS_STOCKOUT_DEAD:
+      fleet.poolsStockoutDead = value;
+      break;
+  }
+}
+
+export async function probesSnapshot(): Promise<ProbesSnapshot> {
+  const fetchedAt = new Date().toISOString();
+  const now = Date.now();
+  const checksCutoff = sqlTimestampUtc(new Date(now - CHECKS_LOOKBACK_MS));
+  const provisioningCutoff = sqlTimestampUtc(new Date(now - PROVISIONING_LOOKBACK_MS));
+  try {
+    const [checkRows, provisioningRows] = await Promise.all([
+      queryFinelog(checksSql(checksCutoff)),
+      queryFinelog(provisioningSql(provisioningCutoff)),
+    ]);
+    return {
+      checks: parseChecks(asCheckRows(checkRows)),
+      provisioning: parseProvisioning(asMetricRows(provisioningRows)),
+      fetchedAt,
+    };
+  } catch (err) {
+    return {
+      checks: [],
+      provisioning: emptyProvisioning(),
+      fetchedAt,
+      error: (err as Error).message,
+    };
+  }
+}

--- a/infra/status-page/server/sources/probes.ts
+++ b/infra/status-page/server/sources/probes.ts
@@ -185,10 +185,16 @@ function parseChecks(rows: CheckRow[]): ProbeCheck[] {
     .sort((a, b) => a.probe.localeCompare(b.probe));
 }
 
+// Decode a row's JSON label blob. The probes write it via json.dumps, so a
+// parse failure is a real anomaly (schema drift / truncation), not an
+// expected case — log it rather than letting the row's scope/pool fields
+// silently vanish from the rollup. The empty fallback keeps one bad row from
+// sinking the whole snapshot.
 function safeLabels(raw: string): Record<string, string> {
   try {
     return JSON.parse(raw) as Record<string, string>;
-  } catch {
+  } catch (err) {
+    console.warn(`probes: unparseable labels ${JSON.stringify(raw.slice(0, 200))}: ${(err as Error).message}`);
     return {};
   }
 }

--- a/infra/status-page/server/sources/serviceHealth.ts
+++ b/infra/status-page/server/sources/serviceHealth.ts
@@ -248,6 +248,18 @@ export function serviceHealthSeries(): ServiceHealthSeries[] {
   return ACTIVE_SERVICE_HEALTH_CONFIGS.map(metadata);
 }
 
+// Base URL of the active environment's finelog log-server (port 10001),
+// honouring the same overrides + GCE discovery the health probe uses. The
+// probes panel queries this server's StatsService for the canary metrics.
+export async function activeFinelogUrl(): Promise<string> {
+  const config = ACTIVE_SERVICE_HEALTH_CONFIGS.find((c) => c.service === "finelog");
+  if (!config) {
+    throw new Error(`no finelog service configured for environment ${ACTIVE_SERVICE_ENVIRONMENT}`);
+  }
+  const url = await discoverGceUrl(config);
+  return url.replace(/\/$/, "");
+}
+
 export async function serviceHealthSnapshot(): Promise<ServiceHealthSnapshot[]> {
   return Promise.all(ACTIVE_SERVICE_HEALTH_CONFIGS.map(probe));
 }

--- a/infra/status-page/web/src/App.tsx
+++ b/infra/status-page/web/src/App.tsx
@@ -2,6 +2,7 @@ import { useAtom } from "jotai";
 import { BuildPanel } from "./components/BuildPanel";
 import { FerryPanel } from "./components/FerryPanel";
 import { IrisPanel } from "./components/IrisPanel";
+import { ProbesPanel } from "./components/ProbesPanel";
 import { autoRefreshAtom } from "./state";
 
 export function App() {
@@ -26,6 +27,7 @@ export function App() {
         <FerryPanel />
         <BuildPanel />
         <IrisPanel />
+        <ProbesPanel />
       </div>
     </div>
   );

--- a/infra/status-page/web/src/api.ts
+++ b/infra/status-page/web/src/api.ts
@@ -183,6 +183,56 @@ export interface JobsSnapshot {
   error?: string;
 }
 
+// Synthetic-canary probes, read from finelog's `infra.canary.metrics`. Mirrors
+// server/sources/probes.ts.
+export interface ProbeCheck {
+  probe: string;
+  up: boolean;
+  latencyMs: number | null;
+  collectedAt: string;
+}
+
+export interface ProvisionPool {
+  resourceType: string;
+  scaleGroup: string;
+  zone: string;
+  ready: number;
+  stockout: number;
+  error: number;
+  preempted: number;
+  outcomes: number;
+  successRatio: number | null;
+  latencyP50Seconds: number | null;
+  latencyP95Seconds: number | null;
+}
+
+export interface ProvisionFleet {
+  ready: number;
+  stockout: number;
+  error: number;
+  preempted: number;
+  outcomes: number;
+  successRatio: number | null;
+  poolsPlacing: number;
+  poolsStockoutDead: number;
+  latencyP50Seconds: number | null;
+  latencyP95Seconds: number | null;
+}
+
+export interface ProvisioningSnapshot {
+  windowHours: number | null;
+  collectedAt: string | null;
+  fleet: ProvisionFleet | null;
+  pools: ProvisionPool[];
+}
+
+export interface ProbesSnapshot {
+  checks: ProbeCheck[];
+  provisioning: ProvisioningSnapshot;
+  fetchedAt: string;
+  error?: string;
+}
+
 async function getJson<T>(path: string): Promise<T> {
   const res = await fetch(path);
   if (!res.ok) {
@@ -199,3 +249,4 @@ export const fetchControlPlaneHealth = () =>
 export const fetchWorkers = () => getJson<WorkersSnapshot>("/api/workers");
 export const fetchWorkersHistory = () => getJson<WorkersHistoryResponse>("/api/workers/history");
 export const fetchJobs = () => getJson<JobsSnapshot>("/api/jobs");
+export const fetchProbes = () => getJson<ProbesSnapshot>("/api/probes");

--- a/infra/status-page/web/src/components/BuildPanel.tsx
+++ b/infra/status-page/web/src/components/BuildPanel.tsx
@@ -1,5 +1,6 @@
 import type { CommitState, CommitStatus } from "../api";
 import { useBuilds } from "../hooks/useBuilds";
+import { formatRelative } from "./chartUtils";
 
 // Mirrors the status dot in GitHub's commits view: green = all checks
 // passed, rose = something failed/errored, amber = still running,
@@ -36,19 +37,6 @@ function stateLabel(state: CommitState): string {
     case "NONE":
       return "no checks";
   }
-}
-
-function formatRelative(iso: string): string {
-  const delta = Date.now() - Date.parse(iso);
-  if (!Number.isFinite(delta)) return iso;
-  const seconds = Math.round(delta / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 48) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  return `${days}d ago`;
 }
 
 // Simple SVG crown rendered as an absolutely-positioned overlay on top

--- a/infra/status-page/web/src/components/FerryPanel.tsx
+++ b/infra/status-page/web/src/components/FerryPanel.tsx
@@ -1,6 +1,7 @@
 import type { CSSProperties } from "react";
 import { useFerry } from "../hooks/useFerry";
 import type { FerryGroupStatus, FerryRun, FerryTierStatus } from "../api";
+import { formatRelative } from "./chartUtils";
 
 // Diagonal gray/red stripe marks cancelled runs — they count as failures
 // for success-rate math but carry a distinct cause worth surfacing.
@@ -76,19 +77,6 @@ function formatDuration(seconds: number | null): string {
   if (minutes < 60) return `${minutes}m ${remSec}s`;
   const hours = Math.floor(minutes / 60);
   return `${hours}h ${minutes % 60}m`;
-}
-
-function formatRelative(iso: string): string {
-  const delta = Date.now() - Date.parse(iso);
-  if (!Number.isFinite(delta)) return iso;
-  const seconds = Math.round(delta / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.round(seconds / 60);
-  if (minutes < 60) return `${minutes}m ago`;
-  const hours = Math.round(minutes / 60);
-  if (hours < 48) return `${hours}h ago`;
-  const days = Math.round(hours / 24);
-  return `${days}d ago`;
 }
 
 // One tier's run strip: latest-run line, success rate, and the last-N-runs

--- a/infra/status-page/web/src/components/IrisPanel.tsx
+++ b/infra/status-page/web/src/components/IrisPanel.tsx
@@ -1,17 +1,8 @@
 import { useIris } from "../hooks/useIris";
-import { formatDuration } from "./chartUtils";
+import { formatDuration, formatRelative } from "./chartUtils";
 import { ControlPlanePanel } from "./ControlPlanePanel";
 import { JobsPanel } from "./JobsPanel";
 import { WorkersPanel } from "./WorkersPanel";
-
-function formatRelative(iso: string): string {
-  const delta = Date.now() - Date.parse(iso);
-  if (!Number.isFinite(delta)) return iso;
-  const seconds = Math.round(delta / 1000);
-  if (seconds < 60) return `${seconds}s ago`;
-  const minutes = Math.round(seconds / 60);
-  return `${minutes}m ago`;
-}
 
 function percentileTitle(spanMs: number, count: number): string {
   if (spanMs > 0) return `over last ${formatDuration(spanMs)}, n=${count}`;

--- a/infra/status-page/web/src/components/ProbesPanel.tsx
+++ b/infra/status-page/web/src/components/ProbesPanel.tsx
@@ -1,0 +1,196 @@
+import type { ProbeCheck, ProvisionFleet, ProvisionPool, ProvisioningSnapshot } from "../api";
+import { useProbes } from "../hooks/useProbes";
+import { formatRelative } from "./chartUtils";
+
+// create→ready latency, reported in seconds; minutes once it crosses 90s.
+function formatLatencySeconds(value: number | null): string {
+  if (value === null) return "—";
+  if (value < 90) return `${Math.round(value)}s`;
+  return `${(value / 60).toFixed(1)}m`;
+}
+
+function ratioColor(ratio: number | null): string {
+  if (ratio === null) return "text-slate-400";
+  if (ratio >= 0.9) return "text-emerald-400";
+  if (ratio >= 0.5) return "text-amber-400";
+  return "text-rose-400";
+}
+
+function formatPercent(ratio: number | null): string {
+  return ratio === null ? "—" : `${Math.round(ratio * 100)}%`;
+}
+
+function CheckPill({ check }: { check: ProbeCheck }) {
+  return (
+    <div
+      className="flex items-center gap-2 rounded-md border border-slate-800 bg-slate-900/60 px-3 py-1.5"
+      title={`updated ${formatRelative(check.collectedAt)}`}
+    >
+      <span
+        className={`h-2.5 w-2.5 shrink-0 rounded-full ${check.up ? "bg-emerald-500" : "bg-rose-500"}`}
+      />
+      <span className="font-mono text-xs text-slate-300">{check.probe}</span>
+      {check.latencyMs !== null && (
+        <span className="text-xs text-slate-500">{check.latencyMs}ms</span>
+      )}
+    </div>
+  );
+}
+
+// One outcome count rendered as a labelled chip; colour cues whether the
+// outcome is good (ready) or a problem (stockout/error/preempted).
+function OutcomeChip({ label, value, tone }: { label: string; value: number; tone: string }) {
+  return (
+    <div className="flex items-baseline gap-1.5">
+      <span className={`font-mono text-sm ${tone}`}>{value}</span>
+      <span className="text-xs text-slate-500">{label}</span>
+    </div>
+  );
+}
+
+function FleetSummary({ fleet }: { fleet: ProvisionFleet }) {
+  return (
+    <div className="flex flex-wrap items-center gap-x-8 gap-y-3">
+      <div>
+        <div className={`text-3xl font-bold ${ratioColor(fleet.successRatio)}`}>
+          {formatPercent(fleet.successRatio)}
+        </div>
+        <div className="text-xs text-slate-500">
+          create success · {fleet.ready}/{fleet.outcomes} attempts
+        </div>
+      </div>
+      <div className="flex flex-wrap gap-x-5 gap-y-1">
+        <OutcomeChip label="ready" value={fleet.ready} tone="text-emerald-400" />
+        <OutcomeChip label="stockout" value={fleet.stockout} tone="text-amber-400" />
+        <OutcomeChip label="error" value={fleet.error} tone="text-rose-400" />
+        <OutcomeChip label="preempted" value={fleet.preempted} tone="text-slate-300" />
+      </div>
+      <div className="flex flex-wrap gap-x-5 gap-y-1">
+        <OutcomeChip label="pools placing" value={fleet.poolsPlacing} tone="text-emerald-400" />
+        <OutcomeChip
+          label="pools stuck"
+          value={fleet.poolsStockoutDead}
+          tone={fleet.poolsStockoutDead > 0 ? "text-rose-400" : "text-slate-300"}
+        />
+      </div>
+      <div className="text-xs text-slate-500">
+        latency p50 {formatLatencySeconds(fleet.latencyP50Seconds)} · p95{" "}
+        {formatLatencySeconds(fleet.latencyP95Seconds)}
+      </div>
+    </div>
+  );
+}
+
+function PoolRow({ pool }: { pool: ProvisionPool }) {
+  return (
+    <tr className="border-t border-slate-800/70">
+      <td className="py-1.5 pr-3">
+        <span className="font-mono text-xs text-slate-300">{pool.resourceType}</span>
+        <span className="text-xs text-slate-500">
+          {" "}
+          · {pool.scaleGroup} · {pool.zone}
+        </span>
+      </td>
+      <td className="px-2 text-right font-mono text-xs text-slate-400">{pool.outcomes}</td>
+      <td className="px-2 text-right font-mono text-xs text-emerald-400">{pool.ready}</td>
+      <td className="px-2 text-right font-mono text-xs text-amber-400">{pool.stockout}</td>
+      <td className="px-2 text-right font-mono text-xs text-rose-400">{pool.error}</td>
+      <td className="px-2 text-right font-mono text-xs text-slate-400">{pool.preempted}</td>
+      <td className={`px-2 text-right font-mono text-xs ${ratioColor(pool.successRatio)}`}>
+        {formatPercent(pool.successRatio)}
+      </td>
+      <td className="pl-2 text-right font-mono text-xs text-slate-400">
+        {formatLatencySeconds(pool.latencyP50Seconds)}
+      </td>
+    </tr>
+  );
+}
+
+function ProvisioningSection({ provisioning }: { provisioning: ProvisioningSnapshot }) {
+  const { fleet, pools, windowHours, collectedAt } = provisioning;
+  return (
+    <section>
+      <div className="mb-3 flex items-baseline gap-2">
+        <h4 className="text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+          Provisioning
+        </h4>
+        {windowHours !== null && (
+          <span className="text-xs text-slate-500">trailing {windowHours}h window</span>
+        )}
+        {collectedAt && (
+          <span className="ml-auto text-xs text-slate-600">
+            collected {formatRelative(collectedAt)}
+          </span>
+        )}
+      </div>
+      {!fleet || collectedAt === null ? (
+        <div className="text-sm text-slate-500">no provisioning data yet</div>
+      ) : (
+        <div className="space-y-4">
+          <FleetSummary fleet={fleet} />
+          {pools.length > 0 && (
+            <table className="w-full">
+              <thead>
+                <tr className="text-left text-[10px] uppercase tracking-wider text-slate-600">
+                  <th className="pb-1 pr-3 font-medium">pool</th>
+                  <th className="px-2 pb-1 text-right font-medium">attempts</th>
+                  <th className="px-2 pb-1 text-right font-medium">ready</th>
+                  <th className="px-2 pb-1 text-right font-medium">stockout</th>
+                  <th className="px-2 pb-1 text-right font-medium">error</th>
+                  <th className="px-2 pb-1 text-right font-medium">preempt</th>
+                  <th className="px-2 pb-1 text-right font-medium">success</th>
+                  <th className="pl-2 pb-1 text-right font-medium">p50</th>
+                </tr>
+              </thead>
+              <tbody>
+                {pools.map((pool) => (
+                  <PoolRow key={`${pool.resourceType} ${pool.scaleGroup} ${pool.zone}`} pool={pool} />
+                ))}
+              </tbody>
+            </table>
+          )}
+        </div>
+      )}
+    </section>
+  );
+}
+
+export function ProbesPanel() {
+  const { data, isLoading, error } = useProbes();
+
+  return (
+    <section>
+      <div className="mb-3 flex flex-wrap items-baseline gap-x-3 gap-y-1">
+        <h2 className="text-xl font-semibold text-slate-200">Probes</h2>
+        <span className="text-xs text-slate-500">synthetic canary · infra/probes</span>
+      </div>
+      <div className="rounded-lg border border-slate-800 bg-slate-900/60 p-4">
+        {isLoading && <div className="text-slate-400">loading…</div>}
+        {error && (
+          <div className="text-rose-400">failed to load: {(error as Error).message}</div>
+        )}
+        {data?.error && <div className="text-sm text-rose-400">{data.error}</div>}
+        {data && !data.error && (
+          <div className="space-y-5">
+            <section>
+              <h4 className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-slate-500">
+                Health checks
+              </h4>
+              {data.checks.length === 0 ? (
+                <div className="text-sm text-slate-500">no probe samples in the last 2h</div>
+              ) : (
+                <div className="flex flex-wrap gap-2">
+                  {data.checks.map((check) => (
+                    <CheckPill key={check.probe} check={check} />
+                  ))}
+                </div>
+              )}
+            </section>
+            <div className="border-t border-slate-800" />
+            <ProvisioningSection provisioning={data.provisioning} />
+          </div>
+        )}
+      </div>
+    </section>
+  );
+}

--- a/infra/status-page/web/src/components/chartUtils.ts
+++ b/infra/status-page/web/src/components/chartUtils.ts
@@ -1,5 +1,20 @@
 import { useCallback, useEffect, useState } from "react";
 
+// Human "N{s,m,h,d} ago" for an ISO timestamp. Non-parseable input is
+// echoed back. Shared by every panel's "updated …" / "collected …" line.
+export function formatRelative(iso: string): string {
+  const delta = Date.now() - Date.parse(iso);
+  if (!Number.isFinite(delta)) return iso;
+  const seconds = Math.round(delta / 1000);
+  if (seconds < 60) return `${seconds}s ago`;
+  const minutes = Math.round(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.round(minutes / 60);
+  if (hours < 48) return `${hours}h ago`;
+  const days = Math.round(hours / 24);
+  return `${days}d ago`;
+}
+
 export function formatClock(ms: number): string {
   const d = new Date(ms);
   const hh = d.getHours().toString().padStart(2, "0");

--- a/infra/status-page/web/src/hooks/useProbes.ts
+++ b/infra/status-page/web/src/hooks/useProbes.ts
@@ -1,0 +1,18 @@
+import { useQuery } from "@tanstack/react-query";
+import { useAtomValue } from "jotai";
+import { fetchProbes } from "../api";
+import { autoRefreshAtom } from "../state";
+
+// Probe metrics move slowly (health checks ≤5min, provisioning 15min) and the
+// backend shields finelog behind a 60s TTL; poll on the same cadence.
+const REFETCH_INTERVAL_MS = 60_000;
+
+export function useProbes() {
+  const autoRefresh = useAtomValue(autoRefreshAtom);
+  return useQuery({
+    queryKey: ["probes"],
+    queryFn: fetchProbes,
+    refetchInterval: autoRefresh ? REFETCH_INTERVAL_MS : false,
+    staleTime: 30_000,
+  });
+}


### PR DESCRIPTION
* surface the metrics `infra/probes/` writes to the finelog `infra.canary.metrics` namespace on the status page — synthetic health checks plus the accelerator-provisioning rollup
* `server/sources/finelogQuery.ts` — run read-only SQL against finelog's `StatsService.Query` Connect RPC (plain JSON POST, same shape as `controllerQuery.ts`), decode the Arrow IPC result table with `apache-arrow`[^1]
  * resolves the active-env finelog URL via a new `activeFinelogUrl()` in `serviceHealth.ts` (same overrides + GCE discovery as the control-plane health probe) — no controller hop
* `server/sources/probes.ts` — two bounded DuckDB queries over `infra.canary.metrics`:
  * health checks: latest `probe_up` (+ matching `probe_latency_ms`) per synthetic check (`controller-ping`, `finelog-write`, `iris-job-submit/<zone>`)
  * provisioning: the latest cycle's `provision_*` gauges → fleet summary (create success ratio = ready / resolved attempts, create→ready latency p50/p95, ready/stockout/error/preempted, pools placing vs stuck) + per-pool breakdown keyed by `(resource_type, scale_group, zone)`
* `ProbesPanel.tsx` + `/api/probes` (60s TTL cache) + `useProbes` hook, wired into `App.tsx`
* dedupe `formatRelative` into `chartUtils` — it had drifted across `IrisPanel`/`BuildPanel`/`FerryPanel` (lint `ml-duplicate-logic-block`)
* `apache-arrow` added as a server-only dep; it never enters the web bundle

[^1]: finelog's `Query` RPC always returns an Arrow IPC stream (proto3 JSON base64-encodes the `bytes` field), so Arrow decode is unavoidable; verified the full decode→parse chain against a mocked Connect response (int64→number coercion, checks join, provisioning rollup). lint, typecheck, and build are green. not yet exercised against a live finelog — worth an `npm run dev` against a finelog tunnel before deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)