### PR TITLE
[zephyr] Remove legacy counter aliases; expose ZephyrExecutionResult.counters as float

### DIFF
--- a/experiments/datakit/cluster/domain/v0/assign.py
+++ b/experiments/datakit/cluster/domain/v0/assign.py
@@ -48,7 +48,7 @@ class AssignmentAttrData(BaseModel):
     embedding_output_dir: str
     k_train: int
     k_views: list[int]
-    counters: dict[str, int] = {}
+    counters: dict[str, int | float] = {}
 
     def shard_paths(self) -> list[str]:
         return sorted(fsspec_glob(f"{self.output_dir.rstrip('/')}/*.parquet"))

--- a/experiments/datakit/cluster/domain/v0/assign.py
+++ b/experiments/datakit/cluster/domain/v0/assign.py
@@ -129,8 +129,8 @@ def _assign_shard(
                 rec[f"cluster_{k}"] = int(coarser[k][i])
             yield rec
 
-    counters.increment("assign/docs_in", n_docs)
-    counters.increment("assign/shards_in", 1)
+    counters.pipeline.update_counter("assign/docs_in", n_docs)
+    counters.pipeline.update_counter("assign/shards_in", 1)
     logger.info(
         "shard %d/%d: %d docs assigned (K=%d centroids, %d coarser views)",
         shard.shard_idx,

--- a/experiments/datakit/cluster/domain/weborganizer/all_sources_topic.py
+++ b/experiments/datakit/cluster/domain/weborganizer/all_sources_topic.py
@@ -108,7 +108,7 @@ class WeborgTopicOutput(BaseModel):
     version: str = "v1"
     output_dir: str
     model_path: str
-    counters: dict[str, int]
+    counters: dict[str, int | float]
 
 
 def _run_one_source(

--- a/experiments/datakit/cluster/quality/dolma3_quality/all_sources_quality.py
+++ b/experiments/datakit/cluster/quality/dolma3_quality/all_sources_quality.py
@@ -119,7 +119,7 @@ class DolmaQualityOutput(BaseModel):
     version: str = "v1"
     output_dir: str
     model_path: str
-    counters: dict[str, int]
+    counters: dict[str, int | float]
 
 
 def _run_one_source(

--- a/experiments/datakit/cluster/quality/v0/all_sources_quality_llm.py
+++ b/experiments/datakit/cluster/quality/v0/all_sources_quality_llm.py
@@ -98,7 +98,7 @@ class LlmQualityOutput(BaseModel):
     version: str = "v1"
     output_dir: str
     model_path: str
-    counters: dict[str, int]
+    counters: dict[str, int | float]
 
 
 def _register_model_step(name: str, model_bin_path: str, output_path_prefix: str | None = None) -> StepSpec:

--- a/experiments/datakit/dedup/ops/fetch_cluster_texts_zephyr.py
+++ b/experiments/datakit/dedup/ops/fetch_cluster_texts_zephyr.py
@@ -200,10 +200,10 @@ def _fetch_one(task: dict) -> Iterator[dict]:
                     break
             if found == target:
                 break
-    counters.increment("fetch/shards_done")
-    counters.increment("fetch/members_found", found)
+    counters.pipeline.update_counter("fetch/shards_done", 1)
+    counters.pipeline.update_counter("fetch/members_found", found)
     if found < target:
-        counters.increment("fetch/members_missing", target - found)
+        counters.pipeline.update_counter("fetch/members_missing", target - found)
 
 
 def _collect_members(cluster_id: str, items: Iterator[dict]) -> dict:

--- a/experiments/datakit/embeddings/luxical/pipeline.py
+++ b/experiments/datakit/embeddings/luxical/pipeline.py
@@ -106,7 +106,7 @@ class EmbeddingAttrData(BaseModel):
     quantization_scale: float
     quantization_range: float
     batch_size: int
-    counters: dict[str, int] = {}
+    counters: dict[str, int | float] = {}
 
     def shard_paths(self) -> list[str]:
         return sorted(fsspec_glob(f"{self.output_dir.rstrip('/')}/*.parquet"))

--- a/experiments/datakit/embeddings/luxical/pipeline.py
+++ b/experiments/datakit/embeddings/luxical/pipeline.py
@@ -199,9 +199,9 @@ def _embed_shard(
         q = quantize_to_int8(raw)
         for i, did in enumerate(ids):
             yield {"id": did, "embedding": q[i].tolist()}
-    counters.increment("embed/docs_in", n_docs)
-    counters.increment("embed/bytes_in", n_bytes)
-    counters.increment("embed/shards_in", 1)
+    counters.pipeline.update_counter("embed/docs_in", n_docs)
+    counters.pipeline.update_counter("embed/bytes_in", n_bytes)
+    counters.pipeline.update_counter("embed/shards_in", 1)
     logger.info(
         "shard %d/%d: %d docs (%.1f MB) encoded",
         shard.shard_idx,

--- a/experiments/datakit/fasttext.py
+++ b/experiments/datakit/fasttext.py
@@ -237,8 +237,8 @@ def _predict_batch(
     to score).
     """
     model = model_load_fn(model_path_str)
-    counters.increment(name="classify/batches_in")
-    counters.increment("classify/docs_in", len(batch))
+    counters.pipeline.update_counter("classify/batches_in", 1)
+    counters.pipeline.update_counter("classify/docs_in", len(batch))
 
     texts: list[str] = []
     records_to_predict: list[dict[str, Any]] = []
@@ -257,13 +257,13 @@ def _predict_batch(
             truncated += 1
         texts.append(normalized)
         records_to_predict.append(record)
-    counters.increment("classify/bytes_in", bytes_in)
-    counters.increment("classify/empty_text", len(batch) - len(texts))
+    counters.pipeline.update_counter("classify/bytes_in", bytes_in)
+    counters.pipeline.update_counter("classify/empty_text", len(batch) - len(texts))
     if truncated:
-        counters.increment("classify/docs_truncated", truncated)
+        counters.pipeline.update_counter("classify/docs_truncated", truncated)
 
     if not texts:
-        counters.increment("classify/batches_skipped_empty")
+        counters.pipeline.update_counter("classify/batches_skipped_empty", 1)
         return
 
     # IMPORTANT: per-text predict, NOT batch predict.
@@ -283,7 +283,7 @@ def _predict_batch(
     for record, text in zip(records_to_predict, texts, strict=True):
         labels, probs = model.predict(text, k=k, threshold=threshold)
         stripped = [_strip_label_prefix(label) for label in labels]
-        counters.increment("classify/predicted")
+        counters.pipeline.update_counter("classify/predicted", 1)
         yield {**record, output_field_name: _value_from_prediction(stripped, probs, score_target_label)}
 
 

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -129,7 +129,7 @@ class ClusteredStoreData(BaseModel):
     buckets: list[BucketCacheStats]
     source_names: list[str]
     tokenizer: str
-    counters: dict[str, int]
+    counters: dict[str, int | float]
 
 
 # ---------------------------------------------------------------------------
@@ -652,7 +652,7 @@ def build_clustered_store(
             raise ValueError(f"{label} source set must equal tokenize: missing={missing!r}, extra={extra!r}")
 
     cluster_col = _validate_cluster_view(cluster_assign, cluster_view)
-    counters: dict[str, int] = {}
+    counters: dict[str, int | float] = {}
 
     if aggregate_only:
         # Skip the zephyr pass entirely and pick up from the durable sidecars

--- a/experiments/datakit/store/datakit_store.py
+++ b/experiments/datakit/store/datakit_store.py
@@ -367,7 +367,7 @@ def _join_filter_stream_shard(
     sidecar = _sidecar_path(output_path, shard_info.shard_idx, shard_info.total_shards)
     cached = _load_shard_sidecar(sidecar)
     if cached is not None:
-        counters.increment("datakit_store/shards_resumed", 1)
+        counters.pipeline.update_counter("datakit_store/shards_resumed", 1)
         yield {"shard_idx": shard_info.shard_idx, "n_buckets": len(cached)}
         return
 
@@ -496,10 +496,10 @@ def _join_filter_stream_shard(
     # ExitStack done: SerialCacheWriter.__exit__ wrote each per-shard ledger;
     # atomic_rename.__exit__ renamed tmp_path -> cache_dir. Load each ledger
     # once so the driver can run _merge_sharded_ledgers without re-reading.
-    counters.increment("datakit_store/records_in", n_in_total)
-    counters.increment("datakit_store/contaminated_dropped", n_contaminated_total)
-    counters.increment("datakit_store/dedup_noncanonical_dropped", n_dedup_dropped_total)
-    counters.increment("datakit_store/records_out", n_out_total)
+    counters.pipeline.update_counter("datakit_store/records_in", n_in_total)
+    counters.pipeline.update_counter("datakit_store/contaminated_dropped", n_contaminated_total)
+    counters.pipeline.update_counter("datakit_store/dedup_noncanonical_dropped", n_dedup_dropped_total)
+    counters.pipeline.update_counter("datakit_store/records_out", n_out_total)
 
     metadata = CacheMetadata.empty()
     records: list[_WrittenShard] = []

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -863,11 +863,11 @@ def write_levanter_cache(
             with ThreadedBatchWriter(_drain_batches) as threaded:
                 threaded.submit([exemplar])
                 count += 1
-                zephyr_counters.increment("zephyr/records_out")
+                zephyr_counters.pipeline.update_counter("zephyr/records_out", 1)
                 for batch in batchify(record_iter, n=batch_size):
                     threaded.submit(batch)
                     count += len(batch)
-                    zephyr_counters.increment("zephyr/records_out", len(batch))
+                    zephyr_counters.pipeline.update_counter("zephyr/records_out", len(batch))
                     logger.info("write_levanter_cache: %s — %d records so far", output_path, count)
 
     logger.info("write_levanter_cache: finished %s — %d records", output_path, count)

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -90,7 +90,7 @@ class DeconAttributes(BaseModel):
     output_dir: str
     num_partitions: int
     eval_hash_index_path: str
-    counters: dict[str, int]
+    counters: dict[str, int | float]
 
 
 _BLOOM_FILENAME = "filter.bin"
@@ -360,7 +360,7 @@ def _make_marker(
                             max_score = score
                         matched.update(hits)
                     contaminated = max_score > 0 and max_score >= threshold
-                    counters.increment("decon/contaminated" if contaminated else "decon/clean")
+                    counters.pipeline.update_counter("decon/contaminated" if contaminated else "decon/clean", 1)
                     # Dataset.from_list yields one shard per item in input order, so shard.shard_idx
                     # matches the input's "part-NNNNN-of-NNNNN" partition number on a sorted file list.
                     yield {

--- a/lib/marin/src/marin/datakit/download/biodiversity.py
+++ b/lib/marin/src/marin/datakit/download/biodiversity.py
@@ -47,10 +47,10 @@ def stitch_pages(item_id: str, pages: Iterator[dict]) -> Iterator[dict]:
     """
     texts = [str(p["text"]) for p in pages if p.get("text")]
     if not texts:
-        counters.increment("biodiversity/dropped_items")
+        counters.pipeline.update_counter("biodiversity/dropped_items", 1)
         return
-    counters.increment("biodiversity/kept_items")
-    counters.increment("biodiversity/pages_stitched", len(texts))
+    counters.pipeline.update_counter("biodiversity/kept_items", 1)
+    counters.pipeline.update_counter("biodiversity/pages_stitched", len(texts))
     yield {
         "text": PAGE_SEPARATOR.join(texts),
         "source": SOURCE_NAME,

--- a/lib/marin/src/marin/datakit/download/coderforge.py
+++ b/lib/marin/src/marin/datakit/download/coderforge.py
@@ -64,19 +64,19 @@ def render_message(msg: dict) -> str:
 def row_to_doc(row: dict) -> list[dict]:
     messages_raw = row.get("messages", "")
     if not messages_raw:
-        counters.increment("coderforge/dropped")
+        counters.pipeline.update_counter("coderforge/dropped", 1)
         return []
 
     messages = json.loads(messages_raw) if isinstance(messages_raw, str) else messages_raw
     if not messages:
-        counters.increment("coderforge/dropped")
+        counters.pipeline.update_counter("coderforge/dropped", 1)
         return []
 
     tag = reward_to_tag(row.get("reward"))
     rendered = "\n\n".join(render_message(m) for m in messages)
     text = f"{tag}\n\n{rendered}"
 
-    counters.increment("coderforge/kept")
+    counters.pipeline.update_counter("coderforge/kept", 1)
     return [text_document(text, "togethercomputer/CoderForge-Preview")]
 
 

--- a/lib/marin/src/marin/datakit/download/common_corpus.py
+++ b/lib/marin/src/marin/datakit/download/common_corpus.py
@@ -17,26 +17,26 @@ OPEN_TYPES = ["Open Science", "Open Government", "Open Culture"]
 
 
 def _count_total(record: dict) -> dict:
-    counters.increment("common_corpus/total")
+    counters.pipeline.update_counter("common_corpus/total", 1)
     return record
 
 
 def _language_is_english(record: dict) -> bool:
     if record.get("language") != "English":
-        counters.increment("common_corpus/dropped_non_english")
+        counters.pipeline.update_counter("common_corpus/dropped_non_english", 1)
         return False
     return True
 
 
 def _open_type_allowed(record: dict) -> bool:
     if record.get("open_type") not in OPEN_TYPES:
-        counters.increment("common_corpus/dropped_wrong_open_type")
+        counters.pipeline.update_counter("common_corpus/dropped_wrong_open_type", 1)
         return False
     return True
 
 
 def _count_kept(record: dict) -> dict:
-    counters.increment("common_corpus/kept")
+    counters.pipeline.update_counter("common_corpus/kept", 1)
     return record
 
 

--- a/lib/marin/src/marin/datakit/download/davinci_dev.py
+++ b/lib/marin/src/marin/datakit/download/davinci_dev.py
@@ -87,7 +87,7 @@ def ctx_row_to_doc(row: dict) -> list[dict]:
     repo_name = row.get("repo_name") or ""
     title = row.get("title") or ""
     if not repo_name or not title:
-        counters.increment("davinci_dev/ctx/dropped")
+        counters.pipeline.update_counter("davinci_dev/ctx/dropped", 1)
         return []
 
     sections = [
@@ -100,10 +100,10 @@ def ctx_row_to_doc(row: dict) -> list[dict]:
     ]
     text = "\n\n".join(s for s in sections if s).strip()
     if not text:
-        counters.increment("davinci_dev/ctx/dropped")
+        counters.pipeline.update_counter("davinci_dev/ctx/dropped", 1)
         return []
 
-    counters.increment("davinci_dev/ctx/kept")
+    counters.pipeline.update_counter("davinci_dev/ctx/kept", 1)
     return [text_document(text, "GAIR/daVinci-Dev/ctx-native")]
 
 
@@ -197,13 +197,13 @@ def _success_to_tag(success: bool | None) -> str | None:
 def env_row_to_doc(row: dict) -> list[dict]:
     messages = row.get("messages")
     if not messages:
-        counters.increment("davinci_dev/env/dropped")
+        counters.pipeline.update_counter("davinci_dev/env/dropped", 1)
         return []
     tag = _success_to_tag(row.get("success") if "success" in row else None)
     rendered = "\n\n".join(_render_env_message(m) for m in messages)
     text = f"{tag}\n\n{rendered}" if tag else rendered
 
-    counters.increment("davinci_dev/env/kept")
+    counters.pipeline.update_counter("davinci_dev/env/kept", 1)
     return [text_document(text, "GAIR/daVinci-Dev/env-native")]
 
 

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -180,7 +180,7 @@ class MaterializedDiagnosticLogParquet(DiagnosticLogsArtifact):
     output_dir: str
     data_glob: str
     record_count: int
-    counters: dict[str, int]
+    counters: dict[str, int | float]
     content_fingerprint: str
 
 
@@ -616,13 +616,13 @@ def _process_ghalogs_member_batch(batch: list[str], archive_path: str) -> Iterat
             for name in batch:
                 with zf.open(name, "r") as member_file:
                     content = member_file.read()
-                counters.increment("zephyr/records_in")
+                counters.pipeline.update_counter("zephyr/records_in", 1)
                 record = ghalogs_member_to_record(name, content)
                 if record is None:
-                    counters.increment("ghalogs_materialize/dropped_empty")
+                    counters.pipeline.update_counter("ghalogs_materialize/dropped_empty", 1)
                     continue
-                counters.increment("ghalogs_materialize/kept")
-                counters.increment(f"ghalogs_materialize/partition_{record['partition']}")
+                counters.pipeline.update_counter("ghalogs_materialize/kept", 1)
+                counters.pipeline.update_counter(f"ghalogs_materialize/partition_{record['partition']}", 1)
                 yield record
 
 
@@ -687,7 +687,7 @@ def materialize_ghalogs_to_parquet(
 
 
 def _count_partition_record(record: dict[str, str], partition: DiagnosticPartition) -> dict[str, str]:
-    counters.increment(f"ghalogs_partition/{partition.value}_kept")
+    counters.pipeline.update_counter(f"ghalogs_partition/{partition.value}_kept", 1)
     return record
 
 

--- a/lib/marin/src/marin/datakit/download/finetranslations.py
+++ b/lib/marin/src/marin/datakit/download/finetranslations.py
@@ -46,7 +46,7 @@ def fold_parallel_text(record: dict) -> Iterator[dict]:
     original = record.get("og_full_text") or ""
     english = record.get("translated_text") or ""
     if not original and not english:
-        counters.increment("finetranslations/empty")
+        counters.pipeline.update_counter("finetranslations/empty", 1)
         return
 
     # Coin flip from the row id (falls back to the original text) so the chosen
@@ -54,13 +54,13 @@ def fold_parallel_text(record: dict) -> Iterator[dict]:
     # sides are dropped from the join, so single-sided rows pass through as-is.
     coin = record.get("id") or original
     if dupekit.hash_xxh3_128(coin.encode("utf-8")) & 1:
-        counters.increment("finetranslations/english_first")
+        counters.pipeline.update_counter("finetranslations/english_first", 1)
         parts = (english, original)
     else:
-        counters.increment("finetranslations/original_first")
+        counters.pipeline.update_counter("finetranslations/original_first", 1)
         parts = (original, english)
 
-    counters.increment("finetranslations/kept")
+    counters.pipeline.update_counter("finetranslations/kept", 1)
     yield {"text": SEPARATOR.join(p for p in parts if p)}
 
 

--- a/lib/marin/src/marin/datakit/download/gpt_oss_rollouts.py
+++ b/lib/marin/src/marin/datakit/download/gpt_oss_rollouts.py
@@ -34,7 +34,7 @@ def row_to_doc(row: dict) -> list[dict]:
     thinking = row.get("assistant_thinking") or ""
     response = row.get("assistant_content") or ""
     if not user or not response:
-        counters.increment("gpt_oss_rollouts/dropped")
+        counters.pipeline.update_counter("gpt_oss_rollouts/dropped", 1)
         return []
 
     parts = [f"<user>\n{user}\n</user>"]
@@ -44,7 +44,7 @@ def row_to_doc(row: dict) -> list[dict]:
 
     text = "\n\n".join(parts)
 
-    counters.increment("gpt_oss_rollouts/kept")
+    counters.pipeline.update_counter("gpt_oss_rollouts/kept", 1)
     return [text_document(text, "andyrdt/gpt-oss-20b-rollouts")]
 
 

--- a/lib/marin/src/marin/datakit/download/hplt.py
+++ b/lib/marin/src/marin/datakit/download/hplt.py
@@ -191,9 +191,9 @@ def _download_and_filter_shard(shard: HpltShard) -> Iterator[dict]:
                     },
                 }
     finally:
-        counters.increment("hplt/input", num_input)
-        counters.increment("hplt/non_cc", num_non_cc)
-        counters.increment("hplt/kept", num_kept)
+        counters.pipeline.update_counter("hplt/input", num_input)
+        counters.pipeline.update_counter("hplt/non_cc", num_non_cc)
+        counters.pipeline.update_counter("hplt/kept", num_kept)
 
 
 def download_hplt_v3(output_path: str) -> None:

--- a/lib/marin/src/marin/datakit/download/institutional_books.py
+++ b/lib/marin/src/marin/datakit/download/institutional_books.py
@@ -38,10 +38,10 @@ def row_to_doc(row: dict) -> list[dict]:
     pages = row.get("text_by_page_gen") or row.get("text_by_page_src") or []
     pages = [p for p in pages if p]
     if not pages:
-        counters.increment("institutional_books/dropped")
+        counters.pipeline.update_counter("institutional_books/dropped", 1)
         return []
 
-    counters.increment("institutional_books/kept")
+    counters.pipeline.update_counter("institutional_books/kept", 1)
     return [
         {
             "text": PAGE_SEPARATOR.join(pages),

--- a/lib/marin/src/marin/datakit/download/molmo2_cap.py
+++ b/lib/marin/src/marin/datakit/download/molmo2_cap.py
@@ -26,7 +26,7 @@ def row_to_doc(row: dict) -> list[dict]:
     frame_captions = row.get("frame_captions") or []
 
     if not merged.strip():
-        counters.increment("molmo2_cap/dropped")
+        counters.pipeline.update_counter("molmo2_cap/dropped", 1)
         return []
 
     parts = [merged.strip()]
@@ -38,7 +38,7 @@ def row_to_doc(row: dict) -> list[dict]:
 
     text = "\n\n".join(parts)
 
-    counters.increment("molmo2_cap/kept")
+    counters.pipeline.update_counter("molmo2_cap/kept", 1)
     return [text_document(text, HF_DATASET_ID)]
 
 

--- a/lib/marin/src/marin/datakit/download/nemotron_terminal.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_terminal.py
@@ -23,12 +23,12 @@ HF_REVISION = "a1667c4"
 def row_to_doc(row: dict) -> list[dict]:
     conversations = row.get("conversations")
     if not conversations:
-        counters.increment("nemotron_terminal/dropped")
+        counters.pipeline.update_counter("nemotron_terminal/dropped", 1)
         return []
 
     text = "\n\n".join(render_role_message(m) for m in conversations)
 
-    counters.increment("nemotron_terminal/kept")
+    counters.pipeline.update_counter("nemotron_terminal/kept", 1)
     return [text_document(text, "nvidia/Nemotron-Terminal-Corpus")]
 
 

--- a/lib/marin/src/marin/datakit/download/nsf_awards.py
+++ b/lib/marin/src/marin/datakit/download/nsf_awards.py
@@ -89,16 +89,16 @@ def download_and_convert_year(year: int, download_url: str, output_path: str) ->
                 continue
             with z.open(name) as f:
                 award = json.load(f)
-            counters.increment("awards_total")
+            counters.pipeline.update_counter("awards_total", 1)
             record = _award_to_record(award)
             if record is None:
-                counters.increment("awards_missing_abstract")
+                counters.pipeline.update_counter("awards_missing_abstract", 1)
                 continue
             for k in KEEP_FIELDS:
                 if not award.get(k):
-                    counters.increment(f"awards_missing_field.{k}")
+                    counters.pipeline.update_counter(f"awards_missing_field.{k}", 1)
             records.append(record)
-    counters.increment("awards_kept", len(records))
+    counters.pipeline.update_counter("awards_kept", len(records))
 
     if not records:
         logger.warning(f"No awards with abstracts for {year}, skipping.")

--- a/lib/marin/src/marin/datakit/download/numinamath_tir.py
+++ b/lib/marin/src/marin/datakit/download/numinamath_tir.py
@@ -63,10 +63,10 @@ def render_messages(messages: Any) -> str | None:
 def row_to_doc(row: dict) -> list[dict]:
     text = render_messages(row.get("messages"))
     if text is None:
-        counters.increment("numinamath_tir/dropped")
+        counters.pipeline.update_counter("numinamath_tir/dropped", 1)
         return []
 
-    counters.increment("numinamath_tir/kept")
+    counters.pipeline.update_counter("numinamath_tir/kept", 1)
     return [text_document(text, HF_DATASET_ID)]
 
 

--- a/lib/marin/src/marin/datakit/download/numinamath_v1_5.py
+++ b/lib/marin/src/marin/datakit/download/numinamath_v1_5.py
@@ -52,16 +52,16 @@ def row_to_doc(row: dict) -> list[dict]:
     problem = _clean_text(row, "problem")
     solution = _clean_text(row, "solution")
     if problem is None or solution is None:
-        counters.increment("numinamath_v1_5/dropped_empty")
+        counters.pipeline.update_counter("numinamath_v1_5/dropped_empty", 1)
         return []
 
     if not _is_valid_row(row):
-        counters.increment("numinamath_v1_5/dropped_invalid")
+        counters.pipeline.update_counter("numinamath_v1_5/dropped_invalid", 1)
         return []
 
     text = f"<user>\n{problem}\n</user>\n\n<assistant>\n{solution}\n</assistant>"
 
-    counters.increment("numinamath_v1_5/kept")
+    counters.pipeline.update_counter("numinamath_v1_5/kept", 1)
     return [
         {
             "id": hashlib.sha256(text.encode("utf-8")).hexdigest(),

--- a/lib/marin/src/marin/datakit/download/principia.py
+++ b/lib/marin/src/marin/datakit/download/principia.py
@@ -22,7 +22,7 @@ def row_to_doc(row: dict) -> list[dict]:
     problem = row.get("problem_statement", "")
     answer = row.get("answer", "")
     if not problem or not answer:
-        counters.increment("principia/dropped")
+        counters.pipeline.update_counter("principia/dropped", 1)
         return []
 
     topic = row.get("topic", "")
@@ -39,7 +39,7 @@ def row_to_doc(row: dict) -> list[dict]:
 
     text = "\n\n".join(parts)
 
-    counters.increment("principia/kept")
+    counters.pipeline.update_counter("principia/kept", 1)
     return [text_document(text, "facebook/principia-collection")]
 
 

--- a/lib/marin/src/marin/datakit/download/rollout_transforms.py
+++ b/lib/marin/src/marin/datakit/download/rollout_transforms.py
@@ -22,7 +22,7 @@ def load_parquet_batched(path: str) -> Iterator[dict]:
             try:
                 rows = batch.to_pydict()
             except UnicodeDecodeError as e:
-                counters.increment("load_parquet_batched/utf8_skip_batch")
+                counters.pipeline.update_counter("load_parquet_batched/utf8_skip_batch", 1)
                 logger.warning("Skipping batch from %s due to invalid UTF-8: %s", path, e)
                 continue
             n = len(next(iter(rows.values())))

--- a/lib/marin/src/marin/datakit/download/superior_reasoning.py
+++ b/lib/marin/src/marin/datakit/download/superior_reasoning.py
@@ -29,17 +29,17 @@ def row_to_doc(row: dict) -> list[dict]:
     prompt = row.get("input") or ""
     response = row.get("output") or ""
     if not prompt or not response:
-        counters.increment("superior_reasoning/dropped")
+        counters.pipeline.update_counter("superior_reasoning/dropped", 1)
         return []
 
     response = strip_think_tags(response)
     if not response:
-        counters.increment("superior_reasoning/dropped")
+        counters.pipeline.update_counter("superior_reasoning/dropped", 1)
         return []
 
     text = f"<user>\n{prompt}\n</user>\n\n<assistant>\n{response}\n</assistant>"
 
-    counters.increment("superior_reasoning/kept")
+    counters.pipeline.update_counter("superior_reasoning/kept", 1)
     return [text_document(text, "Alibaba-Apsara/Superior-Reasoning-SFT-gpt-oss-120b")]
 
 

--- a/lib/marin/src/marin/datakit/download/svgfind.py
+++ b/lib/marin/src/marin/datakit/download/svgfind.py
@@ -39,7 +39,7 @@ def svgfind_row_to_doc(row: dict) -> list[dict]:
     title = row.get("title") or ""
     svg = row.get("svg_content") or ""
     if not title or not svg:
-        counters.increment("svgfind/cc/dropped")
+        counters.pipeline.update_counter("svgfind/cc/dropped", 1)
         return []
 
     tags = ", ".join(row.get("tags") or [])
@@ -52,7 +52,7 @@ def svgfind_row_to_doc(row: dict) -> list[dict]:
         f"{svg}"
     )
 
-    counters.increment("svgfind/cc/kept")
+    counters.pipeline.update_counter("svgfind/cc/kept", 1)
     return [
         {
             "id": row["id"],

--- a/lib/marin/src/marin/datakit/download/swe_rebench_openhands.py
+++ b/lib/marin/src/marin/datakit/download/swe_rebench_openhands.py
@@ -31,14 +31,14 @@ def resolved_to_tag(resolved: int | None) -> str | None:
 def row_to_doc(row: dict) -> list[dict]:
     trajectory = row.get("trajectory")
     if not trajectory:
-        counters.increment("swe_rebench_openhands/dropped")
+        counters.pipeline.update_counter("swe_rebench_openhands/dropped", 1)
         return []
 
     tag = resolved_to_tag(row.get("resolved"))
     rendered = "\n\n".join(render_role_message(m) for m in trajectory)
     text = f"{tag}\n\n{rendered}" if tag else rendered
 
-    counters.increment("swe_rebench_openhands/kept")
+    counters.pipeline.update_counter("swe_rebench_openhands/kept", 1)
     return [text_document(text, "nebius/SWE-rebench-openhands-trajectories")]
 
 

--- a/lib/marin/src/marin/datakit/download/swe_zero_12m.py
+++ b/lib/marin/src/marin/datakit/download/swe_zero_12m.py
@@ -24,12 +24,12 @@ HF_REVISION = "44e0280"
 def row_to_doc(row: dict) -> list[dict]:
     messages = row.get("messages")
     if not messages:
-        counters.increment("swe_zero_12m/dropped")
+        counters.pipeline.update_counter("swe_zero_12m/dropped", 1)
         return []
 
     text = "\n\n".join(render_role_message(m) for m in messages)
 
-    counters.increment("swe_zero_12m/kept")
+    counters.pipeline.update_counter("swe_zero_12m/kept", 1)
     return [text_document(text, HF_DATASET_ID)]
 
 

--- a/lib/marin/src/marin/datakit/download/synthetic1.py
+++ b/lib/marin/src/marin/datakit/download/synthetic1.py
@@ -41,18 +41,18 @@ def row_to_doc(row: dict) -> list[dict]:
     prompt = row.get("prompt", "")
     response = row.get("llm_response", "")
     if not prompt or not response:
-        counters.increment("synthetic1/dropped")
+        counters.pipeline.update_counter("synthetic1/dropped", 1)
         return []
 
     response = strip_think_tags(response)
     if not response.strip():
-        counters.increment("synthetic1/dropped")
+        counters.pipeline.update_counter("synthetic1/dropped", 1)
         return []
 
     tag = score_to_tag(row.get("score"))
     text = f"{prompt}\n\n{tag}\n\n{response}"
 
-    counters.increment("synthetic1/kept")
+    counters.pipeline.update_counter("synthetic1/kept", 1)
     return [text_document(text, "PrimeIntellect/SYNTHETIC-1")]
 
 

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -74,7 +74,7 @@ class NormalizedData(BaseModel):
     version: str = "v1"
     main_output_dir: str
     dup_output_dir: str
-    counters: dict[str, int]
+    counters: dict[str, int | float]
 
 
 def generate_id(text: str) -> str:
@@ -231,7 +231,7 @@ def _make_whitespace_compactor(max_whitespace_run_chars: int) -> Callable[[dict[
         text = record["text"]
         compacted = pattern.sub(lambda m: m.group(0)[:max_whitespace_run_chars], text)
         if len(compacted) != len(text):
-            counters.increment(COMPACTED_WHITESPACE_COUNTER)
+            counters.pipeline.update_counter(COMPACTED_WHITESPACE_COUNTER, 1)
             record = {**record, "text": compacted, "id": generate_id(compacted)}
         return record
 
@@ -289,10 +289,10 @@ def _make_split_writer(
         ):
             for item in records:
                 if isinstance(item, MainOutput):
-                    counters.increment("normalize/unique_records_out")
+                    counters.pipeline.update_counter("normalize/unique_records_out", 1)
                     main_writer.submit(item.data)
                 else:
-                    counters.increment("normalize/duplicate_records_out")
+                    counters.pipeline.update_counter("normalize/duplicate_records_out", 1)
                     dup_writer.submit(item.data)
 
         yield results
@@ -331,7 +331,7 @@ def _build_pipeline(
     def has_text(record: dict[str, Any]) -> bool:
         text = record.get(text_field)
         if text is None or str(text).strip() == "":
-            counters.increment("normalize/empty_text_filtered")
+            counters.pipeline.update_counter("normalize/empty_text_filtered", 1)
             return False
         return True
 

--- a/lib/marin/src/marin/processing/classification/deduplication/connected_components.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/connected_components.py
@@ -123,18 +123,18 @@ def connected_components(
             elif norm < hub["id_norm"]:
                 yield _make_link(record, hub)
                 yield _make_link(hub, record)
-                counters.increment("cc/links", 2)
+                counters.pipeline.update_counter("cc/links", 2)
                 hub = record
             else:
                 yield _make_link(hub, record)
                 yield _make_link(record, hub)
-                counters.increment("cc/links", 2)
+                counters.pipeline.update_counter("cc/links", 2)
 
         if hub is None:
             return
 
-        counters.increment("cc/buckets")
-        counters.increment("cc/bucket_nodes", num_unique)
+        counters.pipeline.update_counter("cc/buckets", 1)
+        counters.pipeline.update_counter("cc/bucket_nodes", num_unique)
 
         if preserve_singletons and num_unique == 1:
             yield _make_link(hub, hub)
@@ -190,10 +190,10 @@ def connected_components(
             def counting_iter():
                 nonlocal num_changes
                 for node in nodes:
-                    counters.increment("cc/iteration_nodes")
+                    counters.pipeline.update_counter("cc/iteration_nodes", 1)
                     if node["changed"]:
                         num_changes += 1
-                        counters.increment("cc/changes")
+                        counters.pipeline.update_counter("cc/changes", 1)
                     yield node
 
             path = (
@@ -245,7 +245,7 @@ def _build_adjacency(node_id: str, links: Iterator[dict]) -> CCNode:
     adj: set[str] = {first["dest_id_norm"]}
     for link in links:
         adj.add(link["dest_id_norm"])
-    counters.increment("cc/nodes")
+    counters.pipeline.update_counter("cc/nodes", 1)
     return CCNode(
         record_id=first["source_record_id"],
         id_norm=first["source_id_norm"],

--- a/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
@@ -165,12 +165,12 @@ def make_document_dedup_aggregator(
             for record in records:
                 is_dup: bool = record["is_dup"]
                 total += 1
-                counters.increment(f"{counter_prefix}/total")
+                counters.pipeline.update_counter(f"{counter_prefix}/total", 1)
                 if is_dup:
                     dups += 1
-                    counters.increment(f"{counter_prefix}/dups")
+                    counters.pipeline.update_counter(f"{counter_prefix}/dups", 1)
                 else:
-                    counters.increment(f"{counter_prefix}/unique")
+                    counters.pipeline.update_counter(f"{counter_prefix}/unique", 1)
                 yield record
 
         def only_dups(records: Iterator[dict]) -> Iterator[dict]:

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -104,12 +104,12 @@ def dedup_exact_paragraph(
             for record in records:
                 is_dup: bool = record["is_dup"]
                 total += 1
-                counters.increment("dedup/exact/paragraph/total")
+                counters.pipeline.update_counter("dedup/exact/paragraph/total", 1)
                 if is_dup:
                     dups += 1
-                    counters.increment("dedup/exact/paragraph/dups")
+                    counters.pipeline.update_counter("dedup/exact/paragraph/dups", 1)
                 else:
-                    counters.increment("dedup/exact/paragraph/unique")
+                    counters.pipeline.update_counter("dedup/exact/paragraph/unique", 1)
                 yield record
 
         def group_by_doc_id(records: Iterator[dict]) -> Iterator[dict]:
@@ -155,7 +155,7 @@ def dedup_exact_paragraph(
 
     def _flat_map_paragraph_hashes(batch: pa.RecordBatch) -> Iterator[dict]:
         hashes = compute_paragraph_hashes(batch).to_pylist()
-        counters.increment("hash/paragraphs", len(hashes))
+        counters.pipeline.update_counter("hash/paragraphs", len(hashes))
         for hash_record in hashes:
             yield {
                 "file_idx": path_to_idx[hash_record.pop(DEFAULT_FILE_PATH_COLUMN)],
@@ -244,7 +244,7 @@ def dedup_exact_document(
     def _flat_map_document_hashes(path: str) -> Iterator[dict]:
         for batch in _load_batches(path):
             hashes = compute_document_hashes(batch).to_pylist()
-            counters.increment("hash/documents", len(hashes))
+            counters.pipeline.update_counter("hash/documents", len(hashes))
             for hash_record in hashes:
                 yield {"file_idx": path_to_idx[path], **hash_record}
 

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -79,7 +79,7 @@ class FuzzyDupsAttrData(BaseModel):
     version: str = "v1"
     params: MinHashParams
     sources: dict[str, FuzzyDupsPerSource]
-    counters: dict[str, int]
+    counters: dict[str, int | float]
 
 
 def _validate_inputs(inputs: list[MinHashAttrData]) -> MinHashParams:
@@ -213,13 +213,13 @@ def _make_per_shard_writer(output_path: str, counter_prefix: str):
             nonlocal cluster_members, canonicals
             for record in records:
                 if record["is_singleton"]:
-                    counters.increment(f"{counter_prefix}/singletons_skipped")
+                    counters.pipeline.update_counter(f"{counter_prefix}/singletons_skipped", 1)
                     continue
                 cluster_members += 1
-                counters.increment(f"{counter_prefix}/cluster_members")
+                counters.pipeline.update_counter(f"{counter_prefix}/cluster_members", 1)
                 if record["is_canonical"]:
                     canonicals += 1
-                    counters.increment(f"{counter_prefix}/canonicals")
+                    counters.pipeline.update_counter(f"{counter_prefix}/canonicals", 1)
                 yield {
                     "id": record["id"],
                     "attributes": {

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -75,7 +75,7 @@ class MinHashAttrData(BaseModel):
     params: MinHashParams
     source_main_dir: str
     attr_dir: str
-    counters: dict[str, int]
+    counters: dict[str, int | float]
 
 
 def _attr_records(batch: pa.RecordBatch, params: MinHashParams) -> list[dict]:
@@ -106,7 +106,7 @@ def _attr_records(batch: pa.RecordBatch, params: MinHashParams) -> list[dict]:
             else:
                 truncated.append(text)
         if n_truncated:
-            counters.increment("minhash/text_truncated", n_truncated)
+            counters.pipeline.update_counter("minhash/text_truncated", n_truncated)
         batch = batch.set_column(
             batch.schema.get_field_index("text"),
             "text",
@@ -132,11 +132,11 @@ def _attr_records(batch: pa.RecordBatch, params: MinHashParams) -> list[dict]:
     out: list[dict] = []
     for doc_id, doc_buckets in zip(ids, buckets_col, strict=True):
         if not doc_buckets.is_valid:
-            counters.increment("minhash/empty_signatures")
+            counters.pipeline.update_counter("minhash/empty_signatures", 1)
             continue
         bucket_strs = [str(b) for b in doc_buckets.as_py()]
-        counters.increment("minhash/documents")
-        counters.increment("minhash/buckets", len(bucket_strs))
+        counters.pipeline.update_counter("minhash/documents", 1)
+        counters.pipeline.update_counter("minhash/buckets", len(bucket_strs))
         out.append({"id": doc_id.as_py(), "buckets": bucket_strs})
     return out
 

--- a/lib/marin/src/marin/processing/tokenize/_core.py
+++ b/lib/marin/src/marin/processing/tokenize/_core.py
@@ -215,8 +215,8 @@ def tokenize_batches_with_id(
         batch_count += 1
         for record in processor(batch):
             n_tokens = len(record.get("input_ids", []))
-            counters.increment("tokenize/docs_out", 1)
-            counters.increment("tokenize/tokens_out", n_tokens)
+            counters.pipeline.update_counter("tokenize/docs_out", 1)
+            counters.pipeline.update_counter("tokenize/tokens_out", n_tokens)
             record_count += 1
             token_count += n_tokens
             yield record

--- a/lib/marin/src/marin/processing/tokenize/attributes.py
+++ b/lib/marin/src/marin/processing/tokenize/attributes.py
@@ -73,7 +73,7 @@ class TokenizedAttrData(BaseModel):
     source_main_dirs: dict[str, str]
     tokenizer: str
     tokenizer_backend: str
-    counters: dict[str, dict[str, int]]
+    counters: dict[str, dict[str, int | float]]
 
     def shard_paths(self, split: str) -> list[str]:
         """Return parquet shard paths for ``split`` in order, or ``[]`` if absent."""
@@ -121,7 +121,7 @@ def _process_split(
     source: NormalizedData,
     split: str,
     config: TokenizeAttributesConfig,
-) -> tuple[str, dict[str, int]]:
+) -> tuple[str, dict[str, int | float]]:
     """Tokenize one split's NormalizedData into co-partitioned attribute parquet.
 
     Returns ``(split_output_dir, counters)``.
@@ -203,7 +203,7 @@ def tokenize_attributes(config: TokenizeAttributesConfig) -> TokenizedAttrData:
     """
     output_dirs: dict[str, str] = {}
     source_main_dirs: dict[str, str] = {}
-    counters: dict[str, dict[str, int]] = {}
+    counters: dict[str, dict[str, int | float]] = {}
 
     splits: list[tuple[str, NormalizedData]] = []
     if config.train_source is not None:

--- a/lib/zephyr/AGENTS.md
+++ b/lib/zephyr/AGENTS.md
@@ -18,7 +18,7 @@ Lazy dataset processing library. Start with the shared instructions in `/AGENTS.
 - `src/zephyr/shuffle.py` — scatter pipeline internals (`ScatterFileIterator`, `ScatterReader`, hash-routing, combiner, zstd-chunk file format with byte-range sidecar)
 - `src/zephyr/expr.py` — `Expr`, `col`, `lit` for filter expressions
 - `src/zephyr/external_sort.py` — `external_sort_merge` k-way merge of sorted runs
-- `src/zephyr/counters.py` — `increment` / `get_counters` per-worker counter API (`CounterSnapshot` lives in `execution.py`)
+- `src/zephyr/counters.py` — `ScopedCounters`, `pipeline`, `stage()`, `current_stage()` scoped counter API (`CounterSnapshot` lives in `worker_context.py`)
 
 ## Execution Model
 

--- a/lib/zephyr/src/zephyr/counters.py
+++ b/lib/zephyr/src/zephyr/counters.py
@@ -37,13 +37,6 @@ coordinator periodically via heartbeats and as a final snapshot on task
 completion.
 
 Outside of a Zephyr worker context, all calls are silent no-ops.
-
-**Legacy aliases** — the bare module-level functions delegate to
-``counters.pipeline`` and are preserved for backward compatibility::
-
-    counters.increment("documents_processed", 100)  # same as pipeline.update_counter(...)
-    counters.set_counter("mem_bytes", value)
-    counters.get_counters()
 """
 
 import logging
@@ -133,33 +126,3 @@ def current_stage() -> ScopedCounters:
     if worker is None:
         return pipeline
     return ScopedCounters(stage=worker.current_stage_name())
-
-
-# ---------------------------------------------------------------------------
-# Legacy module-level aliases (delegate to pipeline scope)
-# ---------------------------------------------------------------------------
-
-
-def increment(name: str, value: int = 1) -> None:
-    """Increment a named pipeline counter by ``value`` (default 1).
-
-    Alias for ``counters.pipeline.update_counter()``. No-op outside a Zephyr worker.
-    """
-    pipeline.update_counter(name, value)
-
-
-def set_counter(name: str, value: int | float) -> None:
-    """Overwrite a named pipeline counter with ``value`` (not additive).
-
-    Alias for ``counters.pipeline.set_counter()``. No-op outside a Zephyr worker.
-    """
-    pipeline.set_counter(name, value)
-
-
-def get_counters() -> dict[str, int | float]:
-    """Return a snapshot of pipeline-level counters.
-
-    Alias for ``counters.pipeline.get_counters()``. Returns an empty dict
-    outside a Zephyr worker context.
-    """
-    return pipeline.get_counters()

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -1543,11 +1543,11 @@ class ZephyrExecutionResult:
             pipeline (e.g. output file paths for write stages).
         counters: Aggregated counter values from the run, including built-in
             zephyr counters (e.g. ``zephyr/records_in``) and any user counters
-            recorded via ``zephyr.counters.increment``.
+            recorded via ``zephyr.counters.pipeline``.
     """
 
     results: list
-    counters: dict[str, int]
+    counters: dict[str, int | float]
 
 
 @dataclass(frozen=True)
@@ -1650,7 +1650,7 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
         try:
             results = coordinator.run_pipeline.submit(config.plan, config.execution_id).result()
             raw_counters = coordinator.get_counters.remote().result(timeout=10.0) or {}
-            payload = ZephyrExecutionResult(results=results, counters={k: int(v) for k, v in raw_counters.items()})
+            payload = ZephyrExecutionResult(results=results, counters=dict(raw_counters))
 
             ensure_parent_dir(result_path)
             with open_url(result_path, "wb") as f:

--- a/lib/zephyr/src/zephyr/plan.py
+++ b/lib/zephyr/src/zephyr/plan.py
@@ -832,7 +832,7 @@ def run_stage(
                 fs = url_to_fs(output_path)[0]
                 if fs.exists(output_path):
                     logger.info(f"Skipping write, output exists: {output_path}")
-                    counters.increment("zephyr/partitions_skipped")
+                    counters.pipeline.update_counter("zephyr/partitions_skipped", 1)
                     yield output_path
                     return
 

--- a/lib/zephyr/src/zephyr/readers.py
+++ b/lib/zephyr/src/zephyr/readers.py
@@ -265,7 +265,7 @@ def load_jsonl(source: str | InputFileSpec) -> Iterator[dict]:
                 continue
             if columns is not None:
                 record = {k: record[k] for k in columns if k in record}
-            counters.increment("zephyr/records_in")
+            counters.pipeline.update_counter("zephyr/records_in", 1)
             yield record
 
 
@@ -310,7 +310,7 @@ def load_parquet_batch(source: str | InputFileSpec) -> Iterator[pa.RecordBatch]:
             table = table.filter(pa_filter)
         if need_project:
             table = table.select(spec.columns)
-        counters.increment("zephyr/records_in", len(table))
+        counters.pipeline.update_counter("zephyr/records_in", len(table))
         yield from table.to_batches()
 
 
@@ -387,7 +387,7 @@ def load_vortex(source: str | InputFileSpec) -> Iterator[dict]:
     else:
         table = dataset.to_table(columns=columns, filter=pa_filter)
 
-    counters.increment("zephyr/records_in", len(table))
+    counters.pipeline.update_counter("zephyr/records_in", len(table))
     yield from table.to_pylist()
 
 
@@ -535,7 +535,7 @@ def load_zip_members(source: str | InputFileSpec, pattern: str = "*") -> Iterato
             for member_name in zf.namelist():
                 if not member_name.endswith("/") and fnmatch.fnmatch(member_name, pattern):
                     with zf.open(member_name, "r") as member_file:
-                        counters.increment("zephyr/records_in")
+                        counters.pipeline.update_counter("zephyr/records_in", 1)
                         yield {
                             "filename": member_name,
                             "content": member_file.read(),

--- a/lib/zephyr/src/zephyr/writers.py
+++ b/lib/zephyr/src/zephyr/writers.py
@@ -85,7 +85,7 @@ def write_jsonl_file(records: Iterable, output_path: str) -> dict:
             for record in records:
                 f.write(encoder.encode(record) + b"\n")
                 count += 1
-                counters.increment("zephyr/records_out")
+                counters.pipeline.update_counter("zephyr/records_out", 1)
 
     return {"path": output_path, "count": count}
 
@@ -232,7 +232,7 @@ def write_parquet_file(
                     writer = pq.ParquetWriter(temp_path, table.schema)
                 writer.write_table(table)
                 count += len(table)
-                counters.increment("zephyr/records_out", len(table))
+                counters.pipeline.update_counter("zephyr/records_out", len(table))
         finally:
             if writer is not None:
                 writer.close()
@@ -282,11 +282,11 @@ def write_vortex_file(
     def _array_batches():
         nonlocal count
         count += len(first_table)
-        counters.increment("zephyr/records_out", len(first_table))
+        counters.pipeline.update_counter("zephyr/records_out", len(first_table))
         yield vortex.Array.from_arrow(first_table)
         for table in table_iter:
             count += len(table)
-            counters.increment("zephyr/records_out", len(table))
+            counters.pipeline.update_counter("zephyr/records_out", len(table))
             yield vortex.Array.from_arrow(table)
 
     array_iter = vortex.ArrayIterator.from_iter(dtype, _array_batches())
@@ -387,6 +387,6 @@ def write_binary_file(records: Iterable[bytes], output_path: str) -> dict:
             for record in records:
                 f.write(record)
                 count += 1
-                counters.increment("zephyr/records_out")
+                counters.pipeline.update_counter("zephyr/records_out", 1)
 
     return {"path": output_path, "count": count}

--- a/lib/zephyr/tests/test_counters.py
+++ b/lib/zephyr/tests/test_counters.py
@@ -73,27 +73,27 @@ def _make_coordinator(
     return coord
 
 
-def test_counters_increment_and_snapshot():
-    """increment() accumulates in-memory; get_counter_snapshot() returns current values."""
+def test_counters_update_and_snapshot():
+    """update_counter() accumulates in-memory; pipeline.get_counters() returns current values."""
     worker = FakeWorker()
     token = _worker_ctx_var.set(worker)
     try:
-        counters.increment("docs", 10)
-        counters.increment("docs", 5)
-        counters.increment("errors", 1)
+        counters.pipeline.update_counter("docs", 10)
+        counters.pipeline.update_counter("docs", 5)
+        counters.pipeline.update_counter("errors", 1)
 
-        snapshot = counters.get_counters()
+        snapshot = counters.pipeline.get_counters()
         assert snapshot == {"docs": 15, "errors": 1}
     finally:
         _worker_ctx_var.reset(token)
 
 
 def test_counters_noop_outside_worker():
-    """increment() is a no-op when not inside a Zephyr worker context."""
+    """update_counter() is a no-op when not inside a Zephyr worker context."""
     token = _worker_ctx_var.set(None)
     try:
-        counters.increment("anything", 999)  # should not raise
-        assert counters.get_counters() == {}
+        counters.pipeline.update_counter("anything", 999)  # should not raise
+        assert counters.pipeline.get_counters() == {}
     finally:
         _worker_ctx_var.reset(token)
 
@@ -103,13 +103,13 @@ def test_counters_set_counter():
     worker = FakeWorker()
     token = _worker_ctx_var.set(worker)
     try:
-        counters.increment("visits", 5)
-        counters.set_counter("visits", 2)  # overwrites, not 5+2
-        assert counters.get_counters() == {"visits": 2}
+        counters.pipeline.update_counter("visits", 5)
+        counters.pipeline.set_counter("visits", 2)  # overwrites, not 5+2
+        assert counters.pipeline.get_counters() == {"visits": 2}
 
-        counters.set_counter("mem_bytes", 1024)
-        counters.set_counter("mem_bytes", 2048)  # replaces previous value
-        assert counters.get_counters()["mem_bytes"] == 2048
+        counters.pipeline.set_counter("mem_bytes", 1024)
+        counters.pipeline.set_counter("mem_bytes", 2048)  # replaces previous value
+        assert counters.pipeline.get_counters()["mem_bytes"] == 2048
     finally:
         _worker_ctx_var.reset(token)
 
@@ -118,8 +118,8 @@ def test_set_counter_noop_outside_worker():
     """set_counter() is a no-op when not inside a Zephyr worker context."""
     token = _worker_ctx_var.set(None)
     try:
-        counters.set_counter("anything", 999)  # should not raise
-        assert counters.get_counters() == {}
+        counters.pipeline.set_counter("anything", 999)  # should not raise
+        assert counters.pipeline.get_counters() == {}
     finally:
         _worker_ctx_var.reset(token)
 
@@ -136,20 +136,6 @@ def test_zephyr_execution_result_empty():
     result = ZephyrExecutionResult(results=[], counters={})
     assert result.results == []
     assert result.counters == {}
-
-
-def test_legacy_aliases_delegate_to_pipeline():
-    """Module-level increment/set_counter/get_counters delegate to pipeline scope."""
-    worker = FakeWorker()
-    token = _worker_ctx_var.set(worker)
-    try:
-        counters.increment("x", 3)
-        counters.set_counter("y", 7)
-        result = counters.get_counters()
-        assert result == {"x": 3, "y": 7}
-        assert counters.pipeline.get_counters() == {"x": 3, "y": 7}
-    finally:
-        _worker_ctx_var.reset(token)
 
 
 def test_stage_scoped_counters():

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -86,13 +86,7 @@ def test_filter(zephyr_ctx):
 
 
 def test_propagates_user_counters(zephyr_ctx):
-    """User counters incremented inside a shard flow back to the coordinator.
-
-    Each task runs in the worker's own process; ``counters.pipeline.update_counter`` writes
-    into the per-task ``_InProcessWorkerContext``. This test verifies the
-    worker forwards the final counter dict to the coordinator via
-    ``report_result``, otherwise the coordinator's ``get_counters`` would
-    silently report 0.
+    """User counters incremented inside a shard are visible in the execution result.
 
     Uses a direct logging handler attachment (rather than ``caplog``) so the
     test works whether or not pytest's logging plugin is enabled.

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -88,7 +88,7 @@ def test_filter(zephyr_ctx):
 def test_propagates_user_counters(zephyr_ctx):
     """User counters incremented inside a shard flow back to the coordinator.
 
-    Each task runs in the worker's own process; ``counters.increment`` writes
+    Each task runs in the worker's own process; ``counters.pipeline.update_counter`` writes
     into the per-task ``_InProcessWorkerContext``. This test verifies the
     worker forwards the final counter dict to the coordinator via
     ``report_result``, otherwise the coordinator's ``get_counters`` would
@@ -99,8 +99,8 @@ def test_propagates_user_counters(zephyr_ctx):
     """
 
     def increment_per_item(x: int) -> int:
-        counters.increment("docs", 1)
-        counters.increment("doubled_sum", x * 2)
+        counters.pipeline.update_counter("docs", 1)
+        counters.pipeline.update_counter("doubled_sum", x * 2)
         return x
 
     captured: list[str] = []

--- a/lib/zephyr/tests/test_runners.py
+++ b/lib/zephyr/tests/test_runners.py
@@ -59,8 +59,8 @@ def test_user_counters_propagate(local_client, tmp_path, runner_factory):
     """User counters flow back from the worker (or its subprocess child) to the coordinator."""
 
     def increment(x: int) -> int:
-        counters.increment("docs", 1)
-        counters.increment("doubled_sum", x * 2)
+        counters.pipeline.update_counter("docs", 1)
+        counters.pipeline.update_counter("doubled_sum", x * 2)
         return x
 
     ctx = _ctx(local_client, tmp_path, stage_runner_factory=runner_factory)
@@ -123,7 +123,7 @@ def test_runner_parametrization_isolates_processes(local_client, tmp_path, runne
     """
 
     def record_pid(x: int) -> int:
-        counters.increment(f"shard_pid_{os.getpid()}", 1)
+        counters.pipeline.update_counter(f"shard_pid_{os.getpid()}", 1)
         return x
 
     ctx = _ctx(local_client, tmp_path, stage_runner_factory=runner_factory_fn)

--- a/scripts/datakit/sync_datakit.py
+++ b/scripts/datakit/sync_datakit.py
@@ -263,9 +263,9 @@ def _copy_shard(
         for fut in as_completed(futures):
             bytes_copied += fut.result()
 
-    counters.increment("upload/shards_copied")
-    counters.increment("upload/files_copied", len(entries))
-    counters.increment("upload/bytes_copied", bytes_copied)
+    counters.pipeline.update_counter("upload/shards_copied", 1)
+    counters.pipeline.update_counter("upload/files_copied", len(entries))
+    counters.pipeline.update_counter("upload/bytes_copied", bytes_copied)
     return {"shard_hash": _shard_hash(entries), "files": len(entries), "bytes": bytes_copied}
 
 
@@ -372,7 +372,7 @@ def _remove_tmp_orphans(dst_dir: str) -> None:
         return
     logger.info("Removing %d .tmp.<uuid> orphan(s) under %s", len(orphans), dst_dir)
     dst_fs.rm(orphans)
-    counters.increment("upload/tmp_orphans_removed", len(orphans))
+    counters.pipeline.update_counter("upload/tmp_orphans_removed", len(orphans))
 
 
 def _shard(items: list[tuple[str, str]], shard_size: int) -> list[list[tuple[str, str]]]:


### PR DESCRIPTION
1. Remove the module-level `increment`/`set_counter`/`get_counters` shims from `zephyr.counters` and migrate all ~43 call sites across the repo to the scoped API (`counters.pipeline.update_counter`, `set_counter`, `get_counters`). The legacy functions were already simple one-line delegates to `counters.pipeline`; removing them eliminates an unnecessary indirection and makes the intended scope (pipeline vs. stage) explicit at each call site.

**Open Question**: The change for basic sum counters from `increment` to `update_counter(..., 1)` is a little less intuitive. I left it that way since keeping `increment` feels more confusing for non-sum counters (what does it do? silent noop?), but if `increment` remains 90% of the usage maybe leaving it around makes sense.

2. Also fix `ZephyrExecutionResult.counters`: the field was annotated `dict[str, int]` and enforced by a lossy `int()` cast at construction time. This silently truncated `Aggregation.AVERAGE` counters (which produce floats) before they reached callers. The type is now `dict[str, int | float]` and the cast is removed. Downstream dataclass and Pydantic model fields that held `dict[str, int]` are updated to match.


Part of #6300