### PR TITLE
[iris] Stage CUDA toolchain for GPU jobs via a setup script

### DIFF
--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -261,6 +261,22 @@ Marin's `gpu` extra installs the JAX CUDA 13 wheel stack from PyPI. CoreWeave
 GPU nodes must expose NVIDIA driver 580 or newer; `nvidia-smi` should report
 CUDA 13.x.
 
+The `gpu` extra also pulls the CUDA toolchain wheels (`ptxas`/`nvlink` from
+`nvidia-cuda-nvcc`, `libdevice.10.bc` from `nvidia-nvvm`) into the task venv. A
+GPU job's setup scripts then expose them (see
+`iris.cluster.setup.cuda_toolchain_setup_script`): the toolchain binaries are
+symlinked into the venv's `bin` (already on `PATH` once the venv is activated),
+and `libdevice.10.bc` is staged into XLA's default CUDA data dir
+(`./cuda_sdk_lib`) and the working directory, where XLA and Mosaic probe.
+JAX/Pallas Mosaic GPU kernels therefore compile without per-job
+`ptxas`/`nvlink`/`libdevice` setup. The staging is a no-op unless the venv
+carries the toolchain, so CPU/TPU jobs and bring-your-own images are untouched.
+
+This staging is appended only to the default setup for a job that requests the
+`gpu` extra. A job that supplies its own `setup_scripts` (run verbatim) or
+installs JAX another way must stage the toolchain itself — call
+`cuda_toolchain_setup_script()` in its setup.
+
 ### Grug MoE Canary Warm-Node Multinode Smoke
 
 For a realistic Grug MoE multinode smoke, use the GPU path in

--- a/lib/iris/src/iris/cluster/setup.py
+++ b/lib/iris/src/iris/cluster/setup.py
@@ -130,23 +130,21 @@ def wants_gpu_extra(extras: Sequence[str]) -> bool:
     return any((e.split(":", 1)[1] if ":" in e else e) == "gpu" for e in extras)
 
 
+# The NVVM bitcode library JAX/XLA load to compile GPU kernels.
+_LIBDEVICE_FILE = "libdevice.10.bc"
+# XLA's built-in default --xla_gpu_cuda_data_dir, resolved relative to the workdir.
+_XLA_CUDA_DATA_DIR = "cuda_sdk_lib"
+
+
 def cuda_toolchain_setup_script() -> str:
-    """Render a setup script that exposes the venv's CUDA toolchain for JAX/Pallas.
+    """Return a setup script that exposes the venv's CUDA toolchain to JAX/Pallas.
 
-    ``jax[cuda13]`` installs the CUDA compiler wheels into the venv — ptxas/nvlink
-    (``nvidia-cuda-nvcc``) under ``nvidia/cu*/bin`` and ``libdevice.10.bc``
-    (``nvidia-nvvm``) under ``nvidia/cu*/nvvm/libdevice`` — but nothing exposes
-    them, so JAX reports "No PTX compilation provider" and Mosaic GPU lowering
-    cannot find ``libdevice.10.bc``.
-
-    Symlinks the toolchain binaries into the venv's ``bin`` (already on ``PATH``
-    once the venv is activated) and stages ``libdevice.10.bc`` into XLA's default
-    CUDA data dir (``./cuda_sdk_lib``) and the working directory — the locations
-    XLA and Mosaic probe — so no run-phase env injection is needed. Keyed on a
-    ``ptxas`` under ``nvidia/cu*`` so it spans CUDA major versions and is a no-op
-    when no toolchain is installed.
+    Appended to a GPU job's setup so Mosaic GPU kernels compile: it puts the
+    ``jax[cuda13]`` toolchain (``ptxas``/``nvlink``) on ``PATH`` by symlinking it
+    into the venv's ``bin``, and stages ``libdevice.10.bc`` where XLA looks, with no
+    run-phase changes. A no-op when the venv carries no CUDA toolchain.
     """
-    return r"""set -e
+    return rf"""set -e
 cuda_bin=""
 for _d in "$IRIS_VENV"/lib/python*/site-packages/nvidia/cu*/bin; do
   if [ -x "$_d/ptxas" ]; then cuda_bin="$_d"; break; fi
@@ -154,11 +152,11 @@ done
 if [ -z "$cuda_bin" ]; then echo 'no CUDA toolchain to stage'; exit 0; fi
 echo 'staging CUDA toolchain'
 ln -sf "$cuda_bin"/* "$IRIS_VENV/bin/"
-_libdevice="$(dirname "$cuda_bin")/nvvm/libdevice/libdevice.10.bc"
+_libdevice="$(dirname "$cuda_bin")/nvvm/libdevice/{_LIBDEVICE_FILE}"
 if [ -f "$_libdevice" ]; then
-  mkdir -p "$IRIS_WORKDIR/cuda_sdk_lib/nvvm/libdevice"
-  cp -f "$_libdevice" "$IRIS_WORKDIR/cuda_sdk_lib/nvvm/libdevice/libdevice.10.bc"
-  cp -f "$_libdevice" "$IRIS_WORKDIR/libdevice.10.bc"
+  mkdir -p "$IRIS_WORKDIR/{_XLA_CUDA_DATA_DIR}/nvvm/libdevice"
+  cp -f "$_libdevice" "$IRIS_WORKDIR/{_XLA_CUDA_DATA_DIR}/nvvm/libdevice/{_LIBDEVICE_FILE}"
+  cp -f "$_libdevice" "$IRIS_WORKDIR/{_LIBDEVICE_FILE}"
 fi
 """
 

--- a/lib/iris/src/iris/cluster/setup.py
+++ b/lib/iris/src/iris/cluster/setup.py
@@ -125,6 +125,44 @@ def default_setup_script(
     return "\n".join(lines) + "\n"
 
 
+def wants_gpu_extra(extras: Sequence[str]) -> bool:
+    """Whether any requested extra is the ``gpu`` extra (``extra`` or ``package:extra``)."""
+    return any((e.split(":", 1)[1] if ":" in e else e) == "gpu" for e in extras)
+
+
+def cuda_toolchain_setup_script() -> str:
+    """Render a setup script that exposes the venv's CUDA toolchain for JAX/Pallas.
+
+    ``jax[cuda13]`` installs the CUDA compiler wheels into the venv — ptxas/nvlink
+    (``nvidia-cuda-nvcc``) under ``nvidia/cu*/bin`` and ``libdevice.10.bc``
+    (``nvidia-nvvm``) under ``nvidia/cu*/nvvm/libdevice`` — but nothing exposes
+    them, so JAX reports "No PTX compilation provider" and Mosaic GPU lowering
+    cannot find ``libdevice.10.bc``.
+
+    Symlinks the toolchain binaries into the venv's ``bin`` (already on ``PATH``
+    once the venv is activated) and stages ``libdevice.10.bc`` into XLA's default
+    CUDA data dir (``./cuda_sdk_lib``) and the working directory — the locations
+    XLA and Mosaic probe — so no run-phase env injection is needed. Keyed on a
+    ``ptxas`` under ``nvidia/cu*`` so it spans CUDA major versions and is a no-op
+    when no toolchain is installed.
+    """
+    return r"""set -e
+cuda_bin=""
+for _d in "$IRIS_VENV"/lib/python*/site-packages/nvidia/cu*/bin; do
+  if [ -x "$_d/ptxas" ]; then cuda_bin="$_d"; break; fi
+done
+if [ -z "$cuda_bin" ]; then echo 'no CUDA toolchain to stage'; exit 0; fi
+echo 'staging CUDA toolchain'
+ln -sf "$cuda_bin"/* "$IRIS_VENV/bin/"
+_libdevice="$(dirname "$cuda_bin")/nvvm/libdevice/libdevice.10.bc"
+if [ -f "$_libdevice" ]; then
+  mkdir -p "$IRIS_WORKDIR/cuda_sdk_lib/nvvm/libdevice"
+  cp -f "$_libdevice" "$IRIS_WORKDIR/cuda_sdk_lib/nvvm/libdevice/libdevice.10.bc"
+  cp -f "$_libdevice" "$IRIS_WORKDIR/libdevice.10.bc"
+fi
+"""
+
+
 def iris_runtime_setup_script(*, quiet: bool = True) -> str:
     """Render the script that installs iris's own runtime deps into ``$IRIS_VENV``.
 

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -27,7 +27,7 @@ import cloudpickle
 import humanfriendly
 from rigging.timing import Timestamp
 
-from iris.cluster.setup import default_setup_script, setup_is_quiet
+from iris.cluster.setup import cuda_toolchain_setup_script, default_setup_script, setup_is_quiet, wants_gpu_extra
 from iris.cluster.tpu_topology import get_tpu_topology
 from iris.rpc import job_pb2
 
@@ -658,15 +658,20 @@ class EnvironmentSpec:
 
         if self.setup_scripts is None:
             py_version = f"{sys.version_info.major}.{sys.version_info.minor}"
+            extras = list(self.extras or [])
             setup_scripts = [
                 default_setup_script(
-                    extras=list(self.extras or []),
+                    extras=extras,
                     pip_packages=list(self.pip_packages or []),
                     python_version=py_version,
                     packages=list(self.sync_packages or []) or None,
                     quiet=setup_is_quiet(merged_env_vars),
                 )
             ]
+            # GPU jobs need the venv's CUDA toolchain (ptxas/nvlink/libdevice)
+            # exposed for JAX/Pallas Mosaic; the script no-ops without it.
+            if wants_gpu_extra(extras):
+                setup_scripts.append(cuda_toolchain_setup_script())
         else:
             setup_scripts = [s for s in self.setup_scripts if s.strip()]
 

--- a/lib/iris/tests/cluster/runtime/test_cuda_staging.py
+++ b/lib/iris/tests/cluster/runtime/test_cuda_staging.py
@@ -11,6 +11,7 @@ source text. The GPU extra wires it into the resolved setup scripts.
 import subprocess
 from pathlib import Path
 
+import pytest
 from iris.cluster.setup import cuda_toolchain_setup_script, wants_gpu_extra
 from iris.cluster.types import EnvironmentSpec
 
@@ -33,13 +34,20 @@ def _make_venv(tmp_path: Path, *, cuda_major: str, with_ptxas: bool, with_libdev
     return venv
 
 
-def _run_setup(venv: Path, workdir: Path) -> None:
+def _run_script(script: str, venv: Path, workdir: Path) -> None:
     env = {"IRIS_VENV": str(venv), "IRIS_WORKDIR": str(workdir), "PATH": "/usr/bin:/bin"}
-    subprocess.run(["bash", "-c", cuda_toolchain_setup_script()], env=env, capture_output=True, text=True, check=True)
+    subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True, check=True)
 
 
-def test_stages_toolchain_when_present(tmp_path):
-    venv = _make_venv(tmp_path, cuda_major="cu13", with_ptxas=True, with_libdevice=True)
+def _run_setup(venv: Path, workdir: Path) -> None:
+    _run_script(cuda_toolchain_setup_script(), venv, workdir)
+
+
+# cu12 and cu13 exercise the version-agnostic glob: the same script must stage
+# either CUDA major with no change.
+@pytest.mark.parametrize("cuda_major", ["cu12", "cu13"])
+def test_stages_toolchain_when_present(tmp_path, cuda_major):
+    venv = _make_venv(tmp_path, cuda_major=cuda_major, with_ptxas=True, with_libdevice=True)
     workdir = tmp_path / "work"
     workdir.mkdir()
 
@@ -51,18 +59,6 @@ def test_stages_toolchain_when_present(tmp_path):
     assert (venv / "bin" / "nvlink").is_symlink()
     # libdevice staged into XLA's default data dir and the working directory.
     assert (workdir / "cuda_sdk_lib" / "nvvm" / "libdevice" / "libdevice.10.bc").is_file()
-    assert (workdir / "libdevice.10.bc").is_file()
-
-
-def test_version_agnostic(tmp_path):
-    # The same script handles a different CUDA major (cu12) with no change.
-    venv = _make_venv(tmp_path, cuda_major="cu12", with_ptxas=True, with_libdevice=True)
-    workdir = tmp_path / "work"
-    workdir.mkdir()
-
-    _run_setup(venv, workdir)
-
-    assert (venv / "bin" / "ptxas").is_symlink()
     assert (workdir / "libdevice.10.bc").is_file()
 
 
@@ -110,17 +106,24 @@ def test_wants_gpu_extra():
     assert not wants_gpu_extra(["tpu", "vllm"])
 
 
-def test_gpu_extra_appends_cuda_setup_script():
-    scripts = list(EnvironmentSpec(extras=["gpu"]).to_proto().setup_scripts)
-    assert cuda_toolchain_setup_script() in scripts
+def test_gpu_extra_appends_a_real_staging_step(tmp_path):
+    """A GPU job appends exactly one setup step over the CPU baseline, and that
+    step actually stages the toolchain — verified by effect, not string identity."""
+    cpu_scripts = list(EnvironmentSpec(extras=["cpu"]).to_proto().setup_scripts)
+    gpu_scripts = list(EnvironmentSpec(extras=["gpu"]).to_proto().setup_scripts)
 
+    appended = gpu_scripts[len(cpu_scripts) :]
+    assert len(appended) == 1
 
-def test_non_gpu_extra_has_no_cuda_setup_script():
-    scripts = list(EnvironmentSpec(extras=["cpu"]).to_proto().setup_scripts)
-    assert cuda_toolchain_setup_script() not in scripts
+    venv = _make_venv(tmp_path, cuda_major="cu13", with_ptxas=True, with_libdevice=True)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    _run_script(appended[0], venv, workdir)
+    assert (venv / "bin" / "ptxas").is_symlink()
 
 
 def test_custom_setup_scripts_skip_cuda_staging():
-    # An explicit setup_scripts list is used verbatim; no CUDA staging is added.
+    # An explicit setup_scripts list is used verbatim even with the gpu extra:
+    # no staging step is appended, so a bring-your-own setup must stage itself.
     scripts = list(EnvironmentSpec(extras=["gpu"], setup_scripts=["echo hi\n"]).to_proto().setup_scripts)
     assert scripts == ["echo hi\n"]

--- a/lib/iris/tests/cluster/runtime/test_cuda_staging.py
+++ b/lib/iris/tests/cluster/runtime/test_cuda_staging.py
@@ -23,9 +23,9 @@ def _make_venv(tmp_path: Path, *, cuda_major: str, with_ptxas: bool, with_libdev
     (cuda / "bin").mkdir(parents=True)
     if with_ptxas:
         for tool in ("ptxas", "nvlink"):
-            exe = cuda / "bin" / tool
-            exe.write_text("#!/bin/sh\n")
-            exe.chmod(0o755)
+            tool_path = cuda / "bin" / tool
+            tool_path.write_text("#!/bin/sh\n")
+            tool_path.chmod(0o755)
     if with_libdevice:
         libdevice = cuda / "nvvm" / "libdevice"
         libdevice.mkdir(parents=True)
@@ -112,15 +112,12 @@ def test_wants_gpu_extra():
 
 def test_gpu_extra_appends_cuda_setup_script():
     scripts = list(EnvironmentSpec(extras=["gpu"]).to_proto().setup_scripts)
-    assert len(scripts) == 2
-    assert "uv sync" in scripts[0]
-    assert "cuda_sdk_lib" in scripts[1]
+    assert cuda_toolchain_setup_script() in scripts
 
 
 def test_non_gpu_extra_has_no_cuda_setup_script():
     scripts = list(EnvironmentSpec(extras=["cpu"]).to_proto().setup_scripts)
-    assert len(scripts) == 1
-    assert "cuda_sdk_lib" not in scripts[0]
+    assert cuda_toolchain_setup_script() not in scripts
 
 
 def test_custom_setup_scripts_skip_cuda_staging():

--- a/lib/iris/tests/cluster/runtime/test_cuda_staging.py
+++ b/lib/iris/tests/cluster/runtime/test_cuda_staging.py
@@ -1,0 +1,129 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavior tests for the CUDA toolchain setup script.
+
+The script runs in real bash, so these tests execute it against a fake venv tree
+and inspect the resulting symlinks and staged files rather than asserting on its
+source text. The GPU extra wires it into the resolved setup scripts.
+"""
+
+import subprocess
+from pathlib import Path
+
+from iris.cluster.setup import cuda_toolchain_setup_script, wants_gpu_extra
+from iris.cluster.types import EnvironmentSpec
+
+
+def _make_venv(tmp_path: Path, *, cuda_major: str, with_ptxas: bool, with_libdevice: bool) -> Path:
+    """Create a fake venv tree mirroring what jax[cuda*] installs."""
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    cuda = venv / "lib" / "python3.12" / "site-packages" / "nvidia" / cuda_major
+    (cuda / "bin").mkdir(parents=True)
+    if with_ptxas:
+        for tool in ("ptxas", "nvlink"):
+            exe = cuda / "bin" / tool
+            exe.write_text("#!/bin/sh\n")
+            exe.chmod(0o755)
+    if with_libdevice:
+        libdevice = cuda / "nvvm" / "libdevice"
+        libdevice.mkdir(parents=True)
+        (libdevice / "libdevice.10.bc").write_bytes(b"BC\xc0\xde")
+    return venv
+
+
+def _run_setup(venv: Path, workdir: Path) -> None:
+    env = {"IRIS_VENV": str(venv), "IRIS_WORKDIR": str(workdir), "PATH": "/usr/bin:/bin"}
+    subprocess.run(["bash", "-c", cuda_toolchain_setup_script()], env=env, capture_output=True, text=True, check=True)
+
+
+def test_stages_toolchain_when_present(tmp_path):
+    venv = _make_venv(tmp_path, cuda_major="cu13", with_ptxas=True, with_libdevice=True)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+
+    _run_setup(venv, workdir)
+
+    ptxas = venv / "bin" / "ptxas"
+    assert ptxas.is_symlink()
+    assert ptxas.resolve().is_file()
+    assert (venv / "bin" / "nvlink").is_symlink()
+    # libdevice staged into XLA's default data dir and the working directory.
+    assert (workdir / "cuda_sdk_lib" / "nvvm" / "libdevice" / "libdevice.10.bc").is_file()
+    assert (workdir / "libdevice.10.bc").is_file()
+
+
+def test_version_agnostic(tmp_path):
+    # The same script handles a different CUDA major (cu12) with no change.
+    venv = _make_venv(tmp_path, cuda_major="cu12", with_ptxas=True, with_libdevice=True)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+
+    _run_setup(venv, workdir)
+
+    assert (venv / "bin" / "ptxas").is_symlink()
+    assert (workdir / "libdevice.10.bc").is_file()
+
+
+def test_noop_when_toolchain_absent(tmp_path):
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+
+    _run_setup(venv, workdir)
+
+    assert not (venv / "bin" / "ptxas").exists()
+    assert not (workdir / "libdevice.10.bc").exists()
+    assert not (workdir / "cuda_sdk_lib").exists()
+
+
+def test_noop_when_ptxas_missing(tmp_path):
+    # cu13/bin exists but carries no compiler — a partial install stages nothing.
+    venv = _make_venv(tmp_path, cuda_major="cu13", with_ptxas=False, with_libdevice=True)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+
+    _run_setup(venv, workdir)
+
+    assert not (venv / "bin" / "ptxas").exists()
+    assert not (workdir / "libdevice.10.bc").exists()
+
+
+def test_stages_when_libdevice_missing(tmp_path):
+    # ptxas present but libdevice absent: still symlink the toolchain, skip copies.
+    venv = _make_venv(tmp_path, cuda_major="cu13", with_ptxas=True, with_libdevice=False)
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+
+    _run_setup(venv, workdir)
+
+    assert (venv / "bin" / "ptxas").is_symlink()
+    assert not (workdir / "libdevice.10.bc").exists()
+
+
+def test_wants_gpu_extra():
+    assert wants_gpu_extra(["gpu"])
+    assert wants_gpu_extra(["marin:gpu"])
+    assert not wants_gpu_extra(["cpu"])
+    assert not wants_gpu_extra(["tpu", "vllm"])
+
+
+def test_gpu_extra_appends_cuda_setup_script():
+    scripts = list(EnvironmentSpec(extras=["gpu"]).to_proto().setup_scripts)
+    assert len(scripts) == 2
+    assert "uv sync" in scripts[0]
+    assert "cuda_sdk_lib" in scripts[1]
+
+
+def test_non_gpu_extra_has_no_cuda_setup_script():
+    scripts = list(EnvironmentSpec(extras=["cpu"]).to_proto().setup_scripts)
+    assert len(scripts) == 1
+    assert "cuda_sdk_lib" not in scripts[0]
+
+
+def test_custom_setup_scripts_skip_cuda_staging():
+    # An explicit setup_scripts list is used verbatim; no CUDA staging is added.
+    scripts = list(EnvironmentSpec(extras=["gpu"], setup_scripts=["echo hi\n"]).to_proto().setup_scripts)
+    assert scripts == ["echo hi\n"]


### PR DESCRIPTION
CoreWeave H100 jobs that lower JAX/Pallas Mosaic GPU kernels failed to compile. jax[cuda13] (the gpu extra) installs the CUDA toolchain into the task venv — ptxas/nvlink from nvidia-cuda-nvcc, libdevice.10.bc from nvidia-nvvm — but nothing exposed it, so XLA reported "No PTX compilation provider" and Mosaic could not find libdevice.10.bc.

The toolchain wheels are already transitive deps of the gpu extra in uv.lock, so this is purely about exposing them. A prior attempt (#6601) appended a setup step that exported PATH/XLA_FLAGS, but after the #6621 setup-script refactor each setup step runs in its own subprocess, so those exports never reach the run command.

Fix it entirely in a client-side setup script, with no changes to the generic execution path (docker/k8s/runtime). cuda_toolchain_setup_script() is appended to the default setup of any job requesting the gpu extra. It symlinks the toolchain binaries into the venv bin (already on PATH after activation, which XLA's FindCudaExecutable searches) and stages libdevice.10.bc into XLA's built-in default CUDA data dir (./cuda_sdk_lib) and the working directory. Both are filesystem changes that persist via the shared workdir, so no run-phase env injection is needed. Keyed on a ptxas under nvidia/cu*, so it spans CUDA major versions and no-ops when no toolchain is installed.

A job that supplies its own setup_scripts (run verbatim) or installs JAX another way must stage the toolchain itself; this is documented in coreweave.md.

Fixes #6600
Fixes #6636