### PR TITLE
[finelog] Raise memory limit to 32Gi for boot-time remote reconcile

### DIFF
--- a/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
+++ b/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
@@ -68,10 +68,10 @@ spec:
           resources:
             requests:
               cpu: "500m"
-              memory: "1Gi"
+              memory: "4Gi"
             limits:
               cpu: "2"
-              memory: "4Gi"
+              memory: "32Gi"
           livenessProbe:
             tcpSocket:
               port: {{ port }}


### PR DESCRIPTION
The boot scan of s3://marin-na/finelog/cw-us-east-02a OOMKilled the finelog pod (exit 137) within ~40s of startup at the old 4Gi limit. Bootstrap reconcile reads parquet footers for all archived segments on an active cluster, which easily exceeds 4Gi.

Raise the memory limit to 32Gi and request to 4Gi to match.