### PR TITLE
[iris] Drop deprecated starlette WSGIMiddleware from dashboards

### DIFF
--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -38,7 +38,6 @@ from rigging.server_auth import (
     identity_scope,
 )
 from starlette.applications import Starlette
-from starlette.middleware.wsgi import WSGIMiddleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse, RedirectResponse, Response
 from starlette.routing import Match, Mount, Route
@@ -64,7 +63,7 @@ from iris.rpc.compression import IRIS_RPC_COMPRESSIONS
 from iris.rpc.controller_connect import ControllerServiceASGIApplication
 from iris.rpc.interceptors import SLOW_RPC_THRESHOLD_MS, RequestTimingInterceptor
 from iris.rpc.stats import RpcStatsCollector
-from iris.rpc.stats_connect import StatsServiceWSGIApplication
+from iris.rpc.stats_connect import StatsServiceASGIApplication
 from iris.rpc.stats_service import RpcStatsService
 
 logger = logging.getLogger(__name__)
@@ -441,12 +440,11 @@ class ControllerDashboard:
         # StatsService: reuses the auth interceptor (so non-admins can't read
         # sampled request previews) but skips RequestTimingInterceptor so the
         # stats endpoint itself doesn't pollute the numbers it reports.
-        stats_wsgi_app = StatsServiceWSGIApplication(
-            service=RpcStatsService(self._stats_collector),
+        stats_app = StatsServiceASGIApplication(
+            service=AsyncServiceAdapter(RpcStatsService(self._stats_collector)),
             interceptors=[auth_interceptor],
             compressions=IRIS_RPC_COMPRESSIONS,
         )
-        stats_app = WSGIMiddleware(stats_wsgi_app)
 
         self._endpoint_proxy = EndpointProxy(self._service.resolve_endpoint)
 
@@ -513,7 +511,7 @@ class ControllerDashboard:
                 methods=["POST"],
             ),
             Mount(rpc_asgi_app.path, app=rpc_asgi_app),
-            Mount(stats_wsgi_app.path, app=stats_app),
+            Mount(stats_app.path, app=stats_app),
         ]
         routes.append(static_files_mount())
 

--- a/lib/iris/src/iris/cluster/worker/dashboard.py
+++ b/lib/iris/src/iris/cluster/worker/dashboard.py
@@ -4,15 +4,15 @@
 """HTTP dashboard with Connect RPC and web UI for worker monitoring."""
 
 from starlette.applications import Starlette
-from starlette.middleware.wsgi import WSGIMiddleware
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Mount, Route
 
 from iris.cluster.dashboard_common import favicon_route, html_shell, static_files_mount
 from iris.cluster.worker.service import WorkerServiceImpl
+from iris.rpc.async_adapter import AsyncServiceAdapter
 from iris.rpc.compression import IRIS_RPC_COMPRESSIONS
-from iris.rpc.worker_connect import WorkerServiceWSGIApplication
+from iris.rpc.worker_connect import WorkerServiceASGIApplication
 
 
 class WorkerDashboard:
@@ -38,8 +38,12 @@ class WorkerDashboard:
         return self._app
 
     def _create_app(self) -> Starlette:
-        rpc_wsgi_app = WorkerServiceWSGIApplication(service=self._service, compressions=IRIS_RPC_COMPRESSIONS)
-        rpc_app = WSGIMiddleware(rpc_wsgi_app)
+        # The ASGI connect app awaits each handler; AsyncServiceAdapter dispatches
+        # the sync WorkerServiceImpl methods to a thread.
+        rpc_app = WorkerServiceASGIApplication(
+            service=AsyncServiceAdapter(self._service),
+            compressions=IRIS_RPC_COMPRESSIONS,
+        )
 
         # Vue Router handles client-side routing, so every SPA path serves the same shell.
         routes = [
@@ -49,7 +53,7 @@ class WorkerDashboard:
             Route("/task/{task_id:path}", self._dashboard),
             Route("/status", self._dashboard),
             static_files_mount(),
-            Mount(rpc_wsgi_app.path, app=rpc_app),
+            Mount(rpc_app.path, app=rpc_app),
         ]
         return Starlette(routes=routes)
 


### PR DESCRIPTION
The worker RPC app and the controller stats app were the last two callers mounting a sync connectrpc WSGI app through starlette.middleware.wsgi, which Starlette deprecated and will remove (it now points callers at the a2wsgi package).

Rather than add a dependency, mount the generated ASGI connect apps directly and wrap the sync service implementations in AsyncServiceAdapter so their handlers are dispatched to a thread. This mirrors how the controller's main RPC chain is already served (controller dashboard already used ControllerServiceASGIApplication + AsyncServiceAdapter for its primary service), so the two stragglers now follow the same pattern and the deprecated import is gone entirely.

All endpoints involved are unary, so there is no streaming behavior to change. Existing worker and controller dashboard tests post real Connect RPCs through the mounted apps and pass; the stats endpoint was additionally verified to serve a unary Connect response through the adapter.