### PR TITLE
[iris] Fix log sort window for custom start date + add UTC/local toggle

### DIFF
--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -65,6 +65,12 @@ const matchScope = ref<MatchScope>('EXACT')
 const presetMs = ref(0)
 const customSince = ref('')
 
+// Timezone for rendering log timestamps and interpreting the date picker.
+// Stored timestamps are UTC epoch ms regardless; 'local' shows the browser's
+// zone (default), 'utc' lines the prefix up with the UTC timestamps processes
+// embed in their raw log lines.
+const timeZone = ref<'local' | 'utc'>('local')
+
 const entries = ref<LogEntry[]>([])
 const loading = ref(false)
 const errorMsg = ref<string | null>(null)
@@ -104,12 +110,24 @@ function applyDefaults() {
   resetAndFetch()
 }
 
+// A `datetime-local` value (e.g. "2026-06-30T02:08") carries no timezone, so
+// interpret it in the panel's selected zone. This keeps the lower bound aligned
+// with the timestamps the panel renders instead of silently assuming local.
+function parseDateTimeLocal(value: string): number {
+  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?/)
+  if (!m) return NaN
+  const [year, month, day, hour, minute, second] = m.slice(1).map((p) => Number(p ?? 0))
+  return timeZone.value === 'utc'
+    ? Date.UTC(year, month - 1, day, hour, minute, second)
+    : new Date(year, month - 1, day, hour, minute, second).getTime()
+}
+
 // Resolve the lower time bound at request time. A relative preset must be
 // recomputed on every fetch (including auto-refresh polls) so the window stays
 // anchored to "now", not to when the preset was first selected.
 function computeSinceMs(): number | undefined {
   if (customSince.value) {
-    const ms = Date.parse(customSince.value)
+    const ms = parseDateTimeLocal(customSince.value)
     return Number.isNaN(ms) ? undefined : ms
   }
   return presetMs.value > 0 ? Date.now() - presetMs.value : undefined
@@ -138,10 +156,13 @@ async function fetchTail() {
   loading.value = true
   errorMsg.value = null
   try {
+    // An explicit start date means "read forward from here": fetch the first
+    // maxLines entries at/after sinceMs (oldest-first). Relative presets and the
+    // default view stay anchored to now, so they tail the newest maxLines.
     const resp = await logServiceRpcCall<FetchLogsResponse>('FetchLogs', {
       ...baseRequest(),
       maxLines: tailLines.value || undefined,
-      tail: true,
+      tail: !customSince.value,
     })
     if (gen !== generation) return
     entries.value = resp.entries ?? []
@@ -215,6 +236,11 @@ watch(selectedAttemptId, applyDefaults)
 watch(tailLines, resetAndFetch)
 watch(level, resetAndFetch)
 watch([presetMs, customSince], resetAndFetch)
+// Changing the zone only alters the query when an absolute date is in effect
+// (it reinterprets the picker); otherwise it just re-renders timestamps.
+watch(timeZone, () => {
+  if (customSince.value) resetAndFetch()
+})
 
 function selectPreset(ms: number) {
   // The synthetic "Custom" option (-1) only appears while an absolute time is
@@ -381,6 +407,14 @@ defineExpose({ selectedAttemptId })
         class="px-2 py-1.5 border border-surface-border rounded text-sm"
       />
       <select
+        v-model="timeZone"
+        title="Timezone for displayed timestamps and the date picker"
+        class="px-2 py-1.5 border border-surface-border rounded text-sm"
+      >
+        <option value="local">Local</option>
+        <option value="utc">UTC</option>
+      </select>
+      <select
         v-model.number="tailLines"
         class="px-2 py-1.5 border border-surface-border rounded text-sm"
       >
@@ -440,7 +474,7 @@ defineExpose({ selectedAttemptId })
         >
           T{{ row.taskRef.taskIndex }}
         </RouterLink>
-        <span class="text-text-muted mr-2">{{ formatLogTime(timestampMs(row.entry.timestamp)) }}</span>
+        <span class="text-text-muted mr-2">{{ formatLogTime(timestampMs(row.entry.timestamp), timeZone === 'utc') }}</span>
         <span class="whitespace-pre-wrap break-all"><template
           v-for="(seg, j) in row.segments"
           :key="j"

--- a/lib/iris/dashboard/src/utils/formatting.ts
+++ b/lib/iris/dashboard/src/utils/formatting.ts
@@ -63,14 +63,18 @@ export function formatDuration(startMs: number, endMs?: number): string {
   return `${hours}h ${mins}m`
 }
 
-/** Format epoch ms as "HH:MM:SS.mmm". */
-export function formatLogTime(epochMs: number): string {
+/**
+ * Format epoch ms as "HH:MM:SS.mmm" in the browser's local zone, or in UTC when
+ * `utc` is set. UTC matches the timestamps most processes embed in their raw log
+ * lines, so the rendered prefix lines up with the line text.
+ */
+export function formatLogTime(epochMs: number, utc = false): string {
   if (!epochMs) return ''
   const d = new Date(epochMs)
-  const hh = String(d.getHours()).padStart(2, '0')
-  const mm = String(d.getMinutes()).padStart(2, '0')
-  const ss = String(d.getSeconds()).padStart(2, '0')
-  const ms = String(d.getMilliseconds()).padStart(3, '0')
+  const hh = String(utc ? d.getUTCHours() : d.getHours()).padStart(2, '0')
+  const mm = String(utc ? d.getUTCMinutes() : d.getMinutes()).padStart(2, '0')
+  const ss = String(utc ? d.getUTCSeconds() : d.getSeconds()).padStart(2, '0')
+  const ms = String(utc ? d.getUTCMilliseconds() : d.getMilliseconds()).padStart(3, '0')
   return `${hh}:${mm}:${ss}.${ms}`
 }
 


### PR DESCRIPTION
## Problem

Two confusing behaviors in the dashboard **Controller Logs** panel (`LogViewer.vue`), reported via the screenshot in weaver #332:

1. **Sort window ignores an explicit start date.** Setting a `Custom` start date (e.g. `06/28 01:42 PM`) still showed the *most recent* N lines (`06/30`), not logs *since* the chosen date. The panel always sent `tail: true`, so finelog returned the newest N entries that satisfy `epoch_ms > since_ms`; the date only moved the lower bound, never the window. When there are more than N matching lines you get the tail, never the head.

2. **Timestamp timezone mismatch.** Each line's rendered prefix used the browser's **local** zone (`02:08:58.902`) while the raw log line embeds **UTC** (`2026-06-30 06:08:58,902`) — a constant offset apart, which reads as a glitch. The `datetime-local` picker was parsed as local with no way to say otherwise.

## Fix

**Sort window** — when a `Custom` start date is in effect, fetch forward from it (`tail: false`), so the panel shows the first N entries at/after that time, oldest-first ("logs since that date"). Relative presets (`Last 1h`, …) and the default view still tail the newest N. One-line change to the request plus a comment; finelog already does `ORDER BY seq ASC LIMIT N` over `epoch_ms > since_ms` when `tail` is false.

**Timezone** — add a **Local / UTC** selector that drives both:
- how the per-line timestamp prefix is rendered (`formatLogTime` gains a `utc` flag), and
- how the timezone-less `datetime-local` picker value is interpreted (`parseDateTimeLocal`), so the lower bound stays aligned with the displayed times.

Stored timestamps remain UTC epoch ms — this is purely presentation. Defaults to **Local** (the user's zone, as requested); switching to **UTC** makes the prefix line up exactly with the UTC text in raw log lines.

## Verification

- `npx vue-tsc --noEmit` — clean; `npm run build` — succeeds.
- `./infra/pre-commit.py --review` — no findings.
- Verified the tz parse/format logic across `America/New_York`, `UTC`, `Asia/Tokyo`: a UTC epoch of `06:08:58.902Z` renders `02:08:58.902` in EDT-local and `06:08:58.902` in UTC (reproducing the screenshot), and the picker round-trips correctly in both zones.

The new selector sits in the existing wrapping filter row; `WorkerDetail.vue`'s static daemon-log view is unaffected (`formatLogTime`'s new arg defaults to local).

🤖 Generated with [Claude Code](https://claude.com/claude-code)