### PR TITLE
[codex] Fix served Qwen Iris config loading

### DIFF
--- a/experiments/evals/served_qwen3_humaneval.py
+++ b/experiments/evals/served_qwen3_humaneval.py
@@ -26,7 +26,8 @@ from pathlib import Path
 import click
 from fray.types import ResourceConfig
 from iris.client import IrisClient
-from iris.cluster.config import IrisConfig
+from iris.cluster.composer import provider_bundle
+from iris.cluster.config import load_config
 from iris.cluster.constraints import preemptible_constraint, region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec
 from iris.rpc import job_pb2
@@ -173,9 +174,9 @@ def submit_iris_humaneval(
         configure_logging()
         run_iris_humaneval(inference_config, eval_config)
 
-    iris_config = IrisConfig.load(iris_config_path)
-    controller = iris_config.provider_bundle().controller
-    controller_address = iris_config.controller_address() or controller.discover_controller(iris_config.proto.controller)
+    iris_config = load_config(iris_config_path)
+    controller = provider_bundle(iris_config).controller
+    controller_address = iris_config.controller_address() or controller.discover_controller(iris_config.controller)
     constraints = [preemptible_constraint(False)]
     if region is not None:
         constraints.append(region_constraint([region]))


### PR DESCRIPTION
## Summary

- update the served Qwen HumanEval script to use the current Iris config loader API
- use `provider_bundle(config)` with the loaded `IrisClusterConfig`

## Why

`origin/main` still called the removed `IrisConfig.load(...)` and `iris_config.provider_bundle()` APIs. The Iris config code now exposes `load_config(...)`, `provider_bundle(config)`, and `iris_config.controller`. This is independent of the TPU/vLLM dependency refresh and should land separately.

## Validation

- `python -m py_compile experiments/evals/served_qwen3_humaneval.py`