### PR TITLE
[iris] Give each backend its own worker-attributes projection

### DIFF
--- a/lib/iris/scripts/benchmark_controller.py
+++ b/lib/iris/scripts/benchmark_controller.py
@@ -82,6 +82,7 @@ from iris.cluster.controller.log_stack import build_log_stack
 from iris.cluster.controller.ops.task import Assignment
 from iris.cluster.controller.ops.worker import apply_reconcile
 from iris.cluster.controller.projections.endpoints import EndpointQuery, EndpointRow, EndpointsProjection
+from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.reads import (  # noqa: F401
     ControlSnapshot,
     SchedulableWorker,
@@ -182,6 +183,7 @@ class _FakeProvider:
         self._scheduler = Scheduler()
         self._store: BackendWorkerStore | None = None
         self.health: WorkerHealthTracker = WorkerHealthTracker()
+        self.worker_attrs: WorkerAttrsProjection | None = None
         self.advertised: dict[str, set[str]] = {}
         self.allowed_users: frozenset[str] = frozenset({"*"})
         self._pending_dead: list[WorkerId] = []
@@ -212,11 +214,12 @@ class _FakeProvider:
         raise RuntimeError("fake provider")
 
     def bind_runtime(self, runtime: BackendRuntime) -> None:
+        self.worker_attrs = WorkerAttrsProjection(runtime.db, owns_scale_group=runtime.owns_scale_group)
         self._store = DbBackendWorkerStore(
             db=runtime.db,
             owns_scale_group=runtime.owns_scale_group,
             health=self.health,
-            worker_attrs=runtime.worker_attrs,
+            worker_attrs=self.worker_attrs,
             endpoints=runtime.endpoints,
             run_template_cache=runtime.run_template_cache,
             defaults=runtime.budget_defaults,

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -40,6 +40,7 @@ from iris.cluster.controller.backend import (
     user_admitted,
 )
 from iris.cluster.controller.ops.task import apply_dispatch_updates
+from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.reconcile.loader import TransitionReader
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
 from iris.cluster.controller.task_state import RunningTaskEntry
@@ -1449,6 +1450,9 @@ class K8sTaskProvider:
     # A cluster backend tracks no Iris worker liveness; the controller's union read
     # skips a None tracker, and no worker registers into a k8s scale group.
     health: WorkerHealthTracker | None = field(default=None, init=False, repr=False)
+    # A cluster backend tracks no Iris worker attributes; no worker registers
+    # into a k8s scale group.
+    worker_attrs: WorkerAttrsProjection | None = field(default=None, init=False, repr=False)
     # The controller-DB read surface this backend authors its dispatch effects
     # from, passed by the composer at construction (a cluster backend has no
     # worker store, so it reads its dispatch drain through this).

--- a/lib/iris/src/iris/cluster/backends/rpc/backend.py
+++ b/lib/iris/src/iris/cluster/backends/rpc/backend.py
@@ -44,6 +44,7 @@ from iris.cluster.controller.backend import (
 )
 from iris.cluster.controller.backend_store import BackendWorkerStore, DbBackendWorkerStore
 from iris.cluster.controller.ops.worker import apply_reconcile
+from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.reconcile.worker import WorkerReconcilePlan, WorkerReconcileResult
 from iris.cluster.controller.scheduling.scheduler import Scheduler
 from iris.cluster.controller.worker_health import (
@@ -200,6 +201,11 @@ class RpcTaskBackend:
     # Fleet/exec/capacity/prune paths and routes a registering worker's liveness to
     # it by scale group.
     health: WorkerHealthTracker = field(init=False, repr=False)
+    # This backend's worker-attributes projection, constructed in ``bind_runtime``
+    # (it needs ``runtime.db``/``owns_scale_group``, unavailable at construction)
+    # and holding only the workers in this backend's scale groups. The controller
+    # routes a registering worker's attributes to it by scale group.
+    worker_attrs: WorkerAttrsProjection | None = field(default=None, init=False, repr=False)
     # One shared scheduler instance reused across cycles; per-tick worker state
     # comes from ``_store``.
     _scheduler: Scheduler = field(default_factory=Scheduler, init=False, repr=False)
@@ -212,13 +218,14 @@ class RpcTaskBackend:
         self.health = WorkerHealthTracker(unreachable_grace=self.unreachable_grace)
 
     def bind_runtime(self, runtime: BackendRuntime) -> None:
-        """Build this backend's worker store from ``runtime`` and the backend's own
-        liveness tracker and ``autoscale`` callback."""
+        """Build this backend's worker-attributes projection and worker store from
+        ``runtime`` and the backend's own liveness tracker and ``autoscale`` callback."""
+        self.worker_attrs = WorkerAttrsProjection(runtime.db, owns_scale_group=runtime.owns_scale_group)
         self._store = DbBackendWorkerStore(
             db=runtime.db,
             owns_scale_group=runtime.owns_scale_group,
             health=self.health,
-            worker_attrs=runtime.worker_attrs,
+            worker_attrs=self.worker_attrs,
             endpoints=runtime.endpoints,
             run_template_cache=runtime.run_template_cache,
             defaults=runtime.budget_defaults,

--- a/lib/iris/src/iris/cluster/controller/backend.py
+++ b/lib/iris/src/iris/cluster/controller/backend.py
@@ -445,8 +445,6 @@ class BackendRuntime:
     """The worker-endpoint projection."""
     run_template_cache: RunTemplateCache
     """Per-job ``RunTaskRequest`` template cache."""
-    worker_attrs: WorkerAttrsProjection
-    """The worker-attributes projection."""
     owns_scale_group: Callable[[str], bool]
     """Whether a scale group belongs to this backend (the default backend also claims
     scale groups mapped to no backend)."""
@@ -486,6 +484,14 @@ class TaskBackend(Protocol):
         workers (k8s). The backend folds and reaps through it; the controller reaches
         worker liveness through it (routed by scale group) for its Fleet/exec/capacity/
         prune readers and to seed/register a worker into its owning backend."""
+        ...
+
+    @property
+    def worker_attrs(self) -> WorkerAttrsProjection | None:
+        """The worker-attributes projection this backend constructs and owns, holding
+        only the workers in its scale groups, or None for a backend that tracks no
+        Iris workers (k8s). The controller reaches it (routed by scale group) to
+        register a worker's attributes into its owning backend."""
         ...
 
     allowed_users: frozenset[str]

--- a/lib/iris/src/iris/cluster/controller/backend_store.py
+++ b/lib/iris/src/iris/cluster/controller/backend_store.py
@@ -251,8 +251,7 @@ class DbBackendWorkerStore:
 
     def _owned_worker_ids(self, snap: Tx) -> set[WorkerId]:
         """The workers this backend owns, by scale group, in the read ``snap``."""
-        groups = reads.worker_scale_groups(snap)
-        return {wid for wid, scale_group in groups.items() if self.owns_scale_group(scale_group)}
+        return reads.owned_worker_ids(snap, self.owns_scale_group)
 
     def _run_templates(self, snap: Tx, reconcile_rows: Sequence[ReconcileRow]) -> dict[JobName, job_pb2.RunTaskRequest]:
         """Per-job ``RunTaskRequest`` templates for the ASSIGNED rows, dropping uncached jobs."""

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -57,7 +57,6 @@ from iris.cluster.controller.ops.task import (
     finalize,
 )
 from iris.cluster.controller.projections.endpoints import EndpointsProjection
-from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.pruner import prune_old_data
 from iris.cluster.controller.reconcile import dispatch
 from iris.cluster.controller.reconcile.commit import commit_effects
@@ -351,8 +350,6 @@ class Controller:
         else:
             self._db = ControllerDB(db_dir=config.local_state_dir / "db")
         self._endpoints = EndpointsProjection(self._db)
-        self._worker_attrs = WorkerAttrsProjection(self._db)
-        writes.validate()
 
         self._threads = threads if threads is not None else get_thread_container()
 
@@ -381,6 +378,10 @@ class Controller:
             if BackendCapability.WORKER_DAEMON in backend.capabilities:
                 backend.bind_runtime(self._build_runtime(backend_id))
 
+        # Runs after binding so the per-backend WorkerAttrsProjection each backend
+        # registers in bind_runtime is present in PROJECTIONS for the owned-table check.
+        writes.validate()
+
         # Seed each backend's liveness from its persisted workers so the scheduler
         # sees them at startup, and reseed after a DB reopen (checkpoint restore).
         # ``find_prunable`` relies on this to keep every ``workers`` row tracked.
@@ -401,7 +402,6 @@ class Controller:
             db=self._db,
             endpoints=self._endpoints,
             endpoint_service=self._endpoint_service,
-            worker_attrs=self._worker_attrs,
             auth=config.auth,
             user_budget_defaults=config.user_budget_defaults,
         )
@@ -922,7 +922,6 @@ class Controller:
             db=self._db,
             endpoints=self._endpoints,
             run_template_cache=self._run_template_cache,
-            worker_attrs=self._worker_attrs,
             owns_scale_group=owns_scale_group,
             budget_defaults=self._config.user_budget_defaults,
         )

--- a/lib/iris/src/iris/cluster/controller/projections/worker_attrs.py
+++ b/lib/iris/src/iris/cluster/controller/projections/worker_attrs.py
@@ -58,9 +58,8 @@ class WorkerAttrsProjection:
     """Process-local write-through cache over the ``worker_attributes`` table.
 
     Scoped to one backend: holds attributes only for workers whose scale group
-    ``owns_scale_group`` claims, mirroring how :class:`WorkerHealthTracker` is
-    constructed per backend. Reads serve the latest committed snapshot from an
-    in-memory dict guarded by a ``threading.Lock``. Writes register a
+    ``owns_scale_group`` claims. Reads serve the latest committed snapshot from
+    an in-memory dict guarded by a ``threading.Lock``. Writes register a
     post-commit hook that updates the dict atomically with the surrounding SQL
     commit; the hook fires under the DB write lock so concurrent readers
     cannot observe torn state.

--- a/lib/iris/src/iris/cluster/controller/projections/worker_attrs.py
+++ b/lib/iris/src/iris/cluster/controller/projections/worker_attrs.py
@@ -23,7 +23,7 @@ from typing import ClassVar, Protocol
 from sqlalchemy import select
 
 from iris.cluster.constraints import AttributeValue
-from iris.cluster.controller import db
+from iris.cluster.controller import db, reads
 from iris.cluster.controller.codec import WorkerAttributeRow, attribute_value_from_row
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.projections import PROJECTIONS
@@ -57,17 +57,20 @@ def _decode_value(row: WorkerAttributeRow) -> AttributeValue:
 class WorkerAttrsProjection:
     """Process-local write-through cache over the ``worker_attributes`` table.
 
-    Reads serve the latest committed snapshot from an in-memory dict guarded
-    by a ``threading.Lock``. Writes register a post-commit hook that
-    updates the dict atomically with the surrounding SQL commit; the hook
-    fires under the DB write lock so concurrent readers cannot observe
-    torn state.
+    Scoped to one backend: holds attributes only for workers whose scale group
+    ``owns_scale_group`` claims, mirroring how :class:`WorkerHealthTracker` is
+    constructed per backend. Reads serve the latest committed snapshot from an
+    in-memory dict guarded by a ``threading.Lock``. Writes register a
+    post-commit hook that updates the dict atomically with the surrounding SQL
+    commit; the hook fires under the DB write lock so concurrent readers
+    cannot observe torn state.
     """
 
     sources: ClassVar = (worker_attributes_table,)
 
-    def __init__(self, db: ControllerDB) -> None:
+    def __init__(self, db: ControllerDB, *, owns_scale_group: Callable[[str], bool]) -> None:
         self._db = db
+        self._owns_scale_group = owns_scale_group
         self._lock = threading.Lock()
         self._cache: dict[WorkerId, dict[str, AttributeValue]] = {}
         PROJECTIONS.append(self)
@@ -78,7 +81,7 @@ class WorkerAttrsProjection:
     # -- Loading --------------------------------------------------------------
 
     def rehydrate(self) -> None:
-        """Reload the cache from SQL via the SA read engine.
+        """Reload the cache from SQL via the SA read engine, scoped to owned workers.
 
         Called once at construction and again after ``ControllerDB.replace_from``
         has swapped the underlying database file. ``WorkerIdType`` on
@@ -87,7 +90,10 @@ class WorkerAttrsProjection:
         """
         decoded: dict[WorkerId, dict[str, AttributeValue]] = {}
         with db.read_snapshot(self._db.sa_read_engine) as tx:
+            owned = reads.owned_worker_ids(tx, self._owns_scale_group)
             for row in tx.execute(select(worker_attributes_table)).all():
+                if row.worker_id not in owned:
+                    continue
                 decoded.setdefault(row.worker_id, {})[row.key] = _decode_value(row)
         with self._lock:
             self._cache.clear()

--- a/lib/iris/src/iris/cluster/controller/reads.py
+++ b/lib/iris/src/iris/cluster/controller/reads.py
@@ -19,7 +19,7 @@ Areas covered:
   control-cycle   — the per-tick ControlSnapshot built via load_control_snapshot
 """
 
-from collections.abc import Iterable, Mapping, Sequence
+from collections.abc import Callable, Iterable, Mapping, Sequence
 from dataclasses import dataclass, field
 from typing import Protocol
 
@@ -1487,6 +1487,11 @@ def worker_scale_groups(tx: Tx) -> dict[WorkerId, str]:
     """
     rows = tx.execute(select(workers_table.c.worker_id, workers_table.c.scale_group)).all()
     return {WorkerId(str(row.worker_id)): str(row.scale_group or "") for row in rows}
+
+
+def owned_worker_ids(tx: Tx, owns_scale_group: Callable[[str], bool]) -> set[WorkerId]:
+    """The workers whose scale group ``owns_scale_group`` claims, in the read ``tx``."""
+    return {wid for wid, scale_group in worker_scale_groups(tx).items() if owns_scale_group(scale_group)}
 
 
 _EXECUTING_TASK_STATES = (int(job_pb2.TASK_STATE_BUILDING), int(job_pb2.TASK_STATE_RUNNING))

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -59,7 +59,6 @@ from iris.cluster.controller.codec import (
 from iris.cluster.controller.db import ControllerDB, Tx
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.projections.endpoints import EndpointsProjection
-from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.reads import TaskJobSummary
 from iris.cluster.controller.reconcile.policy import MAX_ACTIVE_TASKS_PER_USER
 from iris.cluster.controller.reconcile.task import TerminalKind
@@ -1005,7 +1004,6 @@ class ControllerServiceImpl:
         log_client: LogClient for reading task logs through LogService.FetchLogs.
         db: Underlying database connection.
         endpoints: Endpoint projection (in-memory cache over the endpoints table).
-        worker_attrs: Worker attributes projection.
     """
 
     def __init__(
@@ -1017,7 +1015,6 @@ class ControllerServiceImpl:
         db: ControllerDB,
         endpoints: EndpointsProjection,
         endpoint_service: EndpointServiceImpl,
-        worker_attrs: WorkerAttrsProjection,
         auth: ControllerAuth | None = None,
         user_budget_defaults: UserBudgetDefaults | None = None,
     ):
@@ -1026,7 +1023,6 @@ class ControllerServiceImpl:
         # The leased registry owns endpoint logic; the legacy
         # ControllerService.{Register,Unregister,List}Endpoint RPCs delegate here.
         self._endpoint_service = endpoint_service
-        self._worker_attrs = worker_attrs
         self._controller = controller
         self._bundle_store = bundle_store
         self._log_client = log_client
@@ -1842,11 +1838,14 @@ class ControllerServiceImpl:
             )
         worker_id = WorkerId(request.worker_id)
 
-        # Route the worker into the liveness tracker owned by the backend that owns
-        # its scale group; a worker never registers into a k8s scale group.
+        # Route the worker into the liveness tracker and attributes projection owned
+        # by the backend that owns its scale group; a worker never registers into a
+        # k8s scale group.
         backend = self._backend_for_id(self._controller.backend_id_for_scale_group(request.scale_group))
         health = backend.health
+        worker_attrs = backend.worker_attrs
         assert health is not None, f"worker {worker_id} registered into a scale group with no liveness tracker"
+        assert worker_attrs is not None, f"worker {worker_id} registered into a scale group with no attrs projection"
         with self._db.transaction() as cur:
             ops.worker.register(
                 cur,
@@ -1855,7 +1854,7 @@ class ControllerServiceImpl:
                 metadata=request.metadata,
                 ts=Timestamp.now(),
                 health=health,
-                worker_attrs=self._worker_attrs,
+                worker_attrs=worker_attrs,
                 slice_id=request.slice_id,
                 scale_group=request.scale_group,
             )

--- a/lib/iris/tests/cluster/conftest.py
+++ b/lib/iris/tests/cluster/conftest.py
@@ -443,7 +443,7 @@ def _make_k8s_harness(tmp_path, log_address: str) -> ServiceTestHarness:
     db = ControllerDB(db_dir=tmp_path / "k8s_db")
     health = WorkerHealthTracker()
     endpoints = EndpointsProjection(db)
-    worker_attrs = WorkerAttrsProjection(db)
+    worker_attrs = WorkerAttrsProjection(db, owns_scale_group=lambda _scale_group: True)
     state = ControllerTestState(db, health=health, endpoints=endpoints, worker_attrs=worker_attrs)
 
     k8s = InMemoryK8sService()
@@ -472,7 +472,6 @@ def _make_k8s_harness(tmp_path, log_address: str) -> ServiceTestHarness:
         log_client=LogClient.connect(log_address),
         db=db,
         endpoints=endpoints,
-        worker_attrs=worker_attrs,
         endpoint_service=EndpointServiceImpl(db=db, endpoints=endpoints),
     )
 
@@ -490,14 +489,15 @@ def _make_gcp_harness(tmp_path, log_address: str) -> ServiceTestHarness:
     db = ControllerDB(db_dir=tmp_path / "gcp_db")
     health = WorkerHealthTracker()
     endpoints = EndpointsProjection(db)
-    worker_attrs = WorkerAttrsProjection(db)
+    worker_attrs = WorkerAttrsProjection(db, owns_scale_group=lambda _scale_group: True)
     state = ControllerTestState(db, health=health, endpoints=endpoints, worker_attrs=worker_attrs)
 
     ctrl = _HarnessController()
     ctrl.capabilities = frozenset({BackendCapability.WORKER_DAEMON, BackendCapability.IRIS_AUTOSCALER})
-    # Share the harness tracker so the service registers into and reads liveness
-    # through the same object this harness's ControllerTestState exposes.
+    # Share the harness tracker/projection so the service registers into and reads
+    # liveness/attrs through the same objects this harness's ControllerTestState exposes.
     ctrl.provider.health = health
+    ctrl.provider.worker_attrs = worker_attrs
 
     service = ControllerServiceImpl(
         controller=ctrl,
@@ -505,7 +505,6 @@ def _make_gcp_harness(tmp_path, log_address: str) -> ServiceTestHarness:
         log_client=LogClient.connect(log_address),
         db=db,
         endpoints=endpoints,
-        worker_attrs=worker_attrs,
         endpoint_service=EndpointServiceImpl(db=db, endpoints=endpoints),
     )
 

--- a/lib/iris/tests/cluster/controller/_test_support.py
+++ b/lib/iris/tests/cluster/controller/_test_support.py
@@ -40,9 +40,11 @@ class ControllerTestState:
     """Projection bundle for tests that drive ``commands.*`` / ``reconcile_io.*``
     without booting a full ``Controller``.
 
-    Field names match the underscored ones on :class:`Controller`
-    (``_db``, ``_health``, ``_endpoints``, ``_worker_attrs``,
-    ``_run_template_cache``) so the same helpers work against either.
+    Field names match the underscored ones a single-backend :class:`Controller`
+    exposes through its default backend (``_db``, ``_health``, ``_endpoints``,
+    ``_run_template_cache``) so the same helpers work against either. Unlike a
+    real backend's scale-group-scoped projections, ``_worker_attrs`` here claims
+    every worker by default, since tests built on this state simulate one backend.
     """
 
     _db: ControllerDB
@@ -63,7 +65,7 @@ class ControllerTestState:
         self._db = db
         self._health = health or WorkerHealthTracker()
         self._endpoints = endpoints or EndpointsProjection(db)
-        self._worker_attrs = worker_attrs or WorkerAttrsProjection(db)
+        self._worker_attrs = worker_attrs or WorkerAttrsProjection(db, owns_scale_group=lambda _scale_group: True)
         self._run_template_cache = run_template_cache or new_run_template_cache()
 
 

--- a/lib/iris/tests/cluster/controller/conftest.py
+++ b/lib/iris/tests/cluster/controller/conftest.py
@@ -69,6 +69,7 @@ from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.log_stack import build_log_stack
 from iris.cluster.controller.ops.task import Assignment
 from iris.cluster.controller.ops.worker import apply_reconcile
+from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.reads import SchedulableWorker
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
 from iris.cluster.controller.reconcile.worker import WorkerReconcilePlan, WorkerReconcileResult
@@ -171,15 +172,17 @@ def run_worker_daemon_reconcile(
 def store_from_runtime(
     runtime: BackendRuntime,
     health: WorkerHealthTracker,
+    worker_attrs: WorkerAttrsProjection,
     autoscale: Callable[[AutoscaleRequest], AutoscaleResult],
 ) -> DbBackendWorkerStore:
-    """Build a fake's worker store from the controller runtime + its own tracker and
-    ``autoscale`` — the worker-daemon fakes' shared mirror of ``RpcTaskBackend.bind_runtime``."""
+    """Build a fake's worker store from the controller runtime + its own tracker,
+    attrs projection, and ``autoscale`` — the worker-daemon fakes' shared mirror of
+    ``RpcTaskBackend.bind_runtime``."""
     return DbBackendWorkerStore(
         db=runtime.db,
         owns_scale_group=runtime.owns_scale_group,
         health=health,
-        worker_attrs=runtime.worker_attrs,
+        worker_attrs=worker_attrs,
         endpoints=runtime.endpoints,
         run_template_cache=runtime.run_template_cache,
         defaults=runtime.budget_defaults,
@@ -205,6 +208,9 @@ class FakeProvider:
         # This backend's own liveness tracker (the controller builds its worker
         # store over this same object), mirroring RpcTaskBackend.
         self.health: WorkerHealthTracker = WorkerHealthTracker()
+        # This backend's own attributes projection, built in ``bind_runtime`` once
+        # ``runtime.db``/``owns_scale_group`` are known, mirroring RpcTaskBackend.
+        self.worker_attrs: WorkerAttrsProjection | None = None
         self.advertised: dict[str, set[str]] = {}
         self.allowed_users: frozenset[str] = frozenset({"*"})
         # Workers this fake's reconcile fold reaped, awaiting run_teardown.
@@ -254,7 +260,8 @@ class FakeProvider:
         return self._store.prune_dead_workers(cutoff_ms=cutoff_ms, stop_event=stop_event, pause=pause)
 
     def bind_runtime(self, runtime: BackendRuntime) -> None:
-        self._store = store_from_runtime(runtime, self.health, self.autoscale)
+        self.worker_attrs = WorkerAttrsProjection(runtime.db, owns_scale_group=runtime.owns_scale_group)
+        self._store = store_from_runtime(runtime, self.health, self.worker_attrs, self.autoscale)
 
     def seed_liveness(self) -> None:
         assert self._store is not None, "FakeProvider.seed_liveness called before worker store attached"
@@ -282,8 +289,10 @@ class FakeProvider:
 
 
 def worker_daemon_backends_for_prune(state: ControllerTestState) -> list[FakeProvider]:
-    """A single worker-daemon backend bound to ``state``'s db/health/worker_attrs,
-    for tests that drive ``prune_old_data``'s per-backend dead-worker GC."""
+    """A single worker-daemon backend bound to ``state``'s db/health, for tests
+    that drive ``prune_old_data``'s per-backend dead-worker GC. The backend builds
+    its own attrs projection (claiming every worker, like ``state._worker_attrs``)
+    since pruning never reads attribute content."""
     provider = FakeProvider()
     provider.health = state._health
     provider.bind_runtime(
@@ -291,7 +300,6 @@ def worker_daemon_backends_for_prune(state: ControllerTestState) -> list[FakePro
             db=state._db,
             endpoints=state._endpoints,
             run_template_cache=state._run_template_cache,
-            worker_attrs=state._worker_attrs,
             owns_scale_group=lambda _scale_group: True,
             budget_defaults=UserBudgetDefaults(),
         )
@@ -364,18 +372,19 @@ def log_service(embedded_log_server) -> LogServiceClientSync:
 def controller_service(state, log_client, mock_controller, tmp_path) -> ControllerServiceImpl:
     """ControllerServiceImpl with fresh DB, log service, and mock controller.
 
-    The service registers workers into and reads liveness through the controller's
-    backend tracker, so point the mock backend's tracker at this state's ``_health``
-    so liveness writes and reads land on the same object the test inspects.
+    The service registers workers into and reads liveness/attrs through the
+    controller's backend, so point the mock backend's tracker and attrs projection
+    at this state's ``_health``/``_worker_attrs`` so writes and reads land on the
+    same objects the test inspects.
     """
     mock_controller.provider.health = state._health
+    mock_controller.provider.worker_attrs = state._worker_attrs
     return ControllerServiceImpl(
         controller=mock_controller,
         bundle_store=BundleStore(storage_dir=str(tmp_path / "bundles")),
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=state._worker_attrs,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
 
@@ -741,14 +750,16 @@ def register_worker_into_backend(
     healthy: bool = True,
     slice_id: str = "",
 ) -> WorkerId:
-    """Register a worker into the liveness tracker owned by the backend that owns its scale group.
+    """Register a worker into the liveness tracker and attrs projection owned by the
+    backend that owns its scale group.
 
     The multi-backend equivalent of :func:`register_worker`: each backend owns its
-    own tracker, so a worker must land in the tracker of the backend its scale group
-    routes to (rather than one shared tracker).
+    own tracker and attrs projection, so a worker must land in the backend its
+    scale group routes to (rather than one shared tracker/projection).
     """
     backend = controller.backends[controller.backend_id_for_scale_group(scale_group)]
     assert backend.health is not None, f"backend for scale group {scale_group!r} has no liveness tracker"
+    assert backend.worker_attrs is not None, f"backend for scale group {scale_group!r} has no attrs projection"
     wid = WorkerId(worker_id)
     with controller._db.transaction() as cur:
         ops.worker.register(
@@ -758,7 +769,7 @@ def register_worker_into_backend(
             metadata=metadata,
             ts=Timestamp.now(),
             health=backend.health,
-            worker_attrs=controller._worker_attrs,
+            worker_attrs=backend.worker_attrs,
             slice_id=slice_id,
             scale_group=scale_group,
         )

--- a/lib/iris/tests/cluster/controller/test_5470_preemption_reassignment.py
+++ b/lib/iris/tests/cluster/controller/test_5470_preemption_reassignment.py
@@ -430,7 +430,7 @@ class TestPreemptionReassignment:
             ctrl._db,
             health=ctrl.provider.health,
             endpoints=ctrl._endpoints,
-            worker_attrs=ctrl._worker_attrs,
+            worker_attrs=ctrl.provider.worker_attrs,
             run_template_cache=ctrl._run_template_cache,
         )
 

--- a/lib/iris/tests/cluster/controller/test_api_keys.py
+++ b/lib/iris/tests/cluster/controller/test_api_keys.py
@@ -24,7 +24,6 @@ from iris.cluster.controller.backend import BackendCapability
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.projections.endpoints import EndpointsProjection
-from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.rpc import job_pb2
 from rigging.server_auth import IapIdTokenVerifier, VerifiedIdentity, _verified_identity
@@ -41,7 +40,6 @@ def db(tmp_path):
 def _make_service(db, log_client, auth=None):
     """Create a ControllerServiceImpl with minimal dependencies for API key tests."""
     endpoints = EndpointsProjection(db)
-    worker_attrs = WorkerAttrsProjection(db)
 
     controller_mock = Mock()
     controller_mock.wake = Mock()
@@ -57,7 +55,6 @@ def _make_service(db, log_client, auth=None):
         log_client=log_client,
         db=db,
         endpoints=endpoints,
-        worker_attrs=worker_attrs,
         auth=auth or ControllerAuth(),
         endpoint_service=EndpointServiceImpl(db=db, endpoints=endpoints),
     )

--- a/lib/iris/tests/cluster/controller/test_auth.py
+++ b/lib/iris/tests/cluster/controller/test_auth.py
@@ -31,7 +31,6 @@ from iris.cluster.controller.dashboard import (
 )
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
-from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.types import DEFAULT_BACKEND_ID
 from iris.rpc.auth import DASHBOARD_ROLE, SESSION_COOKIE
@@ -88,7 +87,6 @@ def service(state, tmp_path, log_client):
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=WorkerAttrsProjection(state._db),
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
 

--- a/lib/iris/tests/cluster/controller/test_container_profile.py
+++ b/lib/iris/tests/cluster/controller/test_container_profile.py
@@ -18,7 +18,6 @@ from iris.cluster.controller import reads
 from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.backend import BackendCapability
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
-from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.reconcile import dispatch
 from iris.cluster.controller.run_template import RunTemplateCache
 from iris.cluster.controller.service import ControllerServiceImpl
@@ -50,7 +49,6 @@ def _make_service(state, tmp_path, log_client, auth: ControllerAuth) -> Controll
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=WorkerAttrsProjection(state._db),
         auth=auth,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -198,9 +198,10 @@ def _make_controller_mock(state, scheduler, autoscaler=None):
     controller_mock.provider = Mock(capabilities=worker_caps)
     controller_mock.provider.name = "worker"
     controller_mock.provider.autoscaler = autoscaler
-    # The single backend owns the liveness tracker; the service reads liveness
-    # through the controller's union over the backends' trackers.
+    # The single backend owns the liveness tracker and attrs projection; the service
+    # reads liveness through the controller's union over the backends' trackers.
     controller_mock.provider.health = state._health
+    controller_mock.provider.worker_attrs = state._worker_attrs
     controller_mock.capabilities = worker_caps
     controller_mock.backends = {DEFAULT_BACKEND_ID: controller_mock.provider}
     controller_mock.backend_id_for_scale_group = Mock(return_value=DEFAULT_BACKEND_ID)
@@ -220,7 +221,6 @@ def service(state, scheduler, tmp_path, embedded_log_server, log_client):
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=state._worker_attrs,
         endpoint_service=EndpointServiceImpl(
             db=state._db,
             endpoints=state._endpoints,
@@ -244,7 +244,6 @@ def service_with_autoscaler(state, scheduler, mock_autoscaler, tmp_path, log_cli
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=state._worker_attrs,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
 
@@ -1444,7 +1443,6 @@ def test_auth_config_kubernetes_capabilities(state, scheduler, tmp_path, log_cli
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=state._worker_attrs,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
     dashboard = ControllerDashboard(svc)
@@ -1480,7 +1478,6 @@ def _make_k8s_dashboard_client(state, scheduler, tmp_path, log_client):
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=state._worker_attrs,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
     dashboard = ControllerDashboard(svc)
@@ -1678,7 +1675,6 @@ def _multi_backend_client(state, scheduler, tmp_path, log_client, backends):
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=state._worker_attrs,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
     return TestClient(ControllerDashboard(svc).app)
@@ -1823,7 +1819,6 @@ def test_list_workers_stamps_backend_id_and_scale_group(state, scheduler, tmp_pa
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=state._worker_attrs,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
     client = TestClient(ControllerDashboard(svc).app)
@@ -1847,7 +1842,6 @@ def test_worker_backend_id_propagated_to_get_worker_status(state, scheduler, tmp
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=state._worker_attrs,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
     client = TestClient(ControllerDashboard(svc).app)
@@ -1869,7 +1863,6 @@ def test_list_workers_filters_by_backend_id(state, scheduler, tmp_path, log_clie
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=state._worker_attrs,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
     client = TestClient(ControllerDashboard(svc).app)
@@ -1905,7 +1898,6 @@ def test_list_backends_returns_per_backend_summary(state, scheduler, tmp_path, l
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=state._worker_attrs,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
     client = TestClient(ControllerDashboard(svc).app)

--- a/lib/iris/tests/cluster/controller/test_dry_run.py
+++ b/lib/iris/tests/cluster/controller/test_dry_run.py
@@ -37,11 +37,11 @@ def test_dry_run_scheduling_does_not_dispatch(dry_run_controller):
     controller = dry_run_controller
     state = ControllerTestState(
         controller._db,
-        # The single backend owns the liveness tracker now; register workers into
-        # it so the controller's schedule path sees them.
+        # The single backend owns the liveness tracker and attrs projection now;
+        # register workers into them so the controller's schedule path sees them.
         health=controller.provider.health,
         endpoints=controller._endpoints,
-        worker_attrs=controller._worker_attrs,
+        worker_attrs=controller.provider.worker_attrs,
         run_template_cache=controller._run_template_cache,
     )
 

--- a/lib/iris/tests/cluster/controller/test_kick_tasks.py
+++ b/lib/iris/tests/cluster/controller/test_kick_tasks.py
@@ -74,7 +74,7 @@ def _running_task_on_controller(ctrl, request=None):
         ctrl._db,
         health=ctrl.provider.health,
         endpoints=ctrl._endpoints,
-        worker_attrs=ctrl._worker_attrs,
+        worker_attrs=ctrl.provider.worker_attrs,
         run_template_cache=ctrl._run_template_cache,
     )
     register_worker(state, "w0", "10.0.0.1", make_worker_metadata())

--- a/lib/iris/tests/cluster/controller/test_multi_backend_control_loop.py
+++ b/lib/iris/tests/cluster/controller/test_multi_backend_control_loop.py
@@ -51,14 +51,13 @@ def two_backend_controller(make_controller):
 
 @pytest.fixture
 def state(two_backend_controller) -> ControllerTestState:
-    # Each backend owns its own tracker, so workers register through
-    # ``register_worker_into_backend`` (routed by scale group); this state's own
-    # ``_health`` is unused for these multi-backend cases.
+    # Each backend owns its own tracker and attrs projection, so workers register
+    # through ``register_worker_into_backend`` (routed by scale group); this state's
+    # own ``_health``/``_worker_attrs`` are unused for these multi-backend cases.
     controller = two_backend_controller
     return ControllerTestState(
         controller._db,
         endpoints=controller._endpoints,
-        worker_attrs=controller._worker_attrs,
         run_template_cache=controller._run_template_cache,
     )
 

--- a/lib/iris/tests/cluster/controller/test_reconcile.py
+++ b/lib/iris/tests/cluster/controller/test_reconcile.py
@@ -38,6 +38,7 @@ from iris.cluster.controller.backend import (
 )
 from iris.cluster.controller.backend_store import BackendWorkerStore
 from iris.cluster.controller.ops.task import Assignment
+from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.reads import ControlSnapshot
 from iris.cluster.controller.reconcile.loader import load_closed_snapshot
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
@@ -1162,6 +1163,7 @@ class _ScriptedProvider:
     autoscaler: Any = None
     _store: BackendWorkerStore | None = None
     health: WorkerHealthTracker = field(default_factory=WorkerHealthTracker)
+    worker_attrs: WorkerAttrsProjection | None = None
     advertised: dict[str, set[str]] = field(default_factory=dict)
     allowed_users: frozenset[str] = frozenset({"*"})
     capabilities: ClassVar[frozenset[BackendCapability]] = frozenset(
@@ -1187,7 +1189,8 @@ class _ScriptedProvider:
         raise NotImplementedError
 
     def bind_runtime(self, runtime: BackendRuntime) -> None:
-        self._store = store_from_runtime(runtime, self.health, self.autoscale)
+        self.worker_attrs = WorkerAttrsProjection(runtime.db, owns_scale_group=runtime.owns_scale_group)
+        self._store = store_from_runtime(runtime, self.health, self.worker_attrs, self.autoscale)
 
     def seed_liveness(self) -> None:
         assert self._store is not None
@@ -1259,7 +1262,7 @@ def test_e2e_converges_to_succeeded(make_controller):
         ctrl._db,
         health=ctrl.provider.health,
         endpoints=ctrl._endpoints,
-        worker_attrs=ctrl._worker_attrs,
+        worker_attrs=ctrl.provider.worker_attrs,
         run_template_cache=ctrl._run_template_cache,
     )
 
@@ -1311,7 +1314,7 @@ def test_e2e_missing_observation_on_assigned_task_retries_to_pending(make_contro
         ctrl._db,
         health=ctrl.provider.health,
         endpoints=ctrl._endpoints,
-        worker_attrs=ctrl._worker_attrs,
+        worker_attrs=ctrl.provider.worker_attrs,
         run_template_cache=ctrl._run_template_cache,
     )
 
@@ -1351,6 +1354,7 @@ class _UnreachableProvider:
     autoscaler: Any = None
     _store: BackendWorkerStore | None = None
     health: WorkerHealthTracker = field(default_factory=WorkerHealthTracker)
+    worker_attrs: WorkerAttrsProjection | None = None
     advertised: dict[str, set[str]] = field(default_factory=dict)
     allowed_users: frozenset[str] = frozenset({"*"})
     capabilities: ClassVar[frozenset[BackendCapability]] = frozenset(
@@ -1370,7 +1374,8 @@ class _UnreachableProvider:
         self.allowed_users = allowed_users
 
     def bind_runtime(self, runtime: BackendRuntime) -> None:
-        self._store = store_from_runtime(runtime, self.health, self.autoscale)
+        self.worker_attrs = WorkerAttrsProjection(runtime.db, owns_scale_group=runtime.owns_scale_group)
+        self._store = store_from_runtime(runtime, self.health, self.worker_attrs, self.autoscale)
 
     def seed_liveness(self) -> None:
         assert self._store is not None
@@ -1482,7 +1487,7 @@ def test_reconcile_failure_tears_down_worker_without_ping_loop(make_controller, 
         ctrl._db,
         health=ctrl.provider.health,
         endpoints=ctrl._endpoints,
-        worker_attrs=ctrl._worker_attrs,
+        worker_attrs=ctrl.provider.worker_attrs,
         run_template_cache=ctrl._run_template_cache,
     )
 
@@ -1517,7 +1522,7 @@ def test_reconcile_failure_reaps_slice_siblings(make_controller):
         ctrl._db,
         health=ctrl.provider.health,
         endpoints=ctrl._endpoints,
-        worker_attrs=ctrl._worker_attrs,
+        worker_attrs=ctrl.provider.worker_attrs,
         run_template_cache=ctrl._run_template_cache,
     )
 
@@ -1551,7 +1556,7 @@ def test_request_worker_eviction_tears_down_on_next_tick(make_controller):
         ctrl._db,
         health=ctrl.provider.health,
         endpoints=ctrl._endpoints,
-        worker_attrs=ctrl._worker_attrs,
+        worker_attrs=ctrl.provider.worker_attrs,
         run_template_cache=ctrl._run_template_cache,
     )
 
@@ -1604,7 +1609,7 @@ def test_reconcile_reaps_worker_at_build_failure_threshold(make_controller):
         ctrl._db,
         health=ctrl.provider.health,
         endpoints=ctrl._endpoints,
-        worker_attrs=ctrl._worker_attrs,
+        worker_attrs=ctrl.provider.worker_attrs,
         run_template_cache=ctrl._run_template_cache,
     )
 

--- a/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
+++ b/lib/iris/tests/cluster/controller/test_scheduling_fairness.py
@@ -452,7 +452,7 @@ def test_unplaceable_tasks_do_not_starve_placeable_tasks(make_controller, tmp_pa
             metadata=make_worker_metadata(cpu=4, memory_bytes=8 * 1024**3),
             ts=Timestamp.now(),
             health=ctrl.provider.health,
-            worker_attrs=ctrl._worker_attrs,
+            worker_attrs=ctrl.provider.worker_attrs,
         )
 
     outcome = ctrl._run_scheduling()

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -31,7 +31,6 @@ from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.codec import constraints_from_json
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.ops.task import Assignment, finalize
-from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.reads import TaskJobSummary
 from iris.cluster.controller.reconcile import dispatch
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
@@ -973,7 +972,6 @@ def test_terminate_job_rejected_for_non_owner(state, mock_controller, tmp_path, 
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=WorkerAttrsProjection(state._db),
         auth=ControllerAuth(provider="static"),
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
@@ -1002,7 +1000,6 @@ def test_launch_child_job_rejected_for_non_owner(state, mock_controller, tmp_pat
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=WorkerAttrsProjection(state._db),
         auth=ControllerAuth(provider="static"),
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
@@ -1642,7 +1639,6 @@ def test_register_requires_worker_role(state, mock_controller, tmp_path, log_cli
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=WorkerAttrsProjection(state._db),
         auth=auth,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )
@@ -1677,7 +1673,6 @@ def test_register_allows_worker_role(state, mock_controller, tmp_path, log_clien
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=WorkerAttrsProjection(state._db),
         auth=auth,
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )

--- a/lib/iris/tests/cluster/controller/test_worker_attrs_projection.py
+++ b/lib/iris/tests/cluster/controller/test_worker_attrs_projection.py
@@ -16,10 +16,14 @@ from iris.cluster.types import WorkerId
 from sqlalchemy import insert, select
 
 
-def _insert_worker(state, worker_id: str) -> WorkerId:
+def _insert_worker(state, worker_id: str, *, scale_group: str = "") -> WorkerId:
     """SA Core worker insertion used to drive the FK-cascade scenario."""
     with state._db.transaction() as cur:
-        cur.execute(insert(workers_table).values(worker_id=WorkerId(worker_id), address=f"{worker_id}.example:8080"))
+        cur.execute(
+            insert(workers_table).values(
+                worker_id=WorkerId(worker_id), address=f"{worker_id}.example:8080", scale_group=scale_group
+            )
+        )
     return WorkerId(worker_id)
 
 
@@ -85,8 +89,27 @@ def test_rehydrate_reflects_disk_state(state):
             )
         )
 
-    fresh = WorkerAttrsProjection(state._db)
+    fresh = WorkerAttrsProjection(state._db, owns_scale_group=lambda _scale_group: True)
     assert fresh.get(worker_id) == {"zone": AttributeValue("us-east1-b")}
+
+
+def test_rehydrate_scopes_to_owned_scale_group(state):
+    """Two backends sharing one DB each rehydrate only their own scale group's workers."""
+    worker_a = _insert_worker(state, "w-a", scale_group="sg-a")
+    worker_b = _insert_worker(state, "w-b", scale_group="sg-b")
+    for worker_id, zone in ((worker_a, "us-east1-a"), (worker_b, "us-east1-b")):
+        with state._db.transaction() as cur:
+            cur.execute(
+                insert(worker_attributes_table).values(
+                    worker_id=worker_id, key="zone", value_type="str", str_value=zone, int_value=None, float_value=None
+                )
+            )
+
+    backend_a = WorkerAttrsProjection(state._db, owns_scale_group=lambda sg: sg == "sg-a")
+    backend_b = WorkerAttrsProjection(state._db, owns_scale_group=lambda sg: sg == "sg-b")
+
+    assert backend_a.all() == {worker_a: {"zone": AttributeValue("us-east1-a")}}
+    assert backend_b.all() == {worker_b: {"zone": AttributeValue("us-east1-b")}}
 
 
 def test_atomic_write_through_no_visibility_before_commit(state):

--- a/lib/iris/tests/cluster/controller/test_worker_health.py
+++ b/lib/iris/tests/cluster/controller/test_worker_health.py
@@ -177,7 +177,7 @@ def test_seeds_liveness_from_persisted_workers(tmp_path: Path) -> None:
             cur.execute(insert(workers_table).values(worker_id="w-seed-2", address="10.0.0.2:8080"))
 
         health = WorkerHealthTracker()
-        worker_attrs = WorkerAttrsProjection(db)
+        worker_attrs = WorkerAttrsProjection(db, owns_scale_group=lambda _scale_group: True)
 
         # Replicate _seed_liveness_from_workers
         now_ms = Timestamp.now().epoch_ms()

--- a/lib/iris/tests/cluster/controller/test_writes_to_check.py
+++ b/lib/iris/tests/cluster/controller/test_writes_to_check.py
@@ -38,7 +38,7 @@ def fresh_db() -> Iterator[ControllerDB]:
 def projections_built(fresh_db: ControllerDB) -> Iterator[None]:
     """Construct one of each Projection so PROJECTIONS exposes their owned tables."""
     endpoints = EndpointsProjection(fresh_db)
-    worker_attrs = WorkerAttrsProjection(fresh_db)
+    worker_attrs = WorkerAttrsProjection(fresh_db, owns_scale_group=lambda _scale_group: True)
     try:
         yield
     finally:

--- a/lib/iris/tests/test_budget.py
+++ b/lib/iris/tests/test_budget.py
@@ -19,7 +19,6 @@ from iris.cluster.controller.budget import (
 )
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.ops.task import Assignment
-from iris.cluster.controller.projections.worker_attrs import WorkerAttrsProjection
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
 from iris.cluster.controller.service import ControllerServiceImpl
 from iris.cluster.types import JobName, UserBudgetDefaults, WorkerId
@@ -290,7 +289,6 @@ def service(state, tmp_path, log_client) -> ControllerServiceImpl:
         log_client=log_client,
         db=state._db,
         endpoints=state._endpoints,
-        worker_attrs=WorkerAttrsProjection(state._db),
         auth=ControllerAuth(provider="static"),
         endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
     )


### PR DESCRIPTION
WorkerAttrsProjection moves from one controller-wide instance into a per-backend instance scoped to the workers each backend owns by scale group, mirroring how each backend already owns its own WorkerHealthTracker. Construction moves into bind_runtime alongside the health tracker; rehydrate() now restricts the worker_attributes load to the backend's own workers via a shared reads.owned_worker_ids helper (also adopted by DbBackendWorkerStore._owned_worker_ids, replacing its inline duplicate of the same filter).

ControllerServiceImpl.register routes a worker's attributes into its owning backend's projection the same way it already routes liveness, via a new TaskBackend.worker_attrs property (None for backends that track no Iris workers, e.g. k8s). The unused worker_attrs constructor parameter on ControllerServiceImpl is dropped — the register RPC was the only live reader, and now resolves it from the backend instead.

writes.validate()'s owned-table check moves to run after backends bind their runtimes, since the per-backend projections it inspects don't exist before then.

WorkerAttrsProjection.get() is kept: it's exercised directly by test_worker_attrs_projection.py and is a reasonable single-worker lookup API even with no current production caller.

Part of #349