### PR TITLE
[levanter] Add H100 B-tiled fused CE path

### DIFF
--- a/lib/levanter/scripts/bench/bench_fused_cross_entropy_loss_gpu_block_sweep.py
+++ b/lib/levanter/scripts/bench/bench_fused_cross_entropy_loss_gpu_block_sweep.py
@@ -130,7 +130,7 @@ def main() -> None:
         dot_tiles = _ceil_div(embed, h_block_size) * _ceil_div(vocab, v_block_size)
         if dot_tiles > args.max_dot_tiles:
             print(
-                "pallas_gpu",
+                "batched_xla",
                 f"b={b_block_size}",
                 f"h={h_block_size}",
                 f"v={v_block_size}",
@@ -144,8 +144,8 @@ def main() -> None:
             v_block_size=v_block_size,
         )
         try:
-            compile_pallas, steady_pallas = _bench(
-                lambda x_in, w_in, y_in: _loss_fn(x_in, w_in, y_in, block_sizes, "pallas_gpu"),
+            compile_batched_xla, steady_batched_xla = _bench(
+                lambda x_in, w_in, y_in: _loss_fn(x_in, w_in, y_in, block_sizes, "batched_xla"),
                 x,
                 w,
                 y,
@@ -154,7 +154,7 @@ def main() -> None:
             )
         except Exception as exc:  # pragma: no cover - backend/runtime dependent
             print(
-                "pallas_gpu",
+                "batched_xla",
                 f"b={b_block_size}",
                 f"h={h_block_size}",
                 f"v={v_block_size}",
@@ -163,21 +163,21 @@ def main() -> None:
             )
             continue
 
-        pallas_tps = tokens / steady_pallas
+        batched_xla_tps = tokens / steady_batched_xla
         delta = np.nan
         if args.compare_xla:
-            delta = pallas_tps / xla_tps - 1.0
+            delta = batched_xla_tps / xla_tps - 1.0
         print(
-            "pallas_gpu",
+            "batched_xla",
             f"b={b_block_size}",
             f"h={h_block_size}",
             f"v={v_block_size}",
             "compile_s",
-            f"{compile_pallas:.6f}",
+            f"{compile_batched_xla:.6f}",
             "steady_s",
-            f"{steady_pallas:.6f}",
+            f"{steady_batched_xla:.6f}",
             "tokens_per_s",
-            f"{pallas_tps:.3f}",
+            f"{batched_xla_tps:.3f}",
             "vs_xla",
             f"{delta:+.3%}" if args.compare_xla else "n/a",
         )

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -28,7 +28,7 @@ from .xla import linear_softmax_cross_entropy_loss_xla
 
 Implementation: TypeAlias = Literal[
     "pallas_tpu",
-    "pallas_gpu",
+    "batched_xla",
     "xla",
     "reference",
 ]
@@ -44,7 +44,7 @@ IMPLEMENTATIONS: dict[str, ArrayImpl] = {
     "xla": linear_softmax_cross_entropy_loss_xla,
 }
 _DEFAULT_IMPLEMENTATION: tuple[Implementation, ...] = ("xla",)
-_PALLAS_FALLBACK_WARNINGS_EMITTED: set[str] = set()
+_IMPLEMENTATION_FALLBACK_WARNINGS_EMITTED: set[str] = set()
 _SELECTED_IMPL_LOGGED: set[str] = set()
 _AUTOTUNE_ON_MISS_ENV_VAR = "LEVANTER_PALLAS_CE_AUTOTUNE_ON_MISS"
 _AUTOTUNE_KERNEL_NAME = "fused_cross_entropy_loss"
@@ -55,7 +55,7 @@ _AUTOTUNE_COMPILE_HIT_THRESHOLD_S = 0.20
 _VMEM_COMPILE_FALLBACK_WARNINGS_EMITTED: set[str] = set()
 
 logger = logging.getLogger(__name__)
-_CANONICAL_PALLAS_IMPLEMENTATIONS: dict[str, ArrayImpl] = {}
+_CANONICAL_BACKEND_IMPLEMENTATIONS: dict[str, ArrayImpl] = {}
 
 try:
     from .pallas_tpu import (
@@ -64,17 +64,20 @@ try:
     )
 
     IMPLEMENTATIONS["pallas_tpu"] = linear_softmax_cross_entropy_loss_pallas
-    _CANONICAL_PALLAS_IMPLEMENTATIONS["pallas_tpu"] = linear_softmax_cross_entropy_loss_pallas
+    _CANONICAL_BACKEND_IMPLEMENTATIONS["pallas_tpu"] = linear_softmax_cross_entropy_loss_pallas
 except ImportError:
     PallasUnsupportedError = NotImplementedError  # type: ignore[assignment]
 
 try:
-    from .pallas_gpu import PallasUnsupportedError, linear_softmax_cross_entropy_loss_pallas_gpu
+    from .batched_xla import (
+        BatchedXlaUnsupportedError,
+        linear_softmax_cross_entropy_loss_batched_xla,
+    )
 
-    IMPLEMENTATIONS["pallas_gpu"] = linear_softmax_cross_entropy_loss_pallas_gpu
-    _CANONICAL_PALLAS_IMPLEMENTATIONS["pallas_gpu"] = linear_softmax_cross_entropy_loss_pallas_gpu
+    IMPLEMENTATIONS["batched_xla"] = linear_softmax_cross_entropy_loss_batched_xla
+    _CANONICAL_BACKEND_IMPLEMENTATIONS["batched_xla"] = linear_softmax_cross_entropy_loss_batched_xla
 except ImportError:
-    pass
+    BatchedXlaUnsupportedError = NotImplementedError  # type: ignore[assignment]
 
 
 @lru_cache(maxsize=1)
@@ -82,27 +85,27 @@ def _default_implementations() -> tuple[Implementation, ...]:
     implementations = _DEFAULT_IMPLEMENTATION
     backend = jax.default_backend()
 
-    if backend == "gpu" and "pallas_gpu" in IMPLEMENTATIONS:
+    if backend == "gpu" and "batched_xla" in IMPLEMENTATIONS:
         devices = jax.devices()
         device_kind = devices[0].device_kind.lower() if devices else ""
         if "gb10" in device_kind:
-            return cast(tuple[Implementation, ...], implementations + ("pallas_gpu",))
-        return cast(tuple[Implementation, ...], ("pallas_gpu",) + implementations)
+            return cast(tuple[Implementation, ...], implementations + ("batched_xla",))
+        return cast(tuple[Implementation, ...], ("batched_xla",) + implementations)
     if backend == "tpu":
         # Keep TPU default stable and robust unless Pallas is explicitly requested.
         return implementations
     return implementations
 
 
-def _warn_pallas_fallback_once(exc: Exception) -> None:
+def _warn_implementation_fallback_once(exc: Exception) -> None:
     message = str(exc)
     if "requires TPU backend" in message:
         return
-    if message in _PALLAS_FALLBACK_WARNINGS_EMITTED:
+    if message in _IMPLEMENTATION_FALLBACK_WARNINGS_EMITTED:
         return
-    _PALLAS_FALLBACK_WARNINGS_EMITTED.add(message)
+    _IMPLEMENTATION_FALLBACK_WARNINGS_EMITTED.add(message)
     warnings.warn(
-        f"Pallas fused cross-entropy unavailable, falling back to XLA: {message}",
+        f"Fused cross-entropy implementation unavailable, falling back to XLA: {message}",
         RuntimeWarning,
     )
 
@@ -125,8 +128,13 @@ def _warn_vmem_compile_fallback_once(exc: Exception, *, impl_name: str) -> None:
     )
 
 
-def _pallas_impl_matches_current_backend(impl_name: str, *, fn: ArrayImpl | None = None) -> bool:
-    canonical_impl = _CANONICAL_PALLAS_IMPLEMENTATIONS.get(impl_name)
+def _raise_if_renamed_implementation(impl: object) -> None:
+    if impl == "pallas_gpu":
+        raise ValueError('implementation="pallas_gpu" was renamed to "batched_xla"; use implementation="batched_xla".')
+
+
+def _implementation_matches_current_backend(impl_name: str, *, fn: ArrayImpl | None = None) -> bool:
+    canonical_impl = _CANONICAL_BACKEND_IMPLEMENTATIONS.get(impl_name)
     if canonical_impl is None:
         return True
     if fn is None:
@@ -135,7 +143,7 @@ def _pallas_impl_matches_current_backend(impl_name: str, *, fn: ArrayImpl | None
         return True
 
     backend = jax.default_backend()
-    return (impl_name == "pallas_tpu" and backend == "tpu") or (impl_name == "pallas_gpu" and backend == "gpu")
+    return (impl_name == "pallas_tpu" and backend == "tpu") or (impl_name == "batched_xla" and backend == "gpu")
 
 
 def _autotune_enabled() -> bool:
@@ -307,7 +315,7 @@ def _candidate_block_sizes(
                         v_block_size=v_block,
                     )
                 )
-    elif impl_name == "pallas_gpu":
+    elif impl_name == "batched_xla":
         for v_block in (64, 128, 256, 512, 1024, 2048, 4096):
             candidates.append(
                 BlockSizes(
@@ -602,12 +610,13 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
 
     errors: list[Exception] = []
     for impl in impls:
+        _raise_if_renamed_implementation(impl)
         impl_for_call = impl
         if explicit_block_sizes:
             block_sizes_for_impl = resolved_block_sizes
         elif impl_for_call in ("xla", "reference"):
             block_sizes_for_impl = None
-        elif isinstance(impl_for_call, str) and impl_for_call in ("pallas_tpu", "pallas_gpu"):
+        elif isinstance(impl_for_call, str) and impl_for_call in ("pallas_tpu", "batched_xla"):
             inferred, has_tuned_match = infer_block_sizes_with_tuned_match(
                 x.shape[0],
                 x.shape[1],
@@ -617,7 +626,7 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
                 w_dtype=w.dtype,
             )
             fn = IMPLEMENTATIONS.get(impl_for_call)
-            if fn is None or not _pallas_impl_matches_current_backend(impl_for_call, fn=fn):
+            if fn is None or not _implementation_matches_current_backend(impl_for_call, fn=fn):
                 block_sizes_for_impl = inferred
             elif has_tuned_match:
                 block_sizes_for_impl = inferred
@@ -638,7 +647,7 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
                 except Exception as exc:
                     if explicit:
                         raise
-                    _warn_pallas_fallback_once(exc)
+                    _warn_implementation_fallback_once(exc)
                     errors.append(exc)
                     continue
         else:
@@ -661,16 +670,16 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
                 if return_argmax:
                     kwargs["return_argmax"] = True
                 result = impl_for_call(x, labels, w, **kwargs)
-            except PallasUnsupportedError as e:
+            except (PallasUnsupportedError, BatchedXlaUnsupportedError) as e:
                 if explicit:
                     raise
-                _warn_pallas_fallback_once(e)
+                _warn_implementation_fallback_once(e)
                 errors.append(e)
                 continue
             except NotImplementedError as e:
                 if explicit:
                     raise
-                _warn_pallas_fallback_once(e)
+                _warn_implementation_fallback_once(e)
                 errors.append(e)
                 continue
         else:
@@ -687,23 +696,23 @@ def fused_cross_entropy_loss_and_logsumexp_penalty(
                 if return_argmax:
                     kwargs["return_argmax"] = True
                 result = fn(x, labels, w, **kwargs)
-            except PallasUnsupportedError as e:
+            except (PallasUnsupportedError, BatchedXlaUnsupportedError) as e:
                 if explicit:
                     raise
-                _warn_pallas_fallback_once(e)
+                _warn_implementation_fallback_once(e)
                 errors.append(e)
                 continue
             except NotImplementedError as e:
                 if explicit:
                     raise
-                _warn_pallas_fallback_once(e)
+                _warn_implementation_fallback_once(e)
                 errors.append(e)
                 continue
             except Exception as e:
                 should_try_next_impl = (
                     not explicit
                     and isinstance(impl_for_call, str)
-                    and impl_for_call in ("pallas_tpu", "pallas_gpu")
+                    and impl_for_call == "pallas_tpu"
                     and _is_tpu_vmem_compile_error(e)
                 )
                 if should_try_next_impl:

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/api.py
@@ -24,6 +24,10 @@ from .tuned_block_sizes import (
 )
 from .reference import linear_softmax_cross_entropy_loss_reference
 from .xla import linear_softmax_cross_entropy_loss_xla
+from .batched_xla import (
+    BatchedXlaUnsupportedError,
+    linear_softmax_cross_entropy_loss_batched_xla,
+)
 
 
 Implementation: TypeAlias = Literal[
@@ -68,16 +72,8 @@ try:
 except ImportError:
     PallasUnsupportedError = NotImplementedError  # type: ignore[assignment]
 
-try:
-    from .batched_xla import (
-        BatchedXlaUnsupportedError,
-        linear_softmax_cross_entropy_loss_batched_xla,
-    )
-
-    IMPLEMENTATIONS["batched_xla"] = linear_softmax_cross_entropy_loss_batched_xla
-    _CANONICAL_BACKEND_IMPLEMENTATIONS["batched_xla"] = linear_softmax_cross_entropy_loss_batched_xla
-except ImportError:
-    BatchedXlaUnsupportedError = NotImplementedError  # type: ignore[assignment]
+IMPLEMENTATIONS["batched_xla"] = linear_softmax_cross_entropy_loss_batched_xla
+_CANONICAL_BACKEND_IMPLEMENTATIONS["batched_xla"] = linear_softmax_cross_entropy_loss_batched_xla
 
 
 @lru_cache(maxsize=1)

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/batched_xla.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/batched_xla.py
@@ -97,7 +97,7 @@ def _gb10_xla_fallback_block_sizes(
     return None
 
 
-class PallasUnsupportedError(NotImplementedError):
+class BatchedXlaUnsupportedError(NotImplementedError):
     """Raised when the GPU fused cross-entropy backend cannot be used."""
 
 
@@ -119,21 +119,21 @@ def _validate_inputs(
     _validate_input_contract(x, labels, w)
 
     if block_sizes.b_block_size <= 0:
-        raise PallasUnsupportedError(f"b_block_size must be positive, got {block_sizes.b_block_size}.")
+        raise BatchedXlaUnsupportedError(f"b_block_size must be positive, got {block_sizes.b_block_size}.")
     if block_sizes.h_block_size <= 0:
-        raise PallasUnsupportedError(f"h_block_size must be positive, got {block_sizes.h_block_size}.")
+        raise BatchedXlaUnsupportedError(f"h_block_size must be positive, got {block_sizes.h_block_size}.")
     if block_sizes.v_block_size <= 0:
-        raise PallasUnsupportedError(f"v_block_size must be positive, got {block_sizes.v_block_size}.")
+        raise BatchedXlaUnsupportedError(f"v_block_size must be positive, got {block_sizes.v_block_size}.")
     if block_sizes.b_block_size < _GPU_MIN_B_BLOCK_SIZE:
-        raise PallasUnsupportedError(f"b_block_size must be at least {_GPU_MIN_B_BLOCK_SIZE} on GPU.")
+        raise BatchedXlaUnsupportedError(f"b_block_size must be at least {_GPU_MIN_B_BLOCK_SIZE} on GPU.")
     if block_sizes.h_block_size < 16:
-        raise PallasUnsupportedError("h_block_size must be at least 16 on GPU.")
+        raise BatchedXlaUnsupportedError("h_block_size must be at least 16 on GPU.")
     if block_sizes.v_block_size < 16:
-        raise PallasUnsupportedError("v_block_size must be at least 16 on GPU.")
+        raise BatchedXlaUnsupportedError("v_block_size must be at least 16 on GPU.")
     if block_sizes.b_block_size % 16 != 0:
-        raise PallasUnsupportedError("b_block_size must be a multiple of 16 on GPU.")
+        raise BatchedXlaUnsupportedError("b_block_size must be a multiple of 16 on GPU.")
     if block_sizes.h_block_size % 16 != 0:
-        raise PallasUnsupportedError("h_block_size must be a multiple of 16 on GPU.")
+        raise BatchedXlaUnsupportedError("h_block_size must be a multiple of 16 on GPU.")
 
 
 def _validate_input_contract(
@@ -142,26 +142,26 @@ def _validate_input_contract(
     w: Float[Array, "H V"],
 ) -> None:
     if jax.default_backend() != "gpu":
-        raise PallasUnsupportedError("Pallas fused cross-entropy requires GPU backend.")
+        raise BatchedXlaUnsupportedError("Batched XLA fused cross-entropy requires GPU backend.")
 
     if x.ndim != 2:
-        raise PallasUnsupportedError(f"x must be rank-2 [B, H], got shape {x.shape}.")
+        raise BatchedXlaUnsupportedError(f"x must be rank-2 [B, H], got shape {x.shape}.")
     if labels.ndim != 1:
-        raise PallasUnsupportedError(f"labels must be rank-1 [B], got shape {labels.shape}.")
+        raise BatchedXlaUnsupportedError(f"labels must be rank-1 [B], got shape {labels.shape}.")
     if w.ndim != 2:
-        raise PallasUnsupportedError(f"w must be rank-2 [H, V], got shape {w.shape}.")
+        raise BatchedXlaUnsupportedError(f"w must be rank-2 [H, V], got shape {w.shape}.")
     if x.shape[0] != labels.shape[0]:
-        raise PallasUnsupportedError(f"Batch mismatch: x has B={x.shape[0]}, labels has B={labels.shape[0]}.")
+        raise BatchedXlaUnsupportedError(f"Batch mismatch: x has B={x.shape[0]}, labels has B={labels.shape[0]}.")
     if x.shape[1] != w.shape[0]:
-        raise PallasUnsupportedError(f"Hidden mismatch: x has H={x.shape[1]}, w has H={w.shape[0]}.")
+        raise BatchedXlaUnsupportedError(f"Hidden mismatch: x has H={x.shape[1]}, w has H={w.shape[0]}.")
 
     if not jnp.issubdtype(labels.dtype, jnp.integer):
-        raise PallasUnsupportedError(f"labels must be integer dtype, got {labels.dtype}.")
+        raise BatchedXlaUnsupportedError(f"labels must be integer dtype, got {labels.dtype}.")
 
 
 def _zero_pad(x: jax.Array, *, axis: int, multiple: int, pad_value: float | int) -> jax.Array:
     if multiple <= 0:
-        raise PallasUnsupportedError(f"Padding multiple must be positive, got {multiple}.")
+        raise BatchedXlaUnsupportedError(f"Padding multiple must be positive, got {multiple}.")
     dim = x.shape[axis]
     pad = (-dim) % multiple
     if pad == 0:
@@ -180,11 +180,11 @@ def _validate_launch_feasibility(
     num_h_blocks: int,
 ) -> None:
     if not _is_power_of_two(h_block_size):
-        raise PallasUnsupportedError(
+        raise BatchedXlaUnsupportedError(
             "h_block_size must be a power of 2 for current GPU Triton lowering; " f"got h_block_size={h_block_size}."
         )
     if not _is_power_of_two(v_block_size):
-        raise PallasUnsupportedError(
+        raise BatchedXlaUnsupportedError(
             "v_block_size must be a power of 2 for current GPU Triton lowering; " f"got v_block_size={v_block_size}."
         )
 
@@ -193,7 +193,7 @@ def _validate_launch_feasibility(
     if max_weight_tile_bytes is not None:
         requested = h_block_size * v_block_size * jnp.dtype(w_dtype).itemsize
         if requested > max_weight_tile_bytes:
-            raise PallasUnsupportedError(
+            raise BatchedXlaUnsupportedError(
                 "Requested weight tile exceeds GPU shared-memory budget for this device: "
                 f"requested={requested} bytes, limit={max_weight_tile_bytes} bytes, "
                 f"h_block_size={h_block_size}, v_block_size={v_block_size}."
@@ -201,7 +201,7 @@ def _validate_launch_feasibility(
 
     max_h_tiles = _max_h_tiles_for_device(device_kind)
     if max_h_tiles is not None and num_h_blocks > max_h_tiles:
-        raise PallasUnsupportedError(
+        raise BatchedXlaUnsupportedError(
             "Kernel launch would require too many hidden-dimension dot tiles for this GPU and is likely to trigger "
             "pathological compile time. "
             f"num_h_blocks={num_h_blocks}, limit={max_h_tiles}, h_block_size={h_block_size}."
@@ -223,7 +223,7 @@ def _validate_launch_feasibility(
         "return_argmax",
     ],
 )
-def _linear_softmax_cross_entropy_loss_pallas_gpu_fa_style_streaming(
+def _linear_softmax_cross_entropy_loss_batched_xla_fa_style_streaming(
     x: Float[Array, "B H"],
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
@@ -399,7 +399,7 @@ def _h100_full_vocab_b_tiled_block_size(
         "return_argmax",
     ],
 )
-def _linear_softmax_cross_entropy_loss_pallas_gpu_impl(
+def _linear_softmax_cross_entropy_loss_batched_xla_impl(
     x: Float[Array, "B H"],
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
@@ -410,7 +410,7 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_impl(
     precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
     return_argmax: bool = False,
 ) -> tuple[Float[Array, "B"], Float[Array, "B"]] | tuple[Float[Array, "B"], Float[Array, "B"], Int[Array, "B"]]:
-    """GPU Pallas implementation returning per-example loss and logsumexp."""
+    """Batched XLA implementation returning per-example loss and logsumexp."""
     device_kind = _device_kind()
     is_gb10_bf16 = "gb10" in device_kind and x.dtype == jnp.bfloat16 and w.dtype == jnp.bfloat16
 
@@ -487,9 +487,9 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_impl(
 
     out_dtype = jnp.dtype(dtype) if dtype is not None else x.dtype
 
-    # JAX 0.10 Mosaic GPU does not lower the tiled pallas_call dot_general path.
-    # Keep forward on the FA-style streaming path until Mosaic GPU supports this lowering.
-    fa_out = _linear_softmax_cross_entropy_loss_pallas_gpu_fa_style_streaming(
+    # Keep forward on the FA-style streaming path until Mosaic GPU lowers the
+    # tiled dot_general form this path originally targeted.
+    fa_out = _linear_softmax_cross_entropy_loss_batched_xla_fa_style_streaming(
         x_pad,
         labels_pad,
         w_pad,
@@ -714,7 +714,7 @@ def _backward_streaming_from_lse(
 
 
 @partial(jax.custom_vjp, nondiff_argnums=(3, 4, 5, 6))
-def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward(
+def _linear_softmax_cross_entropy_loss_batched_xla_with_custom_backward(
     x: Float[Array, "B H"],
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
@@ -723,7 +723,7 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward(
     logit_soft_cap: Optional[float],
     precision: jax.lax.PrecisionLike,
 ) -> tuple[Float[Array, "B"], Float[Array, "B"]]:
-    return _linear_softmax_cross_entropy_loss_pallas_gpu_impl(
+    return _linear_softmax_cross_entropy_loss_batched_xla_impl(
         x,
         labels,
         w,
@@ -734,7 +734,7 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward(
     )
 
 
-def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_fwd(
+def _linear_softmax_cross_entropy_loss_batched_xla_with_custom_backward_fwd(
     x: Float[Array, "B H"],
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
@@ -743,7 +743,7 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_fwd(
     logit_soft_cap: Optional[float],
     precision: jax.lax.PrecisionLike,
 ):
-    loss, lse = _linear_softmax_cross_entropy_loss_pallas_gpu_impl(
+    loss, lse = _linear_softmax_cross_entropy_loss_batched_xla_impl(
         x,
         labels,
         w,
@@ -767,7 +767,7 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_fwd(
     return (loss, lse), residual
 
 
-def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_bwd(
+def _linear_softmax_cross_entropy_loss_batched_xla_with_custom_backward_bwd(
     block_sizes: BlockSizes | None,
     dtype: Optional[jnp.dtype],
     logit_soft_cap: Optional[float],
@@ -805,9 +805,9 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_bwd(
     return grad_x, None, grad_w
 
 
-_linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward.defvjp(
-    _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_fwd,
-    _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_bwd,
+_linear_softmax_cross_entropy_loss_batched_xla_with_custom_backward.defvjp(
+    _linear_softmax_cross_entropy_loss_batched_xla_with_custom_backward_fwd,
+    _linear_softmax_cross_entropy_loss_batched_xla_with_custom_backward_bwd,
 )
 
 
@@ -821,7 +821,7 @@ _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward.defvjp(
         "return_argmax",
     ],
 )
-def _linear_softmax_cross_entropy_loss_pallas_gpu_dispatch(
+def _linear_softmax_cross_entropy_loss_batched_xla_dispatch(
     x: Float[Array, "B H"],
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
@@ -833,7 +833,7 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_dispatch(
     return_argmax: bool = False,
 ) -> tuple[Float[Array, "B"], Float[Array, "B"]] | tuple[Float[Array, "B"], Float[Array, "B"], Int[Array, "B"]]:
     if return_argmax:
-        return _linear_softmax_cross_entropy_loss_pallas_gpu_impl(
+        return _linear_softmax_cross_entropy_loss_batched_xla_impl(
             x,
             labels,
             w,
@@ -843,7 +843,7 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_dispatch(
             precision=precision,
             return_argmax=True,
         )
-    return _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward(
+    return _linear_softmax_cross_entropy_loss_batched_xla_with_custom_backward(
         x,
         labels,
         w,
@@ -854,7 +854,7 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_dispatch(
     )
 
 
-def linear_softmax_cross_entropy_loss_pallas_gpu(
+def linear_softmax_cross_entropy_loss_batched_xla(
     x: Float[Array, "B H"],
     labels: Int[Array, "B"],
     w: Float[Array, "H V"],
@@ -879,7 +879,7 @@ def linear_softmax_cross_entropy_loss_pallas_gpu(
             return_argmax=return_argmax,
         )
 
-    return _linear_softmax_cross_entropy_loss_pallas_gpu_dispatch(
+    return _linear_softmax_cross_entropy_loss_batched_xla_dispatch(
         x,
         labels,
         w,
@@ -891,4 +891,4 @@ def linear_softmax_cross_entropy_loss_pallas_gpu(
     )
 
 
-__all__ = ["linear_softmax_cross_entropy_loss_pallas_gpu", "PallasUnsupportedError"]
+__all__ = ["linear_softmax_cross_entropy_loss_batched_xla", "BatchedXlaUnsupportedError"]

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/batched_xla.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/batched_xla.py
@@ -598,9 +598,9 @@ def _backward_b_tiled_from_lse(
 
         valid_rows = labels_block >= 0
         safe_labels = jnp.clip(labels_block, 0, v_dim - 1)
-        label_one_hot = jax.nn.one_hot(safe_labels, v_dim, dtype=jnp.float32)
-        label_one_hot = label_one_hot * valid_rows[:, None].astype(jnp.float32)
-        dlogits = dlogits - label_one_hot * g_loss_block[:, None]
+        row_indices = jnp.arange(b_block_size, dtype=jnp.int32)
+        label_grad = jnp.where(valid_rows, -g_loss_block, 0.0)
+        dlogits = dlogits.at[row_indices, safe_labels].add(label_grad)
 
         if logit_soft_cap is not None:
             cap = jnp.asarray(logit_soft_cap, dtype=jnp.float32)

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
@@ -116,19 +116,7 @@ def _validate_inputs(
     w: Float[Array, "H V"],
     block_sizes: BlockSizes,
 ) -> None:
-    if jax.default_backend() != "gpu":
-        raise PallasUnsupportedError("Pallas fused cross-entropy requires GPU backend.")
-
-    if x.ndim != 2:
-        raise PallasUnsupportedError(f"x must be rank-2 [B, H], got shape {x.shape}.")
-    if labels.ndim != 1:
-        raise PallasUnsupportedError(f"labels must be rank-1 [B], got shape {labels.shape}.")
-    if w.ndim != 2:
-        raise PallasUnsupportedError(f"w must be rank-2 [H, V], got shape {w.shape}.")
-    if x.shape[0] != labels.shape[0]:
-        raise PallasUnsupportedError(f"Batch mismatch: x has B={x.shape[0]}, labels has B={labels.shape[0]}.")
-    if x.shape[1] != w.shape[0]:
-        raise PallasUnsupportedError(f"Hidden mismatch: x has H={x.shape[1]}, w has H={w.shape[0]}.")
+    _validate_input_contract(x, labels, w)
 
     if block_sizes.b_block_size <= 0:
         raise PallasUnsupportedError(f"b_block_size must be positive, got {block_sizes.b_block_size}.")
@@ -146,6 +134,26 @@ def _validate_inputs(
         raise PallasUnsupportedError("b_block_size must be a multiple of 16 on GPU.")
     if block_sizes.h_block_size % 16 != 0:
         raise PallasUnsupportedError("h_block_size must be a multiple of 16 on GPU.")
+
+
+def _validate_input_contract(
+    x: Float[Array, "B H"],
+    labels: Int[Array, "B"],
+    w: Float[Array, "H V"],
+) -> None:
+    if jax.default_backend() != "gpu":
+        raise PallasUnsupportedError("Pallas fused cross-entropy requires GPU backend.")
+
+    if x.ndim != 2:
+        raise PallasUnsupportedError(f"x must be rank-2 [B, H], got shape {x.shape}.")
+    if labels.ndim != 1:
+        raise PallasUnsupportedError(f"labels must be rank-1 [B], got shape {labels.shape}.")
+    if w.ndim != 2:
+        raise PallasUnsupportedError(f"w must be rank-2 [H, V], got shape {w.shape}.")
+    if x.shape[0] != labels.shape[0]:
+        raise PallasUnsupportedError(f"Batch mismatch: x has B={x.shape[0]}, labels has B={labels.shape[0]}.")
+    if x.shape[1] != w.shape[0]:
+        raise PallasUnsupportedError(f"Hidden mismatch: x has H={x.shape[1]}, w has H={w.shape[0]}.")
 
     if not jnp.issubdtype(labels.dtype, jnp.integer):
         raise PallasUnsupportedError(f"labels must be integer dtype, got {labels.dtype}.")
@@ -409,7 +417,7 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_impl(
     if block_sizes is None:
         block_sizes = BlockSizes.get_default()
 
-    _validate_inputs(x, labels, w, block_sizes)
+    _validate_input_contract(x, labels, w)
 
     if _should_use_gb10_full_matmul_fallback(x, w):
         return linear_softmax_cross_entropy_loss_reference(
@@ -450,6 +458,8 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_impl(
             precision=precision,
             return_argmax=return_argmax,
         )
+
+    _validate_inputs(x, labels, w, block_sizes)
 
     b_dim, _ = x.shape
     v_dim = w.shape[1]

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
@@ -316,7 +316,7 @@ def _linear_softmax_cross_entropy_loss_full_vocab_b_tiled(
     logit_soft_cap: Optional[float],
     precision: jax.lax.PrecisionLike,
 ) -> tuple[Float[Array, "B"], Float[Array, "B"]]:
-    """Forward pass over batch tiles, materializing one [B_tile, V] logits tile at a time."""
+    """Return per-example loss and logsumexp with bounded peak logits memory."""
     b_dim, h_dim = x.shape
     v_dim = w.shape[1]
     out_dtype = jnp.dtype(dtype) if dtype is not None else x.dtype
@@ -551,7 +551,7 @@ def _backward_b_tiled_from_lse(
     logit_soft_cap: Optional[float],
     precision: jax.lax.PrecisionLike,
 ) -> tuple[Float[Array, "B H"], Float[Array, "H V"]]:
-    """Backward pass over batch tiles using full-vocab GEMMs per tile."""
+    """Return input and weight gradients from saved forward logsumexp."""
     b_dim, h_dim = x.shape
     v_dim = w.shape[1]
 

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
@@ -4,7 +4,7 @@
 from __future__ import annotations
 
 from functools import partial
-from typing import Optional
+from typing import NamedTuple, Optional
 
 import jax
 import jax.numpy as jnp
@@ -99,6 +99,15 @@ def _gb10_xla_fallback_block_sizes(
 
 class PallasUnsupportedError(NotImplementedError):
     """Raised when the GPU fused cross-entropy backend cannot be used."""
+
+
+class _CustomBackwardResidual(NamedTuple):
+    x: jax.Array
+    labels: jax.Array
+    w: jax.Array
+    lse: jax.Array
+    full_vocab_b_block: int | None
+    backward_v_block: int
 
 
 def _validate_inputs(
@@ -326,21 +335,18 @@ def _linear_softmax_cross_entropy_loss_full_vocab_b_tiled(
         x_block = jax.lax.dynamic_slice(x_pad, (b_start, 0), (b_block_size, h_dim))
         labels_block = jax.lax.dynamic_slice(labels_pad, (b_start,), (b_block_size,))
 
-        logits = jax.lax.dot_general(
+        valid_rows = labels_block >= 0
+        safe_labels = jnp.clip(labels_block, 0, v_dim - 1)
+        reference_out = linear_softmax_cross_entropy_loss_reference(
             x_block,
+            safe_labels,
             w,
-            (((1,), (0,)), ((), ())),
+            dtype=dtype,
+            logit_soft_cap=logit_soft_cap,
             precision=precision,
         )
-        if dtype is not None:
-            logits = logits.astype(dtype)
-        logits = _apply_logit_soft_cap(logits, logit_soft_cap)
-
-        valid_rows = labels_block >= 0
-        lse_block = jax.nn.logsumexp(logits, axis=-1)
-        safe_labels = jnp.clip(labels_block, 0, v_dim - 1)
-        label_logits = jnp.take_along_axis(logits, safe_labels[:, None], axis=1).squeeze(-1)
-        loss_block = lse_block - label_logits
+        loss_block = reference_out[0]
+        lse_block = reference_out[1]
 
         loss_block = jnp.where(valid_rows, loss_block, 0.0).astype(out_dtype)
         lse_block = jnp.where(valid_rows, lse_block, 0.0).astype(out_dtype)
@@ -740,7 +746,15 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_fwd(
     # exactly the same policy decision as fwd without recomputing dispatch logic.
     full_vocab_b_block = _h100_full_vocab_b_tiled_block_size(x, w)
     backward_v_block = _custom_backward_v_block_size(x, w, block_sizes)
-    return (loss, lse), (x, labels, w, lse, full_vocab_b_block, backward_v_block)
+    residual = _CustomBackwardResidual(
+        x=x,
+        labels=labels,
+        w=w,
+        lse=lse,
+        full_vocab_b_block=full_vocab_b_block,
+        backward_v_block=backward_v_block,
+    )
+    return (loss, lse), residual
 
 
 def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_bwd(
@@ -751,30 +765,29 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_bwd(
     residuals,
     output_cotangent,
 ):
-    x, labels, w, lse, full_vocab_b_block, backward_v_block = residuals
     g_loss, g_lse = output_cotangent
 
-    if full_vocab_b_block is not None:
+    if residuals.full_vocab_b_block is not None:
         grad_x, grad_w = _backward_b_tiled_from_lse(
-            x,
-            labels,
-            w,
-            lse,
+            residuals.x,
+            residuals.labels,
+            residuals.w,
+            residuals.lse,
             g_loss,
             g_lse,
-            b_block_size=full_vocab_b_block,
+            b_block_size=residuals.full_vocab_b_block,
             logit_soft_cap=logit_soft_cap,
             precision=precision,
         )
     else:
         grad_x, grad_w = _backward_streaming_from_lse(
-            x,
-            labels,
-            w,
-            lse,
+            residuals.x,
+            residuals.labels,
+            residuals.w,
+            residuals.lse,
             g_loss,
             g_lse,
-            v_block_size=backward_v_block,
+            v_block_size=residuals.backward_v_block,
             logit_soft_cap=logit_soft_cap,
             precision=precision,
         )

--- a/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/pallas_gpu.py
@@ -26,9 +26,12 @@ _GB10_FULL_MATMUL_MAX_OUTPUT_ELEMENTS = 67_108_864
 _GB10_XLA_STREAMING_V_BLOCK_BATCH_1K = 2048
 _GB10_XLA_STREAMING_V_BLOCK_BATCH_4K = 3072
 _GB10_XLA_STREAMING_V_BLOCK_BATCH_8K = 3072
+_LARGE_VOCAB_THRESHOLD = 65536
 _GB10_CUSTOM_BWD_V_BLOCK_BATCH_1K = 6144
 _GB10_CUSTOM_BWD_V_BLOCK_BATCH_2K_PLUS = 7168
 _GPU_MIN_B_BLOCK_SIZE = 128
+_H100_FULL_VOCAB_B_TILED_BLOCK_SIZE = 8192
+_H100_FULL_VOCAB_B_TILED_MIN_BATCH = 8192
 
 
 def _apply_logit_soft_cap(logits: jax.Array, logit_soft_cap: Optional[float]) -> jax.Array:
@@ -83,7 +86,7 @@ def _gb10_xla_fallback_block_sizes(
     b_dim: int,
     v_dim: int,
 ) -> BlockSizes | None:
-    if v_dim < 65536:
+    if v_dim < _LARGE_VOCAB_THRESHOLD:
         return None
     if b_dim >= 8192:
         return BlockSizes(v_block_size=_GB10_XLA_STREAMING_V_BLOCK_BATCH_8K)
@@ -293,6 +296,85 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_fa_style_streaming(
     return loss, lse
 
 
+@partial(jax.jit, static_argnames=["b_block_size", "dtype", "logit_soft_cap", "precision"])
+def _linear_softmax_cross_entropy_loss_full_vocab_b_tiled(
+    x: Float[Array, "B H"],
+    labels: Int[Array, "B"],
+    w: Float[Array, "H V"],
+    *,
+    b_block_size: int,
+    dtype: Optional[jnp.dtype],
+    logit_soft_cap: Optional[float],
+    precision: jax.lax.PrecisionLike,
+) -> tuple[Float[Array, "B"], Float[Array, "B"]]:
+    """Forward pass over batch tiles, materializing one [B_tile, V] logits tile at a time."""
+    b_dim, h_dim = x.shape
+    v_dim = w.shape[1]
+    out_dtype = jnp.dtype(dtype) if dtype is not None else x.dtype
+
+    x_pad = _zero_pad(x, axis=0, multiple=b_block_size, pad_value=0.0)
+    labels_pad = _zero_pad(labels.astype(jnp.int32), axis=0, multiple=b_block_size, pad_value=-1)
+    b_pad = x_pad.shape[0]
+    num_b_blocks = b_pad // b_block_size
+
+    loss_init = jnp.zeros((b_pad,), dtype=out_dtype)
+    lse_init = jnp.zeros((b_pad,), dtype=out_dtype)
+
+    def body(block_index, state):
+        loss, lse = state
+        b_start = block_index * b_block_size
+        x_block = jax.lax.dynamic_slice(x_pad, (b_start, 0), (b_block_size, h_dim))
+        labels_block = jax.lax.dynamic_slice(labels_pad, (b_start,), (b_block_size,))
+
+        logits = jax.lax.dot_general(
+            x_block,
+            w,
+            (((1,), (0,)), ((), ())),
+            precision=precision,
+        )
+        if dtype is not None:
+            logits = logits.astype(dtype)
+        logits = _apply_logit_soft_cap(logits, logit_soft_cap)
+
+        valid_rows = labels_block >= 0
+        lse_block = jax.nn.logsumexp(logits, axis=-1)
+        safe_labels = jnp.clip(labels_block, 0, v_dim - 1)
+        label_logits = jnp.take_along_axis(logits, safe_labels[:, None], axis=1).squeeze(-1)
+        loss_block = lse_block - label_logits
+
+        loss_block = jnp.where(valid_rows, loss_block, 0.0).astype(out_dtype)
+        lse_block = jnp.where(valid_rows, lse_block, 0.0).astype(out_dtype)
+        loss = jax.lax.dynamic_update_slice(loss, loss_block, (b_start,))
+        lse = jax.lax.dynamic_update_slice(lse, lse_block, (b_start,))
+        return loss, lse
+
+    loss, lse = jax.lax.fori_loop(0, num_b_blocks, body, (loss_init, lse_init))
+    return loss[:b_dim], lse[:b_dim]
+
+
+def _h100_full_vocab_b_tiled_block_size(
+    x: Float[Array, "B H"],
+    w: Float[Array, "H V"],
+    *,
+    return_argmax: bool = False,
+) -> int | None:
+    """Return the H100 full-vocab batch tile when the materialized logits path would be too large."""
+    if return_argmax:
+        return None
+    device_kind = _device_kind()
+    if "h100" not in device_kind:
+        return None
+    if "gb10" in device_kind:
+        return None
+    if x.dtype != jnp.bfloat16 or w.dtype != jnp.bfloat16:
+        return None
+    if x.shape[0] < _H100_FULL_VOCAB_B_TILED_MIN_BATCH:
+        return None
+    if w.shape[1] < _LARGE_VOCAB_THRESHOLD:
+        return None
+    return _H100_FULL_VOCAB_B_TILED_BLOCK_SIZE
+
+
 @partial(
     jax.jit,
     static_argnames=[
@@ -318,6 +400,11 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_impl(
     device_kind = _device_kind()
     is_gb10_bf16 = "gb10" in device_kind and x.dtype == jnp.bfloat16 and w.dtype == jnp.bfloat16
 
+    if block_sizes is None:
+        block_sizes = BlockSizes.get_default()
+
+    _validate_inputs(x, labels, w, block_sizes)
+
     if _should_use_gb10_full_matmul_fallback(x, w):
         return linear_softmax_cross_entropy_loss_reference(
             x,
@@ -327,6 +414,17 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_impl(
             logit_soft_cap=logit_soft_cap,
             precision=precision,
             return_argmax=return_argmax,
+        )
+    full_vocab_b_block = _h100_full_vocab_b_tiled_block_size(x, w, return_argmax=return_argmax)
+    if full_vocab_b_block is not None:
+        return _linear_softmax_cross_entropy_loss_full_vocab_b_tiled(
+            x,
+            labels,
+            w,
+            b_block_size=full_vocab_b_block,
+            dtype=dtype,
+            logit_soft_cap=logit_soft_cap,
+            precision=precision,
         )
     if is_gb10_bf16:
         # On GB10 BF16 we intentionally keep forward on the XLA streaming path and attach
@@ -346,11 +444,6 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_impl(
             precision=precision,
             return_argmax=return_argmax,
         )
-
-    if block_sizes is None:
-        block_sizes = BlockSizes.get_default()
-
-    _validate_inputs(x, labels, w, block_sizes)
 
     b_dim, _ = x.shape
     v_dim = w.shape[1]
@@ -417,7 +510,7 @@ def _gb10_custom_backward_v_block_size(
         return None
     if _should_use_gb10_full_matmul_fallback(x, w):
         return None
-    if w.shape[1] < 65536:
+    if w.shape[1] < _LARGE_VOCAB_THRESHOLD:
         return None
     if x.shape[0] >= 2048:
         return _GB10_CUSTOM_BWD_V_BLOCK_BATCH_2K_PLUS
@@ -437,6 +530,87 @@ def _custom_backward_v_block_size(
     if block_sizes is not None:
         return block_sizes.v_block_size
     return BlockSizes.get_default().v_block_size
+
+
+@partial(jax.jit, static_argnames=["b_block_size", "logit_soft_cap", "precision"])
+def _backward_b_tiled_from_lse(
+    x: Float[Array, "B H"],
+    labels: Int[Array, "B"],
+    w: Float[Array, "H V"],
+    lse: Float[Array, "B"],
+    g_loss: Float[Array, "B"],
+    g_lse: Float[Array, "B"],
+    *,
+    b_block_size: int,
+    logit_soft_cap: Optional[float],
+    precision: jax.lax.PrecisionLike,
+) -> tuple[Float[Array, "B H"], Float[Array, "H V"]]:
+    """Backward pass over batch tiles using full-vocab GEMMs per tile."""
+    b_dim, h_dim = x.shape
+    v_dim = w.shape[1]
+
+    x_pad = _zero_pad(x, axis=0, multiple=b_block_size, pad_value=0.0)
+    labels_pad = _zero_pad(labels.astype(jnp.int32), axis=0, multiple=b_block_size, pad_value=-1)
+    lse_pad = _zero_pad(lse, axis=0, multiple=b_block_size, pad_value=0.0)
+    g_loss_pad = _zero_pad(g_loss, axis=0, multiple=b_block_size, pad_value=0.0)
+    g_lse_pad = _zero_pad(g_lse, axis=0, multiple=b_block_size, pad_value=0.0)
+    b_pad = x_pad.shape[0]
+    num_b_blocks = b_pad // b_block_size
+
+    grad_x_init = jnp.zeros((b_pad, h_dim), dtype=jnp.float32)
+    grad_w_init = jnp.zeros((h_dim, v_dim), dtype=jnp.float32)
+
+    def body(block_index, state):
+        grad_x, grad_w = state
+        b_start = block_index * b_block_size
+        x_block = jax.lax.dynamic_slice(x_pad, (b_start, 0), (b_block_size, h_dim))
+        labels_block = jax.lax.dynamic_slice(labels_pad, (b_start,), (b_block_size,))
+        lse_block = jax.lax.dynamic_slice(lse_pad, (b_start,), (b_block_size,)).astype(jnp.float32)
+        g_loss_block = jax.lax.dynamic_slice(g_loss_pad, (b_start,), (b_block_size,)).astype(jnp.float32)
+        g_lse_block = jax.lax.dynamic_slice(g_lse_pad, (b_start,), (b_block_size,)).astype(jnp.float32)
+
+        logits_raw = jax.lax.dot_general(
+            x_block,
+            w,
+            (((1,), (0,)), ((), ())),
+            precision=precision,
+        ).astype(jnp.float32)
+        logits = _apply_logit_soft_cap(logits_raw, logit_soft_cap)
+
+        probs = jnp.exp(logits - lse_block[:, None])
+        dlogits = probs * (g_loss_block + g_lse_block)[:, None]
+
+        valid_rows = labels_block >= 0
+        safe_labels = jnp.clip(labels_block, 0, v_dim - 1)
+        label_one_hot = jax.nn.one_hot(safe_labels, v_dim, dtype=jnp.float32)
+        label_one_hot = label_one_hot * valid_rows[:, None].astype(jnp.float32)
+        dlogits = dlogits - label_one_hot * g_loss_block[:, None]
+
+        if logit_soft_cap is not None:
+            cap = jnp.asarray(logit_soft_cap, dtype=jnp.float32)
+            soft_cap_grad = 1.0 - jnp.square(logits / cap)
+            dlogits = dlogits * soft_cap_grad
+
+        dlogits_for_matmul = dlogits.astype(x.dtype)
+        grad_x_block = jax.lax.dot_general(
+            dlogits_for_matmul,
+            w,
+            (((1,), (1,)), ((), ())),
+            precision=precision,
+        ).astype(jnp.float32)
+        grad_w_block = jax.lax.dot_general(
+            x_block,
+            dlogits_for_matmul,
+            (((0,), (0,)), ((), ())),
+            precision=precision,
+        ).astype(jnp.float32)
+
+        grad_x = jax.lax.dynamic_update_slice(grad_x, grad_x_block, (b_start, 0))
+        grad_w = grad_w + grad_w_block
+        return grad_x, grad_w
+
+    grad_x, grad_w = jax.lax.fori_loop(0, num_b_blocks, body, (grad_x_init, grad_w_init))
+    return grad_x[:b_dim].astype(x.dtype), grad_w.astype(w.dtype)
 
 
 @partial(jax.jit, static_argnames=["v_block_size", "logit_soft_cap", "precision"])
@@ -564,8 +738,9 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_fwd(
     )
     # We carry this shape-derived tuning choice in residuals so bwd can use
     # exactly the same policy decision as fwd without recomputing dispatch logic.
+    full_vocab_b_block = _h100_full_vocab_b_tiled_block_size(x, w)
     backward_v_block = _custom_backward_v_block_size(x, w, block_sizes)
-    return (loss, lse), (x, labels, w, lse, backward_v_block)
+    return (loss, lse), (x, labels, w, lse, full_vocab_b_block, backward_v_block)
 
 
 def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_bwd(
@@ -576,20 +751,33 @@ def _linear_softmax_cross_entropy_loss_pallas_gpu_with_custom_backward_bwd(
     residuals,
     output_cotangent,
 ):
-    x, labels, w, lse, backward_v_block = residuals
+    x, labels, w, lse, full_vocab_b_block, backward_v_block = residuals
     g_loss, g_lse = output_cotangent
 
-    grad_x, grad_w = _backward_streaming_from_lse(
-        x,
-        labels,
-        w,
-        lse,
-        g_loss,
-        g_lse,
-        v_block_size=backward_v_block,
-        logit_soft_cap=logit_soft_cap,
-        precision=precision,
-    )
+    if full_vocab_b_block is not None:
+        grad_x, grad_w = _backward_b_tiled_from_lse(
+            x,
+            labels,
+            w,
+            lse,
+            g_loss,
+            g_lse,
+            b_block_size=full_vocab_b_block,
+            logit_soft_cap=logit_soft_cap,
+            precision=precision,
+        )
+    else:
+        grad_x, grad_w = _backward_streaming_from_lse(
+            x,
+            labels,
+            w,
+            lse,
+            g_loss,
+            g_lse,
+            v_block_size=backward_v_block,
+            logit_soft_cap=logit_soft_cap,
+            precision=precision,
+        )
 
     return grad_x, None, grad_w
 

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -477,7 +477,7 @@ def test_fused_cross_entropy_pallas_gpu_name_points_to_batched_xla():
     w = jnp.zeros((3, 5), dtype=jnp.float32)
     y = jnp.zeros((2,), dtype=jnp.int32)
 
-    with pytest.raises(ValueError, match='implementation="pallas_gpu" was renamed to "batched_xla"'):
+    with pytest.raises(ValueError, match="pallas_gpu.*batched_xla"):
         fused_api.fused_cross_entropy_loss_and_logsumexp_penalty(
             x,
             y,

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -822,6 +822,104 @@ def test_fused_cross_entropy_pallas_gpu_requires_gpu():
         )
 
 
+def test_pallas_gpu_full_vocab_b_tiled_forward_matches_reference():
+    if jax.default_backend() == "tpu":
+        pytest.skip("pallas_gpu full-vocab B-tiled helper is covered by CPU/GPU precision paths")
+
+    key = jax.random.PRNGKey(41)
+    key_x, key_w, key_y = jax.random.split(key, 3)
+    x = jax.random.normal(key_x, (7, 5), dtype=jnp.float32)
+    w = jax.random.normal(key_w, (5, 11), dtype=jnp.float32)
+    y = jax.random.randint(key_y, (7,), 0, 11, dtype=jnp.int32)
+
+    expected_loss, expected_lse = linear_softmax_cross_entropy_loss_reference(
+        x,
+        y,
+        w,
+        dtype=jnp.float32,
+        logit_soft_cap=1.7,
+    )
+    actual_loss, actual_lse = pallas_gpu._linear_softmax_cross_entropy_loss_full_vocab_b_tiled(
+        x,
+        y,
+        w,
+        b_block_size=4,
+        dtype=jnp.float32,
+        logit_soft_cap=1.7,
+        precision=None,
+    )
+
+    np.testing.assert_allclose(actual_loss, expected_loss, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(actual_lse, expected_lse, rtol=1e-5, atol=1e-5)
+
+
+def test_pallas_gpu_backward_b_tiled_from_lse_matches_reference_gradients():
+    if jax.default_backend() == "tpu":
+        pytest.skip("pallas_gpu custom backward helper is covered by CPU/GPU precision paths")
+
+    key = jax.random.PRNGKey(43)
+    key_x, key_w, key_y, key_loss, key_lse = jax.random.split(key, 5)
+    x = jax.random.normal(key_x, (7, 5), dtype=jnp.float32)
+    w = jax.random.normal(key_w, (5, 11), dtype=jnp.float32)
+    y = jax.random.randint(key_y, (7,), 0, 11, dtype=jnp.int32)
+    g_loss = jax.random.normal(key_loss, (7,), dtype=jnp.float32)
+    g_lse = jax.random.normal(key_lse, (7,), dtype=jnp.float32)
+
+    _, lse = linear_softmax_cross_entropy_loss_reference(x, y, w, dtype=jnp.float32, logit_soft_cap=1.7)
+
+    def reference_cotangent_loss(x_raw: jax.Array, w_raw: jax.Array) -> jax.Array:
+        loss, logsumexp = linear_softmax_cross_entropy_loss_reference(
+            x_raw,
+            y,
+            w_raw,
+            dtype=jnp.float32,
+            logit_soft_cap=1.7,
+        )
+        return jnp.sum(loss * g_loss + logsumexp * g_lse)
+
+    expected_x, expected_w = jax.grad(reference_cotangent_loss, argnums=(0, 1))(x, w)
+    actual_x, actual_w = pallas_gpu._backward_b_tiled_from_lse(
+        x,
+        y,
+        w,
+        lse,
+        g_loss,
+        g_lse,
+        b_block_size=4,
+        logit_soft_cap=1.7,
+        precision=None,
+    )
+
+    np.testing.assert_allclose(actual_x, expected_x, rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(actual_w, expected_w, rtol=1e-5, atol=1e-5)
+
+
+def test_pallas_gpu_h100_full_vocab_policy_selects_b_tiled_path(monkeypatch: pytest.MonkeyPatch):
+    x = jax.ShapeDtypeStruct((8192, 16), jnp.bfloat16)
+    w = jax.ShapeDtypeStruct((16, 65536), jnp.bfloat16)
+
+    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
+    assert pallas_gpu._h100_full_vocab_b_tiled_block_size(x, w) == 8192
+    assert pallas_gpu._h100_full_vocab_b_tiled_block_size(x, w, return_argmax=True) is None
+    assert (
+        pallas_gpu._h100_full_vocab_b_tiled_block_size(
+            jax.ShapeDtypeStruct((8191, 16), jnp.bfloat16),
+            w,
+        )
+        is None
+    )
+    assert (
+        pallas_gpu._h100_full_vocab_b_tiled_block_size(
+            x,
+            jax.ShapeDtypeStruct((16, 65535), jnp.bfloat16),
+        )
+        is None
+    )
+
+    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia gb10")
+    assert pallas_gpu._h100_full_vocab_b_tiled_block_size(x, w) is None
+
+
 def test_fused_cross_entropy_pallas_gpu_custom_backward_grad_matches_xla():
     if jax.default_backend() != "gpu":
         pytest.skip("requires GPU backend")

--- a/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
+++ b/lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import warnings
+from typing import cast
 
 import jax
 import jax.numpy as jnp
@@ -9,9 +10,9 @@ import numpy as np
 import pytest
 
 from levanter.kernels.pallas import autotune_cache_utils
+from levanter.kernels.pallas.fused_cross_entropy_loss import batched_xla
 from levanter.kernels.pallas.fused_cross_entropy_loss import api as fused_api
 from levanter.kernels.pallas.fused_cross_entropy_loss import pallas_tpu
-from levanter.kernels.pallas.fused_cross_entropy_loss import pallas_gpu
 from levanter.kernels.pallas.fused_cross_entropy_loss import tuned_block_sizes
 from levanter.kernels.pallas.fused_cross_entropy_loss import xla as fused_xla
 from levanter.kernels.pallas.fused_cross_entropy_loss.reference import (
@@ -471,6 +472,21 @@ def test_fused_cross_entropy_pallas_requires_tpu():
         )
 
 
+def test_fused_cross_entropy_pallas_gpu_name_points_to_batched_xla():
+    x = jnp.zeros((2, 3), dtype=jnp.float32)
+    w = jnp.zeros((3, 5), dtype=jnp.float32)
+    y = jnp.zeros((2,), dtype=jnp.int32)
+
+    with pytest.raises(ValueError, match='implementation="pallas_gpu" was renamed to "batched_xla"'):
+        fused_api.fused_cross_entropy_loss_and_logsumexp_penalty(
+            x,
+            y,
+            w,
+            reduction=None,
+            implementation=cast(fused_api.Implementation, "pallas_gpu"),
+        )
+
+
 def test_infer_block_sizes_adapts_to_supported_divisors():
     block_sizes = infer_block_sizes(
         b=512,
@@ -698,10 +714,10 @@ def test_fused_cross_entropy_default_grad_matches_reference():
     ("implementation", "required_backend", "block_sizes"),
     [
         ("pallas_tpu", "tpu", fused_api.BlockSizes(b_block_size=128, h_block_size=128, v_block_size=128)),
-        ("pallas_gpu", "gpu", None),
+        ("batched_xla", "gpu", None),
     ],
 )
-def test_fused_cross_entropy_pallas_matches_reference(
+def test_fused_cross_entropy_named_implementation_matches_reference(
     implementation: str,
     required_backend: str,
     block_sizes: fused_api.BlockSizes | None,
@@ -731,7 +747,7 @@ def test_fused_cross_entropy_pallas_matches_reference(
     assert jnp.allclose(loss, loss_ref, atol=1e-5, rtol=1e-5)
 
 
-def test_fused_cross_entropy_pallas_gpu_matches_reference_non_multiple():
+def test_fused_cross_entropy_batched_xla_matches_reference_non_multiple():
     if jax.default_backend() != "gpu":
         pytest.skip("requires GPU backend")
 
@@ -748,7 +764,7 @@ def test_fused_cross_entropy_pallas_gpu_matches_reference_non_multiple():
         y,
         w,
         reduction=None,
-        implementation="pallas_gpu",
+        implementation="batched_xla",
         block_sizes=block_sizes,
     )
 
@@ -761,7 +777,7 @@ def test_fused_cross_entropy_pallas_gpu_matches_reference_non_multiple():
     assert jnp.allclose(loss, loss_ref, atol=1e-5, rtol=1e-5)
 
 
-def test_fused_cross_entropy_pallas_gpu_return_argmax_matches_reference():
+def test_fused_cross_entropy_batched_xla_return_argmax_matches_reference():
     if jax.default_backend() != "gpu":
         pytest.skip("requires GPU backend")
 
@@ -780,7 +796,7 @@ def test_fused_cross_entropy_pallas_gpu_return_argmax_matches_reference():
         reduction=None,
         logsumexp_weight=0.0,
         logit_soft_cap=1.1,
-        implementation="pallas_gpu",
+        implementation="batched_xla",
         block_sizes=block_sizes,
         return_argmax=True,
     )
@@ -804,7 +820,7 @@ def test_fused_cross_entropy_pallas_gpu_return_argmax_matches_reference():
     assert jnp.array_equal(argmax, argmax_ref)
 
 
-def test_fused_cross_entropy_pallas_gpu_requires_gpu():
+def test_fused_cross_entropy_batched_xla_requires_gpu():
     if jax.default_backend() == "gpu":
         pytest.skip("requires non-GPU backend")
 
@@ -812,19 +828,19 @@ def test_fused_cross_entropy_pallas_gpu_requires_gpu():
     w = jnp.zeros((128, 128), dtype=jnp.float32)
     y = jnp.zeros((128,), dtype=jnp.int32)
 
-    with pytest.raises(pallas_gpu.PallasUnsupportedError):
+    with pytest.raises(batched_xla.BatchedXlaUnsupportedError):
         fused_api.fused_cross_entropy_loss_and_logsumexp_penalty(
             x,
             y,
             w,
             reduction=None,
-            implementation="pallas_gpu",
+            implementation="batched_xla",
         )
 
 
-def test_pallas_gpu_full_vocab_b_tiled_forward_matches_reference():
+def test_batched_xla_full_vocab_b_tiled_forward_matches_reference():
     if jax.default_backend() == "tpu":
-        pytest.skip("pallas_gpu full-vocab B-tiled helper is covered by CPU/GPU precision paths")
+        pytest.skip("batched_xla full-vocab B-tiled helper is covered by CPU/GPU precision paths")
 
     key = jax.random.PRNGKey(41)
     key_x, key_w, key_y = jax.random.split(key, 3)
@@ -839,7 +855,7 @@ def test_pallas_gpu_full_vocab_b_tiled_forward_matches_reference():
         dtype=jnp.float32,
         logit_soft_cap=1.7,
     )
-    actual_loss, actual_lse = pallas_gpu._linear_softmax_cross_entropy_loss_full_vocab_b_tiled(
+    actual_loss, actual_lse = batched_xla._linear_softmax_cross_entropy_loss_full_vocab_b_tiled(
         x,
         y,
         w,
@@ -853,9 +869,9 @@ def test_pallas_gpu_full_vocab_b_tiled_forward_matches_reference():
     np.testing.assert_allclose(actual_lse, expected_lse, rtol=1e-5, atol=1e-5)
 
 
-def test_pallas_gpu_backward_b_tiled_from_lse_matches_reference_gradients():
+def test_batched_xla_backward_b_tiled_from_lse_matches_reference_gradients():
     if jax.default_backend() == "tpu":
-        pytest.skip("pallas_gpu custom backward helper is covered by CPU/GPU precision paths")
+        pytest.skip("batched_xla custom backward helper is covered by CPU/GPU precision paths")
 
     key = jax.random.PRNGKey(43)
     key_x, key_w, key_y, key_loss, key_lse = jax.random.split(key, 5)
@@ -878,7 +894,7 @@ def test_pallas_gpu_backward_b_tiled_from_lse_matches_reference_gradients():
         return jnp.sum(loss * g_loss + logsumexp * g_lse)
 
     expected_x, expected_w = jax.grad(reference_cotangent_loss, argnums=(0, 1))(x, w)
-    actual_x, actual_w = pallas_gpu._backward_b_tiled_from_lse(
+    actual_x, actual_w = batched_xla._backward_b_tiled_from_lse(
         x,
         y,
         w,
@@ -894,33 +910,33 @@ def test_pallas_gpu_backward_b_tiled_from_lse_matches_reference_gradients():
     np.testing.assert_allclose(actual_w, expected_w, rtol=1e-5, atol=1e-5)
 
 
-def test_pallas_gpu_h100_full_vocab_policy_selects_b_tiled_path(monkeypatch: pytest.MonkeyPatch):
+def test_batched_xla_h100_full_vocab_policy_selects_b_tiled_path(monkeypatch: pytest.MonkeyPatch):
     x = jax.ShapeDtypeStruct((8192, 16), jnp.bfloat16)
     w = jax.ShapeDtypeStruct((16, 65536), jnp.bfloat16)
 
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
-    assert pallas_gpu._h100_full_vocab_b_tiled_block_size(x, w) == 8192
-    assert pallas_gpu._h100_full_vocab_b_tiled_block_size(x, w, return_argmax=True) is None
+    monkeypatch.setattr(batched_xla, "_device_kind", lambda: "nvidia h100")
+    assert batched_xla._h100_full_vocab_b_tiled_block_size(x, w) == 8192
+    assert batched_xla._h100_full_vocab_b_tiled_block_size(x, w, return_argmax=True) is None
     assert (
-        pallas_gpu._h100_full_vocab_b_tiled_block_size(
+        batched_xla._h100_full_vocab_b_tiled_block_size(
             jax.ShapeDtypeStruct((8191, 16), jnp.bfloat16),
             w,
         )
         is None
     )
     assert (
-        pallas_gpu._h100_full_vocab_b_tiled_block_size(
+        batched_xla._h100_full_vocab_b_tiled_block_size(
             x,
             jax.ShapeDtypeStruct((16, 65535), jnp.bfloat16),
         )
         is None
     )
 
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia gb10")
-    assert pallas_gpu._h100_full_vocab_b_tiled_block_size(x, w) is None
+    monkeypatch.setattr(batched_xla, "_device_kind", lambda: "nvidia gb10")
+    assert batched_xla._h100_full_vocab_b_tiled_block_size(x, w) is None
 
 
-def test_fused_cross_entropy_pallas_gpu_custom_backward_grad_matches_xla():
+def test_fused_cross_entropy_batched_xla_custom_backward_grad_matches_xla():
     if jax.default_backend() != "gpu":
         pytest.skip("requires GPU backend")
     device_kind = jax.devices()[0].device_kind.lower()
@@ -934,10 +950,10 @@ def test_fused_cross_entropy_pallas_gpu_custom_backward_grad_matches_xla():
     w = jax.random.normal(key_w, (hidden, vocab), dtype=jnp.bfloat16)
     y = jax.random.randint(key_y, (batch,), 0, vocab, dtype=jnp.int32)
 
-    # Match the v-block used by GB10 pallas_gpu forward fallback for B>=1024, V>=65536.
+    # Match the v-block used by GB10 batched_xla forward fallback for B>=1024, V>=65536.
     xla_block_sizes = fused_api.BlockSizes(v_block_size=2048)
 
-    def loss_pallas(x_raw: jax.Array, w_raw: jax.Array) -> jax.Array:
+    def loss_batched_xla(x_raw: jax.Array, w_raw: jax.Array) -> jax.Array:
         return fused_api.fused_cross_entropy_loss_and_logsumexp_penalty(
             x_raw,
             y,
@@ -945,7 +961,7 @@ def test_fused_cross_entropy_pallas_gpu_custom_backward_grad_matches_xla():
             reduction="mean",
             logsumexp_weight=0.2,
             dtype=jnp.float32,
-            implementation="pallas_gpu",
+            implementation="batched_xla",
         )
 
     def loss_xla(x_raw: jax.Array, w_raw: jax.Array) -> jax.Array:
@@ -960,22 +976,22 @@ def test_fused_cross_entropy_pallas_gpu_custom_backward_grad_matches_xla():
             implementation="xla",
         )
 
-    gx_pallas, gw_pallas = jax.grad(loss_pallas, argnums=(0, 1))(x, w)
+    gx_batched_xla, gw_batched_xla = jax.grad(loss_batched_xla, argnums=(0, 1))(x, w)
     gx_xla, gw_xla = jax.grad(loss_xla, argnums=(0, 1))(x, w)
 
-    gx_max_abs = jnp.max(jnp.abs(gx_pallas.astype(jnp.float32) - gx_xla.astype(jnp.float32)))
-    gw_max_abs = jnp.max(jnp.abs(gw_pallas.astype(jnp.float32) - gw_xla.astype(jnp.float32)))
+    gx_max_abs = jnp.max(jnp.abs(gx_batched_xla.astype(jnp.float32) - gx_xla.astype(jnp.float32)))
+    gw_max_abs = jnp.max(jnp.abs(gw_batched_xla.astype(jnp.float32) - gw_xla.astype(jnp.float32)))
     assert gx_max_abs <= 5e-3
     assert gw_max_abs <= 5e-3
 
 
-def test_fused_cross_entropy_pallas_gpu_grad_tracing_non_gb10_path(
+def test_fused_cross_entropy_batched_xla_grad_tracing_non_gb10_path(
     monkeypatch: pytest.MonkeyPatch,
 ):
     if jax.default_backend() != "gpu":
         pytest.skip("requires GPU backend")
 
-    monkeypatch.setattr(pallas_gpu, "_device_kind", lambda: "nvidia h100")
+    monkeypatch.setattr(batched_xla, "_device_kind", lambda: "nvidia h100")
 
     batch, hidden, vocab = 13, 19, 37
     key = jax.random.PRNGKey(31)
@@ -986,7 +1002,7 @@ def test_fused_cross_entropy_pallas_gpu_grad_tracing_non_gb10_path(
     block_sizes = fused_api.BlockSizes(b_block_size=128, h_block_size=16, v_block_size=16)
 
     def loss_fn(x_raw: jax.Array, w_raw: jax.Array) -> jax.Array:
-        loss, _ = pallas_gpu.linear_softmax_cross_entropy_loss_pallas_gpu(
+        loss, _ = batched_xla.linear_softmax_cross_entropy_loss_batched_xla(
             x_raw,
             y,
             w_raw,


### PR DESCRIPTION
Route H100 BF16 large-vocab fused cross entropy through a full-vocab batch-tiled path with an 8192-row tile. This keeps the fast full-vocab GEMM structure while bounding peak logits memory for B=32768, V=128256 cases.

The custom VJP carries the selected batch tile in a named residual and uses saved logsumexp for the matching B-tiled backward. Existing BlockSizes continue to describe the vocab-streaming Pallas tile; the 8192 value is a hardware/shape policy for this separate full-vocab GEMM path.

Focused parity tests cover the B-tiled forward, the saved-LSE B-tiled backward, and the H100 large-vocab policy boundary.

Follow-up: #6596 tracks H100 B-tile timing numbers and the remaining backward-performance gap.
