### PR TITLE
[iris] Add regression tests for username-only job list --prefix

### DIFF
--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -13,6 +13,7 @@ from iris.cli.job import (
     build_job_summary,
     build_resources,
     build_tpu_alternatives,
+    list_jobs,
     run,
     validate_extra_resources,
     validate_region_zone,
@@ -222,6 +223,36 @@ def test_job_run_cli_accepts_task_image_override(monkeypatch):
     assert captured["task_image"] == "ghcr.io/marin-community/iris-task-cuda-devel:test"
     assert captured["controller_url"] == "http://controller.test"
     assert captured["entrypoint"].command == ["python", "train.py"]
+
+
+def test_job_list_cli_forwards_username_only_prefix(monkeypatch):
+    """A username-only --prefix ('/tim') reaches the client verbatim.
+
+    Regresses the crash where the CLI parsed --prefix into a JobName, which
+    rejected single-segment values like '/tim' (the canonical form needs a
+    '/<user>/<job>' shape) before any RPC could be made.
+    """
+    captured: dict[str, object] = {}
+
+    class FakeClient:
+        def list_jobs(self, *, state=None, prefix=None):
+            captured["state"] = state
+            captured["prefix"] = prefix
+            return []
+
+    def fake_remote(controller_url, *, workspace, credentials=None):
+        return FakeClient()
+
+    monkeypatch.setattr("iris.cli.job.IrisClient.remote", fake_remote)
+
+    result = CliRunner().invoke(
+        list_jobs,
+        ["--prefix", "/tim"],
+        obj={"controller_url": "http://controller.test", "config": None, "credentials": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["prefix"] == "/tim"
 
 
 # --tpu multi-variant parsing

--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -226,12 +226,7 @@ def test_job_run_cli_accepts_task_image_override(monkeypatch):
 
 
 def test_job_list_cli_forwards_username_only_prefix(monkeypatch):
-    """A username-only --prefix ('/tim') reaches the client verbatim.
-
-    Regresses the crash where the CLI parsed --prefix into a JobName, which
-    rejected single-segment values like '/tim' (the canonical form needs a
-    '/<user>/<job>' shape) before any RPC could be made.
-    """
+    """A username-only --prefix ('/tim') reaches the client verbatim, not parsed into a JobName."""
     captured: dict[str, object] = {}
 
     class FakeClient:

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -1122,6 +1122,14 @@ _INT32_MAX = (1 << 31) - 1
             {"/test-user/alpha-job"},
             id="job_id_prefix_matches_user_and_name",
         ),
+        # A username-only prefix ("/<user>") matches every job that user owns:
+        # the wire-form job_id is "/<user>/<name>", so the anchored LIKE catches
+        # all of them. This is the common "show me all of tim's jobs" query.
+        pytest.param(
+            {"job_id_prefix": "/test-user"},
+            {"/test-user/alpha-job", "/test-user/beta-job"},
+            id="job_id_prefix_username_only",
+        ),
         # The bare "%" in a prefix must be treated literally; without escaping
         # this would degenerate into "LIKE '%a%'" and match every job.
         pytest.param({"job_id_prefix": "%a"}, set(), id="job_id_prefix_escapes_sql_wildcards"),


### PR DESCRIPTION
`iris job list --prefix=/tim` used to crash with `ValueError: Job name must use canonical '/<user>/<job>[...]' format: /tim`. The CLI parsed the `--prefix` value into a `JobName`, which rejects single-segment values, so a username-only prefix died before any RPC was made.

PR #5634 fixed the behavior — the CLI now forwards the prefix verbatim to an anchored `job_id_prefix` LIKE filter against the wire-form `job_id` — but it did not reference this issue (so it stayed open) and added no test for the bare-username case the report was about. The existing `job_id_prefix` tests only cover a user+name prefix (`/test-user/alpha`), wildcard escaping, and a no-match path.

This adds two regressions at distinct layers:

- Service/SQL: a `job_id_prefix="/test-user"` case asserting a username-only prefix matches every job that user owns (the "show me all of tim's jobs" query).
- CLI: invoking `job list --prefix /tim` and asserting it exits 0 and forwards `/tim` to the client verbatim, guarding against re-introducing the `JobName` parse.

No production code change — the fix is already in the tree; this locks in the username-only behavior.

Fixes #4594