### PR TITLE
rigging: preserve FSSPEC_S3 config_kwargs in S3 timeout defaults

### DIFF
--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -925,8 +925,16 @@ def _with_s3_timeout_defaults(kwargs: dict[str, Any]) -> dict[str, Any]:
 
     Caller-supplied ``config_kwargs`` values win; we only fill in keys the
     caller did not set. See :data:`_S3_READ_TIMEOUT` and #6487.
+
+    We seed ``config_kwargs`` from the ``FSSPEC_S3`` config block first. fsspec
+    builds the filesystem by shallow-merging ``{**conf, **kwargs}``, so a bare
+    ``config_kwargs`` here would *replace* (not merge with) any ``config_kwargs``
+    in ``FSSPEC_S3`` -- silently dropping settings like
+    ``{"s3": {"addressing_style": "virtual"}}`` that S3-compatible endpoints
+    (CoreWeave object storage) require, which then hangs/path-style-rejects.
     """
-    config_kwargs = dict(kwargs.get("config_kwargs") or {})
+    conf_config_kwargs = (fsspec.config.conf.get("s3") or {}).get("config_kwargs") or {}
+    config_kwargs = {**conf_config_kwargs, **dict(kwargs.get("config_kwargs") or {})}
     config_kwargs.setdefault("connect_timeout", _S3_CONNECT_TIMEOUT)
     config_kwargs.setdefault("read_timeout", _S3_READ_TIMEOUT)
     config_kwargs.setdefault("retries", {"max_attempts": _S3_RETRY_MAX_ATTEMPTS, "mode": "standard"})


### PR DESCRIPTION
* preserve `FSSPEC_S3` `config_kwargs` when injecting S3 timeout/retry defaults
* `_with_s3_timeout_defaults` built a fresh `config_kwargs`; fsspec then shallow-merges `{**conf, **kwargs}`, so it *replaced* `FSSPEC_S3`'s `config_kwargs` instead of merging — silently dropping `{"s3": {"addressing_style": "virtual"}}`
  * virtual-only S3 endpoints (CoreWeave `cwobject.com` / `cwlota.com`) then received path-style requests → the write hangs or returns `PathStyleRequestNotAllowed`
* now seed `config_kwargs` from `fsspec.config.conf["s3"]` first, so the `FSSPEC_S3` config and the timeout defaults coexist

🤖 Generated with [Claude Code](https://claude.com/claude-code)
