### PR TITLE
[training] Build checkpoint paths directly, retire the bake/impute cascade

### DIFF
--- a/experiments/grug/base/launch.py
+++ b/experiments/grug/base/launch.py
@@ -32,7 +32,7 @@ from marin.execution.lazy import ArtifactStep, StepContext
 from marin.execution.step_runner import StepRunner
 from marin.experiment.data import mixture
 from marin.experiment.namespacing import user_namespaced_name
-from marin.training.training import LevanterCheckpoint, temporary_checkpoint_base_path
+from marin.training.training import LevanterCheckpoint, resolve_checkpointer_output_path
 
 from experiments.datasets.nemotron import nemotron_datasets
 from experiments.datasets.paloma import paloma_datasets
@@ -145,12 +145,9 @@ def build_grug_run_config(launch: GrugBaseLaunchConfig) -> GrugRunConfig:
         use_explicit_mesh_axes=True,
         require_accelerator=True,
         allow_nondivisible_batch_size=False,
-        checkpointer=CheckpointerConfig(
-            base_path=os.path.join(output_path, "checkpoints"),
-            temporary_base_path=temporary_checkpoint_base_path(output_path),
-            append_run_id_to_base_path=False,
-            save_interval=timedelta(minutes=10),
-            keep=None,
+        checkpointer=resolve_checkpointer_output_path(
+            CheckpointerConfig(save_interval=timedelta(minutes=10), keep=None),
+            output_path,
         ),
     )
 

--- a/experiments/grug/moe/launch.py
+++ b/experiments/grug/moe/launch.py
@@ -34,7 +34,7 @@ from marin.execution.step_runner import StepRunner
 from marin.experiment.data import mixture, tokenized
 from marin.experiment.namespacing import user_namespaced_name
 from marin.processing.tokenize.tokenize import TokenizedCache
-from marin.training.training import LevanterCheckpoint, temporary_checkpoint_base_path
+from marin.training.training import LevanterCheckpoint, resolve_checkpointer_output_path
 
 from experiments.datasets.nemotron import nemotron_datasets
 from experiments.datasets.paloma import paloma_datasets
@@ -162,12 +162,9 @@ def run_grug_moe_trial(config: GrugMoeLaunchConfig) -> None:
         allow_nondivisible_batch_size=False,
         initialize_from=initialize_from,
         checkpointer=config.checkpointer
-        or CheckpointerConfig(
-            base_path=os.path.join(config.output_path, "checkpoints"),
-            temporary_base_path=temporary_checkpoint_base_path(config.output_path),
-            append_run_id_to_base_path=False,
-            save_interval=timedelta(minutes=10),
-            keep=None,
+        or resolve_checkpointer_output_path(
+            CheckpointerConfig(save_interval=timedelta(minutes=10), keep=None),
+            config.output_path,
         ),
     )
 

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -179,9 +179,9 @@ def resolve_checkpointer_output_path(checkpointer: CheckpointerConfig, output_pa
 def apply_output_path(train_config: TrainConfigT, output_path: str) -> TrainConfigT:
     """Set every run-scoped path on ``train_config`` from ``output_path``.
 
-    Points the checkpointer at ``output_path`` (see :func:`resolve_checkpointer_output_path`) and sets
-    ``hf_save_path`` to ``<output_path>/hf``. Adapter LM/DPO exports PEFT rather than a merged HF model,
-    so for those the merged ``hf_save_path`` is cleared and ``peft_save_path`` takes the HF location.
+    Points the checkpointer at ``output_path`` and sets ``hf_save_path`` to ``<output_path>/hf``.
+    Adapter LM/DPO exports PEFT rather than a merged HF model, so for those the merged ``hf_save_path``
+    is cleared and ``peft_save_path`` takes the HF location.
     """
     config = replace(  # type: ignore[bad-specialization]
         train_config,

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -13,10 +13,10 @@ from copy import deepcopy
 from dataclasses import dataclass, replace
 from typing import Any, TypeVar, cast
 
-import draccus
 from draccus.utils import DataclassInstance
 from fray import CpuConfig, ResourceConfig, TpuConfig
 from levanter.adaptor import NoAdaptorConfig
+from levanter.checkpoint import CheckpointerConfig
 from levanter.main.train_dpo import TrainDpoConfig
 from levanter.main.train_lm import TrainLmConfig
 from levanter.schedule import BatchSchedule
@@ -93,13 +93,7 @@ class TrainLmOnPodConfig:
     train_config: object
     resources: ResourceConfig
     output_path: str | None = None
-    """Base output directory to be used for training, mainly for use with executor framework."""
-    impute_run_id_from_output_path: bool = True
-    """
-    If true and out_path is not None, the run id will be set to the basename of the out_path plus a random string.
-
-    Note that trainer.id and the RUN_ID env variable take precedence, in that order.
-    """
+    """Base output directory for the run. The checkpointer, HF export, and run id derive from it."""
     env_vars: dict[str, str] | None = None
     """Environment variables to pass to the training task (e.g., WANDB_MODE, WANDB_API_KEY)."""
     auto_build_caches: bool = False
@@ -118,13 +112,7 @@ class TrainDpoOnPodConfig:
     train_config: object
     resources: ResourceConfig
     output_path: str | None = None
-    """Base output directory to be used for training, mainly for use with executor framework."""
-    impute_run_id_from_output_path: bool = True
-    """
-    If true and out_path is not None, the run id will be set to the basename of the out_path plus a random string.
-
-    Note that trainer.id and the RUN_ID env variable take precedence, in that order.
-    """
+    """Base output directory for the run. The checkpointer, HF export, and run id derive from it."""
     env_vars: dict[str, str] | None = None
     """Environment variables to pass to the training task (e.g., WANDB_MODE, WANDB_API_KEY)."""
     auto_build_caches: bool = False
@@ -173,103 +161,65 @@ def temporary_checkpoint_base_path(output_path: str) -> str:
     )
 
 
-def bake_output_path(train_config: TrainConfigT, output_path: str) -> TrainConfigT:
-    """Bake ``output_path`` into the trainer's checkpointer and HF save path.
+def resolve_checkpointer_output_path(checkpointer: CheckpointerConfig, output_path: str) -> CheckpointerConfig:
+    """Point ``checkpointer`` at ``output_path``: rolling checkpoints under ``<output_path>/checkpoints``
+    and time-policy (temporary) checkpoints on region-local storage keyed off ``output_path``.
 
-    Sets:
-    * ``trainer.checkpointer.base_path`` → ``<output_path>/checkpoints``
-    * ``trainer.checkpointer.temporary_base_path`` → region-local temp bucket
-    * ``hf_save_path`` → ``<output_path>/hf``
-
-    The ``append_run_id_to_base_path`` flag is NOT changed here; callers that
-    impute a run id from the output path should also set it to ``False`` via
-    ``impute_run_id``.
+    ``append_run_id_to_base_path`` is ``False`` because ``output_path`` already encodes the run's
+    identity, so a run id suffix would double it up. Every other checkpointer field is preserved.
     """
-    trainer = replace(
-        train_config.trainer,
-        checkpointer=replace(
-            train_config.trainer.checkpointer,
-            base_path=os.path.join(output_path, DEFAULT_CHECKPOINTS_PATH),
-            temporary_base_path=temporary_checkpoint_base_path(output_path),
-        ),
+    return replace(
+        checkpointer,
+        base_path=os.path.join(output_path, DEFAULT_CHECKPOINTS_PATH),
+        temporary_base_path=temporary_checkpoint_base_path(output_path),
+        append_run_id_to_base_path=False,
     )
-    return replace(  # type: ignore[bad-specialization]
+
+
+def apply_output_path(train_config: TrainConfigT, output_path: str) -> TrainConfigT:
+    """Set every run-scoped path on ``train_config`` from ``output_path``.
+
+    Points the checkpointer at ``output_path`` (see :func:`resolve_checkpointer_output_path`) and sets
+    ``hf_save_path`` to ``<output_path>/hf``. Adapter LM/DPO exports PEFT rather than a merged HF model,
+    so for those the merged ``hf_save_path`` is cleared and ``peft_save_path`` takes the HF location.
+    """
+    config = replace(  # type: ignore[bad-specialization]
         train_config,
-        trainer=trainer,
+        trainer=replace(
+            train_config.trainer,
+            checkpointer=resolve_checkpointer_output_path(train_config.trainer.checkpointer, output_path),
+        ),
         hf_save_path=os.path.join(output_path, DEFAULT_HF_CHECKPOINTS_PATH),
     )
 
-
-def impute_run_id(
-    train_config: TrainConfigT,
-    *,
-    output_path: str | None,
-    env_run_id: str | None = None,
-    impute_from_output_path: bool = True,
-) -> tuple[TrainConfigT, str]:
-    """Pick a stable run id and stamp it into ``train_config``.
-
-    Priority:
-    1. ``train_config.trainer.id`` (already set by the caller)
-    2. ``env_run_id`` (e.g. from ``config.env_vars["RUN_ID"]``)
-    3. ``RUN_ID`` environment variable
-    4. ``basename(output_path)`` when ``impute_from_output_path`` is True
-    5. Random UID (last resort, logged as a warning)
-
-    When the run id is imputed from ``output_path`` (case 4), the path already
-    encodes identity so ``append_run_id_to_base_path`` is set to ``False`` to
-    avoid double-suffixing.  For all other cases it follows
-    ``not impute_from_output_path``.
-
-    Returns:
-        ``(updated_train_config, run_id)``
-    """
-    run_id = train_config.trainer.id
-
-    if run_id is None:
-        run_id = env_run_id or os.environ.get("RUN_ID")
-
-    from_output_path = False
-    if run_id is None and impute_from_output_path and output_path is not None:
-        path = output_path.rstrip("/")
-        run_id = os.path.basename(path)
-        from_output_path = True
-        logger.info(f"Imputing run ID from out path: {run_id}")
-
-    if not run_id:
-        run_id = _cli_helpers_module().default_run_id()
-        logger.warning(f"Run ID not set. Using default: {run_id}")
-
-    append_id_to_checkpoints = not (impute_from_output_path and from_output_path) and not impute_from_output_path
-    checkpointer_config = replace(train_config.trainer.checkpointer, append_run_id_to_base_path=append_id_to_checkpoints)
-    updated = replace(train_config, trainer=replace(train_config.trainer, id=run_id, checkpointer=checkpointer_config))  # type: ignore[bad-specialization]
-    return updated, run_id
-
-
-def _update_config_to_use_out_path(pod_config: TrainOnPodConfigT) -> TrainOnPodConfigT:
-    """
-    Update the config to use the out_path as the base output directory for training.
-
-    This will set the following paths to be subdirectories of the out_path:
-    * checkpoints (in $out_path/checkpoints)
-    * hf checkpoints (in $out_path/hf)
-    * logging (in $out_path/log)
-
-    This is useful when running with the executor framework, where the output path is set by the executor.
-    """
-    if pod_config.output_path is None:
-        return pod_config
-
-    config = bake_output_path(pod_config.train_config, pod_config.output_path)
-
-    # Adapter LM/DPO exports PEFT by default; merged HF export is explicit.
     if isinstance(config, (TrainDpoConfig, TrainLmConfig)) and not isinstance(config.adapter, NoAdaptorConfig):
         peft_save_path = config.peft_save_path
         if peft_save_path is None and config.hf_save_steps is not None:
             peft_save_path = config.hf_save_path
         config = replace(config, hf_save_path=None, peft_save_path=peft_save_path)
 
-    return replace(pod_config, train_config=config)
+    return config
+
+
+def _resolve_run_id(
+    train_config: TrainConfigT, *, output_path: str | None, env_run_id: str | None
+) -> tuple[TrainConfigT, str]:
+    """Pick a stable run id and stamp it into ``train_config.trainer.id``.
+
+    A stable id is required so a run resumes into the same W&B run and checkpoint directory after
+    preemption. Priority: ``trainer.id`` already set by the caller, then ``env_run_id`` (from
+    ``env_vars["RUN_ID"]``), then the ``RUN_ID`` environment variable, then ``basename(output_path)``,
+    and finally a random UID as a last resort.
+    """
+    run_id = train_config.trainer.id or env_run_id or os.environ.get("RUN_ID")
+    if run_id is None and output_path is not None:
+        run_id = os.path.basename(output_path.rstrip("/"))
+        logger.info("Imputing run ID from output path: %s", run_id)
+    if not run_id:
+        run_id = _cli_helpers_module().default_run_id()
+        logger.warning("Run ID not set. Using default: %s", run_id)
+    updated = replace(train_config, trainer=replace(train_config.trainer, id=run_id))  # type: ignore[bad-specialization]
+    return updated, run_id
 
 
 def _num_validation_sequences(total_sequences: int, fraction: float) -> int:
@@ -400,28 +350,6 @@ def _maybe_override_auto_build_caches(config: TrainConfigT, auto_build: bool) ->
     return config
 
 
-def _enforce_run_id(config: TrainOnPodConfigT) -> TrainOnPodConfigT:
-    """
-    Levanter will auto-generate a run ID if it's not set. We want to enforce that it's set, so that it resumes
-    properly after preemption.
-
-    Look for:
-        * config.trainer.id
-        * environment variable RUN_ID in config.env_vars
-        * environment variable RUN_ID
-        * default to a random UID
-    """
-    env_run_id = (config.env_vars or {}).get("RUN_ID")
-    inner_config, run_id = impute_run_id(
-        config.train_config,
-        output_path=config.output_path,
-        env_run_id=env_run_id,
-        impute_from_output_path=config.impute_run_id_from_output_path,
-    )
-    logger.info(f"Using run ID: {run_id}")
-    return replace(config, train_config=inner_config)
-
-
 def _normalize_jax_compilation_cache_dir(path: str) -> str:
     """Normalize cache dir to a form accepted by JAX's compilation cache.
 
@@ -496,19 +424,25 @@ def _prepare_training_run(
     environment dict that callers should merge into ``os.environ`` before
     invoking the Levanter main.
     """
+    train_config = config.train_config
     if config.output_path is not None:
         logger.info(f"Using output path: {config.output_path}")
-        config = _update_config_to_use_out_path(config)
+        train_config = apply_output_path(train_config, config.output_path)
+
+    train_config, run_id = _resolve_run_id(
+        train_config,
+        output_path=config.output_path,
+        env_run_id=(config.env_vars or {}).get("RUN_ID"),
+    )
+    logger.info(f"Using run ID: {run_id}")
+    config = replace(config, train_config=train_config)
 
     if isinstance(config, TrainDpoOnPodConfig):
         config = cast(TrainOnPodConfigT, _maybe_auto_resolve_dpo_schedule(config))
+        train_config = config.train_config
 
     env = resolve_training_env(config.env_vars, config.resources)
 
-    config = _enforce_run_id(config)
-    logger.info(f"Using run ID: {config.train_config.trainer.id}")
-
-    train_config = config.train_config
     train_config = _maybe_override_auto_build_caches(train_config, config.auto_build_caches)
 
     # disable accelerator requirement when running without GPU/TPU resources
@@ -616,7 +550,3 @@ def _check_for_wandb_key(env):
                     "WANDB_API_KEY must be set in the environment. Please add it to your .config, export "
                     "WANDB_API_KEY=..., or add it to the env dict."
                 )
-
-
-if __name__ == "__main__":
-    draccus.wrap()(run_levanter_train_lm)()

--- a/tests/test_training.py
+++ b/tests/test_training.py
@@ -19,9 +19,9 @@ from marin.processing.tokenize import tokenized_cache_stats_path
 from marin.training.training import (
     TrainDpoOnPodConfig,
     TrainLmOnPodConfig,
-    _enforce_run_id,
     _maybe_auto_resolve_dpo_schedule,
-    _update_config_to_use_out_path,
+    _resolve_run_id,
+    apply_output_path,
     doublecheck_paths,
     temporary_checkpoint_base_path,
 )
@@ -80,71 +80,62 @@ def test_temporary_checkpoint_base_path_follows_output_path_region():
         patch.dict(os.environ, {"MARIN_PREFIX": "gs://marin-us-central1/scratch"}),
     ):
         assert temporary_checkpoint_base_path("gs://marin-us-east5/experiments/grug/base-trial") == (
-            "gs://marin-us-east5/tmp/ttl=14d/" "checkpoints-temp/marin-us-east5/experiments/grug/base-trial/checkpoints"
+            "gs://marin-us-east5/tmp/ttl=14d/checkpoints-temp/marin-us-east5/experiments/grug/base-trial/checkpoints"
         )
 
 
-def test_update_config_to_use_out_path_sets_run_specific_temp_checkpoints(trainer_config):
+def test_apply_output_path_sets_run_specific_temp_checkpoints(trainer_config):
     with (
         patch("rigging.filesystem.urllib.request.urlopen", side_effect=OSError("not on GCP")),
         patch.dict(os.environ, {"MARIN_PREFIX": "gs://marin-us-central1/scratch"}),
     ):
-        config = TrainLmOnPodConfig(
-            train_config=train_lm.TrainLmConfig(
-                trainer=trainer_config,
-            ),
-            resources=ResourceConfig.with_tpu("v4-8"),
-            output_path="gs://marin-us-east5/experiments/grug/base-trial",
+        updated = apply_output_path(
+            train_lm.TrainLmConfig(trainer=trainer_config),
+            "gs://marin-us-east5/experiments/grug/base-trial",
         )
 
-        updated = _update_config_to_use_out_path(config)
+    checkpointer = updated.trainer.checkpointer
+    assert checkpointer.base_path == "gs://marin-us-east5/experiments/grug/base-trial/checkpoints"
+    assert checkpointer.temporary_base_path == (
+        "gs://marin-us-east5/tmp/ttl=14d/checkpoints-temp/marin-us-east5/experiments/grug/base-trial/checkpoints"
+    )
+    assert checkpointer.append_run_id_to_base_path is False
+    assert updated.hf_save_path == "gs://marin-us-east5/experiments/grug/base-trial/hf"
 
-        checkpointer = updated.train_config.trainer.checkpointer
-        assert checkpointer.base_path == "gs://marin-us-east5/experiments/grug/base-trial/checkpoints"
-        assert checkpointer.temporary_base_path == (
-            "gs://marin-us-east5/tmp/ttl=14d/" "checkpoints-temp/marin-us-east5/experiments/grug/base-trial/checkpoints"
-        )
 
-
-def test_update_config_to_use_out_path_does_not_enable_adapter_hf_export_without_steps(trainer_config):
+def test_apply_output_path_does_not_enable_adapter_hf_export_without_steps(trainer_config):
     with patch(
         "marin.training.training.marin_temp_bucket", return_value="gs://tmp/ttl=14d/checkpoints-temp/example-run"
     ):
-        config = TrainDpoOnPodConfig(
-            train_config=TrainDpoConfig(
+        updated = apply_output_path(
+            TrainDpoConfig(
                 trainer=dataclasses.replace(trainer_config, num_train_steps=1),
                 adapter=LoraAdaptorConfig(),
                 hf_save_steps=None,
             ),
-            resources=ResourceConfig.with_tpu("v4-8"),
-            output_path="gs://bucket/checkpoints/dpo/example-run",
+            "gs://bucket/checkpoints/dpo/example-run",
         )
 
-        updated = _update_config_to_use_out_path(config)
-
-    assert updated.train_config.hf_save_path is None
-    assert updated.train_config.merged_hf_save_path is None
+    assert updated.hf_save_path is None
+    assert updated.merged_hf_save_path is None
 
 
-def test_update_config_to_use_out_path_routes_adapter_hf_export_to_peft(trainer_config):
+def test_apply_output_path_routes_adapter_hf_export_to_peft(trainer_config):
     with patch(
         "marin.training.training.marin_temp_bucket", return_value="gs://tmp/ttl=14d/checkpoints-temp/example-run"
     ):
-        config = TrainDpoOnPodConfig(
-            train_config=TrainDpoConfig(
+        updated = apply_output_path(
+            TrainDpoConfig(
                 trainer=dataclasses.replace(trainer_config, num_train_steps=1),
                 adapter=LoraAdaptorConfig(),
                 hf_save_steps=10,
             ),
-            resources=ResourceConfig.with_tpu("v4-8"),
-            output_path="gs://bucket/checkpoints/dpo/example-run",
+            "gs://bucket/checkpoints/dpo/example-run",
         )
 
-        updated = _update_config_to_use_out_path(config)
-
-    assert updated.train_config.hf_save_path is None
-    assert updated.train_config.peft_save_path == "gs://bucket/checkpoints/dpo/example-run/hf"
-    assert updated.train_config.merged_hf_save_path is None
+    assert updated.hf_save_path is None
+    assert updated.peft_save_path == "gs://bucket/checkpoints/dpo/example-run/hf"
+    assert updated.merged_hf_save_path is None
 
 
 def test_recursive_path_checking(trainer_config):
@@ -209,29 +200,20 @@ def test_tokenized_cache_stats_path_handles_local_and_gcs_paths():
     )
 
 
-def test_output_path_temp_checkpoint_path_is_run_scoped(trainer_config):
-    config = TrainLmOnPodConfig(
-        train_config=train_lm.TrainLmConfig(
-            data={"train_urls": []},  # type: ignore[arg-type]
-            trainer=dataclasses.replace(trainer_config, id=None),
-        ),
-        resources=ResourceConfig.with_tpu("v4-8"),
-        output_path="gs://bucket/checkpoints/dpo/example-run",
+def test_resolve_run_id_imputes_basename_of_output_path(trainer_config):
+    config = train_lm.TrainLmConfig(trainer=dataclasses.replace(trainer_config, id=None))
+    updated, run_id = _resolve_run_id(config, output_path="gs://bucket/checkpoints/dpo/example-run", env_run_id=None)
+    assert run_id == "example-run"
+    assert updated.trainer.id == "example-run"
+
+
+def test_resolve_run_id_prefers_explicit_id_over_output_path(trainer_config):
+    config = train_lm.TrainLmConfig(trainer=dataclasses.replace(trainer_config, id="explicit-run"))
+    updated, run_id = _resolve_run_id(
+        config, output_path="gs://bucket/checkpoints/dpo/example-run", env_run_id="from-env"
     )
-
-    with patch(
-        "marin.training.training.marin_temp_bucket",
-        return_value="gs://tmp/ttl=14d/checkpoints-temp/example-run",
-    ):
-        updated = _enforce_run_id(_update_config_to_use_out_path(config))
-
-    checkpointer = updated.train_config.trainer.checkpointer
-
-    assert updated.train_config.trainer.id == "example-run"
-    assert checkpointer.append_run_id_to_base_path is False
-    assert checkpointer.base_path == "gs://bucket/checkpoints/dpo/example-run/checkpoints"
-    assert checkpointer.temporary_base_path == "gs://tmp/ttl=14d/checkpoints-temp/example-run"
-    assert checkpointer.expanded_temporary_path("example-run") == "gs://tmp/ttl=14d/checkpoints-temp/example-run"
+    assert run_id == "explicit-run"
+    assert updated.trainer.id == "explicit-run"
 
 
 def test_auto_resolve_dpo_schedule_from_stats(trainer_config, tmp_path):


### PR DESCRIPTION
train_lm was the last path still building a blank Levanter config and patching its output-path-dependent fields on the worker through a chain of `dataclasses.replace`: `bake_output_path`, `_update_config_to_use_out_path`, `impute_run_id`, and `_enforce_run_id`. That indirection is a leftover from the old executor framework, where steps were built at import time before the content-hash output path existed, so the paths had to be injected late.

Under the lazy ArtifactStep model the output path is known when the config runs, so the cascade is pure indirection. Replace it with direct construction:

- `resolve_checkpointer_output_path` points a `CheckpointerConfig` at an output path — `base_path`, region-local `temporary_base_path`, and `append_run_id_to_base_path=False` (the path already encodes identity).
- `apply_output_path` sets the checkpointer and `hf_save_path` in one pass, including the adapter PEFT routing.
- `_resolve_run_id` picks the stable run id (caller id → `env_vars[RUN_ID]` → `RUN_ID` env → basename of the output path → random).

The grug base/moe launchers already built these paths inline, so they now share `resolve_checkpointer_output_path` instead of duplicating it.

Path construction stays at run time rather than moving into `build_config(ctx)`, which is the one non-obvious part. `build_config` also runs at fingerprint time against an `<output_path>` placeholder; `temporary_checkpoint_base_path` can't parse a region from the placeholder and would fall back to resolving the ambient cluster prefix into the fingerprint, making identity depend on where you lowered from. Keeping construction in the run function leaves the fingerprint byte-for-byte unchanged, so no cached training artifacts are invalidated.

Also drops the always-true `impute_run_id_from_output_path` flag and the dead `draccus` `__main__` CLI on the training module.

Part of #6753