### PR TITLE
[iris] Add search, time, and clickable ids to the log viewer

### DIFF
--- a/lib/iris/dashboard/src/App.vue
+++ b/lib/iris/dashboard/src/App.vue
@@ -22,6 +22,7 @@ const ALL_TABS: (Tab & { requires?: string })[] = [
   { key: 'fleet', label: 'Workers', to: '/fleet', requires: 'workers' },
   { key: 'cluster', label: 'Cluster', to: '/cluster', requires: 'cluster' },
   { key: 'endpoints', label: 'Endpoints', to: '/endpoints' },
+  { key: 'logs', label: 'Logs', to: '/logs' },
   { key: 'account', label: 'Account', to: '/account' },
   { key: 'status', label: 'Status', to: '/status' },
 ]
@@ -36,6 +37,7 @@ const PATH_TO_TAB: Record<string, string> = {
   '/fleet': 'fleet',
   '/cluster': 'cluster',
   '/endpoints': 'endpoints',
+  '/logs': 'logs',
   '/account': 'account',
   '/status': 'status',
 }

--- a/lib/iris/dashboard/src/components/controller/LogsTab.vue
+++ b/lib/iris/dashboard/src/components/controller/LogsTab.vue
@@ -1,0 +1,16 @@
+<script setup lang="ts">
+import LogViewer from '@/components/shared/LogViewer.vue'
+</script>
+
+<template>
+  <div class="space-y-4">
+    <p class="text-sm text-text-secondary">
+      Cluster-wide log explorer. Narrow by source key — a user (<code class="font-mono">/alice/</code>),
+      a job (<code class="font-mono">/alice/job/</code>), a task attempt
+      (<code class="font-mono">/alice/job/0:1</code>), or a worker
+      (<code class="font-mono">/system/worker/…</code>) — then filter by text, level, and time.
+      Task and worker ids in each line are clickable.
+    </p>
+    <LogViewer standalone max-height="72vh" />
+  </div>
+</template>

--- a/lib/iris/dashboard/src/components/controller/StatusTab.vue
+++ b/lib/iris/dashboard/src/components/controller/StatusTab.vue
@@ -113,7 +113,7 @@ const totalBytes = computed(() => {
     <!-- Process logs -->
     <div>
       <h3 class="text-sm font-semibold text-text mb-3">Controller Logs</h3>
-      <LogViewer source="controller" />
+      <LogViewer />
     </div>
   </div>
 </template>

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -28,6 +28,8 @@ const AUTO_REFRESH_MAX_LINES = 2000
 const POLL_INTERVAL_MS = 30_000
 // Retain at most this many rendered lines to keep the DOM bounded.
 const MAX_RETAINED_LINES = 20_000
+// Debounce free-text inputs (source key, substring filter) before refetching.
+const INPUT_DEBOUNCE_MS = 250
 
 const route = useRoute()
 
@@ -210,13 +212,13 @@ const { active: autoRefreshActive, toggle: toggleAutoRefresh } = useAutoRefresh(
 let sourceDebounce: ReturnType<typeof setTimeout> | undefined
 function onSourceInput() {
   if (sourceDebounce) clearTimeout(sourceDebounce)
-  sourceDebounce = setTimeout(resetAndFetch, 250)
+  sourceDebounce = setTimeout(resetAndFetch, INPUT_DEBOUNCE_MS)
 }
 
 let filterDebounce: ReturnType<typeof setTimeout> | undefined
 watch(filter, () => {
   if (filterDebounce) clearTimeout(filterDebounce)
-  filterDebounce = setTimeout(resetAndFetch, 250)
+  filterDebounce = setTimeout(resetAndFetch, INPUT_DEBOUNCE_MS)
 })
 
 watch(selectedAttemptId, applyDefaults)

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -10,7 +10,6 @@ import { parseLogLinks } from '@/utils/logLinks'
 const props = withDefaults(defineProps<{
   taskId?: string
   workerId?: string
-  source?: 'controller' | 'worker'
   maxHeight?: string
   attempts?: TaskAttempt[]
   currentAttemptId?: number
@@ -105,13 +104,16 @@ function applyDefaults() {
   resetAndFetch()
 }
 
-const sinceMs = computed<number | undefined>(() => {
+// Resolve the lower time bound at request time. A relative preset must be
+// recomputed on every fetch (including auto-refresh polls) so the window stays
+// anchored to "now", not to when the preset was first selected.
+function computeSinceMs(): number | undefined {
   if (customSince.value) {
     const ms = Date.parse(customSince.value)
     return Number.isNaN(ms) ? undefined : ms
   }
   return presetMs.value > 0 ? Date.now() - presetMs.value : undefined
-})
+}
 
 // Monotonic generation to discard responses from superseded requests (e.g.
 // when the filter changes while a poll is in flight).
@@ -123,7 +125,7 @@ function baseRequest() {
     matchScope: WIRE_SCOPE[matchScope.value],
     substring: filter.value || undefined,
     minLevel: level.value ? level.value.toUpperCase() : undefined,
-    sinceMs: sinceMs.value,
+    sinceMs: computeSinceMs(),
   }
 }
 
@@ -206,12 +208,13 @@ async function resetAndFetch() {
 const { active: autoRefreshActive, toggle: toggleAutoRefresh } = useAutoRefresh(doPoll, POLL_INTERVAL_MS)
 
 // Free-text fields (source key, substring filter) apply on Enter, not on every
-// keystroke. The discrete selectors below refetch immediately on change.
+// keystroke. The discrete selectors below refetch immediately on change. The
+// match-scope select refetches via @change rather than a watch, so the
+// reassignment in applyDefaults() doesn't fire a redundant second fetch.
 watch(selectedAttemptId, applyDefaults)
-watch(matchScope, resetAndFetch)
 watch(tailLines, resetAndFetch)
 watch(level, resetAndFetch)
-watch(sinceMs, resetAndFetch)
+watch([presetMs, customSince], resetAndFetch)
 
 function selectPreset(ms: number) {
   // The synthetic "Custom" option (-1) only appears while an absolute time is
@@ -244,7 +247,17 @@ watch(
   },
 )
 watch(() => props.workerId, applyDefaults)
-watch(() => props.source, applyDefaults)
+
+// vue-router reuses this instance when only the query changes (e.g. clicking a
+// link to a different attempt of the same task), so onMounted alone won't catch
+// it — keep selectedAttemptId in sync with ?attempt= on query-only navigation.
+watch(() => route.query.attempt, () => {
+  if (!props.taskId) return
+  const routeAttempt = attemptFromRoute()
+  if (routeAttempt >= 0 && routeAttempt !== selectedAttemptId.value) {
+    selectedAttemptId.value = routeAttempt
+  }
+})
 
 onMounted(() => {
   if (props.taskId) {
@@ -287,7 +300,9 @@ const logRows = computed<LogRow[]>(() =>
   entries.value.map(entry => ({
     entry,
     taskRef: showTaskLinks.value ? parseTaskFromKey(entry.key) : null,
-    segments: parseLogLinks(entry.data),
+    // proto3-JSON omits default scalars, so an empty log line arrives with
+    // `data` absent (undefined); coalesce so matchAll() doesn't throw.
+    segments: parseLogLinks(entry.data ?? ''),
   })),
 )
 
@@ -312,6 +327,7 @@ defineExpose({ selectedAttemptId })
         v-model="matchScope"
         title="How the source is matched against log keys"
         class="px-2 py-1.5 border border-surface-border rounded text-sm"
+        @change="resetAndFetch"
       >
         <option value="EXACT">Exact</option>
         <option value="PREFIX">Prefix</option>

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -28,8 +28,6 @@ const AUTO_REFRESH_MAX_LINES = 2000
 const POLL_INTERVAL_MS = 30_000
 // Retain at most this many rendered lines to keep the DOM bounded.
 const MAX_RETAINED_LINES = 20_000
-// Debounce free-text inputs (source key, substring filter) before refetching.
-const INPUT_DEBOUNCE_MS = 250
 
 const route = useRoute()
 
@@ -207,20 +205,8 @@ async function resetAndFetch() {
 
 const { active: autoRefreshActive, toggle: toggleAutoRefresh } = useAutoRefresh(doPoll, POLL_INTERVAL_MS)
 
-// Manual query edits: debounce the free-text source/substring inputs, fetch
-// immediately on the discrete selectors.
-let sourceDebounce: ReturnType<typeof setTimeout> | undefined
-function onSourceInput() {
-  if (sourceDebounce) clearTimeout(sourceDebounce)
-  sourceDebounce = setTimeout(resetAndFetch, INPUT_DEBOUNCE_MS)
-}
-
-let filterDebounce: ReturnType<typeof setTimeout> | undefined
-watch(filter, () => {
-  if (filterDebounce) clearTimeout(filterDebounce)
-  filterDebounce = setTimeout(resetAndFetch, INPUT_DEBOUNCE_MS)
-})
-
+// Free-text fields (source key, substring filter) apply on Enter, not on every
+// keystroke. The discrete selectors below refetch immediately on change.
 watch(selectedAttemptId, applyDefaults)
 watch(matchScope, resetAndFetch)
 watch(tailLines, resetAndFetch)
@@ -316,11 +302,11 @@ defineExpose({ selectedAttemptId })
         v-model="sourceInput"
         type="text"
         spellcheck="false"
-        placeholder="Source key, e.g. /alice/job/ or /system/worker/…"
+        placeholder="Source key, e.g. /alice/job/ or /system/worker/… (Enter to apply)"
         class="w-full sm:w-96 px-3 py-1.5 bg-surface border border-surface-border rounded
                text-sm font-mono placeholder:text-text-muted
                focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent"
-        @input="onSourceInput"
+        @keyup.enter="resetAndFetch"
       />
       <select
         v-model="matchScope"
@@ -348,10 +334,11 @@ defineExpose({ selectedAttemptId })
       <input
         v-model="filter"
         type="text"
-        placeholder="Filter text…"
+        placeholder="Filter text… (Enter to apply)"
         class="w-full sm:w-56 px-3 py-1.5 bg-surface border border-surface-border rounded
                text-sm font-mono placeholder:text-text-muted
                focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent"
+        @keyup.enter="resetAndFetch"
       />
       <select
         v-model="level"

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -1,10 +1,11 @@
 <script setup lang="ts">
 import { ref, computed, onMounted, watch } from 'vue'
-import { RouterLink } from 'vue-router'
+import { RouterLink, useRoute } from 'vue-router'
 import { logServiceRpcCall } from '@/composables/useRpc'
 import { useAutoRefresh } from '@/composables/useAutoRefresh'
 import type { FetchLogsResponse, LogEntry, TaskAttempt } from '@/types/rpc'
 import { timestampMs, logLevelClass, formatLogTime } from '@/utils/formatting'
+import { parseLogLinks } from '@/utils/logLinks'
 
 const props = withDefaults(defineProps<{
   taskId?: string
@@ -13,6 +14,9 @@ const props = withDefaults(defineProps<{
   maxHeight?: string
   attempts?: TaskAttempt[]
   currentAttemptId?: number
+  // Cluster-wide explorer with no fixed context: default the source to a
+  // match-everything prefix instead of the local process stream.
+  standalone?: boolean
 }>(), {
   maxHeight: '60vh',
 })
@@ -25,10 +29,42 @@ const POLL_INTERVAL_MS = 30_000
 // Retain at most this many rendered lines to keep the DOM bounded.
 const MAX_RETAINED_LINES = 20_000
 
+const route = useRoute()
+
+type MatchScope = 'EXACT' | 'PREFIX' | 'REGEX'
+type WireMatchScope = 'MATCH_SCOPE_EXACT' | 'MATCH_SCOPE_PREFIX' | 'MATCH_SCOPE_REGEX'
+const WIRE_SCOPE: Record<MatchScope, WireMatchScope> = {
+  EXACT: 'MATCH_SCOPE_EXACT',
+  PREFIX: 'MATCH_SCOPE_PREFIX',
+  REGEX: 'MATCH_SCOPE_REGEX',
+}
+
+// Relative time windows for the "Since" selector. 0 = no lower bound.
+const SINCE_PRESETS: { label: string; ms: number }[] = [
+  { label: 'All time', ms: 0 },
+  { label: 'Last 15m', ms: 15 * 60_000 },
+  { label: 'Last 1h', ms: 60 * 60_000 },
+  { label: 'Last 6h', ms: 6 * 3_600_000 },
+  { label: 'Last 24h', ms: 24 * 3_600_000 },
+  { label: 'Last 7d', ms: 7 * 86_400_000 },
+]
+
 const filter = ref('')
 const level = ref('info')
 const tailLines = ref(500)
 const selectedAttemptId = ref(props.currentAttemptId ?? -1)
+
+// Editable query. Pre-filled from props (task/worker/controller context) but the
+// user is free to retype the source or widen the match scope — that's how you
+// search by job (`/alice/job/` prefix), by user (`/alice/` prefix), or by an
+// arbitrary key pattern (regex).
+const sourceInput = ref('')
+const matchScope = ref<MatchScope>('EXACT')
+
+// Lower time bound. A preset (relative window) and an absolute datetime-local
+// are mutually exclusive — setting one clears the other.
+const presetMs = ref(0)
+const customSince = ref('')
 
 const entries = ref<LogEntry[]>([])
 const loading = ref(false)
@@ -37,51 +73,73 @@ const errorMsg = ref<string | null>(null)
 const cursor = ref<string | number | null>(null)
 
 // Task IDs end with a numeric segment (e.g. /alice/job/0), job IDs don't.
-const isTask = props.taskId ? /\/\d+$/.test(props.taskId) : false
+const isTask = computed(() => (props.taskId ? /\/\d+$/.test(props.taskId) : false))
 
-type WireMatchScope = 'MATCH_SCOPE_EXACT' | 'MATCH_SCOPE_PREFIX'
-
-interface SourceQuery {
-  source: string
-  matchScope: WireMatchScope
+function attemptFromRoute(): number {
+  const raw = route.query.attempt
+  const n = typeof raw === 'string' ? Number(raw) : NaN
+  return Number.isInteger(n) && n >= 0 ? n : -1
 }
 
-// Build a (literal source, match_scope) pair for FetchLogs. Server treats
-// `source` as a literal string — no regex escaping needed for `:`, `/`, etc.
-// PREFIX picks up every attempt of a task or every task of a job; EXACT
-// pins to a specific attempt or system stream.
-function computeSource(): SourceQuery {
+// Derive the default (source, scope) for the current context. Standalone use
+// (no task/worker/controller context) defaults to a cluster-wide prefix so the
+// explorer shows something before the user narrows it down.
+function defaultSource(): { source: string; scope: MatchScope } {
   if (props.taskId) {
     if (selectedAttemptId.value >= 0) {
-      return { source: `${props.taskId}:${selectedAttemptId.value}`, matchScope: 'MATCH_SCOPE_EXACT' }
+      return { source: `${props.taskId}:${selectedAttemptId.value}`, scope: 'EXACT' }
     }
-    // Boundary char (`:` or `/`) baked into the prefix so we don't bleed
-    // into sibling task ids that share the same numeric leader.
-    return { source: isTask ? `${props.taskId}:` : `${props.taskId}/`, matchScope: 'MATCH_SCOPE_PREFIX' }
+    return { source: isTask.value ? `${props.taskId}:` : `${props.taskId}/`, scope: 'PREFIX' }
   }
-  return {
-    source: props.workerId ? `/system/worker/${props.workerId}` : '/system/controller',
-    matchScope: 'MATCH_SCOPE_EXACT',
-  }
+  if (props.workerId) return { source: `/system/worker/${props.workerId}`, scope: 'EXACT' }
+  if (props.standalone) return { source: '/', scope: 'PREFIX' }
+  return { source: '/system/controller', scope: 'EXACT' }
 }
+
+// Reset the editable query to the context default, then refetch. Used on mount
+// and whenever the surrounding context changes (props, selected attempt).
+function applyDefaults() {
+  const d = defaultSource()
+  sourceInput.value = d.source
+  matchScope.value = d.scope
+  resetAndFetch()
+}
+
+const sinceMs = computed<number | undefined>(() => {
+  if (customSince.value) {
+    const ms = Date.parse(customSince.value)
+    return Number.isNaN(ms) ? undefined : ms
+  }
+  return presetMs.value > 0 ? Date.now() - presetMs.value : undefined
+})
 
 // Monotonic generation to discard responses from superseded requests (e.g.
 // when the filter changes while a poll is in flight).
 let generation = 0
 
+function baseRequest() {
+  return {
+    source: sourceInput.value,
+    matchScope: WIRE_SCOPE[matchScope.value],
+    substring: filter.value || undefined,
+    minLevel: level.value ? level.value.toUpperCase() : undefined,
+    sinceMs: sinceMs.value,
+  }
+}
+
 async function fetchTail() {
+  if (!sourceInput.value) {
+    entries.value = []
+    return
+  }
   const gen = ++generation
   loading.value = true
   errorMsg.value = null
   try {
-    const { source, matchScope } = computeSource()
     const resp = await logServiceRpcCall<FetchLogsResponse>('FetchLogs', {
-      source,
-      matchScope,
+      ...baseRequest(),
       maxLines: tailLines.value || undefined,
       tail: true,
-      substring: filter.value || undefined,
-      minLevel: level.value ? level.value.toUpperCase() : undefined,
     })
     if (gen !== generation) return
     entries.value = resp.entries ?? []
@@ -105,15 +163,11 @@ async function fetchIncremental() {
   // Incremental polls don't toggle `loading` so the UI doesn't flash on every
   // poll; the user only sees the spinner on the initial/tail load.
   try {
-    const { source, matchScope } = computeSource()
     const resp = await logServiceRpcCall<FetchLogsResponse>('FetchLogs', {
-      source,
-      matchScope,
+      ...baseRequest(),
       maxLines: AUTO_REFRESH_MAX_LINES,
       tail: false,
       cursor: cursor.value,
-      substring: filter.value || undefined,
-      minLevel: level.value ? level.value.toUpperCase() : undefined,
     })
     if (gen !== generation) return
     const newEntries = resp.entries ?? []
@@ -140,9 +194,9 @@ async function doPoll() {
   await fetchIncremental()
 }
 
-// Reset the cursor and do a full tail fetch. Used whenever the filter set
-// changes (substring, minLevel, source key, attempt, tail size) — the cursor
-// from the previous filter isn't meaningful for the new criteria.
+// Reset the cursor and do a full tail fetch. Used whenever the query changes
+// (source, scope, substring, level, since, attempt, tail size) — the cursor
+// from the previous query isn't meaningful for the new criteria.
 async function resetAndFetch() {
   cursor.value = null
   entries.value = []
@@ -151,26 +205,49 @@ async function resetAndFetch() {
 
 const { active: autoRefreshActive, toggle: toggleAutoRefresh } = useAutoRefresh(doPoll, POLL_INTERVAL_MS)
 
-watch(selectedAttemptId, resetAndFetch)
-watch(tailLines, resetAndFetch)
-watch(level, resetAndFetch)
+// Manual query edits: debounce the free-text source/substring inputs, fetch
+// immediately on the discrete selectors.
+let sourceDebounce: ReturnType<typeof setTimeout> | undefined
+function onSourceInput() {
+  if (sourceDebounce) clearTimeout(sourceDebounce)
+  sourceDebounce = setTimeout(resetAndFetch, 250)
+}
 
 let filterDebounce: ReturnType<typeof setTimeout> | undefined
 watch(filter, () => {
   if (filterDebounce) clearTimeout(filterDebounce)
   filterDebounce = setTimeout(resetAndFetch, 250)
 })
+
+watch(selectedAttemptId, applyDefaults)
+watch(matchScope, resetAndFetch)
+watch(tailLines, resetAndFetch)
+watch(level, resetAndFetch)
+watch(sinceMs, resetAndFetch)
+
+function selectPreset(ms: number) {
+  // The synthetic "Custom" option (-1) only appears while an absolute time is
+  // set; re-selecting it is a no-op so the datetime input stays in effect.
+  if (ms < 0) return
+  customSince.value = ''
+  presetMs.value = ms
+}
+
+watch(customSince, (val) => {
+  if (val) presetMs.value = 0
+})
+
 watch(
   () => [props.taskId, props.currentAttemptId] as const,
   ([taskId, currentAttemptId], [previousTaskId, previousCurrentAttemptId]) => {
     if (taskId !== previousTaskId) {
-      selectedAttemptId.value = -1
-      resetAndFetch()
+      selectedAttemptId.value = attemptFromRoute()
+      applyDefaults()
       return
     }
     if (taskId === undefined || currentAttemptId === previousCurrentAttemptId) return
     if (selectedAttemptId.value === -1) {
-      resetAndFetch()
+      applyDefaults()
       return
     }
     if (selectedAttemptId.value === previousCurrentAttemptId) {
@@ -178,9 +255,16 @@ watch(
     }
   },
 )
-watch(() => props.workerId, resetAndFetch)
+watch(() => props.workerId, applyDefaults)
+watch(() => props.source, applyDefaults)
 
-onMounted(resetAndFetch)
+onMounted(() => {
+  if (props.taskId) {
+    const routeAttempt = attemptFromRoute()
+    if (routeAttempt >= 0) selectedAttemptId.value = routeAttempt
+  }
+  applyDefaults()
+})
 
 // Job-aggregate mode shows logs from many tasks; render a per-line link to the
 // originating task. Single-task mode would link every line to itself, so skip.
@@ -208,12 +292,14 @@ function parseTaskFromKey(key: string | undefined): TaskRef | null {
 interface LogRow {
   entry: LogEntry
   taskRef: TaskRef | null
+  segments: ReturnType<typeof parseLogLinks>
 }
 
 const logRows = computed<LogRow[]>(() =>
   entries.value.map(entry => ({
     entry,
     taskRef: showTaskLinks.value ? parseTaskFromKey(entry.key) : null,
+    segments: parseLogLinks(entry.data),
   })),
 )
 
@@ -222,12 +308,46 @@ defineExpose({ selectedAttemptId })
 
 <template>
   <div class="space-y-2">
+    <!-- Query row: source + match scope (+ attempt picker on task pages) -->
+    <div class="flex flex-wrap items-center gap-2 sm:gap-3 text-sm">
+      <input
+        v-model="sourceInput"
+        type="text"
+        spellcheck="false"
+        placeholder="Source key, e.g. /alice/job/ or /system/worker/…"
+        class="w-full sm:w-96 px-3 py-1.5 bg-surface border border-surface-border rounded
+               text-sm font-mono placeholder:text-text-muted
+               focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent"
+        @input="onSourceInput"
+      />
+      <select
+        v-model="matchScope"
+        title="How the source is matched against log keys"
+        class="px-2 py-1.5 border border-surface-border rounded text-sm"
+      >
+        <option value="EXACT">Exact</option>
+        <option value="PREFIX">Prefix</option>
+        <option value="REGEX">Regex</option>
+      </select>
+      <select
+        v-if="attempts && attempts.length > 0"
+        v-model.number="selectedAttemptId"
+        class="px-2 py-1.5 border border-surface-border rounded text-sm"
+      >
+        <option :value="-1">All attempts</option>
+        <option v-for="a in attempts" :key="a.attemptId" :value="a.attemptId">
+          Attempt {{ a.attemptId }}
+        </option>
+      </select>
+    </div>
+
+    <!-- Filter row: text search + level + since + tail size + auto-refresh -->
     <div class="flex flex-wrap items-center gap-2 sm:gap-3 text-sm">
       <input
         v-model="filter"
         type="text"
-        placeholder="Filter logs..."
-        class="w-full sm:w-64 px-3 py-1.5 bg-surface border border-surface-border rounded
+        placeholder="Filter text…"
+        class="w-full sm:w-56 px-3 py-1.5 bg-surface border border-surface-border rounded
                text-sm font-mono placeholder:text-text-muted
                focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent"
       />
@@ -241,6 +361,21 @@ defineExpose({ selectedAttemptId })
         <option value="error">Error</option>
       </select>
       <select
+        :value="customSince ? -1 : presetMs"
+        title="Only show logs newer than this"
+        class="px-2 py-1.5 border border-surface-border rounded text-sm"
+        @change="selectPreset(Number(($event.target as HTMLSelectElement).value))"
+      >
+        <option v-if="customSince" :value="-1">Custom</option>
+        <option v-for="p in SINCE_PRESETS" :key="p.ms" :value="p.ms">{{ p.label }}</option>
+      </select>
+      <input
+        v-model="customSince"
+        type="datetime-local"
+        title="Show logs since a specific date/time"
+        class="px-2 py-1.5 border border-surface-border rounded text-sm"
+      />
+      <select
         v-model.number="tailLines"
         class="px-2 py-1.5 border border-surface-border rounded text-sm"
       >
@@ -248,16 +383,6 @@ defineExpose({ selectedAttemptId })
         <option :value="1000">1,000 lines</option>
         <option :value="5000">5,000 lines</option>
         <option :value="10000">10,000 lines</option>
-      </select>
-      <select
-        v-if="attempts && attempts.length > 0"
-        v-model.number="selectedAttemptId"
-        class="px-2 py-1.5 border border-surface-border rounded text-sm"
-      >
-        <option :value="-1">All attempts</option>
-        <option v-for="a in attempts" :key="a.attemptId" :value="a.attemptId">
-          Attempt {{ a.attemptId }}
-        </option>
       </select>
       <button
         class="px-2 py-1.5 border border-surface-border rounded text-sm hover:bg-surface-sunken"
@@ -311,7 +436,14 @@ defineExpose({ selectedAttemptId })
           T{{ row.taskRef.taskIndex }}
         </RouterLink>
         <span class="text-text-muted mr-2">{{ formatLogTime(timestampMs(row.entry.timestamp)) }}</span>
-        <span class="whitespace-pre-wrap break-all">{{ row.entry.data }}</span>
+        <span class="whitespace-pre-wrap break-all"><template
+          v-for="(seg, j) in row.segments"
+          :key="j"
+        ><RouterLink
+          v-if="seg.to"
+          :to="seg.to"
+          class="text-accent hover:underline"
+        >{{ seg.text }}</RouterLink><template v-else>{{ seg.text }}</template></template></span>
       </div>
     </div>
   </div>

--- a/lib/iris/dashboard/src/components/worker/WorkerStatusPage.vue
+++ b/lib/iris/dashboard/src/components/worker/WorkerStatusPage.vue
@@ -114,7 +114,7 @@ const totalBytes = computed(() => {
       <!-- Worker process logs -->
       <div>
         <h3 class="text-sm font-semibold text-text mb-3">Worker Logs</h3>
-        <LogViewer source="worker" />
+        <LogViewer />
       </div>
     </template>
   </div>

--- a/lib/iris/dashboard/src/components/worker/WorkerTaskDetail.vue
+++ b/lib/iris/dashboard/src/components/worker/WorkerTaskDetail.vue
@@ -285,7 +285,7 @@ onMounted(async () => {
       <!-- Task logs -->
       <div>
         <h3 class="text-sm font-semibold text-text mb-3">Logs</h3>
-        <LogViewer :task-id="taskId" source="worker" />
+        <LogViewer :task-id="taskId" />
       </div>
     </template>
 

--- a/lib/iris/dashboard/src/router.ts
+++ b/lib/iris/dashboard/src/router.ts
@@ -27,6 +27,10 @@ const routes = [
     component: () => import('./components/controller/EndpointsTab.vue'),
   },
   {
+    path: '/logs',
+    component: () => import('./components/controller/LogsTab.vue'),
+  },
+  {
     path: '/status',
     component: () => import('./components/controller/StatusTab.vue'),
   },

--- a/lib/iris/dashboard/src/utils/logLinks.ts
+++ b/lib/iris/dashboard/src/utils/logLinks.ts
@@ -1,0 +1,64 @@
+// Detect navigable iris identifiers inside free-form log text and turn them
+// into router links. These are deliberately quick regex checks against the
+// rendered line — no store lookups — so a stray false positive just yields a
+// dead-but-harmless link, never a wrong query.
+
+/** A run of log text, optionally carrying a router target to link it to. */
+export interface LogSegment {
+  text: string
+  to?: string
+}
+
+// worker-<slice>-<tpu_index>-<uuid8>. The slice id can itself contain dashes,
+// so anchor on the trailing 8-hex uuid that every worker id ends with.
+const WORKER_PATTERN = 'worker-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*-[0-9a-f]{8}'
+
+// A task id is a slash path whose final segment is the numeric task index
+// (e.g. /alice/train/3), optionally suffixed with :<attempt> (/alice/train/3:1).
+// Requires at least one named segment before the index so a bare /3 or a
+// file:line like foo.py:42 doesn't match.
+const TASK_PATTERN = '(?:/[A-Za-z0-9][A-Za-z0-9._-]*)+/\\d+(?::\\d+)?'
+
+const TOKEN_RE = new RegExp(`(?<worker>${WORKER_PATTERN})|(?<task>${TASK_PATTERN})`, 'g')
+
+function jobIdOf(taskId: string): string {
+  const slash = taskId.lastIndexOf('/')
+  return slash > 0 ? taskId.slice(0, slash) : taskId
+}
+
+/** Router target for a task id, optionally pinned to a specific attempt. */
+export function taskAttemptRoute(taskId: string, attemptId?: string | number): string {
+  const base = `/job/${encodeURIComponent(jobIdOf(taskId))}/task/${encodeURIComponent(taskId)}`
+  return attemptId !== undefined && attemptId !== '' ? `${base}?attempt=${attemptId}` : base
+}
+
+function taskTargetFromMatch(match: string): string {
+  const colon = match.lastIndexOf(':')
+  if (colon > 0) {
+    return taskAttemptRoute(match.slice(0, colon), match.slice(colon + 1))
+  }
+  return taskAttemptRoute(match)
+}
+
+/**
+ * Split a log line into plain-text and linked segments. Worker ids link to the
+ * worker page; task/attempt paths link to the task (attempt) page. Returns a
+ * single plain segment when nothing matches.
+ */
+export function parseLogLinks(text: string): LogSegment[] {
+  const segments: LogSegment[] = []
+  let last = 0
+  for (const m of text.matchAll(TOKEN_RE)) {
+    const start = m.index ?? 0
+    if (start > last) segments.push({ text: text.slice(last, start) })
+    const groups = m.groups ?? {}
+    if (groups.worker) {
+      segments.push({ text: m[0], to: `/worker/${groups.worker}` })
+    } else {
+      segments.push({ text: m[0], to: taskTargetFromMatch(m[0]) })
+    }
+    last = start + m[0].length
+  }
+  if (last < text.length) segments.push({ text: text.slice(last) })
+  return segments
+}

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -421,8 +421,11 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
         "Should have structural elements like a status card and resource info.",
     )
 
-    # "validation failed" only appears in ERROR lines
-    smoke_page.fill("input[placeholder='Filter logs...']", "validation failed")
+    # "validation failed" only appears in ERROR lines. The text filter applies
+    # on Enter, not on every keystroke.
+    filter_input = "input[placeholder^='Filter text']"
+    smoke_page.fill(filter_input, "validation failed")
+    smoke_page.press(filter_input, "Enter")
     smoke_page.wait_for_function(
         "() => document.body.textContent.includes('validation failed') && "
         "!document.body.textContent.includes('processing data batch')",


### PR DESCRIPTION
The dashboard log viewer was a single substring box. This turns the shared
LogViewer into a real explorer while keeping every embedded use (task, job,
worker, status pages) pre-scoped as before.

- The source key and match scope (exact/prefix/regex) are now editable fields,
  pre-filled from context. Retyping the source is how you search by job
  (`/alice/job/` prefix), by user (`/alice/` prefix), or by an arbitrary key
  pattern (regex).
- A "Since" lower bound — relative presets plus an absolute datetime — backed by
  the existing `FetchLogs.since_ms`.
- Each log line is scanned (quick regex, no store lookups) for task/attempt
  paths and worker ids and rendered as links to the attempt and worker pages.
  Task links carry `?attempt=N`, which the viewer reads back to pre-select that
  attempt.
- A new Logs tab hosts the same viewer standalone for cluster-wide searches.

Part of weaver #330.