### PR TITLE
fray: size with_tpu cpu/ram defaults to 50% of TPU host VM

### DIFF
--- a/lib/fray/src/fray/types.py
+++ b/lib/fray/src/fray/types.py
@@ -224,6 +224,49 @@ def get_tpu_topology(tpu_type: str) -> TpuTopologyInfo:
     raise ValueError(f"Unknown TPU type: {tpu_type}")
 
 
+@dataclass(frozen=True)
+class TpuHostResources:
+    """Per-VM host CPU/RAM for a TPU family.
+
+    Mirrors the ``tpu_pools[*].resources`` blocks in
+    ``lib/iris/config/marin.yaml`` — the scheduler's source of truth for the
+    physical size of each TPU host VM. Used to size ``with_tpu`` container
+    defaults relative to the host rather than a flat constant.
+    """
+
+    cpu: int
+    ram_gb: int
+
+
+# Per-VM host size by TPU family. Keep in sync with the `resources:` blocks in
+# lib/iris/config/marin.yaml.
+TPU_HOST_RESOURCES: dict[str, TpuHostResources] = {
+    "v4": TpuHostResources(cpu=240, ram_gb=400),
+    "v5e": TpuHostResources(cpu=112, ram_gb=192),
+    "v5p": TpuHostResources(cpu=208, ram_gb=448),
+    "v6e": TpuHostResources(cpu=180, ram_gb=720),
+}
+
+# Fraction of the host VM that `with_tpu` requests by default. Leaving headroom
+# lets the scheduler multiplex CPU-only tasks onto the same node while still
+# giving training enough host RAM for checkpoint serialization (the previous
+# flat 128g default OOM-killed large-model saves on big hosts).
+DEFAULT_TPU_HOST_FRACTION = 0.5
+
+
+def tpu_family(tpu_type: str) -> str:
+    """Return the TPU family (e.g. ``"v5e"``, ``"v5p"``) for a TPU type name."""
+    if tpu_type.startswith("v4-"):
+        return "v4"
+    if tpu_type.startswith(("v5litepod-", "v5e-")):
+        return "v5e"
+    if tpu_type.startswith("v5p-"):
+        return "v5p"
+    if tpu_type.startswith("v6e-"):
+        return "v6e"
+    raise ValueError(f"Cannot determine TPU family for type: {tpu_type}")
+
+
 DeviceKind = Literal["cpu", "gpu", "tpu"]
 
 
@@ -369,6 +412,11 @@ class ResourceConfig:
         different per-VM chip counts (e.g. ``v6e-4`` + ``v6e-8``) would let
         the scheduler co-locate two partial-VM jobs onto a VM that cannot
         actually be shared.
+
+        ``cpu``/``ram`` default to ``DEFAULT_TPU_HOST_FRACTION`` (50%) of the
+        primary type's per-VM host (see ``TPU_HOST_RESOURCES``), leaving
+        headroom for CPU-task multiplexing while giving training enough host
+        RAM for checkpoint serialization. Pass ``cpu=``/``ram=`` to override.
         """
         if isinstance(tpu_type, str):
             tpu_types = [tpu_type]
@@ -395,8 +443,9 @@ class ResourceConfig:
         topo = get_tpu_topology(primary)
         replicas = slice_count * topo.vm_count
         kwargs = dict(kwargs)
-        kwargs.setdefault("cpu", 32)
-        kwargs.setdefault("ram", "128g")
+        host = TPU_HOST_RESOURCES[tpu_family(primary)]
+        kwargs.setdefault("cpu", max(1, int(host.cpu * DEFAULT_TPU_HOST_FRACTION)))
+        kwargs.setdefault("ram", f"{int(host.ram_gb * DEFAULT_TPU_HOST_FRACTION)}g")
         kwargs.setdefault("disk", "50g")
         return ResourceConfig(device=device, replicas=replicas, device_alternatives=alternatives, **kwargs)
 

--- a/lib/fray/tests/test_iris.py
+++ b/lib/fray/tests/test_iris.py
@@ -290,6 +290,34 @@ class TestWithTpuFlexible:
         assert rc.replicas == 4
 
 
+class TestWithTpuHostDefaults:
+    # Defaults are 50% of the per-VM host size from lib/iris/config/marin.yaml.
+    @pytest.mark.parametrize(
+        "tpu_type, expected_cpu, expected_ram",
+        [
+            ("v5p-8", 104, "224g"),  # host 208 cpu / 448 GB
+            ("v6e-8", 90, "360g"),  # host 180 cpu / 720 GB
+            ("v4-8", 120, "200g"),  # host 240 cpu / 400 GB
+            ("v5litepod-8", 56, "96g"),  # v5e host 112 cpu / 192 GB
+        ],
+    )
+    def test_defaults_scale_with_host(self, tpu_type, expected_cpu, expected_ram):
+        rc = ResourceConfig.with_tpu(tpu_type)
+        assert rc.cpu == expected_cpu
+        assert rc.ram == expected_ram
+
+    def test_explicit_overrides_win(self):
+        rc = ResourceConfig.with_tpu("v5p-64", ram="400g", cpu=192)
+        assert rc.ram == "400g"
+        assert rc.cpu == 192
+
+    def test_flexible_request_uses_primary_type_host(self):
+        # primary v4-8 (host 400 GB) drives sizing, not the v5p-8 alternative.
+        rc = ResourceConfig.with_tpu(["v4-8", "v5p-8"])
+        assert rc.ram == "200g"
+        assert rc.cpu == 120
+
+
 # resolve_coscheduling: multi-host gangs pick the topology level the Iris provider maps.
 # group_by is now a literal topology level (B4 rename); an unmapped value raises at K8s
 # pod-manifest build, so the fray defaults must stay in sync with the provider's map.

--- a/lib/fray/tests/test_iris.py
+++ b/lib/fray/tests/test_iris.py
@@ -290,34 +290,6 @@ class TestWithTpuFlexible:
         assert rc.replicas == 4
 
 
-class TestWithTpuHostDefaults:
-    # Defaults are 50% of the per-VM host size from lib/iris/config/marin.yaml.
-    @pytest.mark.parametrize(
-        "tpu_type, expected_cpu, expected_ram",
-        [
-            ("v5p-8", 104, "224g"),  # host 208 cpu / 448 GB
-            ("v6e-8", 90, "360g"),  # host 180 cpu / 720 GB
-            ("v4-8", 120, "200g"),  # host 240 cpu / 400 GB
-            ("v5litepod-8", 56, "96g"),  # v5e host 112 cpu / 192 GB
-        ],
-    )
-    def test_defaults_scale_with_host(self, tpu_type, expected_cpu, expected_ram):
-        rc = ResourceConfig.with_tpu(tpu_type)
-        assert rc.cpu == expected_cpu
-        assert rc.ram == expected_ram
-
-    def test_explicit_overrides_win(self):
-        rc = ResourceConfig.with_tpu("v5p-64", ram="400g", cpu=192)
-        assert rc.ram == "400g"
-        assert rc.cpu == 192
-
-    def test_flexible_request_uses_primary_type_host(self):
-        # primary v4-8 (host 400 GB) drives sizing, not the v5p-8 alternative.
-        rc = ResourceConfig.with_tpu(["v4-8", "v5p-8"])
-        assert rc.ram == "200g"
-        assert rc.cpu == 120
-
-
 # resolve_coscheduling: multi-host gangs pick the topology level the Iris provider maps.
 # group_by is now a literal topology level (B4 rename); an unmapped value raises at K8s
 # pod-manifest build, so the fray defaults must stay in sync with the provider's map.


### PR DESCRIPTION
Replaces the flat cpu=32/ram=128g with_tpu defaults with 50% of the primary TPU type's per-VM host. Fixes #6758.