### PR TITLE
[docs] Refactor Pallas kernel skill guidance

### DIFF
--- a/.agents/skills/add-pallas-kernel/SKILL.md
+++ b/.agents/skills/add-pallas-kernel/SKILL.md
@@ -21,37 +21,87 @@ autotuning.
 For a kernel `K`, produce:
 
 - A readable **vanilla JAX reference** with the target public API.
-- A **Pallas kernel implementation** plus wrapper with the same API.
 - A **correctness harness** validating value parity vs reference, gradient parity on small shapes, and CPU + accelerator numerics where applicable.
-- A **performance harness** with steady-state timing on representative shape/dtype grids.
+- A **Pallas kernel implementation** plus wrapper with the same API.
+- A **roofline** estimate for the kernel for the relevant hardware type(s).
+- A **performance harness** with steady-state timing on representative shape/dtype grids and progress against the roofline.
 - **Autotuned block/tile sizes** for requested hardware/shape regimes.
 - A checked-in **tuned table module** for runtime selection (with explicit fallback behavior).
 - An **autotune-on-miss fallback path** that sweeps a bounded candidate set and caches winning configs.
 
-## Recommended Module Layout
+The general flow is: Make it right, make it fast, make it usable, make it easy to use.
+
+## Correctness Workflow
+
+### 1) Start from a reference
+
+Use an existing in-repo implementation, pseudocode, a PyTorch reference, or a JAX baseline. The baseline must be obvious and stable, not clever. If the naive baseline would materialize huge intermediates, use a streaming/blockwise baseline with identical math.
+
+### 2) Write value + grad harness
+
+Minimum checks: value parity over a shape/dtype grid, gradient parity on small shapes, backend numerics on CPU and accelerator backends as applicable. Report pointwise deviation metrics (max/mean absolute diff), not only `allclose`. Use explicit shape/dtype annotations for public APIs and references (e.g. `jaxtyping`) where available.
+
+### 3) Promote long-lived checks to pytest
+
+For in-tree kernels, add/extend tests under `lib/levanter/tests/kernels/`. Compare the default implementation against the reference on small CPU shapes and accelerator-aligned shapes for fast paths.
+
+
+## Pallas Kernel workflow
+
+Once the reference is correct, design the Pallas kernel implementation. Use the reference as a correctness oracle and a performance baseline.
+You should ordinarily have other kernels for inspiration. See [kernel sources](./kernel-sources.md) for a curated list of locations.
+Unless you have an especially good inspiration to start from, start by reimplementing the reference in Pallas.
+
+Check correctness against the correctness harness and the reference implementation.
+
+Once the kernel is correct, run a performance harness on representative shapes/dtypes and compare against the roofline. If the kernel is not close to the roofline, investigate compiler dumps and pressure signals for bottlenecks. See [performance loop](./performance-loop.md) for guidance. Continue iterating until you have achieved a performance target or have documented limitations.
+
+
+## API conventions
+
+
+### Recommended Module Layout
 
 Tokamax-style decomposition is preferred for maintainability:
 
+- `__init__.py`: public API, imports from `api.py`.
 - `reference.py`: readable vanilla JAX oracle.
-- `xla.py`: default implementation (often same math as reference).
-- `pallas_tpu.py`: TPU Pallas implementation.
-- `pallas_gpu.py`: optional GPU Pallas implementation.
 - `api.py`: stable user-facing entrypoint with `implementation=` override and fallback order.
+
+Then any variants:
+
+- `xla.py`: default implementation, if different from reference.
+- `pallas_tpu.py`: TPU Pallas implementation.
+- `pallas_mgpu.py`: GPU Pallas Mosaic implementation.
 
 Reference template: `lib/levanter/src/levanter/kernels/pallas/template_kernel.py`
 
-## API and Safety Rules
 
-### Batching convention
+### Top-level API
 
-Prefer one true batched kernel:
+Usually something like:
 
-- Implement the core kernel for batched inputs.
-- Normalize single-example inputs by temporarily adding a leading batch dimension.
-- Reshape leading axes into one batch axis when needed, then restore on output.
-- Preserve explicit parallel-dimension semantics on at least one axis (usually batch) for TPU kernels.
+```
+
+Implementation: TypeAlias = typing.Literal["reference", "xla", "pallas_tpu", ...]
+
+class BlockSizes(Protocol):
+    # possibly empty, possibly dataclass if all implementations share the same block-size config
+    b_block_size: int
+    h_block_size: int
+    v_block_size: int
+
+def template(
+    x: Float[Array, "B H V"]
+    *,
+    implementation: Implementation | Sequence[Implementation | Callable[..., jax.Array]] | None = None,
+    block_sizes: BlockSizes | dict[Implementation, BlockSizes] | None = None,
+) -> jax.Array:
+```
 
 ### Block size config
+
+Use a protocol or union of dataclasses to expose implementation-specific block-size choices. Each implementation should have its own block-size class if they differ.
 
 Expose tile choices via a dataclass with explicit defaults:
 
@@ -67,9 +117,11 @@ class BlockSizes:
         return cls()
 ```
 
+
 Rules:
 
-- Validate TPU-specific alignment constraints (e.g. multiples of 128) in the TPU backend.
+- Block sizes are typically specific to different implementations. Better to have one block-size class per backend unless they are identical.
+- Validate backend-alignment constraints (e.g. multiples of 128 in the TPU backend).
 - Keep reference/XLA paths usable even when TPU constraints are not met.
 - If Mosaic reports a layout mismatch for a batched integer operand (e.g. labels), align the batch block size to the XLA tile size for that TPU generation or raise a clear pre-lowering error.
 - If a legacy `block_size` arg exists, map it clearly to the new config and raise on conflicting inputs.
@@ -85,23 +137,11 @@ Rules:
 
 Prefer a canonical kernel input shape and make callers normalize to it:
 
+- Implement the core kernel for batched inputs.
+- Preserve explicit parallel-dimension semantics on at least one axis (usually batch) for TPU kernels. <-- move to tpu file>
 - Define one canonical shape contract (e.g. rank-2/1/2 forms).
 - Expect callers to flatten or reshape batch axes before kernel invocation.
 - If you provide wrapper reshaping helpers, keep them thin and explicit at API boundaries.
-
-## Correctness Workflow
-
-### 1) Start from a reference
-
-Use an existing in-repo implementation, pseudocode, a PyTorch reference, or an Optax/JAX baseline. The baseline must be obvious and stable, not clever. If the naive baseline would materialize huge intermediates, use a streaming/blockwise baseline with identical math.
-
-### 2) Write value + grad harness
-
-Minimum checks: value parity over a shape/dtype grid, gradient parity on small shapes, backend numerics on CPU and accelerator backends as applicable. Report pointwise deviation metrics (max/mean absolute diff), not only `allclose`. Use explicit shape/dtype annotations for public APIs and references (e.g. `jaxtyping`) where available.
-
-### 3) Promote long-lived checks to pytest
-
-For in-tree kernels, add/extend tests under `lib/levanter/tests/kernels/`. Compare the default implementation against the reference on small CPU shapes and accelerator-aligned shapes for fast paths.
 
 ## Cost Estimate Requirement
 
@@ -141,7 +181,7 @@ apples-to-apples: same shape, dtype, pass mode, backend, device count, and
 environment unless that axis is under test. Only move the baseline after enough
 repeated evidence, and note the change explicitly.
 
-Always report: compile-including timing (`time-to-first-step`), steady-state timing, and exact hardware type and shape/dtype grid.
+Always report: compile-including timing (`time-to-first-step`), steady-state timing, block sizes, and exact hardware type and shape/dtype grid.
 
 ## Autotuning Workflow
 
@@ -151,7 +191,7 @@ Keep tuning explicit and reviewable.
 2. Define target shape/hardware buckets.
 3. Benchmark every `(bucket, config)` pair and capture timing + failures.
 4. Store raw results as artifacts (CSV/JSON; W&B artifact preferred).
-5. Derive a best-config table keyed by `(tpu_type, dtype, shape_bucket[, invariants])`.
+5. Derive a best-config table keyed by `(device_type, dtype, shape_bucket[, invariants])`.
 6. Check in a Python tuned-table module with bucket definitions, best configs, an `infer_block_sizes(...)` helper, and default fallback to `BlockSizes.get_default()`.
 
 Do not key tuned tables by every exact shape; keep buckets stable and reviewable.
@@ -202,6 +242,7 @@ Prefer structural fixes before broad tile sweeps when decomposition variants ind
 
 - Values match reference within tolerance on the tested grid.
 - Gradients match reference on small shapes.
+- Roofline performance is within expected bounds, or limitations are explicitly documented.
 - Performance improves on at least one realistic target shape, or limitations are explicitly documented.
 - Tuned table is checked in for requested hardware/shape regimes.
 - Research artifacts (logbook updates, issue summary, snapshot links) follow the `run-research` workflow.

--- a/.agents/skills/add-pallas-kernel/SKILL.md
+++ b/.agents/skills/add-pallas-kernel/SKILL.md
@@ -5,149 +5,108 @@ description: Add, modify, or autotune a TPU/GPU Pallas kernel.
 
 # Skill: Add or Update a Pallas Kernel
 
-This skill adds kernel-specific standards for numerics, gradient safety,
-backend/fallback API design, TPU/GPU performance diagnosis, and block-size
-autotuning.
+Use this skill to build or change Pallas kernels with explicit standards for
+reference numerics, gradient safety, backend/fallback API design, performance
+measurement, and block-size autotuning.
 
 ## How to apply this skill
 
 1. For long-running kernel research, load `.agents/skills/run-research/SKILL.md`
    first.
-2. Apply the additional kernel rules in this document.
-3. For atomic kernel changes, use only the task skills needed for the work.
+2. Apply the core workflow in this file.
+3. Load only the detail files needed for the task:
+   - [Kernel sources](docs/kernel-sources.md): read when choosing an in-repo or
+     external kernel to imitate.
+   - [Performance workflow](docs/performance-workflow.md): read before
+     benchmarking, profiling, roofline analysis, or autotuning.
+   - [API patterns](docs/api-patterns.md): read before adding or changing a
+     public kernel wrapper, fallback order, or block-size config.
+   - [TPU tips](docs/tpu-tips.md): read for TPU Pallas/Mosaic kernels,
+     TPU-specific lowering failures, scoped VMEM, or TPU compiler dumps.
+   - [GPU tips](docs/gpu-tips.md): read for GPU Pallas/Mosaic work.
+   - Deep references live under `docs/reference/`; read them only when the
+     routed detail files point there.
+4. For atomic kernel changes, use only the task skills needed for the work.
 
 ## Kernel Deliverables
 
 For a kernel `K`, produce:
 
-- A readable **vanilla JAX reference** with the target public API.
-- A **correctness harness** validating value parity vs reference, gradient parity on small shapes, and CPU + accelerator numerics where applicable.
-- A **Pallas kernel implementation** plus wrapper with the same API.
-- A **roofline** estimate for the kernel for the relevant hardware type(s).
-- A **performance harness** with steady-state timing on representative shape/dtype grids and progress against the roofline.
-- **Autotuned block/tile sizes** for requested hardware/shape regimes.
-- A checked-in **tuned table module** for runtime selection (with explicit fallback behavior).
-- An **autotune-on-miss fallback path** that sweeps a bounded candidate set and caches winning configs.
+- A readable vanilla JAX reference with the target public API.
+- A correctness harness validating value parity vs reference, gradient parity on
+  small shapes, and CPU + accelerator numerics where applicable.
+- A Pallas kernel implementation plus wrapper with the same API.
+- A roofline estimate for the relevant hardware type(s).
+- A performance harness with steady-state timing on representative shape/dtype
+  grids and progress against the roofline.
+- Autotuned block/tile sizes for requested hardware/shape regimes.
+- A checked-in tuned table module for runtime selection, with explicit fallback
+  behavior.
+- An autotune-on-miss fallback path that sweeps a bounded candidate set and
+  caches winning configs.
 
-The general flow is: Make it right, make it fast, make it usable, make it easy to use.
+The general flow is: make it right, make it fast, make it usable, make it easy
+to use.
 
 ## Correctness Workflow
 
-### 1) Start from a reference
+### 1. Start from a reference
 
-Use an existing in-repo implementation, pseudocode, a PyTorch reference, or a JAX baseline. The baseline must be obvious and stable, not clever. If the naive baseline would materialize huge intermediates, use a streaming/blockwise baseline with identical math.
+Use an existing in-repo implementation, pseudocode, a PyTorch reference, or a
+JAX baseline. The baseline must be obvious and stable, not clever. If the naive
+baseline would materialize huge intermediates, use a streaming/blockwise
+baseline with identical math.
 
-### 2) Write value + grad harness
+### 2. Write a value and gradient harness
 
-Minimum checks: value parity over a shape/dtype grid, gradient parity on small shapes, backend numerics on CPU and accelerator backends as applicable. Report pointwise deviation metrics (max/mean absolute diff), not only `allclose`. Use explicit shape/dtype annotations for public APIs and references (e.g. `jaxtyping`) where available.
+Minimum checks:
 
-### 3) Promote long-lived checks to pytest
+- Value parity over a shape/dtype grid.
+- Gradient parity on small shapes.
+- Backend numerics on CPU and accelerator backends as applicable.
+- Pointwise deviation metrics such as max/mean absolute diff, not only
+  `allclose`.
 
-For in-tree kernels, add/extend tests under `lib/levanter/tests/kernels/`. Compare the default implementation against the reference on small CPU shapes and accelerator-aligned shapes for fast paths.
+Use explicit shape/dtype annotations for public APIs and references, such as
+`jaxtyping`, where available.
 
+### 3. Promote long-lived checks to pytest
 
-## Pallas Kernel workflow
+For in-tree kernels, add or extend tests under `lib/levanter/tests/kernels/`.
+Compare the default implementation against the reference on small CPU shapes and
+accelerator-aligned shapes for fast paths. Read `TESTING.md` and the nearest
+module `AGENTS.md` before writing or changing tests.
 
-Once the reference is correct, design the Pallas kernel implementation. Use the reference as a correctness oracle and a performance baseline.
-You should ordinarily have other kernels for inspiration. See [kernel sources](./kernel-sources.md) for a curated list of locations.
-Unless you have an especially good inspiration to start from, start by reimplementing the reference in Pallas.
+## Pallas Kernel Workflow
 
-Check correctness against the correctness harness and the reference implementation.
+Once the reference is correct, design the Pallas implementation. Use the
+reference as both a correctness oracle and a performance baseline.
 
-Once the kernel is correct, run a performance harness on representative shapes/dtypes and compare against the roofline. If the kernel is not close to the roofline, investigate compiler dumps and pressure signals for bottlenecks. See [performance loop](./performance-loop.md) for guidance. Continue iterating until you have achieved a performance target or have documented limitations.
+Use existing kernels for structure and API inspiration. Read
+[Kernel sources](docs/kernel-sources.md) unless the user already named the
+specific kernel to follow. Unless there is a stronger local pattern, start by
+reimplementing the reference in Pallas.
 
+Check correctness against the harness and reference implementation before
+tuning. Once the kernel is correct, run a performance harness on representative
+shapes/dtypes and compare against the roofline. If performance is not near the
+expected roofline, read [Performance workflow](docs/performance-workflow.md) and
+investigate compiler dumps, pressure signals, and tile choices before broad
+rewrites.
 
-## API conventions
+## API Conventions
 
-
-### Recommended Module Layout
-
-Tokamax-style decomposition is preferred for maintainability:
-
-- `__init__.py`: public API, imports from `api.py`.
-- `reference.py`: readable vanilla JAX oracle.
-- `api.py`: stable user-facing entrypoint with `implementation=` override and fallback order.
-
-Then any variants:
-
-- `xla.py`: default implementation, if different from reference.
-- `pallas_tpu.py`: TPU Pallas implementation.
-- `pallas_mgpu.py`: GPU Pallas Mosaic implementation.
-
-Reference template: `lib/levanter/src/levanter/kernels/pallas/template_kernel.py`
-
-
-### Top-level API
-
-Usually something like:
-
-```
-
-Implementation: TypeAlias = typing.Literal["reference", "xla", "pallas_tpu", ...]
-
-class BlockSizes(Protocol):
-    # possibly empty, possibly dataclass if all implementations share the same block-size config
-    b_block_size: int
-    h_block_size: int
-    v_block_size: int
-
-def template(
-    x: Float[Array, "B H V"]
-    *,
-    implementation: Implementation | Sequence[Implementation | Callable[..., jax.Array]] | None = None,
-    block_sizes: BlockSizes | dict[Implementation, BlockSizes] | None = None,
-) -> jax.Array:
-```
-
-### Block size config
-
-Use a protocol or union of dataclasses to expose implementation-specific block-size choices. Each implementation should have its own block-size class if they differ.
-
-Expose tile choices via a dataclass with explicit defaults:
-
-```python
-@dataclass(frozen=True, slots=True)
-class BlockSizes:
-    b_block_size: int = 1024
-    h_block_size: int = 512
-    v_block_size: int = 2048
-
-    @classmethod
-    def get_default(cls) -> "BlockSizes":
-        return cls()
-```
-
-
-Rules:
-
-- Block sizes are typically specific to different implementations. Better to have one block-size class per backend unless they are identical.
-- Validate backend-alignment constraints (e.g. multiples of 128 in the TPU backend).
-- Keep reference/XLA paths usable even when TPU constraints are not met.
-- If Mosaic reports a layout mismatch for a batched integer operand (e.g. labels), align the batch block size to the XLA tile size for that TPU generation or raise a clear pre-lowering error.
-- If a legacy `block_size` arg exists, map it clearly to the new config and raise on conflicting inputs.
-
-### Fallback semantics
-
-- If a single implementation is explicitly requested (e.g. `implementation="pallas_tpu"`), fail fast on unsupported backend/shape.
-- If a sequence of implementations is requested, try each in order, warn on each fallback, and raise if none work.
-- A default implementation order is treated the same as a sequence.
-- Keep backend selection explicit and predictable in `api.py`.
-
-### Input normalization rule
-
-Prefer a canonical kernel input shape and make callers normalize to it:
-
-- Implement the core kernel for batched inputs.
-- Preserve explicit parallel-dimension semantics on at least one axis (usually batch) for TPU kernels. <-- move to tpu file>
-- Define one canonical shape contract (e.g. rank-2/1/2 forms).
-- Expect callers to flatten or reshape batch axes before kernel invocation.
-- If you provide wrapper reshaping helpers, keep them thin and explicit at API boundaries.
+Read [API patterns](docs/api-patterns.md) before adding or changing the public
+wrapper, backend selection, block-size config, or input normalization contract.
+Keep the reference/XLA path usable even when accelerator-specific constraints
+are not met. Keep backend-specific validation in backend-specific modules.
 
 ## Cost Estimate Requirement
 
 Add `cost_estimate=` to each `pl.pallas_call`:
 
-- Use `pl.estimate_cost` on a body-equivalent JAX function (not a kernel body with `pl.program_id`).
+- Use `pl.estimate_cost` on a body-equivalent JAX function, not a kernel body
+  with `pl.program_id`.
 - Include IO bytes from call inputs/outputs.
 
 ```python
@@ -170,120 +129,33 @@ def _cost_estimate(
     )
 ```
 
-## Performance and Profiling Workflow
-
-Use the execution environment guidance and cadence from `run-research`; this section adds kernel-specific constraints. For kernel-specific profiling capture/compare guidance, see `docs/reference/profiling.md`.
-
-Key iteration loop: `profile -> hypothesis -> change -> tests -> microbench -> profile`
-
-Run one-axis sweeps first, then interaction sweeps. Keep comparisons
-apples-to-apples: same shape, dtype, pass mode, backend, device count, and
-environment unless that axis is under test. Only move the baseline after enough
-repeated evidence, and note the change explicitly.
-
-Always report: compile-including timing (`time-to-first-step`), steady-state timing, block sizes, and exact hardware type and shape/dtype grid.
-
-## Autotuning Workflow
-
-Keep tuning explicit and reviewable.
-
-1. Define a bounded config space (block/tile candidates).
-2. Define target shape/hardware buckets.
-3. Benchmark every `(bucket, config)` pair and capture timing + failures.
-4. Store raw results as artifacts (CSV/JSON; W&B artifact preferred).
-5. Derive a best-config table keyed by `(device_type, dtype, shape_bucket[, invariants])`.
-6. Check in a Python tuned-table module with bucket definitions, best configs, an `infer_block_sizes(...)` helper, and default fallback to `BlockSizes.get_default()`.
-
-Do not key tuned tables by every exact shape; keep buckets stable and reviewable.
-
-### Fallback autotuning requirement
-
-Support three levels of fallback, similar to the fused softmax cross-entropy kernel:
-
-1. **Static lookup fallback**: infer block sizes from a checked-in tuned table by `(device, dtype, shape bucket)`, validate/sanitize for backend constraints, fall back to default/safe entries when no exact tuned match exists.
-2. **Autotune-on-miss fallback**: when tuned lookup misses (and autotune is enabled), sweep a bounded candidate list, benchmark on the real implementation, select the best viable config, cache and persist the winner under a kernel-specific key (include implementation + shape/device/dtype context).
-3. **Runtime failure fallback**: if a candidate or implementation is unsupported (compile/runtime constraints), warn and try the next candidate/implementation in order when a sequence is available.
-
-## Compiler and Runtime Hints (TPU Pallas)
-
-### Matmul precision
-
-If Mosaic reports errors like `Expected matmul acc to be 32-bit`:
-
-- set `preferred_element_type=jnp.float32` in `lax.dot_general` for the kernel path, or
-- set `jax_default_matmul_precision=highest` in benchmark scripts.
-
-Prefer explicit kernel-side `preferred_element_type` for deterministic behavior.
-
-### Scoped VMEM policy
-
-Set `LIBTPU_INIT_ARGS` by TPU generation during microbench/tuning:
-
-- `v5p` / `v5e`: `--xla_tpu_scoped_vmem_limit_kib=50000`
-- `v6e`: `--xla_tpu_scoped_vmem_limit_kib=98304`
-- `v4`: no special scoped-VMEM override
-
-### Compiler diagnostics and dumps
-
-Capture compiler diagnostics on serious benchmark/tuning runs: HLO dumps via `--xla-dump-dir`, compiler logs via `--compiler-log-path`, and explicit `XLA_FLAGS` and `LIBTPU_INIT_ARGS` recorded with results.
-
-Useful scripts:
-
-- `lib/levanter/scripts/bench/bench_fused_cross_entropy_loss_pallas.py`
-- `lib/levanter/scripts/tune/tune_fused_cross_entropy_loss_block_sizes.py`
-
-### Dump-driven diagnosis
-
-When performance is unclear, run dump-first comparisons on one fixed shape: XLA/reference path, full Pallas path, decomposition variant(s) (temporary toggles). Use separate dump dirs per variant (`hlo_*`, `llo_*`, `mosaic_*`) and compare throughput, fusion/custom-call placement, schedule bundle counts, and pressure signals (heavy `vrot`/`vsel`, spills, vreg pressure).
-
-Prefer structural fixes before broad tile sweeps when decomposition variants indicate stage-structure issues. For the full LLO workflow (flags, artifact layout, comparison checklist, replication loop), see `docs/reference/llo.md`.
-
 ## Definition of Done
 
 - Values match reference within tolerance on the tested grid.
 - Gradients match reference on small shapes.
-- Roofline performance is within expected bounds, or limitations are explicitly documented.
-- Performance improves on at least one realistic target shape, or limitations are explicitly documented.
+- CPU/reference and accelerator fast paths are covered by tests where
+  applicable.
+- Public API, fallback semantics, block-size config, and tuned table behavior
+  match [API patterns](docs/api-patterns.md).
+- Each `pl.pallas_call` has a reviewed `cost_estimate=`.
+- Benchmark/tuning artifacts include the required schema from
+  [Performance workflow](docs/performance-workflow.md).
+- Roofline performance is within expected bounds, or limitations are explicitly
+  documented.
+- Performance improves on at least one realistic target shape, or limitations
+  are explicitly documented.
 - Tuned table is checked in for requested hardware/shape regimes.
-- Research artifacts (logbook updates, issue summary, snapshot links) follow the `run-research` workflow.
+- Research artifacts, issue summaries, and snapshot links follow the
+  `run-research` workflow when the task is long-running.
 
-## Starter References
+## PR Checklist
 
-- `lib/levanter/src/levanter/kernels/pallas/template_kernel.py`
-- `lib/levanter/tests/kernels/test_pallas_template_kernel.py`
-- `lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss`
-
-## Tokamax Notes (Optional)
-
-Tokamax kernels are useful references for API and kernel structure comparisons.
-
-- Typical install path in this repo's uv environment: `.venv/lib/python3.11/site-packages/tokamax/_src/ops`
-- Compare numerics/perf on identical shapes/dtypes before drawing conclusions.
-- Parse `absl.flags` before accessing Tokamax modules that depend on flags.
-- Tokamax Mosaic kernels can OOM VMEM at larger shapes; reduce shape/tile sizes for controlled comparisons.
-
-## Rules
-
-- Separate measurement code from the production path whenever possible.
-- Prefer persistent remote shells/scripts for long sweeps.
-- Check accelerator contention before attributing regressions to code.
-- For long remote runs, track a monotonic progress signal and tail recent logs
-  for context.
-- Validate machine-readable extraction before publishing: expected row counts,
-  key uniqueness, and de-duplication.
-
-Ops hygiene checklist before claiming a regression:
-
-- No stale benchmark process is still occupying the accelerator.
-- Lockfiles/state are clean.
-- Comparison uses the same device count.
-- Command/config/env are identical except the tested axis.
-
-## Further Reading
-
-- [JAX Pallas Overview](https://docs.jax.dev/en/latest/pallas/index.html)
-- [JAX Pallas TPU Docs](https://docs.jax.dev/en/latest/pallas/tpu/index.html)
-- [JAX Pallas Mosaic GPU Docs](https://docs.jax.dev/en/latest/pallas/gpu/index.html)
-- [When XLA Isn't Enough: From Pallas to VLIW](https://patricktoulme.substack.com/p/when-xla-isnt-enough-from-pallas)
-- `docs/reference/llo.md`
-- `docs/reference/profiling.md`
+- Reference implementation and public wrapper are in place.
+- Correctness tests cover values, gradients, and relevant backend paths.
+- Pallas implementation has explicit backend/shape validation.
+- Fallback behavior is tested for explicit and ordered implementation choices.
+- Cost estimates are attached to Pallas calls.
+- Benchmark or tuning script emits machine-readable rows.
+- Tuned table and autotune-on-miss behavior are checked in when tuning is part
+  of the task.
+- Long-running work has the required logbook/artifact/snapshot updates.

--- a/.agents/skills/add-pallas-kernel/docs/api-patterns.md
+++ b/.agents/skills/add-pallas-kernel/docs/api-patterns.md
@@ -1,0 +1,108 @@
+# API Patterns
+
+Read this file before adding or changing a public kernel wrapper, backend
+selection behavior, block-size config, tuned table lookup, or input
+normalization contract.
+
+## Recommended Module Layout
+
+Tokamax-style decomposition is preferred for maintainability:
+
+- `__init__.py`: public API, imports from `api.py`.
+- `reference.py`: readable vanilla JAX oracle.
+- `api.py`: stable user-facing entrypoint with `implementation=` override and
+  fallback order.
+- `config.py`: block-size dataclasses and implementation-neutral config types
+  when needed.
+
+Then add implementation variants as needed:
+
+- `xla.py`: default implementation, if different from reference.
+- `pallas_tpu.py`: TPU Pallas implementation.
+- `pallas_mgpu.py`: GPU Pallas Mosaic implementation.
+- `tuned_block_sizes.py`: checked-in tuned table for runtime selection.
+
+Reference template:
+`lib/levanter/src/levanter/kernels/pallas/template_kernel.py`
+
+## Top-Level API
+
+Use an entrypoint shaped like:
+
+```python
+Implementation: TypeAlias = typing.Literal["reference", "xla", "pallas_tpu", ...]
+
+
+class BlockSizes(Protocol):
+    b_block_size: int
+    h_block_size: int
+    v_block_size: int
+
+
+def template(
+    x: Float[Array, "B H V"],
+    *,
+    implementation: Implementation | Sequence[Implementation | Callable[..., jax.Array]] | None = None,
+    block_sizes: BlockSizes | dict[Implementation, BlockSizes] | None = None,
+) -> jax.Array:
+```
+
+## Block Size Config
+
+Use a protocol or union of dataclasses to expose implementation-specific
+block-size choices. Each implementation should have its own block-size class
+unless the choices are genuinely identical.
+
+Expose tile choices via a dataclass with explicit defaults:
+
+```python
+@dataclass(frozen=True, slots=True)
+class BlockSizes:
+    b_block_size: int = 1024
+    h_block_size: int = 512
+    v_block_size: int = 2048
+
+    @classmethod
+    def get_default(cls) -> "BlockSizes":
+        return cls()
+```
+
+Rules:
+
+- Validate backend-alignment constraints in the backend-specific implementation.
+- Keep reference/XLA paths usable even when TPU or GPU constraints are not met.
+- If a legacy `block_size` arg exists, map it clearly to the new config and
+  raise on conflicting inputs.
+- Keep tuned table keys stable and reviewable; do not key on every exact shape.
+
+## Fallback Semantics
+
+- If a single implementation is explicitly requested, such as
+  `implementation="pallas_tpu"`, fail fast on unsupported backend/shape.
+- If a sequence of implementations is requested, try each in order, warn on each
+  fallback, and raise if none work.
+- Treat a default implementation order the same as a sequence.
+- Keep backend selection explicit and predictable in `api.py`.
+
+## Input Normalization
+
+Prefer one canonical kernel input shape and make callers normalize to it:
+
+- Implement the core kernel for batched inputs.
+- Define one canonical shape contract, such as rank-2/1/2 forms.
+- Expect callers to flatten or reshape batch axes before kernel invocation.
+- If wrapper reshaping helpers are useful, keep them thin and explicit at API
+  boundaries.
+
+For TPU kernels, also read the input-shape notes in [TPU tips](tpu-tips.md).
+
+## Bad Patterns
+
+- Exact-shape tuned tables instead of stable shape buckets.
+- Silent fallback when the user explicitly requested one backend.
+- Benchmark scripts imported by production code.
+- Backend-specific shape hacks spread through callers instead of normalized at
+  the API boundary.
+- Hidden env-var defaults for critical behavior.
+- Compatibility shims for old kernel arguments unless the user explicitly asks
+  for them.

--- a/.agents/skills/add-pallas-kernel/docs/api-patterns.md
+++ b/.agents/skills/add-pallas-kernel/docs/api-patterns.md
@@ -19,7 +19,7 @@ Then add implementation variants as needed:
 
 - `xla.py`: default implementation, if different from reference.
 - `pallas_tpu.py`: TPU Pallas implementation.
-- `pallas_mgpu.py`: GPU Pallas Mosaic implementation.
+- `pallas_mosaic_gpu.py`: GPU Pallas Mosaic implementation.
 - `tuned_block_sizes.py`: checked-in tuned table for runtime selection.
 
 Reference template:

--- a/.agents/skills/add-pallas-kernel/docs/gpu-tips.md
+++ b/.agents/skills/add-pallas-kernel/docs/gpu-tips.md
@@ -2,6 +2,11 @@
 
 Read this file for GPU Pallas/Mosaic work.
 
+Prefer Mosaic GPU for new Pallas GPU kernels. Existing Triton-backend Pallas
+kernels may still exist in the repo, such as Haliax's `ragged_dot`; treat them
+as legacy references unless the user explicitly asks to work on the Triton
+backend.
+
 Start from the official
 [JAX GPU performance tips](https://docs.jax.dev/en/latest/gpu_performance_tips.html)
 and

--- a/.agents/skills/add-pallas-kernel/docs/gpu-tips.md
+++ b/.agents/skills/add-pallas-kernel/docs/gpu-tips.md
@@ -1,0 +1,9 @@
+# GPU Tips
+
+Read this file for GPU Pallas/Mosaic work.
+
+Start from the official
+[JAX GPU performance tips](https://docs.jax.dev/en/latest/gpu_performance_tips.html)
+and
+[JAX Toolbox tips](https://github.com/NVIDIA/JAX-Toolbox/blob/main/docs/GPU_performance.md).
+Keep benchmark setup aligned with [Performance workflow](performance-workflow.md).

--- a/.agents/skills/add-pallas-kernel/docs/kernel-sources.md
+++ b/.agents/skills/add-pallas-kernel/docs/kernel-sources.md
@@ -61,7 +61,7 @@ Benchmark and tuning scripts:
 Tokamax kernels are useful references for API and kernel structure comparisons.
 
 - Typical install path in this repo's uv environment:
-  `.venv/lib/python3.11/site-packages/tokamax/_src/ops`
+  `.venv/lib/python3.12/site-packages/tokamax/_src/ops`
 - Compare numerics/perf on identical shapes/dtypes before drawing conclusions.
 - Parse `absl.flags` before accessing Tokamax modules that depend on flags.
 - Tokamax Mosaic kernels can OOM VMEM at larger shapes; reduce shape/tile sizes

--- a/.agents/skills/add-pallas-kernel/docs/kernel-sources.md
+++ b/.agents/skills/add-pallas-kernel/docs/kernel-sources.md
@@ -1,0 +1,68 @@
+# Kernel Sources
+
+Read this file when choosing a kernel to imitate or when checking whether the
+repo already has helpers for Pallas API layout, autotuning, cost estimates, or
+tests.
+
+## In-Repo Pallas Kernels
+
+- `lib/levanter/src/levanter/kernels/pallas/template_kernel.py`: minimal
+  template for API, reference, and Pallas wrapper structure.
+- `lib/levanter/src/levanter/kernels/pallas/fused_cross_entropy_loss/`: best
+  reference for production-style layout, TPU Pallas implementation, fallback
+  API, cost estimate plumbing, tuned block-size lookup, and autotune-on-miss
+  behavior.
+- `lib/levanter/src/levanter/kernels/pallas/mamba3/`: reference/XLA split and
+  config layout for sequence kernels.
+- `lib/levanter/src/levanter/kernels/pallas/ssd/`: reference/XLA split and
+  config layout for structured state-space kernels.
+- `lib/levanter/src/levanter/kernels/pallas/splash_attention.py`: local Pallas
+  attention reference.
+
+## Shared Helpers
+
+- `lib/levanter/src/levanter/kernels/pallas/autotune_utils.py`: bounded config
+  sweeps and result handling.
+- `lib/levanter/src/levanter/kernels/pallas/autotune_cache_utils.py`: persistent
+  autotune cache helpers.
+- `lib/levanter/src/levanter/kernels/pallas/cost_estimate_utils.py`: IO-byte
+  augmentation for `pl.CostEstimate`.
+
+## Tests and Harnesses
+
+- `lib/levanter/tests/kernels/test_pallas_template_kernel.py`: template kernel
+  test shape.
+- `lib/levanter/tests/kernels/test_pallas_fused_cross_entropy_loss.py`:
+  production kernel correctness, fallback, and tuning coverage.
+- `lib/levanter/tests/kernels/test_pallas_autotune_utils.py`: autotune helper
+  behavior.
+- `lib/levanter/tests/kernels/test_pallas_mamba3.py`: reference/XLA parity for a
+  sequence kernel.
+
+Benchmark and tuning scripts:
+
+- `lib/levanter/scripts/bench/bench_fused_cross_entropy_loss_pallas.py`
+- `lib/levanter/scripts/bench/bench_fused_cross_entropy_loss_xla_streaming.py`
+- `lib/levanter/scripts/bench/bench_fused_cross_entropy_loss_gpu_block_sweep.py`
+- `lib/levanter/scripts/bench/bench_tokamax_linear_softmax_ce.py`
+- `lib/levanter/scripts/tune/tune_fused_cross_entropy_loss_block_sizes.py`
+
+## External References
+
+- [JAX Pallas Overview](https://docs.jax.dev/en/latest/pallas/index.html)
+- [JAX Pallas TPU Docs](https://docs.jax.dev/en/latest/pallas/tpu/index.html)
+- [JAX Pallas Mosaic GPU Docs](https://docs.jax.dev/en/latest/pallas/gpu/index.html)
+- [When XLA Isn't Enough: From Pallas to VLIW](https://patricktoulme.substack.com/p/when-xla-isnt-enough-from-pallas)
+- `reference/llo.md`
+- `reference/profiling.md`
+
+## Tokamax Notes
+
+Tokamax kernels are useful references for API and kernel structure comparisons.
+
+- Typical install path in this repo's uv environment:
+  `.venv/lib/python3.11/site-packages/tokamax/_src/ops`
+- Compare numerics/perf on identical shapes/dtypes before drawing conclusions.
+- Parse `absl.flags` before accessing Tokamax modules that depend on flags.
+- Tokamax Mosaic kernels can OOM VMEM at larger shapes; reduce shape/tile sizes
+  for controlled comparisons.

--- a/.agents/skills/add-pallas-kernel/docs/performance-workflow.md
+++ b/.agents/skills/add-pallas-kernel/docs/performance-workflow.md
@@ -1,0 +1,150 @@
+# Performance Workflow
+
+Read this file before benchmarking, profiling, roofline analysis, or
+autotuning. Use the execution-environment guidance and cadence from
+`run-research` for long-running work.
+
+## Iteration Loop
+
+Use this loop:
+
+```text
+profile -> hypothesis -> change -> tests -> microbench -> profile
+```
+
+Run one-axis sweeps first, then interaction sweeps. Keep comparisons
+apples-to-apples: same shape, dtype, pass mode, backend, device count, and
+environment unless that axis is under test. Only move the baseline after enough
+repeated evidence, and note the baseline change explicitly.
+
+Always report:
+
+- Compile-including timing, such as time-to-first-step.
+- Steady-state timing.
+- Block sizes or tile sizes.
+- Exact hardware type, device count, shape grid, and dtype grid.
+- Relevant env vars and compiler flags.
+
+## Roofline and Harnesses
+
+For each relevant hardware type, estimate whether the kernel is compute-bound,
+memory-bound, or limited by a known compiler/runtime bottleneck. Tie the
+performance harness output to that estimate.
+
+Performance harnesses should:
+
+- Separate compile time from steady-state time.
+- Warm up before measuring steady-state loops.
+- Include representative small, medium, and target production shapes.
+- Emit machine-readable rows with unique keys for
+  `(implementation, shape, dtype, backend, device_count, block_sizes)`.
+- Capture failures with enough context to distinguish unsupported shapes from
+  correctness failures.
+
+Required CSV/JSON fields:
+
+- `kernel`
+- `implementation`
+- `shape`
+- `dtype`
+- `backend`
+- `device_type`
+- `device_count`
+- `block_sizes`
+- `compile_time`
+- `steady_state_time`
+- `error`
+- `git_sha`
+- `xla_flags`
+- `backend_env`
+
+## Autotuning
+
+Keep tuning explicit and reviewable:
+
+1. Define a bounded config space of block/tile candidates.
+2. Define target shape/hardware buckets.
+3. Benchmark every `(bucket, config)` pair and capture timing + failures.
+4. Store raw results as artifacts, preferably CSV/JSON and a W&B artifact.
+5. Derive a best-config table keyed by
+   `(device_type, dtype, shape_bucket[, invariants])`.
+6. Check in a Python tuned-table module with bucket definitions, best configs,
+   an `infer_block_sizes(...)` helper, and default fallback to
+   `BlockSizes.get_default()`.
+
+Do not key tuned tables by every exact shape. Keep buckets stable and
+reviewable.
+
+## When to Stop Tuning
+
+Stop tuning when one of these is true:
+
+- Performance is within the agreed roofline target or another explicit target.
+- The remaining roofline gap is explained by a documented compiler/runtime
+  limitation.
+- A bounded sweep over the planned config space shows no material improvement.
+- Structural decomposition experiments point to the same bottleneck across
+  repeated profiles.
+- The user chooses to prioritize correctness/API landing over more tuning.
+
+When stopping before reaching the target, document the best observed config,
+the best observed timing, the limiting evidence, and the next experiment that
+would be worth running.
+
+## Fallback Autotuning
+
+Support three fallback levels, similar to the fused softmax cross-entropy
+kernel:
+
+1. Static lookup fallback: infer block sizes from a checked-in tuned table by
+   `(device, dtype, shape bucket)`, validate/sanitize for backend constraints,
+   and fall back to default/safe entries when no exact tuned match exists.
+2. Autotune-on-miss fallback: when tuned lookup misses and autotune is enabled,
+   sweep a bounded candidate list, benchmark on the real implementation, select
+   the best viable config, cache and persist the winner under a kernel-specific
+   key that includes implementation + shape/device/dtype context.
+3. Runtime failure fallback: if a candidate or implementation is unsupported by
+   compile/runtime constraints, warn and try the next candidate/implementation
+   in order when a sequence is available.
+
+## Measurement Hygiene
+
+Before claiming a regression:
+
+- Check that no stale benchmark process is occupying the accelerator.
+- Confirm lockfiles/state are clean.
+- Confirm the comparison uses the same device count.
+- Confirm command/config/env are identical except the tested axis.
+- Validate machine-readable extraction: expected row counts, key uniqueness,
+  and de-duplication.
+
+Separate measurement code from the production path whenever possible. Prefer
+persistent remote shells/scripts for long sweeps. For long remote runs, track a
+monotonic progress signal and tail recent logs for context.
+
+## Dump-Driven Diagnosis
+
+When performance is unclear, run dump-first comparisons on one fixed shape:
+XLA/reference path, full Pallas path, and decomposition variants through
+temporary toggles. Use separate dump dirs per variant such as `hlo_*`, `llo_*`,
+and `mosaic_*`.
+
+Compare:
+
+- Throughput.
+- Fusion/custom-call placement.
+- Schedule bundle counts.
+- Pressure signals such as heavy `vrot`/`vsel`, spills, and vreg pressure.
+
+Prefer structural fixes before broad tile sweeps when decomposition variants
+indicate stage-structure issues. For the full LLO workflow, including flags,
+artifact layout, comparison checklist, and replication loop, read
+`reference/llo.md`.
+
+## Performance Bad Patterns
+
+- Moving the baseline after a single noisy win.
+- Comparing across different device counts, dtype grids, or env flags.
+- Publishing aggregate timings without row-level artifacts.
+- Reporting only steady-state time when compile time materially affects usage.
+- Treating unsupported candidate failures as successful slow timings.

--- a/.agents/skills/add-pallas-kernel/docs/performance-workflow.md
+++ b/.agents/skills/add-pallas-kernel/docs/performance-workflow.md
@@ -2,7 +2,8 @@
 
 Read this file before benchmarking, profiling, roofline analysis, or
 autotuning. Use the execution-environment guidance and cadence from
-`run-research` for long-running work.
+`run-research` for long-running work. For profiling capture and comparison
+details, read `reference/profiling.md`.
 
 ## Iteration Loop
 

--- a/.agents/skills/add-pallas-kernel/docs/tpu-tips.md
+++ b/.agents/skills/add-pallas-kernel/docs/tpu-tips.md
@@ -1,0 +1,55 @@
+# TPU Tips
+
+Read this file for TPU Pallas/Mosaic kernels, TPU-specific lowering failures,
+scoped VMEM setup, TPU compiler diagnostics, and TPU input-shape constraints.
+
+## Input Shape and Parallel Dimensions
+
+Preserve explicit parallel-dimension semantics on at least one axis, usually
+batch, for TPU kernels. Prefer a canonical batched input contract and require
+callers to normalize into it before invoking the core kernel.
+
+If Mosaic reports a layout mismatch for a batched integer operand, such as
+labels, align the batch block size to the XLA tile size for that TPU generation
+or raise a clear pre-lowering error.
+
+Validate TPU alignment constraints before lowering. For example, enforce
+required multiples such as 128 in the TPU backend without making reference/XLA
+paths unusable.
+
+## Matmul Precision
+
+If Mosaic reports errors like `Expected matmul acc to be 32-bit`:
+
+- Set `preferred_element_type=jnp.float32` in `lax.dot_general` for the kernel
+  path, or
+- Set `jax_default_matmul_precision=highest` in benchmark scripts.
+
+Prefer explicit kernel-side `preferred_element_type` for deterministic behavior.
+
+## Scoped VMEM Policy
+
+Set `LIBTPU_INIT_ARGS` by TPU generation during microbench/tuning:
+
+- `v5p` / `v5e`: `--xla_tpu_scoped_vmem_limit_kib=50000`
+- `v6e`: `--xla_tpu_scoped_vmem_limit_kib=98304`
+- `v4`: no special scoped-VMEM override
+
+Record the exact `LIBTPU_INIT_ARGS` value with benchmark and tuning results.
+
+## Compiler Diagnostics and Dumps
+
+Capture compiler diagnostics on serious benchmark/tuning runs:
+
+- HLO dumps via `--xla-dump-dir`.
+- Compiler logs via `--compiler-log-path`.
+- Exact `XLA_FLAGS`.
+- Exact `LIBTPU_INIT_ARGS`.
+
+Useful scripts:
+
+- `lib/levanter/scripts/bench/bench_fused_cross_entropy_loss_pallas.py`
+- `lib/levanter/scripts/tune/tune_fused_cross_entropy_loss_block_sizes.py`
+
+For dump-first diagnosis workflow, read
+[Performance workflow](performance-workflow.md).


### PR DESCRIPTION
Split the Pallas kernel skill into a smaller routing document plus focused detail files for API patterns, kernel sources, performance workflow, TPU tips, and GPU tips.

This keeps the core skill easier to load while preserving the detailed guidance needed for benchmarking, autotuning, backend-specific constraints, and PR readiness.