### PR TITLE
[ci] Upgrade GitHub Actions to Node 24 runtimes

### DIFF
--- a/.github/actions/notify-slack/action.yaml
+++ b/.github/actions/notify-slack/action.yaml
@@ -22,7 +22,7 @@ runs:
   steps:
     - name: Download Slack message
       if: inputs.message-artifact != ''
-      uses: actions/download-artifact@v4
+      uses: actions/download-artifact@v8
       continue-on-error: true
       with:
         name: ${{ inputs.message-artifact }}

--- a/.github/workflows/dupekit-release-wheels.yaml
+++ b/.github/workflows/dupekit-release-wheels.yaml
@@ -137,7 +137,7 @@ jobs:
             --version "${{ needs.resolve.outputs.version }}" \
             --build "${{ matrix.target }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}
           path: dist/*
@@ -160,7 +160,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/finelog-release-wheels.yaml
+++ b/.github/workflows/finelog-release-wheels.yaml
@@ -151,7 +151,7 @@ jobs:
             --version "${{ needs.resolve.outputs.version }}" \
             --build "${{ matrix.target }}"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: wheels-${{ matrix.os }}
           path: dist/*
@@ -174,7 +174,7 @@ jobs:
       - uses: astral-sh/setup-uv@v7
       - uses: dtolnay/rust-toolchain@29eef336d9b2848a0b548edc03f92a220660cdb8  # stable
 
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           path: dist
           merge-multiple: true

--- a/.github/workflows/iris-dev-restart.yaml
+++ b/.github/workflows/iris-dev-restart.yaml
@@ -36,12 +36,12 @@ jobs:
           cache-dependency-glob: "lib/iris/pyproject.toml"
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 

--- a/.github/workflows/iris-smoke-coreweave.yaml
+++ b/.github/workflows/iris-smoke-coreweave.yaml
@@ -159,7 +159,7 @@ jobs:
 
       - name: Upload failure diagnostics
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: iris-cw-ci-logs
           path: iris-cw-logs/

--- a/.github/workflows/iris-smoke-gcp.yaml
+++ b/.github/workflows/iris-smoke-gcp.yaml
@@ -62,7 +62,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
@@ -75,12 +75,12 @@ jobs:
         run: cd lib/iris && uv run playwright install --with-deps chromium
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
@@ -172,7 +172,7 @@ jobs:
 
       - name: Upload logs
         if: failure()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: iris-cloud-smoke-logs
           path: iris-cloud-logs/
@@ -202,7 +202,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: iris-cloud-smoke-screenshots
           path: iris-cloud-screenshots/
@@ -235,12 +235,12 @@ jobs:
           cache-dependency-glob: "lib/iris/pyproject.toml"
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 

--- a/.github/workflows/iris-unit.yaml
+++ b/.github/workflows/iris-unit.yaml
@@ -46,7 +46,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -79,7 +79,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 
@@ -96,7 +96,7 @@ jobs:
           echo "version=$version" >> "$GITHUB_OUTPUT"
 
       - name: Cache Playwright browsers
-        uses: actions/cache@v4
+        uses: actions/cache@v6
         with:
           path: ~/.cache/ms-playwright
           key: playwright-${{ runner.os }}-${{ steps.playwright-version.outputs.version }}
@@ -129,7 +129,7 @@ jobs:
 
       - name: Upload screenshots
         if: always()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: iris-smoke-screenshots
           path: iris-screenshots/

--- a/.github/workflows/levanter-unit.yaml
+++ b/.github/workflows/levanter-unit.yaml
@@ -50,7 +50,7 @@ jobs:
           enable-cache: true
           working-directory: lib/levanter
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
       - name: Set up Python
@@ -80,7 +80,7 @@ jobs:
           enable-cache: true
           working-directory: lib/levanter
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
       - name: Set up Python

--- a/.github/workflows/marin-canary-datakit-tier1.yaml
+++ b/.github/workflows/marin-canary-datakit-tier1.yaml
@@ -43,12 +43,12 @@ jobs:
         run: uv sync --all-packages --extra=cpu --no-default-groups
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
@@ -136,7 +136,7 @@ jobs:
 
       - name: Upload perf report
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: datakit-tier1-perf-report
           path: perf-report.json
@@ -162,7 +162,7 @@ jobs:
 
       - name: Upload diagnostics
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: datakit-smoke-diagnostics
           path: datakit-smoke-diagnostics/
@@ -194,7 +194,7 @@ jobs:
       # https://github.com/marin-community/marin/actions/runs/24498461666.
       - name: Upload Slack message
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: slack-message
           path: slack_message.md
@@ -228,7 +228,7 @@ jobs:
   #       run: uv sync --all-packages --extra=cpu --no-default-groups
   #
   #     - name: Authenticate to Google Cloud
-  #       uses: google-github-actions/auth@v2
+  #       uses: google-github-actions/auth@v3
   #       with:
   #         credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
   #

--- a/.github/workflows/marin-canary-datakit-tier2.yaml
+++ b/.github/workflows/marin-canary-datakit-tier2.yaml
@@ -43,12 +43,12 @@ jobs:
         run: uv sync --all-packages --extra=cpu --no-default-groups
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
@@ -116,7 +116,7 @@ jobs:
 
       - name: Upload perf report
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: datakit-tier2-perf-report
           path: perf-report.json
@@ -142,7 +142,7 @@ jobs:
 
       - name: Upload diagnostics
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: datakit-tier2-diagnostics
           path: datakit-tier2-diagnostics/
@@ -169,7 +169,7 @@ jobs:
 
       - name: Upload Slack message
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: slack-message
           path: slack_message.md

--- a/.github/workflows/marin-canary-datakit-tier3.yaml
+++ b/.github/workflows/marin-canary-datakit-tier3.yaml
@@ -41,12 +41,12 @@ jobs:
         run: uv sync --all-packages --extra=cpu --no-default-groups
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
@@ -120,7 +120,7 @@ jobs:
 
       - name: Upload perf report
         if: success()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: datakit-tier3-perf-report
           path: perf-report.json
@@ -146,7 +146,7 @@ jobs:
 
       - name: Upload diagnostics
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: datakit-nemotron-diagnostics
           path: datakit-nemotron-diagnostics/

--- a/.github/workflows/marin-canary-ferry-coreweave.yaml
+++ b/.github/workflows/marin-canary-ferry-coreweave.yaml
@@ -216,7 +216,7 @@ jobs:
 
       - name: Upload diagnostics bundle
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: canary-diag-${{ github.run_id }}
           path: /tmp/canary-diag
@@ -248,7 +248,7 @@ jobs:
       # hides the transcript with "full output hidden for security".
       - name: Upload Claude triage log
         if: (failure() || cancelled()) && github.event_name == 'schedule'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: claude-triage-log-${{ github.run_id }}
           path: /home/runner/work/_temp/claude-execution-output.json
@@ -262,7 +262,7 @@ jobs:
       # https://github.com/marin-community/marin/actions/runs/24498461666.
       - name: Upload Slack message
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: slack-message
           path: slack_message.md

--- a/.github/workflows/marin-canary-ferry.yaml
+++ b/.github/workflows/marin-canary-ferry.yaml
@@ -58,12 +58,12 @@ jobs:
         run: uv sync --all-packages --extra=cpu --no-default-groups
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
@@ -173,7 +173,7 @@ jobs:
 
       - name: Upload diagnostics
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: canary-diagnostics
           path: canary-diagnostics/
@@ -203,7 +203,7 @@ jobs:
       # https://github.com/marin-community/marin/actions/runs/24498461666.
       - name: Upload Slack message
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: slack-message
           path: slack_message.md

--- a/.github/workflows/marin-canary-grug-multislice.yaml
+++ b/.github/workflows/marin-canary-grug-multislice.yaml
@@ -58,12 +58,12 @@ jobs:
         run: uv sync --all-packages --extra=cpu --no-default-groups
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 
@@ -153,7 +153,7 @@ jobs:
 
       - name: Upload diagnostics
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: grug-multislice-diagnostics
           path: grug-multislice-diagnostics/
@@ -178,7 +178,7 @@ jobs:
 
       - name: Upload Slack message
         if: failure() || cancelled()
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: slack-message
           path: slack_message.md

--- a/.github/workflows/marin-docs.yaml
+++ b/.github/workflows/marin-docs.yaml
@@ -48,7 +48,7 @@ jobs:
           enable-cache: true
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/marin-integration.yaml
+++ b/.github/workflows/marin-integration.yaml
@@ -29,7 +29,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 

--- a/.github/workflows/marin-lint.yaml
+++ b/.github/workflows/marin-lint.yaml
@@ -27,7 +27,7 @@ jobs:
         enable-cache: true
 
     - name: Set up Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@v6
       with:
         node-version: '22'
 

--- a/.github/workflows/marin-release-libs-wheels.yaml
+++ b/.github/workflows/marin-release-libs-wheels.yaml
@@ -94,7 +94,7 @@ jobs:
         run: |
           python3 scripts/python_libs_package.py --mode "$MODE" --version "$VERSION"
 
-      - uses: actions/upload-artifact@v4
+      - uses: actions/upload-artifact@v7
         with:
           name: marin-libs-dist
           path: dist/*
@@ -113,7 +113,7 @@ jobs:
     permissions:
       id-token: write   # mint the OIDC token for trusted publishing
     steps:
-      - uses: actions/download-artifact@v4
+      - uses: actions/download-artifact@v8
         with:
           name: marin-libs-dist
           path: dist

--- a/.github/workflows/marin-unit.yaml
+++ b/.github/workflows/marin-unit.yaml
@@ -60,7 +60,7 @@ jobs:
           uv sync --package marin-core --extra cpu --extra dedup --group test --frozen
 
       - name: Set up Node.js 20.10.0
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "20.10.0"
 

--- a/.github/workflows/ops-claude.yaml
+++ b/.github/workflows/ops-claude.yaml
@@ -54,7 +54,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Run Claude Code
         id: claude
@@ -106,7 +106,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Triage Issue
         uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1  # v1.0.140
@@ -220,7 +220,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Apply Autofix
         uses: anthropics/claude-code-action@fbda2eb1bdc90d319b8d853f5deb53bca199a7c1  # v1.0.140

--- a/.github/workflows/ops-cost-report.yaml
+++ b/.github/workflows/ops-cost-report.yaml
@@ -54,12 +54,12 @@ jobs:
         run: uv sync --all-packages --extra=cpu --no-default-groups
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 

--- a/.github/workflows/ops-egress-report.yaml
+++ b/.github/workflows/ops-egress-report.yaml
@@ -32,12 +32,12 @@ jobs:
           cache-dependency-glob: "uv.lock"
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 

--- a/.github/workflows/ops-grug-variant-diff.yaml
+++ b/.github/workflows/ops-grug-variant-diff.yaml
@@ -76,7 +76,7 @@ jobs:
       - name: Upload report artifact
         id: artifact
         if: steps.manifest.outputs.has_reports == 'true'
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v7
         with:
           name: grug-variant-diff-pr-${{ github.event.pull_request.number }}
           path: grug-diff-report
@@ -85,7 +85,7 @@ jobs:
       - name: Publish rendered report to gh-pages
         id: publish
         if: steps.manifest.outputs.has_reports == 'true' && github.event.pull_request.head.repo.full_name == github.repository
-        uses: peaceiris/actions-gh-pages@4f9cc6602d3f66b9c108549d475ec49e8ef4d45e  # v4
+        uses: peaceiris/actions-gh-pages@84c30a85c19949d7eee79c4ff27748b70285e453  # v4.1.0
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: grug-diff-report
@@ -94,7 +94,7 @@ jobs:
 
       - name: Post PR comment with report links
         if: "!cancelled() && github.event.pull_request.head.repo.full_name == github.repository"
-        uses: actions/github-script@f28e40c7f34bde8b3046d885e986cb6290c5673b  # v7
+        uses: actions/github-script@3a2844b7e9c422d3c10d287c895573f7108da1b3  # v9.0.0
         env:
           ARTIFACT_URL: ${{ steps.artifact.outputs.artifact-url }}
           PAGES_URL: https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}/grug-diffs/pr-${{ github.event.pull_request.number }}

--- a/.github/workflows/ops-infra-dashboard.yaml
+++ b/.github/workflows/ops-infra-dashboard.yaml
@@ -31,7 +31,7 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Set up Node.js 20
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: '20'
           cache: 'npm'
@@ -62,12 +62,12 @@ jobs:
         uses: actions/checkout@v5
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.MARIN_CD_CLOUD_RUN_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
           install_components: beta

--- a/.github/workflows/ops-nightshift-ci-tests.yaml
+++ b/.github/workflows/ops-nightshift-ci-tests.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.NIGHTSHIFT_APP_ID }}
           private-key: ${{ secrets.NIGHTSHIFT_APP_PRIVATE_KEY }}
@@ -39,7 +39,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/ops-nightshift-cleanup.yaml
+++ b/.github/workflows/ops-nightshift-cleanup.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.NIGHTSHIFT_APP_ID }}
           private-key: ${{ secrets.NIGHTSHIFT_APP_PRIVATE_KEY }}
@@ -39,7 +39,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/ops-nightshift-doc-drift.yaml
+++ b/.github/workflows/ops-nightshift-doc-drift.yaml
@@ -22,7 +22,7 @@ jobs:
     steps:
       - name: Generate app token
         id: app-token
-        uses: actions/create-github-app-token@v1
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ secrets.NIGHTSHIFT_APP_ID }}
           private-key: ${{ secrets.NIGHTSHIFT_APP_PRIVATE_KEY }}
@@ -39,7 +39,7 @@ jobs:
           python-version: '3.12'
 
       - name: Install uv
-        uses: astral-sh/setup-uv@v5
+        uses: astral-sh/setup-uv@v7
 
       - name: Install Claude Code
         run: npm install -g @anthropic-ai/claude-code

--- a/.github/workflows/ops-stale.yaml
+++ b/.github/workflows/ops-stale.yaml
@@ -14,7 +14,7 @@ jobs:
   stale:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/stale@5bef64f19d7facfb25b37b414482c7164d639639  # v9
+      - uses: actions/stale@eb5cf3af3ac0a1aa4c9c45633dd1ae542a27a899  # v10.3.0
         with:
           # Issues: Mark stale after 83 days, close 7 days later (90 days total = 3 months)
           days-before-issue-stale: 83

--- a/.github/workflows/ops-storage-report.yaml
+++ b/.github/workflows/ops-storage-report.yaml
@@ -58,12 +58,12 @@ jobs:
         run: uv sync --all-packages --extra=cpu --no-default-groups
 
       - name: Authenticate to Google Cloud
-        uses: google-github-actions/auth@v2
+        uses: google-github-actions/auth@v3
         with:
           credentials_json: ${{ secrets.IRIS_CI_GCP_SA_KEY }}
 
       - name: Set up Google Cloud SDK
-        uses: google-github-actions/setup-gcloud@v2
+        uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
 

--- a/.github/workflows/zephyr-unit.yaml
+++ b/.github/workflows/zephyr-unit.yaml
@@ -48,7 +48,7 @@ jobs:
           python-version: "3.12"
 
       - name: Set up Node.js
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@v6
         with:
           node-version: "22"
 


### PR DESCRIPTION
Node.js 20 actions are deprecated: GitHub began force-running them on Node 24 on June 2, 2026 and removes Node 20 from the runners on September 16, 2026. This bumps every action that still declared `using: node20` to its current Node 24 major. Each target was verified against the action`s upstream `action.yml`, because several "obvious" bumps are still on Node 20 (`upload-artifact@v5`, `download-artifact@v5`/`v6`, `create-github-app-token@v2`).

Version-tagged actions:

    actions/setup-node                 v4 -> v6
    actions/upload-artifact            v4 -> v7   (v5 is still node20)
    actions/download-artifact          v4 -> v8   (v5/v6 are still node20)
    actions/cache                      v4 -> v6
    actions/create-github-app-token    v1 -> v3   (v2 is still node20)
    google-github-actions/auth         v2 -> v3
    google-github-actions/setup-gcloud v2 -> v3
    astral-sh/setup-uv                 v5 -> v7   (matches the repo`s existing v7 pins)

SHA-pinned actions move to the first Node 24 release, keeping the pin + comment style:

    actions/stale               5bef64f (v9) -> eb5cf3a (v10.3.0)
    actions/github-script       f28e40c (v7) -> 3a2844b (v9.0.0)
    peaceiris/actions-gh-pages  4f9cc66 (v4) -> 84c30a8 (v4.1.0)

Composite actions (claude-code-action, dtolnay/rust-toolchain, gh-action-pypi-publish) and already-current leaves (checkout, setup-python, docker/*, dorny/paths-filter, codeql-action v4) need no change. 30 files changed, all edits are `uses:` line swaps.

Note: ops-claude.yaml is among the edited files, so the claude-code-action validation check on this PR is expected to fail with a workflow-token guard error; it clears once merged.

Fixes #5560