### PR TITLE
Make iris controller --fresh a one-shot wipe

### DIFF
--- a/lib/iris/src/iris/cluster/platforms/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/controller.py
@@ -394,20 +394,12 @@ class K8sControllerProvider:
     def _persist_deployment_without_fresh(self, deploy_kwargs: dict) -> None:
         """Re-apply the controller Deployment with ``--fresh`` stripped from the pod command.
 
-        ``--fresh`` wipes the SQLite DB and skips checkpoint restore. That belongs
-        at deploy time only, but ``cluster start --fresh`` bakes the flag into the
-        Deployment's pod ``command``, so it persists in the pod template. Any later
-        involuntary respawn of that pod — node eviction, node upgrade, OOMKill, or
-        the Deployment controller simply recreating a lost pod — then comes back
-        ``--fresh`` and silently wipes live job state. That is what wiped a running
-        canary and reaped its task pods in issue #6808.
-
-        Once the fresh controller is up it has emitted an (empty) checkpoint, so we
-        re-apply the same manifest without ``--fresh``. The Recreate strategy swaps
-        the pod in place on the already-warm controller node, and every future
-        respawn restores from the local state PVC / remote checkpoint instead of
-        wiping. ``--fresh`` thus means "ignore existing state on this deploy", not
-        "wipe on every restart forever".
+        ``--fresh`` baked into the pod ``command`` persists in the template, so any
+        involuntary respawn (eviction, node upgrade, OOMKill) comes back ``--fresh``
+        and wipes live job state — the failure in issue #6808. The fresh controller
+        has already emitted an (empty) checkpoint by now, so re-applying without the
+        flag makes ``--fresh`` mean "ignore existing state on this deploy" rather
+        than "wipe on every restart forever".
         """
         logger.info("Re-applying controller Deployment without --fresh so the wipe is one-shot")
         self._kubectl.apply_json(_build_controller_deployment(**deploy_kwargs, fresh=False))

--- a/lib/iris/src/iris/cluster/platforms/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/controller.py
@@ -338,14 +338,14 @@ class K8sControllerProvider:
         self._kubectl.apply_json(_build_controller_state_pvc(namespace=self._namespace))
         logger.info("PersistentVolumeClaim %s applied", _CONTROLLER_STATE_PVC_NAME)
 
-        deploy_manifest = _build_controller_deployment(
+        deploy_kwargs = dict(
             namespace=self._namespace,
             image=config.controller.image,
             port=port,
             node_selector={self._iris_labels.iris_scale_group: cw.scale_group},
             task_env_secret=projects_task_env_secret(config),
-            fresh=fresh,
         )
+        deploy_manifest = _build_controller_deployment(**deploy_kwargs, fresh=fresh)
         # Always stop the old controller before starting the new one. The
         # SQLite state PVC is ReadWriteOnce and a rolling update could briefly
         # mount it from two pods on the same node, corrupting the DB. Iris
@@ -386,7 +386,33 @@ class K8sControllerProvider:
         self.wait_for_deployment_ready()
         self._kubectl.rollout_status(K8sResource.DEPLOYMENTS, "iris-controller")
 
+        if fresh:
+            self._persist_deployment_without_fresh(deploy_kwargs)
+
         return self.discover_controller(config.controller)
+
+    def _persist_deployment_without_fresh(self, deploy_kwargs: dict) -> None:
+        """Re-apply the controller Deployment with ``--fresh`` stripped from the pod command.
+
+        ``--fresh`` wipes the SQLite DB and skips checkpoint restore. That belongs
+        at deploy time only, but ``cluster start --fresh`` bakes the flag into the
+        Deployment's pod ``command``, so it persists in the pod template. Any later
+        involuntary respawn of that pod — node eviction, node upgrade, OOMKill, or
+        the Deployment controller simply recreating a lost pod — then comes back
+        ``--fresh`` and silently wipes live job state. That is what wiped a running
+        canary and reaped its task pods in issue #6808.
+
+        Once the fresh controller is up it has emitted an (empty) checkpoint, so we
+        re-apply the same manifest without ``--fresh``. The Recreate strategy swaps
+        the pod in place on the already-warm controller node, and every future
+        respawn restores from the local state PVC / remote checkpoint instead of
+        wiping. ``--fresh`` thus means "ignore existing state on this deploy", not
+        "wipe on every restart forever".
+        """
+        logger.info("Re-applying controller Deployment without --fresh so the wipe is one-shot")
+        self._kubectl.apply_json(_build_controller_deployment(**deploy_kwargs, fresh=False))
+        self.wait_for_deployment_ready()
+        self._kubectl.rollout_status(K8sResource.DEPLOYMENTS, "iris-controller")
 
     def restart_controller(self, config: IrisClusterConfig) -> str:
         return self.start_controller(config)

--- a/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
@@ -268,6 +268,95 @@ def test_start_controller_reconciles_when_already_available():
     provider.shutdown()
 
 
+def _keep_deployment_ready(k8s: InMemoryK8sService, name: str, stop: threading.Event):
+    """Continuously mark the deployment available until stopped.
+
+    Unlike _auto_ready_deployment (one-shot), this keeps re-marking the
+    deployment available across re-applies, since apply_json replaces the
+    manifest and drops its status.
+    """
+    while not stop.is_set():
+        dep = k8s.get_json(K8sResource.DEPLOYMENTS, name)
+        if dep is not None:
+            dep.setdefault("status", {})["availableReplicas"] = dep.get("spec", {}).get("replicas", 1)
+        time.sleep(0.02)
+
+
+def _controller_command(k8s: InMemoryK8sService) -> list[str]:
+    dep = k8s.get_json(K8sResource.DEPLOYMENTS, "iris-controller")
+    return dep["spec"]["template"]["spec"]["containers"][0]["command"]
+
+
+def test_fresh_start_strips_fresh_from_persisted_deployment():
+    """A --fresh start must not leave --fresh baked into the persisted pod command.
+
+    cluster start --fresh wipes the DB and skips checkpoint restore, but if the
+    flag stayed in the Deployment's pod command an involuntary pod respawn
+    (eviction, node upgrade, OOM) would come back --fresh and silently wipe live
+    job state (issue #6808). After the fresh controller is up, start_controller
+    re-applies the Deployment without --fresh so future respawns restore state.
+    """
+    provider, k8s = _make_provider()
+    cluster_config = _make_cluster_config()
+
+    stop = threading.Event()
+    t = threading.Thread(target=_keep_deployment_ready, args=(k8s, "iris-controller", stop), daemon=True)
+    t.start()
+    try:
+        provider.start_controller(cluster_config, fresh=True)
+    finally:
+        stop.set()
+        t.join(timeout=5)
+
+    assert "--fresh" not in _controller_command(k8s)
+    provider.shutdown()
+
+
+def test_non_fresh_start_never_includes_fresh():
+    """A normal (non-fresh) start deploys a pod command without --fresh."""
+    provider, k8s = _make_provider()
+    cluster_config = _make_cluster_config()
+
+    t = threading.Thread(target=_auto_ready_deployment, args=(k8s, "iris-controller"), daemon=True)
+    t.start()
+
+    provider.start_controller(cluster_config)
+
+    assert "--fresh" not in _controller_command(k8s)
+    t.join(timeout=5)
+    provider.shutdown()
+
+
+def test_fresh_start_reapplies_deployment_after_ready():
+    """The fresh one-shot re-applies the Deployment: apply(fresh) then apply(non-fresh)."""
+    provider, k8s = _make_provider()
+    cluster_config = _make_cluster_config()
+
+    applied_fresh_flags: list[bool] = []
+    real_apply = k8s.apply_json
+
+    def recording_apply(manifest):
+        if manifest.get("kind") == "Deployment" and manifest["metadata"]["name"] == "iris-controller":
+            command = manifest["spec"]["template"]["spec"]["containers"][0]["command"]
+            applied_fresh_flags.append("--fresh" in command)
+        return real_apply(manifest)
+
+    k8s.apply_json = recording_apply
+
+    stop = threading.Event()
+    t = threading.Thread(target=_keep_deployment_ready, args=(k8s, "iris-controller", stop), daemon=True)
+    t.start()
+    try:
+        provider.start_controller(cluster_config, fresh=True)
+    finally:
+        stop.set()
+        t.join(timeout=5)
+
+    # First apply carries --fresh (wipe on deploy), the follow-up apply strips it.
+    assert applied_fresh_flags == [True, False]
+    provider.shutdown()
+
+
 def test_start_controller_stops_old_controller_before_reapply():
     """start_controller tears the old Deployment down before applying the new one.
 

--- a/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
@@ -290,11 +290,8 @@ def _controller_command(k8s: InMemoryK8sService) -> list[str]:
 def test_fresh_start_strips_fresh_from_persisted_deployment():
     """A --fresh start must not leave --fresh baked into the persisted pod command.
 
-    cluster start --fresh wipes the DB and skips checkpoint restore, but if the
-    flag stayed in the Deployment's pod command an involuntary pod respawn
-    (eviction, node upgrade, OOM) would come back --fresh and silently wipe live
-    job state (issue #6808). After the fresh controller is up, start_controller
-    re-applies the Deployment without --fresh so future respawns restore state.
+    Otherwise an involuntary pod respawn comes back --fresh and wipes live job
+    state (issue #6808).
     """
     provider, k8s = _make_provider()
     cluster_config = _make_cluster_config()
@@ -324,36 +321,6 @@ def test_non_fresh_start_never_includes_fresh():
 
     assert "--fresh" not in _controller_command(k8s)
     t.join(timeout=5)
-    provider.shutdown()
-
-
-def test_fresh_start_reapplies_deployment_after_ready():
-    """The fresh one-shot re-applies the Deployment: apply(fresh) then apply(non-fresh)."""
-    provider, k8s = _make_provider()
-    cluster_config = _make_cluster_config()
-
-    applied_fresh_flags: list[bool] = []
-    real_apply = k8s.apply_json
-
-    def recording_apply(manifest):
-        if manifest.get("kind") == "Deployment" and manifest["metadata"]["name"] == "iris-controller":
-            command = manifest["spec"]["template"]["spec"]["containers"][0]["command"]
-            applied_fresh_flags.append("--fresh" in command)
-        return real_apply(manifest)
-
-    k8s.apply_json = recording_apply
-
-    stop = threading.Event()
-    t = threading.Thread(target=_keep_deployment_ready, args=(k8s, "iris-controller", stop), daemon=True)
-    t.start()
-    try:
-        provider.start_controller(cluster_config, fresh=True)
-    finally:
-        stop.set()
-        t.join(timeout=5)
-
-    # First apply carries --fresh (wipe on deploy), the follow-up apply strips it.
-    assert applied_fresh_flags == [True, False]
     provider.shutdown()
 
 

--- a/uv.lock
+++ b/uv.lock
@@ -4615,7 +4615,7 @@ requires-dist = [
     { name = "google-vizier", extras = ["jax"], marker = "extra == 'vizier'" },
     { name = "harbor", marker = "extra == 'harbor'", git = "https://github.com/marin-community/harbor.git?rev=354692d9c0eab497b05f266aa0dff30e2a238d2e" },
     { name = "huggingface-hub", marker = "extra == 'datakit'" },
-    { name = "jax", specifier = ">=0.9.2" },
+    { name = "jax", specifier = ">=0.9.2,<0.11" },
     { name = "jax", marker = "extra == 'cpu'", specifier = "==0.10.0" },
     { name = "jax", marker = "extra == 'tpu'", specifier = "==0.10.0" },
     { name = "jax", marker = "extra == 'vllm'", specifier = "==0.10.0" },
@@ -4843,14 +4843,14 @@ dev = [
     { name = "pytest" },
     { name = "pytest-timeout" },
 ]
-test = [
-    { name = "pytest" },
-    { name = "pytest-timeout" },
-]
 fray-tpu-test = [
     { name = "jax" },
     { name = "jaxlib" },
     { name = "libtpu" },
+    { name = "pytest" },
+    { name = "pytest-timeout" },
+]
+test = [
     { name = "pytest" },
     { name = "pytest-timeout" },
 ]
@@ -4867,14 +4867,14 @@ dev = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-timeout" },
 ]
-test = [
-    { name = "pytest", specifier = ">=8.3.2" },
-    { name = "pytest-timeout" },
-]
 fray-tpu-test = [
     { name = "jax", specifier = "==0.10.0" },
     { name = "jaxlib", specifier = "==0.10.0" },
     { name = "libtpu", specifier = "==0.0.40" },
+    { name = "pytest", specifier = ">=8.3.2" },
+    { name = "pytest-timeout" },
+]
+test = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-timeout" },
 ]
@@ -4906,17 +4906,21 @@ dev = [
     { name = "pygments" },
     { name = "pymdown-extensions" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
+    { name = "safetensors" },
 ]
 test = [
     { name = "chex" },
     { name = "pytest" },
+    { name = "pytest-xdist" },
+    { name = "safetensors" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "aqtp", specifier = ">=0.8.2" },
     { name = "equinox", specifier = ">=0.10.6" },
-    { name = "jax", specifier = ">=0.9.2,<0.11" },
+    { name = "jax", specifier = ">=0.9.2" },
     { name = "jaxtyping", specifier = ">=0.2.20" },
     { name = "jmp", specifier = ">=0.0.4" },
     { name = "safetensors", specifier = ">=0.4.3" },
@@ -4937,10 +4941,14 @@ dev = [
     { name = "pygments" },
     { name = "pymdown-extensions" },
     { name = "pytest", specifier = ">=7.4.0" },
+    { name = "pytest-xdist" },
+    { name = "safetensors", specifier = ">=0.4.3" },
 ]
 test = [
     { name = "chex", specifier = ">=0.1.86" },
     { name = "pytest", specifier = ">=7.4.0" },
+    { name = "pytest-xdist" },
+    { name = "safetensors", specifier = ">=0.4.3" },
 ]
 
 [[package]]


### PR DESCRIPTION
cluster start --fresh baked --fresh into the controller Deployment's pod command, so any involuntary pod respawn came back --fresh and wiped live job state (issue #6808). After the fresh controller is ready, re-apply the Deployment without --fresh so future respawns restore from the state PVC / remote checkpoint.

Closes #6808