### PR TITLE
[iris] Move per-backend dead-worker pruning into the backend store

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1517,6 +1517,10 @@ class K8sTaskProvider:
     def teardown(self, dead_workers: list[WorkerId], *, reason: str) -> None:
         """No-op: a cluster backend tracks no Iris workers to reap."""
 
+    def prune_dead_workers(self, *, cutoff_ms: int, stop_event: threading.Event | None, pause: float) -> int:
+        """No-op: a cluster backend tracks no Iris workers to garbage-collect."""
+        return 0
+
     def sync(self, request: ReconcileRequest) -> list[TaskUpdate]:
         """Sync task state: apply new pods, delete strays, poll running pods.
 

--- a/lib/iris/src/iris/cluster/backends/rpc/backend.py
+++ b/lib/iris/src/iris/cluster/backends/rpc/backend.py
@@ -370,6 +370,11 @@ class RpcTaskBackend:
         assert self._store is not None, "RpcTaskBackend.teardown called before worker store attached"
         self._store.reap_workers(dead_workers, reason=reason)
 
+    def prune_dead_workers(self, *, cutoff_ms: int, stop_event: threading.Event | None, pause: float) -> int:
+        """Garbage-collect this backend's stale DEAD workers through its worker store."""
+        assert self._store is not None, "RpcTaskBackend.prune_dead_workers called before worker store attached"
+        return self._store.prune_dead_workers(cutoff_ms=cutoff_ms, stop_event=stop_event, pause=pause)
+
     def autoscale(self, request: AutoscaleRequest) -> AutoscaleResult:
         """Tear down dead workers' slices, or run one provisioning cycle.
 

--- a/lib/iris/src/iris/cluster/controller/backend.py
+++ b/lib/iris/src/iris/cluster/controller/backend.py
@@ -27,6 +27,7 @@ has no Iris workers, so its ``run_teardown`` is a no-op.
 """
 
 import logging
+import threading
 from collections.abc import Callable, Mapping
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -554,6 +555,17 @@ class TaskBackend(Protocol):
         controller resolved to this backend off the reconcile path — the
         recycled-IP eviction queue. ``reason`` is recorded on the worker failure.
         A backend that tracks no Iris workers is a no-op.
+        """
+        ...
+
+    def prune_dead_workers(self, *, cutoff_ms: int, stop_event: threading.Event | None, pause: float) -> int:
+        """Garbage-collect this backend's DEAD workers whose heartbeat predates ``cutoff_ms``.
+
+        Driven by the controller's background prune loop, not the control tick. The
+        backend deletes its own dead worker rows (and their attributes) from its own
+        tracker, one per transaction, sleeping ``pause`` between deletes and stopping
+        early once ``stop_event`` is set. Returns the count removed. A backend that
+        tracks no Iris workers returns 0.
         """
         ...
 

--- a/lib/iris/src/iris/cluster/controller/backend_store.py
+++ b/lib/iris/src/iris/cluster/controller/backend_store.py
@@ -8,13 +8,15 @@ schedules and reconciles from, resolve a worker's address, and reap dead workers
 :class:`DbBackendWorkerStore` implements the interface against the controller database.
 """
 
+import threading
+import time
 from collections.abc import Callable, Iterable, Sequence
 from dataclasses import dataclass
 from typing import Protocol
 
 from rigging.timing import Timestamp
 
-from iris.cluster.controller import reads
+from iris.cluster.controller import reads, writes
 from iris.cluster.controller.audit_logging import log_event
 from iris.cluster.controller.autoscaler.persistence import persist_autoscaler_state
 from iris.cluster.controller.backend import AutoscaleRequest, AutoscaleResult, BackendSchedulingInputs
@@ -45,6 +47,19 @@ from iris.rpc import job_pb2
 _SLICE_SIBLING_TEARDOWN_REASON = "unhealthy worker failed, slice terminated"
 
 
+def _find_prunable_worker(health: WorkerHealthTracker, before_ms: int) -> WorkerId | None:
+    """Return one tracker-known worker that is DEAD with a heartbeat older than ``before_ms``.
+
+    Every persisted ``workers`` row has a tracker entry by construction (seeded at
+    boot/restore, registered on commit of ``upsert``, removed on commit of
+    ``remove``), so scanning the tracker is sufficient.
+    """
+    for worker_id, liveness in health.all().items():
+        if liveness.usability is WorkerUsability.DEAD and liveness.last_heartbeat_ms < before_ms:
+            return worker_id
+    return None
+
+
 class BackendWorkerStore(TransitionReader, Protocol):
     """The worker-state operations a worker-daemon backend depends on."""
 
@@ -71,6 +86,14 @@ class BackendWorkerStore(TransitionReader, Protocol):
     def reap_workers(self, worker_ids: list[WorkerId], *, reason: str) -> list[WorkerId]:
         """Fail ``worker_ids``, terminate their slices and healthy siblings, and forget
         them. Returns every worker removed (the failed workers plus reaped siblings)."""
+        ...
+
+    def prune_dead_workers(self, *, cutoff_ms: int, stop_event: threading.Event | None, pause: float) -> int:
+        """Delete this backend's DEAD workers whose last heartbeat predates ``cutoff_ms``.
+
+        Removes one worker (and its attributes) per transaction, sleeping ``pause``
+        between deletes so heartbeat and scheduling traffic interleave. Returns the
+        number of workers removed; stops early once ``stop_event`` is set."""
         ...
 
 
@@ -206,6 +229,25 @@ class DbBackendWorkerStore:
             )
         self.health.forget_many(removed_set | set(siblings))
         return removed_ids + siblings
+
+    def prune_dead_workers(self, *, cutoff_ms: int, stop_event: threading.Event | None, pause: float) -> int:
+        """Delete this backend's DEAD workers whose last heartbeat predates ``cutoff_ms``.
+
+        Removes one worker (and its attributes) per transaction, sleeping ``pause``
+        between deletes so heartbeat and scheduling traffic interleave. Returns the
+        number of workers removed; stops early once ``stop_event`` is set.
+        """
+        deleted = 0
+        while stop_event is None or not stop_event.is_set():
+            worker_id = _find_prunable_worker(self.health, cutoff_ms)
+            if worker_id is None:
+                break
+            with self.db.transaction() as cur:
+                writes.remove_worker(cur, worker_id, health=self.health, worker_attrs=self.worker_attrs)
+            log_event("worker_pruned", str(worker_id))
+            deleted += 1
+            time.sleep(pause)
+        return deleted
 
     def _owned_worker_ids(self, snap: Tx) -> set[WorkerId]:
         """The workers this backend owns, by scale group, in the read ``snap``."""

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -80,7 +80,7 @@ from iris.cluster.controller.scheduling.scheduler import (
     SchedulingContext,
 )
 from iris.cluster.controller.service import ControllerServiceImpl, PendingKick
-from iris.cluster.controller.worker_health import WorkerHealthTracker, WorkerLiveness
+from iris.cluster.controller.worker_health import WorkerLiveness
 from iris.cluster.log_keys import CONTROLLER_LOG_KEY
 from iris.cluster.types import (
     DEFAULT_BACKEND_ID,
@@ -523,14 +523,6 @@ class Controller:
             if BackendCapability.WORKER_DAEMON in backend.capabilities:
                 backend.seed_liveness()
 
-    def _worker_daemon_healths(self) -> list[WorkerHealthTracker]:
-        """Each worker-daemon backend's liveness tracker (disjoint by scale group)."""
-        return [
-            backend.health
-            for backend in self._backends.values()
-            if BackendCapability.WORKER_DAEMON in backend.capabilities and backend.health is not None
-        ]
-
     def all_liveness(self) -> dict[WorkerId, WorkerLiveness]:
         """Union of every worker-daemon backend's liveness (the trackers are disjoint).
 
@@ -714,9 +706,8 @@ class Controller:
                 try:
                     prune_old_data(
                         self._db,
-                        self._worker_daemon_healths(),
+                        self._backends.values(),
                         self._endpoints,
-                        self._worker_attrs,
                         job_retention=self._config.job_retention,
                         worker_retention=self._config.worker_retention,
                         slice_retention=self._config.slice_retention,

--- a/lib/iris/src/iris/cluster/controller/pruner.py
+++ b/lib/iris/src/iris/cluster/controller/pruner.py
@@ -16,18 +16,17 @@ see :func:`_prune_orphan_slices`.
 import logging
 import threading
 import time
-from collections.abc import Sequence
+from collections.abc import Iterable
 from dataclasses import dataclass
 
 from rigging.timing import Duration, Timestamp
 
 from iris.cluster.controller import reads, writes
 from iris.cluster.controller.audit_logging import log_event
+from iris.cluster.controller.backend import TaskBackend
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.projections.endpoints import EndpointsProjection
-from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
-from iris.cluster.controller.worker_health import WorkerHealthTracker
-from iris.cluster.types import TERMINAL_JOB_STATES, WorkerId, WorkerUsability
+from iris.cluster.types import TERMINAL_JOB_STATES
 
 logger = logging.getLogger(__name__)
 
@@ -44,19 +43,6 @@ class PruneResult:
     @property
     def total(self) -> int:
         return self.jobs_deleted + self.workers_deleted + self.slices_deleted + self.endpoints_deleted
-
-
-def _find_prunable_worker(health: WorkerHealthTracker, before_ms: int) -> WorkerId | None:
-    """Return one tracker-known worker that is unhealthy/inactive with a stale heartbeat.
-
-    Every persisted ``workers`` row has a tracker entry by construction
-    (seeded at boot/restore, registered on commit of ``upsert``, removed
-    on commit of ``remove``), so scanning the tracker is sufficient.
-    """
-    for worker_id, liveness in health.all().items():
-        if liveness.usability is WorkerUsability.DEAD and liveness.last_heartbeat_ms < before_ms:
-            return worker_id
-    return None
 
 
 def _stopped(stop_event: threading.Event | None) -> bool:
@@ -85,31 +71,18 @@ def _prune_terminal_jobs(
 
 
 def _prune_dead_workers(
-    db: ControllerDB,
-    healths: Sequence[WorkerHealthTracker],
-    worker_attrs: WorkerAttrsProjection,
-    cutoff_ms: int,
-    stop_event: threading.Event | None,
-    pause: float,
+    backends: Iterable[TaskBackend], cutoff_ms: int, stop_event: threading.Event | None, pause: float
 ) -> int:
-    """Delete DEAD workers whose last heartbeat predates ``cutoff_ms``, one CASCADE (attributes) at a time.
+    """Delete each backend's DEAD workers whose last heartbeat predates ``cutoff_ms``.
 
-    Each backend owns its own tracker, so a worker is reaped from the tracker that
-    holds it (the trackers are disjoint); scanning each in turn finds every
-    prunable worker.
+    Each backend garbage-collects the dead workers in its own tracker (the trackers
+    are disjoint by scale group); a backend that tracks no Iris workers prunes
+    nothing. The per-worker delete cadence (one CASCADE per transaction, ``pause``
+    between deletes, early stop on ``stop_event``) lives in the backend.
     """
-    deleted = 0
-    for health in healths:
-        while not _stopped(stop_event):
-            worker_id = _find_prunable_worker(health, cutoff_ms)
-            if worker_id is None:
-                break
-            with db.transaction() as cur:
-                writes.remove_worker(cur, worker_id, health=health, worker_attrs=worker_attrs)
-            log_event("worker_pruned", str(worker_id))
-            deleted += 1
-            time.sleep(pause)
-    return deleted
+    return sum(
+        backend.prune_dead_workers(cutoff_ms=cutoff_ms, stop_event=stop_event, pause=pause) for backend in backends
+    )
 
 
 def _prune_orphan_slices(db: ControllerDB, cutoff_ms: int, stop_event: threading.Event | None, pause: float) -> int:
@@ -151,9 +124,8 @@ def _sweep_expired_endpoints(db: ControllerDB, endpoints: EndpointsProjection, n
 
 def prune_old_data(
     db: ControllerDB,
-    healths: Sequence[WorkerHealthTracker],
+    backends: Iterable[TaskBackend],
     endpoints: EndpointsProjection,
-    worker_attrs: WorkerAttrsProjection,
     *,
     job_retention: Duration,
     worker_retention: Duration,
@@ -169,9 +141,8 @@ def prune_old_data(
 
     Args:
         db: Controller database handle.
-        healths: Each backend's worker health tracker, scanned in turn for stale workers.
+        backends: The backends, each of which garbage-collects its own dead workers.
         endpoints: Endpoints projection invalidated before each job CASCADE.
-        worker_attrs: Worker attributes projection invalidated on worker removal.
         job_retention: Delete terminal jobs whose finished_at is older than this.
         worker_retention: Delete inactive/unhealthy workers whose last heartbeat is older than this.
         slice_retention: Delete orphaned slices from abandoned scale groups (no backing worker row) older than this.
@@ -182,9 +153,7 @@ def prune_old_data(
     now_ms = now.epoch_ms()
     result = PruneResult(
         jobs_deleted=_prune_terminal_jobs(db, endpoints, now_ms - job_retention.to_ms(), stop_event, pause_between_s),
-        workers_deleted=_prune_dead_workers(
-            db, healths, worker_attrs, now_ms - worker_retention.to_ms(), stop_event, pause_between_s
-        ),
+        workers_deleted=_prune_dead_workers(backends, now_ms - worker_retention.to_ms(), stop_event, pause_between_s),
         slices_deleted=_prune_orphan_slices(db, now_ms - slice_retention.to_ms(), stop_event, pause_between_s),
         endpoints_deleted=_sweep_expired_endpoints(db, endpoints, now),
     )

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -283,12 +283,8 @@ class FakeProvider:
 
 
 def worker_daemon_backends_for_prune(state: ControllerTestState) -> list[FakeProvider]:
-    """A single worker-daemon backend bound to ``state``'s db/health/worker_attrs.
-
-    The per-backend dead-worker GC ``prune_old_data`` drives lives on a backend's
-    worker store, so prune tests pass a real backend built over the test state
-    rather than reaching into a tracker directly.
-    """
+    """A single worker-daemon backend bound to ``state``'s db/health/worker_attrs,
+    for tests that drive ``prune_old_data``'s per-backend dead-worker GC."""
     provider = FakeProvider()
     provider.health = state._health
     provider.bind_runtime(

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -5,6 +5,7 @@
 
 import shutil
 import tempfile
+import threading
 from collections.abc import Callable
 from contextlib import contextmanager
 from dataclasses import dataclass
@@ -95,6 +96,7 @@ from iris.cluster.types import (
     AcceleratorType,
     CapacityType,
     JobName,
+    UserBudgetDefaults,
     WorkerId,
     is_job_finished,
 )
@@ -248,6 +250,10 @@ class FakeProvider:
         assert self._store is not None, "FakeProvider.teardown called before worker store attached"
         self._store.reap_workers(dead_workers, reason=reason)
 
+    def prune_dead_workers(self, *, cutoff_ms: int, stop_event: threading.Event | None, pause: float) -> int:
+        assert self._store is not None, "FakeProvider.prune_dead_workers called before worker store attached"
+        return self._store.prune_dead_workers(cutoff_ms=cutoff_ms, stop_event=stop_event, pause=pause)
+
     def bind_runtime(self, runtime: BackendRuntime) -> None:
         self._store = store_from_runtime(runtime, self.health, self.autoscale)
 
@@ -274,6 +280,28 @@ class FakeProvider:
 
     def close(self) -> None:
         pass
+
+
+def worker_daemon_backends_for_prune(state: ControllerTestState) -> list[FakeProvider]:
+    """A single worker-daemon backend bound to ``state``'s db/health/worker_attrs.
+
+    The per-backend dead-worker GC ``prune_old_data`` drives lives on a backend's
+    worker store, so prune tests pass a real backend built over the test state
+    rather than reaching into a tracker directly.
+    """
+    provider = FakeProvider()
+    provider.health = state._health
+    provider.bind_runtime(
+        BackendRuntime(
+            db=state._db,
+            endpoints=state._endpoints,
+            run_template_cache=state._run_template_cache,
+            worker_attrs=state._worker_attrs,
+            owns_scale_group=lambda _scale_group: True,
+            budget_defaults=UserBudgetDefaults(),
+        )
+    )
+    return [provider]
 
 
 @pytest.fixture

--- a/lib/iris/tests/cluster/controller/replay/scenarios.py
+++ b/lib/iris/tests/cluster/controller/replay/scenarios.py
@@ -28,6 +28,7 @@ from sqlalchemy import select
 from sqlalchemy import update as sa_update
 
 from tests.cluster.controller._test_support import ControllerTestState
+from tests.cluster.controller.conftest import worker_daemon_backends_for_prune
 from tests.cluster.controller.replay.events import (
     AddEndpoint,
     ApplyDirectProviderUpdates,
@@ -516,9 +517,8 @@ def scenario_prune_old_data(transitions: ControllerTestState, clock: FrozenClock
     # Direct call: prune_old_data is intentionally not an IrisEvent.
     prune_old_data(
         transitions._db,
-        [transitions._health],
+        worker_daemon_backends_for_prune(transitions),
         transitions._endpoints,
-        transitions._worker_attrs,
         job_retention=Duration.from_seconds(0),
         worker_retention=Duration.from_seconds(3600),
         slice_retention=Duration.from_seconds(3600),

--- a/lib/iris/tests/cluster/controller/test_direct_controller.py
+++ b/lib/iris/tests/cluster/controller/test_direct_controller.py
@@ -3,6 +3,8 @@
 
 """Tests for KubernetesProvider integration with controller and transitions."""
 
+import threading
+
 from finelog.rpc import logging_pb2
 from iris.cluster.controller import ops
 from iris.cluster.controller.backend import (
@@ -71,6 +73,10 @@ class FakeDirectProvider:
 
     def teardown(self, dead_workers, *, reason: str) -> None:
         """No-op: a cluster-view backend tracks no Iris workers to reap."""
+
+    def prune_dead_workers(self, *, cutoff_ms: int, stop_event: threading.Event | None, pause: float) -> int:
+        """No-op: a cluster-view backend tracks no Iris workers to garbage-collect."""
+        return 0
 
     def schedule(self, request: ScheduleRequest) -> ScheduleResult:
         return ScheduleResult()

--- a/lib/iris/tests/cluster/controller/test_reconcile.py
+++ b/lib/iris/tests/cluster/controller/test_reconcile.py
@@ -14,6 +14,7 @@ Three layers, exercised in order:
    tick's reconcile phase (``reconcile_once``).
 """
 
+import threading
 from dataclasses import dataclass, field
 from typing import Any, ClassVar, cast
 
@@ -1225,6 +1226,10 @@ class _ScriptedProvider:
         assert self._store is not None, "_ScriptedProvider.teardown called before worker store attached"
         self._store.reap_workers(dead_workers, reason=reason)
 
+    def prune_dead_workers(self, *, cutoff_ms: int, stop_event: threading.Event | None, pause: float) -> int:
+        assert self._store is not None, "_ScriptedProvider.prune_dead_workers called before worker store attached"
+        return self._store.prune_dead_workers(cutoff_ms=cutoff_ms, stop_event=stop_event, pause=pause)
+
     def close(self):
         pass
 
@@ -1418,6 +1423,10 @@ class _UnreachableProvider:
     def teardown(self, dead_workers: list[WorkerId], *, reason: str) -> None:
         assert self._store is not None, "_UnreachableProvider.teardown called before worker store attached"
         self._store.reap_workers(dead_workers, reason=reason)
+
+    def prune_dead_workers(self, *, cutoff_ms: int, stop_event: threading.Event | None, pause: float) -> int:
+        assert self._store is not None, "_UnreachableProvider.prune_dead_workers called before worker store attached"
+        return self._store.prune_dead_workers(cutoff_ms=cutoff_ms, stop_event=stop_event, pause=pause)
 
     def autoscale(self, request: AutoscaleRequest) -> AutoscaleResult:
         self.autoscale_calls.append(list(request.dead_workers))

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -74,6 +74,7 @@ from .conftest import (
     register_worker,
     submit_job,
     transition_task,
+    worker_daemon_backends_for_prune,
     worker_running_tasks,
 )
 from .conftest import (
@@ -3575,9 +3576,8 @@ def test_prune_old_terminal_jobs(state):
     # Prune with a 1-day retention — old-job finished at ~epoch, recent-job finished just now
     result = prune_old_data(
         state._db,
-        [state._health],
+        worker_daemon_backends_for_prune(state),
         state._endpoints,
-        state._worker_attrs,
         job_retention=Duration.from_seconds(86400),
         worker_retention=Duration.from_seconds(86400),
         slice_retention=Duration.from_seconds(86400),
@@ -3611,9 +3611,8 @@ def test_prune_old_inactive_workers(state):
 
     result = prune_old_data(
         state._db,
-        [state._health],
+        worker_daemon_backends_for_prune(state),
         state._endpoints,
-        state._worker_attrs,
         job_retention=Duration.from_seconds(86400),
         worker_retention=Duration.from_seconds(86400),
         slice_retention=Duration.from_seconds(86400),
@@ -3629,9 +3628,8 @@ def test_prune_noop_when_nothing_old(state):
 
     result = prune_old_data(
         state._db,
-        [state._health],
+        worker_daemon_backends_for_prune(state),
         state._endpoints,
-        state._worker_attrs,
         job_retention=Duration.from_seconds(86400),
         worker_retention=Duration.from_seconds(86400),
         slice_retention=Duration.from_seconds(86400),
@@ -3685,9 +3683,8 @@ def test_prune_orphaned_slices(state):
 
     result = prune_old_data(
         state._db,
-        [state._health],
+        worker_daemon_backends_for_prune(state),
         state._endpoints,
-        state._worker_attrs,
         job_retention=Duration.from_seconds(86400),
         worker_retention=Duration.from_seconds(86400),
         slice_retention=Duration.from_seconds(3600),
@@ -3715,9 +3712,8 @@ def test_prune_keeps_slice_with_live_worker_despite_empty_worker_ids(state):
 
     result = prune_old_data(
         state._db,
-        [state._health],
+        worker_daemon_backends_for_prune(state),
         state._endpoints,
-        state._worker_attrs,
         job_retention=Duration.from_seconds(86400),
         worker_retention=Duration.from_seconds(86400),
         slice_retention=Duration.from_seconds(3600),
@@ -3781,9 +3777,8 @@ def test_prune_old_data_short_circuits_when_nothing_prunable(state):
 
     result = prune_old_data(
         state._db,
-        [state._health],
+        worker_daemon_backends_for_prune(state),
         state._endpoints,
-        state._worker_attrs,
         job_retention=Duration.from_seconds(86400),
         worker_retention=Duration.from_seconds(86400),
         slice_retention=Duration.from_seconds(86400),


### PR DESCRIPTION
The controller's background prune loop reached into every backend's health tracker and worker-attributes projection to delete stale DEAD workers. Make each backend garbage-collect its own dead workers instead.

`prune_dead_workers` is added to the `BackendWorkerStore` protocol — implemented on `DbBackendWorkerStore`, which already holds the `db`, `health` tracker, and `worker_attrs` it needs — and to the `TaskBackend` protocol, delegated by `RpcTaskBackend` and a no-op on the Kubernetes backend (it tracks no Iris workers). `prune_old_data` now takes the backends collection and sums each backend's own GC, so the controller keeps only the cross-backend prune concerns: terminal jobs, orphan slices, and expired endpoints.

This continues the `BackendWorkerStore` ownership transfer (P3): the controller moves toward a thin router while each backend owns its workers, attributes, and liveness. The worker prune still runs on the controller's background prune thread — it touches only worker rows, attributes, and tracker entries, never the autoscaler — and preserves the cutoff semantics, the one-delete-per-transaction-plus-`pause` cadence, the `PruneResult.workers_deleted` count, and the `worker_pruned` audit event. The `prune_old_data` replay golden is unchanged.

Design note: `prune_old_data` takes the backends collection (`self._backends.values()`) rather than a list of stores, since the controller holds backends and each backend already encapsulates its store.

Part of #6718.