### PR TITLE
Fix conflicting uv dependencies (numba/tpu-inference vs vllm)

### DIFF
--- a/lib/marin/pyproject.toml
+++ b/lib/marin/pyproject.toml
@@ -108,6 +108,13 @@ conflicts = [
         { extra = "vllm" },
         { extra = "gpu" },
     ],
+    [
+        # cpu (CPU dev/testing) and vllm (TPU inference) pin conflicting
+        # versions of common deps (e.g. numba) and are never activated
+        # together in any workflow or deployment.
+        { extra = "cpu" },
+        { extra = "vllm" },
+    ],
 ]
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -75,6 +75,11 @@ override-dependencies = [
     "mistune>=3.2.1",
     "multipart>=1.3.1",
     "nltk>=3.9.4",
+    # tpu-inference pins numba==0.62.1; the vllm CPU wheel pins numba==0.65.0.
+    # Both live in marin-core[vllm], so they must co-resolve. Widen both pins
+    # to this range so uv can pick a single version (0.65.0). Remove this
+    # override once tpu-inference is updated to support numba>=0.65.0.
+    "numba>=0.62.1,<=0.65.0",
     "notebook>=7.5.6",
     "orjson>=3.11.9",
     "pillow>=12.2.0",
@@ -113,6 +118,12 @@ conflicts = [
     [
         { package = "marin-levanter", extra = "gpu" },
         { package = "marin-fray", group = "fray_tpu_test" },
+    ],
+    [
+        # marin-core[cpu] and marin-core[vllm] pin conflicting numba versions
+        # (see override-dependencies above). They are never co-installed.
+        { package = "marin-core", extra = "cpu" },
+        { package = "marin-core", extra = "vllm" },
     ],
 ]
 


### PR DESCRIPTION
tpu-inference==0.22.1 and the vllm CPU wheel both live in marin-core[vllm] but pin incompatible numba versions (==0.62.1 and ==0.65.0 respectively), causing uv lock to fail on any resolution split that included that extra.

Three changes:

- Add a numba>=0.62.1,<=0.65.0 override-dependency so uv can pick a single numba version (0.65.0) that satisfies both packages within the vllm extra. This is a stopgap; the override should be removed once tpu-inference is updated to support numba>=0.65.0.
- Declare marin-core[cpu] and marin-core[vllm] as conflicting in both lib/marin/pyproject.toml (package-level) and the root pyproject.toml (workspace-level), consistent with how other incompatible extra pairs are declared. The two extras are never co-installed in any workflow.
- Update uv.lock to reflect the new conflict.