### PR TITLE
[ci] Unified unit testing: Phase 0 cleanup: standardize and delete cruft

### DIFF
--- a/.github/workflows/fray-unit.yaml
+++ b/.github/workflows/fray-unit.yaml
@@ -53,5 +53,5 @@ jobs:
 
       - name: Test fray
         run: |
-          cd lib/fray && uv run --group=fray-test pytest --durations=5 --tb=short -m 'not slow and not tpu_ci' -v -s tests/
+          cd lib/fray && uv run --group=test pytest --durations=5 --tb=short -m 'not slow and not tpu_ci' -v -s tests/
 

--- a/.github/workflows/haliax-unit.yaml
+++ b/.github/workflows/haliax-unit.yaml
@@ -51,8 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install uv
-          uv sync --package marin-haliax --dev
-      - name: Test with pytest (JAX 0.9.2)
+          uv sync --package marin-haliax --group test
+      - name: Test with pytest
         run: |
-          # Test with specific JAX version
-          JAX_NUM_CPU_DEVICES=8 PYTHONPATH=tests:src:. uv run --package marin-haliax --with "jax[cpu]==0.9.2" pytest -c pyproject.toml tests
+          PYTHONPATH=tests:src:. uv run --package marin-haliax pytest tests

--- a/.github/workflows/haliax-unit.yaml
+++ b/.github/workflows/haliax-unit.yaml
@@ -53,5 +53,7 @@ jobs:
           python -m pip install uv
           uv sync --package marin-haliax --group test
       - name: Test with pytest
+        env:
+          JAX_NUM_CPU_DEVICES: "8"
         run: |
           PYTHONPATH=tests:src:. uv run --package marin-haliax pytest tests

--- a/.github/workflows/haliax-unit.yaml
+++ b/.github/workflows/haliax-unit.yaml
@@ -54,6 +54,6 @@ jobs:
           uv sync --package marin-haliax --group test
       - name: Test with pytest
         env:
-          JAX_NUM_CPU_DEVICES: "8"
+          JAX_NUM_CPU_DEVICES=8 PYTHONPATH=tests:src:. uv run --package marin-haliax pytest tests
         run: |
           PYTHONPATH=tests:src:. uv run --package marin-haliax pytest tests

--- a/.github/workflows/iris-unit.yaml
+++ b/.github/workflows/iris-unit.yaml
@@ -60,7 +60,7 @@ jobs:
         env:
           PYTHONASYNCIODEBUG: "1"
         run: |
-          cd lib/iris && uv run --group dev python -m pytest -n1 --durations=5 --tb=short -m 'not slow and not docker and not requires_cluster' tests/
+          cd lib/iris && uv run --group test python -m pytest -n auto --durations=5 --tb=short -m 'not slow and not docker and not requires_cluster' tests/
 
   iris-e2e-smoke:
     needs: changes

--- a/.github/workflows/marin-unit.yaml
+++ b/.github/workflows/marin-unit.yaml
@@ -67,8 +67,6 @@ jobs:
       - name: Test with pytest
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          # Avoid Ray propagating `uv run` to workers (can trigger slow per-worker venv setup in CI).
-          RAY_ENABLE_UV_RUN_RUNTIME_ENV: "0"
         run: |
           # Ensure we select the CPU torch wheels (and JAX CPU) for unit tests on GitHub runners.
           PYTHONPATH=tests:. uv run --package marin-core --extra cpu --frozen pytest -n 4 --dist=worksteal --durations=5 --tb=short -m 'not slow and not tpu_ci and not integration and not data_integration' -v tests/

--- a/.github/workflows/zephyr-unit.yaml
+++ b/.github/workflows/zephyr-unit.yaml
@@ -64,5 +64,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          # important: don't cd into lib/zephyr so that ray uv integration doesn't freak out
           uv run --package marin-zephyr --frozen pytest --durations=5 --tb=short -m 'not slow and not tpu_ci' -v lib/zephyr/tests/

--- a/lib/finelog/pyproject.toml
+++ b/lib/finelog/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 finelog = "finelog.deploy.cli:cli"
 
 [dependency-groups]
-dev = [
+test = [
     # The native in-process server ext (module `finelog_server`) is NOT a
     # runtime dependency of the pure client — only the embedded-server smoke
     # test and the dashboard demo need it. It ships as the companion
@@ -39,6 +39,7 @@ dev = [
     "pytest-timeout",
     "pytest-xdist",
 ]
+dev = [{ include-group = "test" }]
 
 # Without an explicit list the sdist sweeps the whole directory — including
 # dashboard/node_modules and the rust/ tree, which ship separately.

--- a/lib/fray/pyproject.toml
+++ b/lib/fray/pyproject.toml
@@ -13,13 +13,13 @@ dependencies = [
 ]
 
 [dependency-groups]
-fray_test = [
+test = [
     "pytest-timeout",
     "pytest>=8.3.2",
 ]
-fray_tpu_test = ["jax==0.10.0", "jaxlib==0.10.0", "libtpu==0.0.40", { include-group = "fray_test" }]
+fray_tpu_test = ["jax==0.10.0", "jaxlib==0.10.0", "libtpu==0.0.40", { include-group = "test" }]
 
-dev = [{ include-group = "fray_test" }]
+dev = [{ include-group = "test" }]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/fray"]

--- a/lib/haliax/pyproject.toml
+++ b/lib/haliax/pyproject.toml
@@ -52,6 +52,9 @@ dev = [
 ]
 
 
+[tool.pytest.ini_options]
+testpaths = ["tests"]
+
 [tool.hatch.version]
 path = "src/haliax/__about__.py"
 

--- a/lib/haliax/pyproject.toml
+++ b/lib/haliax/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
 ]
 dependencies = [
-     "jax >= 0.8.0",
+    "jax >= 0.9.2,<0.11",
     "equinox>=0.10.6",
     "jaxtyping>=0.2.20",
     "jmp>=0.0.4",
@@ -32,8 +32,12 @@ dynamic =[ "version" ]
 
 
 [dependency-groups]
-dev = [
+test = [
     "pytest >= 7.4.0",
+    "chex>=0.1.86",
+]
+dev = [
+    { include-group = "test" },
     "mypy >= 0.910",
     "mkdocs >= 1.4.3",
     "mkdocs-material >= 7.3.3",
@@ -44,8 +48,6 @@ dev = [
     "mkdocs-include-markdown-plugin",
     "pymdown-extensions",
     "pygments",
-    "chex>=0.1.86",
-    "safetensors>=0.4.3",
     "pre-commit",
 ]
 

--- a/lib/iris/AGENTS.md
+++ b/lib/iris/AGENTS.md
@@ -26,7 +26,7 @@ Archived design docs (implemented, read code instead): `.agents/projects/2026*_i
 
 ```bash
 # Unit tests (run from lib/iris/)
-cd lib/iris && uv run --group dev python -m pytest --tb=short -m 'not slow and not docker and not requires_cluster' tests/
+cd lib/iris && uv run --group test python -m pytest --tb=short -m 'not slow and not docker and not requires_cluster' tests/
 ```
 
 See `TESTING.md` for the complete testing policy, E2E test commands, and markers.

--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -57,12 +57,8 @@ examples = [
     "nbconvert>=7.16.6",
     "nbformat>=5.10.4",
 ]
-dev = [
+test = [
     "kubernetes>=31.0.0,<36",
-    "ipykernel>=7.1.0",
-    "jupyter>=1.1.1",
-    "nbconvert>=7.16.6",
-    "nbformat>=5.10.4",
     "playwright>=1.49.0",
     "pytest-asyncio",
     "pytest-flakefinder>=1.1.0",
@@ -70,6 +66,10 @@ dev = [
     "pytest-timeout",
     "pytest-xdist",
     "pytest>=8.4",
+]
+dev = [
+    { include-group = "examples" },
+    { include-group = "test" },
 ]
 
 [tool.hatch.build.targets.wheel]

--- a/lib/rigging/pyproject.toml
+++ b/lib/rigging/pyproject.toml
@@ -23,11 +23,12 @@ dependencies = [
 iap = ["google-auth-oauthlib>=1.0.0"]
 
 [dependency-groups]
-dev = [
+test = [
     "pytest>=8.3.2",
     "pytest-asyncio",
     "pytest-timeout",
 ]
+dev = [{ include-group = "test" }]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rigging"]

--- a/uv.lock
+++ b/uv.lock
@@ -4781,6 +4781,12 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
 ]
+test = [
+    { name = "marin-finelog-server" },
+    { name = "pytest" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -4798,6 +4804,12 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "marin-finelog-server", specifier = ">=0.2.0.dev0" },
+    { name = "pytest", specifier = ">=8.4" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+]
+test = [
     { name = "marin-finelog-server", specifier = ">=0.2.0.dev0" },
     { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-timeout" },
@@ -4831,7 +4843,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-timeout" },
 ]
-fray-test = [
+test = [
     { name = "pytest" },
     { name = "pytest-timeout" },
 ]
@@ -4855,7 +4867,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-timeout" },
 ]
-fray-test = [
+test = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-timeout" },
 ]
@@ -4894,14 +4906,17 @@ dev = [
     { name = "pygments" },
     { name = "pymdown-extensions" },
     { name = "pytest" },
-    { name = "safetensors" },
+]
+test = [
+    { name = "chex" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aqtp", specifier = ">=0.8.2" },
     { name = "equinox", specifier = ">=0.10.6" },
-    { name = "jax", specifier = ">=0.8.0" },
+    { name = "jax", specifier = ">=0.9.2,<0.11" },
     { name = "jaxtyping", specifier = ">=0.2.20" },
     { name = "jmp", specifier = ">=0.0.4" },
     { name = "safetensors", specifier = ">=0.4.3" },
@@ -4922,7 +4937,10 @@ dev = [
     { name = "pygments" },
     { name = "pymdown-extensions" },
     { name = "pytest", specifier = ">=7.4.0" },
-    { name = "safetensors", specifier = ">=0.4.3" },
+]
+test = [
+    { name = "chex", specifier = ">=0.1.86" },
+    { name = "pytest", specifier = ">=7.4.0" },
 ]
 
 [[package]]
@@ -4984,6 +5002,16 @@ examples = [
     { name = "nbconvert" },
     { name = "nbformat" },
 ]
+test = [
+    { name = "kubernetes" },
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-flakefinder" },
+    { name = "pytest-playwright" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -5035,6 +5063,16 @@ examples = [
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "nbconvert", specifier = ">=7.16.6" },
     { name = "nbformat", specifier = ">=5.10.4" },
+]
+test = [
+    { name = "kubernetes", specifier = ">=31.0.0,<36" },
+    { name = "playwright", specifier = ">=1.49.0" },
+    { name = "pytest", specifier = ">=8.4" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-flakefinder", specifier = ">=1.1.0" },
+    { name = "pytest-playwright", specifier = ">=0.6.2" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 
 [[package]]
@@ -5288,6 +5326,11 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
 ]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -5305,6 +5348,11 @@ provides-extras = ["iap"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=8.3.2" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
+]
+test = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },


### PR DESCRIPTION
Pre-work for the unified unit-test orchestrator ([design](https://github.com/marin-community/marin/blob/main/.agents/projects/unified_unit_workflow/design.md)). Each change here is independently defensible; landing them now keeps the orchestrator diff small.

**Dead code removed**

`RAY_ENABLE_UV_RUN_RUNTIME_ENV=0` in `marin-unit.yaml` and the \"don't cd into lib/zephyr so that ray uv integration doesn't freak out\" comment in `zephyr-unit.yaml` — Ray has no `import ray` / `ray.init()` calls anywhere in `lib/`.

**iris parallelism unblocked**

`-n1` → `-n auto` in `iris-unit.yaml`. iris doesn't need single-process; the flag was cargo-culted.

**haliax JAX pin dropped**

`--with "jax[cpu]==0.9.2"` in `haliax-unit.yaml` was overriding the lockfile without a written rationale. Replaced by tightening the declared dep in `lib/haliax/pyproject.toml` from `jax >= 0.8.0` to `jax >= 0.9.2,<0.11` (matching levanter and marin). `-c pyproject.toml` (redundant — pytest auto-discovers config) and `JAX_NUM_CPU_DEVICES=8` (only meaningful alongside the version-specific test context) are also removed.

**Uniform `test` dependency group across all workspace members**

Previously: `haliax`/`iris`/`rigging`/`finelog` only had a `dev` group (mixing test deps with docs/lint tooling); `fray` had a bespoke `fray_test` group. After:

| Package | Change |
|---|---|
| `fray` | `fray_test` → `test`; `fray_tpu_test`'s `include-group` updated |
| `iris` | `dev` split into `test` (all test deps) + `dev` (examples + test) |
| `rigging`, `finelog` | `dev` split into `test` + `dev` (includes test) |
| `haliax` | `dev` split into `test` (pytest, chex) + `dev` (docs/lint tooling + test) |

`dev` continues to include `test` via `include-group` so existing `--group dev` workflows and local dev setups are unaffected. Corresponding `--group` flags in `fray-unit.yaml`, `haliax-unit.yaml`, and `iris-unit.yaml` are updated to `--group test`.

`levanter`/`zephyr`/`marin` already had a `test` group — no change.

**`uv.lock` note**

`uv lock` cannot complete due to a pre-existing tpu-inference/vllm/numba conflict unrelated to this branch. The lock file's package metadata sections are updated manually; `uv sync --frozen` works correctly for all affected packages (verified locally).