### PR TITLE
[ops] Add Together backend scaffold to cost_manager

### DIFF
--- a/scripts/cost_manager/README.md
+++ b/scripts/cost_manager/README.md
@@ -16,7 +16,7 @@ every line item into a `CostEvent`, and appends the rows to the finelog
 CostEvent:
   ts            UTC midnight of the usage day (finelog ordering timestamp)
   usage_date    "YYYY-MM-DD" UTC usage day
-  provider      openai | anthropic | gcp | coreweave
+  provider      openai | anthropic | gcp | coreweave | together
   category      provider-natural grouping (api / a GCP service / compute / storage / ...)
   detail        finer grain: model, line item, SKU, region, instance type
   cost          amount in `currency`
@@ -84,6 +84,7 @@ Secrets are passed via the environment only — `config.yaml` holds the env-var
 | **anthropic** | Admin Cost Report `GET /v1/organizations/cost_report` | `ANTHROPIC_ADMIN_KEY` | Works. Needs an **Admin key** (`sk-ant-admin01-…`). Amounts arrive in cents → converted to USD. |
 | **gcp** | BigQuery billing export (`bq query`) | none (ADC / runner SA) | Disabled by default. The Cloud Billing API exposes no actual spend; detailed cost lives only in the BigQuery export. Enable once `billing_export_table` points at an export dataset the runner's service account can read. |
 | **coreweave** | Prometheus usage API (`observe.coreweave.com`) × rate card | `COREWEAVE_API_TOKEN` | Disabled by default, **estimate only**. CoreWeave has no dollar API; cost is `usage × rate_card` and tagged `amount_kind=estimated`. Fill in real `unit_rate`s and a token with the Observability Viewer role. |
+| **together** | none yet | `TOGETHER_API_KEY` (when available) | Disabled by default, **scaffold only**. Together has no programmatic cost API: spend lives only in the cookie-authenticated billing dashboard (Usage / draft invoice), and the API key is inference-only. `fetch` raises until Together ships a usage/cost endpoint; enabling it before then fails loudly. |
 
 Adding a provider: drop a `fetch(config, window) -> list[CostEvent]` module in
 `backends/`, register it in `backends/__init__.py`, and add a block to

--- a/scripts/cost_manager/backends/__init__.py
+++ b/scripts/cost_manager/backends/__init__.py
@@ -12,7 +12,7 @@ to :data:`BACKENDS`.
 from collections.abc import Callable, Mapping
 from typing import Any
 
-from scripts.cost_manager.backends import anthropic, coreweave, gcp, openai
+from scripts.cost_manager.backends import anthropic, coreweave, gcp, openai, together
 from scripts.cost_manager.cost_event import CostEvent, DateWindow
 
 ProviderFetcher = Callable[[Mapping[str, Any], DateWindow], list[CostEvent]]
@@ -22,4 +22,5 @@ BACKENDS: dict[str, ProviderFetcher] = {
     "anthropic": anthropic.fetch,
     "gcp": gcp.fetch,
     "coreweave": coreweave.fetch,
+    "together": together.fetch,
 }

--- a/scripts/cost_manager/backends/together.py
+++ b/scripts/cost_manager/backends/together.py
@@ -1,0 +1,35 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Together AI costs — scaffold pending a programmatic cost API.
+
+Together bills per token for inference (plus dedicated endpoints, storage, and
+fine-tuning), but exposes spend **only** through the cookie-authenticated web
+dashboard (Billing -> Usage, including the "Current Usage" draft invoice). The
+``TOGETHER_API_KEY`` bearer token reaches the inference surface (``/v1/models``,
+``/v1/endpoints``, ...) and nothing under billing/usage, so there is no endpoint
+for the runner to pull dollar cost from.
+
+This backend is therefore a disabled-by-default scaffold: it is registered and
+carried in ``config.yaml`` so the provider slots in the moment Together ships a
+usage/cost API, but until then ``fetch`` raises :class:`CostFetchError` rather
+than guess at a schema.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Mapping
+from typing import Any
+
+from scripts.cost_manager.cost_event import CostEvent, CostFetchError, DateWindow
+
+PROVIDER = "together"
+
+
+def fetch(config: Mapping[str, Any], window: DateWindow) -> list[CostEvent]:
+    raise CostFetchError(
+        "together: no programmatic cost API. Spend is reachable only via the "
+        "cookie-authenticated billing dashboard, not the TOGETHER_API_KEY bearer "
+        "surface, so there is nothing to pull. Keep this provider disabled until "
+        "Together ships a usage/cost endpoint."
+    )

--- a/scripts/cost_manager/config.yaml
+++ b/scripts/cost_manager/config.yaml
@@ -65,6 +65,15 @@ providers:
     location: US
     billing_export_table: "hai-gcp-models.billing_export.gcp_billing_export_v1_XXXXXX_XXXXXX_XXXXXX"
 
+  # Together AI inference spend. Disabled: Together has no programmatic cost API
+  # — spend is reachable only through the cookie-authenticated billing dashboard,
+  # and the TOGETHER_API_KEY bearer surface is inference-only, so there is nothing
+  # for the runner to pull. Wired in (and naming its intended secret) so it
+  # activates the moment Together ships a usage/cost endpoint.
+  - name: together
+    enabled: false
+    api_key_env: TOGETHER_API_KEY
+
   # CoreWeave costs. CoreWeave has NO dollar-denominated API, so this estimates
   # cost from Prometheus usage metrics times a rate card (rows are tagged
   # amount_kind=estimated). Disabled until a real rate card is filled in.


### PR DESCRIPTION
Wire a `together` provider into cost_manager so the slot exists when Together ships a usage/cost API.

Issue #6581 assumed Together exposes spend via a billing/usage API keyed by `TOGETHER_API_KEY`. That is not the case today: the bearer token reaches only the inference surface (`/v1/models`, `/v1/endpoints` → 401), and every billing/usage path (`/v1/usage`, `/v1/billing`, `/v1/organization/costs`, `/api/usage`, …) returns 404. Together's own docs confirm cost analytics — the Usage view and the "Current Usage" draft invoice — live only in the cookie-authenticated web dashboard, with no documented programmatic endpoint.

Rather than guess at an undocumented, cookie-only schema, this adds a disabled-by-default scaffold mirroring the `gcp` and `coreweave` placeholders: a `together` backend registered in `BACKENDS` and carried in `config.yaml` (enabled: false), plus a README row. Its `fetch()` raises a clear `CostFetchError` documenting the gap, so enabling the provider before an API exists fails loudly instead of silently recording zero spend. The slot activates with a real puller the moment Together ships a usage/cost endpoint.

Part of #6581