### PR TITLE
configure TTL temp buckets for coreweave object storage

### DIFF
--- a/config/coreweave.yaml
+++ b/config/coreweave.yaml
@@ -1,6 +1,13 @@
 iris: coreweave
 data:
   scheme: s3
-  region_buckets: { na: marin-na }
+  # S3-compatible storage for the CoreWeave clusters. `store` selects the backend
+  # (endpoint/addressing/credentials); CoreWeave AI Object Storage buckets also
+  # carry their signing `region`. Consumed by rigging temp-path routing and by
+  # infra/configure_buckets.py lifecycle rules.
+  region_buckets:
+    na:          { bucket: marin-na,          store: r2 }
+    us-east-02a: { bucket: marin-us-east-02a, store: coreweave, region: US-EAST-02A }
+    us-west-04a: { bucket: marin-us-west-04a, store: coreweave, region: US-WEST-04A }
   temp: { path: tmp, ttl_days: [1, 2, 3, 7] }
   root: s3://marin-na/marin

--- a/config/coreweave.yaml
+++ b/config/coreweave.yaml
@@ -3,11 +3,11 @@ data:
   scheme: s3
   # S3-compatible storage for the CoreWeave clusters. `store` selects the backend
   # (endpoint/addressing/credentials); CoreWeave AI Object Storage buckets also
-  # carry their signing `region`. Consumed by rigging temp-path routing and by
+  # carry their `signing_region`. Consumed by rigging temp-path routing and by
   # infra/configure_buckets.py lifecycle rules.
   region_buckets:
     na:          { bucket: marin-na,          store: r2 }
-    us-east-02a: { bucket: marin-us-east-02a, store: coreweave, region: US-EAST-02A }
-    us-west-04a: { bucket: marin-us-west-04a, store: coreweave, region: US-WEST-04A }
+    us-east-02a: { bucket: marin-us-east-02a, store: coreweave, signing_region: US-EAST-02A }
+    us-west-04a: { bucket: marin-us-west-04a, store: coreweave, signing_region: US-WEST-04A }
   temp: { path: tmp, ttl_days: [1, 2, 3, 7] }
   root: s3://marin-na/marin

--- a/config/marin.yaml
+++ b/config/marin.yaml
@@ -2,10 +2,10 @@ iris: marin
 data:
   scheme: gs
   region_buckets:
-    us-central1:  marin-us-central1
-    us-central2:  marin-us-central2
-    us-east1:     marin-us-east1
-    us-east5:     marin-us-east5
-    us-west4:     marin-us-west4
-    europe-west4: marin-eu-west4
+    us-central1:  { bucket: marin-us-central1, store: gcs }
+    us-central2:  { bucket: marin-us-central2, store: gcs }
+    us-east1:     { bucket: marin-us-east1,    store: gcs }
+    us-east5:     { bucket: marin-us-east5,    store: gcs }
+    us-west4:     { bucket: marin-us-west4,    store: gcs }
+    europe-west4: { bucket: marin-eu-west4,    store: gcs }
   temp: { path: tmp, ttl_days: [1, 2, 3, 4, 5, 6, 7, 14, 30] }

--- a/infra/configure_buckets.py
+++ b/infra/configure_buckets.py
@@ -24,24 +24,21 @@ Three backends are configured:
   CoreWeave AOS is virtual-host only, served from :data:`CW_ENDPOINT_URL`, and
   signs with each bucket's CoreWeave region. Owned-rule shape is identical to R2.
 
-R2 access needs credentials (``R2_ACCESS_KEY_ID`` / ``R2_SECRET_ACCESS_KEY``,
-or their ``AWS_*`` equivalents) and an endpoint (``AWS_ENDPOINT_URL_S3`` /
-``AWS_ENDPOINT_URL`` / ``R2_ENDPOINT_URL``, defaulting to
-:data:`R2_ENDPOINT_URL`). CoreWeave access uses the standard
-``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY`` env vars (set them to your
-CoreWeave object-storage key). Target a specific GCS bucket with ``--bucket`` to
+Each S3 backend reads its own namespaced credentials — ``R2_ACCESS_KEY_ID`` /
+``R2_SECRET_ACCESS_KEY`` for R2, ``CW_ACCESS_KEY_ID`` / ``CW_SECRET_ACCESS_KEY``
+for CoreWeave — each falling back to the generic ``AWS_*`` pair. The default
+all-buckets run configures R2 and CoreWeave together and they have distinct keys,
+so set the namespaced pairs there; the ``AWS_*`` fallback suits single-backend
+runs. R2's endpoint comes from ``AWS_ENDPOINT_URL_S3`` / ``AWS_ENDPOINT_URL`` /
+``R2_ENDPOINT_URL`` (defaulting to :data:`R2_ENDPOINT_URL`); CoreWeave uses
+:data:`CW_ENDPOINT_URL`. Target a specific GCS bucket with ``--bucket`` to
 configure GCS without S3 credentials on hand.
 
-CoreWeave is not part of the default all-buckets run — its ``AWS_*`` credentials
-would collide with R2's in the same invocation — so reach it with ``--coreweave``
-(all CoreWeave buckets) or ``--bucket <cw-bucket>`` (one of them).
-
 Usage:
-    uv run infra/configure_buckets.py                  # GCS + R2 (all buckets)
+    uv run infra/configure_buckets.py                  # GCS + R2 + CoreWeave (all buckets)
     uv run infra/configure_buckets.py --dry-run        # preview without applying
-    uv run infra/configure_buckets.py --bucket marin-us-central2
+    uv run infra/configure_buckets.py --bucket marin-us-central2    # one GCS bucket
     uv run infra/configure_buckets.py --bucket marin-na             # R2 only
-    uv run infra/configure_buckets.py --coreweave                   # all CoreWeave buckets
     uv run infra/configure_buckets.py --bucket marin-us-east-02a    # one CoreWeave bucket
 """
 
@@ -259,27 +256,37 @@ def configure_gcs_bucket(bucket: str, region: str, owned: list[dict], dry_run: b
 # ---------------------------------------------------------------------------
 
 
+def _resolve_s3_credentials(backend: str, prefix: str) -> tuple[str, str]:
+    """Resolve an ``(access_key, secret)`` pair for *backend* from the environment.
+
+    Reads the backend's namespaced ``{prefix}_ACCESS_KEY_ID`` /
+    ``{prefix}_SECRET_ACCESS_KEY`` first, falling back to the generic ``AWS_*``
+    pair. The default all-buckets run configures R2 and CoreWeave together, and
+    they have distinct keys, so set the namespaced ``R2_*`` and ``CW_*`` pairs
+    there; the ``AWS_*`` fallback suits a single-backend run. Raises
+    :class:`click.ClickException` if neither pair is fully set.
+    """
+    key = os.environ.get(f"{prefix}_ACCESS_KEY_ID") or os.environ.get("AWS_ACCESS_KEY_ID")
+    secret = os.environ.get(f"{prefix}_SECRET_ACCESS_KEY") or os.environ.get("AWS_SECRET_ACCESS_KEY")
+    if not key or not secret:
+        raise click.ClickException(
+            f"{backend} credentials are required. Set {prefix}_ACCESS_KEY_ID and "
+            f"{prefix}_SECRET_ACCESS_KEY (or their AWS_* equivalents), or target a different "
+            f"bucket with --bucket to skip this backend."
+        )
+    return key, secret
+
+
 def make_r2_client() -> botocore.client.BaseClient:
     """Build a botocore S3 client for R2, failing fast if credentials are missing.
 
-    Credentials come from ``R2_ACCESS_KEY_ID`` / ``R2_SECRET_ACCESS_KEY`` (or
-    their ``AWS_*`` equivalents); the endpoint from ``AWS_ENDPOINT_URL_S3`` /
+    Credentials come from ``R2_*`` (or ``AWS_*``) via
+    :func:`_resolve_s3_credentials`; the endpoint from ``AWS_ENDPOINT_URL_S3`` /
     ``AWS_ENDPOINT_URL`` / ``R2_ENDPOINT_URL``, defaulting to
     :data:`R2_ENDPOINT_URL`. R2 ignores the AWS region scheme, so we sign with
     ``region_name="auto"`` and force virtual-host addressing.
-
-    The namespaced ``R2_*`` vars take precedence over ``AWS_*``: CoreWeave uses
-    ``AWS_*`` for its own key, so a shell with both backends' credentials
-    exported would otherwise send the CoreWeave key to the R2 endpoint.
     """
-    key = os.environ.get("R2_ACCESS_KEY_ID") or os.environ.get("AWS_ACCESS_KEY_ID")
-    secret = os.environ.get("R2_SECRET_ACCESS_KEY") or os.environ.get("AWS_SECRET_ACCESS_KEY")
-    if not key or not secret:
-        raise click.ClickException(
-            "R2 credentials are required to configure R2 buckets. Set R2_ACCESS_KEY_ID and "
-            "R2_SECRET_ACCESS_KEY (or their AWS_* equivalents), or target a specific GCS bucket "
-            "with --bucket to skip R2."
-        )
+    key, secret = _resolve_s3_credentials("R2", "R2")
     endpoint = (
         os.environ.get("AWS_ENDPOINT_URL_S3")
         or os.environ.get("AWS_ENDPOINT_URL")
@@ -302,17 +309,10 @@ def make_cw_client(region: str) -> botocore.client.BaseClient:
 
     CoreWeave AOS is S3-compatible but virtual-host only, served from
     :data:`CW_ENDPOINT_URL`, and signs with the bucket's CoreWeave region (e.g.
-    ``US-EAST-02A``). Credentials come from the standard ``AWS_ACCESS_KEY_ID`` /
-    ``AWS_SECRET_ACCESS_KEY`` env vars — set them to your CoreWeave
-    object-storage key.
+    ``US-EAST-02A``). Credentials come from ``CW_*`` (or ``AWS_*``) via
+    :func:`_resolve_s3_credentials`.
     """
-    key = os.environ.get("AWS_ACCESS_KEY_ID")
-    secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
-    if not key or not secret:
-        raise click.ClickException(
-            "CoreWeave object-storage credentials are required to configure CoreWeave buckets. "
-            "Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to your CoreWeave object-storage key."
-        )
+    key, secret = _resolve_s3_credentials("CoreWeave", "CW")
     session = botocore.session.get_session()
     return session.create_client(
         "s3",
@@ -390,32 +390,19 @@ def configure_s3_bucket(
         "bucket in R2_DATA_BUCKETS, or a CoreWeave bucket in CW_DATA_BUCKETS)."
     ),
 )
-@click.option(
-    "--coreweave",
-    is_flag=True,
-    help=(
-        "Configure all CoreWeave object-storage buckets (CW_DATA_BUCKETS) and skip GCS/R2. "
-        "Uses AWS_* credentials against cwobject.com. Kept out of the default run because its "
-        "AWS_* credentials would collide with R2's."
-    ),
-)
-def main(dry_run: bool, bucket: str | None, coreweave: bool) -> None:
+def main(dry_run: bool, bucket: str | None) -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
-    if coreweave and bucket is not None:
-        raise click.UsageError("--coreweave and --bucket are mutually exclusive.")
-
-    # Default run is GCS + R2; CoreWeave is opt-in (see --coreweave help).
+    # Default run configures every backend; each S3 backend reads its own
+    # namespaced credentials (R2_* / CW_*, AWS_* fallback) in its client factory.
     gcs_targets: dict[str, str] = BUCKETS
     r2_targets: frozenset[str] = R2_DATA_BUCKETS
-    cw_targets: dict[str, str] = {}
-    if coreweave:
-        gcs_targets, r2_targets, cw_targets = {}, frozenset(), dict(CW_DATA_BUCKETS)
-    elif bucket is not None:
+    cw_targets: dict[str, str] = dict(CW_DATA_BUCKETS)
+    if bucket is not None:
         if bucket in BUCKETS:
-            gcs_targets, r2_targets = {bucket: BUCKETS[bucket]}, frozenset()
+            gcs_targets, r2_targets, cw_targets = {bucket: BUCKETS[bucket]}, frozenset(), {}
         elif bucket in R2_DATA_BUCKETS:
-            gcs_targets, r2_targets = {}, frozenset({bucket})
+            gcs_targets, r2_targets, cw_targets = {}, frozenset({bucket}), {}
         elif bucket in CW_DATA_BUCKETS:
             gcs_targets, r2_targets, cw_targets = {}, frozenset(), {bucket: CW_DATA_BUCKETS[bucket]}
         else:

--- a/infra/configure_buckets.py
+++ b/infra/configure_buckets.py
@@ -432,8 +432,9 @@ def configure_s3_buckets(targets: dict[str, BucketSpec], owned: list[dict], dry_
             r2_client = r2_client or make_r2_client()
             configure_s3_bucket(r2_client, name, owned, dry_run, label="R2")
         elif spec.store == StoreType.COREWEAVE:
-            assert spec.region is not None, f"CoreWeave bucket {name!r} missing signing region"
-            configure_s3_bucket(make_cw_client(spec.region), name, owned, dry_run, label=f"CoreWeave {spec.region}")
+            assert spec.signing_region is not None, f"CoreWeave bucket {name!r} missing signing_region"
+            region = spec.signing_region
+            configure_s3_bucket(make_cw_client(region), name, owned, dry_run, label=f"CoreWeave {region}")
         else:
             raise click.ClickException(f"bucket {name!r} has non-S3 store {spec.store!r}")
 

--- a/infra/configure_buckets.py
+++ b/infra/configure_buckets.py
@@ -16,13 +16,14 @@ Three backends are configured:
   backend also enforces that soft-delete is disabled — Marin churns a lot of
   multi-gigabyte ephemeral data, and soft-delete retention quickly explodes
   storage cost.
-* **Cloudflare R2** buckets (:data:`rigging.filesystem.R2_DATA_BUCKETS`), via the
-  S3 lifecycle API (botocore). The owned rules are ``Expiration`` rules whose
-  ``ID`` starts with ``marin-ttl-``. R2 has no soft-delete to manage.
-* **CoreWeave AI Object Storage** buckets
-  (:data:`rigging.filesystem.CW_DATA_BUCKETS`), via the same S3 lifecycle API.
-  CoreWeave AOS is virtual-host only, served from :data:`CW_ENDPOINT_URL`, and
-  signs with each bucket's CoreWeave region. Owned-rule shape is identical to R2.
+* **Cloudflare R2** and **CoreWeave AI Object Storage** buckets, via the S3
+  lifecycle API (botocore). Both are enumerated from
+  :func:`rigging.filesystem.s3_data_buckets` — the R2/CoreWeave buckets declared
+  in ``config/*.yaml`` by their ``store`` type — so the set lives in config, not
+  here. The owned rules are ``Expiration`` rules whose ``ID`` starts with
+  ``marin-ttl-``; neither backend has soft-delete to manage. CoreWeave AOS is
+  virtual-host only, served from :data:`CW_ENDPOINT_URL`, and signs with each
+  bucket's CoreWeave region; R2 is region-agnostic (``region_name="auto"``).
 
 Each S3 backend reads its own namespaced credentials — ``R2_ACCESS_KEY_ID`` /
 ``R2_SECRET_ACCESS_KEY`` for R2, ``CW_ACCESS_KEY_ID`` / ``CW_SECRET_ACCESS_KEY``
@@ -55,15 +56,18 @@ import botocore.config
 import botocore.session
 import click
 from botocore.exceptions import ClientError
-from rigging.filesystem import CW_DATA_BUCKETS, R2_DATA_BUCKETS, load_cluster_config
+from rigging.filesystem import BucketSpec, StoreType, load_cluster_config, s3_data_buckets
 
 logger = logging.getLogger(__name__)
 
 _MARIN_CONFIG = load_cluster_config("marin")
 
-# Region from which each bucket is served. Built from the canonical
-# region_buckets map so this script never drifts from the runtime view.
-BUCKETS: dict[str, str] = {bucket: region for region, bucket in _MARIN_CONFIG.region_buckets.items()}
+# GCS bucket -> serving region, from the marin cluster's region_buckets so this
+# script never drifts from the runtime view. The R2/CoreWeave (S3) buckets come
+# from s3_data_buckets(), which reads their `store` type from config/*.yaml.
+BUCKETS: dict[str, str] = {
+    spec.name: region for region, spec in _MARIN_CONFIG.region_buckets.items() if spec.store == StoreType.GCS
+}
 
 PROJECT = "hai-gcp-models"
 
@@ -385,28 +389,23 @@ def configure_s3_bucket(
     "--bucket",
     type=str,
     default=None,
-    help=(
-        "Only configure this bucket (a GCS bucket in config/marin.yaml, an R2 "
-        "bucket in R2_DATA_BUCKETS, or a CoreWeave bucket in CW_DATA_BUCKETS)."
-    ),
+    help="Only configure this bucket (a GCS bucket in config/marin.yaml, or an R2/CoreWeave bucket in config/*.yaml).",
 )
 def main(dry_run: bool, bucket: str | None) -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
     # Default run configures every backend; each S3 backend reads its own
     # namespaced credentials (R2_* / CW_*, AWS_* fallback) in its client factory.
+    s3_buckets = s3_data_buckets()
     gcs_targets: dict[str, str] = BUCKETS
-    r2_targets: frozenset[str] = R2_DATA_BUCKETS
-    cw_targets: dict[str, str] = dict(CW_DATA_BUCKETS)
+    s3_targets: dict[str, BucketSpec] = dict(s3_buckets)
     if bucket is not None:
         if bucket in BUCKETS:
-            gcs_targets, r2_targets, cw_targets = {bucket: BUCKETS[bucket]}, frozenset(), {}
-        elif bucket in R2_DATA_BUCKETS:
-            gcs_targets, r2_targets, cw_targets = {}, frozenset({bucket}), {}
-        elif bucket in CW_DATA_BUCKETS:
-            gcs_targets, r2_targets, cw_targets = {}, frozenset(), {bucket: CW_DATA_BUCKETS[bucket]}
+            gcs_targets, s3_targets = {bucket: BUCKETS[bucket]}, {}
+        elif bucket in s3_buckets:
+            gcs_targets, s3_targets = {}, {bucket: s3_buckets[bucket]}
         else:
-            known = ", ".join(sorted([*BUCKETS, *R2_DATA_BUCKETS, *CW_DATA_BUCKETS]))
+            known = ", ".join(sorted([*BUCKETS, *s3_buckets]))
             logger.error("Unknown bucket %r. Known buckets: %s", bucket, known)
             sys.exit(1)
 
@@ -415,18 +414,28 @@ def main(dry_run: bool, bucket: str | None) -> None:
         for name, region in sorted(gcs_targets.items()):
             configure_gcs_bucket(name, region, owned_gcs, dry_run)
 
-    owned_s3 = build_s3_ttl_rules()
-
-    if r2_targets:
-        client = make_r2_client()
-        for name in sorted(r2_targets):
-            configure_s3_bucket(client, name, owned_s3, dry_run, label="R2")
-
-    for name, region in sorted(cw_targets.items()):
-        client = make_cw_client(region)
-        configure_s3_bucket(client, name, owned_s3, dry_run, label=f"CoreWeave {region}")
+    if s3_targets:
+        configure_s3_buckets(s3_targets, build_s3_ttl_rules(), dry_run)
 
     logger.info("Done.")
+
+
+def configure_s3_buckets(targets: dict[str, BucketSpec], owned: list[dict], dry_run: bool) -> None:
+    """Configure lifecycle rules on R2/CoreWeave buckets, one client per backend.
+
+    The R2 client is shared across all R2 buckets; CoreWeave signs per bucket
+    region, so each gets its own client.
+    """
+    r2_client: botocore.client.BaseClient | None = None
+    for name, spec in sorted(targets.items()):
+        if spec.store == StoreType.R2:
+            r2_client = r2_client or make_r2_client()
+            configure_s3_bucket(r2_client, name, owned, dry_run, label="R2")
+        elif spec.store == StoreType.COREWEAVE:
+            assert spec.region is not None, f"CoreWeave bucket {name!r} missing signing region"
+            configure_s3_bucket(make_cw_client(spec.region), name, owned, dry_run, label=f"CoreWeave {spec.region}")
+        else:
+            raise click.ClickException(f"bucket {name!r} has non-S3 store {spec.store!r}")
 
 
 if __name__ == "__main__":

--- a/infra/configure_buckets.py
+++ b/infra/configure_buckets.py
@@ -2,14 +2,14 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Configure TTL lifecycle rules on each marin data bucket (GCS and R2).
+"""Configure TTL lifecycle rules on each marin data bucket (GCS, R2, CoreWeave).
 
 This script owns the lifecycle rules that delete objects under ``tmp/ttl=Nd/``
 after ``N`` days, for every ``N`` in `config/marin.yaml`.
 Rules it does not recognize as its own are preserved untouched, so it is safe to
 re-run alongside hand-curated lifecycle rules.
 
-Two backends are configured:
+Three backends are configured:
 
 * **GCS** ``marin-{region}`` buckets, via ``gcloud storage``. The owned rules are
   ``Delete`` rules whose ``matchesPrefix`` is exactly ``["tmp/ttl=Nd/"]``. This
@@ -19,18 +19,30 @@ Two backends are configured:
 * **Cloudflare R2** buckets (:data:`rigging.filesystem.R2_DATA_BUCKETS`), via the
   S3 lifecycle API (botocore). The owned rules are ``Expiration`` rules whose
   ``ID`` starts with ``marin-ttl-``. R2 has no soft-delete to manage.
+* **CoreWeave AI Object Storage** buckets
+  (:data:`rigging.filesystem.CW_DATA_BUCKETS`), via the same S3 lifecycle API.
+  CoreWeave AOS is virtual-host only, served from :data:`CW_ENDPOINT_URL`, and
+  signs with each bucket's CoreWeave region. Owned-rule shape is identical to R2.
 
 R2 access needs credentials (``R2_ACCESS_KEY_ID`` / ``R2_SECRET_ACCESS_KEY``,
 or their ``AWS_*`` equivalents) and an endpoint (``AWS_ENDPOINT_URL_S3`` /
 ``AWS_ENDPOINT_URL`` / ``R2_ENDPOINT_URL``, defaulting to
-:data:`R2_ENDPOINT_URL`). Target a specific GCS bucket with ``--bucket`` to
-configure GCS without R2 credentials on hand.
+:data:`R2_ENDPOINT_URL`). CoreWeave access uses the standard
+``AWS_ACCESS_KEY_ID`` / ``AWS_SECRET_ACCESS_KEY`` env vars (set them to your
+CoreWeave object-storage key). Target a specific GCS bucket with ``--bucket`` to
+configure GCS without S3 credentials on hand.
+
+CoreWeave is not part of the default all-buckets run — its ``AWS_*`` credentials
+would collide with R2's in the same invocation — so reach it with ``--coreweave``
+(all CoreWeave buckets) or ``--bucket <cw-bucket>`` (one of them).
 
 Usage:
-    uv run infra/configure_buckets.py                  # apply to all buckets
+    uv run infra/configure_buckets.py                  # GCS + R2 (all buckets)
     uv run infra/configure_buckets.py --dry-run        # preview without applying
     uv run infra/configure_buckets.py --bucket marin-us-central2
-    uv run infra/configure_buckets.py --bucket marin-na  # R2 only
+    uv run infra/configure_buckets.py --bucket marin-na             # R2 only
+    uv run infra/configure_buckets.py --coreweave                   # all CoreWeave buckets
+    uv run infra/configure_buckets.py --bucket marin-us-east-02a    # one CoreWeave bucket
 """
 
 import json
@@ -46,7 +58,7 @@ import botocore.config
 import botocore.session
 import click
 from botocore.exceptions import ClientError
-from rigging.filesystem import R2_DATA_BUCKETS, load_cluster_config
+from rigging.filesystem import CW_DATA_BUCKETS, R2_DATA_BUCKETS, load_cluster_config
 
 logger = logging.getLogger(__name__)
 
@@ -63,9 +75,14 @@ PROJECT = "hai-gcp-models"
 # / R2_ENDPOINT_URL env vars.
 R2_ENDPOINT_URL = "https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com"
 
-# Lifecycle rules this script owns on R2 buckets carry an ``ID`` with this
-# prefix; everything else is treated as a foreign rule and left alone.
-R2_RULE_ID_PREFIX = "marin-ttl-"
+# CoreWeave AI Object Storage S3 API endpoint (account-level VIP). CoreWeave AOS
+# is virtual-host only and signs with each bucket's CoreWeave region.
+CW_ENDPOINT_URL = "https://cwobject.com"
+
+# Lifecycle rules this script owns on S3-compatible buckets (R2 and CoreWeave)
+# carry an ``ID`` with this prefix; everything else is treated as a foreign rule
+# and left alone.
+S3_RULE_ID_PREFIX = "marin-ttl-"
 
 
 def run(argv: list[str], *, raise_on_error: bool = True) -> subprocess.CompletedProcess[str]:
@@ -238,7 +255,7 @@ def configure_gcs_bucket(bucket: str, region: str, owned: list[dict], dry_run: b
 
 
 # ---------------------------------------------------------------------------
-# R2 backend (S3 lifecycle API via botocore)
+# S3-compatible backend (R2 and CoreWeave, via the S3 lifecycle API / botocore)
 # ---------------------------------------------------------------------------
 
 
@@ -276,11 +293,38 @@ def make_r2_client() -> botocore.client.BaseClient:
     )
 
 
-def build_r2_ttl_rules() -> list[dict]:
+def make_cw_client(region: str) -> botocore.client.BaseClient:
+    """Build a botocore S3 client for CoreWeave AI Object Storage in *region*.
+
+    CoreWeave AOS is S3-compatible but virtual-host only, served from
+    :data:`CW_ENDPOINT_URL`, and signs with the bucket's CoreWeave region (e.g.
+    ``US-EAST-02A``). Credentials come from the standard ``AWS_ACCESS_KEY_ID`` /
+    ``AWS_SECRET_ACCESS_KEY`` env vars — set them to your CoreWeave
+    object-storage key.
+    """
+    key = os.environ.get("AWS_ACCESS_KEY_ID")
+    secret = os.environ.get("AWS_SECRET_ACCESS_KEY")
+    if not key or not secret:
+        raise click.ClickException(
+            "CoreWeave object-storage credentials are required to configure CoreWeave buckets. "
+            "Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY to your CoreWeave object-storage key."
+        )
+    session = botocore.session.get_session()
+    return session.create_client(
+        "s3",
+        endpoint_url=CW_ENDPOINT_URL,
+        region_name=region,
+        aws_access_key_id=key,
+        aws_secret_access_key=secret,
+        config=botocore.config.Config(s3={"addressing_style": "virtual"}),
+    )
+
+
+def build_s3_ttl_rules() -> list[dict]:
     """Return S3 Expiration rules for every TTL value, scoped to ``tmp/ttl=Nd/``."""
     return [
         {
-            "ID": f"{R2_RULE_ID_PREFIX}{n}d",
+            "ID": f"{S3_RULE_ID_PREFIX}{n}d",
             "Filter": {"Prefix": _ttl_prefix(n)},
             "Expiration": {"Days": n},
             "Status": "Enabled",
@@ -289,12 +333,12 @@ def build_r2_ttl_rules() -> list[dict]:
     ]
 
 
-def _is_marin_r2_ttl_rule(rule: dict) -> bool:
+def _is_marin_s3_ttl_rule(rule: dict) -> bool:
     """Return True iff *rule* is one this script owns (``ID`` starts with ``marin-ttl-``)."""
-    return str(rule.get("ID", "")).startswith(R2_RULE_ID_PREFIX)
+    return str(rule.get("ID", "")).startswith(S3_RULE_ID_PREFIX)
 
 
-def get_r2_lifecycle_rules(client: botocore.client.BaseClient, bucket: str) -> list[dict]:
+def get_s3_lifecycle_rules(client: botocore.client.BaseClient, bucket: str) -> list[dict]:
     """Return the bucket's existing lifecycle rules, or ``[]`` if none are set."""
     try:
         resp = client.get_bucket_lifecycle_configuration(Bucket=bucket)
@@ -305,23 +349,29 @@ def get_r2_lifecycle_rules(client: botocore.client.BaseClient, bucket: str) -> l
     return resp.get("Rules", [])
 
 
-def apply_r2_lifecycle(client: botocore.client.BaseClient, bucket: str, rules: list[dict]) -> None:
+def apply_s3_lifecycle(client: botocore.client.BaseClient, bucket: str, rules: list[dict]) -> None:
     client.put_bucket_lifecycle_configuration(Bucket=bucket, LifecycleConfiguration={"Rules": rules})
 
 
-def configure_r2_bucket(client: botocore.client.BaseClient, bucket: str, owned: list[dict], dry_run: bool) -> None:
-    """Apply the owned TTL rules to one R2 bucket (R2 has no soft-delete to manage)."""
-    logger.info("=== %s (R2) ===", bucket)
+def configure_s3_bucket(
+    client: botocore.client.BaseClient, bucket: str, owned: list[dict], dry_run: bool, *, label: str
+) -> None:
+    """Apply the owned TTL rules to one S3-compatible bucket (R2 or CoreWeave).
 
-    existing_rules = get_r2_lifecycle_rules(client, bucket)
-    merged = merge_lifecycle_rules(existing_rules, owned, _is_marin_r2_ttl_rule)
+    Neither backend has soft-delete to manage. *label* names the backend in the
+    log header (e.g. ``"R2"`` or ``"CoreWeave US-EAST-02A"``).
+    """
+    logger.info("=== %s (%s) ===", bucket, label)
+
+    existing_rules = get_s3_lifecycle_rules(client, bucket)
+    merged = merge_lifecycle_rules(existing_rules, owned, _is_marin_s3_ttl_rule)
 
     _apply_or_preview_lifecycle(
         merged,
         owned,
         dry_run,
         preview_doc={"Rules": merged},
-        apply=lambda: apply_r2_lifecycle(client, bucket, merged),
+        apply=lambda: apply_s3_lifecycle(client, bucket, merged),
     )
 
 
@@ -331,20 +381,41 @@ def configure_r2_bucket(client: botocore.client.BaseClient, bucket: str, owned: 
     "--bucket",
     type=str,
     default=None,
-    help=("Only configure this bucket (a GCS bucket in config/marin.yaml " "or an R2 bucket in R2_DATA_BUCKETS)."),
+    help=(
+        "Only configure this bucket (a GCS bucket in config/marin.yaml, an R2 "
+        "bucket in R2_DATA_BUCKETS, or a CoreWeave bucket in CW_DATA_BUCKETS)."
+    ),
 )
-def main(dry_run: bool, bucket: str | None) -> None:
+@click.option(
+    "--coreweave",
+    is_flag=True,
+    help=(
+        "Configure all CoreWeave object-storage buckets (CW_DATA_BUCKETS) and skip GCS/R2. "
+        "Uses AWS_* credentials against cwobject.com. Kept out of the default run because its "
+        "AWS_* credentials would collide with R2's."
+    ),
+)
+def main(dry_run: bool, bucket: str | None, coreweave: bool) -> None:
     logging.basicConfig(level=logging.INFO, format="%(levelname)s: %(message)s")
 
-    gcs_targets = BUCKETS
-    r2_targets = R2_DATA_BUCKETS
-    if bucket is not None:
+    if coreweave and bucket is not None:
+        raise click.UsageError("--coreweave and --bucket are mutually exclusive.")
+
+    # Default run is GCS + R2; CoreWeave is opt-in (see --coreweave help).
+    gcs_targets: dict[str, str] = BUCKETS
+    r2_targets: frozenset[str] = R2_DATA_BUCKETS
+    cw_targets: dict[str, str] = {}
+    if coreweave:
+        gcs_targets, r2_targets, cw_targets = {}, frozenset(), dict(CW_DATA_BUCKETS)
+    elif bucket is not None:
         if bucket in BUCKETS:
             gcs_targets, r2_targets = {bucket: BUCKETS[bucket]}, frozenset()
         elif bucket in R2_DATA_BUCKETS:
             gcs_targets, r2_targets = {}, frozenset({bucket})
+        elif bucket in CW_DATA_BUCKETS:
+            gcs_targets, r2_targets, cw_targets = {}, frozenset(), {bucket: CW_DATA_BUCKETS[bucket]}
         else:
-            known = ", ".join(sorted([*BUCKETS, *R2_DATA_BUCKETS]))
+            known = ", ".join(sorted([*BUCKETS, *R2_DATA_BUCKETS, *CW_DATA_BUCKETS]))
             logger.error("Unknown bucket %r. Known buckets: %s", bucket, known)
             sys.exit(1)
 
@@ -353,11 +424,16 @@ def main(dry_run: bool, bucket: str | None) -> None:
         for name, region in sorted(gcs_targets.items()):
             configure_gcs_bucket(name, region, owned_gcs, dry_run)
 
+    owned_s3 = build_s3_ttl_rules()
+
     if r2_targets:
         client = make_r2_client()
-        owned_r2 = build_r2_ttl_rules()
         for name in sorted(r2_targets):
-            configure_r2_bucket(client, name, owned_r2, dry_run)
+            configure_s3_bucket(client, name, owned_s3, dry_run, label="R2")
+
+    for name, region in sorted(cw_targets.items()):
+        client = make_cw_client(region)
+        configure_s3_bucket(client, name, owned_s3, dry_run, label=f"CoreWeave {region}")
 
     logger.info("Done.")
 

--- a/infra/configure_buckets.py
+++ b/infra/configure_buckets.py
@@ -267,9 +267,13 @@ def make_r2_client() -> botocore.client.BaseClient:
     ``AWS_ENDPOINT_URL`` / ``R2_ENDPOINT_URL``, defaulting to
     :data:`R2_ENDPOINT_URL`. R2 ignores the AWS region scheme, so we sign with
     ``region_name="auto"`` and force virtual-host addressing.
+
+    The namespaced ``R2_*`` vars take precedence over ``AWS_*``: CoreWeave uses
+    ``AWS_*`` for its own key, so a shell with both backends' credentials
+    exported would otherwise send the CoreWeave key to the R2 endpoint.
     """
-    key = os.environ.get("AWS_ACCESS_KEY_ID") or os.environ.get("R2_ACCESS_KEY_ID")
-    secret = os.environ.get("AWS_SECRET_ACCESS_KEY") or os.environ.get("R2_SECRET_ACCESS_KEY")
+    key = os.environ.get("R2_ACCESS_KEY_ID") or os.environ.get("AWS_ACCESS_KEY_ID")
+    secret = os.environ.get("R2_SECRET_ACCESS_KEY") or os.environ.get("AWS_SECRET_ACCESS_KEY")
     if not key or not secret:
         raise click.ClickException(
             "R2 credentials are required to configure R2 buckets. Set R2_ACCESS_KEY_ID and "

--- a/infra/probes/deploy/deploy.py
+++ b/infra/probes/deploy/deploy.py
@@ -31,7 +31,7 @@ IMAGE_NAME = "infra-probes"
 # when a stranded local file is re-uploaded after a restart, so the SA needs
 # create+get+delete — granted via objectUser, scoped by IAM condition to the
 # prefix so the canary can't touch the rest of this shared data bucket.
-RESULTS_BUCKET = _MARIN_CONFIG.region_buckets["us-central1"]
+RESULTS_BUCKET = _MARIN_CONFIG.region_buckets["us-central1"].name
 RESULTS_GCS_PREFIX = "infra/probes"
 RESULTS_HOST_PATH = "/var/lib/probes"
 # Build context / git repo root for `build`: this script lives in deploy/.

--- a/infra/probes/src/infra_probes.py
+++ b/infra/probes/src/infra_probes.py
@@ -95,7 +95,7 @@ FINELOG_READBACK_POLL_INTERVAL = 0.25
 # the VM's /var/lib/probes host mount; finished daily files roll up to GCS in the
 # same region as the VM (no cross-region egress).
 PROBE_RESULTS_DIR = Path("/var/lib/probes")
-PROBE_RESULTS_GCS_PREFIX = f"gs://{_MARIN_CONFIG.region_buckets['us-central1']}/infra/probes"
+PROBE_RESULTS_GCS_PREFIX = f"gs://{_MARIN_CONFIG.region_buckets['us-central1'].name}/infra/probes"
 PROBE_RESULTS_NAMESPACE = "infra.canary.metrics"
 
 

--- a/lib/marin/src/marin/rl/placement.py
+++ b/lib/marin/src/marin/rl/placement.py
@@ -122,10 +122,10 @@ def resolve_launcher_region(train_tpu_type: str, inference_tpu_type: str | None)
 
 def marin_prefix_for_region(region: str) -> str:
     """Return the canonical Marin bucket prefix for a region."""
-    bucket = data_config().region_buckets.get(region.lower())
-    if bucket is None:
+    spec = data_config().region_buckets.get(region.lower())
+    if spec is None:
         raise ValueError(f"No Marin data bucket configured for region {region!r}.")
-    return f"gs://{bucket}"
+    return f"gs://{spec.name}"
 
 
 def singleton_region_list(region: str) -> list[str]:

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -115,14 +115,15 @@ class BucketSpec:
     Attributes:
         name: Bucket name without scheme, e.g. ``marin-us-east1`` or ``marin-na``.
         store: Backend serving the bucket.
-        region: Backend signing region for backends that require one (CoreWeave,
-            e.g. ``US-EAST-02A``). ``None`` for GCS (the region is the
-            ``region_buckets`` key / VM metadata) and R2 (region-agnostic).
+        signing_region: S3 signing region for backends that require one
+            (CoreWeave, e.g. ``US-EAST-02A``). Distinct from the *placement*
+            region (the ``region_buckets`` key). ``None`` for GCS (not S3) and R2
+            (which signs with ``"auto"``).
     """
 
     name: str
     store: StoreType
-    region: str | None = None
+    signing_region: str | None = None
 
 
 @dataclasses.dataclass(frozen=True)
@@ -233,28 +234,26 @@ def _load_cluster_config_cached(cluster: str) -> DataConfig:
     return _parse_data_config(data)
 
 
-def _parse_bucket_spec(value: object, scheme: str) -> BucketSpec:
+def _parse_bucket_spec(value: object) -> BucketSpec:
     """Normalize one ``region_buckets`` YAML entry into a :class:`BucketSpec`.
 
-    Accepts either a bare bucket-name string — allowed only under ``scheme: gs``,
-    which pins the store to GCS — or a mapping ``{bucket, store[, region]}``. A
-    bare string under an ``s3`` scheme is rejected because it cannot distinguish
-    R2 from CoreWeave. CoreWeave entries must carry a signing ``region``.
+    Each entry is an explicit mapping ``{bucket, store[, signing_region]}``. The
+    ``store`` (``gcs``/``r2``/``coreweave``) is required because it cannot be
+    inferred — R2 and CoreWeave share the ``s3`` scheme but need different
+    endpoints and credentials. CoreWeave entries must carry a ``signing_region``.
     """
-    if isinstance(value, str):
-        if scheme != "gs":
-            raise ValueError(
-                f"bucket {value!r} under scheme={scheme!r} must be a mapping with an explicit "
-                f"'store' ({', '.join(s.value for s in StoreType)}); a bare name is GCS-only."
-            )
-        return BucketSpec(name=value, store=StoreType.GCS)
-    if isinstance(value, Mapping):
-        store = StoreType(str(value["store"]))
-        region = str(value["region"]) if value.get("region") is not None else None
-        if store is StoreType.COREWEAVE and region is None:
-            raise ValueError(f"CoreWeave bucket {value.get('bucket')!r} must specify a signing 'region'.")
-        return BucketSpec(name=str(value["bucket"]), store=store, region=region)
-    raise ValueError(f"region_buckets entry must be a str or mapping, got {type(value).__name__}: {value!r}")
+    if not isinstance(value, Mapping):
+        raise ValueError(
+            f"region_buckets entry must be a mapping {{bucket, store[, signing_region]}}, "
+            f"got {type(value).__name__}: {value!r}"
+        )
+    if "bucket" not in value or "store" not in value:
+        raise ValueError(f"region_buckets entry must set 'bucket' and 'store': {value!r}")
+    store = StoreType(str(value["store"]))
+    signing_region = str(value["signing_region"]) if value.get("signing_region") is not None else None
+    if store is StoreType.COREWEAVE and signing_region is None:
+        raise ValueError(f"CoreWeave bucket {value['bucket']!r} must specify a 'signing_region'.")
+    return BucketSpec(name=str(value["bucket"]), store=store, signing_region=signing_region)
 
 
 def _parse_data_config(data: Mapping[str, object]) -> DataConfig:
@@ -268,7 +267,7 @@ def _parse_data_config(data: Mapping[str, object]) -> DataConfig:
     root = data.get("root")
     scheme = str(data.get("scheme") or DataConfig.scheme)
     raw_buckets = data.get("region_buckets") or {}
-    region_buckets = {region: _parse_bucket_spec(value, scheme) for region, value in raw_buckets.items()}
+    region_buckets = {region: _parse_bucket_spec(value) for region, value in raw_buckets.items()}
     return DataConfig(
         region_buckets=region_buckets,
         scheme=scheme,

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -46,6 +46,7 @@ import urllib.request
 import uuid
 from collections.abc import Callable, Generator, Mapping, Sequence
 from pathlib import PurePath
+from types import MappingProxyType
 from typing import Any, cast
 
 import fsspec
@@ -276,6 +277,19 @@ def marin_prefix() -> str:
 # explicit here.
 R2_DATA_BUCKETS: frozenset[str] = frozenset({"marin-na"})
 
+# CoreWeave AI Object Storage buckets (S3-compatible, ``s3://`` scheme, served
+# virtual-host-only from cwobject.com/cwlota.com). Each maps to its CoreWeave
+# region, used both to route temp paths here (alongside R2, see
+# :func:`_s3_bucket_from_prefix`) and to sign lifecycle requests in
+# ``infra/configure_buckets.py``. Like R2, this is cross-cluster S3 detection
+# that does not belong to any single cluster's profile.
+CW_DATA_BUCKETS: Mapping[str, str] = MappingProxyType(
+    {
+        "marin-us-east-02a": "US-EAST-02A",
+        "marin-us-west-04a": "US-WEST-04A",
+    }
+)
+
 # Finite botocore timeouts/retries for every S3/R2 filesystem we build.
 # s3fs/aiobotocore default to *no* read or connect timeout, so a silently dead
 # R2 connection wedges ``upload_part`` forever (#6487): the blocked socket never
@@ -295,15 +309,16 @@ _S3_RETRY_MAX_ATTEMPTS = 5
 def _s3_bucket_from_prefix(prefix: str | None) -> str | None:
     """Return the bucket from an ``s3://bucket/…`` prefix, or ``None``.
 
-    Only recognizes buckets in :data:`R2_DATA_BUCKETS`, so unknown S3 buckets
-    (which have no lifecycle rules configured) fall through to the flat
-    non-TTL fallback instead of getting a ``tmp/ttl=Nd/`` path that would
+    Only recognizes buckets in :data:`R2_DATA_BUCKETS` or :data:`CW_DATA_BUCKETS`
+    (the S3-compatible backends with lifecycle rules configured by
+    ``infra/configure_buckets.py``), so unknown S3 buckets fall through to the
+    flat non-TTL fallback instead of getting a ``tmp/ttl=Nd/`` path that would
     never be cleaned up.
     """
     if not prefix or not prefix.startswith("s3://"):
         return None
     bucket = prefix[len("s3://") :].split("/", 1)[0]
-    return bucket if bucket in R2_DATA_BUCKETS else None
+    return bucket if bucket in R2_DATA_BUCKETS or bucket in CW_DATA_BUCKETS else None
 
 
 # ---------------------------------------------------------------------------
@@ -347,17 +362,19 @@ def marin_temp_bucket(ttl_days: int, prefix: str = "", *, source_prefix: str | N
 
         gs://marin-{region}/tmp/ttl={N}d/{prefix}
 
-    For a Cloudflare R2 prefix on a known bucket (:data:`R2_DATA_BUCKETS`),
+    For a known S3-compatible prefix — a Cloudflare R2 bucket
+    (:data:`R2_DATA_BUCKETS`) or a CoreWeave bucket (:data:`CW_DATA_BUCKETS`) —
     returns a path at the bucket root::
 
         s3://marin-na/tmp/ttl={N}d/{prefix}
+        s3://marin-us-east-02a/tmp/ttl={N}d/{prefix}
 
     Otherwise falls back to a flat path under the marin prefix::
 
         {marin_prefix}/tmp/{prefix}
 
-    Lifecycle rules on each ``marin-{region}`` GCS bucket and each R2 data
-    bucket — managed by ``infra/configure_buckets.py`` — auto-delete objects
+    Lifecycle rules on each ``marin-{region}`` GCS bucket and each R2/CoreWeave
+    data bucket — managed by ``infra/configure_buckets.py`` — auto-delete objects
     under ``tmp/ttl=Nd/`` after *N* days.
 
     Args:
@@ -393,10 +410,11 @@ def marin_temp_bucket(ttl_days: int, prefix: str = "", *, source_prefix: str | N
             path = f"gs://{bucket}/{cfg.temp_path}/ttl={ttl_days}d"
             return _append_path_prefix(path, prefix)
 
-    # R2 is single-bucket and non-regional. Place temp at the bucket root so the
-    # `tmp/ttl=Nd/` lifecycle prefix configured by infra/configure_buckets.py
-    # applies — note the runtime marin prefix on R2 is `s3://marin-na/marin`,
-    # so we deliberately strip the `marin/` data subdir here.
+    # R2 and CoreWeave temp lives at the bucket root so the `tmp/ttl=Nd/`
+    # lifecycle prefix configured by infra/configure_buckets.py applies. The
+    # bucket already pins the region (R2 is non-regional; CoreWeave encodes it in
+    # the name, e.g. marin-us-east-02a), and the runtime marin prefix carries a
+    # `marin/` data subdir (e.g. `s3://marin-na/marin`) that we deliberately strip.
     if s3_bucket:
         path = f"s3://{s3_bucket}/{cfg.temp_path}/ttl={ttl_days}d"
         return _append_path_prefix(path, prefix)

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -45,6 +45,7 @@ import urllib.error
 import urllib.request
 import uuid
 from collections.abc import Callable, Generator, Mapping, Sequence
+from enum import StrEnum
 from pathlib import PurePath
 from types import MappingProxyType
 from typing import Any, cast
@@ -56,7 +57,7 @@ from fsspec.implementations.local import LocalFileSystem
 from google.api_core.exceptions import Forbidden as GcpForbiddenException
 from google.cloud import storage
 
-from rigging.config_discovery import resolve_cluster_config
+from rigging.config_discovery import list_cluster_configs, resolve_cluster_config
 from rigging.distributed_lock import create_lock, default_worker_id
 from rigging.timing import ExponentialBackoff, retry_with_backoff
 
@@ -95,12 +96,42 @@ _GCP_METADATA_ZONE_URL = "http://metadata.google.internal/computeMetadata/v1/ins
 _DEFAULT_LOCAL_PREFIX = "/tmp/marin"
 
 
+class StoreType(StrEnum):
+    """Object-storage backend serving a bucket.
+
+    Distinguishes the two S3-compatible backends — which share the ``s3://``
+    scheme but differ in endpoint, addressing, and credentials — from GCS.
+    """
+
+    GCS = "gcs"
+    R2 = "r2"
+    COREWEAVE = "coreweave"
+
+
+@dataclasses.dataclass(frozen=True)
+class BucketSpec:
+    """A single data bucket: its name and which backend serves it.
+
+    Attributes:
+        name: Bucket name without scheme, e.g. ``marin-us-east1`` or ``marin-na``.
+        store: Backend serving the bucket.
+        region: Backend signing region for backends that require one (CoreWeave,
+            e.g. ``US-EAST-02A``). ``None`` for GCS (the region is the
+            ``region_buckets`` key / VM metadata) and R2 (region-agnostic).
+    """
+
+    name: str
+    store: StoreType
+    region: str | None = None
+
+
 @dataclasses.dataclass(frozen=True)
 class DataConfig:
     """Where a cluster's data lives — the single source for storage layout.
 
     Attributes:
-        region_buckets: Region name -> bucket name for the cross-region mirror set.
+        region_buckets: Region name -> :class:`BucketSpec` for the cross-region
+            mirror set.
         scheme: URL scheme for the cluster's storage (e.g. ``"gs"`` or ``"s3"``).
         temp_path: Path segment for TTL-managed scratch data.
         ttl_days: Allowed TTL-day values for temp lifecycle rules.
@@ -108,7 +139,7 @@ class DataConfig:
             only for clusters that do not use region-local bucket selection.
     """
 
-    region_buckets: Mapping[str, str]
+    region_buckets: Mapping[str, BucketSpec]
     scheme: str = "gs"
     temp_path: str = "tmp"
     ttl_days: tuple[int, ...] = (1, 2, 3, 4, 5, 6, 7, 14, 30)
@@ -128,9 +159,9 @@ class DataConfig:
             return self.root
         region = region_from_metadata()
         if region is not None:
-            bucket = self.region_buckets.get(region)
-            if bucket is not None:
-                return f"{self.scheme}://{bucket}"
+            spec = self.region_buckets.get(region)
+            if spec is not None:
+                return f"{self.scheme}://{spec.name}"
             return f"{self.scheme}://marin-{region}"
         return _DEFAULT_LOCAL_PREFIX
 
@@ -202,6 +233,30 @@ def _load_cluster_config_cached(cluster: str) -> DataConfig:
     return _parse_data_config(data)
 
 
+def _parse_bucket_spec(value: object, scheme: str) -> BucketSpec:
+    """Normalize one ``region_buckets`` YAML entry into a :class:`BucketSpec`.
+
+    Accepts either a bare bucket-name string — allowed only under ``scheme: gs``,
+    which pins the store to GCS — or a mapping ``{bucket, store[, region]}``. A
+    bare string under an ``s3`` scheme is rejected because it cannot distinguish
+    R2 from CoreWeave. CoreWeave entries must carry a signing ``region``.
+    """
+    if isinstance(value, str):
+        if scheme != "gs":
+            raise ValueError(
+                f"bucket {value!r} under scheme={scheme!r} must be a mapping with an explicit "
+                f"'store' ({', '.join(s.value for s in StoreType)}); a bare name is GCS-only."
+            )
+        return BucketSpec(name=value, store=StoreType.GCS)
+    if isinstance(value, Mapping):
+        store = StoreType(str(value["store"]))
+        region = str(value["region"]) if value.get("region") is not None else None
+        if store is StoreType.COREWEAVE and region is None:
+            raise ValueError(f"CoreWeave bucket {value.get('bucket')!r} must specify a signing 'region'.")
+        return BucketSpec(name=str(value["bucket"]), store=store, region=region)
+    raise ValueError(f"region_buckets entry must be a str or mapping, got {type(value).__name__}: {value!r}")
+
+
 def _parse_data_config(data: Mapping[str, object]) -> DataConfig:
     """Build a :class:`DataConfig` from a parsed ``data:`` config block.
 
@@ -211,9 +266,12 @@ def _parse_data_config(data: Mapping[str, object]) -> DataConfig:
     temp = data.get("temp") or {}
     raw_ttl = temp.get("ttl_days")
     root = data.get("root")
+    scheme = str(data.get("scheme") or DataConfig.scheme)
+    raw_buckets = data.get("region_buckets") or {}
+    region_buckets = {region: _parse_bucket_spec(value, scheme) for region, value in raw_buckets.items()}
     return DataConfig(
-        region_buckets=dict(data.get("region_buckets") or {}),
-        scheme=str(data.get("scheme") or DataConfig.scheme),
+        region_buckets=region_buckets,
+        scheme=scheme,
         temp_path=str(temp.get("path") or DataConfig.temp_path),
         ttl_days=tuple(raw_ttl) if raw_ttl is not None else DataConfig.ttl_days,
         root=str(root) if root is not None else None,
@@ -221,8 +279,9 @@ def _parse_data_config(data: Mapping[str, object]) -> DataConfig:
 
 
 def reset_data_config_cache() -> None:
-    """Clear the :func:`load_cluster_config` cache. For tests."""
+    """Clear the cluster-config and S3-bucket-registry caches. For tests."""
     _load_cluster_config_cached.cache_clear()
+    _s3_data_bucket_registry.cache_clear()
 
 
 # ---------------------------------------------------------------------------
@@ -254,8 +313,8 @@ def region_from_prefix(prefix: str) -> str | None:
     if not m:
         return None
     bucket = m.group(1)
-    for region, region_bucket in data_config().region_buckets.items():
-        if region_bucket == bucket:
+    for region, spec in data_config().region_buckets.items():
+        if spec.name == bucket:
             return region
     if bucket.startswith("marin-"):
         return bucket[len("marin-") :]
@@ -272,23 +331,35 @@ def marin_prefix() -> str:
     return data_config().resolved_root()
 
 
-# Cloudflare R2 data buckets (S3-compatible, ``s3://`` scheme). Cross-cluster S3
-# detection that is not part of any single cluster's profile, so it stays
-# explicit here.
-R2_DATA_BUCKETS: frozenset[str] = frozenset({"marin-na"})
+@functools.cache
+def _s3_data_bucket_registry() -> Mapping[str, BucketSpec]:
+    """Map bucket name -> :class:`BucketSpec` for every R2/CoreWeave bucket
+    declared in any discoverable cluster config.
 
-# CoreWeave AI Object Storage buckets (S3-compatible, ``s3://`` scheme, served
-# virtual-host-only from cwobject.com/cwlota.com). Each maps to its CoreWeave
-# region, used both to route temp paths here (alongside R2, see
-# :func:`_s3_bucket_from_prefix`) and to sign lifecycle requests in
-# ``infra/configure_buckets.py``. Like R2, this is cross-cluster S3 detection
-# that does not belong to any single cluster's profile.
-CW_DATA_BUCKETS: Mapping[str, str] = MappingProxyType(
-    {
-        "marin-us-east-02a": "US-EAST-02A",
-        "marin-us-west-04a": "US-WEST-04A",
-    }
-)
+    S3-compatible buckets are the ones with ``tmp/ttl=Nd/`` lifecycle rules.
+    Recognition must be cross-cluster — a launcher on a GCS cluster may target an
+    R2/CoreWeave output prefix (see :func:`marin_temp_bucket`'s ``source_prefix``)
+    — so this aggregates across all cluster configs rather than only the active
+    one. Cached; :func:`reset_data_config_cache` clears it.
+    """
+    registry: dict[str, BucketSpec] = {}
+    for cluster in list_cluster_configs(MARIN_CLUSTER_CONFIG_DIRS):
+        for spec in load_cluster_config(cluster).region_buckets.values():
+            if spec.store in (StoreType.R2, StoreType.COREWEAVE):
+                registry.setdefault(spec.name, spec)
+    return MappingProxyType(registry)
+
+
+def s3_data_buckets() -> Mapping[str, BucketSpec]:
+    """R2/CoreWeave data buckets (name -> :class:`BucketSpec`) across all configs.
+
+    These S3-compatible buckets carry ``tmp/ttl=Nd/`` lifecycle rules; used to
+    route temp paths (:func:`marin_temp_bucket`) and to drive
+    ``infra/configure_buckets.py``. Replaces the old hardcoded bucket constants:
+    the set is now defined in ``config/*.yaml`` via each bucket's ``store`` type.
+    """
+    return _s3_data_bucket_registry()
+
 
 # Finite botocore timeouts/retries for every S3/R2 filesystem we build.
 # s3fs/aiobotocore default to *no* read or connect timeout, so a silently dead
@@ -309,16 +380,15 @@ _S3_RETRY_MAX_ATTEMPTS = 5
 def _s3_bucket_from_prefix(prefix: str | None) -> str | None:
     """Return the bucket from an ``s3://bucket/…`` prefix, or ``None``.
 
-    Only recognizes buckets in :data:`R2_DATA_BUCKETS` or :data:`CW_DATA_BUCKETS`
-    (the S3-compatible backends with lifecycle rules configured by
-    ``infra/configure_buckets.py``), so unknown S3 buckets fall through to the
-    flat non-TTL fallback instead of getting a ``tmp/ttl=Nd/`` path that would
-    never be cleaned up.
+    Only recognizes buckets in :func:`s3_data_buckets` (the R2/CoreWeave buckets
+    with lifecycle rules configured by ``infra/configure_buckets.py``), so unknown
+    S3 buckets fall through to the flat non-TTL fallback instead of getting a
+    ``tmp/ttl=Nd/`` path that would never be cleaned up.
     """
     if not prefix or not prefix.startswith("s3://"):
         return None
     bucket = prefix[len("s3://") :].split("/", 1)[0]
-    return bucket if bucket in R2_DATA_BUCKETS or bucket in CW_DATA_BUCKETS else None
+    return bucket if bucket in s3_data_buckets() else None
 
 
 # ---------------------------------------------------------------------------
@@ -362,9 +432,8 @@ def marin_temp_bucket(ttl_days: int, prefix: str = "", *, source_prefix: str | N
 
         gs://marin-{region}/tmp/ttl={N}d/{prefix}
 
-    For a known S3-compatible prefix — a Cloudflare R2 bucket
-    (:data:`R2_DATA_BUCKETS`) or a CoreWeave bucket (:data:`CW_DATA_BUCKETS`) —
-    returns a path at the bucket root::
+    For a known S3-compatible prefix — an R2 or CoreWeave bucket in
+    :func:`s3_data_buckets` — returns a path at the bucket root::
 
         s3://marin-na/tmp/ttl={N}d/{prefix}
         s3://marin-us-east-02a/tmp/ttl={N}d/{prefix}
@@ -405,9 +474,9 @@ def marin_temp_bucket(ttl_days: int, prefix: str = "", *, source_prefix: str | N
         s3_bucket = _s3_bucket_from_prefix(mp)
 
     if region:
-        bucket = cfg.region_buckets.get(region)
-        if bucket:
-            path = f"gs://{bucket}/{cfg.temp_path}/ttl={ttl_days}d"
+        spec = cfg.region_buckets.get(region)
+        if spec:
+            path = f"gs://{spec.name}/{cfg.temp_path}/ttl={ttl_days}d"
             return _append_path_prefix(path, prefix)
 
     # R2 and CoreWeave temp lives at the bucket root so the `tmp/ttl=Nd/`
@@ -1118,8 +1187,8 @@ def atomic_rename(output_path: str, fs: Any = None) -> Generator[str, None, None
 
 
 def _all_data_bucket_prefixes() -> list[str]:
-    """Return gs:// prefixes for all of the active cluster's data buckets."""
-    return [f"gs://{bucket}" for bucket in data_config().region_buckets.values()]
+    """Return gs:// prefixes for all of the active cluster's GCS data buckets."""
+    return [f"gs://{spec.name}" for spec in data_config().region_buckets.values() if spec.store == StoreType.GCS]
 
 
 def _mirror_remote_prefixes(local_prefix: str) -> list[str]:

--- a/lib/rigging/tests/test_data_config.py
+++ b/lib/rigging/tests/test_data_config.py
@@ -8,12 +8,15 @@ import pytest
 import rigging.filesystem as fs
 from rigging.config_discovery import find_project_root
 from rigging.filesystem import (
+    BucketSpec,
     DataConfig,
+    StoreType,
     data_config,
     load_cluster_config,
     marin_prefix,
     marin_temp_bucket,
     reset_data_config_cache,
+    s3_data_buckets,
     use_data_config,
 )
 
@@ -69,7 +72,7 @@ def test_cluster_yaml_sets_given_fields_and_defaults_the_rest(tmp_path, monkeypa
         "iris: synth\n"
         "data:\n"
         "  scheme: s3\n"
-        "  region_buckets: {na: synth-na}\n"
+        "  region_buckets: {na: {bucket: synth-na, store: r2}}\n"
         "  root: s3://synth-na/data\n"
         "  temp: {ttl_days: [1, 5]}\n"
     )
@@ -79,7 +82,7 @@ def test_cluster_yaml_sets_given_fields_and_defaults_the_rest(tmp_path, monkeypa
     config = load_cluster_config("synth")
     # Fields present in the YAML are parsed through:
     assert config.scheme == "s3"
-    assert config.region_buckets == {"na": "synth-na"}
+    assert config.region_buckets == {"na": BucketSpec(name="synth-na", store=StoreType.R2)}
     assert config.root == "s3://synth-na/data"
     assert config.ttl_days == (1, 5)
     # Fields absent from the YAML fall back to the DataConfig field defaults:
@@ -123,7 +126,7 @@ def test_resolved_root_selects_region_local_bucket(monkeypatch):
     """A detected metadata region selects its region-local bucket."""
     monkeypatch.delenv("MARIN_PREFIX", raising=False)
     monkeypatch.setattr(fs, "region_from_metadata", lambda: "us-east5")
-    config = DataConfig(region_buckets={"us-east5": "marin-us-east5"})
+    config = DataConfig(region_buckets={"us-east5": BucketSpec("marin-us-east5", StoreType.GCS)})
     assert config.resolved_root() == "gs://marin-us-east5"
 
 
@@ -131,7 +134,7 @@ def test_resolved_root_constructs_default_for_unmapped_region(monkeypatch):
     """A detected-but-unmapped region constructs gs://marin-{region}."""
     monkeypatch.delenv("MARIN_PREFIX", raising=False)
     monkeypatch.setattr(fs, "region_from_metadata", lambda: "antarctica-south1")
-    config = DataConfig(region_buckets={"us-east5": "marin-us-east5"})
+    config = DataConfig(region_buckets={"us-east5": BucketSpec("marin-us-east5", StoreType.GCS)})
     assert config.resolved_root() == "gs://marin-antarctica-south1"
 
 
@@ -148,8 +151,9 @@ def test_resolved_root_local_fallback(monkeypatch):
 def test_marin_temp_bucket_routes_coreweave_to_bucket_root():
     """A CoreWeave source prefix yields a TTL temp path at the CW bucket root.
 
-    The CW bucket is recognized (CW_DATA_BUCKETS) so it gets a managed
-    ``tmp/ttl=Nd/`` prefix, and the ``marin/`` data subdir is stripped.
+    The CW bucket is recognized via its config-declared ``store: coreweave`` (see
+    :func:`s3_data_buckets`), so it gets a managed ``tmp/ttl=Nd/`` prefix, and the
+    ``marin/`` data subdir is stripped.
     """
     cfg = DataConfig(region_buckets={}, scheme="s3", ttl_days=(1, 3, 7))
     with use_data_config(cfg):
@@ -172,3 +176,27 @@ def test_marin_temp_bucket_unknown_s3_bucket_falls_back(monkeypatch):
     with use_data_config(cfg):
         path = marin_temp_bucket(3, source_prefix="s3://random-bucket/marin")
     assert path == "s3://random-bucket/marin/tmp"
+
+
+# --- config-driven S3 bucket registry --------------------------------------
+
+
+def test_s3_data_buckets_reads_store_types_from_config(monkeypatch):
+    """The R2/CoreWeave registry is aggregated from config, with regions preserved."""
+    monkeypatch.delenv("MARIN_CLUSTER", raising=False)
+    buckets = s3_data_buckets()
+    assert buckets["marin-na"] == BucketSpec("marin-na", StoreType.R2)
+    assert buckets["marin-us-east-02a"] == BucketSpec("marin-us-east-02a", StoreType.COREWEAVE, "US-EAST-02A")
+    # GCS buckets are not S3-managed and must not appear.
+    assert not any(spec.store == StoreType.GCS for spec in buckets.values())
+
+
+def test_bare_string_bucket_rejected_under_s3_scheme(tmp_path, monkeypatch):
+    """A bare bucket name under scheme s3 is ambiguous (R2 vs CoreWeave) and rejected."""
+    cluster_dir = tmp_path / "clusters"
+    cluster_dir.mkdir()
+    (cluster_dir / "ambig.yaml").write_text("data:\n  scheme: s3\n  region_buckets: {na: marin-na}\n")
+    monkeypatch.setattr(fs, "MARIN_CLUSTER_CONFIG_DIRS", (str(cluster_dir),))
+    reset_data_config_cache()
+    with pytest.raises(ValueError, match="must be a mapping with an explicit 'store'"):
+        load_cluster_config("ambig")

--- a/lib/rigging/tests/test_data_config.py
+++ b/lib/rigging/tests/test_data_config.py
@@ -12,6 +12,7 @@ from rigging.filesystem import (
     data_config,
     load_cluster_config,
     marin_prefix,
+    marin_temp_bucket,
     reset_data_config_cache,
     use_data_config,
 )
@@ -139,3 +140,35 @@ def test_resolved_root_local_fallback(monkeypatch):
     monkeypatch.delenv("MARIN_PREFIX", raising=False)
     monkeypatch.setattr(fs, "region_from_metadata", lambda: None)
     assert DataConfig(region_buckets={}).resolved_root() == "/tmp/marin"
+
+
+# --- temp-bucket routing ----------------------------------------------------
+
+
+def test_marin_temp_bucket_routes_coreweave_to_bucket_root():
+    """A CoreWeave source prefix yields a TTL temp path at the CW bucket root.
+
+    The CW bucket is recognized (CW_DATA_BUCKETS) so it gets a managed
+    ``tmp/ttl=Nd/`` prefix, and the ``marin/`` data subdir is stripped.
+    """
+    cfg = DataConfig(region_buckets={}, scheme="s3", ttl_days=(1, 3, 7))
+    with use_data_config(cfg):
+        path = marin_temp_bucket(3, "store/x", source_prefix="s3://marin-us-east-02a/marin")
+    assert path == "s3://marin-us-east-02a/tmp/ttl=3d/store/x"
+
+
+def test_marin_temp_bucket_routes_r2_to_bucket_root():
+    """An R2 source prefix yields a TTL temp path at the R2 bucket root (unchanged)."""
+    cfg = DataConfig(region_buckets={}, scheme="s3", ttl_days=(1, 3, 7))
+    with use_data_config(cfg):
+        path = marin_temp_bucket(1, source_prefix="s3://marin-na/marin")
+    assert path == "s3://marin-na/tmp/ttl=1d"
+
+
+def test_marin_temp_bucket_unknown_s3_bucket_falls_back(monkeypatch):
+    """An unrecognized S3 bucket has no lifecycle rules, so it gets the flat non-TTL path."""
+    monkeypatch.setenv("MARIN_PREFIX", "s3://random-bucket/marin")
+    cfg = DataConfig(region_buckets={}, scheme="s3", ttl_days=(1, 3, 7))
+    with use_data_config(cfg):
+        path = marin_temp_bucket(3, source_prefix="s3://random-bucket/marin")
+    assert path == "s3://random-bucket/marin/tmp"

--- a/lib/rigging/tests/test_data_config.py
+++ b/lib/rigging/tests/test_data_config.py
@@ -191,12 +191,25 @@ def test_s3_data_buckets_reads_store_types_from_config(monkeypatch):
     assert not any(spec.store == StoreType.GCS for spec in buckets.values())
 
 
-def test_bare_string_bucket_rejected_under_s3_scheme(tmp_path, monkeypatch):
-    """A bare bucket name under scheme s3 is ambiguous (R2 vs CoreWeave) and rejected."""
+def test_bucket_entry_requires_explicit_store(tmp_path, monkeypatch):
+    """A bare bucket-name string is rejected: the store type must be explicit."""
     cluster_dir = tmp_path / "clusters"
     cluster_dir.mkdir()
-    (cluster_dir / "ambig.yaml").write_text("data:\n  scheme: s3\n  region_buckets: {na: marin-na}\n")
+    (cluster_dir / "bare.yaml").write_text("data:\n  scheme: gs\n  region_buckets: {us-east5: marin-us-east5}\n")
     monkeypatch.setattr(fs, "MARIN_CLUSTER_CONFIG_DIRS", (str(cluster_dir),))
     reset_data_config_cache()
-    with pytest.raises(ValueError, match="must be a mapping with an explicit 'store'"):
-        load_cluster_config("ambig")
+    with pytest.raises(ValueError, match="must be a mapping"):
+        load_cluster_config("bare")
+
+
+def test_coreweave_bucket_requires_signing_region(tmp_path, monkeypatch):
+    """A CoreWeave bucket without a signing_region is rejected."""
+    cluster_dir = tmp_path / "clusters"
+    cluster_dir.mkdir()
+    (cluster_dir / "cw.yaml").write_text(
+        "data:\n  scheme: s3\n  region_buckets: {e: {bucket: marin-us-east-02a, store: coreweave}}\n"
+    )
+    monkeypatch.setattr(fs, "MARIN_CLUSTER_CONFIG_DIRS", (str(cluster_dir),))
+    reset_data_config_cache()
+    with pytest.raises(ValueError, match="must specify a 'signing_region'"):
+        load_cluster_config("cw")

--- a/tests/test_inspect_data_region.py
+++ b/tests/test_inspect_data_region.py
@@ -40,7 +40,7 @@ def _validate_data_region(wandb_dict: dict, cluster: str) -> None:
 
     # Build reverse mapping: bucket name -> region
     bucket_to_region: dict[str, str] = {
-        bucket: region for region, bucket in load_cluster_config("marin").region_buckets.items()
+        spec.name: region for region, spec in load_cluster_config("marin").region_buckets.items()
     }
 
     mismatches: list[str] = []


### PR DESCRIPTION
see https://docs.coreweave.com/products/storage/object-storage/buckets/lifecycle-policies

* configure `tmp/ttl=Nd/` lifecycle rules on the CoreWeave object-store buckets `marin-us-east-02a` / `marin-us-west-04a`, and route rigging temp paths (`marin_temp_bucket()`) onto them
* bucket store type lives in **config**, not source: each `region_buckets` entry in `config/*.yaml` is now a `BucketSpec` with an explicit `store` (`gcs`/`r2`/`coreweave`) and, for CoreWeave, its signing `region`
  * `config/coreweave.yaml` gains the two CoreWeave buckets alongside the `marin-na` R2 bucket
  * bare-string entries stay valid for GCS; an `s3` bare string is rejected (ambiguous R2 vs CoreWeave)
* `s3_data_buckets()` replaces the hardcoded `R2_DATA_BUCKETS` / `CW_DATA_BUCKETS` constants — a registry aggregated across **all** cluster configs
  * aggregating across configs (not just the active one) preserves cross-cluster recognition: a launcher on a GCS cluster may target an R2/CoreWeave output prefix[^1]
* `infra/configure_buckets.py` selects each S3 bucket's backend/endpoint/region from its `BucketSpec`, so adding or retyping a bucket is a config edit
  * CW AOS is S3-compatible (same `Expiration`/`tmp/ttl=Nd/` rule shape as R2), differing only in endpoint (`cwobject.com`), per-bucket region, and virtual-host addressing
* each S3 backend reads its own namespaced creds via shared `_resolve_s3_credentials`: `R2_*` for R2, `CW_*` for CoreWeave, each falling back to `AWS_*`

[^1]: see `marin_temp_bucket`'s `source_prefix` arg