### PR TITLE
[iris] Add processes_per_task: one JAX process per GPU via in-task supervisor

### DIFF
--- a/experiments/grug/dispatch.py
+++ b/experiments/grug/dispatch.py
@@ -44,6 +44,7 @@ def dispatch_grug_training_run(
     local_entrypoint: Callable[[ConfigT], None],
     resources: ResourceConfig,
     max_retries_failure: int = 3,
+    processes_per_task: int = 1,
 ) -> None:
     """Submit a grug train entrypoint through Fray and wait for completion."""
     safe_run_id = _safe_job_suffix(run_id)
@@ -54,6 +55,7 @@ def dispatch_grug_training_run(
         resources=resources,
         environment=create_environment(env_vars=env_vars, extras=extras_for_resources(resources)),
         max_retries_failure=max_retries_failure,
+        processes_per_task=processes_per_task,
     )
     logger.info("Dispatching grug training via Fray: %s", request.name)
     job = current_client().submit(request)

--- a/experiments/grug/moe/launch.py
+++ b/experiments/grug/moe/launch.py
@@ -57,6 +57,10 @@ class GrugMoeLaunchConfig:
     profiler: ProfilerConfig = field(default_factory=ProfilerConfig)
     grug_trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
     eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
+    processes_per_task: int = 1
+    """GPU processes per task. > 1 fans each node into one JAX process per GPU
+    (multi-controller) via the iris.runtime.multigpu supervisor; 1 keeps the
+    single-process-per-node model."""
     checkpointer: CheckpointerConfig | None = None
     """Override the checkpointer. None builds the default (periodic + final saves
     under output_path). Throughput experiments point this at node-local disk so a
@@ -149,6 +153,7 @@ def run_grug_moe_trial(config: GrugMoeLaunchConfig) -> None:
         optimizer=config.optimizer,
         trainer=grug_trainer,
         eval=config.eval,
+        processes_per_task=config.processes_per_task,
     )
     run_grug(run_config)
 

--- a/experiments/grug/moe/launch_cw_scale.py
+++ b/experiments/grug/moe/launch_cw_scale.py
@@ -18,6 +18,8 @@ Env knobs (all optional; defaults give the full 90B run on 256 H100):
     SCALE_GPU_REPLICAS  number of 8xH100 nodes (default 32 -> 256 GPUs)
     SCALE_EXPERT_AXIS   expert-parallel axis size, intra-node (default 8)
     SCALE_REPLICA_AXIS  cross-node replication; 1 = pure FSDP (default 1)
+    SCALE_PROCESSES_PER_TASK  GPU processes per node: 1 = one process per node
+                          (default), 8 = one JAX process per GPU (multi-controller)
     SCALE_BATCH         global batch in sequences (default 256)
     SCALE_SEQ_LEN       sequence length (default 2048)
     SCALE_STEPS         training steps (default 50)
@@ -126,6 +128,9 @@ def build_scale_step() -> ExecutorStep:
     replica_axis = env_int("SCALE_REPLICA_AXIS", 1)
     batch_size = env_int("SCALE_BATCH", DEFAULT_BATCH)
     steps = env_int("SCALE_STEPS", 50)
+    # 1 = one process per node (8 local GPUs). 8 = one JAX process per GPU
+    # (multi-controller) via the iris.runtime.multigpu supervisor.
+    processes_per_task = env_int("SCALE_PROCESSES_PER_TASK", 1)
     # SCALE_PROFILER_STEPS > 0 captures a jax_profile window of that many steps
     # (uploaded via the tracker, so pair with SCALE_TRACKER=wandb to retrieve it).
     profiler_steps = env_int("SCALE_PROFILER_STEPS", 0)
@@ -196,6 +201,7 @@ def build_scale_step() -> ExecutorStep:
             tracker=tracker,
             optimizer=versioned(SCALE_OPTIMIZER),
             grug_trainer=versioned(grug_trainer),
+            processes_per_task=versioned(processes_per_task),
             eval=None,
             profiler=profiler,
             checkpointer=checkpointer,

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -92,6 +92,9 @@ class GrugRunConfig:
     optimizer: OptimizerConfig = field(default_factory=AdamConfig)
     trainer: GrugTrainerConfig = field(default_factory=GrugTrainerConfig)
     eval: GrugEvalConfig | None = field(default_factory=GrugEvalConfig)
+    # GPU processes per task: > 1 runs one JAX process per GPU (multi-controller)
+    # via the iris.runtime.multigpu supervisor instead of one process per node.
+    processes_per_task: int = 1
 
 
 def build_train_dataset(
@@ -568,6 +571,7 @@ def run_grug(config: GrugRunConfig) -> None:
         config=config,
         local_entrypoint=_run_grug_local,
         resources=config.resources,
+        processes_per_task=config.processes_per_task,
     )
 
 

--- a/lib/fray/src/fray/iris_backend.py
+++ b/lib/fray/src/fray/iris_backend.py
@@ -597,6 +597,7 @@ class FrayIrisClient:
                 constraints=iris_constraints if iris_constraints else None,
                 coscheduling=coscheduling,
                 replicas=replicas,
+                processes_per_task=request.processes_per_task,
                 max_retries_failure=request.max_retries_failure,
                 max_retries_preemption=request.max_retries_preemption,
                 max_task_failures=request.max_task_failures,

--- a/lib/fray/src/fray/types.py
+++ b/lib/fray/src/fray/types.py
@@ -611,6 +611,9 @@ class JobRequest:
         resources: Resource requirements per replica
         environment: Environment configuration (dependencies, env vars)
         replicas: Gang-scheduled replicas (e.g. TPU slices for multislice training)
+        processes_per_task: GPU processes to run inside each task (default 1). When
+            > 1, each task fans out into that many JAX processes (one per GPU group)
+            via the iris.runtime.multigpu supervisor. ``1`` is a no-op.
         max_retries_failure: Max retries on failure
         max_retries_preemption: Max retries on preemption
         max_task_failures: Cumulative failed task attempts the job tolerates before it
@@ -624,6 +627,7 @@ class JobRequest:
     resources: ResourceConfig = field(default_factory=ResourceConfig)
     environment: EnvironmentConfig | None = None
     replicas: int | None = None
+    processes_per_task: int = 1
     max_retries_failure: int = 0
     max_retries_preemption: int = 100
     max_task_failures: int = 0

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -551,6 +551,7 @@ def run_iris_job(
     wait: bool = True,
     job_name: str | None = None,
     replicas: int | None = None,
+    processes_per_task: int = 1,
     max_retries: int = 0,
     timeout: int = 0,
     extras: list[str] | None = None,
@@ -669,6 +670,7 @@ def run_iris_job(
         terminate_on_exit=terminate_on_exit,
         constraints=constraints or None,
         coscheduling=coscheduling,
+        processes_per_task=processes_per_task,
         user=user,
         priority_band=priority_band,
         container_profile=profile,
@@ -695,6 +697,7 @@ def _submit_and_wait_job(
     terminate_on_exit: bool = True,
     constraints: list[Constraint] | None = None,
     coscheduling: CoschedulingConfig | None = None,
+    processes_per_task: int = 1,
     user: str | None = None,
     priority_band: job_pb2.PriorityBand = job_pb2.PRIORITY_BAND_UNSPECIFIED,
     container_profile: job_pb2.ContainerProfile = job_pb2.CONTAINER_PROFILE_UNSPECIFIED,
@@ -721,6 +724,7 @@ def _submit_and_wait_job(
         constraints=constraints,
         coscheduling=coscheduling,
         replicas=replicas,
+        processes_per_task=processes_per_task,
         max_retries_failure=max_retries,
         max_task_failures=max_retries,
         timeout=Duration.from_seconds(timeout) if timeout else None,
@@ -837,6 +841,12 @@ Examples:
 @click.option(
     "--replicas", type=int, default=None, help="Number of tasks for gang scheduling (auto-detected for multinode TPUs)"
 )
+@click.option(
+    "--processes-per-task",
+    type=int,
+    default=1,
+    help="GPU processes to run inside each task (default 1). >1 fans each task into N JAX processes per GPU group.",
+)
 @click.option("--max-retries", type=int, default=0, help="Max retries on failure (default: 0)")
 @click.option("--timeout", type=int, default=0, show_default=True, help="Job timeout in seconds (0 = no timeout)")
 @click.option("--region", multiple=True, help="Restrict to region(s) (e.g., --region us-central2). Can be repeated.")
@@ -920,6 +930,7 @@ def run(
     job_name: str | None,
     user: str | None,
     replicas: int | None,
+    processes_per_task: int,
     max_retries: int,
     timeout: int,
     region: tuple[str, ...],
@@ -977,6 +988,7 @@ def run(
             job_name=job_name,
             user=user,
             replicas=replicas,
+            processes_per_task=processes_per_task,
             max_retries=max_retries,
             timeout=timeout,
             extras=list(extra),

--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -669,12 +669,11 @@ class IrisClient:
             constraints: Constraints for filtering workers by attribute
             coscheduling: Configuration for atomic multi-task scheduling
             replicas: Number of tasks to create for gang scheduling (default: 1)
-            processes_per_task: Number of GPU processes to run inside each task
-                (default: 1). When > 1, the entrypoint is wrapped with the
-                iris.runtime.multigpu supervisor, which spawns that many JAX
-                processes per task — one per GPU group — so jax.process_count()
-                equals the total GPU process count. Requires a GPU device whose
-                count is divisible by this value. ``1`` is a strict no-op.
+            processes_per_task: Number of JAX processes to run inside each task,
+                one per GPU group, so ``jax.process_count()`` equals
+                ``replicas * processes_per_task`` (default: 1, one process per
+                task). Must divide the task's GPU count, and requires a GPU
+                device. ``1`` is a strict no-op.
             max_retries_failure: Max retries per task on failure (default: 0)
             max_retries_preemption: Max retries per task on preemption (default: 100)
             max_task_failures: Cumulative failed task attempts the job tolerates before

--- a/lib/iris/src/iris/client/client.py
+++ b/lib/iris/src/iris/client/client.py
@@ -55,6 +55,7 @@ from iris.cluster.types import (
     ResourceSpec,
     TaskAttempt,
     adjust_tpu_replicas,
+    get_gpu_count,
     is_job_finished,
 )
 from iris.rpc import controller_pb2, job_pb2
@@ -445,6 +446,44 @@ class LocalClientConfig:
     max_workers: int = 4
 
 
+# Module path of the in-task GPU process supervisor (see iris/runtime/multigpu.py).
+_MULTIGPU_MODULE = "iris.runtime.multigpu"
+
+
+def _wrap_entrypoint_for_multiprocess(
+    entrypoint: Entrypoint, resources: ResourceSpec, processes_per_task: int
+) -> Entrypoint:
+    """Wrap an entrypoint so each task runs ``processes_per_task`` GPU processes.
+
+    Prepends ``python -m iris.runtime.multigpu --nproc N --devices-per-proc D --``
+    to the command. The supervisor spawns N children, each pinned to a contiguous
+    group of D of the task's GPUs. Requires a GPU device whose count is divisible
+    by ``processes_per_task``.
+    """
+    device = resources.device
+    gpu_count = get_gpu_count(device) if device is not None and device.HasField("gpu") else 0
+    if gpu_count <= 0:
+        raise ValueError("processes_per_task > 1 requires a GPU device")
+    if gpu_count % processes_per_task != 0:
+        raise ValueError(f"processes_per_task ({processes_per_task}) must divide the GPU count ({gpu_count})")
+    devices_per_proc = gpu_count // processes_per_task
+    wrapper = [
+        "python",
+        "-m",
+        _MULTIGPU_MODULE,
+        "--nproc",
+        str(processes_per_task),
+        "--devices-per-proc",
+        str(devices_per_proc),
+        "--",
+    ]
+    return Entrypoint(
+        command=[*wrapper, *entrypoint.command],
+        workdir_files=entrypoint.workdir_files,
+        workdir_file_refs=entrypoint.workdir_file_refs,
+    )
+
+
 class IrisClient:
     """High-level client with automatic job hierarchy and namespace-based actor discovery.
 
@@ -605,6 +644,7 @@ class IrisClient:
         constraints: list[Constraint] | None = None,
         coscheduling: CoschedulingConfig | None = None,
         replicas: int = 1,
+        processes_per_task: int = 1,
         max_retries_failure: int = 0,
         max_retries_preemption: int = 1000,
         max_task_failures: int = 0,
@@ -629,6 +669,12 @@ class IrisClient:
             constraints: Constraints for filtering workers by attribute
             coscheduling: Configuration for atomic multi-task scheduling
             replicas: Number of tasks to create for gang scheduling (default: 1)
+            processes_per_task: Number of GPU processes to run inside each task
+                (default: 1). When > 1, the entrypoint is wrapped with the
+                iris.runtime.multigpu supervisor, which spawns that many JAX
+                processes per task — one per GPU group — so jax.process_count()
+                equals the total GPU process count. Requires a GPU device whose
+                count is divisible by this value. ``1`` is a strict no-op.
             max_retries_failure: Max retries per task on failure (default: 0)
             max_retries_preemption: Max retries per task on preemption (default: 100)
             max_task_failures: Cumulative failed task attempts the job tolerates before
@@ -656,6 +702,11 @@ class IrisClient:
         if replicas < 1:
             raise ValueError(f"replicas must be >= 1, got {replicas}")
         replicas = adjust_tpu_replicas(resources.device, replicas)
+
+        if processes_per_task < 1:
+            raise ValueError(f"processes_per_task must be >= 1, got {processes_per_task}")
+        if processes_per_task > 1:
+            entrypoint = _wrap_entrypoint_for_multiprocess(entrypoint, resources, processes_per_task)
 
         # Get parent job ID from context
         ctx = get_iris_ctx()

--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -13,6 +13,7 @@ import atexit
 import logging
 import os
 import time
+from enum import StrEnum
 
 from connectrpc.code import Code
 from connectrpc.errors import ConnectError
@@ -22,6 +23,7 @@ from rigging.timing import Deadline, Duration, ExponentialBackoff
 from iris.actor.resolver import Resolver
 from iris.client.client import iris_ctx
 from iris.cluster.client.job_info import get_job_info
+from iris.runtime.multigpu import JAX_LOCAL_DEVICE_IDS_ENV, JAX_PROCESS_COUNT_ENV, JAX_PROCESS_INDEX_ENV
 
 logger = logging.getLogger(__name__)
 
@@ -129,13 +131,6 @@ def _poll_for_coordinator(
             time.sleep(interval)
 
 
-# Env vars stamped per child by iris.runtime.multigpu (the in-task GPU
-# supervisor). Their presence switches initialize_jax into supervised mode.
-_SUPERVISED_PROCESS_COUNT_ENV = "JAX_PROCESS_COUNT"
-_SUPERVISED_PROCESS_INDEX_ENV = "JAX_PROCESS_INDEX"
-_SUPERVISED_LOCAL_DEVICE_IDS_ENV = "JAX_LOCAL_DEVICE_IDS"
-
-
 def _parse_local_device_ids(raw: str | None) -> list[int] | None:
     """Parse a ``JAX_LOCAL_DEVICE_IDS`` value ("0" or "2,3") into a list, or None."""
     if not raw:
@@ -143,23 +138,32 @@ def _parse_local_device_ids(raw: str | None) -> list[int] | None:
     return [int(part) for part in raw.split(",") if part]
 
 
-def _supervised_coordinator_plan(proc_index: int, task_index: int, num_tasks: int) -> tuple[bool, bool]:
-    """Decide how a supervised rank obtains the coordinator address.
+class _CoordinatorRole(StrEnum):
+    """How a supervised rank obtains the JAX coordinator address."""
 
-    Returns ``(register, poll)``. Global rank 0 (``proc_index == 0``) owns the
-    coordinator and registers its own address, but only when the job spans
-    multiple hosts (otherwise no peer needs to discover it). Other ranks on
-    host 0 reuse that same advertise_host directly, with no registry round-trip.
-    Ranks on other hosts poll the registry for global rank 0's address.
+    REGISTER = "register"  # global rank 0 on a multi-host job: bind + publish its address
+    POLL = "poll"  # a rank on another host: discover rank 0's address via the registry
+    REUSE_LOCAL = "reuse_local"  # rank 0 single-host, or a host-0 peer: use advertise_host directly
+
+
+def _supervised_coordinator_role(proc_index: int, task_index: int, num_tasks: int) -> _CoordinatorRole:
+    """Pick the coordinator-discovery role for a supervised rank.
+
+    Global rank 0 (``proc_index == 0``) owns the coordinator: it publishes its
+    address only when the job spans multiple hosts (otherwise no peer needs to
+    discover it). Other ranks on host 0 reuse that same advertise_host directly,
+    with no registry round-trip. Ranks on other hosts poll for rank 0's address.
     """
     if proc_index == 0:
-        return (num_tasks > 1, False)
+        return _CoordinatorRole.REGISTER if num_tasks > 1 else _CoordinatorRole.REUSE_LOCAL
     if task_index == 0:
-        return (False, False)
-    return (False, True)
+        return _CoordinatorRole.REUSE_LOCAL
+    return _CoordinatorRole.POLL
 
 
-def _initialize_supervised_jax(jax, job_info, *, port: int, endpoint_name: str) -> None:
+def _initialize_supervised_jax(
+    jax, job_info, *, port: int, endpoint_name: str, poll_timeout: float, poll_interval: float
+) -> None:
     """Join the JAX mesh for a process launched by ``iris.runtime.multigpu``.
 
     The supervisor runs N JAX processes inside one Iris task and stamps each
@@ -169,9 +173,9 @@ def _initialize_supervised_jax(jax, job_info, *, port: int, endpoint_name: str) 
     from per-task to per-global-rank so every process across every host joins one
     mesh.
     """
-    proc_count = int(os.environ[_SUPERVISED_PROCESS_COUNT_ENV])
-    proc_index = int(os.environ[_SUPERVISED_PROCESS_INDEX_ENV])
-    device_ids = _parse_local_device_ids(os.environ.get(_SUPERVISED_LOCAL_DEVICE_IDS_ENV))
+    proc_count = int(os.environ[JAX_PROCESS_COUNT_ENV])
+    proc_index = int(os.environ[JAX_PROCESS_INDEX_ENV])
+    device_ids = _parse_local_device_ids(os.environ.get(JAX_LOCAL_DEVICE_IDS_ENV))
 
     if proc_count <= 1:
         jax.distributed.initialize(num_processes=1, process_id=0, local_device_ids=device_ids)
@@ -183,11 +187,11 @@ def _initialize_supervised_jax(jax, job_info, *, port: int, endpoint_name: str) 
     bound_port = job_info.ports.get("jax", port) if job_info else port
     coordinator = f"{advertise_host}:{bound_port}"
 
-    register, poll = _supervised_coordinator_plan(proc_index, task_index, num_tasks)
-    if poll:
+    role = _supervised_coordinator_role(proc_index, task_index, num_tasks)
+    if role is _CoordinatorRole.POLL:
         ctx = iris_ctx()
-        coordinator = _poll_for_coordinator(ctx.resolver, endpoint_name, 300.0, 2.0)
-    elif register:
+        coordinator = _poll_for_coordinator(ctx.resolver, endpoint_name, poll_timeout, poll_interval)
+    elif role is _CoordinatorRole.REGISTER:
         ctx = iris_ctx()
         endpoint_id = ctx.registry.register(endpoint_name, coordinator)
         atexit.register(ctx.registry.unregister, endpoint_id)
@@ -268,8 +272,15 @@ def initialize_jax(
     # rank, so the single/multi-task branches below (which assume one process
     # per task) do not apply. This runs even when job_info is None so a local
     # supervisor smoke can bring up a localhost mesh.
-    if _SUPERVISED_PROCESS_COUNT_ENV in os.environ:
-        _initialize_supervised_jax(jax, job_info, port=port, endpoint_name=endpoint_name)
+    if JAX_PROCESS_COUNT_ENV in os.environ:
+        _initialize_supervised_jax(
+            jax,
+            job_info,
+            port=port,
+            endpoint_name=endpoint_name,
+            poll_timeout=poll_timeout,
+            poll_interval=poll_interval,
+        )
         return
 
     if job_info is None:

--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -14,6 +14,8 @@ import logging
 import os
 import time
 
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
 from rigging.filesystem import marin_prefix
 from rigging.timing import Deadline, Duration, ExponentialBackoff
 
@@ -81,6 +83,15 @@ def configure_jax_compilation_cache() -> None:
     logger.info("JAX compilation cache: %s", cache_dir)
 
 
+# An endpoint name that has not been registered yet surfaces differently across
+# controller versions: an empty result, a Connect NOT_FOUND, or — on controllers
+# that answer the lookup with a bare HTTP 404 — a Connect UNIMPLEMENTED. A
+# coordinator that has not come up is the expected state while polling, as is a
+# transiently unreachable controller (UNAVAILABLE), so all are retried. Other
+# Connect errors are genuine and propagate.
+_COORDINATOR_PENDING_CODES = frozenset({Code.NOT_FOUND, Code.UNIMPLEMENTED, Code.UNAVAILABLE})
+
+
 def _poll_for_coordinator(
     resolver: Resolver,
     endpoint_name: str,
@@ -104,9 +115,13 @@ def _poll_for_coordinator(
     backoff = ExponentialBackoff(initial=poll_interval, maximum=max(poll_interval, 30.0))
     deadline = Deadline.from_now(Duration.from_seconds(timeout))
     while True:
-        resolved = resolver.resolve(endpoint_name)
-        if not resolved.is_empty:
-            return resolved.first().url
+        try:
+            resolved = resolver.resolve(endpoint_name)
+            if not resolved.is_empty:
+                return resolved.first().url
+        except ConnectError as e:
+            if e.code not in _COORDINATOR_PENDING_CODES:
+                raise
         if deadline.expired():
             raise TimeoutError(f"Timed out after {timeout}s waiting for coordinator endpoint '{endpoint_name}'")
         interval = min(backoff.next_interval(), deadline.remaining_seconds())

--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -23,7 +23,11 @@ from rigging.timing import Deadline, Duration, ExponentialBackoff
 from iris.actor.resolver import Resolver
 from iris.client.client import iris_ctx
 from iris.cluster.client.job_info import get_job_info
-from iris.runtime.multigpu import JAX_LOCAL_DEVICE_IDS_ENV, JAX_PROCESS_COUNT_ENV, JAX_PROCESS_INDEX_ENV
+from iris.runtime.multigpu import (
+    IRIS_MULTIGPU_LOCAL_DEVICE_IDS_ENV,
+    IRIS_MULTIGPU_PROCESS_COUNT_ENV,
+    IRIS_MULTIGPU_PROCESS_INDEX_ENV,
+)
 
 logger = logging.getLogger(__name__)
 
@@ -33,11 +37,11 @@ _JAX_ENV_KEYS = (
     "IRIS_TASK_ID",
     "IRIS_NUM_TASKS",
     "IRIS_PORT_jax",
+    IRIS_MULTIGPU_PROCESS_COUNT_ENV,
+    IRIS_MULTIGPU_PROCESS_INDEX_ENV,
+    IRIS_MULTIGPU_LOCAL_DEVICE_IDS_ENV,
     "JAX_COORDINATOR_ADDRESS",
     "JAX_COORDINATOR_BIND_ADDRESS",
-    "JAX_LOCAL_DEVICE_IDS",
-    "JAX_PROCESS_COUNT",
-    "JAX_PROCESS_INDEX",
 )
 
 
@@ -132,7 +136,7 @@ def _poll_for_coordinator(
 
 
 def _parse_local_device_ids(raw: str | None) -> list[int] | None:
-    """Parse a ``JAX_LOCAL_DEVICE_IDS`` value ("0" or "2,3") into a list, or None."""
+    """Parse an ``IRIS_MULTIGPU_LOCAL_DEVICE_IDS`` value ("0" or "2,3") into a list, or None."""
     if not raw:
         return None
     return [int(part) for part in raw.split(",") if part]
@@ -167,15 +171,15 @@ def _initialize_supervised_jax(
     """Join the JAX mesh for a process launched by ``iris.runtime.multigpu``.
 
     The supervisor runs N JAX processes inside one Iris task and stamps each
-    child with its global rank (``JAX_PROCESS_INDEX``), the global world size
-    (``JAX_PROCESS_COUNT``), and the device ids it owns (``JAX_LOCAL_DEVICE_IDS``).
-    Coordinator discovery reuses the one-process-per-task endpoint dance, lifted
-    from per-task to per-global-rank so every process across every host joins one
-    mesh.
+    child with its global rank (``IRIS_MULTIGPU_PROCESS_INDEX``), the global world
+    size (``IRIS_MULTIGPU_PROCESS_COUNT``), and the device ids it owns
+    (``IRIS_MULTIGPU_LOCAL_DEVICE_IDS``). Coordinator discovery reuses the
+    one-process-per-task endpoint dance, lifted from per-task to per-global-rank
+    so every process across every host joins one mesh.
     """
-    proc_count = int(os.environ[JAX_PROCESS_COUNT_ENV])
-    proc_index = int(os.environ[JAX_PROCESS_INDEX_ENV])
-    device_ids = _parse_local_device_ids(os.environ.get(JAX_LOCAL_DEVICE_IDS_ENV))
+    proc_count = int(os.environ[IRIS_MULTIGPU_PROCESS_COUNT_ENV])
+    proc_index = int(os.environ[IRIS_MULTIGPU_PROCESS_INDEX_ENV])
+    device_ids = _parse_local_device_ids(os.environ.get(IRIS_MULTIGPU_LOCAL_DEVICE_IDS_ENV))
 
     if proc_count <= 1:
         jax.distributed.initialize(num_processes=1, process_id=0, local_device_ids=device_ids)
@@ -272,7 +276,7 @@ def initialize_jax(
     # rank, so the single/multi-task branches below (which assume one process
     # per task) do not apply. This runs even when job_info is None so a local
     # supervisor smoke can bring up a localhost mesh.
-    if JAX_PROCESS_COUNT_ENV in os.environ:
+    if IRIS_MULTIGPU_PROCESS_COUNT_ENV in os.environ:
         _initialize_supervised_jax(
             jax,
             job_info,

--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -114,6 +114,79 @@ def _poll_for_coordinator(
             time.sleep(interval)
 
 
+# Env vars stamped per child by iris.runtime.multigpu (the in-task GPU
+# supervisor). Their presence switches initialize_jax into supervised mode.
+_SUPERVISED_PROCESS_COUNT_ENV = "JAX_PROCESS_COUNT"
+_SUPERVISED_PROCESS_INDEX_ENV = "JAX_PROCESS_INDEX"
+_SUPERVISED_LOCAL_DEVICE_IDS_ENV = "JAX_LOCAL_DEVICE_IDS"
+
+
+def _parse_local_device_ids(raw: str | None) -> list[int] | None:
+    """Parse a ``JAX_LOCAL_DEVICE_IDS`` value ("0" or "2,3") into a list, or None."""
+    if not raw:
+        return None
+    return [int(part) for part in raw.split(",") if part]
+
+
+def _supervised_coordinator_plan(proc_index: int, task_index: int, num_tasks: int) -> tuple[bool, bool]:
+    """Decide how a supervised rank obtains the coordinator address.
+
+    Returns ``(register, poll)``. Global rank 0 (``proc_index == 0``) owns the
+    coordinator and registers its own address, but only when the job spans
+    multiple hosts (otherwise no peer needs to discover it). Other ranks on
+    host 0 reuse that same advertise_host directly, with no registry round-trip.
+    Ranks on other hosts poll the registry for global rank 0's address.
+    """
+    if proc_index == 0:
+        return (num_tasks > 1, False)
+    if task_index == 0:
+        return (False, False)
+    return (False, True)
+
+
+def _initialize_supervised_jax(jax, job_info, *, port: int, endpoint_name: str) -> None:
+    """Join the JAX mesh for a process launched by ``iris.runtime.multigpu``.
+
+    The supervisor runs N JAX processes inside one Iris task and stamps each
+    child with its global rank (``JAX_PROCESS_INDEX``), the global world size
+    (``JAX_PROCESS_COUNT``), and the device ids it owns (``JAX_LOCAL_DEVICE_IDS``).
+    Coordinator discovery reuses the one-process-per-task endpoint dance, lifted
+    from per-task to per-global-rank so every process across every host joins one
+    mesh.
+    """
+    proc_count = int(os.environ[_SUPERVISED_PROCESS_COUNT_ENV])
+    proc_index = int(os.environ[_SUPERVISED_PROCESS_INDEX_ENV])
+    device_ids = _parse_local_device_ids(os.environ.get(_SUPERVISED_LOCAL_DEVICE_IDS_ENV))
+
+    if proc_count <= 1:
+        jax.distributed.initialize(num_processes=1, process_id=0, local_device_ids=device_ids)
+        return
+
+    num_tasks = job_info.num_tasks if job_info else 1
+    task_index = job_info.task_index if job_info else 0
+    advertise_host = job_info.advertise_host if job_info else "127.0.0.1"
+    bound_port = job_info.ports.get("jax", port) if job_info else port
+    coordinator = f"{advertise_host}:{bound_port}"
+
+    register, poll = _supervised_coordinator_plan(proc_index, task_index, num_tasks)
+    if poll:
+        ctx = iris_ctx()
+        coordinator = _poll_for_coordinator(ctx.resolver, endpoint_name, 300.0, 2.0)
+    elif register:
+        ctx = iris_ctx()
+        endpoint_id = ctx.registry.register(endpoint_name, coordinator)
+        atexit.register(ctx.registry.unregister, endpoint_id)
+
+    logger.info(
+        "initialize_jax (supervised): process_id=%d/%d local_device_ids=%s coordinator=%s",
+        proc_index,
+        proc_count,
+        device_ids,
+        coordinator,
+    )
+    jax.distributed.initialize(coordinator, proc_count, proc_index, local_device_ids=device_ids)
+
+
 def initialize_jax(
     port: int = 8476,
     endpoint_name: str = "jax_coordinator",
@@ -174,6 +247,16 @@ def initialize_jax(
 
     job_info = get_job_info()
     _log_jax_bootstrap_inputs(job_info, port=port, endpoint_name=endpoint_name)
+
+    # Supervised (multi-process-per-task) mode short-circuits the task-derived
+    # paths: iris.runtime.multigpu has already assigned this process its global
+    # rank, so the single/multi-task branches below (which assume one process
+    # per task) do not apply. This runs even when job_info is None so a local
+    # supervisor smoke can bring up a localhost mesh.
+    if _SUPERVISED_PROCESS_COUNT_ENV in os.environ:
+        _initialize_supervised_jax(jax, job_info, port=port, endpoint_name=endpoint_name)
+        return
+
     if job_info is None:
         return
 

--- a/lib/iris/src/iris/runtime/multigpu.py
+++ b/lib/iris/src/iris/runtime/multigpu.py
@@ -1,0 +1,190 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Per-node multi-process supervisor: run one JAX process per device group.
+
+``python -m iris.runtime.multigpu --nproc N [--devices-per-proc D] -- <argv>``
+spawns N copies of ``<argv>`` inside a single Iris task, each pinned to a
+contiguous group of D local accelerator devices. It is the GPU analogue of
+``srun``/``torchrun`` scoped to one host: the children share the pod's IPC
+namespace and ``/dev/shm``, so NCCL keeps the intra-node NVLink P2P that
+separate single-GPU pods cannot use.
+
+Each child inherits the supervisor's environment plus its rank::
+
+    JAX_PROCESS_COUNT    = num_tasks * nproc           (global world size)
+    JAX_PROCESS_INDEX    = task_index * nproc + local  (global rank)
+    JAX_LOCAL_DEVICE_IDS = the child's D device ids     ("0", or "2,3")
+
+``iris.runtime.jax_init.initialize_jax`` reads these and joins the JAX mesh.
+
+The supervisor owns child lifecycle: it forwards SIGINT/SIGTERM to every child,
+tears the group down and exits non-zero if any child fails, and prefixes each
+child's output with its local rank. It deliberately does not import jax — the
+children initialize CUDA only after the supervisor has already spawned them, so
+no CUDA context exists in the supervisor's address space.
+"""
+
+import argparse
+import logging
+import os
+import signal
+import subprocess
+import sys
+import threading
+from types import FrameType
+
+from iris.cluster.client.job_info import get_job_info
+
+logger = logging.getLogger("iris.multigpu")
+
+_SHUTDOWN_SIGNALS = (signal.SIGINT, signal.SIGTERM)
+# How often to re-poll child liveness while waiting for the group (seconds).
+_REAP_POLL_INTERVAL = 1.0
+
+
+def _child_rank_env(
+    local_rank: int, nproc: int, devices_per_proc: int, task_index: int, num_tasks: int
+) -> dict[str, str]:
+    """Compute the rank env vars handed to one child process.
+
+    Device ids are a contiguous slice so rank ``i`` owns devices
+    ``[i*D, (i+1)*D)``; the common case ``D == 1`` gives one device per process.
+    """
+    begin = local_rank * devices_per_proc
+    device_ids = ",".join(str(d) for d in range(begin, begin + devices_per_proc))
+    return {
+        "JAX_PROCESS_COUNT": str(num_tasks * nproc),
+        "JAX_PROCESS_INDEX": str(task_index * nproc + local_rank),
+        "JAX_LOCAL_DEVICE_IDS": device_ids,
+    }
+
+
+def _pump_output(local_rank: int, stream, write_lock: threading.Lock) -> None:
+    """Forward a child's merged stdout/stderr, line-prefixed with its rank."""
+    prefix = f"[rank{local_rank}] "
+    for line in iter(stream.readline, ""):
+        with write_lock:
+            sys.stdout.write(prefix + line)
+            sys.stdout.flush()
+    stream.close()
+
+
+def _terminate(children: list[subprocess.Popen], ranks) -> None:
+    for rank in ranks:
+        child = children[rank]
+        if child.poll() is None:
+            child.terminate()
+
+
+def run(nproc: int, devices_per_proc: int, child_argv: list[str]) -> int:
+    """Spawn ``nproc`` children, supervise them, return the process exit code.
+
+    Returns the first non-zero child exit code (after tearing the rest down), or
+    0 once every child exits cleanly.
+    """
+    if nproc < 1:
+        raise ValueError(f"--nproc must be >= 1, got {nproc}")
+    if devices_per_proc < 1:
+        raise ValueError(f"--devices-per-proc must be >= 1, got {devices_per_proc}")
+    if not child_argv:
+        raise ValueError("no child command given after '--'")
+
+    job_info = get_job_info()
+    num_tasks = job_info.num_tasks if job_info else 1
+    task_index = job_info.task_index if job_info else 0
+    logger.info(
+        "supervising %d process(es) x %d device(s) each; task_index=%d num_tasks=%d; command=%s",
+        nproc,
+        devices_per_proc,
+        task_index,
+        num_tasks,
+        " ".join(child_argv),
+    )
+
+    children: list[subprocess.Popen] = []
+    pumps: list[threading.Thread] = []
+    write_lock = threading.Lock()
+
+    for local_rank in range(nproc):
+        rank_env = _child_rank_env(local_rank, nproc, devices_per_proc, task_index, num_tasks)
+        child_env = {**os.environ, **rank_env}
+        logger.info(
+            "launch local rank %d: JAX_PROCESS_INDEX=%s JAX_LOCAL_DEVICE_IDS=%s",
+            local_rank,
+            rank_env["JAX_PROCESS_INDEX"],
+            rank_env["JAX_LOCAL_DEVICE_IDS"],
+        )
+        child = subprocess.Popen(
+            child_argv,
+            env=child_env,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.STDOUT,
+            text=True,
+            bufsize=1,
+        )
+        children.append(child)
+        pump = threading.Thread(target=_pump_output, args=(local_rank, child.stdout, write_lock), daemon=True)
+        pump.start()
+        pumps.append(pump)
+
+    terminating = threading.Event()
+
+    def _forward_signal(signum: int, _frame: FrameType | None) -> None:
+        terminating.set()
+        logger.warning("received signal %d; forwarding to children", signum)
+        for child in children:
+            if child.poll() is None:
+                child.send_signal(signum)
+
+    for sig in _SHUTDOWN_SIGNALS:
+        signal.signal(sig, _forward_signal)
+
+    first_failure: int | None = None
+    pending = set(range(nproc))
+    while pending:
+        for local_rank in list(pending):
+            child = children[local_rank]
+            try:
+                code = child.wait(timeout=_REAP_POLL_INTERVAL)
+            except subprocess.TimeoutExpired:
+                continue
+            pending.discard(local_rank)
+            logger.info("local rank %d exited with code %d", local_rank, code)
+            # A failure tears the whole group down: a collective job cannot make
+            # progress once one rank is gone. A clean exit does not — peers run to
+            # their own completion.
+            if code != 0 and first_failure is None:
+                first_failure = code
+                if not terminating.is_set():
+                    terminating.set()
+                    logger.error(
+                        "local rank %d failed (code %d); terminating %d peer(s)", local_rank, code, len(pending)
+                    )
+                    _terminate(children, pending)
+
+    for pump in pumps:
+        pump.join(timeout=5.0)
+
+    return first_failure or 0
+
+
+def main(argv: list[str] | None = None) -> int:
+    logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s %(message)s")
+    raw = list(sys.argv[1:] if argv is None else argv)
+    if "--" not in raw:
+        raise SystemExit("usage: python -m iris.runtime.multigpu --nproc N [--devices-per-proc D] -- <command...>")
+    split = raw.index("--")
+    own_args, child_argv = raw[:split], raw[split + 1 :]
+
+    parser = argparse.ArgumentParser(prog="python -m iris.runtime.multigpu")
+    parser.add_argument("--nproc", type=int, required=True, help="number of processes to launch on this host")
+    parser.add_argument(
+        "--devices-per-proc", type=int, default=1, help="local accelerator devices assigned to each process"
+    )
+    args = parser.parse_args(own_args)
+    return run(args.nproc, args.devices_per_proc, child_argv)
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/lib/iris/src/iris/runtime/multigpu.py
+++ b/lib/iris/src/iris/runtime/multigpu.py
@@ -12,11 +12,13 @@ separate single-GPU pods cannot use.
 
 Each child inherits the supervisor's environment plus its rank::
 
-    JAX_PROCESS_COUNT    = num_tasks * nproc           (global world size)
-    JAX_PROCESS_INDEX    = task_index * nproc + local  (global rank)
-    JAX_LOCAL_DEVICE_IDS = the child's D device ids     ("0", or "2,3")
+    IRIS_MULTIGPU_PROCESS_COUNT    = num_tasks * nproc           (global world size)
+    IRIS_MULTIGPU_PROCESS_INDEX    = task_index * nproc + local  (global rank)
+    IRIS_MULTIGPU_LOCAL_DEVICE_IDS = the child's D device ids     ("0", or "2,3")
 
-``iris.runtime.jax_init.initialize_jax`` reads these and joins the JAX mesh.
+``iris.runtime.jax_init.initialize_jax`` reads these and joins the JAX mesh. The
+names are iris-private (not the JAX_*/framework namespace) so a job that already
+sets JAX rank vars never trips the supervised path.
 
 The supervisor owns child lifecycle: it forwards SIGINT/SIGTERM to every child,
 tears the group down and exits non-zero if any child fails, and prefixes each
@@ -32,6 +34,7 @@ import signal
 import subprocess
 import sys
 import threading
+import time
 from types import FrameType
 
 from iris.cluster.client.job_info import get_job_info
@@ -41,14 +44,19 @@ logger = logging.getLogger("iris.multigpu")
 _SHUTDOWN_SIGNALS = (signal.SIGINT, signal.SIGTERM)
 # How often to re-poll child liveness while waiting for the group (seconds).
 _REAP_POLL_INTERVAL = 1.0
+# Grace period after a SIGTERM before escalating to SIGKILL, so a child that
+# traps or ignores SIGTERM cannot wedge the supervisor (and hence the task).
+_TERMINATE_GRACE = 10.0
 
 # The supervisor→child rank contract: each child is stamped with these env vars,
 # and iris.runtime.jax_init reads them to switch initialize_jax into supervised
-# mode. Defined here (the producer) and imported by the consumer so the names
-# cannot drift between the two.
-JAX_PROCESS_COUNT_ENV = "JAX_PROCESS_COUNT"
-JAX_PROCESS_INDEX_ENV = "JAX_PROCESS_INDEX"
-JAX_LOCAL_DEVICE_IDS_ENV = "JAX_LOCAL_DEVICE_IDS"
+# mode. They are iris-private (not the JAX_*/framework namespace) so an unrelated
+# job that happens to set JAX rank vars never trips the supervised path —
+# processes_per_task=1 stays a strict no-op. Defined here (the producer) and
+# imported by the consumer so the names cannot drift between the two.
+IRIS_MULTIGPU_PROCESS_COUNT_ENV = "IRIS_MULTIGPU_PROCESS_COUNT"
+IRIS_MULTIGPU_PROCESS_INDEX_ENV = "IRIS_MULTIGPU_PROCESS_INDEX"
+IRIS_MULTIGPU_LOCAL_DEVICE_IDS_ENV = "IRIS_MULTIGPU_LOCAL_DEVICE_IDS"
 
 
 def _child_rank_env(
@@ -62,9 +70,9 @@ def _child_rank_env(
     begin = local_rank * devices_per_proc
     device_ids = ",".join(str(d) for d in range(begin, begin + devices_per_proc))
     return {
-        JAX_PROCESS_COUNT_ENV: str(num_tasks * nproc),
-        JAX_PROCESS_INDEX_ENV: str(task_index * nproc + local_rank),
-        JAX_LOCAL_DEVICE_IDS_ENV: device_ids,
+        IRIS_MULTIGPU_PROCESS_COUNT_ENV: str(num_tasks * nproc),
+        IRIS_MULTIGPU_PROCESS_INDEX_ENV: str(task_index * nproc + local_rank),
+        IRIS_MULTIGPU_LOCAL_DEVICE_IDS_ENV: device_ids,
     }
 
 
@@ -78,18 +86,68 @@ def _pump_output(local_rank: int, stream, write_lock: threading.Lock) -> None:
     stream.close()
 
 
-def _terminate(children: list[subprocess.Popen], ranks) -> None:
+def _signal_children(children: list[subprocess.Popen], ranks, sig: int) -> None:
+    """Send ``sig`` to every still-running child in ``ranks``."""
     for rank in ranks:
         child = children[rank]
         if child.poll() is None:
-            child.terminate()
+            child.send_signal(sig)
+
+
+def _spawn_children(
+    nproc: int, devices_per_proc: int, task_index: int, num_tasks: int, child_argv: list[str]
+) -> tuple[list[subprocess.Popen], list[threading.Thread]]:
+    """Spawn all children, or SIGKILL any that started and re-raise on failure.
+
+    A partial spawn (rank 0 up, rank 3 fails on ``EAGAIN`` / a missing binary /
+    thread-creation failure) would otherwise leave the started ranks orphaned,
+    holding GPUs after the supervisor exits.
+    """
+    children: list[subprocess.Popen] = []
+    pumps: list[threading.Thread] = []
+    write_lock = threading.Lock()
+    try:
+        for local_rank in range(nproc):
+            rank_env = _child_rank_env(local_rank, nproc, devices_per_proc, task_index, num_tasks)
+            child_env = {**os.environ, **rank_env}
+            logger.info(
+                "launch local rank %d: %s=%s %s=%s",
+                local_rank,
+                IRIS_MULTIGPU_PROCESS_INDEX_ENV,
+                rank_env[IRIS_MULTIGPU_PROCESS_INDEX_ENV],
+                IRIS_MULTIGPU_LOCAL_DEVICE_IDS_ENV,
+                rank_env[IRIS_MULTIGPU_LOCAL_DEVICE_IDS_ENV],
+            )
+            child = subprocess.Popen(
+                child_argv,
+                env=child_env,
+                stdout=subprocess.PIPE,
+                stderr=subprocess.STDOUT,
+                text=True,
+                bufsize=1,
+            )
+            children.append(child)
+            pump = threading.Thread(target=_pump_output, args=(local_rank, child.stdout, write_lock), daemon=True)
+            pump.start()
+            pumps.append(pump)
+    except BaseException:
+        logger.error("spawn failed after starting %d/%d child(ren); killing them", len(children), nproc)
+        _signal_children(children, range(len(children)), signal.SIGKILL)
+        for child in children:
+            try:
+                child.wait(timeout=5.0)
+            except subprocess.TimeoutExpired:
+                pass
+        raise
+    return children, pumps
 
 
 def run(nproc: int, devices_per_proc: int, child_argv: list[str]) -> int:
     """Spawn ``nproc`` children, supervise them, return the process exit code.
 
-    Returns the first non-zero child exit code (after tearing the rest down), or
-    0 once every child exits cleanly.
+    Returns the first non-zero child exit code (after tearing the rest down),
+    ``128 + signum`` if a SIGINT/SIGTERM initiated the teardown (the task did not
+    complete), or 0 once every child exits cleanly.
     """
     if nproc < 1:
         raise ValueError(f"--nproc must be >= 1, got {nproc}")
@@ -110,40 +168,24 @@ def run(nproc: int, devices_per_proc: int, child_argv: list[str]) -> int:
         " ".join(child_argv),
     )
 
-    children: list[subprocess.Popen] = []
-    pumps: list[threading.Thread] = []
-    write_lock = threading.Lock()
-
-    for local_rank in range(nproc):
-        rank_env = _child_rank_env(local_rank, nproc, devices_per_proc, task_index, num_tasks)
-        child_env = {**os.environ, **rank_env}
-        logger.info(
-            "launch local rank %d: JAX_PROCESS_INDEX=%s JAX_LOCAL_DEVICE_IDS=%s",
-            local_rank,
-            rank_env["JAX_PROCESS_INDEX"],
-            rank_env["JAX_LOCAL_DEVICE_IDS"],
-        )
-        child = subprocess.Popen(
-            child_argv,
-            env=child_env,
-            stdout=subprocess.PIPE,
-            stderr=subprocess.STDOUT,
-            text=True,
-            bufsize=1,
-        )
-        children.append(child)
-        pump = threading.Thread(target=_pump_output, args=(local_rank, child.stdout, write_lock), daemon=True)
-        pump.start()
-        pumps.append(pump)
+    children, pumps = _spawn_children(nproc, devices_per_proc, task_index, num_tasks, child_argv)
 
     terminating = threading.Event()
+    shutdown_signum: int | None = None
+    # Monotonic deadline after which surviving children are SIGKILLed; ``None``
+    # until a teardown begins. Shared between the signal handler and the reap
+    # loop, both of which run in the main thread (no lock needed).
+    kill_deadline: float | None = None
 
     def _forward_signal(signum: int, _frame: FrameType | None) -> None:
+        nonlocal shutdown_signum, kill_deadline
+        if shutdown_signum is None:
+            shutdown_signum = signum
         terminating.set()
         logger.warning("received signal %d; forwarding to children", signum)
-        for child in children:
-            if child.poll() is None:
-                child.send_signal(signum)
+        _signal_children(children, range(nproc), signum)
+        if kill_deadline is None:
+            kill_deadline = time.monotonic() + _TERMINATE_GRACE
 
     for sig in _SHUTDOWN_SIGNALS:
         signal.signal(sig, _forward_signal)
@@ -151,6 +193,14 @@ def run(nproc: int, devices_per_proc: int, child_argv: list[str]) -> int:
     first_failure: int | None = None
     pending = set(range(nproc))
     while pending:
+        # Escalate to SIGKILL if a requested teardown overran its grace period,
+        # so a child that traps or ignores SIGTERM cannot wedge the supervisor.
+        if kill_deadline is not None and time.monotonic() >= kill_deadline:
+            survivors = [r for r in pending if children[r].poll() is None]
+            if survivors:
+                logger.error("SIGTERM grace expired; SIGKILL %d straggler(s): %s", len(survivors), survivors)
+                _signal_children(children, survivors, signal.SIGKILL)
+            kill_deadline = None  # SIGKILL is final; do not re-fire each tick
         for local_rank in list(pending):
             child = children[local_rank]
             try:
@@ -159,22 +209,25 @@ def run(nproc: int, devices_per_proc: int, child_argv: list[str]) -> int:
                 continue
             pending.discard(local_rank)
             logger.info("local rank %d exited with code %d", local_rank, code)
+            if code != 0 and first_failure is None:
+                first_failure = code
             # A failure tears the whole group down: a collective job cannot make
             # progress once one rank is gone. A clean exit does not — peers run to
             # their own completion.
-            if code != 0 and first_failure is None:
-                first_failure = code
-                if not terminating.is_set():
-                    terminating.set()
-                    logger.error(
-                        "local rank %d failed (code %d); terminating %d peer(s)", local_rank, code, len(pending)
-                    )
-                    _terminate(children, pending)
+            if code != 0 and not terminating.is_set():
+                terminating.set()
+                logger.error("local rank %d failed (code %d); terminating %d peer(s)", local_rank, code, len(pending))
+                _signal_children(children, pending, signal.SIGTERM)
+                kill_deadline = time.monotonic() + _TERMINATE_GRACE
 
     for pump in pumps:
         pump.join(timeout=5.0)
 
-    return first_failure or 0
+    if first_failure is not None:
+        return first_failure
+    if shutdown_signum is not None:
+        return 128 + shutdown_signum
+    return 0
 
 
 def main(argv: list[str] | None = None) -> int:

--- a/lib/iris/src/iris/runtime/multigpu.py
+++ b/lib/iris/src/iris/runtime/multigpu.py
@@ -42,6 +42,14 @@ _SHUTDOWN_SIGNALS = (signal.SIGINT, signal.SIGTERM)
 # How often to re-poll child liveness while waiting for the group (seconds).
 _REAP_POLL_INTERVAL = 1.0
 
+# The supervisor→child rank contract: each child is stamped with these env vars,
+# and iris.runtime.jax_init reads them to switch initialize_jax into supervised
+# mode. Defined here (the producer) and imported by the consumer so the names
+# cannot drift between the two.
+JAX_PROCESS_COUNT_ENV = "JAX_PROCESS_COUNT"
+JAX_PROCESS_INDEX_ENV = "JAX_PROCESS_INDEX"
+JAX_LOCAL_DEVICE_IDS_ENV = "JAX_LOCAL_DEVICE_IDS"
+
 
 def _child_rank_env(
     local_rank: int, nproc: int, devices_per_proc: int, task_index: int, num_tasks: int
@@ -54,9 +62,9 @@ def _child_rank_env(
     begin = local_rank * devices_per_proc
     device_ids = ",".join(str(d) for d in range(begin, begin + devices_per_proc))
     return {
-        "JAX_PROCESS_COUNT": str(num_tasks * nproc),
-        "JAX_PROCESS_INDEX": str(task_index * nproc + local_rank),
-        "JAX_LOCAL_DEVICE_IDS": device_ids,
+        JAX_PROCESS_COUNT_ENV: str(num_tasks * nproc),
+        JAX_PROCESS_INDEX_ENV: str(task_index * nproc + local_rank),
+        JAX_LOCAL_DEVICE_IDS_ENV: device_ids,
     }
 
 

--- a/lib/iris/src/iris/runtime/multigpu.py
+++ b/lib/iris/src/iris/runtime/multigpu.py
@@ -34,8 +34,9 @@ import signal
 import subprocess
 import sys
 import threading
-import time
 from types import FrameType
+
+from rigging.timing import Deadline, Duration
 
 from iris.cluster.client.job_info import get_job_info
 
@@ -46,7 +47,7 @@ _SHUTDOWN_SIGNALS = (signal.SIGINT, signal.SIGTERM)
 _REAP_POLL_INTERVAL = 1.0
 # Grace period after a SIGTERM before escalating to SIGKILL, so a child that
 # traps or ignores SIGTERM cannot wedge the supervisor (and hence the task).
-_TERMINATE_GRACE = 10.0
+_TERMINATE_GRACE = Duration.from_seconds(10.0)
 
 # The supervisor→child rank contract: each child is stamped with these env vars,
 # and iris.runtime.jax_init reads them to switch initialize_jax into supervised
@@ -145,9 +146,11 @@ def _spawn_children(
 def run(nproc: int, devices_per_proc: int, child_argv: list[str]) -> int:
     """Spawn ``nproc`` children, supervise them, return the process exit code.
 
-    Returns the first non-zero child exit code (after tearing the rest down),
-    ``128 + signum`` if a SIGINT/SIGTERM initiated the teardown (the task did not
-    complete), or 0 once every child exits cleanly.
+    ``128 + signum`` if a SIGINT/SIGTERM was delivered to the supervisor (an
+    external termination/preemption); this takes precedence because the children
+    it forwards the signal to report their own (negative) signal codes, which
+    must not be surfaced as a task failure. Otherwise the first non-zero child
+    exit code (after tearing the rest down), or 0 once every child exits cleanly.
     """
     if nproc < 1:
         raise ValueError(f"--nproc must be >= 1, got {nproc}")
@@ -172,10 +175,10 @@ def run(nproc: int, devices_per_proc: int, child_argv: list[str]) -> int:
 
     terminating = threading.Event()
     shutdown_signum: int | None = None
-    # Monotonic deadline after which surviving children are SIGKILLed; ``None``
-    # until a teardown begins. Shared between the signal handler and the reap
-    # loop, both of which run in the main thread (no lock needed).
-    kill_deadline: float | None = None
+    # Deadline after which surviving children are SIGKILLed; ``None`` until a
+    # teardown begins. Shared between the signal handler and the reap loop, both
+    # of which run in the main thread (no lock needed).
+    kill_deadline: Deadline | None = None
 
     def _forward_signal(signum: int, _frame: FrameType | None) -> None:
         nonlocal shutdown_signum, kill_deadline
@@ -185,7 +188,7 @@ def run(nproc: int, devices_per_proc: int, child_argv: list[str]) -> int:
         logger.warning("received signal %d; forwarding to children", signum)
         _signal_children(children, range(nproc), signum)
         if kill_deadline is None:
-            kill_deadline = time.monotonic() + _TERMINATE_GRACE
+            kill_deadline = Deadline.from_now(_TERMINATE_GRACE)
 
     for sig in _SHUTDOWN_SIGNALS:
         signal.signal(sig, _forward_signal)
@@ -195,7 +198,7 @@ def run(nproc: int, devices_per_proc: int, child_argv: list[str]) -> int:
     while pending:
         # Escalate to SIGKILL if a requested teardown overran its grace period,
         # so a child that traps or ignores SIGTERM cannot wedge the supervisor.
-        if kill_deadline is not None and time.monotonic() >= kill_deadline:
+        if kill_deadline is not None and kill_deadline.expired():
             survivors = [r for r in pending if children[r].poll() is None]
             if survivors:
                 logger.error("SIGTERM grace expired; SIGKILL %d straggler(s): %s", len(survivors), survivors)
@@ -218,15 +221,19 @@ def run(nproc: int, devices_per_proc: int, child_argv: list[str]) -> int:
                 terminating.set()
                 logger.error("local rank %d failed (code %d); terminating %d peer(s)", local_rank, code, len(pending))
                 _signal_children(children, pending, signal.SIGTERM)
-                kill_deadline = time.monotonic() + _TERMINATE_GRACE
+                kill_deadline = Deadline.from_now(_TERMINATE_GRACE)
 
     for pump in pumps:
         pump.join(timeout=5.0)
 
-    if first_failure is not None:
-        return first_failure
+    # An external signal wins over child exit codes: the children we forwarded it
+    # to report negative (signal) codes that are an artifact of the teardown, not
+    # a task failure. A child failing on its own never sets shutdown_signum, so
+    # its genuine non-zero code surfaces.
     if shutdown_signum is not None:
         return 128 + shutdown_signum
+    if first_failure is not None:
+        return first_failure
     return 0
 
 

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -19,8 +19,9 @@ from iris.actor.resolver import ResolvedEndpoint, ResolveResult
 from iris.cluster.client.job_info import JobInfo
 from iris.cluster.types import JobName
 from iris.runtime.jax_init import (
+    _CoordinatorRole,
     _poll_for_coordinator,
-    _supervised_coordinator_plan,
+    _supervised_coordinator_role,
     configure_jax_compilation_cache,
     initialize_jax,
 )
@@ -220,17 +221,17 @@ def test_initialize_jax_poll_timeout(
 @pytest.mark.parametrize(
     "proc_index,task_index,num_tasks,expected",
     [
-        (0, 0, 1, (False, False)),  # single-host global rank 0: bind, no registry
-        (0, 0, 4, (True, False)),  # multi-host global rank 0: register its address
-        (3, 0, 1, (False, False)),  # host-0 local rank: reuse advertise_host directly
-        (5, 0, 4, (False, False)),  # host-0 local rank on a multi-host job: same
-        (8, 2, 4, (False, True)),  # other host: poll the registry for rank 0
+        (0, 0, 1, _CoordinatorRole.REUSE_LOCAL),  # single-host global rank 0: bind, no registry
+        (0, 0, 4, _CoordinatorRole.REGISTER),  # multi-host global rank 0: register its address
+        (3, 0, 1, _CoordinatorRole.REUSE_LOCAL),  # host-0 local rank: reuse advertise_host directly
+        (5, 0, 4, _CoordinatorRole.REUSE_LOCAL),  # host-0 local rank on a multi-host job: same
+        (8, 2, 4, _CoordinatorRole.POLL),  # other host: poll the registry for rank 0
     ],
 )
-def test_supervised_coordinator_plan(
-    proc_index: int, task_index: int, num_tasks: int, expected: tuple[bool, bool]
+def test_supervised_coordinator_role(
+    proc_index: int, task_index: int, num_tasks: int, expected: _CoordinatorRole
 ) -> None:
-    assert _supervised_coordinator_plan(proc_index, task_index, num_tasks) == expected
+    assert _supervised_coordinator_role(proc_index, task_index, num_tasks) == expected
 
 
 @patch("iris.runtime.jax_init.atexit")

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -13,6 +13,8 @@ import pytest
 pytest.importorskip("jax")
 
 import jax
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
 from iris.actor.resolver import ResolvedEndpoint, ResolveResult
 from iris.cluster.client.job_info import JobInfo
 from iris.cluster.types import JobName
@@ -304,6 +306,43 @@ def test_initialize_jax_supervised_other_host_polls(
 
     mock_jax_init.assert_called_once_with("10.0.0.9:8476", 16, 8, local_device_ids=[0])
     assert fake_ctx.registry.registered == []
+
+
+# NOT_FOUND is the proper Connect "name absent"; UNIMPLEMENTED is what an older
+# controller's bare HTTP 404 decodes to for the same condition. Both must retry.
+@pytest.mark.parametrize("pending_code", [Code.NOT_FOUND, Code.UNIMPLEMENTED])
+def test_poll_for_coordinator_retries_until_registered(pending_code: Code) -> None:
+    """The lookup reports the name absent until rank 0 registers; the poller retries, not crashes."""
+    found = ResolveResult(
+        name="jax_coordinator",
+        endpoints=[ResolvedEndpoint(url="10.0.0.9:8476", actor_id="ep-1")],
+    )
+
+    class NotYetRegisteredResolver:
+        def __init__(self) -> None:
+            self.calls = 0
+
+        def resolve(self, name: str) -> ResolveResult:
+            self.calls += 1
+            if self.calls < 3:
+                raise ConnectError(pending_code, f"{name} not registered")
+            return found
+
+    resolver = NotYetRegisteredResolver()
+    url = _poll_for_coordinator(resolver, "jax_coordinator", timeout=5.0, poll_interval=0.001)
+    assert url == "10.0.0.9:8476"
+    assert resolver.calls == 3
+
+
+def test_poll_for_coordinator_propagates_real_connect_errors() -> None:
+    """A Connect error outside the pending set (e.g. PERMISSION_DENIED) is real and propagates."""
+
+    class DeniedResolver:
+        def resolve(self, name: str) -> ResolveResult:
+            raise ConnectError(Code.PERMISSION_DENIED, "not allowed")
+
+    with pytest.raises(ConnectError):
+        _poll_for_coordinator(DeniedResolver(), "jax_coordinator", timeout=5.0, poll_interval=0.001)
 
 
 @contextmanager

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -247,9 +247,9 @@ def test_initialize_jax_supervised_single_host(
 ) -> None:
     """A supervised non-zero rank on a single host joins via advertise_host, no registry."""
     mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=1)
-    monkeypatch.setenv("JAX_PROCESS_COUNT", "8")
-    monkeypatch.setenv("JAX_PROCESS_INDEX", "3")
-    monkeypatch.setenv("JAX_LOCAL_DEVICE_IDS", "3")
+    monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_COUNT", "8")
+    monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_INDEX", "3")
+    monkeypatch.setenv("IRIS_MULTIGPU_LOCAL_DEVICE_IDS", "3")
 
     initialize_jax()
 
@@ -272,9 +272,9 @@ def test_initialize_jax_supervised_global_rank0_registers(
     mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=2)
     fake_ctx = FakeContext()
     mock_iris_ctx.return_value = fake_ctx
-    monkeypatch.setenv("JAX_PROCESS_COUNT", "16")
-    monkeypatch.setenv("JAX_PROCESS_INDEX", "0")
-    monkeypatch.setenv("JAX_LOCAL_DEVICE_IDS", "0")
+    monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_COUNT", "16")
+    monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_INDEX", "0")
+    monkeypatch.setenv("IRIS_MULTIGPU_LOCAL_DEVICE_IDS", "0")
 
     initialize_jax()
 
@@ -299,9 +299,9 @@ def test_initialize_jax_supervised_other_host_polls(
     )
     fake_ctx = FakeContext(resolver=FakeResolver(results=[found]))
     mock_iris_ctx.return_value = fake_ctx
-    monkeypatch.setenv("JAX_PROCESS_COUNT", "16")
-    monkeypatch.setenv("JAX_PROCESS_INDEX", "8")
-    monkeypatch.setenv("JAX_LOCAL_DEVICE_IDS", "0")
+    monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_COUNT", "16")
+    monkeypatch.setenv("IRIS_MULTIGPU_PROCESS_INDEX", "8")
+    monkeypatch.setenv("IRIS_MULTIGPU_LOCAL_DEVICE_IDS", "0")
 
     initialize_jax()
 

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -19,9 +19,7 @@ from iris.actor.resolver import ResolvedEndpoint, ResolveResult
 from iris.cluster.client.job_info import JobInfo
 from iris.cluster.types import JobName
 from iris.runtime.jax_init import (
-    _CoordinatorRole,
     _poll_for_coordinator,
-    _supervised_coordinator_role,
     configure_jax_compilation_cache,
     initialize_jax,
 )
@@ -216,22 +214,6 @@ def test_initialize_jax_poll_timeout(
         initialize_jax(poll_timeout=0.1, poll_interval=0.01)
 
     mock_jax_init.assert_not_called()
-
-
-@pytest.mark.parametrize(
-    "proc_index,task_index,num_tasks,expected",
-    [
-        (0, 0, 1, _CoordinatorRole.REUSE_LOCAL),  # single-host global rank 0: bind, no registry
-        (0, 0, 4, _CoordinatorRole.REGISTER),  # multi-host global rank 0: register its address
-        (3, 0, 1, _CoordinatorRole.REUSE_LOCAL),  # host-0 local rank: reuse advertise_host directly
-        (5, 0, 4, _CoordinatorRole.REUSE_LOCAL),  # host-0 local rank on a multi-host job: same
-        (8, 2, 4, _CoordinatorRole.POLL),  # other host: poll the registry for rank 0
-    ],
-)
-def test_supervised_coordinator_role(
-    proc_index: int, task_index: int, num_tasks: int, expected: _CoordinatorRole
-) -> None:
-    assert _supervised_coordinator_role(proc_index, task_index, num_tasks) == expected
 
 
 @patch("iris.runtime.jax_init.atexit")

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -18,6 +18,7 @@ from iris.cluster.client.job_info import JobInfo
 from iris.cluster.types import JobName
 from iris.runtime.jax_init import (
     _poll_for_coordinator,
+    _supervised_coordinator_plan,
     configure_jax_compilation_cache,
     initialize_jax,
 )
@@ -212,6 +213,97 @@ def test_initialize_jax_poll_timeout(
         initialize_jax(poll_timeout=0.1, poll_interval=0.01)
 
     mock_jax_init.assert_not_called()
+
+
+@pytest.mark.parametrize(
+    "proc_index,task_index,num_tasks,expected",
+    [
+        (0, 0, 1, (False, False)),  # single-host global rank 0: bind, no registry
+        (0, 0, 4, (True, False)),  # multi-host global rank 0: register its address
+        (3, 0, 1, (False, False)),  # host-0 local rank: reuse advertise_host directly
+        (5, 0, 4, (False, False)),  # host-0 local rank on a multi-host job: same
+        (8, 2, 4, (False, True)),  # other host: poll the registry for rank 0
+    ],
+)
+def test_supervised_coordinator_plan(
+    proc_index: int, task_index: int, num_tasks: int, expected: tuple[bool, bool]
+) -> None:
+    assert _supervised_coordinator_plan(proc_index, task_index, num_tasks) == expected
+
+
+@patch("iris.runtime.jax_init.atexit")
+@patch("jax.distributed.initialize")
+@patch("iris.runtime.jax_init.iris_ctx")
+@patch("iris.runtime.jax_init.get_job_info")
+def test_initialize_jax_supervised_single_host(
+    mock_get_job_info: MagicMock,
+    mock_iris_ctx: MagicMock,
+    mock_jax_init: MagicMock,
+    mock_atexit: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A supervised non-zero rank on a single host joins via advertise_host, no registry."""
+    mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=1)
+    monkeypatch.setenv("JAX_PROCESS_COUNT", "8")
+    monkeypatch.setenv("JAX_PROCESS_INDEX", "3")
+    monkeypatch.setenv("JAX_LOCAL_DEVICE_IDS", "3")
+
+    initialize_jax()
+
+    mock_jax_init.assert_called_once_with("10.0.0.1:8476", 8, 3, local_device_ids=[3])
+    mock_iris_ctx.assert_not_called()
+
+
+@patch("iris.runtime.jax_init.atexit")
+@patch("jax.distributed.initialize")
+@patch("iris.runtime.jax_init.iris_ctx")
+@patch("iris.runtime.jax_init.get_job_info")
+def test_initialize_jax_supervised_global_rank0_registers(
+    mock_get_job_info: MagicMock,
+    mock_iris_ctx: MagicMock,
+    mock_jax_init: MagicMock,
+    mock_atexit: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Global rank 0 on a multi-host supervised job registers the coordinator."""
+    mock_get_job_info.return_value = _make_job_info(task_index=0, num_tasks=2)
+    fake_ctx = FakeContext()
+    mock_iris_ctx.return_value = fake_ctx
+    monkeypatch.setenv("JAX_PROCESS_COUNT", "16")
+    monkeypatch.setenv("JAX_PROCESS_INDEX", "0")
+    monkeypatch.setenv("JAX_LOCAL_DEVICE_IDS", "0")
+
+    initialize_jax()
+
+    assert fake_ctx.registry.registered == [("jax_coordinator", "10.0.0.1:8476")]
+    mock_jax_init.assert_called_once_with("10.0.0.1:8476", 16, 0, local_device_ids=[0])
+
+
+@patch("jax.distributed.initialize")
+@patch("iris.runtime.jax_init.iris_ctx")
+@patch("iris.runtime.jax_init.get_job_info")
+def test_initialize_jax_supervised_other_host_polls(
+    mock_get_job_info: MagicMock,
+    mock_iris_ctx: MagicMock,
+    mock_jax_init: MagicMock,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """A supervised rank on host != 0 polls the registry for rank 0's address."""
+    mock_get_job_info.return_value = _make_job_info(task_index=1, num_tasks=2)
+    found = ResolveResult(
+        name="jax_coordinator",
+        endpoints=[ResolvedEndpoint(url="10.0.0.9:8476", actor_id="ep-1")],
+    )
+    fake_ctx = FakeContext(resolver=FakeResolver(results=[found]))
+    mock_iris_ctx.return_value = fake_ctx
+    monkeypatch.setenv("JAX_PROCESS_COUNT", "16")
+    monkeypatch.setenv("JAX_PROCESS_INDEX", "8")
+    monkeypatch.setenv("JAX_LOCAL_DEVICE_IDS", "0")
+
+    initialize_jax()
+
+    mock_jax_init.assert_called_once_with("10.0.0.9:8476", 16, 8, local_device_ids=[0])
+    assert fake_ctx.registry.registered == []
 
 
 @contextmanager

--- a/lib/iris/tests/test_multigpu.py
+++ b/lib/iris/tests/test_multigpu.py
@@ -1,0 +1,112 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the iris.runtime.multigpu in-task GPU process supervisor and the
+client-side entrypoint wrapping that drives it. None of this imports jax."""
+
+from __future__ import annotations
+
+import sys
+
+import pytest
+from iris.client.client import _wrap_entrypoint_for_multiprocess
+from iris.cluster.types import Entrypoint, ResourceSpec, gpu_device
+from iris.runtime.multigpu import _child_rank_env, run
+
+
+def _py(code: str) -> list[str]:
+    """A child command that runs `code` with this interpreter."""
+    return [sys.executable, "-c", code]
+
+
+def test_child_rank_env_global_rank_and_device_slice() -> None:
+    # task 1 of 3, 4 procs/task, 2 devices/proc, local rank 2:
+    # global rank = 1*4 + 2 = 6; world = 3*4 = 12; devices = [2*2, 2*2+1] = 4,5
+    env = _child_rank_env(local_rank=2, nproc=4, devices_per_proc=2, task_index=1, num_tasks=3)
+    assert env == {
+        "JAX_PROCESS_COUNT": "12",
+        "JAX_PROCESS_INDEX": "6",
+        "JAX_LOCAL_DEVICE_IDS": "4,5",
+    }
+
+
+def test_child_rank_env_one_device_per_proc() -> None:
+    env = _child_rank_env(local_rank=0, nproc=8, devices_per_proc=1, task_index=0, num_tasks=1)
+    assert env["JAX_PROCESS_COUNT"] == "8"
+    assert env["JAX_PROCESS_INDEX"] == "0"
+    assert env["JAX_LOCAL_DEVICE_IDS"] == "0"
+
+
+def test_run_all_children_succeed_returns_zero() -> None:
+    check = _py("import os; assert os.environ['JAX_PROCESS_COUNT'] == '3'")
+    assert run(nproc=3, devices_per_proc=1, child_argv=check) == 0
+
+
+def test_run_propagates_first_child_failure() -> None:
+    # The rank-1 child exits 7; siblings exit 0. The supervisor surfaces 7.
+    code = "import os,sys; sys.exit(7 if os.environ['JAX_PROCESS_INDEX']=='1' else 0)"
+    assert run(nproc=3, devices_per_proc=1, child_argv=_py(code)) == 7
+
+
+def test_run_terminates_peers_when_one_fails() -> None:
+    # Rank 0 fails immediately; the peers would otherwise sleep 30s. The
+    # supervisor must tear them down and return promptly with the failure code.
+    code = "import os,sys,time; sys.exit(3) if os.environ['JAX_PROCESS_INDEX']=='0' else time.sleep(30)"
+    assert run(nproc=3, devices_per_proc=1, child_argv=_py(code)) == 3
+
+
+def test_run_rejects_empty_command() -> None:
+    with pytest.raises(ValueError, match="no child command"):
+        run(nproc=2, devices_per_proc=1, child_argv=[])
+
+
+def _gpu_resources(count: int) -> ResourceSpec:
+    return ResourceSpec(cpu=4, memory="8GB", disk="16GB", device=gpu_device("H100", count))
+
+
+def test_wrap_entrypoint_one_process_per_gpu() -> None:
+    wrapped = _wrap_entrypoint_for_multiprocess(
+        Entrypoint.from_command("python", "train.py", "--steps", "10"), _gpu_resources(8), processes_per_task=8
+    )
+    assert wrapped.command == [
+        "python",
+        "-m",
+        "iris.runtime.multigpu",
+        "--nproc",
+        "8",
+        "--devices-per-proc",
+        "1",
+        "--",
+        "python",
+        "train.py",
+        "--steps",
+        "10",
+    ]
+
+
+def test_wrap_entrypoint_groups_devices_when_fewer_processes() -> None:
+    wrapped = _wrap_entrypoint_for_multiprocess(
+        Entrypoint.from_command("python", "train.py"), _gpu_resources(8), processes_per_task=4
+    )
+    assert wrapped.command[:8] == [
+        "python",
+        "-m",
+        "iris.runtime.multigpu",
+        "--nproc",
+        "4",
+        "--devices-per-proc",
+        "2",
+        "--",
+    ]
+
+
+def test_wrap_entrypoint_requires_gpu() -> None:
+    cpu_only = ResourceSpec(cpu=4, memory="8GB", disk="16GB", device=None)
+    with pytest.raises(ValueError, match="requires a GPU device"):
+        _wrap_entrypoint_for_multiprocess(Entrypoint.from_command("python", "x.py"), cpu_only, processes_per_task=2)
+
+
+def test_wrap_entrypoint_requires_divisible_gpu_count() -> None:
+    entry = Entrypoint.from_command("python", "x.py")
+    with pytest.raises(ValueError, match="must divide the GPU count"):
+        _wrap_entrypoint_for_multiprocess(entry, _gpu_resources(8), processes_per_task=3)

--- a/lib/iris/tests/test_multigpu.py
+++ b/lib/iris/tests/test_multigpu.py
@@ -6,14 +6,17 @@ client-side entrypoint wrapping that drives it. None of this imports jax."""
 
 from __future__ import annotations
 
+import signal
 import subprocess
 import sys
+import textwrap
 
 import pytest
 from iris.client.client import _wrap_entrypoint_for_multiprocess
 from iris.cluster.types import Entrypoint, ResourceSpec, gpu_device
 from iris.runtime import multigpu
 from iris.runtime.multigpu import run
+from rigging.timing import Duration
 
 
 def _py(code: str) -> list[str]:
@@ -43,7 +46,7 @@ def test_run_terminates_peers_when_one_fails() -> None:
 def test_run_sigkills_a_peer_that_ignores_sigterm(monkeypatch: pytest.MonkeyPatch) -> None:
     # Rank 0 fails; the peer traps SIGTERM and would sleep 30s. With escalation,
     # the supervisor SIGKILLs it after the grace period and still returns 3.
-    monkeypatch.setattr(multigpu, "_TERMINATE_GRACE", 0.5)
+    monkeypatch.setattr(multigpu, "_TERMINATE_GRACE", Duration.from_seconds(0.5))
     code = (
         "import os,sys,signal,time\n"
         "if os.environ['IRIS_MULTIGPU_PROCESS_INDEX']=='0': sys.exit(3)\n"
@@ -74,6 +77,37 @@ def test_spawn_failure_kills_already_started_children(monkeypatch: pytest.Monkey
     assert len(started) == 1
     # Killed by SIGKILL → returncode is the negative signal number, never 0.
     assert started[0].returncode is not None and started[0].returncode < 0
+
+
+def test_external_sigterm_returns_128_plus_signum() -> None:
+    # The supervisor itself is SIGTERMed (preemption/task termination). It
+    # forwards the signal to the children, which die reporting negative signal
+    # codes (-15). The supervisor must surface 128+SIGTERM (143) — the killed
+    # task — not map a child's -15 to an arbitrary failure code (241).
+    supervisor_src = textwrap.dedent(
+        """
+        import sys
+        from iris.runtime.multigpu import run
+        child = [sys.executable, "-c", "print('READY', flush=True); import time; time.sleep(30)"]
+        sys.exit(run(nproc=2, devices_per_proc=1, child_argv=child))
+        """
+    )
+    proc = subprocess.Popen(
+        [sys.executable, "-c", supervisor_src], stdout=subprocess.PIPE, stderr=subprocess.STDOUT, text=True
+    )
+    assert proc.stdout is not None
+    # Signal only once both children are live, so the forwarded SIGTERM is what
+    # ends them (rather than racing their startup).
+    ready = 0
+    for line in proc.stdout:
+        if "READY" in line:
+            ready += 1
+            if ready == 2:
+                break
+    assert ready == 2, "children did not start"
+    proc.send_signal(signal.SIGTERM)
+    proc.communicate(timeout=30)
+    assert proc.returncode == 128 + signal.SIGTERM
 
 
 def test_run_rejects_empty_command() -> None:

--- a/lib/iris/tests/test_multigpu.py
+++ b/lib/iris/tests/test_multigpu.py
@@ -13,7 +13,7 @@ import pytest
 from iris.client.client import _wrap_entrypoint_for_multiprocess
 from iris.cluster.types import Entrypoint, ResourceSpec, gpu_device
 from iris.runtime import multigpu
-from iris.runtime.multigpu import _child_rank_env, run
+from iris.runtime.multigpu import run
 
 
 def _py(code: str) -> list[str]:
@@ -21,25 +21,8 @@ def _py(code: str) -> list[str]:
     return [sys.executable, "-c", code]
 
 
-def test_child_rank_env_global_rank_and_device_slice() -> None:
-    # task 1 of 3, 4 procs/task, 2 devices/proc, local rank 2:
-    # global rank = 1*4 + 2 = 6; world = 3*4 = 12; devices = [2*2, 2*2+1] = 4,5
-    env = _child_rank_env(local_rank=2, nproc=4, devices_per_proc=2, task_index=1, num_tasks=3)
-    assert env == {
-        "IRIS_MULTIGPU_PROCESS_COUNT": "12",
-        "IRIS_MULTIGPU_PROCESS_INDEX": "6",
-        "IRIS_MULTIGPU_LOCAL_DEVICE_IDS": "4,5",
-    }
-
-
-def test_child_rank_env_one_device_per_proc() -> None:
-    env = _child_rank_env(local_rank=0, nproc=8, devices_per_proc=1, task_index=0, num_tasks=1)
-    assert env["IRIS_MULTIGPU_PROCESS_COUNT"] == "8"
-    assert env["IRIS_MULTIGPU_PROCESS_INDEX"] == "0"
-    assert env["IRIS_MULTIGPU_LOCAL_DEVICE_IDS"] == "0"
-
-
 def test_run_all_children_succeed_returns_zero() -> None:
+    # Each child sees the global world size the supervisor stamped on it.
     check = _py("import os; assert os.environ['IRIS_MULTIGPU_PROCESS_COUNT'] == '3'")
     assert run(nproc=3, devices_per_proc=1, child_argv=check) == 0
 

--- a/lib/iris/tests/test_multigpu.py
+++ b/lib/iris/tests/test_multigpu.py
@@ -6,11 +6,13 @@ client-side entrypoint wrapping that drives it. None of this imports jax."""
 
 from __future__ import annotations
 
+import subprocess
 import sys
 
 import pytest
 from iris.client.client import _wrap_entrypoint_for_multiprocess
 from iris.cluster.types import Entrypoint, ResourceSpec, gpu_device
+from iris.runtime import multigpu
 from iris.runtime.multigpu import _child_rank_env, run
 
 
@@ -24,35 +26,71 @@ def test_child_rank_env_global_rank_and_device_slice() -> None:
     # global rank = 1*4 + 2 = 6; world = 3*4 = 12; devices = [2*2, 2*2+1] = 4,5
     env = _child_rank_env(local_rank=2, nproc=4, devices_per_proc=2, task_index=1, num_tasks=3)
     assert env == {
-        "JAX_PROCESS_COUNT": "12",
-        "JAX_PROCESS_INDEX": "6",
-        "JAX_LOCAL_DEVICE_IDS": "4,5",
+        "IRIS_MULTIGPU_PROCESS_COUNT": "12",
+        "IRIS_MULTIGPU_PROCESS_INDEX": "6",
+        "IRIS_MULTIGPU_LOCAL_DEVICE_IDS": "4,5",
     }
 
 
 def test_child_rank_env_one_device_per_proc() -> None:
     env = _child_rank_env(local_rank=0, nproc=8, devices_per_proc=1, task_index=0, num_tasks=1)
-    assert env["JAX_PROCESS_COUNT"] == "8"
-    assert env["JAX_PROCESS_INDEX"] == "0"
-    assert env["JAX_LOCAL_DEVICE_IDS"] == "0"
+    assert env["IRIS_MULTIGPU_PROCESS_COUNT"] == "8"
+    assert env["IRIS_MULTIGPU_PROCESS_INDEX"] == "0"
+    assert env["IRIS_MULTIGPU_LOCAL_DEVICE_IDS"] == "0"
 
 
 def test_run_all_children_succeed_returns_zero() -> None:
-    check = _py("import os; assert os.environ['JAX_PROCESS_COUNT'] == '3'")
+    check = _py("import os; assert os.environ['IRIS_MULTIGPU_PROCESS_COUNT'] == '3'")
     assert run(nproc=3, devices_per_proc=1, child_argv=check) == 0
 
 
 def test_run_propagates_first_child_failure() -> None:
     # The rank-1 child exits 7; siblings exit 0. The supervisor surfaces 7.
-    code = "import os,sys; sys.exit(7 if os.environ['JAX_PROCESS_INDEX']=='1' else 0)"
+    code = "import os,sys; sys.exit(7 if os.environ['IRIS_MULTIGPU_PROCESS_INDEX']=='1' else 0)"
     assert run(nproc=3, devices_per_proc=1, child_argv=_py(code)) == 7
 
 
 def test_run_terminates_peers_when_one_fails() -> None:
     # Rank 0 fails immediately; the peers would otherwise sleep 30s. The
     # supervisor must tear them down and return promptly with the failure code.
-    code = "import os,sys,time; sys.exit(3) if os.environ['JAX_PROCESS_INDEX']=='0' else time.sleep(30)"
+    code = "import os,sys,time; sys.exit(3) if os.environ['IRIS_MULTIGPU_PROCESS_INDEX']=='0' else time.sleep(30)"
     assert run(nproc=3, devices_per_proc=1, child_argv=_py(code)) == 3
+
+
+def test_run_sigkills_a_peer_that_ignores_sigterm(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Rank 0 fails; the peer traps SIGTERM and would sleep 30s. With escalation,
+    # the supervisor SIGKILLs it after the grace period and still returns 3.
+    monkeypatch.setattr(multigpu, "_TERMINATE_GRACE", 0.5)
+    code = (
+        "import os,sys,signal,time\n"
+        "if os.environ['IRIS_MULTIGPU_PROCESS_INDEX']=='0': sys.exit(3)\n"
+        "signal.signal(signal.SIGTERM, signal.SIG_IGN)\n"
+        "time.sleep(30)\n"
+    )
+    assert run(nproc=2, devices_per_proc=1, child_argv=_py(code)) == 3
+
+
+def test_spawn_failure_kills_already_started_children(monkeypatch: pytest.MonkeyPatch) -> None:
+    # Rank 0 spawns; rank 1's Popen raises. The started rank-0 child must be
+    # killed (not orphaned) before the error propagates.
+    real_popen = subprocess.Popen
+    started: list[subprocess.Popen] = []
+    calls = {"n": 0}
+
+    def flaky_popen(*args, **kwargs):
+        calls["n"] += 1
+        if calls["n"] == 2:
+            raise OSError("simulated spawn failure")
+        proc = real_popen(*args, **kwargs)
+        started.append(proc)
+        return proc
+
+    monkeypatch.setattr(multigpu.subprocess, "Popen", flaky_popen)
+    with pytest.raises(OSError, match="simulated spawn failure"):
+        run(nproc=3, devices_per_proc=1, child_argv=_py("import time; time.sleep(30)"))
+    assert len(started) == 1
+    # Killed by SIGKILL → returncode is the negative signal number, never 0.
+    assert started[0].returncode is not None and started[0].returncode < 0
 
 
 def test_run_rejects_empty_command() -> None:


### PR DESCRIPTION
Fixes #6690

Adds `processes_per_task` to Iris GPU jobs: run **one JAX process per GPU**
(`process_count() == num_gpus`, the multi-controller model) instead of the
default one process per node (one task = one pod = N local devices,
`process_count() == 1`).

Motivated by #6690: some GPU kernels (DeepEP and other per-rank paths) need the
multi-controller layout. The naive way to get there — schedule eight 1-GPU pods
on one box — **loses intra-node NVLink P2P**, because a 1-GPU pod can't open a
CUDA-IPC handle to a sibling pod's GPU under the device plugin's exclusive
allocation. So instead this keeps all GPUs in **one pod** and fans out N
processes inside it, sharing the pod IPC namespace and `/dev/shm` so NCCL keeps
NVLink.

## How

- **`iris.runtime.multigpu`** — an in-task supervisor (the GPU analogue of
  `srun`/`torchrun` scoped to one host). `python -m iris.runtime.multigpu
  --nproc N --devices-per-proc D -- <argv>` spawns N children, each pinned to a
  contiguous device slice and stamped with `IRIS_MULTIGPU_PROCESS_COUNT` /
  `IRIS_MULTIGPU_PROCESS_INDEX` / `IRIS_MULTIGPU_LOCAL_DEVICE_IDS` (iris-private
  names, not the JAX_* namespace, so a job that already sets JAX rank vars never
  trips the supervised path). It forwards SIGINT/SIGTERM, escalates to SIGKILL
  after a grace period if a child traps it, tears the group down on any child
  failure (killing already-started ranks if a later spawn fails), and
  rank-prefixes child output. It does **not** import jax (children create their
  CUDA context only after spawn).
- **`initialize_jax`** — a supervised branch keyed on
  `IRIS_MULTIGPU_PROCESS_COUNT`. Coordinator discovery reuses the existing
  one-process-per-task endpoint dance, lifted from per-task to per-global-rank:
  global rank 0 registers its advertise address, host-0 peers reuse it directly
  (no registry round-trip), other hosts poll the registry.
- **`IrisClient.submit(processes_per_task=N)`** — wraps the entrypoint with the
  supervisor at the submit boundary (covers both the k8s and worker backends,
  which run the same `argv`). N must divide the GPU count. **N=1 is a strict
  no-op** (no wrapping at all), so this can roll out without touching any
  existing job.
- Threaded through the `iris job run` CLI (`--processes-per-task`), Fray
  `JobRequest`, and the grug/moe launcher (`SCALE_PROCESSES_PER_TASK`).

Also fixes a latent bug in `_poll_for_coordinator` surfaced by the multi-host
path: the endpoint registry reports an unregistered name by *raising* (Connect
`NOT_FOUND`, or `UNIMPLEMENTED` from controllers that answer a bare HTTP 404),
not by returning empty. The poll only handled the empty case, so a rank that
polled before rank 0 registered crashed instead of retrying. Now the
not-registered-yet/transient codes retry to the deadline; other errors
propagate. This hardens the pre-existing per-task multi-host path too.

## Validation on real 8xH100 (CoreWeave cw-us-east-02a)

- **Single-node, `processes_per_task=8` (gang JAX smoke):** `process_count=8`,
  one device/process; cross-process NCCL all-reduce over NVLink summed to the
  expected **36** (`1+…+8`); data-parallel loss decreased monotonically; job
  succeeded, all 8 ranks exit 0.
- **Multi-host, 4 nodes × `processes_per_task=8` = 32 proc (gang JAX smoke):**
  `process_count=32`, all 32 ranks present; cross-host NCCL all-reduce over
  **InfiniBand** summed to the expected **528** (`1+…+32`); `DONE` on every host;
  job succeeded. Exercises global rank 0 registering, other hosts polling +
  retrying, and the mesh spanning hosts.
- **Single-node grug MoE, `processes_per_task=8`:** the supervisor launched 8
  grug processes; all 8 ranks trained the tiny expert-parallel MoE
  (`expert_axis_size=8`) to completion (20/20 steps, loss 8.47), and the gang +
  coordinator both `succeeded`. Confirms the full path (Fray callable → levanter
  `trainer.initialize()` → `initialize_iris_jax` → supervised branch,
  `process_count=8` in logs) and expert-parallel collectives across 8 processes.
  - Note: a degenerate tiny config (`num_heads=4`) tripped a **pre-existing**
    levanter/grug sharding bug (`DuplicateSpecError` on the `model` axis during
    compile) that is **independent of this feature** — a `processes_per_task=1`
    run (normal single-controller, wrapping a no-op) hits the identical error.
    `num_heads=8` compiles and trains fine.
