### PR TITLE
[codex] Repin GrugMoE forks onto previous Marin baselines

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,10 +158,10 @@ nvidia-cutlass-dsl-libs-cu13 = { index = "nvidia" }
 # NOTE: harbor is a pinned git dependency (not a workspace member).
 # harbor lives in marin-community/harbor as a pinned git dependency.
 harbor = { git = "https://github.com/marin-community/harbor.git", rev = "354692d9c0eab497b05f266aa0dff30e2a238d2e" }
-# https://github.com/marin-community/vllm/compare/e6e3b6b10c1d44936306be3a67c709d763f89e48...7557e69ddb2e28b287d0729b4aee4d7de8de18f9
-vllm = { git = "https://github.com/marin-community/vllm.git", rev = "7557e69ddb2e28b287d0729b4aee4d7de8de18f9" }
-# https://github.com/marin-community/tpu-inference/compare/c0c901b2b5f3617f5250881c3458d58f4b20b10d...217fc45b078b1030bfcb5b704ed1169b448a5808
-tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "217fc45b078b1030bfcb5b704ed1169b448a5808" }
+# https://github.com/marin-community/vllm/compare/04321f0f01b8e60d577a85a1b1af688e4433e7e0...9b02ecc2115a1b3d190d8bdfd39b893495e75eff
+vllm = { git = "https://github.com/marin-community/vllm.git", rev = "9b02ecc2115a1b3d190d8bdfd39b893495e75eff" }
+# https://github.com/marin-community/tpu-inference/compare/4c38590e29d33451f2b4375a78ad8f70cacd7b98...67a07c1083bdc7c177ba71522a2d935b24d6d03f
+tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "67a07c1083bdc7c177ba71522a2d935b24d6d03f" }
 # ### BEGIN RUST-DEV SOURCES ###
 # ### END RUST-DEV SOURCES ###
 

--- a/uv.lock
+++ b/uv.lock
@@ -4669,12 +4669,12 @@ requires-dist = [
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'cpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "cpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'tpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "tpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'vllm'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "vllm" } },
-    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=217fc45b078b1030bfcb5b704ed1169b448a5808" },
+    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=67a07c1083bdc7c177ba71522a2d935b24d6d03f" },
     { name = "tqdm" },
     { name = "tqdm-loggable" },
     { name = "triton", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=3.6.0,<3.7" },
     { name = "verifiers", marker = "extra == 'rl'", specifier = "==0.1.5" },
-    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=7557e69ddb2e28b287d0729b4aee4d7de8de18f9" },
+    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=9b02ecc2115a1b3d190d8bdfd39b893495e75eff" },
     { name = "wandb", specifier = ">0.24.0" },
 ]
 provides-extras = ["gpu", "tpu", "cpu", "rl", "eval", "evalchemy", "vizier", "vllm", "harbor", "dedup", "datakit", "math"]
@@ -10726,9 +10726,10 @@ wheels = [
 [[package]]
 name = "tpu-inference"
 version = "0.22.1"
-source = { git = "https://github.com/marin-community/tpu-inference.git?rev=217fc45b078b1030bfcb5b704ed1169b448a5808#217fc45b078b1030bfcb5b704ed1169b448a5808" }
+source = { git = "https://github.com/marin-community/tpu-inference.git?rev=67a07c1083bdc7c177ba71522a2d935b24d6d03f#67a07c1083bdc7c177ba71522a2d935b24d6d03f" }
 dependencies = [
     { name = "absl-py" },
+    { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-10-marin-core-vllm' or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-gpu') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'group-10-marin-fray-fray-tpu-test') or (extra == 'extra-10-marin-core-tpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'group-10-marin-fray-fray-tpu-test')" },
     { name = "flax" },
     { name = "gcsfs" },
     { name = "google-cloud-storage" },
@@ -11155,8 +11156,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.20.1rc1.dev0+g7557e69dd.tpu"
-source = { git = "https://github.com/marin-community/vllm.git?rev=7557e69ddb2e28b287d0729b4aee4d7de8de18f9#7557e69ddb2e28b287d0729b4aee4d7de8de18f9" }
+version = "0.20.1rc1.dev993+g9b02ecc21.tpu"
+source = { git = "https://github.com/marin-community/vllm.git?rev=9b02ecc2115a1b3d190d8bdfd39b893495e75eff#9b02ecc2115a1b3d190d8bdfd39b893495e75eff" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },


### PR DESCRIPTION
## Summary

This repins Marin's `vllm` and `tpu-inference` dependencies to new GrugMoE fork commits built on top of the fork SHAs Marin was using before #6664. The Marin diff is intentionally limited to `pyproject.toml` and `uv.lock`.

The intent is to preserve the GrugMoE serving functionality from #6664 while avoiding unrelated newer upstream fork changes. Each fork branch groups the ported GrugMoE overlay into one focused commit.

## Review links

Primary review surfaces:

- Marin PR files: https://github.com/marin-community/marin/pull/6732/files
- Marin repin commit: [`1b215a5`](https://github.com/marin-community/marin/commit/1b215a56bf9f6bb33ad07b9ad6f02dda140aedde)
- vLLM new fork code, previous Marin pin -> new pin: [`04321f0...9b02ecc`](https://github.com/marin-community/vllm/compare/04321f0f01b8e60d577a85a1b1af688e4433e7e0...9b02ecc2115a1b3d190d8bdfd39b893495e75eff)
- tpu-inference new fork code, previous Marin pin -> new pin: [`4c38590...67a07c1`](https://github.com/marin-community/tpu-inference/compare/4c38590e29d33451f2b4375a78ad8f70cacd7b98...67a07c1083bdc7c177ba71522a2d935b24d6d03f)

Fork branches:

- [`marin-community/vllm:codex/grugmoe-on-marin-pin-20260627`](https://github.com/marin-community/vllm/tree/codex/grugmoe-on-marin-pin-20260627)
- [`marin-community/tpu-inference:codex/grugmoe-on-marin-pin-20260627`](https://github.com/marin-community/tpu-inference/tree/codex/grugmoe-on-marin-pin-20260627)

## SHA comparison

| Component | Previously used Marin pin before #6664 | Landed #6664 pin on `main` | New pin in this PR |
| --- | --- | --- | --- |
| Marin | [`05a1d4d`](https://github.com/marin-community/marin/commit/05a1d4d474b9dccc8189c031c24cc6452c2e589a) base | [`05a1d4d`](https://github.com/marin-community/marin/commit/05a1d4d474b9dccc8189c031c24cc6452c2e589a) | [`1b215a5`](https://github.com/marin-community/marin/commit/1b215a56bf9f6bb33ad07b9ad6f02dda140aedde) |
| vLLM | [`04321f0`](https://github.com/marin-community/vllm/commit/04321f0f01b8e60d577a85a1b1af688e4433e7e0) | [`7557e69`](https://github.com/marin-community/vllm/commit/7557e69ddb2e28b287d0729b4aee4d7de8de18f9) | [`9b02ecc`](https://github.com/marin-community/vllm/commit/9b02ecc2115a1b3d190d8bdfd39b893495e75eff) |
| tpu-inference | [`4c38590`](https://github.com/marin-community/tpu-inference/commit/4c38590e29d33451f2b4375a78ad8f70cacd7b98) | [`217fc45`](https://github.com/marin-community/tpu-inference/commit/217fc45b078b1030bfcb5b704ed1169b448a5808) | [`67a07c1`](https://github.com/marin-community/tpu-inference/commit/67a07c1083bdc7c177ba71522a2d935b24d6d03f) |

<details>
<summary>Validation</summary>

- `uv lock --locked`
  - `Resolved 616 packages in 12ms`
- Cheap Marin collection/skip check:
  - `uv run --with pytest --with pytest-timeout --with pytest-xdist pytest -q tests/vllm/test_grugmoe_real_checkpoint_e2e.py`
  - `1 passed, 2 deselected in 0.06s`
- Focused tpu-inference CPU checks:
  - `PYTHONPATH=/home/romain/dev/marin-wt/grugmoe-vllm-on-marin-pin-20260627 uv run --python 3.12 --with-editable . --with-requirements requirements.txt --with-requirements requirements_test.txt --with-requirements /home/romain/dev/marin-wt/grugmoe-vllm-on-marin-pin-20260627/requirements/common.txt python -m pytest -q tests/models/common/test_model_loader.py::test_register_layers_registers_grugmoe_for_tpu tests/models/common/test_model_loader.py::test_grugmoe_attention_mode_rejects_unknown_values tests/models/jax/test_grugmoe.py`
  - `7 passed, 19 warnings in 12.63s`
- Marin lint review:
  - `./infra/pre-commit.py --review`
  - `No findings.`
- Real v6e-4 europe-west4 e2e:
  - Iris job: `/romain/grugmoe-real-checkpoint-e2e-1b215a-r3`
  - Command:
    ```bash
    uv run iris --cluster=marin job run --job-name grugmoe-real-checkpoint-e2e-1b215a-r3 \
      --tpu v6e-4 --enable-extra-resources --region europe-west4 \
      --extra tpu --extra vllm --extra gcp --cpu 4 --memory 32GB --disk 90GB \
      --timeout 7200 -e MARIN_TPU_REGION europe-west4 \
      -- python -m pytest -o addopts='' -s -q tests/vllm/test_grugmoe_real_checkpoint_e2e.py
    ```
  - Result: `3 passed, 1 warning in 221.21s`
  - Summary JSON: `gs://marin-eu-west4/tmp/ttl=14d/grugmoe-real-checkpoint-e2e/20260627T165827Z-1a77f4bd/result.json`
  - vLLM output: ` The Ultimate. The Ultimate. The Ultimate`
  - Levanter/JAX output: ` The Ultimate. The Ultimate. The Ultimate`
  - Runtime package SHAs in result JSON:
    - vLLM: `9b02ecc2115a1b3d190d8bdfd39b893495e75eff`
    - tpu-inference: `67a07c1083bdc7c177ba71522a2d935b24d6d03f`

Note: the result JSON reports `marin_sha` as unavailable because the Iris bundle is not a git checkout. The submitted Marin branch commit is [`1b215a5`](https://github.com/marin-community/marin/commit/1b215a56bf9f6bb33ad07b9ad6f02dda140aedde).

</details>
