### PR TITLE
[iris] Match registry cache compression to image output (zstd)

### DIFF
--- a/.github/workflows/ops-docker-images.yaml
+++ b/.github/workflows/ops-docker-images.yaml
@@ -62,7 +62,7 @@ jobs:
           docker buildx build --file lib/iris/Dockerfile \
             --target ${{ matrix.target }} \
             --cache-from type=registry,ref=ghcr.io/marin-community/iris-cache:${{ matrix.target }} \
-            --cache-to type=registry,ref=ghcr.io/marin-community/iris-cache:${{ matrix.target }},mode=max \
+            --cache-to type=registry,ref=ghcr.io/marin-community/iris-cache:${{ matrix.target }},mode=max,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true \
             --output type=image,compression=zstd,compression-level=3,push=true \
             --provenance=false \
             --build-arg IRIS_GIT_HASH=${{ steps.set-tags.outputs.HASH_TAG }} \
@@ -101,7 +101,7 @@ jobs:
         run: |
           docker buildx build --file lib/finelog/deploy/Dockerfile \
             --cache-from type=registry,ref=ghcr.io/marin-community/finelog-cache:latest \
-            --cache-to type=registry,ref=ghcr.io/marin-community/finelog-cache:latest,mode=max \
+            --cache-to type=registry,ref=ghcr.io/marin-community/finelog-cache:latest,mode=max,compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true \
             --output type=image,compression=zstd,compression-level=3,push=true \
             --provenance=false \
             --tag ghcr.io/marin-community/finelog:latest \

--- a/lib/iris/src/iris/cli/build.py
+++ b/lib/iris/src/iris/cli/build.py
@@ -231,7 +231,21 @@ def build_image(
     cmd.extend(["--cache-from", f"type=registry,ref={cache_ref}"])
 
     if push:
-        cmd.extend(["--cache-to", f"type=registry,ref={cache_ref},mode=max"])
+        # Match the cache compression to the image output (zstd level 3). The
+        # cache exporter defaults to gzip, so a mismatched setting makes BuildKit
+        # decompress every zstd image layer and recompress it to gzip for the
+        # cache — the dominant cost of "exporting cache to registry". Aligned
+        # compression yields byte-identical blob digests, so GHCR cross-repo
+        # blob-mounts the layers already pushed for the image instead of
+        # re-uploading them. oci-mediatypes/image-manifest store the cache as a
+        # single OCI image (required for zstd cache on registries).
+        cmd.extend(
+            [
+                "--cache-to",
+                f"type=registry,ref={cache_ref},mode=max,"
+                "compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true",
+            ]
+        )
         cmd.extend(["--output", "type=image,compression=zstd,compression-level=3,push=true"])
         cmd.append("--provenance=false")
     else:

--- a/lib/iris/src/iris/cli/build.py
+++ b/lib/iris/src/iris/cli/build.py
@@ -10,6 +10,12 @@ import click
 
 GHCR_DEFAULT_ORG = "marin-community"
 
+# Compression for pushed images and their registry cache. The two must match: a
+# mismatch forces BuildKit to recompress every layer when exporting the cache
+# (the dominant cost of "exporting cache to registry"), whereas aligned settings
+# let it reuse the already-built blobs and let GHCR cross-repo blob-mount them.
+PUSH_COMPRESSION = "compression=zstd,compression-level=3"
+
 
 def _is_verbose(ctx: click.Context) -> bool:
     """Walk up the Click context chain to find the top-level --verbose flag."""
@@ -231,22 +237,16 @@ def build_image(
     cmd.extend(["--cache-from", f"type=registry,ref={cache_ref}"])
 
     if push:
-        # Match the cache compression to the image output (zstd level 3). The
-        # cache exporter defaults to gzip, so a mismatched setting makes BuildKit
-        # decompress every zstd image layer and recompress it to gzip for the
-        # cache — the dominant cost of "exporting cache to registry". Aligned
-        # compression yields byte-identical blob digests, so GHCR cross-repo
-        # blob-mounts the layers already pushed for the image instead of
-        # re-uploading them. oci-mediatypes/image-manifest store the cache as a
-        # single OCI image (required for zstd cache on registries).
+        # oci-mediatypes/image-manifest store the cache as a single OCI image,
+        # required for non-gzip (zstd) cache on registries. See PUSH_COMPRESSION
+        # for why the cache and image compression are kept in lockstep.
         cmd.extend(
             [
                 "--cache-to",
-                f"type=registry,ref={cache_ref},mode=max,"
-                "compression=zstd,compression-level=3,oci-mediatypes=true,image-manifest=true",
+                f"type=registry,ref={cache_ref},mode=max,{PUSH_COMPRESSION},oci-mediatypes=true,image-manifest=true",
             ]
         )
-        cmd.extend(["--output", "type=image,compression=zstd,compression-level=3,push=true"])
+        cmd.extend(["--output", f"type=image,{PUSH_COMPRESSION},push=true"])
         cmd.append("--provenance=false")
     else:
         cmd.extend(["--output", f"type=docker,compression=zstd,compression-level=1,name={tag}"])


### PR DESCRIPTION
The Iris image builds push layers with zstd compression but the `--cache-to`
exporter specified no compression, so it defaulted to gzip. On every push,
BuildKit decompressed each zstd image layer and recompressed it to gzip just for
the registry cache — this is the dominant cost behind the slow "exporting cache
to registry" phase (the ~16s per-layer writes and ~20s total visible in build
logs), and it re-uploads the big dependency/venv layers a second time.

This aligns the cache exporter compression with the image output (zstd level 3,
hoisted to a shared `PUSH_COMPRESSION` constant so the two can't drift) and
stores the cache as an OCI image manifest (`oci-mediatypes`/`image-manifest`,
required for non-gzip cache on registries). BuildKit can now reuse the
already-built compressed blobs for the cache instead of recompressing, and GHCR
can cross-repo blob-mount the layers already pushed for the image rather than
re-uploading them.

`mode=max` is unchanged, so intermediate-stage caching (dashboard npm build,
docker-cli, the uv-sync layers) and rebuild times are fully preserved — this only
touches how the cache is encoded on export.

On the "82 layers" itself: that count is the `mode=max` cache graph across both
build platforms (`linux/amd64,linux/arm64`) plus every intermediate stage and
base image, not the final image (~25 content layers per platform). The per-step
`COPY ... DONE 0.1s` lines are cache hits and not a real cost; the layer count is
not the bottleneck — the gzip↔zstd recompression was. The 8 `COPY lib/*/
pyproject.toml` layers are required for uv workspace discovery under `--frozen`
and are left as-is.

Applies the same fix to the scheduled `ops-docker-images` workflow (iris
controller/worker/task and the finelog image).

Part of #315