### PR TITLE
[iris] Stage CUDA toolchain for GPU tasks

### DIFF
--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -854,3 +854,47 @@
 - Next action: Productionize the ring-gather dispatch-up path behind the
   Mosaic/Grug MoE backend boundary, with an explicit correctness check for the
   receiver-local row metadata or a full combine path.
+
+### 2026-06-24 - Fused Pallas ready-dispatch plus block-ready W13 diagnostic
+
+- Hypothesis: Calling scratch-ready Mosaic GPU dispatch and block-ready Mosaic
+  GPU W13/SiLU inside one `jax.jit(shard_map(...))` may expose enough
+  producer/consumer structure for scheduling overlap, or at least quantify the
+  gap before attempting a deeper single-kernel rewrite.
+- Changes:
+  - Added `--run-pallas-fused-dispatch-up` to
+    `bench_moe_dispatch_up_mosaic_gpu.py`.
+  - The mode invokes `dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local`
+    or `dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local`,
+    immediately feeds the resulting `recv_x` and `ready_block_count` to
+    `compute_moe_up_mosaic_gpu_block_ready_local`, and reports W13/reference
+    parity plus exact ready-count checks.
+- Commands:
+  - Local validation: `uv run --package marin-levanter python -m py_compile lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py`
+  - Local checks: `./infra/pre-commit.py --changed-files --fix`
+  - H128 correctness: `... --job-name dlwh-6597-moe-pallas-fused-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --recv-capacity-factor 1.25 --dispatch-copy-mode scratch_ready --dispatch-rows-per-program 4 --w13-impl mosaic_gpu_block_ready --run-pallas-fused-dispatch-up --bench-iters 1 --warmup-steps 1`
+  - H2560/T=8 correctness: `... --job-name dlwh-6597-moe-pallas-fused-h2560-t8 -- ... --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --recv-capacity-factor 1.25 --dispatch-copy-mode scratch_ready --dispatch-rows-per-program 4 --w13-impl mosaic_gpu_block_ready --run-pallas-fused-dispatch-up --bench-iters 1 --warmup-steps 1`
+  - T/rank=4096 perf attempt: `... --job-name dlwh-6597-moe-pallas-fused-t4096-buf100 -- ... --tokens-per-rank 4096 --hidden 2560 --intermediate 2560 --recv-capacity-factor 1.0 --dispatch-copy-mode scratch_ready --dispatch-rows-per-program 16 --run-pallas-fused-dispatch-up --skip-reference-checks --bench-iters 1 --warmup-steps 1`
+- Result:
+  - H128: ready-count and ready-block-count errors `0`; W13 max abs
+    `0.0078125`; steady `1.604 ms`.
+  - H2560/T=8: ready-count and ready-block-count errors `0`; W13 max abs
+    `0.015625`; steady `1.951 ms`.
+  - T/rank=4096 0% buffer: prepack completed in `27.3 s`, then the fused
+    Pallas candidate produced no timing or error after roughly 40 minutes in
+    compile/run. The job was stopped to avoid burning more H100 time:
+    `/dlwh/dlwh-6597-moe-pallas-fused-t4096-buf100`.
+- Interpretation: The fused diagnostic is correct on the requested H=I=2560,
+  E=256, topk=4 validation shape at T/rank=8 and narrowly under 2 ms there.
+  It is not viable for the relevant T/rank=4096 throughput shape in the current
+  prepacked scratch-ready form: compilation/codegen does not return in a
+  practical window, whereas the ring-gather built-in collective path returns
+  `1.816-1.861 ms` across 0-25% buffers. A real overlapped Mosaic path likely
+  needs a smaller in-kernel/ring transport schedule or a production
+  ring-gather/GMM integration rather than the current giant prepacked scratch
+  dispatch.
+- Next action: Treat the current prepacked scratch-ready fused path as a
+  validation/negative-result harness. For production, integrate the correct
+  ring-gather dispatch-up path first, or redesign Mosaic dispatch around a
+  streaming fixed-neighbor schedule that avoids the `EP x send_capacity x H`
+  scratch/prepack shape.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -1347,3 +1347,36 @@
   chunks step-by-step instead of waiting for a completed all-to-all result.
 - Next action: Build the first ordered cumulative-semaphore compact ring-step
   Mosaic prototype on H128, then target cap 64/80 once correctness is stable.
+
+### 2026-06-24 11:58 PT - Ordered compact ring transport prototype
+
+- Hypothesis: A compact source/expert ring transport using cumulative GMEM
+  semaphore thresholds can reproduce compact all-to-all layout and become the
+  producer side of the overlapped W13 kernel.
+- Change:
+  - Added `compact_source_expert_ring_transport_mosaic_gpu_local`.
+  - Added `--run-compact-ring-transport` to compare the Mosaic ring-step
+    transport against `lax.all_to_all` compact transport.
+  - The transport uses one cumulative regular semaphore and waits with
+    `decrement=False`, matching the local JAX collective-matmul pattern.
+- Commands:
+  - H128 correctness: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-compact-ring-transport-h128-rowvec -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --run-compact-ring-transport --bench-iters 1 --warmup-steps 1`
+  - Target cap64: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-compact-ring-transport-target-cap64-rowvec --env-vars JAX_OPTIMIZATION_LEVEL O1 --env-vars XLA_FLAGS "--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true" -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.0 --source-expert-capacity 64 --run-compact-ring-transport --skip-reference-checks --bench-iters 3 --warmup-steps 1`
+- Results:
+  - H128 ring transport matched compact all-to-all exactly: `x` max abs error
+    `0`, count max abs error `0`; steady `1.439 ms`.
+  - Initial target cap64 attempt with 256-column tiled row copies failed during
+    Mosaic layout inference with a recursion error.
+  - Switching to a single row-vector remote assignment fixed target lowering.
+  - Target cap64 ring transport matched compact all-to-all exactly: `x` max abs
+    error `0`, count max abs error `0`; steady mean `1.792 ms` (min `1.752`,
+    max `1.848`).
+- Interpretation: The ordered cumulative-semaphore transport is correct at the
+  target shape, so the synchronization substrate is proven. However, the raw
+  ring row-vector transport is much slower than built-in compact all-to-all
+  transport (`~0.56 ms` at cap64). A successful overlap kernel must either
+  overlap this transport aggressively with W13 or replace the row-vector copy
+  with a bulk/pipelined copy path that avoids the layout-inference blow-up.
+- Next action: Insert W13 consumption into the ordered ring step on H128 first.
+  If the target transport remains too expensive, revisit the transport copy as
+  a separate bulk-copy optimization before tuning for `<2 ms`.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -85,3 +85,25 @@
   by reverse dispatch from destination rows to source-rank token gradients.
 - Next action: Port the W13/SiLU VJP and reverse dispatch to Mosaic GPU, then
   profile the serial forward dispatch to prioritize tiled/staged copies.
+
+### 2026-06-23 - Steady-state perf harness kickoff
+
+- Hypothesis: Separating compile-including timings from steady-state timings
+  will make the serial dispatch bottleneck visible enough to guide the next
+  tiled/staged-copy implementation.
+- Command: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name 6597-moe-dispatch-up-perf-1 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 64 --intermediate 64 --dtype bf16 --run-pallas --bench-iters 3 --warmup-steps 1`
+- Config: Single-node CoreWeave `cw-us-east-02a`, H100x8, explicit `expert`
+  mesh, bf16, `H=64`, `I=64`, `T/rank=8`, top-k 4, four local experts per
+  rank.
+- Result:
+  - Dispatch compile-including: 106.7 s.
+  - Dispatch steady-state: mean 1.897 ms, min 1.776 ms, max 2.000 ms.
+  - W13/SiLU compile-including: 615 ms.
+  - W13/SiLU steady-state: mean 0.201 ms, min 0.188 ms, max 0.213 ms.
+  - Correctness remained clean: dispatch max error 0, metadata errors 0,
+    W13/SiLU max bf16 error 2.
+- Interpretation: The deliberately serial validation dispatch is already the
+  dominant steady-state cost on this small shape. The next performance step
+  should replace scalar row writes with tiled SMEM-staged remote copies.
+- Next action: Implement tiled dispatch copy path and rerun the same steady-state
+  command for an apples-to-apples comparison.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -753,3 +753,51 @@
   then either profile the ragged path to split sort/collective/W13 costs or
   prototype a fixed-neighbor ring/all-gather schedule that avoids arbitrary-peer
   TMA while enabling overlap.
+
+### 2026-06-24 - Ragged all-to-all dispatch-up stage breakdown
+
+- Hypothesis: The ~6 ms T/rank=4096 ragged collective dispatch-up baseline is
+  dominated by either the source-side sort/compact, the collective/local
+  receive permute, or W13 on the real routed layout. Splitting those stages
+  should tell us whether overlap can plausibly reach <2 ms or whether transport
+  must be replaced.
+- Changes:
+  - Added `--run-ragged-a2a-breakdown` stage splits to
+    `bench_moe_dispatch_up_mosaic_gpu.py`.
+  - The split reports full ragged dispatch-only, W13 on the dispatched layout,
+    pre-collective sort/compact/all-gather, ragged-all-to-all plus local
+    permute, and W13 on the transport output.
+- Commands:
+  - Local validation: `uv run --package marin-levanter python -m py_compile lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py`
+  - Local checks: `./infra/pre-commit.py --changed-files --fix`
+  - H128 split correctness: `... --job-name dlwh-6597-moe-ragged-a2a-breakdown-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --run-ragged-a2a-breakdown --w13-impl ragged_dot --ragged-dot-impl auto --bench-iters 1 --warmup-steps 1`
+  - H128 deep split correctness: `... --job-name dlwh-6597-moe-ragged-a2a-deep-breakdown-h128 -- ... same command after adding pre-collective/transport split`
+  - T/rank=4096 split: `... --job-name dlwh-6597-moe-ragged-a2a-breakdown-t4096 -- ... for factor in 1.0 1.25; do ... --tokens-per-rank 4096 --hidden 2560 --intermediate 2560 --recv-capacity-factor $factor --run-ragged-a2a-breakdown --skip-reference-checks --bench-iters 2 --warmup-steps 1; done`
+  - T/rank=4096 deep split: `... --job-name dlwh-6597-moe-ragged-a2a-deep-breakdown-t4096-buf100 -- ... --recv-capacity-factor 1.0 --run-ragged-a2a-breakdown --skip-reference-checks --bench-iters 2 --warmup-steps 1`
+- Result:
+  - H128 split remained correct: max abs error `1.90735e-06`.
+    Full dispatch-only `0.584-0.597 ms`; W13 on dispatched layout
+    `0.187-0.217 ms`. Deep split: pre-collective `0.420 ms`,
+    transport/local-permute `0.438 ms`, W13 `0.157 ms`. Separate launches sum
+    higher than fused end-to-end, so use large-shape splits for bottleneck
+    allocation.
+  - T/rank=4096 top-level split:
+    - 0% buffer: dispatch-only `5.036-5.038 ms`, W13 `1.138-1.149 ms`,
+      sum `6.174-6.187 ms`.
+    - 25% buffer: dispatch-only `5.140 ms`, W13 `1.347 ms`, sum `6.487 ms`.
+  - T/rank=4096 deep split at 0% buffer:
+    - pre-collective sort/compact/all-gather: `0.796 ms`.
+    - ragged-all-to-all plus local receive permute: `4.595 ms`.
+    - W13 on transport layout: `1.137 ms`.
+    - deep split sum: `6.527 ms` (extra launch overhead versus fused).
+- Interpretation: The front sort/compact is not the blocker. The target gap is
+  almost entirely the built-in ragged transport/local-permute stage. Even perfect
+  overlap of W13 under current ragged dispatch would leave roughly a 5 ms
+  dispatch floor, so <2 ms requires replacing that transport/local-permute
+  structure. The next viable direction is a fixed-neighbor/ring/all-gather style
+  schedule that avoids arbitrary-peer TMA and avoids the expensive ragged
+  all-to-all/local re-permute, or a lower-level collective primitive that can
+  produce the expert-major layout directly.
+- Next action: Prototype a fixed-neighbor ring/all-gather dispatch layout for
+  dispatch-up, using the ragged collective baseline as the correctness oracle
+  and preserving built-in `ragged_dot` for W13.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -325,3 +325,38 @@
   later overlapped prototype only after dispatch is improved, likely by
   coarsening row programs into larger transfer tiles or fusing compaction with
   W13 consumption.
+
+### 2026-06-24 - Large-token grouped W13 baseline
+
+- Hypothesis: At the more relevant per-rank token count
+  `T/rank=4096 * 8 = 32768`, the W13/SiLU grouped matmul should be compute
+  intensive, not HBM-bound. Built-in Haliax `ragged_dot(auto)` should provide a
+  stronger target than `ragged_dot_general` XLA lowering.
+- Commands:
+  - XLA grouped matmul baseline: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 3600 --job-name dlwh-6597-moe-bigshape-ragged-dot-xla -- ... bench_moe_dispatch_up_mosaic_gpu.py --synthetic-layout --ep-size 8 --tokens-per-rank 32768 --recv-capacity 131072 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --w13-impl ragged_dot --ragged-dot-impl xla --bench-iters 3 --warmup-steps 1`
+  - Triton/auto grouped matmul baseline: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 3600 --job-name dlwh-6597-moe-bigshape-ragged-dot-auto -- ... bench_moe_dispatch_up_mosaic_gpu.py --synthetic-layout --ep-size 8 --tokens-per-rank 32768 --recv-capacity-factor 1.0 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --w13-impl ragged_dot --ragged-dot-impl auto --bench-iters 3 --warmup-steps 1`
+- Config: Single-node CoreWeave `cw-us-east-02a`, H100x8, synthetic
+  expert-major layout, bf16, `H=2560`, `I=2560`, top-k 4, 32 local experts per
+  rank, 256 global experts, Grug-truncated expert weights. Capacity was sized
+  to 0% buffer for the balanced synthetic layout:
+  `recv_capacity=32768 * 4 = 131072`, so each local expert received 4096 rows.
+- Result:
+  - XLA `ragged_dot_general` W13/SiLU steady-state mean was 139.973 ms,
+    measuring 196.38 TFLOP/s.
+  - Haliax `ragged_dot(auto)`, which selects the Pallas Triton grouped matmul
+    on GPU, compiled in 370.7 ms and reached steady-state mean 7.321 ms,
+    measuring 3754.64 TFLOP/s.
+  - Large-shape roofline summary: 1,048,576 routed rows globally; W13 work
+    27.49 PFLOP; estimated W13 bytes 17.45 GB; arithmetic intensity
+    1575 flop/byte including activations and weights; simple 8xH100 BF16
+    peak estimate 7912 TFLOP/s.
+- Interpretation: The earlier `~1 flop/byte` estimate was only true for the
+  tiny `T/rank=8` probe. At the large token count, W13/SiLU is compute
+  intensive and the built-in Triton grouped matmul is the relevant baseline.
+  The measured 7.321 ms is about 47% of the simple BF16 peak estimate; the
+  W13-only compute lower bound is roughly 3.5 ms, so a `<2 ms` end-to-end
+  target for this full W13 shape is below roofline.
+- Next action: Treat `ragged_dot(auto)` as the grouped W13 baseline and focus
+  Mosaic work on dispatch/overlap only where it can improve end-to-end time.
+  Benchmark capacity should be expressed as a per-rank routed-token factor:
+  1.0 for no buffer and roughly 1.1-1.25 for normal imbalance.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -1225,3 +1225,91 @@
   substrate, but shift the next implementation attempt toward a collective
   ring/all-gather schedule or built-in GMM path that can overlap transport with
   W13 instead of relying on per-row arbitrary peer async copies.
+
+### 2026-06-24 10:55 PT - Ring/all-gather transport with Mosaic W13
+
+- Hypothesis: The compact source/expert shape fix was necessary, but the
+  arbitrary peer-copy transport is the wrong primitive. Reusing the Grug
+  ring/all-gather dispatch layout and feeding it to the tuned Mosaic W13 kernel
+  should isolate whether the collective substrate is close enough for overlap.
+- Changes:
+  - Added `--run-ring-gather-mosaic-dispatch-up` to the benchmark harness.
+  - The new path calls `_dispatch_up_ep_ring_local`, then runs
+    `compute_moe_up_mosaic_gpu_local` on `dispatch.x_dispatch` and
+    `dispatch.group_sizes`.
+  - Large candidate runs with this flag now participate in the
+    `--skip-reference-checks` prepack skip path.
+- Commands:
+  - Syntax: `uv run --package marin-levanter python -m py_compile lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py`
+  - H128 validation: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-ring-mosaic-h128 -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --run-ring-gather-dispatch-up --run-ring-gather-mosaic-dispatch-up --bench-iters 1 --warmup-steps 1`
+  - Target comparison: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-ring-mosaic-target --env-vars JAX_OPTIMIZATION_LEVEL O1 --env-vars XLA_FLAGS "--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true" -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --run-ring-gather-dispatch-up --run-ring-gather-mosaic-dispatch-up --skip-reference-checks --bench-iters 3 --warmup-steps 1`
+- Result:
+  - H128 ring+ragged: steady `0.315 ms`, max abs error `1.90735e-06`.
+  - H128 ring+Mosaic: steady `0.359 ms`, max abs error `0.0078125`.
+  - Target ring+ragged: steady mean `1.889 ms`, min `1.843`, max `1.917`,
+    dropped `0`.
+  - Target ring+Mosaic: steady mean `2.221 ms`, min `2.199`, max `2.254`,
+    dropped `0`.
+- Interpretation: The collective/ring substrate is the right next direction.
+  Ring+Mosaic is much faster than compact peer-copy Mosaic (`3.722 ms`) and is
+  within `0.221 ms` of the `<2 ms` goal, while ring+ragged remains below target.
+  This supports moving the overlap work toward the ring/all-gather schedule
+  rather than generic arbitrary peer refs.
+- Next action: Sweep Mosaic W13 tile/schedule choices on the ring transport
+  layout; if one gets below `2 ms`, promote that as the current Mosaic
+  dispatch-up target path.
+
+### 2026-06-24 11:25 PT - Compact source/expert all-to-all Mosaic path
+
+- Direction update: The Mosaic-facing subkernel should not consume the old
+  destination-major `[dst, T*K, H]` prepack. The compact shape is
+  `[dst, local_expert, source_expert_capacity, H]` on the sender and
+  `[src, local_expert, source_expert_capacity, H]` on the receiver. For the
+  target shape, balanced source/expert rows are `4096 * 4 / 256 = 64`, so a
+  25% buffer uses `source_expert_capacity=80` instead of `T*K=16384`.
+- Changes:
+  - Added a diagnostic `--run-compact-a2a-mosaic-dispatch-up` path.
+  - The path builds the compact source/expert prepack, exchanges compact
+    groups with `lax.all_to_all`, runs Mosaic W13 over padded
+    `(source, local_expert)` groups, then scatters the compact result back to
+    the destination-major layout only for correctness comparison.
+  - Added `compute_moe_up_mosaic_gpu_source_expert_padded_local`, which indexes
+    local W13 weights by `group_id % local_experts` so compact source/expert
+    groups do not require an 8x weight materialization.
+- H128 correctness:
+  - First H128 attempt `/dlwh/dlwh-6597-moe-compact-a2a-mosaic-h128` failed
+    before running the kernel because `_print_source_expert_load_stats` assumed
+    the old prepack type.
+  - Rerun `/dlwh/dlwh-6597-moe-compact-a2a-mosaic-h128-capmax` succeeded with
+    inferred `source_expert_capacity=4`, zero overflow, max abs error
+    `0.0078125`, and steady `0.390 ms`.
+  - Tiny H128 has balanced source/expert rows `1` but max count `4`; therefore
+    the usual 1.25x/2x caps intentionally overflow this synthetic routing and
+    are not appropriate for correctness.
+- Target command:
+  - `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-compact-a2a-mosaic-target-cap80 --env-vars JAX_OPTIMIZATION_LEVEL O1 --env-vars XLA_FLAGS "--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true" -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --source-expert-capacity 80 --block-m 64 --block-n 128 --block-k 64 --num-stages 4 --grid-block-n 1 --run-compact-a2a-mosaic-dispatch-up --skip-reference-checks --bench-iters 3 --warmup-steps 1`
+- Target results:
+  - `/dlwh/dlwh-6597-moe-compact-a2a-mosaic-target-cap80` succeeded with cap
+    `80`, zero overflow, and steady `15.351 ms`. This path scattered the
+    compact W13 output back into the old destination-major layout.
+  - `/dlwh/dlwh-6597-moe-compact-a2a-mosaic-target-cap80-compactout` skipped
+    the destination-major scatter but still used 256 padded source/expert W13
+    groups; steady was `14.273 ms`. The scatter was not the primary issue.
+  - `/dlwh/dlwh-6597-moe-compact-a2a-mosaic-target-cap80-merge` merged source
+    groups per local expert before W13, giving cap `80`, zero overflow, and
+    steady mean `2.706 ms` (min `2.147`, max `3.013`).
+  - `/dlwh/dlwh-6597-moe-compact-a2a-mosaic-target-cap64-merge` used 0% buffer
+    with cap `64`, zero overflow for the deterministic Grug-style routing, and
+    steady mean `2.399 ms` (min `1.864`, max `2.559`).
+- Interpretation: Compact all-to-all plus merged local-expert W13 is the right
+  compact substrate shape. It preserves the source/expert capacity win and gets
+  near the ring+Mosaic diagnostic, but it is not stably below `2 ms` without
+  overlap. Running W13 directly on 256 `(source, expert)` groups is
+  pathological; W13 should consume merged local-expert groups or a pipelined
+  equivalent.
+- Next action: Read the target result. If compact all-to-all plus compact
+  Mosaic W13 is near the ring+Mosaic `2.221 ms` result, use it as the substrate
+  for overlap. The immediate overlap implementation should keep
+  source/expert-capacity transport but feed merged local-expert W13 tiles as
+  each source chunk arrives, instead of materializing all compact chunks and
+  then launching W13.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -480,3 +480,47 @@
 - Next action: Replace the full-kernel ready marking with a row/block
   coordinator that signals block readiness as soon as each receive block is
   complete, then run W13 from the block-ready schedule.
+
+### 2026-06-24 - Block-ready W13 consumer
+
+- Hypothesis: A W13/SiLU consumer that still schedules expert-major blocks but
+  masks stores with `ready_block_count[recv_block]` should preserve the fast
+  non-fragmented Mosaic W13 schedule while testing the consumer-side
+  block-readiness contract.
+- Commands:
+  - Local validation:
+    `uv run --package marin-levanter --group test pytest lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py -q`
+  - H128 smoke: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-block-ready-w13-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode scratch_ready --w13-impl mosaic_gpu_block_ready --bench-iters 1 --warmup-steps 1`
+  - H2560 relevant-shape smoke: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-block-ready-w13-h2560-grug -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode scratch_ready --w13-impl mosaic_gpu_block_ready --bench-iters 2 --warmup-steps 1`
+- Config: Single-node CoreWeave `cw-us-east-02a`, H100x8, explicit `expert`
+  mesh, Grug-truncated weights, top-k 4, `T/rank=8`, capacity factor 1.25.
+  This matches the normal 10-25% imbalance buffer; use
+  `--recv-capacity-factor 1.0` when probing the no-buffer case.
+- Result:
+  - Local tests passed (`11 passed`), and `./infra/pre-commit.py
+    --changed-files --fix` passed.
+  - H128: dispatch max error 0, metadata errors 0, source/expert ready-count
+    max error 0, block-ready-count max error 0. Block-ready W13/SiLU
+    steady-state mean 0.210 ms versus 0.169 ms reference JIT, with max abs
+    error 0.0078125.
+  - H2560: dispatch max error 0, metadata errors 0, source/expert ready-count
+    max error 0, block-ready-count max error 0. Dispatch steady-state mean
+    1.680 ms versus 0.772 ms reference JIT. Block-ready W13/SiLU
+    steady-state mean 0.610 ms versus 8.514 ms reference JIT, with max abs
+    error 0.015625.
+  - H2560 roofline summary for this small-token probe: 256 routed rows,
+    dispatch payload 1280 KiB, W13 work 6710.886 MFLOP, arithmetic intensity
+    1.000 flop/byte, measured W13 11.00 TFLOP/s, estimated HBM-bound W13
+    roofline 26.79 TFLOP/s.
+- Interpretation: The block-ready consumer fixes the fragmentation regression
+  from source/expert range scheduling and returns W13 to the expected
+  expert-major Mosaic speed on the relevant H2560 shape. This is still not the
+  overlapped kernel: readiness is produced after the full dispatch barrier. The
+  result does say that overlap should be built around coalesced block readiness
+  and a non-fragmented W13 consumer. For production, the built-in grouped
+  matmul path remains the better consumer target unless we need custom
+  synchronization inside the W13 kernel itself.
+- Next action: Implement the actual overlapped path by signaling block
+  readiness at receive-block completion and feeding a non-fragmented W13
+  consumer. Keep benchmark capacity factors at 1.0 for no-buffer probes and
+  1.1-1.25 for realistic imbalance.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -827,6 +827,7 @@
   - Fixed-neighbor H128 correctness: `... --job-name dlwh-6597-moe-fixed-neighbor-h128 -- ... bench_moe_mgpu_block_transport.py --ep-size 8 --rows 32 --hidden 128 --block-rows 16 --block-cols 128 --dtype bf16 --fixed-neighbor --bench-iters 2 --warmup-steps 1`
   - Fixed-neighbor H2560 bulk probe: `... --job-name dlwh-6597-moe-fixed-neighbor-h2560-rows2560 -- ... --rows 2560 --hidden 2560 --block-rows 32 --block-cols 256 --fixed-neighbor --skip-reference-checks --bench-iters 2 --warmup-steps 1`
   - Ring-gather H128 smoke: `... --job-name dlwh-6597-moe-ring-gather-up-h128-nopad-gmm -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --recv-capacity-factor 1.25 --run-ring-gather-dispatch-up --skip-reference-checks --ragged-dot-impl auto --bench-iters 1 --warmup-steps 1`
+  - Ring-gather H128 correctness: `... --job-name dlwh-6597-moe-ring-gather-up-h128-correctness -- ... same shape with --run-ring-gather-dispatch-up and reference checks enabled`
   - Ring-gather T/rank=4096 buffer sweep: `... --job-name dlwh-6597-moe-ring-gather-up-t4096-nopad-sweep -- ... for factor in 1.0 1.1 1.25; do ... --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --recv-capacity-factor $factor --run-ring-gather-dispatch-up --skip-reference-checks --ragged-dot-impl auto --bench-iters 2 --warmup-steps 1; done`
 - Result:
   - Fixed-neighbor H128 was correct: max abs error `0`, steady `1.492 ms` for
@@ -836,6 +837,8 @@
     a seven-hop ring unattractive versus built-in collectives.
   - Ring-gather H128 25% capacity smoke lowered and ran at `0.340 ms`, dropped
     `0`.
+  - Ring-gather H128 with reference checks enabled matched the W13 oracle: max
+    abs error `1.90735e-06`, dropped `0`, steady `0.400 ms`.
   - Ring-gather T/rank=4096, H=I=2560, E=256, topk=4, Grug-truncated weights:
     - 0% buffer (`recv_capacity=16384`): dropped `0`, steady `1.816 ms`.
     - 10% buffer (`recv_capacity=18023`): dropped `0`, steady `1.856 ms`.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -569,3 +569,49 @@
   all-gather matmul pattern.
 - Next action: Replace the scratch row-copy transport with block/coalesced
   receive writes before rerunning T/rank=4096 or the full T/rank=32768 shape.
+
+### 2026-06-24 - Direct-ready dispatch transport probe
+
+- Hypothesis: The stalled T/rank=4096 probes may be dominated by the scratch
+  transport's second local compaction pass. A direct-ready transport that writes
+  routed rows straight into final receive buffers, then emits the same
+  source/expert and block readiness metadata, should isolate whether scratch
+  compaction or row-wise remote writes are the large-shape blocker.
+- Changes:
+  - Added `direct_ready` dispatch mode. It uses the same dynamic row-program
+    structure as `scratch_ready`, but writes remote rows directly into
+    destination `recv_x` and metadata buffers.
+  - Added an explicit zero barrier before remote writes so destination-local
+    output initialization cannot race with incoming writes.
+- Commands:
+  - Local validation: `uv run --package marin-levanter python -m py_compile lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py`
+  - Local checks: `./infra/pre-commit.py --changed-files --fix`
+  - H128 smoke: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-direct-ready-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode direct_ready --dispatch-rows-per-program 16 --w13-impl mosaic_gpu_block_ready --bench-iters 1 --warmup-steps 1`
+  - Required H2560 validation: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-direct-ready-h2560 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode direct_ready --dispatch-rows-per-program 16 --w13-impl mosaic_gpu_block_ready --bench-iters 2 --warmup-steps 1`
+  - Stopped medium candidate: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-direct-ready-t4096-ragged -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --send-capacity-factor 1.25 --run-pallas --dispatch-copy-mode direct_ready --dispatch-rows-per-program 16 --w13-impl ragged_dot --ragged-dot-impl auto --skip-reference-checks --bench-iters 2 --warmup-steps 1`
+- Result:
+  - H128: dispatch max error 0, metadata errors 0, source/expert ready-count
+    max error 0, block-ready-count max error 0. Dispatch steady-state mean
+    1.628 ms. Block-ready W13/SiLU steady-state mean 0.193 ms, max abs error
+    0.0078125.
+  - H2560 required validation: dispatch max error 0, metadata errors 0,
+    source/expert ready-count max error 0, block-ready-count max error 0.
+    Dispatch steady-state mean 1.733 ms versus 0.790 ms reference JIT.
+    Block-ready W13/SiLU steady-state mean 0.611 ms versus 8.522 ms reference
+    JIT, max abs error 0.015625.
+  - H2560 roofline summary: 256 routed rows, dispatch payload 1280 KiB,
+    W13 work 6710.886 MFLOP, arithmetic intensity 1.000 flop/byte, measured W13
+    10.99 TFLOP/s, estimated HBM-bound W13 roofline 26.79 TFLOP/s.
+  - T/rank=4096 direct-ready candidate used `recv_capacity=20480` and
+    `send_capacity=2560` from 25% buffers. Prepack completed in 21.2 s, but no
+    dispatch timing appeared after several minutes; the job was stopped.
+- Interpretation: Direct final-row writes preserve correctness on the required
+  H2560 validation shape, but they do not fix the large-token scaling failure.
+  This narrows the bottleneck from "scratch compaction" to the broader row-wise
+  remote-write transport and synchronization pattern. The next implementation
+  should move data in coalesced receive blocks or use a collective-style
+  primitive closer to the JAX all-gather matmul example, then signal
+  `ready_block_count` as blocks complete.
+- Next action: Prototype block/coalesced remote movement for expert-major
+  receive blocks. Do not spend more H100 time on row-wise scratch or direct
+  final-row transport at T/rank=4096+ unless the transport changes.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -386,3 +386,32 @@
 - Next action: Add the Mosaic source/expert ready dispatch variant, validate it
   against the existing layout reference, then attach W13 scheduling to those
   ready ranges.
+
+### 2026-06-24 - Scratch-ready Pallas dispatch
+
+- Hypothesis: A Pallas scratch dispatch variant can expose
+  `ready_count[src_rank, local_expert]` matching the clipped source/expert
+  receive ranges. This is the producer-side contract needed before W13 can wait
+  on source/expert readiness instead of full-buffer completion.
+- Commands:
+  - H128 smoke: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-dispatch-scratch-ready-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode scratch_ready --bench-iters 1 --warmup-steps 1`
+  - H2560 relevant-shape smoke: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-dispatch-scratch-ready-h2560-grug -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode scratch_ready --bench-iters 2 --warmup-steps 1`
+- Config: Single-node CoreWeave `cw-us-east-02a`, H100x8, explicit `expert`
+  mesh. Both runs use Grug-truncated weights and 1.25 capacity factor
+  (`recv_capacity=40` for `T/rank=8`, top-k 4).
+- Result:
+  - H128: dispatch max error 0, metadata errors 0, ready-count max error 0.
+    Dispatch steady-state mean 1.689 ms versus 0.689 ms reference JIT.
+    W13/SiLU max abs error 0.0078125.
+  - H2560: dispatch max error 0, metadata errors 0, ready-count max error 0.
+    Dispatch steady-state mean 1.685 ms versus 0.782 ms reference JIT.
+    W13/SiLU steady-state mean 0.667 ms versus 8.528 ms reference JIT.
+    W13/SiLU max abs error 0.015625.
+- Interpretation: The producer side can now materialize exact source/expert
+  readiness counts on the Mosaic path. This still uses a full-kernel barrier
+  before marking ranges ready; it is not the final overlap design. The next
+  step is to replace the whole-buffer barrier with range/block-local
+  coordination, then schedule W13 over ready ranges.
+- Next action: Add a W13 consumer mode that consumes source/expert ranges from
+  `ready_count` and validate it against the current whole-buffer W13 result
+  before attempting to remove the full barrier.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -415,3 +415,34 @@
 - Next action: Add a W13 consumer mode that consumes source/expert ranges from
   `ready_count` and validate it against the current whole-buffer W13 result
   before attempting to remove the full barrier.
+
+### 2026-06-24 - Ready-range W13 consumer
+
+- Hypothesis: A W13/SiLU Mosaic kernel scheduled over flattened
+  source/expert ready ranges can consume `ready_count` directly and preserve
+  correctness. This tests the consumer-side scheduling contract before removing
+  the full producer barrier.
+- Commands:
+  - H128 smoke: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-ready-w13-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode scratch_ready --w13-impl mosaic_gpu_ready --bench-iters 1 --warmup-steps 1`
+  - H2560 relevant-shape smoke: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-ready-w13-h2560-grug -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode scratch_ready --w13-impl mosaic_gpu_ready --bench-iters 2 --warmup-steps 1`
+- Config: Single-node CoreWeave `cw-us-east-02a`, H100x8, explicit `expert`
+  mesh, Grug-truncated weights, top-k 4, `T/rank=8`, capacity factor 1.25.
+- Result:
+  - H128: dispatch max error 0, metadata errors 0, ready-count max error 0.
+    Ready-range W13/SiLU max abs error 0.0078125; steady-state mean
+    0.231 ms versus 0.174 ms reference JIT.
+  - H2560: dispatch max error 0, metadata errors 0, ready-count max error 0.
+    Ready-range W13/SiLU max abs error 0.015625; steady-state mean
+    5.370 ms versus 8.506 ms reference JIT.
+- Interpretation: The consumer-side ready-count contract is correct, but the
+  naive source/expert range schedule fragments W13 badly on the small-token
+  relevant-shape probe. The earlier expert-major W13 kernel ran about 0.667 ms
+  on the same shape; splitting into 256 source/expert groups costs most of the
+  TensorCore efficiency. The final overlap path should not simply run one
+  independent W13 schedule per source/expert range. It needs either coarser
+  block readiness, expert-local coalescing of ready ranges, or enough
+  communication/compute pipeline overlap at the large-token shape to offset the
+  scheduling fragmentation.
+- Next action: For the large-token shape, prototype block-level readiness with
+  expert-major coalescing, or keep W13 as the built-in grouped matmul and focus
+  on overlapping dispatch with the non-fragmented expert-major consumer.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -1313,3 +1313,37 @@
   source/expert-capacity transport but feed merged local-expert W13 tiles as
   each source chunk arrives, instead of materializing all compact chunks and
   then launching W13.
+
+### 2026-06-24 11:46 PT - Compact all-to-all breakdown and overlap target
+
+- Hypothesis: The merged compact-a2a path is close enough that overlap only
+  needs to hide transport behind W13. Split transport and W13 to quantify the
+  required overlap.
+- Change:
+  - Added `--run-compact-a2a-breakdown`.
+  - The breakdown times compact source/expert `lax.all_to_all` transport
+    separately from the merged local-expert Mosaic W13 consumer.
+- Commands:
+  - Cap 64 / no buffer: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-compact-a2a-breakdown-target-cap64 --env-vars JAX_OPTIMIZATION_LEVEL O1 --env-vars XLA_FLAGS "--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true" -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.0 --source-expert-capacity 64 --block-m 64 --block-n 128 --block-k 64 --num-stages 4 --grid-block-n 1 --run-compact-a2a-breakdown --skip-reference-checks --bench-iters 5 --warmup-steps 2`
+  - Cap 80 / 25% source-expert buffer: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-compact-a2a-breakdown-target-cap80 --env-vars JAX_OPTIMIZATION_LEVEL O1 --env-vars XLA_FLAGS "--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true" -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --source-expert-capacity 80 --block-m 64 --block-n 128 --block-k 64 --num-stages 4 --grid-block-n 1 --run-compact-a2a-breakdown --skip-reference-checks --bench-iters 5 --warmup-steps 2`
+- Results:
+  - Cap 64: transport steady `0.559 ms` (min `0.546`, max `0.575`), merged
+    Mosaic W13 steady `1.446 ms` (min `1.440`, max `1.451`), sum `2.006 ms`.
+  - Cap 80: transport steady `0.635 ms` (min `0.609`, max `0.676`), merged
+    Mosaic W13 steady `1.742 ms` (min `1.715`, max `1.779`), sum `2.377 ms`.
+- Synchronization decision:
+  - Local JAX `collective_matmul_mgpu.py` uses a single ordered cumulative
+    GMEM semaphore with `decrement=False`, where receivers wait for cumulative
+    thresholds per ring step.
+  - Shaped semaphore refs exist, but installed examples and lowering evidence
+    favor scalar cumulative semaphores for cross-device producer/consumer
+    synchronization. Use a ring-step pipeline rather than unordered per-block
+    semaphore slots.
+- Interpretation: The overlap target is realistic. For cap 80, hiding
+  `0.4-0.6 ms` of transport under `~1.7 ms` of W13 should get below `2 ms`.
+  The next prototype should implement an ordered source-step pipeline: send a
+  compact source/expert chunk into destination scratch, signal the cumulative
+  step semaphore, and have the destination W13 consume merged local-expert
+  chunks step-by-step instead of waiting for a completed all-to-all result.
+- Next action: Build the first ordered cumulative-semaphore compact ring-step
+  Mosaic prototype on H128, then target cap 64/80 once correctness is stable.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -360,3 +360,29 @@
   Mosaic work on dispatch/overlap only where it can improve end-to-end time.
   Benchmark capacity should be expressed as a per-rank routed-token factor:
   1.0 for no buffer and roughly 1.1-1.25 for normal imbalance.
+
+### 2026-06-24 - Source/expert readiness metadata
+
+- Hypothesis: The overlapped dispatch/W13 kernel needs explicit
+  `(src_rank, local_expert)` row ranges before Mosaic semaphores can signal
+  readiness at the granularity described in the spec. Encoding those ranges in
+  the prepacked reference representation should make the later Pallas scheduler
+  less error-prone.
+- Commands:
+  - `uv run --package marin-levanter --group test pytest lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py -q`
+  - `uv run --package marin-levanter --group test python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py --synthetic-layout --ep-size 1 --tokens-per-rank 8 --experts-per-rank 2 --top-k 2 --hidden 8 --intermediate 8 --dtype fp32 --weight-init grug_truncated --w13-impl ragged_dot --ragged-dot-impl xla --bench-iters 1 --warmup-steps 1`
+  - `uv run --package marin-levanter --group test python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py --ep-size 1 --tokens-per-rank 8 --experts-per-rank 2 --top-k 2 --hidden 8 --intermediate 8 --dtype fp32 --weight-init grug_truncated --w13-impl ragged_dot --ragged-dot-impl xla --bench-iters 1 --warmup-steps 1`
+- Config: CPU smoke shapes only. The new metadata records source-side send
+  ranges `[src_rank, dst_rank, local_expert]` and destination receive ranges
+  `[dst_rank, src_rank, local_expert]`.
+- Result: Kernel tests passed (`11 passed`). Synthetic and routed benchmark
+  smokes completed successfully. The hand-authored routing test now pins exact
+  send and receive range matrices for a two-rank, two-local-expert example.
+- Interpretation: This does not implement overlap yet, but it establishes the
+  static range contract required by the spec's `ready[src_rank, local_expert]`
+  design. The next Mosaic step is to use these ranges in a scratch/ready
+  dispatch variant whose producer signals per source/expert range instead of a
+  single full-buffer fan-in.
+- Next action: Add the Mosaic source/expert ready dispatch variant, validate it
+  against the existing layout reference, then attach W13 scheduling to those
+  ready ranges.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -701,3 +701,55 @@
 - Next action: Keep built-in `ragged_dot` as the W13 consumer and switch the
   dispatch/transport plan to either a built-in collective all-to-all/all-gather
   route or an all-gather-style fixed-neighbor ring if overlap is still required.
+
+### 2026-06-24 - Built-in collective dispatch-up probes
+
+- Hypothesis: If arbitrary-peer Pallas TMA is blocked, the practical path to
+  fast dispatch-up may be built-in collective transport followed by built-in
+  grouped matmul. Grug's existing `ragged_all_to_all` and fixed-bucket
+  `all_to_all` helpers provide good baselines for this direction.
+- Changes:
+  - Added `--run-ragged-a2a-dispatch-up` to
+    `bench_moe_dispatch_up_mosaic_gpu.py`. It uses Grug's global-expert sort,
+    `lax.ragged_all_to_all`, local expert-major permute, and
+    `ragged_dot(auto)` W13/SiLU.
+  - Added `--run-padded-a2a-dispatch-up`. It uses Grug's fixed-bucket
+    `lax.all_to_all` dispatch helper, reports dropped assignments, and runs
+    `ragged_dot(auto)` W13/SiLU.
+  - Candidate-only collective runs now skip reference prepack when
+    `--skip-reference-checks` is set and no Mosaic dispatch mode is requested.
+- Commands:
+  - Local validation: `uv run --package marin-levanter python -m py_compile lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py`
+  - Local checks: `./infra/pre-commit.py --changed-files --fix`
+  - H128 ragged correctness: `... --job-name dlwh-6597-moe-ragged-a2a-up-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --run-ragged-a2a-dispatch-up --w13-impl ragged_dot --ragged-dot-impl auto --bench-iters 1 --warmup-steps 1`
+  - Required H2560 ragged correctness: `... --job-name dlwh-6597-moe-ragged-a2a-up-h2560-t8 -- ... --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --run-ragged-a2a-dispatch-up --w13-impl ragged_dot --ragged-dot-impl auto --bench-iters 2 --warmup-steps 1`
+  - T/rank=4096 ragged capacity sweep: `... --job-name dlwh-6597-moe-ragged-a2a-up-t4096-buf-sweep -- ... for factor in 1.0 1.1 1.25; do ... --tokens-per-rank 4096 --hidden 2560 --intermediate 2560 --recv-capacity-factor $factor --run-ragged-a2a-dispatch-up --skip-reference-checks --bench-iters 2 --warmup-steps 1; done`
+  - H128 padded correctness/drop probe: `... --job-name dlwh-6597-moe-padded-a2a-up-h128 -- ... --hidden 128 --intermediate 64 --recv-capacity-factor 1.25 --run-padded-a2a-dispatch-up --bench-iters 1 --warmup-steps 1`
+  - T/rank=4096 padded 0% probe: `... --job-name dlwh-6597-moe-padded-a2a-up-t4096-buf-sweep -- ... --run-padded-a2a-dispatch-up --skip-reference-checks --bench-iters 2 --warmup-steps 1`; stopped during the 10% compile after the 0% result.
+- Result:
+  - H128 ragged all-to-all dispatch-up: max abs error `1.90735e-06`, steady
+    end-to-end `0.629 ms`.
+  - Required H2560/T=8 ragged all-to-all dispatch-up: max abs error
+    `0.0078125`, steady end-to-end `0.840 ms`. Reference JIT dispatch was
+    `0.751 ms`; reference W13 was `8.507 ms`.
+  - T/rank=4096 ragged all-to-all dispatch-up candidate-only:
+    - 0% buffer (`recv_capacity=16384`): `5.999 ms`.
+    - 10% buffer (`recv_capacity=18023`): `6.122 ms`.
+    - 25% buffer (`recv_capacity=20480`): `6.190 ms`.
+  - H128 padded all-to-all dispatch-up: steady `0.424 ms`, but max abs error
+    `1.78906`; the small random shape can exceed fixed per-peer buckets and
+    drop routed rows.
+  - T/rank=4096 padded all-to-all 0%: dropped assignments `0`, but steady
+    end-to-end `12.821 ms`. The 10% compile was stopped because the zero-drop
+    0% result was already far above target and slower than ragged all-to-all.
+- Interpretation: Built-in `ragged_all_to_all + ragged_dot` is a correct
+  end-to-end collective baseline, but it is ~6 ms at the relevant T/rank=4096
+  shape. Fixed-bucket `all_to_all` is not a shortcut to <2 ms here: it is fast
+  on tiny shapes but either drops rows under small skewed capacity or is much
+  slower at the large no-drop shape. Since isolated `ragged_dot` is ~1.1-1.4 ms,
+  the remaining gap is dispatch transport plus permutation/sort overhead, not
+  W13 math.
+- Next action: Use the collective baseline as the correctness/perf comparator,
+  then either profile the ragged path to split sort/collective/W13 costs or
+  prototype a fixed-neighbor ring/all-gather schedule that avoids arbitrary-peer
+  TMA while enabling overlap.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -446,3 +446,37 @@
 - Next action: For the large-token shape, prototype block-level readiness with
   expert-major coalescing, or keep W13 as the built-in grouped matmul and focus
   on overlapping dispatch with the non-fragmented expert-major consumer.
+
+### 2026-06-24 - Coalesced block-ready dispatch metadata
+
+- Hypothesis: A coalesced `ready_block_count[recv_block]` surface can represent
+  row/block readiness without fragmenting W13 by source rank. This keeps the
+  readiness contract aligned with expert-major W13 block scheduling.
+- Commands:
+  - Failed first H128 attempt: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-block-ready-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode scratch_ready --bench-iters 1 --warmup-steps 1`
+  - Fixed H128 smoke: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-block-ready-h128-2 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode scratch_ready --bench-iters 1 --warmup-steps 1`
+  - H2560 relevant-shape smoke: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-block-ready-h2560-grug -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode scratch_ready --bench-iters 2 --warmup-steps 1`
+- Config: Single-node CoreWeave `cw-us-east-02a`, H100x8, explicit `expert`
+  mesh, Grug-truncated weights, top-k 4, `T/rank=8`, capacity factor 1.25.
+  Block-ready counts use the W13 `block_m` tile height.
+- Result:
+  - The first H128 attempt failed during Pallas lowering because the kernel
+    captured non-scalar `rows_per_expert` constants while computing
+    block-ready counts. Passing the total ready row count as an explicit scalar
+    input fixed the issue.
+  - Fixed H128: dispatch max error 0, metadata errors 0, source/expert
+    ready-count max error 0, block-ready-count max error 0. W13 max abs error
+    0.0078125.
+  - H2560: dispatch max error 0, metadata errors 0, source/expert ready-count
+    max error 0, block-ready-count max error 0. Dispatch steady-state mean
+    1.713 ms, W13 steady-state mean 0.613 ms, W13 max abs error 0.015625.
+- Interpretation: The Mosaic dispatch path now emits both fine-grained
+  source/expert readiness and coalesced receive-block readiness. The latter
+  preserves the expert-major W13 schedule and avoids the severe fragmentation
+  observed in the source/expert ready-range W13 consumer. The path still marks
+  blocks after a full dispatch barrier; the next step is to move block-ready
+  signaling earlier, at row/block copy completion, and have W13 wait on those
+  block signals.
+- Next action: Replace the full-kernel ready marking with a row/block
+  coordinator that signals block readiness as soon as each receive block is
+  complete, then run W13 from the block-ready schedule.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -935,3 +935,58 @@
   Mosaic/Grug backend selection boundary or continue toward a true overlapped
   Mosaic dispatch/W13 implementation if avoiding the built-in collective is
   still required.
+
+### 2026-06-24 00:32 PT - Compact source/expert Mosaic dispatch substrate
+
+- Hypothesis: The prepacked Mosaic path stalls at the target shape because it
+  uses `[dst, T*K, H]` source/destination buffers. Repacking by
+  source/destination/local-expert should size capacity by source-expert
+  imbalance instead. At the target shape, the balanced group is
+  `4096 * 4 / 256 = 64` rows.
+- Changes:
+  - Added `MoeDispatchUpSourceExpertPrepackedSend` plus
+    `prepack_moe_dispatch_up_source_expert_reference` and
+    `dispatch_prepacked_moe_dispatch_up_source_expert_reference`.
+  - Added CPU tests that compact prepack reconstructs the same destination
+    layout as the original prepack and reports source-expert capacity overflow.
+  - Added compact source/expert Mosaic dispatch entrypoints and benchmark flags:
+    `--run-compact-source-expert-dispatch` and
+    `--run-compact-source-expert-dispatch-up`.
+  - Added benchmark source/expert load stats and compact capacity projections.
+- Commands:
+  - Local syntax: `uv run --package marin-levanter python -m py_compile lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/reference.py lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py`
+  - Local tests: `uv run --package marin-levanter pytest lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py -q`
+  - H128 compact dispatch+W13: `... --job-name dlwh-6597-moe-compact-source-expert-h128 -- ... --run-compact-source-expert-dispatch-up --dispatch-rows-per-program 4 --block-m 64 --bench-iters 1 --warmup-steps 1`
+  - H128 compact dispatch-only after column tiling: `... --job-name dlwh-6597-moe-compact-dispatch-h128-coltile -- ... --run-compact-source-expert-dispatch --dispatch-rows-per-program 4 --block-m 64 --bench-iters 1 --warmup-steps 1`
+  - Large compact dispatch attempts:
+    - `... --job-name dlwh-6597-moe-compact-source-expert-t4096 -- ... --run-compact-source-expert-dispatch-up --dispatch-rows-per-program 64 --skip-reference-checks`
+    - `... --job-name dlwh-6597-moe-compact-source-expert-dispatch-t4096 -- ... --run-compact-source-expert-dispatch --dispatch-rows-per-program 64 --skip-reference-checks`
+    - `... --job-name dlwh-6597-moe-compact-source-expert-dispatch-t4096-rpp8-cap80 -- ... --run-compact-source-expert-dispatch --source-expert-capacity 80 --dispatch-rows-per-program 8 --skip-reference-checks`
+    - `... --job-name dlwh-6597-moe-compact-dispatch-t4096-rpp1-cap80-coltile -- ... --run-compact-source-expert-dispatch --source-expert-capacity 80 --dispatch-rows-per-program 1 --skip-reference-checks`
+- Result:
+  - Local kernel tests: `13 passed`.
+  - H128 compact dispatch+W13: ready-count and ready-block-count errors `0`,
+    W13 max abs error `0.0078125`, steady `1.477 ms`.
+  - H128 compact dispatch-only: exact `recv_x`, metadata, ready-count, and
+    ready-block-count parity. Before column tiling, steady `1.577 ms`; after
+    column tiling, steady `1.748 ms`.
+  - Target-shape source/expert stats:
+    - balanced `64.000`, mean `64.000`, max `64`, p95 `64`, p99 `64`.
+    - old full send slots/source: `131072`.
+    - compact 1.25x source/expert capacity: cap `80`, overflow `0`,
+      slots/source `20480` (6.4x fewer source slots).
+  - Large barriered compact Mosaic attempts still did not emit first timing:
+    the dispatch+W13 rpp64 job was killed after about 9 minutes, dispatch-only
+    rpp64 after about 7 minutes, dispatch-only rpp8/cap80 after about 7
+    minutes, and dispatch-only rpp1/cap80/column-tiled after about 7 minutes.
+- Interpretation: The compact source/expert representation is the right data
+  model and is validated on small H100x8 correctness runs. It fixes the shape
+  economics: target-shape capacity should be source/expert based, and 25% buffer
+  is zero-overflow in this harness. The remaining failure is in the barriered
+  Mosaic copy kernel shape/schedule, not in the compact layout. The next kernel
+  iteration should stop zeroing the full receive capacity and stop using a
+  global all-program barrier before readiness; instead copy only valid compact
+  rows, mark valid/ready metadata, and let W13 consume ready groups/blocks.
+- Next action: Replace the barriered compact dispatch with a producer-marked
+  valid/ready schedule and then merge W13 consumption into the same Mosaic
+  kernel or ordered ring pipeline.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -990,3 +990,238 @@
 - Next action: Replace the barriered compact dispatch with a producer-marked
   valid/ready schedule and then merge W13 consumption into the same Mosaic
   kernel or ordered ring pipeline.
+
+### 2026-06-24 01:00 PT - Tiled compact dispatch transport lowering
+
+- Hypothesis: The target-shape compact dispatch stall is from large row-vector
+  peer stores and barriers, not the source/expert layout. Tiling hidden columns
+  and writing only valid source/expert rows should produce a smaller Mosaic
+  transport substrate.
+- Changes:
+  - Added `--compact-dispatch-skip-zero-recv` to avoid zeroing the full receive
+    payload and metadata when validation only needs written rows.
+  - Added `--compact-dispatch-copy-cols` and a tiled compact source/expert
+    dispatch kernel that copies one row/column tile per program and writes
+    row metadata from column tile zero.
+  - The tiled payload path uses `copy_gmem_to_smem` then `copy_smem_to_gmem`
+    for remote payload writes. Direct remote vector assignment failed Mosaic
+    layout inference; Warpgroup lowering then failed with peer GMEM refs, so
+    the tiled transport uses the generic Mosaic GPU lowering while W13 remains
+    a separate Warpgroup kernel.
+- Commands:
+  - Local syntax: `uv run --package marin-levanter python -m py_compile lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py`
+  - Local tests: `uv run --package marin-levanter pytest lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py -q`
+  - H128 tiled dispatch first attempt: `... --job-name dlwh-6597-moe-compact-tiled-smem-dispatch-h128 -- ... --hidden 128 --intermediate 64 --compact-dispatch-copy-cols 64 --run-compact-source-expert-dispatch --bench-iters 1 --warmup-steps 1`
+  - H128 tiled dispatch without Warpgroup lowering: `... --job-name dlwh-6597-moe-compact-tiled-smem-dispatch-h128-nw -- ... --hidden 128 --intermediate 64 --compact-dispatch-copy-cols 64 --run-compact-source-expert-dispatch --bench-iters 1 --warmup-steps 1`
+- Result:
+  - Local kernel tests: `13 passed`.
+  - H128 first attempt got past the previous layout-inference failure but failed
+    in lowering with `NotImplementedError: GMEM refs with peer ids are not
+    supported in warpgroup lowering`.
+  - H128 non-Warpgroup tiled dispatch matched reference exactly: ready-count,
+    ready-block-count, `recv_x`, `recv_valid`, metadata, and router-weight
+    max errors were all `0`. Steady dispatch time was `1.623 ms`.
+- Interpretation: Compact tiled remote payload transport is correct on H100x8
+  once it is kept out of Warpgroup lowering. The next target-shape run should
+  use explicit source/expert capacity `80`, because for `T/rank=4096`,
+  `topk=4`, `E=256`, the balanced source/expert group has `64` rows and the
+  normal 25% imbalance buffer gives `80` rows with zero overflow in this
+  synthetic routing case.
+- Next action: Run target-shape dispatch-only with `H=2560`, `I=2560`,
+  `E=256`, `topk=4`, `T/rank=4096`, source/expert capacity `80`, and
+  `copy_cols=256`. If that returns, measure dispatch+W13 and then decide the
+  overlap boundary.
+
+### 2026-06-24 01:03 PT - Target-shape compact tiled dispatch returns
+
+- Hypothesis: The compact tiled dispatch transport should return on the
+  relevant `H=2560`, `T/rank=4096` shape once capacity is source/expert based
+  and payload writes are tiled.
+- Command: `... --job-name dlwh-6597-moe-compact-tiled-dispatch-t4096-cap80 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --source-expert-capacity 80 --block-m 64 --compact-dispatch-copy-cols 256 --run-compact-source-expert-dispatch --skip-reference-checks --bench-iters 1 --warmup-steps 1`
+- Result:
+  - Source/expert load stats: balanced `64.000`, mean `64.000`, max `64`,
+    p95 `64.0`, p99 `64.0`.
+  - Compact capacity: old full send slots/source `131072`; compact 25% buffer
+    cap `80`, overflow `0`, slots/source `20480`.
+  - Dispatch-only compile+first run: `1802.188 ms`.
+  - Dispatch-only steady: `2.766 ms` for one measured iteration.
+  - Ready-count and ready-block-count max errors: `0`.
+- Interpretation: The compact tiled transport solves the previous non-returning
+  large-shape Mosaic dispatch problem. It is not yet fast enough: dispatch
+  alone is above the desired `<2 ms` end-to-end target. With `copy_cols=256`,
+  the kernel launches `8 * 32 * 80 * 10 = 204800` tiny payload programs, so the
+  next axis is wider column tiles to reduce program count.
+- Next action: Sweep `copy_cols` over wider tiles (`512`, `1280`, `2560`) on
+  the same target shape, then measure compact dispatch+W13 at the best dispatch
+  tile.
+
+### 2026-06-24 01:16 PT - Row-tiling compact transport probe
+
+- Hypothesis: Since Mosaic async copies cap each dimension at `256`, wider
+  column tiles cannot reduce the target dispatch program count. Grouping
+  multiple source/expert rows per program while keeping `copy_cols <= 256`
+  should reduce program count without changing the compact layout.
+- Changes:
+  - Added `--compact-dispatch-copy-rows`.
+  - Rejected `copy_cols > 256` and `copy_rows > 256` in the tiled dispatch
+    wrapper.
+  - Tried a 2D `(copy_rows, copy_cols)` peer payload copy, then switched back
+    to repeated 1D row payload copies inside each row-tile program because
+    Mosaic could not recompute the peer id for the 2D remote copy descriptor.
+- Commands:
+  - Failed wider-column runs: `... --compact-dispatch-copy-cols 512` and
+    `... --compact-dispatch-copy-cols 1280` on the target shape.
+  - H128 row-tile correctness: `... --job-name dlwh-6597-moe-compact-tiled-smem-dispatch-h128-r4-1d -- ... --hidden 128 --intermediate 64 --compact-dispatch-copy-cols 64 --compact-dispatch-copy-rows 4 --run-compact-source-expert-dispatch --bench-iters 1 --warmup-steps 1`
+- Result:
+  - `copy_cols=512` and `1280` both failed with `Async copies only support
+    copying <=256 elements along each dimension`.
+  - The first 2D row-tile attempt failed with `Failed to recompute the
+    async_copy peer id on the host`.
+  - Repeated 1D row copies with `copy_rows=4` passed H128 correctness: ready
+    counts, ready blocks, payload, valid mask, metadata, and router weights all
+    had max error `0`; steady dispatch was `1.711 ms`.
+- Interpretation: The viable row-tiling path is multiple 1D peer copies per
+  program, not a 2D peer TMA tile. This reduces program count and may reduce
+  scheduling overhead, but it does not reduce the number of payload copy
+  operations.
+- Next action: Measure target-shape dispatch with `copy_rows=8` and
+  `copy_cols=256`; if it improves, sweep row tile size and then measure
+  dispatch+W13.
+
+### 2026-06-24 01:18 PT - Target-shape row-tile dispatch improves modestly
+
+- Hypothesis: Repeated 1D row copies inside a row-tile program should reduce
+  program scheduling overhead enough to improve target dispatch time.
+- Command: `... --job-name dlwh-6597-moe-compact-tiled-dispatch-t4096-cap80-r8 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --source-expert-capacity 80 --block-m 64 --compact-dispatch-copy-cols 256 --compact-dispatch-copy-rows 8 --run-compact-source-expert-dispatch --skip-reference-checks --bench-iters 2 --warmup-steps 1`
+- Result:
+  - Source/expert load stats unchanged: balanced/mean/max all `64`, compact
+    cap `80`, overflow `0`, slots/source `20480`.
+  - Dispatch-only compile+first run: `2103.207 ms`.
+  - Dispatch-only steady: mean `2.477 ms`, min `2.375`, max `2.579`, iters `2`.
+  - Ready-count and ready-block-count max errors: `0`.
+- Interpretation: Row tiling improves dispatch-only time from `2.766 ms` to
+  `2.477 ms`, but the effect is modest because each row still performs the same
+  number of 1D async payload copies. The substrate is correct and now returns
+  reliably, but dispatch alone remains above the desired end-to-end budget.
+- Next action: Try `copy_rows=16`; then measure dispatch+W13 to quantify the
+  non-overlapped floor before deciding whether overlap must happen above this
+  remote-copy primitive or by switching back to the built-in ring/GMM path.
+
+### 2026-06-24 01:21 PT - Row tiling plateaus
+
+- Hypothesis: Increasing row tile size from `8` to `16` should further reduce
+  dispatch program overhead if program count is the dominant cost.
+- Command: `... --job-name dlwh-6597-moe-compact-tiled-dispatch-t4096-cap80-r16 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --source-expert-capacity 80 --block-m 64 --compact-dispatch-copy-cols 256 --compact-dispatch-copy-rows 16 --run-compact-source-expert-dispatch --skip-reference-checks --bench-iters 2 --warmup-steps 1`
+- Result:
+  - Dispatch-only compile+first run: `2349.337 ms`.
+  - Dispatch-only steady: mean `2.450 ms`, min `2.339`, max `2.561`, iters `2`.
+  - Ready-count and ready-block-count max errors: `0`.
+- Interpretation: `copy_rows=16` is only slightly faster than `copy_rows=8`
+  (`2.450 ms` vs `2.477 ms`) and remains much slower than the ring-gather/GMM
+  helper (`~1.86 ms` end-to-end). This suggests the limiting cost is the
+  per-row 1D peer-copy work or Mosaic async-copy overhead, not just program
+  launch count.
+- Next action: Measure compact tiled dispatch+W13 with `copy_rows=16` to get
+  the non-overlapped Mosaic floor, then decide whether true overlap can recover
+  enough or whether the built-in collective path should be the production path.
+
+### 2026-06-24 08:24 PT - Compact tiled dispatch+W13 target floor
+
+- Hypothesis: The compact source/expert substrate plus block-ready W13 should
+  compile and return on the target shape, giving the non-overlapped Mosaic
+  dispatch-up floor.
+- Command: `... --job-name dlwh-6597-moe-compact-tiled-dispatch-up-t4096-cap80-r16 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --source-expert-capacity 80 --block-m 64 --block-n 64 --block-k 64 --num-stages 2 --compact-dispatch-copy-cols 256 --compact-dispatch-copy-rows 16 --run-compact-source-expert-dispatch-up --skip-reference-checks --bench-iters 2 --warmup-steps 1`
+- Result:
+  - Source/expert load stats: balanced/mean/max all `64`, compact cap `80`,
+    overflow `0`, slots/source `20480`.
+  - Dispatch+W13 compile+first run: `3084.608 ms`.
+  - Dispatch+W13 steady: mean `5.911 ms`, min `5.847`, max `5.976`, iters `2`.
+  - Ready-count and ready-block-count max errors: `0`.
+- Interpretation: The compact Mosaic substrate is now correct and returns at
+  the target shape, but the non-overlapped end-to-end floor is far above the
+  `<2 ms` goal and the ring-gather/GMM helper (`~1.86 ms`). Overlap would need
+  to hide most of the remaining remote-copy/W13 work; small tiling changes on
+  this peer-copy primitive are unlikely to close the gap.
+- Next action: Treat this as the Mosaic remote-copy negative result and move
+  the production path toward the built-in ring/GMM helper for the <2 ms target,
+  or design a fundamentally different overlapped schedule that does not depend
+  on per-row peer async copies.
+
+### 2026-06-24 09:31 PT - Isolated W13 target baseline
+
+- Hypothesis: The compact dispatch+W13 result is too slow partly because the
+  block-ready Mosaic W13 consumer is slow, independent of dispatch. Measure W13
+  alone on a synthetic expert-major target layout.
+- Command: `... --job-name dlwh-6597-moe-w13-synthetic-target-mosaic-ragged -- ... bench_moe_dispatch_up_mosaic_gpu.py --synthetic-layout --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity 20480 --block-m 64 --block-n 64 --block-k 64 --num-stages 2 --w13-impl both --ragged-dot-impl auto --check-w13 --bench-iters 2 --warmup-steps 1`
+- Result:
+  - Synthetic layout: recv capacity `20480`, rows/expert `640`.
+  - Mosaic W13 steady: mean `4.200 ms`, min `4.194`, max `4.207`.
+  - `ragged_dot` W13 steady: mean `1.366 ms`, min `1.354`, max `1.377`.
+  - Mosaic vs ragged max abs error: `0.03125` with mean abs `0.000183599`.
+  - Reported W13 throughput: Mosaic `~1022 TFLOP/s`, ragged `~3145 TFLOP/s`.
+- Interpretation: The non-overlapped compact dispatch+W13 floor is not only a
+  transport problem. The current Mosaic W13 kernel is about 3x slower than
+  `ragged_dot` on the same target layout. True dispatch/W13 overlap cannot hit
+  `<2 ms` unless the W13 consumer is also tuned or replaced.
+- Next action: Expose `--grid-block-n` and sweep Mosaic W13 tile/scheduling
+  choices on the same synthetic target layout.
+
+### 2026-06-24 10:41 PT - Compact-layout Mosaic W13 sweep
+
+- Hypothesis: The first isolated W13 baseline used a conservative tile; larger
+  `N` tiles and deeper stages may make Mosaic W13 competitive enough that
+  dispatch/W13 overlap is still plausible.
+- Command: `... --job-name dlwh-6597-moe-w13-synthetic-target-sweep1 -- ... for cfg in "64 128 64 2 1" "64 128 64 4 1" "128 64 64 2 1" "128 128 64 2 1" "128 128 64 4 1" "64 64 128 2 1" "64 128 128 2 1" "64 128 64 2 4" "128 128 64 2 4"; do ... bench_moe_dispatch_up_mosaic_gpu.py --synthetic-layout --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity 20480 --block-m $bm --block-n $bn --block-k $bk --num-stages $stages --grid-block-n $gbn --w13-impl mosaic_gpu --bench-iters 2 --warmup-steps 1; done`
+- Result:
+  - Job `/dlwh/dlwh-6597-moe-w13-synthetic-target-sweep1` succeeded on
+    `cw-us-east-02a`.
+  - Steady W13 timings:
+
+    | block_m | block_n | block_k | stages | grid_block_n | mean ms | min ms | max ms |
+    |---:|---:|---:|---:|---:|---:|---:|---:|
+    | 64 | 128 | 64 | 2 | 1 | 2.551 | 2.539 | 2.564 |
+    | 64 | 128 | 64 | 4 | 1 | 1.658 | 1.649 | 1.668 |
+    | 128 | 64 | 64 | 2 | 1 | 3.028 | 3.026 | 3.030 |
+    | 128 | 128 | 64 | 2 | 1 | 4.672 | 4.660 | 4.684 |
+    | 128 | 128 | 64 | 4 | 1 | 5.225 | 5.174 | 5.276 |
+    | 64 | 64 | 128 | 2 | 1 | 3.232 | 3.196 | 3.268 |
+    | 64 | 128 | 128 | 2 | 1 | 2.263 | 2.258 | 2.268 |
+    | 64 | 128 | 64 | 2 | 4 | 2.438 | 2.437 | 2.439 |
+    | 128 | 128 | 64 | 2 | 4 | 4.561 | 4.558 | 4.563 |
+
+  - Best config: `block_m=64`, `block_n=128`, `block_k=64`, `num_stages=4`,
+    `grid_block_n=1` at `1.658 ms`.
+- Interpretation: Mosaic W13 is tunable on the compact layout: the best sweep
+  point is 2.5x faster than the first `4.200 ms` baseline, though still slower
+  than `ragged_dot` (`1.366 ms`). The target end-to-end path is now limited by
+  the compact remote-copy transport (`~2.45 ms`) plus any non-hidden W13 work;
+  true overlap would need to hide most of the transport behind this `~1.66 ms`
+  consumer.
+- Next action: Remeasure compact source/expert dispatch+W13 with the best W13
+  config and `source_expert_capacity=80` before deeper overlap changes.
+
+### 2026-06-24 10:45 PT - Compact dispatch+W13 with tuned W13 tile
+
+- Hypothesis: Reusing the best isolated Mosaic W13 tile should lower the
+  compact source/expert dispatch+W13 floor enough to clarify the remaining
+  overlap gap.
+- Command: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --no-wait --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 3600 --job-name dlwh-6597-moe-compact-tiled-dispatch-up-t4096-cap80-r16-w13best -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --source-expert-capacity 80 --block-m 64 --block-n 128 --block-k 64 --num-stages 4 --grid-block-n 1 --compact-dispatch-copy-cols 256 --compact-dispatch-copy-rows 16 --run-compact-source-expert-dispatch-up --skip-reference-checks --bench-iters 3 --warmup-steps 1`
+- Result:
+  - Job `/dlwh/dlwh-6597-moe-compact-tiled-dispatch-up-t4096-cap80-r16-w13best`
+    succeeded on `cw-us-east-02a`.
+  - Source/expert load stats: balanced/mean/max all `64`, compact cap `80`,
+    overflow `0`, slots/source `20480`.
+  - Dispatch+W13 compile+first run: `3394.243 ms`.
+  - Dispatch+W13 steady: mean `3.722 ms`, min `3.700`, max `3.760`, iters `3`.
+  - Ready-count and ready-block-count max errors: `0`.
+- Interpretation: Tuning the W13 tile improves the compact Mosaic
+  dispatch+W13 floor from `5.911 ms` to `3.722 ms`, but it remains above both
+  the `<2 ms` target and the ring-gather/GMM helper (`~1.86 ms`). The compact
+  source/expert layout is still the right shape fix: it shrinks source slots
+  from `131072` to `20480` at this target. The remaining issue is not capacity;
+  it is the non-overlapped generic Mosaic peer-copy transport, whose
+  dispatch-only floor is `~2.45 ms`.
+- Next action: Keep the compact source/expert layout as the Mosaic-facing
+  substrate, but shift the next implementation attempt toward a collective
+  ring/all-gather schedule or built-in GMM path that can overlap transport with
+  W13 instead of relying on per-row arbitrary peer async copies.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -615,3 +615,21 @@
 - Next action: Prototype block/coalesced remote movement for expert-major
   receive blocks. Do not spend more H100 time on row-wise scratch or direct
   final-row transport at T/rank=4096+ unless the transport changes.
+
+### 2026-06-24 - Failed direct block-copy lowering
+
+- Hypothesis: A `direct_ready` fast path that copies a contiguous
+  `[rows_per_program, hidden]` slice when send rows map to contiguous
+  destination rows could reduce row-wise remote write overhead without changing
+  the layout contract.
+- Command: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-direct-ready-blockcopy-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode direct_ready --dispatch-rows-per-program 16 --w13-impl mosaic_gpu_block_ready --bench-iters 1 --warmup-steps 1`
+- Result: The candidate failed during Mosaic lowering before dispatch timing:
+  `ValueError: Layout inference failed to find a solution`. The failing
+  fast-path code was not kept.
+- Interpretation: Naively assigning dynamic remote GMEM slices for
+  `[rows_per_program, hidden]` blocks is not enough; the coalesced transport
+  likely needs explicit layout annotations or a structure closer to the
+  existing collective matmul pipeline.
+- Next action: Revisit block movement with a minimal standalone remote block
+  copy kernel or an all-gather-style pipeline before reintroducing it into the
+  MoE dispatch benchmark.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -173,3 +173,30 @@
 - Next action: Keep W13/SiLU as the viable fast subkernel and prioritize tiled
   SMEM-staged remote dispatch. Rerun the integrated shape after dispatch no
   longer lowers as a hidden-dimension scalar loop.
+
+### 2026-06-23 - Grug-consistent W13 correctness check
+
+- Hypothesis: The previous relevant-shape W13/SiLU max error of 128 may be an
+  artifact of using unrealistic standard-normal expert weights instead of the
+  Grug MoE initialization scale.
+- Command: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 1800 --job-name 6597-moe-w13-gruginit-h2560-i2560-e256-summary -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --run-pallas --pallas-w13-from-reference-layout --bench-iters 5 --warmup-steps 2`
+- Config: Single-node CoreWeave `cw-us-east-02a`, H100x8, explicit `expert`
+  mesh, bf16, `H=2560`, `I=2560`, `T/rank=8`, top-k 4, 32 local experts per
+  rank, 256 global experts. Expert weights used the Grug MoE distribution:
+  truncated normal in `[-3, 3] * (0.5 / sqrt(2560))`.
+- Result:
+  - JIT W13/SiLU steady-state mean 10.524 ms.
+  - Mosaic GPU W13/SiLU steady-state mean 0.640 ms, min 0.637 ms, max 0.648 ms,
+    or 16.44x faster than the JIT W13/SiLU baseline.
+  - Error summary: max abs 0.015625, mean abs 2.28e-05, RMS abs 1.77e-04,
+    max relative 0.0141, mean relative 2.27e-05. The max-error element had
+    expected abs 2.015625 and actual abs 2.0.
+  - Roofline summary, using the benchmark's H100 SXM assumptions: measured W13
+    10.48 TFLOP/s, estimated HBM-bound W13 roofline 26.79 TFLOP/s.
+- Interpretation: The prior max abs error of 128 was caused by the deliberately
+  unrealistic standard-normal weight scale. With Grug-consistent weight scale,
+  the W13/SiLU error is at bf16 rounding scale for this probe. The subkernel
+  still needs broader numerical sweeps before production use, but this run does
+  not indicate a routing or matmul correctness bug.
+- Next action: Keep Grug-style random inputs as the default comparison for
+  relevant-shape correctness claims, and continue prioritizing tiled dispatch.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -1,10 +1,10 @@
-# Pallas Mosaic MGPU MoE: Research Logbook
+# Pallas MoE Dispatch-Up Mosaic GPU: Research Logbook
 
 ## Scope
 
 - Goal: Build a DeepEP-free single-node EP8 Grug MoE backend using Pallas
-  Mosaic MGPU remote refs, with fused dispatch + W13/SiLU as the first product
-  target and a custom-VJP/backward path before training integration.
+  Mosaic GPU remote refs. The first subkernel target is dispatch + W13/SiLU
+  (`moe_dispatch_up`), before W2/combine and backward integration.
 - Primary metrics: fused dispatch + W13/SiLU time, MoE forward time,
   MoE forward+backward time, end-to-end fwd+bwd+SGD MFU.
 - Constraints: single-node 8xH100 first, `model_axis=1`, no DeepEP/NCCL
@@ -32,7 +32,7 @@
 
 ### 2026-06-23 - Kickoff spec handoff
 
-- Hypothesis: A Pallas Mosaic MGPU backend can route token blocks directly into
+- Hypothesis: A Pallas Mosaic GPU dispatch-up subkernel can route token blocks directly into
   destination expert-major tiles and consume them with W13/SiLU, avoiding
   DeepEP's opaque FFI/runtime fragility and avoiding high-level collective
   permutation overhead.
@@ -46,3 +46,27 @@
   dispatch + W13/SiLU; training integration also requires backward/custom VJP.
 - Next action: Assign an implementation agent to start with the routing/layout
   JAX reference and Mosaic remote-dispatch validation slice.
+
+### 2026-06-23 - Milestones 1 and 2 validation slice
+
+- Hypothesis: A shard-local Mosaic GPU remote-ref dispatch can reproduce the
+  prepacked expert-major layout exactly, and a local W13/SiLU Pallas kernel can
+  consume that layout for top-k 1 and top-k 4 routing.
+- Commands:
+  - `uv run --package marin-levanter --group test pytest lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py -q`
+  - `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name 6597-mosaic-mgpu-smoke-20 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 1 --top-k 1 --hidden 64 --intermediate 64 --dtype bf16 --run-pallas`
+  - `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name 6597-mosaic-mgpu-smoke-21 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 64 --intermediate 64 --dtype bf16 --run-pallas`
+- Config: Single-node CoreWeave `cw-us-east-02a`, H100x8, explicit `expert`
+  mesh, bf16 activations/weights, `H=64`, `I=64`, `T/rank=8`.
+- Result:
+  - Local tests: 8 passed.
+  - Top-k 1: dispatch payload max error 0, dispatch metadata errors
+    `valid=0 local_expert=0 src_rank=0`, W13/SiLU max bf16 error 2.
+  - Top-k 4: dispatch payload max error 0, dispatch metadata errors
+    `valid=0 local_expert=0 src_rank=0`, W13/SiLU max bf16 error 2.
+- Interpretation: Milestone 1 is validated for the prepacked remote-ref layout.
+  Milestone 2 is validated for local dispatch-up W13/SiLU on the dispatched layout at
+  the requested top-k 1 and top-k 4 slices. The dispatch kernel is still a
+  deliberately serial validation primitive, not a performance implementation.
+- Next action: Replace serial scalar remote writes with tiled/staged copies and
+  add backward/custom-VJP coverage before Grug integration.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -633,3 +633,71 @@
 - Next action: Revisit block movement with a minimal standalone remote block
   copy kernel or an all-gather-style pipeline before reintroducing it into the
   MoE dispatch benchmark.
+
+### 2026-06-24 - Block transport TMA and built-in GMM capacity probes
+
+- Hypothesis: A coalesced SMEM-mediated remote block transport could replace
+  the row-wise MoE dispatch transport, then feed built-in grouped matmul with
+  realistic 0-25% capacity buffers.
+- Changes:
+  - Added `bench_moe_mgpu_block_transport.py`, a standalone transport probe
+    that copies packed `[source, destination, rows, hidden]` blocks through
+    SMEM to remote refs and checks the all-to-all transpose on small shapes.
+  - Added hidden-column tiling, scratch-output mode, and loop-tile mode to
+    isolate Mosaic GPU TMA lowering constraints.
+- Commands:
+  - Local validation: `uv run --package marin-levanter python -m py_compile lib/levanter/scripts/bench/bench_moe_mgpu_block_transport.py`
+  - Local checks: `./infra/pre-commit.py --changed-files --fix`
+  - H128 direct transport: `... --job-name dlwh-6597-moe-block-transport-h128-hostcheck -- ... bench_moe_mgpu_block_transport.py --ep-size 8 --rows 32 --hidden 128 --block-rows 16 --dtype bf16 --bench-iters 2 --warmup-steps 1`
+  - H128 column-tiled/flat/loop/scratch variants:
+    `dlwh-6597-moe-block-transport-h128-coltile`,
+    `dlwh-6597-moe-block-transport-h128-flattiles`,
+    `dlwh-6597-moe-block-transport-h128-scratchout`,
+    `dlwh-6597-moe-block-transport-h128-looptiles`.
+  - Large packed transport failures used the relevant T/rank=4096, topk=4,
+    25% send-buffer shape: `rows=2560`, `hidden=2560`, `block_cols=256`,
+    jobs `dlwh-6597-moe-block-transport-t4096buf125-b64`,
+    `dlwh-6597-moe-block-transport-t4096buf125-b32`,
+    `dlwh-6597-moe-block-transport-t4096buf125-flat-b32c256`,
+    `dlwh-6597-moe-block-transport-t4096buf125-scratch-b32c256`, and
+    `dlwh-6597-moe-block-transport-t4096buf125-loop-b32c256`.
+  - Built-in grouped matmul capacity probes:
+    `dlwh-6597-moe-ragged-dot-synth-t4096-buf125` and
+    `dlwh-6597-moe-ragged-dot-synth-t4096-buf100-110`, with
+    `JAX_OPTIMIZATION_LEVEL=O1` and XLA flags
+    `--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true`.
+- Result:
+  - H128 transport is correct for all retained variants. Direct host-check:
+    max error 0, steady mean 1.545 ms for 0.5 MiB. Flattened column-tiled:
+    max error 0, steady mean 1.409 ms. Scratch-output: max error 0, steady
+    mean 1.456 ms. Loop-tiles: max error 0, steady mean 1.619 ms.
+  - Large direct block copy with `block_rows=64` exceeded SMEM:
+    `smem_bytes=327688 > max_smem_bytes=232448`.
+  - Large `block_rows=32`, untiled hidden copy failed because Mosaic async
+    copies require each dimension to be <=256 elements: shape `(1, 32, 2560)`.
+  - Large column-tiled copies failed TMA lowering when the remote peer id or
+    remote TMA descriptor depended on grid ids: failures reported
+    `Failed to recompute the async_copy peer id on the host` for
+    `gpu.block_id z`, then `gpu.block_id y`, and loop-tiles reduced this to
+    `gpu.block_id x` because the peer id was still `program_id(0)`.
+  - Writing to a separate scratch output did not change the large TMA failure.
+  - Built-in `ragged_dot(auto)` W13/SiLU on the relevant H=I=2560,
+    E=256, topk=4, T/rank=4096 synthetic receive layout:
+    - 0% buffer (`recv_capacity=16384`, 512 rows/expert): 1.145 ms steady,
+      3001 TFLOP/s measured, AI 426.7 flop/byte.
+    - ~10% buffer (`recv_capacity=18048`, 564 rows/expert): 1.402 ms steady,
+      2700 TFLOP/s measured, AI 462.2 flop/byte.
+    - 25% buffer (`recv_capacity=20480`, 640 rows/expert): 1.363 ms steady,
+      3150 TFLOP/s measured, AI 512.0 flop/byte.
+- Interpretation: Direct arbitrary-peer Mosaic GPU remote TMA copies are not a
+  viable dispatch transport with the current structure because the peer id must
+  be host-recomputable and cannot come from a grid/program id. The JAX
+  all-gather matmul avoids this by sending to a fixed neighbor derived from
+  `axis_index`, so an overlapped Pallas transport would need a ring/all-gather
+  style schedule or multiple fixed-peer kernels. For the target shape, built-in
+  grouped matmul is already around 1.1-1.4 ms across realistic 0-25% buffers;
+  the path to <2 ms end-to-end depends on using an efficient collective
+  transport rather than replacing NCCL with arbitrary-peer Pallas TMA.
+- Next action: Keep built-in `ragged_dot` as the W13 consumer and switch the
+  dispatch/transport plan to either a built-in collective all-to-all/all-gather
+  route or an all-gather-style fixed-neighbor ring if overlap is still required.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -801,3 +801,53 @@
 - Next action: Prototype a fixed-neighbor ring/all-gather dispatch layout for
   dispatch-up, using the ragged collective baseline as the correctness oracle
   and preserving built-in `ragged_dot` for W13.
+
+### 2026-06-24 - Fixed-neighbor and ring-gather dispatch-up probes
+
+- Hypothesis: A fixed-neighbor transport pattern might avoid the arbitrary-peer
+  Mosaic GPU remote-ref lowering failure, and an all-gather-style dispatch-up
+  path might be a better built-in-collective baseline than ragged all-to-all for
+  the relevant Grug MoE shape.
+- Changes:
+  - Added `--fixed-neighbor` to `bench_moe_mgpu_block_transport.py`. It copies
+    each rank's `[rows, hidden]` payload to `(rank + 1) % EP` with Pallas
+    Mosaic GPU remote refs, then checks against `np.roll` when reference checks
+    are enabled.
+  - Added `--run-ring-gather-dispatch-up` to
+    `bench_moe_dispatch_up_mosaic_gpu.py`. It mirrors Grug's `ep_ring`
+    dispatch-up structure: all-gather token/routing inputs, select this rank's
+    local expert assignments, run `ragged_dot(auto)` W13/SiLU, and report
+    dropped assignments.
+  - For dispatch-up-only timing, the ring-gather path keeps the buffered output
+    capacity but passes only accepted rows to `ragged_dot`, so 10-25% capacity
+    buffers do not charge padded GMM compute.
+- Commands:
+  - Local validation: `uv run --package marin-levanter python -m py_compile lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py lib/levanter/scripts/bench/bench_moe_mgpu_block_transport.py`
+  - Local checks: `./infra/pre-commit.py --changed-files --fix`
+  - Fixed-neighbor H128 correctness: `... --job-name dlwh-6597-moe-fixed-neighbor-h128 -- ... bench_moe_mgpu_block_transport.py --ep-size 8 --rows 32 --hidden 128 --block-rows 16 --block-cols 128 --dtype bf16 --fixed-neighbor --bench-iters 2 --warmup-steps 1`
+  - Fixed-neighbor H2560 bulk probe: `... --job-name dlwh-6597-moe-fixed-neighbor-h2560-rows2560 -- ... --rows 2560 --hidden 2560 --block-rows 32 --block-cols 256 --fixed-neighbor --skip-reference-checks --bench-iters 2 --warmup-steps 1`
+  - Ring-gather H128 smoke: `... --job-name dlwh-6597-moe-ring-gather-up-h128-nopad-gmm -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --recv-capacity-factor 1.25 --run-ring-gather-dispatch-up --skip-reference-checks --ragged-dot-impl auto --bench-iters 1 --warmup-steps 1`
+  - Ring-gather T/rank=4096 buffer sweep: `... --job-name dlwh-6597-moe-ring-gather-up-t4096-nopad-sweep -- ... for factor in 1.0 1.1 1.25; do ... --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --recv-capacity-factor $factor --run-ring-gather-dispatch-up --skip-reference-checks --ragged-dot-impl auto --bench-iters 2 --warmup-steps 1; done`
+- Result:
+  - Fixed-neighbor H128 was correct: max abs error `0`, steady `1.492 ms` for
+    `0.062 MiB`.
+  - Fixed-neighbor H2560 bulk copy was still `1.486 ms` for `100 MiB`, or
+    `70.6 GB/s`. The lowering works, but the launch/synchronization floor makes
+    a seven-hop ring unattractive versus built-in collectives.
+  - Ring-gather H128 25% capacity smoke lowered and ran at `0.340 ms`, dropped
+    `0`.
+  - Ring-gather T/rank=4096, H=I=2560, E=256, topk=4, Grug-truncated weights:
+    - 0% buffer (`recv_capacity=16384`): dropped `0`, steady `1.816 ms`.
+    - 10% buffer (`recv_capacity=18023`): dropped `0`, steady `1.856 ms`.
+    - 25% buffer (`recv_capacity=20480`): dropped `0`, steady `1.861 ms`.
+- Interpretation: The fixed-neighbor Pallas transport is a useful lowering
+  proof but not a viable ring transport as written. The all-gather/ring-style
+  dispatch-up path using built-in collective transport and built-in
+  `ragged_dot` reaches the <2 ms target across the realistic 0-25% buffer
+  range on the relevant large shape. This is not yet a drop-in production
+  subkernel because the benchmark reports the receiver-local W13 layout and
+  skips reference row-order checks; the next correctness step is to return the
+  metadata needed to compare or combine the ring-gather dispatch-up output.
+- Next action: Productionize the ring-gather dispatch-up path behind the
+  Mosaic/Grug MoE backend boundary, with an explicit correctness check for the
+  receiver-local row metadata or a full combine path.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -898,3 +898,40 @@
   ring-gather dispatch-up path first, or redesign Mosaic dispatch around a
   streaming fixed-neighbor schedule that avoids the `EP x send_capacity x H`
   scratch/prepack shape.
+
+### 2026-06-23 23:31 PT - Production helper extraction for ring-gather dispatch-up
+
+- Hypothesis: The fast ring-gather dispatch-up benchmark path should share the
+  Grug EP ring helper instead of carrying a duplicate all-gather/select/GMM
+  implementation. This makes the measured 0-25% buffer behavior correspond to
+  the production `moe_mlp` backend path.
+- Changes:
+  - Extracted `_dispatch_up_ep_ring_local` in
+    `lib/levanter/src/levanter/grug/_moe/ep_ring.py`.
+  - The helper returns receiver-local `x_dispatch`, accepted `group_sizes`,
+    `token_local`, `weight_dispatch`, a `valid` row mask, and dropped-assignment
+    count.
+  - Updated `bench_moe_dispatch_up_mosaic_gpu.py` so
+    `--run-ring-gather-dispatch-up` calls `_dispatch_up_ep_ring_local` and uses
+    the explicit `valid` mask for capacity padding.
+- Commands:
+  - Local syntax: `uv run --package marin-levanter python -m py_compile lib/levanter/src/levanter/grug/_moe/ep_ring.py lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py`
+  - Local tests: `uv run --package marin-levanter pytest lib/levanter/tests/grug/test_grugformer_moe.py -q -k 'ring or a2a_backend_matches_ring or ep_path_lowers'`
+  - Local checks: `./infra/pre-commit.py --changed-files --fix`
+  - CoreWeave H128 correctness: `... --job-name dlwh-6597-moe-ring-gather-prod-helper-h128-correctness -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --run-ring-gather-dispatch-up --ragged-dot-impl auto --bench-iters 1 --warmup-steps 1`
+  - CoreWeave T/rank=4096, 25% buffer smoke: `... --job-name dlwh-6597-moe-ring-gather-prod-helper-t4096-buf125 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --recv-capacity-factor 1.25 --run-ring-gather-dispatch-up --skip-reference-checks --ragged-dot-impl auto --bench-iters 2 --warmup-steps 1`
+- Result:
+  - Local Grug MoE focused tests: `9 passed, 4 skipped`.
+  - Changed-file precommit: clean, including Pyrefly.
+  - H128 correctness on H100x8: dropped `0`, max abs error `1.90735e-06`,
+    steady `0.381 ms`.
+  - T/rank=4096, H=I=2560, E=256, topk=4, 25% buffer on H100x8: dropped `0`,
+    steady `1.859 ms` (`min=1.843`, `max=1.876`, `iters=2`).
+- Interpretation: The production helper extraction preserves the previous
+  benchmark behavior and keeps the realistic 25% imbalance-buffer case under
+  the 2 ms target. For normal routing imbalance policy, 10-25% remains the
+  relevant validation range; 0% is useful as a balanced-routing stress case.
+- Next action: Commit the helper extraction, then wire the helper behind the
+  Mosaic/Grug backend selection boundary or continue toward a true overlapped
+  Mosaic dispatch/W13 implementation if avoiding the built-in collective is
+  still required.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -272,3 +272,56 @@
 - Next action: Use `row_vector` as the default validation dispatch path for the
   milestone branch. For the perf phase, prototype a scratch-mediated dispatch
   modeled after collective matmul's remote-ref exchange.
+
+### 2026-06-24 - Symmetric scratch dispatch prototype
+
+- Hypothesis: A destination-owned symmetric scratch exchange, following the
+  remote-ref pattern in JAX's `collective_matmul_mgpu.py`, should reduce the
+  direct final-buffer remote-write bottleneck and provide the right structure
+  for eventual dispatch/W13 overlap. The communication remains sparse
+  all-to-all: each source writes only rows routed to a destination rank.
+- Commands:
+  - Serial scratch H128 probe: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-dispatch-scratch-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --run-pallas --dispatch-copy-mode scratch --bench-iters 2 --warmup-steps 1`
+  - Serial scratch-count H128/relevant probes: same command shape, with per-row
+    valid scratch metadata replaced by one per-source scratch count.
+  - Parallel scratch H128 probe: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-dispatch-scratch-parallel-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --run-pallas --dispatch-copy-mode scratch_parallel --bench-iters 2 --warmup-steps 1`
+  - Parallel scratch relevant probe: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-dispatch-scratch-parallel-h2560-grug -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode scratch_parallel --bench-iters 3 --warmup-steps 1`
+- Config: Single-node CoreWeave `cw-us-east-02a`, H100x8, explicit `expert`
+  mesh. H128 probes used bf16 standard-normal weights and are dispatch
+  correctness/perf probes; the relevant probe used Grug-truncated weights at
+  `H=2560`, `I=2560`, `T/rank=8`, top-k 4, 32 local experts per rank, 256
+  global experts.
+- Result:
+  - Serial scratch H128 compiled and matched dispatch exactly, but dispatch
+    steady-state was 1.793 ms versus 0.723 ms for the JIT reference. The later
+    W13 failure was the known standard-normal max-error tolerance issue.
+  - Replacing per-row scratch-valid flags with one per-source scratch count did
+    not improve H128 dispatch: 1.795 ms versus 0.683 ms for the JIT reference.
+  - Count-based serial scratch at the relevant Grug shape matched dispatch
+    exactly and preserved W13 parity, but dispatch was 1.800 ms versus 0.747 ms
+    for the JIT reference.
+  - Parallel scratch, using one Pallas program per `(peer_rank, send_row)`,
+    improved H128 dispatch to 1.539 ms versus 0.721 ms for the JIT reference.
+  - Parallel scratch at the relevant Grug shape matched dispatch exactly:
+    dispatch max error 0, metadata errors 0. Steady-state dispatch was
+    1.512 ms versus 0.745 ms for the JIT reference.
+  - After renaming the best variant to the checked-in `scratch` mode, a final
+    H128 Grug smoke passed with dispatch max error 0, metadata errors 0, and
+    W13 max abs error 0.0078125.
+  - Relevant integrated W13/SiLU remained correct: steady-state mean 0.657 ms
+    versus 10.478 ms for the JIT baseline, max abs error 0.015625.
+  - Relevant roofline summary for the parallel scratch run: dispatch payload
+    1280 KiB, dispatch payload bandwidth 0.867 GB/s, W13 measured
+    10.21 TFLOP/s, estimated HBM-bound W13 roofline 26.79 TFLOP/s.
+- Interpretation: The scratch implementation now follows the symmetric
+  remote-ref exchange shape and validates the sparse all-to-all semantics, but
+  it is still not close enough to the JIT dispatch baseline to justify overlap.
+  The best current dispatch is 1.512 ms versus 0.745 ms, roughly 2.0x slower and
+  outside the requested within-30% threshold. Parallelizing per row helped
+  compile time and steady-state time, but the design still pays for separate
+  scratch writes, local compaction, and a full fan-in semaphore before W13.
+- Next action: Do not implement overlap yet. Keep the parallel scratch path as
+  the default `scratch` validation mode and use it as the structural base for a
+  later overlapped prototype only after dispatch is improved, likely by
+  coarsening row programs into larger transfer tiles or fusing compaction with
+  W13 consumption.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -231,3 +231,44 @@
 - Next action: Stop pursuing these XLA flags for this microbench. For baseline
   pressure, compare against Grug's production MoE implementation directly; for
   Mosaic work, continue with tiled dispatch.
+
+### 2026-06-24 - Vectorized remote dispatch validation
+
+- Hypothesis: The relevant-shape integrated dispatch hang is caused by scalar
+  hidden-dimension remote writes in the validation dispatch kernel, not by a
+  semantic routing bug. Replacing the inner scalar loop with a row-slice remote
+  copy should compile at `H=2560` and preserve dispatch correctness.
+- Commands:
+  - H128 row-vector probe: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-dispatch-row-vector-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --run-pallas --dispatch-copy-mode row_vector --bench-iters 2 --warmup-steps 1`
+  - H128 SMEM probe: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-dispatch-row-smem-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --run-pallas --dispatch-copy-mode row_smem --bench-iters 2 --warmup-steps 1`
+  - Relevant-shape row-vector probe: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 2400 --job-name dlwh-6597-moe-dispatch-row-vector-h2560-grug -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode row_vector --bench-iters 3 --warmup-steps 1`
+- Result:
+  - H128 row-vector dispatch compiled and matched the reference exactly:
+    dispatch max error 0, metadata errors 0. Steady-state dispatch was
+    1.753 ms versus 0.739 ms for the JIT reference.
+  - H128 SMEM copy failed in ptxas with `Entry function ... uses too much
+    parameter space (0x8080 bytes, 0x7ffc max)`. An earlier H64 SMEM attempt
+    also failed before the peer copy because lane lowering requires vector
+    element counts that are multiples of 128. This path was removed instead of
+    retaining dead diagnostic code.
+  - Relevant-shape row-vector dispatch compiled in 16.1 s and ran correctly:
+    dispatch max error 0, metadata errors 0. Steady-state dispatch was
+    1.739 ms versus 0.783 ms for the JIT reference.
+  - Relevant-shape integrated W13/SiLU stayed correct under Grug weights:
+    Mosaic GPU W13/SiLU steady-state mean 0.639 ms versus 10.518 ms for the
+    JIT baseline, with max abs error 0.015625.
+  - Relevant-shape roofline summary: 256 routed rows, dispatch payload
+    1280 KiB, dispatch payload bandwidth 0.754 GB/s, W13 measured
+    10.51 TFLOP/s, estimated HBM-bound W13 roofline 26.79 TFLOP/s.
+- Interpretation: The dispatch correctness issue was the scalar lowering path,
+  not the routing data. Row-vector remote stores make the current milestone-1
+  integrated path compile and validate at the requested `H=2560`, `I=2560`,
+  256-expert, top-k 4 shape. It is still slower than the JIT reference dispatch
+  because each routed row is copied serially and synchronized coarsely. The JAX
+  `collective_matmul_mgpu.py` pattern points to the next production design:
+  structured symmetric scratch/ring exchange or multimem-style collectives,
+  then local compaction/W13, rather than per-row direct remote writes into the
+  final receive buffer.
+- Next action: Use `row_vector` as the default validation dispatch path for the
+  milestone branch. For the perf phase, prototype a scratch-mediated dispatch
+  modeled after collective matmul's remote-ref exchange.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -70,3 +70,18 @@
   deliberately serial validation primitive, not a performance implementation.
 - Next action: Replace serial scalar remote writes with tiled/staged copies and
   add backward/custom-VJP coverage before Grug integration.
+
+### 2026-06-23 - Backward oracle kickoff
+
+- Hypothesis: A hand-written VJP for dispatch + W13/SiLU can match JAX autodiff
+  on small routed shapes and serve as the target contract for a Mosaic GPU
+  backward kernel.
+- Command: `uv run --package marin-levanter --group test pytest lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py -q`
+- Config: CPU reference, EP2, top-k 2, two local experts per rank, explicit
+  receive capacity larger than per-sender send capacity.
+- Result: 9 tests passed. The explicit backward oracle matches autodiff for
+  gradients with respect to source activations and W13 weights.
+- Interpretation: Backward can be decomposed into local W13/SiLU VJP followed
+  by reverse dispatch from destination rows to source-rank token gradients.
+- Next action: Port the W13/SiLU VJP and reverse dispatch to Mosaic GPU, then
+  profile the serial forward dispatch to prioritize tiled/staged copies.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -136,3 +136,40 @@
 - Next action: Do not tune block sizes yet. First replace scalar dispatch with
   tiled SMEM-staged remote copies, then rerun this exact comparison. Only after
   that should we scale toward the May D2560 target.
+
+### 2026-06-23 - Relevant-shape W13 probe
+
+- Hypothesis: At the requested MoE shape (`H=2560`, `I=2560`, 256 global
+  experts, top-k 4), the local Mosaic GPU W13/SiLU kernel should become useful
+  even if the serial validation dispatch is not yet scalable.
+- Commands:
+  - Integrated dispatch+W13 probe: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 3600 --job-name 6597-moe-dispatch-up-relevant-h2560-i2560-e256 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --run-pallas --bench-iters 3 --warmup-steps 1`
+  - Split W13 probe: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 1800 --job-name 6597-moe-w13-relevant-h2560-i2560-e256-roofline -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 32 --top-k 4 --hidden 2560 --intermediate 2560 --dtype bf16 --run-pallas --pallas-w13-from-reference-layout --bench-iters 5 --warmup-steps 2 --w13-atol 256`
+- Config: Single-node CoreWeave `cw-us-east-02a`, H100x8, explicit `expert`
+  mesh, bf16, `H=2560`, `I=2560`, `T/rank=8`, top-k 4, 32 local experts per
+  rank, 256 global experts.
+- Result:
+  - Integrated path reached JIT baselines but produced no Mosaic dispatch timing
+    after roughly nine minutes in dispatch compile/lowering; the job was
+    terminated before the 3600 s timeout.
+  - Integrated JIT baselines before termination: dispatch steady-state mean
+    0.784 ms; W13/SiLU steady-state mean 10.504 ms.
+  - Split W13 JIT baselines: dispatch steady-state mean 0.742 ms; W13/SiLU
+    steady-state mean 10.479 ms.
+  - Split Mosaic GPU W13/SiLU, using the reference dispatch layout:
+    compile-including 911 ms; steady-state mean 0.646 ms, min 0.640 ms,
+    max 0.655 ms; 16.23x faster than the JIT W13/SiLU baseline.
+  - W13/SiLU max bf16 absolute error was 128 at this accumulation size. The
+    performance probe used `--w13-atol 256`.
+  - Roofline summary, using the benchmark's H100 SXM assumptions: 256 routed
+    rows, dispatch payload 1280 KiB, W13 work 6.71 GFLOP, W13 bytes 6.25 GiB,
+    arithmetic intensity 1.0 flop/byte, measured W13 10.39 TFLOP/s, estimated
+    HBM-bound W13 roofline 26.79 TFLOP/s.
+- Interpretation: The W13/SiLU subkernel is now meaningfully faster than the
+  JIT baseline at the requested expert/hidden/intermediate shape, reaching about
+  39% of the simple HBM-bound roofline estimate. The integrated `moe_dispatch_up`
+  kernel is still blocked by the serial scalar remote dispatch lowering path, so
+  it cannot yet provide a full relevant-shape end-to-end timing.
+- Next action: Keep W13/SiLU as the viable fast subkernel and prioritize tiled
+  SMEM-staged remote dispatch. Rerun the integrated shape after dispatch no
+  longer lowers as a hidden-dimension scalar loop.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -524,3 +524,48 @@
   readiness at receive-block completion and feeding a non-fragmented W13
   consumer. Keep benchmark capacity factors at 1.0 for no-buffer probes and
   1.1-1.25 for realistic imbalance.
+
+### 2026-06-24 - Candidate-only built-in GMM probes
+
+- Hypothesis: The large-token path should use the built-in grouped matmul
+  (`ragged_dot(auto)`) for W13 and focus Mosaic work on dispatch/overlap. The
+  benchmark needs candidate-only execution and realistic per-peer send capacity
+  before it can probe those shapes without pure-reference overhead or 8x
+  send-buffer over-allocation.
+- Changes:
+  - Added `--skip-reference-checks` for candidate-only perf runs after
+    correctness has been established on smaller shapes.
+  - Added `--send-capacity` / `--send-capacity-factor`, where the factor is
+    applied to balanced `T*K/EP` source/destination traffic. The default remains
+    conservative `T*K` for skewed smoke tests.
+  - Added `--dispatch-rows-per-program` for `scratch_ready`, so one Pallas
+    program can copy a small block of send rows instead of exactly one row.
+- Commands:
+  - Local validation: `uv run --package marin-levanter python -m py_compile lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py`
+  - Local smoke: `uv run --package marin-levanter --group test python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py --ep-size 1 --tokens-per-rank 32 --experts-per-rank 2 --top-k 2 --hidden 8 --intermediate 8 --dtype fp32 --send-capacity-factor 1.0 --skip-reference-checks`
+  - H128 row-blocked dispatch smoke: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name dlwh-6597-moe-scratch-ready-rows16-h128 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated --run-pallas --dispatch-copy-mode scratch_ready --dispatch-rows-per-program 16 --w13-impl mosaic_gpu_block_ready --bench-iters 1 --warmup-steps 1`
+  - Stopped medium row-program candidate: `... --job-name dlwh-6597-moe-ragged-dot-t4096-candidate -- ... --tokens-per-rank 4096 --experts-per-rank 32 --hidden 2560 --intermediate 2560 --recv-capacity-factor 1.25 --send-capacity-factor 1.25 --dispatch-copy-mode scratch_ready --w13-impl ragged_dot --ragged-dot-impl auto --skip-reference-checks`
+  - Stopped medium row-blocked candidate: same shape with
+    `--dispatch-rows-per-program 16`, job
+    `dlwh-6597-moe-ragged-dot-t4096-rows16`.
+- Result:
+  - Local compile/smoke and `./infra/pre-commit.py --changed-files --fix`
+    passed.
+  - H128 rows16: dispatch max error 0, metadata errors 0, source/expert
+    ready-count max error 0, block-ready-count max error 0. Dispatch
+    steady-state mean 1.637 ms. Block-ready W13/SiLU steady-state mean
+    0.183 ms, max abs error 0.0078125.
+  - T/rank=4096 candidate setup used `recv_capacity=20480` and
+    `send_capacity=2560` from 25% buffers. Prepack completed in about 22 s.
+    Both row-program and rows16 scratch dispatch attempts produced no dispatch
+    timing after several minutes and were stopped to avoid burning H100 time.
+- Interpretation: Using built-in GMM for W13 is still the right direction, but
+  the current scratch dispatch transport is the large-shape blocker. Batching
+  rows per Pallas program preserves correctness but does not fix the fundamental
+  cost of copying every 2560-wide row through remote scratch and then compacting
+  it. The next overlap prototype should avoid this row-wise remote scratch
+  transport, likely by writing/coalescing receive blocks directly and signaling
+  block readiness, or by using a collective-style primitive closer to the JAX
+  all-gather matmul pattern.
+- Next action: Replace the scratch row-copy transport with block/coalesced
+  receive writes before rerunning T/rank=4096 or the full T/rank=32768 shape.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -200,3 +200,34 @@
   not indicate a routing or matmul correctness bug.
 - Next action: Keep Grug-style random inputs as the default comparison for
   relevant-shape correctness claims, and continue prioritizing tiled dispatch.
+
+### 2026-06-24 - XLA baseline flag check
+
+- Hypothesis: Enabling Triton GEMM and latency-hiding scheduler flags, and then
+  lowering JAX optimization level to O1, may speed up the JIT W13/SiLU baseline
+  enough to narrow the Mosaic GPU advantage.
+- Commands:
+  - Invalid first attempt: `XLA_FLAGS="-O1 --xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_cuda_data_dir=..." ...`
+  - Valid subset: `XLA_FLAGS="--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_cuda_data_dir=..." ...`
+  - Corrected O1: `JAX_OPTIMIZATION_LEVEL=O1 XLA_FLAGS="--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true --xla_gpu_cuda_data_dir=..." ...`
+- Config: Same split W13/SiLU probe as the Grug-consistent relevant-shape check:
+  single-node CoreWeave `cw-us-east-02a`, H100x8, bf16, `H=2560`, `I=2560`,
+  `T/rank=8`, top-k 4, 32 local experts per rank, 256 global experts,
+  `--weight-init grug_truncated`, reference dispatch layout.
+- Result:
+  - `-O1` inside `XLA_FLAGS` failed at startup: `Unknown flag in XLA_FLAGS: -O1`.
+  - Valid subset run: JIT W13/SiLU steady-state mean 10.526 ms; Mosaic GPU
+    W13/SiLU steady-state mean 0.647 ms; speedup 16.27x.
+  - Corrected O1 run: JIT W13/SiLU steady-state mean 10.492 ms; Mosaic GPU
+    W13/SiLU steady-state mean 0.637 ms; speedup 16.47x.
+  - Correctness stayed unchanged: max abs 0.015625, mean abs 2.28e-05,
+    RMS abs 1.77e-04, max relative 0.0141.
+  - Corrected O1 roofline summary: measured W13 10.54 TFLOP/s, estimated
+    HBM-bound W13 roofline 26.79 TFLOP/s.
+- Interpretation: These flags do not materially improve the JIT W13/SiLU
+  baseline for this split relevant-shape probe. The corrected O1 run improved
+  the baseline by roughly 0.3%, which is within run-to-run noise for this
+  benchmark. The Mosaic GPU W13/SiLU timing is also essentially unchanged.
+- Next action: Stop pursuing these XLA flags for this microbench. For baseline
+  pressure, compare against Grug's production MoE implementation directly; for
+  Mosaic work, continue with tiled dispatch.

--- a/.agents/logbooks/pallas-mosaic-mgpu-moe.md
+++ b/.agents/logbooks/pallas-mosaic-mgpu-moe.md
@@ -107,3 +107,32 @@
   should replace scalar row writes with tiled SMEM-staged remote copies.
 - Next action: Implement tiled dispatch copy path and rerun the same steady-state
   command for an apples-to-apples comparison.
+
+### 2026-06-23 - Baseline and roofline comparison
+
+- Hypothesis: On the validation shape, JIT reference baselines and roofline math
+  will show whether Mosaic GPU is compute-limited or dominated by the current
+  scalar remote-write validation structure.
+- Command: `uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 --job-name 6597-moe-dispatch-up-perf-2 -- ... bench_moe_dispatch_up_mosaic_gpu.py --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 --hidden 64 --intermediate 64 --dtype bf16 --run-pallas --bench-iters 5 --warmup-steps 2`
+- Config: Single-node CoreWeave `cw-us-east-02a`, H100x8, explicit `expert`
+  mesh, bf16, `H=64`, `I=64`, `T/rank=8`, top-k 4, four local experts per
+  rank. This is still the validation shape, not the May D2560 shape.
+- Result:
+  - JIT reference dispatch steady-state: mean 0.638 ms.
+  - Mosaic GPU dispatch steady-state: mean 1.796 ms, or 0.355x reference.
+  - JIT reference W13/SiLU steady-state: mean 0.160 ms.
+  - Mosaic GPU W13/SiLU steady-state: mean 0.214 ms, or 0.751x reference.
+  - Correctness remained clean: dispatch max error 0, metadata errors 0,
+    W13/SiLU max bf16 error 2.
+  - Roofline summary, using H100 SXM order-of-magnitude peaks: 256 routed rows,
+    dispatch payload 32 KiB, dispatch payload bandwidth 0.018 GB/s, W13 work
+    4.19 MFLOP, W13 measured 0.0196 TFLOP/s, estimated W13 roofline
+    190.6 TFLOP/s.
+- Interpretation: The current Mosaic GPU kernels are not near hardware limits.
+  Dispatch is dominated by serial scalar remote writes and synchronization, not
+  payload bandwidth. W13/SiLU is far below roofline because this shape is tiny
+  and launch/scheduling overhead dominates. The JIT reference remains faster on
+  both subphases for this validation shape.
+- Next action: Do not tune block sizes yet. First replace scalar dispatch with
+  tiled SMEM-staged remote copies, then rerun this exact comparison. Only after
+  that should we scale toward the May D2560 target.

--- a/.agents/projects/6597-mosaic-mgpu-moe-handoff.md
+++ b/.agents/projects/6597-mosaic-mgpu-moe-handoff.md
@@ -1,0 +1,283 @@
+# 6597 Mosaic MGPU MoE Dispatch-Up Handoff
+
+## Current State
+
+- Branch: `codex/6597-mosaic-mgpu-moe-m1-m2`
+- Latest pushed commit: `dd08c1326 [levanter] Add compact ring MoE transport probe`
+- Research logbook: `.agents/logbooks/pallas-mosaic-mgpu-moe.md`
+- Main benchmark harness: `lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py`
+- Main Mosaic implementation file: `lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py`
+
+## Status Against The Spec
+
+Requested final goal:
+
+> Implement an overlapped Mosaic GPU MoE dispatch-up path where scratch dispatch signals row/block readiness and W13 consumes ready blocks without waiting for full dispatch completion. Validate against the reference at H=2560, I=2560, E=256, topk=4 with Grug-style weights, then tune the end-to-end steady-state runtime below 2 ms on CoreWeave H100x8.
+
+Current status:
+
+- Bigger target shape is runnable on CoreWeave H100x8:
+  - `H=2560`, `I=2560`, `E=256`, `topk=4`, `T/rank=4096`, `EP=8`, bf16, Grug-truncated weights.
+- Correct compact source/expert capacity direction is established:
+  - Average source/expert rows: `4096 * 4 / 256 = 64`.
+  - 0% buffer: `source_expert_capacity=64`.
+  - 25% buffer: `source_expert_capacity=80`.
+  - Old full source slots/source: `131072`.
+  - Compact 25% source slots/source: `20480`.
+- Correctness:
+  - H128 correctness passes against reference for compact all-to-all + Mosaic W13.
+  - H128 ordered ring transport exactly matches compact all-to-all payload/count tensors.
+  - Target runs generally use `--skip-reference-checks`; full target-shape reference validation is still not done because reference/prepack is expensive and prior target perf probes were candidate-only.
+- Performance:
+  - Best current clean non-overlapped compact path:
+    - Cap64 merged compact all-to-all + Mosaic W13: mean `2.399 ms`, min `1.864 ms`.
+    - Cap80 merged compact all-to-all + Mosaic W13: mean `2.706 ms`, min `2.147 ms`.
+  - Split timing:
+    - Cap64: transport `0.559 ms`, W13 `1.446 ms`, sum `2.006 ms`.
+    - Cap80: transport `0.635 ms`, W13 `1.742 ms`, sum `2.377 ms`.
+  - Existing Grug ring+ragged baseline/helper remains faster:
+    - Ring+ragged target: about `1.889 ms`.
+  - Ring+Mosaic diagnostic:
+    - Target: about `2.221 ms`.
+- Not yet achieved:
+  - No production fused/overlapped Mosaic W13 consumer yet.
+  - No stable `<2 ms` target-shape Mosaic path yet.
+  - No tuned table/autotune-on-miss integration yet.
+  - No backward/gradient kernel path yet.
+
+## Cleanest Happy Path Today
+
+Use the compact source/expert all-to-all path with merged local-expert W13:
+
+1. Build compact source/expert groups sized by `source_expert_capacity`, not by full `T*K`.
+2. Use built-in `lax.all_to_all` to exchange compact `[dst, local_expert, Cse, H]` payloads into receiver-local `[src, local_expert, Cse, H]`.
+3. Merge source groups per local expert into `[local_expert, EP*Cse, H]`.
+4. Run Mosaic W13 over local-expert groups.
+
+This is not the final overlap design, but it is the cleanest correct measured substrate and gives the target latency budget:
+
+- cap64: `0.559 ms` transport + `1.446 ms` W13 = `2.006 ms`.
+- cap80: `0.635 ms` transport + `1.742 ms` W13 = `2.377 ms`.
+
+The overlap implementation only needs to hide roughly `0.4-0.6 ms` of transport to cross `<2 ms` for this deterministic target shape.
+
+## Key Commands
+
+Run commands from repo root:
+
+```bash
+cd /Users/dlwh/.codex/worktrees/b809/marin
+```
+
+### Local Checks
+
+```bash
+uv run --package marin-levanter python -m py_compile \
+  lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py \
+  lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+
+uv run --package marin-levanter pytest \
+  lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py -q
+
+./infra/pre-commit.py --changed-files --fix
+```
+
+### H128 Correctness: Compact All-To-All + Mosaic W13
+
+```bash
+uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run \
+  --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 \
+  --job-name dlwh-6597-moe-compact-a2a-mosaic-h128-capmax \
+  -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py \
+  --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 \
+  --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated \
+  --recv-capacity-factor 1.25 \
+  --run-compact-a2a-mosaic-dispatch-up \
+  --bench-iters 1 --warmup-steps 1
+```
+
+Expected previously:
+
+- `source_expert_capacity: 4`
+- `source_expert_overflow_count: 0`
+- `dispatch_up_compact_a2a_mosaic_gpu_max_abs_error: 0.0078125`
+- `dispatch_up/compact_a2a_mosaic_gpu_end_to_end_ms: 0.390`
+
+### Target Shape: Compact All-To-All + Merged Mosaic W13, Cap64
+
+```bash
+uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run \
+  --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 \
+  --job-name dlwh-6597-moe-compact-a2a-mosaic-target-cap64-merge \
+  --env-vars JAX_OPTIMIZATION_LEVEL O1 \
+  --env-vars XLA_FLAGS "--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true" \
+  -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py \
+  --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 \
+  --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated \
+  --recv-capacity-factor 1.0 --source-expert-capacity 64 \
+  --block-m 64 --block-n 128 --block-k 64 --num-stages 4 --grid-block-n 1 \
+  --run-compact-a2a-mosaic-dispatch-up \
+  --compact-a2a-return-compact-output --compact-a2a-merge-source-groups \
+  --skip-reference-checks --bench-iters 5 --warmup-steps 2
+```
+
+Expected previously:
+
+- `source_expert_capacity: 64`
+- `source_expert_overflow_count: 0`
+- `dispatch_up/compact_a2a_mosaic_gpu/steady: mean=2.399 ms min=1.864 ms max=2.559 ms iters=5`
+
+### Target Shape: Compact All-To-All + Merged Mosaic W13, Cap80
+
+```bash
+uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run \
+  --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 \
+  --job-name dlwh-6597-moe-compact-a2a-mosaic-target-cap80-merge \
+  --env-vars JAX_OPTIMIZATION_LEVEL O1 \
+  --env-vars XLA_FLAGS "--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true" \
+  -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py \
+  --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 \
+  --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated \
+  --recv-capacity-factor 1.25 --source-expert-capacity 80 \
+  --block-m 64 --block-n 128 --block-k 64 --num-stages 4 --grid-block-n 1 \
+  --run-compact-a2a-mosaic-dispatch-up \
+  --compact-a2a-return-compact-output --compact-a2a-merge-source-groups \
+  --skip-reference-checks --bench-iters 3 --warmup-steps 1
+```
+
+Expected previously:
+
+- `source_expert_capacity: 80`
+- `source_expert_overflow_count: 0`
+- `dispatch_up/compact_a2a_mosaic_gpu/steady: mean=2.706 ms min=2.147 ms max=3.013 ms iters=3`
+
+### Target Breakdown: Transport vs W13, Cap64
+
+```bash
+uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run \
+  --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 \
+  --job-name dlwh-6597-moe-compact-a2a-breakdown-target-cap64 \
+  --env-vars JAX_OPTIMIZATION_LEVEL O1 \
+  --env-vars XLA_FLAGS "--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true" \
+  -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py \
+  --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 \
+  --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated \
+  --recv-capacity-factor 1.0 --source-expert-capacity 64 \
+  --block-m 64 --block-n 128 --block-k 64 --num-stages 4 --grid-block-n 1 \
+  --run-compact-a2a-breakdown \
+  --skip-reference-checks --bench-iters 5 --warmup-steps 2
+```
+
+Expected previously:
+
+- `dispatch/compact_a2a_transport/steady: mean=0.559 ms`
+- `w13_silu/compact_a2a_merged_mosaic_gpu/steady: mean=1.446 ms`
+- `dispatch_up/compact_a2a_breakdown_sum_ms: 2.006`
+
+### Target Breakdown: Transport vs W13, Cap80
+
+```bash
+uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run \
+  --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 \
+  --job-name dlwh-6597-moe-compact-a2a-breakdown-target-cap80 \
+  --env-vars JAX_OPTIMIZATION_LEVEL O1 \
+  --env-vars XLA_FLAGS "--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true" \
+  -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py \
+  --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 \
+  --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated \
+  --recv-capacity-factor 1.25 --source-expert-capacity 80 \
+  --block-m 64 --block-n 128 --block-k 64 --num-stages 4 --grid-block-n 1 \
+  --run-compact-a2a-breakdown \
+  --skip-reference-checks --bench-iters 5 --warmup-steps 2
+```
+
+Expected previously:
+
+- `dispatch/compact_a2a_transport/steady: mean=0.635 ms`
+- `w13_silu/compact_a2a_merged_mosaic_gpu/steady: mean=1.742 ms`
+- `dispatch_up/compact_a2a_breakdown_sum_ms: 2.377`
+
+### H128 Correctness: Ordered Compact Ring Transport
+
+```bash
+uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run \
+  --gpu H100x8 --enable-extra-resources --cpu 16 --memory 128GB --disk 50GB --extra gpu --timeout 1800 \
+  --job-name dlwh-6597-moe-compact-ring-transport-h128-rowvec \
+  -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py \
+  --ep-size 8 --tokens-per-rank 8 --experts-per-rank 4 --top-k 4 \
+  --hidden 128 --intermediate 64 --dtype bf16 --weight-init grug_truncated \
+  --recv-capacity-factor 1.25 \
+  --run-compact-ring-transport \
+  --bench-iters 1 --warmup-steps 1
+```
+
+Expected previously:
+
+- `dispatch_compact_ring_transport_x_max_abs_error: 0`
+- `dispatch_compact_ring_transport_count_max_abs_error: 0`
+- `dispatch/compact_ring_transport_end_to_end_ms: 1.439`
+
+### Target: Ordered Compact Ring Transport, Cap64
+
+```bash
+uv run --package marin-iris --extra controller iris --cluster=cw-us-east-02a job run \
+  --gpu H100x8 --enable-extra-resources --cpu 16 --memory 160GB --disk 80GB --extra gpu --timeout 2400 \
+  --job-name dlwh-6597-moe-compact-ring-transport-target-cap64-rowvec \
+  --env-vars JAX_OPTIMIZATION_LEVEL O1 \
+  --env-vars XLA_FLAGS "--xla_gpu_triton_gemm_any=True --xla_gpu_enable_latency_hiding_scheduler=true" \
+  -- python lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py \
+  --ep-size 8 --tokens-per-rank 4096 --experts-per-rank 32 --top-k 4 \
+  --hidden 2560 --intermediate 2560 --dtype bf16 --weight-init grug_truncated \
+  --recv-capacity-factor 1.0 --source-expert-capacity 64 \
+  --run-compact-ring-transport \
+  --skip-reference-checks --bench-iters 3 --warmup-steps 1
+```
+
+Expected previously:
+
+- `dispatch_compact_ring_transport_x_max_abs_error: 0`
+- `dispatch_compact_ring_transport_count_max_abs_error: 0`
+- `dispatch/compact_ring_transport/steady: mean=1.792 ms min=1.752 ms max=1.848 ms iters=3`
+
+## Important Negative Results
+
+- Original destination-major `[dst, T*K, H]` Mosaic peer-copy prepack is the wrong direction.
+- Compact source/expert peer-copy transport returns and is correct, but remains too slow:
+  - dispatch-only around `2.45 ms`.
+  - dispatch+W13 around `3.722 ms`.
+- Compact all-to-all W13 over 256 tiny `(source, local_expert)` groups is pathological:
+  - cap80 compact-output run was about `14.273 ms`.
+  - W13 must consume merged local-expert groups or equivalent pipelined chunks.
+- Ordered compact ring transport with row-vector remote copies is correct but slow:
+  - cap64 target transport around `1.792 ms`.
+  - Built-in compact all-to-all transport is only around `0.559 ms`.
+- A 256-column tiled version of ordered ring transport failed at target shape with a Mosaic layout-inference recursion error. H128 compiled, target did not.
+
+## Next Engineering Step
+
+Implement the first single-launch overlap prototype:
+
+1. Keep compact source/expert payloads.
+2. Use ordered cumulative GMEM semaphore thresholds, matching `collective_matmul_mgpu.py`.
+3. For each source/ring step:
+   - copy one source chunk into destination scratch,
+   - signal the cumulative step semaphore,
+   - consume the received chunk with W13 before all sources have arrived.
+4. On H128, compare against reference.
+5. On target, compare against:
+   - cap64 non-overlapped compact all-to-all merged W13 (`2.399 ms`, split sum `2.006 ms`),
+   - cap80 non-overlapped compact all-to-all merged W13 (`2.706 ms`, split sum `2.377 ms`),
+   - ring+ragged helper baseline (`~1.889 ms`).
+
+If the overlapped ring path is still above target because raw transport is too slow, optimize transport separately:
+
+- Try fewer programs with larger per-program row chunks.
+- Revisit bulk copy/TMA-style copies while avoiding the target layout-inference recursion.
+- Consider wrapping the built-in compact all-to-all layout as the production happy path while the Pallas ring transport matures.
+
+## Notes For Humans
+
+- The current work is benchmark/prototype code, not production API integration.
+- The benchmark harness now has several useful modes; prefer the compact all-to-all merged W13 path for clean numbers.
+- The active objective is not complete until a real overlapped Mosaic path is correct at the target shape and steady-state `<2 ms`.
+- The branch was clean and pushed before this handoff was written.

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -259,6 +259,13 @@ Marin's `gpu` extra installs the JAX CUDA 13 wheel stack from PyPI. CoreWeave
 GPU nodes must expose NVIDIA driver 580 or newer; `nvidia-smi` should report
 CUDA 13.x.
 
+Iris task bootstrap exposes the PyPI CUDA 13 toolchain after `uv sync`: it adds
+the venv's `nvidia/cu13/bin` directory to `PATH`, sets `XLA_FLAGS` with
+`--xla_gpu_cuda_data_dir` when that flag is not already present, and stages
+`libdevice.10.bc` under `cuda_sdk_lib/nvvm/libdevice/` plus `/app`. This keeps
+JAX/Pallas Mosaic kernels working without per-job shell setup for `ptxas`,
+`nvlink`, or `libdevice.10.bc`.
+
 ### Grug MoE Canary Warm-Node Multinode Smoke
 
 For a realistic Grug MoE multinode smoke, use the GPU path in

--- a/lib/iris/src/iris/cluster/runtime/entrypoint.py
+++ b/lib/iris/src/iris/cluster/runtime/entrypoint.py
@@ -41,6 +41,29 @@ def _build_pip_install_args(pip_packages: Sequence[str]) -> str:
     return " ".join(shlex.quote(pkg) for pkg in packages)
 
 
+def _stage_cuda_toolchain_command() -> str:
+    """Expose CUDA tools installed by PyPI packages in the task venv."""
+    return (
+        "cuda_dir='';"
+        " for d in .venv/lib/python*/site-packages/nvidia/cu13; do"
+        ' [ -d "$d" ] && cuda_dir="$d" && break;'
+        " done;"
+        ' if [ -n "$cuda_dir" ]; then'
+        ' export PATH="$PWD/$cuda_dir/bin:$PATH";'
+        ' case "${XLA_FLAGS:-}" in'
+        ' *"--xla_gpu_cuda_data_dir="*) ;;'
+        ' *) export XLA_FLAGS="${XLA_FLAGS:+$XLA_FLAGS }--xla_gpu_cuda_data_dir=$PWD/$cuda_dir" ;;'
+        " esac;"
+        ' libdevice="$cuda_dir/nvvm/libdevice/libdevice.10.bc";'
+        ' if [ -f "$libdevice" ]; then'
+        " mkdir -p cuda_sdk_lib/nvvm/libdevice;"
+        ' cp -f "$libdevice" cuda_sdk_lib/nvvm/libdevice/libdevice.10.bc;'
+        ' cp -f "$libdevice" libdevice.10.bc;'
+        " fi;"
+        " fi"
+    )
+
+
 def build_runtime_entrypoint(
     entrypoint: Entrypoint,
     env_config: job_pb2.EnvironmentConfig,
@@ -80,6 +103,7 @@ def build_runtime_entrypoint(
         )
     else:
         setup_commands.append(f"uv sync {quiet_flag} {frozen_flag} {link_mode_flag} {python_flag}".strip())
+    setup_commands.append(_stage_cuda_toolchain_command())
     # In rust-dev mode, uv sync creates .pth links for editable path sources but
     # doesn't invoke the build backend (maturin), so native extensions are missing.
     # The RUST-DEV SOURCES block is the only place we use `editable = true`; when

--- a/lib/iris/tests/cluster/runtime/test_entrypoint.py
+++ b/lib/iris/tests/cluster/runtime/test_entrypoint.py
@@ -53,6 +53,23 @@ def test_build_runtime_entrypoint_includes_pip_packages():
     assert "memray" in setup
 
 
+def test_build_runtime_entrypoint_stages_cuda_toolchain_after_uv_sync():
+    ep = _make_entrypoint(["python", "train.py"])
+    env = _make_env_config(extras=["gpu"])
+    rt = build_runtime_entrypoint(ep, env)
+
+    setup_commands = list(rt.setup_commands)
+    sync_index = next(i for i, command in enumerate(setup_commands) if command.startswith("uv sync"))
+    cuda_index = next(i for i, command in enumerate(setup_commands) if "nvidia/cu13" in command)
+    cuda_command = setup_commands[cuda_index]
+
+    assert cuda_index == sync_index + 1
+    assert 'export PATH="$PWD/$cuda_dir/bin:$PATH"' in cuda_command
+    assert "--xla_gpu_cuda_data_dir=$PWD/$cuda_dir" in cuda_command
+    assert "cuda_sdk_lib/nvvm/libdevice/libdevice.10.bc" in cuda_command
+    assert 'cp -f "$libdevice" libdevice.10.bc' in cuda_command
+
+
 def test_build_runtime_entrypoint_with_python_version():
     ep = _make_entrypoint(["python", "app.py"])
     env = _make_env_config(python_version="3.11")

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -911,6 +911,84 @@ def _compact_a2a_mosaic_w13_dispatch_up_fn(
     )
 
 
+def _compact_a2a_transport_fn(mesh: Mesh) -> Callable[..., tuple[jax.Array, jax.Array]]:
+    def local_transport(send_x_by_dst_expert, send_count_by_dst_expert):
+        send_x_by_dst_expert = jnp.squeeze(send_x_by_dst_expert, axis=0)
+        send_count_by_dst_expert = jnp.squeeze(send_count_by_dst_expert, axis=0)
+        source_expert_x = lax.all_to_all(
+            send_x_by_dst_expert,
+            "expert",
+            split_axis=0,
+            concat_axis=0,
+        )
+        source_expert_count = lax.all_to_all(
+            send_count_by_dst_expert,
+            "expert",
+            split_axis=0,
+            concat_axis=0,
+        )
+        return source_expert_x[None, ...], source_expert_count[None, ...]
+
+    return jax.jit(
+        shard_map(
+            local_transport,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None, None, None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(
+                P("expert", None, None, None, None),
+                P("expert", None, None),
+            ),
+            check_vma=False,
+        )
+    )
+
+
+def _compact_a2a_merged_mosaic_w13_fn(
+    mesh: Mesh,
+    args,
+) -> Callable[..., jax.Array]:
+    def local_w13(source_expert_x, local_w_gate_up):
+        source_expert_x = jnp.squeeze(source_expert_x, axis=0)
+        local_w_gate_up = jnp.squeeze(local_w_gate_up, axis=0)
+        ep_size, local_experts, source_expert_capacity, hidden = source_expert_x.shape
+        local_expert_x = jnp.swapaxes(source_expert_x, 0, 1).reshape(
+            local_experts * ep_size * source_expert_capacity,
+            hidden,
+        )
+        local_expert_rows = jnp.full(
+            (local_experts,),
+            ep_size * source_expert_capacity,
+            dtype=jnp.int32,
+        )
+        h = compute_moe_up_mosaic_gpu_local(
+            local_expert_x,
+            local_expert_rows,
+            local_w_gate_up,
+            block_m=args.block_m,
+            block_n=args.block_n,
+            block_k=args.block_k,
+            max_concurrent_steps=args.num_stages,
+            grid_block_n=args.grid_block_n,
+        )
+        return h[None, ...]
+
+    return jax.jit(
+        shard_map(
+            local_w13,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None, None, None, None),
+                P("expert", None, None, None),
+            ),
+            out_specs=P("expert", None, None),
+            check_vma=False,
+        )
+    )
+
+
 def _pallas_compact_source_expert_dispatch_fn(
     mesh: Mesh,
     *,
@@ -1861,6 +1939,11 @@ def main() -> None:
         help="Benchmark compact source/expert all-to-all followed by Mosaic GPU W13/SiLU.",
     )
     parser.add_argument(
+        "--run-compact-a2a-breakdown",
+        action="store_true",
+        help="Benchmark compact source/expert all-to-all transport and merged Mosaic W13 separately.",
+    )
+    parser.add_argument(
         "--compact-a2a-return-compact-output",
         action="store_true",
         help="Return compact source/expert W13 output instead of scattering back to destination-major rows.",
@@ -2030,6 +2113,7 @@ def main() -> None:
             or args.run_ring_gather_dispatch_up
             or args.run_ring_gather_mosaic_dispatch_up
             or args.run_compact_a2a_mosaic_dispatch_up
+            or args.run_compact_a2a_breakdown
         )
         and not args.run_pallas
     ):
@@ -2105,6 +2189,7 @@ def main() -> None:
         and not args.run_compact_source_expert_dispatch
         and not args.run_compact_source_expert_dispatch_up
         and not args.run_compact_a2a_mosaic_dispatch_up
+        and not args.run_compact_a2a_breakdown
     ):
         return
     if len(devices) < args.ep_size:
@@ -2523,6 +2608,83 @@ def main() -> None:
                 )
             if compact_a2a_mosaic_steady_ms is not None:
                 print(f"dispatch_up/compact_a2a_mosaic_gpu_end_to_end_ms: {compact_a2a_mosaic_steady_ms:.3f}")
+
+        if args.run_compact_a2a_breakdown:
+            source_expert_capacity, source_expert_capacity_factor = _resolve_source_expert_capacity(args)
+            compact_prepacked, _ = _time_block(
+                "prepack/source_expert_reference",
+                lambda: prepack_moe_dispatch_up_source_expert_reference(
+                    x_by_rank,
+                    expert_ids,
+                    router_weights,
+                    num_experts=num_experts,
+                    recv_capacity=recv_capacity,
+                    source_expert_capacity=source_expert_capacity,
+                ),
+            )
+            inferred_source_expert_capacity = compact_prepacked.send_x_by_dst_expert.shape[3]
+            if source_expert_capacity_factor is None:
+                print(f"source_expert_capacity: {inferred_source_expert_capacity}")
+            else:
+                print(
+                    "source_expert_capacity: "
+                    f"{inferred_source_expert_capacity} from factor={source_expert_capacity_factor:g}"
+                )
+            print(f"source_expert_overflow_count: {int(jax.device_get(compact_prepacked.overflow_count))}")
+            _print_source_expert_load_stats(compact_prepacked, args, send_capacity=send_capacity)
+
+            compact_transport_fn = _compact_a2a_transport_fn(mesh)
+            compact_transport_args = (
+                _sharded(mesh, compact_prepacked.send_x_by_dst_expert, P("expert", None, None, None, None)),
+                _sharded(mesh, compact_prepacked.send_count_by_dst_expert, P("expert", None, None)),
+            )
+
+            def run_compact_a2a_transport():
+                return compact_transport_fn(*compact_transport_args)
+
+            compact_transport_result, _ = _time_block(
+                "dispatch/compact_a2a_transport",
+                run_compact_a2a_transport,
+            )
+            source_expert_x, source_expert_count = compact_transport_result
+            if args.bench_iters > 0:
+                compact_transport_steady_ms = _measure_steady_state(
+                    "dispatch/compact_a2a_transport",
+                    run_compact_a2a_transport,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            else:
+                compact_transport_steady_ms = None
+            print(f"dispatch/compact_a2a_transport_count_max: {int(jnp.max(source_expert_count))}")
+
+            compact_merged_w13_fn = _compact_a2a_merged_mosaic_w13_fn(mesh, args)
+            compact_merged_w13_args = (
+                source_expert_x,
+                _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+            )
+
+            def run_compact_merged_w13():
+                return compact_merged_w13_fn(*compact_merged_w13_args)
+
+            _compact_merged_h, _ = _time_block(
+                "w13_silu/compact_a2a_merged_mosaic_gpu",
+                run_compact_merged_w13,
+            )
+            if args.bench_iters > 0:
+                compact_merged_w13_steady_ms = _measure_steady_state(
+                    "w13_silu/compact_a2a_merged_mosaic_gpu",
+                    run_compact_merged_w13,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            else:
+                compact_merged_w13_steady_ms = None
+            if compact_transport_steady_ms is not None and compact_merged_w13_steady_ms is not None:
+                print(
+                    "dispatch_up/compact_a2a_breakdown_sum_ms: "
+                    f"{compact_transport_steady_ms + compact_merged_w13_steady_ms:.3f}"
+                )
 
         if args.run_compact_source_expert_dispatch:
             source_expert_capacity, source_expert_capacity_factor = _resolve_source_expert_capacity(args)

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -21,10 +21,10 @@ from levanter.grug._moe.ep_common import (
     _expert_prefix_keep_mask,
     _local_permute_from_counts,
     _permute_by_global_expert,
-    _prefix_cap_counts,
     _shard_a2a_params,
 )
 from levanter.grug._moe.ep_padded_all_to_all import _dispatch_fixed_buckets
+from levanter.grug._moe.ep_ring import _dispatch_up_ep_ring_local
 from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local,
@@ -1056,65 +1056,45 @@ def _ring_gather_dispatch_up_fn(
     *,
     local_capacity: int,
 ) -> Callable[..., tuple[jax.Array, jax.Array]]:
-    def local_dispatch_up(x_local, selected_experts_local, local_w_gate_up):
+    num_experts = args.ep_size * args.experts_per_rank
+    capacity_factor = local_capacity / (args.tokens_per_rank * args.top_k)
+
+    def local_dispatch_up(x_local, selected_experts_local, combine_weights_local, local_w_gate_up):
         x_local = jnp.squeeze(x_local, axis=0)
         selected_experts_local = jnp.squeeze(selected_experts_local, axis=0)
+        combine_weights_local = jnp.squeeze(combine_weights_local, axis=0)
         local_w_gate_up = jnp.squeeze(local_w_gate_up, axis=0)
         local_experts = local_w_gate_up.shape[0]
 
-        x_global = lax.all_gather(x_local, "expert", tiled=True)
-        selected_experts_global = lax.all_gather(selected_experts_local, "expert", tiled=True)
-
-        tokens = x_global.shape[0]
-        topk = selected_experts_global.shape[1]
-        assignments = tokens * topk
-        if local_capacity < local_experts:
-            raise ValueError(f"local_capacity={local_capacity} must be >= local_experts={local_experts}")
-
-        expert_start = lax.axis_index("expert") * local_experts
-        local_expert = selected_experts_global.reshape(assignments) - expert_start
-        local_mask = (local_expert >= 0) & (local_expert < local_experts)
-
-        local_expert = jnp.where(local_mask, local_expert, 0)
-        expert_ids = jnp.arange(local_experts, dtype=jnp.int32)
-        counts = jnp.sum(
-            (local_expert[:, None] == expert_ids[None, :]).astype(jnp.int32) * local_mask[:, None].astype(jnp.int32),
-            axis=0,
-            dtype=jnp.int32,
+        dispatch = _dispatch_up_ep_ring_local(
+            x_local,
+            selected_experts_local,
+            combine_weights_local,
+            local_experts=local_experts,
+            num_experts=num_experts,
+            capacity_factor=capacity_factor,
         )
-        accepted_counts = _prefix_cap_counts(counts, capacity=local_capacity)
-        accepted_total = jnp.sum(accepted_counts, dtype=jnp.int32)
-        valid = jnp.arange(local_capacity, dtype=jnp.int32) < accepted_total
-
-        flat_pos = jnp.arange(assignments, dtype=jnp.int32)
-        order_key = local_expert * assignments + flat_pos
-        max_order_key = local_experts * assignments
-        selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
-        _, local_idx = lax.top_k(selection_key, local_capacity)
-
-        token_local = local_idx // topk
-        x_take = jnp.take(x_global, token_local, axis=0)
-        x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))
-        # Keep the capacity buffer in the output shape, but do not charge W13
-        # for padded rows in this dispatch-up-only benchmark.
-        group_sizes = accepted_counts
-
         w13_out = ragged_dot(
-            x_dispatch,
+            dispatch.x_dispatch,
             local_w_gate_up,
-            group_sizes,
+            dispatch.group_sizes,
             implementation=args.ragged_dot_impl,
         )
         gate, up = jnp.split(w13_out, 2, axis=-1)
         h = jax.nn.silu(gate.astype(jnp.float32)).astype(gate.dtype) * up
-        dropped_total = lax.psum(jnp.sum(counts, dtype=jnp.int32) - accepted_total, "expert")
-        return jnp.where(valid[:, None], h, jnp.zeros((), dtype=h.dtype))[None, ...], dropped_total[None]
+        dropped_total = lax.psum(dispatch.dropped_local, "expert")
+        return jnp.where(dispatch.valid[:, None], h, jnp.zeros((), dtype=h.dtype))[None, ...], dropped_total[None]
 
     return jax.jit(
         shard_map(
             local_dispatch_up,
             mesh=mesh,
-            in_specs=(P("expert", None, None), P("expert", None, None), P("expert", None, None, None)),
+            in_specs=(
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None, None),
+            ),
             out_specs=(P("expert", None, None), P("expert")),
             check_vma=False,
         )
@@ -1883,6 +1863,7 @@ def main() -> None:
             ring_gather_args = (
                 _sharded(mesh, x_by_rank, P("expert", None, None)),
                 _sharded(mesh, expert_ids, P("expert", None, None)),
+                _sharded(mesh, router_weights, P("expert", None, None)),
                 _sharded(mesh, w_gate_up, P("expert", None, None, None)),
             )
 

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -1779,7 +1779,7 @@ def main() -> None:
                 return ring_gather_fn(*ring_gather_args)
 
             ring_gather_result, _ = _time_block("dispatch_up/ring_gather_ragged_dot", run_ring_gather_dispatch_up)
-            _, ring_gather_dropped = ring_gather_result
+            ring_gather_h, ring_gather_dropped = ring_gather_result
             ring_gather_dropped_int = int(jnp.max(ring_gather_dropped))
             print(f"dispatch_up/ring_gather_dropped_total: {ring_gather_dropped_int}")
             ring_gather_steady_ms = None
@@ -1790,7 +1790,18 @@ def main() -> None:
                     warmup_steps=args.warmup_steps,
                     bench_iters=args.bench_iters,
                 )
-            print("dispatch_up/ring_gather_ragged_dot/reference_check: skipped")
+            if ref_h is None:
+                print("dispatch_up/ring_gather_ragged_dot/reference_check: skipped")
+            else:
+                ring_gather_err = jnp.max(jnp.abs(ring_gather_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
+                ring_gather_err_float = float(ring_gather_err)
+                print(f"dispatch_up_ring_gather_ragged_dot_max_abs_error: {ring_gather_err_float:.6g}")
+                _print_error_summary("dispatch_up_ring_gather_ragged_dot", ring_gather_h, ref_h)
+                _check_error(
+                    "dispatch_up_ring_gather_ragged_dot_max_abs_error",
+                    ring_gather_err_float,
+                    args.w13_atol,
+                )
             if ring_gather_steady_ms is not None:
                 print(f"dispatch_up/ring_gather_ragged_dot_end_to_end_ms: {ring_gather_steady_ms:.3f}")
 

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -181,6 +181,12 @@ def _expected_ready_count(prepacked, recv_capacity: int) -> jax.Array:
     return jnp.minimum(prepacked.recv_source_expert_count, remaining_capacity)
 
 
+def _expected_ready_block_count(prepacked, recv_capacity: int, block_m: int) -> jax.Array:
+    total_ready_rows = jnp.minimum(jnp.sum(prepacked.rows_per_expert, axis=1, dtype=jnp.int32), recv_capacity)
+    block_starts = jnp.arange(math.ceil(recv_capacity / block_m), dtype=jnp.int32) * block_m
+    return jnp.minimum(jnp.maximum(total_ready_rows[:, None] - block_starts[None, :], 0), block_m)
+
+
 def _pallas_dispatch_fn(
     mesh: Mesh,
     *,
@@ -263,7 +269,8 @@ def _pallas_dispatch_ready_fn(
     mesh: Mesh,
     *,
     recv_capacity: int,
-) -> Callable[..., tuple[MoeDispatchUpLayout, jax.Array]]:
+    ready_block_m: int,
+) -> Callable[..., tuple[MoeDispatchUpLayout, jax.Array, jax.Array]]:
     def local_dispatch(
         send_x,
         send_row,
@@ -279,7 +286,7 @@ def _pallas_dispatch_ready_fn(
         recv_source_expert_base,
         recv_source_expert_count,
     ):
-        layout, ready_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local(
+        layout, ready_count, ready_block_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local(
             jnp.squeeze(send_x, axis=0),
             jnp.squeeze(send_row, axis=0),
             jnp.squeeze(send_local_expert, axis=0),
@@ -295,6 +302,7 @@ def _pallas_dispatch_ready_fn(
             jnp.squeeze(recv_source_expert_count, axis=0),
             axis_name="expert",
             recv_capacity=recv_capacity,
+            ready_block_m=ready_block_m,
         )
         return (
             MoeDispatchUpLayout(
@@ -310,6 +318,7 @@ def _pallas_dispatch_ready_fn(
                 layout.overflow_count[None],
             ),
             ready_count[None, ...],
+            ready_block_count[None, ...],
         )
 
     out_specs = (
@@ -326,6 +335,7 @@ def _pallas_dispatch_ready_fn(
             P("expert"),
         ),
         P("expert", None, None),
+        P("expert", None),
     )
     fn = jax.jit(
         shard_map(
@@ -853,12 +863,15 @@ def main() -> None:
     with jax.set_mesh(mesh):
         pallas_dispatch_steady_ms = None
         pallas_ready_count = None
+        pallas_ready_block_count = None
         if args.pallas_w13_from_reference_layout:
             pallas_layout = ref_layout
             print("dispatch/mosaic_gpu: skipped; using reference layout for W13/SiLU")
         else:
             if args.dispatch_copy_mode == "scratch_ready":
-                pallas_dispatch_fn = _pallas_dispatch_ready_fn(mesh, recv_capacity=recv_capacity)
+                pallas_dispatch_fn = _pallas_dispatch_ready_fn(
+                    mesh, recv_capacity=recv_capacity, ready_block_m=args.block_m
+                )
                 pallas_dispatch_args = _pallas_dispatch_ready_args(mesh, prepacked)
             else:
                 pallas_dispatch_fn = _pallas_dispatch_fn(
@@ -871,7 +884,7 @@ def main() -> None:
 
             pallas_dispatch_result, _ = _time_block("dispatch/mosaic_gpu", run_pallas_dispatch)
             if args.dispatch_copy_mode == "scratch_ready":
-                pallas_layout, pallas_ready_count = pallas_dispatch_result
+                pallas_layout, pallas_ready_count, pallas_ready_block_count = pallas_dispatch_result
             else:
                 pallas_layout = pallas_dispatch_result
             if args.bench_iters > 0:
@@ -911,6 +924,15 @@ def main() -> None:
                 print(f"dispatch_ready_count_max_abs_error: {ready_count_err_int}")
                 if ready_count_err_int != 0:
                     raise AssertionError(f"dispatch ready-count mismatch: max_abs={ready_count_err_int}")
+            if pallas_ready_block_count is not None:
+                expected_ready_block_count = _sharded(
+                    mesh, _expected_ready_block_count(prepacked, recv_capacity, args.block_m), P("expert", None)
+                )
+                ready_block_count_err = jnp.max(jnp.abs(pallas_ready_block_count - expected_ready_block_count))
+                ready_block_count_err_int = int(ready_block_count_err)
+                print(f"dispatch_ready_block_count_max_abs_error: {ready_block_count_err_int}")
+                if ready_block_count_err_int != 0:
+                    raise AssertionError(f"dispatch ready-block-count mismatch: max_abs={ready_block_count_err_int}")
             _check_error("dispatch_max_abs_error", dispatch_err_float, args.dispatch_atol)
             if valid_err_int != 0 or expert_err_int != 0 or src_rank_err_int != 0:
                 raise AssertionError(

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -34,6 +34,31 @@ def _time_block(label: str, fn: Callable[[], jax.Array | MoeDispatchUpLayout]) -
     return result, elapsed
 
 
+def _measure_steady_state(
+    label: str,
+    fn: Callable[[], jax.Array | MoeDispatchUpLayout],
+    *,
+    warmup_steps: int,
+    bench_iters: int,
+) -> None:
+    for _ in range(warmup_steps):
+        jax.block_until_ready(fn())
+
+    times = []
+    for _ in range(bench_iters):
+        start = time.perf_counter()
+        jax.block_until_ready(fn())
+        times.append(time.perf_counter() - start)
+    times_ms = np.asarray(times) * 1e3
+    print(
+        f"{label}/steady: "
+        f"mean={float(np.mean(times_ms)):.3f} ms "
+        f"min={float(np.min(times_ms)):.3f} ms "
+        f"max={float(np.max(times_ms)):.3f} ms "
+        f"iters={bench_iters}"
+    )
+
+
 def _make_inputs(
     *,
     ep_size: int,
@@ -59,15 +84,29 @@ def _make_inputs(
     return x_by_rank, expert_ids, router_weights, w_gate_up
 
 
-def _pallas_dispatch(
+def _sharded(mesh: Mesh, value: jax.Array, spec: P) -> jax.Array:
+    return jax.device_put(value, NamedSharding(mesh, spec))
+
+
+def _pallas_dispatch_args(mesh: Mesh, prepacked) -> tuple[jax.Array, ...]:
+    return (
+        _sharded(mesh, prepacked.send_x_by_dst, P("expert", None, None, None)),
+        _sharded(mesh, prepacked.send_row_by_dst, P("expert", None, None)),
+        _sharded(mesh, prepacked.send_local_expert_by_dst, P("expert", None, None)),
+        _sharded(mesh, prepacked.send_src_token_idx_by_dst, P("expert", None, None)),
+        _sharded(mesh, prepacked.send_topk_slot_by_dst, P("expert", None, None)),
+        _sharded(mesh, prepacked.send_router_weight_by_dst, P("expert", None, None)),
+        _sharded(mesh, prepacked.send_count_by_dst, P("expert", None)),
+        _sharded(mesh, prepacked.rows_per_expert, P("expert", None)),
+        _sharded(mesh, prepacked.expert_base, P("expert", None)),
+    )
+
+
+def _pallas_dispatch_fn(
     mesh: Mesh,
-    prepacked,
     *,
     recv_capacity: int,
-) -> MoeDispatchUpLayout:
-    def sharded(value: jax.Array, spec: P) -> jax.Array:
-        return jax.device_put(value, NamedSharding(mesh, spec))
-
+) -> Callable[..., MoeDispatchUpLayout]:
     def local_dispatch(
         send_x,
         send_row,
@@ -136,23 +175,18 @@ def _pallas_dispatch(
             check_vma=False,
         )
     )
-    return fn(
-        sharded(prepacked.send_x_by_dst, P("expert", None, None, None)),
-        sharded(prepacked.send_row_by_dst, P("expert", None, None)),
-        sharded(prepacked.send_local_expert_by_dst, P("expert", None, None)),
-        sharded(prepacked.send_src_token_idx_by_dst, P("expert", None, None)),
-        sharded(prepacked.send_topk_slot_by_dst, P("expert", None, None)),
-        sharded(prepacked.send_router_weight_by_dst, P("expert", None, None)),
-        sharded(prepacked.send_count_by_dst, P("expert", None)),
-        sharded(prepacked.rows_per_expert, P("expert", None)),
-        sharded(prepacked.expert_base, P("expert", None)),
+    return fn
+
+
+def _pallas_w13_silu_args(mesh: Mesh, layout: MoeDispatchUpLayout, w_gate_up: jax.Array) -> tuple[jax.Array, ...]:
+    return (
+        _sharded(mesh, layout.recv_x, P("expert", None, None)),
+        _sharded(mesh, layout.rows_per_expert, P("expert", None)),
+        _sharded(mesh, w_gate_up, P("expert", None, None, None)),
     )
 
 
-def _pallas_w13_silu(mesh: Mesh, layout: MoeDispatchUpLayout, w_gate_up: jax.Array, args) -> jax.Array:
-    def sharded(value: jax.Array, spec: P) -> jax.Array:
-        return jax.device_put(value, NamedSharding(mesh, spec))
-
+def _pallas_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
     def local_w13(recv_x, rows_per_expert, local_w_gate_up):
         h = compute_moe_up_mosaic_gpu_local(
             jnp.squeeze(recv_x, axis=0),
@@ -175,11 +209,7 @@ def _pallas_w13_silu(mesh: Mesh, layout: MoeDispatchUpLayout, w_gate_up: jax.Arr
             check_vma=False,
         )
     )
-    return fn(
-        sharded(layout.recv_x, P("expert", None, None)),
-        sharded(layout.rows_per_expert, P("expert", None)),
-        sharded(w_gate_up, P("expert", None, None, None)),
-    )
+    return fn
 
 
 def _print_error_debug(
@@ -235,6 +265,8 @@ def main() -> None:
     parser.add_argument("--debug-errors", action="store_true")
     parser.add_argument("--dispatch-atol", type=float, default=0.0)
     parser.add_argument("--w13-atol", type=float, default=2.0)
+    parser.add_argument("--warmup-steps", type=int, default=1)
+    parser.add_argument("--bench-iters", type=int, default=0)
     args = parser.parse_args()
 
     dtype = jnp.bfloat16 if args.dtype == "bf16" else jnp.float32
@@ -282,9 +314,20 @@ def main() -> None:
 
     mesh = Mesh(np.array(devices[: args.ep_size]), ("expert",), axis_types=(AxisType.Explicit,))
     with jax.set_mesh(mesh):
-        pallas_layout, _ = _time_block(
-            "dispatch/mosaic_gpu", lambda: _pallas_dispatch(mesh, prepacked, recv_capacity=recv_capacity)
-        )
+        pallas_dispatch_fn = _pallas_dispatch_fn(mesh, recv_capacity=recv_capacity)
+        pallas_dispatch_args = _pallas_dispatch_args(mesh, prepacked)
+
+        def run_pallas_dispatch():
+            return pallas_dispatch_fn(*pallas_dispatch_args)
+
+        pallas_layout, _ = _time_block("dispatch/mosaic_gpu", run_pallas_dispatch)
+        if args.bench_iters > 0:
+            _measure_steady_state(
+                "dispatch/mosaic_gpu",
+                run_pallas_dispatch,
+                warmup_steps=args.warmup_steps,
+                bench_iters=args.bench_iters,
+            )
         dispatch_err = jnp.max(
             jnp.abs(pallas_layout.recv_x.astype(jnp.float32) - ref_layout.recv_x.astype(jnp.float32))
         )
@@ -307,9 +350,20 @@ def main() -> None:
                 f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
             )
 
-        pallas_h, _ = _time_block(
-            "w13_silu/mosaic_gpu", lambda: _pallas_w13_silu(mesh, pallas_layout, w_gate_up, args)
-        )
+        pallas_w13_fn = _pallas_w13_silu_fn(mesh, args)
+        pallas_w13_args = _pallas_w13_silu_args(mesh, pallas_layout, w_gate_up)
+
+        def run_pallas_w13():
+            return pallas_w13_fn(*pallas_w13_args)
+
+        pallas_h, _ = _time_block("w13_silu/mosaic_gpu", run_pallas_w13)
+        if args.bench_iters > 0:
+            _measure_steady_state(
+                "w13_silu/mosaic_gpu",
+                run_pallas_w13,
+                warmup_steps=args.warmup_steps,
+                bench_iters=args.bench_iters,
+            )
         h_err = jnp.max(jnp.abs(pallas_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
         h_err_float = float(h_err)
         print(f"w13_silu_max_abs_error: {h_err_float:.6g}")

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -4,6 +4,7 @@
 """Validate the experimental MoE dispatch-up Mosaic GPU subkernel."""
 
 import argparse
+import math
 import time
 from collections.abc import Callable
 
@@ -119,6 +120,8 @@ def _make_inputs(
     hidden: int,
     intermediate: int,
     dtype: jnp.dtype,
+    weight_init: str,
+    weight_std: float | None,
 ) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
     num_experts = ep_size * experts_per_rank
     k_x, k_w = jax.random.split(jax.random.key(6597))
@@ -131,7 +134,14 @@ def _make_inputs(
         jnp.arange(ep_size * tokens_per_rank * top_k, dtype=jnp.float32).reshape(ep_size, tokens_per_rank, top_k),
         axis=-1,
     ).astype(dtype)
-    w_gate_up = jax.random.normal(k_w, (ep_size, experts_per_rank, hidden, 2 * intermediate), dtype=dtype)
+    w_shape = (ep_size, experts_per_rank, hidden, 2 * intermediate)
+    if weight_init == "grug_truncated":
+        std = 0.5 / math.sqrt(hidden) if weight_std is None else weight_std
+        w_gate_up = (std * jax.random.truncated_normal(k_w, -3, 3, w_shape)).astype(dtype)
+    elif weight_init == "standard_normal":
+        w_gate_up = jax.random.normal(k_w, w_shape, dtype=dtype)
+    else:
+        raise ValueError(f"unknown weight_init={weight_init!r}")
     return x_by_rank, expert_ids, router_weights, w_gate_up
 
 
@@ -294,6 +304,28 @@ def _print_error_debug(
     )
 
 
+def _print_error_summary(label: str, actual: jax.Array, expected: jax.Array) -> None:
+    actual_f32 = actual.astype(jnp.float32)
+    expected_f32 = expected.astype(jnp.float32)
+    abs_err = jnp.abs(actual_f32 - expected_f32)
+    denom = jnp.maximum(jnp.abs(expected_f32), 1.0)
+    rel_err = abs_err / denom
+    max_abs = jnp.max(abs_err)
+    max_mask = abs_err == max_abs
+    expected_abs_at_max = jnp.max(jnp.where(max_mask, jnp.abs(expected_f32), 0.0))
+    actual_abs_at_max = jnp.max(jnp.where(max_mask, jnp.abs(actual_f32), 0.0))
+    print(
+        f"{label}_error_summary: "
+        f"max_abs={float(max_abs):.6g} "
+        f"mean_abs={float(jnp.mean(abs_err)):.6g} "
+        f"rms_abs={float(jnp.sqrt(jnp.mean(abs_err * abs_err))):.6g} "
+        f"max_rel={float(jnp.max(rel_err)):.6g} "
+        f"mean_rel={float(jnp.mean(rel_err)):.6g} "
+        f"expected_abs_at_max={float(expected_abs_at_max):.6g} "
+        f"actual_abs_at_max={float(actual_abs_at_max):.6g}"
+    )
+
+
 def _check_error(label: str, value: float, tolerance: float) -> None:
     if value > tolerance:
         raise AssertionError(f"{label}={value:.6g} exceeds tolerance {tolerance:.6g}")
@@ -307,6 +339,18 @@ def main() -> None:
     parser.add_argument("--top-k", type=int, default=4)
     parser.add_argument("--hidden", type=int, default=64)
     parser.add_argument("--intermediate", type=int, default=64)
+    parser.add_argument(
+        "--weight-init",
+        choices=("standard_normal", "grug_truncated"),
+        default="standard_normal",
+        help="Random expert weight distribution for W13/SiLU validation.",
+    )
+    parser.add_argument(
+        "--weight-std",
+        type=float,
+        default=None,
+        help="Override expert weight std. Defaults to 0.5/sqrt(hidden) for grug_truncated.",
+    )
     parser.add_argument("--block-m", type=int, default=64)
     parser.add_argument("--block-n", type=int, default=64)
     parser.add_argument("--block-k", type=int, default=64)
@@ -331,7 +375,8 @@ def main() -> None:
     print(
         "shape: "
         f"EP={args.ep_size} T/rank={args.tokens_per_rank} E/rank={args.experts_per_rank} "
-        f"K={args.top_k} H={args.hidden} I={args.intermediate} dtype={args.dtype}"
+        f"K={args.top_k} H={args.hidden} I={args.intermediate} dtype={args.dtype} "
+        f"weight_init={args.weight_init} weight_std={args.weight_std}"
     )
 
     x_by_rank, expert_ids, router_weights, w_gate_up = _make_inputs(
@@ -342,6 +387,8 @@ def main() -> None:
         hidden=args.hidden,
         intermediate=args.intermediate,
         dtype=dtype,
+        weight_init=args.weight_init,
+        weight_std=args.weight_std,
     )
     recv_capacity = args.ep_size * args.tokens_per_rank * args.top_k
     num_experts = args.ep_size * args.experts_per_rank
@@ -468,6 +515,7 @@ def main() -> None:
         h_err = jnp.max(jnp.abs(pallas_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
         h_err_float = float(h_err)
         print(f"w13_silu_max_abs_error: {h_err_float:.6g}")
+        _print_error_summary("w13_silu", pallas_h, ref_h)
         if args.debug_errors:
             _print_error_debug("w13_silu", pallas_h, ref_h, pallas_layout, w_gate_up)
         _check_error("w13_silu_max_abs_error", h_err_float, args.w13_atol)

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -361,8 +361,8 @@ def main() -> None:
     parser.add_argument("--run-pallas", action="store_true")
     parser.add_argument(
         "--dispatch-copy-mode",
-        choices=("scalar", "row_vector"),
-        default="row_vector",
+        choices=("scalar", "row_vector", "scratch"),
+        default="scratch",
         help="Mosaic GPU dispatch copy implementation.",
     )
     parser.add_argument(

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -19,6 +19,7 @@ from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local,
     compute_moe_up_mosaic_gpu_local,
+    compute_moe_up_mosaic_gpu_ready_local,
 )
 from levanter.kernels.pallas.moe_dispatch_up.reference import (
     MoeDispatchUpLayout,
@@ -360,6 +361,19 @@ def _pallas_w13_silu_args(mesh: Mesh, layout: MoeDispatchUpLayout, w_gate_up: ja
     )
 
 
+def _pallas_ready_w13_silu_args(
+    mesh: Mesh,
+    layout: MoeDispatchUpLayout,
+    ready_count: jax.Array,
+    w_gate_up: jax.Array,
+) -> tuple[jax.Array, ...]:
+    return (
+        _sharded(mesh, layout.recv_x, P("expert", None, None)),
+        ready_count,
+        _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+    )
+
+
 def _pallas_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
     def local_w13(recv_x, rows_per_expert, local_w_gate_up):
         h = compute_moe_up_mosaic_gpu_local(
@@ -379,6 +393,32 @@ def _pallas_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
             local_w13,
             mesh=mesh,
             in_specs=(P("expert", None, None), P("expert", None), P("expert", None, None, None)),
+            out_specs=P("expert", None, None),
+            check_vma=False,
+        )
+    )
+    return fn
+
+
+def _pallas_ready_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
+    def local_w13(recv_x, ready_count, local_w_gate_up):
+        h = compute_moe_up_mosaic_gpu_ready_local(
+            jnp.squeeze(recv_x, axis=0),
+            jnp.squeeze(ready_count, axis=0),
+            jnp.squeeze(local_w_gate_up, axis=0),
+            block_m=args.block_m,
+            block_n=args.block_n,
+            block_k=args.block_k,
+            max_concurrent_steps=args.num_stages,
+            grid_block_n=1,
+        )
+        return h[None, ...]
+
+    fn = jax.jit(
+        shard_map(
+            local_w13,
+            mesh=mesh,
+            in_specs=(P("expert", None, None), P("expert", None, None), P("expert", None, None, None)),
             out_specs=P("expert", None, None),
             check_vma=False,
         )
@@ -506,6 +546,8 @@ def _resolve_recv_capacity(args, *, synthetic_layout: bool) -> tuple[int, float 
 def _run_synthetic_layout_benchmark(args, dtype: jnp.dtype, devices: list[jax.Device]) -> None:
     if len(devices) < args.ep_size:
         raise RuntimeError(f"Need at least {args.ep_size} local devices, found {len(devices)}")
+    if args.w13_impl == "mosaic_gpu_ready":
+        raise ValueError("--w13-impl=mosaic_gpu_ready requires routed source/expert ready-count metadata")
     recv_capacity, recv_capacity_factor = _resolve_recv_capacity(args, synthetic_layout=True)
     mesh = Mesh(np.array(devices[: args.ep_size]), ("expert",), axis_types=(AxisType.Explicit,))
     capacity_desc = (
@@ -690,7 +732,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--w13-impl",
-        choices=("mosaic_gpu", "ragged_dot", "both"),
+        choices=("mosaic_gpu", "mosaic_gpu_ready", "ragged_dot", "both"),
         default="mosaic_gpu",
         help="W13/SiLU implementation to benchmark.",
     )
@@ -810,11 +852,11 @@ def main() -> None:
     mesh = Mesh(np.array(devices[: args.ep_size]), ("expert",), axis_types=(AxisType.Explicit,))
     with jax.set_mesh(mesh):
         pallas_dispatch_steady_ms = None
+        pallas_ready_count = None
         if args.pallas_w13_from_reference_layout:
             pallas_layout = ref_layout
             print("dispatch/mosaic_gpu: skipped; using reference layout for W13/SiLU")
         else:
-            pallas_ready_count = None
             if args.dispatch_copy_mode == "scratch_ready":
                 pallas_dispatch_fn = _pallas_dispatch_ready_fn(mesh, recv_capacity=recv_capacity)
                 pallas_dispatch_args = _pallas_dispatch_ready_args(mesh, prepacked)
@@ -878,13 +920,22 @@ def main() -> None:
 
         if args.w13_impl == "both":
             raise ValueError("--w13-impl=both is only supported with --synthetic-layout")
-        if args.w13_impl == "ragged_dot":
+        if args.w13_impl == "mosaic_gpu_ready":
+            if pallas_ready_count is None:
+                pallas_ready_count = _sharded(
+                    mesh, _expected_ready_count(prepacked, recv_capacity), P("expert", None, None)
+                )
+            pallas_w13_fn = _pallas_ready_w13_silu_fn(mesh, args)
+            pallas_w13_args = _pallas_ready_w13_silu_args(mesh, pallas_layout, pallas_ready_count, w_gate_up)
+            w13_label = "w13_silu/mosaic_gpu_ready"
+        elif args.w13_impl == "ragged_dot":
             pallas_w13_fn = _ragged_dot_w13_silu_fn(mesh, args)
+            pallas_w13_args = _pallas_w13_silu_args(mesh, pallas_layout, w_gate_up)
             w13_label = "w13_silu/ragged_dot"
         else:
             pallas_w13_fn = _pallas_w13_silu_fn(mesh, args)
+            pallas_w13_args = _pallas_w13_silu_args(mesh, pallas_layout, w_gate_up)
             w13_label = "w13_silu/mosaic_gpu"
-        pallas_w13_args = _pallas_w13_silu_args(mesh, pallas_layout, w_gate_up)
 
         def run_pallas_w13():
             return pallas_w13_fn(*pallas_w13_args)

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -567,6 +567,111 @@ def _pallas_block_ready_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array
     return fn
 
 
+def _pallas_fused_dispatch_block_ready_w13_fn(
+    mesh: Mesh,
+    args,
+    *,
+    recv_capacity: int,
+    ready_block_m: int,
+    rows_per_program: int,
+    copy_mode: str,
+) -> Callable[..., tuple[jax.Array, jax.Array, jax.Array]]:
+    if copy_mode not in ("scratch_ready", "direct_ready"):
+        raise ValueError(f"copy_mode must be 'scratch_ready' or 'direct_ready', got {copy_mode!r}")
+
+    def local_dispatch_up(
+        send_x,
+        send_row,
+        send_local_expert,
+        send_src_token_idx,
+        send_topk_slot,
+        send_router_weight,
+        send_count,
+        rows_per_expert,
+        expert_base,
+        send_expert_base,
+        send_expert_count,
+        recv_source_expert_base,
+        recv_source_expert_count,
+        local_w_gate_up,
+    ):
+        if copy_mode == "scratch_ready":
+            layout, ready_count, ready_block_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local(
+                jnp.squeeze(send_x, axis=0),
+                jnp.squeeze(send_row, axis=0),
+                jnp.squeeze(send_local_expert, axis=0),
+                jnp.squeeze(send_src_token_idx, axis=0),
+                jnp.squeeze(send_topk_slot, axis=0),
+                jnp.squeeze(send_router_weight, axis=0),
+                jnp.squeeze(send_count, axis=0),
+                jnp.squeeze(rows_per_expert, axis=0),
+                jnp.squeeze(expert_base, axis=0),
+                jnp.squeeze(send_expert_base, axis=0),
+                jnp.squeeze(send_expert_count, axis=0),
+                jnp.squeeze(recv_source_expert_base, axis=0),
+                jnp.squeeze(recv_source_expert_count, axis=0),
+                axis_name="expert",
+                recv_capacity=recv_capacity,
+                ready_block_m=ready_block_m,
+                rows_per_program=rows_per_program,
+            )
+        else:
+            layout, ready_count, ready_block_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local(
+                jnp.squeeze(send_x, axis=0),
+                jnp.squeeze(send_row, axis=0),
+                jnp.squeeze(send_local_expert, axis=0),
+                jnp.squeeze(send_src_token_idx, axis=0),
+                jnp.squeeze(send_topk_slot, axis=0),
+                jnp.squeeze(send_router_weight, axis=0),
+                jnp.squeeze(send_count, axis=0),
+                jnp.squeeze(rows_per_expert, axis=0),
+                jnp.squeeze(expert_base, axis=0),
+                jnp.squeeze(recv_source_expert_base, axis=0),
+                jnp.squeeze(recv_source_expert_count, axis=0),
+                axis_name="expert",
+                recv_capacity=recv_capacity,
+                ready_block_m=ready_block_m,
+                rows_per_program=rows_per_program,
+            )
+        h = compute_moe_up_mosaic_gpu_block_ready_local(
+            layout.recv_x,
+            layout.rows_per_expert,
+            ready_block_count,
+            jnp.squeeze(local_w_gate_up, axis=0),
+            block_m=args.block_m,
+            block_n=args.block_n,
+            block_k=args.block_k,
+            max_concurrent_steps=args.num_stages,
+            grid_block_n=1,
+        )
+        return h[None, ...], ready_count[None, ...], ready_block_count[None, ...]
+
+    return jax.jit(
+        shard_map(
+            local_dispatch_up,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None, None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None, None),
+            ),
+            out_specs=(P("expert", None, None), P("expert", None, None), P("expert", None)),
+            check_vma=False,
+        )
+    )
+
+
 def _pallas_ready_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
     def local_w13(recv_x, ready_count, local_w_gate_up):
         h = compute_moe_up_mosaic_gpu_ready_local(
@@ -1314,6 +1419,11 @@ def main() -> None:
         help="Benchmark all-gather/ring-style dispatch followed by ragged_dot W13/SiLU.",
     )
     parser.add_argument(
+        "--run-pallas-fused-dispatch-up",
+        action="store_true",
+        help="Benchmark one jitted ready-dispatch plus block-ready Mosaic GPU W13/SiLU path.",
+    )
+    parser.add_argument(
         "--synthetic-layout",
         action="store_true",
         help="Skip routing/prepack and benchmark W13/SiLU on a synthetic expert-major layout.",
@@ -1509,6 +1619,7 @@ def main() -> None:
         and not args.run_ragged_a2a_breakdown
         and not args.run_padded_a2a_dispatch_up
         and not args.run_ring_gather_dispatch_up
+        and not args.run_pallas_fused_dispatch_up
     ):
         return
     if len(devices) < args.ep_size:
@@ -1804,6 +1915,73 @@ def main() -> None:
                 )
             if ring_gather_steady_ms is not None:
                 print(f"dispatch_up/ring_gather_ragged_dot_end_to_end_ms: {ring_gather_steady_ms:.3f}")
+
+        if args.run_pallas_fused_dispatch_up:
+            if prepacked is None:
+                raise AssertionError("prepacked sends are required for fused Mosaic GPU dispatch-up")
+            if args.dispatch_copy_mode not in ("scratch_ready", "direct_ready"):
+                raise ValueError(
+                    "--run-pallas-fused-dispatch-up requires --dispatch-copy-mode=scratch_ready or direct_ready"
+                )
+            fused_dispatch_up_fn = _pallas_fused_dispatch_block_ready_w13_fn(
+                mesh,
+                args,
+                recv_capacity=recv_capacity,
+                ready_block_m=args.block_m,
+                rows_per_program=args.dispatch_rows_per_program,
+                copy_mode=args.dispatch_copy_mode,
+            )
+            fused_dispatch_up_args = (
+                *_pallas_dispatch_ready_args(mesh, prepacked),
+                _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+            )
+
+            def run_pallas_fused_dispatch_up():
+                return fused_dispatch_up_fn(*fused_dispatch_up_args)
+
+            fused_dispatch_up_result, _ = _time_block(
+                "dispatch_up/mosaic_gpu_fused_block_ready",
+                run_pallas_fused_dispatch_up,
+            )
+            fused_h, fused_ready_count, fused_ready_block_count = fused_dispatch_up_result
+            fused_dispatch_up_steady_ms = None
+            if args.bench_iters > 0:
+                fused_dispatch_up_steady_ms = _measure_steady_state(
+                    "dispatch_up/mosaic_gpu_fused_block_ready",
+                    run_pallas_fused_dispatch_up,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            expected_ready_count = _sharded(
+                mesh, _expected_ready_count(prepacked, recv_capacity), P("expert", None, None)
+            )
+            fused_ready_count_err = int(jnp.max(jnp.abs(fused_ready_count - expected_ready_count)))
+            print(f"dispatch_up_fused_ready_count_max_abs_error: {fused_ready_count_err}")
+            if fused_ready_count_err != 0:
+                raise AssertionError(f"fused dispatch ready-count mismatch: max_abs={fused_ready_count_err}")
+            expected_ready_block_count = _sharded(
+                mesh, _expected_ready_block_count(prepacked, recv_capacity, args.block_m), P("expert", None)
+            )
+            fused_ready_block_count_err = int(jnp.max(jnp.abs(fused_ready_block_count - expected_ready_block_count)))
+            print(f"dispatch_up_fused_ready_block_count_max_abs_error: {fused_ready_block_count_err}")
+            if fused_ready_block_count_err != 0:
+                raise AssertionError(
+                    f"fused dispatch ready-block-count mismatch: max_abs={fused_ready_block_count_err}"
+                )
+            if ref_h is None:
+                print("dispatch_up/mosaic_gpu_fused_block_ready/reference_check: skipped")
+            else:
+                fused_err = jnp.max(jnp.abs(fused_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
+                fused_err_float = float(fused_err)
+                print(f"dispatch_up_mosaic_gpu_fused_block_ready_max_abs_error: {fused_err_float:.6g}")
+                _print_error_summary("dispatch_up_mosaic_gpu_fused_block_ready", fused_h, ref_h)
+                _check_error(
+                    "dispatch_up_mosaic_gpu_fused_block_ready_max_abs_error",
+                    fused_err_float,
+                    args.w13_atol,
+                )
+            if fused_dispatch_up_steady_ms is not None:
+                print(f"dispatch_up/mosaic_gpu_fused_block_ready_end_to_end_ms: {fused_dispatch_up_steady_ms:.3f}")
 
         if not args.run_pallas:
             return

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -19,6 +19,7 @@ from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local,
     compute_moe_up_mosaic_gpu_local,
+    compute_moe_up_mosaic_gpu_block_ready_local,
     compute_moe_up_mosaic_gpu_ready_local,
 )
 from levanter.kernels.pallas.moe_dispatch_up.reference import (
@@ -384,6 +385,20 @@ def _pallas_ready_w13_silu_args(
     )
 
 
+def _pallas_block_ready_w13_silu_args(
+    mesh: Mesh,
+    layout: MoeDispatchUpLayout,
+    ready_block_count: jax.Array,
+    w_gate_up: jax.Array,
+) -> tuple[jax.Array, ...]:
+    return (
+        _sharded(mesh, layout.recv_x, P("expert", None, None)),
+        _sharded(mesh, layout.rows_per_expert, P("expert", None)),
+        ready_block_count,
+        _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+    )
+
+
 def _pallas_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
     def local_w13(recv_x, rows_per_expert, local_w_gate_up):
         h = compute_moe_up_mosaic_gpu_local(
@@ -403,6 +418,33 @@ def _pallas_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
             local_w13,
             mesh=mesh,
             in_specs=(P("expert", None, None), P("expert", None), P("expert", None, None, None)),
+            out_specs=P("expert", None, None),
+            check_vma=False,
+        )
+    )
+    return fn
+
+
+def _pallas_block_ready_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
+    def local_w13(recv_x, rows_per_expert, ready_block_count, local_w_gate_up):
+        h = compute_moe_up_mosaic_gpu_block_ready_local(
+            jnp.squeeze(recv_x, axis=0),
+            jnp.squeeze(rows_per_expert, axis=0),
+            jnp.squeeze(ready_block_count, axis=0),
+            jnp.squeeze(local_w_gate_up, axis=0),
+            block_m=args.block_m,
+            block_n=args.block_n,
+            block_k=args.block_k,
+            max_concurrent_steps=args.num_stages,
+            grid_block_n=1,
+        )
+        return h[None, ...]
+
+    fn = jax.jit(
+        shard_map(
+            local_w13,
+            mesh=mesh,
+            in_specs=(P("expert", None, None), P("expert", None), P("expert", None), P("expert", None, None, None)),
             out_specs=P("expert", None, None),
             check_vma=False,
         )
@@ -556,8 +598,8 @@ def _resolve_recv_capacity(args, *, synthetic_layout: bool) -> tuple[int, float 
 def _run_synthetic_layout_benchmark(args, dtype: jnp.dtype, devices: list[jax.Device]) -> None:
     if len(devices) < args.ep_size:
         raise RuntimeError(f"Need at least {args.ep_size} local devices, found {len(devices)}")
-    if args.w13_impl == "mosaic_gpu_ready":
-        raise ValueError("--w13-impl=mosaic_gpu_ready requires routed source/expert ready-count metadata")
+    if args.w13_impl in ("mosaic_gpu_block_ready", "mosaic_gpu_ready"):
+        raise ValueError(f"--w13-impl={args.w13_impl} requires routed dispatch readiness metadata")
     recv_capacity, recv_capacity_factor = _resolve_recv_capacity(args, synthetic_layout=True)
     mesh = Mesh(np.array(devices[: args.ep_size]), ("expert",), axis_types=(AxisType.Explicit,))
     capacity_desc = (
@@ -738,11 +780,14 @@ def main() -> None:
         "--recv-capacity-factor",
         type=float,
         default=None,
-        help="Capacity multiplier for T*K routed rows per destination rank; defaults to 1.25 routed, 1.0 synthetic.",
+        help=(
+            "Capacity multiplier for T*K routed rows per destination rank; defaults to 1.25 routed, "
+            "1.0 synthetic. Use 1.0 for no buffer and 1.1-1.25 for typical imbalance probes."
+        ),
     )
     parser.add_argument(
         "--w13-impl",
-        choices=("mosaic_gpu", "mosaic_gpu_ready", "ragged_dot", "both"),
+        choices=("mosaic_gpu", "mosaic_gpu_block_ready", "mosaic_gpu_ready", "ragged_dot", "both"),
         default="mosaic_gpu",
         help="W13/SiLU implementation to benchmark.",
     )
@@ -942,7 +987,19 @@ def main() -> None:
 
         if args.w13_impl == "both":
             raise ValueError("--w13-impl=both is only supported with --synthetic-layout")
-        if args.w13_impl == "mosaic_gpu_ready":
+        if args.w13_impl == "mosaic_gpu_block_ready":
+            if pallas_ready_block_count is None:
+                pallas_ready_block_count = _sharded(
+                    mesh,
+                    _expected_ready_block_count(prepacked, recv_capacity, args.block_m),
+                    P("expert", None),
+                )
+            pallas_w13_fn = _pallas_block_ready_w13_silu_fn(mesh, args)
+            pallas_w13_args = _pallas_block_ready_w13_silu_args(
+                mesh, pallas_layout, pallas_ready_block_count, w_gate_up
+            )
+            w13_label = "w13_silu/mosaic_gpu_block_ready"
+        elif args.w13_impl == "mosaic_gpu_ready":
             if pallas_ready_count is None:
                 pallas_ready_count = _sharded(
                     mesh, _expected_ready_count(prepacked, recv_capacity), P("expert", None, None)

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -167,6 +167,7 @@ def _pallas_dispatch_fn(
     mesh: Mesh,
     *,
     recv_capacity: int,
+    copy_mode: str,
 ) -> Callable[..., MoeDispatchUpLayout]:
     def local_dispatch(
         send_x,
@@ -191,6 +192,7 @@ def _pallas_dispatch_fn(
             jnp.squeeze(expert_base, axis=0),
             axis_name="expert",
             recv_capacity=recv_capacity,
+            copy_mode=copy_mode,
         )
         return MoeDispatchUpLayout(
             layout.recv_x[None, ...],
@@ -358,6 +360,12 @@ def main() -> None:
     parser.add_argument("--dtype", choices=("bf16", "fp32"), default="bf16")
     parser.add_argument("--run-pallas", action="store_true")
     parser.add_argument(
+        "--dispatch-copy-mode",
+        choices=("scalar", "row_vector"),
+        default="row_vector",
+        help="Mosaic GPU dispatch copy implementation.",
+    )
+    parser.add_argument(
         "--pallas-w13-from-reference-layout",
         action="store_true",
         help="Run Mosaic GPU W13/SiLU against the reference dispatch layout, skipping Mosaic dispatch.",
@@ -453,7 +461,9 @@ def main() -> None:
             pallas_layout = ref_layout
             print("dispatch/mosaic_gpu: skipped; using reference layout for W13/SiLU")
         else:
-            pallas_dispatch_fn = _pallas_dispatch_fn(mesh, recv_capacity=recv_capacity)
+            pallas_dispatch_fn = _pallas_dispatch_fn(
+                mesh, recv_capacity=recv_capacity, copy_mode=args.dispatch_copy_mode
+            )
             pallas_dispatch_args = _pallas_dispatch_args(mesh, prepacked)
 
             def run_pallas_dispatch():

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -16,6 +16,7 @@ from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
 
 from haliax.nn.ragged_dot import ragged_dot
 from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
+    dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local,
     compute_moe_up_mosaic_gpu_local,
@@ -356,6 +357,108 @@ def _pallas_dispatch_ready_fn(
                 P("expert", None),
                 P("expert", None, None),
                 P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=out_specs,
+            check_vma=False,
+        )
+    )
+    return fn
+
+
+def _pallas_dispatch_direct_ready_args(mesh: Mesh, prepacked) -> tuple[jax.Array, ...]:
+    return (
+        *_pallas_dispatch_args(mesh, prepacked),
+        _sharded(mesh, prepacked.recv_source_expert_base, P("expert", None, None)),
+        _sharded(mesh, prepacked.recv_source_expert_count, P("expert", None, None)),
+    )
+
+
+def _pallas_dispatch_direct_ready_fn(
+    mesh: Mesh,
+    *,
+    recv_capacity: int,
+    ready_block_m: int,
+    rows_per_program: int,
+) -> Callable[..., tuple[MoeDispatchUpLayout, jax.Array, jax.Array]]:
+    def local_dispatch(
+        send_x,
+        send_row,
+        send_local_expert,
+        send_src_token_idx,
+        send_topk_slot,
+        send_router_weight,
+        send_count,
+        rows_per_expert,
+        expert_base,
+        recv_source_expert_base,
+        recv_source_expert_count,
+    ):
+        layout, ready_count, ready_block_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local(
+            jnp.squeeze(send_x, axis=0),
+            jnp.squeeze(send_row, axis=0),
+            jnp.squeeze(send_local_expert, axis=0),
+            jnp.squeeze(send_src_token_idx, axis=0),
+            jnp.squeeze(send_topk_slot, axis=0),
+            jnp.squeeze(send_router_weight, axis=0),
+            jnp.squeeze(send_count, axis=0),
+            jnp.squeeze(rows_per_expert, axis=0),
+            jnp.squeeze(expert_base, axis=0),
+            jnp.squeeze(recv_source_expert_base, axis=0),
+            jnp.squeeze(recv_source_expert_count, axis=0),
+            axis_name="expert",
+            recv_capacity=recv_capacity,
+            ready_block_m=ready_block_m,
+            rows_per_program=rows_per_program,
+        )
+        return (
+            MoeDispatchUpLayout(
+                layout.recv_x[None, ...],
+                layout.recv_valid[None, ...],
+                layout.rows_per_expert[None, ...],
+                layout.expert_base[None, ...],
+                layout.recv_local_expert[None, ...],
+                layout.recv_src_rank[None, ...],
+                layout.recv_src_token_idx[None, ...],
+                layout.recv_topk_slot[None, ...],
+                layout.recv_router_weight[None, ...],
+                layout.overflow_count[None],
+            ),
+            ready_count[None, ...],
+            ready_block_count[None, ...],
+        )
+
+    out_specs = (
+        MoeDispatchUpLayout(
+            P("expert", None, None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert"),
+        ),
+        P("expert", None, None),
+        P("expert", None),
+    )
+    fn = jax.jit(
+        shard_map(
+            local_dispatch,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None, None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None),
                 P("expert", None, None),
                 P("expert", None, None),
             ),
@@ -835,7 +938,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--dispatch-copy-mode",
-        choices=("scalar", "row_vector", "scratch", "scratch_ready"),
+        choices=("scalar", "row_vector", "scratch", "scratch_ready", "direct_ready"),
         default="scratch",
         help="Mosaic GPU dispatch copy implementation.",
     )
@@ -980,6 +1083,14 @@ def main() -> None:
                     rows_per_program=args.dispatch_rows_per_program,
                 )
                 pallas_dispatch_args = _pallas_dispatch_ready_args(mesh, prepacked)
+            elif args.dispatch_copy_mode == "direct_ready":
+                pallas_dispatch_fn = _pallas_dispatch_direct_ready_fn(
+                    mesh,
+                    recv_capacity=recv_capacity,
+                    ready_block_m=args.block_m,
+                    rows_per_program=args.dispatch_rows_per_program,
+                )
+                pallas_dispatch_args = _pallas_dispatch_direct_ready_args(mesh, prepacked)
             else:
                 pallas_dispatch_fn = _pallas_dispatch_fn(
                     mesh, recv_capacity=recv_capacity, copy_mode=args.dispatch_copy_mode
@@ -990,7 +1101,7 @@ def main() -> None:
                 return pallas_dispatch_fn(*pallas_dispatch_args)
 
             pallas_dispatch_result, _ = _time_block("dispatch/mosaic_gpu", run_pallas_dispatch)
-            if args.dispatch_copy_mode == "scratch_ready":
+            if args.dispatch_copy_mode in ("direct_ready", "scratch_ready"):
                 pallas_layout, pallas_ready_count, pallas_ready_block_count = pallas_dispatch_result
             else:
                 pallas_layout = pallas_dispatch_result

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -1,0 +1,322 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Validate the experimental MoE dispatch-up Mosaic GPU subkernel."""
+
+import argparse
+import time
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import shard_map
+from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
+    dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local,
+    compute_moe_up_mosaic_gpu_local,
+)
+from levanter.kernels.pallas.moe_dispatch_up.reference import (
+    MoeDispatchUpLayout,
+    dispatch_prepacked_moe_dispatch_up_reference,
+    compute_moe_up_from_layout_reference,
+    prepack_moe_dispatch_up_reference,
+)
+
+
+def _time_block(label: str, fn: Callable[[], jax.Array | MoeDispatchUpLayout]) -> tuple[object, float]:
+    start = time.perf_counter()
+    result = fn()
+    jax.block_until_ready(result)
+    elapsed = time.perf_counter() - start
+    print(f"{label}: {elapsed * 1e3:.3f} ms")
+    return result, elapsed
+
+
+def _make_inputs(
+    *,
+    ep_size: int,
+    tokens_per_rank: int,
+    experts_per_rank: int,
+    top_k: int,
+    hidden: int,
+    intermediate: int,
+    dtype: jnp.dtype,
+) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    num_experts = ep_size * experts_per_rank
+    k_x, k_w = jax.random.split(jax.random.key(6597))
+    x_by_rank = jax.random.normal(k_x, (ep_size, tokens_per_rank, hidden), dtype=dtype)
+    rank_ids = jnp.arange(ep_size, dtype=jnp.int32)[:, None, None]
+    token_ids = jnp.arange(tokens_per_rank, dtype=jnp.int32)[None, :, None]
+    slot_ids = jnp.arange(top_k, dtype=jnp.int32)[None, None, :]
+    expert_ids = (rank_ids * experts_per_rank + token_ids + slot_ids) % num_experts
+    router_weights = jax.nn.softmax(
+        jnp.arange(ep_size * tokens_per_rank * top_k, dtype=jnp.float32).reshape(ep_size, tokens_per_rank, top_k),
+        axis=-1,
+    ).astype(dtype)
+    w_gate_up = jax.random.normal(k_w, (ep_size, experts_per_rank, hidden, 2 * intermediate), dtype=dtype)
+    return x_by_rank, expert_ids, router_weights, w_gate_up
+
+
+def _pallas_dispatch(
+    mesh: Mesh,
+    prepacked,
+    *,
+    recv_capacity: int,
+) -> MoeDispatchUpLayout:
+    def sharded(value: jax.Array, spec: P) -> jax.Array:
+        return jax.device_put(value, NamedSharding(mesh, spec))
+
+    def local_dispatch(
+        send_x,
+        send_row,
+        send_local_expert,
+        send_src_token_idx,
+        send_topk_slot,
+        send_router_weight,
+        send_count,
+        rows_per_expert,
+        expert_base,
+    ):
+        layout = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local(
+            jnp.squeeze(send_x, axis=0),
+            jnp.squeeze(send_row, axis=0),
+            jnp.squeeze(send_local_expert, axis=0),
+            jnp.squeeze(send_src_token_idx, axis=0),
+            jnp.squeeze(send_topk_slot, axis=0),
+            jnp.squeeze(send_router_weight, axis=0),
+            jnp.squeeze(send_count, axis=0),
+            jnp.squeeze(rows_per_expert, axis=0),
+            jnp.squeeze(expert_base, axis=0),
+            axis_name="expert",
+            recv_capacity=recv_capacity,
+        )
+        return MoeDispatchUpLayout(
+            layout.recv_x[None, ...],
+            layout.recv_valid[None, ...],
+            layout.rows_per_expert[None, ...],
+            layout.expert_base[None, ...],
+            layout.recv_local_expert[None, ...],
+            layout.recv_src_rank[None, ...],
+            layout.recv_src_token_idx[None, ...],
+            layout.recv_topk_slot[None, ...],
+            layout.recv_router_weight[None, ...],
+            layout.overflow_count[None],
+        )
+
+    out_specs = MoeDispatchUpLayout(
+        P("expert", None, None),
+        P("expert", None),
+        P("expert", None),
+        P("expert", None),
+        P("expert", None),
+        P("expert", None),
+        P("expert", None),
+        P("expert", None),
+        P("expert", None),
+        P("expert"),
+    )
+    fn = jax.jit(
+        shard_map(
+            local_dispatch,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None, None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None),
+            ),
+            out_specs=out_specs,
+            check_vma=False,
+        )
+    )
+    return fn(
+        sharded(prepacked.send_x_by_dst, P("expert", None, None, None)),
+        sharded(prepacked.send_row_by_dst, P("expert", None, None)),
+        sharded(prepacked.send_local_expert_by_dst, P("expert", None, None)),
+        sharded(prepacked.send_src_token_idx_by_dst, P("expert", None, None)),
+        sharded(prepacked.send_topk_slot_by_dst, P("expert", None, None)),
+        sharded(prepacked.send_router_weight_by_dst, P("expert", None, None)),
+        sharded(prepacked.send_count_by_dst, P("expert", None)),
+        sharded(prepacked.rows_per_expert, P("expert", None)),
+        sharded(prepacked.expert_base, P("expert", None)),
+    )
+
+
+def _pallas_w13_silu(mesh: Mesh, layout: MoeDispatchUpLayout, w_gate_up: jax.Array, args) -> jax.Array:
+    def sharded(value: jax.Array, spec: P) -> jax.Array:
+        return jax.device_put(value, NamedSharding(mesh, spec))
+
+    def local_w13(recv_x, rows_per_expert, local_w_gate_up):
+        h = compute_moe_up_mosaic_gpu_local(
+            jnp.squeeze(recv_x, axis=0),
+            jnp.squeeze(rows_per_expert, axis=0),
+            jnp.squeeze(local_w_gate_up, axis=0),
+            block_m=args.block_m,
+            block_n=args.block_n,
+            block_k=args.block_k,
+            max_concurrent_steps=args.num_stages,
+            grid_block_n=1,
+        )
+        return h[None, ...]
+
+    fn = jax.jit(
+        shard_map(
+            local_w13,
+            mesh=mesh,
+            in_specs=(P("expert", None, None), P("expert", None), P("expert", None, None, None)),
+            out_specs=P("expert", None, None),
+            check_vma=False,
+        )
+    )
+    return fn(
+        sharded(layout.recv_x, P("expert", None, None)),
+        sharded(layout.rows_per_expert, P("expert", None)),
+        sharded(w_gate_up, P("expert", None, None, None)),
+    )
+
+
+def _print_error_debug(
+    label: str,
+    actual: jax.Array,
+    expected: jax.Array,
+    layout: MoeDispatchUpLayout,
+    w_gate_up: jax.Array,
+) -> None:
+    actual_host = np.asarray(jax.device_get(actual)).astype(np.float32)
+    expected_host = np.asarray(jax.device_get(expected)).astype(np.float32)
+    err = np.abs(actual_host - expected_host)
+    flat_idx = int(np.argmax(err))
+    idx = np.unravel_index(flat_idx, err.shape)
+    rank, row, col = idx
+    layout_host = jax.tree.map(lambda x: np.asarray(jax.device_get(x)), layout)
+    weights_host = np.asarray(jax.device_get(w_gate_up)).astype(np.float32)
+    local_expert = int(layout_host.recv_local_expert[rank, row])
+    intermediate = weights_host.shape[-1] // 2
+    x = layout_host.recv_x[rank, row].astype(np.float32)
+    gate = float(x @ weights_host[rank, local_expert, :, col])
+    up = float(x @ weights_host[rank, local_expert, :, intermediate + col])
+    print(
+        f"{label}_max_error_at: {idx} "
+        f"actual={float(actual_host[idx]):.6g} "
+        f"expected={float(expected_host[idx]):.6g} "
+        f"valid={bool(layout_host.recv_valid[rank, row])} "
+        f"local_expert={local_expert} "
+        f"rows_per_expert={layout_host.rows_per_expert[rank].tolist()} "
+        f"gate={gate:.6g} up={up:.6g}"
+    )
+
+
+def _check_error(label: str, value: float, tolerance: float) -> None:
+    if value > tolerance:
+        raise AssertionError(f"{label}={value:.6g} exceeds tolerance {tolerance:.6g}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ep-size", type=int, default=8)
+    parser.add_argument("--tokens-per-rank", type=int, default=16)
+    parser.add_argument("--experts-per-rank", type=int, default=4)
+    parser.add_argument("--top-k", type=int, default=4)
+    parser.add_argument("--hidden", type=int, default=64)
+    parser.add_argument("--intermediate", type=int, default=64)
+    parser.add_argument("--block-m", type=int, default=64)
+    parser.add_argument("--block-n", type=int, default=64)
+    parser.add_argument("--block-k", type=int, default=64)
+    parser.add_argument("--num-stages", type=int, default=2)
+    parser.add_argument("--dtype", choices=("bf16", "fp32"), default="bf16")
+    parser.add_argument("--run-pallas", action="store_true")
+    parser.add_argument("--debug-errors", action="store_true")
+    parser.add_argument("--dispatch-atol", type=float, default=0.0)
+    parser.add_argument("--w13-atol", type=float, default=2.0)
+    args = parser.parse_args()
+
+    dtype = jnp.bfloat16 if args.dtype == "bf16" else jnp.float32
+    devices = jax.local_devices()
+    print(f"devices: {len(devices)} {[device.platform for device in devices]}")
+    print(
+        "shape: "
+        f"EP={args.ep_size} T/rank={args.tokens_per_rank} E/rank={args.experts_per_rank} "
+        f"K={args.top_k} H={args.hidden} I={args.intermediate} dtype={args.dtype}"
+    )
+
+    x_by_rank, expert_ids, router_weights, w_gate_up = _make_inputs(
+        ep_size=args.ep_size,
+        tokens_per_rank=args.tokens_per_rank,
+        experts_per_rank=args.experts_per_rank,
+        top_k=args.top_k,
+        hidden=args.hidden,
+        intermediate=args.intermediate,
+        dtype=dtype,
+    )
+    recv_capacity = args.ep_size * args.tokens_per_rank * args.top_k
+    num_experts = args.ep_size * args.experts_per_rank
+
+    prepacked, _ = _time_block(
+        "prepack/reference",
+        lambda: prepack_moe_dispatch_up_reference(
+            x_by_rank,
+            expert_ids,
+            router_weights,
+            num_experts=num_experts,
+            recv_capacity=recv_capacity,
+            send_capacity=args.tokens_per_rank * args.top_k,
+        ),
+    )
+    ref_layout, _ = _time_block(
+        "dispatch/reference",
+        lambda: dispatch_prepacked_moe_dispatch_up_reference(prepacked, recv_capacity=recv_capacity),
+    )
+    ref_h, _ = _time_block("w13_silu/reference", lambda: compute_moe_up_from_layout_reference(ref_layout, w_gate_up))
+
+    if not args.run_pallas:
+        return
+    if len(devices) < args.ep_size:
+        raise RuntimeError(f"Need at least {args.ep_size} local devices, found {len(devices)}")
+
+    mesh = Mesh(np.array(devices[: args.ep_size]), ("expert",), axis_types=(AxisType.Explicit,))
+    with jax.set_mesh(mesh):
+        pallas_layout, _ = _time_block(
+            "dispatch/mosaic_gpu", lambda: _pallas_dispatch(mesh, prepacked, recv_capacity=recv_capacity)
+        )
+        dispatch_err = jnp.max(
+            jnp.abs(pallas_layout.recv_x.astype(jnp.float32) - ref_layout.recv_x.astype(jnp.float32))
+        )
+        dispatch_err_float = float(dispatch_err)
+        print(f"dispatch_max_abs_error: {dispatch_err_float:.6g}")
+        valid_err = jnp.sum(pallas_layout.recv_valid != ref_layout.recv_valid, dtype=jnp.int32)
+        expert_err = jnp.sum(pallas_layout.recv_local_expert != ref_layout.recv_local_expert, dtype=jnp.int32)
+        src_rank_err = jnp.sum(pallas_layout.recv_src_rank != ref_layout.recv_src_rank, dtype=jnp.int32)
+        valid_err_int = int(valid_err)
+        expert_err_int = int(expert_err)
+        src_rank_err_int = int(src_rank_err)
+        print(
+            "dispatch_metadata_errors: "
+            f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
+        )
+        _check_error("dispatch_max_abs_error", dispatch_err_float, args.dispatch_atol)
+        if valid_err_int != 0 or expert_err_int != 0 or src_rank_err_int != 0:
+            raise AssertionError(
+                "dispatch metadata mismatch: "
+                f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
+            )
+
+        pallas_h, _ = _time_block(
+            "w13_silu/mosaic_gpu", lambda: _pallas_w13_silu(mesh, pallas_layout, w_gate_up, args)
+        )
+        h_err = jnp.max(jnp.abs(pallas_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
+        h_err_float = float(h_err)
+        print(f"w13_silu_max_abs_error: {h_err_float:.6g}")
+        if args.debug_errors:
+            _print_error_debug("w13_silu", pallas_h, ref_h, pallas_layout, w_gate_up)
+        _check_error("w13_silu_max_abs_error", h_err_float, args.w13_atol)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -271,6 +271,7 @@ def _pallas_dispatch_ready_fn(
     *,
     recv_capacity: int,
     ready_block_m: int,
+    rows_per_program: int,
 ) -> Callable[..., tuple[MoeDispatchUpLayout, jax.Array, jax.Array]]:
     def local_dispatch(
         send_x,
@@ -304,6 +305,7 @@ def _pallas_dispatch_ready_fn(
             axis_name="expert",
             recv_capacity=recv_capacity,
             ready_block_m=ready_block_m,
+            rows_per_program=rows_per_program,
         )
         return (
             MoeDispatchUpLayout(
@@ -595,6 +597,20 @@ def _resolve_recv_capacity(args, *, synthetic_layout: bool) -> tuple[int, float 
     return math.ceil(default_capacity_factor * routed_rows_per_rank), default_capacity_factor
 
 
+def _resolve_send_capacity(args) -> tuple[int, float | None]:
+    if args.send_capacity is not None and args.send_capacity_factor is not None:
+        raise ValueError("Specify at most one of --send-capacity and --send-capacity-factor")
+
+    if args.send_capacity is not None:
+        return args.send_capacity, None
+
+    if args.send_capacity_factor is not None:
+        balanced_rows_per_destination = args.tokens_per_rank * args.top_k / args.ep_size
+        return math.ceil(args.send_capacity_factor * balanced_rows_per_destination), args.send_capacity_factor
+
+    return args.tokens_per_rank * args.top_k, None
+
+
 def _run_synthetic_layout_benchmark(args, dtype: jnp.dtype, devices: list[jax.Device]) -> None:
     if len(devices) < args.ep_size:
         raise RuntimeError(f"Need at least {args.ep_size} local devices, found {len(devices)}")
@@ -786,6 +802,21 @@ def main() -> None:
         ),
     )
     parser.add_argument(
+        "--send-capacity",
+        type=int,
+        default=None,
+        help="Rows per source/destination pair. Overrides --send-capacity-factor.",
+    )
+    parser.add_argument(
+        "--send-capacity-factor",
+        type=float,
+        default=None,
+        help=(
+            "Capacity multiplier for balanced T*K/EP rows per source/destination pair. "
+            "Defaults to T*K for conservative skew tolerance."
+        ),
+    )
+    parser.add_argument(
         "--w13-impl",
         choices=("mosaic_gpu", "mosaic_gpu_block_ready", "mosaic_gpu_ready", "ragged_dot", "both"),
         default="mosaic_gpu",
@@ -809,9 +840,20 @@ def main() -> None:
         help="Mosaic GPU dispatch copy implementation.",
     )
     parser.add_argument(
+        "--dispatch-rows-per-program",
+        type=int,
+        default=1,
+        help="Send rows handled by each scratch_ready dispatch program.",
+    )
+    parser.add_argument(
         "--pallas-w13-from-reference-layout",
         action="store_true",
         help="Run Mosaic GPU W13/SiLU against the reference dispatch layout, skipping Mosaic dispatch.",
+    )
+    parser.add_argument(
+        "--skip-reference-checks",
+        action="store_true",
+        help="Skip reference dispatch/W13 construction and correctness checks for large candidate-only perf runs.",
     )
     parser.add_argument("--debug-errors", action="store_true")
     parser.add_argument("--dispatch-atol", type=float, default=0.0)
@@ -832,6 +874,8 @@ def main() -> None:
     if args.synthetic_layout:
         _run_synthetic_layout_benchmark(args, dtype, devices)
         return
+    if args.skip_reference_checks and args.pallas_w13_from_reference_layout:
+        raise ValueError("--skip-reference-checks cannot be used with --pallas-w13-from-reference-layout")
 
     x_by_rank, expert_ids, router_weights, w_gate_up = _make_inputs(
         ep_size=args.ep_size,
@@ -849,6 +893,11 @@ def main() -> None:
         print(f"recv_capacity: {recv_capacity} from factor={recv_capacity_factor:g}")
     else:
         print(f"recv_capacity: {recv_capacity}")
+    send_capacity, send_capacity_factor = _resolve_send_capacity(args)
+    if send_capacity_factor is not None:
+        print(f"send_capacity: {send_capacity} from factor={send_capacity_factor:g}")
+    else:
+        print(f"send_capacity: {send_capacity}")
     num_experts = args.ep_size * args.experts_per_rank
 
     prepacked, _ = _time_block(
@@ -859,45 +908,53 @@ def main() -> None:
             router_weights,
             num_experts=num_experts,
             recv_capacity=recv_capacity,
-            send_capacity=args.tokens_per_rank * args.top_k,
+            send_capacity=send_capacity,
         ),
     )
-    ref_layout, _ = _time_block(
-        "dispatch/reference",
-        lambda: dispatch_prepacked_moe_dispatch_up_reference(prepacked, recv_capacity=recv_capacity),
-    )
-    ref_h, _ = _time_block("w13_silu/reference", lambda: compute_moe_up_from_layout_reference(ref_layout, w_gate_up))
     ref_dispatch_steady_ms = None
     ref_w13_steady_ms = None
-    if args.bench_iters > 0:
-        ref_dispatch_fn = jax.jit(
-            lambda prepacked_arg: dispatch_prepacked_moe_dispatch_up_reference(
-                prepacked_arg,
-                recv_capacity=recv_capacity,
+    ref_layout = None
+    ref_h = None
+    if args.skip_reference_checks:
+        print("reference_checks: skipped")
+    else:
+        ref_layout, _ = _time_block(
+            "dispatch/reference",
+            lambda: dispatch_prepacked_moe_dispatch_up_reference(prepacked, recv_capacity=recv_capacity),
+        )
+        ref_h, _ = _time_block(
+            "w13_silu/reference",
+            lambda: compute_moe_up_from_layout_reference(ref_layout, w_gate_up),
+        )
+        if args.bench_iters > 0:
+            ref_dispatch_fn = jax.jit(
+                lambda prepacked_arg: dispatch_prepacked_moe_dispatch_up_reference(
+                    prepacked_arg,
+                    recv_capacity=recv_capacity,
+                )
             )
-        )
-        ref_w13_fn = jax.jit(compute_moe_up_from_layout_reference)
+            ref_w13_fn = jax.jit(compute_moe_up_from_layout_reference)
 
-        def run_ref_dispatch():
-            return ref_dispatch_fn(prepacked)
+            def run_ref_dispatch():
+                return ref_dispatch_fn(prepacked)
 
-        def run_ref_w13():
-            return ref_w13_fn(ref_layout, w_gate_up)
+            def run_ref_w13():
+                return ref_w13_fn(ref_layout, w_gate_up)
 
-        _time_block("dispatch/reference_jit", run_ref_dispatch)
-        ref_dispatch_steady_ms = _measure_steady_state(
-            "dispatch/reference_jit",
-            run_ref_dispatch,
-            warmup_steps=args.warmup_steps,
-            bench_iters=args.bench_iters,
-        )
-        _time_block("w13_silu/reference_jit", run_ref_w13)
-        ref_w13_steady_ms = _measure_steady_state(
-            "w13_silu/reference_jit",
-            run_ref_w13,
-            warmup_steps=args.warmup_steps,
-            bench_iters=args.bench_iters,
-        )
+            _time_block("dispatch/reference_jit", run_ref_dispatch)
+            ref_dispatch_steady_ms = _measure_steady_state(
+                "dispatch/reference_jit",
+                run_ref_dispatch,
+                warmup_steps=args.warmup_steps,
+                bench_iters=args.bench_iters,
+            )
+            _time_block("w13_silu/reference_jit", run_ref_w13)
+            ref_w13_steady_ms = _measure_steady_state(
+                "w13_silu/reference_jit",
+                run_ref_w13,
+                warmup_steps=args.warmup_steps,
+                bench_iters=args.bench_iters,
+            )
 
     if not args.run_pallas:
         return
@@ -910,12 +967,17 @@ def main() -> None:
         pallas_ready_count = None
         pallas_ready_block_count = None
         if args.pallas_w13_from_reference_layout:
+            if ref_layout is None:
+                raise AssertionError("reference layout is required for --pallas-w13-from-reference-layout")
             pallas_layout = ref_layout
             print("dispatch/mosaic_gpu: skipped; using reference layout for W13/SiLU")
         else:
             if args.dispatch_copy_mode == "scratch_ready":
                 pallas_dispatch_fn = _pallas_dispatch_ready_fn(
-                    mesh, recv_capacity=recv_capacity, ready_block_m=args.block_m
+                    mesh,
+                    recv_capacity=recv_capacity,
+                    ready_block_m=args.block_m,
+                    rows_per_program=args.dispatch_rows_per_program,
                 )
                 pallas_dispatch_args = _pallas_dispatch_ready_args(mesh, prepacked)
             else:
@@ -945,21 +1007,24 @@ def main() -> None:
                         ref_dispatch_steady_ms,
                         pallas_dispatch_steady_ms,
                     )
-            dispatch_err = jnp.max(
-                jnp.abs(pallas_layout.recv_x.astype(jnp.float32) - ref_layout.recv_x.astype(jnp.float32))
-            )
-            dispatch_err_float = float(dispatch_err)
-            print(f"dispatch_max_abs_error: {dispatch_err_float:.6g}")
-            valid_err = jnp.sum(pallas_layout.recv_valid != ref_layout.recv_valid, dtype=jnp.int32)
-            expert_err = jnp.sum(pallas_layout.recv_local_expert != ref_layout.recv_local_expert, dtype=jnp.int32)
-            src_rank_err = jnp.sum(pallas_layout.recv_src_rank != ref_layout.recv_src_rank, dtype=jnp.int32)
-            valid_err_int = int(valid_err)
-            expert_err_int = int(expert_err)
-            src_rank_err_int = int(src_rank_err)
-            print(
-                "dispatch_metadata_errors: "
-                f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
-            )
+            if ref_layout is None:
+                print("dispatch/reference_check: skipped")
+            else:
+                dispatch_err = jnp.max(
+                    jnp.abs(pallas_layout.recv_x.astype(jnp.float32) - ref_layout.recv_x.astype(jnp.float32))
+                )
+                dispatch_err_float = float(dispatch_err)
+                print(f"dispatch_max_abs_error: {dispatch_err_float:.6g}")
+                valid_err = jnp.sum(pallas_layout.recv_valid != ref_layout.recv_valid, dtype=jnp.int32)
+                expert_err = jnp.sum(pallas_layout.recv_local_expert != ref_layout.recv_local_expert, dtype=jnp.int32)
+                src_rank_err = jnp.sum(pallas_layout.recv_src_rank != ref_layout.recv_src_rank, dtype=jnp.int32)
+                valid_err_int = int(valid_err)
+                expert_err_int = int(expert_err)
+                src_rank_err_int = int(src_rank_err)
+                print(
+                    "dispatch_metadata_errors: "
+                    f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
+                )
             if pallas_ready_count is not None:
                 expected_ready_count = _sharded(
                     mesh, _expected_ready_count(prepacked, recv_capacity), P("expert", None, None)
@@ -978,12 +1043,13 @@ def main() -> None:
                 print(f"dispatch_ready_block_count_max_abs_error: {ready_block_count_err_int}")
                 if ready_block_count_err_int != 0:
                     raise AssertionError(f"dispatch ready-block-count mismatch: max_abs={ready_block_count_err_int}")
-            _check_error("dispatch_max_abs_error", dispatch_err_float, args.dispatch_atol)
-            if valid_err_int != 0 or expert_err_int != 0 or src_rank_err_int != 0:
-                raise AssertionError(
-                    "dispatch metadata mismatch: "
-                    f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
-                )
+            if ref_layout is not None:
+                _check_error("dispatch_max_abs_error", dispatch_err_float, args.dispatch_atol)
+                if valid_err_int != 0 or expert_err_int != 0 or src_rank_err_int != 0:
+                    raise AssertionError(
+                        "dispatch metadata mismatch: "
+                        f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
+                    )
 
         if args.w13_impl == "both":
             raise ValueError("--w13-impl=both is only supported with --synthetic-layout")
@@ -1030,13 +1096,16 @@ def main() -> None:
             )
             if ref_w13_steady_ms is not None:
                 _print_speedup(f"{w13_label}_vs_reference_jit", ref_w13_steady_ms, pallas_w13_steady_ms)
-        h_err = jnp.max(jnp.abs(pallas_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
-        h_err_float = float(h_err)
-        print(f"w13_silu_max_abs_error: {h_err_float:.6g}")
-        _print_error_summary("w13_silu", pallas_h, ref_h)
-        if args.debug_errors:
-            _print_error_debug("w13_silu", pallas_h, ref_h, pallas_layout, w_gate_up)
-        _check_error("w13_silu_max_abs_error", h_err_float, args.w13_atol)
+        if ref_h is None:
+            print("w13_silu/reference_check: skipped")
+        else:
+            h_err = jnp.max(jnp.abs(pallas_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
+            h_err_float = float(h_err)
+            print(f"w13_silu_max_abs_error: {h_err_float:.6g}")
+            _print_error_summary("w13_silu", pallas_h, ref_h)
+            if args.debug_errors:
+                _print_error_debug("w13_silu", pallas_h, ref_h, pallas_layout, w_gate_up)
+            _check_error("w13_silu_max_abs_error", h_err_float, args.w13_atol)
         if pallas_w13_steady_ms is not None:
             _print_roofline(
                 ep_size=args.ep_size,

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -30,6 +30,7 @@ from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local,
+    dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_tiled_local,
     compute_moe_up_mosaic_gpu_local,
     compute_moe_up_mosaic_gpu_block_ready_local,
     compute_moe_up_mosaic_gpu_ready_local,
@@ -527,7 +528,7 @@ def _pallas_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
             block_n=args.block_n,
             block_k=args.block_k,
             max_concurrent_steps=args.num_stages,
-            grid_block_n=1,
+            grid_block_n=args.grid_block_n,
         )
         return h[None, ...]
 
@@ -554,7 +555,7 @@ def _pallas_block_ready_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array
             block_n=args.block_n,
             block_k=args.block_k,
             max_concurrent_steps=args.num_stages,
-            grid_block_n=1,
+            grid_block_n=args.grid_block_n,
         )
         return h[None, ...]
 
@@ -645,7 +646,7 @@ def _pallas_fused_dispatch_block_ready_w13_fn(
             block_n=args.block_n,
             block_k=args.block_k,
             max_concurrent_steps=args.num_stages,
-            grid_block_n=1,
+            grid_block_n=args.grid_block_n,
         )
         return h[None, ...], ready_count[None, ...], ready_block_count[None, ...]
 
@@ -699,6 +700,9 @@ def _pallas_compact_source_expert_dispatch_up_fn(
     recv_capacity: int,
     ready_block_m: int,
     rows_per_program: int,
+    zero_recv: bool,
+    copy_cols: int | None,
+    copy_rows: int,
 ) -> Callable[..., tuple[jax.Array, jax.Array, jax.Array]]:
     def local_dispatch_up(
         send_x_by_dst_expert,
@@ -726,13 +730,26 @@ def _pallas_compact_source_expert_dispatch_up_fn(
             jnp.squeeze(recv_source_expert_count, axis=0),
             jnp.array(0, dtype=jnp.int32),
         )
-        layout, ready_count, ready_block_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
-            compact_prepacked,
-            axis_name="expert",
-            recv_capacity=recv_capacity,
-            ready_block_m=ready_block_m,
-            rows_per_program=rows_per_program,
-        )
+        if copy_cols is None:
+            layout, ready_count, ready_block_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
+                compact_prepacked,
+                axis_name="expert",
+                recv_capacity=recv_capacity,
+                ready_block_m=ready_block_m,
+                rows_per_program=rows_per_program,
+                zero_recv=zero_recv,
+            )
+        else:
+            layout, ready_count, ready_block_count = (
+                dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_tiled_local(
+                    compact_prepacked,
+                    axis_name="expert",
+                    recv_capacity=recv_capacity,
+                    ready_block_m=ready_block_m,
+                    copy_cols=copy_cols,
+                    copy_rows=copy_rows,
+                )
+            )
         h = compute_moe_up_mosaic_gpu_block_ready_local(
             layout.recv_x,
             layout.rows_per_expert,
@@ -742,7 +759,7 @@ def _pallas_compact_source_expert_dispatch_up_fn(
             block_n=args.block_n,
             block_k=args.block_k,
             max_concurrent_steps=args.num_stages,
-            grid_block_n=1,
+            grid_block_n=args.grid_block_n,
         )
         return h[None, ...], ready_count[None, ...], ready_block_count[None, ...]
 
@@ -775,6 +792,9 @@ def _pallas_compact_source_expert_dispatch_fn(
     recv_capacity: int,
     ready_block_m: int,
     rows_per_program: int,
+    zero_recv: bool,
+    copy_cols: int | None,
+    copy_rows: int,
 ) -> Callable[..., tuple[jax.Array, ...]]:
     def local_dispatch(
         send_x_by_dst_expert,
@@ -801,13 +821,26 @@ def _pallas_compact_source_expert_dispatch_fn(
             jnp.squeeze(recv_source_expert_count, axis=0),
             jnp.array(0, dtype=jnp.int32),
         )
-        layout, ready_count, ready_block_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
-            compact_prepacked,
-            axis_name="expert",
-            recv_capacity=recv_capacity,
-            ready_block_m=ready_block_m,
-            rows_per_program=rows_per_program,
-        )
+        if copy_cols is None:
+            layout, ready_count, ready_block_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
+                compact_prepacked,
+                axis_name="expert",
+                recv_capacity=recv_capacity,
+                ready_block_m=ready_block_m,
+                rows_per_program=rows_per_program,
+                zero_recv=zero_recv,
+            )
+        else:
+            layout, ready_count, ready_block_count = (
+                dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_tiled_local(
+                    compact_prepacked,
+                    axis_name="expert",
+                    recv_capacity=recv_capacity,
+                    ready_block_m=ready_block_m,
+                    copy_cols=copy_cols,
+                    copy_rows=copy_rows,
+                )
+            )
         return (
             layout.recv_x[None, ...],
             layout.recv_valid[None, ...],
@@ -862,7 +895,7 @@ def _pallas_ready_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
             block_n=args.block_n,
             block_k=args.block_k,
             max_concurrent_steps=args.num_stages,
-            grid_block_n=1,
+            grid_block_n=args.grid_block_n,
         )
         return h[None, ...]
 
@@ -1588,9 +1621,15 @@ def main() -> None:
         help="Override expert weight std. Defaults to 0.5/sqrt(hidden) for grug_truncated.",
     )
     parser.add_argument("--block-m", type=int, default=64)
-    parser.add_argument("--block-n", type=int, default=64)
+    parser.add_argument("--block-n", type=int, default=128)
     parser.add_argument("--block-k", type=int, default=64)
-    parser.add_argument("--num-stages", type=int, default=2)
+    parser.add_argument("--num-stages", type=int, default=4)
+    parser.add_argument(
+        "--grid-block-n",
+        type=int,
+        default=1,
+        help="N-axis snake-grid tile width for Mosaic W13/SiLU kernels.",
+    )
     parser.add_argument("--dtype", choices=("bf16", "fp32"), default="bf16")
     parser.add_argument("--run-pallas", action="store_true")
     parser.add_argument(
@@ -1703,6 +1742,23 @@ def main() -> None:
         type=int,
         default=1,
         help="Send rows handled by each scratch_ready dispatch program.",
+    )
+    parser.add_argument(
+        "--compact-dispatch-skip-zero-recv",
+        action="store_true",
+        help="For compact source/expert dispatch, skip receive-buffer zeroing and validate only written rows.",
+    )
+    parser.add_argument(
+        "--compact-dispatch-copy-cols",
+        type=int,
+        default=None,
+        help="Use the tiled compact source/expert dispatch path with this hidden-column tile size.",
+    )
+    parser.add_argument(
+        "--compact-dispatch-copy-rows",
+        type=int,
+        default=1,
+        help="Rows per compact source/expert payload tile when --compact-dispatch-copy-cols is set.",
     )
     parser.add_argument(
         "--pallas-w13-from-reference-layout",
@@ -2163,6 +2219,9 @@ def main() -> None:
                 recv_capacity=recv_capacity,
                 ready_block_m=args.block_m,
                 rows_per_program=args.dispatch_rows_per_program,
+                zero_recv=not args.compact_dispatch_skip_zero_recv,
+                copy_cols=args.compact_dispatch_copy_cols,
+                copy_rows=args.compact_dispatch_copy_rows,
             )
             compact_dispatch_args = _compact_source_expert_args(mesh, compact_prepacked)
 
@@ -2218,19 +2277,31 @@ def main() -> None:
             if ref_layout is None:
                 print("dispatch/mosaic_gpu_compact_source_expert/reference_check: skipped")
             else:
+                valid_mask = ref_layout.recv_valid
                 recv_x_err = float(
-                    jnp.max(jnp.abs(compact_recv_x.astype(jnp.float32) - ref_layout.recv_x.astype(jnp.float32)))
+                    jnp.max(
+                        jnp.abs(compact_recv_x.astype(jnp.float32) - ref_layout.recv_x.astype(jnp.float32))
+                        * valid_mask[:, :, None].astype(jnp.float32)
+                    )
                 )
                 print(f"dispatch_mosaic_gpu_compact_source_expert_recv_x_max_abs_error: {recv_x_err:.6g}")
                 _check_error("dispatch_mosaic_gpu_compact_source_expert_recv_x_max_abs_error", recv_x_err, 0.0)
+                valid_err = int(jnp.max(jnp.abs(compact_recv_valid.astype(jnp.int32) - valid_mask.astype(jnp.int32))))
+                print(f"dispatch_mosaic_gpu_compact_source_expert_recv_valid_max_abs_error: {valid_err}")
+                if valid_err != 0:
+                    raise AssertionError(f"compact source/expert recv_valid mismatch: max_abs={valid_err}")
                 for label, actual, expected in (
-                    ("recv_valid", compact_recv_valid, ref_layout.recv_valid),
                     ("recv_local_expert", compact_recv_local_expert, ref_layout.recv_local_expert),
                     ("recv_src_rank", compact_recv_src_rank, ref_layout.recv_src_rank),
                     ("recv_src_token_idx", compact_recv_src_token_idx, ref_layout.recv_src_token_idx),
                     ("recv_topk_slot", compact_recv_topk_slot, ref_layout.recv_topk_slot),
                 ):
-                    err = int(jnp.max(jnp.abs(actual.astype(jnp.int32) - expected.astype(jnp.int32))))
+                    err = int(
+                        jnp.max(
+                            jnp.abs(actual.astype(jnp.int32) - expected.astype(jnp.int32))
+                            * valid_mask.astype(jnp.int32)
+                        )
+                    )
                     print(f"dispatch_mosaic_gpu_compact_source_expert_{label}_max_abs_error: {err}")
                     if err != 0:
                         raise AssertionError(f"compact source/expert {label} mismatch: max_abs={err}")
@@ -2240,6 +2311,7 @@ def main() -> None:
                             compact_recv_router_weight.astype(jnp.float32)
                             - ref_layout.recv_router_weight.astype(jnp.float32)
                         )
+                        * valid_mask.astype(jnp.float32)
                     )
                 )
                 print(
@@ -2281,6 +2353,9 @@ def main() -> None:
                 recv_capacity=recv_capacity,
                 ready_block_m=args.block_m,
                 rows_per_program=args.dispatch_rows_per_program,
+                zero_recv=not args.compact_dispatch_skip_zero_recv,
+                copy_cols=args.compact_dispatch_copy_cols,
+                copy_rows=args.compact_dispatch_copy_rows,
             )
             compact_dispatch_up_args = (
                 *_compact_source_expert_args(mesh, compact_prepacked),

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -40,7 +40,7 @@ def _measure_steady_state(
     *,
     warmup_steps: int,
     bench_iters: int,
-) -> None:
+) -> float:
     for _ in range(warmup_steps):
         jax.block_until_ready(fn())
 
@@ -56,6 +56,53 @@ def _measure_steady_state(
         f"min={float(np.min(times_ms)):.3f} ms "
         f"max={float(np.max(times_ms)):.3f} ms "
         f"iters={bench_iters}"
+    )
+    return float(np.mean(times_ms))
+
+
+def _print_speedup(label: str, baseline_ms: float, candidate_ms: float) -> None:
+    print(
+        f"{label}_speedup: "
+        f"{baseline_ms / candidate_ms:.3f}x baseline={baseline_ms:.3f} ms candidate={candidate_ms:.3f} ms"
+    )
+
+
+def _print_roofline(
+    *,
+    ep_size: int,
+    tokens_per_rank: int,
+    experts_per_rank: int,
+    top_k: int,
+    hidden: int,
+    intermediate: int,
+    dtype_bytes: int,
+    dispatch_ms: float,
+    w13_ms: float,
+) -> None:
+    routed_rows = ep_size * tokens_per_rank * top_k
+    dispatch_payload_bytes = routed_rows * hidden * dtype_bytes
+    w13_flops = 2 * routed_rows * hidden * (2 * intermediate)
+    w13_bytes = (
+        routed_rows * hidden * dtype_bytes
+        + ep_size * experts_per_rank * hidden * (2 * intermediate) * dtype_bytes
+        + routed_rows * intermediate * dtype_bytes
+    )
+    dispatch_payload_gbs = dispatch_payload_bytes / (dispatch_ms / 1e3) / 1e9
+    w13_tflops = w13_flops / (w13_ms / 1e3) / 1e12
+    w13_intensity = w13_flops / w13_bytes
+    w13_hbm_bound_tflops = 3.35e12 * w13_intensity / 1e12
+    h100_bf16_peak_tflops = 989.0
+    w13_roofline_tflops = min(h100_bf16_peak_tflops * ep_size, w13_hbm_bound_tflops * ep_size)
+    print(
+        "roofline: "
+        f"routed_rows={routed_rows} "
+        f"dispatch_payload={dispatch_payload_bytes / 1024:.1f} KiB "
+        f"dispatch_payload_bw={dispatch_payload_gbs:.6f} GB/s "
+        f"w13_flops={w13_flops / 1e6:.3f} MFLOP "
+        f"w13_bytes={w13_bytes / 1024:.1f} KiB "
+        f"w13_intensity={w13_intensity:.3f} flop/byte "
+        f"w13_measured={w13_tflops:.6f} TFLOP/s "
+        f"w13_h100_sxm_roofline_estimate={w13_roofline_tflops:.3f} TFLOP/s"
     )
 
 
@@ -306,6 +353,37 @@ def main() -> None:
         lambda: dispatch_prepacked_moe_dispatch_up_reference(prepacked, recv_capacity=recv_capacity),
     )
     ref_h, _ = _time_block("w13_silu/reference", lambda: compute_moe_up_from_layout_reference(ref_layout, w_gate_up))
+    ref_dispatch_steady_ms = None
+    ref_w13_steady_ms = None
+    if args.bench_iters > 0:
+        ref_dispatch_fn = jax.jit(
+            lambda prepacked_arg: dispatch_prepacked_moe_dispatch_up_reference(
+                prepacked_arg,
+                recv_capacity=recv_capacity,
+            )
+        )
+        ref_w13_fn = jax.jit(compute_moe_up_from_layout_reference)
+
+        def run_ref_dispatch():
+            return ref_dispatch_fn(prepacked)
+
+        def run_ref_w13():
+            return ref_w13_fn(ref_layout, w_gate_up)
+
+        _time_block("dispatch/reference_jit", run_ref_dispatch)
+        ref_dispatch_steady_ms = _measure_steady_state(
+            "dispatch/reference_jit",
+            run_ref_dispatch,
+            warmup_steps=args.warmup_steps,
+            bench_iters=args.bench_iters,
+        )
+        _time_block("w13_silu/reference_jit", run_ref_w13)
+        ref_w13_steady_ms = _measure_steady_state(
+            "w13_silu/reference_jit",
+            run_ref_w13,
+            warmup_steps=args.warmup_steps,
+            bench_iters=args.bench_iters,
+        )
 
     if not args.run_pallas:
         return
@@ -321,13 +399,20 @@ def main() -> None:
             return pallas_dispatch_fn(*pallas_dispatch_args)
 
         pallas_layout, _ = _time_block("dispatch/mosaic_gpu", run_pallas_dispatch)
+        pallas_dispatch_steady_ms = None
         if args.bench_iters > 0:
-            _measure_steady_state(
+            pallas_dispatch_steady_ms = _measure_steady_state(
                 "dispatch/mosaic_gpu",
                 run_pallas_dispatch,
                 warmup_steps=args.warmup_steps,
                 bench_iters=args.bench_iters,
             )
+            if ref_dispatch_steady_ms is not None:
+                _print_speedup(
+                    "dispatch/mosaic_gpu_vs_reference_jit",
+                    ref_dispatch_steady_ms,
+                    pallas_dispatch_steady_ms,
+                )
         dispatch_err = jnp.max(
             jnp.abs(pallas_layout.recv_x.astype(jnp.float32) - ref_layout.recv_x.astype(jnp.float32))
         )
@@ -357,19 +442,34 @@ def main() -> None:
             return pallas_w13_fn(*pallas_w13_args)
 
         pallas_h, _ = _time_block("w13_silu/mosaic_gpu", run_pallas_w13)
+        pallas_w13_steady_ms = None
         if args.bench_iters > 0:
-            _measure_steady_state(
+            pallas_w13_steady_ms = _measure_steady_state(
                 "w13_silu/mosaic_gpu",
                 run_pallas_w13,
                 warmup_steps=args.warmup_steps,
                 bench_iters=args.bench_iters,
             )
+            if ref_w13_steady_ms is not None:
+                _print_speedup("w13_silu/mosaic_gpu_vs_reference_jit", ref_w13_steady_ms, pallas_w13_steady_ms)
         h_err = jnp.max(jnp.abs(pallas_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
         h_err_float = float(h_err)
         print(f"w13_silu_max_abs_error: {h_err_float:.6g}")
         if args.debug_errors:
             _print_error_debug("w13_silu", pallas_h, ref_h, pallas_layout, w_gate_up)
         _check_error("w13_silu_max_abs_error", h_err_float, args.w13_atol)
+        if pallas_dispatch_steady_ms is not None and pallas_w13_steady_ms is not None:
+            _print_roofline(
+                ep_size=args.ep_size,
+                tokens_per_rank=args.tokens_per_rank,
+                experts_per_rank=args.experts_per_rank,
+                top_k=args.top_k,
+                hidden=args.hidden,
+                intermediate=args.intermediate,
+                dtype_bytes=2 if dtype == jnp.bfloat16 else 4,
+                dispatch_ms=pallas_dispatch_steady_ms,
+                w13_ms=pallas_w13_steady_ms,
+            )
 
 
 if __name__ == "__main__":

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -29,14 +29,17 @@ from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local,
+    dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local,
     compute_moe_up_mosaic_gpu_local,
     compute_moe_up_mosaic_gpu_block_ready_local,
     compute_moe_up_mosaic_gpu_ready_local,
 )
 from levanter.kernels.pallas.moe_dispatch_up.reference import (
     MoeDispatchUpLayout,
+    MoeDispatchUpSourceExpertPrepackedSend,
     dispatch_prepacked_moe_dispatch_up_reference,
     compute_moe_up_from_layout_reference,
+    prepack_moe_dispatch_up_source_expert_reference,
     prepack_moe_dispatch_up_reference,
 )
 
@@ -672,6 +675,183 @@ def _pallas_fused_dispatch_block_ready_w13_fn(
     )
 
 
+def _compact_source_expert_args(
+    mesh: Mesh, prepacked: MoeDispatchUpSourceExpertPrepackedSend
+) -> tuple[jax.Array, ...]:
+    return (
+        _sharded(mesh, prepacked.send_x_by_dst_expert, P("expert", None, None, None, None)),
+        _sharded(mesh, prepacked.send_src_token_idx_by_dst_expert, P("expert", None, None, None)),
+        _sharded(mesh, prepacked.send_topk_slot_by_dst_expert, P("expert", None, None, None)),
+        _sharded(mesh, prepacked.send_router_weight_by_dst_expert, P("expert", None, None, None)),
+        _sharded(mesh, prepacked.send_row_base_by_dst_expert, P("expert", None, None)),
+        _sharded(mesh, prepacked.send_count_by_dst_expert, P("expert", None, None)),
+        _sharded(mesh, prepacked.rows_per_expert, P("expert", None)),
+        _sharded(mesh, prepacked.expert_base, P("expert", None)),
+        _sharded(mesh, prepacked.recv_source_expert_base, P("expert", None, None)),
+        _sharded(mesh, prepacked.recv_source_expert_count, P("expert", None, None)),
+    )
+
+
+def _pallas_compact_source_expert_dispatch_up_fn(
+    mesh: Mesh,
+    args,
+    *,
+    recv_capacity: int,
+    ready_block_m: int,
+    rows_per_program: int,
+) -> Callable[..., tuple[jax.Array, jax.Array, jax.Array]]:
+    def local_dispatch_up(
+        send_x_by_dst_expert,
+        send_src_token_idx_by_dst_expert,
+        send_topk_slot_by_dst_expert,
+        send_router_weight_by_dst_expert,
+        send_row_base_by_dst_expert,
+        send_count_by_dst_expert,
+        rows_per_expert,
+        expert_base,
+        recv_source_expert_base,
+        recv_source_expert_count,
+        local_w_gate_up,
+    ):
+        compact_prepacked = MoeDispatchUpSourceExpertPrepackedSend(
+            jnp.squeeze(send_x_by_dst_expert, axis=0),
+            jnp.squeeze(send_src_token_idx_by_dst_expert, axis=0),
+            jnp.squeeze(send_topk_slot_by_dst_expert, axis=0),
+            jnp.squeeze(send_router_weight_by_dst_expert, axis=0),
+            jnp.squeeze(send_row_base_by_dst_expert, axis=0),
+            jnp.squeeze(send_count_by_dst_expert, axis=0),
+            jnp.squeeze(rows_per_expert, axis=0),
+            jnp.squeeze(expert_base, axis=0),
+            jnp.squeeze(recv_source_expert_base, axis=0),
+            jnp.squeeze(recv_source_expert_count, axis=0),
+            jnp.array(0, dtype=jnp.int32),
+        )
+        layout, ready_count, ready_block_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
+            compact_prepacked,
+            axis_name="expert",
+            recv_capacity=recv_capacity,
+            ready_block_m=ready_block_m,
+            rows_per_program=rows_per_program,
+        )
+        h = compute_moe_up_mosaic_gpu_block_ready_local(
+            layout.recv_x,
+            layout.rows_per_expert,
+            ready_block_count,
+            jnp.squeeze(local_w_gate_up, axis=0),
+            block_m=args.block_m,
+            block_n=args.block_n,
+            block_k=args.block_k,
+            max_concurrent_steps=args.num_stages,
+            grid_block_n=1,
+        )
+        return h[None, ...], ready_count[None, ...], ready_block_count[None, ...]
+
+    return jax.jit(
+        shard_map(
+            local_dispatch_up,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None, None, None, None),
+                P("expert", None, None, None),
+                P("expert", None, None, None),
+                P("expert", None, None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None, None),
+            ),
+            out_specs=(P("expert", None, None), P("expert", None, None), P("expert", None)),
+            check_vma=False,
+        )
+    )
+
+
+def _pallas_compact_source_expert_dispatch_fn(
+    mesh: Mesh,
+    *,
+    recv_capacity: int,
+    ready_block_m: int,
+    rows_per_program: int,
+) -> Callable[..., tuple[jax.Array, ...]]:
+    def local_dispatch(
+        send_x_by_dst_expert,
+        send_src_token_idx_by_dst_expert,
+        send_topk_slot_by_dst_expert,
+        send_router_weight_by_dst_expert,
+        send_row_base_by_dst_expert,
+        send_count_by_dst_expert,
+        rows_per_expert,
+        expert_base,
+        recv_source_expert_base,
+        recv_source_expert_count,
+    ):
+        compact_prepacked = MoeDispatchUpSourceExpertPrepackedSend(
+            jnp.squeeze(send_x_by_dst_expert, axis=0),
+            jnp.squeeze(send_src_token_idx_by_dst_expert, axis=0),
+            jnp.squeeze(send_topk_slot_by_dst_expert, axis=0),
+            jnp.squeeze(send_router_weight_by_dst_expert, axis=0),
+            jnp.squeeze(send_row_base_by_dst_expert, axis=0),
+            jnp.squeeze(send_count_by_dst_expert, axis=0),
+            jnp.squeeze(rows_per_expert, axis=0),
+            jnp.squeeze(expert_base, axis=0),
+            jnp.squeeze(recv_source_expert_base, axis=0),
+            jnp.squeeze(recv_source_expert_count, axis=0),
+            jnp.array(0, dtype=jnp.int32),
+        )
+        layout, ready_count, ready_block_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
+            compact_prepacked,
+            axis_name="expert",
+            recv_capacity=recv_capacity,
+            ready_block_m=ready_block_m,
+            rows_per_program=rows_per_program,
+        )
+        return (
+            layout.recv_x[None, ...],
+            layout.recv_valid[None, ...],
+            layout.recv_local_expert[None, ...],
+            layout.recv_src_rank[None, ...],
+            layout.recv_src_token_idx[None, ...],
+            layout.recv_topk_slot[None, ...],
+            layout.recv_router_weight[None, ...],
+            ready_count[None, ...],
+            ready_block_count[None, ...],
+        )
+
+    return jax.jit(
+        shard_map(
+            local_dispatch,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None, None, None, None),
+                P("expert", None, None, None),
+                P("expert", None, None, None),
+                P("expert", None, None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(
+                P("expert", None, None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None, None),
+                P("expert", None),
+            ),
+            check_vma=False,
+        )
+    )
+
+
 def _pallas_ready_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
     def local_w13(recv_x, ready_count, local_w_gate_up):
         h = compute_moe_up_mosaic_gpu_ready_local(
@@ -1208,6 +1388,41 @@ def _resolve_send_capacity(args) -> tuple[int, float | None]:
     return args.tokens_per_rank * args.top_k, None
 
 
+def _resolve_source_expert_capacity(args) -> tuple[int | None, float | None]:
+    if args.source_expert_capacity is not None and args.source_expert_capacity_factor is not None:
+        raise ValueError("Specify at most one of --source-expert-capacity and --source-expert-capacity-factor")
+    if args.source_expert_capacity is not None:
+        return args.source_expert_capacity, None
+    if args.source_expert_capacity_factor is not None:
+        balanced = args.tokens_per_rank * args.top_k / (args.ep_size * args.experts_per_rank)
+        return max(1, math.ceil(args.source_expert_capacity_factor * balanced)), args.source_expert_capacity_factor
+    return None, None
+
+
+def _print_source_expert_load_stats(prepacked, args, *, send_capacity: int) -> None:
+    counts = np.asarray(jax.device_get(prepacked.send_expert_count_by_dst))
+    balanced = args.tokens_per_rank * args.top_k / (args.ep_size * args.experts_per_rank)
+    print(
+        "source_expert_loads: "
+        f"balanced={balanced:.3f} "
+        f"mean={float(np.mean(counts)):.3f} "
+        f"max={int(np.max(counts))} "
+        f"p95={float(np.percentile(counts, 95)):.1f} "
+        f"p99={float(np.percentile(counts, 99)):.1f}"
+    )
+    current_slots_per_source = args.ep_size * send_capacity
+    compact_parts = []
+    for factor in (1.25, 1.5, 2.0):
+        capacity = max(1, math.ceil(factor * balanced))
+        overflow = int(np.maximum(counts - capacity, 0).sum())
+        slots_per_source = args.ep_size * args.experts_per_rank * capacity
+        compact_parts.append(f"{factor:g}x:cap={capacity},overflow={overflow},slots/source={slots_per_source}")
+    print(
+        "source_expert_compact_capacity: "
+        f"current_slots/source={current_slots_per_source} " + " ".join(compact_parts)
+    )
+
+
 def _run_synthetic_layout_benchmark(args, dtype: jnp.dtype, devices: list[jax.Device]) -> None:
     if len(devices) < args.ep_size:
         raise RuntimeError(f"Need at least {args.ep_size} local devices, found {len(devices)}")
@@ -1404,6 +1619,16 @@ def main() -> None:
         help="Benchmark one jitted ready-dispatch plus block-ready Mosaic GPU W13/SiLU path.",
     )
     parser.add_argument(
+        "--run-compact-source-expert-dispatch",
+        action="store_true",
+        help="Benchmark compact source/expert Mosaic dispatch without W13/SiLU.",
+    )
+    parser.add_argument(
+        "--run-compact-source-expert-dispatch-up",
+        action="store_true",
+        help="Benchmark compact source/expert Mosaic dispatch followed by block-ready W13/SiLU.",
+    )
+    parser.add_argument(
         "--synthetic-layout",
         action="store_true",
         help="Skip routing/prepack and benchmark W13/SiLU on a synthetic expert-major layout.",
@@ -1437,6 +1662,18 @@ def main() -> None:
             "Capacity multiplier for balanced T*K/EP rows per source/destination pair. "
             "Defaults to T*K for conservative skew tolerance."
         ),
+    )
+    parser.add_argument(
+        "--source-expert-capacity",
+        type=int,
+        default=None,
+        help="Rows per source/destination/local-expert compact send group. Overrides factor.",
+    )
+    parser.add_argument(
+        "--source-expert-capacity-factor",
+        type=float,
+        default=None,
+        help="Compact send capacity multiplier for balanced T*K/(EP*experts_per_rank) source/expert rows.",
     )
     parser.add_argument(
         "--w13-impl",
@@ -1546,6 +1783,7 @@ def main() -> None:
                 send_capacity=send_capacity,
             ),
         )
+        _print_source_expert_load_stats(prepacked, args, send_capacity=send_capacity)
     ref_dispatch_steady_ms = None
     ref_w13_steady_ms = None
     ref_layout = None
@@ -1600,6 +1838,8 @@ def main() -> None:
         and not args.run_padded_a2a_dispatch_up
         and not args.run_ring_gather_dispatch_up
         and not args.run_pallas_fused_dispatch_up
+        and not args.run_compact_source_expert_dispatch
+        and not args.run_compact_source_expert_dispatch_up
     ):
         return
     if len(devices) < args.ep_size:
@@ -1896,6 +2136,215 @@ def main() -> None:
                 )
             if ring_gather_steady_ms is not None:
                 print(f"dispatch_up/ring_gather_ragged_dot_end_to_end_ms: {ring_gather_steady_ms:.3f}")
+
+        if args.run_compact_source_expert_dispatch:
+            source_expert_capacity, source_expert_capacity_factor = _resolve_source_expert_capacity(args)
+            compact_prepacked, _ = _time_block(
+                "prepack/source_expert_reference",
+                lambda: prepack_moe_dispatch_up_source_expert_reference(
+                    x_by_rank,
+                    expert_ids,
+                    router_weights,
+                    num_experts=num_experts,
+                    recv_capacity=recv_capacity,
+                    source_expert_capacity=source_expert_capacity,
+                ),
+            )
+            inferred_source_expert_capacity = compact_prepacked.send_x_by_dst_expert.shape[3]
+            if source_expert_capacity_factor is None:
+                print(f"source_expert_capacity: {inferred_source_expert_capacity}")
+            else:
+                print(
+                    "source_expert_capacity: "
+                    f"{inferred_source_expert_capacity} from factor={source_expert_capacity_factor:g}"
+                )
+            compact_dispatch_fn = _pallas_compact_source_expert_dispatch_fn(
+                mesh,
+                recv_capacity=recv_capacity,
+                ready_block_m=args.block_m,
+                rows_per_program=args.dispatch_rows_per_program,
+            )
+            compact_dispatch_args = _compact_source_expert_args(mesh, compact_prepacked)
+
+            def run_compact_source_expert_dispatch():
+                return compact_dispatch_fn(*compact_dispatch_args)
+
+            compact_dispatch_result, _ = _time_block(
+                "dispatch/mosaic_gpu_compact_source_expert",
+                run_compact_source_expert_dispatch,
+            )
+            (
+                compact_recv_x,
+                compact_recv_valid,
+                compact_recv_local_expert,
+                compact_recv_src_rank,
+                compact_recv_src_token_idx,
+                compact_recv_topk_slot,
+                compact_recv_router_weight,
+                compact_ready_count,
+                compact_ready_block_count,
+            ) = compact_dispatch_result
+            compact_dispatch_steady_ms = None
+            if args.bench_iters > 0:
+                compact_dispatch_steady_ms = _measure_steady_state(
+                    "dispatch/mosaic_gpu_compact_source_expert",
+                    run_compact_source_expert_dispatch,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            if prepacked is not None:
+                expected_ready_count = _sharded(
+                    mesh, _expected_ready_count(prepacked, recv_capacity), P("expert", None, None)
+                )
+                compact_ready_count_err = int(jnp.max(jnp.abs(compact_ready_count - expected_ready_count)))
+                print(f"dispatch_compact_source_expert_ready_count_max_abs_error: {compact_ready_count_err}")
+                if compact_ready_count_err != 0:
+                    raise AssertionError(
+                        f"compact source/expert ready-count mismatch: max_abs={compact_ready_count_err}"
+                    )
+                expected_ready_block_count = _sharded(
+                    mesh, _expected_ready_block_count(prepacked, recv_capacity, args.block_m), P("expert", None)
+                )
+                compact_ready_block_count_err = int(
+                    jnp.max(jnp.abs(compact_ready_block_count - expected_ready_block_count))
+                )
+                print(
+                    f"dispatch_compact_source_expert_ready_block_count_max_abs_error: {compact_ready_block_count_err}"
+                )
+                if compact_ready_block_count_err != 0:
+                    raise AssertionError(
+                        "compact source/expert ready-block-count mismatch: " f"max_abs={compact_ready_block_count_err}"
+                    )
+            if ref_layout is None:
+                print("dispatch/mosaic_gpu_compact_source_expert/reference_check: skipped")
+            else:
+                recv_x_err = float(
+                    jnp.max(jnp.abs(compact_recv_x.astype(jnp.float32) - ref_layout.recv_x.astype(jnp.float32)))
+                )
+                print(f"dispatch_mosaic_gpu_compact_source_expert_recv_x_max_abs_error: {recv_x_err:.6g}")
+                _check_error("dispatch_mosaic_gpu_compact_source_expert_recv_x_max_abs_error", recv_x_err, 0.0)
+                for label, actual, expected in (
+                    ("recv_valid", compact_recv_valid, ref_layout.recv_valid),
+                    ("recv_local_expert", compact_recv_local_expert, ref_layout.recv_local_expert),
+                    ("recv_src_rank", compact_recv_src_rank, ref_layout.recv_src_rank),
+                    ("recv_src_token_idx", compact_recv_src_token_idx, ref_layout.recv_src_token_idx),
+                    ("recv_topk_slot", compact_recv_topk_slot, ref_layout.recv_topk_slot),
+                ):
+                    err = int(jnp.max(jnp.abs(actual.astype(jnp.int32) - expected.astype(jnp.int32))))
+                    print(f"dispatch_mosaic_gpu_compact_source_expert_{label}_max_abs_error: {err}")
+                    if err != 0:
+                        raise AssertionError(f"compact source/expert {label} mismatch: max_abs={err}")
+                router_weight_err = float(
+                    jnp.max(
+                        jnp.abs(
+                            compact_recv_router_weight.astype(jnp.float32)
+                            - ref_layout.recv_router_weight.astype(jnp.float32)
+                        )
+                    )
+                )
+                print(
+                    "dispatch_mosaic_gpu_compact_source_expert_recv_router_weight_max_abs_error: "
+                    f"{router_weight_err:.6g}"
+                )
+                _check_error(
+                    "dispatch_mosaic_gpu_compact_source_expert_recv_router_weight_max_abs_error",
+                    router_weight_err,
+                    0.0,
+                )
+            if compact_dispatch_steady_ms is not None:
+                print(f"dispatch/mosaic_gpu_compact_source_expert_end_to_end_ms: {compact_dispatch_steady_ms:.3f}")
+
+        if args.run_compact_source_expert_dispatch_up:
+            source_expert_capacity, source_expert_capacity_factor = _resolve_source_expert_capacity(args)
+            compact_prepacked, _ = _time_block(
+                "prepack/source_expert_reference",
+                lambda: prepack_moe_dispatch_up_source_expert_reference(
+                    x_by_rank,
+                    expert_ids,
+                    router_weights,
+                    num_experts=num_experts,
+                    recv_capacity=recv_capacity,
+                    source_expert_capacity=source_expert_capacity,
+                ),
+            )
+            inferred_source_expert_capacity = compact_prepacked.send_x_by_dst_expert.shape[3]
+            if source_expert_capacity_factor is None:
+                print(f"source_expert_capacity: {inferred_source_expert_capacity}")
+            else:
+                print(
+                    "source_expert_capacity: "
+                    f"{inferred_source_expert_capacity} from factor={source_expert_capacity_factor:g}"
+                )
+            compact_dispatch_up_fn = _pallas_compact_source_expert_dispatch_up_fn(
+                mesh,
+                args,
+                recv_capacity=recv_capacity,
+                ready_block_m=args.block_m,
+                rows_per_program=args.dispatch_rows_per_program,
+            )
+            compact_dispatch_up_args = (
+                *_compact_source_expert_args(mesh, compact_prepacked),
+                _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+            )
+
+            def run_compact_source_expert_dispatch_up():
+                return compact_dispatch_up_fn(*compact_dispatch_up_args)
+
+            compact_result, _ = _time_block(
+                "dispatch_up/mosaic_gpu_compact_source_expert_block_ready",
+                run_compact_source_expert_dispatch_up,
+            )
+            compact_h, compact_ready_count, compact_ready_block_count = compact_result
+            compact_steady_ms = None
+            if args.bench_iters > 0:
+                compact_steady_ms = _measure_steady_state(
+                    "dispatch_up/mosaic_gpu_compact_source_expert_block_ready",
+                    run_compact_source_expert_dispatch_up,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            if prepacked is not None:
+                expected_ready_count = _sharded(
+                    mesh, _expected_ready_count(prepacked, recv_capacity), P("expert", None, None)
+                )
+                compact_ready_count_err = int(jnp.max(jnp.abs(compact_ready_count - expected_ready_count)))
+                print(f"dispatch_up_compact_source_expert_ready_count_max_abs_error: {compact_ready_count_err}")
+                if compact_ready_count_err != 0:
+                    raise AssertionError(
+                        f"compact source/expert ready-count mismatch: max_abs={compact_ready_count_err}"
+                    )
+                expected_ready_block_count = _sharded(
+                    mesh, _expected_ready_block_count(prepacked, recv_capacity, args.block_m), P("expert", None)
+                )
+                compact_ready_block_count_err = int(
+                    jnp.max(jnp.abs(compact_ready_block_count - expected_ready_block_count))
+                )
+                print(
+                    "dispatch_up_compact_source_expert_ready_block_count_max_abs_error: "
+                    f"{compact_ready_block_count_err}"
+                )
+                if compact_ready_block_count_err != 0:
+                    raise AssertionError(
+                        "compact source/expert ready-block-count mismatch: " f"max_abs={compact_ready_block_count_err}"
+                    )
+            if ref_h is None:
+                print("dispatch_up/mosaic_gpu_compact_source_expert_block_ready/reference_check: skipped")
+            else:
+                compact_err = jnp.max(jnp.abs(compact_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
+                compact_err_float = float(compact_err)
+                print(
+                    f"dispatch_up_mosaic_gpu_compact_source_expert_block_ready_max_abs_error: {compact_err_float:.6g}"
+                )
+                _print_error_summary("dispatch_up_mosaic_gpu_compact_source_expert_block_ready", compact_h, ref_h)
+                _check_error(
+                    "dispatch_up_mosaic_gpu_compact_source_expert_block_ready_max_abs_error",
+                    compact_err_float,
+                    args.w13_atol,
+                )
+            if compact_steady_ms is not None:
+                print(
+                    f"dispatch_up/mosaic_gpu_compact_source_expert_block_ready_end_to_end_ms: {compact_steady_ms:.3f}"
+                )
 
         if args.run_pallas_fused_dispatch_up:
             if prepacked is None:

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -701,6 +701,203 @@ def _ragged_a2a_dispatch_up_fn(
     )
 
 
+def _ragged_a2a_dispatch_only_fn(
+    mesh: Mesh,
+    *,
+    recv_capacity: int,
+    num_experts: int,
+) -> Callable[..., tuple[jax.Array, jax.Array, jax.Array]]:
+    def local_dispatch(x_local, selected_experts_local):
+        x_local = jnp.squeeze(x_local, axis=0)
+        selected_experts_local = jnp.squeeze(selected_experts_local, axis=0)
+        shard_id = lax.axis_index("expert")
+        local_experts = num_experts // lax.axis_size("expert")
+        topk = selected_experts_local.shape[1]
+        assignments_per_shard = x_local.shape[0] * topk
+
+        sorted_x, _, group_sizes = _permute_by_global_expert(
+            x_local,
+            selected_experts_local,
+            num_experts=num_experts,
+        )
+        all_group_sizes = lax.all_gather(group_sizes.astype(jnp.int32), "expert")
+        clipped_group_sizes = _clip_receiver_group_sizes(
+            all_group_sizes,
+            local_expert_size=local_experts,
+            receiver_capacity=recv_capacity,
+        )
+        sender_group_sizes = clipped_group_sizes[shard_id]
+        keep_mask = _expert_prefix_keep_mask(
+            group_sizes.astype(jnp.int32),
+            sender_group_sizes,
+            total_size=assignments_per_shard,
+        )
+        compacted_x = _compact_by_keep_mask(sorted_x, keep_mask)
+
+        ep_size = num_experts // local_experts
+        all_shard_counts = jnp.sum(clipped_group_sizes.reshape(ep_size, ep_size, local_experts), axis=2)
+        input_offsets, send_sizes, output_offsets, recv_sizes = _shard_a2a_params(all_shard_counts, shard_id)
+        dispatched_shape = jnp.zeros((recv_capacity, x_local.shape[1]), dtype=x_local.dtype)
+        x_dispatched = lax.ragged_all_to_all(
+            compacted_x,
+            dispatched_shape,
+            input_offsets,
+            send_sizes,
+            output_offsets,
+            recv_sizes,
+            axis_name="expert",
+        )
+
+        x_dispatch, _, ragged_group_sizes = _local_permute_from_counts(
+            x_dispatched,
+            clipped_group_sizes,
+            local_expert_size=local_experts,
+            shard_index=shard_id,
+        )
+        local_counts_by_sender = lax.dynamic_slice_in_dim(
+            clipped_group_sizes,
+            start_index=shard_id * local_experts,
+            slice_size=local_experts,
+            axis=1,
+        )
+        true_local_group_sizes = jnp.sum(local_counts_by_sender, axis=0, dtype=jnp.int32)
+        return x_dispatch[None, ...], ragged_group_sizes[None, ...], true_local_group_sizes[None, ...]
+
+    return jax.jit(
+        shard_map(
+            local_dispatch,
+            mesh=mesh,
+            in_specs=(P("expert", None, None), P("expert", None, None)),
+            out_specs=(P("expert", None, None), P("expert", None), P("expert", None)),
+            check_vma=False,
+        )
+    )
+
+
+def _ragged_a2a_dispatched_w13_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
+    def local_w13(x_dispatch, ragged_group_sizes, true_group_sizes, local_w_gate_up):
+        x_dispatch = jnp.squeeze(x_dispatch, axis=0)
+        ragged_group_sizes = jnp.squeeze(ragged_group_sizes, axis=0)
+        true_group_sizes = jnp.squeeze(true_group_sizes, axis=0)
+        local_w_gate_up = jnp.squeeze(local_w_gate_up, axis=0)
+
+        w13_out = ragged_dot(
+            x_dispatch,
+            local_w_gate_up,
+            ragged_group_sizes,
+            implementation=args.ragged_dot_impl,
+        )
+        gate, up = jnp.split(w13_out, 2, axis=-1)
+        h = jax.nn.silu(gate.astype(jnp.float32)).astype(gate.dtype) * up
+        valid_rows = jnp.arange(x_dispatch.shape[0], dtype=jnp.int32) < jnp.sum(true_group_sizes, dtype=jnp.int32)
+        return jnp.where(valid_rows[:, None], h, jnp.zeros((), dtype=h.dtype))[None, ...]
+
+    return jax.jit(
+        shard_map(
+            local_w13,
+            mesh=mesh,
+            in_specs=(P("expert", None, None), P("expert", None), P("expert", None), P("expert", None, None, None)),
+            out_specs=P("expert", None, None),
+            check_vma=False,
+        )
+    )
+
+
+def _ragged_a2a_precollective_fn(
+    mesh: Mesh,
+    *,
+    recv_capacity: int,
+    num_experts: int,
+) -> Callable[..., tuple[jax.Array, jax.Array]]:
+    def local_precollective(x_local, selected_experts_local):
+        x_local = jnp.squeeze(x_local, axis=0)
+        selected_experts_local = jnp.squeeze(selected_experts_local, axis=0)
+        shard_id = lax.axis_index("expert")
+        local_experts = num_experts // lax.axis_size("expert")
+        topk = selected_experts_local.shape[1]
+        assignments_per_shard = x_local.shape[0] * topk
+
+        sorted_x, _, group_sizes = _permute_by_global_expert(
+            x_local,
+            selected_experts_local,
+            num_experts=num_experts,
+        )
+        all_group_sizes = lax.all_gather(group_sizes.astype(jnp.int32), "expert")
+        clipped_group_sizes = _clip_receiver_group_sizes(
+            all_group_sizes,
+            local_expert_size=local_experts,
+            receiver_capacity=recv_capacity,
+        )
+        sender_group_sizes = clipped_group_sizes[shard_id]
+        keep_mask = _expert_prefix_keep_mask(
+            group_sizes.astype(jnp.int32),
+            sender_group_sizes,
+            total_size=assignments_per_shard,
+        )
+        compacted_x = _compact_by_keep_mask(sorted_x, keep_mask)
+        return compacted_x[None, ...], clipped_group_sizes
+
+    return jax.jit(
+        shard_map(
+            local_precollective,
+            mesh=mesh,
+            in_specs=(P("expert", None, None), P("expert", None, None)),
+            out_specs=(P("expert", None, None), P(None, None)),
+            check_vma=False,
+        )
+    )
+
+
+def _ragged_a2a_transport_from_precollective_fn(
+    mesh: Mesh,
+    *,
+    recv_capacity: int,
+    num_experts: int,
+) -> Callable[..., tuple[jax.Array, jax.Array, jax.Array]]:
+    def local_transport(compacted_x, clipped_group_sizes):
+        compacted_x = jnp.squeeze(compacted_x, axis=0)
+        shard_id = lax.axis_index("expert")
+        local_experts = num_experts // lax.axis_size("expert")
+
+        ep_size = num_experts // local_experts
+        all_shard_counts = jnp.sum(clipped_group_sizes.reshape(ep_size, ep_size, local_experts), axis=2)
+        input_offsets, send_sizes, output_offsets, recv_sizes = _shard_a2a_params(all_shard_counts, shard_id)
+        dispatched_shape = jnp.zeros((recv_capacity, compacted_x.shape[1]), dtype=compacted_x.dtype)
+        x_dispatched = lax.ragged_all_to_all(
+            compacted_x,
+            dispatched_shape,
+            input_offsets,
+            send_sizes,
+            output_offsets,
+            recv_sizes,
+            axis_name="expert",
+        )
+        x_dispatch, _, ragged_group_sizes = _local_permute_from_counts(
+            x_dispatched,
+            clipped_group_sizes,
+            local_expert_size=local_experts,
+            shard_index=shard_id,
+        )
+        local_counts_by_sender = lax.dynamic_slice_in_dim(
+            clipped_group_sizes,
+            start_index=shard_id * local_experts,
+            slice_size=local_experts,
+            axis=1,
+        )
+        true_local_group_sizes = jnp.sum(local_counts_by_sender, axis=0, dtype=jnp.int32)
+        return x_dispatch[None, ...], ragged_group_sizes[None, ...], true_local_group_sizes[None, ...]
+
+    return jax.jit(
+        shard_map(
+            local_transport,
+            mesh=mesh,
+            in_specs=(P("expert", None, None), P(None, None)),
+            out_specs=(P("expert", None, None), P("expert", None), P("expert", None)),
+            check_vma=False,
+        )
+    )
+
+
 def _padded_a2a_dispatch_up_fn(
     mesh: Mesh,
     args,
@@ -1030,6 +1227,11 @@ def main() -> None:
         help="Benchmark built-in ragged_all_to_all dispatch followed by ragged_dot W13/SiLU.",
     )
     parser.add_argument(
+        "--run-ragged-a2a-breakdown",
+        action="store_true",
+        help="Benchmark ragged_all_to_all dispatch-only and ragged_dot-on-dispatched-layout as separate steps.",
+    )
+    parser.add_argument(
         "--run-padded-a2a-dispatch-up",
         action="store_true",
         help="Benchmark fixed-bucket all_to_all dispatch followed by ragged_dot W13/SiLU.",
@@ -1156,7 +1358,7 @@ def main() -> None:
     prepacked = None
     if (
         args.skip_reference_checks
-        and (args.run_ragged_a2a_dispatch_up or args.run_padded_a2a_dispatch_up)
+        and (args.run_ragged_a2a_dispatch_up or args.run_ragged_a2a_breakdown or args.run_padded_a2a_dispatch_up)
         and not args.run_pallas
     ):
         print("prepack/reference: skipped")
@@ -1219,7 +1421,12 @@ def main() -> None:
                 bench_iters=args.bench_iters,
             )
 
-    if not args.run_pallas and not args.run_ragged_a2a_dispatch_up and not args.run_padded_a2a_dispatch_up:
+    if (
+        not args.run_pallas
+        and not args.run_ragged_a2a_dispatch_up
+        and not args.run_ragged_a2a_breakdown
+        and not args.run_padded_a2a_dispatch_up
+    ):
         return
     if len(devices) < args.ep_size:
         raise RuntimeError(f"Need at least {args.ep_size} local devices, found {len(devices)}")
@@ -1265,6 +1472,163 @@ def main() -> None:
                 )
             if ragged_a2a_steady_ms is not None:
                 print(f"dispatch_up/ragged_a2a_ragged_dot_end_to_end_ms: {ragged_a2a_steady_ms:.3f}")
+
+        if args.run_ragged_a2a_breakdown:
+            ragged_dispatch_fn = _ragged_a2a_dispatch_only_fn(
+                mesh,
+                recv_capacity=recv_capacity,
+                num_experts=num_experts,
+            )
+            ragged_dispatch_args = (
+                _sharded(mesh, x_by_rank, P("expert", None, None)),
+                _sharded(mesh, expert_ids, P("expert", None, None)),
+            )
+
+            def run_ragged_dispatch():
+                return ragged_dispatch_fn(*ragged_dispatch_args)
+
+            ragged_dispatch_result, _ = _time_block("dispatch/ragged_a2a", run_ragged_dispatch)
+            x_dispatch, ragged_group_sizes, true_group_sizes = ragged_dispatch_result
+            ragged_dispatch_steady_ms = None
+            if args.bench_iters > 0:
+                ragged_dispatch_steady_ms = _measure_steady_state(
+                    "dispatch/ragged_a2a",
+                    run_ragged_dispatch,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+
+            ragged_dispatched_w13_fn = _ragged_a2a_dispatched_w13_fn(mesh, args)
+            ragged_dispatched_w13_args = (
+                x_dispatch,
+                ragged_group_sizes,
+                true_group_sizes,
+                _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+            )
+
+            def run_ragged_dispatched_w13():
+                return ragged_dispatched_w13_fn(*ragged_dispatched_w13_args)
+
+            ragged_breakdown_h, _ = _time_block(
+                "w13_silu/ragged_dot_on_ragged_a2a_layout",
+                run_ragged_dispatched_w13,
+            )
+            ragged_dispatched_w13_steady_ms = None
+            if args.bench_iters > 0:
+                ragged_dispatched_w13_steady_ms = _measure_steady_state(
+                    "w13_silu/ragged_dot_on_ragged_a2a_layout",
+                    run_ragged_dispatched_w13,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            if ref_h is None:
+                print("dispatch/ragged_a2a/reference_check: skipped")
+            else:
+                ragged_breakdown_err = jnp.max(
+                    jnp.abs(ragged_breakdown_h.astype(jnp.float32) - ref_h.astype(jnp.float32))
+                )
+                ragged_breakdown_err_float = float(ragged_breakdown_err)
+                print(f"dispatch_up_ragged_a2a_breakdown_max_abs_error: {ragged_breakdown_err_float:.6g}")
+                _print_error_summary("dispatch_up_ragged_a2a_breakdown", ragged_breakdown_h, ref_h)
+                _check_error(
+                    "dispatch_up_ragged_a2a_breakdown_max_abs_error",
+                    ragged_breakdown_err_float,
+                    args.w13_atol,
+                )
+            if ragged_dispatch_steady_ms is not None and ragged_dispatched_w13_steady_ms is not None:
+                print(
+                    "dispatch_up/ragged_a2a_breakdown_sum_ms: "
+                    f"{ragged_dispatch_steady_ms + ragged_dispatched_w13_steady_ms:.3f}"
+                )
+
+            ragged_precollective_fn = _ragged_a2a_precollective_fn(
+                mesh,
+                recv_capacity=recv_capacity,
+                num_experts=num_experts,
+            )
+
+            def run_ragged_precollective():
+                return ragged_precollective_fn(*ragged_dispatch_args)
+
+            ragged_precollective_result, _ = _time_block(
+                "dispatch/ragged_a2a_precollective",
+                run_ragged_precollective,
+            )
+            compacted_x, clipped_group_sizes = ragged_precollective_result
+            ragged_precollective_steady_ms = None
+            if args.bench_iters > 0:
+                ragged_precollective_steady_ms = _measure_steady_state(
+                    "dispatch/ragged_a2a_precollective",
+                    run_ragged_precollective,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+
+            ragged_transport_fn = _ragged_a2a_transport_from_precollective_fn(
+                mesh,
+                recv_capacity=recv_capacity,
+                num_experts=num_experts,
+            )
+
+            def run_ragged_transport():
+                return ragged_transport_fn(compacted_x, clipped_group_sizes)
+
+            ragged_transport_result, _ = _time_block(
+                "dispatch/ragged_a2a_transport_local_permute",
+                run_ragged_transport,
+            )
+            transport_x_dispatch, transport_ragged_group_sizes, transport_true_group_sizes = ragged_transport_result
+            ragged_transport_steady_ms = None
+            if args.bench_iters > 0:
+                ragged_transport_steady_ms = _measure_steady_state(
+                    "dispatch/ragged_a2a_transport_local_permute",
+                    run_ragged_transport,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+
+            ragged_transport_w13_args = (
+                transport_x_dispatch,
+                transport_ragged_group_sizes,
+                transport_true_group_sizes,
+                _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+            )
+
+            def run_ragged_transport_w13():
+                return ragged_dispatched_w13_fn(*ragged_transport_w13_args)
+
+            ragged_transport_w13_h, _ = _time_block(
+                "w13_silu/ragged_dot_on_transport_layout",
+                run_ragged_transport_w13,
+            )
+            ragged_transport_w13_steady_ms = None
+            if args.bench_iters > 0:
+                ragged_transport_w13_steady_ms = _measure_steady_state(
+                    "w13_silu/ragged_dot_on_transport_layout",
+                    run_ragged_transport_w13,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            if ref_h is not None:
+                transport_breakdown_err = jnp.max(
+                    jnp.abs(ragged_transport_w13_h.astype(jnp.float32) - ref_h.astype(jnp.float32))
+                )
+                transport_breakdown_err_float = float(transport_breakdown_err)
+                print(f"dispatch_up_ragged_a2a_transport_breakdown_max_abs_error: {transport_breakdown_err_float:.6g}")
+                _check_error(
+                    "dispatch_up_ragged_a2a_transport_breakdown_max_abs_error",
+                    transport_breakdown_err_float,
+                    args.w13_atol,
+                )
+            if (
+                ragged_precollective_steady_ms is not None
+                and ragged_transport_steady_ms is not None
+                and ragged_transport_w13_steady_ms is not None
+            ):
+                print(
+                    "dispatch_up/ragged_a2a_deep_breakdown_sum_ms: "
+                    f"{ragged_precollective_steady_ms + ragged_transport_steady_ms + ragged_transport_w13_steady_ms:.3f}"
+                )
 
         if args.run_padded_a2a_dispatch_up:
             padded_capacity_factor = recv_capacity / (args.tokens_per_rank * args.top_k)

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -26,6 +26,7 @@ from levanter.grug._moe.ep_common import (
 from levanter.grug._moe.ep_padded_all_to_all import _dispatch_fixed_buckets
 from levanter.grug._moe.ep_ring import _dispatch_up_ep_ring_local
 from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
+    compact_source_expert_ring_transport_mosaic_gpu_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local,
@@ -926,6 +927,32 @@ def _compact_a2a_transport_fn(mesh: Mesh) -> Callable[..., tuple[jax.Array, jax.
             "expert",
             split_axis=0,
             concat_axis=0,
+        )
+        return source_expert_x[None, ...], source_expert_count[None, ...]
+
+    return jax.jit(
+        shard_map(
+            local_transport,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None, None, None, None),
+                P("expert", None, None),
+            ),
+            out_specs=(
+                P("expert", None, None, None, None),
+                P("expert", None, None),
+            ),
+            check_vma=False,
+        )
+    )
+
+
+def _compact_ring_transport_fn(mesh: Mesh) -> Callable[..., tuple[jax.Array, jax.Array]]:
+    def local_transport(send_x_by_dst_expert, send_count_by_dst_expert):
+        source_expert_x, source_expert_count = compact_source_expert_ring_transport_mosaic_gpu_local(
+            jnp.squeeze(send_x_by_dst_expert, axis=0),
+            jnp.squeeze(send_count_by_dst_expert, axis=0),
+            axis_name="expert",
         )
         return source_expert_x[None, ...], source_expert_count[None, ...]
 
@@ -1944,6 +1971,11 @@ def main() -> None:
         help="Benchmark compact source/expert all-to-all transport and merged Mosaic W13 separately.",
     )
     parser.add_argument(
+        "--run-compact-ring-transport",
+        action="store_true",
+        help="Benchmark ordered ring-step Mosaic transport for compact source/expert payloads.",
+    )
+    parser.add_argument(
         "--compact-a2a-return-compact-output",
         action="store_true",
         help="Return compact source/expert W13 output instead of scattering back to destination-major rows.",
@@ -2114,6 +2146,7 @@ def main() -> None:
             or args.run_ring_gather_mosaic_dispatch_up
             or args.run_compact_a2a_mosaic_dispatch_up
             or args.run_compact_a2a_breakdown
+            or args.run_compact_ring_transport
         )
         and not args.run_pallas
     ):
@@ -2190,6 +2223,7 @@ def main() -> None:
         and not args.run_compact_source_expert_dispatch_up
         and not args.run_compact_a2a_mosaic_dispatch_up
         and not args.run_compact_a2a_breakdown
+        and not args.run_compact_ring_transport
     ):
         return
     if len(devices) < args.ep_size:
@@ -2685,6 +2719,75 @@ def main() -> None:
                     "dispatch_up/compact_a2a_breakdown_sum_ms: "
                     f"{compact_transport_steady_ms + compact_merged_w13_steady_ms:.3f}"
                 )
+
+        if args.run_compact_ring_transport:
+            source_expert_capacity, source_expert_capacity_factor = _resolve_source_expert_capacity(args)
+            compact_prepacked, _ = _time_block(
+                "prepack/source_expert_reference",
+                lambda: prepack_moe_dispatch_up_source_expert_reference(
+                    x_by_rank,
+                    expert_ids,
+                    router_weights,
+                    num_experts=num_experts,
+                    recv_capacity=recv_capacity,
+                    source_expert_capacity=source_expert_capacity,
+                ),
+            )
+            inferred_source_expert_capacity = compact_prepacked.send_x_by_dst_expert.shape[3]
+            if source_expert_capacity_factor is None:
+                print(f"source_expert_capacity: {inferred_source_expert_capacity}")
+            else:
+                print(
+                    "source_expert_capacity: "
+                    f"{inferred_source_expert_capacity} from factor={source_expert_capacity_factor:g}"
+                )
+            print(f"source_expert_overflow_count: {int(jax.device_get(compact_prepacked.overflow_count))}")
+            _print_source_expert_load_stats(compact_prepacked, args, send_capacity=send_capacity)
+            compact_transport_args = (
+                _sharded(mesh, compact_prepacked.send_x_by_dst_expert, P("expert", None, None, None, None)),
+                _sharded(mesh, compact_prepacked.send_count_by_dst_expert, P("expert", None, None)),
+            )
+
+            compact_transport_fn = _compact_a2a_transport_fn(mesh)
+            expected_transport, _ = _time_block(
+                "dispatch/compact_a2a_transport_for_ring_check",
+                lambda: compact_transport_fn(*compact_transport_args),
+            )
+            expected_source_expert_x, expected_source_expert_count = expected_transport
+
+            compact_ring_transport_fn = _compact_ring_transport_fn(mesh)
+
+            def run_compact_ring_transport():
+                return compact_ring_transport_fn(*compact_transport_args)
+
+            ring_transport_result, _ = _time_block(
+                "dispatch/compact_ring_transport",
+                run_compact_ring_transport,
+            )
+            ring_source_expert_x, ring_source_expert_count = ring_transport_result
+            if args.bench_iters > 0:
+                ring_transport_steady_ms = _measure_steady_state(
+                    "dispatch/compact_ring_transport",
+                    run_compact_ring_transport,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            else:
+                ring_transport_steady_ms = None
+
+            ring_x_err = jnp.max(
+                jnp.abs(ring_source_expert_x.astype(jnp.float32) - expected_source_expert_x.astype(jnp.float32))
+            )
+            ring_count_err = jnp.max(jnp.abs(ring_source_expert_count - expected_source_expert_count))
+            ring_x_err_float = float(ring_x_err)
+            ring_count_err_int = int(ring_count_err)
+            print(f"dispatch_compact_ring_transport_x_max_abs_error: {ring_x_err_float:.6g}")
+            print(f"dispatch_compact_ring_transport_count_max_abs_error: {ring_count_err_int}")
+            _check_error("dispatch_compact_ring_transport_x_max_abs_error", ring_x_err_float, 0.0)
+            if ring_count_err_int != 0:
+                raise AssertionError(f"compact ring transport count mismatch: max_abs={ring_count_err_int}")
+            if ring_transport_steady_ms is not None:
+                print(f"dispatch/compact_ring_transport_end_to_end_ms: {ring_transport_steady_ms:.3f}")
 
         if args.run_compact_source_expert_dispatch:
             source_expert_capacity, source_expert_capacity_factor = _resolve_source_expert_capacity(args)

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -76,7 +76,7 @@ def _print_roofline(
     hidden: int,
     intermediate: int,
     dtype_bytes: int,
-    dispatch_ms: float,
+    dispatch_ms: float | None,
     w13_ms: float,
 ) -> None:
     routed_rows = ep_size * tokens_per_rank * top_k
@@ -87,7 +87,11 @@ def _print_roofline(
         + ep_size * experts_per_rank * hidden * (2 * intermediate) * dtype_bytes
         + routed_rows * intermediate * dtype_bytes
     )
-    dispatch_payload_gbs = dispatch_payload_bytes / (dispatch_ms / 1e3) / 1e9
+    dispatch_payload = f"{dispatch_payload_bytes / 1024:.1f} KiB"
+    if dispatch_ms is None:
+        dispatch_payload_bw = "not-run"
+    else:
+        dispatch_payload_bw = f"{dispatch_payload_bytes / (dispatch_ms / 1e3) / 1e9:.6f} GB/s"
     w13_tflops = w13_flops / (w13_ms / 1e3) / 1e12
     w13_intensity = w13_flops / w13_bytes
     w13_hbm_bound_tflops = 3.35e12 * w13_intensity / 1e12
@@ -96,8 +100,8 @@ def _print_roofline(
     print(
         "roofline: "
         f"routed_rows={routed_rows} "
-        f"dispatch_payload={dispatch_payload_bytes / 1024:.1f} KiB "
-        f"dispatch_payload_bw={dispatch_payload_gbs:.6f} GB/s "
+        f"dispatch_payload={dispatch_payload} "
+        f"dispatch_payload_bw={dispatch_payload_bw} "
         f"w13_flops={w13_flops / 1e6:.3f} MFLOP "
         f"w13_bytes={w13_bytes / 1024:.1f} KiB "
         f"w13_intensity={w13_intensity:.3f} flop/byte "
@@ -309,6 +313,11 @@ def main() -> None:
     parser.add_argument("--num-stages", type=int, default=2)
     parser.add_argument("--dtype", choices=("bf16", "fp32"), default="bf16")
     parser.add_argument("--run-pallas", action="store_true")
+    parser.add_argument(
+        "--pallas-w13-from-reference-layout",
+        action="store_true",
+        help="Run Mosaic GPU W13/SiLU against the reference dispatch layout, skipping Mosaic dispatch.",
+    )
     parser.add_argument("--debug-errors", action="store_true")
     parser.add_argument("--dispatch-atol", type=float, default=0.0)
     parser.add_argument("--w13-atol", type=float, default=2.0)
@@ -392,48 +401,52 @@ def main() -> None:
 
     mesh = Mesh(np.array(devices[: args.ep_size]), ("expert",), axis_types=(AxisType.Explicit,))
     with jax.set_mesh(mesh):
-        pallas_dispatch_fn = _pallas_dispatch_fn(mesh, recv_capacity=recv_capacity)
-        pallas_dispatch_args = _pallas_dispatch_args(mesh, prepacked)
-
-        def run_pallas_dispatch():
-            return pallas_dispatch_fn(*pallas_dispatch_args)
-
-        pallas_layout, _ = _time_block("dispatch/mosaic_gpu", run_pallas_dispatch)
         pallas_dispatch_steady_ms = None
-        if args.bench_iters > 0:
-            pallas_dispatch_steady_ms = _measure_steady_state(
-                "dispatch/mosaic_gpu",
-                run_pallas_dispatch,
-                warmup_steps=args.warmup_steps,
-                bench_iters=args.bench_iters,
-            )
-            if ref_dispatch_steady_ms is not None:
-                _print_speedup(
-                    "dispatch/mosaic_gpu_vs_reference_jit",
-                    ref_dispatch_steady_ms,
-                    pallas_dispatch_steady_ms,
+        if args.pallas_w13_from_reference_layout:
+            pallas_layout = ref_layout
+            print("dispatch/mosaic_gpu: skipped; using reference layout for W13/SiLU")
+        else:
+            pallas_dispatch_fn = _pallas_dispatch_fn(mesh, recv_capacity=recv_capacity)
+            pallas_dispatch_args = _pallas_dispatch_args(mesh, prepacked)
+
+            def run_pallas_dispatch():
+                return pallas_dispatch_fn(*pallas_dispatch_args)
+
+            pallas_layout, _ = _time_block("dispatch/mosaic_gpu", run_pallas_dispatch)
+            if args.bench_iters > 0:
+                pallas_dispatch_steady_ms = _measure_steady_state(
+                    "dispatch/mosaic_gpu",
+                    run_pallas_dispatch,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
                 )
-        dispatch_err = jnp.max(
-            jnp.abs(pallas_layout.recv_x.astype(jnp.float32) - ref_layout.recv_x.astype(jnp.float32))
-        )
-        dispatch_err_float = float(dispatch_err)
-        print(f"dispatch_max_abs_error: {dispatch_err_float:.6g}")
-        valid_err = jnp.sum(pallas_layout.recv_valid != ref_layout.recv_valid, dtype=jnp.int32)
-        expert_err = jnp.sum(pallas_layout.recv_local_expert != ref_layout.recv_local_expert, dtype=jnp.int32)
-        src_rank_err = jnp.sum(pallas_layout.recv_src_rank != ref_layout.recv_src_rank, dtype=jnp.int32)
-        valid_err_int = int(valid_err)
-        expert_err_int = int(expert_err)
-        src_rank_err_int = int(src_rank_err)
-        print(
-            "dispatch_metadata_errors: "
-            f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
-        )
-        _check_error("dispatch_max_abs_error", dispatch_err_float, args.dispatch_atol)
-        if valid_err_int != 0 or expert_err_int != 0 or src_rank_err_int != 0:
-            raise AssertionError(
-                "dispatch metadata mismatch: "
+                if ref_dispatch_steady_ms is not None:
+                    _print_speedup(
+                        "dispatch/mosaic_gpu_vs_reference_jit",
+                        ref_dispatch_steady_ms,
+                        pallas_dispatch_steady_ms,
+                    )
+            dispatch_err = jnp.max(
+                jnp.abs(pallas_layout.recv_x.astype(jnp.float32) - ref_layout.recv_x.astype(jnp.float32))
+            )
+            dispatch_err_float = float(dispatch_err)
+            print(f"dispatch_max_abs_error: {dispatch_err_float:.6g}")
+            valid_err = jnp.sum(pallas_layout.recv_valid != ref_layout.recv_valid, dtype=jnp.int32)
+            expert_err = jnp.sum(pallas_layout.recv_local_expert != ref_layout.recv_local_expert, dtype=jnp.int32)
+            src_rank_err = jnp.sum(pallas_layout.recv_src_rank != ref_layout.recv_src_rank, dtype=jnp.int32)
+            valid_err_int = int(valid_err)
+            expert_err_int = int(expert_err)
+            src_rank_err_int = int(src_rank_err)
+            print(
+                "dispatch_metadata_errors: "
                 f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
             )
+            _check_error("dispatch_max_abs_error", dispatch_err_float, args.dispatch_atol)
+            if valid_err_int != 0 or expert_err_int != 0 or src_rank_err_int != 0:
+                raise AssertionError(
+                    "dispatch metadata mismatch: "
+                    f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
+                )
 
         pallas_w13_fn = _pallas_w13_silu_fn(mesh, args)
         pallas_w13_args = _pallas_w13_silu_args(mesh, pallas_layout, w_gate_up)
@@ -458,7 +471,7 @@ def main() -> None:
         if args.debug_errors:
             _print_error_debug("w13_silu", pallas_h, ref_h, pallas_layout, w_gate_up)
         _check_error("w13_silu_max_abs_error", h_err_float, args.w13_atol)
-        if pallas_dispatch_steady_ms is not None and pallas_w13_steady_ms is not None:
+        if pallas_w13_steady_ms is not None:
             _print_roofline(
                 ep_size=args.ep_size,
                 tokens_per_rank=args.tokens_per_rank,

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -31,12 +31,14 @@ from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_tiled_local,
+    compute_moe_up_mosaic_gpu_source_expert_padded_local,
     compute_moe_up_mosaic_gpu_local,
     compute_moe_up_mosaic_gpu_block_ready_local,
     compute_moe_up_mosaic_gpu_ready_local,
 )
 from levanter.kernels.pallas.moe_dispatch_up.reference import (
     MoeDispatchUpLayout,
+    MoeDispatchUpPrepackedSend,
     MoeDispatchUpSourceExpertPrepackedSend,
     dispatch_prepacked_moe_dispatch_up_reference,
     compute_moe_up_from_layout_reference,
@@ -786,6 +788,129 @@ def _pallas_compact_source_expert_dispatch_up_fn(
     )
 
 
+def _compact_a2a_mosaic_w13_dispatch_up_fn(
+    mesh: Mesh,
+    args,
+    *,
+    recv_capacity: int,
+    return_compact_output: bool,
+    merge_source_groups: bool,
+) -> Callable[..., tuple[jax.Array, jax.Array]]:
+    def local_dispatch_up(
+        send_x_by_dst_expert,
+        send_count_by_dst_expert,
+        recv_source_expert_base,
+        local_w_gate_up,
+    ):
+        send_x_by_dst_expert = jnp.squeeze(send_x_by_dst_expert, axis=0)
+        send_count_by_dst_expert = jnp.squeeze(send_count_by_dst_expert, axis=0)
+        recv_source_expert_base = jnp.squeeze(recv_source_expert_base, axis=0)
+        local_w_gate_up = jnp.squeeze(local_w_gate_up, axis=0)
+
+        source_expert_x = lax.all_to_all(
+            send_x_by_dst_expert,
+            "expert",
+            split_axis=0,
+            concat_axis=0,
+        )
+        source_expert_count = lax.all_to_all(
+            send_count_by_dst_expert,
+            "expert",
+            split_axis=0,
+            concat_axis=0,
+        )
+
+        ep_size, local_experts, source_expert_capacity, hidden = source_expert_x.shape
+        source_expert_groups = ep_size * local_experts
+        if merge_source_groups:
+            local_expert_x = jnp.swapaxes(source_expert_x, 0, 1).reshape(
+                local_experts * ep_size * source_expert_capacity,
+                hidden,
+            )
+            local_expert_rows = jnp.full(
+                (local_experts,),
+                ep_size * source_expert_capacity,
+                dtype=jnp.int32,
+            )
+            local_expert_h = compute_moe_up_mosaic_gpu_local(
+                local_expert_x,
+                local_expert_rows,
+                local_w_gate_up,
+                block_m=args.block_m,
+                block_n=args.block_n,
+                block_k=args.block_k,
+                max_concurrent_steps=args.num_stages,
+                grid_block_n=args.grid_block_n,
+            )
+            source_expert_overflow = jnp.sum(
+                jnp.maximum(source_expert_count - source_expert_capacity, 0),
+                dtype=jnp.int32,
+            )
+            receiver_overflow = jnp.maximum(jnp.max(recv_source_expert_base + source_expert_count) - recv_capacity, 0)
+            overflow_count = lax.psum(source_expert_overflow + receiver_overflow, "expert")
+            return local_expert_h[None, ...], overflow_count[None]
+
+        compact_x = source_expert_x.reshape(source_expert_groups * source_expert_capacity, hidden)
+        compact_rows_per_group = jnp.full(
+            (source_expert_groups,),
+            source_expert_capacity,
+            dtype=jnp.int32,
+        )
+
+        compact_h = compute_moe_up_mosaic_gpu_source_expert_padded_local(
+            compact_x,
+            compact_rows_per_group,
+            local_w_gate_up,
+            block_m=args.block_m,
+            block_n=args.block_n,
+            block_k=args.block_k,
+            max_concurrent_steps=args.num_stages,
+            grid_block_n=args.grid_block_n,
+        ).reshape(ep_size, local_experts, source_expert_capacity, args.intermediate)
+
+        source_expert_overflow = jnp.sum(
+            jnp.maximum(source_expert_count - source_expert_capacity, 0),
+            dtype=jnp.int32,
+        )
+        receiver_overflow = jnp.maximum(jnp.max(recv_source_expert_base + source_expert_count) - recv_capacity, 0)
+        overflow_count = lax.psum(source_expert_overflow + receiver_overflow, "expert")
+        if return_compact_output:
+            return (
+                compact_h.reshape(source_expert_groups * source_expert_capacity, args.intermediate)[None, ...],
+                overflow_count[None],
+            )
+
+        h = jnp.zeros((recv_capacity, args.intermediate), dtype=compact_h.dtype)
+        source_positions = jnp.arange(source_expert_capacity, dtype=jnp.int32)
+        for src_rank in range(ep_size):
+            for local_expert in range(local_experts):
+                base = recv_source_expert_base[src_rank, local_expert]
+                count = source_expert_count[src_rank, local_expert]
+                rows = base + source_positions
+                valid = (source_positions < count) & (rows < recv_capacity)
+                safe_rows = jnp.where(valid, rows, 0)
+                h = h.at[safe_rows].add(
+                    jnp.where(valid[:, None], compact_h[src_rank, local_expert], jnp.zeros((), dtype=compact_h.dtype))
+                )
+
+        return h[None, ...], overflow_count[None]
+
+    return jax.jit(
+        shard_map(
+            local_dispatch_up,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None, None, None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None, None),
+            ),
+            out_specs=(P("expert", None, None), P("expert")),
+            check_vma=False,
+        )
+    )
+
+
 def _pallas_compact_source_expert_dispatch_fn(
     mesh: Mesh,
     *,
@@ -1314,6 +1439,59 @@ def _ring_gather_dispatch_up_fn(
     )
 
 
+def _ring_gather_mosaic_w13_dispatch_up_fn(
+    mesh: Mesh,
+    args,
+    *,
+    local_capacity: int,
+) -> Callable[..., tuple[jax.Array, jax.Array]]:
+    num_experts = args.ep_size * args.experts_per_rank
+    capacity_factor = local_capacity / (args.tokens_per_rank * args.top_k)
+
+    def local_dispatch_up(x_local, selected_experts_local, combine_weights_local, local_w_gate_up):
+        x_local = jnp.squeeze(x_local, axis=0)
+        selected_experts_local = jnp.squeeze(selected_experts_local, axis=0)
+        combine_weights_local = jnp.squeeze(combine_weights_local, axis=0)
+        local_w_gate_up = jnp.squeeze(local_w_gate_up, axis=0)
+        local_experts = local_w_gate_up.shape[0]
+
+        dispatch = _dispatch_up_ep_ring_local(
+            x_local,
+            selected_experts_local,
+            combine_weights_local,
+            local_experts=local_experts,
+            num_experts=num_experts,
+            capacity_factor=capacity_factor,
+        )
+        h = compute_moe_up_mosaic_gpu_local(
+            dispatch.x_dispatch,
+            dispatch.group_sizes,
+            local_w_gate_up,
+            block_m=args.block_m,
+            block_n=args.block_n,
+            block_k=args.block_k,
+            max_concurrent_steps=args.num_stages,
+            grid_block_n=args.grid_block_n,
+        )
+        dropped_total = lax.psum(dispatch.dropped_local, "expert")
+        return jnp.where(dispatch.valid[:, None], h, jnp.zeros((), dtype=h.dtype))[None, ...], dropped_total[None]
+
+    return jax.jit(
+        shard_map(
+            local_dispatch_up,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None, None),
+            ),
+            out_specs=(P("expert", None, None), P("expert")),
+            check_vma=False,
+        )
+    )
+
+
 def _synthetic_layout(
     mesh: Mesh,
     *,
@@ -1433,7 +1611,12 @@ def _resolve_source_expert_capacity(args) -> tuple[int | None, float | None]:
 
 
 def _print_source_expert_load_stats(prepacked, args, *, send_capacity: int) -> None:
-    counts = np.asarray(jax.device_get(prepacked.send_expert_count_by_dst))
+    if isinstance(prepacked, MoeDispatchUpPrepackedSend):
+        counts = np.asarray(jax.device_get(prepacked.send_expert_count_by_dst))
+    elif isinstance(prepacked, MoeDispatchUpSourceExpertPrepackedSend):
+        counts = np.asarray(jax.device_get(prepacked.send_count_by_dst_expert))
+    else:
+        raise TypeError(f"unsupported prepack type: {type(prepacked).__name__}")
     balanced = args.tokens_per_rank * args.top_k / (args.ep_size * args.experts_per_rank)
     print(
         "source_expert_loads: "
@@ -1653,6 +1836,11 @@ def main() -> None:
         help="Benchmark all-gather/ring-style dispatch followed by ragged_dot W13/SiLU.",
     )
     parser.add_argument(
+        "--run-ring-gather-mosaic-dispatch-up",
+        action="store_true",
+        help="Benchmark all-gather/ring-style dispatch followed by Mosaic GPU W13/SiLU.",
+    )
+    parser.add_argument(
         "--run-pallas-fused-dispatch-up",
         action="store_true",
         help="Benchmark one jitted ready-dispatch plus block-ready Mosaic GPU W13/SiLU path.",
@@ -1666,6 +1854,21 @@ def main() -> None:
         "--run-compact-source-expert-dispatch-up",
         action="store_true",
         help="Benchmark compact source/expert Mosaic dispatch followed by block-ready W13/SiLU.",
+    )
+    parser.add_argument(
+        "--run-compact-a2a-mosaic-dispatch-up",
+        action="store_true",
+        help="Benchmark compact source/expert all-to-all followed by Mosaic GPU W13/SiLU.",
+    )
+    parser.add_argument(
+        "--compact-a2a-return-compact-output",
+        action="store_true",
+        help="Return compact source/expert W13 output instead of scattering back to destination-major rows.",
+    )
+    parser.add_argument(
+        "--compact-a2a-merge-source-groups",
+        action="store_true",
+        help="After compact all-to-all, merge source groups per local expert before Mosaic W13.",
     )
     parser.add_argument(
         "--synthetic-layout",
@@ -1791,6 +1994,8 @@ def main() -> None:
         return
     if args.skip_reference_checks and args.pallas_w13_from_reference_layout:
         raise ValueError("--skip-reference-checks cannot be used with --pallas-w13-from-reference-layout")
+    if args.compact_a2a_merge_source_groups and not args.compact_a2a_return_compact_output:
+        raise ValueError("--compact-a2a-merge-source-groups requires --compact-a2a-return-compact-output")
 
     x_by_rank, expert_ids, router_weights, w_gate_up = _make_inputs(
         ep_size=args.ep_size,
@@ -1823,6 +2028,8 @@ def main() -> None:
             or args.run_ragged_a2a_breakdown
             or args.run_padded_a2a_dispatch_up
             or args.run_ring_gather_dispatch_up
+            or args.run_ring_gather_mosaic_dispatch_up
+            or args.run_compact_a2a_mosaic_dispatch_up
         )
         and not args.run_pallas
     ):
@@ -1893,9 +2100,11 @@ def main() -> None:
         and not args.run_ragged_a2a_breakdown
         and not args.run_padded_a2a_dispatch_up
         and not args.run_ring_gather_dispatch_up
+        and not args.run_ring_gather_mosaic_dispatch_up
         and not args.run_pallas_fused_dispatch_up
         and not args.run_compact_source_expert_dispatch
         and not args.run_compact_source_expert_dispatch_up
+        and not args.run_compact_a2a_mosaic_dispatch_up
     ):
         return
     if len(devices) < args.ep_size:
@@ -2192,6 +2401,128 @@ def main() -> None:
                 )
             if ring_gather_steady_ms is not None:
                 print(f"dispatch_up/ring_gather_ragged_dot_end_to_end_ms: {ring_gather_steady_ms:.3f}")
+
+        if args.run_ring_gather_mosaic_dispatch_up:
+            ring_gather_mosaic_fn = _ring_gather_mosaic_w13_dispatch_up_fn(
+                mesh,
+                args,
+                local_capacity=recv_capacity,
+            )
+            ring_gather_mosaic_args = (
+                _sharded(mesh, x_by_rank, P("expert", None, None)),
+                _sharded(mesh, expert_ids, P("expert", None, None)),
+                _sharded(mesh, router_weights, P("expert", None, None)),
+                _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+            )
+
+            def run_ring_gather_mosaic_dispatch_up():
+                return ring_gather_mosaic_fn(*ring_gather_mosaic_args)
+
+            ring_gather_mosaic_result, _ = _time_block(
+                "dispatch_up/ring_gather_mosaic_gpu",
+                run_ring_gather_mosaic_dispatch_up,
+            )
+            ring_gather_mosaic_h, ring_gather_mosaic_dropped = ring_gather_mosaic_result
+            ring_gather_mosaic_dropped_int = int(jnp.max(ring_gather_mosaic_dropped))
+            print(f"dispatch_up/ring_gather_mosaic_gpu_dropped_total: {ring_gather_mosaic_dropped_int}")
+            ring_gather_mosaic_steady_ms = None
+            if args.bench_iters > 0:
+                ring_gather_mosaic_steady_ms = _measure_steady_state(
+                    "dispatch_up/ring_gather_mosaic_gpu",
+                    run_ring_gather_mosaic_dispatch_up,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            if ref_h is None:
+                print("dispatch_up/ring_gather_mosaic_gpu/reference_check: skipped")
+            else:
+                ring_gather_mosaic_err = jnp.max(
+                    jnp.abs(ring_gather_mosaic_h.astype(jnp.float32) - ref_h.astype(jnp.float32))
+                )
+                ring_gather_mosaic_err_float = float(ring_gather_mosaic_err)
+                print(f"dispatch_up_ring_gather_mosaic_gpu_max_abs_error: {ring_gather_mosaic_err_float:.6g}")
+                _print_error_summary("dispatch_up_ring_gather_mosaic_gpu", ring_gather_mosaic_h, ref_h)
+                _check_error(
+                    "dispatch_up_ring_gather_mosaic_gpu_max_abs_error",
+                    ring_gather_mosaic_err_float,
+                    args.w13_atol,
+                )
+            if ring_gather_mosaic_steady_ms is not None:
+                print(f"dispatch_up/ring_gather_mosaic_gpu_end_to_end_ms: {ring_gather_mosaic_steady_ms:.3f}")
+
+        if args.run_compact_a2a_mosaic_dispatch_up:
+            source_expert_capacity, source_expert_capacity_factor = _resolve_source_expert_capacity(args)
+            compact_prepacked, _ = _time_block(
+                "prepack/source_expert_reference",
+                lambda: prepack_moe_dispatch_up_source_expert_reference(
+                    x_by_rank,
+                    expert_ids,
+                    router_weights,
+                    num_experts=num_experts,
+                    recv_capacity=recv_capacity,
+                    source_expert_capacity=source_expert_capacity,
+                ),
+            )
+            inferred_source_expert_capacity = compact_prepacked.send_x_by_dst_expert.shape[3]
+            if source_expert_capacity_factor is None:
+                print(f"source_expert_capacity: {inferred_source_expert_capacity}")
+            else:
+                print(
+                    "source_expert_capacity: "
+                    f"{inferred_source_expert_capacity} from factor={source_expert_capacity_factor:g}"
+                )
+            print(f"source_expert_overflow_count: {int(jax.device_get(compact_prepacked.overflow_count))}")
+            _print_source_expert_load_stats(compact_prepacked, args, send_capacity=send_capacity)
+            compact_a2a_mosaic_fn = _compact_a2a_mosaic_w13_dispatch_up_fn(
+                mesh,
+                args,
+                recv_capacity=recv_capacity,
+                return_compact_output=args.compact_a2a_return_compact_output,
+                merge_source_groups=args.compact_a2a_merge_source_groups,
+            )
+            compact_a2a_mosaic_args = (
+                _sharded(mesh, compact_prepacked.send_x_by_dst_expert, P("expert", None, None, None, None)),
+                _sharded(mesh, compact_prepacked.send_count_by_dst_expert, P("expert", None, None)),
+                _sharded(mesh, compact_prepacked.recv_source_expert_base, P("expert", None, None)),
+                _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+            )
+
+            def run_compact_a2a_mosaic_dispatch_up():
+                return compact_a2a_mosaic_fn(*compact_a2a_mosaic_args)
+
+            compact_a2a_mosaic_result, _ = _time_block(
+                "dispatch_up/compact_a2a_mosaic_gpu",
+                run_compact_a2a_mosaic_dispatch_up,
+            )
+            compact_a2a_mosaic_h, compact_a2a_mosaic_overflow = compact_a2a_mosaic_result
+            compact_a2a_mosaic_overflow_int = int(jnp.max(compact_a2a_mosaic_overflow))
+            print(f"dispatch_up/compact_a2a_mosaic_gpu_overflow_total: {compact_a2a_mosaic_overflow_int}")
+            compact_a2a_mosaic_steady_ms = None
+            if args.bench_iters > 0:
+                compact_a2a_mosaic_steady_ms = _measure_steady_state(
+                    "dispatch_up/compact_a2a_mosaic_gpu",
+                    run_compact_a2a_mosaic_dispatch_up,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            if ref_h is None:
+                print("dispatch_up/compact_a2a_mosaic_gpu/reference_check: skipped")
+            elif args.compact_a2a_return_compact_output:
+                print("dispatch_up/compact_a2a_mosaic_gpu/reference_check: skipped_compact_output")
+            else:
+                compact_a2a_mosaic_err = jnp.max(
+                    jnp.abs(compact_a2a_mosaic_h.astype(jnp.float32) - ref_h.astype(jnp.float32))
+                )
+                compact_a2a_mosaic_err_float = float(compact_a2a_mosaic_err)
+                print(f"dispatch_up_compact_a2a_mosaic_gpu_max_abs_error: {compact_a2a_mosaic_err_float:.6g}")
+                _print_error_summary("dispatch_up_compact_a2a_mosaic_gpu", compact_a2a_mosaic_h, ref_h)
+                _check_error(
+                    "dispatch_up_compact_a2a_mosaic_gpu_max_abs_error",
+                    compact_a2a_mosaic_err_float,
+                    args.w13_atol,
+                )
+            if compact_a2a_mosaic_steady_ms is not None:
+                print(f"dispatch_up/compact_a2a_mosaic_gpu_end_to_end_ms: {compact_a2a_mosaic_steady_ms:.3f}")
 
         if args.run_compact_source_expert_dispatch:
             source_expert_capacity, source_expert_capacity_factor = _resolve_source_expert_capacity(args)

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -14,6 +14,7 @@ import numpy as np
 from jax import shard_map
 from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
 
+from haliax.nn.ragged_dot import ragged_dot
 from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local,
     compute_moe_up_mosaic_gpu_local,
@@ -275,6 +276,207 @@ def _pallas_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
     return fn
 
 
+def _ragged_dot_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
+    def local_w13(recv_x, rows_per_expert, local_w_gate_up):
+        w13_out = ragged_dot(
+            jnp.squeeze(recv_x, axis=0),
+            jnp.squeeze(local_w_gate_up, axis=0),
+            jnp.squeeze(rows_per_expert, axis=0),
+            implementation=args.ragged_dot_impl,
+        )
+        gate, up = jnp.split(w13_out, 2, axis=-1)
+        h = jax.nn.silu(gate.astype(jnp.float32)).astype(gate.dtype) * up
+        return h[None, ...]
+
+    fn = jax.jit(
+        shard_map(
+            local_w13,
+            mesh=mesh,
+            in_specs=(P("expert", None, None), P("expert", None), P("expert", None, None, None)),
+            out_specs=P("expert", None, None),
+            check_vma=False,
+        )
+    )
+    return fn
+
+
+def _synthetic_layout(
+    mesh: Mesh,
+    *,
+    ep_size: int,
+    recv_capacity: int,
+    experts_per_rank: int,
+    hidden: int,
+    intermediate: int,
+    dtype: jnp.dtype,
+    weight_init: str,
+    weight_std: float | None,
+) -> tuple[MoeDispatchUpLayout, jax.Array]:
+    if recv_capacity % experts_per_rank != 0:
+        raise ValueError(
+            f"synthetic recv_capacity={recv_capacity} must be divisible by experts_per_rank={experts_per_rank}"
+        )
+    recv_sharding = NamedSharding(mesh, P("expert", None, None))
+    metadata_sharding = NamedSharding(mesh, P("expert", None))
+    weight_sharding = NamedSharding(mesh, P("expert", None, None, None))
+
+    k_x, k_w = jax.random.split(jax.random.key(6597))
+    recv_x = jax.random.normal(
+        k_x,
+        (ep_size, recv_capacity, hidden),
+        dtype=dtype,
+        out_sharding=recv_sharding,
+    )
+    rows_per_expert_host = np.full((ep_size, experts_per_rank), recv_capacity // experts_per_rank, dtype=np.int32)
+    rows_per_expert = jax.device_put(rows_per_expert_host, metadata_sharding)
+    expert_base = jax.device_put(
+        np.broadcast_to(
+            np.arange(experts_per_rank, dtype=np.int32) * (recv_capacity // experts_per_rank),
+            (ep_size, experts_per_rank),
+        ),
+        metadata_sharding,
+    )
+    recv_valid = jnp.ones((ep_size, recv_capacity), dtype=jnp.bool, out_sharding=metadata_sharding)
+    metadata_zeros = jnp.zeros((ep_size, recv_capacity), dtype=jnp.int32, out_sharding=metadata_sharding)
+    router_weights = jnp.ones((ep_size, recv_capacity), dtype=dtype, out_sharding=metadata_sharding)
+    overflow_count = jnp.zeros((ep_size,), dtype=jnp.int32, out_sharding=NamedSharding(mesh, P("expert")))
+
+    w_shape = (ep_size, experts_per_rank, hidden, 2 * intermediate)
+    if weight_init == "grug_truncated":
+        std = 0.5 / math.sqrt(hidden) if weight_std is None else weight_std
+        w_gate_up = (
+            std
+            * jax.random.truncated_normal(
+                k_w,
+                -3,
+                3,
+                w_shape,
+                dtype=dtype,
+                out_sharding=weight_sharding,
+            )
+        ).astype(dtype)
+    elif weight_init == "standard_normal":
+        w_gate_up = jax.random.normal(k_w, w_shape, dtype=dtype, out_sharding=weight_sharding)
+    else:
+        raise ValueError(f"unknown weight_init={weight_init!r}")
+
+    layout = MoeDispatchUpLayout(
+        recv_x,
+        recv_valid,
+        rows_per_expert,
+        expert_base,
+        metadata_zeros,
+        metadata_zeros,
+        metadata_zeros,
+        metadata_zeros,
+        router_weights,
+        overflow_count,
+    )
+    return layout, w_gate_up
+
+
+def _resolve_recv_capacity(args, *, synthetic_layout: bool) -> tuple[int, float | None]:
+    if args.recv_capacity is not None and args.recv_capacity_factor is not None:
+        raise ValueError("Specify at most one of --recv-capacity and --recv-capacity-factor")
+
+    routed_rows_per_rank = args.tokens_per_rank * args.top_k
+    if args.recv_capacity is not None:
+        return args.recv_capacity, None
+
+    if args.recv_capacity_factor is not None:
+        return math.ceil(args.recv_capacity_factor * routed_rows_per_rank), args.recv_capacity_factor
+
+    if synthetic_layout:
+        return routed_rows_per_rank, 1.0
+
+    default_capacity_factor = 1.25
+    return math.ceil(default_capacity_factor * routed_rows_per_rank), default_capacity_factor
+
+
+def _run_synthetic_layout_benchmark(args, dtype: jnp.dtype, devices: list[jax.Device]) -> None:
+    if len(devices) < args.ep_size:
+        raise RuntimeError(f"Need at least {args.ep_size} local devices, found {len(devices)}")
+    recv_capacity, recv_capacity_factor = _resolve_recv_capacity(args, synthetic_layout=True)
+    mesh = Mesh(np.array(devices[: args.ep_size]), ("expert",), axis_types=(AxisType.Explicit,))
+    capacity_desc = (
+        f"recv_capacity_factor={recv_capacity_factor:g}"
+        if recv_capacity_factor is not None
+        else "recv_capacity=explicit"
+    )
+    print(
+        "synthetic_layout: "
+        f"recv_capacity={recv_capacity} {capacity_desc} rows_per_expert={recv_capacity // args.experts_per_rank} "
+        f"w13_impl={args.w13_impl} ragged_dot_impl={args.ragged_dot_impl}"
+    )
+    with jax.set_mesh(mesh):
+        layout, w_gate_up = _synthetic_layout(
+            mesh,
+            ep_size=args.ep_size,
+            recv_capacity=recv_capacity,
+            experts_per_rank=args.experts_per_rank,
+            hidden=args.hidden,
+            intermediate=args.intermediate,
+            dtype=dtype,
+            weight_init=args.weight_init,
+            weight_std=args.weight_std,
+        )
+
+        timings: dict[str, float] = {}
+        outputs: dict[str, jax.Array] = {}
+        if args.w13_impl in ("mosaic_gpu", "both"):
+            pallas_w13_fn = _pallas_w13_silu_fn(mesh, args)
+            pallas_w13_args = _pallas_w13_silu_args(mesh, layout, w_gate_up)
+
+            def run_pallas_w13():
+                return pallas_w13_fn(*pallas_w13_args)
+
+            pallas_h, _ = _time_block("w13_silu/mosaic_gpu", run_pallas_w13)
+            outputs["mosaic_gpu"] = pallas_h
+            if args.bench_iters > 0:
+                timings["mosaic_gpu"] = _measure_steady_state(
+                    "w13_silu/mosaic_gpu",
+                    run_pallas_w13,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+        if args.w13_impl in ("ragged_dot", "both"):
+            ragged_w13_fn = _ragged_dot_w13_silu_fn(mesh, args)
+            ragged_w13_args = _pallas_w13_silu_args(mesh, layout, w_gate_up)
+
+            def run_ragged_w13():
+                return ragged_w13_fn(*ragged_w13_args)
+
+            ragged_h, _ = _time_block("w13_silu/ragged_dot", run_ragged_w13)
+            outputs["ragged_dot"] = ragged_h
+            if args.bench_iters > 0:
+                timings["ragged_dot"] = _measure_steady_state(
+                    "w13_silu/ragged_dot",
+                    run_ragged_w13,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+        if args.check_w13 and set(outputs) == {"mosaic_gpu", "ragged_dot"}:
+            h_err = jnp.max(
+                jnp.abs(outputs["mosaic_gpu"].astype(jnp.float32) - outputs["ragged_dot"].astype(jnp.float32))
+            )
+            h_err_float = float(h_err)
+            print(f"w13_silu_mosaic_vs_ragged_dot_max_abs_error: {h_err_float:.6g}")
+            _print_error_summary("w13_silu_mosaic_vs_ragged_dot", outputs["mosaic_gpu"], outputs["ragged_dot"])
+            _check_error("w13_silu_mosaic_vs_ragged_dot_max_abs_error", h_err_float, args.w13_atol)
+        for label, steady_ms in timings.items():
+            _print_roofline(
+                ep_size=args.ep_size,
+                tokens_per_rank=recv_capacity // args.top_k,
+                experts_per_rank=args.experts_per_rank,
+                top_k=args.top_k,
+                hidden=args.hidden,
+                intermediate=args.intermediate,
+                dtype_bytes=2 if dtype == jnp.bfloat16 else 4,
+                dispatch_ms=None,
+                w13_ms=steady_ms,
+            )
+
+
 def _print_error_debug(
     label: str,
     actual: jax.Array,
@@ -360,6 +562,40 @@ def main() -> None:
     parser.add_argument("--dtype", choices=("bf16", "fp32"), default="bf16")
     parser.add_argument("--run-pallas", action="store_true")
     parser.add_argument(
+        "--synthetic-layout",
+        action="store_true",
+        help="Skip routing/prepack and benchmark W13/SiLU on a synthetic expert-major layout.",
+    )
+    parser.add_argument(
+        "--recv-capacity",
+        type=int,
+        default=None,
+        help="Rows per destination rank. Overrides --recv-capacity-factor.",
+    )
+    parser.add_argument(
+        "--recv-capacity-factor",
+        type=float,
+        default=None,
+        help="Capacity multiplier for T*K routed rows per destination rank; defaults to 1.25 routed, 1.0 synthetic.",
+    )
+    parser.add_argument(
+        "--w13-impl",
+        choices=("mosaic_gpu", "ragged_dot", "both"),
+        default="mosaic_gpu",
+        help="W13/SiLU implementation to benchmark.",
+    )
+    parser.add_argument(
+        "--ragged-dot-impl",
+        choices=("auto", "triton", "xla"),
+        default="auto",
+        help="haliax.nn.ragged_dot implementation when --w13-impl includes ragged_dot.",
+    )
+    parser.add_argument(
+        "--check-w13",
+        action="store_true",
+        help="In synthetic layout mode with --w13-impl=both, compare Mosaic GPU W13 against ragged_dot.",
+    )
+    parser.add_argument(
         "--dispatch-copy-mode",
         choices=("scalar", "row_vector", "scratch"),
         default="scratch",
@@ -386,6 +622,9 @@ def main() -> None:
         f"K={args.top_k} H={args.hidden} I={args.intermediate} dtype={args.dtype} "
         f"weight_init={args.weight_init} weight_std={args.weight_std}"
     )
+    if args.synthetic_layout:
+        _run_synthetic_layout_benchmark(args, dtype, devices)
+        return
 
     x_by_rank, expert_ids, router_weights, w_gate_up = _make_inputs(
         ep_size=args.ep_size,
@@ -398,7 +637,11 @@ def main() -> None:
         weight_init=args.weight_init,
         weight_std=args.weight_std,
     )
-    recv_capacity = args.ep_size * args.tokens_per_rank * args.top_k
+    recv_capacity, recv_capacity_factor = _resolve_recv_capacity(args, synthetic_layout=False)
+    if recv_capacity_factor is not None:
+        print(f"recv_capacity: {recv_capacity} from factor={recv_capacity_factor:g}")
+    else:
+        print(f"recv_capacity: {recv_capacity}")
     num_experts = args.ep_size * args.experts_per_rank
 
     prepacked, _ = _time_block(
@@ -505,23 +748,30 @@ def main() -> None:
                     f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
                 )
 
-        pallas_w13_fn = _pallas_w13_silu_fn(mesh, args)
+        if args.w13_impl == "both":
+            raise ValueError("--w13-impl=both is only supported with --synthetic-layout")
+        if args.w13_impl == "ragged_dot":
+            pallas_w13_fn = _ragged_dot_w13_silu_fn(mesh, args)
+            w13_label = "w13_silu/ragged_dot"
+        else:
+            pallas_w13_fn = _pallas_w13_silu_fn(mesh, args)
+            w13_label = "w13_silu/mosaic_gpu"
         pallas_w13_args = _pallas_w13_silu_args(mesh, pallas_layout, w_gate_up)
 
         def run_pallas_w13():
             return pallas_w13_fn(*pallas_w13_args)
 
-        pallas_h, _ = _time_block("w13_silu/mosaic_gpu", run_pallas_w13)
+        pallas_h, _ = _time_block(w13_label, run_pallas_w13)
         pallas_w13_steady_ms = None
         if args.bench_iters > 0:
             pallas_w13_steady_ms = _measure_steady_state(
-                "w13_silu/mosaic_gpu",
+                w13_label,
                 run_pallas_w13,
                 warmup_steps=args.warmup_steps,
                 bench_iters=args.bench_iters,
             )
             if ref_w13_steady_ms is not None:
-                _print_speedup("w13_silu/mosaic_gpu_vs_reference_jit", ref_w13_steady_ms, pallas_w13_steady_ms)
+                _print_speedup(f"{w13_label}_vs_reference_jit", ref_w13_steady_ms, pallas_w13_steady_ms)
         h_err = jnp.max(jnp.abs(pallas_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
         h_err_float = float(h_err)
         print(f"w13_silu_max_abs_error: {h_err_float:.6g}")

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -21,6 +21,7 @@ from levanter.grug._moe.ep_common import (
     _expert_prefix_keep_mask,
     _local_permute_from_counts,
     _permute_by_global_expert,
+    _prefix_cap_counts,
     _shard_a2a_params,
 )
 from levanter.grug._moe.ep_padded_all_to_all import _dispatch_fixed_buckets
@@ -944,6 +945,77 @@ def _padded_a2a_dispatch_up_fn(
     )
 
 
+def _ring_gather_dispatch_up_fn(
+    mesh: Mesh,
+    args,
+    *,
+    local_capacity: int,
+) -> Callable[..., tuple[jax.Array, jax.Array]]:
+    def local_dispatch_up(x_local, selected_experts_local, local_w_gate_up):
+        x_local = jnp.squeeze(x_local, axis=0)
+        selected_experts_local = jnp.squeeze(selected_experts_local, axis=0)
+        local_w_gate_up = jnp.squeeze(local_w_gate_up, axis=0)
+        local_experts = local_w_gate_up.shape[0]
+
+        x_global = lax.all_gather(x_local, "expert", tiled=True)
+        selected_experts_global = lax.all_gather(selected_experts_local, "expert", tiled=True)
+
+        tokens = x_global.shape[0]
+        topk = selected_experts_global.shape[1]
+        assignments = tokens * topk
+        if local_capacity < local_experts:
+            raise ValueError(f"local_capacity={local_capacity} must be >= local_experts={local_experts}")
+
+        expert_start = lax.axis_index("expert") * local_experts
+        local_expert = selected_experts_global.reshape(assignments) - expert_start
+        local_mask = (local_expert >= 0) & (local_expert < local_experts)
+
+        local_expert = jnp.where(local_mask, local_expert, 0)
+        expert_ids = jnp.arange(local_experts, dtype=jnp.int32)
+        counts = jnp.sum(
+            (local_expert[:, None] == expert_ids[None, :]).astype(jnp.int32) * local_mask[:, None].astype(jnp.int32),
+            axis=0,
+            dtype=jnp.int32,
+        )
+        accepted_counts = _prefix_cap_counts(counts, capacity=local_capacity)
+        accepted_total = jnp.sum(accepted_counts, dtype=jnp.int32)
+        valid = jnp.arange(local_capacity, dtype=jnp.int32) < accepted_total
+
+        flat_pos = jnp.arange(assignments, dtype=jnp.int32)
+        order_key = local_expert * assignments + flat_pos
+        max_order_key = local_experts * assignments
+        selection_key = jnp.where(local_mask, max_order_key - order_key, -1)
+        _, local_idx = lax.top_k(selection_key, local_capacity)
+
+        token_local = local_idx // topk
+        x_take = jnp.take(x_global, token_local, axis=0)
+        x_dispatch = jnp.where(valid[:, None], x_take, jnp.zeros_like(x_take))
+        # Keep the capacity buffer in the output shape, but do not charge W13
+        # for padded rows in this dispatch-up-only benchmark.
+        group_sizes = accepted_counts
+
+        w13_out = ragged_dot(
+            x_dispatch,
+            local_w_gate_up,
+            group_sizes,
+            implementation=args.ragged_dot_impl,
+        )
+        gate, up = jnp.split(w13_out, 2, axis=-1)
+        h = jax.nn.silu(gate.astype(jnp.float32)).astype(gate.dtype) * up
+        dropped_total = lax.psum(jnp.sum(counts, dtype=jnp.int32) - accepted_total, "expert")
+        return jnp.where(valid[:, None], h, jnp.zeros((), dtype=h.dtype))[None, ...], dropped_total[None]
+
+    return jax.jit(
+        shard_map(
+            local_dispatch_up,
+            mesh=mesh,
+            in_specs=(P("expert", None, None), P("expert", None, None), P("expert", None, None, None)),
+            out_specs=(P("expert", None, None), P("expert")),
+            check_vma=False,
+        )
+    )
+
+
 def _synthetic_layout(
     mesh: Mesh,
     *,
@@ -1237,6 +1309,11 @@ def main() -> None:
         help="Benchmark fixed-bucket all_to_all dispatch followed by ragged_dot W13/SiLU.",
     )
     parser.add_argument(
+        "--run-ring-gather-dispatch-up",
+        action="store_true",
+        help="Benchmark all-gather/ring-style dispatch followed by ragged_dot W13/SiLU.",
+    )
+    parser.add_argument(
         "--synthetic-layout",
         action="store_true",
         help="Skip routing/prepack and benchmark W13/SiLU on a synthetic expert-major layout.",
@@ -1358,7 +1435,12 @@ def main() -> None:
     prepacked = None
     if (
         args.skip_reference_checks
-        and (args.run_ragged_a2a_dispatch_up or args.run_ragged_a2a_breakdown or args.run_padded_a2a_dispatch_up)
+        and (
+            args.run_ragged_a2a_dispatch_up
+            or args.run_ragged_a2a_breakdown
+            or args.run_padded_a2a_dispatch_up
+            or args.run_ring_gather_dispatch_up
+        )
         and not args.run_pallas
     ):
         print("prepack/reference: skipped")
@@ -1426,6 +1508,7 @@ def main() -> None:
         and not args.run_ragged_a2a_dispatch_up
         and not args.run_ragged_a2a_breakdown
         and not args.run_padded_a2a_dispatch_up
+        and not args.run_ring_gather_dispatch_up
     ):
         return
     if len(devices) < args.ep_size:
@@ -1679,6 +1762,37 @@ def main() -> None:
                 )
             if padded_a2a_steady_ms is not None:
                 print(f"dispatch_up/padded_a2a_ragged_dot_end_to_end_ms: {padded_a2a_steady_ms:.3f}")
+
+        if args.run_ring_gather_dispatch_up:
+            ring_gather_fn = _ring_gather_dispatch_up_fn(
+                mesh,
+                args,
+                local_capacity=recv_capacity,
+            )
+            ring_gather_args = (
+                _sharded(mesh, x_by_rank, P("expert", None, None)),
+                _sharded(mesh, expert_ids, P("expert", None, None)),
+                _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+            )
+
+            def run_ring_gather_dispatch_up():
+                return ring_gather_fn(*ring_gather_args)
+
+            ring_gather_result, _ = _time_block("dispatch_up/ring_gather_ragged_dot", run_ring_gather_dispatch_up)
+            _, ring_gather_dropped = ring_gather_result
+            ring_gather_dropped_int = int(jnp.max(ring_gather_dropped))
+            print(f"dispatch_up/ring_gather_dropped_total: {ring_gather_dropped_int}")
+            ring_gather_steady_ms = None
+            if args.bench_iters > 0:
+                ring_gather_steady_ms = _measure_steady_state(
+                    "dispatch_up/ring_gather_ragged_dot",
+                    run_ring_gather_dispatch_up,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            print("dispatch_up/ring_gather_ragged_dot/reference_check: skipped")
+            if ring_gather_steady_ms is not None:
+                print(f"dispatch_up/ring_gather_ragged_dot_end_to_end_ms: {ring_gather_steady_ms:.3f}")
 
         if not args.run_pallas:
             return

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -17,6 +17,7 @@ from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
 from haliax.nn.ragged_dot import ragged_dot
 from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local,
+    dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local,
     compute_moe_up_mosaic_gpu_local,
 )
 from levanter.kernels.pallas.moe_dispatch_up.reference import (
@@ -164,6 +165,21 @@ def _pallas_dispatch_args(mesh: Mesh, prepacked) -> tuple[jax.Array, ...]:
     )
 
 
+def _pallas_dispatch_ready_args(mesh: Mesh, prepacked) -> tuple[jax.Array, ...]:
+    return (
+        *_pallas_dispatch_args(mesh, prepacked),
+        _sharded(mesh, prepacked.send_expert_base_by_dst, P("expert", None, None)),
+        _sharded(mesh, prepacked.send_expert_count_by_dst, P("expert", None, None)),
+        _sharded(mesh, prepacked.recv_source_expert_base, P("expert", None, None)),
+        _sharded(mesh, prepacked.recv_source_expert_count, P("expert", None, None)),
+    )
+
+
+def _expected_ready_count(prepacked, recv_capacity: int) -> jax.Array:
+    remaining_capacity = jnp.maximum(recv_capacity - prepacked.recv_source_expert_base, 0)
+    return jnp.minimum(prepacked.recv_source_expert_count, remaining_capacity)
+
+
 def _pallas_dispatch_fn(
     mesh: Mesh,
     *,
@@ -234,6 +250,100 @@ def _pallas_dispatch_fn(
                 P("expert", None),
                 P("expert", None),
                 P("expert", None),
+            ),
+            out_specs=out_specs,
+            check_vma=False,
+        )
+    )
+    return fn
+
+
+def _pallas_dispatch_ready_fn(
+    mesh: Mesh,
+    *,
+    recv_capacity: int,
+) -> Callable[..., tuple[MoeDispatchUpLayout, jax.Array]]:
+    def local_dispatch(
+        send_x,
+        send_row,
+        send_local_expert,
+        send_src_token_idx,
+        send_topk_slot,
+        send_router_weight,
+        send_count,
+        rows_per_expert,
+        expert_base,
+        send_expert_base,
+        send_expert_count,
+        recv_source_expert_base,
+        recv_source_expert_count,
+    ):
+        layout, ready_count = dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local(
+            jnp.squeeze(send_x, axis=0),
+            jnp.squeeze(send_row, axis=0),
+            jnp.squeeze(send_local_expert, axis=0),
+            jnp.squeeze(send_src_token_idx, axis=0),
+            jnp.squeeze(send_topk_slot, axis=0),
+            jnp.squeeze(send_router_weight, axis=0),
+            jnp.squeeze(send_count, axis=0),
+            jnp.squeeze(rows_per_expert, axis=0),
+            jnp.squeeze(expert_base, axis=0),
+            jnp.squeeze(send_expert_base, axis=0),
+            jnp.squeeze(send_expert_count, axis=0),
+            jnp.squeeze(recv_source_expert_base, axis=0),
+            jnp.squeeze(recv_source_expert_count, axis=0),
+            axis_name="expert",
+            recv_capacity=recv_capacity,
+        )
+        return (
+            MoeDispatchUpLayout(
+                layout.recv_x[None, ...],
+                layout.recv_valid[None, ...],
+                layout.rows_per_expert[None, ...],
+                layout.expert_base[None, ...],
+                layout.recv_local_expert[None, ...],
+                layout.recv_src_rank[None, ...],
+                layout.recv_src_token_idx[None, ...],
+                layout.recv_topk_slot[None, ...],
+                layout.recv_router_weight[None, ...],
+                layout.overflow_count[None],
+            ),
+            ready_count[None, ...],
+        )
+
+    out_specs = (
+        MoeDispatchUpLayout(
+            P("expert", None, None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert", None),
+            P("expert"),
+        ),
+        P("expert", None, None),
+    )
+    fn = jax.jit(
+        shard_map(
+            local_dispatch,
+            mesh=mesh,
+            in_specs=(
+                P("expert", None, None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
+                P("expert", None, None),
             ),
             out_specs=out_specs,
             check_vma=False,
@@ -597,7 +707,7 @@ def main() -> None:
     )
     parser.add_argument(
         "--dispatch-copy-mode",
-        choices=("scalar", "row_vector", "scratch"),
+        choices=("scalar", "row_vector", "scratch", "scratch_ready"),
         default="scratch",
         help="Mosaic GPU dispatch copy implementation.",
     )
@@ -704,15 +814,24 @@ def main() -> None:
             pallas_layout = ref_layout
             print("dispatch/mosaic_gpu: skipped; using reference layout for W13/SiLU")
         else:
-            pallas_dispatch_fn = _pallas_dispatch_fn(
-                mesh, recv_capacity=recv_capacity, copy_mode=args.dispatch_copy_mode
-            )
-            pallas_dispatch_args = _pallas_dispatch_args(mesh, prepacked)
+            pallas_ready_count = None
+            if args.dispatch_copy_mode == "scratch_ready":
+                pallas_dispatch_fn = _pallas_dispatch_ready_fn(mesh, recv_capacity=recv_capacity)
+                pallas_dispatch_args = _pallas_dispatch_ready_args(mesh, prepacked)
+            else:
+                pallas_dispatch_fn = _pallas_dispatch_fn(
+                    mesh, recv_capacity=recv_capacity, copy_mode=args.dispatch_copy_mode
+                )
+                pallas_dispatch_args = _pallas_dispatch_args(mesh, prepacked)
 
             def run_pallas_dispatch():
                 return pallas_dispatch_fn(*pallas_dispatch_args)
 
-            pallas_layout, _ = _time_block("dispatch/mosaic_gpu", run_pallas_dispatch)
+            pallas_dispatch_result, _ = _time_block("dispatch/mosaic_gpu", run_pallas_dispatch)
+            if args.dispatch_copy_mode == "scratch_ready":
+                pallas_layout, pallas_ready_count = pallas_dispatch_result
+            else:
+                pallas_layout = pallas_dispatch_result
             if args.bench_iters > 0:
                 pallas_dispatch_steady_ms = _measure_steady_state(
                     "dispatch/mosaic_gpu",
@@ -741,6 +860,15 @@ def main() -> None:
                 "dispatch_metadata_errors: "
                 f"valid={valid_err_int} local_expert={expert_err_int} src_rank={src_rank_err_int}"
             )
+            if pallas_ready_count is not None:
+                expected_ready_count = _sharded(
+                    mesh, _expected_ready_count(prepacked, recv_capacity), P("expert", None, None)
+                )
+                ready_count_err = jnp.max(jnp.abs(pallas_ready_count - expected_ready_count))
+                ready_count_err_int = int(ready_count_err)
+                print(f"dispatch_ready_count_max_abs_error: {ready_count_err_int}")
+                if ready_count_err_int != 0:
+                    raise AssertionError(f"dispatch ready-count mismatch: max_abs={ready_count_err_int}")
             _check_error("dispatch_max_abs_error", dispatch_err_float, args.dispatch_atol)
             if valid_err_int != 0 or expert_err_int != 0 or src_rank_err_int != 0:
                 raise AssertionError(

--- a/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
+++ b/lib/levanter/scripts/bench/bench_moe_dispatch_up_mosaic_gpu.py
@@ -11,10 +11,19 @@ from collections.abc import Callable
 import jax
 import jax.numpy as jnp
 import numpy as np
-from jax import shard_map
+from jax import lax, shard_map
 from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
 
 from haliax.nn.ragged_dot import ragged_dot
+from levanter.grug._moe.ep_common import (
+    _clip_receiver_group_sizes,
+    _compact_by_keep_mask,
+    _expert_prefix_keep_mask,
+    _local_permute_from_counts,
+    _permute_by_global_expert,
+    _shard_a2a_params,
+)
+from levanter.grug._moe.ep_padded_all_to_all import _dispatch_fixed_buckets
 from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import (
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local,
     dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local,
@@ -607,6 +616,137 @@ def _ragged_dot_w13_silu_fn(mesh: Mesh, args) -> Callable[..., jax.Array]:
     return fn
 
 
+def _ragged_a2a_dispatch_up_fn(
+    mesh: Mesh,
+    args,
+    *,
+    recv_capacity: int,
+    num_experts: int,
+) -> Callable[..., jax.Array]:
+    def local_dispatch_up(x_local, selected_experts_local, local_w_gate_up):
+        x_local = jnp.squeeze(x_local, axis=0)
+        selected_experts_local = jnp.squeeze(selected_experts_local, axis=0)
+        local_w_gate_up = jnp.squeeze(local_w_gate_up, axis=0)
+        shard_id = lax.axis_index("expert")
+        local_experts = local_w_gate_up.shape[0]
+        topk = selected_experts_local.shape[1]
+        assignments_per_shard = x_local.shape[0] * topk
+
+        sorted_x, _, group_sizes = _permute_by_global_expert(
+            x_local,
+            selected_experts_local,
+            num_experts=num_experts,
+        )
+        all_group_sizes = lax.all_gather(group_sizes.astype(jnp.int32), "expert")
+        clipped_group_sizes = _clip_receiver_group_sizes(
+            all_group_sizes,
+            local_expert_size=local_experts,
+            receiver_capacity=recv_capacity,
+        )
+        sender_group_sizes = clipped_group_sizes[shard_id]
+        keep_mask = _expert_prefix_keep_mask(
+            group_sizes.astype(jnp.int32),
+            sender_group_sizes,
+            total_size=assignments_per_shard,
+        )
+        compacted_x = _compact_by_keep_mask(sorted_x, keep_mask)
+
+        ep_size = num_experts // local_experts
+        all_shard_counts = jnp.sum(clipped_group_sizes.reshape(ep_size, ep_size, local_experts), axis=2)
+        input_offsets, send_sizes, output_offsets, recv_sizes = _shard_a2a_params(all_shard_counts, shard_id)
+        dispatched_shape = jnp.zeros((recv_capacity, x_local.shape[1]), dtype=x_local.dtype)
+        x_dispatched = lax.ragged_all_to_all(
+            compacted_x,
+            dispatched_shape,
+            input_offsets,
+            send_sizes,
+            output_offsets,
+            recv_sizes,
+            axis_name="expert",
+        )
+
+        x_dispatch, _, ragged_group_sizes = _local_permute_from_counts(
+            x_dispatched,
+            clipped_group_sizes,
+            local_expert_size=local_experts,
+            shard_index=shard_id,
+        )
+        local_counts_by_sender = lax.dynamic_slice_in_dim(
+            clipped_group_sizes,
+            start_index=shard_id * local_experts,
+            slice_size=local_experts,
+            axis=1,
+        )
+        true_local_group_sizes = jnp.sum(local_counts_by_sender, axis=0, dtype=jnp.int32)
+        valid_rows = jnp.arange(recv_capacity, dtype=jnp.int32) < jnp.sum(true_local_group_sizes, dtype=jnp.int32)
+
+        w13_out = ragged_dot(
+            x_dispatch,
+            local_w_gate_up,
+            ragged_group_sizes,
+            implementation=args.ragged_dot_impl,
+        )
+        gate, up = jnp.split(w13_out, 2, axis=-1)
+        h = jax.nn.silu(gate.astype(jnp.float32)).astype(gate.dtype) * up
+        return jnp.where(valid_rows[:, None], h, jnp.zeros((), dtype=h.dtype))[None, ...]
+
+    return jax.jit(
+        shard_map(
+            local_dispatch_up,
+            mesh=mesh,
+            in_specs=(P("expert", None, None), P("expert", None, None), P("expert", None, None, None)),
+            out_specs=P("expert", None, None),
+            check_vma=False,
+        )
+    )
+
+
+def _padded_a2a_dispatch_up_fn(
+    mesh: Mesh,
+    args,
+    *,
+    capacity_factor: float,
+    num_experts: int,
+) -> Callable[..., tuple[jax.Array, jax.Array]]:
+    def local_dispatch_up(x_local, selected_experts_local, local_w_gate_up):
+        x_local = jnp.squeeze(x_local, axis=0)
+        selected_experts_local = jnp.squeeze(selected_experts_local, axis=0)
+        local_w_gate_up = jnp.squeeze(local_w_gate_up, axis=0)
+        local_experts = local_w_gate_up.shape[0]
+
+        dispatch = _dispatch_fixed_buckets(
+            x_local,
+            selected_experts_local,
+            num_experts=num_experts,
+            local_experts=local_experts,
+            capacity_factor=capacity_factor,
+        )
+        w13_out = ragged_dot(
+            dispatch.x_dispatch,
+            local_w_gate_up,
+            dispatch.local_group_sizes,
+            implementation=args.ragged_dot_impl,
+        )
+        gate, up = jnp.split(w13_out, 2, axis=-1)
+        h = jax.nn.silu(gate.astype(jnp.float32)).astype(gate.dtype) * up
+        valid_rows = jnp.arange(dispatch.x_dispatch.shape[0], dtype=jnp.int32) < jnp.sum(
+            dispatch.local_group_sizes[:-1],
+            dtype=jnp.int32,
+        )
+        dropped_total = lax.psum(dispatch.dropped_local, "expert")
+        return jnp.where(valid_rows[:, None], h, jnp.zeros((), dtype=h.dtype))[None, ...], dropped_total[None]
+
+    return jax.jit(
+        shard_map(
+            local_dispatch_up,
+            mesh=mesh,
+            in_specs=(P("expert", None, None), P("expert", None, None), P("expert", None, None, None)),
+            out_specs=(P("expert", None, None), P("expert")),
+            check_vma=False,
+        )
+    )
+
+
 def _synthetic_layout(
     mesh: Mesh,
     *,
@@ -885,6 +1025,16 @@ def main() -> None:
     parser.add_argument("--dtype", choices=("bf16", "fp32"), default="bf16")
     parser.add_argument("--run-pallas", action="store_true")
     parser.add_argument(
+        "--run-ragged-a2a-dispatch-up",
+        action="store_true",
+        help="Benchmark built-in ragged_all_to_all dispatch followed by ragged_dot W13/SiLU.",
+    )
+    parser.add_argument(
+        "--run-padded-a2a-dispatch-up",
+        action="store_true",
+        help="Benchmark fixed-bucket all_to_all dispatch followed by ragged_dot W13/SiLU.",
+    )
+    parser.add_argument(
         "--synthetic-layout",
         action="store_true",
         help="Skip routing/prepack and benchmark W13/SiLU on a synthetic expert-major layout.",
@@ -1003,17 +1153,25 @@ def main() -> None:
         print(f"send_capacity: {send_capacity}")
     num_experts = args.ep_size * args.experts_per_rank
 
-    prepacked, _ = _time_block(
-        "prepack/reference",
-        lambda: prepack_moe_dispatch_up_reference(
-            x_by_rank,
-            expert_ids,
-            router_weights,
-            num_experts=num_experts,
-            recv_capacity=recv_capacity,
-            send_capacity=send_capacity,
-        ),
-    )
+    prepacked = None
+    if (
+        args.skip_reference_checks
+        and (args.run_ragged_a2a_dispatch_up or args.run_padded_a2a_dispatch_up)
+        and not args.run_pallas
+    ):
+        print("prepack/reference: skipped")
+    else:
+        prepacked, _ = _time_block(
+            "prepack/reference",
+            lambda: prepack_moe_dispatch_up_reference(
+                x_by_rank,
+                expert_ids,
+                router_weights,
+                num_experts=num_experts,
+                recv_capacity=recv_capacity,
+                send_capacity=send_capacity,
+            ),
+        )
     ref_dispatch_steady_ms = None
     ref_w13_steady_ms = None
     ref_layout = None
@@ -1021,6 +1179,8 @@ def main() -> None:
     if args.skip_reference_checks:
         print("reference_checks: skipped")
     else:
+        if prepacked is None:
+            raise AssertionError("reference prepack is required when reference checks are enabled")
         ref_layout, _ = _time_block(
             "dispatch/reference",
             lambda: dispatch_prepacked_moe_dispatch_up_reference(prepacked, recv_capacity=recv_capacity),
@@ -1059,13 +1219,106 @@ def main() -> None:
                 bench_iters=args.bench_iters,
             )
 
-    if not args.run_pallas:
+    if not args.run_pallas and not args.run_ragged_a2a_dispatch_up and not args.run_padded_a2a_dispatch_up:
         return
     if len(devices) < args.ep_size:
         raise RuntimeError(f"Need at least {args.ep_size} local devices, found {len(devices)}")
 
     mesh = Mesh(np.array(devices[: args.ep_size]), ("expert",), axis_types=(AxisType.Explicit,))
     with jax.set_mesh(mesh):
+        if args.run_ragged_a2a_dispatch_up:
+            ragged_a2a_fn = _ragged_a2a_dispatch_up_fn(
+                mesh,
+                args,
+                recv_capacity=recv_capacity,
+                num_experts=num_experts,
+            )
+            ragged_a2a_args = (
+                _sharded(mesh, x_by_rank, P("expert", None, None)),
+                _sharded(mesh, expert_ids, P("expert", None, None)),
+                _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+            )
+
+            def run_ragged_a2a_dispatch_up():
+                return ragged_a2a_fn(*ragged_a2a_args)
+
+            ragged_a2a_h, _ = _time_block("dispatch_up/ragged_a2a_ragged_dot", run_ragged_a2a_dispatch_up)
+            ragged_a2a_steady_ms = None
+            if args.bench_iters > 0:
+                ragged_a2a_steady_ms = _measure_steady_state(
+                    "dispatch_up/ragged_a2a_ragged_dot",
+                    run_ragged_a2a_dispatch_up,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            if ref_h is None:
+                print("dispatch_up/ragged_a2a_ragged_dot/reference_check: skipped")
+            else:
+                ragged_a2a_err = jnp.max(jnp.abs(ragged_a2a_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
+                ragged_a2a_err_float = float(ragged_a2a_err)
+                print(f"dispatch_up_ragged_a2a_ragged_dot_max_abs_error: {ragged_a2a_err_float:.6g}")
+                _print_error_summary("dispatch_up_ragged_a2a_ragged_dot", ragged_a2a_h, ref_h)
+                _check_error(
+                    "dispatch_up_ragged_a2a_ragged_dot_max_abs_error",
+                    ragged_a2a_err_float,
+                    args.w13_atol,
+                )
+            if ragged_a2a_steady_ms is not None:
+                print(f"dispatch_up/ragged_a2a_ragged_dot_end_to_end_ms: {ragged_a2a_steady_ms:.3f}")
+
+        if args.run_padded_a2a_dispatch_up:
+            padded_capacity_factor = recv_capacity / (args.tokens_per_rank * args.top_k)
+            padded_a2a_fn = _padded_a2a_dispatch_up_fn(
+                mesh,
+                args,
+                capacity_factor=padded_capacity_factor,
+                num_experts=num_experts,
+            )
+            padded_a2a_args = (
+                _sharded(mesh, x_by_rank, P("expert", None, None)),
+                _sharded(mesh, expert_ids, P("expert", None, None)),
+                _sharded(mesh, w_gate_up, P("expert", None, None, None)),
+            )
+
+            def run_padded_a2a_dispatch_up():
+                return padded_a2a_fn(*padded_a2a_args)
+
+            padded_a2a_result, _ = _time_block("dispatch_up/padded_a2a_ragged_dot", run_padded_a2a_dispatch_up)
+            padded_a2a_h, padded_a2a_dropped = padded_a2a_result
+            padded_a2a_dropped_int = int(jnp.max(padded_a2a_dropped))
+            print(f"dispatch_up/padded_a2a_dropped_total: {padded_a2a_dropped_int}")
+            padded_a2a_steady_ms = None
+            if args.bench_iters > 0:
+                padded_a2a_steady_ms = _measure_steady_state(
+                    "dispatch_up/padded_a2a_ragged_dot",
+                    run_padded_a2a_dispatch_up,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+            if ref_h is None:
+                print("dispatch_up/padded_a2a_ragged_dot/reference_check: skipped")
+            elif padded_a2a_h.shape[1] < ref_h.shape[1]:
+                raise AssertionError(
+                    "padded all-to-all output has fewer rows than reference: "
+                    f"{padded_a2a_h.shape[1]} < {ref_h.shape[1]}"
+                )
+            else:
+                comparable_padded_h = padded_a2a_h[:, : ref_h.shape[1], :]
+                padded_a2a_err = jnp.max(jnp.abs(comparable_padded_h.astype(jnp.float32) - ref_h.astype(jnp.float32)))
+                padded_a2a_err_float = float(padded_a2a_err)
+                print(f"dispatch_up_padded_a2a_ragged_dot_max_abs_error: {padded_a2a_err_float:.6g}")
+                _print_error_summary("dispatch_up_padded_a2a_ragged_dot", comparable_padded_h, ref_h)
+                _check_error(
+                    "dispatch_up_padded_a2a_ragged_dot_max_abs_error",
+                    padded_a2a_err_float,
+                    args.w13_atol,
+                )
+            if padded_a2a_steady_ms is not None:
+                print(f"dispatch_up/padded_a2a_ragged_dot_end_to_end_ms: {padded_a2a_steady_ms:.3f}")
+
+        if not args.run_pallas:
+            return
+
         pallas_dispatch_steady_ms = None
         pallas_ready_count = None
         pallas_ready_block_count = None
@@ -1075,6 +1328,8 @@ def main() -> None:
             pallas_layout = ref_layout
             print("dispatch/mosaic_gpu: skipped; using reference layout for W13/SiLU")
         else:
+            if prepacked is None:
+                raise AssertionError("prepacked sends are required for Mosaic GPU dispatch")
             if args.dispatch_copy_mode == "scratch_ready":
                 pallas_dispatch_fn = _pallas_dispatch_ready_fn(
                     mesh,

--- a/lib/levanter/scripts/bench/bench_moe_mgpu_block_transport.py
+++ b/lib/levanter/scripts/bench/bench_moe_mgpu_block_transport.py
@@ -139,6 +139,64 @@ def _remote_block_copy_local(
     return scratch
 
 
+def _remote_neighbor_copy_local(
+    send_x: jax.Array,
+    *,
+    axis_name: str,
+    block_rows: int,
+    block_cols: int,
+) -> jax.Array:
+    if send_x.ndim != 2:
+        raise ValueError(f"send_x must have shape [R, H], got {send_x.shape}")
+    if block_rows < 1:
+        raise ValueError(f"block_rows must be positive, got {block_rows}")
+    if block_cols < 1:
+        raise ValueError(f"block_cols must be positive, got {block_cols}")
+    rows, hidden = send_x.shape
+    if rows % block_rows != 0:
+        raise ValueError(f"rows={rows} must be divisible by block_rows={block_rows}")
+    if hidden % block_cols != 0:
+        raise ValueError(f"hidden={hidden} must be divisible by block_cols={block_cols}")
+    row_blocks = rows // block_rows
+    col_blocks = hidden // block_cols
+    tiles = row_blocks * col_blocks
+
+    def kernel_body(send_ref, recv_ref):
+        recv_sem = pl.get_global(plgpu.SemaphoreType.REGULAR)
+        src_rank = lax.axis_index(axis_name)
+        axis_size = lax.axis_size(axis_name)
+        dst_rank = lax.rem(src_rank + jnp.int32(1), jnp.int32(axis_size))
+        remote_recv_ref = plgpu.remote_ref(recv_ref, dst_rank)
+        tile = pl.program_id(0)
+        row_block = tile // col_blocks
+        col_block = tile - row_block * col_blocks
+        row_start = row_block * block_rows
+        col_start = col_block * block_cols
+
+        @functools.partial(
+            pl.run_scoped,
+            tile_smem=plgpu.SMEM((block_rows, block_cols), dtype=send_ref.dtype),
+            barrier=plgpu.Barrier(),
+        )
+        def copy_scope(tile_smem, barrier):
+            src_slice = send_ref.at[pl.ds(row_start, block_rows), pl.ds(col_start, block_cols)]
+            plgpu.copy_gmem_to_smem(src_slice, tile_smem, barrier)
+            plgpu.barrier_wait(barrier)
+            dst_slice = remote_recv_ref.at[pl.ds(row_start, block_rows), pl.ds(col_start, block_cols)]
+            plgpu.copy_smem_to_gmem(tile_smem, dst_slice)
+            plgpu.wait_smem_to_gmem(0, wait_read_only=False)
+
+        pl.semaphore_signal(recv_sem, device_id=dst_rank)
+        pl.semaphore_wait(recv_sem, value=tiles, decrement=False)
+
+    return plgpu.kernel(
+        kernel_body,
+        out_shape=jax.ShapeDtypeStruct((rows, hidden), send_x.dtype),
+        grid=(tiles,),
+        grid_names=("tile",),
+    )(send_x)
+
+
 def _block_copy_fn(
     mesh: Mesh,
     *,
@@ -169,6 +227,27 @@ def _block_copy_fn(
     )
 
 
+def _neighbor_copy_fn(mesh: Mesh, *, block_rows: int, block_cols: int) -> Callable[[jax.Array], jax.Array]:
+    def local_copy(send_x):
+        recv = _remote_neighbor_copy_local(
+            jnp.squeeze(send_x, axis=0),
+            axis_name="expert",
+            block_rows=block_rows,
+            block_cols=block_cols,
+        )
+        return recv[None, ...]
+
+    return jax.jit(
+        shard_map(
+            local_copy,
+            mesh=mesh,
+            in_specs=P("expert", None, None),
+            out_specs=P("expert", None, None),
+            check_vma=False,
+        )
+    )
+
+
 def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--ep-size", type=int, default=8)
@@ -182,6 +261,7 @@ def main() -> None:
     parser.add_argument("--skip-reference-checks", action="store_true")
     parser.add_argument("--use-scratch-output", action="store_true")
     parser.add_argument("--loop-tiles", action="store_true")
+    parser.add_argument("--fixed-neighbor", action="store_true")
     args = parser.parse_args()
 
     dtype = jnp.bfloat16 if args.dtype == "bf16" else jnp.float32
@@ -193,12 +273,53 @@ def main() -> None:
     )
     print(f"use_scratch_output={args.use_scratch_output}")
     print(f"loop_tiles={args.loop_tiles}")
+    print(f"fixed_neighbor={args.fixed_neighbor}")
     if len(devices) < args.ep_size:
         raise RuntimeError(f"Need at least {args.ep_size} local devices, found {len(devices)}")
 
     mesh = Mesh(np.array(devices[: args.ep_size]), ("expert",), axis_types=(AxisType.Explicit,))
     send_sharding = NamedSharding(mesh, P("expert", None, None, None))
+    neighbor_send_sharding = NamedSharding(mesh, P("expert", None, None))
     with jax.set_mesh(mesh):
+        if args.fixed_neighbor:
+            send_neighbor = jax.random.normal(
+                jax.random.key(6597),
+                (args.ep_size, args.rows, args.hidden),
+                dtype=dtype,
+                out_sharding=neighbor_send_sharding,
+            )
+            expected_neighbor_host = None
+            if not args.skip_reference_checks:
+                expected_neighbor_host = np.roll(np.asarray(send_neighbor), shift=1, axis=0)
+
+            neighbor_copy_fn = _neighbor_copy_fn(mesh, block_rows=args.block_rows, block_cols=args.block_cols)
+
+            def run_neighbor_copy():
+                return neighbor_copy_fn(send_neighbor)
+
+            actual_neighbor, _ = _time_block("transport/fixed_neighbor_copy", run_neighbor_copy)
+            if args.bench_iters > 0:
+                steady_ms = _measure_steady_state(
+                    "transport/fixed_neighbor_copy",
+                    run_neighbor_copy,
+                    warmup_steps=args.warmup_steps,
+                    bench_iters=args.bench_iters,
+                )
+                dtype_bytes = 2 if dtype == jnp.bfloat16 else 4
+                payload_bytes = args.ep_size * args.rows * args.hidden * dtype_bytes
+                print(f"transport_payload={payload_bytes / 1024 / 1024:.3f} MiB")
+                print(f"transport_bandwidth={payload_bytes / (steady_ms / 1e3) / 1e9:.6f} GB/s")
+
+            if expected_neighbor_host is not None:
+                actual_neighbor_host = np.asarray(actual_neighbor)
+                max_abs_float = float(
+                    np.max(np.abs(actual_neighbor_host.astype(np.float32) - expected_neighbor_host.astype(np.float32)))
+                )
+                print(f"transport_max_abs_error: {max_abs_float:.6g}")
+                if max_abs_float != 0.0:
+                    raise AssertionError(f"transport max abs error {max_abs_float:.6g}")
+            return
+
         send_x = jax.random.normal(
             jax.random.key(6597),
             (args.ep_size, args.ep_size, args.rows, args.hidden),

--- a/lib/levanter/scripts/bench/bench_moe_mgpu_block_transport.py
+++ b/lib/levanter/scripts/bench/bench_moe_mgpu_block_transport.py
@@ -1,0 +1,245 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Probe SMEM-mediated Mosaic GPU block transport for MoE dispatch-up."""
+
+import argparse
+import functools
+import time
+from collections.abc import Callable
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax import lax, shard_map
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import mosaic_gpu as plgpu
+from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+
+def _time_block(label: str, fn: Callable[[], jax.Array]) -> tuple[jax.Array, float]:
+    start = time.perf_counter()
+    result = fn()
+    jax.block_until_ready(result)
+    elapsed = time.perf_counter() - start
+    print(f"{label}: {elapsed * 1e3:.3f} ms")
+    return result, elapsed
+
+
+def _measure_steady_state(label: str, fn: Callable[[], jax.Array], *, warmup_steps: int, bench_iters: int) -> float:
+    for _ in range(warmup_steps):
+        jax.block_until_ready(fn())
+
+    times = []
+    for _ in range(bench_iters):
+        start = time.perf_counter()
+        jax.block_until_ready(fn())
+        times.append(time.perf_counter() - start)
+    times_ms = np.asarray(times) * 1e3
+    print(
+        f"{label}/steady: "
+        f"mean={float(np.mean(times_ms)):.3f} ms "
+        f"min={float(np.min(times_ms)):.3f} ms "
+        f"max={float(np.max(times_ms)):.3f} ms "
+        f"iters={bench_iters}"
+    )
+    return float(np.mean(times_ms))
+
+
+def _remote_block_copy_local(
+    send_x_by_dst: jax.Array,
+    *,
+    axis_name: str,
+    block_rows: int,
+    block_cols: int,
+    use_scratch_output: bool,
+    loop_tiles: bool,
+) -> jax.Array:
+    if send_x_by_dst.ndim != 3:
+        raise ValueError(f"send_x_by_dst must have shape [EP, R, H], got {send_x_by_dst.shape}")
+    if block_rows < 1:
+        raise ValueError(f"block_rows must be positive, got {block_rows}")
+    if block_cols < 1:
+        raise ValueError(f"block_cols must be positive, got {block_cols}")
+    ep_size, rows, hidden = send_x_by_dst.shape
+    if rows % block_rows != 0:
+        raise ValueError(f"rows={rows} must be divisible by block_rows={block_rows}")
+    if hidden % block_cols != 0:
+        raise ValueError(f"hidden={hidden} must be divisible by block_cols={block_cols}")
+    row_blocks = rows // block_rows
+    col_blocks = hidden // block_cols
+    tiles = row_blocks * col_blocks
+
+    def copy_body(send_ref, recv_ref):
+        recv_sem = pl.get_global(plgpu.SemaphoreType.REGULAR)
+        src_rank = lax.axis_index(axis_name)
+        dst_rank = pl.program_id(0)
+        remote_recv_ref = plgpu.remote_ref(recv_ref, jnp.int32(dst_rank))
+
+        def copy_tile(tile):
+            row_block = tile // col_blocks
+            col_block = tile - row_block * col_blocks
+            row_start = row_block * block_rows
+            col_start = col_block * block_cols
+
+            @functools.partial(
+                pl.run_scoped,
+                tile_smem=plgpu.SMEM((block_rows, block_cols), dtype=send_ref.dtype),
+                barrier=plgpu.Barrier(),
+            )
+            def copy_scope(
+                tile_smem,
+                barrier,
+            ):
+                src_slice = send_ref.at[dst_rank, pl.ds(row_start, block_rows), pl.ds(col_start, block_cols)]
+                plgpu.copy_gmem_to_smem(src_slice, tile_smem, barrier)
+                plgpu.barrier_wait(barrier)
+                dst_slice = remote_recv_ref.at[src_rank, pl.ds(row_start, block_rows), pl.ds(col_start, block_cols)]
+                plgpu.copy_smem_to_gmem(tile_smem, dst_slice)
+                plgpu.wait_smem_to_gmem(0, wait_read_only=False)
+
+        if loop_tiles:
+
+            @pl.loop(0, tiles)
+            def _copy_loop(tile):
+                copy_tile(tile)
+
+            pl.semaphore_signal(recv_sem, device_id=jnp.int32(dst_rank))
+            pl.semaphore_wait(recv_sem, value=ep_size, decrement=False)
+            return
+
+        copy_tile(pl.program_id(1))
+
+        pl.semaphore_signal(recv_sem, device_id=jnp.int32(dst_rank))
+        pl.semaphore_wait(recv_sem, value=ep_size * row_blocks * col_blocks, decrement=False)
+
+    grid = (ep_size,) if loop_tiles else (ep_size, tiles)
+    grid_names = ("dst",) if loop_tiles else ("dst", "tile")
+    if not use_scratch_output:
+        return plgpu.kernel(
+            copy_body,
+            out_shape=jax.ShapeDtypeStruct((ep_size, rows, hidden), send_x_by_dst.dtype),
+            grid=grid,
+            grid_names=grid_names,
+        )(send_x_by_dst)
+
+    def scratch_kernel_body(send_ref, dummy_ref, scratch_ref):
+        del dummy_ref
+        copy_body(send_ref, scratch_ref)
+
+    _, scratch = plgpu.kernel(
+        scratch_kernel_body,
+        out_shape=[
+            jax.ShapeDtypeStruct((), send_x_by_dst.dtype),
+            jax.ShapeDtypeStruct((ep_size, rows, hidden), send_x_by_dst.dtype),
+        ],
+        grid=grid,
+        grid_names=grid_names,
+    )(send_x_by_dst)
+    return scratch
+
+
+def _block_copy_fn(
+    mesh: Mesh,
+    *,
+    block_rows: int,
+    block_cols: int,
+    use_scratch_output: bool,
+    loop_tiles: bool,
+) -> Callable[[jax.Array], jax.Array]:
+    def local_copy(send_x):
+        recv = _remote_block_copy_local(
+            jnp.squeeze(send_x, axis=0),
+            axis_name="expert",
+            block_rows=block_rows,
+            block_cols=block_cols,
+            use_scratch_output=use_scratch_output,
+            loop_tiles=loop_tiles,
+        )
+        return recv[None, ...]
+
+    return jax.jit(
+        shard_map(
+            local_copy,
+            mesh=mesh,
+            in_specs=P("expert", None, None, None),
+            out_specs=P("expert", None, None, None),
+            check_vma=False,
+        )
+    )
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--ep-size", type=int, default=8)
+    parser.add_argument("--rows", type=int, default=32)
+    parser.add_argument("--hidden", type=int, default=128)
+    parser.add_argument("--block-rows", type=int, default=16)
+    parser.add_argument("--block-cols", type=int, default=128)
+    parser.add_argument("--dtype", choices=("bf16", "fp32"), default="bf16")
+    parser.add_argument("--warmup-steps", type=int, default=1)
+    parser.add_argument("--bench-iters", type=int, default=1)
+    parser.add_argument("--skip-reference-checks", action="store_true")
+    parser.add_argument("--use-scratch-output", action="store_true")
+    parser.add_argument("--loop-tiles", action="store_true")
+    args = parser.parse_args()
+
+    dtype = jnp.bfloat16 if args.dtype == "bf16" else jnp.float32
+    devices = jax.local_devices()
+    print(f"devices: {len(devices)} {[device.platform for device in devices]}")
+    print(
+        f"shape: EP={args.ep_size} rows={args.rows} H={args.hidden} "
+        f"block_rows={args.block_rows} block_cols={args.block_cols} dtype={args.dtype}"
+    )
+    print(f"use_scratch_output={args.use_scratch_output}")
+    print(f"loop_tiles={args.loop_tiles}")
+    if len(devices) < args.ep_size:
+        raise RuntimeError(f"Need at least {args.ep_size} local devices, found {len(devices)}")
+
+    mesh = Mesh(np.array(devices[: args.ep_size]), ("expert",), axis_types=(AxisType.Explicit,))
+    send_sharding = NamedSharding(mesh, P("expert", None, None, None))
+    with jax.set_mesh(mesh):
+        send_x = jax.random.normal(
+            jax.random.key(6597),
+            (args.ep_size, args.ep_size, args.rows, args.hidden),
+            dtype=dtype,
+            out_sharding=send_sharding,
+        )
+        expected_host = None
+        if not args.skip_reference_checks:
+            expected_host = np.asarray(send_x).transpose((1, 0, 2, 3))
+
+        copy_fn = _block_copy_fn(
+            mesh,
+            block_rows=args.block_rows,
+            block_cols=args.block_cols,
+            use_scratch_output=args.use_scratch_output,
+            loop_tiles=args.loop_tiles,
+        )
+
+        def run_copy():
+            return copy_fn(send_x)
+
+        actual, _ = _time_block("transport/block_copy", run_copy)
+        if args.bench_iters > 0:
+            steady_ms = _measure_steady_state(
+                "transport/block_copy",
+                run_copy,
+                warmup_steps=args.warmup_steps,
+                bench_iters=args.bench_iters,
+            )
+            dtype_bytes = 2 if dtype == jnp.bfloat16 else 4
+            payload_bytes = args.ep_size * args.ep_size * args.rows * args.hidden * dtype_bytes
+            print(f"transport_payload={payload_bytes / 1024 / 1024:.3f} MiB")
+            print(f"transport_bandwidth={payload_bytes / (steady_ms / 1e3) / 1e9:.6f} GB/s")
+
+        if expected_host is not None:
+            actual_host = np.asarray(actual)
+            max_abs_float = float(np.max(np.abs(actual_host.astype(np.float32) - expected_host.astype(np.float32))))
+            print(f"transport_max_abs_error: {max_abs_float:.6g}")
+            if max_abs_float != 0.0:
+                raise AssertionError(f"transport max abs error {max_abs_float:.6g}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/levanter/src/levanter/grug/_moe/ep_ring.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ring.py
@@ -5,6 +5,7 @@
 
 import math
 from collections.abc import Callable
+from typing import NamedTuple
 
 import jax
 import jax.numpy as jnp
@@ -21,22 +22,28 @@ from levanter.grug._moe.ep_common import _prefix_cap_counts
 from levanter.grug.sharding import _batch_axes
 
 
-def _moe_mlp_ep_ring_local(
-    x_local: Float[Array, "TL D"],
-    selected_experts_local: Int[Array, "TL K"],
-    combine_weights_local: Float[Array, "TL K"],
-    moe_w13_local: Float[Array, "EL D I2"],
-    moe_w2_local: Float[Array, "EL I D"],
+class RingDispatchUp(NamedTuple):
+    """Receiver-local rows and metadata for ring-style expert dispatch-up."""
+
+    x_dispatch: jax.Array
+    group_sizes: jax.Array
+    token_local: jax.Array
+    weight_dispatch: jax.Array
+    valid: jax.Array
+    dropped_local: jax.Array
+
+
+def _dispatch_up_ep_ring_local(
+    x_local: jax.Array,
+    selected_experts_local: jax.Array,
+    combine_weights_local: jax.Array,
     *,
-    activation_fn: Callable[[jax.Array], jax.Array],
+    local_experts: int,
     num_experts: int,
     capacity_factor: float,
-    remat_mode: str = "none",
-) -> tuple[Float[Array, "TL D"], Int[Array, ""]]:
-    """Ring-style EP routed path: all-gather dispatch + psum-scatter collect."""
-    del remat_mode
-    # #2710 ring EP strategy: gather tokens and their selected-expert routing
-    # assignments across expert shards, then psum-scatter back to local tokens.
+) -> RingDispatchUp:
+    """All-gather tokens and pack this rank's local expert rows for W13."""
+
     with jax.named_scope("moe_ep_ring/gather_inputs"):
         x_global = jax.lax.all_gather(x_local, "expert", tiled=True)
         selected_experts_global = jax.lax.all_gather(selected_experts_local, "expert", tiled=True)
@@ -49,7 +56,6 @@ def _moe_mlp_ep_ring_local(
         expert_flat = selected_experts_global.reshape(assignments)
         weight_flat = combine_weights_global.reshape(assignments)
 
-        local_experts = moe_w13_local.shape[0]
         if num_experts % local_experts != 0:
             raise ValueError(
                 f"num_experts={num_experts} must be divisible by local expert count={local_experts} in EP mode"
@@ -102,12 +108,46 @@ def _moe_mlp_ep_ring_local(
 
     with jax.named_scope("moe_ep_ring/group_sizes"):
         group_sizes = accepted_counts
-        # `local_idx` pads by appending invalid rows at the end; keep GMM segment
-        # boundaries aligned by attributing padding to the final expert segment.
-        group_sizes = group_sizes.at[-1].add(local_capacity - jnp.sum(group_sizes, dtype=jnp.int32))
+
+    return RingDispatchUp(
+        x_dispatch=x_dispatch,
+        group_sizes=group_sizes,
+        token_local=token_local,
+        weight_dispatch=weight_dispatch,
+        valid=valid,
+        dropped_local=dropped_local,
+    )
+
+
+def _moe_mlp_ep_ring_local(
+    x_local: Float[Array, "TL D"],
+    selected_experts_local: Int[Array, "TL K"],
+    combine_weights_local: Float[Array, "TL K"],
+    moe_w13_local: Float[Array, "EL D I2"],
+    moe_w2_local: Float[Array, "EL I D"],
+    *,
+    activation_fn: Callable[[jax.Array], jax.Array],
+    num_experts: int,
+    capacity_factor: float,
+    remat_mode: str = "none",
+) -> tuple[Float[Array, "TL D"], Int[Array, ""]]:
+    """Ring-style EP routed path: all-gather dispatch + psum-scatter collect."""
+    del remat_mode
+    local_experts = moe_w13_local.shape[0]
+    dispatch = _dispatch_up_ep_ring_local(
+        x_local,
+        selected_experts_local,
+        combine_weights_local,
+        local_experts=local_experts,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+    )
 
     with jax.named_scope("moe_expert_mlp/w13_ragged_dot"):
-        w13_out = tree_checkpoint_name(ragged_dot(x_dispatch, moe_w13_local, group_sizes), _CHECKPOINT_EXPERT_HIDDEN)
+        w13_out = tree_checkpoint_name(
+            ragged_dot(dispatch.x_dispatch, moe_w13_local, dispatch.group_sizes),
+            _CHECKPOINT_EXPERT_HIDDEN,
+        )
     with jax.named_scope("moe_expert_mlp/split_gate_up"):
         moe_dim = moe_w2_local.shape[1]
         gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
@@ -115,16 +155,23 @@ def _moe_mlp_ep_ring_local(
         hidden = activation_fn(gate) * up
     with jax.named_scope("moe_expert_mlp/w2_ragged_dot"):
         out_dispatch = tree_checkpoint_name(
-            ragged_dot(hidden, moe_w2_local, group_sizes),
+            ragged_dot(hidden, moe_w2_local, dispatch.group_sizes),
             _CHECKPOINT_DISPATCH_OUTPUT,
         )
 
     with jax.named_scope("moe_ep_ring/combine_scatter_add"):
-        out_global = jnp.zeros_like(x_global).at[token_local].add(out_dispatch * weight_dispatch[:, None], mode="drop")
+        out_global = (
+            jnp.zeros(
+                (x_local.shape[0] * (num_experts // local_experts), x_local.shape[1]),
+                dtype=out_dispatch.dtype,
+            )
+            .at[dispatch.token_local]
+            .add(out_dispatch * dispatch.weight_dispatch[:, None], mode="drop")
+        )
     with jax.named_scope("moe_ep_ring/psum_scatter_output"):
         # #2710 ring EP strategy: collect only this shard's token slice after
         # reducing contributions from experts across the EP mesh.
         out_local = jax.lax.psum_scatter(out_global, "expert", scatter_dimension=0, tiled=True)
     with jax.named_scope("moe_ep_ring/psum_dropped_assignments"):
-        dropped_total = jax.lax.psum(dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
+        dropped_total = jax.lax.psum(dispatch.dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
     return out_local, dropped_total

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/__init__.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/__init__.py
@@ -1,0 +1,4 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Experimental MoE dispatch-up subkernel."""

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/api.py
@@ -14,6 +14,7 @@ from levanter.kernels.pallas.moe_dispatch_up.reference import (
     MoeDispatchUpLayout,
     MoeDispatchUpPrepackedSend,
     compute_moe_up_from_layout_reference,
+    compute_moe_up_from_layout_ragged_dot,
     dispatch_prepacked_moe_dispatch_up_reference,
     moe_dispatch_up_reference_bwd,
     moe_dispatch_up_layout_reference as _moe_dispatch_up_layout_reference,
@@ -21,6 +22,8 @@ from levanter.kernels.pallas.moe_dispatch_up.reference import (
 )
 
 Implementation: TypeAlias = Literal["reference", "mosaic_gpu"]
+W13Implementation: TypeAlias = Literal["reference", "ragged_dot"]
+RaggedDotImplementation: TypeAlias = Literal["auto", "megablox", "triton", "xla"]
 
 
 def _mosaic_gpu_dispatch(
@@ -111,6 +114,8 @@ def moe_dispatch_up(
     capacity_factor: float = 1.25,
     recv_capacity: int | None = None,
     implementation: Implementation | Sequence[Implementation | Callable[..., MoeDispatchUpLayout]] | None = None,
+    w13_implementation: W13Implementation = "reference",
+    ragged_dot_implementation: RaggedDotImplementation = "auto",
 ) -> tuple[jax.Array, MoeDispatchUpLayout]:
     prepacked = prepack_moe_dispatch_up(
         x_by_rank,
@@ -121,7 +126,17 @@ def moe_dispatch_up(
         recv_capacity=recv_capacity,
     )
     layout = moe_dispatch_up_layout(prepacked, recv_capacity=recv_capacity, implementation=implementation)
-    return compute_moe_up_from_layout_reference(layout, w_gate_up_by_rank), layout
+    if w13_implementation == "reference":
+        dispatch_up = compute_moe_up_from_layout_reference(layout, w_gate_up_by_rank)
+    elif w13_implementation == "ragged_dot":
+        dispatch_up = compute_moe_up_from_layout_ragged_dot(
+            layout,
+            w_gate_up_by_rank,
+            implementation=ragged_dot_implementation,
+        )
+    else:
+        raise ValueError(f"Unsupported MoE dispatch-up W13 implementation: {w13_implementation!r}")
+    return dispatch_up, layout
 
 
 def moe_dispatch_up_layout_reference(

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/api.py
@@ -15,6 +15,7 @@ from levanter.kernels.pallas.moe_dispatch_up.reference import (
     MoeDispatchUpPrepackedSend,
     compute_moe_up_from_layout_reference,
     dispatch_prepacked_moe_dispatch_up_reference,
+    moe_dispatch_up_reference_bwd,
     moe_dispatch_up_layout_reference as _moe_dispatch_up_layout_reference,
     prepack_moe_dispatch_up_reference,
 )
@@ -136,6 +137,29 @@ def moe_dispatch_up_layout_reference(
         x_by_rank,
         expert_ids_by_rank,
         router_weights_by_rank,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        recv_capacity=recv_capacity,
+    )
+
+
+def moe_dispatch_up_bwd_reference(
+    x_by_rank: jax.Array,
+    expert_ids_by_rank: jax.Array,
+    router_weights_by_rank: jax.Array,
+    w_gate_up_by_rank: jax.Array,
+    grad_dispatch_up: jax.Array,
+    *,
+    num_experts: int,
+    capacity_factor: float = 1.25,
+    recv_capacity: int | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    return moe_dispatch_up_reference_bwd(
+        x_by_rank,
+        expert_ids_by_rank,
+        router_weights_by_rank,
+        w_gate_up_by_rank,
+        grad_dispatch_up,
         num_experts=num_experts,
         capacity_factor=capacity_factor,
         recv_capacity=recv_capacity,

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/api.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/api.py
@@ -1,0 +1,142 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Public API for the MoE dispatch-up subkernel."""
+
+from collections.abc import Callable, Sequence
+from typing import Literal, TypeAlias, cast
+
+import jax
+
+from levanter.kernels.pallas.moe_dispatch_up.errors import MosaicGpuUnsupportedError
+from levanter.kernels.pallas.moe_dispatch_up.mosaic_gpu import dispatch_prepacked_moe_dispatch_up_mosaic_gpu
+from levanter.kernels.pallas.moe_dispatch_up.reference import (
+    MoeDispatchUpLayout,
+    MoeDispatchUpPrepackedSend,
+    compute_moe_up_from_layout_reference,
+    dispatch_prepacked_moe_dispatch_up_reference,
+    moe_dispatch_up_layout_reference as _moe_dispatch_up_layout_reference,
+    prepack_moe_dispatch_up_reference,
+)
+
+Implementation: TypeAlias = Literal["reference", "mosaic_gpu"]
+
+
+def _mosaic_gpu_dispatch(
+    prepacked: MoeDispatchUpPrepackedSend,
+    *,
+    recv_capacity: int | None,
+) -> MoeDispatchUpLayout:
+    return dispatch_prepacked_moe_dispatch_up_mosaic_gpu(prepacked, recv_capacity=recv_capacity)
+
+
+DISPATCH_IMPLEMENTATIONS: dict[str, Callable[..., MoeDispatchUpLayout]] = {
+    "reference": dispatch_prepacked_moe_dispatch_up_reference,
+    "mosaic_gpu": _mosaic_gpu_dispatch,
+}
+_DEFAULT_DISPATCH_IMPLEMENTATION: tuple[Implementation, ...] = ("reference",)
+
+
+def prepack_moe_dispatch_up(
+    x_by_rank: jax.Array,
+    expert_ids_by_rank: jax.Array,
+    router_weights_by_rank: jax.Array,
+    *,
+    num_experts: int,
+    capacity_factor: float = 1.25,
+    recv_capacity: int | None = None,
+    send_capacity: int | None = None,
+) -> MoeDispatchUpPrepackedSend:
+    return prepack_moe_dispatch_up_reference(
+        x_by_rank,
+        expert_ids_by_rank,
+        router_weights_by_rank,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        recv_capacity=recv_capacity,
+        send_capacity=send_capacity,
+    )
+
+
+def moe_dispatch_up_layout(
+    prepacked: MoeDispatchUpPrepackedSend,
+    *,
+    recv_capacity: int | None = None,
+    implementation: Implementation | Sequence[Implementation | Callable[..., MoeDispatchUpLayout]] | None = None,
+) -> MoeDispatchUpLayout:
+    if implementation is None:
+        implementations: Sequence[Implementation | Callable[..., MoeDispatchUpLayout]] = (
+            _DEFAULT_DISPATCH_IMPLEMENTATION
+        )
+    elif isinstance(implementation, Sequence) and not isinstance(implementation, (str, bytes)):
+        implementations = cast(Sequence[Implementation | Callable[..., MoeDispatchUpLayout]], implementation)
+    else:
+        implementations = (cast(Implementation, implementation),)
+
+    errors: list[Exception] = []
+    explicit_single = implementation is not None and len(implementations) == 1
+    for impl in implementations:
+        if callable(impl):
+            try:
+                return impl(prepacked, recv_capacity=recv_capacity)
+            except MosaicGpuUnsupportedError as exc:
+                if explicit_single:
+                    raise
+                errors.append(exc)
+                continue
+        else:
+            fn = DISPATCH_IMPLEMENTATIONS.get(impl)
+            if fn is None:
+                raise ValueError(f"Unsupported MoE dispatch-up Mosaic GPU dispatch implementation: {impl!r}")
+            try:
+                return fn(prepacked, recv_capacity=recv_capacity)
+            except MosaicGpuUnsupportedError as exc:
+                if explicit_single:
+                    raise
+                errors.append(exc)
+                continue
+    if errors:
+        raise ExceptionGroup("all MoE dispatch-up Mosaic GPU dispatch implementations failed", errors)
+    raise AssertionError("no MoE dispatch-up Mosaic GPU dispatch implementations were attempted")
+
+
+def moe_dispatch_up(
+    x_by_rank: jax.Array,
+    expert_ids_by_rank: jax.Array,
+    router_weights_by_rank: jax.Array,
+    w_gate_up_by_rank: jax.Array,
+    *,
+    num_experts: int,
+    capacity_factor: float = 1.25,
+    recv_capacity: int | None = None,
+    implementation: Implementation | Sequence[Implementation | Callable[..., MoeDispatchUpLayout]] | None = None,
+) -> tuple[jax.Array, MoeDispatchUpLayout]:
+    prepacked = prepack_moe_dispatch_up(
+        x_by_rank,
+        expert_ids_by_rank,
+        router_weights_by_rank,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        recv_capacity=recv_capacity,
+    )
+    layout = moe_dispatch_up_layout(prepacked, recv_capacity=recv_capacity, implementation=implementation)
+    return compute_moe_up_from_layout_reference(layout, w_gate_up_by_rank), layout
+
+
+def moe_dispatch_up_layout_reference(
+    x_by_rank: jax.Array,
+    expert_ids_by_rank: jax.Array,
+    router_weights_by_rank: jax.Array,
+    *,
+    num_experts: int,
+    capacity_factor: float = 1.25,
+    recv_capacity: int | None = None,
+) -> MoeDispatchUpLayout:
+    return _moe_dispatch_up_layout_reference(
+        x_by_rank,
+        expert_ids_by_rank,
+        router_weights_by_rank,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        recv_capacity=recv_capacity,
+    )

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/config.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/config.py
@@ -15,7 +15,7 @@ class MoeDispatchUpConfig:
     block_m: int = 64
     block_n: int = 128
     block_k: int = 64
-    num_stages: int = 2
+    num_stages: int = 4
     prepacked_send: bool = True
     overlap_dispatch_compute: bool = False
     fuse_w13_silu: bool = False

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/config.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/config.py
@@ -1,0 +1,32 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Configuration for the experimental MoE dispatch-up subkernel."""
+
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True, slots=True)
+class MoeDispatchUpConfig:
+    """Static options for the single-node MoE dispatch-up prototype."""
+
+    ep_size: int = 8
+    top_k: int = 4
+    block_m: int = 64
+    block_n: int = 128
+    block_k: int = 64
+    num_stages: int = 2
+    prepacked_send: bool = True
+    overlap_dispatch_compute: bool = False
+    fuse_w13_silu: bool = False
+    backward_impl: str = "reference"
+    backward_dx_transport: str = "two_stage"
+    save_recv_x: bool = True
+    save_gate_up: bool = False
+    save_h: bool = True
+    static_capacity_factor: float = 1.25
+    fail_on_overflow: bool = True
+
+    @classmethod
+    def get_default(cls) -> "MoeDispatchUpConfig":
+        return cls()

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/errors.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/errors.py
@@ -1,0 +1,8 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Shared exceptions for the MoE dispatch-up subkernel."""
+
+
+class MosaicGpuUnsupportedError(NotImplementedError):
+    """Raised when the MoE dispatch-up Mosaic GPU backend is requested but unavailable."""

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -16,6 +16,7 @@ from jax.experimental.pallas.ops.gpu.ragged_dot_mgpu import GroupInfo
 from levanter.kernels.pallas.moe_dispatch_up.errors import MosaicGpuUnsupportedError
 from levanter.kernels.pallas.moe_dispatch_up.reference import (
     MoeDispatchUpLayout,
+    MoeDispatchUpSourceExpertPrepackedSend,
     MoeDispatchUpPrepackedSend,
     dispatch_prepacked_moe_dispatch_up_reference,
 )
@@ -958,6 +959,253 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local(
         expert_base,
         recv_source_expert_base,
         recv_source_expert_count,
+        axis_name=axis_name,
+        recv_capacity=recv_capacity,
+        ready_block_m=ready_block_m,
+        rows_per_program=rows_per_program,
+    )
+
+
+def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
+    send_x_by_dst_expert: jax.Array,
+    send_src_token_idx_by_dst_expert: jax.Array,
+    send_topk_slot_by_dst_expert: jax.Array,
+    send_router_weight_by_dst_expert: jax.Array,
+    send_row_base_by_dst_expert: jax.Array,
+    send_count_by_dst_expert: jax.Array,
+    rows_per_expert: jax.Array,
+    expert_base: jax.Array,
+    recv_source_expert_base: jax.Array,
+    recv_source_expert_count: jax.Array,
+    *,
+    axis_name: str,
+    recv_capacity: int,
+    ready_block_m: int = 64,
+    rows_per_program: int = 1,
+) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
+    """Compact source/expert remote dispatch with readiness metadata."""
+
+    if rows_per_program < 1:
+        raise ValueError(f"rows_per_program must be positive, got {rows_per_program}")
+    ep_size, local_experts, source_expert_capacity, hidden = send_x_by_dst_expert.shape
+    copy_cols = 256 if hidden >= 256 and hidden % 256 == 0 else hidden
+    recv_blocks = math.ceil(recv_capacity / ready_block_m)
+    copy_chunks = math.ceil(source_expert_capacity / rows_per_program)
+    zero_programs = math.ceil(recv_capacity / rows_per_program)
+    copy_programs = local_experts * copy_chunks
+    grid_rows = max(zero_programs, copy_programs, local_experts, recv_blocks)
+    ready_rows = jnp.minimum(jnp.sum(rows_per_expert, dtype=jnp.int32), jnp.int32(recv_capacity))
+
+    def kernel_body(
+        send_x_ref,
+        send_src_token_idx_ref,
+        send_topk_slot_ref,
+        send_router_weight_ref,
+        send_row_base_ref,
+        send_count_ref,
+        recv_source_expert_base_ref,
+        recv_source_expert_count_ref,
+        ready_rows_ref,
+        recv_x_ref,
+        recv_valid_count_ref,
+        recv_local_expert_ref,
+        recv_src_rank_ref,
+        recv_src_token_idx_ref,
+        recv_topk_slot_ref,
+        recv_router_weight_ref,
+        ready_count_ref,
+        ready_block_count_ref,
+    ):
+        recv_sem = pl.get_global(plgpu.SemaphoreType.REGULAR)
+        src_rank = lax.axis_index(axis_name)
+        dst_rank = pl.program_id(0)
+        row_or_group = pl.program_id(1)
+
+        @pl.when((dst_rank == 0) & (row_or_group < zero_programs))
+        def _zero_recv_rows():
+            row_start = row_or_group * rows_per_program
+            for row_offset in range(rows_per_program):
+                recv_row = row_start + row_offset
+
+                @pl.when(recv_row < recv_capacity)
+                def _zero_recv_row():
+                    for col_start in range(0, hidden, copy_cols):
+                        recv_x_ref.at[recv_row, pl.ds(col_start, copy_cols)][...] = jnp.zeros(
+                            (copy_cols,), dtype=recv_x_ref.dtype
+                        )
+                    recv_valid_count_ref[recv_row] = jnp.int32(0)
+                    recv_local_expert_ref[recv_row] = jnp.int32(0)
+                    recv_src_rank_ref[recv_row] = jnp.int32(0)
+                    recv_src_token_idx_ref[recv_row] = jnp.int32(0)
+                    recv_topk_slot_ref[recv_row] = jnp.int32(0)
+                    recv_router_weight_ref[recv_row] = jnp.zeros((), dtype=recv_router_weight_ref.dtype)
+
+        @pl.when(row_or_group < local_experts)
+        def _zero_ready_count():
+            ready_count_ref[dst_rank, row_or_group] = jnp.int32(0)
+
+        @pl.when((dst_rank == 0) & (row_or_group < recv_blocks))
+        def _zero_ready_block_count():
+            ready_block_count_ref[row_or_group] = jnp.int32(0)
+
+        pl.semaphore_signal(recv_sem, device_id=dst_rank)
+        pl.semaphore_wait(recv_sem, value=ep_size * grid_rows, decrement=False)
+
+        remote_recv_x = plgpu.remote_ref(recv_x_ref, jnp.int32(dst_rank))
+        remote_recv_valid_count = plgpu.remote_ref(recv_valid_count_ref, jnp.int32(dst_rank))
+        remote_recv_local_expert = plgpu.remote_ref(recv_local_expert_ref, jnp.int32(dst_rank))
+        remote_recv_src_rank = plgpu.remote_ref(recv_src_rank_ref, jnp.int32(dst_rank))
+        remote_recv_src_token_idx = plgpu.remote_ref(recv_src_token_idx_ref, jnp.int32(dst_rank))
+        remote_recv_topk_slot = plgpu.remote_ref(recv_topk_slot_ref, jnp.int32(dst_rank))
+        remote_recv_router_weight = plgpu.remote_ref(recv_router_weight_ref, jnp.int32(dst_rank))
+
+        @pl.when(row_or_group < copy_programs)
+        def _copy_source_expert_rows():
+            local_expert = row_or_group // copy_chunks
+            chunk = row_or_group - local_expert * copy_chunks
+            row_start = chunk * rows_per_program
+            count = send_count_ref[dst_rank, local_expert]
+            dst_base = send_row_base_ref[dst_rank, local_expert]
+
+            for row_offset in range(rows_per_program):
+                source_expert_row = row_start + row_offset
+                safe_row = jnp.minimum(source_expert_row, jnp.int32(source_expert_capacity - 1))
+                dst_row = dst_base + source_expert_row
+                send_valid = (source_expert_row < count) & (dst_row < recv_capacity)
+
+                @pl.when(send_valid)
+                def _copy_row_to_recv():
+                    for col_start in range(0, hidden, copy_cols):
+                        remote_recv_x.at[dst_row, pl.ds(col_start, copy_cols)][...] = send_x_ref.at[
+                            dst_rank, local_expert, safe_row, pl.ds(col_start, copy_cols)
+                        ][...]
+                    remote_recv_valid_count[dst_row] = jnp.int32(1)
+                    remote_recv_local_expert[dst_row] = local_expert
+                    remote_recv_src_rank[dst_row] = src_rank
+                    remote_recv_src_token_idx[dst_row] = send_src_token_idx_ref[dst_rank, local_expert, safe_row]
+                    remote_recv_topk_slot[dst_row] = send_topk_slot_ref[dst_rank, local_expert, safe_row]
+                    remote_recv_router_weight[dst_row] = send_router_weight_ref[dst_rank, local_expert, safe_row]
+
+        pl.semaphore_signal(recv_sem, device_id=dst_rank)
+        pl.semaphore_wait(recv_sem, value=2 * ep_size * grid_rows, decrement=False)
+
+        @pl.when(row_or_group < local_experts)
+        def _mark_ready_count():
+            base = recv_source_expert_base_ref[dst_rank, row_or_group]
+            count = recv_source_expert_count_ref[dst_rank, row_or_group]
+            remaining_capacity = jnp.maximum(jnp.int32(recv_capacity) - base, jnp.int32(0))
+            ready_count_ref[dst_rank, row_or_group] = jnp.minimum(count, remaining_capacity)
+
+        @pl.when((dst_rank == 0) & (row_or_group < recv_blocks))
+        def _mark_ready_block_count():
+            block_start = row_or_group * ready_block_m
+            remaining_rows = jnp.maximum(ready_rows_ref[()] - block_start, jnp.int32(0))
+            ready_block_count_ref[row_or_group] = jnp.minimum(remaining_rows, jnp.int32(ready_block_m))
+
+    (
+        recv_x,
+        recv_valid_count,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        ready_count,
+        ready_block_count,
+    ) = plgpu.kernel(
+        kernel_body,
+        out_shape=[
+            jax.ShapeDtypeStruct((recv_capacity, hidden), send_x_by_dst_expert.dtype),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), send_router_weight_by_dst_expert.dtype),
+            jax.ShapeDtypeStruct((ep_size, local_experts), jnp.int32),
+            jax.ShapeDtypeStruct((recv_blocks,), jnp.int32),
+        ],
+        grid=(ep_size, grid_rows),
+        grid_names=("dst", "row_or_group"),
+        compiler_params=plgpu.CompilerParams(
+            lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
+        ),
+    )(
+        send_x_by_dst_expert,
+        send_src_token_idx_by_dst_expert,
+        send_topk_slot_by_dst_expert,
+        send_router_weight_by_dst_expert,
+        send_row_base_by_dst_expert,
+        send_count_by_dst_expert,
+        recv_source_expert_base,
+        recv_source_expert_count,
+        ready_rows,
+    )
+    overflow_count = jnp.maximum(jnp.sum(rows_per_expert, dtype=jnp.int32) - recv_capacity, 0)
+    layout = MoeDispatchUpLayout(
+        recv_x,
+        recv_valid_count > 0,
+        rows_per_expert,
+        expert_base,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        overflow_count,
+    )
+    return layout, ready_count, ready_block_count
+
+
+def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
+    prepacked: MoeDispatchUpSourceExpertPrepackedSend,
+    *,
+    axis_name: str,
+    recv_capacity: int,
+    ready_block_m: int = 64,
+    rows_per_program: int = 1,
+) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
+    """Compact source/expert dispatch plus source/expert and block ready counts."""
+
+    _require_mgpu_runtime()
+    if prepacked.send_x_by_dst_expert.ndim != 4:
+        raise ValueError(
+            "local compact send_x_by_dst_expert must have shape [EP, EL, C, D], "
+            f"got {prepacked.send_x_by_dst_expert.shape}"
+        )
+    ep_size, local_experts, _capacity, _hidden = prepacked.send_x_by_dst_expert.shape
+    if prepacked.send_count_by_dst_expert.shape != (ep_size, local_experts):
+        raise ValueError(
+            "local send_count_by_dst_expert must have shape "
+            f"{(ep_size, local_experts)}, got {prepacked.send_count_by_dst_expert.shape}"
+        )
+    if prepacked.send_row_base_by_dst_expert.shape != (ep_size, local_experts):
+        raise ValueError(
+            "local send_row_base_by_dst_expert must have shape "
+            f"{(ep_size, local_experts)}, got {prepacked.send_row_base_by_dst_expert.shape}"
+        )
+    if prepacked.recv_source_expert_base.shape != (ep_size, local_experts):
+        raise ValueError(
+            "local recv_source_expert_base must have shape "
+            f"{(ep_size, local_experts)}, got {prepacked.recv_source_expert_base.shape}"
+        )
+    if prepacked.recv_source_expert_count.shape != (ep_size, local_experts):
+        raise ValueError(
+            "local recv_source_expert_count must have shape "
+            f"{(ep_size, local_experts)}, got {prepacked.recv_source_expert_count.shape}"
+        )
+
+    return _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
+        prepacked.send_x_by_dst_expert,
+        prepacked.send_src_token_idx_by_dst_expert,
+        prepacked.send_topk_slot_by_dst_expert,
+        prepacked.send_router_weight_by_dst_expert,
+        prepacked.send_row_base_by_dst_expert,
+        prepacked.send_count_by_dst_expert,
+        prepacked.rows_per_expert,
+        prepacked.expert_base,
+        prepacked.recv_source_expert_base,
+        prepacked.recv_source_expert_count,
         axis_name=axis_name,
         recv_capacity=recv_capacity,
         ready_block_m=ready_block_m,

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -430,12 +430,15 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
     *,
     axis_name: str,
     recv_capacity: int,
-) -> tuple[MoeDispatchUpLayout, jax.Array]:
+    ready_block_m: int = 64,
+) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
     """Scratch dispatch that exposes clipped ready rows per source/expert."""
 
     ep_size, send_capacity, hidden = send_x_by_dst.shape
     local_experts = rows_per_expert.shape[0]
-    grid_rows = max(send_capacity, local_experts)
+    recv_blocks = math.ceil(recv_capacity / ready_block_m)
+    grid_rows = max(send_capacity, local_experts, recv_blocks)
+    ready_rows = jnp.minimum(jnp.sum(rows_per_expert, dtype=jnp.int32), jnp.int32(recv_capacity))
 
     def kernel_body(
         send_x_ref,
@@ -449,6 +452,7 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
         send_expert_count_ref,
         recv_source_expert_base_ref,
         recv_source_expert_count_ref,
+        ready_rows_ref,
         recv_x_ref,
         recv_valid_count_ref,
         recv_local_expert_ref,
@@ -457,6 +461,7 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
         recv_topk_slot_ref,
         recv_router_weight_ref,
         ready_count_ref,
+        ready_block_count_ref,
         scratch_x_ref,
         scratch_count_ref,
         scratch_dst_row_ref,
@@ -484,6 +489,10 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
         @pl.when(row_or_expert < local_experts)
         def _zero_ready_count():
             ready_count_ref[peer_rank, row_or_expert] = jnp.int32(0)
+
+        @pl.when((peer_rank == 0) & (row_or_expert < recv_blocks))
+        def _zero_ready_block_count():
+            ready_block_count_ref[row_or_expert] = jnp.int32(0)
 
         remote_scratch_x = plgpu.remote_ref(scratch_x_ref, jnp.int32(peer_rank))
         remote_scratch_count = plgpu.remote_ref(scratch_count_ref, jnp.int32(peer_rank))
@@ -553,6 +562,12 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
             remaining_capacity = jnp.maximum(jnp.int32(recv_capacity) - base, jnp.int32(0))
             ready_count_ref[peer_rank, row_or_expert] = jnp.minimum(count, remaining_capacity)
 
+        @pl.when((peer_rank == 0) & (row_or_expert < recv_blocks))
+        def _mark_ready_block_count():
+            block_start = row_or_expert * ready_block_m
+            remaining_rows = jnp.maximum(ready_rows_ref[()] - block_start, jnp.int32(0))
+            ready_block_count_ref[row_or_expert] = jnp.minimum(remaining_rows, jnp.int32(ready_block_m))
+
     (
         recv_x,
         recv_valid_count,
@@ -562,6 +577,7 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
         recv_topk_slot,
         recv_router_weight,
         ready_count,
+        ready_block_count,
         _scratch_x,
         _scratch_count,
         _scratch_dst_row,
@@ -580,6 +596,7 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
             jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
             jax.ShapeDtypeStruct((recv_capacity,), send_router_weight_by_dst.dtype),
             jax.ShapeDtypeStruct((ep_size, local_experts), jnp.int32),
+            jax.ShapeDtypeStruct((recv_blocks,), jnp.int32),
             jax.ShapeDtypeStruct((ep_size, send_capacity, hidden), send_x_by_dst.dtype),
             jax.ShapeDtypeStruct((ep_size,), jnp.int32),
             jax.ShapeDtypeStruct((ep_size, send_capacity), jnp.int32),
@@ -605,6 +622,7 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
         send_expert_count_by_dst,
         recv_source_expert_base,
         recv_source_expert_count,
+        ready_rows,
     )
     overflow_count = jnp.maximum(jnp.sum(rows_per_expert, dtype=jnp.int32) - recv_capacity, 0)
     layout = MoeDispatchUpLayout(
@@ -619,7 +637,7 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
         recv_router_weight,
         overflow_count,
     )
-    return layout, ready_count
+    return layout, ready_count, ready_block_count
 
 
 def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local(
@@ -639,7 +657,8 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local(
     *,
     axis_name: str,
     recv_capacity: int,
-) -> tuple[MoeDispatchUpLayout, jax.Array]:
+    ready_block_m: int = 64,
+) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
     """Scratch dispatch plus source/expert ready counts for overlap bring-up."""
 
     _require_mgpu_runtime()
@@ -684,6 +703,7 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local(
         recv_source_expert_count,
         axis_name=axis_name,
         recv_capacity=recv_capacity,
+        ready_block_m=ready_block_m,
     )
 
 

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -1564,6 +1564,133 @@ def compute_moe_up_mosaic_gpu_local(
     return jnp.where(valid_rows[:, None], out, jnp.zeros((), dtype=out.dtype))
 
 
+def compute_moe_up_mosaic_gpu_source_expert_padded_local(
+    compact_x: jax.Array,
+    rows_per_source_expert: jax.Array,
+    w_gate_up_local: jax.Array,
+    *,
+    block_m: int = 64,
+    block_n: int = 64,
+    block_k: int = 64,
+    max_concurrent_steps: int = 2,
+    grid_block_n: int = 1,
+) -> jax.Array:
+    """Local W13/SiLU over padded source/expert groups without duplicating weights."""
+
+    _require_mgpu_runtime()
+    if compact_x.ndim != 2:
+        raise ValueError(f"compact_x must have shape [R, D], got {compact_x.shape}")
+    if rows_per_source_expert.ndim != 1:
+        raise ValueError(
+            "rows_per_source_expert must have shape [source_expert_groups], " f"got {rows_per_source_expert.shape}"
+        )
+    if w_gate_up_local.ndim != 3:
+        raise ValueError(f"w_gate_up_local must have shape [EL, D, 2I], got {w_gate_up_local.shape}")
+    recv_capacity, hidden = compact_x.shape
+    local_experts, hidden_2, gate_up = w_gate_up_local.shape
+    source_expert_groups = rows_per_source_expert.shape[0]
+    if source_expert_groups % local_experts != 0:
+        raise ValueError(
+            "source/expert group count must be divisible by local expert count; "
+            f"got {source_expert_groups} groups and {local_experts} local experts"
+        )
+    if hidden != hidden_2:
+        raise ValueError(f"compact_x hidden={hidden} must match w_gate_up_local hidden={hidden_2}")
+    if gate_up % 2 != 0:
+        raise ValueError(f"w_gate_up_local last dimension must be even, got {gate_up}")
+    if hidden % block_k != 0:
+        raise ValueError(f"hidden={hidden} must be divisible by block_k={block_k}")
+    intermediate = gate_up // 2
+
+    def kernel_body(rows_per_source_expert_gmem, compact_x_gmem, w_gate_up_gmem, out_gmem):
+        grid_m = pl.cdiv(recv_capacity, block_m) + source_expert_groups - 1
+        grid_n = pl.cdiv(intermediate, block_n)
+        grid = (grid_m * grid_n,)
+
+        @plgpu.nd_loop(grid, collective_axes="sm")
+        def mn_loop(loop_info: plgpu.NDLoopInfo):
+            mi, ni = plgpu.planar_snake(loop_info.index[0], (grid_m, grid_n), 1, grid_block_n)
+            group_info = GroupInfo.create(rows_per_source_expert_gmem, block_m, mi)
+            local_expert = group_info.group_id % local_experts
+
+            def acc_scope(gate_acc_ref, up_acc_ref):
+                def pipeline_body(_, x_smem, gate_w_smem, up_w_smem):
+                    plgpu.wgmma(gate_acc_ref, x_smem, gate_w_smem)
+                    plgpu.wgmma(up_acc_ref, x_smem, up_w_smem)
+
+                gate_w_ref = w_gate_up_gmem.at[local_expert, :, pl.ds(0, intermediate)]
+                up_w_ref = w_gate_up_gmem.at[local_expert, :, pl.ds(intermediate, intermediate)]
+                plgpu.emit_pipeline(
+                    pipeline_body,
+                    grid=(hidden // block_k,),
+                    in_specs=[
+                        plgpu.BlockSpec(
+                            (block_m, block_k),
+                            lambda k: (group_info.block, k),
+                            delay_release=1,
+                        ),
+                        plgpu.BlockSpec(
+                            (block_k, block_n),
+                            lambda k: (k, ni),
+                            delay_release=1,
+                        ),
+                        plgpu.BlockSpec(
+                            (block_k, block_n),
+                            lambda k: (k, ni),
+                            delay_release=1,
+                        ),
+                    ],
+                    max_concurrent_steps=max_concurrent_steps,
+                )(compact_x_gmem, gate_w_ref, up_w_ref)
+                return gate_acc_ref[...], up_acc_ref[...]
+
+            gate_acc, up_acc = pl.run_scoped(
+                acc_scope,
+                plgpu.ACC((block_m, block_n), jnp.float32),
+                plgpu.ACC((block_m, block_n), jnp.float32),
+            )
+
+            @functools.partial(pl.run_scoped, out_smem=plgpu.SMEM((block_m, block_n), dtype=out_gmem.dtype))
+            def store_scope(out_smem):
+                activated = jax.nn.silu(gate_acc) * up_acc
+                out_smem[...] = activated.astype(out_smem.dtype)
+                plgpu.commit_smem()
+
+                smem_start = group_info.start_within_block
+                remaining_rows = min(block_m, recv_capacity)
+                while remaining_rows > 0:
+                    const_rows_len = 1 << int(math.log2(remaining_rows))
+                    remaining_rows //= 2
+
+                    @pl.when(group_info.actual_size & const_rows_len != 0)
+                    def _():
+                        out_smem_slice = out_smem.at[pl.ds(smem_start, const_rows_len)]
+                        out_gmem_slice = out_gmem.at[
+                            pl.ds(group_info.block_start + smem_start, const_rows_len),
+                            pl.ds(ni * block_n, block_n),
+                        ]
+                        plgpu.copy_smem_to_gmem(out_smem_slice, out_gmem_slice)
+
+                    smem_start += group_info.actual_size & const_rows_len
+                plgpu.wait_smem_to_gmem(0, wait_read_only=True)
+
+    num_sms = jax.local_devices()[0].core_count
+    kernel = plgpu.kernel(
+        kernel_body,
+        out_shape=jax.ShapeDtypeStruct((recv_capacity, intermediate), compact_x.dtype),
+        grid=(num_sms,),
+        grid_names=("sm",),
+        compiler_params=plgpu.CompilerParams(
+            lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
+        ),
+    )
+    out = kernel(rows_per_source_expert, compact_x, w_gate_up_local)
+    valid_rows = jnp.arange(recv_capacity, dtype=jnp.int32) < jnp.minimum(
+        jnp.sum(rows_per_source_expert, dtype=jnp.int32), recv_capacity
+    )
+    return jnp.where(valid_rows[:, None], out, jnp.zeros((), dtype=out.dtype))
+
+
 def compute_moe_up_mosaic_gpu_ready_local(
     recv_x: jax.Array,
     ready_count: jax.Array,

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -727,6 +727,244 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local(
     )
 
 
+def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local(
+    send_x_by_dst: jax.Array,
+    send_row_by_dst: jax.Array,
+    send_local_expert_by_dst: jax.Array,
+    send_src_token_idx_by_dst: jax.Array,
+    send_topk_slot_by_dst: jax.Array,
+    send_router_weight_by_dst: jax.Array,
+    send_count_by_dst: jax.Array,
+    rows_per_expert: jax.Array,
+    expert_base: jax.Array,
+    recv_source_expert_base: jax.Array,
+    recv_source_expert_count: jax.Array,
+    *,
+    axis_name: str,
+    recv_capacity: int,
+    ready_block_m: int = 64,
+    rows_per_program: int = 1,
+) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
+    """Direct remote dispatch that exposes clipped readiness metadata."""
+
+    if rows_per_program < 1:
+        raise ValueError(f"rows_per_program must be positive, got {rows_per_program}")
+    ep_size, send_capacity, hidden = send_x_by_dst.shape
+    local_experts = rows_per_expert.shape[0]
+    recv_blocks = math.ceil(recv_capacity / ready_block_m)
+    send_programs = math.ceil(send_capacity / rows_per_program)
+    zero_programs = math.ceil(recv_capacity / rows_per_program)
+    grid_rows = max(send_programs, zero_programs, local_experts, recv_blocks)
+    ready_rows = jnp.minimum(jnp.sum(rows_per_expert, dtype=jnp.int32), jnp.int32(recv_capacity))
+
+    def kernel_body(
+        send_x_ref,
+        send_row_ref,
+        send_local_expert_ref,
+        send_src_token_idx_ref,
+        send_topk_slot_ref,
+        send_router_weight_ref,
+        send_count_ref,
+        recv_source_expert_base_ref,
+        recv_source_expert_count_ref,
+        ready_rows_ref,
+        recv_x_ref,
+        recv_valid_count_ref,
+        recv_local_expert_ref,
+        recv_src_rank_ref,
+        recv_src_token_idx_ref,
+        recv_topk_slot_ref,
+        recv_router_weight_ref,
+        ready_count_ref,
+        ready_block_count_ref,
+    ):
+        recv_sem = pl.get_global(plgpu.SemaphoreType.REGULAR)
+        src_rank = lax.axis_index(axis_name)
+        peer_rank = pl.program_id(0)
+        row_or_expert = pl.program_id(1)
+        row_start = row_or_expert * rows_per_program
+
+        @pl.when(row_or_expert < zero_programs)
+        def _zero_recv_rows():
+            for row_offset in range(rows_per_program):
+                recv_row = row_start + row_offset
+
+                @pl.when(recv_row < recv_capacity)
+                def _zero_recv_row():
+                    recv_x_ref.at[recv_row, pl.ds(0, hidden)][...] = jnp.zeros((hidden,), dtype=recv_x_ref.dtype)
+                    recv_valid_count_ref[recv_row] = jnp.int32(0)
+                    recv_local_expert_ref[recv_row] = jnp.int32(0)
+                    recv_src_rank_ref[recv_row] = jnp.int32(0)
+                    recv_src_token_idx_ref[recv_row] = jnp.int32(0)
+                    recv_topk_slot_ref[recv_row] = jnp.int32(0)
+                    recv_router_weight_ref[recv_row] = jnp.zeros((), dtype=recv_router_weight_ref.dtype)
+
+        @pl.when(row_or_expert < local_experts)
+        def _zero_ready_count():
+            ready_count_ref[peer_rank, row_or_expert] = jnp.int32(0)
+
+        @pl.when((peer_rank == 0) & (row_or_expert < recv_blocks))
+        def _zero_ready_block_count():
+            ready_block_count_ref[row_or_expert] = jnp.int32(0)
+
+        remote_recv_x = plgpu.remote_ref(recv_x_ref, jnp.int32(peer_rank))
+        remote_recv_valid_count = plgpu.remote_ref(recv_valid_count_ref, jnp.int32(peer_rank))
+        remote_recv_local_expert = plgpu.remote_ref(recv_local_expert_ref, jnp.int32(peer_rank))
+        remote_recv_src_rank = plgpu.remote_ref(recv_src_rank_ref, jnp.int32(peer_rank))
+        remote_recv_src_token_idx = plgpu.remote_ref(recv_src_token_idx_ref, jnp.int32(peer_rank))
+        remote_recv_topk_slot = plgpu.remote_ref(recv_topk_slot_ref, jnp.int32(peer_rank))
+        remote_recv_router_weight = plgpu.remote_ref(recv_router_weight_ref, jnp.int32(peer_rank))
+
+        pl.semaphore_signal(recv_sem, device_id=jnp.int32(peer_rank))
+        pl.semaphore_wait(recv_sem, value=ep_size * grid_rows, decrement=False)
+
+        @pl.when(row_or_expert < send_programs)
+        def _copy_source_rows():
+            for row_offset in range(rows_per_program):
+                send_row = row_start + row_offset
+                safe_send_row = jnp.minimum(send_row, jnp.int32(send_capacity - 1))
+                dst_row = send_row_ref[peer_rank, safe_send_row]
+                send_valid = (send_row < send_count_ref[peer_rank]) & (dst_row < recv_capacity)
+
+                @pl.when(send_valid)
+                def _copy_row_to_recv():
+                    remote_recv_x.at[dst_row, pl.ds(0, hidden)][...] = send_x_ref.at[
+                        peer_rank, safe_send_row, pl.ds(0, hidden)
+                    ][...]
+                    remote_recv_valid_count[dst_row] = jnp.int32(1)
+                    remote_recv_local_expert[dst_row] = send_local_expert_ref[peer_rank, safe_send_row]
+                    remote_recv_src_rank[dst_row] = src_rank
+                    remote_recv_src_token_idx[dst_row] = send_src_token_idx_ref[peer_rank, safe_send_row]
+                    remote_recv_topk_slot[dst_row] = send_topk_slot_ref[peer_rank, safe_send_row]
+                    remote_recv_router_weight[dst_row] = send_router_weight_ref[peer_rank, safe_send_row]
+
+        pl.semaphore_signal(recv_sem, device_id=jnp.int32(peer_rank))
+        pl.semaphore_wait(recv_sem, value=2 * ep_size * grid_rows, decrement=False)
+
+        @pl.when(row_or_expert < local_experts)
+        def _mark_ready_count():
+            base = recv_source_expert_base_ref[peer_rank, row_or_expert]
+            count = recv_source_expert_count_ref[peer_rank, row_or_expert]
+            remaining_capacity = jnp.maximum(jnp.int32(recv_capacity) - base, jnp.int32(0))
+            ready_count_ref[peer_rank, row_or_expert] = jnp.minimum(count, remaining_capacity)
+
+        @pl.when((peer_rank == 0) & (row_or_expert < recv_blocks))
+        def _mark_ready_block_count():
+            block_start = row_or_expert * ready_block_m
+            remaining_rows = jnp.maximum(ready_rows_ref[()] - block_start, jnp.int32(0))
+            ready_block_count_ref[row_or_expert] = jnp.minimum(remaining_rows, jnp.int32(ready_block_m))
+
+    (
+        recv_x,
+        recv_valid_count,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        ready_count,
+        ready_block_count,
+    ) = plgpu.kernel(
+        kernel_body,
+        out_shape=[
+            jax.ShapeDtypeStruct((recv_capacity, hidden), send_x_by_dst.dtype),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), send_router_weight_by_dst.dtype),
+            jax.ShapeDtypeStruct((ep_size, local_experts), jnp.int32),
+            jax.ShapeDtypeStruct((recv_blocks,), jnp.int32),
+        ],
+        grid=(ep_size, grid_rows),
+        grid_names=("peer", "row_or_expert"),
+        compiler_params=plgpu.CompilerParams(
+            lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
+        ),
+    )(
+        send_x_by_dst,
+        send_row_by_dst,
+        send_local_expert_by_dst,
+        send_src_token_idx_by_dst,
+        send_topk_slot_by_dst,
+        send_router_weight_by_dst,
+        send_count_by_dst,
+        recv_source_expert_base,
+        recv_source_expert_count,
+        ready_rows,
+    )
+    overflow_count = jnp.maximum(jnp.sum(rows_per_expert, dtype=jnp.int32) - recv_capacity, 0)
+    layout = MoeDispatchUpLayout(
+        recv_x,
+        recv_valid_count > 0,
+        rows_per_expert,
+        expert_base,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        overflow_count,
+    )
+    return layout, ready_count, ready_block_count
+
+
+def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local(
+    send_x_by_dst: jax.Array,
+    send_row_by_dst: jax.Array,
+    send_local_expert_by_dst: jax.Array,
+    send_src_token_idx_by_dst: jax.Array,
+    send_topk_slot_by_dst: jax.Array,
+    send_router_weight_by_dst: jax.Array,
+    send_count_by_dst: jax.Array,
+    rows_per_expert: jax.Array,
+    expert_base: jax.Array,
+    recv_source_expert_base: jax.Array,
+    recv_source_expert_count: jax.Array,
+    *,
+    axis_name: str,
+    recv_capacity: int,
+    ready_block_m: int = 64,
+    rows_per_program: int = 1,
+) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
+    """Direct remote dispatch plus source/expert and block ready counts."""
+
+    _require_mgpu_runtime()
+    if send_x_by_dst.ndim != 3:
+        raise ValueError(f"send_x_by_dst must have shape [EP, S, D], got {send_x_by_dst.shape}")
+    ep_size, _send_capacity, _hidden = send_x_by_dst.shape
+    local_experts = rows_per_expert.shape[0]
+    if recv_source_expert_base.shape != (ep_size, local_experts):
+        raise ValueError(
+            "recv_source_expert_base must have shape "
+            f"{(ep_size, local_experts)}, got {recv_source_expert_base.shape}"
+        )
+    if recv_source_expert_count.shape != (ep_size, local_experts):
+        raise ValueError(
+            "recv_source_expert_count must have shape "
+            f"{(ep_size, local_experts)}, got {recv_source_expert_count.shape}"
+        )
+
+    return _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_direct_ready_local(
+        send_x_by_dst,
+        send_row_by_dst,
+        send_local_expert_by_dst,
+        send_src_token_idx_by_dst,
+        send_topk_slot_by_dst,
+        send_router_weight_by_dst,
+        send_count_by_dst,
+        rows_per_expert,
+        expert_base,
+        recv_source_expert_base,
+        recv_source_expert_count,
+        axis_name=axis_name,
+        recv_capacity=recv_capacity,
+        ready_block_m=ready_block_m,
+        rows_per_program=rows_per_program,
+    )
+
+
 def compute_moe_up_mosaic_gpu_local(
     recv_x: jax.Array,
     rows_per_expert: jax.Array,

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -1441,6 +1441,72 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_tiled_local(
     )
 
 
+def compact_source_expert_ring_transport_mosaic_gpu_local(
+    send_x_by_dst_expert: jax.Array,
+    send_count_by_dst_expert: jax.Array,
+    *,
+    axis_name: str,
+) -> tuple[jax.Array, jax.Array]:
+    """Ordered ring-step transport for compact source/expert MoE payloads."""
+
+    _require_mgpu_runtime()
+    if send_x_by_dst_expert.ndim != 4:
+        raise ValueError("send_x_by_dst_expert must have shape [EP, EL, C, D], " f"got {send_x_by_dst_expert.shape}")
+    ep_size, local_experts, source_expert_capacity, hidden = send_x_by_dst_expert.shape
+    if send_count_by_dst_expert.shape != (ep_size, local_experts):
+        raise ValueError(
+            "send_count_by_dst_expert must have shape "
+            f"{(ep_size, local_experts)}, got {send_count_by_dst_expert.shape}"
+        )
+    num_sms = jax.local_devices()[0].core_count
+    rows_per_destination = local_experts * source_expert_capacity
+
+    def kernel_body(send_x_ref, send_count_ref, recv_x_ref, recv_count_ref):
+        received_sem = pl.get_global(plgpu.SemaphoreType.REGULAR)
+        src_rank = lax.axis_index(axis_name)
+        sm = pl.program_id(0)
+
+        for step in range(ep_size):
+            dst_rank = lax.rem(src_rank + step, jnp.int32(ep_size))
+            remote_recv_x = plgpu.remote_ref(recv_x_ref, dst_rank)
+            remote_recv_count = plgpu.remote_ref(recv_count_ref, dst_rank)
+
+            @pl.when(sm == 0)
+            def _copy_counts():
+                for local_expert in range(local_experts):
+                    remote_recv_count[src_rank, local_expert] = send_count_ref[dst_rank, local_expert]
+
+            for row_start in range(0, rows_per_destination, num_sms):
+                linear_row = row_start + sm
+
+                @pl.when(linear_row < rows_per_destination)
+                def _copy_row():
+                    local_expert = linear_row // source_expert_capacity
+                    source_expert_row = linear_row - local_expert * source_expert_capacity
+                    remote_recv_x.at[src_rank, local_expert, source_expert_row, pl.ds(0, hidden)][...] = send_x_ref.at[
+                        dst_rank, local_expert, source_expert_row, pl.ds(0, hidden)
+                    ][...]
+
+            pl.semaphore_signal(received_sem, device_id=dst_rank)
+            pl.semaphore_wait(received_sem, value=(step + 1) * num_sms, decrement=False)
+
+    return plgpu.kernel(
+        kernel_body,
+        out_shape=[
+            jax.ShapeDtypeStruct(
+                (ep_size, local_experts, source_expert_capacity, hidden),
+                send_x_by_dst_expert.dtype,
+            ),
+            jax.ShapeDtypeStruct((ep_size, local_experts), jnp.int32),
+        ],
+        grid=(num_sms,),
+        grid_names=("sm",),
+        compiler_params=plgpu.CompilerParams(
+            lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
+        ),
+    )(send_x_by_dst_expert, send_count_by_dst_expert)
+
+
 def compute_moe_up_mosaic_gpu_local(
     recv_x: jax.Array,
     rows_per_expert: jax.Array,

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -413,6 +413,280 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_local(
     )
 
 
+def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
+    send_x_by_dst: jax.Array,
+    send_row_by_dst: jax.Array,
+    send_local_expert_by_dst: jax.Array,
+    send_src_token_idx_by_dst: jax.Array,
+    send_topk_slot_by_dst: jax.Array,
+    send_router_weight_by_dst: jax.Array,
+    send_count_by_dst: jax.Array,
+    rows_per_expert: jax.Array,
+    expert_base: jax.Array,
+    send_expert_base_by_dst: jax.Array,
+    send_expert_count_by_dst: jax.Array,
+    recv_source_expert_base: jax.Array,
+    recv_source_expert_count: jax.Array,
+    *,
+    axis_name: str,
+    recv_capacity: int,
+) -> tuple[MoeDispatchUpLayout, jax.Array]:
+    """Scratch dispatch that exposes clipped ready rows per source/expert."""
+
+    ep_size, send_capacity, hidden = send_x_by_dst.shape
+    local_experts = rows_per_expert.shape[0]
+    grid_rows = max(send_capacity, local_experts)
+
+    def kernel_body(
+        send_x_ref,
+        send_row_ref,
+        send_local_expert_ref,
+        send_src_token_idx_ref,
+        send_topk_slot_ref,
+        send_router_weight_ref,
+        send_count_ref,
+        send_expert_base_ref,
+        send_expert_count_ref,
+        recv_source_expert_base_ref,
+        recv_source_expert_count_ref,
+        recv_x_ref,
+        recv_valid_count_ref,
+        recv_local_expert_ref,
+        recv_src_rank_ref,
+        recv_src_token_idx_ref,
+        recv_topk_slot_ref,
+        recv_router_weight_ref,
+        ready_count_ref,
+        scratch_x_ref,
+        scratch_count_ref,
+        scratch_dst_row_ref,
+        scratch_local_expert_ref,
+        scratch_src_token_idx_ref,
+        scratch_topk_slot_ref,
+        scratch_router_weight_ref,
+    ):
+        recv_sem = pl.get_global(plgpu.SemaphoreType.REGULAR)
+        src_rank = lax.axis_index(axis_name)
+        peer_rank = pl.program_id(0)
+        row_or_expert = pl.program_id(1)
+        linear_row = peer_rank * send_capacity + row_or_expert
+
+        @pl.when((row_or_expert < send_capacity) & (linear_row < recv_capacity))
+        def _zero_recv_row():
+            recv_x_ref.at[linear_row, pl.ds(0, hidden)][...] = jnp.zeros((hidden,), dtype=recv_x_ref.dtype)
+            recv_valid_count_ref[linear_row] = jnp.int32(0)
+            recv_local_expert_ref[linear_row] = jnp.int32(0)
+            recv_src_rank_ref[linear_row] = jnp.int32(0)
+            recv_src_token_idx_ref[linear_row] = jnp.int32(0)
+            recv_topk_slot_ref[linear_row] = jnp.int32(0)
+            recv_router_weight_ref[linear_row] = jnp.zeros((), dtype=recv_router_weight_ref.dtype)
+
+        @pl.when(row_or_expert < local_experts)
+        def _zero_ready_count():
+            ready_count_ref[peer_rank, row_or_expert] = jnp.int32(0)
+
+        remote_scratch_x = plgpu.remote_ref(scratch_x_ref, jnp.int32(peer_rank))
+        remote_scratch_count = plgpu.remote_ref(scratch_count_ref, jnp.int32(peer_rank))
+        remote_scratch_dst_row = plgpu.remote_ref(scratch_dst_row_ref, jnp.int32(peer_rank))
+        remote_scratch_local_expert = plgpu.remote_ref(scratch_local_expert_ref, jnp.int32(peer_rank))
+        remote_scratch_src_token_idx = plgpu.remote_ref(scratch_src_token_idx_ref, jnp.int32(peer_rank))
+        remote_scratch_topk_slot = plgpu.remote_ref(scratch_topk_slot_ref, jnp.int32(peer_rank))
+        remote_scratch_router_weight = plgpu.remote_ref(scratch_router_weight_ref, jnp.int32(peer_rank))
+
+        @pl.when(row_or_expert == 0)
+        def _write_count():
+            remote_scratch_count[src_rank] = send_count_ref[peer_rank]
+
+        @pl.when(row_or_expert < local_experts)
+        def _touch_source_expert_ranges():
+            # These loads keep the producer-side range contract in the compiled
+            # path; a later coordinator uses the same base/count pair to signal
+            # per-source/expert completion instead of whole-buffer completion.
+            _ = send_expert_base_ref[peer_rank, row_or_expert] + send_expert_count_ref[peer_rank, row_or_expert]
+
+        @pl.when(row_or_expert < send_capacity)
+        def _copy_source_row():
+            dst_row = send_row_ref[peer_rank, row_or_expert]
+            send_valid = (row_or_expert < send_count_ref[peer_rank]) & (dst_row < recv_capacity)
+
+            @pl.when(send_valid)
+            def _copy_row_to_scratch():
+                remote_scratch_x.at[src_rank, row_or_expert, pl.ds(0, hidden)][...] = send_x_ref.at[
+                    peer_rank, row_or_expert, pl.ds(0, hidden)
+                ][...]
+                remote_scratch_dst_row[src_rank, row_or_expert] = dst_row
+                remote_scratch_local_expert[src_rank, row_or_expert] = send_local_expert_ref[peer_rank, row_or_expert]
+                remote_scratch_src_token_idx[src_rank, row_or_expert] = send_src_token_idx_ref[
+                    peer_rank, row_or_expert
+                ]
+                remote_scratch_topk_slot[src_rank, row_or_expert] = send_topk_slot_ref[peer_rank, row_or_expert]
+                remote_scratch_router_weight[src_rank, row_or_expert] = send_router_weight_ref[
+                    peer_rank, row_or_expert
+                ]
+
+        pl.semaphore_signal(recv_sem, device_id=jnp.int32(peer_rank))
+        pl.semaphore_wait(recv_sem, value=ep_size * grid_rows, decrement=False)
+
+        @pl.when(row_or_expert < send_capacity)
+        def _compact_source_row():
+            dst_row = scratch_dst_row_ref[peer_rank, row_or_expert]
+            recv_valid = (row_or_expert < scratch_count_ref[peer_rank]) & (dst_row < recv_capacity)
+
+            @pl.when(recv_valid)
+            def _compact_row():
+                scratch_row = scratch_x_ref.at[peer_rank, row_or_expert, pl.ds(0, hidden)]
+                recv_x_ref.at[dst_row, pl.ds(0, hidden)][...] = scratch_row[...]
+                recv_valid_count_ref[dst_row] = jnp.int32(1)
+                recv_local_expert_ref[dst_row] = scratch_local_expert_ref[peer_rank, row_or_expert]
+                recv_src_rank_ref[dst_row] = jnp.int32(peer_rank)
+                recv_src_token_idx_ref[dst_row] = scratch_src_token_idx_ref[peer_rank, row_or_expert]
+                recv_topk_slot_ref[dst_row] = scratch_topk_slot_ref[peer_rank, row_or_expert]
+                recv_router_weight_ref[dst_row] = scratch_router_weight_ref[peer_rank, row_or_expert]
+
+        pl.semaphore_signal(recv_sem, device_id=src_rank)
+        pl.semaphore_wait(recv_sem, value=2 * ep_size * grid_rows, decrement=False)
+
+        @pl.when(row_or_expert < local_experts)
+        def _mark_ready_count():
+            base = recv_source_expert_base_ref[peer_rank, row_or_expert]
+            count = recv_source_expert_count_ref[peer_rank, row_or_expert]
+            remaining_capacity = jnp.maximum(jnp.int32(recv_capacity) - base, jnp.int32(0))
+            ready_count_ref[peer_rank, row_or_expert] = jnp.minimum(count, remaining_capacity)
+
+    (
+        recv_x,
+        recv_valid_count,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        ready_count,
+        _scratch_x,
+        _scratch_count,
+        _scratch_dst_row,
+        _scratch_local_expert,
+        _scratch_src_token_idx,
+        _scratch_topk_slot,
+        _scratch_router_weight,
+    ) = plgpu.kernel(
+        kernel_body,
+        out_shape=[
+            jax.ShapeDtypeStruct((recv_capacity, hidden), send_x_by_dst.dtype),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), send_router_weight_by_dst.dtype),
+            jax.ShapeDtypeStruct((ep_size, local_experts), jnp.int32),
+            jax.ShapeDtypeStruct((ep_size, send_capacity, hidden), send_x_by_dst.dtype),
+            jax.ShapeDtypeStruct((ep_size,), jnp.int32),
+            jax.ShapeDtypeStruct((ep_size, send_capacity), jnp.int32),
+            jax.ShapeDtypeStruct((ep_size, send_capacity), jnp.int32),
+            jax.ShapeDtypeStruct((ep_size, send_capacity), jnp.int32),
+            jax.ShapeDtypeStruct((ep_size, send_capacity), jnp.int32),
+            jax.ShapeDtypeStruct((ep_size, send_capacity), send_router_weight_by_dst.dtype),
+        ],
+        grid=(ep_size, grid_rows),
+        grid_names=("peer", "row_or_expert"),
+        compiler_params=plgpu.CompilerParams(
+            lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
+        ),
+    )(
+        send_x_by_dst,
+        send_row_by_dst,
+        send_local_expert_by_dst,
+        send_src_token_idx_by_dst,
+        send_topk_slot_by_dst,
+        send_router_weight_by_dst,
+        send_count_by_dst,
+        send_expert_base_by_dst,
+        send_expert_count_by_dst,
+        recv_source_expert_base,
+        recv_source_expert_count,
+    )
+    overflow_count = jnp.maximum(jnp.sum(rows_per_expert, dtype=jnp.int32) - recv_capacity, 0)
+    layout = MoeDispatchUpLayout(
+        recv_x,
+        recv_valid_count > 0,
+        rows_per_expert,
+        expert_base,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        overflow_count,
+    )
+    return layout, ready_count
+
+
+def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local(
+    send_x_by_dst: jax.Array,
+    send_row_by_dst: jax.Array,
+    send_local_expert_by_dst: jax.Array,
+    send_src_token_idx_by_dst: jax.Array,
+    send_topk_slot_by_dst: jax.Array,
+    send_router_weight_by_dst: jax.Array,
+    send_count_by_dst: jax.Array,
+    rows_per_expert: jax.Array,
+    expert_base: jax.Array,
+    send_expert_base_by_dst: jax.Array,
+    send_expert_count_by_dst: jax.Array,
+    recv_source_expert_base: jax.Array,
+    recv_source_expert_count: jax.Array,
+    *,
+    axis_name: str,
+    recv_capacity: int,
+) -> tuple[MoeDispatchUpLayout, jax.Array]:
+    """Scratch dispatch plus source/expert ready counts for overlap bring-up."""
+
+    _require_mgpu_runtime()
+    if send_x_by_dst.ndim != 3:
+        raise ValueError(f"send_x_by_dst must have shape [EP, S, D], got {send_x_by_dst.shape}")
+    ep_size, send_capacity, hidden = send_x_by_dst.shape
+    local_experts = rows_per_expert.shape[0]
+    if send_expert_base_by_dst.shape != (ep_size, local_experts):
+        raise ValueError(
+            "send_expert_base_by_dst must have shape "
+            f"{(ep_size, local_experts)}, got {send_expert_base_by_dst.shape}"
+        )
+    if send_expert_count_by_dst.shape != (ep_size, local_experts):
+        raise ValueError(
+            "send_expert_count_by_dst must have shape "
+            f"{(ep_size, local_experts)}, got {send_expert_count_by_dst.shape}"
+        )
+    if recv_source_expert_base.shape != (ep_size, local_experts):
+        raise ValueError(
+            "recv_source_expert_base must have shape "
+            f"{(ep_size, local_experts)}, got {recv_source_expert_base.shape}"
+        )
+    if recv_source_expert_count.shape != (ep_size, local_experts):
+        raise ValueError(
+            "recv_source_expert_count must have shape "
+            f"{(ep_size, local_experts)}, got {recv_source_expert_count.shape}"
+        )
+
+    return _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
+        send_x_by_dst,
+        send_row_by_dst,
+        send_local_expert_by_dst,
+        send_src_token_idx_by_dst,
+        send_topk_slot_by_dst,
+        send_router_weight_by_dst,
+        send_count_by_dst,
+        rows_per_expert,
+        expert_base,
+        send_expert_base_by_dst,
+        send_expert_count_by_dst,
+        recv_source_expert_base,
+        recv_source_expert_count,
+        axis_name=axis_name,
+        recv_capacity=recv_capacity,
+    )
+
+
 def compute_moe_up_mosaic_gpu_local(
     recv_x: jax.Array,
     rows_per_expert: jax.Array,

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -65,11 +65,10 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local(
 ) -> MoeDispatchUpLayout:
     """Shard-local MGPU remote-dispatch validation primitive.
 
-    This is milestone 1's deliberately conservative kernel: each source rank
-    receives prepacked rows for every destination rank, then remote-writes those
-    rows and metadata into the destination rank's output buffers. It is serial
-    by construction and meant to validate remote refs, semaphores, and layout
-    parity before introducing overlapped tiled copies.
+    The default `scratch` mode writes routed rows into destination-owned
+    symmetric scratch, then locally compacts them into the expert-major receive
+    layout. `row_vector` and `scalar` remain as direct remote-write diagnostic
+    modes for comparison.
     """
 
     _require_mgpu_runtime()
@@ -78,8 +77,22 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local(
     ep_size, send_capacity, hidden = send_x_by_dst.shape
     if recv_capacity is None:
         recv_capacity = send_capacity
-    if copy_mode not in ("scalar", "row_vector"):
-        raise ValueError(f"copy_mode must be 'scalar' or 'row_vector', got {copy_mode!r}")
+    if copy_mode not in ("scalar", "row_vector", "scratch"):
+        raise ValueError(f"copy_mode must be 'scalar', 'row_vector', or 'scratch', got {copy_mode!r}")
+    if copy_mode == "scratch":
+        return _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_local(
+            send_x_by_dst,
+            send_row_by_dst,
+            send_local_expert_by_dst,
+            send_src_token_idx_by_dst,
+            send_topk_slot_by_dst,
+            send_router_weight_by_dst,
+            send_count_by_dst,
+            rows_per_expert,
+            expert_base,
+            axis_name=axis_name,
+            recv_capacity=recv_capacity,
+        )
 
     def kernel_body(
         send_x_ref,
@@ -211,6 +224,168 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local(
         ],
         grid=(1,),
         grid_names=("program",),
+        compiler_params=plgpu.CompilerParams(
+            lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
+        ),
+    )(
+        send_x_by_dst,
+        send_row_by_dst,
+        send_local_expert_by_dst,
+        send_src_token_idx_by_dst,
+        send_topk_slot_by_dst,
+        send_router_weight_by_dst,
+        send_count_by_dst,
+    )
+    overflow_count = jnp.maximum(jnp.sum(rows_per_expert, dtype=jnp.int32) - recv_capacity, 0)
+    return MoeDispatchUpLayout(
+        recv_x,
+        recv_valid_count > 0,
+        rows_per_expert,
+        expert_base,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        overflow_count,
+    )
+
+
+def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_local(
+    send_x_by_dst: jax.Array,
+    send_row_by_dst: jax.Array,
+    send_local_expert_by_dst: jax.Array,
+    send_src_token_idx_by_dst: jax.Array,
+    send_topk_slot_by_dst: jax.Array,
+    send_router_weight_by_dst: jax.Array,
+    send_count_by_dst: jax.Array,
+    rows_per_expert: jax.Array,
+    expert_base: jax.Array,
+    *,
+    axis_name: str,
+    recv_capacity: int,
+) -> MoeDispatchUpLayout:
+    """Dispatch through symmetric scratch with one program per peer row."""
+
+    ep_size, send_capacity, hidden = send_x_by_dst.shape
+
+    def kernel_body(
+        send_x_ref,
+        send_row_ref,
+        send_local_expert_ref,
+        send_src_token_idx_ref,
+        send_topk_slot_ref,
+        send_router_weight_ref,
+        send_count_ref,
+        recv_x_ref,
+        recv_valid_count_ref,
+        recv_local_expert_ref,
+        recv_src_rank_ref,
+        recv_src_token_idx_ref,
+        recv_topk_slot_ref,
+        recv_router_weight_ref,
+        scratch_x_ref,
+        scratch_count_ref,
+        scratch_dst_row_ref,
+        scratch_local_expert_ref,
+        scratch_src_token_idx_ref,
+        scratch_topk_slot_ref,
+        scratch_router_weight_ref,
+    ):
+        recv_sem = pl.get_global(plgpu.SemaphoreType.REGULAR)
+        src_rank = lax.axis_index(axis_name)
+        peer_rank = pl.program_id(0)
+        send_row = pl.program_id(1)
+        linear_row = peer_rank * send_capacity + send_row
+
+        @pl.when(linear_row < recv_capacity)
+        def _zero_recv_row():
+            recv_x_ref.at[linear_row, pl.ds(0, hidden)][...] = jnp.zeros((hidden,), dtype=recv_x_ref.dtype)
+            recv_valid_count_ref[linear_row] = jnp.int32(0)
+            recv_local_expert_ref[linear_row] = jnp.int32(0)
+            recv_src_rank_ref[linear_row] = jnp.int32(0)
+            recv_src_token_idx_ref[linear_row] = jnp.int32(0)
+            recv_topk_slot_ref[linear_row] = jnp.int32(0)
+            recv_router_weight_ref[linear_row] = jnp.zeros((), dtype=recv_router_weight_ref.dtype)
+
+        remote_scratch_x = plgpu.remote_ref(scratch_x_ref, jnp.int32(peer_rank))
+        remote_scratch_count = plgpu.remote_ref(scratch_count_ref, jnp.int32(peer_rank))
+        remote_scratch_dst_row = plgpu.remote_ref(scratch_dst_row_ref, jnp.int32(peer_rank))
+        remote_scratch_local_expert = plgpu.remote_ref(scratch_local_expert_ref, jnp.int32(peer_rank))
+        remote_scratch_src_token_idx = plgpu.remote_ref(scratch_src_token_idx_ref, jnp.int32(peer_rank))
+        remote_scratch_topk_slot = plgpu.remote_ref(scratch_topk_slot_ref, jnp.int32(peer_rank))
+        remote_scratch_router_weight = plgpu.remote_ref(scratch_router_weight_ref, jnp.int32(peer_rank))
+
+        @pl.when(send_row == 0)
+        def _write_count():
+            remote_scratch_count[src_rank] = send_count_ref[peer_rank]
+
+        dst_row = send_row_ref[peer_rank, send_row]
+        send_valid = (send_row < send_count_ref[peer_rank]) & (dst_row < recv_capacity)
+
+        @pl.when(send_valid)
+        def _copy_row_to_scratch():
+            remote_scratch_x.at[src_rank, send_row, pl.ds(0, hidden)][...] = send_x_ref.at[
+                peer_rank, send_row, pl.ds(0, hidden)
+            ][...]
+            remote_scratch_dst_row[src_rank, send_row] = dst_row
+            remote_scratch_local_expert[src_rank, send_row] = send_local_expert_ref[peer_rank, send_row]
+            remote_scratch_src_token_idx[src_rank, send_row] = send_src_token_idx_ref[peer_rank, send_row]
+            remote_scratch_topk_slot[src_rank, send_row] = send_topk_slot_ref[peer_rank, send_row]
+            remote_scratch_router_weight[src_rank, send_row] = send_router_weight_ref[peer_rank, send_row]
+
+        pl.semaphore_signal(recv_sem, device_id=jnp.int32(peer_rank))
+        pl.semaphore_wait(recv_sem, value=ep_size * send_capacity, decrement=False)
+
+        dst_row = scratch_dst_row_ref[peer_rank, send_row]
+        recv_valid = (send_row < scratch_count_ref[peer_rank]) & (dst_row < recv_capacity)
+
+        @pl.when(recv_valid)
+        def _compact_row():
+            scratch_row = scratch_x_ref.at[peer_rank, send_row, pl.ds(0, hidden)]
+            recv_x_ref.at[dst_row, pl.ds(0, hidden)][...] = scratch_row[...]
+            recv_valid_count_ref[dst_row] = jnp.int32(1)
+            recv_local_expert_ref[dst_row] = scratch_local_expert_ref[peer_rank, send_row]
+            recv_src_rank_ref[dst_row] = jnp.int32(peer_rank)
+            recv_src_token_idx_ref[dst_row] = scratch_src_token_idx_ref[peer_rank, send_row]
+            recv_topk_slot_ref[dst_row] = scratch_topk_slot_ref[peer_rank, send_row]
+            recv_router_weight_ref[dst_row] = scratch_router_weight_ref[peer_rank, send_row]
+
+    (
+        recv_x,
+        recv_valid_count,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        _scratch_x,
+        _scratch_count,
+        _scratch_dst_row,
+        _scratch_local_expert,
+        _scratch_src_token_idx,
+        _scratch_topk_slot,
+        _scratch_router_weight,
+    ) = plgpu.kernel(
+        kernel_body,
+        out_shape=[
+            jax.ShapeDtypeStruct((recv_capacity, hidden), send_x_by_dst.dtype),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), send_router_weight_by_dst.dtype),
+            jax.ShapeDtypeStruct((ep_size, send_capacity, hidden), send_x_by_dst.dtype),
+            jax.ShapeDtypeStruct((ep_size,), jnp.int32),
+            jax.ShapeDtypeStruct((ep_size, send_capacity), jnp.int32),
+            jax.ShapeDtypeStruct((ep_size, send_capacity), jnp.int32),
+            jax.ShapeDtypeStruct((ep_size, send_capacity), jnp.int32),
+            jax.ShapeDtypeStruct((ep_size, send_capacity), jnp.int32),
+            jax.ShapeDtypeStruct((ep_size, send_capacity), send_router_weight_by_dst.dtype),
+        ],
+        grid=(ep_size, send_capacity),
+        grid_names=("peer", "row"),
         compiler_params=plgpu.CompilerParams(
             lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
         ),

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -1,0 +1,310 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Mosaic GPU implementation of the MoE dispatch-up subkernel."""
+
+import functools
+import math
+
+import jax
+import jax.numpy as jnp
+from jax import lax
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import mosaic_gpu as plgpu
+from jax.experimental.pallas.ops.gpu.ragged_dot_mgpu import GroupInfo
+
+from levanter.kernels.pallas.moe_dispatch_up.errors import MosaicGpuUnsupportedError
+from levanter.kernels.pallas.moe_dispatch_up.reference import (
+    MoeDispatchUpLayout,
+    MoeDispatchUpPrepackedSend,
+    dispatch_prepacked_moe_dispatch_up_reference,
+)
+
+
+def _require_mgpu_runtime() -> None:
+    gpu_devices = [device for device in jax.local_devices() if device.platform == "gpu"]
+    if len(gpu_devices) < 2:
+        raise MosaicGpuUnsupportedError(
+            "MoE dispatch-up Mosaic GPU dispatch requires at least two local GPU devices; "
+            f"found {len(gpu_devices)} GPU device(s)."
+        )
+
+
+def dispatch_prepacked_moe_dispatch_up_mosaic_gpu(
+    prepacked: MoeDispatchUpPrepackedSend,
+    *,
+    recv_capacity: int | None = None,
+) -> MoeDispatchUpLayout:
+    """Validation-slice dispatch entrypoint for the Pallas MGPU backend.
+
+    The API is intentionally separate from the reference implementation so the
+    remote-ref kernel can replace this body without changing callers or tests.
+    Until the CoreWeave validation kernel lands, explicit `mosaic_gpu` requests
+    fail fast on non-MGPU hosts and use the reference layout only as a local
+    bring-up path.
+    """
+
+    _require_mgpu_runtime()
+    return dispatch_prepacked_moe_dispatch_up_reference(prepacked, recv_capacity=recv_capacity)
+
+
+def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local(
+    send_x_by_dst: jax.Array,
+    send_row_by_dst: jax.Array,
+    send_local_expert_by_dst: jax.Array,
+    send_src_token_idx_by_dst: jax.Array,
+    send_topk_slot_by_dst: jax.Array,
+    send_router_weight_by_dst: jax.Array,
+    send_count_by_dst: jax.Array,
+    rows_per_expert: jax.Array,
+    expert_base: jax.Array,
+    *,
+    axis_name: str,
+    recv_capacity: int | None = None,
+) -> MoeDispatchUpLayout:
+    """Shard-local MGPU remote-dispatch validation primitive.
+
+    This is milestone 1's deliberately conservative kernel: each source rank
+    receives prepacked rows for every destination rank, then remote-writes those
+    rows and metadata into the destination rank's output buffers. It is serial
+    by construction and meant to validate remote refs, semaphores, and layout
+    parity before introducing overlapped tiled copies.
+    """
+
+    _require_mgpu_runtime()
+    if send_x_by_dst.ndim != 3:
+        raise ValueError(f"send_x_by_dst must have shape [EP, S, D], got {send_x_by_dst.shape}")
+    ep_size, send_capacity, hidden = send_x_by_dst.shape
+    if recv_capacity is None:
+        recv_capacity = send_capacity
+
+    def kernel_body(
+        send_x_ref,
+        send_row_ref,
+        send_local_expert_ref,
+        send_src_token_idx_ref,
+        send_topk_slot_ref,
+        send_router_weight_ref,
+        send_count_ref,
+        recv_x_ref,
+        recv_valid_count_ref,
+        recv_local_expert_ref,
+        recv_src_rank_ref,
+        recv_src_token_idx_ref,
+        recv_topk_slot_ref,
+        recv_router_weight_ref,
+    ):
+        recv_sem = pl.get_global(plgpu.SemaphoreType.REGULAR)
+        src_rank = lax.axis_index(axis_name)
+
+        for recv_row in range(recv_capacity):
+            for hidden_idx in range(hidden):
+                recv_x_ref[recv_row, hidden_idx] = jnp.zeros((), dtype=recv_x_ref.dtype)
+            recv_valid_count_ref[recv_row] = jnp.int32(0)
+            recv_local_expert_ref[recv_row] = jnp.int32(0)
+            recv_src_rank_ref[recv_row] = jnp.int32(0)
+            recv_src_token_idx_ref[recv_row] = jnp.int32(0)
+            recv_topk_slot_ref[recv_row] = jnp.int32(0)
+            recv_router_weight_ref[recv_row] = jnp.zeros((), dtype=recv_router_weight_ref.dtype)
+
+        for peer_rank in range(ep_size):
+            pl.semaphore_signal(recv_sem, device_id=jnp.int32(peer_rank))
+        pl.semaphore_wait(recv_sem, value=ep_size, decrement=False)
+
+        for dst_rank in range(ep_size):
+            remote_recv_x = plgpu.remote_ref(recv_x_ref, jnp.int32(dst_rank))
+            remote_recv_valid_count = plgpu.remote_ref(recv_valid_count_ref, jnp.int32(dst_rank))
+            remote_recv_local_expert = plgpu.remote_ref(recv_local_expert_ref, jnp.int32(dst_rank))
+            remote_recv_src_rank = plgpu.remote_ref(recv_src_rank_ref, jnp.int32(dst_rank))
+            remote_recv_src_token_idx = plgpu.remote_ref(recv_src_token_idx_ref, jnp.int32(dst_rank))
+            remote_recv_topk_slot = plgpu.remote_ref(recv_topk_slot_ref, jnp.int32(dst_rank))
+            remote_recv_router_weight = plgpu.remote_ref(recv_router_weight_ref, jnp.int32(dst_rank))
+
+            for send_row in range(send_capacity):
+                dst_row = send_row_ref[dst_rank, send_row]
+                valid = (send_row < send_count_ref[dst_rank]) & (dst_row < recv_capacity)
+
+                @pl.when(valid)
+                def _copy_row():
+                    for hidden_idx in range(hidden):
+                        remote_recv_x[dst_row, hidden_idx] = send_x_ref[dst_rank, send_row, hidden_idx]
+                    remote_recv_valid_count[dst_row] = jnp.int32(1)
+                    remote_recv_local_expert[dst_row] = send_local_expert_ref[dst_rank, send_row]
+                    remote_recv_src_rank[dst_row] = src_rank
+                    remote_recv_src_token_idx[dst_row] = send_src_token_idx_ref[dst_rank, send_row]
+                    remote_recv_topk_slot[dst_row] = send_topk_slot_ref[dst_rank, send_row]
+                    remote_recv_router_weight[dst_row] = send_router_weight_ref[dst_rank, send_row]
+
+            pl.semaphore_signal(recv_sem, device_id=jnp.int32(dst_rank))
+
+        pl.semaphore_wait(recv_sem, value=2 * ep_size, decrement=False)
+
+    (
+        recv_x,
+        recv_valid_count,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+    ) = plgpu.kernel(
+        kernel_body,
+        out_shape=[
+            jax.ShapeDtypeStruct((recv_capacity, hidden), send_x_by_dst.dtype),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), send_router_weight_by_dst.dtype),
+        ],
+        grid=(1,),
+        grid_names=("program",),
+        compiler_params=plgpu.CompilerParams(
+            lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
+        ),
+    )(
+        send_x_by_dst,
+        send_row_by_dst,
+        send_local_expert_by_dst,
+        send_src_token_idx_by_dst,
+        send_topk_slot_by_dst,
+        send_router_weight_by_dst,
+        send_count_by_dst,
+    )
+    overflow_count = jnp.maximum(jnp.sum(rows_per_expert, dtype=jnp.int32) - recv_capacity, 0)
+    return MoeDispatchUpLayout(
+        recv_x,
+        recv_valid_count > 0,
+        rows_per_expert,
+        expert_base,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        overflow_count,
+    )
+
+
+def compute_moe_up_mosaic_gpu_local(
+    recv_x: jax.Array,
+    rows_per_expert: jax.Array,
+    w_gate_up_local: jax.Array,
+    *,
+    block_m: int = 64,
+    block_n: int = 64,
+    block_k: int = 64,
+    max_concurrent_steps: int = 2,
+    grid_block_n: int = 1,
+) -> jax.Array:
+    """Local expert-major W13/SiLU kernel with a fused activation epilogue.
+
+    This consumes milestone 1's destination-owned `recv_x` layout. It computes
+    `gate = X @ W_gate`, `up = X @ W_up`, and stores only
+    `silu(gate) * up`, avoiding a global `[tokens, 2 * d_ff]` temporary.
+    """
+
+    _require_mgpu_runtime()
+    if recv_x.ndim != 2:
+        raise ValueError(f"recv_x must have shape [R, D], got {recv_x.shape}")
+    if w_gate_up_local.ndim != 3:
+        raise ValueError(f"w_gate_up_local must have shape [EL, D, 2I], got {w_gate_up_local.shape}")
+    recv_capacity, hidden = recv_x.shape
+    local_experts, hidden_2, gate_up = w_gate_up_local.shape
+    if hidden != hidden_2:
+        raise ValueError(f"recv_x hidden={hidden} must match w_gate_up_local hidden={hidden_2}")
+    if rows_per_expert.shape != (local_experts,):
+        raise ValueError(f"rows_per_expert must have shape ({local_experts},), got {rows_per_expert.shape}")
+    if gate_up % 2 != 0:
+        raise ValueError(f"w_gate_up_local last dimension must be even, got {gate_up}")
+    if hidden % block_k != 0:
+        raise ValueError(f"hidden={hidden} must be divisible by block_k={block_k}")
+    intermediate = gate_up // 2
+
+    def kernel_body(rows_per_expert_gmem, recv_x_gmem, w_gate_up_gmem, out_gmem):
+        grid_m = pl.cdiv(recv_capacity, block_m) + local_experts - 1
+        grid_n = pl.cdiv(intermediate, block_n)
+        grid = (grid_m * grid_n,)
+
+        @plgpu.nd_loop(grid, collective_axes="sm")
+        def mn_loop(loop_info: plgpu.NDLoopInfo):
+            mi, ni = plgpu.planar_snake(loop_info.index[0], (grid_m, grid_n), 1, grid_block_n)
+            group_info = GroupInfo.create(rows_per_expert_gmem, block_m, mi)
+
+            def acc_scope(gate_acc_ref, up_acc_ref):
+                def pipeline_body(_, x_smem, gate_w_smem, up_w_smem):
+                    plgpu.wgmma(gate_acc_ref, x_smem, gate_w_smem)
+                    plgpu.wgmma(up_acc_ref, x_smem, up_w_smem)
+
+                gate_w_ref = w_gate_up_gmem.at[group_info.group_id, :, pl.ds(0, intermediate)]
+                up_w_ref = w_gate_up_gmem.at[group_info.group_id, :, pl.ds(intermediate, intermediate)]
+                plgpu.emit_pipeline(
+                    pipeline_body,
+                    grid=(hidden // block_k,),
+                    in_specs=[
+                        plgpu.BlockSpec(
+                            (block_m, block_k),
+                            lambda k: (group_info.block, k),
+                            delay_release=1,
+                        ),
+                        plgpu.BlockSpec(
+                            (block_k, block_n),
+                            lambda k: (k, ni),
+                            delay_release=1,
+                        ),
+                        plgpu.BlockSpec(
+                            (block_k, block_n),
+                            lambda k: (k, ni),
+                            delay_release=1,
+                        ),
+                    ],
+                    max_concurrent_steps=max_concurrent_steps,
+                )(recv_x_gmem, gate_w_ref, up_w_ref)
+                return gate_acc_ref[...], up_acc_ref[...]
+
+            gate_acc, up_acc = pl.run_scoped(
+                acc_scope,
+                plgpu.ACC((block_m, block_n), jnp.float32),
+                plgpu.ACC((block_m, block_n), jnp.float32),
+            )
+
+            @functools.partial(pl.run_scoped, out_smem=plgpu.SMEM((block_m, block_n), dtype=out_gmem.dtype))
+            def store_scope(out_smem):
+                activated = jax.nn.silu(gate_acc) * up_acc
+                out_smem[...] = activated.astype(out_smem.dtype)
+                plgpu.commit_smem()
+
+                smem_start = group_info.start_within_block
+                remaining_rows = min(block_m, recv_capacity)
+                while remaining_rows > 0:
+                    const_rows_len = 1 << int(math.log2(remaining_rows))
+                    remaining_rows //= 2
+
+                    @pl.when(group_info.actual_size & const_rows_len != 0)
+                    def _():
+                        out_smem_slice = out_smem.at[pl.ds(smem_start, const_rows_len)]
+                        out_gmem_slice = out_gmem.at[
+                            pl.ds(group_info.block_start + smem_start, const_rows_len),
+                            pl.ds(ni * block_n, block_n),
+                        ]
+                        plgpu.copy_smem_to_gmem(out_smem_slice, out_gmem_slice)
+
+                    smem_start += group_info.actual_size & const_rows_len
+                plgpu.wait_smem_to_gmem(0, wait_read_only=True)
+
+    num_sms = jax.local_devices()[0].core_count
+    kernel = plgpu.kernel(
+        kernel_body,
+        out_shape=jax.ShapeDtypeStruct((recv_capacity, intermediate), recv_x.dtype),
+        grid=(num_sms,),
+        grid_names=("sm",),
+        compiler_params=plgpu.CompilerParams(
+            lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
+        ),
+    )
+    out = kernel(rows_per_expert, recv_x, w_gate_up_local)
+    valid_rows = jnp.arange(recv_capacity, dtype=jnp.int32) < jnp.minimum(
+        jnp.sum(rows_per_expert, dtype=jnp.int32), recv_capacity
+    )
+    return jnp.where(valid_rows[:, None], out, jnp.zeros((), dtype=out.dtype))

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -431,13 +431,17 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
     axis_name: str,
     recv_capacity: int,
     ready_block_m: int = 64,
+    rows_per_program: int = 1,
 ) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
     """Scratch dispatch that exposes clipped ready rows per source/expert."""
 
+    if rows_per_program < 1:
+        raise ValueError(f"rows_per_program must be positive, got {rows_per_program}")
     ep_size, send_capacity, hidden = send_x_by_dst.shape
     local_experts = rows_per_expert.shape[0]
     recv_blocks = math.ceil(recv_capacity / ready_block_m)
-    grid_rows = max(send_capacity, local_experts, recv_blocks)
+    send_programs = math.ceil(send_capacity / rows_per_program)
+    grid_rows = max(send_programs, local_experts, recv_blocks)
     ready_rows = jnp.minimum(jnp.sum(rows_per_expert, dtype=jnp.int32), jnp.int32(recv_capacity))
 
     def kernel_body(
@@ -474,17 +478,23 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
         src_rank = lax.axis_index(axis_name)
         peer_rank = pl.program_id(0)
         row_or_expert = pl.program_id(1)
-        linear_row = peer_rank * send_capacity + row_or_expert
+        send_program_start = row_or_expert * rows_per_program
 
-        @pl.when((row_or_expert < send_capacity) & (linear_row < recv_capacity))
-        def _zero_recv_row():
-            recv_x_ref.at[linear_row, pl.ds(0, hidden)][...] = jnp.zeros((hidden,), dtype=recv_x_ref.dtype)
-            recv_valid_count_ref[linear_row] = jnp.int32(0)
-            recv_local_expert_ref[linear_row] = jnp.int32(0)
-            recv_src_rank_ref[linear_row] = jnp.int32(0)
-            recv_src_token_idx_ref[linear_row] = jnp.int32(0)
-            recv_topk_slot_ref[linear_row] = jnp.int32(0)
-            recv_router_weight_ref[linear_row] = jnp.zeros((), dtype=recv_router_weight_ref.dtype)
+        @pl.when(row_or_expert < send_programs)
+        def _zero_recv_rows():
+            for row_offset in range(rows_per_program):
+                send_row = send_program_start + row_offset
+                linear_row = peer_rank * send_capacity + send_row
+
+                @pl.when((send_row < send_capacity) & (linear_row < recv_capacity))
+                def _zero_recv_row():
+                    recv_x_ref.at[linear_row, pl.ds(0, hidden)][...] = jnp.zeros((hidden,), dtype=recv_x_ref.dtype)
+                    recv_valid_count_ref[linear_row] = jnp.int32(0)
+                    recv_local_expert_ref[linear_row] = jnp.int32(0)
+                    recv_src_rank_ref[linear_row] = jnp.int32(0)
+                    recv_src_token_idx_ref[linear_row] = jnp.int32(0)
+                    recv_topk_slot_ref[linear_row] = jnp.int32(0)
+                    recv_router_weight_ref[linear_row] = jnp.zeros((), dtype=recv_router_weight_ref.dtype)
 
         @pl.when(row_or_expert < local_experts)
         def _zero_ready_count():
@@ -513,44 +523,52 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_scratch_ready_local(
             # per-source/expert completion instead of whole-buffer completion.
             _ = send_expert_base_ref[peer_rank, row_or_expert] + send_expert_count_ref[peer_rank, row_or_expert]
 
-        @pl.when(row_or_expert < send_capacity)
-        def _copy_source_row():
-            dst_row = send_row_ref[peer_rank, row_or_expert]
-            send_valid = (row_or_expert < send_count_ref[peer_rank]) & (dst_row < recv_capacity)
+        @pl.when(row_or_expert < send_programs)
+        def _copy_source_rows():
+            for row_offset in range(rows_per_program):
+                send_row = send_program_start + row_offset
+                safe_send_row = jnp.minimum(send_row, jnp.int32(send_capacity - 1))
+                dst_row = send_row_ref[peer_rank, safe_send_row]
+                send_valid = (send_row < send_count_ref[peer_rank]) & (dst_row < recv_capacity)
 
-            @pl.when(send_valid)
-            def _copy_row_to_scratch():
-                remote_scratch_x.at[src_rank, row_or_expert, pl.ds(0, hidden)][...] = send_x_ref.at[
-                    peer_rank, row_or_expert, pl.ds(0, hidden)
-                ][...]
-                remote_scratch_dst_row[src_rank, row_or_expert] = dst_row
-                remote_scratch_local_expert[src_rank, row_or_expert] = send_local_expert_ref[peer_rank, row_or_expert]
-                remote_scratch_src_token_idx[src_rank, row_or_expert] = send_src_token_idx_ref[
-                    peer_rank, row_or_expert
-                ]
-                remote_scratch_topk_slot[src_rank, row_or_expert] = send_topk_slot_ref[peer_rank, row_or_expert]
-                remote_scratch_router_weight[src_rank, row_or_expert] = send_router_weight_ref[
-                    peer_rank, row_or_expert
-                ]
+                @pl.when(send_valid)
+                def _copy_row_to_scratch():
+                    remote_scratch_x.at[src_rank, safe_send_row, pl.ds(0, hidden)][...] = send_x_ref.at[
+                        peer_rank, safe_send_row, pl.ds(0, hidden)
+                    ][...]
+                    remote_scratch_dst_row[src_rank, safe_send_row] = dst_row
+                    remote_scratch_local_expert[src_rank, safe_send_row] = send_local_expert_ref[
+                        peer_rank, safe_send_row
+                    ]
+                    remote_scratch_src_token_idx[src_rank, safe_send_row] = send_src_token_idx_ref[
+                        peer_rank, safe_send_row
+                    ]
+                    remote_scratch_topk_slot[src_rank, safe_send_row] = send_topk_slot_ref[peer_rank, safe_send_row]
+                    remote_scratch_router_weight[src_rank, safe_send_row] = send_router_weight_ref[
+                        peer_rank, safe_send_row
+                    ]
 
         pl.semaphore_signal(recv_sem, device_id=jnp.int32(peer_rank))
         pl.semaphore_wait(recv_sem, value=ep_size * grid_rows, decrement=False)
 
-        @pl.when(row_or_expert < send_capacity)
-        def _compact_source_row():
-            dst_row = scratch_dst_row_ref[peer_rank, row_or_expert]
-            recv_valid = (row_or_expert < scratch_count_ref[peer_rank]) & (dst_row < recv_capacity)
+        @pl.when(row_or_expert < send_programs)
+        def _compact_source_rows():
+            for row_offset in range(rows_per_program):
+                send_row = send_program_start + row_offset
+                safe_send_row = jnp.minimum(send_row, jnp.int32(send_capacity - 1))
+                dst_row = scratch_dst_row_ref[peer_rank, safe_send_row]
+                recv_valid = (send_row < scratch_count_ref[peer_rank]) & (dst_row < recv_capacity)
 
-            @pl.when(recv_valid)
-            def _compact_row():
-                scratch_row = scratch_x_ref.at[peer_rank, row_or_expert, pl.ds(0, hidden)]
-                recv_x_ref.at[dst_row, pl.ds(0, hidden)][...] = scratch_row[...]
-                recv_valid_count_ref[dst_row] = jnp.int32(1)
-                recv_local_expert_ref[dst_row] = scratch_local_expert_ref[peer_rank, row_or_expert]
-                recv_src_rank_ref[dst_row] = jnp.int32(peer_rank)
-                recv_src_token_idx_ref[dst_row] = scratch_src_token_idx_ref[peer_rank, row_or_expert]
-                recv_topk_slot_ref[dst_row] = scratch_topk_slot_ref[peer_rank, row_or_expert]
-                recv_router_weight_ref[dst_row] = scratch_router_weight_ref[peer_rank, row_or_expert]
+                @pl.when(recv_valid)
+                def _compact_row():
+                    scratch_row = scratch_x_ref.at[peer_rank, safe_send_row, pl.ds(0, hidden)]
+                    recv_x_ref.at[dst_row, pl.ds(0, hidden)][...] = scratch_row[...]
+                    recv_valid_count_ref[dst_row] = jnp.int32(1)
+                    recv_local_expert_ref[dst_row] = scratch_local_expert_ref[peer_rank, safe_send_row]
+                    recv_src_rank_ref[dst_row] = jnp.int32(peer_rank)
+                    recv_src_token_idx_ref[dst_row] = scratch_src_token_idx_ref[peer_rank, safe_send_row]
+                    recv_topk_slot_ref[dst_row] = scratch_topk_slot_ref[peer_rank, safe_send_row]
+                    recv_router_weight_ref[dst_row] = scratch_router_weight_ref[peer_rank, safe_send_row]
 
         pl.semaphore_signal(recv_sem, device_id=src_rank)
         pl.semaphore_wait(recv_sem, value=2 * ep_size * grid_rows, decrement=False)
@@ -658,6 +676,7 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local(
     axis_name: str,
     recv_capacity: int,
     ready_block_m: int = 64,
+    rows_per_program: int = 1,
 ) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
     """Scratch dispatch plus source/expert ready counts for overlap bring-up."""
 
@@ -704,6 +723,7 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_ready_local(
         axis_name=axis_name,
         recv_capacity=recv_capacity,
         ready_block_m=ready_block_m,
+        rows_per_program=rows_per_program,
     )
 
 

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -982,6 +982,7 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
     recv_capacity: int,
     ready_block_m: int = 64,
     rows_per_program: int = 1,
+    zero_recv: bool = True,
 ) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
     """Compact source/expert remote dispatch with readiness metadata."""
 
@@ -993,7 +994,7 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
     copy_chunks = math.ceil(source_expert_capacity / rows_per_program)
     zero_programs = math.ceil(recv_capacity / rows_per_program)
     copy_programs = local_experts * copy_chunks
-    grid_rows = max(zero_programs, copy_programs, local_experts, recv_blocks)
+    grid_rows = max(zero_programs if zero_recv else 0, copy_programs, local_experts, recv_blocks)
     ready_rows = jnp.minimum(jnp.sum(rows_per_expert, dtype=jnp.int32), jnp.int32(recv_capacity))
 
     def kernel_body(
@@ -1021,24 +1022,26 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
         dst_rank = pl.program_id(0)
         row_or_group = pl.program_id(1)
 
-        @pl.when((dst_rank == 0) & (row_or_group < zero_programs))
-        def _zero_recv_rows():
-            row_start = row_or_group * rows_per_program
-            for row_offset in range(rows_per_program):
-                recv_row = row_start + row_offset
+        if zero_recv:
 
-                @pl.when(recv_row < recv_capacity)
-                def _zero_recv_row():
-                    for col_start in range(0, hidden, copy_cols):
-                        recv_x_ref.at[recv_row, pl.ds(col_start, copy_cols)][...] = jnp.zeros(
-                            (copy_cols,), dtype=recv_x_ref.dtype
-                        )
-                    recv_valid_count_ref[recv_row] = jnp.int32(0)
-                    recv_local_expert_ref[recv_row] = jnp.int32(0)
-                    recv_src_rank_ref[recv_row] = jnp.int32(0)
-                    recv_src_token_idx_ref[recv_row] = jnp.int32(0)
-                    recv_topk_slot_ref[recv_row] = jnp.int32(0)
-                    recv_router_weight_ref[recv_row] = jnp.zeros((), dtype=recv_router_weight_ref.dtype)
+            @pl.when((dst_rank == 0) & (row_or_group < zero_programs))
+            def _zero_recv_rows():
+                row_start = row_or_group * rows_per_program
+                for row_offset in range(rows_per_program):
+                    recv_row = row_start + row_offset
+
+                    @pl.when(recv_row < recv_capacity)
+                    def _zero_recv_row():
+                        for col_start in range(0, hidden, copy_cols):
+                            recv_x_ref.at[recv_row, pl.ds(col_start, copy_cols)][...] = jnp.zeros(
+                                (copy_cols,), dtype=recv_x_ref.dtype
+                            )
+                        recv_valid_count_ref[recv_row] = jnp.int32(0)
+                        recv_local_expert_ref[recv_row] = jnp.int32(0)
+                        recv_src_rank_ref[recv_row] = jnp.int32(0)
+                        recv_src_token_idx_ref[recv_row] = jnp.int32(0)
+                        recv_topk_slot_ref[recv_row] = jnp.int32(0)
+                        recv_router_weight_ref[recv_row] = jnp.zeros((), dtype=recv_router_weight_ref.dtype)
 
         @pl.when(row_or_group < local_experts)
         def _zero_ready_count():
@@ -1048,8 +1051,9 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
         def _zero_ready_block_count():
             ready_block_count_ref[row_or_group] = jnp.int32(0)
 
-        pl.semaphore_signal(recv_sem, device_id=dst_rank)
-        pl.semaphore_wait(recv_sem, value=ep_size * grid_rows, decrement=False)
+        if zero_recv:
+            pl.semaphore_signal(recv_sem, device_id=dst_rank)
+            pl.semaphore_wait(recv_sem, value=ep_size * grid_rows, decrement=False)
 
         remote_recv_x = plgpu.remote_ref(recv_x_ref, jnp.int32(dst_rank))
         remote_recv_valid_count = plgpu.remote_ref(recv_valid_count_ref, jnp.int32(dst_rank))
@@ -1087,7 +1091,11 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
                     remote_recv_router_weight[dst_row] = send_router_weight_ref[dst_rank, local_expert, safe_row]
 
         pl.semaphore_signal(recv_sem, device_id=dst_rank)
-        pl.semaphore_wait(recv_sem, value=2 * ep_size * grid_rows, decrement=False)
+        pl.semaphore_wait(
+            recv_sem,
+            value=(2 if zero_recv else 1) * ep_size * grid_rows,
+            decrement=False,
+        )
 
         @pl.when(row_or_group < local_experts)
         def _mark_ready_count():
@@ -1142,9 +1150,10 @@ def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
         ready_rows,
     )
     overflow_count = jnp.maximum(jnp.sum(rows_per_expert, dtype=jnp.int32) - recv_capacity, 0)
+    recv_valid = recv_valid_count > 0 if zero_recv else jnp.arange(recv_capacity, dtype=jnp.int32) < ready_rows
     layout = MoeDispatchUpLayout(
         recv_x,
-        recv_valid_count > 0,
+        recv_valid,
         rows_per_expert,
         expert_base,
         recv_local_expert,
@@ -1164,6 +1173,7 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
     recv_capacity: int,
     ready_block_m: int = 64,
     rows_per_program: int = 1,
+    zero_recv: bool = True,
 ) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
     """Compact source/expert dispatch plus source/expert and block ready counts."""
 
@@ -1210,6 +1220,224 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_local(
         recv_capacity=recv_capacity,
         ready_block_m=ready_block_m,
         rows_per_program=rows_per_program,
+        zero_recv=zero_recv,
+    )
+
+
+def _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_tiled_local(
+    send_x_by_dst_expert: jax.Array,
+    send_src_token_idx_by_dst_expert: jax.Array,
+    send_topk_slot_by_dst_expert: jax.Array,
+    send_router_weight_by_dst_expert: jax.Array,
+    send_row_base_by_dst_expert: jax.Array,
+    send_count_by_dst_expert: jax.Array,
+    rows_per_expert: jax.Array,
+    expert_base: jax.Array,
+    recv_source_expert_base: jax.Array,
+    recv_source_expert_count: jax.Array,
+    *,
+    axis_name: str,
+    recv_capacity: int,
+    ready_block_m: int = 64,
+    copy_cols: int = 256,
+    copy_rows: int = 1,
+) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
+    """Compact source/expert remote dispatch tiled over row and hidden columns."""
+
+    ep_size, local_experts, source_expert_capacity, hidden = send_x_by_dst_expert.shape
+    if copy_cols < 1:
+        raise ValueError(f"copy_cols must be positive, got {copy_cols}")
+    if copy_cols > 256:
+        raise ValueError(f"copy_cols must be <= 256 for Mosaic async copies, got {copy_cols}")
+    if hidden % copy_cols != 0:
+        raise ValueError(f"hidden={hidden} must be divisible by copy_cols={copy_cols}")
+    if copy_rows < 1:
+        raise ValueError(f"copy_rows must be positive, got {copy_rows}")
+    if copy_rows > 256:
+        raise ValueError(f"copy_rows must be <= 256 for Mosaic async copies, got {copy_rows}")
+    recv_blocks = math.ceil(recv_capacity / ready_block_m)
+    row_tiles = math.ceil(source_expert_capacity / copy_rows)
+    row_or_block_count = max(row_tiles, recv_blocks)
+    col_tiles = hidden // copy_cols
+    ready_rows = jnp.minimum(jnp.sum(rows_per_expert, dtype=jnp.int32), jnp.int32(recv_capacity))
+
+    def kernel_body(
+        send_x_ref,
+        send_src_token_idx_ref,
+        send_topk_slot_ref,
+        send_router_weight_ref,
+        send_row_base_ref,
+        send_count_ref,
+        recv_source_expert_base_ref,
+        recv_source_expert_count_ref,
+        ready_rows_ref,
+        recv_x_ref,
+        recv_local_expert_ref,
+        recv_src_rank_ref,
+        recv_src_token_idx_ref,
+        recv_topk_slot_ref,
+        recv_router_weight_ref,
+        ready_count_ref,
+        ready_block_count_ref,
+    ):
+        src_rank = lax.axis_index(axis_name)
+        dst_rank = pl.program_id(0)
+        local_expert = pl.program_id(1)
+        row_or_block = pl.program_id(2)
+        col_tile = pl.program_id(3)
+        source_row_start = row_or_block * copy_rows
+        col_start = col_tile * copy_cols
+
+        remote_recv_x = plgpu.remote_ref(recv_x_ref, jnp.int32(dst_rank))
+        remote_recv_local_expert = plgpu.remote_ref(recv_local_expert_ref, jnp.int32(dst_rank))
+        remote_recv_src_rank = plgpu.remote_ref(recv_src_rank_ref, jnp.int32(dst_rank))
+        remote_recv_src_token_idx = plgpu.remote_ref(recv_src_token_idx_ref, jnp.int32(dst_rank))
+        remote_recv_topk_slot = plgpu.remote_ref(recv_topk_slot_ref, jnp.int32(dst_rank))
+        remote_recv_router_weight = plgpu.remote_ref(recv_router_weight_ref, jnp.int32(dst_rank))
+
+        def _write_row_metadata(source_row, dst_row):
+            remote_recv_local_expert[dst_row] = local_expert
+            remote_recv_src_rank[dst_row] = src_rank
+            remote_recv_src_token_idx[dst_row] = send_src_token_idx_ref[dst_rank, local_expert, source_row]
+            remote_recv_topk_slot[dst_row] = send_topk_slot_ref[dst_rank, local_expert, source_row]
+            remote_recv_router_weight[dst_row] = send_router_weight_ref[dst_rank, local_expert, source_row]
+
+        def _copy_one_row(source_row, dst_row):
+            @functools.partial(
+                pl.run_scoped,
+                tile_smem=plgpu.SMEM((copy_cols,), dtype=send_x_ref.dtype),
+                barrier=plgpu.Barrier(),
+            )
+            def _copy_payload_tile(tile_smem, barrier):
+                src_slice = send_x_ref.at[dst_rank, local_expert, source_row, pl.ds(col_start, copy_cols)]
+                plgpu.copy_gmem_to_smem(src_slice, tile_smem, barrier)
+                plgpu.barrier_wait(barrier)
+                dst_slice = remote_recv_x.at[dst_row, pl.ds(col_start, copy_cols)]
+                plgpu.copy_smem_to_gmem(tile_smem, dst_slice)
+                plgpu.wait_smem_to_gmem(0, wait_read_only=False)
+
+        @pl.when(row_or_block < row_tiles)
+        def _copy_source_expert_tile():
+            count = send_count_ref[dst_rank, local_expert]
+            dst_base = send_row_base_ref[dst_rank, local_expert]
+            dst_row_start = dst_base + source_row_start
+            for row_offset in range(copy_rows):
+                source_row = source_row_start + row_offset
+                dst_row = dst_row_start + row_offset
+                send_valid = (source_row < count) & (dst_row < recv_capacity)
+
+                @pl.when(send_valid)
+                def _copy_row_to_recv():
+                    _copy_one_row(source_row, dst_row)
+
+                    @pl.when(col_tile == 0)
+                    def _write_partial_metadata():
+                        _write_row_metadata(source_row, dst_row)
+
+        @pl.when((col_tile == 0) & (row_or_block == 0))
+        def _mark_ready_count():
+            base = recv_source_expert_base_ref[dst_rank, local_expert]
+            count = recv_source_expert_count_ref[dst_rank, local_expert]
+            remaining_capacity = jnp.maximum(jnp.int32(recv_capacity) - base, jnp.int32(0))
+            ready_count_ref[dst_rank, local_expert] = jnp.minimum(count, remaining_capacity)
+
+        @pl.when((dst_rank == 0) & (local_expert == 0) & (col_tile == 0) & (row_or_block < recv_blocks))
+        def _mark_ready_block_count():
+            block_start = row_or_block * ready_block_m
+            remaining_rows = jnp.maximum(ready_rows_ref[()] - block_start, jnp.int32(0))
+            ready_block_count_ref[row_or_block] = jnp.minimum(remaining_rows, jnp.int32(ready_block_m))
+
+    (
+        recv_x,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        ready_count,
+        ready_block_count,
+    ) = plgpu.kernel(
+        kernel_body,
+        out_shape=[
+            jax.ShapeDtypeStruct((recv_capacity, hidden), send_x_by_dst_expert.dtype),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), jnp.int32),
+            jax.ShapeDtypeStruct((recv_capacity,), send_router_weight_by_dst_expert.dtype),
+            jax.ShapeDtypeStruct((ep_size, local_experts), jnp.int32),
+            jax.ShapeDtypeStruct((recv_blocks,), jnp.int32),
+        ],
+        grid=(ep_size, local_experts, row_or_block_count, col_tiles),
+        grid_names=("dst", "local_expert", "row_or_block", "col"),
+    )(
+        send_x_by_dst_expert,
+        send_src_token_idx_by_dst_expert,
+        send_topk_slot_by_dst_expert,
+        send_router_weight_by_dst_expert,
+        send_row_base_by_dst_expert,
+        send_count_by_dst_expert,
+        recv_source_expert_base,
+        recv_source_expert_count,
+        ready_rows,
+    )
+    overflow_count = jnp.maximum(jnp.sum(rows_per_expert, dtype=jnp.int32) - recv_capacity, 0)
+    recv_valid = jnp.arange(recv_capacity, dtype=jnp.int32) < ready_rows
+    layout = MoeDispatchUpLayout(
+        recv_x,
+        recv_valid,
+        rows_per_expert,
+        expert_base,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        overflow_count,
+    )
+    return layout, ready_count, ready_block_count
+
+
+def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_tiled_local(
+    prepacked: MoeDispatchUpSourceExpertPrepackedSend,
+    *,
+    axis_name: str,
+    recv_capacity: int,
+    ready_block_m: int = 64,
+    copy_cols: int = 256,
+    copy_rows: int = 1,
+) -> tuple[MoeDispatchUpLayout, jax.Array, jax.Array]:
+    """Compact source/expert dispatch tiled over rows and hidden columns."""
+
+    _require_mgpu_runtime()
+    if prepacked.send_x_by_dst_expert.ndim != 4:
+        raise ValueError(
+            "local compact send_x_by_dst_expert must have shape [EP, EL, C, D], "
+            f"got {prepacked.send_x_by_dst_expert.shape}"
+        )
+    ep_size, local_experts, _capacity, _hidden = prepacked.send_x_by_dst_expert.shape
+    if prepacked.send_count_by_dst_expert.shape != (ep_size, local_experts):
+        raise ValueError(
+            "local send_count_by_dst_expert must have shape "
+            f"{(ep_size, local_experts)}, got {prepacked.send_count_by_dst_expert.shape}"
+        )
+
+    return _dispatch_prepacked_moe_dispatch_up_mosaic_gpu_source_expert_tiled_local(
+        prepacked.send_x_by_dst_expert,
+        prepacked.send_src_token_idx_by_dst_expert,
+        prepacked.send_topk_slot_by_dst_expert,
+        prepacked.send_router_weight_by_dst_expert,
+        prepacked.send_row_base_by_dst_expert,
+        prepacked.send_count_by_dst_expert,
+        prepacked.rows_per_expert,
+        prepacked.expert_base,
+        prepacked.recv_source_expert_base,
+        prepacked.recv_source_expert_count,
+        axis_name=axis_name,
+        recv_capacity=recv_capacity,
+        ready_block_m=ready_block_m,
+        copy_cols=copy_cols,
+        copy_rows=copy_rows,
     )
 
 

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -954,3 +954,132 @@ def compute_moe_up_mosaic_gpu_ready_local(
         jnp.sum(ready_count, dtype=jnp.int32), recv_capacity
     )
     return jnp.where(valid_rows[:, None], out, jnp.zeros((), dtype=out.dtype))
+
+
+def compute_moe_up_mosaic_gpu_block_ready_local(
+    recv_x: jax.Array,
+    rows_per_expert: jax.Array,
+    ready_block_count: jax.Array,
+    w_gate_up_local: jax.Array,
+    *,
+    block_m: int = 64,
+    block_n: int = 64,
+    block_k: int = 64,
+    max_concurrent_steps: int = 2,
+    grid_block_n: int = 1,
+) -> jax.Array:
+    """Local W13/SiLU scheduled by expert groups with block-ready row masks."""
+
+    _require_mgpu_runtime()
+    if recv_x.ndim != 2:
+        raise ValueError(f"recv_x must have shape [R, D], got {recv_x.shape}")
+    if rows_per_expert.ndim != 1:
+        raise ValueError(f"rows_per_expert must have shape [EL], got {rows_per_expert.shape}")
+    if ready_block_count.ndim != 1:
+        raise ValueError(f"ready_block_count must have shape [B], got {ready_block_count.shape}")
+    if w_gate_up_local.ndim != 3:
+        raise ValueError(f"w_gate_up_local must have shape [EL, D, 2I], got {w_gate_up_local.shape}")
+    recv_capacity, hidden = recv_x.shape
+    local_experts, hidden_2, gate_up = w_gate_up_local.shape
+    if hidden != hidden_2:
+        raise ValueError(f"recv_x hidden={hidden} must match w_gate_up_local hidden={hidden_2}")
+    if rows_per_expert.shape != (local_experts,):
+        raise ValueError(f"rows_per_expert must have shape ({local_experts},), got {rows_per_expert.shape}")
+    expected_blocks = math.ceil(recv_capacity / block_m)
+    if ready_block_count.shape != (expected_blocks,):
+        raise ValueError(f"ready_block_count must have shape ({expected_blocks},), got {ready_block_count.shape}")
+    if gate_up % 2 != 0:
+        raise ValueError(f"w_gate_up_local last dimension must be even, got {gate_up}")
+    if hidden % block_k != 0:
+        raise ValueError(f"hidden={hidden} must be divisible by block_k={block_k}")
+    intermediate = gate_up // 2
+
+    def kernel_body(rows_per_expert_gmem, ready_block_count_gmem, recv_x_gmem, w_gate_up_gmem, out_gmem):
+        grid_m = pl.cdiv(recv_capacity, block_m) + local_experts - 1
+        grid_n = pl.cdiv(intermediate, block_n)
+        grid = (grid_m * grid_n,)
+
+        @plgpu.nd_loop(grid, collective_axes="sm")
+        def mn_loop(loop_info: plgpu.NDLoopInfo):
+            mi, ni = plgpu.planar_snake(loop_info.index[0], (grid_m, grid_n), 1, grid_block_n)
+            group_info = GroupInfo.create(rows_per_expert_gmem, block_m, mi)
+            ready_rows_in_block = ready_block_count_gmem[group_info.block]
+            ready_after_start = jnp.maximum(ready_rows_in_block - group_info.start_within_block, jnp.int32(0))
+            ready_actual_size = jnp.minimum(group_info.actual_size, ready_after_start)
+
+            def acc_scope(gate_acc_ref, up_acc_ref):
+                def pipeline_body(_, x_smem, gate_w_smem, up_w_smem):
+                    plgpu.wgmma(gate_acc_ref, x_smem, gate_w_smem)
+                    plgpu.wgmma(up_acc_ref, x_smem, up_w_smem)
+
+                gate_w_ref = w_gate_up_gmem.at[group_info.group_id, :, pl.ds(0, intermediate)]
+                up_w_ref = w_gate_up_gmem.at[group_info.group_id, :, pl.ds(intermediate, intermediate)]
+                plgpu.emit_pipeline(
+                    pipeline_body,
+                    grid=(hidden // block_k,),
+                    in_specs=[
+                        plgpu.BlockSpec(
+                            (block_m, block_k),
+                            lambda k: (group_info.block, k),
+                            delay_release=1,
+                        ),
+                        plgpu.BlockSpec(
+                            (block_k, block_n),
+                            lambda k: (k, ni),
+                            delay_release=1,
+                        ),
+                        plgpu.BlockSpec(
+                            (block_k, block_n),
+                            lambda k: (k, ni),
+                            delay_release=1,
+                        ),
+                    ],
+                    max_concurrent_steps=max_concurrent_steps,
+                )(recv_x_gmem, gate_w_ref, up_w_ref)
+                return gate_acc_ref[...], up_acc_ref[...]
+
+            gate_acc, up_acc = pl.run_scoped(
+                acc_scope,
+                plgpu.ACC((block_m, block_n), jnp.float32),
+                plgpu.ACC((block_m, block_n), jnp.float32),
+            )
+
+            @functools.partial(pl.run_scoped, out_smem=plgpu.SMEM((block_m, block_n), dtype=out_gmem.dtype))
+            def store_scope(out_smem):
+                activated = jax.nn.silu(gate_acc) * up_acc
+                out_smem[...] = activated.astype(out_smem.dtype)
+                plgpu.commit_smem()
+
+                smem_start = group_info.start_within_block
+                remaining_rows = min(block_m, recv_capacity)
+                while remaining_rows > 0:
+                    const_rows_len = 1 << int(math.log2(remaining_rows))
+                    remaining_rows //= 2
+
+                    @pl.when(ready_actual_size & const_rows_len != 0)
+                    def _():
+                        out_smem_slice = out_smem.at[pl.ds(smem_start, const_rows_len)]
+                        out_gmem_slice = out_gmem.at[
+                            pl.ds(group_info.block_start + smem_start, const_rows_len),
+                            pl.ds(ni * block_n, block_n),
+                        ]
+                        plgpu.copy_smem_to_gmem(out_smem_slice, out_gmem_slice)
+
+                    smem_start += ready_actual_size & const_rows_len
+                plgpu.wait_smem_to_gmem(0, wait_read_only=True)
+
+    num_sms = jax.local_devices()[0].core_count
+    kernel = plgpu.kernel(
+        kernel_body,
+        out_shape=jax.ShapeDtypeStruct((recv_capacity, intermediate), recv_x.dtype),
+        grid=(num_sms,),
+        grid_names=("sm",),
+        compiler_params=plgpu.CompilerParams(
+            lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
+        ),
+    )
+    out = kernel(rows_per_expert, ready_block_count, recv_x, w_gate_up_local)
+    valid_rows = jnp.arange(recv_capacity, dtype=jnp.int32) < jnp.minimum(
+        jnp.sum(ready_block_count, dtype=jnp.int32), recv_capacity
+    )
+    return jnp.where(valid_rows[:, None], out, jnp.zeros((), dtype=out.dtype))

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -808,3 +808,129 @@ def compute_moe_up_mosaic_gpu_local(
         jnp.sum(rows_per_expert, dtype=jnp.int32), recv_capacity
     )
     return jnp.where(valid_rows[:, None], out, jnp.zeros((), dtype=out.dtype))
+
+
+def compute_moe_up_mosaic_gpu_ready_local(
+    recv_x: jax.Array,
+    ready_count: jax.Array,
+    w_gate_up_local: jax.Array,
+    *,
+    block_m: int = 64,
+    block_n: int = 64,
+    block_k: int = 64,
+    max_concurrent_steps: int = 2,
+    grid_block_n: int = 1,
+) -> jax.Array:
+    """Local W13/SiLU scheduled over source/expert ready ranges."""
+
+    _require_mgpu_runtime()
+    if recv_x.ndim != 2:
+        raise ValueError(f"recv_x must have shape [R, D], got {recv_x.shape}")
+    if ready_count.ndim != 2:
+        raise ValueError(f"ready_count must have shape [EP, EL], got {ready_count.shape}")
+    if w_gate_up_local.ndim != 3:
+        raise ValueError(f"w_gate_up_local must have shape [EL, D, 2I], got {w_gate_up_local.shape}")
+    recv_capacity, hidden = recv_x.shape
+    ep_size, local_experts = ready_count.shape
+    if w_gate_up_local.shape[0] != local_experts:
+        raise ValueError(
+            "ready_count local expert dimension must match w_gate_up_local; "
+            f"got {ready_count.shape} vs {w_gate_up_local.shape}"
+        )
+    if w_gate_up_local.shape[1] != hidden:
+        raise ValueError(f"recv_x hidden={hidden} must match w_gate_up_local hidden={w_gate_up_local.shape[1]}")
+    if w_gate_up_local.shape[2] % 2 != 0:
+        raise ValueError(f"w_gate_up_local last dimension must be even, got {w_gate_up_local.shape[2]}")
+    if hidden % block_k != 0:
+        raise ValueError(f"hidden={hidden} must be divisible by block_k={block_k}")
+    intermediate = w_gate_up_local.shape[2] // 2
+    group_count = ep_size * local_experts
+    ready_count_expert_major = jnp.swapaxes(ready_count, 0, 1).reshape((group_count,))
+
+    def kernel_body(ready_count_gmem, recv_x_gmem, w_gate_up_gmem, out_gmem):
+        grid_m = pl.cdiv(recv_capacity, block_m) + group_count - 1
+        grid_n = pl.cdiv(intermediate, block_n)
+        grid = (grid_m * grid_n,)
+
+        @plgpu.nd_loop(grid, collective_axes="sm")
+        def mn_loop(loop_info: plgpu.NDLoopInfo):
+            mi, ni = plgpu.planar_snake(loop_info.index[0], (grid_m, grid_n), 1, grid_block_n)
+            group_info = GroupInfo.create(ready_count_gmem, block_m, mi)
+            local_expert = group_info.group_id // ep_size
+
+            def acc_scope(gate_acc_ref, up_acc_ref):
+                def pipeline_body(_, x_smem, gate_w_smem, up_w_smem):
+                    plgpu.wgmma(gate_acc_ref, x_smem, gate_w_smem)
+                    plgpu.wgmma(up_acc_ref, x_smem, up_w_smem)
+
+                gate_w_ref = w_gate_up_gmem.at[local_expert, :, pl.ds(0, intermediate)]
+                up_w_ref = w_gate_up_gmem.at[local_expert, :, pl.ds(intermediate, intermediate)]
+                plgpu.emit_pipeline(
+                    pipeline_body,
+                    grid=(hidden // block_k,),
+                    in_specs=[
+                        plgpu.BlockSpec(
+                            (block_m, block_k),
+                            lambda k: (group_info.block, k),
+                            delay_release=1,
+                        ),
+                        plgpu.BlockSpec(
+                            (block_k, block_n),
+                            lambda k: (k, ni),
+                            delay_release=1,
+                        ),
+                        plgpu.BlockSpec(
+                            (block_k, block_n),
+                            lambda k: (k, ni),
+                            delay_release=1,
+                        ),
+                    ],
+                    max_concurrent_steps=max_concurrent_steps,
+                )(recv_x_gmem, gate_w_ref, up_w_ref)
+                return gate_acc_ref[...], up_acc_ref[...]
+
+            gate_acc, up_acc = pl.run_scoped(
+                acc_scope,
+                plgpu.ACC((block_m, block_n), jnp.float32),
+                plgpu.ACC((block_m, block_n), jnp.float32),
+            )
+
+            @functools.partial(pl.run_scoped, out_smem=plgpu.SMEM((block_m, block_n), dtype=out_gmem.dtype))
+            def store_scope(out_smem):
+                activated = jax.nn.silu(gate_acc) * up_acc
+                out_smem[...] = activated.astype(out_smem.dtype)
+                plgpu.commit_smem()
+
+                smem_start = group_info.start_within_block
+                remaining_rows = min(block_m, recv_capacity)
+                while remaining_rows > 0:
+                    const_rows_len = 1 << int(math.log2(remaining_rows))
+                    remaining_rows //= 2
+
+                    @pl.when(group_info.actual_size & const_rows_len != 0)
+                    def _():
+                        out_smem_slice = out_smem.at[pl.ds(smem_start, const_rows_len)]
+                        out_gmem_slice = out_gmem.at[
+                            pl.ds(group_info.block_start + smem_start, const_rows_len),
+                            pl.ds(ni * block_n, block_n),
+                        ]
+                        plgpu.copy_smem_to_gmem(out_smem_slice, out_gmem_slice)
+
+                    smem_start += group_info.actual_size & const_rows_len
+                plgpu.wait_smem_to_gmem(0, wait_read_only=True)
+
+    num_sms = jax.local_devices()[0].core_count
+    kernel = plgpu.kernel(
+        kernel_body,
+        out_shape=jax.ShapeDtypeStruct((recv_capacity, intermediate), recv_x.dtype),
+        grid=(num_sms,),
+        grid_names=("sm",),
+        compiler_params=plgpu.CompilerParams(
+            lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
+        ),
+    )
+    out = kernel(ready_count_expert_major, recv_x, w_gate_up_local)
+    valid_rows = jnp.arange(recv_capacity, dtype=jnp.int32) < jnp.minimum(
+        jnp.sum(ready_count, dtype=jnp.int32), recv_capacity
+    )
+    return jnp.where(valid_rows[:, None], out, jnp.zeros((), dtype=out.dtype))

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/mosaic_gpu.py
@@ -61,6 +61,7 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local(
     *,
     axis_name: str,
     recv_capacity: int | None = None,
+    copy_mode: str = "row_vector",
 ) -> MoeDispatchUpLayout:
     """Shard-local MGPU remote-dispatch validation primitive.
 
@@ -77,6 +78,8 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local(
     ep_size, send_capacity, hidden = send_x_by_dst.shape
     if recv_capacity is None:
         recv_capacity = send_capacity
+    if copy_mode not in ("scalar", "row_vector"):
+        raise ValueError(f"copy_mode must be 'scalar' or 'row_vector', got {copy_mode!r}")
 
     def kernel_body(
         send_x_ref,
@@ -97,45 +100,93 @@ def dispatch_prepacked_moe_dispatch_up_mosaic_gpu_local(
         recv_sem = pl.get_global(plgpu.SemaphoreType.REGULAR)
         src_rank = lax.axis_index(axis_name)
 
-        for recv_row in range(recv_capacity):
-            for hidden_idx in range(hidden):
-                recv_x_ref[recv_row, hidden_idx] = jnp.zeros((), dtype=recv_x_ref.dtype)
-            recv_valid_count_ref[recv_row] = jnp.int32(0)
-            recv_local_expert_ref[recv_row] = jnp.int32(0)
-            recv_src_rank_ref[recv_row] = jnp.int32(0)
-            recv_src_token_idx_ref[recv_row] = jnp.int32(0)
-            recv_topk_slot_ref[recv_row] = jnp.int32(0)
-            recv_router_weight_ref[recv_row] = jnp.zeros((), dtype=recv_router_weight_ref.dtype)
+        def _zero_metadata():
+            for recv_row in range(recv_capacity):
+                recv_valid_count_ref[recv_row] = jnp.int32(0)
+                recv_local_expert_ref[recv_row] = jnp.int32(0)
+                recv_src_rank_ref[recv_row] = jnp.int32(0)
+                recv_src_token_idx_ref[recv_row] = jnp.int32(0)
+                recv_topk_slot_ref[recv_row] = jnp.int32(0)
+                recv_router_weight_ref[recv_row] = jnp.zeros((), dtype=recv_router_weight_ref.dtype)
+
+        def _zero_recv_x_scalar():
+            for recv_row in range(recv_capacity):
+                for hidden_idx in range(hidden):
+                    recv_x_ref[recv_row, hidden_idx] = jnp.zeros((), dtype=recv_x_ref.dtype)
+
+        def _zero_recv_x_vector():
+            for recv_row in range(recv_capacity):
+                recv_x_ref.at[recv_row, pl.ds(0, hidden)][...] = jnp.zeros((hidden,), dtype=recv_x_ref.dtype)
+
+        def _copy_rows_scalar():
+            for dst_rank in range(ep_size):
+                remote_recv_x = plgpu.remote_ref(recv_x_ref, jnp.int32(dst_rank))
+                remote_recv_valid_count = plgpu.remote_ref(recv_valid_count_ref, jnp.int32(dst_rank))
+                remote_recv_local_expert = plgpu.remote_ref(recv_local_expert_ref, jnp.int32(dst_rank))
+                remote_recv_src_rank = plgpu.remote_ref(recv_src_rank_ref, jnp.int32(dst_rank))
+                remote_recv_src_token_idx = plgpu.remote_ref(recv_src_token_idx_ref, jnp.int32(dst_rank))
+                remote_recv_topk_slot = plgpu.remote_ref(recv_topk_slot_ref, jnp.int32(dst_rank))
+                remote_recv_router_weight = plgpu.remote_ref(recv_router_weight_ref, jnp.int32(dst_rank))
+
+                for send_row in range(send_capacity):
+                    dst_row = send_row_ref[dst_rank, send_row]
+                    valid = (send_row < send_count_ref[dst_rank]) & (dst_row < recv_capacity)
+
+                    @pl.when(valid)
+                    def _copy_row():
+                        for hidden_idx in range(hidden):
+                            remote_recv_x[dst_row, hidden_idx] = send_x_ref[dst_rank, send_row, hidden_idx]
+                        remote_recv_valid_count[dst_row] = jnp.int32(1)
+                        remote_recv_local_expert[dst_row] = send_local_expert_ref[dst_rank, send_row]
+                        remote_recv_src_rank[dst_row] = src_rank
+                        remote_recv_src_token_idx[dst_row] = send_src_token_idx_ref[dst_rank, send_row]
+                        remote_recv_topk_slot[dst_row] = send_topk_slot_ref[dst_rank, send_row]
+                        remote_recv_router_weight[dst_row] = send_router_weight_ref[dst_rank, send_row]
+
+                pl.semaphore_signal(recv_sem, device_id=jnp.int32(dst_rank))
+
+        def _copy_rows_vector():
+            for dst_rank in range(ep_size):
+                remote_recv_x = plgpu.remote_ref(recv_x_ref, jnp.int32(dst_rank))
+                remote_recv_valid_count = plgpu.remote_ref(recv_valid_count_ref, jnp.int32(dst_rank))
+                remote_recv_local_expert = plgpu.remote_ref(recv_local_expert_ref, jnp.int32(dst_rank))
+                remote_recv_src_rank = plgpu.remote_ref(recv_src_rank_ref, jnp.int32(dst_rank))
+                remote_recv_src_token_idx = plgpu.remote_ref(recv_src_token_idx_ref, jnp.int32(dst_rank))
+                remote_recv_topk_slot = plgpu.remote_ref(recv_topk_slot_ref, jnp.int32(dst_rank))
+                remote_recv_router_weight = plgpu.remote_ref(recv_router_weight_ref, jnp.int32(dst_rank))
+
+                for send_row in range(send_capacity):
+                    dst_row = send_row_ref[dst_rank, send_row]
+                    valid = (send_row < send_count_ref[dst_rank]) & (dst_row < recv_capacity)
+
+                    @pl.when(valid)
+                    def _copy_row():
+                        remote_recv_x.at[dst_row, pl.ds(0, hidden)][...] = send_x_ref.at[
+                            dst_rank, send_row, pl.ds(0, hidden)
+                        ][...]
+                        remote_recv_valid_count[dst_row] = jnp.int32(1)
+                        remote_recv_local_expert[dst_row] = send_local_expert_ref[dst_rank, send_row]
+                        remote_recv_src_rank[dst_row] = src_rank
+                        remote_recv_src_token_idx[dst_row] = send_src_token_idx_ref[dst_rank, send_row]
+                        remote_recv_topk_slot[dst_row] = send_topk_slot_ref[dst_rank, send_row]
+                        remote_recv_router_weight[dst_row] = send_router_weight_ref[dst_rank, send_row]
+
+                pl.semaphore_signal(recv_sem, device_id=jnp.int32(dst_rank))
+
+        _zero_metadata()
+        if copy_mode == "scalar":
+            _zero_recv_x_scalar()
+        else:
+            _zero_recv_x_vector()
 
         for peer_rank in range(ep_size):
             pl.semaphore_signal(recv_sem, device_id=jnp.int32(peer_rank))
         pl.semaphore_wait(recv_sem, value=ep_size, decrement=False)
 
-        for dst_rank in range(ep_size):
-            remote_recv_x = plgpu.remote_ref(recv_x_ref, jnp.int32(dst_rank))
-            remote_recv_valid_count = plgpu.remote_ref(recv_valid_count_ref, jnp.int32(dst_rank))
-            remote_recv_local_expert = plgpu.remote_ref(recv_local_expert_ref, jnp.int32(dst_rank))
-            remote_recv_src_rank = plgpu.remote_ref(recv_src_rank_ref, jnp.int32(dst_rank))
-            remote_recv_src_token_idx = plgpu.remote_ref(recv_src_token_idx_ref, jnp.int32(dst_rank))
-            remote_recv_topk_slot = plgpu.remote_ref(recv_topk_slot_ref, jnp.int32(dst_rank))
-            remote_recv_router_weight = plgpu.remote_ref(recv_router_weight_ref, jnp.int32(dst_rank))
-
-            for send_row in range(send_capacity):
-                dst_row = send_row_ref[dst_rank, send_row]
-                valid = (send_row < send_count_ref[dst_rank]) & (dst_row < recv_capacity)
-
-                @pl.when(valid)
-                def _copy_row():
-                    for hidden_idx in range(hidden):
-                        remote_recv_x[dst_row, hidden_idx] = send_x_ref[dst_rank, send_row, hidden_idx]
-                    remote_recv_valid_count[dst_row] = jnp.int32(1)
-                    remote_recv_local_expert[dst_row] = send_local_expert_ref[dst_rank, send_row]
-                    remote_recv_src_rank[dst_row] = src_rank
-                    remote_recv_src_token_idx[dst_row] = send_src_token_idx_ref[dst_rank, send_row]
-                    remote_recv_topk_slot[dst_row] = send_topk_slot_ref[dst_rank, send_row]
-                    remote_recv_router_weight[dst_row] = send_router_weight_ref[dst_rank, send_row]
-
-            pl.semaphore_signal(recv_sem, device_id=jnp.int32(dst_rank))
+        if copy_mode == "scalar":
+            _copy_rows_scalar()
+        else:
+            _copy_rows_vector()
 
         pl.semaphore_wait(recv_sem, value=2 * ep_size, decrement=False)
 

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/reference.py
@@ -306,3 +306,127 @@ def compute_moe_up_from_layout_reference(
             expert_h = jax.nn.silu(gate.astype(jnp.float32)).astype(gate.dtype) * up
             h = h.at[dst_rank].add(expert_h * mask[:, None])
     return h
+
+
+def compute_moe_up_from_layout_reference_bwd(
+    layout: MoeDispatchUpLayout,
+    w_gate_up_by_rank: jax.Array,
+    grad_dispatch_up: jax.Array,
+) -> tuple[jax.Array, jax.Array]:
+    """Backward oracle for the W13/SiLU part of `moe_dispatch_up`.
+
+    Returns gradients for `layout.recv_x` and `w_gate_up_by_rank`.
+    Metadata in `layout` is treated as non-differentiable routing state.
+    """
+
+    if grad_dispatch_up.shape[:2] != layout.recv_x.shape[:2]:
+        raise ValueError(
+            "grad_dispatch_up must share EP and recv row dimensions with layout.recv_x; "
+            f"got {grad_dispatch_up.shape} vs {layout.recv_x.shape}"
+        )
+    if w_gate_up_by_rank.ndim != 4:
+        raise ValueError(f"w_gate_up_by_rank must have shape [EP, EL, D, 2I], got {w_gate_up_by_rank.shape}")
+
+    ep_size, recv_capacity, hidden = layout.recv_x.shape
+    local_experts = w_gate_up_by_rank.shape[1]
+    intermediate = w_gate_up_by_rank.shape[3] // 2
+    if grad_dispatch_up.shape != (ep_size, recv_capacity, intermediate):
+        raise ValueError(
+            "grad_dispatch_up must have shape [EP, R, I] matching W13 output; "
+            f"got {grad_dispatch_up.shape}, expected {(ep_size, recv_capacity, intermediate)}"
+        )
+
+    grad_recv_x = jnp.zeros_like(layout.recv_x)
+    grad_w_gate_up = jnp.zeros_like(w_gate_up_by_rank)
+    for dst_rank in range(ep_size):
+        for local_expert in range(local_experts):
+            mask = (layout.recv_local_expert[dst_rank] == local_expert) & layout.recv_valid[dst_rank]
+            x = layout.recv_x[dst_rank]
+            weights = w_gate_up_by_rank[dst_rank, local_expert]
+            gate_up = x @ weights
+            gate, up = jnp.split(gate_up, [intermediate], axis=-1)
+            grad_h = grad_dispatch_up[dst_rank] * mask[:, None]
+
+            gate_f32 = gate.astype(jnp.float32)
+            sigmoid_gate = jax.nn.sigmoid(gate_f32)
+            silu_gate = (gate_f32 * sigmoid_gate).astype(gate.dtype)
+            silu_grad = (sigmoid_gate * (1 + gate_f32 * (1 - sigmoid_gate))).astype(gate.dtype)
+            grad_gate = grad_h * up * silu_grad
+            grad_up = grad_h * silu_gate
+            grad_gate_up = jnp.concatenate([grad_gate, grad_up], axis=-1)
+
+            grad_recv_x = grad_recv_x.at[dst_rank].add(grad_gate_up @ weights.T)
+            grad_w_gate_up = grad_w_gate_up.at[dst_rank, local_expert].add(x.T @ grad_gate_up)
+    return grad_recv_x, grad_w_gate_up
+
+
+def dispatch_moe_dispatch_up_grad_reference(
+    prepacked: MoeDispatchUpPrepackedSend,
+    grad_recv_x: jax.Array,
+    *,
+    tokens_per_rank: int,
+    recv_capacity: int | None = None,
+) -> jax.Array:
+    """Route dispatched-row gradients back to source-rank token gradients."""
+
+    send_x = prepacked.send_x_by_dst
+    ep_size, _, send_capacity, hidden = send_x.shape
+    if recv_capacity is None:
+        recv_capacity = send_capacity
+    if grad_recv_x.shape != (ep_size, recv_capacity, hidden):
+        raise ValueError(
+            "grad_recv_x must have shape [EP, recv_capacity, hidden]; "
+            f"got {grad_recv_x.shape}, expected {(ep_size, recv_capacity, hidden)}"
+        )
+
+    grad_x_by_rank = jnp.zeros((ep_size, tokens_per_rank, hidden), dtype=grad_recv_x.dtype)
+    send_positions = jnp.arange(send_capacity, dtype=jnp.int32)
+    for src_rank in range(ep_size):
+        for dst_rank in range(ep_size):
+            valid_send = send_positions < prepacked.send_count_by_dst[src_rank, dst_rank]
+            row = prepacked.send_row_by_dst[src_rank, dst_rank]
+            valid_recv = valid_send & (row < recv_capacity)
+            safe_row = jnp.where(valid_recv, row, 0)
+            token_idx = prepacked.send_src_token_idx_by_dst[src_rank, dst_rank]
+            grad_x_by_rank = grad_x_by_rank.at[src_rank, token_idx].add(
+                grad_recv_x[dst_rank, safe_row] * valid_recv[:, None]
+            )
+    return grad_x_by_rank
+
+
+def moe_dispatch_up_reference_bwd(
+    x_by_rank: jax.Array,
+    expert_ids_by_rank: jax.Array,
+    router_weights_by_rank: jax.Array,
+    w_gate_up_by_rank: jax.Array,
+    grad_dispatch_up: jax.Array,
+    *,
+    num_experts: int,
+    capacity_factor: float = 1.25,
+    recv_capacity: int | None = None,
+) -> tuple[jax.Array, jax.Array]:
+    """Backward oracle for dispatch + W13/SiLU.
+
+    Returns gradients for `x_by_rank` and `w_gate_up_by_rank`. Expert ids and
+    router weights are routing metadata for this subkernel and are not
+    differentiated here.
+    """
+
+    prepacked = prepack_moe_dispatch_up_reference(
+        x_by_rank,
+        expert_ids_by_rank,
+        router_weights_by_rank,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        recv_capacity=recv_capacity,
+    )
+    actual_recv_capacity = recv_capacity if recv_capacity is not None else prepacked.send_x_by_dst.shape[2]
+    layout = dispatch_prepacked_moe_dispatch_up_reference(prepacked, recv_capacity=actual_recv_capacity)
+    grad_recv_x, grad_w_gate_up = compute_moe_up_from_layout_reference_bwd(layout, w_gate_up_by_rank, grad_dispatch_up)
+    grad_x_by_rank = dispatch_moe_dispatch_up_grad_reference(
+        prepacked,
+        grad_recv_x,
+        tokens_per_rank=x_by_rank.shape[1],
+        recv_capacity=actual_recv_capacity,
+    )
+    return grad_x_by_rank, grad_w_gate_up

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/reference.py
@@ -37,6 +37,10 @@ class MoeDispatchUpPrepackedSend(NamedTuple):
     send_count_by_dst: jax.Array
     rows_per_expert: jax.Array
     expert_base: jax.Array
+    send_expert_base_by_dst: jax.Array
+    send_expert_count_by_dst: jax.Array
+    recv_source_expert_base: jax.Array
+    recv_source_expert_count: jax.Array
     overflow_count: jax.Array
 
 
@@ -143,6 +147,13 @@ def prepack_moe_dispatch_up_reference(
     counts = _counts_by_destination_source_expert(expert_ids_by_rank, num_experts=num_experts)
     rows_per_expert = jnp.sum(counts, axis=2, dtype=jnp.int32)
     expert_base = jnp.cumsum(rows_per_expert, axis=1, dtype=jnp.int32) - rows_per_expert
+    send_expert_count_by_dst = jnp.transpose(counts, (2, 0, 1))
+    send_expert_base_by_dst = jnp.cumsum(send_expert_count_by_dst, axis=2, dtype=jnp.int32) - send_expert_count_by_dst
+    recv_source_expert_count = jnp.transpose(counts, (0, 2, 1))
+    recv_source_expert_base = jnp.transpose(
+        expert_base[:, :, None] + jnp.cumsum(counts, axis=2, dtype=jnp.int32) - counts,
+        (0, 2, 1),
+    )
     rows_per_rank = jnp.sum(rows_per_expert, axis=1, dtype=jnp.int32)
     overflow_count = jnp.sum(jnp.maximum(rows_per_rank - recv_capacity, 0), dtype=jnp.int32)
 
@@ -202,6 +213,10 @@ def prepack_moe_dispatch_up_reference(
         send_count,
         rows_per_expert,
         expert_base,
+        send_expert_base_by_dst,
+        send_expert_count_by_dst,
+        recv_source_expert_base,
+        recv_source_expert_count,
         overflow_count,
     )
 

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/reference.py
@@ -1,0 +1,308 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Pure JAX oracle for the MoE dispatch-up subkernel."""
+
+import math
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+
+
+class MoeDispatchUpLayout(NamedTuple):
+    recv_x: jax.Array
+    recv_valid: jax.Array
+    rows_per_expert: jax.Array
+    expert_base: jax.Array
+    recv_local_expert: jax.Array
+    recv_src_rank: jax.Array
+    recv_src_token_idx: jax.Array
+    recv_topk_slot: jax.Array
+    recv_router_weight: jax.Array
+    overflow_count: jax.Array
+
+
+class MoeDispatchUpPrepackedSend(NamedTuple):
+    send_x_by_dst: jax.Array
+    send_row_by_dst: jax.Array
+    send_local_expert_by_dst: jax.Array
+    send_src_token_idx_by_dst: jax.Array
+    send_topk_slot_by_dst: jax.Array
+    send_router_weight_by_dst: jax.Array
+    send_count_by_dst: jax.Array
+    rows_per_expert: jax.Array
+    expert_base: jax.Array
+    overflow_count: jax.Array
+
+
+def _validate_routing_inputs(
+    x_by_rank: jax.Array,
+    expert_ids_by_rank: jax.Array,
+    router_weights_by_rank: jax.Array,
+    *,
+    num_experts: int,
+) -> tuple[int, int, int, int]:
+    if x_by_rank.ndim != 3:
+        raise ValueError(f"x_by_rank must have shape [EP, T, D], got {x_by_rank.shape}")
+    if expert_ids_by_rank.ndim != 3:
+        raise ValueError(f"expert_ids_by_rank must have shape [EP, T, K], got {expert_ids_by_rank.shape}")
+    if router_weights_by_rank.shape != expert_ids_by_rank.shape:
+        raise ValueError(
+            "router_weights_by_rank must match expert_ids_by_rank shape; "
+            f"got {router_weights_by_rank.shape} vs {expert_ids_by_rank.shape}"
+        )
+    ep_size, tokens_per_rank, hidden = x_by_rank.shape
+    if expert_ids_by_rank.shape[0] != ep_size or expert_ids_by_rank.shape[1] != tokens_per_rank:
+        raise ValueError(
+            "x_by_rank and expert_ids_by_rank must share EP and token dimensions; "
+            f"got {x_by_rank.shape} vs {expert_ids_by_rank.shape}"
+        )
+    if num_experts % ep_size != 0:
+        raise ValueError(f"num_experts={num_experts} must be divisible by ep_size={ep_size}")
+    top_k = expert_ids_by_rank.shape[2]
+    return ep_size, tokens_per_rank, hidden, top_k
+
+
+def _recv_capacity(
+    *,
+    ep_size: int,
+    tokens_per_rank: int,
+    top_k: int,
+    capacity_factor: float,
+    recv_capacity: int | None,
+) -> int:
+    if recv_capacity is not None:
+        return recv_capacity
+    assignments_per_rank = tokens_per_rank * top_k
+    return max(1, int(math.ceil(capacity_factor * assignments_per_rank)))
+
+
+def _send_capacity(*, tokens_per_rank: int, top_k: int, send_capacity: int | None) -> int:
+    if send_capacity is not None:
+        return send_capacity
+    return tokens_per_rank * top_k
+
+
+def _counts_by_destination_source_expert(
+    expert_ids_by_rank: jax.Array,
+    *,
+    num_experts: int,
+) -> jax.Array:
+    ep_size = expert_ids_by_rank.shape[0]
+    local_experts = num_experts // ep_size
+    counts = jnp.zeros((ep_size, local_experts, ep_size), dtype=jnp.int32)
+    flat_experts_by_rank = expert_ids_by_rank.reshape(ep_size, -1)
+    for dst_rank in range(ep_size):
+        expert_start = dst_rank * local_experts
+        for local_expert in range(local_experts):
+            global_expert = expert_start + local_expert
+            for src_rank in range(ep_size):
+                count = jnp.sum(flat_experts_by_rank[src_rank] == global_expert, dtype=jnp.int32)
+                counts = counts.at[dst_rank, local_expert, src_rank].set(count)
+    return counts
+
+
+def prepack_moe_dispatch_up_reference(
+    x_by_rank: jax.Array,
+    expert_ids_by_rank: jax.Array,
+    router_weights_by_rank: jax.Array,
+    *,
+    num_experts: int,
+    capacity_factor: float = 1.25,
+    recv_capacity: int | None = None,
+    send_capacity: int | None = None,
+) -> MoeDispatchUpPrepackedSend:
+    """Prepack source-owned sends and final destination row indices.
+
+    Rows are ordered by destination local expert, then source rank, then source
+    local assignment position. The final row index is included so the Mosaic
+    validation primitive can focus only on remote writes.
+    """
+
+    ep_size, tokens_per_rank, hidden, top_k = _validate_routing_inputs(
+        x_by_rank,
+        expert_ids_by_rank,
+        router_weights_by_rank,
+        num_experts=num_experts,
+    )
+    local_experts = num_experts // ep_size
+    recv_capacity = _recv_capacity(
+        ep_size=ep_size,
+        tokens_per_rank=tokens_per_rank,
+        top_k=top_k,
+        capacity_factor=capacity_factor,
+        recv_capacity=recv_capacity,
+    )
+    send_capacity = _send_capacity(tokens_per_rank=tokens_per_rank, top_k=top_k, send_capacity=send_capacity)
+
+    counts = _counts_by_destination_source_expert(expert_ids_by_rank, num_experts=num_experts)
+    rows_per_expert = jnp.sum(counts, axis=2, dtype=jnp.int32)
+    expert_base = jnp.cumsum(rows_per_expert, axis=1, dtype=jnp.int32) - rows_per_expert
+    rows_per_rank = jnp.sum(rows_per_expert, axis=1, dtype=jnp.int32)
+    overflow_count = jnp.sum(jnp.maximum(rows_per_rank - recv_capacity, 0), dtype=jnp.int32)
+
+    send_x = jnp.zeros((ep_size, ep_size, send_capacity, hidden), dtype=x_by_rank.dtype)
+    send_row = jnp.zeros((ep_size, ep_size, send_capacity), dtype=jnp.int32)
+    send_local_expert = jnp.zeros((ep_size, ep_size, send_capacity), dtype=jnp.int32)
+    send_src_token_idx = jnp.zeros((ep_size, ep_size, send_capacity), dtype=jnp.int32)
+    send_topk_slot = jnp.zeros((ep_size, ep_size, send_capacity), dtype=jnp.int32)
+    send_router_weight = jnp.zeros((ep_size, ep_size, send_capacity), dtype=router_weights_by_rank.dtype)
+    send_count = jnp.zeros((ep_size, ep_size), dtype=jnp.int32)
+
+    token_ids = jnp.arange(tokens_per_rank, dtype=jnp.int32)[:, None]
+    topk_slots = jnp.arange(top_k, dtype=jnp.int32)[None, :]
+    flat_token_ids = jnp.broadcast_to(token_ids, (tokens_per_rank, top_k)).reshape(-1)
+    flat_topk_slots = jnp.broadcast_to(topk_slots, (tokens_per_rank, top_k)).reshape(-1)
+
+    for src_rank in range(ep_size):
+        flat_experts = expert_ids_by_rank[src_rank].reshape(-1)
+        flat_weights = router_weights_by_rank[src_rank].reshape(-1)
+        flat_x = x_by_rank[src_rank, flat_token_ids]
+        for dst_rank in range(ep_size):
+            send_base_for_expert = (
+                jnp.cumsum(counts[dst_rank, :, src_rank], dtype=jnp.int32) - counts[dst_rank, :, src_rank]
+            )
+            for local_expert in range(local_experts):
+                global_expert = dst_rank * local_experts + local_expert
+                mask = flat_experts == global_expert
+                local_rank = jnp.cumsum(mask.astype(jnp.int32), dtype=jnp.int32) - 1
+                send_slot = send_base_for_expert[local_expert] + local_rank
+                dst_src_base = jnp.sum(counts[dst_rank, local_expert, :src_rank], dtype=jnp.int32)
+                dst_row = expert_base[dst_rank, local_expert] + dst_src_base + local_rank
+                safe_slot = jnp.where(mask, send_slot, 0)
+
+                send_x = send_x.at[src_rank, dst_rank, safe_slot].add(flat_x * mask[:, None])
+                send_row = send_row.at[src_rank, dst_rank, safe_slot].add(jnp.where(mask, dst_row, 0))
+                send_local_expert = send_local_expert.at[src_rank, dst_rank, safe_slot].add(
+                    jnp.where(mask, local_expert, 0)
+                )
+                send_src_token_idx = send_src_token_idx.at[src_rank, dst_rank, safe_slot].add(
+                    jnp.where(mask, flat_token_ids, 0)
+                )
+                send_topk_slot = send_topk_slot.at[src_rank, dst_rank, safe_slot].add(
+                    jnp.where(mask, flat_topk_slots, 0)
+                )
+                send_router_weight = send_router_weight.at[src_rank, dst_rank, safe_slot].add(
+                    flat_weights * mask.astype(flat_weights.dtype)
+                )
+            send_count = send_count.at[src_rank, dst_rank].set(jnp.sum(counts[dst_rank, :, src_rank], dtype=jnp.int32))
+
+    return MoeDispatchUpPrepackedSend(
+        send_x,
+        send_row,
+        send_local_expert,
+        send_src_token_idx,
+        send_topk_slot,
+        send_router_weight,
+        send_count,
+        rows_per_expert,
+        expert_base,
+        overflow_count,
+    )
+
+
+def dispatch_prepacked_moe_dispatch_up_reference(
+    prepacked: MoeDispatchUpPrepackedSend,
+    *,
+    recv_capacity: int | None = None,
+) -> MoeDispatchUpLayout:
+    """Destination-owned expert-major dispatch from prepacked source sends."""
+
+    send_x = prepacked.send_x_by_dst
+    ep_size, _, send_capacity, hidden = send_x.shape
+    if recv_capacity is None:
+        recv_capacity = send_capacity
+
+    recv_x = jnp.zeros((ep_size, recv_capacity, hidden), dtype=send_x.dtype)
+    recv_valid_count = jnp.zeros((ep_size, recv_capacity), dtype=jnp.int32)
+    recv_local_expert = jnp.zeros((ep_size, recv_capacity), dtype=jnp.int32)
+    recv_src_rank = jnp.zeros((ep_size, recv_capacity), dtype=jnp.int32)
+    recv_src_token_idx = jnp.zeros((ep_size, recv_capacity), dtype=jnp.int32)
+    recv_topk_slot = jnp.zeros((ep_size, recv_capacity), dtype=jnp.int32)
+    recv_router_weight = jnp.zeros((ep_size, recv_capacity), dtype=prepacked.send_router_weight_by_dst.dtype)
+
+    send_positions = jnp.arange(send_capacity, dtype=jnp.int32)
+    for src_rank in range(ep_size):
+        for dst_rank in range(ep_size):
+            valid_send = send_positions < prepacked.send_count_by_dst[src_rank, dst_rank]
+            row = prepacked.send_row_by_dst[src_rank, dst_rank]
+            valid_recv = valid_send & (row < recv_capacity)
+            safe_row = jnp.where(valid_recv, row, 0)
+            recv_x = recv_x.at[dst_rank, safe_row].add(
+                prepacked.send_x_by_dst[src_rank, dst_rank] * valid_recv[:, None]
+            )
+            recv_valid_count = recv_valid_count.at[dst_rank, safe_row].add(valid_recv.astype(jnp.int32))
+            recv_local_expert = recv_local_expert.at[dst_rank, safe_row].add(
+                prepacked.send_local_expert_by_dst[src_rank, dst_rank] * valid_recv.astype(jnp.int32)
+            )
+            recv_src_rank = recv_src_rank.at[dst_rank, safe_row].add(src_rank * valid_recv.astype(jnp.int32))
+            recv_src_token_idx = recv_src_token_idx.at[dst_rank, safe_row].add(
+                prepacked.send_src_token_idx_by_dst[src_rank, dst_rank] * valid_recv.astype(jnp.int32)
+            )
+            recv_topk_slot = recv_topk_slot.at[dst_rank, safe_row].add(
+                prepacked.send_topk_slot_by_dst[src_rank, dst_rank] * valid_recv.astype(jnp.int32)
+            )
+            recv_router_weight = recv_router_weight.at[dst_rank, safe_row].add(
+                prepacked.send_router_weight_by_dst[src_rank, dst_rank]
+                * valid_recv.astype(prepacked.send_router_weight_by_dst.dtype)
+            )
+
+    return MoeDispatchUpLayout(
+        recv_x,
+        recv_valid_count > 0,
+        prepacked.rows_per_expert,
+        prepacked.expert_base,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        prepacked.overflow_count,
+    )
+
+
+def moe_dispatch_up_layout_reference(
+    x_by_rank: jax.Array,
+    expert_ids_by_rank: jax.Array,
+    router_weights_by_rank: jax.Array,
+    *,
+    num_experts: int,
+    capacity_factor: float = 1.25,
+    recv_capacity: int | None = None,
+) -> MoeDispatchUpLayout:
+    prepacked = prepack_moe_dispatch_up_reference(
+        x_by_rank,
+        expert_ids_by_rank,
+        router_weights_by_rank,
+        num_experts=num_experts,
+        capacity_factor=capacity_factor,
+        recv_capacity=recv_capacity,
+    )
+    return dispatch_prepacked_moe_dispatch_up_reference(prepacked, recv_capacity=prepacked.send_x_by_dst.shape[2])
+
+
+def compute_moe_up_from_layout_reference(
+    layout: MoeDispatchUpLayout,
+    w_gate_up_by_rank: jax.Array,
+) -> jax.Array:
+    """Compute expert-local W13 followed by `silu(gate) * up` for routed rows."""
+
+    if w_gate_up_by_rank.ndim != 4:
+        raise ValueError(f"w_gate_up_by_rank must have shape [EP, EL, D, 2I], got {w_gate_up_by_rank.shape}")
+    ep_size, recv_capacity, hidden = layout.recv_x.shape
+    if w_gate_up_by_rank.shape[0] != ep_size or w_gate_up_by_rank.shape[2] != hidden:
+        raise ValueError(
+            "w_gate_up_by_rank must share EP and hidden dimensions with layout.recv_x; "
+            f"got {w_gate_up_by_rank.shape} vs {layout.recv_x.shape}"
+        )
+    intermediate = w_gate_up_by_rank.shape[3] // 2
+    h = jnp.zeros((ep_size, recv_capacity, intermediate), dtype=layout.recv_x.dtype)
+    for dst_rank in range(ep_size):
+        for local_expert in range(w_gate_up_by_rank.shape[1]):
+            mask = (layout.recv_local_expert[dst_rank] == local_expert) & layout.recv_valid[dst_rank]
+            gate_up = layout.recv_x[dst_rank] @ w_gate_up_by_rank[dst_rank, local_expert]
+            gate, up = jnp.split(gate_up, [intermediate], axis=-1)
+            expert_h = jax.nn.silu(gate.astype(jnp.float32)).astype(gate.dtype) * up
+            h = h.at[dst_rank].add(expert_h * mask[:, None])
+    return h

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/reference.py
@@ -44,6 +44,20 @@ class MoeDispatchUpPrepackedSend(NamedTuple):
     overflow_count: jax.Array
 
 
+class MoeDispatchUpSourceExpertPrepackedSend(NamedTuple):
+    send_x_by_dst_expert: jax.Array
+    send_src_token_idx_by_dst_expert: jax.Array
+    send_topk_slot_by_dst_expert: jax.Array
+    send_router_weight_by_dst_expert: jax.Array
+    send_row_base_by_dst_expert: jax.Array
+    send_count_by_dst_expert: jax.Array
+    rows_per_expert: jax.Array
+    expert_base: jax.Array
+    recv_source_expert_base: jax.Array
+    recv_source_expert_count: jax.Array
+    overflow_count: jax.Array
+
+
 def _validate_routing_inputs(
     x_by_rank: jax.Array,
     expert_ids_by_rank: jax.Array,
@@ -218,6 +232,180 @@ def prepack_moe_dispatch_up_reference(
         recv_source_expert_base,
         recv_source_expert_count,
         overflow_count,
+    )
+
+
+def prepack_moe_dispatch_up_source_expert_reference(
+    x_by_rank: jax.Array,
+    expert_ids_by_rank: jax.Array,
+    router_weights_by_rank: jax.Array,
+    *,
+    num_experts: int,
+    capacity_factor: float = 1.25,
+    recv_capacity: int | None = None,
+    source_expert_capacity: int | None = None,
+) -> MoeDispatchUpSourceExpertPrepackedSend:
+    """Prepack sends by destination and local expert.
+
+    This is a compact source-owned representation for Mosaic GPU bring-up. Rows
+    are grouped as `[src, dst, local_expert, source_expert_row]`, avoiding the
+    conservative `[src, dst, T*K]` capacity used by the original validation
+    prepack.
+    """
+
+    ep_size, tokens_per_rank, hidden, top_k = _validate_routing_inputs(
+        x_by_rank,
+        expert_ids_by_rank,
+        router_weights_by_rank,
+        num_experts=num_experts,
+    )
+    local_experts = num_experts // ep_size
+    recv_capacity = _recv_capacity(
+        ep_size=ep_size,
+        tokens_per_rank=tokens_per_rank,
+        top_k=top_k,
+        capacity_factor=capacity_factor,
+        recv_capacity=recv_capacity,
+    )
+
+    counts = _counts_by_destination_source_expert(expert_ids_by_rank, num_experts=num_experts)
+    if source_expert_capacity is None:
+        source_expert_capacity = max(1, int(jax.device_get(jnp.max(counts))))
+    if source_expert_capacity < 1:
+        raise ValueError(f"source_expert_capacity must be positive, got {source_expert_capacity}")
+
+    rows_per_expert = jnp.sum(counts, axis=2, dtype=jnp.int32)
+    expert_base = jnp.cumsum(rows_per_expert, axis=1, dtype=jnp.int32) - rows_per_expert
+    recv_source_expert_count = jnp.transpose(counts, (0, 2, 1))
+    recv_source_expert_base = jnp.transpose(
+        expert_base[:, :, None] + jnp.cumsum(counts, axis=2, dtype=jnp.int32) - counts,
+        (0, 2, 1),
+    )
+    rows_per_rank = jnp.sum(rows_per_expert, axis=1, dtype=jnp.int32)
+    receiver_overflow = jnp.sum(jnp.maximum(rows_per_rank - recv_capacity, 0), dtype=jnp.int32)
+    source_expert_overflow = jnp.sum(jnp.maximum(counts - source_expert_capacity, 0), dtype=jnp.int32)
+    overflow_count = receiver_overflow + source_expert_overflow
+
+    send_x = jnp.zeros(
+        (ep_size, ep_size, local_experts, source_expert_capacity, hidden),
+        dtype=x_by_rank.dtype,
+    )
+    send_src_token_idx = jnp.zeros(
+        (ep_size, ep_size, local_experts, source_expert_capacity),
+        dtype=jnp.int32,
+    )
+    send_topk_slot = jnp.zeros(
+        (ep_size, ep_size, local_experts, source_expert_capacity),
+        dtype=jnp.int32,
+    )
+    send_router_weight = jnp.zeros(
+        (ep_size, ep_size, local_experts, source_expert_capacity),
+        dtype=router_weights_by_rank.dtype,
+    )
+    send_row_base = jnp.transpose(recv_source_expert_base, (1, 0, 2))
+    send_count = jnp.transpose(counts, (2, 0, 1))
+
+    token_ids = jnp.arange(tokens_per_rank, dtype=jnp.int32)[:, None]
+    topk_slots = jnp.arange(top_k, dtype=jnp.int32)[None, :]
+    flat_token_ids = jnp.broadcast_to(token_ids, (tokens_per_rank, top_k)).reshape(-1)
+    flat_topk_slots = jnp.broadcast_to(topk_slots, (tokens_per_rank, top_k)).reshape(-1)
+
+    for src_rank in range(ep_size):
+        flat_experts = expert_ids_by_rank[src_rank].reshape(-1)
+        flat_weights = router_weights_by_rank[src_rank].reshape(-1)
+        flat_x = x_by_rank[src_rank, flat_token_ids]
+        for dst_rank in range(ep_size):
+            for local_expert in range(local_experts):
+                global_expert = dst_rank * local_experts + local_expert
+                mask = flat_experts == global_expert
+                local_rank = jnp.cumsum(mask.astype(jnp.int32), dtype=jnp.int32) - 1
+                valid = mask & (local_rank < source_expert_capacity)
+                safe_slot = jnp.where(valid, local_rank, 0)
+
+                send_x = send_x.at[src_rank, dst_rank, local_expert, safe_slot].add(flat_x * valid[:, None])
+                send_src_token_idx = send_src_token_idx.at[src_rank, dst_rank, local_expert, safe_slot].add(
+                    jnp.where(valid, flat_token_ids, 0)
+                )
+                send_topk_slot = send_topk_slot.at[src_rank, dst_rank, local_expert, safe_slot].add(
+                    jnp.where(valid, flat_topk_slots, 0)
+                )
+                send_router_weight = send_router_weight.at[src_rank, dst_rank, local_expert, safe_slot].add(
+                    flat_weights * valid.astype(flat_weights.dtype)
+                )
+
+    return MoeDispatchUpSourceExpertPrepackedSend(
+        send_x,
+        send_src_token_idx,
+        send_topk_slot,
+        send_router_weight,
+        send_row_base,
+        send_count,
+        rows_per_expert,
+        expert_base,
+        recv_source_expert_base,
+        recv_source_expert_count,
+        overflow_count,
+    )
+
+
+def dispatch_prepacked_moe_dispatch_up_source_expert_reference(
+    prepacked: MoeDispatchUpSourceExpertPrepackedSend,
+    *,
+    recv_capacity: int | None = None,
+) -> MoeDispatchUpLayout:
+    """Destination-owned dispatch from compact source/expert prepack."""
+
+    send_x = prepacked.send_x_by_dst_expert
+    ep_size, _, local_experts, source_expert_capacity, hidden = send_x.shape
+    if recv_capacity is None:
+        recv_capacity = source_expert_capacity * ep_size * local_experts
+
+    recv_x = jnp.zeros((ep_size, recv_capacity, hidden), dtype=send_x.dtype)
+    recv_valid_count = jnp.zeros((ep_size, recv_capacity), dtype=jnp.int32)
+    recv_local_expert = jnp.zeros((ep_size, recv_capacity), dtype=jnp.int32)
+    recv_src_rank = jnp.zeros((ep_size, recv_capacity), dtype=jnp.int32)
+    recv_src_token_idx = jnp.zeros((ep_size, recv_capacity), dtype=jnp.int32)
+    recv_topk_slot = jnp.zeros((ep_size, recv_capacity), dtype=jnp.int32)
+    recv_router_weight = jnp.zeros((ep_size, recv_capacity), dtype=prepacked.send_router_weight_by_dst_expert.dtype)
+
+    positions = jnp.arange(source_expert_capacity, dtype=jnp.int32)
+    for dst_rank in range(ep_size):
+        for src_rank in range(ep_size):
+            for local_expert in range(local_experts):
+                count = prepacked.send_count_by_dst_expert[src_rank, dst_rank, local_expert]
+                row = prepacked.send_row_base_by_dst_expert[src_rank, dst_rank, local_expert] + positions
+                valid_recv = (positions < count) & (row < recv_capacity)
+                safe_row = jnp.where(valid_recv, row, 0)
+                valid_i32 = valid_recv.astype(jnp.int32)
+
+                recv_x = recv_x.at[dst_rank, safe_row].add(
+                    prepacked.send_x_by_dst_expert[src_rank, dst_rank, local_expert] * valid_recv[:, None]
+                )
+                recv_valid_count = recv_valid_count.at[dst_rank, safe_row].add(valid_i32)
+                recv_local_expert = recv_local_expert.at[dst_rank, safe_row].add(local_expert * valid_i32)
+                recv_src_rank = recv_src_rank.at[dst_rank, safe_row].add(src_rank * valid_i32)
+                recv_src_token_idx = recv_src_token_idx.at[dst_rank, safe_row].add(
+                    prepacked.send_src_token_idx_by_dst_expert[src_rank, dst_rank, local_expert] * valid_i32
+                )
+                recv_topk_slot = recv_topk_slot.at[dst_rank, safe_row].add(
+                    prepacked.send_topk_slot_by_dst_expert[src_rank, dst_rank, local_expert] * valid_i32
+                )
+                recv_router_weight = recv_router_weight.at[dst_rank, safe_row].add(
+                    prepacked.send_router_weight_by_dst_expert[src_rank, dst_rank, local_expert]
+                    * valid_recv.astype(prepacked.send_router_weight_by_dst_expert.dtype)
+                )
+
+    return MoeDispatchUpLayout(
+        recv_x,
+        recv_valid_count > 0,
+        prepacked.rows_per_expert,
+        prepacked.expert_base,
+        recv_local_expert,
+        recv_src_rank,
+        recv_src_token_idx,
+        recv_topk_slot,
+        recv_router_weight,
+        prepacked.overflow_count,
     )
 
 

--- a/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/reference.py
+++ b/lib/levanter/src/levanter/kernels/pallas/moe_dispatch_up/reference.py
@@ -4,10 +4,14 @@
 """Pure JAX oracle for the MoE dispatch-up subkernel."""
 
 import math
-from typing import NamedTuple
+from typing import Literal, NamedTuple
 
 import jax
 import jax.numpy as jnp
+
+from haliax.nn.ragged_dot import ragged_dot
+
+RaggedDotImplementation = Literal["auto", "megablox", "triton", "xla"]
 
 
 class MoeDispatchUpLayout(NamedTuple):
@@ -306,6 +310,43 @@ def compute_moe_up_from_layout_reference(
             expert_h = jax.nn.silu(gate.astype(jnp.float32)).astype(gate.dtype) * up
             h = h.at[dst_rank].add(expert_h * mask[:, None])
     return h
+
+
+def _effective_rows_per_expert(layout: MoeDispatchUpLayout) -> jax.Array:
+    recv_capacity = layout.recv_x.shape[1]
+    remaining_capacity = jnp.maximum(recv_capacity - layout.expert_base, 0)
+    return jnp.minimum(layout.rows_per_expert, remaining_capacity)
+
+
+def compute_moe_up_from_layout_ragged_dot(
+    layout: MoeDispatchUpLayout,
+    w_gate_up_by_rank: jax.Array,
+    *,
+    implementation: RaggedDotImplementation = "auto",
+) -> jax.Array:
+    """Compute W13/SiLU from a dispatched layout using Haliax grouped matmul."""
+
+    if w_gate_up_by_rank.ndim != 4:
+        raise ValueError(f"w_gate_up_by_rank must have shape [EP, EL, D, 2I], got {w_gate_up_by_rank.shape}")
+    ep_size, recv_capacity, hidden = layout.recv_x.shape
+    if w_gate_up_by_rank.shape[0] != ep_size or w_gate_up_by_rank.shape[2] != hidden:
+        raise ValueError(
+            "w_gate_up_by_rank must share EP and hidden dimensions with layout.recv_x; "
+            f"got {w_gate_up_by_rank.shape} vs {layout.recv_x.shape}"
+        )
+    if w_gate_up_by_rank.shape[3] % 2 != 0:
+        raise ValueError(f"w_gate_up_by_rank last dimension must be even, got {w_gate_up_by_rank.shape[3]}")
+
+    effective_rows = _effective_rows_per_expert(layout)
+
+    def rank_w13(recv_x: jax.Array, group_sizes: jax.Array, w_gate_up: jax.Array) -> jax.Array:
+        w13_out = ragged_dot(recv_x, w_gate_up, group_sizes, implementation=implementation)
+        gate, up = jnp.split(w13_out, 2, axis=-1)
+        h = jax.nn.silu(gate.astype(jnp.float32)).astype(gate.dtype) * up
+        valid_rows = jnp.arange(recv_capacity, dtype=jnp.int32) < jnp.sum(group_sizes, dtype=jnp.int32)
+        return jnp.where(valid_rows[:, None], h, jnp.zeros((), dtype=h.dtype))
+
+    return jax.vmap(rank_w13)(layout.recv_x, effective_rows, w_gate_up_by_rank)
 
 
 def compute_moe_up_from_layout_reference_bwd(

--- a/lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py
+++ b/lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py
@@ -202,6 +202,55 @@ def test_moe_dispatch_up_reference_is_differentiable():
     assert jnp.isfinite(grad).all()
 
 
+def test_moe_dispatch_up_backward_reference_matches_autodiff():
+    ep_size = 2
+    tokens_per_rank = 4
+    experts_per_rank = 2
+    top_k = 2
+    hidden = 3
+    intermediate = 5
+    num_experts = ep_size * experts_per_rank
+    recv_capacity = ep_size * tokens_per_rank * top_k
+    key = jax.random.key(6597)
+    k_x, k_w, k_g = jax.random.split(key, 3)
+    x_by_rank = jax.random.normal(k_x, (ep_size, tokens_per_rank, hidden), dtype=jnp.float32)
+    w_gate_up = jax.random.normal(k_w, (ep_size, experts_per_rank, hidden, 2 * intermediate), dtype=jnp.float32)
+    rank_ids = jnp.arange(ep_size, dtype=jnp.int32)[:, None, None]
+    token_ids = jnp.arange(tokens_per_rank, dtype=jnp.int32)[None, :, None]
+    slot_ids = jnp.arange(top_k, dtype=jnp.int32)[None, None, :]
+    expert_ids = (rank_ids * experts_per_rank + token_ids + slot_ids) % num_experts
+    router_weights = jax.nn.softmax(
+        jnp.arange(ep_size * tokens_per_rank * top_k, dtype=jnp.float32).reshape(ep_size, tokens_per_rank, top_k),
+        axis=-1,
+    )
+    grad_dispatch_up = jax.random.normal(k_g, (ep_size, recv_capacity, intermediate), dtype=jnp.float32)
+
+    def loss(x_arg, w_arg):
+        dispatch_up, _layout = dispatch_up_api.moe_dispatch_up(
+            x_arg,
+            expert_ids,
+            router_weights,
+            w_arg,
+            num_experts=num_experts,
+            recv_capacity=recv_capacity,
+        )
+        return jnp.sum(dispatch_up * grad_dispatch_up)
+
+    autodiff_grad_x, autodiff_grad_w = jax.grad(loss, argnums=(0, 1))(x_by_rank, w_gate_up)
+    explicit_grad_x, explicit_grad_w = dispatch_up_api.moe_dispatch_up_bwd_reference(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        w_gate_up,
+        grad_dispatch_up,
+        num_experts=num_experts,
+        recv_capacity=recv_capacity,
+    )
+
+    np.testing.assert_allclose(np.asarray(explicit_grad_x), np.asarray(autodiff_grad_x), rtol=1e-5, atol=1e-5)
+    np.testing.assert_allclose(np.asarray(explicit_grad_w), np.asarray(autodiff_grad_w), rtol=1e-5, atol=1e-5)
+
+
 def test_explicit_mosaic_gpu_dispatch_requires_local_gpu_mesh():
     if len([device for device in jax.local_devices() if device.platform == "gpu"]) >= 2:
         pytest.skip("local host has an MGPU runtime")

--- a/lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py
+++ b/lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py
@@ -12,6 +12,7 @@ from levanter.kernels.pallas.moe_dispatch_up.reference import (
     MoeDispatchUpLayout,
     dispatch_prepacked_moe_dispatch_up_reference,
     compute_moe_up_from_layout_reference,
+    compute_moe_up_from_layout_ragged_dot,
     prepack_moe_dispatch_up_reference,
 )
 
@@ -200,6 +201,52 @@ def test_moe_dispatch_up_reference_is_differentiable():
 
     assert grad.shape == w_gate_up.shape
     assert jnp.isfinite(grad).all()
+
+
+def test_moe_dispatch_up_ragged_dot_matches_reference_with_capacity_overflow():
+    x_by_rank, expert_ids, router_weights = _hand_routing_inputs()
+    w_gate_up = jnp.arange(2 * 2 * 2 * 6, dtype=jnp.float32).reshape(2, 2, 2, 6) / 13.0
+    prepacked = prepack_moe_dispatch_up_reference(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        num_experts=4,
+        recv_capacity=4,
+    )
+    layout = dispatch_prepacked_moe_dispatch_up_reference(prepacked, recv_capacity=4)
+
+    expected = compute_moe_up_from_layout_reference(layout, w_gate_up)
+    actual = compute_moe_up_from_layout_ragged_dot(layout, w_gate_up, implementation="xla")
+
+    np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
+    assert int(np.asarray(layout.overflow_count)) == 4
+
+
+def test_moe_dispatch_up_api_can_use_ragged_dot_w13():
+    x_by_rank, expert_ids, router_weights = _hand_routing_inputs()
+    w_gate_up = jnp.arange(2 * 2 * 2 * 6, dtype=jnp.float32).reshape(2, 2, 2, 6) / 13.0
+
+    expected, expected_layout = dispatch_up_api.moe_dispatch_up(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        w_gate_up,
+        num_experts=4,
+        recv_capacity=6,
+    )
+    actual, actual_layout = dispatch_up_api.moe_dispatch_up(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        w_gate_up,
+        num_experts=4,
+        recv_capacity=6,
+        w13_implementation="ragged_dot",
+        ragged_dot_implementation="xla",
+    )
+
+    np.testing.assert_allclose(np.asarray(actual), np.asarray(expected), rtol=1e-5, atol=1e-5)
+    np.testing.assert_array_equal(np.asarray(actual_layout.recv_x), np.asarray(expected_layout.recv_x))
 
 
 def test_moe_dispatch_up_backward_reference_matches_autodiff():

--- a/lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py
+++ b/lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py
@@ -63,6 +63,46 @@ def test_moe_dispatch_up_layout_reference_uses_expert_major_source_rank_order():
         np.array([[0, 3], [0, 3]], dtype=np.int32),
     )
     np.testing.assert_array_equal(
+        np.asarray(prepacked.send_expert_count_by_dst),
+        np.array(
+            [
+                [[2, 1], [1, 2]],
+                [[1, 2], [2, 1]],
+            ],
+            dtype=np.int32,
+        ),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(prepacked.send_expert_base_by_dst),
+        np.array(
+            [
+                [[0, 2], [0, 1]],
+                [[0, 1], [0, 2]],
+            ],
+            dtype=np.int32,
+        ),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(prepacked.recv_source_expert_count),
+        np.array(
+            [
+                [[2, 1], [1, 2]],
+                [[1, 2], [2, 1]],
+            ],
+            dtype=np.int32,
+        ),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(prepacked.recv_source_expert_base),
+        np.array(
+            [
+                [[0, 3], [2, 4]],
+                [[0, 3], [1, 5]],
+            ],
+            dtype=np.int32,
+        ),
+    )
+    np.testing.assert_array_equal(
         np.asarray(layout.recv_valid),
         np.ones((2, 6), dtype=np.bool_),
     )

--- a/lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py
+++ b/lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py
@@ -1,0 +1,218 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import numpy as np
+import pytest
+
+import jax
+import jax.numpy as jnp
+
+from levanter.kernels.pallas.moe_dispatch_up import api as dispatch_up_api
+from levanter.kernels.pallas.moe_dispatch_up.reference import (
+    MoeDispatchUpLayout,
+    dispatch_prepacked_moe_dispatch_up_reference,
+    compute_moe_up_from_layout_reference,
+    prepack_moe_dispatch_up_reference,
+)
+
+
+def _hand_routing_inputs():
+    x_by_rank = jnp.array(
+        [
+            [[10.0, 11.0], [12.0, 13.0], [14.0, 15.0]],
+            [[20.0, 21.0], [22.0, 23.0], [24.0, 25.0]],
+        ],
+        dtype=jnp.float32,
+    )
+    expert_ids = jnp.array(
+        [
+            [[0, 2], [1, 3], [0, 3]],
+            [[1, 2], [0, 3], [2, 1]],
+        ],
+        dtype=jnp.int32,
+    )
+    router_weights = jnp.array(
+        [
+            [[0.1, 0.2], [0.3, 0.4], [0.5, 0.6]],
+            [[0.7, 0.8], [0.9, 1.0], [1.1, 1.2]],
+        ],
+        dtype=jnp.float32,
+    )
+    return x_by_rank, expert_ids, router_weights
+
+
+def test_moe_dispatch_up_layout_reference_uses_expert_major_source_rank_order():
+    x_by_rank, expert_ids, router_weights = _hand_routing_inputs()
+
+    prepacked = prepack_moe_dispatch_up_reference(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        num_experts=4,
+        recv_capacity=6,
+    )
+    layout = dispatch_prepacked_moe_dispatch_up_reference(prepacked, recv_capacity=6)
+
+    np.testing.assert_array_equal(
+        np.asarray(layout.rows_per_expert),
+        np.array([[3, 3], [3, 3]], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(layout.expert_base),
+        np.array([[0, 3], [0, 3]], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(
+        np.asarray(layout.recv_valid),
+        np.ones((2, 6), dtype=np.bool_),
+    )
+    np.testing.assert_allclose(
+        np.asarray(layout.recv_x[0]),
+        np.array(
+            [
+                [10.0, 11.0],
+                [14.0, 15.0],
+                [22.0, 23.0],
+                [12.0, 13.0],
+                [20.0, 21.0],
+                [24.0, 25.0],
+            ],
+            dtype=np.float32,
+        ),
+        rtol=0,
+        atol=0,
+    )
+    np.testing.assert_array_equal(np.asarray(layout.recv_src_rank[0]), np.array([0, 0, 1, 0, 1, 1], dtype=np.int32))
+    np.testing.assert_array_equal(
+        np.asarray(layout.recv_src_token_idx[0]),
+        np.array([0, 2, 1, 1, 0, 2], dtype=np.int32),
+    )
+    np.testing.assert_array_equal(np.asarray(layout.recv_topk_slot[0]), np.array([0, 0, 0, 0, 0, 1], dtype=np.int32))
+    np.testing.assert_allclose(
+        np.asarray(layout.recv_router_weight[0]),
+        np.array([0.1, 0.5, 0.9, 0.3, 0.7, 1.2], dtype=np.float32),
+        rtol=1e-6,
+        atol=1e-6,
+    )
+
+
+def test_moe_dispatch_up_prepack_matches_direct_layout_reference():
+    x_by_rank, expert_ids, router_weights = _hand_routing_inputs()
+
+    prepacked = dispatch_up_api.prepack_moe_dispatch_up(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        num_experts=4,
+        recv_capacity=6,
+    )
+    from_prepack = dispatch_up_api.moe_dispatch_up_layout(prepacked, recv_capacity=6)
+    direct = dispatch_up_api.moe_dispatch_up_layout_reference(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        num_experts=4,
+        recv_capacity=6,
+    )
+
+    np.testing.assert_allclose(np.asarray(from_prepack.recv_x), np.asarray(direct.recv_x), rtol=0, atol=0)
+    np.testing.assert_array_equal(np.asarray(from_prepack.recv_valid), np.asarray(direct.recv_valid))
+    np.testing.assert_array_equal(np.asarray(from_prepack.recv_src_rank), np.asarray(direct.recv_src_rank))
+    np.testing.assert_array_equal(np.asarray(from_prepack.recv_src_token_idx), np.asarray(direct.recv_src_token_idx))
+    np.testing.assert_array_equal(np.asarray(from_prepack.recv_topk_slot), np.asarray(direct.recv_topk_slot))
+
+
+def _manual_w13_silu(layout: MoeDispatchUpLayout, w_gate_up_by_rank: jax.Array) -> jax.Array:
+    ep_size, recv_capacity, _hidden = layout.recv_x.shape
+    intermediate = w_gate_up_by_rank.shape[-1] // 2
+    out = []
+    for dst_rank in range(ep_size):
+        rows = []
+        for row in range(recv_capacity):
+            if not bool(np.asarray(layout.recv_valid[dst_rank, row])):
+                rows.append(np.zeros((intermediate,), dtype=np.float32))
+                continue
+            local_expert = int(np.asarray(layout.recv_local_expert[dst_rank, row]))
+            gate_up = np.asarray(layout.recv_x[dst_rank, row]) @ np.asarray(w_gate_up_by_rank[dst_rank, local_expert])
+            gate, up = np.split(gate_up, 2)
+            rows.append(np.asarray(jax.nn.silu(jnp.asarray(gate)) * jnp.asarray(up)))
+        out.append(np.stack(rows, axis=0))
+    return jnp.asarray(np.stack(out, axis=0), dtype=layout.recv_x.dtype)
+
+
+@pytest.mark.parametrize(
+    ("ep_size", "experts_per_rank", "top_k"),
+    [
+        (2, 1, 1),
+        (2, 2, 4),
+        (8, 1, 1),
+        (8, 4, 4),
+    ],
+)
+def test_moe_dispatch_up_matches_manual_reference(ep_size: int, experts_per_rank: int, top_k: int):
+    tokens_per_rank = 5
+    hidden = 8
+    intermediate = 6
+    num_experts = ep_size * experts_per_rank
+    key = jax.random.key(ep_size * 100 + experts_per_rank * 10 + top_k)
+    k_x, k_w = jax.random.split(key)
+    x_by_rank = jax.random.normal(k_x, (ep_size, tokens_per_rank, hidden), dtype=jnp.float32)
+    token_ids = jnp.arange(tokens_per_rank, dtype=jnp.int32)[None, :, None]
+    rank_ids = jnp.arange(ep_size, dtype=jnp.int32)[:, None, None]
+    slot_ids = jnp.arange(top_k, dtype=jnp.int32)[None, None, :]
+    expert_ids = (rank_ids * experts_per_rank + token_ids + slot_ids) % num_experts
+    router_weights = jax.nn.softmax(
+        jnp.arange(ep_size * tokens_per_rank * top_k, dtype=jnp.float32).reshape(ep_size, tokens_per_rank, top_k),
+        axis=-1,
+    )
+    w_gate_up = jax.random.normal(k_w, (ep_size, experts_per_rank, hidden, 2 * intermediate), dtype=jnp.float32)
+    recv_capacity = ep_size * tokens_per_rank * top_k
+
+    dispatch_up, layout = dispatch_up_api.moe_dispatch_up(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        w_gate_up,
+        num_experts=num_experts,
+        recv_capacity=recv_capacity,
+    )
+    expected = _manual_w13_silu(layout, w_gate_up)
+
+    np.testing.assert_allclose(np.asarray(dispatch_up), np.asarray(expected), rtol=1e-5, atol=1e-5)
+    assert int(np.asarray(layout.overflow_count)) == 0
+
+
+def test_moe_dispatch_up_reference_is_differentiable():
+    x_by_rank, expert_ids, router_weights = _hand_routing_inputs()
+    w_gate_up = jnp.arange(2 * 2 * 2 * 6, dtype=jnp.float32).reshape(2, 2, 2, 6) / 13.0
+    prepacked = prepack_moe_dispatch_up_reference(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        num_experts=4,
+        recv_capacity=6,
+    )
+    layout = dispatch_prepacked_moe_dispatch_up_reference(prepacked, recv_capacity=6)
+
+    def loss(weights):
+        return jnp.sum(compute_moe_up_from_layout_reference(layout, weights).astype(jnp.float32))
+
+    grad = jax.grad(loss)(w_gate_up)
+
+    assert grad.shape == w_gate_up.shape
+    assert jnp.isfinite(grad).all()
+
+
+def test_explicit_mosaic_gpu_dispatch_requires_local_gpu_mesh():
+    if len([device for device in jax.local_devices() if device.platform == "gpu"]) >= 2:
+        pytest.skip("local host has an MGPU runtime")
+    x_by_rank, expert_ids, router_weights = _hand_routing_inputs()
+    prepacked = prepack_moe_dispatch_up_reference(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        num_experts=4,
+        recv_capacity=6,
+    )
+
+    with pytest.raises(dispatch_up_api.MosaicGpuUnsupportedError, match="at least two local GPU"):
+        dispatch_up_api.moe_dispatch_up_layout(prepacked, recv_capacity=6, implementation="mosaic_gpu")

--- a/lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py
+++ b/lib/levanter/tests/kernels/test_pallas_moe_dispatch_up.py
@@ -10,9 +10,11 @@ import jax.numpy as jnp
 from levanter.kernels.pallas.moe_dispatch_up import api as dispatch_up_api
 from levanter.kernels.pallas.moe_dispatch_up.reference import (
     MoeDispatchUpLayout,
+    dispatch_prepacked_moe_dispatch_up_source_expert_reference,
     dispatch_prepacked_moe_dispatch_up_reference,
     compute_moe_up_from_layout_reference,
     compute_moe_up_from_layout_ragged_dot,
+    prepack_moe_dispatch_up_source_expert_reference,
     prepack_moe_dispatch_up_reference,
 )
 
@@ -160,6 +162,59 @@ def test_moe_dispatch_up_prepack_matches_direct_layout_reference():
     np.testing.assert_array_equal(np.asarray(from_prepack.recv_src_rank), np.asarray(direct.recv_src_rank))
     np.testing.assert_array_equal(np.asarray(from_prepack.recv_src_token_idx), np.asarray(direct.recv_src_token_idx))
     np.testing.assert_array_equal(np.asarray(from_prepack.recv_topk_slot), np.asarray(direct.recv_topk_slot))
+
+
+def test_source_expert_prepack_matches_standard_prepack():
+    x_by_rank, expert_ids, router_weights = _hand_routing_inputs()
+
+    standard_prepacked = prepack_moe_dispatch_up_reference(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        num_experts=4,
+        recv_capacity=6,
+    )
+    compact_prepacked = prepack_moe_dispatch_up_source_expert_reference(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        num_experts=4,
+        recv_capacity=6,
+    )
+    standard = dispatch_prepacked_moe_dispatch_up_reference(standard_prepacked, recv_capacity=6)
+    compact = dispatch_prepacked_moe_dispatch_up_source_expert_reference(compact_prepacked, recv_capacity=6)
+
+    np.testing.assert_allclose(np.asarray(compact.recv_x), np.asarray(standard.recv_x), rtol=0, atol=0)
+    np.testing.assert_array_equal(np.asarray(compact.recv_valid), np.asarray(standard.recv_valid))
+    np.testing.assert_array_equal(np.asarray(compact.recv_local_expert), np.asarray(standard.recv_local_expert))
+    np.testing.assert_array_equal(np.asarray(compact.recv_src_rank), np.asarray(standard.recv_src_rank))
+    np.testing.assert_array_equal(np.asarray(compact.recv_src_token_idx), np.asarray(standard.recv_src_token_idx))
+    np.testing.assert_array_equal(np.asarray(compact.recv_topk_slot), np.asarray(standard.recv_topk_slot))
+    np.testing.assert_allclose(
+        np.asarray(compact.recv_router_weight),
+        np.asarray(standard.recv_router_weight),
+        rtol=1e-6,
+        atol=1e-6,
+    )
+    assert compact_prepacked.send_x_by_dst_expert.shape == (2, 2, 2, 2, 2)
+    assert int(np.asarray(compact.overflow_count)) == 0
+
+
+def test_source_expert_prepack_reports_source_capacity_overflow():
+    x_by_rank, expert_ids, router_weights = _hand_routing_inputs()
+
+    compact_prepacked = prepack_moe_dispatch_up_source_expert_reference(
+        x_by_rank,
+        expert_ids,
+        router_weights,
+        num_experts=4,
+        recv_capacity=6,
+        source_expert_capacity=1,
+    )
+    compact = dispatch_prepacked_moe_dispatch_up_source_expert_reference(compact_prepacked, recv_capacity=6)
+
+    assert int(np.asarray(compact.overflow_count)) == 4
+    assert int(np.asarray(jnp.sum(compact.recv_valid))) == 8
 
 
 def _manual_w13_silu(layout: MoeDispatchUpLayout, w_gate_up_by_rank: jax.Array) -> jax.Array:


### PR DESCRIPTION
Stage the CUDA 13 toolchain that `jax[cuda13]` installs into Iris task venvs so CoreWeave GPU tasks can compile JAX/Pallas Mosaic kernels without per-job shell setup. The task bootstrap now exposes the venv `nvidia/cu13/bin` directory, preserves an existing CUDA data-dir flag while setting one when absent, and copies `libdevice.10.bc` into the legacy locations Mosaic currently probes.

Document the CoreWeave behavior in the operator guide and cover the generated entrypoint setup order in the Iris runtime tests.

Fixes #6600
