### PR TITLE
[iris] Persist Kubernetes controller state

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/controller.py
@@ -55,6 +55,8 @@ _KUBECTL_TIMEOUT = 1800.0
 
 _CONTROLLER_CPU_REQUEST = "4"
 _CONTROLLER_MEMORY_REQUEST = "16Gi"
+_CONTROLLER_STATE_PVC_NAME = "iris-controller-state"
+_CONTROLLER_STATE_PVC_SIZE = "50Gi"
 
 
 # S3-compatible endpoints that require virtual-hosted-style addressing where the
@@ -126,19 +128,15 @@ def _build_controller_deployment(
         "requests": {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST},
         "limits": {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST},
     }
-    # `--fresh` wipes the controller's SQLite, so the new pod must NOT overlap
-    # with the OLD one — otherwise a job submitted in the rollout surge window
-    # lands on the OLD controller, then the NEW empty-DB controller deletes
-    # the runner pod as "stray" on its first reconcile (#5590). Setting
-    # `strategy.type: Recreate` here, combined with deleting the existing
-    # Deployment in start_controller (because SSA can't clear the
-    # API-server-defaulted rollingUpdate field), guarantees the old pod is
-    # gone before the new one starts. Non-fresh restarts omit `strategy` so
-    # the API server defaults to RollingUpdate and in-place upgrades stay
-    # zero-downtime.
+    # The controller SQLite DB lives on a PersistentVolumeClaim, so two
+    # controller pods must never mount the same local state dir at once. We
+    # guarantee that by tearing the old Deployment down and waiting for it to
+    # fully disappear before applying the new one (see start_controller); the
+    # Recreate strategy is belt-and-suspenders for any in-place apply path.
     deploy_spec: dict = {
         "replicas": 1,
         "selector": {"matchLabels": {"app": "iris-controller"}},
+        "strategy": {"type": "Recreate"},
         "template": {
             "metadata": {"labels": {"app": "iris-controller"}},
             "spec": {
@@ -195,13 +193,14 @@ def _build_controller_deployment(
                 ],
                 "volumes": [
                     {"name": "config", "configMap": {"name": "iris-cluster-config"}},
-                    {"name": "local-state", "emptyDir": {}},
+                    {
+                        "name": "local-state",
+                        "persistentVolumeClaim": {"claimName": _CONTROLLER_STATE_PVC_NAME},
+                    },
                 ],
             },
         },
     }
-    if fresh:
-        deploy_spec["strategy"] = {"type": "Recreate"}
     return {
         "apiVersion": "apps/v1",
         "kind": "Deployment",
@@ -211,6 +210,23 @@ def _build_controller_deployment(
             "labels": {"app": "iris-controller"},
         },
         "spec": deploy_spec,
+    }
+
+
+def _build_controller_state_pvc(*, namespace: str) -> dict:
+    """Build the PVC that stores the controller SQLite state."""
+    return {
+        "apiVersion": "v1",
+        "kind": "PersistentVolumeClaim",
+        "metadata": {
+            "name": _CONTROLLER_STATE_PVC_NAME,
+            "namespace": namespace,
+            "labels": {"app": "iris-controller"},
+        },
+        "spec": {
+            "accessModes": ["ReadWriteOnce"],
+            "resources": {"requests": {"storage": _CONTROLLER_STATE_PVC_SIZE}},
+        },
     }
 
 
@@ -320,6 +336,8 @@ class K8sControllerProvider:
         self.ensure_nodepools(config)
         self.ensure_kueue_queues(config)
         self.ensure_priority_classes()
+        self._kubectl.apply_json(_build_controller_state_pvc(namespace=self._namespace))
+        logger.info("PersistentVolumeClaim %s applied", _CONTROLLER_STATE_PVC_NAME)
 
         deploy_manifest = _build_controller_deployment(
             namespace=self._namespace,
@@ -329,18 +347,17 @@ class K8sControllerProvider:
             task_env_secret=projects_task_env_secret(config),
             fresh=fresh,
         )
-        if fresh:
-            # SSA preserves the API-server-defaulted spec.strategy.rollingUpdate
-            # field, so an apply that switches type to Recreate fails validation
-            # ("rollingUpdate may not be specified when type is Recreate").
-            # Delete the existing Deployment first and wait for it to be gone
-            # so the apply creates a fresh object with no leftover strategy
-            # fields. This also enforces no-overlap with the OLD controller
-            # pod, avoiding the stray-pod race in #5590.
-            self._delete_controller_deployment_and_wait()
+        # Always stop the old controller before starting the new one. The
+        # SQLite state PVC is ReadWriteOnce and a rolling update could briefly
+        # mount it from two pods on the same node, corrupting the DB. Iris
+        # restarts are fast and clients tolerate a short controller outage, so a
+        # clean stop/start is simpler and safer than any overlap-avoidance hack.
+        # The PVC is intentionally retained across the restart so the new
+        # controller reuses the local DB (a --fresh controller wipes its DB
+        # directory itself after starting).
+        self._delete_controller_deployment_and_wait()
         self._kubectl.apply_json(deploy_manifest)
-        self._kubectl.rollout_restart(K8sResource.DEPLOYMENTS, "iris-controller")
-        logger.info("Controller Deployment iris-controller applied (rollout restarted)")
+        logger.info("Controller Deployment iris-controller applied")
 
         svc_manifest = {
             "apiVersion": "v1",
@@ -397,6 +414,7 @@ class K8sControllerProvider:
         self._kubectl.delete(K8sResource.SERVICES, service_name)
         self._kubectl.delete(K8sResource.PDBS, "iris-controller-pdb")
         self._kubectl.delete(K8sResource.CONFIGMAPS, "iris-cluster-config")
+        self._kubectl.delete(K8sResource.PERSISTENT_VOLUME_CLAIMS, _CONTROLLER_STATE_PVC_NAME)
         if self.uses_s3_storage(config) or config.defaults.inject_env:
             self._kubectl.delete(K8sResource.SECRETS, TASK_ENV_SECRET_NAME)
 

--- a/lib/iris/src/iris/cluster/backends/k8s/types.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/types.py
@@ -32,6 +32,7 @@ class K8sResource(Enum):
     NAMESPACES = ("", "v1", False, "namespaces", "Namespace")
     NODES = ("", "v1", False, "nodes", "Node")
     SERVICE_ACCOUNTS = ("", "v1", True, "serviceaccounts", "ServiceAccount")
+    PERSISTENT_VOLUME_CLAIMS = ("", "v1", True, "persistentvolumeclaims", "PersistentVolumeClaim")
 
     # Apps v1
     DEPLOYMENTS = ("apps", "v1", True, "deployments", "Deployment")

--- a/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
@@ -20,6 +20,8 @@ import pytest
 from iris.cluster.backends.k8s.controller import (
     _CONTROLLER_CPU_REQUEST,
     _CONTROLLER_MEMORY_REQUEST,
+    _CONTROLLER_STATE_PVC_NAME,
+    _CONTROLLER_STATE_PVC_SIZE,
     K8sControllerProvider,
 )
 from iris.cluster.backends.k8s.fake import InMemoryK8sService
@@ -151,6 +153,7 @@ def test_start_controller_creates_all_resources():
     assert address == "iris-controller-svc.iris.svc.cluster.local:10000"
     assert k8s.get_json(K8sResource.CONFIGMAPS, "iris-cluster-config") is not None
     assert k8s.get_json(K8sResource.DEPLOYMENTS, "iris-controller") is not None
+    assert k8s.get_json(K8sResource.PERSISTENT_VOLUME_CLAIMS, _CONTROLLER_STATE_PVC_NAME) is not None
     assert k8s.get_json(K8sResource.SERVICES, "iris-controller-svc") is not None
 
     # S3 storage auth lives in the iris-task-env Secret, not the ConfigMap.
@@ -171,6 +174,20 @@ def test_start_controller_creates_all_resources():
     assert container["envFrom"] == [{"secretRef": {"name": "iris-task-env", "optional": True}}]
     assert container["resources"]["requests"] == {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST}
     assert container["resources"]["limits"] == {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST}
+    # Recreate (not RollingUpdate): the old controller pod must be gone before
+    # the new one mounts the ReadWriteOnce SQLite state PVC.
+    assert deploy_spec["strategy"] == {"type": "Recreate"}
+    assert {"name": "local-state", "mountPath": "/var/cache/iris/controller"} in container["volumeMounts"]
+    assert {
+        "name": "local-state",
+        "persistentVolumeClaim": {"claimName": _CONTROLLER_STATE_PVC_NAME},
+    } in deploy_spec[
+        "template"
+    ]["spec"]["volumes"]
+
+    pvc = k8s.get_json(K8sResource.PERSISTENT_VOLUME_CLAIMS, _CONTROLLER_STATE_PVC_NAME)
+    assert pvc["spec"]["accessModes"] == ["ReadWriteOnce"]
+    assert pvc["spec"]["resources"]["requests"]["storage"] == _CONTROLLER_STATE_PVC_SIZE
 
     t.join(timeout=5)
     provider.shutdown()
@@ -240,6 +257,45 @@ def test_start_controller_reconciles_when_already_available():
     provider.shutdown()
 
 
+def test_start_controller_stops_old_controller_before_reapply():
+    """start_controller tears the old Deployment down before applying the new one.
+
+    The controller SQLite state lives on a ReadWriteOnce PVC, so two controller
+    pods must never run at once. start_controller must delete the existing
+    Deployment (and wait for it to disappear) before re-applying, rather than
+    letting a rolling update briefly run two pods.
+    """
+    provider, k8s = _make_provider()
+    cluster_config = _make_cluster_config()
+
+    events: list[tuple[str, str]] = []
+    real_delete = k8s.delete
+    real_apply = k8s.apply_json
+
+    def recording_delete(resource, name, **kwargs):
+        if resource is K8sResource.DEPLOYMENTS and name == "iris-controller":
+            events.append(("delete", name))
+        return real_delete(resource, name, **kwargs)
+
+    def recording_apply(manifest):
+        if manifest.get("kind") == "Deployment" and manifest["metadata"]["name"] == "iris-controller":
+            events.append(("apply", "iris-controller"))
+        return real_apply(manifest)
+
+    k8s.delete = recording_delete
+    k8s.apply_json = recording_apply
+
+    t = threading.Thread(target=_auto_ready_deployment, args=(k8s, "iris-controller"), daemon=True)
+    t.start()
+
+    provider.start_controller(cluster_config)
+
+    assert events == [("delete", "iris-controller"), ("apply", "iris-controller")]
+
+    t.join(timeout=5)
+    provider.shutdown()
+
+
 def test_stop_controller_deletes_resources():
     """stop_controller deletes Deployment, Service, ConfigMap, S3 secret, and RBAC."""
     provider, k8s = _make_provider()
@@ -250,6 +306,7 @@ def test_stop_controller_deletes_resources():
     _apply_stub(k8s, "Service", "iris-controller-svc")
     _apply_stub(k8s, "ConfigMap", "iris-cluster-config")
     _apply_stub(k8s, "Secret", "iris-task-env")
+    _apply_stub(k8s, "PersistentVolumeClaim", _CONTROLLER_STATE_PVC_NAME)
 
     provider.stop_controller(cluster_config)
 
@@ -257,6 +314,7 @@ def test_stop_controller_deletes_resources():
     assert k8s.get_json(K8sResource.SERVICES, "iris-controller-svc") is None
     assert k8s.get_json(K8sResource.CONFIGMAPS, "iris-cluster-config") is None
     assert k8s.get_json(K8sResource.SECRETS, "iris-task-env") is None
+    assert k8s.get_json(K8sResource.PERSISTENT_VOLUME_CLAIMS, _CONTROLLER_STATE_PVC_NAME) is None
     provider.shutdown()
 
 


### PR DESCRIPTION
Mount the Kubernetes Iris controller local state directory on a retained PersistentVolumeClaim instead of pod-local emptyDir storage. Controller restarts now reuse the local SQLite database when present, avoiding slow remote checkpoint restores and reducing state loss when operators need --skip-checkpoint.

Use a no-surge rollout strategy so only one controller pod can write the SQLite volume at a time. Explicit controller stop still deletes the PVC to avoid leaving an orphaned disk.