### PR TITLE
[iris] Correct erapids RAM/disk and Genoa disk to actual node specs

### DIFF
--- a/lib/iris/config/coreweave-ci.yaml
+++ b/lib/iris/config/coreweave-ci.yaml
@@ -50,9 +50,9 @@ scale_groups:
   cpu-erapids:
     num_vms: 1
     resources:
-      cpu: 64
-      ram: 256GB
-      disk: 1TB
+      cpu: 64        # cd-gp-i64-erapids: 64 vCPUs (32 physical Emerald Rapids 8562Y+ cores)
+      ram: 512GB     # 512 GB on-node RAM (8 GB per vCPU)
+      disk: 15.36TB  # 15.36 TB local NVMe
       device_type: cpu
       capacity_type: on-demand
     worker:

--- a/lib/iris/config/coreweave-controller-gpu-smoke.yaml
+++ b/lib/iris/config/coreweave-controller-gpu-smoke.yaml
@@ -70,9 +70,9 @@ scale_groups:
     # provisions it up front; _set_target_nodes leaves it alone (GPU pools only).
     num_vms: 1
     resources:
-      cpu: 64
-      ram: 256GB
-      disk: 1TB
+      cpu: 64        # cd-gp-i64-erapids: 64 vCPUs (32 physical Emerald Rapids 8562Y+ cores)
+      ram: 512GB     # 512 GB on-node RAM (8 GB per vCPU)
+      disk: 15.36TB  # 15.36 TB local NVMe
       device_type: cpu
       capacity_type: on-demand
     buffer_slices: 1

--- a/lib/iris/config/coreweave.yaml
+++ b/lib/iris/config/coreweave.yaml
@@ -84,9 +84,9 @@ scale_groups:
   cpu-erapids:
     num_vms: 1
     resources:
-      cpu: 64
-      ram: 256GB
-      disk: 1TB
+      cpu: 64        # cd-gp-i64-erapids: 64 vCPUs (32 physical Emerald Rapids 8562Y+ cores)
+      ram: 512GB     # 512 GB on-node RAM (8 GB per vCPU)
+      disk: 15.36TB  # 15.36 TB local NVMe
       device_type: cpu
       capacity_type: on-demand
     worker:

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -86,9 +86,9 @@ scale_groups:
   cpu-genoa:
     num_vms: 1
     resources:
-      cpu: 192      # cd-gp-a192-genoa: 192 vCPUs (96 physical Genoa 9454 cores)
-      ram: 1536GB   # 1.5 TB on-node RAM (8 GB per vCPU)
-      disk: 1TB
+      cpu: 192       # cd-gp-a192-genoa: 192 vCPUs (96 physical Genoa 9454 cores)
+      ram: 1536GB    # 1.5 TB on-node RAM (8 GB per vCPU)
+      disk: 7.68TB   # 7.68 TB local NVMe
       device_type: cpu
       capacity_type: on-demand
     worker:

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -523,10 +523,11 @@ CoreWeave instance types follow the pattern `{prefix}-{count}x{model}{networking
 
 **Known-good instance types**:
 
-| Instance Type | GPUs | vCPUs | RAM | Use Case |
-|---------------|------|-------|-----|----------|
-| `gd-8xh100ib-i128` | 8x H100 | 128 | 2 TB | GPU training (primary) |
-| `cd-gp-i64-erapids` | none | 64 | 256 GB | Controller / CPU tasks |
+| Instance Type | GPUs | vCPUs | RAM | Disk | Use Case |
+|---------------|------|-------|-----|------|----------|
+| `gd-8xh100ib-i128` | 8x H100 | 128 | 2 TB | — | GPU training (primary) |
+| `cd-gp-a192-genoa` | none | 192 | 1.5 TB | 7.68 TB | Controller / CPU tasks (US-EAST-02A) |
+| `cd-gp-i64-erapids` | none | 64 | 512 GB | 15.36 TB | Controller / CPU tasks (US-WEST-04A) |
 
 Full list: [CoreWeave GPU Instances](https://docs.coreweave.com/docs/platform/instances/gpu-instances)
 
@@ -552,7 +553,7 @@ dedicated `cpu: 2` and `memory: 4Gi` (with matching limits) so it runs with
 Guaranteed QoS instead of BestEffort.
 
 Cost note: the smallest CoreWeave CPU instance (`cd-gp-i64-erapids`, 64 vCPU,
-256 GB RAM) is overprovisioned for the controller. CoreWeave does not offer
+512 GB RAM) is overprovisioned for the controller. CoreWeave does not offer
 smaller bare-metal nodes.
 
 ### Bootstrap via Platform.create_slice() with async state model


### PR DESCRIPTION
Correct the CoreWeave CPU scale-group resources so the advertised RAM and disk match the real node hardware. Both groups were carried over from the Emerald Rapids template at a 4 GB/vCPU ratio with a placeholder 1 TB disk; the real nodes have 8 GB/vCPU and multi-TB local NVMe.

| Instance type | vCPU | RAM | Disk |
|---|---|---|---|
| `cd-gp-a192-genoa` | 192 | 1536 GB | 1 TB → **7.68 TB** |
| `cd-gp-i64-erapids` | 64 | 256 GB → **512 GB** | 1 TB → **15.36 TB** |

PR #6793 landed only the Genoa RAM (768 → 1536 GB) half of this. This finishes the job: the erapids RAM/disk across the three configs that define that group (`coreweave.yaml`, `coreweave-ci.yaml`, `coreweave-controller-gpu-smoke.yaml`), the Genoa disk in `cw-us-east-02a.yaml`, and the instance table in `coreweave.md`.

vCPU counts were already correct (they match the instance-type name). All four configs load through `load_config` and parse to the expected cpu/ram/disk after the change.
