### PR TITLE
[iris] Fungible-reservation chip ledger and unified drain lifecycle

### DIFF
--- a/lib/iris/config/marin.yaml
+++ b/lib/iris/config/marin.yaml
@@ -151,18 +151,23 @@ tpu_pools:
       gcp:
         service_account: iris-worker@hai-gcp-models.iam.gserviceaccount.com
         runtime_version: tpu-ubuntu2204-base
-    # max_slices = 2048 / size for each entry (~2048-chip-equivalent reservation
-    # in TensorCore units; sizes >2048 omitted since they'd exceed the budget).
+    # Chips are fungible across slice sizes up to the reservation: 1024 physical
+    # v4 chips (= 2048 TensorCores; the GCP vN-SIZE suffix counts TensorCores, so
+    # a v4-8 slice is 4 chips). Each size's max_slices defaults to
+    # reservation_chips // chips-per-slice (the most that size could ever place),
+    # so the shared budget is the only number to keep in sync.
+    fungible_reservation: true
+    reservation_chips: 1024
     sizes:
-      8:    { buffer_slices: 0, max_slices: 256 }
-      16:   { buffer_slices: 0, max_slices: 128 }
-      32:   { buffer_slices: 0, max_slices: 64 }
-      64:   { buffer_slices: 0, max_slices: 32 }
-      128:  { buffer_slices: 0, max_slices: 16 }
-      256:  { buffer_slices: 0, max_slices: 8 }
-      512:  { buffer_slices: 0, max_slices: 4 }
-      1024: { buffer_slices: 0, max_slices: 2 }
-      2048: { buffer_slices: 0, max_slices: 1 }
+      8: {}
+      16: {}
+      32: {}
+      64: {}
+      128: {}
+      256: {}
+      512: {}
+      1024: {}
+      2048: {}
 
 # ---------------------------------------------------------------------------
 # Non-TPU scale groups (not part of tpu_pools)

--- a/lib/iris/dashboard/src/components/controller/CapacityTab.vue
+++ b/lib/iris/dashboard/src/components/controller/CapacityTab.vue
@@ -245,7 +245,7 @@ const lastEvalMs = computed(() => timestampMs(autoscaler.value?.lastEvaluation))
 function formatSliceSummary(totals: Record<string, number>): string {
   const total = Object.values(totals).reduce((a, b) => a + b, 0)
   if (total === 0) return '0'
-  const order = ['ready', 'requesting', 'booting', 'initializing', 'failed']
+  const order = ['ready', 'requesting', 'booting', 'initializing', 'draining', 'failed']
   const parts = order
     .filter(state => (totals[state] ?? 0) > 0)
     .map(state => `${totals[state]} ${state}`)

--- a/lib/iris/dashboard/src/types/status.ts
+++ b/lib/iris/dashboard/src/types/status.ts
@@ -265,6 +265,14 @@ export const SLICE_STATUS_STYLES: Record<SliceStatus, SliceStatusStyle> = {
     text: 'text-status-purple',
     border: 'border-status-purple-border',
   },
+  draining: {
+    label: 'draining',
+    description: 'Being torn down — still counted until the cloud confirms its VMs are gone',
+    dot: 'bg-status-warning',
+    bg: 'bg-status-warning-bg',
+    text: 'text-status-warning',
+    border: 'border-status-warning-border',
+  },
   failed: {
     label: 'failed',
     description: 'Slice failed to provision or was lost',
@@ -295,6 +303,7 @@ export const SLICE_STATUS_SUMMARY_ORDER: readonly SliceStatus[] = [
   'idle',
   'degraded',
   'failed',
+  'draining',
   'requesting',
   'booting',
   'initializing',

--- a/lib/iris/dashboard/src/utils/slices.ts
+++ b/lib/iris/dashboard/src/utils/slices.ts
@@ -16,7 +16,7 @@
 import type { SliceInfo } from '@/types/rpc'
 import { timestampMs } from '@/utils/formatting'
 
-export type SliceLifecycle = 'requesting' | 'booting' | 'initializing' | 'ready' | 'failed'
+export type SliceLifecycle = 'requesting' | 'booting' | 'initializing' | 'ready' | 'draining' | 'failed'
 
 /**
  * Display status: lifecycle for non-ready slices, else the server-derived capacity
@@ -58,6 +58,7 @@ const LIFECYCLE_VALUES: ReadonlySet<string> = new Set([
   'booting',
   'initializing',
   'ready',
+  'draining',
   'failed',
 ])
 
@@ -153,6 +154,7 @@ const STATUS_RANK: Record<SliceStatus, number> = {
   requesting: 2,
   booting: 2,
   initializing: 2,
+  draining: 2,
   idle: 3,
   in_use: 4,
   available: 5,

--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -1493,7 +1493,7 @@ class K8sTaskProvider:
 
     def autoscale(self, request: AutoscaleRequest) -> AutoscaleResult:
         """No-op: the cluster autoscaler + Kueue provision nodes; K8s has no
-        Iris-managed slices to tear down."""
+        Iris-managed slices to tear down or drain."""
         return AutoscaleResult()
 
     def bind_runtime(self, runtime: BackendRuntime) -> None:

--- a/lib/iris/src/iris/cluster/backends/rpc/backend.py
+++ b/lib/iris/src/iris/cluster/backends/rpc/backend.py
@@ -383,21 +383,22 @@ class RpcTaskBackend:
         return self._store.prune_dead_workers(cutoff_ms=cutoff_ms, stop_event=stop_event, pause=pause)
 
     def autoscale(self, request: AutoscaleRequest) -> AutoscaleResult:
-        """Tear down dead workers' slices, or run one provisioning cycle.
+        """Drain dead workers' slices, or run one provisioning cycle.
 
-        With ``request.dead_workers`` set the autoscaler terminates their slices
-        and returns the dead workers plus their healthy siblings as
-        ``removed_workers`` (no provisioning this call). Stubs for the removed
-        workers are not evicted here: a dead worker's stub was already dropped as
-        it accrued UNREACHABLE reconcile rounds, and a healthy sibling's stub
-        self-evicts on the next reconcile RPC once its slice is gone. Otherwise it
-        runs a refresh + probe_health + update cycle against
-        ``request.residual_demand``, reading its own worker status.
+        With ``request.dead_workers`` set the autoscaler drains their slices —
+        marked DRAINING and reaped by a later refresh — and returns the dead
+        workers plus their healthy siblings as ``removed_workers`` (no
+        provisioning this call). Stubs for the removed workers are not evicted
+        here: a dead worker's stub was already dropped as it accrued UNREACHABLE
+        reconcile rounds, and a healthy sibling's stub self-evicts on the next
+        reconcile RPC once its slice is gone. Otherwise it runs a refresh +
+        probe_health + update cycle against ``request.residual_demand``, reading
+        its own worker status.
         """
         if self.autoscaler is None:
             return AutoscaleResult()
         if request.dead_workers:
-            siblings = self.autoscaler.terminate_slices_for_workers([str(wid) for wid in request.dead_workers])
+            siblings = self.autoscaler.drain_slices_for_workers([str(wid) for wid in request.dead_workers])
             removed = list(request.dead_workers) + [WorkerId(wid) for wid in siblings]
             return AutoscaleResult(removed_workers=removed, autoscaler_state=self.autoscaler.persistable_state())
         assert self._store is not None, "RpcTaskBackend.autoscale called before worker store attached"

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -29,7 +29,7 @@ import yaml
 from pydantic import BaseModel, BeforeValidator, ConfigDict, Field, PlainSerializer, model_validator
 from rigging.timing import Duration
 
-from iris.cluster.tpu_topology import TPU_FAMILY_VARIANT_PREFIX, get_tpu_topology, tpu_variant_name
+from iris.cluster.tpu_topology import TPU_FAMILY_VARIANT_PREFIX, TpuTopologyInfo, get_tpu_topology, tpu_variant_name
 from iris.cluster.types import (
     DEFAULT_BACKEND_ID,
     AcceleratorType,
@@ -345,6 +345,13 @@ class ScaleGroupConfig(_Config):
     quota_pool: str = ""
     # Tier within the quota pool (1-based, lower preferred; 0 = unset).
     allocation_tier: int = 0
+    # Fungible-reservation chip budget shared across all groups in this group's
+    # quota_pool. >0 marks the group as a member of a reserved pool whose TPU
+    # chips are interchangeable across slice sizes up to this many physical chips
+    # (see tpu_topology chip_count, NOT the GCP size suffix). Every member of one
+    # quota_pool carries the same value. 0 means the group is not part of a
+    # fungible reservation (default; preemptible/on-demand groups never set it).
+    reservation_chips: int = 0
 
     @model_validator(mode="after")
     def _derive_slice_template(self) -> ScaleGroupConfig:
@@ -964,6 +971,77 @@ def _merge_zones_into_platform_gcp(data: dict, zones: set[str]) -> None:
         platform_gcp["zones"] = sorted(existing)
 
 
+def _validate_fungible_reservation(
+    pool_name: str,
+    pool: dict,
+    base_resources: dict,
+    family: str,
+    sorted_sizes: list,
+) -> int:
+    """Validate a pool's optional fungible-reservation budget; return chips (0 if absent).
+
+    Fungibility means the pool's TPU chips are interchangeable across its slice
+    sizes up to a shared budget. It is only sound on a true reservation — where
+    freeing a slice guarantees the chips can be re-provisioned at a different size
+    — so it is rejected on preemptible/on-demand capacity. The budget is in
+    physical chips (topology ``chip_count``), not the GCP ``vN-SIZE`` suffix.
+    """
+    fungible = bool(pool.get("fungible_reservation", False))
+    reservation_chips = pool.get("reservation_chips", 0)
+    if not fungible and not reservation_chips:
+        return 0
+    if not fungible:
+        raise ValueError(f"tpu_pools.{pool_name}: reservation_chips set without 'fungible_reservation: true'")
+    if _coerce_capacity_type(base_resources.get("capacity_type", "")) != CapacityType.RESERVED:
+        raise ValueError(
+            f"tpu_pools.{pool_name}: fungible_reservation requires resources.capacity_type=reserved, "
+            f"got {base_resources.get('capacity_type')!r}"
+        )
+    if not isinstance(reservation_chips, int) or reservation_chips <= 0:
+        raise ValueError(
+            f"tpu_pools.{pool_name}: fungible_reservation requires a positive integer reservation_chips, "
+            f"got {reservation_chips!r}"
+        )
+    # Every slice size must individually fit within the reservation, else a job of
+    # that size could never be placed in the pool.
+    largest = tpu_variant_name(family, int(sorted_sizes[-1]))
+    largest_chips = get_tpu_topology(largest).chip_count
+    if largest_chips > reservation_chips:
+        raise ValueError(
+            f"tpu_pools.{pool_name}: reservation_chips={reservation_chips} is smaller than the largest slice "
+            f"'{largest}' ({largest_chips} chips); it could never be placed"
+        )
+    return reservation_chips
+
+
+def _resolve_max_slices(
+    pool_name: str, size: object, size_overrides: dict, reservation_chips: int, topo: TpuTopologyInfo
+) -> int:
+    """Resolve one size's ``max_slices``, defaulting fungible members to the reservation ceiling.
+
+    On a fungible reservation, a single size can never legitimately place more
+    than ``reservation_chips // topo.chip_count`` slices — the shared budget is
+    the real constraint, so that ceiling is a safe default and an override may
+    only tighten it, never loosen it (a looser override would just be the same
+    hand-computed number the ceiling already gives you, restated and liable to
+    drift). Non-fungible pools (``reservation_chips == 0``) still require
+    ``max_slices`` explicitly.
+    """
+    default_max_slices = reservation_chips // topo.chip_count if reservation_chips else None
+    max_slices = size_overrides.get("max_slices", default_max_slices)
+    if max_slices is None:
+        raise ValueError(
+            f"tpu_pools.{pool_name}.sizes.{size}: 'max_slices' is required (pool is not a fungible reservation)"
+        )
+    if reservation_chips and max_slices > reservation_chips // topo.chip_count:
+        raise ValueError(
+            f"tpu_pools.{pool_name}.sizes.{size}: max_slices={max_slices} exceeds "
+            f"reservation_chips // chip_count = {reservation_chips // topo.chip_count}; "
+            "a single size can never legitimately use more than the shared reservation allows"
+        )
+    return max_slices
+
+
 def _expand_tpu_pools(data: dict) -> None:
     """Expand ``tpu_pools`` into per-(size, zone) scale groups.
 
@@ -1009,11 +1087,17 @@ def _expand_tpu_pools(data: dict) -> None:
             except ValueError:
                 raise ValueError(f"tpu_pools.{pool_name}.sizes.{size}: unknown TPU topology '{variant}'") from None
 
+        # Fungible reservation: chips are interchangeable across this pool's slice
+        # sizes up to a shared budget. Only legal on reserved capacity; the budget
+        # is in physical chips (topology chip_count), not the GCP size suffix.
+        reservation_chips = _validate_fungible_reservation(pool_name, pool, base_resources, family, sorted_sizes)
+
         for tier_index, size in enumerate(sorted_sizes):
             size_int = int(size)
             size_overrides = sizes[size] or {}
             variant = tpu_variant_name(family, size_int)
             topo = get_tpu_topology(variant)
+            max_slices = _resolve_max_slices(pool_name, size, size_overrides, reservation_chips, topo)
 
             for zone in zones:
                 sg_name = f"tpu_{pool_name}_{size_int}-{zone}"
@@ -1031,7 +1115,7 @@ def _expand_tpu_pools(data: dict) -> None:
                 gcp = st.setdefault("gcp", {})
                 gcp["zone"] = zone
 
-                scale_groups[sg_name] = {
+                sg = {
                     "name": sg_name,
                     "num_vms": topo.vm_count,
                     "priority": size_overrides.get("priority", base_priority + tier_index * 10),
@@ -1039,9 +1123,12 @@ def _expand_tpu_pools(data: dict) -> None:
                     "allocation_tier": tier_index + 1,
                     "resources": resources,
                     "buffer_slices": size_overrides.get("buffer_slices", 0),
-                    "max_slices": size_overrides["max_slices"],
+                    "max_slices": max_slices,
                     "slice_template": st,
                 }
+                if reservation_chips:
+                    sg["reservation_chips"] = reservation_chips
+                scale_groups[sg_name] = sg
 
     _merge_zones_into_platform_gcp(data, all_zones)
 

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -1019,13 +1019,10 @@ def _resolve_max_slices(
 ) -> int:
     """Resolve one size's ``max_slices``, defaulting fungible members to the reservation ceiling.
 
-    On a fungible reservation, a single size can never legitimately place more
-    than ``reservation_chips // topo.chip_count`` slices — the shared budget is
-    the real constraint, so that ceiling is a safe default and an override may
-    only tighten it, never loosen it (a looser override would just be the same
-    hand-computed number the ceiling already gives you, restated and liable to
-    drift). Non-fungible pools (``reservation_chips == 0``) still require
-    ``max_slices`` explicitly.
+    Defaults to ``reservation_chips // topo.chip_count`` when ``reservation_chips``
+    is set; an explicit override may only tighten that ceiling, never loosen it —
+    raises otherwise. Non-fungible pools (``reservation_chips == 0``) still require
+    ``max_slices`` explicitly; raises if it is missing.
     """
     default_max_slices = reservation_chips // topo.chip_count if reservation_chips else None
     max_slices = size_overrides.get("max_slices", default_max_slices)

--- a/lib/iris/src/iris/cluster/controller/autoscaler/models.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/models.py
@@ -9,6 +9,11 @@ from enum import Enum
 from iris.cluster.constraints import Constraint, PlacementRequirements
 from iris.rpc import job_pb2
 
+# Band for a demand entry whose tasks carry no resolved effective band; sorts after
+# every real band (lower band = higher priority) so unranked demand yields chips to
+# ranked demand for the same fungible pool.
+UNRANKED_DEMAND_BAND = 1 << 30
+
 
 class ScalingAction(Enum):
     """Type of scaling action."""
@@ -35,6 +40,11 @@ class DemandEntry:
     constraints: list[Constraint]
     resources: job_pb2.ResourceSpecProto
     invalid_reason: str | None = None
+    band: int = UNRANKED_DEMAND_BAND
+    """Effective band (min over the entry's tasks; lower = higher priority) the
+    reservation-aware launch cap admits fungible-pool slices by. Stamped by the
+    scheduler from its resolved band map; defaults to unranked for demand emitted
+    where no band was resolved (e.g. the no-schedulable-work path)."""
 
 
 @dataclass(frozen=True)

--- a/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
@@ -18,7 +18,7 @@ logger = logging.getLogger(__name__)
 
 @dataclass(frozen=True)
 class SliceTerminationRequest:
-    """A detached slice handle scheduled for termination."""
+    """A DRAINING slice handle whose VMs the caller must terminate."""
 
     slice_id: str
     group: ScalingGroup
@@ -27,27 +27,33 @@ class SliceTerminationRequest:
 
 @dataclass(frozen=True)
 class SliceTerminationResult:
-    """Batch termination work derived from a set of failed workers."""
+    """Drain work derived from a set of workers leaving their slices."""
 
     sibling_worker_ids: list[str]
     termination_requests: list[SliceTerminationRequest]
 
 
-def terminate_slices_for_workers(
+def drain_slices_for_workers(
     groups: dict[str, ScalingGroup],
     worker_ids: Sequence[str],
     unregister_slice_workers: Callable[[str, Sequence[str] | None], None],
     log_action: Callable[..., vm_pb2.AutoscalerAction],
     timestamp: Timestamp,
 ) -> SliceTerminationResult:
-    """Detach and schedule slice termination for the given failed workers.
+    """Mark every slice holding ``worker_ids`` DRAINING and collect its handle.
 
-    Every observed slice termination is reported to the group's churn detector
-    as :class:`~iris.cluster.controller.autoscaler.backoff_detector.SliceFate.PREEMPTED`.
+    Workers are grouped by physical slice because the teardown removes a whole
+    slice: every task on it goes together and its chips free once. Each slice is
+    drained at most once. The slice stays tracked — counted against its reservation
+    pool as DRAINING — until ``refresh`` observes its VMs are gone and reaps it; the
+    caller terminates the returned handles to start that deletion.
+
+    Every observed drain is reported to the group's churn detector as
+    :class:`~iris.cluster.controller.autoscaler.backoff_detector.SliceFate.PREEMPTED`.
     The detector classifies internally based on slice age — short-lived deaths
-    move churn rate; long-lived deaths count as positive samples.
+    move churn rate; long-lived deaths count as positive samples. Returns the
+    drained slices' sibling worker ids for the caller to fail immediately.
     """
-
     if not worker_ids:
         return SliceTerminationResult(sibling_worker_ids=[], termination_requests=[])
 
@@ -67,17 +73,17 @@ def terminate_slices_for_workers(
 
         slice_worker_ids = group.get_slice_worker_ids(slice_id)
         sibling_worker_ids.update(wid for wid in slice_worker_ids if wid not in primary_workers)
-        failed_workers = sorted(primary_workers & set(slice_worker_ids))
+        affected_workers = sorted(primary_workers & set(slice_worker_ids))
 
-        logger.info("Workers %s triggered slice termination for %s", failed_workers, slice_id)
+        logger.info("Workers %s triggered slice drain for %s", affected_workers, slice_id)
         log_action(
             "worker_failed",
             group.name,
             slice_id=slice_id,
-            reason=f"workers failed: {', '.join(failed_workers)}",
+            reason=f"workers failed: {', '.join(affected_workers)}",
         )
         group.record_slice_preempted(slice_id, timestamp)
-        handle = group.detach_slice(slice_id)
+        handle = group.drain_slice(slice_id, timestamp)
         unregister_slice_workers(slice_id, slice_worker_ids)
         if handle is not None:
             termination_requests.append(SliceTerminationRequest(slice_id=slice_id, group=group, handle=handle))

--- a/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
@@ -10,7 +10,7 @@ from dataclasses import dataclass
 from rigging.timing import Timestamp
 
 from iris.cluster.backends.types import SliceHandle
-from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
+from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup, SliceLifecycleState
 from iris.rpc import vm_pb2
 
 logger = logging.getLogger(__name__)
@@ -43,12 +43,16 @@ def drain_slices_for_workers(
     """Mark every slice holding ``worker_ids`` DRAINING and collect its handle.
 
     Workers are grouped by physical slice because the teardown removes a whole
-    slice: every task on it goes together and its chips free once. Each slice is
-    drained at most once. The slice stays tracked — counted against its reservation
-    pool as DRAINING — until ``refresh`` observes its VMs are gone and reaps it; the
-    caller terminates the returned handles to start that deletion.
+    slice: every task on it goes together and its chips free once. A slice
+    already DRAINING (e.g. a prior call drained it and this one reports another
+    of its sibling workers dead) is not re-entered — only its sibling worker ids
+    are collected — so the reap-timeout clock and the churn detector are each
+    charged once per slice. The slice stays tracked — counted against its
+    reservation pool as DRAINING — until ``refresh`` observes its VMs are gone
+    and reaps it; the caller terminates the returned handles to start that
+    deletion.
 
-    Every observed drain is reported to the group's churn detector as
+    Every newly observed drain is reported to the group's churn detector as
     :class:`~iris.cluster.controller.autoscaler.backoff_detector.SliceFate.PREEMPTED`.
     The detector classifies internally based on slice age — short-lived deaths
     move churn rate; long-lived deaths count as positive samples. Returns the
@@ -73,8 +77,12 @@ def drain_slices_for_workers(
 
         slice_worker_ids = group.get_slice_worker_ids(slice_id)
         sibling_worker_ids.update(wid for wid in slice_worker_ids if wid not in primary_workers)
-        affected_workers = sorted(primary_workers & set(slice_worker_ids))
+        unregister_slice_workers(slice_id, slice_worker_ids)
 
+        if group.slice_lifecycle(slice_id) == SliceLifecycleState.DRAINING:
+            continue
+
+        affected_workers = sorted(primary_workers & set(slice_worker_ids))
         logger.info("Workers %s triggered slice drain for %s", affected_workers, slice_id)
         log_action(
             "worker_failed",
@@ -84,7 +92,6 @@ def drain_slices_for_workers(
         )
         group.record_slice_preempted(slice_id, timestamp)
         handle = group.drain_slice(slice_id, timestamp)
-        unregister_slice_workers(slice_id, slice_worker_ids)
         if handle is not None:
             termination_requests.append(SliceTerminationRequest(slice_id=slice_id, group=group, handle=handle))
 

--- a/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/planning.py
@@ -3,12 +3,21 @@
 
 """Scale-up planning helpers built on top of routed demand."""
 
-from dataclasses import dataclass
+from collections import defaultdict
+from dataclasses import dataclass, replace
+from typing import NamedTuple
 
 from rigging.timing import Timestamp
 
-from iris.cluster.controller.autoscaler.models import RoutingDecision, ScalingAction, ScalingDecision
+from iris.cluster.controller.autoscaler.models import (
+    UNRANKED_DEMAND_BAND,
+    RoutingDecision,
+    ScalingAction,
+    ScalingDecision,
+)
+from iris.cluster.controller.autoscaler.reserved_pool import ReservationLedger, build_reservation_ledger
 from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup, SliceLifecycleState
+from iris.cluster.tpu_topology import get_tpu_topology
 
 
 @dataclass(frozen=True)
@@ -122,15 +131,127 @@ def build_group_scale_plan(group: ScalingGroup, required_slices: int, ts: Timest
     )
 
 
+class _PoolCandidate(NamedTuple):
+    """A scaling group of one fungible pool that wants to launch slices this tick."""
+
+    name: str
+    band: int
+    chips_per_slice: int
+    want_slices: int
+
+
+def _admit_in_band_order(candidates: list[_PoolCandidate], free_chips: int, draining_chips: int) -> dict[str, int]:
+    """Admit per-group new-slice counts under one fungible pool's chip budget.
+
+    ``candidates`` are the groups of one ``quota_pool`` that want to launch this tick
+    (lower band = higher priority). Returns ``group_name -> admitted_slices``. Groups
+    are admitted highest priority first, each taking as many slices as its own share
+    of the remaining budget allows. When a band comes up short, the rest of the
+    budget is reserved for it — locking out every strictly-lower-priority group — but
+    only when relief is actually achievable: enough chips free now plus
+    ``draining_chips`` to eventually cover one more of its slices (e.g. a multi-tick
+    drain still trickling chips back). Otherwise the shortfall can't be resolved by
+    holding back lower bands, so they stay free to use what's left instead of sitting
+    idle. Same-band groups share the remaining chips greedily.
+    """
+    remaining = max(0, free_chips)
+    admitted: dict[str, int] = {}
+    # Once set: every strictly-lower band is admitted nothing further this tick —
+    # the rest of the pool's budget is held in reserve for this band.
+    reserved_for_band: int | None = None
+
+    for cand in sorted(candidates, key=lambda c: (c.band, c.name)):
+        # A higher-priority band already claimed the remaining budget.
+        if reserved_for_band is not None and cand.band > reserved_for_band:
+            admitted[cand.name] = 0
+            continue
+
+        # Grant this candidate as many slices as its own share of the remaining
+        # budget allows.
+        grant = (
+            cand.want_slices if cand.chips_per_slice <= 0 else min(cand.want_slices, remaining // cand.chips_per_slice)
+        )
+        admitted[cand.name] = grant
+        remaining -= grant * cand.chips_per_slice
+
+        # This candidate came up short. Only start reserving the rest of the budget
+        # for it if relief is achievable: the chips free now plus what's draining
+        # would cover one more of its slices. Otherwise the chips free now plus
+        # what's draining can't satisfy this band's next slice anyway, so holding
+        # them back from lower bands wouldn't help — leave those free to use what's
+        # left.
+        fully_granted = grant == cand.want_slices
+        relief_achievable = remaining + draining_chips >= cand.chips_per_slice
+        if not fully_granted and reserved_for_band is None and relief_achievable:
+            reserved_for_band = cand.band
+
+    return admitted
+
+
+def _cap_fungible_pool_launches(
+    group_plans: dict[str, GroupScalePlan],
+    groups: dict[str, ScalingGroup],
+    routing_decision: RoutingDecision,
+    ledger: ReservationLedger,
+) -> dict[str, GroupScalePlan]:
+    """Trim new launches per fungible reservation pool to its chip budget.
+
+    A fungible reservation's per-size groups share one physical chip pool, but each
+    group's ``max_slices`` bounds it independently and ``route_demand`` never reads
+    the shared budget — so unconstrained planning can request far more chips than the
+    reservation holds (256 v4-8 *and* 128 v4-16 = 2048 chips against a 1024-chip
+    pool). This caps each pool's total ``slices_to_add * chips`` to the chips free
+    against the reservation *now* (live + in-flight slices, excluding draining chips
+    that aren't free until reaped), admitting groups highest priority first and
+    holding chips for an unsatisfied high-priority slice rather than a lower one —
+    but only while a drain in progress could still make that hold worthwhile.
+    Non-fungible groups are untouched.
+    """
+    if not ledger.pools:
+        return group_plans
+
+    candidates_by_pool: dict[str, list[_PoolCandidate]] = defaultdict(list)
+    for name, group in groups.items():
+        plan = group_plans[name]
+        if group.reservation_chips <= 0 or plan.slices_to_add <= 0:
+            continue
+        band = min(
+            (entry.band for entry in routing_decision.routed_entries.get(name, ())),
+            default=UNRANKED_DEMAND_BAND,
+        )
+        chips = get_tpu_topology(group.accelerator_variant).chip_count
+        candidates_by_pool[group.config.quota_pool].append(
+            _PoolCandidate(name=name, band=band, chips_per_slice=chips, want_slices=plan.slices_to_add)
+        )
+
+    if not candidates_by_pool:
+        return group_plans
+
+    capped = dict(group_plans)
+    for pool_id, candidates in candidates_by_pool.items():
+        admitted = _admit_in_band_order(candidates, ledger.free_chips(pool_id), ledger.draining_chips(pool_id))
+        for name, grant in admitted.items():
+            if grant != capped[name].slices_to_add:
+                capped[name] = replace(capped[name], slices_to_add=grant)
+    return capped
+
+
 def build_scale_plan(
     groups: dict[str, ScalingGroup],
     routing_decision: RoutingDecision,
     ts: Timestamp,
 ) -> ScalePlan:
-    """Build the canonical autoscaler plan for the current routing decision."""
+    """Build the canonical autoscaler plan for the current routing decision.
+
+    Fungible reservation pools are capped to their shared chip budget after per-group
+    planning, so a high-priority job's larger slice claims the reservation before a
+    lower-priority job's and the pool is never over-committed.
+    """
 
     group_plans = {
         name: build_group_scale_plan(group, routing_decision.group_required_slices.get(name, 0), ts)
         for name, group in groups.items()
     }
+    ledger = build_reservation_ledger(groups.values())
+    group_plans = _cap_fungible_pool_launches(group_plans, groups, routing_decision, ledger)
     return ScalePlan(routing_decision=routing_decision, group_plans=group_plans)

--- a/lib/iris/src/iris/cluster/controller/autoscaler/reserved_pool.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/reserved_pool.py
@@ -5,16 +5,12 @@
 
 On a fungible reservation, the per-size scale groups sharing a ``quota_pool`` draw
 from one physical pool of interchangeable TPU chips. This module builds, once per
-control tick, the single chip ledger both the scheduler's cross-variant preemption
-pass and the autoscaler's launch planner read.
+control tick, a chip ledger over those pools from live scale-group state.
 
 The ledger buckets every pool's chips into live (READY), in-flight
-(REQUESTING/BOOTING/INITIALIZING), and draining (DRAINING) slices. The launch
-planner asks how many chips are free *now* to bound new launches; the preemption
-pass asks whether a pool's deficit is already being addressed — by chips that are
-free or about to be freed by a drain, or by a replacement slice of the preemptor's
-own variant already booting — so it does not re-preempt across the drain-and-
-reprovision window. It changes no scaling decision on its own.
+(REQUESTING/BOOTING/INITIALIZING), and draining (DRAINING) slices, and exposes how
+many are free now versus free-or-draining. It is a pure accounting view: building
+it changes no scaling decision on its own.
 """
 
 import logging
@@ -65,10 +61,9 @@ class PoolLedger:
 class ReservationLedger:
     """Single per-tick chip ledger over all fungible reservation pools.
 
-    The one capacity view both the scheduler's cross-variant preemption pass and
-    the autoscaler's launch planner read. The pass asks ``incoming_chips`` /
-    ``inflight_slices`` ("is the deficit already being addressed?"); the planner
-    asks ``free_chips`` ("how many new slices may I launch now?").
+    Exposes each pool's chip accounting (``free_chips``, ``incoming_chips``,
+    ``draining_chips``, ``inflight_slices``) plus lookup maps from worker/variant
+    to the pool and physical slice they belong to.
     """
 
     pools: dict[str, PoolLedger]

--- a/lib/iris/src/iris/cluster/controller/autoscaler/reserved_pool.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/reserved_pool.py
@@ -1,0 +1,193 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reserved-pool chip accounting.
+
+On a fungible reservation, the per-size scale groups sharing a ``quota_pool`` draw
+from one physical pool of interchangeable TPU chips. This module builds, once per
+control tick, the single chip ledger both the scheduler's cross-variant preemption
+pass and the autoscaler's launch planner read.
+
+The ledger buckets every pool's chips into live (READY), in-flight
+(REQUESTING/BOOTING/INITIALIZING), and draining (DRAINING) slices. The launch
+planner asks how many chips are free *now* to bound new launches; the preemption
+pass asks whether a pool's deficit is already being addressed — by chips that are
+free or about to be freed by a drain, or by a replacement slice of the preemptor's
+own variant already booting — so it does not re-preempt across the drain-and-
+reprovision window. It changes no scaling decision on its own.
+"""
+
+import logging
+from collections.abc import Iterable
+from dataclasses import dataclass
+
+from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup, SliceLifecycleState
+from iris.cluster.tpu_topology import get_tpu_topology
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class PoolLedger:
+    """Chip accounting for one fungible reservation pool, one tick."""
+
+    pool_id: str
+    reservation_chips: int
+    live_chips: int  # READY slices
+    inflight_chips: int  # REQUESTING/BOOTING/INITIALIZING (+ pending_scale_ups), NOT draining
+    draining_chips: int  # DRAINING slices (still physically allocated until reaped)
+    inflight_slices_by_variant: dict[str, int]  # variant -> count of in-flight (non-draining) slices
+
+    @property
+    def allocated_chips(self) -> int:
+        """Chips currently held by any slice (live + in-flight + draining)."""
+        return self.live_chips + self.inflight_chips + self.draining_chips
+
+    @property
+    def free_chips(self) -> int:
+        """Chips free against the reservation budget right now (excludes draining)."""
+        return self.reservation_chips - self.allocated_chips
+
+    @property
+    def incoming_chips(self) -> int:
+        """Chips free now or being freed by an in-flight drain (free + draining)."""
+        return self.free_chips + self.draining_chips
+
+    @property
+    def utilization(self) -> float:
+        """Fraction of the reservation consumed (0.0 when the budget is zero)."""
+        if self.reservation_chips <= 0:
+            return 0.0
+        return self.allocated_chips / self.reservation_chips
+
+
+@dataclass(frozen=True)
+class ReservationLedger:
+    """Single per-tick chip ledger over all fungible reservation pools.
+
+    The one capacity view both the scheduler's cross-variant preemption pass and
+    the autoscaler's launch planner read. The pass asks ``incoming_chips`` /
+    ``inflight_slices`` ("is the deficit already being addressed?"); the planner
+    asks ``free_chips`` ("how many new slices may I launch now?").
+    """
+
+    pools: dict[str, PoolLedger]
+    worker_pool: dict[str, str]  # worker_id -> pool_id of the pool that worker's slice draws from
+    worker_slice: dict[str, str]  # worker_id -> slice_id of the physical slice the worker belongs to
+    variant_pool: dict[str, str]  # device_variant -> pool_id the variant's slices draw from
+    chips_per_variant: dict[str, int]  # device_variant -> physical chips one slice of that variant consumes
+
+    def is_empty(self) -> bool:
+        """True when no fungible reservation pool participates."""
+        return not self.variant_pool
+
+    def free_chips(self, pool_id: str) -> int:
+        """Chips free against the reservation budget now (0 if the pool is absent)."""
+        pool = self.pools.get(pool_id)
+        return pool.free_chips if pool is not None else 0
+
+    def incoming_chips(self, pool_id: str) -> int:
+        """Chips free now or being freed by a drain (0 if the pool is absent)."""
+        pool = self.pools.get(pool_id)
+        return pool.incoming_chips if pool is not None else 0
+
+    def draining_chips(self, pool_id: str) -> int:
+        """Chips currently draining in this pool (0 if the pool is absent)."""
+        pool = self.pools.get(pool_id)
+        return pool.draining_chips if pool is not None else 0
+
+    def inflight_slices(self, pool_id: str, variant: str) -> int:
+        """In-flight (non-draining) slice count of ``variant`` in ``pool_id`` (0 if absent)."""
+        pool = self.pools.get(pool_id)
+        if pool is None:
+            return 0
+        return pool.inflight_slices_by_variant.get(variant, 0)
+
+
+_INFLIGHT_LIFECYCLES = (
+    SliceLifecycleState.REQUESTING,
+    SliceLifecycleState.BOOTING,
+    SliceLifecycleState.INITIALIZING,
+)
+
+
+def build_reservation_ledger(groups: Iterable[ScalingGroup]) -> ReservationLedger:
+    """Build the per-tick chip ledger from live scaling-group state.
+
+    Only groups with ``reservation_chips > 0`` participate; they are bucketed by
+    ``quota_pool``. Each slice consumes ``chip_count(variant)`` physical chips, so a
+    v4-16 (8 chips) and two v4-8s (4 chips each) count equally against the pool.
+    Every member of a pool carries the same budget; a mismatch (or a member with no
+    ``quota_pool``) is a config error and raises.
+    """
+    budgets: dict[str, int] = {}
+    live: dict[str, int] = {}
+    inflight: dict[str, int] = {}
+    draining: dict[str, int] = {}
+    inflight_slices_by_variant: dict[str, dict[str, int]] = {}
+    variant_pool: dict[str, str] = {}
+    chips_per_variant: dict[str, int] = {}
+    worker_pool: dict[str, str] = {}
+    worker_slice: dict[str, str] = {}
+
+    for group in groups:
+        budget = group.reservation_chips
+        if budget <= 0:
+            continue
+        pool_id = group.config.quota_pool
+        if not pool_id:
+            raise ValueError(f"scale group {group.name!r} sets reservation_chips but no quota_pool")
+        prior = budgets.setdefault(pool_id, budget)
+        if prior != budget:
+            raise ValueError(f"reservation pool {pool_id!r} has conflicting reservation_chips: {prior} vs {budget}")
+
+        variant = group.accelerator_variant
+        chips = get_tpu_topology(variant).chip_count
+        variant_pool[variant] = pool_id
+        chips_per_variant[variant] = chips
+
+        counts = group.slice_state_counts()
+        inflight_count = sum(counts[state] for state in _INFLIGHT_LIFECYCLES)
+        live[pool_id] = live.get(pool_id, 0) + counts[SliceLifecycleState.READY] * chips
+        inflight[pool_id] = inflight.get(pool_id, 0) + inflight_count * chips
+        draining[pool_id] = draining.get(pool_id, 0) + counts[SliceLifecycleState.DRAINING] * chips
+        if inflight_count:
+            inflight_slices_by_variant.setdefault(pool_id, {})[variant] = inflight_count
+
+        for worker_id in group.all_worker_ids():
+            worker_pool[worker_id] = pool_id
+        worker_slice.update(group.worker_slice_ids())
+
+    pools = {
+        pool_id: PoolLedger(
+            pool_id=pool_id,
+            reservation_chips=budget,
+            live_chips=live.get(pool_id, 0),
+            inflight_chips=inflight.get(pool_id, 0),
+            draining_chips=draining.get(pool_id, 0),
+            inflight_slices_by_variant=inflight_slices_by_variant.get(pool_id, {}),
+        )
+        for pool_id, budget in budgets.items()
+    }
+    return ReservationLedger(
+        pools=pools,
+        worker_pool=worker_pool,
+        worker_slice=worker_slice,
+        variant_pool=variant_pool,
+        chips_per_variant=chips_per_variant,
+    )
+
+
+def log_reservation_ledger(ledger: ReservationLedger) -> None:
+    """Emit one utilization line per fungible reservation pool."""
+    for pool in ledger.pools.values():
+        logger.info(
+            "reserved pool %s: res=%d live=%d inflight=%d draining=%d free=%d (%.0f%% utilized)",
+            pool.pool_id,
+            pool.reservation_chips,
+            pool.live_chips,
+            pool.inflight_chips,
+            pool.draining_chips,
+            pool.free_chips,
+            pool.utilization * 100,
+        )

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -45,7 +45,7 @@ from iris.cluster.controller.autoscaler.models import (
     ScalingDecision,
 )
 from iris.cluster.controller.autoscaler.operations import (
-    terminate_slices_for_workers as terminate_slices_for_workers_operation,
+    drain_slices_for_workers as drain_slices_for_workers_operation,
 )
 from iris.cluster.controller.autoscaler.planning import build_scale_plan
 from iris.cluster.controller.autoscaler.provisioning import (
@@ -58,6 +58,11 @@ from iris.cluster.controller.autoscaler.recovery import (
     load_autoscaler_checkpoint,
     restore_autoscaler_state,
 )
+from iris.cluster.controller.autoscaler.reserved_pool import (
+    ReservationLedger,
+    build_reservation_ledger,
+    log_reservation_ledger,
+)
 from iris.cluster.controller.autoscaler.routing import (
     availability_probe_entries,
     empirical_zone_capabilities,
@@ -66,6 +71,7 @@ from iris.cluster.controller.autoscaler.routing import (
 )
 from iris.cluster.controller.autoscaler.scaling_group import (
     ScalingGroup,
+    SliceLifecycleState,
     build_worker_config_for_group,
 )
 from iris.cluster.controller.autoscaler.state import AutoscalerState, GroupPersist, SlicePersist
@@ -414,6 +420,9 @@ class Autoscaler:
 
         routing_decision = route_demand(list(self._groups.values()), demand_entries, ts, zone_capabilities=caps)
         scale_plan = build_scale_plan(self._groups, routing_decision, ts)
+
+        # Log fungible-reservation chip utilization for operability.
+        log_reservation_ledger(build_reservation_ledger(self._groups.values()))
         # Build cached views eagerly here so dashboard/service RPCs never pay
         # the conversion cost on the hot path (#4844).
         self._last_routing_decision_proto = routing_decision_to_proto(
@@ -654,6 +663,9 @@ class Autoscaler:
         for (group, slice_id, handle), status in zip(targets, statuses, strict=True):
             if status is None:
                 continue
+            if group.slice_lifecycle(slice_id) == SliceLifecycleState.DRAINING:
+                self._fold_draining_slice(group, slice_id, status, timestamp)
+                continue
             if status.state == CloudSliceState.READY:
                 worker_ids = [w.worker_id for w in status.workers]
                 worker_urls = self._worker_urls(status.workers)
@@ -670,8 +682,10 @@ class Autoscaler:
                     worker_count=len(worker_ids),
                 )
             elif status.state == CloudSliceState.FAILED:
+                # The cloud already reports the allocation gone, so this is the
+                # cleanup step: detach directly (no terminate to issue).
                 group.mark_slice_failed(slice_id, error_message=status.error_message)
-                group.scale_down(slice_id)
+                group.detach_slice(slice_id)
                 self._unregister_slice_workers(slice_id)
                 group.record_slice_boot_failed(slice_id, timestamp)
                 reason = status.error_message if status.error_message else "bootstrap failed"
@@ -691,8 +705,12 @@ class Autoscaler:
                 # still has running tasks.
                 unknown_for = group.note_slice_unknown(slice_id, timestamp)
                 if unknown_for >= self._unresolvable_timeout:
+                    # Given up on an undescribable slice: detach and best-effort
+                    # terminate, since its VMs may still be live.
                     group.mark_slice_failed(slice_id, error_message="unresolvable after timeout")
-                    group.scale_down(slice_id)
+                    handle = group.detach_slice(slice_id)
+                    if handle is not None:
+                        group.terminate_slice_handle(handle, context="unresolvable after timeout")
                     self._unregister_slice_workers(slice_id)
                     group.record_slice_boot_failed(slice_id, timestamp)
                     self._log_action(
@@ -724,6 +742,49 @@ class Autoscaler:
                     slice_id=handle.slice_id,
                     reason=f"idle slice (target={target_capacity}, ready={ready_before})",
                 )
+
+    def _fold_draining_slice(
+        self,
+        group: ScalingGroup,
+        slice_id: str,
+        status: SliceStatus,
+        timestamp: Timestamp,
+    ) -> None:
+        """Fold one describe of a DRAINING slice: reap it once its VMs are gone.
+
+        A DRAINING slice has already had its VMs terminated; this only watches for
+        the deletion to land. When the cloud reports it FAILED or with zero workers
+        (allocation gone), the slice is cleanly removed — without a FAILED outcome
+        and without feeding the churn detector, since the teardown is deliberate. A
+        slice still stuck DRAINING past the reap timeout is force-detached and
+        re-terminated. While its VMs are still deleting the slice stays DRAINING and
+        counted against the reservation pool.
+        """
+        gone = status.state == CloudSliceState.FAILED or not status.workers
+        if gone:
+            group.detach_slice(slice_id)
+            self._unregister_slice_workers(slice_id)
+            self._log_action(
+                "slice_drain_complete",
+                group.name,
+                slice_id,
+                reason="drain reaped (cloud allocation gone)",
+            )
+            return
+
+        draining_for = group.draining_for(slice_id, timestamp)
+        if draining_for >= self._unresolvable_timeout:
+            logger.warning("Slice %s stuck DRAINING for %s; forcing teardown", slice_id, draining_for)
+            self._unregister_slice_workers(slice_id)
+            self._log_action(
+                "slice_drain_complete",
+                group.name,
+                slice_id,
+                reason=f"drain timed out after {draining_for}; forcing teardown",
+            )
+            detached = group.detach_slice(slice_id)
+            if detached is not None:
+                group.terminate_slice_handle(detached, context="draining timed out")
 
     def probe_health(self, timestamp: Timestamp | None = None) -> None:
         """Probe each READY slice's worker /health endpoint and terminate dead slices.
@@ -790,12 +851,13 @@ class Autoscaler:
                     logger.warning("Slice %s: %s; terminating", slice_id, reason)
                     tripped[slice_id] = (group, reason)
 
-        # Phase 4: terminate tripped slices. These booted cleanly and only died
-        # at runtime, so record PREEMPTED (excluded from the create success rate),
-        # not a boot failure — the BackoffDetector's scale-up budget shouldn't decay.
+        # Phase 4: drain tripped slices. These booted cleanly and only died at
+        # runtime, so record PREEMPTED (excluded from the create success rate), not a
+        # boot failure — the BackoffDetector's scale-up budget shouldn't decay. The
+        # VM is a live zombie, so it drains (mark DRAINING, terminate, reap on
+        # confirm) rather than detaching before its deletion lands.
         for slice_id, (group, reason) in tripped.items():
-            group.mark_slice_failed(slice_id, error_message=reason)
-            group.scale_down(slice_id, timestamp)
+            handle = group.drain_slice(slice_id, timestamp)
             self._unregister_slice_workers(slice_id)
             self._log_action(
                 "slice_failed",
@@ -806,6 +868,8 @@ class Autoscaler:
                 group=group,
                 outcome=ProvisioningOutcome.PREEMPTED,
             )
+            if handle is not None:
+                group.terminate_slice_handle(handle, context="health probe failed")
 
     def _worker_urls(self, workers: Sequence[RemoteWorkerHandle]) -> dict[str, str]:
         """Map worker_id to the worker's reachable ``http://host:port`` URL.
@@ -971,18 +1035,21 @@ class Autoscaler:
         """All scale groups."""
         return self._groups
 
-    def terminate_slices_for_workers(self, worker_ids: Sequence[str]) -> list[str]:
-        """Terminate the unique slices containing the given workers.
+    def drain_slices_for_workers(self, worker_ids: Sequence[str]) -> list[str]:
+        """Drain the unique slices holding the given workers and start their deletion.
 
-        Returns sibling worker IDs that should be failed immediately because
-        their slices are being torn down. The operation detaches the slices from
-        tracking serially (the state mutation), then issues the deletes in a
-        bounded parallel fan-out: each ``terminate_slice_handle`` is a bounded
-        cloud request that catches and logs its own errors and touches no shared
-        state, so the fan-out stays within the phase budget under a mass
-        preemption without racing.
+        Each affected slice is marked DRAINING (kept tracked, still counted against
+        its reservation pool) and its VMs are terminated now; ``refresh`` reaps it
+        once the cloud confirms it is gone. The slices are mutated serially, then the
+        deletes issue in a bounded parallel fan-out — each ``terminate_slice_handle``
+        is a self-contained cloud request that logs its own errors and touches no
+        shared state, so a mass teardown stays within the phase budget without
+        racing.
+
+        Returns the drained slices' sibling worker ids for the caller to fail
+        immediately.
         """
-        result = terminate_slices_for_workers_operation(
+        result = drain_slices_for_workers_operation(
             groups=self._groups,
             worker_ids=worker_ids,
             unregister_slice_workers=self._unregister_slice_workers,
@@ -1001,6 +1068,10 @@ class Autoscaler:
             result.termination_requests,
             lambda req: req.group.terminate_slice_handle(req.handle, context="cleaning up anyway"),
             max_workers=_CLOUD_OP_MAX_WORKERS,
-            thread_name_prefix="slice-terminate",
+            thread_name_prefix="slice-drain",
         )
         return result.sibling_worker_ids
+
+    def reservation_ledger(self) -> ReservationLedger:
+        """Build the per-tick reservation chip ledger from live group state."""
+        return build_reservation_ledger(self._groups.values())

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -59,8 +59,8 @@ class SliceLifecycleState(StrEnum):
     - BOOTING: At least one VM is booting (VM_STATE_BOOTING)
     - INITIALIZING: At least one VM is initializing (VM_STATE_INITIALIZING)
     - READY: All VMs are ready (VM_STATE_READY)
-    - DRAINING: Cross-variant preemption is tearing the slice down; its VMs are
-      being deleted but still count against the reservation pool until reaped.
+    - DRAINING: The slice is being torn down; its VMs are being deleted but it
+      still counts against its reservation pool (if any) until reaped.
     - FAILED: At least one VM has failed (VM_STATE_FAILED or VM_STATE_PREEMPTED)
 
     Note: These are slice-level aggregate states, not direct VM states.
@@ -152,10 +152,10 @@ class SliceState:
     # Memory-only.
     unknown_since: Timestamp | None = None
     error_message: str = ""
-    # Timestamp at which the slice was marked DRAINING for cross-variant
-    # preemption. The reap-timeout fallback is measured from here; None (e.g. a
-    # DRAINING slice restored from a checkpoint) makes refresh measure from the
-    # first describe instead. Memory-only.
+    # Timestamp at which the slice was marked DRAINING. The reap-timeout
+    # fallback is measured from here; None (e.g. a DRAINING slice restored from
+    # a checkpoint) makes refresh measure from the first describe instead.
+    # Memory-only.
     drain_started: Timestamp | None = None
 
 
@@ -951,7 +951,7 @@ class ScalingGroup:
         eligible: list[tuple[SliceState, int]] = []
         for slice_id, state in snapshot:
             # Only READY slices are reclaimable as idle capacity — this also excludes
-            # a DRAINING slice, which is already being torn down for preemption.
+            # a DRAINING slice, which is already being torn down.
             if state.lifecycle != SliceLifecycleState.READY:
                 continue
             if not self.is_slice_eligible_for_scaledown(slice_id, timestamp):

--- a/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/scaling_group.py
@@ -59,6 +59,8 @@ class SliceLifecycleState(StrEnum):
     - BOOTING: At least one VM is booting (VM_STATE_BOOTING)
     - INITIALIZING: At least one VM is initializing (VM_STATE_INITIALIZING)
     - READY: All VMs are ready (VM_STATE_READY)
+    - DRAINING: Cross-variant preemption is tearing the slice down; its VMs are
+      being deleted but still count against the reservation pool until reaped.
     - FAILED: At least one VM has failed (VM_STATE_FAILED or VM_STATE_PREEMPTED)
 
     Note: These are slice-level aggregate states, not direct VM states.
@@ -68,6 +70,7 @@ class SliceLifecycleState(StrEnum):
     BOOTING = "booting"
     INITIALIZING = "initializing"
     READY = "ready"
+    DRAINING = "draining"
     FAILED = "failed"
 
 
@@ -149,6 +152,11 @@ class SliceState:
     # Memory-only.
     unknown_since: Timestamp | None = None
     error_message: str = ""
+    # Timestamp at which the slice was marked DRAINING for cross-variant
+    # preemption. The reap-timeout fallback is measured from here; None (e.g. a
+    # DRAINING slice restored from a checkpoint) makes refresh measure from the
+    # first describe instead. Memory-only.
+    drain_started: Timestamp | None = None
 
 
 def prepare_slice_config(
@@ -264,6 +272,7 @@ def _lifecycle_to_vm_state(lifecycle: SliceLifecycleState) -> vm_pb2.VmState:
         SliceLifecycleState.BOOTING: vm_pb2.VM_STATE_BOOTING,
         SliceLifecycleState.INITIALIZING: vm_pb2.VM_STATE_INITIALIZING,
         SliceLifecycleState.READY: vm_pb2.VM_STATE_READY,
+        SliceLifecycleState.DRAINING: vm_pb2.VM_STATE_STOPPING,
         SliceLifecycleState.FAILED: vm_pb2.VM_STATE_FAILED,
     }[lifecycle]
 
@@ -430,6 +439,16 @@ class ScalingGroup:
         return self._config.max_slices
 
     @property
+    def reservation_chips(self) -> int:
+        """Fungible-reservation chip budget shared across this group's quota_pool.
+
+        >0 marks the group as a member of a reserved pool whose chips are
+        interchangeable across slice sizes; 0 means not part of a fungible
+        reservation.
+        """
+        return self._config.reservation_chips
+
+    @property
     def region(self) -> str | None:
         """Region derived from the slice template."""
         template = self._config.slice_template
@@ -587,6 +606,31 @@ class ScalingGroup:
                 error_message,
             )
 
+    def drain_slice(self, slice_id: str, timestamp: Timestamp | None = None) -> SliceHandle | None:
+        """Begin tearing down a live slice: mark it DRAINING and return its handle.
+
+        The slice stays tracked (still counted against its reservation pool) so the
+        ledger reports its chips as ``draining`` until the cloud VMs are observed
+        gone and it is reaped. The caller terminates the returned handle to start
+        the deletion. Returns None if the slice is not tracked.
+        """
+        timestamp = timestamp or Timestamp.now()
+        with self._slices_lock:
+            state = self._slices.get(slice_id)
+            if state is None:
+                return None
+            state.lifecycle = SliceLifecycleState.DRAINING
+            state.drain_started = timestamp
+            state.quiet_since = None
+            handle = state.handle
+        logger.info(
+            "slice draining group=%s slice=%s workers=%s",
+            self._config.name,
+            slice_id,
+            state.worker_ids,
+        )
+        return handle
+
     def note_slice_unknown(self, slice_id: str, timestamp: Timestamp) -> Duration:
         """Record an UNKNOWN describe and return how long the slice has been continuously UNKNOWN.
 
@@ -663,24 +707,13 @@ class ScalingGroup:
 
         return self._platform.create_slice(slice_config, worker_config=worker_config)
 
-    def scale_down(self, slice_id: str, timestamp: Timestamp | None = None) -> None:
-        """Terminate a slice.
-
-        Always removes the slice from in-memory tracking and the DB, even if
-        the cloud terminate call fails (e.g. resource already deleted by
-        preemption). This prevents ghost slices that the autoscaler counts as
-        live capacity but that no longer exist.
-
-        Args:
-            slice_id: ID of the slice to terminate
-            timestamp: Optional timestamp (for testing)
-        """
-        handle = self.detach_slice(slice_id, timestamp=timestamp)
-        if handle is not None:
-            self.terminate_slice_handle(handle, context="cleaning up anyway")
-
     def detach_slice(self, slice_id: str, timestamp: Timestamp | None = None) -> SliceHandle | None:
-        """Remove a slice from tracking and persistence without terminating it."""
+        """Remove a slice from tracking and persistence without terminating it.
+
+        The cleanup step of a teardown, used once a slice's VMs are gone (or for one
+        the cloud already reports dead). Returns the handle so a caller that is
+        giving up can still issue a terminate.
+        """
         timestamp = timestamp or Timestamp.now()
         with self._slices_lock:
             state = self._slices.pop(slice_id, None)
@@ -720,9 +753,10 @@ class ScalingGroup:
     def slices_needing_describe(self) -> list[tuple[str, SliceHandle]]:
         """Snapshot slice handles the caller must ``describe()`` this tick.
 
-        Returns not-yet-ready slices (BOOTING/INITIALIZING), plus READY slices
-        the autoscaler tracks no workers for. A READY slice with empty
-        ``worker_ids`` never resolved its membership (e.g. adopted from a
+        Returns not-yet-ready slices (BOOTING/INITIALIZING), DRAINING slices (so
+        ``refresh`` polls them and reaps the slice once its VMs are gone), plus
+        READY slices the autoscaler tracks no workers for. A READY slice with
+        empty ``worker_ids`` never resolved its membership (e.g. adopted from a
         checkpoint that recorded none); re-describing lets ``refresh`` repopulate
         or reap it instead of leaving it stuck DEGRADED.
         """
@@ -730,7 +764,12 @@ class ScalingGroup:
             return [
                 (slice_id, state.handle)
                 for slice_id, state in self._slices.items()
-                if state.lifecycle in (SliceLifecycleState.BOOTING, SliceLifecycleState.INITIALIZING)
+                if state.lifecycle
+                in (
+                    SliceLifecycleState.BOOTING,
+                    SliceLifecycleState.INITIALIZING,
+                    SliceLifecycleState.DRAINING,
+                )
                 or (state.lifecycle == SliceLifecycleState.READY and not state.worker_ids)
             ]
 
@@ -810,6 +849,29 @@ class ScalingGroup:
                 return None
             return state.handle
 
+    def slice_lifecycle(self, slice_id: str) -> SliceLifecycleState | None:
+        """Lifecycle of a tracked slice, or None if untracked."""
+        with self._slices_lock:
+            state = self._slices.get(slice_id)
+            return state.lifecycle if state is not None else None
+
+    def draining_for(self, slice_id: str, timestamp: Timestamp) -> Duration:
+        """How long a slice has been DRAINING, measured from ``drain_started``.
+
+        When ``drain_started`` is unset (e.g. a DRAINING slice restored from a
+        checkpoint), it is stamped to ``timestamp`` on this first observation so the
+        reap-timeout is measured from first-seen rather than from an unknown drain
+        start. Returns a zero duration for an untracked slice.
+        """
+        with self._slices_lock:
+            state = self._slices.get(slice_id)
+            if state is None:
+                return Duration.from_ms(0)
+            if state.drain_started is None:
+                state.drain_started = timestamp
+                return Duration.from_ms(0)
+            return Duration.from_ms(timestamp.epoch_ms() - state.drain_started.epoch_ms())
+
     def update_demand(self, demand: int) -> None:
         """Update current demand."""
         self._current_demand = demand
@@ -888,6 +950,8 @@ class ScalingGroup:
             snapshot = list(self._slices.items())
         eligible: list[tuple[SliceState, int]] = []
         for slice_id, state in snapshot:
+            # Only READY slices are reclaimable as idle capacity — this also excludes
+            # a DRAINING slice, which is already being torn down for preemption.
             if state.lifecycle != SliceLifecycleState.READY:
                 continue
             if not self.is_slice_eligible_for_scaledown(slice_id, timestamp):
@@ -967,7 +1031,9 @@ class ScalingGroup:
                 pending,
                 target_capacity,
             )
-            self.scale_down(slice_state.handle.slice_id, timestamp)
+            handle = self.drain_slice(slice_state.handle.slice_id, timestamp)
+            if handle is not None:
+                self.terminate_slice_handle(handle, context="draining idle slice")
             terminated.append(slice_state.handle)
 
         return terminated
@@ -1180,6 +1246,16 @@ class ScalingGroup:
         if state is None:
             return []
         return list(state.worker_ids)
+
+    def all_worker_ids(self) -> list[str]:
+        """Worker IDs across all tracked slices (any lifecycle)."""
+        with self._slices_lock:
+            return [wid for state in self._slices.values() for wid in state.worker_ids]
+
+    def worker_slice_ids(self) -> dict[str, str]:
+        """Map each tracked worker id to its slice id (any lifecycle)."""
+        with self._slices_lock:
+            return {wid: slice_id for slice_id, state in self._slices.items() for wid in state.worker_ids}
 
     def terminate_all(self) -> None:
         """Terminate all slices in this scale group.

--- a/lib/iris/src/iris/cluster/controller/backend.py
+++ b/lib/iris/src/iris/cluster/controller/backend.py
@@ -29,12 +29,12 @@ has no Iris workers, so its ``run_teardown`` is a no-op.
 import logging
 import threading
 from collections.abc import Callable, Mapping
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from typing import ClassVar, Protocol
 
 from iris.cluster.controller.autoscaler import Autoscaler
-from iris.cluster.controller.autoscaler.models import DemandEntry
+from iris.cluster.controller.autoscaler.models import UNRANKED_DEMAND_BAND, DemandEntry
 from iris.cluster.controller.autoscaler.state import AutoscalerState
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.ops.task import Assignment
@@ -383,6 +383,12 @@ def run_scheduling_decision(
     preemptions = apply_preemptions(order, placed_jobs, all_assignments, ctx.running_for_preemption, context)
     diagnostics = compute_diagnostics(scheduler, context, placed_jobs, all_assignments, order.ordered_task_ids)
 
+    # Stamp each demand entry with its tasks' effective band so the autoscaler's
+    # reservation-aware launch cap admits a fungible pool's new slices in priority
+    # order: the higher-priority job's larger slice claims the shared chip budget
+    # before a lower-priority job's.
+    banded_residual = _stamp_demand_bands(residual_demand, order.task_band_map)
+
     return ScheduleResult(
         assignments=[
             Assignment(task_id=task_id, worker_id=worker_id, priority_band=order.task_band_map.get(task_id))
@@ -399,8 +405,28 @@ def run_scheduling_decision(
         unschedulable=list(gated.expired_tasks),
         diagnostics=diagnostics,
         scheduling_context=context,
-        residual_demand=residual_demand,
+        residual_demand=banded_residual,
     )
+
+
+def _stamp_demand_bands(
+    residual_demand: list[DemandEntry],
+    task_band_map: Mapping[JobName, int],
+) -> list[DemandEntry]:
+    """Stamp each demand entry with its tasks' effective band for the autoscaler.
+
+    Band is the min (highest-priority) resolved band over the entry's tasks; an
+    entry whose tasks carry no resolved band trails ranked demand. The autoscaler's
+    reservation-aware launch cap admits a fungible pool's new slices in band order,
+    so it needs each entry's priority alongside its shape and constraints.
+    """
+    if not residual_demand:
+        return residual_demand
+    stamped: list[DemandEntry] = []
+    for entry in residual_demand:
+        bands = [band for tid in entry.task_ids if (band := task_band_map.get(JobName.from_wire(tid))) is not None]
+        stamped.append(replace(entry, band=min(bands) if bands else UNRANKED_DEMAND_BAND))
+    return stamped
 
 
 def apply_placements(

--- a/lib/iris/tests/cluster/backends/test_config.py
+++ b/lib/iris/tests/cluster/backends/test_config.py
@@ -1902,6 +1902,146 @@ def test_smoke_gcp_config_boots_locally():
         client.close()
 
 
+class TestFungibleReservation:
+    """Tests for the optional fungible-reservation chip budget on tpu_pools."""
+
+    _BASE = """\
+platform:
+  gcp:
+    project_id: test
+
+defaults:
+  worker:
+    docker_image: ghcr.io/test/iris-worker:latest
+
+tpu_pools:
+  {pool_yaml}
+"""
+
+    _DEFAULT_SIZES = """\
+      8:  { max_slices: 256 }
+      16: { max_slices: 128 }"""
+
+    def _reserved_pool(self, *, fungible: str, chips: str, capacity: str = "reserved", sizes: str | None = None) -> str:
+        sizes = self._DEFAULT_SIZES if sizes is None else sizes
+        return f"""\
+v4-res:
+    family: v4
+    zones: [us-central2-b]
+    base_priority: 1000
+    resources: {{ cpu: 240, ram: 400GB, disk: 100GB, capacity_type: {capacity} }}
+    slice_template:
+      gcp:
+        service_account: test@test.iam.gserviceaccount.com
+        runtime_version: tpu-ubuntu2204-base
+{fungible}{chips}    sizes:
+{sizes}"""
+
+    def test_expands_reservation_chips_onto_every_member(self, tmp_path: Path):
+        pool_yaml = self._reserved_pool(
+            fungible="    fungible_reservation: true\n", chips="    reservation_chips: 1024\n"
+        )
+        p = tmp_path / "config.yaml"
+        p.write_text(self._BASE.format(pool_yaml=pool_yaml))
+        config = load_config(p)
+
+        members = {n: g for n, g in config.scale_groups.items() if n.startswith("tpu_v4-res_")}
+        assert len(members) == 2
+        for g in members.values():
+            assert g.reservation_chips == 1024
+            assert g.quota_pool == "v4-res/us-central2-b"
+
+    def test_absent_reservation_leaves_chips_zero(self, tmp_path: Path):
+        # A pool without fungible_reservation must not set reservation_chips.
+        pool_yaml = self._reserved_pool(fungible="", chips="")
+        p = tmp_path / "config.yaml"
+        p.write_text(self._BASE.format(pool_yaml=pool_yaml))
+        config = load_config(p)
+        for n, g in config.scale_groups.items():
+            if n.startswith("tpu_v4-res_"):
+                assert g.reservation_chips == 0
+
+    def test_max_slices_defaults_to_reservation_ceiling_when_omitted(self, tmp_path: Path):
+        # v4-8 is 4 chips/slice, v4-16 is 8: 1024 // 4 = 256, 1024 // 8 = 128.
+        pool_yaml = self._reserved_pool(
+            fungible="    fungible_reservation: true\n",
+            chips="    reservation_chips: 1024\n",
+            sizes="      8: {}\n      16: {}",
+        )
+        p = tmp_path / "config.yaml"
+        p.write_text(self._BASE.format(pool_yaml=pool_yaml))
+        config = load_config(p)
+
+        assert config.scale_groups["tpu_v4-res_8-us-central2-b"].max_slices == 256
+        assert config.scale_groups["tpu_v4-res_16-us-central2-b"].max_slices == 128
+
+    def test_max_slices_override_within_ceiling_is_honored(self, tmp_path: Path):
+        pool_yaml = self._reserved_pool(
+            fungible="    fungible_reservation: true\n",
+            chips="    reservation_chips: 1024\n",
+            sizes="      8: { max_slices: 10 }\n      16: {}",
+        )
+        p = tmp_path / "config.yaml"
+        p.write_text(self._BASE.format(pool_yaml=pool_yaml))
+        config = load_config(p)
+
+        assert config.scale_groups["tpu_v4-res_8-us-central2-b"].max_slices == 10
+        assert config.scale_groups["tpu_v4-res_16-us-central2-b"].max_slices == 128
+
+    def test_max_slices_override_exceeding_ceiling_rejected(self, tmp_path: Path):
+        pool_yaml = self._reserved_pool(
+            fungible="    fungible_reservation: true\n",
+            chips="    reservation_chips: 1024\n",
+            sizes="      8: { max_slices: 300 }\n      16: {}",
+        )
+        p = tmp_path / "config.yaml"
+        p.write_text(self._BASE.format(pool_yaml=pool_yaml))
+        with pytest.raises(ValueError, match="exceeds"):
+            load_config(p)
+
+    def test_max_slices_required_when_not_fungible(self, tmp_path: Path):
+        pool_yaml = self._reserved_pool(fungible="", chips="", sizes="      8: {}\n      16: {}")
+        p = tmp_path / "config.yaml"
+        p.write_text(self._BASE.format(pool_yaml=pool_yaml))
+        with pytest.raises(ValueError, match="'max_slices' is required"):
+            load_config(p)
+
+    _FUNGIBLE = "    fungible_reservation: true\n"
+
+    @pytest.mark.parametrize(
+        "fungible, chips, capacity, match",
+        [
+            pytest.param(
+                "", "    reservation_chips: 1024\n", "reserved", "reservation_chips set without", id="chips-without-flag"
+            ),
+            pytest.param(
+                _FUNGIBLE, "    reservation_chips: 1024\n", "preemptible", "capacity_type=reserved", id="on-preemptible"
+            ),
+            # Largest slice is v4-16 = 8 chips, so a 4-chip budget can never place it.
+            pytest.param(
+                _FUNGIBLE,
+                "    reservation_chips: 4\n",
+                "reserved",
+                "smaller than the largest slice",
+                id="budget-too-small",
+            ),
+            pytest.param(
+                _FUNGIBLE,
+                "    reservation_chips: 0\n",
+                "reserved",
+                "positive integer reservation_chips",
+                id="nonpositive-chips",
+            ),
+        ],
+    )
+    def test_invalid_reservation_rejected(self, tmp_path: Path, fungible: str, chips: str, capacity: str, match: str):
+        pool_yaml = self._reserved_pool(fungible=fungible, chips=chips, capacity=capacity)
+        p = tmp_path / "config.yaml"
+        p.write_text(self._BASE.format(pool_yaml=pool_yaml))
+        with pytest.raises(ValueError, match=match):
+            load_config(p)
+
+
 def _worker_daemon_backend(**overrides) -> BackendConfig:
     """A minimal valid worker_daemon backend (worker_provider present, in_process)."""
     fields = {"kind": "worker_daemon", "worker_provider": WorkerProviderConfig()}

--- a/lib/iris/tests/cluster/backends/test_scaling_group.py
+++ b/lib/iris/tests/cluster/backends/test_scaling_group.py
@@ -191,8 +191,12 @@ class TestScalingGroupVmGroupOwnership:
         assert slice_config.labels["env"] == "prod"
         assert slice_config.labels["team"] == "ml"
 
-    def test_scale_down_terminates_and_removes_vm_group(self, scale_group_config: ScaleGroupConfig):
-        """scale_down() terminates the VM group and removes it from tracking."""
+    def test_drain_slice_marks_draining_and_returns_handle(self, scale_group_config: ScaleGroupConfig):
+        """drain_slice() marks the slice DRAINING (still tracked) and returns its handle.
+
+        The handle comes back so the caller issues the terminate; the slice is
+        removed only later, by the reap, once the cloud confirms its VMs are gone.
+        """
         handle = make_fake_slice_handle("slice-001")
         platform = make_mock_platform(slices_to_discover=[handle])
         group = ScalingGroup(scale_group_config, platform)
@@ -200,27 +204,26 @@ class TestScalingGroupVmGroupOwnership:
 
         assert group.slice_count() == 1
 
-        group.scale_down("slice-001")
+        returned = group.drain_slice("slice-001")
 
-        assert handle.terminated
-        assert group.slice_count() == 0
-        assert group.get_slice("slice-001") is None
+        assert returned is handle
+        assert not handle.terminated  # drain_slice does not terminate; the caller does
+        assert group.slice_count() == 1
+        assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
 
-    def test_scale_down_nonexistent_vm_group_is_noop(self, scale_group_config: ScaleGroupConfig):
-        """scale_down() on a nonexistent VM group does nothing."""
+    def test_drain_slice_nonexistent_is_noop(self, scale_group_config: ScaleGroupConfig):
+        """drain_slice() on a nonexistent slice returns None and does nothing."""
         platform = make_mock_platform()
         group = ScalingGroup(scale_group_config, platform)
 
-        # Should not raise
-        group.scale_down("nonexistent-slice")
-
+        assert group.drain_slice("nonexistent-slice") is None
         assert group.slice_count() == 0
 
-    def test_scale_down_cleans_up_even_if_terminate_fails(self, scale_group_config: ScaleGroupConfig):
-        """scale_down() removes the slice from tracking even if terminate() raises.
+    def test_detach_slice_removes_and_terminate_handle_swallows_errors(self, scale_group_config: ScaleGroupConfig):
+        """detach_slice() drops tracking; terminate_slice_handle() swallows a terminate() error.
 
-        This prevents ghost slices where the cloud resource is gone (e.g.
-        preempted) but the autoscaler still counts it as live capacity.
+        Together they reap a slice whose cloud resource is already gone (e.g.
+        preempted) without leaving a ghost the autoscaler counts as live capacity.
         """
         handle = make_fake_slice_handle("slice-001")
         handle.terminate_error = RuntimeError("resource not found")
@@ -230,12 +233,15 @@ class TestScalingGroupVmGroupOwnership:
 
         assert group.slice_count() == 1
 
-        # Should NOT raise despite terminate() failure
-        group.scale_down("slice-001")
+        detached = group.detach_slice("slice-001")
 
-        assert handle.terminated
+        assert detached is handle
         assert group.slice_count() == 0
         assert group.get_slice("slice-001") is None
+
+        # Should NOT raise despite terminate() failure.
+        group.terminate_slice_handle(handle, context="test")
+        assert handle.terminated
 
     def test_terminate_all_continues_on_individual_failure(self, scale_group_config: ScaleGroupConfig):
         """terminate_all() terminates remaining slices even if one fails."""
@@ -595,7 +601,8 @@ class TestScalingGroupIdleTracking:
         )
 
         assert len(scaled_down) == 1
-        assert group.slice_count() == 1  # One slice was terminated
+        assert scaled_down[0].terminated  # the drain issued the VM delete
+        assert group.ready_slice_count() == 1  # one slice drained, one stays READY
 
     def test_scale_down_retains_degraded_idle_slice(self, unbounded_config: ScaleGroupConfig):
         """A slice whose worker is idle but DEGRADED is NOT reclaimed as spare.
@@ -668,25 +675,26 @@ class TestScalingGroupIdleTracking:
         assert len(scaled_down) == 0
         assert group.slice_count() == 1
 
-    def test_scale_down_cleans_up_idle_tracking(self, unbounded_config: ScaleGroupConfig):
-        """scale_down removes the slice from idle tracking."""
+    def test_drain_slice_removes_from_idle_candidates(self, unbounded_config: ScaleGroupConfig):
+        """A drained slice is DRAINING and no longer offered as an idle scale-down candidate."""
         discovered = [make_fake_slice_handle("slice-001", all_ready=True)]
         platform = make_mock_platform(slices_to_discover=discovered)
-        group = ScalingGroup(unbounded_config, platform)
+        group = ScalingGroup(unbounded_config, platform, idle_threshold=Duration.from_ms(0))
         group.reconcile()
+        _mark_discovered_ready(group, discovered)
 
         handle = group.get_slice("slice-001")
         worker_id = _get_worker_id(handle)
-
-        vm_status_map = {
-            worker_id: WorkerStatus(worker_id=worker_id, running_task_ids=frozenset({"task-1"})),
-        }
+        vm_status_map = {worker_id: WorkerStatus(worker_id=worker_id, running_task_ids=frozenset())}
         group.update_slice_activity(vm_status_map, Timestamp.from_ms(1000))
 
-        # Scale down
-        group.scale_down("slice-001")
+        # READY, idle, past threshold, so it is an idle candidate — until it is drained.
+        assert [s.handle.slice_id for s in group.get_idle_slices(Timestamp.from_ms(2000))] == ["slice-001"]
 
-        assert group.get_slice("slice-001") is None
+        group.drain_slice("slice-001")
+
+        assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
+        assert group.get_idle_slices(Timestamp.from_ms(2000)) == []
 
 
 def test_scale_down_no_misleading_rate_limit_log(unbounded_config: ScaleGroupConfig, caplog):
@@ -1307,7 +1315,7 @@ class TestMultiVmSliceIdleScaleDown:
         scaled_down = group.scale_down_if_idle(idle_map, target_capacity=0, timestamp=Timestamp.from_ms(10_000))
 
         assert len(scaled_down) == 1
-        assert group.slice_count() == 0
+        assert group.ready_slice_count() == 0
 
     def test_multi_vm_slice_not_idle_when_one_worker_busy(self):
         """A 4-VM slice does NOT scale down when 1 of 4 workers has a running task."""
@@ -1391,7 +1399,7 @@ class TestMultiVmSliceIdleScaleDown:
 
         assert len(scaled_down) == 1
         assert scaled_down[0].slice_id == "slice-001"
-        assert group.slice_count() == 1
+        assert group.ready_slice_count() == 1
 
     def test_multi_vm_verify_idle_requires_all_workers_known(self):
         """_verify_slice_idle returns False if some workers are not in the status map."""

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -21,6 +21,7 @@ from iris.cluster.constraints import DeviceType, WellKnownAttribute
 from iris.cluster.controller.autoscaler import DEFAULT_UNRESOLVABLE_TIMEOUT, Autoscaler
 from iris.cluster.controller.autoscaler.backoff_detector import GroupHealth
 from iris.cluster.controller.autoscaler.models import ScalingAction, ScalingDecision
+from iris.cluster.controller.autoscaler.operations import drain_slices_for_workers
 from iris.cluster.controller.autoscaler.routing import route_demand
 from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup, SliceLifecycleState
 from iris.cluster.controller.worker_health import CONSECUTIVE_FAILURE_THRESHOLD
@@ -546,6 +547,48 @@ class TestAutoscalerWorkerFailure:
 
         assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
         assert siblings == []
+
+    def test_second_call_on_already_draining_slice_does_not_reset_reap_clock_or_double_count(
+        self, scale_group_config: ScaleGroupConfig
+    ):
+        """A slice's VMs shut down one at a time, so a second dead-worker report for
+        the same (already-draining) slice arrives on a later tick. It must not
+        re-stamp the reap-timeout clock or record a second churn-detector failure."""
+
+        def make_group() -> ScalingGroup:
+            handle = make_mock_slice_handle(
+                "slice-001",
+                all_ready=True,
+                vm_states=[vm_pb2.VM_STATE_READY] * 2,
+                created_at_ms=Timestamp.now().epoch_ms(),
+            )
+            platform = make_mock_platform(slices_to_discover=[handle])
+            g = ScalingGroup(scale_group_config, platform)
+            g.reconcile()
+            _mark_discovered_ready(g, [handle])
+            return g
+
+        def drain(group: ScalingGroup, worker_id: str, timestamp: Timestamp) -> None:
+            drain_slices_for_workers(
+                {group.name: group},
+                [worker_id],
+                lambda *_: None,
+                lambda *_, **__: vm_pb2.AutoscalerAction(),
+                timestamp,
+            )
+
+        t0 = Timestamp.from_ms(1_000_000)
+        t1 = Timestamp.from_ms(1_060_000)
+
+        once_group = make_group()
+        drain(once_group, "slice-001-vm-0", t0)
+
+        twice_group = make_group()
+        drain(twice_group, "slice-001-vm-0", t0)
+        drain(twice_group, "slice-001-vm-1", t1)
+
+        assert twice_group.draining_for("slice-001", t1) == Duration.from_ms(60_000)
+        assert twice_group.health(t1) == once_group.health(t1)
 
 
 class TestAutoscalerDrainReap:

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -22,7 +22,7 @@ from iris.cluster.controller.autoscaler import DEFAULT_UNRESOLVABLE_TIMEOUT, Aut
 from iris.cluster.controller.autoscaler.backoff_detector import GroupHealth
 from iris.cluster.controller.autoscaler.models import ScalingAction, ScalingDecision
 from iris.cluster.controller.autoscaler.routing import route_demand
-from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup
+from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup, SliceLifecycleState
 from iris.cluster.controller.worker_health import CONSECUTIVE_FAILURE_THRESHOLD
 from iris.cluster.types import AcceleratorType, WorkerStatus
 from iris.rpc import vm_pb2
@@ -232,7 +232,9 @@ class TestAutoscalerScaleDown:
         # At t=10_000 dwell=8s, well past the 1s threshold.
         autoscaler.run_once(demand, vm_status_map, timestamp=Timestamp.from_ms(10_000))
 
-        assert group.slice_count() == 1
+        # run_once drains the idle slices; they linger DRAINING until the reap.
+        assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
+        assert group.slice_lifecycle("slice-002") == SliceLifecycleState.DRAINING
 
     def test_no_scale_down_at_buffer_target(self):
         """Does not scale down when at buffer target."""
@@ -342,7 +344,7 @@ class TestAutoscalerScaleDown:
 
         # With rate_limit=1, only 1 slice should be scaled down per cycle
         autoscaler.run_once(demand, vm_status_map, timestamp=Timestamp.from_ms(10_000))
-        assert group.slice_count() == 2
+        assert group.ready_slice_count() == 2
 
     def test_scale_down_multiple_idle_slices_in_one_cycle(self, scale_group_config: ScaleGroupConfig):
         """With enough rate-limit tokens, multiple idle slices are scaled down in one cycle."""
@@ -381,7 +383,7 @@ class TestAutoscalerScaleDown:
         # With rate_limit=5, all 3 idle slices should be scaled down in one cycle
         # at t=10_000 (8s dwell, past 1s threshold).
         autoscaler.run_once(demand, vm_status_map, timestamp=Timestamp.from_ms(10_000))
-        assert group.slice_count() == 0
+        assert group.ready_slice_count() == 0
 
 
 class TestAutoscalerExecution:
@@ -452,10 +454,10 @@ class TestAutoscalerExecution:
 
 
 class TestAutoscalerWorkerFailure:
-    """Tests for worker failure handling."""
+    """Tests for worker-liveness failure teardown (drains the slice)."""
 
-    def test_terminate_slices_for_workers_terminates_slice(self, scale_group_config: ScaleGroupConfig):
-        """terminate_slices_for_workers() terminates the slice containing the worker."""
+    def test_worker_failure_drains_slice(self, scale_group_config: ScaleGroupConfig):
+        """A failed worker's slice drains: DRAINING, VMs terminated, still tracked until reaped."""
         mock_handle = make_mock_slice_handle("slice-001", all_ready=True)
         platform = make_mock_platform(slices_to_discover=[mock_handle])
         group = ScalingGroup(scale_group_config, platform)
@@ -463,26 +465,26 @@ class TestAutoscalerWorkerFailure:
         autoscaler = make_autoscaler({"test-group": group})
         _mark_discovered_ready(group, [mock_handle])
 
-        failed_worker_id = "slice-001-vm-0"
-        autoscaler.terminate_slices_for_workers([failed_worker_id])
+        autoscaler.drain_slices_for_workers(["slice-001-vm-0"])
 
-        assert group.slice_count() == 0
+        assert group.slice_count() == 1
+        assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
+        assert mock_handle.terminated
 
-    def test_terminate_slices_for_workers_unknown_worker_is_noop(self, scale_group_config: ScaleGroupConfig):
-        """terminate_slices_for_workers() does nothing for unknown workers."""
+    def test_worker_failure_unknown_worker_is_noop(self, scale_group_config: ScaleGroupConfig):
+        """An unknown worker drains nothing."""
         mock_handle = make_mock_slice_handle("slice-001", all_ready=True)
         platform = make_mock_platform(slices_to_discover=[mock_handle])
         group = ScalingGroup(scale_group_config, platform)
         group.reconcile()
         autoscaler = make_autoscaler({"test-group": group})
 
-        autoscaler.terminate_slices_for_workers(["unknown-worker-99"])
+        autoscaler.drain_slices_for_workers(["unknown-worker-99"])
 
         assert group.slice_count() == 1
 
-    def test_terminate_slices_for_workers_returns_sibling_worker_ids(self, scale_group_config: ScaleGroupConfig):
-        """terminate_slices_for_workers() returns sibling worker IDs for multi-VM slices."""
-        # Create a slice with 4 VMs
+    def test_worker_failure_returns_sibling_worker_ids(self, scale_group_config: ScaleGroupConfig):
+        """A multi-VM slice returns its other workers to be failed immediately."""
         mock_handle = make_mock_slice_handle(
             "slice-001",
             all_ready=True,
@@ -494,15 +496,12 @@ class TestAutoscalerWorkerFailure:
         autoscaler = make_autoscaler({"test-group": group})
         _mark_discovered_ready(group, [mock_handle])
 
-        # Fail the first worker -- should return 3 sibling worker IDs
-        failed_worker_id = "slice-001-vm-0"
-        siblings = autoscaler.terminate_slices_for_workers([failed_worker_id])
+        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0"])
 
-        expected_siblings = [f"slice-001-vm-{i}" for i in range(1, 4)]
-        assert sorted(siblings) == sorted(expected_siblings)
-        assert group.slice_count() == 0
+        assert sorted(siblings) == [f"slice-001-vm-{i}" for i in range(1, 4)]
+        assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
 
-    def test_terminate_slices_for_workers_returns_empty_for_single_vm_slice(self, scale_group_config: ScaleGroupConfig):
+    def test_worker_failure_returns_empty_for_single_vm_slice(self, scale_group_config: ScaleGroupConfig):
         """Single-VM slices return no siblings."""
         mock_handle = make_mock_slice_handle("slice-001", all_ready=True)
         platform = make_mock_platform(slices_to_discover=[mock_handle])
@@ -511,13 +510,12 @@ class TestAutoscalerWorkerFailure:
         autoscaler = make_autoscaler({"test-group": group})
         _mark_discovered_ready(group, [mock_handle])
 
-        failed_worker_id = "slice-001-vm-0"
-        siblings = autoscaler.terminate_slices_for_workers([failed_worker_id])
+        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0"])
 
         assert siblings == []
 
-    def test_terminate_slices_for_workers_dedupes_by_slice(self, scale_group_config: ScaleGroupConfig):
-        """Workers from the same slice trigger one slice termination."""
+    def test_worker_failure_dedupes_by_slice(self, scale_group_config: ScaleGroupConfig):
+        """Workers from the same slice drain it once."""
         mock_handle = make_mock_slice_handle(
             "slice-001",
             all_ready=True,
@@ -529,13 +527,13 @@ class TestAutoscalerWorkerFailure:
         autoscaler = make_autoscaler({"test-group": group})
         _mark_discovered_ready(group, [mock_handle])
 
-        siblings = autoscaler.terminate_slices_for_workers(["slice-001-vm-0", "slice-001-vm-1"])
+        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0", "slice-001-vm-1"])
 
         assert siblings == ["slice-001-vm-2", "slice-001-vm-3"]
-        assert group.slice_count() == 0
+        assert group.slice_count() == 1
 
-    def test_terminate_slices_for_workers_cleans_up_even_if_terminate_fails(self, scale_group_config: ScaleGroupConfig):
-        """terminate_slices_for_workers() removes the slice even if terminate() raises."""
+    def test_worker_failure_does_not_raise_when_terminate_fails(self, scale_group_config: ScaleGroupConfig):
+        """A terminate() error during the drain is swallowed; the slice still drains."""
         mock_handle = make_mock_slice_handle("slice-001", all_ready=True)
         mock_handle.terminate_error = RuntimeError("resource not found")
         platform = make_mock_platform(slices_to_discover=[mock_handle])
@@ -544,12 +542,80 @@ class TestAutoscalerWorkerFailure:
         autoscaler = make_autoscaler({"test-group": group})
         _mark_discovered_ready(group, [mock_handle])
 
-        failed_worker_id = "slice-001-vm-0"
-        siblings = autoscaler.terminate_slices_for_workers([failed_worker_id])
+        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0"])
 
-        # Slice should be removed despite terminate() failure
-        assert group.slice_count() == 0
+        assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
         assert siblings == []
+
+
+class TestAutoscalerDrainReap:
+    """Tests for reaping a DRAINING slice once its VMs are confirmed gone."""
+
+    def test_refresh_reaps_draining_slice_when_vms_gone(self, scale_group_config: ScaleGroupConfig):
+        handle = make_mock_slice_handle("slice-001", all_ready=True, vm_states=[vm_pb2.VM_STATE_READY] * 2)
+        platform = make_mock_platform(slices_to_discover=[handle])
+        group = ScalingGroup(scale_group_config, platform)
+        group.reconcile()
+        autoscaler = make_autoscaler({"test-group": group})
+        _mark_discovered_ready(group, [handle])
+        group.drain_slice("slice-001")
+        assert isinstance(handle, FakeSliceHandle)
+
+        # The cloud now reports the allocation gone (zero workers): a clean reap.
+        handle._status = SliceStatus(state=CloudSliceState.READY, worker_count=0, workers=[])
+        before = group.health()
+        autoscaler.refresh({})
+
+        assert group.slice_count() == 0
+        # The reap is clean: it does NOT feed the churn detector.
+        assert group.health() == before
+
+    def test_refresh_keeps_draining_slice_while_vms_still_alive(self, scale_group_config: ScaleGroupConfig):
+        handle = make_mock_slice_handle("slice-001", all_ready=True, vm_states=[vm_pb2.VM_STATE_READY] * 2)
+        platform = make_mock_platform(slices_to_discover=[handle])
+        group = ScalingGroup(scale_group_config, platform)
+        group.reconcile()
+        autoscaler = make_autoscaler({"test-group": group})
+        _mark_discovered_ready(group, [handle])
+        group.drain_slice("slice-001")
+
+        # describe() still reports live VMs: the slice stays DRAINING (VMs deleting).
+        autoscaler.refresh({})
+
+        assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
+
+    def test_refresh_force_reaps_draining_slice_past_timeout(self, scale_group_config: ScaleGroupConfig):
+        handle = make_mock_slice_handle("slice-001", all_ready=True, vm_states=[vm_pb2.VM_STATE_READY] * 2)
+        platform = make_mock_platform(slices_to_discover=[handle])
+        group = ScalingGroup(scale_group_config, platform)
+        group.reconcile()
+        autoscaler = make_autoscaler({"test-group": group})
+        _mark_discovered_ready(group, [handle])
+        group.drain_slice("slice-001")
+
+        # The VMs never disappear; past the reap timeout the slice is force-reaped.
+        late = Timestamp.from_ms(Timestamp.now().epoch_ms() + DEFAULT_UNRESOLVABLE_TIMEOUT.to_ms() + 1000)
+        autoscaler.refresh({}, late)
+
+        assert group.slice_count() == 0
+
+    def test_drain_counts_slice_as_draining_in_ledger(self, scale_group_config: ScaleGroupConfig):
+        scale_group_config.quota_pool = "v4-res/zone"
+        scale_group_config.reservation_chips = 4
+        handle = make_mock_slice_handle("slice-001", all_ready=True, vm_states=[vm_pb2.VM_STATE_READY] * 2)
+        platform = make_mock_platform(slices_to_discover=[handle])
+        group = ScalingGroup(scale_group_config, platform)
+        group.reconcile()
+        autoscaler = make_autoscaler({group.name: group})
+        _mark_discovered_ready(group, [handle])
+
+        ledger_before = autoscaler.reservation_ledger()
+        assert ledger_before.pools["v4-res/zone"].draining_chips == 0
+
+        group.drain_slice("slice-001")
+
+        pool = autoscaler.reservation_ledger().pools["v4-res/zone"]
+        assert pool.draining_chips == pool.reservation_chips
 
 
 class TestAutoscalerIdleVerification:
@@ -822,7 +888,7 @@ class TestAutoscalerActionLogging:
         _mark_discovered_ready(group, [mock_handle])
 
         failed_worker_id = "slice-001-vm-0"
-        autoscaler.terminate_slices_for_workers([failed_worker_id])
+        autoscaler.drain_slices_for_workers([failed_worker_id])
 
         status = autoscaler.get_status()
         actions_by_type = {a.action_type: a for a in status.recent_actions}
@@ -1452,8 +1518,8 @@ class TestMultiSliceScaleUp:
         group.update_slice_activity(vm_status_map, Timestamp.from_ms(2_000))
         autoscaler.run_once([], vm_status_map, timestamp=Timestamp.from_ms(10_000))
 
-        # One idle slice should be scaled down.
-        assert group.slice_count() == 1
+        # One idle slice should be scaled down (drained, lingering DRAINING).
+        assert group.ready_slice_count() == 1
 
 
 class TestAutoscalerUnresolvableTimeout:

--- a/lib/iris/tests/cluster/controller/test_provisioning.py
+++ b/lib/iris/tests/cluster/controller/test_provisioning.py
@@ -146,7 +146,7 @@ def test_runtime_worker_loss_records_preempted():
     table = FakeTable()
     autoscaler = make_autoscaler({group.name: group}, provisioning_table=table)
     try:
-        autoscaler.terminate_slices_for_workers(["slice-001-vm-0"])
+        autoscaler.drain_slices_for_workers(["slice-001-vm-0"])
     finally:
         autoscaler.shutdown()
 

--- a/lib/iris/tests/cluster/controller/test_recovery.py
+++ b/lib/iris/tests/cluster/controller/test_recovery.py
@@ -123,14 +123,18 @@ def test_configured_group_not_replaced_by_drain():
 
 
 @pytest.mark.parametrize(
-    ("running_task_ids", "expected_slice_count"),
+    ("running_task_ids", "expected_ready_count"),
     [
         pytest.param(frozenset(), 0, id="idle-reclaimed"),
         pytest.param(frozenset({"task-1"}), 1, id="busy-kept"),
     ],
 )
-def test_drain_group_reclaims_only_idle_slices(monkeypatch, running_task_ids, expected_slice_count):
-    """A draining group reclaims an idle slice (target=0) but never kills one running a task."""
+def test_drain_group_reclaims_only_idle_slices(monkeypatch, running_task_ids, expected_ready_count):
+    """A draining group reclaims an idle slice (target=0) but never kills one running a task.
+
+    The reclaimed slice drains (lingers DRAINING until reaped), so live capacity is
+    measured by ready_slice_count.
+    """
     monkeypatch.setattr("iris.cluster.controller.autoscaler.runtime._probe_worker_health", lambda url: True)
     handle = make_fake_slice_handle("slice-001", scale_group="retired-group", all_ready=True)
     platform = make_mock_platform(slices_to_discover=[handle])
@@ -144,5 +148,5 @@ def test_drain_group_reclaims_only_idle_slices(monkeypatch, running_task_ids, ex
     drain.update_slice_activity(status, Timestamp.from_ms(2_000))  # stamp quiet_since
     autoscaler.run_once([], status, timestamp=Timestamp.from_ms(10_000))
 
-    assert drain.slice_count() == expected_slice_count
+    assert drain.ready_slice_count() == expected_ready_count
     autoscaler.shutdown()

--- a/lib/iris/tests/cluster/controller/test_reserved_pool.py
+++ b/lib/iris/tests/cluster/controller/test_reserved_pool.py
@@ -1,0 +1,457 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the fungible reservation pool: chip ledger and the launch cap it feeds."""
+
+import pytest
+from iris.cluster.constraints import PlacementRequirements
+from iris.cluster.controller.autoscaler.models import UNRANKED_DEMAND_BAND, DemandEntry, RoutingDecision
+from iris.cluster.controller.autoscaler.planning import (
+    _admit_in_band_order,
+    _PoolCandidate,
+    build_group_scale_plan,
+    build_scale_plan,
+)
+from iris.cluster.controller.autoscaler.reserved_pool import build_reservation_ledger
+from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
+from iris.cluster.controller.backend import _stamp_demand_bands
+from iris.cluster.types import JobName
+from iris.rpc import job_pb2, vm_pb2
+from rigging.timing import Timestamp
+from tests.cluster.backends.conftest import make_fake_slice_handle, make_mock_platform
+
+from .conftest import make_scale_group_config
+
+# Lower band_sort_key = higher priority.
+PRODUCTION = job_pb2.PRIORITY_BAND_PRODUCTION
+INTERACTIVE = job_pb2.PRIORITY_BAND_INTERACTIVE
+BATCH = job_pb2.PRIORITY_BAND_BATCH
+
+
+def _ready_group(
+    name: str,
+    variant: str,
+    *,
+    quota_pool: str,
+    reservation_chips: int,
+    slice_ids: list[str],
+    vms_per_slice: int = 1,
+) -> ScalingGroup:
+    """Build a fungible-reservation ScalingGroup with READY slices.
+
+    Each slice is discovered via the mock platform and marked READY so its
+    worker ids populate, matching how the autoscaler tracks live slices.
+    """
+    config = make_scale_group_config(name=name, accelerator_variant=variant, max_slices=64)
+    config.quota_pool = quota_pool
+    config.reservation_chips = reservation_chips
+    handles = [
+        make_fake_slice_handle(
+            sid,
+            scale_group=name,
+            vm_states=[vm_pb2.VM_STATE_READY] * vms_per_slice,
+        )
+        for sid in slice_ids
+    ]
+    platform = make_mock_platform(slices_to_discover=handles)
+    group = ScalingGroup(config, platform)
+    group.reconcile()
+    for handle in handles:
+        worker_ids = [w.worker_id for w in handle.describe().workers]
+        group.mark_slice_ready(handle.slice_id, worker_ids)
+    return group
+
+
+# -- Reservation ledger chip buckets --
+
+
+def test_live_chips_sum_across_variants_in_a_pool():
+    # Two v4-8 slices (4 chips each) + one v4-16 slice (8 chips) = 16 chips
+    # live against a shared 64-chip budget.
+    v8 = _ready_group("v4-8", "v4-8", quota_pool="pool-a", reservation_chips=64, slice_ids=["a1", "a2"])
+    v16 = _ready_group("v4-16", "v4-16", quota_pool="pool-a", reservation_chips=64, slice_ids=["b1"], vms_per_slice=2)
+
+    ledger = build_reservation_ledger([v8, v16])
+
+    assert set(ledger.pools) == {"pool-a"}
+    pool = ledger.pools["pool-a"]
+    assert pool.reservation_chips == 64
+    assert pool.live_chips == 4 + 4 + 8
+    assert pool.inflight_chips == 0
+    assert pool.draining_chips == 0
+    assert pool.allocated_chips == 16
+    assert pool.free_chips == 64 - 16
+    assert pool.incoming_chips == 64 - 16
+    assert pool.utilization == pytest.approx(16 / 64)
+
+
+def test_inflight_slices_counted_as_inflight_chips():
+    # A pending scale-up (begin_scale_up) is one in-flight slice; a booting
+    # discovered slice (not marked READY) is another. Both consume chips but
+    # are not live.
+    config = make_scale_group_config(name="v4-8", accelerator_variant="v4-8", max_slices=64)
+    config.quota_pool = "pool-a"
+    config.reservation_chips = 64
+    booting = make_fake_slice_handle("boot1", scale_group="v4-8", vm_states=[vm_pb2.VM_STATE_BOOTING])
+    platform = make_mock_platform(slices_to_discover=[booting])
+    group = ScalingGroup(config, platform)
+    group.reconcile()  # booting slice tracked as BOOTING (never marked READY)
+    group.begin_scale_up()  # one pending (REQUESTING) scale-up
+
+    pool = build_reservation_ledger([group]).pools["pool-a"]
+
+    # 2 in-flight slices (1 booting + 1 requesting) * 4 chips each.
+    assert pool.live_chips == 0
+    assert pool.inflight_chips == 8
+    assert pool.draining_chips == 0
+    assert pool.free_chips == 64 - 8
+
+
+def test_draining_slice_counted_as_draining_not_free():
+    # A drained slice stays counted until reaped: its chips are draining, not
+    # free, but they are incoming (free + draining).
+    group = _ready_group("v4-8", "v4-8", quota_pool="pool-a", reservation_chips=16, slice_ids=["a1", "a2"])
+    group.drain_slice("a1")
+
+    pool = build_reservation_ledger([group]).pools["pool-a"]
+
+    assert pool.live_chips == 4  # only a2 remains live
+    assert pool.draining_chips == 4  # a1 is draining
+    assert pool.allocated_chips == 8  # both still allocated
+    assert pool.free_chips == 16 - 8
+    assert pool.incoming_chips == (16 - 8) + 4  # free + draining
+
+
+def test_inflight_slices_by_variant():
+    # Two distinct variants share a pool; each contributes its in-flight slice
+    # count keyed by variant.
+    config8 = make_scale_group_config(name="v4-8", accelerator_variant="v4-8", max_slices=64)
+    config8.quota_pool = "pool-a"
+    config8.reservation_chips = 64
+    g8 = ScalingGroup(config8, make_mock_platform())
+    g8.begin_scale_up()
+    g8.begin_scale_up()
+
+    config16 = make_scale_group_config(name="v4-16", accelerator_variant="v4-16", max_slices=64)
+    config16.quota_pool = "pool-a"
+    config16.reservation_chips = 64
+    g16 = ScalingGroup(config16, make_mock_platform())
+    g16.begin_scale_up()
+
+    ledger = build_reservation_ledger([g8, g16])
+
+    assert ledger.inflight_slices("pool-a", "v4-8") == 2
+    assert ledger.inflight_slices("pool-a", "v4-16") == 1
+    assert ledger.inflight_slices("pool-a", "v4-32") == 0
+    assert ledger.inflight_slices("absent-pool", "v4-8") == 0
+
+
+def test_distinct_pools_bucket_separately():
+    a = _ready_group("v4-8", "v4-8", quota_pool="pool-a", reservation_chips=32, slice_ids=["a1"])
+    b = _ready_group("v5p-8", "v5p-8", quota_pool="pool-b", reservation_chips=16, slice_ids=["b1"])
+
+    ledger = build_reservation_ledger([a, b])
+
+    assert ledger.pools["pool-a"].live_chips == 4
+    assert ledger.pools["pool-b"].live_chips == 4
+    assert ledger.free_chips("pool-a") == 28
+    assert ledger.free_chips("pool-b") == 12
+
+
+def test_non_fungible_groups_excluded():
+    fungible = _ready_group("v4-8", "v4-8", quota_pool="pool-a", reservation_chips=32, slice_ids=["a1"])
+    # reservation_chips defaults to 0 -> not part of any fungible pool.
+    plain_config = make_scale_group_config(name="plain", accelerator_variant="v4-8", max_slices=8)
+    plain_config.quota_pool = "pool-a"
+    plain = ScalingGroup(plain_config, make_mock_platform())
+
+    ledger = build_reservation_ledger([fungible, plain])
+
+    assert set(ledger.pools) == {"pool-a"}
+    # Only the fungible group's slice counts; the plain group is invisible.
+    assert ledger.pools["pool-a"].live_chips == 4
+
+
+def test_conflicting_budgets_in_one_pool_raise():
+    a = _ready_group("v4-8", "v4-8", quota_pool="pool-a", reservation_chips=64, slice_ids=["a1"])
+    b = _ready_group("v4-16", "v4-16", quota_pool="pool-a", reservation_chips=128, slice_ids=["b1"], vms_per_slice=2)
+
+    with pytest.raises(ValueError, match="conflicting reservation_chips"):
+        build_reservation_ledger([a, b])
+
+
+def test_reservation_chips_without_quota_pool_raises():
+    config = make_scale_group_config(name="v4-8", accelerator_variant="v4-8", max_slices=8)
+    config.reservation_chips = 64
+    # quota_pool intentionally left empty.
+    group = ScalingGroup(config, make_mock_platform())
+
+    with pytest.raises(ValueError, match="no quota_pool"):
+        build_reservation_ledger([group])
+
+
+# -- Reservation ledger lookup maps (worker/variant/chip) --
+
+
+def test_maps_workers_variants_and_chips():
+    v8 = _ready_group("v4-8", "v4-8", quota_pool="pool-a", reservation_chips=64, slice_ids=["a1"])
+    v16 = _ready_group("v4-16", "v4-16", quota_pool="pool-a", reservation_chips=64, slice_ids=["b1"], vms_per_slice=2)
+
+    ledger = build_reservation_ledger([v8, v16])
+
+    assert ledger.variant_pool == {"v4-8": "pool-a", "v4-16": "pool-a"}
+    assert ledger.chips_per_variant == {"v4-8": 4, "v4-16": 8}
+    # Every worker in both groups maps back to the shared pool.
+    assert ledger.worker_pool == {
+        "a1-vm-0": "pool-a",
+        "b1-vm-0": "pool-a",
+        "b1-vm-1": "pool-a",
+    }
+    # ...and to its physical slice, so the preemption pass groups victims by
+    # slice. The two VMs of the v4-16 slice share one slice id.
+    assert ledger.worker_slice == {
+        "a1-vm-0": "a1",
+        "b1-vm-0": "b1",
+        "b1-vm-1": "b1",
+    }
+    assert not ledger.is_empty()
+
+
+def test_empty_when_no_fungible_groups():
+    plain_config = make_scale_group_config(name="plain", accelerator_variant="v4-8", max_slices=8)
+    plain = ScalingGroup(plain_config, make_mock_platform())
+
+    ledger = build_reservation_ledger([plain])
+
+    assert ledger.is_empty()
+    assert ledger.variant_pool == {}
+    assert ledger.pools == {}
+    assert ledger.free_chips("anything") == 0
+    assert ledger.incoming_chips("anything") == 0
+
+
+def _demand_entry(band: int) -> DemandEntry:
+    return DemandEntry(
+        task_ids=("/u/t/0",),
+        coschedule_group_id=None,
+        normalized=PlacementRequirements(
+            device_type=None, device_variants=None, preemptible=None, required_regions=None, required_zones=None
+        ),
+        constraints=[],
+        resources=job_pb2.ResourceSpecProto(),
+        band=band,
+    )
+
+
+def _routing(required: dict[str, int], routed_bands: dict[str, int]) -> RoutingDecision:
+    return RoutingDecision(
+        group_to_launch={},
+        group_required_slices=required,
+        routed_entries={name: [_demand_entry(band)] for name, band in routed_bands.items()},
+        unmet_entries=[],
+        group_reasons={},
+        group_statuses=[],
+    )
+
+
+# -- Band-ordered, head-of-line chip admission under one pool's budget --
+
+
+def test_highest_band_claims_chips_first():
+    # PROD v4-16 (8 chips) and BATCH v4-8 (4 chips) each want 2 slices; only 16
+    # chips free. PROD takes all 16; BATCH gets nothing.
+    admitted = _admit_in_band_order(
+        [_PoolCandidate("v4-8", BATCH, 4, 2), _PoolCandidate("v4-16", PRODUCTION, 8, 2)], free_chips=16, draining_chips=0
+    )
+    assert admitted == {"v4-16": 2, "v4-8": 0}
+
+
+def test_head_of_line_admits_lower_band_when_no_relief_is_coming():
+    # Only 4 chips free — too few for the PROD v4-16 slice (8) — and nothing is
+    # draining, so no more chips are ever coming for PROD from this pass. Holding
+    # them back from BATCH would just leave them idle, so BATCH gets them.
+    admitted = _admit_in_band_order(
+        [_PoolCandidate("v4-16", PRODUCTION, 8, 1), _PoolCandidate("v4-8", BATCH, 4, 1)],
+        free_chips=4,
+        draining_chips=0,
+    )
+    assert admitted == {"v4-16": 0, "v4-8": 1}
+
+
+def test_head_of_line_holds_chips_when_relief_would_satisfy_high_band():
+    # Same 4 free chips for the PROD v4-16 slice (8), but 4 more are draining —
+    # enough (4 free + 4 draining = 8) to eventually complete PROD's slice. The 4
+    # free chips are held for PROD instead of being re-grabbed by BATCH, which
+    # would just force PROD to preempt it right back once the drain lands.
+    admitted = _admit_in_band_order(
+        [_PoolCandidate("v4-16", PRODUCTION, 8, 1), _PoolCandidate("v4-8", BATCH, 4, 1)],
+        free_chips=4,
+        draining_chips=4,
+    )
+    assert admitted == {"v4-16": 0, "v4-8": 0}
+
+
+def test_head_of_line_admits_lower_band_when_relief_is_insufficient():
+    # 4 free chips + 2 draining = 6 incoming, still short of the 8 the PROD v4-16
+    # slice needs. The drain in flight can never satisfy PROD on its own, so
+    # holding back BATCH buys nothing; BATCH gets the 4 free chips.
+    admitted = _admit_in_band_order(
+        [_PoolCandidate("v4-16", PRODUCTION, 8, 1), _PoolCandidate("v4-8", BATCH, 4, 1)],
+        free_chips=4,
+        draining_chips=2,
+    )
+    assert admitted == {"v4-16": 0, "v4-8": 1}
+
+
+def test_same_band_groups_share_remaining():
+    # Equal priority: no head-of-line between them; admitted greedily in name
+    # order until chips run out (a takes 2 of the 3 affordable, b takes 1).
+    admitted = _admit_in_band_order(
+        [_PoolCandidate("a", PRODUCTION, 4, 2), _PoolCandidate("b", PRODUCTION, 4, 2)], free_chips=12, draining_chips=0
+    )
+    assert admitted == {"a": 2, "b": 1}
+
+
+def test_unranked_band_yields_to_ranked():
+    admitted = _admit_in_band_order(
+        [_PoolCandidate("v4-8", UNRANKED_DEMAND_BAND, 4, 1), _PoolCandidate("v4-16", PRODUCTION, 8, 1)],
+        free_chips=8,
+        draining_chips=0,
+    )
+    assert admitted == {"v4-16": 1, "v4-8": 0}
+
+
+def test_demand_trimmed_to_budget():
+    admitted = _admit_in_band_order([_PoolCandidate("v4-8", BATCH, 4, 10)], free_chips=16, draining_chips=0)
+    assert admitted == {"v4-8": 4}
+
+
+def test_over_committed_pool_admits_nothing():
+    # Negative free chips (pool already over budget) launches nothing more.
+    admitted = _admit_in_band_order([_PoolCandidate("v4-8", BATCH, 4, 2)], free_chips=-4, draining_chips=0)
+    assert admitted == {"v4-8": 0}
+
+
+# -- build_scale_plan caps a fungible pool's launches to its reservation budget --
+
+
+def test_high_band_slice_wins_reservation_over_low_band():
+    # Empty 16-chip pool. PROD v4-16 wants 2 slices (16 chips), BATCH v4-8 wants
+    # 2 (8 chips): 24 requested, 16 available. PROD claims the reservation.
+    v16 = _ready_group("v4-16", "v4-16", quota_pool="pool-a", reservation_chips=16, slice_ids=[])
+    v8 = _ready_group("v4-8", "v4-8", quota_pool="pool-a", reservation_chips=16, slice_ids=[])
+    groups = {g.name: g for g in (v16, v8)}
+
+    plan = build_scale_plan(
+        groups, _routing({"v4-16": 2, "v4-8": 2}, {"v4-16": PRODUCTION, "v4-8": BATCH}), Timestamp.now()
+    )
+
+    assert plan.group_plans["v4-16"].slices_to_add == 2
+    assert plan.group_plans["v4-8"].slices_to_add == 0
+
+
+def test_drained_victim_cannot_regrab_chips_held_for_preemptor():
+    # 16-chip pool: two live v4-8 slices (8 chips) plus one just-drained v4-8
+    # slice (4 chips, still draining) -> 4 free, 8 incoming. A PROD v4-16 (needs
+    # 8) is waiting; the incoming chips are enough to eventually satisfy it, so
+    # they're held for the preemptor instead of letting the re-queued BATCH
+    # v4-8 (needs 4) re-grab the 4 that are free right now.
+    v16 = _ready_group("v4-16", "v4-16", quota_pool="pool-a", reservation_chips=16, slice_ids=[])
+    v8 = _ready_group("v4-8", "v4-8", quota_pool="pool-a", reservation_chips=16, slice_ids=["a1", "a2", "a3"])
+    v8.drain_slice("a3")
+    groups = {g.name: g for g in (v16, v8)}
+
+    plan = build_scale_plan(
+        groups, _routing({"v4-16": 1, "v4-8": 1}, {"v4-16": PRODUCTION, "v4-8": BATCH}), Timestamp.now()
+    )
+
+    assert plan.group_plans["v4-16"].slices_to_add == 0
+    assert plan.group_plans["v4-8"].slices_to_add == 0
+
+
+def test_head_of_line_admits_lower_band_when_nothing_is_draining():
+    # Same 16-chip pool and the same PROD v4-16 deficit, but all three v4-8
+    # slices are live — nothing draining. 4 free chips can never cover PROD's
+    # 8-chip need on their own, and nothing is coming to make up the
+    # difference, so holding them back from BATCH would just leave them idle.
+    v16 = _ready_group("v4-16", "v4-16", quota_pool="pool-a", reservation_chips=16, slice_ids=[])
+    v8 = _ready_group("v4-8", "v4-8", quota_pool="pool-a", reservation_chips=16, slice_ids=["a1", "a2", "a3"])
+    groups = {g.name: g for g in (v16, v8)}
+
+    plan = build_scale_plan(
+        groups, _routing({"v4-16": 1, "v4-8": 1}, {"v4-16": PRODUCTION, "v4-8": BATCH}), Timestamp.now()
+    )
+
+    assert plan.group_plans["v4-16"].slices_to_add == 0
+    assert plan.group_plans["v4-8"].slices_to_add == 1
+
+
+def test_launch_cap_reads_free_not_incoming_so_draining_chips_are_unavailable():
+    # A draining slice's chips are NOT free for a new launch until reaped. Pool
+    # of 16 chips: a1,a2 live (8) + a3 draining (4) -> 4 free, 8 incoming. The
+    # cap must read free (4) and admit exactly one v4-8 (4 chips); reading
+    # incoming (8) would wrongly admit two.
+    v8 = _ready_group("v4-8", "v4-8", quota_pool="pool-a", reservation_chips=16, slice_ids=["a1", "a2", "a3"])
+    v8.drain_slice("a3")
+    groups = {v8.name: v8}
+
+    plan = build_scale_plan(groups, _routing({"v4-8": 2}, {"v4-8": BATCH}), Timestamp.now())
+
+    assert plan.group_plans["v4-8"].slices_to_add == 1
+
+
+def test_non_fungible_group_untouched():
+    # A plain group (reservation_chips=0) is not part of any pool, so the cap
+    # leaves its planned launches exactly as build_group_scale_plan computed them.
+    ts = Timestamp.now()
+    plain_config = make_scale_group_config(name="plain", accelerator_variant="v4-8", max_slices=8)
+    plain = ScalingGroup(plain_config, make_mock_platform())
+    expected = build_group_scale_plan(plain, 3, ts).slices_to_add
+
+    plan = build_scale_plan({"plain": plain}, _routing({"plain": 3}, {"plain": BATCH}), ts)
+
+    assert plan.group_plans["plain"].slices_to_add == expected
+    assert expected > 0
+
+
+def _demand(*task_wires: str) -> DemandEntry:
+    return DemandEntry(
+        task_ids=task_wires,
+        coschedule_group_id=None,
+        normalized=PlacementRequirements(
+            device_type=None, device_variants=None, preemptible=None, required_regions=None, required_zones=None
+        ),
+        constraints=[],
+        resources=job_pb2.ResourceSpecProto(),
+    )
+
+
+def _band_map(**by_wire: int) -> dict[JobName, int]:
+    return {JobName.from_wire(wire): band for wire, band in by_wire.items()}
+
+
+# -- _stamp_demand_bands: the scheduler stamps each demand entry's effective band for the cap --
+
+
+def test_stamp_demand_entry_takes_its_task_band():
+    bands = _band_map(**{"/u/prod/0": PRODUCTION})
+
+    [stamped] = _stamp_demand_bands([_demand("/u/prod/0")], bands)
+
+    assert stamped.band == PRODUCTION
+
+
+def test_stamp_demand_entry_without_resolved_band_is_unranked():
+    [stamped] = _stamp_demand_bands([_demand("/u/mystery/0")], _band_map())
+
+    assert stamped.band == UNRANKED_DEMAND_BAND
+
+
+def test_stamp_demand_coscheduled_entry_takes_highest_priority_member_band():
+    # A gang carries several tasks; the entry's band is the min (highest
+    # priority) so the whole slice is admitted at its strongest member's band.
+    bands = _band_map(**{"/u/g/0": BATCH, "/u/g/1": PRODUCTION})
+
+    [stamped] = _stamp_demand_bands([_demand("/u/g/0", "/u/g/1")], bands)
+
+    assert stamped.band == PRODUCTION


### PR DESCRIPTION
First of two stacked PRs splitting out the fungible-reservation preemption work (#6217) into a lower-risk mechanism PR and a follow-up behavior PR (#6819, cross-variant preemption itself).

Introduces a DRAINING slice lifecycle: idle scale-down, worker-liveness teardown, health-probe failures, and unresolvable-slice timeouts now mark a slice DRAINING and terminate its VMs, but keep it tracked (still counted against its reservation pool) until `refresh()` confirms the cloud allocation is gone and reaps it. Previously these paths removed a slice from tracking immediately, so its chips looked free for the window between issuing the terminate and the cloud actually freeing them.

Adds a per-tick `ReservationLedger`/`PoolLedger` (`reserved_pool.py`) that buckets each fungible reservation pool's chips into live, in-flight, and draining, built from live `ScalingGroup` state. A fungible pool's per-size scale groups now derive `max_slices` from `reservation_chips` (the physical chip budget) instead of hand-computed YAML numbers, with a validator rejecting looser overrides. The autoscaler's launch planner reads the ledger to cap a pool's new-slice launches to its free chips, admitting higher-priority demand first and holding chips back from a lower band only when a drain in flight could still relieve the higher one.

This PR is infrastructure only: no code yet preempts a running task to free reserved chips for a different variant — that's the follow-up PR.