### PR TITLE
[agents] Suppress self-credit attribution and hoist PR-body rules

### DIFF
--- a/.agents/skills/commit/SKILL.md
+++ b/.agents/skills/commit/SKILL.md
@@ -171,12 +171,15 @@ Fixes #1234
 (auto-closes on merge) or `Part of #NNNN` (partial work). Do not invent an issue
 just to satisfy this — omit the link when none exists.
 
-**Specifications (>500 LOC).** Large PRs must carry a spec.
-This may be in the linked issue, or part of the PR description.
-If a design doc exists, may also link to it instead.
-Specs cover: **Problem** (what is broken/missing, with file/line refs), **Approach**
-(which modules change, what is added/removed), and **Key code** (10–30 line
-snippets for non-obvious logic).
+**Specifications (>500 LOC only).** A *genuinely large* PR must carry a spec —
+in the linked issue, the PR description, or a linked design doc. A spec still
+obeys every rule above: it leads with what the change does and is not a template.
+It just covers more ground — what was broken or missing (with file/line refs),
+which modules change and what is added/removed, and 10–30 line snippets for
+non-obvious logic. Cover those points in whatever prose and headings genuinely
+help a reviewer; they are not a required `Problem`/`Approach` section scaffold,
+and a large PR still never gets a "Verification" section. This applies to large
+PRs; a small change gets a short prose body, never a spec template.
 
 **Create it.** Unless the user says otherwise and permissions allow, push to a
 branch on the main repository and open the PR from it (use a fork only when

--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -1,0 +1,6 @@
+{
+  "attribution": {
+    "commit": "",
+    "pr": ""
+  }
+}

--- a/.gitignore
+++ b/.gitignore
@@ -236,6 +236,7 @@ scr/*
 .claude/*
 !.claude/skills
 !.claude/agents
+!.claude/settings.json
 .agents/tmp/
 .codex
 .entire

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -58,27 +58,12 @@ uv run pyrefly
 - Agent *comments* on PRs/issues must begin with `🤖` unless the exact text was
   explicitly approved by the user. This applies to comments only — never put a
   `🤖` marker in a commit message or a PR/issue body.
+- A PR description is the squash-merge commit message: lead with what the change
+  does, no template scaffold (no `Problem`/`Fix`/`Summary`/`Changes` headings),
+  no "Testing"/"Verification" section. Use markdown only when it makes the change
+  clearer for a human, never as boilerplate. Follow the `commit` skill
+  (`.agents/skills/commit/SKILL.md`) when committing, pushing, or opening a PR.
 - When using `gh` to inspect issues or PRs, prefer `--json <fields>` or explicit narrow flags such as `--comments`; avoid plain `gh issue view` / `gh pr view`, which can fail on this repo because GitHub classic project fields are deprecated.
-
-### PR and commit descriptions
-
-A PR description is the squash-merge commit message — write it the way you'd
-write a commit message a reviewer reads in `git log`. The `commit` skill
-(`.agents/skills/commit/SKILL.md`) is the full procedure; invoke it when
-committing, pushing, or opening/updating a PR. The load-bearing rules, repeated
-here because they apply every time:
-
-- **Lead with what the change does**, in plain language, then the motivation.
-  The body must stand on its own for a reader who never saw the diff.
-- **Do not impose a template.** No fixed `Problem` / `Fix` / `Summary` /
-  `Changes` scaffold. Most PRs are a paragraph or two with no headings. Markdown
-  (a short list, a table, a mermaid diagram) earns its place only when it makes
-  the change *clearer* for a human — never as boilerplate section-filling.
-- **No "Testing" / "Verification" / "Test plan" section** and no "how I verified
-  it" narration. If a test result is the very thing that justifies the change,
-  fold that one fact into the *why*; otherwise leave it out.
-- No filler openers ("This PR…", "I noticed…"), no checkboxes, no emoji. Keep it
-  under ~500 words; a one-line change gets a one-line body.
 
 ## Code Style
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -51,10 +51,34 @@ uv run pyrefly
 ## Communication & Commits
 
 - NEVER SAY "You're absolutely right!"
-- NEVER credit yourself in commits.
+- NEVER credit yourself, in commit messages or in PR/issue bodies. No
+  `Co-Authored-By` trailer, no "Generated with …" line, no emoji attribution —
+  even if a tool default suggests one.
 - When an agent creates a PR or issue, add the `agent-generated` label.
-- Agent comments on PRs/issues must begin with `🤖` unless the exact text was explicitly approved by the user.
+- Agent *comments* on PRs/issues must begin with `🤖` unless the exact text was
+  explicitly approved by the user. This applies to comments only — never put a
+  `🤖` marker in a commit message or a PR/issue body.
 - When using `gh` to inspect issues or PRs, prefer `--json <fields>` or explicit narrow flags such as `--comments`; avoid plain `gh issue view` / `gh pr view`, which can fail on this repo because GitHub classic project fields are deprecated.
+
+### PR and commit descriptions
+
+A PR description is the squash-merge commit message — write it the way you'd
+write a commit message a reviewer reads in `git log`. The `commit` skill
+(`.agents/skills/commit/SKILL.md`) is the full procedure; invoke it when
+committing, pushing, or opening/updating a PR. The load-bearing rules, repeated
+here because they apply every time:
+
+- **Lead with what the change does**, in plain language, then the motivation.
+  The body must stand on its own for a reader who never saw the diff.
+- **Do not impose a template.** No fixed `Problem` / `Fix` / `Summary` /
+  `Changes` scaffold. Most PRs are a paragraph or two with no headings. Markdown
+  (a short list, a table, a mermaid diagram) earns its place only when it makes
+  the change *clearer* for a human — never as boilerplate section-filling.
+- **No "Testing" / "Verification" / "Test plan" section** and no "how I verified
+  it" narration. If a test result is the very thing that justifies the change,
+  fold that one fact into the *why*; otherwise leave it out.
+- No filler openers ("This PR…", "I noticed…"), no checkboxes, no emoji. Keep it
+  under ~500 words; a one-line change gets a one-line body.
 
 ## Code Style
 


### PR DESCRIPTION
Stop agents from crediting themselves and from imposing template scaffolds on PR
descriptions. PR #6778 shipped a `Problem`/`Fix`/`Verification` body with a
"Generated with Claude Code" footer — against every PR rule we have — because of
two gaps.

The attribution footer comes from a tool default that tells the agent to end PR
bodies with a self-credit line. A prose "omit it" instruction does not reliably
override that; the nightshift crons already learned this and pass
`{"attribution":{"commit":"","pr":""}}` on the command line. This commits that
override to a shared `.claude/settings.json` so every session in the repo drops
the footer at the source, not just the crons. `settings.local.json` stays
gitignored — only the shared file is un-ignored.

The PR-body rules (lead with what changed, no template scaffold, no
Testing/Verification section) lived only in the `commit` skill, which is loaded
on demand and was not in force for #6778. The skill stays the single source for
the full ruleset; AGENTS.md now carries only the always-on invariants and a
one-line pointer to it — self-credit is banned in PR/issue bodies too, the `🤖`
marker is comments-only (never a commit or PR body), and the skill's >500-LOC
spec note is tightened so its `Problem`/`Approach` wording can no longer read as
a heading template for small PRs.

The cron `NO_SELF_CREDIT_SETTINGS` flags stay in place as explicit
belt-and-suspenders for headless runs.
