### PR TITLE
[skills] Write PR descriptions like commit messages, not templates

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -121,23 +121,38 @@ force-push.
 ## 8. Open or update the PR
 
 Do this once the branch is ready for review. The PR description becomes the
-squash-merge commit message — write it as plain text.
+squash-merge commit message, so **write it the way you'd write a good commit
+message a reviewer reads in `git log`.**
 
 **Title:** short imperative sentence; optional `[scope]` tag.
-**Body:** what changed and why. End with an issue link if one exists.
+
+**Body:** Lead with what the change does, in plain language, then the motivation —
+the problem it fixes or the reason it's shaped this way. Include only what a
+reviewer needs to understand and approve it. The body should stand on its own: a
+reader who never saw the diff should come away knowing what happened and why.
+
+Write for the reviewer, not for a template. Most PRs are a paragraph or two with
+no headings. Markdown earns its place when it makes the change *clearer* — a
+short list of the distinct things that changed, a table, a mermaid diagram of a
+new flow are all welcome when they help. Reach for them to aid the reviewer,
+never to fill in a standard set of sections. Let the change decide the shape; do
+not impose a What/Change/Scope/Testing scaffold.
 
 Keep the title and body aligned with the branch's actual scope — including when
 you change a branch that already has a PR.
 
 **Hard rules — violations are rejected:**
 
-- No "Validation" / "Testing" / "written by …" filler. The body is *what & why*,
-  not *how I tested it* or *who wrote it*.
+- No "Testing" / "Validation" / "Test plan" section, and no "how I verified it"
+  narration. The body is *what & why*. If a test result is the very thing that
+  justifies the change, fold that one fact into the *why*; otherwise leave it out.
+- No empty boilerplate headings — a `## Summary` that restates the title, a
+  `## Changes` that just lists the touched files. If a heading's body adds nothing
+  the reviewer can't get from the title or the diff, delete the heading.
+- No "written by …" / "Created by Claude" notes; don't credit yourself.
 - No checkboxes (`- [ ]`, `- [x]`), no emoji.
 - No filler openers ("This PR…", "I noticed…", "Summary of changes:").
-- Under ~500 words.
-- Don't credit yourself, no "Created by Claude" filler.
-- Only use Markdown & sections if this is a large change that requires structured description
+- Under ~500 words. Shorter is better; a one-line change gets a one-line body.
 
 Example:
 

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -24,7 +24,23 @@ Follow these steps precisely:
    - The root CLAUDE.md and AGENTS.md files, if they exist
    - Any CLAUDE.md or AGENTS.md files in directories (and parent directories) containing files modified by the PR
 
-3. Launch a sonnet agent to view the PR and return a summary of the changes.
+3. Launch a sonnet agent to view the PR and return a summary of the changes. The
+   same agent also checks the PR *description* against the PR-body rules in
+   `.agents/skills/commit/SKILL.md` §8 and returns any problems it finds:
+
+   - a "Testing" / "Validation" / "Test plan" section, or "how I verified it" narration;
+   - a templated What/Change/Scope/Testing heading scaffold, or empty boilerplate
+     headings (a `## Summary` that restates the title, a `## Changes` that just
+     lists the touched files) — markdown is fine when it makes the change clearer,
+     the problem is structure that carries no information a reviewer needs;
+   - checkboxes, emoji, self-credit ("written by …" / "Created by Claude"), or a
+     filler opener ("This PR…", "Summary of changes:");
+   - a body that buries what-the-change-does under boilerplate instead of leading
+     with it.
+
+   A terse, plain body for a small change is correct — do not flag mere brevity or
+   the absence of markdown. Flag only descriptions that read like a filled-in form
+   rather than a commit message.
 
 4. Launch 4 agents in parallel to independently review the changes. Each returns a list of issues; each issue includes a description and the reason it was flagged (e.g. "CLAUDE.md adherence", "bug").
 
@@ -84,12 +100,20 @@ Follow these steps precisely:
 8. Output a summary of the review findings to the terminal:
    - If issues were found, list each issue with a brief description.
    - If no issues were found, state: "No issues found. Checked for bugs and CLAUDE.md compliance."
+   - Separately, report any PR-description problems from step 3.
 
    If `--comment` argument was NOT provided, stop here. Do not post any GitHub comments.
 
-   If `--comment` argument IS provided and NO issues were found, post a summary comment using `gh pr comment` and stop.
+   If `--comment` IS provided and step 3 found PR-description problems, post **one**
+   top-level comment with `gh pr comment` (prefixed `🤖`, not inline) naming the
+   specific problems and the concrete fix (e.g. "drop the Testing section; lead
+   with what changed and why"). This is independent of the code review — post it
+   whether or not code issues were found, but skip it when the description is fine.
 
-   If `--comment` argument IS provided and issues were found, continue to step 9.
+   If `--comment` argument IS provided and NO code issues were found, post the
+   no-issues summary comment using `gh pr comment` and stop.
+
+   If `--comment` argument IS provided and code issues were found, continue to step 9.
 
 9. Draft the list of comments you plan to leave. For your own review only — do not post it anywhere.
 

--- a/.agents/skills/review-pr/SKILL.md
+++ b/.agents/skills/review-pr/SKILL.md
@@ -24,7 +24,7 @@ Follow these steps precisely:
    - The root CLAUDE.md and AGENTS.md files, if they exist
    - Any CLAUDE.md or AGENTS.md files in directories (and parent directories) containing files modified by the PR
 
-3. Launch a sonnet agent to view the PR and return a summary of the changes. The
+3. Launch an opus agent to view the PR and return a summary of the changes. The
    same agent also checks the PR *description* against the PR-body rules in
    `.agents/skills/commit/SKILL.md` §8 and returns any problems it finds:
 
@@ -44,7 +44,7 @@ Follow these steps precisely:
 
 4. Launch 4 agents in parallel to independently review the changes. Each returns a list of issues; each issue includes a description and the reason it was flagged (e.g. "CLAUDE.md adherence", "bug").
 
-   Agents 1 + 2: CLAUDE.md/AGENTS.md compliance sonnet agents. Audit changes for compliance. When evaluating a file, only consider CLAUDE.md/AGENTS.md files that share its path or are parents. If the PR adds or changes tests, read root `TESTING.md` plus the relevant module-specific testing docs, and check for low-value/slop tests or local testing-policy violations.
+   Agents 1 + 2: CLAUDE.md/AGENTS.md compliance opus agents. Audit changes for compliance. When evaluating a file, only consider CLAUDE.md/AGENTS.md files that share its path or are parents. If the PR adds or changes tests, read root `TESTING.md` plus the relevant module-specific testing docs, and check for low-value/slop tests or local testing-policy violations.
 
    Agents 3 + 4: Opus bug agents (parallel). Scan for obvious bugs, security issues, and incorrect logic within the changed code. Focus only on the diff without reading extra context. Flag only significant bugs you can validate from the diff alone; ignore nitpicks and likely false positives.
 
@@ -64,7 +64,7 @@ Follow these steps precisely:
 
    **Marin-specific:** In `experiments/grug`, duplication is often intentional for high-velocity research iteration. Do not flag copy/paste or DRY concerns if behavior/contracts are correct.
 
-5. For each issue from agents 3 and 4, launch a parallel subagent to validate it. Give the subagent the PR title, description, and issue description. It must confirm with high confidence that the issue is real — e.g. for "variable is not defined", verify that in the code; for a CLAUDE.md issue, verify the rule is scoped to this file and actually violated. Use Opus subagents for bugs/logic, sonnet for CLAUDE.md violations.
+5. For each issue from agents 3 and 4, launch a parallel subagent to validate it. Give the subagent the PR title, description, and issue description. It must confirm with high confidence that the issue is real — e.g. for "variable is not defined", verify that in the code; for a CLAUDE.md issue, verify the rule is scoped to this file and actually violated. Use Opus subagents throughout — for both bugs/logic and CLAUDE.md violations.
 
 6. Filter out any issues not validated in step 5. The remainder is the high-signal review list.
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,8 +1,11 @@
 <!-- See .agents/skills/commit/ for full PR guidelines. -->
 
-Describe what changed and why. Follow with bullets for
-specific changes if needed. Keep it concise — this text becomes the squash-merge
-commit message, so avoid markdown formatting (headers, tables, images).
+Lead with what the change does, then why — the problem it fixes or the reason
+it's shaped this way. This text becomes the squash-merge commit message, so write
+it like one: what a reviewer needs to understand and approve the change, nothing
+more. Most PRs are a paragraph or two with no headings. Add markdown (a short
+list, a table, a mermaid diagram) only when it makes the change clearer to a
+reviewer — not to fill in a template. No "Testing"/"Validation" section.
 
 e.g.
 

--- a/.github/workflows/ops-claude-review.yaml
+++ b/.github/workflows/ops-claude-review.yaml
@@ -10,7 +10,10 @@ concurrency:
 
 jobs:
   review:
-    # Runs on non-draft PRs opened/reopened/marked-ready by a writer.
+    # Runs on non-draft PRs opened/reopened/marked-ready by a writer. The
+    # correctness review (/review-pr) also scans the PR *description* against the
+    # commit skill's PR-body rules and flags template slop (Testing/Validation
+    # sections, empty boilerplate headings) as a single top-level comment.
     if: >-
       github.event.pull_request.draft == false &&
       (

--- a/.github/workflows/ops-claude.yaml
+++ b/.github/workflows/ops-claude.yaml
@@ -180,8 +180,11 @@ jobs:
             ## PR format (critical)
 
             When opening a PR, you MUST follow .agents/skills/commit/SKILL.md exactly.
-            PR descriptions are plain text — no markdown headers, no bullet lists, no emoji,
-            no "## Summary" or "## Test plan" sections. Violations will be rejected.
+            Write the description like a commit message: lead with what the change
+            does, then why. No "Testing"/"Validation" section, no empty boilerplate
+            headings, no emoji, no self-credit. Markdown (a short list, a table, a
+            mermaid diagram) is fine only when it makes the change clearer to a
+            reviewer. Violations will be rejected.
 
             Always produce output — either a PR or an analysis comment. Never silently exit.
           claude_args: |

--- a/docs/dev-guide/contributing.md
+++ b/docs/dev-guide/contributing.md
@@ -60,7 +60,7 @@ Before opening a pull request:
 3. If your change adds, removes, renames, or rewires docs pages or docs-owned links, run `uv run python infra/check_docs_source_links.py`.
 4. If your change is docs-heavy, run `uv run mkdocs build --strict`.
 5. If your change adds or rewrites substantial prose, do a final prose-only review using `./.agents/skills/writing-style/SKILL.md`. Remove generic significance framing, stock AI-writing templates, and polished filler that does not add information.
-6. Keep the PR description concise and plain text because it becomes the squash-merge commit message. The `.github/PULL_REQUEST_TEMPLATE.md` file shows the expected style.
+6. Write the PR description like a commit message — it becomes the squash-merge commit message: lead with what the change does, then why, and keep it to what a reviewer needs. The `.github/PULL_REQUEST_TEMPLATE.md` file shows the expected style.
 7. Make sure the PR body references an issue with `Fixes #NNNN` or `Part of #NNNN`.
 8. After pushing, verify the relevant GitHub CI checks pass before considering the PR ready for review.
 


### PR DESCRIPTION
Agents have been producing template-heavy PR descriptions — a
What/Change/Scope/Testing scaffold with a "Testing" section on every PR — instead
of a concise account of the change. Retune the rules so the body leads with what
the change does and why, includes only what a reviewer needs, and reaches for
markdown or a mermaid diagram only when it makes the change clearer.

The PR-body rules were duplicated across five surfaces that had drifted (the PR
template and the autonomous bot's prompt both forbade markdown outright). This
aligns all of them — the commit skill (canonical), the PR template, the
ops-claude.yaml bot prompt, and the contributing guide — on the same policy.

It also teaches the Claude review workflow to police descriptions: the review-pr
skill now scans the PR description against these rules and, when run with
--comment, posts one top-level comment flagging template slop (Testing sections,
empty boilerplate headings) with the concrete fix. A terse, plain body for a
small change is correct and is not flagged.