### PR TITLE
[iris] Show Kueue status for gated pods

### DIFF
--- a/lib/iris/dashboard/src/components/controller/KubernetesClusterTab.vue
+++ b/lib/iris/dashboard/src/components/controller/KubernetesClusterTab.vue
@@ -327,17 +327,14 @@ function nodeDisplayClass(nodeName?: string, phase?: string): string {
                   pod.phase === 'Failed' ? 'bg-status-danger-bg/30' : '',
                 ]"
               >
-                <!-- Pod name -->
                 <td class="px-3 pt-2 pb-1 text-[13px] font-mono text-text-secondary truncate" :title="pod.podName">
                   {{ pod.podName }}
                 </td>
 
-                <!-- Task ID -->
                 <td class="px-3 pt-2 pb-1 text-[13px] font-mono text-text-secondary truncate" :title="pod.taskId">
                   {{ pod.taskId || '-' }}
                 </td>
 
-                <!-- Phase with dot -->
                 <td class="px-3 pt-2 pb-1 text-[13px]">
                   <span class="inline-flex items-center gap-1.5">
                     <span :class="['w-1.5 h-1.5 rounded-full flex-shrink-0', phaseDotClass(pod.phase)]" />
@@ -345,19 +342,16 @@ function nodeDisplayClass(nodeName?: string, phase?: string): string {
                   </span>
                 </td>
 
-                <!-- Node -->
                 <td class="px-3 pt-2 pb-1 text-[13px] font-mono truncate" :title="pod.nodeName || undefined">
                   <span :class="nodeDisplayClass(pod.nodeName, pod.phase)">
                     {{ nodeDisplayName(pod.nodeName, pod.phase) }}
                   </span>
                 </td>
 
-                <!-- Reason -->
                 <td class="px-3 pt-2 pb-1 text-[13px] text-text-secondary truncate" :title="pod.reason || undefined">
                   {{ pod.reason || '-' }}
                 </td>
 
-                <!-- Age -->
                 <td class="px-3 pt-2 pb-1 text-[13px] text-text-muted font-mono whitespace-nowrap">
                   {{ formatTransition(pod.lastTransition) }}
                 </td>

--- a/lib/iris/dashboard/src/components/controller/KubernetesClusterTab.vue
+++ b/lib/iris/dashboard/src/components/controller/KubernetesClusterTab.vue
@@ -304,67 +304,82 @@ function nodeDisplayClass(nodeName?: string, phase?: string): string {
       <EmptyState v-if="pods.length === 0" message="No iris-managed pods found." />
 
       <div v-else class="overflow-x-auto rounded-lg border border-surface-border">
-        <table class="w-full border-collapse">
+        <table class="w-full border-collapse lg:table-fixed">
           <thead>
             <tr class="border-b border-surface-border bg-surface">
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Pod</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Task ID</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left w-24">Phase</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Node</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Reason</th>
-              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left">Message</th>
+              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left lg:w-[22%]">Pod</th>
+              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left lg:w-[20%]">Task ID</th>
+              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left w-24 lg:w-[8%]">Phase</th>
+              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left lg:w-[16%]">Node</th>
+              <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left lg:w-[24%]">Reason</th>
               <th class="px-3 py-2 text-xs font-semibold uppercase tracking-wider text-text-secondary text-left w-24">Age</th>
             </tr>
           </thead>
           <tbody>
-            <tr
+            <template
               v-for="pod in pods"
               :key="pod.podName"
-              :class="[
-                'border-b border-surface-border-subtle hover:bg-surface-raised transition-colors',
-                pod.phase === 'Failed' ? 'bg-status-danger-bg/30' : '',
-              ]"
             >
-              <!-- Pod name -->
-              <td class="px-3 py-2 text-[13px] font-mono text-text-secondary truncate max-w-[200px]" :title="pod.podName">
-                {{ pod.podName }}
-              </td>
+              <tr
+                :class="[
+                  pod.message ? '' : 'border-b border-surface-border-subtle',
+                  'hover:bg-surface-raised transition-colors',
+                  pod.phase === 'Failed' ? 'bg-status-danger-bg/30' : '',
+                ]"
+              >
+                <!-- Pod name -->
+                <td class="px-3 pt-2 pb-1 text-[13px] font-mono text-text-secondary truncate" :title="pod.podName">
+                  {{ pod.podName }}
+                </td>
 
-              <!-- Task ID -->
-              <td class="px-3 py-2 text-[13px] font-mono text-text-secondary truncate max-w-[200px]" :title="pod.taskId">
-                {{ pod.taskId || '-' }}
-              </td>
+                <!-- Task ID -->
+                <td class="px-3 pt-2 pb-1 text-[13px] font-mono text-text-secondary truncate" :title="pod.taskId">
+                  {{ pod.taskId || '-' }}
+                </td>
 
-              <!-- Phase with dot -->
-              <td class="px-3 py-2 text-[13px]">
-                <span class="inline-flex items-center gap-1.5">
-                  <span :class="['w-1.5 h-1.5 rounded-full flex-shrink-0', phaseDotClass(pod.phase)]" />
-                  <span :class="['font-semibold', phaseClass(pod.phase)]">{{ pod.phase }}</span>
-                </span>
-              </td>
+                <!-- Phase with dot -->
+                <td class="px-3 pt-2 pb-1 text-[13px]">
+                  <span class="inline-flex items-center gap-1.5">
+                    <span :class="['w-1.5 h-1.5 rounded-full flex-shrink-0', phaseDotClass(pod.phase)]" />
+                    <span :class="['font-semibold', phaseClass(pod.phase)]">{{ pod.phase }}</span>
+                  </span>
+                </td>
 
-              <!-- Node -->
-              <td class="px-3 py-2 text-[13px] font-mono truncate max-w-[180px]" :title="pod.nodeName || undefined">
-                <span :class="nodeDisplayClass(pod.nodeName, pod.phase)">
-                  {{ nodeDisplayName(pod.nodeName, pod.phase) }}
-                </span>
-              </td>
+                <!-- Node -->
+                <td class="px-3 pt-2 pb-1 text-[13px] font-mono truncate" :title="pod.nodeName || undefined">
+                  <span :class="nodeDisplayClass(pod.nodeName, pod.phase)">
+                    {{ nodeDisplayName(pod.nodeName, pod.phase) }}
+                  </span>
+                </td>
 
-              <!-- Reason -->
-              <td class="px-3 py-2 text-[13px] text-text-secondary">
-                {{ pod.reason || '-' }}
-              </td>
+                <!-- Reason -->
+                <td class="px-3 pt-2 pb-1 text-[13px] text-text-secondary truncate" :title="pod.reason || undefined">
+                  {{ pod.reason || '-' }}
+                </td>
 
-              <!-- Message -->
-              <td class="px-3 py-2 text-[13px] text-text-secondary truncate max-w-[250px]" :title="pod.message || undefined">
-                {{ pod.message || '-' }}
-              </td>
+                <!-- Age -->
+                <td class="px-3 pt-2 pb-1 text-[13px] text-text-muted font-mono whitespace-nowrap">
+                  {{ formatTransition(pod.lastTransition) }}
+                </td>
+              </tr>
 
-              <!-- Age -->
-              <td class="px-3 py-2 text-[13px] text-text-muted font-mono">
-                {{ formatTransition(pod.lastTransition) }}
-              </td>
-            </tr>
+              <tr
+                v-if="pod.message"
+                :class="[
+                  'border-b border-surface-border-subtle',
+                  pod.phase === 'Failed' ? 'bg-status-danger-bg/30' : '',
+                ]"
+              >
+                <td colspan="6" class="px-3 pb-2 pt-0">
+                  <div class="pl-0 lg:pl-[42%]">
+                    <div class="rounded bg-surface-sunken px-2 py-1.5 text-[12px] leading-relaxed text-text-secondary">
+                      <span class="mr-2 font-semibold uppercase tracking-wider text-text-muted">Diagnostic</span>
+                      <span class="font-mono whitespace-pre-wrap break-words">{{ pod.message }}</span>
+                    </div>
+                  </div>
+                </td>
+              </tr>
+            </template>
           </tbody>
         </table>
       </div>

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -867,9 +867,73 @@ def _is_preemptible_blocker(pod: dict) -> bool:
     return _pod_gpu_request(pod) > 0
 
 
-def _build_pod_statuses(pods: list[dict]) -> list[controller_pb2.Controller.KubernetesPodStatus]:
+def _kueue_workloads_by_name(workloads: list[dict]) -> dict[str, dict]:
+    """Index Kueue Workloads by metadata.name."""
+    result = {}
+    for workload in workloads:
+        name = workload.get("metadata", {}).get("name", "")
+        if name:
+            result[name] = workload
+    return result
+
+
+def _format_kueue_condition(cond: dict) -> str:
+    """Render one Kueue Workload condition as a compact diagnostic."""
+    condition_type = cond.get("type", "Condition")
+    status = cond.get("status", "")
+    reason = cond.get("reason", "")
+    message = cond.get("message", "")
+
+    prefix = condition_type
+    if status and status != "False":
+        prefix = f"{prefix}={status}"
+    if reason:
+        prefix = f"{prefix} ({reason})"
+    return f"{prefix}: {message}" if message else prefix
+
+
+def _format_kueue_workload_status(pod: dict, workload: dict | None) -> str:
+    """Return Kueue admission context for a gated pod."""
+    pod_group = pod.get("metadata", {}).get("labels", {}).get(_KUEUE_POD_GROUP_NAME, "")
+    if workload is None:
+        return f"Kueue workload {pod_group!r} not found yet; waiting for Kueue to create/admit the pod group"
+
+    spec = workload.get("spec", {})
+    status = workload.get("status", {})
+    details = []
+
+    cluster_queue = status.get("admission", {}).get("clusterQueue", "")
+    queue_name = spec.get("queueName", "")
+    if queue_name and cluster_queue:
+        details.append(f"queue={queue_name}, clusterQueue={cluster_queue}")
+    elif queue_name:
+        details.append(f"queue={queue_name}")
+    elif cluster_queue:
+        details.append(f"clusterQueue={cluster_queue}")
+
+    conditions = status.get("conditions", [])
+    waiting_conditions = [
+        _format_kueue_condition(cond)
+        for cond in conditions
+        if cond.get("status") != "True" and (cond.get("reason") or cond.get("message"))
+    ]
+    if waiting_conditions:
+        details.extend(waiting_conditions)
+    elif status.get("admission"):
+        details.append("admitted by Kueue; waiting for scheduler gate removal")
+    else:
+        details.append("waiting for Kueue admission")
+
+    workload_name = workload.get("metadata", {}).get("name", pod_group)
+    return f"Kueue workload {workload_name}: " + "; ".join(details)
+
+
+def _build_pod_statuses(
+    pods: list[dict], workloads: list[dict] | None = None
+) -> list[controller_pb2.Controller.KubernetesPodStatus]:
     """Build pod status protos from raw kubectl pod objects."""
     statuses = []
+    workloads_by_name = _kueue_workloads_by_name(workloads or [])
     for pod in pods:
         meta = pod.get("metadata", {})
         pod_name = meta.get("name", "")
@@ -903,6 +967,10 @@ def _build_pod_statuses(pods: list[dict]) -> list[controller_pb2.Controller.Kube
                         except (ValueError, AttributeError):
                             pass
                     break
+        if reason == "SchedulingGated" and labels.get(_KUEUE_POD_GROUP_NAME):
+            pod_group = labels[_KUEUE_POD_GROUP_NAME]
+            kueue_status = _format_kueue_workload_status(pod, workloads_by_name.get(pod_group))
+            message = f"{message}; {kueue_status}" if message else kueue_status
 
         ps = controller_pb2.Controller.KubernetesPodStatus(
             pod_name=pod_name,
@@ -972,20 +1040,24 @@ class ClusterState:
         self._lock = threading.Lock()
         self._pods: list[dict] = []
         self._nodes: list[dict] = []
+        self._workloads: list[dict] = []
         self._node_pools: list[controller_pb2.Controller.NodePoolStatus] = []
 
     def update(
         self,
         pods: list[dict],
         nodes: list[dict],
+        workloads: list[dict],
         node_pools: list[controller_pb2.Controller.NodePoolStatus],
     ) -> None:
         """Atomically replace all cluster state from a completed sync cycle."""
         new_pods = sorted(pods, key=lambda p: p.get("metadata", {}).get("name", ""))
         new_nodes = sorted(nodes, key=lambda n: n.get("metadata", {}).get("name", ""))
+        new_workloads = sorted(workloads, key=lambda w: w.get("metadata", {}).get("name", ""))
         with self._lock:
             self._pods = new_pods
             self._nodes = new_nodes
+            self._workloads = new_workloads
             self._node_pools = list(node_pools)
 
     def to_status_response(self, namespace: str) -> controller_pb2.Controller.GetKubernetesClusterStatusResponse:
@@ -993,6 +1065,7 @@ class ClusterState:
         with self._lock:
             pods = self._pods[:]
             nodes = self._nodes[:]
+            workloads = self._workloads[:]
             node_pools = self._node_pools[:]
 
         total_nodes = len(nodes)
@@ -1019,7 +1092,7 @@ class ClusterState:
             schedulable_nodes=schedulable_nodes,
             allocatable_cpu=f"{total_cpu_mc / 1000:.1f} cores" if total_cpu_mc else "0 cores",
             allocatable_memory=_format_bytes(total_memory_bytes),
-            pod_statuses=_build_pod_statuses(pods),
+            pod_statuses=_build_pod_statuses(pods, workloads),
             provider_version="iris-kubernetes/v1",
             node_pools=node_pools,
         )
@@ -1439,8 +1512,17 @@ class K8sTaskProvider:
             logger.warning("Failed to query node resources: %s", e)
             nodes = []
 
+        if self.local_queue:
+            try:
+                workloads = self.kubectl.list_json(K8sResource.WORKLOADS)
+            except Exception as e:
+                logger.warning("Failed to query Kueue workloads: %s", e)
+                workloads = []
+        else:
+            workloads = []
+
         node_pools = _fetch_node_pools(self.kubectl, self.managed_label)
-        self._cluster_state.update(managed_pods, nodes, node_pools)
+        self._cluster_state.update(managed_pods, nodes, workloads, node_pools)
 
         self._maybe_gc_terminal_resources(managed_pods)
 

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -868,7 +868,6 @@ def _is_preemptible_blocker(pod: dict) -> bool:
 
 
 def _kueue_workloads_by_name(workloads: list[dict]) -> dict[str, dict]:
-    """Index Kueue Workloads by metadata.name."""
     result = {}
     for workload in workloads:
         name = workload.get("metadata", {}).get("name", "")

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -1542,7 +1542,8 @@ def test_k8s_cluster_status_returns_nodes_and_pods(state, scheduler, tmp_path, l
 def test_k8s_cluster_status_enriches_scheduling_gated_pods_with_kueue_workload(state, scheduler, tmp_path, log_client):
     """SchedulingGated pod statuses include Kueue admission diagnostics."""
     client, k8s, provider = _make_k8s_dashboard_client(state, scheduler, tmp_path, log_client)
-    provider.local_queue = "iris-local"
+    queue_name = "iris-local"
+    provider.local_queue = queue_name
     pod_group = "iris-pg-test-0"
 
     k8s.seed_resource(
@@ -1556,7 +1557,7 @@ def test_k8s_cluster_status_enriches_scheduling_gated_pods_with_kueue_workload(s
                     _LABEL_MANAGED: "true",
                     _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE,
                     _KUEUE_POD_GROUP_NAME: pod_group,
-                    _KUEUE_QUEUE_NAME: "iris-local",
+                    _KUEUE_QUEUE_NAME: queue_name,
                     "iris.task_id": "job.0",
                 },
             },
@@ -1580,7 +1581,7 @@ def test_k8s_cluster_status_enriches_scheduling_gated_pods_with_kueue_workload(s
         {
             "kind": "Workload",
             "metadata": {"name": pod_group},
-            "spec": {"queueName": "iris-local"},
+            "spec": {"queueName": queue_name},
             "status": {
                 "conditions": [
                     {
@@ -1608,7 +1609,7 @@ def test_k8s_cluster_status_enriches_scheduling_gated_pods_with_kueue_workload(s
     status = resp.json()["podStatuses"][0]
     assert status["reason"] == "SchedulingGated"
     assert "Kueue workload iris-pg-test-0" in status["message"]
-    assert "queue=iris-local" in status["message"]
+    assert f"queue={queue_name}" in status["message"]
     assert "insufficient unused quota for nvidia.com/gpu" in status["message"]
 
     provider.close()

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -11,7 +11,14 @@ from unittest.mock import Mock
 
 import pytest
 from iris.cluster.backends.k8s.fake import InMemoryK8sService
-from iris.cluster.backends.k8s.tasks import _LABEL_MANAGED, _LABEL_RUNTIME, _RUNTIME_LABEL_VALUE, K8sTaskProvider
+from iris.cluster.backends.k8s.tasks import (
+    _KUEUE_POD_GROUP_NAME,
+    _KUEUE_QUEUE_NAME,
+    _LABEL_MANAGED,
+    _LABEL_RUNTIME,
+    _RUNTIME_LABEL_VALUE,
+    K8sTaskProvider,
+)
 from iris.cluster.backends.k8s.types import K8sResource
 from iris.cluster.bundle import BundleStore
 from iris.cluster.constraints import WellKnownAttribute
@@ -1528,6 +1535,81 @@ def test_k8s_cluster_status_returns_nodes_and_pods(state, scheduler, tmp_path, l
     assert len(data["podStatuses"]) == 1
     assert data["podStatuses"][0]["podName"] == "iris-task-0"
     assert data["podStatuses"][0]["phase"] == "Running"
+
+    provider.close()
+
+
+def test_k8s_cluster_status_enriches_scheduling_gated_pods_with_kueue_workload(state, scheduler, tmp_path, log_client):
+    """SchedulingGated pod statuses include Kueue admission diagnostics."""
+    client, k8s, provider = _make_k8s_dashboard_client(state, scheduler, tmp_path, log_client)
+    provider.local_queue = "iris-local"
+    pod_group = "iris-pg-test-0"
+
+    k8s.seed_resource(
+        K8sResource.PODS,
+        "iris-task-0",
+        {
+            "kind": "Pod",
+            "metadata": {
+                "name": "iris-task-0",
+                "labels": {
+                    _LABEL_MANAGED: "true",
+                    _LABEL_RUNTIME: _RUNTIME_LABEL_VALUE,
+                    _KUEUE_POD_GROUP_NAME: pod_group,
+                    _KUEUE_QUEUE_NAME: "iris-local",
+                    "iris.task_id": "job.0",
+                },
+            },
+            "spec": {"schedulingGates": [{"name": "kueue.x-k8s.io/admission"}]},
+            "status": {
+                "phase": "Pending",
+                "conditions": [
+                    {
+                        "type": "PodScheduled",
+                        "status": "False",
+                        "reason": "SchedulingGated",
+                        "message": "Scheduling is blocked due to non-empty scheduling gates",
+                    }
+                ],
+            },
+        },
+    )
+    k8s.seed_resource(
+        K8sResource.WORKLOADS,
+        pod_group,
+        {
+            "kind": "Workload",
+            "metadata": {"name": pod_group},
+            "spec": {"queueName": "iris-local"},
+            "status": {
+                "conditions": [
+                    {
+                        "type": "QuotaReserved",
+                        "status": "False",
+                        "reason": "Pending",
+                        "message": (
+                            "couldn't assign flavors to pod set main: insufficient unused quota for nvidia.com/gpu"
+                        ),
+                    }
+                ]
+            },
+        },
+    )
+
+    provider.reconcile(ControlSnapshot(worker_addresses={}, reconcile_rows=[], timeout_rows=[]))
+
+    resp = client.post(
+        "/iris.cluster.ControllerService/GetKubernetesClusterStatus",
+        json={},
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert resp.status_code == 200
+    status = resp.json()["podStatuses"][0]
+    assert status["reason"] == "SchedulingGated"
+    assert "Kueue workload iris-pg-test-0" in status["message"]
+    assert "queue=iris-local" in status["message"]
+    assert "insufficient unused quota for nvidia.com/gpu" in status["message"]
 
     provider.close()
 

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -1545,6 +1545,7 @@ def test_k8s_cluster_status_enriches_scheduling_gated_pods_with_kueue_workload(s
     queue_name = "iris-local"
     provider.local_queue = queue_name
     pod_group = "iris-pg-test-0"
+    workload_message = "gpu-quota-diagnostic-token"
 
     k8s.seed_resource(
         K8sResource.PODS,
@@ -1588,9 +1589,7 @@ def test_k8s_cluster_status_enriches_scheduling_gated_pods_with_kueue_workload(s
                         "type": "QuotaReserved",
                         "status": "False",
                         "reason": "Pending",
-                        "message": (
-                            "couldn't assign flavors to pod set main: insufficient unused quota for nvidia.com/gpu"
-                        ),
+                        "message": workload_message,
                     }
                 ]
             },
@@ -1608,9 +1607,9 @@ def test_k8s_cluster_status_enriches_scheduling_gated_pods_with_kueue_workload(s
     assert resp.status_code == 200
     status = resp.json()["podStatuses"][0]
     assert status["reason"] == "SchedulingGated"
-    assert "Kueue workload iris-pg-test-0" in status["message"]
-    assert f"queue={queue_name}" in status["message"]
-    assert "insufficient unused quota for nvidia.com/gpu" in status["message"]
+    assert pod_group in status["message"]
+    assert queue_name in status["message"]
+    assert workload_message in status["message"]
 
     provider.close()
 


### PR DESCRIPTION
Enrich Kubernetes pod status feedback for Kueue-gated Iris tasks by snapshotting matching Kueue Workloads during the cluster scan and appending their admission state to the existing pod status message.

This gives pending K8s jobs concrete queue, clusterQueue, and Workload condition context instead of only the generic SchedulingGated pod condition.