### PR TITLE
[iris] Compact and declutter the controller dashboard

### DIFF
--- a/lib/iris/dashboard/src/components/controller/CapacityTab.vue
+++ b/lib/iris/dashboard/src/components/controller/CapacityTab.vue
@@ -866,7 +866,6 @@ function sliceIdShort(sliceId?: string): string {
                         </template>
                       </span>
                     </div>
-                    <!-- One-line pool state summary -->
                     <div class="flex items-center gap-1.5 flex-shrink-0">
                       <template v-if="poolStatusSummary(section).length">
                         <span

--- a/lib/iris/dashboard/src/components/controller/CapacityTab.vue
+++ b/lib/iris/dashboard/src/components/controller/CapacityTab.vue
@@ -217,9 +217,9 @@ function formatSliceSummary(totals: Record<string, number>): string {
 // ===========================================================================
 
 const expandedSlices = ref<Set<string>>(new Set())
-// Explicit per-pool open/closed intent (set on user click). Pools with no slices and
-// no demand default to collapsed — just their one-line state summary — while the rest
-// default to expanded. An override recorded here wins over that default.
+// Explicit per-pool open/closed intent (set on user click). Every pool defaults to
+// collapsed — just its one-line state summary — since an operator usually cares about
+// one slice type and expands it. An override recorded here wins over that default.
 const poolOverrides = ref<Map<string, boolean>>(new Map())
 // Pools whose idle (zero-slice, idle-decision) tiers have been revealed. By default an
 // expanded pool shows only its active tiers plus a "+N idle sizes" toggle.
@@ -387,12 +387,9 @@ function poolDemand(section: PoolSection): number {
 function poolLaunch(section: PoolSection): number {
   return section.groups.reduce((n, gs) => n + (gs.launch ?? 0), 0)
 }
-function poolSliceTotal(section: PoolSection): number {
-  return poolStatusSummary(section).reduce((n, c) => n + c.count, 0)
-}
 
 // A group needs attention when its availability is constrained even if it holds no
-// slices yet — these must stay visible rather than collapse into "no slices".
+// slices yet — these stay visible rather than collapse into the idle remainder.
 function groupNeedsAttention(name: string): boolean {
   const status = group(name)?.availabilityStatus
   return status === 'quota_exceeded' || status === 'backoff' || status === 'at_capacity' || status === 'requesting'
@@ -402,19 +399,9 @@ function groupIsActive(gs: GroupRoutingStatus): boolean {
   return (decision !== 'idle' && decision !== '') || groupNeedsAttention(gs.group)
 }
 
-// A pool is "active" — and so expanded by default — when it has materialized slices,
-// outstanding demand, a planned launch, a tier-blocking condition, or any group with a
-// non-idle decision or constrained availability. Empty inert pools collapse to their
-// one-line header so the table stays scannable.
-function poolHasActivity(section: PoolSection): boolean {
-  if (poolSliceTotal(section) > 0 || poolDemand(section) > 0 || poolLaunch(section) > 0 || section.blockedAtTier != null) {
-    return true
-  }
-  return section.groups.some(groupIsActive)
-}
+// Every pool defaults to collapsed; only an explicit user toggle opens one.
 function isPoolCollapsed(section: PoolSection): boolean {
-  const override = poolOverrides.value.get(section.pool)
-  return override !== undefined ? override : !poolHasActivity(section)
+  return poolOverrides.value.get(section.pool) ?? true
 }
 function togglePool(section: PoolSection) {
   const next = new Map(poolOverrides.value)

--- a/lib/iris/dashboard/src/components/controller/CapacityTab.vue
+++ b/lib/iris/dashboard/src/components/controller/CapacityTab.vue
@@ -217,15 +217,21 @@ function formatSliceSummary(totals: Record<string, number>): string {
 // ===========================================================================
 
 const expandedSlices = ref<Set<string>>(new Set())
-const collapsedPools = ref<Set<string>>(new Set())
+// Explicit per-pool open/closed intent (set on user click). Pools with no slices and
+// no demand default to collapsed — just their one-line state summary — while the rest
+// default to expanded. An override recorded here wins over that default.
+const poolOverrides = ref<Map<string, boolean>>(new Map())
+// Pools whose idle (zero-slice, idle-decision) tiers have been revealed. By default an
+// expanded pool shows only its active tiers plus a "+N idle sizes" toggle.
+const expandedIdleSizes = ref<Set<string>>(new Set())
 
 function toggleSet(set: Set<string>, key: string): Set<string> {
   const next = new Set(set)
   next.has(key) ? next.delete(key) : next.add(key)
   return next
 }
-function togglePool(pool: string) { collapsedPools.value = toggleSet(collapsedPools.value, pool) }
 function toggleSlices(name: string) { expandedSlices.value = toggleSet(expandedSlices.value, name) }
+function toggleIdleSizes(pool: string) { expandedIdleSizes.value = toggleSet(expandedIdleSizes.value, pool) }
 
 const sortedGroupStatuses = computed<GroupRoutingStatus[]>(() => {
   const statuses = routing.value?.groupStatuses ?? []
@@ -342,6 +348,12 @@ function groupStatusSummary(name: string): SliceStatusCount[] {
     .map(s => ({ status: s, count: counts.get(s)!, style: SLICE_STATUS_STYLES[s] }))
 }
 
+// Total slices the group holds, from the same status rollup the chips use (real ready
+// slices + in-flight lifecycle counts), so the tier ladder agrees with the chips.
+function groupSliceCountTotal(name: string): number {
+  return groupStatusSummary(name).reduce((n, c) => n + c.count, 0)
+}
+
 // Free = healthy slices that can take work now (available + idle). Both counts
 // are slice-granular — a fully-booked healthy slice is `in_use`, not free.
 function groupFreeSlices(name: string): number {
@@ -352,6 +364,78 @@ function groupFreeSlices(name: string): number {
 }
 function groupDegradedSliceCount(name: string): number {
   return countSliceStatus(groupSliceViews(name), 'degraded')
+}
+
+// -- Pool-level rollups (the one-line state summary on each pool header) --
+
+// Aggregate the slice-status chips across every group in a pool, in canonical order,
+// so a collapsed pool still says what it holds (e.g. "52 in use · 3 booting").
+function poolStatusSummary(section: PoolSection): SliceStatusCount[] {
+  const counts = new Map<SliceStatus, number>()
+  for (const gs of section.groups) {
+    for (const c of groupStatusSummary(gs.group)) {
+      counts.set(c.status, (counts.get(c.status) ?? 0) + c.count)
+    }
+  }
+  return SLICE_STATUS_SUMMARY_ORDER
+    .filter(s => (counts.get(s) ?? 0) > 0)
+    .map(s => ({ status: s, count: counts.get(s)!, style: SLICE_STATUS_STYLES[s] }))
+}
+function poolDemand(section: PoolSection): number {
+  return section.groups.reduce((n, gs) => n + groupDemand(gs.group), 0)
+}
+function poolLaunch(section: PoolSection): number {
+  return section.groups.reduce((n, gs) => n + (gs.launch ?? 0), 0)
+}
+function poolSliceTotal(section: PoolSection): number {
+  return poolStatusSummary(section).reduce((n, c) => n + c.count, 0)
+}
+
+// A group needs attention when its availability is constrained even if it holds no
+// slices yet — these must stay visible rather than collapse into "no slices".
+function groupNeedsAttention(name: string): boolean {
+  const status = group(name)?.availabilityStatus
+  return status === 'quota_exceeded' || status === 'backoff' || status === 'at_capacity' || status === 'requesting'
+}
+function groupIsActive(gs: GroupRoutingStatus): boolean {
+  const decision = gs.decision ?? 'idle'
+  return (decision !== 'idle' && decision !== '') || groupNeedsAttention(gs.group)
+}
+
+// A pool is "active" — and so expanded by default — when it has materialized slices,
+// outstanding demand, a planned launch, a tier-blocking condition, or any group with a
+// non-idle decision or constrained availability. Empty inert pools collapse to their
+// one-line header so the table stays scannable.
+function poolHasActivity(section: PoolSection): boolean {
+  if (poolSliceTotal(section) > 0 || poolDemand(section) > 0 || poolLaunch(section) > 0 || section.blockedAtTier != null) {
+    return true
+  }
+  return section.groups.some(groupIsActive)
+}
+function isPoolCollapsed(section: PoolSection): boolean {
+  const override = poolOverrides.value.get(section.pool)
+  return override !== undefined ? override : !poolHasActivity(section)
+}
+function togglePool(section: PoolSection) {
+  const next = new Map(poolOverrides.value)
+  next.set(section.pool, !isPoolCollapsed(section))
+  poolOverrides.value = next
+}
+
+// Tiers worth showing by default: any with slices, demand, a non-idle decision, or
+// constrained availability. The fully-idle remainder hides behind a "show N idle sizes"
+// toggle (but never hide all of a pool's tiers — keep them if none are active).
+function activeGroups(section: PoolSection): GroupRoutingStatus[] {
+  return section.groups.filter(gs => !isInactiveRow(gs) || groupIsActive(gs))
+}
+function visibleGroups(section: PoolSection): GroupRoutingStatus[] {
+  if (expandedIdleSizes.value.has(section.pool)) return section.groups
+  const active = activeGroups(section)
+  return active.length > 0 ? active : section.groups
+}
+function idleSizeCount(section: PoolSection): number {
+  const active = activeGroups(section)
+  return active.length > 0 ? section.groups.length - active.length : 0
 }
 
 // Shared layout/typography for the slice-status chips; each chip adds its own
@@ -672,27 +756,30 @@ function sliceIdShort(sliceId?: string): string {
     <!-- ===== Capacity summary strip ===== -->
     <section>
       <div class="grid grid-cols-2 sm:grid-cols-4 lg:grid-cols-8 gap-2">
-        <MetricCard :value="`${onlineGroups} / ${groups.length}`" label="Pools online" />
-        <MetricCard :value="totalSlices" label="Slices" :detail="formatSliceSummary(sliceTotals)" />
+        <MetricCard size="sm" :value="`${onlineGroups} / ${groups.length}`" label="Pools online" />
+        <MetricCard size="sm" :value="totalSlices" label="Slices" :detail="formatSliceSummary(sliceTotals)" />
         <MetricCard
+          size="sm"
           :value="totalIdle"
           label="Idle spare"
           :variant="totalIdle > 0 ? 'warning' : 'default'"
         />
         <MetricCard
+          size="sm"
           :value="totalDegradedSlices"
           label="Degraded slices"
           :variant="totalDegradedSlices > 0 ? 'orange' : 'default'"
           :detail="totalDegradedSlices > 0 ? 'unschedulable' : undefined"
         />
-        <MetricCard :value="totalDemand" label="Demand" :variant="totalDemand > 0 ? 'accent' : 'default'" />
-        <MetricCard :value="launchPlanned" label="Launch planned" :variant="launchPlanned > 0 ? 'accent' : 'default'" />
+        <MetricCard size="sm" :value="totalDemand" label="Demand" :variant="totalDemand > 0 ? 'accent' : 'default'" />
+        <MetricCard size="sm" :value="launchPlanned" label="Launch planned" :variant="launchPlanned > 0 ? 'accent' : 'default'" />
         <MetricCard
+          size="sm"
           :value="aggregatedUnmet.length"
           label="Unmet jobs"
           :variant="aggregatedUnmet.length > 0 ? 'danger' : 'default'"
         />
-        <MetricCard :value="formatRelativeTime(lastEvalMs)" label="Last evaluation" />
+        <MetricCard size="sm" :value="formatRelativeTime(lastEvalMs)" label="Last evaluation" />
       </div>
     </section>
 
@@ -725,59 +812,95 @@ function sliceIdShort(sliceId?: string): string {
           </thead>
           <tbody>
             <template v-for="section in poolSections" :key="section.pool || '__unpooled'">
-              <!-- Pool header row -->
+              <!-- Pool header row: toggle + name + tier chain on the left, an
+                   always-visible one-line state summary (slice chips + demand) on
+                   the right so a collapsed pool still tells its story. -->
               <tr class="bg-surface border-b border-surface-border hover:bg-surface-raised">
                 <td colspan="8" class="px-3 py-1.5">
-                  <div class="flex items-center gap-2">
-                    <button
-                      type="button"
-                      class="inline-flex items-center gap-2 text-left cursor-pointer hover:opacity-80"
-                      :aria-expanded="!collapsedPools.has(section.pool)"
-                      :aria-label="(collapsedPools.has(section.pool) ? 'Expand ' : 'Collapse ') + (section.pool === '__unpooled' ? 'unpooled groups' : 'pool ' + section.pool)"
-                      @click="togglePool(section.pool)"
-                    >
-                      <span class="text-[10px] text-text-muted">
-                        {{ collapsedPools.has(section.pool) ? '▶' : '▼' }}
+                  <div class="flex items-center justify-between gap-3">
+                    <div class="flex items-center gap-2 min-w-0">
+                      <button
+                        type="button"
+                        class="inline-flex items-center gap-2 text-left cursor-pointer hover:opacity-80"
+                        :aria-expanded="!isPoolCollapsed(section)"
+                        :aria-label="(isPoolCollapsed(section) ? 'Expand ' : 'Collapse ') + (section.pool === '__unpooled' ? 'unpooled groups' : 'pool ' + section.pool)"
+                        @click="togglePool(section)"
+                      >
+                        <span class="text-[10px] text-text-muted">
+                          {{ isPoolCollapsed(section) ? '▶' : '▼' }}
+                        </span>
+                        <span class="text-xs font-semibold uppercase tracking-wider text-text-secondary whitespace-nowrap">
+                          {{ section.pool === '__unpooled' ? 'Unpooled' : `Pool: ${section.pool}` }}
+                        </span>
+                      </button>
+                      <span
+                        v-if="section.blockedAtTier"
+                        class="inline-flex items-center px-1.5 py-0.5 rounded text-xs border
+                               bg-status-danger-bg text-status-danger border-status-danger-border"
+                      >
+                        blocked at tier {{ section.blockedAtTier }}+
                       </span>
-                      <span class="text-xs font-semibold uppercase tracking-wider text-text-secondary">
-                        {{ section.pool === '__unpooled' ? 'Unpooled' : `Pool: ${section.pool}` }}
+                      <!-- Tier ladder: slice count at each fallback tier (left = first
+                           tried). Position encodes the tier; the number is how many
+                           slices sit there. Hover for the tier label and group. -->
+                      <span v-if="section.pool !== '__unpooled'" class="flex items-center gap-0.5 text-xs text-text-muted ml-2">
+                        <template v-for="(gs, idx) in section.groups" :key="gs.group">
+                          <span v-if="idx > 0" class="text-text-muted mx-0.5">&rarr;</span>
+                          <span
+                            :title="`${tierLabel(gs) || 'tier'} · ${gs.group} · ${groupSliceCountTotal(gs.group)} slice${groupSliceCountTotal(gs.group) === 1 ? '' : 's'}`"
+                            :class="[
+                              'px-1 py-0.5 rounded border text-[11px] font-mono tabular-nums',
+                              isTierBlocked(gs, section)
+                                ? 'bg-status-danger-bg text-status-danger border-status-danger-border line-through'
+                                : group(gs.group)?.availabilityStatus === 'quota_exceeded'
+                                  ? 'bg-status-danger-bg text-status-danger border-status-danger-border'
+                                  : group(gs.group)?.availabilityStatus === 'backoff'
+                                    ? 'bg-status-orange-bg text-status-orange border-status-orange-border'
+                                    : groupSliceCountTotal(gs.group) > 0
+                                      ? 'bg-surface border-surface-border text-text-secondary'
+                                      : 'bg-surface border-surface-border text-text-muted',
+                            ]"
+                          >
+                            {{ groupSliceCountTotal(gs.group) }}
+                          </span>
+                        </template>
                       </span>
-                    </button>
-                    <span
-                      v-if="section.blockedAtTier"
-                      class="inline-flex items-center px-1.5 py-0.5 rounded text-xs border
-                             bg-status-danger-bg text-status-danger border-status-danger-border"
-                    >
-                      blocked at tier {{ section.blockedAtTier }}+
-                    </span>
-                    <!-- Tier chain visualization (not shown for unpooled groups) -->
-                    <span v-if="section.pool !== '__unpooled'" class="flex items-center gap-0.5 text-xs text-text-muted ml-2">
-                      <template v-for="(gs, idx) in section.groups" :key="gs.group">
-                        <span v-if="idx > 0" class="text-text-muted mx-0.5">&rarr;</span>
+                    </div>
+                    <!-- One-line pool state summary -->
+                    <div class="flex items-center gap-1.5 flex-shrink-0">
+                      <template v-if="poolStatusSummary(section).length">
                         <span
-                          :class="[
-                            'px-1 py-0.5 rounded border text-[11px] font-mono',
-                            isTierBlocked(gs, section)
-                              ? 'bg-status-danger-bg text-status-danger border-status-danger-border line-through'
-                              : group(gs.group)?.availabilityStatus === 'quota_exceeded'
-                                ? 'bg-status-danger-bg text-status-danger border-status-danger-border'
-                                : group(gs.group)?.availabilityStatus === 'backoff'
-                                  ? 'bg-status-orange-bg text-status-orange border-status-orange-border'
-                                  : 'bg-surface border-surface-border text-text-secondary',
-                          ]"
+                          v-for="b in poolStatusSummary(section)"
+                          :key="b.status"
+                          :class="[BADGE_BASE, b.style.bg, b.style.text, b.style.border]"
+                          :title="`${b.count} ${b.style.label} slice${b.count > 1 ? 's' : ''} — ${b.style.description}`"
                         >
-                          {{ tierLabel(gs) }}
+                          <span class="w-1.5 h-1.5 rounded-full" :class="b.style.dot" />
+                          {{ b.count }} {{ b.style.label }}
                         </span>
                       </template>
-                    </span>
+                      <span v-else class="text-xs text-text-muted">no slices</span>
+                      <span
+                        v-if="poolDemand(section) > 0"
+                        class="inline-flex items-center px-1.5 py-0.5 rounded text-xs border bg-accent-subtle text-accent border-accent-border"
+                      >
+                        demand {{ poolDemand(section) }}
+                      </span>
+                      <span
+                        v-if="poolLaunch(section) > 0"
+                        class="inline-flex items-center px-1.5 py-0.5 rounded text-xs border bg-accent-subtle text-accent border-accent-border"
+                      >
+                        launch {{ poolLaunch(section) }}
+                      </span>
+                    </div>
                   </div>
                 </td>
               </tr>
 
-              <template v-for="gs in section.groups" :key="gs.group">
+              <template v-for="gs in visibleGroups(section)" :key="gs.group">
                 <!-- Main row -->
                 <tr
-                  v-if="!collapsedPools.has(section.pool)"
+                  v-if="!isPoolCollapsed(section)"
                   :class="[
                     'border-b border-surface-border-subtle hover:bg-surface-raised transition-colors',
                     isInactiveRow(gs) ? 'opacity-50' : '',
@@ -879,12 +1002,27 @@ function sliceIdShort(sliceId?: string): string {
                 </tr>
 
                 <!-- Slice detail (expanded) -->
-                <tr v-if="expandedSlices.has(gs.group) && groupHasSlices(gs.group) && !collapsedPools.has(section.pool)" class="bg-surface-sunken">
+                <tr v-if="expandedSlices.has(gs.group) && groupHasSlices(gs.group) && !isPoolCollapsed(section)" class="bg-surface-sunken">
                   <td colspan="8" class="px-6 py-3">
                     <SliceList :slices="groupSlices(gs.group)" :worker-jobs="sliceWorkerJobs" :now="nowMs" />
                   </td>
                 </tr>
               </template>
+
+              <!-- Idle-tier toggle: an active pool hides its fully-idle sizes here. -->
+              <tr v-if="!isPoolCollapsed(section) && idleSizeCount(section) > 0" class="border-b border-surface-border-subtle">
+                <td colspan="8" class="px-3 py-1">
+                  <button
+                    type="button"
+                    class="ml-6 text-xs text-text-muted hover:text-text-secondary cursor-pointer"
+                    @click="toggleIdleSizes(section.pool)"
+                  >
+                    {{ expandedIdleSizes.has(section.pool)
+                      ? `hide ${idleSizeCount(section)} idle size${idleSizeCount(section) > 1 ? 's' : ''}`
+                      : `show ${idleSizeCount(section)} idle size${idleSizeCount(section) > 1 ? 's' : ''}` }}
+                  </button>
+                </td>
+              </tr>
             </template>
           </tbody>
         </table>

--- a/lib/iris/dashboard/src/components/controller/FleetOverview.vue
+++ b/lib/iris/dashboard/src/components/controller/FleetOverview.vue
@@ -99,7 +99,7 @@ const fleetSummary = computed<FleetChipSummary[]>(() => {
     const chip = chipFromGroupName(g.name)
     if (chip == null) continue
     const region = regionFromGroupName(g.name)
-    const entry = chips.get(chip) ?? { total: 0, inUse: 0, uptimes: [], regions: new Map(), bands: new Map<string, number>(), capacityByRegion: new Map<string, string[]>() }
+    const entry = chips.get(chip) ?? { total: 0, inUse: 0, uptimes: [] as number[], regions: new Map<string, number>(), bands: new Map<string, number>(), capacityByRegion: new Map<string, string[]>() }
 
     const readyCount = g.sliceStateCounts?.['ready'] ?? 0
     const readySlices = (g.slices ?? []).filter(s => {
@@ -209,14 +209,36 @@ function regionColor(region: string): string {
   return CATEGORICAL_COLORS[idx % CATEGORICAL_COLORS.length]
 }
 
-function capacityTooltip(capacity: RegionCapacity[]): string {
-  if (capacity.length === 0) return ''
-  return 'Capacity:\n' + capacity
-    .map(c => {
-      const icon = c.status === 'available' ? '✓' : c.status === 'limited' ? '~' : '✗'
-      return `  ${icon} ${c.region}: ${c.detail}`
-    })
-    .join('\n')
+// Fleet-wide region totals in shared-legend (color) order. One legend above the cards
+// names each region's color, so the per-card bars need no repeated legend of their own.
+const legendRegions = computed<RegionCount[]>(() => {
+  const totals = new Map<string, number>()
+  for (const c of fleetSummary.value) {
+    for (const r of c.regions) totals.set(r.region, (totals.get(r.region) ?? 0) + r.count)
+  }
+  return Array.from(totals.entries())
+    .map(([region, count]) => ({ region, count }))
+    .sort((a, b) => (allRegions.value.get(a.region) ?? 0) - (allRegions.value.get(b.region) ?? 0))
+})
+
+function cardTooltip(c: FleetChipSummary): string {
+  const lines: string[] = []
+  if (c.bands.length > 0) {
+    lines.push('Running by band:')
+    for (const b of c.bands) {
+      const share = c.total > 0 ? Math.round((b.count / c.total) * 100) : 0
+      lines.push(`  ${share}% ${b.band}`)
+    }
+  }
+  if (c.capacity.length > 0) {
+    if (lines.length > 0) lines.push('')
+    lines.push('Capacity:')
+    for (const cap of c.capacity) {
+      const icon = cap.status === 'available' ? '✓' : cap.status === 'limited' ? '~' : '✗'
+      lines.push(`  ${icon} ${cap.region}: ${cap.detail}`)
+    }
+  }
+  return lines.join('\n')
 }
 
 function formatUptimeShort(ms: number | null): string {
@@ -231,50 +253,50 @@ function formatUptimeShort(ms: number | null): string {
 
 <template>
   <section v-if="fleetSummary.length > 0">
-    <h3 class="text-sm font-semibold text-text-secondary uppercase tracking-wider mb-3">
-      Fleet Overview
-    </h3>
-    <div class="grid grid-cols-4 gap-2">
+    <!-- Heading + one shared region legend; per-card bars reuse these colors. -->
+    <div class="flex items-baseline justify-between gap-x-4 gap-y-1 flex-wrap mb-2">
+      <h3 class="text-sm font-semibold text-text-secondary uppercase tracking-wider">
+        Fleet Overview
+      </h3>
+      <div class="flex flex-wrap gap-x-3 gap-y-0.5 text-text-muted" style="font-size: clamp(8px, 0.6vw, 11px)">
+        <span v-for="r in legendRegions" :key="r.region" class="flex items-center gap-1 whitespace-nowrap">
+          <span class="rounded-full inline-block" :style="{ backgroundColor: regionColor(r.region), width: '7px', height: '7px' }" />
+          {{ r.region }} {{ r.count }}
+        </span>
+      </div>
+    </div>
+    <div class="grid grid-cols-2 sm:grid-cols-3 lg:grid-cols-4 2xl:grid-cols-5 gap-2">
       <div
         v-for="c in fleetSummary"
         :key="c.chip"
-        class="rounded-lg border border-surface-border bg-surface px-4 py-2"
-        :title="capacityTooltip(c.capacity)"
+        class="rounded-lg border border-surface-border bg-surface px-3 py-1.5"
+        :title="cardTooltip(c)"
       >
-        <div class="flex items-baseline gap-[0.4vw] mb-1" style="font-size: clamp(10px, 0.75vw, 14px)">
-          <span class="font-semibold font-mono tabular-nums text-text" style="font-size: clamp(14px, 1.1vw, 22px)">{{ c.total }}</span>
+        <!-- Count + chip, inline region bar (regions read from the shared legend;
+             exact per-region counts on hover), in-use share. -->
+        <div class="flex items-center gap-2" style="font-size: clamp(9px, 0.7vw, 12px)">
+          <span class="font-semibold font-mono tabular-nums text-text leading-none" style="font-size: clamp(14px, 1.05vw, 20px)">{{ c.total }}</span>
           <span class="font-medium text-text-secondary uppercase whitespace-nowrap">{{ c.chip }}</span>
-          <span class="tabular-nums" :class="c.total > 0 && c.inUse === c.total ? 'text-status-warning' : 'text-text-muted'">
+          <div class="flex flex-1 min-w-[40px] rounded-full overflow-hidden bg-surface-sunken" style="height: clamp(5px, 0.45vw, 9px)">
+            <div
+              v-for="r in c.regions"
+              :key="r.region"
+              class="transition-all"
+              :title="`${r.region}: ${r.count}`"
+              :style="{ width: (r.count / c.total * 100) + '%', backgroundColor: regionColor(r.region) }"
+            />
+          </div>
+          <span class="tabular-nums whitespace-nowrap" :class="c.total > 0 && c.inUse === c.total ? 'text-status-warning' : 'text-text-muted'">
             {{ c.total > 0 ? Math.round(c.inUse / c.total * 100) : 0 }}% in use
           </span>
-          <span class="text-text-muted tabular-nums whitespace-nowrap">
-            avg uptime {{ formatUptimeShort(c.avgUptimeMs) }}
-          </span>
         </div>
-        <!-- Region bar -->
-        <div class="flex rounded-full overflow-hidden bg-surface-sunken" style="height: clamp(4px, 0.4vw, 8px)">
-          <div
-            v-for="r in c.regions"
-            :key="r.region"
-            class="transition-all"
-            :style="{ width: (r.count / c.total * 100) + '%', backgroundColor: regionColor(r.region) }"
-          />
-        </div>
-        <div class="flex flex-wrap gap-x-[0.5vw] gap-y-0.5 mt-0.5" style="font-size: clamp(8px, 0.6vw, 11px)">
-          <span
-            v-for="r in c.regions"
-            :key="r.region"
-            class="text-text-muted flex items-center gap-0.5"
-          >
-            <span class="rounded-full inline-block" :style="{ backgroundColor: regionColor(r.region), width: 'clamp(4px, 0.4vw, 8px)', height: 'clamp(4px, 0.4vw, 8px)' }" />
-            {{ r.region }} ({{ r.count }})
-          </span>
-        </div>
-        <!-- Priority band breakdown -->
-        <div v-if="c.bands.length > 0" class="mt-0.5 text-text-muted" style="font-size: clamp(8px, 0.6vw, 11px)">
-          <span v-for="(b, i) in c.bands" :key="b.band">
-            <span v-if="i > 0">, </span>
-            {{ c.total > 0 ? Math.round(b.count / c.total * 100) : 0 }}% {{ b.band }}
+        <!-- Footer: avg uptime, plus the band mix when it is a genuine mix. -->
+        <div class="flex items-center justify-between gap-2 mt-0.5 text-text-muted" style="font-size: clamp(8px, 0.6vw, 11px)">
+          <span class="whitespace-nowrap tabular-nums">avg {{ formatUptimeShort(c.avgUptimeMs) }}</span>
+          <span v-if="c.bands.length > 1" class="truncate text-right">
+            <span v-for="(b, i) in c.bands" :key="b.band">
+              <span v-if="i > 0"> · </span>{{ c.total > 0 ? Math.round(b.count / c.total * 100) : 0 }}% {{ b.band }}
+            </span>
           </span>
         </div>
       </div>

--- a/lib/iris/dashboard/src/components/controller/FleetOverview.vue
+++ b/lib/iris/dashboard/src/components/controller/FleetOverview.vue
@@ -189,28 +189,9 @@ const fleetSummary = computed<FleetChipSummary[]>(() => {
     .sort((a, b) => b.total - a.total)
 })
 
-/** Stable color index for a region across all chip types. */
-const allRegions = computed<Map<string, number>>(() => {
-  const regionTotals = new Map<string, number>()
-  for (const c of fleetSummary.value) {
-    for (const r of c.regions) {
-      regionTotals.set(r.region, (regionTotals.get(r.region) ?? 0) + r.count)
-    }
-  }
-  const seen = new Map<string, number>()
-  for (const [region] of Array.from(regionTotals.entries()).sort((a, b) => b[1] - a[1])) {
-    seen.set(region, seen.size)
-  }
-  return seen
-})
-
-function regionColor(region: string): string {
-  const idx = allRegions.value.get(region) ?? 0
-  return CATEGORICAL_COLORS[idx % CATEGORICAL_COLORS.length]
-}
-
-// Fleet-wide region totals in shared-legend (color) order. One legend above the cards
-// names each region's color, so the per-card bars need no repeated legend of their own.
+// Fleet-wide region totals, largest first. The single place region aggregation
+// happens: the shared legend renders these, and both the per-region color index and
+// the bar colors follow this order so a region keeps one color across every card.
 const legendRegions = computed<RegionCount[]>(() => {
   const totals = new Map<string, number>()
   for (const c of fleetSummary.value) {
@@ -218,8 +199,19 @@ const legendRegions = computed<RegionCount[]>(() => {
   }
   return Array.from(totals.entries())
     .map(([region, count]) => ({ region, count }))
-    .sort((a, b) => (allRegions.value.get(a.region) ?? 0) - (allRegions.value.get(b.region) ?? 0))
+    .sort((a, b) => b.count - a.count)
 })
+
+const regionColorIndex = computed<Map<string, number>>(() => {
+  const index = new Map<string, number>()
+  legendRegions.value.forEach((r, i) => index.set(r.region, i))
+  return index
+})
+
+function regionColor(region: string): string {
+  const idx = regionColorIndex.value.get(region) ?? 0
+  return CATEGORICAL_COLORS[idx % CATEGORICAL_COLORS.length]
+}
 
 function cardTooltip(c: FleetChipSummary): string {
   const lines: string[] = []
@@ -290,7 +282,7 @@ function formatUptimeShort(ms: number | null): string {
             {{ c.total > 0 ? Math.round(c.inUse / c.total * 100) : 0 }}% in use
           </span>
         </div>
-        <!-- Footer: avg uptime, plus the band mix when it is a genuine mix. -->
+        <!-- Band mix is shown only for genuine mixes; a lone 100% band stays in the tooltip. -->
         <div class="flex items-center justify-between gap-2 mt-0.5 text-text-muted" style="font-size: clamp(8px, 0.6vw, 11px)">
           <span class="whitespace-nowrap tabular-nums">avg {{ formatUptimeShort(c.avgUptimeMs) }}</span>
           <span v-if="c.bands.length > 1" class="truncate text-right">

--- a/lib/iris/dashboard/src/components/controller/JobDetail.vue
+++ b/lib/iris/dashboard/src/components/controller/JobDetail.vue
@@ -541,6 +541,12 @@ const taskCounts = computed(() => {
   return counts
 })
 
+// The Scheduling pane auto-opens while tasks are pending — that's when placement
+// constraints explain why the job can't run — but a manual collapse then sticks
+// instead of being forced back open on the next auto-refresh.
+const schedulingOpen = ref(false)
+watch(() => taskCounts.value.pending > 0, pending => { if (pending) schedulingOpen.value = true }, { immediate: true })
+
 const MAX_FAILURE_EXAMPLES = 8
 
 interface TaskFailureSummary {
@@ -960,52 +966,42 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
           <InfoRow label="Failed">{{ taskCounts.failed }}</InfoRow>
         </InfoCard>
 
+        <!-- Resources: per-VM reservation, annotated inline with live usage across the
+             running tasks so the card reads as utilization (am I using what I booked,
+             and how close to OOM) rather than two disconnected lists of numbers. -->
         <InfoCard title="Resources (per VM)">
-          <InfoRow label="CPU">{{ cpuDisplay }}</InfoRow>
-          <InfoRow label="Memory">{{ memoryDisplay }}</InfoRow>
+          <InfoRow label="CPU">
+            <span class="font-mono">{{ cpuDisplay }}</span>
+            <span v-if="runningResourceRange" class="text-text-muted"> · {{ formatCpuMillicores(runningResourceRange.cpuMillicoresMin) }}&ndash;{{ formatCpuMillicores(runningResourceRange.cpuMillicoresMax) }} used</span>
+          </InfoRow>
+          <InfoRow label="Memory">
+            <span class="font-mono">{{ memoryDisplay }}</span>
+            <span v-if="runningResourceRange" class="text-text-muted"> · {{ formatBytes(runningResourceRange.memoryBytesMin) }}&ndash;{{ formatBytes(runningResourceRange.memoryBytesMax) }} used</span>
+          </InfoRow>
+          <InfoRow v-if="runningResourceRange?.memoryPeakBytesMax" label="Peak memory">
+            <span class="font-mono">{{ formatBytes(runningResourceRange.memoryPeakBytesMax) }}</span>
+          </InfoRow>
           <InfoRow label="Disk">{{ diskDisplay }}</InfoRow>
           <InfoRow label="Accelerator">{{ acceleratorDisplay }}</InfoRow>
           <InfoRow label="Replicas">{{ tasks.length || '-' }}</InfoRow>
         </InfoCard>
       </div>
 
-      <!-- Live resource usage (min/max across running tasks) -->
-      <div
-        v-if="runningResourceRange"
-        class="mb-6 rounded-lg border border-surface-border bg-surface px-4 py-3"
-      >
-        <h3 class="text-xs font-semibold uppercase tracking-wider text-text-secondary mb-2">
-          Live Resource Usage (across running tasks)
-        </h3>
-        <div class="grid grid-cols-1 sm:grid-cols-3 gap-2 sm:gap-4 text-sm">
-          <div>
-            <span class="text-text-muted">CPU:</span>
-            <span class="font-mono ml-1">{{ formatCpuMillicores(runningResourceRange.cpuMillicoresMin) }}</span>
-            <span class="text-text-muted mx-1">&ndash;</span>
-            <span class="font-mono">{{ formatCpuMillicores(runningResourceRange.cpuMillicoresMax) }}</span>
-          </div>
-          <div>
-            <span class="text-text-muted">Memory:</span>
-            <span class="font-mono ml-1">{{ formatBytes(runningResourceRange.memoryBytesMin) }}</span>
-            <span class="text-text-muted mx-1">&ndash;</span>
-            <span class="font-mono">{{ formatBytes(runningResourceRange.memoryBytesMax) }}</span>
-          </div>
-          <div v-if="runningResourceRange.memoryPeakBytesMax">
-            <span class="text-text-muted">Peak Memory:</span>
-            <span class="font-mono ml-1">{{ formatBytes(runningResourceRange.memoryPeakBytesMax) }}</span>
-          </div>
-        </div>
-      </div>
-
-      <!-- Constraints -->
-      <div
+      <!-- Scheduling: placement constraints, auto-opened while tasks are pending so an
+           operator sees what the job is asking for right when it can't be placed. -->
+      <details
         v-if="jobRequest?.constraints && jobRequest.constraints.length > 0"
-        class="mb-6 rounded-lg border border-surface-border bg-surface px-4 py-3"
+        class="mb-6 rounded-lg border border-surface-border bg-surface"
+        :open="schedulingOpen"
+        @toggle="schedulingOpen = ($event.target as HTMLDetailsElement).open"
       >
-        <h3 class="text-xs font-semibold uppercase tracking-wider text-text-secondary mb-2">
-          Constraints
-        </h3>
-        <div class="flex flex-wrap gap-1.5">
+        <summary class="flex items-center gap-2 px-4 py-2 cursor-pointer select-none text-xs font-semibold uppercase tracking-wider text-text-secondary">
+          Scheduling
+          <span class="font-normal normal-case tracking-normal text-text-muted">
+            — {{ jobRequest.constraints.length }} constraint{{ jobRequest.constraints.length > 1 ? 's' : '' }}<template v-if="taskCounts.pending > 0"> · {{ taskCounts.pending }} task{{ taskCounts.pending > 1 ? 's' : '' }} pending</template>
+          </span>
+        </summary>
+        <div class="border-t border-surface-border px-4 py-3 flex flex-wrap gap-1.5">
           <span
             v-for="(c, i) in jobRequest.constraints"
             :key="i"
@@ -1014,17 +1010,18 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
             {{ c.key }} {{ c.op }} {{ c.value?.stringValue ?? c.value?.intValue ?? '' }}
           </span>
         </div>
-      </div>
+      </details>
 
-      <!-- Job Request Details -->
-      <div
+      <!-- Job Request Details (collapsed by default — open to inspect command/env) -->
+      <details
         v-if="jobRequest?.entrypoint?.runCommand?.argv?.length || jobRequest?.submitArgv?.length || jobRequest?.environment?.envVars || jobRequest?.environment?.pipPackages?.length || jobRequest?.ports?.length"
-        class="mb-6 rounded-lg border border-surface-border bg-surface px-4 py-3"
+        class="mb-6 rounded-lg border border-surface-border bg-surface"
       >
-        <h3 class="text-xs font-semibold uppercase tracking-wider text-text-secondary mb-2">
+        <summary class="flex items-center gap-2 px-4 py-2 cursor-pointer select-none text-xs font-semibold uppercase tracking-wider text-text-secondary">
           Job Request
-        </h3>
-        <div class="flex flex-col gap-2 text-sm">
+          <span class="font-normal normal-case tracking-normal text-text-muted">— command, setup &amp; environment</span>
+        </summary>
+        <div class="flex flex-col gap-2 text-sm border-t border-surface-border px-4 py-3">
           <div v-if="jobRequest.entrypoint?.runCommand?.argv?.length">
             <span class="text-text-muted text-xs">Command</span>
             <pre class="mt-0.5 px-2 py-1 bg-surface-sunken rounded font-mono text-xs whitespace-pre-wrap break-all">{{ jobRequest.entrypoint.runCommand.argv.join(' ') }}</pre>
@@ -1074,7 +1071,7 @@ async function handleProfile(taskId: string, profilerType: string, format: strin
             </div>
           </div>
         </div>
-      </div>
+      </details>
 
       <!-- Child Jobs -->
       <div v-if="flattenedChildJobs.length > 0" class="mb-6">

--- a/lib/iris/dashboard/src/components/shared/MetricCard.vue
+++ b/lib/iris/dashboard/src/components/shared/MetricCard.vue
@@ -4,8 +4,10 @@ const props = withDefaults(defineProps<{
   label: string
   detail?: string
   variant?: string
+  size?: 'sm' | 'md'
 }>(), {
   variant: 'default',
+  size: 'md',
 })
 
 const VARIANT_CLASSES: Record<string, string> = {
@@ -24,14 +26,14 @@ function valueClass(): string {
 </script>
 
 <template>
-  <div class="rounded-lg border border-surface-border bg-surface px-4 py-3">
-    <div :class="['text-2xl font-semibold font-mono tabular-nums', valueClass()]">
+  <div :class="['rounded-lg border border-surface-border bg-surface', size === 'sm' ? 'px-3 py-1.5' : 'px-4 py-3']">
+    <div :class="[size === 'sm' ? 'text-lg' : 'text-2xl', 'font-semibold font-mono tabular-nums leading-tight', valueClass()]">
       {{ value }}
     </div>
-    <div class="text-xs font-medium text-text-secondary mt-1 uppercase tracking-wider">
+    <div :class="['font-medium text-text-secondary uppercase tracking-wider', size === 'sm' ? 'text-[10px] mt-0.5' : 'text-xs mt-1']">
       {{ label }}
     </div>
-    <div v-if="detail" class="text-xs text-text-muted mt-0.5">
+    <div v-if="detail" :class="['text-text-muted', size === 'sm' ? 'text-[10px] mt-0' : 'text-xs mt-0.5']">
       {{ detail }}
     </div>
   </div>

--- a/lib/iris/tests/e2e/conftest.py
+++ b/lib/iris/tests/e2e/conftest.py
@@ -507,6 +507,9 @@ class _NoOpPage:
     def wait_for_function(self, expression, **kwargs):
         pass
 
+    def evaluate(self, expression, *args, **kwargs):
+        pass
+
     def click(self, selector, **kwargs):
         pass
 

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -454,13 +454,20 @@ def test_dashboard_constraints(smoke_cluster, smoke_page, smoke_screenshot):
         dashboard_goto(smoke_page, f"{smoke_cluster.url}/job/{job.job_id.to_wire()}")
         wait_for_dashboard_ready(smoke_page)
 
+        # Placement constraints live in the collapsible "Scheduling" pane, which
+        # stays collapsed unless the job has pending tasks. Open it to inspect the chips.
         smoke_page.wait_for_function(
-            "() => document.body.textContent.includes('Constraints')",
+            "() => document.body.textContent.includes('Scheduling')",
             timeout=5000,
+        )
+        smoke_page.evaluate(
+            "() => [...document.querySelectorAll('details')]"
+            ".filter(d => d.querySelector('summary')?.textContent.includes('Scheduling'))"
+            ".forEach(d => { d.open = true })"
         )
         assert_visible(smoke_page, "text=region")
         smoke_screenshot(
-            "constraints", "Job detail page showing constraint chips for region, env-tag, and device-variant"
+            "constraints", "Job detail Scheduling pane showing constraint chips for region, env-tag, and device-variant"
         )
 
 


### PR DESCRIPTION
Tighten the controller dashboard around an operator's reading order — health
first, then what a job is doing, with the request spec as collapsed reference —
and reclaim wasted vertical space. The Capacity tab is ~38% shorter at the same
data without dropping signal.

Capacity & Scheduling
- Pools waterfall: each pool header now carries a one-line state summary
  (slice-status chips plus demand/launch). Pools with no slices, demand, launch,
  or attention auto-collapse to that single line; an active pool hides its
  fully-idle tiers behind a "show N idle sizes" toggle. The tier ladder shows the
  slice count at each fallback tier (e.g. 1 -> 0 -> 0 -> 0 -> 0) instead of bare
  T1 -> T2 labels.
- Fleet Overview: one shared region legend replaces the legend repeated on every
  card, so each chip card shrinks to about two lines (count, chip, inline region
  bar, in-use share, with uptime and band-mix below). Exact per-region counts move
  to hover.
- The eight summary metric cards use a new MetricCard size="sm" compact strip.

Job detail
- The Resources card folds in the separate Live Resource Usage panel and reads as
  utilization: each reserved value is annotated inline with live usage across the
  running tasks, with peak memory as the OOM signal.
- Constraints become a Scheduling pane that is collapsed when the job is healthy
  and auto-opens while tasks are pending — the moment those constraints explain
  why a job can't place.
- The Job Request box (command, setup, environment) is collapsed by default so
  live task state and logs sit above the fold.

Everything uses the existing semantic tokens, so the compact layout carries to
dark mode unchanged. Driven and screenshotted live against the marin cluster.