### PR TITLE
[iris] Let a blocked gang preempt CPU-only squatters on its hosts

### DIFF
--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -54,6 +54,7 @@ from iris.cluster.controller.scheduling.scheduler import (
     SchedulingContext,
     WorkerCapacity,
     WorkerSnapshot,
+    ranked_groups_for_req,
     worker_snapshot_from_row,
 )
 from iris.cluster.controller.task_state import job_scheduling_deadline, task_row_can_be_scheduled
@@ -62,6 +63,7 @@ from iris.cluster.types import (
     JobName,
     PendingTask,
     UserBudgetDefaults,
+    WorkerId,
     is_job_finished,
 )
 from iris.rpc import job_pb2
@@ -457,6 +459,118 @@ def _preempt_coscheduled(
     return []
 
 
+def _solo_victims_freeing_host(
+    candidate: PreemptionCandidate,
+    cap: WorkerCapacity,
+    host_victims: list[RunningTaskInfo],
+) -> list[RunningTaskInfo] | None:
+    """Lowest-priority solo victims whose combined eviction lets the gang's req
+    fit on ``cap``'s host, or None if the host cannot be freed.
+
+    ``host_victims`` is pre-sorted lowest-priority-first; this accumulates the
+    resources each evicted victim returns and stops as soon as the req fits. Only
+    victims strictly lower band than the candidate are eligible.
+
+    The host's ``building_task_count`` is left unchanged in the hypothetical:
+    ``RunningTaskInfo`` carries no build state and a long-running squatter holds
+    no build slot, so eviction must not be assumed to free one. A host blocked
+    solely by the build limit is therefore not recoverable here, which is correct
+    — that limit is transient back-pressure, not a held resource.
+    """
+    req = candidate.requirements
+    available_cpu = cap.available_cpu_millicores
+    available_memory = cap.available_memory
+    available_gpus = cap.available_gpus
+    available_tpus = cap.available_tpus
+    chosen: list[RunningTaskInfo] = []
+    for victim in host_victims:
+        if victim.already_preempted:
+            continue
+        # Only strictly lower priority (higher band_sort_key) victims are eligible.
+        if victim.band_sort_key <= candidate.band:
+            continue
+        chosen.append(victim)
+        available_cpu += victim.cpu_millicores
+        available_memory += victim.memory_bytes
+        available_gpus += victim.gpu_count
+        available_tpus += victim.tpu_count
+        hypothetical = WorkerCapacity(
+            worker_id=cap.worker_id,
+            available_cpu_millicores=available_cpu,
+            available_memory=available_memory,
+            available_gpus=available_gpus,
+            available_tpus=available_tpus,
+            attributes=cap.attributes,
+            building_task_count=cap.building_task_count,
+            max_building_tasks=cap.max_building_tasks,
+        )
+        if hypothetical.can_fit(req) is None:
+            return chosen
+    return None
+
+
+def _preempt_coscheduled_partial_hosts(
+    candidate: PreemptionCandidate,
+    n_required: int,
+    solo_victims_by_worker: Mapping[WorkerId, list[RunningTaskInfo]],
+    reserved_workers: set[WorkerId],
+    context: SchedulingContext,
+) -> list[tuple[JobName, JobName]]:
+    """Free a blocked gang by evicting lower-band solo co-tenants on its hosts.
+
+    Fallback for when no whole victim slice qualifies but the gang is short a few
+    hosts whose only blocker is a solo task squatting on per-host CPU/RAM. Finds
+    the group the gang would place in (``ranked_groups_for_req`` — the same
+    ranking placement uses), then frees each
+    capacity-blocked host via :func:`_solo_victims_freeing_host`. Commits
+    evictions only when enough hosts can be freed for the whole gang to place
+    (``n_required`` workers); otherwise the eviction would be wasted and the gang
+    is left pending.
+
+    ``reserved_workers`` holds hosts an earlier gang's eviction already claimed
+    this pass; they are skipped here, and the committed gang's hosts are added to
+    it, so two gangs contending for one group never double-book the same hosts.
+    """
+    req = candidate.requirements
+    for _group_key, worker_ids in ranked_groups_for_req(context, req):
+        if len(worker_ids) < n_required:
+            continue
+        fitting: list[WorkerId] = []
+        recoverable: list[tuple[WorkerId, list[RunningTaskInfo]]] = []
+        for wid in worker_ids:
+            if wid in reserved_workers:
+                continue
+            cap = context.capacities.get(wid)
+            if cap is None:
+                continue
+            if cap.can_fit(req) is None:
+                fitting.append(wid)
+                continue
+            victims = _solo_victims_freeing_host(candidate, cap, solo_victims_by_worker.get(wid, []))
+            if victims is not None:
+                recoverable.append((wid, victims))
+
+        needed = n_required - len(fitting)
+        if needed <= 0:
+            return []  # group already has room for the gang; no preemption needed
+        if len(recoverable) < needed:
+            continue  # cannot free enough hosts in this group; try the next
+
+        # Commit the cheapest `needed` host-evictions (fewest victims, then least
+        # resource) to bound blast radius; reserve every host the gang will use.
+        recoverable.sort(key=lambda item: (len(item[1]), sum(v.resource_value for v in item[1])))
+        used_hosts: set[WorkerId] = set(fitting)
+        pairs: list[tuple[JobName, JobName]] = []
+        for wid, victims in recoverable[:needed]:
+            used_hosts.add(wid)
+            for victim in victims:
+                victim.already_preempted = True
+                pairs.append((candidate.job_name, victim.task_id))
+        reserved_workers |= used_hosts
+        return pairs
+    return []
+
+
 def run_preemption_pass(
     unscheduled_tasks: list[PreemptionCandidate],
     running_tasks_info: list[RunningTaskInfo],
@@ -485,6 +599,18 @@ def run_preemption_pass(
         key=lambda t: (-t.band_sort_key, t.resource_value),
     )
 
+    # Same solo victims bucketed by host for the gang partial-host fallback. Holds
+    # the *same* RunningTaskInfo objects, so already_preempted is shared across the
+    # solo path, the fallback, and competing gangs. Each bucket inherits the sort
+    # above: lowest-priority-first, then cheapest-first.
+    solo_victims_by_worker: dict[WorkerId, list[RunningTaskInfo]] = defaultdict(list)
+    for v in solo_victims:
+        solo_victims_by_worker[v.worker_id].append(v)
+
+    # Hosts a gang's partial-host eviction has claimed this pass; keeps two gangs
+    # contending for one group from double-booking the same hosts.
+    reserved_workers: set[WorkerId] = set()
+
     # Lazy: only build coscheduled-victim slice index if some preemptor needs
     # one. The common case (no coscheduled preemptors) skips the bucketing.
     sorted_groups: list[tuple[JobName, list[RunningTaskInfo]]] = []
@@ -508,6 +634,11 @@ def run_preemption_pass(
     # Preemptor jobs whose siblings have already been satisfied by a slice
     # eviction this pass; the remaining N-1 siblings short-circuit.
     satisfied_preemptor_jobs: set[JobName] = set()
+    # Gangs whose coscheduled preemption was already attempted this pass (success
+    # or failure). A gang's siblings select identically (same req, n_required, and
+    # candidate group), so one attempt suffices and a failed gang does not re-run
+    # the index-scanning search for each of its N pending siblings.
+    attempted_coscheduled_jobs: set[JobName] = set()
     sibling_count: dict[JobName, int] = defaultdict(int)
     for c in unscheduled_tasks:
         if c.job_name.parent is not None:
@@ -530,8 +661,20 @@ def run_preemption_pass(
                 preemptions.append(pair)
             continue
 
+        # Attempt a gang's coscheduled preemption once per gang, not per sibling.
+        if parent is not None and parent in attempted_coscheduled_jobs:
+            continue
+        if parent is not None:
+            attempted_coscheduled_jobs.add(parent)
+
         n_required = sibling_count.get(parent, 1) if parent is not None else 1
         pairs = _preempt_coscheduled(candidate, wanted_variant, n_required, sorted_groups, context)
+        if not pairs:
+            # No whole victim slice qualified; try freeing the gang's blocking
+            # hosts by evicting lower-band solo co-tenants squatting on them.
+            pairs = _preempt_coscheduled_partial_hosts(
+                candidate, n_required, solo_victims_by_worker, reserved_workers, context
+            )
         if pairs:
             preemptions.extend(pairs)
             if parent is not None:

--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -464,18 +464,14 @@ def _solo_victims_freeing_host(
     cap: WorkerCapacity,
     host_victims: list[RunningTaskInfo],
 ) -> list[RunningTaskInfo] | None:
-    """Lowest-priority solo victims whose combined eviction lets the gang's req
-    fit on ``cap``'s host, or None if the host cannot be freed.
+    """Lowest-priority solo victims whose eviction lets the gang's req fit on
+    ``cap``'s host, or None if the host cannot be freed. Only victims strictly
+    lower band than the candidate are eligible; ``host_victims`` must be ordered
+    lowest-priority-first.
 
-    ``host_victims`` is pre-sorted lowest-priority-first; this accumulates the
-    resources each evicted victim returns and stops as soon as the req fits. Only
-    victims strictly lower band than the candidate are eligible.
-
-    The host's ``building_task_count`` is left unchanged in the hypothetical:
-    ``RunningTaskInfo`` carries no build state and a long-running squatter holds
-    no build slot, so eviction must not be assumed to free one. A host blocked
-    solely by the build limit is therefore not recoverable here, which is correct
-    — that limit is transient back-pressure, not a held resource.
+    The host's build-slot count is treated as fixed: a long-running squatter
+    holds no build slot, so a host blocked solely by the build limit is not
+    recoverable here (that limit is transient back-pressure, not a held resource).
     """
     req = candidate.requirements
     available_cpu = cap.available_cpu_millicores
@@ -516,20 +512,17 @@ def _preempt_coscheduled_partial_hosts(
     reserved_workers: set[WorkerId],
     context: SchedulingContext,
 ) -> list[tuple[JobName, JobName]]:
-    """Free a blocked gang by evicting lower-band solo co-tenants on its hosts.
+    """Free a blocked gang by evicting lower-band solo co-tenants on its hosts,
+    returning (preemptor, victim) pairs or [] if the gang cannot be placed.
 
     Fallback for when no whole victim slice qualifies but the gang is short a few
-    hosts whose only blocker is a solo task squatting on per-host CPU/RAM. Finds
-    the group the gang would place in (``ranked_groups_for_req`` — the same
-    ranking placement uses), then frees each
-    capacity-blocked host via :func:`_solo_victims_freeing_host`. Commits
-    evictions only when enough hosts can be freed for the whole gang to place
-    (``n_required`` workers); otherwise the eviction would be wasted and the gang
-    is left pending.
+    hosts whose only blocker is a solo task squatting on per-host CPU/RAM. Evicts
+    only when enough hosts can be freed for the whole gang (``n_required``
+    workers) to place; otherwise nothing is evicted, since a partial eviction
+    would be wasted.
 
-    ``reserved_workers`` holds hosts an earlier gang's eviction already claimed
-    this pass; they are skipped here, and the committed gang's hosts are added to
-    it, so two gangs contending for one group never double-book the same hosts.
+    ``reserved_workers`` is read and updated so two gangs contending for one group
+    never double-book the same hosts.
     """
     req = candidate.requirements
     for _group_key, worker_ids in ranked_groups_for_req(context, req):

--- a/lib/iris/src/iris/cluster/controller/scheduling/scheduler.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/scheduler.py
@@ -532,6 +532,46 @@ def first_fitting_worker(
     return None
 
 
+def ranked_groups_for_req(
+    context: SchedulingContext,
+    req: JobRequirements,
+) -> list[tuple[str, list[WorkerId]]]:
+    """Constraint-matched worker groups for a coscheduled req, ranked by total
+    soft-constraint score (descending) — the order placement tries them in.
+
+    Used by both the placement pass and the preemption fallback so they agree on
+    which group a gang would land in. Returns ``[]`` for a req with no
+    ``coscheduling_group_by``.
+    """
+    group_by = req.coscheduling_group_by
+    if group_by is None:
+        return []
+    hard_constraints, soft_constraints = split_hard_soft(list(req.constraints))
+    matching_worker_ids = context.matching_workers(hard_constraints)
+    groups = context.workers_by_group(group_by, matching_worker_ids)
+    if not soft_constraints:
+        return list(groups.items())
+
+    soft_key_tail = tuple(soft_constraints)
+    cache = context._soft_score_cache
+
+    def _group_soft_score(group_worker_ids: list[WorkerId]) -> int:
+        total = 0
+        for wid in group_worker_ids:
+            cap = context.capacities.get(wid)
+            if cap is None:
+                continue
+            key = (wid, soft_key_tail)
+            score = cache.get(key)
+            if score is None:
+                score = soft_constraint_score(dict(cap.attributes), soft_constraints)
+                cache[key] = score
+            total += score
+        return total
+
+    return sorted(groups.items(), key=lambda kv: _group_soft_score(kv[1]), reverse=True)
+
+
 def _format_rejection_summary(
     rejection_counts: dict[RejectionKind, int],
     rejection_samples: dict[RejectionKind, RejectionReason],
@@ -752,42 +792,16 @@ class Scheduler:
 
         Returns None if no valid worker group exists with sufficient capacity.
         """
-        group_by = req.coscheduling_group_by
-        if group_by is None:
+        if req.coscheduling_group_by is None:
             return None
 
         if not task_ids:
             return None
 
         num_tasks = len(task_ids)
-        all_constraints = list(req.constraints)
-        hard_constraints, soft_constraints = split_hard_soft(all_constraints)
-
-        # Only hard constraints filter candidates; soft constraints rank groups.
-        matching_worker_ids = context.matching_workers(hard_constraints)
-        groups = context.workers_by_group(group_by, matching_worker_ids)
-
-        # Sort groups so those satisfying more soft constraints are tried first.
-        soft_key_tail = tuple(soft_constraints)
-        cache = context._soft_score_cache
-
-        def _group_soft_score(group_worker_ids: list[WorkerId]) -> int:
-            if not soft_constraints:
-                return 0
-            total = 0
-            for wid in group_worker_ids:
-                cap = context.capacities.get(wid)
-                if cap is None:
-                    continue
-                key = (wid, soft_key_tail)
-                score = cache.get(key)
-                if score is None:
-                    score = soft_constraint_score(dict(cap.attributes), soft_constraints)
-                    cache[key] = score
-                total += score
-            return total
-
-        sorted_groups = sorted(groups.items(), key=lambda kv: _group_soft_score(kv[1]), reverse=True)
+        # Constraint-match + group + soft-rank, shared with the preemption fallback
+        # so placement and preemption agree on which group the gang prefers.
+        sorted_groups = ranked_groups_for_req(context, req)
 
         # Find first group with enough workers that have capacity.
         # Note: matching_worker_ids passed attribute constraints (e.g., tpu-name=my-tpu),
@@ -829,7 +843,7 @@ class Scheduler:
         logger.debug(
             "Coscheduled job: no group with %d available workers for group_by=%s",
             num_tasks,
-            group_by,
+            req.coscheduling_group_by,
         )
         return None
 

--- a/lib/iris/src/iris/cluster/controller/scheduling/scheduler.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/scheduler.py
@@ -538,10 +538,7 @@ def ranked_groups_for_req(
 ) -> list[tuple[str, list[WorkerId]]]:
     """Constraint-matched worker groups for a coscheduled req, ranked by total
     soft-constraint score (descending) — the order placement tries them in.
-
-    Used by both the placement pass and the preemption fallback so they agree on
-    which group a gang would land in. Returns ``[]`` for a req with no
-    ``coscheduling_group_by``.
+    Returns ``[]`` for a req with no ``coscheduling_group_by``.
     """
     group_by = req.coscheduling_group_by
     if group_by is None:

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -604,19 +604,25 @@ def test_solo_preemptor_does_not_tear_down_slice():
 
 # ---------------------------------------------------------------------------
 # Coscheduled partial-host fallback: a blocked gang evicts lower-band solo
-# co-tenants squatting on the few hosts it needs (issue #6672).
+# co-tenants squatting on the few hosts it needs.
 # ---------------------------------------------------------------------------
 
 _GB = 1024**3
+_HOST_CPU = 4000  # millicores free on a host with no squatter
+_FULL_TPUS = 4  # chips on a whole TPU host
+_FREE_RAM = 200 * _GB  # RAM free on a host that fits the gang
+_BLOCKED_RAM = 10 * _GB  # RAM free on a host a squatter is hogging
+_SQUATTER_RAM = 200 * _GB  # RAM a squatter holds; freeing it unblocks its host
+_GANG_RAM = 128 * _GB  # per-host RAM the gang requests
 
 
 def _pod_capacity(
     worker_id: WorkerId,
     *,
     pod: str = "pod-a",
-    cpu_millicores: int,
+    cpu_millicores: int = _HOST_CPU,
     memory_bytes: int,
-    tpus: int,
+    tpus: int = _FULL_TPUS,
 ) -> WorkerCapacity:
     """A TPU host in coscheduling group ``pod`` with the given free resources."""
     return WorkerCapacity(
@@ -632,9 +638,9 @@ def _pod_capacity(
 def _gang_req(
     *,
     variant: str = "v4-2048",
-    tpus: int = 4,
+    tpus: int = _FULL_TPUS,
     cpu_millicores: int = 1000,
-    memory_bytes: int = 128 * _GB,
+    memory_bytes: int = _GANG_RAM,
 ) -> JobRequirements:
     return JobRequirements(
         req_cpu_millicores=cpu_millicores,
@@ -678,14 +684,14 @@ def _gang_unscheduled(job: JobName, req: JobRequirements, n: int) -> list[Preemp
 
 
 def test_gang_preempts_cpu_squatter_on_blocking_host():
-    """The #6672 repro: a PRODUCTION gang needs every host in its pod; N-1 fit and
-    one is blocked only by a BATCH CPU-only squatter's RAM. The gang evicts the
-    squatter (which has no device variant), freeing the host."""
+    """The reserved-pod repro: a PRODUCTION gang needs every host in its pod; N-1
+    fit and one is blocked only by a BATCH CPU-only squatter's RAM. The gang
+    evicts the squatter (which has no device variant), freeing the host."""
     workers = [WorkerId(f"w{i}") for i in range(4)]
-    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
-    # w0-w2 fit; w3 has TPUs free but only 10 GB RAM (squatter holds the rest).
-    caps = [_pod_capacity(workers[i], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4) for i in range(3)]
-    caps.append(_pod_capacity(workers[3], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4))
+    req = _gang_req()
+    # w0-w2 fit; w3 has TPUs free but its RAM is held by the squatter.
+    caps = [_pod_capacity(workers[i], memory_bytes=_FREE_RAM) for i in range(3)]
+    caps.append(_pod_capacity(workers[3], memory_bytes=_BLOCKED_RAM))
     ctx = _make_simple_context(caps)
 
     squatter = _solo_victim(
@@ -693,7 +699,7 @@ def test_gang_preempts_cpu_squatter_on_blocking_host():
         workers[3],
         band=job_pb2.PRIORITY_BAND_BATCH,
         cpu_millicores=64000,
-        memory_bytes=200 * _GB,  # freeing makes w3's 10 GB -> 210 GB, fits 128 GB
+        memory_bytes=_SQUATTER_RAM,  # freeing it lifts w3 past the gang's RAM ask
     )
 
     gang = JobName.from_wire("/larry/grug-moe")
@@ -707,10 +713,10 @@ def test_gang_preempts_cpu_squatter_on_blocking_host():
 def test_gang_does_not_preempt_same_band_squatter():
     """A squatter at or above the gang's band is never evicted by the fallback."""
     workers = [WorkerId(f"w{i}") for i in range(2)]
-    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    req = _gang_req()
     caps = [
-        _pod_capacity(workers[0], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
-        _pod_capacity(workers[1], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
+        _pod_capacity(workers[0], memory_bytes=_FREE_RAM),
+        _pod_capacity(workers[1], memory_bytes=_BLOCKED_RAM),
     ]
     ctx = _make_simple_context(caps)
 
@@ -719,7 +725,7 @@ def test_gang_does_not_preempt_same_band_squatter():
         JobName.from_wire("/peer/prod-cpu:0"),
         workers[1],
         band=job_pb2.PRIORITY_BAND_PRODUCTION,
-        memory_bytes=200 * _GB,
+        memory_bytes=_SQUATTER_RAM,
     )
 
     gang = JobName.from_wire("/larry/grug-moe")
@@ -731,13 +737,13 @@ def test_gang_partial_host_skips_when_not_enough_recoverable():
     """No eviction when fewer hosts can be freed than the gang needs — freeing a
     strict subset would be wasted (the gang still can't place)."""
     workers = [WorkerId(f"w{i}") for i in range(4)]
-    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    req = _gang_req()
     # w0,w1 fit; w2,w3 both RAM-blocked but only w2 has an evictable victim.
     caps = [
-        _pod_capacity(workers[0], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
-        _pod_capacity(workers[1], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
-        _pod_capacity(workers[2], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
-        _pod_capacity(workers[3], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
+        _pod_capacity(workers[0], memory_bytes=_FREE_RAM),
+        _pod_capacity(workers[1], memory_bytes=_FREE_RAM),
+        _pod_capacity(workers[2], memory_bytes=_BLOCKED_RAM),
+        _pod_capacity(workers[3], memory_bytes=_BLOCKED_RAM),
     ]
     ctx = _make_simple_context(caps)
 
@@ -745,7 +751,7 @@ def test_gang_partial_host_skips_when_not_enough_recoverable():
         JobName.from_wire("/m/batch:0"),
         workers[2],
         band=job_pb2.PRIORITY_BAND_BATCH,
-        memory_bytes=200 * _GB,
+        memory_bytes=_SQUATTER_RAM,
     )
 
     gang = JobName.from_wire("/larry/grug-moe")
@@ -757,17 +763,17 @@ def test_gang_partial_host_no_preemption_when_enough_hosts_free():
     """When the group has enough free hosts for the gang already, the squatter on
     a spare host is left alone (the gang places without preemption)."""
     workers = [WorkerId(f"w{i}") for i in range(5)]
-    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    req = _gang_req()
     # 4 free hosts (>= n_required=4) plus one squatted spare; no preemption needed.
-    caps = [_pod_capacity(workers[i], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4) for i in range(4)]
-    caps.append(_pod_capacity(workers[4], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4))
+    caps = [_pod_capacity(workers[i], memory_bytes=_FREE_RAM) for i in range(4)]
+    caps.append(_pod_capacity(workers[4], memory_bytes=_BLOCKED_RAM))
     ctx = _make_simple_context(caps)
 
     squatter = _solo_victim(
         JobName.from_wire("/m/batch:0"),
         workers[4],
         band=job_pb2.PRIORITY_BAND_BATCH,
-        memory_bytes=200 * _GB,
+        memory_bytes=_SQUATTER_RAM,
     )
 
     gang = JobName.from_wire("/larry/grug-moe")
@@ -778,15 +784,15 @@ def test_gang_partial_host_no_preemption_when_enough_hosts_free():
 def test_gang_partial_host_commits_minimal_evictions():
     """With more recoverable hosts than needed, evict only the cheapest `needed`."""
     workers = [WorkerId(f"w{i}") for i in range(5)]
-    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    req = _gang_req()
     # w0,w1 fit; w2,w3,w4 each blocked with one evictable victim. Gang needs 3, so
     # only one host (the cheapest victim) is freed.
     caps = [
-        _pod_capacity(workers[0], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
-        _pod_capacity(workers[1], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
-        _pod_capacity(workers[2], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
-        _pod_capacity(workers[3], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
-        _pod_capacity(workers[4], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
+        _pod_capacity(workers[0], memory_bytes=_FREE_RAM),
+        _pod_capacity(workers[1], memory_bytes=_FREE_RAM),
+        _pod_capacity(workers[2], memory_bytes=_BLOCKED_RAM),
+        _pod_capacity(workers[3], memory_bytes=_BLOCKED_RAM),
+        _pod_capacity(workers[4], memory_bytes=_BLOCKED_RAM),
     ]
     ctx = _make_simple_context(caps)
 
@@ -795,21 +801,21 @@ def test_gang_partial_host_commits_minimal_evictions():
             JobName.from_wire("/m/batch-a:0"),
             workers[2],
             band=job_pb2.PRIORITY_BAND_BATCH,
-            memory_bytes=200 * _GB,
+            memory_bytes=_SQUATTER_RAM,
             resource_value=9000,
         ),
         _solo_victim(
             JobName.from_wire("/m/batch-b:0"),
             workers[3],
             band=job_pb2.PRIORITY_BAND_BATCH,
-            memory_bytes=200 * _GB,
+            memory_bytes=_SQUATTER_RAM,
             resource_value=1000,  # cheapest
         ),
         _solo_victim(
             JobName.from_wire("/m/batch-c:0"),
             workers[4],
             band=job_pb2.PRIORITY_BAND_BATCH,
-            memory_bytes=200 * _GB,
+            memory_bytes=_SQUATTER_RAM,
             resource_value=5000,
         ),
     ]
@@ -824,10 +830,10 @@ def test_gang_partial_host_ignores_coscheduled_cotenant():
     """The fallback never evicts a *coscheduled* co-tenant — only whole-slice
     eviction (``_preempt_coscheduled``) may touch a gang, and only at slice size."""
     workers = [WorkerId(f"w{i}") for i in range(2)]
-    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    req = _gang_req()
     caps = [
-        _pod_capacity(workers[0], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
-        _pod_capacity(workers[1], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
+        _pod_capacity(workers[0], memory_bytes=_FREE_RAM),
+        _pod_capacity(workers[1], memory_bytes=_BLOCKED_RAM),
     ]
     ctx = _make_simple_context(caps)
 
@@ -840,7 +846,7 @@ def test_gang_partial_host_ignores_coscheduled_cotenant():
         resource_value=1000,
         is_coscheduled=True,
         cpu_millicores=0,
-        memory_bytes=200 * _GB,
+        memory_bytes=_SQUATTER_RAM,
         gpu_count=0,
         tpu_count=0,
         device_variant="v4-2048",
@@ -856,11 +862,11 @@ def test_gang_preempts_solo_tpu_cotenant_on_blocking_host():
     needs is preemptible too (on a host matching the gang's group, any TPU solo
     victim is necessarily the same variant)."""
     workers = [WorkerId(f"w{i}") for i in range(2)]
-    req = _gang_req(variant="v5p-8", tpus=4, memory_bytes=_GB)
+    req = _gang_req(variant="v5p-8", memory_bytes=_GB)
     # w0 fits; w1 has only 2 of 4 chips free (a solo BATCH task holds the other 2).
     caps = [
-        _pod_capacity(workers[0], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
-        _pod_capacity(workers[1], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=2),
+        _pod_capacity(workers[0], memory_bytes=_FREE_RAM),
+        _pod_capacity(workers[1], memory_bytes=_FREE_RAM, tpus=2),
     ]
     ctx = _make_simple_context(caps)
 
@@ -882,17 +888,17 @@ def test_two_gangs_do_not_double_book_hosts():
     """Two gangs contending for one pod don't double-book hosts: the first claims
     the freed pod; the second finds every host reserved and preempts nothing."""
     workers = [WorkerId(f"w{i}") for i in range(4)]
-    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    req = _gang_req()
     # 3 hosts fit; w3 is RAM-blocked with one evictable BATCH squatter.
-    caps = [_pod_capacity(workers[i], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4) for i in range(3)]
-    caps.append(_pod_capacity(workers[3], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4))
+    caps = [_pod_capacity(workers[i], memory_bytes=_FREE_RAM) for i in range(3)]
+    caps.append(_pod_capacity(workers[3], memory_bytes=_BLOCKED_RAM))
     ctx = _make_simple_context(caps)
 
     squatter = _solo_victim(
         JobName.from_wire("/m/batch:0"),
         workers[3],
         band=job_pb2.PRIORITY_BAND_BATCH,
-        memory_bytes=200 * _GB,
+        memory_bytes=_SQUATTER_RAM,
     )
 
     gang_a = JobName.from_wire("/larry/gang-a")

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -3,7 +3,7 @@
 
 """Tests for the preemption loop — higher-priority tasks evict lower-priority running tasks."""
 
-from iris.cluster.constraints import AttributeValue, Constraint, ConstraintOp, WellKnownAttribute
+from iris.cluster.constraints import AttributeValue, Constraint, ConstraintIndex, ConstraintOp, WellKnownAttribute
 from iris.cluster.controller import ops, reads
 from iris.cluster.controller.budget import compute_effective_band
 from iris.cluster.controller.ops.task import Assignment, finalize
@@ -46,10 +46,27 @@ def _make_simple_context(workers: list[WorkerCapacity]) -> "FakeSchedulingContex
 
 
 class FakeSchedulingContext:
-    """Minimal stand-in for SchedulingContext used by run_preemption_pass."""
+    """Minimal stand-in for SchedulingContext used by run_preemption_pass.
+
+    Builds the same constraint index the real context does, so the coscheduled
+    partial-host fallback (which groups candidate workers by attribute) behaves
+    faithfully: attribute-less workers form no groups, so it no-ops.
+    """
 
     def __init__(self, capacities: dict[WorkerId, WorkerCapacity]):
         self.capacities = capacities
+        self._str_to_wid = {str(wid): wid for wid in capacities}
+        entity_attrs = {str(wid): dict(cap.attributes) for wid, cap in capacities.items()}
+        self.index = ConstraintIndex.build(entity_attrs)
+        self._soft_score_cache: dict[tuple[WorkerId, tuple[Constraint, ...]], int] = {}
+
+    def matching_workers(self, constraints: list[Constraint]) -> set[WorkerId]:
+        return {self._str_to_wid[s] for s in self.index.matching_entities(constraints)}
+
+    def workers_by_group(self, group_by: str, matching_worker_ids: set[WorkerId]) -> dict[str, list[WorkerId]]:
+        matching_strs = {str(wid) for wid in matching_worker_ids}
+        str_groups = self.index.entities_by_group(group_by, matching_strs)
+        return {key: [self._str_to_wid[s] for s in ids] for key, ids in str_groups.items()}
 
 
 def _cpu_requirements(cpu_cores: int = 1) -> JobRequirements:
@@ -583,6 +600,310 @@ def test_solo_preemptor_does_not_tear_down_slice():
 
     preemptions = run_preemption_pass(unscheduled, victims, ctx)
     assert preemptions == []
+
+
+# ---------------------------------------------------------------------------
+# Coscheduled partial-host fallback: a blocked gang evicts lower-band solo
+# co-tenants squatting on the few hosts it needs (issue #6672).
+# ---------------------------------------------------------------------------
+
+_GB = 1024**3
+
+
+def _pod_capacity(
+    worker_id: WorkerId,
+    *,
+    pod: str = "pod-a",
+    cpu_millicores: int,
+    memory_bytes: int,
+    tpus: int,
+) -> WorkerCapacity:
+    """A TPU host in coscheduling group ``pod`` with the given free resources."""
+    return WorkerCapacity(
+        worker_id=worker_id,
+        available_cpu_millicores=cpu_millicores,
+        available_memory=memory_bytes,
+        available_gpus=0,
+        available_tpus=tpus,
+        attributes={WellKnownAttribute.TPU_NAME: AttributeValue(pod)},
+    )
+
+
+def _gang_req(
+    *,
+    variant: str = "v4-2048",
+    tpus: int = 4,
+    cpu_millicores: int = 1000,
+    memory_bytes: int = 128 * _GB,
+) -> JobRequirements:
+    return JobRequirements(
+        req_cpu_millicores=cpu_millicores,
+        req_memory_bytes=memory_bytes,
+        req_gpu_count=0,
+        req_tpu_count=tpus,
+        device_variant=variant,
+        constraints=[],
+        is_coscheduled=True,
+        coscheduling_group_by=WellKnownAttribute.TPU_NAME,
+    )
+
+
+def _solo_victim(
+    task_id: JobName,
+    worker_id: WorkerId,
+    *,
+    band: int,
+    cpu_millicores: int = 0,
+    memory_bytes: int = 0,
+    tpus: int = 0,
+    variant: str | None = None,
+    resource_value: int = 1000,
+) -> RunningTaskInfo:
+    return RunningTaskInfo(
+        task_id=task_id,
+        worker_id=worker_id,
+        band_sort_key=band,
+        resource_value=resource_value,
+        is_coscheduled=False,
+        cpu_millicores=cpu_millicores,
+        memory_bytes=memory_bytes,
+        gpu_count=0,
+        tpu_count=tpus,
+        device_variant=variant,
+    )
+
+
+def _gang_unscheduled(job: JobName, req: JobRequirements, n: int) -> list[PreemptionCandidate]:
+    return [PreemptionCandidate(job.child(str(i)), req, job_pb2.PRIORITY_BAND_PRODUCTION) for i in range(n)]
+
+
+def test_gang_preempts_cpu_squatter_on_blocking_host():
+    """The #6672 repro: a PRODUCTION gang needs every host in its pod; N-1 fit and
+    one is blocked only by a BATCH CPU-only squatter's RAM. The gang evicts the
+    squatter (which has no device variant), freeing the host."""
+    workers = [WorkerId(f"w{i}") for i in range(4)]
+    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    # w0-w2 fit; w3 has TPUs free but only 10 GB RAM (squatter holds the rest).
+    caps = [_pod_capacity(workers[i], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4) for i in range(3)]
+    caps.append(_pod_capacity(workers[3], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4))
+    ctx = _make_simple_context(caps)
+
+    squatter = _solo_victim(
+        JobName.from_wire("/michael/ft-prep:0"),
+        workers[3],
+        band=job_pb2.PRIORITY_BAND_BATCH,
+        cpu_millicores=64000,
+        memory_bytes=200 * _GB,  # freeing makes w3's 10 GB -> 210 GB, fits 128 GB
+    )
+
+    gang = JobName.from_wire("/larry/grug-moe")
+    preemptions = run_preemption_pass(_gang_unscheduled(gang, req, 4), [squatter], ctx)
+
+    assert len(preemptions) == 1
+    assert preemptions[0][1] == squatter.task_id
+    assert preemptions[0][0].parent == gang  # attributed to one gang sibling
+
+
+def test_gang_does_not_preempt_same_band_squatter():
+    """A squatter at or above the gang's band is never evicted by the fallback."""
+    workers = [WorkerId(f"w{i}") for i in range(2)]
+    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    caps = [
+        _pod_capacity(workers[0], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
+        _pod_capacity(workers[1], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
+    ]
+    ctx = _make_simple_context(caps)
+
+    # Same-band (PRODUCTION) squatter — strictly-lower-band gate rejects it.
+    squatter = _solo_victim(
+        JobName.from_wire("/peer/prod-cpu:0"),
+        workers[1],
+        band=job_pb2.PRIORITY_BAND_PRODUCTION,
+        memory_bytes=200 * _GB,
+    )
+
+    gang = JobName.from_wire("/larry/grug-moe")
+    preemptions = run_preemption_pass(_gang_unscheduled(gang, req, 2), [squatter], ctx)
+    assert preemptions == []
+
+
+def test_gang_partial_host_skips_when_not_enough_recoverable():
+    """No eviction when fewer hosts can be freed than the gang needs — freeing a
+    strict subset would be wasted (the gang still can't place)."""
+    workers = [WorkerId(f"w{i}") for i in range(4)]
+    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    # w0,w1 fit; w2,w3 both RAM-blocked but only w2 has an evictable victim.
+    caps = [
+        _pod_capacity(workers[0], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
+        _pod_capacity(workers[1], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
+        _pod_capacity(workers[2], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
+        _pod_capacity(workers[3], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
+    ]
+    ctx = _make_simple_context(caps)
+
+    only_victim = _solo_victim(
+        JobName.from_wire("/m/batch:0"),
+        workers[2],
+        band=job_pb2.PRIORITY_BAND_BATCH,
+        memory_bytes=200 * _GB,
+    )
+
+    gang = JobName.from_wire("/larry/grug-moe")
+    preemptions = run_preemption_pass(_gang_unscheduled(gang, req, 4), [only_victim], ctx)
+    assert preemptions == []
+
+
+def test_gang_partial_host_no_preemption_when_enough_hosts_free():
+    """When the group has enough free hosts for the gang already, the squatter on
+    a spare host is left alone (the gang places without preemption)."""
+    workers = [WorkerId(f"w{i}") for i in range(5)]
+    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    # 4 free hosts (>= n_required=4) plus one squatted spare; no preemption needed.
+    caps = [_pod_capacity(workers[i], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4) for i in range(4)]
+    caps.append(_pod_capacity(workers[4], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4))
+    ctx = _make_simple_context(caps)
+
+    squatter = _solo_victim(
+        JobName.from_wire("/m/batch:0"),
+        workers[4],
+        band=job_pb2.PRIORITY_BAND_BATCH,
+        memory_bytes=200 * _GB,
+    )
+
+    gang = JobName.from_wire("/larry/grug-moe")
+    preemptions = run_preemption_pass(_gang_unscheduled(gang, req, 4), [squatter], ctx)
+    assert preemptions == []
+
+
+def test_gang_partial_host_commits_minimal_evictions():
+    """With more recoverable hosts than needed, evict only the cheapest `needed`."""
+    workers = [WorkerId(f"w{i}") for i in range(5)]
+    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    # w0,w1 fit; w2,w3,w4 each blocked with one evictable victim. Gang needs 3, so
+    # only one host (the cheapest victim) is freed.
+    caps = [
+        _pod_capacity(workers[0], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
+        _pod_capacity(workers[1], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
+        _pod_capacity(workers[2], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
+        _pod_capacity(workers[3], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
+        _pod_capacity(workers[4], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
+    ]
+    ctx = _make_simple_context(caps)
+
+    victims = [
+        _solo_victim(
+            JobName.from_wire("/m/batch-a:0"),
+            workers[2],
+            band=job_pb2.PRIORITY_BAND_BATCH,
+            memory_bytes=200 * _GB,
+            resource_value=9000,
+        ),
+        _solo_victim(
+            JobName.from_wire("/m/batch-b:0"),
+            workers[3],
+            band=job_pb2.PRIORITY_BAND_BATCH,
+            memory_bytes=200 * _GB,
+            resource_value=1000,  # cheapest
+        ),
+        _solo_victim(
+            JobName.from_wire("/m/batch-c:0"),
+            workers[4],
+            band=job_pb2.PRIORITY_BAND_BATCH,
+            memory_bytes=200 * _GB,
+            resource_value=5000,
+        ),
+    ]
+
+    gang = JobName.from_wire("/larry/grug-moe")
+    preemptions = run_preemption_pass(_gang_unscheduled(gang, req, 3), victims, ctx)
+    assert len(preemptions) == 1
+    assert preemptions[0][1] == victims[1].task_id  # the cheapest victim's host
+
+
+def test_gang_partial_host_ignores_coscheduled_cotenant():
+    """The fallback never evicts a *coscheduled* co-tenant — only whole-slice
+    eviction (``_preempt_coscheduled``) may touch a gang, and only at slice size."""
+    workers = [WorkerId(f"w{i}") for i in range(2)]
+    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    caps = [
+        _pod_capacity(workers[0], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
+        _pod_capacity(workers[1], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4),
+    ]
+    ctx = _make_simple_context(caps)
+
+    # A coscheduled BATCH co-tenant (single member) holds w1's RAM. It is not a
+    # solo victim, and its slice (size 1) is smaller than the gang (size 2).
+    cosched_cotenant = RunningTaskInfo(
+        task_id=JobName.from_wire("/other/cosched-batch").child("0"),
+        worker_id=workers[1],
+        band_sort_key=job_pb2.PRIORITY_BAND_BATCH,
+        resource_value=1000,
+        is_coscheduled=True,
+        cpu_millicores=0,
+        memory_bytes=200 * _GB,
+        gpu_count=0,
+        tpu_count=0,
+        device_variant="v4-2048",
+    )
+
+    gang = JobName.from_wire("/larry/grug-moe")
+    preemptions = run_preemption_pass(_gang_unscheduled(gang, req, 2), [cosched_cotenant], ctx)
+    assert preemptions == []
+
+
+def test_gang_preempts_solo_tpu_cotenant_on_blocking_host():
+    """Intended broader behavior: a BATCH *solo TPU* task occupying chips the gang
+    needs is preemptible too (on a host matching the gang's group, any TPU solo
+    victim is necessarily the same variant)."""
+    workers = [WorkerId(f"w{i}") for i in range(2)]
+    req = _gang_req(variant="v5p-8", tpus=4, memory_bytes=_GB)
+    # w0 fits; w1 has only 2 of 4 chips free (a solo BATCH task holds the other 2).
+    caps = [
+        _pod_capacity(workers[0], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4),
+        _pod_capacity(workers[1], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=2),
+    ]
+    ctx = _make_simple_context(caps)
+
+    tpu_cotenant = _solo_victim(
+        JobName.from_wire("/m/batch-tpu:0"),
+        workers[1],
+        band=job_pb2.PRIORITY_BAND_BATCH,
+        tpus=2,  # freeing restores w1 to 4 chips
+        variant="v5p-8",
+    )
+
+    gang = JobName.from_wire("/larry/grug-moe")
+    preemptions = run_preemption_pass(_gang_unscheduled(gang, req, 2), [tpu_cotenant], ctx)
+    assert len(preemptions) == 1
+    assert preemptions[0][1] == tpu_cotenant.task_id
+
+
+def test_two_gangs_do_not_double_book_hosts():
+    """Two gangs contending for one pod don't double-book hosts: the first claims
+    the freed pod; the second finds every host reserved and preempts nothing."""
+    workers = [WorkerId(f"w{i}") for i in range(4)]
+    req = _gang_req(tpus=4, memory_bytes=128 * _GB)
+    # 3 hosts fit; w3 is RAM-blocked with one evictable BATCH squatter.
+    caps = [_pod_capacity(workers[i], cpu_millicores=4000, memory_bytes=200 * _GB, tpus=4) for i in range(3)]
+    caps.append(_pod_capacity(workers[3], cpu_millicores=4000, memory_bytes=10 * _GB, tpus=4))
+    ctx = _make_simple_context(caps)
+
+    squatter = _solo_victim(
+        JobName.from_wire("/m/batch:0"),
+        workers[3],
+        band=job_pb2.PRIORITY_BAND_BATCH,
+        memory_bytes=200 * _GB,
+    )
+
+    gang_a = JobName.from_wire("/larry/gang-a")
+    gang_b = JobName.from_wire("/larry/gang-b")
+    unscheduled = _gang_unscheduled(gang_a, req, 4) + _gang_unscheduled(gang_b, req, 4)
+
+    preemptions = run_preemption_pass(unscheduled, [squatter], ctx)
+    # Only gang A's single squatter eviction; gang B sees every host reserved.
+    assert len(preemptions) == 1
+    assert preemptions[0][1] == squatter.task_id
+    assert preemptions[0][0].parent == gang_a
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
A PRODUCTION coscheduled (gang) job stayed PENDING indefinitely instead of preempting a lower-band, CPU-only task squatting on one of the hosts it needs. The band check permits the eviction, but gang preemption's victim selection structurally cannot see the squatter, so the gang wedged on a single host until a human terminated the squatter (which killed its run).

Problem
A coscheduled preemptor only reaches `_preempt_coscheduled`, which evicts whole same-variant victim slices and never a solo CPU-only co-tenant. Three independent gates exclude the squatter in `scheduling/policy.py`: the gang victim index drops non-coscheduled / variant-less tasks; the variant-equality gate rejects a CPU victim; and the slice path does no per-host CPU/RAM arithmetic. The only per-host hypothetical-capacity math (`_preempt_solo`) is reachable only by non-coscheduled preemptors, so a gang blocked on one host's RAM has no path to the squatter.

Approach
Add a partial-host fallback to the coscheduled path: when no whole slice qualifies, free the gang's blocking hosts by evicting lower-band solo co-tenants on exactly those hosts. It gates on band (not device-variant equality), reuses per-host hypothetical-capacity math, and commits evictions only when enough hosts can be freed for the whole gang to place — otherwise nothing is evicted and the gang stays pending. Victims route through the existing `preempt_one` path, so they land in PREEMPTED (charged to `max_retries_preemption`, survivable), not FAILED.

A pass-level reserved-hosts set keeps two gangs contending for one group from double-booking the same hosts, and each gang's coscheduled preemption is attempted once per pass rather than once per pending sibling. The grouping/ranking placement uses is extracted into `ranked_groups_for_req` and shared with the fallback so both agree on which group a gang lands in. The build-slot count is held fixed in the fallback's hypothetical: a long-running squatter holds no build slot, so a host blocked solely by the transient build limit is correctly not recovered.

The design was peer-reviewed by Codex; its findings (build-slot accounting, same-pass host double-booking, group-ranking divergence) are incorporated.

Fixes #6672