### PR TITLE
[levanter] Always write tracker replicate file when wandb finish() hangs

### DIFF
--- a/lib/levanter/src/levanter/tracker/wandb.py
+++ b/lib/levanter/src/levanter/tracker/wandb.py
@@ -147,10 +147,15 @@ class WandbTracker(Tracker):
             return
 
         logger.info("Finishing wandb run...")
-        # Finish wandb first to ensure all metrics are synced to the summary
-        self.run.finish()
-        # Then write the replicate file with the complete summary
-        self._write_replicate_file()
+        try:
+            # Finish wandb first so the summary reflects every synced metric.
+            self.run.finish()
+        finally:
+            # Always write the replicate file, even when run.finish() hangs or
+            # raises (e.g. HandleAbandonedError on a wedged upload). The summary
+            # is already populated in memory, so a healthy run must still emit
+            # tracker_metrics.jsonl for the canary metrics gate.
+            self._write_replicate_file()
 
     def _write_replicate_file(self):
         if self._replicate_path is None:

--- a/lib/levanter/tests/test_tracker.py
+++ b/lib/levanter/tests/test_tracker.py
@@ -193,11 +193,11 @@ def test_wandb_tracker_materializes_before_dynamic_stale_step_check(monkeypatch)
 
 
 def test_wandb_tracker_writes_replicate_file_when_finish_raises(tmp_path, monkeypatch):
-    """A wedged run.finish() must not drop tracker_metrics.jsonl (issue #6364).
+    """A wedged run.finish() must not drop the tracker_metrics.jsonl replicate.
 
     The canary metrics gate reads the replicate file, so a W&B upload hiccup at
-    teardown (which surfaced as HandleAbandonedError) must not skip the write for
-    an otherwise healthy run.
+    teardown (which surfaces as a raised finish) must not skip the write for an
+    otherwise healthy run.
     """
     monkeypatch.setenv("WANDB_ERROR_REPORTING", "false")
 

--- a/lib/levanter/tests/test_tracker.py
+++ b/lib/levanter/tests/test_tracker.py
@@ -3,7 +3,6 @@
 
 # NOTE: Do not explicitly import wandb/other trackers here, as this will cause the tests to trivially pass.
 import dataclasses
-import json
 import logging
 import re
 import warnings
@@ -190,33 +189,6 @@ def test_wandb_tracker_materializes_before_dynamic_stale_step_check(monkeypatch)
     tracker.log({"metric": 2.0}, step=10)
 
     assert converted == [2.0]
-
-
-def test_wandb_tracker_writes_replicate_file_when_finish_raises(tmp_path, monkeypatch):
-    """A wedged run.finish() must not drop the tracker_metrics.jsonl replicate.
-
-    The canary metrics gate reads the replicate file, so a W&B upload hiccup at
-    teardown (which surfaces as a raised finish) must not skip the write for an
-    otherwise healthy run.
-    """
-    monkeypatch.setenv("WANDB_ERROR_REPORTING", "false")
-
-    class FakeRun:
-        config = {"learning_rate": 0.1}
-        summary = {"train/loss": 6.61, "_step": 99}
-
-        def finish(self):
-            raise RuntimeError("wandb finish hung")
-
-    tracker = WandbTracker(FakeRun(), replicate_path=str(tmp_path / "replicate"))
-
-    # finish() still surfaces the teardown failure, but only after the replicate write.
-    with pytest.raises(RuntimeError, match="wandb finish hung"):
-        tracker.finish()
-
-    record = json.loads((tmp_path / "replicate" / "tracker_metrics.jsonl").read_text())
-    assert record["summary"]["train/loss"] == 6.61
-    assert record["config"]["learning_rate"] == 0.1
 
 
 def test_truncate_wandb_run_name_preserves_scientific_notation_lr_suffix():

--- a/lib/levanter/tests/test_tracker.py
+++ b/lib/levanter/tests/test_tracker.py
@@ -3,6 +3,7 @@
 
 # NOTE: Do not explicitly import wandb/other trackers here, as this will cause the tests to trivially pass.
 import dataclasses
+import json
 import logging
 import re
 import warnings
@@ -189,6 +190,33 @@ def test_wandb_tracker_materializes_before_dynamic_stale_step_check(monkeypatch)
     tracker.log({"metric": 2.0}, step=10)
 
     assert converted == [2.0]
+
+
+def test_wandb_tracker_writes_replicate_file_when_finish_raises(tmp_path, monkeypatch):
+    """A wedged run.finish() must not drop tracker_metrics.jsonl (issue #6364).
+
+    The canary metrics gate reads the replicate file, so a W&B upload hiccup at
+    teardown (which surfaced as HandleAbandonedError) must not skip the write for
+    an otherwise healthy run.
+    """
+    monkeypatch.setenv("WANDB_ERROR_REPORTING", "false")
+
+    class FakeRun:
+        config = {"learning_rate": 0.1}
+        summary = {"train/loss": 6.61, "_step": 99}
+
+        def finish(self):
+            raise RuntimeError("wandb finish hung")
+
+    tracker = WandbTracker(FakeRun(), replicate_path=str(tmp_path / "replicate"))
+
+    # finish() still surfaces the teardown failure, but only after the replicate write.
+    with pytest.raises(RuntimeError, match="wandb finish hung"):
+        tracker.finish()
+
+    record = json.loads((tmp_path / "replicate" / "tracker_metrics.jsonl").read_text())
+    assert record["summary"]["train/loss"] == 6.61
+    assert record["config"]["learning_rate"] == 0.1
 
 
 def test_truncate_wandb_run_name_preserves_scientific_notation_lr_suffix():


### PR DESCRIPTION
WandbTracker.finish() called self.run.finish() first and wrote the
tracker_metrics.jsonl replicate only after it returned. When run.finish() wedged
on a W&B upload and raised HandleAbandonedError (observed on the CoreWeave H100
Grug MoE canary), the replicate write was skipped, so scripts/canary/validate_canary_metrics.py
failed with FileNotFoundError on a run that had passed every training threshold
(train/loss 6.61, _step 99, W&B state finished).

The fix moves the replicate write into a finally block in WandbTracker.finish().
The summary is already populated in memory before the upload, so a healthy run
always emits tracker_metrics.jsonl; the underlying finish() failure still
propagates to the BackgroundTracker worker, which logs it.

Fixes #6364