### PR TITLE
[iris] Restore fleet overview and per-node job links on capacity tab

### DIFF
--- a/lib/iris/dashboard/src/components/controller/CapacityTab.vue
+++ b/lib/iris/dashboard/src/components/controller/CapacityTab.vue
@@ -24,6 +24,7 @@ import type {
 import { timestampMs, formatRelativeTime, bandDisplayName, bandColor } from '@/utils/formatting'
 import { buildSliceView, type SliceJob, type SliceStatus, type SliceView } from '@/utils/slices'
 import SliceList from '@/components/controller/SliceList.vue'
+import FleetOverview from '@/components/controller/FleetOverview.vue'
 import EmptyState from '@/components/shared/EmptyState.vue'
 import LogViewer from '@/components/shared/LogViewer.vue'
 import LoadingSpinner from '@/components/shared/LoadingSpinner.vue'
@@ -123,15 +124,28 @@ const routing = computed(() => autoscaler.value?.lastRoutingDecision ?? null)
 const unmetEntries = computed(() => routing.value?.unmetEntries ?? [])
 const actions = computed(() => (autoscaler.value?.recentActions ?? []).slice().reverse())
 
-// SliceList wants a worker_id → jobs map; the pool-keyed view has no per-host job
-// join (it lived in the dropped Fleet Overview), so pass empty. Status
-// classification does not use it.
-const NO_WORKER_JOBS: Map<string, SliceJob[]> = new Map()
+// worker_id → jobs running on that host, from the scheduler running buckets the
+// users table already fetches. SliceList renders these as per-job links in the
+// expanded slice rows; status classification does not depend on it.
+const sliceWorkerJobs = computed<Map<string, SliceJob[]>>(() => {
+  const map = new Map<string, SliceJob[]>()
+  for (const bucket of (schedulerData.value?.runningBuckets ?? []) as RunningTaskBucket[]) {
+    if (!bucket.workerId || !bucket.jobId) continue
+    if (!map.has(bucket.workerId)) map.set(bucket.workerId, [])
+    map.get(bucket.workerId)!.push({
+      jobId: bucket.jobId,
+      userId: bucket.userId,
+      taskCount: bucket.count,
+      hostCount: 1,
+    })
+  }
+  return map
+})
 
 // One view-model per slice, shared by the summary strip, the per-group badges, and
 // the expanded list — so the row summary can never disagree with the detail.
 const allSliceViews = computed<SliceView[]>(() =>
-  groups.value.flatMap(g => (g.slices ?? []).map(s => buildSliceView(s, NO_WORKER_JOBS, nowMs.value)))
+  groups.value.flatMap(g => (g.slices ?? []).map(s => buildSliceView(s, sliceWorkerJobs.value, nowMs.value)))
 )
 function countSliceStatus(views: SliceView[], status: SliceStatus): number {
   return views.reduce((n, v) => n + (v.status === status ? 1 : 0), 0)
@@ -299,7 +313,7 @@ function groupDemand(name: string): number { return group(name)?.currentDemand ?
 // Per-group slice view-models, built from the same buildSliceView the expanded
 // list uses, so the row summary and the detail rows can never disagree.
 function groupSliceViews(name: string): SliceView[] {
-  return groupSlices(name).map(s => buildSliceView(s, NO_WORKER_JOBS, nowMs.value))
+  return groupSlices(name).map(s => buildSliceView(s, sliceWorkerJobs.value, nowMs.value))
 }
 
 interface SliceStatusCount { status: SliceStatus; count: number; style: SliceStatusStyle }
@@ -682,6 +696,9 @@ function sliceIdShort(sliceId?: string): string {
       </div>
     </section>
 
+    <!-- ===== Fleet overview — what we have, where ===== -->
+    <FleetOverview :groups="groups" :running-buckets="schedulerData?.runningBuckets ?? []" />
+
     <!-- ===== Pools — capacity & routing ===== -->
     <section>
       <h3 class="text-sm font-semibold text-text-secondary uppercase tracking-wider mb-3">
@@ -864,7 +881,7 @@ function sliceIdShort(sliceId?: string): string {
                 <!-- Slice detail (expanded) -->
                 <tr v-if="expandedSlices.has(gs.group) && groupHasSlices(gs.group) && !collapsedPools.has(section.pool)" class="bg-surface-sunken">
                   <td colspan="8" class="px-6 py-3">
-                    <SliceList :slices="groupSlices(gs.group)" :worker-jobs="NO_WORKER_JOBS" :now="nowMs" />
+                    <SliceList :slices="groupSlices(gs.group)" :worker-jobs="sliceWorkerJobs" :now="nowMs" />
                   </td>
                 </tr>
               </template>

--- a/lib/iris/dashboard/src/components/controller/FleetOverview.vue
+++ b/lib/iris/dashboard/src/components/controller/FleetOverview.vue
@@ -1,0 +1,284 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { ScaleGroupStatus, SliceInfo, RunningTaskBucket } from '@/types/rpc'
+import { timestampMs } from '@/utils/formatting'
+import { CATEGORICAL_COLORS } from '@/types/status'
+
+// Header "what do we have, where" view: one card per chip type (e.g. v5p-64),
+// with a region breakdown and in-use share. Everything is derived from the
+// autoscaler groups + the scheduler running buckets the parent already fetches —
+// no extra RPCs. Region/chip are parsed from the scale-group name.
+
+const props = defineProps<{
+  groups: ScaleGroupStatus[]
+  runningBuckets: RunningTaskBucket[]
+}>()
+
+interface RegionCount {
+  region: string
+  count: number
+}
+
+interface BandCount {
+  band: string
+  count: number
+}
+
+interface RegionCapacity {
+  region: string
+  status: 'available' | 'limited' | 'blocked'
+  detail: string
+}
+
+interface FleetChipSummary {
+  chip: string
+  total: number
+  inUse: number
+  avgUptimeMs: number | null
+  regions: RegionCount[]
+  bands: BandCount[]
+  capacity: RegionCapacity[]
+}
+
+/** Map workerId → band (lowercased, no prefix) → task count. */
+const workerBands = computed<Map<string, Map<string, number>>>(() => {
+  const map = new Map<string, Map<string, number>>()
+  for (const bucket of props.runningBuckets) {
+    if (!bucket.workerId || !bucket.band) continue
+    const band = bucket.band.replace(/^PRIORITY_BAND_/, '').toLowerCase()
+    if (!map.has(bucket.workerId)) map.set(bucket.workerId, new Map())
+    const bands = map.get(bucket.workerId)!
+    bands.set(band, (bands.get(band) ?? 0) + bucket.count)
+  }
+  return map
+})
+
+/** True if any VM in the slice is currently running at least one task. */
+function sliceInUse(slice: SliceInfo): boolean {
+  return (slice.vms ?? []).some(vm => (vm.runningTaskCount ?? 0) > 0)
+}
+
+/** Extract chip type + size from scale group name.
+ *  e.g. "TPU_V5E_PREEMPTIBLE_16_US_EAST" → "v5e-16"
+ *       "TPU_V5P_SERVING_64_US_CENTRAL"  → "v5p-64"
+ *       "GPU_A100_8_US_CENTRAL"          → "A100-8"
+ */
+function chipFromGroupName(name: string): string | null {
+  const norm = name.toUpperCase().replace(/-/g, '_')
+  const tpuMatch = norm.match(/TPU_(V\d+[A-Z]?)_(?:PREEMPTIBLE|SERVING|ON_DEMAND|RESERVED)_(\d+)/)
+  if (tpuMatch) return `${tpuMatch[1].toLowerCase()}-${tpuMatch[2]}`
+  const tpuFallback = norm.match(/TPU_(V\d+[A-Z]?)_\w+_(\d+)/)
+  if (tpuFallback) return `${tpuFallback[1].toLowerCase()}-${tpuFallback[2]}`
+  const gpuMatch = norm.match(/(A100|H100|H200|L4|L40S?|B200)_(\d+)/)
+  if (gpuMatch) return `${gpuMatch[1]}-${gpuMatch[2]}`
+  if (norm.startsWith('CPU')) return null
+  return name
+}
+
+/** Extract region from scale group name, dropping the trailing zone letter.
+ *  e.g. "TPU_V5E_PREEMPTIBLE_16_US_WEST4_A" → "us-west4"
+ */
+function regionFromGroupName(name: string): string {
+  const norm = name.toUpperCase().replace(/-/g, '_')
+  const tpuMatch = norm.match(/TPU_V\d+[A-Z]?_(?:PREEMPTIBLE|SERVING|ON_DEMAND|RESERVED)_\d+_(.+)/)
+  if (tpuMatch) {
+    let region = tpuMatch[1]
+    region = region.replace(/_[A-Z]$/, '')
+    return region.toLowerCase().replace(/_/g, '-')
+  }
+  const fallback = norm.match(/_\d+_(.+)/)
+  if (fallback) return fallback[1].toLowerCase().replace(/_/g, '-')
+  return 'unknown'
+}
+
+const fleetSummary = computed<FleetChipSummary[]>(() => {
+  const now = Date.now()
+  const chips = new Map<string, { total: number; inUse: number; uptimes: number[]; regions: Map<string, number>; bands: Map<string, number>; capacityByRegion: Map<string, { statuses: string[]; failures: number }> }>()
+
+  for (const g of props.groups) {
+    const chip = chipFromGroupName(g.name)
+    if (chip == null) continue
+    const region = regionFromGroupName(g.name)
+    const entry = chips.get(chip) ?? { total: 0, inUse: 0, uptimes: [], regions: new Map(), bands: new Map<string, number>(), capacityByRegion: new Map<string, { statuses: string[]; failures: number }>() }
+
+    const readyCount = g.sliceStateCounts?.['ready'] ?? 0
+    const readySlices = (g.slices ?? []).filter(s => {
+      const state = s.state ?? (s.vms?.length ? 'ready' : '')
+      return state === 'ready' || state === 'SLICE_STATE_READY'
+    })
+
+    // Count slices (logical machines), not individual VMs.
+    const sliceCount = readySlices.length > 0 ? readySlices.length : readyCount
+    entry.total += sliceCount
+    entry.inUse += readySlices.filter(s => sliceInUse(s)).length
+    entry.regions.set(region, (entry.regions.get(region) ?? 0) + sliceCount)
+
+    const capEntry = entry.capacityByRegion.get(region) ?? { statuses: [], failures: 0 }
+    if (g.availabilityStatus) capEntry.statuses.push(g.availabilityStatus)
+    capEntry.failures += g.consecutiveFailures ?? 0
+    entry.capacityByRegion.set(region, capEntry)
+
+    // Assign each in-use slice to a single dominant band (the band with the most
+    // task-count across its VMs) so band shares partition slices rather than
+    // double-counting slices that host multiple bands.
+    for (const slice of readySlices) {
+      const sliceBandCounts = new Map<string, number>()
+      for (const vm of slice.vms ?? []) {
+        if (!vm.workerId) continue
+        const bands = workerBands.value.get(vm.workerId)
+        if (!bands) continue
+        for (const [band, count] of bands) {
+          sliceBandCounts.set(band, (sliceBandCounts.get(band) ?? 0) + count)
+        }
+      }
+      let topBand: string | null = null
+      let topCount = 0
+      for (const [band, count] of sliceBandCounts) {
+        if (count > topCount) {
+          topBand = band
+          topCount = count
+        }
+      }
+      if (topBand) {
+        entry.bands.set(topBand, (entry.bands.get(topBand) ?? 0) + 1)
+      }
+    }
+
+    // Average uptime: use the earliest VM createdAt per slice as the slice uptime.
+    for (const slice of readySlices) {
+      const vmTimes = (slice.vms ?? [])
+        .map(vm => timestampMs(vm.createdAt))
+        .filter((ms): ms is number => ms != null && ms > 0)
+      if (vmTimes.length > 0) {
+        entry.uptimes.push(now - Math.min(...vmTimes))
+      }
+    }
+    chips.set(chip, entry)
+  }
+
+  return Array.from(chips.entries())
+    .filter(([, c]) => c.total > 0)
+    .map(([chip, c]) => ({
+      chip,
+      total: c.total,
+      inUse: c.inUse,
+      avgUptimeMs: c.uptimes.length > 0
+        ? c.uptimes.reduce((a, b) => a + b, 0) / c.uptimes.length
+        : null,
+      regions: Array.from(c.regions.entries())
+        .map(([region, count]) => ({ region, count }))
+        .sort((a, b) => b.count - a.count),
+      bands: Array.from(c.bands.entries())
+        .map(([band, count]) => ({ band, count }))
+        .sort((a, b) => b.count - a.count),
+      capacity: Array.from(c.capacityByRegion.entries()).map(([region, cap]) => {
+        const hasQuotaExceeded = cap.statuses.includes('quota_exceeded')
+        const hasBackoff = cap.statuses.includes('backoff')
+        const hasAtCapacity = cap.statuses.includes('at_capacity')
+        if (hasQuotaExceeded) {
+          return { region, status: 'blocked' as const, detail: 'At Region Quota' }
+        }
+        if (hasAtCapacity || hasBackoff) {
+          return { region, status: 'limited' as const, detail: 'At TRC Capacity' }
+        }
+        return { region, status: 'available' as const, detail: 'Compute Potentially Available' }
+      }).sort((a, b) => {
+        const order = { blocked: 0, limited: 1, available: 2 }
+        return order[a.status] - order[b.status]
+      }),
+    }))
+    .sort((a, b) => b.total - a.total)
+})
+
+/** Stable color index for a region across all chip types. */
+const allRegions = computed<Map<string, number>>(() => {
+  const regionTotals = new Map<string, number>()
+  for (const c of fleetSummary.value) {
+    for (const r of c.regions) {
+      regionTotals.set(r.region, (regionTotals.get(r.region) ?? 0) + r.count)
+    }
+  }
+  const seen = new Map<string, number>()
+  for (const [region] of Array.from(regionTotals.entries()).sort((a, b) => b[1] - a[1])) {
+    seen.set(region, seen.size)
+  }
+  return seen
+})
+
+function regionColor(region: string): string {
+  const idx = allRegions.value.get(region) ?? 0
+  return CATEGORICAL_COLORS[idx % CATEGORICAL_COLORS.length]
+}
+
+function capacityTooltip(capacity: RegionCapacity[]): string {
+  if (capacity.length === 0) return ''
+  return 'Capacity:\n' + capacity
+    .map(c => {
+      const icon = c.status === 'available' ? '✓' : c.status === 'limited' ? '~' : '✗'
+      return `  ${icon} ${c.region}: ${c.detail}`
+    })
+    .join('\n')
+}
+
+function formatUptimeShort(ms: number | null): string {
+  if (ms == null) return '-'
+  const secs = Math.floor(ms / 1000)
+  if (secs < 3600) return `${Math.floor(secs / 60)}m`
+  const hours = Math.floor(secs / 3600)
+  if (hours < 24) return `${hours}h ${Math.floor((secs % 3600) / 60)}m`
+  return `${Math.floor(hours / 24)}d ${hours % 24}h`
+}
+</script>
+
+<template>
+  <section v-if="fleetSummary.length > 0">
+    <h3 class="text-sm font-semibold text-text-secondary uppercase tracking-wider mb-3">
+      Fleet Overview
+    </h3>
+    <div class="grid grid-cols-4 gap-2">
+      <div
+        v-for="c in fleetSummary"
+        :key="c.chip"
+        class="rounded-lg border border-surface-border bg-surface px-4 py-2"
+        :title="capacityTooltip(c.capacity)"
+      >
+        <div class="flex items-baseline gap-[0.4vw] mb-1" style="font-size: clamp(10px, 0.75vw, 14px)">
+          <span class="font-semibold font-mono tabular-nums text-text" style="font-size: clamp(14px, 1.1vw, 22px)">{{ c.total }}</span>
+          <span class="font-medium text-text-secondary uppercase whitespace-nowrap">{{ c.chip }}</span>
+          <span class="tabular-nums" :class="c.total > 0 && c.inUse === c.total ? 'text-status-warning' : 'text-text-muted'">
+            {{ c.total > 0 ? Math.round(c.inUse / c.total * 100) : 0 }}% in use
+          </span>
+          <span class="text-text-muted tabular-nums whitespace-nowrap">
+            avg uptime {{ formatUptimeShort(c.avgUptimeMs) }}
+          </span>
+        </div>
+        <!-- Region bar -->
+        <div class="flex rounded-full overflow-hidden bg-surface-sunken" style="height: clamp(4px, 0.4vw, 8px)">
+          <div
+            v-for="r in c.regions"
+            :key="r.region"
+            class="transition-all"
+            :style="{ width: (r.count / c.total * 100) + '%', backgroundColor: regionColor(r.region) }"
+          />
+        </div>
+        <div class="flex flex-wrap gap-x-[0.5vw] gap-y-0.5 mt-0.5" style="font-size: clamp(8px, 0.6vw, 11px)">
+          <span
+            v-for="r in c.regions"
+            :key="r.region"
+            class="text-text-muted flex items-center gap-0.5"
+          >
+            <span class="rounded-full inline-block" :style="{ backgroundColor: regionColor(r.region), width: 'clamp(4px, 0.4vw, 8px)', height: 'clamp(4px, 0.4vw, 8px)' }" />
+            {{ r.region }} ({{ r.count }})
+          </span>
+        </div>
+        <!-- Priority band breakdown -->
+        <div v-if="c.bands.length > 0" class="mt-0.5 text-text-muted" style="font-size: clamp(8px, 0.6vw, 11px)">
+          <span v-for="(b, i) in c.bands" :key="b.band">
+            <span v-if="i > 0">, </span>
+            {{ c.total > 0 ? Math.round(b.count / c.total * 100) : 0 }}% {{ b.band }}
+          </span>
+        </div>
+      </div>
+    </div>
+  </section>
+</template>

--- a/lib/iris/dashboard/src/components/controller/FleetOverview.vue
+++ b/lib/iris/dashboard/src/components/controller/FleetOverview.vue
@@ -93,13 +93,13 @@ function regionFromGroupName(name: string): string {
 
 const fleetSummary = computed<FleetChipSummary[]>(() => {
   const now = Date.now()
-  const chips = new Map<string, { total: number; inUse: number; uptimes: number[]; regions: Map<string, number>; bands: Map<string, number>; capacityByRegion: Map<string, { statuses: string[]; failures: number }> }>()
+  const chips = new Map<string, { total: number; inUse: number; uptimes: number[]; regions: Map<string, number>; bands: Map<string, number>; capacityByRegion: Map<string, string[]> }>()
 
   for (const g of props.groups) {
     const chip = chipFromGroupName(g.name)
     if (chip == null) continue
     const region = regionFromGroupName(g.name)
-    const entry = chips.get(chip) ?? { total: 0, inUse: 0, uptimes: [], regions: new Map(), bands: new Map<string, number>(), capacityByRegion: new Map<string, { statuses: string[]; failures: number }>() }
+    const entry = chips.get(chip) ?? { total: 0, inUse: 0, uptimes: [], regions: new Map(), bands: new Map<string, number>(), capacityByRegion: new Map<string, string[]>() }
 
     const readyCount = g.sliceStateCounts?.['ready'] ?? 0
     const readySlices = (g.slices ?? []).filter(s => {
@@ -113,10 +113,9 @@ const fleetSummary = computed<FleetChipSummary[]>(() => {
     entry.inUse += readySlices.filter(s => sliceInUse(s)).length
     entry.regions.set(region, (entry.regions.get(region) ?? 0) + sliceCount)
 
-    const capEntry = entry.capacityByRegion.get(region) ?? { statuses: [], failures: 0 }
-    if (g.availabilityStatus) capEntry.statuses.push(g.availabilityStatus)
-    capEntry.failures += g.consecutiveFailures ?? 0
-    entry.capacityByRegion.set(region, capEntry)
+    const statuses = entry.capacityByRegion.get(region) ?? []
+    if (g.availabilityStatus) statuses.push(g.availabilityStatus)
+    entry.capacityByRegion.set(region, statuses)
 
     // Assign each in-use slice to a single dominant band (the band with the most
     // task-count across its VMs) so band shares partition slices rather than
@@ -171,14 +170,14 @@ const fleetSummary = computed<FleetChipSummary[]>(() => {
       bands: Array.from(c.bands.entries())
         .map(([band, count]) => ({ band, count }))
         .sort((a, b) => b.count - a.count),
-      capacity: Array.from(c.capacityByRegion.entries()).map(([region, cap]) => {
-        const hasQuotaExceeded = cap.statuses.includes('quota_exceeded')
-        const hasBackoff = cap.statuses.includes('backoff')
-        const hasAtCapacity = cap.statuses.includes('at_capacity')
-        if (hasQuotaExceeded) {
+      capacity: Array.from(c.capacityByRegion.entries()).map(([region, statuses]) => {
+        if (statuses.includes('quota_exceeded')) {
           return { region, status: 'blocked' as const, detail: 'At Region Quota' }
         }
-        if (hasAtCapacity || hasBackoff) {
+        if (statuses.includes('at_max_slices')) {
+          return { region, status: 'limited' as const, detail: 'At Max Slices' }
+        }
+        if (statuses.includes('backoff')) {
           return { region, status: 'limited' as const, detail: 'At TRC Capacity' }
         }
         return { region, status: 'available' as const, detail: 'Compute Potentially Available' }


### PR DESCRIPTION
Bring back two creature comforts that were dropped when the autoscaler and scheduler tabs were merged into the capacity tab in #6416. Both are reconstructed from data the capacity tab already fetches, so neither adds an RPC. 

Fleet Overview header: per-chip cards (e.g. v5p-64) showing how many slices are allocated, broken down by region with an in-use share and average uptime. Derived from the autoscaler groups plus the scheduler running buckets; chip type and region are parsed from the scale-group name. Lives in a new FleetOverview.vue so the already-large capacity tab does not grow back toward the size that motivated the merge.

Per-node job links: the capacity tab was passing an empty worker-jobs map into SliceList, so expanded slice rows no longer linked to the jobs running on each host. Rebuild the worker_id to jobs map from the running buckets the users table already loads and feed it to SliceList, which restores the per-job links.