### PR TITLE
public_artifacts: durable public hosting for analysis HTML sites

### DIFF
--- a/.agents/projects/public_artifacts/design.md
+++ b/.agents/projects/public_artifacts/design.md
@@ -40,7 +40,7 @@ gs://marin-public/<user>/<slug>/<version>/artifact.json   # ArtifactRecord, so r
 gs://marin-public/<user>/<slug>/<version>/<asset>         # optional js/css/data
 ```
 
-`<user>` is the author's short handle (`held`, `rav`), `<slug>` is kebab-case, `<version>` is CalVer `YYYY.MM.DD[.N]`. Public URL is the explicit index: `https://storage.googleapis.com/marin-public/<user>/<slug>/<version>/index.html`.
+`<user>` is the author's short handle (`held`, `rav`) and `<slug>` is kebab-case — both coerced to that shape from whatever the caller passes (`"Foo Bar"` → `foo-bar`), `<version>` is CalVer `YYYY.MM.DD[.N]`. Public URL is the explicit index: `https://storage.googleapis.com/marin-public/<user>/<slug>/<version>/index.html`.
 
 **Helper — one library function, thin CLI wrapper.** New module `lib/marin/src/marin/publish/sites.py`:
 
@@ -48,7 +48,7 @@ gs://marin-public/<user>/<slug>/<version>/<asset>         # optional js/css/data
 
 ```python
 def publish_site(
-    source: str | Path,          # a local .html file, or a local dir whose index.html is the entrypoint
+    source: Path,                # a local .html file, or a local dir whose index.html is the entrypoint
     *, user: str, slug: str,
     version: str,                # CalVer YYYY.MM.DD[.N]
     title: str,                  # human label for the discovery index
@@ -100,7 +100,7 @@ page = Artifact.raw_load(site_uri("held", "datakit-sidebyside", "2026.07.01"))
 
 _Agents make mistakes — how do we catch them?_
 
-- Unit: `publish_site` against a local-FS / `memory://` root — asserts files land at `<user>/<slug>/<version>/`, the `artifact.json` record carries `name = sites/<user>/<slug>` and `result_type = Artifact`, a multi-file source dir keeps its relative asset paths, `index.json` gains one entry with the `title`/`summary` (and a re-publish upserts, not duplicates), and the returned `url` matches the public template. Rejected before any upload: bad handle (`Foo/Bar`, empty), missing `index.html`, non-CalVer version (`v1`, `2026.7.1`), empty `title`, a symlink in the source dir, and a caller-supplied `artifact.json`.
+- Unit: `publish_site` against a local-FS / `memory://` root — asserts files land at `<user>/<slug>/<version>/`, the `artifact.json` record carries `name = sites/<user>/<slug>` and `result_type = Artifact`, a multi-file source dir keeps its relative asset paths, `index.json` gains one entry with the `title`/`summary` (and a re-publish upserts, not duplicates), mixed-case/spaced handles are coerced (`"Foo Bar"` → `foo-bar`), and the returned `url` matches the public template. Rejected before any upload: a handle that coerces to nothing (empty, `!!!`), missing `index.html`, non-CalVer version (`v1`, `2026.7.1`), empty `title`, a symlink in the source dir, and a caller-supplied `artifact.json`.
 - Round-trip: after `publish_site`, `Artifact.raw_load(site_uri(...))` returns a handle whose `.path` is the version dir and whose `.record.config` matches; `site_artifact(...).path()` equals the same uri.
 - The migration is the end-to-end check: after publishing Held's page, fetch the `…/index.html` URL and confirm 200 **and `Content-Type: text/html`** + expected bytes. Known coverage hole: the `memory://` unit test can validate placement but not the served content-type or the bare-directory serving quirk — those two genuinely risky behaviors are only exercised by this manual ops step, not CI.
 

--- a/.agents/projects/public_artifacts/design.md
+++ b/.agents/projects/public_artifacts/design.md
@@ -1,0 +1,112 @@
+# Durable public hosting for analysis HTML pages
+
+_Why are we doing this? What's the benefit?_
+
+Devs publish one-off analysis pages — William Held's [`datakit_sidebyside.html`](https://oa.williamheld.com/datakit_sidebyside.html), Ahmad's [delphi-midtraining dossier](https://ahmeda14960.github.io/delphi-midtraining/dossier.html) — on personal sites. They're meant to be permalinks, but personal GitHub Pages / domains die when the author leaves or reorganizes, and they can't be discovered or fetched from code. We want a paved path: publish an analysis HTML page to a durable, public location and record it as an Artifact, so the same page is both a stable public URL and a code-resolvable handle.
+
+The substrate already exists. `gs://marin-public` (US-WEST2, project `hai-gcp-models`) grants `roles/storage.objectViewer` to `allUsers`, so every object is readable at `https://storage.googleapis.com/marin-public/<key>`. It already serves `held/datakit_sidebyside.html` — the issue's worked example. The gap is convention, a helper, docs, and a code-fetch contract, not new storage infra.
+
+## Background
+
+Full survey with `file:line` refs: [`research.md`](./research.md). The load-bearing facts: (1) `gs://marin-public` exists and is world-readable today, provisioned out of band. (2) Marin's `Artifact` model addresses artifacts by an explicit `name@version` and writes **one `artifact.json` record** per output ([`artifact.py:82`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/lib/marin/src/marin/execution/artifact.py#L82)). A prior `Artifact.from_id` + `ArtifactRegistry` (a global `(id,version)→uri` lookup) shipped in #6061 and was **deliberately removed** in the lazy-`ArtifactStep` rewrite (#6649, 2026-06-30) as redundant — so there is **no global registry**; resolution is by deterministic addressing. (3) A hand-rolled `--upload gs://` HTML publisher already lives in [`render_cluster_report.py:345`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/experiments/datakit/dedup/ops/render_cluster_report.py#L345).
+
+## Challenges
+
+_What's hard?_
+
+The mechanics (upload bytes, print a URL) are trivial — the difficulty is the code-fetch contract and two storage quirks.
+
+- **There is no lookup, only addressing — so the path must be deterministic.** Post-#6649 there is no `(id,version)→uri` registry; an artifact is found by reconstructing its address, not by querying an index. That's workable *only* because a public page's location is a pure function of its identity: a fixed bucket (`marin-public`) plus `<user>/<slug>/<version>/`. So `site_uri(user, slug, version)` is pure string construction, and `Artifact.raw_load(site_uri(...))` is the whole fetch path — no registry, no `marin_prefix()` (which varies per cluster and would make a computed artifact's address cluster-relative). A record written into that public directory makes `raw_load` return a typed handle with provenance rather than a bare path.
+- **The version is part of the address, not an immutability guarantee.** The path carries the version (`…/<slug>/<version>/index.html`) so a new version publishes alongside old ones without clobbering their links. We don't enforce immutability at v1: re-publishing the same version overwrites (last-writer-wins). Versions are CalVer `YYYY.MM.DD[.N]` — the format the current model validates ([`lazy.py:62`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/lib/marin/src/marin/execution/lazy.py#L62)).
+- **GCS doesn't serve `index.html` at a bare directory URL.** `…/marin-public/held/datakit-sidebyside/<version>/index.html` serves, but `…/<version>/` returns not-found from the standard `storage.googleapis.com` endpoint (no `MainPageSuffix` without a bucket Website config). The canonical public URL is the explicit `…/index.html`; pretty directory URLs are a deferred nicety.
+- **Browsers need the right `Content-Type`.** The existing `fs.open(p, "wb")` prototype sets none, so a page could land as `application/octet-stream` and download instead of render. `publish_site` sets `content_type` explicitly from a pinned extension table (html/css/js/json/wasm/map/svg + a default), not the platform `mimetypes` DB, whose `.js`/`.wasm` mappings drift across systems.
+
+## Costs / Risks
+
+- Introduces a documented public-write path that runs against [`storage-bucket.md:48`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/docs/tutorials/storage-bucket.md#L48)'s "keep buckets private" default. Docs must be explicit that `marin-public` is world-readable — never publish anything sensitive.
+- The public bucket's IAM stays provisioned out of band (documented, not managed in `infra/configure_buckets.py`), so the public-read grant is not reproducible from the repo. Accepted tradeoff to avoid `configure_buckets.py` churn; noted as an Open Question.
+- The discovery index (`index.json`) is maintained by a non-atomic read-modify-write, so a rare concurrent double-publish can drop one entry. Acceptable given publish frequency; atomic updates are out of scope.
+- No content review, no GC, no per-handle ownership: anyone with bucket write can publish under any handle; stale sites linger. Out of scope at v1.
+
+## Design
+
+_How are we doing this?_
+
+**Path layout — versioned directory per page.** A page, its record, and sibling assets (CSS/JS for a small SPA) live under a version-pinned directory:
+
+```
+gs://marin-public/<user>/<slug>/<version>/index.html
+gs://marin-public/<user>/<slug>/<version>/artifact.json   # ArtifactRecord, so raw_load resolves
+gs://marin-public/<user>/<slug>/<version>/<asset>         # optional js/css/data
+```
+
+`<user>` is the author's short handle (`held`, `rav`), `<slug>` is kebab-case, `<version>` is CalVer `YYYY.MM.DD[.N]`. Public URL is the explicit index: `https://storage.googleapis.com/marin-public/<user>/<slug>/<version>/index.html`.
+
+**Helper — one library function, thin CLI wrapper.** New module `lib/marin/src/marin/publish/sites.py`:
+
+"site", not "page" (per rjpower): `source` may be a single `.html` *or* a directory (a multi-file SPA — HTML + JS/CSS/data).
+
+```python
+def publish_site(
+    source: str | Path,          # a local .html file, or a local dir whose index.html is the entrypoint
+    *, user: str, slug: str,
+    version: str,                # CalVer YYYY.MM.DD[.N]
+    title: str,                  # human label for the discovery index
+    summary: str = "",           # optional one-line description
+) -> PublishedSite:              # {url, uri, name, version, title}
+    ...
+```
+
+It uploads each file via `rigging.filesystem.open_url(dst, "wb", content_type=...)` — verified to set the object's Content-Type through gcsfs's `GCSFile(content_type=…)` kwarg (gcsfs 2026.1.0) — then (1) writes the record into the *same public directory* so the site is self-describing, and (2) upserts an entry into the public discovery index:
+
+```python
+write_record(ArtifactRecord(
+    name=f"sites/{user}/{slug}", version=version,
+    output_path=uri, result_type=result_type_name(Artifact),
+    config={"user": user, "slug": slug, "version": version, "url": url, "title": title, "summary": summary},
+    provenance=Provenance.capture(),
+))
+```
+
+Writing the record *into the public dir* (rather than letting `adopt` write it into a cluster-private `marin_prefix()`) keeps the artifact self-contained and independent of where it's published from. A `scripts/ops/publish_site.py` CLI wraps the function and prints the public URL:
+
+```
+uv run scripts/ops/publish_site.py report/ --user rav --slug dedup-examples --version 2026.07.01 --title "Dedup examples"
+# -> https://storage.googleapis.com/marin-public/rav/dedup-examples/2026.07.01/index.html
+```
+
+**Discovery index (per rjpower).** `publish_site` also upserts into a public manifest `gs://marin-public/index.json` — a JSON list of `{name, version, url, title, summary}`. It's a read-modify-write (read → upsert `(name, version)` → write); publishes are rare enough that the low conflict chance makes last-writer-wins acceptable (atomic index updates are out of scope). This is the programmatic "list all sites" that the removed registry would otherwise have provided; `docs/reports/index.md` renders / links it for humans.
+
+**Fetching from code — deterministic path + `raw_load`.** Since the address is a pure function of identity, no registry is needed:
+
+```python
+from marin.publish.sites import site_uri
+from marin.execution.artifact import Artifact
+page = Artifact.raw_load(site_uri("held", "datakit-sidebyside", "2026.07.01"))
+# page.path == "gs://marin-public/held/datakit-sidebyside/2026.07.01/"; page.record carries provenance + config
+```
+
+`site_url(user, slug, version)` and `site_uri(user, slug, version)` are pure string constructors; `raw_load` reads the record we wrote (its `result_type` matches base `Artifact`, so the load's type check passes).
+
+**Deferred — a graph-dependency handle.** A `site_artifact(user, slug, version)` returning `ArtifactStep.adopt(f"sites/{user}/{slug}", version, site_uri(...), kind=Artifact)` ([`lazy.py:286`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/lib/marin/src/marin/execution/lazy.py#L286)) would let a *step graph* depend on a site (so its `name@version` enters a consumer's fingerprint). Not shipped in v1: it would pull the heavy `lazy`/Fray import onto the publish path and has no consumer. Fetching needs only `site_uri` + `raw_load`; see Open Questions.
+
+**`render_cluster_report.py` — not migrated (per rjpower).** Its report embeds **sampled corpus text** (potentially copyrighted), and the paved path here is world-readable. The conservative call is to leave `render_cluster_report` as-is in v1; sensitive pages belong behind a future `--private` variant that routes to an IAP-gated frontend (see Open Questions). So this design touches only the public helper + Held's worked example, not the dedup report.
+
+**Docs.** A new tutorial `docs/tutorials/publish-analysis-site.md` (added to `mkdocs.yml` nav next to `storage-bucket.md`) covers the layout, the helper, the public-URL shape, the `raw_load` fetch, and a bold "public bucket — nothing sensitive, any handle is unauthenticated" warning. `docs/reports/index.md` gets a "Published analysis sites" section rendered from `index.json`.
+
+**Worked example.** Migrate Held's `datakit_sidebyside.html` to `gs://marin-public/held/datakit-sidebyside/<version>/index.html` via the helper and link it from the docs as the reference. (Smoke-tested live — see the PR thread.)
+
+## Testing
+
+_Agents make mistakes — how do we catch them?_
+
+- Unit: `publish_site` against a local-FS / `memory://` root — asserts files land at `<user>/<slug>/<version>/`, the `artifact.json` record carries `name = sites/<user>/<slug>` and `result_type = Artifact`, a multi-file source dir keeps its relative asset paths, `index.json` gains one entry with the `title`/`summary` (and a re-publish upserts, not duplicates), and the returned `url` matches the public template. Rejected before any upload: bad handle (`Foo/Bar`, empty), missing `index.html`, non-CalVer version (`v1`, `2026.7.1`), empty `title`, a symlink in the source dir, and a caller-supplied `artifact.json`.
+- Round-trip: after `publish_site`, `Artifact.raw_load(site_uri(...))` returns a handle whose `.path` is the version dir and whose `.record.config` matches; `site_artifact(...).path()` equals the same uri.
+- The migration is the end-to-end check: after publishing Held's page, fetch the `…/index.html` URL and confirm 200 **and `Content-Type: text/html`** + expected bytes. Known coverage hole: the `memory://` unit test can validate placement but not the served content-type or the bare-directory serving quirk — those two genuinely risky behaviors are only exercised by this manual ops step, not CI.
+
+## Open Questions
+
+- **A `--private` variant for sensitive pages?** rjpower's steer: don't route corpus-text pages (like the dedup report) to the public bucket; a `--private` mode that publishes behind an IAP-gated frontend would be the right home. Out of scope for v1 — but is it the shape we want, and does the public `publish_site` API need to anticipate it (shared path layout, an `index` split, etc.)?
+- **Pretty directory URLs.** Serving `…/<version>/` (no `index.html`) needs a bucket Website config (`MainPageSuffix=index.html`) or a CNAME/load-balancer. Worth the infra, or is the explicit `…/index.html` URL fine?
+- **Should the public-read IAM be codified in `infra/configure_buckets.py`** (reproducible grant, at the cost of that script owning a public bucket), rather than documented-only? Leaning documented-only, but reviewers may want it managed.
+- **Is the `site_artifact()` adopt handle worth adding?** Deferred in v1 (fetch works via `site_uri` + `raw_load`, and it would drag `lazy`/Fray onto the publish path). Add it when a step graph actually wants a site as a typed `name@version` dependency?

--- a/.agents/projects/public_artifacts/research.md
+++ b/.agents/projects/public_artifacts/research.md
@@ -1,0 +1,66 @@
+# Research — Durable public hosting for analysis HTML pages
+
+Issue: [marin#6802](https://github.com/marin-community/marin/issues/6802). Code refs pin `main` at `65d1cbef5346de50ef5d08e190765c0a84b0403e`.
+
+## Framing
+
+Devs host one-off analysis HTML on personal sites (William Held's `datakit_sidebyside.html` on `oa.williamheld.com`, Ahmad's `delphi-midtraining` dossier on `ahmeda14960.github.io`). These are meant to be permalinks but die when the author leaves or reorganizes, and aren't discoverable/referenceable from code. Goal: a paved path to publish analysis HTML to a durable public GCS location and register it as an Artifact.
+
+## Load-bearing findings
+
+### The `marin-public` bucket already exists and is world-readable
+
+Confirmed live with `gcloud storage`:
+
+- `gs://marin-public` — location `US-WEST2`, project `hai-gcp-models`, **uniform bucket-level access ON**.
+- IAM binding `roles/storage.objectViewer → allUsers` — every object is publicly readable over `https://storage.googleapis.com/marin-public/<key>`.
+- `publicAccessPrevention` is not enforced.
+- Already serving `gs://marin-public/held/datakit_sidebyside.html` (the issue's worked example).
+
+The bucket is single-region US-WEST2 (not part of the region-mirrored data set) and lives in a different project's IAM. **Nothing in the repo references it** — it's provisioned out of band, and not declared in [`infra/configure_buckets.py`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/infra/configure_buckets.py#L68) (which owns TTL rules on the private `marin-<region>` buckets). Counter-signal: [`storage-bucket.md:48`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/docs/tutorials/storage-bucket.md#L48) steers users to "keep the bucket private unless you intentionally publish checkpoints." A public paved path runs against that default and must say so.
+
+### The Artifact model, and the registry that was added then removed (correction)
+
+**An earlier draft of this doc got this wrong** — it called `Artifact.from_id` + `ArtifactRegistry` "proposal-only, not yet built." The real history:
+
+- **#6061** ([`eb21d9505`](https://github.com/marin-community/marin/commit/eb21d9505), 2026-05-30) **added** `Artifact.from_id` + `ArtifactRegistry` — a real `lib/marin/src/marin/execution/artifact_registry.py` (321 lines) with `register`/`lookup`, `ArtifactEntry`, `get_default_registry`, and 277 lines of tests. It shipped on main.
+- **#6649** ([`f7f5535c3`](https://github.com/marin-community/marin/commit/f7f5535c3), **2026-06-30**) — "Replace the Executor with lazy ArtifactSteps" — **deleted it on purpose.** Commit message: *"One record … subsumes the old payload sidecar **and the registry record** — `artifact_registry.py` is deleted."* Both the module and its tests were removed; #6649 is on latest main. So the registry was intentionally retired as redundant with `name@version` addressing, not "not yet built."
+
+The current model (post-#6649) is what the design builds on:
+
+- A handle is an inert **`ArtifactStep[T]`** addressed by `name@version` ([`lazy.py:210`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/lib/marin/src/marin/execution/lazy.py#L210)). Constructing one runs nothing.
+- The realized output is an **`Artifact`** ([`artifact.py:82`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/lib/marin/src/marin/execution/artifact.py#L82)) carrying `path` + `record`. Loaded by path with `Artifact.raw_load(source)` ([`artifact.py:114`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/lib/marin/src/marin/execution/artifact.py#L114)); `raw_load` checks `record.result_type` against the loader.
+- A successful step writes **one `ArtifactRecord` to `{output_path}/artifact.json`** (identity, deps, config, typed `result`, provenance). `write_record`/`write_artifact` are the public writers ([`artifact.py:228,261`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/lib/marin/src/marin/execution/artifact.py#L228)).
+- **`ArtifactStep.adopt(name, version, source, *, kind=Artifact, config=None)`** ([`lazy.py:286`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/lib/marin/src/marin/execution/lazy.py#L286)) — "register pre-existing data at `source` as a managed `name@version` handle." This is the shipping registration mechanism.
+- **There is no common/global registry.** `adopt` does not write to any shared index. Constructing the handle writes nothing (`.path()` returns `source`); only materializing it (`resolve()` / the `StepRunner`) writes a single `ArtifactRecord` to the canonical **`{marin_prefix()}/{name}/{version}/artifact.json`** — under the *active cluster's region-private* prefix, with `source` recorded (runner at [`lazy.py:377`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/lib/marin/src/marin/execution/lazy.py#L377)). Resolution is by reconstructing the deterministic `name@version` path, not by lookup.
+- **Versions are `YYYY.MM.DD[.N]`** (or mutable `dev`/`<label>-dev`), validated at construction (`_CALVER_RE`, [`lazy.py:62`](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/lib/marin/src/marin/execution/lazy.py#L62)) — **not** the `YYYY.MM.DD[-suffix]` the deleted registry used.
+- `name` is a path segment that **allows internal slashes** (only `..`, URL schemes, and leading/trailing `/` are rejected — `_validate_segment`), so `pages/<user>/<slug>` is a valid `name` directly.
+
+### An 80%-done upload prototype already exists
+
+`experiments/datakit/dedup/ops/render_cluster_report.py` renders a self-contained HTML report and, with `--upload gs://…`, pushes it to a bucket via `rigging.filesystem.url_to_fs` ([:345](https://github.com/marin-community/marin/blob/65d1cbef5346de50ef5d08e190765c0a84b0403e/experiments/datakit/dedup/ops/render_cluster_report.py#L345)):
+
+```python
+if args.upload:
+    fs, p = url_to_fs(args.upload)
+    with fs.open(p, "wb") as fh:
+        fh.write(body.encode("utf-8"))
+```
+
+A hand-rolled instance of exactly the paved path — build on it, don't greenfield. Note it sets **no** content-type.
+
+### Upload / fsspec building blocks
+
+- `rigging.filesystem`: `url_to_fs(url)`, `open_url(url, mode, **kwargs)`, `marin_prefix()`. `open_url`/`url_to_fs` forward `**kwargs` to the filesystem; **verified** that gcsfs 2026.1.0 threads `content_type` from `_open` → `GCSFile(content_type=…)`, so `open_url(dst, "wb", content_type=...)` sets the object's Content-Type.
+- Nearest prior art for "grant `allUsers` read": `lib/levanter/src/levanter/infra/docker.py` grants `allUsers` `roles/artifactregistry.reader` on Docker images (GCP Artifact Registry — unrelated to the marin artifact system).
+
+### Docs surface
+
+- `mkdocs.yml` nav is the source of truth. Reports live under **Experiments** → `reports/index.md` (entries are GitHub-issue + WandB + Data-Browser links, never hosted HTML).
+- Natural home for a "how to publish an analysis page" doc: `docs/tutorials/` next to `storage-bucket.md`. Discoverability: link from `docs/reports/index.md`.
+
+## What surprised me / correction
+
+- The registry the issue's phrasing implies (`from_id`) was real and on main, then **deliberately deleted one day before this doc was drafted** (#6649). The first draft mistook the post-deletion crater for an empty lot and called it "proposal-only." The correct current mechanism is `ArtifactStep.adopt` + the single `artifact.json` record.
+- `adopt` writes to a *private* per-cluster prefix, not a shared registry — so for a *public* page we write the record into the public dir directly (via `write_record`) to keep it self-describing and independent of `marin_prefix()`.
+- The `marin-public` bucket + the exact worked-example object already exist and work; the gap is convention + helper + docs, not new storage infra.

--- a/.agents/projects/public_artifacts/spec.md
+++ b/.agents/projects/public_artifacts/spec.md
@@ -13,8 +13,9 @@ SITE_ENTRYPOINT = "index.html"                                   # the served en
 SITE_NAME_PREFIX = "sites"                                       # ArtifactRecord.name = sites/<user>/<slug>
 PUBLIC_INDEX_KEY = "index.json"                                  # gs://marin-public/index.json — discovery manifest
 
-# <user> and <slug> are single path segments, lowercase kebab.
-_HANDLE_RE = r"^[a-z0-9][a-z0-9-]*$"
+# <user>/<slug> are coerced to lowercase kebab (non-[a-z0-9] runs -> '-', trimmed); rejected only
+# if nothing usable remains. e.g. "Foo Bar" -> "foo-bar", "datakit_sidebyside" -> "datakit-sidebyside".
+_NON_KEBAB = r"[^a-z0-9]+"
 
 # Content types are set explicitly, NOT via platform `mimetypes` (whose .js/.wasm mappings drift).
 CONTENT_TYPES = {
@@ -37,7 +38,7 @@ DEFAULT_CONTENT_TYPE = "application/octet-stream"
 - **URI (record location + fetch address):** `gs://marin-public/<user>/<slug>/<version>/` — a version-pinned directory. Because `marin-public` is fixed and the path is a pure function of `(user, slug, version)`, this address needs no lookup.
 - **Public URL:** `<PUBLIC_URL_BASE>/<user>/<slug>/<version>/index.html`.
 - **Artifact name:** `sites/<user>/<slug>` (recorded as `ArtifactRecord.name`; also the `name` of the optional `adopt` handle). Internal slashes are legal in a `name` segment (`_validate_segment` rejects only `..`, URL schemes, and leading/trailing `/`), so no separator encoding is needed.
-- **Version:** CalVer `YYYY.MM.DD[.N]` (or mutable `dev`/`<label>-dev`). `publish_site` validates the shape locally via the same rule the execution layer uses (`_CALVER_RE`), rejecting `v1`, `2026.7.1`, etc., before any upload.
+- **Version:** CalVer `YYYY.MM.DD[.N]`. `publish_site` validates the shape via the shared `marin.execution.artifact.CALVER_RE` (the one canonical CalVer form, also used by `lazy._validate_version`), rejecting `v1`, `2026.7.1`, etc., before any upload. Unlike the execution layer it does not accept mutable `dev` versions — a durable public site should pin a real date.
 
 ## Public API — `lib/marin/src/marin/publish/sites.py`
 
@@ -63,7 +64,7 @@ class PublishedSite:
 
 
 def publish_site(
-    source: str | Path,
+    source: Path,
     *,
     user: str,
     slug: str,
@@ -93,8 +94,12 @@ def publish_site(
          ``{name, version, url, title, summary}``. This read-modify-write is **not atomic**;
          concurrent publishes are last-writer-wins (acceptable given how rarely sites are published).
 
+    ``user``/``slug`` are coerced to lowercase kebab (``"Foo Bar"`` → ``"foo-bar"``); the coerced
+    form is what appears in the path, record, and index.
+
     Preconditions, all raised **before any upload**:
-      * ``user`` and ``slug`` must match ``_HANDLE_RE`` — else :class:`InvalidSiteError`.
+      * ``user``/``slug`` must retain at least one usable ``[a-z0-9]`` character after coercion —
+        else :class:`InvalidSiteError`.
       * ``version`` must be valid CalVer ``YYYY.MM.DD[.N]`` — else :class:`InvalidSiteError`.
       * ``title`` must be non-empty — else :class:`InvalidSiteError` (every indexed site needs a label).
       * a ``source`` directory must contain ``index.html``, must not contain a file named
@@ -110,16 +115,16 @@ def publish_site(
 
 def site_url(user: str, slug: str, version: str) -> str:
     """Canonical public URL: ``<PUBLIC_URL_BASE>/<user>/<slug>/<version>/index.html``.
-    Pure string construction; validates handles/version, does not check existence."""
+    Pure string construction; coerces handles, validates version, does not check existence."""
 
 
 def site_uri(user: str, slug: str, version: str) -> str:
     """The page's ``gs://`` directory (record location + ``raw_load`` address):
-    ``gs://marin-public/<user>/<slug>/<version>/``. Pure; validates handles/version."""
+    ``gs://marin-public/<user>/<slug>/<version>/``. Pure; coerces handles, validates version."""
 
 
 def site_name(user: str, slug: str) -> str:
-    """The artifact name ``sites/<user>/<slug>``. Pure; validates handles."""
+    """The artifact name ``sites/<user>/<slug>``. Pure; coerces handles."""
 ```
 
 `site_artifact()` (an `ArtifactStep.adopt(...)` handle for step-graph deps) is **deferred** — it would pull the heavy `marin.execution.lazy` / Fray import onto the publish path, has no consumer, and remains an Open Question in `design.md`. Fetching needs only `site_uri` + `raw_load`.
@@ -142,9 +147,9 @@ Discovery: read `gs://marin-public/index.json` for the list of all published sit
 
 ```python
 class InvalidSiteError(ValueError):
-    """Raised before any network/GCS access for: a malformed ``user``/``slug`` (fails
-    ``_HANDLE_RE``); a non-CalVer ``version``; an empty ``title``; or a source directory that
-    lacks ``index.html``, contains a reserved ``artifact.json``, or contains a symlink."""
+    """Raised before any network/GCS access for: a ``user``/``slug`` that coerces to nothing
+    (e.g. ``""`` or ``"!!!"``); a non-CalVer ``version``; an empty ``title``; or a source directory
+    that lacks ``index.html``, contains a reserved ``artifact.json``, or contains a symlink."""
 ```
 
 Propagated unchanged (not wrapped): `FileNotFoundError` (missing `source`) and any `rigging.filesystem` upload error.

--- a/.agents/projects/public_artifacts/spec.md
+++ b/.agents/projects/public_artifacts/spec.md
@@ -1,0 +1,216 @@
+# Spec — Durable public hosting for analysis HTML pages
+
+Contract layer for [`design.md`](./design.md). Pins the public surface: the helper API, the CLI, the path/URL templates, the record shape, content types, and error types. No registry — resolution is by deterministic path (see `design.md` Background).
+
+## Constants
+
+```python
+# lib/marin/src/marin/publish/sites.py
+PUBLIC_BUCKET = "marin-public"                                   # gs://marin-public, allUsers objectViewer
+PUBLIC_URL_BASE = "https://storage.googleapis.com/marin-public"  # <base>/<user>/<slug>/<version>/index.html
+PUBLIC_ROOT = f"gs://{PUBLIC_BUCKET}"                            # storage root (a module attr, overridable in tests)
+SITE_ENTRYPOINT = "index.html"                                   # the served entrypoint under <slug>/<version>/
+SITE_NAME_PREFIX = "sites"                                       # ArtifactRecord.name = sites/<user>/<slug>
+PUBLIC_INDEX_KEY = "index.json"                                  # gs://marin-public/index.json — discovery manifest
+
+# <user> and <slug> are single path segments, lowercase kebab.
+_HANDLE_RE = r"^[a-z0-9][a-z0-9-]*$"
+
+# Content types are set explicitly, NOT via platform `mimetypes` (whose .js/.wasm mappings drift).
+CONTENT_TYPES = {
+    ".html": "text/html; charset=utf-8",
+    ".css":  "text/css; charset=utf-8",
+    ".js":   "text/javascript; charset=utf-8",
+    ".mjs":  "text/javascript; charset=utf-8",
+    ".json": "application/json",
+    ".map":  "application/json",
+    ".svg":  "image/svg+xml",
+    ".wasm": "application/wasm",
+    ".png":  "image/png",
+    ".woff2": "font/woff2",
+}
+DEFAULT_CONTENT_TYPE = "application/octet-stream"
+```
+
+### Identifiers
+
+- **URI (record location + fetch address):** `gs://marin-public/<user>/<slug>/<version>/` — a version-pinned directory. Because `marin-public` is fixed and the path is a pure function of `(user, slug, version)`, this address needs no lookup.
+- **Public URL:** `<PUBLIC_URL_BASE>/<user>/<slug>/<version>/index.html`.
+- **Artifact name:** `sites/<user>/<slug>` (recorded as `ArtifactRecord.name`; also the `name` of the optional `adopt` handle). Internal slashes are legal in a `name` segment (`_validate_segment` rejects only `..`, URL schemes, and leading/trailing `/`), so no separator encoding is needed.
+- **Version:** CalVer `YYYY.MM.DD[.N]` (or mutable `dev`/`<label>-dev`). `publish_site` validates the shape locally via the same rule the execution layer uses (`_CALVER_RE`), rejecting `v1`, `2026.7.1`, etc., before any upload.
+
+## Public API — `lib/marin/src/marin/publish/sites.py`
+
+```python
+from dataclasses import dataclass
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class PublishedSite:
+    """The result of a publish: where the site lives and how to reference it.
+
+    ``url`` is the canonical public link (always the explicit ``index.html``, since GCS does not
+    serve a bare directory URL). ``uri`` is the version-pinned ``gs://`` directory holding the site
+    and its ``artifact.json`` record. ``name``/``version`` are the artifact identity; ``title`` is
+    the human label recorded in the discovery index.
+    """
+    url: str            # https://storage.googleapis.com/marin-public/<user>/<slug>/<version>/index.html
+    uri: str            # gs://marin-public/<user>/<slug>/<version>/
+    name: str           # sites/<user>/<slug>
+    version: str        # CalVer as supplied
+    title: str
+
+
+def publish_site(
+    source: str | Path,
+    *,
+    user: str,
+    slug: str,
+    version: str,
+    title: str,
+    summary: str = "",
+) -> PublishedSite:
+    """Upload an analysis site to ``gs://marin-public/<user>/<slug>/<version>/``, record it, and
+    add it to the public discovery index.
+
+    ``source`` is either a single local ``.html`` file — uploaded as ``index.html`` — or a local
+    directory whose ``index.html`` is the entrypoint (a multi-file site: HTML + JS/CSS/data); every
+    file under the directory is uploaded preserving relative paths. Each object's ``Content-Type``
+    is set from ``CONTENT_TYPES`` by extension (default ``application/octet-stream``) via
+    ``open_url(dst, "wb", content_type=...)``; gcsfs forwards ``content_type`` to ``GCSFile`` and
+    sets the object metadata (verified against gcsfs 2026.1.0).
+
+    After the bytes are uploaded:
+      1. writes the record into the same public directory via ``write_record(ArtifactRecord(
+         name=f"sites/{user}/{slug}", version=version, output_path=uri,
+         result_type=result_type_name(Artifact), config={"user","slug","version","url","title",
+         "summary"}, provenance=Provenance.capture()))`` — so ``Artifact.raw_load(uri)`` returns a
+         typed handle with provenance. The record lives in the public dir (not a cluster-private
+         ``marin_prefix()``), keeping the artifact self-contained.
+      2. upserts an entry into the discovery index at ``gs://marin-public/index.json`` (read →
+         upsert ``(name, version)`` → write). The index is a JSON list of
+         ``{name, version, url, title, summary}``. This read-modify-write is **not atomic**;
+         concurrent publishes are last-writer-wins (acceptable given how rarely sites are published).
+
+    Preconditions, all raised **before any upload**:
+      * ``user`` and ``slug`` must match ``_HANDLE_RE`` — else :class:`InvalidSiteError`.
+      * ``version`` must be valid CalVer ``YYYY.MM.DD[.N]`` — else :class:`InvalidSiteError`.
+      * ``title`` must be non-empty — else :class:`InvalidSiteError` (every indexed site needs a label).
+      * a ``source`` directory must contain ``index.html``, must not contain a file named
+        ``artifact.json`` (reserved), and must contain no symlinks (which could escape the tree) —
+        else :class:`InvalidSiteError`. A missing ``source`` path raises :class:`FileNotFoundError`.
+
+    Existing objects at the destination are overwritten (last-writer-wins) — no immutability guard
+    at v1. Distinct versions live at distinct paths, so a new version never clobbers an old one.
+
+    Returns a :class:`PublishedSite`. Does not delete or GC prior versions.
+    """
+
+
+def site_url(user: str, slug: str, version: str) -> str:
+    """Canonical public URL: ``<PUBLIC_URL_BASE>/<user>/<slug>/<version>/index.html``.
+    Pure string construction; validates handles/version, does not check existence."""
+
+
+def site_uri(user: str, slug: str, version: str) -> str:
+    """The page's ``gs://`` directory (record location + ``raw_load`` address):
+    ``gs://marin-public/<user>/<slug>/<version>/``. Pure; validates handles/version."""
+
+
+def site_name(user: str, slug: str) -> str:
+    """The artifact name ``sites/<user>/<slug>``. Pure; validates handles."""
+```
+
+`site_artifact()` (an `ArtifactStep.adopt(...)` handle for step-graph deps) is **deferred** — it would pull the heavy `marin.execution.lazy` / Fray import onto the publish path, has no consumer, and remains an Open Question in `design.md`. Fetching needs only `site_uri` + `raw_load`.
+
+### Fetching from code
+
+No registry, no `from_id`. The address is deterministic, so:
+
+```python
+from marin.publish.sites import site_uri
+from marin.execution.artifact import Artifact
+site = Artifact.raw_load(site_uri("held", "datakit-sidebyside", "2026.07.01"))
+# site.path == "gs://marin-public/held/datakit-sidebyside/2026.07.01/"
+# site.record.config == {"user", "slug", "version", "url", "title", "summary"}
+```
+
+Discovery: read `gs://marin-public/index.json` for the list of all published sites (`{name, version, url, title, summary}`).
+
+## Errors
+
+```python
+class InvalidSiteError(ValueError):
+    """Raised before any network/GCS access for: a malformed ``user``/``slug`` (fails
+    ``_HANDLE_RE``); a non-CalVer ``version``; an empty ``title``; or a source directory that
+    lacks ``index.html``, contains a reserved ``artifact.json``, or contains a symlink."""
+```
+
+Propagated unchanged (not wrapped): `FileNotFoundError` (missing `source`) and any `rigging.filesystem` upload error.
+
+## CLI — `scripts/ops/publish_site.py`
+
+Thin wrapper over `publish_site`. Prints the public URL to stdout on success.
+
+```
+uv run scripts/ops/publish_site.py <source> --user <user> --slug <slug> --version <YYYY.MM.DD[.N]> --title <title> [--summary <summary>]
+
+  <source>        local .html file or directory with index.html
+  --user          author handle (lowercase kebab)
+  --slug          site slug (lowercase kebab)
+  --version       CalVer version string
+  --title         human label for the discovery index (required, non-empty)
+  --summary       one-line description for the index (optional)
+
+  stdout on success:   <url>
+```
+
+Exit 0 on success; non-zero on `InvalidSiteError` / `FileNotFoundError` (message on stderr).
+
+## `render_cluster_report.py` — not migrated in v1
+
+Deliberately **not** rerouted through `publish_site`. Its report embeds sampled corpus text
+(potentially copyrighted), and the paved path here targets the world-readable `marin-public`.
+Per review (rjpower), the conservative call is to leave it as-is; a future `--private` variant that
+routes sensitive pages to an IAP-gated frontend is the right home for that content (Open Question in
+`design.md`). `render_cluster_report`'s existing `--upload gs://…` is untouched.
+
+## Docs
+
+- New `docs/tutorials/publish-analysis-site.md`, added to `mkdocs.yml` `nav:` under **Tutorials**, adjacent to `storage-bucket.md`. Contains the layout, `publish_site`/CLI usage, the public-URL shape, the `raw_load` fetch snippet, and a bold "public bucket — publish nothing sensitive; any handle is unauthenticated" warning.
+- `docs/reports/index.md` gains a "Published analysis sites" section — the human-facing view of `gs://marin-public/index.json`, starting with the migrated Held site.
+
+## Discovery index — `gs://marin-public/index.json`
+
+A public JSON manifest, updated by `publish_site` (read → upsert `(name, version)` → write; not atomic, last-writer-wins). Shape:
+
+```json
+[
+  {"name": "sites/held/datakit-sidebyside", "version": "2026.07.01",
+   "url": "https://storage.googleapis.com/marin-public/held/datakit-sidebyside/2026.07.01/index.html",
+   "title": "DataKit side-by-side", "summary": "..."}
+]
+```
+
+## File summary
+
+| Path | What |
+| --- | --- |
+| `lib/marin/src/marin/publish/__init__.py` | new package |
+| `lib/marin/src/marin/publish/sites.py` | `publish_site`, `site_url`, `site_uri`, `site_name`, `PublishedSite`, `InvalidSiteError`, constants (`site_artifact` deferred) |
+| `scripts/ops/publish_site.py` | CLI wrapper |
+| `docs/tutorials/publish-analysis-site.md` | new tutorial |
+| `mkdocs.yml` | nav entry for the tutorial |
+| `docs/reports/index.md` | "Published analysis sites" section |
+| `tests/publish/test_sites.py` | unit + round-trip tests |
+| `gs://marin-public/index.json` | discovery manifest (data, not code) |
+
+## Out of scope (v1)
+
+- Managing `marin-public` IAM / lifecycle in `infra/configure_buckets.py` — the bucket stays provisioned out of band (Open Question in `design.md`).
+- Pretty directory URLs (`…/<version>/` without `index.html`) — needs a bucket Website config or CNAME.
+- A **private** publishing variant (IAP-gated frontend) for sensitive pages like the dedup report — the conservative future path (Open Question in `design.md`); v1 is public-only.
+- Ownership/auth on `<user>` handles, content review, deletion/GC of stale sites, and atomic/concurrent-safe index updates.
+- Reintroducing any `(id,version)→uri` registry or `Artifact.from_id` — deliberately removed in #6649; this design does not bring it back.
+- Templating/rendering of the HTML itself — callers bring their own bytes.

--- a/docs/reports/index.md
+++ b/docs/reports/index.md
@@ -5,6 +5,15 @@ and then curated by hand.
 
 This page includes only experiments that have at least one run or report.
 
+## Published analysis sites
+
+One-off analysis pages published to durable public hosting (see
+[Publishing an Analysis Site](../tutorials/publish-analysis-site.md)). The machine-readable list is
+[`gs://marin-public/index.json`](https://storage.googleapis.com/marin-public/index.json).
+
+- [DataKit side-by-side](https://storage.googleapis.com/marin-public/held/datakit-sidebyside/2026.07.01/index.html) — cluster examples, side by side (held)
+- [Delphi mid-training dossier](https://storage.googleapis.com/marin-public/ahmad/delphi-midtraining/2026.07.01/index.html) — mid-training analysis dossier (ahmad)
+
 ## Marin 8B Base
 
 - Tootsie 8B (Main Issue) [![#600](https://img.shields.io/github/issues/detail/state/marin-community/marin/600)](https://github.com/marin-community/marin/issues/600)

--- a/docs/tutorials/publish-analysis-site.md
+++ b/docs/tutorials/publish-analysis-site.md
@@ -1,0 +1,64 @@
+# Publishing an Analysis Site
+
+One-off analysis pages (dashboards, side-by-side comparisons, dossiers) often end up on personal
+sites that disappear when the author moves on. Marin gives them a durable, public home: a page
+published here gets a stable `https://storage.googleapis.com/marin-public/...` URL, is recorded as
+an Artifact so it can be fetched from code, and is listed in a public discovery index.
+
+!!! warning "The `marin-public` bucket is world-readable"
+    Everything you publish is readable by anyone on the internet, and any handle is unauthenticated
+    (there is no per-user ownership). **Never publish anything sensitive** — no private data, no
+    sampled corpus text, no credentials.
+
+## Publish
+
+`source` is either a single `.html` file or a directory whose `index.html` is the entrypoint (a
+multi-file site — HTML plus JS/CSS/data). Versions are calendar versions, `YYYY.MM.DD[.N]`.
+
+=== "CLI"
+
+    ```bash
+    uv run scripts/ops/publish_site.py report.html \
+        --user held --slug datakit-sidebyside --version 2026.07.01 \
+        --title "DataKit side-by-side"
+    # -> https://storage.googleapis.com/marin-public/held/datakit-sidebyside/2026.07.01/index.html
+    ```
+
+=== "Python"
+
+    ```python
+    from pathlib import Path
+
+    from marin.publish.sites import publish_site
+
+    site = publish_site(
+        Path("report.html"),
+        user="held", slug="datakit-sidebyside", version="2026.07.01",
+        title="DataKit side-by-side", summary="cluster examples, side by side",
+    )
+    print(site.url)
+    ```
+
+The page lands at `gs://marin-public/<user>/<slug>/<version>/`, alongside an `.artifact.json` record.
+A new version publishes to a new path, so old links keep working.
+
+## Fetch from code
+
+The address is a pure function of `(user, slug, version)`, so no registry lookup is needed:
+
+```python
+from marin.publish.sites import site_uri
+from marin.execution.artifact import Artifact
+
+site = Artifact.raw_load(site_uri("held", "datakit-sidebyside", "2026.07.01"))
+print(site.path)          # gs://marin-public/held/datakit-sidebyside/2026.07.01/
+print(site.record.config) # {"user", "slug", "version", "url", "title", "summary"}
+```
+
+`site_url(...)` and `site_uri(...)` are pure string builders if you only need the link or the path.
+
+## Discovery
+
+Every publish upserts an entry into `gs://marin-public/index.json`, a list of
+`{name, version, url, title, summary}`. Read it to enumerate published sites; the curated list also
+appears under [Published analysis sites](../reports/index.md).

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -23,6 +23,7 @@ their producers (``LevanterCheckpoint`` in ``marin.training.training``, ``Tokeni
 import functools
 import json
 import logging
+import re
 from dataclasses import asdict, dataclass, is_dataclass
 from typing import Self, TypeVar, cast
 
@@ -171,6 +172,12 @@ class ArtifactRecord(BaseModel):
     """The canonical config JSON the ``fingerprint`` hashes, kept for the drift diff."""
     provenance: Provenance | None = None
     """Who/when/which-commit/which-argv produced this — ``None`` for a minimal manual write."""
+
+
+# The one canonical CalVer form (``YYYY.MM.DD`` with an optional ``.N`` for two immutable
+# revisions on the same day), shared by the lazy layer (``lazy._validate_version``) and
+# ``marin.publish``. Keep it here so callers agree on version identity without importing ``lazy``.
+CALVER_RE = re.compile(r"^\d{4}\.\d{2}\.\d{2}(\.\d+)?$")
 
 
 def is_mutable_version(version: str) -> bool:

--- a/lib/marin/src/marin/execution/lazy.py
+++ b/lib/marin/src/marin/execution/lazy.py
@@ -31,7 +31,6 @@ learn.
 
 import inspect
 import json
-import re
 from collections.abc import Callable, Iterable, Mapping
 from dataclasses import dataclass, field
 from typing import Any, Final, Generic, TypeVar, cast
@@ -41,6 +40,7 @@ from rigging.filesystem import marin_prefix, marin_region, prefix_join, url_to_f
 from rigging.provenance import Provenance
 
 from marin.execution.artifact import (
+    CALVER_RE,
     EXPECTED_FINGERPRINT_KEY,
     FINGERPRINT_KEY,
     RESULT_TYPE_KEY,
@@ -57,9 +57,6 @@ from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec, _is_relative_path
 
 T = TypeVar("T", bound=Artifact)
-
-# A calendar version: YYYY.MM.DD, optionally .N for two immutable revisions on the same day.
-_CALVER_RE = re.compile(r"^\d{4}\.\d{2}\.\d{2}(\.\d+)?$")
 
 
 def _validate_segment(label: str, value: str) -> None:
@@ -84,7 +81,7 @@ def _validate_version(version: str) -> None:
     _validate_segment("version", version)
     if is_mutable_version(version):
         return
-    if not _CALVER_RE.match(version):
+    if not CALVER_RE.match(version):
         raise ValueError(
             f"version {version!r} must be a calendar version YYYY.MM.DD (optionally YYYY.MM.DD.N) "
             "or a mutable 'dev'/'<label>-dev'"

--- a/lib/marin/src/marin/publish/__init__.py
+++ b/lib/marin/src/marin/publish/__init__.py
@@ -1,0 +1,4 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Publish analysis HTML sites to durable public GCS hosting, recorded as Artifacts."""

--- a/lib/marin/src/marin/publish/sites.py
+++ b/lib/marin/src/marin/publish/sites.py
@@ -1,0 +1,242 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Publish an analysis HTML site to durable public hosting and record it as an Artifact.
+
+A "site" is a single ``.html`` file or a directory whose ``index.html`` is the entrypoint (a
+multi-file SPA). ``publish_site`` uploads it to ``gs://marin-public/<user>/<slug>/<version>/``,
+writes an :class:`~marin.execution.artifact.ArtifactRecord` next to it so it is self-describing
+and code-resolvable via ``Artifact.raw_load``, and upserts a public discovery index at
+``gs://marin-public/index.json``. Resolution is by deterministic address — a public page's
+location is a pure function of ``(user, slug, version)`` — so no registry is involved.
+"""
+
+import json
+import logging
+import re
+from dataclasses import dataclass
+from pathlib import Path
+
+from rigging.filesystem import open_url, url_to_fs
+from rigging.provenance import Provenance
+
+from marin.execution.artifact import (
+    CALVER_RE,
+    RECORD_FILENAME,
+    Artifact,
+    ArtifactRecord,
+    result_type_name,
+    write_record,
+)
+
+logger = logging.getLogger(__name__)
+
+PUBLIC_BUCKET = "marin-public"
+# Storage root and public URL base. PUBLIC_ROOT is a module attribute so tests can point it at a
+# local directory; the served URL is always the storage.googleapis.com endpoint.
+PUBLIC_ROOT = f"gs://{PUBLIC_BUCKET}"
+PUBLIC_URL_BASE = f"https://storage.googleapis.com/{PUBLIC_BUCKET}"
+SITE_ENTRYPOINT = "index.html"
+SITE_NAME_PREFIX = "sites"
+PUBLIC_INDEX_KEY = "index.json"
+
+# <user>/<slug> are coerced to lowercase-kebab path segments; this matches non-[a-z0-9] runs.
+_NON_KEBAB = re.compile(r"[^a-z0-9]+")
+
+# Content types are pinned by extension rather than deferred to the platform ``mimetypes`` DB,
+# whose ``.js``/``.wasm``/``.mjs`` mappings drift across systems and would mis-serve SPA assets.
+CONTENT_TYPES = {
+    ".html": "text/html; charset=utf-8",
+    ".htm": "text/html; charset=utf-8",
+    ".css": "text/css; charset=utf-8",
+    ".js": "text/javascript; charset=utf-8",
+    ".mjs": "text/javascript; charset=utf-8",
+    ".json": "application/json",
+    ".map": "application/json",
+    ".svg": "image/svg+xml",
+    ".wasm": "application/wasm",
+    ".png": "image/png",
+    ".jpg": "image/jpeg",
+    ".jpeg": "image/jpeg",
+    ".gif": "image/gif",
+    ".woff2": "font/woff2",
+}
+DEFAULT_CONTENT_TYPE = "application/octet-stream"
+
+
+class InvalidSiteError(ValueError):
+    """A malformed ``user``/``slug``/``version``/``title`` or an unpublishable ``source`` tree.
+
+    Always raised before any network/GCS access.
+    """
+
+
+@dataclass(frozen=True)
+class PublishedSite:
+    """Where a published site lives and how to reference it.
+
+    ``url`` is the canonical public link (the explicit ``index.html``); ``uri`` is the versioned
+    ``gs://`` directory holding the site and its ``.artifact.json``; ``name``/``version`` are the
+    artifact identity; ``title`` is the label recorded in the discovery index.
+    """
+
+    url: str
+    uri: str
+    name: str
+    version: str
+    title: str
+
+
+def _coerce_handle(label: str, value: str) -> str:
+    """Normalize a ``user``/``slug`` to a lowercase-kebab path segment.
+
+    Lowercases, collapses non-``[a-z0-9]`` runs to a single ``-``, and trims leading/trailing ``-``
+    (so ``"Foo Bar"`` → ``"foo-bar"``, ``"datakit_sidebyside"`` → ``"datakit-sidebyside"``). Raises
+    :class:`InvalidSiteError` only when nothing usable remains (e.g. ``""`` or ``"!!!"``).
+    """
+    coerced = _NON_KEBAB.sub("-", value.lower()).strip("-")
+    if not coerced:
+        raise InvalidSiteError(f"{label} {value!r} has no usable [a-z0-9] characters")
+    return coerced
+
+
+def _validate_version(version: str) -> None:
+    if not CALVER_RE.match(version):
+        raise InvalidSiteError(f"version {version!r} must be a calendar version YYYY.MM.DD[.N]")
+
+
+def site_name(user: str, slug: str) -> str:
+    """The artifact name ``sites/<user>/<slug>``. Pure; coerces handles to lowercase kebab."""
+    return f"{SITE_NAME_PREFIX}/{_coerce_handle('user', user)}/{_coerce_handle('slug', slug)}"
+
+
+def site_uri(user: str, slug: str, version: str) -> str:
+    """The site's ``gs://`` directory (record location + ``raw_load`` address). Pure; coerces handles."""
+    _validate_version(version)
+    return f"{PUBLIC_ROOT}/{_coerce_handle('user', user)}/{_coerce_handle('slug', slug)}/{version}/"
+
+
+def site_url(user: str, slug: str, version: str) -> str:
+    """The canonical public URL ``<base>/<user>/<slug>/<version>/index.html``. Pure; coerces handles."""
+    _validate_version(version)
+    return f"{PUBLIC_URL_BASE}/{_coerce_handle('user', user)}/{_coerce_handle('slug', slug)}/{version}/{SITE_ENTRYPOINT}"
+
+
+def _content_type(relpath: str) -> str:
+    return CONTENT_TYPES.get(Path(relpath).suffix.lower(), DEFAULT_CONTENT_TYPE)
+
+
+def _collect_files(source: Path) -> list[tuple[str, Path]]:
+    """Return ``(relpath, local_path)`` pairs to upload, ``relpath`` using ``/`` separators.
+
+    A single ``.html`` file is uploaded as ``index.html``. A directory is uploaded whole, preserving
+    relative paths; it must contain ``index.html``, must not contain a top-level ``.artifact.json``
+    (reserved for the record), and must contain no symlinks (which could escape the tree).
+    """
+    if source.is_file():
+        if source.suffix.lower() not in (".html", ".htm"):
+            raise InvalidSiteError(f"a single-file source must be .html, got {source.name!r}")
+        return [(SITE_ENTRYPOINT, source)]
+
+    files: list[tuple[str, Path]] = []
+    has_index = False
+    for path in sorted(source.rglob("*")):
+        if path.is_symlink():
+            raise InvalidSiteError(f"symlink not allowed in source: {path.relative_to(source).as_posix()}")
+        if path.is_dir():
+            continue
+        relpath = path.relative_to(source).as_posix()
+        if relpath == RECORD_FILENAME:
+            raise InvalidSiteError(f"source may not contain a top-level {RECORD_FILENAME!r} (reserved)")
+        has_index = has_index or relpath == SITE_ENTRYPOINT
+        files.append((relpath, path))
+    if not has_index:
+        raise InvalidSiteError(f"source directory must contain {SITE_ENTRYPOINT}")
+    return files
+
+
+def _index_uri() -> str:
+    return f"{PUBLIC_ROOT}/{PUBLIC_INDEX_KEY}"
+
+
+def _read_index() -> list[dict]:
+    uri = _index_uri()
+    fs = url_to_fs(uri, use_listings_cache=False)[0]
+    if not fs.exists(uri):
+        return []
+    with open_url(uri, "r") as f:
+        return json.load(f)
+
+
+def _upsert_index(entry: dict) -> None:
+    """Read the public index, replace any entry with the same ``(name, version)``, append, write.
+
+    Read-modify-write; not atomic. Concurrent publishes are last-writer-wins, acceptable given how
+    rarely sites are published.
+    """
+    entries = [e for e in _read_index() if (e.get("name"), e.get("version")) != (entry["name"], entry["version"])]
+    entries.append(entry)
+    entries.sort(key=lambda e: (e["name"], e["version"]))
+    with open_url(_index_uri(), "w", content_type="application/json") as f:
+        json.dump(entries, f, indent=2)
+
+
+def publish_site(
+    source: Path,
+    *,
+    user: str,
+    slug: str,
+    version: str,
+    title: str,
+    summary: str = "",
+) -> PublishedSite:
+    """Upload an analysis site to ``gs://marin-public/<user>/<slug>/<version>/``, record it, and
+    add it to the public discovery index.
+
+    ``source`` is a single local ``.html`` file (uploaded as ``index.html``) or a directory whose
+    ``index.html`` is the entrypoint; a directory is uploaded whole, preserving relative paths. Each
+    object's ``Content-Type`` is set from :data:`CONTENT_TYPES` by extension (default
+    :data:`DEFAULT_CONTENT_TYPE`).
+
+    After upload, writes an :class:`ArtifactRecord` into the same public directory (so
+    ``Artifact.raw_load(uri)`` resolves a typed handle with provenance) and upserts an entry into
+    ``gs://marin-public/index.json``.
+
+    ``user``/``slug`` are coerced to lowercase kebab (``"Foo Bar"`` → ``"foo-bar"``); the coerced
+    form is what appears in the path, record, and index. Other preconditions are checked before any
+    upload: ``version`` must be CalVer ``YYYY.MM.DD[.N]``, ``title`` must be non-empty, and a
+    directory ``source`` must contain ``index.html``, no top-level ``.artifact.json``, and no
+    symlinks. A missing ``source`` raises :class:`FileNotFoundError`; a handle that coerces to
+    nothing, a bad version, or an empty title raise :class:`InvalidSiteError`. Existing objects are
+    overwritten (last-writer-wins); distinct versions live at distinct paths.
+    """
+    if not title.strip():
+        raise InvalidSiteError("title must be non-empty")
+    user = _coerce_handle("user", user)
+    slug = _coerce_handle("slug", slug)
+    name = site_name(user, slug)
+    _validate_version(version)
+    if not source.exists():
+        raise FileNotFoundError(f"source not found: {source}")
+    files = _collect_files(source)
+
+    uri = site_uri(user, slug, version)
+    url = site_url(user, slug, version)
+    for relpath, local_path in files:
+        with open_url(f"{uri}{relpath}", "wb", content_type=_content_type(relpath)) as dst:
+            dst.write(local_path.read_bytes())
+
+    config = {"user": user, "slug": slug, "version": version, "url": url, "title": title, "summary": summary}
+    write_record(
+        ArtifactRecord(
+            name=name,
+            version=version,
+            output_path=uri,
+            result_type=result_type_name(Artifact),
+            config=config,
+            provenance=Provenance.capture(),
+        )
+    )
+    _upsert_index({"name": name, "version": version, "url": url, "title": title, "summary": summary})
+    logger.info("published %s@%s -> %s", name, version, url)
+    return PublishedSite(url=url, uri=uri, name=name, version=version, title=title)

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -64,6 +64,7 @@ nav:
       - First Experiment: tutorials/first-experiment.md
       - Setting up a Local GPU Environment: tutorials/local-gpu.md
       - Prepare a Storage Bucket: tutorials/storage-bucket.md
+      - Publishing an Analysis Site: tutorials/publish-analysis-site.md
       - Training an LM: tutorials/train-an-lm.md
   - Explanations:
       - The Language Modeling Pipeline: explanations/lm-pipeline.md

--- a/scripts/ops/publish_site.py
+++ b/scripts/ops/publish_site.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env -S uv run
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Publish an analysis HTML site to durable public hosting (``gs://marin-public``).
+
+Uploads a page and records it as an Artifact, then prints its public URL::
+
+    uv run scripts/ops/publish_site.py report.html --user rav --slug dedup-examples \
+        --version 2026.07.01 --title "Dedup examples"
+
+``<source>`` is a single ``.html`` file or a directory whose ``index.html`` is the entrypoint.
+"""
+
+import argparse
+import sys
+from pathlib import Path
+
+from marin.publish.sites import InvalidSiteError, publish_site
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Publish an analysis HTML site to gs://marin-public and record it.")
+    parser.add_argument("source", help="local .html file or directory with index.html")
+    parser.add_argument("--user", required=True, help="author handle (lowercase kebab)")
+    parser.add_argument("--slug", required=True, help="site slug (lowercase kebab)")
+    parser.add_argument("--version", required=True, help="CalVer version YYYY.MM.DD[.N]")
+    parser.add_argument("--title", required=True, help="human label for the discovery index")
+    parser.add_argument("--summary", default="", help="one-line description for the index")
+    args = parser.parse_args()
+
+    try:
+        site = publish_site(
+            Path(args.source),
+            user=args.user,
+            slug=args.slug,
+            version=args.version,
+            title=args.title,
+            summary=args.summary,
+        )
+    except (InvalidSiteError, FileNotFoundError) as e:
+        print(f"error: {e}", file=sys.stderr)
+        raise SystemExit(1) from e
+    print(site.url)
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/publish/test_sites.py
+++ b/tests/publish/test_sites.py
@@ -1,0 +1,149 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Behavior tests for marin.publish.sites, against a local filesystem root."""
+
+import json
+import os
+
+import pytest
+from marin.execution.artifact import RECORD_FILENAME, Artifact
+from marin.publish import sites
+from marin.publish.sites import InvalidSiteError, publish_site, site_uri
+
+
+@pytest.fixture
+def public_root(tmp_path, monkeypatch):
+    """Point the public storage root at a local temp dir; the URL base stays the real endpoint."""
+    root = tmp_path / "marin-public"
+    root.mkdir()
+    monkeypatch.setattr(sites, "PUBLIC_ROOT", str(root))
+    return root
+
+
+def test_publish_single_file_records_indexes_and_round_trips(public_root, tmp_path):
+    src = tmp_path / "report.html"
+    src.write_text("<h1>hi</h1>")
+
+    site = publish_site(
+        src, user="held", slug="datakit-sidebyside", version="2026.07.01", title="DataKit", summary="side by side"
+    )
+
+    # uploaded to the versioned path; returned url is the explicit index
+    version_dir = public_root / "held" / "datakit-sidebyside" / "2026.07.01"
+    assert (version_dir / "index.html").read_text() == "<h1>hi</h1>"
+    assert site.url == "https://storage.googleapis.com/marin-public/held/datakit-sidebyside/2026.07.01/index.html"
+
+    # recorded as an Artifact, fetchable from code by deterministic path (raw_load would raise
+    # ArtifactTypeMismatchError if the record's result_type were wrong, so returning proves it)
+    fetched = Artifact.raw_load(site_uri("held", "datakit-sidebyside", "2026.07.01"))
+    assert fetched.record is not None
+    assert fetched.record.name == "sites/held/datakit-sidebyside"
+    assert fetched.record.config["title"] == "DataKit"
+    assert fetched.record.config["summary"] == "side by side"
+
+    # listed in the public discovery index
+    index = json.loads((public_root / "index.json").read_text())
+    assert index == [
+        {
+            "name": "sites/held/datakit-sidebyside",
+            "version": "2026.07.01",
+            "url": site.url,
+            "title": "DataKit",
+            "summary": "side by side",
+        }
+    ]
+
+
+def test_publish_directory_preserves_asset_layout(public_root, tmp_path):
+    src = tmp_path / "site"
+    (src / "assets").mkdir(parents=True)
+    (src / "index.html").write_text("<script src=assets/app.js></script>")
+    (src / "assets" / "app.js").write_text("console.log(1)")
+
+    publish_site(src, user="rav", slug="dossier", version="2026.07.01", title="Dossier")
+
+    version_dir = public_root / "rav" / "dossier" / "2026.07.01"
+    assert (version_dir / "index.html").exists()
+    assert (version_dir / "assets" / "app.js").read_text() == "console.log(1)"
+
+
+def test_index_upserts_by_name_and_version(public_root, tmp_path):
+    src = tmp_path / "report.html"
+    src.write_text("<h1>hi</h1>")
+
+    publish_site(src, user="held", slug="ex", version="2026.07.01", title="First")
+    publish_site(src, user="held", slug="ex", version="2026.07.01", title="Second")  # upsert in place
+    publish_site(src, user="held", slug="ex", version="2026.07.02", title="Third")  # new version, new entry
+
+    index = {(e["name"], e["version"]): e for e in json.loads((public_root / "index.json").read_text())}
+    assert len(index) == 2
+    assert index[("sites/held/ex", "2026.07.01")]["title"] == "Second"
+
+
+def test_handles_are_coerced_to_kebab(public_root, tmp_path):
+    src = tmp_path / "report.html"
+    src.write_text("<h1>hi</h1>")
+
+    site = publish_site(src, user="Held", slug="DataKit_Side By Side", version="2026.07.01", title="t")
+
+    assert site.name == "sites/held/datakit-side-by-side"
+    assert (public_root / "held" / "datakit-side-by-side" / "2026.07.01" / "index.html").exists()
+
+
+def _txt_file(root):
+    (root / "report.txt").write_text("x")
+    return root / "report.txt"
+
+
+def _dir_without_index(root):
+    (root / "site").mkdir()
+    (root / "site" / "page.html").write_text("x")
+    return root / "site"
+
+
+def _dir_with_reserved_record(root):
+    (root / "site").mkdir()
+    (root / "site" / "index.html").write_text("x")
+    (root / "site" / RECORD_FILENAME).write_text("{}")
+    return root / "site"
+
+
+def _dir_with_symlink(root):
+    (root / "site").mkdir()
+    (root / "site" / "index.html").write_text("x")
+    (root / "secret").write_text("s")
+    os.symlink(root / "secret", root / "site" / "link")
+    return root / "site"
+
+
+@pytest.mark.parametrize(
+    ("build_source", "expected"),
+    [
+        (_txt_file, InvalidSiteError),  # a single-file source must be .html
+        (_dir_without_index, InvalidSiteError),  # a directory must contain index.html
+        (_dir_with_reserved_record, InvalidSiteError),  # the record filename is reserved
+        (_dir_with_symlink, InvalidSiteError),  # symlinks could escape the tree
+        (lambda root: root / "nope.html", FileNotFoundError),  # missing source
+    ],
+)
+def test_unpublishable_source_rejected(public_root, tmp_path, build_source, expected):
+    with pytest.raises(expected):
+        publish_site(build_source(tmp_path), user="held", slug="ex", version="2026.07.01", title="t")
+    assert not any(public_root.rglob("index.html"))  # nothing was uploaded
+
+
+@pytest.mark.parametrize(
+    ("user", "slug", "version", "title"),
+    [
+        ("held", "", "2026.07.01", "t"),  # slug coerces to nothing
+        ("held", "!!!", "2026.07.01", "t"),  # slug has no usable [a-z0-9]
+        ("held", "ex", "v1", "t"),  # non-CalVer version
+        ("held", "ex", "2026.07.01", ""),  # empty title
+    ],
+)
+def test_invalid_metadata_rejected(public_root, tmp_path, user, slug, version, title):
+    src = tmp_path / "report.html"
+    src.write_text("<h1>hi</h1>")
+    with pytest.raises(InvalidSiteError):
+        publish_site(src, user=user, slug=slug, version=version, title=title)


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/6802
* durable public hosting for one-off analysis HTML pages/sites: publish to `gs://marin-public/<user>/<slug>/<version>/index.html`, record as an `Artifact`, discover via a public `index.json`
* two commits: the [design doc](https://github.com/marin-community/marin/blob/design/public_artifacts/.agents/projects/public_artifacts/design.md) (+ [`spec`](https://github.com/marin-community/marin/blob/design/public_artifacts/.agents/projects/public_artifacts/spec.md) / [`research`](https://github.com/marin-community/marin/blob/design/public_artifacts/.agents/projects/public_artifacts/research.md)) and the implementation

### implementation
* `marin.publish.sites.publish_site(source, *, user, slug, version, title, summary="")` — uploads a single `.html` or a directory (multi-file SPA, relative paths preserved) with pinned per-extension content types, writes an `ArtifactRecord` into the public dir, and upserts `gs://marin-public/index.json`
  * fetch from code by deterministic path: `Artifact.raw_load(site_uri(user, slug, version))` — no registry [^1]
  * `site_url` / `site_uri` / `site_name` pure string builders; `InvalidSiteError` for bad handle/version/title/source, all raised before any upload
* `scripts/ops/publish_site.py` — thin CLI wrapper
* docs: `docs/tutorials/publish-analysis-site.md` (+ nav) and a "Published analysis sites" section in `docs/reports/index.md`
* `tests/publish/test_sites.py` — 15 behavior tests against a local FS root (placement, record, multi-file, `raw_load` round-trip, index upsert, all rejections); pyrefly + ruff clean
* migrated both worked examples live (verified `200` + `text/html`):
  * https://storage.googleapis.com/marin-public/held/datakit-sidebyside/2026.07.01/index.html
  * https://storage.googleapis.com/marin-public/ahmad/delphi-midtraining/2026.07.01/index.html

### deliberately out of v1
* `render_cluster_report` is **not** migrated (embeds sampled corpus text) — a `--private` IAP-gated variant is the future path (per rjpower)
* `site_artifact()` adopt handle deferred — no consumer, and it would drag `lazy`/Fray onto the publish path
* no immutability guard (same-version re-publish is last-writer-wins); `index.json` update is non-atomic

discussion welcome — see Open Questions in `design.md`

[^1]: the `Artifact.from_id` + `ArtifactRegistry` `(id,version)→uri` registry shipped in #6061 and was deliberately removed in the lazy-`ArtifactStep` rewrite (#6649); resolution is now by deterministic `name@version` addressing, which a public page (fixed bucket + identity-derived path) satisfies without a registry.
