### PR TITLE
Document post-merge fork promotion protocol

### DIFF
--- a/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
+++ b/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
@@ -45,6 +45,16 @@ titled `TPU-vLLM fork refresh blocked: <short reason>`, with current pins,
 selected release, branch names/SHAs if created, attempted fixes, remaining
 failure, artifacts, and the logs Gist.
 
+## Post-Merge Follow-Up
+
+This skill does not run post-merge fork-main promotion. A successful refresh run
+stops after opening the Marin PR; if blocked, it stops after filing or updating
+the blocker issue.
+
+After the Marin PR has merged and Marin `main` contains the new exact fork SHA
+pins, a separate operator may run the post-merge protocol in
+`docs/post-merge-protocol.md`.
+
 ## Workspace Setup
 
 - Marin working copy:

--- a/.agents/skills/refresh-tpu-vllm-forks/docs/post-merge-protocol.md
+++ b/.agents/skills/refresh-tpu-vllm-forks/docs/post-merge-protocol.md
@@ -1,13 +1,34 @@
-# Post fork changes merge protocol
+# Post-Marin-Merge Fork Main Promotion Protocol
 
-For clarity purposes, we want:
-- The head of the main branch of both `vllm` and `tpu-inference` forks should always point to
-the same commits as the ones pinned in Marin's `tool.uv.sources` section of the root `pyproject.toml`.
-- We want the fork commit history to be linear: A few custom commits overlayed on top of the upstream commits (i.e. no merge commits).
+Run this only after the Marin fork-refresh PR has merged and Marin `main`
+contains the new exact SHA pins for both forks. Do not run it while preparing,
+reviewing, or validating the Marin PR.
 
-Consequently, we must force push the tip of each fork, each time the main branch of the marin repo is updated to point to 
-different fork commits. Refer to `.agents/skills/refresh-tpu-vllm-forks/SKILL.md` for additional context.  
+The goal is cosmetic but useful: keep each fork's `main` branch pointing at the
+same commit Marin actually pins, so human readers see the active fork tip
+without opening Marin's root `pyproject.toml`.
 
-Here is the protocol (identical for both forks):
-- Backup the current head of the main branch into a branch called `main-backup/YYYYMMDD/SLUG`. Skip if already exists (for the same commit)
-- Make the main branch of the fork post to the same sha as pinned by the marin reqo. This requires a force push.
+For clarity, both `vllm` and `tpu-inference` fork `main` branches should point
+to the same commits pinned in Marin's root `tool.uv.sources`, and each fork
+should keep linear history: Marin overlay commits over upstream commits, with no
+merge commits.
+
+For each fork:
+
+- Read the target SHA from Marin `main` root `pyproject.toml`.
+- Fetch the fork and record current `origin/main`.
+- Verify the target SHA exists in that fork.
+- Create or verify `main-backup/YYYYMMDD/pre-<old-main-shortsha>`.
+- Update fork `main` with `--force-with-lease` from the old `origin/main` SHA
+  to the target SHA.
+- Verify remote `main` resolves to the target SHA.
+
+If the backup branch already exists and points to the old fork `main` SHA, reuse
+it. If it exists and points elsewhere, stop and inspect instead of guessing.
+
+If one fork promotion succeeds and the other fails, Marin remains correct
+because it pins exact SHAs. Do not roll back the successful fork automatically;
+record the mismatch and ask whether to retry the failed fork promotion. If the
+retry still fails, file a new `marin-community/marin` issue assigned to
+`@yonromai` with the pinned SHAs, promoted fork, failed fork, backup branches,
+commands attempted, and error output.

--- a/.agents/skills/refresh-tpu-vllm-forks/docs/post-merge-protocol.md
+++ b/.agents/skills/refresh-tpu-vllm-forks/docs/post-merge-protocol.md
@@ -1,0 +1,13 @@
+# Post fork changes merge protocol
+
+For clarity purposes, we want:
+- The head of the main branch of both `vllm` and `tpu-inference` forks should always point to
+the same commits as the ones pinned in Marin's `tool.uv.sources` section of the root `pyproject.toml`.
+- We want the fork commit history to be linear: A few custom commits overlayed on top of the upstream commits (i.e. no merge commits).
+
+Consequently, we must force push the tip of each fork, each time the main branch of the marin repo is updated to point to 
+different fork commits. Refer to `.agents/skills/refresh-tpu-vllm-forks/SKILL.md` for additional context.  
+
+Here is the protocol (identical for both forks):
+- Backup the current head of the main branch into a branch called `main-backup/YYYYMMDD/SLUG`. Skip if already exists (for the same commit)
+- Make the main branch of the fork post to the same sha as pinned by the marin reqo. This requires a force push.


### PR DESCRIPTION
## Summary

- Add a post-merge protocol document for promoting the Marin TPU-vLLM fork `main` branches after the Marin PR has merged.
- Link the protocol from the refresh skill while keeping the refresh skill's pre-merge boundary explicit.
- Capture compact safety gates for backup branches, `--force-with-lease`, post-push verification, and partial-promotion failure handling.

## Review Notes

This is intentionally split into two commits:

1. `Document post-merge fork promotion protocol` preserves the original prompt text.
2. `Clarify post-merge fork promotion protocol` applies the follow-up wording and safety clarifications.

## Validation

- `git commit --amend --no-edit` ran the repo hooks successfully on the final commit:
  - Large files
  - Merge conflicts
  - Trailing whitespace
  - End-of-file newline
  - Markdown pre-commit command
  - Skill metadata