### PR TITLE
[optim] Curvature-corrected Muon (Nesterov + one-sided Shampoo curvature, hyperball)

### DIFF
--- a/experiments/speedrun/__init__.py
+++ b/experiments/speedrun/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/speedrun/curvature_muon_qwen3/__init__.py
+++ b/experiments/speedrun/curvature_muon_qwen3/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/experiments/speedrun/curvature_muon_qwen3/sweep.py
+++ b/experiments/speedrun/curvature_muon_qwen3/sweep.py
@@ -63,6 +63,8 @@ LAMBDAS: tuple[float, ...] = _floats("LAMBDAS", "0.0,0.1,1.0")
 KS: tuple[int, ...] = _ints("KS", "1,2")
 ALPHAS: tuple[float, ...] = _floats("ALPHAS", "1.0,1.2")  # multiplier on the sqrt(e_max) shift
 CURV_POWER: str = os.environ.get("CURV_POWER", "sqrt")  # "sqrt" (P^{1/2}, default) or "linear" (P/sqrt(e_max))
+# two-sided curvature P_L^{1/4} X P_R^{1/4} + Shampoo warm-start msign(P_L^{-1/4} N P_R^{-1/4}).
+TWO_SIDED: bool = os.environ.get("TWO_SIDED", "false").lower() in ("1", "true", "yes")
 # warm-start X0 = msign(P^{-1/2} N) (Mudam direction, coupled-NS q_k) instead of msign(N); default on.
 MUDAM_INIT: bool = os.environ.get("MUDAM_INIT", "true").lower() in ("1", "true", "yes")
 POWER_ITERS: int = int(os.environ.get("POWER_ITERS", "8"))  # power-iteration steps for e_max(P)
@@ -146,6 +148,7 @@ def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
         curvature_lambda=lam,
         curvature_alpha=alpha,
         curv_power=CURV_POWER,
+        two_sided=TWO_SIDED,
         mudam_init=MUDAM_INIT,
         inner_steps=k,
         power_iters=POWER_ITERS,
@@ -164,7 +167,7 @@ def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
         optimizer_config=optimizer,
     )
     cf = {"polar_express": "pe", "quintic": "qx", "simple": "sm", "aol": "aol"}.get(COEFF_TYPE, COEFF_TYPE)
-    cp = "sq" if CURV_POWER == "sqrt" else "lin"
+    cp = "2s" if TWO_SIDED else ("sq" if CURV_POWER == "sqrt" else "lin")
     mi = "_mi" if MUDAM_INIT else ""
     tag = f"_{cp}{mi}_{cf}{BACKEND_STEPS}{('_' + RUN_TAG) if RUN_TAG else ''}"
     if lam == 0.0:

--- a/experiments/speedrun/curvature_muon_qwen3/sweep.py
+++ b/experiments/speedrun/curvature_muon_qwen3/sweep.py
@@ -46,7 +46,7 @@ logger = logging.getLogger(__name__)
 REGION = os.environ.get("REGION", "us-east5")
 SEQ_LEN = 4096
 WANDB_ENTITY = "marin-community"
-WANDB_PROJECT = "speedrun"
+WANDB_PROJECT = os.environ.get("WANDB_PROJECT", "speedrun")
 
 
 def _floats(env: str, default: str) -> tuple[float, ...]:
@@ -63,6 +63,8 @@ LAMBDAS: tuple[float, ...] = _floats("LAMBDAS", "0.0,0.1,1.0")
 KS: tuple[int, ...] = _ints("KS", "1,2")
 ALPHAS: tuple[float, ...] = _floats("ALPHAS", "1.0,1.5")
 NORMALIZE: bool = os.environ.get("NORMALIZE", "true").lower() in ("1", "true", "yes")
+# lambda tracks the LR schedule: lambda_t = (swept lambda = peak) * lr_t / peak_lr.
+LAMBDA_TRACKS_LR: bool = os.environ.get("LAMBDA_TRACKS_LR", "false").lower() in ("1", "true", "yes")
 RUN_TAG: str = os.environ.get("RUN_TAG", "")
 
 
@@ -138,6 +140,7 @@ def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
         curvature_alpha=alpha,
         inner_steps=k,
         normalize_curvature=NORMALIZE,
+        lambda_tracks_lr=LAMBDA_TRACKS_LR,
         learning_rate=SIZE.learning_rate,
         lr_schedule="cosine",
         warmup=SIZE.warmup,
@@ -156,7 +159,8 @@ def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
         clabel = "_lam0"  # MuonH control (alpha/K/normalize irrelevant)
     else:
         nlabel = "n" if NORMALIZE else "r"
-        clabel = f"_lam{_label(lam)}_a{_label(alpha)}_K{k}_{nlabel}"
+        tlabel = "_tl" if LAMBDA_TRACKS_LR else ""
+        clabel = f"_lam{_label(lam)}_a{_label(alpha)}_K{k}_{nlabel}{tlabel}"
     run_id = f"qwen3_{SIZE.label}_curvmuon{clabel}{tag}_{SEQ_LEN}"
     step = default_train(
         name=run_id,

--- a/experiments/speedrun/curvature_muon_qwen3/sweep.py
+++ b/experiments/speedrun/curvature_muon_qwen3/sweep.py
@@ -65,6 +65,10 @@ ALPHAS: tuple[float, ...] = _floats("ALPHAS", "1.0,1.5")
 NORMALIZE: bool = os.environ.get("NORMALIZE", "true").lower() in ("1", "true", "yes")
 # lambda tracks the LR schedule: lambda_t = (swept lambda = peak) * lr_t / peak_lr.
 LAMBDA_TRACKS_LR: bool = os.environ.get("LAMBDA_TRACKS_LR", "false").lower() in ("1", "true", "yes")
+# msign Newton-Schulz coefficients. polar_express (8-step schedule) is more precise than quintic (5);
+# use BACKEND_STEPS=8 to run the full polar_express schedule (truncating to 5 drops the fine-polish steps).
+COEFF_TYPE: str = os.environ.get("COEFF_TYPE", "polar_express")
+BACKEND_STEPS: int = int(os.environ.get("BACKEND_STEPS", "8"))
 RUN_TAG: str = os.environ.get("RUN_TAG", "")
 
 
@@ -134,7 +138,8 @@ def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
         epsilon=1e-15,
         muon_epsilon=1e-5,
         max_grad_norm=1.0,
-        coefficient_type="quintic",
+        backend_steps=BACKEND_STEPS,
+        coefficient_type=COEFF_TYPE,
         curvature_beta=0.95,
         curvature_lambda=lam,
         curvature_alpha=alpha,
@@ -154,7 +159,8 @@ def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
         learning_rate=SIZE.learning_rate,
         optimizer_config=optimizer,
     )
-    tag = f"_{RUN_TAG}" if RUN_TAG else ""
+    cf = {"polar_express": "pe", "quintic": "qx", "simple": "sm", "aol": "aol"}.get(COEFF_TYPE, COEFF_TYPE)
+    tag = f"_{cf}{BACKEND_STEPS}{('_' + RUN_TAG) if RUN_TAG else ''}"
     if lam == 0.0:
         clabel = "_lam0"  # MuonH control (alpha/K/normalize irrelevant)
     else:

--- a/experiments/speedrun/curvature_muon_qwen3/sweep.py
+++ b/experiments/speedrun/curvature_muon_qwen3/sweep.py
@@ -57,12 +57,11 @@ def _ints(env: str, default: str) -> tuple[int, ...]:
     return tuple(int(x) for x in os.environ.get(env, default).split(","))
 
 
-# Curvature sweep axes. lambda=0 is the MuonH control (must reproduce 1.1661). alpha near 1 = aggressive
-# curvature suppression of high-curvature directions; larger alpha (the spec's 1.2-2) is milder.
+# Curvature sweep axes. Operator = lambda*(sqrt(e_max) I - P/sqrt(e_max)) (PSD, stable at any lambda;
+# lambda dimensionless). lambda=0 is the MuonH control (must reproduce 1.1661).
 LAMBDAS: tuple[float, ...] = _floats("LAMBDAS", "0.0,0.1,1.0")
 KS: tuple[int, ...] = _ints("KS", "1,2")
-ALPHAS: tuple[float, ...] = _floats("ALPHAS", "1.0,1.5")
-NORMALIZE: bool = os.environ.get("NORMALIZE", "true").lower() in ("1", "true", "yes")
+POWER_ITERS: int = int(os.environ.get("POWER_ITERS", "8"))  # power-iteration steps for e_max(P)
 # lambda tracks the LR schedule: lambda_t = (swept lambda = peak) * lr_t / peak_lr.
 LAMBDA_TRACKS_LR: bool = os.environ.get("LAMBDA_TRACKS_LR", "false").lower() in ("1", "true", "yes")
 # msign Newton-Schulz coefficients. polar_express (8-step schedule) is more precise than quintic (5);
@@ -127,7 +126,7 @@ def _override_tracker(step: ExecutorStep) -> ExecutorStep:
     return dataclasses.replace(step, config=dataclasses.replace(pod, train_config=inner))
 
 
-def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
+def _build_step(lam: float, k: int) -> ExecutorStep:
     optimizer = CurvatureMuonConfig(
         adam_lr=SIZE.adam_lr,
         momentum=0.95,
@@ -141,9 +140,8 @@ def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
         coefficient_type=COEFF_TYPE,
         curvature_beta=0.95,
         curvature_lambda=lam,
-        curvature_alpha=alpha,
         inner_steps=k,
-        normalize_curvature=NORMALIZE,
+        power_iters=POWER_ITERS,
         lambda_tracks_lr=LAMBDA_TRACKS_LR,
         learning_rate=SIZE.learning_rate,
         lr_schedule="cosine",
@@ -161,11 +159,10 @@ def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
     cf = {"polar_express": "pe", "quintic": "qx", "simple": "sm", "aol": "aol"}.get(COEFF_TYPE, COEFF_TYPE)
     tag = f"_{cf}{BACKEND_STEPS}{('_' + RUN_TAG) if RUN_TAG else ''}"
     if lam == 0.0:
-        clabel = "_lam0"  # MuonH control (alpha/K/normalize irrelevant)
+        clabel = "_lam0"  # MuonH control (K irrelevant)
     else:
-        nlabel = "n" if NORMALIZE else "r"
         tlabel = "_tl" if LAMBDA_TRACKS_LR else ""
-        clabel = f"_lam{_label(lam)}_a{_label(alpha)}_K{k}_{nlabel}{tlabel}"
+        clabel = f"_lam{_label(lam)}_K{k}{tlabel}"
     run_id = f"qwen3_{SIZE.label}_curvmuon{clabel}{tag}_{SEQ_LEN}"
     step = default_train(
         name=run_id,
@@ -185,28 +182,28 @@ def main() -> None:
     if os.getenv("CI") is not None:
         logger.info("Skipping experiment execution on CI environment, needs HF access.")
         return
-    # lambda=0 control once; lambda>0 across alpha x K.
-    combos: list[tuple[float, int, float]] = []
+    # lambda=0 control once; lambda>0 across K.
+    combos: list[tuple[float, int]] = []
     seen_control = False
     for lam in LAMBDAS:
         if lam == 0.0:
             if not seen_control:
-                combos.append((0.0, 1, ALPHAS[0]))
+                combos.append((0.0, 1))
                 seen_control = True
             continue
-        for alpha in ALPHAS:
-            for k in KS:
-                combos.append((lam, k, alpha))
-    steps = [_build_step(lam, k, alpha) for (lam, k, alpha) in combos]
+        for k in KS:
+            combos.append((lam, k))
+    steps = [_build_step(lam, k) for (lam, k) in combos]
     logger.info(
-        "Curvature-Muon 130m sweep (normalize=%s): %d runs lambdas=%s alphas=%s Ks=%s",
-        NORMALIZE,
+        "Curvature-Muon 130m sweep (coeff=%s@%d, tracks_lr=%s): %d runs lambdas=%s Ks=%s",
+        COEFF_TYPE,
+        BACKEND_STEPS,
+        LAMBDA_TRACKS_LR,
         len(steps),
         LAMBDAS,
-        ALPHAS,
         KS,
     )
-    executor_main(steps=steps, description="Qwen3-130m curvature-corrected Muon sweep: lambda x alpha x K.")
+    executor_main(steps=steps, description="Qwen3-130m curvature-corrected Muon sweep: lambda x K.")
 
 
 if __name__ == "__main__":

--- a/experiments/speedrun/curvature_muon_qwen3/sweep.py
+++ b/experiments/speedrun/curvature_muon_qwen3/sweep.py
@@ -62,9 +62,9 @@ def _ints(env: str, default: str) -> tuple[int, ...]:
 LAMBDAS: tuple[float, ...] = _floats("LAMBDAS", "0.0,0.1,1.0")
 KS: tuple[int, ...] = _ints("KS", "1,2")
 ALPHAS: tuple[float, ...] = _floats("ALPHAS", "1.0,1.2")  # multiplier on the sqrt(e_max) shift
-CURV_POWER: str = os.environ.get("CURV_POWER", "linear")  # "linear" (P/sqrt(e_max)) or "sqrt" (P^{1/2})
-# sqrt mode: warm-start X0 = msign(P^{-1/2} N) (Mudam direction) instead of msign(N).
-MUDAM_INIT: bool = os.environ.get("MUDAM_INIT", "false").lower() in ("1", "true", "yes")
+CURV_POWER: str = os.environ.get("CURV_POWER", "sqrt")  # "sqrt" (P^{1/2}, default) or "linear" (P/sqrt(e_max))
+# warm-start X0 = msign(P^{-1/2} N) (Mudam direction, coupled-NS q_k) instead of msign(N); default on.
+MUDAM_INIT: bool = os.environ.get("MUDAM_INIT", "true").lower() in ("1", "true", "yes")
 POWER_ITERS: int = int(os.environ.get("POWER_ITERS", "8"))  # power-iteration steps for e_max(P)
 # lambda tracks the LR schedule: lambda_t = (swept lambda = peak) * lr_t / peak_lr.
 LAMBDA_TRACKS_LR: bool = os.environ.get("LAMBDA_TRACKS_LR", "false").lower() in ("1", "true", "yes")

--- a/experiments/speedrun/curvature_muon_qwen3/sweep.py
+++ b/experiments/speedrun/curvature_muon_qwen3/sweep.py
@@ -1,0 +1,204 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Qwen3-130m sweep for Curvature-corrected Muon (Nesterov + one-sided Shampoo curvature, hyperball).
+
+    max_{X'X=I} <N_t, X> - (lambda/2) tr(X' P_t X) ,  P_t = EMA(G_t G_t')
+    X_{k+1} = msign( N_t + (c_t I - lambda P_t) X_k ) ,  then MuonH hyperball reparam.
+
+Built on the MuonH qwen3-130m speedrun submission (origin/qwen3-speedrun-muonh, c4_en/bpb = 1.1661):
+all non-curvature hypers are held fixed at that submission; we sweep the curvature knobs lambda, K, alpha.
+lambda = 0 reduces EXACTLY to MuonH (control). normalize_curvature renders lambda dimensionless (operator
+lambda*||N||*(alpha*I - P/lmax)) so a fixed lambda transfers across layers/scales.
+
+Compare on **eval/paloma/c4_en/bpb** (MuonH baseline 1.1661).
+
+Submit (v6e-8 preemptible, us-east5):
+
+    MARIN_PREFIX=gs://marin-us-east5 .venv/bin/iris --config lib/iris/config/marin.yaml job run \\
+      --no-wait --preemptible --region us-east5 --extra tpu \\
+      -e WANDB_API_KEY "$WANDB_API_KEY" -e MARIN_PREFIX gs://marin-us-east5 \\
+      -e REGION us-east5 -e TPU_VARIANT v6e-8 \\
+      -e LAMBDAS -e KS -e ALPHAS -e NORMALIZE -e RUN_TAG \\
+      -- python -m experiments.speedrun.curvature_muon_qwen3.sweep
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import os
+from dataclasses import dataclass
+
+from fray.cluster import ResourceConfig
+from levanter.models.llama import LlamaConfig
+from levanter.models.qwen import Qwen3Config
+from levanter.optim.curvature_muon import CurvatureMuonConfig
+from marin.execution.executor import ExecutorStep, executor_main
+
+from experiments.defaults import default_train
+from experiments.llama import llama_150m
+from experiments.prebuilt_caches import fineweb_edu_subcache_10B
+from experiments.simple_train_config import SimpleTrainConfig
+
+logger = logging.getLogger(__name__)
+
+REGION = os.environ.get("REGION", "us-east5")
+SEQ_LEN = 4096
+WANDB_ENTITY = "marin-community"
+WANDB_PROJECT = "speedrun"
+
+
+def _floats(env: str, default: str) -> tuple[float, ...]:
+    return tuple(float(x) for x in os.environ.get(env, default).split(","))
+
+
+def _ints(env: str, default: str) -> tuple[int, ...]:
+    return tuple(int(x) for x in os.environ.get(env, default).split(","))
+
+
+# Curvature sweep axes. lambda=0 is the MuonH control (must reproduce 1.1661). alpha near 1 = aggressive
+# curvature suppression of high-curvature directions; larger alpha (the spec's 1.2-2) is milder.
+LAMBDAS: tuple[float, ...] = _floats("LAMBDAS", "0.0,0.1,1.0")
+KS: tuple[int, ...] = _ints("KS", "1,2")
+ALPHAS: tuple[float, ...] = _floats("ALPHAS", "1.0,1.5")
+NORMALIZE: bool = os.environ.get("NORMALIZE", "true").lower() in ("1", "true", "yes")
+RUN_TAG: str = os.environ.get("RUN_TAG", "")
+
+
+@dataclass(frozen=True)
+class SizeSpec:
+    label: str
+    llama_cfg: LlamaConfig
+    learning_rate: float
+    adam_lr: float
+    train_batch_size: int
+    num_train_steps: int
+    tpu_variant: str
+    warmup: int
+
+
+_TPU_VARIANT = os.environ.get("TPU_VARIANT", "v6e-8")
+# MuonH submission hypers: lr 0.02, adam_lr 4.615e-3, cosine + warmup 1000, 4959 steps, bs 128.
+SIZE = SizeSpec("130m", llama_150m, 0.02, 0.004615384615384616, 128, 4959, _TPU_VARIANT, 1000)
+
+
+def _to_qwen3_from_llama(llama_cfg: LlamaConfig) -> Qwen3Config:
+    return Qwen3Config(
+        max_seq_len=SEQ_LEN,
+        hidden_dim=llama_cfg.hidden_dim,
+        intermediate_dim=llama_cfg.intermediate_dim,
+        num_layers=llama_cfg.num_layers,
+        num_heads=llama_cfg.num_heads,
+        num_kv_heads=llama_cfg.num_kv_heads,
+        head_dim=getattr(llama_cfg, "head_dim", None),
+        use_bias=getattr(llama_cfg, "use_bias", False),
+        rope=llama_cfg.rope,
+        activation_function=llama_cfg.activation_function,
+        initializer_range=llama_cfg.initializer_range,
+        layer_norm_epsilon=llama_cfg.layer_norm_epsilon,
+        tie_word_embeddings=llama_cfg.tie_word_embeddings,
+        upcast_attn=llama_cfg.upcast_attn,
+        attn_backend=llama_cfg.attn_backend,
+        flash_attention_block_size=llama_cfg.flash_attention_block_size,
+        hybrid_norm=False,
+        scan_layers=True,
+        gradient_checkpointing=True,
+    )
+
+
+def _label(x: float) -> str:
+    return f"{x:g}".replace(".", "_").replace("-", "m")
+
+
+def _override_tracker(step: ExecutorStep) -> ExecutorStep:
+    pod = step.config
+    inner = pod.train_config
+    trainer = dataclasses.replace(
+        inner.trainer, tracker=dataclasses.replace(inner.trainer.tracker, entity=WANDB_ENTITY, project=WANDB_PROJECT)
+    )
+    inner = dataclasses.replace(inner, trainer=trainer)
+    return dataclasses.replace(step, config=dataclasses.replace(pod, train_config=inner))
+
+
+def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
+    optimizer = CurvatureMuonConfig(
+        adam_lr=SIZE.adam_lr,
+        momentum=0.95,
+        nesterov=True,
+        backend_steps=5,
+        beta1=0.9,
+        beta2=0.98,
+        epsilon=1e-15,
+        muon_epsilon=1e-5,
+        max_grad_norm=1.0,
+        coefficient_type="quintic",
+        curvature_beta=0.95,
+        curvature_lambda=lam,
+        curvature_alpha=alpha,
+        inner_steps=k,
+        normalize_curvature=NORMALIZE,
+        learning_rate=SIZE.learning_rate,
+        lr_schedule="cosine",
+        warmup=SIZE.warmup,
+        min_lr_ratio=0.0,
+    )
+    train = SimpleTrainConfig(
+        resources=ResourceConfig.with_tpu(SIZE.tpu_variant, regions=[REGION], preemptible=True),
+        train_seq_len=SEQ_LEN,
+        train_batch_size=SIZE.train_batch_size,
+        num_train_steps=SIZE.num_train_steps,
+        learning_rate=SIZE.learning_rate,
+        optimizer_config=optimizer,
+    )
+    tag = f"_{RUN_TAG}" if RUN_TAG else ""
+    if lam == 0.0:
+        clabel = "_lam0"  # MuonH control (alpha/K/normalize irrelevant)
+    else:
+        nlabel = "n" if NORMALIZE else "r"
+        clabel = f"_lam{_label(lam)}_a{_label(alpha)}_K{k}_{nlabel}"
+    run_id = f"qwen3_{SIZE.label}_curvmuon{clabel}{tag}_{SEQ_LEN}"
+    step = default_train(
+        name=run_id,
+        tokenized=fineweb_edu_subcache_10B,
+        model_config=_to_qwen3_from_llama(SIZE.llama_cfg),
+        train_config=train,
+        tags=["speedrun", "curvature_muon", f"qwen3_{SIZE.label}"],
+        use_default_validation=True,
+        eval_harness_tasks=(),
+        wandb_name=run_id,
+        wandb_group="curvature_muon_qwen3_130m",
+    )
+    return _override_tracker(step)
+
+
+def main() -> None:
+    if os.getenv("CI") is not None:
+        logger.info("Skipping experiment execution on CI environment, needs HF access.")
+        return
+    # lambda=0 control once; lambda>0 across alpha x K.
+    combos: list[tuple[float, int, float]] = []
+    seen_control = False
+    for lam in LAMBDAS:
+        if lam == 0.0:
+            if not seen_control:
+                combos.append((0.0, 1, ALPHAS[0]))
+                seen_control = True
+            continue
+        for alpha in ALPHAS:
+            for k in KS:
+                combos.append((lam, k, alpha))
+    steps = [_build_step(lam, k, alpha) for (lam, k, alpha) in combos]
+    logger.info(
+        "Curvature-Muon 130m sweep (normalize=%s): %d runs lambdas=%s alphas=%s Ks=%s",
+        NORMALIZE,
+        len(steps),
+        LAMBDAS,
+        ALPHAS,
+        KS,
+    )
+    executor_main(steps=steps, description="Qwen3-130m curvature-corrected Muon sweep: lambda x alpha x K.")
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/speedrun/curvature_muon_qwen3/sweep.py
+++ b/experiments/speedrun/curvature_muon_qwen3/sweep.py
@@ -57,10 +57,12 @@ def _ints(env: str, default: str) -> tuple[int, ...]:
     return tuple(int(x) for x in os.environ.get(env, default).split(","))
 
 
-# Curvature sweep axes. Operator = lambda*(sqrt(e_max) I - P/sqrt(e_max)) (PSD, stable at any lambda;
-# lambda dimensionless). lambda=0 is the MuonH control (must reproduce 1.1661).
+# Curvature sweep axes. Operator = lambda*(alpha*sqrt(e_max) I - C), C = P/sqrt(e_max) [linear] or
+# P^{1/2} [sqrt]. PSD for alpha>=1, lambda dimensionless. lambda=0 is the MuonH control (reproduces 1.1661).
 LAMBDAS: tuple[float, ...] = _floats("LAMBDAS", "0.0,0.1,1.0")
 KS: tuple[int, ...] = _ints("KS", "1,2")
+ALPHAS: tuple[float, ...] = _floats("ALPHAS", "1.0,1.2")  # multiplier on the sqrt(e_max) shift
+CURV_POWER: str = os.environ.get("CURV_POWER", "linear")  # "linear" (P/sqrt(e_max)) or "sqrt" (P^{1/2})
 POWER_ITERS: int = int(os.environ.get("POWER_ITERS", "8"))  # power-iteration steps for e_max(P)
 # lambda tracks the LR schedule: lambda_t = (swept lambda = peak) * lr_t / peak_lr.
 LAMBDA_TRACKS_LR: bool = os.environ.get("LAMBDA_TRACKS_LR", "false").lower() in ("1", "true", "yes")
@@ -126,7 +128,7 @@ def _override_tracker(step: ExecutorStep) -> ExecutorStep:
     return dataclasses.replace(step, config=dataclasses.replace(pod, train_config=inner))
 
 
-def _build_step(lam: float, k: int) -> ExecutorStep:
+def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
     optimizer = CurvatureMuonConfig(
         adam_lr=SIZE.adam_lr,
         momentum=0.95,
@@ -140,6 +142,8 @@ def _build_step(lam: float, k: int) -> ExecutorStep:
         coefficient_type=COEFF_TYPE,
         curvature_beta=0.95,
         curvature_lambda=lam,
+        curvature_alpha=alpha,
+        curv_power=CURV_POWER,
         inner_steps=k,
         power_iters=POWER_ITERS,
         lambda_tracks_lr=LAMBDA_TRACKS_LR,
@@ -157,12 +161,13 @@ def _build_step(lam: float, k: int) -> ExecutorStep:
         optimizer_config=optimizer,
     )
     cf = {"polar_express": "pe", "quintic": "qx", "simple": "sm", "aol": "aol"}.get(COEFF_TYPE, COEFF_TYPE)
-    tag = f"_{cf}{BACKEND_STEPS}{('_' + RUN_TAG) if RUN_TAG else ''}"
+    cp = "sq" if CURV_POWER == "sqrt" else "lin"
+    tag = f"_{cp}_{cf}{BACKEND_STEPS}{('_' + RUN_TAG) if RUN_TAG else ''}"
     if lam == 0.0:
-        clabel = "_lam0"  # MuonH control (K irrelevant)
+        clabel = "_lam0"  # MuonH control (alpha/K irrelevant)
     else:
         tlabel = "_tl" if LAMBDA_TRACKS_LR else ""
-        clabel = f"_lam{_label(lam)}_K{k}{tlabel}"
+        clabel = f"_lam{_label(lam)}_a{_label(alpha)}_K{k}{tlabel}"
     run_id = f"qwen3_{SIZE.label}_curvmuon{clabel}{tag}_{SEQ_LEN}"
     step = default_train(
         name=run_id,
@@ -182,25 +187,28 @@ def main() -> None:
     if os.getenv("CI") is not None:
         logger.info("Skipping experiment execution on CI environment, needs HF access.")
         return
-    # lambda=0 control once; lambda>0 across K.
-    combos: list[tuple[float, int]] = []
+    # lambda=0 control once; lambda>0 across alpha x K.
+    combos: list[tuple[float, int, float]] = []
     seen_control = False
     for lam in LAMBDAS:
         if lam == 0.0:
             if not seen_control:
-                combos.append((0.0, 1))
+                combos.append((0.0, 1, ALPHAS[0]))
                 seen_control = True
             continue
-        for k in KS:
-            combos.append((lam, k))
-    steps = [_build_step(lam, k) for (lam, k) in combos]
+        for alpha in ALPHAS:
+            for k in KS:
+                combos.append((lam, k, alpha))
+    steps = [_build_step(lam, k, alpha) for (lam, k, alpha) in combos]
     logger.info(
-        "Curvature-Muon 130m sweep (coeff=%s@%d, tracks_lr=%s): %d runs lambdas=%s Ks=%s",
+        "Curvature-Muon 130m sweep (curv_power=%s coeff=%s@%d tracks_lr=%s): %d runs lambdas=%s alphas=%s Ks=%s",
+        CURV_POWER,
         COEFF_TYPE,
         BACKEND_STEPS,
         LAMBDA_TRACKS_LR,
         len(steps),
         LAMBDAS,
+        ALPHAS,
         KS,
     )
     executor_main(steps=steps, description="Qwen3-130m curvature-corrected Muon sweep: lambda x K.")

--- a/experiments/speedrun/curvature_muon_qwen3/sweep.py
+++ b/experiments/speedrun/curvature_muon_qwen3/sweep.py
@@ -132,7 +132,6 @@ def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
         adam_lr=SIZE.adam_lr,
         momentum=0.95,
         nesterov=True,
-        backend_steps=5,
         beta1=0.9,
         beta2=0.98,
         epsilon=1e-15,

--- a/experiments/speedrun/curvature_muon_qwen3/sweep.py
+++ b/experiments/speedrun/curvature_muon_qwen3/sweep.py
@@ -63,6 +63,8 @@ LAMBDAS: tuple[float, ...] = _floats("LAMBDAS", "0.0,0.1,1.0")
 KS: tuple[int, ...] = _ints("KS", "1,2")
 ALPHAS: tuple[float, ...] = _floats("ALPHAS", "1.0,1.2")  # multiplier on the sqrt(e_max) shift
 CURV_POWER: str = os.environ.get("CURV_POWER", "linear")  # "linear" (P/sqrt(e_max)) or "sqrt" (P^{1/2})
+# sqrt mode: warm-start X0 = msign(P^{-1/2} N) (Mudam direction) instead of msign(N).
+MUDAM_INIT: bool = os.environ.get("MUDAM_INIT", "false").lower() in ("1", "true", "yes")
 POWER_ITERS: int = int(os.environ.get("POWER_ITERS", "8"))  # power-iteration steps for e_max(P)
 # lambda tracks the LR schedule: lambda_t = (swept lambda = peak) * lr_t / peak_lr.
 LAMBDA_TRACKS_LR: bool = os.environ.get("LAMBDA_TRACKS_LR", "false").lower() in ("1", "true", "yes")
@@ -144,6 +146,7 @@ def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
         curvature_lambda=lam,
         curvature_alpha=alpha,
         curv_power=CURV_POWER,
+        mudam_init=MUDAM_INIT,
         inner_steps=k,
         power_iters=POWER_ITERS,
         lambda_tracks_lr=LAMBDA_TRACKS_LR,
@@ -162,7 +165,8 @@ def _build_step(lam: float, k: int, alpha: float) -> ExecutorStep:
     )
     cf = {"polar_express": "pe", "quintic": "qx", "simple": "sm", "aol": "aol"}.get(COEFF_TYPE, COEFF_TYPE)
     cp = "sq" if CURV_POWER == "sqrt" else "lin"
-    tag = f"_{cp}_{cf}{BACKEND_STEPS}{('_' + RUN_TAG) if RUN_TAG else ''}"
+    mi = "_mi" if MUDAM_INIT else ""
+    tag = f"_{cp}{mi}_{cf}{BACKEND_STEPS}{('_' + RUN_TAG) if RUN_TAG else ''}"
     if lam == 0.0:
         clabel = "_lam0"  # MuonH control (alpha/K irrelevant)
     else:

--- a/lib/levanter/src/levanter/optim/curvature_muon.py
+++ b/lib/levanter/src/levanter/optim/curvature_muon.py
@@ -68,6 +68,9 @@ class CurvatureMuonConfig(OptimizerConfig):
     # fixed λ is scale-fragile. normalize_curvature renders it dimensionless per-matrix by using the
     # coefficient λ·‖N‖ instead of λ·λ̂_max (operator = λ‖N‖(α I − P/λ̂_max)), so λ~O(1) is meaningful.
     normalize_curvature: bool = True
+    # If set, the curvature strength tracks the LR schedule: lambda_t = curvature_lambda * lr_t / peak_lr.
+    # So curvature is strongest at peak LR and fades during warmup / cosine decay (curvature_lambda = peak).
+    lambda_tracks_lr: bool = False
 
     def build(self, num_train_steps):
         learning_rate_schedule = self.lr_scheduler(num_train_steps)
@@ -91,6 +94,8 @@ class CurvatureMuonConfig(OptimizerConfig):
                         self.curvature_alpha,
                         self.inner_steps,
                         self.normalize_curvature,
+                        self.learning_rate,
+                        self.lambda_tracks_lr,
                     )
                 )
                 return optax.chain(*components)
@@ -143,9 +148,11 @@ class ScaleByCurvatureMuonState(NamedTuple):
     power_vec: optax.Updates  # q, flattened-linear tree of [..., M]
 
 
-def _curv_direction_2d(g, n, p, q, *, rho, lam, alpha, steps, eps, ctype, inner_steps, normalize):
+def _curv_direction_2d(g, n, p, q, *, rho, lam_static, lam_coef, alpha, steps, eps, ctype, inner_steps, normalize):
     """One matrix. g, n: [out, in] (gradient, Nesterov signal). p: [M, M], q: [M], M = max(out, in).
 
+    lam_static (python float) is the on/off / peak strength used for the static branch; lam_coef is the
+    actual coefficient (may be a traced scalar when it tracks the LR schedule).
     Returns (new_p, new_q, x) with x in the original [out, in] orientation.
     """
     out, inn = g.shape
@@ -159,15 +166,15 @@ def _curv_direction_2d(g, n, p, q, *, rho, lam, alpha, steps, eps, ctype, inner_
     ell = jnp.dot(new_q, new_p @ new_q)  # Rayleigh estimate of λ_max(P)
 
     x = zeropower_via_newtonschulz5(n_t, steps=steps, eps=eps, coefficient_type=ctype)
-    if lam > 0.0:
+    if lam_static > 0.0:
         eye = jnp.eye(new_p.shape[0], dtype=new_p.dtype)
         if normalize:
             # dimensionless: operator = λ·‖N‖·(α I − P/λ̂_max)
-            coef = lam * jnp.linalg.norm(n_t)
+            coef = lam_coef * jnp.linalg.norm(n_t)
             operator = coef * (alpha * eye - new_p / (ell + eps))
         else:
             # literal spec: (c I − λ P), c = α λ λ̂_max
-            operator = (alpha * lam * ell) * eye - lam * new_p
+            operator = (alpha * lam_coef * ell) * eye - lam_coef * new_p
         for _ in range(int(inner_steps)):
             x = zeropower_via_newtonschulz5(n_t + operator @ x, steps=steps, eps=eps, coefficient_type=ctype)
 
@@ -187,13 +194,17 @@ def scale_with_curvature_muon(
     curvature_alpha=1.5,
     inner_steps=1,
     normalize_curvature=True,
+    peak_lr=0.02,
+    lambda_tracks_lr=False,
 ):
     steps = int(steps)
     mu = float(momentum)
     rho = float(curvature_beta)
-    lam = float(curvature_lambda)
+    lam = float(curvature_lambda)  # static peak strength (also the on/off switch)
     alpha = float(curvature_alpha)
     normalize = bool(normalize_curvature)
+    peak_lr = float(peak_lr)
+    tracks_lr = bool(lambda_tracks_lr)
 
     def _is_linear_weight(layer):
         return isinstance(layer, haliax.nn.Linear) and isinstance(layer.weight, haliax.NamedArray)
@@ -241,6 +252,9 @@ def scale_with_curvature_muon(
         flat_grad = flatten_linear_layers(updates)
         flat_signal = flatten_linear_layers(signal)
 
+        # Effective coefficient: tracks the LR schedule when requested (traced scalar), else the static peak.
+        lam_coef = lam * (learning_rate / peak_lr) if tracks_lr else lam
+
         def per_layer(g_layer, n_layer, p, q):
             if not _is_linear_weight(g_layer):
                 return n_layer  # passthrough (these are routed to adam/adamh anyway)
@@ -252,7 +266,8 @@ def scale_with_curvature_muon(
                 pp,
                 qq,
                 rho=rho,
-                lam=lam,
+                lam_static=lam,
+                lam_coef=lam_coef,
                 alpha=alpha,
                 steps=steps,
                 eps=muon_eps,

--- a/lib/levanter/src/levanter/optim/curvature_muon.py
+++ b/lib/levanter/src/levanter/optim/curvature_muon.py
@@ -1,0 +1,299 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Curvature-corrected Muon: Nesterov Muon with a one-sided Shampoo curvature penalty, on the
+hyperball (MuonH) base.
+
+Per matrix ``W`` (oriented so rows ≥ cols), the orthogonal update direction approximately solves
+
+    max_{XᵀX=I}  ⟨N_t, X⟩  −  (λ/2)·tr(Xᵀ P_t X),     P_t = EMA(G_t G_tᵀ)   (left/output curvature)
+
+via the inner Newton–Schulz fixed point
+
+    X⁽⁰⁾   = msign(N_t)
+    X⁽ᵏ⁺¹⁾ = msign( N_t + (c_t I − λ P_t) X⁽ᵏ⁾ ),     c_t = α·λ·λ̂_max(P_t)  (one power iteration)
+
+``msign`` is the usual Muon Newton–Schulz orthogonalization. The curvature enters only through matmuls
+and one power iteration — no eigendecomposition. The resulting ``X_t`` is then mapped through the MuonH
+hyperball (scale-invariant, constant-Frobenius-norm) reparam instead of the ``√(Out/In)`` scaling.
+
+λ = 0 ⟹ c_t = 0 and this is exactly MuonH (Nesterov Muon + hyperball). K = 1 is a single curvature-
+corrected polishing step on top of Muon.
+"""
+
+import dataclasses
+from dataclasses import dataclass
+from typing import NamedTuple
+
+import jax
+import jax.numpy as jnp
+import optax
+from optax import tree_utils as otu
+
+import haliax
+
+from levanter.optim.adamh import scale_by_adamh
+from levanter.optim.config import OptimizerConfig
+from levanter.optim.util import (
+    CoefficientType,
+    flatten_linear_layers,
+    label_linear_like_module,
+    unflatten_linear_layers,
+    zeropower_via_newtonschulz5,
+)
+from levanter.utils.jax_utils import leaf_key_paths
+
+
+@OptimizerConfig.register_subclass("curvature_muon")
+@dataclass(frozen=True)
+class CurvatureMuonConfig(OptimizerConfig):
+    """Curvature-corrected Muon on the hyperball base (cf. MuonH). λ=0 recovers MuonH exactly."""
+
+    adam_lr: float = 6e-4
+    momentum: float = 0.95  # μ
+    nesterov: bool = True
+    backend_steps: int = 5  # Newton-Schulz steps for msign
+    beta1: float = 0.9
+    beta2: float = 0.95
+    epsilon: float = 1e-8
+    muon_epsilon: float = 1e-8
+    max_grad_norm: float = 1.0
+    coefficient_type: CoefficientType = "quintic"
+    # --- curvature knobs ---
+    curvature_beta: float = 0.95  # ρ, EMA decay of P = EMA(G Gᵀ)
+    curvature_lambda: float = 0.0  # λ, curvature strength (0 ⟹ MuonH)
+    curvature_alpha: float = 1.5  # α ≥ 1, shift safety so the operator ⪰ 0
+    inner_steps: int = 1  # K, inner fixed-point iterations
+    # The literal spec's operator (c I − λ P) = λ·λ̂_max·(α I − P/λ̂_max) is in 1/gradient units, so a
+    # fixed λ is scale-fragile. normalize_curvature renders it dimensionless per-matrix by using the
+    # coefficient λ·‖N‖ instead of λ·λ̂_max (operator = λ‖N‖(α I − P/λ̂_max)), so λ~O(1) is meaningful.
+    normalize_curvature: bool = True
+
+    def build(self, num_train_steps):
+        learning_rate_schedule = self.lr_scheduler(num_train_steps)
+        adam_lr_schedule = self.lr_scheduler(num_train_steps, override_lr=self.adam_lr)
+
+        def optimizer(learning_rate, adam_lr):
+            def curvature_muon_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(
+                    scale_with_curvature_muon(
+                        self.momentum,
+                        self.nesterov,
+                        self.backend_steps,
+                        self.muon_epsilon,
+                        learning_rate,
+                        self.coefficient_type,
+                        self.curvature_beta,
+                        self.curvature_lambda,
+                        self.curvature_alpha,
+                        self.inner_steps,
+                        self.normalize_curvature,
+                    )
+                )
+                return optax.chain(*components)
+
+            def adamh_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(scale_by_adamh(self.beta1, self.beta2, self.epsilon, learning_rate))
+                return optax.chain(*components)
+
+            def adam_transform():
+                components = []
+                if self.max_grad_norm:
+                    components.append(optax.clip_by_global_norm(self.max_grad_norm))
+                components.append(optax.scale_by_adam(self.beta1, self.beta2, self.epsilon))
+                components.append(optax.scale(-adam_lr))
+                return optax.chain(*components)
+
+            transformations = {
+                "curvature_muon": curvature_muon_transform(),
+                "adamh": adamh_transform(),
+                "adam": adam_transform(),
+            }
+            return optax.multi_transform(transformations, self.create_mask)
+
+        return optax.inject_hyperparams(optimizer)(learning_rate=learning_rate_schedule, adam_lr=adam_lr_schedule)
+
+    def create_mask(self, params):
+        """Embeddings → adam, lm_head → adamh, Linear weights → curvature_muon, else → adam (matches MuonH)."""
+        paths = leaf_key_paths(params)
+
+        def mask_fn(param, path):
+            path_str = ".".join(path) if isinstance(path, (list, tuple)) else str(path)
+            if "Embedding" in path_str:
+                return "adam"
+            elif "lm_head" in path_str:
+                return "adamh"
+            elif isinstance(param, haliax.nn.Linear):
+                return label_linear_like_module(param, weight_label="curvature_muon", bias_label="adam")
+            else:
+                return "adam"
+
+        return haliax.tree_util.tree_map(mask_fn, params, paths, is_leaf=lambda x: isinstance(x, haliax.nn.Linear))
+
+
+class ScaleByCurvatureMuonState(NamedTuple):
+    momentum_buffer: optax.Updates  # B, full param tree
+    curvature: optax.Updates  # P, flattened-linear tree of [..., M, M] (M = max(out, in))
+    power_vec: optax.Updates  # q, flattened-linear tree of [..., M]
+
+
+def _curv_direction_2d(g, n, p, q, *, rho, lam, alpha, steps, eps, ctype, inner_steps, normalize):
+    """One matrix. g, n: [out, in] (gradient, Nesterov signal). p: [M, M], q: [M], M = max(out, in).
+
+    Returns (new_p, new_q, x) with x in the original [out, in] orientation.
+    """
+    out, inn = g.shape
+    transpose = out < inn
+    g_t = g.T if transpose else g  # [M, N], M ≥ N
+    n_t = n.T if transpose else n
+
+    new_p = rho * p + (1.0 - rho) * (g_t @ g_t.T)  # [M, M]
+    pq = new_p @ q
+    new_q = pq / (jnp.linalg.norm(pq) + eps)
+    ell = jnp.dot(new_q, new_p @ new_q)  # Rayleigh estimate of λ_max(P)
+
+    x = zeropower_via_newtonschulz5(n_t, steps=steps, eps=eps, coefficient_type=ctype)
+    if lam > 0.0:
+        eye = jnp.eye(new_p.shape[0], dtype=new_p.dtype)
+        if normalize:
+            # dimensionless: operator = λ·‖N‖·(α I − P/λ̂_max)
+            coef = lam * jnp.linalg.norm(n_t)
+            operator = coef * (alpha * eye - new_p / (ell + eps))
+        else:
+            # literal spec: (c I − λ P), c = α λ λ̂_max
+            operator = (alpha * lam * ell) * eye - lam * new_p
+        for _ in range(int(inner_steps)):
+            x = zeropower_via_newtonschulz5(n_t + operator @ x, steps=steps, eps=eps, coefficient_type=ctype)
+
+    x_out = x.T if transpose else x
+    return new_p, new_q, x_out
+
+
+def scale_with_curvature_muon(
+    momentum=0.95,
+    nesterov=True,
+    steps=5,
+    muon_eps=1e-8,
+    learning_rate=0.02,
+    coefficient_type="quintic",
+    curvature_beta=0.95,
+    curvature_lambda=0.0,
+    curvature_alpha=1.5,
+    inner_steps=1,
+    normalize_curvature=True,
+):
+    steps = int(steps)
+    mu = float(momentum)
+    rho = float(curvature_beta)
+    lam = float(curvature_lambda)
+    alpha = float(curvature_alpha)
+    normalize = bool(normalize_curvature)
+
+    def _is_linear_weight(layer):
+        return isinstance(layer, haliax.nn.Linear) and isinstance(layer.weight, haliax.NamedArray)
+
+    def init_fn(params):
+        momentum_buffer = otu.tree_zeros_like(params)
+        flat = flatten_linear_layers(params)
+
+        def to_p(layer):
+            if not _is_linear_weight(layer):
+                return layer
+            a = layer.weight.array
+            m = max(a.shape[-2], a.shape[-1])
+            return jnp.broadcast_to(muon_eps * jnp.eye(m, dtype=a.dtype), a.shape[:-2] + (m, m))
+
+        def to_q(layer):
+            if not _is_linear_weight(layer):
+                return layer
+            a = layer.weight.array
+            m = max(a.shape[-2], a.shape[-1])
+            return jnp.broadcast_to(jnp.ones(m, dtype=a.dtype) / jnp.sqrt(m), a.shape[:-2] + (m,))
+
+        curvature = haliax.tree_util.tree_map(to_p, flat, is_leaf=_is_linear_weight)
+        power_vec = haliax.tree_util.tree_map(to_q, flat, is_leaf=_is_linear_weight)
+        return ScaleByCurvatureMuonState(momentum_buffer=momentum_buffer, curvature=curvature, power_vec=power_vec)
+
+    def update_fn(updates, state, params=None):
+        # Momentum buffer + scale-preserving Nesterov signal N = (1-μ)G + μB.
+        buf = jax.tree.map(
+            lambda m, g: None if g is None else mu * m + (1.0 - mu) * g,
+            state.momentum_buffer,
+            updates,
+            is_leaf=lambda x: x is None,
+        )
+        if nesterov:
+            signal = jax.tree.map(
+                lambda b, g: None if g is None else (1.0 - mu) * g + mu * b,
+                buf,
+                updates,
+                is_leaf=lambda x: x is None,
+            )
+        else:
+            signal = buf
+
+        flat_grad = flatten_linear_layers(updates)
+        flat_signal = flatten_linear_layers(signal)
+
+        def per_layer(g_layer, n_layer, p, q):
+            if not _is_linear_weight(g_layer):
+                return n_layer  # passthrough (these are routed to adam/adamh anyway)
+            g = g_layer.weight.array
+            n = n_layer.weight.array
+            fn = lambda gg, nn, pp, qq: _curv_direction_2d(
+                gg,
+                nn,
+                pp,
+                qq,
+                rho=rho,
+                lam=lam,
+                alpha=alpha,
+                steps=steps,
+                eps=muon_eps,
+                ctype=coefficient_type,
+                inner_steps=inner_steps,
+                normalize=normalize,
+            )
+            new_p, new_q, x = jax.vmap(fn)(g, n, p, q) if g.ndim == 3 else fn(g, n, p, q)
+            new_w = dataclasses.replace(n_layer.weight, array=x)
+            return (dataclasses.replace(n_layer, weight=new_w), new_p, new_q)  # type: ignore
+
+        combined = haliax.tree_util.tree_map(
+            per_layer, flat_grad, flat_signal, state.curvature, state.power_vec, is_leaf=_is_linear_weight
+        )
+
+        is_triple = lambda c: isinstance(c, tuple) and len(c) == 3
+        flat_dir = jax.tree.map(lambda c: c[0] if is_triple(c) else c, combined, is_leaf=is_triple)
+        new_curvature = jax.tree.map(lambda c: c[1] if is_triple(c) else c, combined, is_leaf=is_triple)
+        new_power = jax.tree.map(lambda c: c[2] if is_triple(c) else c, combined, is_leaf=is_triple)
+        direction = unflatten_linear_layers(signal, flat_dir)
+
+        # Hyperball: constant-Frobenius-norm scale-invariant update (identical to MuonH).
+        def scale_invariant_update(p, u):
+            if p is None:
+                return None
+            if p.ndim == 2:
+                new_p = p - learning_rate * u * jnp.linalg.norm(p) / jnp.maximum(jnp.linalg.norm(u), 1e-10)
+                return new_p / jnp.linalg.norm(new_p) * jnp.linalg.norm(p) - p
+            else:
+                axes = tuple(range(1, p.ndim))
+                p_norm = jnp.sqrt(jnp.sum(jnp.square(p), axis=axes, keepdims=True))
+                u_norm = jnp.sqrt(jnp.sum(jnp.square(u), axis=axes, keepdims=True))
+                new_p = p - learning_rate * u * p_norm / jnp.maximum(u_norm, 1e-10)
+                new_p_norm = jnp.sqrt(jnp.sum(jnp.square(new_p), axis=axes, keepdims=True))
+                return new_p / jnp.maximum(new_p_norm, 1e-10) * p_norm - p
+
+        hyperball_updates = jax.tree_util.tree_map(
+            scale_invariant_update, params, direction, is_leaf=lambda x: x is None
+        )
+        return hyperball_updates, ScaleByCurvatureMuonState(
+            momentum_buffer=buf, curvature=new_curvature, power_vec=new_power
+        )
+
+    return optax.GradientTransformation(init_fn, update_fn)

--- a/lib/levanter/src/levanter/optim/curvature_muon.py
+++ b/lib/levanter/src/levanter/optim/curvature_muon.py
@@ -11,14 +11,17 @@ Per matrix ``W`` (oriented so rows ≥ cols), the orthogonal update direction ap
 via the inner Newton–Schulz fixed point
 
     X⁽⁰⁾   = msign(N_t)
-    X⁽ᵏ⁺¹⁾ = msign( N_t + (c_t I − λ P_t) X⁽ᵏ⁾ ),     c_t = α·λ·λ̂_max(P_t)  (one power iteration)
+    X⁽ᵏ⁺¹⁾ = msign( N_t + λ·(√e_max·I − P_t/√e_max)·X⁽ᵏ⁾ ),   e_max = λ_max(P_t)  (power iteration)
 
-``msign`` is the usual Muon Newton–Schulz orthogonalization. The curvature enters only through matmuls
-and one power iteration — no eigendecomposition. The resulting ``X_t`` is then mapped through the MuonH
-hyperball (scale-invariant, constant-Frobenius-norm) reparam instead of the ``√(Out/In)`` scaling.
+``msign`` is the usual Muon Newton–Schulz orthogonalization. The operator ``√e_max·I − P_t/√e_max`` is
+**PSD** (eigenvalues ``(e_max − p_i)/√e_max ≥ 0``: ``√e_max`` in flat directions, ``0`` in the top-curvature
+one), so the fixed point is a contraction — **stable at any λ, no α shift needed**. And ``P/√e_max`` has
+gradient units (``P ~ G²`` ⟹ ``P/√e_max ~ G``), matching ``N``, so **λ is dimensionless** (no ``‖N‖``
+factor) and its LR coupling is unambiguous. Curvature enters only through matmuls + a power iteration —
+no eigendecomposition. ``X_t`` is then mapped through the MuonH hyperball (scale-invariant,
+constant-Frobenius-norm) reparam instead of ``√(Out/In)`` scaling.
 
-λ = 0 ⟹ c_t = 0 and this is exactly MuonH (Nesterov Muon + hyperball). K = 1 is a single curvature-
-corrected polishing step on top of Muon.
+λ = 0 ⟹ exactly MuonH (Nesterov Muon + hyperball). K = 1 is a single curvature-corrected polishing step.
 """
 
 import dataclasses
@@ -60,14 +63,15 @@ class CurvatureMuonConfig(OptimizerConfig):
     max_grad_norm: float = 1.0
     coefficient_type: CoefficientType = "quintic"
     # --- curvature knobs ---
+    # Inner fixed point: X = msign( N + λ·(√e_max·I − P/√e_max)·X ), P = EMA(G Gᵀ), e_max = λ_max(P).
+    # The operator √e_max·I − P/√e_max is PSD (eigenvalues (e_max−p_i)/√e_max ≥ 0; 0 in the top-curvature
+    # direction, √e_max in flat ones), so the iteration is a contraction — stable at any λ (no α needed).
+    # P/√e_max has gradient units (P~G², so P/√e_max~G), matching N, so λ is dimensionless and its LR
+    # coupling is clean (no ‖N‖ factor). λ=0 ⟹ MuonH.
     curvature_beta: float = 0.95  # ρ, EMA decay of P = EMA(G Gᵀ)
     curvature_lambda: float = 0.0  # λ, curvature strength (0 ⟹ MuonH)
-    curvature_alpha: float = 1.5  # α ≥ 1, shift safety so the operator ⪰ 0
     inner_steps: int = 1  # K, inner fixed-point iterations
-    # The literal spec's operator (c I − λ P) = λ·λ̂_max·(α I − P/λ̂_max) is in 1/gradient units, so a
-    # fixed λ is scale-fragile. normalize_curvature renders it dimensionless per-matrix by using the
-    # coefficient λ·‖N‖ instead of λ·λ̂_max (operator = λ‖N‖(α I − P/λ̂_max)), so λ~O(1) is meaningful.
-    normalize_curvature: bool = True
+    power_iters: int = 8  # power-iteration steps for the e_max(P) estimate (warm-started from stored q)
     # If set, the curvature strength tracks the LR schedule: lambda_t = curvature_lambda * lr_t / peak_lr.
     # So curvature is strongest at peak LR and fades during warmup / cosine decay (curvature_lambda = peak).
     lambda_tracks_lr: bool = False
@@ -91,9 +95,8 @@ class CurvatureMuonConfig(OptimizerConfig):
                         self.coefficient_type,
                         self.curvature_beta,
                         self.curvature_lambda,
-                        self.curvature_alpha,
                         self.inner_steps,
-                        self.normalize_curvature,
+                        self.power_iters,
                         self.learning_rate,
                         self.lambda_tracks_lr,
                     )
@@ -148,12 +151,15 @@ class ScaleByCurvatureMuonState(NamedTuple):
     power_vec: optax.Updates  # q, flattened-linear tree of [..., M]
 
 
-def _curv_direction_2d(g, n, p, q, *, rho, lam_static, lam_coef, alpha, steps, eps, ctype, inner_steps, normalize):
+_EMAX_MARGIN = 1.05  # inflate the (lower-bound) Rayleigh e_max estimate so the operator stays strictly PSD
+
+
+def _curv_direction_2d(g, n, p, q, *, rho, lam_static, lam_coef, steps, eps, ctype, inner_steps, power_iters):
     """One matrix. g, n: [out, in] (gradient, Nesterov signal). p: [M, M], q: [M], M = max(out, in).
 
-    lam_static (python float) is the on/off / peak strength used for the static branch; lam_coef is the
-    actual coefficient (may be a traced scalar when it tracks the LR schedule).
-    Returns (new_p, new_q, x) with x in the original [out, in] orientation.
+    Inner fixed point X = msign( N + λ·(√e_max·I − P/√e_max)·X ). lam_static (python float) gates on/off;
+    lam_coef is the actual coefficient (a traced scalar when it tracks the LR schedule).
+    e_max(P) via a warm-started multi-step power iteration. Returns (new_p, new_q, x) in [out, in] orient.
     """
     out, inn = g.shape
     transpose = out < inn
@@ -161,20 +167,18 @@ def _curv_direction_2d(g, n, p, q, *, rho, lam_static, lam_coef, alpha, steps, e
     n_t = n.T if transpose else n
 
     new_p = rho * p + (1.0 - rho) * (g_t @ g_t.T)  # [M, M]
-    pq = new_p @ q
-    new_q = pq / (jnp.linalg.norm(pq) + eps)
-    ell = jnp.dot(new_q, new_p @ new_q)  # Rayleigh estimate of λ_max(P)
+    new_q = q
+    for _ in range(int(power_iters)):
+        pq = new_p @ new_q
+        new_q = pq / (jnp.linalg.norm(pq) + eps)
+    # Rayleigh quotient lower-bounds λ_max; inflate by the margin so √e_max·I − P/√e_max is strictly PSD.
+    emax = jnp.dot(new_q, new_p @ new_q) * _EMAX_MARGIN
+    se = jnp.sqrt(emax) + eps
 
     x = zeropower_via_newtonschulz5(n_t, steps=steps, eps=eps, coefficient_type=ctype)
     if lam_static > 0.0:
         eye = jnp.eye(new_p.shape[0], dtype=new_p.dtype)
-        if normalize:
-            # dimensionless: operator = λ·‖N‖·(α I − P/λ̂_max)
-            coef = lam_coef * jnp.linalg.norm(n_t)
-            operator = coef * (alpha * eye - new_p / (ell + eps))
-        else:
-            # literal spec: (c I − λ P), c = α λ λ̂_max
-            operator = (alpha * lam_coef * ell) * eye - lam_coef * new_p
+        operator = lam_coef * (se * eye - new_p / se)  # PSD: λ(√e_max I − P/√e_max)
         for _ in range(int(inner_steps)):
             x = zeropower_via_newtonschulz5(n_t + operator @ x, steps=steps, eps=eps, coefficient_type=ctype)
 
@@ -191,9 +195,8 @@ def scale_with_curvature_muon(
     coefficient_type="quintic",
     curvature_beta=0.95,
     curvature_lambda=0.0,
-    curvature_alpha=1.5,
     inner_steps=1,
-    normalize_curvature=True,
+    power_iters=8,
     peak_lr=0.02,
     lambda_tracks_lr=False,
 ):
@@ -201,8 +204,6 @@ def scale_with_curvature_muon(
     mu = float(momentum)
     rho = float(curvature_beta)
     lam = float(curvature_lambda)  # static peak strength (also the on/off switch)
-    alpha = float(curvature_alpha)
-    normalize = bool(normalize_curvature)
     peak_lr = float(peak_lr)
     tracks_lr = bool(lambda_tracks_lr)
 
@@ -268,12 +269,11 @@ def scale_with_curvature_muon(
                 rho=rho,
                 lam_static=lam,
                 lam_coef=lam_coef,
-                alpha=alpha,
                 steps=steps,
                 eps=muon_eps,
                 ctype=coefficient_type,
                 inner_steps=inner_steps,
-                normalize=normalize,
+                power_iters=power_iters,
             )
             new_p, new_q, x = jax.vmap(fn)(g, n, p, q) if g.ndim == 3 else fn(g, n, p, q)
             new_w = dataclasses.replace(n_layer.weight, array=x)

--- a/lib/levanter/src/levanter/optim/curvature_muon.py
+++ b/lib/levanter/src/levanter/optim/curvature_muon.py
@@ -71,7 +71,10 @@ class CurvatureMuonConfig(OptimizerConfig):
     curvature_beta: float = 0.95  # ρ, EMA decay of P = EMA(G Gᵀ)
     curvature_lambda: float = 0.0  # λ, curvature strength (0 ⟹ MuonH)
     curvature_alpha: float = 1.0  # α ≥ 1, multiplier on the √e_max shift (α=1 = boundary PSD)
-    curv_power: str = "sqrt"  # "sqrt" (C = P^{1/2}, default) or "linear" (C = P/√e_max)
+    curv_power: str = "sqrt"  # "sqrt" (C = P^{1/2}, default) or "linear" (C = P/√e_max); ignored if two_sided
+    two_sided: bool = (
+        False  # two-sided curvature P_L^{1/4} X P_R^{1/4} + Shampoo warm-start msign(P_L^{-1/4} N P_R^{-1/4})
+    )
     mudam_init: bool = True  # warm-start X⁰ = msign(P^{-1/2} N) (Mudam direction, coupled-NS q_k); default on
     mudam_steps: int = 5  # coupled-NS steps for the Mudam warm-start (kept small — stable only under-converged)
     inner_steps: int = 1  # K, inner fixed-point iterations
@@ -101,6 +104,7 @@ class CurvatureMuonConfig(OptimizerConfig):
                         self.curvature_lambda,
                         self.curvature_alpha,
                         self.curv_power,
+                        self.two_sided,
                         self.mudam_init,
                         self.mudam_steps,
                         self.inner_steps,
@@ -155,11 +159,14 @@ class CurvatureMuonConfig(OptimizerConfig):
 
 class ScaleByCurvatureMuonState(NamedTuple):
     momentum_buffer: optax.Updates  # B, full param tree
-    curvature: optax.Updates  # P, flattened-linear tree of [..., M, M] (M = max(out, in))
-    power_vec: optax.Updates  # q, flattened-linear tree of [..., M]
+    curvature: optax.Updates  # P_L (left Gram), flattened-linear tree of [..., M, M] (M = max(out, in))
+    power_vec: optax.Updates  # q_L, flattened-linear tree of [..., M]
+    curvature_r: optax.Updates  # P_R (right Gram), flattened-linear tree of [..., N, N] (N = min(out, in))
+    power_vec_r: optax.Updates  # q_R, flattened-linear tree of [..., N]
 
 
 _EMAX_MARGIN = 1.05  # inflate the (lower-bound) Rayleigh e_max estimate so the operator stays strictly PSD
+_POW4_FLOOR = 1e-2  # spectrum floor for the inverse-4th-root NS (two-sided warm start) so it stays bounded
 
 
 def _matrix_sqrt_ns(a, iters):
@@ -177,6 +184,22 @@ def _matrix_sqrt_ns(a, iters):
         y = y @ t
         z = t @ z
     return y, z
+
+
+def _pow4_inv_quarter(p, iters, floor, eps):
+    """(P^{1/4}, P^{-1/4}) for SPD P, via two trace-normalized coupled-sqrt-NS passes (matmul-only).
+
+    A = P/trace(P) has spectrum ≤ 1 (trace ≥ λ_max), so neither sqrt-NS pass can diverge. First pass →
+    A^{1/2}; second pass on A^{1/2} → A^{1/4} (Y) and, with a spectrum floor, the bounded/saturating
+    A^{-1/4} (Z). Rescale by trace^{±1/4}. The 4th-root inverse is gentler than P^{-1/2} (smaller exponent).
+    """
+    tr = jnp.trace(p) + eps
+    a = p / tr
+    eye = jnp.eye(p.shape[0], dtype=p.dtype)
+    a_half, _ = _matrix_sqrt_ns(a, iters)  # A^{1/2}
+    a_quarter, _ = _matrix_sqrt_ns(a_half, iters)  # A^{1/4} (forward; no floor needed)
+    _, a_inv_quarter = _matrix_sqrt_ns(a_half + floor * eye, iters)  # ≈ A^{-1/4}, floored ⟹ bounded
+    return tr**0.25 * a_quarter, tr**-0.25 * a_inv_quarter
 
 
 _MUON_NS_COEFFS = (3.4445, -4.7750, 2.0315)
@@ -212,11 +235,20 @@ def _mudam_direction(n_t, p, steps, eps):
     return x
 
 
+def _power_iter(mat, q, iters, eps):
+    for _ in range(int(iters)):
+        mq = mat @ q
+        q = mq / (jnp.linalg.norm(mq) + eps)
+    return q, jnp.dot(q, mat @ q) * _EMAX_MARGIN  # (updated q, inflated Rayleigh ≈ λ_max)
+
+
 def _curv_direction_2d(
     g,
     n,
     p,
     q,
+    p_r,
+    q_r,
     *,
     rho,
     lam_static,
@@ -230,53 +262,60 @@ def _curv_direction_2d(
     curv_power,
     mudam_init,
     mudam_steps,
+    two_sided,
+    floor,
 ):
-    """One matrix. g, n: [out, in] (gradient, Nesterov signal). p: [M, M], q: [M], M = max(out, in).
+    """One matrix. g, n: [out, in]; p/q = left Gram P_L [M,M] + power vec; p_r/q_r = right Gram P_R [N,N] + vec.
 
-    Inner fixed point X = msign( N + λ·(α√e_max·I − C)·X ), curvature term C = P/√e_max (curv_power="linear",
-    penalty ∝ p_i) or P^{1/2} (curv_power="sqrt", ∝ √p_i). C has max eigenvalue √e_max ⟹ α√e_max·I − C is PSD
-    for α≥1 ⟹ stable. lam_static gates on/off; lam_coef is the (possibly LR-tracked) coefficient. e_max(P)
-    via warm-started power iteration. mudam_init: warm-start X⁰ = msign(P^{-1/2} N) (the Mudam direction,
-    via the safe coupled-NS q_k product form, `mudam_steps` iterations) instead of msign(N).
+    one-sided (two_sided=False): X = msign(N + λ(α√e_max·I − C)X), C = P_L^{1/2} (sqrt) or P_L/√e_max (linear);
+    warm start msign(P_L^{-1/2} N) (Mudam q_k).
+    two-sided (two_sided=True): X = msign(N + λ(α(e_L·e_R)^{1/4}·X − P_L^{1/4} X P_R^{1/4})); warm start the
+    Shampoo direction msign(P_L^{-1/4} N P_R^{-1/4}). 1/4+1/4 = 1/2 total power ⟹ same ~G units, λ dimensionless.
+    Returns (new_p, new_q, new_p_r, new_q_r, x).
     """
     out, inn = g.shape
     transpose = out < inn
     g_t = g.T if transpose else g  # [M, N], M ≥ N
     n_t = n.T if transpose else n
 
-    new_p = rho * p + (1.0 - rho) * (g_t @ g_t.T)  # [M, M]
-    new_q = q
-    for _ in range(int(power_iters)):
-        pq = new_p @ new_q
-        new_q = pq / (jnp.linalg.norm(pq) + eps)
-    # Rayleigh quotient lower-bounds λ_max; inflate by the margin so α√e_max·I − C is strictly PSD.
-    emax = jnp.dot(new_q, new_p @ new_q) * _EMAX_MARGIN
-    se = jnp.sqrt(emax) + eps
+    new_p = rho * p + (1.0 - rho) * (g_t @ g_t.T)  # P_L [M, M]
+    new_q, emax = _power_iter(new_p, q, power_iters, eps)
     eye = jnp.eye(new_p.shape[0], dtype=new_p.dtype)
 
-    # Curvature term C.
+    if two_sided:
+        new_p_r = rho * p_r + (1.0 - rho) * (g_t.T @ g_t)  # P_R [N, N]
+        new_q_r, emax_r = _power_iter(new_p_r, q_r, power_iters, eps)
+        pl4, plinv4 = _pow4_inv_quarter(new_p, power_iters, floor, eps)  # P_L^{1/4}, P_L^{-1/4}
+        pr4, prinv4 = _pow4_inv_quarter(new_p_r, power_iters, floor, eps)  # P_R^{1/4}, P_R^{-1/4}
+        if mudam_init:
+            x = zeropower_via_newtonschulz5(plinv4 @ n_t @ prinv4, steps=steps, eps=eps, coefficient_type=ctype)
+        else:
+            x = zeropower_via_newtonschulz5(n_t, steps=steps, eps=eps, coefficient_type=ctype)
+        if lam_static > 0.0:
+            shift2 = alpha * (emax * emax_r) ** 0.25  # = max singular value of X ↦ P_L^{1/4} X P_R^{1/4}
+            for _ in range(int(inner_steps)):
+                arg = n_t + lam_coef * (shift2 * x - pl4 @ x @ pr4)
+                x = zeropower_via_newtonschulz5(arg, steps=steps, eps=eps, coefficient_type=ctype)
+        return new_p, new_q, new_p_r, new_q_r, (x.T if transpose else x)
+
+    # --- one-sided ---
+    se = jnp.sqrt(emax) + eps
     if curv_power == "sqrt":
-        # Normalize by trace(P) ≥ λ_max(P) (sum of nonneg eigenvalues), so P/tr has spectrum ≤ 1 and the
-        # coupled-NS sqrt CANNOT diverge. (Normalizing by the power-iteration e_max — a LOWER bound on
-        # λ_max — let P/e_max exceed 1 when the estimate lagged, blowing up the NS → NaN loss.)
+        # Normalize by trace(P) ≥ λ_max (sum of nonneg eigenvalues) ⟹ P/tr spectrum ≤ 1 ⟹ NS sqrt can't diverge.
         tr = jnp.trace(new_p) + eps
         y_half, _ = _matrix_sqrt_ns(new_p / tr, power_iters)
-        curv = jnp.sqrt(tr) * y_half  # = P^{1/2}, exact regardless of the (over-)normalization constant
+        curv = jnp.sqrt(tr) * y_half  # = P^{1/2}
     else:
         curv = new_p / se  # P/√e_max
-
-    # Warm start: Mudam direction msign(P^{-1/2} N) via the safe coupled-NS q_k (PR #6588), else msign(N).
     if mudam_init:
         x = _mudam_direction(n_t, new_p, mudam_steps, eps)
     else:
         x = zeropower_via_newtonschulz5(n_t, steps=steps, eps=eps, coefficient_type=ctype)
     if lam_static > 0.0:
-        operator = lam_coef * (alpha * se * eye - curv)  # PSD for α≥1: λ(α√e_max I − C)
+        operator = lam_coef * (alpha * se * eye - curv)  # PSD for α≥1
         for _ in range(int(inner_steps)):
             x = zeropower_via_newtonschulz5(n_t + operator @ x, steps=steps, eps=eps, coefficient_type=ctype)
-
-    x_out = x.T if transpose else x
-    return new_p, new_q, x_out
+    return new_p, new_q, p_r, q_r, (x.T if transpose else x)  # p_r/q_r passthrough
 
 
 def scale_with_curvature_muon(
@@ -290,6 +329,7 @@ def scale_with_curvature_muon(
     curvature_lambda=0.0,
     curvature_alpha=1.0,
     curv_power="sqrt",
+    two_sided=False,
     mudam_init=True,
     mudam_steps=5,
     inner_steps=1,
@@ -303,6 +343,7 @@ def scale_with_curvature_muon(
     lam = float(curvature_lambda)  # static peak strength (also the on/off switch)
     alpha = float(curvature_alpha)
     cpow = str(curv_power)
+    two_side = bool(two_sided)
     mudam = bool(mudam_init)
     mudam_k = int(mudam_steps)
     peak_lr = float(peak_lr)
@@ -329,9 +370,28 @@ def scale_with_curvature_muon(
             m = max(a.shape[-2], a.shape[-1])
             return jnp.broadcast_to(jnp.ones(m, dtype=a.dtype) / jnp.sqrt(m), a.shape[:-2] + (m,))
 
-        curvature = haliax.tree_util.tree_map(to_p, flat, is_leaf=_is_linear_weight)
-        power_vec = haliax.tree_util.tree_map(to_q, flat, is_leaf=_is_linear_weight)
-        return ScaleByCurvatureMuonState(momentum_buffer=momentum_buffer, curvature=curvature, power_vec=power_vec)
+        def to_p_r(layer):  # right Gram P_R [..., N, N], N = min(out, in)
+            if not _is_linear_weight(layer):
+                return layer
+            a = layer.weight.array
+            nn = min(a.shape[-2], a.shape[-1])
+            return jnp.broadcast_to(muon_eps * jnp.eye(nn, dtype=a.dtype), a.shape[:-2] + (nn, nn))
+
+        def to_q_r(layer):
+            if not _is_linear_weight(layer):
+                return layer
+            a = layer.weight.array
+            nn = min(a.shape[-2], a.shape[-1])
+            return jnp.broadcast_to(jnp.ones(nn, dtype=a.dtype) / jnp.sqrt(nn), a.shape[:-2] + (nn,))
+
+        tm = haliax.tree_util.tree_map
+        return ScaleByCurvatureMuonState(
+            momentum_buffer=momentum_buffer,
+            curvature=tm(to_p, flat, is_leaf=_is_linear_weight),
+            power_vec=tm(to_q, flat, is_leaf=_is_linear_weight),
+            curvature_r=tm(to_p_r, flat, is_leaf=_is_linear_weight),
+            power_vec_r=tm(to_q_r, flat, is_leaf=_is_linear_weight),
+        )
 
     def update_fn(updates, state, params=None):
         # Momentum buffer + scale-preserving Nesterov signal N = (1-μ)G + μB.
@@ -357,16 +417,18 @@ def scale_with_curvature_muon(
         # Effective coefficient: tracks the LR schedule when requested (traced scalar), else the static peak.
         lam_coef = lam * (learning_rate / peak_lr) if tracks_lr else lam
 
-        def per_layer(g_layer, n_layer, p, q):
+        def per_layer(g_layer, n_layer, p, q, p_r, q_r):
             if not _is_linear_weight(g_layer):
                 return n_layer  # passthrough (these are routed to adam/adamh anyway)
             g = g_layer.weight.array
             n = n_layer.weight.array
-            fn = lambda gg, nn, pp, qq: _curv_direction_2d(
+            fn = lambda gg, nn, pp, qq, ppr, qqr: _curv_direction_2d(
                 gg,
                 nn,
                 pp,
                 qq,
+                ppr,
+                qqr,
                 rho=rho,
                 lam_static=lam,
                 lam_coef=lam_coef,
@@ -379,19 +441,33 @@ def scale_with_curvature_muon(
                 curv_power=cpow,
                 mudam_init=mudam,
                 mudam_steps=mudam_k,
+                two_sided=two_side,
+                floor=_POW4_FLOOR,
             )
-            new_p, new_q, x = jax.vmap(fn)(g, n, p, q) if g.ndim == 3 else fn(g, n, p, q)
+            if g.ndim == 3:
+                new_p, new_q, new_p_r, new_q_r, x = jax.vmap(fn)(g, n, p, q, p_r, q_r)
+            else:
+                new_p, new_q, new_p_r, new_q_r, x = fn(g, n, p, q, p_r, q_r)
             new_w = dataclasses.replace(n_layer.weight, array=x)
-            return (dataclasses.replace(n_layer, weight=new_w), new_p, new_q)  # type: ignore
+            return (dataclasses.replace(n_layer, weight=new_w), new_p, new_q, new_p_r, new_q_r)  # type: ignore
 
         combined = haliax.tree_util.tree_map(
-            per_layer, flat_grad, flat_signal, state.curvature, state.power_vec, is_leaf=_is_linear_weight
+            per_layer,
+            flat_grad,
+            flat_signal,
+            state.curvature,
+            state.power_vec,
+            state.curvature_r,
+            state.power_vec_r,
+            is_leaf=_is_linear_weight,
         )
 
-        is_triple = lambda c: isinstance(c, tuple) and len(c) == 3
-        flat_dir = jax.tree.map(lambda c: c[0] if is_triple(c) else c, combined, is_leaf=is_triple)
-        new_curvature = jax.tree.map(lambda c: c[1] if is_triple(c) else c, combined, is_leaf=is_triple)
-        new_power = jax.tree.map(lambda c: c[2] if is_triple(c) else c, combined, is_leaf=is_triple)
+        is_tup = lambda c: isinstance(c, tuple) and len(c) == 5
+        flat_dir = jax.tree.map(lambda c: c[0] if is_tup(c) else c, combined, is_leaf=is_tup)
+        new_curvature = jax.tree.map(lambda c: c[1] if is_tup(c) else c, combined, is_leaf=is_tup)
+        new_power = jax.tree.map(lambda c: c[2] if is_tup(c) else c, combined, is_leaf=is_tup)
+        new_curvature_r = jax.tree.map(lambda c: c[3] if is_tup(c) else c, combined, is_leaf=is_tup)
+        new_power_r = jax.tree.map(lambda c: c[4] if is_tup(c) else c, combined, is_leaf=is_tup)
         direction = unflatten_linear_layers(signal, flat_dir)
 
         # Hyperball: constant-Frobenius-norm scale-invariant update (identical to MuonH).
@@ -413,7 +489,11 @@ def scale_with_curvature_muon(
             scale_invariant_update, params, direction, is_leaf=lambda x: x is None
         )
         return hyperball_updates, ScaleByCurvatureMuonState(
-            momentum_buffer=buf, curvature=new_curvature, power_vec=new_power
+            momentum_buffer=buf,
+            curvature=new_curvature,
+            power_vec=new_power,
+            curvature_r=new_curvature_r,
+            power_vec_r=new_power_r,
         )
 
     return optax.GradientTransformation(init_fn, update_fn)

--- a/lib/levanter/src/levanter/optim/curvature_muon.py
+++ b/lib/levanter/src/levanter/optim/curvature_muon.py
@@ -72,7 +72,8 @@ class CurvatureMuonConfig(OptimizerConfig):
     curvature_lambda: float = 0.0  # λ, curvature strength (0 ⟹ MuonH)
     curvature_alpha: float = 1.0  # α ≥ 1, multiplier on the √e_max shift (α=1 = boundary PSD)
     curv_power: str = "linear"  # "linear" (C = P/√e_max) or "sqrt" (C = P^{1/2})
-    mudam_init: bool = False  # sqrt mode: warm-start X⁰ = msign(P^{-1/2} N) (Mudam direction) vs msign(N)
+    mudam_init: bool = False  # warm-start X⁰ = msign(P^{-1/2} N) (Mudam direction, coupled-NS q_k) vs msign(N)
+    mudam_steps: int = 5  # coupled-NS steps for the Mudam warm-start (kept small — stable only under-converged)
     inner_steps: int = 1  # K, inner fixed-point iterations
     power_iters: int = 8  # power-iteration steps for e_max(P) (warm-started) + Newton-Schulz steps for P^{1/2}
     # If set, the curvature strength tracks the LR schedule: lambda_t = curvature_lambda * lr_t / peak_lr.
@@ -101,6 +102,7 @@ class CurvatureMuonConfig(OptimizerConfig):
                         self.curvature_alpha,
                         self.curv_power,
                         self.mudam_init,
+                        self.mudam_steps,
                         self.inner_steps,
                         self.power_iters,
                         self.learning_rate,
@@ -158,8 +160,6 @@ class ScaleByCurvatureMuonState(NamedTuple):
 
 
 _EMAX_MARGIN = 1.05  # inflate the (lower-bound) Rayleigh e_max estimate so the operator stays strictly PSD
-_SQRT_FLOOR = 1e-2  # floor the normalized spectrum before the matrix-sqrt NS so its Z~A^{-1/2} stays bounded
-#                    (P is low-rank early on → near-zero eigenvalues would blow up the coupled iteration)
 
 
 def _matrix_sqrt_ns(a, iters):
@@ -179,6 +179,39 @@ def _matrix_sqrt_ns(a, iters):
     return y, z
 
 
+_MUON_NS_COEFFS = (3.4445, -4.7750, 2.0315)
+
+
+def _mudam_direction(n_t, p, steps, eps):
+    """polar( P^{-1/2}_coarse · N ) via the Mudam coupled-NS product form (Muon coeffs, eigh-free).
+
+    Ports levanter.optim.mudam.ns_generalized (muon branch + another_muon): never materializes P^{-1/2};
+    the few-step, under-converged Muon-coeff iteration SATURATES, giving the stable q_k inverse-sqrt of
+    PR #6588 (= the Mudam inner direction). Used as the optional warm start X⁰ for the curvature fixed
+    point. `steps` is kept small (~5) — the iteration is only stable while under-converged.
+    """
+    a, b, c = _MUON_NS_COEFFS
+    m = p.shape[0]
+    eye = jnp.eye(m, dtype=p.dtype)
+    x = n_t  # [M, N]
+    pp = p - x @ x.T  # so A₀ = X Xᵀ + P = p (the curvature); +εI below guards indefiniteness
+    nf = jnp.sqrt(jnp.sqrt(jnp.trace(pp @ pp) + eps) + eps + jnp.linalg.norm(x) ** 2)
+    x = x / nf
+    pp = pp / (nf * nf) + eps * eye
+    for _ in range(int(steps)):
+        amat = x @ x.T + pp
+        bmat = b * amat + c * (amat @ amat)
+        x = a * x + bmat @ x
+        pp = a * a * pp + a * (bmat @ pp + pp @ bmat) + bmat @ pp @ bmat
+    # another_muon: re-orthogonalize (msign) the whitened direction
+    x = x / (jnp.linalg.norm(x) + eps)
+    for _ in range(int(steps)):
+        amat = x @ x.T
+        bmat = b * amat + c * (amat @ amat)
+        x = a * x + bmat @ x
+    return x
+
+
 def _curv_direction_2d(
     g,
     n,
@@ -196,14 +229,15 @@ def _curv_direction_2d(
     power_iters,
     curv_power,
     mudam_init,
+    mudam_steps,
 ):
     """One matrix. g, n: [out, in] (gradient, Nesterov signal). p: [M, M], q: [M], M = max(out, in).
 
     Inner fixed point X = msign( N + λ·(α√e_max·I − C)·X ), curvature term C = P/√e_max (curv_power="linear",
     penalty ∝ p_i) or P^{1/2} (curv_power="sqrt", ∝ √p_i). C has max eigenvalue √e_max ⟹ α√e_max·I − C is PSD
     for α≥1 ⟹ stable. lam_static gates on/off; lam_coef is the (possibly LR-tracked) coefficient. e_max(P)
-    via warm-started power iteration. mudam_init (sqrt mode only): warm-start X⁰ = msign(P^{-1/2} N) (the
-    Mudam direction, using the floored-NS inverse-sqrt iterate) instead of msign(N).
+    via warm-started power iteration. mudam_init: warm-start X⁰ = msign(P^{-1/2} N) (the Mudam direction,
+    via the safe coupled-NS q_k product form, `mudam_steps` iterations) instead of msign(N).
     """
     out, inn = g.shape
     transpose = out < inn
@@ -220,26 +254,22 @@ def _curv_direction_2d(
     se = jnp.sqrt(emax) + eps
     eye = jnp.eye(new_p.shape[0], dtype=new_p.dtype)
 
-    # Curvature term C (and, in sqrt mode, the inverse-sqrt iterate for the optional Mudam warm start).
+    # Curvature term C.
     if curv_power == "sqrt":
         # Normalize by trace(P) ≥ λ_max(P) (sum of nonneg eigenvalues), so P/tr has spectrum ≤ 1 and the
         # coupled-NS sqrt CANNOT diverge. (Normalizing by the power-iteration e_max — a LOWER bound on
         # λ_max — let P/e_max exceed 1 when the estimate lagged, blowing up the NS → NaN loss.)
         tr = jnp.trace(new_p) + eps
-        s_tr = jnp.sqrt(tr)
         y_half, _ = _matrix_sqrt_ns(new_p / tr, power_iters)
-        curv = s_tr * y_half  # = P^{1/2}, exact regardless of the (over-)normalization constant
-        if mudam_init:
-            # Inverse-sqrt iterate needs a spectrum floor (Z ~ A^{-1/2} blows up near 0) ⟹ separate floored NS.
-            _, z_inv = _matrix_sqrt_ns(new_p / tr + _SQRT_FLOOR * eye, power_iters)
-            x0_arg = z_inv @ n_t  # ∝ (P + floor·tr·I)^{-1/2} N; msign scale-invariant
-        else:
-            x0_arg = n_t
+        curv = jnp.sqrt(tr) * y_half  # = P^{1/2}, exact regardless of the (over-)normalization constant
     else:
         curv = new_p / se  # P/√e_max
-        x0_arg = n_t
 
-    x = zeropower_via_newtonschulz5(x0_arg, steps=steps, eps=eps, coefficient_type=ctype)
+    # Warm start: Mudam direction msign(P^{-1/2} N) via the safe coupled-NS q_k (PR #6588), else msign(N).
+    if mudam_init:
+        x = _mudam_direction(n_t, new_p, mudam_steps, eps)
+    else:
+        x = zeropower_via_newtonschulz5(n_t, steps=steps, eps=eps, coefficient_type=ctype)
     if lam_static > 0.0:
         operator = lam_coef * (alpha * se * eye - curv)  # PSD for α≥1: λ(α√e_max I − C)
         for _ in range(int(inner_steps)):
@@ -261,6 +291,7 @@ def scale_with_curvature_muon(
     curvature_alpha=1.0,
     curv_power="linear",
     mudam_init=False,
+    mudam_steps=5,
     inner_steps=1,
     power_iters=8,
     peak_lr=0.02,
@@ -273,6 +304,7 @@ def scale_with_curvature_muon(
     alpha = float(curvature_alpha)
     cpow = str(curv_power)
     mudam = bool(mudam_init)
+    mudam_k = int(mudam_steps)
     peak_lr = float(peak_lr)
     tracks_lr = bool(lambda_tracks_lr)
 
@@ -346,6 +378,7 @@ def scale_with_curvature_muon(
                 power_iters=power_iters,
                 curv_power=cpow,
                 mudam_init=mudam,
+                mudam_steps=mudam_k,
             )
             new_p, new_q, x = jax.vmap(fn)(g, n, p, q) if g.ndim == 3 else fn(g, n, p, q)
             new_w = dataclasses.replace(n_layer.weight, array=x)

--- a/lib/levanter/src/levanter/optim/curvature_muon.py
+++ b/lib/levanter/src/levanter/optim/curvature_muon.py
@@ -72,6 +72,7 @@ class CurvatureMuonConfig(OptimizerConfig):
     curvature_lambda: float = 0.0  # λ, curvature strength (0 ⟹ MuonH)
     curvature_alpha: float = 1.0  # α ≥ 1, multiplier on the √e_max shift (α=1 = boundary PSD)
     curv_power: str = "linear"  # "linear" (C = P/√e_max) or "sqrt" (C = P^{1/2})
+    mudam_init: bool = False  # sqrt mode: warm-start X⁰ = msign(P^{-1/2} N) (Mudam direction) vs msign(N)
     inner_steps: int = 1  # K, inner fixed-point iterations
     power_iters: int = 8  # power-iteration steps for e_max(P) (warm-started) + Newton-Schulz steps for P^{1/2}
     # If set, the curvature strength tracks the LR schedule: lambda_t = curvature_lambda * lr_t / peak_lr.
@@ -99,6 +100,7 @@ class CurvatureMuonConfig(OptimizerConfig):
                         self.curvature_lambda,
                         self.curvature_alpha,
                         self.curv_power,
+                        self.mudam_init,
                         self.inner_steps,
                         self.power_iters,
                         self.learning_rate,
@@ -161,9 +163,10 @@ _SQRT_FLOOR = 1e-2  # floor the normalized spectrum before the matrix-sqrt NS so
 
 
 def _matrix_sqrt_ns(a, iters):
-    """A^{1/2} for SPD A with spectrum in (0, 1], via the coupled Newton-Schulz (Denman–Beavers) Y-iterate.
+    """A^{1/2} and A^{-1/2} for SPD A with spectrum in (0, 1], via the coupled Newton-Schulz (Denman–Beavers).
 
-    Y → A^{1/2}, stable (Y stays bounded; we never read the inverse-sqrt Z). Matmul-only, no eigh.
+    Returns (Y, Z), Y → A^{1/2}, Z → A^{-1/2}. Matmul-only, no eigh. Stable as long as A's spectrum is
+    floored away from 0 (else Z blows up). Z is used for the optional Mudam-style P^{-1/2} N warm start.
     """
     n = a.shape[0]
     eye = jnp.eye(n, dtype=a.dtype)
@@ -173,18 +176,34 @@ def _matrix_sqrt_ns(a, iters):
         t = 1.5 * eye - 0.5 * (z @ y)
         y = y @ t
         z = t @ z
-    return y
+    return y, z
 
 
 def _curv_direction_2d(
-    g, n, p, q, *, rho, lam_static, lam_coef, alpha, steps, eps, ctype, inner_steps, power_iters, curv_power
+    g,
+    n,
+    p,
+    q,
+    *,
+    rho,
+    lam_static,
+    lam_coef,
+    alpha,
+    steps,
+    eps,
+    ctype,
+    inner_steps,
+    power_iters,
+    curv_power,
+    mudam_init,
 ):
     """One matrix. g, n: [out, in] (gradient, Nesterov signal). p: [M, M], q: [M], M = max(out, in).
 
-    Inner fixed point X = msign( N + λ·(√e_max·I − C)·X ), where the curvature term C is either
-    P/√e_max (curv_power="linear", penalty ∝ p_i) or P^{1/2} (curv_power="sqrt", penalty ∝ √p_i). Both
-    have max eigenvalue √e_max ⟹ √e_max·I − C is PSD ⟹ stable. lam_static gates on/off; lam_coef is the
-    coefficient (traced when it tracks the LR schedule). e_max(P) via warm-started power iteration.
+    Inner fixed point X = msign( N + λ·(α√e_max·I − C)·X ), curvature term C = P/√e_max (curv_power="linear",
+    penalty ∝ p_i) or P^{1/2} (curv_power="sqrt", ∝ √p_i). C has max eigenvalue √e_max ⟹ α√e_max·I − C is PSD
+    for α≥1 ⟹ stable. lam_static gates on/off; lam_coef is the (possibly LR-tracked) coefficient. e_max(P)
+    via warm-started power iteration. mudam_init (sqrt mode only): warm-start X⁰ = msign(P^{-1/2} N) (the
+    Mudam direction, using the floored-NS inverse-sqrt iterate) instead of msign(N).
     """
     out, inn = g.shape
     transpose = out < inn
@@ -196,18 +215,23 @@ def _curv_direction_2d(
     for _ in range(int(power_iters)):
         pq = new_p @ new_q
         new_q = pq / (jnp.linalg.norm(pq) + eps)
-    # Rayleigh quotient lower-bounds λ_max; inflate by the margin so √e_max·I − C is strictly PSD.
+    # Rayleigh quotient lower-bounds λ_max; inflate by the margin so α√e_max·I − C is strictly PSD.
     emax = jnp.dot(new_q, new_p @ new_q) * _EMAX_MARGIN
     se = jnp.sqrt(emax) + eps
+    eye = jnp.eye(new_p.shape[0], dtype=new_p.dtype)
 
-    x = zeropower_via_newtonschulz5(n_t, steps=steps, eps=eps, coefficient_type=ctype)
+    # Curvature term C (and, in sqrt mode, the inverse-sqrt iterate for the optional Mudam warm start).
+    if curv_power == "sqrt":
+        a_norm = new_p / (emax + eps) + _SQRT_FLOOR * eye  # floored to [_SQRT_FLOOR, <1]; +eps guards P≈0
+        y_half, z_inv = _matrix_sqrt_ns(a_norm, power_iters)
+        curv = se * y_half  # ≈ (P + _SQRT_FLOOR·e_max·I)^{1/2}
+        x0_arg = (z_inv @ n_t) if mudam_init else n_t  # z_inv ∝ (P + floor)^{-1/2}; msign scale-invariant
+    else:
+        curv = new_p / se  # P/√e_max
+        x0_arg = n_t
+
+    x = zeropower_via_newtonschulz5(x0_arg, steps=steps, eps=eps, coefficient_type=ctype)
     if lam_static > 0.0:
-        eye = jnp.eye(new_p.shape[0], dtype=new_p.dtype)
-        if curv_power == "sqrt":
-            a_norm = new_p / (emax + eps) + _SQRT_FLOOR * eye  # floored to [_SQRT_FLOOR, <1]; +eps guards P≈0
-            curv = se * _matrix_sqrt_ns(a_norm, power_iters)  # ≈ (P + _SQRT_FLOOR·e_max·I)^{1/2}
-        else:
-            curv = new_p / se  # P/√e_max
         operator = lam_coef * (alpha * se * eye - curv)  # PSD for α≥1: λ(α√e_max I − C)
         for _ in range(int(inner_steps)):
             x = zeropower_via_newtonschulz5(n_t + operator @ x, steps=steps, eps=eps, coefficient_type=ctype)
@@ -227,6 +251,7 @@ def scale_with_curvature_muon(
     curvature_lambda=0.0,
     curvature_alpha=1.0,
     curv_power="linear",
+    mudam_init=False,
     inner_steps=1,
     power_iters=8,
     peak_lr=0.02,
@@ -238,6 +263,7 @@ def scale_with_curvature_muon(
     lam = float(curvature_lambda)  # static peak strength (also the on/off switch)
     alpha = float(curvature_alpha)
     cpow = str(curv_power)
+    mudam = bool(mudam_init)
     peak_lr = float(peak_lr)
     tracks_lr = bool(lambda_tracks_lr)
 
@@ -310,6 +336,7 @@ def scale_with_curvature_muon(
                 inner_steps=inner_steps,
                 power_iters=power_iters,
                 curv_power=cpow,
+                mudam_init=mudam,
             )
             new_p, new_q, x = jax.vmap(fn)(g, n, p, q) if g.ndim == 3 else fn(g, n, p, q)
             new_w = dataclasses.replace(n_layer.weight, array=x)

--- a/lib/levanter/src/levanter/optim/curvature_muon.py
+++ b/lib/levanter/src/levanter/optim/curvature_muon.py
@@ -71,8 +71,8 @@ class CurvatureMuonConfig(OptimizerConfig):
     curvature_beta: float = 0.95  # ρ, EMA decay of P = EMA(G Gᵀ)
     curvature_lambda: float = 0.0  # λ, curvature strength (0 ⟹ MuonH)
     curvature_alpha: float = 1.0  # α ≥ 1, multiplier on the √e_max shift (α=1 = boundary PSD)
-    curv_power: str = "linear"  # "linear" (C = P/√e_max) or "sqrt" (C = P^{1/2})
-    mudam_init: bool = False  # warm-start X⁰ = msign(P^{-1/2} N) (Mudam direction, coupled-NS q_k) vs msign(N)
+    curv_power: str = "sqrt"  # "sqrt" (C = P^{1/2}, default) or "linear" (C = P/√e_max)
+    mudam_init: bool = True  # warm-start X⁰ = msign(P^{-1/2} N) (Mudam direction, coupled-NS q_k); default on
     mudam_steps: int = 5  # coupled-NS steps for the Mudam warm-start (kept small — stable only under-converged)
     inner_steps: int = 1  # K, inner fixed-point iterations
     power_iters: int = 8  # power-iteration steps for e_max(P) (warm-started) + Newton-Schulz steps for P^{1/2}
@@ -289,8 +289,8 @@ def scale_with_curvature_muon(
     curvature_beta=0.95,
     curvature_lambda=0.0,
     curvature_alpha=1.0,
-    curv_power="linear",
-    mudam_init=False,
+    curv_power="sqrt",
+    mudam_init=True,
     mudam_steps=5,
     inner_steps=1,
     power_iters=8,

--- a/lib/levanter/src/levanter/optim/curvature_muon.py
+++ b/lib/levanter/src/levanter/optim/curvature_muon.py
@@ -222,10 +222,19 @@ def _curv_direction_2d(
 
     # Curvature term C (and, in sqrt mode, the inverse-sqrt iterate for the optional Mudam warm start).
     if curv_power == "sqrt":
-        a_norm = new_p / (emax + eps) + _SQRT_FLOOR * eye  # floored to [_SQRT_FLOOR, <1]; +eps guards P≈0
-        y_half, z_inv = _matrix_sqrt_ns(a_norm, power_iters)
-        curv = se * y_half  # ≈ (P + _SQRT_FLOOR·e_max·I)^{1/2}
-        x0_arg = (z_inv @ n_t) if mudam_init else n_t  # z_inv ∝ (P + floor)^{-1/2}; msign scale-invariant
+        # Normalize by trace(P) ≥ λ_max(P) (sum of nonneg eigenvalues), so P/tr has spectrum ≤ 1 and the
+        # coupled-NS sqrt CANNOT diverge. (Normalizing by the power-iteration e_max — a LOWER bound on
+        # λ_max — let P/e_max exceed 1 when the estimate lagged, blowing up the NS → NaN loss.)
+        tr = jnp.trace(new_p) + eps
+        s_tr = jnp.sqrt(tr)
+        y_half, _ = _matrix_sqrt_ns(new_p / tr, power_iters)
+        curv = s_tr * y_half  # = P^{1/2}, exact regardless of the (over-)normalization constant
+        if mudam_init:
+            # Inverse-sqrt iterate needs a spectrum floor (Z ~ A^{-1/2} blows up near 0) ⟹ separate floored NS.
+            _, z_inv = _matrix_sqrt_ns(new_p / tr + _SQRT_FLOOR * eye, power_iters)
+            x0_arg = z_inv @ n_t  # ∝ (P + floor·tr·I)^{-1/2} N; msign scale-invariant
+        else:
+            x0_arg = n_t
     else:
         curv = new_p / se  # P/√e_max
         x0_arg = n_t

--- a/lib/levanter/src/levanter/optim/curvature_muon.py
+++ b/lib/levanter/src/levanter/optim/curvature_muon.py
@@ -63,15 +63,17 @@ class CurvatureMuonConfig(OptimizerConfig):
     max_grad_norm: float = 1.0
     coefficient_type: CoefficientType = "quintic"
     # --- curvature knobs ---
-    # Inner fixed point: X = msign( N + λ·(√e_max·I − P/√e_max)·X ), P = EMA(G Gᵀ), e_max = λ_max(P).
-    # The operator √e_max·I − P/√e_max is PSD (eigenvalues (e_max−p_i)/√e_max ≥ 0; 0 in the top-curvature
-    # direction, √e_max in flat ones), so the iteration is a contraction — stable at any λ (no α needed).
-    # P/√e_max has gradient units (P~G², so P/√e_max~G), matching N, so λ is dimensionless and its LR
-    # coupling is clean (no ‖N‖ factor). λ=0 ⟹ MuonH.
+    # Inner fixed point: X = msign( N + λ·(α·√e_max·I − C)·X ), P = EMA(G Gᵀ), e_max = λ_max(P), with the
+    # curvature term C = P/√e_max (curv_power="linear", penalty ∝ p_i) or P^{1/2} (curv_power="sqrt", ∝ √p_i).
+    # C has max eigenvalue √e_max, so α·√e_max·I − C is PSD for α ≥ 1 (α=1 zeroes the top-curvature
+    # direction; α>1 leaves a strictly-positive floor — gentler). C has gradient units (P~G² ⟹ C~G),
+    # matching N, so λ is dimensionless and its LR coupling is clean (no ‖N‖ factor). λ=0 ⟹ MuonH.
     curvature_beta: float = 0.95  # ρ, EMA decay of P = EMA(G Gᵀ)
     curvature_lambda: float = 0.0  # λ, curvature strength (0 ⟹ MuonH)
+    curvature_alpha: float = 1.0  # α ≥ 1, multiplier on the √e_max shift (α=1 = boundary PSD)
+    curv_power: str = "linear"  # "linear" (C = P/√e_max) or "sqrt" (C = P^{1/2})
     inner_steps: int = 1  # K, inner fixed-point iterations
-    power_iters: int = 8  # power-iteration steps for the e_max(P) estimate (warm-started from stored q)
+    power_iters: int = 8  # power-iteration steps for e_max(P) (warm-started) + Newton-Schulz steps for P^{1/2}
     # If set, the curvature strength tracks the LR schedule: lambda_t = curvature_lambda * lr_t / peak_lr.
     # So curvature is strongest at peak LR and fades during warmup / cosine decay (curvature_lambda = peak).
     lambda_tracks_lr: bool = False
@@ -95,6 +97,8 @@ class CurvatureMuonConfig(OptimizerConfig):
                         self.coefficient_type,
                         self.curvature_beta,
                         self.curvature_lambda,
+                        self.curvature_alpha,
+                        self.curv_power,
                         self.inner_steps,
                         self.power_iters,
                         self.learning_rate,
@@ -152,14 +156,35 @@ class ScaleByCurvatureMuonState(NamedTuple):
 
 
 _EMAX_MARGIN = 1.05  # inflate the (lower-bound) Rayleigh e_max estimate so the operator stays strictly PSD
+_SQRT_FLOOR = 1e-2  # floor the normalized spectrum before the matrix-sqrt NS so its Z~A^{-1/2} stays bounded
+#                    (P is low-rank early on → near-zero eigenvalues would blow up the coupled iteration)
 
 
-def _curv_direction_2d(g, n, p, q, *, rho, lam_static, lam_coef, steps, eps, ctype, inner_steps, power_iters):
+def _matrix_sqrt_ns(a, iters):
+    """A^{1/2} for SPD A with spectrum in (0, 1], via the coupled Newton-Schulz (Denman–Beavers) Y-iterate.
+
+    Y → A^{1/2}, stable (Y stays bounded; we never read the inverse-sqrt Z). Matmul-only, no eigh.
+    """
+    n = a.shape[0]
+    eye = jnp.eye(n, dtype=a.dtype)
+    y = a
+    z = eye
+    for _ in range(int(iters)):
+        t = 1.5 * eye - 0.5 * (z @ y)
+        y = y @ t
+        z = t @ z
+    return y
+
+
+def _curv_direction_2d(
+    g, n, p, q, *, rho, lam_static, lam_coef, alpha, steps, eps, ctype, inner_steps, power_iters, curv_power
+):
     """One matrix. g, n: [out, in] (gradient, Nesterov signal). p: [M, M], q: [M], M = max(out, in).
 
-    Inner fixed point X = msign( N + λ·(√e_max·I − P/√e_max)·X ). lam_static (python float) gates on/off;
-    lam_coef is the actual coefficient (a traced scalar when it tracks the LR schedule).
-    e_max(P) via a warm-started multi-step power iteration. Returns (new_p, new_q, x) in [out, in] orient.
+    Inner fixed point X = msign( N + λ·(√e_max·I − C)·X ), where the curvature term C is either
+    P/√e_max (curv_power="linear", penalty ∝ p_i) or P^{1/2} (curv_power="sqrt", penalty ∝ √p_i). Both
+    have max eigenvalue √e_max ⟹ √e_max·I − C is PSD ⟹ stable. lam_static gates on/off; lam_coef is the
+    coefficient (traced when it tracks the LR schedule). e_max(P) via warm-started power iteration.
     """
     out, inn = g.shape
     transpose = out < inn
@@ -171,14 +196,19 @@ def _curv_direction_2d(g, n, p, q, *, rho, lam_static, lam_coef, steps, eps, cty
     for _ in range(int(power_iters)):
         pq = new_p @ new_q
         new_q = pq / (jnp.linalg.norm(pq) + eps)
-    # Rayleigh quotient lower-bounds λ_max; inflate by the margin so √e_max·I − P/√e_max is strictly PSD.
+    # Rayleigh quotient lower-bounds λ_max; inflate by the margin so √e_max·I − C is strictly PSD.
     emax = jnp.dot(new_q, new_p @ new_q) * _EMAX_MARGIN
     se = jnp.sqrt(emax) + eps
 
     x = zeropower_via_newtonschulz5(n_t, steps=steps, eps=eps, coefficient_type=ctype)
     if lam_static > 0.0:
         eye = jnp.eye(new_p.shape[0], dtype=new_p.dtype)
-        operator = lam_coef * (se * eye - new_p / se)  # PSD: λ(√e_max I − P/√e_max)
+        if curv_power == "sqrt":
+            a_norm = new_p / (emax + eps) + _SQRT_FLOOR * eye  # floored to [_SQRT_FLOOR, <1]; +eps guards P≈0
+            curv = se * _matrix_sqrt_ns(a_norm, power_iters)  # ≈ (P + _SQRT_FLOOR·e_max·I)^{1/2}
+        else:
+            curv = new_p / se  # P/√e_max
+        operator = lam_coef * (alpha * se * eye - curv)  # PSD for α≥1: λ(α√e_max I − C)
         for _ in range(int(inner_steps)):
             x = zeropower_via_newtonschulz5(n_t + operator @ x, steps=steps, eps=eps, coefficient_type=ctype)
 
@@ -195,6 +225,8 @@ def scale_with_curvature_muon(
     coefficient_type="quintic",
     curvature_beta=0.95,
     curvature_lambda=0.0,
+    curvature_alpha=1.0,
+    curv_power="linear",
     inner_steps=1,
     power_iters=8,
     peak_lr=0.02,
@@ -204,6 +236,8 @@ def scale_with_curvature_muon(
     mu = float(momentum)
     rho = float(curvature_beta)
     lam = float(curvature_lambda)  # static peak strength (also the on/off switch)
+    alpha = float(curvature_alpha)
+    cpow = str(curv_power)
     peak_lr = float(peak_lr)
     tracks_lr = bool(lambda_tracks_lr)
 
@@ -269,11 +303,13 @@ def scale_with_curvature_muon(
                 rho=rho,
                 lam_static=lam,
                 lam_coef=lam_coef,
+                alpha=alpha,
                 steps=steps,
                 eps=muon_eps,
                 ctype=coefficient_type,
                 inner_steps=inner_steps,
                 power_iters=power_iters,
+                curv_power=cpow,
             )
             new_p, new_q, x = jax.vmap(fn)(g, n, p, q) if g.ndim == 3 else fn(g, n, p, q)
             new_w = dataclasses.replace(n_layer.weight, array=x)


### PR DESCRIPTION
## Curvature-corrected Muon (Nesterov + one-sided Shampoo curvature, hyperball)

A new optimizer that adds a **curvature correction** to the Muon update by approximately solving a
trust-region subproblem on the Stiefel manifold, on top of the **MuonH (hyperball)** base.

### The subproblem

Muon picks the orthogonal update direction `X` (with `XᵀX = I`) that maximizes `⟨N, X⟩` — the inner
product with the (Nesterov) momentum signal. Curvature-corrected Muon instead solves

```
max_{XᵀX=I}  ⟨N_t, X⟩  −  (λ/2)·tr(Xᵀ P_t X)
```

where `P_t ≈ EMA(G_t G_tᵀ)` is a **one-sided Shampoo (left/output) curvature** estimate. The penalty
discourages putting update energy into high-curvature output directions.

### The update (per matrix `W ∈ R^{m×n}`, oriented so `m ≥ n`; transpose `Wᵀ` otherwise)

```
B_t  ← μ B_{t-1} + (1−μ) G_t                      # momentum buffer
N_t  ← (1−μ) G_t + μ B_t                           # scale-preserving Nesterov signal
P_t  ← ρ P_{t-1} + (1−ρ) G_t G_tᵀ                  # one-sided curvature  (m×m)
q_t  ← P_t q_{t-1} / ‖P_t q_{t-1}‖                 # one power-iteration step
ℓ̂_t ← q_tᵀ P_t q_t                                 # Rayleigh est. of λ_max(P_t)
c_t  ← α λ ℓ̂_t                                      # shift, α ≥ 1 ⟹ (c_t I − λ P_t) ⪰ 0

X⁽⁰⁾ ← msign(N_t)                                  # = standard Nesterov Muon
for k = 0 … K−1:
    X⁽ᵏ⁺¹⁾ ← msign( N_t + (c_t I − λ P_t) X⁽ᵏ⁾ )    # curvature-corrected fixed point
X_t  ← X⁽ᴷ⁾
```

`msign` is the usual Muon Newton–Schulz orthogonalization (`msign(A)=UVᵀ`). The curvature touches the
update **only through matmuls and one power iteration — no `eigh`** (TPU-friendly, unlike a Shampoo
`H^{-1/2}`).

### Hyperball integration

Like MuonH, the orthogonal direction `X_t` is then mapped through the **scale-invariant (hyperball)
constant-norm reparam** instead of the `√(Out/In)` scaling — each matrix's Frobenius norm is held at
its initialization value:

```
W_{t+1} = (W_t − η_t X_t·‖W‖/‖X_t‖) normalized back to ‖W‖
```

### Special cases (built-in sanity checks)

- **λ = 0** ⟹ `c_t = 0`, the curvature term vanishes, and the algorithm is **exactly MuonH** (Nesterov
  Muon + hyperball). This is the control and must reproduce the MuonH baseline.
- **K = 1** ⟹ one curvature-corrected polishing step on top of Muon:
  `X_t = msign(N_t + (c_t I − λ P_t)·msign(N_t))`.

### Base configuration — MuonH qwen3-130m speedrun submission

All non-curvature hypers are held at the MuonH 130m submission (`origin/qwen3-speedrun-muonh`,
run `qwen3_130m_muonh_4096_lrx1`, **eval/paloma/c4_en/bpb = 1.1661**):

| | |
|---|---|
| learning_rate | 0.02 |
| adam_lr | 4.615e-3 |
| momentum (μ) | 0.95 |
| beta1 / beta2 | 0.9 / 0.98 |
| epsilon | 1e-15 |
| muon_epsilon | 1e-5 |
| weight_decay | 0.1 |
| max_grad_norm | 1.0 |
| NS | quintic, 5 steps |
| schedule | cosine, warmup 1000, min_lr_ratio 0 |
| steps / batch / seq | 4959 / 128 / 4096 |
| data / model | fineweb-edu-10B / qwen3-130m (llama_150m shape) |

New curvature knobs: `curvature_beta (ρ)=0.95`, `curvature_lambda (λ)`, `curvature_alpha (α)`,
`inner_steps (K)`.

### What actually controls the curvature: α, not λ (offline diagnostic)

With the dimensionless (`normalize_curvature=True`) operator `λ‖N‖(αI − P̂)`, `P̂ = P/λ̂_max`, an offline
test on a realistic anisotropic `P` (cond ~1e3) measured how much the curvature rotates the Muon
direction `X⁰ = msign(N)` (K=1):

| α | cos(X¹, X⁰) | direction change |
|---|---|---|
| **1.0** | 0.87–0.90 | **~50%** (P dominant; top-curvature direction zeroed) |
| 1.2 | 0.92–0.95 | ~37% |
| 1.5 | 0.98–0.99 | ~15% |
| 2.0 | 0.995 | ~9%, λ-independent (scalar floor swamps P ⟹ ≈ MuonH) |

**α is the real dial.** The operator eigenvalues are `(α − p̂_i) ∈ [α−1, α]`; the scalar floor `α−1`
(which washes through `msign`) competes with the anisotropic `−P̂`. So α→1 = pure curvature (the
highest-curvature direction is fully suppressed), α large ⟹ P negligible. The spec's recommended
α∈[1.2,2] is the *diluted* end. **λ saturates** above ~0.3 (once the curvature term dominates `N` inside
`msign`, λ's scale stops mattering) — so λ is a coarse on/off, α is the fine control.

### Experiment plan (v6e-8 preemptible, us-east5, W&B marin-community/speedrun)

Hold everything at the MuonH submission; sweep **α (primary) × K**, with λ as on/off:

- `λ = 0` — control, must match MuonH 1.1661.
- `λ = 1.0` (curvature on, saturated regime) × `α ∈ {1.0, 1.2, 1.5}` × `K ∈ {1, 2}`.

Compare on **eval/paloma/c4_en/bpb** vs MuonH 1.1661. α=1.0 is the aggressive curvature test; α=1.5 is
near the spec's conservative regime; K=2 tests whether iterating the fixed point sharpens it. A λ
sensitivity sweep is a fast follow-up if any α beats MuonH.
