### PR TITLE
[iris] Fix dashboard TypeScript 6 build

### DIFF
--- a/lib/iris/dashboard/env.d.ts
+++ b/lib/iris/dashboard/env.d.ts
@@ -1,5 +1,7 @@
 /// <reference types="@rsbuild/core/types" />
 
+declare module '@fontsource-variable/*'
+
 declare module '*.vue' {
   import type { DefineComponent } from 'vue'
   const component: DefineComponent<{}, {}, any>

--- a/lib/iris/dashboard/src/components/controller/FleetTab.vue
+++ b/lib/iris/dashboard/src/components/controller/FleetTab.vue
@@ -1,6 +1,7 @@
 <script setup lang="ts">
 import { ref, computed, watch, onMounted } from 'vue'
 import { RouterLink, useRoute, useRouter } from 'vue-router'
+import type { LocationQueryValue } from 'vue-router'
 import { useControllerRpc } from '@/composables/useRpc'
 import { useAutoRefresh, DEFAULT_REFRESH_MS } from '@/composables/useAutoRefresh'
 import type { ListWorkersResponse, WorkerHealthStatus, WorkerQuery } from '@/types/rpc'
@@ -31,7 +32,7 @@ const SORT_DIRS: SortDir[] = ['asc', 'desc']
 const route = useRoute()
 const router = useRouter()
 
-function queryStr(v: string | string[] | null | undefined): string {
+function queryStr(v: LocationQueryValue | LocationQueryValue[]): string {
   if (Array.isArray(v)) return v[0] ?? ''
   return v ?? ''
 }

--- a/lib/iris/dashboard/src/components/shared/ProfileLink.vue
+++ b/lib/iris/dashboard/src/components/shared/ProfileLink.vue
@@ -126,7 +126,7 @@ async function openLatest() {
     }
     const ext = profileExtension(fetched[0].format)
     const ts = new Date(row.captured_at).toISOString().replace(/T/g, '_').replace(/:/g, '-').replace(/\.\d+Z$/, '')
-    const blob = new Blob([bytes], { type: 'application/octet-stream' })
+    const blob = new Blob([new Uint8Array(bytes)], { type: 'application/octet-stream' })
     const url = URL.createObjectURL(blob)
     const a = document.createElement('a')
     a.href = url

--- a/lib/iris/dashboard/src/composables/useProfileAction.ts
+++ b/lib/iris/dashboard/src/composables/useProfileAction.ts
@@ -41,7 +41,7 @@ function showThreadDump(raw: string, label: string) {
 }
 
 function downloadBytes(bytes: Uint8Array, label: string, ext: string) {
-  const blob = new Blob([bytes], { type: 'application/octet-stream' })
+  const blob = new Blob([new Uint8Array(bytes)], { type: 'application/octet-stream' })
   const url = URL.createObjectURL(blob)
   const a = document.createElement('a')
   a.href = url

--- a/lib/iris/dashboard/src/utils/speedscope.ts
+++ b/lib/iris/dashboard/src/utils/speedscope.ts
@@ -50,7 +50,7 @@ export function openSpeedscopeWindow(): PendingSpeedscope {
   }
   return {
     show(bytes: Uint8Array, title: string) {
-      const url = URL.createObjectURL(new Blob([bytes], { type: 'application/json' }))
+      const url = URL.createObjectURL(new Blob([new Uint8Array(bytes)], { type: 'application/json' }))
       const target = `${SPEEDSCOPE_URL}#profileURL=${encodeURIComponent(url)}&title=${encodeURIComponent(title)}`
       // Navigate the already-open window (path changes from about:blank, so
       // speedscope loads fresh and reads the hash param on mount). Fall back to

--- a/lib/iris/dashboard/tsconfig.json
+++ b/lib/iris/dashboard/tsconfig.json
@@ -13,8 +13,7 @@
     "noEmit": true,
     "paths": {
       "@/*": ["./src/*"]
-    },
-    "baseUrl": "."
+    }
   },
   "include": ["src/**/*.ts", "src/**/*.vue", "env.d.ts"]
 }


### PR DESCRIPTION
Remove the deprecated TypeScript baseUrl setting from the Iris dashboard config while preserving the @/* path alias.

Tighten the dashboard's TypeScript 6 compatibility so build:check succeeds: router query parsing now accepts vue-router's nullable query value type, profile byte blobs copy into ArrayBuffer-backed Uint8Array values, and font side-effect imports have ambient module declarations.