### PR TITLE
[codex] Clarify TPU vLLM refresh dependency policy

### DIFF
--- a/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
+++ b/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
@@ -169,6 +169,15 @@ Also make only fork-stack update changes needed in Marin:
 
 - remove any old `vllm-tpu==0.19.0` path;
 - make `marin-core[vllm]` own the TPU-vLLM runtime stack;
+- keep shared Marin workspace dependencies aligned by default. When the refresh
+  requires a new version of packages shared with training/test stacks
+  (`jax`, `jaxlib`, `libtpu`, `transformers`, `torch`, etc.), first update all
+  relevant Marin workspace consumers together, including `marin-core`,
+  `marin-levanter`, and `marin-fray`, then validate the unified graph;
+- do not add resolver conflicts or package splits that isolate serving from
+  training/test profiles unless the unified monorepo update has been attempted,
+  the failure is understood, and the PR or blocker issue explains why the split
+  is necessary and how it should be removed later;
 - preserve worker/eval paths that intentionally combine `tpu` and `vllm`
   extras, unless refreshed-stack validation proves they must change;
 - set `VLLM_TARGET_DEVICE=tpu` for TPU source-build workers.


### PR DESCRIPTION
Splits the refresh-skill policy update out of #6733.\n\nThe skill now says TPU/vLLM refreshes should keep shared Marin workspace dependencies aligned by default, including training and test consumers, before falling back to resolver conflicts or serving/training package splits.\n\nValidation: git diff --check --cached before commit.