### PR TITLE
Drop unneeded from __future__ import annotations (py>=3.12)

### DIFF
--- a/experiments/datakit/cluster/domain/v0/assign.py
+++ b/experiments/datakit/cluster/domain/v0/assign.py
@@ -18,8 +18,6 @@ cache valid across Zephyr tasks.
 Counters: ``assign/docs_in``, ``assign/shards_in``.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import tempfile

--- a/experiments/datakit/cluster/domain/v0/ops/coherence_eval.py
+++ b/experiments/datakit/cluster/domain/v0/ops/coherence_eval.py
@@ -20,8 +20,6 @@ Anthropic API key is read from ``ANTHROPIC_API_KEY`` (env var). The repo's
 it manually -- never echo or commit it.
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import logging

--- a/experiments/datakit/cluster/domain/v0/sample.py
+++ b/experiments/datakit/cluster/domain/v0/sample.py
@@ -28,8 +28,6 @@ independent so the pipeline is fully resumable across preemptions
 survive a restart).
 """
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Iterator
 from concurrent.futures import ThreadPoolExecutor, as_completed

--- a/experiments/datakit/cluster/quality/v0/all_sources_quality_llm.py
+++ b/experiments/datakit/cluster/quality/v0/all_sources_quality_llm.py
@@ -37,8 +37,6 @@ Submit:
               --inference-name sonnet46-thr05
 """
 
-from __future__ import annotations
-
 import argparse
 import logging
 import os

--- a/experiments/datakit/cluster/quality/v0/ops/eval_holdout.py
+++ b/experiments/datakit/cluster/quality/v0/ops/eval_holdout.py
@@ -38,8 +38,6 @@ Submit:
 where BASE=gs://marin-eu-west4/datakit/llm-quality-classifier
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import logging

--- a/experiments/datakit/cluster/quality/v0/ops/eval_vs_dolma3.py
+++ b/experiments/datakit/cluster/quality/v0/ops/eval_vs_dolma3.py
@@ -35,8 +35,6 @@ Submit:
 where BASE=gs://marin-eu-west4/datakit/llm-quality-classifier
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import logging

--- a/experiments/datakit/cluster/quality/v0/ops/exp_smoke.py
+++ b/experiments/datakit/cluster/quality/v0/ops/exp_smoke.py
@@ -19,8 +19,6 @@ Submit (eu-west4 worker so we read marin-eu-west4 in-region):
         python -m experiments.datakit.cluster.quality.v0.ops.exp_smoke
 """
 
-from __future__ import annotations
-
 import logging
 import os
 

--- a/experiments/datakit/cluster/quality/v0/ops/spot_check.py
+++ b/experiments/datakit/cluster/quality/v0/ops/spot_check.py
@@ -27,8 +27,6 @@ Submit on iris in eu-west4 so the GCS reads stay in-region:
           --top-k 3 --bottom-k 3
 """
 
-from __future__ import annotations
-
 import argparse
 import logging
 import os

--- a/experiments/datakit/cluster/quality/v0/rubric.py
+++ b/experiments/datakit/cluster/quality/v0/rubric.py
@@ -10,8 +10,6 @@ per-call cost from token usage. ``score.py`` imports everything from
 here so the prompt + parsing live in one place.
 """
 
-from __future__ import annotations
-
 import json
 import os
 import re

--- a/experiments/datakit/cluster/quality/v0/sample.py
+++ b/experiments/datakit/cluster/quality/v0/sample.py
@@ -29,8 +29,6 @@ Run from anywhere that can read ``gs://marin-eu-west4/datakit/...``:
         --total-size 7000 --floor-per-source 20 --seed 42
 """
 
-from __future__ import annotations
-
 import argparse
 import logging
 import math

--- a/experiments/datakit/cluster/quality/v0/score.py
+++ b/experiments/datakit/cluster/quality/v0/score.py
@@ -42,8 +42,6 @@ Submit:
           --budget-usd 45  # leave $5 for the held-out eval sample
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import logging

--- a/experiments/datakit/cluster/quality/v0/train.py
+++ b/experiments/datakit/cluster/quality/v0/train.py
@@ -25,8 +25,6 @@ Submit:
           --output-dir gs://marin-eu-west4/datakit/llm-quality-classifier/model/sonnet46-thr05/
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import logging

--- a/experiments/datakit/dedup/ops/fetch_cluster_texts.py
+++ b/experiments/datakit/dedup/ops/fetch_cluster_texts.py
@@ -27,8 +27,6 @@ Submit on iris (us-central2 pinned by the worker's MARIN_PREFIX):
         -- python experiments/datakit/dedup/ops/fetch_cluster_texts.py
 """
 
-from __future__ import annotations
-
 import concurrent.futures
 import json
 import logging

--- a/experiments/datakit/dedup/ops/fetch_cluster_texts_zephyr.py
+++ b/experiments/datakit/dedup/ops/fetch_cluster_texts_zephyr.py
@@ -23,8 +23,6 @@ Submit on iris (us-central2 pinned by the worker's MARIN_PREFIX):
         -- python experiments/datakit/dedup/ops/fetch_cluster_texts_zephyr.py
 """
 
-from __future__ import annotations
-
 import concurrent.futures
 import json
 import logging

--- a/experiments/datakit/dedup/ops/render_cluster_report.py
+++ b/experiments/datakit/dedup/ops/render_cluster_report.py
@@ -17,8 +17,6 @@ Run locally (small parquet, cheap cross-region read) or on iris in us-central2:
     uv run python experiments/datakit/dedup/ops/render_cluster_report.py
 """
 
-from __future__ import annotations
-
 import argparse
 import html
 import logging

--- a/experiments/datakit/dedup/ops/sample_clusters.py
+++ b/experiments/datakit/dedup/ops/sample_clusters.py
@@ -34,8 +34,6 @@ Submit on iris (us-central2 pinned by the worker's MARIN_PREFIX):
         -- python experiments/datakit/dedup/ops/sample_clusters.py
 """
 
-from __future__ import annotations
-
 import logging
 
 import pyarrow as pa

--- a/experiments/datakit/embeddings/luxical/pipeline.py
+++ b/experiments/datakit/embeddings/luxical/pipeline.py
@@ -27,8 +27,6 @@ in coordinator RAM.
 Counters emitted: ``embed/docs_in``, ``embed/bytes_in``, ``embed/shards_in``.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import tempfile

--- a/experiments/datakit/fasttext.py
+++ b/experiments/datakit/fasttext.py
@@ -38,8 +38,6 @@ score. Individual classifiers wire their own input discovery, output
 naming, hash_attrs, projection, and downstream artifact shape.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import tempfile

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -43,8 +43,6 @@ writes the small ``<output>/cluster=<C>/quality=<Q>/shard_ledger.json``. No
 second Zephyr context.
 """
 
-from __future__ import annotations
-
 import bisect
 import contextlib
 import dataclasses

--- a/experiments/datakit/testbed/baseline.py
+++ b/experiments/datakit/testbed/baseline.py
@@ -21,8 +21,6 @@ The whole pipeline (ferry → tokenize → weights → train) lives in one
 executor DAG so ``--dry_run`` validates structure without touching GCS.
 """
 
-from __future__ import annotations
-
 import dataclasses
 import logging
 import os

--- a/experiments/datakit/testbed/mixture.py
+++ b/experiments/datakit/testbed/mixture.py
@@ -1,7 +1,5 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
-from __future__ import annotations
-
 import json
 import logging
 from dataclasses import dataclass

--- a/experiments/datakit/testbed/sampler.py
+++ b/experiments/datakit/testbed/sampler.py
@@ -27,8 +27,6 @@ Design choices:
   against ``RAW_TARGET_TOTAL_TOKENS_B`` via :func:`proportional_sample_fractions`.
 """
 
-from __future__ import annotations
-
 import logging
 import math
 import os

--- a/experiments/datakit/testbed/train.py
+++ b/experiments/datakit/testbed/train.py
@@ -17,8 +17,6 @@ to preserve the per-source shares over the shortened horizon (see
 ``levanter/data/text/datasets.py:763-770``).
 """
 
-from __future__ import annotations
-
 import dataclasses
 import logging
 import os

--- a/experiments/datakit/testbed/variants.py
+++ b/experiments/datakit/testbed/variants.py
@@ -14,8 +14,6 @@ The whole pipeline (ferry → minhash → fuzzy_dups → consolidate → tokeniz
 structure without touching GCS.
 """
 
-from __future__ import annotations
-
 import dataclasses
 import logging
 import os

--- a/experiments/evals/hf_log_probs.py
+++ b/experiments/evals/hf_log_probs.py
@@ -15,8 +15,6 @@ network I/O; the config is read only when the step actually executes (which is
 also when the model itself is downloaded).
 """
 
-from __future__ import annotations
-
 import dataclasses
 from dataclasses import dataclass
 

--- a/experiments/evals/served_qwen3_humaneval.py
+++ b/experiments/evals/served_qwen3_humaneval.py
@@ -18,8 +18,6 @@ Examples:
   uv run python experiments/evals/served_qwen3_humaneval.py --local
 """
 
-from __future__ import annotations
-
 import shlex
 import subprocess
 from dataclasses import dataclass, replace

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import dataclasses
 import functools
 import logging

--- a/experiments/grug/checkpointing.py
+++ b/experiments/grug/checkpointing.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import json
 import logging
 import os

--- a/experiments/grug/dispatch.py
+++ b/experiments/grug/dispatch.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import logging
 import os
 import re

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import dataclasses
 import functools
 import logging

--- a/infra/codehealth/complexity.py
+++ b/infra/codehealth/complexity.py
@@ -20,8 +20,6 @@ only bound what we *show* — they are not thresholds the agent must flag, and t
 agent stays free to flag a unit the leads missed or to ignore a flagged one that
 is genuinely cohesive.
 """
-from __future__ import annotations
-
 import ast
 import sys
 from dataclasses import dataclass

--- a/infra/codehealth/log_stats.py
+++ b/infra/codehealth/log_stats.py
@@ -38,8 +38,6 @@ Expected stdin payload:
     }
 """
 
-from __future__ import annotations
-
 import datetime as dt
 import hashlib
 import json

--- a/infra/codehealth/review.py
+++ b/infra/codehealth/review.py
@@ -51,8 +51,6 @@ Requires a logged-in `claude` CLI (subscription auth) and W&B auth, plus
 `gh auth login` for the GitHub side. Designed to run as a daily GHA cron.
 """
 
-from __future__ import annotations
-
 import datetime as dt
 import json
 import logging

--- a/infra/cron/nightshift_ci_tests.py
+++ b/infra/cron/nightshift_ci_tests.py
@@ -3,8 +3,6 @@
 
 """Nightshift CI test audit: inspect recent CI logs for slow or unstable tests."""
 
-from __future__ import annotations
-
 import datetime as dt
 import hashlib
 import json

--- a/infra/probes/deploy/deploy.py
+++ b/infra/probes/deploy/deploy.py
@@ -14,8 +14,6 @@ Run with ``uv run deploy/deploy.py <command>`` (click resolves from the project
 venv), or ``python deploy/deploy.py <command>`` if click is on the path.
 """
 
-from __future__ import annotations
-
 import logging
 import subprocess
 from pathlib import Path

--- a/infra/probes/src/cluster.py
+++ b/infra/probes/src/cluster.py
@@ -10,8 +10,6 @@ I/O (the iris RPC / SQL call) is separated from the pure ``aggregate_*`` rollups
 so the labelling/windowing is unit-testable without a live controller.
 """
 
-from __future__ import annotations
-
 import json
 from collections import defaultdict
 from collections.abc import Sequence

--- a/infra/probes/src/infra_probes.py
+++ b/infra/probes/src/infra_probes.py
@@ -7,8 +7,6 @@ samples are logged to stdout (picked up by Cloud Logging on COS) and fanned to t
 sinks.
 """
 
-from __future__ import annotations
-
 import logging
 import tempfile
 import time

--- a/infra/probes/src/provisioning.py
+++ b/infra/probes/src/provisioning.py
@@ -15,8 +15,6 @@ I/O (the bounded finelog query) is separated from the pure ``aggregate`` so the
 windowing/rollup logic is unit-testable without a live controller.
 """
 
-from __future__ import annotations
-
 import math
 import time
 from collections import defaultdict

--- a/infra/probes/src/runner.py
+++ b/infra/probes/src/runner.py
@@ -13,8 +13,6 @@ Imports stay light (stdlib + ``sample``) so the runner is testable without the
 iris/finelog clients the entrypoint wires up.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import time

--- a/infra/probes/src/sample.py
+++ b/infra/probes/src/sample.py
@@ -12,8 +12,6 @@ Its own module so the runner and the sinks can share it without importing the
 ``python -m`` entrypoint (which would re-import it as a second ``__main__`` copy).
 """
 
-from __future__ import annotations
-
 import json
 from dataclasses import dataclass
 from datetime import datetime
@@ -40,7 +38,7 @@ class Sample:
     collected_at: datetime | None = None
 
     @classmethod
-    def of(cls, metric: str, value: float, /, **labels: str) -> Sample:
+    def of(cls, metric: str, value: float, /, **labels: str) -> "Sample":
         """Build an unstamped Sample with JSON-encoded labels.
 
         The runner stamps ``collected_at`` with the cycle's start time so all

--- a/infra/probes/src/sinks.py
+++ b/infra/probes/src/sinks.py
@@ -15,8 +15,6 @@ best-effort telemetry: the runner calls them after logging and swallows their
 failures, so a sink fault never disrupts collection.
 """
 
-from __future__ import annotations
-
 import gzip
 import json
 import logging

--- a/infra/probes/tests/test_cluster.py
+++ b/infra/probes/tests/test_cluster.py
@@ -6,8 +6,6 @@ per-region head count) and the job-state split into in-flight vs terminal-24h
 buckets. These exercise the pure ``aggregate_*`` over synthetic inputs, no live
 controller."""
 
-from __future__ import annotations
-
 import json
 
 import pytest

--- a/infra/probes/tests/test_provisioning.py
+++ b/infra/probes/tests/test_provisioning.py
@@ -5,8 +5,6 @@
 runtime deaths (preemptions) kept out of the success rate, and latency from READY
 rows. These exercise the pure ``aggregate`` over synthetic iris.provisioning rows."""
 
-from __future__ import annotations
-
 import json
 
 import pytest

--- a/infra/probes/tests/test_runner.py
+++ b/infra/probes/tests/test_runner.py
@@ -5,8 +5,6 @@
 tests assert on it via caplog and on the samples delivered to a recording sink.
 asyncio.wait_for bounds duration."""
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import time

--- a/infra/probes/tests/test_sample.py
+++ b/infra/probes/tests/test_sample.py
@@ -6,8 +6,6 @@ register_table contract: a declared key_column that names an existing column
 (or an implicit `timestamp_ms` column). Without it the metrics table never
 registers and FinelogTableSink drops every row."""
 
-from __future__ import annotations
-
 from finelog.client.log_client import schema_from_dataclass
 from sample import Sample
 

--- a/infra/probes/tests/test_sinks.py
+++ b/infra/probes/tests/test_sinks.py
@@ -5,8 +5,6 @@
 upload + local delete). The GCS write (open_url) is the only I/O boundary and
 is stubbed to capture uploads in memory."""
 
-from __future__ import annotations
-
 import dataclasses
 import gzip
 import io

--- a/lib/finelog/dashboard/scripts/demo.py
+++ b/lib/finelog/dashboard/scripts/demo.py
@@ -19,8 +19,6 @@ Requires the native extension (the marin-finelog-server wheel, or a
 rust_mode.py dev build).
 """
 
-from __future__ import annotations
-
 import argparse
 import base64
 import dataclasses

--- a/lib/finelog/scripts/safe_deploy.py
+++ b/lib/finelog/scripts/safe_deploy.py
@@ -18,8 +18,6 @@ Usage:
     uv run python lib/finelog/scripts/safe_deploy.py status marin-dev
 """
 
-from __future__ import annotations
-
 import json
 import subprocess
 from datetime import UTC, datetime

--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import dataclasses
 import io
 import logging
@@ -491,7 +489,7 @@ class LogClient:
         resolver: Callable[[str], str] | None = None,
         timeout_ms: int = 10_000,
         interceptors: Iterable[Interceptor] = (),
-    ) -> LogClient:
+    ) -> "LogClient":
         """Construct a LogClient against ``endpoint``.
 
         ``endpoint`` is either an HTTP URL string or a ``(host, port)``

--- a/lib/finelog/src/finelog/client/remote_log_handler.py
+++ b/lib/finelog/src/finelog/client/remote_log_handler.py
@@ -7,8 +7,6 @@ Batching, retries, and backoff live inside the LogClient's per-namespace
 Table; the handler just formats records and calls ``write_batch``.
 """
 
-from __future__ import annotations
-
 import logging
 from typing import Protocol
 

--- a/lib/finelog/src/finelog/deploy/_gcp.py
+++ b/lib/finelog/src/finelog/deploy/_gcp.py
@@ -9,8 +9,6 @@ Lifted verbatim from the original `cli.py`, reshaped to take a
 /health poll, status, logs) lives here.
 """
 
-from __future__ import annotations
-
 import json
 import subprocess
 import sys

--- a/lib/finelog/src/finelog/deploy/_k8s.py
+++ b/lib/finelog/src/finelog/deploy/_k8s.py
@@ -8,8 +8,6 @@ shells out to `kubectl`. No kubernetes-client Python dep — the manifest
 list is small enough that subprocess is the right tool.
 """
 
-from __future__ import annotations
-
 import base64
 import json
 import os

--- a/lib/finelog/src/finelog/deploy/bootstrap.py
+++ b/lib/finelog/src/finelog/deploy/bootstrap.py
@@ -11,8 +11,6 @@ The finelog Docker image is assumed to be public on GHCR; no Artifact Registry
 or `docker login` wiring is performed here.
 """
 
-from __future__ import annotations
-
 import re
 
 # Container/host conventions baked into the bootstrap.

--- a/lib/finelog/src/finelog/deploy/build.py
+++ b/lib/finelog/src/finelog/deploy/build.py
@@ -13,8 +13,6 @@ The image must be pushed to a registry the deployment can pull from
 ``config/marin*.yaml`` references). Use ``docker login ghcr.io`` first.
 """
 
-from __future__ import annotations
-
 import subprocess
 from pathlib import Path
 

--- a/lib/finelog/src/finelog/deploy/cli.py
+++ b/lib/finelog/src/finelog/deploy/cli.py
@@ -11,8 +11,6 @@ config schema, mirroring how `iris cluster start` decides backend from
 cluster yaml.
 """
 
-from __future__ import annotations
-
 import csv
 import json
 import logging

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -10,8 +10,6 @@ and explicit; finelog owns its deployment knobs so iris's cluster yaml only
 has to reference the config by name.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from importlib.resources import files
 from pathlib import Path

--- a/lib/finelog/src/finelog/deploy/image.py
+++ b/lib/finelog/src/finelog/deploy/image.py
@@ -9,8 +9,6 @@ redeploy lands the exact image the tag points to right now — no node-cache
 staleness, and the rendered manifest records precisely what is running.
 """
 
-from __future__ import annotations
-
 import json
 import subprocess
 

--- a/lib/finelog/src/finelog/policy.py
+++ b/lib/finelog/src/finelog/policy.py
@@ -18,8 +18,6 @@ whose ``created_at_ms`` is older than ``now - max_age_seconds``, on
 top of the existing size / count caps.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 from finelog.rpc import finelog_stats_pb2 as stats_pb2

--- a/lib/finelog/src/finelog/schema.py
+++ b/lib/finelog/src/finelog/schema.py
@@ -15,8 +15,6 @@ on-disk persistence. The client only needs to declare schemas, encode
 them for the wire, and build Arrow tables, so that is all that lives here.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 import pyarrow as pa

--- a/lib/finelog/src/finelog/types.py
+++ b/lib/finelog/src/finelog/types.py
@@ -8,8 +8,6 @@ Finelog treats keys as opaque strings — any structure (e.g.
 concern.
 """
 
-from __future__ import annotations
-
 from typing import Protocol
 
 from connectrpc.code import Code

--- a/lib/finelog/tests/test_client.py
+++ b/lib/finelog/tests/test_client.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import io
 import logging
 import threading

--- a/lib/finelog/tests/test_config.py
+++ b/lib/finelog/tests/test_config.py
@@ -3,8 +3,6 @@
 
 """Tests for `finelog.deploy.config`."""
 
-from __future__ import annotations
-
 import textwrap
 from pathlib import Path
 

--- a/lib/finelog/tests/test_deploy_cli.py
+++ b/lib/finelog/tests/test_deploy_cli.py
@@ -7,8 +7,6 @@ The CLI command itself opens a real connection (gcsfs in production); these
 tests cover the testable seams against a local parquet directory.
 """
 
-from __future__ import annotations
-
 import os
 from pathlib import Path
 

--- a/lib/finelog/tests/test_deploy_k8s.py
+++ b/lib/finelog/tests/test_deploy_k8s.py
@@ -3,8 +3,6 @@
 
 """Tests for k8s manifest rendering in `finelog.deploy._k8s`."""
 
-from __future__ import annotations
-
 import base64
 import json
 

--- a/lib/fray/src/fray/actor.py
+++ b/lib/fray/src/fray/actor.py
@@ -8,8 +8,6 @@ returns an ActorFuture, handle.method() calls synchronously. ActorGroup
 holds a set of actor handles with lifecycle tied to underlying jobs.
 """
 
-from __future__ import annotations
-
 import threading
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -19,7 +17,7 @@ from typing import Any, Protocol
 class ActorHandle(Protocol):
     """Handle to a remote actor with .method.remote() calling convention."""
 
-    def __getattr__(self, method_name: str) -> ActorMethod: ...
+    def __getattr__(self, method_name: str) -> "ActorMethod": ...
 
 
 @dataclass(frozen=True)

--- a/lib/fray/src/fray/client.py
+++ b/lib/fray/src/fray/client.py
@@ -3,8 +3,6 @@
 
 """Client protocol and helpers for fray."""
 
-from __future__ import annotations
-
 import logging
 import time
 from collections.abc import Sequence

--- a/lib/fray/src/fray/current_client.py
+++ b/lib/fray/src/fray/current_client.py
@@ -9,8 +9,6 @@ exceptions) does not transitively import fray.iris_backend or
 fray.local_backend, which would form a circular dependency.
 """
 
-from __future__ import annotations
-
 import contextlib
 import contextvars
 import logging

--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -8,8 +8,6 @@ Handles type conversion between fray types and Iris types, actor hosting
 via submitted jobs, and deferred actor handle resolution.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import sys
@@ -320,7 +318,7 @@ class IrisActorHandle:
             self._client = ActorClient(ctx.resolver, self._endpoint_name)
             return self._client
 
-    def __getattr__(self, method_name: str) -> _IrisActorMethod:
+    def __getattr__(self, method_name: str) -> "_IrisActorMethod":
         if method_name.startswith("_"):
             raise AttributeError(method_name)
         return _IrisActorMethod(self, method_name)
@@ -570,7 +568,7 @@ class FrayIrisClient:
         self._iris = IrisClientLib.remote(controller_address, workspace=workspace, bundle_id=bundle_id)
 
     @staticmethod
-    def from_iris_client(iris_client: IrisClientLib) -> FrayIrisClient:
+    def from_iris_client(iris_client: IrisClientLib) -> "FrayIrisClient":
         """Create a FrayIrisClient by wrapping an existing IrisClient.
 
         This avoids creating a new connection when we already have an IrisClient

--- a/lib/fray/src/fray/local_backend.py
+++ b/lib/fray/src/fray/local_backend.py
@@ -3,8 +3,6 @@
 
 """LocalClient: in-process fray backend for development and testing."""
 
-from __future__ import annotations
-
 import contextvars
 import logging
 import subprocess
@@ -172,7 +170,7 @@ class LocalClient:
         resources: ResourceConfig = ResourceConfig(),
         actor_config: ActorConfig = ActorConfig(),
         **kwargs: Any,
-    ) -> LocalActorHandle:
+    ) -> "LocalActorHandle":
         """Create an in-process actor, returning a handle immediately."""
         group = self.create_actor_group(actor_class, *args, name=name, count=1, resources=resources, **kwargs)
         return group.wait_ready()[0]  # type: ignore[return-value]
@@ -240,7 +238,7 @@ class LocalActorHandle:
             raise RuntimeError(f"Actor not found in registry: {self._endpoint}")
         return instance
 
-    def __getattr__(self, method_name: str) -> LocalActorMethod:
+    def __getattr__(self, method_name: str) -> "LocalActorMethod":
         if method_name.startswith("_"):
             raise AttributeError(method_name)
         instance = self._resolve()

--- a/lib/fray/src/fray/types.py
+++ b/lib/fray/src/fray/types.py
@@ -9,8 +9,6 @@ ResourceConfig to JobRequest (it's a job-level gang-scheduling concern,
 not a per-task resource requirement).
 """
 
-from __future__ import annotations
-
 import os
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
@@ -361,7 +359,7 @@ class ResourceConfig:
         return self.device_flops(dtype) * self.chip_count()
 
     @staticmethod
-    def with_tpu(tpu_type: str | Sequence[str], *, slice_count: int = 1, **kwargs: Any) -> ResourceConfig:
+    def with_tpu(tpu_type: str | Sequence[str], *, slice_count: int = 1, **kwargs: Any) -> "ResourceConfig":
         """Create a resource config for TPU(s).
 
         When ``tpu_type`` is a list, the first entry is canonical (used for
@@ -403,12 +401,12 @@ class ResourceConfig:
         return ResourceConfig(device=device, replicas=replicas, device_alternatives=alternatives, **kwargs)
 
     @staticmethod
-    def with_gpu(gpu_type: str, count: int = 1, **kwargs: Any) -> ResourceConfig:
+    def with_gpu(gpu_type: str, count: int = 1, **kwargs: Any) -> "ResourceConfig":
         device = GpuConfig(variant=gpu_type, count=count)
         return ResourceConfig(device=device, **kwargs)
 
     @staticmethod
-    def with_cpu(**kwargs: Any) -> ResourceConfig:
+    def with_cpu(**kwargs: Any) -> "ResourceConfig":
         return ResourceConfig(device=CpuConfig(), **kwargs)
 
 
@@ -541,11 +539,11 @@ class Entrypoint:
         c: Callable[..., Any],
         args: Sequence[Any] = (),
         kwargs: dict[str, Any] | None = None,
-    ) -> Entrypoint:
+    ) -> "Entrypoint":
         return Entrypoint(callable_entrypoint=CallableEntrypoint(callable=c, args=args, kwargs=kwargs or {}))
 
     @staticmethod
-    def from_binary(command: str, args: Sequence[str]) -> Entrypoint:
+    def from_binary(command: str, args: Sequence[str]) -> "Entrypoint":
         return Entrypoint(binary_entrypoint=BinaryEntrypoint(command=command, args=args))
 
 
@@ -595,5 +593,5 @@ class JobStatus(StrEnum):
     STOPPED = "stopped"
 
     @staticmethod
-    def finished(status: JobStatus) -> bool:
+    def finished(status: "JobStatus") -> bool:
         return status in (JobStatus.SUCCEEDED, JobStatus.FAILED, JobStatus.STOPPED)

--- a/lib/iris/scripts/iap_gclb.py
+++ b/lib/iris/scripts/iap_gclb.py
@@ -61,8 +61,6 @@ Usage:
     uv run lib/iris/scripts/iap_gclb.py teardown marin-dev
 """
 
-from __future__ import annotations
-
 import dataclasses
 import json
 import logging

--- a/lib/iris/scripts/job_profile_summary.py
+++ b/lib/iris/scripts/job_profile_summary.py
@@ -38,8 +38,6 @@ Usage:
     uv run python scripts/job_profile_summary.py <job> -o merged.folded --svg flame.svg
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import logging
@@ -289,7 +287,7 @@ class Aggregate:
     tasks: set[str]
 
     @classmethod
-    def empty(cls) -> Aggregate:
+    def empty(cls) -> "Aggregate":
         return cls(
             stacks=defaultdict(float),
             leaves=defaultdict(float),
@@ -411,7 +409,7 @@ def library_rollup_rows(agg: Aggregate, top: int) -> list[list[str]]:
 class CallNode:
     label: str
     value: float
-    children: dict[str, CallNode]
+    children: "dict[str, CallNode]"
 
 
 def build_call_tree(stacks: dict[str, float]) -> CallNode:

--- a/lib/iris/scripts/setup_iam.py
+++ b/lib/iris/scripts/setup_iam.py
@@ -9,8 +9,6 @@ grants their project roles, and wires impersonation / act-as bindings for the
 configured CI and operator principals.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import os

--- a/lib/iris/src/iris/cluster/backends/_worker_base.py
+++ b/lib/iris/src/iris/cluster/backends/_worker_base.py
@@ -11,8 +11,6 @@ operations (status queries, terminate, labels, etc.).
 Local handles use subprocess rather than SSH, so they do not use this base.
 """
 
-from __future__ import annotations
-
 import logging
 import shlex
 from collections.abc import Callable

--- a/lib/iris/src/iris/cluster/backends/gcp/bootstrap.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/bootstrap.py
@@ -8,8 +8,6 @@ bootstrap handles Docker setup and container startup. TPU metadata discovery
 is performed by the worker environment probe at runtime.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import re

--- a/lib/iris/src/iris/cluster/backends/gcp/controller.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/controller.py
@@ -7,8 +7,6 @@ Implements the ControllerProvider protocol: discover, start, restart, stop,
 stop_all, tunnel, resolve_image, debug_report.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import subprocess

--- a/lib/iris/src/iris/cluster/backends/gcp/fake.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/fake.py
@@ -11,8 +11,6 @@ Failure injection (inject_failure, set_zone_quota, set_tpu_type_unavailable) is
 supported in DRY_RUN and LOCAL modes for testing.
 """
 
-from __future__ import annotations
-
 import dataclasses
 import logging
 import uuid

--- a/lib/iris/src/iris/cluster/backends/gcp/handles.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/handles.py
@@ -9,8 +9,6 @@ GcpSliceHandle: TPU pod slice (describe, terminate)
 GcpVmSliceHandle: Single-VM GCE-backed slice
 """
 
-from __future__ import annotations
-
 import logging
 import re
 import threading

--- a/lib/iris/src/iris/cluster/backends/gcp/local.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/local.py
@@ -7,8 +7,6 @@ Provides LocalSliceHandle and worker handle classes used by InMemoryGcpService
 in LOCAL mode. Local testing uses GcpWorkerProvider + InMemoryGcpService(mode=ServiceMode.LOCAL).
 """
 
-from __future__ import annotations
-
 import logging
 import subprocess
 from collections.abc import Callable

--- a/lib/iris/src/iris/cluster/backends/gcp/service.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/service.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import json
 import logging
 import re

--- a/lib/iris/src/iris/cluster/backends/gcp/ssh.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/ssh.py
@@ -3,8 +3,6 @@
 
 """Shared SSH helpers for GCP providers."""
 
-from __future__ import annotations
-
 from iris.rpc import config_pb2
 
 # Instance metadata that opts a VM into OS Login. Applied at VM creation by

--- a/lib/iris/src/iris/cluster/backends/gcp/workers.py
+++ b/lib/iris/src/iris/cluster/backends/gcp/workers.py
@@ -8,8 +8,6 @@ for the Autoscaler and ScalingGroup. Manages GCE instances (standalone VMs)
 and TPU slices via GcpService.
 """
 
-from __future__ import annotations
-
 import logging
 import threading
 import time

--- a/lib/iris/src/iris/cluster/backends/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/controller.py
@@ -7,8 +7,6 @@ Manages the controller Deployment, Service, ConfigMap, RBAC, NodePools, and
 S3 credential Secrets. Worker pods and node scaling are handled by K8sTaskProvider.
 """
 
-from __future__ import annotations
-
 import base64
 import json
 import logging

--- a/lib/iris/src/iris/cluster/backends/k8s/fake.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/fake.py
@@ -11,8 +11,6 @@ background threads, with stdout/stderr captured as pod logs and pod
 status updated automatically on completion.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import subprocess

--- a/lib/iris/src/iris/cluster/backends/k8s/logship.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/logship.py
@@ -20,8 +20,6 @@ The push is unauthenticated: the finelog log service performs no auth, the same
 posture under which the controller writes its own logs.
 """
 
-from __future__ import annotations
-
 import glob
 import logging
 import os

--- a/lib/iris/src/iris/cluster/backends/k8s/service.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/service.py
@@ -3,8 +3,6 @@
 
 """K8sService protocol and CloudK8sService (kubernetes DynamicClient) implementation."""
 
-from __future__ import annotations
-
 import logging
 import os
 import socket
@@ -185,10 +183,10 @@ class CloudK8sService:
     namespace: str
     kubeconfig_path: str | None = None
     timeout: float = DEFAULT_TIMEOUT
-    _api_client: kubernetes.client.ApiClient = field(init=False, repr=False)
-    _dyn: DynamicClient = field(init=False, repr=False)
-    _core_v1: kubernetes.client.CoreV1Api = field(init=False, repr=False)
-    _custom: kubernetes.client.CustomObjectsApi = field(init=False, repr=False)
+    _api_client: "kubernetes.client.ApiClient" = field(init=False, repr=False)
+    _dyn: "DynamicClient" = field(init=False, repr=False)
+    _core_v1: "kubernetes.client.CoreV1Api" = field(init=False, repr=False)
+    _custom: "kubernetes.client.CustomObjectsApi" = field(init=False, repr=False)
     _kubectl_prefix: list[str] = field(init=False, repr=False)
 
     def __post_init__(self) -> None:
@@ -209,7 +207,7 @@ class CloudK8sService:
             cmd.extend(["--kubeconfig", self.kubeconfig_path])
         self._kubectl_prefix = cmd
 
-    def create_api_client(self) -> kubernetes.client.ApiClient:
+    def create_api_client(self) -> "kubernetes.client.ApiClient":
         if self.kubeconfig_path:
             return kubernetes.config.new_client_from_config(
                 config_file=self.kubeconfig_path,

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -7,8 +7,6 @@ No worker daemon, no synthetic worker row. The controller talks directly to the
 k8s API via kubectl, launching one Pod per task attempt.
 """
 
-from __future__ import annotations
-
 import base64
 import hashlib
 import json

--- a/lib/iris/src/iris/cluster/backends/k8s/types.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/types.py
@@ -3,8 +3,6 @@
 
 """Shared data types for the k8s cluster layer."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from datetime import datetime
 from enum import Enum
@@ -84,7 +82,7 @@ class K8sResource(Enum):
         return f"{self.collection_path(namespace)}/{name}"
 
     @classmethod
-    def from_kind(cls, kind: str) -> K8sResource:
+    def from_kind(cls, kind: str) -> "K8sResource":
         """Look up a resource by its manifest kind string."""
         for member in cls:
             if member.kind == kind:

--- a/lib/iris/src/iris/cluster/backends/protocols.py
+++ b/lib/iris/src/iris/cluster/backends/protocols.py
@@ -11,8 +11,6 @@ Two protocols define the boundary between Iris orchestration and infrastructure:
 Concrete implementations live under providers/gcp/, providers/k8s/, etc.
 """
 
-from __future__ import annotations
-
 from contextlib import AbstractContextManager
 from typing import Protocol
 

--- a/lib/iris/src/iris/cluster/backends/remote_exec.py
+++ b/lib/iris/src/iris/cluster/backends/remote_exec.py
@@ -11,8 +11,6 @@ This module provides:
 - Utility functions for connection testing and streaming commands
 """
 
-from __future__ import annotations
-
 import dataclasses
 import logging
 import subprocess

--- a/lib/iris/src/iris/cluster/backends/rpc/backend.py
+++ b/lib/iris/src/iris/cluster/backends/rpc/backend.py
@@ -10,8 +10,6 @@ back to the controller, and surfaces the per-worker liveness it observed
 (REACHED / UNREACHABLE) as health events the controller folds.
 """
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import threading

--- a/lib/iris/src/iris/cluster/backends/types.py
+++ b/lib/iris/src/iris/cluster/backends/types.py
@@ -7,8 +7,6 @@ Provider implementations and consumers depend on this single, self-contained
 module without pulling in the full provider protocols or any concrete implementation.
 """
 
-from __future__ import annotations
-
 import datetime
 import logging
 import os
@@ -203,7 +201,7 @@ class SliceStatus:
 
     state: CloudSliceState
     worker_count: int
-    workers: list[RemoteWorkerHandle] = field(default_factory=list)
+    workers: "list[RemoteWorkerHandle]" = field(default_factory=list)
     error_message: str = ""
 
 

--- a/lib/iris/src/iris/cluster/backends/vm_lifecycle.py
+++ b/lib/iris/src/iris/cluster/backends/vm_lifecycle.py
@@ -21,8 +21,6 @@ uniformly across GCP and Manual providers.  For local mode, use LocalCluster
 directly (fundamentally different mechanism: in-process, no SSH/Docker).
 """
 
-from __future__ import annotations
-
 import logging
 import time
 from collections.abc import Callable

--- a/lib/iris/src/iris/cluster/bundle.py
+++ b/lib/iris/src/iris/cluster/bundle.py
@@ -11,8 +11,6 @@ i.e. on workers). Eviction from the in-memory cache does not delete from
 fsspec storage.
 """
 
-from __future__ import annotations
-
 import hashlib
 import io
 import logging

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -10,8 +10,6 @@ Supports YAML config files for cluster management. This module provides:
 - IrisConfig high-level wrapper with component factories
 """
 
-from __future__ import annotations
-
 import copy
 import logging
 import os
@@ -1079,7 +1077,7 @@ class IrisConfig:
         self._proto = apply_defaults(proto)
 
     @classmethod
-    def load(cls, config_path: Path | str) -> IrisConfig:
+    def load(cls, config_path: Path | str) -> "IrisConfig":
         """Load IrisConfig from YAML file.
 
         Args:
@@ -1118,7 +1116,7 @@ class IrisConfig:
             ssh_config=self._proto.defaults.ssh,
         )
 
-    def as_local(self) -> IrisConfig:
+    def as_local(self) -> "IrisConfig":
         """Create local variant of this config.
 
         Returns:

--- a/lib/iris/src/iris/cluster/config_serde.py
+++ b/lib/iris/src/iris/cluster/config_serde.py
@@ -3,8 +3,6 @@
 
 """Pure serialization for Iris cluster config: proto -> YAML-friendly dict."""
 
-from __future__ import annotations
-
 from google.protobuf.json_format import MessageToDict
 
 from iris.rpc import config_pb2

--- a/lib/iris/src/iris/cluster/constraints.py
+++ b/lib/iris/src/iris/cluster/constraints.py
@@ -32,8 +32,6 @@ A job's region requirement has three distinct states:
   ``region EXISTS`` would otherwise exclude workers/groups that advertise no region).
 """
 
-from __future__ import annotations
-
 from collections import defaultdict
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
@@ -131,7 +129,7 @@ class AttributeValue:
         return proto
 
     @staticmethod
-    def from_proto(proto: job_pb2.AttributeValue) -> AttributeValue:
+    def from_proto(proto: job_pb2.AttributeValue) -> "AttributeValue":
         """Convert from protobuf representation."""
         if proto.HasField("string_value"):
             return AttributeValue(proto.string_value)
@@ -259,7 +257,7 @@ class Constraint:
         return proto
 
     @staticmethod
-    def from_proto(proto: job_pb2.Constraint) -> Constraint:
+    def from_proto(proto: job_pb2.Constraint) -> "Constraint":
         """Convert from protobuf representation.
 
         Normalization (strip/lowercase for strings) happens inside
@@ -284,7 +282,7 @@ class Constraint:
         value: str | int | float | None = None,
         values: Sequence[str | int | float] | None = None,
         mode: int = job_pb2.CONSTRAINT_MODE_REQUIRED,
-    ) -> Constraint:
+    ) -> "Constraint":
         """Ergonomic factory: wraps raw scalars in AttributeValue automatically.
 
         - Singular ops (EQ/NE/GT/GE/LT/LE): pass ``value=``.
@@ -1099,7 +1097,7 @@ class ConstraintIndex:
     _entity_attributes: dict[str, dict[str, AttributeValue]]
 
     @classmethod
-    def build(cls, entities: dict[str, dict[str, AttributeValue]]) -> ConstraintIndex:
+    def build(cls, entities: dict[str, dict[str, AttributeValue]]) -> "ConstraintIndex":
         """Build index from entity_id -> attributes mapping."""
         discrete_lists: dict[str, dict[str | int | float, set[str]]] = {}
         for entity_id, attrs in entities.items():

--- a/lib/iris/src/iris/cluster/controller/autoscaler/provisioning.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/provisioning.py
@@ -3,8 +3,6 @@
 
 """The ``iris.provisioning`` finelog namespace: one row per slice provisioning outcome."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum

--- a/lib/iris/src/iris/cluster/controller/backend.py
+++ b/lib/iris/src/iris/cluster/controller/backend.py
@@ -31,8 +31,6 @@ folded by the controller; cluster backends have no Iris workers, so they emit no
 health events.
 """
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Mapping
 from dataclasses import dataclass, field
@@ -113,7 +111,7 @@ class BackendDescriptor:
     capabilities: list[str]
 
 
-def backend_descriptor(backend: TaskBackend) -> BackendDescriptor:
+def backend_descriptor(backend: "TaskBackend") -> BackendDescriptor:
     """Build the dashboard capability descriptor from a live backend."""
     return BackendDescriptor(
         name=backend.name,

--- a/lib/iris/src/iris/cluster/controller/scheduling/decision.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/decision.py
@@ -8,8 +8,6 @@ Pure scheduling-layer helpers: they consume only ``scheduling.policy`` /
 carry no edge back to the controller's ops/reconcile/schema layer.
 """
 
-from __future__ import annotations
-
 from iris.cluster.controller.scheduling.policy import (
     PreemptionCandidate,
     SchedulingOrder,

--- a/lib/iris/src/iris/cluster/endpoints.py
+++ b/lib/iris/src/iris/cluster/endpoints.py
@@ -32,8 +32,6 @@ Example YAML:
           port: "10001"
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import subprocess

--- a/lib/iris/src/iris/cluster/inject_env.py
+++ b/lib/iris/src/iris/cluster/inject_env.py
@@ -9,8 +9,6 @@ in its own module (importing only the proto) so the controller backends can use
 it without the `config` → `backends.factory` import cycle.
 """
 
-from __future__ import annotations
-
 import os
 from collections.abc import Sequence
 

--- a/lib/iris/src/iris/cluster/lifecycle.py
+++ b/lib/iris/src/iris/cluster/lifecycle.py
@@ -7,8 +7,6 @@ Provides high-level helpers that construct concrete provider implementations and
 drive cluster startup/shutdown.
 """
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 from contextlib import contextmanager
 

--- a/lib/iris/src/iris/cluster/log_keys.py
+++ b/lib/iris/src/iris/cluster/log_keys.py
@@ -7,8 +7,6 @@ Keys are plain strings on the finelog side; this module owns the mapping from
 iris-domain values (`JobName`, `TaskAttempt`) to those strings.
 """
 
-from __future__ import annotations
-
 from finelog.rpc import logging_pb2
 
 from iris.cluster.types import JobName, TaskAttempt

--- a/lib/iris/src/iris/cluster/runtime/process.py
+++ b/lib/iris/src/iris/cluster/runtime/process.py
@@ -14,8 +14,6 @@ Lifecycle management includes:
 - Process group termination on Unix platforms
 """
 
-from __future__ import annotations
-
 import atexit
 import logging
 import os
@@ -65,7 +63,7 @@ logger = logging.getLogger(__name__)
 # Python interpreter shuts down (normal exit, sys.exit, unhandled exceptions).
 # This does NOT cover SIGKILL of the parent.
 
-_active_runtimes: weakref.WeakSet[ProcessRuntime] = weakref.WeakSet()
+_active_runtimes: "weakref.WeakSet[ProcessRuntime]" = weakref.WeakSet()
 
 
 def _cleanup_all_runtimes() -> None:
@@ -389,7 +387,7 @@ class ProcessContainerHandle:
     """
 
     config: ContainerConfig
-    runtime: ProcessRuntime
+    runtime: "ProcessRuntime"
     _container: ProcessContainer | None = field(default=None, repr=False)
     _container_id: str | None = field(default=None, repr=False)
     _prev_cpu_total: float = field(default=0.0, repr=False)

--- a/lib/iris/src/iris/cluster/runtime/profile.py
+++ b/lib/iris/src/iris/cluster/runtime/profile.py
@@ -11,8 +11,6 @@ The module also provides `profile_local_process` for profiling the current
 interpreter process (used by the controller and worker for /system/process).
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import shutil

--- a/lib/iris/src/iris/cluster/tpu_topology.py
+++ b/lib/iris/src/iris/cluster/tpu_topology.py
@@ -8,8 +8,6 @@ Leaf module shared by :mod:`iris.cluster.types` and
 either without inducing a top-level import cycle.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 

--- a/lib/iris/src/iris/cluster/worker/stats.py
+++ b/lib/iris/src/iris/cluster/worker/stats.py
@@ -16,8 +16,6 @@ schema is registered lazily on first ``report_task_status_text`` call so a
 CLI that never touches status text doesn't open a finelog connection.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 from datetime import datetime
 from enum import StrEnum

--- a/lib/iris/src/iris/env_resources.py
+++ b/lib/iris/src/iris/env_resources.py
@@ -14,8 +14,6 @@ factory that discovers limits using an escalation strategy:
 GPU/TPU counts are only available via the ``IRIS_TASK_RESOURCES`` env var.
 """
 
-from __future__ import annotations
-
 import dataclasses
 import functools
 import logging
@@ -53,7 +51,7 @@ class TaskResources:
     tpu_count: int
 
     @staticmethod
-    def from_environment() -> TaskResources:
+    def from_environment() -> "TaskResources":
         """Discover resource limits from env var, cgroups, and /proc.
 
         CPU/memory fall back to host values when no Iris env var or cgroup

--- a/lib/iris/src/iris/rpc/async_adapter.py
+++ b/lib/iris/src/iris/rpc/async_adapter.py
@@ -19,8 +19,6 @@ Interceptors are not adapted here — each interceptor that participates in
 an ASGI chain implements ``async intercept_unary`` directly.
 """
 
-from __future__ import annotations
-
 import asyncio
 import functools
 import inspect

--- a/lib/iris/src/iris/rpc/codecs.py
+++ b/lib/iris/src/iris/rpc/codecs.py
@@ -17,8 +17,6 @@ no-behavior wire-size + CPU win.
 Idempotent. Safe to import from multiple modules.
 """
 
-from __future__ import annotations
-
 import threading
 
 from connectrpc import _codec

--- a/lib/iris/src/iris/rpc/compression.py
+++ b/lib/iris/src/iris/rpc/compression.py
@@ -10,8 +10,6 @@ zstd is listed first as the preferred response encoding; gzip is kept for
 interop with older peers.
 """
 
-from __future__ import annotations
-
 from connectrpc.compression.gzip import GzipCompression
 from connectrpc.compression.zstd import ZstdCompression
 

--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -9,8 +9,6 @@ Single-task jobs skip distributed init entirely — JAX defaults suffice.
 JAX is imported at call time — iris does not depend on jax.
 """
 
-from __future__ import annotations
-
 import atexit
 import logging
 import os

--- a/lib/iris/tests/cluster/backends/gcp/test_bootstrap.py
+++ b/lib/iris/tests/cluster/backends/gcp/test_bootstrap.py
@@ -3,8 +3,6 @@
 
 """Tests for worker bootstrap script generation."""
 
-from __future__ import annotations
-
 import pytest
 from iris.cluster.backends.gcp.bootstrap import (
     build_worker_bootstrap_script,

--- a/lib/iris/tests/cluster/backends/gcp/test_cloud_service_integration.py
+++ b/lib/iris/tests/cluster/backends/gcp/test_cloud_service_integration.py
@@ -10,8 +10,6 @@ call is recorded so we can compare the REST API behavior against what the old
 gcloud CLI produced.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import urllib.parse

--- a/lib/iris/tests/cluster/backends/gcp/test_gcp_service.py
+++ b/lib/iris/tests/cluster/backends/gcp/test_gcp_service.py
@@ -11,8 +11,6 @@ These tests cover:
 - Failure injection (one-shot error injection for testing error paths)
 """
 
-from __future__ import annotations
-
 import time
 from collections.abc import Callable
 from unittest.mock import MagicMock, patch

--- a/lib/iris/tests/cluster/backends/gcp/test_platform.py
+++ b/lib/iris/tests/cluster/backends/gcp/test_platform.py
@@ -8,8 +8,6 @@ Tests exercise the Platform protocol contract through parameterized fixtures
 tests that cannot be expressed through the protocol are in dedicated sections.
 """
 
-from __future__ import annotations
-
 import unittest.mock
 from collections.abc import Iterator
 from dataclasses import dataclass

--- a/lib/iris/tests/cluster/backends/k8s/conftest.py
+++ b/lib/iris/tests/cluster/backends/k8s/conftest.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import pytest
 from finelog.rpc.logging_connect import LogServiceClientSync
 from iris.cluster.backends.k8s.fake import InMemoryK8sService

--- a/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_cloud_k8s_service.py
@@ -3,8 +3,6 @@
 
 """Tests for CloudK8sService helpers and K8sResource enum path construction."""
 
-from __future__ import annotations
-
 import pytest
 from iris.cluster.backends.k8s.types import K8sResource
 

--- a/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
@@ -9,8 +9,6 @@ configuration. Worker/slice management is handled by K8sTaskProvider (not
 K8sControllerProvider).
 """
 
-from __future__ import annotations
-
 import base64
 import json
 import threading

--- a/lib/iris/tests/cluster/backends/k8s/test_k8s_parsers.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_k8s_parsers.py
@@ -3,8 +3,6 @@
 
 """Tests for K8s resource quantity parsers."""
 
-from __future__ import annotations
-
 from datetime import UTC, datetime
 
 import pytest

--- a/lib/iris/tests/cluster/backends/k8s/test_k8s_service.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_k8s_service.py
@@ -7,8 +7,6 @@ Covers validation, scheduling, resource tracking, and protocol behavior
 that matters to K8sTaskProvider and CoreWeave controller consumers.
 """
 
-from __future__ import annotations
-
 import pytest
 from iris.cluster.backends.k8s.fake import FakeNodeResources, InMemoryK8sService
 from iris.cluster.backends.k8s.types import K8sResource, KubectlError

--- a/lib/iris/tests/cluster/backends/k8s/test_logship.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_logship.py
@@ -3,8 +3,6 @@
 
 """Tests for the log-shipper sidecar: CRI parsing, tailing, rotation, key derivation."""
 
-from __future__ import annotations
-
 import threading
 import time
 

--- a/lib/iris/tests/cluster/backends/k8s/test_provider.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_provider.py
@@ -3,8 +3,6 @@
 
 """Tests for K8sTaskProvider: sync lifecycle, capacity, scheduling, profiling."""
 
-from __future__ import annotations
-
 from datetime import UTC, datetime, timedelta
 
 import pytest

--- a/lib/iris/tests/cluster/conftest.py
+++ b/lib/iris/tests/cluster/conftest.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import hashlib
 from dataclasses import dataclass
 from unittest.mock import Mock

--- a/lib/iris/tests/cluster/controller/test_backoff_detector.py
+++ b/lib/iris/tests/cluster/controller/test_backoff_detector.py
@@ -3,8 +3,6 @@
 
 """Unit tests for the AIMD backoff detector."""
 
-from __future__ import annotations
-
 import math
 
 import pytest

--- a/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
@@ -9,8 +9,6 @@ round-trip: method, path suffix, query string, headers, and streaming
 bodies.
 """
 
-from __future__ import annotations
-
 import asyncio
 import socket
 import time

--- a/lib/iris/tests/cluster/controller/test_endpoints_projection.py
+++ b/lib/iris/tests/cluster/controller/test_endpoints_projection.py
@@ -3,8 +3,6 @@
 
 """Tests for ``EndpointsProjection`` — write-through cache over the ``endpoints`` table."""
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import pytest

--- a/lib/iris/tests/cluster/controller/test_main_endpoints.py
+++ b/lib/iris/tests/cluster/controller/test_main_endpoints.py
@@ -3,8 +3,6 @@
 
 """Tests for endpoint resolution in the controller daemon entrypoint."""
 
-from __future__ import annotations
-
 import json
 import subprocess
 from pathlib import Path

--- a/lib/iris/tests/cluster/controller/test_provisioning.py
+++ b/lib/iris/tests/cluster/controller/test_provisioning.py
@@ -9,8 +9,6 @@ authoritative resource_type/zone/variant and the ready-only latency rule are
 covered without driving a live controller.
 """
 
-from __future__ import annotations
-
 import pytest
 from iris.cluster.backends.types import InfraError, QuotaExhaustedError
 from iris.cluster.controller.autoscaler.provisioning import (

--- a/lib/iris/tests/cluster/controller/test_reconcile.py
+++ b/lib/iris/tests/cluster/controller/test_reconcile.py
@@ -14,8 +14,6 @@ Three layers, exercised in order:
    tick's reconcile phase (``reconcile_once``).
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from typing import Any, ClassVar
 

--- a/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
+++ b/lib/iris/tests/cluster/controller/test_vm_lifecycle.py
@@ -26,8 +26,6 @@ when ``healthy=False``, it returns failure. A short health_check_timeout
 ensures unhealthy tests complete quickly without real polling delays.
 """
 
-from __future__ import annotations
-
 from collections.abc import Callable
 from contextlib import AbstractContextManager, nullcontext
 

--- a/lib/iris/tests/cluster/controller/test_worker_attrs_projection.py
+++ b/lib/iris/tests/cluster/controller/test_worker_attrs_projection.py
@@ -3,8 +3,6 @@
 
 """Tests for ``WorkerAttrsProjection`` — write-through cache over ``worker_attributes``."""
 
-from __future__ import annotations
-
 import threading
 from pathlib import Path
 

--- a/lib/iris/tests/cluster/controller/test_writes_to_check.py
+++ b/lib/iris/tests/cluster/controller/test_writes_to_check.py
@@ -3,8 +3,6 @@
 
 """Tests for the Stage 12 ``@writes_to`` owned-table startup check."""
 
-from __future__ import annotations
-
 import shutil
 import tempfile
 from collections.abc import Iterator

--- a/lib/iris/tests/cluster/runtime/test_docker_runtime.py
+++ b/lib/iris/tests/cluster/runtime/test_docker_runtime.py
@@ -3,8 +3,6 @@
 
 """Tests for DockerRuntime mount resolution, staging, and container creation."""
 
-from __future__ import annotations
-
 import subprocess
 from unittest.mock import Mock
 

--- a/lib/iris/tests/cluster/test_endpoints.py
+++ b/lib/iris/tests/cluster/test_endpoints.py
@@ -3,8 +3,6 @@
 
 """Tests for ``iris.cluster.endpoints.resolve_endpoint_uri``."""
 
-from __future__ import annotations
-
 import json
 import subprocess
 from unittest.mock import mock_open, patch

--- a/lib/iris/tests/cluster/test_env_propagation.py
+++ b/lib/iris/tests/cluster/test_env_propagation.py
@@ -10,8 +10,6 @@ vars like TPU_NAME or PATH that happen to be in os.environ.
 The parent's resolved setup is inherited via IRIS_JOB_SETUP_SCRIPTS.
 """
 
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from unittest.mock import patch
 

--- a/lib/iris/tests/e2e/gang_jax_smoke_workload.py
+++ b/lib/iris/tests/e2e/gang_jax_smoke_workload.py
@@ -18,8 +18,6 @@ across every device. The gradient all-reduce is the real inter-host collective
     GANG_SMOKE_PDB    per-device batch (default 8)
 """
 
-from __future__ import annotations
-
 import math
 import os
 

--- a/lib/iris/tests/e2e/gpu_gang_smoke.py
+++ b/lib/iris/tests/e2e/gpu_gang_smoke.py
@@ -40,8 +40,6 @@ Usage:
         --i-understand-the-cost
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import socket

--- a/lib/iris/tests/e2e/test_cli.py
+++ b/lib/iris/tests/e2e/test_cli.py
@@ -7,8 +7,6 @@ Uses ``iris cluster start --local`` through Click's test runner, then submits
 a job through the IrisClient to verify the full stack works.
 """
 
-from __future__ import annotations
-
 import threading
 import time
 from pathlib import Path

--- a/lib/iris/tests/e2e/test_demo_notebook.py
+++ b/lib/iris/tests/e2e/test_demo_notebook.py
@@ -3,8 +3,6 @@
 
 """E2E tests verifying the demo notebook submission patterns work end-to-end."""
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import pytest

--- a/lib/iris/tests/e2e/test_env_propagation.py
+++ b/lib/iris/tests/e2e/test_env_propagation.py
@@ -7,8 +7,6 @@ These tests boot a real local cluster and execute jobs to verify that env vars
 and the parent's resolved setup propagate correctly through job hierarchies.
 """
 
-from __future__ import annotations
-
 import json
 import time
 from unittest.mock import patch

--- a/lib/iris/tests/e2e/test_iris_run.py
+++ b/lib/iris/tests/e2e/test_iris_run.py
@@ -3,8 +3,6 @@
 
 """E2E integration tests for iris job CLI helpers that boot a real local cluster."""
 
-from __future__ import annotations
-
 import sys
 from pathlib import Path
 

--- a/lib/iris/tests/rpc/test_codecs.py
+++ b/lib/iris/tests/rpc/test_codecs.py
@@ -3,8 +3,6 @@
 
 """Tests for the compact JSON codec installed via :mod:`iris.rpc.codecs`."""
 
-from __future__ import annotations
-
 from connectrpc._codec import (
     CODEC_NAME_JSON,
     CODEC_NAME_JSON_CHARSET_UTF8,

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 from dataclasses import dataclass, field
 from unittest.mock import MagicMock, patch
 

--- a/lib/iris/tests/test_jax_init_integration.py
+++ b/lib/iris/tests/test_jax_init_integration.py
@@ -15,8 +15,6 @@ No real GPUs or Iris cluster needed — uses a thread-safe in-memory endpoint
 store and mocks jax.distributed.initialize.
 """
 
-from __future__ import annotations
-
 import threading
 import time
 from concurrent.futures import ThreadPoolExecutor

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -32,8 +32,6 @@ The bloom can also be built once and shared across many corpus marks via
 :func:`decon_to_parquet` as ``prebuilt_bloom_dir`` to skip the inline build.
 """
 
-from __future__ import annotations
-
 import hashlib
 import logging
 import os

--- a/lib/marin/src/marin/datakit/download/bio_chem/_runtime.py
+++ b/lib/marin/src/marin/datakit/download/bio_chem/_runtime.py
@@ -8,8 +8,6 @@ parquet file with ``{id, text, source}`` rows where ``text`` is one packed
 document containing one or more original records preserved verbatim.
 """
 
-from __future__ import annotations
-
 import enum
 import hashlib
 import logging

--- a/lib/marin/src/marin/datakit/download/bio_chem/chembl.py
+++ b/lib/marin/src/marin/datakit/download/bio_chem/chembl.py
@@ -15,8 +15,6 @@ Slices:
 * ``chembl_<v>.sdf.gz`` — full SDF dump; capped to a small head.
 """
 
-from __future__ import annotations
-
 from marin.datakit.download.bio_chem._runtime import (
     NotationFormat,
     NotationSliceSpec,

--- a/lib/marin/src/marin/datakit/download/bio_chem/moleculenet.py
+++ b/lib/marin/src/marin/datakit/download/bio_chem/moleculenet.py
@@ -14,8 +14,6 @@ modelling. To add more MoleculeNet tasks, append more ``NotationSliceSpec``
 entries pointing at the deepchem CSV/CSV.gz URLs.
 """
 
-from __future__ import annotations
-
 from marin.datakit.download.bio_chem._runtime import (
     NotationFormat,
     NotationSliceSpec,

--- a/lib/marin/src/marin/datakit/download/bio_chem/pubchem.py
+++ b/lib/marin/src/marin/datakit/download/bio_chem/pubchem.py
@@ -9,8 +9,6 @@
   shard. SDF entries are tens of KB each so the cap matters.
 """
 
-from __future__ import annotations
-
 from marin.datakit.download.bio_chem._runtime import (
     NotationFormat,
     NotationSliceSpec,

--- a/lib/marin/src/marin/datakit/download/bio_chem/rcsb_pdb.py
+++ b/lib/marin/src/marin/datakit/download/bio_chem/rcsb_pdb.py
@@ -14,8 +14,6 @@ capsid, etc.) so the slice exercises a range of mmCIF dialects without pulling
 megabytes per entry. Override ``RCSB_DEFAULT_IDS`` to widen the slice.
 """
 
-from __future__ import annotations
-
 from marin.datakit.download.bio_chem._runtime import (
     NotationFormat,
     NotationSliceSpec,

--- a/lib/marin/src/marin/datakit/download/bio_chem/refseq.py
+++ b/lib/marin/src/marin/datakit/download/bio_chem/refseq.py
@@ -13,8 +13,6 @@ Bacterial / fungal RefSeq subdivisions are far larger; if you want them, build
 another step with their FTP URLs.
 """
 
-from __future__ import annotations
-
 from marin.datakit.download.bio_chem._runtime import (
     NotationFormat,
     NotationSliceSpec,

--- a/lib/marin/src/marin/datakit/download/bio_chem/rnacentral.py
+++ b/lib/marin/src/marin/datakit/download/bio_chem/rnacentral.py
@@ -8,8 +8,6 @@ Streams ``rnacentral_active.fasta.gz`` from the EBI mirror. The full release is
 need to estimate perplexity on RNA notation.
 """
 
-from __future__ import annotations
-
 from marin.datakit.download.bio_chem._runtime import (
     NotationFormat,
     NotationSliceSpec,

--- a/lib/marin/src/marin/datakit/download/bio_chem/uniprot.py
+++ b/lib/marin/src/marin/datakit/download/bio_chem/uniprot.py
@@ -17,8 +17,6 @@ preferable for scale; add them as separate slices if you need them.
   the dedicated UniProt helper here.
 """
 
-from __future__ import annotations
-
 from marin.datakit.download.bio_chem._runtime import (
     NotationFormat,
     NotationSliceSpec,

--- a/lib/marin/src/marin/datakit/download/biodiversity.py
+++ b/lib/marin/src/marin/datakit/download/biodiversity.py
@@ -17,8 +17,6 @@ Zephyr ``group_by``) rather than as a list field on a single row (a
 per-row ``flat_map``).
 """
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 
 from fray import ResourceConfig

--- a/lib/marin/src/marin/datakit/download/common_pile.py
+++ b/lib/marin/src/marin/datakit/download/common_pile.py
@@ -14,8 +14,6 @@ shows the user-facing unfiltered names, but what actually downloads (and what
 the staged dirs on GCS hold) is the ``_filtered`` version.
 """
 
-from __future__ import annotations
-
 from marin.datakit.download.hf_simple_util import hf_normalize_steps
 from marin.execution.step_spec import StepSpec
 

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -3,8 +3,6 @@
 
 """Public diagnostic-log source inventory and GHALogs extraction helpers."""
 
-from __future__ import annotations
-
 import hashlib
 import json
 import logging
@@ -341,7 +339,7 @@ class _DocumentIdentityPseudonymizer:
     username_ids: dict[str, str]
 
     @classmethod
-    def from_text(cls, text: str) -> _DocumentIdentityPseudonymizer:
+    def from_text(cls, text: str) -> "_DocumentIdentityPseudonymizer":
         pseudonymizer = cls(identity_ids={}, username_ids={})
         for match in _EMAIL_RE.finditer(text):
             pseudonymizer._register_email(match.group(0))

--- a/lib/marin/src/marin/datakit/download/finepdfs.py
+++ b/lib/marin/src/marin/datakit/download/finepdfs.py
@@ -9,8 +9,6 @@ already holds only that language's shards). One chain per language, returned
 by :func:`finepdfs_normalize_steps`.
 """
 
-from __future__ import annotations
-
 from marin.datakit.download.hf_simple_util import hf_normalize_steps
 from marin.execution.step_spec import StepSpec
 

--- a/lib/marin/src/marin/datakit/download/finetranslations.py
+++ b/lib/marin/src/marin/datakit/download/finetranslations.py
@@ -14,8 +14,6 @@ read English→original. The order is chosen deterministically from a content ha
 so the step is reproducible across re-runs.
 """
 
-from __future__ import annotations
-
 from collections.abc import Iterator
 
 import dupekit

--- a/lib/marin/src/marin/datakit/download/formal_methods_evals.py
+++ b/lib/marin/src/marin/datakit/download/formal_methods_evals.py
@@ -22,8 +22,6 @@ Supported archive formats: ``tar``, ``tar.gz`` (``.tgz``), ``tar.bz2``, ``tar.xz
 the issue discussion and not supported by this module.
 """
 
-from __future__ import annotations
-
 import fnmatch
 import gzip
 import io

--- a/lib/marin/src/marin/datakit/download/game_music_evals.py
+++ b/lib/marin/src/marin/datakit/download/game_music_evals.py
@@ -3,8 +3,6 @@
 
 """Manifest-backed first-pass game/music ingestion helpers for long-tail PPL evals."""
 
-from __future__ import annotations
-
 import io
 import json
 import logging

--- a/lib/marin/src/marin/datakit/download/gh_archive.py
+++ b/lib/marin/src/marin/datakit/download/gh_archive.py
@@ -3,8 +3,6 @@
 
 """Download and normalize held-out GH Archive event slices for PPL/gap evals."""
 
-from __future__ import annotations
-
 import gzip
 import io
 import json

--- a/lib/marin/src/marin/datakit/download/hf_simple_util.py
+++ b/lib/marin/src/marin/datakit/download/hf_simple_util.py
@@ -22,8 +22,6 @@ Usage::
     # canonical artifact consumers sample/tokenize off of.
 """
 
-from __future__ import annotations
-
 from marin.datakit.download.huggingface import download_hf_step
 from marin.datakit.normalize import normalize_step as _normalize_step
 from marin.execution.step_spec import StepSpec

--- a/lib/marin/src/marin/datakit/download/http_session.py
+++ b/lib/marin/src/marin/datakit/download/http_session.py
@@ -3,8 +3,6 @@
 
 """Shared retry-aware ``requests.Session`` factory for HTTP-based download modules."""
 
-from __future__ import annotations
-
 import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util import Retry

--- a/lib/marin/src/marin/datakit/download/institutional_books.py
+++ b/lib/marin/src/marin/datakit/download/institutional_books.py
@@ -14,8 +14,6 @@ pages (``text_by_page_src``); we fall back when the corrected list is
 missing or empty. Pages are joined with a blank line.
 """
 
-from __future__ import annotations
-
 from fray import ResourceConfig
 from zephyr import Dataset, ZephyrContext, counters, load_parquet
 

--- a/lib/marin/src/marin/datakit/download/massive.py
+++ b/lib/marin/src/marin/datakit/download/massive.py
@@ -15,8 +15,6 @@ with ``requests`` — same pattern as ``nemotron_v1.py`` — and extract one
 ``{locale}.jsonl`` per locale into the staging dir.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import os

--- a/lib/marin/src/marin/datakit/download/npm_registry_metadata.py
+++ b/lib/marin/src/marin/datakit/download/npm_registry_metadata.py
@@ -16,8 +16,6 @@ We intentionally exclude README blobs and maintainer identity fields so the slic
 stays focused on dependency metadata rather than free-form package docs.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import posixpath

--- a/lib/marin/src/marin/datakit/download/uncheatable_eval.py
+++ b/lib/marin/src/marin/datakit/download/uncheatable_eval.py
@@ -3,8 +3,6 @@
 
 """Download and normalize the latest Uncheatable Eval data dumps."""
 
-from __future__ import annotations
-
 import json
 import logging
 import os
@@ -233,7 +231,7 @@ def _normalize_record(raw: Any, dataset: UncheatableEvalDataset, index: int) -> 
 
 
 def _download_and_convert_single(
-    task: DownloadTask,
+    task: "DownloadTask",
 ) -> dict[str, Any]:
     session = build_retrying_session(status_forcelist=(500, 502, 503, 504))
 

--- a/lib/marin/src/marin/datakit/download/uwf_zeek.py
+++ b/lib/marin/src/marin/datakit/download/uwf_zeek.py
@@ -19,8 +19,6 @@ as the ``text`` field inside a gzipped JSONL document::
     {"id": str, "text": str, "source": str, "category": str, "row_index": int}
 """
 
-from __future__ import annotations
-
 import csv
 import json
 import logging

--- a/lib/marin/src/marin/datakit/ingestion_manifest.py
+++ b/lib/marin/src/marin/datakit/ingestion_manifest.py
@@ -3,8 +3,6 @@
 
 """Typed source manifests for small ingestion registries and sidecar metadata."""
 
-from __future__ import annotations
-
 import hashlib
 import json
 import posixpath

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -14,8 +14,6 @@ All discovered files are merged into a single output: main records land in
 ``<output_path>/outputs/dups/``. Input directory structure is not preserved.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import re

--- a/lib/marin/src/marin/execution/context.py
+++ b/lib/marin/src/marin/execution/context.py
@@ -16,8 +16,6 @@ worker unpickling a step never trips the guard; only direct construction and
 ``dataclasses.replace`` do.
 """
 
-from __future__ import annotations
-
 import contextlib
 import contextvars
 import dataclasses

--- a/lib/marin/src/marin/execution/disk_cache.py
+++ b/lib/marin/src/marin/execution/disk_cache.py
@@ -3,8 +3,6 @@
 
 """Run a function once, cache the result, and return it on subsequent calls."""
 
-from __future__ import annotations
-
 import functools
 import hashlib
 import logging

--- a/lib/marin/src/marin/execution/remote.py
+++ b/lib/marin/src/marin/execution/remote.py
@@ -15,8 +15,6 @@ Usage::
     def train(...): ...             # explicit resources
 """
 
-from __future__ import annotations
-
 import dataclasses
 import re
 import uuid
@@ -57,7 +55,7 @@ class RemoteCallable(Generic[P, R]):
     pip_dependency_groups: list[str] | None = None
     name: str | None = None
 
-    def named(self, name: str) -> RemoteCallable:
+    def named(self, name: str) -> "RemoteCallable":
         """Noop if already has a name. Otherwise use provided name."""
         if self.name:
             return self

--- a/lib/marin/src/marin/execution/step_runner.py
+++ b/lib/marin/src/marin/execution/step_runner.py
@@ -10,8 +10,6 @@ distributed locking, heartbeats, and status writes are handled explicitly in
 easy to follow and debug.
 """
 
-from __future__ import annotations
-
 import contextvars
 import json
 import logging

--- a/lib/marin/src/marin/execution/step_spec.py
+++ b/lib/marin/src/marin/execution/step_spec.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import dataclasses
 import hashlib
 import json
@@ -52,7 +50,7 @@ class StepSpec:
     """Name of the step, used for readability and in the output path."""
     output_path_prefix: str | None = None
     """Output path prefix for the step. If not provided, it will be taken from the MARIN_PREFIX environment variable."""
-    deps: list[StepSpec] = dataclasses.field(default_factory=list)
+    deps: "list[StepSpec]" = dataclasses.field(default_factory=list)
     """Steps that this step depends on. Their output paths are used for dependency tracking and cache invalidation."""
     hash_attrs: dict[str, Any] = dataclasses.field(default_factory=dict)
     """Attributes to include in the hash calculation for the step. Used for cache invalidation.

--- a/lib/marin/src/marin/execution/sweep_coordination.py
+++ b/lib/marin/src/marin/execution/sweep_coordination.py
@@ -23,8 +23,6 @@ Multi-host sweep jobs must request an ``actor`` port (``ports=['actor']``) so th
 leader's actor server is reachable by its followers.
 """
 
-from __future__ import annotations
-
 import logging
 import threading
 from dataclasses import dataclass

--- a/lib/marin/src/marin/execution/types.py
+++ b/lib/marin/src/marin/execution/types.py
@@ -8,8 +8,6 @@ cycle between ``executor`` and ``step_spec``. ``executor`` re-exports the
 symbols defined here for backwards compatibility with existing call sites.
 """
 
-from __future__ import annotations
-
 import dataclasses
 import os
 from collections.abc import Callable
@@ -54,11 +52,11 @@ class ExecutorStep(Generic[ConfigT_co]):
     def __post_init__(self):
         check_build_context("ExecutorStep", self.name)
 
-    def cd(self, name: str) -> InputName:
+    def cd(self, name: str) -> "InputName":
         """Refer to the `name` under `self`'s output_path."""
         return InputName(self, name=name)
 
-    def __truediv__(self, other: str) -> InputName:
+    def __truediv__(self, other: str) -> "InputName":
         """Alias for `cd`. That looks more Pythonic."""
         return InputName(self, name=other)
 
@@ -66,11 +64,11 @@ class ExecutorStep(Generic[ConfigT_co]):
         """Hash based on the ID (every object is different)."""
         return hash(id(self))
 
-    def with_output_path(self, output_path: str) -> ExecutorStep:
+    def with_output_path(self, output_path: str) -> "ExecutorStep":
         """Return a copy of the step with the given output_path."""
         return dataclasses.replace(self, override_output_path=output_path)
 
-    def as_input_name(self) -> InputName:
+    def as_input_name(self) -> "InputName":
         return InputName(step=self, name=None)
 
 
@@ -91,22 +89,22 @@ class InputName:
     These "pseudo-dependencies" still impact the hash of the step, but they don't block execution.
     """
 
-    def cd(self, name: str) -> InputName:
+    def cd(self, name: str) -> "InputName":
         return InputName(self.step, name=os.path.join(self.name, name) if self.name else name)
 
-    def __truediv__(self, other: str) -> InputName:
+    def __truediv__(self, other: str) -> "InputName":
         """Alias for `cd` that looks more Pythonic."""
         return self.cd(other)
 
     @staticmethod
-    def hardcoded(path: str) -> InputName:
+    def hardcoded(path: str) -> "InputName":
         """
         Sometimes we want to specify a path that is not part of the pipeline but is still relative to the prefix.
         Try to use this sparingly.
         """
         return InputName(None, name=path)
 
-    def nonblocking(self) -> InputName:
+    def nonblocking(self) -> "InputName":
         """
         the step will not block on (or attempt to execute) the parent step.
 

--- a/lib/marin/src/marin/inference/broker.py
+++ b/lib/marin/src/marin/inference/broker.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import logging
 import threading
 import time

--- a/lib/marin/src/marin/inference/proxy.py
+++ b/lib/marin/src/marin/inference/proxy.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import logging
 import socket
 import threading
@@ -84,7 +82,7 @@ class InferenceProxy:
             ],
         )
 
-    def __enter__(self) -> InferenceProxy:
+    def __enter__(self) -> "InferenceProxy":
         self.start_response_poller()
         return self
 

--- a/lib/marin/src/marin/inference/quick_serve.py
+++ b/lib/marin/src/marin/inference/quick_serve.py
@@ -13,8 +13,6 @@ This module holds the serving config and the in-job entrypoint that boots vLLM o
 the slice; the ``marin-serve`` launcher CLI is a separate module.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import re

--- a/lib/marin/src/marin/inference/quick_serve_cli.py
+++ b/lib/marin/src/marin/inference/quick_serve_cli.py
@@ -16,8 +16,6 @@ The TPU's tensor-parallel size and (for clamped-RoPE models) max sequence length
 inferred automatically; override with ``--tensor-parallel-size`` / ``--max-model-len``.
 """
 
-from __future__ import annotations
-
 import contextlib
 import logging
 import re

--- a/lib/marin/src/marin/inference/quick_serve_dashboard.py
+++ b/lib/marin/src/marin/inference/quick_serve_dashboard.py
@@ -13,8 +13,6 @@ absolute path like ``/v1/chat/completions`` would escape the prefix.
 streamed back verbatim, so server-sent-event token streaming works end to end.
 """
 
-from __future__ import annotations
-
 import dataclasses
 import importlib.resources
 import logging

--- a/lib/marin/src/marin/inference/vllm.py
+++ b/lib/marin/src/marin/inference/vllm.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import contextlib
 import logging
 import uuid

--- a/lib/marin/src/marin/inference/worker.py
+++ b/lib/marin/src/marin/inference/worker.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import logging
 import threading
 from collections import Counter

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -31,8 +31,6 @@ global dedup: re-running this job over the union of all per-dataset MinHash
 artifacts produces fresh markers without re-reading any source text.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 from collections.abc import Iterator

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -14,8 +14,6 @@ deduplication.fuzzy_dups.compute_fuzzy_dups_attrs` consumes one or more of
 these artifacts to produce duplicate markers.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 from collections.abc import Iterator

--- a/lib/marin/src/marin/processing/tokenize/_core.py
+++ b/lib/marin/src/marin/processing/tokenize/_core.py
@@ -12,8 +12,6 @@ Used by:
 
 Public API lives in those modules; helpers here are package-private.
 """
-from __future__ import annotations
-
 import json
 import logging
 import os

--- a/lib/marin/src/marin/processing/tokenize/attributes.py
+++ b/lib/marin/src/marin/processing/tokenize/attributes.py
@@ -22,8 +22,6 @@ Downstream:
 * Other datakit attribute consumers (joins, mixing) can use the ``id`` column to
   align tokens with quality scores, dedup flags, etc.
 """
-from __future__ import annotations
-
 import dataclasses
 import logging
 import os

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -22,8 +22,6 @@ be removed — those subdirectories are the cache. Downstream readers load via
 ``TreeCache.load`` (or ``UrlDatasetSourceConfig``), which transparently
 dispatches on the sharded layout.
 """
-from __future__ import annotations
-
 import dataclasses
 import json
 import logging

--- a/lib/marin/src/marin/profiling/cli.py
+++ b/lib/marin/src/marin/profiling/cli.py
@@ -3,8 +3,6 @@
 
 """CLI for profile ingestion, querying, and before/after comparison."""
 
-from __future__ import annotations
-
 import argparse
 import json
 from pathlib import Path

--- a/lib/marin/src/marin/profiling/compare_bundle.py
+++ b/lib/marin/src/marin/profiling/compare_bundle.py
@@ -3,8 +3,6 @@
 
 """One-shot compare/track/report bundle orchestration for profile summaries."""
 
-from __future__ import annotations
-
 import json
 from dataclasses import dataclass
 from pathlib import Path

--- a/lib/marin/src/marin/profiling/ingest.py
+++ b/lib/marin/src/marin/profiling/ingest.py
@@ -3,8 +3,6 @@
 
 """Ingest JAX profile artifacts into a normalized profile summary."""
 
-from __future__ import annotations
-
 import hashlib
 import json
 import logging

--- a/lib/marin/src/marin/profiling/publish.py
+++ b/lib/marin/src/marin/profiling/publish.py
@@ -3,8 +3,6 @@
 
 """Publish profile summaries and reports as W&B artifacts."""
 
-from __future__ import annotations
-
 import json
 from datetime import UTC, datetime
 from pathlib import Path

--- a/lib/marin/src/marin/profiling/query.py
+++ b/lib/marin/src/marin/profiling/query.py
@@ -3,8 +3,6 @@
 
 """Query and comparison helpers for normalized profile summaries."""
 
-from __future__ import annotations
-
 import re
 from dataclasses import dataclass
 from typing import Any

--- a/lib/marin/src/marin/profiling/report.py
+++ b/lib/marin/src/marin/profiling/report.py
@@ -3,8 +3,6 @@
 
 """Human-readable report generation from profile summaries."""
 
-from __future__ import annotations
-
 from collections import Counter
 from dataclasses import dataclass, field
 

--- a/lib/marin/src/marin/profiling/schema.py
+++ b/lib/marin/src/marin/profiling/schema.py
@@ -3,8 +3,6 @@
 
 """Versioned schema for agent-consumable profile summaries."""
 
-from __future__ import annotations
-
 import dataclasses
 import json
 import re
@@ -69,7 +67,7 @@ class DurationStats:
     max: float | None
 
     @classmethod
-    def from_values(cls, values: list[float]) -> DurationStats:
+    def from_values(cls, values: list[float]) -> "DurationStats":
         if not values:
             return cls(count=0, mean=None, median=None, p90=None, min=None, max=None)
 
@@ -95,7 +93,7 @@ class StepTimeSummary:
     warmup_steps_ignored: int
     all_steps: DurationStats
     steady_state_steps: DurationStats
-    classes: list[StepClassSummary] = field(default_factory=list)
+    classes: "list[StepClassSummary]" = field(default_factory=list)
 
 
 @dataclass(frozen=True)
@@ -275,7 +273,7 @@ class ProfileSummary:
         hierarchical_regions: list[RegionAggregate],
         gap_region_contexts: list[GapRegionContext],
         optimization_candidates: list[OptimizationCandidate],
-    ) -> ProfileSummary:
+    ) -> "ProfileSummary":
         """Create a summary with default schema version and timestamp."""
         generated_at = datetime.now(UTC).isoformat().replace("+00:00", "Z")
         return cls(

--- a/lib/marin/src/marin/profiling/semantics.py
+++ b/lib/marin/src/marin/profiling/semantics.py
@@ -3,8 +3,6 @@
 
 """Semantic helpers for profile op grouping and shape-signature extraction."""
 
-from __future__ import annotations
-
 import math
 import re
 from collections.abc import Iterable

--- a/lib/marin/src/marin/profiling/trace_summary.py
+++ b/lib/marin/src/marin/profiling/trace_summary.py
@@ -8,8 +8,6 @@ Perfetto/Chrome trace ingester (`marin.profiling.ingest`) and the XPlane
 ingester (`marin.profiling.xplane`).
 """
 
-from __future__ import annotations
-
 import gzip
 import hashlib
 import json

--- a/lib/marin/src/marin/profiling/tracking.py
+++ b/lib/marin/src/marin/profiling/tracking.py
@@ -3,8 +3,6 @@
 
 """Regression tracking utilities for profile-summary before/after loops."""
 
-from __future__ import annotations
-
 import json
 from collections import Counter
 from dataclasses import dataclass

--- a/lib/marin/src/marin/profiling/xplane.py
+++ b/lib/marin/src/marin/profiling/xplane.py
@@ -3,8 +3,6 @@
 
 """Ingest XPlane protobuf profiles directly and through xprof tables."""
 
-from __future__ import annotations
-
 import json
 import logging
 import re

--- a/lib/marin/src/marin/rl/environments/inference_ctx/staging.py
+++ b/lib/marin/src/marin/rl/environments/inference_ctx/staging.py
@@ -3,8 +3,6 @@
 
 """Helpers for staging remote vLLM metadata locally before inflight startup."""
 
-from __future__ import annotations
-
 import dataclasses
 import hashlib
 import logging

--- a/lib/marin/src/marin/rl/environments/math_env.py
+++ b/lib/marin/src/marin/rl/environments/math_env.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass, field

--- a/lib/marin/src/marin/transform/bio_chem/splitters.py
+++ b/lib/marin/src/marin/transform/bio_chem/splitters.py
@@ -10,8 +10,6 @@ the bytes that appeared in the input. Where a format requires a terminator
 that was not associated with any record.
 """
 
-from __future__ import annotations
-
 from collections.abc import Iterable, Iterator
 from dataclasses import dataclass
 

--- a/lib/marin/src/marin/transform/evaluation/code_interpretation.py
+++ b/lib/marin/src/marin/transform/evaluation/code_interpretation.py
@@ -3,8 +3,6 @@
 
 """Deterministic code-interpretation records for supervised PPL evals."""
 
-from __future__ import annotations
-
 import json
 import posixpath
 from collections.abc import Callable

--- a/lib/marin/src/marin/transform/evaluation/prompt_format_sensitivity.py
+++ b/lib/marin/src/marin/transform/evaluation/prompt_format_sensitivity.py
@@ -3,8 +3,6 @@
 
 """Deterministic prompt-format sensitivity records for supervised PPL evals."""
 
-from __future__ import annotations
-
 import csv
 import html
 import io

--- a/lib/marin/src/marin/transform/evaluation/raw_lm_eval.py
+++ b/lib/marin/src/marin/transform/evaluation/raw_lm_eval.py
@@ -3,8 +3,6 @@
 
 """Stage small LM-eval-style HF datasets into raw text for PPL probes."""
 
-from __future__ import annotations
-
 import json
 import posixpath
 from dataclasses import dataclass, field

--- a/lib/marin/src/marin/transform/hf_parquet_splits.py
+++ b/lib/marin/src/marin/transform/hf_parquet_splits.py
@@ -9,8 +9,6 @@ on an fsspec filesystem. These helpers locate the shards for a requested
 ``split`` (optionally scoped to a ``subset``) and stream their rows.
 """
 
-from __future__ import annotations
-
 import os
 import posixpath
 from collections.abc import Iterable

--- a/lib/marin/src/marin/transform/huggingface/raw_text.py
+++ b/lib/marin/src/marin/transform/huggingface/raw_text.py
@@ -3,8 +3,6 @@
 
 """Materialize Hugging Face dataset rows as raw-text eval shards."""
 
-from __future__ import annotations
-
 import json
 import logging
 import posixpath

--- a/lib/marin/src/marin/transform/security_artifacts/renderers.py
+++ b/lib/marin/src/marin/transform/security_artifacts/renderers.py
@@ -17,8 +17,6 @@ The public surface:
   ``#separator`` / ``#fields`` / ``#types`` headers and ``#close`` trailer.
 """
 
-from __future__ import annotations
-
 import logging
 from collections.abc import Iterable, Mapping, Sequence
 from typing import Any

--- a/lib/marin/src/marin/transform/security_artifacts/zeek_to_dolma.py
+++ b/lib/marin/src/marin/transform/security_artifacts/zeek_to_dolma.py
@@ -16,8 +16,6 @@ Grouping records into blocks (rather than one record per Dolma row) keeps the
 what Zeek's on-disk format looks like.
 """
 
-from __future__ import annotations
-
 import hashlib
 import logging
 import posixpath

--- a/lib/marin/src/marin/transform/structured_text/table_records.py
+++ b/lib/marin/src/marin/transform/structured_text/table_records.py
@@ -11,8 +11,6 @@ must survive into the emitted text verbatim**. No ``float(cell)``, no
 ``" ".join(cell.split())``, no case folding.
 """
 
-from __future__ import annotations
-
 import hashlib
 import json
 import logging

--- a/lib/marin/src/marin/transform/structured_text/web_data_commons.py
+++ b/lib/marin/src/marin/transform/structured_text/web_data_commons.py
@@ -13,8 +13,6 @@ staging path therefore preserves the CSV bytes after UTF-8 decoding and only
 splits documents at source line boundaries.
 """
 
-from __future__ import annotations
-
 import gzip
 import hashlib
 import io

--- a/lib/rigging/src/rigging/rpc.py
+++ b/lib/rigging/src/rigging/rpc.py
@@ -3,8 +3,6 @@
 
 """Connect/RPC interceptors shared across Marin RPC servers."""
 
-from __future__ import annotations
-
 import asyncio
 import logging
 import threading

--- a/lib/rigging/src/rigging/tunnel.py
+++ b/lib/rigging/src/rigging/tunnel.py
@@ -28,8 +28,6 @@ finelog's CLI translate their own config schema into a ``TunnelTarget``
 and use this directly; iris's k8s port-forward should migrate here too.
 """
 
-from __future__ import annotations
-
 import contextlib
 import logging
 import os

--- a/lib/zephyr/src/zephyr/_test_helpers.py
+++ b/lib/zephyr/src/zephyr/_test_helpers.py
@@ -3,8 +3,6 @@
 
 """Helpers shared by tests to avoid pickling import issues on distributed workers."""
 
-from __future__ import annotations
-
 from dataclasses import dataclass
 
 

--- a/lib/zephyr/src/zephyr/dataset.py
+++ b/lib/zephyr/src/zephyr/dataset.py
@@ -3,8 +3,6 @@
 
 """Core Dataset API with lazy evaluation."""
 
-from __future__ import annotations
-
 import functools
 import logging
 import re
@@ -331,7 +329,7 @@ class JoinOp:
 
     left_key_fn: Callable
     right_key_fn: Callable
-    right_dataset: Dataset
+    right_dataset: "Dataset"
     combiner_fn: Callable
     join_type: JoinType
 
@@ -390,7 +388,7 @@ class Dataset(Generic[T]):
         self.source = source
         self.operations = operations or []
 
-    def _derive(self, *ops: LogicalOp) -> Dataset[Any]:
+    def _derive(self, *ops: LogicalOp) -> "Dataset[Any]":
         """Build a derived dataset with additional logical ops appended.
 
         The constructor infers the element type from ``self.source``, but a
@@ -402,12 +400,12 @@ class Dataset(Generic[T]):
         return Dataset(self.source, [*self.operations, *ops])
 
     @staticmethod
-    def from_list(items: list[T]) -> Dataset[T]:
+    def from_list(items: list[T]) -> "Dataset[T]":
         """Create a dataset from a list."""
         return Dataset(items)
 
     @staticmethod
-    def from_iterable(iterable: Iterable[T]) -> Dataset[T]:
+    def from_iterable(iterable: Iterable[T]) -> "Dataset[T]":
         """Create a dataset from any iterable."""
         return Dataset(iterable)
 
@@ -415,7 +413,7 @@ class Dataset(Generic[T]):
     def from_files(
         pattern: str,
         empty_glob_ok: bool = False,
-    ) -> Dataset[str]:
+    ) -> "Dataset[str]":
         """Create dataset from file glob pattern.
 
         This method finds all files matching the glob pattern and returns a
@@ -441,7 +439,7 @@ class Dataset(Generic[T]):
         """
         return Dataset(GlobSource(pattern, empty_glob_ok))
 
-    def map(self, fn: Callable[[T], R]) -> Dataset[R]:
+    def map(self, fn: Callable[[T], R]) -> "Dataset[R]":
         """Map a function over the dataset.
 
         Args:
@@ -457,7 +455,7 @@ class Dataset(Generic[T]):
         """
         return cast("Dataset[R]", self._derive(MapOp(fn)))
 
-    def filter(self, predicate: Callable[[T], bool] | Expr) -> Dataset[T]:
+    def filter(self, predicate: Callable[[T], bool] | Expr) -> "Dataset[T]":
         """Filter dataset elements by a predicate or expression.
 
         Args:
@@ -479,7 +477,7 @@ class Dataset(Generic[T]):
             return Dataset(self.source, [*self.operations, FilterOp(predicate.evaluate, expr=predicate)])
         return Dataset(self.source, [*self.operations, FilterOp(predicate)])
 
-    def select(self, *columns: str) -> Dataset[dict]:
+    def select(self, *columns: str) -> "Dataset[dict]":
         """Select specific columns (projection).
 
         Args:
@@ -498,7 +496,7 @@ class Dataset(Generic[T]):
         """
         return cast("Dataset[dict]", self._derive(SelectOp(tuple(columns))))
 
-    def take_per_shard(self, n: int) -> Dataset[T]:
+    def take_per_shard(self, n: int) -> "Dataset[T]":
         """Take the first n items from each shard.
 
         Limits each shard to its first n items independently. This is useful
@@ -519,7 +517,7 @@ class Dataset(Generic[T]):
         """
         return Dataset(self.source, [*self.operations, TakePerShardOp(n)])
 
-    def window(self, size: int) -> Dataset[list[T]]:
+    def window(self, size: int) -> "Dataset[list[T]]":
         """Compute a sliding window of `size` elements across the dataset, returning a list of elements in each window.
 
         Args:
@@ -543,7 +541,7 @@ class Dataset(Generic[T]):
         self,
         folder_fn: Callable[[object, T], tuple[bool, object]],
         initial_state: object = None,
-    ) -> Dataset[list[T]]:
+    ) -> "Dataset[list[T]]":
         """Window elements using a custom fold function.
 
         Args:
@@ -567,7 +565,7 @@ class Dataset(Generic[T]):
         """
         return cast("Dataset[list[T]]", self._derive(WindowOp(folder_fn, initial_state)))
 
-    def flat_map(self, fn: Callable[[T], Iterable[R]]) -> Dataset[R]:
+    def flat_map(self, fn: Callable[[T], Iterable[R]]) -> "Dataset[R]":
         """Apply function that returns an iterable, flattening results.
 
         Args:
@@ -594,7 +592,7 @@ class Dataset(Generic[T]):
         approx_shard_bytes: int | None = None,
         include_file_paths: bool = False,
         file_path_column: str = DEFAULT_FILE_PATH_COLUMN,
-    ) -> Dataset[dict]:
+    ) -> "Dataset[dict]":
         """Load records from file sources, auto-detecting format.
 
         Args:
@@ -632,7 +630,7 @@ class Dataset(Generic[T]):
         file_path_column: str = ...,
         *,
         batch_mode: Literal[False] = ...,
-    ) -> Dataset[dict]: ...
+    ) -> "Dataset[dict]": ...
 
     @overload
     def load_parquet(
@@ -643,7 +641,7 @@ class Dataset(Generic[T]):
         file_path_column: str = ...,
         *,
         batch_mode: Literal[True],
-    ) -> Dataset[RecordBatch]: ...
+    ) -> "Dataset[RecordBatch]": ...
 
     def load_parquet(
         self,
@@ -653,7 +651,7 @@ class Dataset(Generic[T]):
         file_path_column: str = DEFAULT_FILE_PATH_COLUMN,
         *,
         batch_mode: bool = False,
-    ) -> Dataset[dict] | Dataset[RecordBatch]:
+    ) -> "Dataset[dict] | Dataset[RecordBatch]":
         """Load records from parquet files.
 
         Args:
@@ -680,7 +678,7 @@ class Dataset(Generic[T]):
         self,
         include_file_paths: bool = False,
         file_path_column: str = DEFAULT_FILE_PATH_COLUMN,
-    ) -> Dataset[dict]:
+    ) -> "Dataset[dict]":
         """Load records from JSONL files.
 
         Args:
@@ -698,7 +696,7 @@ class Dataset(Generic[T]):
         columns: list[str] | None = None,
         include_file_paths: bool = False,
         file_path_column: str = DEFAULT_FILE_PATH_COLUMN,
-    ) -> Dataset[dict]:
+    ) -> "Dataset[dict]":
         """Load records from Vortex files.
 
         Args:
@@ -715,7 +713,7 @@ class Dataset(Generic[T]):
     def map_shard(
         self,
         fn: Callable[[Iterator[T], ShardInfo], Iterator[R]],
-    ) -> Dataset[R]:
+    ) -> "Dataset[R]":
         """Apply function to entire shard iterator.
 
         The function receives an iterator of all items in the shard and a
@@ -751,7 +749,7 @@ class Dataset(Generic[T]):
         """
         return cast("Dataset[R]", self._derive(MapShardOp(fn)))
 
-    def reshard(self, num_shards: int | None) -> Dataset[T]:
+    def reshard(self, num_shards: int | None) -> "Dataset[T]":
         """Redistribute data across target number of shards (best-effort).
 
         Changes parallelism for subsequent operations.
@@ -780,7 +778,9 @@ class Dataset(Generic[T]):
             raise ValueError(f"num_shards must be positive, got {num_shards}")
         return Dataset(self.source, [*self.operations, ReshardOp(num_shards)]) if num_shards else self
 
-    def write_jsonl(self, output_pattern: str | Callable[[int, int], str], skip_existing: bool = False) -> Dataset[str]:
+    def write_jsonl(
+        self, output_pattern: str | Callable[[int, int], str], skip_existing: bool = False
+    ) -> "Dataset[str]":
         """Write records as JSONL files.
 
         Args:
@@ -799,7 +799,9 @@ class Dataset(Generic[T]):
             ),
         )
 
-    def write_binary(self, output_pattern: str | Callable[[int, int], str], skip_existing: bool = False) -> Dataset[str]:
+    def write_binary(
+        self, output_pattern: str | Callable[[int, int], str], skip_existing: bool = False
+    ) -> "Dataset[str]":
         """Write records directly as uninterpreted binary files.
 
         No delimitation or framing is applied - records are written back-to-back.
@@ -826,7 +828,7 @@ class Dataset(Generic[T]):
         output_pattern: str | Callable[[int, int], str],
         schema: object | None = None,
         skip_existing: bool = False,
-    ) -> Dataset[str]:
+    ) -> "Dataset[str]":
         """Write records as Parquet files.
 
         Schema can be provided or inferred from the first record or dataclass type.
@@ -854,7 +856,7 @@ class Dataset(Generic[T]):
         output_pattern: str | Callable[[int, int], str],
         schema: object | None = None,
         skip_existing: bool = False,
-    ) -> Dataset[str]:
+    ) -> "Dataset[str]":
         """Write records as Vortex files."""
         return cast(
             "Dataset[str]",
@@ -877,7 +879,7 @@ class Dataset(Generic[T]):
         sort_by: Callable[[T], Any] | None = None,
         num_output_shards: int | None = None,
         combiner: Callable[[K, Iterator[T]], Iterator[T]] | None = None,
-    ) -> Dataset[R]: ...
+    ) -> "Dataset[R]": ...
 
     @overload
     def group_by(
@@ -888,7 +890,7 @@ class Dataset(Generic[T]):
         sort_by: Callable[[T], Any] | None = None,
         num_output_shards: int | None = None,
         combiner: Callable[[K, Iterator[T]], Iterator[T]] | None = None,
-    ) -> Dataset[R]: ...
+    ) -> "Dataset[R]": ...
 
     def group_by(
         self,
@@ -898,7 +900,7 @@ class Dataset(Generic[T]):
         sort_by: Callable[[T], Any] | None = None,
         num_output_shards: int | None = None,
         combiner: Callable[[K, Iterator[T]], Iterator[T]] | None = None,
-    ) -> Dataset[R]:
+    ) -> "Dataset[R]":
         """Group items by key and apply reducer function.
 
         The reducer receives (key, iterator_of_items) and returns a single result or an iterator of
@@ -947,7 +949,7 @@ class Dataset(Generic[T]):
             self._derive(GroupByOp(key, reducer, num_output_shards, sort_fn=sort_by, combiner_fn=combiner)),
         )
 
-    def deduplicate(self, key: Callable[[T], object], num_output_shards: int | None = None) -> Dataset[T]:
+    def deduplicate(self, key: Callable[[T], object], num_output_shards: int | None = None) -> "Dataset[T]":
         """Deduplicate items by key.
 
         Example:
@@ -978,7 +980,7 @@ class Dataset(Generic[T]):
         self,
         local_reducer: Callable[[Iterator[T]], R],
         global_reducer: Callable[[Iterator[R]], R] | None = None,
-    ) -> Dataset[R]:
+    ) -> "Dataset[R]":
         """Reduce dataset to a single value via two-phase reduction.
 
         Phase 1: Apply local_reducer to each shard independently
@@ -1001,7 +1003,7 @@ class Dataset(Generic[T]):
 
         return cast("Dataset[R]", self._derive(ReduceOp(local_reducer, global_reducer)))
 
-    def count(self) -> Dataset[int]:
+    def count(self) -> "Dataset[int]":
         """Count the total number of items in the dataset.
 
         Returns:
@@ -1022,12 +1024,12 @@ class Dataset(Generic[T]):
 
     def sorted_merge_join(
         self,
-        right: Dataset[R],
+        right: "Dataset[R]",
         left_key: Callable[[T], object],
         right_key: Callable[[R], object],
         combiner: Callable[[T | None, R | None], object] | None = None,
         how: str = JoinType.INNER,
-    ) -> Dataset:
+    ) -> "Dataset":
         """Streaming merge join for already-sorted, co-partitioned datasets.
 
         Preconditions:

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -11,8 +11,6 @@ up when the coordinator exits or is killed — preventing stale-coordinator
 bugs where orphaned coordinators and workers consume resources indefinitely.
 """
 
-from __future__ import annotations
-
 import enum
 import logging
 import os

--- a/lib/zephyr/src/zephyr/expr.py
+++ b/lib/zephyr/src/zephyr/expr.py
@@ -6,8 +6,6 @@
 Modeled on Vortex expressions: https://docs.vortex.dev/api/python/expr
 """
 
-from __future__ import annotations
-
 import operator
 from abc import ABC, abstractmethod
 from collections.abc import Callable
@@ -41,56 +39,56 @@ class Expr(ABC):
         return hash(repr(self))
 
     # Comparison operators
-    def __eq__(self, other: object) -> CompareExpr:  # type: ignore[override]
+    def __eq__(self, other: object) -> "CompareExpr":  # type: ignore[override]
         return CompareExpr(self, _to_expr(other), "eq")
 
-    def __ne__(self, other: object) -> CompareExpr:  # type: ignore[override]
+    def __ne__(self, other: object) -> "CompareExpr":  # type: ignore[override]
         return CompareExpr(self, _to_expr(other), "ne")
 
-    def __lt__(self, other: object) -> CompareExpr:
+    def __lt__(self, other: object) -> "CompareExpr":
         return CompareExpr(self, _to_expr(other), "lt")
 
-    def __le__(self, other: object) -> CompareExpr:
+    def __le__(self, other: object) -> "CompareExpr":
         return CompareExpr(self, _to_expr(other), "le")
 
-    def __gt__(self, other: object) -> CompareExpr:
+    def __gt__(self, other: object) -> "CompareExpr":
         return CompareExpr(self, _to_expr(other), "gt")
 
-    def __ge__(self, other: object) -> CompareExpr:
+    def __ge__(self, other: object) -> "CompareExpr":
         return CompareExpr(self, _to_expr(other), "ge")
 
     # Arithmetic operators
-    def __add__(self, other: object) -> ArithmeticExpr:
+    def __add__(self, other: object) -> "ArithmeticExpr":
         return ArithmeticExpr(self, _to_expr(other), "add")
 
-    def __sub__(self, other: object) -> ArithmeticExpr:
+    def __sub__(self, other: object) -> "ArithmeticExpr":
         return ArithmeticExpr(self, _to_expr(other), "sub")
 
-    def __mul__(self, other: object) -> ArithmeticExpr:
+    def __mul__(self, other: object) -> "ArithmeticExpr":
         return ArithmeticExpr(self, _to_expr(other), "mul")
 
-    def __truediv__(self, other: object) -> ArithmeticExpr:
+    def __truediv__(self, other: object) -> "ArithmeticExpr":
         return ArithmeticExpr(self, _to_expr(other), "truediv")
 
     # Logical operators (use & and | since and/or can't be overloaded)
-    def __and__(self, other: object) -> LogicalExpr:
+    def __and__(self, other: object) -> "LogicalExpr":
         return LogicalExpr(self, _to_expr(other), "and")
 
-    def __or__(self, other: object) -> LogicalExpr:
+    def __or__(self, other: object) -> "LogicalExpr":
         return LogicalExpr(self, _to_expr(other), "or")
 
-    def __invert__(self) -> NotExpr:
+    def __invert__(self) -> "NotExpr":
         return NotExpr(self)
 
     # Field access for nested structs
-    def __getitem__(self, key: str) -> FieldAccessExpr:
+    def __getitem__(self, key: str) -> "FieldAccessExpr":
         return FieldAccessExpr(self, key)
 
     # Null checks
-    def is_null(self) -> IsNullExpr:
+    def is_null(self) -> "IsNullExpr":
         return IsNullExpr(self)
 
-    def is_not_null(self) -> NotExpr:
+    def is_not_null(self) -> "NotExpr":
         return NotExpr(IsNullExpr(self))
 
 

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -8,8 +8,6 @@ They encapsulate execution logic as callables, decoupling the backend from
 knowledge of logical operation types.
 """
 
-from __future__ import annotations
-
 import functools
 import heapq
 import logging
@@ -151,7 +149,7 @@ class Join:
     """Join two sorted streams."""
 
     fn: Callable[[Iterator, Iterator], Iterator]
-    right_plan: PhysicalPlan | None = None
+    right_plan: "PhysicalPlan | None" = None
 
 
 PhysicalOp = Map | Write | Scatter | Reduce | Fold | Reshard | Join

--- a/lib/zephyr/src/zephyr/readers.py
+++ b/lib/zephyr/src/zephyr/readers.py
@@ -6,8 +6,6 @@
 Supports reading from local filesystems, cloud storage (gs://, s3://) and HuggingFace Hub (hf://) via fsspec.
 """
 
-from __future__ import annotations
-
 import fnmatch
 import logging
 import zipfile

--- a/lib/zephyr/src/zephyr/runners.py
+++ b/lib/zephyr/src/zephyr/runners.py
@@ -23,8 +23,6 @@ separate so the ``python -m`` target is not also imported during ``zephyr``
 package initialization (which would trip a ``runpy`` re-execution warning).
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import re

--- a/lib/zephyr/src/zephyr/shard_keys.py
+++ b/lib/zephyr/src/zephyr/shard_keys.py
@@ -3,8 +3,6 @@
 
 """Deterministic hashing and sort-key helpers for Zephyr shard routing."""
 
-from __future__ import annotations
-
 from collections.abc import Callable
 
 import msgspec

--- a/lib/zephyr/src/zephyr/shard_subprocess.py
+++ b/lib/zephyr/src/zephyr/shard_subprocess.py
@@ -16,8 +16,6 @@ in ``sys.modules`` and warn while re-executing its body a second time. Nothing
 in the package-init graph imports ``shard_subprocess``, so no such warning.
 """
 
-from __future__ import annotations
-
 import logging
 import os
 import sys

--- a/lib/zephyr/src/zephyr/shuffle.py
+++ b/lib/zephyr/src/zephyr/shuffle.py
@@ -31,8 +31,6 @@ OOM on skewed or large-item workloads where a row-count limit provides no
 reliable bound.
 """
 
-from __future__ import annotations
-
 import concurrent.futures
 import functools
 import io
@@ -326,7 +324,7 @@ class ScatterReader:
         self.avg_item_bytes = avg_item_bytes
 
     @classmethod
-    def from_sidecars(cls, scatter_paths: list[str], target_shard: int) -> ScatterReader:
+    def from_sidecars(cls, scatter_paths: list[str], target_shard: int) -> "ScatterReader":
         """Build a ScatterReader by reading per-mapper sidecars directly.
 
         Each reducer reads every mapper's ``.scatter_meta`` sidecar in parallel
@@ -674,7 +672,7 @@ class ScatterWriter:
         if self._fs.exists(self._fs_path):
             self._fs.rm(self._fs_path)
 
-    def __enter__(self) -> ScatterWriter:
+    def __enter__(self) -> "ScatterWriter":
         return self
 
     def __exit__(self, exc_type: type[BaseException] | None, *exc: Any) -> None:

--- a/lib/zephyr/src/zephyr/stage_io.py
+++ b/lib/zephyr/src/zephyr/stage_io.py
@@ -9,8 +9,6 @@ work (``ShardTask``), its result (``TaskResult``), the strategy that executes it
 disk (pickle chunks for map stages, scattered shuffle files for reduce stages).
 """
 
-from __future__ import annotations
-
 import itertools
 import logging
 import pickle
@@ -75,7 +73,7 @@ class PickleDiskChunk:
         return iter(self.read())
 
     @classmethod
-    def write(cls, path: str, data: list) -> PickleDiskChunk:
+    def write(cls, path: str, data: list) -> "PickleDiskChunk":
         """Write *data* to a UUID-unique path derived from *path*.
 
         The UUID suffix avoids collisions when multiple workers race on

--- a/lib/zephyr/src/zephyr/stats.py
+++ b/lib/zephyr/src/zephyr/stats.py
@@ -16,8 +16,6 @@ via :func:`zephyr.runners._sample_process_stats` and stored with
 sent to the coordinator via heartbeats for aggregation into stage stats.
 """
 
-from __future__ import annotations
-
 import enum
 import logging
 import time
@@ -135,7 +133,7 @@ class StatsWriter:
                 self._worker_table = log_client.get_table(ZEPHYR_WORKER_STATS_NAMESPACE, ZephyrWorkerStat)
 
     @classmethod
-    def connect(cls, url: str | None = None) -> StatsWriter:
+    def connect(cls, url: str | None = None) -> "StatsWriter":
         """Connect to finelog; resolves the URL via Iris if not provided.
 
         Returns a no-op instance if the URL cannot be determined or the

--- a/lib/zephyr/src/zephyr/worker_context.py
+++ b/lib/zephyr/src/zephyr/worker_context.py
@@ -3,8 +3,6 @@
 
 """Worker-side execution context exposed to user task code."""
 
-from __future__ import annotations
-
 import enum
 from contextvars import ContextVar
 from dataclasses import dataclass, field
@@ -29,7 +27,7 @@ class CounterEntry:
     stage: str | None = None
     count: int = 1  # number of observations; used for rolling average via update_counter
 
-    def merge(self, other: CounterEntry) -> None:
+    def merge(self, other: "CounterEntry") -> None:
         """Fold *other* into this entry in-place using this entry's aggregation.
 
         ``other.count`` is respected for AVERAGE so that merging two accumulated
@@ -65,7 +63,7 @@ class CounterSnapshot:
     generation: int
 
     @staticmethod
-    def empty(generation: int = 0) -> CounterSnapshot:
+    def empty(generation: int = 0) -> "CounterSnapshot":
         return CounterSnapshot(counters={}, generation=generation)
 
 

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -3,8 +3,6 @@
 
 """Writers for common output formats."""
 
-from __future__ import annotations
-
 import itertools
 import logging
 import os
@@ -362,7 +360,7 @@ class ThreadedBatchWriter:
         if self._error is not None:
             raise self._error
 
-    def __enter__(self) -> ThreadedBatchWriter:
+    def __enter__(self) -> "ThreadedBatchWriter":
         return self
 
     def __exit__(self, exc_type, exc_val, exc_tb) -> bool:

--- a/lib/zephyr/tests/benchmark_shuffle.py
+++ b/lib/zephyr/tests/benchmark_shuffle.py
@@ -31,8 +31,6 @@ Examples:
 Output: prints a single JSON line ``RESULT: {...}`` for easy log scraping.
 """
 
-from __future__ import annotations
-
 import json
 import logging
 import os

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -3,8 +3,6 @@
 
 """Tests for the actor-based execution engine (ZephyrContext)."""
 
-from __future__ import annotations
-
 import json
 import logging
 import os

--- a/lib/zephyr/tests/test_runners.py
+++ b/lib/zephyr/tests/test_runners.py
@@ -3,8 +3,6 @@
 
 """Tests for the pluggable StageRunner strategies (zephyr.runners)."""
 
-from __future__ import annotations
-
 import os
 import uuid
 from contextlib import suppress

--- a/lib/zephyr/tests/test_worker_group_race.py
+++ b/lib/zephyr/tests/test_worker_group_race.py
@@ -14,8 +14,6 @@ The race (before fix):
 Fix: _check_worker_group skips when all shards are completed.
 """
 
-from __future__ import annotations
-
 import threading
 import time
 from unittest.mock import MagicMock

--- a/scripts/ci/collect_perf_metrics.py
+++ b/scripts/ci/collect_perf_metrics.py
@@ -17,8 +17,6 @@ across time and architecture changes.
 Used by the scheduled ``marin-canary-datakit-tier{1,2,3}`` workflows.
 """
 
-from __future__ import annotations
-
 import datetime
 import json
 import logging

--- a/scripts/ci/grug_dir_diff.py
+++ b/scripts/ci/grug_dir_diff.py
@@ -3,8 +3,6 @@
 
 """Generate an HTML side-by-side diff report for two code directories."""
 
-from __future__ import annotations
-
 import argparse
 import difflib
 import html

--- a/scripts/ci/grug_variant_diff_ci.py
+++ b/scripts/ci/grug_variant_diff_ci.py
@@ -3,8 +3,6 @@
 
 """Generate Grug variant comparison reports for newly added variants in a PR."""
 
-from __future__ import annotations
-
 import argparse
 import json
 import subprocess

--- a/scripts/ci/submit_perf_run.py
+++ b/scripts/ci/submit_perf_run.py
@@ -25,8 +25,6 @@ The status JSON path is the standard ``FERRY_STATUS_PATH`` contract (see
 ``marin_prefix`` there on completion.
 """
 
-from __future__ import annotations
-
 import argparse
 import dataclasses
 import datetime

--- a/scripts/cost_manager/backends/anthropic.py
+++ b/scripts/cost_manager/backends/anthropic.py
@@ -18,8 +18,6 @@ Priority-tier spend is excluded from this endpoint (it is reported via the
 usage endpoint), so totals here track on-demand cost.
 """
 
-from __future__ import annotations
-
 import datetime as dt
 import logging
 from collections.abc import Mapping

--- a/scripts/cost_manager/backends/coreweave.py
+++ b/scripts/cost_manager/backends/coreweave.py
@@ -22,8 +22,6 @@ UTC day approximates resource-hours, which times ``unit_rate`` ($/unit/hour)
 gives the estimated daily cost. Series are grouped by ``detail_label``.
 """
 
-from __future__ import annotations
-
 import datetime as dt
 import logging
 from collections import defaultdict

--- a/scripts/cost_manager/backends/cost_api.py
+++ b/scripts/cost_manager/backends/cost_api.py
@@ -10,8 +10,6 @@ clear error on auth/permission failures) and the page loop, so each backend
 only maps its buckets to :class:`CostEvent`.
 """
 
-from __future__ import annotations
-
 from collections.abc import Iterator, Mapping
 from typing import Any
 

--- a/scripts/cost_manager/backends/gcp.py
+++ b/scripts/cost_manager/backends/gcp.py
@@ -16,8 +16,6 @@ The billing export must be enabled and readable by the runner's service
 account; point ``billing_export_table`` at that dataset.
 """
 
-from __future__ import annotations
-
 import datetime as dt
 import json
 import logging

--- a/scripts/cost_manager/backends/openai.py
+++ b/scripts/cost_manager/backends/openai.py
@@ -13,8 +13,6 @@ a day into per-feature rows (e.g. a model's input/output tokens), which become
 the :class:`CostEvent` ``detail``. Amounts are already in dollars.
 """
 
-from __future__ import annotations
-
 import datetime as dt
 import logging
 from collections.abc import Mapping

--- a/scripts/cost_manager/backends/together.py
+++ b/scripts/cost_manager/backends/together.py
@@ -16,8 +16,6 @@ usage/cost API, but until then ``fetch`` raises :class:`CostFetchError` rather
 than guess at a schema.
 """
 
-from __future__ import annotations
-
 from collections.abc import Mapping
 from typing import Any
 

--- a/scripts/cost_manager/cost_event.py
+++ b/scripts/cost_manager/cost_event.py
@@ -15,8 +15,6 @@ Readers take the latest snapshot by keeping the row with the greatest
 README for the canonical "latest snapshot" SQL.
 """
 
-from __future__ import annotations
-
 import datetime as dt
 import os
 from dataclasses import dataclass, replace
@@ -103,7 +101,7 @@ class DateWindow:
             raise ValueError(f"DateWindow end {self.end} precedes start {self.start}")
 
     @staticmethod
-    def trailing(days: int, *, today: dt.date) -> DateWindow:
+    def trailing(days: int, *, today: dt.date) -> "DateWindow":
         """The window of the last ``days`` UTC days ending at ``today``."""
         if days < 1:
             raise ValueError(f"lookback days must be >= 1, got {days}")

--- a/scripts/cost_manager/finelog_sink.py
+++ b/scripts/cost_manager/finelog_sink.py
@@ -15,8 +15,6 @@ configured destination:
   interactive IAP login.
 """
 
-from __future__ import annotations
-
 import logging
 from collections import defaultdict
 from collections.abc import Iterator, Mapping

--- a/scripts/cost_manager/run.py
+++ b/scripts/cost_manager/run.py
@@ -20,8 +20,6 @@ Examples::
     uv run python -m scripts.cost_manager.run
 """
 
-from __future__ import annotations
-
 import datetime as dt
 import logging
 import os

--- a/scripts/cost_manager/slack_alert.py
+++ b/scripts/cost_manager/slack_alert.py
@@ -16,8 +16,6 @@ from I/O (:func:`post_slack_message`) so the threshold logic is testable without
 the network and the runner can print-instead-of-post on a dry run.
 """
 
-from __future__ import annotations
-
 import datetime as dt
 import logging
 from collections.abc import Iterable

--- a/scripts/datakit/generate_tier2_skewed.py
+++ b/scripts/datakit/generate_tier2_skewed.py
@@ -16,8 +16,6 @@ temp prefix. Output path is provided by the caller; suggested layout::
     gs://marin-us-central1/tmp/ttl=3d/datakit-tier2-skew-v1/data/part-NNNNN.parquet
 """
 
-from __future__ import annotations
-
 import argparse
 import logging
 import secrets

--- a/scripts/datakit/sync_datakit.py
+++ b/scripts/datakit/sync_datakit.py
@@ -69,8 +69,6 @@ Usage::
         --dest-prefix s3://marin-na/marin
 """
 
-from __future__ import annotations
-
 import argparse
 import logging
 import re

--- a/scripts/datakit/upload_tier2_skewed_to_hf.py
+++ b/scripts/datakit/upload_tier2_skewed_to_hf.py
@@ -16,8 +16,6 @@ Token resolution order:
      ``--marin-yaml`` override) — the same file iris reads
 """
 
-from __future__ import annotations
-
 import argparse
 import io
 import logging

--- a/scripts/ferries/daily_analysis.py
+++ b/scripts/ferries/daily_analysis.py
@@ -14,8 +14,6 @@ Examples:
     --format json
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import statistics

--- a/scripts/fix_datakit_artifacts.py
+++ b/scripts/fix_datakit_artifacts.py
@@ -23,8 +23,6 @@ Before rewriting any artifact, the original is copied to
 Default is dry-run; pass ``--apply`` to actually write.
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import logging

--- a/scripts/iris/dev_gpu.py
+++ b/scripts/iris/dev_gpu.py
@@ -4,8 +4,6 @@
 
 """Allocate and use development GPU (CoreWeave H100) pods on Iris-managed clusters."""
 
-from __future__ import annotations
-
 import getpass
 import json
 import logging
@@ -81,7 +79,7 @@ class DevGpuState:
         return json.dumps(asdict(self), indent=2, sort_keys=True)
 
     @classmethod
-    def from_json(cls, raw: str) -> DevGpuState:
+    def from_json(cls, raw: str) -> "DevGpuState":
         data = json.loads(raw)
         return cls(
             session_name=data["session_name"],

--- a/scripts/iris/dev_tpu.py
+++ b/scripts/iris/dev_tpu.py
@@ -4,8 +4,6 @@
 
 """Allocate and use development TPUs on Iris-managed clusters."""
 
-from __future__ import annotations
-
 import atexit
 import getpass
 import json
@@ -82,7 +80,7 @@ class DevTpuState:
         return json.dumps(asdict(self), indent=2, sort_keys=True)
 
     @classmethod
-    def from_json(cls, raw: str) -> DevTpuState:
+    def from_json(cls, raw: str) -> "DevTpuState":
         data = json.loads(raw)
         workers = [
             DevTpuWorker(

--- a/scripts/ops/cross_region.py
+++ b/scripts/ops/cross_region.py
@@ -14,8 +14,6 @@ This script:
 The default mode analyzes the last 24 hours.
 """
 
-from __future__ import annotations
-
 import csv
 import datetime as dt
 import json

--- a/scripts/ops/discord.py
+++ b/scripts/ops/discord.py
@@ -21,8 +21,6 @@ Library:
     post("code-review", "PR #123 ready for review")
 """
 
-from __future__ import annotations
-
 import argparse
 import json
 import logging

--- a/scripts/ops/egress_report.py
+++ b/scripts/ops/egress_report.py
@@ -16,8 +16,6 @@ bodies or summary contents at INFO/WARN — the per-user counts are only safe
 inside the Discord message and the gist.
 """
 
-from __future__ import annotations
-
 import datetime as dt
 import json
 import logging

--- a/scripts/ops/storage/constants.py
+++ b/scripts/ops/storage/constants.py
@@ -3,8 +3,6 @@
 
 """Shared constants and tiny helpers for the storage tooling."""
 
-from __future__ import annotations
-
 from pathlib import Path
 
 import pyarrow as pa

--- a/scripts/ops/storage/generate_report.py
+++ b/scripts/ops/storage/generate_report.py
@@ -40,8 +40,6 @@ Usage:
     ./scripts/ops/storage/generate_report.py --gist secret --discord internal-discuss
 """
 
-from __future__ import annotations
-
 import re
 import subprocess
 import sys

--- a/scripts/ops/storage/render_report.py
+++ b/scripts/ops/storage/render_report.py
@@ -22,8 +22,6 @@ PARQUET_DIR (a local dir or gs:// path) is required; it points at the parquet
 segments written by the scan stage.
 """
 
-from __future__ import annotations
-
 import hashlib
 import re
 import sys

--- a/scripts/ops/storage/scan_gcs.py
+++ b/scripts/ops/storage/scan_gcs.py
@@ -21,8 +21,6 @@ Usage:
         --workers 128
 """
 
-from __future__ import annotations
-
 import logging
 import threading
 import time

--- a/scripts/pm/scrub_experiment_issue_tldrs.py
+++ b/scripts/pm/scrub_experiment_issue_tldrs.py
@@ -7,8 +7,6 @@
 # ///
 """Select experiment issues for agent-authored TL;DR maintenance."""
 
-from __future__ import annotations
-
 import argparse
 import json
 import logging
@@ -92,7 +90,7 @@ def extract_existing_doc_issue_number(body: str | None) -> int | None:
     return int(match.group(1))
 
 
-def collect_issue_context(issue: Issue) -> tuple[str, list[str]]:
+def collect_issue_context(issue: "Issue") -> tuple[str, list[str]]:
     comments = list(issue.get_comments())[:MAX_COMMENT_COUNT]
     comment_blocks = []
     candidate_links = extract_urls(issue.body or "")
@@ -128,7 +126,7 @@ def collect_issue_context(issue: Issue) -> tuple[str, list[str]]:
     return context, dedupe_preserving_order(candidate_links)
 
 
-def issue_needs_summary_refresh(issue: Issue, *, refresh_existing: bool) -> bool:
+def issue_needs_summary_refresh(issue: "Issue", *, refresh_existing: bool) -> bool:
     has_managed_block = issue_has_managed_block(issue.body)
     has_tldr_label = any(label.name == TLDR_LABEL for label in issue.labels)
     if refresh_existing:
@@ -138,7 +136,7 @@ def issue_needs_summary_refresh(issue: Issue, *, refresh_existing: bool) -> bool
     return not has_tldr_label
 
 
-def issue_candidates(repo: Repository, args: argparse.Namespace) -> list[Issue]:
+def issue_candidates(repo: "Repository", args: argparse.Namespace) -> "list[Issue]":
     if args.issue_number is not None:
         issue = repo.get_issue(args.issue_number)
         return [issue]
@@ -157,7 +155,7 @@ def issue_candidates(repo: Repository, args: argparse.Namespace) -> list[Issue]:
     return candidates
 
 
-def serialize_issue(issue: Issue) -> dict[str, object]:
+def serialize_issue(issue: "Issue") -> dict[str, object]:
     issue_context, candidate_links = collect_issue_context(issue)
     labels = [label.name for label in issue.labels]
     return {

--- a/scripts/sample_v0_1_store.py
+++ b/scripts/sample_v0_1_store.py
@@ -10,8 +10,6 @@ completed runs:
     uv run python scripts/sample_v0_1_store.py [--output PATH] [--per-cluster N]
 """
 
-from __future__ import annotations
-
 import argparse
 import logging
 import os

--- a/scripts/verify_smoke_v0.py
+++ b/scripts/verify_smoke_v0.py
@@ -32,8 +32,6 @@ Submit on iris (eu-west4)::
         -- python scripts/verify_smoke_v0.py {v0,mixed}
 """
 
-from __future__ import annotations
-
 import argparse
 import logging
 from collections import Counter, defaultdict

--- a/tests/datakit/download/test_formal_methods_evals.py
+++ b/tests/datakit/download/test_formal_methods_evals.py
@@ -13,8 +13,6 @@ so no network access is required. The focus is on externally-observable behaviou
 * ``zip`` and ``tar.gz`` archive formats both round-trip.
 """
 
-from __future__ import annotations
-
 import gzip
 import io
 import json

--- a/tests/datakit/download/test_game_music_evals.py
+++ b/tests/datakit/download/test_game_music_evals.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import io
 import json
 from pathlib import Path
@@ -43,7 +41,7 @@ class _FakeResponse:
         for line in self.raw.getvalue().splitlines():
             yield line.decode("utf-8") if decode_unicode else line
 
-    def __enter__(self) -> _FakeResponse:
+    def __enter__(self) -> "_FakeResponse":
         return self
 
     def __exit__(self, exc_type, exc, tb) -> None:

--- a/tests/datakit/download/test_massive.py
+++ b/tests/datakit/download/test_massive.py
@@ -3,8 +3,6 @@
 
 """Sanity tests for the AmazonScience/massive function-calling converter."""
 
-from __future__ import annotations
-
 import io
 import json
 import tarfile

--- a/tests/datakit/test_fasttext.py
+++ b/tests/datakit/test_fasttext.py
@@ -3,8 +3,6 @@
 
 """Tests for experiments.datakit.fasttext."""
 
-from __future__ import annotations
-
 from typing import Any
 
 import pytest

--- a/tests/processing/classification/deduplication/resources/parser_variants/_utils.py
+++ b/tests/processing/classification/deduplication/resources/parser_variants/_utils.py
@@ -6,8 +6,6 @@ Imported by the ``generate_*.py`` scripts under the same directory. This
 module is not a PEP 723 script itself — the importing scripts pull in the
 runtime deps via their ``# /// script`` blocks.
 """
-from __future__ import annotations
-
 import argparse
 import gzip
 import io

--- a/tests/processing/classification/deduplication/resources/parser_variants/generate_parser_variants.py
+++ b/tests/processing/classification/deduplication/resources/parser_variants/generate_parser_variants.py
@@ -21,8 +21,6 @@ Run with::
 
     HF_TOKEN=... uv run tests/.../parser_variants/generate_parser_variants.py [--dry-run]
 """
-from __future__ import annotations
-
 import sys
 from collections.abc import Iterator
 from pathlib import Path

--- a/tests/processing/classification/deduplication/resources/parser_variants/generate_quote_inclusion.py
+++ b/tests/processing/classification/deduplication/resources/parser_variants/generate_quote_inclusion.py
@@ -27,8 +27,6 @@ Run with::
 
     HF_TOKEN=... uv run tests/.../parser_variants/generate_quote_inclusion.py [--dry-run]
 """
-from __future__ import annotations
-
 import sys
 from collections.abc import Iterator
 from pathlib import Path

--- a/tests/processing/classification/deduplication/resources/parser_variants/generate_same_site_distinct_bodies.py
+++ b/tests/processing/classification/deduplication/resources/parser_variants/generate_same_site_distinct_bodies.py
@@ -31,8 +31,6 @@ Run with::
 
     HF_TOKEN=... uv run tests/.../parser_variants/generate_same_site_distinct_bodies.py [--dry-run]
 """
-from __future__ import annotations
-
 import sys
 from collections.abc import Iterator
 from pathlib import Path

--- a/tests/processing/classification/deduplication/resources/parser_variants/generate_wikipedia_revisions.py
+++ b/tests/processing/classification/deduplication/resources/parser_variants/generate_wikipedia_revisions.py
@@ -26,8 +26,6 @@ Run with::
 
     HF_TOKEN=... uv run tests/.../parser_variants/generate_wikipedia_revisions.py [--dry-run]
 """
-from __future__ import annotations
-
 import sys
 from collections.abc import Iterator
 from pathlib import Path

--- a/tests/processing/tokenize/test_split_tokenize.py
+++ b/tests/processing/tokenize/test_split_tokenize.py
@@ -7,8 +7,6 @@ Unit tests cover the pure helpers (``attach_id``, ``IdPreservingPreprocessor``).
 The slow integration test exercises the A→B pipeline end-to-end against the
 legacy ``tokenize()`` path on a tiny local parquet fixture.
 """
-from __future__ import annotations
-
 import json
 import os
 

--- a/tests/profiling/test_compare_bundle.py
+++ b/tests/profiling/test_compare_bundle.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import gzip
 import json
 from pathlib import Path

--- a/tests/profiling/test_profile_summary.py
+++ b/tests/profiling/test_profile_summary.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import gzip
 import json
 import sys

--- a/tests/profiling/test_publish.py
+++ b/tests/profiling/test_publish.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import gzip
 import json
 from pathlib import Path

--- a/tests/profiling/test_semantics.py
+++ b/tests/profiling/test_semantics.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 from marin.profiling.semantics import estimate_flop_proxy
 
 

--- a/tests/profiling/test_tracking.py
+++ b/tests/profiling/test_tracking.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import gzip
 import json
 from pathlib import Path

--- a/tests/test_grug_checkpointing.py
+++ b/tests/test_grug_checkpointing.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import json
 from datetime import timedelta
 from pathlib import Path

--- a/tests/transform/common_pile/test_filter_by_extension.py
+++ b/tests/transform/common_pile/test_filter_by_extension.py
@@ -1,8 +1,6 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-from __future__ import annotations
-
 import gzip
 import json
 from pathlib import Path

--- a/tests/transform/security_artifacts/test_renderers.py
+++ b/tests/transform/security_artifacts/test_renderers.py
@@ -3,8 +3,6 @@
 
 """Tests for deterministic security-artifact text renderers."""
 
-from __future__ import annotations
-
 import pytest
 from marin.transform.security_artifacts.renderers import (
     DEFAULT_ZEEK_EMPTY_FIELD,

--- a/tests/transform/security_artifacts/test_zeek_to_dolma.py
+++ b/tests/transform/security_artifacts/test_zeek_to_dolma.py
@@ -3,8 +3,6 @@
 
 """Tests for the Zeek → Dolma transform."""
 
-from __future__ import annotations
-
 import gzip
 import json
 from pathlib import Path

--- a/tests/transform/test_bio_chem_splitters.py
+++ b/tests/transform/test_bio_chem_splitters.py
@@ -8,8 +8,6 @@ reproduces the original byte sequence" — that is the definition of a
 format-preserving splitter.
 """
 
-from __future__ import annotations
-
 from marin.transform.bio_chem.splitters import (
     SamplingCap,
     iter_fasta_records,

--- a/tests/transform/test_format_converters.py
+++ b/tests/transform/test_format_converters.py
@@ -3,8 +3,6 @@
 
 """Tests for format conversion transforms to Dolma."""
 
-from __future__ import annotations
-
 import gzip
 import hashlib
 import json


### PR DESCRIPTION
The repo requires Python >=3.12, where PEP 604 unions (`X | Y`) and PEP 585 builtin generics (`list[int]`) already evaluate natively at runtime. The `from __future__ import annotations` import was therefore noise across the marin-owned trees. This removes it from 286 files.

Removal is not a blind delete. Without the import, annotations evaluate eagerly at definition time instead of as lazy strings, so genuine forward references would raise at import. A codemod removed the import and quoted only the annotations that actually need it — 113 annotations across 35 files — leaving every other file a plain one-line deletion. The quoted cases are the common self-referential builder/method pattern (a method whose param/return is its own enclosing class) plus a few annotations referencing optional-dependency or conditionally-imported names, which must stay lazy to preserve import behavior when the dependency is absent (e.g. `kubernetes.client.ApiClient` where `kubernetes` falls back to `None`).

`lib/levanter` and `lib/haliax` carry their own semi-upstream conventions and tooling and are excluded.

No lint guard against re-introduction is added — `ruff` has no rule that flags an unneeded future-annotations import, and a custom check was judged not worth the ceremony.

Verification: black + ruff + pyrefly clean; all 142 modified library modules import without error (eager evaluation introduces no `NameError`/`AttributeError`); and the targeted test suites for the most-quoted modules pass (zephyr expr/dataset, fray, marin execution — 301 tests).

Fixes #6579