### PR TITLE
[iris] k8s: bulk pod-metrics query to cut controller load

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/fake.py
@@ -275,12 +275,14 @@ class InMemoryK8sService:
         )
         self._resources: dict[tuple[str, str], dict] = {}  # (kind, name) -> manifest
         self._injected_failures: dict[str, Exception] = {}
+        self._persistent_failures: dict[str, Exception] = {}
         self._logs: dict[str, str] = {}  # pod_name -> log text
         self._events: list[dict] = []
         self._exec_responses: dict[str, list[ExecResult]] = {}
         self._file_contents: dict[tuple[str, str], bytes] = {}  # (pod_name, path) -> data
         self._rm_files_calls: list[tuple[str, list[str]]] = []
         self._top_pod_overrides: dict[str, PodResourceUsage | None] = {}
+        self.top_pods_call_count = 0
         self._log_watermarks: dict[str, int] = {}  # pod_name -> bytes consumed
 
         # Pods living outside the service's own namespace, keyed by
@@ -472,12 +474,21 @@ class InMemoryK8sService:
 
     # -- Failure injection --
 
-    def inject_failure(self, operation: str, error: Exception) -> None:
-        """Inject a one-shot failure for the next call to *operation*."""
-        self._injected_failures[operation] = error
+    def inject_failure(self, operation: str, error: Exception, *, persistent: bool = False) -> None:
+        """Inject a failure for *operation*.
+
+        One-shot by default (consumed by the next call); ``persistent=True``
+        raises on every call until cleared — needed for operations a background
+        loop retries on its own cadence.
+        """
+        if persistent:
+            self._persistent_failures[operation] = error
+        else:
+            self._injected_failures[operation] = error
 
     def clear_failure(self, operation: str) -> None:
         self._injected_failures.pop(operation, None)
+        self._persistent_failures.pop(operation, None)
 
     # -- Node pool management --
 
@@ -610,7 +621,7 @@ class InMemoryK8sService:
         self._file_contents[(pod_name, path)] = data
 
     def set_top_pod(self, pod_name: str, result: PodResourceUsage | None) -> None:
-        """Configure a specific top_pod result for a pod."""
+        """Configure a pod's reported resource usage (None = metrics absent)."""
         self._top_pod_overrides[pod_name] = result
 
     def seed_resource(self, resource: K8sResource, name: str, manifest: dict) -> None:
@@ -628,6 +639,8 @@ class InMemoryK8sService:
     # -- Protocol methods --
 
     def _check_failure(self, operation: str) -> None:
+        if err := self._persistent_failures.get(operation):
+            raise err
         if err := self._injected_failures.pop(operation, None):
             raise err
 
@@ -852,13 +865,27 @@ class InMemoryK8sService:
                 results.append(event)
         return results
 
-    def top_pod(self, pod_name: str) -> PodResourceUsage | None:
-        self._check_failure("top_pod")
-        if pod_name in self._top_pod_overrides:
-            return self._top_pod_overrides[pod_name]
-        if any(name == pod_name for (_, name) in self._resources):
-            return PodResourceUsage(cpu_millicores=100, memory_bytes=256 * 1024 * 1024)
-        return None
+    def top_pods(self, *, labels: dict[str, str] | None = None) -> dict[str, PodResourceUsage]:
+        self._check_failure("top_pods")
+        self.top_pods_call_count += 1
+        plural = K8sResource.PODS.plural
+        usage: dict[str, PodResourceUsage] = {}
+        for (stored_plural, name), manifest in self._resources.items():
+            if stored_plural != plural:
+                continue
+            if labels:
+                res_labels = manifest.get("metadata", {}).get("labels", {})
+                if not all(res_labels.get(k) == v for k, v in labels.items()):
+                    continue
+            usage[name] = PodResourceUsage(cpu_millicores=100, memory_bytes=256 * 1024 * 1024)
+        # Per-pod overrides win regardless of the label scope; a None override
+        # means "metrics absent" and drops the pod from the result.
+        for name, override in self._top_pod_overrides.items():
+            if override is None:
+                usage.pop(name, None)
+            else:
+                usage[name] = override
+        return usage
 
     def read_file(
         self,

--- a/lib/iris/src/iris/cluster/backends/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/fake.py
@@ -282,7 +282,6 @@ class InMemoryK8sService:
         self._file_contents: dict[tuple[str, str], bytes] = {}  # (pod_name, path) -> data
         self._rm_files_calls: list[tuple[str, list[str]]] = []
         self._top_pod_overrides: dict[str, PodResourceUsage | None] = {}
-        self.top_pods_call_count = 0
         self._log_watermarks: dict[str, int] = {}  # pod_name -> bytes consumed
 
         # Pods living outside the service's own namespace, keyed by
@@ -867,7 +866,6 @@ class InMemoryK8sService:
 
     def top_pods(self, *, labels: dict[str, str] | None = None) -> dict[str, PodResourceUsage]:
         self._check_failure("top_pods")
-        self.top_pods_call_count += 1
         plural = K8sResource.PODS.plural
         usage: dict[str, PodResourceUsage] = {}
         for (stored_plural, name), manifest in self._resources.items():

--- a/lib/iris/src/iris/cluster/backends/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/fake.py
@@ -474,17 +474,17 @@ class InMemoryK8sService:
 
     # -- Failure injection --
 
-    def inject_failure(self, operation: str, error: Exception, *, persistent: bool = False) -> None:
-        """Inject a failure for *operation*.
+    def inject_failure(self, operation: str, error: Exception) -> None:
+        """Inject a one-shot failure consumed by the next call to *operation*."""
+        self._injected_failures[operation] = error
 
-        One-shot by default (consumed by the next call); ``persistent=True``
-        raises on every call until cleared — needed for operations a background
-        loop retries on its own cadence.
+    def inject_persistent_failure(self, operation: str, error: Exception) -> None:
+        """Fail every call to *operation* until cleared.
+
+        Needed for operations a background loop retries on its own cadence,
+        where a one-shot failure would be consumed by the first poll.
         """
-        if persistent:
-            self._persistent_failures[operation] = error
-        else:
-            self._injected_failures[operation] = error
+        self._persistent_failures[operation] = error
 
     def clear_failure(self, operation: str) -> None:
         self._injected_failures.pop(operation, None)

--- a/lib/iris/src/iris/cluster/backends/k8s/service.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/service.py
@@ -687,15 +687,12 @@ class CloudK8sService:
     # -- top_pods ------------------------------------------------------------
 
     def top_pods(self, *, labels: dict[str, str] | None = None) -> dict[str, PodResourceUsage]:
-        """Bulk pod CPU/memory usage via a single metrics.k8s.io list call.
+        """Return CPU/memory usage for every pod, keyed by pod name.
 
         Lists ``PodMetrics`` for the namespace (optionally scoped by ``labels``)
-        in one request and returns a ``pod_name -> PodResourceUsage`` map. One
-        request covers every pod, so resource collection over N pods costs a
-        single API round-trip instead of N per-pod GETs.
-
-        A 404 means the metrics API is unavailable (metrics-server absent);
-        returns an empty map rather than raising so collection degrades quietly.
+        via the metrics.k8s.io list endpoint. A 404 means the metrics API is
+        unavailable (metrics-server absent); returns an empty map rather than
+        raising so callers degrade quietly.
         """
         logger.info("k8s: top_pods labels=%s", labels)
         kwargs = self._request_timeout_kwargs()

--- a/lib/iris/src/iris/cluster/backends/k8s/service.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/service.py
@@ -134,7 +134,7 @@ class K8sService(Protocol):
         field_selector: str | None = None,
     ) -> list[dict]: ...
 
-    def top_pod(self, pod_name: str) -> PodResourceUsage | None: ...
+    def top_pods(self, *, labels: dict[str, str] | None = None) -> dict[str, PodResourceUsage]: ...
 
     def read_file(
         self,
@@ -684,39 +684,53 @@ class CloudK8sService:
         """Remove files inside a Pod container. Ignores missing files."""
         self.exec(pod_name, ["rm", "-f", *paths], container=container, timeout=10)
 
-    # -- top_pod -------------------------------------------------------------
+    # -- top_pods ------------------------------------------------------------
 
-    def top_pod(self, pod_name: str) -> PodResourceUsage | None:
-        """Get CPU/memory usage for a pod via metrics.k8s.io API."""
-        logger.info("k8s: top_pod %s", pod_name)
-        with slow_log(logger, f"top_pod {pod_name}", threshold_ms=_SLOW_THRESHOLD_MS):
+    def top_pods(self, *, labels: dict[str, str] | None = None) -> dict[str, PodResourceUsage]:
+        """Bulk pod CPU/memory usage via a single metrics.k8s.io list call.
+
+        Lists ``PodMetrics`` for the namespace (optionally scoped by ``labels``)
+        in one request and returns a ``pod_name -> PodResourceUsage`` map. One
+        request covers every pod, so resource collection over N pods costs a
+        single API round-trip instead of N per-pod GETs.
+
+        A 404 means the metrics API is unavailable (metrics-server absent);
+        returns an empty map rather than raising so collection degrades quietly.
+        """
+        logger.info("k8s: top_pods labels=%s", labels)
+        kwargs = self._request_timeout_kwargs()
+        if labels:
+            kwargs["label_selector"] = _label_selector(labels)
+        with slow_log(logger, "top_pods", threshold_ms=_SLOW_THRESHOLD_MS):
             try:
-                result = self._custom.get_namespaced_custom_object(
+                result = self._custom.list_namespaced_custom_object(
                     group="metrics.k8s.io",
                     version="v1beta1",
                     namespace=self.namespace,
                     plural="pods",
-                    name=pod_name,
-                    **self._request_timeout_kwargs(),
+                    **kwargs,
                 )
             except ApiException as e:
                 if e.status == 404:
-                    return None
+                    return {}
                 raise
 
-        containers = result.get("containers", [])
-        if not containers:
-            return None
-
-        total_cpu = 0
-        total_mem = 0
-        for c in containers:
-            usage = c.get("usage", {})
-            if "cpu" in usage:
-                total_cpu += parse_k8s_cpu(usage["cpu"])
-            if "memory" in usage:
-                total_mem += parse_k8s_quantity(usage["memory"])
-        return PodResourceUsage(cpu_millicores=total_cpu, memory_bytes=total_mem)
+        usage_by_pod: dict[str, PodResourceUsage] = {}
+        for item in result.get("items", []):
+            name = item.get("metadata", {}).get("name", "")
+            containers = item.get("containers", [])
+            if not name or not containers:
+                continue
+            total_cpu = 0
+            total_mem = 0
+            for c in containers:
+                usage = c.get("usage", {})
+                if "cpu" in usage:
+                    total_cpu += parse_k8s_cpu(usage["cpu"])
+                if "memory" in usage:
+                    total_mem += parse_k8s_quantity(usage["memory"])
+            usage_by_pod[name] = PodResourceUsage(cpu_millicores=total_cpu, memory_bytes=total_mem)
+        return usage_by_pod
 
     # -- port_forward (subprocess-based) -------------------------------------
 

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -10,7 +10,6 @@ k8s API via kubectl, launching one Pod per task attempt.
 from __future__ import annotations
 
 import base64
-import concurrent.futures
 import hashlib
 import json
 import logging
@@ -69,7 +68,7 @@ from iris.cluster.runtime.profile import (
     wrap_with_kill_watchdog,
 )
 from iris.cluster.types import JobName, TaskAttempt, WorkerId, get_gpu_count
-from iris.cluster.worker.stats import build_task_stat
+from iris.cluster.worker.stats import IrisTaskStat, build_task_stat
 from iris.rpc import controller_pb2, job_pb2, worker_pb2
 from iris.time_proto import timestamp_to_proto
 
@@ -1138,22 +1137,35 @@ class ResourceCollector:
     """Background resource usage collector that writes to ``iris.task`` stats.
 
     Same set_pods() pattern as LogCollector: the sync loop declares the
-    authoritative set of running pods once per cycle. Each tick, the collector
-    fans out to ``kubectl top`` per pod and appends one ``IrisTaskStat`` row
-    per successful read to the supplied stats Table — the same table the
-    worker daemon writes to on the GCE/TPU path, so the dashboard's
-    ``iris.task`` queries cover both runtimes uniformly.
+    authoritative set of running pods once per cycle. Each tick the collector
+    issues a single bulk metrics list (``kubectl top`` equivalent) scoped to the
+    managed-pod labels, then appends one ``IrisTaskStat`` row per tracked pod
+    that has a sample — to the same table the worker daemon writes to on the
+    GCE/TPU path, so the dashboard's ``iris.task`` queries cover both runtimes
+    uniformly. One API round-trip covers every pod, so cost is independent of
+    pod count and no per-pod thread fan-out is needed.
+
+    ``poll_interval`` defaults to the metrics-server scrape resolution (15s);
+    polling faster only re-reads the same sample.
     """
 
-    def __init__(self, kubectl: K8sService, task_stats_table: Table, *, concurrency: int = 8):
+    def __init__(
+        self,
+        kubectl: K8sService,
+        task_stats_table: Table,
+        *,
+        labels: dict[str, str] | None = None,
+        poll_interval: float = 15.0,
+    ):
         self._kubectl = kubectl
         self._table = task_stats_table
+        self._labels = labels
+        self._poll_interval = poll_interval
         # (task_id_wire, attempt_id) -> pod_name. Tuple keys carry the
         # identity needed to build IrisTaskStat without parsing strings.
         self._pods: dict[tuple[str, int], str] = {}
         self._lock = threading.Lock()
         self._stop = threading.Event()
-        self._executor = ThreadPoolExecutor(max_workers=concurrency, thread_name_prefix="resource-collect")
         self._thread = threading.Thread(target=self._run, daemon=True, name="resource-collector")
         self._thread.start()
 
@@ -1164,47 +1176,47 @@ class ResourceCollector:
 
     def _run(self) -> None:
         while not self._stop.is_set():
-            with self._lock:
-                snapshot = list(self._pods.items())
-            if snapshot:
-                futures = [self._executor.submit(self._fetch_one, key, pod_name) for key, pod_name in snapshot]
-                for f in concurrent.futures.as_completed(futures):
-                    try:
-                        f.result()
-                    except Exception:
-                        pass
-            self._stop.wait(timeout=5.0)
+            self._collect_once()
+            self._stop.wait(timeout=self._poll_interval)
 
-    def _fetch_one(self, key: tuple[str, int], pod_name: str) -> None:
+    def _collect_once(self) -> None:
+        with self._lock:
+            snapshot = list(self._pods.items())
+        if not snapshot:
+            return
         try:
-            top = self._kubectl.top_pod(pod_name)
+            usage_by_pod = self._kubectl.top_pods(labels=self._labels)
         except Exception as e:
-            logger.debug("ResourceCollector: top_pod raised for pod %s: %s", pod_name, e)
-            return
-        if top is None:
+            logger.debug("ResourceCollector: top_pods raised: %s", e)
             return
 
-        task_id_wire, attempt_id = key
-        usage = job_pb2.ResourceUsage(
-            cpu_millicores=top.cpu_millicores,
-            memory_mb=top.memory_bytes // (1024 * 1024),
-        )
-        stat = build_task_stat(
-            task_id=task_id_wire,
-            attempt_id=attempt_id,
-            # Pod name is the per-attempt platform identity on k8s, mirroring
-            # worker_id on the GCE/TPU path.
-            worker_id=pod_name,
-            usage=usage,
-        )
+        stats: list[IrisTaskStat] = []
+        for (task_id_wire, attempt_id), pod_name in snapshot:
+            top = usage_by_pod.get(pod_name)
+            if top is None:
+                continue
+            stats.append(
+                build_task_stat(
+                    task_id=task_id_wire,
+                    attempt_id=attempt_id,
+                    # Pod name is the per-attempt platform identity on k8s,
+                    # mirroring worker_id on the GCE/TPU path.
+                    worker_id=pod_name,
+                    usage=job_pb2.ResourceUsage(
+                        cpu_millicores=top.cpu_millicores,
+                        memory_mb=top.memory_bytes // (1024 * 1024),
+                    ),
+                )
+            )
+        if not stats:
+            return
         try:
-            self._table.write([stat])
+            self._table.write(stats)
         except Exception:
             logger.debug("ResourceCollector: write to iris.task failed", exc_info=True)
 
     def close(self) -> None:
         self._stop.set()
-        self._executor.shutdown(wait=False)
         self._thread.join(timeout=5)
 
 
@@ -1310,8 +1322,14 @@ class K8sTaskProvider:
     # Pre-resolved iris.profile Table handle injected by the controller
     # alongside task_stats_table. None in test mode.
     profile_table: Table | None = None
+    # Log fetch fan-out: logs have no bulk API, so each pod is streamed on its
+    # own worker thread.
     poll_concurrency: int = 32
     log_poll_interval: float = 15.0
+    # Resource-usage poll cadence. Defaults to the metrics-server scrape
+    # resolution (15s) — sampling faster only re-reads the same value. One bulk
+    # metrics list per tick covers every managed pod (see ResourceCollector).
+    resource_poll_interval: float = 15.0
     # Cluster-wide kubectl scans (pod list, stray-pod GC, pod poll, node refresh)
     # are coarse-grained: the controller ticks reconcile at poll_interval (1s),
     # but these LISTs run at most once per cluster_scan_interval to bound kubectl
@@ -1335,7 +1353,10 @@ class K8sTaskProvider:
             return None
         if self._resource_collector is None:
             self._resource_collector = ResourceCollector(
-                self.kubectl, self.task_stats_table, concurrency=self.poll_concurrency
+                self.kubectl,
+                self.task_stats_table,
+                labels=_MANAGED_POD_LABELS,
+                poll_interval=self.resource_poll_interval,
             )
         return self._resource_collector
 

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1174,10 +1174,15 @@ class ResourceCollector:
 
     def _run(self) -> None:
         while not self._stop.is_set():
-            self._collect_once()
+            self.collect_once()
             self._stop.wait(timeout=self._poll_interval)
 
-    def _collect_once(self) -> None:
+    def collect_once(self) -> None:
+        """Sample every tracked pod once and append a stat row per pod with usage.
+
+        Runs each ``poll_interval`` on the background thread; also the unit of
+        collection tests drive directly.
+        """
         with self._lock:
             snapshot = list(self._pods.items())
         if not snapshot:

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1134,16 +1134,14 @@ class LogCollector:
 
 
 class ResourceCollector:
-    """Background resource usage collector that writes to ``iris.task`` stats.
+    """Background thread that samples running pods' CPU/memory usage.
 
-    Same set_pods() pattern as LogCollector: the sync loop declares the
-    authoritative set of running pods once per cycle. Each tick the collector
-    issues a single bulk metrics list (``kubectl top`` equivalent) scoped to the
-    managed-pod labels, then appends one ``IrisTaskStat`` row per tracked pod
-    that has a sample — to the same table the worker daemon writes to on the
-    GCE/TPU path, so the dashboard's ``iris.task`` queries cover both runtimes
-    uniformly. One API round-trip covers every pod, so cost is independent of
-    pod count and no per-pod thread fan-out is needed.
+    The reconcile loop declares the authoritative set of running pods via
+    ``set_pods()`` once per cycle. Each ``poll_interval`` the collector samples
+    those pods via one bulk metrics query and appends an ``IrisTaskStat`` row
+    per pod to the ``iris.task`` table — the same table the worker daemon writes
+    to on the GCE/TPU path, so the dashboard's ``iris.task`` queries cover both
+    runtimes uniformly.
 
     ``poll_interval`` defaults to the metrics-server scrape resolution (15s);
     polling faster only re-reads the same sample.

--- a/lib/iris/tests/cluster/backends/k8s/conftest.py
+++ b/lib/iris/tests/cluster/backends/k8s/conftest.py
@@ -54,6 +54,7 @@ def provider(k8s, log_client, task_stats_table):
         log_client=log_client,
         task_stats_table=task_stats_table,
         log_poll_interval=1.0,
+        resource_poll_interval=0.5,
         cluster_scan_interval=0.0,
     )
     yield p

--- a/lib/iris/tests/cluster/backends/k8s/conftest.py
+++ b/lib/iris/tests/cluster/backends/k8s/conftest.py
@@ -54,9 +54,7 @@ def provider(k8s, log_client, task_stats_table):
         log_client=log_client,
         task_stats_table=task_stats_table,
         log_poll_interval=1.0,
-        # Long enough that the background collector never fires mid-test; resource
-        # tests drive a collection pass synchronously instead of racing the thread.
-        resource_poll_interval=3600.0,
+        resource_poll_interval=0.05,
         cluster_scan_interval=0.0,
     )
     yield p

--- a/lib/iris/tests/cluster/backends/k8s/conftest.py
+++ b/lib/iris/tests/cluster/backends/k8s/conftest.py
@@ -54,7 +54,9 @@ def provider(k8s, log_client, task_stats_table):
         log_client=log_client,
         task_stats_table=task_stats_table,
         log_poll_interval=1.0,
-        resource_poll_interval=0.5,
+        # Long enough that the background collector never fires mid-test; resource
+        # tests drive a collection pass synchronously instead of racing the thread.
+        resource_poll_interval=3600.0,
         cluster_scan_interval=0.0,
     )
     yield p

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -532,8 +532,19 @@ def test_sync_survives_node_list_failure(provider, k8s):
 # ---------------------------------------------------------------------------
 
 
+def _collect_resources_once(provider) -> None:
+    """Drive one synchronous resource-collection pass.
+
+    reconcile() registers the running-pod set with the background collector;
+    this runs a single collection against that set without waiting on (or
+    racing) the collector's poll thread.
+    """
+    assert provider._resource_collector is not None, "reconcile should have started the collector"
+    provider._resource_collector._collect_once()
+
+
 def test_resource_stats_from_kubectl_top(provider, k8s, task_stats_table):
-    """Running pods emit IrisTaskStat rows via the background ResourceCollector."""
+    """Running pods emit IrisTaskStat rows via the ResourceCollector."""
 
     task_id = JobName.from_wire("/job/0")
     attempt_id = 0
@@ -543,12 +554,9 @@ def test_resource_stats_from_kubectl_top(provider, k8s, task_stats_table):
     populate_pod(k8s, pod_name, "Running")
     k8s.set_top_pod(pod_name, PodResourceUsage(cpu_millicores=500, memory_bytes=1024 * 1024 * 1024))
 
-    batch = make_batch(running_tasks=[entry])
-    # First sync registers the pod with the ResourceCollector.
-    provider.reconcile(batch)
-    # Wait for background collector to fetch and write.
-    time.sleep(2)
-    # No more sync needed — the row has already been written to the table.
+    # reconcile registers the pod; then collect once.
+    provider.reconcile(make_batch(running_tasks=[entry]))
+    _collect_resources_once(provider)
 
     rows = [row for batch_rows in task_stats_table.writes for row in batch_rows]
     assert rows, "ResourceCollector did not write any IrisTaskStat rows"
@@ -562,7 +570,7 @@ def test_resource_stats_from_kubectl_top(provider, k8s, task_stats_table):
 
 
 def test_resource_stats_skipped_when_metrics_unavailable(provider, k8s, task_stats_table):
-    """No IrisTaskStat row is written when kubectl top returns None."""
+    """No IrisTaskStat row is written when a pod has no metrics sample."""
     task_id = JobName.from_wire("/job/0")
     attempt_id = 0
     pod_name = _pod_name(task_id, attempt_id)
@@ -571,28 +579,24 @@ def test_resource_stats_skipped_when_metrics_unavailable(provider, k8s, task_sta
     populate_pod(k8s, pod_name, "Running")
     k8s.set_top_pod(pod_name, None)
 
-    batch = make_batch(running_tasks=[entry])
-    provider.reconcile(batch)
-    time.sleep(2)
+    provider.reconcile(make_batch(running_tasks=[entry]))
+    _collect_resources_once(provider)
 
     assert task_stats_table.writes == []
 
 
 def test_resource_stats_skipped_when_top_pods_raises(provider, k8s, task_stats_table):
-    """No IrisTaskStat row is written when the bulk metrics query raises."""
+    """A raising bulk metrics query is swallowed; no IrisTaskStat row is written."""
     task_id = JobName.from_wire("/job/0")
     attempt_id = 0
     pod_name = _pod_name(task_id, attempt_id)
     entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
 
     populate_pod(k8s, pod_name, "Running")
-    # Persistent: the background collector retries on its own cadence, so a
-    # one-shot failure would be consumed and later polls would succeed.
-    k8s.inject_failure("top_pods", RuntimeError("metrics-server unavailable"), persistent=True)
+    k8s.inject_persistent_failure("top_pods", RuntimeError("metrics-server unavailable"))
 
-    batch = make_batch(running_tasks=[entry])
-    provider.reconcile(batch)
-    time.sleep(2)
+    provider.reconcile(make_batch(running_tasks=[entry]))
+    _collect_resources_once(provider)
 
     assert task_stats_table.writes == []
 
@@ -606,9 +610,8 @@ def test_resource_stats_skipped_for_non_running_pods(provider, k8s, task_stats_t
 
     populate_pod(k8s, pod_name, "Succeeded")
 
-    batch = make_batch(running_tasks=[entry])
-    provider.reconcile(batch)
-    time.sleep(2)
+    provider.reconcile(make_batch(running_tasks=[entry]))
+    _collect_resources_once(provider)
 
     assert task_stats_table.writes == []
 

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -547,7 +547,7 @@ def test_resource_stats_from_kubectl_top(provider, k8s, task_stats_table):
     # First sync registers the pod with the ResourceCollector.
     provider.reconcile(batch)
     # Wait for background collector to fetch and write.
-    time.sleep(6)
+    time.sleep(2)
     # No more sync needed — the row has already been written to the table.
 
     rows = [row for batch_rows in task_stats_table.writes for row in batch_rows]
@@ -573,24 +573,26 @@ def test_resource_stats_skipped_when_metrics_unavailable(provider, k8s, task_sta
 
     batch = make_batch(running_tasks=[entry])
     provider.reconcile(batch)
-    time.sleep(6)
+    time.sleep(2)
 
     assert task_stats_table.writes == []
 
 
-def test_resource_stats_skipped_when_top_pod_raises(provider, k8s, task_stats_table):
-    """No IrisTaskStat row is written when kubectl top raises an exception."""
+def test_resource_stats_skipped_when_top_pods_raises(provider, k8s, task_stats_table):
+    """No IrisTaskStat row is written when the bulk metrics query raises."""
     task_id = JobName.from_wire("/job/0")
     attempt_id = 0
     pod_name = _pod_name(task_id, attempt_id)
     entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
 
     populate_pod(k8s, pod_name, "Running")
-    k8s.inject_failure("top_pod", RuntimeError("metrics-server unavailable"))
+    # Persistent: the background collector retries on its own cadence, so a
+    # one-shot failure would be consumed and later polls would succeed.
+    k8s.inject_failure("top_pods", RuntimeError("metrics-server unavailable"), persistent=True)
 
     batch = make_batch(running_tasks=[entry])
     provider.reconcile(batch)
-    time.sleep(6)
+    time.sleep(2)
 
     assert task_stats_table.writes == []
 
@@ -606,7 +608,7 @@ def test_resource_stats_skipped_for_non_running_pods(provider, k8s, task_stats_t
 
     batch = make_batch(running_tasks=[entry])
     provider.reconcile(batch)
-    time.sleep(6)
+    time.sleep(2)
 
     assert task_stats_table.writes == []
 
@@ -1137,7 +1139,7 @@ def test_log_collector_set_pods_preserves_cursor_state(k8s, log_client):
 def test_resource_collector_set_pods_replaces_active_set(k8s, task_stats_table):
     """set_pods() replaces the tracked pod set wholesale."""
 
-    collector = ResourceCollector(k8s, task_stats_table, concurrency=1)
+    collector = ResourceCollector(k8s, task_stats_table, poll_interval=60.0)
     key_a = ("/job/0", 0)
     key_b = ("/job/1", 0)
 
@@ -1153,14 +1155,15 @@ def test_resource_collector_set_pods_replaces_active_set(k8s, task_stats_table):
 
 
 def test_resource_collector_writes_iris_task_rows(k8s, task_stats_table):
-    """A successful kubectl top read appends one IrisTaskStat row to the Table."""
+    """A successful bulk metrics read appends one IrisTaskStat row to the Table."""
 
     k8s.set_top_pod("pod-a", PodResourceUsage(cpu_millicores=750, memory_bytes=2 * 1024 * 1024 * 1024))
 
-    collector = ResourceCollector(k8s, task_stats_table, concurrency=1)
-    collector.set_pods({("/job/0", 3): "pod-a"})
-    time.sleep(6)
+    collector = ResourceCollector(k8s, task_stats_table, poll_interval=60.0)
+    # Stop the background loop so we drive a single collection deterministically.
     collector.close()
+    collector.set_pods({("/job/0", 3): "pod-a"})
+    collector._collect_once()
 
     rows = [row for batch_rows in task_stats_table.writes for row in batch_rows]
     assert rows, "no rows emitted"
@@ -1171,6 +1174,28 @@ def test_resource_collector_writes_iris_task_rows(k8s, task_stats_table):
     assert row.worker_id == "pod-a"
     assert row.cpu_millicores == 750
     assert row.memory_mb == 2048
+
+
+def test_resource_collector_uses_one_bulk_query_for_many_pods(k8s, task_stats_table):
+    """One poll fetches every tracked pod's usage in a single metrics query.
+
+    This is the load fix: cost is one API round-trip per tick regardless of how
+    many pods are running, and the resulting rows land in a single batched write.
+    """
+    pods = {(f"/job/{i}", 0): f"pod-{i}" for i in range(50)}
+    for _, pod_name in pods.items():
+        k8s.set_top_pod(pod_name, PodResourceUsage(cpu_millicores=100, memory_bytes=128 * 1024 * 1024))
+
+    collector = ResourceCollector(k8s, task_stats_table, poll_interval=60.0)
+    # Stop the background loop so the single collection below is deterministic.
+    collector.close()
+    collector.set_pods(pods)
+    calls_before = k8s.top_pods_call_count
+    collector._collect_once()
+
+    assert k8s.top_pods_call_count - calls_before == 1, "expected exactly one bulk metrics query"
+    assert len(task_stats_table.writes) == 1, "expected a single batched write"
+    assert len(task_stats_table.writes[0]) == len(pods), "every tracked pod should produce one row"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -1148,28 +1148,6 @@ def test_resource_collector_writes_iris_task_rows(k8s, task_stats_table):
     assert row.memory_mb == 2048
 
 
-def test_resource_collector_uses_one_bulk_query_for_many_pods(k8s, task_stats_table):
-    """One poll fetches every tracked pod's usage in a single metrics query.
-
-    This is the load fix: cost is one API round-trip per tick regardless of how
-    many pods are running, and the resulting rows land in a single batched write.
-    """
-    pods = {(f"/job/{i}", 0): f"pod-{i}" for i in range(50)}
-    for _, pod_name in pods.items():
-        k8s.set_top_pod(pod_name, PodResourceUsage(cpu_millicores=100, memory_bytes=128 * 1024 * 1024))
-
-    collector = ResourceCollector(k8s, task_stats_table, poll_interval=60.0)
-    # Stop the background loop so the single collection below is deterministic.
-    collector.close()
-    collector.set_pods(pods)
-    calls_before = k8s.top_pods_call_count
-    collector.collect_once()
-
-    assert k8s.top_pods_call_count - calls_before == 1, "expected exactly one bulk metrics query"
-    assert len(task_stats_table.writes) == 1, "expected a single batched write"
-    assert len(task_stats_table.writes[0]) == len(pods), "every tracked pod should produce one row"
-
-
 # ---------------------------------------------------------------------------
 # Kueue gang admission: sync() applies one pod-group per gang generation
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -41,6 +41,8 @@ from iris.cluster.log_keys import task_log_key
 from iris.cluster.types import JobName, TaskAttempt
 from iris.cluster.worker.stats import IrisTaskStat
 from iris.rpc import job_pb2
+from iris.test_util import wait_for_condition
+from rigging.timing import Duration
 
 from .conftest import make_batch, make_kueue_provider, make_run_req, populate_node, populate_pod
 
@@ -532,86 +534,53 @@ def test_sync_survives_node_list_failure(provider, k8s):
 # ---------------------------------------------------------------------------
 
 
-def _collect_resources_once(provider) -> None:
-    """Drive one synchronous resource-collection pass.
+def test_resource_stats_only_for_running_tasks(provider, k8s, task_stats_table):
+    """reconcile registers running pods (not terminal ones) so the background
+    collector emits IrisTaskStat rows only for running tasks."""
+    running = RunningTaskEntry(task_id=JobName.from_wire("/job/run"), attempt_id=0)
+    terminal = RunningTaskEntry(task_id=JobName.from_wire("/job/done"), attempt_id=0)
+    running_pod = _pod_name(running.task_id, running.attempt_id)
+    terminal_pod = _pod_name(terminal.task_id, terminal.attempt_id)
 
-    reconcile() registers the running-pod set with the background collector;
-    this runs a single collection against that set without waiting on (or
-    racing) the collector's poll thread.
-    """
-    assert provider._resource_collector is not None, "reconcile should have started the collector"
-    provider._resource_collector._collect_once()
+    populate_pod(k8s, running_pod, "Running")
+    populate_pod(k8s, terminal_pod, "Succeeded")
+    k8s.set_top_pod(running_pod, PodResourceUsage(cpu_millicores=500, memory_bytes=1024 * 1024 * 1024))
+    k8s.set_top_pod(terminal_pod, PodResourceUsage(cpu_millicores=999, memory_bytes=1024))
 
+    provider.reconcile(make_batch(running_tasks=[running, terminal]))
+    # The collector samples all tracked pods in one pass, so once the running
+    # pod's row lands a full cycle has run — the terminal pod's absence is real.
+    wait_for_condition(lambda: bool(task_stats_table.writes), timeout=Duration.from_seconds(5.0))
 
-def test_resource_stats_from_kubectl_top(provider, k8s, task_stats_table):
-    """Running pods emit IrisTaskStat rows via the ResourceCollector."""
-
-    task_id = JobName.from_wire("/job/0")
-    attempt_id = 0
-    pod_name = _pod_name(task_id, attempt_id)
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
-
-    populate_pod(k8s, pod_name, "Running")
-    k8s.set_top_pod(pod_name, PodResourceUsage(cpu_millicores=500, memory_bytes=1024 * 1024 * 1024))
-
-    # reconcile registers the pod; then collect once.
-    provider.reconcile(make_batch(running_tasks=[entry]))
-    _collect_resources_once(provider)
-
-    rows = [row for batch_rows in task_stats_table.writes for row in batch_rows]
-    assert rows, "ResourceCollector did not write any IrisTaskStat rows"
+    rows = [row for batch_rows in list(task_stats_table.writes) for row in batch_rows]
     assert all(isinstance(r, IrisTaskStat) for r in rows)
-    latest = rows[-1]
-    assert latest.task_id == task_id.to_wire()
-    assert latest.attempt_id == attempt_id
-    assert latest.worker_id == pod_name
-    assert latest.cpu_millicores == 500
-    assert latest.memory_mb == 1024
+    assert {r.worker_id for r in rows} == {running_pod}, "only the running pod should be sampled"
+    row = next(r for r in rows if r.worker_id == running_pod)
+    assert row.task_id == running.task_id.to_wire()
+    assert row.cpu_millicores == 500
+    assert row.memory_mb == 1024
 
 
-def test_resource_stats_skipped_when_metrics_unavailable(provider, k8s, task_stats_table):
-    """No IrisTaskStat row is written when a pod has no metrics sample."""
-    task_id = JobName.from_wire("/job/0")
-    attempt_id = 0
-    pod_name = _pod_name(task_id, attempt_id)
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
+def test_resource_collector_skips_pod_without_metrics_sample(k8s, task_stats_table):
+    """A tracked pod with no metrics sample produces no row."""
+    k8s.set_top_pod("pod-a", None)
 
-    populate_pod(k8s, pod_name, "Running")
-    k8s.set_top_pod(pod_name, None)
-
-    provider.reconcile(make_batch(running_tasks=[entry]))
-    _collect_resources_once(provider)
+    collector = ResourceCollector(k8s, task_stats_table, poll_interval=60.0)
+    collector.close()  # stop the background loop; drive one collection synchronously
+    collector.set_pods({("/job/0", 0): "pod-a"})
+    collector.collect_once()
 
     assert task_stats_table.writes == []
 
 
-def test_resource_stats_skipped_when_top_pods_raises(provider, k8s, task_stats_table):
-    """A raising bulk metrics query is swallowed; no IrisTaskStat row is written."""
-    task_id = JobName.from_wire("/job/0")
-    attempt_id = 0
-    pod_name = _pod_name(task_id, attempt_id)
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
-
-    populate_pod(k8s, pod_name, "Running")
+def test_resource_collector_swallows_metrics_query_failure(k8s, task_stats_table):
+    """A raising bulk metrics query is swallowed; no row is written."""
     k8s.inject_persistent_failure("top_pods", RuntimeError("metrics-server unavailable"))
 
-    provider.reconcile(make_batch(running_tasks=[entry]))
-    _collect_resources_once(provider)
-
-    assert task_stats_table.writes == []
-
-
-def test_resource_stats_skipped_for_non_running_pods(provider, k8s, task_stats_table):
-    """Terminal pods are not registered with the resource collector, so no rows land."""
-    task_id = JobName.from_wire("/job/0")
-    attempt_id = 0
-    pod_name = _pod_name(task_id, attempt_id)
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
-
-    populate_pod(k8s, pod_name, "Succeeded")
-
-    provider.reconcile(make_batch(running_tasks=[entry]))
-    _collect_resources_once(provider)
+    collector = ResourceCollector(k8s, task_stats_table, poll_interval=60.0)
+    collector.close()
+    collector.set_pods({("/job/0", 0): "pod-a"})
+    collector.collect_once()
 
     assert task_stats_table.writes == []
 
@@ -1140,21 +1109,21 @@ def test_log_collector_set_pods_preserves_cursor_state(k8s, log_client):
 
 
 def test_resource_collector_set_pods_replaces_active_set(k8s, task_stats_table):
-    """set_pods() replaces the tracked pod set wholesale."""
+    """set_pods() replaces the tracked pod set wholesale: a pod dropped from the
+    set stops being sampled on the next collection."""
+    k8s.set_top_pod("pod-a", PodResourceUsage(cpu_millicores=100, memory_bytes=128 * 1024 * 1024))
+    k8s.set_top_pod("pod-b", PodResourceUsage(cpu_millicores=100, memory_bytes=128 * 1024 * 1024))
 
     collector = ResourceCollector(k8s, task_stats_table, poll_interval=60.0)
-    key_a = ("/job/0", 0)
-    key_b = ("/job/1", 0)
+    collector.close()  # stop the background loop; drive collections synchronously
 
-    collector.set_pods({key_a: "pod-a", key_b: "pod-b"})
-    with collector._lock:
-        assert collector._pods == {key_a: "pod-a", key_b: "pod-b"}
+    collector.set_pods({("/job/0", 0): "pod-a", ("/job/1", 0): "pod-b"})
+    collector.collect_once()
+    assert {r.worker_id for r in task_stats_table.writes[-1]} == {"pod-a", "pod-b"}
 
-    collector.set_pods({key_b: "pod-b"})
-    with collector._lock:
-        assert collector._pods == {key_b: "pod-b"}
-
-    collector.close()
+    collector.set_pods({("/job/1", 0): "pod-b"})
+    collector.collect_once()
+    assert {r.worker_id for r in task_stats_table.writes[-1]} == {"pod-b"}
 
 
 def test_resource_collector_writes_iris_task_rows(k8s, task_stats_table):
@@ -1166,7 +1135,7 @@ def test_resource_collector_writes_iris_task_rows(k8s, task_stats_table):
     # Stop the background loop so we drive a single collection deterministically.
     collector.close()
     collector.set_pods({("/job/0", 3): "pod-a"})
-    collector._collect_once()
+    collector.collect_once()
 
     rows = [row for batch_rows in task_stats_table.writes for row in batch_rows]
     assert rows, "no rows emitted"
@@ -1194,7 +1163,7 @@ def test_resource_collector_uses_one_bulk_query_for_many_pods(k8s, task_stats_ta
     collector.close()
     collector.set_pods(pods)
     calls_before = k8s.top_pods_call_count
-    collector._collect_once()
+    collector.collect_once()
 
     assert k8s.top_pods_call_count - calls_before == 1, "expected exactly one bulk metrics query"
     assert len(task_stats_table.writes) == 1, "expected a single batched write"


### PR DESCRIPTION
k8s pod resource collection polled one pod at a time. Every tick the
ResourceCollector fanned out top_pod(pod_name) across a 32-thread pool, and each
call was a get_namespaced_custom_object GET against metrics.k8s.io. So an N-pod
cluster issued N metrics-API requests per tick — at ~1000 pods that is the
dominant load on kube-apiserver (and 1000 INFO log lines per tick).

## The k8s controller control loop

The Iris controller runs a single-threaded control tick at poll_interval (1s).
Each tick calls K8sTaskProvider.reconcile(snapshot). Kueue owns scheduling and
the cluster autoscaler owns capacity, so reconcile() only syncs pod state:

- Every tick (ungated): apply pods for tasks_to_run (_apply_pod), so dispatch
  stays responsive.
- At most once per cluster_scan_interval (5s), the cluster-wide kubectl scans:
  - one pod LIST (managed labels, active-only field selector)
  - stray-pod GC (delete pods not in the desired set)
  - _poll_pods: derive task-state updates from pod phases, and hand the
    authoritative running-pod set to the background collectors via set_pods()
  - node LIST + node-pool refresh -> ClusterState
  - terminal-resource GC

Two background daemon threads, fed by set_pods() each cycle, run on their own
cadence:

- LogCollector: every 15s, per-pod stream_logs over a bounded thread pool. Logs
  have no bulk API, so per-pod fan-out is inherent here.
- ResourceCollector: the hotspot. Before this change it ran every 5s and fanned
  out top_pod(pod_name) per running pod over a 32-thread pool, one
  metrics.k8s.io GET each.

(The report of "every second" maps to this collector; the real cadence was 5s,
but the per-pod fan-out is the actual problem.)

## Fix

Bulk query. metrics.k8s.io exposes a list endpoint that returns every pod's
metrics in one request (PodMetricsList). Replace top_pod with top_pods(labels=),
a single list_namespaced_custom_object scoped to the managed-pod label selector,
returning pod_name -> usage for the whole namespace. The collector now makes one
API call per tick regardless of pod count, looks up each tracked pod in the
result, and writes all rows in a single batched Table.write.

Threading. The per-pod ThreadPoolExecutor is removed — one bulk call plus an
in-memory loop needs no fan-out.

Frequency. metrics-server only refreshes samples about every 15s (its default
scrape resolution), so polling every 5s re-read identical values. Resource
polling now uses a dedicated resource_poll_interval, defaulting to 15s, separate
from log_poll_interval.

Net effect at 1000 pods: from 1000 requests / 5s to 1 request / 15s, and one log
line per tick instead of 1000.
