### PR TITLE
Refresh TPU vLLM fork stack

### DIFF
--- a/.github/workflows/levanter-unit.yaml
+++ b/.github/workflows/levanter-unit.yaml
@@ -132,7 +132,7 @@ jobs:
     needs: changes
     if: needs.changes.outputs.should_run == 'true' && (github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository)
     runs-on: [tpu-ci]
-    timeout-minutes: 15
+    timeout-minutes: 25
     steps:
       - name: Checkout code
         uses: actions/checkout@v5
@@ -186,7 +186,7 @@ jobs:
                 echo '::endgroup::'; \
               fi && \
               cp -a /workspace-src/. /workspace/ && cd /workspace && \
-              timeout --kill-after=5 --signal=TERM 890 \
+              timeout --kill-after=5 --signal=TERM 1490 \
               uv run --package marin-levanter --frozen --group test --extra tpu \
               pytest -n 0 lib/levanter/tests \
               --ignore=lib/levanter/tests/test_audio.py \

--- a/lib/fray/pyproject.toml
+++ b/lib/fray/pyproject.toml
@@ -17,7 +17,7 @@ test = [
     "pytest-timeout",
     "pytest>=8.3.2",
 ]
-fray_tpu_test = ["jax==0.10.0", "jaxlib==0.10.0", "libtpu==0.0.40", { include-group = "test" }]
+fray_tpu_test = ["jax==0.10.1", "jaxlib==0.10.1", "libtpu==0.0.41", { include-group = "test" }]
 
 dev = [{ include-group = "test" }]
 

--- a/lib/haliax/tests/test_pool.py
+++ b/lib/haliax/tests/test_pool.py
@@ -110,23 +110,23 @@ def test_mean_pool_1d():
     output = mean_pool((D.resize(2),), x, stride=(3,))
     answer = jnp.array([0.5, 3.5, 6.5, 9.5, 12.5])
 
-    assert jnp.all(output.array == answer)
+    assert jnp.allclose(output.array, answer)
 
     # no pad
     output = mean_pool(D.resize(3), x, stride=(3,), padding=0)
     answer = jnp.array([1, 4, 7, 10])
-    assert jnp.all(output.array == answer)
+    assert jnp.allclose(output.array, answer)
 
     # pad, no include pad in avg
     output = mean_pool(D.resize(3), x, stride=(3,), padding="SAME", count_include_pad=False)
     answer = jnp.array([1, 4, 7, 10, 12.5])
 
-    assert jnp.all(output.array == answer)
+    assert jnp.allclose(output.array, answer)
 
     output = mean_pool(D.resize(3), x, stride=(3,), padding="SAME", count_include_pad=True)
     answer = jnp.array([1, 4, 7, 10, (12 + 13) / 3.0])
 
-    assert jnp.all(output.array == answer)
+    assert jnp.allclose(output.array, answer)
 
 
 def test_mean_pool_2d():
@@ -136,7 +136,7 @@ def test_mean_pool_2d():
     output = mean_pool((hax.Axis("H", 1), hax.Axis("W", 3)), x, stride=2)
     answer = jnp.array([[1, 3], [13, 15], [25, 27]])
 
-    assert jnp.all(output.array == answer)
+    assert jnp.allclose(output.array, answer)
 
     # test batch axes
     B = hax.Axis("B", 2)
@@ -145,7 +145,7 @@ def test_mean_pool_2d():
     output = mean_pool((hax.Axis("H", 1), hax.Axis("W", 3)), x, stride=2)
     answer = jnp.array([[[1, 3], [13, 15], [25, 27]], [[1, 3], [13, 15], [25, 27]]])
 
-    assert jnp.all(output.array == answer)
+    assert jnp.allclose(output.array, answer)
 
 
 def test_mean_pool3d():
@@ -155,7 +155,7 @@ def test_mean_pool3d():
 
     answer = jnp.array([[[4, 6]], [[36, 38]]])
 
-    assert jnp.all(output.array == answer)
+    assert jnp.allclose(output.array, answer)
 
 
 def test_pool_backprop():

--- a/lib/levanter/pyproject.toml
+++ b/lib/levanter/pyproject.toml
@@ -80,7 +80,7 @@ Homepage = "https://github.com/stanford-crfm/levanter"
 
 [project.optional-dependencies]
 gpu = [
-  "jax[cuda13]==0.10.0",
+  "jax[cuda13]==0.10.1",
   # B200 emits a cuBLAS warning with older CUDA 13 cuBLAS builds.
   "nvidia-cublas>=13.2.0.9; sys_platform == 'linux'",
   # Preserve the CoreWeave H100 all-to-all guard under CUDA 13.
@@ -100,7 +100,7 @@ deepep = [
   # The Levanter wheel ships the JAX FFI shim sources; CUDA toolchain dependencies
   # come from the host GPU environment.
 ]
-tpu = ["jax==0.10.0", "jaxlib==0.10.0", "libtpu==0.0.40"]
+tpu = ["jax==0.10.1", "jaxlib==0.10.1", "libtpu==0.0.41"]
 torch_test = [
   "torch>=2.7.0",
   "peft>=0.12.0",

--- a/lib/levanter/src/levanter/data/loader.py
+++ b/lib/levanter/src/levanter/data/loader.py
@@ -40,7 +40,6 @@ from levanter.utils.background_iterable import BackgroundIterator
 from levanter.utils.jax_utils import local_cpu_mesh
 from levanter.utils.thread_utils import AsyncIteratorWrapper, blocking_wait
 
-
 Ex = TypeVar("Ex")
 
 _TensorSliceIndex = tuple[slice, ...]
@@ -350,7 +349,7 @@ class DataLoaderIterator(Iterator[Ex]):
         Stacks the individual examples (pytrees) into a single example (pytree) with the batch axis added
         and creates a global array for each leaf of the example.
         """
-        cache: dict[tuple[int, int], list[Array | hax.NamedArray]] = {}
+        cache: dict[tuple[int, int], list[Array | hax.NamedArray | np.ndarray]] = {}
         padded_batch_size = self.dl.rounded_batch_size_at_step(batch.index)
         Batch = hax.Axis(self.dl.batch_axis_name, padded_batch_size)
 
@@ -368,14 +367,14 @@ class DataLoaderIterator(Iterator[Ex]):
 
             # TODO: if we ever do "big data" (i.e. huge examples) we might want to be able to load part of an example
             # which will require support from the datastore (i.e. tensorstore)
-            device_batch = stack_tree(self.dl.batch_axis_name, local_data)
-            batch_leaves = hax.tree_util.tree_leaves(device_batch)
+            host_batch = _stack_tree_on_host(self.dl.batch_axis_name, local_data)
+            batch_leaves = hax.tree_util.tree_leaves(host_batch)
 
             cache[(begin, end)] = batch_leaves
 
             return batch_leaves
 
-        def get_local_data_for_leaf(indices: _TensorSliceIndex, leaf_index: int) -> Array:
+        def get_local_data_for_leaf(indices: _TensorSliceIndex, leaf_index: int) -> Array | np.ndarray:
             batch_slice = indices[0]
             begin, end, stride = batch_slice.indices(padded_batch_size)
             if stride != 1:
@@ -564,6 +563,19 @@ def stack_tree(batch_name, individual_datums):
             return jnp.stack(leaves)
 
     return jax.tree.map(_stack_leaves_unchecked, *individual_datums, is_leaf=is_named_array)
+
+
+def _stack_tree_on_host(batch_name, individual_datums):
+    def _stack_leaves_on_host(*leaves):
+        if is_named_array(leaves[0]):
+            batch_axis = hax.Axis(batch_name, len(leaves)) if isinstance(batch_name, str) else batch_name
+            return hax.NamedArray(
+                np.stack([np.asarray(leaf.array) for leaf in leaves]), (batch_axis,) + leaves[0].axes
+            )
+        else:
+            return np.stack([np.asarray(leaf) for leaf in leaves])
+
+    return jax.tree.map(_stack_leaves_on_host, *individual_datums, is_leaf=is_named_array)
 
 
 def check_sharded_consistency(tree: PyTree, check_disjoint_indices_are_different: bool = False):

--- a/lib/marin/pyproject.toml
+++ b/lib/marin/pyproject.toml
@@ -114,7 +114,7 @@ conflicts = [
 [project.optional-dependencies]
 
 gpu = [
-  "jax[cuda13]==0.10.0",
+  "jax[cuda13]==0.10.1",
   # B200 emits a cuBLAS warning with older CUDA 13 cuBLAS builds.
   "nvidia-cublas>=13.2.0.9; sys_platform == 'linux'",
   # Preserve the CoreWeave H100 all-to-all guard under CUDA 13.
@@ -132,9 +132,9 @@ gpu = [
   "torchvision==0.26.0",
 ]
 tpu = [
-  "jax==0.10.0",
-  "jaxlib==0.10.0",
-  "libtpu==0.0.40",
+  "jax==0.10.1",
+  "jaxlib==0.10.1",
+  "libtpu==0.0.41",
   "torch==2.11.0",
   # Linux x86_64
   "torchvision==0.26.0+cpu; sys_platform == 'linux' and platform_machine == 'x86_64'",
@@ -145,7 +145,7 @@ tpu = [
 ]
 
 cpu = [
-  "jax==0.10.0",
+  "jax==0.10.1",
   "torch==2.11.0",
   # Linux x86_64
   "torchvision==0.26.0+cpu; sys_platform == 'linux' and platform_machine == 'x86_64'",
@@ -188,11 +188,11 @@ vizier = [
 ]
 
 vllm = [
-    "jax==0.10.0",
-    "jaxlib==0.10.0",
-    "libtpu==0.0.40",
+    "jax==0.10.1",
+    "jaxlib==0.10.1",
+    "libtpu==0.0.41",
     "vllm",
-    "tpu-inference==0.22.1",
+    "tpu-inference==0.23.0",
     # Pin torch + torchvision explicitly so the per-extra source map below
     # routes them to the pytorch-cpu index during fresh Iris resolves.
     "torch==2.11.0",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,12 +158,10 @@ nvidia-cutlass-dsl-libs-cu13 = { index = "nvidia" }
 # NOTE: harbor is a pinned git dependency (not a workspace member).
 # harbor lives in marin-community/harbor as a pinned git dependency.
 harbor = { git = "https://github.com/marin-community/harbor.git", rev = "354692d9c0eab497b05f266aa0dff30e2a238d2e" }
-# TF5 fork branch: codex/issue-6735-tf5-from-marin-pin-20260628.
-# https://github.com/marin-community/vllm/compare/9b02ecc2115a1b3d190d8bdfd39b893495e75eff...571de565eb1ef76dfdff9bd70ca8ab31b7136f11
-vllm = { git = "https://github.com/marin-community/vllm.git", rev = "571de565eb1ef76dfdff9bd70ca8ab31b7136f11" }
-# TF5 fork branch: codex/issue-6735-tf5-from-marin-pin-20260628.
-# https://github.com/marin-community/tpu-inference/compare/67a07c1083bdc7c177ba71522a2d935b24d6d03f...29faff43207e42836217ba9bf33691c6e5f28614
-tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "29faff43207e42836217ba9bf33691c6e5f28614" }
+# https://github.com/marin-community/vllm/compare/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c...04f7da7e26eacb4e8d7e7d2dce6347d2ff90af4d
+vllm = { git = "https://github.com/marin-community/vllm.git", rev = "04f7da7e26eacb4e8d7e7d2dce6347d2ff90af4d" }
+# https://github.com/marin-community/tpu-inference/compare/23d17a8120d9cc34890135599f42e1db4f947c10...808415f45bbfcb512e9c593c4a3330aed115917e
+tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "808415f45bbfcb512e9c593c4a3330aed115917e" }
 # ### BEGIN RUST-DEV SOURCES ###
 # ### END RUST-DEV SOURCES ###
 

--- a/uv.lock
+++ b/uv.lock
@@ -1198,7 +1198,7 @@ wheels = [
 
 [[package]]
 name = "compressed-tensors"
-version = "0.15.0.1"
+version = "0.17.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "loguru" },
@@ -1207,9 +1207,9 @@ dependencies = [
     { name = "torch", version = "2.11.0+cpu", source = { registry = "https://download.pytorch.org/whl/cpu" }, marker = "(platform_machine != 'arm64' and extra == 'extra-10-marin-core-vllm') or (sys_platform != 'darwin' and extra == 'extra-10-marin-core-vllm') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-gpu') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-vllm') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'group-10-marin-fray-fray-tpu-test') or (extra == 'extra-10-marin-core-tpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-vllm' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'group-10-marin-fray-fray-tpu-test')" },
     { name = "transformers" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/41/1b/c3c4a98ec5f2727656336f07a0c35862195c310d8eb0b2fa5b4be6848680/compressed_tensors-0.15.0.1.tar.gz", hash = "sha256:a8e93054e8a5ec49c980b09ed36c4c1249b4a8ee167920a8e461c4da26e78d99", size = 229412, upload-time = "2026-04-10T14:23:54.708Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/9e/d7f18bd9a0354088abc11a0c1f2c7698f7c49e5a709faedf6a46e388f693/compressed_tensors-0.17.0.tar.gz", hash = "sha256:15c20d06bdbcf35b51fc99fd125e7b9be1e1855567c33b7a46dfac26ad6fb126", size = 257091, upload-time = "2026-06-03T16:49:17.208Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/a8/52/93833dc1610e017ac5b7dcd59b8304d8ef67d1114c2d124e728a2cbbea12/compressed_tensors-0.15.0.1-py3-none-any.whl", hash = "sha256:e1b1f322e82e475715e242bad46925a304ea8e5c98b5055a15b8eb22fb6bfea9", size = 194260, upload-time = "2026-04-10T14:23:53.098Z" },
+    { url = "https://files.pythonhosted.org/packages/35/63/6edf0415b072fff0bf8b546074dea3f0f9b148e49b601ac98bdc60a76c68/compressed_tensors-0.17.0-py3-none-any.whl", hash = "sha256:4a1b89b508f7efb8ffb4eee8a6e69e0452d9b080cae130146025c64fbe9fa9aa", size = 211714, upload-time = "2026-06-03T16:49:15.672Z" },
 ]
 
 [[package]]
@@ -3387,7 +3387,7 @@ wheels = [
 
 [[package]]
 name = "jax"
-version = "0.10.0"
+version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jaxlib" },
@@ -3396,9 +3396,9 @@ dependencies = [
     { name = "opt-einsum" },
     { name = "scipy" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/50/f0/bcb81d28267d2054d0daed766c7fa16bcee5e481331b4d1e14f5fbe662be/jax-0.10.0.tar.gz", hash = "sha256:0119c767de1645f407df72345d28a3837dc904f1d698911c121d8f2b396fdece", size = 2663397, upload-time = "2026-04-22T13:22:28.563Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/24/49/b082387119c4a6bc7596296bbdc6bce034628cdd2845ebb27304cbca3624/jax-0.10.1.tar.gz", hash = "sha256:11672410faf8752429eb9a131de203dc488a2a3a012d509baa2b39878008810d", size = 2718178, upload-time = "2026-05-20T14:54:09.441Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/70/aa/dfac6d72cc35bc07e7587115b6946e333ef4ccb2e6cd26ecf639438c5d26/jax-0.10.0-py3-none-any.whl", hash = "sha256:76c42ba163c8db3dc2e449e225b888c0edfb623ded31efdc96d85e0fda1d26e8", size = 3094950, upload-time = "2026-04-16T12:32:11.576Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/6e/5087e0347188f6970aba1ffbd0018754d23c3f3461e9f21785f2f27a02c2/jax-0.10.1-py3-none-any.whl", hash = "sha256:47f3192c76e9e3358de1b106a8af5e943fccb10510903f25d96ea53652729134", size = 3150973, upload-time = "2026-05-20T14:51:30.066Z" },
 ]
 
 [package.optional-dependencies]
@@ -3409,27 +3409,27 @@ cuda13 = [
 
 [[package]]
 name = "jax-cuda13-pjrt"
-version = "0.10.0"
+version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/8a/7b/222e957b28c38b6ae37cbcf0e397c9f2b5be0c08236ddf72c545d185b3f5/jax_cuda13_pjrt-0.10.0-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:18f8dcd3b18778f5174bc01313c214c5cb8bfb3fb1c3d01344795d7424fe2b51", size = 113182882, upload-time = "2026-04-16T12:32:46.599Z" },
-    { url = "https://files.pythonhosted.org/packages/21/98/77f15d81fd0637da454e453c8456d4a2b5c8b2e66823b4237ee8689152cf/jax_cuda13_pjrt-0.10.0-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:848d6ae3e663d040c53e902ea9d380a902bfa5e7da881053cec408360036fa7a", size = 118949754, upload-time = "2026-04-16T12:32:51.216Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/8e/57eebc0c4d6d63bad64f7443cbc96d3e3c5535fa4992af58568ad7388cbb/jax_cuda13_pjrt-0.10.1-py3-none-manylinux_2_27_aarch64.whl", hash = "sha256:7dd9f518876857e238a9a63abc185b277e9435470cc286b92209ef79d51d03cf", size = 113795506, upload-time = "2026-05-20T14:52:06.61Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/05adf1f245de3b37518ba1e7e668cdc38ec0291313ab63fc0768089f8baa/jax_cuda13_pjrt-0.10.1-py3-none-manylinux_2_27_x86_64.whl", hash = "sha256:af8042c7697fb6faa0cc4851d4f5e0504878ea1f6b6fc067255f449016336a6f", size = 119552553, upload-time = "2026-05-20T14:52:11.087Z" },
 ]
 
 [[package]]
 name = "jax-cuda13-plugin"
-version = "0.10.0"
+version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "jax-cuda13-pjrt" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/bf/6fadfbc22270a53b90e514d764d59c26a62a4c1159194868a69e9c6290f2/jax_cuda13_plugin-0.10.0-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:56f1ca2a5ebcc4d399aaa72d845543d9291574d49545dca75d1cb1fff04637b4", size = 6074330, upload-time = "2026-04-16T12:32:57.772Z" },
-    { url = "https://files.pythonhosted.org/packages/21/1b/4e64882c7182828160236f92087f4a82cd0d9217608ef52d64bc91eeaa28/jax_cuda13_plugin-0.10.0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:34bbe4978e5534ef88d944ca8c3d12480ebbcd53fc75a7deb3fcab80769afd39", size = 6117248, upload-time = "2026-04-16T12:32:59.263Z" },
-    { url = "https://files.pythonhosted.org/packages/c0/7a/afb7dec2b393a916b479c61ebd86aa993429834ed805a03a6c2c5e68915d/jax_cuda13_plugin-0.10.0-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:894006be79b60310176c31fb2aae0f9182b7dc7a30081a2cb8de5917059f84bd", size = 6074152, upload-time = "2026-04-16T12:33:00.99Z" },
-    { url = "https://files.pythonhosted.org/packages/49/86/d166a452240c299c99bde6a4c3d410c690597d17b13a251d3e2a0a7bff19/jax_cuda13_plugin-0.10.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:4c2022a2be1f4f3654dca98bd5487081ca9b5ae25b7004c8f86c449a4a1cd43f", size = 6116938, upload-time = "2026-04-16T12:33:02.517Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/cb/65abe3f07c3349d13fa526e38de00abaef962c25d336b3a33ac79bbe25f7/jax_cuda13_plugin-0.10.0-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:beca99daffb43690fa54f3bf73f42e68a0e1440b4ab36a0830da079786357222", size = 6089528, upload-time = "2026-04-16T12:33:04.31Z" },
-    { url = "https://files.pythonhosted.org/packages/10/0f/fa9a6ac2c0374c645430d799f91242ca3de47218e6bc4d88a3471b24e10e/jax_cuda13_plugin-0.10.0-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:4fd6fbd99ccc91c3c1bce9b9f566a5498922227085e55fa1109efb82e4842cd3", size = 6125592, upload-time = "2026-04-16T12:33:06.249Z" },
+    { url = "https://files.pythonhosted.org/packages/88/1e/6f8135ac3f6dbee231392131cb278fabccbceddbc0a1a160a579bfe7b37a/jax_cuda13_plugin-0.10.1-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:a4f8c2ad46fcf6edbe09b66578ec5fd7f8d189fcdb5d0a2500e473c5eebfc824", size = 7254249, upload-time = "2026-05-20T14:52:18.2Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/c2/6f9911b2a7f1f333320b3600118f13b57b43248288f2e4a3b276aa95c85e/jax_cuda13_plugin-0.10.1-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:6799bf4e59574f5a49638fa4e1b6a43ddea75cc7eb19f726c4f6d94aa1e05cdd", size = 7306406, upload-time = "2026-05-20T14:52:20.056Z" },
+    { url = "https://files.pythonhosted.org/packages/47/cf/d6d807cbbb4e61103291a34856b32766b252c96a39897bf4e0143942f030/jax_cuda13_plugin-0.10.1-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:a31e7859ecebfa0680eca260ea64046d5c54c7596d734897526ebeb89d54e48b", size = 7255426, upload-time = "2026-05-20T14:52:21.663Z" },
+    { url = "https://files.pythonhosted.org/packages/80/80/ec043edee9db3debf5074fe5fd0431c6fea3f94d1b9a53458b35cd30544d/jax_cuda13_plugin-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:9070b1af00ebc7f5d6f20aafb789058f53812afd85e237dce0f1709a52cfd0f8", size = 7306050, upload-time = "2026-05-20T14:52:23.216Z" },
+    { url = "https://files.pythonhosted.org/packages/44/94/d480e1fb807cf67c3796200dca01cbe4c75dfa82ce64460b90c944e218cf/jax_cuda13_plugin-0.10.1-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:6baea37967bd9759f5bc014d8d6291782332478f746302f46fd08a9009a23304", size = 7268591, upload-time = "2026-05-20T14:52:24.77Z" },
+    { url = "https://files.pythonhosted.org/packages/3b/7f/da438722130ca56ec5b15a3318c477418088aaa818480280816e6ce6259d/jax_cuda13_plugin-0.10.1-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:699a984d67b040f6dd26bae1b9326d748c62cafee769a9050085f953b42db0e5", size = 7316498, upload-time = "2026-05-20T14:52:26.47Z" },
 ]
 
 [package.optional-dependencies]
@@ -3465,7 +3465,7 @@ wheels = [
 
 [[package]]
 name = "jaxlib"
-version = "0.10.0"
+version = "0.10.1"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "ml-dtypes" },
@@ -3473,17 +3473,17 @@ dependencies = [
     { name = "scipy" },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/79/0c/279cb4dc009fe87a8315d1b182f520693236ad07b852152df344ea4e4021/jaxlib-0.10.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7c1d9b463327c7a2333f210114ecb04f28fefc51ba8233a85a2280cce75bdb42", size = 60137156, upload-time = "2026-04-16T12:33:30.306Z" },
-    { url = "https://files.pythonhosted.org/packages/e3/cd/59ead5a90df739d1b8c1d1d00443558fd30adf5abb0319966ce340d49ff3/jaxlib-0.10.0-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:aa1d70f1a4e27eb403654e71e2fb28d5786d3e9b77fc1847e8c5389880927ca4", size = 79398938, upload-time = "2026-04-16T12:33:34.14Z" },
-    { url = "https://files.pythonhosted.org/packages/b5/20/9b07fc8b327b222b6f72a4978eb4f2ebe856ee71237d63c4d808ec3945e0/jaxlib-0.10.0-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:b0bfb865a07df2e6d7418c0b0c292dd294b5500523b1dd5872b180db2aa480d4", size = 85028702, upload-time = "2026-04-16T12:33:37.815Z" },
-    { url = "https://files.pythonhosted.org/packages/08/3b/4f798fffed4229a2d7de07c1f4feabac7676a26c695a418796dbe29bae7f/jaxlib-0.10.0-cp312-cp312-win_amd64.whl", hash = "sha256:25bf167e0d8b594e0ec50783ff4892c0b7ec37236c88b2b425a7c252823f8680", size = 64221923, upload-time = "2026-04-16T12:33:41.343Z" },
-    { url = "https://files.pythonhosted.org/packages/d4/b6/b66b0abb9df8f9f8f19a5244b849cb07fc7389a4a5e1fb7794f7cefd7f26/jaxlib-0.10.0-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:384635fff55899a295bbc82ee6c6f773a300e787dc472ca92bbe79abfaac8369", size = 60138213, upload-time = "2026-04-16T12:33:45.13Z" },
-    { url = "https://files.pythonhosted.org/packages/30/1e/844e525a72a08a2744ae2722e2332a0159a6d0efdc1e561cf378f7259a01/jaxlib-0.10.0-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:6d8d78b7070b34e4c5bba5f7e10927e7f4aac9b69be17e9b0a5898553a4338f3", size = 79401054, upload-time = "2026-04-16T12:33:49.263Z" },
-    { url = "https://files.pythonhosted.org/packages/f7/95/305854c2ef2b645f7df1666be66b1167c392cc39384d09aca2e9499b71bf/jaxlib-0.10.0-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:d303dc31b65e8b793d5600f81b1583be03dc9b876a4c10b3e259b6609a1cbe3b", size = 85027218, upload-time = "2026-04-16T12:33:54.325Z" },
-    { url = "https://files.pythonhosted.org/packages/a8/63/a5e1dcb65dca6efbae7189f185588fc939e17c284f272254fbeb68a39817/jaxlib-0.10.0-cp313-cp313-win_amd64.whl", hash = "sha256:3869be623c2f3391be2ee86f8b412372b102492e67cac0a5f0ab1037bbc3a5cc", size = 64221972, upload-time = "2026-04-16T12:46:24.762Z" },
-    { url = "https://files.pythonhosted.org/packages/ce/d6/411e580b70f64a5a4b095cb2c03c1e2c7b3b35c6754e5cacd4a8f8a2d480/jaxlib-0.10.0-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:9050ce2ae7eeca62b1a235065056cad62cac590ddc035486faa4472a47eed9f6", size = 60250897, upload-time = "2026-04-16T12:46:13.185Z" },
-    { url = "https://files.pythonhosted.org/packages/2c/5c/f40ac9d40eb39c359f268e087ff1f21bdad664f86691c52a288d0f9152e8/jaxlib-0.10.0-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:59e07aab3bdfaad9bdd3cf32e0d3d4f228837b9b231c53f5ae1c0fc284481094", size = 79518774, upload-time = "2026-04-16T12:46:16.684Z" },
-    { url = "https://files.pythonhosted.org/packages/49/36/dea7a0ea64a5551244e2140ef6ad36e2dff308b6f5facaa6f1c1272bb47f/jaxlib-0.10.0-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:3088503812cfe49f34a3083d3b7ef5cb3aaf33d89ceb1b3f647fa52713aee59d", size = 85134776, upload-time = "2026-04-16T12:46:20.855Z" },
+    { url = "https://files.pythonhosted.org/packages/53/b4/fdb6e989b142d8a8d2093f342cbc5323fe0d4a7217fd899c8ddf9e108a5a/jaxlib-0.10.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:7a4399c7429c87ee6f7ab1e5712c5548ecfabde974ee9f4a12957fea4e35efb8", size = 60816137, upload-time = "2026-05-20T14:52:53.028Z" },
+    { url = "https://files.pythonhosted.org/packages/a7/29/0b4eaaca005708751ff301903a2ca760dcc34175dadb7536498c57a7de85/jaxlib-0.10.1-cp312-cp312-manylinux_2_27_aarch64.whl", hash = "sha256:12126603ba472300c62480f86d20972d563143041039d9dea349ad510aa6123c", size = 80294034, upload-time = "2026-05-20T14:52:56.941Z" },
+    { url = "https://files.pythonhosted.org/packages/38/69/2912ab63036e21c72748019e1d8e09e8a1fc3368b3e83fc27898a1858575/jaxlib-0.10.1-cp312-cp312-manylinux_2_27_x86_64.whl", hash = "sha256:f3cdf5b7f48470ab5455ab79aab746419694ccb6b52651cc2ce5fb27def03588", size = 85828774, upload-time = "2026-05-20T14:53:01.749Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/8f/993ea419eca6f34fe12613e22a03b93f40e5b1e8e0df18d4060e1313a1fc/jaxlib-0.10.1-cp312-cp312-win_amd64.whl", hash = "sha256:0acf3f8e7dca9074c0327f0f61502845792ca9f82fab23b841b00daa78e85488", size = 64830187, upload-time = "2026-05-20T14:53:05.932Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/76/3b637d4def229015a3035a7b44fac0dcf2536ae337540cdbffc651334d4e/jaxlib-0.10.1-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:4167213aa00f14bb0d8fbd90f9ded75e976f71ce8baf8c3c44e04c8fb80ea0c1", size = 60815855, upload-time = "2026-05-20T14:53:11.718Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/76/9a1971bc9edb8728a7ba86d2693127ee46add9811230b8452321415fd4e9/jaxlib-0.10.1-cp313-cp313-manylinux_2_27_aarch64.whl", hash = "sha256:e53223d8f6861d33c02dd02343fa464700401ff5363784d37c33407218e328b8", size = 80293947, upload-time = "2026-05-20T14:53:15.408Z" },
+    { url = "https://files.pythonhosted.org/packages/20/1d/69a0ba52fb546261e71a7209378ee6059950e9c088a2a18355e01509f474/jaxlib-0.10.1-cp313-cp313-manylinux_2_27_x86_64.whl", hash = "sha256:bb073a1224e659e01e8d32d47c000edb52ec2aa8ba97ec22b2228b3a46e5c167", size = 85829861, upload-time = "2026-05-20T14:53:19.773Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/df/48659e2ee57705c63a51525f810fe3e0c87af4ca9f89d4738281a872d58e/jaxlib-0.10.1-cp313-cp313-win_amd64.whl", hash = "sha256:6449f1d4a22324f5f02c843360475783f9fd1d353fe711806cbf4e927d1360ae", size = 64828863, upload-time = "2026-05-20T14:53:24.562Z" },
+    { url = "https://files.pythonhosted.org/packages/c7/34/3f7c95ee1b2555d611f836988a49b522c04b8d186e0528f91d45118089bf/jaxlib-0.10.1-cp313-cp313t-macosx_11_0_arm64.whl", hash = "sha256:72a7db1242d6b7773340e430c244e73a8d13f82ce83933c0529a8b4b1520dcf3", size = 60934063, upload-time = "2026-05-20T14:53:28.549Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/84/855a2395d299e00e1d9ffd0aecd516b52b81780f3e4ef537527be6d8c1fc/jaxlib-0.10.1-cp313-cp313t-manylinux_2_27_aarch64.whl", hash = "sha256:649c26ca92e9bbffb3c35226b37893916f20e6b89fb3911ce79b39e5cfb27b46", size = 80402500, upload-time = "2026-05-20T14:53:32.444Z" },
+    { url = "https://files.pythonhosted.org/packages/be/35/153e91a9c770a981d525d845b3f4cdb71a1e119681594a33908e9536bdff/jaxlib-0.10.1-cp313-cp313t-manylinux_2_27_x86_64.whl", hash = "sha256:cfe75d8a17e0d33a7bed27f32d7a5344a66e8d4af7073973f396e14ff4a9c503", size = 85941210, upload-time = "2026-05-20T14:53:36.982Z" },
 ]
 
 [[package]]
@@ -4100,12 +4100,12 @@ wheels = [
 
 [[package]]
 name = "libtpu"
-version = "0.0.40"
+version = "0.0.41"
 source = { registry = "https://pypi.org/simple" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/92/27/47a8ccb0007b5e52b49e9dd156213c5ec9eb14cefed880d4a4ebadc25198/libtpu-0.0.40-cp312-cp312-manylinux_2_31_x86_64.whl", hash = "sha256:aa861000608ae4b8cc8f01728253ec2829532894dfccb691665bde79a7aa5f3c", size = 227429479, upload-time = "2026-04-14T04:09:18.49Z" },
-    { url = "https://files.pythonhosted.org/packages/05/dc/2da41c48589285933f72dc91dba33a5830e2c8ca82c0ed2c84db319bb4d4/libtpu-0.0.40-cp313-cp313-manylinux_2_31_x86_64.whl", hash = "sha256:c1a280a6d216131c1d81d30f0b3ca13428d0c06e6781ec88190aa2400198cefc", size = 227429745, upload-time = "2026-04-14T04:09:54.703Z" },
-    { url = "https://files.pythonhosted.org/packages/05/77/67b50acabe70efdff0e00edfdebc39c74a47eba1e698e98d687ed55173ca/libtpu-0.0.40-cp313-cp313t-manylinux_2_31_x86_64.whl", hash = "sha256:90803ebcccffd4206e7a52344583fec246deb83de95fbc7b5e0137e4ae480a35", size = 227430840, upload-time = "2026-04-14T04:09:42.728Z" },
+    { url = "https://files.pythonhosted.org/packages/27/bb/70a97644f2114fe5dff0fb7ac58922e2188b6355a0439ea6ae14358a61d0/libtpu-0.0.41-cp312-cp312-manylinux_2_31_x86_64.whl", hash = "sha256:47feeac3cd4cd88c58342c20f3cb3635d1f2d53f8689aa24bbe9690e664629de", size = 211768760, upload-time = "2026-05-13T22:40:22.982Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/6e/16eee4b4c3a642cef091f8aafea7797edc3d20f224ea265ae05dceba31b0/libtpu-0.0.41-cp313-cp313-manylinux_2_31_x86_64.whl", hash = "sha256:5dd67e594cefb67f4272efb5a3fa38cf9206b7dd1ab5fbd559001809f8b9dddb", size = 211768672, upload-time = "2026-05-13T22:41:07.061Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/16/d5faa773888b6abb6575ad8ee347cf35e6cbfc8879340fcd7e8f3ba6fbaf/libtpu-0.0.41-cp313-cp313t-manylinux_2_31_x86_64.whl", hash = "sha256:ca9dd60976c035b071b2d5d61acdd78598f717bba4f277b3708269d05b5c32fb", size = 211769221, upload-time = "2026-05-13T22:40:56.767Z" },
 ]
 
 [[package]]
@@ -4616,16 +4616,16 @@ requires-dist = [
     { name = "harbor", marker = "extra == 'harbor'", git = "https://github.com/marin-community/harbor.git?rev=354692d9c0eab497b05f266aa0dff30e2a238d2e" },
     { name = "huggingface-hub", marker = "extra == 'datakit'" },
     { name = "jax", specifier = ">=0.9.2,<0.11" },
-    { name = "jax", marker = "extra == 'cpu'", specifier = "==0.10.0" },
-    { name = "jax", marker = "extra == 'tpu'", specifier = "==0.10.0" },
-    { name = "jax", marker = "extra == 'vllm'", specifier = "==0.10.0" },
-    { name = "jax", extras = ["cuda13"], marker = "extra == 'gpu'", specifier = "==0.10.0" },
+    { name = "jax", marker = "extra == 'cpu'", specifier = "==0.10.1" },
+    { name = "jax", marker = "extra == 'tpu'", specifier = "==0.10.1" },
+    { name = "jax", marker = "extra == 'vllm'", specifier = "==0.10.1" },
+    { name = "jax", extras = ["cuda13"], marker = "extra == 'gpu'", specifier = "==0.10.1" },
     { name = "jax-triton", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = "==0.3.1" },
-    { name = "jaxlib", marker = "extra == 'tpu'", specifier = "==0.10.0" },
-    { name = "jaxlib", marker = "extra == 'vllm'", specifier = "==0.10.0" },
+    { name = "jaxlib", marker = "extra == 'tpu'", specifier = "==0.10.1" },
+    { name = "jaxlib", marker = "extra == 'vllm'", specifier = "==0.10.1" },
     { name = "jaxopt", specifier = ">=0.8.3" },
-    { name = "libtpu", marker = "extra == 'tpu'", specifier = "==0.0.40" },
-    { name = "libtpu", marker = "extra == 'vllm'", specifier = "==0.0.40" },
+    { name = "libtpu", marker = "extra == 'tpu'", specifier = "==0.0.41" },
+    { name = "libtpu", marker = "extra == 'vllm'", specifier = "==0.0.41" },
     { name = "lm-eval", extras = ["math"], marker = "extra == 'evalchemy'", git = "https://github.com/stanford-crfm/lm-evaluation-harness?rev=d5e3391f22cde186c827674d5c3ec7c5f4fe0cab" },
     { name = "lm-eval", extras = ["math", "api", "ifeval"], marker = "extra == 'eval'", git = "https://github.com/stanford-crfm/lm-evaluation-harness?rev=d5e3391f22cde186c827674d5c3ec7c5f4fe0cab" },
     { name = "luxical", marker = "extra == 'datakit'" },
@@ -4674,13 +4674,13 @@ requires-dist = [
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'cpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "cpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'tpu'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "tpu" } },
     { name = "torchvision", marker = "platform_machine == 'AMD64' and sys_platform == 'win32' and extra == 'vllm'", specifier = "==0.26.0+cpu", index = "https://download.pytorch.org/whl/cpu", conflict = { package = "marin-core", extra = "vllm" } },
-    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=29faff43207e42836217ba9bf33691c6e5f28614" },
+    { name = "tpu-inference", marker = "extra == 'vllm'", git = "https://github.com/marin-community/tpu-inference.git?rev=808415f45bbfcb512e9c593c4a3330aed115917e" },
     { name = "tqdm" },
     { name = "tqdm-loggable" },
     { name = "transformers", specifier = ">=5.5.3,<6.0" },
     { name = "triton", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=3.6.0,<3.7" },
     { name = "verifiers", marker = "extra == 'rl'", specifier = "==0.1.5" },
-    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=571de565eb1ef76dfdff9bd70ca8ab31b7136f11" },
+    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=04f7da7e26eacb4e8d7e7d2dce6347d2ff90af4d" },
     { name = "wandb", specifier = ">0.24.0" },
 ]
 provides-extras = ["gpu", "tpu", "cpu", "rl", "eval", "evalchemy", "vizier", "vllm", "harbor", "dedup", "datakit", "math"]
@@ -4868,9 +4868,9 @@ dev = [
     { name = "pytest-timeout" },
 ]
 fray-tpu-test = [
-    { name = "jax", specifier = "==0.10.0" },
-    { name = "jaxlib", specifier = "==0.10.0" },
-    { name = "libtpu", specifier = "==0.0.40" },
+    { name = "jax", specifier = "==0.10.1" },
+    { name = "jaxlib", specifier = "==0.10.1" },
+    { name = "libtpu", specifier = "==0.0.41" },
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-timeout" },
 ]
@@ -5231,15 +5231,15 @@ requires-dist = [
     { name = "humanfriendly", specifier = "==10.0" },
     { name = "immutabledict" },
     { name = "jax", specifier = ">=0.9.2,<0.11" },
-    { name = "jax", marker = "extra == 'tpu'", specifier = "==0.10.0" },
-    { name = "jax", extras = ["cuda13"], marker = "extra == 'gpu'", specifier = "==0.10.0" },
+    { name = "jax", marker = "extra == 'tpu'", specifier = "==0.10.1" },
+    { name = "jax", extras = ["cuda13"], marker = "extra == 'gpu'", specifier = "==0.10.1" },
     { name = "jax-triton", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = "==0.3.1" },
-    { name = "jaxlib", marker = "extra == 'tpu'", specifier = "==0.10.0" },
+    { name = "jaxlib", marker = "extra == 'tpu'", specifier = "==0.10.1" },
     { name = "jaxtyping", specifier = ">=0.2.34" },
     { name = "jinja2" },
     { name = "jmp", specifier = ">=0.0.3" },
     { name = "lenses" },
-    { name = "libtpu", marker = "extra == 'tpu'", specifier = "==0.0.40" },
+    { name = "libtpu", marker = "extra == 'tpu'", specifier = "==0.0.41" },
     { name = "lm-eval", marker = "extra == 'lm-eval'", git = "https://github.com/stanford-crfm/lm-evaluation-harness.git?rev=d5e3391f22cde186c827674d5c3ec7c5f4fe0cab" },
     { name = "marin-fray", editable = "lib/fray" },
     { name = "marin-haliax", editable = "lib/haliax" },
@@ -10787,8 +10787,8 @@ wheels = [
 
 [[package]]
 name = "tpu-inference"
-version = "0.22.1"
-source = { git = "https://github.com/marin-community/tpu-inference.git?rev=29faff43207e42836217ba9bf33691c6e5f28614#29faff43207e42836217ba9bf33691c6e5f28614" }
+version = "0.23.0"
+source = { git = "https://github.com/marin-community/tpu-inference.git?rev=808415f45bbfcb512e9c593c4a3330aed115917e#808415f45bbfcb512e9c593c4a3330aed115917e" }
 dependencies = [
     { name = "absl-py" },
     { name = "fastapi", extra = ["standard"], marker = "extra == 'extra-10-marin-core-vllm' or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-10-marin-core-gpu') or (extra == 'extra-10-marin-core-cpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-10-marin-core-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-10-marin-core-gpu' and extra == 'group-10-marin-fray-fray-tpu-test') or (extra == 'extra-10-marin-core-tpu' and extra == 'extra-14-marin-levanter-gpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'extra-14-marin-levanter-tpu') or (extra == 'extra-14-marin-levanter-gpu' and extra == 'group-10-marin-fray-fray-tpu-test')" },
@@ -11217,8 +11217,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.20.1rc1.dev994+g571de565e.tpu"
-source = { git = "https://github.com/marin-community/vllm.git?rev=571de565eb1ef76dfdff9bd70ca8ab31b7136f11#571de565eb1ef76dfdff9bd70ca8ab31b7136f11" }
+version = "0.20.1rc1.dev1459+g04f7da7e2.tpu"
+source = { git = "https://github.com/marin-community/vllm.git?rev=04f7da7e26eacb4e8d7e7d2dce6347d2ff90af4d#04f7da7e26eacb4e8d7e7d2dce6347d2ff90af4d" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },


### PR DESCRIPTION
Refreshes Marin's TPU/vLLM serving stack to `tpu-inference v0.23.0` and its tested vLLM LKG, rebased onto current `main` after #6735, #6749, and #6756.

## What changed

- Pins refreshed `marin-community/vllm` and `marin-community/tpu-inference` fork tips.
- Updates the vLLM fork packaging so macOS metadata generation honors an explicit `VLLM_TARGET_DEVICE=tpu`, preventing accidental `.cpu` metadata and `numba==0.65.0` during relock.
- Regenerates `uv.lock` with one monorepo TPU stack instead of splitting inference and training extras:
  - `jax==0.10.1` / `jax[cuda13]==0.10.1`
  - `jaxlib==0.10.1`
  - `libtpu==0.0.41`
- Keeps only the Marin fork overlays still needed for TPU source builds, TPU metadata, TorchVision alignment, and GrugMoE support.
- Drops the temporary Transformers 4 compatibility relaxations from earlier refresh attempts; Marin `main` is already on the Transformers 5 baseline from #6735.
- Fixes the Levanter `DataLoader` callback path exposed by JAX 0.10.1 by stacking callback-local data on host before `make_array_from_callback` returns slices to JAX.
- Raises the `levanter-tpu-tests` timeout from 15 to 25 minutes so the TPU suite can complete instead of being killed near the old inner timeout.

## Forks

| Repo | Selected base | Fork branch | Tip | Compare |
| --- | --- | --- | --- | --- |
| `marin-community/vllm` | LKG `a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c` | [`auto-refresh/20260627/lkg-a30addc7-r4`](https://github.com/marin-community/vllm/tree/auto-refresh/20260627/lkg-a30addc7-r4) | `04f7da7e26eacb4e8d7e7d2dce6347d2ff90af4d` | [compare](https://github.com/marin-community/vllm/compare/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c...04f7da7e26eacb4e8d7e7d2dce6347d2ff90af4d) |
| `marin-community/tpu-inference` | `v0.23.0` release commit `23d17a8120d9cc34890135599f42e1db4f947c10` | [`auto-refresh/20260627/v0.23.0-23d17a8-r3`](https://github.com/marin-community/tpu-inference/tree/auto-refresh/20260627/v0.23.0-23d17a8-r3) | `808415f45bbfcb512e9c593c4a3330aed115917e` | [compare](https://github.com/marin-community/tpu-inference/compare/23d17a8120d9cc34890135599f42e1db4f947c10...808415f45bbfcb512e9c593c4a3330aed115917e) |

Selected upstream inputs:

- `vllm-project/tpu-inference v0.23.0`: `23d17a8120d9cc34890135599f42e1db4f947c10`
- vLLM LKG from `.buildkite/vllm_lkg.version`: `a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c`

<details>
<summary>Fork overlay scope</summary>

| Repo | Carried overlays | Dropped overlays |
| --- | --- | --- |
| vLLM | Marin TPU inference dependency wiring, stale CMake cleanup before source builds, TPU metadata without importing torch, GrugMoE scheduler/version support, and explicit TPU metadata on macOS metadata hosts. | Temporary Transformers 4 resolver/runtime relaxations. |
| tpu-inference | Source-install version `0.23.0`, TorchVision compatibility with Marin's vLLM stack, GrugMoE model support. | Temporary Transformers 4 relaxations; old `tpu_runner.py` routed-experts helper now covered upstream by `_reconstruct_routed_experts`. |

</details>

<details>
<summary>JAX 0.10.1 DataLoader mesh issue</summary>

Levanter's `DataLoader` loads examples under `local_cpu_mesh()`, then uses `jax.make_array_from_callback(..., NamedSharding(self.dl.mesh, ...), get_data)` to materialize target-mesh arrays. After the JAX refresh, callback-local CPU-mesh leaves could fail when stacked through `jnp.stack` inside the target-mesh callback path.

The Marin fix is intentionally narrow: keep the existing callback batching shape, but stack callback-local data on host with NumPy before returning the callback slice to JAX. That avoids invoking JAX 0.10.1's `stack` primitive on CPU-mesh arrays in a target-mesh context.

JAX pointers:

- JAX 0.10.1 release notes move mesh context usage toward `jax.set_mesh(mesh)`: https://github.com/jax-ml/jax/blob/jax-v0.10.1/CHANGELOG.md#L41-L43
- The relevant change is `bfafe3c142`, "Make stack and unstack jax primitives": https://github.com/jax-ml/jax/commit/bfafe3c142372a2aeb896cb5fb98bfef1b4e6e09
- JAX 0.10.0 `jnp.stack` expanded operands and returned `concatenate(...)`: https://github.com/jax-ml/jax/blob/jax-v0.10.0/jax/_src/numpy/lax_numpy.py#L4380-L4388
- JAX 0.10.1 `jnp.stack` calls `lax.stack(...)`: https://github.com/jax-ml/jax/blob/jax-v0.10.1/jax/_src/numpy/lax_numpy.py#L4380-L4385
- `lax.stack` binds the new `stack_p` primitive via `core.auto_insert_reshard(...)`: https://github.com/jax-ml/jax/blob/jax-v0.10.1/jax/_src/lax/lax.py#L2075-L2078
- Primitive abstract evaluation checks input/output aval meshes against the current context mesh: https://github.com/jax-ml/jax/blob/jax-v0.10.1/jax/_src/lax/utils.py#L187-L202
- The failure path is `check_avals_context_mesh`, which raises when the context mesh and aval mesh differ: https://github.com/jax-ml/jax/blob/jax-v0.10.1/jax/_src/core.py#L732-L747

</details>

<details>
<summary>Validation</summary>

Local checks used capped build concurrency:

```sh
UV_CONCURRENT_BUILDS=1 UV_CONCURRENT_INSTALLS=1 MAX_JOBS=1 CMAKE_BUILD_PARALLEL_LEVEL=1 CARGO_BUILD_JOBS=1
```

Final local checks:

- `uv lock --check`: passed.
- `git diff --check origin/main...HEAD`: passed.
- `python -m py_compile lib/levanter/src/levanter/data/loader.py`: passed.
- `./infra/pre-commit.py --all-files`: passed.
- `uv tree --locked --invert --package jax`: single `jax v0.10.1` graph.
- `uv tree --locked --invert --package jaxlib`: single `jaxlib v0.10.1` graph.
- `uv tree --locked --invert --package libtpu`: single `libtpu v0.0.41` graph.
- `uv tree --locked --package vllm`: `vllm v0.20.1rc1.dev1459+g04f7da7e2.tpu`; no `numba` dependency from vLLM.
- Direct vLLM metadata probe on Linux with `VLLM_TARGET_DEVICE=tpu python setup.py egg_info`: `.tpu` version and no vLLM-side `numba`.
- Fresh Linux clone exact repro with capped concurrency, `uv add requests`: passed; vLLM remained `.tpu` and no vLLM-side `numba` appeared.
- macOS clean repro on the first vLLM r4 commit (`f5c33000a`, before the env-var presence cleanup), `uv add --no-sync requests`: passed; vLLM remained `.tpu` and had no `numba` dependency. Re-run this on current r4 head `04f7da7e` before treating macOS as final.
- Direct vLLM metadata probe on macOS with `VLLM_TARGET_DEVICE=tpu python setup.py egg_info`: `PKG-INFO` version was `.tpu` and had no `Requires-Dist: numba`.
- `uv tree --locked --package tpu-inference`: `tpu-inference v0.23.0` depends on `numba v0.62.1`; no vLLM/tpu-inference numba resolver conflict remains.
- `uv tree --locked --invert --package numba`: serving path uses `numba v0.62.1` via `tpu-inference`; unrelated `numba v0.63.1` remains via `luxical` / `marin-core[datakit]`.
- `uv run --locked --package marin-core --extra cpu python -c 'import jax; print(jax.__version__)'`: `0.10.1`.
- `uv run --locked --package marin-levanter --extra tpu python -c 'import jax; print(jax.__version__)'`: `0.10.1`.
- `uv run --locked --package marin-fray --group fray_tpu_test python -c 'import jax; print(jax.__version__)'`: `0.10.1`.
- `uv run --locked --package marin-core --group test pytest -n 0 --tb=short tests/test_grug_variant_contracts.py`: `12 passed`.
- `uv run --locked --package marin-levanter --group test pytest -n 0 --tb=short lib/levanter/tests/test_new_loader.py`: `6 passed, 7 skipped`.
- `uv run --locked --package marin-levanter --group test --with 'jax[cpu]==0.9.2' pytest -n 0 --tb=short lib/levanter/tests/test_eval.py::test_tagged_evaluator_accepts_mixed_lm_example_types`: `1 passed`.
- `XLA_FLAGS=--xla_force_host_platform_device_count=4 uv run --locked --package marin-levanter --group test pytest -n 0 --tb=short lib/levanter/tests/test_new_loader.py::test_structured_batches_model_axis_1_with_names lib/levanter/tests/test_new_loader.py::test_structured_batches_model_axis_2_with_names lib/levanter/tests/test_new_loader.py::test_structured_batches_model_axis_2_subsharded`: `3 passed`.
- `uv run --locked --package marin-haliax --group test pytest -n 0 --tb=short lib/haliax/tests/test_pool.py::test_mean_pool_1d lib/haliax/tests/test_pool.py::test_mean_pool_2d lib/haliax/tests/test_pool.py::test_mean_pool3d`: `3 passed`.

Earlier focused checks still relevant to the serving fork overlay:

- Earlier source-build/import smoke through `uv run --locked --package marin-core --extra vllm`: JAX `0.10.1`, Transformers `5.12.1`, and vLLM imports passed before the macOS metadata-only vLLM r4 bump.
- `uv tree --locked --invert --package transformers`: one Transformers `5.12.1` graph across Marin, Levanter, tpu-inference, and vLLM.
- Focused Marin dependency/eval/worker/RL tests: 10 passed.
- vLLM retained-overlay scheduler test through Marin's locked env: 1 passed.
- tpu-inference model-loader and GrugMoE tests through Marin's locked env: 27 passed.
- `./infra/pre-commit.py --review`: all lanes reported no findings.

Real TPU checks on Iris `marin`, interactive priority, `v6e-4`, `europe-west4`:

- Direct `vllm.LLM.generate`: `/romain/vllm-direct-generate-20260629T1844Z-r3-preemptible`, `1 passed in 92.44s`.
- GrugMoE real-checkpoint e2e: `/romain/grugmoe-vllm-e2e-20260629T1847Z-r3-preemptible`, `2 passed, 1 deselected in 241.91s`.
- Local-mode broker/proxy/worker HumanEval: `/romain/served-qwen3-humaneval-local-20260629T1852Z-r3-preemptible`, job succeeded. The proxy served 8 `/v1/completions` requests with status 200, reported 9 matched responses, 0 dropped, 0 timed out, and lm-eval wrote results/samples with limited HumanEval pass@1 `0.375 +/- 0.183`.

CI should be treated as the gate for the broadened Levanter/Fray/GPU JAX package move, especially `levanter-tpu-tests`.

Logs gist: https://gist.github.com/yonromai/867546fbb364ff8c298c9b443c757ef3

</details>

<details>
<summary>Known limits and operational notes</summary>

- The fully brokered Iris parent/child HumanEval path is not claimed here. Attempt `/romain/served-qwen3-humaneval-20260629T1825Z-r3` failed before any TPU worker or vLLM server started because the live current-main Iris controller returned Connect 404 for `EndpointService/ListEndpoints`; tracked in #6754.
- Non-preemptible `v6e-4` capacity was unavailable in `europe-west4`; runtime checks used preemptible workers.
- Raw remote `pytest` missed repo plugin options, so TPU runtime checks ran through `uv run --group test` with `-m tpu_ci`.
- The isolated lm-eval client environment pulls large CUDA/NVIDIA packages outside the Marin lock, making cold HumanEval smokes heavier than the TPU serving path itself.

</details>





