### PR TITLE
Add virtual-hosted S3 addressing for path-style-rejecting endpoints (CoreWeave cwobject)

### DIFF
--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -38,6 +38,11 @@ def _format_gib(num_bytes: int) -> str:
     return f"{num_bytes / (1024**3):.2f}GiB"
 
 
+def _env_flag(name: str) -> bool:
+    """Return True if the named environment variable is set to a truthy value."""
+    return os.environ.get(name, "").strip().lower() in ("1", "true", "yes")
+
+
 def _estimate_array_nbytes(array: Any) -> int:
     size = getattr(array, "size", None)
     dtype = getattr(array, "dtype", None)
@@ -56,10 +61,26 @@ def build_kvstore_spec(path: str) -> dict:
     """
     parsed = urllib.parse.urlparse(path)
     if parsed.scheme == "s3":
-        spec: dict = {"driver": "s3", "bucket": parsed.netloc, "path": parsed.path.lstrip("/")}
+        bucket = parsed.netloc
+        spec: dict = {"driver": "s3", "bucket": bucket, "path": parsed.path.lstrip("/")}
         endpoint = os.environ.get("AWS_ENDPOINT_URL")
         if endpoint:
-            spec["endpoint"] = endpoint
+            if _env_flag("LEVANTER_S3_VIRTUAL_HOSTED"):
+                # Virtual-hosted addressing for S3-compatible providers (e.g. CoreWeave
+                # "cwobject") that REJECT path-style requests with
+                # "PathStyleRequestNotAllowed". By default tensorstore's s3 driver uses
+                # path-style addressing for a custom endpoint, i.e. it issues requests to
+                # ``{endpoint}/{bucket}/{key}``. Virtual-hosted addressing instead folds the
+                # bucket into the endpoint host as a subdomain (``{scheme}://{bucket}.{host}``)
+                # and uses an empty ``bucket`` field. NOTE: an empty bucket combined with a
+                # custom endpoint requires tensorstore>=0.1.84 (google/tensorstore PR #285).
+                ep = urllib.parse.urlparse(endpoint)
+                host = ep.netloc or ep.path  # tolerate endpoints given without a scheme
+                scheme = ep.scheme or "https"
+                spec["bucket"] = ""
+                spec["endpoint"] = f"{scheme}://{bucket}.{host}"
+            else:
+                spec["endpoint"] = endpoint
         region = os.environ.get("AWS_DEFAULT_REGION") or os.environ.get("AWS_REGION")
         if region:
             spec["aws_region"] = region

--- a/lib/levanter/tests/test_tensorstore_serialization.py
+++ b/lib/levanter/tests/test_tensorstore_serialization.py
@@ -17,7 +17,11 @@ from jax.sharding import PartitionSpec as P
 from test_utils import MLP, arrays_only, assert_trees_not_close, use_test_mesh
 
 from levanter.models.gpt2 import Gpt2Mlp
-from levanter.tensorstore_serialization import tree_deserialize_leaves_tensorstore, tree_serialize_leaves_tensorstore
+from levanter.tensorstore_serialization import (
+    build_kvstore_spec,
+    tree_deserialize_leaves_tensorstore,
+    tree_serialize_leaves_tensorstore,
+)
 
 
 def test_tensorstore_checkpoint_simple():
@@ -194,3 +198,62 @@ def test_tensorstore_ok_with_missing():
             m3 = tree_deserialize_leaves_tensorstore(tmpdir, m2, allow_missing=True)
             assert hax.all(m3.a == hax.full(A, 4))
             assert hax.all(m3.b == hax.zeros(A))
+
+
+@pytest.fixture
+def _clean_s3_env(monkeypatch):
+    """Start each S3 spec test from a known environment."""
+    for name in (
+        "AWS_ENDPOINT_URL",
+        "AWS_DEFAULT_REGION",
+        "AWS_REGION",
+        "AWS_ACCESS_KEY_ID",
+        "AWS_SECRET_ACCESS_KEY",
+        "LEVANTER_S3_VIRTUAL_HOSTED",
+    ):
+        monkeypatch.delenv(name, raising=False)
+    return monkeypatch
+
+
+def test_build_kvstore_spec_s3_path_style_default(_clean_s3_env):
+    # Without the virtual-hosted flag, a custom endpoint is passed through unchanged
+    # (path-style addressing), preserving the bucket name. This is the default that keeps
+    # path-style providers like Cloudflare R2 working.
+    _clean_s3_env.setenv("AWS_ENDPOINT_URL", "https://cwobject.com")
+
+    spec = build_kvstore_spec("s3://my-bucket/checkpoints/step-100")
+    assert spec["driver"] == "s3"
+    assert spec["bucket"] == "my-bucket"
+    assert spec["path"] == "checkpoints/step-100"
+    assert spec["endpoint"] == "https://cwobject.com"
+    assert spec["aws_region"] == "us-east-1"
+    assert "aws_credentials" not in spec
+
+
+def test_build_kvstore_spec_s3_virtual_hosted(_clean_s3_env):
+    # With the flag set, the bucket is folded into the endpoint host as a subdomain and the
+    # bucket field is emptied, producing the virtual-hosted spec CoreWeave cwobject requires.
+    _clean_s3_env.setenv("AWS_ENDPOINT_URL", "https://cwobject.com")
+    _clean_s3_env.setenv("LEVANTER_S3_VIRTUAL_HOSTED", "1")
+    _clean_s3_env.setenv("AWS_ACCESS_KEY_ID", "key")
+    _clean_s3_env.setenv("AWS_SECRET_ACCESS_KEY", "secret")
+
+    spec = build_kvstore_spec("s3://marin-us-east-02a/checkpoints/step-100")
+    assert spec == {
+        "driver": "s3",
+        "bucket": "",
+        "path": "checkpoints/step-100",
+        "endpoint": "https://marin-us-east-02a.cwobject.com",
+        "aws_region": "us-east-1",
+        "aws_credentials": {"type": "environment"},
+    }
+
+
+def test_build_kvstore_spec_virtual_hosted_noop_without_endpoint(_clean_s3_env):
+    # The flag only takes effect when a custom endpoint is configured; without one it is a
+    # no-op and ordinary AWS S3 (default path/virtual handling) is left untouched.
+    _clean_s3_env.setenv("LEVANTER_S3_VIRTUAL_HOSTED", "true")
+
+    spec = build_kvstore_spec("s3://my-bucket/checkpoints/step-100")
+    assert spec["bucket"] == "my-bucket"
+    assert "endpoint" not in spec


### PR DESCRIPTION
## Motivation

levanter's tensorstore checkpoint kvstore builder (`build_kvstore_spec`) configures the `s3` driver with a custom `AWS_ENDPOINT_URL` to support S3-compatible object stores. tensorstore's `s3` driver, however, uses **path-style** addressing for a custom endpoint, i.e. it issues requests to `{endpoint}/{bucket}/{key}`.

Some S3-compatible providers reject path-style requests. In particular **CoreWeave "cwobject"** returns `PathStyleRequestNotAllowed` and requires **virtual-hosted** addressing, where the bucket is a subdomain of the endpoint host (`https://{bucket}.{host}/{key}`). This currently makes it impossible for levanter to read/write checkpoints on cwobject.

## Change

Add virtual-hosted addressing support, gated behind a new environment variable `LEVANTER_S3_VIRTUAL_HOSTED` (accepts `1`/`true`/`yes`, case-insensitive):

- When the flag is set **and** a custom `AWS_ENDPOINT_URL` is present, emit an **empty** `bucket` field and fold the bucket name into the endpoint host as a subdomain: `endpoint = f"{scheme}://{bucket}.{endpoint_host}"`.
- Region and credential handling are unchanged (region from `AWS_DEFAULT_REGION`/`AWS_REGION` else `us-east-1`; `aws_credentials: {type: environment}` when keys are present).
- The `gs` / `file` / unsupported-scheme branches are untouched.

**Backwards compatible:** the flag defaults off, so existing path-style users (e.g. Cloudflare R2) get the exact same spec as before. The new code path only runs when the flag is explicitly enabled.

### Verified spec

With `AWS_ENDPOINT_URL=https://cwobject.com`, `LEVANTER_S3_VIRTUAL_HOSTED=1`, and bucket `marin-us-east-02a`, `build_kvstore_spec("s3://marin-us-east-02a/<key>")` produces:

```json
{"driver":"s3","bucket":"","path":"<key>","endpoint":"https://marin-us-east-02a.cwobject.com","aws_region":"us-east-1","aws_credentials":{"type":"environment"}}
```

This spec was verified end-to-end to read cwobject and decode correct llama3 tokens.

## Requirement: tensorstore >= 0.1.84

An empty `bucket` combined with a custom `endpoint` requires **tensorstore >= 0.1.84** ([google/tensorstore PR #285](https://github.com/google/tensorstore/pull/285), merged 2026-02-27). Note `lib/levanter/pyproject.toml` currently pins `tensorstore>=0.1.73,<0.1.82` (upper bound added for Dependabot security fixes in #4410); that cap must be raised before this feature can be exercised. The pin is intentionally left unchanged here to avoid re-opening the security-motivated bound in this PR — it can be bumped in a follow-up once compatibility is validated.

## Tests

Added unit tests in `lib/levanter/tests/test_tensorstore_serialization.py` covering: default path-style pass-through, the virtual-hosted spec shape, and the no-op-without-endpoint case. All pass locally (`pytest -k build_kvstore_spec` → 3 passed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)