### PR TITLE
execution: dot-prefix the written artifact record

### DIFF
--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -42,9 +42,8 @@ type JSONValue = None | bool | int | float | str | list[JSONValue] | dict[str, J
 
 # The record file written next to every output. Dot-prefixed so the datakit
 # ``normalize._discover_files`` walk and the tokenizer file filter — both skip dotfiles — never
-# mistake it for training data and parse it as JSONL (#5864). Legacy names are read for back-compat
-# with already-materialized outputs, never written — including the brief un-dotted ``artifact.json``
-# form that shipped between #6649 and this change.
+# mistake it for training data and parse it as JSONL. Legacy names are read for back-compat with
+# already-materialized outputs, never written — including a brief un-dotted ``artifact.json`` form.
 RECORD_FILENAME = ".artifact.json"
 _LEGACY_RECORD_FILENAMES = (".artifact_record.json", "artifact.json", ".artifact")
 _LEGACY_PAYLOAD_FILENAMES = (".artifact.json", ".artifact")

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -40,13 +40,10 @@ M = TypeVar("M", bound=BaseModel)
 # JSON-shaped value, used for the human-readable config and the value payload.
 type JSONValue = None | bool | int | float | str | list[JSONValue] | dict[str, JSONValue]
 
-# The record file written next to every output. Dot-prefixed so the datakit
-# ``normalize._discover_files`` walk and the tokenizer file filter — both skip dotfiles — never
-# mistake it for training data and parse it as JSONL. Legacy names are read for back-compat with
-# already-materialized outputs, never written — including a brief un-dotted ``artifact.json`` form.
+# The record file written next to every output, and the only record name read back. Dot-prefixed so
+# the datakit ``normalize._discover_files`` walk and the tokenizer file filter — both skip dotfiles —
+# never mistake it for training data and parse it as JSONL.
 RECORD_FILENAME = ".artifact.json"
-_LEGACY_RECORD_FILENAMES = (".artifact_record.json", "artifact.json", ".artifact")
-_LEGACY_PAYLOAD_FILENAMES = (".artifact.json", ".artifact")
 
 # The old Ray executor wrote a per-step ``.executor_info`` sidecar (the ``ExecutorStepInfo``
 # schema) instead of an ``.artifact.json``. Caches built that way — e.g. the pinned llama3
@@ -210,17 +207,16 @@ def _record_from_executor_info(text: str) -> ArtifactRecord:
 
 
 def read_record(output_path: str) -> ArtifactRecord | None:
-    """The full record at ``{output_path}/.artifact.json`` (or a legacy name), else ``None``.
+    """The record at ``{output_path}/.artifact.json``, else ``None``.
 
-    Falls back to an old Ray executor ``.executor_info`` sidecar when no modern or legacy record
-    file is present, so caches built before the record file existed still resolve their config.
-    A corrupt/partial file raises :class:`pydantic.ValidationError`.
+    Falls back to an old Ray executor ``.executor_info`` sidecar when no record file is present, so
+    caches built before the record file existed still resolve their config. A corrupt/partial file
+    raises :class:`pydantic.ValidationError`.
     """
     output_path = _resolved(output_path)
-    for filename in (RECORD_FILENAME, *_LEGACY_RECORD_FILENAMES):
-        text = _read_text(output_path, filename)
-        if text is not None:
-            return ArtifactRecord.model_validate_json(text)
+    text = _read_text(output_path, RECORD_FILENAME)
+    if text is not None:
+        return ArtifactRecord.model_validate_json(text)
     executor_info = _read_text(output_path, _LEGACY_EXECUTOR_INFO_FILENAME)
     if executor_info is not None:
         return _record_from_executor_info(executor_info)
@@ -244,8 +240,7 @@ def _payload_json(value: object) -> JSONValue:
 def read_artifact(output_path: str, schema: type[M]) -> M:
     """Load a typed payload: ``read_record(output_path).result`` validated as ``schema``.
 
-    Falls back to a legacy bare-payload sidecar when the record carries no ``result``.
-    Raises :class:`FileNotFoundError` if nothing is present.
+    Raises :class:`FileNotFoundError` if no record carrying a ``result`` is present.
     """
     if not (isinstance(schema, type) and issubclass(schema, BaseModel)):
         raise TypeError(f"schema must be a pydantic BaseModel subclass, got {schema!r}")
@@ -253,10 +248,6 @@ def read_artifact(output_path: str, schema: type[M]) -> M:
     record = read_record(output_path)
     if record is not None and record.result is not None:
         return cast(M, schema.model_validate(record.result))
-    for filename in _LEGACY_PAYLOAD_FILENAMES:
-        text = _read_text(output_path, filename)
-        if text is not None:
-            return cast(M, schema.model_validate_json(text))
     raise FileNotFoundError(f"no artifact payload at {output_path}")
 
 

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -40,14 +40,17 @@ M = TypeVar("M", bound=BaseModel)
 # JSON-shaped value, used for the human-readable config and the value payload.
 type JSONValue = None | bool | int | float | str | list[JSONValue] | dict[str, JSONValue]
 
-# The record file written next to every output. Legacy names are read for back-compat
-# with already-materialized outputs, never written.
-RECORD_FILENAME = "artifact.json"
-_LEGACY_RECORD_FILENAMES = (".artifact_record.json", ".artifact")
+# The record file written next to every output. Dot-prefixed so the datakit
+# ``normalize._discover_files`` walk and the tokenizer file filter — both skip dotfiles — never
+# mistake it for training data and parse it as JSONL (#5864). Legacy names are read for back-compat
+# with already-materialized outputs, never written — including the brief un-dotted ``artifact.json``
+# form that shipped between #6649 and this change.
+RECORD_FILENAME = ".artifact.json"
+_LEGACY_RECORD_FILENAMES = (".artifact_record.json", "artifact.json", ".artifact")
 _LEGACY_PAYLOAD_FILENAMES = (".artifact.json", ".artifact")
 
 # The old Ray executor wrote a per-step ``.executor_info`` sidecar (the ``ExecutorStepInfo``
-# schema) instead of an ``artifact.json``. Caches built that way — e.g. the pinned llama3
+# schema) instead of an ``.artifact.json``. Caches built that way — e.g. the pinned llama3
 # Nemotron-CC caches — carry their materialized ``config`` (tokenizer, format, tags) only there,
 # so we read it as a last resort to recover the record. Never written.
 _LEGACY_EXECUTOR_INFO_FILENAME = ".executor_info"
@@ -208,10 +211,10 @@ def _record_from_executor_info(text: str) -> ArtifactRecord:
 
 
 def read_record(output_path: str) -> ArtifactRecord | None:
-    """The full record at ``{output_path}/artifact.json`` (or a legacy name), else ``None``.
+    """The full record at ``{output_path}/.artifact.json`` (or a legacy name), else ``None``.
 
     Falls back to an old Ray executor ``.executor_info`` sidecar when no modern or legacy record
-    file is present, so caches built before ``artifact.json`` existed still resolve their config.
+    file is present, so caches built before the record file existed still resolve their config.
     A corrupt/partial file raises :class:`pydantic.ValidationError`.
     """
     output_path = _resolved(output_path)
@@ -226,7 +229,7 @@ def read_record(output_path: str) -> ArtifactRecord | None:
 
 
 def write_record(record: ArtifactRecord) -> None:
-    """Write ``record`` to ``{record.output_path}/artifact.json``."""
+    """Write ``record`` to ``{record.output_path}/.artifact.json``."""
     with open_url(_join(record.output_path, RECORD_FILENAME), "w") as f:
         f.write(record.model_dump_json(indent=2))
 

--- a/tests/execution/test_artifact.py
+++ b/tests/execution/test_artifact.py
@@ -208,10 +208,18 @@ def test_read_record_recovers_config_from_executor_info(tmp_path):
 
 
 def test_read_record_prefers_modern_record_over_executor_info(tmp_path):
-    """``.executor_info`` is a last resort: a modern ``artifact.json`` still wins."""
+    """``.executor_info`` is a last resort: a modern ``.artifact.json`` still wins."""
     (tmp_path / ".executor_info").write_text(_EXECUTOR_INFO)
-    (tmp_path / "artifact.json").write_text('{"name": "modern", "config": {"tokenizer": "gpt2"}}')
+    (tmp_path / ".artifact.json").write_text('{"name": "modern", "config": {"tokenizer": "gpt2"}}')
 
     record = read_record(tmp_path.as_posix())
     assert record.name == "modern"
     assert record.config == {"tokenizer": "gpt2"}
+
+
+def test_read_record_reads_legacy_undotted_record(tmp_path):
+    """Outputs materialized while the record was briefly written un-dotted still resolve."""
+    (tmp_path / "artifact.json").write_text('{"name": "undotted", "config": {"tokenizer": "gpt2"}}')
+
+    record = read_record(tmp_path.as_posix())
+    assert record.name == "undotted"

--- a/tests/execution/test_artifact.py
+++ b/tests/execution/test_artifact.py
@@ -171,13 +171,6 @@ def test_read_artifact_missing_raises(tmp_path):
         read_artifact((tmp_path / "nothing").as_posix(), _Doc)
 
 
-def test_read_artifact_reads_legacy_bare_payload(tmp_path):
-    """Old outputs wrote a bare ``.artifact`` payload; the manual API still loads them."""
-    (tmp_path / ".artifact").write_text('{"title": "legacy", "tokens": 3}')
-    loaded = read_artifact(tmp_path.as_posix(), _Doc)
-    assert loaded == _Doc(title="legacy", tokens=3)
-
-
 # --- the legacy Ray executor .executor_info fallback ---------------------------
 
 # A trimmed per-step ``.executor_info`` in the old ``ExecutorStepInfo`` schema, as written for the
@@ -215,11 +208,3 @@ def test_read_record_prefers_modern_record_over_executor_info(tmp_path):
     record = read_record(tmp_path.as_posix())
     assert record.name == "modern"
     assert record.config == {"tokenizer": "gpt2"}
-
-
-def test_read_record_reads_legacy_undotted_record(tmp_path):
-    """Outputs materialized while the record was briefly written un-dotted still resolve."""
-    (tmp_path / "artifact.json").write_text('{"name": "undotted", "config": {"tokenizer": "gpt2"}}')
-
-    record = read_record(tmp_path.as_posix())
-    assert record.name == "undotted"

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -298,7 +298,7 @@ def test_runner_skips_completed_steps(tmp_path: Path):
     runner1.run(steps)
 
     # Record modification times
-    tokenize_artifact_path = os.path.join(steps[1].output_path, "artifact.json")
+    tokenize_artifact_path = os.path.join(steps[1].output_path, ".artifact.json")
     mtime_before = os.path.getmtime(tokenize_artifact_path)
 
     # Re-run — all steps should be skipped


### PR DESCRIPTION
read and write the record sidecar as `.artifact.json` only

* re-fixes the marin-community/marin#5864 regression
* an un-dotted `artifact.json` record was matched by datakit `normalize._discover_files` and the tokenizer file filter (both include any `.json` by extension), which parsed the record as JSONL training data — crashing normalize or injecting phantom rows
  * #5874 dot-prefixed the executor sidecars to fix this originally; the lazy-executor rewrite in #6649 reverted the record to the un-dotted name and reintroduced the collision
* drop the legacy record-name and bare-payload-name fallbacks entirely (`artifact.json`, `.artifact_record.json`, `.artifact`) — outputs materialized under those names must be rebuilt
  * also removes the case where the modern `.artifact.json` was listed as a legacy payload name, so a record with `result=None` again raises `FileNotFoundError` instead of validating the record JSON as the payload
* the `.executor_info` fallback is kept — the pinned llama3 Nemotron-CC caches carry their config only there