### PR TITLE
[execution] Prune already-built subtrees so cached outputs short-circuit ancestors

### DIFF
--- a/lib/marin/src/marin/execution/step_runner.py
+++ b/lib/marin/src/marin/execution/step_runner.py
@@ -29,7 +29,7 @@ from fray.types import Entrypoint, JobRequest, ResourceConfig, create_environmen
 from rigging.filesystem import open_url, url_to_fs
 from rigging.log_setup import configure_logging
 
-from marin.execution.artifact import check_drift, write_artifact
+from marin.execution.artifact import FINGERPRINT_KEY, VERSION_KEY, check_drift, is_mutable_version, write_artifact
 from marin.execution.remote import RemoteCallable, _sanitize_job_name
 from marin.execution.step_spec import StepSpec
 
@@ -86,14 +86,39 @@ def _write_executor_info(step: StepSpec) -> None:
 # ---------------------------------------------------------------------------
 
 
-def _expand_unseen(step: StepSpec, seen: set[str]) -> list[StepSpec]:
+def _is_built(step: StepSpec) -> bool:
+    """True when the runner will serve ``step`` from cache rather than rebuild it.
+
+    A non-mutable step whose output already has a ``SUCCESS`` status. This is the
+    same condition the launcher uses to skip a step, evaluated here at scheduling
+    time so an already-built node's dependencies are pruned from the schedule
+    instead of rebuilt; the launcher re-checks authoritatively before serving the
+    node. A mutable (``dev``) artifact always rebuilds, so it is never pruned.
+    """
+    if step.hash_attrs.get(FINGERPRINT_KEY) is not None and is_mutable_version(step.hash_attrs.get(VERSION_KEY, "")):
+        return False
+    return StatusFile(step.output_path, worker_id="cache-check").status == STATUS_SUCCESS
+
+
+def _expand_unseen(
+    step: StepSpec,
+    seen: set[str],
+    is_built: Callable[[StepSpec], bool] = lambda _s: False,
+    pruned: set[str] | None = None,
+) -> list[StepSpec]:
     """Return ``step`` and its transitive deps (post-order), excluding any in ``seen``.
 
     ``seen`` is mutated in place to include every returned step, so subsequent
     calls skip nodes already scheduled by an earlier terminal. Cycles within
     this expansion raise ``ValueError`` — by DAG construction they shouldn't
     exist, but the check guards against silent hangs.
+
+    When ``is_built(node)`` holds, ``node``'s output is already cached: the walk
+    records its ``output_path`` in ``pruned`` and does not descend into its deps,
+    so they are neither scheduled nor rebuilt. ``node`` itself is still returned (as
+    a cache-only leaf the caller confirms). The default ``is_built`` prunes nothing.
     """
+    recorded = pruned if pruned is not None else set()
     in_stack: set[str] = set()
     ordered: list[StepSpec] = []
 
@@ -104,8 +129,11 @@ def _expand_unseen(step: StepSpec, seen: set[str]) -> list[StepSpec]:
         if path in in_stack:
             raise ValueError(f"Cycle detected in step graph involving {s.name_with_hash}")
         in_stack.add(path)
-        for dep in s.deps:
-            visit(dep)
+        if is_built(s):
+            recorded.add(path)
+        else:
+            for dep in s.deps:
+                visit(dep)
         in_stack.remove(path)
         seen.add(path)
         ordered.append(s)
@@ -167,6 +195,11 @@ class StepRunner:
         failures: list[Exception] = []
         # output_path → name_with_hash, for human-readable logging
         path_to_name: dict[str, str] = {}
+        # Outputs already cached: their deps are pruned from the schedule and they are
+        # confirmed from cache rather than run. Disabled under dry_run, which stays
+        # I/O-free and lists the full static graph.
+        pruned: set[str] = set()
+        is_built = (lambda _s: False) if dry_run else _is_built
 
         def _display_name(output_path: str) -> str:
             return path_to_name.get(output_path, output_path)
@@ -229,16 +262,40 @@ class StepRunner:
             else:
                 completed.add(path)
 
+        def _confirm_pruned(step: StepSpec) -> None:
+            """Mark a pruned cache-only leaf complete without running it.
+
+            Its dependencies were dropped from the schedule, so the step must not run.
+            If its cached output is no longer a clean success, record a failure (which
+            cascades to dependents) so a rerun rebuilds it and its now-unpruned inputs.
+            """
+            path = step.output_path
+            mutable = check_drift(step)
+            status = StatusFile(path, worker_id="check").status
+            if status == STATUS_SUCCESS and not mutable:
+                logger.info(f"Skip {step.name_with_hash}: already succeeded (pruned subtree)")
+                completed.add(path)
+            else:
+                failed.add(path)
+                failures.append(
+                    RuntimeError(
+                        f"Step {step.name_with_hash}: cached output disappeared after its inputs were "
+                        f"pruned (status={status}); rerun to rebuild it and its inputs."
+                    )
+                )
+
         scheduled: set[str] = set()
         for raw_step in steps:
-            for step in _expand_unseen(raw_step, scheduled):
+            for step in _expand_unseen(raw_step, scheduled, is_built, pruned):
                 path_to_name[step.output_path] = step.name_with_hash
 
                 _harvest()
                 _flush_waiting()
 
                 path = step.output_path
-                if any(d in failed for d in step.dep_paths):
+                if path in pruned:
+                    _confirm_pruned(step)
+                elif any(d in failed for d in step.dep_paths):
                     failed.add(path)
                 elif all(d in completed for d in step.dep_paths):
                     _do_launch(step)

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -7,13 +7,15 @@ import os
 import threading
 from pathlib import Path
 
+import marin.execution.step_runner as step_runner_module
 import pytest
 from fray.current_client import current_client, set_current_client
 from fray.types import ResourceConfig
-from marin.execution.artifact import Artifact, read_artifact, write_artifact
+from marin.execution.artifact import FINGERPRINT_KEY, VERSION_KEY, Artifact, read_artifact, write_artifact
 from marin.execution.remote import RemoteCallable, remote
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
+from marin.execution.step_status import STATUS_SUCCESS, StatusFile, worker_id
 from pydantic import BaseModel
 
 # ---------------------------------------------------------------------------
@@ -401,6 +403,122 @@ def test_runner_walks_transitive_deps_with_cache_hit(tmp_path: Path):
     # Pass only ``downstream``; the runner walks deps and cache-hits ``dep``.
     StepRunner().run([downstream])
     assert downstream_ran == [(tmp_path / "downstream").as_posix()]
+
+
+# ---------------------------------------------------------------------------
+# Pruning already-built subtrees
+# ---------------------------------------------------------------------------
+
+
+def _recording_step(name: str, out: str, executed: list[str], deps: list[StepSpec] | None = None) -> StepSpec:
+    """A StepSpec whose fn appends ``name`` to ``executed`` when (and only when) it runs."""
+
+    def _fn(output_path: str) -> Artifact:
+        executed.append(name)
+        return Artifact(path=output_path)
+
+    return StepSpec(name=name, override_output_path=out, deps=deps or [], fn=_fn)
+
+
+def _download_normalize_tokenize(tmp_path: Path, executed: list[str]) -> tuple[StepSpec, StepSpec, StepSpec]:
+    download = _recording_step("download", (tmp_path / "download").as_posix(), executed)
+    normalize = _recording_step("normalize", (tmp_path / "normalize").as_posix(), executed, deps=[download])
+    tokenize = _recording_step("tokenize", (tmp_path / "tokenize").as_posix(), executed, deps=[normalize])
+    return download, normalize, tokenize
+
+
+def test_runner_prunes_built_terminal_subtree(tmp_path: Path):
+    """A cached terminal must not rebuild its unbuilt intermediate ancestors.
+
+    Regression for #6783: ``download → normalize → tokenize`` with only ``tokenize``
+    cached used to rebuild the unpinned ``normalize`` (and ``download``) anyway.
+    """
+    executed: list[str] = []
+    _download, _normalize, tokenize = _download_normalize_tokenize(tmp_path, executed)
+
+    # Prime ONLY the terminal as a cached SUCCESS; its ancestors stay unbuilt.
+    StatusFile(tokenize.output_path, worker_id()).write_status(STATUS_SUCCESS)
+
+    StepRunner().run([tokenize])
+
+    # Terminal served from cache, ancestors pruned: nothing ran.
+    assert executed == []
+
+
+def test_runner_builds_unbuilt_ancestors(tmp_path: Path):
+    """With nothing cached, the full chain runs in dependency order (no over-pruning)."""
+    executed: list[str] = []
+    _download, _normalize, tokenize = _download_normalize_tokenize(tmp_path, executed)
+
+    StepRunner().run([tokenize])
+
+    assert executed == ["download", "normalize", "tokenize"]
+
+
+def test_runner_prune_keeps_unbuilt_sibling_branch(tmp_path: Path):
+    """A shared dep feeding a cached branch and an unbuilt branch still runs once.
+
+    Diamond ``a → {b, c}``, ``b → d``, ``c → d``: ``c`` is cached but its dep ``d``
+    is not. Pruning ``c`` must not strand ``d`` — ``d`` is still needed by ``b``.
+    """
+    executed: list[str] = []
+    d = _recording_step("d", (tmp_path / "d").as_posix(), executed)
+    b = _recording_step("b", (tmp_path / "b").as_posix(), executed, deps=[d])
+    c = _recording_step("c", (tmp_path / "c").as_posix(), executed, deps=[d])
+    a = _recording_step("a", (tmp_path / "a").as_posix(), executed, deps=[b, c])
+
+    # ``c`` is already built; its dep ``d`` is not.
+    StatusFile(c.output_path, worker_id()).write_status(STATUS_SUCCESS)
+
+    StepRunner().run([a])
+
+    assert "c" not in executed  # served from cache, not rebuilt
+    assert executed.count("d") == 1  # built once, for the unbuilt ``b`` branch
+    assert sorted(executed) == ["a", "b", "d"]
+
+
+def test_runner_does_not_prune_dev_node(tmp_path: Path):
+    """A mutable (dev) artifact at SUCCESS always rebuilds, so its deps are not pruned."""
+    executed: list[str] = []
+    dep = StepSpec(
+        name="dep",
+        override_output_path=(tmp_path / "dep").as_posix(),
+        hash_attrs={FINGERPRINT_KEY: "dep-fp", VERSION_KEY: "2026.01.01"},
+        fn=lambda output_path: executed.append("dep") or Artifact(path=output_path),
+    )
+    dev = StepSpec(
+        name="dev",
+        override_output_path=(tmp_path / "dev").as_posix(),
+        deps=[dep],
+        hash_attrs={FINGERPRINT_KEY: "dev-fp", VERSION_KEY: "dev"},
+        fn=lambda output_path: executed.append("dev") or Artifact(path=output_path),
+    )
+
+    # Even with a SUCCESS status on disk, a dev version is rebuilt — and pulls its dep.
+    StatusFile(dev.output_path, worker_id()).write_status(STATUS_SUCCESS)
+
+    StepRunner().run([dev])
+
+    assert "dev" in executed
+    assert "dep" in executed
+
+
+def test_runner_prune_cache_vanished_fails(tmp_path: Path, monkeypatch):
+    """If a pruned node's cached output is gone at confirm time, the run fails loudly
+    rather than running the node with its inputs pruned away."""
+    executed: list[str] = []
+    dep = _recording_step("dep", (tmp_path / "dep").as_posix(), executed)
+    terminal = _recording_step("terminal", (tmp_path / "terminal").as_posix(), executed, deps=[dep])
+
+    # Treat ``terminal`` as built (pruning ``dep``) although nothing is on disk — the
+    # state if its cached output vanished between scheduling and confirmation.
+    monkeypatch.setattr(step_runner_module, "_is_built", lambda s: s.output_path == terminal.output_path)
+
+    with pytest.raises(RuntimeError, match=r"1 step\(s\) failed"):
+        StepRunner().run([terminal])
+
+    # The pruned node is not run (its inputs were dropped), and neither is its dep.
+    assert executed == []
 
 
 def test_runner_consumes_unbounded_iterator(tmp_path: Path):


### PR DESCRIPTION
A cached top-level artifact no longer rebuilds its unpinned intermediate ancestors. The runner expanded the full transitive DAG and cache-checked each node independently, so a `tokenize(raw=normalize(download(...)))` chain pinned only at `tokenize` still re-ran `normalize`.

`_expand_unseen` now stops descending at an already-built node, recording it as a cache-only leaf; the scheduler confirms that leaf from cache instead of waiting on its now-pruned deps, and never runs its function. If the cached output vanished between scheduling and confirmation, the leaf fails loudly so a rerun rebuilds it and its now-unpruned inputs. Pruning is disabled under `dry_run`, which stays I/O-free and lists the full static graph.

The prune predicate `_is_built` is the launcher's own skip condition (a non-mutable step whose output is a `SUCCESS`), evaluated at scheduling time without `check_drift`'s side effects so no drift warning is duplicated and a pinned-fingerprint mismatch still raises once, at launch. That scheduling-time check intentionally mirrors the launch-time skip; the gap between them is exactly what the cache-only confirm re-checks, failing loudly rather than rebuilding from pruned inputs.

The original issue proposed returning a depless copy of each built node during `lower()`. That is unsafe here: `StepSpec.hash_id` is derived from `dep_names`, so dropping a generic step's deps changes its `hash_id` and therefore its `output_path`, and the runner would then look up a different path than the one that is actually cached. Stopping the traversal leaves every node's identity untouched, works for lazy and plain `StepSpec`s alike, and covers every entry point (`run`, `resolve`, `lower` + `StepRunner().run`) since it lives at the single point that decides what gets scheduled.

Design peer-reviewed by Codex (which caught an earlier revision that deadlocked by keeping the cached node gated on its pruned deps).

Closes #6783