### PR TITLE
Add jaxtyping axis annotations to EP MoE helpers

### DIFF
--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -11,7 +11,7 @@ import jax
 import jax.numpy as jnp
 from haliax.jax_utils import named_call
 from jax.sharding import PartitionSpec as P
-from jaxtyping import Array, Float, Int
+from jaxtyping import Array, Float, Int, Key
 
 from levanter.utils.activation import ActivationFunctionEnum
 
@@ -80,8 +80,8 @@ def resolve_moe_implementation(implementation: MoeImplementation | str | None) -
 
 
 def split_moe_w13_output(
-    w13_out: jax.Array, *, intermediate_dim: int, interleaved: bool
-) -> tuple[jax.Array, jax.Array]:
+    w13_out: Float[Array, "... I2"], *, intermediate_dim: int, interleaved: bool
+) -> tuple[Float[Array, "... I"], Float[Array, "... I"]]:
     expected = 2 * intermediate_dim
     if w13_out.shape[-1] != expected:
         raise ValueError(f"w13 output last dimension must be {expected}, got shape={w13_out.shape}")
@@ -91,19 +91,19 @@ def split_moe_w13_output(
     return gate, up
 
 
-def _init_weight(key: jax.Array, shape: tuple[int, ...], std: float) -> Float[Array, "..."]:
+def _init_weight(key: Key[Array, ""], shape: tuple[int, ...], std: float) -> Float[Array, "..."]:
     return std * jax.random.truncated_normal(key, -3, 3, shape)
 
 
 @named_call
 def _prepare_moe_dispatch(
-    x: Float[Array, "T D"],
+    x: Float[Array, "T H"],
     selected_experts: Int[Array, "T K"],
     combine_weights: Float[Array, "T K"],
     *,
     num_experts: int,
 ) -> tuple[
-    Float[Array, "TK D"],
+    Float[Array, "TK H"],
     Float[Array, "TK"],
     Int[Array, "TK"],
     Int[Array, "E"],

--- a/lib/levanter/src/levanter/grug/_moe/ep_common.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_common.py
@@ -50,7 +50,7 @@ def _permute_by_global_expert(
     selected_experts_local: Int[Array, "Tlocal K"],
     *,
     num_experts: int,
-) -> tuple[Float[Array, "Tlocal K H"], Int[Array, "Tlocal K"], Int[Array, "E"]]:
+) -> tuple[Float[Array, "TK H"], Int[Array, "TK"], Int[Array, "E"]]:
     topk = selected_experts_local.shape[1]
     flat_selected = selected_experts_local.reshape(-1)
     sorted_indices = jnp.argsort(flat_selected)
@@ -61,8 +61,8 @@ def _permute_by_global_expert(
 
 
 def _unpermute_from_global_expert(
-    intermediate: Float[Array, "T K H"],
-    sorted_indices: Int[Array, "T K"],
+    intermediate: Float[Array, "TK H"],
+    sorted_indices: Int[Array, "TK"],
     combine_weights_local: Float[Array, "Tlocal K"],
     *,
     tokens_per_shard: int,

--- a/lib/levanter/src/levanter/grug/_moe/ep_common.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_common.py
@@ -8,26 +8,28 @@ import jax.numpy as jnp
 from jaxtyping import Array, Bool, Float, Int
 
 
-def _sort_activations(inputs: Float[Array, "T *"], sort_indices: Int[Array, "T"]) -> Float[Array, "T *"]:
+def _sort_activations(inputs: Float[Array, "N *tail"], sort_indices: Int[Array, "N"]) -> Float[Array, "N *tail"]:
     if inputs.shape[0] != sort_indices.shape[0]:
         raise ValueError(f"Expected matching leading dims, got {inputs.shape[0]} and {sort_indices.shape[0]}")
     return _sort_activations_custom(inputs, sort_indices)
 
 
 @jax.custom_vjp
-def _sort_activations_custom(inputs: Float[Array, "T *"], sort_indices: Int[Array, "T"]) -> Float[Array, "T *"]:
+def _sort_activations_custom(
+    inputs: Float[Array, "N *tail"], sort_indices: Int[Array, "N"]
+) -> Float[Array, "N *tail"]:
     return inputs[sort_indices, ...]
 
 
 def _sort_activations_custom_fwd(
-    inputs: Float[Array, "T *"], sort_indices: Int[Array, "T"]
-) -> tuple[Float[Array, "T *"], Int[Array, "T"]]:
+    inputs: Float[Array, "N *tail"], sort_indices: Int[Array, "N"]
+) -> tuple[Float[Array, "N *tail"], Int[Array, "N"]]:
     return _sort_activations_custom(inputs, sort_indices), sort_indices
 
 
 def _sort_activations_custom_bwd(
-    residuals: Int[Array, "T"], grads: Float[Array, "T *"]
-) -> tuple[Float[Array, "T *"], None]:
+    residuals: Int[Array, "N"], grads: Float[Array, "N *tail"]
+) -> tuple[Float[Array, "N *tail"], None]:
     sort_indices = residuals
     return _sort_activations_custom(grads, jnp.argsort(sort_indices)), None
 
@@ -76,9 +78,9 @@ def _unpermute_from_global_expert(
 
 
 def _shard_a2a_params(
-    shard_counts: Int[Array, "S E"],
+    shard_counts: Int[Array, "S S"],
     shard_id: Int[Array, ""],
-) -> tuple[Int[Array, "E"], Int[Array, "E"], Int[Array, "E"], Int[Array, "S"]]:
+) -> tuple[Int[Array, "S"], Int[Array, "S"], Int[Array, "S"], Int[Array, "S"]]:
     row = shard_counts[shard_id]
     input_offsets = jnp.cumsum(jnp.concatenate((jnp.array([0], dtype=row.dtype), row[:-1])))
     send_sizes = row
@@ -94,12 +96,12 @@ def _shard_a2a_params(
 
 
 def _local_permute_from_counts(
-    inputs: Float[Array, "TK H"],
+    inputs: Float[Array, "C H"],
     global_group_sizes: Int[Array, "S E"],
     *,
     local_expert_size: int,
     shard_index: Int[Array, ""],
-) -> tuple[Float[Array, "TK H"], Int[Array, "TK"], Int[Array, "Elocal"]]:
+) -> tuple[Float[Array, "C H"], Int[Array, "C"], Int[Array, "Elocal"]]:
     all_shard_local_sizes = jax.lax.dynamic_slice_in_dim(
         global_group_sizes,
         start_index=shard_index * local_expert_size,
@@ -159,7 +161,7 @@ def _expert_prefix_keep_mask(
     accepted_group_sizes: Int[Array, "E"],
     *,
     total_size: int,
-) -> Bool[Array, "T"]:
+) -> Bool[Array, "TK"]:
     segment_ends = jnp.cumsum(group_sizes, dtype=jnp.int32)
     segment_starts = jnp.concatenate((jnp.array([0], dtype=segment_ends.dtype), segment_ends[:-1]))
     positions = jnp.arange(total_size, dtype=jnp.int32)
@@ -173,7 +175,7 @@ def _expert_prefix_keep_mask(
     return local_rank < accepted
 
 
-def _compact_by_keep_mask(inputs: Float[Array, "T *"], keep_mask: Bool[Array, "T"]) -> Float[Array, "T *"]:
+def _compact_by_keep_mask(inputs: Float[Array, "N *tail"], keep_mask: Bool[Array, "N"]) -> Float[Array, "N *tail"]:
     total_size = inputs.shape[0]
     positions = jnp.arange(total_size, dtype=jnp.int32)
     sort_key = jnp.where(keep_mask, positions, positions + total_size)
@@ -182,7 +184,7 @@ def _compact_by_keep_mask(inputs: Float[Array, "T *"], keep_mask: Bool[Array, "T
     return jnp.where(valid[:, None], compacted, 0)
 
 
-def _expand_from_keep_mask(compacted: Float[Array, "T *"], keep_mask: Bool[Array, "T"]) -> Float[Array, "T *"]:
+def _expand_from_keep_mask(compacted: Float[Array, "N *tail"], keep_mask: Bool[Array, "N"]) -> Float[Array, "N *tail"]:
     keep_i32 = keep_mask.astype(jnp.int32)
     compact_index = jnp.cumsum(keep_i32, dtype=jnp.int32) - 1
     gathered = jnp.take(compacted, jnp.maximum(compact_index, 0), axis=0)

--- a/lib/levanter/src/levanter/grug/_moe/ep_common.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_common.py
@@ -5,25 +5,29 @@
 
 import jax
 import jax.numpy as jnp
-from jaxtyping import Array, Bool, Int
+from jaxtyping import Array, Bool, Float, Int
 
 
-def _sort_activations(inputs: jax.Array, sort_indices: jax.Array) -> jax.Array:
+def _sort_activations(inputs: Float[Array, "T *"], sort_indices: Int[Array, "T"]) -> Float[Array, "T *"]:
     if inputs.shape[0] != sort_indices.shape[0]:
         raise ValueError(f"Expected matching leading dims, got {inputs.shape[0]} and {sort_indices.shape[0]}")
     return _sort_activations_custom(inputs, sort_indices)
 
 
 @jax.custom_vjp
-def _sort_activations_custom(inputs: jax.Array, sort_indices: jax.Array) -> jax.Array:
+def _sort_activations_custom(inputs: Float[Array, "T *"], sort_indices: Int[Array, "T"]) -> Float[Array, "T *"]:
     return inputs[sort_indices, ...]
 
 
-def _sort_activations_custom_fwd(inputs: jax.Array, sort_indices: jax.Array) -> tuple[jax.Array, jax.Array]:
+def _sort_activations_custom_fwd(
+    inputs: Float[Array, "T *"], sort_indices: Int[Array, "T"]
+) -> tuple[Float[Array, "T *"], Int[Array, "T"]]:
     return _sort_activations_custom(inputs, sort_indices), sort_indices
 
 
-def _sort_activations_custom_bwd(residuals: jax.Array, grads: jax.Array) -> tuple[jax.Array, None]:
+def _sort_activations_custom_bwd(
+    residuals: Int[Array, "T"], grads: Float[Array, "T *"]
+) -> tuple[Float[Array, "T *"], None]:
     sort_indices = residuals
     return _sort_activations_custom(grads, jnp.argsort(sort_indices)), None
 
@@ -42,11 +46,11 @@ def _prefix_cap_counts(counts: Int[Array, "E"], *, capacity: int) -> Int[Array, 
 
 
 def _permute_by_global_expert(
-    x_local: jax.Array,
-    selected_experts_local: jax.Array,
+    x_local: Float[Array, "Tlocal H"],
+    selected_experts_local: Int[Array, "Tlocal K"],
     *,
     num_experts: int,
-) -> tuple[jax.Array, jax.Array, jax.Array]:
+) -> tuple[Float[Array, "Tlocal K H"], Int[Array, "Tlocal K"], Int[Array, "E"]]:
     topk = selected_experts_local.shape[1]
     flat_selected = selected_experts_local.reshape(-1)
     sorted_indices = jnp.argsort(flat_selected)
@@ -57,13 +61,13 @@ def _permute_by_global_expert(
 
 
 def _unpermute_from_global_expert(
-    intermediate: jax.Array,
-    sorted_indices: jax.Array,
-    combine_weights_local: jax.Array,
+    intermediate: Float[Array, "T K H"],
+    sorted_indices: Int[Array, "T K"],
+    combine_weights_local: Float[Array, "Tlocal K"],
     *,
     tokens_per_shard: int,
     topk: int,
-) -> jax.Array:
+) -> Float[Array, "Tlocal H"]:
     unsorted = _sort_activations(intermediate, jnp.argsort(sorted_indices))
     reshaped = unsorted.reshape(tokens_per_shard, topk, -1)
     return jnp.einsum(
@@ -72,9 +76,9 @@ def _unpermute_from_global_expert(
 
 
 def _shard_a2a_params(
-    shard_counts: jax.Array,
-    shard_id: jax.Array,
-) -> tuple[jax.Array, jax.Array, jax.Array, jax.Array]:
+    shard_counts: Int[Array, "S E"],
+    shard_id: Int[Array, ""],
+) -> tuple[Int[Array, "E"], Int[Array, "E"], Int[Array, "E"], Int[Array, "S"]]:
     row = shard_counts[shard_id]
     input_offsets = jnp.cumsum(jnp.concatenate((jnp.array([0], dtype=row.dtype), row[:-1])))
     send_sizes = row
@@ -90,12 +94,12 @@ def _shard_a2a_params(
 
 
 def _local_permute_from_counts(
-    inputs: jax.Array,
-    global_group_sizes: jax.Array,
+    inputs: Float[Array, "TK H"],
+    global_group_sizes: Int[Array, "S E"],
     *,
     local_expert_size: int,
-    shard_index: jax.Array,
-) -> tuple[jax.Array, jax.Array, jax.Array]:
+    shard_index: Int[Array, ""],
+) -> tuple[Float[Array, "TK H"], Int[Array, "TK"], Int[Array, "Elocal"]]:
     all_shard_local_sizes = jax.lax.dynamic_slice_in_dim(
         global_group_sizes,
         start_index=shard_index * local_expert_size,
@@ -169,7 +173,7 @@ def _expert_prefix_keep_mask(
     return local_rank < accepted
 
 
-def _compact_by_keep_mask(inputs: jax.Array, keep_mask: Bool[Array, "T"]) -> jax.Array:
+def _compact_by_keep_mask(inputs: Float[Array, "T *"], keep_mask: Bool[Array, "T"]) -> Float[Array, "T *"]:
     total_size = inputs.shape[0]
     positions = jnp.arange(total_size, dtype=jnp.int32)
     sort_key = jnp.where(keep_mask, positions, positions + total_size)
@@ -178,7 +182,7 @@ def _compact_by_keep_mask(inputs: jax.Array, keep_mask: Bool[Array, "T"]) -> jax
     return jnp.where(valid[:, None], compacted, 0)
 
 
-def _expand_from_keep_mask(compacted: jax.Array, keep_mask: Bool[Array, "T"]) -> jax.Array:
+def _expand_from_keep_mask(compacted: Float[Array, "T *"], keep_mask: Bool[Array, "T"]) -> Float[Array, "T *"]:
     keep_i32 = keep_mask.astype(jnp.int32)
     compact_index = jnp.cumsum(keep_i32, dtype=jnp.int32) - 1
     gathered = jnp.take(compacted, jnp.maximum(compact_index, 0), axis=0)

--- a/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
@@ -34,16 +34,16 @@ class DeepEPLocalAssignments(NamedTuple):
         local_group_sizes: Assignment counts per local expert for `ragged_dot`.
     """
 
-    x_dispatch: Float[Array, "TK D"]
+    x_dispatch: Float[Array, "TK H"]
     assignment_weights: Float[Array, "TK"]
     recv_token_indices: Int[Array, "TK"]
-    local_group_sizes: Int[Array, "EL"]
+    local_group_sizes: Int[Array, "Elocal"]
 
 
 def _pack_deepep_local_assignments(
-    recv_x: Float[Array, "TR D"],
-    recv_topk_idx: Int[Array, "TR K"],
-    recv_topk_weights: Float[Array, "TR K"],
+    recv_x: Float[Array, "Trecv H"],
+    recv_topk_idx: Int[Array, "Trecv K"],
+    recv_topk_weights: Float[Array, "Trecv K"],
     *,
     local_experts: int,
     num_recv_tokens: Int[Array, ""],
@@ -79,13 +79,13 @@ def _pack_deepep_local_assignments(
 
 
 def _collapse_deepep_local_assignments(
-    out_dispatch: Float[Array, "TK D"],
+    out_dispatch: Float[Array, "TK H"],
     assignment_weights: Float[Array, "TK"],
     recv_token_indices: Int[Array, "TK"],
     *,
     recv_capacity: int,
     num_recv_tokens: Int[Array, ""],
-) -> Float[Array, "TR D"]:
+) -> Float[Array, "Trecv H"]:
     with jax.named_scope("deepep_collapse_local_assignments"):
         recv_out = jax.ops.segment_sum(
             out_dispatch * assignment_weights[:, None],
@@ -98,16 +98,16 @@ def _collapse_deepep_local_assignments(
 
 
 def _moe_mlp_ep_deepep_local(
-    x_local: Float[Array, "TL D"],
-    selected_experts_local: Int[Array, "TL K"],
-    combine_weights_local: Float[Array, "TL K"],
-    moe_w13_local: Float[Array, "EL D I2"],
-    moe_w2_local: Float[Array, "EL I D"],
+    x_local: Float[Array, "Tlocal H"],
+    selected_experts_local: Int[Array, "Tlocal K"],
+    combine_weights_local: Float[Array, "Tlocal K"],
+    moe_w13_local: Float[Array, "Elocal H I2"],
+    moe_w2_local: Float[Array, "Elocal I H"],
     *,
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
     capacity_factor: float,
-) -> tuple[Float[Array, "TL D"], Int[Array, ""]]:
+) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
     """DeepEP dispatch/combine path for an intranode expert mesh."""
     del capacity_factor
     local_experts = moe_w13_local.shape[0]

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -8,6 +8,7 @@ from collections.abc import Callable
 
 import jax
 import jax.numpy as jnp
+from jaxtyping import Array, Float, Int
 
 from haliax.nn.ragged_dot import ragged_dot
 from levanter.grug._moe.ep_common import (
@@ -25,16 +26,16 @@ from levanter.grug.sharding import _batch_axes
 
 
 def _moe_mlp_ep_ragged_a2a_local(
-    x_local: jax.Array,
-    selected_experts_local: jax.Array,
-    combine_weights_local: jax.Array,
-    moe_w13_local: jax.Array,
-    moe_w2_local: jax.Array,
+    x_local: Float[Array, "Tlocal H"],
+    selected_experts_local: Int[Array, "Tlocal K"],
+    combine_weights_local: Float[Array, "Tlocal K"],
+    moe_w13_local: Float[Array, "Elocal H I2"],
+    moe_w2_local: Float[Array, "Elocal I H"],
     *,
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
     capacity_factor: float,
-) -> tuple[jax.Array, jax.Array]:
+) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
     local_experts = moe_w13_local.shape[0]
     if num_experts % local_experts != 0:
         raise ValueError(

--- a/lib/levanter/src/levanter/grug/_moe/ep_ring.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ring.py
@@ -22,16 +22,16 @@ from levanter.grug.sharding import _batch_axes
 
 
 def _moe_mlp_ep_ring_local(
-    x_local: Float[Array, "TL D"],
-    selected_experts_local: Int[Array, "TL K"],
-    combine_weights_local: Float[Array, "TL K"],
-    moe_w13_local: Float[Array, "EL D I2"],
-    moe_w2_local: Float[Array, "EL I D"],
+    x_local: Float[Array, "Tlocal H"],
+    selected_experts_local: Int[Array, "Tlocal K"],
+    combine_weights_local: Float[Array, "Tlocal K"],
+    moe_w13_local: Float[Array, "Elocal H I2"],
+    moe_w2_local: Float[Array, "Elocal I H"],
     *,
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
     capacity_factor: float,
-) -> tuple[Float[Array, "TL D"], Int[Array, ""]]:
+) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
     """Ring-style EP routed path: all-gather dispatch + psum-scatter collect."""
     # #2710 ring EP strategy: gather tokens and their selected-expert routing
     # assignments across expert shards, then psum-scatter back to local tokens.

--- a/lib/levanter/src/levanter/grug/_moe/local.py
+++ b/lib/levanter/src/levanter/grug/_moe/local.py
@@ -19,16 +19,16 @@ _MOE_LOCAL_FNS = {
 
 
 def _moe_mlp_local(
-    x: Float[Array, "T D"],
+    x: Float[Array, "T H"],
     selected_experts: Int[Array, "T K"],
     combine_weights: Float[Array, "T K"],
-    moe_w13: Float[Array, "E D I2"],
-    moe_w2: Float[Array, "E I D"],
+    moe_w13: Float[Array, "E H I2"],
+    moe_w2: Float[Array, "E I H"],
     *,
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
     implementation: MoeImplementation,
-) -> tuple[Float[Array, "T D"], Int[Array, ""]]:
+) -> tuple[Float[Array, "T H"], Int[Array, ""]]:
     local_key = implementation if implementation in _LOCAL_MOE_IMPLEMENTATIONS else "scatter"
     return _MOE_LOCAL_FNS[local_key](
         x,

--- a/lib/levanter/src/levanter/grug/_moe/scatter.py
+++ b/lib/levanter/src/levanter/grug/_moe/scatter.py
@@ -22,15 +22,15 @@ from levanter.grug._moe.common import (
 
 
 def _moe_mlp_local_scatter(
-    x: Float[Array, "T D"],
+    x: Float[Array, "T H"],
     selected_experts: Int[Array, "T K"],
     combine_weights: Float[Array, "T K"],
-    moe_w13: Float[Array, "E D I2"],
-    moe_w2: Float[Array, "E I D"],
+    moe_w13: Float[Array, "E H I2"],
+    moe_w2: Float[Array, "E I H"],
     *,
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
-) -> tuple[Float[Array, "T D"], Int[Array, ""]]:
+) -> tuple[Float[Array, "T H"], Int[Array, ""]]:
     """Local fallback MoE path: sorted grouped GMM then scatter-add combine."""
     x_dispatch, w_dispatch, token_dispatch, group_sizes = _prepare_moe_dispatch(
         x,

--- a/lib/levanter/src/levanter/grug/_moe/sonic.py
+++ b/lib/levanter/src/levanter/grug/_moe/sonic.py
@@ -166,7 +166,7 @@ def _sonic_kernel_config(hidden_dim: int) -> tuple[int, int, int]:
     return block_h, block_k, num_warps
 
 
-def _sonic_fixed_k_offsets(*, tokens: int, topk: int) -> Int[Array, "T+1"]:
+def _sonic_fixed_k_offsets(*, tokens: int, topk: int) -> Int[Array, "Tp1"]:
     return jnp.arange(0, tokens * topk + 1, topk, dtype=jnp.int32)
 
 
@@ -174,7 +174,7 @@ def _sonic_gather_sum_impl(
     dispatch_output: Float[Array, "M H"],
     weights_flat: Float[Array, "M"],
     positions_flat: Int[Array, "M"],
-    offsets: Int[Array, "T+1"],
+    offsets: Int[Array, "Tp1"],
     *,
     tokens: int,
     topk: int,
@@ -212,7 +212,7 @@ def _sonic_gather_sum_bwd_impl(
     dispatch_output: Float[Array, "M H"],
     weights_flat: Float[Array, "M"],
     positions_flat: Int[Array, "M"],
-    offsets: Int[Array, "T+1"],
+    offsets: Int[Array, "Tp1"],
     *,
     tokens: int,
     topk: int,
@@ -310,15 +310,15 @@ sonic_gather_sum.defvjp(_sonic_gather_sum_fwd, _sonic_gather_sum_bwd)
 
 
 def _moe_mlp_local_sonic(
-    x: Float[Array, "T D"],
+    x: Float[Array, "T H"],
     selected_experts: Int[Array, "T K"],
     combine_weights: Float[Array, "T K"],
-    moe_w13: Float[Array, "E D I2"],
-    moe_w2: Float[Array, "E I D"],
+    moe_w13: Float[Array, "E H I2"],
+    moe_w2: Float[Array, "E I H"],
     *,
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
-) -> tuple[Float[Array, "T D"], Int[Array, ""]]:
+) -> tuple[Float[Array, "T H"], Int[Array, ""]]:
     """Local raw-Sonic path: JAX grouped GEMMs plus Sonic Triton gather/combine."""
     token_ids_sort, dispatch_positions, group_sizes, _sorted_assignment_ids = (
         _prepare_moe_dispatch_indices_with_assignment_ids(

--- a/lib/levanter/src/levanter/grug/_moe/sonic.py
+++ b/lib/levanter/src/levanter/grug/_moe/sonic.py
@@ -247,7 +247,7 @@ def _sonic_gather_sum_bwd_impl(
 @jax.custom_vjp
 def sonic_gather_sum(
     dispatch_output: Float[Array, "M H"],
-    dispatch_positions: Int[Array, "M"],
+    dispatch_positions: Int[Array, "T K"],
     combine_weights: Float[Array, "T K"],
 ) -> Float[Array, "T H"]:
     tokens, topk = combine_weights.shape
@@ -266,9 +266,9 @@ def sonic_gather_sum(
 
 def _sonic_gather_sum_fwd(
     dispatch_output: Float[Array, "M H"],
-    dispatch_positions: Int[Array, "M"],
+    dispatch_positions: Int[Array, "T K"],
     combine_weights: Float[Array, "T K"],
-) -> tuple[Float[Array, "T H"], tuple[Float[Array, "M H"], Int[Array, "M"], Float[Array, "T K"]]]:
+) -> tuple[Float[Array, "T H"], tuple[Float[Array, "M H"], Int[Array, "T K"], Float[Array, "T K"]]]:
     tokens, topk = combine_weights.shape
     weights_flat = combine_weights.reshape(tokens * topk).astype(jnp.float32)
     positions_flat = dispatch_positions.reshape(tokens * topk).astype(jnp.int32)
@@ -285,7 +285,7 @@ def _sonic_gather_sum_fwd(
 
 
 def _sonic_gather_sum_bwd(
-    residuals: tuple[Float[Array, "M H"], Int[Array, "M"], Float[Array, "T K"]],
+    residuals: tuple[Float[Array, "M H"], Int[Array, "T K"], Float[Array, "T K"]],
     dout: Float[Array, "T H"],
 ) -> tuple[Float[Array, "M H"], None, Float[Array, "T K"]]:
     dispatch_output, dispatch_positions, combine_weights = residuals

--- a/lib/levanter/src/levanter/grug/_moe/sonic.py
+++ b/lib/levanter/src/levanter/grug/_moe/sonic.py
@@ -166,7 +166,7 @@ def _sonic_kernel_config(hidden_dim: int) -> tuple[int, int, int]:
     return block_h, block_k, num_warps
 
 
-def _sonic_fixed_k_offsets(*, tokens: int, topk: int) -> Int[Array, "T"]:
+def _sonic_fixed_k_offsets(*, tokens: int, topk: int) -> Int[Array, "T+1"]:
     return jnp.arange(0, tokens * topk + 1, topk, dtype=jnp.int32)
 
 
@@ -174,7 +174,7 @@ def _sonic_gather_sum_impl(
     dispatch_output: Float[Array, "M H"],
     weights_flat: Float[Array, "M"],
     positions_flat: Int[Array, "M"],
-    offsets: Int[Array, "T"],
+    offsets: Int[Array, "T+1"],
     *,
     tokens: int,
     topk: int,
@@ -212,7 +212,7 @@ def _sonic_gather_sum_bwd_impl(
     dispatch_output: Float[Array, "M H"],
     weights_flat: Float[Array, "M"],
     positions_flat: Int[Array, "M"],
-    offsets: Int[Array, "T"],
+    offsets: Int[Array, "T+1"],
     *,
     tokens: int,
     topk: int,

--- a/lib/levanter/src/levanter/grug/_moe/sonic.py
+++ b/lib/levanter/src/levanter/grug/_moe/sonic.py
@@ -166,19 +166,19 @@ def _sonic_kernel_config(hidden_dim: int) -> tuple[int, int, int]:
     return block_h, block_k, num_warps
 
 
-def _sonic_fixed_k_offsets(*, tokens: int, topk: int) -> jax.Array:
+def _sonic_fixed_k_offsets(*, tokens: int, topk: int) -> Int[Array, "T"]:
     return jnp.arange(0, tokens * topk + 1, topk, dtype=jnp.int32)
 
 
 def _sonic_gather_sum_impl(
-    dispatch_output: jax.Array,
-    weights_flat: jax.Array,
-    positions_flat: jax.Array,
-    offsets: jax.Array,
+    dispatch_output: Float[Array, "M H"],
+    weights_flat: Float[Array, "M"],
+    positions_flat: Int[Array, "M"],
+    offsets: Int[Array, "T"],
     *,
     tokens: int,
     topk: int,
-) -> jax.Array:
+) -> Float[Array, "T H"]:
     _require_sonic_deps()
     hidden_dim = dispatch_output.shape[1]
     block_h, block_k, num_warps = _sonic_kernel_config(hidden_dim)
@@ -208,15 +208,15 @@ def _sonic_gather_sum_impl(
 
 
 def _sonic_gather_sum_bwd_impl(
-    dout: jax.Array,
-    dispatch_output: jax.Array,
-    weights_flat: jax.Array,
-    positions_flat: jax.Array,
-    offsets: jax.Array,
+    dout: Float[Array, "T H"],
+    dispatch_output: Float[Array, "M H"],
+    weights_flat: Float[Array, "M"],
+    positions_flat: Int[Array, "M"],
+    offsets: Int[Array, "T"],
     *,
     tokens: int,
     topk: int,
-) -> tuple[jax.Array, jax.Array]:
+) -> tuple[Float[Array, "M H"], Float[Array, "M"]]:
     _require_sonic_deps()
     hidden_dim = dispatch_output.shape[1]
     block_h, _block_k, num_warps = _sonic_kernel_config(hidden_dim)
@@ -246,10 +246,10 @@ def _sonic_gather_sum_bwd_impl(
 
 @jax.custom_vjp
 def sonic_gather_sum(
-    dispatch_output: jax.Array,
-    dispatch_positions: jax.Array,
-    combine_weights: jax.Array,
-) -> jax.Array:
+    dispatch_output: Float[Array, "M H"],
+    dispatch_positions: Int[Array, "M"],
+    combine_weights: Float[Array, "T K"],
+) -> Float[Array, "T H"]:
     tokens, topk = combine_weights.shape
     weights_flat = combine_weights.reshape(tokens * topk).astype(jnp.float32)
     positions_flat = dispatch_positions.reshape(tokens * topk).astype(jnp.int32)
@@ -265,10 +265,10 @@ def sonic_gather_sum(
 
 
 def _sonic_gather_sum_fwd(
-    dispatch_output: jax.Array,
-    dispatch_positions: jax.Array,
-    combine_weights: jax.Array,
-) -> tuple[jax.Array, tuple[jax.Array, jax.Array, jax.Array]]:
+    dispatch_output: Float[Array, "M H"],
+    dispatch_positions: Int[Array, "M"],
+    combine_weights: Float[Array, "T K"],
+) -> tuple[Float[Array, "T H"], tuple[Float[Array, "M H"], Int[Array, "M"], Float[Array, "T K"]]]:
     tokens, topk = combine_weights.shape
     weights_flat = combine_weights.reshape(tokens * topk).astype(jnp.float32)
     positions_flat = dispatch_positions.reshape(tokens * topk).astype(jnp.int32)
@@ -285,9 +285,9 @@ def _sonic_gather_sum_fwd(
 
 
 def _sonic_gather_sum_bwd(
-    residuals: tuple[jax.Array, jax.Array, jax.Array],
-    dout: jax.Array,
-) -> tuple[jax.Array, None, jax.Array]:
+    residuals: tuple[Float[Array, "M H"], Int[Array, "M"], Float[Array, "T K"]],
+    dout: Float[Array, "T H"],
+) -> tuple[Float[Array, "M H"], None, Float[Array, "T K"]]:
     dispatch_output, dispatch_positions, combine_weights = residuals
     tokens, topk = combine_weights.shape
     weights_flat = combine_weights.reshape(tokens * topk).astype(jnp.float32)


### PR DESCRIPTION
## Summary

- Add semantically meaningful jaxtyping axis names for expert-parallel MoE tensor args:
  - `T`, `Tlocal`, `H`, `K`, `E`, `Elocal`, `I", `I2" across EP ring/ragged helpers
  - Annotate remaining raw
  -`jax.Array` function arguments in EP siblings with `Float`, `Int`, and `Bool` shapes where applicable