### PR TITLE
Add GrugMoE support for TPU vLLM serving

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -769,50 +769,6 @@ def _linear_inference_tensor(value: jax.Array) -> jax.Array:
     return jnp.swapaxes(value, -1, -2)
 
 
-def canonical_grugmoe_tensor_names(cfg: GrugModelConfig) -> frozenset[str]:
-    names = {
-        "model.embed_tokens.weight",
-        "model.embed_norm.weight",
-        "model.embed_gated_norm.down_proj.weight",
-        "model.embed_gated_norm.up_proj.weight",
-        "model.norm.weight",
-        "model.final_gated_norm.down_proj.weight",
-        "model.final_gated_norm.up_proj.weight",
-        "lm_head.weight",
-    }
-    for layer_index in range(cfg.num_layers):
-        prefix = f"model.layers.{layer_index}"
-        names.update(
-            {
-                f"{prefix}.input_layernorm.weight",
-                f"{prefix}.attn_gated_norm.down_proj.weight",
-                f"{prefix}.attn_gated_norm.up_proj.weight",
-                f"{prefix}.self_attn.q_proj.weight",
-                f"{prefix}.self_attn.k_proj.weight",
-                f"{prefix}.self_attn.v_proj.weight",
-                f"{prefix}.self_attn.o_proj.weight",
-                f"{prefix}.self_attn.attn_gate.weight",
-                f"{prefix}.post_attention_layernorm.weight",
-                f"{prefix}.mlp_gated_norm.down_proj.weight",
-                f"{prefix}.mlp_gated_norm.up_proj.weight",
-                f"{prefix}.mlp.router.weight",
-                f"{prefix}.mlp.router.bias",
-                f"{prefix}.mlp.experts.gate_proj.weight",
-                f"{prefix}.mlp.experts.up_proj.weight",
-                f"{prefix}.mlp.experts.down_proj.weight",
-            }
-        )
-        if cfg.shared_expert_intermediate_dim > 0:
-            names.update(
-                {
-                    f"{prefix}.shared_expert.gate_proj.weight",
-                    f"{prefix}.shared_expert.up_proj.weight",
-                    f"{prefix}.shared_expert.down_proj.weight",
-                }
-            )
-    return frozenset(names)
-
-
 def grugmoe_inference_state_dict(model: Transformer, prefix: str | None = None) -> dict[str, jax.Array]:
     tensors: dict[str, jax.Array] = {
         "model.embed_tokens.weight": model.token_embed,
@@ -859,9 +815,6 @@ def grugmoe_inference_state_dict(model: Transformer, prefix: str | None = None) 
                 }
             )
 
-    if set(tensors) != canonical_grugmoe_tensor_names(model.config):
-        raise ValueError("GrugMoE inference state dict tensor names do not match the canonical schema")
-
     return {_with_state_dict_prefix(prefix, name): value for name, value in tensors.items()}
 
 
@@ -880,7 +833,6 @@ __all__ = [
     "MoeActivation",
     "RMSNorm",
     "Transformer",
-    "canonical_grugmoe_tensor_names",
     "debug_mesh_and_token_pspec",
     "grugmoe_inference_state_dict",
 ]

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -9,13 +9,14 @@ No load-balancing loss; router z-loss only. All layers are MoE (no dense layers)
 
 import dataclasses
 from dataclasses import dataclass
-from typing import Literal
+from typing import Any, Literal
 
 import equinox as eqx
 import jax
 import jax.numpy as jnp
 import jax.scipy as jsp
 from einops import rearrange
+from haliax import Axis
 from haliax.jax_utils import named_call
 from jax import random
 from jax.sharding import PartitionSpec as P
@@ -26,6 +27,7 @@ try:
 except ModuleNotFoundError:
     from jax.experimental.shard_map import shard_map
 from jaxtyping import Array, Float, Int, PRNGKeyArray
+from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.grug.attention import (
     AttentionMask,
     GrugAttentionImplementation,
@@ -45,9 +47,14 @@ from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
 from levanter.grug.sharding import Pembed_vocab, Plm_head, unshard
 from levanter.tracker.histogram import Histogram, SummaryStats
 from levanter.utils.activation import ActivationFunctionEnum
+from transformers import PretrainedConfig as HfConfig
 
 _DEFAULT_EP_CAPACITY_FACTOR = 1.0
 _GATED_NORM_RANK = 128
+GRUG_MOE_MODEL_TYPE = "grug_moe"
+GRUG_MOE_ARCHITECTURE = "GrugMoeForCausalLM"
+GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY = "grugmoe_artifact_schema_version"
+GRUG_MOE_ARTIFACT_SCHEMA_VERSION = 1
 
 
 _BATCH_AXES: tuple[str, ...] = ("replica_dcn", "data", "expert")
@@ -76,6 +83,17 @@ def _batch_reshard(x: jax.Array) -> jax.Array:
 
 def _layer_attention_masks(mask: AttentionMask, *, sliding_window: int) -> tuple[AttentionMask, AttentionMask]:
     return mask.with_sliding_window(sliding_window // 2), mask.with_sliding_window(sliding_window)
+
+
+class GrugMoeHfConfig(HfConfig):
+    model_type = GRUG_MOE_MODEL_TYPE
+
+
+def _hf_config_attr(config: HfConfig, names: tuple[str, ...], default: Any = None) -> Any:
+    for name in names:
+        if hasattr(config, name):
+            return getattr(config, name)
+    return default
 
 
 @dataclass(frozen=True)
@@ -129,6 +147,14 @@ class GrugModelConfig:
         resolve_moe_implementation(self.moe_implementation)
 
     @property
+    def Embed(self) -> Axis:
+        return Axis("embed", self.hidden_dim)
+
+    @property
+    def model_type(self) -> type["Transformer"]:
+        return Transformer
+
+    @property
     def inferred_head_dim(self) -> int:
         if self.head_dim is not None:
             return self.head_dim
@@ -137,6 +163,90 @@ class GrugModelConfig:
                 f"hidden_dim={self.hidden_dim} is not divisible by num_heads={self.num_heads}; set head_dim explicitly"
             )
         return self.hidden_dim // self.num_heads
+
+    def build(self, Vocab: Axis, *, key: PRNGKeyArray) -> "Transformer":
+        cfg = self if Vocab.size == self.vocab_size else dataclasses.replace(self, vocab_size=Vocab.size)
+        return Transformer.init(cfg, key=key)
+
+    def hf_checkpoint_converter(
+        self,
+        ref_checkpoint: str | None = None,
+    ) -> HFCheckpointConverter["GrugModelConfig"]:  # type: ignore[type-var]
+        return HFCheckpointConverter(
+            self.__class__,
+            reference_checkpoint=ref_checkpoint,
+            HfConfigClass=GrugMoeHfConfig,
+            tokenizer=ref_checkpoint,
+        )
+
+    @classmethod
+    def from_hf_config(cls, hf_config: HfConfig) -> "GrugModelConfig":
+        rope = RotaryConfig(theta=float(_hf_config_attr(hf_config, ("rope_theta",), 10000.0)))
+        return cls(
+            vocab_size=int(_hf_config_attr(hf_config, ("vocab_size",))),
+            hidden_dim=int(_hf_config_attr(hf_config, ("hidden_dim", "hidden_size"), 2048)),
+            intermediate_dim=int(
+                _hf_config_attr(hf_config, ("intermediate_dim", "moe_intermediate_size", "intermediate_size"), 5632)
+            ),
+            shared_expert_intermediate_dim=int(
+                _hf_config_attr(
+                    hf_config,
+                    ("shared_expert_intermediate_dim", "shared_expert_intermediate_size"),
+                    5632,
+                )
+            ),
+            num_experts=int(_hf_config_attr(hf_config, ("num_experts", "num_local_experts"), 8)),
+            num_experts_per_token=int(_hf_config_attr(hf_config, ("num_experts_per_token", "num_experts_per_tok"), 2)),
+            num_layers=int(_hf_config_attr(hf_config, ("num_layers", "num_hidden_layers"), 24)),
+            num_heads=int(_hf_config_attr(hf_config, ("num_heads", "num_attention_heads"), 16)),
+            num_kv_heads=int(_hf_config_attr(hf_config, ("num_kv_heads", "num_key_value_heads"), 16)),
+            head_dim=_hf_config_attr(hf_config, ("head_dim", "attention_head_dim")),
+            max_seq_len=int(_hf_config_attr(hf_config, ("max_seq_len", "max_position_embeddings"), 4096)),
+            sliding_window=int(_hf_config_attr(hf_config, ("sliding_window",), 4096)),
+            layer_norm_eps=float(_hf_config_attr(hf_config, ("layer_norm_eps", "rms_norm_eps"), 1e-5)),
+            initializer_std=float(_hf_config_attr(hf_config, ("initializer_std", "initializer_range"), 0.02)),
+            qk_mult=float(_hf_config_attr(hf_config, ("qk_mult",), 1.0)),
+            rope=rope,
+        )
+
+    def to_hf_config(self, vocab_size: int, config_overrides: dict[str, Any] | None = None) -> GrugMoeHfConfig:
+        config = {
+            "architectures": [GRUG_MOE_ARCHITECTURE],
+            "vocab_size": vocab_size,
+            "hidden_dim": self.hidden_dim,
+            "hidden_size": self.hidden_dim,
+            "intermediate_dim": self.intermediate_dim,
+            "intermediate_size": self.intermediate_dim,
+            "moe_intermediate_size": self.intermediate_dim,
+            "shared_expert_intermediate_dim": self.shared_expert_intermediate_dim,
+            "shared_expert_intermediate_size": self.shared_expert_intermediate_dim,
+            "num_experts": self.num_experts,
+            "num_local_experts": self.num_experts,
+            "num_experts_per_token": self.num_experts_per_token,
+            "num_experts_per_tok": self.num_experts_per_token,
+            "num_layers": self.num_layers,
+            "num_hidden_layers": self.num_layers,
+            "num_heads": self.num_heads,
+            "num_attention_heads": self.num_heads,
+            "num_kv_heads": self.num_kv_heads,
+            "num_key_value_heads": self.num_kv_heads,
+            "head_dim": self.inferred_head_dim,
+            "max_seq_len": self.max_seq_len,
+            "max_position_embeddings": self.max_seq_len,
+            "sliding_window": self.sliding_window,
+            "layer_norm_eps": self.layer_norm_eps,
+            "rms_norm_eps": self.layer_norm_eps,
+            "initializer_std": self.initializer_std,
+            "initializer_range": self.initializer_std,
+            "qk_mult": self.qk_mult,
+            "grugmoe_attention_mode": "production",
+            GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY: GRUG_MOE_ARTIFACT_SCHEMA_VERSION,
+            "rope_theta": self.rope.theta,
+            "tie_word_embeddings": False,
+        }
+        if config_overrides is not None:
+            config.update(config_overrides)
+        return GrugMoeHfConfig(**config)
 
 
 def rms_norm(x: jax.Array, eps: float = 1e-6) -> jax.Array:
@@ -499,7 +609,25 @@ class Transformer(eqx.Module):
     config: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
-    def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "Transformer":
+    def init(
+        cfg_or_vocab: GrugModelConfig | Axis,
+        config: GrugModelConfig | None = None,
+        *,
+        key: PRNGKeyArray,
+    ) -> "Transformer":
+        if isinstance(cfg_or_vocab, Axis):
+            if config is None:
+                raise ValueError("config must be provided when initializing with a Vocab axis")
+            cfg = (
+                config
+                if cfg_or_vocab.size == config.vocab_size
+                else dataclasses.replace(config, vocab_size=cfg_or_vocab.size)
+            )
+        else:
+            if config is not None:
+                raise ValueError("config must not be provided when initializing directly from GrugModelConfig")
+            cfg = cfg_or_vocab
+
         embed_key, out_key, embed_gn_key, final_gn_key, *block_keys = random.split(key, cfg.num_layers + 4)
         token_embed = reshard(
             _init_weight(embed_key, (cfg.vocab_size, cfg.hidden_dim), cfg.initializer_std), Pembed_vocab
@@ -516,6 +644,10 @@ class Transformer(eqx.Module):
             final_gated_norm=GatedNorm.init(cfg.hidden_dim, cfg.initializer_std, key=final_gn_key),
             config=cfg,
         )
+
+    @property
+    def Vocab(self) -> Axis:
+        return Axis("vocab", self.config.vocab_size)
 
     @named_call
     def __call__(
@@ -565,6 +697,9 @@ class Transformer(eqx.Module):
         batch_spec = _batch_spec()
         hidden, _ = self(token_ids, mask=mask)
         return jnp.einsum("bsh,hd->bsd", hidden, self.output_proj, out_sharding=batch_spec)
+
+    def to_state_dict(self, prefix: str | None = None) -> dict[str, jax.Array]:
+        return grugmoe_inference_state_dict(self, prefix=prefix)
 
     def next_token_loss(
         self,
@@ -626,15 +761,126 @@ def debug_mesh_and_token_pspec(num_devices: int) -> tuple[jax.sharding.AbstractM
     return mesh, P(("replica_dcn", "data", "expert"), None)
 
 
+def _with_state_dict_prefix(prefix: str | None, name: str) -> str:
+    return name if prefix is None else f"{prefix}.{name}"
+
+
+def _linear_inference_tensor(value: jax.Array) -> jax.Array:
+    return jnp.swapaxes(value, -1, -2)
+
+
+def canonical_grugmoe_tensor_names(cfg: GrugModelConfig) -> frozenset[str]:
+    names = {
+        "model.embed_tokens.weight",
+        "model.embed_norm.weight",
+        "model.embed_gated_norm.down_proj.weight",
+        "model.embed_gated_norm.up_proj.weight",
+        "model.norm.weight",
+        "model.final_gated_norm.down_proj.weight",
+        "model.final_gated_norm.up_proj.weight",
+        "lm_head.weight",
+    }
+    for layer_index in range(cfg.num_layers):
+        prefix = f"model.layers.{layer_index}"
+        names.update(
+            {
+                f"{prefix}.input_layernorm.weight",
+                f"{prefix}.attn_gated_norm.down_proj.weight",
+                f"{prefix}.attn_gated_norm.up_proj.weight",
+                f"{prefix}.self_attn.q_proj.weight",
+                f"{prefix}.self_attn.k_proj.weight",
+                f"{prefix}.self_attn.v_proj.weight",
+                f"{prefix}.self_attn.o_proj.weight",
+                f"{prefix}.self_attn.attn_gate.weight",
+                f"{prefix}.post_attention_layernorm.weight",
+                f"{prefix}.mlp_gated_norm.down_proj.weight",
+                f"{prefix}.mlp_gated_norm.up_proj.weight",
+                f"{prefix}.mlp.router.weight",
+                f"{prefix}.mlp.router.bias",
+                f"{prefix}.mlp.experts.gate_proj.weight",
+                f"{prefix}.mlp.experts.up_proj.weight",
+                f"{prefix}.mlp.experts.down_proj.weight",
+            }
+        )
+        if cfg.shared_expert_intermediate_dim > 0:
+            names.update(
+                {
+                    f"{prefix}.shared_expert.gate_proj.weight",
+                    f"{prefix}.shared_expert.up_proj.weight",
+                    f"{prefix}.shared_expert.down_proj.weight",
+                }
+            )
+    return frozenset(names)
+
+
+def grugmoe_inference_state_dict(model: Transformer, prefix: str | None = None) -> dict[str, jax.Array]:
+    tensors: dict[str, jax.Array] = {
+        "model.embed_tokens.weight": model.token_embed,
+        "model.embed_norm.weight": model.embed_norm.weight,
+        "model.embed_gated_norm.down_proj.weight": _linear_inference_tensor(model.embed_gated_norm.w_down),
+        "model.embed_gated_norm.up_proj.weight": _linear_inference_tensor(model.embed_gated_norm.w_up),
+        "model.norm.weight": model.final_norm.weight,
+        "model.final_gated_norm.down_proj.weight": _linear_inference_tensor(model.final_gated_norm.w_down),
+        "model.final_gated_norm.up_proj.weight": _linear_inference_tensor(model.final_gated_norm.w_up),
+        "lm_head.weight": _linear_inference_tensor(model.output_proj),
+    }
+
+    for layer_index, block in enumerate(model.blocks):
+        layer_prefix = f"model.layers.{layer_index}"
+        gate, up = jnp.split(block.mlp.expert_mlp.w_gate_up, [model.config.intermediate_dim], axis=-1)
+        tensors.update(
+            {
+                f"{layer_prefix}.input_layernorm.weight": block.rms_attn.weight,
+                f"{layer_prefix}.attn_gated_norm.down_proj.weight": _linear_inference_tensor(
+                    block.attn_gated_norm.w_down
+                ),
+                f"{layer_prefix}.attn_gated_norm.up_proj.weight": _linear_inference_tensor(block.attn_gated_norm.w_up),
+                f"{layer_prefix}.self_attn.q_proj.weight": _linear_inference_tensor(block.attn.w_q),
+                f"{layer_prefix}.self_attn.k_proj.weight": _linear_inference_tensor(block.attn.w_k),
+                f"{layer_prefix}.self_attn.v_proj.weight": _linear_inference_tensor(block.attn.w_v),
+                f"{layer_prefix}.self_attn.o_proj.weight": _linear_inference_tensor(block.attn.w_o),
+                f"{layer_prefix}.self_attn.attn_gate.weight": _linear_inference_tensor(block.attn.attn_gate),
+                f"{layer_prefix}.post_attention_layernorm.weight": block.rms_mlp.weight,
+                f"{layer_prefix}.mlp_gated_norm.down_proj.weight": _linear_inference_tensor(block.mlp_gated_norm.w_down),
+                f"{layer_prefix}.mlp_gated_norm.up_proj.weight": _linear_inference_tensor(block.mlp_gated_norm.w_up),
+                f"{layer_prefix}.mlp.router.weight": _linear_inference_tensor(block.mlp.router),
+                f"{layer_prefix}.mlp.router.bias": block.mlp.router_bias,
+                f"{layer_prefix}.mlp.experts.gate_proj.weight": _linear_inference_tensor(gate),
+                f"{layer_prefix}.mlp.experts.up_proj.weight": _linear_inference_tensor(up),
+                f"{layer_prefix}.mlp.experts.down_proj.weight": _linear_inference_tensor(block.mlp.expert_mlp.w_down),
+            }
+        )
+        if block.shared is not None:
+            tensors.update(
+                {
+                    f"{layer_prefix}.shared_expert.gate_proj.weight": _linear_inference_tensor(block.shared.w_gate),
+                    f"{layer_prefix}.shared_expert.up_proj.weight": _linear_inference_tensor(block.shared.w_up),
+                    f"{layer_prefix}.shared_expert.down_proj.weight": _linear_inference_tensor(block.shared.w_down),
+                }
+            )
+
+    if set(tensors) != canonical_grugmoe_tensor_names(model.config):
+        raise ValueError("GrugMoE inference state dict tensor names do not match the canonical schema")
+
+    return {_with_state_dict_prefix(prefix, name): value for name, value in tensors.items()}
+
+
 __all__ = [
+    "GRUG_MOE_ARCHITECTURE",
+    "GRUG_MOE_ARTIFACT_SCHEMA_VERSION",
+    "GRUG_MOE_ARTIFACT_SCHEMA_VERSION_KEY",
+    "GRUG_MOE_MODEL_TYPE",
     "Block",
     "CausalSelfAttention",
     "DenseMLP",
     "GatedNorm",
     "GrugModelConfig",
+    "GrugMoeHfConfig",
     "MoEMLP",
     "MoeActivation",
     "RMSNorm",
     "Transformer",
+    "canonical_grugmoe_tensor_names",
     "debug_mesh_and_token_pspec",
+    "grugmoe_inference_state_dict",
 ]

--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -425,8 +425,9 @@ def _to_state_dict_with_dtype(
             else:
                 logger.debug(f"Skipping dtype conversion for non-floating point array {k} with dtype {v.dtype}")
 
-    # deshard. We could be smarter here and use a process mesh or host offloading, but this is simpler for now
-    state_dict = jax.lax.with_sharding_constraint(state_dict, PartitionSpec())
+    # This is the shared Levanter HF export path, not a GrugMoE-specific hook.
+    # Deshard before writing; reshard handles explicit meshes moving partitioned arrays to replicated leaves.
+    state_dict = jax.tree.map(lambda value: jax.sharding.reshard(value, PartitionSpec()), state_dict)
 
     return state_dict
 
@@ -622,7 +623,7 @@ class HFCheckpointConverter(Generic[LevConfig]):
     def _infer_tokenizer(tokenizer, ref, trust_remote_code: bool = False) -> Any:
         if tokenizer is None:
             if ref is None:
-                raise ValueError("Must provide either tokenizer or reference_checkpoint")
+                return None
             tokenizer = ref
 
         if isinstance(tokenizer, (str, RepoRef)):
@@ -670,6 +671,8 @@ class HFCheckpointConverter(Generic[LevConfig]):
 
     @cached_property
     def Vocab(self) -> Axis:
+        if self.tokenizer is None:
+            raise ValueError("Cannot infer vocabulary size without a tokenizer")
         return Axis("vocab", len(self.tokenizer))
 
     def config_from_hf_config(self, hf_config, overrides: Optional[dict] = None) -> LevConfig:
@@ -928,6 +931,8 @@ class HFCheckpointConverter(Generic[LevConfig]):
         """Determine whether reference code should be bundled with the checkpoint."""
         #  the way we determine this is if the config class is in the HF package or not
         if save_reference_code is None:
+            if self.reference_checkpoint is None:
+                return False
             return not self.HfConfigClass.__module__.startswith("transformers.")
 
         return save_reference_code

--- a/lib/levanter/src/levanter/main/export_lm_to_hf.py
+++ b/lib/levanter/src/levanter/main/export_lm_to_hf.py
@@ -4,7 +4,7 @@
 import logging
 from contextlib import ExitStack
 from dataclasses import dataclass
-from typing import Optional
+from typing import Any, Optional, Protocol, runtime_checkable
 
 import equinox as eqx
 import haliax
@@ -15,7 +15,7 @@ from haliax import Axis
 import levanter
 import levanter.utils.logging as logging_utils
 from levanter.checkpoint import latest_checkpoint_path, load_checkpoint
-from levanter.compat.hf_checkpoints import RepoRef, load_tokenizer, HFCompatConfig
+from levanter.compat.hf_checkpoints import DEFAULT_MAX_SHARD_SIZE, RepoRef, load_tokenizer
 from levanter.models.llama import LlamaConfig
 from levanter.models.lm_model import LmConfig, LmHeadModel
 from levanter.trainer import TrainerConfig
@@ -24,12 +24,19 @@ from levanter.utils.jax_utils import is_inexact_arrayish, local_cpu_mesh
 logger = logging.getLogger(__name__)
 
 
+@runtime_checkable
+class _HFCheckpointConvertible(Protocol):
+    def hf_checkpoint_converter(self) -> Any: ...
+
+
 @dataclass
 class ConvertLmConfig:
     trainer: TrainerConfig
     checkpoint_path: str
     output_dir: str
     upload_to_hf: Optional[RepoRef] = None  # if specified, attempt to upload this checkpoint to the hf hub
+    checkpoint_subpath: str = "model"
+    max_shard_size: int = DEFAULT_MAX_SHARD_SIZE
 
     model: LmConfig = LlamaConfig()
     save_tokenizer: bool = True  # if True, save the tokenizer to the output directory
@@ -42,14 +49,21 @@ class ConvertLmConfig:
 
 def main(config: ConvertLmConfig):
     logging_utils.init_logging("logs", "export")
+    if not isinstance(config.model, _HFCheckpointConvertible):
+        raise TypeError("model must provide hf_checkpoint_converter()")
+    converter = config.model.hf_checkpoint_converter()
     tokenizer_spec = config.tokenizer
     if tokenizer_spec is None:
-        assert isinstance(config.model, HFCompatConfig)
-        tokenizer = config.model.hf_checkpoint_converter().tokenizer
+        tokenizer = converter.tokenizer
     else:
         tokenizer = load_tokenizer(tokenizer_spec)
 
-    vocab_size = config.override_vocab_size or len(tokenizer)
+    if tokenizer is None:
+        vocab_size = config.override_vocab_size or getattr(config.model, "vocab_size", None)
+        if vocab_size is None:
+            raise ValueError("override_vocab_size is required when exporting without a tokenizer")
+    else:
+        vocab_size = config.override_vocab_size or len(tokenizer)
     Vocab = Axis("vocab", vocab_size)
 
     key = jax.random.PRNGKey(0)
@@ -68,7 +82,7 @@ def main(config: ConvertLmConfig):
         # TODO: don't load the entire checkpoint into CPU memory when we only need our share of the model
         checkpoint_path = latest_checkpoint_path(config.checkpoint_path)
         logger.info(f"Loading checkpoint from {checkpoint_path}...")
-        trainable = load_checkpoint(trainable, checkpoint_path, subpath="model")
+        trainable = load_checkpoint(trainable, checkpoint_path, subpath=config.checkpoint_subpath)
 
         assert trainable is not None
         model = eqx.combine(trainable, non_trainable)
@@ -76,9 +90,12 @@ def main(config: ConvertLmConfig):
         if config.override_vocab_size:
             model = model.resize_vocab(config.override_vocab_size)
 
-        converter = model.config.hf_checkpoint_converter()
         if config.tokenizer:
             converter = converter.replaced(tokenizer=tokenizer)
+        if config.config_overrides:
+            converter = converter.with_config_overrides(config.config_overrides)
+        if config.save_tokenizer and tokenizer is None:
+            raise ValueError("save_tokenizer=True requires a tokenizer")
 
         logger.info(f"Converting {config.checkpoint_path}...")
 
@@ -87,6 +104,7 @@ def main(config: ConvertLmConfig):
             config.output_dir,
             upload_to_hf=config.upload_to_hf or False,
             save_tokenizer=config.save_tokenizer,
+            max_shard_size=config.max_shard_size,
         )
 
 

--- a/lib/levanter/tests/test_export_to_hf.py
+++ b/lib/levanter/tests/test_export_to_hf.py
@@ -11,15 +11,28 @@ from types import SimpleNamespace
 import equinox as eqx
 import jax
 from transformers import AutoModelForCausalLM
+from transformers import GPT2Config as HfGpt2Config
 
 import haliax
 
 import levanter.main.export_lm_to_hf as export_lm_to_hf
 import tiny_test_corpus
 from levanter.checkpoint import save_checkpoint
+from levanter.compat.hf_checkpoints import HFCheckpointConverter, SAFE_TENSORS_INDEX_NAME
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
 from levanter.utils.jax_utils import is_inexact_arrayish
 from test_utils import has_torch
+
+
+class TokenizerlessGpt2Config(Gpt2Config):
+    def hf_checkpoint_converter(self, ref_checkpoint: str | None = None) -> HFCheckpointConverter["Gpt2Config"]:
+        return HFCheckpointConverter(
+            self.__class__,
+            reference_checkpoint=None,
+            HfConfigClass=HfGpt2Config,
+            tokenizer=None,
+            ignore_prefix="transformer",
+        )
 
 
 def test_export_lm_to_hf():
@@ -71,3 +84,47 @@ def test_export_lm_to_hf():
             reloaded = AutoModelForCausalLM.from_pretrained(output_dir)
             assert reloaded.config.n_layer == 2
             assert reloaded.config.vocab_size == len(tok)
+
+
+def test_export_lm_to_hf_custom_subpath_without_tokenizer():
+    model_config = TokenizerlessGpt2Config(
+        num_layers=1,
+        num_heads=2,
+        max_seq_len=16,
+        use_flash_attention=False,
+        hidden_dim=16,
+    )
+    vocab_size = 64
+
+    with tempfile.TemporaryDirectory() as tmpdir:
+        Vocab = haliax.Axis("vocab", vocab_size)
+        model = Gpt2LMHeadModel.init(Vocab, model_config, key=jax.random.PRNGKey(0))
+        trainable, _ = eqx.partition(model, is_inexact_arrayish)
+        save_checkpoint({"params": trainable}, 0, f"{tmpdir}/ckpt")
+
+        trainer = SimpleNamespace(
+            device_mesh=contextlib.nullcontext(),
+            parameter_axis_mapping={},
+        )
+        output_dir = f"{tmpdir}/output"
+        config = export_lm_to_hf.ConvertLmConfig(
+            trainer=trainer,
+            checkpoint_path=f"{tmpdir}/ckpt",
+            checkpoint_subpath="params",
+            output_dir=output_dir,
+            model=model_config,
+            save_tokenizer=False,
+            override_vocab_size=vocab_size,
+            max_shard_size=512,
+            use_cpu=True,
+        )
+        export_lm_to_hf.main(config)
+
+        with open(os.path.join(output_dir, "config.json")) as f:
+            hf_config = json.load(f)
+        assert hf_config["vocab_size"] == vocab_size
+        assert hf_config["n_layer"] == 1
+        assert hf_config["n_head"] == 2
+        assert not os.path.exists(os.path.join(output_dir, "tokenizer.json"))
+        assert os.path.exists(os.path.join(output_dir, SAFE_TENSORS_INDEX_NAME))
+        assert len(glob.glob(os.path.join(output_dir, "*.safetensors"))) > 1

--- a/lib/marin/src/marin/export/levanter_checkpoint.py
+++ b/lib/marin/src/marin/export/levanter_checkpoint.py
@@ -18,7 +18,7 @@ from fray.types import (
     create_environment,
 )
 from levanter.checkpoint import discover_latest_checkpoint
-from levanter.compat.hf_checkpoints import RepoRef
+from levanter.compat.hf_checkpoints import DEFAULT_MAX_SHARD_SIZE, RepoRef
 from levanter.main import export_lm_to_hf
 from levanter.main.export_lm_to_hf import ConvertLmConfig
 from levanter.models.lm_model import LmConfig
@@ -47,6 +47,8 @@ class ConvertCheckpointStepConfig:
     checkpoint_path: str | InputName | VersionedValue[str]
     trainer: TrainerConfig
     model: LmConfig
+    checkpoint_subpath: str = "model"
+    max_shard_size: int = DEFAULT_MAX_SHARD_SIZE
     resources: ResourceConfig = dataclasses.field(default_factory=_default_export_resources)
     output_path: str = dataclasses.field(default_factory=this_output_path)  # type: ignore[arg-type]
     upload_to_hf: bool | str | RepoRef = False
@@ -79,6 +81,8 @@ def convert_checkpoint_to_hf(config: ConvertCheckpointStepConfig) -> None:
         checkpoint_path=checkpoint_path,  # type: ignore[arg-type]
         output_dir=config.output_path,
         upload_to_hf=config.upload_to_hf,
+        checkpoint_subpath=config.checkpoint_subpath,
+        max_shard_size=config.max_shard_size,
         model=config.model,
         save_tokenizer=config.save_tokenizer,
         tokenizer=config.tokenizer,
@@ -127,6 +131,8 @@ def convert_checkpoint_to_hf_step(
     tokenizer: str | None = None,
     override_vocab_size: int | None = None,
     config_overrides: dict[str, Any] | None = None,
+    checkpoint_subpath: str = "model",
+    max_shard_size: int = DEFAULT_MAX_SHARD_SIZE,
     save_tokenizer: bool = True,
     use_cpu: bool = False,
     override_output_path: str | None = None,
@@ -147,6 +153,9 @@ def convert_checkpoint_to_hf_step(
         tokenizer: Optional tokenizer override. Defaults to the tokenizer specified by ``model``.
         override_vocab_size: If provided, resizes the vocabulary before exporting.
         config_overrides: Optional dict merged into the HF config prior to saving.
+        checkpoint_subpath: Checkpoint subtree to load as the model parameters. Standard Levanter LM checkpoints use
+            ``model``; GrugMoE training-state checkpoints use ``params``.
+        max_shard_size: Maximum safetensors shard size, in bytes. Defaults to Levanter's standard HF export size.
         save_tokenizer: Whether to emit tokenizer files alongside the model weights.
         use_cpu: Force conversion to run on CPU instead of the configured device mesh. When False, CPU mode is enabled
             automatically if the provided resources do not expose an accelerator.
@@ -169,6 +178,8 @@ def convert_checkpoint_to_hf_step(
         tokenizer=tokenizer,
         override_vocab_size=override_vocab_size,
         config_overrides=config_overrides,
+        checkpoint_subpath=checkpoint_subpath,
+        max_shard_size=max_shard_size,
         save_tokenizer=save_tokenizer,
         use_cpu=use_cpu,
         discover_latest=discover_latest,

--- a/lib/marin/src/marin/inference/vllm_server.py
+++ b/lib/marin/src/marin/inference/vllm_server.py
@@ -188,8 +188,7 @@ def _poll_until_ready(
         elapsed = time.time() - start_time
         if elapsed > timeout_seconds:
             raise TimeoutError(
-                f"vLLM server at {models_url} did not become ready within {timeout_seconds}s "
-                f"(elapsed {elapsed:.1f}s)."
+                f"vLLM server at {models_url} did not become ready within {timeout_seconds}s (elapsed {elapsed:.1f}s)."
             )
 
         time.sleep(poll_interval_seconds)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,10 +158,10 @@ nvidia-cutlass-dsl-libs-cu13 = { index = "nvidia" }
 # NOTE: harbor is a pinned git dependency (not a workspace member).
 # harbor lives in marin-community/harbor as a pinned git dependency.
 harbor = { git = "https://github.com/marin-community/harbor.git", rev = "354692d9c0eab497b05f266aa0dff30e2a238d2e" }
-# https://github.com/marin-community/vllm/compare/7b98f498cdf0bf9cf0ecc37b5c0c994cb94513c3...04321f0f01b8e60d577a85a1b1af688e4433e7e0
-vllm = { git = "https://github.com/marin-community/vllm.git", rev = "04321f0f01b8e60d577a85a1b1af688e4433e7e0" }
-# https://github.com/marin-community/tpu-inference/compare/0045517c4ba75b1d624dba3be8b77e16c18b1a1e...4c38590e29d33451f2b4375a78ad8f70cacd7b98
-tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "4c38590e29d33451f2b4375a78ad8f70cacd7b98" }
+# https://github.com/marin-community/vllm/compare/e6e3b6b10c1d44936306be3a67c709d763f89e48...7557e69ddb2e28b287d0729b4aee4d7de8de18f9
+vllm = { git = "https://github.com/marin-community/vllm.git", rev = "7557e69ddb2e28b287d0729b4aee4d7de8de18f9" }
+# https://github.com/marin-community/tpu-inference/compare/c0c901b2b5f3617f5250881c3458d58f4b20b10d...217fc45b078b1030bfcb5b704ed1169b448a5808
+tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "217fc45b078b1030bfcb5b704ed1169b448a5808" }
 # ### BEGIN RUST-DEV SOURCES ###
 # ### END RUST-DEV SOURCES ###
 

--- a/tests/vllm/__init__.py
+++ b/tests/vllm/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/tests/vllm/grugmoe_real_checkpoint_backend.py
+++ b/tests/vllm/grugmoe_real_checkpoint_backend.py
@@ -1,0 +1,847 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Backend subprocess entrypoints for the GrugMoE real-checkpoint e2e.
+
+Heavy TPU/JAX/vLLM imports stay inside explicitly-run backend phases so pytest
+collection remains cheap.
+"""
+
+from __future__ import annotations
+
+import argparse
+import dataclasses
+import importlib.metadata as md
+import importlib.util
+import json
+import os
+import posixpath
+import shutil
+import subprocess
+import sys
+import tempfile
+import time
+from contextlib import ExitStack
+from dataclasses import dataclass
+from typing import Any
+from urllib.error import URLError
+from urllib.parse import urlparse
+from urllib.request import Request, urlopen
+
+EUROPE_WEST4_GCS_PREFIX = "gs://marin-eu-west4/"
+REGION = "europe-west4"
+TPU_TYPE = "v6e-4"
+CHECKPOINT_PATH = "gs://marin-eu-west4/grug/moe_may_compute_opt_d512_ep1-05c39b/checkpoints/step-10980"
+TOKENIZER_PATH = "gs://marin-eu-west4/tokenizers/meta-llama/Meta-Llama-3.1-8B/hf-hub-0.36.0"
+OUTPUT_ROOT = "gs://marin-eu-west4/tmp/ttl=14d/grugmoe-real-checkpoint-e2e"
+CACHE_ROOT = "gs://marin-eu-west4/compilation-cache/grugmoe-real-checkpoint-e2e"
+PROMPT = (
+    "Answer with digits only. No words. No punctuation. What is the Answer to the Ultimate Question of Life, "
+    "the Universe, and Everything?"
+)
+EXPECTED_CONTINUATION = " The Ultimate. The Ultimate. The Ultimate"
+MAX_MODEL_LEN = 128
+MAX_NUM_BATCHED_TOKENS = 128
+MAX_NEW_TOKENS = 8
+LEVANTER_PROMPT_ADD_SPECIAL_TOKENS = True
+EXPECTED_PROMPT_TOKEN_COUNT = 29
+DECODE_SEQ_LEN = 128
+SERVER_TIMEOUT_SECONDS = 1800
+SERVED_MODEL_NAME = "grugmoe-real-checkpoint-e2e"
+VLLM_DTYPE = "bfloat16"
+MAX_SHARD_SIZE = 256 * 1024 * 1024
+_REAL_CHECKPOINT_HIDDEN_DIM = 512
+
+
+@dataclass(frozen=True)
+class E2EPaths:
+    output_dir: str
+    cache_dir: str
+    artifact_dir: str
+    export_result_path: str
+    vllm_result_path: str
+    levanter_result_path: str
+    summary_result_path: str
+
+
+@dataclass(frozen=True)
+class StagedArtifact:
+    vllm_model_path: str
+    staging: dict[str, Any]
+
+
+def _join_path(base: str, *parts: str) -> str:
+    parsed = urlparse(base)
+    if parsed.scheme in {"", "file"}:
+        return os.path.join(base, *parts)
+    return posixpath.join(base.rstrip("/"), *parts)
+
+
+def _fs_path(path: str):
+    import fsspec  # noqa: PLC0415
+
+    return fsspec.core.url_to_fs(path)
+
+
+def _exists(path: str) -> bool:
+    fs, plain_path = _fs_path(path)
+    return fs.exists(plain_path)
+
+
+def _remove_tree(path: str) -> None:
+    fs, plain_path = _fs_path(path)
+    if fs.exists(plain_path):
+        fs.rm(plain_path, recursive=True)
+
+
+def _write_json(path: str, payload: dict[str, Any]) -> None:
+    import fsspec  # noqa: PLC0415
+
+    parent = path.rsplit("/", 1)[0]
+    fs, plain_parent = _fs_path(parent)
+    fs.makedirs(plain_parent, exist_ok=True)
+    with fsspec.open(path, "w") as f:
+        json.dump(payload, f, indent=2, sort_keys=True)
+        f.write("\n")
+
+
+def _read_json(path: str) -> dict[str, Any]:
+    import fsspec  # noqa: PLC0415
+
+    _require_europe_west4_path("json_path", path)
+    with fsspec.open(path, "r") as f:
+        payload = json.load(f)
+    if not isinstance(payload, dict):
+        raise TypeError(f"expected JSON object at {path}, got {type(payload).__name__}")
+    return payload
+
+
+def _require_europe_west4_path(label: str, path: str) -> None:
+    parsed = urlparse(path)
+    if parsed.scheme == "gs":
+        if path.startswith(EUROPE_WEST4_GCS_PREFIX):
+            return
+        raise ValueError(f"{label} must be under {EUROPE_WEST4_GCS_PREFIX}, got {path!r}")
+    if parsed.scheme in {"", "file"}:
+        return
+    raise ValueError(f"{label} must be a local path or {EUROPE_WEST4_GCS_PREFIX} path, got {path!r}")
+
+
+def _require_file(label: str, path: str) -> None:
+    _require_europe_west4_path(label, path)
+    if not _exists(path):
+        raise FileNotFoundError(f"{label} not found at {path}")
+
+
+def _require_constants_are_europe_west4(paths: E2EPaths | None = None) -> None:
+    if REGION != "europe-west4":
+        raise ValueError(f"GrugMoE e2e region must be europe-west4, got {REGION!r}")
+    for label, path in {
+        "checkpoint_path": CHECKPOINT_PATH,
+        "tokenizer_path": TOKENIZER_PATH,
+        "output_root": OUTPUT_ROOT,
+        "cache_root": CACHE_ROOT,
+        **(
+            {
+                "output_dir": paths.output_dir,
+                "cache_dir": paths.cache_dir,
+                "artifact_dir": paths.artifact_dir,
+                "export_result_path": paths.export_result_path,
+                "vllm_result_path": paths.vllm_result_path,
+                "levanter_result_path": paths.levanter_result_path,
+                "summary_result_path": paths.summary_result_path,
+            }
+            if paths is not None
+            else {}
+        ),
+    }.items():
+        _require_europe_west4_path(label, path)
+
+
+def _metadata_text(path: str, *, timeout_seconds: float = 1.0) -> str | None:
+    request = Request(
+        f"http://metadata.google.internal/computeMetadata/v1/{path}",
+        headers={"Metadata-Flavor": "Google"},
+    )
+    try:
+        with urlopen(request, timeout=timeout_seconds) as response:
+            return response.read().decode("utf-8")
+    except (OSError, URLError, TimeoutError):
+        return None
+
+
+def _runtime_region() -> str | None:
+    for env_name in ("MARIN_TPU_REGION", "TPU_REGION", "GOOGLE_CLOUD_REGION", "CLOUD_ML_REGION"):
+        value = os.environ.get(env_name)
+        if value:
+            return value
+
+    zone = _metadata_text("instance/zone")
+    if zone:
+        zone_name = zone.rsplit("/", 1)[-1]
+        if "-" in zone_name:
+            return zone_name.rsplit("-", 1)[0]
+    return None
+
+
+def _require_runtime_region() -> None:
+    region = _runtime_region()
+    if region != REGION:
+        raise RuntimeError(
+            f"GrugMoE real-checkpoint e2e must run in {REGION}; detected {region!r}. "
+            "Run it on a v6e-4 TPU VM in europe-west4 or set MARIN_TPU_REGION for explicit validation."
+        )
+
+
+def _git_sha() -> str:
+    try:
+        return subprocess.check_output(["git", "rev-parse", "HEAD"], text=True).strip()
+    except (subprocess.CalledProcessError, OSError) as exc:
+        return f"unavailable:{exc!r}"
+
+
+def _direct_url(package: str) -> str:
+    try:
+        direct_url = md.distribution(package).read_text("direct_url.json")
+    except md.PackageNotFoundError:
+        return "not-installed"
+    return direct_url.strip() if direct_url else ""
+
+
+def _version(package: str) -> str:
+    try:
+        return md.version(package)
+    except md.PackageNotFoundError:
+        return "not-installed"
+
+
+def _runtime_snapshot(*, include_jax_devices: bool = False, include_grugmoe_spec: bool = False) -> dict[str, Any]:
+    snapshot: dict[str, Any] = {
+        "argv": sys.argv,
+        "cwd": os.getcwd(),
+        "marin_sha": os.environ.get("MARIN_GIT_SHA") or _git_sha(),
+        "region": _runtime_region(),
+        "tpu_type": TPU_TYPE,
+        "packages": {
+            package: {"version": _version(package), "direct_url": _direct_url(package)}
+            for package in ("marin-core", "vllm", "tpu-inference", "jax", "libtpu")
+        },
+    }
+    if include_grugmoe_spec:
+        try:
+            snapshot["grugmoe_spec"] = repr(importlib.util.find_spec("tpu_inference.models.jax.grugmoe"))
+        except ModuleNotFoundError as exc:
+            snapshot["grugmoe_spec"] = f"unavailable:{exc!r}"
+    if include_jax_devices:
+        import jax  # noqa: PLC0415
+
+        snapshot.update(
+            {
+                "jax_process_index": jax.process_index(),
+                "jax_process_count": jax.process_count(),
+                "jax_local_device_count": jax.local_device_count(),
+                "jax_devices": [str(device) for device in jax.devices()],
+            }
+        )
+    return snapshot
+
+
+def _real_checkpoint_model_config():
+    from experiments.grug.moe.model import GrugModelConfig  # noqa: PLC0415
+
+    return GrugModelConfig(
+        vocab_size=128_256,
+        hidden_dim=_REAL_CHECKPOINT_HIDDEN_DIM,
+        intermediate_dim=256,
+        shared_expert_intermediate_dim=512,
+        num_experts=256,
+        num_experts_per_token=4,
+        num_layers=6,
+        num_heads=4,
+        num_kv_heads=1,
+        max_seq_len=4096,
+        sliding_window=2048,
+        initializer_std=0.5 / (_REAL_CHECKPOINT_HIDDEN_DIM**0.5),
+        qk_mult=1.3,
+        router_z_loss_coef=0.0,
+    )
+
+
+# This adapter exists only because the pinned real checkpoint predates the
+# current fused GrugMoE expert layout. Keep it backend-local unless another
+# production export path needs to support legacy split-expert checkpoints.
+def _legacy_split_expert_inference_state_dict(model: Any, cfg: Any, prefix: str | None = None) -> dict[str, Any]:
+    from experiments.grug.moe.model import (  # noqa: PLC0415
+        _linear_inference_tensor,
+        _with_state_dict_prefix,
+        canonical_grugmoe_tensor_names,
+    )
+
+    tensors: dict[str, Any] = {
+        "model.embed_tokens.weight": model.token_embed,
+        "model.embed_norm.weight": model.embed_norm.weight,
+        "model.embed_gated_norm.down_proj.weight": _linear_inference_tensor(model.embed_gated_norm.w_down),
+        "model.embed_gated_norm.up_proj.weight": _linear_inference_tensor(model.embed_gated_norm.w_up),
+        "model.norm.weight": model.final_norm.weight,
+        "model.final_gated_norm.down_proj.weight": _linear_inference_tensor(model.final_gated_norm.w_down),
+        "model.final_gated_norm.up_proj.weight": _linear_inference_tensor(model.final_gated_norm.w_up),
+        "lm_head.weight": _linear_inference_tensor(model.output_proj),
+    }
+    for layer_index, block in enumerate(model.blocks):
+        layer_prefix = f"model.layers.{layer_index}"
+        tensors.update(
+            {
+                f"{layer_prefix}.input_layernorm.weight": block.rms_attn.weight,
+                f"{layer_prefix}.attn_gated_norm.down_proj.weight": _linear_inference_tensor(
+                    block.attn_gated_norm.w_down
+                ),
+                f"{layer_prefix}.attn_gated_norm.up_proj.weight": _linear_inference_tensor(block.attn_gated_norm.w_up),
+                f"{layer_prefix}.self_attn.q_proj.weight": _linear_inference_tensor(block.attn.w_q),
+                f"{layer_prefix}.self_attn.k_proj.weight": _linear_inference_tensor(block.attn.w_k),
+                f"{layer_prefix}.self_attn.v_proj.weight": _linear_inference_tensor(block.attn.w_v),
+                f"{layer_prefix}.self_attn.o_proj.weight": _linear_inference_tensor(block.attn.w_o),
+                f"{layer_prefix}.self_attn.attn_gate.weight": _linear_inference_tensor(block.attn.attn_gate),
+                f"{layer_prefix}.post_attention_layernorm.weight": block.rms_mlp.weight,
+                f"{layer_prefix}.mlp_gated_norm.down_proj.weight": _linear_inference_tensor(block.mlp_gated_norm.w_down),
+                f"{layer_prefix}.mlp_gated_norm.up_proj.weight": _linear_inference_tensor(block.mlp_gated_norm.w_up),
+                f"{layer_prefix}.mlp.router.weight": _linear_inference_tensor(block.mlp.router),
+                f"{layer_prefix}.mlp.router.bias": block.mlp.router_bias,
+                f"{layer_prefix}.mlp.experts.gate_proj.weight": _linear_inference_tensor(block.mlp.w_gate),
+                f"{layer_prefix}.mlp.experts.up_proj.weight": _linear_inference_tensor(block.mlp.w_up),
+                f"{layer_prefix}.mlp.experts.down_proj.weight": _linear_inference_tensor(block.mlp.w_down),
+            }
+        )
+        if block.shared is not None:
+            tensors.update(
+                {
+                    f"{layer_prefix}.shared_expert.gate_proj.weight": _linear_inference_tensor(block.shared.w_gate),
+                    f"{layer_prefix}.shared_expert.up_proj.weight": _linear_inference_tensor(block.shared.w_up),
+                    f"{layer_prefix}.shared_expert.down_proj.weight": _linear_inference_tensor(block.shared.w_down),
+                }
+            )
+    if set(tensors) != canonical_grugmoe_tensor_names(cfg):
+        raise ValueError("Legacy GrugMoE export tensor names do not match the canonical schema")
+    return {_with_state_dict_prefix(prefix, name): value for name, value in tensors.items()}
+
+
+def _load_legacy_split_expert_checkpoint(checkpoint_path: str, model_cfg: Any):
+    import equinox as eqx  # noqa: PLC0415
+    import jax  # noqa: PLC0415
+    import jax.numpy as jnp  # noqa: PLC0415
+    from haliax import Axis  # noqa: PLC0415
+    from levanter.checkpoint import latest_checkpoint_path, load_checkpoint  # noqa: PLC0415
+    from levanter.utils.jax_utils import is_inexact_arrayish  # noqa: PLC0415
+
+    class LegacySplitMoEMLP(eqx.Module):
+        router: jax.Array
+        router_bias: jax.Array
+        w_gate: jax.Array
+        w_up: jax.Array
+        w_down: jax.Array
+        cfg: Any = eqx.field(static=True)
+
+    def legacy_split_expert_template(cfg: Any, vocab: Axis, *, key: jax.Array):
+        model = cfg.build(vocab, key=key)
+        for layer_index in range(cfg.num_layers):
+            expert = model.blocks[layer_index].mlp.expert_mlp
+            gate, up = jnp.split(expert.w_gate_up, [cfg.intermediate_dim], axis=-1)
+            original_mlp = model.blocks[layer_index].mlp
+            split_mlp = LegacySplitMoEMLP(
+                router=original_mlp.router,
+                router_bias=original_mlp.router_bias,
+                w_gate=gate,
+                w_up=up,
+                w_down=expert.w_down,
+                cfg=original_mlp.cfg,
+            )
+            model = eqx.tree_at(lambda m, i=layer_index: m.blocks[i].mlp, model, split_mlp)
+        return model
+
+    vocab = Axis("vocab", model_cfg.vocab_size)
+    key = jax.random.PRNGKey(0)
+    model = eqx.filter_eval_shape(legacy_split_expert_template, model_cfg, vocab, key=key)
+    trainable, non_trainable = eqx.partition(model, is_inexact_arrayish)
+    latest_checkpoint = latest_checkpoint_path(checkpoint_path)
+    print("loading_grugmoe_real_checkpoint=" + str(latest_checkpoint), flush=True)
+    trainable = load_checkpoint(trainable, latest_checkpoint, subpath="params")
+    if trainable is None:
+        raise RuntimeError(f"Failed to load trainable params from {latest_checkpoint}")
+    return eqx.combine(trainable, non_trainable)
+
+
+def _export_backend(args: argparse.Namespace) -> None:
+    _require_constants_are_europe_west4(
+        E2EPaths(
+            output_dir=args.output_dir,
+            cache_dir=args.cache_dir,
+            artifact_dir=args.artifact_dir,
+            export_result_path=args.result_path,
+            vllm_result_path=_join_path(args.output_dir, "vllm-result.json"),
+            levanter_result_path=_join_path(args.output_dir, "levanter-result.json"),
+            summary_result_path=_join_path(args.output_dir, "result.json"),
+        )
+    )
+    _require_file("checkpoint metadata", _join_path(args.checkpoint_path, "metadata.json"))
+    _require_file("tokenizer.json", _join_path(args.tokenizer_path, "tokenizer.json"))
+    if _exists(args.artifact_dir):
+        _remove_tree(args.artifact_dir)
+
+    import equinox as eqx  # noqa: PLC0415
+    import haliax  # noqa: PLC0415
+    import jax  # noqa: PLC0415
+    from haliax import Axis  # noqa: PLC0415
+    from haliax.partitioning import set_mesh  # noqa: PLC0415
+    from levanter.compat.hf_checkpoints import load_tokenizer  # noqa: PLC0415
+    from levanter.grug.sharding import compact_grug_mesh  # noqa: PLC0415
+
+    class LegacySplitExpertExportModel(eqx.Module):
+        model: Any
+        config: Any = eqx.field(static=True)
+
+        @property
+        def Vocab(self) -> Axis:
+            return Axis("vocab", self.config.vocab_size)
+
+        def to_state_dict(self, prefix: str | None = None) -> dict[str, jax.Array]:
+            return _legacy_split_expert_inference_state_dict(self.model, self.config, prefix=prefix)
+
+    os.environ.setdefault("JAX_COMPILATION_CACHE_DIR", args.cache_dir)
+    model_cfg = _real_checkpoint_model_config()
+    mesh = compact_grug_mesh()
+    started = time.time()
+    with ExitStack() as stack:
+        stack.enter_context(set_mesh(mesh))
+        stack.enter_context(haliax.axis_mapping({}))
+        loaded_model = _load_legacy_split_expert_checkpoint(args.checkpoint_path, model_cfg)
+        tokenizer = load_tokenizer(args.tokenizer_path)
+        converter = model_cfg.hf_checkpoint_converter().replaced(tokenizer=tokenizer)
+        converter.save_pretrained(
+            LegacySplitExpertExportModel(loaded_model, model_cfg),
+            args.artifact_dir,
+            save_tokenizer=True,
+            max_shard_size=MAX_SHARD_SIZE,
+        )
+    _require_file("exported config.json", _join_path(args.artifact_dir, "config.json"))
+    _require_file("exported tokenizer.json", _join_path(args.artifact_dir, "tokenizer.json"))
+    result = {
+        "phase": "export",
+        "checkpoint_path": args.checkpoint_path,
+        "tokenizer_path": args.tokenizer_path,
+        "artifact_dir": args.artifact_dir,
+        "result_path": args.result_path,
+        "model_config": dataclasses.asdict(model_cfg),
+        "runtime": _runtime_snapshot(include_jax_devices=True, include_grugmoe_spec=True),
+        "elapsed_seconds": time.time() - started,
+    }
+    _write_json(args.result_path, result)
+    print("grugmoe_real_checkpoint_export_result=" + json.dumps(result, sort_keys=True), flush=True)
+
+
+def _local_filesystem_path(path: str) -> str:
+    parsed = urlparse(path)
+    if parsed.scheme == "file":
+        return parsed.path
+    if parsed.scheme == "":
+        return path
+    raise ValueError(f"{path!r} is not a local filesystem path")
+
+
+def _copy_tree_to_local(source_dir: str, local_dir: str) -> int:
+    _require_europe_west4_path("artifact_dir", source_dir)
+    fs, source_path = _fs_path(source_dir)
+    if not fs.exists(source_path):
+        raise FileNotFoundError(f"artifact_dir not found at {source_dir}")
+    if os.path.exists(local_dir):
+        shutil.rmtree(local_dir)
+    os.makedirs(local_dir, exist_ok=True)
+
+    copied = 0
+    for source_file in fs.find(source_path):
+        rel_path = posixpath.relpath(source_file, source_path)
+        local_file = os.path.join(local_dir, *rel_path.split("/"))
+        os.makedirs(os.path.dirname(local_file), exist_ok=True)
+        with fs.open(source_file, "rb") as src, open(local_file, "wb") as dst:
+            shutil.copyfileobj(src, dst)
+        copied += 1
+    if copied == 0:
+        raise FileNotFoundError(f"artifact_dir contained no files: {source_dir}")
+    return copied
+
+
+def _stage_artifact_for_vllm(artifact_dir: str) -> StagedArtifact:
+    _require_europe_west4_path("artifact_dir", artifact_dir)
+    parsed = urlparse(artifact_dir)
+    if parsed.scheme in {"", "file"}:
+        local_path = _local_filesystem_path(artifact_dir)
+        return StagedArtifact(
+            vllm_model_path=local_path,
+            staging={
+                "staged": False,
+                "source_artifact_dir": artifact_dir,
+                "vllm_model_path": local_path,
+                "copied_files": None,
+            },
+        )
+
+    local_root = tempfile.mkdtemp(prefix="grugmoe-real-checkpoint-vllm-artifact-")
+    local_path = os.path.join(local_root, "artifact")
+    copied_files = _copy_tree_to_local(artifact_dir, local_path)
+    _require_file("staged artifact config.json", _join_path(local_path, "config.json"))
+    _require_file("staged artifact tokenizer.json", _join_path(local_path, "tokenizer.json"))
+    return StagedArtifact(
+        vllm_model_path=local_path,
+        staging={
+            "staged": True,
+            "source_artifact_dir": artifact_dir,
+            "vllm_model_path": local_path,
+            "copied_files": copied_files,
+        },
+    )
+
+
+def _completion_payload(env: Any) -> dict[str, Any]:
+    import requests  # noqa: PLC0415
+
+    if env.model_id is None:
+        raise RuntimeError("Expected vLLM server to expose a model id.")
+    response = requests.post(
+        f"{env.server_url}/completions",
+        json={
+            "model": env.model_id,
+            "prompt": PROMPT,
+            "temperature": 0.0,
+            "max_tokens": MAX_NEW_TOKENS,
+        },
+        timeout=300,
+    )
+    print("vllm_completions_status_code=" + str(response.status_code), flush=True)
+    if not response.ok:
+        print("vllm_completions_response_text=" + response.text[:4000], flush=True)
+        print("vllm_server_logs_tail_begin", flush=True)
+        print(env.logs_tail(max_lines=400), flush=True)
+        print("vllm_server_logs_tail_end", flush=True)
+        response.raise_for_status()
+    return response.json()
+
+
+def _vllm_backend(args: argparse.Namespace) -> None:
+    _require_constants_are_europe_west4(
+        E2EPaths(
+            output_dir=args.output_dir,
+            cache_dir=args.cache_dir,
+            artifact_dir=args.artifact_dir,
+            export_result_path=_join_path(args.output_dir, "export-result.json"),
+            vllm_result_path=args.result_path,
+            levanter_result_path=_join_path(args.output_dir, "levanter-result.json"),
+            summary_result_path=_join_path(args.output_dir, "result.json"),
+        )
+    )
+    _require_file("artifact config.json", _join_path(args.artifact_dir, "config.json"))
+    os.environ["VLLM_TARGET_DEVICE"] = "tpu"
+    os.environ["MODEL_IMPL_TYPE"] = "auto"
+    os.environ["VLLM_ENABLE_V1_MULTIPROCESSING"] = "0"
+    os.environ.setdefault("JAX_COMPILATION_CACHE_DIR", args.cache_dir)
+    os.environ.setdefault("VLLM_XLA_CACHE_PATH", args.cache_dir)
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+
+    from marin.evaluation.evaluators.evaluator import ModelConfig  # noqa: PLC0415
+    from marin.inference.vllm_server import VllmEnvironment  # noqa: PLC0415
+
+    staged_artifact = _stage_artifact_for_vllm(args.artifact_dir)
+    model = ModelConfig(
+        name=SERVED_MODEL_NAME,
+        path=staged_artifact.vllm_model_path,
+        engine_kwargs={
+            "max_model_len": MAX_MODEL_LEN,
+            "max_num_batched_tokens": MAX_NUM_BATCHED_TOKENS,
+        },
+    )
+    extra_args = [
+        "--runner",
+        "generate",
+        "--tensor-parallel-size",
+        "1",
+        "--dtype",
+        VLLM_DTYPE,
+        "--served-model-name",
+        SERVED_MODEL_NAME,
+        "--enforce-eager",
+        "--max-num-seqs",
+        "1",
+    ]
+    started = time.time()
+    with VllmEnvironment(model=model, timeout_seconds=SERVER_TIMEOUT_SECONDS, extra_args=extra_args) as env:
+        print("vllm_server_initialized=True", flush=True)
+        print("vllm_server_url=" + env.server_url, flush=True)
+        print("vllm_model_path=" + staged_artifact.vllm_model_path, flush=True)
+        print("vllm_artifact_staging=" + json.dumps(staged_artifact.staging, sort_keys=True), flush=True)
+        print("vllm_server_log_dir=" + (env.vllm_server.log_dir if env.vllm_server else ""), flush=True)
+        payload = _completion_payload(env)
+        logs_tail = env.logs_tail(max_lines=120)
+        model_id = env.model_id
+    choices = payload.get("choices")
+    if not isinstance(choices, list) or len(choices) != 1:
+        raise AssertionError(f"expected exactly one completion choice, got {payload!r}")
+    completion = str(choices[0].get("text", ""))
+    result = {
+        "phase": "vllm",
+        "checkpoint_path": args.checkpoint_path,
+        "tokenizer_path": args.tokenizer_path,
+        "artifact_dir": args.artifact_dir,
+        "result_path": args.result_path,
+        "prompt": PROMPT,
+        "completion": completion,
+        "expected_continuation": EXPECTED_CONTINUATION,
+        "passed": completion == EXPECTED_CONTINUATION,
+        "served_model_name": SERVED_MODEL_NAME,
+        "vllm_model_id": model_id,
+        "vllm_model_path": staged_artifact.vllm_model_path,
+        "artifact_staging": staged_artifact.staging,
+        "vllm_engine_kwargs": model.engine_kwargs,
+        "vllm_args": extra_args,
+        "raw_response": payload,
+        "vllm_logs_tail": logs_tail,
+        "runtime": _runtime_snapshot(include_grugmoe_spec=True),
+        "elapsed_seconds": time.time() - started,
+    }
+    _write_json(args.result_path, result)
+    print("grugmoe_real_checkpoint_vllm_result=" + json.dumps(result, sort_keys=True), flush=True)
+    if completion != EXPECTED_CONTINUATION:
+        raise AssertionError(f"vLLM completion {completion!r} != expected {EXPECTED_CONTINUATION!r}")
+
+
+def _tokenizer_encode(tokenizer: Any, text: str, *, add_special_tokens: bool) -> list[int]:
+    ids = tokenizer.encode(text, add_special_tokens=add_special_tokens)
+    return [int(token_id) for token_id in ids]
+
+
+def _levanter_prompt_token_ids(tokenizer: Any) -> tuple[list[int], dict[str, Any]]:
+    token_ids = _tokenizer_encode(
+        tokenizer,
+        PROMPT,
+        add_special_tokens=LEVANTER_PROMPT_ADD_SPECIAL_TOKENS,
+    )
+    report = {
+        "add_special_tokens": LEVANTER_PROMPT_ADD_SPECIAL_TOKENS,
+        "expected_prompt_token_count": EXPECTED_PROMPT_TOKEN_COUNT,
+        "prompt_token_count": len(token_ids),
+        "prompt_token_ids": token_ids,
+        "matches_expected_count": len(token_ids) == EXPECTED_PROMPT_TOKEN_COUNT,
+    }
+    if len(token_ids) != EXPECTED_PROMPT_TOKEN_COUNT:
+        raise ValueError(
+            f"Levanter prompt token count {len(token_ids)} != expected {EXPECTED_PROMPT_TOKEN_COUNT}; "
+            f"tokenization={report!r}"
+        )
+    return token_ids, report
+
+
+def _decode_one(tokenizer: Any, token_id: int) -> str:
+    return tokenizer.decode([token_id], skip_special_tokens=False)
+
+
+def _mesh_batch_axis_size(mesh: Any) -> int:
+    size = 1
+    for axis_name in ("replica_dcn", "data", "expert"):
+        size *= int(mesh.shape.get(axis_name, 1))
+    return size
+
+
+def _selected_logprob(logits: Any, token_id: int) -> float:
+    import numpy as np  # noqa: PLC0415
+
+    logits_f64 = logits.astype(np.float64)
+    max_logit = np.max(logits_f64)
+    log_z = max_logit + np.log(np.exp(logits_f64 - max_logit).sum())
+    return float(logits_f64[token_id] - log_z)
+
+
+def _executable_model_from_legacy_split(model: Any) -> Any:
+    import equinox as eqx  # noqa: PLC0415
+    import jax.numpy as jnp  # noqa: PLC0415
+    from levanter.grug.grug_moe import MoEExpertMlp  # noqa: PLC0415
+    from levanter.utils.activation import ActivationFunctionEnum  # noqa: PLC0415
+
+    from experiments.grug.moe.model import MoEMLP  # noqa: PLC0415
+
+    def executable_mlp_from_legacy_split(split_mlp: Any) -> MoEMLP:
+        w_gate_up = jnp.concatenate([split_mlp.w_gate, split_mlp.w_up], axis=-1)
+        expert_mlp = MoEExpertMlp(
+            w_gate_up=w_gate_up,
+            w_down=split_mlp.w_down,
+            implementation=split_mlp.cfg.moe_implementation,
+            activation=ActivationFunctionEnum.silu,
+            capacity_factor=1.0,
+        )
+        return MoEMLP(
+            router=split_mlp.router,
+            router_bias=split_mlp.router_bias,
+            expert_mlp=expert_mlp,
+            cfg=split_mlp.cfg,
+        )
+
+    for layer_index, block in enumerate(model.blocks):
+        if hasattr(block.mlp, "expert_mlp"):
+            continue
+        executable_mlp = executable_mlp_from_legacy_split(block.mlp)
+        model = eqx.tree_at(lambda m, i=layer_index: m.blocks[i].mlp, model, executable_mlp)
+    return model
+
+
+def _greedy_decode(
+    model: Any,
+    tokenizer: Any,
+    prompt_ids: list[int],
+    *,
+    max_new_tokens: int,
+    batch_size: int,
+    decode_seq_len: int,
+    pad_token_id: int,
+) -> dict[str, Any]:
+    import jax  # noqa: PLC0415
+    import jax.numpy as jnp  # noqa: PLC0415
+    import numpy as np  # noqa: PLC0415
+
+    if len(prompt_ids) + max_new_tokens > decode_seq_len:
+        raise ValueError(
+            f"prompt length {len(prompt_ids)} + max_new_tokens {max_new_tokens} exceeds decode_seq_len {decode_seq_len}"
+        )
+
+    def position_logits_batch(the_model: Any, token_ids: Any, position: Any) -> Any:
+        return the_model.logits(token_ids)[:, position, :].astype(jnp.float32)
+
+    token_ids_array = np.full((batch_size, decode_seq_len), pad_token_id, dtype=np.int32)
+    token_ids_array[:, : len(prompt_ids)] = np.asarray(prompt_ids, dtype=np.int32)
+    generated_ids: list[int] = []
+    generated_token_texts: list[str] = []
+    selected_token_logprobs: list[float] = []
+    steps: list[dict[str, Any]] = []
+    position_logits = jax.jit(position_logits_batch)
+    started = time.time()
+
+    for step_index in range(max_new_tokens):
+        position = jnp.asarray(len(prompt_ids) + step_index - 1, dtype=jnp.int32)
+        step_logits_batch = position_logits(model, jnp.asarray(token_ids_array, dtype=jnp.int32), position)
+        step_logits = np.asarray(jax.device_get(step_logits_batch))[0]
+        selected_token_id = int(np.argmax(step_logits, axis=-1))
+        selected_text = _decode_one(tokenizer, selected_token_id)
+        selected_logprob = _selected_logprob(step_logits, selected_token_id)
+        generated_ids.append(selected_token_id)
+        generated_token_texts.append(selected_text)
+        selected_token_logprobs.append(selected_logprob)
+        steps.append(
+            {
+                "generated_token_index": step_index,
+                "token_id": selected_token_id,
+                "token_text": selected_text,
+                "selected_token_logprob": selected_logprob,
+            }
+        )
+        token_ids_array[:, len(prompt_ids) + step_index] = selected_token_id
+
+    return {
+        "prompt_token_ids": [int(token_id) for token_id in prompt_ids],
+        "prompt_token_count": len(prompt_ids),
+        "decode_batch_size": batch_size,
+        "decode_seq_len": decode_seq_len,
+        "pad_token_id": pad_token_id,
+        "generated_token_ids": generated_ids,
+        "generated_token_texts": generated_token_texts,
+        "completion": tokenizer.decode(generated_ids, skip_special_tokens=False),
+        "selected_token_logprobs": selected_token_logprobs,
+        "steps": steps,
+        "elapsed_seconds": time.time() - started,
+    }
+
+
+def _levanter_backend(args: argparse.Namespace) -> None:
+    _require_constants_are_europe_west4(
+        E2EPaths(
+            output_dir=args.output_dir,
+            cache_dir=args.cache_dir,
+            artifact_dir=args.artifact_dir,
+            export_result_path=_join_path(args.output_dir, "export-result.json"),
+            vllm_result_path=_join_path(args.output_dir, "vllm-result.json"),
+            levanter_result_path=args.result_path,
+            summary_result_path=_join_path(args.output_dir, "result.json"),
+        )
+    )
+    _require_file("checkpoint metadata", _join_path(args.checkpoint_path, "metadata.json"))
+    _require_file("tokenizer.json", _join_path(args.tokenizer_path, "tokenizer.json"))
+    os.environ.setdefault("JAX_COMPILATION_CACHE_DIR", args.cache_dir)
+    os.environ.setdefault("PYTHONUNBUFFERED", "1")
+
+    import haliax  # noqa: PLC0415
+    from haliax.partitioning import set_mesh  # noqa: PLC0415
+    from levanter.compat.hf_checkpoints import load_tokenizer  # noqa: PLC0415
+    from levanter.grug.sharding import compact_grug_mesh  # noqa: PLC0415
+
+    tokenizer = load_tokenizer(args.tokenizer_path)
+    prompt_ids, tokenization = _levanter_prompt_token_ids(tokenizer)
+    model_cfg = _real_checkpoint_model_config()
+    mesh = compact_grug_mesh()
+    decode_batch_size = _mesh_batch_axis_size(mesh)
+    pad_token_id = int(getattr(tokenizer, "pad_token_id", None) or getattr(tokenizer, "eos_token_id", None) or 0)
+    started = time.time()
+    with ExitStack() as stack:
+        stack.enter_context(set_mesh(mesh))
+        stack.enter_context(haliax.axis_mapping({}))
+        loaded_model = _load_legacy_split_expert_checkpoint(args.checkpoint_path, model_cfg)
+        model = _executable_model_from_legacy_split(loaded_model)
+        decode_result = _greedy_decode(
+            model,
+            tokenizer,
+            prompt_ids,
+            max_new_tokens=MAX_NEW_TOKENS,
+            batch_size=decode_batch_size,
+            decode_seq_len=DECODE_SEQ_LEN,
+            pad_token_id=pad_token_id,
+        )
+    completion = str(decode_result["completion"])
+    result = {
+        "phase": "levanter",
+        "checkpoint_path": args.checkpoint_path,
+        "tokenizer_path": args.tokenizer_path,
+        "result_path": args.result_path,
+        "prompt": PROMPT,
+        "completion": completion,
+        "expected_continuation": EXPECTED_CONTINUATION,
+        "passed": completion == EXPECTED_CONTINUATION,
+        "tokenization": tokenization,
+        "decode_result": decode_result,
+        "runtime": _runtime_snapshot(include_jax_devices=True, include_grugmoe_spec=True),
+        "elapsed_seconds": time.time() - started,
+    }
+    _write_json(args.result_path, result)
+    print("grugmoe_real_checkpoint_levanter_result=" + json.dumps(result, sort_keys=True), flush=True)
+    if completion != EXPECTED_CONTINUATION:
+        raise AssertionError(f"Levanter/JAX completion {completion!r} != expected {EXPECTED_CONTINUATION!r}")
+
+
+def _parse_backend_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="Internal GrugMoE real-checkpoint e2e backend")
+    parser.add_argument("--backend", choices=("export", "vllm", "levanter"), required=True)
+    parser.add_argument("--checkpoint-path", required=True)
+    parser.add_argument("--tokenizer-path", required=True)
+    parser.add_argument("--output-dir", required=True)
+    parser.add_argument("--artifact-dir", required=True)
+    parser.add_argument("--cache-dir", required=True)
+    parser.add_argument("--result-path", required=True)
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_backend_args(sys.argv[1:] if argv is None else argv)
+    _require_runtime_region()
+    match args.backend:
+        case "export":
+            _export_backend(args)
+        case "vllm":
+            _vllm_backend(args)
+        case "levanter":
+            _levanter_backend(args)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main(sys.argv[1:]))

--- a/tests/vllm/grugmoe_real_checkpoint_backend.py
+++ b/tests/vllm/grugmoe_real_checkpoint_backend.py
@@ -274,7 +274,6 @@ def _legacy_split_expert_inference_state_dict(model: Any, cfg: Any, prefix: str 
     from experiments.grug.moe.model import (  # noqa: PLC0415
         _linear_inference_tensor,
         _with_state_dict_prefix,
-        canonical_grugmoe_tensor_names,
     )
 
     tensors: dict[str, Any] = {
@@ -319,8 +318,6 @@ def _legacy_split_expert_inference_state_dict(model: Any, cfg: Any, prefix: str 
                     f"{layer_prefix}.shared_expert.down_proj.weight": _linear_inference_tensor(block.shared.w_down),
                 }
             )
-    if set(tensors) != canonical_grugmoe_tensor_names(cfg):
-        raise ValueError("Legacy GrugMoE export tensor names do not match the canonical schema")
     return {_with_state_dict_prefix(prefix, name): value for name, value in tensors.items()}
 
 

--- a/tests/vllm/test_grugmoe_real_checkpoint_e2e.py
+++ b/tests/vllm/test_grugmoe_real_checkpoint_e2e.py
@@ -1,0 +1,257 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Opt-in real-checkpoint GrugMoE e2e for TPU vLLM and Levanter/JAX.
+
+Lower-level diagnostics for failures are linked from the PR body; this test keeps
+Marin coverage focused on the trained checkpoint correctness path.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import json
+import os
+import shutil
+import subprocess
+import sys
+import time
+import uuid
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from tests.vllm import grugmoe_real_checkpoint_backend as backend
+
+TPU_LOCK_PATH = "/tmp/marin-tpu-e2e.lock"
+BACKEND_MODULE = "tests.vllm.grugmoe_real_checkpoint_backend"
+
+
+def _require_no_active_xdist(request: pytest.FixtureRequest) -> None:
+    xdist_env = {key: value for key, value in os.environ.items() if key.startswith("PYTEST_XDIST_WORKER")}
+    workerinput = getattr(request.config, "workerinput", None)
+    numprocesses = getattr(request.config.option, "numprocesses", None)
+    if xdist_env or workerinput is not None or numprocesses not in (None, 0, "0"):
+        raise RuntimeError(
+            "GrugMoE real-checkpoint e2e cannot run under active pytest-xdist parallelism. "
+            f"Detected env={xdist_env!r}, workerinput={workerinput is not None}, numprocesses={numprocesses!r}. "
+            "Run this test with -n 0 or without xdist."
+        )
+
+
+def _vfio_lsof_diagnostic() -> dict[str, Any]:
+    vfio_dir = Path("/dev/vfio")
+    diagnostic: dict[str, Any] = {"vfio_dir": str(vfio_dir), "checked": False, "holders": []}
+    if not vfio_dir.exists():
+        diagnostic["reason"] = "missing /dev/vfio"
+        return diagnostic
+
+    device_paths = [str(path) for path in vfio_dir.iterdir()]
+    if not device_paths:
+        diagnostic["reason"] = "empty /dev/vfio"
+        return diagnostic
+
+    lsof = shutil.which("lsof")
+    if lsof is None:
+        diagnostic["reason"] = "lsof not installed"
+        return diagnostic
+
+    result = subprocess.run([lsof, *device_paths], text=True, capture_output=True, check=False)
+    diagnostic.update(
+        {
+            "checked": True,
+            "returncode": result.returncode,
+            "stdout": result.stdout,
+            "stderr": result.stderr,
+        }
+    )
+    rows = [line for line in result.stdout.splitlines()[1:] if line.strip()]
+    diagnostic["holders"] = rows
+    if rows:
+        raise RuntimeError(
+            "Detected existing /dev/vfio users before a GrugMoE TPU-owning phase. "
+            f"Release stale/manual TPU processes first. lsof rows: {rows[:20]!r}"
+        )
+    return diagnostic
+
+
+@pytest.fixture(scope="module", autouse=True)
+def no_active_xdist(request: pytest.FixtureRequest) -> None:
+    _require_no_active_xdist(request)
+
+
+@pytest.fixture(scope="module")
+def tpu_lock(no_active_xdist: None):
+    del no_active_xdist
+    with open(TPU_LOCK_PATH, "w") as lock_file:
+        try:
+            try:
+                fcntl.flock(lock_file, fcntl.LOCK_EX | fcntl.LOCK_NB)
+            except BlockingIOError as exc:
+                raise RuntimeError(f"Another Marin TPU e2e appears to hold {TPU_LOCK_PATH}") from exc
+            lock_file.seek(0)
+            lock_file.truncate()
+            lock_file.write(json.dumps({"pid": os.getpid(), "test": __name__, "started": time.time()}) + "\n")
+            lock_file.flush()
+            yield
+        finally:
+            fcntl.flock(lock_file, fcntl.LOCK_UN)
+
+
+@pytest.fixture(scope="module")
+def e2e_paths(tpu_lock: None) -> backend.E2EPaths:
+    del tpu_lock
+    backend._require_runtime_region()
+    stamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    run_id = f"{stamp}-{uuid.uuid4().hex[:8]}"
+    output_dir = backend._join_path(backend.OUTPUT_ROOT, run_id)
+    paths = backend.E2EPaths(
+        output_dir=output_dir,
+        cache_dir=backend._join_path(backend.CACHE_ROOT, run_id),
+        artifact_dir=backend._join_path(output_dir, "artifact"),
+        export_result_path=backend._join_path(output_dir, "export-result.json"),
+        vllm_result_path=backend._join_path(output_dir, "vllm-result.json"),
+        levanter_result_path=backend._join_path(output_dir, "levanter-result.json"),
+        summary_result_path=backend._join_path(output_dir, "result.json"),
+    )
+    backend._require_constants_are_europe_west4(paths)
+    return paths
+
+
+def _run_backend(phase: str, paths: backend.E2EPaths, result_path: str) -> dict[str, Any]:
+    backend._require_europe_west4_path("result_path", result_path)
+    command = [
+        sys.executable,
+        "-m",
+        BACKEND_MODULE,
+        "--backend",
+        phase,
+        "--checkpoint-path",
+        backend.CHECKPOINT_PATH,
+        "--tokenizer-path",
+        backend.TOKENIZER_PATH,
+        "--output-dir",
+        paths.output_dir,
+        "--artifact-dir",
+        paths.artifact_dir,
+        "--cache-dir",
+        paths.cache_dir,
+        "--result-path",
+        result_path,
+    ]
+    env = dict(os.environ)
+    env.setdefault("PYTHONUNBUFFERED", "1")
+    env.setdefault("MARIN_GIT_SHA", backend._git_sha())
+    print("grugmoe_real_checkpoint_e2e_command=" + json.dumps(command), flush=True)
+    completed = subprocess.run(command, check=False, env=env)
+    if completed.returncode == 0:
+        return backend._read_json(result_path)
+    if backend._exists(result_path):
+        result = backend._read_json(result_path)
+        result["backend_returncode"] = completed.returncode
+        return result
+    completed.check_returncode()
+    raise AssertionError("unreachable")
+
+
+@pytest.fixture(scope="module")
+def export_result(e2e_paths: backend.E2EPaths) -> dict[str, Any]:
+    diagnostic = _vfio_lsof_diagnostic()
+    print("grugmoe_real_checkpoint_export_tpu_preflight=" + json.dumps(diagnostic, sort_keys=True), flush=True)
+    return _run_backend("export", e2e_paths, e2e_paths.export_result_path)
+
+
+@pytest.fixture(scope="module")
+def vllm_result(e2e_paths: backend.E2EPaths, export_result: dict[str, Any]) -> dict[str, Any]:
+    assert export_result["artifact_dir"] == e2e_paths.artifact_dir
+    diagnostic = _vfio_lsof_diagnostic()
+    print("grugmoe_real_checkpoint_vllm_tpu_preflight=" + json.dumps(diagnostic, sort_keys=True), flush=True)
+    return _run_backend("vllm", e2e_paths, e2e_paths.vllm_result_path)
+
+
+@pytest.fixture(scope="module")
+def levanter_result(e2e_paths: backend.E2EPaths) -> dict[str, Any]:
+    diagnostic = _vfio_lsof_diagnostic()
+    print("grugmoe_real_checkpoint_levanter_tpu_preflight=" + json.dumps(diagnostic, sort_keys=True), flush=True)
+    return _run_backend("levanter", e2e_paths, e2e_paths.levanter_result_path)
+
+
+def _write_summary_update(
+    e2e_paths: backend.E2EPaths,
+    *,
+    export_result: dict[str, Any] | None = None,
+    backend_result: dict[str, Any] | None = None,
+) -> None:
+    if backend._exists(e2e_paths.summary_result_path):
+        summary = backend._read_json(e2e_paths.summary_result_path)
+    else:
+        summary = {
+            "checkpoint_path": backend.CHECKPOINT_PATH,
+            "tokenizer_path": backend.TOKENIZER_PATH,
+            "region": backend.REGION,
+            "tpu_type": backend.TPU_TYPE,
+            "prompt": backend.PROMPT,
+            "expected_continuation": backend.EXPECTED_CONTINUATION,
+            "result_paths": {
+                "export": e2e_paths.export_result_path,
+                "vllm": e2e_paths.vllm_result_path,
+                "levanter": e2e_paths.levanter_result_path,
+                "summary": e2e_paths.summary_result_path,
+            },
+            "runtime": backend._runtime_snapshot(include_grugmoe_spec=True),
+            "backend_results": {},
+            "caveat": (
+                "This e2e validates real trained-checkpoint serving correctness through vLLM and Levanter/JAX. "
+                "It does not validate TP, broad context windows, logprob parity, router replay, or performance."
+            ),
+        }
+
+    if export_result is not None:
+        summary["export_result"] = export_result
+    if backend_result is not None:
+        phase = str(backend_result["phase"])
+        summary.setdefault("backend_results", {})[phase] = backend_result
+        summary[f"actual_{phase}_output"] = backend_result.get("completion")
+
+    backend_results = summary.get("backend_results", {})
+    summary["completed_backend_phases"] = sorted(backend_results)
+    summary["passed"] = all(backend_results.get(phase, {}).get("passed") is True for phase in ("vllm", "levanter"))
+    backend._write_json(e2e_paths.summary_result_path, summary)
+    print("grugmoe_real_checkpoint_e2e_result=" + json.dumps(summary, sort_keys=True), flush=True)
+
+
+def test_grugmoe_real_checkpoint_e2e_static_preconditions() -> None:
+    backend._require_constants_are_europe_west4()
+    assert backend.REGION == "europe-west4"
+    assert backend.TPU_TYPE == "v6e-4"
+    assert backend.CHECKPOINT_PATH.startswith(backend.EUROPE_WEST4_GCS_PREFIX)
+    assert backend.TOKENIZER_PATH.startswith(backend.EUROPE_WEST4_GCS_PREFIX)
+
+
+@pytest.mark.tpu_ci
+@pytest.mark.slow
+@pytest.mark.data_integration
+def test_grugmoe_real_checkpoint_vllm_output(
+    e2e_paths: backend.E2EPaths,
+    export_result: dict[str, Any],
+    vllm_result: dict[str, Any],
+) -> None:
+    _write_summary_update(e2e_paths, export_result=export_result, backend_result=vllm_result)
+    assert vllm_result["phase"] == "vllm"
+    assert vllm_result["completion"] == backend.EXPECTED_CONTINUATION
+    assert vllm_result["passed"] is True
+
+
+@pytest.mark.tpu_ci
+@pytest.mark.slow
+@pytest.mark.data_integration
+def test_grugmoe_real_checkpoint_levanter_output(
+    e2e_paths: backend.E2EPaths,
+    levanter_result: dict[str, Any],
+) -> None:
+    _write_summary_update(e2e_paths, backend_result=levanter_result)
+    assert levanter_result["phase"] == "levanter"
+    assert levanter_result["completion"] == backend.EXPECTED_CONTINUATION
+    assert levanter_result["passed"] is True

--- a/tests/vllm/test_grugmoe_real_checkpoint_e2e.py
+++ b/tests/vllm/test_grugmoe_real_checkpoint_e2e.py
@@ -77,7 +77,7 @@ def _vfio_lsof_diagnostic() -> dict[str, Any]:
     return diagnostic
 
 
-@pytest.fixture(scope="module", autouse=True)
+@pytest.fixture(scope="module")
 def no_active_xdist(request: pytest.FixtureRequest) -> None:
     _require_no_active_xdist(request)
 

--- a/uv.lock
+++ b/uv.lock
@@ -4632,12 +4632,12 @@ requires-dist = [
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'cpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "cpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'tpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "tpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'vllm'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "vllm" } },
-    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=4c38590e29d33451f2b4375a78ad8f70cacd7b98" },
+    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=217fc45b078b1030bfcb5b704ed1169b448a5808" },
     { name = "tqdm" },
     { name = "tqdm-loggable" },
     { name = "triton", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=3.6.0,<3.7" },
     { name = "verifiers", marker = "extra == 'rl'", specifier = "==0.1.5" },
-    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=04321f0f01b8e60d577a85a1b1af688e4433e7e0" },
+    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=7557e69ddb2e28b287d0729b4aee4d7de8de18f9" },
     { name = "wandb", specifier = ">0.24.0" },
 ]
 provides-extras = ["gpu", "tpu", "cpu", "rl", "eval", "evalchemy", "vizier", "vllm", "harbor", "dedup", "datakit", "math"]
@@ -10679,10 +10679,9 @@ wheels = [
 [[package]]
 name = "tpu-inference"
 version = "0.22.1"
-source = { git = "https://github.com/marin-community/tpu-inference.git?rev=4c38590e29d33451f2b4375a78ad8f70cacd7b98#4c38590e29d33451f2b4375a78ad8f70cacd7b98" }
+source = { git = "https://github.com/marin-community/tpu-inference.git?rev=217fc45b078b1030bfcb5b704ed1169b448a5808#217fc45b078b1030bfcb5b704ed1169b448a5808" }
 dependencies = [
     { name = "absl-py" },
-    { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-10-marin-core-vllm' or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-gpu') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'group-10-marin-fray-fray-tpu-test') or (extra == 'extra-10-marin-core-tpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'group-10-marin-fray-fray-tpu-test')" },
     { name = "flax" },
     { name = "gcsfs" },
     { name = "google-cloud-storage" },
@@ -11109,8 +11108,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.20.1rc1.dev992+g04321f0f0.tpu"
-source = { git = "https://github.com/marin-community/vllm.git?rev=04321f0f01b8e60d577a85a1b1af688e4433e7e0#04321f0f01b8e60d577a85a1b1af688e4433e7e0" }
+version = "0.20.1rc1.dev0+g7557e69dd.tpu"
+source = { git = "https://github.com/marin-community/vllm.git?rev=7557e69ddb2e28b287d0729b4aee4d7de8de18f9#7557e69ddb2e28b287d0729b4aee4d7de8de18f9" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },


### PR DESCRIPTION
# Add GrugMoE support for TPU vLLM serving

## Summary

Adds correctness-first GrugMoE support for Marin's TPU vLLM path:

- exports a Levanter GrugMoE checkpoint into a vLLM/tpu-inference-compatible artifact;
- pins Marin-owned `vllm` and `tpu-inference` fork commits with GrugMoE TPU support;
- adds an opt-in real-checkpoint TPU e2e under `tests/vllm/` that validates both vLLM serving and the Levanter/JAX reference path.

## Fork Review Links

- [vLLM pinned diff: `e6e3b6b...7557e69`](https://github.com/marin-community/vllm/compare/e6e3b6b10c1d44936306be3a67c709d763f89e48...7557e69ddb2e28b287d0729b4aee4d7de8de18f9)
- [tpu-inference pinned diff: `c0c901b...217fc45`](https://github.com/marin-community/tpu-inference/compare/c0c901b2b5f3617f5250881c3458d58f4b20b10d...217fc45b078b1030bfcb5b704ed1169b448a5808)

## Validation

<details>
<summary>Fresh real-hardware e2e and local checks</summary>

Fresh real-hardware e2e:

- TPU/region: `v6e-4`, `europe-west4`
- Job: `/romain/grugmoe-real-checkpoint-e2e-c3ed9f-r3`
- Dashboard: https://iris.oa.dev/#/job/%2Fromain%2Fgrugmoe-real-checkpoint-e2e-c3ed9f-r3
- Result root: `gs://marin-eu-west4/tmp/ttl=14d/grugmoe-real-checkpoint-e2e/20260625T222315Z-0112016f`
- Summary: `gs://marin-eu-west4/tmp/ttl=14d/grugmoe-real-checkpoint-e2e/20260625T222315Z-0112016f/result.json`
- Pytest: `2 passed, 1 deselected in 215.03s`
- vLLM output: `" The Ultimate. The Ultimate. The Ultimate"`
- Levanter/JAX output: `" The Ultimate. The Ultimate. The Ultimate"`

Recorded SHAs:

- Current Marin branch: `69f2117cfc626fba17b80456a12da3c027f9bd13`
- TPU-validated history-cleaned Marin head: `a9c0adcce8de23897ab3bcd1d2b8512763f59273`
- TPU-validated Marin tree: `c3ed9f7009888dffb6d68affb11eb294a26a9639`
- vLLM: `7557e69ddb2e28b287d0729b4aee4d7de8de18f9`
- tpu-inference: `217fc45b078b1030bfcb5b704ed1169b448a5808`

The draft PR was opened at `a9c0adc...`, which was history-cleaned after the TPU run and is tree-identical
to the TPU-validated `c3ed9f...` head. The follow-up CI fix at `69f2117...` only scopes the pytest-xdist
guard to TPU-owning e2e phases so normal xdist Marin unit CI can run the cheap static precondition; it does
not change GrugMoE model/export/backend/vLLM/Levanter execution code.

Local checks:

```bash
uv run --locked --package marin-core python -m pytest tests/vllm/test_grugmoe_real_checkpoint_e2e.py -q
uv run --locked --package marin-core python -m pytest lib/levanter/tests/test_export_to_hf.py -q
./infra/pre-commit.py --changed-files --skip pyrefly
```

</details>

## Caveats

This validates one real checkpoint, one prompt, short decode, single `v6e-4` serving path. It does not validate throughput/latency, tensor/pipeline parallel serving, broad context windows, router replay, or vLLM routed-expert/logprob exposure through `/v1/completions`.

The expected continuation is a deterministic smoke assertion for this checkpoint and prompt, not an instruction-following quality claim.

## Review Aids

- [PR companion](https://yonromai.github.io/pr-companions/scratch/marin/20260619/grugmoe-tpu-vllm-agent-review/index.html)
- [Diagnostic gist](https://gist.github.com/yonromai/f3805b5f1c0234af53b66465f61fcdb0)
