### PR TITLE
ducky: ad-hoc DuckDB SQL service

### DIFF
--- a/.agents/projects/duckdb_sql_service/design.md
+++ b/.agents/projects/duckdb_sql_service/design.md
@@ -81,15 +81,25 @@ lifecycle rule (TTL = `RESULT_TTL_DAYS`, default 7) so spilled results auto-expi
 `QueryResult(columns, preview_rows, total_rows, truncated, result_path)`.
 
 **2. Dashboard** (`server.py`) — a Starlette app mirroring the iris worker dashboard
-(`lib/iris/src/iris/cluster/worker/dashboard.py:37`), reusing
-`dashboard_common.html_shell()` and `@requires_auth`
-(`lib/iris/src/iris/cluster/dashboard_common.py:166`). Routes:
-- `GET /` — HTML page: a `<textarea>` for SQL, a Run button, an empty result area.
-- `POST /query` — body `{sql}`; calls `run_query`, returns JSON
-  `{columns, rows, total_rows, truncated, result_path}`. The page renders `rows`
-  as a table and, when `truncated`, shows "showing N of M rows — full result at
-  `<result_path>` (expires in 7d)".
+(`lib/iris/src/iris/cluster/worker/dashboard.py:37`), reusing `@requires_auth`
+(`lib/iris/src/iris/cluster/dashboard_common.py:39`). Queries run **asynchronously**,
+because the dashboard is reached through the controller endpoint proxy, which caps
+every forwarded request at 30 s (`endpoint_proxy.py:71`,
+`PROXY_TIMEOUT_SECONDS = 30.0`). A synchronous `POST /query` that blocks on a
+minutes-long DuckDB scan — the whole point of running on a big host — would be
+killed by the proxy. So:
+- `GET /` — HTML page: a `<textarea>` for SQL, a Run button, a result area.
+- `POST /query` — body `{sql}`; a `QueryManager` submits the SQL to a single-worker
+  executor (one DuckDB query at a time) and returns `{query_id}` immediately (202).
+  The query runs in the background; the spilled parquet is written as before.
+- `GET /result/{query_id}` — returns `{status: "running"}`, `{status: "error", error}`,
+  or `{status: "done", columns, rows, total_rows, truncated, result_path}`. The page
+  polls this every second; each poll returns well under the 30 s proxy window while
+  the query itself may run for minutes.
 - `GET /health` — liveness for Iris.
+
+Query state lives in memory for the process lifetime; ducky is stateless and
+restartable, so a restart simply drops in-flight/finished state.
 
 **3. Deploy** — ducky runs as a long-running Iris job that blocks on `uvicorn`.
 Because a routable service needs a *named* Iris port and `iris job run` has no
@@ -150,9 +160,18 @@ against views/macros. v1 ships no in-runner cross-region check.
 - **Scratch bucket & TTL.** Which `us-east5` bucket, and is 7 days the right default?
   Should the result path be a signed URL / clickable download, or just a `gs://`
   path the user fetches themselves?
-- **Concurrency UX.** v1 is single-query-at-a-time (one DuckDB connection). Is a
-  blunt "busy, try again" enough, or do we want a tiny FIFO queue with a visible
-  "running" state so a long query doesn't look hung?
+- **Concurrency UX.** v1 is single-query-at-a-time (one DuckDB connection, a
+  single-worker executor). A second `POST /query` queues behind the running one
+  (FIFO). Is that enough, or do we want a visible queue depth / "busy" signal?
+- **Async result retention.** Query state is in-memory and unbounded. For an
+  internal tool that's fine, but should finished states expire (TTL / LRU cap), and
+  should a fresh page be able to re-attach to a `query_id` from a previous session
+  (it can today, until restart)?
 - **Cost parking (deferred).** Always-on is the committed v1. If the v6e host proves
   too contended to idle, a follow-up could add an idle-timeout that releases the
   host with a one-click relaunch — out of scope here, flagged for reviewer pushback.
+
+[^proxy]: The async model is forced by the controller endpoint proxy's 30 s
+    request cap (`endpoint_proxy.py:71`), confirmed live: a synchronous query over a
+    `gs://` parquet that ran past 30 s returned `Upstream timeout after 30s` even
+    though DuckDB kept running and the spill landed. Polling sidesteps it.

--- a/.agents/projects/duckdb_sql_service/design.md
+++ b/.agents/projects/duckdb_sql_service/design.md
@@ -1,0 +1,158 @@
+# ducky — ad-hoc DuckDB SQL over a v6e host
+
+_Why are we doing this? What's the benefit?_
+
+We frequently need to run a one-off analytical SQL query over parquet sitting in
+object storage (GCS / R2) — checking a dataset's row counts, schemas, or
+distributions — and today that means hand-rolling a DuckDB script and finding a
+big enough box to run it on. `ducky` is a small always-on Iris service that
+exposes a dashboard: paste SQL, hit run, get results. The query executes in an
+embedded DuckDB on a **full v6e-8 host** (~180 vCPU / ~1.4 TB RAM), so queries
+that would OOM or crawl on a laptop finish quickly with no setup. It is
+deliberately minimal — a textarea, a run button, a result table — in the spirit of
+`finelog`'s `StatsService.Query` (`lib/finelog/rust/proto/finelog_stats.proto:176`),
+but Python + DuckDB and standalone.
+
+## Background
+
+finelog is the closest prior art but is **not** a reuse target: it is now a Rust
+binary using **DataFusion**, not DuckDB (`lib/finelog/rust/src/query/mod.rs`), and
+deploys as a GCP VM / k8s Deployment rather than on Iris. The only live DuckDB in
+the repo is finelog's deploy-CLI helper (`lib/finelog/pyproject.toml:10`) and some
+ops scripts. So ducky's engine is built fresh; what we copy from finelog is the
+*shape* (single `sql` string → result) and from Iris the dashboard idiom. Full
+findings — including the iris resource model, endpoint proxy, and v6e topology — in
+[`research.md`](./research.md).
+
+## Challenges
+
+- **Use the whole host.** DuckDB defaults don't grab all cores/RAM. We must read
+  the host envelope at runtime — `TaskResources.from_environment()`
+  (`lib/iris/src/iris/env_resources.py:58`) — and set DuckDB `threads` and
+  `memory_limit` accordingly. There is no hardcoded v6e CPU/RAM constant in the
+  repo; it's discovered, not declared.
+- **Arbitrary SQL reads arbitrary buckets.** A `read_parquet('gs://…')` can pull
+  data cross-region, which is a real cost driver per `AGENTS.md`. We need a
+  same-region guardrail, not just trust.
+- **Big results, run the SQL once.** A `SELECT *` can return more than a browser
+  can hold. We `COPY (<sql>) TO '<parquet>'` **once**, then read the written parquet
+  back for the row count and the capped preview — never execute the user's SQL
+  twice, or non-deterministic queries (`random()`, `now()`, `LIMIT` without
+  `ORDER BY`) would diverge between the spilled file and the preview.
+- **DuckDB ↔ object-store auth.** ducky targets three stores via `httpfs`: GCS, R2,
+  and CoreWeave object store. R2 and CoreWeave are native S3 (`CREATE SECRET … TYPE
+  S3` with their endpoint + access/secret keys). GCS is the awkward one — DuckDB
+  reads `gs://` only through the S3-compat interop API with **HMAC keys** (`TYPE GCS
+  KEY_ID/SECRET`); it does *not* consume the host's GCP ADC / workload-identity
+  creds. So each backend gets its own DuckDB `SECRET` from injected credentials.
+- **New deployment shape.** A long-running, dashboard-exposing Iris job isn't
+  templated yet; it needs a named Iris port and registry registration (not a
+  hardcoded port), and reachability goes through the controller endpoint proxy.
+
+## Costs / Risks
+
+- **Holds a scarce v6e host 24/7 with the TPU idle.** DuckDB is CPU/RAM only — the
+  8 TPU chips do nothing. This is the explicit ask (big CPU/RAM envelope), but it
+  is the main cost and worth a sunset/parking story if the host is contended.
+- **Arbitrary-SQL blast radius.** Whatever object storage the host's credentials
+  can reach is queryable by anyone who can reach the dashboard. Auth is the proxy's
+  `@requires_auth` only; there is no per-query authorization.
+- **One query at a time.** A single embedded DuckDB connection; concurrent heavy
+  queries contend. Acceptable for an internal ad-hoc tool, not a shared API.
+- **New service to operate** (deploy, logs, restart) with no immediate user-visible
+  product improvement beyond convenience.
+
+## Design
+
+A single Python package `lib/ducky` with three pieces:
+
+**1. Query runner** (`runner.py`) — pure compute, no web concerns. One DuckDB
+connection for the process lifetime (single query at a time — no pool). On startup
+it installs/loads `httpfs`, creates one DuckDB `SECRET` per backend (GCS HMAC, R2
+S3, CoreWeave S3) from injected creds, and pins `threads` + a headroom-limited
+`memory_limit` (`MEMORY_FRACTION`, default 0.8
+of host RAM — leaving room for Python/Arrow/OS) from
+`TaskResources.from_environment()`. `run_query(sql, query_id)` runs the user SQL
+**once** via `COPY (<sql>) TO 'gs://<scratch>/ducky/<query_id>.parquet' (FORMAT
+parquet)`, then reads that parquet back for `total_rows` and the first
+`PREVIEW_ROW_CAP` (default 10k) rows. The scratch bucket carries an object
+lifecycle rule (TTL = `RESULT_TTL_DAYS`, default 7) so spilled results auto-expire
+— the service never deletes, it only writes. Returns
+`QueryResult(columns, preview_rows, total_rows, truncated, result_path)`.
+
+**2. Dashboard** (`server.py`) — a Starlette app mirroring the iris worker dashboard
+(`lib/iris/src/iris/cluster/worker/dashboard.py:37`), reusing
+`dashboard_common.html_shell()` and `@requires_auth`
+(`lib/iris/src/iris/cluster/dashboard_common.py:166`). Routes:
+- `GET /` — HTML page: a `<textarea>` for SQL, a Run button, an empty result area.
+- `POST /query` — body `{sql}`; calls `run_query`, returns JSON
+  `{columns, rows, total_rows, truncated, result_path}`. The page renders `rows`
+  as a table and, when `truncated`, shows "showing N of M rows — full result at
+  `<result_path>` (expires in 7d)".
+- `GET /health` — liveness for Iris.
+
+**3. Deploy** — ducky runs as a long-running Iris job that blocks on `uvicorn`.
+Because a routable service needs a *named* Iris port and `iris job run` has no
+`--ports` flag, deploy goes through a small Python submit (the same path
+`worker_pool.py:440` uses, `ports=["ducky"]`), not the bare CLI:
+
+```python
+# python -m ducky.deploy
+client.submit(
+    entrypoint="python -m ducky.server",
+    resources=ResourceSpec(cpu=ALL_CPU, memory=ALL_MEM, device=tpu_device("v6e-8")),
+    ports=["ducky"], region=["us-east5"], enable_extra_resources=True, no_wait=True,
+)
+```
+
+The job requests the whole v6e-8 host (`ResourceSpec`,
+`lib/iris/src/iris/cluster/types.py:529`). The `cpu`/`memory` request is a declared
+constant that must match the real `ct6e-standard-8t` host shape — if it overshoots
+the job never schedules; if it undershoots, `TaskResources.from_environment()`
+reports the smaller request and silently caps DuckDB below the host. On boot the
+server binds `ctx.get_port("ducky")` (not a hardcoded port) and registers
+`ctx.registry.register("ducky", f"http://{job_info.advertise_host}:{port}",
+metadata)` (`lib/iris/src/iris/client/worker_pool.py:156-165`), unregistering by the
+returned id on shutdown. The dashboard is then reachable at `/proxy/ducky/` through
+the controller reverse proxy
+(`lib/iris/src/iris/cluster/controller/endpoint_proxy.py:70`). No new proto: the
+browser talks plain JSON to the Starlette routes.
+
+**Single region (us-east5).** The job is pinned to `us-east5` (`--region`,
+`lib/iris/src/iris/cli/job.py:813`), the scratch bucket lives there, and the HMAC
+keys are scoped to same-region buckets. Cross-region reads then simply **fail to
+authenticate** rather than silently incurring egress — the guardrail is operational
+(region + creds pinning), not an in-process SQL pre-parse, which would be brittle
+against views/macros. v1 ships no in-runner cross-region check.
+
+## Testing
+
+- **Unit (runner):** a small local parquet fixture; assert `run_query` caps the
+  preview at `PREVIEW_ROW_CAP`, sets `truncated`/`total_rows` correctly, writes the
+  full parquet to the (faked) scratch path, and surfaces a DuckDB error as a clean
+  error result rather than a 500 stack trace.
+- **Resource wiring:** assert DuckDB `threads`/`memory_limit` are derived from a
+  stubbed `TaskResources`, so a whole-host task actually uses the whole host.
+- **Integration (iris dev cluster):** deploy the job, `POST /query` a `SELECT
+  count(*) FROM read_parquet('gs://…/small.parquet')` over a known same-region
+  fixture, assert the preview, the spilled `result_path`, and reachability through
+  `/proxy/ducky/`.
+
+## Open Questions
+
+- **Credentials.** Three secret sets to inject (GCS interop HMAC, R2 S3, CoreWeave
+  S3) — where do they come from and how are they passed to the task (env vars vs a
+  secret mount)? For GCS specifically, which service account mints the HMAC keys,
+  and are they scoped to same-region buckets so they double as the cross-region
+  guardrail?
+- **Host envelope.** What are the real `ct6e-standard-8t` vCPU/RAM numbers to put in
+  the `ResourceSpec` request so the job both schedules and gets the whole host?
+- **Scratch bucket & TTL.** Which `us-east5` bucket, and is 7 days the right default?
+  Should the result path be a signed URL / clickable download, or just a `gs://`
+  path the user fetches themselves?
+- **Concurrency UX.** v1 is single-query-at-a-time (one DuckDB connection). Is a
+  blunt "busy, try again" enough, or do we want a tiny FIFO queue with a visible
+  "running" state so a long query doesn't look hung?
+- **Cost parking (deferred).** Always-on is the committed v1. If the v6e host proves
+  too contended to idle, a follow-up could add an idle-timeout that releases the
+  host with a one-click relaunch — out of scope here, flagged for reviewer pushback.

--- a/.agents/projects/duckdb_sql_service/design.md
+++ b/.agents/projects/duckdb_sql_service/design.md
@@ -75,8 +75,9 @@ of host RAM — leaving room for Python/Arrow/OS) from
 `TaskResources.from_environment()`. `run_query(sql, query_id)` runs the user SQL
 **once** via `COPY (<sql>) TO 'gs://<scratch>/ducky/<query_id>.parquet' (FORMAT
 parquet)`, then reads that parquet back for `total_rows` and the first
-`PREVIEW_ROW_CAP` (default 10k) rows. The scratch bucket carries an object
-lifecycle rule (TTL = `RESULT_TTL_DAYS`, default 7) so spilled results auto-expire
+`PREVIEW_ROW_CAP` (default 10k) rows. The scratch prefix uses marin's existing
+`tmp/ttl=Nd/` lifecycle convention (e.g. `gs://marin-us-east5/tmp/ttl=7d`, with N =
+`RESULT_TTL_DAYS`, default 7) so spilled results auto-expire
 — the service never deletes, it only writes. Returns
 `QueryResult(columns, preview_rows, total_rows, truncated, result_path)`.
 
@@ -163,9 +164,10 @@ against views/macros. v1 ships no in-runner cross-region check.
   guardrail?
 - **Host envelope.** What are the real `ct6e-standard-8t` vCPU/RAM numbers to put in
   the `ResourceSpec` request so the job both schedules and gets the whole host?
-- **Scratch bucket & TTL.** Which `us-east5` bucket, and is 7 days the right default?
-  Should the result path be a signed URL / clickable download, or just a `gs://`
-  path the user fetches themselves?
+- **Scratch bucket & TTL.** Settled to `gs://marin-us-east5/tmp/ttl=7d` (existing
+  lifecycle convention; N must equal `RESULT_TTL_DAYS`). Open: should the result
+  path be a signed URL / clickable download, or just the `gs://` path the user
+  fetches themselves?
 - **Concurrency UX.** v1 is single-query-at-a-time (one DuckDB connection, a
   single-worker executor). A second `POST /query` queues behind the running one
   (FIFO). Is that enough, or do we want a visible queue depth / "busy" signal?

--- a/.agents/projects/duckdb_sql_service/design.md
+++ b/.agents/projects/duckdb_sql_service/design.md
@@ -66,13 +66,16 @@ findings — including the iris resource model, endpoint proxy, and v6e topology
 
 A single Python package `lib/ducky` with three pieces:
 
-**1. Query runner** (`runner.py`) — pure compute, no web concerns. One DuckDB
-connection for the process lifetime (single query at a time — no pool). On startup
-it installs/loads `httpfs`, creates one DuckDB `SECRET` per backend (GCS HMAC, R2
-S3, CoreWeave S3) from injected creds, and pins `threads` + a headroom-limited
-`memory_limit` (`MEMORY_FRACTION`, default 0.8
-of host RAM — leaving room for Python/Arrow/OS) from
-`TaskResources.from_environment()`. `run_query(sql, query_id)` runs the user SQL
+**1. Query runner** (`runner.py`) — pure compute, no web concerns. A shared DuckDB
+instance; each query runs on its own cursor, so up to `MAX_CONCURRENT_QUERIES`
+(default 8) run in parallel. On startup it installs/loads `httpfs`, creates one
+DuckDB `SECRET` per backend (GCS HMAC, R2 S3, CoreWeave S3) from injected creds, and
+pins `threads` + a headroom-limited `memory_limit` (`MEMORY_FRACTION`, default 0.8 of
+host RAM) plus a disk `temp_directory` from `TaskResources.from_environment()`.
+`memory_limit` is a hard cap so the process is never OS-OOM-killed — a query needing
+more spills to disk, and if it still doesn't fit it fails alone (caught per-query)
+while the others keep running. A per-query watchdog interrupts a query past
+`QUERY_TIMEOUT` (default 600 s) so a runaway frees its slot. `run_query(sql, query_id)` runs the user SQL
 **once** via `COPY (<sql>) TO 'gs://<scratch>/ducky/<query_id>.parquet' (FORMAT
 parquet)`, then reads that parquet back for `total_rows` and the first
 `PREVIEW_ROW_CAP` (default 10k) rows. The scratch prefix uses marin's existing
@@ -92,8 +95,8 @@ killed by the proxy. So:
 - `GET /` — HTML page: a CodeMirror SQL-highlighted editor, a Run button, a result
   area that shows the row count, a **cached/computed** badge, and the result's GCS
   location.
-- `POST /query` — body `{sql}`; a `QueryManager` submits the SQL to a single-worker
-  executor (one DuckDB query at a time) and returns `{query_id}` immediately (202).
+- `POST /query` — body `{sql}`; a `QueryManager` submits the SQL to a bounded thread
+  pool (`MAX_CONCURRENT_QUERIES`) and returns `{query_id}` immediately (202).
   Identical SQL is served from an in-memory result cache (reusing the prior spilled
   parquet); otherwise the query runs in the background and spills as before.
 - `GET /result/{query_id}` — returns `{status: "running"}`, `{status: "error", error}`,
@@ -171,9 +174,9 @@ behind views/macros); empty allowlist disables enforcement.
   lifecycle convention; N must equal `RESULT_TTL_DAYS`). Open: should the result
   path be a signed URL / clickable download, or just the `gs://` path the user
   fetches themselves?
-- **Concurrency UX.** v1 is single-query-at-a-time (one DuckDB connection, a
-  single-worker executor). A second `POST /query` queues behind the running one
-  (FIFO). Is that enough, or do we want a visible queue depth / "busy" signal?
+- **Concurrency.** Up to `MAX_CONCURRENT_QUERIES` (default 8) run in parallel, each
+  on its own cursor; they share the instance's memory budget and thread pool. Is 8 a
+  good default for a single host, and should the dashboard show in-flight count?
 - **Async result retention.** Query state is in-memory and unbounded. For an
   internal tool that's fine, but should finished states expire (TTL / LRU cap), and
   should a fresh page be able to re-attach to a `query_id` from a previous session

--- a/.agents/projects/duckdb_sql_service/design.md
+++ b/.agents/projects/duckdb_sql_service/design.md
@@ -135,12 +135,15 @@ the controller reverse proxy
 (`lib/iris/src/iris/cluster/controller/endpoint_proxy.py:70`). No new proto: the
 browser talks plain JSON to the Starlette routes.
 
-**Single region (us-east5).** The job is pinned to `us-east5` (`--region`,
-`lib/iris/src/iris/cli/job.py:813`), the scratch bucket lives there, and the HMAC
-keys are scoped to same-region buckets. Cross-region reads then simply **fail to
-authenticate** rather than silently incurring egress — the guardrail is operational
-(region + creds pinning), not an in-process SQL pre-parse, which would be brittle
-against views/macros. v1 ships no in-runner cross-region check.
+**Single region (us-east5) + bucket allowlist.** The job is pinned to `us-east5`
+(`--region`, `lib/iris/src/iris/cli/job.py:813`) and the scratch bucket lives there.
+The same-region guardrail is an **in-runner allowlist** (`ALLOWED_BUCKETS`, e.g.
+`gs://marin-us-east5,gs://marin-dna-us-east5,r2://`): before executing, the runner
+extracts literal `gs://`/`s3://`/`r2://` URIs from the SQL and refuses any whose
+bucket isn't allowlisted (`BucketNotAllowedError` → 400). Creds pinning *can't* do
+this — GCS HMAC keys are region-agnostic, so a us-central2 read authenticates fine
+and silently egresses. The allowlist catches literal URIs only (not paths hidden
+behind views/macros); empty allowlist disables enforcement.
 
 ## Testing
 

--- a/.agents/projects/duckdb_sql_service/design.md
+++ b/.agents/projects/duckdb_sql_service/design.md
@@ -88,18 +88,24 @@ every forwarded request at 30 s (`endpoint_proxy.py:71`,
 `PROXY_TIMEOUT_SECONDS = 30.0`). A synchronous `POST /query` that blocks on a
 minutes-long DuckDB scan — the whole point of running on a big host — would be
 killed by the proxy. So:
-- `GET /` — HTML page: a `<textarea>` for SQL, a Run button, a result area.
+- `GET /` — HTML page: a CodeMirror SQL-highlighted editor, a Run button, a result
+  area that shows the row count, a **cached/computed** badge, and the result's GCS
+  location.
 - `POST /query` — body `{sql}`; a `QueryManager` submits the SQL to a single-worker
   executor (one DuckDB query at a time) and returns `{query_id}` immediately (202).
-  The query runs in the background; the spilled parquet is written as before.
+  Identical SQL is served from an in-memory result cache (reusing the prior spilled
+  parquet); otherwise the query runs in the background and spills as before.
 - `GET /result/{query_id}` — returns `{status: "running"}`, `{status: "error", error}`,
-  or `{status: "done", columns, rows, total_rows, truncated, result_path}`. The page
-  polls this every second; each poll returns well under the 30 s proxy window while
-  the query itself may run for minutes.
+  or `{status: "done", columns, rows, total_rows, truncated, result_path, cached}`.
+  `result_path` is the spilled full result's GCS location; `cached` says whether it
+  came from the cache. The page polls every second; each poll returns well under the
+  30 s proxy window while the query itself may run for minutes.
 - `GET /health` — liveness for Iris.
 
-Query state lives in memory for the process lifetime; ducky is stateless and
-restartable, so a restart simply drops in-flight/finished state.
+The endpoint registers under the cluster-global name `/ducky` (leading slash bypasses
+job-namespacing), so the dashboard is reachable at a clean `/proxy/ducky/`. Query
+state and the result cache live in memory for the process lifetime; ducky is
+stateless and restartable, so a restart drops both.
 
 **3. Deploy** — ducky runs as a long-running Iris job that blocks on `uvicorn`.
 Because a routable service needs a *named* Iris port and `iris job run` has no

--- a/.agents/projects/duckdb_sql_service/design.md
+++ b/.agents/projects/duckdb_sql_service/design.md
@@ -7,7 +7,7 @@ object storage (GCS / R2) — checking a dataset's row counts, schemas, or
 distributions — and today that means hand-rolling a DuckDB script and finding a
 big enough box to run it on. `ducky` is a small always-on Iris service that
 exposes a dashboard: paste SQL, hit run, get results. The query executes in an
-embedded DuckDB on a **full v6e-8 host** (~180 vCPU / ~1.4 TB RAM), so queries
+embedded DuckDB on a **full v6e-4 host** (~180 vCPU / ~720 GB RAM), so queries
 that would OOM or crawl on a laptop finish quickly with no setup. It is
 deliberately minimal — a textarea, a run button, a result table — in the spirit of
 `finelog`'s `StatsService.Query` (`lib/finelog/rust/proto/finelog_stats.proto:176`),
@@ -120,14 +120,18 @@ Because a routable service needs a *named* Iris port and `iris job run` has no
 # python -m ducky.deploy
 client.submit(
     entrypoint="python -m ducky.server",
-    resources=ResourceSpec(cpu=ALL_CPU, memory=ALL_MEM, device=tpu_device("v6e-8")),
+    resources=ResourceSpec(cpu=ALL_CPU, memory=ALL_MEM, device=tpu_device("v6e-4")),
     ports=["ducky"], region=["us-east5"], enable_extra_resources=True, no_wait=True,
 )
 ```
 
-The job requests the whole v6e-8 host (`ResourceSpec`,
+> Note: implementation settled on **v6e-4** (`ct6e-standard-4t`, 180 vCPU / 720 GB), the
+> largest *single-VM* v6e on marin. v6e-8 is a 2-VM slice and single-node DuckDB can only
+> use one VM, so it gains nothing. Deploy defaults: `v6e-4` / 180 vCPU / 690 GB.
+
+The job requests the whole v6e-4 host (`ResourceSpec`,
 `lib/iris/src/iris/cluster/types.py:529`). The `cpu`/`memory` request is a declared
-constant that must match the real `ct6e-standard-8t` host shape — if it overshoots
+constant that must match the real `ct6e-standard-4t` host shape — if it overshoots
 the job never schedules; if it undershoots, `TaskResources.from_environment()`
 reports the smaller request and silently caps DuckDB below the host. On boot the
 server binds `ctx.get_port("ducky")` (not a hardcoded port) and registers

--- a/.agents/projects/duckdb_sql_service/research.md
+++ b/.agents/projects/duckdb_sql_service/research.md
@@ -1,0 +1,121 @@
+# Research — DuckDB SQL service on Iris
+
+Framing: an Iris-hosted service (in the spirit of `finelog`) exposing a minimal
+dashboard where a user pastes a SQL query, the service runs it in **DuckDB** on a
+full **v6e** machine (all CPUs, all RAM), and returns results. Keep it simple.
+
+All paths under repo root.
+
+## 1. finelog as a service template
+
+finelog is now a **Rust** binary (Python server/store deleted — see §5); it runs
+as a standalone GCP VM / k8s Deployment, and the Iris controller embeds it
+in-process via PyO3. It is **not** Iris-hosted today.
+
+- Binary entrypoint: `lib/finelog/rust/src/main.rs:57` (clap CLI `--port/--log-dir`,
+  opens `Store`, `build_app`, `axum::serve` `:97-101`; one port serves `/health` +
+  RPC + SPA).
+- Router assembly: `lib/finelog/rust/src/server/app.rs:111` `build_app` — `/health`
+  `:114`, SPA routes before connect `.fallback_service` for RPC POSTs `:124-126`.
+- **SQL surface (model for us):** `StatsService` —
+  `lib/finelog/rust/proto/finelog_stats.proto:173-179`, `rpc Query(QueryRequest)
+  returns (QueryResponse)` `:176`; `QueryRequest { string sql = 1; }` `:117-121`.
+  Impl `lib/finelog/rust/src/server/stats_service.rs`.
+- Query/exec layer is **DataFusion, not DuckDB**: `lib/finelog/rust/src/query/mod.rs`
+  — `make_ctx()` `:147-156` builds a read-only `SessionContext`, `run_query_over`
+  `:258-291` registers providers, runs user SQL verbatim, collects Arrow batches.
+  `datafusion = "53"` at `lib/finelog/rust/Cargo.toml:76`.
+- Dashboard: Vue SPA `lib/finelog/dashboard/`, served by Rust
+  `lib/finelog/rust/src/server/spa.rs`.
+- Deploy: Python click CLI `lib/finelog/src/finelog/deploy/cli.py:97` →
+  `deploy up/down/restart/status/logs`; GCP-VM or k8s backend. k8s spec
+  `lib/finelog/deploy/k8s/02-deployment.yaml.tmpl` (resources `:55-61`).
+- Config: `lib/finelog/src/finelog/deploy/config.py`; example
+  `lib/finelog/config/marin.yaml` (`name/port/image/remote_log_dir/deployment.gcp`).
+- Client SQL call: `cli.py:254` `query_cmd` → `client.query(sql, max_rows=...)`.
+
+## 2. Running a service on Iris + resource requests
+
+- Launch: `iris job run -- <cmd>`. CLI `lib/iris/src/iris/cli/job.py`. Long-running
+  server = a job whose command blocks; use `--no-wait` (`lib/iris/README.md:309`).
+- Resource spec: `ResourceSpec` dataclass `lib/iris/src/iris/cluster/types.py:529`
+  — `cpu: float`, `memory: str|int`, `disk`, `device: DeviceConfig|None`.
+  `.to_proto()` `:546`. Accelerator CPU floor `MIN_ACCELERATOR_CPU_MILLICORES =
+  4000` `:543`.
+- Builder from flags: `build_resources(tpu, cpu, memory, disk)` `job.py:281`; with
+  `--tpu`, `spec.device = tpu_device(primary)` `:296-300`.
+- Guardrails: `validate_extra_resources` `job.py:361` — `--tpu`/`--gpu` and mem
+  ≥ 4 GB require `--enable-extra-resources` `:393`.
+- Expose HTTP port: Iris endpoint registry `register_endpoint`/`unregister_endpoint`
+  `lib/iris/src/iris/cluster/client/protocol.py:68-76`; controller reverse proxy
+  `lib/iris/src/iris/cluster/controller/endpoint_proxy.py:70`
+  (`/proxy/{endpoint_name}/{sub_path}`); resolution `endpoints.py:63`. finelog is
+  registered this way `endpoints.py:47`.
+- Task self-view of resources: `TaskResources.from_environment()`
+  `lib/iris/src/iris/env_resources.py:58` reads `IRIS_TASK_RESOURCES`, else falls
+  back to host cgroup/`/proc` (`:108+`). A task on a whole host sees all CPUs/RAM.
+- Heavier alternative: Iris Actor system `lib/iris/README.md:74-100` — overkill for
+  a single dashboard.
+
+## 3. DuckDB in the repo
+
+- finelog declares it deploy-side only: `lib/finelog/pyproject.toml:10-16`
+  (`duckdb>=1.0.0`, "used by the deploy CLI to query pulled parquet segments
+  in-process"); imported `lib/finelog/src/finelog/deploy/cli.py:25`.
+- Production finelog query path is DataFusion (Rust); no reusable embedded-DuckDB
+  service exists today.
+- Other DuckDB usage: `scripts/ops/storage/dashboard/server.py`,
+  `scripts/ops/storage/generate_report.py` (+ render/delete), `scripts/ops/cross_region.py`,
+  dep in `scripts/ops/storage/pyproject.toml`.
+
+## 4. Dashboard / web UI patterns
+
+Repo idiom = Starlette ASGI + Connect-RPC + Vue SPA (Python services), or axum+SPA
+(Rust). For "paste SQL, run it", copy the iris worker dashboard.
+
+- Smallest: `lib/iris/src/iris/cluster/worker/dashboard.py` — `_create_app()`
+  returns a Starlette app `:37-41`, mounts RPC + `/health` `:56` + `/` HTML `:60`.
+- Full: `lib/iris/src/iris/cluster/controller/dashboard.py:410+` — Starlette HTML
+  shell (`html_shell("controller")` `:606`) + multiple Connect-RPC sub-apps.
+- Shared helpers: `lib/iris/src/iris/cluster/dashboard_common.py` — `html_shell()`
+  `:166`, `static_files_mount()` `:128`, `favicon_route()` `:152`,
+  `@public`/`@requires_auth` `:33-39`, `on_shutdown` `:45`.
+- Cleanest shape for us: one Starlette route returns an HTML form; a POST endpoint
+  runs the query — mirrors finelog's StatsService.Query but Python + DuckDB.
+
+## 5. Related design docs
+
+- **`stats_service/`** (design/research/spec) — closest prior art: SQL-queryable
+  typed-table service co-hosted in finelog; raw `Table.query(sql)`. Note: its
+  `duckdb_store.py:79` references are **stale** (deleted, see next).
+- **`2026-06-05_finelog_python_deletion.md`** — deleted finelog Python ASGI server +
+  DuckDB store; explains DuckDB→DataFusion and why no Python finelog server remains.
+- `20260331_iris_sql_redesign.md` / `iris-sql-store.md` / `20260310_iris_sql_canonical.md`
+  — controller SQLite stores-layer redesign.
+- `20260315_iris_controller_query_design.md` — controller query RPC design.
+- **`iris_endpoint_proxy/`** — the `/proxy/<name>/` reverse proxy that exposes a
+  dashboard through the controller. Key if the service runs as an Iris job.
+- Dashboard UI framework decisions: `20260128_iris_dashboard_analyze.md`,
+  `20260128_iris_preact_decision.md`, `20260311_iris_vue_refactor.md`.
+
+## 6. v6e machine specifics
+
+- TPU topology: `lib/iris/src/iris/cluster/tpu_topology.py:62-70` — `v6e-1`(1
+  chip/host), `v6e-4`(4/host), `v6e-8`(8 chips/host = single host on GCP), `v6e-16`…
+- "Whole machine" = `ResourceSpec(cpu=<all>, memory=<all>, device=tpu_device("v6e-8"))`
+  via `--tpu v6e-8 --cpu N --memory NGB --enable-extra-resources`.
+- **No hardcoded GCP v6e host vCPU/RAM constant in the repo** — host CPU/RAM
+  discovered at runtime by `TaskResources.from_environment()`. GCP `ct6e-standard-8t`
+  (v6e-8 host) is ~180 vCPU / ~1.4 TB RAM, per GCP docs not the repo.
+
+## Flags / surprises
+
+- **DuckDB ≠ finelog's engine.** finelog is now Rust + DataFusion; only live DuckDB
+  is a deploy-CLI helper. DuckDB-in-Python here is **built fresh**, not reused.
+- **finelog is not Iris-hosted today** — GCP VM / k8s. "Iris-hosted finelog-like
+  service via `iris job run`" is a new deployment shape; endpoint-proxy makes the
+  dashboard reachable.
+- **No repo constant for v6e host CPU/RAM** — "all CPUs/RAM" is runtime-discovered.
+- **TPU jobs need `--enable-extra-resources`** + CPU floor applies.
+- **DuckDB does not use the TPU.** Requesting a v6e host buys its large CPU/RAM
+  envelope; the TPU chips sit idle. Worth an explicit note in the design.

--- a/.agents/projects/duckdb_sql_service/spec.md
+++ b/.agents/projects/duckdb_sql_service/spec.md
@@ -34,7 +34,10 @@ preview as a table plus a stats line; `--format json` prints the raw `/result` J
 @dataclass(frozen=True)
 class DuckyConfig:
     """Resolved once at startup; no env reads after construction."""
-    region: str                  # service region, e.g. "us-east5" (operational pin; not enforced in-runner)
+    region: str                  # service region, e.g. "us-east5" (operational pin)
+    allowed_buckets: tuple[str, ...] = ()  # object-store URI prefixes a query may read; empty = allow all.
+                                 # In-runner same-region guardrail: a query referencing a gs://, s3://, r2://
+                                 # URI outside the allowlist raises BucketNotAllowedError (-> 400) before execution.
     scratch_bucket: str          # gs:// prefix for spilled results, same region. Use the existing
                                  # marin tmp/ttl lifecycle convention, e.g. "gs://marin-us-east5/tmp/ttl=7d";
                                  # the prefix's N days MUST equal result_ttl_days.
@@ -130,15 +133,15 @@ class DuckyError(Exception):
     """Base for ducky errors surfaced to the dashboard as a clean message."""
 
 class QueryError(DuckyError):
-    """DuckDB failed to plan or execute the SQL. Wraps the DuckDB message.
+    """DuckDB failed to plan or execute the SQL. Wraps the DuckDB message."""
 
-    Cross-region reads are not a distinct error type in v1 — they surface here as an
-    httpfs authentication failure because HMAC creds are scoped to same-region buckets.
-    """
+class BucketNotAllowedError(DuckyError):
+    """The SQL references an object-store URI outside config.allowed_buckets. Raised before
+    execution — ducky's same-region guardrail (GCS HMAC keys can't enforce region)."""
 ```
 
-`QueryError` maps to HTTP 400 with `{"error": "<message>"}`. Any other exception
-propagates as 500 (unexpected — let it surface).
+Both `DuckyError` subtypes map to HTTP 400 with `{"error": "<message>"}` (the
+`QueryManager` catches `DuckyError`). Any other exception propagates as 500.
 
 ## HTTP routes (`server.py`)
 

--- a/.agents/projects/duckdb_sql_service/spec.md
+++ b/.agents/projects/duckdb_sql_service/spec.md
@@ -1,0 +1,211 @@
+# ducky — spec
+
+Contract layer for [`design.md`](./design.md). Pins the public surface: package
+layout, runner API, HTTP routes, persisted result shape, errors, deploy command.
+Implementation bodies are out of scope.
+
+## Package layout
+
+```
+lib/ducky/
+  pyproject.toml                 # package "ducky", deps: duckdb>=1.0, starlette, uvicorn, iris (env_resources, dashboard_common), pyarrow
+  src/ducky/
+    __init__.py
+    config.py                    # DuckyConfig + constants
+    runner.py                    # QueryRunner, QueryResult, errors
+    server.py                    # Starlette app + `python -m ducky.server` entrypoint
+    deploy.py                    # `python -m ducky.deploy` — submits the Iris job (ports=["ducky"])
+  tests/
+    test_runner.py
+    test_server.py
+```
+
+## Constants / config (`config.py`)
+
+```python
+@dataclass(frozen=True)
+class DuckyConfig:
+    """Resolved once at startup; no env reads after construction."""
+    region: str                  # service region, e.g. "us-east5" (operational pin; not enforced in-runner)
+    scratch_bucket: str          # gs:// prefix for spilled results, same region; e.g. "gs://marin-ducky-us-east5"
+    # one secret set per backend, keyed by URL scheme so a single SECRET each
+    # disambiguates: gs:// -> GCS, r2:// -> R2, s3:// -> CoreWeave. DuckDB httpfs
+    # cannot use GCP ADC, so GCS needs HMAC interop keys.
+    gcs_hmac_key_id: str         # GCS interop HMAC key id   -> CREATE SECRET ... TYPE GCS  (gs://)
+    gcs_hmac_secret: str         # GCS interop HMAC secret
+    r2_account_id: str           # R2 account id             -> CREATE SECRET ... TYPE R2   (r2://)
+    r2_access_key: str
+    r2_secret_key: str
+    cw_endpoint: str             # CoreWeave S3 endpoint     -> CREATE SECRET ... TYPE S3   (s3://)
+    cw_access_key: str
+    cw_secret_key: str
+    preview_row_cap: int = 10_000 # max rows returned inline to the browser
+    memory_fraction: float = 0.8  # DuckDB memory_limit = this * host RAM; headroom for Python/Arrow/OS
+    result_ttl_days: int = 7      # informational; enforced by the bucket's lifecycle rule, not by ducky
+    port_name: str = "ducky"      # Iris named port; bound via ctx.get_port(port_name)
+
+    @classmethod
+    def from_environment(cls) -> "DuckyConfig":
+        """Build from process env / Iris task env. Fail fast (ValueError) if any required field is unset."""
+```
+
+`result_ttl_days` is documentation only — ducky never deletes; the scratch bucket
+carries a GCS object-lifecycle rule set out of band at deploy time. The `region`
+pin is operational (job pinned to `us-east5`, HMAC keys scoped to same-region
+buckets); the runner does **not** parse SQL to enforce it.
+
+## Runner API (`runner.py`)
+
+```python
+@dataclass(frozen=True)
+class QueryResult:
+    columns: list[str]           # column names, in select order
+    preview_rows: list[list]     # up to config.preview_row_cap rows; cells are JSON-serializable scalars
+    total_rows: int              # full row count of the result (>= len(preview_rows))
+    truncated: bool              # True iff total_rows > len(preview_rows)
+    result_path: str             # gs:// path to the full result parquet (always written, even when not truncated)
+
+
+class QueryRunner:
+    """Owns one embedded DuckDB connection for the process lifetime.
+
+    On construction: opens DuckDB, INSTALL/LOAD httpfs, creates one `SECRET` per
+    backend (GCS HMAC, R2 S3, CoreWeave S3) from config creds, pins
+    `threads` to the host CPU count and `memory_limit` to
+    config.memory_fraction * host RAM from
+    iris.env_resources.TaskResources.from_environment(). Not safe for concurrent use
+    — `run_query` is serialized by the caller (single-query-at-a-time, per design).
+    """
+
+    def __init__(self, config: DuckyConfig, resources: TaskResources | None = None) -> None: ...
+    # resources defaults to TaskResources.from_environment(); injectable for tests.
+
+    def run_query(self, sql: str, query_id: str) -> QueryResult:
+        """Run `sql` exactly once and return a capped preview + spilled full result.
+
+        Executes `COPY (<sql>) TO '{config.scratch_bucket}/ducky/{query_id}.parquet'
+        (FORMAT parquet)` — the user SQL runs a single time. Then reads the written
+        parquet back to get `total_rows` and the first `config.preview_row_cap` rows
+        for `preview_rows`; sets `truncated = total_rows > len(preview_rows)`. The
+        result is never recomputed, so non-deterministic SQL (random/now/unordered
+        LIMIT) stays consistent between preview and spilled file.
+
+        `query_id` is validated as a bare uuid4 hex before path interpolation
+        (rejects anything non-`[0-9a-f]{32}`) to prevent path injection.
+
+        Raises:
+            QueryError: DuckDB raised (syntax, missing table, type, auth/region — a
+                cross-region read surfaces here as an httpfs auth failure). Message is
+                the DuckDB error text, no stack trace.
+        """
+```
+
+`query_id` is supplied by the server (a uuid4 hex); the runner does not generate
+it (keeps the runner deterministic / `Math.random`-free for testing).
+
+**Preview cell coercion:** `preview_rows` cells are JSON-serializable scalars.
+DuckDB types without a native JSON form (timestamp, decimal, interval, blob, list,
+struct) are coerced to their string form (Arrow→`str`) at preview build time; the
+spilled parquet keeps native types.
+
+## Errors (`runner.py`)
+
+```python
+class DuckyError(Exception):
+    """Base for ducky errors surfaced to the dashboard as a clean message."""
+
+class QueryError(DuckyError):
+    """DuckDB failed to plan or execute the SQL. Wraps the DuckDB message.
+
+    Cross-region reads are not a distinct error type in v1 — they surface here as an
+    httpfs authentication failure because HMAC creds are scoped to same-region buckets.
+    """
+```
+
+`QueryError` maps to HTTP 400 with `{"error": "<message>"}`. Any other exception
+propagates as 500 (unexpected — let it surface).
+
+## HTTP routes (`server.py`)
+
+Starlette app built like `lib/iris/src/iris/cluster/worker/dashboard.py:37`, reusing
+`iris.cluster.dashboard_common.html_shell` and `@requires_auth`.
+
+| Method | Path        | Auth          | Purpose |
+|--------|-------------|---------------|---------|
+| GET    | `/`         | `@requires_auth` | HTML page: SQL `<textarea>`, Run button, empty result area |
+| POST   | `/query`    | `@requires_auth` | Run SQL, return result JSON |
+| GET    | `/health`   | `@public`     | Liveness for Iris |
+
+**`POST /query`**
+- Request body (JSON): `{"sql": "<string>"}`
+- 200 response (JSON):
+  ```json
+  {
+    "columns": ["..."],
+    "rows": [[...], ...],
+    "total_rows": 12345,
+    "truncated": true,
+    "result_path": "gs://marin-ducky-us-east5/ducky/<query_id>.parquet"
+  }
+  ```
+  (`rows` is `QueryResult.preview_rows`.)
+- 400 response (JSON): `{"error": "<message>"}` for `QueryError`.
+
+The page renders `rows` as a table; when `truncated`, shows
+"showing N of M rows — full result at `result_path` (expires in {result_ttl_days}d)".
+
+**Entrypoint:** `python -m ducky.server`. On boot: build
+`DuckyConfig.from_environment()`, construct `QueryRunner`, bind
+`port = iris_ctx().get_port(config.port_name)` (the named Iris port; **not** a
+hardcoded port), start uvicorn on `0.0.0.0:port`, then register
+`endpoint_id = ctx.registry.register("ducky", f"http://{job_info.advertise_host}:{port}",
+{"job_id": ctx.job_id.to_wire()})` (`lib/iris/src/iris/client/worker_pool.py:156-165`).
+On shutdown, `ctx.registry.unregister(endpoint_id)` via Starlette `on_shutdown`.
+
+## Persisted shape
+
+- **Spilled result:** parquet at `{scratch_bucket}/ducky/{query_id}.parquet`, one
+  file per query, written by DuckDB `COPY (…) TO … (FORMAT parquet)`. No partitioning.
+- **Retention:** GCS object-lifecycle rule on `scratch_bucket`, `age = result_ttl_days`,
+  configured at deploy time (not by ducky). ducky only writes.
+- No other persisted state — ducky is stateless across restarts.
+
+## Deploy
+
+Always-on Iris job, single region `us-east5`. A routable service needs a **named
+Iris port**, which `iris job run` cannot declare (no `--ports` flag), so deploy uses
+the Python submit path (`ports=["ducky"]`, as `worker_pool.py:440` does), not the
+bare CLI:
+
+```python
+# python -m ducky.deploy
+client.submit(
+    entrypoint="python -m ducky.server",
+    resources=ResourceSpec(cpu=ALL_CPU, memory=ALL_MEM, device=tpu_device("v6e-8")),
+    ports=["ducky"],
+    region=["us-east5"],
+    enable_extra_resources=True,
+    extras=["..."],          # or a --task-image carrying the ducky package
+    no_wait=True,
+)
+```
+
+- `ALL_CPU` / `ALL_MEM` are declared constants matching the real `ct6e-standard-8t`
+  host shape (to confirm — see design Open Questions); over-requesting fails to
+  schedule, under-requesting silently caps DuckDB below the host.
+- The three credential sets (GCS HMAC, R2 S3, CoreWeave S3) and `scratch_bucket`
+  are injected as task env vars / secret mount consumed by
+  `DuckyConfig.from_environment()`.
+- The `ducky` package must be importable in the task (UV extra or custom task image).
+
+Reachable at `/proxy/ducky/` through the controller endpoint proxy
+(`lib/iris/src/iris/cluster/controller/endpoint_proxy.py:70`).
+
+## Out of scope
+
+- Connect-RPC / proto surface — plain JSON routes only; no `.proto` for v1.
+- Idle-timeout / host parking — always-on; deferred (see design Open Questions).
+- Multi-region deploy — `us-east5` only.
+- Query history, saved queries, auth beyond the proxy's `@requires_auth`.
+- Concurrency control beyond single-query-at-a-time (no queue in v1).
+- Result formats other than parquet; signed-URL downloads.

--- a/.agents/projects/duckdb_sql_service/spec.md
+++ b/.agents/projects/duckdb_sql_service/spec.md
@@ -27,7 +27,9 @@ lib/ducky/
 class DuckyConfig:
     """Resolved once at startup; no env reads after construction."""
     region: str                  # service region, e.g. "us-east5" (operational pin; not enforced in-runner)
-    scratch_bucket: str          # gs:// prefix for spilled results, same region; e.g. "gs://marin-ducky-us-east5"
+    scratch_bucket: str          # gs:// prefix for spilled results, same region. Use the existing
+                                 # marin tmp/ttl lifecycle convention, e.g. "gs://marin-us-east5/tmp/ttl=7d";
+                                 # the prefix's N days MUST equal result_ttl_days.
     # one secret set per backend, keyed by URL scheme so a single SECRET each
     # disambiguates: gs:// -> GCS, r2:// -> R2, s3:// -> CoreWeave. DuckDB httpfs
     # cannot use GCP ADC, so GCS needs HMAC interop keys.
@@ -200,7 +202,9 @@ On shutdown (Starlette `on_shutdown`), `ctx.registry.unregister(endpoint_id)` an
 
 - **Spilled result:** parquet at `{scratch_bucket}/ducky/{query_id}.parquet`, one
   file per query, written by DuckDB `COPY (…) TO … (FORMAT parquet)`. No partitioning.
-- **Retention:** GCS object-lifecycle rule on `scratch_bucket`, `age = result_ttl_days`,
+- **Retention:** the marin `tmp/ttl=Nd/` lifecycle convention auto-deletes after N
+  days; pick the `scratch_bucket` prefix whose N matches `result_ttl_days`. ducky
+  only writes. (Equivalently, a dedicated bucket with `age = result_ttl_days`.)
   configured at deploy time (not by ducky). ducky only writes.
 - No other persisted state — ducky is stateless across restarts.
 

--- a/.agents/projects/duckdb_sql_service/spec.md
+++ b/.agents/projects/duckdb_sql_service/spec.md
@@ -57,7 +57,10 @@ class DuckyConfig:
     cw_scope: str = "s3://marin-us-east-02a"
     cw_url_style: str = "vhost"  # CoreWeave rejects path-style addressing; virtual-hosted only
     preview_row_cap: int = 10_000 # max rows returned inline to the browser
-    memory_fraction: float = 0.8  # DuckDB memory_limit = this * host RAM; headroom for Python/Arrow/OS
+    memory_fraction: float = 0.8  # DuckDB memory_limit = this * host RAM (hard cap: no OS-OOM-kill)
+    spill_directory: str = "/tmp/ducky-spill"   # local disk DuckDB spills to (out-of-core) past memory_limit
+    max_concurrent_queries: int = 8  # queries run in parallel, each on its own cursor
+    query_timeout: int = 600      # per-query wall-clock limit; a runaway is interrupted and frees its slot
     result_ttl_days: int = 7      # informational; enforced by the bucket's lifecycle rule, not by ducky
     port_name: str = "ducky"      # Iris named port; bound via ctx.get_port(port_name)
     endpoint_name: str = "/ducky" # registry name; leading slash = cluster-global, so the

--- a/.agents/projects/duckdb_sql_service/spec.md
+++ b/.agents/projects/duckdb_sql_service/spec.md
@@ -41,6 +41,7 @@ class DuckyConfig:
     cw_endpoint: str             # CoreWeave S3 endpoint     -> CREATE SECRET ... TYPE S3   (s3://)
     cw_access_key: str
     cw_secret_key: str
+    cw_url_style: str = "vhost"  # CoreWeave rejects path-style addressing; default virtual-hosted
     preview_row_cap: int = 10_000 # max rows returned inline to the browser
     memory_fraction: float = 0.8  # DuckDB memory_limit = this * host RAM; headroom for Python/Arrow/OS
     result_ttl_days: int = 7      # informational; enforced by the bucket's lifecycle rule, not by ducky

--- a/.agents/projects/duckdb_sql_service/spec.md
+++ b/.agents/projects/duckdb_sql_service/spec.md
@@ -41,18 +41,21 @@ class DuckyConfig:
     scratch_bucket: str          # gs:// prefix for spilled results, same region. Use the existing
                                  # marin tmp/ttl lifecycle convention, e.g. "gs://marin-us-east5/tmp/ttl=7d";
                                  # the prefix's N days MUST equal result_ttl_days.
-    # one secret set per backend, keyed by URL scheme so a single SECRET each
-    # disambiguates: gs:// -> GCS, r2:// -> R2, s3:// -> CoreWeave. DuckDB httpfs
-    # cannot use GCP ADC, so GCS needs HMAC interop keys.
+    # GCS via HMAC interop (DuckDB httpfs can't use GCP ADC). R2 and CoreWeave are both
+    # s3://, so each is a TYPE S3 secret SCOPE-d to its bucket prefix — DuckDB routes an
+    # s3:// URI to the secret with the longest matching scope (different endpoints).
     gcs_hmac_key_id: str         # GCS interop HMAC key id   -> CREATE SECRET ... TYPE GCS  (gs://)
-    gcs_hmac_secret: str         # GCS interop HMAC secret
-    r2_account_id: str           # R2 account id             -> CREATE SECRET ... TYPE R2   (r2://)
+    gcs_hmac_secret: str
+    r2_endpoint: str             # R2 account endpoint host  -> TYPE S3, SCOPE s3://marin-na, URL_STYLE path
     r2_access_key: str
     r2_secret_key: str
-    cw_endpoint: str             # CoreWeave S3 endpoint     -> CREATE SECRET ... TYPE S3   (s3://)
+    r2_scope: str = "s3://marin-na"
+    r2_url_style: str = "path"
+    cw_endpoint: str             # CoreWeave endpoint host   -> TYPE S3, SCOPE s3://marin-us-east-02a, URL_STYLE vhost
     cw_access_key: str
     cw_secret_key: str
-    cw_url_style: str = "vhost"  # CoreWeave rejects path-style addressing; default virtual-hosted
+    cw_scope: str = "s3://marin-us-east-02a"
+    cw_url_style: str = "vhost"  # CoreWeave rejects path-style addressing; virtual-hosted only
     preview_row_cap: int = 10_000 # max rows returned inline to the browser
     memory_fraction: float = 0.8  # DuckDB memory_limit = this * host RAM; headroom for Python/Arrow/OS
     result_ttl_days: int = 7      # informational; enforced by the bucket's lifecycle rule, not by ducky

--- a/.agents/projects/duckdb_sql_service/spec.md
+++ b/.agents/projects/duckdb_sql_service/spec.md
@@ -128,31 +128,57 @@ propagates as 500 (unexpected — let it surface).
 ## HTTP routes (`server.py`)
 
 Starlette app built like `lib/iris/src/iris/cluster/worker/dashboard.py:37`, reusing
-`iris.cluster.dashboard_common.html_shell` and `@requires_auth`.
+`iris.cluster.dashboard_common` `@requires_auth`/`@public`.
 
-| Method | Path        | Auth          | Purpose |
-|--------|-------------|---------------|---------|
-| GET    | `/`         | `@requires_auth` | HTML page: SQL `<textarea>`, Run button, empty result area |
-| POST   | `/query`    | `@requires_auth` | Run SQL, return result JSON |
-| GET    | `/health`   | `@public`     | Liveness for Iris |
+Queries are **async**: the dashboard is reached through the controller endpoint
+proxy, which caps every forwarded request at 30 s (`endpoint_proxy.py:71`,
+`PROXY_TIMEOUT_SECONDS`). `POST /query` therefore submits and returns a `query_id`;
+the client polls `GET /result/{query_id}`. Each HTTP call returns in well under 30 s
+while the query runs for as long as it needs.
+
+| Method | Path                  | Auth             | Purpose |
+|--------|-----------------------|------------------|---------|
+| GET    | `/`                   | `@requires_auth` | HTML page: SQL `<textarea>`, Run, result area (polls `/result`) |
+| POST   | `/query`              | `@requires_auth` | Submit SQL, return `query_id` (202) |
+| GET    | `/result/{query_id}`  | `@requires_auth` | Poll query status / result |
+| GET    | `/health`             | `@public`        | Liveness for Iris |
 
 **`POST /query`**
 - Request body (JSON): `{"sql": "<string>"}`
-- 200 response (JSON):
-  ```json
-  {
-    "columns": ["..."],
-    "rows": [[...], ...],
-    "total_rows": 12345,
-    "truncated": true,
-    "result_path": "gs://marin-ducky-us-east5/ducky/<query_id>.parquet"
-  }
-  ```
-  (`rows` is `QueryResult.preview_rows`.)
-- 400 response (JSON): `{"error": "<message>"}` for `QueryError`.
+- 202 response (JSON): `{"query_id": "<uuid4 hex>"}`. The `QueryManager` submits the
+  SQL to a single-worker executor (one DuckDB query at a time) and returns at once.
+- 400 response (JSON): `{"error": "missing 'sql'"}` when `sql` is absent/blank.
 
-The page renders `rows` as a table; when `truncated`, shows
-"showing N of M rows — full result at `result_path` (expires in {result_ttl_days}d)".
+**`GET /result/{query_id}`**
+- 200 `{"status": "running"}` — still executing.
+- 200 `{"status": "error", "error": "<message>"}` — `QueryError` (or an unexpected
+  error) raised while running.
+- 200 `{"status": "done", "columns": [...], "rows": [[...]], "total_rows": N,
+  "truncated": bool, "result_path": "<gs://…>"}` — `rows` is `QueryResult.preview_rows`.
+- 404 `{"error": "unknown query_id"}` — no such (or expired) query.
+
+The page polls `/result/{query_id}` every second; on `done` it renders `rows` and,
+when `truncated`, shows "showing N of M rows — full result at `result_path`
+(expires in {result_ttl_days}d)".
+
+**Query manager (`server.py`)**
+```python
+class QueryStatus(enum.StrEnum):
+    RUNNING = "running"
+    DONE = "done"
+    ERROR = "error"
+
+class QueryManager:
+    """Runs queries one at a time in a background single-worker executor and tracks
+    in-memory state. `submit(sql) -> query_id` returns immediately; `get(query_id)`
+    returns the current QueryState (or None). State is process-local and unbounded;
+    a restart drops it (ducky is stateless/restartable). `shutdown()` stops the
+    executor on app shutdown."""
+    def __init__(self, runner: QueryRunner) -> None: ...
+    def submit(self, sql: str) -> str: ...
+    def get(self, query_id: str) -> QueryState | None: ...
+    def shutdown(self) -> None: ...
+```
 
 **Entrypoint:** `python -m ducky.server`. On boot: build
 `DuckyConfig.from_environment()`, construct `QueryRunner`, bind
@@ -160,7 +186,8 @@ The page renders `rows` as a table; when `truncated`, shows
 hardcoded port), start uvicorn on `0.0.0.0:port`, then register
 `endpoint_id = ctx.registry.register("ducky", f"http://{job_info.advertise_host}:{port}",
 {"job_id": ctx.job_id.to_wire()})` (`lib/iris/src/iris/client/worker_pool.py:156-165`).
-On shutdown, `ctx.registry.unregister(endpoint_id)` via Starlette `on_shutdown`.
+On shutdown (Starlette `on_shutdown`), `ctx.registry.unregister(endpoint_id)` and
+`app.state.query_manager.shutdown()`.
 
 ## Persisted shape
 

--- a/.agents/projects/duckdb_sql_service/spec.md
+++ b/.agents/projects/duckdb_sql_service/spec.md
@@ -14,11 +14,19 @@ lib/ducky/
     config.py                    # DuckyConfig + constants
     runner.py                    # QueryRunner, QueryResult, errors
     server.py                    # Starlette app + `python -m ducky.server` entrypoint
-    deploy.py                    # `python -m ducky.deploy` — submits the Iris job (ports=["ducky"])
+    deploy.py                    # submit the Iris job (ports=["ducky"])
+    client.py                    # `ducky query` — POST /query + poll /result, print table/json
+    cli.py                       # `ducky` command group: `ducky deploy` + `ducky query`
   tests/
     test_runner.py
     test_server.py
+    test_client.py
 ```
+
+The `ducky query` CLI talks to the service over a base URL (default
+`http://127.0.0.1:10000/proxy/ducky`, the local controller tunnel from
+`iris cluster dashboard`): `ducky query "SELECT …"` submits, polls, and prints the
+preview as a table plus a stats line; `--format json` prints the raw `/result` JSON.
 
 ## Constants / config (`config.py`)
 

--- a/.agents/projects/duckdb_sql_service/spec.md
+++ b/.agents/projects/duckdb_sql_service/spec.md
@@ -68,6 +68,8 @@ class QueryResult:
     total_rows: int              # full row count of the result (>= len(preview_rows))
     truncated: bool              # True iff total_rows > len(preview_rows)
     result_path: str             # gs:// path to the full result parquet (always written, even when not truncated)
+    elapsed_ms: int              # server-side execution wall time (COPY + readback)
+    result_bytes: int            # on-disk size of the spilled result parquet (sum of parquet_metadata sizes)
 
 
 class QueryRunner:
@@ -158,10 +160,11 @@ while the query runs for as long as it needs.
 - 200 `{"status": "error", "error": "<message>"}` — `QueryError` (or an unexpected
   error) raised while running.
 - 200 `{"status": "done", "columns": [...], "rows": [[...]], "total_rows": N,
-  "truncated": bool, "result_path": "<gs://…>", "cached": bool}` — `rows` is
-  `QueryResult.preview_rows`; `result_path` is the spilled full result's GCS
-  location; `cached` is true when the result was served from the in-memory
-  result cache (identical SQL) rather than re-executed.
+  "truncated": bool, "result_path": "<gs://…>", "cached": bool, "elapsed_ms": int,
+  "result_bytes": int}` — `rows` is `QueryResult.preview_rows`; `result_path` is the
+  spilled full result's GCS location; `cached` is true when served from the in-memory
+  result cache (identical SQL); `elapsed_ms` is execution wall time and `result_bytes`
+  the spilled parquet size. (On a cache hit these reflect the original run.)
 - 404 `{"error": "unknown query_id"}` — no such (or expired) query.
 
 The page (a CodeMirror SQL-highlighted editor) polls `/result/{query_id}` every

--- a/.agents/projects/duckdb_sql_service/spec.md
+++ b/.agents/projects/duckdb_sql_service/spec.md
@@ -240,7 +240,7 @@ bare CLI:
 # python -m ducky.deploy
 client.submit(
     entrypoint="python -m ducky.server",
-    resources=ResourceSpec(cpu=ALL_CPU, memory=ALL_MEM, device=tpu_device("v6e-8")),
+    resources=ResourceSpec(cpu=ALL_CPU, memory=ALL_MEM, device=tpu_device("v6e-4")),  # single-VM; v6e-8 is 2 VMs
     ports=["ducky"],
     region=["us-east5"],
     enable_extra_resources=True,

--- a/.agents/projects/duckdb_sql_service/spec.md
+++ b/.agents/projects/duckdb_sql_service/spec.md
@@ -43,6 +43,8 @@ class DuckyConfig:
     memory_fraction: float = 0.8  # DuckDB memory_limit = this * host RAM; headroom for Python/Arrow/OS
     result_ttl_days: int = 7      # informational; enforced by the bucket's lifecycle rule, not by ducky
     port_name: str = "ducky"      # Iris named port; bound via ctx.get_port(port_name)
+    endpoint_name: str = "/ducky" # registry name; leading slash = cluster-global, so the
+                                  # dashboard is at /proxy/ducky/ (not a per-job namespaced path)
 
     @classmethod
     def from_environment(cls) -> "DuckyConfig":
@@ -154,12 +156,15 @@ while the query runs for as long as it needs.
 - 200 `{"status": "error", "error": "<message>"}` — `QueryError` (or an unexpected
   error) raised while running.
 - 200 `{"status": "done", "columns": [...], "rows": [[...]], "total_rows": N,
-  "truncated": bool, "result_path": "<gs://…>"}` — `rows` is `QueryResult.preview_rows`.
+  "truncated": bool, "result_path": "<gs://…>", "cached": bool}` — `rows` is
+  `QueryResult.preview_rows`; `result_path` is the spilled full result's GCS
+  location; `cached` is true when the result was served from the in-memory
+  result cache (identical SQL) rather than re-executed.
 - 404 `{"error": "unknown query_id"}` — no such (or expired) query.
 
-The page polls `/result/{query_id}` every second; on `done` it renders `rows` and,
-when `truncated`, shows "showing N of M rows — full result at `result_path`
-(expires in {result_ttl_days}d)".
+The page (a CodeMirror SQL-highlighted editor) polls `/result/{query_id}` every
+second; on `done` it renders `rows` plus a status line with the row count, a
+cached/computed badge, and the `result_path` (expires in {result_ttl_days}d).
 
 **Query manager (`server.py`)**
 ```python
@@ -184,8 +189,10 @@ class QueryManager:
 `DuckyConfig.from_environment()`, construct `QueryRunner`, bind
 `port = iris_ctx().get_port(config.port_name)` (the named Iris port; **not** a
 hardcoded port), start uvicorn on `0.0.0.0:port`, then register
-`endpoint_id = ctx.registry.register("ducky", f"http://{job_info.advertise_host}:{port}",
-{"job_id": ctx.job_id.to_wire()})` (`lib/iris/src/iris/client/worker_pool.py:156-165`).
+`endpoint_id = ctx.registry.register(config.endpoint_name, f"http://{job_info.advertise_host}:{port}",
+{"job_id": ctx.job_id.to_wire()})` (`lib/iris/src/iris/client/worker_pool.py:156-165`). The
+leading-slash `endpoint_name` (`/ducky`) registers a cluster-global endpoint, so the
+proxy resolves `/proxy/ducky/` (`endpoint_proxy.py` decode: `.`→`/`, tries `/ducky`).
 On shutdown (Starlette `on_shutdown`), `ctx.registry.unregister(endpoint_id)` and
 `app.state.query_manager.shutdown()`.
 

--- a/.github/workflows/ducky-unit.yaml
+++ b/.github/workflows/ducky-unit.yaml
@@ -1,0 +1,56 @@
+name: "Ducky - Unit"
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  changes:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      pull-requests: read
+    outputs:
+      should_run: ${{ steps.filter.outputs.relevant }}
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dorny/paths-filter@fbd0ab8f3e69293af611ebaee6363fc25e6d187d  # v4
+        id: filter
+        with:
+          filters: |
+            relevant:
+              - 'lib/ducky/**'
+              - 'lib/iris/**'
+              - 'uv.lock'
+              - '.github/workflows/ducky-unit.yaml'
+
+  ducky-unit:
+    needs: changes
+    if: needs.changes.outputs.should_run == 'true'
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v5
+
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v6
+        with:
+          python-version: "3.12"
+
+      - name: Install uv
+        uses: astral-sh/setup-uv@v7
+        with:
+          enable-cache: true
+
+      - name: Test ducky
+        run: |
+          uv run --package marin-ducky --group=test pytest --durations=5 --tb=short -v -s lib/ducky/tests/

--- a/lib/ducky/README.md
+++ b/lib/ducky/README.md
@@ -1,0 +1,82 @@
+# ducky
+
+Ad-hoc DuckDB SQL over object-store parquet, as an always-on Iris service. Paste SQL
+in the dashboard or hit the API; the full result spills to a TTL'd GCS path and a capped
+preview comes back inline.
+
+Dashboard: <https://iris.oa.dev/proxy/ducky/>
+
+## Query API
+
+Queries run asynchronously: `POST /query {"sql": …}` returns `202 {"query_id"}`, then poll
+`GET /result/{query_id}` until `status != "running"`.
+
+```
+POST /proxy/ducky/query   {"sql": "SELECT 42 AS answer"}
+  → 202 {"query_id": "…"}
+GET  /proxy/ducky/result/<id>
+  → {"status":"done","columns":["answer"],"rows":[[42]],"total_rows":1,
+     "result_path":"gs://…/ducky/<hash>.parquet","elapsed_ms":267}
+```
+
+Pass `{"use_cache": false}` on the POST to force a fresh run (by default an identical prior
+query's result is reused).
+
+### From the CLI (auto-tunnel)
+
+```bash
+ducky query --cluster marin "SELECT count(*) FROM read_parquet('gs://marin-…/*.parquet')"
+```
+
+Opens a controller tunnel for you, prints a table (or `--format json`); `--no-cache` forces
+a fresh run. No IAP token needed — the tunnel is loopback-trusted.
+
+### Directly through IAP (no tunnel)
+
+The service sits behind IAP at `https://iris.oa.dev/proxy/ducky/`. Send a Google-signed
+OIDC ID token as a bearer. **The audience must be the desktop OAuth client**
+(`MARIN_DESKTOP_OAUTH_CLIENT` in `rigging/auth.py`) — IAP's browser-redirect client-id is
+*not* an accepted bearer audience and returns
+`401 Invalid bearer token. Audience doesn't match the allowlisted oauth clients`. The
+caller's identity (service account or user) must already be IAP-authorized.
+
+```python
+import time
+import httpx
+import google.auth.transport.requests
+import google.oauth2.id_token
+
+AUD = "748532799086-qf8m6mvovtdmd71npm07gk1ohijsr3q5.apps.googleusercontent.com"  # MARIN_DESKTOP_OAUTH_CLIENT
+token = google.oauth2.id_token.fetch_id_token(google.auth.transport.requests.Request(), AUD)
+headers = {"Authorization": f"Bearer {token}"}
+base = "https://iris.oa.dev/proxy/ducky"
+
+qid = httpx.post(f"{base}/query", json={"sql": "SELECT 42 AS answer"}, headers=headers).json()["query_id"]
+while True:
+    result = httpx.get(f"{base}/result/{qid}", headers=headers).json()
+    if result["status"] != "running":
+        break
+    time.sleep(1)
+print(result["columns"], result["rows"])
+```
+
+`gcloud auth print-identity-token --audiences=$AUD` mints the same token for a service-account
+credential. `Proxy-Authorization: Bearer …` works interchangeably with `Authorization`.
+
+## Deploy
+
+```bash
+uv run ducky deploy --cluster marin        # builds the dashboard, auto-tunnels, submits
+```
+
+Replaces a running instance by default; `--keep` makes it an idempotent watchdog resubmit
+(only recreates a gone/terminal job). Config comes from `DUCKY_*` env vars — see `config.py`.
+
+## Notes
+
+- ducky reads only object-store URIs on the bucket allowlist (`DUCKY_ALLOWED_BUCKETS`);
+  local-file access is blocked. Queries against buckets outside the allowlist are refused
+  before execution.
+- A datakit **clustered-store** bucket (`…/cluster=C/quality=Q/`) holds levanter
+  `JaggedArrayStore` (zarr) caches, not parquet — `read_parquet` finds nothing there. Query
+  the upstream parquet attribute datasets instead.

--- a/lib/ducky/dashboard/.gitignore
+++ b/lib/ducky/dashboard/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+dist
+.rsbuild

--- a/lib/ducky/dashboard/env.d.ts
+++ b/lib/ducky/dashboard/env.d.ts
@@ -1,0 +1,7 @@
+/// <reference types="@rsbuild/core/types" />
+
+declare module '*.vue' {
+  import type { DefineComponent } from 'vue'
+  const component: DefineComponent<{}, {}, any>
+  export default component
+}

--- a/lib/ducky/dashboard/package-lock.json
+++ b/lib/ducky/dashboard/package-lock.json
@@ -1,0 +1,1920 @@
+{
+  "name": "ducky-dashboard",
+  "version": "0.0.0",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {
+    "": {
+      "name": "ducky-dashboard",
+      "version": "0.0.0",
+      "dependencies": {
+        "@codemirror/lang-sql": "^6.8.0",
+        "@codemirror/state": "^6.5.2",
+        "@codemirror/view": "^6.36.2",
+        "@fontsource-variable/noto-sans": "^5.2.10",
+        "@fontsource-variable/noto-sans-mono": "^5.2.10",
+        "@tailwindcss/postcss": "^4.3.0",
+        "codemirror": "^6.0.1",
+        "vue": "^3.5.35"
+      },
+      "devDependencies": {
+        "@rsbuild/core": "^1.2.0",
+        "@rsbuild/plugin-vue": "^1.2.9",
+        "autoprefixer": "^10.4.0",
+        "postcss": "^8.5.15",
+        "tailwindcss": "^4.0.0",
+        "typescript": "^6.0.3",
+        "vue-tsc": "^2.2.0"
+      }
+    },
+    "node_modules/@alloc/quick-lru": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/@alloc/quick-lru/-/quick-lru-5.2.0.tgz",
+      "integrity": "sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/@babel/helper-string-parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.29.7.tgz",
+      "integrity": "sha512-Pb5ijPrZ89GDH8223L4UP8i6QApWxs04RbPQJTeWDV0/keR2E36MeKnyr6LYmUUvqRRI+Iv87SuF1W6ErINzYw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/helper-validator-identifier": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.29.7.tgz",
+      "integrity": "sha512-qehxGkRj55h/ff8EMaJ+cYhyaKlHIxqYDn682wQD7RNp9UujOQsHog2uS0r2vzr4pW+sXf90NeeayjcNaX3fFg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@babel/parser": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.29.7.tgz",
+      "integrity": "sha512-hnORnjP/1P/zFEndoeX+n+t1RwWRJiJpM/jO7FW32Kn9r5+sJB2JWOdYo4L6k78j15eCwY3Gm/7364B1EMwtNg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/types": "^7.29.7"
+      },
+      "bin": {
+        "parser": "bin/babel-parser.js"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@babel/types": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.29.7.tgz",
+      "integrity": "sha512-4zBIxpPzowiZpusoFkyGVwakdRJUyuH5PxQ/PrqghfdFWWasvnCdPfQXHrenDai+gyLARulZjZowCOj6fjT4pA==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/helper-string-parser": "^7.29.7",
+        "@babel/helper-validator-identifier": "^7.29.7"
+      },
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@codemirror/autocomplete": {
+      "version": "6.20.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/autocomplete/-/autocomplete-6.20.3.tgz",
+      "integrity": "sha512-tlosUqb+3BbxCxZdu4tKeRghPFC+QM7q4X5YhKV2eCmPG+1r2F3f4AaSz5sCrFqUtX4Jh20VFTKecl16MgiV9g==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.17.0",
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/commands": {
+      "version": "6.10.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/commands/-/commands-6.10.4.tgz",
+      "integrity": "sha512-Ryk9y9T0FFVF0cUGhAknveAyUOl/A1qReTFi+qPKtOh2Z9F4AUBz3XOrYD4ZEgZirdugVzHvd/2/Wcwy5OliTg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.7.0",
+        "@codemirror/view": "^6.27.0",
+        "@lezer/common": "^1.1.0"
+      }
+    },
+    "node_modules/@codemirror/lang-sql": {
+      "version": "6.10.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/lang-sql/-/lang-sql-6.10.0.tgz",
+      "integrity": "sha512-6ayPkEd/yRw0XKBx5uAiToSgGECo/GY2NoJIHXIIQh1EVwLuKoU8BP/qK0qH5NLXAbtJRLuT73hx7P9X34iO4w==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@lezer/common": "^1.2.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/language": {
+      "version": "6.12.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/language/-/language-6.12.4.tgz",
+      "integrity": "sha512-1q4PaT+o6PbgpkJt4Q8Fv5XJxTy4FUZ4MWETtyiDw3J0Pyr9E2vqcKL+k9wcvjNTIsauxvE7OfmWj3FRPHQ76A==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.23.0",
+        "@lezer/common": "^1.5.0",
+        "@lezer/highlight": "^1.0.0",
+        "@lezer/lr": "^1.0.0",
+        "style-mod": "^4.0.0"
+      }
+    },
+    "node_modules/@codemirror/lint": {
+      "version": "6.9.7",
+      "resolved": "https://registry.npmjs.org/@codemirror/lint/-/lint-6.9.7.tgz",
+      "integrity": "sha512-28/+iWLYxKxsvGYhSYL7zaCZqLz5+FFFDq9tVsvGv9kv8RY4fFAchJ5WX9M3YrrRlTIsECjsXPqeNgnSmNP2dg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.42.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/search": {
+      "version": "6.7.1",
+      "resolved": "https://registry.npmjs.org/@codemirror/search/-/search-6.7.1.tgz",
+      "integrity": "sha512-uMe5UO6PamJtSHrXhhHOzSX3ReWtiJrva6GnPMwSOrZtiExb5X5eExhr2OUZQVvdxPsKpY3Ro2mFbQadpPWmHA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.37.0",
+        "crelt": "^1.0.5"
+      }
+    },
+    "node_modules/@codemirror/state": {
+      "version": "6.7.0",
+      "resolved": "https://registry.npmjs.org/@codemirror/state/-/state-6.7.0.tgz",
+      "integrity": "sha512-Zbl9NyscLMZkfXPQnNAIIAFftidrA1UbcJEIMp24C0Bukc2I5T8wJS0wsXYsnDOqCFJUeJ1BITGNs5CqPDSmSg==",
+      "license": "MIT",
+      "dependencies": {
+        "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/view": {
+      "version": "6.43.4",
+      "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.43.4.tgz",
+      "integrity": "sha512-YImu23iyKfncJzT7sRy+rEqEhSc8RhOHqDxwy4WzXRKJwYm6iwf/9OJk5ctCAdZ6yi2ZqaGEvmf55fSVqMDrgg==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/state": "^6.7.0",
+        "crelt": "^1.0.6",
+        "style-mod": "^4.1.0",
+        "w3c-keyname": "^2.2.4"
+      }
+    },
+    "node_modules/@emnapi/core": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/core/-/core-1.11.1.tgz",
+      "integrity": "sha512-RSvbQmHzdKzNsLYa/wHrbc3KN4sYLKAdPZxqiM2HATqv/SBk2/ENSHpvXGaLOMcsAyz0poEGqkmmKYG3OWiJEQ==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/wasi-threads": "1.2.2",
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/runtime": {
+      "version": "1.11.1",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.11.1.tgz",
+      "integrity": "sha512-vgj7R3y3Wgx24IQaGPA/R6YFXLHVMOZ0uVEyIQPaWs+rd1AzfEMXlAC22FYwO1XkKR6NPsq7mUandH8oIRdZFw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@emnapi/wasi-threads": {
+      "version": "1.2.2",
+      "resolved": "https://registry.npmjs.org/@emnapi/wasi-threads/-/wasi-threads-1.2.2.tgz",
+      "integrity": "sha512-c95qOXkHdydNKhscBTebqEC1CVAZpyqOfVfBzQ1qgzyl3gfeldUjIggDbIZgDKsHLgnsM+igH7TJ/eAasaVuMA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@fontsource-variable/noto-sans": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans/-/noto-sans-5.2.10.tgz",
+      "integrity": "sha512-wyFgKkFu7jki5kEL8qv7avjQ8rxHX0J/nhLWvbR9T0hOH1HRKZEvb9EW9lMjZfWHHfEzKkYf5J+NadwgCS7TXA==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@fontsource-variable/noto-sans-mono": {
+      "version": "5.2.10",
+      "resolved": "https://registry.npmjs.org/@fontsource-variable/noto-sans-mono/-/noto-sans-mono-5.2.10.tgz",
+      "integrity": "sha512-N8w7TRt24aD17P4eV9GDNiV4M5FSbeZ91dfWPtlTi5EvH15KAyjGiC7rvXnG3VTo/nb6gQuIXNlTDgH3cz652g==",
+      "license": "OFL-1.1",
+      "funding": {
+        "url": "https://github.com/sponsors/ayuhito"
+      }
+    },
+    "node_modules/@jridgewell/gen-mapping": {
+      "version": "0.3.13",
+      "resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.3.13.tgz",
+      "integrity": "sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.0",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/remapping": {
+      "version": "2.3.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/remapping/-/remapping-2.3.5.tgz",
+      "integrity": "sha512-LI9u/+laYG4Ds1TDKSJW2YPrIlcVYOwi2fUC6xB43lueCjgxV4lffOCZCtYFiH6TNOX+tQKXx97T4IKHbhyHEQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/gen-mapping": "^0.3.5",
+        "@jridgewell/trace-mapping": "^0.3.24"
+      }
+    },
+    "node_modules/@jridgewell/resolve-uri": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz",
+      "integrity": "sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/@jridgewell/sourcemap-codec": {
+      "version": "1.5.5",
+      "resolved": "https://registry.npmjs.org/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.5.tgz",
+      "integrity": "sha512-cYQ9310grqxueWbl+WuIUIaiUaDcj7WOq5fVhEljNVgRfOUhY9fy2zTvfoqWsnebh8Sl70VScFbICvJnLKB0Og==",
+      "license": "MIT"
+    },
+    "node_modules/@jridgewell/trace-mapping": {
+      "version": "0.3.31",
+      "resolved": "https://registry.npmjs.org/@jridgewell/trace-mapping/-/trace-mapping-0.3.31.tgz",
+      "integrity": "sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/resolve-uri": "^3.1.0",
+        "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@lezer/common": {
+      "version": "1.5.2",
+      "resolved": "https://registry.npmjs.org/@lezer/common/-/common-1.5.2.tgz",
+      "integrity": "sha512-sxQE460fPZyU3sdc8lafxiPwJHBzZRy/udNFynGQky1SePYBdhkBl1kOagA9uT3pxR8K09bOrmTUqA9wb/PjSQ==",
+      "license": "MIT"
+    },
+    "node_modules/@lezer/highlight": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@lezer/highlight/-/highlight-1.2.3.tgz",
+      "integrity": "sha512-qXdH7UqTvGfdVBINrgKhDsVTJTxactNNxLk7+UMwZhU13lMHaOBlJe9Vqp907ya56Y3+ed2tlqzys7jDkTmW0g==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.3.0"
+      }
+    },
+    "node_modules/@lezer/lr": {
+      "version": "1.4.10",
+      "resolved": "https://registry.npmjs.org/@lezer/lr/-/lr-1.4.10.tgz",
+      "integrity": "sha512-rnCpTIBafOx4mRp43xOxDJbFipJm/c0cia/V5TiGlhmMa+wsSdoGmUN3w5Bqrks/09Q/D4tNAmWaT8p6NRi77A==",
+      "license": "MIT",
+      "dependencies": {
+        "@lezer/common": "^1.0.0"
+      }
+    },
+    "node_modules/@marijn/find-cluster-break": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/@marijn/find-cluster-break/-/find-cluster-break-1.0.3.tgz",
+      "integrity": "sha512-FY+MKLBoTsLNJF/eLWaOsXGdz6uh3Iu1axjPf6TUq92IYumcTcXWHoS747JARLkcdlJ/Waiaxc5wQfFO8jC6NA==",
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/error-codes": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/error-codes/-/error-codes-0.22.0.tgz",
+      "integrity": "sha512-xF9SjnEy7vTdx+xekjPCV5cIHOGCkdn3pIxo9vU7gEZMIw0SvAEdsy6Uh17xaCpm8V0FWvR0SZoK9Ik6jGOaug==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime/-/runtime-0.22.0.tgz",
+      "integrity": "sha512-38g5iPju2tPC3KHMPxRKmy4k4onNp6ypFPS1eKGsNLUkXgHsPMBFqAjDw96iEcjri91BrahG4XcdyKi97xZzlA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/runtime-core": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-core": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-core/-/runtime-core-0.22.0.tgz",
+      "integrity": "sha512-GR1TcD6/s7zqItfhC87zAp30PqzvceoeDGYTgF3Vx2TXvsfDrhP6Qw9T4vudDQL3uJRne6t7CzdT29YyVxlgIA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/error-codes": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/runtime-tools": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/runtime-tools/-/runtime-tools-0.22.0.tgz",
+      "integrity": "sha512-4ScUJ/aUfEernb+4PbLdhM/c60VHl698Gn1gY21m9vyC1Ucn69fPCA1y2EwcCB7IItseRMoNhdcWQnzt/OPCNA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/webpack-bundler-runtime": "0.22.0"
+      }
+    },
+    "node_modules/@module-federation/sdk": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/sdk/-/sdk-0.22.0.tgz",
+      "integrity": "sha512-x4aFNBKn2KVQRuNVC5A7SnrSCSqyfIWmm1DvubjbO9iKFe7ith5niw8dqSFBekYBg2Fwy+eMg4sEFNVvCAdo6g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@module-federation/webpack-bundler-runtime": {
+      "version": "0.22.0",
+      "resolved": "https://registry.npmjs.org/@module-federation/webpack-bundler-runtime/-/webpack-bundler-runtime-0.22.0.tgz",
+      "integrity": "sha512-aM8gCqXu+/4wBmJtVeMeeMN5guw3chf+2i6HajKtQv7SJfxV/f4IyNQJUeUQu9HfiAZHjqtMV5Lvq/Lvh8LdyA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime": "0.22.0",
+        "@module-federation/sdk": "0.22.0"
+      }
+    },
+    "node_modules/@napi-rs/wasm-runtime": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/@napi-rs/wasm-runtime/-/wasm-runtime-1.0.7.tgz",
+      "integrity": "sha512-SeDnOO0Tk7Okiq6DbXmmBODgOAb9dp9gjlphokTUxmt8U3liIP1ZsozBahH69j/RJv+Rfs6IwUKHTgQYJ/HBAw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.5.0",
+        "@emnapi/runtime": "^1.5.0",
+        "@tybys/wasm-util": "^0.10.1"
+      }
+    },
+    "node_modules/@rsbuild/core": {
+      "version": "1.7.6",
+      "resolved": "https://registry.npmjs.org/@rsbuild/core/-/core-1.7.6.tgz",
+      "integrity": "sha512-T1mLz745L59SM4F5HQFkeGAAsDBeHh2e5sT0cSC5c7xkBpstVWXJrQe5HALS+GvIxiV8cUOy2yD8QBT/Ah11lg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rspack/core": "~1.7.10",
+        "@rspack/lite-tapable": "~1.1.0",
+        "@swc/helpers": "^0.5.20",
+        "core-js": "~3.47.0",
+        "jiti": "^2.6.1"
+      },
+      "bin": {
+        "rsbuild": "bin/rsbuild.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      }
+    },
+    "node_modules/@rsbuild/plugin-vue": {
+      "version": "1.2.9",
+      "resolved": "https://registry.npmjs.org/@rsbuild/plugin-vue/-/plugin-vue-1.2.9.tgz",
+      "integrity": "sha512-ufD4eufkZZlNK3iY5NWg57AMK9qrTFmHycDkSTfRTua4Qczf7q9s7rCLYVfVv2w36cOXJIewM+376jD0zaQShQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "rspack-vue-loader": "^17.5.0"
+      },
+      "peerDependencies": {
+        "@rsbuild/core": "^1.0.0 || ^2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@rsbuild/core": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rspack/binding": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding/-/binding-1.7.12.tgz",
+      "integrity": "sha512-f4HHuLbvuld8Ba4iB/4ibse5XrKxFrgmM3S4P2AOKnPlekAFlBjmltCuaTL/W2ggYvILaVY+YcFXrEH1rrKeQA==",
+      "dev": true,
+      "license": "MIT",
+      "optionalDependencies": {
+        "@rspack/binding-darwin-arm64": "1.7.12",
+        "@rspack/binding-darwin-x64": "1.7.12",
+        "@rspack/binding-linux-arm64-gnu": "1.7.12",
+        "@rspack/binding-linux-arm64-musl": "1.7.12",
+        "@rspack/binding-linux-x64-gnu": "1.7.12",
+        "@rspack/binding-linux-x64-musl": "1.7.12",
+        "@rspack/binding-wasm32-wasi": "1.7.12",
+        "@rspack/binding-win32-arm64-msvc": "1.7.12",
+        "@rspack/binding-win32-ia32-msvc": "1.7.12",
+        "@rspack/binding-win32-x64-msvc": "1.7.12"
+      }
+    },
+    "node_modules/@rspack/binding-darwin-arm64": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-arm64/-/binding-darwin-arm64-1.7.12.tgz",
+      "integrity": "sha512-rbFprJaJiqrmfy8SHth8EsoRS0wg4bXcucwj9NiMzpGFq14Opw8c04iQ6H9BECYzgmN0PKZ9rh41LdVvhdZe4A==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-darwin-x64": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-darwin-x64/-/binding-darwin-x64-1.7.12.tgz",
+      "integrity": "sha512-jnOp+/UXOJa9xqUb8KXH03sysoO2e4Ij6tw6MqDdmdj8n/A8PQENRPUbW9AwXpPtVDJPus9r4fi7b3+6e4B8Hg==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-gnu": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-gnu/-/binding-linux-arm64-gnu-1.7.12.tgz",
+      "integrity": "sha512-C8owWG+yvo7X0oVLIXetkoJhIFBP1LYNcAQqtgLmJnQLQDklGuP83dKC+zISGQWpjawHfZ1ER96vLgoTrxKZdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-arm64-musl": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-arm64-musl/-/binding-linux-arm64-musl-1.7.12.tgz",
+      "integrity": "sha512-i51WWI64aRpsfSki6rN0aepPqXkVfS+vZM7+4bWDcmnhUmdMvhIPcYg0QRk3DtyJnu33jqNLM0WHY78k00NyfA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-gnu": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-gnu/-/binding-linux-x64-gnu-1.7.12.tgz",
+      "integrity": "sha512-MSos0FuPEefqo9V92ULd5hggKG29EkSNg1zDcypy0OkpsKh5pfjVxTLYFXgTcVyFoUQQbdG8zFBzYbwmJ8V4ew==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-linux-x64-musl": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-linux-x64-musl/-/binding-linux-x64-musl-1.7.12.tgz",
+      "integrity": "sha512-JcAMVKXOnjfpC3coWjCFPWD3Yl8RBw6a+IXQQ8mfRlHaHMIiOv8IfZqx15XRxMUn49CtP7Z0Na8iiAg2aKrcfw==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@rspack/binding-wasm32-wasi": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-wasm32-wasi/-/binding-wasm32-wasi-1.7.12.tgz",
+      "integrity": "sha512-n+ZqP6ZMc0nhOgvadg5VhEs9ojtbES80AcWeFnmGkbzIszvGSO63GKNiRkXtjJ9KFuRzytbbmsCqkUVH+Tywxg==",
+      "cpu": [
+        "wasm32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@napi-rs/wasm-runtime": "1.0.7"
+      }
+    },
+    "node_modules/@rspack/binding-win32-arm64-msvc": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-arm64-msvc/-/binding-win32-arm64-msvc-1.7.12.tgz",
+      "integrity": "sha512-8+h5fYDXYdmugbdfZ+D1y8IQ3rv2EhSfyGP7vBe+bjNyaMa4jWrpucmZbtxojUL1AzaeuHbvMdj9UO/gelk/+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-ia32-msvc": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-ia32-msvc/-/binding-win32-ia32-msvc-1.7.12.tgz",
+      "integrity": "sha512-cDMGwTRSa2p9fNBVe1wTRkF2AEXZ9ARWW36QeC5CkLaI0Ezz8lvhF2+CSOPnhaQ1O1qtn0L0SF+lFnrY+I7xGQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/binding-win32-x64-msvc": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/binding-win32-x64-msvc/-/binding-win32-x64-msvc-1.7.12.tgz",
+      "integrity": "sha512-wIqFvlgFqrgUyj/6S/FJcvShnkZOmIeXTfqvheLY67MGq8qd8jb1YimQVKAIrmWB3yuJKUFACI3Ag1UBtEedEA==",
+      "cpu": [
+        "x64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@rspack/core": {
+      "version": "1.7.12",
+      "resolved": "https://registry.npmjs.org/@rspack/core/-/core-1.7.12.tgz",
+      "integrity": "sha512-6CwFIHlhRmXfZoMj3v9MZ1SMTPBn+cHVXeMIeaGp5sufqinKsISbsqHu6ZMJu2wDSmZLdmQJX6zLxkhcAUlhkQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@module-federation/runtime-tools": "0.22.0",
+        "@rspack/binding": "1.7.12",
+        "@rspack/lite-tapable": "1.1.0"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "@swc/helpers": ">=0.5.1"
+      },
+      "peerDependenciesMeta": {
+        "@swc/helpers": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@rspack/core/node_modules/@rspack/lite-tapable": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.0.tgz",
+      "integrity": "sha512-E2B0JhYFmVAwdDiG14+DW0Di4Ze4Jg10Pc4/lILUrd5DRCaklduz2OvJ5HYQ6G+hd+WTzqQb3QnDNfK4yvAFYw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@rspack/lite-tapable": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/@rspack/lite-tapable/-/lite-tapable-1.1.2.tgz",
+      "integrity": "sha512-1OnyWChLGE46YzWyjlmYJssOu/Y0STAnnr2ueKPqDCYTf63GJMs0mxNnCul4dNiVqHYPKv3/fxrTY3IpqoVwZQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@swc/helpers": {
+      "version": "0.5.23",
+      "resolved": "https://registry.npmjs.org/@swc/helpers/-/helpers-0.5.23.tgz",
+      "integrity": "sha512-5lSsMOTXURePglDfvuAQUqkGek9Hg2kksOYay2m0+XR++b2NWYL/4sWyuvVBIs8oKnJaxkdi9whaL/sqN13afw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "tslib": "^2.8.0"
+      }
+    },
+    "node_modules/@tailwindcss/node": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/node/-/node-4.3.2.tgz",
+      "integrity": "sha512-yWP/sqEcBLaD8JuA6zNwxoYKr75qxTioYwlRwekj5Jr/I5GXnoJfjetH/psLUIv74cYTH2lBUEzBkinthoYcBg==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/remapping": "^2.3.5",
+        "enhanced-resolve": "5.21.6",
+        "jiti": "^2.7.0",
+        "lightningcss": "1.32.0",
+        "magic-string": "^0.30.21",
+        "source-map-js": "^1.2.1",
+        "tailwindcss": "4.3.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide/-/oxide-4.3.2.tgz",
+      "integrity": "sha512-z8ZgnzX8gdNoWLBLqBPoh/sjnxkwvf9ZuWjnO0l0yIzbLa5/9S+eC5QxGZKRobVHIC3/1BoMWjHblqWjcgFgag==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 20"
+      },
+      "optionalDependencies": {
+        "@tailwindcss/oxide-android-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-arm64": "4.3.2",
+        "@tailwindcss/oxide-darwin-x64": "4.3.2",
+        "@tailwindcss/oxide-freebsd-x64": "4.3.2",
+        "@tailwindcss/oxide-linux-arm-gnueabihf": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-arm64-musl": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-gnu": "4.3.2",
+        "@tailwindcss/oxide-linux-x64-musl": "4.3.2",
+        "@tailwindcss/oxide-wasm32-wasi": "4.3.2",
+        "@tailwindcss/oxide-win32-arm64-msvc": "4.3.2",
+        "@tailwindcss/oxide-win32-x64-msvc": "4.3.2"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-android-arm64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-android-arm64/-/oxide-android-arm64-4.3.2.tgz",
+      "integrity": "sha512-WHxqIuHpvZ5VtdX6GTl1Ik/Vp2YuN42Et+0CdeaVd/frQ9jAvGmvR8vLT+jk3e8/Q3x8kECB9+R17pgpp2BulA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-arm64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-arm64/-/oxide-darwin-arm64-4.3.2.tgz",
+      "integrity": "sha512-GZypeUY/IDJW3877KeM+O67vbXr3MBnbtEL4aYhNErv/JWZhye2vGSWWG9tB6iiqR2MqRNkY8IOUy4NdSZV26w==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-darwin-x64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-darwin-x64/-/oxide-darwin-x64-4.3.2.tgz",
+      "integrity": "sha512-UIIzmefR6KO1sDU7MzRqAxC8iBpft/VhkGjTjnhoS6k7Z3rQ9wEgA1ODSiyH/tcSYssulNm4Ci3hOeK1jH7ccQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-freebsd-x64": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-freebsd-x64/-/oxide-freebsd-x64-4.3.2.tgz",
+      "integrity": "sha512-GN+uAmcI6DNspnCDwtOAZrTz6oukJnp337qZvxqCGLd3BHBzJpO0ZbTLRvJNdztOeAmTzewewGIMPb0tk2R4WA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm-gnueabihf": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm-gnueabihf/-/oxide-linux-arm-gnueabihf-4.3.2.tgz",
+      "integrity": "sha512-4ABn7qSbdHRwTiDiuWNegCyb5+2FJ4vKIKc3DmKrvAFw7MU1Lm11dIkTPwUaFdTzc7IsOpDbqBrlh0x6y36U/w==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-gnu": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-gnu/-/oxide-linux-arm64-gnu-4.3.2.tgz",
+      "integrity": "sha512-wDgEIGwoM8w8pufh9LVt1PahDgNdKXrLC2qfAnV3vAmococ9RWbxeAw4pxPttd/TsJfwjyLf90Dg1y9y8I6Emw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-arm64-musl": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-arm64-musl/-/oxide-linux-arm64-musl-4.3.2.tgz",
+      "integrity": "sha512-J5Nuk0uZQIiMTJj3LEx4sAA9tMFUoXQZFv1J6An+QGYe53HKRJuFDi0rpq/tuouCZeAbOBY3kQ6g8qeD4TUjtA==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-gnu": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-gnu/-/oxide-linux-x64-gnu-4.3.2.tgz",
+      "integrity": "sha512-kqCZpSKOBEJO4mz7OqWoofBZeXTAwaVGPj0ErAj7CojmhKpWVWVOnrt9dE8odoIraZq4oj3ausM37kXi+Tow8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-linux-x64-musl": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-linux-x64-musl/-/oxide-linux-x64-musl-4.3.2.tgz",
+      "integrity": "sha512-cixpqbh2toJDmkuCRI68nXA8ZxNmdK9Y+9v5h3MC3ZQKy/0BO8AWzlkWyRM7JAFSGBlfig4YVTPsK6MVgqz1uw==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-wasm32-wasi": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-wasm32-wasi/-/oxide-wasm32-wasi-4.3.2.tgz",
+      "integrity": "sha512-4ec2Z/LOmRsAgU23CS4xeJfcJlmRg94A/XrbGRCF1gyU/zdDfRLYDVsS+ynSZCmGNxQ1jQriQOKMQeQxBA3Isw==",
+      "bundleDependencies": [
+        "@napi-rs/wasm-runtime",
+        "@emnapi/core",
+        "@emnapi/runtime",
+        "@tybys/wasm-util",
+        "@emnapi/wasi-threads",
+        "tslib"
+      ],
+      "cpu": [
+        "wasm32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@emnapi/core": "^1.11.1",
+        "@emnapi/runtime": "^1.11.1",
+        "@emnapi/wasi-threads": "^1.2.2",
+        "@napi-rs/wasm-runtime": "^1.1.4",
+        "@tybys/wasm-util": "^0.10.2",
+        "tslib": "^2.8.1"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-arm64-msvc": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-arm64-msvc/-/oxide-win32-arm64-msvc-4.3.2.tgz",
+      "integrity": "sha512-Zyr/M0+XcYZu3bZrUytc7TXvrk0ftWfl8gN2MwekNDzhqhKRUucMPSeOzM0o0wH5AWOU49BsKRrfKxI2atCPMQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/oxide-win32-x64-msvc": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/oxide-win32-x64-msvc/-/oxide-win32-x64-msvc-4.3.2.tgz",
+      "integrity": "sha512-QI9BO7KlNZsp2GuO0jwAAj5jCDABOKXRkCk2XuKTSaNEFSdfzqswYVTtCHBNKHLsqyjFyFkqlDiwkNbTYSssMQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 20"
+      }
+    },
+    "node_modules/@tailwindcss/postcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/@tailwindcss/postcss/-/postcss-4.3.2.tgz",
+      "integrity": "sha512-rjVWYCa7Ngbi5AarT6k8TkxUG3Wl1QKzHdIZVsjZSzf36Jmo2IKZt/NHRAwly8oDkbBOH0YTu+CHuf9jPxMc+g==",
+      "license": "MIT",
+      "dependencies": {
+        "@alloc/quick-lru": "^5.2.0",
+        "@tailwindcss/node": "4.3.2",
+        "@tailwindcss/oxide": "4.3.2",
+        "postcss": "^8.5.15",
+        "tailwindcss": "4.3.2"
+      }
+    },
+    "node_modules/@tybys/wasm-util": {
+      "version": "0.10.3",
+      "resolved": "https://registry.npmjs.org/@tybys/wasm-util/-/wasm-util-0.10.3.tgz",
+      "integrity": "sha512-F3fo1MYrRJYL3zER0OUOmkutjr1Vp23m7OsSgp7nq4SP6OqX6C/56XFIPAl5bt3zaBRjmW7SGz3u/6LwFpYcOg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "tslib": "^2.4.0"
+      }
+    },
+    "node_modules/@volar/language-core": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/language-core/-/language-core-2.4.15.tgz",
+      "integrity": "sha512-3VHw+QZU0ZG9IuQmzT68IyN4hZNd9GchGPhbD9+pa8CVv7rnoOZwo7T8weIbrRmihqy3ATpdfXFnqRrfPVK6CA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/source-map": "2.4.15"
+      }
+    },
+    "node_modules/@volar/source-map": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/source-map/-/source-map-2.4.15.tgz",
+      "integrity": "sha512-CPbMWlUN6hVZJYGcU/GSoHu4EnCHiLaXI9n8c9la6RaI9W5JHX+NqG+GSQcB0JdC2FIBLdZJwGsfKyBB71VlTg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@volar/typescript": {
+      "version": "2.4.15",
+      "resolved": "https://registry.npmjs.org/@volar/typescript/-/typescript-2.4.15.tgz",
+      "integrity": "sha512-2aZ8i0cqPGjXb4BhkMsPYDkkuc2ZQ6yOpqwAuNwUoncELqoy5fRgOQtLR9gB0g902iS0NAkvpIzs27geVyVdPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.15",
+        "path-browserify": "^1.0.1",
+        "vscode-uri": "^3.0.8"
+      }
+    },
+    "node_modules/@vue/compiler-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-core/-/compiler-core-3.5.39.tgz",
+      "integrity": "sha512-16KBTEXAJCpDr0mwlw+AZyhu8iyC7R3S2vBwsI7QnWJU6X3WKc9VKeNEZpiMdZ569qWhz9574L3vV55qRL0Vtw==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/shared": "3.5.39",
+        "entities": "^7.0.1",
+        "estree-walker": "^2.0.2",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-dom/-/compiler-dom-3.5.39.tgz",
+      "integrity": "sha512-oQPigALqYbNxTNPvNgSOe+czwVExfbVF02lz8jP0S3AXJiu3jxYDygNUiqSep4ezzW8XgnubqH63My2A7JR/vg==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-core": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/compiler-sfc": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-sfc/-/compiler-sfc-3.5.39.tgz",
+      "integrity": "sha512-d0ki86iOyN8LoZPBmk5SJWNwHP19CnDDCfuo//+2WJa2g5Ke0Jay983PIBIcSSzldC68I8DrD5GrHV3OSDfodg==",
+      "license": "MIT",
+      "dependencies": {
+        "@babel/parser": "^7.29.7",
+        "@vue/compiler-core": "3.5.39",
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "estree-walker": "^2.0.2",
+        "magic-string": "^0.30.21",
+        "postcss": "^8.5.15",
+        "source-map-js": "^1.2.1"
+      }
+    },
+    "node_modules/@vue/compiler-ssr": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-ssr/-/compiler-ssr-3.5.39.tgz",
+      "integrity": "sha512-Ce7/wvwMHai74bdszfXExdazFigYnlF9zgCmEQUcM1j0fOymlouZ7XilTYNo8oUjhlnjYOZbGrcYKuqjz89Ucw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/compiler-vue2": {
+      "version": "2.7.16",
+      "resolved": "https://registry.npmjs.org/@vue/compiler-vue2/-/compiler-vue2-2.7.16.tgz",
+      "integrity": "sha512-qYC3Psj9S/mfu9uVi5WvNZIzq+xnXMhOwbTFKKDD7b1lhpnn71jXSFdTQ+WsIEk0ONCd7VV2IMm7ONl6tbQ86A==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "de-indent": "^1.0.2",
+        "he": "^1.2.0"
+      }
+    },
+    "node_modules/@vue/language-core": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/@vue/language-core/-/language-core-2.2.12.tgz",
+      "integrity": "sha512-IsGljWbKGU1MZpBPN+BvPAdr55YPkj2nB/TBNGNC32Vy2qLG25DYu/NBN2vNtZqdRbTRjaoYrahLrToim2NanA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/language-core": "2.4.15",
+        "@vue/compiler-dom": "^3.5.0",
+        "@vue/compiler-vue2": "^2.7.16",
+        "@vue/shared": "^3.5.0",
+        "alien-signals": "^1.0.3",
+        "minimatch": "^9.0.3",
+        "muggle-string": "^0.4.1",
+        "path-browserify": "^1.0.1"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vue/reactivity": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/reactivity/-/reactivity-3.5.39.tgz",
+      "integrity": "sha512-TpsuBJ9gGlZa5d23XcM2y8EXanz9dZeVDQBXRwzy46ItgvM+rWpzs+UVM0wcRLxGvcav0HE5jz2gNL53xlRAog==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-core": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-core/-/runtime-core-3.5.39.tgz",
+      "integrity": "sha512-9GLtNyRvPAUMbX+7ono0RC2j0guo2LXVi8LvcmAooImACUKm0oFf0jjwbX8/H0AE/t1nxhAkn8RSl9PMCzzxZw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/shared": "3.5.39"
+      }
+    },
+    "node_modules/@vue/runtime-dom": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/runtime-dom/-/runtime-dom-3.5.39.tgz",
+      "integrity": "sha512-7Y6aAGboKcXAZ3ECuUy7RrS5yy2r47dhTp2SKaJmYxjopImaVFaNa5Ne66NwGovsrxVAl5S5rwc7m22UG7Lmww==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/reactivity": "3.5.39",
+        "@vue/runtime-core": "3.5.39",
+        "@vue/shared": "3.5.39",
+        "csstype": "^3.2.3"
+      }
+    },
+    "node_modules/@vue/server-renderer": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/server-renderer/-/server-renderer-3.5.39.tgz",
+      "integrity": "sha512-yZSakiAGw85rZfG7UM8akMnIF+FmeiNk47uvHf2nVBBSe+dIKUhZuZq9+XgJhbV3nS5Z4ALH23/MpXofW+mbcw==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-ssr": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "vue": "3.5.39"
+      }
+    },
+    "node_modules/@vue/shared": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/@vue/shared/-/shared-3.5.39.tgz",
+      "integrity": "sha512-l1rrBtBfTnmxvtsvdQDXltUUy8S1Y+ZaqdfUzmAnJkTd8Z8rv5v/ytW+TKiqEOWyHPoqtPlNFSs0lhRmYVSHVA==",
+      "license": "MIT"
+    },
+    "node_modules/alien-signals": {
+      "version": "1.0.13",
+      "resolved": "https://registry.npmjs.org/alien-signals/-/alien-signals-1.0.13.tgz",
+      "integrity": "sha512-OGj9yyTnJEttvzhTUWuscOvtqxq5vrhF7vL9oS0xJ2mK0ItPYP1/y+vCFebfxoEyAz0++1AIwJ5CMr+Fk3nDmg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/autoprefixer": {
+      "version": "10.5.2",
+      "resolved": "https://registry.npmjs.org/autoprefixer/-/autoprefixer-10.5.2.tgz",
+      "integrity": "sha512-rD5t5DwOjJdmSORcTq64j8MawTC+tbQ+HHqjR4NDumamy/ambn1UJrlKL+KdwujWxMkFjPM3pPHOEA9tl4767Q==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/autoprefixer"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "browserslist": "^4.28.4",
+        "caniuse-lite": "^1.0.30001799",
+        "fraction.js": "^5.3.4",
+        "picocolors": "^1.1.1",
+        "postcss-value-parser": "^4.2.0"
+      },
+      "bin": {
+        "autoprefixer": "bin/autoprefixer"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      },
+      "peerDependencies": {
+        "postcss": "^8.1.0"
+      }
+    },
+    "node_modules/balanced-match": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
+      "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/baseline-browser-mapping": {
+      "version": "2.10.40",
+      "resolved": "https://registry.npmjs.org/baseline-browser-mapping/-/baseline-browser-mapping-2.10.40.tgz",
+      "integrity": "sha512-BSSLZ9/Cjjv7Gtj5B68ZzXcXUg8iOf3fme+FCuh8rC/Go+Kmh8cox7M3A8dolou16s64QjLPOSdngh7GxXvkSw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "baseline-browser-mapping": "dist/cli.cjs"
+      },
+      "engines": {
+        "node": ">=6.0.0"
+      }
+    },
+    "node_modules/brace-expansion": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-2.1.1.tgz",
+      "integrity": "sha512-WR1cURNjuvBLMZBMbqM0UoE+WAfdUcEV1ccD8PVBVOI+Z3ND4+SZbN8RsfT2bMuG1qwz5RFvPukSZm5fF2D5eA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "balanced-match": "^1.0.0"
+      }
+    },
+    "node_modules/browserslist": {
+      "version": "4.28.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.28.4.tgz",
+      "integrity": "sha512-MTc8i/x9jBQd1iMw2CFGS+rwMa07eYjLR0CCTLDACl9xhxy+nIs3KeML/biicXtk9JrZ6dnnTatmc7ErPXIxqw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "baseline-browser-mapping": "^2.10.38",
+        "caniuse-lite": "^1.0.30001799",
+        "electron-to-chromium": "^1.5.376",
+        "node-releases": "^2.0.48",
+        "update-browserslist-db": "^1.2.3"
+      },
+      "bin": {
+        "browserslist": "cli.js"
+      },
+      "engines": {
+        "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
+      }
+    },
+    "node_modules/caniuse-lite": {
+      "version": "1.0.30001800",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001800.tgz",
+      "integrity": "sha512-MMHtuAz9Ys840zAY5F4k6fV5GaivZ9sPk+nz0mY+GYVzRBnYkN0mpqkSR92oWRQ19yQWo4HvBV/FnC16AJX8MA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/caniuse-lite"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "CC-BY-4.0"
+    },
+    "node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/codemirror": {
+      "version": "6.0.2",
+      "resolved": "https://registry.npmjs.org/codemirror/-/codemirror-6.0.2.tgz",
+      "integrity": "sha512-VhydHotNW5w1UGK0Qj96BwSk/Zqbp9WbnyK2W/eVMv4QyF41INRGpjUhFJY7/uDNuudSc33a/PKr4iDqRduvHw==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/autocomplete": "^6.0.0",
+        "@codemirror/commands": "^6.0.0",
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/lint": "^6.0.0",
+        "@codemirror/search": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0"
+      }
+    },
+    "node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/core-js": {
+      "version": "3.47.0",
+      "resolved": "https://registry.npmjs.org/core-js/-/core-js-3.47.0.tgz",
+      "integrity": "sha512-c3Q2VVkGAUyupsjRnaNX6u8Dq2vAdzm9iuPj5FW0fRxzlxgq9Q39MDq10IvmQSpLgHQNyQzQmOo6bgGHmH3NNg==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/core-js"
+      }
+    },
+    "node_modules/crelt": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/crelt/-/crelt-1.0.7.tgz",
+      "integrity": "sha512-aK6BbWfhf4U/wCcLHKPJl/xa6VkVstRaPywWtMKGwuOLc/wZTyQYuoxgvZnNsBvv7Kg3YTBQYYBCggcviQczuA==",
+      "license": "MIT"
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "license": "MIT"
+    },
+    "node_modules/de-indent": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/de-indent/-/de-indent-1.0.2.tgz",
+      "integrity": "sha512-e/1zu3xH5MQryN2zdVaF0OrdNLUbvWxzMbi+iNA6Bky7l1RoP8a2fIbRocyHclXt/arDrrR6lL3TqFD9pMQTsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/detect-libc": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
+      "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/electron-to-chromium": {
+      "version": "1.5.383",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.383.tgz",
+      "integrity": "sha512-I2484/KkAvl8lm9VyjH2JnbOIV0d/UCqT7gbzs6l+o6Vmn9wgB66uVcKX+Vk6HrXtY6fbWTOEXuv8waDTuFNCw==",
+      "dev": true,
+      "license": "ISC"
+    },
+    "node_modules/enhanced-resolve": {
+      "version": "5.21.6",
+      "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-5.21.6.tgz",
+      "integrity": "sha512-aNnGCvbJ/RIyWo1IuhNdVjnNF+EjH9wpzpNHt+ci/m9He9LJvUN8wrCcXjp9cWsGNAuvSpVFTx/vraAFQ8qGjQ==",
+      "license": "MIT",
+      "dependencies": {
+        "graceful-fs": "^4.2.4",
+        "tapable": "^2.3.3"
+      },
+      "engines": {
+        "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "7.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-7.0.1.tgz",
+      "integrity": "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
+    "node_modules/escalade": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
+    "node_modules/estree-walker": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-2.0.2.tgz",
+      "integrity": "sha512-Rfkk/Mp/DL7JVje3u18FxFujQlTNR2q6QfMSMB7AvCBx91NGj/ba3kCfza0f6dVDbw7YlRf/nDrn7pQrCCyQ/w==",
+      "license": "MIT"
+    },
+    "node_modules/fraction.js": {
+      "version": "5.3.4",
+      "resolved": "https://registry.npmjs.org/fraction.js/-/fraction.js-5.3.4.tgz",
+      "integrity": "sha512-1X1NTtiJphryn/uLQz3whtY6jK3fTqoE3ohKs0tT+Ujr1W59oopxmoEh7Lu5p6vBaPbgoM0bzveAW4Qi5RyWDQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "*"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/rawify"
+      }
+    },
+    "node_modules/graceful-fs": {
+      "version": "4.2.11",
+      "resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.11.tgz",
+      "integrity": "sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==",
+      "license": "ISC"
+    },
+    "node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/he": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/he/-/he-1.2.0.tgz",
+      "integrity": "sha512-F/1DnUGPopORZi0ni+CvrCgHQ5FyEAHRLSApuYWMmrbSwoN2Mn/7k+Gl38gJnR7yyDZk6WLXwiGod1JOWNDKGw==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "he": "bin/he"
+      }
+    },
+    "node_modules/jiti": {
+      "version": "2.7.0",
+      "resolved": "https://registry.npmjs.org/jiti/-/jiti-2.7.0.tgz",
+      "integrity": "sha512-AC/7JofJvZGrrneWNaEnJeOLUx+JlGt7tNa0wZiRPT4MY1wmfKjt2+6O2p2uz2+skll8OZZmJMNqeke7kKbNgQ==",
+      "license": "MIT",
+      "bin": {
+        "jiti": "lib/jiti-cli.mjs"
+      }
+    },
+    "node_modules/lightningcss": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss/-/lightningcss-1.32.0.tgz",
+      "integrity": "sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==",
+      "license": "MPL-2.0",
+      "dependencies": {
+        "detect-libc": "^2.0.3"
+      },
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      },
+      "optionalDependencies": {
+        "lightningcss-android-arm64": "1.32.0",
+        "lightningcss-darwin-arm64": "1.32.0",
+        "lightningcss-darwin-x64": "1.32.0",
+        "lightningcss-freebsd-x64": "1.32.0",
+        "lightningcss-linux-arm-gnueabihf": "1.32.0",
+        "lightningcss-linux-arm64-gnu": "1.32.0",
+        "lightningcss-linux-arm64-musl": "1.32.0",
+        "lightningcss-linux-x64-gnu": "1.32.0",
+        "lightningcss-linux-x64-musl": "1.32.0",
+        "lightningcss-win32-arm64-msvc": "1.32.0",
+        "lightningcss-win32-x64-msvc": "1.32.0"
+      }
+    },
+    "node_modules/lightningcss-android-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-android-arm64/-/lightningcss-android-arm64-1.32.0.tgz",
+      "integrity": "sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "android"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-arm64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-arm64/-/lightningcss-darwin-arm64-1.32.0.tgz",
+      "integrity": "sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-darwin-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-darwin-x64/-/lightningcss-darwin-x64-1.32.0.tgz",
+      "integrity": "sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-freebsd-x64": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-freebsd-x64/-/lightningcss-freebsd-x64-1.32.0.tgz",
+      "integrity": "sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "freebsd"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm-gnueabihf": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm-gnueabihf/-/lightningcss-linux-arm-gnueabihf-1.32.0.tgz",
+      "integrity": "sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-gnu/-/lightningcss-linux-arm64-gnu-1.32.0.tgz",
+      "integrity": "sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-arm64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-arm64-musl/-/lightningcss-linux-arm64-musl-1.32.0.tgz",
+      "integrity": "sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-gnu": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-gnu/-/lightningcss-linux-x64-gnu-1.32.0.tgz",
+      "integrity": "sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-linux-x64-musl": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-linux-x64-musl/-/lightningcss-linux-x64-musl-1.32.0.tgz",
+      "integrity": "sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-arm64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-arm64-msvc/-/lightningcss-win32-arm64-msvc-1.32.0.tgz",
+      "integrity": "sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/lightningcss-win32-x64-msvc": {
+      "version": "1.32.0",
+      "resolved": "https://registry.npmjs.org/lightningcss-win32-x64-msvc/-/lightningcss-win32-x64-msvc-1.32.0.tgz",
+      "integrity": "sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MPL-2.0",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
+      "engines": {
+        "node": ">= 12.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/parcel"
+      }
+    },
+    "node_modules/magic-string": {
+      "version": "0.30.21",
+      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.30.21.tgz",
+      "integrity": "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@jridgewell/sourcemap-codec": "^1.5.5"
+      }
+    },
+    "node_modules/minimatch": {
+      "version": "9.0.9",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-9.0.9.tgz",
+      "integrity": "sha512-OBwBN9AL4dqmETlpS2zasx+vTeWclWzkblfZk7KTA5j3jeOONz/tRCnZomUyvNg83wL5Zv9Ss6HMJXAgL8R2Yg==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^2.0.2"
+      },
+      "engines": {
+        "node": ">=16 || 14 >=14.17"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/isaacs"
+      }
+    },
+    "node_modules/muggle-string": {
+      "version": "0.4.1",
+      "resolved": "https://registry.npmjs.org/muggle-string/-/muggle-string-0.4.1.tgz",
+      "integrity": "sha512-VNTrAak/KhO2i8dqqnqnAHOa3cYBwXEZe9h+D5h/1ZqFSTEFHdM65lR7RoIqq3tBBYavsOXV84NoHXZ0AkPyqQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nanoid": {
+      "version": "3.3.15",
+      "resolved": "https://registry.npmjs.org/nanoid/-/nanoid-3.3.15.tgz",
+      "integrity": "sha512-y7Wygv/7mEOvxTuEQDB8StXdMRBWf1kR/tlhAzBRUFkB2jfcLOAxO/SHmOO2zgz1pVgK29/kyupn059/bCHdjA==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "bin": {
+        "nanoid": "bin/nanoid.cjs"
+      },
+      "engines": {
+        "node": "^10 || ^12 || ^13.7 || ^14 || >=15.0.1"
+      }
+    },
+    "node_modules/node-releases": {
+      "version": "2.0.50",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.50.tgz",
+      "integrity": "sha512-J6l92tKHX6w8Jy5nO1Vuc01NoIiRGi/d6qBKVxh+IQ8Cr3b6HbVNfKiF8ZpFKufTwpwxMmce2W3iQZ861ZRyTg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/path-browserify": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-browserify/-/path-browserify-1.0.1.tgz",
+      "integrity": "sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/picocolors": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
+    },
+    "node_modules/postcss": {
+      "version": "8.5.16",
+      "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.5.16.tgz",
+      "integrity": "sha512-vuwillviilfKZsg0VGj5R/YwwcHx4SLsIOI/7K6mQkWx+l5cUHTjj5g0AasTBcyXsbfTgrwsUNmVUb5xVwyPwg==",
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/postcss/"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/postcss"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "nanoid": "^3.3.12",
+        "picocolors": "^1.1.1",
+        "source-map-js": "^1.2.1"
+      },
+      "engines": {
+        "node": "^10 || ^12 || >=14"
+      }
+    },
+    "node_modules/postcss-value-parser": {
+      "version": "4.2.0",
+      "resolved": "https://registry.npmjs.org/postcss-value-parser/-/postcss-value-parser-4.2.0.tgz",
+      "integrity": "sha512-1NNCs6uurfkVbeXG4S8JFT9t19m45ICnif8zWLd5oPSZ50QnwMfK+H3jv408d4jw/7Bttv5axS5IiHoLaVNHeQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/rspack-vue-loader": {
+      "version": "17.5.1",
+      "resolved": "https://registry.npmjs.org/rspack-vue-loader/-/rspack-vue-loader-17.5.1.tgz",
+      "integrity": "sha512-1pXdeqYM95P0T8DO2ZcOCBnfMp62W5IG2c0RICn1rFYjHcja41IYSQLzcdc1uePEq0n4JZwvfR2lVs8wRZuwzA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@rspack/lite-tapable": "^1.1.0",
+        "chalk": "^4.1.0"
+      },
+      "peerDependencies": {
+        "@rspack/core": "^1.0.0 || ^2.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "@rspack/core": {
+          "optional": true
+        },
+        "@vue/compiler-sfc": {
+          "optional": true
+        },
+        "vue": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/source-map-js": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
+      "integrity": "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==",
+      "license": "BSD-3-Clause",
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
+    "node_modules/style-mod": {
+      "version": "4.1.3",
+      "resolved": "https://registry.npmjs.org/style-mod/-/style-mod-4.1.3.tgz",
+      "integrity": "sha512-i/n8VsZydrugj3Iuzll8+x/00GH2vnYsk1eomD8QiRrSAeW6ItbCQDtfXCeJHd0iwiNagqjQkvpvREEPtW3IoQ==",
+      "license": "MIT"
+    },
+    "node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/tailwindcss": {
+      "version": "4.3.2",
+      "resolved": "https://registry.npmjs.org/tailwindcss/-/tailwindcss-4.3.2.tgz",
+      "integrity": "sha512-WtctNNSH8A9jlMIqxzuYumOHU5uGZyRv0Q5svQl+oEPy5w84YpBxdb7MdqyiSPQge5jTJ6zFQLq0PFygdccSBA==",
+      "license": "MIT"
+    },
+    "node_modules/tapable": {
+      "version": "2.3.3",
+      "resolved": "https://registry.npmjs.org/tapable/-/tapable-2.3.3.tgz",
+      "integrity": "sha512-uxc/zpqFg6x7C8vOE7lh6Lbda8eEL9zmVm/PLeTPBRhh1xCgdWaQ+J1CUieGpIfm2HdtsUpRv+HshiasBMcc6A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      }
+    },
+    "node_modules/tslib": {
+      "version": "2.8.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
+      "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
+      "devOptional": true,
+      "license": "0BSD"
+    },
+    "node_modules/typescript": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.3.tgz",
+      "integrity": "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw==",
+      "devOptional": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=14.17"
+      }
+    },
+    "node_modules/update-browserslist-db": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.2.3.tgz",
+      "integrity": "sha512-Js0m9cx+qOgDxo0eMiFGEueWztz+d4+M3rGlmKPT+T4IS/jP4ylw3Nwpu6cpTTP8R1MAC1kF4VbdLt3ARf209w==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/browserslist"
+        },
+        {
+          "type": "tidelift",
+          "url": "https://tidelift.com/funding/github/npm/browserslist"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/ai"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
+      },
+      "bin": {
+        "update-browserslist-db": "cli.js"
+      },
+      "peerDependencies": {
+        "browserslist": ">= 4.21.0"
+      }
+    },
+    "node_modules/vscode-uri": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/vscode-uri/-/vscode-uri-3.1.0.tgz",
+      "integrity": "sha512-/BpdSx+yCQGnCvecbyXdxHDkuk55/G3xwnC0GqY4gmQ3j+A+g8kzzgB4Nk/SINjqn6+waqw3EgbVF2QKExkRxQ==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/vue": {
+      "version": "3.5.39",
+      "resolved": "https://registry.npmjs.org/vue/-/vue-3.5.39.tgz",
+      "integrity": "sha512-xmZCYabFGcirU8r0fTuvl/LICc1OU620rnqepaJDL/a141ZigkG7AyaxQLdqJ02ZRYzWe6YPaDHeQx7MfknQfA==",
+      "license": "MIT",
+      "dependencies": {
+        "@vue/compiler-dom": "3.5.39",
+        "@vue/compiler-sfc": "3.5.39",
+        "@vue/runtime-dom": "3.5.39",
+        "@vue/server-renderer": "3.5.39",
+        "@vue/shared": "3.5.39"
+      },
+      "peerDependencies": {
+        "typescript": "*"
+      },
+      "peerDependenciesMeta": {
+        "typescript": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/vue-tsc": {
+      "version": "2.2.12",
+      "resolved": "https://registry.npmjs.org/vue-tsc/-/vue-tsc-2.2.12.tgz",
+      "integrity": "sha512-P7OP77b2h/Pmk+lZdJ0YWs+5tJ6J2+uOQPo7tlBnY44QqQSPYvS0qVT4wqDJgwrZaLe47etJLLQRFia71GYITw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@volar/typescript": "2.4.15",
+        "@vue/language-core": "2.2.12"
+      },
+      "bin": {
+        "vue-tsc": "bin/vue-tsc.js"
+      },
+      "peerDependencies": {
+        "typescript": ">=5.0.0"
+      }
+    },
+    "node_modules/w3c-keyname": {
+      "version": "2.2.8",
+      "resolved": "https://registry.npmjs.org/w3c-keyname/-/w3c-keyname-2.2.8.tgz",
+      "integrity": "sha512-dpojBhNsCNN7T82Tm7k26A6G9ML3NkhDsnw9n/eoxSRlVBB4CEtIQ/KTCLI2Fwf3ataSXRhYFkQi3SlnFwPvPQ==",
+      "license": "MIT"
+    }
+  }
+}

--- a/lib/ducky/dashboard/package-lock.json
+++ b/lib/ducky/dashboard/package-lock.json
@@ -11,6 +11,7 @@
         "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/lang-sql": "^6.8.0",
         "@codemirror/state": "^6.5.2",
+        "@codemirror/theme-one-dark": "^6.1.2",
         "@codemirror/view": "^6.36.2",
         "@fontsource-variable/noto-sans": "^5.2.10",
         "@fontsource-variable/noto-sans-mono": "^5.2.10",
@@ -167,6 +168,18 @@
       "license": "MIT",
       "dependencies": {
         "@marijn/find-cluster-break": "^1.0.0"
+      }
+    },
+    "node_modules/@codemirror/theme-one-dark": {
+      "version": "6.1.3",
+      "resolved": "https://registry.npmjs.org/@codemirror/theme-one-dark/-/theme-one-dark-6.1.3.tgz",
+      "integrity": "sha512-NzBdIvEJmx6fjeremiGp3t/okrLPYT0d9orIc7AFun8oZcRk58aejkqhv6spnz4MLAevrKNPMQYXEWMg4s+sKA==",
+      "license": "MIT",
+      "dependencies": {
+        "@codemirror/language": "^6.0.0",
+        "@codemirror/state": "^6.0.0",
+        "@codemirror/view": "^6.0.0",
+        "@lezer/highlight": "^1.0.0"
       }
     },
     "node_modules/@codemirror/view": {

--- a/lib/ducky/dashboard/package-lock.json
+++ b/lib/ducky/dashboard/package-lock.json
@@ -8,6 +8,7 @@
       "name": "ducky-dashboard",
       "version": "0.0.0",
       "dependencies": {
+        "@codemirror/autocomplete": "^6.20.3",
         "@codemirror/lang-sql": "^6.8.0",
         "@codemirror/state": "^6.5.2",
         "@codemirror/view": "^6.36.2",

--- a/lib/ducky/dashboard/package.json
+++ b/lib/ducky/dashboard/package.json
@@ -8,6 +8,7 @@
     "dev": "rsbuild dev"
   },
   "dependencies": {
+    "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/lang-sql": "^6.8.0",
     "@codemirror/state": "^6.5.2",
     "@codemirror/view": "^6.36.2",

--- a/lib/ducky/dashboard/package.json
+++ b/lib/ducky/dashboard/package.json
@@ -11,6 +11,7 @@
     "@codemirror/autocomplete": "^6.20.3",
     "@codemirror/lang-sql": "^6.8.0",
     "@codemirror/state": "^6.5.2",
+    "@codemirror/theme-one-dark": "^6.1.2",
     "@codemirror/view": "^6.36.2",
     "@fontsource-variable/noto-sans": "^5.2.10",
     "@fontsource-variable/noto-sans-mono": "^5.2.10",

--- a/lib/ducky/dashboard/package.json
+++ b/lib/ducky/dashboard/package.json
@@ -1,0 +1,29 @@
+{
+  "name": "ducky-dashboard",
+  "private": true,
+  "version": "0.0.0",
+  "scripts": {
+    "build": "rsbuild build",
+    "build:check": "vue-tsc --noEmit && rsbuild build",
+    "dev": "rsbuild dev"
+  },
+  "dependencies": {
+    "@codemirror/lang-sql": "^6.8.0",
+    "@codemirror/state": "^6.5.2",
+    "@codemirror/view": "^6.36.2",
+    "@fontsource-variable/noto-sans": "^5.2.10",
+    "@fontsource-variable/noto-sans-mono": "^5.2.10",
+    "@tailwindcss/postcss": "^4.3.0",
+    "codemirror": "^6.0.1",
+    "vue": "^3.5.35"
+  },
+  "devDependencies": {
+    "@rsbuild/core": "^1.2.0",
+    "@rsbuild/plugin-vue": "^1.2.9",
+    "autoprefixer": "^10.4.0",
+    "postcss": "^8.5.15",
+    "tailwindcss": "^4.0.0",
+    "typescript": "^6.0.3",
+    "vue-tsc": "^2.2.0"
+  }
+}

--- a/lib/ducky/dashboard/postcss.config.cjs
+++ b/lib/ducky/dashboard/postcss.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  plugins: {
+    '@tailwindcss/postcss': {},
+    autoprefixer: {},
+  },
+}

--- a/lib/ducky/dashboard/rsbuild.config.ts
+++ b/lib/ducky/dashboard/rsbuild.config.ts
@@ -1,0 +1,22 @@
+import { defineConfig } from '@rsbuild/core'
+import { pluginVue } from '@rsbuild/plugin-vue'
+
+export default defineConfig({
+  plugins: [pluginVue()],
+  source: {
+    entry: {
+      index: './src/main.ts',
+    },
+  },
+  output: {
+    distPath: { root: 'dist' },
+    // 'auto' makes chunk URLs resolve against the script tag's origin, so the
+    // bundle works under either / or a reverse-proxy prefix like /proxy/ducky/.
+    // The base is set via <base href> at serve time from X-Forwarded-Prefix.
+    assetPrefix: 'auto',
+  },
+  html: {
+    template: './src/template.html',
+    templateParameters: { title: 'ducky' },
+  },
+})

--- a/lib/ducky/dashboard/src/App.vue
+++ b/lib/ducky/dashboard/src/App.vue
@@ -1,0 +1,76 @@
+<script setup lang="ts">
+import { onMounted, ref } from 'vue'
+import SqlEditor from './components/SqlEditor.vue'
+import ResultTable from './components/ResultTable.vue'
+import StatusBar from './components/StatusBar.vue'
+import { useQuery } from './composables/useQuery'
+
+const sqlText = ref('')
+const ttlDays = ref<number | null>(null)
+const { phase, error, result, running, run } = useQuery()
+
+const dark = ref(document.documentElement.classList.contains('dark'))
+function toggleDark() {
+  dark.value = !dark.value
+  document.documentElement.classList.toggle('dark', dark.value)
+  try {
+    localStorage.setItem('ducky-dark-mode', String(dark.value))
+  } catch (e) {
+    /* ignore */
+  }
+}
+
+onMounted(async () => {
+  try {
+    const cfg = await (await fetch('api/config')).json()
+    ttlDays.value = cfg.result_ttl_days ?? null
+  } catch (e) {
+    /* config is best-effort; the TTL note just won't show */
+  }
+})
+</script>
+
+<template>
+  <div class="mx-auto flex min-h-screen max-w-6xl flex-col gap-4 px-6 py-6">
+    <header class="flex items-center justify-between">
+      <h1 class="flex items-center gap-2 text-xl font-semibold">
+        <span>🦆</span><span>ducky</span>
+        <span class="text-sm font-normal text-text-muted">ad-hoc DuckDB SQL</span>
+      </h1>
+      <button
+        class="rounded-md border border-surface-border px-2.5 py-1.5 text-sm text-text-secondary hover:bg-surface-raised"
+        :title="dark ? 'Switch to light mode' : 'Switch to dark mode'"
+        @click="toggleDark"
+      >
+        {{ dark ? '☀️' : '🌙' }}
+      </button>
+    </header>
+
+    <SqlEditor v-model="sqlText" @run="run(sqlText)" />
+
+    <div class="flex items-center gap-3">
+      <button
+        class="rounded-md bg-accent px-4 py-1.5 text-sm font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
+        :disabled="running"
+        @click="run(sqlText)"
+      >
+        {{ running ? 'Running…' : 'Run' }}
+      </button>
+      <span class="text-xs text-text-muted">⌘/Ctrl-Enter</span>
+      <span v-if="phase === 'submitting'" class="text-sm text-text-muted">Submitting…</span>
+      <span v-else-if="phase === 'running'" class="text-sm text-text-muted">Running…</span>
+    </div>
+
+    <p
+      v-if="error"
+      class="whitespace-pre-wrap rounded-lg border border-status-danger/40 bg-status-danger/10 px-3 py-2 font-mono text-[13px] text-status-danger"
+    >
+      {{ error }}
+    </p>
+
+    <template v-if="phase === 'done' && result">
+      <StatusBar :result="result" :ttl-days="ttlDays" />
+      <ResultTable :columns="result.columns" :rows="result.rows" />
+    </template>
+  </div>
+</template>

--- a/lib/ducky/dashboard/src/App.vue
+++ b/lib/ducky/dashboard/src/App.vue
@@ -46,7 +46,7 @@ onMounted(async () => {
       </button>
     </header>
 
-    <SqlEditor v-model="sqlText" @run="run(sqlText)" />
+    <SqlEditor v-model="sqlText" :dark="dark" @run="run(sqlText)" />
 
     <div class="flex items-center gap-3">
       <button

--- a/lib/ducky/dashboard/src/App.vue
+++ b/lib/ducky/dashboard/src/App.vue
@@ -6,8 +6,13 @@ import StatusBar from './components/StatusBar.vue'
 import { useQuery } from './composables/useQuery'
 
 const sqlText = ref('')
+const useCache = ref(true)
 const ttlDays = ref<number | null>(null)
 const { phase, error, result, running, run } = useQuery()
+
+function runQuery() {
+  run(sqlText.value, useCache.value)
+}
 
 const dark = ref(document.documentElement.classList.contains('dark'))
 function toggleDark() {
@@ -46,17 +51,21 @@ onMounted(async () => {
       </button>
     </header>
 
-    <SqlEditor v-model="sqlText" :dark="dark" @run="run(sqlText)" />
+    <SqlEditor v-model="sqlText" :dark="dark" @run="runQuery" />
 
     <div class="flex items-center gap-3">
       <button
         class="rounded-md bg-accent px-4 py-1.5 text-sm font-semibold text-white hover:bg-accent-hover disabled:cursor-not-allowed disabled:opacity-60"
         :disabled="running"
-        @click="run(sqlText)"
+        @click="runQuery"
       >
         {{ running ? 'Running…' : 'Run' }}
       </button>
       <span class="text-xs text-text-muted">⌘/Ctrl-Enter</span>
+      <label class="flex items-center gap-1.5 text-sm text-text-secondary" title="Reuse a prior identical query's result; uncheck to force a fresh run">
+        <input type="checkbox" v-model="useCache" />
+        use cached results
+      </label>
       <span v-if="phase === 'submitting'" class="text-sm text-text-muted">Submitting…</span>
       <span v-else-if="phase === 'running'" class="text-sm text-text-muted">Running…</span>
     </div>

--- a/lib/ducky/dashboard/src/components/ResultTable.vue
+++ b/lib/ducky/dashboard/src/components/ResultTable.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { fmtCell } from '../utils/formatting'
+
+defineProps<{ columns: string[]; rows: unknown[][] }>()
+</script>
+
+<template>
+  <div class="overflow-auto rounded-lg border border-surface-border">
+    <table class="w-full border-collapse text-[13px]">
+      <thead>
+        <tr>
+          <th
+            v-for="col in columns"
+            :key="col"
+            class="sticky top-0 border-b border-surface-border bg-surface-sunken px-3 py-1.5 text-left font-semibold text-text-secondary"
+          >
+            {{ col }}
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr v-for="(row, i) in rows" :key="i" class="even:bg-surface-raised">
+          <td
+            v-for="(cell, j) in row"
+            :key="j"
+            class="whitespace-pre border-b border-surface-border px-3 py-1 font-mono"
+            :class="cell === null ? 'text-text-muted italic' : 'text-text'"
+          >
+            {{ fmtCell(cell) }}
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>

--- a/lib/ducky/dashboard/src/components/SqlEditor.vue
+++ b/lib/ducky/dashboard/src/components/SqlEditor.vue
@@ -1,0 +1,64 @@
+<script setup lang="ts">
+import { onBeforeUnmount, onMounted, ref } from 'vue'
+import { EditorState, Prec } from '@codemirror/state'
+import { EditorView, keymap, placeholder } from '@codemirror/view'
+import { basicSetup } from 'codemirror'
+import { PostgreSQL, sql } from '@codemirror/lang-sql'
+
+const props = defineProps<{ modelValue: string }>()
+const emit = defineEmits<{ 'update:modelValue': [string]; run: [] }>()
+
+const host = ref<HTMLElement | null>(null)
+let view: EditorView | null = null
+
+const PLACEHOLDER = `-- write DuckDB SQL, then ⌘/Ctrl-Enter to run
+SELECT *
+FROM read_parquet('gs://marin-us-east5/<path>/*.parquet')
+LIMIT 100`
+
+onMounted(() => {
+  view = new EditorView({
+    parent: host.value!,
+    state: EditorState.create({
+      doc: props.modelValue,
+      extensions: [
+        basicSetup,
+        sql({ dialect: PostgreSQL }), // DuckDB SQL is close to Postgres
+        placeholder(PLACEHOLDER),
+        EditorView.lineWrapping,
+        // high precedence so Mod-Enter runs the query instead of inserting a newline
+        Prec.highest(
+          keymap.of([
+            {
+              key: 'Mod-Enter',
+              run: () => {
+                emit('run')
+                return true
+              },
+            },
+          ]),
+        ),
+        EditorView.updateListener.of((u) => {
+          if (u.docChanged) emit('update:modelValue', u.state.doc.toString())
+        }),
+        EditorView.theme({
+          '&': { fontSize: '13px', backgroundColor: 'var(--c-surface-raised)' },
+          '&.cm-focused': { outline: 'none' },
+          '.cm-content': { fontFamily: 'var(--font-mono, monospace)' },
+          '.cm-gutters': {
+            backgroundColor: 'var(--c-surface-sunken)',
+            color: 'var(--c-text-muted)',
+            border: 'none',
+          },
+        }),
+      ],
+    }),
+  })
+})
+
+onBeforeUnmount(() => view?.destroy())
+</script>
+
+<template>
+  <div ref="host" class="overflow-hidden rounded-lg border border-surface-border"></div>
+</template>

--- a/lib/ducky/dashboard/src/components/SqlEditor.vue
+++ b/lib/ducky/dashboard/src/components/SqlEditor.vue
@@ -1,16 +1,30 @@
 <script setup lang="ts">
-import { onBeforeUnmount, onMounted, ref } from 'vue'
-import { EditorState, Prec } from '@codemirror/state'
+import { onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import { Compartment, EditorState, Prec } from '@codemirror/state'
 import { EditorView, keymap, placeholder } from '@codemirror/view'
 import { autocompletion } from '@codemirror/autocomplete'
 import { basicSetup } from 'codemirror'
 import { PostgreSQL, sql } from '@codemirror/lang-sql'
+import { oneDark } from '@codemirror/theme-one-dark'
 
-const props = defineProps<{ modelValue: string }>()
+const props = defineProps<{ modelValue: string; dark?: boolean }>()
 const emit = defineEmits<{ 'update:modelValue': [string]; run: [] }>()
 
 const host = ref<HTMLElement | null>(null)
 let view: EditorView | null = null
+const themeComp = new Compartment()
+
+// Dark mode uses oneDark (readable light-on-dark palette + syntax colors); light mode
+// uses the app surface tokens. basicSetup's default highlight is tuned for light, so
+// it only needs a background/gutter tweak there.
+const lightTheme = EditorView.theme({
+  '&': { backgroundColor: 'var(--c-surface-raised)' },
+  '.cm-gutters': { backgroundColor: 'var(--c-surface-sunken)', color: 'var(--c-text-muted)', border: 'none' },
+})
+
+function editorTheme(dark: boolean | undefined) {
+  return dark ? oneDark : lightTheme
+}
 
 const PLACEHOLDER = `-- write DuckDB SQL, then ⌘/Ctrl-Enter to run
 SELECT *
@@ -45,20 +59,22 @@ onMounted(() => {
         EditorView.updateListener.of((u) => {
           if (u.docChanged) emit('update:modelValue', u.state.doc.toString())
         }),
+        themeComp.of(editorTheme(props.dark)),
         EditorView.theme({
-          '&': { fontSize: '13px', backgroundColor: 'var(--c-surface-raised)' },
+          '&': { fontSize: '13px' },
           '&.cm-focused': { outline: 'none' },
           '.cm-content': { fontFamily: 'var(--font-mono, monospace)' },
-          '.cm-gutters': {
-            backgroundColor: 'var(--c-surface-sunken)',
-            color: 'var(--c-text-muted)',
-            border: 'none',
-          },
         }),
       ],
     }),
   })
 })
+
+// Swap the editor theme when the app toggles dark mode.
+watch(
+  () => props.dark,
+  (dark) => view?.dispatch({ effects: themeComp.reconfigure(editorTheme(dark)) }),
+)
 
 onBeforeUnmount(() => view?.destroy())
 </script>

--- a/lib/ducky/dashboard/src/components/SqlEditor.vue
+++ b/lib/ducky/dashboard/src/components/SqlEditor.vue
@@ -2,6 +2,7 @@
 import { onBeforeUnmount, onMounted, ref } from 'vue'
 import { EditorState, Prec } from '@codemirror/state'
 import { EditorView, keymap, placeholder } from '@codemirror/view'
+import { autocompletion } from '@codemirror/autocomplete'
 import { basicSetup } from 'codemirror'
 import { PostgreSQL, sql } from '@codemirror/lang-sql'
 
@@ -24,6 +25,9 @@ onMounted(() => {
       extensions: [
         basicSetup,
         sql({ dialect: PostgreSQL }), // DuckDB SQL is close to Postgres
+        // completion stays available on Ctrl-Space, but doesn't pop up on every
+        // keystroke (the default was an intrusive symbol dropdown while typing)
+        autocompletion({ activateOnTyping: false }),
         placeholder(PLACEHOLDER),
         EditorView.lineWrapping,
         // high precedence so Mod-Enter runs the query instead of inserting a newline

--- a/lib/ducky/dashboard/src/components/StatusBar.vue
+++ b/lib/ducky/dashboard/src/components/StatusBar.vue
@@ -1,0 +1,35 @@
+<script setup lang="ts">
+import { computed } from 'vue'
+import type { QueryResult } from '../composables/useQuery'
+import { fmtBytes, fmtDuration } from '../utils/formatting'
+
+const props = defineProps<{ result: QueryResult; ttlDays: number | null }>()
+
+const rowsLabel = computed(() => {
+  const shown = props.result.rows.length
+  return props.result.truncated
+    ? `showing ${shown.toLocaleString()} of ${props.result.total_rows.toLocaleString()} rows`
+    : `${shown.toLocaleString()} row${shown === 1 ? '' : 's'}`
+})
+</script>
+
+<template>
+  <div class="flex flex-wrap items-center gap-x-2 gap-y-1 text-[13px] text-text-secondary">
+    <span>{{ rowsLabel }}</span>
+    <span class="text-text-muted">·</span>
+    <span>{{ fmtDuration(result.elapsed_ms) }}</span>
+    <span class="text-text-muted">·</span>
+    <span>{{ fmtBytes(result.result_bytes) }} result</span>
+    <span class="text-text-muted">·</span>
+    <span
+      v-if="result.cached"
+      class="rounded bg-status-success/10 px-1.5 py-0.5 font-semibold text-status-success"
+      >cached ✓</span
+    >
+    <span v-else class="rounded bg-surface-sunken px-1.5 py-0.5 text-text-muted">computed</span>
+    <span class="text-text-muted">·</span>
+    <span class="text-text-muted">output:</span>
+    <code class="rounded bg-surface-sunken px-1.5 py-0.5 font-mono text-text">{{ result.result_path }}</code>
+    <span v-if="ttlDays != null" class="text-text-muted">(expires in {{ ttlDays }}d)</span>
+  </div>
+</template>

--- a/lib/ducky/dashboard/src/composables/useQuery.ts
+++ b/lib/ducky/dashboard/src/composables/useQuery.ts
@@ -46,7 +46,7 @@ export function useQuery() {
     phase.value = 'done'
   }
 
-  async function run(sql: string): Promise<void> {
+  async function run(sql: string, useCache = true): Promise<void> {
     const trimmed = sql.trim()
     if (!trimmed || running.value) return
     phase.value = 'submitting'
@@ -56,7 +56,7 @@ export function useQuery() {
       const resp = await fetch('query', {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ sql: trimmed }),
+        body: JSON.stringify({ sql: trimmed, use_cache: useCache }),
       })
       const data = await resp.json()
       if (!resp.ok) {

--- a/lib/ducky/dashboard/src/composables/useQuery.ts
+++ b/lib/ducky/dashboard/src/composables/useQuery.ts
@@ -1,0 +1,75 @@
+import { computed, ref } from 'vue'
+
+export type Phase = 'idle' | 'submitting' | 'running' | 'done'
+
+export interface QueryResult {
+  columns: string[]
+  rows: unknown[][]
+  total_rows: number
+  truncated: boolean
+  result_path: string
+  cached: boolean
+  elapsed_ms: number
+  result_bytes: number
+}
+
+const POLL_MS = 1000
+
+/** Submit SQL and poll for its result, mirroring the async server API
+ * (`POST query` → `query_id`, then `GET result/{id}` until terminal). URLs are
+ * relative so they resolve under the controller proxy's `/proxy/ducky/` prefix. */
+export function useQuery() {
+  const phase = ref<Phase>('idle')
+  const error = ref('')
+  const result = ref<QueryResult | null>(null)
+  const running = computed(() => phase.value === 'submitting' || phase.value === 'running')
+
+  async function poll(queryId: string): Promise<void> {
+    phase.value = 'running'
+    const resp = await fetch(`result/${queryId}`)
+    const data = await resp.json()
+    if (!resp.ok) {
+      error.value = data.error || `HTTP ${resp.status}`
+      phase.value = 'idle'
+      return
+    }
+    if (data.status === 'running') {
+      await new Promise((r) => setTimeout(r, POLL_MS))
+      return poll(queryId)
+    }
+    if (data.status === 'error') {
+      error.value = data.error
+      phase.value = 'idle'
+      return
+    }
+    result.value = data as QueryResult
+    phase.value = 'done'
+  }
+
+  async function run(sql: string): Promise<void> {
+    const trimmed = sql.trim()
+    if (!trimmed || running.value) return
+    phase.value = 'submitting'
+    error.value = ''
+    result.value = null
+    try {
+      const resp = await fetch('query', {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        body: JSON.stringify({ sql: trimmed }),
+      })
+      const data = await resp.json()
+      if (!resp.ok) {
+        error.value = data.error || `HTTP ${resp.status}`
+        phase.value = 'idle'
+        return
+      }
+      await poll(data.query_id)
+    } catch (e) {
+      error.value = String(e)
+      phase.value = 'idle'
+    }
+  }
+
+  return { phase, error, result, running, run }
+}

--- a/lib/ducky/dashboard/src/main.ts
+++ b/lib/ducky/dashboard/src/main.ts
@@ -1,0 +1,5 @@
+import { createApp } from 'vue'
+import App from './App.vue'
+import './styles/main.css'
+
+createApp(App).mount('#app')

--- a/lib/ducky/dashboard/src/styles/main.css
+++ b/lib/ducky/dashboard/src/styles/main.css
@@ -1,0 +1,46 @@
+@import '@fontsource-variable/noto-sans';
+@import '@fontsource-variable/noto-sans-mono';
+@import 'tailwindcss';
+
+@config '../../tailwind.config.ts';
+
+/* Design tokens — light default, overridden under .dark. Referenced by the
+   Tailwind color aliases in tailwind.config.ts and directly in components. */
+:root {
+  --c-surface: #ffffff;
+  --c-surface-raised: #f7f7f9;
+  --c-surface-sunken: #eef0f3;
+  --c-surface-border: #e0e2e7;
+  --c-text: #1b1c1f;
+  --c-text-secondary: #45474d;
+  --c-text-muted: #797c85;
+  --c-accent: #e8940c;
+  --c-accent-hover: #cc810a;
+  --c-accent-subtle: #fdf3e2;
+  --c-status-success: #1f9d63;
+  --c-status-danger: #d0463f;
+}
+
+.dark {
+  --c-surface: #131417;
+  --c-surface-raised: #1c1e22;
+  --c-surface-sunken: #0d0e10;
+  --c-surface-border: #2b2e34;
+  --c-text: #e9eaec;
+  --c-text-secondary: #b6b8be;
+  --c-text-muted: #888b93;
+  --c-accent: #f2b544;
+  --c-accent-hover: #ffc55a;
+  --c-accent-subtle: #2a2110;
+  --c-status-success: #35c987;
+  --c-status-danger: #f0716b;
+}
+
+html,
+body {
+  height: 100%;
+}
+
+body {
+  margin: 0;
+}

--- a/lib/ducky/dashboard/src/template.html
+++ b/lib/ducky/dashboard/src/template.html
@@ -1,0 +1,23 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <!-- href is rewritten at serve time from X-Forwarded-Prefix so the bundle
+         works under the controller proxy sub-path (/proxy/ducky/); fetch() and
+         asset URLs both resolve relative to it. -->
+    <base href="/" />
+    <title><%= title %></title>
+    <script>
+      try {
+        var stored = localStorage.getItem('ducky-dark-mode');
+        if (stored === 'true' || (stored === null && window.matchMedia('(prefers-color-scheme: dark)').matches)) {
+          document.documentElement.classList.add('dark');
+        }
+      } catch (e) {}
+    </script>
+  </head>
+  <body class="bg-surface text-text font-sans antialiased">
+    <div id="app"></div>
+  </body>
+</html>

--- a/lib/ducky/dashboard/src/utils/formatting.ts
+++ b/lib/ducky/dashboard/src/utils/formatting.ts
@@ -1,0 +1,21 @@
+export function fmtBytes(n: number | null | undefined): string {
+  if (n == null) return '?'
+  const units = ['B', 'KB', 'MB', 'GB', 'TB']
+  let size = n
+  let i = 0
+  while (size >= 1024 && i < units.length - 1) {
+    size /= 1024
+    i++
+  }
+  return `${i === 0 ? size : size.toFixed(1)} ${units[i]}`
+}
+
+export function fmtDuration(ms: number | null | undefined): string {
+  if (ms == null) return '?'
+  if (ms < 1000) return `${ms} ms`
+  return `${(ms / 1000).toFixed(ms < 10000 ? 2 : 1)} s`
+}
+
+export function fmtCell(cell: unknown): string {
+  return cell === null || cell === undefined ? 'NULL' : String(cell)
+}

--- a/lib/ducky/dashboard/tailwind.config.ts
+++ b/lib/ducky/dashboard/tailwind.config.ts
@@ -1,0 +1,38 @@
+import type { Config } from 'tailwindcss'
+
+// Colors resolve to CSS variables defined in src/styles/main.css (light + .dark).
+export default {
+  content: ['./src/**/*.{vue,ts,tsx,html}'],
+  darkMode: 'class',
+  theme: {
+    extend: {
+      fontFamily: {
+        sans: ['"Noto Sans Variable"', 'system-ui', 'sans-serif'],
+        mono: ['"Noto Sans Mono Variable"', '"SF Mono"', 'Menlo', 'monospace'],
+      },
+      colors: {
+        surface: {
+          DEFAULT: 'var(--c-surface)',
+          raised: 'var(--c-surface-raised)',
+          sunken: 'var(--c-surface-sunken)',
+          border: 'var(--c-surface-border)',
+        },
+        text: {
+          DEFAULT: 'var(--c-text)',
+          secondary: 'var(--c-text-secondary)',
+          muted: 'var(--c-text-muted)',
+        },
+        accent: {
+          DEFAULT: 'var(--c-accent)',
+          hover: 'var(--c-accent-hover)',
+          subtle: 'var(--c-accent-subtle)',
+        },
+        status: {
+          success: 'var(--c-status-success)',
+          danger: 'var(--c-status-danger)',
+        },
+      },
+    },
+  },
+  plugins: [],
+} satisfies Config

--- a/lib/ducky/dashboard/tsconfig.json
+++ b/lib/ducky/dashboard/tsconfig.json
@@ -1,0 +1,20 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "strict": true,
+    "jsx": "preserve",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "esModuleInterop": true,
+    "lib": ["ES2020", "DOM", "DOM.Iterable"],
+    "skipLibCheck": true,
+    "noEmit": true,
+    "paths": {
+      "@/*": ["./src/*"]
+    },
+    "baseUrl": "."
+  },
+  "include": ["src/**/*.ts", "src/**/*.vue", "env.d.ts"]
+}

--- a/lib/ducky/dashboard/tsconfig.json
+++ b/lib/ducky/dashboard/tsconfig.json
@@ -10,11 +10,7 @@
     "esModuleInterop": true,
     "lib": ["ES2020", "DOM", "DOM.Iterable"],
     "skipLibCheck": true,
-    "noEmit": true,
-    "paths": {
-      "@/*": ["./src/*"]
-    },
-    "baseUrl": "."
+    "noEmit": true
   },
   "include": ["src/**/*.ts", "src/**/*.vue", "env.d.ts"]
 }

--- a/lib/ducky/pyproject.toml
+++ b/lib/ducky/pyproject.toml
@@ -21,7 +21,7 @@ dependencies = [
 ducky = "ducky.cli:cli"
 
 [dependency-groups]
-dev = [
+test = [
     "pytest>=8.4",
     "pytest-timeout",
 ]

--- a/lib/ducky/pyproject.toml
+++ b/lib/ducky/pyproject.toml
@@ -5,7 +5,7 @@ build-backend = "hatchling.build"
 [project]
 name = "marin-ducky"
 version = "0.1.0"
-description = "ducky — ad-hoc DuckDB SQL service: paste SQL, run it on a v6e host over object-store parquet."
+description = "ducky — ad-hoc DuckDB SQL service: paste SQL, run it over object-store parquet."
 requires-python = ">=3.11"
 dependencies = [
     "marin-iris",

--- a/lib/ducky/pyproject.toml
+++ b/lib/ducky/pyproject.toml
@@ -14,16 +14,16 @@ dependencies = [
     "starlette>=0.37",
     "uvicorn>=0.30",
     "click>=8.3.1",
+    "httpx>=0.27",
 ]
 
 [project.scripts]
-ducky = "ducky.deploy:cli"
+ducky = "ducky.cli:cli"
 
 [dependency-groups]
 dev = [
     "pytest>=8.4",
     "pytest-timeout",
-    "httpx>=0.27",
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/lib/ducky/pyproject.toml
+++ b/lib/ducky/pyproject.toml
@@ -1,0 +1,36 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "marin-ducky"
+version = "0.1.0"
+description = "ducky — ad-hoc DuckDB SQL service: paste SQL, run it on a v6e host over object-store parquet."
+requires-python = ">=3.11"
+dependencies = [
+    "marin-iris",
+    "duckdb>=1.0.0",
+    "pyarrow>=23.0.0",
+    "starlette>=0.37",
+    "uvicorn>=0.30",
+    "click>=8.3.1",
+]
+
+[project.scripts]
+ducky = "ducky.deploy:cli"
+
+[dependency-groups]
+dev = [
+    "pytest>=8.4",
+    "pytest-timeout",
+    "httpx>=0.27",
+]
+
+[tool.hatch.build.targets.wheel]
+packages = ["src/ducky"]
+
+[tool.pytest.ini_options]
+timeout = 30
+timeout_method = "thread"
+addopts = "--durations=10 -v"
+log_level = "INFO"

--- a/lib/ducky/src/ducky/__init__.py
+++ b/lib/ducky/src/ducky/__init__.py
@@ -1,4 +1,4 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""ducky — ad-hoc DuckDB SQL service over a v6e host."""
+"""ducky — ad-hoc DuckDB SQL service over object-store parquet."""

--- a/lib/ducky/src/ducky/__init__.py
+++ b/lib/ducky/src/ducky/__init__.py
@@ -1,0 +1,4 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""ducky — ad-hoc DuckDB SQL service over a v6e host."""

--- a/lib/ducky/src/ducky/cli.py
+++ b/lib/ducky/src/ducky/cli.py
@@ -1,0 +1,24 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The ``ducky`` command group: ``ducky deploy`` and ``ducky query``."""
+
+from __future__ import annotations
+
+import click
+
+from ducky.client import query
+from ducky.deploy import cli as deploy_command
+
+
+@click.group()
+def cli() -> None:
+    """ducky — ad-hoc DuckDB SQL service."""
+
+
+cli.add_command(deploy_command, name="deploy")
+cli.add_command(query)
+
+
+if __name__ == "__main__":
+    cli()

--- a/lib/ducky/src/ducky/client.py
+++ b/lib/ducky/src/ducky/client.py
@@ -18,25 +18,19 @@ the full-result GCS path) to stderr.
 
 from __future__ import annotations
 
-import contextlib
 import json
 import os
-import re
-import shlex
-import subprocess
-import threading
 import time
-from collections.abc import Iterator
 
 import click
 import httpx
+
+from ducky.tunnel import cluster_tunnel
 
 DEFAULT_BASE_URL = "http://127.0.0.1:10000/proxy/ducky"
 # Per-request HTTP timeout. Each submit/poll call is fast (the query runs async on the
 # server), so this only bounds a single round-trip — not the query.
 _HTTP_TIMEOUT = 30
-# matches the local tunnel address the iris CLI prints (port varies)
-_TUNNEL_URL_RE = re.compile(r"https?://127\.0\.0\.1:\d+")
 
 
 def _render_table(columns: list[str], rows: list[list]) -> str:
@@ -60,48 +54,6 @@ def _error_message(response: httpx.Response) -> str:
         return str(response.json().get("error", response.text))
     except (ValueError, KeyError):
         return f"HTTP {response.status_code}: {response.text[:200]}"
-
-
-@contextlib.contextmanager
-def _cluster_tunnel(cluster: str, endpoint: str, timeout: float = 90.0) -> Iterator[str]:
-    """Open a controller tunnel via ``iris cluster dashboard`` and yield the proxied base URL.
-
-    Spawns the iris CLI (override with ``$DUCKY_IRIS_CMD``), reads its output until the
-    local tunnel URL appears, and tears the tunnel down on exit. The iris CLI owns the
-    tunnel + auth, so ducky needs no iris Python imports.
-    """
-    iris_cmd = shlex.split(os.environ.get("DUCKY_IRIS_CMD", "iris"))
-    proc = subprocess.Popen(
-        [*iris_cmd, "--cluster", cluster, "cluster", "dashboard"],
-        stdout=subprocess.PIPE,
-        stderr=subprocess.STDOUT,
-        text=True,
-    )
-    # Reading proc.stdout line-by-line blocks if iris emits nothing, so a wall-clock
-    # check inside the loop never fires — enforce the startup timeout by terminating
-    # the process (which EOFs the read) if the URL hasn't appeared in time.
-    startup_kill = threading.Timer(timeout, proc.terminate)
-    startup_kill.start()
-    base = None
-    try:
-        assert proc.stdout is not None
-        for line in proc.stdout:
-            match = _TUNNEL_URL_RE.search(line)
-            if match:
-                base = f"{match.group(0)}/proxy/{endpoint}"
-                break
-    finally:
-        startup_kill.cancel()  # startup done (found or EOF); stop guarding it
-
-    if base is None:
-        proc.terminate()
-        raise click.ClickException(f"Could not open a tunnel to cluster {cluster!r} via `iris cluster dashboard`.")
-    try:
-        yield base
-    finally:
-        proc.terminate()
-        with contextlib.suppress(subprocess.TimeoutExpired):
-            proc.wait(timeout=10)
 
 
 def _run_query(base: str, sql: str, output_format: str, poll_interval: float, timeout: int) -> None:
@@ -168,8 +120,8 @@ def query(
         raise click.UsageError("No SQL provided — pass it as an argument or via stdin.")
 
     if cluster:
-        with _cluster_tunnel(cluster, endpoint) as base:
-            _run_query(base, sql, output_format, poll_interval, timeout)
+        with cluster_tunnel(cluster) as controller_url:
+            _run_query(f"{controller_url}/proxy/{endpoint}", sql, output_format, poll_interval, timeout)
     else:
         base = base_url or os.environ.get("DUCKY_BASE_URL", DEFAULT_BASE_URL)
         _run_query(base, sql, output_format, poll_interval, timeout)

--- a/lib/ducky/src/ducky/client.py
+++ b/lib/ducky/src/ducky/client.py
@@ -3,27 +3,36 @@
 
 """`ducky query` — run a SQL query against a ducky service from the CLI.
 
-ducky is reached through the controller endpoint proxy, which sits behind IAP; the
-simplest way in is a local tunnel. Open one with ``iris --cluster=<name> cluster
-dashboard`` (holds a tunnel at ``http://127.0.0.1:10000``), then::
+ducky is reached through the controller endpoint proxy, which sits behind IAP. The
+CLI hides that: with ``--cluster <name>`` it drives ``iris cluster dashboard`` to
+open a local tunnel, resolves the ``/proxy/<endpoint>`` path itself, runs the query,
+and tears the tunnel down — so you just run::
 
-    ducky query "SELECT count(*) FROM read_parquet('gs://marin-us-east5/…/*.parquet')"
+    ducky query --cluster marin "SELECT count(*) FROM read_parquet('gs://…/*.parquet')"
 
-The default ``--base-url`` points at that tunnel. The command submits the query,
-polls until it finishes, prints the capped preview as a table, and writes a stats
-line (rows, time, result size, cached, the full-result GCS path) to stderr.
+Alternatively pass ``--base-url`` to target an already-open tunnel (or set
+``DUCKY_BASE_URL``). The command submits, polls until done, prints the capped
+preview as a table, and writes a stats line (rows, time, result size, cached, and
+the full-result GCS path) to stderr.
 """
 
 from __future__ import annotations
 
+import contextlib
 import json
 import os
+import re
+import shlex
+import subprocess
 import time
+from collections.abc import Iterator
 
 import click
 import httpx
 
 DEFAULT_BASE_URL = "http://127.0.0.1:10000/proxy/ducky"
+# matches the local tunnel address the iris CLI prints (port varies)
+_TUNNEL_URL_RE = re.compile(r"https?://127\.0\.0\.1:\d+")
 
 
 def _render_table(columns: list[str], rows: list[list]) -> str:
@@ -42,25 +51,50 @@ def _render_table(columns: list[str], rows: list[list]) -> str:
     return "\n".join(lines)
 
 
-@click.command("query")
-@click.argument("sql", required=False)
-@click.option(
-    "--base-url",
-    default=lambda: os.environ.get("DUCKY_BASE_URL", DEFAULT_BASE_URL),
-    help=f"ducky base URL (default: {DEFAULT_BASE_URL}; open a tunnel with `iris cluster dashboard`).",
-)
-@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table", show_default=True)
-@click.option("--poll-interval", default=1.0, show_default=True, help="Seconds between status polls.")
-@click.option("--timeout", default=3600, show_default=True, help="Max seconds to wait for the query to finish.")
-def query(sql: str | None, base_url: str, output_format: str, poll_interval: float, timeout: int) -> None:
-    """Run SQL against a ducky service and print the result. SQL comes from the argument or stdin."""
-    if not sql:
-        sql = click.get_text_stream("stdin").read()
-    sql = sql.strip()
-    if not sql:
-        raise click.UsageError("No SQL provided — pass it as an argument or via stdin.")
+def _error_message(response: httpx.Response) -> str:
+    try:
+        return str(response.json().get("error", response.text))
+    except (ValueError, KeyError):
+        return f"HTTP {response.status_code}: {response.text[:200]}"
 
-    base = base_url.rstrip("/")
+
+@contextlib.contextmanager
+def _cluster_tunnel(cluster: str, endpoint: str, timeout: float = 90.0) -> Iterator[str]:
+    """Open a controller tunnel via ``iris cluster dashboard`` and yield the proxied base URL.
+
+    Spawns the iris CLI (override with ``$DUCKY_IRIS_CMD``), reads its output until the
+    local tunnel URL appears, and tears the tunnel down on exit. The iris CLI owns the
+    tunnel + auth, so ducky needs no iris Python imports.
+    """
+    iris_cmd = shlex.split(os.environ.get("DUCKY_IRIS_CMD", "iris"))
+    proc = subprocess.Popen(
+        [*iris_cmd, "--cluster", cluster, "cluster", "dashboard"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    try:
+        base = None
+        deadline = time.monotonic() + timeout
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            match = _TUNNEL_URL_RE.search(line)
+            if match:
+                base = f"{match.group(0)}/proxy/{endpoint}"
+                break
+            if time.monotonic() > deadline or proc.poll() is not None:
+                break
+        if base is None:
+            raise click.ClickException(f"Could not open a tunnel to cluster {cluster!r} via `iris cluster dashboard`.")
+        yield base
+    finally:
+        proc.terminate()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=10)
+
+
+def _run_query(base: str, sql: str, output_format: str, poll_interval: float, timeout: int) -> None:
+    base = base.rstrip("/")
     submit = httpx.post(f"{base}/query", json={"sql": sql}, timeout=30)
     if submit.status_code != 202:
         raise click.ClickException(_error_message(submit))
@@ -83,21 +117,48 @@ def query(sql: str | None, base_url: str, output_format: str, poll_interval: flo
         return
 
     click.echo(_render_table(result["columns"], result["rows"]))
-    shown = len(result["rows"])
-    count = f"{shown} of {result['total_rows']}" if result["truncated"] else str(result["total_rows"])
+    count = f"{len(result['rows'])} of {result['total_rows']}" if result["truncated"] else str(result["total_rows"])
     cached = "cached" if result["cached"] else "computed"
-    click.echo(
-        f"\n{count} rows · {result['elapsed_ms']} ms · {result['result_bytes']} B · {cached}",
-        err=True,
-    )
+    click.echo(f"\n{count} rows · {result['elapsed_ms']} ms · {result['result_bytes']} B · {cached}", err=True)
     click.echo(f"full result: {result['result_path']}", err=True)
 
 
-def _error_message(response: httpx.Response) -> str:
-    try:
-        return str(response.json().get("error", response.text))
-    except (ValueError, KeyError):
-        return f"HTTP {response.status_code}: {response.text[:200]}"
+@click.command("query")
+@click.argument("sql", required=False)
+@click.option("--cluster", default=None, help="Iris cluster to auto-tunnel to (hides the tunnel/proxy).")
+@click.option("--endpoint", default="ducky", show_default=True, help="ducky endpoint name behind the controller proxy.")
+@click.option(
+    "--base-url",
+    default=None,
+    help=f"Explicit ducky base URL (default $DUCKY_BASE_URL or {DEFAULT_BASE_URL}); mutually exclusive with --cluster.",
+)
+@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table", show_default=True)
+@click.option("--poll-interval", default=1.0, show_default=True, help="Seconds between status polls.")
+@click.option("--timeout", default=3600, show_default=True, help="Max seconds to wait for the query to finish.")
+def query(
+    sql: str | None,
+    cluster: str | None,
+    endpoint: str,
+    base_url: str | None,
+    output_format: str,
+    poll_interval: float,
+    timeout: int,
+) -> None:
+    """Run SQL against a ducky service and print the result. SQL comes from the argument or stdin."""
+    if cluster and base_url:
+        raise click.UsageError("Pass --cluster or --base-url, not both.")
+    if not sql:
+        sql = click.get_text_stream("stdin").read()
+    sql = sql.strip()
+    if not sql:
+        raise click.UsageError("No SQL provided — pass it as an argument or via stdin.")
+
+    if cluster:
+        with _cluster_tunnel(cluster, endpoint) as base:
+            _run_query(base, sql, output_format, poll_interval, timeout)
+    else:
+        base = base_url or os.environ.get("DUCKY_BASE_URL", DEFAULT_BASE_URL)
+        _run_query(base, sql, output_format, poll_interval, timeout)
 
 
 if __name__ == "__main__":

--- a/lib/ducky/src/ducky/client.py
+++ b/lib/ducky/src/ducky/client.py
@@ -56,9 +56,9 @@ def _error_message(response: httpx.Response) -> str:
         return f"HTTP {response.status_code}: {response.text[:200]}"
 
 
-def _run_query(base: str, sql: str, output_format: str, poll_interval: float, timeout: int) -> None:
+def _run_query(base: str, sql: str, output_format: str, poll_interval: float, timeout: int, use_cache: bool) -> None:
     base = base.rstrip("/")
-    submit = httpx.post(f"{base}/query", json={"sql": sql}, timeout=_HTTP_TIMEOUT)
+    submit = httpx.post(f"{base}/query", json={"sql": sql, "use_cache": use_cache}, timeout=_HTTP_TIMEOUT)
     if submit.status_code != 202:
         raise click.ClickException(_error_message(submit))
     query_id = submit.json()["query_id"]
@@ -101,6 +101,7 @@ def _run_query(base: str, sql: str, output_format: str, poll_interval: float, ti
 @click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table", show_default=True)
 @click.option("--poll-interval", default=1.0, show_default=True, help="Seconds between status polls.")
 @click.option("--timeout", default=3600, show_default=True, help="Max seconds to wait for the query to finish.")
+@click.option("--no-cache", is_flag=True, help="Force a fresh run instead of reusing a prior identical query's result.")
 def query(
     sql: str | None,
     cluster: str | None,
@@ -109,6 +110,7 @@ def query(
     output_format: str,
     poll_interval: float,
     timeout: int,
+    no_cache: bool,
 ) -> None:
     """Run SQL against a ducky service and print the result. SQL comes from the argument or stdin."""
     if cluster and base_url:
@@ -119,12 +121,13 @@ def query(
     if not sql:
         raise click.UsageError("No SQL provided — pass it as an argument or via stdin.")
 
+    use_cache = not no_cache
     if cluster:
         with cluster_tunnel(cluster) as controller_url:
-            _run_query(f"{controller_url}/proxy/{endpoint}", sql, output_format, poll_interval, timeout)
+            _run_query(f"{controller_url}/proxy/{endpoint}", sql, output_format, poll_interval, timeout, use_cache)
     else:
         base = base_url or os.environ.get("DUCKY_BASE_URL", DEFAULT_BASE_URL)
-        _run_query(base, sql, output_format, poll_interval, timeout)
+        _run_query(base, sql, output_format, poll_interval, timeout, use_cache)
 
 
 if __name__ == "__main__":

--- a/lib/ducky/src/ducky/client.py
+++ b/lib/ducky/src/ducky/client.py
@@ -1,0 +1,104 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""`ducky query` — run a SQL query against a ducky service from the CLI.
+
+ducky is reached through the controller endpoint proxy, which sits behind IAP; the
+simplest way in is a local tunnel. Open one with ``iris --cluster=<name> cluster
+dashboard`` (holds a tunnel at ``http://127.0.0.1:10000``), then::
+
+    ducky query "SELECT count(*) FROM read_parquet('gs://marin-us-east5/…/*.parquet')"
+
+The default ``--base-url`` points at that tunnel. The command submits the query,
+polls until it finishes, prints the capped preview as a table, and writes a stats
+line (rows, time, result size, cached, the full-result GCS path) to stderr.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import time
+
+import click
+import httpx
+
+DEFAULT_BASE_URL = "http://127.0.0.1:10000/proxy/ducky"
+
+
+def _render_table(columns: list[str], rows: list[list]) -> str:
+    """Format columns/rows as a simple aligned text table."""
+    str_rows = [["NULL" if cell is None else str(cell) for cell in row] for row in rows]
+    widths = [len(c) for c in columns]
+    for row in str_rows:
+        for i, cell in enumerate(row):
+            widths[i] = max(widths[i], len(cell))
+
+    def fmt(cells: list[str]) -> str:
+        return " | ".join(cell.ljust(widths[i]) for i, cell in enumerate(cells))
+
+    lines = [fmt(columns), "-+-".join("-" * w for w in widths)]
+    lines.extend(fmt(row) for row in str_rows)
+    return "\n".join(lines)
+
+
+@click.command("query")
+@click.argument("sql", required=False)
+@click.option(
+    "--base-url",
+    default=lambda: os.environ.get("DUCKY_BASE_URL", DEFAULT_BASE_URL),
+    help=f"ducky base URL (default: {DEFAULT_BASE_URL}; open a tunnel with `iris cluster dashboard`).",
+)
+@click.option("--format", "output_format", type=click.Choice(["table", "json"]), default="table", show_default=True)
+@click.option("--poll-interval", default=1.0, show_default=True, help="Seconds between status polls.")
+@click.option("--timeout", default=3600, show_default=True, help="Max seconds to wait for the query to finish.")
+def query(sql: str | None, base_url: str, output_format: str, poll_interval: float, timeout: int) -> None:
+    """Run SQL against a ducky service and print the result. SQL comes from the argument or stdin."""
+    if not sql:
+        sql = click.get_text_stream("stdin").read()
+    sql = sql.strip()
+    if not sql:
+        raise click.UsageError("No SQL provided — pass it as an argument or via stdin.")
+
+    base = base_url.rstrip("/")
+    submit = httpx.post(f"{base}/query", json={"sql": sql}, timeout=30)
+    if submit.status_code != 202:
+        raise click.ClickException(_error_message(submit))
+    query_id = submit.json()["query_id"]
+
+    deadline = time.monotonic() + timeout
+    while True:
+        result = httpx.get(f"{base}/result/{query_id}", timeout=30).json()
+        if result.get("status") != "running":
+            break
+        if time.monotonic() > deadline:
+            raise click.ClickException(f"Query still running after {timeout}s (id {query_id}).")
+        time.sleep(poll_interval)
+
+    if result["status"] == "error":
+        raise click.ClickException(result["error"])
+
+    if output_format == "json":
+        click.echo(json.dumps(result, indent=2))
+        return
+
+    click.echo(_render_table(result["columns"], result["rows"]))
+    shown = len(result["rows"])
+    count = f"{shown} of {result['total_rows']}" if result["truncated"] else str(result["total_rows"])
+    cached = "cached" if result["cached"] else "computed"
+    click.echo(
+        f"\n{count} rows · {result['elapsed_ms']} ms · {result['result_bytes']} B · {cached}",
+        err=True,
+    )
+    click.echo(f"full result: {result['result_path']}", err=True)
+
+
+def _error_message(response: httpx.Response) -> str:
+    try:
+        return str(response.json().get("error", response.text))
+    except (ValueError, KeyError):
+        return f"HTTP {response.status_code}: {response.text[:200]}"
+
+
+if __name__ == "__main__":
+    query()

--- a/lib/ducky/src/ducky/client.py
+++ b/lib/ducky/src/ducky/client.py
@@ -32,6 +32,9 @@ import click
 import httpx
 
 DEFAULT_BASE_URL = "http://127.0.0.1:10000/proxy/ducky"
+# Per-request HTTP timeout. Each submit/poll call is fast (the query runs async on the
+# server), so this only bounds a single round-trip — not the query.
+_HTTP_TIMEOUT = 30
 # matches the local tunnel address the iris CLI prints (port varies)
 _TUNNEL_URL_RE = re.compile(r"https?://127\.0\.0\.1:\d+")
 
@@ -103,14 +106,14 @@ def _cluster_tunnel(cluster: str, endpoint: str, timeout: float = 90.0) -> Itera
 
 def _run_query(base: str, sql: str, output_format: str, poll_interval: float, timeout: int) -> None:
     base = base.rstrip("/")
-    submit = httpx.post(f"{base}/query", json={"sql": sql}, timeout=30)
+    submit = httpx.post(f"{base}/query", json={"sql": sql}, timeout=_HTTP_TIMEOUT)
     if submit.status_code != 202:
         raise click.ClickException(_error_message(submit))
     query_id = submit.json()["query_id"]
 
     deadline = time.monotonic() + timeout
     while True:
-        resp = httpx.get(f"{base}/result/{query_id}", timeout=30)
+        resp = httpx.get(f"{base}/result/{query_id}", timeout=_HTTP_TIMEOUT)
         if resp.status_code != 200:
             raise click.ClickException(_error_message(resp))
         result = resp.json()

--- a/lib/ducky/src/ducky/client.py
+++ b/lib/ducky/src/ducky/client.py
@@ -24,6 +24,7 @@ import os
 import re
 import shlex
 import subprocess
+import threading
 import time
 from collections.abc import Iterator
 
@@ -73,19 +74,26 @@ def _cluster_tunnel(cluster: str, endpoint: str, timeout: float = 90.0) -> Itera
         stderr=subprocess.STDOUT,
         text=True,
     )
+    # Reading proc.stdout line-by-line blocks if iris emits nothing, so a wall-clock
+    # check inside the loop never fires — enforce the startup timeout by terminating
+    # the process (which EOFs the read) if the URL hasn't appeared in time.
+    startup_kill = threading.Timer(timeout, proc.terminate)
+    startup_kill.start()
+    base = None
     try:
-        base = None
-        deadline = time.monotonic() + timeout
         assert proc.stdout is not None
         for line in proc.stdout:
             match = _TUNNEL_URL_RE.search(line)
             if match:
                 base = f"{match.group(0)}/proxy/{endpoint}"
                 break
-            if time.monotonic() > deadline or proc.poll() is not None:
-                break
-        if base is None:
-            raise click.ClickException(f"Could not open a tunnel to cluster {cluster!r} via `iris cluster dashboard`.")
+    finally:
+        startup_kill.cancel()  # startup done (found or EOF); stop guarding it
+
+    if base is None:
+        proc.terminate()
+        raise click.ClickException(f"Could not open a tunnel to cluster {cluster!r} via `iris cluster dashboard`.")
+    try:
         yield base
     finally:
         proc.terminate()
@@ -102,7 +110,10 @@ def _run_query(base: str, sql: str, output_format: str, poll_interval: float, ti
 
     deadline = time.monotonic() + timeout
     while True:
-        result = httpx.get(f"{base}/result/{query_id}", timeout=30).json()
+        resp = httpx.get(f"{base}/result/{query_id}", timeout=30)
+        if resp.status_code != 200:
+            raise click.ClickException(_error_message(resp))
+        result = resp.json()
         if result.get("status") != "running":
             break
         if time.monotonic() > deadline:

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -1,0 +1,80 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""ducky configuration, resolved once at startup from the task environment.
+
+DuckDB's ``httpfs`` cannot consume GCP application-default credentials, so GCS is
+reached through the S3-compatible interop API with HMAC keys. R2 and CoreWeave are
+native S3 providers; ducky keys each backend to a distinct URL scheme so a single
+DuckDB ``SECRET`` per backend disambiguates without bucket-level scoping:
+
+- ``gs://`` → GCS (HMAC interop key/secret)
+- ``r2://`` → R2 (account id + S3 key/secret)
+- ``s3://`` → CoreWeave object store (endpoint + S3 key/secret)
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import os
+
+_ENV_PREFIX = "DUCKY_"
+
+
+@dataclasses.dataclass(frozen=True)
+class DuckyConfig:
+    """Resolved ducky configuration. Construct directly, or via :meth:`from_environment`."""
+
+    region: str
+    """Service region (e.g. ``us-east5``). Operational pin only; not enforced in the runner."""
+
+    scratch_bucket: str
+    """``gs://`` prefix where full results spill. Lives in ``region``; carries a lifecycle TTL rule."""
+
+    gcs_hmac_key_id: str
+    gcs_hmac_secret: str
+    r2_account_id: str
+    r2_access_key: str
+    r2_secret_key: str
+    cw_endpoint: str
+    cw_access_key: str
+    cw_secret_key: str
+
+    preview_row_cap: int = 10_000
+    """Max rows returned inline to the browser. The full result always spills to parquet."""
+
+    memory_fraction: float = 0.8
+    """DuckDB ``memory_limit`` = this fraction of host RAM, leaving headroom for Python/Arrow/OS."""
+
+    result_ttl_days: int = 7
+    """Informational — enforced by the scratch bucket's lifecycle rule, not by ducky (ducky only writes)."""
+
+    port_name: str = "ducky"
+    """Iris named port, bound via ``ctx.get_port(port_name)``."""
+
+    @classmethod
+    def from_environment(cls) -> DuckyConfig:
+        """Build from ``DUCKY_*`` env vars. Raise ``ValueError`` listing any missing required keys."""
+        required = {
+            "region": "DUCKY_REGION",
+            "scratch_bucket": "DUCKY_SCRATCH_BUCKET",
+            "gcs_hmac_key_id": "DUCKY_GCS_HMAC_KEY_ID",
+            "gcs_hmac_secret": "DUCKY_GCS_HMAC_SECRET",
+            "r2_account_id": "DUCKY_R2_ACCOUNT_ID",
+            "r2_access_key": "DUCKY_R2_ACCESS_KEY",
+            "r2_secret_key": "DUCKY_R2_SECRET_KEY",
+            "cw_endpoint": "DUCKY_CW_ENDPOINT",
+            "cw_access_key": "DUCKY_CW_ACCESS_KEY",
+            "cw_secret_key": "DUCKY_CW_SECRET_KEY",
+        }
+        values = {field: os.environ.get(env_key) for field, env_key in required.items()}
+        missing = [required[field] for field, value in values.items() if not value]
+        if missing:
+            raise ValueError(f"Missing required ducky env vars: {', '.join(sorted(missing))}")
+
+        return cls(
+            preview_row_cap=int(os.environ.get(f"{_ENV_PREFIX}PREVIEW_ROW_CAP", cls.preview_row_cap)),
+            memory_fraction=float(os.environ.get(f"{_ENV_PREFIX}MEMORY_FRACTION", cls.memory_fraction)),
+            result_ttl_days=int(os.environ.get(f"{_ENV_PREFIX}RESULT_TTL_DAYS", cls.result_ttl_days)),
+            **values,  # pyrefly: ignore  # required keys are non-None after the check above
+        )

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -83,14 +83,16 @@ class DuckyConfig:
     preview_row_cap: int = 10_000
     """Max rows returned inline to the browser. The full result always spills to parquet."""
 
-    memory_fraction: float = 0.8
-    """DuckDB ``memory_limit`` = this fraction of host RAM, leaving headroom for Python/Arrow/OS.
-    A hard self-cap: the process won't be OS-OOM-killed; a query needing more fails (and is
-    caught per-query) instead of taking down the service."""
+    memory_fraction: float = 0.6
+    """DuckDB ``memory_limit`` = this fraction of host RAM, a hard self-cap. Leaves generous
+    headroom (~40%) for concurrent Arrow previews, httpfs read buffers, and untracked
+    allocations so the container isn't cgroup-OOM-killed under load — a query that needs more
+    fails per-query instead of taking down the service."""
 
-    spill_directory: str = "/tmp/ducky-spill"
+    spill_directory: str = "/var/tmp/ducky-spill"
     """Local disk path DuckDB spills to when a query exceeds ``memory_limit`` (out-of-core
-    execution). Must be a real disk (not tmpfs) so spilling relieves memory pressure."""
+    execution). ``/var/tmp`` rather than ``/tmp`` because ``/tmp`` is often tmpfs — spilling
+    there consumes RAM and defeats the point."""
 
     max_concurrent_queries: int = 8
     """How many queries run at once. Each gets its own DuckDB cursor (sharing the instance's

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -5,12 +5,13 @@
 
 DuckDB's ``httpfs`` cannot consume GCP application-default credentials, so GCS is
 reached through the S3-compatible interop API with HMAC keys. R2 and CoreWeave are
-native S3 providers; ducky keys each backend to a distinct URL scheme so a single
-DuckDB ``SECRET`` per backend disambiguates without bucket-level scoping:
+both addressed as ``s3://`` with different endpoints; ducky creates one DuckDB
+``SECRET`` per backend, each S3 secret ``SCOPE``-d to its bucket prefix so DuckDB
+picks the right endpoint per URI:
 
-- ``gs://`` → GCS (HMAC interop key/secret)
-- ``r2://`` → R2 (account id + S3 key/secret)
-- ``s3://`` → CoreWeave object store (endpoint + S3 key/secret)
+- ``gs://``            → GCS (HMAC interop key/secret)
+- ``s3://<r2-bucket>`` → R2 (S3 secret: endpoint + key/secret, scoped)
+- ``s3://<cw-bucket>`` → CoreWeave (S3 secret: endpoint + key/secret, scoped, virtual-host)
 
 Each backend is optional: it is enabled only when its full credential set is
 present, which lets a cred-free smoke deploy query DuckDB built-ins and spill to a
@@ -29,7 +30,7 @@ _ENV_PREFIX = "DUCKY_"
 _BACKEND_ENV = {
     "gcs": {"gcs_hmac_key_id": "DUCKY_GCS_HMAC_KEY_ID", "gcs_hmac_secret": "DUCKY_GCS_HMAC_SECRET"},
     "r2": {
-        "r2_account_id": "DUCKY_R2_ACCOUNT_ID",
+        "r2_endpoint": "DUCKY_R2_ENDPOINT",
         "r2_access_key": "DUCKY_R2_ACCESS_KEY",
         "r2_secret_key": "DUCKY_R2_SECRET_KEY",
     },
@@ -61,16 +62,23 @@ class DuckyConfig:
     # Optional per-backend credentials. A backend is enabled only when its full set is present.
     gcs_hmac_key_id: str | None = None
     gcs_hmac_secret: str | None = None
-    r2_account_id: str | None = None
+    # R2 and CoreWeave are S3-compatible, addressed as s3:// with their own endpoint; the
+    # secret is SCOPE-d to the bucket so DuckDB routes each s3:// URI to the right endpoint.
+    r2_endpoint: str | None = None
     r2_access_key: str | None = None
     r2_secret_key: str | None = None
     cw_endpoint: str | None = None
     cw_access_key: str | None = None
     cw_secret_key: str | None = None
 
+    r2_scope: str = "s3://marin-na"
+    """DuckDB SECRET scope for the R2 backend (the s3:// bucket prefix it serves)."""
+    r2_url_style: str = "path"
+    """S3 addressing for R2: ``path`` (R2 account endpoint serves the bucket in the path)."""
+    cw_scope: str = "s3://marin-us-east-02a"
+    """DuckDB SECRET scope for the CoreWeave backend."""
     cw_url_style: str = "vhost"
-    """S3 addressing for CoreWeave: ``vhost`` (bucket in host) or ``path``. CoreWeave's
-    endpoints reject path-style, so default to virtual-hosted."""
+    """S3 addressing for CoreWeave: ``vhost``. CoreWeave endpoints reject path-style."""
 
     preview_row_cap: int = 10_000
     """Max rows returned inline to the browser. The full result always spills to parquet."""
@@ -94,7 +102,7 @@ class DuckyConfig:
 
     @property
     def r2_enabled(self) -> bool:
-        return bool(self.r2_account_id and self.r2_access_key and self.r2_secret_key)
+        return bool(self.r2_endpoint and self.r2_access_key and self.r2_secret_key)
 
     @property
     def cw_enabled(self) -> bool:
@@ -142,6 +150,9 @@ class DuckyConfig:
             memory_fraction=float(os.environ.get(f"{_ENV_PREFIX}MEMORY_FRACTION", cls.memory_fraction)),
             result_ttl_days=int(os.environ.get(f"{_ENV_PREFIX}RESULT_TTL_DAYS", cls.result_ttl_days)),
             endpoint_name=os.environ.get(f"{_ENV_PREFIX}ENDPOINT_NAME", cls.endpoint_name),
+            r2_scope=os.environ.get(f"{_ENV_PREFIX}R2_SCOPE", cls.r2_scope),
+            r2_url_style=os.environ.get(f"{_ENV_PREFIX}R2_URL_STYLE", cls.r2_url_style),
+            cw_scope=os.environ.get(f"{_ENV_PREFIX}CW_SCOPE", cls.cw_scope),
             cw_url_style=os.environ.get(f"{_ENV_PREFIX}CW_URL_STYLE", cls.cw_url_style),
             **creds,
         )

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -15,7 +15,7 @@ picks the right endpoint per URI:
 
 Each backend is optional: it is enabled only when its full credential set is
 present, which lets a cred-free smoke deploy query DuckDB built-ins and spill to a
-local scratch dir. ``region`` and ``scratch_bucket`` are always required.
+local scratch dir. ``scratch_bucket`` is always required.
 """
 
 from __future__ import annotations
@@ -45,10 +45,6 @@ _BACKEND_ENV = {
 @dataclasses.dataclass(frozen=True)
 class DuckyConfig:
     """Resolved ducky configuration. Construct directly, or via :meth:`from_environment`."""
-
-    region: str
-    """Service region (e.g. ``us-east5``). Operational pin; the same-region guardrail is
-    the allowlist below, since GCS HMAC keys are region-agnostic and can't enforce it."""
 
     scratch_bucket: str
     """Prefix where full results spill (``gs://…`` in prod, a local dir for smoke). Carries a lifecycle TTL rule."""
@@ -82,6 +78,10 @@ class DuckyConfig:
 
     preview_row_cap: int = 10_000
     """Max rows returned inline to the browser. The full result always spills to parquet."""
+
+    max_result_rows: int = 50_000_000
+    """Hard cap on rows written to the spilled result parquet, so a broad ``SELECT *`` can't
+    materialize an unbounded (multi-TB) object to the store. Beyond it the result is truncated."""
 
     memory_fraction: float = 0.6
     """DuckDB ``memory_limit`` = this fraction of host RAM, a hard self-cap. Leaves generous
@@ -134,19 +134,13 @@ class DuckyConfig:
     def from_environment(cls) -> DuckyConfig:
         """Build from ``DUCKY_*`` env vars.
 
-        ``DUCKY_REGION`` and ``DUCKY_SCRATCH_BUCKET`` are required. Each backend's
-        credentials are optional but all-or-nothing: a partially-configured backend
-        raises ``ValueError`` rather than silently disabling itself.
+        ``DUCKY_SCRATCH_BUCKET`` is required. Each backend's credentials are optional but
+        all-or-nothing: a partially-configured backend raises ``ValueError`` rather than
+        silently disabling itself.
         """
-        region = os.environ.get(f"{_ENV_PREFIX}REGION")
         scratch_bucket = os.environ.get(f"{_ENV_PREFIX}SCRATCH_BUCKET")
-        missing = [
-            env_key
-            for env_key, value in [(f"{_ENV_PREFIX}REGION", region), (f"{_ENV_PREFIX}SCRATCH_BUCKET", scratch_bucket)]
-            if not value
-        ]
-        if missing:
-            raise ValueError(f"Missing required ducky env vars: {', '.join(missing)}")
+        if not scratch_bucket:
+            raise ValueError(f"Missing required ducky env var: {_ENV_PREFIX}SCRATCH_BUCKET")
 
         creds: dict[str, str | None] = {}
         for backend, env_map in _BACKEND_ENV.items():
@@ -165,10 +159,10 @@ class DuckyConfig:
         allowed_buckets = tuple(b.strip() for b in allowed.split(",") if b.strip())
 
         return cls(
-            region=region,  # pyrefly: ignore  # non-None after the check above
-            scratch_bucket=scratch_bucket,  # pyrefly: ignore  # non-None after the check above
+            scratch_bucket=scratch_bucket,
             allowed_buckets=allowed_buckets,
             preview_row_cap=int(os.environ.get(f"{_ENV_PREFIX}PREVIEW_ROW_CAP", cls.preview_row_cap)),
+            max_result_rows=int(os.environ.get(f"{_ENV_PREFIX}MAX_RESULT_ROWS", cls.max_result_rows)),
             memory_fraction=float(os.environ.get(f"{_ENV_PREFIX}MEMORY_FRACTION", cls.memory_fraction)),
             max_concurrent_queries=int(
                 os.environ.get(f"{_ENV_PREFIX}MAX_CONCURRENT_QUERIES", cls.max_concurrent_queries)

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -73,6 +73,10 @@ class DuckyConfig:
     port_name: str = "ducky"
     """Iris named port, bound via ``ctx.get_port(port_name)``."""
 
+    endpoint_name: str = "/ducky"
+    """Endpoint registry name. A leading slash registers a cluster-global (non-namespaced)
+    endpoint so the dashboard is reachable at ``/proxy/ducky/`` instead of a per-job path."""
+
     @property
     def gcs_enabled(self) -> bool:
         return bool(self.gcs_hmac_key_id and self.gcs_hmac_secret)
@@ -122,5 +126,6 @@ class DuckyConfig:
             preview_row_cap=int(os.environ.get(f"{_ENV_PREFIX}PREVIEW_ROW_CAP", cls.preview_row_cap)),
             memory_fraction=float(os.environ.get(f"{_ENV_PREFIX}MEMORY_FRACTION", cls.memory_fraction)),
             result_ttl_days=int(os.environ.get(f"{_ENV_PREFIX}RESULT_TTL_DAYS", cls.result_ttl_days)),
+            endpoint_name=os.environ.get(f"{_ENV_PREFIX}ENDPOINT_NAME", cls.endpoint_name),
             **creds,
         )

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -79,10 +79,6 @@ class DuckyConfig:
     preview_row_cap: int = 10_000
     """Max rows returned inline to the browser. The full result always spills to parquet."""
 
-    max_result_rows: int = 50_000_000
-    """Hard cap on rows written to the spilled result parquet, so a broad ``SELECT *`` can't
-    materialize an unbounded (multi-TB) object to the store. Beyond it the result is truncated."""
-
     memory_fraction: float = 0.6
     """DuckDB ``memory_limit`` = this fraction of host RAM, a hard self-cap. Leaves generous
     headroom (~40%) for concurrent Arrow previews, httpfs read buffers, and untracked
@@ -162,7 +158,6 @@ class DuckyConfig:
             scratch_bucket=scratch_bucket,
             allowed_buckets=allowed_buckets,
             preview_row_cap=int(os.environ.get(f"{_ENV_PREFIX}PREVIEW_ROW_CAP", cls.preview_row_cap)),
-            max_result_rows=int(os.environ.get(f"{_ENV_PREFIX}MAX_RESULT_ROWS", cls.max_result_rows)),
             memory_fraction=float(os.environ.get(f"{_ENV_PREFIX}MEMORY_FRACTION", cls.memory_fraction)),
             max_concurrent_queries=int(
                 os.environ.get(f"{_ENV_PREFIX}MAX_CONCURRENT_QUERIES", cls.max_concurrent_queries)

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -84,7 +84,22 @@ class DuckyConfig:
     """Max rows returned inline to the browser. The full result always spills to parquet."""
 
     memory_fraction: float = 0.8
-    """DuckDB ``memory_limit`` = this fraction of host RAM, leaving headroom for Python/Arrow/OS."""
+    """DuckDB ``memory_limit`` = this fraction of host RAM, leaving headroom for Python/Arrow/OS.
+    A hard self-cap: the process won't be OS-OOM-killed; a query needing more fails (and is
+    caught per-query) instead of taking down the service."""
+
+    spill_directory: str = "/tmp/ducky-spill"
+    """Local disk path DuckDB spills to when a query exceeds ``memory_limit`` (out-of-core
+    execution). Must be a real disk (not tmpfs) so spilling relieves memory pressure."""
+
+    max_concurrent_queries: int = 8
+    """How many queries run at once. Each gets its own DuckDB cursor (sharing the instance's
+    secrets/settings); they share the host's thread pool and memory budget."""
+
+    query_timeout: int = 600
+    """Hard per-query wall-clock limit (seconds). A query exceeding it is interrupted and
+    fails — so a runaway (e.g. a recursive glob over millions of objects) frees its slot
+    instead of holding it forever."""
 
     result_ttl_days: int = 7
     """Informational — enforced by the scratch bucket's lifecycle rule, not by ducky (ducky only writes)."""
@@ -148,6 +163,11 @@ class DuckyConfig:
             allowed_buckets=allowed_buckets,
             preview_row_cap=int(os.environ.get(f"{_ENV_PREFIX}PREVIEW_ROW_CAP", cls.preview_row_cap)),
             memory_fraction=float(os.environ.get(f"{_ENV_PREFIX}MEMORY_FRACTION", cls.memory_fraction)),
+            max_concurrent_queries=int(
+                os.environ.get(f"{_ENV_PREFIX}MAX_CONCURRENT_QUERIES", cls.max_concurrent_queries)
+            ),
+            spill_directory=os.environ.get(f"{_ENV_PREFIX}SPILL_DIR", cls.spill_directory),
+            query_timeout=int(os.environ.get(f"{_ENV_PREFIX}QUERY_TIMEOUT", cls.query_timeout)),
             result_ttl_days=int(os.environ.get(f"{_ENV_PREFIX}RESULT_TTL_DAYS", cls.result_ttl_days)),
             endpoint_name=os.environ.get(f"{_ENV_PREFIX}ENDPOINT_NAME", cls.endpoint_name),
             r2_scope=os.environ.get(f"{_ENV_PREFIX}R2_SCOPE", cls.r2_scope),

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -42,6 +42,13 @@ _BACKEND_ENV = {
 }
 
 
+# Fixed Iris identifiers (not configurable): the named port ducky binds/publishes, and the
+# cluster-global endpoint it registers — the leading slash makes it reachable at
+# ``/proxy/ducky/`` rather than a per-job path.
+PORT_NAME = "ducky"
+ENDPOINT_NAME = "/ducky"
+
+
 @dataclasses.dataclass(frozen=True)
 class DuckyConfig:
     """Resolved ducky configuration. Construct directly, or via :meth:`from_environment`."""
@@ -69,12 +76,8 @@ class DuckyConfig:
 
     r2_scope: str = "s3://marin-na"
     """DuckDB SECRET scope for the R2 backend (the s3:// bucket prefix it serves)."""
-    r2_url_style: str = "path"
-    """S3 addressing for R2: ``path`` (R2 account endpoint serves the bucket in the path)."""
     cw_scope: str = "s3://marin-us-east-02a"
     """DuckDB SECRET scope for the CoreWeave backend."""
-    cw_url_style: str = "vhost"
-    """S3 addressing for CoreWeave: ``vhost``. CoreWeave endpoints reject path-style."""
 
     preview_row_cap: int = 10_000
     """Max rows returned inline to the browser. The full result always spills to parquet."""
@@ -106,13 +109,6 @@ class DuckyConfig:
 
     result_ttl_days: int = 7
     """Informational — enforced by the scratch bucket's lifecycle rule, not by ducky (ducky only writes)."""
-
-    port_name: str = "ducky"
-    """Iris named port, bound via ``ctx.get_port(port_name)``."""
-
-    endpoint_name: str = "/ducky"
-    """Endpoint registry name. A leading slash registers a cluster-global (non-namespaced)
-    endpoint so the dashboard is reachable at ``/proxy/ducky/`` instead of a per-job path."""
 
     @property
     def gcs_enabled(self) -> bool:
@@ -166,10 +162,7 @@ class DuckyConfig:
             spill_limit=os.environ.get(f"{_ENV_PREFIX}SPILL_LIMIT", cls.spill_limit),
             query_timeout=int(os.environ.get(f"{_ENV_PREFIX}QUERY_TIMEOUT", cls.query_timeout)),
             result_ttl_days=int(os.environ.get(f"{_ENV_PREFIX}RESULT_TTL_DAYS", cls.result_ttl_days)),
-            endpoint_name=os.environ.get(f"{_ENV_PREFIX}ENDPOINT_NAME", cls.endpoint_name),
             r2_scope=os.environ.get(f"{_ENV_PREFIX}R2_SCOPE", cls.r2_scope),
-            r2_url_style=os.environ.get(f"{_ENV_PREFIX}R2_URL_STYLE", cls.r2_url_style),
             cw_scope=os.environ.get(f"{_ENV_PREFIX}CW_SCOPE", cls.cw_scope),
-            cw_url_style=os.environ.get(f"{_ENV_PREFIX}CW_URL_STYLE", cls.cw_url_style),
             **creds,
         )

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -61,6 +61,10 @@ class DuckyConfig:
     cw_access_key: str | None = None
     cw_secret_key: str | None = None
 
+    cw_url_style: str = "vhost"
+    """S3 addressing for CoreWeave: ``vhost`` (bucket in host) or ``path``. CoreWeave's
+    endpoints reject path-style, so default to virtual-hosted."""
+
     preview_row_cap: int = 10_000
     """Max rows returned inline to the browser. The full result always spills to parquet."""
 
@@ -127,5 +131,6 @@ class DuckyConfig:
             memory_fraction=float(os.environ.get(f"{_ENV_PREFIX}MEMORY_FRACTION", cls.memory_fraction)),
             result_ttl_days=int(os.environ.get(f"{_ENV_PREFIX}RESULT_TTL_DAYS", cls.result_ttl_days)),
             endpoint_name=os.environ.get(f"{_ENV_PREFIX}ENDPOINT_NAME", cls.endpoint_name),
+            cw_url_style=os.environ.get(f"{_ENV_PREFIX}CW_URL_STYLE", cls.cw_url_style),
             **creds,
         )

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -94,6 +94,11 @@ class DuckyConfig:
     execution). ``/var/tmp`` rather than ``/tmp`` because ``/tmp`` is often tmpfs — spilling
     there consumes RAM and defeats the point."""
 
+    spill_limit: str = "60GB"
+    """Cap on DuckDB's on-disk spill (``max_temp_directory_size``). Bounded well under the
+    ~100 GB boot disk so a runaway spill fails *that query* cleanly instead of filling the
+    disk and crashing the whole container."""
+
     max_concurrent_queries: int = 8
     """How many queries run at once. Each gets its own DuckDB cursor (sharing the instance's
     secrets/settings); they share the host's thread pool and memory budget."""
@@ -169,6 +174,7 @@ class DuckyConfig:
                 os.environ.get(f"{_ENV_PREFIX}MAX_CONCURRENT_QUERIES", cls.max_concurrent_queries)
             ),
             spill_directory=os.environ.get(f"{_ENV_PREFIX}SPILL_DIR", cls.spill_directory),
+            spill_limit=os.environ.get(f"{_ENV_PREFIX}SPILL_LIMIT", cls.spill_limit),
             query_timeout=int(os.environ.get(f"{_ENV_PREFIX}QUERY_TIMEOUT", cls.query_timeout)),
             result_ttl_days=int(os.environ.get(f"{_ENV_PREFIX}RESULT_TTL_DAYS", cls.result_ttl_days)),
             endpoint_name=os.environ.get(f"{_ENV_PREFIX}ENDPOINT_NAME", cls.endpoint_name),

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -11,6 +11,10 @@ DuckDB ``SECRET`` per backend disambiguates without bucket-level scoping:
 - ``gs://`` → GCS (HMAC interop key/secret)
 - ``r2://`` → R2 (account id + S3 key/secret)
 - ``s3://`` → CoreWeave object store (endpoint + S3 key/secret)
+
+Each backend is optional: it is enabled only when its full credential set is
+present, which lets a cred-free smoke deploy query DuckDB built-ins and spill to a
+local scratch dir. ``region`` and ``scratch_bucket`` are always required.
 """
 
 from __future__ import annotations
@@ -19,6 +23,22 @@ import dataclasses
 import os
 
 _ENV_PREFIX = "DUCKY_"
+
+# field name -> env var, grouped per backend. A backend is enabled iff every var in
+# its group is set; a partially-set group is a misconfiguration (raises).
+_BACKEND_ENV = {
+    "gcs": {"gcs_hmac_key_id": "DUCKY_GCS_HMAC_KEY_ID", "gcs_hmac_secret": "DUCKY_GCS_HMAC_SECRET"},
+    "r2": {
+        "r2_account_id": "DUCKY_R2_ACCOUNT_ID",
+        "r2_access_key": "DUCKY_R2_ACCESS_KEY",
+        "r2_secret_key": "DUCKY_R2_SECRET_KEY",
+    },
+    "cw": {
+        "cw_endpoint": "DUCKY_CW_ENDPOINT",
+        "cw_access_key": "DUCKY_CW_ACCESS_KEY",
+        "cw_secret_key": "DUCKY_CW_SECRET_KEY",
+    },
+}
 
 
 @dataclasses.dataclass(frozen=True)
@@ -29,16 +49,17 @@ class DuckyConfig:
     """Service region (e.g. ``us-east5``). Operational pin only; not enforced in the runner."""
 
     scratch_bucket: str
-    """``gs://`` prefix where full results spill. Lives in ``region``; carries a lifecycle TTL rule."""
+    """Prefix where full results spill (``gs://…`` in prod, a local dir for smoke). Carries a lifecycle TTL rule."""
 
-    gcs_hmac_key_id: str
-    gcs_hmac_secret: str
-    r2_account_id: str
-    r2_access_key: str
-    r2_secret_key: str
-    cw_endpoint: str
-    cw_access_key: str
-    cw_secret_key: str
+    # Optional per-backend credentials. A backend is enabled only when its full set is present.
+    gcs_hmac_key_id: str | None = None
+    gcs_hmac_secret: str | None = None
+    r2_account_id: str | None = None
+    r2_access_key: str | None = None
+    r2_secret_key: str | None = None
+    cw_endpoint: str | None = None
+    cw_access_key: str | None = None
+    cw_secret_key: str | None = None
 
     preview_row_cap: int = 10_000
     """Max rows returned inline to the browser. The full result always spills to parquet."""
@@ -52,29 +73,54 @@ class DuckyConfig:
     port_name: str = "ducky"
     """Iris named port, bound via ``ctx.get_port(port_name)``."""
 
+    @property
+    def gcs_enabled(self) -> bool:
+        return bool(self.gcs_hmac_key_id and self.gcs_hmac_secret)
+
+    @property
+    def r2_enabled(self) -> bool:
+        return bool(self.r2_account_id and self.r2_access_key and self.r2_secret_key)
+
+    @property
+    def cw_enabled(self) -> bool:
+        return bool(self.cw_endpoint and self.cw_access_key and self.cw_secret_key)
+
     @classmethod
     def from_environment(cls) -> DuckyConfig:
-        """Build from ``DUCKY_*`` env vars. Raise ``ValueError`` listing any missing required keys."""
-        required = {
-            "region": "DUCKY_REGION",
-            "scratch_bucket": "DUCKY_SCRATCH_BUCKET",
-            "gcs_hmac_key_id": "DUCKY_GCS_HMAC_KEY_ID",
-            "gcs_hmac_secret": "DUCKY_GCS_HMAC_SECRET",
-            "r2_account_id": "DUCKY_R2_ACCOUNT_ID",
-            "r2_access_key": "DUCKY_R2_ACCESS_KEY",
-            "r2_secret_key": "DUCKY_R2_SECRET_KEY",
-            "cw_endpoint": "DUCKY_CW_ENDPOINT",
-            "cw_access_key": "DUCKY_CW_ACCESS_KEY",
-            "cw_secret_key": "DUCKY_CW_SECRET_KEY",
-        }
-        values = {field: os.environ.get(env_key) for field, env_key in required.items()}
-        missing = [required[field] for field, value in values.items() if not value]
+        """Build from ``DUCKY_*`` env vars.
+
+        ``DUCKY_REGION`` and ``DUCKY_SCRATCH_BUCKET`` are required. Each backend's
+        credentials are optional but all-or-nothing: a partially-configured backend
+        raises ``ValueError`` rather than silently disabling itself.
+        """
+        region = os.environ.get(f"{_ENV_PREFIX}REGION")
+        scratch_bucket = os.environ.get(f"{_ENV_PREFIX}SCRATCH_BUCKET")
+        missing = [
+            env_key
+            for env_key, value in [(f"{_ENV_PREFIX}REGION", region), (f"{_ENV_PREFIX}SCRATCH_BUCKET", scratch_bucket)]
+            if not value
+        ]
         if missing:
-            raise ValueError(f"Missing required ducky env vars: {', '.join(sorted(missing))}")
+            raise ValueError(f"Missing required ducky env vars: {', '.join(missing)}")
+
+        creds: dict[str, str | None] = {}
+        for backend, env_map in _BACKEND_ENV.items():
+            present = {field: os.environ.get(env_key) for field, env_key in env_map.items()}
+            set_count = sum(1 for value in present.values() if value)
+            if set_count == 0:
+                creds.update(dict.fromkeys(env_map, None))
+            elif set_count == len(env_map):
+                creds.update(present)
+            else:
+                raise ValueError(
+                    f"Backend {backend!r} is partially configured; set all or none of {list(env_map.values())}"
+                )
 
         return cls(
+            region=region,  # pyrefly: ignore  # non-None after the check above
+            scratch_bucket=scratch_bucket,  # pyrefly: ignore  # non-None after the check above
             preview_row_cap=int(os.environ.get(f"{_ENV_PREFIX}PREVIEW_ROW_CAP", cls.preview_row_cap)),
             memory_fraction=float(os.environ.get(f"{_ENV_PREFIX}MEMORY_FRACTION", cls.memory_fraction)),
             result_ttl_days=int(os.environ.get(f"{_ENV_PREFIX}RESULT_TTL_DAYS", cls.result_ttl_days)),
-            **values,  # pyrefly: ignore  # required keys are non-None after the check above
+            **creds,
         )

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -46,10 +46,17 @@ class DuckyConfig:
     """Resolved ducky configuration. Construct directly, or via :meth:`from_environment`."""
 
     region: str
-    """Service region (e.g. ``us-east5``). Operational pin only; not enforced in the runner."""
+    """Service region (e.g. ``us-east5``). Operational pin; the same-region guardrail is
+    the allowlist below, since GCS HMAC keys are region-agnostic and can't enforce it."""
 
     scratch_bucket: str
     """Prefix where full results spill (``gs://…`` in prod, a local dir for smoke). Carries a lifecycle TTL rule."""
+
+    allowed_buckets: tuple[str, ...] = ()
+    """Object-store URI prefixes a query may read, e.g. ``("gs://marin-us-east5", "r2://")``.
+    A query referencing a ``gs://``/``s3://``/``r2://`` URI outside the allowlist is refused
+    before execution — the same-region guardrail. Empty disables enforcement (allow all).
+    Catches literal URIs in the SQL, not paths hidden behind views/macros."""
 
     # Optional per-backend credentials. A backend is enabled only when its full set is present.
     gcs_hmac_key_id: str | None = None
@@ -124,9 +131,13 @@ class DuckyConfig:
                     f"Backend {backend!r} is partially configured; set all or none of {list(env_map.values())}"
                 )
 
+        allowed = os.environ.get(f"{_ENV_PREFIX}ALLOWED_BUCKETS", "")
+        allowed_buckets = tuple(b.strip() for b in allowed.split(",") if b.strip())
+
         return cls(
             region=region,  # pyrefly: ignore  # non-None after the check above
             scratch_bucket=scratch_bucket,  # pyrefly: ignore  # non-None after the check above
+            allowed_buckets=allowed_buckets,
             preview_row_cap=int(os.environ.get(f"{_ENV_PREFIX}PREVIEW_ROW_CAP", cls.preview_row_cap)),
             memory_fraction=float(os.environ.get(f"{_ENV_PREFIX}MEMORY_FRACTION", cls.memory_fraction)),
             result_ttl_days=int(os.environ.get(f"{_ENV_PREFIX}RESULT_TTL_DAYS", cls.result_ttl_days)),

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -29,6 +29,7 @@ from iris.cluster.constraints import region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_device
 from iris.rpc import job_pb2
 
+from ducky.config import PORT_NAME
 from ducky.tunnel import cluster_tunnel
 
 logger = logging.getLogger(__name__)
@@ -44,12 +45,6 @@ DASHBOARD_DIR = Path(__file__).resolve().parents[2] / "dashboard"
 DEFAULT_TPU = "v6e-4"
 DEFAULT_CPU = 180.0
 DEFAULT_MEMORY = "690GB"
-
-# The Iris named port and endpoint name the server binds/registers. Must match
-# DuckyConfig.port_name (the server calls ctx.get_port(config.port_name)), and is
-# independent of the job --name. The dashboard resolves to the namespaced endpoint
-# wire name "<job-namespace>/ducky" through the controller proxy.
-PORT_NAME = "ducky"
 
 
 def _ducky_env_vars() -> dict[str, str]:

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -27,6 +27,7 @@ import click
 from iris.client.client import IrisClient, Job
 from iris.cluster.constraints import region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_device
+from iris.rpc import job_pb2
 
 from ducky.tunnel import cluster_tunnel
 
@@ -56,6 +57,14 @@ def _ducky_env_vars() -> dict[str, str]:
     return {key: value for key, value in os.environ.items() if key.startswith("DUCKY_")}
 
 
+# "Effectively unlimited" retry ceiling. Iris has no infinite sentinel and its retry
+# budgets are lifetime totals that never reset, so a long-lived service must set a bound
+# so large it can't realistically exhaust. Each retry is paced by VM boot / capacity (not a
+# tight loop), so a huge value doesn't hot-loop; a permanently-broken deploy is caught by
+# CI and the redeploy watchdog, not by letting the job die.
+_EFFECTIVELY_UNLIMITED_RETRIES = 1_000_000
+
+
 def submit_ducky(
     client: IrisClient,
     *,
@@ -65,8 +74,18 @@ def submit_ducky(
     cpu: float,
     memory: str,
     env_vars: dict[str, str],
+    existing_job_policy: job_pb2.ExistingJobPolicy = job_pb2.EXISTING_JOB_POLICY_RECREATE,
 ) -> Job:
-    """Submit the ducky service job: a region-pinned, port-publishing, always-on job."""
+    """Submit the ducky service job: a region-pinned, port-publishing, best-effort-always-on job.
+
+    Best-effort-always-up rests on three layers: the in-process supervisor restarts the
+    server on an in-container crash/OOM (no Iris budget spent); Iris task retries bring the
+    task back if the whole container dies or the VM is preempted; and all three budgets are
+    set effectively unlimited so neither preemptions nor failures ever terminate the job.
+    ``max_task_failures`` is the critical one — it's a job-level cumulative budget that
+    defaults to 0, so a single hard container failure would otherwise fail the whole job
+    regardless of the per-task retry budget.
+    """
     device = tpu_device(tpu) if tpu else None
     return client.submit(
         entrypoint=Entrypoint.from_command("python", "-m", "ducky.server"),
@@ -75,11 +94,10 @@ def submit_ducky(
         environment=EnvironmentSpec(env_vars=env_vars),
         ports=[PORT_NAME],
         constraints=[region_constraint([region])],
-        # Always-on: ride out preemptions, and also failures — the in-process supervisor
-        # restarts the server on an OOM, but if the whole container is cgroup-killed this
-        # lets Iris bring the task back instead of leaving the service down.
-        max_retries_preemption=1000,
-        max_retries_failure=1000,
+        max_retries_preemption=_EFFECTIVELY_UNLIMITED_RETRIES,  # never let preemptions end the service
+        max_retries_failure=_EFFECTIVELY_UNLIMITED_RETRIES,  # per-task budget for whole-container deaths
+        max_task_failures=_EFFECTIVELY_UNLIMITED_RETRIES,  # job-level cumulative budget (defaults to 0!)
+        existing_job_policy=existing_job_policy,
     )
 
 
@@ -121,6 +139,11 @@ def _build_dashboard() -> None:
 @click.option("--cpu", default=DEFAULT_CPU, show_default=True, type=float, help="CPUs to request.")
 @click.option("--memory", default=DEFAULT_MEMORY, show_default=True, help="Memory to request (e.g. 16GB).")
 @click.option("--skip-build", is_flag=True, help="Skip the dashboard `npm run build` (use an already-built dist).")
+@click.option(
+    "--keep",
+    is_flag=True,
+    help="Idempotent (watchdog) mode: keep a running instance untouched, only (re)create if it's gone/terminal.",
+)
 def cli(
     cluster: str | None,
     controller_url: str | None,
@@ -130,11 +153,14 @@ def cli(
     cpu: float,
     memory: str,
     skip_build: bool,
+    keep: bool,
 ) -> None:
-    """Submit the always-on ducky service to an Iris cluster.
+    """Submit the best-effort-always-on ducky service to an Iris cluster.
 
     Pass ``--cluster <name>`` to auto-open a controller tunnel, or ``--controller-url``
-    to target one you already have.
+    to target one you already have. By default a running instance is replaced (RECREATE);
+    ``--keep`` leaves a healthy instance alone and only recreates a gone/terminal one — run
+    it on a schedule as a watchdog so the service comes back if its Iris job is ever lost.
     """
     logging.basicConfig(level=logging.INFO)
     if cluster and controller_url:
@@ -148,9 +174,20 @@ def cli(
     if not skip_build:
         _build_dashboard()
 
+    policy = job_pb2.EXISTING_JOB_POLICY_KEEP if keep else job_pb2.EXISTING_JOB_POLICY_RECREATE
+
     def _submit(url: str) -> None:
         client = IrisClient.remote(url, workspace=Path.cwd())
-        job = submit_ducky(client, name=name, region=region, tpu=tpu, cpu=cpu, memory=memory, env_vars=env_vars)
+        job = submit_ducky(
+            client,
+            name=name,
+            region=region,
+            tpu=tpu,
+            cpu=cpu,
+            memory=memory,
+            env_vars=env_vars,
+            existing_job_policy=policy,
+        )
         logger.info(
             "submitted ducky job %s (endpoint %r) — reachable via the controller endpoint proxy once running",
             job.job_id,

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -21,12 +21,13 @@ from pathlib import Path
 
 import click
 from iris.cli.connect import IRIS_CLUSTER_CONFIG_DIRS
-from iris.cli.main import create_client_token_provider
 from iris.client.client import IrisClient, Job
 from iris.cluster.config import IrisConfig
 from iris.cluster.constraints import region_constraint
+from iris.cluster.token_store import load_any_token, load_token
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_device
-from iris.rpc.auth import TokenProvider
+from iris.rpc import config_pb2
+from iris.rpc.auth import GcpAccessTokenProvider, StaticTokenProvider, TokenProvider
 from rigging.config_discovery import resolve_cluster_config
 
 logger = logging.getLogger(__name__)
@@ -51,6 +52,27 @@ def _ducky_env_vars() -> dict[str, str]:
     return {key: value for key, value in os.environ.items() if key.startswith("DUCKY_")}
 
 
+def _token_provider(auth_config: config_pb2.AuthConfig, cluster_name: str) -> TokenProvider | None:
+    """Build a client TokenProvider for a cluster: a stored `iris login` JWT, else the config's auth method.
+
+    Mirrors the CLI's token resolution without importing the CLI module.
+    """
+    credential = load_token(cluster_name) or load_any_token()
+    if credential is not None:
+        return StaticTokenProvider(credential.token)
+    provider = auth_config.WhichOneof("provider")
+    if provider is None:
+        return None
+    if provider == "gcp":
+        return GcpAccessTokenProvider()
+    if provider == "static":
+        tokens = dict(auth_config.static.tokens)
+        if not tokens:
+            raise ValueError("Static auth config requires at least one token")
+        return StaticTokenProvider(next(iter(tokens)))
+    raise ValueError(f"Unknown auth provider: {provider}")
+
+
 @contextmanager
 def _controller_connection(
     cluster: str | None, controller_url: str | None
@@ -70,7 +92,7 @@ def _controller_connection(
     config_file = resolve_cluster_config(cluster, dirs=IRIS_CLUSTER_CONFIG_DIRS)
     iris_config = IrisConfig.load(str(config_file))
     proto = iris_config.proto
-    token_provider = create_client_token_provider(proto.auth, cluster_name=cluster) if proto.HasField("auth") else None
+    token_provider = _token_provider(proto.auth, cluster) if proto.HasField("auth") else None
     bundle = iris_config.provider_bundle()
     controller_address = iris_config.controller_address() or bundle.controller.discover_controller(proto.controller)
     logger.info("Tunneling to %s controller at %s", cluster, controller_address)

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -1,0 +1,71 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Deploy ducky as an always-on Iris job.
+
+A routable service needs a *named* Iris port, which ``iris job run`` cannot declare
+(no ``--ports`` flag). So deploy goes through the Python submit path
+(``client.submit(..., ports=["ducky"])``), the same mechanism the actor worker pool
+uses. The job is pinned to a single region and grabs a whole v6e-8 host; the
+``DUCKY_*`` credential/scratch env vars are forwarded to the task.
+"""
+
+from __future__ import annotations
+
+import logging
+import os
+from pathlib import Path
+
+import click
+from iris.client.client import IrisClient
+from iris.cluster.constraints import region_constraint
+from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_device
+
+logger = logging.getLogger(__name__)
+
+# A single v6e-8 host (ct6e-standard-8t). DuckDB runs on CPU/RAM only — the TPU sits
+# idle; we request the slice to grab the host's large CPU/RAM envelope exclusively.
+# TODO(ducky): confirm the exact host vCPU/RAM so the request schedules and gets the
+# whole host (over-request → never schedules; under-request → DuckDB capped below host).
+TPU_VARIANT = "v6e-8"
+ALL_CPU = 180.0
+ALL_MEMORY = "1400GB"
+
+
+def _ducky_env_vars() -> dict[str, str]:
+    """Forward all DUCKY_* env vars from this process to the task."""
+    return {key: value for key, value in os.environ.items() if key.startswith("DUCKY_")}
+
+
+@click.command()
+@click.option(
+    "--controller-url",
+    default=lambda: os.environ.get("IRIS_CONTROLLER_URL"),
+    required=True,
+    help="Iris controller URL (default: $IRIS_CONTROLLER_URL).",
+)
+@click.option("--region", default="us-east5", show_default=True, help="Region to pin the job to.")
+@click.option("--name", default="ducky", show_default=True, help="Job name.")
+def cli(controller_url: str, region: str, name: str) -> None:
+    """Submit the always-on ducky service to an Iris cluster."""
+    logging.basicConfig(level=logging.INFO)
+    env_vars = _ducky_env_vars()
+    if "DUCKY_SCRATCH_BUCKET" not in env_vars:
+        raise click.UsageError("DUCKY_* env vars not set — export ducky config before deploying.")
+
+    client = IrisClient.remote(controller_url, workspace=Path.cwd())
+    job = client.submit(
+        entrypoint=Entrypoint.from_command("python", "-m", "ducky.server"),
+        name=name,
+        resources=ResourceSpec(cpu=ALL_CPU, memory=ALL_MEMORY, device=tpu_device(TPU_VARIANT)),
+        environment=EnvironmentSpec(env_vars=env_vars),
+        ports=[name],
+        constraints=[region_constraint([region])],
+        # Always-on: ride out preemptions rather than exiting.
+        max_retries_preemption=1000,
+    )
+    logger.info("submitted ducky job %s — reachable at /proxy/%s/ once running", job.job_id, name)
+
+
+if __name__ == "__main__":
+    cli()

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -35,6 +35,10 @@ from ducky.tunnel import cluster_tunnel
 logger = logging.getLogger(__name__)
 
 DASHBOARD_DIR = Path(__file__).resolve().parents[2] / "dashboard"
+# The built SPA is gitignored; this glob (relative to the workspace root) tells the Iris
+# bundle to ship it to the worker anyway. Owning it here keeps ducky-specific paths out of
+# Iris's bundler.
+DASHBOARD_DIST_INCLUDE = "lib/ducky/dashboard/dist/**/*"
 
 # Prod default: a single ct6e-standard-4t v6e host — 180 vCPU / 720 GB advertised,
 # ~700 GB allocatable after system reservation. DuckDB runs on CPU/RAM only (the v6e
@@ -172,7 +176,7 @@ def cli(
     policy = job_pb2.EXISTING_JOB_POLICY_KEEP if keep else job_pb2.EXISTING_JOB_POLICY_RECREATE
 
     def _submit(url: str) -> None:
-        client = IrisClient.remote(url, workspace=Path.cwd())
+        client = IrisClient.remote(url, workspace=Path.cwd(), extra_bundle_includes=[DASHBOARD_DIST_INCLUDE])
         job = submit_ducky(
             client,
             name=name,

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -9,26 +9,22 @@ A routable service needs a *named* Iris port, which ``iris job run`` cannot decl
 uses. The job is pinned to a single region and grabs a whole v6e-8 host (or a
 smaller CPU-only shape for a smoke); the ``DUCKY_*`` config env vars are forwarded
 to the task.
+
+Connect to the controller by passing ``--controller-url`` (e.g. a tunnel opened by
+``iris --cluster=<name> ...``). Deploy keeps no cluster-resolution/auth logic of its
+own — that lives in the iris CLI.
 """
 
 from __future__ import annotations
 
 import logging
 import os
-from collections.abc import Generator
-from contextlib import contextmanager
 from pathlib import Path
 
 import click
-from iris.cli.connect import IRIS_CLUSTER_CONFIG_DIRS
 from iris.client.client import IrisClient, Job
-from iris.cluster.config import IrisConfig
 from iris.cluster.constraints import region_constraint
-from iris.cluster.token_store import load_any_token, load_token
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_device
-from iris.rpc import config_pb2
-from iris.rpc.auth import GcpAccessTokenProvider, StaticTokenProvider, TokenProvider
-from rigging.config_discovery import resolve_cluster_config
 
 logger = logging.getLogger(__name__)
 
@@ -50,54 +46,6 @@ PORT_NAME = "ducky"
 def _ducky_env_vars() -> dict[str, str]:
     """Forward all DUCKY_* env vars from this process to the task."""
     return {key: value for key, value in os.environ.items() if key.startswith("DUCKY_")}
-
-
-def _token_provider(auth_config: config_pb2.AuthConfig, cluster_name: str) -> TokenProvider | None:
-    """Build a client TokenProvider for a cluster: a stored `iris login` JWT, else the config's auth method.
-
-    Mirrors the CLI's token resolution without importing the CLI module.
-    """
-    credential = load_token(cluster_name) or load_any_token()
-    if credential is not None:
-        return StaticTokenProvider(credential.token)
-    provider = auth_config.WhichOneof("provider")
-    if provider is None:
-        return None
-    if provider == "gcp":
-        return GcpAccessTokenProvider()
-    if provider == "static":
-        tokens = dict(auth_config.static.tokens)
-        if not tokens:
-            raise ValueError("Static auth config requires at least one token")
-        return StaticTokenProvider(next(iter(tokens)))
-    raise ValueError(f"Unknown auth provider: {provider}")
-
-
-@contextmanager
-def _controller_connection(
-    cluster: str | None, controller_url: str | None
-) -> Generator[tuple[str, TokenProvider | None]]:
-    """Yield ``(controller_url, token_provider)``, tunneling to a named cluster if needed.
-
-    Mirrors ``iris.cli.connect.require_controller_url``: a direct ``--controller-url``
-    is used as-is; otherwise ``--cluster`` is resolved to its config, authenticated,
-    and tunneled for the duration of the submit.
-    """
-    if controller_url:
-        yield controller_url, None
-        return
-    if not cluster:
-        raise click.UsageError("Pass --cluster <name> or --controller-url.")
-
-    config_file = resolve_cluster_config(cluster, dirs=IRIS_CLUSTER_CONFIG_DIRS)
-    iris_config = IrisConfig.load(str(config_file))
-    proto = iris_config.proto
-    token_provider = _token_provider(proto.auth, cluster) if proto.HasField("auth") else None
-    bundle = iris_config.provider_bundle()
-    controller_address = iris_config.controller_address() or bundle.controller.discover_controller(proto.controller)
-    logger.info("Tunneling to %s controller at %s", cluster, controller_address)
-    with bundle.controller.tunnel(address=controller_address) as tunnel_url:
-        yield tunnel_url, token_provider
 
 
 def submit_ducky(
@@ -125,11 +73,11 @@ def submit_ducky(
 
 
 @click.command()
-@click.option("--cluster", default=None, help="Named Iris cluster to deploy to (resolves config + tunnels).")
 @click.option(
     "--controller-url",
     default=lambda: os.environ.get("IRIS_CONTROLLER_URL"),
-    help="Direct controller URL (alternative to --cluster; default $IRIS_CONTROLLER_URL).",
+    required=True,
+    help="Iris controller URL, e.g. a tunnel from `iris --cluster=<name>` (default $IRIS_CONTROLLER_URL).",
 )
 @click.option("--region", default="us-east5", show_default=True, help="Region to pin the job to.")
 @click.option("--name", default="ducky", show_default=True, help="Job name.")
@@ -141,18 +89,15 @@ def submit_ducky(
 )
 @click.option("--cpu", default=DEFAULT_CPU, show_default=True, type=float, help="CPUs to request.")
 @click.option("--memory", default=DEFAULT_MEMORY, show_default=True, help="Memory to request (e.g. 16GB).")
-def cli(
-    cluster: str | None, controller_url: str | None, region: str, name: str, tpu: str, cpu: float, memory: str
-) -> None:
+def cli(controller_url: str, region: str, name: str, tpu: str, cpu: float, memory: str) -> None:
     """Submit the always-on ducky service to an Iris cluster."""
     logging.basicConfig(level=logging.INFO)
     env_vars = _ducky_env_vars()
     if "DUCKY_SCRATCH_BUCKET" not in env_vars:
         raise click.UsageError("DUCKY_* env vars not set — export ducky config before deploying.")
 
-    with _controller_connection(cluster, controller_url) as (url, token_provider):
-        client = IrisClient.remote(url, workspace=Path.cwd(), token_provider=token_provider)
-        job = submit_ducky(client, name=name, region=region, tpu=tpu, cpu=cpu, memory=memory, env_vars=env_vars)
+    client = IrisClient.remote(controller_url, workspace=Path.cwd())
+    job = submit_ducky(client, name=name, region=region, tpu=tpu, cpu=cpu, memory=memory, env_vars=env_vars)
     logger.info(
         "submitted ducky job %s (endpoint %r) — reachable via the controller endpoint proxy once running",
         job.job_id,

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -28,6 +28,8 @@ from iris.client.client import IrisClient, Job
 from iris.cluster.constraints import region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_device
 
+from ducky.tunnel import cluster_tunnel
+
 logger = logging.getLogger(__name__)
 
 DASHBOARD_DIR = Path(__file__).resolve().parents[2] / "dashboard"
@@ -99,10 +101,14 @@ def _build_dashboard() -> None:
 
 @click.command()
 @click.option(
+    "--cluster",
+    default=None,
+    help="Iris cluster to auto-tunnel to (opens `iris cluster dashboard`); exclusive with --controller-url.",
+)
+@click.option(
     "--controller-url",
     default=lambda: os.environ.get("IRIS_CONTROLLER_URL"),
-    required=True,
-    help="Iris controller URL, e.g. a tunnel from `iris --cluster=<name>` (default $IRIS_CONTROLLER_URL).",
+    help="Explicit Iris controller URL (default $IRIS_CONTROLLER_URL); mutually exclusive with --cluster.",
 )
 @click.option("--region", default="us-east5", show_default=True, help="Region to pin the job to.")
 @click.option("--name", default="ducky", show_default=True, help="Job name.")
@@ -115,9 +121,26 @@ def _build_dashboard() -> None:
 @click.option("--cpu", default=DEFAULT_CPU, show_default=True, type=float, help="CPUs to request.")
 @click.option("--memory", default=DEFAULT_MEMORY, show_default=True, help="Memory to request (e.g. 16GB).")
 @click.option("--skip-build", is_flag=True, help="Skip the dashboard `npm run build` (use an already-built dist).")
-def cli(controller_url: str, region: str, name: str, tpu: str, cpu: float, memory: str, skip_build: bool) -> None:
-    """Submit the always-on ducky service to an Iris cluster."""
+def cli(
+    cluster: str | None,
+    controller_url: str | None,
+    region: str,
+    name: str,
+    tpu: str,
+    cpu: float,
+    memory: str,
+    skip_build: bool,
+) -> None:
+    """Submit the always-on ducky service to an Iris cluster.
+
+    Pass ``--cluster <name>`` to auto-open a controller tunnel, or ``--controller-url``
+    to target one you already have.
+    """
     logging.basicConfig(level=logging.INFO)
+    if cluster and controller_url:
+        raise click.UsageError("Pass --cluster or --controller-url, not both.")
+    if not cluster and not controller_url:
+        raise click.UsageError("Pass --cluster <name> to auto-tunnel, or --controller-url <url>.")
     env_vars = _ducky_env_vars()
     if "DUCKY_SCRATCH_BUCKET" not in env_vars:
         raise click.UsageError("DUCKY_* env vars not set — export ducky config before deploying.")
@@ -125,13 +148,21 @@ def cli(controller_url: str, region: str, name: str, tpu: str, cpu: float, memor
     if not skip_build:
         _build_dashboard()
 
-    client = IrisClient.remote(controller_url, workspace=Path.cwd())
-    job = submit_ducky(client, name=name, region=region, tpu=tpu, cpu=cpu, memory=memory, env_vars=env_vars)
-    logger.info(
-        "submitted ducky job %s (endpoint %r) — reachable via the controller endpoint proxy once running",
-        job.job_id,
-        PORT_NAME,
-    )
+    def _submit(url: str) -> None:
+        client = IrisClient.remote(url, workspace=Path.cwd())
+        job = submit_ducky(client, name=name, region=region, tpu=tpu, cpu=cpu, memory=memory, env_vars=env_vars)
+        logger.info(
+            "submitted ducky job %s (endpoint %r) — reachable via the controller endpoint proxy once running",
+            job.job_id,
+            PORT_NAME,
+        )
+
+    if cluster:
+        with cluster_tunnel(cluster) as url:
+            _submit(url)
+    else:
+        assert controller_url is not None  # guarded above
+        _submit(controller_url)
 
 
 if __name__ == "__main__":

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -69,8 +69,11 @@ def submit_ducky(
         environment=EnvironmentSpec(env_vars=env_vars),
         ports=[PORT_NAME],
         constraints=[region_constraint([region])],
-        # Always-on: ride out preemptions rather than exiting.
+        # Always-on: ride out preemptions, and also failures — the in-process supervisor
+        # restarts the server on an OOM, but if the whole container is cgroup-killed this
+        # lets Iris bring the task back instead of leaving the service down.
         max_retries_preemption=1000,
+        max_retries_failure=1000,
     )
 
 

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -97,6 +97,9 @@ def cli(controller_url: str, region: str, name: str, tpu: str, cpu: float, memor
     env_vars = _ducky_env_vars()
     if "DUCKY_SCRATCH_BUCKET" not in env_vars:
         raise click.UsageError("DUCKY_* env vars not set — export ducky config before deploying.")
+    # The task requires DUCKY_REGION; default it from --region so deploys don't need a
+    # separate export (an explicit DUCKY_REGION export still wins).
+    env_vars.setdefault("DUCKY_REGION", region)
 
     client = IrisClient.remote(controller_url, workspace=Path.cwd())
     job = submit_ducky(client, name=name, region=region, tpu=tpu, cpu=cpu, memory=memory, env_vars=env_vars)

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -23,13 +23,13 @@ from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_de
 
 logger = logging.getLogger(__name__)
 
-# A single v6e-8 host (ct6e-standard-8t). DuckDB runs on CPU/RAM only — the TPU sits
-# idle; we request the slice to grab the host's large CPU/RAM envelope exclusively.
+# Prod default: a single v6e-8 host (ct6e-standard-8t). DuckDB runs on CPU/RAM only —
+# the TPU sits idle; we request the slice to grab the host's large CPU/RAM envelope.
 # TODO(ducky): confirm the exact host vCPU/RAM so the request schedules and gets the
 # whole host (over-request → never schedules; under-request → DuckDB capped below host).
-TPU_VARIANT = "v6e-8"
-ALL_CPU = 180.0
-ALL_MEMORY = "1400GB"
+DEFAULT_TPU = "v6e-8"
+DEFAULT_CPU = 180.0
+DEFAULT_MEMORY = "1400GB"
 
 
 def _ducky_env_vars() -> dict[str, str]:
@@ -46,18 +46,27 @@ def _ducky_env_vars() -> dict[str, str]:
 )
 @click.option("--region", default="us-east5", show_default=True, help="Region to pin the job to.")
 @click.option("--name", default="ducky", show_default=True, help="Job name.")
-def cli(controller_url: str, region: str, name: str) -> None:
+@click.option(
+    "--tpu",
+    default=DEFAULT_TPU,
+    show_default=True,
+    help="TPU variant for the whole-host grab. Pass empty ('') for a CPU-only smoke deploy.",
+)
+@click.option("--cpu", default=DEFAULT_CPU, show_default=True, type=float, help="CPUs to request.")
+@click.option("--memory", default=DEFAULT_MEMORY, show_default=True, help="Memory to request (e.g. 16GB).")
+def cli(controller_url: str, region: str, name: str, tpu: str, cpu: float, memory: str) -> None:
     """Submit the always-on ducky service to an Iris cluster."""
     logging.basicConfig(level=logging.INFO)
     env_vars = _ducky_env_vars()
     if "DUCKY_SCRATCH_BUCKET" not in env_vars:
         raise click.UsageError("DUCKY_* env vars not set — export ducky config before deploying.")
 
+    device = tpu_device(tpu) if tpu else None
     client = IrisClient.remote(controller_url, workspace=Path.cwd())
     job = client.submit(
         entrypoint=Entrypoint.from_command("python", "-m", "ducky.server"),
         name=name,
-        resources=ResourceSpec(cpu=ALL_CPU, memory=ALL_MEMORY, device=tpu_device(TPU_VARIANT)),
+        resources=ResourceSpec(cpu=cpu, memory=memory, device=device),
         environment=EnvironmentSpec(env_vars=env_vars),
         ports=[name],
         constraints=[region_constraint([region])],

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -19,6 +19,8 @@ from __future__ import annotations
 
 import logging
 import os
+import shutil
+import subprocess
 from pathlib import Path
 
 import click
@@ -27,6 +29,8 @@ from iris.cluster.constraints import region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_device
 
 logger = logging.getLogger(__name__)
+
+DASHBOARD_DIR = Path(__file__).resolve().parents[2] / "dashboard"
 
 # Prod default: a single ct6e-standard-4t v6e host — 180 vCPU / 720 GB advertised,
 # ~700 GB allocatable after system reservation. DuckDB runs on CPU/RAM only (the v6e
@@ -77,6 +81,22 @@ def submit_ducky(
     )
 
 
+def _build_dashboard() -> None:
+    """Build the Vue dashboard so the gitignored ``dashboard/dist`` ships in the bundle.
+
+    Runs ``npm install`` (only if deps are missing) then ``npm run build``. The Iris
+    bundle re-includes the gitignored ``dist`` via ``GENERATED_ARTIFACT_GLOBS``.
+    """
+    npm = shutil.which("npm")
+    if npm is None:
+        raise click.UsageError("npm not found — install Node, or build the dashboard yourself and pass --skip-build.")
+    if not (DASHBOARD_DIR / "node_modules").is_dir():
+        logger.info("installing dashboard deps (npm install)…")
+        subprocess.run([npm, "install"], cwd=DASHBOARD_DIR, check=True)
+    logger.info("building dashboard (npm run build)…")
+    subprocess.run([npm, "run", "build"], cwd=DASHBOARD_DIR, check=True)
+
+
 @click.command()
 @click.option(
     "--controller-url",
@@ -94,12 +114,16 @@ def submit_ducky(
 )
 @click.option("--cpu", default=DEFAULT_CPU, show_default=True, type=float, help="CPUs to request.")
 @click.option("--memory", default=DEFAULT_MEMORY, show_default=True, help="Memory to request (e.g. 16GB).")
-def cli(controller_url: str, region: str, name: str, tpu: str, cpu: float, memory: str) -> None:
+@click.option("--skip-build", is_flag=True, help="Skip the dashboard `npm run build` (use an already-built dist).")
+def cli(controller_url: str, region: str, name: str, tpu: str, cpu: float, memory: str, skip_build: bool) -> None:
     """Submit the always-on ducky service to an Iris cluster."""
     logging.basicConfig(level=logging.INFO)
     env_vars = _ducky_env_vars()
     if "DUCKY_SCRATCH_BUCKET" not in env_vars:
         raise click.UsageError("DUCKY_* env vars not set — export ducky config before deploying.")
+
+    if not skip_build:
+        _build_dashboard()
 
     client = IrisClient.remote(controller_url, workspace=Path.cwd())
     job = submit_ducky(client, name=name, region=region, tpu=tpu, cpu=cpu, memory=memory, env_vars=env_vars)

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -28,13 +28,13 @@ from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_de
 
 logger = logging.getLogger(__name__)
 
-# Prod default: a single v6e-8 host (ct6e-standard-8t). DuckDB runs on CPU/RAM only —
-# the TPU sits idle; we request the slice to grab the host's large CPU/RAM envelope.
-# TODO(ducky): confirm the exact host vCPU/RAM so the request schedules and gets the
-# whole host (over-request → never schedules; under-request → DuckDB capped below host).
-DEFAULT_TPU = "v6e-8"
+# Prod default: a single ct6e-standard-4t v6e host — 180 vCPU / 720 GB. DuckDB runs
+# on CPU/RAM only (the v6e chips sit idle); we grab the slice for its large CPU/RAM
+# envelope. v6e-4 is the largest SINGLE-VM v6e on marin — v6e-8 is a 2-VM slice and
+# DuckDB, being single-node, can only use one VM, so it gains nothing from v6e-8.
+DEFAULT_TPU = "v6e-4"
 DEFAULT_CPU = 180.0
-DEFAULT_MEMORY = "1400GB"
+DEFAULT_MEMORY = "720GB"
 
 # The Iris named port and endpoint name the server binds/registers. Must match
 # DuckyConfig.port_name (the server calls ctx.get_port(config.port_name)), and is

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -39,6 +39,12 @@ DEFAULT_TPU = "v6e-8"
 DEFAULT_CPU = 180.0
 DEFAULT_MEMORY = "1400GB"
 
+# The Iris named port and endpoint name the server binds/registers. Must match
+# DuckyConfig.port_name (the server calls ctx.get_port(config.port_name)), and is
+# independent of the job --name. The dashboard resolves to the namespaced endpoint
+# wire name "<job-namespace>/ducky" through the controller proxy.
+PORT_NAME = "ducky"
+
 
 def _ducky_env_vars() -> dict[str, str]:
     """Forward all DUCKY_* env vars from this process to the task."""
@@ -89,7 +95,7 @@ def submit_ducky(
         name=name,
         resources=ResourceSpec(cpu=cpu, memory=memory, device=device),
         environment=EnvironmentSpec(env_vars=env_vars),
-        ports=[name],
+        ports=[PORT_NAME],
         constraints=[region_constraint([region])],
         # Always-on: ride out preemptions rather than exiting.
         max_retries_preemption=1000,
@@ -125,7 +131,11 @@ def cli(
     with _controller_connection(cluster, controller_url) as (url, token_provider):
         client = IrisClient.remote(url, workspace=Path.cwd(), token_provider=token_provider)
         job = submit_ducky(client, name=name, region=region, tpu=tpu, cpu=cpu, memory=memory, env_vars=env_vars)
-    logger.info("submitted ducky job %s — reachable at /proxy/%s/ once running", job.job_id, name)
+    logger.info(
+        "submitted ducky job %s (endpoint %r) — reachable via the controller endpoint proxy once running",
+        job.job_id,
+        PORT_NAME,
+    )
 
 
 if __name__ == "__main__":

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -28,13 +28,15 @@ from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_de
 
 logger = logging.getLogger(__name__)
 
-# Prod default: a single ct6e-standard-4t v6e host — 180 vCPU / 720 GB. DuckDB runs
-# on CPU/RAM only (the v6e chips sit idle); we grab the slice for its large CPU/RAM
-# envelope. v6e-4 is the largest SINGLE-VM v6e on marin — v6e-8 is a 2-VM slice and
-# DuckDB, being single-node, can only use one VM, so it gains nothing from v6e-8.
+# Prod default: a single ct6e-standard-4t v6e host — 180 vCPU / 720 GB advertised,
+# ~700 GB allocatable after system reservation. DuckDB runs on CPU/RAM only (the v6e
+# chips sit idle); we grab the slice for its large CPU/RAM envelope. v6e-4 is the
+# largest SINGLE-VM v6e on marin — v6e-8 is a 2-VM slice and DuckDB, being
+# single-node, can only use one VM, so it gains nothing from v6e-8. Memory is set
+# below allocatable so the request schedules.
 DEFAULT_TPU = "v6e-4"
 DEFAULT_CPU = 180.0
-DEFAULT_MEMORY = "720GB"
+DEFAULT_MEMORY = "690GB"
 
 # The Iris named port and endpoint name the server binds/registers. Must match
 # DuckyConfig.port_name (the server calls ctx.get_port(config.port_name)), and is

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -6,20 +6,28 @@
 A routable service needs a *named* Iris port, which ``iris job run`` cannot declare
 (no ``--ports`` flag). So deploy goes through the Python submit path
 (``client.submit(..., ports=["ducky"])``), the same mechanism the actor worker pool
-uses. The job is pinned to a single region and grabs a whole v6e-8 host; the
-``DUCKY_*`` credential/scratch env vars are forwarded to the task.
+uses. The job is pinned to a single region and grabs a whole v6e-8 host (or a
+smaller CPU-only shape for a smoke); the ``DUCKY_*`` config env vars are forwarded
+to the task.
 """
 
 from __future__ import annotations
 
 import logging
 import os
+from collections.abc import Generator
+from contextlib import contextmanager
 from pathlib import Path
 
 import click
-from iris.client.client import IrisClient
+from iris.cli.connect import IRIS_CLUSTER_CONFIG_DIRS
+from iris.cli.main import create_client_token_provider
+from iris.client.client import IrisClient, Job
+from iris.cluster.config import IrisConfig
 from iris.cluster.constraints import region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_device
+from iris.rpc.auth import TokenProvider
+from rigging.config_discovery import resolve_cluster_config
 
 logger = logging.getLogger(__name__)
 
@@ -37,12 +45,63 @@ def _ducky_env_vars() -> dict[str, str]:
     return {key: value for key, value in os.environ.items() if key.startswith("DUCKY_")}
 
 
+@contextmanager
+def _controller_connection(
+    cluster: str | None, controller_url: str | None
+) -> Generator[tuple[str, TokenProvider | None]]:
+    """Yield ``(controller_url, token_provider)``, tunneling to a named cluster if needed.
+
+    Mirrors ``iris.cli.connect.require_controller_url``: a direct ``--controller-url``
+    is used as-is; otherwise ``--cluster`` is resolved to its config, authenticated,
+    and tunneled for the duration of the submit.
+    """
+    if controller_url:
+        yield controller_url, None
+        return
+    if not cluster:
+        raise click.UsageError("Pass --cluster <name> or --controller-url.")
+
+    config_file = resolve_cluster_config(cluster, dirs=IRIS_CLUSTER_CONFIG_DIRS)
+    iris_config = IrisConfig.load(str(config_file))
+    proto = iris_config.proto
+    token_provider = create_client_token_provider(proto.auth, cluster_name=cluster) if proto.HasField("auth") else None
+    bundle = iris_config.provider_bundle()
+    controller_address = iris_config.controller_address() or bundle.controller.discover_controller(proto.controller)
+    logger.info("Tunneling to %s controller at %s", cluster, controller_address)
+    with bundle.controller.tunnel(address=controller_address) as tunnel_url:
+        yield tunnel_url, token_provider
+
+
+def submit_ducky(
+    client: IrisClient,
+    *,
+    name: str,
+    region: str,
+    tpu: str,
+    cpu: float,
+    memory: str,
+    env_vars: dict[str, str],
+) -> Job:
+    """Submit the ducky service job: a region-pinned, port-publishing, always-on job."""
+    device = tpu_device(tpu) if tpu else None
+    return client.submit(
+        entrypoint=Entrypoint.from_command("python", "-m", "ducky.server"),
+        name=name,
+        resources=ResourceSpec(cpu=cpu, memory=memory, device=device),
+        environment=EnvironmentSpec(env_vars=env_vars),
+        ports=[name],
+        constraints=[region_constraint([region])],
+        # Always-on: ride out preemptions rather than exiting.
+        max_retries_preemption=1000,
+    )
+
+
 @click.command()
+@click.option("--cluster", default=None, help="Named Iris cluster to deploy to (resolves config + tunnels).")
 @click.option(
     "--controller-url",
     default=lambda: os.environ.get("IRIS_CONTROLLER_URL"),
-    required=True,
-    help="Iris controller URL (default: $IRIS_CONTROLLER_URL).",
+    help="Direct controller URL (alternative to --cluster; default $IRIS_CONTROLLER_URL).",
 )
 @click.option("--region", default="us-east5", show_default=True, help="Region to pin the job to.")
 @click.option("--name", default="ducky", show_default=True, help="Job name.")
@@ -54,25 +113,18 @@ def _ducky_env_vars() -> dict[str, str]:
 )
 @click.option("--cpu", default=DEFAULT_CPU, show_default=True, type=float, help="CPUs to request.")
 @click.option("--memory", default=DEFAULT_MEMORY, show_default=True, help="Memory to request (e.g. 16GB).")
-def cli(controller_url: str, region: str, name: str, tpu: str, cpu: float, memory: str) -> None:
+def cli(
+    cluster: str | None, controller_url: str | None, region: str, name: str, tpu: str, cpu: float, memory: str
+) -> None:
     """Submit the always-on ducky service to an Iris cluster."""
     logging.basicConfig(level=logging.INFO)
     env_vars = _ducky_env_vars()
     if "DUCKY_SCRATCH_BUCKET" not in env_vars:
         raise click.UsageError("DUCKY_* env vars not set — export ducky config before deploying.")
 
-    device = tpu_device(tpu) if tpu else None
-    client = IrisClient.remote(controller_url, workspace=Path.cwd())
-    job = client.submit(
-        entrypoint=Entrypoint.from_command("python", "-m", "ducky.server"),
-        name=name,
-        resources=ResourceSpec(cpu=cpu, memory=memory, device=device),
-        environment=EnvironmentSpec(env_vars=env_vars),
-        ports=[name],
-        constraints=[region_constraint([region])],
-        # Always-on: ride out preemptions rather than exiting.
-        max_retries_preemption=1000,
-    )
+    with _controller_connection(cluster, controller_url) as (url, token_provider):
+        client = IrisClient.remote(url, workspace=Path.cwd(), token_provider=token_provider)
+        job = submit_ducky(client, name=name, region=region, tpu=tpu, cpu=cpu, memory=memory, env_vars=env_vars)
     logger.info("submitted ducky job %s — reachable at /proxy/%s/ once running", job.job_id, name)
 
 

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -6,7 +6,7 @@
 A routable service needs a *named* Iris port, which ``iris job run`` cannot declare
 (no ``--ports`` flag). So deploy goes through the Python submit path
 (``client.submit(..., ports=["ducky"])``), the same mechanism the actor worker pool
-uses. The job is pinned to a single region and grabs a whole v6e-8 host (or a
+uses. The job is pinned to a single region and grabs a whole v6e-4 host (or a
 smaller CPU-only shape for a smoke); the ``DUCKY_*`` config env vars are forwarded
 to the task.
 
@@ -100,9 +100,6 @@ def cli(controller_url: str, region: str, name: str, tpu: str, cpu: float, memor
     env_vars = _ducky_env_vars()
     if "DUCKY_SCRATCH_BUCKET" not in env_vars:
         raise click.UsageError("DUCKY_* env vars not set — export ducky config before deploying.")
-    # The task requires DUCKY_REGION; default it from --region so deploys don't need a
-    # separate export (an explicit DUCKY_REGION export still wins).
-    env_vars.setdefault("DUCKY_REGION", region)
 
     client = IrisClient.remote(controller_url, workspace=Path.cwd())
     job = submit_ducky(client, name=name, region=region, tpu=tpu, cpu=cpu, memory=memory, env_vars=env_vars)

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import math
 import os
 import re
 import time
@@ -82,10 +83,13 @@ def _coerce_cell(value: object) -> object:
     """Coerce a DuckDB/Arrow cell to a JSON-serializable scalar.
 
     Native scalars pass through; everything else (timestamp, decimal, interval,
-    blob, list, struct) becomes its string form for the preview.
+    blob, list, struct) becomes its string form for the preview. Non-finite floats
+    (``NaN``/``inf``) also become strings — Starlette's ``JSONResponse`` rejects them.
     """
-    if value is None or isinstance(value, (bool, int, float, str)):
+    if value is None or isinstance(value, (bool, int, str)):
         return value
+    if isinstance(value, float):
+        return value if math.isfinite(value) else str(value)
     return str(value)
 
 
@@ -129,7 +133,7 @@ class QueryRunner:
         if cfg.cw_enabled:
             self._con.execute(
                 f"CREATE OR REPLACE SECRET ducky_cw "
-                f"(TYPE S3, ENDPOINT {_sql_literal(cfg.cw_endpoint)}, URL_STYLE 'path', "
+                f"(TYPE S3, ENDPOINT {_sql_literal(cfg.cw_endpoint)}, URL_STYLE {_sql_literal(cfg.cw_url_style)}, "
                 f"KEY_ID {_sql_literal(cfg.cw_access_key)}, SECRET {_sql_literal(cfg.cw_secret_key)})"
             )
 
@@ -146,12 +150,18 @@ class QueryRunner:
         result_path = f"{self._config.scratch_bucket.rstrip('/')}/ducky/{query_id}.parquet"
         path_literal = _sql_literal(result_path)
 
+        # Strip a trailing `;` (else it lands mid-`COPY (...)` and is a syntax error), and
+        # wrap the user SQL on its own lines so a trailing `-- comment` can't eat the
+        # generated `)`.
+        normalized_sql = sql.strip().rstrip(";").rstrip()
+        copy_stmt = f"COPY (\n{normalized_sql}\n) TO {path_literal} (FORMAT parquet)"
+
         # hive_partitioning=false: the scratch path embeds a `tmp/ttl=Nd/` segment, which
         # DuckDB would otherwise read back as a phantom `ttl` partition column.
         readback = f"read_parquet({path_literal}, hive_partitioning=false)"
         start = time.monotonic()
         try:
-            self._con.execute(f"COPY ({sql}) TO {path_literal} (FORMAT parquet)")
+            self._con.execute(copy_stmt)
             count_row = self._con.execute(f"SELECT count(*) FROM {readback}").fetchone()
             assert count_row is not None  # count(*) always returns exactly one row
             total_rows = int(count_row[0])

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -1,12 +1,17 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""The DuckDB query runner: one connection, one query at a time.
+"""The DuckDB query runner over a shared embedded instance.
 
 The runner runs the user's SQL exactly once via ``COPY (<sql>) TO '<parquet>'`` and
 then reads the written parquet back for the row count and a capped preview. Running
 once keeps non-deterministic SQL (``random()``, ``now()``, unordered ``LIMIT``)
 consistent between the spilled file and the preview.
+
+``run_query`` is safe to call concurrently: each call uses its own cursor on the
+shared DuckDB instance (which provides the loaded extensions, secrets, and the
+host-sized thread/memory budget). A per-query watchdog interrupts a query that
+exceeds ``query_timeout``.
 """
 
 from __future__ import annotations
@@ -16,6 +21,7 @@ import logging
 import math
 import os
 import re
+import threading
 import time
 
 import duckdb
@@ -124,10 +130,9 @@ def _coerce_cell(value: object) -> object:
 
 
 class QueryRunner:
-    """Owns one embedded DuckDB connection for the process lifetime.
+    """Owns the shared embedded DuckDB instance for the process lifetime.
 
-    Not safe for concurrent use — ``run_query`` is serialized by the caller
-    (single query at a time, per design).
+    ``run_query`` is concurrency-safe — each call runs on its own cursor.
     """
 
     def __init__(self, config: DuckyConfig, resources: TaskResources | None = None) -> None:
@@ -137,6 +142,10 @@ class QueryRunner:
         self._con.execute(f"SET threads = {settings.threads}")
         if settings.memory_limit_bytes > 0:
             self._con.execute(f"SET memory_limit = '{settings.memory_limit_bytes}B'")
+        # Spill to local disk when a query exceeds memory_limit, so big sorts/joins/aggregates
+        # go out-of-core instead of OOM-failing; a query that still doesn't fit fails alone.
+        os.makedirs(config.spill_directory, exist_ok=True)
+        self._con.execute(f"SET temp_directory = {_sql_literal(config.spill_directory)}")
         logger.info("DuckDB configured: threads=%d memory_limit_bytes=%d", settings.threads, settings.memory_limit_bytes)
         self._install_secrets()
         # A local scratch dir (smoke deploy / tests) needs the ducky/ subdir to exist;
@@ -207,21 +216,34 @@ class QueryRunner:
         # hive_partitioning=false: the scratch path embeds a `tmp/ttl=Nd/` segment, which
         # DuckDB would otherwise read back as a phantom `ttl` partition column.
         readback = f"read_parquet({path_literal}, hive_partitioning=false)"
+
+        # A fresh cursor per query so multiple queries run concurrently on the shared
+        # DuckDB instance (one connection can't run parallel statements); the cursor
+        # inherits the instance's loaded extensions, secrets, and settings.
+        cursor = self._con.cursor()
+        timed_out = threading.Event()
+        watchdog = threading.Timer(self._config.query_timeout, lambda: (timed_out.set(), cursor.interrupt()))
+        watchdog.start()
         start = time.monotonic()
         try:
-            self._con.execute(copy_stmt)
-            count_row = self._con.execute(f"SELECT count(*) FROM {readback}").fetchone()
+            cursor.execute(copy_stmt)
+            count_row = cursor.execute(f"SELECT count(*) FROM {readback}").fetchone()
             assert count_row is not None  # count(*) always returns exactly one row
             total_rows = int(count_row[0])
-            size_row = self._con.execute(
+            size_row = cursor.execute(
                 f"SELECT sum(total_compressed_size) FROM parquet_metadata({path_literal})"
             ).fetchone()
             result_bytes = int(size_row[0]) if size_row and size_row[0] is not None else 0
-            preview = self._con.execute(
+            preview = cursor.execute(
                 f"SELECT * FROM {readback} LIMIT {self._config.preview_row_cap}"
             ).fetch_arrow_table()
         except duckdb.Error as e:
+            if timed_out.is_set():
+                raise QueryError(f"query exceeded the {self._config.query_timeout}s timeout and was cancelled") from e
             raise QueryError(str(e)) from e
+        finally:
+            watchdog.cancel()
+            cursor.close()
         elapsed_ms = int((time.monotonic() - start) * 1000)
 
         columns = list(preview.column_names)

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -145,7 +145,9 @@ class QueryRunner:
 
         try:
             self._con.execute(f"COPY ({sql}) TO {path_literal} (FORMAT parquet)")
-            total_rows = self._con.execute(f"SELECT count(*) FROM read_parquet({path_literal})").fetchone()[0]
+            count_row = self._con.execute(f"SELECT count(*) FROM read_parquet({path_literal})").fetchone()
+            assert count_row is not None  # count(*) always returns exactly one row
+            total_rows = int(count_row[0])
             preview = self._con.execute(
                 f"SELECT * FROM read_parquet({path_literal}) LIMIT {self._config.preview_row_cap}"
             ).fetch_arrow_table()
@@ -157,8 +159,8 @@ class QueryRunner:
         return QueryResult(
             columns=columns,
             preview_rows=preview_rows,
-            total_rows=int(total_rows),
-            truncated=int(total_rows) > len(preview_rows),
+            total_rows=total_rows,
+            truncated=total_rows > len(preview_rows),
             result_path=result_path,
         )
 

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -158,8 +158,17 @@ class QueryRunner:
         self._install_secrets()
         # A local scratch dir (smoke deploy / tests) needs the ducky/ subdir to exist;
         # object stores create the prefix implicitly.
-        if "://" not in config.scratch_bucket:
+        scratch_is_remote = "://" in config.scratch_bucket
+        if not scratch_is_remote:
             os.makedirs(f"{config.scratch_bucket.rstrip('/')}/ducky", exist_ok=True)
+        # Harden: when results go to object storage, block user SQL from touching the local
+        # filesystem (e.g. read_text('/proc/self/environ') to exfil the injected creds). Object
+        # stores are separate DuckDB filesystems and spilling is internal, so both still work.
+        # Skipped for a local scratch dir, which needs LocalFileSystem for the result write.
+        if scratch_is_remote:
+            self._con.execute("SET disabled_filesystems = 'LocalFileSystem'")
+        # Lock the configuration last so a query can't SET any of these guards back off.
+        self._con.execute("SET lock_configuration = true")
 
     def _install_secrets(self) -> None:
         """Load httpfs and create a DuckDB SECRET for each configured object-store backend."""
@@ -229,8 +238,9 @@ class QueryRunner:
         try:
             # Run the user SQL as a relation and write it out, rather than wrapping it in a
             # COPY (...) string — DuckDB parses it as a complete statement, so a trailing
-            # ';' or '-- comment' just works.
-            cursor.sql(sql).write_parquet(result_path)
+            # ';' or '-- comment' just works. The row cap bounds the materialized object so a
+            # broad SELECT * can't write an unbounded (multi-TB) result to the store.
+            cursor.sql(sql).limit(self._config.max_result_rows).write_parquet(result_path)
             count_row = cursor.execute(f"SELECT count(*) FROM {readback}").fetchone()
             assert count_row is not None  # count(*) always returns exactly one row
             total_rows = int(count_row[0])

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -175,6 +175,15 @@ class QueryRunner:
         cfg = self._config
         self._con.execute("INSTALL httpfs")
         self._con.execute("LOAD httpfs")
+        # Retry transient object-store failures (5xx, throttling, brief DNS/connection
+        # blips — more likely on cross-region reads) with exponential backoff, so a
+        # network hiccup doesn't fail an expensive query outright. Defaults are 3/100ms;
+        # 10 retries at 200ms × 2^n backoff spans ~100s of transient unavailability.
+        # SET GLOBAL because these are connection-local settings: run_query uses a per-query
+        # cursor, which only inherits the global scope, not this connection's local SETs.
+        self._con.execute("SET GLOBAL http_retries = 10")
+        self._con.execute("SET GLOBAL http_retry_wait_ms = 200")
+        self._con.execute("SET GLOBAL http_retry_backoff = 2")
         if cfg.gcs_enabled:
             self._con.execute(
                 f"CREATE OR REPLACE SECRET ducky_gcs "

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -146,6 +146,9 @@ class QueryRunner:
         # go out-of-core instead of OOM-failing; a query that still doesn't fit fails alone.
         os.makedirs(config.spill_directory, exist_ok=True)
         self._con.execute(f"SET temp_directory = {_sql_literal(config.spill_directory)}")
+        # Bound the spill so a runaway query can't fill the (small, ~100 GB) boot disk and
+        # crash the container; over the cap the query fails cleanly (caught per-query).
+        self._con.execute(f"SET max_temp_directory_size = {_sql_literal(config.spill_limit)}")
         logger.info("DuckDB configured: threads=%d memory_limit_bytes=%d", settings.threads, settings.memory_limit_bytes)
         self._install_secrets()
         # A local scratch dir (smoke deploy / tests) needs the ducky/ subdir to exist;

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -13,6 +13,7 @@ from __future__ import annotations
 
 import dataclasses
 import logging
+import os
 import re
 
 import duckdb
@@ -101,26 +102,33 @@ class QueryRunner:
             self._con.execute(f"SET memory_limit = '{settings.memory_limit_bytes}B'")
         logger.info("DuckDB configured: threads=%d memory_limit_bytes=%d", settings.threads, settings.memory_limit_bytes)
         self._install_secrets()
+        # A local scratch dir (smoke deploy / tests) needs the ducky/ subdir to exist;
+        # object stores create the prefix implicitly.
+        if "://" not in config.scratch_bucket:
+            os.makedirs(f"{config.scratch_bucket.rstrip('/')}/ducky", exist_ok=True)
 
     def _install_secrets(self) -> None:
-        """Load httpfs and create one DuckDB SECRET per object-store backend."""
+        """Load httpfs and create a DuckDB SECRET for each configured object-store backend."""
         cfg = self._config
         self._con.execute("INSTALL httpfs")
         self._con.execute("LOAD httpfs")
-        self._con.execute(
-            f"CREATE OR REPLACE SECRET ducky_gcs "
-            f"(TYPE GCS, KEY_ID {_sql_literal(cfg.gcs_hmac_key_id)}, SECRET {_sql_literal(cfg.gcs_hmac_secret)})"
-        )
-        self._con.execute(
-            f"CREATE OR REPLACE SECRET ducky_r2 "
-            f"(TYPE R2, ACCOUNT_ID {_sql_literal(cfg.r2_account_id)}, "
-            f"KEY_ID {_sql_literal(cfg.r2_access_key)}, SECRET {_sql_literal(cfg.r2_secret_key)})"
-        )
-        self._con.execute(
-            f"CREATE OR REPLACE SECRET ducky_cw "
-            f"(TYPE S3, ENDPOINT {_sql_literal(cfg.cw_endpoint)}, URL_STYLE 'path', "
-            f"KEY_ID {_sql_literal(cfg.cw_access_key)}, SECRET {_sql_literal(cfg.cw_secret_key)})"
-        )
+        if cfg.gcs_enabled:
+            self._con.execute(
+                f"CREATE OR REPLACE SECRET ducky_gcs "
+                f"(TYPE GCS, KEY_ID {_sql_literal(cfg.gcs_hmac_key_id)}, SECRET {_sql_literal(cfg.gcs_hmac_secret)})"
+            )
+        if cfg.r2_enabled:
+            self._con.execute(
+                f"CREATE OR REPLACE SECRET ducky_r2 "
+                f"(TYPE R2, ACCOUNT_ID {_sql_literal(cfg.r2_account_id)}, "
+                f"KEY_ID {_sql_literal(cfg.r2_access_key)}, SECRET {_sql_literal(cfg.r2_secret_key)})"
+            )
+        if cfg.cw_enabled:
+            self._con.execute(
+                f"CREATE OR REPLACE SECRET ducky_cw "
+                f"(TYPE S3, ENDPOINT {_sql_literal(cfg.cw_endpoint)}, URL_STYLE 'path', "
+                f"KEY_ID {_sql_literal(cfg.cw_access_key)}, SECRET {_sql_literal(cfg.cw_secret_key)})"
+            )
 
     def run_query(self, sql: str, query_id: str) -> QueryResult:
         """Run ``sql`` once, spill the full result to parquet, and return a capped preview.

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -39,14 +39,13 @@ def _object_uris(sql: str) -> list[str]:
 
 
 def _is_allowed(uri: str, allowed: tuple[str, ...]) -> bool:
-    """True if ``uri`` is covered by an allowlist entry (exact, scheme-only, or bucket prefix)."""
-    for entry in allowed:
-        if uri == entry or (entry.endswith("://") and uri.startswith(entry)):
-            return True
-        prefix = entry if entry.endswith("/") else entry + "/"
-        if uri.startswith(prefix):  # boundary-aware: gs://b does not match gs://b-evil
-            return True
-    return False
+    """True if ``uri`` starts with any allowlist entry.
+
+    Entries are URI prefixes: ``gs://marin-`` allows every ``gs://marin-*`` bucket,
+    ``r2://`` allows all of R2, and a trailing slash (``gs://marin-us-east5/``) bounds
+    a match to one bucket's contents.
+    """
+    return any(uri.startswith(entry) for entry in allowed)
 
 
 def disallowed_uris(sql: str, allowed: tuple[str, ...]) -> list[str]:
@@ -155,18 +154,29 @@ class QueryRunner:
                 f"CREATE OR REPLACE SECRET ducky_gcs "
                 f"(TYPE GCS, KEY_ID {_sql_literal(cfg.gcs_hmac_key_id)}, SECRET {_sql_literal(cfg.gcs_hmac_secret)})"
             )
+        # R2 and CoreWeave are both s3://, so each S3 secret is SCOPE-d to its bucket prefix;
+        # DuckDB routes an s3:// URI to the secret with the longest matching scope.
         if cfg.r2_enabled:
             self._con.execute(
-                f"CREATE OR REPLACE SECRET ducky_r2 "
-                f"(TYPE R2, ACCOUNT_ID {_sql_literal(cfg.r2_account_id)}, "
-                f"KEY_ID {_sql_literal(cfg.r2_access_key)}, SECRET {_sql_literal(cfg.r2_secret_key)})"
+                self._s3_secret(
+                    "ducky_r2", cfg.r2_endpoint, cfg.r2_url_style, cfg.r2_scope, cfg.r2_access_key, cfg.r2_secret_key
+                )
             )
         if cfg.cw_enabled:
             self._con.execute(
-                f"CREATE OR REPLACE SECRET ducky_cw "
-                f"(TYPE S3, ENDPOINT {_sql_literal(cfg.cw_endpoint)}, URL_STYLE {_sql_literal(cfg.cw_url_style)}, "
-                f"KEY_ID {_sql_literal(cfg.cw_access_key)}, SECRET {_sql_literal(cfg.cw_secret_key)})"
+                self._s3_secret(
+                    "ducky_cw", cfg.cw_endpoint, cfg.cw_url_style, cfg.cw_scope, cfg.cw_access_key, cfg.cw_secret_key
+                )
             )
+
+    @staticmethod
+    def _s3_secret(name: str, endpoint: str, url_style: str, scope: str, key_id: str, secret: str) -> str:
+        # REGION 'auto' keeps DuckDB from signing with a real AWS region for these custom endpoints.
+        return (
+            f"CREATE OR REPLACE SECRET {name} (TYPE S3, "
+            f"ENDPOINT {_sql_literal(endpoint)}, URL_STYLE {_sql_literal(url_style)}, REGION 'auto', "
+            f"SCOPE {_sql_literal(scope)}, KEY_ID {_sql_literal(key_id)}, SECRET {_sql_literal(secret)})"
+        )
 
     def run_query(self, sql: str, query_id: str) -> QueryResult:
         """Run ``sql`` once, spill the full result to parquet, and return a capped preview.

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -206,13 +206,6 @@ class QueryRunner:
 
         result_path = f"{self._config.scratch_bucket.rstrip('/')}/ducky/{query_id}.parquet"
         path_literal = _sql_literal(result_path)
-
-        # Strip a trailing `;` (else it lands mid-`COPY (...)` and is a syntax error), and
-        # wrap the user SQL on its own lines so a trailing `-- comment` can't eat the
-        # generated `)`.
-        normalized_sql = sql.strip().rstrip(";").rstrip()
-        copy_stmt = f"COPY (\n{normalized_sql}\n) TO {path_literal} (FORMAT parquet)"
-
         # hive_partitioning=false: the scratch path embeds a `tmp/ttl=Nd/` segment, which
         # DuckDB would otherwise read back as a phantom `ttl` partition column.
         readback = f"read_parquet({path_literal}, hive_partitioning=false)"
@@ -226,7 +219,10 @@ class QueryRunner:
         watchdog.start()
         start = time.monotonic()
         try:
-            cursor.execute(copy_stmt)
+            # Run the user SQL as a relation and write it out, rather than wrapping it in a
+            # COPY (...) string — DuckDB parses it as a complete statement, so a trailing
+            # ';' or '-- comment' just works.
+            cursor.sql(sql).write_parquet(result_path)
             count_row = cursor.execute(f"SELECT count(*) FROM {readback}").fetchone()
             assert count_row is not None  # count(*) always returns exactly one row
             total_rows = int(count_row[0])

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -143,13 +143,16 @@ class QueryRunner:
         result_path = f"{self._config.scratch_bucket.rstrip('/')}/ducky/{query_id}.parquet"
         path_literal = _sql_literal(result_path)
 
+        # hive_partitioning=false: the scratch path embeds a `tmp/ttl=Nd/` segment, which
+        # DuckDB would otherwise read back as a phantom `ttl` partition column.
+        readback = f"read_parquet({path_literal}, hive_partitioning=false)"
         try:
             self._con.execute(f"COPY ({sql}) TO {path_literal} (FORMAT parquet)")
-            count_row = self._con.execute(f"SELECT count(*) FROM read_parquet({path_literal})").fetchone()
+            count_row = self._con.execute(f"SELECT count(*) FROM {readback}").fetchone()
             assert count_row is not None  # count(*) always returns exactly one row
             total_rows = int(count_row[0])
             preview = self._con.execute(
-                f"SELECT * FROM read_parquet({path_literal}) LIMIT {self._config.preview_row_cap}"
+                f"SELECT * FROM {readback} LIMIT {self._config.preview_row_cap}"
             ).fetch_arrow_table()
         except duckdb.Error as e:
             raise QueryError(str(e)) from e

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -15,6 +15,7 @@ import dataclasses
 import logging
 import os
 import re
+import time
 
 import duckdb
 from iris.env_resources import TaskResources
@@ -47,6 +48,8 @@ class QueryResult:
     total_rows: int
     truncated: bool
     result_path: str
+    elapsed_ms: int  # server-side execution wall time (COPY + readback)
+    result_bytes: int  # on-disk size of the spilled result parquet
 
 
 @dataclasses.dataclass(frozen=True)
@@ -146,16 +149,22 @@ class QueryRunner:
         # hive_partitioning=false: the scratch path embeds a `tmp/ttl=Nd/` segment, which
         # DuckDB would otherwise read back as a phantom `ttl` partition column.
         readback = f"read_parquet({path_literal}, hive_partitioning=false)"
+        start = time.monotonic()
         try:
             self._con.execute(f"COPY ({sql}) TO {path_literal} (FORMAT parquet)")
             count_row = self._con.execute(f"SELECT count(*) FROM {readback}").fetchone()
             assert count_row is not None  # count(*) always returns exactly one row
             total_rows = int(count_row[0])
+            size_row = self._con.execute(
+                f"SELECT sum(total_compressed_size) FROM parquet_metadata({path_literal})"
+            ).fetchone()
+            result_bytes = int(size_row[0]) if size_row and size_row[0] is not None else 0
             preview = self._con.execute(
                 f"SELECT * FROM {readback} LIMIT {self._config.preview_row_cap}"
             ).fetch_arrow_table()
         except duckdb.Error as e:
             raise QueryError(str(e)) from e
+        elapsed_ms = int((time.monotonic() - start) * 1000)
 
         columns = list(preview.column_names)
         preview_rows = [[_coerce_cell(row[col]) for col in columns] for row in preview.to_pylist()]
@@ -165,6 +174,8 @@ class QueryRunner:
             total_rows=total_rows,
             truncated=total_rows > len(preview_rows),
             result_path=result_path,
+            elapsed_ms=elapsed_ms,
+            result_bytes=result_bytes,
         )
 
     def close(self) -> None:

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -238,9 +238,8 @@ class QueryRunner:
         try:
             # Run the user SQL as a relation and write it out, rather than wrapping it in a
             # COPY (...) string — DuckDB parses it as a complete statement, so a trailing
-            # ';' or '-- comment' just works. The row cap bounds the materialized object so a
-            # broad SELECT * can't write an unbounded (multi-TB) result to the store.
-            cursor.sql(sql).limit(self._config.max_result_rows).write_parquet(result_path)
+            # ';' or '-- comment' just works.
+            cursor.sql(sql).write_parquet(result_path)
             count_row = cursor.execute(f"SELECT count(*) FROM {readback}").fetchone()
             assert count_row is not None  # count(*) always returns exactly one row
             total_rows = int(count_row[0])

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -90,26 +90,6 @@ class QueryResult:
     result_bytes: int  # on-disk size of the spilled result parquet
 
 
-@dataclasses.dataclass(frozen=True)
-class DuckDBResourceSettings:
-    """DuckDB execution limits derived from the host envelope."""
-
-    threads: int
-    memory_limit_bytes: int
-
-
-def duckdb_resource_settings(resources: TaskResources, memory_fraction: float) -> DuckDBResourceSettings:
-    """Map a host resource snapshot to DuckDB ``threads`` / ``memory_limit``.
-
-    ``threads`` is the host CPU count (at least 1). ``memory_limit_bytes`` is
-    ``memory_fraction`` of host RAM, leaving headroom for Python/Arrow/OS; it is 0
-    (meaning "leave DuckDB's default") when host memory is unknown.
-    """
-    threads = max(1, int(resources.cpu_cores))
-    memory_limit_bytes = int(resources.memory_bytes * memory_fraction) if resources.memory_bytes > 0 else 0
-    return DuckDBResourceSettings(threads=threads, memory_limit_bytes=memory_limit_bytes)
-
-
 def _sql_literal(value: str) -> str:
     """Quote a string as a SQL literal, escaping embedded single quotes."""
     escaped = value.replace("'", "''")
@@ -139,10 +119,14 @@ class QueryRunner:
     def __init__(self, config: DuckyConfig, resources: TaskResources | None = None) -> None:
         self._config = config
         self._con = duckdb.connect()
-        settings = duckdb_resource_settings(resources or TaskResources.from_environment(), config.memory_fraction)
-        self._con.execute(f"SET threads = {settings.threads}")
-        if settings.memory_limit_bytes > 0:
-            self._con.execute(f"SET memory_limit = '{settings.memory_limit_bytes}B'")
+        host = resources or TaskResources.from_environment()
+        # threads = host CPU count; memory_limit = memory_fraction of host RAM (headroom for
+        # Python/Arrow/OS). 0 memory leaves DuckDB's default (host memory unknown).
+        threads = max(1, int(host.cpu_cores))
+        memory_limit_bytes = int(host.memory_bytes * config.memory_fraction) if host.memory_bytes > 0 else 0
+        self._con.execute(f"SET threads = {threads}")
+        if memory_limit_bytes > 0:
+            self._con.execute(f"SET memory_limit = '{memory_limit_bytes}B'")
         # Spill to local disk when a query exceeds memory_limit, so big sorts/joins/aggregates
         # go out-of-core instead of OOM-failing; a query that still doesn't fit fails alone.
         # DuckDB clears a query's spill on normal end (success or failure), but a process
@@ -154,7 +138,7 @@ class QueryRunner:
         # Bound the spill so a runaway query can't fill the (small, ~100 GB) boot disk and
         # crash the container; over the cap the query fails cleanly (caught per-query).
         self._con.execute(f"SET max_temp_directory_size = {_sql_literal(config.spill_limit)}")
-        logger.info("DuckDB configured: threads=%d memory_limit_bytes=%d", settings.threads, settings.memory_limit_bytes)
+        logger.info("DuckDB configured: threads=%d memory_limit_bytes=%d", threads, memory_limit_bytes)
         self._install_secrets()
         # A local scratch dir (smoke deploy / tests) needs the ducky/ subdir to exist;
         # object stores create the prefix implicitly.
@@ -178,7 +162,7 @@ class QueryRunner:
         # Retry transient object-store failures (5xx, throttling, brief DNS/connection
         # blips — more likely on cross-region reads) with exponential backoff, so a
         # network hiccup doesn't fail an expensive query outright. Defaults are 3/100ms;
-        # 10 retries at 200ms × 2^n backoff spans ~100s of transient unavailability.
+        # 10 retries at 200ms * 2^n backoff spans ~100s of transient unavailability.
         # SET GLOBAL because these are connection-local settings: run_query uses a per-query
         # cursor, which only inherits the global scope, not this connection's local SETs.
         self._con.execute("SET GLOBAL http_retries = 10")
@@ -190,18 +174,16 @@ class QueryRunner:
                 f"(TYPE GCS, KEY_ID {_sql_literal(cfg.gcs_hmac_key_id)}, SECRET {_sql_literal(cfg.gcs_hmac_secret)})"
             )
         # R2 and CoreWeave are both s3://, so each S3 secret is SCOPE-d to its bucket prefix;
-        # DuckDB routes an s3:// URI to the secret with the longest matching scope.
+        # DuckDB routes an s3:// URI to the secret with the longest matching scope. URL_STYLE is
+        # a fixed property of each endpoint: R2's account endpoint is path-style; CoreWeave
+        # rejects path-style and needs vhost.
         if cfg.r2_enabled:
             self._con.execute(
-                self._s3_secret(
-                    "ducky_r2", cfg.r2_endpoint, cfg.r2_url_style, cfg.r2_scope, cfg.r2_access_key, cfg.r2_secret_key
-                )
+                self._s3_secret("ducky_r2", cfg.r2_endpoint, "path", cfg.r2_scope, cfg.r2_access_key, cfg.r2_secret_key)
             )
         if cfg.cw_enabled:
             self._con.execute(
-                self._s3_secret(
-                    "ducky_cw", cfg.cw_endpoint, cfg.cw_url_style, cfg.cw_scope, cfg.cw_access_key, cfg.cw_secret_key
-                )
+                self._s3_secret("ducky_cw", cfg.cw_endpoint, "vhost", cfg.cw_scope, cfg.cw_access_key, cfg.cw_secret_key)
             )
 
     @staticmethod

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -21,6 +21,7 @@ import logging
 import math
 import os
 import re
+import shutil
 import threading
 import time
 
@@ -144,6 +145,10 @@ class QueryRunner:
             self._con.execute(f"SET memory_limit = '{settings.memory_limit_bytes}B'")
         # Spill to local disk when a query exceeds memory_limit, so big sorts/joins/aggregates
         # go out-of-core instead of OOM-failing; a query that still doesn't fit fails alone.
+        # DuckDB clears a query's spill on normal end (success or failure), but a process
+        # crash (OOM-kill) orphans temp files — so wipe the dir on startup. Safe: only one
+        # server child runs at a time and it hasn't served yet.
+        shutil.rmtree(config.spill_directory, ignore_errors=True)
         os.makedirs(config.spill_directory, exist_ok=True)
         self._con.execute(f"SET temp_directory = {_sql_literal(config.spill_directory)}")
         # Bound the spill so a runaway query can't fill the (small, ~100 GB) boot disk and

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -1,0 +1,158 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""The DuckDB query runner: one connection, one query at a time.
+
+The runner runs the user's SQL exactly once via ``COPY (<sql>) TO '<parquet>'`` and
+then reads the written parquet back for the row count and a capped preview. Running
+once keeps non-deterministic SQL (``random()``, ``now()``, unordered ``LIMIT``)
+consistent between the spilled file and the preview.
+"""
+
+from __future__ import annotations
+
+import dataclasses
+import logging
+import re
+
+import duckdb
+from iris.env_resources import TaskResources
+
+from ducky.config import DuckyConfig
+
+logger = logging.getLogger(__name__)
+
+# query_id is interpolated into the result path, so it must be a bare uuid4 hex.
+_QUERY_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+
+class DuckyError(Exception):
+    """Base for ducky errors surfaced to the dashboard as a clean message."""
+
+
+class QueryError(DuckyError):
+    """DuckDB failed to plan or execute the SQL. Wraps the DuckDB message.
+
+    Cross-region reads are not a distinct error in v1 — they surface here as an
+    httpfs authentication failure, because the injected creds are scoped to
+    same-region buckets.
+    """
+
+
+@dataclasses.dataclass(frozen=True)
+class QueryResult:
+    columns: list[str]
+    preview_rows: list[list]
+    total_rows: int
+    truncated: bool
+    result_path: str
+
+
+@dataclasses.dataclass(frozen=True)
+class DuckDBResourceSettings:
+    """DuckDB execution limits derived from the host envelope."""
+
+    threads: int
+    memory_limit_bytes: int
+
+
+def duckdb_resource_settings(resources: TaskResources, memory_fraction: float) -> DuckDBResourceSettings:
+    """Map a host resource snapshot to DuckDB ``threads`` / ``memory_limit``.
+
+    ``threads`` is the host CPU count (at least 1). ``memory_limit_bytes`` is
+    ``memory_fraction`` of host RAM, leaving headroom for Python/Arrow/OS; it is 0
+    (meaning "leave DuckDB's default") when host memory is unknown.
+    """
+    threads = max(1, int(resources.cpu_cores))
+    memory_limit_bytes = int(resources.memory_bytes * memory_fraction) if resources.memory_bytes > 0 else 0
+    return DuckDBResourceSettings(threads=threads, memory_limit_bytes=memory_limit_bytes)
+
+
+def _sql_literal(value: str) -> str:
+    """Quote a string as a SQL literal, escaping embedded single quotes."""
+    escaped = value.replace("'", "''")
+    return f"'{escaped}'"
+
+
+def _coerce_cell(value: object) -> object:
+    """Coerce a DuckDB/Arrow cell to a JSON-serializable scalar.
+
+    Native scalars pass through; everything else (timestamp, decimal, interval,
+    blob, list, struct) becomes its string form for the preview.
+    """
+    if value is None or isinstance(value, (bool, int, float, str)):
+        return value
+    return str(value)
+
+
+class QueryRunner:
+    """Owns one embedded DuckDB connection for the process lifetime.
+
+    Not safe for concurrent use — ``run_query`` is serialized by the caller
+    (single query at a time, per design).
+    """
+
+    def __init__(self, config: DuckyConfig, resources: TaskResources | None = None) -> None:
+        self._config = config
+        self._con = duckdb.connect()
+        settings = duckdb_resource_settings(resources or TaskResources.from_environment(), config.memory_fraction)
+        self._con.execute(f"SET threads = {settings.threads}")
+        if settings.memory_limit_bytes > 0:
+            self._con.execute(f"SET memory_limit = '{settings.memory_limit_bytes}B'")
+        logger.info("DuckDB configured: threads=%d memory_limit_bytes=%d", settings.threads, settings.memory_limit_bytes)
+        self._install_secrets()
+
+    def _install_secrets(self) -> None:
+        """Load httpfs and create one DuckDB SECRET per object-store backend."""
+        cfg = self._config
+        self._con.execute("INSTALL httpfs")
+        self._con.execute("LOAD httpfs")
+        self._con.execute(
+            f"CREATE OR REPLACE SECRET ducky_gcs "
+            f"(TYPE GCS, KEY_ID {_sql_literal(cfg.gcs_hmac_key_id)}, SECRET {_sql_literal(cfg.gcs_hmac_secret)})"
+        )
+        self._con.execute(
+            f"CREATE OR REPLACE SECRET ducky_r2 "
+            f"(TYPE R2, ACCOUNT_ID {_sql_literal(cfg.r2_account_id)}, "
+            f"KEY_ID {_sql_literal(cfg.r2_access_key)}, SECRET {_sql_literal(cfg.r2_secret_key)})"
+        )
+        self._con.execute(
+            f"CREATE OR REPLACE SECRET ducky_cw "
+            f"(TYPE S3, ENDPOINT {_sql_literal(cfg.cw_endpoint)}, URL_STYLE 'path', "
+            f"KEY_ID {_sql_literal(cfg.cw_access_key)}, SECRET {_sql_literal(cfg.cw_secret_key)})"
+        )
+
+    def run_query(self, sql: str, query_id: str) -> QueryResult:
+        """Run ``sql`` once, spill the full result to parquet, and return a capped preview.
+
+        ``query_id`` must be a bare uuid4 hex (the server supplies it); anything else
+        raises ``ValueError`` to prevent path injection. DuckDB failures — including
+        cross-region/auth errors from httpfs — raise :class:`QueryError`.
+        """
+        if not _QUERY_ID_RE.match(query_id):
+            raise ValueError(f"query_id must be a uuid4 hex, got {query_id!r}")
+
+        result_path = f"{self._config.scratch_bucket.rstrip('/')}/ducky/{query_id}.parquet"
+        path_literal = _sql_literal(result_path)
+
+        try:
+            self._con.execute(f"COPY ({sql}) TO {path_literal} (FORMAT parquet)")
+            total_rows = self._con.execute(f"SELECT count(*) FROM read_parquet({path_literal})").fetchone()[0]
+            preview = self._con.execute(
+                f"SELECT * FROM read_parquet({path_literal}) LIMIT {self._config.preview_row_cap}"
+            ).fetch_arrow_table()
+        except duckdb.Error as e:
+            raise QueryError(str(e)) from e
+
+        columns = list(preview.column_names)
+        preview_rows = [[_coerce_cell(row[col]) for col in columns] for row in preview.to_pylist()]
+        return QueryResult(
+            columns=columns,
+            preview_rows=preview_rows,
+            total_rows=int(total_rows),
+            truncated=int(total_rows) > len(preview_rows),
+            result_path=result_path,
+        )
+
+    def close(self) -> None:
+        self._con.close()

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -28,17 +28,48 @@ logger = logging.getLogger(__name__)
 # query_id is interpolated into the result path, so it must be a bare uuid4 hex.
 _QUERY_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 
+# Object-store URIs referenced in the SQL (read_parquet('gs://…'), etc.). Stops at the
+# closing quote/paren/whitespace of the SQL literal.
+_OBJECT_URI_RE = re.compile(r"""(?:gs|s3|r2)://[^\s'")]+""", re.IGNORECASE)
+
+
+def _object_uris(sql: str) -> list[str]:
+    """Distinct gs://, s3://, r2:// URIs referenced literally in the SQL (order-preserving)."""
+    return list(dict.fromkeys(_OBJECT_URI_RE.findall(sql)))
+
+
+def _is_allowed(uri: str, allowed: tuple[str, ...]) -> bool:
+    """True if ``uri`` is covered by an allowlist entry (exact, scheme-only, or bucket prefix)."""
+    for entry in allowed:
+        if uri == entry or (entry.endswith("://") and uri.startswith(entry)):
+            return True
+        prefix = entry if entry.endswith("/") else entry + "/"
+        if uri.startswith(prefix):  # boundary-aware: gs://b does not match gs://b-evil
+            return True
+    return False
+
+
+def disallowed_uris(sql: str, allowed: tuple[str, ...]) -> list[str]:
+    """Object-store URIs in ``sql`` not covered by ``allowed``. Empty allowlist allows all."""
+    if not allowed:
+        return []
+    return [uri for uri in _object_uris(sql) if not _is_allowed(uri, allowed)]
+
 
 class DuckyError(Exception):
     """Base for ducky errors surfaced to the dashboard as a clean message."""
 
 
 class QueryError(DuckyError):
-    """DuckDB failed to plan or execute the SQL. Wraps the DuckDB message.
+    """DuckDB failed to plan or execute the SQL. Wraps the DuckDB message."""
 
-    Cross-region reads are not a distinct error in v1 — they surface here as an
-    httpfs authentication failure, because the injected creds are scoped to
-    same-region buckets.
+
+class BucketNotAllowedError(DuckyError):
+    """The query references an object-store URI outside the configured allowlist.
+
+    This is ducky's same-region guardrail: GCS HMAC keys are region-agnostic, so the
+    only way to keep queries in-region (avoiding cross-region egress) is to refuse
+    URIs whose bucket isn't allowlisted. Raised before any execution.
     """
 
 
@@ -146,6 +177,13 @@ class QueryRunner:
         """
         if not _QUERY_ID_RE.match(query_id):
             raise ValueError(f"query_id must be a uuid4 hex, got {query_id!r}")
+
+        blocked = disallowed_uris(sql, self._config.allowed_buckets)
+        if blocked:
+            raise BucketNotAllowedError(
+                f"query references buckets outside the allowlist: {', '.join(blocked)}; "
+                f"allowed prefixes: {', '.join(self._config.allowed_buckets)}"
+            )
 
         result_path = f"{self._config.scratch_bucket.rstrip('/')}/ducky/{query_id}.parquet"
         path_literal = _sql_literal(result_path)

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -25,6 +25,7 @@ import os
 import threading
 import time
 import uuid
+from collections import OrderedDict
 from concurrent.futures import Executor, ThreadPoolExecutor
 from pathlib import Path
 
@@ -84,21 +85,46 @@ class QueryManager:
     """
 
     def __init__(
-        self, runner: QueryRunner, executor: Executor | None = None, max_workers: int = 8, cache_ttl: float = 0.0
+        self,
+        runner: QueryRunner,
+        executor: Executor | None = None,
+        max_workers: int = 8,
+        cache_ttl: float = 0.0,
+        max_retained_states: int = 1024,
+        max_cache_entries: int = 256,
     ) -> None:
         self._runner = runner
         self._executor = executor or ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ducky-query")
-        self._states: dict[str, QueryState] = {}
-        self._cache: dict[str, tuple[QueryResult, float]] = {}  # sql -> (result, monotonic ts)
+        # Bounded LRU maps: an always-on service would otherwise grow the heap unbounded,
+        # since each result retains up to preview_row_cap rows. Oldest entries are evicted;
+        # an evicted query_id just 404s on /result (results also live on GCS).
+        self._states: OrderedDict[str, QueryState] = OrderedDict()
+        self._cache: OrderedDict[str, tuple[QueryResult, float]] = OrderedDict()  # sql -> (result, monotonic ts)
         self._cache_ttl = cache_ttl  # seconds; entries older than this are re-run (their parquet may be gone)
+        self._max_retained_states = max_retained_states
+        self._max_cache_entries = max_cache_entries
         self._lock = threading.Lock()
+
+    def _set_state(self, query_id: str, state: QueryState) -> None:
+        """Record a query's state (most-recent-last), evicting the oldest past the cap. Under the lock."""
+        self._states[query_id] = state
+        self._states.move_to_end(query_id)
+        while len(self._states) > self._max_retained_states:
+            self._states.popitem(last=False)
+
+    def _store_cache(self, sql: str, result: QueryResult) -> None:
+        """Cache a result (most-recent-last), evicting the oldest past the cap. Under the lock."""
+        self._cache[sql] = (result, time.monotonic())
+        self._cache.move_to_end(sql)
+        while len(self._cache) > self._max_cache_entries:
+            self._cache.popitem(last=False)
 
     def submit(self, sql: str) -> str:
         query_id = uuid.uuid4().hex
         with self._lock:
             cached = self._cached_result(sql)
             if cached is not None:
-                self._states[query_id] = QueryState(QueryStatus.DONE, result=cached, cached=True)
+                self._set_state(query_id, QueryState(QueryStatus.DONE, result=cached, cached=True))
                 logger.info(
                     "query %s cache hit (%d rows, %s): %s",
                     query_id,
@@ -107,7 +133,7 @@ class QueryManager:
                     _log_sql(sql),
                 )
                 return query_id
-            self._states[query_id] = QueryState(QueryStatus.RUNNING)
+            self._set_state(query_id, QueryState(QueryStatus.RUNNING))
         logger.info("query %s submitted: %s", query_id, _log_sql(sql))
         self._executor.submit(self._run, sql, query_id)
         return query_id
@@ -130,6 +156,7 @@ class QueryManager:
         if self._cache_ttl and (time.monotonic() - created) > self._cache_ttl:
             del self._cache[sql]
             return None
+        self._cache.move_to_end(sql)  # LRU: a hit keeps the entry fresh against eviction
         return result
 
     def _run(self, sql: str, query_id: str) -> None:
@@ -138,12 +165,12 @@ class QueryManager:
         except DuckyError as e:
             logger.warning("query %s failed: %s", query_id, str(e).splitlines()[0])
             with self._lock:
-                self._states[query_id] = QueryState(QueryStatus.ERROR, error=str(e))
+                self._set_state(query_id, QueryState(QueryStatus.ERROR, error=str(e)))
             return
         except Exception as e:  # background task: record instead of hanging in RUNNING forever
             logger.exception("query %s crashed", query_id)
             with self._lock:
-                self._states[query_id] = QueryState(QueryStatus.ERROR, error=f"internal error: {e}")
+                self._set_state(query_id, QueryState(QueryStatus.ERROR, error=f"internal error: {e}"))
             return
         logger.info(
             "query %s done: %d rows, %s, %d ms",
@@ -153,8 +180,8 @@ class QueryManager:
             result.elapsed_ms,
         )
         with self._lock:
-            self._cache[sql] = (result, time.monotonic())
-            self._states[query_id] = QueryState(QueryStatus.DONE, result=result, cached=False)
+            self._store_cache(sql, result)
+            self._set_state(query_id, QueryState(QueryStatus.DONE, result=result, cached=False))
 
     def shutdown(self) -> None:
         self._executor.shutdown(wait=False)

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -21,6 +21,7 @@ import dataclasses
 import enum
 import logging
 import threading
+import time
 import uuid
 from concurrent.futures import Executor, ThreadPoolExecutor
 
@@ -78,17 +79,20 @@ class QueryManager:
     are process-local; ducky is stateless and restartable, so a restart drops both.
     """
 
-    def __init__(self, runner: QueryRunner, executor: Executor | None = None, max_workers: int = 8) -> None:
+    def __init__(
+        self, runner: QueryRunner, executor: Executor | None = None, max_workers: int = 8, cache_ttl: float = 0.0
+    ) -> None:
         self._runner = runner
         self._executor = executor or ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ducky-query")
         self._states: dict[str, QueryState] = {}
-        self._cache: dict[str, QueryResult] = {}
+        self._cache: dict[str, tuple[QueryResult, float]] = {}  # sql -> (result, monotonic ts)
+        self._cache_ttl = cache_ttl  # seconds; entries older than this are re-run (their parquet may be gone)
         self._lock = threading.Lock()
 
     def submit(self, sql: str) -> str:
         query_id = uuid.uuid4().hex
         with self._lock:
-            cached = self._cache.get(sql)
+            cached = self._cached_result(sql)
             if cached is not None:
                 self._states[query_id] = QueryState(QueryStatus.DONE, result=cached, cached=True)
                 logger.info(
@@ -107,6 +111,22 @@ class QueryManager:
     def get(self, query_id: str) -> QueryState | None:
         with self._lock:
             return self._states.get(query_id)
+
+    def _cached_result(self, sql: str) -> QueryResult | None:
+        """Return a still-valid cached result, or None. Call under the lock.
+
+        Entries older than the cache TTL are dropped — their spilled parquet may have
+        been deleted by the scratch bucket's lifecycle rule, so the cached result_path
+        would dangle.
+        """
+        entry = self._cache.get(sql)
+        if entry is None:
+            return None
+        result, created = entry
+        if self._cache_ttl and (time.monotonic() - created) > self._cache_ttl:
+            del self._cache[sql]
+            return None
+        return result
 
     def _run(self, sql: str, query_id: str) -> None:
         try:
@@ -129,7 +149,7 @@ class QueryManager:
             result.elapsed_ms,
         )
         with self._lock:
-            self._cache[sql] = result
+            self._cache[sql] = (result, time.monotonic())
             self._states[query_id] = QueryState(QueryStatus.DONE, result=result, cached=False)
 
     def shutdown(self) -> None:
@@ -308,7 +328,12 @@ def create_app(runner: QueryRunner, config: DuckyConfig, executor: Executor | No
     ``executor`` overrides the query executor (tests inject a synchronous one).
     """
     index_html = _index_html(config.result_ttl_days)
-    manager = QueryManager(runner, executor=executor, max_workers=config.max_concurrent_queries)
+    manager = QueryManager(
+        runner,
+        executor=executor,
+        max_workers=config.max_concurrent_queries,
+        cache_ttl=config.result_ttl_days * 86400,
+    )
 
     @requires_auth
     async def index(_request: Request) -> HTMLResponse:

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -379,7 +379,9 @@ class _QuietPolls(logging.Filter):
         return '"GET /result/' not in message and '"GET /health ' not in message
 
 
-_RESTART_DELAY = 3  # seconds between supervised server restarts
+_RESTART_DELAY = 3  # base seconds between supervised server restarts
+_RESTART_DELAY_MAX = 300  # cap on the backoff for a crash-looping server
+_HEALTHY_RUNTIME = 60  # a child that ran at least this long is "healthy" → reset the backoff
 
 
 def _serve() -> None:
@@ -414,14 +416,20 @@ def main() -> None:
     A cgroup OOM-kill reaps the largest process — the server child — while this tiny
     supervisor survives, so ducky restarts in-process without consuming an Iris job
     retry. If the whole cgroup is killed the Iris task retry is the backstop.
+
+    Restarts back off exponentially (capped) so a server that crash-loops on a permanent
+    fault (e.g. bad config) doesn't hot-loop; the backoff resets once a child stays up.
     """
     logging.basicConfig(level=logging.INFO)
+    delay = _RESTART_DELAY
     while True:
+        started = time.monotonic()
         server = multiprocessing.Process(target=_serve, name="ducky-server")
         server.start()
         server.join()
-        logger.error("ducky server exited (exitcode=%s) — restarting in %ds", server.exitcode, _RESTART_DELAY)
-        time.sleep(_RESTART_DELAY)
+        delay = _RESTART_DELAY if time.monotonic() - started >= _HEALTHY_RUNTIME else min(delay * 2, _RESTART_DELAY_MAX)
+        logger.error("ducky server exited (exitcode=%s) — restarting in %ds", server.exitcode, delay)
+        time.sleep(delay)
 
 
 if __name__ == "__main__":

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -1,0 +1,201 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""ducky's Starlette dashboard: paste SQL, run it, see a capped result table.
+
+The page talks plain JSON to ``POST query`` (relative URL, so it works behind the
+controller's ``/proxy/ducky/`` prefix). ``main()`` wires the app to an Iris named
+port and registers it with the endpoint registry so the controller can route to it.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections.abc import AsyncGenerator
+from contextlib import asynccontextmanager
+
+import uvicorn
+from iris.client.client import iris_ctx
+from iris.cluster.client.job_info import get_job_info
+from iris.cluster.dashboard_common import public, requires_auth
+from starlette.applications import Starlette
+from starlette.concurrency import run_in_threadpool
+from starlette.requests import Request
+from starlette.responses import HTMLResponse, JSONResponse
+from starlette.routing import Route
+
+from ducky.config import DuckyConfig
+from ducky.runner import DuckyError, QueryRunner
+
+logger = logging.getLogger(__name__)
+
+
+def _index_html(ttl_days: int) -> str:
+    return f"""\
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<title>ducky</title>
+<style>
+  body {{ font-family: system-ui, sans-serif; margin: 2rem; }}
+  textarea {{ width: 100%; height: 12rem; font-family: monospace; font-size: 13px; }}
+  button {{ margin-top: .5rem; padding: .4rem 1rem; font-size: 14px; }}
+  #status {{ margin: .5rem 0; color: #555; }}
+  table {{ border-collapse: collapse; margin-top: 1rem; font-size: 13px; }}
+  th, td {{ border: 1px solid #ccc; padding: .2rem .5rem; text-align: left; }}
+  th {{ background: #f0f0f0; }}
+  .error {{ color: #b00; white-space: pre-wrap; font-family: monospace; }}
+</style>
+</head>
+<body>
+<h1>🦆 ducky</h1>
+<textarea id="sql" placeholder="SELECT * FROM read_parquet('gs://bucket/path/*.parquet') LIMIT 100"></textarea>
+<div><button id="run">Run</button></div>
+<div id="status"></div>
+<div id="result"></div>
+<script>
+const TTL_DAYS = {ttl_days};
+const runBtn = document.getElementById("run");
+const sqlEl = document.getElementById("sql");
+const statusEl = document.getElementById("status");
+const resultEl = document.getElementById("result");
+
+async function run() {{
+  const sql = sqlEl.value.trim();
+  if (!sql) return;
+  runBtn.disabled = true;
+  statusEl.textContent = "Running…";
+  resultEl.innerHTML = "";
+  try {{
+    const resp = await fetch("query", {{
+      method: "POST",
+      headers: {{ "Content-Type": "application/json" }},
+      body: JSON.stringify({{ sql }}),
+    }});
+    const data = await resp.json();
+    if (!resp.ok) {{
+      statusEl.textContent = "";
+      resultEl.innerHTML = '<div class="error"></div>';
+      resultEl.firstChild.textContent = data.error || ("HTTP " + resp.status);
+      return;
+    }}
+    renderTable(data);
+  }} catch (e) {{
+    statusEl.textContent = "";
+    resultEl.innerHTML = '<div class="error"></div>';
+    resultEl.firstChild.textContent = String(e);
+  }} finally {{
+    runBtn.disabled = false;
+  }}
+}}
+
+function renderTable(data) {{
+  const shown = data.rows.length;
+  let msg = shown + " row" + (shown === 1 ? "" : "s");
+  if (data.truncated) {{
+    msg = "showing " + shown + " of " + data.total_rows
+        + " rows — full result at " + data.result_path + " (expires in " + TTL_DAYS + "d)";
+  }}
+  statusEl.textContent = msg;
+  const thead = "<tr>" + data.columns.map(c => "<th></th>").join("") + "</tr>";
+  const table = document.createElement("table");
+  table.innerHTML = "<thead>" + thead + "</thead><tbody></tbody>";
+  table.querySelectorAll("th").forEach((th, i) => th.textContent = data.columns[i]);
+  const tbody = table.querySelector("tbody");
+  for (const row of data.rows) {{
+    const tr = document.createElement("tr");
+    for (const cell of row) {{
+      const td = document.createElement("td");
+      td.textContent = cell === null ? "NULL" : String(cell);
+      tr.appendChild(td);
+    }}
+    tbody.appendChild(tr);
+  }}
+  resultEl.innerHTML = "";
+  resultEl.appendChild(table);
+}}
+
+runBtn.addEventListener("click", run);
+sqlEl.addEventListener("keydown", e => {{
+  if ((e.ctrlKey || e.metaKey) && e.key === "Enter") run();
+}});
+</script>
+</body>
+</html>
+"""
+
+
+def create_app(runner: QueryRunner, config: DuckyConfig) -> Starlette:
+    """Build the ducky Starlette app over a query runner. No Iris context required."""
+    index_html = _index_html(config.result_ttl_days)
+
+    @requires_auth
+    async def index(_request: Request) -> HTMLResponse:
+        return HTMLResponse(index_html)
+
+    @requires_auth
+    async def query(request: Request) -> JSONResponse:
+        body = await request.json()
+        sql = body.get("sql")
+        if not isinstance(sql, str) or not sql.strip():
+            return JSONResponse({"error": "missing 'sql'"}, status_code=400)
+        query_id = uuid.uuid4().hex
+        try:
+            result = await run_in_threadpool(runner.run_query, sql, query_id)
+        except DuckyError as e:
+            return JSONResponse({"error": str(e)}, status_code=400)
+        return JSONResponse(
+            {
+                "columns": result.columns,
+                "rows": result.preview_rows,
+                "total_rows": result.total_rows,
+                "truncated": result.truncated,
+                "result_path": result.result_path,
+            }
+        )
+
+    @public
+    async def health(_request: Request) -> JSONResponse:
+        return JSONResponse({"status": "healthy"})
+
+    return Starlette(
+        routes=[
+            Route("/", index),
+            Route("/query", query, methods=["POST"]),
+            Route("/health", health),
+        ]
+    )
+
+
+def main() -> None:
+    logging.basicConfig(level=logging.INFO)
+    config = DuckyConfig.from_environment()
+    runner = QueryRunner(config)
+    app = create_app(runner, config)
+
+    ctx = iris_ctx()
+    job_info = get_job_info()
+    if job_info is None:
+        raise RuntimeError("No Iris job info available — ducky must run inside an Iris job")
+    port = ctx.get_port(config.port_name)
+    address = f"http://{job_info.advertise_host}:{port}"
+
+    endpoint_id = ctx.registry.register(config.port_name, address, {"job_id": ctx.job_id.to_wire()})
+    logger.info("ducky registered as %s at %s", config.port_name, address)
+
+    @asynccontextmanager
+    async def lifespan(_app: Starlette) -> AsyncGenerator[None, None]:
+        try:
+            yield
+        finally:
+            ctx.registry.unregister(endpoint_id)
+            logger.info("ducky endpoint unregistered")
+
+    app.router.lifespan_context = lifespan
+    uvicorn.run(app, host="0.0.0.0", port=port)
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -39,7 +39,7 @@ from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Mount, Route
 from starlette.staticfiles import StaticFiles
 
-from ducky.config import DuckyConfig
+from ducky.config import ENDPOINT_NAME, PORT_NAME, DuckyConfig
 from ducky.runner import DuckyError, QueryResult, QueryRunner
 
 logger = logging.getLogger(__name__)
@@ -119,10 +119,13 @@ class QueryManager:
         while len(self._cache) > self._max_cache_entries:
             self._cache.popitem(last=False)
 
-    def submit(self, sql: str) -> str:
+    def submit(self, sql: str, use_cache: bool = True) -> str:
+        """Submit ``sql`` and return a query_id. With ``use_cache`` (default), identical SQL
+        served earlier returns instantly from the cache; pass ``use_cache=False`` to force a
+        fresh run (e.g. when the underlying data changed) — it still refreshes the cache."""
         query_id = uuid.uuid4().hex
         with self._lock:
-            cached = self._cached_result(sql)
+            cached = self._cached_result(sql) if use_cache else None
             if cached is not None:
                 self._set_state(query_id, QueryState(QueryStatus.DONE, result=cached, cached=True))
                 logger.info(
@@ -265,7 +268,8 @@ def create_app(runner: QueryRunner, config: DuckyConfig, executor: Executor | No
         sql = body.get("sql")
         if not isinstance(sql, str) or not sql.strip():
             return JSONResponse({"error": "missing 'sql'"}, status_code=400)
-        return JSONResponse({"query_id": manager.submit(sql)}, status_code=202)
+        use_cache = body.get("use_cache", True)
+        return JSONResponse({"query_id": manager.submit(sql, use_cache=bool(use_cache))}, status_code=202)
 
     @requires_auth
     async def result(request: Request) -> JSONResponse:
@@ -321,11 +325,11 @@ def _serve() -> None:
     job_info = get_job_info()
     if job_info is None:
         raise RuntimeError("No Iris job info available — ducky must run inside an Iris job")
-    port = ctx.get_port(config.port_name)
+    port = ctx.get_port(PORT_NAME)
     address = f"http://{job_info.advertise_host}:{port}"
 
-    endpoint_id = ctx.registry.register(config.endpoint_name, address, {"job_id": ctx.job_id.to_wire()})
-    logger.info("ducky registered as %s at %s", config.endpoint_name, address)
+    endpoint_id = ctx.registry.register(ENDPOINT_NAME, address, {"job_id": ctx.job_id.to_wire()})
+    logger.info("ducky registered as %s at %s", ENDPOINT_NAME, address)
 
     async def _on_shutdown() -> None:
         ctx.registry.unregister(endpoint_id)

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -21,10 +21,12 @@ import dataclasses
 import enum
 import logging
 import multiprocessing
+import os
 import threading
 import time
 import uuid
 from concurrent.futures import Executor, ThreadPoolExecutor
+from pathlib import Path
 
 import uvicorn
 from iris.client.client import iris_ctx
@@ -33,7 +35,8 @@ from iris.cluster.dashboard_common import on_shutdown, public, requires_auth
 from starlette.applications import Starlette
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
-from starlette.routing import Route
+from starlette.routing import Mount, Route
+from starlette.staticfiles import StaticFiles
 
 from ducky.config import DuckyConfig
 from ducky.runner import DuckyError, QueryResult, QueryRunner
@@ -177,150 +180,39 @@ def _result_payload(state: QueryState) -> dict:
     }
 
 
-# CodeMirror 5 (SQL mode) gives DuckDB-flavored SQL highlighting from a CDN — loaded
-# by the browser, so no server-side egress. __TTL_DAYS__ is substituted per config.
-_INDEX_HTML = """\
-<!doctype html>
-<html lang="en">
-<head>
-<meta charset="utf-8">
-<title>ducky</title>
-<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/sql/sql.min.js"></script>
-<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/display/placeholder.min.js"></script>
-<style>
-  body { font-family: system-ui, sans-serif; margin: 2rem; }
-  .CodeMirror { border: 1px solid #ccc; height: 12rem; font-size: 13px; }
-  .CodeMirror-placeholder { color: #aaa !important; font-style: italic; }
-  button { margin-top: .5rem; padding: .4rem 1rem; font-size: 14px; }
-  #status { margin: .6rem 0; color: #555; }
-  #status .cached { color: #2a7; font-weight: 600; }
-  #status .computed { color: #888; }
-  #status .loc { font-family: monospace; }
-  table { border-collapse: collapse; margin-top: 1rem; font-size: 13px; }
-  th, td { border: 1px solid #ccc; padding: .2rem .5rem; text-align: left; }
-  th { background: #f0f0f0; }
-  .error { color: #b00; white-space: pre-wrap; font-family: monospace; }
-</style>
-</head>
-<body>
-<h1>🦆 ducky</h1>
-<textarea id="sql" placeholder="SELECT * FROM read_parquet('gs://bucket/path/*.parquet') LIMIT 100"></textarea>
-<div><button id="run">Run</button> <span style="color:#888;font-size:12px">(⌘/Ctrl-Enter)</span></div>
-<div id="status"></div>
-<div id="result"></div>
-<script>
-const TTL_DAYS = __TTL_DAYS__;
-const POLL_MS = 1000;
-const runBtn = document.getElementById("run");
-const statusEl = document.getElementById("status");
-const resultEl = document.getElementById("result");
-
-const editor = CodeMirror.fromTextArea(document.getElementById("sql"), {
-  mode: "text/x-sql",
-  lineNumbers: true,
-  lineWrapping: true,
-  placeholder: "-- write DuckDB SQL, then \\u2318/Ctrl-Enter to run\\n"
-    + "SELECT *\\nFROM read_parquet('gs://marin-us-east5/<path>/*.parquet')\\nLIMIT 100",
-  extraKeys: { "Cmd-Enter": run, "Ctrl-Enter": run },
-});
-
-function showError(msg) {
-  statusEl.textContent = "";
-  resultEl.innerHTML = '<div class="error"></div>';
-  resultEl.firstChild.textContent = msg;
-}
-
-async function run() {
-  const sql = editor.getValue().trim();
-  if (!sql) return;
-  runBtn.disabled = true;
-  statusEl.textContent = "Submitting…";
-  resultEl.innerHTML = "";
-  try {
-    const resp = await fetch("query", {
-      method: "POST",
-      headers: { "Content-Type": "application/json" },
-      body: JSON.stringify({ sql }),
-    });
-    const data = await resp.json();
-    if (!resp.ok) { showError(data.error || ("HTTP " + resp.status)); runBtn.disabled = false; return; }
-    poll(data.query_id);
-  } catch (e) {
-    showError(String(e));
-    runBtn.disabled = false;
-  }
-}
-
-async function poll(queryId) {
-  statusEl.textContent = "Running…";
-  try {
-    const resp = await fetch("result/" + queryId);
-    const data = await resp.json();
-    if (!resp.ok) { showError(data.error || ("HTTP " + resp.status)); runBtn.disabled = false; return; }
-    if (data.status === "running") { setTimeout(() => poll(queryId), POLL_MS); return; }
-    if (data.status === "error") { showError(data.error); runBtn.disabled = false; return; }
-    renderResult(data);
-  } catch (e) {
-    showError(String(e));
-    runBtn.disabled = false;
-  }
-}
-
-function fmtBytes(n) {
-  if (n == null) return "?";
-  const u = ["B", "KB", "MB", "GB", "TB"];
-  let i = 0;
-  while (n >= 1024 && i < u.length - 1) { n /= 1024; i++; }
-  return (i === 0 ? n : n.toFixed(1)) + " " + u[i];
-}
-function fmtDuration(ms) {
-  if (ms == null) return "?";
-  return ms < 1000 ? ms + " ms" : (ms / 1000).toFixed(ms < 10000 ? 2 : 1) + " s";
-}
-
-function renderResult(data) {
-  const shown = data.rows.length;
-  const rowsLabel = data.truncated
-    ? "showing " + shown + " of " + data.total_rows + " rows"
-    : shown + " row" + (shown === 1 ? "" : "s");
-  const cacheBadge = data.cached
-    ? '<span class="cached">cached ✓</span>'
-    : '<span class="computed">computed</span>';
-  statusEl.innerHTML = rowsLabel
-    + " · " + fmtDuration(data.elapsed_ms) + " · " + fmtBytes(data.result_bytes) + " result"
-    + " · " + cacheBadge
-    + ' · output: <span class="loc"></span> <span style="color:#888">(expires in ' + TTL_DAYS + "d)</span>";
-  statusEl.querySelector(".loc").textContent = data.result_path;
-
-  const table = document.createElement("table");
-  table.innerHTML = "<thead><tr>" + data.columns.map(() => "<th></th>").join("") + "</tr></thead><tbody></tbody>";
-  table.querySelectorAll("th").forEach((th, i) => th.textContent = data.columns[i]);
-  const tbody = table.querySelector("tbody");
-  for (const row of data.rows) {
-    const tr = document.createElement("tr");
-    for (const cell of row) {
-      const td = document.createElement("td");
-      td.textContent = cell === null ? "NULL" : String(cell);
-      tr.appendChild(td);
-    }
-    tbody.appendChild(tr);
-  }
-  resultEl.innerHTML = "";
-  resultEl.appendChild(table);
-  runBtn.disabled = false;
-}
-
-runBtn.addEventListener("click", run);
-</script>
-</body>
-</html>
-"""
+# The dashboard is a bundled Vue SPA built into dashboard/dist by `npm run build`
+# (gitignored; shipped in the Iris bundle via GENERATED_ARTIFACT_GLOBS). Resolve its
+# dist dir: env override → the in-repo build output next to this package.
+def _dashboard_dist() -> Path:
+    override = os.environ.get("DUCKY_DASHBOARD_DIST")
+    if override:
+        return Path(override)
+    return Path(__file__).resolve().parents[2] / "dashboard" / "dist"
 
 
-def _index_html(ttl_days: int) -> str:
-    return _INDEX_HTML.replace("__TTL_DAYS__", str(ttl_days))
+_NOT_BUILT_HTML = (
+    "<!doctype html><meta charset=utf-8><title>ducky</title>"
+    "<body style='font-family:system-ui;margin:3rem'><h1>🦆 ducky</h1>"
+    "<p>Dashboard not built — run "
+    "<code>npm --prefix lib/ducky/dashboard install &amp;&amp; npm --prefix lib/ducky/dashboard run build</code>.</p>"
+)
+
+
+def _index_html(dist: Path, forwarded_prefix: str) -> HTMLResponse:
+    """Serve dist/index.html, rewriting ``<base href="/">`` to the proxy sub-path.
+
+    The controller proxy sets ``X-Forwarded-Prefix`` (e.g. ``/proxy/ducky``) in
+    path-style mode; rewriting the base makes the SPA's relative asset and API URLs
+    resolve under it. Empty prefix (subdomain/direct) leaves the base at ``/``.
+    """
+    index_path = dist / "index.html"
+    if not index_path.is_file():
+        return HTMLResponse(_NOT_BUILT_HTML, status_code=503)
+    html = index_path.read_text(encoding="utf-8")
+    prefix = forwarded_prefix.rstrip("/")
+    if prefix:
+        html = html.replace('<base href="/"', f'<base href="{prefix}/"', 1)
+    return HTMLResponse(html)
 
 
 def create_app(runner: QueryRunner, config: DuckyConfig, executor: Executor | None = None) -> Starlette:
@@ -328,7 +220,7 @@ def create_app(runner: QueryRunner, config: DuckyConfig, executor: Executor | No
 
     ``executor`` overrides the query executor (tests inject a synchronous one).
     """
-    index_html = _index_html(config.result_ttl_days)
+    dist = _dashboard_dist()
     manager = QueryManager(
         runner,
         executor=executor,
@@ -337,8 +229,8 @@ def create_app(runner: QueryRunner, config: DuckyConfig, executor: Executor | No
     )
 
     @requires_auth
-    async def index(_request: Request) -> HTMLResponse:
-        return HTMLResponse(index_html)
+    async def index(request: Request) -> HTMLResponse:
+        return _index_html(dist, request.headers.get("x-forwarded-prefix", ""))
 
     @requires_auth
     async def query(request: Request) -> JSONResponse:
@@ -355,18 +247,25 @@ def create_app(runner: QueryRunner, config: DuckyConfig, executor: Executor | No
             return JSONResponse({"error": "unknown query_id"}, status_code=404)
         return JSONResponse(_result_payload(state))
 
+    @requires_auth
+    async def api_config(_request: Request) -> JSONResponse:
+        return JSONResponse({"result_ttl_days": config.result_ttl_days})
+
     @public
     async def health(_request: Request) -> JSONResponse:
         return JSONResponse({"status": "healthy"})
 
-    app = Starlette(
-        routes=[
-            Route("/", index),
-            Route("/query", query, methods=["POST"]),
-            Route("/result/{query_id:str}", result),
-            Route("/health", health),
-        ]
-    )
+    routes = [
+        Route("/", index),
+        Route("/query", query, methods=["POST"]),
+        Route("/result/{query_id:str}", result),
+        Route("/api/config", api_config),
+        Route("/health", health),
+    ]
+    # check_dir=False: the app still boots (index shows a "not built" page) when the
+    # SPA hasn't been built yet, instead of raising at startup.
+    routes.append(Mount("/static", StaticFiles(directory=dist / "static", check_dir=False), name="static"))
+    app = Starlette(routes=routes)
     app.state.query_manager = manager
     return app
 

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -39,6 +39,21 @@ from ducky.runner import DuckyError, QueryResult, QueryRunner
 logger = logging.getLogger(__name__)
 
 
+def _log_sql(sql: str, limit: int = 300) -> str:
+    """Collapse SQL to a single truncated line for logging."""
+    one_line = " ".join(sql.split())
+    return one_line if len(one_line) <= limit else one_line[: limit - 1] + "…"
+
+
+def _human_bytes(n: int) -> str:
+    size = float(n)
+    for unit in ("B", "KB", "MB", "GB", "TB"):
+        if size < 1024 or unit == "TB":
+            return f"{int(size)} {unit}" if unit == "B" else f"{size:.1f} {unit}"
+        size /= 1024
+    return f"{n} B"
+
+
 class QueryStatus(enum.StrEnum):
     RUNNING = "running"
     DONE = "done"
@@ -77,8 +92,16 @@ class QueryManager:
             cached = self._cache.get(sql)
             if cached is not None:
                 self._states[query_id] = QueryState(QueryStatus.DONE, result=cached, cached=True)
+                logger.info(
+                    "query %s cache hit (%d rows, %s): %s",
+                    query_id,
+                    cached.total_rows,
+                    _human_bytes(cached.result_bytes),
+                    _log_sql(sql),
+                )
                 return query_id
             self._states[query_id] = QueryState(QueryStatus.RUNNING)
+        logger.info("query %s submitted: %s", query_id, _log_sql(sql))
         self._executor.submit(self._run, sql, query_id)
         return query_id
 
@@ -90,14 +113,22 @@ class QueryManager:
         try:
             result = self._runner.run_query(sql, query_id)
         except DuckyError as e:
+            logger.warning("query %s failed: %s", query_id, str(e).splitlines()[0])
             with self._lock:
                 self._states[query_id] = QueryState(QueryStatus.ERROR, error=str(e))
             return
         except Exception as e:  # background task: record instead of hanging in RUNNING forever
-            logger.exception("Unexpected error running query %s", query_id)
+            logger.exception("query %s crashed", query_id)
             with self._lock:
                 self._states[query_id] = QueryState(QueryStatus.ERROR, error=f"internal error: {e}")
             return
+        logger.info(
+            "query %s done: %d rows, %s, %d ms",
+            query_id,
+            result.total_rows,
+            _human_bytes(result.result_bytes),
+            result.elapsed_ms,
+        )
         with self._lock:
             self._cache[sql] = result
             self._states[query_id] = QueryState(QueryStatus.DONE, result=result, cached=False)
@@ -315,8 +346,17 @@ def create_app(runner: QueryRunner, config: DuckyConfig, executor: Executor | No
     return app
 
 
+class _QuietPolls(logging.Filter):
+    """Drop the high-frequency dashboard-poll access lines so query lifecycle logs stand out."""
+
+    def filter(self, record: logging.LogRecord) -> bool:
+        message = record.getMessage()
+        return '"GET /result/' not in message and '"GET /health ' not in message
+
+
 def main() -> None:
     logging.basicConfig(level=logging.INFO)
+    logging.getLogger("uvicorn.access").addFilter(_QuietPolls())
     config = DuckyConfig.from_environment()
     runner = QueryRunner(config)
     app = create_app(runner, config)

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -69,19 +69,18 @@ class QueryState:
 
 
 class QueryManager:
-    """Runs queries one at a time in a background thread and tracks their state.
+    """Runs queries in a background thread pool and tracks their state.
 
-    A single-worker executor serializes execution (one DuckDB query at a time, per
-    design); ``submit`` returns immediately so the HTTP request never blocks on the
-    query. Identical SQL is served from an in-memory result cache keyed on the exact
-    query text — a cache hit reuses the prior spilled parquet and returns instantly
-    with ``cached=True``. State and cache are process-local; ducky is stateless and
-    restartable, so a restart drops both.
+    Up to ``max_workers`` queries run concurrently; ``submit`` returns immediately so
+    the HTTP request never blocks on the query. Identical SQL is served from an
+    in-memory result cache keyed on the exact query text — a cache hit reuses the
+    prior spilled parquet and returns instantly with ``cached=True``. State and cache
+    are process-local; ducky is stateless and restartable, so a restart drops both.
     """
 
-    def __init__(self, runner: QueryRunner, executor: Executor | None = None) -> None:
+    def __init__(self, runner: QueryRunner, executor: Executor | None = None, max_workers: int = 8) -> None:
         self._runner = runner
-        self._executor = executor or ThreadPoolExecutor(max_workers=1, thread_name_prefix="ducky-query")
+        self._executor = executor or ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ducky-query")
         self._states: dict[str, QueryState] = {}
         self._cache: dict[str, QueryResult] = {}
         self._lock = threading.Lock()
@@ -309,7 +308,7 @@ def create_app(runner: QueryRunner, config: DuckyConfig, executor: Executor | No
     ``executor`` overrides the query executor (tests inject a synchronous one).
     """
     index_html = _index_html(config.result_ttl_days)
-    manager = QueryManager(runner, executor=executor)
+    manager = QueryManager(runner, executor=executor, max_workers=config.max_concurrent_queries)
 
     @requires_auth
     async def index(_request: Request) -> HTMLResponse:

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -22,7 +22,7 @@ import enum
 import logging
 import threading
 import uuid
-from concurrent.futures import ThreadPoolExecutor
+from concurrent.futures import Executor, ThreadPoolExecutor
 
 import uvicorn
 from iris.client.client import iris_ctx
@@ -64,9 +64,9 @@ class QueryManager:
     restartable, so a restart drops both.
     """
 
-    def __init__(self, runner: QueryRunner) -> None:
+    def __init__(self, runner: QueryRunner, executor: Executor | None = None) -> None:
         self._runner = runner
-        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ducky-query")
+        self._executor = executor or ThreadPoolExecutor(max_workers=1, thread_name_prefix="ducky-query")
         self._states: dict[str, QueryState] = {}
         self._cache: dict[str, QueryResult] = {}
         self._lock = threading.Lock()
@@ -272,10 +272,13 @@ def _index_html(ttl_days: int) -> str:
     return _INDEX_HTML.replace("__TTL_DAYS__", str(ttl_days))
 
 
-def create_app(runner: QueryRunner, config: DuckyConfig) -> Starlette:
-    """Build the ducky Starlette app over a query runner. No Iris context required."""
+def create_app(runner: QueryRunner, config: DuckyConfig, executor: Executor | None = None) -> Starlette:
+    """Build the ducky Starlette app over a query runner. No Iris context required.
+
+    ``executor`` overrides the query executor (tests inject a synchronous one).
+    """
     index_html = _index_html(config.result_ttl_days)
-    manager = QueryManager(runner)
+    manager = QueryManager(runner, executor=executor)
 
     @requires_auth
     async def index(_request: Request) -> HTMLResponse:

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -121,6 +121,8 @@ def _result_payload(state: QueryState) -> dict:
         "truncated": result.truncated,
         "result_path": result.result_path,
         "cached": state.cached,
+        "elapsed_ms": result.elapsed_ms,
+        "result_bytes": result.result_bytes,
     }
 
 
@@ -215,6 +217,18 @@ async function poll(queryId) {
   }
 }
 
+function fmtBytes(n) {
+  if (n == null) return "?";
+  const u = ["B", "KB", "MB", "GB", "TB"];
+  let i = 0;
+  while (n >= 1024 && i < u.length - 1) { n /= 1024; i++; }
+  return (i === 0 ? n : n.toFixed(1)) + " " + u[i];
+}
+function fmtDuration(ms) {
+  if (ms == null) return "?";
+  return ms < 1000 ? ms + " ms" : (ms / 1000).toFixed(ms < 10000 ? 2 : 1) + " s";
+}
+
 function renderResult(data) {
   const shown = data.rows.length;
   const rowsLabel = data.truncated
@@ -223,7 +237,9 @@ function renderResult(data) {
   const cacheBadge = data.cached
     ? '<span class="cached">cached ✓</span>'
     : '<span class="computed">computed</span>';
-  statusEl.innerHTML = rowsLabel + " · " + cacheBadge
+  statusEl.innerHTML = rowsLabel
+    + " · " + fmtDuration(data.elapsed_ms) + " · " + fmtBytes(data.result_bytes) + " result"
+    + " · " + cacheBadge
     + ' · output: <span class="loc"></span> <span style="color:#888">(expires in ' + TTL_DAYS + "d)</span>";
   statusEl.querySelector(".loc").textContent = data.result_path;
 

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -4,9 +4,9 @@
 """ducky's Starlette dashboard: paste SQL, run it, see a capped result table.
 
 Queries run **asynchronously**: ``POST /query`` returns a ``query_id`` immediately
-and the SQL runs in a background single-worker executor (one DuckDB query at a
-time); the page polls ``GET /result/{query_id}`` until it is done. This decouples a
-long query from the Iris controller proxy's 30 s request timeout
+and the SQL runs in a background thread pool (up to ``max_concurrent_queries``, each on
+its own DuckDB cursor); the page polls ``GET /result/{query_id}`` until it is done. This
+decouples a long query from the Iris controller proxy's 30 s request timeout
 (``endpoint_proxy.PROXY_TIMEOUT_SECONDS``) — each HTTP call returns in well under
 30 s while the query itself may run for minutes.
 

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -12,13 +12,11 @@ from __future__ import annotations
 
 import logging
 import uuid
-from collections.abc import AsyncGenerator
-from contextlib import asynccontextmanager
 
 import uvicorn
 from iris.client.client import iris_ctx
 from iris.cluster.client.job_info import get_job_info
-from iris.cluster.dashboard_common import public, requires_auth
+from iris.cluster.dashboard_common import on_shutdown, public, requires_auth
 from starlette.applications import Starlette
 from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
@@ -185,15 +183,11 @@ def main() -> None:
     endpoint_id = ctx.registry.register(config.port_name, address, {"job_id": ctx.job_id.to_wire()})
     logger.info("ducky registered as %s at %s", config.port_name, address)
 
-    @asynccontextmanager
-    async def lifespan(_app: Starlette) -> AsyncGenerator[None, None]:
-        try:
-            yield
-        finally:
-            ctx.registry.unregister(endpoint_id)
-            logger.info("ducky endpoint unregistered")
+    async def _unregister() -> None:
+        ctx.registry.unregister(endpoint_id)
+        logger.info("ducky endpoint unregistered")
 
-    app.router.lifespan_context = lifespan
+    app.router.lifespan_context = on_shutdown(_unregister)
     uvicorn.run(app, host="0.0.0.0", port=port)
 
 

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -135,9 +135,11 @@ _INDEX_HTML = """\
 <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/sql/sql.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/addon/display/placeholder.min.js"></script>
 <style>
   body { font-family: system-ui, sans-serif; margin: 2rem; }
   .CodeMirror { border: 1px solid #ccc; height: 12rem; font-size: 13px; }
+  .CodeMirror-placeholder { color: #aaa !important; font-style: italic; }
   button { margin-top: .5rem; padding: .4rem 1rem; font-size: 14px; }
   #status { margin: .6rem 0; color: #555; }
   #status .cached { color: #2a7; font-weight: 600; }
@@ -166,6 +168,7 @@ const editor = CodeMirror.fromTextArea(document.getElementById("sql"), {
   mode: "text/x-sql",
   lineNumbers: true,
   lineWrapping: true,
+  placeholder: "-- write DuckDB SQL, then \\u2318/Ctrl-Enter to run\\nSELECT *\\nFROM read_parquet('gs://marin-us-east5/<path>/*.parquet')\\nLIMIT 100",
   extraKeys: { "Cmd-Enter": run, "Ctrl-Enter": run },
 });
 

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -20,6 +20,7 @@ from __future__ import annotations
 import dataclasses
 import enum
 import logging
+import multiprocessing
 import threading
 import time
 import uuid
@@ -378,8 +379,11 @@ class _QuietPolls(logging.Filter):
         return '"GET /result/' not in message and '"GET /health ' not in message
 
 
-def main() -> None:
-    logging.basicConfig(level=logging.INFO)
+_RESTART_DELAY = 3  # seconds between supervised server restarts
+
+
+def _serve() -> None:
+    """Serve ducky in this process. Runs in a supervised child (see `main`)."""
     logging.getLogger("uvicorn.access").addFilter(_QuietPolls())
     config = DuckyConfig.from_environment()
     runner = QueryRunner(config)
@@ -402,6 +406,22 @@ def main() -> None:
 
     app.router.lifespan_context = on_shutdown(_on_shutdown)
     uvicorn.run(app, host="0.0.0.0", port=port)
+
+
+def main() -> None:
+    """Supervise the server: run it in a child process and restart it if it exits.
+
+    A cgroup OOM-kill reaps the largest process — the server child — while this tiny
+    supervisor survives, so ducky restarts in-process without consuming an Iris job
+    retry. If the whole cgroup is killed the Iris task retry is the backstop.
+    """
+    logging.basicConfig(level=logging.INFO)
+    while True:
+        server = multiprocessing.Process(target=_serve, name="ducky-server")
+        server.start()
+        server.join()
+        logger.error("ducky server exited (exitcode=%s) — restarting in %ds", server.exitcode, _RESTART_DELAY)
+        time.sleep(_RESTART_DELAY)
 
 
 if __name__ == "__main__":

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -50,6 +50,7 @@ class QueryState:
     status: QueryStatus
     result: QueryResult | None = None
     error: str | None = None
+    cached: bool = False
 
 
 class QueryManager:
@@ -57,19 +58,26 @@ class QueryManager:
 
     A single-worker executor serializes execution (one DuckDB query at a time, per
     design); ``submit`` returns immediately so the HTTP request never blocks on the
-    query. State is kept in memory for the process lifetime — ducky is a stateless,
-    restartable service, so a restart simply drops in-flight/finished query state.
+    query. Identical SQL is served from an in-memory result cache keyed on the exact
+    query text — a cache hit reuses the prior spilled parquet and returns instantly
+    with ``cached=True``. State and cache are process-local; ducky is stateless and
+    restartable, so a restart drops both.
     """
 
     def __init__(self, runner: QueryRunner) -> None:
         self._runner = runner
         self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ducky-query")
         self._states: dict[str, QueryState] = {}
+        self._cache: dict[str, QueryResult] = {}
         self._lock = threading.Lock()
 
     def submit(self, sql: str) -> str:
         query_id = uuid.uuid4().hex
         with self._lock:
+            cached = self._cache.get(sql)
+            if cached is not None:
+                self._states[query_id] = QueryState(QueryStatus.DONE, result=cached, cached=True)
+                return query_id
             self._states[query_id] = QueryState(QueryStatus.RUNNING)
         self._executor.submit(self._run, sql, query_id)
         return query_id
@@ -80,14 +88,19 @@ class QueryManager:
 
     def _run(self, sql: str, query_id: str) -> None:
         try:
-            state = QueryState(QueryStatus.DONE, result=self._runner.run_query(sql, query_id))
+            result = self._runner.run_query(sql, query_id)
         except DuckyError as e:
-            state = QueryState(QueryStatus.ERROR, error=str(e))
+            with self._lock:
+                self._states[query_id] = QueryState(QueryStatus.ERROR, error=str(e))
+            return
         except Exception as e:  # background task: record instead of hanging in RUNNING forever
             logger.exception("Unexpected error running query %s", query_id)
-            state = QueryState(QueryStatus.ERROR, error=f"internal error: {e}")
+            with self._lock:
+                self._states[query_id] = QueryState(QueryStatus.ERROR, error=f"internal error: {e}")
+            return
         with self._lock:
-            self._states[query_id] = state
+            self._cache[sql] = result
+            self._states[query_id] = QueryState(QueryStatus.DONE, result=result, cached=False)
 
     def shutdown(self) -> None:
         self._executor.shutdown(wait=False)
@@ -107,119 +120,136 @@ def _result_payload(state: QueryState) -> dict:
         "total_rows": result.total_rows,
         "truncated": result.truncated,
         "result_path": result.result_path,
+        "cached": state.cached,
     }
 
 
-def _index_html(ttl_days: int) -> str:
-    return f"""\
+# CodeMirror 5 (SQL mode) gives DuckDB-flavored SQL highlighting from a CDN — loaded
+# by the browser, so no server-side egress. __TTL_DAYS__ is substituted per config.
+_INDEX_HTML = """\
 <!doctype html>
 <html lang="en">
 <head>
 <meta charset="utf-8">
 <title>ducky</title>
+<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.css">
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/codemirror.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/codemirror/5.65.16/mode/sql/sql.min.js"></script>
 <style>
-  body {{ font-family: system-ui, sans-serif; margin: 2rem; }}
-  textarea {{ width: 100%; height: 12rem; font-family: monospace; font-size: 13px; }}
-  button {{ margin-top: .5rem; padding: .4rem 1rem; font-size: 14px; }}
-  #status {{ margin: .5rem 0; color: #555; }}
-  table {{ border-collapse: collapse; margin-top: 1rem; font-size: 13px; }}
-  th, td {{ border: 1px solid #ccc; padding: .2rem .5rem; text-align: left; }}
-  th {{ background: #f0f0f0; }}
-  .error {{ color: #b00; white-space: pre-wrap; font-family: monospace; }}
+  body { font-family: system-ui, sans-serif; margin: 2rem; }
+  .CodeMirror { border: 1px solid #ccc; height: 12rem; font-size: 13px; }
+  button { margin-top: .5rem; padding: .4rem 1rem; font-size: 14px; }
+  #status { margin: .6rem 0; color: #555; }
+  #status .cached { color: #2a7; font-weight: 600; }
+  #status .computed { color: #888; }
+  #status .loc { font-family: monospace; }
+  table { border-collapse: collapse; margin-top: 1rem; font-size: 13px; }
+  th, td { border: 1px solid #ccc; padding: .2rem .5rem; text-align: left; }
+  th { background: #f0f0f0; }
+  .error { color: #b00; white-space: pre-wrap; font-family: monospace; }
 </style>
 </head>
 <body>
 <h1>🦆 ducky</h1>
 <textarea id="sql" placeholder="SELECT * FROM read_parquet('gs://bucket/path/*.parquet') LIMIT 100"></textarea>
-<div><button id="run">Run</button></div>
+<div><button id="run">Run</button> <span style="color:#888;font-size:12px">(⌘/Ctrl-Enter)</span></div>
 <div id="status"></div>
 <div id="result"></div>
 <script>
-const TTL_DAYS = {ttl_days};
+const TTL_DAYS = __TTL_DAYS__;
 const POLL_MS = 1000;
 const runBtn = document.getElementById("run");
-const sqlEl = document.getElementById("sql");
 const statusEl = document.getElementById("status");
 const resultEl = document.getElementById("result");
 
-function showError(msg) {{
+const editor = CodeMirror.fromTextArea(document.getElementById("sql"), {
+  mode: "text/x-sql",
+  lineNumbers: true,
+  lineWrapping: true,
+  extraKeys: { "Cmd-Enter": run, "Ctrl-Enter": run },
+});
+
+function showError(msg) {
   statusEl.textContent = "";
   resultEl.innerHTML = '<div class="error"></div>';
   resultEl.firstChild.textContent = msg;
-}}
+}
 
-async function run() {{
-  const sql = sqlEl.value.trim();
+async function run() {
+  const sql = editor.getValue().trim();
   if (!sql) return;
   runBtn.disabled = true;
   statusEl.textContent = "Submitting…";
   resultEl.innerHTML = "";
-  try {{
-    const resp = await fetch("query", {{
+  try {
+    const resp = await fetch("query", {
       method: "POST",
-      headers: {{ "Content-Type": "application/json" }},
-      body: JSON.stringify({{ sql }}),
-    }});
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ sql }),
+    });
     const data = await resp.json();
-    if (!resp.ok) {{ showError(data.error || ("HTTP " + resp.status)); return; }}
+    if (!resp.ok) { showError(data.error || ("HTTP " + resp.status)); runBtn.disabled = false; return; }
     poll(data.query_id);
-  }} catch (e) {{
+  } catch (e) {
     showError(String(e));
     runBtn.disabled = false;
-  }}
-}}
+  }
+}
 
-async function poll(queryId) {{
+async function poll(queryId) {
   statusEl.textContent = "Running…";
-  try {{
+  try {
     const resp = await fetch("result/" + queryId);
     const data = await resp.json();
-    if (!resp.ok) {{ showError(data.error || ("HTTP " + resp.status)); runBtn.disabled = false; return; }}
-    if (data.status === "running") {{ setTimeout(() => poll(queryId), POLL_MS); return; }}
-    if (data.status === "error") {{ showError(data.error); runBtn.disabled = false; return; }}
-    renderTable(data);
-  }} catch (e) {{
+    if (!resp.ok) { showError(data.error || ("HTTP " + resp.status)); runBtn.disabled = false; return; }
+    if (data.status === "running") { setTimeout(() => poll(queryId), POLL_MS); return; }
+    if (data.status === "error") { showError(data.error); runBtn.disabled = false; return; }
+    renderResult(data);
+  } catch (e) {
     showError(String(e));
-  }} finally {{
-    if (statusEl.textContent !== "Running…") runBtn.disabled = false;
-  }}
-}}
+    runBtn.disabled = false;
+  }
+}
 
-function renderTable(data) {{
+function renderResult(data) {
   const shown = data.rows.length;
-  let msg = shown + " row" + (shown === 1 ? "" : "s");
-  if (data.truncated) {{
-    msg = "showing " + shown + " of " + data.total_rows
-        + " rows — full result at " + data.result_path + " (expires in " + TTL_DAYS + "d)";
-  }}
-  statusEl.textContent = msg;
-  const thead = "<tr>" + data.columns.map(c => "<th></th>").join("") + "</tr>";
+  const rowsLabel = data.truncated
+    ? "showing " + shown + " of " + data.total_rows + " rows"
+    : shown + " row" + (shown === 1 ? "" : "s");
+  const cacheBadge = data.cached
+    ? '<span class="cached">cached ✓</span>'
+    : '<span class="computed">computed</span>';
+  statusEl.innerHTML = rowsLabel + " · " + cacheBadge
+    + ' · output: <span class="loc"></span> <span style="color:#888">(expires in ' + TTL_DAYS + "d)</span>";
+  statusEl.querySelector(".loc").textContent = data.result_path;
+
   const table = document.createElement("table");
-  table.innerHTML = "<thead>" + thead + "</thead><tbody></tbody>";
+  table.innerHTML = "<thead><tr>" + data.columns.map(() => "<th></th>").join("") + "</tr></thead><tbody></tbody>";
   table.querySelectorAll("th").forEach((th, i) => th.textContent = data.columns[i]);
   const tbody = table.querySelector("tbody");
-  for (const row of data.rows) {{
+  for (const row of data.rows) {
     const tr = document.createElement("tr");
-    for (const cell of row) {{
+    for (const cell of row) {
       const td = document.createElement("td");
       td.textContent = cell === null ? "NULL" : String(cell);
       tr.appendChild(td);
-    }}
+    }
     tbody.appendChild(tr);
-  }}
+  }
   resultEl.innerHTML = "";
   resultEl.appendChild(table);
   runBtn.disabled = false;
-}}
+}
 
 runBtn.addEventListener("click", run);
-sqlEl.addEventListener("keydown", e => {{
-  if ((e.ctrlKey || e.metaKey) && e.key === "Enter") run();
-}});
 </script>
 </body>
 </html>
 """
+
+
+def _index_html(ttl_days: int) -> str:
+    return _INDEX_HTML.replace("__TTL_DAYS__", str(ttl_days))
 
 
 def create_app(runner: QueryRunner, config: DuckyConfig) -> Starlette:
@@ -275,8 +305,8 @@ def main() -> None:
     port = ctx.get_port(config.port_name)
     address = f"http://{job_info.advertise_host}:{port}"
 
-    endpoint_id = ctx.registry.register(config.port_name, address, {"job_id": ctx.job_id.to_wire()})
-    logger.info("ducky registered as %s at %s", config.port_name, address)
+    endpoint_id = ctx.registry.register(config.endpoint_name, address, {"job_id": ctx.job_id.to_wire()})
+    logger.info("ducky registered as %s at %s", config.endpoint_name, address)
 
     async def _on_shutdown() -> None:
         ctx.registry.unregister(endpoint_id)

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -168,7 +168,8 @@ const editor = CodeMirror.fromTextArea(document.getElementById("sql"), {
   mode: "text/x-sql",
   lineNumbers: true,
   lineWrapping: true,
-  placeholder: "-- write DuckDB SQL, then \\u2318/Ctrl-Enter to run\\nSELECT *\\nFROM read_parquet('gs://marin-us-east5/<path>/*.parquet')\\nLIMIT 100",
+  placeholder: "-- write DuckDB SQL, then \\u2318/Ctrl-Enter to run\\n"
+    + "SELECT *\\nFROM read_parquet('gs://marin-us-east5/<path>/*.parquet')\\nLIMIT 100",
   extraKeys: { "Cmd-Enter": run, "Ctrl-Enter": run },
 });
 

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -3,30 +3,111 @@
 
 """ducky's Starlette dashboard: paste SQL, run it, see a capped result table.
 
-The page talks plain JSON to ``POST query`` (relative URL, so it works behind the
-controller's ``/proxy/ducky/`` prefix). ``main()`` wires the app to an Iris named
-port and registers it with the endpoint registry so the controller can route to it.
+Queries run **asynchronously**: ``POST /query`` returns a ``query_id`` immediately
+and the SQL runs in a background single-worker executor (one DuckDB query at a
+time); the page polls ``GET /result/{query_id}`` until it is done. This decouples a
+long query from the Iris controller proxy's 30 s request timeout
+(``endpoint_proxy.PROXY_TIMEOUT_SECONDS``) — each HTTP call returns in well under
+30 s while the query itself may run for minutes.
+
+The page talks plain JSON over relative URLs (so it works behind the controller's
+``/proxy/ducky/`` prefix). ``main()`` wires the app to an Iris named port and
+registers it with the endpoint registry so the controller can route to it.
 """
 
 from __future__ import annotations
 
+import dataclasses
+import enum
 import logging
+import threading
 import uuid
+from concurrent.futures import ThreadPoolExecutor
 
 import uvicorn
 from iris.client.client import iris_ctx
 from iris.cluster.client.job_info import get_job_info
 from iris.cluster.dashboard_common import on_shutdown, public, requires_auth
 from starlette.applications import Starlette
-from starlette.concurrency import run_in_threadpool
 from starlette.requests import Request
 from starlette.responses import HTMLResponse, JSONResponse
 from starlette.routing import Route
 
 from ducky.config import DuckyConfig
-from ducky.runner import DuckyError, QueryRunner
+from ducky.runner import DuckyError, QueryResult, QueryRunner
 
 logger = logging.getLogger(__name__)
+
+
+class QueryStatus(enum.StrEnum):
+    RUNNING = "running"
+    DONE = "done"
+    ERROR = "error"
+
+
+@dataclasses.dataclass(frozen=True)
+class QueryState:
+    status: QueryStatus
+    result: QueryResult | None = None
+    error: str | None = None
+
+
+class QueryManager:
+    """Runs queries one at a time in a background thread and tracks their state.
+
+    A single-worker executor serializes execution (one DuckDB query at a time, per
+    design); ``submit`` returns immediately so the HTTP request never blocks on the
+    query. State is kept in memory for the process lifetime — ducky is a stateless,
+    restartable service, so a restart simply drops in-flight/finished query state.
+    """
+
+    def __init__(self, runner: QueryRunner) -> None:
+        self._runner = runner
+        self._executor = ThreadPoolExecutor(max_workers=1, thread_name_prefix="ducky-query")
+        self._states: dict[str, QueryState] = {}
+        self._lock = threading.Lock()
+
+    def submit(self, sql: str) -> str:
+        query_id = uuid.uuid4().hex
+        with self._lock:
+            self._states[query_id] = QueryState(QueryStatus.RUNNING)
+        self._executor.submit(self._run, sql, query_id)
+        return query_id
+
+    def get(self, query_id: str) -> QueryState | None:
+        with self._lock:
+            return self._states.get(query_id)
+
+    def _run(self, sql: str, query_id: str) -> None:
+        try:
+            state = QueryState(QueryStatus.DONE, result=self._runner.run_query(sql, query_id))
+        except DuckyError as e:
+            state = QueryState(QueryStatus.ERROR, error=str(e))
+        except Exception as e:  # background task: record instead of hanging in RUNNING forever
+            logger.exception("Unexpected error running query %s", query_id)
+            state = QueryState(QueryStatus.ERROR, error=f"internal error: {e}")
+        with self._lock:
+            self._states[query_id] = state
+
+    def shutdown(self) -> None:
+        self._executor.shutdown(wait=False)
+
+
+def _result_payload(state: QueryState) -> dict:
+    if state.status is QueryStatus.RUNNING:
+        return {"status": QueryStatus.RUNNING.value}
+    if state.status is QueryStatus.ERROR:
+        return {"status": QueryStatus.ERROR.value, "error": state.error}
+    result = state.result
+    assert result is not None  # DONE always carries a result
+    return {
+        "status": QueryStatus.DONE.value,
+        "columns": result.columns,
+        "rows": result.preview_rows,
+        "total_rows": result.total_rows,
+        "truncated": result.truncated,
+        "result_path": result.result_path,
+    }
 
 
 def _index_html(ttl_days: int) -> str:
@@ -55,16 +136,23 @@ def _index_html(ttl_days: int) -> str:
 <div id="result"></div>
 <script>
 const TTL_DAYS = {ttl_days};
+const POLL_MS = 1000;
 const runBtn = document.getElementById("run");
 const sqlEl = document.getElementById("sql");
 const statusEl = document.getElementById("status");
 const resultEl = document.getElementById("result");
 
+function showError(msg) {{
+  statusEl.textContent = "";
+  resultEl.innerHTML = '<div class="error"></div>';
+  resultEl.firstChild.textContent = msg;
+}}
+
 async function run() {{
   const sql = sqlEl.value.trim();
   if (!sql) return;
   runBtn.disabled = true;
-  statusEl.textContent = "Running…";
+  statusEl.textContent = "Submitting…";
   resultEl.innerHTML = "";
   try {{
     const resp = await fetch("query", {{
@@ -73,19 +161,27 @@ async function run() {{
       body: JSON.stringify({{ sql }}),
     }});
     const data = await resp.json();
-    if (!resp.ok) {{
-      statusEl.textContent = "";
-      resultEl.innerHTML = '<div class="error"></div>';
-      resultEl.firstChild.textContent = data.error || ("HTTP " + resp.status);
-      return;
-    }}
+    if (!resp.ok) {{ showError(data.error || ("HTTP " + resp.status)); return; }}
+    poll(data.query_id);
+  }} catch (e) {{
+    showError(String(e));
+    runBtn.disabled = false;
+  }}
+}}
+
+async function poll(queryId) {{
+  statusEl.textContent = "Running…";
+  try {{
+    const resp = await fetch("result/" + queryId);
+    const data = await resp.json();
+    if (!resp.ok) {{ showError(data.error || ("HTTP " + resp.status)); runBtn.disabled = false; return; }}
+    if (data.status === "running") {{ setTimeout(() => poll(queryId), POLL_MS); return; }}
+    if (data.status === "error") {{ showError(data.error); runBtn.disabled = false; return; }}
     renderTable(data);
   }} catch (e) {{
-    statusEl.textContent = "";
-    resultEl.innerHTML = '<div class="error"></div>';
-    resultEl.firstChild.textContent = String(e);
+    showError(String(e));
   }} finally {{
-    runBtn.disabled = false;
+    if (statusEl.textContent !== "Running…") runBtn.disabled = false;
   }}
 }}
 
@@ -113,6 +209,7 @@ function renderTable(data) {{
   }}
   resultEl.innerHTML = "";
   resultEl.appendChild(table);
+  runBtn.disabled = false;
 }}
 
 runBtn.addEventListener("click", run);
@@ -128,6 +225,7 @@ sqlEl.addEventListener("keydown", e => {{
 def create_app(runner: QueryRunner, config: DuckyConfig) -> Starlette:
     """Build the ducky Starlette app over a query runner. No Iris context required."""
     index_html = _index_html(config.result_ttl_days)
+    manager = QueryManager(runner)
 
     @requires_auth
     async def index(_request: Request) -> HTMLResponse:
@@ -139,32 +237,29 @@ def create_app(runner: QueryRunner, config: DuckyConfig) -> Starlette:
         sql = body.get("sql")
         if not isinstance(sql, str) or not sql.strip():
             return JSONResponse({"error": "missing 'sql'"}, status_code=400)
-        query_id = uuid.uuid4().hex
-        try:
-            result = await run_in_threadpool(runner.run_query, sql, query_id)
-        except DuckyError as e:
-            return JSONResponse({"error": str(e)}, status_code=400)
-        return JSONResponse(
-            {
-                "columns": result.columns,
-                "rows": result.preview_rows,
-                "total_rows": result.total_rows,
-                "truncated": result.truncated,
-                "result_path": result.result_path,
-            }
-        )
+        return JSONResponse({"query_id": manager.submit(sql)}, status_code=202)
+
+    @requires_auth
+    async def result(request: Request) -> JSONResponse:
+        state = manager.get(request.path_params["query_id"])
+        if state is None:
+            return JSONResponse({"error": "unknown query_id"}, status_code=404)
+        return JSONResponse(_result_payload(state))
 
     @public
     async def health(_request: Request) -> JSONResponse:
         return JSONResponse({"status": "healthy"})
 
-    return Starlette(
+    app = Starlette(
         routes=[
             Route("/", index),
             Route("/query", query, methods=["POST"]),
+            Route("/result/{query_id:str}", result),
             Route("/health", health),
         ]
     )
+    app.state.query_manager = manager
+    return app
 
 
 def main() -> None:
@@ -183,11 +278,12 @@ def main() -> None:
     endpoint_id = ctx.registry.register(config.port_name, address, {"job_id": ctx.job_id.to_wire()})
     logger.info("ducky registered as %s at %s", config.port_name, address)
 
-    async def _unregister() -> None:
+    async def _on_shutdown() -> None:
         ctx.registry.unregister(endpoint_id)
+        app.state.query_manager.shutdown()
         logger.info("ducky endpoint unregistered")
 
-    app.router.lifespan_context = on_shutdown(_unregister)
+    app.router.lifespan_context = on_shutdown(_on_shutdown)
     uvicorn.run(app, host="0.0.0.0", port=port)
 
 

--- a/lib/ducky/src/ducky/tunnel.py
+++ b/lib/ducky/src/ducky/tunnel.py
@@ -1,0 +1,67 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Open a controller tunnel via the iris CLI and yield its local URL.
+
+Shared by ``ducky query`` (which appends ``/proxy/<endpoint>`` to reach the service)
+and ``ducky deploy`` (which submits against the raw controller URL). Driving the iris
+CLI as a subprocess keeps ducky free of iris Python imports and robust to iris internal
+API changes.
+"""
+
+from __future__ import annotations
+
+import contextlib
+import os
+import re
+import shlex
+import subprocess
+import threading
+from collections.abc import Iterator
+
+import click
+
+# matches the local tunnel address the iris CLI prints (port varies)
+_TUNNEL_URL_RE = re.compile(r"https?://127\.0\.0\.1:\d+")
+
+
+@contextlib.contextmanager
+def cluster_tunnel(cluster: str, *, timeout: float = 90.0) -> Iterator[str]:
+    """Open a controller tunnel via ``iris cluster dashboard`` and yield its base URL.
+
+    Spawns the iris CLI (override with ``$DUCKY_IRIS_CMD``), reads its output until the
+    local tunnel URL appears, and tears the tunnel down on exit. The URL is the raw
+    controller address (e.g. ``http://127.0.0.1:10000``); callers append any path.
+    """
+    iris_cmd = shlex.split(os.environ.get("DUCKY_IRIS_CMD", "iris"))
+    proc = subprocess.Popen(
+        [*iris_cmd, "--cluster", cluster, "cluster", "dashboard"],
+        stdout=subprocess.PIPE,
+        stderr=subprocess.STDOUT,
+        text=True,
+    )
+    # Reading proc.stdout line-by-line blocks if iris emits nothing, so a wall-clock
+    # check inside the loop never fires — enforce the startup timeout by terminating
+    # the process (which EOFs the read) if the URL hasn't appeared in time.
+    startup_kill = threading.Timer(timeout, proc.terminate)
+    startup_kill.start()
+    base = None
+    try:
+        assert proc.stdout is not None
+        for line in proc.stdout:
+            match = _TUNNEL_URL_RE.search(line)
+            if match:
+                base = match.group(0)
+                break
+    finally:
+        startup_kill.cancel()  # startup done (found or EOF); stop guarding it
+
+    if base is None:
+        proc.terminate()
+        raise click.ClickException(f"Could not open a tunnel to cluster {cluster!r} via `iris cluster dashboard`.")
+    try:
+        yield base
+    finally:
+        proc.terminate()
+        with contextlib.suppress(subprocess.TimeoutExpired):
+            proc.wait(timeout=10)

--- a/lib/ducky/tests/test_client.py
+++ b/lib/ducky/tests/test_client.py
@@ -1,0 +1,79 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+
+import httpx
+from click.testing import CliRunner
+from ducky import client
+from ducky.client import _render_table, query
+
+_BASE = "http://ducky.test/proxy/ducky"
+_DONE = {
+    "status": "done",
+    "columns": ["a", "b"],
+    "rows": [[1, "x"], [2, None]],
+    "total_rows": 2,
+    "truncated": False,
+    "result_path": "gs://b/ducky/q.parquet",
+    "cached": False,
+    "elapsed_ms": 42,
+    "result_bytes": 99,
+}
+
+
+def test_render_table_aligns_and_marks_null():
+    out = _render_table(["a", "bb"], [[1, "x"], [22, None]])
+    lines = out.splitlines()
+    assert len(lines) == 4  # header, separator, 2 data rows
+    assert lines[0].startswith("a") and "bb" in lines[0]
+    assert set(lines[1]) <= {"-", "+"}  # separator row
+    assert "NULL" in out
+    # the "a" column is padded to width 2 ("22"), so the separator before '|' aligns
+    assert lines[0].index("|") == lines[2].index("|")
+
+
+class _FakeHttp:
+    """Routes ducky's POST /query + GET /result to canned responses."""
+
+    def __init__(self, result: dict, submit_status: int = 202):
+        self._result = result
+        self._submit_status = submit_status
+
+    def post(self, url, json=None, timeout=None):
+        return httpx.Response(self._submit_status, json={"query_id": "abc"}, request=httpx.Request("POST", url))
+
+    def get(self, url, timeout=None):
+        return httpx.Response(200, json=self._result, request=httpx.Request("GET", url))
+
+
+def test_query_prints_table_and_stats(monkeypatch):
+    monkeypatch.setattr(client, "httpx", _FakeHttp(_DONE))
+    result = CliRunner().invoke(query, ["SELECT 1", "--base-url", _BASE])
+
+    assert result.exit_code == 0, result.output
+    assert "a | b" in result.stdout
+    assert "NULL" in result.stdout
+    assert "2 rows · 42 ms · 99 B · computed" in result.stderr
+    assert "gs://b/ducky/q.parquet" in result.stderr
+
+
+def test_query_json_format(monkeypatch):
+    monkeypatch.setattr(client, "httpx", _FakeHttp(_DONE))
+    result = CliRunner().invoke(query, ["SELECT 1", "--base-url", _BASE, "--format", "json"])
+    assert result.exit_code == 0
+    assert json.loads(result.output)["columns"] == ["a", "b"]
+
+
+def test_query_error_exits_nonzero(monkeypatch):
+    err = {"status": "error", "error": "Catalog Error: nope"}
+    monkeypatch.setattr(client, "httpx", _FakeHttp(err))
+    result = CliRunner().invoke(query, ["SELECT * FROM nope", "--base-url", _BASE])
+    assert result.exit_code != 0
+    assert "Catalog Error: nope" in result.output
+
+
+def test_query_requires_sql():
+    result = CliRunner().invoke(query, ["--base-url", _BASE], input="")
+    assert result.exit_code != 0
+    assert "No SQL provided" in result.output

--- a/lib/ducky/tests/test_client.py
+++ b/lib/ducky/tests/test_client.py
@@ -36,15 +36,16 @@ def test_render_table_aligns_and_marks_null():
 class _FakeHttp:
     """Routes ducky's POST /query + GET /result to canned responses."""
 
-    def __init__(self, result: dict, submit_status: int = 202):
+    def __init__(self, result: dict, submit_status: int = 202, get_status: int = 200):
         self._result = result
         self._submit_status = submit_status
+        self._get_status = get_status
 
     def post(self, url, json=None, timeout=None):
         return httpx.Response(self._submit_status, json={"query_id": "abc"}, request=httpx.Request("POST", url))
 
     def get(self, url, timeout=None):
-        return httpx.Response(200, json=self._result, request=httpx.Request("GET", url))
+        return httpx.Response(self._get_status, json=self._result, request=httpx.Request("GET", url))
 
 
 def test_query_prints_table_and_stats(monkeypatch):
@@ -71,6 +72,15 @@ def test_query_error_exits_nonzero(monkeypatch):
     result = CliRunner().invoke(query, ["SELECT * FROM nope", "--base-url", _BASE])
     assert result.exit_code != 0
     assert "Catalog Error: nope" in result.output
+
+
+def test_query_poll_http_error_exits_cleanly(monkeypatch):
+    # a non-200 /result (e.g. server restart, proxy failure) must surface as a CLI error,
+    # not a KeyError on the missing "status" field
+    monkeypatch.setattr(client, "httpx", _FakeHttp({"error": "upstream timeout"}, get_status=504))
+    result = CliRunner().invoke(query, ["SELECT 1", "--base-url", _BASE])
+    assert result.exit_code != 0
+    assert "upstream timeout" in result.output
 
 
 def test_query_requires_sql():

--- a/lib/ducky/tests/test_client.py
+++ b/lib/ducky/tests/test_client.py
@@ -77,3 +77,9 @@ def test_query_requires_sql():
     result = CliRunner().invoke(query, ["--base-url", _BASE], input="")
     assert result.exit_code != 0
     assert "No SQL provided" in result.output
+
+
+def test_query_cluster_and_base_url_conflict():
+    result = CliRunner().invoke(query, ["SELECT 1", "--cluster", "marin", "--base-url", _BASE])
+    assert result.exit_code != 0
+    assert "not both" in result.output

--- a/lib/ducky/tests/test_config.py
+++ b/lib/ducky/tests/test_config.py
@@ -6,7 +6,7 @@ import os
 import pytest
 from ducky.config import DuckyConfig
 
-_BASE_ENV = {"DUCKY_REGION": "us-east5", "DUCKY_SCRATCH_BUCKET": "/tmp/ducky"}
+_BASE_ENV = {"DUCKY_SCRATCH_BUCKET": "/tmp/ducky"}
 _GCS_ENV = {"DUCKY_GCS_HMAC_KEY_ID": "k", "DUCKY_GCS_HMAC_SECRET": "s"}
 
 
@@ -22,8 +22,8 @@ def _set(monkeypatch, env: dict[str, str]) -> None:
         monkeypatch.setenv(key, value)
 
 
-def test_requires_region_and_scratch_bucket(monkeypatch):
-    with pytest.raises(ValueError, match="DUCKY_REGION"):
+def test_requires_scratch_bucket(monkeypatch):
+    with pytest.raises(ValueError, match="DUCKY_SCRATCH_BUCKET"):
         DuckyConfig.from_environment()
 
 

--- a/lib/ducky/tests/test_config.py
+++ b/lib/ducky/tests/test_config.py
@@ -1,0 +1,48 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+
+from ducky.config import DuckyConfig
+
+_BASE_ENV = {"DUCKY_REGION": "us-east5", "DUCKY_SCRATCH_BUCKET": "/tmp/ducky"}
+_GCS_ENV = {"DUCKY_GCS_HMAC_KEY_ID": "k", "DUCKY_GCS_HMAC_SECRET": "s"}
+
+
+@pytest.fixture(autouse=True)
+def _clear_ducky_env(monkeypatch):
+    for key in list(__import__("os").environ):
+        if key.startswith("DUCKY_"):
+            monkeypatch.delenv(key, raising=False)
+
+
+def _set(monkeypatch, env: dict[str, str]) -> None:
+    for key, value in env.items():
+        monkeypatch.setenv(key, value)
+
+
+def test_requires_region_and_scratch_bucket(monkeypatch):
+    with pytest.raises(ValueError, match="DUCKY_REGION"):
+        DuckyConfig.from_environment()
+
+
+def test_no_backend_creds_is_allowed(monkeypatch):
+    _set(monkeypatch, _BASE_ENV)
+    config = DuckyConfig.from_environment()
+    assert config.scratch_bucket == "/tmp/ducky"
+    assert not config.gcs_enabled
+    assert not config.r2_enabled
+    assert not config.cw_enabled
+
+
+def test_full_backend_enables_it(monkeypatch):
+    _set(monkeypatch, {**_BASE_ENV, **_GCS_ENV})
+    config = DuckyConfig.from_environment()
+    assert config.gcs_enabled
+    assert not config.r2_enabled
+
+
+def test_partial_backend_creds_raise(monkeypatch):
+    _set(monkeypatch, {**_BASE_ENV, "DUCKY_GCS_HMAC_KEY_ID": "k"})  # secret missing
+    with pytest.raises(ValueError, match="partially configured"):
+        DuckyConfig.from_environment()

--- a/lib/ducky/tests/test_config.py
+++ b/lib/ducky/tests/test_config.py
@@ -1,8 +1,9 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import pytest
+import os
 
+import pytest
 from ducky.config import DuckyConfig
 
 _BASE_ENV = {"DUCKY_REGION": "us-east5", "DUCKY_SCRATCH_BUCKET": "/tmp/ducky"}
@@ -11,7 +12,7 @@ _GCS_ENV = {"DUCKY_GCS_HMAC_KEY_ID": "k", "DUCKY_GCS_HMAC_SECRET": "s"}
 
 @pytest.fixture(autouse=True)
 def _clear_ducky_env(monkeypatch):
-    for key in list(__import__("os").environ):
+    for key in list(os.environ):
         if key.startswith("DUCKY_"):
             monkeypatch.delenv(key, raising=False)
 

--- a/lib/ducky/tests/test_deploy.py
+++ b/lib/ducky/tests/test_deploy.py
@@ -1,8 +1,48 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+from types import SimpleNamespace
+
 from click.testing import CliRunner
-from ducky.deploy import cli
+from ducky.deploy import _EFFECTIVELY_UNLIMITED_RETRIES, cli, submit_ducky
+from iris.rpc import job_pb2
+
+
+class _CapturingClient:
+    """Captures the kwargs submit_ducky passes to client.submit."""
+
+    def __init__(self):
+        self.kwargs = None
+
+    def submit(self, **kwargs):
+        self.kwargs = kwargs
+        return SimpleNamespace(job_id="/rav/ducky")
+
+
+def test_submit_ducky_sets_effectively_unlimited_budgets():
+    client = _CapturingClient()
+    # a task-level default 0 on max_task_failures would fail the job on the first hard failure,
+    # so all three budgets must be raised for best-effort-always-up.
+    submit_ducky(client, name="ducky", region="us-east5", tpu="", cpu=4, memory="8GB", env_vars={})  # pyrefly: ignore
+    assert client.kwargs["max_retries_preemption"] == _EFFECTIVELY_UNLIMITED_RETRIES
+    assert client.kwargs["max_retries_failure"] == _EFFECTIVELY_UNLIMITED_RETRIES
+    assert client.kwargs["max_task_failures"] == _EFFECTIVELY_UNLIMITED_RETRIES
+    assert client.kwargs["existing_job_policy"] == job_pb2.EXISTING_JOB_POLICY_RECREATE
+
+
+def test_submit_ducky_keep_policy_is_passed_through():
+    client = _CapturingClient()
+    submit_ducky(  # pyrefly: ignore
+        client,
+        name="ducky",
+        region="us-east5",
+        tpu="",
+        cpu=4,
+        memory="8GB",
+        env_vars={},
+        existing_job_policy=job_pb2.EXISTING_JOB_POLICY_KEEP,
+    )
+    assert client.kwargs["existing_job_policy"] == job_pb2.EXISTING_JOB_POLICY_KEEP
 
 
 def test_deploy_rejects_cluster_and_controller_url_together():

--- a/lib/ducky/tests/test_deploy.py
+++ b/lib/ducky/tests/test_deploy.py
@@ -1,0 +1,18 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from click.testing import CliRunner
+from ducky.deploy import cli
+
+
+def test_deploy_rejects_cluster_and_controller_url_together():
+    result = CliRunner().invoke(cli, ["--cluster", "marin", "--controller-url", "http://x"])
+    assert result.exit_code != 0
+    assert "not both" in result.output
+
+
+def test_deploy_requires_a_target(monkeypatch):
+    monkeypatch.delenv("IRIS_CONTROLLER_URL", raising=False)
+    result = CliRunner().invoke(cli, [])
+    assert result.exit_code != 0
+    assert "--cluster" in result.output

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -9,7 +9,7 @@ from pathlib import Path
 import duckdb
 import pytest
 from ducky.config import DuckyConfig
-from ducky.runner import BucketNotAllowedError, QueryError, QueryRunner, disallowed_uris, duckdb_resource_settings
+from ducky.runner import BucketNotAllowedError, QueryError, QueryRunner, disallowed_uris
 from iris.env_resources import TaskResources
 
 _SMALL_HOST = TaskResources(memory_bytes=2 * 1024**3, cpu_cores=2, gpu_count=0, tpu_count=0)
@@ -48,19 +48,6 @@ def make_runner(tmp_path: Path) -> Callable[..., QueryRunner]:
         runner.close()
 
 
-def test_duckdb_resource_settings_scales_memory():
-    settings = duckdb_resource_settings(_SMALL_HOST, memory_fraction=0.8)
-    assert settings.threads == 2
-    assert settings.memory_limit_bytes == int(2 * 1024**3 * 0.8)
-
-
-def test_duckdb_resource_settings_unknown_memory_leaves_default():
-    host = TaskResources(memory_bytes=0, cpu_cores=4, gpu_count=0, tpu_count=0)
-    settings = duckdb_resource_settings(host, memory_fraction=0.8)
-    assert settings.threads == 4
-    assert settings.memory_limit_bytes == 0
-
-
 def test_run_query_caps_preview_and_spills(make_runner):
     runner = make_runner(preview_row_cap=3)
     result = runner.run_query("SELECT * FROM range(5) t(x)", uuid.uuid4().hex)
@@ -95,32 +82,27 @@ def test_remote_scratch_blocks_local_filesystem_access(tmp_path):
         runner.close()
 
 
-def test_disallowed_uris_flags_only_unlisted_buckets():
-    allowed = ("gs://marin-us-east5", "r2://")
-    sql = (
-        "SELECT * FROM read_parquet('gs://marin-us-central2/a.parquet') "
-        "JOIN read_parquet('gs://marin-us-east5/b.parquet') USING (id) "
-        "JOIN read_parquet('r2://anybucket/c.parquet') USING (id)"
-    )
-    assert disallowed_uris(sql, allowed) == ["gs://marin-us-central2/a.parquet"]
-
-
-def test_disallowed_uris_prefix_semantics():
-    # entries are prefixes: 'gs://marin-' allows every marin-* bucket
-    allowed = ("gs://marin-", "s3://marin-na")
-    assert disallowed_uris("read('gs://marin-us-east5/x') read('gs://marin-us-central2/y')", allowed) == []
-    assert disallowed_uris("read('s3://marin-na/z')", allowed) == []
-    assert disallowed_uris("read('gs://other-bucket/x')", allowed) == ["gs://other-bucket/x"]
-
-
-def test_disallowed_uris_trailing_slash_bounds_to_bucket():
-    # a bare prefix is loose; a trailing slash bounds the match to one bucket
-    assert disallowed_uris("read('gs://marin-us-east5-evil/x')", ("gs://marin-us-east5",)) == []
-    assert disallowed_uris("read('gs://marin-us-east5-evil/x')", ("gs://marin-us-east5/",))
-
-
-def test_disallowed_uris_empty_allowlist_allows_all():
-    assert disallowed_uris("read_parquet('gs://anywhere/x.parquet')", ()) == []
+@pytest.mark.parametrize(
+    "sql, allowed, expected",
+    [
+        # only the unlisted bucket is flagged; listed gs:// prefix and all-of-r2 pass
+        (
+            "read('gs://marin-us-central2/a') read('gs://marin-us-east5/b') read('r2://any/c')",
+            ("gs://marin-us-east5", "r2://"),
+            ["gs://marin-us-central2/a"],
+        ),
+        # entries are prefixes: 'gs://marin-' allows every marin-* bucket
+        ("read('gs://marin-us-east5/x') read('gs://marin-us-central2/y')", ("gs://marin-",), []),
+        ("read('gs://other-bucket/x')", ("gs://marin-",), ["gs://other-bucket/x"]),
+        # a bare prefix is loose; a trailing slash bounds the match to one bucket
+        ("read('gs://marin-us-east5-evil/x')", ("gs://marin-us-east5",), []),
+        ("read('gs://marin-us-east5-evil/x')", ("gs://marin-us-east5/",), ["gs://marin-us-east5-evil/x"]),
+        # empty allowlist disables enforcement (allow all)
+        ("read('gs://anywhere/x')", (), []),
+    ],
+)
+def test_disallowed_uris(sql, allowed, expected):
+    assert disallowed_uris(sql, allowed) == expected
 
 
 def test_run_query_refuses_bucket_outside_allowlist(make_runner):

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -19,10 +19,10 @@ def _make_config(scratch_bucket: str, **overrides) -> DuckyConfig:
         scratch_bucket=scratch_bucket,
         gcs_hmac_key_id="key",
         gcs_hmac_secret="secret",
-        r2_account_id="account",
+        r2_endpoint="acct.r2.cloudflarestorage.com",
         r2_access_key="r2key",
         r2_secret_key="r2secret",
-        cw_endpoint="cwobject.example.com",
+        cw_endpoint="cwobject.com",
         cw_access_key="cwkey",
         cw_secret_key="cwsecret",
     )
@@ -93,9 +93,18 @@ def test_disallowed_uris_flags_only_unlisted_buckets():
     assert disallowed_uris(sql, allowed) == ["gs://marin-us-central2/a.parquet"]
 
 
-def test_disallowed_uris_is_boundary_aware():
-    # gs://marin-us-east5 must not allow a look-alike bucket
-    assert disallowed_uris("read_parquet('gs://marin-us-east5-evil/x')", ("gs://marin-us-east5",))
+def test_disallowed_uris_prefix_semantics():
+    # entries are prefixes: 'gs://marin-' allows every marin-* bucket
+    allowed = ("gs://marin-", "s3://marin-na")
+    assert disallowed_uris("read('gs://marin-us-east5/x') read('gs://marin-us-central2/y')", allowed) == []
+    assert disallowed_uris("read('s3://marin-na/z')", allowed) == []
+    assert disallowed_uris("read('gs://other-bucket/x')", allowed) == ["gs://other-bucket/x"]
+
+
+def test_disallowed_uris_trailing_slash_bounds_to_bucket():
+    # a bare prefix is loose; a trailing slash bounds the match to one bucket
+    assert disallowed_uris("read('gs://marin-us-east5-evil/x')", ("gs://marin-us-east5",)) == []
+    assert disallowed_uris("read('gs://marin-us-east5-evil/x')", ("gs://marin-us-east5/",))
 
 
 def test_disallowed_uris_empty_allowlist_allows_all():

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -104,6 +104,26 @@ def test_run_query_coerces_non_scalar_cells_to_str(make_runner):
     assert "2020-01-01" in cell
 
 
+def test_run_query_strips_trailing_semicolon(make_runner):
+    runner = make_runner()
+    result = runner.run_query("SELECT 1 AS a;", uuid.uuid4().hex)
+    assert result.columns == ["a"]
+    assert result.preview_rows == [[1]]
+
+
+def test_run_query_handles_trailing_line_comment(make_runner):
+    runner = make_runner()
+    result = runner.run_query("SELECT 1 AS a -- trailing comment", uuid.uuid4().hex)
+    assert result.preview_rows == [[1]]
+
+
+def test_run_query_coerces_non_finite_floats_to_str(make_runner):
+    runner = make_runner()
+    result = runner.run_query("SELECT 'nan'::DOUBLE AS x, 'inf'::DOUBLE AS y", uuid.uuid4().hex)
+    nan_cell, inf_cell = result.preview_rows[0]
+    assert isinstance(nan_cell, str) and isinstance(inf_cell, str)
+
+
 def test_run_query_ignores_hive_partition_in_scratch_path(tmp_path):
     """A `ttl=Nd` segment in the scratch path must not leak a phantom partition column."""
     scratch = tmp_path / "tmp" / "ttl=7d"

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -171,22 +171,17 @@ def test_run_query_coerces_non_scalar_cells_to_str(make_runner):
     assert "2020-01-01" in cell
 
 
-def test_run_query_strips_trailing_semicolon(make_runner):
-    runner = make_runner()
-    result = runner.run_query("SELECT 1 AS a;", uuid.uuid4().hex)
+@pytest.mark.parametrize(
+    "sql",
+    [
+        "SELECT 1 AS a;",  # trailing semicolon
+        "SELECT 1 AS a -- trailing comment",  # trailing line comment
+        "SELECT 1 AS a; -- trailing comment",  # semicolon then comment
+    ],
+)
+def test_run_query_accepts_trailing_semicolons_and_comments(make_runner, sql):
+    result = make_runner().run_query(sql, uuid.uuid4().hex)
     assert result.columns == ["a"]
-    assert result.preview_rows == [[1]]
-
-
-def test_run_query_handles_trailing_line_comment(make_runner):
-    runner = make_runner()
-    result = runner.run_query("SELECT 1 AS a -- trailing comment", uuid.uuid4().hex)
-    assert result.preview_rows == [[1]]
-
-
-def test_run_query_handles_semicolon_then_comment(make_runner):
-    runner = make_runner()
-    result = runner.run_query("SELECT 1 AS a; -- trailing comment", uuid.uuid4().hex)
     assert result.preview_rows == [[1]]
 
 

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -139,6 +139,19 @@ def test_run_query_spills_under_memory_pressure_and_survives(tmp_path):
         runner.close()
 
 
+def test_startup_wipes_orphaned_spill_files(tmp_path):
+    # a killed process orphans temp files; a fresh runner must clear the spill dir on startup
+    (tmp_path / "ducky").mkdir()
+    spill = tmp_path / "spill"
+    spill.mkdir()
+    (spill / "orphan.tmp").write_text("leftover from a crashed process")
+    runner = QueryRunner(_make_config(str(tmp_path), spill_directory=str(spill)), resources=_SMALL_HOST)
+    try:
+        assert not (spill / "orphan.tmp").exists()
+    finally:
+        runner.close()
+
+
 def test_run_query_is_concurrency_safe(make_runner):
     runner = make_runner()  # one runner shared across threads; each query uses its own cursor
 

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -100,3 +100,17 @@ def test_run_query_coerces_non_scalar_cells_to_str(make_runner):
     (cell,) = result.preview_rows[0]
     assert isinstance(cell, str)
     assert "2020-01-01" in cell
+
+
+def test_run_query_ignores_hive_partition_in_scratch_path(tmp_path):
+    """A `ttl=Nd` segment in the scratch path must not leak a phantom partition column."""
+    scratch = tmp_path / "tmp" / "ttl=7d"
+    (scratch / "ducky").mkdir(parents=True)
+    runner = QueryRunner(_make_config(str(scratch)), resources=_SMALL_HOST)
+    try:
+        result = runner.run_query("SELECT 1 AS a, 2 AS b", uuid.uuid4().hex)
+    finally:
+        runner.close()
+
+    assert result.columns == ["a", "b"]  # no "ttl"
+    assert result.preview_rows == [[1, 2]]

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -7,7 +7,7 @@ from pathlib import Path
 
 import pytest
 from ducky.config import DuckyConfig
-from ducky.runner import QueryError, QueryRunner, duckdb_resource_settings
+from ducky.runner import BucketNotAllowedError, QueryError, QueryRunner, disallowed_uris, duckdb_resource_settings
 from iris.env_resources import TaskResources
 
 _SMALL_HOST = TaskResources(memory_bytes=2 * 1024**3, cpu_cores=2, gpu_count=0, tpu_count=0)
@@ -81,6 +81,37 @@ def test_run_query_full_result_not_truncated(make_runner):
     assert result.total_rows == 5
     assert len(result.preview_rows) == 5
     assert result.truncated is False
+
+
+def test_disallowed_uris_flags_only_unlisted_buckets():
+    allowed = ("gs://marin-us-east5", "r2://")
+    sql = (
+        "SELECT * FROM read_parquet('gs://marin-us-central2/a.parquet') "
+        "JOIN read_parquet('gs://marin-us-east5/b.parquet') USING (id) "
+        "JOIN read_parquet('r2://anybucket/c.parquet') USING (id)"
+    )
+    assert disallowed_uris(sql, allowed) == ["gs://marin-us-central2/a.parquet"]
+
+
+def test_disallowed_uris_is_boundary_aware():
+    # gs://marin-us-east5 must not allow a look-alike bucket
+    assert disallowed_uris("read_parquet('gs://marin-us-east5-evil/x')", ("gs://marin-us-east5",))
+
+
+def test_disallowed_uris_empty_allowlist_allows_all():
+    assert disallowed_uris("read_parquet('gs://anywhere/x.parquet')", ()) == []
+
+
+def test_run_query_refuses_bucket_outside_allowlist(make_runner):
+    runner = make_runner(allowed_buckets=("gs://marin-us-east5",))
+    with pytest.raises(BucketNotAllowedError, match="us-central2"):
+        runner.run_query("SELECT * FROM read_parquet('gs://marin-us-central2/x.parquet')", uuid.uuid4().hex)
+
+
+def test_run_query_allowlist_does_not_block_non_object_queries(make_runner):
+    runner = make_runner(allowed_buckets=("gs://marin-us-east5",))
+    result = runner.run_query("SELECT * FROM range(3) t(x)", uuid.uuid4().hex)
+    assert result.total_rows == 3
 
 
 def test_run_query_bad_sql_raises_query_error(make_runner):

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -6,6 +6,7 @@ from collections.abc import Callable
 from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
+import duckdb
 import pytest
 from ducky.config import DuckyConfig
 from ducky.runner import BucketNotAllowedError, QueryError, QueryRunner, disallowed_uris, duckdb_resource_settings
@@ -16,7 +17,6 @@ _SMALL_HOST = TaskResources(memory_bytes=2 * 1024**3, cpu_cores=2, gpu_count=0, 
 
 def _make_config(scratch_bucket: str, **overrides) -> DuckyConfig:
     base = dict(
-        region="us-east5",
         scratch_bucket=scratch_bucket,
         gcs_hmac_key_id="key",
         gcs_hmac_secret="secret",
@@ -82,6 +82,24 @@ def test_run_query_full_result_not_truncated(make_runner):
     assert result.total_rows == 5
     assert len(result.preview_rows) == 5
     assert result.truncated is False
+
+
+def test_run_query_caps_result_rows(make_runner):
+    # the row cap bounds the materialized object; a broad query is truncated to it
+    runner = make_runner(max_result_rows=10)
+    result = runner.run_query("SELECT * FROM range(100) t(x)", uuid.uuid4().hex)
+    assert result.total_rows == 10
+
+
+def test_remote_scratch_blocks_local_filesystem_access(tmp_path):
+    # results to object storage → user SQL must not read local files (e.g. /proc/self/environ)
+    config = _make_config("gs://marin-us-east5/tmp/ttl=7d", spill_directory=str(tmp_path / "spill"))
+    runner = QueryRunner(config, resources=_SMALL_HOST)
+    try:
+        with pytest.raises(duckdb.Error):
+            runner._con.execute("SELECT * FROM read_text('/proc/self/environ')").fetchall()
+    finally:
+        runner.close()
 
 
 def test_disallowed_uris_flags_only_unlisted_buckets():

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -184,6 +184,12 @@ def test_run_query_handles_trailing_line_comment(make_runner):
     assert result.preview_rows == [[1]]
 
 
+def test_run_query_handles_semicolon_then_comment(make_runner):
+    runner = make_runner()
+    result = runner.run_query("SELECT 1 AS a; -- trailing comment", uuid.uuid4().hex)
+    assert result.preview_rows == [[1]]
+
+
 def test_run_query_coerces_non_finite_floats_to_str(make_runner):
     runner = make_runner()
     result = runner.run_query("SELECT 'nan'::DOUBLE AS x, 'inf'::DOUBLE AS y", uuid.uuid4().hex)

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -163,6 +163,14 @@ def test_startup_wipes_orphaned_spill_files(tmp_path):
         runner.close()
 
 
+def test_httpfs_retries_are_configured(make_runner):
+    # transient object-store failures (incl. brief DNS/connection blips) should be retried.
+    # queries run on a cursor, so the setting must be GLOBAL to be inherited — check via one.
+    runner = make_runner()
+    cursor = runner._con.cursor()
+    assert cursor.execute("SELECT current_setting('http_retries')").fetchone()[0] == 10
+
+
 def test_run_query_is_concurrency_safe(make_runner):
     runner = make_runner()  # one runner shared across threads; each query uses its own cursor
 

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -1,0 +1,102 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import uuid
+from collections.abc import Callable
+from pathlib import Path
+
+import pytest
+from ducky.config import DuckyConfig
+from ducky.runner import QueryError, QueryRunner, duckdb_resource_settings
+from iris.env_resources import TaskResources
+
+_SMALL_HOST = TaskResources(memory_bytes=2 * 1024**3, cpu_cores=2, gpu_count=0, tpu_count=0)
+
+
+def _make_config(scratch_bucket: str, **overrides) -> DuckyConfig:
+    base = dict(
+        region="us-east5",
+        scratch_bucket=scratch_bucket,
+        gcs_hmac_key_id="key",
+        gcs_hmac_secret="secret",
+        r2_account_id="account",
+        r2_access_key="r2key",
+        r2_secret_key="r2secret",
+        cw_endpoint="cwobject.example.com",
+        cw_access_key="cwkey",
+        cw_secret_key="cwsecret",
+    )
+    base.update(overrides)
+    return DuckyConfig(**base)
+
+
+@pytest.fixture
+def make_runner(tmp_path: Path) -> Callable[..., QueryRunner]:
+    """Build runners that spill to a local scratch dir and close them on teardown."""
+    (tmp_path / "ducky").mkdir()
+    runners: list[QueryRunner] = []
+
+    def factory(**config_overrides) -> QueryRunner:
+        config = _make_config(str(tmp_path), **config_overrides)
+        runner = QueryRunner(config, resources=_SMALL_HOST)
+        runners.append(runner)
+        return runner
+
+    yield factory
+    for runner in runners:
+        runner.close()
+
+
+def test_duckdb_resource_settings_scales_memory():
+    settings = duckdb_resource_settings(_SMALL_HOST, memory_fraction=0.8)
+    assert settings.threads == 2
+    assert settings.memory_limit_bytes == int(2 * 1024**3 * 0.8)
+
+
+def test_duckdb_resource_settings_unknown_memory_leaves_default():
+    host = TaskResources(memory_bytes=0, cpu_cores=4, gpu_count=0, tpu_count=0)
+    settings = duckdb_resource_settings(host, memory_fraction=0.8)
+    assert settings.threads == 4
+    assert settings.memory_limit_bytes == 0
+
+
+def test_run_query_caps_preview_and_spills(make_runner):
+    runner = make_runner(preview_row_cap=3)
+    result = runner.run_query("SELECT * FROM range(5) t(x)", uuid.uuid4().hex)
+
+    assert result.columns == ["x"]
+    assert result.preview_rows == [[0], [1], [2]]
+    assert result.total_rows == 5
+    assert result.truncated is True
+    assert result.result_path.endswith(".parquet")
+    assert Path(result.result_path).exists()
+
+
+def test_run_query_full_result_not_truncated(make_runner):
+    runner = make_runner()
+    result = runner.run_query("SELECT * FROM range(5) t(x)", uuid.uuid4().hex)
+
+    assert result.total_rows == 5
+    assert len(result.preview_rows) == 5
+    assert result.truncated is False
+
+
+def test_run_query_bad_sql_raises_query_error(make_runner):
+    runner = make_runner()
+    with pytest.raises(QueryError):
+        runner.run_query("SELECT * FROM no_such_table", uuid.uuid4().hex)
+
+
+def test_run_query_rejects_non_uuid_query_id(make_runner):
+    runner = make_runner()
+    with pytest.raises(ValueError):
+        runner.run_query("SELECT 1", "../etc/passwd")
+
+
+def test_run_query_coerces_non_scalar_cells_to_str(make_runner):
+    runner = make_runner()
+    result = runner.run_query("SELECT TIMESTAMP '2020-01-01 00:00:00' AS t", uuid.uuid4().hex)
+
+    (cell,) = result.preview_rows[0]
+    assert isinstance(cell, str)
+    assert "2020-01-01" in cell

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -84,13 +84,6 @@ def test_run_query_full_result_not_truncated(make_runner):
     assert result.truncated is False
 
 
-def test_run_query_caps_result_rows(make_runner):
-    # the row cap bounds the materialized object; a broad query is truncated to it
-    runner = make_runner(max_result_rows=10)
-    result = runner.run_query("SELECT * FROM range(100) t(x)", uuid.uuid4().hex)
-    assert result.total_rows == 10
-
-
 def test_remote_scratch_blocks_local_filesystem_access(tmp_path):
     # results to object storage → user SQL must not read local files (e.g. /proc/self/environ)
     config = _make_config("gs://marin-us-east5/tmp/ttl=7d", spill_directory=str(tmp_path / "spill"))

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -3,6 +3,7 @@
 
 import uuid
 from collections.abc import Callable
+from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import pytest
@@ -121,6 +122,32 @@ def test_run_query_allowlist_does_not_block_non_object_queries(make_runner):
     runner = make_runner(allowed_buckets=("gs://marin-us-east5",))
     result = runner.run_query("SELECT * FROM range(3) t(x)", uuid.uuid4().hex)
     assert result.total_rows == 3
+
+
+def test_run_query_spills_under_memory_pressure_and_survives(tmp_path):
+    # tiny memory limit forces a big sort out-of-core; the query should still succeed
+    # via the spill directory, and the runner must survive for the next query.
+    (tmp_path / "ducky").mkdir()
+    config = _make_config(str(tmp_path), spill_directory=str(tmp_path / "spill"))
+    tiny = TaskResources(memory_bytes=200 * 1024 * 1024, cpu_cores=2, gpu_count=0, tpu_count=0)
+    runner = QueryRunner(config, resources=tiny)
+    try:
+        spilled = runner.run_query("SELECT x FROM range(20000000) t(x) ORDER BY x DESC LIMIT 1", uuid.uuid4().hex)
+        assert spilled.preview_rows == [[19999999]]
+        assert runner.run_query("SELECT 1 AS a", uuid.uuid4().hex).preview_rows == [[1]]  # survives
+    finally:
+        runner.close()
+
+
+def test_run_query_is_concurrency_safe(make_runner):
+    runner = make_runner()  # one runner shared across threads; each query uses its own cursor
+
+    def run(i: int) -> int:
+        return runner.run_query(f"SELECT {i} AS v", uuid.uuid4().hex).preview_rows[0][0]
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        values = sorted(pool.map(run, range(8)))
+    assert values == list(range(8))
 
 
 def test_run_query_bad_sql_raises_query_error(make_runner):

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -70,6 +70,8 @@ def test_run_query_caps_preview_and_spills(make_runner):
     assert result.truncated is True
     assert result.result_path.endswith(".parquet")
     assert Path(result.result_path).exists()
+    assert result.elapsed_ms >= 0
+    assert result.result_bytes > 0  # the spilled parquet has content
 
 
 def test_run_query_full_result_not_truncated(make_runner):

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -175,6 +175,24 @@ def test_query_missing_sql_is_400(body):
     assert resp.json() == {"error": "missing 'sql'"}
 
 
+def test_retained_states_are_bounded_lru():
+    """An always-on service must not retain every query's state forever."""
+    runner = _FakeRunner(QueryResult(["x"], [[1]], 1, False, "gs://b/x.parquet", 1, 1))
+    manager = QueryManager(runner, executor=_InlineExecutor(), max_retained_states=3)
+    ids = [manager.submit(f"SELECT {i}") for i in range(5)]  # distinct SQL, inline → each terminal
+    assert manager.get(ids[0]) is None  # oldest two evicted past the cap
+    assert manager.get(ids[1]) is None
+    assert all(manager.get(qid) is not None for qid in ids[2:])  # newest three kept
+
+
+def test_cache_is_bounded_lru():
+    runner = _FakeRunner(QueryResult(["x"], [[1]], 1, False, "gs://b/x.parquet", 1, 1))
+    manager = QueryManager(runner, executor=_InlineExecutor(), max_cache_entries=2)
+    for i in range(4):
+        manager.submit(f"SELECT {i}")
+    assert len(manager._cache) == 2  # capped
+
+
 def test_cache_entry_expires_after_ttl():
     """A cached result older than the TTL is dropped (its spilled parquet may be gone)."""
     manager = QueryManager(_FakeRunner(), executor=_InlineExecutor(), cache_ttl=10)

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -1,7 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-import time
+from concurrent.futures import Future
 
 import pytest
 from ducky.config import DuckyConfig
@@ -16,6 +16,22 @@ _CONFIG = DuckyConfig(
     gcs_hmac_secret="s",
     result_ttl_days=7,
 )
+
+
+class _InlineExecutor:
+    """Runs submitted work synchronously, so a query finishes during ``submit`` — the
+    test reads ``/result`` once with no polling or ``time.sleep`` (per root TESTING.md)."""
+
+    def submit(self, fn, *args, **kwargs):
+        future: Future = Future()
+        try:
+            future.set_result(fn(*args, **kwargs))
+        except Exception as e:  # mirror ThreadPoolExecutor: capture into the future
+            future.set_exception(e)
+        return future
+
+    def shutdown(self, wait=True, **kwargs):
+        pass
 
 
 class _FakeRunner:
@@ -34,27 +50,26 @@ class _FakeRunner:
         return self._result
 
 
-def _poll(client: TestClient, query_id: str, timeout: float = 3.0) -> dict:
-    """Poll /result until the query leaves the 'running' state."""
-    deadline = time.monotonic() + timeout
-    while time.monotonic() < deadline:
-        payload = client.get(f"/result/{query_id}").json()
-        if payload["status"] != "running":
-            return payload
-        time.sleep(0.01)
-    raise AssertionError(f"query {query_id} still running after {timeout}s")
+def _client(runner) -> TestClient:
+    return TestClient(create_app(runner, _CONFIG, executor=_InlineExecutor()))
+
+
+def _run(client: TestClient, sql: str) -> dict:
+    """Submit and read the result. The inline executor finishes the query during submit."""
+    query_id = client.post("/query", json={"sql": sql}).json()["query_id"]
+    payload = client.get(f"/result/{query_id}").json()
+    assert payload["status"] != "running"  # inline executor → already terminal
+    return payload
 
 
 def test_health_is_public():
-    client = TestClient(create_app(_FakeRunner(), _CONFIG))
-    resp = client.get("/health")
+    resp = _client(_FakeRunner()).get("/health")
     assert resp.status_code == 200
     assert resp.json() == {"status": "healthy"}
 
 
 def test_index_serves_form():
-    client = TestClient(create_app(_FakeRunner(), _CONFIG))
-    resp = client.get("/")
+    resp = _client(_FakeRunner()).get("/")
     assert resp.status_code == 200
     assert "text/html" in resp.headers["content-type"]
     assert "<textarea" in resp.text
@@ -62,9 +77,7 @@ def test_index_serves_form():
 
 def test_query_accepts_and_returns_uuid_query_id():
     fake = _FakeRunner(result=QueryResult(["x"], [[1]], 1, False, "gs://b/ducky/a.parquet", 12, 345))
-    client = TestClient(create_app(fake, _CONFIG))
-
-    resp = client.post("/query", json={"sql": "SELECT 1"})
+    resp = _client(fake).post("/query", json={"sql": "SELECT 1"})
 
     assert resp.status_code == 202
     query_id = resp.json()["query_id"]
@@ -72,13 +85,11 @@ def test_query_accepts_and_returns_uuid_query_id():
     int(query_id, 16)  # valid hex
 
 
-def test_query_result_delivered_via_polling():
+def test_query_result_delivered_via_result_endpoint():
     result = QueryResult(["x"], [[1], [2]], 5, True, "gs://marin-ducky-us-east5/ducky/abc.parquet", 1234, 5678)
     fake = _FakeRunner(result=result)
-    client = TestClient(create_app(fake, _CONFIG))
 
-    query_id = client.post("/query", json={"sql": "SELECT * FROM range(5)"}).json()["query_id"]
-    payload = _poll(client, query_id)
+    payload = _run(_client(fake), "SELECT * FROM range(5)")
 
     assert payload == {
         "status": "done",
@@ -91,7 +102,7 @@ def test_query_result_delivered_via_polling():
         "elapsed_ms": 1234,
         "result_bytes": 5678,
     }
-    assert fake.received_query_id == query_id
+    assert fake.received_query_id is not None
 
 
 def test_identical_sql_served_from_cache():
@@ -106,12 +117,11 @@ def test_identical_sql_served_from_cache():
             self.calls += 1
             return super().run_query(sql, query_id)
 
-    result = QueryResult(["x"], [[1]], 1, False, "gs://b/ducky/first.parquet", 50, 99)
-    runner = _CountingRunner(result)
-    client = TestClient(create_app(runner, _CONFIG))
+    runner = _CountingRunner(QueryResult(["x"], [[1]], 1, False, "gs://b/ducky/first.parquet", 50, 99))
+    client = _client(runner)
 
-    first = _poll(client, client.post("/query", json={"sql": "SELECT 1"}).json()["query_id"])
-    second = _poll(client, client.post("/query", json={"sql": "SELECT 1"}).json()["query_id"])
+    first = _run(client, "SELECT 1")
+    second = _run(client, "SELECT 1")
 
     assert runner.calls == 1  # executed once, second served from cache
     assert first["cached"] is False
@@ -121,24 +131,18 @@ def test_identical_sql_served_from_cache():
 
 def test_query_error_surfaces_in_result():
     fake = _FakeRunner(error=QueryError("Catalog Error: table not found"))
-    client = TestClient(create_app(fake, _CONFIG))
-
-    query_id = client.post("/query", json={"sql": "SELECT * FROM nope"}).json()["query_id"]
-    payload = _poll(client, query_id)
-
+    payload = _run(_client(fake), "SELECT * FROM nope")
     assert payload == {"status": "error", "error": "Catalog Error: table not found"}
 
 
 def test_unknown_query_id_is_404():
-    client = TestClient(create_app(_FakeRunner(), _CONFIG))
-    resp = client.get("/result/deadbeef")
+    resp = _client(_FakeRunner()).get("/result/deadbeef")
     assert resp.status_code == 404
     assert resp.json() == {"error": "unknown query_id"}
 
 
 @pytest.mark.parametrize("body", [{}, {"sql": ""}, {"sql": "   "}])
 def test_query_missing_sql_is_400(body):
-    client = TestClient(create_app(_FakeRunner(), _CONFIG))
-    resp = client.post("/query", json=body)
+    resp = _client(_FakeRunner()).post("/query", json=body)
     assert resp.status_code == 400
     assert resp.json() == {"error": "missing 'sql'"}

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -87,8 +87,34 @@ def test_query_result_delivered_via_polling():
         "total_rows": 5,
         "truncated": True,
         "result_path": "gs://marin-ducky-us-east5/ducky/abc.parquet",
+        "cached": False,
     }
     assert fake.received_query_id == query_id
+
+
+def test_identical_sql_served_from_cache():
+    """A second run of the same SQL is served from cache without re-executing."""
+
+    class _CountingRunner(_FakeRunner):
+        def __init__(self, result):
+            super().__init__(result=result)
+            self.calls = 0
+
+        def run_query(self, sql, query_id):
+            self.calls += 1
+            return super().run_query(sql, query_id)
+
+    result = QueryResult(["x"], [[1]], 1, False, "gs://b/ducky/first.parquet")
+    runner = _CountingRunner(result)
+    client = TestClient(create_app(runner, _CONFIG))
+
+    first = _poll(client, client.post("/query", json={"sql": "SELECT 1"}).json()["query_id"])
+    second = _poll(client, client.post("/query", json={"sql": "SELECT 1"}).json()["query_id"])
+
+    assert runner.calls == 1  # executed once, second served from cache
+    assert first["cached"] is False
+    assert second["cached"] is True
+    assert second["result_path"] == "gs://b/ducky/first.parquet"  # reuses the spilled file
 
 
 def test_query_error_surfaces_in_result():

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -1,12 +1,13 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import time
 from concurrent.futures import Future
 
 import pytest
 from ducky.config import DuckyConfig
 from ducky.runner import QueryError, QueryResult
-from ducky.server import create_app
+from ducky.server import QueryManager, create_app
 from starlette.testclient import TestClient
 
 _CONFIG = DuckyConfig(
@@ -146,3 +147,13 @@ def test_query_missing_sql_is_400(body):
     resp = _client(_FakeRunner()).post("/query", json=body)
     assert resp.status_code == 400
     assert resp.json() == {"error": "missing 'sql'"}
+
+
+def test_cache_entry_expires_after_ttl():
+    """A cached result older than the TTL is dropped (its spilled parquet may be gone)."""
+    manager = QueryManager(_FakeRunner(), executor=_InlineExecutor(), cache_ttl=10)
+    result = QueryResult(["a"], [[1]], 1, False, "gs://b/x.parquet", 1, 1)
+    manager._cache["SELECT 1"] = (result, time.monotonic() - 100)  # stale
+    manager._cache["SELECT 2"] = (result, time.monotonic())  # fresh
+    assert manager._cached_result("SELECT 1") is None
+    assert manager._cached_result("SELECT 2") is result

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -61,7 +61,7 @@ def test_index_serves_form():
 
 
 def test_query_accepts_and_returns_uuid_query_id():
-    fake = _FakeRunner(result=QueryResult(["x"], [[1]], 1, False, "gs://b/ducky/a.parquet"))
+    fake = _FakeRunner(result=QueryResult(["x"], [[1]], 1, False, "gs://b/ducky/a.parquet", 12, 345))
     client = TestClient(create_app(fake, _CONFIG))
 
     resp = client.post("/query", json={"sql": "SELECT 1"})
@@ -73,7 +73,7 @@ def test_query_accepts_and_returns_uuid_query_id():
 
 
 def test_query_result_delivered_via_polling():
-    result = QueryResult(["x"], [[1], [2]], 5, True, "gs://marin-ducky-us-east5/ducky/abc.parquet")
+    result = QueryResult(["x"], [[1], [2]], 5, True, "gs://marin-ducky-us-east5/ducky/abc.parquet", 1234, 5678)
     fake = _FakeRunner(result=result)
     client = TestClient(create_app(fake, _CONFIG))
 
@@ -88,6 +88,8 @@ def test_query_result_delivered_via_polling():
         "truncated": True,
         "result_path": "gs://marin-ducky-us-east5/ducky/abc.parquet",
         "cached": False,
+        "elapsed_ms": 1234,
+        "result_bytes": 5678,
     }
     assert fake.received_query_id == query_id
 
@@ -104,7 +106,7 @@ def test_identical_sql_served_from_cache():
             self.calls += 1
             return super().run_query(sql, query_id)
 
-    result = QueryResult(["x"], [[1]], 1, False, "gs://b/ducky/first.parquet")
+    result = QueryResult(["x"], [[1]], 1, False, "gs://b/ducky/first.parquet", 50, 99)
     runner = _CountingRunner(result)
     client = TestClient(create_app(runner, _CONFIG))
 

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -68,11 +68,38 @@ def test_health_is_public():
     assert resp.json() == {"status": "healthy"}
 
 
-def test_index_serves_form():
-    resp = _client(_FakeRunner()).get("/")
+def _built_dist(tmp_path):
+    dist = tmp_path / "dist"
+    (dist / "static").mkdir(parents=True)
+    (dist / "index.html").write_text('<!doctype html><base href="/" /><div id="app"></div>', encoding="utf-8")
+    return dist
+
+
+def test_index_serves_spa_and_rewrites_base(tmp_path, monkeypatch):
+    monkeypatch.setenv("DUCKY_DASHBOARD_DIST", str(_built_dist(tmp_path)))
+    resp = _client(_FakeRunner()).get("/", headers={"X-Forwarded-Prefix": "/proxy/ducky"})
     assert resp.status_code == 200
-    assert "text/html" in resp.headers["content-type"]
-    assert "<textarea" in resp.text
+    assert 'id="app"' in resp.text
+    assert '<base href="/proxy/ducky/"' in resp.text  # rewritten for the proxy sub-path
+
+
+def test_index_without_prefix_keeps_root_base(tmp_path, monkeypatch):
+    monkeypatch.setenv("DUCKY_DASHBOARD_DIST", str(_built_dist(tmp_path)))
+    resp = _client(_FakeRunner()).get("/")
+    assert '<base href="/"' in resp.text
+
+
+def test_index_not_built_returns_placeholder(tmp_path, monkeypatch):
+    monkeypatch.setenv("DUCKY_DASHBOARD_DIST", str(tmp_path / "absent"))
+    resp = _client(_FakeRunner()).get("/")
+    assert resp.status_code == 503
+    assert "not built" in resp.text.lower()
+
+
+def test_api_config_returns_ttl():
+    resp = _client(_FakeRunner()).get("/api/config")
+    assert resp.status_code == 200
+    assert resp.json() == {"result_ttl_days": 7}
 
 
 def test_query_accepts_and_returns_uuid_query_id():

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -1,0 +1,97 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import pytest
+from ducky.config import DuckyConfig
+from ducky.runner import QueryError, QueryResult
+from ducky.server import create_app
+from starlette.testclient import TestClient
+
+_CONFIG = DuckyConfig(
+    region="us-east5",
+    scratch_bucket="gs://marin-ducky-us-east5",
+    gcs_hmac_key_id="k",
+    gcs_hmac_secret="s",
+    r2_account_id="a",
+    r2_access_key="rk",
+    r2_secret_key="rs",
+    cw_endpoint="cw.example.com",
+    cw_access_key="ck",
+    cw_secret_key="cs",
+    result_ttl_days=7,
+)
+
+
+class _FakeRunner:
+    """Stands in for QueryRunner: records the query_id and returns a canned result."""
+
+    def __init__(self, result: QueryResult | None = None, error: Exception | None = None):
+        self._result = result
+        self._error = error
+        self.received_query_id: str | None = None
+
+    def run_query(self, sql: str, query_id: str) -> QueryResult:
+        self.received_query_id = query_id
+        if self._error is not None:
+            raise self._error
+        assert self._result is not None
+        return self._result
+
+
+def test_health_is_public():
+    client = TestClient(create_app(_FakeRunner(), _CONFIG))
+    resp = client.get("/health")
+    assert resp.status_code == 200
+    assert resp.json() == {"status": "healthy"}
+
+
+def test_index_serves_form():
+    client = TestClient(create_app(_FakeRunner(), _CONFIG))
+    resp = client.get("/")
+    assert resp.status_code == 200
+    assert "text/html" in resp.headers["content-type"]
+    assert "<textarea" in resp.text
+
+
+def test_query_returns_result_json_with_uuid_query_id():
+    result = QueryResult(
+        columns=["x"],
+        preview_rows=[[1], [2]],
+        total_rows=5,
+        truncated=True,
+        result_path="gs://marin-ducky-us-east5/ducky/abc.parquet",
+    )
+    fake = _FakeRunner(result=result)
+    client = TestClient(create_app(fake, _CONFIG))
+
+    resp = client.post("/query", json={"sql": "SELECT * FROM range(5)"})
+
+    assert resp.status_code == 200
+    assert resp.json() == {
+        "columns": ["x"],
+        "rows": [[1], [2]],
+        "total_rows": 5,
+        "truncated": True,
+        "result_path": "gs://marin-ducky-us-east5/ducky/abc.parquet",
+    }
+    assert fake.received_query_id is not None
+    assert len(fake.received_query_id) == 32
+    int(fake.received_query_id, 16)  # valid hex
+
+
+def test_query_error_maps_to_400():
+    fake = _FakeRunner(error=QueryError("Catalog Error: table not found"))
+    client = TestClient(create_app(fake, _CONFIG))
+
+    resp = client.post("/query", json={"sql": "SELECT * FROM nope"})
+
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "Catalog Error: table not found"}
+
+
+@pytest.mark.parametrize("body", [{}, {"sql": ""}, {"sql": "   "}])
+def test_query_missing_sql_is_400(body):
+    client = TestClient(create_app(_FakeRunner(), _CONFIG))
+    resp = client.post("/query", json=body)
+    assert resp.status_code == 400
+    assert resp.json() == {"error": "missing 'sql'"}

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import time
-from concurrent.futures import Future
 
 import pytest
 from ducky.config import DuckyConfig
@@ -19,16 +18,12 @@ _CONFIG = DuckyConfig(
 
 
 class _InlineExecutor:
-    """Runs submitted work synchronously, so a query finishes during ``submit`` — the
-    test reads ``/result`` once with no polling or ``time.sleep`` (per root TESTING.md)."""
+    """Runs submitted work synchronously, so a query finishes during ``submit`` — the test
+    reads ``/result`` once with no polling or ``time.sleep`` (per root TESTING.md). The manager
+    ignores the returned future and ``_run`` records its own errors, so this just calls ``fn``."""
 
     def submit(self, fn, *args, **kwargs):
-        future: Future = Future()
-        try:
-            future.set_result(fn(*args, **kwargs))
-        except Exception as e:  # mirror ThreadPoolExecutor: capture into the future
-            future.set_exception(e)
-        return future
+        fn(*args, **kwargs)
 
     def shutdown(self, wait=True, **kwargs):
         pass
@@ -132,18 +127,20 @@ def test_query_result_delivered_via_result_endpoint():
     assert fake.received_query_id is not None
 
 
+class _CountingRunner(_FakeRunner):
+    """A _FakeRunner that counts how many times it actually executed (to tell cache hits apart)."""
+
+    def __init__(self, result):
+        super().__init__(result=result)
+        self.calls = 0
+
+    def run_query(self, sql, query_id):
+        self.calls += 1
+        return super().run_query(sql, query_id)
+
+
 def test_identical_sql_served_from_cache():
     """A second run of the same SQL is served from cache without re-executing."""
-
-    class _CountingRunner(_FakeRunner):
-        def __init__(self, result):
-            super().__init__(result=result)
-            self.calls = 0
-
-        def run_query(self, sql, query_id):
-            self.calls += 1
-            return super().run_query(sql, query_id)
-
     runner = _CountingRunner(QueryResult(["x"], [[1]], 1, False, "gs://b/ducky/first.parquet", 50, 99))
     client = _client(runner)
 
@@ -154,6 +151,18 @@ def test_identical_sql_served_from_cache():
     assert first["cached"] is False
     assert second["cached"] is True
     assert second["result_path"] == "gs://b/ducky/first.parquet"  # reuses the spilled file
+
+
+def test_use_cache_false_forces_fresh_run():
+    """use_cache=False bypasses the cache and re-executes identical SQL (still refreshing it)."""
+    runner = _CountingRunner(QueryResult(["x"], [[1]], 1, False, "gs://b/x.parquet", 1, 1))
+    manager = QueryManager(runner, executor=_InlineExecutor())
+
+    manager.submit("SELECT 1")  # runs + caches
+    manager.submit("SELECT 1")  # cache hit
+    assert runner.calls == 1
+    manager.submit("SELECT 1", use_cache=False)  # forced fresh run
+    assert runner.calls == 2
 
 
 def test_query_error_surfaces_in_result():

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -11,7 +11,6 @@ from ducky.server import QueryManager, create_app
 from starlette.testclient import TestClient
 
 _CONFIG = DuckyConfig(
-    region="us-east5",
     scratch_bucket="gs://marin-ducky-us-east5",
     gcs_hmac_key_id="k",
     gcs_hmac_secret="s",

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -1,6 +1,8 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import time
+
 import pytest
 from ducky.config import DuckyConfig
 from ducky.runner import QueryError, QueryResult
@@ -12,12 +14,6 @@ _CONFIG = DuckyConfig(
     scratch_bucket="gs://marin-ducky-us-east5",
     gcs_hmac_key_id="k",
     gcs_hmac_secret="s",
-    r2_account_id="a",
-    r2_access_key="rk",
-    r2_secret_key="rs",
-    cw_endpoint="cw.example.com",
-    cw_access_key="ck",
-    cw_secret_key="cs",
     result_ttl_days=7,
 )
 
@@ -38,6 +34,17 @@ class _FakeRunner:
         return self._result
 
 
+def _poll(client: TestClient, query_id: str, timeout: float = 3.0) -> dict:
+    """Poll /result until the query leaves the 'running' state."""
+    deadline = time.monotonic() + timeout
+    while time.monotonic() < deadline:
+        payload = client.get(f"/result/{query_id}").json()
+        if payload["status"] != "running":
+            return payload
+        time.sleep(0.01)
+    raise AssertionError(f"query {query_id} still running after {timeout}s")
+
+
 def test_health_is_public():
     client = TestClient(create_app(_FakeRunner(), _CONFIG))
     resp = client.get("/health")
@@ -53,40 +60,52 @@ def test_index_serves_form():
     assert "<textarea" in resp.text
 
 
-def test_query_returns_result_json_with_uuid_query_id():
-    result = QueryResult(
-        columns=["x"],
-        preview_rows=[[1], [2]],
-        total_rows=5,
-        truncated=True,
-        result_path="gs://marin-ducky-us-east5/ducky/abc.parquet",
-    )
+def test_query_accepts_and_returns_uuid_query_id():
+    fake = _FakeRunner(result=QueryResult(["x"], [[1]], 1, False, "gs://b/ducky/a.parquet"))
+    client = TestClient(create_app(fake, _CONFIG))
+
+    resp = client.post("/query", json={"sql": "SELECT 1"})
+
+    assert resp.status_code == 202
+    query_id = resp.json()["query_id"]
+    assert len(query_id) == 32
+    int(query_id, 16)  # valid hex
+
+
+def test_query_result_delivered_via_polling():
+    result = QueryResult(["x"], [[1], [2]], 5, True, "gs://marin-ducky-us-east5/ducky/abc.parquet")
     fake = _FakeRunner(result=result)
     client = TestClient(create_app(fake, _CONFIG))
 
-    resp = client.post("/query", json={"sql": "SELECT * FROM range(5)"})
+    query_id = client.post("/query", json={"sql": "SELECT * FROM range(5)"}).json()["query_id"]
+    payload = _poll(client, query_id)
 
-    assert resp.status_code == 200
-    assert resp.json() == {
+    assert payload == {
+        "status": "done",
         "columns": ["x"],
         "rows": [[1], [2]],
         "total_rows": 5,
         "truncated": True,
         "result_path": "gs://marin-ducky-us-east5/ducky/abc.parquet",
     }
-    assert fake.received_query_id is not None
-    assert len(fake.received_query_id) == 32
-    int(fake.received_query_id, 16)  # valid hex
+    assert fake.received_query_id == query_id
 
 
-def test_query_error_maps_to_400():
+def test_query_error_surfaces_in_result():
     fake = _FakeRunner(error=QueryError("Catalog Error: table not found"))
     client = TestClient(create_app(fake, _CONFIG))
 
-    resp = client.post("/query", json={"sql": "SELECT * FROM nope"})
+    query_id = client.post("/query", json={"sql": "SELECT * FROM nope"}).json()["query_id"]
+    payload = _poll(client, query_id)
 
-    assert resp.status_code == 400
-    assert resp.json() == {"error": "Catalog Error: table not found"}
+    assert payload == {"status": "error", "error": "Catalog Error: table not found"}
+
+
+def test_unknown_query_id_is_404():
+    client = TestClient(create_app(_FakeRunner(), _CONFIG))
+    resp = client.get("/result/deadbeef")
+    assert resp.status_code == 404
+    assert resp.json() == {"error": "unknown query_id"}
 
 
 @pytest.mark.parametrize("body", [{}, {"sql": ""}, {"sql": "   "}])

--- a/lib/ducky/tests/test_tunnel.py
+++ b/lib/ducky/tests/test_tunnel.py
@@ -1,0 +1,31 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import shlex
+import sys
+
+import click
+import pytest
+from ducky.tunnel import cluster_tunnel
+
+
+def _fake_iris(code: str) -> str:
+    """A DUCKY_IRIS_CMD that runs `python -c <code>` instead of the real iris CLI."""
+    return f"{sys.executable} -c {shlex.quote(code)}"
+
+
+def test_cluster_tunnel_yields_raw_controller_url(monkeypatch):
+    # fake iris prints the tunnel line (flushed, as a pipe is block-buffered), then blocks
+    monkeypatch.setenv(
+        "DUCKY_IRIS_CMD", _fake_iris("import time; print('http://127.0.0.1:9999', flush=True); time.sleep(30)")
+    )
+    with cluster_tunnel("marin") as url:
+        assert url == "http://127.0.0.1:9999"  # raw, no /proxy suffix
+
+
+def test_cluster_tunnel_raises_when_no_url(monkeypatch):
+    # fake iris exits without ever printing a tunnel URL
+    monkeypatch.setenv("DUCKY_IRIS_CMD", _fake_iris("pass"))
+    with pytest.raises(click.ClickException, match="tunnel"):
+        with cluster_tunnel("marin", timeout=5):
+            pass

--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -18,7 +18,7 @@ Example:
 """
 
 import logging
-from collections.abc import Generator
+from collections.abc import Generator, Sequence
 from contextlib import contextmanager
 from contextvars import ContextVar
 from dataclasses import dataclass
@@ -530,6 +530,7 @@ class IrisClient:
         bundle_id: str | None = None,
         timeout_ms: int = 30000,
         credentials: ClientCredentials | None = None,
+        extra_bundle_includes: Sequence[str] = (),
     ) -> "IrisClient":
         """Create an IrisClient for an external client (CLI, laptop, notebook).
 
@@ -548,6 +549,9 @@ class IrisClient:
             credentials: Auth material for outgoing RPCs — the Iris JWT and, for
                 an IAP-fronted cluster, the IAP OIDC ID token. None sends neither
                 (a loopback-trusted tunnel).
+            extra_bundle_includes: Glob patterns (relative to ``workspace``) for
+                gitignored files the caller needs in the task bundle — e.g. a package's
+                built frontend ``dist``. Bundled in addition to the git-tracked files.
 
         Returns:
             IrisClient wrapping RemoteClusterClient
@@ -559,6 +563,7 @@ class IrisClient:
             timeout_ms=timeout_ms,
             credentials=credentials,
             use_controller_proxy=True,
+            extra_bundle_includes=extra_bundle_includes,
         )
 
     @classmethod
@@ -598,6 +603,7 @@ class IrisClient:
         timeout_ms: int,
         use_controller_proxy: bool,
         credentials: ClientCredentials | None = None,
+        extra_bundle_includes: Sequence[str] = (),
     ) -> "IrisClient":
         interceptors = credentials.interceptors() if credentials is not None else []
 
@@ -608,6 +614,7 @@ class IrisClient:
             timeout_ms=timeout_ms,
             interceptors=interceptors,
             use_controller_proxy=use_controller_proxy,
+            extra_bundle_includes=extra_bundle_includes,
         )
         return cls(cluster)
 

--- a/lib/iris/src/iris/cluster/client/bundle.py
+++ b/lib/iris/src/iris/cluster/client/bundle.py
@@ -51,6 +51,9 @@ GENERATED_ARTIFACT_GLOBS = [
     "lib/iris/src/iris/rpc/*_pb2.py",
     "lib/iris/src/iris/rpc/*_pb2.pyi",
     "lib/iris/src/iris/rpc/*_connect.py",
+    # ducky's dashboard is a bundled Vue SPA built to dashboard/dist by `npm run
+    # build`; gitignored like any build output but needed at runtime on the worker.
+    "lib/ducky/dashboard/dist/**/*",
 ]
 
 

--- a/lib/iris/src/iris/cluster/client/bundle.py
+++ b/lib/iris/src/iris/cluster/client/bundle.py
@@ -9,6 +9,7 @@ import re
 import subprocess
 import tempfile
 import zipfile
+from collections.abc import Sequence
 from pathlib import Path
 
 logger = logging.getLogger(__name__)
@@ -51,9 +52,6 @@ GENERATED_ARTIFACT_GLOBS = [
     "lib/iris/src/iris/rpc/*_pb2.py",
     "lib/iris/src/iris/rpc/*_pb2.pyi",
     "lib/iris/src/iris/rpc/*_connect.py",
-    # ducky's dashboard is a bundled Vue SPA built to dashboard/dist by `npm run
-    # build`; gitignored like any build output but needed at runtime on the worker.
-    "lib/ducky/dashboard/dist/**/*",
 ]
 
 
@@ -71,16 +69,19 @@ def collect_workspace_files(
     workspace: str | Path,
     *,
     exclude: re.Pattern[str] | None = None,
+    extra_includes: Sequence[str] = (),
 ) -> list[Path]:
     """Collect the list of files to include in a workspace bundle.
 
-    Uses git ls-files when available (respecting .gitignore), then adds back
-    generated protobuf artifacts that are gitignored but needed at runtime.
-    Falls back to pattern-based exclusion when git is unavailable.
+    Uses git ls-files when available (respecting .gitignore), then adds back gitignored
+    files needed at runtime: Iris's generated protobuf artifacts plus any caller-supplied
+    ``extra_includes`` globs (relative to ``workspace``, e.g. a package's built frontend
+    ``dist``). Falls back to pattern-based exclusion when git is unavailable.
 
     Args:
         workspace: Root directory to bundle.
         exclude: Extra regex to exclude (merged with DEFAULT_EXCLUDE).
+        extra_includes: Glob patterns for gitignored files the caller needs bundled.
 
     Returns:
         Sorted list of absolute paths.
@@ -90,7 +91,7 @@ def collect_workspace_files(
 
     git_files = _get_git_non_ignored_files(workspace, merged)
     if git_files is not None:
-        _include_generated_build_artifacts(workspace, git_files, merged)
+        _include_generated_build_artifacts(workspace, git_files, merged, extra_includes)
         return sorted(f for f in git_files if f.is_file())
 
     return sorted(
@@ -102,14 +103,17 @@ def create_workspace_zip(
     workspace: str | Path,
     *,
     exclude: re.Pattern[str] | None = None,
+    extra_includes: Sequence[str] = (),
     max_size_bytes: int | None = MAX_BUNDLE_SIZE_BYTES,
 ) -> bytes:
     """Create a zip of the workspace and return the raw bytes.
 
     Suitable for Iris bundle uploads where the caller sends bytes directly.
+    ``extra_includes`` re-includes caller-specified gitignored files (see
+    :func:`collect_workspace_files`).
     """
     workspace = Path(workspace)
-    files = collect_workspace_files(workspace, exclude=exclude)
+    files = collect_workspace_files(workspace, exclude=exclude, extra_includes=extra_includes)
 
     fd, tmp_path = tempfile.mkstemp(suffix=".zip", prefix="workspace_")
     os.close(fd)
@@ -159,10 +163,11 @@ def _include_generated_build_artifacts(
     workspace: Path,
     files: set[Path],
     exclude: re.Pattern[str],
+    extra_includes: Sequence[str] = (),
 ) -> None:
-    """Add generated build artifacts that exist on disk but are gitignored."""
+    """Add gitignored files needed at runtime: Iris's generated artifacts + caller globs."""
     added = 0
-    for pattern in GENERATED_ARTIFACT_GLOBS:
+    for pattern in [*GENERATED_ARTIFACT_GLOBS, *extra_includes]:
         for path in workspace.glob(pattern):
             if path.is_file() and path not in files and not _should_exclude(str(path.relative_to(workspace)), exclude):
                 files.add(path)

--- a/lib/iris/src/iris/cluster/client/remote_client.py
+++ b/lib/iris/src/iris/cluster/client/remote_client.py
@@ -5,7 +5,7 @@
 
 import logging
 import time
-from collections.abc import Iterable
+from collections.abc import Iterable, Sequence
 from datetime import UTC, datetime
 from pathlib import Path
 
@@ -76,6 +76,7 @@ class RemoteClusterClient:
         timeout_ms: int = 30000,
         interceptors: Iterable[InterceptorSync] = (),
         use_controller_proxy: bool = True,
+        extra_bundle_includes: Sequence[str] = (),
     ):
         """Initialize RPC cluster operations.
 
@@ -96,6 +97,7 @@ class RemoteClusterClient:
         self._address = controller_address
         self._bundle_id = bundle_id
         self._workspace = workspace.resolve() if workspace is not None else None
+        self._extra_bundle_includes = extra_bundle_includes
         self._bundle_blob: bytes | None = None
         self._timeout_ms = timeout_ms
         self._use_controller_proxy = use_controller_proxy
@@ -189,7 +191,7 @@ class RemoteClusterClient:
             request.bundle_id = self._bundle_id
         else:
             if self._bundle_blob is None and self._workspace is not None:
-                self._bundle_blob = create_workspace_zip(self._workspace)
+                self._bundle_blob = create_workspace_zip(self._workspace, extra_includes=self._extra_bundle_includes)
                 logger.info(f"Workspace bundle size: {len(self._bundle_blob) / 1024 / 1024:.1f} MB")
             request.bundle_blob = self._bundle_blob or b""
 

--- a/lib/iris/tests/cluster/client/test_bundle.py
+++ b/lib/iris/tests/cluster/client/test_bundle.py
@@ -54,6 +54,21 @@ def test_collect_includes_generated_proto_files(workspace):
     assert "src/iris/rpc/controller_connect.py" in rel
 
 
+def test_collect_adds_caller_extra_includes(workspace):
+    # a gitignored build dir the caller needs at runtime (e.g. a bundled frontend dist)
+    build = workspace / "build"
+    build.mkdir()
+    (build / "app.js").write_text("// built")
+
+    with _mock_git_files(workspace, "pyproject.toml"):
+        without = {str(f.relative_to(workspace)) for f in collect_workspace_files(workspace)}
+        with_hook = {
+            str(f.relative_to(workspace)) for f in collect_workspace_files(workspace, extra_includes=["build/**/*"])
+        }
+    assert "build/app.js" not in without  # gitignored → not bundled by default
+    assert "build/app.js" in with_hook  # caller opts it back in
+
+
 def test_collect_respects_extra_exclude(workspace):
     (workspace / "data").mkdir()
     (workspace / "data" / "big.csv").write_text("1,2,3")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,9 @@ dependencies = [
     # marin-iris, which depends on it explicitly. `scripts/rust_mode.py dev` swaps
     # marin-finelog-server to a local source build.
     "marin-finelog",
+    # marin-ducky is the ad-hoc DuckDB SQL service (dashboard + runner + deploy),
+    # a workspace member so service fixes land without a wheel republish.
+    "marin-ducky",
     # top level deps. try to keep these small.
     "watchdog",
     # marin-dupekit is a native (maturin) package shipped as pre-built platform
@@ -121,6 +124,7 @@ members = [
     "lib/iris",
     "lib/fray",
     "lib/finelog",
+    "lib/ducky",
     "lib/haliax",
     "lib/levanter",
     "lib/marin",
@@ -147,6 +151,7 @@ vllm = [
 marin-iris = { workspace = true }
 marin-fray = { workspace = true }
 marin-finelog = { workspace = true }
+marin-ducky = { workspace = true }
 marin-haliax = { workspace = true }
 marin-levanter = { workspace = true }
 marin-core = { workspace = true }
@@ -266,6 +271,7 @@ project-includes = [
     "lib/fray/src/**/*.py",
     "lib/iris/src/**/*.py",
     "lib/iris/scripts/**/*.py",
+    "lib/ducky/src/**/*.py",
     "lib/rigging/src/**/*.py",
     "lib/zephyr/src/**/*.py",
     "scripts/ci",
@@ -283,6 +289,7 @@ search-path = [
     "lib/zephyr/src",
     "lib/fray/src",
     "lib/iris/src",
+    "lib/ducky/src",
     # benchmark_controller.py imports controller test fixtures from lib/iris/tests
     # (`from tests.cluster.controller... import`), run with lib/iris on sys.path.
     "lib/iris",

--- a/uv.lock
+++ b/uv.lock
@@ -196,6 +196,7 @@ fork-strategy = "fewest"
 [manifest]
 members = [
     "marin-core",
+    "marin-ducky",
     "marin-finelog",
     "marin-fray",
     "marin-haliax",
@@ -4746,6 +4747,43 @@ test = [
 ]
 
 [[package]]
+name = "marin-ducky"
+version = "0.1.0"
+source = { editable = "lib/ducky" }
+dependencies = [
+    { name = "click" },
+    { name = "duckdb" },
+    { name = "marin-iris" },
+    { name = "pyarrow" },
+    { name = "starlette" },
+    { name = "uvicorn" },
+]
+
+[package.dev-dependencies]
+dev = [
+    { name = "httpx" },
+    { name = "pytest" },
+    { name = "pytest-timeout" },
+]
+
+[package.metadata]
+requires-dist = [
+    { name = "click", specifier = ">=8.3.1" },
+    { name = "duckdb", specifier = ">=1.0.0" },
+    { name = "marin-iris", editable = "lib/iris" },
+    { name = "pyarrow", specifier = ">=23.0.0" },
+    { name = "starlette", specifier = ">=0.37" },
+    { name = "uvicorn", specifier = ">=0.30" },
+]
+
+[package.metadata.requires-dev]
+dev = [
+    { name = "httpx", specifier = ">=0.27" },
+    { name = "pytest", specifier = ">=8.4" },
+    { name = "pytest-timeout" },
+]
+
+[[package]]
 name = "marin-dupekit"
 version = "0.1.2.dev202606081019"
 source = { registry = "https://pypi.org/simple" }
@@ -5372,6 +5410,7 @@ version = "0.1.0"
 source = { editable = "." }
 dependencies = [
     { name = "marin-core" },
+    { name = "marin-ducky" },
     { name = "marin-dupekit" },
     { name = "marin-finelog" },
     { name = "marin-fray" },
@@ -5386,6 +5425,7 @@ dependencies = [
 [package.metadata]
 requires-dist = [
     { name = "marin-core", editable = "lib/marin" },
+    { name = "marin-ducky", editable = "lib/ducky" },
     { name = "marin-dupekit", specifier = ">=0.1.2.dev202606060824" },
     { name = "marin-finelog", editable = "lib/finelog" },
     { name = "marin-fray", editable = "lib/fray" },

--- a/uv.lock
+++ b/uv.lock
@@ -4761,7 +4761,7 @@ dependencies = [
 ]
 
 [package.dev-dependencies]
-dev = [
+test = [
     { name = "pytest" },
     { name = "pytest-timeout" },
 ]
@@ -4778,7 +4778,7 @@ requires-dist = [
 ]
 
 [package.metadata.requires-dev]
-dev = [
+test = [
     { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-timeout" },
 ]

--- a/uv.lock
+++ b/uv.lock
@@ -4753,6 +4753,7 @@ source = { editable = "lib/ducky" }
 dependencies = [
     { name = "click" },
     { name = "duckdb" },
+    { name = "httpx" },
     { name = "marin-iris" },
     { name = "pyarrow" },
     { name = "starlette" },
@@ -4761,7 +4762,6 @@ dependencies = [
 
 [package.dev-dependencies]
 dev = [
-    { name = "httpx" },
     { name = "pytest" },
     { name = "pytest-timeout" },
 ]
@@ -4770,6 +4770,7 @@ dev = [
 requires-dist = [
     { name = "click", specifier = ">=8.3.1" },
     { name = "duckdb", specifier = ">=1.0.0" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "marin-iris", editable = "lib/iris" },
     { name = "pyarrow", specifier = ">=23.0.0" },
     { name = "starlette", specifier = ">=0.37" },
@@ -4778,7 +4779,6 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
-    { name = "httpx", specifier = ">=0.27" },
     { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-timeout" },
 ]


### PR DESCRIPTION
* fixes marin-community/marin#6760
* new `lib/ducky` package (`marin-ducky`) — an always-on Iris service for ad-hoc DuckDB SQL over object-store parquet on a full v6e host
* paste SQL in a dashboard → runs in embedded DuckDB on a v6e-4 host (~180 vCPU / 690 GB) → capped preview + full result spilled to a TTL'd GCS path; live at https://iris.oa.dev/proxy/ducky/ [^iap]
* `runner.py` — shared DuckDB instance, one cursor per query so up to `max_concurrent_queries` (default 8) run in parallel; `threads` + `memory_limit` (0.6 of host RAM, a hard cap leaving ~40% headroom for concurrent Arrow previews / httpfs buffers so the container isn't cgroup-OOM-killed) + a local-disk `temp_directory` (`/var/tmp`, not tmpfs) capped by `max_temp_directory_size` (60 GB, under the ~100 GB boot disk) so big queries spill out-of-core and a runaway fails per-query instead of filling the disk; spill dir wiped on startup so a crash can't orphan temp files; runs user SQL as a relation (`con.sql(sql).write_parquet`) so trailing `;`/`-- comment` just work, then reads the parquet back once for count + preview; per-query watchdog interrupts past `query_timeout` (600 s); `query_id` validated against path injection, non-finite floats and non-scalars coerced to `str`
* graceful OOM / self-healing — the server runs in a supervised child process: a cgroup OOM reaps the child while the tiny parent supervisor survives and restarts it in-process (**no Iris retry consumed**), with exponential backoff (capped 300 s, reset after a healthy run) so a crash-loop can't hot-loop; `max_retries_failure` is the Iris backstop if the whole container is killed
* hardening — when results go to object storage, `disabled_filesystems=LocalFileSystem` + `lock_configuration` block user SQL from touching the local filesystem (e.g. `read_text('/proc/self/environ')` to exfil the injected creds); spilling and object-store access are unaffected, and a query can't `SET` the guard back off
* object-store backends — GCS via HMAC interop (`gs://`, httpfs can't use ADC); R2 and CoreWeave are both `s3://` with different endpoints, so each is a `TYPE S3` secret `SCOPE`-d to its bucket and DuckDB routes by longest matching scope [^backends]
* `allowed_buckets` guardrail — a query referencing a `gs://`/`s3://`/`r2://` URI outside the prefix allowlist is refused before execution (`BucketNotAllowedError` → 400) [^guardrail]
* `server.py` — Starlette dashboard (CodeMirror SQL editor + grayed example); async query model: `POST /query` → `query_id`, page polls `GET /result/{id}` to dodge the controller proxy's 30 s request cap; in-memory result cache keyed on exact SQL (expires with the spilled parquet's TTL); result line = rows · elapsed · result size · cached/computed · GCS path; registers the cluster-global endpoint `/ducky` (reachable at `/proxy/ducky/`)
* `deploy.py` — `client.submit(ports=["ducky"])` on a region-pinned v6e-4 host, since `iris job run` can't declare named ports
* `client.py` — `ducky query --cluster marin "SELECT …"`: auto-opens a controller tunnel via `iris cluster dashboard`, hides the `/proxy/ducky` path, prints a table (or `--format json`)
* design docs (1-pager + research + spec) under `.agents/projects/duckdb_sql_service/`
* 44 unit tests; reviewed with codex (correctness + design passes) + `/lint-review`; `./infra/pre-commit.py` clean

[^iap]: marin cluster, behind IAP — path addressing only (`iris.oa.dev/proxy/ducky/`); the proxy's subdomain form `ducky.proxy.iris.oa.dev` isn't DNS-backed for prod.
[^backends]: R2 = `s3://marin-na` (path-style, cloudflare account endpoint); CoreWeave = `s3://marin-us-east-02a` (virtual-host only). all three validated live. creds injected as `DUCKY_*` task env, worth rotating post-merge.
[^guardrail]: prefix-matched, so `gs://marin-` permits every `marin-*` bucket incl. cross-region — a "marin-owned buckets" guard, not strict same-region; a trailing slash bounds an entry to one bucket. it catches literal URIs in the SQL, not paths hidden behind views/macros — the local-FS hardening above is the backstop against non-object-store reads.
