### PR TITLE
rigging: collapse s3_data_buckets wrapper and de-slop its test

### DIFF
--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -280,7 +280,7 @@ def _parse_data_config(data: Mapping[str, object]) -> DataConfig:
 def reset_data_config_cache() -> None:
     """Clear the cluster-config and S3-bucket-registry caches. For tests."""
     _load_cluster_config_cached.cache_clear()
-    _s3_data_bucket_registry.cache_clear()
+    s3_data_buckets.cache_clear()
 
 
 # ---------------------------------------------------------------------------
@@ -331,11 +331,14 @@ def marin_prefix() -> str:
 
 
 @functools.cache
-def _s3_data_bucket_registry() -> Mapping[str, BucketSpec]:
-    """Map bucket name -> :class:`BucketSpec` for every R2/CoreWeave bucket
-    declared in any discoverable cluster config.
+def s3_data_buckets() -> Mapping[str, BucketSpec]:
+    """R2/CoreWeave data buckets (name -> :class:`BucketSpec`) across all configs.
 
-    S3-compatible buckets are the ones with ``tmp/ttl=Nd/`` lifecycle rules.
+    These S3-compatible buckets carry ``tmp/ttl=Nd/`` lifecycle rules; used to
+    route temp paths (:func:`marin_temp_bucket`) and to drive
+    ``infra/configure_buckets.py``. The set is defined in ``config/*.yaml`` via
+    each bucket's ``store`` type (``r2``/``coreweave``).
+
     Recognition must be cross-cluster — a launcher on a GCS cluster may target an
     R2/CoreWeave output prefix (see :func:`marin_temp_bucket`'s ``source_prefix``)
     — so this aggregates across all cluster configs rather than only the active
@@ -347,17 +350,6 @@ def _s3_data_bucket_registry() -> Mapping[str, BucketSpec]:
             if spec.store in (StoreType.R2, StoreType.COREWEAVE):
                 registry.setdefault(spec.name, spec)
     return MappingProxyType(registry)
-
-
-def s3_data_buckets() -> Mapping[str, BucketSpec]:
-    """R2/CoreWeave data buckets (name -> :class:`BucketSpec`) across all configs.
-
-    These S3-compatible buckets carry ``tmp/ttl=Nd/`` lifecycle rules; used to
-    route temp paths (:func:`marin_temp_bucket`) and to drive
-    ``infra/configure_buckets.py``. Replaces the old hardcoded bucket constants:
-    the set is now defined in ``config/*.yaml`` via each bucket's ``store`` type.
-    """
-    return _s3_data_bucket_registry()
 
 
 # Finite botocore timeouts/retries for every S3/R2 filesystem we build.

--- a/lib/rigging/tests/test_data_config.py
+++ b/lib/rigging/tests/test_data_config.py
@@ -181,14 +181,26 @@ def test_marin_temp_bucket_unknown_s3_bucket_falls_back(monkeypatch):
 # --- config-driven S3 bucket registry --------------------------------------
 
 
-def test_s3_data_buckets_reads_store_types_from_config(monkeypatch):
-    """The R2/CoreWeave registry is aggregated from config, with regions preserved."""
-    monkeypatch.delenv("MARIN_CLUSTER", raising=False)
-    buckets = s3_data_buckets()
-    assert buckets["marin-na"] == BucketSpec("marin-na", StoreType.R2)
-    assert buckets["marin-us-east-02a"] == BucketSpec("marin-us-east-02a", StoreType.COREWEAVE, "US-EAST-02A")
-    # GCS buckets are not S3-managed and must not appear.
-    assert not any(spec.store == StoreType.GCS for spec in buckets.values())
+def test_s3_data_buckets_aggregates_across_configs(tmp_path, monkeypatch):
+    """The registry unions R2/CoreWeave buckets from every config, drops GCS, keeps signing_region."""
+    cluster_dir = tmp_path / "clusters"
+    cluster_dir.mkdir()
+    (cluster_dir / "gcs.yaml").write_text("data:\n  scheme: gs\n  region_buckets: {r1: {bucket: b-gcs, store: gcs}}\n")
+    (cluster_dir / "s3.yaml").write_text(
+        "data:\n"
+        "  scheme: s3\n"
+        "  region_buckets:\n"
+        "    na: {bucket: b-r2, store: r2}\n"
+        "    e: {bucket: b-cw, store: coreweave, signing_region: US-EAST-02A}\n"
+    )
+    monkeypatch.setattr(fs, "MARIN_CLUSTER_CONFIG_DIRS", (str(cluster_dir),))
+    reset_data_config_cache()
+
+    # Aggregated across both configs; the GCS bucket is excluded; CoreWeave keeps its signing_region.
+    assert s3_data_buckets() == {
+        "b-r2": BucketSpec("b-r2", StoreType.R2),
+        "b-cw": BucketSpec("b-cw", StoreType.COREWEAVE, "US-EAST-02A"),
+    }
 
 
 def test_bucket_entry_requires_explicit_store(tmp_path, monkeypatch):


### PR DESCRIPTION
follow-up to #6770, landing three review comments that merged before they were addressed

* collapse the no-op `s3_data_buckets()` pass-through — cache the public function directly instead of wrapping `_s3_data_bucket_registry()`
* rewrite the registry test to exercise behavior (aggregate two synthetic configs → assert union, GCS exclusion, `signing_region` preserved) instead of snapshotting the committed bucket names
* drop the rotting "replaces the old constants" reference from the docstring