### PR TITLE
feat: add cache_to_prefix for distributed-locked model snapshot caching

### DIFF
--- a/lib/levanter/src/levanter/__init__.py
+++ b/lib/levanter/src/levanter/__init__.py
@@ -19,6 +19,7 @@ __all__ = [
     "trainer",
     "grug",
     "cache_to_prefix",
+    "cache_hf_model",
     "current_tracker",
     "initialize",
 ]
@@ -35,7 +36,7 @@ import levanter.optim as optim
 import levanter.tracker as tracker
 import levanter.trainer as trainer
 import levanter.grug as grug
-from levanter.model_cache import cache_to_prefix
+from levanter.model_cache import cache_hf_model, cache_to_prefix
 from levanter.tracker import current_tracker
 from levanter.trainer import initialize
 

--- a/lib/levanter/src/levanter/__init__.py
+++ b/lib/levanter/src/levanter/__init__.py
@@ -12,11 +12,13 @@ __all__ = [
     "distributed",
     "eval",
     "eval_harness",
+    "model_cache",
     "models",
     "optim",
     "tracker",
     "trainer",
     "grug",
+    "cache_to_prefix",
     "current_tracker",
     "initialize",
 ]
@@ -27,11 +29,13 @@ import levanter.checkpoint as checkpoint
 import levanter.config as config
 import levanter.data as data
 import levanter.distributed as distributed
+import levanter.model_cache as model_cache
 import levanter.models as models
 import levanter.optim as optim
 import levanter.tracker as tracker
 import levanter.trainer as trainer
 import levanter.grug as grug
+from levanter.model_cache import cache_to_prefix
 from levanter.tracker import current_tracker
 from levanter.trainer import initialize
 

--- a/lib/levanter/src/levanter/model_cache.py
+++ b/lib/levanter/src/levanter/model_cache.py
@@ -8,24 +8,28 @@ bandwidth. :func:`cache_to_prefix` mirrors a snapshot once to a shared cache
 prefix (typically a region-local TTL bucket from
 :func:`rigging.filesystem.marin_temp_bucket`) under a distributed lock, so
 concurrent workers do not all hammer HuggingFace at the same time: the first
-worker downloads and uploads while the rest **block** until the cache is
-populated, then read the snapshot from the nearby cache.
+worker populates the cache while the rest **block** until it is complete, then
+read the snapshot from the nearby cache.
 
-The download is injected as a callback so this module stays free of any
-``huggingface_hub`` dependency; callers bind ``snapshot_download`` (or any other
-populator) themselves.
+The populate step streams **directly into the cache filesystem** — there is no
+full local copy of the snapshot. :func:`cache_hf_model` is the easy path for the
+common case (mirror an HF repo by id), downloading and uploading one file at a
+time so a multi-hundred-GB repo never has to fit on local disk. :func:`cache_to_prefix`
+takes an arbitrary populate callback for callers that need a custom source.
 """
 
 from __future__ import annotations
 
 import contextlib
 import logging
+import os
 import tempfile
 import threading
 import time
 from collections.abc import Callable, Generator
 
 import fsspec
+from huggingface_hub import hf_hub_download, list_repo_files
 from rigging.distributed_lock import HEARTBEAT_INTERVAL, DistributedLease, LeaseLostError, create_lock
 
 logger = logging.getLogger(__name__)
@@ -34,26 +38,30 @@ DEFAULT_COMPLETE_MARKER = ".cache_complete"
 """Marker written last after a full upload; its presence is the cache-hit signal."""
 
 _LOCK_SUFFIX = ".lock"
-# How often losers re-check the completion marker while the winner downloads.
+# How often losers re-check the completion marker while the winner populates.
 _DEFAULT_POLL_INTERVAL = 10.0
+
+# A populate callback streams the snapshot into ``cache_path`` on the given
+# filesystem. It must write every file but NOT the completion marker (the cache
+# writes that last so a crashed populate never reads as a hit).
+Populate = Callable[[fsspec.AbstractFileSystem, str], None]
 
 
 def cache_to_prefix(
     cache_path: str,
-    download: Callable[[str], None],
+    populate: Populate,
     *,
     complete_marker: str = DEFAULT_COMPLETE_MARKER,
     poll_interval: float = _DEFAULT_POLL_INTERVAL,
 ) -> str:
-    """Populate *cache_path* once under a distributed lock and return a loadable path.
+    """Populate *cache_path* once under a distributed lock and return it.
 
     Fast path: if the completion marker already exists, return ``cache_path``
     immediately. Otherwise acquire a distributed lock keyed on ``cache_path``:
 
-    - The **winner** downloads into a fresh local temp dir via ``download``,
-      uploads the result to ``cache_path``, writes the marker last (so a crashed
-      upload never reads as a hit), and returns the **local temp dir** — a fast
-      local read that avoids re-reading what it just uploaded.
+    - The **winner** runs ``populate`` (which streams files straight into the
+      cache filesystem), writes the marker last (so a crashed populate never
+      reads as a hit), and returns ``cache_path``.
     - **Losers** block, polling for the marker every ``poll_interval`` seconds,
       then return ``cache_path`` once the winner finishes. If the holder dies
       without completing (its lease goes stale), a loser takes over and becomes
@@ -62,15 +70,15 @@ def cache_to_prefix(
     Args:
         cache_path: Destination prefix for the mirrored snapshot (any fsspec
             path, e.g. ``gs://…`` or a local directory).
-        download: Callback that populates the local directory passed to it with
-            the files to cache. Typically binds ``snapshot_download``.
+        populate: Callback ``(fs, cache_path) -> None`` that streams the snapshot
+            into ``cache_path`` on filesystem ``fs``. Use :func:`cache_hf_model`
+            for the common HF-repo case instead of writing one by hand.
         complete_marker: Filename (relative to ``cache_path``) written last to
             mark the cache complete.
         poll_interval: Seconds a blocked worker waits between marker re-checks.
 
     Returns:
-        A path that the caller can load the snapshot from: the local temp dir for
-        the worker that populated the cache, or ``cache_path`` otherwise.
+        ``cache_path`` — a path the caller can load the snapshot from.
     """
     cache_path = cache_path.rstrip("/")
     fs, _ = fsspec.core.url_to_fs(cache_path)
@@ -95,21 +103,71 @@ def cache_to_prefix(
             logger.info("model cache populated while acquiring lock: %s", cache_path)
             return cache_path
         with _heartbeat(lock):
-            return _populate(fs, cache_path, marker, download)
+            _populate(fs, cache_path, marker, populate)
+        return cache_path
     finally:
         lock.release()
 
 
-def _populate(fs: fsspec.AbstractFileSystem, cache_path: str, marker: str, download: Callable[[str], None]) -> str:
-    """Download to a local temp dir, mirror it to *cache_path*, then write *marker*."""
-    logger.info("model cache miss; downloading to populate %s", cache_path)
-    local_dir = tempfile.mkdtemp(prefix="model_cache_")
-    download(local_dir)
-    fs.put(f"{local_dir.rstrip('/')}/", f"{cache_path}/", recursive=True)
-    # Marker last: its presence is the cache-hit signal, so a crashed upload won't read as complete.
+def cache_hf_model(
+    cache_path: str,
+    model_id: str,
+    *,
+    revision: str | None = None,
+    complete_marker: str = DEFAULT_COMPLETE_MARKER,
+    poll_interval: float = _DEFAULT_POLL_INTERVAL,
+) -> str:
+    """Mirror HuggingFace repo *model_id* to *cache_path* once under a distributed lock.
+
+    The easy path over :func:`cache_to_prefix`: streams the repo into the cache
+    one file at a time (see :func:`_stream_hf_snapshot`), so the snapshot never
+    has to fit on local disk. Returns ``cache_path``.
+
+    Args:
+        cache_path: Destination prefix for the mirrored snapshot.
+        model_id: HuggingFace repo id, e.g. ``Qwen/Qwen3-0.6B``.
+        revision: Optional git revision (branch, tag, or commit) to mirror.
+        complete_marker: Filename written last to mark the cache complete.
+        poll_interval: Seconds a blocked worker waits between marker re-checks.
+    """
+    return cache_to_prefix(
+        cache_path,
+        lambda fs, dest: _stream_hf_snapshot(fs, dest, model_id, revision),
+        complete_marker=complete_marker,
+        poll_interval=poll_interval,
+    )
+
+
+def _stream_hf_snapshot(fs: fsspec.AbstractFileSystem, dest: str, model_id: str, revision: str | None) -> None:
+    """Copy every file of HF repo *model_id* into *dest*, one file at a time.
+
+    Each file is downloaded to a scratch dir, uploaded to ``dest``, then deleted
+    before the next download, so peak local disk is one file rather than the full
+    repo.
+    """
+    filenames = list_repo_files(model_id, revision=revision)
+    logger.info("streaming %d files from HF repo %s into %s", len(filenames), model_id, dest)
+    with tempfile.TemporaryDirectory(prefix="hf_stream_") as scratch:
+        for filename in filenames:
+            local_path = hf_hub_download(model_id, filename, revision=revision, local_dir=scratch)
+            remote_path = f"{dest}/{filename}"
+            # Local/posix-backed fsspec filesystems don't auto-create parents; object
+            # stores treat this as a no-op since they have no real directories.
+            fs.makedirs(remote_path.rsplit("/", 1)[0], exist_ok=True)
+            fs.put_file(local_path, remote_path)
+            os.remove(local_path)
+
+
+def _populate(fs: fsspec.AbstractFileSystem, cache_path: str, marker: str, populate: Populate) -> None:
+    """Stream the snapshot into *cache_path* via *populate*, then write *marker*."""
+    logger.info("model cache miss; populating %s", cache_path)
+    # Object stores have no real directories, but local/posix-backed fsspec
+    # filesystems need the prefix to exist before files are written into it.
+    fs.makedirs(cache_path, exist_ok=True)
+    populate(fs, cache_path)
+    # Marker last: its presence is the cache-hit signal, so a crashed populate won't read as complete.
     with fs.open(marker, "w") as handle:
         handle.write("ok")
-    return local_dir
 
 
 @contextlib.contextmanager

--- a/lib/levanter/src/levanter/model_cache.py
+++ b/lib/levanter/src/levanter/model_cache.py
@@ -1,0 +1,140 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Distributed-locked caching of model snapshots to a shared prefix.
+
+Downloading a large model repo from HuggingFace on every job is slow and wastes
+bandwidth. :func:`cache_to_prefix` mirrors a snapshot once to a shared cache
+prefix (typically a region-local TTL bucket from
+:func:`rigging.filesystem.marin_temp_bucket`) under a distributed lock, so
+concurrent workers do not all hammer HuggingFace at the same time: the first
+worker downloads and uploads while the rest **block** until the cache is
+populated, then read the snapshot from the nearby cache.
+
+The download is injected as a callback so this module stays free of any
+``huggingface_hub`` dependency; callers bind ``snapshot_download`` (or any other
+populator) themselves.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import logging
+import tempfile
+import threading
+import time
+from collections.abc import Callable, Generator
+
+import fsspec
+from rigging.distributed_lock import HEARTBEAT_INTERVAL, DistributedLease, LeaseLostError, create_lock
+
+logger = logging.getLogger(__name__)
+
+DEFAULT_COMPLETE_MARKER = ".cache_complete"
+"""Marker written last after a full upload; its presence is the cache-hit signal."""
+
+_LOCK_SUFFIX = ".lock"
+# How often losers re-check the completion marker while the winner downloads.
+_DEFAULT_POLL_INTERVAL = 10.0
+
+
+def cache_to_prefix(
+    cache_path: str,
+    download: Callable[[str], None],
+    *,
+    complete_marker: str = DEFAULT_COMPLETE_MARKER,
+    poll_interval: float = _DEFAULT_POLL_INTERVAL,
+) -> str:
+    """Populate *cache_path* once under a distributed lock and return a loadable path.
+
+    Fast path: if the completion marker already exists, return ``cache_path``
+    immediately. Otherwise acquire a distributed lock keyed on ``cache_path``:
+
+    - The **winner** downloads into a fresh local temp dir via ``download``,
+      uploads the result to ``cache_path``, writes the marker last (so a crashed
+      upload never reads as a hit), and returns the **local temp dir** — a fast
+      local read that avoids re-reading what it just uploaded.
+    - **Losers** block, polling for the marker every ``poll_interval`` seconds,
+      then return ``cache_path`` once the winner finishes. If the holder dies
+      without completing (its lease goes stale), a loser takes over and becomes
+      the new winner.
+
+    Args:
+        cache_path: Destination prefix for the mirrored snapshot (any fsspec
+            path, e.g. ``gs://…`` or a local directory).
+        download: Callback that populates the local directory passed to it with
+            the files to cache. Typically binds ``snapshot_download``.
+        complete_marker: Filename (relative to ``cache_path``) written last to
+            mark the cache complete.
+        poll_interval: Seconds a blocked worker waits between marker re-checks.
+
+    Returns:
+        A path that the caller can load the snapshot from: the local temp dir for
+        the worker that populated the cache, or ``cache_path`` otherwise.
+    """
+    cache_path = cache_path.rstrip("/")
+    fs, _ = fsspec.core.url_to_fs(cache_path)
+    marker = f"{cache_path}/{complete_marker}"
+
+    if fs.exists(marker):
+        logger.info("model cache hit: %s", cache_path)
+        return cache_path
+
+    lock = create_lock(f"{cache_path}{_LOCK_SUFFIX}")
+    while not lock.try_acquire():
+        # Another worker is populating the cache; block then re-check the marker
+        # rather than piling another download onto HuggingFace.
+        if fs.exists(marker):
+            logger.info("model cache populated by another worker: %s", cache_path)
+            return cache_path
+        time.sleep(poll_interval)
+
+    try:
+        # A prior holder may have finished while we were acquiring the lock.
+        if fs.exists(marker):
+            logger.info("model cache populated while acquiring lock: %s", cache_path)
+            return cache_path
+        with _heartbeat(lock):
+            return _populate(fs, cache_path, marker, download)
+    finally:
+        lock.release()
+
+
+def _populate(fs: fsspec.AbstractFileSystem, cache_path: str, marker: str, download: Callable[[str], None]) -> str:
+    """Download to a local temp dir, mirror it to *cache_path*, then write *marker*."""
+    logger.info("model cache miss; downloading to populate %s", cache_path)
+    local_dir = tempfile.mkdtemp(prefix="model_cache_")
+    download(local_dir)
+    fs.put(f"{local_dir.rstrip('/')}/", f"{cache_path}/", recursive=True)
+    # Marker last: its presence is the cache-hit signal, so a crashed upload won't read as complete.
+    with fs.open(marker, "w") as handle:
+        handle.write("ok")
+    return local_dir
+
+
+@contextlib.contextmanager
+def _heartbeat(lock: DistributedLease) -> Generator[None, None, None]:
+    """Refresh *lock*'s lease on a daemon thread for the duration of the block.
+
+    A large download can take far longer than ``HEARTBEAT_TIMEOUT``; without
+    refreshing, blocked workers would treat the lease as stale and start their
+    own downloads. ``LeaseLostError`` is logged but not raised: a duplicate
+    download is wasteful but not incorrect (the marker-last write stays atomic).
+    """
+    stop = threading.Event()
+
+    def _beat() -> None:
+        while not stop.wait(HEARTBEAT_INTERVAL):
+            try:
+                lock.refresh()
+            except LeaseLostError:
+                logger.error("Lease lost for %s while populating cache", lock.lock_path, exc_info=True)
+                return
+
+    thread = threading.Thread(target=_beat, daemon=True)
+    thread.start()
+    try:
+        yield
+    finally:
+        stop.set()
+        thread.join(timeout=5)

--- a/lib/levanter/tests/test_model_cache.py
+++ b/lib/levanter/tests/test_model_cache.py
@@ -8,56 +8,61 @@ import time
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
-from levanter.model_cache import DEFAULT_COMPLETE_MARKER, cache_to_prefix
+import fsspec
+
+import levanter.model_cache as model_cache
+from levanter.model_cache import DEFAULT_COMPLETE_MARKER, cache_hf_model, cache_to_prefix
 
 
-def _make_download(call_count: list[int], lock: threading.Lock, *, delay: float = 0.0):
-    """Return a download callback that records invocations and writes a payload."""
+def _make_populate(call_count: list[int], lock: threading.Lock, *, delay: float = 0.0):
+    """Return a populate callback that records invocations and streams a payload to the cache."""
 
-    def download(local_dir: str) -> None:
+    def populate(fs: fsspec.AbstractFileSystem, dest: str) -> None:
         with lock:
             call_count.append(1)
         if delay:
             time.sleep(delay)
-        Path(local_dir, "weights.bin").write_text("payload")
+        with fs.open(f"{dest}/weights.bin", "w") as handle:
+            handle.write("payload")
 
-    return download
+    return populate
 
 
-def test_concurrent_callers_download_once(tmp_path):
-    """Under N concurrent callers only one download runs; the rest get the cached path."""
+def test_concurrent_callers_populate_once(tmp_path):
+    """Under N concurrent callers only one populate runs; all get the cached path."""
     cache_path = str(tmp_path / "cache" / "model")
     calls: list[int] = []
     count_lock = threading.Lock()
-    # A non-trivial download window forces losers to actually block on the lock
+    # A non-trivial populate window forces losers to actually block on the lock
     # instead of all winning the marker fast-path on the first check.
-    download = _make_download(calls, count_lock, delay=0.3)
+    populate = _make_populate(calls, count_lock, delay=0.3)
 
     def run() -> str:
-        return cache_to_prefix(cache_path, download, poll_interval=0.02)
+        return cache_to_prefix(cache_path, populate, poll_interval=0.02)
 
     with ThreadPoolExecutor(max_workers=8) as pool:
         results = list(pool.map(lambda _: run(), range(8)))
 
-    assert len(calls) == 1, f"expected a single download, got {len(calls)}"
+    assert len(calls) == 1, f"expected a single populate, got {len(calls)}"
     assert Path(cache_path, DEFAULT_COMPLETE_MARKER).exists()
-    # Every caller returns a path containing the populated snapshot.
+    # Every caller returns the cache path holding the populated snapshot.
     for path in results:
+        assert path == cache_path.rstrip("/")
         assert Path(path, "weights.bin").read_text() == "payload"
 
 
-def test_cache_hit_skips_download(tmp_path):
-    """A second call after the marker exists returns the cache path without downloading."""
+def test_cache_hit_skips_populate(tmp_path):
+    """A second call after the marker exists returns the cache path without re-populating."""
     cache_path = str(tmp_path / "cache" / "model")
     calls: list[int] = []
     count_lock = threading.Lock()
-    download = _make_download(calls, count_lock)
+    populate = _make_populate(calls, count_lock)
 
-    first = cache_to_prefix(cache_path, download)
-    second = cache_to_prefix(cache_path, download)
+    first = cache_to_prefix(cache_path, populate)
+    second = cache_to_prefix(cache_path, populate)
 
     assert len(calls) == 1
-    assert second == cache_path.rstrip("/")
+    assert first == second == cache_path.rstrip("/")
     assert Path(first, "weights.bin").read_text() == "payload"
 
 
@@ -66,10 +71,43 @@ def test_custom_complete_marker(tmp_path):
     cache_path = str(tmp_path / "cache" / "model")
     calls: list[int] = []
     count_lock = threading.Lock()
-    download = _make_download(calls, count_lock)
+    populate = _make_populate(calls, count_lock)
 
-    cache_to_prefix(cache_path, download, complete_marker=".done")
+    cache_to_prefix(cache_path, populate, complete_marker=".done")
     assert Path(cache_path, ".done").exists()
 
-    cache_to_prefix(cache_path, download, complete_marker=".done")
+    cache_to_prefix(cache_path, populate, complete_marker=".done")
     assert len(calls) == 1
+
+
+def test_cache_hf_model_streams_one_file_at_a_time(tmp_path, monkeypatch):
+    """cache_hf_model mirrors every repo file and keeps only one on local disk at a time."""
+    repo_files = ["config.json", "model.safetensors", "tokenizer.json"]
+    max_local_files = 0
+
+    def fake_list_repo_files(model_id, revision=None):
+        assert model_id == "org/model"
+        return repo_files
+
+    def fake_hf_hub_download(model_id, filename, revision=None, local_dir=None):
+        nonlocal max_local_files
+        local_path = Path(local_dir, filename)
+        local_path.parent.mkdir(parents=True, exist_ok=True)
+        local_path.write_text(f"contents of {filename}")
+        # The streamer must delete each file before fetching the next: peak local
+        # footprint is one file, not the whole repo.
+        present = [p for p in Path(local_dir).rglob("*") if p.is_file()]
+        max_local_files = max(max_local_files, len(present))
+        return str(local_path)
+
+    monkeypatch.setattr(model_cache, "list_repo_files", fake_list_repo_files)
+    monkeypatch.setattr(model_cache, "hf_hub_download", fake_hf_hub_download)
+
+    cache_path = str(tmp_path / "cache" / "model")
+    result = cache_hf_model(cache_path, "org/model")
+
+    assert result == cache_path
+    assert max_local_files == 1, f"expected at most one staged file, saw {max_local_files}"
+    for filename in repo_files:
+        assert Path(cache_path, filename).read_text() == f"contents of {filename}"
+    assert Path(cache_path, DEFAULT_COMPLETE_MARKER).exists()

--- a/lib/levanter/tests/test_model_cache.py
+++ b/lib/levanter/tests/test_model_cache.py
@@ -1,0 +1,75 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the distributed-locked model snapshot cache."""
+
+import threading
+import time
+from concurrent.futures import ThreadPoolExecutor
+from pathlib import Path
+
+from levanter.model_cache import DEFAULT_COMPLETE_MARKER, cache_to_prefix
+
+
+def _make_download(call_count: list[int], lock: threading.Lock, *, delay: float = 0.0):
+    """Return a download callback that records invocations and writes a payload."""
+
+    def download(local_dir: str) -> None:
+        with lock:
+            call_count.append(1)
+        if delay:
+            time.sleep(delay)
+        Path(local_dir, "weights.bin").write_text("payload")
+
+    return download
+
+
+def test_concurrent_callers_download_once(tmp_path):
+    """Under N concurrent callers only one download runs; the rest get the cached path."""
+    cache_path = str(tmp_path / "cache" / "model")
+    calls: list[int] = []
+    count_lock = threading.Lock()
+    # A non-trivial download window forces losers to actually block on the lock
+    # instead of all winning the marker fast-path on the first check.
+    download = _make_download(calls, count_lock, delay=0.3)
+
+    def run() -> str:
+        return cache_to_prefix(cache_path, download, poll_interval=0.02)
+
+    with ThreadPoolExecutor(max_workers=8) as pool:
+        results = list(pool.map(lambda _: run(), range(8)))
+
+    assert len(calls) == 1, f"expected a single download, got {len(calls)}"
+    assert Path(cache_path, DEFAULT_COMPLETE_MARKER).exists()
+    # Every caller returns a path containing the populated snapshot.
+    for path in results:
+        assert Path(path, "weights.bin").read_text() == "payload"
+
+
+def test_cache_hit_skips_download(tmp_path):
+    """A second call after the marker exists returns the cache path without downloading."""
+    cache_path = str(tmp_path / "cache" / "model")
+    calls: list[int] = []
+    count_lock = threading.Lock()
+    download = _make_download(calls, count_lock)
+
+    first = cache_to_prefix(cache_path, download)
+    second = cache_to_prefix(cache_path, download)
+
+    assert len(calls) == 1
+    assert second == cache_path.rstrip("/")
+    assert Path(first, "weights.bin").read_text() == "payload"
+
+
+def test_custom_complete_marker(tmp_path):
+    """The completion marker name is configurable and gates the cache-hit fast path."""
+    cache_path = str(tmp_path / "cache" / "model")
+    calls: list[int] = []
+    count_lock = threading.Lock()
+    download = _make_download(calls, count_lock)
+
+    cache_to_prefix(cache_path, download, complete_marker=".done")
+    assert Path(cache_path, ".done").exists()
+
+    cache_to_prefix(cache_path, download, complete_marker=".done")
+    assert len(calls) == 1

--- a/lib/marin/src/marin/inference/quick_serve.py
+++ b/lib/marin/src/marin/inference/quick_serve.py
@@ -25,11 +25,10 @@ from dataclasses import dataclass, field
 
 import fsspec
 import requests
-from huggingface_hub import snapshot_download
 from iris.client import iris_ctx
 from iris.cluster.client.job_info import get_job_info
 from iris.cluster.tpu_topology import get_tpu_topology
-from levanter.model_cache import cache_to_prefix
+from levanter.model_cache import cache_hf_model
 from rigging.connect import proxy_path
 from rigging.filesystem import marin_temp_bucket
 from rigging.log_setup import configure_logging
@@ -159,11 +158,7 @@ def resolve_model_path(model: str, cache_ttl_days: int) -> str:
         return model
 
     cache_path = marin_temp_bucket(cache_ttl_days, f"{_MODEL_CACHE_PREFIX}/{_model_cache_slug(model)}")
-    return cache_to_prefix(
-        cache_path,
-        lambda local_dir: snapshot_download(model, local_dir=local_dir),
-        complete_marker=_CACHE_COMPLETE_MARKER,
-    )
+    return cache_hf_model(cache_path, model, complete_marker=_CACHE_COMPLETE_MARKER)
 
 
 def detect_chat_support(vllm_base_url: str, model_id: str) -> bool:

--- a/lib/marin/src/marin/inference/quick_serve.py
+++ b/lib/marin/src/marin/inference/quick_serve.py
@@ -29,6 +29,7 @@ from huggingface_hub import snapshot_download
 from iris.client import iris_ctx
 from iris.cluster.client.job_info import get_job_info
 from iris.cluster.tpu_topology import get_tpu_topology
+from levanter.model_cache import cache_to_prefix
 from rigging.connect import proxy_path
 from rigging.filesystem import marin_temp_bucket
 from rigging.log_setup import configure_logging
@@ -149,27 +150,20 @@ def resolve_model_path(model: str, cache_ttl_days: int) -> str:
 
     Object-store paths are served directly. HF ids are mirrored once to a region-local
     GCS cache (``marin_temp_bucket``); a later serve of the same model reads the cached
-    snapshot from same-region GCS instead of re-downloading from HuggingFace. On a cache
-    miss the freshly downloaded local snapshot is served (fast local read) and uploaded
-    for next time.
+    snapshot from same-region GCS instead of re-downloading from HuggingFace. The mirror
+    is populated under a distributed lock (:func:`levanter.model_cache.cache_to_prefix`),
+    so concurrent serves of the same model do not all hit HuggingFace at once: the first
+    worker downloads while the rest block until the cache is populated.
     """
     if cache_ttl_days <= 0 or _is_object_store_path(model):
         return model
 
-    cache_path = marin_temp_bucket(cache_ttl_days, f"{_MODEL_CACHE_PREFIX}/{_model_cache_slug(model)}").rstrip("/")
-    fs, _ = fsspec.core.url_to_fs(cache_path)
-    if fs.exists(f"{cache_path}/{_CACHE_COMPLETE_MARKER}"):
-        logger.info("quick-serve model cache hit: %s", cache_path)
-        return cache_path
-
-    logger.info("quick-serve model cache miss; downloading %s and mirroring to %s", model, cache_path)
-    local_dir = tempfile.mkdtemp(prefix="quick_serve_model_")
-    snapshot_download(model, local_dir=local_dir)
-    fs.put(f"{local_dir.rstrip('/')}/", f"{cache_path}/", recursive=True)
-    # Marker last: its presence is the cache-hit signal, so a crashed upload won't read as complete.
-    with fs.open(f"{cache_path}/{_CACHE_COMPLETE_MARKER}", "w") as marker:
-        marker.write("ok")
-    return local_dir
+    cache_path = marin_temp_bucket(cache_ttl_days, f"{_MODEL_CACHE_PREFIX}/{_model_cache_slug(model)}")
+    return cache_to_prefix(
+        cache_path,
+        lambda local_dir: snapshot_download(model, local_dir=local_dir),
+        complete_marker=_CACHE_COMPLETE_MARKER,
+    )
 
 
 def detect_chat_support(vllm_base_url: str, model_id: str) -> bool:


### PR DESCRIPTION
Adds `levanter/model_cache.py` with `cache_to_prefix`, which mirrors a model snapshot to a shared prefix once under a distributed lock so concurrent workers do not all hit HuggingFace. Refactors `quick_serve.resolve_model_path` to use it.

Closes #6630