### PR TITLE
[optim] Left-preconditioned Muon (Ali idea 4): U=ρ H^{-1/2} polar(H^{-1/2} M), H=EMA(GGᵀ)

### DIFF
--- a/experiments/speedrun/left_precond_muon_qwen3/__init__.py
+++ b/experiments/speedrun/left_precond_muon_qwen3/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/speedrun/left_precond_muon_qwen3/smoke_test.py
+++ b/experiments/speedrun/left_precond_muon_qwen3/smoke_test.py
@@ -1,0 +1,82 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""CPU smoke test: left-precond Muon (idea 4) — helper reduces to Muon at H=I + full step finite."""
+
+import equinox as eqx
+import haliax as hax
+import jax
+import jax.numpy as jnp
+import numpy as np
+from levanter.layers.attention import AttentionMask
+from levanter.models.qwen import Qwen3Config
+from levanter.optim.left_precond_muon import (
+    LeftPrecondMuonConfig,
+    _left_precond_matrix,
+    _trunc_inv_sqrt,
+)
+from levanter.trainer_state import take_train_step
+
+np.random.seed(0)
+
+# 1. _left_precond_matrix with H = c*I should match plain Muon (cos ~ 1)
+out, inn = 256, 128
+M = jnp.asarray(np.random.randn(out, inn).astype(np.float32))
+from levanter.optim.util import zeropower_via_newtonschulz5
+
+muon = zeropower_via_newtonschulz5(M, steps=5, eps=1e-7, coefficient_type="quintic")
+muon = muon * jnp.sqrt(max(1.0, out / inn))
+for c in [1.0, 7.3, 1e3]:
+    H = (c * jnp.eye(out)).astype(jnp.float32)
+    D = _left_precond_matrix(M, H, clamp_rel=1e-6, ns_steps=5, eps=1e-7, use_kimi_scaling=False)
+    cos = float((D * muon).sum() / (jnp.linalg.norm(D) * jnp.linalg.norm(muon)))
+    print(
+        f"H=c*I (c={c:<6g}) cos(D,Muon)={cos:.4f}  ||D||/||Muon||={float(jnp.linalg.norm(D)/jnp.linalg.norm(muon)):.4f}"
+    )
+
+# 2. truncated pseudo-inverse: rank-deficient H zeros the null directions
+Q, _ = np.linalg.qr(np.random.randn(out, out))
+ev = np.zeros(out)
+ev[:50] = np.logspace(0, -3, 50)  # only 50 nonzero eigenvalues
+Hrank = jnp.asarray((Q * ev) @ Q.T).astype(jnp.float32)
+inv = _trunc_inv_sqrt(Hrank, clamp_rel=1e-6, eps=1e-7)
+print("trunc-inv finite:", bool(jnp.all(jnp.isfinite(inv))), "| rank(inv)~", int(jnp.linalg.matrix_rank(inv)))
+
+# 3. full optimizer through take_train_step on tiny qwen3
+cfg = Qwen3Config(
+    max_seq_len=32,
+    hidden_dim=64,
+    intermediate_dim=128,
+    num_layers=3,
+    num_heads=4,
+    num_kv_heads=2,
+    scan_layers=True,
+    gradient_checkpointing=False,
+    tie_word_embeddings=True,
+)
+Vocab = hax.Axis("vocab", 128)
+key = jax.random.PRNGKey(0)
+model = cfg.build(Vocab, key=key)
+B, P = hax.Axis("batch", 2), hax.Axis("position", 32)
+tok = hax.named(jax.random.randint(key, (2, 32), 0, 128), (B, P))
+am = AttentionMask.causal()
+
+
+def loss_fn(m):
+    return m(tok, attn_mask=am, key=None).mean().scalar()
+
+
+loss, grads = eqx.filter_value_and_grad(loss_fn)(model)
+opt = LeftPrecondMuonConfig(
+    lr=0.02, adam_lr=6e-4, h_beta=0.95, clamp_rel=1e-6, weight_decay=0.0, learning_rate=0.02
+).build(10)
+gp = eqx.filter(model, eqx.is_inexact_array)
+st = opt.init(gp)
+# two steps to exercise the H EMA
+for i in range(2):
+    new_model, st, updates = take_train_step(opt, model, st, grads, is_trainable=True)
+    leaves = jax.tree_util.tree_leaves(eqx.filter(updates, eqx.is_inexact_array))
+    allfin = all(bool(jnp.all(jnp.isfinite(l))) for l in leaves)
+    print(f"step {i}: updates finite={allfin}  n_leaves={len(leaves)}")
+    assert allfin
+print("SMOKE PASS")

--- a/experiments/speedrun/left_precond_muon_qwen3/sweep.py
+++ b/experiments/speedrun/left_precond_muon_qwen3/sweep.py
@@ -76,6 +76,11 @@ VARIANT_LRS: dict[str, tuple[float, ...]] = {
 VARIANTS: tuple[str, ...] = tuple(
     v.strip() for v in os.environ.get("VARIANTS", "inner_only,full,full_fro,full_outer_msign").split(",")
 )
+# Override the per-variant LR list for ALL launched variants (e.g. to resume a single failed run after a
+# preemption/SIGSEGV without re-launching its siblings). Same RUN_TAG ⟹ same run_id ⟹ resumes the checkpoint.
+LR_OVERRIDE: tuple[float, ...] | None = (
+    tuple(float(x) for x in os.environ["LR_OVERRIDE"].split(",")) if os.environ.get("LR_OVERRIDE") else None
+)
 
 
 @dataclass(frozen=True)
@@ -194,7 +199,7 @@ def main() -> None:
     if os.getenv("CI") is not None:
         logger.info("Skipping experiment execution on CI environment, needs HF access.")
         return
-    steps = [_build_step(m, v) for v in VARIANTS for m in VARIANT_LRS[v]]
+    steps = [_build_step(m, v) for v in VARIANTS for m in (LR_OVERRIDE or VARIANT_LRS[v])]
     logger.info(
         "Left-precond Muon 130m sweep (solver=%s qk_steps=%d): %d runs (%s)",
         SOLVER,

--- a/experiments/speedrun/left_precond_muon_qwen3/sweep.py
+++ b/experiments/speedrun/left_precond_muon_qwen3/sweep.py
@@ -5,11 +5,12 @@
 
     U = ρ · H^{-1/2} · polar( H^{-1/2} · M ) ,   H = EMA(G Gᵀ)
 
-Left/output-side whitening by the gradient's own second moment H (Shampoo left factor),
-with a truncated pseudo-inverse for H^{-1/2} (facebookresearch/optimizers#265). Pure
-optimizer — gradient-only, no activation capture (cf. idea 3). H = I recovers plain Muon.
+Left/output-side whitening by the gradient's own second moment H (Shampoo left factor).
+H^{-1/2} uses the SATURATING coarse inverse-sqrt q_k (eigh + k-step Muon-coeff NS scalar map),
+which reproduces Mudam's operator exactly and caps the amplification of noisy small-eigenvalue
+directions (vs the exact w^{-1/2}, which over-whitens). Pure optimizer — gradient-only, no
+activation capture (cf. idea 3). H = I recovers plain Muon.
 
-Swept knobs: learning rate (primary) × clamp_rel (truncated-pseudo-inverse threshold).
 Everything else mirrors the gain-gated / activation-aware Qwen3 speedrun (marin#4933):
 130m = llama_150m, fineweb-edu-10B, paloma, W&B marin-community/speedrun. Compare on
 **eval/paloma/c4_en/bpb** (Muon baseline 1.1663; a same-setup Muon control = 1.1673).
@@ -20,7 +21,7 @@ Submit (v6e-8 preemptible, us-east5):
     .venv/bin/iris --config lib/iris/config/marin.yaml job run --no-wait \\
       --preemptible --region us-east5 --extra tpu \\
       -e WANDB_API_KEY "$WANDB_API_KEY" -e MARIN_PREFIX "gs://marin-us-east5" \\
-      -e REGION us-east5 -e TPU_VARIANT v6e-8 -e LR_MULTS -e CLAMPS -e RUN_TAG \\
+      -e REGION us-east5 -e TPU_VARIANT v6e-8 -e VARIANTS -e SOLVER -e QK_STEPS -e RUN_TAG \\
       -- python -m experiments.speedrun.left_precond_muon_qwen3.sweep
 """
 
@@ -50,35 +51,31 @@ WANDB_ENTITY = "marin-community"
 WANDB_PROJECT = "speedrun"
 
 
-def _floats(env: str, default: str) -> tuple[float, ...]:
-    return tuple(float(x) for x in os.environ.get(env, default).split(","))
+# q_k = the saturating coarse inverse-sqrt (eigh + k-step Muon-coeff NS scalar map on eigenvalues),
+# which reproduces Mudam exactly and beats exact w^{-1/2} by capping noisy-direction amplification.
+SOLVER: str = os.environ.get("SOLVER", "qk")
+QK_STEPS: int = int(os.environ.get("QK_STEPS", "5"))
 
-
-# LR is the primary tuning axis (per the goal). clamp_rel is fixed near Shampoo's 1e-15 (only
-# numerically-zero directions truncated); 1e-8 included once to confirm insensitivity to mild truncation.
-LR_MULTIPLIERS: tuple[float, ...] = _floats("LR_MULTS", "0.5,1.0,2.0,4.0")
-CLAMPS: tuple[float, ...] = _floats("CLAMPS", "1e-15,1e-8")
-
-# Variant ablations (comma-separated). Each maps to optimizer flags:
-#   full       — U = H^{-1/2} polar(H^{-1/2} M)            (the base idea 4)
-#   inner_only — U = polar(H^{-1/2} M)                     (v1: drop the outer H^{-1/2})
-#   real_inv   — damped real inverse instead of truncated  (v2)
-#   fro_norm   — rescale U to Muon's Frobenius norm        (v3)
+# Each variant → (variant_flags, LR multipliers to sweep). The q_k finding's test plan:
+#   inner_only            — U = polar(H^{-1/2} M)                        — sanity (≈ Mudam 1.165), LR 1×
+#   full                  — U = H^{-1/2} polar(H^{-1/2} M)               — does a SATURATING outer help? LR 1×,2×
+#   full_fro              — full, rescaled to Muon's Frobenius norm                                LR 1×,2×
+#   full_outer_msign      — U = polar(H^{-1/2} polar(H^{-1/2} M))        — re-orthogonalize the outer LR 1×,2×
 VARIANT_FLAGS = {
-    "full": dict(outer_precond=True, real_inverse=False, normalize_fro=False),
-    "inner_only": dict(outer_precond=False, real_inverse=False, normalize_fro=False),
-    "real_inv": dict(outer_precond=True, real_inverse=True, normalize_fro=False),
-    "fro_norm": dict(outer_precond=True, real_inverse=False, normalize_fro=True),
+    "inner_only": dict(outer_precond=False, outer_msign=False, normalize_fro=False),
+    "full": dict(outer_precond=True, outer_msign=False, normalize_fro=False),
+    "full_fro": dict(outer_precond=True, outer_msign=False, normalize_fro=True),
+    "full_outer_msign": dict(outer_precond=True, outer_msign=True, normalize_fro=False),
 }
-VARIANTS: tuple[str, ...] = tuple(v.strip() for v in os.environ.get("VARIANTS", "full").split(","))
-
-# Damping λ on mean-normalized H eigenvalues: (w/mean + λ)^{-1/2}. λ=0 = un-damped (over-amplifies
-# tiny eigenvalues); larger λ bounds it, λ→∞ ⟹ Muon. Swept (esp. for inner_only) to test whether a
-# damped inner whitening beats Muon.
-DAMPINGS: tuple[float, ...] = _floats("DAMPINGS", "0.0")
-
-# Whitening exponent p in (w/mean+λ)^{-p}: 0.5 = H^{-1/2}, 0.25 = H^{-1/4} (gentler).
-INV_POWERS: tuple[float, ...] = _floats("INV_POWERS", "0.5")
+VARIANT_LRS: dict[str, tuple[float, ...]] = {
+    "inner_only": (1.0,),
+    "full": (1.0, 2.0),
+    "full_fro": (1.0, 2.0),
+    "full_outer_msign": (1.0, 2.0),
+}
+VARIANTS: tuple[str, ...] = tuple(
+    v.strip() for v in os.environ.get("VARIANTS", "inner_only,full,full_fro,full_outer_msign").split(",")
+)
 
 
 @dataclass(frozen=True)
@@ -128,10 +125,6 @@ def _lr_label(m: float) -> str:
     return f"lrx{f'{m:g}'.replace('.', '_')}"
 
 
-def _clamp_label(c: float) -> str:
-    return f"c{f'{c:g}'.replace('.', '_').replace('-', 'm').replace('+', 'p')}"
-
-
 def _override_tracker(step: ExecutorStep) -> ExecutorStep:
     pod = step.config
     inner = pod.train_config
@@ -145,17 +138,14 @@ def _override_tracker(step: ExecutorStep) -> ExecutorStep:
 RUN_TAG: str = os.environ.get("RUN_TAG", "")
 
 
-def _build_step(
-    multiplier: float, clamp_rel: float, variant: str, damping: float = 0.0, inv_power: float = 0.5
-) -> ExecutorStep:
+def _build_step(multiplier: float, variant: str) -> ExecutorStep:
     matrix_lr = SIZE.muon_lr * multiplier
     adam_lr = SIZE.adam_lr * multiplier
     optimizer = LeftPrecondMuonConfig(
         h_beta=0.95,
-        clamp_rel=clamp_rel,
+        solver=SOLVER,
+        qk_steps=QK_STEPS,
         ns_steps=5,
-        damping=damping,
-        inv_power=inv_power,
         **VARIANT_FLAGS[variant],
         lr=matrix_lr,
         learning_rate=matrix_lr,
@@ -184,16 +174,14 @@ def _build_step(
         optimizer_config=optimizer,
     )
     tag = f"_{RUN_TAG}" if RUN_TAG else ""
-    vlabel = "" if variant == "full" else f"_{variant}"
-    dlabel = "" if damping == 0.0 else f"_dmp{f'{damping:g}'.replace('.', '_')}"
-    plabel = "" if inv_power == 0.5 else f"_p{f'{inv_power:g}'.replace('.', '_')}"
-    run_id = f"qwen3_{SIZE.label}_leftprec{vlabel}{plabel}{dlabel}{tag}_{_clamp_label(clamp_rel)}_{SEQ_LEN}_{_lr_label(multiplier)}"
+    slabel = "" if SOLVER == "qk" else f"_{SOLVER}"
+    run_id = f"qwen3_{SIZE.label}_leftprec_{variant}{slabel}{tag}_{SEQ_LEN}_{_lr_label(multiplier)}"
     step = default_train(
         name=run_id,
         tokenized=fineweb_edu_subcache_10B,
         model_config=_to_qwen3_from_llama(SIZE.llama_cfg),
         train_config=train,
-        tags=["speedrun", "left_precond_muon", variant, _clamp_label(clamp_rel), f"qwen3_{SIZE.label}"],
+        tags=["speedrun", "left_precond_muon", variant, SOLVER, f"qwen3_{SIZE.label}"],
         use_default_validation=True,
         eval_harness_tasks=(),
         wandb_name=run_id,
@@ -206,26 +194,15 @@ def main() -> None:
     if os.getenv("CI") is not None:
         logger.info("Skipping experiment execution on CI environment, needs HF access.")
         return
-    steps = [
-        _build_step(m, c, v, d, p)
-        for v in VARIANTS
-        for m in LR_MULTIPLIERS
-        for c in CLAMPS
-        for d in DAMPINGS
-        for p in INV_POWERS
-    ]
+    steps = [_build_step(m, v) for v in VARIANTS for m in VARIANT_LRS[v]]
     logger.info(
-        "Left-precond Muon 130m sweep: %d runs (variants=%s lr=%s clamps=%s dampings=%s inv_powers=%s)",
+        "Left-precond Muon 130m sweep (solver=%s qk_steps=%d): %d runs (%s)",
+        SOLVER,
+        QK_STEPS,
         len(steps),
-        VARIANTS,
-        LR_MULTIPLIERS,
-        CLAMPS,
-        DAMPINGS,
-        INV_POWERS,
+        ", ".join(f"{v}@{VARIANT_LRS[v]}" for v in VARIANTS),
     )
-    executor_main(
-        steps=steps, description="Qwen3-130m left-preconditioned Muon sweep (Ali idea 4): variant x LR x clamp."
-    )
+    executor_main(steps=steps, description="Qwen3-130m left-preconditioned Muon (Ali idea 4) q_k sweep: variant x LR.")
 
 
 if __name__ == "__main__":

--- a/experiments/speedrun/left_precond_muon_qwen3/sweep.py
+++ b/experiments/speedrun/left_precond_muon_qwen3/sweep.py
@@ -59,6 +59,19 @@ def _floats(env: str, default: str) -> tuple[float, ...]:
 LR_MULTIPLIERS: tuple[float, ...] = _floats("LR_MULTS", "0.5,1.0,2.0,4.0")
 CLAMPS: tuple[float, ...] = _floats("CLAMPS", "1e-15,1e-8")
 
+# Variant ablations (comma-separated). Each maps to optimizer flags:
+#   full       — U = H^{-1/2} polar(H^{-1/2} M)            (the base idea 4)
+#   inner_only — U = polar(H^{-1/2} M)                     (v1: drop the outer H^{-1/2})
+#   real_inv   — damped real inverse instead of truncated  (v2)
+#   fro_norm   — rescale U to Muon's Frobenius norm        (v3)
+VARIANT_FLAGS = {
+    "full": dict(outer_precond=True, real_inverse=False, normalize_fro=False),
+    "inner_only": dict(outer_precond=False, real_inverse=False, normalize_fro=False),
+    "real_inv": dict(outer_precond=True, real_inverse=True, normalize_fro=False),
+    "fro_norm": dict(outer_precond=True, real_inverse=False, normalize_fro=True),
+}
+VARIANTS: tuple[str, ...] = tuple(v.strip() for v in os.environ.get("VARIANTS", "full").split(","))
+
 
 @dataclass(frozen=True)
 class SizeSpec:
@@ -124,13 +137,14 @@ def _override_tracker(step: ExecutorStep) -> ExecutorStep:
 RUN_TAG: str = os.environ.get("RUN_TAG", "")
 
 
-def _build_step(multiplier: float, clamp_rel: float) -> ExecutorStep:
+def _build_step(multiplier: float, clamp_rel: float, variant: str) -> ExecutorStep:
     matrix_lr = SIZE.muon_lr * multiplier
     adam_lr = SIZE.adam_lr * multiplier
     optimizer = LeftPrecondMuonConfig(
         h_beta=0.95,
         clamp_rel=clamp_rel,
         ns_steps=5,
+        **VARIANT_FLAGS[variant],
         lr=matrix_lr,
         learning_rate=matrix_lr,
         adam_lr=adam_lr,
@@ -158,13 +172,14 @@ def _build_step(multiplier: float, clamp_rel: float) -> ExecutorStep:
         optimizer_config=optimizer,
     )
     tag = f"_{RUN_TAG}" if RUN_TAG else ""
-    run_id = f"qwen3_{SIZE.label}_leftprec{tag}_{_clamp_label(clamp_rel)}_{SEQ_LEN}_{_lr_label(multiplier)}"
+    vlabel = "" if variant == "full" else f"_{variant}"
+    run_id = f"qwen3_{SIZE.label}_leftprec{vlabel}{tag}_{_clamp_label(clamp_rel)}_{SEQ_LEN}_{_lr_label(multiplier)}"
     step = default_train(
         name=run_id,
         tokenized=fineweb_edu_subcache_10B,
         model_config=_to_qwen3_from_llama(SIZE.llama_cfg),
         train_config=train,
-        tags=["speedrun", "left_precond_muon", _clamp_label(clamp_rel), f"qwen3_{SIZE.label}"],
+        tags=["speedrun", "left_precond_muon", variant, _clamp_label(clamp_rel), f"qwen3_{SIZE.label}"],
         use_default_validation=True,
         eval_harness_tasks=(),
         wandb_name=run_id,
@@ -177,9 +192,17 @@ def main() -> None:
     if os.getenv("CI") is not None:
         logger.info("Skipping experiment execution on CI environment, needs HF access.")
         return
-    steps = [_build_step(m, c) for m in LR_MULTIPLIERS for c in CLAMPS]
-    logger.info("Left-precond Muon 130m sweep: %d runs (lr=%s clamps=%s)", len(steps), LR_MULTIPLIERS, CLAMPS)
-    executor_main(steps=steps, description="Qwen3-130m left-preconditioned Muon sweep (Ali idea 4): LR x clamp.")
+    steps = [_build_step(m, c, v) for v in VARIANTS for m in LR_MULTIPLIERS for c in CLAMPS]
+    logger.info(
+        "Left-precond Muon 130m sweep: %d runs (variants=%s lr=%s clamps=%s)",
+        len(steps),
+        VARIANTS,
+        LR_MULTIPLIERS,
+        CLAMPS,
+    )
+    executor_main(
+        steps=steps, description="Qwen3-130m left-preconditioned Muon sweep (Ali idea 4): variant x LR x clamp."
+    )
 
 
 if __name__ == "__main__":

--- a/experiments/speedrun/left_precond_muon_qwen3/sweep.py
+++ b/experiments/speedrun/left_precond_muon_qwen3/sweep.py
@@ -72,6 +72,11 @@ VARIANT_FLAGS = {
 }
 VARIANTS: tuple[str, ...] = tuple(v.strip() for v in os.environ.get("VARIANTS", "full").split(","))
 
+# Damping λ on mean-normalized H eigenvalues: (w/mean + λ)^{-1/2}. λ=0 = un-damped (over-amplifies
+# tiny eigenvalues); larger λ bounds it, λ→∞ ⟹ Muon. Swept (esp. for inner_only) to test whether a
+# damped inner whitening beats Muon.
+DAMPINGS: tuple[float, ...] = _floats("DAMPINGS", "0.0")
+
 
 @dataclass(frozen=True)
 class SizeSpec:
@@ -137,13 +142,14 @@ def _override_tracker(step: ExecutorStep) -> ExecutorStep:
 RUN_TAG: str = os.environ.get("RUN_TAG", "")
 
 
-def _build_step(multiplier: float, clamp_rel: float, variant: str) -> ExecutorStep:
+def _build_step(multiplier: float, clamp_rel: float, variant: str, damping: float = 0.0) -> ExecutorStep:
     matrix_lr = SIZE.muon_lr * multiplier
     adam_lr = SIZE.adam_lr * multiplier
     optimizer = LeftPrecondMuonConfig(
         h_beta=0.95,
         clamp_rel=clamp_rel,
         ns_steps=5,
+        damping=damping,
         **VARIANT_FLAGS[variant],
         lr=matrix_lr,
         learning_rate=matrix_lr,
@@ -173,7 +179,8 @@ def _build_step(multiplier: float, clamp_rel: float, variant: str) -> ExecutorSt
     )
     tag = f"_{RUN_TAG}" if RUN_TAG else ""
     vlabel = "" if variant == "full" else f"_{variant}"
-    run_id = f"qwen3_{SIZE.label}_leftprec{vlabel}{tag}_{_clamp_label(clamp_rel)}_{SEQ_LEN}_{_lr_label(multiplier)}"
+    dlabel = "" if damping == 0.0 else f"_dmp{f'{damping:g}'.replace('.', '_')}"
+    run_id = f"qwen3_{SIZE.label}_leftprec{vlabel}{dlabel}{tag}_{_clamp_label(clamp_rel)}_{SEQ_LEN}_{_lr_label(multiplier)}"
     step = default_train(
         name=run_id,
         tokenized=fineweb_edu_subcache_10B,
@@ -192,13 +199,14 @@ def main() -> None:
     if os.getenv("CI") is not None:
         logger.info("Skipping experiment execution on CI environment, needs HF access.")
         return
-    steps = [_build_step(m, c, v) for v in VARIANTS for m in LR_MULTIPLIERS for c in CLAMPS]
+    steps = [_build_step(m, c, v, d) for v in VARIANTS for m in LR_MULTIPLIERS for c in CLAMPS for d in DAMPINGS]
     logger.info(
-        "Left-precond Muon 130m sweep: %d runs (variants=%s lr=%s clamps=%s)",
+        "Left-precond Muon 130m sweep: %d runs (variants=%s lr=%s clamps=%s dampings=%s)",
         len(steps),
         VARIANTS,
         LR_MULTIPLIERS,
         CLAMPS,
+        DAMPINGS,
     )
     executor_main(
         steps=steps, description="Qwen3-130m left-preconditioned Muon sweep (Ali idea 4): variant x LR x clamp."

--- a/experiments/speedrun/left_precond_muon_qwen3/sweep.py
+++ b/experiments/speedrun/left_precond_muon_qwen3/sweep.py
@@ -1,0 +1,184 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen3-130m sweep for Ali Jadbabaie's left-preconditioned Muon ("idea 4").
+
+    U = ρ · H^{-1/2} · polar( H^{-1/2} · M ) ,   H = EMA(G Gᵀ)
+
+Left/output-side whitening by the gradient's own second moment H (Shampoo left factor),
+with a truncated pseudo-inverse for H^{-1/2} (facebookresearch/optimizers#265). Pure
+optimizer — gradient-only, no activation capture (cf. idea 3). H = I recovers plain Muon.
+
+Swept knobs: learning rate (primary) × clamp_rel (truncated-pseudo-inverse threshold).
+Everything else mirrors the gain-gated / activation-aware Qwen3 speedrun (marin#4933):
+130m = llama_150m, fineweb-edu-10B, paloma, W&B marin-community/speedrun. Compare on
+**eval/paloma/c4_en/bpb** (Muon baseline 1.1663; a same-setup Muon control = 1.1673).
+
+Submit (v6e-8 preemptible, us-east5):
+
+    MARIN_PREFIX=gs://marin-us-east5 \\
+    .venv/bin/iris --config lib/iris/config/marin.yaml job run --no-wait \\
+      --preemptible --region us-east5 --extra tpu \\
+      -e WANDB_API_KEY "$WANDB_API_KEY" -e MARIN_PREFIX "gs://marin-us-east5" \\
+      -e REGION us-east5 -e TPU_VARIANT v6e-8 -e LR_MULTS -e CLAMPS -e RUN_TAG \\
+      -- python -m experiments.speedrun.left_precond_muon_qwen3.sweep
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+from dataclasses import dataclass
+
+from fray.cluster import ResourceConfig
+from levanter.models.llama import LlamaConfig
+from levanter.models.qwen import Qwen3Config
+from levanter.optim.left_precond_muon import LeftPrecondMuonConfig
+from marin.execution.executor import ExecutorStep, executor_main
+
+from experiments.defaults import default_train
+from experiments.llama import llama_150m
+from experiments.prebuilt_caches import fineweb_edu_subcache_10B
+from experiments.simple_train_config import SimpleTrainConfig
+
+logger = logging.getLogger(__name__)
+
+REGION = os.environ.get("REGION", "us-east5")
+SEQ_LEN = 4096
+WANDB_ENTITY = "marin-community"
+WANDB_PROJECT = "speedrun"
+
+
+def _floats(env: str, default: str) -> tuple[float, ...]:
+    return tuple(float(x) for x in os.environ.get(env, default).split(","))
+
+
+LR_MULTIPLIERS: tuple[float, ...] = _floats("LR_MULTS", "0.5,1.0,2.0")
+CLAMPS: tuple[float, ...] = _floats("CLAMPS", "1e-6,1e-4")
+
+
+@dataclass(frozen=True)
+class SizeSpec:
+    label: str
+    llama_cfg: LlamaConfig
+    muon_lr: float
+    adam_lr: float
+    train_batch_size: int
+    num_train_steps: int
+    tpu_variant: str
+    momentum: float
+    adam_epsilon: float
+    max_grad_norm: float
+    decay: float
+
+
+_TPU_VARIANT = os.environ.get("TPU_VARIANT", "v6e-8")
+SIZE = SizeSpec("130m", llama_150m, 0.016, 0.0032, 128, 4959, _TPU_VARIANT, 0.95, 1e-15, 1.0, 0.8)
+
+
+def _to_qwen3_from_llama(llama_cfg: LlamaConfig) -> Qwen3Config:
+    return Qwen3Config(
+        max_seq_len=SEQ_LEN,
+        hidden_dim=llama_cfg.hidden_dim,
+        intermediate_dim=llama_cfg.intermediate_dim,
+        num_layers=llama_cfg.num_layers,
+        num_heads=llama_cfg.num_heads,
+        num_kv_heads=llama_cfg.num_kv_heads,
+        head_dim=getattr(llama_cfg, "head_dim", None),
+        use_bias=getattr(llama_cfg, "use_bias", False),
+        rope=llama_cfg.rope,
+        activation_function=llama_cfg.activation_function,
+        initializer_range=llama_cfg.initializer_range,
+        layer_norm_epsilon=llama_cfg.layer_norm_epsilon,
+        tie_word_embeddings=llama_cfg.tie_word_embeddings,
+        upcast_attn=llama_cfg.upcast_attn,
+        attn_backend=llama_cfg.attn_backend,
+        flash_attention_block_size=llama_cfg.flash_attention_block_size,
+        hybrid_norm=False,
+        scan_layers=True,
+        gradient_checkpointing=True,
+    )
+
+
+def _lr_label(m: float) -> str:
+    return f"lrx{f'{m:g}'.replace('.', '_')}"
+
+
+def _clamp_label(c: float) -> str:
+    return f"c{f'{c:g}'.replace('.', '_').replace('-', 'm').replace('+', 'p')}"
+
+
+def _override_tracker(step: ExecutorStep) -> ExecutorStep:
+    pod = step.config
+    inner = pod.train_config
+    trainer = dataclasses.replace(
+        inner.trainer, tracker=dataclasses.replace(inner.trainer.tracker, entity=WANDB_ENTITY, project=WANDB_PROJECT)
+    )
+    inner = dataclasses.replace(inner, trainer=trainer)
+    return dataclasses.replace(step, config=dataclasses.replace(pod, train_config=inner))
+
+
+RUN_TAG: str = os.environ.get("RUN_TAG", "")
+
+
+def _build_step(multiplier: float, clamp_rel: float) -> ExecutorStep:
+    matrix_lr = SIZE.muon_lr * multiplier
+    adam_lr = SIZE.adam_lr * multiplier
+    optimizer = LeftPrecondMuonConfig(
+        h_beta=0.95,
+        clamp_rel=clamp_rel,
+        ns_steps=5,
+        lr=matrix_lr,
+        learning_rate=matrix_lr,
+        adam_lr=adam_lr,
+        momentum=SIZE.momentum,
+        nesterov=True,
+        weight_decay=0.1,
+        beta1=0.8,
+        beta2=0.98,
+        epsilon=SIZE.adam_epsilon,
+        matrix_epsilon=1e-7,
+        max_grad_norm=SIZE.max_grad_norm,
+        use_kimi_scaling=False,
+        lr_schedule="linear",
+        warmup=0,
+        rewarmup=0,
+        decay=SIZE.decay,
+        min_lr_ratio=0,
+    )
+    train = SimpleTrainConfig(
+        resources=ResourceConfig.with_tpu(SIZE.tpu_variant, regions=[REGION], preemptible=True),
+        train_seq_len=SEQ_LEN,
+        train_batch_size=SIZE.train_batch_size,
+        num_train_steps=SIZE.num_train_steps,
+        learning_rate=matrix_lr,
+        optimizer_config=optimizer,
+    )
+    tag = f"_{RUN_TAG}" if RUN_TAG else ""
+    run_id = f"qwen3_{SIZE.label}_leftprec{tag}_{_clamp_label(clamp_rel)}_{SEQ_LEN}_{_lr_label(multiplier)}"
+    step = default_train(
+        name=run_id,
+        tokenized=fineweb_edu_subcache_10B,
+        model_config=_to_qwen3_from_llama(SIZE.llama_cfg),
+        train_config=train,
+        tags=["speedrun", "left_precond_muon", _clamp_label(clamp_rel), f"qwen3_{SIZE.label}"],
+        use_default_validation=True,
+        eval_harness_tasks=(),
+        wandb_name=run_id,
+        wandb_group="left_precond_muon_qwen3_130m",
+    )
+    return _override_tracker(step)
+
+
+def main() -> None:
+    if os.getenv("CI") is not None:
+        logger.info("Skipping experiment execution on CI environment, needs HF access.")
+        return
+    steps = [_build_step(m, c) for m in LR_MULTIPLIERS for c in CLAMPS]
+    logger.info("Left-precond Muon 130m sweep: %d runs (lr=%s clamps=%s)", len(steps), LR_MULTIPLIERS, CLAMPS)
+    executor_main(steps=steps, description="Qwen3-130m left-preconditioned Muon sweep (Ali idea 4): LR x clamp.")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/speedrun/left_precond_muon_qwen3/sweep.py
+++ b/experiments/speedrun/left_precond_muon_qwen3/sweep.py
@@ -54,8 +54,10 @@ def _floats(env: str, default: str) -> tuple[float, ...]:
     return tuple(float(x) for x in os.environ.get(env, default).split(","))
 
 
-LR_MULTIPLIERS: tuple[float, ...] = _floats("LR_MULTS", "0.5,1.0,2.0")
-CLAMPS: tuple[float, ...] = _floats("CLAMPS", "1e-6,1e-4")
+# LR is the primary tuning axis (per the goal). clamp_rel is fixed near Shampoo's 1e-15 (only
+# numerically-zero directions truncated); 1e-8 included once to confirm insensitivity to mild truncation.
+LR_MULTIPLIERS: tuple[float, ...] = _floats("LR_MULTS", "0.5,1.0,2.0,4.0")
+CLAMPS: tuple[float, ...] = _floats("CLAMPS", "1e-15,1e-8")
 
 
 @dataclass(frozen=True)

--- a/experiments/speedrun/left_precond_muon_qwen3/sweep.py
+++ b/experiments/speedrun/left_precond_muon_qwen3/sweep.py
@@ -77,6 +77,9 @@ VARIANTS: tuple[str, ...] = tuple(v.strip() for v in os.environ.get("VARIANTS", 
 # damped inner whitening beats Muon.
 DAMPINGS: tuple[float, ...] = _floats("DAMPINGS", "0.0")
 
+# Whitening exponent p in (w/mean+λ)^{-p}: 0.5 = H^{-1/2}, 0.25 = H^{-1/4} (gentler).
+INV_POWERS: tuple[float, ...] = _floats("INV_POWERS", "0.5")
+
 
 @dataclass(frozen=True)
 class SizeSpec:
@@ -142,7 +145,9 @@ def _override_tracker(step: ExecutorStep) -> ExecutorStep:
 RUN_TAG: str = os.environ.get("RUN_TAG", "")
 
 
-def _build_step(multiplier: float, clamp_rel: float, variant: str, damping: float = 0.0) -> ExecutorStep:
+def _build_step(
+    multiplier: float, clamp_rel: float, variant: str, damping: float = 0.0, inv_power: float = 0.5
+) -> ExecutorStep:
     matrix_lr = SIZE.muon_lr * multiplier
     adam_lr = SIZE.adam_lr * multiplier
     optimizer = LeftPrecondMuonConfig(
@@ -150,6 +155,7 @@ def _build_step(multiplier: float, clamp_rel: float, variant: str, damping: floa
         clamp_rel=clamp_rel,
         ns_steps=5,
         damping=damping,
+        inv_power=inv_power,
         **VARIANT_FLAGS[variant],
         lr=matrix_lr,
         learning_rate=matrix_lr,
@@ -180,7 +186,8 @@ def _build_step(multiplier: float, clamp_rel: float, variant: str, damping: floa
     tag = f"_{RUN_TAG}" if RUN_TAG else ""
     vlabel = "" if variant == "full" else f"_{variant}"
     dlabel = "" if damping == 0.0 else f"_dmp{f'{damping:g}'.replace('.', '_')}"
-    run_id = f"qwen3_{SIZE.label}_leftprec{vlabel}{dlabel}{tag}_{_clamp_label(clamp_rel)}_{SEQ_LEN}_{_lr_label(multiplier)}"
+    plabel = "" if inv_power == 0.5 else f"_p{f'{inv_power:g}'.replace('.', '_')}"
+    run_id = f"qwen3_{SIZE.label}_leftprec{vlabel}{plabel}{dlabel}{tag}_{_clamp_label(clamp_rel)}_{SEQ_LEN}_{_lr_label(multiplier)}"
     step = default_train(
         name=run_id,
         tokenized=fineweb_edu_subcache_10B,
@@ -199,14 +206,22 @@ def main() -> None:
     if os.getenv("CI") is not None:
         logger.info("Skipping experiment execution on CI environment, needs HF access.")
         return
-    steps = [_build_step(m, c, v, d) for v in VARIANTS for m in LR_MULTIPLIERS for c in CLAMPS for d in DAMPINGS]
+    steps = [
+        _build_step(m, c, v, d, p)
+        for v in VARIANTS
+        for m in LR_MULTIPLIERS
+        for c in CLAMPS
+        for d in DAMPINGS
+        for p in INV_POWERS
+    ]
     logger.info(
-        "Left-precond Muon 130m sweep: %d runs (variants=%s lr=%s clamps=%s dampings=%s)",
+        "Left-precond Muon 130m sweep: %d runs (variants=%s lr=%s clamps=%s dampings=%s inv_powers=%s)",
         len(steps),
         VARIANTS,
         LR_MULTIPLIERS,
         CLAMPS,
         DAMPINGS,
+        INV_POWERS,
     )
     executor_main(
         steps=steps, description="Qwen3-130m left-preconditioned Muon sweep (Ali idea 4): variant x LR x clamp."

--- a/experiments/speedrun/mudam_qwen3/sweep.py
+++ b/experiments/speedrun/mudam_qwen3/sweep.py
@@ -111,8 +111,8 @@ def _build_step(lr: float, side: str) -> ExecutorStep:
     optimizer = MudamConfig(
         momentum=0.95,
         shampoo_beta=0.95,
-        beta1=0.95,
-        beta2=0.95,
+        beta1=0.8,
+        beta2=0.98,
         epsilon=1e-15,
         weight_decay=0.1,
         max_grad_norm=1.0,

--- a/experiments/speedrun/mudam_qwen3/sweep.py
+++ b/experiments/speedrun/mudam_qwen3/sweep.py
@@ -1,0 +1,160 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen3-130m reproduction sweep for Mudam (Shampoo-Muon), to compare against Muon.
+
+Mudam (`levanter.optim.mudam`) is a one-sided SOAP / matrix-Adam: precondition the momentum by
+the inverse-sqrt of the gradient second moment H=EMA(GGᵀ or GᵀG) via a coupled Newton-Schulz
+(no explicit eigh). Defaults: input-side preconditioner, kimi update scaling, no extra Muon
+re-orthogonalization (another_muon=None). Run as-is and sweep LR to see if it matches/beats the
+Muon baseline (eval/paloma/c4_en/bpb = 1.1663; same-setup Muon control = 1.1673).
+
+Because kimi scaling (scale = √max(d_out,d_in)) makes the update ~√d larger than Muon's, the
+optimal LR is well below Muon's 0.016 — so LR is swept wide and low.
+
+    MARIN_PREFIX=gs://marin-us-east5 .venv/bin/iris --config lib/iris/config/marin.yaml job run \\
+      --no-wait --preemptible --region us-east5 --extra tpu \\
+      -e WANDB_API_KEY "$WANDB_API_KEY" -e MARIN_PREFIX gs://marin-us-east5 \\
+      -e REGION us-east5 -e TPU_VARIANT v6e-8 -e LRS -e RUN_TAG \\
+      -- python -m experiments.speedrun.mudam_qwen3.sweep
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+from dataclasses import dataclass
+
+from fray.cluster import ResourceConfig
+from levanter.models.llama import LlamaConfig
+from levanter.models.qwen import Qwen3Config
+from levanter.optim.mudam import MudamConfig
+from marin.execution.executor import ExecutorStep, executor_main
+
+from experiments.defaults import default_train
+from experiments.llama import llama_150m
+from experiments.prebuilt_caches import fineweb_edu_subcache_10B
+from experiments.simple_train_config import SimpleTrainConfig
+
+logger = logging.getLogger(__name__)
+
+REGION = os.environ.get("REGION", "us-east5")
+SEQ_LEN = 4096
+WANDB_ENTITY = "marin-community"
+WANDB_PROJECT = "speedrun"
+
+# Absolute matrix LRs (kimi scaling → optimum well below Muon's 0.016).
+LRS: tuple[float, ...] = tuple(float(x) for x in os.environ.get("LRS", "0.0002,0.0005,0.001,0.003,0.01").split(","))
+USE_SCALING: str = os.environ.get("USE_SCALING", "kimi")
+RUN_TAG: str = os.environ.get("RUN_TAG", "")
+
+
+@dataclass(frozen=True)
+class SizeSpec:
+    label: str
+    llama_cfg: LlamaConfig
+    adam_lr: float
+    train_batch_size: int
+    num_train_steps: int
+    tpu_variant: str
+    decay: float
+
+
+_TPU_VARIANT = os.environ.get("TPU_VARIANT", "v6e-8")
+SIZE = SizeSpec("130m", llama_150m, 0.0032, 128, 4959, _TPU_VARIANT, 0.8)
+
+
+def _to_qwen3_from_llama(llama_cfg: LlamaConfig) -> Qwen3Config:
+    return Qwen3Config(
+        max_seq_len=SEQ_LEN,
+        hidden_dim=llama_cfg.hidden_dim,
+        intermediate_dim=llama_cfg.intermediate_dim,
+        num_layers=llama_cfg.num_layers,
+        num_heads=llama_cfg.num_heads,
+        num_kv_heads=llama_cfg.num_kv_heads,
+        head_dim=getattr(llama_cfg, "head_dim", None),
+        use_bias=getattr(llama_cfg, "use_bias", False),
+        rope=llama_cfg.rope,
+        activation_function=llama_cfg.activation_function,
+        initializer_range=llama_cfg.initializer_range,
+        layer_norm_epsilon=llama_cfg.layer_norm_epsilon,
+        tie_word_embeddings=llama_cfg.tie_word_embeddings,
+        upcast_attn=llama_cfg.upcast_attn,
+        attn_backend=llama_cfg.attn_backend,
+        flash_attention_block_size=llama_cfg.flash_attention_block_size,
+        hybrid_norm=False,
+        scan_layers=True,
+        gradient_checkpointing=True,
+    )
+
+
+def _lr_label(lr: float) -> str:
+    return f"lr{f'{lr:g}'.replace('.', '_').replace('-', 'm')}"
+
+
+def _override_tracker(step: ExecutorStep) -> ExecutorStep:
+    pod = step.config
+    inner = pod.train_config
+    trainer = dataclasses.replace(
+        inner.trainer, tracker=dataclasses.replace(inner.trainer.tracker, entity=WANDB_ENTITY, project=WANDB_PROJECT)
+    )
+    inner = dataclasses.replace(inner, trainer=trainer)
+    return dataclasses.replace(step, config=dataclasses.replace(pod, train_config=inner))
+
+
+def _build_step(lr: float) -> ExecutorStep:
+    optimizer = MudamConfig(
+        momentum=0.95,
+        shampoo_beta=0.95,
+        beta1=0.95,
+        beta2=0.95,
+        epsilon=1e-15,
+        weight_decay=0.1,
+        max_grad_norm=1.0,
+        adam_lr=SIZE.adam_lr,
+        use_scaling=USE_SCALING,
+        prefer_input_side=True,
+        normalization="muon",
+        learning_rate=lr,
+        lr_schedule="linear",
+        warmup=0,
+        rewarmup=0,
+        decay=SIZE.decay,
+        min_lr_ratio=0,
+    )
+    train = SimpleTrainConfig(
+        resources=ResourceConfig.with_tpu(SIZE.tpu_variant, regions=[REGION], preemptible=True),
+        train_seq_len=SEQ_LEN,
+        train_batch_size=SIZE.train_batch_size,
+        num_train_steps=SIZE.num_train_steps,
+        learning_rate=lr,
+        optimizer_config=optimizer,
+    )
+    tag = f"_{RUN_TAG}" if RUN_TAG else ""
+    run_id = f"qwen3_{SIZE.label}_mudam{tag}_{USE_SCALING}_{SEQ_LEN}_{_lr_label(lr)}"
+    step = default_train(
+        name=run_id,
+        tokenized=fineweb_edu_subcache_10B,
+        model_config=_to_qwen3_from_llama(SIZE.llama_cfg),
+        train_config=train,
+        tags=["speedrun", "mudam", USE_SCALING, f"qwen3_{SIZE.label}"],
+        use_default_validation=True,
+        eval_harness_tasks=(),
+        wandb_name=run_id,
+        wandb_group="mudam_qwen3_130m",
+    )
+    return _override_tracker(step)
+
+
+def main() -> None:
+    if os.getenv("CI") is not None:
+        logger.info("Skipping experiment execution on CI environment, needs HF access.")
+        return
+    steps = [_build_step(lr) for lr in LRS]
+    logger.info("Mudam 130m repro: %d runs (scaling=%s lrs=%s)", len(steps), USE_SCALING, LRS)
+    executor_main(steps=steps, description="Qwen3-130m Mudam (Shampoo-Muon) reproduction vs Muon: LR sweep.")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/speedrun/mudam_qwen3/sweep.py
+++ b/experiments/speedrun/mudam_qwen3/sweep.py
@@ -47,6 +47,10 @@ WANDB_PROJECT = "speedrun"
 # Absolute matrix LRs (kimi scaling → optimum well below Muon's 0.016).
 LRS: tuple[float, ...] = tuple(float(x) for x in os.environ.get("LRS", "0.0002,0.0005,0.001,0.003,0.01").split(","))
 USE_SCALING: str = os.environ.get("USE_SCALING", "kimi")
+# Re-orthogonalize after the SOAP whitening (apply a second, standard Muon NS on top).
+ANOTHER_MUON: bool = os.environ.get("ANOTHER_MUON", "true").lower() in ("1", "true", "yes")
+# Which side to precondition: "input" (prefer_input_side=True, GᵀG) or "output" (prefer_input_side=False, GGᵀ).
+SIDES: tuple[str, ...] = tuple(s.strip() for s in os.environ.get("SIDES", "input,output").split(","))
 RUN_TAG: str = os.environ.get("RUN_TAG", "")
 
 
@@ -103,7 +107,7 @@ def _override_tracker(step: ExecutorStep) -> ExecutorStep:
     return dataclasses.replace(step, config=dataclasses.replace(pod, train_config=inner))
 
 
-def _build_step(lr: float) -> ExecutorStep:
+def _build_step(lr: float, side: str) -> ExecutorStep:
     optimizer = MudamConfig(
         momentum=0.95,
         shampoo_beta=0.95,
@@ -114,7 +118,8 @@ def _build_step(lr: float) -> ExecutorStep:
         max_grad_norm=1.0,
         adam_lr=SIZE.adam_lr,
         use_scaling=USE_SCALING,
-        prefer_input_side=True,
+        prefer_input_side=(side == "input"),
+        another_muon=ANOTHER_MUON,
         normalization="muon",
         learning_rate=lr,
         lr_schedule="linear",
@@ -132,13 +137,13 @@ def _build_step(lr: float) -> ExecutorStep:
         optimizer_config=optimizer,
     )
     tag = f"_{RUN_TAG}" if RUN_TAG else ""
-    run_id = f"qwen3_{SIZE.label}_mudam{tag}_{USE_SCALING}_{SEQ_LEN}_{_lr_label(lr)}"
+    run_id = f"qwen3_{SIZE.label}_mudam_{side}{tag}_{USE_SCALING}_{SEQ_LEN}_{_lr_label(lr)}"
     step = default_train(
         name=run_id,
         tokenized=fineweb_edu_subcache_10B,
         model_config=_to_qwen3_from_llama(SIZE.llama_cfg),
         train_config=train,
-        tags=["speedrun", "mudam", USE_SCALING, f"qwen3_{SIZE.label}"],
+        tags=["speedrun", "mudam", side, USE_SCALING, f"qwen3_{SIZE.label}"],
         use_default_validation=True,
         eval_harness_tasks=(),
         wandb_name=run_id,
@@ -151,8 +156,11 @@ def main() -> None:
     if os.getenv("CI") is not None:
         logger.info("Skipping experiment execution on CI environment, needs HF access.")
         return
-    steps = [_build_step(lr) for lr in LRS]
-    logger.info("Mudam 130m repro: %d runs (scaling=%s lrs=%s)", len(steps), USE_SCALING, LRS)
+    steps = [_build_step(lr, side) for side in SIDES for lr in LRS]
+    logger.info(
+        "Mudam 130m repro: %d runs (scaling=%s another_muon=%s sides=%s lrs=%s)",
+        len(steps), USE_SCALING, ANOTHER_MUON, SIDES, LRS,
+    )
     executor_main(steps=steps, description="Qwen3-130m Mudam (Shampoo-Muon) reproduction vs Muon: LR sweep.")
 
 

--- a/lib/levanter/src/levanter/optim/left_precond_muon.py
+++ b/lib/levanter/src/levanter/optim/left_precond_muon.py
@@ -57,8 +57,9 @@ class LeftPrecondMuonConfig(OptimizerConfig):
     # 1e-15 (= Shampoo / fb#265) truncates only numerically-zero directions; larger values
     # aggressively drop real low-curvature directions (which hurts) — keep this tiny.
     ns_steps: int = 5  # Newton-Schulz steps for the polar factor
-    damping: float = 0.0  # additive damping λ on mean-normalized eigenvalues: (w/mean + λ)^{-1/2}.
+    damping: float = 0.0  # additive damping λ on mean-normalized eigenvalues: (w/mean + λ)^{-p}.
     # λ=0 over-amplifies tiny eigenvalues; larger λ bounds the amplification; λ→∞ ⟹ plain Muon.
+    inv_power: float = 0.5  # whitening exponent p in (w/mean+λ)^{-p}: 0.5 = H^{-1/2}, 0.25 = H^{-1/4} (gentler).
 
     # --- variants (ablations) ---
     outer_precond: bool = True  # True: U = H^{-1/2} polar(H^{-1/2} M); False (v1): U = polar(H^{-1/2} M)
@@ -98,6 +99,7 @@ class LeftPrecondMuonConfig(OptimizerConfig):
                         self.real_inverse,
                         self.normalize_fro,
                         self.damping,
+                        self.inv_power,
                     )
                 ]
                 if self.weight_decay > 0:
@@ -148,13 +150,14 @@ class ScaleByLeftPrecondMuonState(NamedTuple):
     h_ema: optax.Updates  # per-matrix gradient second moment EMA, [..., d_out, d_out] (raw arrays)
 
 
-def _inv_sqrt(h, clamp_rel, eps, real_inverse, damping):
-    """H^{-1/2}. Eigenvalues normalized by the mean (scale-free; H ∝ I ⟹ H^{-1/2} = I).
+def _inv_sqrt(h, clamp_rel, eps, real_inverse, damping, inv_power):
+    """H^{-p}. Eigenvalues normalized by the mean (scale-free; H ∝ I ⟹ H^{-p} ∝ I).
 
     real_inverse=False: truncated pseudo-inverse — zero eigenvalues below clamp_rel·λ_max (fb#265).
-    real_inverse=True : damped real inverse — invert ALL eigenvalues (no truncation).
-    damping λ floors the (mean-normalized) eigenvalues: (w/mean + λ)^{-1/2}, bounding the
-    amplification of tiny eigenvalues; λ→∞ ⟹ H^{-1/2} ∝ I ⟹ plain Muon.
+    real_inverse=True : invert ALL eigenvalues (no truncation).
+    damping λ floors the (mean-normalized) eigenvalues: (w/mean + λ)^{-p}, bounding the
+    amplification of tiny eigenvalues; λ→∞ ⟹ H^{-p} ∝ I ⟹ plain Muon.
+    inv_power p: 0.5 = H^{-1/2}, 0.25 = H^{-1/4} (gentler whitening).
     """
     h = h.astype(jnp.float32)
     h = 0.5 * (h + h.T)
@@ -164,15 +167,13 @@ def _inv_sqrt(h, clamp_rel, eps, real_inverse, damping):
     keep = w > clamp_rel * wmax + eps
     mean_kept = jnp.sum(jnp.where(keep, w, 0.0)) / jnp.maximum(jnp.sum(keep), 1.0)
     wn = w / (mean_kept + eps)
-    if real_inverse:
-        inv = 1.0 / jnp.sqrt(wn + damping + eps)  # invert all (no truncation)
-    else:
-        inv = jnp.where(keep, 1.0 / jnp.sqrt(wn + damping + eps), 0.0)
+    pw = (wn + damping + eps) ** (-inv_power)
+    inv = pw if real_inverse else jnp.where(keep, pw, 0.0)
     return (u * inv[None, :]) @ u.T
 
 
 def _left_precond_matrix(
-    m, h, *, clamp_rel, ns_steps, eps, use_kimi_scaling, outer_precond, real_inverse, normalize_fro, damping
+    m, h, *, clamp_rel, ns_steps, eps, use_kimi_scaling, outer_precond, real_inverse, normalize_fro, damping, inv_power
 ):
     """U for one weight M (d_out × d_in), H (d_out × d_out).
 
@@ -180,7 +181,7 @@ def _left_precond_matrix(
     """
     orig_dtype = m.dtype
     x = m.astype(jnp.float32)
-    hih = _inv_sqrt(h, clamp_rel, eps, real_inverse, damping)  # (out, out)
+    hih = _inv_sqrt(h, clamp_rel, eps, real_inverse, damping, inv_power)  # (out, out)
     whitened = hih @ x  # H^{-1/2} M
     ortho = zeropower_via_newtonschulz5(whitened, steps=ns_steps, eps=eps, coefficient_type="quintic")
     u = (hih @ ortho) if outer_precond else ortho
@@ -208,6 +209,7 @@ def scale_with_left_precond_muon(
     real_inverse=False,
     normalize_fro=False,
     damping=0.0,
+    inv_power=0.5,
 ):
     momentum = float(momentum)
     h_beta = float(h_beta)
@@ -277,6 +279,7 @@ def scale_with_left_precond_muon(
                 real_inverse=real_inverse,
                 normalize_fro=normalize_fro,
                 damping=damping,
+                inv_power=inv_power,
             )
             new_arr = jax.vmap(fn)(arr, h) if arr.ndim == 3 else fn(arr, h)
             return dataclasses.replace(layer, weight=dataclasses.replace(w, array=new_arr))  # type: ignore

--- a/lib/levanter/src/levanter/optim/left_precond_muon.py
+++ b/lib/levanter/src/levanter/optim/left_precond_muon.py
@@ -1,0 +1,249 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Left-preconditioned Muon (Ali Jadbabaie's "idea 4").
+
+Muon orthogonalizes the (momentum) gradient via its matrix sign / polar factor.
+**Left-preconditioned** Muon additionally whitens on the *output* side by the gradient's
+own left second moment ``H = EMA(G Gᵀ)`` (the Shampoo-style left factor). For a weight
+``W`` (d_out × d_in) with momentum ``M`` and gradient second moment ``H`` (d_out × d_out):
+
+    U = ρ · H^{-1/2} · polar( H^{-1/2} · M )           (polar = matrix sign = NS5)
+    W ← W − η · U
+
+i.e. whiten on the left by ``H^{-1/2}``, orthogonalize, whiten again. ``H = I`` recovers plain
+Muon. Unlike idea 3 (which whitened by the *activation* second moment AAᵀ and needed forward
+capture), ``H`` here is built from the gradient alone — so this is a pure optimizer with no
+trainer/model changes. Using the EMA (rather than the current ``G Gᵀ``) keeps it non-degenerate:
+``H^{-1/2}M`` is not the polar factor of ``M`` because ``H`` reflects the gradient's *history*.
+
+``H^{-1/2}`` uses a **truncated (rank-)pseudo-inverse** (facebookresearch/optimizers#265): tiny
+eigenvalues are zeroed rather than blown up by the inverse root, which is more stable than a
+plain inverse-root or additive damping. The eigenvalues are normalized by the mean kept
+eigenvalue first, so ``H^{-1/2}`` is scale-free and the update magnitude (and the learning rate)
+stays comparable to Muon.
+"""
+
+import dataclasses
+from dataclasses import dataclass
+from functools import partial
+from typing import NamedTuple, Optional
+
+import jax
+import jax.numpy as jnp
+import optax
+from optax import tree_utils as otu
+
+import haliax
+
+from levanter.optim.config import OptimizerConfig
+from levanter.optim.util import (
+    flatten_linear_layers,
+    label_linear_like_module,
+    unflatten_linear_layers,
+    zeropower_via_newtonschulz5,
+)
+from levanter.utils.jax_utils import leaf_key_paths
+
+
+@OptimizerConfig.register_subclass("left_precond_muon")
+@dataclass(frozen=True)
+class LeftPrecondMuonConfig(OptimizerConfig):
+    """Left-preconditioned Muon (idea 4): U = ρ H^{-1/2} polar(H^{-1/2} M), H = EMA(G Gᵀ)."""
+
+    # --- the new knobs (vs Muon) ---
+    h_beta: float = 0.95  # EMA decay for the gradient second moment H = EMA(G Gᵀ)
+    clamp_rel: float = 1e-6  # truncated pseudo-inverse: zero eigenvalues below clamp_rel · λ_max
+    ns_steps: int = 5  # Newton-Schulz steps for the polar factor
+
+    # --- Muon-shared knobs ---
+    lr: float = 0.02
+    adam_lr: float = 6e-4
+    momentum: float = 0.95
+    nesterov: bool = True
+    weight_decay: float = 0.0
+    adam_weight_decay: Optional[float] = None
+    beta1: float = 0.9
+    beta2: float = 0.95
+    epsilon: float = 1e-8
+    matrix_epsilon: float = 1e-7  # NS5 normalization floor
+    max_grad_norm: float = 1.0
+    use_kimi_scaling: bool = False
+
+    def build(self, num_train_steps):
+        learning_rate_schedule = self.lr_scheduler(num_train_steps)
+        adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
+
+        def optimizer(learning_rate, adam_lr):
+            def matrix_transform():
+                components = [
+                    scale_with_left_precond_muon(
+                        self.momentum,
+                        self.nesterov,
+                        self.h_beta,
+                        self.clamp_rel,
+                        self.ns_steps,
+                        self.matrix_epsilon,
+                        self.use_kimi_scaling,
+                    )
+                ]
+                if self.weight_decay > 0:
+                    components.append(optax.add_decayed_weights(self.weight_decay, self.build_weight_decay_mask()))
+                components.append(optax.scale(-learning_rate))
+                return optax.chain(*components)
+
+            def adamw_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
+                adam_weight_decay = self.adam_weight_decay if self.adam_weight_decay is not None else self.weight_decay
+                if adam_weight_decay > 0:
+                    components.append(optax.add_decayed_weights(adam_weight_decay, self.build_weight_decay_mask()))
+                components.append(optax.scale(-adam_lr))
+                return optax.chain(*components)
+
+            transformations = {
+                "left_precond_muon": matrix_transform(),
+                "adamw": adamw_transform(),
+            }
+            return optax.multi_transform(
+                transformations, partial(self.create_mask, use_kimi_scaling=self.use_kimi_scaling)
+            )
+
+        return optax.inject_hyperparams(optimizer)(learning_rate=learning_rate_schedule, adam_lr=adam_lr_schedule)
+
+    def create_mask(self, params, use_kimi_scaling=True):
+        """Label matrix (Linear) weights 'left_precond_muon', everything else 'adamw' (matches Muon)."""
+        paths = leaf_key_paths(params)
+
+        def mask_fn(param, path):
+            path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
+            if "Embedding" in path_str or "lm_head" in path_str:
+                return "adamw"
+            elif isinstance(param, haliax.nn.Linear):
+                assert param._out_first or use_kimi_scaling
+                return label_linear_like_module(param, weight_label="left_precond_muon", bias_label="adamw")
+            else:
+                return "adamw"
+
+        return haliax.tree_util.tree_map(mask_fn, params, paths, is_leaf=lambda x: isinstance(x, haliax.nn.Linear))
+
+
+class ScaleByLeftPrecondMuonState(NamedTuple):
+    momentum_buffer: optax.Updates
+    h_ema: optax.Updates  # per-matrix gradient second moment EMA, [..., d_out, d_out] (raw arrays)
+
+
+def _trunc_inv_sqrt(h, clamp_rel, eps):
+    """H^{-1/2} via truncated pseudo-inverse: zero eigenvalues below clamp_rel·λ_max (fb#265).
+
+    Eigenvalues are normalized by the mean kept eigenvalue first, so the result is scale-free
+    (H ∝ I ⟹ H^{-1/2} = I) and the update stays Muon-scaled.
+    """
+    h = h.astype(jnp.float32)
+    h = 0.5 * (h + h.T)
+    w, u = jnp.linalg.eigh(h)
+    w = jnp.maximum(w, 0.0)
+    wmax = jnp.max(w)
+    keep = w > clamp_rel * wmax + eps
+    mean_kept = jnp.sum(jnp.where(keep, w, 0.0)) / jnp.maximum(jnp.sum(keep), 1.0)
+    wn = w / (mean_kept + eps)
+    inv = jnp.where(keep, 1.0 / jnp.sqrt(wn + eps), 0.0)
+    return (u * inv[None, :]) @ u.T
+
+
+def _left_precond_matrix(m, h, *, clamp_rel, ns_steps, eps, use_kimi_scaling):
+    """U = H^{-1/2} polar(H^{-1/2} M) for one weight M (d_out × d_in), H (d_out × d_out)."""
+    orig_dtype = m.dtype
+    x = m.astype(jnp.float32)
+    hih = _trunc_inv_sqrt(h, clamp_rel, eps)  # (out, out)
+    whitened = hih @ x  # H^{-1/2} M
+    ortho = zeropower_via_newtonschulz5(whitened, steps=ns_steps, eps=eps, coefficient_type="quintic")
+    u = hih @ ortho  # H^{-1/2} polar(·)
+
+    if not use_kimi_scaling:
+        scale = jnp.sqrt(jnp.maximum(1.0, u.shape[0] / u.shape[1]))  # sqrt(Out/In)
+    else:
+        scale = 0.2 * jnp.sqrt(jnp.maximum(u.shape[0], u.shape[1]))
+    return (u * scale).astype(orig_dtype)
+
+
+def scale_with_left_precond_muon(
+    momentum=0.95, nesterov=True, h_beta=0.95, clamp_rel=1e-6, ns_steps=5, eps=1e-7, use_kimi_scaling=False
+):
+    momentum = float(momentum)
+    h_beta = float(h_beta)
+    clamp_rel = float(clamp_rel)
+
+    def _gram(weight_array):
+        # weight_array: [..., out, in] → left Gram [..., out, out] = G Gᵀ (sum over in)
+        x = weight_array.astype(jnp.float32)
+        return jnp.einsum("...oi,...pi->...op", x, x)
+
+    def init_fn(params):
+        flat = flatten_linear_layers(params)
+
+        def to_h(layer):
+            if isinstance(layer, haliax.nn.Linear) and isinstance(layer.weight, haliax.NamedArray):
+                a = layer.weight.array
+                return jnp.zeros(a.shape[:-1] + (a.shape[-2],), jnp.float32)  # [..., out, out]
+            return layer  # passthrough non-Linear leaves so h_ema matches the flattened structure
+
+        h_ema = haliax.tree_util.tree_map(to_h, flat, is_leaf=lambda x: isinstance(x, haliax.nn.Linear))
+        return ScaleByLeftPrecondMuonState(momentum_buffer=otu.tree_zeros_like(params), h_ema=h_ema)
+
+    def update_fn(updates, state, params=None):
+        # momentum on the search direction (like Muon)
+        buf = jax.tree.map(
+            lambda m, g: None if g is None else momentum * m + g,
+            state.momentum_buffer,
+            updates,
+            is_leaf=lambda x: x is None,
+        )
+        direction = (
+            jax.tree.map(
+                lambda m, g: None if g is None else momentum * m + g, buf, updates, is_leaf=lambda x: x is None
+            )
+            if nesterov
+            else buf
+        )
+
+        # update H = EMA(G Gᵀ) from the RAW gradient (flattened to 2D-per-layer)
+        flat_grad = flatten_linear_layers(updates)
+
+        def new_h(layer, h):
+            if not (isinstance(layer, haliax.nn.Linear) and isinstance(layer.weight, haliax.NamedArray)):
+                return h
+            return h_beta * h + (1.0 - h_beta) * _gram(layer.weight.array)
+
+        h_ema = haliax.tree_util.tree_map(
+            new_h, flat_grad, state.h_ema, is_leaf=lambda x: isinstance(x, haliax.nn.Linear)
+        )
+
+        # apply U = H^{-1/2} polar(H^{-1/2} M) per matrix (vmapped over the stacked Layer axis)
+        flat_dir = flatten_linear_layers(direction)
+        paths = leaf_key_paths(flat_dir, is_leaf=lambda x: isinstance(x, haliax.nn.Linear))
+
+        def precond(layer, h, path):
+            if not (isinstance(layer, haliax.nn.Linear) and isinstance(layer.weight, haliax.NamedArray)):
+                return layer
+            w = layer.weight
+            arr = w.array
+            fn = partial(
+                _left_precond_matrix,
+                clamp_rel=clamp_rel,
+                ns_steps=ns_steps,
+                eps=eps,
+                use_kimi_scaling=use_kimi_scaling,
+            )
+            new_arr = jax.vmap(fn)(arr, h) if arr.ndim == 3 else fn(arr, h)
+            return dataclasses.replace(layer, weight=dataclasses.replace(w, array=new_arr))  # type: ignore
+
+        flat_out = haliax.tree_util.tree_map(
+            precond, flat_dir, h_ema, paths, is_leaf=lambda x: isinstance(x, haliax.nn.Linear)
+        )
+        new_updates = unflatten_linear_layers(direction, flat_out)
+        return new_updates, ScaleByLeftPrecondMuonState(momentum_buffer=buf, h_ema=h_ema)
+
+    return optax.GradientTransformation(init_fn, update_fn)

--- a/lib/levanter/src/levanter/optim/left_precond_muon.py
+++ b/lib/levanter/src/levanter/optim/left_precond_muon.py
@@ -53,7 +53,9 @@ class LeftPrecondMuonConfig(OptimizerConfig):
 
     # --- the new knobs (vs Muon) ---
     h_beta: float = 0.95  # EMA decay for the gradient second moment H = EMA(G Gᵀ)
-    clamp_rel: float = 1e-6  # truncated pseudo-inverse: zero eigenvalues below clamp_rel · λ_max
+    clamp_rel: float = 1e-15  # truncated pseudo-inverse: zero eigenvalues below clamp_rel · λ_max
+    # 1e-15 (= Shampoo / fb#265) truncates only numerically-zero directions; larger values
+    # aggressively drop real low-curvature directions (which hurts) — keep this tiny.
     ns_steps: int = 5  # Newton-Schulz steps for the polar factor
 
     # --- Muon-shared knobs ---

--- a/lib/levanter/src/levanter/optim/left_precond_muon.py
+++ b/lib/levanter/src/levanter/optim/left_precond_muon.py
@@ -1,27 +1,21 @@
 # Copyright The Levanter Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Left-preconditioned Muon (Ali Jadbabaie's "idea 4").
+"""Left-preconditioned Muon (Ali Jadbabaie's "idea 4"), Mudam-style coupled-Newton solver.
 
-Muon orthogonalizes the (momentum) gradient via its matrix sign / polar factor.
-**Left-preconditioned** Muon additionally whitens on the *output* side by the gradient's
-own left second moment ``H = EMA(G Gᵀ)`` (the Shampoo-style left factor). For a weight
-``W`` (d_out × d_in) with momentum ``M`` and gradient second moment ``H`` (d_out × d_out):
+    U = ρ · H^{-1/2} · polar( H^{-1/2} · M ) ,   H = EMA(G Gᵀ)   (output/left side)
 
-    U = ρ · H^{-1/2} · polar( H^{-1/2} · M )           (polar = matrix sign = NS5)
-    W ← W − η · U
+``H^{-1/2}`` is the **saturating coarse inverse-sqrt** ``q_k`` (``solver="qk"``): eigh, then the k-step
+Muon-coeff NS scalar map applied to the (λ_max-normalized) eigenvalues. This reproduces Mudam's
+coupled-NS operator exactly (proven by spectral mapping) and beats the exact ``w^{-1/2}``
+(``solver="eigh"``) because it *caps* the amplification of the smallest/noisiest eigen-directions
+rather than blowing them up — the beneficial regularization that makes Mudam (1.165) beat exact
+whitening (1.185).
 
-i.e. whiten on the left by ``H^{-1/2}``, orthogonalize, whiten again. ``H = I`` recovers plain
-Muon. Unlike idea 3 (which whitened by the *activation* second moment AAᵀ and needed forward
-capture), ``H`` here is built from the gradient alone — so this is a pure optimizer with no
-trainer/model changes. Using the EMA (rather than the current ``G Gᵀ``) keeps it non-degenerate:
-``H^{-1/2}M`` is not the polar factor of ``M`` because ``H`` reflects the gradient's *history*.
-
-``H^{-1/2}`` uses a **truncated (rank-)pseudo-inverse** (facebookresearch/optimizers#265): tiny
-eigenvalues are zeroed rather than blown up by the inverse root, which is more stable than a
-plain inverse-root or additive damping. The eigenvalues are normalized by the mean kept
-eigenvalue first, so ``H^{-1/2}`` is scale-free and the update magnitude (and the learning rate)
-stays comparable to Muon.
+``outer_precond=False`` drops the outer factor, giving ``polar(H^{-1/2} M)`` — provably identical to
+Mudam-with-another_muon. ``outer_precond=True`` is the full idea-4 update; ``outer_msign`` re-
+orthogonalizes after it; ``normalize_fro`` rescales to plain-Muon's Frobenius norm. ``H = I`` recovers
+plain Muon. Gradient-only; no activation capture.
 """
 
 import dataclasses
@@ -51,20 +45,14 @@ from levanter.utils.jax_utils import leaf_key_paths
 class LeftPrecondMuonConfig(OptimizerConfig):
     """Left-preconditioned Muon (idea 4): U = ρ H^{-1/2} polar(H^{-1/2} M), H = EMA(G Gᵀ)."""
 
-    # --- the new knobs (vs Muon) ---
+    # --- the idea-4 knobs ---
     h_beta: float = 0.95  # EMA decay for the gradient second moment H = EMA(G Gᵀ)
-    clamp_rel: float = 1e-15  # truncated pseudo-inverse: zero eigenvalues below clamp_rel · λ_max
-    # 1e-15 (= Shampoo / fb#265) truncates only numerically-zero directions; larger values
-    # aggressively drop real low-curvature directions (which hurts) — keep this tiny.
+    solver: str = "qk"  # "qk": saturating coarse NS-polynomial inverse-sqrt (= Mudam); "eigh": exact w^{-1/2}
+    qk_steps: int = 5  # k in the q_k saturating polynomial (Muon-coeff scalar map on eigenvalues)
+    outer_precond: bool = True  # True: U = H^{-1/2} polar(H^{-1/2} M) (full); False: U = polar(H^{-1/2} M)
+    outer_msign: bool = False  # re-orthogonalize after the outer factor: U = polar(H^{-1/2} polar(H^{-1/2} M))
+    normalize_fro: bool = False  # rescale U to plain-Muon's Frobenius norm (polar(M))
     ns_steps: int = 5  # Newton-Schulz steps for the polar factor
-    damping: float = 0.0  # additive damping λ on mean-normalized eigenvalues: (w/mean + λ)^{-p}.
-    # λ=0 over-amplifies tiny eigenvalues; larger λ bounds the amplification; λ→∞ ⟹ plain Muon.
-    inv_power: float = 0.5  # whitening exponent p in (w/mean+λ)^{-p}: 0.5 = H^{-1/2}, 0.25 = H^{-1/4} (gentler).
-
-    # --- variants (ablations) ---
-    outer_precond: bool = True  # True: U = H^{-1/2} polar(H^{-1/2} M); False (v1): U = polar(H^{-1/2} M)
-    real_inverse: bool = False  # False: truncated pseudo-inverse; True (v2): damped real inverse (no truncation)
-    normalize_fro: bool = False  # True (v3): rescale U to Muon's Frobenius norm √(min(d_out,d_in))
 
     # --- Muon-shared knobs ---
     lr: float = 0.02
@@ -76,7 +64,7 @@ class LeftPrecondMuonConfig(OptimizerConfig):
     beta1: float = 0.9
     beta2: float = 0.95
     epsilon: float = 1e-8
-    matrix_epsilon: float = 1e-7  # NS5 normalization floor
+    matrix_epsilon: float = 1e-7  # NS / normalization floor
     max_grad_norm: float = 1.0
     use_kimi_scaling: bool = False
 
@@ -91,15 +79,14 @@ class LeftPrecondMuonConfig(OptimizerConfig):
                         self.momentum,
                         self.nesterov,
                         self.h_beta,
-                        self.clamp_rel,
+                        self.solver,
+                        self.qk_steps,
                         self.ns_steps,
                         self.matrix_epsilon,
                         self.use_kimi_scaling,
                         self.outer_precond,
-                        self.real_inverse,
+                        self.outer_msign,
                         self.normalize_fro,
-                        self.damping,
-                        self.inv_power,
                     )
                 ]
                 if self.weight_decay > 0:
@@ -118,10 +105,7 @@ class LeftPrecondMuonConfig(OptimizerConfig):
                 components.append(optax.scale(-adam_lr))
                 return optax.chain(*components)
 
-            transformations = {
-                "left_precond_muon": matrix_transform(),
-                "adamw": adamw_transform(),
-            }
+            transformations = {"left_precond_muon": matrix_transform(), "adamw": adamw_transform()}
             return optax.multi_transform(
                 transformations, partial(self.create_mask, use_kimi_scaling=self.use_kimi_scaling)
             )
@@ -150,45 +134,65 @@ class ScaleByLeftPrecondMuonState(NamedTuple):
     h_ema: optax.Updates  # per-matrix gradient second moment EMA, [..., d_out, d_out] (raw arrays)
 
 
-def _inv_sqrt(h, clamp_rel, eps, real_inverse, damping, inv_power):
-    """H^{-p}. Eigenvalues normalized by the mean (scale-free; H ∝ I ⟹ H^{-p} ∝ I).
+_MUON_NS_COEFFS = (3.4445, -4.7750, 2.0315)
 
-    real_inverse=False: truncated pseudo-inverse — zero eigenvalues below clamp_rel·λ_max (fb#265).
-    real_inverse=True : invert ALL eigenvalues (no truncation).
-    damping λ floors the (mean-normalized) eigenvalues: (w/mean + λ)^{-p}, bounding the
-    amplification of tiny eigenvalues; λ→∞ ⟹ H^{-p} ∝ I ⟹ plain Muon.
-    inv_power p: 0.5 = H^{-1/2}, 0.25 = H^{-1/4} (gentler whitening).
+
+def _qk_inv_sqrt(h, steps, eps):
+    """Saturating coarse inverse-sqrt: eigh + the k-step Muon-coeff NS scalar map q_k(w).
+
+    Reproduces Mudam's coupled-NS operator exactly (proven by spectral mapping). Normalize the
+    eigenvalues by λ_max so the spectrum is in (0,1] (the NS convergence basin). As k→∞, q_k(w) →
+    w^{-1/2}; at finite k it SATURATES the amplification of the smallest/noisiest eigen-directions
+    instead of blowing them up — that cap is the beneficial regularization over the exact inverse.
+    Reduces to plain Muon when H ∝ I (all eigenvalues equal → uniform scaling, washed by the polar).
     """
     h = h.astype(jnp.float32)
     h = 0.5 * (h + h.T)
-    w, u = jnp.linalg.eigh(h)
+    w, u_vec = jnp.linalg.eigh(h)
     w = jnp.maximum(w, 0.0)
-    wmax = jnp.max(w)
-    keep = w > clamp_rel * wmax + eps
-    mean_kept = jnp.sum(jnp.where(keep, w, 0.0)) / jnp.maximum(jnp.sum(keep), 1.0)
-    wn = w / (mean_kept + eps)
-    pw = (wn + damping + eps) ** (-inv_power)
-    inv = pw if real_inverse else jnp.where(keep, pw, 0.0)
-    return (u * inv[None, :]) @ u.T
+    lam = w / (jnp.max(w) + eps)  # spectrum in (0, 1]
+    a, b, c = _MUON_NS_COEFFS
+    al = lam
+    mult = jnp.ones_like(lam)
+    for _ in range(steps):
+        f = a + b * al + c * al * al
+        mult = mult * f
+        al = f * f * al
+    return (u_vec * mult) @ u_vec.T
+
+
+def _exact_inv_sqrt(h, eps):
+    """Exact mean-normalized H^{-1/2} via eigh (the un-regularized 'inner_muon' whitening)."""
+    h = h.astype(jnp.float32)
+    h = 0.5 * (h + h.T)
+    w, u_vec = jnp.linalg.eigh(h)
+    w = jnp.maximum(w, 0.0)
+    lam = w / (jnp.mean(w) + eps)
+    inv = jnp.where(lam > 1e-12, lam**-0.5, 0.0)
+    return (u_vec * inv) @ u_vec.T
 
 
 def _left_precond_matrix(
-    m, h, *, clamp_rel, ns_steps, eps, use_kimi_scaling, outer_precond, real_inverse, normalize_fro, damping, inv_power
+    m, h, *, solver, qk_steps, ns_steps, eps, use_kimi_scaling, outer_precond, outer_msign, normalize_fro
 ):
-    """U for one weight M (d_out × d_in), H (d_out × d_out).
+    """U = H^{-1/2} polar(H^{-1/2} M) for one weight M (d_out × d_in), H (d_out × d_out).
 
-    Full (idea 4): U = H^{-1/2} polar(H^{-1/2} M). outer_precond=False drops the outer factor.
+    outer_precond=False drops the outer H^{-1/2} (gives polar(H^{-1/2} M)).
+    outer_msign re-orthogonalizes after the outer factor: U = polar(H^{-1/2} polar(H^{-1/2} M)).
+    normalize_fro rescales U to plain-Muon's Frobenius norm (polar(M)).
     """
     orig_dtype = m.dtype
     x = m.astype(jnp.float32)
-    hih = _inv_sqrt(h, clamp_rel, eps, real_inverse, damping, inv_power)  # (out, out)
+    hih = _qk_inv_sqrt(h, qk_steps, eps) if solver == "qk" else _exact_inv_sqrt(h, eps)  # (out, out)
     whitened = hih @ x  # H^{-1/2} M
     ortho = zeropower_via_newtonschulz5(whitened, steps=ns_steps, eps=eps, coefficient_type="quintic")
     u = (hih @ ortho) if outer_precond else ortho
+    if outer_msign:
+        u = zeropower_via_newtonschulz5(u, steps=ns_steps, eps=eps, coefficient_type="quintic")
 
     if normalize_fro:
-        k = min(u.shape[0], u.shape[1])
-        u = u * (jnp.sqrt(jnp.float32(k)) / (jnp.linalg.norm(u) + eps))
+        muon = zeropower_via_newtonschulz5(x, steps=ns_steps, eps=eps, coefficient_type="quintic")
+        u = u * (jnp.linalg.norm(muon) / (jnp.linalg.norm(u) + eps))
 
     if not use_kimi_scaling:
         scale = jnp.sqrt(jnp.maximum(1.0, u.shape[0] / u.shape[1]))  # sqrt(Out/In)
@@ -201,19 +205,17 @@ def scale_with_left_precond_muon(
     momentum=0.95,
     nesterov=True,
     h_beta=0.95,
-    clamp_rel=1e-15,
+    solver="qk",
+    qk_steps=5,
     ns_steps=5,
     eps=1e-7,
     use_kimi_scaling=False,
     outer_precond=True,
-    real_inverse=False,
+    outer_msign=False,
     normalize_fro=False,
-    damping=0.0,
-    inv_power=0.5,
 ):
     momentum = float(momentum)
     h_beta = float(h_beta)
-    clamp_rel = float(clamp_rel)
 
     def _gram(weight_array):
         # weight_array: [..., out, in] → left Gram [..., out, out] = G Gᵀ (sum over in)
@@ -233,7 +235,6 @@ def scale_with_left_precond_muon(
         return ScaleByLeftPrecondMuonState(momentum_buffer=otu.tree_zeros_like(params), h_ema=h_ema)
 
     def update_fn(updates, state, params=None):
-        # momentum on the search direction (like Muon)
         buf = jax.tree.map(
             lambda m, g: None if g is None else momentum * m + g,
             state.momentum_buffer,
@@ -248,7 +249,7 @@ def scale_with_left_precond_muon(
             else buf
         )
 
-        # update H = EMA(G Gᵀ) from the RAW gradient (flattened to 2D-per-layer)
+        # H = EMA(G Gᵀ) from the RAW gradient; newest term = current gradient.
         flat_grad = flatten_linear_layers(updates)
 
         def new_h(layer, h):
@@ -260,32 +261,29 @@ def scale_with_left_precond_muon(
             new_h, flat_grad, state.h_ema, is_leaf=lambda x: isinstance(x, haliax.nn.Linear)
         )
 
-        # apply U = H^{-1/2} polar(H^{-1/2} M) per matrix (vmapped over the stacked Layer axis)
         flat_dir = flatten_linear_layers(direction)
-        paths = leaf_key_paths(flat_dir, is_leaf=lambda x: isinstance(x, haliax.nn.Linear))
 
-        def precond(layer, h, path):
+        def precond(layer, h):
             if not (isinstance(layer, haliax.nn.Linear) and isinstance(layer.weight, haliax.NamedArray)):
                 return layer
             w = layer.weight
             arr = w.array
             fn = partial(
                 _left_precond_matrix,
-                clamp_rel=clamp_rel,
+                solver=solver,
+                qk_steps=qk_steps,
                 ns_steps=ns_steps,
                 eps=eps,
                 use_kimi_scaling=use_kimi_scaling,
                 outer_precond=outer_precond,
-                real_inverse=real_inverse,
+                outer_msign=outer_msign,
                 normalize_fro=normalize_fro,
-                damping=damping,
-                inv_power=inv_power,
             )
             new_arr = jax.vmap(fn)(arr, h) if arr.ndim == 3 else fn(arr, h)
             return dataclasses.replace(layer, weight=dataclasses.replace(w, array=new_arr))  # type: ignore
 
         flat_out = haliax.tree_util.tree_map(
-            precond, flat_dir, h_ema, paths, is_leaf=lambda x: isinstance(x, haliax.nn.Linear)
+            precond, flat_dir, h_ema, is_leaf=lambda x: isinstance(x, haliax.nn.Linear)
         )
         new_updates = unflatten_linear_layers(direction, flat_out)
         return new_updates, ScaleByLeftPrecondMuonState(momentum_buffer=buf, h_ema=h_ema)

--- a/lib/levanter/src/levanter/optim/left_precond_muon.py
+++ b/lib/levanter/src/levanter/optim/left_precond_muon.py
@@ -57,6 +57,8 @@ class LeftPrecondMuonConfig(OptimizerConfig):
     # 1e-15 (= Shampoo / fb#265) truncates only numerically-zero directions; larger values
     # aggressively drop real low-curvature directions (which hurts) — keep this tiny.
     ns_steps: int = 5  # Newton-Schulz steps for the polar factor
+    damping: float = 0.0  # additive damping λ on mean-normalized eigenvalues: (w/mean + λ)^{-1/2}.
+    # λ=0 over-amplifies tiny eigenvalues; larger λ bounds the amplification; λ→∞ ⟹ plain Muon.
 
     # --- variants (ablations) ---
     outer_precond: bool = True  # True: U = H^{-1/2} polar(H^{-1/2} M); False (v1): U = polar(H^{-1/2} M)
@@ -95,6 +97,7 @@ class LeftPrecondMuonConfig(OptimizerConfig):
                         self.outer_precond,
                         self.real_inverse,
                         self.normalize_fro,
+                        self.damping,
                     )
                 ]
                 if self.weight_decay > 0:
@@ -145,11 +148,13 @@ class ScaleByLeftPrecondMuonState(NamedTuple):
     h_ema: optax.Updates  # per-matrix gradient second moment EMA, [..., d_out, d_out] (raw arrays)
 
 
-def _inv_sqrt(h, clamp_rel, eps, real_inverse):
+def _inv_sqrt(h, clamp_rel, eps, real_inverse, damping):
     """H^{-1/2}. Eigenvalues normalized by the mean (scale-free; H ∝ I ⟹ H^{-1/2} = I).
 
     real_inverse=False: truncated pseudo-inverse — zero eigenvalues below clamp_rel·λ_max (fb#265).
-    real_inverse=True : damped real inverse — invert ALL eigenvalues (no truncation), eps-damped.
+    real_inverse=True : damped real inverse — invert ALL eigenvalues (no truncation).
+    damping λ floors the (mean-normalized) eigenvalues: (w/mean + λ)^{-1/2}, bounding the
+    amplification of tiny eigenvalues; λ→∞ ⟹ H^{-1/2} ∝ I ⟹ plain Muon.
     """
     h = h.astype(jnp.float32)
     h = 0.5 * (h + h.T)
@@ -160,14 +165,14 @@ def _inv_sqrt(h, clamp_rel, eps, real_inverse):
     mean_kept = jnp.sum(jnp.where(keep, w, 0.0)) / jnp.maximum(jnp.sum(keep), 1.0)
     wn = w / (mean_kept + eps)
     if real_inverse:
-        inv = 1.0 / jnp.sqrt(wn + eps)  # invert all (no truncation)
+        inv = 1.0 / jnp.sqrt(wn + damping + eps)  # invert all (no truncation)
     else:
-        inv = jnp.where(keep, 1.0 / jnp.sqrt(wn + eps), 0.0)
+        inv = jnp.where(keep, 1.0 / jnp.sqrt(wn + damping + eps), 0.0)
     return (u * inv[None, :]) @ u.T
 
 
 def _left_precond_matrix(
-    m, h, *, clamp_rel, ns_steps, eps, use_kimi_scaling, outer_precond, real_inverse, normalize_fro
+    m, h, *, clamp_rel, ns_steps, eps, use_kimi_scaling, outer_precond, real_inverse, normalize_fro, damping
 ):
     """U for one weight M (d_out × d_in), H (d_out × d_out).
 
@@ -175,7 +180,7 @@ def _left_precond_matrix(
     """
     orig_dtype = m.dtype
     x = m.astype(jnp.float32)
-    hih = _inv_sqrt(h, clamp_rel, eps, real_inverse)  # (out, out)
+    hih = _inv_sqrt(h, clamp_rel, eps, real_inverse, damping)  # (out, out)
     whitened = hih @ x  # H^{-1/2} M
     ortho = zeropower_via_newtonschulz5(whitened, steps=ns_steps, eps=eps, coefficient_type="quintic")
     u = (hih @ ortho) if outer_precond else ortho
@@ -202,6 +207,7 @@ def scale_with_left_precond_muon(
     outer_precond=True,
     real_inverse=False,
     normalize_fro=False,
+    damping=0.0,
 ):
     momentum = float(momentum)
     h_beta = float(h_beta)
@@ -270,6 +276,7 @@ def scale_with_left_precond_muon(
                 outer_precond=outer_precond,
                 real_inverse=real_inverse,
                 normalize_fro=normalize_fro,
+                damping=damping,
             )
             new_arr = jax.vmap(fn)(arr, h) if arr.ndim == 3 else fn(arr, h)
             return dataclasses.replace(layer, weight=dataclasses.replace(w, array=new_arr))  # type: ignore

--- a/lib/levanter/src/levanter/optim/left_precond_muon.py
+++ b/lib/levanter/src/levanter/optim/left_precond_muon.py
@@ -58,6 +58,11 @@ class LeftPrecondMuonConfig(OptimizerConfig):
     # aggressively drop real low-curvature directions (which hurts) — keep this tiny.
     ns_steps: int = 5  # Newton-Schulz steps for the polar factor
 
+    # --- variants (ablations) ---
+    outer_precond: bool = True  # True: U = H^{-1/2} polar(H^{-1/2} M); False (v1): U = polar(H^{-1/2} M)
+    real_inverse: bool = False  # False: truncated pseudo-inverse; True (v2): damped real inverse (no truncation)
+    normalize_fro: bool = False  # True (v3): rescale U to Muon's Frobenius norm √(min(d_out,d_in))
+
     # --- Muon-shared knobs ---
     lr: float = 0.02
     adam_lr: float = 6e-4
@@ -87,6 +92,9 @@ class LeftPrecondMuonConfig(OptimizerConfig):
                         self.ns_steps,
                         self.matrix_epsilon,
                         self.use_kimi_scaling,
+                        self.outer_precond,
+                        self.real_inverse,
+                        self.normalize_fro,
                     )
                 ]
                 if self.weight_decay > 0:
@@ -137,11 +145,11 @@ class ScaleByLeftPrecondMuonState(NamedTuple):
     h_ema: optax.Updates  # per-matrix gradient second moment EMA, [..., d_out, d_out] (raw arrays)
 
 
-def _trunc_inv_sqrt(h, clamp_rel, eps):
-    """H^{-1/2} via truncated pseudo-inverse: zero eigenvalues below clamp_rel·λ_max (fb#265).
+def _inv_sqrt(h, clamp_rel, eps, real_inverse):
+    """H^{-1/2}. Eigenvalues normalized by the mean (scale-free; H ∝ I ⟹ H^{-1/2} = I).
 
-    Eigenvalues are normalized by the mean kept eigenvalue first, so the result is scale-free
-    (H ∝ I ⟹ H^{-1/2} = I) and the update stays Muon-scaled.
+    real_inverse=False: truncated pseudo-inverse — zero eigenvalues below clamp_rel·λ_max (fb#265).
+    real_inverse=True : damped real inverse — invert ALL eigenvalues (no truncation), eps-damped.
     """
     h = h.astype(jnp.float32)
     h = 0.5 * (h + h.T)
@@ -151,18 +159,30 @@ def _trunc_inv_sqrt(h, clamp_rel, eps):
     keep = w > clamp_rel * wmax + eps
     mean_kept = jnp.sum(jnp.where(keep, w, 0.0)) / jnp.maximum(jnp.sum(keep), 1.0)
     wn = w / (mean_kept + eps)
-    inv = jnp.where(keep, 1.0 / jnp.sqrt(wn + eps), 0.0)
+    if real_inverse:
+        inv = 1.0 / jnp.sqrt(wn + eps)  # invert all (no truncation)
+    else:
+        inv = jnp.where(keep, 1.0 / jnp.sqrt(wn + eps), 0.0)
     return (u * inv[None, :]) @ u.T
 
 
-def _left_precond_matrix(m, h, *, clamp_rel, ns_steps, eps, use_kimi_scaling):
-    """U = H^{-1/2} polar(H^{-1/2} M) for one weight M (d_out × d_in), H (d_out × d_out)."""
+def _left_precond_matrix(
+    m, h, *, clamp_rel, ns_steps, eps, use_kimi_scaling, outer_precond, real_inverse, normalize_fro
+):
+    """U for one weight M (d_out × d_in), H (d_out × d_out).
+
+    Full (idea 4): U = H^{-1/2} polar(H^{-1/2} M). outer_precond=False drops the outer factor.
+    """
     orig_dtype = m.dtype
     x = m.astype(jnp.float32)
-    hih = _trunc_inv_sqrt(h, clamp_rel, eps)  # (out, out)
+    hih = _inv_sqrt(h, clamp_rel, eps, real_inverse)  # (out, out)
     whitened = hih @ x  # H^{-1/2} M
     ortho = zeropower_via_newtonschulz5(whitened, steps=ns_steps, eps=eps, coefficient_type="quintic")
-    u = hih @ ortho  # H^{-1/2} polar(·)
+    u = (hih @ ortho) if outer_precond else ortho
+
+    if normalize_fro:
+        k = min(u.shape[0], u.shape[1])
+        u = u * (jnp.sqrt(jnp.float32(k)) / (jnp.linalg.norm(u) + eps))
 
     if not use_kimi_scaling:
         scale = jnp.sqrt(jnp.maximum(1.0, u.shape[0] / u.shape[1]))  # sqrt(Out/In)
@@ -172,7 +192,16 @@ def _left_precond_matrix(m, h, *, clamp_rel, ns_steps, eps, use_kimi_scaling):
 
 
 def scale_with_left_precond_muon(
-    momentum=0.95, nesterov=True, h_beta=0.95, clamp_rel=1e-6, ns_steps=5, eps=1e-7, use_kimi_scaling=False
+    momentum=0.95,
+    nesterov=True,
+    h_beta=0.95,
+    clamp_rel=1e-15,
+    ns_steps=5,
+    eps=1e-7,
+    use_kimi_scaling=False,
+    outer_precond=True,
+    real_inverse=False,
+    normalize_fro=False,
 ):
     momentum = float(momentum)
     h_beta = float(h_beta)
@@ -238,6 +267,9 @@ def scale_with_left_precond_muon(
                 ns_steps=ns_steps,
                 eps=eps,
                 use_kimi_scaling=use_kimi_scaling,
+                outer_precond=outer_precond,
+                real_inverse=real_inverse,
+                normalize_fro=normalize_fro,
             )
             new_arr = jax.vmap(fn)(arr, h) if arr.ndim == 3 else fn(arr, h)
             return dataclasses.replace(layer, weight=dataclasses.replace(w, array=new_arr))  # type: ignore

--- a/lib/levanter/src/levanter/optim/mudam.py
+++ b/lib/levanter/src/levanter/optim/mudam.py
@@ -135,7 +135,10 @@ class MudamConfig(OptimizerConfig):
                     )
                 )
                 if self.weight_decay > 0:
-                    components.append(optax.add_decayed_weights(self.weight_decay, self.build_weight_decay_mask()))
+                    # No mask: the muon group is only Linear weights (norms/biases are routed to
+                    # adamw), so decay applies to all of them — and build_weight_decay_mask() crashes
+                    # on the masked qk_norm NamedArrays (MaskedNode) that land in this group.
+                    components.append(optax.add_decayed_weights(self.weight_decay))
                 components.append(optax.scale(-learning_rate))
                 optimizer = optax.chain(*components)
                 return optimizer

--- a/lib/levanter/src/levanter/optim/mudam.py
+++ b/lib/levanter/src/levanter/optim/mudam.py
@@ -153,11 +153,17 @@ class MudamConfig(OptimizerConfig):
                 optimizer = optax.chain(*components)
                 return optimizer
 
-            transformations = {
-                "muon_left": muon_transform(prefer_input_side=False),
-                "muon_right": muon_transform(prefer_input_side=True),
-                "adamw": adamw_transform(),
-            }
+            # Only include the muon group(s) the mask actually routes to — otherwise
+            # multi_transform inits the unused group on an all-masked tree, which crashes
+            # Mudam's raw shape inference on MaskedNode leaves.
+            transformations = {"adamw": adamw_transform()}
+            if self.prefer_embedding_side:
+                transformations["muon_left"] = muon_transform(prefer_input_side=False)
+                transformations["muon_right"] = muon_transform(prefer_input_side=True)
+            elif self.prefer_input_side:
+                transformations["muon_right"] = muon_transform(prefer_input_side=True)
+            else:
+                transformations["muon_left"] = muon_transform(prefer_input_side=False)
 
             return optax.multi_transform(
                 transformations,
@@ -922,15 +928,10 @@ def init_conditioner(
     if len(p_shape) == 1:
         return ([jnp.zeros((p_shape[0], p_shape[0]), dtype=dtype)], [PartitionSpec()])
 
-    # sharding purpose
-    mesh = hax.partitioning._get_mesh()
-    if mesh.devices.shape == ():
-        mesh = None
-    # get fsdp mesh axis
-    if mesh is not None:
-        fsdp_axis_name = hax.partitioning.ResourceAxis.DATA
-        fsdp_axis = mesh.axis_names.index(fsdp_axis_name)
-        fsdp_size = mesh.devices.shape[fsdp_axis]
+    # sharding purpose. NOTE: replicate the (small) GG conditioners — robust to JAX AbstractMesh
+    # during optimizer init (mesh.devices is unavailable on AbstractMesh). Fine at 130m.
+    mesh = None
+    fsdp_axis_name = hax.partitioning.ResourceAxis.DATA
 
     sharding_out = [PartitionSpec(None)] * len(p_shape)
     preconditioner_types = _get_preconditioner_types(p_shape, max_precond_dim, prefer_input_side, force_full_rank)

--- a/lib/levanter/src/levanter/optim/mudam.py
+++ b/lib/levanter/src/levanter/optim/mudam.py
@@ -1,0 +1,1158 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mudam — Shampoo-Muon: a block-partitioned Shampoo preconditioner composed with Muon.
+
+For each matrix (Linear) weight the update is, on one side (input "right" or output "left"):
+
+    M  = EMA_b1(G)                                   # first moment (momentum, Nesterov optional)
+    H  = EMA_b2(G Gᵀ  or  Gᵀ G)                       # Shampoo one-sided second moment (shampoo_beta)
+    Ĝ  = H^{-1/4} M    (or H^{-1/2} M)                # Shampoo whitening on the preferred side
+    U  = muon_normalize(Ĝ)                            # Newton-Schulz orthogonalization (+ Kimi scaling)
+    W ← W − η · U
+
+i.e. a one-sided Shampoo preconditioner feeding a Muon orthogonalization — hence "Shampoo-Muon".
+Large matrices are **block-partitioned** (``block_size``, ``partition_grads_into_blocks``) and small
+dims optionally **merged** (``merge_small_dims``) to bound the eigendecomposition cost, à la
+distributed Shampoo / SOAP. ``prefer_input_side`` chooses the right (input) vs left (output) factor;
+``o_proj`` can be flipped to the embedding side. Embeddings / lm_head / biases use AdamW.
+
+Knobs of note: ``shampoo_beta`` (H EMA), ``block_size``/``merge_small_dims`` (cost control),
+``normalization`` (``"muon"`` orthogonalization), ``use_scaling`` (``"kimi"`` LR scaling),
+``interpolation_to_muon`` / ``debug_to_muon`` (ablate back to plain Muon), and momentum/Nesterov
+placement in the first/second moments. Authored by Kaiyue Wen; ported from a standalone levanter
+checkout. Variants ``Mudam2Config`` / ``Mudam3Config`` are later iterations of the same idea.
+"""
+
+from collections import defaultdict
+from dataclasses import dataclass
+from functools import partial
+from itertools import chain
+from typing import Any, List, Optional, Tuple, Union
+import dataclasses
+import jax
+import jax.numpy as jnp
+import numpy as np
+import optax
+import optax.tree_utils as otu
+import chex
+from jax import vmap
+from jax.lax import with_sharding_constraint
+from jax.sharding import PartitionSpec
+from jaxtyping import Array
+from optax import GradientTransformation, Updates
+from optax._src.utils import canonicalize_dtype
+
+import haliax as hax
+
+from levanter.optim.config import OptimizerConfig
+from levanter.utils.jax_utils import leaf_key_paths
+from haliax.nn import Linear
+
+jax.config.update("jax_enable_x64", False)
+
+
+@OptimizerConfig.register_subclass("mudam")
+@dataclass(frozen=True)
+class MudamConfig(OptimizerConfig):
+    weight_decay: float = 0.0
+    beta1: float = 0.95
+    momentum: float = 0.95
+    momentum_2: float = 1.0
+    momentum_out: float = 1.0
+    shampoo_beta: float = 0.95
+    muon_epsilon: float = 1e-5
+    beta2: float = 0.95
+    epsilon: float = 1e-8
+    max_grad_norm: Optional[float] = 1.0
+    haps: Optional[list[int]] = None
+    schedule_list: Optional[list[str]] = None
+    max_precond_dim: int = 10000
+    merge_small_dims: bool = True
+    target_merged_dim_size: int = 2048
+    mu_dtype: Optional[str] = None
+    precond_dtype: Optional[str] = None
+    partition_grads_into_blocks: bool = False
+    adam_lr: float = 6e-4
+    block_size: int = 256
+    steps: int = 5
+    force_full_rank: bool = False
+    normalize_gradient: bool = False
+    use_mudam_for_embedding: bool = False
+    use_nesterov_in_second_moment: bool = False
+    use_momentum_in_second_moment: bool = False
+    prefer_embedding_side: bool = False
+    prefer_input_side: bool = True
+    update_normed: bool = False
+    use_nesterov_in_first_moment: bool = True
+    nesterov_adam: bool = True
+    another_muon: Optional[bool] = None
+    normalization: Optional[str] = "muon"
+    use_scaling: Optional[str] = "kimi"
+    interpolation_to_muon: float = 0.0
+    debug_to_muon: bool = False
+    spectral_normalize: bool = False
+
+    def build(self, num_train_steps):
+        """Creates the optimizer"""
+        learning_rate_schedule = self.lr_scheduler(num_train_steps)
+        adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
+
+        # indirection makes it work with optax.inject_hyperparams so we can log the learning rate
+        def optimizer(learning_rate, adam_lr):
+
+            def muon_transform(prefer_input_side: bool = True):
+                components = []
+                components.append(
+                    scale_by_mudam(
+                        b1=self.momentum,
+                        b1_2=self.momentum_2,
+                        b1_out=self.momentum_out,
+                        b2=self.shampoo_beta,
+                        steps=self.steps,
+                        epsilon=self.epsilon,
+                        muon_epsilon=self.muon_epsilon,
+                        max_precond_dim=self.max_precond_dim,
+                        merge_small_dims=self.merge_small_dims,
+                        target_merged_dim_size=self.target_merged_dim_size,
+                        mu_dtype=self.mu_dtype,
+                        interpolation_to_muon=self.interpolation_to_muon,
+                        precond_dtype=self.precond_dtype,
+                        partition_grads_into_blocks=self.partition_grads_into_blocks,
+                        normalize_gradient=self.normalize_gradient,
+                        block_size=self.block_size,
+                        use_nesterov_in_second_moment=self.use_nesterov_in_second_moment,
+                        use_nesterov_in_first_moment=self.use_nesterov_in_first_moment,
+                        use_momentum_in_second_moment=self.use_momentum_in_second_moment,
+                        prefer_input_side=prefer_input_side,
+                        force_full_rank=self.force_full_rank,
+                        normalization=self.normalization,
+                        another_muon=self.another_muon,
+                        use_scaling=self.use_scaling,
+                        update_normed=self.update_normed,
+                        debug_to_muon=self.debug_to_muon,
+                        spectral_normalize=self.spectral_normalize,
+                    )
+                )
+                if self.weight_decay > 0:
+                    components.append(optax.add_decayed_weights(self.weight_decay, self.build_weight_decay_mask()))
+                components.append(optax.scale(-learning_rate))
+                optimizer = optax.chain(*components)
+                return optimizer
+
+            def adamw_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(
+                    optax.scale_by_adam(self.beta1, self.beta2, self.epsilon, nesterov=self.nesterov_adam)
+                )
+                if self.weight_decay > 0:
+                    components.append(optax.add_decayed_weights(self.weight_decay, self.build_weight_decay_mask()))
+                components.append(optax.scale(-adam_lr))
+                optimizer = optax.chain(*components)
+                return optimizer
+
+            transformations = {
+                "muon_left": muon_transform(prefer_input_side=False),
+                "muon_right": muon_transform(prefer_input_side=True),
+                "adamw": adamw_transform(),
+            }
+
+            return optax.multi_transform(
+                transformations,
+                partial(
+                    self.create_mask,
+                    use_mudam_for_embedding=self.use_mudam_for_embedding,
+                    prefer_embedding_side=self.prefer_embedding_side,
+                    prefer_input_side=self.prefer_input_side,
+                ),
+            )
+
+        return optax.inject_hyperparams(optimizer)(learning_rate=learning_rate_schedule, adam_lr=adam_lr_schedule)
+
+    def create_mask(
+        self,
+        params,
+        use_mudam_for_embedding: bool = False,
+        prefer_embedding_side: bool = False,
+        prefer_input_side: bool = True,
+    ):
+        """
+        Creates a mask that labels parameters as 'muon' or 'adamw' based on their
+        dimensionality and module path, using AdamW for Embedding and lm_head parameters.
+        """
+        paths = leaf_key_paths(params)
+        assert not (prefer_embedding_side and prefer_input_side), "Cannot have two preferences"
+
+        def mask_fn(param, path):
+            path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
+            if "Embedding" in path_str or "lm_head" in path_str:
+                if use_mudam_for_embedding:
+                    return "muon_right"
+                else:
+                    return "adamw"
+            elif isinstance(param, Linear):
+                # muon for linear layers
+                if prefer_input_side:
+                    optim_type = "muon_right"
+                elif prefer_embedding_side:
+                    if "o_proj" in path_str:
+                        optim_type = "muon_left"
+                    else:
+                        optim_type = "muon_right"
+                else:
+                    optim_type = "muon_left"
+                return dataclasses.replace(param, weight=optim_type, bias="adamw" if param.bias is not None else None)
+            else:
+                return "adamw"
+
+        return jax.tree_util.tree_map(mask_fn, params, paths, is_leaf=lambda x: isinstance(x, Linear))
+
+
+def _safe_sharding_constraint(x, sharding):
+    if sharding is None:
+        return x
+    else:
+        return with_sharding_constraint(x, sharding)
+
+
+def p_over_x(b1, b2, use_nesterov_in_first_moment):
+    if not use_nesterov_in_first_moment:
+        # denominator is N = (1 - b2) * (g_t^2 + b2 * g_{t-1}^2 + b2^2 * g_{t-2}^2 + ...) / (1 - b2^t)
+        # nominator is M = (g_t +  b1 * g_{t-1} +  b1^2 * g_{t-2} + ...) * (1 - b1) / (1 - b1^t)
+        # output a number c such that c^2 N >= M^2 for all t
+        return jnp.sqrt(1 / ((1 - b2) * (1 - b1**2 / b2))) * (1 - b1)
+    else:
+        # denominator is N = (1 - b2) * (g_t^2 + b2 * g_{t-1}^2 + b2^2 * g_{t-2}^2 + ...) / (1 - b2^t)
+        # nominator is M = (g_t + b1 * g_t +  b1^2 * g_{t-1} +  b1^3 * g_{t-2} + ...) * (1 - b1) / (1 - b1^{t + 1})
+        # output a number c such that c^2 N >= M^2 for all t
+        term = (1 + b1) ** 2 + b1**4 / (1 - b1**2 / b2)
+        return jnp.sqrt(1 / (1 - b2) * term) * (1 - b1)
+
+
+def _map_fn(lax_map, bs, n_maps, fn, *args):
+    """Maybe map a fn along multiple leading axes."""
+    if n_maps <= 0:
+        return fn(*args)
+
+    if lax_map:
+        mapped_fn = lambda xs: _map_fn(lax_map, bs, n_maps - 1, fn, *xs)
+        return jax.lax.map(mapped_fn, xs=args, batch_size=bs if bs > 1 else None)
+    else:
+        mapped_fn = lambda *xs: _map_fn(lax_map, bs, n_maps - 1, fn, *xs)
+        return vmap(mapped_fn)(*args)
+
+
+def scale_by_mudam(
+    b1: float = 0.95,
+    b1_out: float = 1.0,
+    b1_2: float = 1.0,
+    b2: float = 0.95,
+    steps: int = 5,
+    epsilon: float = 1e-8,
+    interpolation_to_muon: float = 0.0,
+    muon_epsilon: float = 1e-10,
+    max_precond_dim: int = 10000,
+    precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
+    mu_dtype: Any = None,
+    precond_dtype: Any = None,
+    partition_grads_into_blocks: Optional[bool] = True,
+    normalize_gradient: Optional[bool] = True,
+    block_size: Optional[int] = 256,
+    lax_map_scanned_layers: Optional[bool] = True,
+    lax_map_batch_size: Optional[int] = 4,
+    merge_small_dims: bool = False,
+    target_merged_dim_size: int = 2048,
+    use_nesterov_in_second_moment: bool = False,
+    use_nesterov_in_first_moment: bool = True,
+    use_momentum_in_second_moment: bool = False,
+    prefer_input_side: bool = True,
+    force_full_rank: bool = True,
+    normalization: Optional[str] = "muon",
+    another_muon: Optional[bool] = None,
+    use_scaling: Optional[str] = "kimi",
+    update_normed: bool = False,
+    debug_to_muon: bool = False,
+    spectral_normalize: bool = False,
+) -> GradientTransformation:
+    mu_dtype = canonicalize_dtype(mu_dtype) if mu_dtype is not None else None
+    precond_dtype = canonicalize_dtype(precond_dtype) if precond_dtype is not None else None
+
+    def init_fn(params: Updates) -> dict:
+        scanned_layers_ = jax.tree.map(
+            lambda x: (
+                jax.tree.map(lambda _: True, x, is_leaf=lambda x: isinstance(x, jax.Array))
+                if isinstance(x, hax.nn.Stacked)
+                else jax.tree.map(lambda _: False, x, is_leaf=lambda x: isinstance(x, jax.Array))
+            ),
+            params,
+            is_leaf=lambda x: isinstance(x, hax.nn.Stacked),
+        )
+        params_sharding_ = hax.partitioning.infer_resource_partitions(params)
+        params_sharding_ = jax.tree.map(lambda x: x.spec, params_sharding_)
+        shapes = jax.tree.map(lambda p, s: p.shape[int(s) :], params, scanned_layers_)
+
+        shapes_leaf = jax.tree.map(
+            lambda p, s: p.shape[int(s) :], jax.tree.leaves(params), jax.tree.leaves(scanned_layers_)
+        )
+
+        exp_avg = otu.tree_zeros_like(params, dtype=mu_dtype)
+        scanned_dim_sharding = [
+            PartitionSpec(sh[0]) if s else None
+            for sh, s in zip(jax.tree.leaves(params_sharding_), jax.tree.leaves(scanned_layers_))
+        ]
+
+        merged_shapes = shapes
+        merged_shapes_leaf = shapes_leaf
+        if merge_small_dims:
+            merged_shapes = jax.tree.map(
+                lambda p, s: _merge_small_dims(p.shape[int(s) :], target_merged_dim_size),
+                params,
+                scanned_layers_,
+            )
+            merged_shapes_leaf = [
+                _merge_small_dims(p.shape[int(s) :], target_merged_dim_size)
+                for p, s in zip(
+                    jax.tree.leaves(params),
+                    jax.tree.leaves(scanned_layers_),
+                )
+            ]
+        partitioned_shapes = merged_shapes
+        partitioned_shapes_leaf = merged_shapes_leaf
+        if partition_grads_into_blocks:
+            partitioners = jax.tree.map(
+                lambda _, ps: BlockPartitioner(ps, block_size),
+                params,
+                partitioned_shapes,
+            )
+            # we can grab resulting shapes from partitioners
+            partitioned_shapes = jax.tree.map(lambda _, p_cls: p_cls._padded_stacked_shape, params, partitioners)
+            partitioned_shapes_leaf = [p_cls._padded_stacked_shape for p_cls in jax.tree.leaves(partitioners)]
+            print("Block partitioned shapes: ", partitioned_shapes_leaf)
+
+        def broadcast_qs(_, ps, q, s):
+            stack_n = ps[0]
+            if partition_grads_into_blocks:
+                # add leading dim for stacked partitions
+                q = jax.tree.map(lambda x: jnp.repeat(jnp.expand_dims(x, 0), stack_n, axis=0), q)
+            if s > 0:
+                # add leading dim if we're scanning this layer
+                q = jax.tree.map(lambda d: jnp.repeat(jnp.expand_dims(d, 0), s, axis=0), q)
+            return q
+
+        def add_dims_to_spec(qss, sds):
+            if partition_grads_into_blocks:
+                qss = jax.tree.map(lambda qs: PartitionSpec(*((None,) + qs)), qss)
+            if sds is not None:
+                qss = jax.tree.map(lambda qs: PartitionSpec(*(sds + qs)), qss)
+            return qss
+
+        scanned_sizes = jax.tree.map(lambda p, s: p.shape[0] if s else 0, params, scanned_layers_)
+
+        GG_and_sharding = [
+            init_conditioner(
+                t[1:] if partition_grads_into_blocks else t,
+                max_precond_dim,
+                precond_dtype,
+                prefer_input_side,
+                force_full_rank,
+            )
+            for t in partitioned_shapes_leaf
+        ]
+        GG = [x[0] for x in GG_and_sharding]
+        GG_sharding_without_scan = [x[1] for x in GG_and_sharding]
+        GG = [
+            broadcast_qs(None, shape, gg, size)
+            for shape, gg, size in zip(partitioned_shapes_leaf, GG, jax.tree.leaves(scanned_sizes))
+        ]
+        GG_sharding = [add_dims_to_spec(qss, sds) for qss, sds in zip(GG_sharding_without_scan, scanned_dim_sharding)]
+        GG = _safe_sharding_constraint(GG, GG_sharding)
+
+        state = {
+            "count": jnp.zeros([], jnp.int32),
+            "exp_avg": exp_avg,
+            "GG": GG,
+        }
+        if b1_2 < 1:
+            last_gradient = otu.tree_zeros_like(params, dtype=mu_dtype)
+            state["last_gradient"] = last_gradient
+        if b1_out < 1:
+            update_momentum = otu.tree_zeros_like(params, dtype=mu_dtype)
+            state["update_momentum"] = update_momentum
+        return state
+
+    def update_step(updates: Updates, state: dict, scanned_layers_: Updates) -> tuple[Updates, dict]:
+        # Update moments
+        _, grads_structure = jax.tree.flatten(updates, is_leaf=lambda x: isinstance(x, jax.Array))
+
+        if normalize_gradient:
+            updates = jax.tree.map(lambda g: g / jnp.linalg.norm(g), updates)
+
+        exp_avg = state["exp_avg"]
+        if b1_2 < 1:
+            last_gradient = state["last_gradient"]
+            current_gradient = updates
+            updates = jax.tree.map(lambda g, g_old: g + (1 - b1_2) * (g - g_old), updates, last_gradient)
+        gradient = updates
+        exp_avg = jax.tree.map(lambda m, g: None if g is None else b1 * m + g, exp_avg, updates)
+        updates = jax.tree.map(lambda m, g: None if g is None else b1 * m + g, exp_avg, updates)
+        shapes = jax.tree.map(lambda p, s: p.shape[int(s) :], updates, scanned_layers_)
+        # bias correction for nominator
+        if use_nesterov_in_first_moment:
+            nominator = jax.tree.map(
+                lambda g: (1 - b1) * g / (1 - b1 ** (state["count"] + 1)) if g is not None else None, updates
+            )
+        else:
+            nominator = jax.tree.map(
+                lambda g: (1 - b1) * g / (1 - b1 ** state["count"]) if g is not None else None, exp_avg
+            )
+
+        # bias correction for denominator
+        if use_nesterov_in_second_moment:
+            denominator_diff = jax.tree.map(
+                lambda g: (1 - b1) * g / (1 - b1 ** (state["count"] + 1)) if g is not None else None, updates
+            )
+        elif use_momentum_in_second_moment:
+            denominator_diff = jax.tree.map(
+                lambda g: (1 - b1) * g / (1 - b1 ** state["count"]) if g is not None else None, exp_avg
+            )
+        else:
+            denominator_diff = gradient
+
+        # block gradients, exp_avg
+        n_dims_to_map = jax.tree.map(lambda s: int(s), scanned_layers_)
+        dummy_updates_tree = jax.tree.map(lambda _: jnp.zeros([]), updates)
+        # merge small dims
+        merged_shapes = shapes
+        if merge_small_dims:
+            original_shapes = shapes
+            merged_shapes = jax.tree.map(
+                lambda g, s: _merge_small_dims(g.shape[int(s) :], target_merged_dim_size),
+                nominator,
+                scanned_layers_,
+            )
+            # reshape
+            nominator = jax.tree.map(
+                lambda g, s, ns: _map_fn(False, 0, int(s), lambda x, shape=ns: jnp.reshape(x, shape), g),
+                nominator,
+                scanned_layers_,
+                merged_shapes,
+            )
+            denominator_diff = jax.tree.map(
+                lambda g, s, ns: _map_fn(False, 0, int(s), lambda x, shape=ns: jnp.reshape(x, shape), g),
+                denominator_diff,
+                scanned_layers_,
+                merged_shapes,
+            )
+
+        # partition
+        partitioned_shapes = merged_shapes
+        if partition_grads_into_blocks:
+            partitioners = jax.tree.map(
+                lambda _, ps: BlockPartitioner(ps, block_size),
+                nominator,
+                partitioned_shapes,
+            )
+            blocked_nominator = jax.tree.map(
+                lambda g, p_cls, s: _map_fn(False, 0, int(s), p_cls.partition, g),
+                nominator,
+                partitioners,
+                scanned_layers_,
+            )
+            blocked_denominator_diff = jax.tree.map(
+                lambda g, p_cls, s: _map_fn(False, 0, int(s), p_cls.partition, g),
+                denominator_diff,
+                partitioners,
+                scanned_layers_,
+            )
+            partitioned_shapes = jax.tree.map(
+                lambda _, g, s: jax.tree.map(lambda x: x.shape[int(s) :], g),
+                dummy_updates_tree,
+                blocked_nominator,
+                scanned_layers_,
+            )
+            blocked_nominator = jax.tree.map(
+                lambda _, g, s: _map_fn(
+                    False,
+                    0,
+                    int(s),
+                    lambda x, bs=block_size: _pad_and_stack_matrices(x, bs),
+                    g,
+                ),
+                dummy_updates_tree,
+                blocked_nominator,
+                scanned_layers_,
+            )
+            blocked_denominator_diff = jax.tree.map(
+                lambda _, g, s: _map_fn(
+                    False,
+                    0,
+                    int(s),
+                    lambda x, bs=block_size: _pad_and_stack_matrices(x, bs),
+                    g,
+                ),
+                dummy_updates_tree,
+                blocked_denominator_diff,
+                scanned_layers_,
+            )
+            n_dims_to_map = jax.tree.map(lambda x: x + 1, n_dims_to_map)
+        else:
+            blocked_nominator = nominator
+            blocked_denominator_diff = denominator_diff
+
+        # first update denominator
+        new_GG = jax.tree.map(
+            lambda nm, grad, gg: _map_fn(False, 0, nm, partial(update_preconditioner, beta=b2), grad, gg),
+            jax.tree.leaves(n_dims_to_map),
+            jax.tree.leaves(blocked_denominator_diff),
+            state["GG"],
+        )
+
+        assert b2 > b1**2, "b2 must be greater than b1^2 for the shampoo to have bounded norm update"
+        P_over_X = p_over_x(b1, b2, use_nesterov_in_first_moment)
+        denominator = jax.tree.map(lambda gg: (1 - b2 ** state["count"]) / (1 - b2) * gg, new_GG)
+
+        if not debug_to_muon:
+            blocked_norm_updates_leaves = jax.tree.map(
+                lambda _, nm, e, gg: _map_fn(
+                    False,
+                    0,
+                    nm,
+                    partial(
+                        ns_generalized,
+                        b2=b2,
+                        steps=steps,
+                        eps=muon_epsilon,
+                        P_over_X=P_over_X,
+                        normalization=normalization,
+                        another_muon=another_muon,
+                        use_scaling=use_scaling,
+                        update_normed=update_normed,
+                        interpolation_to_muon=interpolation_to_muon,
+                        spectral_normalize=spectral_normalize,
+                    ),
+                    e,
+                    gg,
+                ),
+                jax.tree.leaves(dummy_updates_tree),
+                jax.tree.leaves(n_dims_to_map),
+                jax.tree.leaves(blocked_nominator),
+                denominator,
+            )
+        else:
+            blocked_norm_updates_leaves = jax.tree.map(
+                lambda _, nm, e: _map_fn(
+                    False,
+                    0,
+                    nm,
+                    partial(
+                        ns_for_debug,
+                        steps=steps,
+                        eps=muon_epsilon,
+                        use_scaling=use_scaling,
+                        normalization=normalization,
+                    ),
+                    e,
+                ),
+                jax.tree.leaves(dummy_updates_tree),
+                jax.tree.leaves(n_dims_to_map),
+                jax.tree.leaves(blocked_nominator),
+            )
+        blocked_norm_updates = grads_structure.unflatten(blocked_norm_updates_leaves)
+
+        # revert blocking of everything
+        if partition_grads_into_blocks:
+            norm_updates = jax.tree.map(
+                lambda g, s, ps: _map_fn(
+                    False,
+                    0,
+                    int(s),
+                    lambda p, shapes=ps: _unstack_and_unpad_matrices(p, shapes),
+                    g,
+                ),
+                blocked_norm_updates,
+                scanned_layers_,
+                partitioned_shapes,
+            )
+            norm_updates = jax.tree.map(
+                lambda _, g, s, p_cls: _map_fn(False, 0, int(s), p_cls.merge_partitions, g),
+                dummy_updates_tree,
+                norm_updates,
+                scanned_layers_,
+                partitioners,
+            )
+        else:
+            norm_updates = blocked_norm_updates
+
+        # unmerge
+        if merge_small_dims:
+            norm_updates = jax.tree.map(
+                lambda g, s, os: _map_fn(False, 0, int(s), lambda p, shape=os: jnp.reshape(p, shape), g),
+                norm_updates,
+                scanned_layers_,
+                original_shapes,
+            )
+
+        # precision
+        new_GG = otu.tree_cast(new_GG, precond_dtype)
+        exp_avg = otu.tree_cast(exp_avg, mu_dtype)
+
+        new_state = {
+            "GG": new_GG,
+            "exp_avg": exp_avg,
+            "count": state["count"],
+        }
+
+        if b1_2 < 1:
+            new_state["last_gradient"] = current_gradient
+        if b1_out < 1:
+            new_state["update_momentum"] = jax.tree.map(
+                lambda g, m: g + (1 - b1_out) * m, norm_updates, state["update_momentum"]
+            )
+            # bias correction for update
+            norm_updates = jax.tree.map(
+                lambda m: (1 - b1_out) * m / (1 - b1_out ** state["count"]) if m is not None else None,
+                new_state["update_momentum"],
+            )
+
+        return norm_updates, new_state
+
+    def update_fn(updates: Updates, state: dict, params: Optional[Updates] = None) -> tuple[Updates, dict]:
+        count_inc = jnp.asarray(optax.safe_int32_increment(state["count"]))
+        state["count"] = count_inc
+        scanned_layers_ = jax.tree.map(
+            lambda x: (
+                jax.tree.map(lambda _: True, x, is_leaf=lambda x: isinstance(x, jax.Array))
+                if isinstance(x, hax.nn.Stacked)
+                else jax.tree.map(lambda _: False, x, is_leaf=lambda x: isinstance(x, jax.Array))
+            ),
+            params,
+            is_leaf=lambda x: isinstance(x, hax.nn.Stacked),
+        )
+
+        updates, new_state = update_step(updates, state, scanned_layers_)
+
+        return updates, new_state
+
+    return optax.GradientTransformation(init_fn, update_fn)  # type: ignore
+
+
+def update_preconditioner(
+    grad: Array,
+    GG: List[Union[Array, None]],
+    beta: float,
+    precision: jax.lax.PrecisionLike = jax.lax.Precision.HIGHEST,
+) -> List[Union[Array, None]]:
+    if grad.ndim == 1:
+        return [jnp.matmul(grad[:, None], grad[None, :], precision=precision) + beta * GG[0]]  # type: ignore
+
+    def update_gg(idx, gg):
+        if gg is None:
+            return None
+        outer_product = jnp.tensordot(
+            grad,
+            grad,
+            axes=[[*chain(range(idx), range(idx + 1, len(grad.shape)))]] * 2,
+            precision=precision,
+        )
+        return outer_product + beta * gg
+
+    new_GG = jax.tree.map(update_gg, list(range(len(GG))), GG)
+
+    return new_GG
+
+
+def ns_for_debug(X, steps=5, eps=1e-7, normalization="muon", use_scaling="kimi"):
+    """
+    Newton-Schulz iteration to compute the zeroth power / orthogonalization of G.
+    """
+    chex.assert_rank(X, 2)
+    if normalization == "muon":
+        a, b, c = (3.4445, -4.7750, 2.0315)
+        hs = [(a, b, c)] * steps
+    X /= jnp.linalg.norm(X) + eps  # Ensure top singular value <= 1
+    transpose = False
+    # assert X.shape[0] <= X.shape[1], "X should have more columns than rows for this implementation."
+    # TODO: we should be smarter and also transpose if they're ~the same and X is already sharded along first axis
+    if X.shape[0] > X.shape[1]:
+        X = X.T
+        transpose = True
+    if len(hax.partitioning._get_mesh().devices):
+        X = jax.lax.with_sharding_constraint(X, PartitionSpec(None, ("data", "model")))
+
+    for i in range(len(hs)):
+        a, b, c = hs[i]
+        A = X @ X.T
+        B = b * A + c * A @ A
+        X = a * X + B @ X
+
+    if transpose:
+        X = X.T
+    if use_scaling == "kimi":
+        scale = jnp.sqrt(jnp.maximum(X.shape[0], X.shape[1]))
+    elif use_scaling == "zhiyuan":
+        scale = jnp.sqrt(jnp.minimum(X.shape[0], X.shape[1]))
+    elif use_scaling == "muon":
+        scale = jnp.sqrt(jnp.maximum(1, X.shape[0] / X.shape[1]))
+    else:
+        scale = jnp.sqrt(X.shape[0])
+    return X * scale
+
+
+def approximated_spectral_norm(X, num_iterations=10):
+    """
+    Approximates the spectral norm of a matrix X using power iteration.
+    """
+    # Initialize a random vector with the correct shape.
+    # The vector v should have shape (X.shape[1], 1)
+    key = jax.random.PRNGKey(0)
+    v = jax.random.normal(key, (X.shape[1],))  # use a fixed probing vector for now
+    v = v / jnp.linalg.norm(v)
+
+    # Power iteration loop
+    for _ in range(num_iterations):
+        # This is more numerically stable and efficient than forming X.T @ X
+        u = X @ v
+        v = X.T @ u
+        v = v / jnp.linalg.norm(v)
+
+    # The spectral norm is the L2 norm of (X @ v)
+    final_norm = jnp.linalg.norm(X @ v)
+    return final_norm
+
+
+def ns_generalized(
+    X: Array,
+    GG: List[Union[Array, None]],
+    steps: int = 5,
+    b2: float = 0.0,
+    eps: float = 1e-7,
+    P_over_X: Any = 1.0,
+    normalization: Optional[str] = "muon",
+    interpolation_to_muon: float = 0.0,
+    another_muon: Optional[bool] = None,
+    spectral_normalize: bool = False,
+    use_scaling: Optional[str] = "kimi",
+    update_normed: bool = False,
+) -> Array:
+    idx = 0
+    for i, mat in enumerate(GG):
+        if mat is not None:  # noqa: SIM108
+            idx = i
+    chex.assert_rank(X, 2)
+
+    transpose = False
+    if idx == 1:
+        X = X.T
+        transpose = True
+
+    P_raw = GG[idx]
+
+    # if len(hax.partitioning._get_mesh().devices):
+    # X = jax.lax.with_sharding_constraint(X, PartitionSpec(None, ("data", "model")))
+    # P_raw = jax.lax.with_sharding_constraint(P_raw, PartitionSpec(None, None))
+
+    # for nominator X, need to subtract XX.T from the denominator
+    P = interpolation_to_muon * X @ X.T + (1 - interpolation_to_muon) * P_raw  # pyrefly: ignore[unsupported-operation]
+
+    if normalization == "svd":
+        s, u = jnp.linalg.eigh(P + X @ X.T)
+        s_inv_sqrt = jnp.where(s > eps, 1.0 / jnp.sqrt(s), 0.0)
+        P_inv_sqrt = u @ jnp.diag(s_inv_sqrt) @ u.T
+        X = P_inv_sqrt @ X
+    elif normalization == "jianlin":
+        I1 = jnp.eye(P.shape[0])
+        P = P + eps * I1
+        normalized_factor_p = jnp.sqrt(jnp.trace(P @ P))
+        normalized_factor_x = jnp.linalg.norm(X) + eps
+        P = P / normalized_factor_p
+        X = X / normalized_factor_x
+        hs = [
+            [2.003698915546185, -0.12738228464323412, -0.9913739512092223],
+            [1.7312012486502126, 0.11574802804004483, -0.650104836053695],
+            [1.756732832712327, 0.08760436701325444, -0.6062859774838089],
+            [1.6774879041707145, 0.1265063444437542, -0.5850694621322253],
+            [1.5240377698859244, 0.16539061780947165, -0.5799808499244595],
+            [1.5389518470783554, 0.15096635863051178, -0.5781799066369828],
+            [1.5230508848208697, 0.18063663836127025, -0.5433476761697408],
+            [0.8831254701177772, 0.6900069105312058, -0.5045468048486641],
+            [0.8885959911978427, 0.5789969826532673, -0.4718140813257857],
+            [1.0230225077411645, 0.4597415301949877, -0.48280094211975133],
+        ]
+        for a, b, c in hs:
+            W1 = a * I1 + b * P + c * P @ P
+            X = W1 @ X
+            P = 0.5 * (W1 @ (P + P.T) @ W1.T)
+        X = X * normalized_factor_x / (normalized_factor_p**0.5)
+    else:
+        # calling the subprocess to compute
+        P_over_X = jnp.sqrt(interpolation_to_muon + P_over_X**2 * (1 - interpolation_to_muon))
+        X = X / P_over_X
+        P = P - X @ X.T
+        # when not including nominator, need to add eps * I to ensure P is positive definite
+        normalized_factor = jnp.sqrt(jnp.sqrt(jnp.trace(P @ P)) + eps + jnp.linalg.norm(X) ** 2)
+        # jax.debug.print("X norm {x}, P norm {p}, Normalized factor {n}", x = jnp.linalg.norm(X), p = jnp.sqrt(jnp.trace(P)), n = normalized_factor)
+        P = P + eps * jnp.eye(P.shape[0])  # avoid non positive definite
+        X /= normalized_factor
+        P /= normalized_factor**2
+        if normalization == "polar":
+            coeffs_list_polar = [
+                (8.28721201814563, -23.595886519098837, 17.300387312530933),
+                (4.107059111542203, -2.9478499167379106, 0.5448431082926601),
+                (3.9486908534822946, -2.908902115962949, 0.5518191394370137),
+                (3.3184196573706015, -2.488488024314874, 0.51004894012372),
+                (2.300652019954817, -1.6689039845747493, 0.4188073119525673),
+                (1.891301407787398, -1.2679958271945868, 0.37680408948524835),
+                (1.8750014808534479, -1.2500016453999487, 0.3750001645474248),
+                (1.875, -1.25, 0.375),
+            ]  # subsequent coeffs equal this numerically
+            # safety factor for numerical stability (but exclude last polynomial)
+            coeffs_list_polar = [(a / 1.01, b / 1.01**3, c / 1.01**5) for (a, b, c) in coeffs_list_polar[:-1]] + [
+                coeffs_list_polar[-1]
+            ]
+            hs = coeffs_list_polar[:steps] + [coeffs_list_polar[-1]] * max(0, steps - len(coeffs_list_polar))
+        elif normalization == "heavy":
+            coefficient_list = [
+                [2.7016027669794043, -1.602970321850751, 0.39423894803566567],
+                [2.8401746851601453, -1.6053566347080421, 0.3840046561658029],
+                [2.7156109765394056, -1.6695204205086023, 0.32209664174118957],
+                [2.601508909818141, -1.6226872362221807, 0.3657957045623002],
+                [2.4751052423152244, -1.5953618300406027, 0.394339195930196],
+                [2.585463724527698, -1.5768104299646881, 0.41509996062370064],
+                [2.6521988290513394, -1.6717314166731414, 0.3240032693041669],
+                [2.0441429057969813, -1.5153187043371619, 0.47478569113020946],
+                [1.9630651968491937, -1.5499418485715168, 0.4516820484751629],
+                [2.008830255477319, -1.5030574864379898, 0.48563512296169237],
+            ]
+            hs = coefficient_list  # for now ignore steps, assume it always equals to 10
+        elif normalization == "muon":
+            a, b, c = (3.4445, -4.7750, 2.0315)
+            hs = [(a, b, c)] * steps
+        else:
+            a, b, c = (2.0, -1.5, 0.5)
+            hs = [(a, b, c)] * steps
+        for a, b, c in hs:
+            A = X @ X.T + P
+            B = b * A + c * A @ A
+            X = a * X + B @ X
+            P = a * a * P + a * (B @ P + P @ B) + B @ P @ B
+        X = X * P_over_X
+
+    if another_muon:
+        X = X / (jnp.linalg.norm(X) + eps)
+        for a, b, c in hs:
+            A = X @ X.T
+            B = b * A + c * A @ A
+            X = a * X + B @ X
+
+    if spectral_normalize:
+        # spectral_norm = jnp.linalg.norm(X, ord=2)
+        spectral_norm = approximated_spectral_norm(X)
+        X = X / spectral_norm
+
+    if transpose:
+        X = X.T
+
+    if update_normed:
+        X = X / jnp.linalg.norm(X)
+
+    if use_scaling == "kimi":
+        scale = jnp.sqrt(jnp.maximum(X.shape[0], X.shape[1]))
+    elif use_scaling == "zhiyuan":
+        scale = jnp.sqrt(jnp.minimum(X.shape[0], X.shape[1]))
+    elif use_scaling == "muon":
+        scale = jnp.sqrt(jnp.maximum(1, X.shape[0] / X.shape[1]))
+    elif use_scaling == "interpolation":
+        scale = jnp.sqrt(
+            jnp.maximum(1, X.shape[0] / X.shape[1]) * interpolation_to_muon + X.shape[0] * (1 - interpolation_to_muon)
+        )
+    elif use_scaling == "interpolation2":
+        scale = jnp.sqrt(
+            jnp.maximum(1, X.shape[0] / X.shape[1]) * interpolation_to_muon
+            + 16 * X.shape[0] * (1 - interpolation_to_muon)
+        )
+    elif use_scaling == "interpolation3":
+        scale = jnp.sqrt(
+            jnp.maximum(1, X.shape[0] / X.shape[1]) * interpolation_to_muon
+            + 64 * X.shape[0] * (1 - interpolation_to_muon)
+        )
+    elif use_scaling == "interpolation4":
+        scale = jnp.sqrt(
+            jnp.maximum(1, X.shape[0] / X.shape[1]) * interpolation_to_muon
+            + 32 * X.shape[0] * (1 - interpolation_to_muon)
+        )
+    else:
+        scale = jnp.sqrt(X.shape[0])
+    return X * scale
+
+
+def _get_preconditioner_types(
+    shape: Tuple[int, ...], max_precond_dim: int, prefer_input_side: bool = True, force_full_rank: bool = True
+) -> List[bool]:
+    if len(shape) == 0:
+        return [False]
+
+    if len(shape) == 1:
+        return [False]
+
+    min_dim = min(shape)
+    new_result = []
+    flag = True
+    if prefer_input_side:
+        shape = shape[::-1]
+    for i in range(len(shape)):
+        if (shape[i] == min_dim or (not force_full_rank)) and flag:
+            flag = False
+            new_result.append(False)
+        else:
+            new_result.append(True)
+    if prefer_input_side:
+        new_result = new_result[::-1]
+    return new_result
+
+
+def init_conditioner(
+    p_shape,
+    max_precond_dim: int,
+    dtype: Optional[Union[str, jnp.dtype]],
+    prefer_input_side: bool = True,
+    force_full_rank: bool = True,
+):
+    if len(p_shape) == 1:
+        return ([jnp.zeros((p_shape[0], p_shape[0]), dtype=dtype)], [PartitionSpec()])
+
+    # sharding purpose
+    mesh = hax.partitioning._get_mesh()
+    if mesh.devices.shape == ():
+        mesh = None
+    # get fsdp mesh axis
+    if mesh is not None:
+        fsdp_axis_name = hax.partitioning.ResourceAxis.DATA
+        fsdp_axis = mesh.axis_names.index(fsdp_axis_name)
+        fsdp_size = mesh.devices.shape[fsdp_axis]
+
+    sharding_out = [PartitionSpec(None)] * len(p_shape)
+    preconditioner_types = _get_preconditioner_types(p_shape, max_precond_dim, prefer_input_side, force_full_rank)
+    output = []
+    for i in range(len(p_shape)):
+        s = p_shape[i]
+        if not preconditioner_types[i]:
+            output.append(jnp.zeros((s, s), dtype=dtype))
+            if mesh is not None:
+                if s % fsdp_size == 0:
+                    q_sharding = PartitionSpec(fsdp_axis_name, None)
+                else:
+                    q_sharding = PartitionSpec(None, None)
+            else:
+                q_sharding = PartitionSpec(None, None)
+            sharding_out[i] = q_sharding
+        else:
+            output.append(None)
+    return (output, sharding_out)
+
+
+class BlockPartitioner:
+    """Partitions a tensor into smaller tensors.
+
+    Modified from distributed_shampoo.
+    https://github.com/google-research/google-research/blob/master/scalable_shampoo/optax/distributed_shampoo.py
+    Scalable Second Order Optimization for Deep Learning,
+    Rohan Anil, Vineet Gupta, Tomer Koren, Kevin Regan, Yoram Singer
+    https://arxiv.org/abs/2002.09018
+    """
+
+    def __init__(self, param_shape, block_size):
+        self._shape = param_shape
+        self._shape = tuple(int(_) for _ in self._shape)  # jnp value refuse to be equal to integer, manually convert
+        self._splits = []
+        split_sizes = []
+        # We split params into smaller blocks. Here we store the metadata to make
+        # that split.
+        for i, d in enumerate(param_shape):
+            if 0 < block_size < d:
+                # d-1, otherwise split appends a 0-size array.
+                nsplit = (d - 1) // block_size
+                indices = (np.arange(nsplit, dtype=np.int32) + 1) * block_size
+                sizes = np.ones(nsplit + 1, dtype=np.int32) * block_size
+                sizes[-1] = d - indices[-1]
+                self._splits.append((i, indices))
+                split_sizes.append(sizes)
+            else:
+                split_sizes.append(np.array([d], dtype=np.int32))
+        self._split_sizes = split_sizes
+
+        # TODO (evanatyourservice)
+        # this might fail with scalar params but for now we're reshaping those
+        single_shape = [a[0] for a in split_sizes]
+        padded_single_shape = [-(-dim // block_size) * block_size for dim in single_shape]
+        stack_size = max(1, np.prod([max(1, len(s)) for s in split_sizes]))
+        self._padded_stacked_shape = tuple([stack_size] + padded_single_shape)
+
+    def split_sizes(self):
+        return self._split_sizes
+
+    def partition(self, tensor):
+        """Partition tensor into blocks."""
+        assert tensor.shape == self._shape
+        tensors = [tensor]
+        for i, indices in self._splits:
+            tensors_local = []
+            for t in tensors:
+                tensors_local.extend(jnp.split(t, indices_or_sections=indices, axis=i))
+            tensors = tensors_local
+        return tuple(tensors)
+
+    def merge_partitions(self, partitions):
+        """Merge partitions back to original shape."""
+
+        for i, indices in reversed(self._splits):
+            n = len(indices) + 1
+            partial_merged_tensors = []
+            ind = 0
+            while ind < len(partitions):
+                partial_merged_tensors.append(jnp.concatenate(partitions[ind : ind + n], axis=i))
+                ind += n
+            partitions = partial_merged_tensors
+        assert len(partitions) == 1
+        return partitions[0]
+
+
+def _partitions(lst):
+    """Generate all partitions of a list."""
+    if not lst:
+        yield [[]]
+    else:
+        for i in range(len(lst)):
+            for part in _partitions(lst[i + 1 :]):
+                yield [lst[: i + 1]] + part
+
+
+def _pad_and_stack_matrices(array_list, block_size):
+    # Handle scalar arrays by adding a dummy dimension
+    is_scalar = len(array_list[0].shape) == 0
+    if is_scalar:
+        array_list = [arr[None] for arr in array_list]
+
+    shapes = [arr.shape for arr in array_list]
+    max_dims = [max(shape[i] for shape in shapes) for i in range(len(shapes[0]))]
+    padded_shape = [-(-dim // block_size) * block_size for dim in max_dims]
+    padded_arrays = []
+    for arr in array_list:
+        pad_width = [(0, padded_shape[i] - arr.shape[i]) for i in range(arr.ndim)]
+        padded = jnp.pad(arr, pad_width)
+        padded_arrays.append(padded)
+
+    stacked = jnp.stack(padded_arrays)
+    return stacked
+
+
+def _unstack_and_unpad_matrices(stacked_array, shapes):
+    # Handle scalar arrays
+    is_scalar = len(shapes[0]) == 0
+
+    unstacked = jnp.split(stacked_array, stacked_array.shape[0], axis=0)
+    unpadded = []
+    for arr, orig_shape in zip(unstacked, shapes):
+        arr = jnp.squeeze(arr, axis=0)
+        if is_scalar:
+            # For scalars, just take the first element
+            arr = arr[0]
+        else:
+            # For non-scalars, slice to original shape
+            slices = tuple(slice(0, dim) for dim in orig_shape)
+            arr = arr[slices]
+        unpadded.append(arr)
+    return tuple(unpadded)
+
+
+# unused fns (can be used for stacking partitions without padding):
+def _sort_and_group_matrices(matrix_shapes: List[Tuple[int, ...]]):
+    indexed_list = list(enumerate(matrix_shapes))
+    sorted_indexed = sorted(indexed_list, key=lambda x: x[1])
+    sorted_shapes = [shape for _, shape in sorted_indexed]
+    change_indices = [original_index for original_index, _ in sorted_indexed]
+    revert_indices = [0] * len(matrix_shapes)
+    for new_pos, (original_index, _) in enumerate(sorted_indexed):
+        revert_indices[original_index] = new_pos
+    shape_groups = defaultdict(list)
+    for i, shape in enumerate(sorted_shapes):
+        shape_groups[shape].append(i)
+    unique_sorted_shapes = list(shape_groups.keys())
+    return unique_sorted_shapes, dict(shape_groups), change_indices, revert_indices
+
+
+def _stack_matrices(array_list):
+    in_tuple = isinstance(array_list, tuple)
+    shapes = [arr.shape for arr in array_list]
+    unique_shapes, shape_groups, change_indices, _ = _sort_and_group_matrices(shapes)
+    sorted_arrays = [array_list[i] for i in change_indices]
+    stacked_arrays = []
+    for shape in unique_shapes:
+        indices = shape_groups[shape]
+        stacked = jnp.stack([sorted_arrays[i] for i in indices])
+        stacked_arrays.append(stacked)
+    if in_tuple:
+        return tuple(stacked_arrays)
+    return stacked_arrays
+
+
+def _unstack_matrices(stacked_arrays, revert_indices):
+    in_tuple = isinstance(stacked_arrays, tuple)
+    unstacked = []
+    for arr in stacked_arrays:
+        unstacked.extend(jnp.split(arr, arr.shape[0]))
+    array_list = [jnp.squeeze(unstacked[i], axis=0) for i in revert_indices]
+    if in_tuple:
+        return tuple(array_list)
+    return array_list
+
+
+def _merge_small_dims(
+    shape_to_merge, max_dim
+) -> Tuple[List[int], List[bool], Optional[Tuple]] | Tuple[List[int], List[bool]] | List[int]:
+    if not shape_to_merge:  # handles scalar shape ()
+        return [], [True]
+    if np.all(np.array(shape_to_merge) == 1):  # handles shape (1,)
+        return (
+            [1],
+            [True],
+        )
+
+    def dim2loss(d, dim0=max_dim):
+        """A heuristic map from dim to loss with the least loss occurs at dim0."""
+        loss = 0
+        if d < dim0:
+            loss += np.log2(dim0 / d)
+            too_small = dim0 / 8
+            if d < too_small:
+                loss += 100 * np.log2(too_small / d)
+        else:
+            loss += 10 * np.log2(d / dim0)
+            too_large = 8 * dim0
+            if d > too_large:
+                loss += 1000 * np.log2(d / too_large)
+        return loss
+
+    best_loss = float("inf")
+    best_partition = []
+
+    for p in _partitions(list(range(len(shape_to_merge)))):
+        loss = 0
+        merged = []
+        for group in p:
+            if not group:
+                continue
+            d = np.prod([shape_to_merge[i] for i in group])
+            loss += dim2loss(d)
+            merged.append(group)
+
+        if loss < best_loss:
+            best_loss = loss
+            best_partition = merged
+
+    merged_shape = []
+    for group in best_partition:
+        merged_shape.append(np.prod([shape_to_merge[i] for i in group]))
+
+    return merged_shape


### PR DESCRIPTION
## Left-preconditioned Muon (Ali Jadbabaie's "idea 4")

    U = ρ · H^{-1/2} · polar( H^{-1/2} · M ) ,   H = EMA(G Gᵀ)

Output-side ("left") whitening of the Muon update by the gradient's own second moment `H` (the Shampoo left factor), with a **truncated pseudo-inverse** for `H^{-1/2}` (facebookresearch/optimizers#265). Unlike idea 3 (which whitened by the activation moment `AAᵀ` and needed forward capture), `H` is built from the gradient alone — so this is a **pure optimizer, no trainer/model changes**. `H = I` recovers plain Muon (verified offline: cos = 1.0000, scale = 1.0000).

### Design notes
- **Truncated pseudo-inverse**, clamp `1e-15` (Shampoo's value): only numerically-zero eigen-directions are dropped. Larger clamps (1e-6/1e-4) over-truncate real low-curvature directions and hurt.
- **Polar on a rank-truncated input is well-defined**: NS5 is an odd polynomial with `p(0)=0`, so zeroed singular directions stay zero (a *partial isometry*) — no arbitrary rotation, no blow-up (verified).
- Eigenvalues are normalized by the mean before inversion, so `H^{-1/2}` is scale-free and the LR stays comparable to Muon.

### Results so far — qwen3-130m, `eval/paloma/c4_en/bpb` (Muon control, same setup = **1.1673**)

Base form (`H^{-1/2} polar(H^{-1/2} M)`), LR × clamp sweep (✅ complete):

| LR× | clamp 1e-15 | clamp 1e-8 |
|---|---|---|
| **0.5** | **1.2665** | 1.2699 |
| 1.0 | 1.2961 | 1.2891 |
| 2.0 | 1.3452 | 1.3398 |
| 4.0 | 1.3895 | 1.4071 |

So far idea 4 is **behind Muon** (best 1.2665 vs 1.1673, +0.10) and monotonically worse with higher LR — the optimum is at/below the lowest LR tested. Clamp 1e-15 vs 1e-8 barely matters.

### 🔄 Running now (results pending)
- **Lower-LR sweep** (`iris-run-job-20260623-154842`): LR {0.0625, 0.125, 0.25}× × clamp 1e-15 — to pin the optimum, since the curve is still descending toward low LR.
- **Three variants** (`iris-run-job-20260623-155553`), LR {0.25, 0.5, 1.0}× × clamp 1e-15:
  1. `inner_only` — drop the outer `H^{-1/2}`: `U = polar(H^{-1/2} M)`
  2. `real_inv` — damped real inverse instead of the truncated pseudo-inverse
  3. `fro_norm` — rescale `U` to Muon's Frobenius norm

I'll update this PR with the low-LR curve + variant numbers (and a plot) once they finish.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
