### PR TITLE
[ci] standardize test configuration and resolve pytest namespace collisions

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -8,12 +8,12 @@ This directory contains thin trigger YAML around behavior implemented in `script
 | --- | --- | --- | --- | --- | --- |
 | `dupekit-release-wheels.yaml` | Dupekit - Release Wheels | PR + push to main + workflow_dispatch | release | dupekit | see job steps |
 | `dupekit-unit.yaml` | Dupekit - Unit | PR + push to main | unit | dupekit | `cd lib/dupekit && uv run --frozen --group test pytest tests/ -v` |
-| `fray-unit.yaml` | Fray - Unit | PR + push to main | unit | fray | `cd lib/fray && uv run --group=fray-test pytest --durations=5 --tb=short -m 'not slow and not tpu_ci' -v -s tests/` |
-| `haliax-unit.yaml` | Haliax - Unit | PR + push to main | unit | haliax | `JAX_NUM_CPU_DEVICES=8 uv run --package marin-haliax pytest -c pyproject.toml tests` |
+| `fray-unit.yaml` | Fray - Unit | PR + push to main | unit | fray | `cd lib/fray && uv run --group=test pytest --durations=5 --tb=short -m 'not slow and not tpu_ci' -v -s tests/` |
+| `haliax-unit.yaml` | Haliax - Unit | PR + push to main | unit | haliax | `JAX_NUM_CPU_DEVICES=8 uv run --package marin-haliax pytest tests` |
 | `iris-dev-restart.yaml` | Iris - Dev Restart | schedule (daily) + workflow_dispatch | ops | iris | see job steps |
 | `iris-smoke-coreweave.yaml` | Iris - Smoke - CoreWeave | PR + issue_comment + workflow_dispatch | smoke | iris | see job steps |
 | `iris-smoke-gcp.yaml` | Iris - Smoke - GCP | PR + issue_comment + workflow_dispatch | smoke | iris | see job steps |
-| `iris-unit.yaml` | Iris - Unit | PR + push to main | unit | iris | `cd lib/iris && uv run --group dev python -m pytest -n1 --durations=5 --tb=short -m 'not slow and not docker and not requires_cluster' tests/` |
+| `iris-unit.yaml` | Iris - Unit | PR + push to main | unit | iris | `cd lib/iris && uv run --group test python -m pytest -n auto --durations=5 --tb=short -m 'not slow and not docker and not requires_cluster' tests/` |
 | `levanter-dev-launch-small-fast.yaml` | Levanter - Dev - Launch Small Fast | workflow_dispatch | dev | levanter | see job steps |
 | `levanter-integration-gpt2-small.yaml` | Levanter - Integration - GPT-2 Small | workflow_dispatch | integration | levanter | see job steps |
 | `levanter-unit.yaml` | Levanter - Unit | PR + push to main | unit | levanter | `uv run --package marin-levanter --frozen --with "jax[cpu]==0.9.2" pytest tests -m "not slow and not torch"` |

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -2,43 +2,6 @@
 
 This directory contains thin trigger YAML around behavior implemented in `scripts/ci/`. See the design at `.agents/projects/workflow_scripts/design.md` and contracts at `.agents/projects/workflow_scripts/spec.md`.
 
-## Inventory
-
-| File | Workflow Name | Trigger | Gate Type | Owner Domain | Local Reproduction |
-| --- | --- | --- | --- | --- | --- |
-| `dupekit-release-wheels.yaml` | Dupekit - Release Wheels | PR + push to main + workflow_dispatch | release | dupekit | see job steps |
-| `dupekit-unit.yaml` | Dupekit - Unit | PR + push to main | unit | dupekit | `cd lib/dupekit && uv run --frozen --group test pytest tests/ -v` |
-| `fray-unit.yaml` | Fray - Unit | PR + push to main | unit | fray | `cd lib/fray && uv run --group=test pytest --durations=5 --tb=short -m 'not slow and not tpu_ci' -v -s tests/` |
-| `haliax-unit.yaml` | Haliax - Unit | PR + push to main | unit | haliax | `JAX_NUM_CPU_DEVICES=8 uv run --package marin-haliax pytest tests` |
-| `iris-dev-restart.yaml` | Iris - Dev Restart | schedule (daily) + workflow_dispatch | ops | iris | see job steps |
-| `iris-smoke-coreweave.yaml` | Iris - Smoke - CoreWeave | PR + issue_comment + workflow_dispatch | smoke | iris | see job steps |
-| `iris-smoke-gcp.yaml` | Iris - Smoke - GCP | PR + issue_comment + workflow_dispatch | smoke | iris | see job steps |
-| `iris-unit.yaml` | Iris - Unit | PR + push to main | unit | iris | `cd lib/iris && uv run --group test python -m pytest -n auto --durations=5 --tb=short -m 'not slow and not docker and not requires_cluster' tests/` |
-| `levanter-dev-launch-small-fast.yaml` | Levanter - Dev - Launch Small Fast | workflow_dispatch | dev | levanter | see job steps |
-| `levanter-integration-gpt2-small.yaml` | Levanter - Integration - GPT-2 Small | workflow_dispatch | integration | levanter | see job steps |
-| `levanter-unit.yaml` | Levanter - Unit | PR + push to main | unit | levanter | `uv run --package marin-levanter --frozen --with "jax[cpu]==0.9.2" pytest tests -m "not slow and not torch"` |
-| `marin-canary-datakit-nemotron.yaml` | Marin - Canary - Datakit Nemotron | schedule + workflow_dispatch | canary | marin | see job steps |
-| `marin-canary-ferry-coreweave.yaml` | Marin - Canary Ferry - CoreWeave | schedule + workflow_dispatch | canary | marin | see job steps |
-| `marin-canary-ferry.yaml` | Marin - Canary Ferry | schedule + workflow_dispatch | canary | marin | see job steps |
-| `marin-docs.yaml` | Marin - Docs | PR + push to main | docs | marin | `uv run python infra/check_docs_source_links.py` |
-| `marin-integration.yaml` | Marin - Integration | PR + push to main + workflow_dispatch | integration | marin | `uv run pytest tests/integration/iris/` |
-| `marin-lint.yaml` | Marin - Lint | PR + push to main | lint | marin | `./infra/pre-commit.py --all-files` |
-| `marin-release-libs-wheels.yaml` | Marin - Release Libs Wheels | PR + tag push + schedule + workflow_dispatch | release | marin | see job steps |
-| `marin-smoke-datakit.yaml` | Marin - Smoke - Datakit | schedule + workflow_dispatch | smoke | marin | see job steps |
-| `marin-unit.yaml` | Marin - Unit | PR + push to main | unit | marin | `uv run --package marin-core --extra cpu --frozen pytest -n 4 --dist=worksteal --durations=5 --tb=short -m 'not slow and not tpu_ci and not integration' -v tests/` |
-| `ops-claude-review.yaml` | Ops - Claude Review | PR + issue_comment | ops | claude | see job steps |
-| `ops-claude.yaml` | Ops - Claude | issue_comment + issues | ops | claude | see job steps |
-| `ops-codeql.yaml` | Ops - CodeQL | PR + push to main + schedule | ops | ops | see job steps |
-| `ops-docker-images.yaml` | Ops - Docker Images | schedule (weekly) + workflow_dispatch | ops | ops | see job steps |
-| `ops-grug-variant-diff.yaml` | Ops - Grug Variant Diff | PR | ops | ops | see job steps |
-| `ops-infra-dashboard.yaml` | Ops - Infra Dashboard | PR + push to main | ops | ops | see job steps |
-| `ops-nightshift-ci-tests.yaml` | Ops - Nightshift CI Tests | schedule + workflow_dispatch | integration | ops | see job steps |
-| `ops-nightshift-cleanup.yaml` | Ops - Nightshift Cleanup | schedule + workflow_dispatch | ops | ops | see job steps |
-| `ops-nightshift-doc-drift.yaml` | Ops - Nightshift Doc Drift | schedule + workflow_dispatch | docs | ops | see job steps |
-| `ops-stale.yaml` | Ops - Stale | schedule + workflow_dispatch | ops | ops | see job steps |
-| `zephyr-integration-shuffle.yaml` | Zephyr - Integration - Shuffle | workflow_dispatch | integration | zephyr | see job steps |
-| `zephyr-unit.yaml` | Zephyr - Unit | PR + push to main | unit | zephyr | `uv run --package marin-zephyr --frozen pytest --durations=5 --tb=short -m 'not slow and not tpu_ci' -v lib/zephyr/tests/` |
-
 ## Canonical recipe: open or update a bot PR with `git + gh`
 
 This recipe replaces `peter-evans/create-pull-request@v7`. It creates the PR if missing, updates it (force-with-lease) if present, reconciles labels, and writes `pr_url` and `pr_created` to `$GITHUB_OUTPUT`.
@@ -96,11 +59,15 @@ echo "pr_url=$PR_URL" >>"$GITHUB_OUTPUT"
 echo "pr_created=true" >>"$GITHUB_OUTPUT"
 ```
 
+
+
 ### Three details that bit v1
 
 - **URL capture.** `gh pr create` writes a human banner before the URL on non-TTY runners; capture from `gh pr view --json url` (or `gh pr list --json url`) instead of parsing `gh pr create` stdout.
-- **Stale branch + `--force-with-lease`.** `git checkout -B` against `HEAD` with no knowledge of `origin/$BRANCH` yields an empty lease, and the push will be rejected. Always `git fetch` the branch first and reset onto it when present, then re-apply the build-step edits before staging.
+- **Stale branch +** `--force-with-lease`**.** `git checkout -B` against `HEAD` with no knowledge of `origin/$BRANCH` yields an empty lease, and the push will be rejected. Always `git fetch` the branch first and reset onto it when present, then re-apply the build-step edits before staging.
 - **Label semantics.** `gh pr edit --add-label` accumulates; peter-evans `labels:` replaced. The reconcile loop above expresses replace-semantics explicitly. If callers want accumulate-only, they should set `DESIRED_LABELS` to the union and skip the second loop.
+
+
 
 ### `gh` token and permissions notes
 

--- a/.github/workflows/dupekit-unit.yaml
+++ b/.github/workflows/dupekit-unit.yaml
@@ -89,7 +89,7 @@ jobs:
 
       - name: Test dupekit
         run: |
-          cd lib/dupekit && uv run --frozen --group test pytest tests/ -v
+          uv run --directory lib/dupekit --frozen --group test pytest -v tests/
 
   rust-checks:
     needs: changes

--- a/.github/workflows/fray-unit.yaml
+++ b/.github/workflows/fray-unit.yaml
@@ -53,5 +53,5 @@ jobs:
 
       - name: Test fray
         run: |
-          cd lib/fray && uv run --group=fray-test pytest --durations=5 --tb=short -m 'not slow and not tpu_ci' -v -s tests/
+          uv run --package marin-fray --group=test pytest --durations=5 --tb=short -v -s lib/fray/tests/
 

--- a/.github/workflows/haliax-unit.yaml
+++ b/.github/workflows/haliax-unit.yaml
@@ -51,8 +51,7 @@ jobs:
       - name: Install dependencies
         run: |
           python -m pip install uv
-          uv sync --package marin-haliax --dev
-      - name: Test with pytest (JAX 0.9.2)
+          uv sync --package marin-haliax --group test
+      - name: Test with pytest
         run: |
-          # Test with specific JAX version
-          JAX_NUM_CPU_DEVICES=8 PYTHONPATH=tests:src:. uv run --package marin-haliax --with "jax[cpu]==0.9.2" pytest -c pyproject.toml tests
+          uv run --package marin-haliax pytest tests

--- a/.github/workflows/iris-unit.yaml
+++ b/.github/workflows/iris-unit.yaml
@@ -60,7 +60,7 @@ jobs:
         env:
           PYTHONASYNCIODEBUG: "1"
         run: |
-          cd lib/iris && uv run --group dev python -m pytest -n1 --durations=5 --tb=short -m 'not slow and not docker and not requires_cluster' tests/
+          uv run --package marin-iris --frozen --group test pytest --durations=5 --tb=short lib/iris/tests/
 
   iris-e2e-smoke:
     needs: changes
@@ -106,7 +106,7 @@ jobs:
         # have, so a warm cache stays fast, while a partial or stale cache self-heals
         # instead of leaving a missing browser binary. `--with-deps` reinstalls the system
         # libraries that the browser cache cannot hold.
-        run: cd lib/iris && uv run playwright install --with-deps chromium
+        run: uv run --package marin-iris playwright install --with-deps chromium
 
       - name: Run E2E smoke tests
         env:
@@ -114,8 +114,8 @@ jobs:
           PYTHONASYNCIODEBUG: "1"
         run: |
           mkdir -p ${{ github.workspace }}/iris-screenshots
-          cd lib/iris && uv run --group dev python -m pytest \
-            tests/e2e/test_smoke.py \
+          uv run --package marin-iris --frozen --group test pytest \
+            lib/iris/tests/e2e/test_smoke.py \
             -m requires_cluster -o "addopts=" --tb=short -v
 
       - name: Verify screenshots with Claude

--- a/.github/workflows/levanter-unit.yaml
+++ b/.github/workflows/levanter-unit.yaml
@@ -60,7 +60,7 @@ jobs:
       - name: Test with pytest
         run: |
           # Test with specific JAX version, excluding TPU tests
-          PYTHONPATH=tests:src:. uv run --package marin-levanter --frozen --with "jax[cpu]==0.9.2" pytest tests -m "not slow and not torch" --durations=20
+          uv run --package marin-levanter --frozen pytest tests --durations=20
 
   levanter-torch:
     needs: changes
@@ -125,8 +125,8 @@ jobs:
       - name: Test torch-marked suite
         run: |
           # run directly on CPU to avoid GPU dependency issues
-          CUDA_VISIBLE_DEVICES="" PYTHONPATH=tests:src:. ../../.venv/bin/python -m pytest tests -m "torch" --durations=20
-#          CUDA_VISIBLE_DEVICES="" PYTHONPATH=tests:src:. uv run --package levanter --frozen --extra torch_test pytest tests -m "torch" --durations=20
+          CUDA_VISIBLE_DEVICES="" ../../.venv/bin/python -m pytest tests -m "torch" --durations=20
+#          CUDA_VISIBLE_DEVICES="" uv run --package levanter --frozen --extra torch_test pytest tests -m "torch" --durations=20
 
   levanter-tpu-tests:
     needs: changes
@@ -189,7 +189,6 @@ jobs:
               timeout --kill-after=5 --signal=TERM 890 \
               uv run --package marin-levanter --frozen --group test --extra tpu \
               pytest -n 0 lib/levanter/tests \
-              -m 'not slow and not torch' \
               --ignore=lib/levanter/tests/test_audio.py \
               --ignore=lib/levanter/tests/test_new_cache.py \
               --ignore=lib/levanter/tests/test_hf_checkpoints.py \

--- a/.github/workflows/marin-unit.yaml
+++ b/.github/workflows/marin-unit.yaml
@@ -67,8 +67,6 @@ jobs:
       - name: Test with pytest
         env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          # Avoid Ray propagating `uv run` to workers (can trigger slow per-worker venv setup in CI).
-          RAY_ENABLE_UV_RUN_RUNTIME_ENV: "0"
         run: |
           # Ensure we select the CPU torch wheels (and JAX CPU) for unit tests on GitHub runners.
-          PYTHONPATH=tests:. uv run --package marin-core --extra cpu --frozen pytest -n 4 --dist=worksteal --durations=5 --tb=short -m 'not slow and not tpu_ci and not integration and not data_integration' -v tests/
+          uv run --package marin-core --extra cpu --frozen pytest -n 4 --dist=worksteal --durations=5 --tb=short -v tests/

--- a/.github/workflows/zephyr-unit.yaml
+++ b/.github/workflows/zephyr-unit.yaml
@@ -64,5 +64,4 @@ jobs:
 
       - name: Test with pytest
         run: |
-          # important: don't cd into lib/zephyr so that ray uv integration doesn't freak out
-          uv run --package marin-zephyr --frozen pytest --durations=5 --tb=short -m 'not slow and not tpu_ci' -v lib/zephyr/tests/
+          uv run --package marin-zephyr --frozen pytest --durations=5 --tb=short -v lib/zephyr/tests/

--- a/lib/dupekit/pyproject.toml
+++ b/lib/dupekit/pyproject.toml
@@ -56,3 +56,6 @@ benchmark = [
     "pytest-benchmark>=5.2.3",
     "pytest-memray>=1.8.0"
 ]
+
+[tool.pytest.ini_options]
+pythonpath = ["src", "tests"]

--- a/lib/finelog/pyproject.toml
+++ b/lib/finelog/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
 finelog = "finelog.deploy.cli:cli"
 
 [dependency-groups]
-dev = [
+test = [
     # The native in-process server ext (module `finelog_server`) is NOT a
     # runtime dependency of the pure client — only the embedded-server smoke
     # test and the dashboard demo need it. It ships as the companion
@@ -39,6 +39,7 @@ dev = [
     "pytest-timeout",
     "pytest-xdist",
 ]
+dev = [{ include-group = "test" }]
 
 # Without an explicit list the sdist sweeps the whole directory — including
 # dashboard/node_modules and the rust/ tree, which ship separately.
@@ -62,7 +63,8 @@ packages = ["src/finelog"]
 [tool.pytest.ini_options]
 timeout = 10
 timeout_method = "thread"
-addopts = "-n auto --durations=25 -v"
+addopts = "-n auto --durations=25 -v --import-mode=importlib"
+pythonpath = ["src", "tests"]
 filterwarnings = ["ignore::DeprecationWarning"]
 log_level = "INFO"
 log_format = "%(asctime)s %(levelname)s %(message)s"

--- a/lib/finelog/tests/__init__.py
+++ b/lib/finelog/tests/__init__.py
@@ -1,2 +1,0 @@
-# Copyright The Marin Authors
-# SPDX-License-Identifier: Apache-2.0

--- a/lib/fray/pyproject.toml
+++ b/lib/fray/pyproject.toml
@@ -13,13 +13,17 @@ dependencies = [
 ]
 
 [dependency-groups]
-fray_test = [
+test = [
     "pytest-timeout",
     "pytest>=8.3.2",
 ]
-fray_tpu_test = ["jax==0.10.0", "jaxlib==0.10.0", "libtpu==0.0.40", { include-group = "fray_test" }]
+fray_tpu_test = ["jax==0.10.0", "jaxlib==0.10.0", "libtpu==0.0.40", { include-group = "test" }]
 
-dev = [{ include-group = "fray_test" }]
+dev = [{ include-group = "test" }]
+
+[tool.pytest.ini_options]
+addopts = "-m 'not slow and not tpu_ci' --import-mode=importlib"
+pythonpath = ["src", "tests"]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/fray"]

--- a/lib/haliax/pyproject.toml
+++ b/lib/haliax/pyproject.toml
@@ -21,7 +21,7 @@ classifiers = [
     "Intended Audience :: Science/Research",
 ]
 dependencies = [
-     "jax >= 0.8.0",
+    "jax >= 0.9.2",
     "equinox>=0.10.6",
     "jaxtyping>=0.2.20",
     "jmp>=0.0.4",
@@ -32,8 +32,14 @@ dynamic =[ "version" ]
 
 
 [dependency-groups]
-dev = [
+test = [
     "pytest >= 7.4.0",
+    "pytest-xdist",
+    "chex>=0.1.86",
+    "safetensors>=0.4.3",
+]
+dev = [
+    { include-group = "test" },
     "mypy >= 0.910",
     "mkdocs >= 1.4.3",
     "mkdocs-material >= 7.3.3",
@@ -44,11 +50,14 @@ dev = [
     "mkdocs-include-markdown-plugin",
     "pymdown-extensions",
     "pygments",
-    "chex>=0.1.86",
-    "safetensors>=0.4.3",
     "pre-commit",
 ]
 
+
+[tool.pytest.ini_options]
+addopts = "-n auto --import-mode=importlib"
+testpaths = ["tests"]
+pythonpath = ["src", "tests"]
 
 [tool.hatch.version]
 path = "src/haliax/__about__.py"

--- a/lib/haliax/tests/conftest.py
+++ b/lib/haliax/tests/conftest.py
@@ -1,0 +1,9 @@
+# Copyright The Levanter Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import os
+
+# Must be set before JAX initializes its backend. Simulates 8 CPU devices so
+# sharding tests guarded by skip_if_not_enough_devices(2|4) actually run.
+os.environ.setdefault("JAX_NUM_CPU_DEVICES", "8")

--- a/lib/iris/AGENTS.md
+++ b/lib/iris/AGENTS.md
@@ -25,8 +25,8 @@ Archived design docs (implemented, read code instead): `.agents/projects/2026*_i
 ## Development
 
 ```bash
-# Unit tests (run from lib/iris/)
-cd lib/iris && uv run --group dev python -m pytest --tb=short -m 'not slow and not docker and not requires_cluster' tests/
+# Unit tests
+uv run --package marin-iris --group test pytest --tb=short lib/iris/tests/
 ```
 
 See `TESTING.md` for the complete testing policy, E2E test commands, and markers.

--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -57,12 +57,8 @@ examples = [
     "nbconvert>=7.16.6",
     "nbformat>=5.10.4",
 ]
-dev = [
+test = [
     "kubernetes>=31.0.0,<36",
-    "ipykernel>=7.1.0",
-    "jupyter>=1.1.1",
-    "nbconvert>=7.16.6",
-    "nbformat>=5.10.4",
     "playwright>=1.49.0",
     "pytest-asyncio",
     "pytest-flakefinder>=1.1.0",
@@ -70,6 +66,10 @@ dev = [
     "pytest-timeout",
     "pytest-xdist",
     "pytest>=8.4",
+]
+dev = [
+    { include-group = "examples" },
+    { include-group = "test" },
 ]
 
 [tool.hatch.build.targets.wheel]
@@ -95,7 +95,8 @@ packages = ["src/iris"]
 [tool.pytest.ini_options]
 timeout = 10
 timeout_method = "thread"
-addopts = "-n auto --durations=25 -m 'not slow and not docker and not requires_cluster' -v"
+addopts = "-n auto --durations=25 -m 'not slow and not docker and not requires_cluster' -v --import-mode=importlib"
+pythonpath = ["src", "."]
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
     "docker: marks tests requiring Docker runtime (slow, needs daemon)",

--- a/lib/iris/tests/__init__.py
+++ b/lib/iris/tests/__init__.py
@@ -1,2 +1,0 @@
-# Copyright The Marin Authors
-# SPDX-License-Identifier: Apache-2.0

--- a/lib/iris/tests/cluster/backends/test_scaling_group.py
+++ b/lib/iris/tests/cluster/backends/test_scaling_group.py
@@ -40,7 +40,6 @@ from iris.cluster.controller.autoscaler.scaling_group import (
 from iris.cluster.types import AcceleratorType, CapacityType, WorkerStatus, WorkerUsability
 from iris.rpc import vm_pb2
 from rigging.timing import Duration, Timestamp
-
 from tests.cluster.backends.conftest import (
     FakeSliceHandle,
     FakeWorkerHandle,

--- a/lib/iris/tests/cluster/conftest.py
+++ b/lib/iris/tests/cluster/conftest.py
@@ -32,7 +32,6 @@ from iris.cluster.types import DEFAULT_BACKEND_ID, JobName, WorkerId
 from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
 from sqlalchemy import select
-
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.conftest import make_test_entrypoint
 from tests.cluster.controller.transition_driver import WorkerTaskUpdates, apply_task_observations

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -107,7 +107,6 @@ from iris.time_proto import duration_to_proto
 from rigging.timing import Duration, RateLimiter, Timestamp
 from sqlalchemy import func, select
 from sqlalchemy import update as sa_update
-
 from tests.cluster.backends.conftest import make_mock_platform
 from tests.cluster.controller._test_support import ControllerTestState, set_task_state_for_test
 from tests.cluster.controller.transition_driver import WorkerTaskUpdates, apply_task_observations

--- a/lib/iris/tests/cluster/controller/replay/events.py
+++ b/lib/iris/tests/cluster/controller/replay/events.py
@@ -25,7 +25,6 @@ from iris.cluster.controller.reconcile.task import TerminalDecision, TerminalKin
 from iris.cluster.types import JobName, WorkerId
 from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
-
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.transition_driver import (
     CursorTransitionReader,

--- a/lib/iris/tests/cluster/controller/replay/scenarios.py
+++ b/lib/iris/tests/cluster/controller/replay/scenarios.py
@@ -26,7 +26,6 @@ from rigging import timing
 from rigging.timing import Duration, Timestamp
 from sqlalchemy import select
 from sqlalchemy import update as sa_update
-
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.replay.events import (
     AddEndpoint,

--- a/lib/iris/tests/cluster/controller/replay/test_replay_goldens.py
+++ b/lib/iris/tests/cluster/controller/replay/test_replay_goldens.py
@@ -20,7 +20,6 @@ from iris.cluster.controller.task_state import ACTIVE_TASK_STATES
 from iris.cluster.types import TERMINAL_TASK_STATES
 from rigging.timing import Timestamp
 from sqlalchemy import Integer, case, func, literal, select
-
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.replay.db_dump import deterministic_dump
 from tests.cluster.controller.replay.scenarios import SCENARIO_NAMES, SCENARIOS, frozen_clock

--- a/lib/iris/tests/cluster/controller/test_5470_preemption_reassignment.py
+++ b/lib/iris/tests/cluster/controller/test_5470_preemption_reassignment.py
@@ -37,7 +37,6 @@ from iris.cluster.types import JobName, UserBudgetDefaults, WorkerId
 from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
 from sqlalchemy import func, select, update
-
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.transition_driver import WorkerTaskUpdates, apply_task_observations
 

--- a/lib/iris/tests/cluster/controller/test_auth.py
+++ b/lib/iris/tests/cluster/controller/test_auth.py
@@ -49,7 +49,6 @@ from sqlalchemy import text
 from starlette.responses import JSONResponse
 from starlette.routing import Route
 from starlette.testclient import TestClient
-
 from tests.cluster.controller._test_support import ControllerTestState
 
 _TEST_TOKEN = "valid-test-token"

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -27,7 +27,6 @@ from iris.cluster.controller.worker_health import CONSECUTIVE_FAILURE_THRESHOLD
 from iris.cluster.types import AcceleratorType, WorkerStatus
 from iris.rpc import vm_pb2
 from rigging.timing import Duration, Timestamp
-
 from tests.cluster.backends.conftest import (
     FakeSliceHandle,
     FakeWorkerHandle,

--- a/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler_integration.py
@@ -19,7 +19,6 @@ from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, 
 from iris.cluster.platforms.gcp.fake import InMemoryGcpService
 from iris.rpc import job_pb2
 from rigging.timing import Duration, Timestamp
-
 from tests.cluster.controller.conftest import (
     advance_all_tpus,
     make_autoscaler,

--- a/lib/iris/tests/cluster/controller/test_container_profile.py
+++ b/lib/iris/tests/cluster/controller/test_container_profile.py
@@ -25,7 +25,6 @@ from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.types import JobName
 from iris.rpc import controller_pb2, job_pb2
 from rigging.server_auth import VerifiedIdentity, _verified_identity
-
 from tests.cluster.controller.conftest import (
     MockController,
     make_controller_state,

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -50,7 +50,6 @@ from rigging.timing import Timestamp
 from sqlalchemy import func, select
 from sqlalchemy import update as sa_update
 from starlette.testclient import TestClient
-
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.transition_driver import WorkerTaskUpdates, apply_task_observations
 

--- a/lib/iris/tests/cluster/controller/test_demand_routing.py
+++ b/lib/iris/tests/cluster/controller/test_demand_routing.py
@@ -29,7 +29,6 @@ from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, 
 from iris.cluster.types import AcceleratorType, CapacityType
 from iris.rpc import job_pb2
 from rigging.timing import Duration, Timestamp
-
 from tests.cluster.backends.conftest import (
     make_mock_platform,
     make_mock_slice_handle,

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -25,7 +25,6 @@ from iris.cluster.types import JobName
 from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
 from sqlalchemy import update as sa_update
-
 from tests.cluster.controller.transition_driver import commit_dispatch_updates
 
 from .conftest import (

--- a/lib/iris/tests/cluster/controller/test_dry_run.py
+++ b/lib/iris/tests/cluster/controller/test_dry_run.py
@@ -8,7 +8,6 @@ from unittest.mock import MagicMock
 import pytest
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
-
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.conftest import (
     autoscale_once,

--- a/lib/iris/tests/cluster/controller/test_empirical_availability.py
+++ b/lib/iris/tests/cluster/controller/test_empirical_availability.py
@@ -27,7 +27,6 @@ from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
 from iris.cluster.types import AcceleratorType
 from iris.rpc import job_pb2
 from rigging.timing import Timestamp
-
 from tests.cluster.backends.conftest import make_fake_slice_handle, make_mock_platform
 
 TS = Timestamp.from_ms(1_000_000)

--- a/lib/iris/tests/cluster/controller/test_kick_tasks.py
+++ b/lib/iris/tests/cluster/controller/test_kick_tasks.py
@@ -23,7 +23,6 @@ from iris.cluster.controller.service import PendingKick
 from iris.cluster.types import JobName, WorkerId
 from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
-
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.transition_driver import WorkerTaskUpdates, apply_task_observations
 

--- a/lib/iris/tests/cluster/controller/test_multi_backend_control_loop.py
+++ b/lib/iris/tests/cluster/controller/test_multi_backend_control_loop.py
@@ -16,7 +16,6 @@ from iris.cluster.config import BackendConfig
 from iris.cluster.constraints import Constraint, ConstraintOp
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
-
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.conftest import (
     FakeProvider,

--- a/lib/iris/tests/cluster/controller/test_perf_baselines.py
+++ b/lib/iris/tests/cluster/controller/test_perf_baselines.py
@@ -22,7 +22,6 @@ from iris.cluster.types import JobName, WorkerId
 from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
 from sqlalchemy import select, text
-
 from tests.cluster.controller._test_support import ControllerTestState
 
 _TICKS = 200

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -20,7 +20,6 @@ from iris.cluster.controller.scheduling.scheduler import JobRequirements, Runnin
 from iris.cluster.types import TERMINAL_JOB_STATES, JobName, UserBudgetDefaults, WorkerId
 from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Timestamp
-
 from tests.cluster.controller.transition_driver import WorkerTaskUpdates, apply_task_observations
 
 from .conftest import (

--- a/lib/iris/tests/cluster/controller/test_provisioning.py
+++ b/lib/iris/tests/cluster/controller/test_provisioning.py
@@ -19,7 +19,6 @@ from iris.cluster.controller.autoscaler.runtime import _ScaleUpOutcome, _ScaleUp
 from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
 from iris.cluster.types import CapacityType
 from rigging.timing import Timestamp
-
 from tests.cluster.backends.conftest import make_mock_platform, make_mock_slice_handle
 from tests.cluster.controller.conftest import make_autoscaler, make_scale_group_config, mark_discovered_ready
 

--- a/lib/iris/tests/cluster/controller/test_reconcile.py
+++ b/lib/iris/tests/cluster/controller/test_reconcile.py
@@ -64,7 +64,6 @@ from iris.rpc import job_pb2, worker_pb2
 from rigging.timing import Duration, Timestamp
 from sqlalchemy import select
 from sqlalchemy.exc import IntegrityError
-
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.transition_driver import (
     WorkerTaskUpdates,

--- a/lib/iris/tests/cluster/controller/test_recovery.py
+++ b/lib/iris/tests/cluster/controller/test_recovery.py
@@ -15,7 +15,6 @@ from iris.cluster.controller.autoscaler.scaling_group import (
 )
 from iris.cluster.types import WorkerStatus
 from rigging.timing import Duration, Timestamp
-
 from tests.cluster.backends.conftest import make_fake_slice_handle, make_mock_platform
 
 from .conftest import make_autoscaler, mark_discovered_ready

--- a/lib/iris/tests/cluster/controller/test_scheduler.py
+++ b/lib/iris/tests/cluster/controller/test_scheduler.py
@@ -35,7 +35,6 @@ from iris.time_proto import duration_to_proto
 from rigging.timing import Duration, Timestamp
 from sqlalchemy import select
 from sqlalchemy import update as sa_update
-
 from tests.cluster.conftest import eq_constraint, in_constraint
 from tests.cluster.controller._test_support import ControllerTestState, set_worker_health_for_test
 from tests.cluster.controller.transition_driver import WorkerTaskUpdates, apply_task_observations

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -53,7 +53,6 @@ from rigging.server_auth import VerifiedIdentity, _verified_identity
 from rigging.timing import Duration, Timestamp
 from sqlalchemy import func
 from sqlalchemy import update as sa_update
-
 from tests.cluster.controller._test_support import ControllerTestState
 from tests.cluster.controller.transition_driver import WorkerTaskUpdates, apply_task_observations
 

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -52,7 +52,6 @@ from iris.rpc import controller_pb2, job_pb2
 from rigging.timing import Duration, Timestamp
 from sqlalchemy import func, insert, select
 from sqlalchemy import update as sa_update
-
 from tests.cluster.controller._test_support import ControllerTestState, create_attempt_for_test
 from tests.cluster.controller.transition_driver import (
     WorkerTaskUpdates,

--- a/lib/iris/tests/cluster/controller/test_worker_health.py
+++ b/lib/iris/tests/cluster/controller/test_worker_health.py
@@ -26,7 +26,6 @@ from iris.cluster.controller.worker_health import (
 from iris.cluster.types import WorkerId, WorkerUsability
 from rigging.timing import Duration, Timestamp
 from sqlalchemy import insert, select
-
 from tests.cluster.controller._test_support import set_worker_consecutive_failures_for_test
 
 from .conftest import make_worker_metadata, register_worker

--- a/lib/iris/tests/cluster/worker/test_dashboard.py
+++ b/lib/iris/tests/cluster/worker/test_dashboard.py
@@ -17,7 +17,6 @@ from iris.rpc import job_pb2, worker_pb2
 from iris.test_util import wait_for_condition
 from rigging.timing import Duration
 from starlette.testclient import TestClient
-
 from tests.cluster.worker.conftest import create_run_task_request
 
 pytestmark = pytest.mark.timeout(10)

--- a/lib/iris/tests/cluster/worker/test_reconcile.py
+++ b/lib/iris/tests/cluster/worker/test_reconcile.py
@@ -16,7 +16,6 @@ from iris.cluster.worker.worker import Worker, WorkerConfig
 from iris.rpc import job_pb2, worker_pb2
 from iris.test_util import wait_for_condition
 from rigging.timing import Duration
-
 from tests.cluster.worker.conftest import create_mock_container_handle, create_run_task_request
 
 pytestmark = pytest.mark.timeout(10)

--- a/lib/iris/tests/cluster/worker/test_worker.py
+++ b/lib/iris/tests/cluster/worker/test_worker.py
@@ -38,7 +38,6 @@ from iris.managed_thread import ThreadContainer
 from iris.rpc import job_pb2, worker_pb2
 from iris.test_util import wait_for_condition
 from rigging.timing import Deadline, Duration
-
 from tests.cluster.worker.conftest import (
     FakeContainerHandle,
     FakeLogReader,

--- a/lib/iris/tests/e2e/test_docker.py
+++ b/lib/iris/tests/e2e/test_docker.py
@@ -16,7 +16,6 @@ import pytest
 from iris.cluster.types import AcceleratorType, Entrypoint, EnvironmentSpec, ResourceSpec
 from iris.cluster.worker.env_probe import FixedEnvironmentProvider, HardwareProbe, build_worker_metadata
 from iris.rpc import job_pb2
-
 from tests.e2e._docker_cluster import E2ECluster
 
 pytestmark = [pytest.mark.requires_cluster, pytest.mark.docker]

--- a/lib/iris/tests/test_auth.py
+++ b/lib/iris/tests/test_auth.py
@@ -18,7 +18,7 @@ from rigging.server_auth import (
     resolve_auth,
 )
 
-from .conftest import _make_controller_only_config
+from tests.conftest import _make_controller_only_config
 
 _AUTH_TOKEN = "e2e-test-token"
 _AUTH_USER = "test-user"

--- a/lib/iris/tests/test_budget.py
+++ b/lib/iris/tests/test_budget.py
@@ -27,7 +27,6 @@ from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.proto_display import PRIORITY_BAND_VALUES, priority_band_name, priority_band_value
 from rigging.server_auth import VerifiedIdentity, _verified_identity
 from rigging.timing import Timestamp
-
 from tests.cluster.controller.conftest import (
     MockController,
     make_controller_state,

--- a/lib/levanter/pyproject.toml
+++ b/lib/levanter/pyproject.toml
@@ -208,7 +208,7 @@ mypy_path = ["src"]
 ignore_missing_imports = true
 
 [tool.pytest.ini_options]
-addopts = "-n auto"
+addopts = "-n auto -m 'not slow and not torch' --import-mode=importlib"
 pythonpath = ["src", "tests"]
 filterwarnings = [
     "ignore:Transparent hugepages are not enabled\\..*:UserWarning:jax._src.cloud_tpu_init",

--- a/lib/levanter/tests/__init__.py
+++ b/lib/levanter/tests/__init__.py
@@ -1,2 +1,0 @@
-# Copyright The Levanter Authors
-# SPDX-License-Identifier: Apache-2.0

--- a/lib/levanter/tests/kernels/test_pallas_mamba3.py
+++ b/lib/levanter/tests/kernels/test_pallas_mamba3.py
@@ -40,7 +40,7 @@ from levanter.kernels.pallas.mamba3.reference import (
 )
 from levanter.kernels.pallas.mamba3.xla import mamba3_mimo_chunked_forward_ranked_xla_batched
 from levanter.kernels.pallas.ssd import intra_chunk_log_alpha_cumsum, local_log_alpha
-from tests.test_utils import skip_if_no_torch
+from test_utils import skip_if_no_torch
 
 MAMBA3_MIMO_RANKED_PARITY_ATOL = 1e-4
 MAMBA3_MIMO_RANKED_PARITY_RTOL = 1e-4

--- a/lib/levanter/tests/test_eval.py
+++ b/lib/levanter/tests/test_eval.py
@@ -34,8 +34,8 @@ from levanter.tracker import current_tracker
 from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.utils.tree_utils import inference_mode
 
-from .test_lm_model_loss import ToyLmConfig, ToyLmHeadModel
-from .test_utils import use_test_mesh
+from test_lm_model_loss import ToyLmConfig, ToyLmHeadModel
+from test_utils import use_test_mesh
 
 
 def test_tagged_evaluator_accepts_grug_lm_examples():

--- a/lib/levanter/tests/test_gdn_kernels.py
+++ b/lib/levanter/tests/test_gdn_kernels.py
@@ -9,7 +9,7 @@ import pytest
 from haliax import Axis
 
 from levanter.layers.gated_deltanet import chunk_gated_delta_rule, recurrent_gated_delta_rule
-from tests.test_utils import skip_if_no_torch
+from test_utils import skip_if_no_torch
 
 jax.config.update("jax_default_matmul_precision", "float32")
 

--- a/lib/levanter/tests/test_gdn_layer.py
+++ b/lib/levanter/tests/test_gdn_layer.py
@@ -14,7 +14,7 @@ from levanter.layers.gated_deltanet import (
     _causal_depthwise_conv1d_full,
     _causal_depthwise_conv1d_update,
 )
-from tests.test_utils import skip_if_no_torch
+from test_utils import skip_if_no_torch
 
 jax.config.update("jax_default_matmul_precision", "float32")
 

--- a/lib/levanter/tests/test_hf_checkpoints.py
+++ b/lib/levanter/tests/test_hf_checkpoints.py
@@ -29,7 +29,7 @@ from levanter.compat.hf_checkpoints import (
     _convert_to_jnp,
 )
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
-from tests.test_utils import use_test_mesh
+from test_utils import use_test_mesh
 
 
 @skip_if_no_torch

--- a/lib/levanter/tests/test_hf_gpt2_serialize.py
+++ b/lib/levanter/tests/test_hf_gpt2_serialize.py
@@ -27,7 +27,7 @@ from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
 from levanter.models.lm_model import LmExample, LmHeadModel
 from levanter.optim import AdamConfig
 from levanter.utils.tree_utils import inference_mode
-from tests.test_utils import use_test_mesh
+from test_utils import use_test_mesh
 
 TEST_GPT2_MODEL_ID = "sshleifer/tiny-gpt2"
 

--- a/lib/levanter/tests/test_new_loader.py
+++ b/lib/levanter/tests/test_new_loader.py
@@ -16,7 +16,7 @@ from levanter.data.dataset import AsyncDataset, ListAsyncDataset
 from levanter.data.loader import DataLoader, check_sharded_consistency
 from levanter.schedule import ScheduleStep
 
-from .test_utils import skip_if_not_enough_devices, use_test_mesh
+from test_utils import skip_if_not_enough_devices, use_test_mesh
 
 
 def _small_dataset(seq_len=128, num_sequences=200) -> AsyncDataset[Sequence[int]]:

--- a/lib/rigging/pyproject.toml
+++ b/lib/rigging/pyproject.toml
@@ -23,11 +23,12 @@ dependencies = [
 iap = ["google-auth-oauthlib>=1.0.0"]
 
 [dependency-groups]
-dev = [
+test = [
     "pytest>=8.3.2",
     "pytest-asyncio",
     "pytest-timeout",
 ]
+dev = [{ include-group = "test" }]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/rigging"]

--- a/lib/zephyr/pyproject.toml
+++ b/lib/zephyr/pyproject.toml
@@ -43,6 +43,7 @@ packages = ["src/zephyr"]
 packages = ["src/zephyr"]
 
 [tool.pytest.ini_options]
+pythonpath = ["src", "tests"]
 timeout = 60
 filterwarnings = ["ignore::DeprecationWarning"]
 log_level = "INFO"
@@ -52,4 +53,4 @@ log_cli_level = "INFO"
 markers = [
     "slow: marks tests as slow (deselect with '-m \"not slow\"')",
 ]
-addopts = "-m 'not slow'"
+addopts = "-m 'not slow and not tpu_ci' --import-mode=importlib"

--- a/lib/zephyr/tests/__init__.py
+++ b/lib/zephyr/tests/__init__.py
@@ -1,2 +1,0 @@
-# Copyright The Marin Authors
-# SPDX-License-Identifier: Apache-2.0

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -436,10 +436,11 @@ markers = [
     "requires_cluster: mark tests that need a running iris cluster",
 ]
 testpaths = ["tests", "experiments"]
+pythonpath = ["."]
 
 # Don't run TPU, slow, integration, data_integration, or cluster-bound tests by default.
 # Integration tests require external infrastructure (Iris cluster, GCS,
 # gated HF repos, etc.); data_integration tests fetch fixtures from HF;
 # requires_cluster tests need a running iris cluster (local or remote).
 # All are run from dedicated CI workflows.
-addopts = "--session-timeout=600 -m 'not tpu_ci and not slow and not integration and not data_integration and not requires_cluster'"
+addopts = "--session-timeout=600 -m 'not tpu_ci and not slow and not integration and not data_integration and not requires_cluster' --import-mode=importlib"

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,0 @@
-# Copyright The Marin Authors
-# SPDX-License-Identifier: Apache-2.0

--- a/uv.lock
+++ b/uv.lock
@@ -4615,7 +4615,7 @@ requires-dist = [
     { name = "google-vizier", extras = ["jax"], marker = "extra == 'vizier'" },
     { name = "harbor", marker = "extra == 'harbor'", git = "https://github.com/marin-community/harbor.git?rev=354692d9c0eab497b05f266aa0dff30e2a238d2e" },
     { name = "huggingface-hub", marker = "extra == 'datakit'" },
-    { name = "jax", specifier = ">=0.9.2,<0.11" },
+    { name = "jax", specifier = ">=0.9.2" },
     { name = "jax", marker = "extra == 'cpu'", specifier = "==0.10.0" },
     { name = "jax", marker = "extra == 'tpu'", specifier = "==0.10.0" },
     { name = "jax", marker = "extra == 'vllm'", specifier = "==0.10.0" },
@@ -4781,6 +4781,12 @@ dev = [
     { name = "pytest-timeout" },
     { name = "pytest-xdist" },
 ]
+test = [
+    { name = "marin-finelog-server" },
+    { name = "pytest" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -4798,6 +4804,12 @@ requires-dist = [
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "marin-finelog-server", specifier = ">=0.2.0.dev0" },
+    { name = "pytest", specifier = ">=8.4" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+]
+test = [
     { name = "marin-finelog-server", specifier = ">=0.2.0.dev0" },
     { name = "pytest", specifier = ">=8.4" },
     { name = "pytest-timeout" },
@@ -4831,7 +4843,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-timeout" },
 ]
-fray-test = [
+test = [
     { name = "pytest" },
     { name = "pytest-timeout" },
 ]
@@ -4855,7 +4867,7 @@ dev = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-timeout" },
 ]
-fray-test = [
+test = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-timeout" },
 ]
@@ -4894,14 +4906,17 @@ dev = [
     { name = "pygments" },
     { name = "pymdown-extensions" },
     { name = "pytest" },
-    { name = "safetensors" },
+]
+test = [
+    { name = "chex" },
+    { name = "pytest" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aqtp", specifier = ">=0.8.2" },
     { name = "equinox", specifier = ">=0.10.6" },
-    { name = "jax", specifier = ">=0.8.0" },
+    { name = "jax", specifier = ">=0.9.2,<0.11" },
     { name = "jaxtyping", specifier = ">=0.2.20" },
     { name = "jmp", specifier = ">=0.0.4" },
     { name = "safetensors", specifier = ">=0.4.3" },
@@ -4922,7 +4937,10 @@ dev = [
     { name = "pygments" },
     { name = "pymdown-extensions" },
     { name = "pytest", specifier = ">=7.4.0" },
-    { name = "safetensors", specifier = ">=0.4.3" },
+]
+test = [
+    { name = "chex", specifier = ">=0.1.86" },
+    { name = "pytest", specifier = ">=7.4.0" },
 ]
 
 [[package]]
@@ -4984,6 +5002,16 @@ examples = [
     { name = "nbconvert" },
     { name = "nbformat" },
 ]
+test = [
+    { name = "kubernetes" },
+    { name = "playwright" },
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-flakefinder" },
+    { name = "pytest-playwright" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -5035,6 +5063,16 @@ examples = [
     { name = "jupyter", specifier = ">=1.1.1" },
     { name = "nbconvert", specifier = ">=7.16.6" },
     { name = "nbformat", specifier = ">=5.10.4" },
+]
+test = [
+    { name = "kubernetes", specifier = ">=31.0.0,<36" },
+    { name = "playwright", specifier = ">=1.49.0" },
+    { name = "pytest", specifier = ">=8.4" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-flakefinder", specifier = ">=1.1.0" },
+    { name = "pytest-playwright", specifier = ">=0.6.2" },
+    { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 
 [[package]]
@@ -5288,6 +5326,11 @@ dev = [
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
 ]
+test = [
+    { name = "pytest" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
+]
 
 [package.metadata]
 requires-dist = [
@@ -5305,6 +5348,11 @@ provides-extras = ["iap"]
 
 [package.metadata.requires-dev]
 dev = [
+    { name = "pytest", specifier = ">=8.3.2" },
+    { name = "pytest-asyncio" },
+    { name = "pytest-timeout" },
+]
+test = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },


### PR DESCRIPTION
Step one in implementing the [Unified Unit-Test Workflow](https://github.com/marin-community/marin/blob/main/.agents/projects/unified_unit_workflow/design.md)

Make all packages unit tests run look approximately like `uv run --package <package> pytest lib/<package>/tests. I didn't bother updating the various `--durations=`, `-n`, `--tb=` since we can just pick a default in the next stage and they will all be fine.


- Removed `--with "jax[cpu]==0.9.2"` from `haliax` and `levanter`
- Remove `__init__.py` files from `tests/` directories across `haliax`, `levanter`, `iris`, `finelog`, and `zephyr` to prevent `ImportPathMismatchError` collisions during multi-package pytest runs.
- Use `[tool.pytest.ini_options]` in `pyproject.toml` for configurations like `pythonpath = ["src", "tests"]` and `addopts=-m 'not slow ...'`
- Move JAX CPU device configuration in `lib/haliax/tests/conftest.py`
- Added `--import-mode=importlib` to avoid filename collisions
- Added `pythonpath = ["."]` to top-level `pyproject.toml`
- A bunch of small reformatting things because of removing `__init__.py`