### PR TITLE
[iris] Replace k8s controller pod-log pulling with a finelog log-shipper sidecar

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/logship.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/logship.py
@@ -27,6 +27,7 @@ import logging
 import os
 import signal
 import sys
+import threading
 import time
 from dataclasses import dataclass, field
 from datetime import datetime
@@ -208,17 +209,13 @@ class LogShipper:
     sidecar and wedge pod teardown.
     """
 
-    def __init__(self, client: LogClient, log_dir_glob: str, key: str, attempt_id: int):
+    def __init__(self, client: LogClient, log_dir_glob: str, key: str, attempt_id: int, stop: threading.Event):
         self._client = client
         self._log_dir_glob = log_dir_glob
         self._key = key
         self._attempt_id = attempt_id
         self._buffer = _LineBuffer()
-        self._stop = False
-
-    def request_stop(self) -> None:
-        """Signal the ship loop to drain to EOF and exit (called from SIGTERM)."""
-        self._stop = True
+        self._stop = stop
 
     def run(self) -> None:
         """Follow the active log file across rotations until stopped, then flush.
@@ -245,7 +242,7 @@ class LogShipper:
         partial = ""
         while True:
             partial = self._drain(handle, partial)
-            if self._stop:
+            if self._stop.is_set():
                 # Final drain to EOF after the task container exited.
                 self._drain(handle, partial)
                 return None
@@ -256,7 +253,7 @@ class LogShipper:
 
     def _await_file(self) -> str | None:
         """Wait for the active CRI log file to appear; stop early if asked to."""
-        while not self._stop:
+        while not self._stop.is_set():
             path = _active_log_file(self._log_dir_glob)
             if path is not None:
                 return path
@@ -343,9 +340,8 @@ def _connect_log_client(controller_address: str) -> LogClient:
     )
 
 
-def main() -> int:
-    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s logship %(message)s")
-
+def _ship(stop: threading.Event) -> None:
+    """Connect to the log server and ship the task container's logs until stopped."""
     task_id = os.environ["IRIS_TASK_ID"]
     controller_address = os.environ["IRIS_CONTROLLER_ADDRESS"]
     namespace = os.environ["IRIS_POD_NAMESPACE"]
@@ -353,13 +349,27 @@ def main() -> int:
 
     key, attempt_id = split_key_attempt(task_id)
     client = _connect_log_client(controller_address)
-    shipper = LogShipper(client, _log_dir_glob(namespace, pod_name), key, attempt_id)
-
-    signal.signal(signal.SIGTERM, lambda *_: shipper.request_stop())
+    shipper = LogShipper(client, _log_dir_glob(namespace, pod_name), key, attempt_id, stop)
 
     logger.info("logship: shipping logs for %s (attempt %d) from %s", key, attempt_id, pod_name)
     shipper.run()
     client.close()
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s logship %(message)s")
+
+    # As a native sidecar, this process must stay running for the task container
+    # to start. Log shipping is best-effort: any failure is logged and the
+    # process then idles until SIGTERM, so a broken shipper degrades to "no logs"
+    # rather than wedging the task pod in PodInitializing.
+    stop = threading.Event()
+    signal.signal(signal.SIGTERM, lambda *_: stop.set())
+    try:
+        _ship(stop)
+    except Exception:
+        logger.exception("logship: shipping failed; idling so the task pod is not blocked")
+        stop.wait()
     return 0
 
 

--- a/lib/iris/src/iris/cluster/backends/k8s/logship.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/logship.py
@@ -75,15 +75,26 @@ class CriLogLine:
     message: str
 
 
-def parse_cri_line(raw: str) -> tuple[int, str, bool, str] | None:
+@dataclass(frozen=True)
+class ParsedCriLine:
+    """One CRI log line after field splitting, before partial-line reassembly.
+
+    ``is_full`` is True for an ``F`` tag (a complete line) and False for ``P`` (a
+    continuation to be joined onto the next fragment).
+    """
+
+    epoch_ms: int
+    stream: str
+    is_full: bool
+    message: str
+
+
+def parse_cri_line(raw: str) -> ParsedCriLine | None:
     """Parse one CRI on-disk log line.
 
     The format is ``<rfc3339> <stdout|stderr> <F|P> <message>``: a timestamp, the
     stream, a full/partial tag, then the message (which may itself contain
-    spaces). Returns ``(epoch_ms, stream, is_full, message)``; ``is_full`` is
-    True for an ``F`` tag (complete line) and False for ``P`` (a continuation to
-    be joined onto the next fragment). Returns None for a line that does not
-    match the format.
+    spaces). Returns None for a line that does not match the format.
     """
     parts = raw.split(" ", 3)
     if len(parts) < 4:
@@ -94,7 +105,7 @@ def parse_cri_line(raw: str) -> tuple[int, str, bool, str] | None:
     epoch_ms = _rfc3339_to_epoch_ms(timestamp_str)
     if epoch_ms is None:
         return None
-    return epoch_ms, stream, tag == "F", message
+    return ParsedCriLine(epoch_ms=epoch_ms, stream=stream, is_full=tag == "F", message=message)
 
 
 def _rfc3339_to_epoch_ms(timestamp_str: str) -> int | None:
@@ -177,14 +188,14 @@ class _LineBuffer:
         parsed = parse_cri_line(raw)
         if parsed is None:
             return None
-        epoch_ms, stream, is_full, message = parsed
-        if not is_full:
-            self.pending.append(message)
+        if not parsed.is_full:
+            self.pending.append(parsed.message)
             return None
+        message = parsed.message
         if self.pending:
             message = "".join(self.pending) + message
             self.pending.clear()
-        return CriLogLine(epoch_ms=epoch_ms, stream=stream, message=message)
+        return CriLogLine(epoch_ms=parsed.epoch_ms, stream=parsed.stream, message=message)
 
 
 class LogShipper:

--- a/lib/iris/src/iris/cluster/backends/k8s/logship.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/logship.py
@@ -1,0 +1,356 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Native sidecar that ships a task pod's container logs to finelog.
+
+Runs as a native sidecar (initContainer with ``restartPolicy: Always``) in every
+k8s task pod. It tails the task container's on-disk CRI log file from the node
+(mounted read-only via hostPath at ``/var/log/pods``) and pushes the lines to the
+finelog log server, so the controller does not pull logs per pod through the
+apiserver.
+
+Run as ``python -m iris.cluster.backends.k8s.logship``. Configuration comes from
+the environment the pod manifest sets:
+
+- ``IRIS_TASK_ID`` — the wire ``task:attempt`` id; it is the finelog key.
+- ``IRIS_CONTROLLER_ADDRESS`` — resolves the log server endpoint.
+- ``IRIS_POD_NAMESPACE`` / ``IRIS_POD_NAME`` — locate the CRI log directory.
+
+The push is unauthenticated: the finelog log service performs no auth, the same
+posture under which the controller writes its own logs.
+"""
+
+from __future__ import annotations
+
+import glob
+import logging
+import os
+import signal
+import sys
+import time
+from dataclasses import dataclass, field
+from datetime import datetime
+
+from finelog.client import LogClient
+from finelog.rpc import logging_pb2
+from finelog.types import str_to_log_level
+from rigging.log_setup import parse_log_level
+from rigging.timing import Timestamp
+
+from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
+from iris.rpc import controller_pb2
+from iris.rpc.controller_connect import ControllerServiceClientSync
+
+logger = logging.getLogger(__name__)
+
+# Name of the task container in the pod manifest. The CRI log directory holds one
+# subdirectory per container; we tail only the task's.
+_TASK_CONTAINER_NAME = "task"
+
+# Max log entries per write_batch RPC. Keeps a burst of output from building one
+# unbounded request while still amortizing the round-trip over many lines.
+_MAX_BATCH_ENTRIES = 1000
+
+# How long to wait for the CRI log file to appear before the first read, and the
+# idle poll interval once it exists. The kubelet creates the file when the
+# container starts, which is after this sidecar; tailing simply waits for it.
+_FILE_WAIT_POLL_SECONDS = 0.5
+_TAIL_IDLE_POLL_SECONDS = 0.25
+
+# Flush deadline applied on shutdown so a finelog hiccup cannot hang pod teardown.
+_SHUTDOWN_FLUSH_TIMEOUT_SECONDS = 5.0
+
+
+@dataclass
+class CriLogLine:
+    """One parsed CRI log line.
+
+    ``epoch_ms`` is the kubelet-stamped timestamp; ``stream`` is ``stdout`` or
+    ``stderr``; ``message`` is the reassembled log text (partial ``P`` fragments
+    joined onto the following ``F`` line).
+    """
+
+    epoch_ms: int
+    stream: str
+    message: str
+
+
+def parse_cri_line(raw: str) -> tuple[int, str, bool, str] | None:
+    """Parse one CRI on-disk log line.
+
+    The format is ``<rfc3339> <stdout|stderr> <F|P> <message>``: a timestamp, the
+    stream, a full/partial tag, then the message (which may itself contain
+    spaces). Returns ``(epoch_ms, stream, is_full, message)``; ``is_full`` is
+    True for an ``F`` tag (complete line) and False for ``P`` (a continuation to
+    be joined onto the next fragment). Returns None for a line that does not
+    match the format.
+    """
+    parts = raw.split(" ", 3)
+    if len(parts) < 4:
+        return None
+    timestamp_str, stream, tag, message = parts
+    if stream not in ("stdout", "stderr") or tag not in ("F", "P"):
+        return None
+    epoch_ms = _rfc3339_to_epoch_ms(timestamp_str)
+    if epoch_ms is None:
+        return None
+    return epoch_ms, stream, tag == "F", message
+
+
+def _rfc3339_to_epoch_ms(timestamp_str: str) -> int | None:
+    """Convert a CRI RFC3339 timestamp (nanosecond precision, ``Z`` suffix) to epoch ms."""
+    text = timestamp_str.replace("Z", "+00:00")
+    # datetime.fromisoformat accepts at most microsecond precision; CRI writes
+    # nanoseconds, so truncate the fractional part to 6 digits before parsing.
+    if "." in text:
+        head, _, tail = text.partition(".")
+        frac = tail
+        offset = ""
+        for sep in ("+", "-"):
+            if sep in tail:
+                frac, _, off = tail.partition(sep)
+                offset = sep + off
+                break
+        text = f"{head}.{frac[:6]}{offset}"
+    try:
+        return Timestamp.from_seconds(datetime.fromisoformat(text).timestamp()).epoch_ms()
+    except ValueError:
+        return None
+
+
+def _make_log_entry(line: CriLogLine, attempt_id: int) -> logging_pb2.LogEntry:
+    """Build a finelog LogEntry from a parsed CRI line."""
+    level = str_to_log_level(parse_log_level(line.message))
+    entry = logging_pb2.LogEntry(source=line.stream, data=line.message, attempt_id=attempt_id, level=level)
+    entry.timestamp.epoch_ms = line.epoch_ms
+    return entry
+
+
+def split_key_attempt(task_id: str) -> tuple[str, int]:
+    """Split ``IRIS_TASK_ID`` into the finelog key and attempt id.
+
+    The wire id is ``task:attempt`` for retries and bare ``task`` for the first
+    attempt (attempt 0). The key written to finelog is the full wire id; the
+    attempt is parsed off the ``:`` suffix for the LogEntry's ``attempt_id``.
+    """
+    _base, sep, attempt = task_id.rpartition(":")
+    if sep and attempt.isdigit():
+        return task_id, int(attempt)
+    return task_id, 0
+
+
+def _log_dir_glob(namespace: str, pod_name: str) -> str:
+    """Glob pattern for the task container's CRI log directory.
+
+    kubelet lays out logs at ``/var/log/pods/{namespace}_{name}_{uid}/{container}/``;
+    the uid is unknown to the pod, so it is globbed.
+    """
+    return f"/var/log/pods/{namespace}_{pod_name}_*/{_TASK_CONTAINER_NAME}"
+
+
+def _active_log_file(log_dir_glob: str) -> str | None:
+    """Return the active CRI log file (``0.log``) under the globbed container dir.
+
+    kubelet writes the live stream to ``0.log`` and rotates older content to
+    ``0.log.<timestamp>`` / ``1.log`` etc. We only follow the active file.
+    """
+    for container_dir in glob.glob(log_dir_glob):
+        candidate = os.path.join(container_dir, "0.log")
+        if os.path.exists(candidate):
+            return candidate
+    return None
+
+
+@dataclass
+class _LineBuffer:
+    """Reassembles CRI partial (``P``) fragments into full lines.
+
+    A ``P``-tagged line is a fragment of a long line the kubelet split at its read
+    buffer boundary; fragments accumulate until an ``F`` line closes them. The
+    closing line's timestamp and stream are used for the reassembled entry.
+    """
+
+    pending: list[str] = field(default_factory=list)
+
+    def feed(self, raw: str) -> CriLogLine | None:
+        """Feed one raw CRI line; return a CriLogLine when a full line is complete."""
+        parsed = parse_cri_line(raw)
+        if parsed is None:
+            return None
+        epoch_ms, stream, is_full, message = parsed
+        if not is_full:
+            self.pending.append(message)
+            return None
+        if self.pending:
+            message = "".join(self.pending) + message
+            self.pending.clear()
+        return CriLogLine(epoch_ms=epoch_ms, stream=stream, message=message)
+
+
+class LogShipper:
+    """Tails a task container's CRI log file and ships parsed lines to finelog.
+
+    The shipper follows the active ``0.log``, reassembles partial lines, and
+    writes batched LogEntries under the task's finelog key. It survives kubelet
+    log rotation by reopening the active file when its inode changes or it
+    shrinks. The ship loop never raises: a finelog outage must not crash the
+    sidecar and wedge pod teardown.
+    """
+
+    def __init__(self, client: LogClient, log_dir_glob: str, key: str, attempt_id: int):
+        self._client = client
+        self._log_dir_glob = log_dir_glob
+        self._key = key
+        self._attempt_id = attempt_id
+        self._buffer = _LineBuffer()
+        self._stop = False
+
+    def request_stop(self) -> None:
+        """Signal the ship loop to drain to EOF and exit (called from SIGTERM)."""
+        self._stop = True
+
+    def run(self) -> None:
+        """Follow the active log file across rotations until stopped, then flush.
+
+        The outer loop owns one open file handle per generation of ``0.log``;
+        when kubelet rotates the file (new inode), the handle is closed and the
+        loop reopens the fresh file from the start.
+        """
+        path = self._await_file()
+        if path is None:
+            return
+        while path is not None:
+            with open(path, encoding="utf-8", errors="replace") as handle:
+                inode = os.fstat(handle.fileno()).st_ino
+                path = self._tail(handle, inode)
+        self._flush()
+
+    def _tail(self, handle, inode: int) -> str | None:
+        """Drain ``handle`` until stop or rotation.
+
+        Returns the path of the rotated-in file to reopen, or None when the
+        shipper was asked to stop (the caller then flushes and exits).
+        """
+        partial = ""
+        while True:
+            partial = self._drain(handle, partial)
+            if self._stop:
+                # Final drain to EOF after the task container exited.
+                self._drain(handle, partial)
+                return None
+            rotated_path = self._rotated_path(handle, inode)
+            if rotated_path is not None:
+                return rotated_path
+            time.sleep(_TAIL_IDLE_POLL_SECONDS)
+
+    def _await_file(self) -> str | None:
+        """Wait for the active CRI log file to appear; stop early if asked to."""
+        while not self._stop:
+            path = _active_log_file(self._log_dir_glob)
+            if path is not None:
+                return path
+            time.sleep(_FILE_WAIT_POLL_SECONDS)
+        return _active_log_file(self._log_dir_glob)
+
+    def _drain(self, handle, partial: str) -> str:
+        """Read all currently-available complete lines from ``handle`` and ship them.
+
+        Returns the trailing partial read (an unterminated final chunk) to carry
+        into the next drain so a line split across reads is not shipped twice.
+        """
+        chunk = handle.read()
+        if not chunk:
+            return partial
+        data = partial + chunk
+        lines = data.split("\n")
+        trailing = lines.pop()
+        batch: list[logging_pb2.LogEntry] = []
+        for raw in lines:
+            cri_line = self._buffer.feed(raw)
+            if cri_line is not None:
+                batch.append(_make_log_entry(cri_line, self._attempt_id))
+            if len(batch) >= _MAX_BATCH_ENTRIES:
+                self._write(batch)
+                batch = []
+        if batch:
+            self._write(batch)
+        return trailing
+
+    def _rotated_path(self, handle, inode: int) -> str | None:
+        """Return the active log file path when kubelet has rotated ``0.log``.
+
+        Rotation replaces ``0.log`` with a fresh inode (and the file may briefly
+        shrink below the current read offset). Returns the path to reopen on a
+        detected rotation, or None when the current handle is still the live file.
+        """
+        path = _active_log_file(self._log_dir_glob)
+        if path is None:
+            return None
+        try:
+            stat = os.stat(path)
+        except OSError:
+            return None
+        if stat.st_ino == inode and stat.st_size >= handle.tell():
+            return None
+        return path
+
+    def _write(self, entries: list[logging_pb2.LogEntry]) -> None:
+        try:
+            self._client.write_batch(self._key, entries)
+        except Exception:
+            logger.warning("logship: write_batch of %d entries failed", len(entries), exc_info=True)
+
+    def _flush(self) -> None:
+        try:
+            self._client.flush(timeout=_SHUTDOWN_FLUSH_TIMEOUT_SECONDS)
+        except Exception:
+            logger.warning("logship: final flush failed", exc_info=True)
+
+
+def _resolve_log_service(controller_client: ControllerServiceClientSync, server_url: str) -> str:
+    """Resolve the log server address via the controller's endpoint registry."""
+    resp = controller_client.list_endpoints(
+        controller_pb2.Controller.ListEndpointsRequest(prefix=server_url, exact=True),
+    )
+    if not resp.endpoints:
+        raise ConnectionError(f"No {server_url!r} endpoint registered on controller")
+    return resp.endpoints[0].address
+
+
+def _connect_log_client(controller_address: str) -> LogClient:
+    """Build a finelog write client that resolves the log server via the controller.
+
+    Unauthenticated — the finelog log service performs no auth.
+    """
+    controller_client = ControllerServiceClientSync(
+        address=controller_address,
+        timeout_ms=10_000,
+    )
+    return LogClient.connect(
+        LOG_SERVER_ENDPOINT_NAME,
+        resolver=lambda server_url: _resolve_log_service(controller_client, server_url),
+    )
+
+
+def main() -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s logship %(message)s")
+
+    task_id = os.environ["IRIS_TASK_ID"]
+    controller_address = os.environ["IRIS_CONTROLLER_ADDRESS"]
+    namespace = os.environ["IRIS_POD_NAMESPACE"]
+    pod_name = os.environ["IRIS_POD_NAME"]
+
+    key, attempt_id = split_key_attempt(task_id)
+    client = _connect_log_client(controller_address)
+    shipper = LogShipper(client, _log_dir_glob(namespace, pod_name), key, attempt_id)
+
+    signal.signal(signal.SIGTERM, lambda *_: shipper.request_stop())
+
+    logger.info("logship: shipping logs for %s (attempt %d) from %s", key, attempt_id, pod_name)
+    shipper.run()
+    client.close()
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1959,39 +1959,33 @@ class K8sTaskProvider:
         gang_pod_names: list[str] = []
         gang_pod_groups: set[str] = set()
         gang_task_hashes: set[str] = set()
-        for phase in ("Succeeded", "Failed"):
-            pods = self.kubectl.list_json(
-                K8sResource.PODS,
-                labels=_MANAGED_POD_LABELS,
-                field_selector=f"status.phase={phase}",
-            )
-            for pod in pods:
-                meta = pod.get("metadata", {})
-                created = meta.get("creationTimestamp", "")
-                if not created:
-                    continue
-                ts = parse_k8s_timestamp(created).timestamp()
-                task_hash = meta.get("labels", {}).get(_LABEL_TASK_HASH)
-                pod_group = meta.get("labels", {}).get(_KUEUE_POD_GROUP_NAME)
-                # Gang sweep: a deletionTimestamp means a prior delete is
-                # wedged on the Kueue finalizer; otherwise the shorter gang
-                # retention applies. Handled pods are excluded from the 1h
-                # sweep below. Pods whose group still has live members are
-                # deferred wholesale (not even age-swept): a partial delete
-                # would wedge on the finalizer, and releasing the shared
-                # Workload would evict the running siblings.
-                if pod_group and pod_group in active_gang_groups:
-                    continue
-                if pod_group and (meta.get("deletionTimestamp") or ts < gang_cutoff):
-                    gang_pod_names.append(meta["name"])
-                    gang_pod_groups.add(pod_group)
-                    if task_hash:
-                        gang_task_hashes.add(task_hash)
-                    continue
-                if ts < cutoff:
-                    old_pod_names.append(meta["name"])
-                    if task_hash:
-                        old_task_hashes.add(task_hash)
+        for pod in self._list_terminal_pods():
+            meta = pod.get("metadata", {})
+            created = meta.get("creationTimestamp", "")
+            if not created:
+                continue
+            ts = parse_k8s_timestamp(created).timestamp()
+            task_hash = meta.get("labels", {}).get(_LABEL_TASK_HASH)
+            pod_group = meta.get("labels", {}).get(_KUEUE_POD_GROUP_NAME)
+            # Gang sweep: a deletionTimestamp means a prior delete is
+            # wedged on the Kueue finalizer; otherwise the shorter gang
+            # retention applies. Handled pods are excluded from the 1h
+            # sweep below. Pods whose group still has live members are
+            # deferred wholesale (not even age-swept): a partial delete
+            # would wedge on the finalizer, and releasing the shared
+            # Workload would evict the running siblings.
+            if pod_group and pod_group in active_gang_groups:
+                continue
+            if pod_group and (meta.get("deletionTimestamp") or ts < gang_cutoff):
+                gang_pod_names.append(meta["name"])
+                gang_pod_groups.add(pod_group)
+                if task_hash:
+                    gang_task_hashes.add(task_hash)
+                continue
+            if ts < cutoff:
+                old_pod_names.append(meta["name"])
+                if task_hash:
+                    old_task_hashes.add(task_hash)
 
         if gang_pod_names:
             # force (gracePeriodSeconds=0): these pods are already terminal, so
@@ -2026,15 +2020,11 @@ class K8sTaskProvider:
             )
 
     def _list_terminal_pods(self) -> list[dict]:
-        """Bulk-list managed pods in a terminal phase (Succeeded or Failed).
-
-        Field selectors AND their comma-separated terms, so the active-pods
-        selector ``status.phase!=Succeeded,status.phase!=Failed`` excludes both,
-        but the inverse ``status.phase==Succeeded,status.phase==Failed`` matches
-        nothing (a pod is never both), so the two terminal phases are listed
-        separately.
-        """
+        """Bulk-list managed pods in a terminal phase (Succeeded or Failed)."""
         pods: list[dict] = []
+        # Field selectors AND their comma-separated terms, so a single
+        # status.phase==Succeeded,status.phase==Failed matches nothing (a pod is
+        # never both); list each terminal phase separately.
         for phase in ("Succeeded", "Failed"):
             pods.extend(
                 self.kubectl.list_json(

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -343,6 +343,11 @@ class PodConfig:
 
     namespace: str
     default_image: str
+    # Image for the log-shipper sidecar. The task default_image is a bare runtime
+    # that only gains the iris package after the task's own `uv sync`, so the
+    # sidecar instead runs the iris controller image (iris + finelog installed),
+    # which can launch `python -m iris.cluster.backends.k8s.logship` directly.
+    logship_image: str = ""
     cache_dir: str = "/cache"
     service_account: str = ""
     host_network: bool = False
@@ -454,7 +459,7 @@ def _build_init_container_spec(
 def _build_logship_sidecar(
     task_id_wire: str,
     controller_address: str | None,
-    default_image: str,
+    logship_image: str,
 ) -> dict:
     """Build the native log-shipping sidecar container spec.
 
@@ -466,6 +471,9 @@ def _build_logship_sidecar(
     ``varlogpods`` hostPath) and pushes lines to finelog. It resolves the log
     server via the controller and pushes unauthenticated — the finelog log
     service performs no auth, matching the controller's own writes.
+
+    Runs ``logship_image`` (the iris controller image) rather than the task
+    image, which lacks the iris package until the task's own dependency sync.
     """
     env: list[dict] = [
         {"name": "IRIS_TASK_ID", "value": task_id_wire},
@@ -476,7 +484,7 @@ def _build_logship_sidecar(
         env.append({"name": "IRIS_CONTROLLER_ADDRESS", "value": controller_address})
     return {
         "name": _LOGSHIP_CONTAINER_NAME,
-        "image": default_image,
+        "image": logship_image,
         "imagePullPolicy": "IfNotPresent",
         "restartPolicy": "Always",
         "command": ["python", "-m", "iris.cluster.backends.k8s.logship"],
@@ -705,7 +713,7 @@ def _build_pod_manifest(
     logship = _build_logship_sidecar(
         iris_env["IRIS_TASK_ID"],
         config.controller_address,
-        default_image,
+        config.logship_image,
     )
     volumes.append(
         {
@@ -1358,6 +1366,8 @@ class K8sTaskProvider:
     kubectl: K8sService
     namespace: str
     default_image: str
+    # Iris controller image, used for the log-shipper sidecar (see PodConfig).
+    logship_image: str = ""
     cache_dir: str = "/cache"
     service_account: str = ""
     host_network: bool = False
@@ -1628,6 +1638,7 @@ class K8sTaskProvider:
         return PodConfig(
             namespace=self.namespace,
             default_image=self.default_image,
+            logship_image=self.logship_image,
             cache_dir=self.cache_dir,
             service_account=self.service_account,
             host_network=self.host_network,

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -2025,13 +2025,36 @@ class K8sTaskProvider:
                 len(old_task_hashes - safe_hashes),
             )
 
+    def _list_terminal_pods(self) -> list[dict]:
+        """Bulk-list managed pods in a terminal phase (Succeeded or Failed).
+
+        Field selectors AND their comma-separated terms, so the active-pods
+        selector ``status.phase!=Succeeded,status.phase!=Failed`` excludes both,
+        but the inverse ``status.phase==Succeeded,status.phase==Failed`` matches
+        nothing (a pod is never both), so the two terminal phases are listed
+        separately.
+        """
+        pods: list[dict] = []
+        for phase in ("Succeeded", "Failed"):
+            pods.extend(
+                self.kubectl.list_json(
+                    K8sResource.PODS,
+                    labels=_MANAGED_POD_LABELS,
+                    field_selector=f"status.phase={phase}",
+                )
+            )
+        return pods
+
     def _poll_pods(self, running: list[RunningTaskEntry], cached_pods: list[dict]) -> list[TaskUpdate]:
         """Poll pod phases for all running tasks.
 
-        Uses the pre-fetched pod list (active pods only, terminal pods excluded
-        by field selector). For entries missing from the cached list, does a
-        targeted get_json to check if the pod completed — this avoids the grace-
-        period-to-FAILED path for legitimately Succeeded pods.
+        Uses the pre-fetched active-pods list (terminal pods excluded by field
+        selector). Running tasks whose pod has left that list have either
+        completed (phase moved to Succeeded/Failed) or vanished; they are
+        resolved with a single bulk terminal-pods list rather than a per-pod
+        get_json each, so the reconcile thread issues only bulk LISTs even when a
+        whole gang finishes in one cycle. A pod absent from both lists falls to
+        the grace-period path below.
 
         Log fetching and resource usage collection are handled by background
         LogCollector and ResourceCollector threads. After building updates,
@@ -2050,6 +2073,15 @@ class K8sTaskProvider:
         pods_by_name: dict[str, dict] = {pod.get("metadata", {}).get("name", ""): pod for pod in cached_pods}
         updates: list[TaskUpdate] = []
 
+        # Resolve running tasks whose pod has left the active list (completed or
+        # vanished) with one bulk terminal-pods list instead of a per-pod GET
+        # each. Lazy: only fetched on cycles where at least one pod is missing,
+        # so steady-state cycles add no call. setdefault keeps the active entry
+        # if a name somehow appears in both.
+        if any(_pod_name(entry.task_id, entry.attempt_id) not in pods_by_name for entry in running):
+            for pod in self._list_terminal_pods():
+                pods_by_name.setdefault(pod.get("metadata", {}).get("name", ""), pod)
+
         # Build up the authoritative pod sets for collectors.
         log_pods: dict[str, _LogPod] = {}
         # (task_id_wire, attempt_id) -> pod_name. Resource samples are
@@ -2062,10 +2094,6 @@ class K8sTaskProvider:
             pod_name = _pod_name(entry.task_id, entry.attempt_id)
             cursor_key = f"{entry.task_id.to_wire()}:{entry.attempt_id}"
             pod = pods_by_name.get(pod_name)
-
-            if pod is None:
-                # Pod not in active list — may have completed or truly vanished.
-                pod = self.kubectl.get_json(K8sResource.PODS, pod_name)
 
             if pod is None:
                 count = self._pod_not_found_counts.get(cursor_key, 0) + 1

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -487,7 +487,9 @@ def _build_logship_sidecar(
         "image": logship_image,
         "imagePullPolicy": "IfNotPresent",
         "restartPolicy": "Always",
-        "command": ["python", "-m", "iris.cluster.backends.k8s.logship"],
+        # iris is installed in the image's .venv (resolved relative to the image
+        # WORKDIR), so launch the same interpreter the controller container does.
+        "command": [".venv/bin/python", "-m", "iris.cluster.backends.k8s.logship"],
         "env": env,
         "volumeMounts": [{"name": _LOGSHIP_VOLUME_NAME, "mountPath": _NODE_POD_LOG_DIR, "readOnly": True}],
         "resources": {"requests": {"cpu": "50m", "memory": "64Mi"}},

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -18,7 +18,6 @@ import shlex
 import threading
 import time
 from collections.abc import Iterator, Sequence
-from concurrent.futures import ThreadPoolExecutor
 from contextlib import contextmanager
 from dataclasses import dataclass, field
 from datetime import UTC, datetime
@@ -26,9 +25,7 @@ from pathlib import Path
 from typing import ClassVar
 
 from finelog.client.log_client import Table
-from finelog.rpc import logging_pb2
-from finelog.types import LogWriterProtocol, str_to_log_level
-from rigging.log_setup import parse_log_level
+from finelog.types import LogWriterProtocol
 from rigging.timing import Timestamp
 
 from iris.cluster.backends.k8s.constants import COREWEAVE_INTERRUPTABLE_TOLERATION, NVIDIA_GPU_TOLERATION
@@ -37,7 +34,6 @@ from iris.cluster.backends.k8s.service import K8sService
 from iris.cluster.backends.k8s.types import (
     K8sResource,
     KubectlError,
-    KubectlLogLine,
     parse_k8s_quantity,
     parse_k8s_timestamp,
 )
@@ -55,7 +51,6 @@ from iris.cluster.controller.backend import (
 from iris.cluster.controller.reads import ControlSnapshot
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
 from iris.cluster.controller.task_state import RunningTaskEntry
-from iris.cluster.log_keys import task_log_key
 from iris.cluster.runtime.env import build_common_iris_env, normalize_workdir_relative_path
 from iris.cluster.runtime.profile import (
     PROFILER_WATCHDOG_GRACE_SECONDS,
@@ -67,7 +62,7 @@ from iris.cluster.runtime.profile import (
     sigcont_sweep_argv,
     wrap_with_kill_watchdog,
 )
-from iris.cluster.types import JobName, TaskAttempt, WorkerId, get_gpu_count
+from iris.cluster.types import JobName, WorkerId, get_gpu_count
 from iris.cluster.worker.stats import IrisTaskStat, build_task_stat
 from iris.rpc import controller_pb2, job_pb2, worker_pb2
 from iris.time_proto import timestamp_to_proto
@@ -88,6 +83,17 @@ _RUNTIME_LABEL_VALUE = "iris-kubernetes"
 
 # Extended resource name for NVIDIA GPUs in pod requests/limits.
 _GPU_RESOURCE = "nvidia.com/gpu"
+
+# Name of the task container in the pod. Exit-code/error extraction matches the
+# task status by this name rather than by position in containerStatuses.
+_TASK_CONTAINER_NAME = "task"
+
+# Native log-shipping sidecar (initContainer + restartPolicy: Always). It reads
+# the task container's CRI log file from the node and pushes to finelog, so the
+# controller never pulls pod logs through the apiserver.
+_LOGSHIP_CONTAINER_NAME = "log-shipper"
+_LOGSHIP_VOLUME_NAME = "varlogpods"
+_NODE_POD_LOG_DIR = "/var/log/pods"
 
 # Max pod name length is 253 chars in k8s. We stay well under it.
 _MAX_POD_NAME_LEN = 63
@@ -445,6 +451,41 @@ def _build_init_container_spec(
     return init_containers, extra_volumes, configmap_name
 
 
+def _build_logship_sidecar(
+    task_id_wire: str,
+    controller_address: str | None,
+    default_image: str,
+) -> dict:
+    """Build the native log-shipping sidecar container spec.
+
+    A native sidecar (initContainer with ``restartPolicy: Always``) so it starts
+    before the task container and is excluded from the pod-phase computation —
+    the pod still reaches Succeeded/Failed when only the task container exits,
+    and the kubelet terminates the sidecar after it. The sidecar tails the task
+    container's CRI log file from the node (mounted read-only via the
+    ``varlogpods`` hostPath) and pushes lines to finelog. It resolves the log
+    server via the controller and pushes unauthenticated — the finelog log
+    service performs no auth, matching the controller's own writes.
+    """
+    env: list[dict] = [
+        {"name": "IRIS_TASK_ID", "value": task_id_wire},
+        {"name": "IRIS_POD_NAMESPACE", "valueFrom": {"fieldRef": {"fieldPath": "metadata.namespace"}}},
+        {"name": "IRIS_POD_NAME", "valueFrom": {"fieldRef": {"fieldPath": "metadata.name"}}},
+    ]
+    if controller_address:
+        env.append({"name": "IRIS_CONTROLLER_ADDRESS", "value": controller_address})
+    return {
+        "name": _LOGSHIP_CONTAINER_NAME,
+        "image": default_image,
+        "imagePullPolicy": "IfNotPresent",
+        "restartPolicy": "Always",
+        "command": ["python", "-m", "iris.cluster.backends.k8s.logship"],
+        "env": env,
+        "volumeMounts": [{"name": _LOGSHIP_VOLUME_NAME, "mountPath": _NODE_POD_LOG_DIR, "readOnly": True}],
+        "resources": {"requests": {"cpu": "50m", "memory": "64Mi"}},
+    }
+
+
 def _is_coordinator_task(run_req: job_pb2.RunTaskRequest) -> bool:
     """Heuristic: single-task job with no accelerators is a coordinator/orchestrator.
 
@@ -656,9 +697,27 @@ def _build_pod_manifest(
             anno_key: node_label,
         }
 
+    # Native log-shipping sidecar: ships the task container's node-side CRI log
+    # file to finelog. As an initContainer with restartPolicy: Always it is
+    # excluded from pod-phase computation, so completion detection (which keys on
+    # pod.status.phase) is unaffected. The hostPath volume gives it read-only
+    # access to the node's pod log directory.
+    logship = _build_logship_sidecar(
+        iris_env["IRIS_TASK_ID"],
+        config.controller_address,
+        default_image,
+    )
+    volumes.append(
+        {
+            "name": _LOGSHIP_VOLUME_NAME,
+            "hostPath": {"path": _NODE_POD_LOG_DIR, "type": "Directory"},
+        }
+    )
+
     spec: dict = {
         "restartPolicy": "Never",
         "containers": [container],
+        "initContainers": [logship],
         "volumes": volumes,
     }
 
@@ -707,13 +766,20 @@ def _build_pod_manifest(
     }
 
 
-def _kubectl_log_line_to_log_entry(kll: KubectlLogLine, attempt_id: int) -> logging_pb2.LogEntry:
-    level_name = parse_log_level(kll.data)
-    level = str_to_log_level(level_name)
-    entry = logging_pb2.LogEntry(source=kll.stream, data=kll.data, attempt_id=attempt_id, level=level)
-    # finelog's LogEntry.timestamp is a finelog.logging.Timestamp; assign epoch_ms directly.
-    entry.timestamp.epoch_ms = Timestamp.from_seconds(kll.timestamp.timestamp()).epoch_ms()
-    return entry
+def _task_container_status(pod: dict) -> dict | None:
+    """Return the task container's status, matched by name.
+
+    Returns None when the pod has no container statuses yet. Matching by name
+    rather than by position keeps exit-code extraction pinned to the task
+    container; falls back to the first status if none is named ``task``.
+    """
+    statuses = pod.get("status", {}).get("containerStatuses", [])
+    if not statuses:
+        return None
+    for status in statuses:
+        if status.get("name") == _TASK_CONTAINER_NAME:
+            return status
+    return statuses[0]
 
 
 def _is_infrastructure_failure(pod: dict) -> bool:
@@ -723,12 +789,12 @@ def _is_infrastructure_failure(pod: dict) -> bool:
     by the application itself, so it should be classified as a worker/preemption
     failure rather than an application failure.
     """
-    statuses = pod.get("status", {}).get("containerStatuses", [])
-    if not statuses:
+    status = _task_container_status(pod)
+    if status is None:
         # Pod-level eviction: the pod status reason indicates infrastructure.
         pod_reason = pod.get("status", {}).get("reason", "")
         return pod_reason in _INFRASTRUCTURE_FAILURE_REASONS
-    terminated = statuses[0].get("state", {}).get("terminated", {})
+    terminated = status.get("state", {}).get("terminated", {})
     return terminated.get("reason", "") in _INFRASTRUCTURE_FAILURE_REASONS
 
 
@@ -781,10 +847,10 @@ def _task_update_from_pod(entry: RunningTaskEntry, pod: dict) -> TaskUpdate:
 
 
 def _extract_exit_code(pod: dict) -> int | None:
-    """Extract exit code from the first container's terminated state."""
-    statuses = pod.get("status", {}).get("containerStatuses", [])
-    if statuses:
-        terminated = statuses[0].get("state", {}).get("terminated", {})
+    """Extract exit code from the task container's terminated state."""
+    status = _task_container_status(pod)
+    if status is not None:
+        terminated = status.get("state", {}).get("terminated", {})
         code = terminated.get("exitCode")
         if isinstance(code, int):
             return code
@@ -792,11 +858,11 @@ def _extract_exit_code(pod: dict) -> int | None:
 
 
 def _extract_error(pod: dict) -> str | None:
-    """Extract error reason/message from pod container statuses."""
-    statuses = pod.get("status", {}).get("containerStatuses", [])
-    if not statuses:
+    """Extract error reason/message from the task container's status."""
+    status = _task_container_status(pod)
+    if status is None:
         return pod.get("status", {}).get("reason") or None
-    terminated = statuses[0].get("state", {}).get("terminated", {})
+    terminated = status.get("state", {}).get("terminated", {})
     reason = terminated.get("reason", "")
     message = terminated.get("message", "")
     if reason == "Completed":
@@ -1122,118 +1188,6 @@ class ClusterState:
         )
 
 
-@dataclass
-class _LogPod:
-    """A pod tracked by LogCollector for incremental log fetching."""
-
-    pod_name: str
-    task_id: JobName
-    attempt_id: int
-    last_timestamp: datetime | None = None
-    consecutive_failures: int = 0
-
-
-class LogCollector:
-    """Background log fetcher that pushes entries to the LogService.
-
-    Runs on its own daemon thread with a bounded ThreadPoolExecutor.
-    The sync loop calls set_pods() once per cycle with the authoritative
-    set of pods to track. The collector diffs against its internal state,
-    does a final fetch for removed pods, and starts tracking new ones.
-    This avoids drift between what the sync loop thinks is tracked and
-    what the collector is actually polling.
-    """
-
-    _DEFAULT_LIMIT_BYTES: int = 100_000
-
-    def __init__(
-        self,
-        kubectl: K8sService,
-        log_client: LogWriterProtocol,
-        concurrency: int = 8,
-        poll_interval: float = 15.0,
-        limit_bytes: int | None = _DEFAULT_LIMIT_BYTES,
-    ):
-        self._kubectl = kubectl
-        self._log_client = log_client
-        self._poll_interval = poll_interval
-        self._limit_bytes = limit_bytes
-        self._pods: dict[str, _LogPod] = {}
-        self._lock = threading.Lock()
-        self._pod_locks: dict[str, threading.Lock] = {}
-        self._stop = threading.Event()
-        self._executor = ThreadPoolExecutor(max_workers=concurrency, thread_name_prefix="log-collect")
-        self._thread = threading.Thread(target=self._run, daemon=True, name="log-collector")
-        self._thread.start()
-
-    def set_pods(self, pods: dict[str, _LogPod]) -> None:
-        """Declare the authoritative set of pods to collect logs for.
-
-        New keys are added. Keys absent from `pods` are removed after a
-        synchronous final log fetch. Existing keys are preserved (keeping
-        their cursor state).
-        """
-        with self._lock:
-            removed_keys = self._pods.keys() - pods.keys()
-            removed = [(key, self._pods[key], self._pod_locks.get(key)) for key in removed_keys]
-            for key in removed_keys:
-                del self._pods[key]
-                self._pod_locks.pop(key, None)
-            for key, pod in pods.items():
-                if key not in self._pods:
-                    self._pods[key] = pod
-                    self._pod_locks[key] = threading.Lock()
-
-        # Final fetch for removed pods (outside lock to avoid holding it during I/O).
-        for _key, pod, pod_lock in removed:
-            if pod_lock is not None:
-                with pod_lock:
-                    self._fetch_and_store(pod)
-
-    def _run(self) -> None:
-        while not self._stop.is_set():
-            with self._lock:
-                snapshot = list(self._pods.items())
-            for key, pod in snapshot:
-                with self._lock:
-                    pod_lock = self._pod_locks.get(key)
-                if pod_lock is not None:
-                    self._executor.submit(self._guarded_fetch, key, pod, pod_lock)
-            self._stop.wait(timeout=self._poll_interval)
-
-    def _guarded_fetch(self, key: str, pod: _LogPod, pod_lock: threading.Lock) -> None:
-        if not pod_lock.acquire(blocking=False):
-            return
-        try:
-            self._fetch_and_store(pod)
-        finally:
-            pod_lock.release()
-
-    def _fetch_and_store(self, pod: _LogPod) -> bool:
-        """Fetch logs since last timestamp and advance. Must be called under pod lock."""
-        try:
-            result = self._kubectl.stream_logs(
-                pod.pod_name, container="task", since_time=pod.last_timestamp, limit_bytes=self._limit_bytes
-            )
-            if result.lines:
-                entries = [_kubectl_log_line_to_log_entry(kll, pod.attempt_id) for kll in result.lines]
-                key = task_log_key(TaskAttempt(task_id=pod.task_id, attempt_id=pod.attempt_id))
-                self._log_client.write_batch(key, entries)
-            pod.last_timestamp = result.last_timestamp
-            pod.consecutive_failures = 0
-            return True
-        except Exception as e:
-            pod.consecutive_failures += 1
-            if pod.consecutive_failures <= 1:
-                logger.warning("LogCollector: fetch failed for pod %s: %s", pod.pod_name, e)
-            return False
-
-    def close(self) -> None:
-        self._stop.set()
-        self._executor.shutdown(wait=False)
-        self._thread.join(timeout=5)
-
-
 class ResourceCollector:
     """Background thread that samples running pods' CPU/memory usage.
 
@@ -1419,7 +1373,6 @@ class K8sTaskProvider:
     # when it has gang work for Kueue. Empty disables the feature; see
     # _evict_preemptible_blockers for the safety guards.
     preempt_namespaces: list[str] = field(default_factory=list)
-    log_client: LogWriterProtocol | None = None
     # Pre-resolved iris.task Table handle. The controller injects this after
     # constructing the LogClient (see controller.py); when None — e.g. tests
     # without finelog — the resource collector is disabled.
@@ -1427,10 +1380,6 @@ class K8sTaskProvider:
     # Pre-resolved iris.profile Table handle injected by the controller
     # alongside task_stats_table. None in test mode.
     profile_table: Table | None = None
-    # Log fetch fan-out: logs have no bulk API, so each pod is streamed on its
-    # own worker thread.
-    poll_concurrency: int = 32
-    log_poll_interval: float = 15.0
     # Resource-usage poll cadence. Defaults to the metrics-server scrape
     # resolution (15s) — sampling faster only re-reads the same value. One bulk
     # metrics list per tick covers every managed pod (see ResourceCollector).
@@ -1445,7 +1394,6 @@ class K8sTaskProvider:
     # K8s provisions its own capacity (cluster autoscaler + Kueue); no Iris autoscaler.
     autoscaler: Autoscaler | None = field(default=None, init=False, repr=False)
     _pod_not_found_counts: dict[str, int] = field(default_factory=dict, init=False, repr=False)
-    _log_collector: LogCollector | None = field(default=None, init=False, repr=False)
     _resource_collector: ResourceCollector | None = field(default=None, init=False, repr=False)
     _cluster_state: ClusterState = field(default_factory=ClusterState, init=False, repr=False)
     _last_gc_time: float = field(default=0.0, init=False, repr=False)
@@ -1464,13 +1412,6 @@ class K8sTaskProvider:
                 poll_interval=self.resource_poll_interval,
             )
         return self._resource_collector
-
-    def _ensure_log_collector(self) -> LogCollector | None:
-        if self._log_collector is None and self.log_client is not None:
-            self._log_collector = LogCollector(
-                self.kubectl, self.log_client, concurrency=self.poll_concurrency, poll_interval=self.log_poll_interval
-            )
-        return self._log_collector
 
     def schedule(self, snapshot: ScheduleInput) -> ScheduleResult:
         """No-op: Kueue owns placement, so Iris makes no scheduling decisions."""
@@ -1660,16 +1601,16 @@ class K8sTaskProvider:
     ) -> None:
         """Inject the finelog handles the controller resolves after connecting.
 
-        K8s pods have no worker daemon, so the backend collects logs and writes
-        per-pod resource samples + profiles directly to finelog.
+        K8s task pods ship their own logs via the log-shipper sidecar rather than
+        through a worker daemon, so ``log_client`` is unused here: the sidecar
+        resolves its own connection to the log server (which performs no auth).
+        The backend writes per-pod resource samples + profiles to the injected
+        tables directly.
         """
-        self.log_client = log_client
         self.task_stats_table = task_stats_table
         self.profile_table = profile_table
 
     def close(self) -> None:
-        if self._log_collector is not None:
-            self._log_collector.close()
         if self._resource_collector is not None:
             self._resource_collector.close()
 
@@ -1735,8 +1676,12 @@ class K8sTaskProvider:
             }
             self.kubectl.apply_json(cm)
 
+        # Prepend the workdir-staging init containers before the log-shipper
+        # native sidecar already on the manifest: staging must run to completion
+        # first; the native sidecar starts before the task container regardless
+        # of its position in the list.
         if init_containers:
-            manifest["spec"]["initContainers"] = init_containers
+            manifest["spec"]["initContainers"] = init_containers + manifest["spec"]["initContainers"]
         if extra_volumes:
             manifest["spec"]["volumes"].extend(extra_volumes)
 
@@ -2046,16 +1991,12 @@ class K8sTaskProvider:
         whole gang finishes in one cycle. A pod absent from both lists falls to
         the grace-period path below.
 
-        Log fetching and resource usage collection are handled by background
-        LogCollector and ResourceCollector threads. After building updates,
-        this method calls set_pods() on each collector with the authoritative
-        set of non-terminal pods, so the collectors can never drift.
+        Task logs are shipped by the per-pod log-shipper sidecar, not pulled
+        here. This method drives task state and registers running pods with the
+        ResourceCollector, calling set_pods() once with the authoritative set of
+        running pods so the collector can never drift.
         """
         if not running:
-            # No running tasks — clear all collectors.
-            log_collector = self._ensure_log_collector()
-            if log_collector is not None:
-                log_collector.set_pods({})
             if self._resource_collector is not None:
                 self._resource_collector.set_pods({})
             return []
@@ -2072,13 +2013,10 @@ class K8sTaskProvider:
             for pod in self._list_terminal_pods():
                 pods_by_name.setdefault(pod.get("metadata", {}).get("name", ""), pod)
 
-        # Build up the authoritative pod sets for collectors.
-        log_pods: dict[str, _LogPod] = {}
         # (task_id_wire, attempt_id) -> pod_name. Resource samples are
         # appended directly to iris.task by the collector; the controller no
         # longer multiplexes them through TaskUpdate.
         resource_pods: dict[tuple[str, int], str] = {}
-        terminal_log_pods: dict[str, _LogPod] = {}  # pods that completed this cycle
 
         for entry in running:
             pod_name = _pod_name(entry.task_id, entry.attempt_id)
@@ -2117,28 +2055,11 @@ class K8sTaskProvider:
             self._pod_not_found_counts.pop(cursor_key, None)
             update = _task_update_from_pod(entry, pod)
             phase = pod.get("status", {}).get("phase", "")
-
-            if phase not in ("Succeeded", "Failed"):
-                log_pods[cursor_key] = _LogPod(pod_name=pod_name, task_id=entry.task_id, attempt_id=entry.attempt_id)
-                if phase == "Running":
-                    resource_pods[(entry.task_id.to_wire(), entry.attempt_id)] = pod_name
-            else:
-                terminal_log_pods[cursor_key] = _LogPod(
-                    pod_name=pod_name, task_id=entry.task_id, attempt_id=entry.attempt_id
-                )
+            if phase == "Running":
+                resource_pods[(entry.task_id.to_wire(), entry.attempt_id)] = pod_name
 
             updates.append(update)
 
-        # Sync collectors with the authoritative pod sets.
-        # set_pods() does a final log fetch for pods that drop out of the set.
-        # For pods that completed this cycle, we include them first so they're
-        # added (if not already tracked), then call set_pods again without them
-        # to trigger the final fetch on removal.
-        log_collector = self._ensure_log_collector()
-        if log_collector is not None:
-            if terminal_log_pods:
-                log_collector.set_pods({**log_pods, **terminal_log_pods})
-            log_collector.set_pods(log_pods)
         resource_collector = self._ensure_resource_collector()
         if resource_collector is not None:
             resource_collector.set_pods(resource_pods)

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -1187,6 +1187,7 @@ def make_provider(cluster_config: config_pb2.IrisClusterConfig) -> TaskBackend:
             kubectl=CloudK8sService(namespace=namespace, kubeconfig_path=kp.kubeconfig or None),
             namespace=namespace,
             default_image=kp.default_image,
+            logship_image=cluster_config.controller.image,
             service_account=kp.service_account or "",
             host_network=kp.host_network,
             cache_dir=kp.cache_dir or "/cache",

--- a/lib/iris/tests/cluster/backends/k8s/conftest.py
+++ b/lib/iris/tests/cluster/backends/k8s/conftest.py
@@ -45,15 +45,13 @@ def task_stats_table() -> FakeStatsTable:
 
 
 @pytest.fixture
-def provider(k8s, log_client, task_stats_table):
+def provider(k8s, task_stats_table):
     p = K8sTaskProvider(
         kubectl=k8s,
         namespace="iris",
         default_image="myrepo/iris:latest",
         cache_dir="/cache",
-        log_client=log_client,
         task_stats_table=task_stats_table,
-        log_poll_interval=1.0,
         resource_poll_interval=0.05,
         cluster_scan_interval=0.0,
     )

--- a/lib/iris/tests/cluster/backends/k8s/test_logship.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_logship.py
@@ -150,12 +150,13 @@ def test_tail_ships_full_lines(tmp_path):
     )
 
     writer = FakeLogWriter()
-    shipper = LogShipper(writer, str(tmp_path / "*" / "task"), key="/u/job/0:1", attempt_id=1)
+    stop = threading.Event()
+    shipper = LogShipper(writer, str(tmp_path / "*" / "task"), key="/u/job/0:1", attempt_id=1, stop=stop)
     thread = _run_shipper_until_drained(shipper)
     try:
         _wait_until(lambda: len(writer.entries()) >= 2)
     finally:
-        shipper.request_stop()
+        stop.set()
         thread.join(timeout=5)
 
     entries = writer.entries()
@@ -175,7 +176,8 @@ def test_tail_continues_across_rotation_without_duplicates(tmp_path):
     _write_cri_lines(active, ["2026-06-24T12:00:00.000000000Z stdout F line-before-rotation"])
 
     writer = FakeLogWriter()
-    shipper = LogShipper(writer, str(tmp_path / "*" / "task"), key="/u/job/0", attempt_id=0)
+    stop = threading.Event()
+    shipper = LogShipper(writer, str(tmp_path / "*" / "task"), key="/u/job/0", attempt_id=0, stop=stop)
     thread = _run_shipper_until_drained(shipper)
     try:
         _wait_until(lambda: any(e.data == "line-before-rotation" for e in writer.entries()))
@@ -186,7 +188,7 @@ def test_tail_continues_across_rotation_without_duplicates(tmp_path):
 
         _wait_until(lambda: any(e.data == "line-after-rotation" for e in writer.entries()))
     finally:
-        shipper.request_stop()
+        stop.set()
         thread.join(timeout=5)
 
     messages = [e.data for e in writer.entries()]

--- a/lib/iris/tests/cluster/backends/k8s/test_logship.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_logship.py
@@ -44,29 +44,31 @@ class FakeLogWriter:
 def test_parse_full_line():
     parsed = parse_cri_line("2026-06-24T12:00:00.123456789Z stdout F hello world")
     assert parsed is not None
-    epoch_ms, stream, is_full, message = parsed
-    assert stream == "stdout"
-    assert is_full is True
-    assert message == "hello world"
+    assert parsed.stream == "stdout"
+    assert parsed.is_full is True
+    assert parsed.message == "hello world"
     # Nanosecond precision is truncated to ms.
-    assert epoch_ms % 1000 == 123
+    assert parsed.epoch_ms % 1000 == 123
 
 
 def test_parse_stderr_stream():
-    _epoch, stream, _is_full, message = parse_cri_line("2026-06-24T12:00:00Z stderr F boom")
-    assert stream == "stderr"
-    assert message == "boom"
+    parsed = parse_cri_line("2026-06-24T12:00:00Z stderr F boom")
+    assert parsed is not None
+    assert parsed.stream == "stderr"
+    assert parsed.message == "boom"
 
 
 def test_parse_partial_line_flagged_not_full():
-    _epoch, _stream, is_full, message = parse_cri_line("2026-06-24T12:00:00Z stdout P frag")
-    assert is_full is False
-    assert message == "frag"
+    parsed = parse_cri_line("2026-06-24T12:00:00Z stdout P frag")
+    assert parsed is not None
+    assert parsed.is_full is False
+    assert parsed.message == "frag"
 
 
 def test_parse_message_with_spaces_preserved():
-    _epoch, _stream, _is_full, message = parse_cri_line("2026-06-24T12:00:00Z stdout F a b  c")
-    assert message == "a b  c"
+    parsed = parse_cri_line("2026-06-24T12:00:00Z stdout F a b  c")
+    assert parsed is not None
+    assert parsed.message == "a b  c"
 
 
 def test_parse_rejects_malformed_lines():
@@ -77,7 +79,7 @@ def test_parse_rejects_malformed_lines():
 
 
 def test_full_line_carries_parsed_log_level():
-    """A glog-style line yields a LogEntry with the parsed level, like the worker."""
+    """A glog-style line yields a LogEntry with the parsed level."""
     buffer = _LineBuffer()
     line = buffer.feed("2026-06-24T12:00:00Z stderr F E0624 12:00:00 boom")
     assert line is not None

--- a/lib/iris/tests/cluster/backends/k8s/test_logship.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_logship.py
@@ -1,0 +1,201 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the log-shipper sidecar: CRI parsing, tailing, rotation, key derivation."""
+
+from __future__ import annotations
+
+import threading
+import time
+
+from finelog.rpc import logging_pb2
+from finelog.types import str_to_log_level
+from iris.cluster.backends.k8s.logship import (
+    LogShipper,
+    _LineBuffer,
+    _log_dir_glob,
+    _make_log_entry,
+    parse_cri_line,
+    split_key_attempt,
+)
+
+
+class FakeLogWriter:
+    """Records every write_batch call so tests can assert the shipped entries."""
+
+    def __init__(self) -> None:
+        self.batches: list[tuple[str, list[logging_pb2.LogEntry]]] = []
+
+    def write_batch(self, key: str, messages: list[logging_pb2.LogEntry]) -> None:
+        self.batches.append((key, list(messages)))
+
+    def flush(self, timeout: float | None = None) -> None:
+        pass
+
+    def entries(self) -> list[logging_pb2.LogEntry]:
+        return [entry for _key, batch in self.batches for entry in batch]
+
+
+# ---------------------------------------------------------------------------
+# CRI line parsing
+# ---------------------------------------------------------------------------
+
+
+def test_parse_full_line():
+    parsed = parse_cri_line("2026-06-24T12:00:00.123456789Z stdout F hello world")
+    assert parsed is not None
+    epoch_ms, stream, is_full, message = parsed
+    assert stream == "stdout"
+    assert is_full is True
+    assert message == "hello world"
+    # Nanosecond precision is truncated to ms.
+    assert epoch_ms % 1000 == 123
+
+
+def test_parse_stderr_stream():
+    _epoch, stream, _is_full, message = parse_cri_line("2026-06-24T12:00:00Z stderr F boom")
+    assert stream == "stderr"
+    assert message == "boom"
+
+
+def test_parse_partial_line_flagged_not_full():
+    _epoch, _stream, is_full, message = parse_cri_line("2026-06-24T12:00:00Z stdout P frag")
+    assert is_full is False
+    assert message == "frag"
+
+
+def test_parse_message_with_spaces_preserved():
+    _epoch, _stream, _is_full, message = parse_cri_line("2026-06-24T12:00:00Z stdout F a b  c")
+    assert message == "a b  c"
+
+
+def test_parse_rejects_malformed_lines():
+    assert parse_cri_line("garbage") is None
+    assert parse_cri_line("2026-06-24T12:00:00Z notastream F x") is None
+    assert parse_cri_line("2026-06-24T12:00:00Z stdout X x") is None
+    assert parse_cri_line("not-a-timestamp stdout F x") is None
+
+
+def test_full_line_carries_parsed_log_level():
+    """A glog-style line yields a LogEntry with the parsed level, like the worker."""
+    buffer = _LineBuffer()
+    line = buffer.feed("2026-06-24T12:00:00Z stderr F E0624 12:00:00 boom")
+    assert line is not None
+    entry = _make_log_entry(line, attempt_id=0)
+    assert entry.level == str_to_log_level("ERROR")
+
+
+def test_partial_lines_join_onto_following_full_line():
+    buffer = _LineBuffer()
+    assert buffer.feed("2026-06-24T12:00:00Z stdout P part1-") is None
+    assert buffer.feed("2026-06-24T12:00:00Z stdout P part2-") is None
+    line = buffer.feed("2026-06-24T12:00:00Z stdout F part3")
+    assert line is not None
+    assert line.message == "part1-part2-part3"
+    assert line.stream == "stdout"
+
+
+# ---------------------------------------------------------------------------
+# IRIS_TASK_ID -> (key, attempt)
+# ---------------------------------------------------------------------------
+
+
+def test_split_key_attempt_with_retry_suffix():
+    key, attempt = split_key_attempt("/u/job/0:2")
+    assert key == "/u/job/0:2"
+    assert attempt == 2
+
+
+def test_split_key_attempt_first_attempt_has_no_suffix():
+    key, attempt = split_key_attempt("/u/job/0")
+    assert key == "/u/job/0"
+    assert attempt == 0
+
+
+def test_log_dir_glob_targets_task_container():
+    assert _log_dir_glob("iris", "iris-job-0-abc-0") == "/var/log/pods/iris_iris-job-0-abc-0_*/task"
+
+
+# ---------------------------------------------------------------------------
+# Tailing a CRI log file end-to-end
+# ---------------------------------------------------------------------------
+
+
+def _write_cri_lines(path, lines: list[str]) -> None:
+    with open(path, "a", encoding="utf-8") as handle:
+        for line in lines:
+            handle.write(line + "\n")
+
+
+def _run_shipper_until_drained(shipper: LogShipper) -> threading.Thread:
+    thread = threading.Thread(target=shipper.run)
+    thread.start()
+    return thread
+
+
+def test_tail_ships_full_lines(tmp_path):
+    """Lines written to the active 0.log are shipped as LogEntries with the right
+    key, stream, level, and message."""
+    log_dir = tmp_path / "iris_pod_uid" / "task"
+    log_dir.mkdir(parents=True)
+    active = log_dir / "0.log"
+    _write_cri_lines(
+        active,
+        [
+            "2026-06-24T12:00:00.000000000Z stdout F starting up",
+            "2026-06-24T12:00:01.000000000Z stderr F it broke",
+        ],
+    )
+
+    writer = FakeLogWriter()
+    shipper = LogShipper(writer, str(tmp_path / "*" / "task"), key="/u/job/0:1", attempt_id=1)
+    thread = _run_shipper_until_drained(shipper)
+    try:
+        _wait_until(lambda: len(writer.entries()) >= 2)
+    finally:
+        shipper.request_stop()
+        thread.join(timeout=5)
+
+    entries = writer.entries()
+    by_data = {e.data: e for e in entries}
+    assert by_data["starting up"].source == "stdout"
+    assert by_data["starting up"].attempt_id == 1
+    assert by_data["it broke"].source == "stderr"
+    assert all(key == "/u/job/0:1" for key, _batch in writer.batches)
+
+
+def test_tail_continues_across_rotation_without_duplicates(tmp_path):
+    """When kubelet rotates 0.log (replaces the inode), the shipper reopens the
+    new file and continues; already-shipped lines are not re-sent."""
+    log_dir = tmp_path / "iris_pod_uid" / "task"
+    log_dir.mkdir(parents=True)
+    active = log_dir / "0.log"
+    _write_cri_lines(active, ["2026-06-24T12:00:00.000000000Z stdout F line-before-rotation"])
+
+    writer = FakeLogWriter()
+    shipper = LogShipper(writer, str(tmp_path / "*" / "task"), key="/u/job/0", attempt_id=0)
+    thread = _run_shipper_until_drained(shipper)
+    try:
+        _wait_until(lambda: any(e.data == "line-before-rotation" for e in writer.entries()))
+
+        # Rotate: move the old file aside and create a fresh 0.log (new inode).
+        active.rename(log_dir / "0.log.20260624")
+        _write_cri_lines(active, ["2026-06-24T12:00:02.000000000Z stdout F line-after-rotation"])
+
+        _wait_until(lambda: any(e.data == "line-after-rotation" for e in writer.entries()))
+    finally:
+        shipper.request_stop()
+        thread.join(timeout=5)
+
+    messages = [e.data for e in writer.entries()]
+    assert messages.count("line-before-rotation") == 1
+    assert messages.count("line-after-rotation") == 1
+
+
+def _wait_until(predicate, timeout: float = 5.0, interval: float = 0.05) -> None:
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        if predicate():
+            return
+        time.sleep(interval)
+    raise AssertionError("condition not met within timeout")

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -155,66 +155,6 @@ def test_build_pod_manifest_no_env_secret_omits_envfrom():
     assert "envFrom" not in manifest["spec"]["containers"][0]
 
 
-# ---------------------------------------------------------------------------
-# Log-shipper native sidecar
-# ---------------------------------------------------------------------------
-
-
-def _logship_container(manifest: dict) -> dict:
-    return next(c for c in manifest["spec"]["initContainers"] if c["name"] == "log-shipper")
-
-
-def test_logship_sidecar_is_native_init_container():
-    """The log-shipper runs as a native sidecar: an initContainer with
-    restartPolicy Always, the iris runtime image, and the logship entrypoint."""
-    manifest = _build_pod_manifest(make_run_req("/test-job/0"), pod_config(controller_address="http://ctrl:8080"))
-
-    # Native sidecar lives in initContainers, NOT containers, so the pod still
-    # reaches Succeeded/Failed when only the task container exits.
-    assert all(c["name"] != "log-shipper" for c in manifest["spec"]["containers"])
-    sidecar = _logship_container(manifest)
-    assert sidecar["restartPolicy"] == "Always"
-    assert sidecar["image"] == "myrepo/iris:latest"
-    assert sidecar["command"] == ["python", "-m", "iris.cluster.backends.k8s.logship"]
-
-
-def test_logship_sidecar_downward_api_and_task_id():
-    """The sidecar receives the same IRIS_TASK_ID as the task plus namespace/name
-    via the downward API and the controller address."""
-    req = make_run_req("/test-job/0", attempt_id=2)
-    manifest = _build_pod_manifest(req, pod_config(controller_address="http://ctrl:8080"))
-    sidecar = _logship_container(manifest)
-    env = {e["name"]: e for e in sidecar["env"]}
-
-    task_env = {e["name"]: e for e in manifest["spec"]["containers"][0]["env"]}
-    assert env["IRIS_TASK_ID"]["value"] == task_env["IRIS_TASK_ID"]["value"] == "/test-job/0:2"
-    assert env["IRIS_CONTROLLER_ADDRESS"]["value"] == "http://ctrl:8080"
-    assert env["IRIS_POD_NAMESPACE"]["valueFrom"]["fieldRef"]["fieldPath"] == "metadata.namespace"
-    assert env["IRIS_POD_NAME"]["valueFrom"]["fieldRef"]["fieldPath"] == "metadata.name"
-
-
-def test_logship_sidecar_mounts_node_pod_logs_readonly():
-    """The sidecar reads node CRI logs via a read-only varlogpods hostPath."""
-    manifest = _build_pod_manifest(make_run_req("/test-job/0"), pod_config())
-    sidecar = _logship_container(manifest)
-
-    mount = next(m for m in sidecar["volumeMounts"] if m["name"] == "varlogpods")
-    assert mount["mountPath"] == "/var/log/pods"
-    assert mount["readOnly"] is True
-
-    volume = next(v for v in manifest["spec"]["volumes"] if v["name"] == "varlogpods")
-    assert volume["hostPath"] == {"path": "/var/log/pods", "type": "Directory"}
-
-
-def test_task_container_unchanged_by_sidecar():
-    """The task container keeps its bash entrypoint and is not wrapped in a tee
-    pipe — log shipping reads the node file, leaving the task untouched."""
-    manifest = _build_pod_manifest(make_run_req("/test-job/0"), pod_config())
-    task = next(c for c in manifest["spec"]["containers"] if c["name"] == "task")
-    assert task["command"][:2] == ["bash", "-lc"]
-    assert "tee" not in task["command"][2]
-
-
 def test_build_pod_manifest_gpu():
     req = make_run_req("/test-job/0")
     req.resources.device.gpu.CopyFrom(job_pb2.GpuDevice(variant="A100", count=4))

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -155,6 +155,66 @@ def test_build_pod_manifest_no_env_secret_omits_envfrom():
     assert "envFrom" not in manifest["spec"]["containers"][0]
 
 
+# ---------------------------------------------------------------------------
+# Log-shipper native sidecar
+# ---------------------------------------------------------------------------
+
+
+def _logship_container(manifest: dict) -> dict:
+    return next(c for c in manifest["spec"]["initContainers"] if c["name"] == "log-shipper")
+
+
+def test_logship_sidecar_is_native_init_container():
+    """The log-shipper runs as a native sidecar: an initContainer with
+    restartPolicy Always, the iris runtime image, and the logship entrypoint."""
+    manifest = _build_pod_manifest(make_run_req("/test-job/0"), pod_config(controller_address="http://ctrl:8080"))
+
+    # Native sidecar lives in initContainers, NOT containers, so the pod still
+    # reaches Succeeded/Failed when only the task container exits.
+    assert all(c["name"] != "log-shipper" for c in manifest["spec"]["containers"])
+    sidecar = _logship_container(manifest)
+    assert sidecar["restartPolicy"] == "Always"
+    assert sidecar["image"] == "myrepo/iris:latest"
+    assert sidecar["command"] == ["python", "-m", "iris.cluster.backends.k8s.logship"]
+
+
+def test_logship_sidecar_downward_api_and_task_id():
+    """The sidecar receives the same IRIS_TASK_ID as the task plus namespace/name
+    via the downward API and the controller address."""
+    req = make_run_req("/test-job/0", attempt_id=2)
+    manifest = _build_pod_manifest(req, pod_config(controller_address="http://ctrl:8080"))
+    sidecar = _logship_container(manifest)
+    env = {e["name"]: e for e in sidecar["env"]}
+
+    task_env = {e["name"]: e for e in manifest["spec"]["containers"][0]["env"]}
+    assert env["IRIS_TASK_ID"]["value"] == task_env["IRIS_TASK_ID"]["value"] == "/test-job/0:2"
+    assert env["IRIS_CONTROLLER_ADDRESS"]["value"] == "http://ctrl:8080"
+    assert env["IRIS_POD_NAMESPACE"]["valueFrom"]["fieldRef"]["fieldPath"] == "metadata.namespace"
+    assert env["IRIS_POD_NAME"]["valueFrom"]["fieldRef"]["fieldPath"] == "metadata.name"
+
+
+def test_logship_sidecar_mounts_node_pod_logs_readonly():
+    """The sidecar reads node CRI logs via a read-only varlogpods hostPath."""
+    manifest = _build_pod_manifest(make_run_req("/test-job/0"), pod_config())
+    sidecar = _logship_container(manifest)
+
+    mount = next(m for m in sidecar["volumeMounts"] if m["name"] == "varlogpods")
+    assert mount["mountPath"] == "/var/log/pods"
+    assert mount["readOnly"] is True
+
+    volume = next(v for v in manifest["spec"]["volumes"] if v["name"] == "varlogpods")
+    assert volume["hostPath"] == {"path": "/var/log/pods", "type": "Directory"}
+
+
+def test_task_container_unchanged_by_sidecar():
+    """The task container keeps its bash entrypoint and is not wrapped in a tee
+    pipe — log shipping reads the node file, leaving the task untouched."""
+    manifest = _build_pod_manifest(make_run_req("/test-job/0"), pod_config())
+    task = next(c for c in manifest["spec"]["containers"] if c["name"] == "task")
+    assert task["command"][:2] == ["bash", "-lc"]
+    assert "tee" not in task["command"][2]
+
+
 def test_build_pod_manifest_gpu():
     req = make_run_req("/test-job/0")
     req.resources.device.gpu.CopyFrom(job_pb2.GpuDevice(variant="A100", count=4))
@@ -465,18 +525,20 @@ def test_zero_timeout_no_deadline():
 
 
 def test_build_pod_manifest_includes_standard_volumes():
-    """Pod manifest includes all 5 standard volumes plus dshm (6 total)."""
+    """Pod manifest includes the 5 standard volumes, dshm, and the log-shipper
+    varlogpods hostPath; the task container mounts the 6 task volumes (not
+    varlogpods, which is the sidecar's)."""
     req = make_run_req("/test-job/0", attempt_id=1)
     manifest = _build_pod_manifest(req, pod_config())
 
     spec = manifest["spec"]
     container = spec["containers"][0]
 
+    task_volume_names = {"workdir", "tmpfs", "uv-cache", "cargo-registry", "cargo-target", "dshm"}
     volume_names = {v["name"] for v in spec["volumes"]}
     mount_names = {m["name"] for m in container["volumeMounts"]}
-    expected_names = {"workdir", "tmpfs", "uv-cache", "cargo-registry", "cargo-target", "dshm"}
-    assert volume_names == expected_names
-    assert mount_names == expected_names
+    assert volume_names == task_volume_names | {"varlogpods"}
+    assert mount_names == task_volume_names
 
     mount_paths = {m["mountPath"] for m in container["volumeMounts"]}
     assert "/app" in mount_paths

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -1,16 +1,13 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Tests for K8sTaskProvider: sync lifecycle, logs, capacity, scheduling, profiling."""
+"""Tests for K8sTaskProvider: sync lifecycle, capacity, scheduling, profiling."""
 
 from __future__ import annotations
 
-import time
 from datetime import UTC, datetime, timedelta
 
 import pytest
-from finelog.rpc import logging_pb2
-from finelog.rpc.logging_connect import LogServiceClientSync
 from iris.cluster.backends.k8s.tasks import (
     _GANG_GC_MAX_AGE_SECONDS,
     _GC_MAX_AGE_SECONDS,
@@ -27,9 +24,7 @@ from iris.cluster.backends.k8s.tasks import (
     _POD_NOT_FOUND_GRACE_CYCLES,
     _RUNTIME_LABEL_VALUE,
     K8sTaskProvider,
-    LogCollector,
     ResourceCollector,
-    _LogPod,
     _pod_name,
     _sanitize_label_value,
     _task_hash,
@@ -37,20 +32,13 @@ from iris.cluster.backends.k8s.tasks import (
 from iris.cluster.backends.k8s.types import ExecResult, K8sResource, KubectlError, PodResourceUsage
 from iris.cluster.controller.backend import TaskTarget
 from iris.cluster.controller.task_state import RunningTaskEntry
-from iris.cluster.log_keys import task_log_key
-from iris.cluster.types import JobName, TaskAttempt
+from iris.cluster.types import JobName
 from iris.cluster.worker.stats import IrisTaskStat
 from iris.rpc import job_pb2
 from iris.test_util import wait_for_condition
 from rigging.timing import Duration
 
 from .conftest import make_batch, make_kueue_provider, make_run_req, populate_node, populate_pod
-
-
-def _fetch_logs(log_service: LogServiceClientSync, key: str, max_lines: int = 100) -> list[logging_pb2.LogEntry]:
-    resp = log_service.fetch_logs(logging_pb2.FetchLogsRequest(source=key, max_lines=max_lines))
-    return list(resp.entries)
-
 
 # ---------------------------------------------------------------------------
 # sync(): tasks_to_run
@@ -285,27 +273,6 @@ def test_pod_not_found_grace_resets_when_pod_reappears(provider, k8s):
     assert result.updates[0].new_state == job_pb2.TASK_STATE_FAILED
 
 
-def test_sync_succeeded_pod_fetches_logs(provider, k8s, log_service: LogServiceClientSync, log_client):
-    task_id = JobName.from_wire("/job/0")
-    attempt_id = 0
-    pod_name = _pod_name(task_id, attempt_id)
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
-
-    populate_pod(k8s, pod_name, "Succeeded")
-    k8s.set_logs(pod_name, "task complete\n")
-
-    batch = make_batch(running_tasks=[entry])
-    result = provider.reconcile(batch)
-
-    assert result.updates[0].new_state == job_pb2.TASK_STATE_SUCCEEDED
-    # set_pods() removal does a synchronous final fetch that enqueues the entries
-    # on the (buffered) log client; flush forces them to the server before we read.
-    log_client.flush(timeout=5.0)
-    key = task_log_key(TaskAttempt(task_id=task_id, attempt_id=attempt_id))
-    logs = _fetch_logs(log_service, key)
-    assert any(e.data == "task complete" for e in logs)
-
-
 def test_completed_pod_resolved_via_bulk_list_without_per_pod_get(provider, k8s, monkeypatch):
     """A running task whose pod went terminal is read from the bulk terminal-pods
     list, never a per-pod GET — so a whole gang completing in one cycle costs one
@@ -335,84 +302,6 @@ def test_sync_empty_batch(provider):
     batch = make_batch()
     result = provider.reconcile(batch)
     assert result.updates == []
-
-
-# ---------------------------------------------------------------------------
-# Incremental log polling
-# ---------------------------------------------------------------------------
-
-
-def test_poll_fetches_incremental_logs_for_running_pods(provider, k8s, log_service: LogServiceClientSync):
-    """Running pods get incremental logs via the background LogCollector."""
-    task_id = JobName.from_wire("/job/0")
-    attempt_id = 0
-    pod_name = _pod_name(task_id, attempt_id)
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
-
-    populate_pod(k8s, pod_name, "Running")
-    k8s.set_logs(pod_name, "hello from running pod\n")
-
-    batch = make_batch(running_tasks=[entry])
-    result = provider.reconcile(batch)
-
-    assert len(result.updates) == 1
-    assert result.updates[0].new_state == job_pb2.TASK_STATE_RUNNING
-    # Logs are collected by the background LogCollector thread.
-    # Give it time to run one cycle.
-    time.sleep(3)
-    key = task_log_key(TaskAttempt(task_id=task_id, attempt_id=attempt_id))
-    logs = _fetch_logs(log_service, key)
-    assert len(logs) >= 1
-    assert logs[0].data == "hello from running pod"
-
-
-def test_log_cursors_advance_across_sync_cycles(provider, k8s, log_service: LogServiceClientSync):
-    """LogCollector advances byte offsets: repeated fetches don't duplicate."""
-    task_id = JobName.from_wire("/job/0")
-    attempt_id = 0
-    pod_name = _pod_name(task_id, attempt_id)
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
-
-    populate_pod(k8s, pod_name, "Running")
-    k8s.set_logs(pod_name, "line 1\n")
-
-    # First sync: LogCollector starts tracking the pod.
-    provider.reconcile(make_batch(running_tasks=[entry]))
-    time.sleep(3)
-    key = task_log_key(TaskAttempt(task_id=task_id, attempt_id=attempt_id))
-    logs = _fetch_logs(log_service, key)
-    assert len(logs) == 1
-    assert logs[0].data == "line 1"
-
-    # Append new content and let collector run again.
-    k8s.set_logs(pod_name, "line 1\nline 2\n")
-    provider.reconcile(make_batch(running_tasks=[entry]))
-    time.sleep(3)
-    logs = _fetch_logs(log_service, key)
-    assert len(logs) == 2
-    assert logs[1].data == "line 2"
-
-
-def test_final_log_fetch_on_pod_completion(provider, k8s, log_service: LogServiceClientSync, log_client):
-    """Completed pods get a final log fetch when removed from the collector's tracked set."""
-    task_id = JobName.from_wire("/job/0")
-    attempt_id = 0
-    pod_name = _pod_name(task_id, attempt_id)
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=attempt_id)
-
-    populate_pod(k8s, pod_name, "Succeeded")
-    k8s.set_logs(pod_name, "line 1\nline 2\nline 3\n")
-
-    result = provider.reconcile(make_batch(running_tasks=[entry]))
-
-    assert result.updates[0].new_state == job_pb2.TASK_STATE_SUCCEEDED
-    # set_pods() removal does a synchronous final fetch that enqueues the entries
-    # on the (buffered) log client; flush forces them to the server before we read.
-    log_client.flush(timeout=5.0)
-    key = task_log_key(TaskAttempt(task_id=task_id, attempt_id=attempt_id))
-    logs = _fetch_logs(log_service, key)
-    assert len(logs) == 3
-    assert logs[0].data == "line 1"
 
 
 # ---------------------------------------------------------------------------
@@ -810,6 +699,19 @@ def test_no_configmap_when_no_workdir_files(provider, k8s):
     assert pods[0]["kind"] == "Pod"
 
 
+def test_apply_pod_orders_staging_before_logship_sidecar(provider, k8s):
+    """The workdir-staging init container runs before the log-shipper native
+    sidecar so staging completes first; the sidecar stays in initContainers."""
+    req = make_run_req("/my-job/task-0")
+    req.entrypoint.workdir_files["script.py"] = b"print('hi')"
+
+    provider._apply_pod(req)
+
+    pod = k8s.list_json(K8sResource.PODS)[0]
+    names = [c["name"] for c in pod["spec"]["initContainers"]]
+    assert names == ["stage-workdir", "log-shipper"]
+
+
 # ---------------------------------------------------------------------------
 # PodDisruptionBudget for coordinator tasks
 # ---------------------------------------------------------------------------
@@ -1064,73 +966,6 @@ def test_gc_skips_hashes_with_active_pods(provider, k8s):
 # ---------------------------------------------------------------------------
 # Collector set_pods
 # ---------------------------------------------------------------------------
-
-
-def test_log_collector_set_pods_adds_and_removes(k8s, log_client):
-    """LogCollector.set_pods() adds new pods and removes absent ones."""
-
-    collector = LogCollector(k8s, log_client, concurrency=1)
-    task_a = JobName.from_wire("/job/0")
-    task_b = JobName.from_wire("/job/1")
-    key_a = f"{task_a.to_wire()}:0"
-    key_b = f"{task_b.to_wire()}:0"
-
-    collector.set_pods(
-        {
-            key_a: _LogPod(pod_name="pod-a", task_id=task_a, attempt_id=0),
-            key_b: _LogPod(pod_name="pod-b", task_id=task_b, attempt_id=0),
-        }
-    )
-    with collector._lock:
-        assert key_a in collector._pods
-        assert key_b in collector._pods
-
-    # Remove pod A, keep pod B.
-    collector.set_pods(
-        {
-            key_b: _LogPod(pod_name="pod-b", task_id=task_b, attempt_id=0),
-        }
-    )
-    with collector._lock:
-        assert key_a not in collector._pods
-        assert key_b in collector._pods
-
-    # Clear all.
-    collector.set_pods({})
-    with collector._lock:
-        assert len(collector._pods) == 0
-
-    collector.close()
-
-
-def test_log_collector_set_pods_preserves_cursor_state(k8s, log_client):
-    """set_pods() preserves last_timestamp for pods that remain tracked."""
-
-    collector = LogCollector(k8s, log_client, concurrency=1)
-    task_id = JobName.from_wire("/job/0")
-    key = f"{task_id.to_wire()}:0"
-
-    collector.set_pods(
-        {
-            key: _LogPod(pod_name="pod-0", task_id=task_id, attempt_id=0),
-        }
-    )
-
-    # Simulate the collector having advanced the cursor.
-    marker = datetime(2026, 1, 1, tzinfo=UTC)
-    with collector._lock:
-        collector._pods[key].last_timestamp = marker
-
-    # Re-declare the same pod — cursor should be preserved.
-    collector.set_pods(
-        {
-            key: _LogPod(pod_name="pod-0", task_id=task_id, attempt_id=0),
-        }
-    )
-    with collector._lock:
-        assert collector._pods[key].last_timestamp == marker
-
-    collector.close()
 
 
 def test_resource_collector_set_pods_replaces_active_set(k8s, task_stats_table):

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -1122,8 +1122,7 @@ def test_gc_sweeps_finalizer_wedged_gang_pod(provider, k8s):
     )
     k8s.seed_resource(K8sResource.WORKLOADS, group, {"kind": "Workload", "metadata": {"name": group}})
 
-    provider._last_gc_time = 0.0
-    provider._maybe_gc_terminal_resources(active_pods=[])
+    provider._gc_terminal_resources(active_pods=[])
 
     assert k8s.get_json(K8sResource.PODS, "wedged-gang-pod") is None
     assert k8s.get_json(K8sResource.WORKLOADS, group) is None

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -306,6 +306,31 @@ def test_sync_succeeded_pod_fetches_logs(provider, k8s, log_service: LogServiceC
     assert any(e.data == "task complete" for e in logs)
 
 
+def test_completed_pod_resolved_via_bulk_list_without_per_pod_get(provider, k8s, monkeypatch):
+    """A running task whose pod went terminal is read from the bulk terminal-pods
+    list, never a per-pod GET — so a whole gang completing in one cycle costs one
+    extra LIST, not one GET per pod."""
+    task_id = JobName.from_wire("/job/done")
+    pod_name = _pod_name(task_id, 0)
+    populate_pod(k8s, pod_name, "Succeeded")
+    entry = RunningTaskEntry(task_id=task_id, attempt_id=0)
+
+    pod_gets: list[str] = []
+    real_get_json = k8s.get_json
+
+    def spy_get_json(resource, name):
+        if resource == K8sResource.PODS:
+            pod_gets.append(name)
+        return real_get_json(resource, name)
+
+    monkeypatch.setattr(k8s, "get_json", spy_get_json)
+
+    result = provider.reconcile(make_batch(running_tasks=[entry]))
+
+    assert result.updates[0].new_state == job_pb2.TASK_STATE_SUCCEEDED
+    assert pod_gets == []
+
+
 def test_sync_empty_batch(provider):
     batch = make_batch()
     result = provider.reconcile(batch)

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -273,31 +273,6 @@ def test_pod_not_found_grace_resets_when_pod_reappears(provider, k8s):
     assert result.updates[0].new_state == job_pb2.TASK_STATE_FAILED
 
 
-def test_completed_pod_resolved_via_bulk_list_without_per_pod_get(provider, k8s, monkeypatch):
-    """A running task whose pod went terminal is read from the bulk terminal-pods
-    list, never a per-pod GET — so a whole gang completing in one cycle costs one
-    extra LIST, not one GET per pod."""
-    task_id = JobName.from_wire("/job/done")
-    pod_name = _pod_name(task_id, 0)
-    populate_pod(k8s, pod_name, "Succeeded")
-    entry = RunningTaskEntry(task_id=task_id, attempt_id=0)
-
-    pod_gets: list[str] = []
-    real_get_json = k8s.get_json
-
-    def spy_get_json(resource, name):
-        if resource == K8sResource.PODS:
-            pod_gets.append(name)
-        return real_get_json(resource, name)
-
-    monkeypatch.setattr(k8s, "get_json", spy_get_json)
-
-    result = provider.reconcile(make_batch(running_tasks=[entry]))
-
-    assert result.updates[0].new_state == job_pb2.TASK_STATE_SUCCEEDED
-    assert pod_gets == []
-
-
 def test_sync_empty_batch(provider):
     batch = make_batch()
     result = provider.reconcile(batch)
@@ -697,19 +672,6 @@ def test_no_configmap_when_no_workdir_files(provider, k8s):
     assert len(configmaps) == 0
     assert len(pods) == 1
     assert pods[0]["kind"] == "Pod"
-
-
-def test_apply_pod_orders_staging_before_logship_sidecar(provider, k8s):
-    """The workdir-staging init container runs before the log-shipper native
-    sidecar so staging completes first; the sidecar stays in initContainers."""
-    req = make_run_req("/my-job/task-0")
-    req.entrypoint.workdir_files["script.py"] = b"print('hi')"
-
-    provider._apply_pod(req)
-
-    pod = k8s.list_json(K8sResource.PODS)[0]
-    names = [c["name"] for c in pod["spec"]["initContainers"]]
-    assert names == ["stage-workdir", "log-shipper"]
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Replace per-pod fetches with a single bulk fetch for pod status, and move log acquisition out of the controller.

This should reduce controller load on k8s.