### PR TITLE
[iris] Cross-variant preemption on fungible TPU reservations

### DIFF
--- a/lib/iris/src/iris/cluster/backends/rpc/backend.py
+++ b/lib/iris/src/iris/cluster/backends/rpc/backend.py
@@ -25,6 +25,7 @@ from rigging.timing import Duration, Timestamp
 
 from iris.chaos import chaos
 from iris.cluster.controller.autoscaler import Autoscaler
+from iris.cluster.controller.autoscaler.operations import SliceDrainCause
 from iris.cluster.controller.backend import (
     AutoscaleRequest,
     AutoscaleResult,
@@ -268,6 +269,10 @@ class RpcTaskBackend:
         assert self._store is not None, "RpcTaskBackend.schedule called before worker store attached"
         context = assemble_scheduling_context(self._store.scheduling_inputs(), request)
         zone_capabilities = self.autoscaler.zone_capabilities() if self.autoscaler is not None else None
+        # The reservation ledger drives cross-variant preemption, whose victim drain
+        # is applied by the autoscaler. Build it only on ticks the autoscaler runs,
+        # so a schedule-only mini-tick never commits a preemption the drain can't reap.
+        ledger = self.autoscaler.reservation_ledger() if self.autoscaler is not None and request.autoscale_runs else None
         return run_scheduling_decision(
             self._scheduler,
             ScheduleInput(
@@ -276,6 +281,7 @@ class RpcTaskBackend:
                 trace=request.trace,
             ),
             zone_capabilities,
+            ledger,
         )
 
     def _observe_fleet(self) -> "FleetObservation":
@@ -383,23 +389,33 @@ class RpcTaskBackend:
         return self._store.prune_dead_workers(cutoff_ms=cutoff_ms, stop_event=stop_event, pause=pause)
 
     def autoscale(self, request: AutoscaleRequest) -> AutoscaleResult:
-        """Drain dead workers' slices, or run one provisioning cycle.
+        """Drain dead/drained workers' slices, or run one provisioning cycle.
 
         With ``request.dead_workers`` set the autoscaler drains their slices —
-        marked DRAINING and reaped by a later refresh — and returns the dead
+        charging the loss to the group's churn detector — and returns the dead
         workers plus their healthy siblings as ``removed_workers`` (no
-        provisioning this call). Stubs for the removed workers are not evicted
-        here: a dead worker's stub was already dropped as it accrued UNREACHABLE
-        reconcile rounds, and a healthy sibling's stub self-evicts on the next
-        reconcile RPC once its slice is gone. Otherwise it runs a refresh +
-        probe_health + update cycle against ``request.residual_demand``, reading
-        its own worker status.
+        provisioning this call). With only ``request.drain_workers`` set
+        (cross-variant reserved-pool preemption), it drains those slices without
+        charging the group, so health and backoff signals stay clean, and returns
+        them the same way. Either way the slices are marked DRAINING and reaped by
+        a later refresh; stubs for removed workers are not evicted here — a
+        torn-down worker's stub self-evicts on its next reconcile RPC once its
+        slice is gone. Otherwise it runs a refresh + probe_health + update cycle
+        against ``request.residual_demand``, reading its own worker status.
         """
         if self.autoscaler is None:
             return AutoscaleResult()
-        if request.dead_workers:
-            siblings = self.autoscaler.drain_slices_for_workers([str(wid) for wid in request.dead_workers])
-            removed = list(request.dead_workers) + [WorkerId(wid) for wid in siblings]
+        assert not (
+            request.dead_workers and request.drain_workers
+        ), "AutoscaleRequest cannot carry both dead_workers and drain_workers in one tick"
+        if request.dead_workers or request.drain_workers:
+            workers, cause = (
+                (request.dead_workers, SliceDrainCause.WORKER_FAILED)
+                if request.dead_workers
+                else (request.drain_workers, SliceDrainCause.PREEMPTED)
+            )
+            siblings = self.autoscaler.drain_slices_for_workers([str(wid) for wid in workers], cause=cause)
+            removed = list(workers) + [WorkerId(wid) for wid in siblings]
             return AutoscaleResult(removed_workers=removed, autoscaler_state=self.autoscaler.persistable_state())
         assert self._store is not None, "RpcTaskBackend.autoscale called before worker store attached"
         self.autoscaler.refresh(self._store.worker_status())

--- a/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/operations.py
@@ -6,6 +6,7 @@
 import logging
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass
+from enum import StrEnum
 
 from rigging.timing import Timestamp
 
@@ -14,6 +15,44 @@ from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup, Slice
 from iris.rpc import vm_pb2
 
 logger = logging.getLogger(__name__)
+
+
+class SliceDrainCause(StrEnum):
+    """Why a slice's workers are being drained.
+
+    Selects telemetry and whether the teardown counts against the group's health
+    and backoff signals: a lost-liveness failure is charged to the group as churn,
+    a deliberate cross-variant preemption leaves those signals untouched.
+    """
+
+    WORKER_FAILED = "worker_failed"
+    PREEMPTED = "preempted"
+
+
+@dataclass(frozen=True)
+class DrainTelemetry:
+    """Per-cause action label, reason prefix, log verb, and terminate context."""
+
+    action_type: str
+    reason_prefix: str
+    log_verb: str
+    terminate_context: str
+
+
+DRAIN_TELEMETRY: dict[SliceDrainCause, DrainTelemetry] = {
+    SliceDrainCause.WORKER_FAILED: DrainTelemetry(
+        action_type="worker_failed",
+        reason_prefix="workers failed",
+        log_verb="termination",
+        terminate_context="cleaning up anyway",
+    ),
+    SliceDrainCause.PREEMPTED: DrainTelemetry(
+        action_type="slice_drained",
+        reason_prefix="drained for preemption",
+        log_verb="drain",
+        terminate_context="draining for preemption",
+    ),
+}
 
 
 @dataclass(frozen=True)
@@ -34,11 +73,13 @@ class SliceTerminationResult:
 
 
 def drain_slices_for_workers(
+    *,
     groups: dict[str, ScalingGroup],
     worker_ids: Sequence[str],
     unregister_slice_workers: Callable[[str, Sequence[str] | None], None],
     log_action: Callable[..., vm_pb2.AutoscalerAction],
     timestamp: Timestamp,
+    cause: SliceDrainCause,
 ) -> SliceTerminationResult:
     """Mark every slice holding ``worker_ids`` DRAINING and collect its handle.
 
@@ -52,15 +93,14 @@ def drain_slices_for_workers(
     and reaps it; the caller terminates the returned handles to start that
     deletion.
 
-    Every newly observed drain is reported to the group's churn detector as
-    :class:`~iris.cluster.controller.autoscaler.backoff_detector.SliceFate.PREEMPTED`.
-    The detector classifies internally based on slice age — short-lived deaths
-    move churn rate; long-lived deaths count as positive samples. Returns the
-    drained slices' sibling worker ids for the caller to fail immediately.
+    ``cause`` selects telemetry and, for ``WORKER_FAILED``, records a PREEMPTED fate
+    on the group's churn detector. Returns the drained slices' sibling worker ids
+    for the caller to fail immediately.
     """
     if not worker_ids:
         return SliceTerminationResult(sibling_worker_ids=[], termination_requests=[])
 
+    telemetry = DRAIN_TELEMETRY[cause]
     primary_workers = set(worker_ids)
     sibling_worker_ids: set[str] = set()
     termination_requests: list[SliceTerminationRequest] = []
@@ -83,14 +123,15 @@ def drain_slices_for_workers(
             continue
 
         affected_workers = sorted(primary_workers & set(slice_worker_ids))
-        logger.info("Workers %s triggered slice drain for %s", affected_workers, slice_id)
+        logger.info("Workers %s triggered slice %s for %s", affected_workers, telemetry.log_verb, slice_id)
         log_action(
-            "worker_failed",
+            telemetry.action_type,
             group.name,
             slice_id=slice_id,
-            reason=f"workers failed: {', '.join(affected_workers)}",
+            reason=f"{telemetry.reason_prefix}: {', '.join(affected_workers)}",
         )
-        group.record_slice_preempted(slice_id, timestamp)
+        if cause is SliceDrainCause.WORKER_FAILED:
+            group.record_slice_preempted(slice_id, timestamp)
         handle = group.drain_slice(slice_id, timestamp)
         if handle is not None:
             termination_requests.append(SliceTerminationRequest(slice_id=slice_id, group=group, handle=handle))

--- a/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
+++ b/lib/iris/src/iris/cluster/controller/autoscaler/runtime.py
@@ -44,6 +44,7 @@ from iris.cluster.controller.autoscaler.models import (
     ScalingAction,
     ScalingDecision,
 )
+from iris.cluster.controller.autoscaler.operations import DRAIN_TELEMETRY, SliceDrainCause
 from iris.cluster.controller.autoscaler.operations import (
     drain_slices_for_workers as drain_slices_for_workers_operation,
 )
@@ -421,7 +422,9 @@ class Autoscaler:
         routing_decision = route_demand(list(self._groups.values()), demand_entries, ts, zone_capabilities=caps)
         scale_plan = build_scale_plan(self._groups, routing_decision, ts)
 
-        # Log fungible-reservation chip utilization for operability.
+        # Log fungible-reservation chip utilization for operability. The same
+        # ledger is what the scheduler's cross-variant preemption pass consults;
+        # provisioning itself is still bounded by GCP, not this budget.
         log_reservation_ledger(build_reservation_ledger(self._groups.values()))
         # Build cached views eagerly here so dashboard/service RPCs never pay
         # the conversion cost on the hot path (#4844).
@@ -1035,7 +1038,7 @@ class Autoscaler:
         """All scale groups."""
         return self._groups
 
-    def drain_slices_for_workers(self, worker_ids: Sequence[str]) -> list[str]:
+    def drain_slices_for_workers(self, worker_ids: Sequence[str], *, cause: SliceDrainCause) -> list[str]:
         """Drain the unique slices holding the given workers and start their deletion.
 
         Each affected slice is marked DRAINING (kept tracked, still counted against
@@ -1046,8 +1049,10 @@ class Autoscaler:
         shared state, so a mass teardown stays within the phase budget without
         racing.
 
-        Returns the drained slices' sibling worker ids for the caller to fail
-        immediately.
+        ``cause`` distinguishes a worker-liveness failure (charged to the group as a
+        PREEMPTED provisioning outcome and churn) from a deliberate cross-variant
+        preemption (health and backoff signals stay clean). Returns the drained
+        slices' sibling worker ids for the caller to fail immediately.
         """
         result = drain_slices_for_workers_operation(
             groups=self._groups,
@@ -1055,18 +1060,19 @@ class Autoscaler:
             unregister_slice_workers=self._unregister_slice_workers,
             log_action=self._log_action,
             timestamp=Timestamp.now(),
+            cause=cause,
         )
-        # These slices had registered workers (so they reached READY) and lost
-        # them at runtime — the primary preemption path, which the probe_health
-        # backstop never sees. Record PREEMPTED so they don't pollute the create
-        # success rate (mirrors the probe_health termination path).
-        for req in result.termination_requests:
-            self._record_provisioning_outcome(
-                req.group, ProvisioningOutcome.PREEMPTED, error_message="worker liveness lost"
-            )
+        if cause is SliceDrainCause.WORKER_FAILED:
+            # Reached READY then lost liveness at runtime — record PREEMPTED so these
+            # don't pollute the create success rate.
+            for req in result.termination_requests:
+                self._record_provisioning_outcome(
+                    req.group, ProvisioningOutcome.PREEMPTED, error_message="worker liveness lost"
+                )
+        context = DRAIN_TELEMETRY[cause].terminate_context
         _run_io_batch(
             result.termination_requests,
-            lambda req: req.group.terminate_slice_handle(req.handle, context="cleaning up anyway"),
+            lambda req: req.group.terminate_slice_handle(req.handle, context=context),
             max_workers=_CLOUD_OP_MAX_WORKERS,
             thread_name_prefix="slice-drain",
         )

--- a/lib/iris/src/iris/cluster/controller/backend.py
+++ b/lib/iris/src/iris/cluster/controller/backend.py
@@ -35,6 +35,7 @@ from typing import ClassVar, Protocol
 
 from iris.cluster.controller.autoscaler import Autoscaler
 from iris.cluster.controller.autoscaler.models import UNRANKED_DEMAND_BAND, DemandEntry
+from iris.cluster.controller.autoscaler.reserved_pool import ReservationLedger
 from iris.cluster.controller.autoscaler.state import AutoscalerState
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.ops.task import Assignment
@@ -190,6 +191,9 @@ class ScheduleResult:
     """Per-job scheduling diagnostics surfaced on the dashboard."""
     scheduling_context: SchedulingContext | None = None
     """Post-placement scheduling context cached for dashboard diagnostics."""
+    reserved_drain_workers: list[WorkerId] = field(default_factory=list)
+    """Workers whose slices the autoscaler must drain to free reserved chips for
+    a cross-variant preemptor whose victim PREEMPT decisions this tick commits."""
 
 
 @dataclass(frozen=True)
@@ -258,6 +262,11 @@ class ScheduleRequest:
     user_budget_defaults: UserBudgetDefaults
     max_tasks_per_job_per_cycle: int
     trace: bool = False
+    autoscale_runs: bool = False
+    """Whether the autoscaler runs this tick. Cross-variant reserved-pool
+    preemption is only valid when it does: the victim PREEMPT and the slice drain
+    that reclaims its chips must commit together, so a schedule-only mini-tick
+    (a submit wake) must not emit cross-variant preemptions the drain never reaps."""
 
 
 @dataclass(frozen=True)
@@ -287,6 +296,7 @@ class AutoscaleRequest:
 
     residual_demand: list[DemandEntry] = field(default_factory=list)
     dead_workers: list[WorkerId] = field(default_factory=list)
+    drain_workers: list[WorkerId] = field(default_factory=list)
 
 
 def user_admitted(allowed_users: frozenset[str], user: str) -> bool:
@@ -321,6 +331,7 @@ def run_scheduling_decision(
     scheduler: Scheduler,
     snapshot: ScheduleInput,
     zone_capabilities: Mapping[str, frozenset[str]] | None = None,
+    ledger: ReservationLedger | None = None,
 ) -> ScheduleResult:
     """Run the full Iris scheduling decision pipeline over a DB-less snapshot.
 
@@ -334,6 +345,11 @@ def run_scheduling_decision(
     is folded onto worker attributes as ``availability:<variant>`` markers so a hard
     availability constraint confines a job to a zone where the accelerator has
     actually been obtained.
+
+    ``ledger`` (the fungible reservation chip ledger) enables cross-variant
+    preemption: a higher-band preemptor on a full reserved pool evicts the minimal
+    set of lower-band victim slices (any variant) so the autoscaler can drain them
+    and reprovision. The drained workers ride back in ``reserved_drain_workers``.
     """
     ctx = snapshot.context
     trace = snapshot.trace
@@ -376,17 +392,21 @@ def run_scheduling_decision(
             unschedulable=list(gated.expired_tasks),
             scheduling_context=ctx,
             residual_demand=residual_demand,
+            reserved_drain_workers=[],
         )
 
     order = compute_scheduling_order(ctx, gated, trace=trace)
     all_assignments, context, placed_jobs = apply_placements(scheduler, order, gated, ctx, trace=trace)
-    preemptions = apply_preemptions(order, placed_jobs, all_assignments, ctx.running_for_preemption, context)
+    preemptions, drain_workers = apply_preemptions(
+        order, placed_jobs, all_assignments, ctx.running_for_preemption, context, ledger
+    )
     diagnostics = compute_diagnostics(scheduler, context, placed_jobs, all_assignments, order.ordered_task_ids)
 
     # Stamp each demand entry with its tasks' effective band so the autoscaler's
     # reservation-aware launch cap admits a fungible pool's new slices in priority
     # order: the higher-priority job's larger slice claims the shared chip budget
-    # before a lower-priority job's.
+    # before a lower-priority job's, and a just-drained victim cannot re-grab the
+    # freed chips.
     banded_residual = _stamp_demand_bands(residual_demand, order.task_band_map)
 
     return ScheduleResult(
@@ -406,6 +426,7 @@ def run_scheduling_decision(
         diagnostics=diagnostics,
         scheduling_context=context,
         residual_demand=banded_residual,
+        reserved_drain_workers=sorted(drain_workers),
     )
 
 
@@ -602,15 +623,18 @@ class TaskBackend(Protocol):
         ...
 
     def autoscale(self, request: AutoscaleRequest) -> AutoscaleResult:
-        """Provision capacity for unmet demand, OR tear down dead workers.
+        """Provision capacity for unmet demand, OR tear down dead/drained workers.
 
         Bounded I/O. With ``request.dead_workers`` set, the backend terminates
         those workers' slices AND their healthy siblings and returns the full set
-        as ``removed_workers`` (no provisioning this call). Otherwise it runs one
-        scaling cycle against ``request.residual_demand``, reading its own worker
-        status. Either way it returns its tracked ``autoscaler_state`` for the
-        controller to persist. Backends that manage their own capacity (k8s)
-        return an empty result.
+        as ``removed_workers`` (no provisioning this call). With only
+        ``request.drain_workers`` set (cross-variant reserved-pool preemption) it
+        tears them down through an intentional-drain path that does not feed the
+        churn detector, returning them the same way. Otherwise it runs one scaling
+        cycle against ``request.residual_demand``, reading its own worker status.
+        Either way it returns its tracked ``autoscaler_state`` for the controller
+        to persist. Backends that manage their own capacity (k8s) return an empty
+        result.
         """
         ...
 

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -809,7 +809,7 @@ class Controller:
         backend_pins: list[tuple[JobName, str]] = []
         routing_unschedulable: list[tuple[PendingTask, str]] = []
         if run_schedule:
-            sched = self._schedule_phase(inputs)
+            sched = self._schedule_phase(inputs, autoscale_runs=run_autoscale)
             sched_results, backend_pins, routing_unschedulable = sched.results, sched.pins, sched.unschedulable
 
         recon_results: dict[str, ReconcileResult] = {}
@@ -826,8 +826,9 @@ class Controller:
         if run_autoscale:
             for backend_id in self._backend_ids:
                 residual_demand = sched_results[backend_id].residual_demand if backend_id in sched_results else []
+                drain_workers = sched_results[backend_id].reserved_drain_workers if backend_id in sched_results else []
                 auto_results[backend_id] = self._backends[backend_id].autoscale(
-                    AutoscaleRequest(residual_demand=residual_demand)
+                    AutoscaleRequest(residual_demand=residual_demand, drain_workers=drain_workers)
                 )
 
         merged_sched = self._merge_schedule_results(sched_results) if run_schedule else None
@@ -843,6 +844,16 @@ class Controller:
             auto_results=auto_results,
             now=now,
         )
+
+        # A cross-variant reserved-pool drain deletes whole slices: their workers
+        # are gone, so fail them out of the registry now (closing the victims'
+        # dangling attempts) rather than waiting for ping timeouts to reap zombie
+        # rows that would otherwise stay schedulable. The victims' tasks were
+        # already moved to PENDING by the committed PREEMPT decisions above.
+        for backend_id in self._backend_ids:
+            auto_result = auto_results.get(backend_id)
+            if auto_result is not None and auto_result.removed_workers:
+                self._remove_drained_workers(backend_id, auto_result.removed_workers)
 
         # Force the next reconcile so workers are told to stop the kicked attempts
         # promptly instead of waiting a full reconcile interval.
@@ -937,7 +948,7 @@ class Controller:
             for wid, scale_group in reads.worker_scale_groups(snap).items()
         }
 
-    def _schedule_phase(self, inputs: _TickInputs) -> SchedulePhaseResult:
+    def _schedule_phase(self, inputs: _TickInputs, *, autoscale_runs: bool) -> SchedulePhaseResult:
         """Route unpinned jobs, then run each backend's scheduler over its tasks.
 
         Returns the per-backend ``ScheduleResult``s, the ``(job_id, backend_id)``
@@ -947,6 +958,8 @@ class Controller:
         hands each backend its slice; the backend sources its own workers. The
         global user budget is threaded across backends in ``self._backend_ids``
         order so two backends cannot double-spend one user's budget in a tick.
+        ``autoscale_runs`` flags whether the autoscaler runs this tick, gating
+        cross-variant reserved-pool preemption to ticks that also apply its drain.
         """
         routing = inputs.routing
         if routing is None:
@@ -981,6 +994,7 @@ class Controller:
                     user_budget_defaults=routing.user_budget_defaults,
                     max_tasks_per_job_per_cycle=self._config.max_tasks_per_job_per_cycle,
                     trace=trace,
+                    autoscale_runs=autoscale_runs,
                 )
             )
             results[backend_id] = result
@@ -1410,6 +1424,31 @@ class Controller:
             tasks_to_run=batch.tasks_to_run,
             running_tasks=batch.running_tasks,
         )
+
+    def _remove_drained_workers(self, backend_id: str, drained_workers: list[WorkerId]) -> None:
+        """Fail and forget workers whose slices a cross-variant drain is tearing down.
+
+        The autoscaler marked their slices DRAINING and started terminating the VMs;
+        the slices linger DRAINING (still counted against the reservation pool) until
+        refresh reaps them. This clears the worker rows (and any still-active attempt)
+        so the scheduler stops seeing draining VMs as live placement targets. The
+        reason marks the drain so it is distinguishable from a health failure in the
+        audit log.
+        """
+        health = self._backends[backend_id].health
+        assert health is not None, f"backend {backend_id!r} produced removed_workers without a liveness tracker"
+        reason = "drained for cross-variant preemption"
+        for wid in drained_workers:
+            log_event("worker_failing", str(wid), trigger=reason)
+        ops.worker.fail(
+            self._db,
+            worker_ids=[str(wid) for wid in drained_workers],
+            reason=reason,
+            health=health,
+            endpoints=self._endpoints,
+            worker_attrs=self._worker_attrs,
+        )
+        health.forget_many(set(drained_workers))
 
     def _drain_pending_evictions(self) -> None:
         """Tear down the workers queued by :meth:`request_worker_eviction`.

--- a/lib/iris/src/iris/cluster/controller/scheduling/decision.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/decision.py
@@ -60,10 +60,19 @@ def apply_preemptions(
 
     # Only preemptors the same-variant pass did not already satisfy fall through
     # to the cross-variant reserved pass (the freed slot otherwise double-counts).
-    # Key on the preemptor *job* (parent), matching the reserved pass's own dedup,
-    # so a coscheduled preemptor satisfied via one sibling excludes all siblings.
-    satisfied_jobs = {preemptor.parent or preemptor for preemptor, _ in pairs}
-    remaining = [c for c in unscheduled if (c.job_name.parent or c.job_name) not in satisfied_jobs]
+    # A coscheduled preemptor satisfied via one sibling excludes all its siblings
+    # (keyed on the parent job); a non-coscheduled replica excludes only itself
+    # (keyed on its own task id), matching the reserved pass's own dedup.
+    candidates_by_task = {c.job_name: c for c in unscheduled}
+
+    def _dedup_key(task_id: JobName) -> JobName:
+        candidate = candidates_by_task.get(task_id)
+        if candidate is not None and candidate.requirements.is_coscheduled and task_id.parent is not None:
+            return task_id.parent
+        return task_id
+
+    satisfied_jobs = {_dedup_key(preemptor) for preemptor, _ in pairs}
+    remaining = [c for c in unscheduled if _dedup_key(c.job_name) not in satisfied_jobs]
     reserved_pairs, drain_workers = run_reserved_pool_preemption(remaining, running_for_preemption, ledger)
     return pairs + reserved_pairs, drain_workers
 

--- a/lib/iris/src/iris/cluster/controller/scheduling/decision.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/decision.py
@@ -8,10 +8,12 @@ Pure scheduling-layer helpers: they consume only ``scheduling.policy`` /
 carry no edge back to the controller's ops/reconcile/schema layer.
 """
 
+from iris.cluster.controller.autoscaler.reserved_pool import ReservationLedger
 from iris.cluster.controller.scheduling.policy import (
     PreemptionCandidate,
     SchedulingOrder,
     run_preemption_pass,
+    run_reserved_pool_preemption,
 )
 from iris.cluster.controller.scheduling.scheduler import (
     JobRequirements,
@@ -29,8 +31,16 @@ def apply_preemptions(
     all_assignments: list[tuple[JobName, WorkerId]],
     running_for_preemption: list[RunningTaskInfo],
     context: SchedulingContext,
-) -> list[tuple[JobName, JobName]]:
-    """Decide which running tasks to evict for higher-priority unscheduled work."""
+    ledger: ReservationLedger | None = None,
+) -> tuple[list[tuple[JobName, JobName]], set[WorkerId]]:
+    """Decide which running tasks to evict for higher-priority unscheduled work.
+
+    Runs the same-variant pass first, then a cross-variant pass over fungible
+    reserved pools for the preemptors the same-variant pass could not satisfy.
+    Returns the combined ``(preemptor, victim)`` pairs and the set of worker ids
+    whose slices the autoscaler must drain (empty for same-variant evictions,
+    which the worker-failure teardown already handles).
+    """
     assigned_ids = {task_id for task_id, _ in all_assignments}
     unscheduled = [
         PreemptionCandidate(
@@ -42,8 +52,20 @@ def apply_preemptions(
         if tid not in assigned_ids and tid.parent is not None and tid.parent in jobs
     ]
     if not unscheduled:
-        return []
-    return run_preemption_pass(unscheduled, running_for_preemption, context)
+        return [], set()
+
+    pairs = run_preemption_pass(unscheduled, running_for_preemption, context)
+    if ledger is None or ledger.is_empty():
+        return pairs, set()
+
+    # Only preemptors the same-variant pass did not already satisfy fall through
+    # to the cross-variant reserved pass (the freed slot otherwise double-counts).
+    # Key on the preemptor *job* (parent), matching the reserved pass's own dedup,
+    # so a coscheduled preemptor satisfied via one sibling excludes all siblings.
+    satisfied_jobs = {preemptor.parent or preemptor for preemptor, _ in pairs}
+    remaining = [c for c in unscheduled if (c.job_name.parent or c.job_name) not in satisfied_jobs]
+    reserved_pairs, drain_workers = run_reserved_pool_preemption(remaining, running_for_preemption, ledger)
+    return pairs + reserved_pairs, drain_workers
 
 
 def compute_diagnostics(

--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -701,12 +701,10 @@ def _victim_slices_by_pool(
 ) -> dict[str, list[_VictimSlice]]:
     """Group evictable running tasks into per-pool victim slices.
 
-    Victims are grouped by physical slice because the drain tears down a whole
-    slice: every task on it is evicted together and its chips free once (grouping
-    by task would double-count chips and silently kill a sibling task the pass
-    never checked). A coscheduled job spanning multiple slices is excluded —
-    preempting one slice's tasks cascades to siblings on the others, which the
-    drain never reaps. Tasks the same-variant pass already claimed this tick are
+    Victims are grouped by physical slice: draining one evicts every task on it
+    and frees its chips once. A coscheduled job spanning multiple slices is
+    excluded, since evicting one of its slices would still strand its tasks on
+    the others. Tasks the same-variant pass already claimed this tick are
     skipped so their chips are not double-counted.
     """
     slice_members: dict[str, list[RunningTaskInfo]] = defaultdict(list)
@@ -763,9 +761,7 @@ def run_reserved_pool_preemption(
     The pass does not re-preempt a pool whose deficit is already being addressed:
     its incoming chips (free now plus chips a drain is in the middle of freeing)
     already cover the need, or a replacement slice of the preemptor's own variant
-    is already booting. That direct observation of in-flight recovery — not a
-    timer — is what holds further preemptions back across the drain-and-reprovision
-    window.
+    is already booting.
 
     A preemptor evicts only strictly lower-priority victims
     (``band_sort_key > candidate.band``), and a BATCH preemptor never preempts.

--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -726,7 +726,10 @@ def _victim_slices_by_pool(
     for slice_id, members in slice_members.items():
         if slice_id in entangled:
             continue
-        variant = members[0].device_variant
+        # A member's device_variant is None for a CPU-only co-tenant sharing the
+        # slice's hosts; use the first TPU member's variant so such a co-tenant
+        # (which may sort first) never hides an evictable TPU slice.
+        variant = next((m.device_variant for m in members if m.device_variant is not None), None)
         if variant is None or variant not in ledger.chips_per_variant:
             continue
         worker_pools = {ledger.worker_pool.get(str(m.worker_id)) for m in members}
@@ -794,7 +797,13 @@ def run_reserved_pool_preemption(
         # slice's worth of chips. Mark the job handled up front so a later sibling
         # candidate never re-consumes incoming/replacement capacity already spent
         # on this job, regardless of which branch below this job resolves through.
-        preemptor_job = candidate.job_name.parent or candidate.job_name
+        # A non-coscheduled replica needs its own slice's worth, so it dedups on
+        # its own task id instead of the parent.
+        preemptor_job = (
+            candidate.job_name.parent
+            if candidate.requirements.is_coscheduled and candidate.job_name.parent is not None
+            else candidate.job_name
+        )
         if preemptor_job in handled_preemptor_jobs:
             continue
         handled_preemptor_jobs.add(preemptor_job)
@@ -810,13 +819,14 @@ def run_reserved_pool_preemption(
         pool_replacement = replacement.setdefault(pool, {})
         pool_replacement.setdefault(variant, ledger.inflight_slices(pool, variant))
 
+        if pool_replacement[variant] >= 1:
+            # A same-variant replacement already booting covers this candidate
+            # without spending the pool's shared incoming chips on it.
+            pool_replacement[variant] -= 1
+            continue
         if incoming[pool] >= need:
             # Covered by free chips or chips a drain is already freeing; no preemption.
             incoming[pool] -= need
-            continue
-        if pool_replacement[variant] >= 1:
-            # A replacement slice of the preemptor's variant is already booting.
-            pool_replacement[variant] -= 1
             continue
 
         deficit = need - incoming[pool]

--- a/lib/iris/src/iris/cluster/controller/scheduling/policy.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/policy.py
@@ -31,6 +31,7 @@ from iris.cluster.constraints import (
 )
 from iris.cluster.controller import reads
 from iris.cluster.controller.autoscaler.models import DemandEntry
+from iris.cluster.controller.autoscaler.reserved_pool import ReservationLedger
 from iris.cluster.controller.budget import (
     UserTask,
     compute_effective_band,
@@ -678,6 +679,175 @@ def run_preemption_pass(
                 satisfied_preemptor_jobs.add(parent)
 
     return preemptions
+
+
+@dataclass(frozen=True)
+class _VictimSlice:
+    """A running slice eligible for cross-variant reserved-pool eviction."""
+
+    slice_id: str
+    chips: int
+    # Highest priority (min band_sort_key) among the slice's members: evicting the
+    # slice tears down every task on it, so the most important one must still be
+    # strictly lower priority than the preemptor for the slice to be evictable.
+    band: int
+    workers: frozenset[WorkerId]
+    tasks: tuple[JobName, ...]
+
+
+def _victim_slices_by_pool(
+    running_tasks_info: list[RunningTaskInfo],
+    ledger: ReservationLedger,
+) -> dict[str, list[_VictimSlice]]:
+    """Group evictable running tasks into per-pool victim slices.
+
+    Victims are grouped by physical slice because the drain tears down a whole
+    slice: every task on it is evicted together and its chips free once (grouping
+    by task would double-count chips and silently kill a sibling task the pass
+    never checked). A coscheduled job spanning multiple slices is excluded —
+    preempting one slice's tasks cascades to siblings on the others, which the
+    drain never reaps. Tasks the same-variant pass already claimed this tick are
+    skipped so their chips are not double-counted.
+    """
+    slice_members: dict[str, list[RunningTaskInfo]] = defaultdict(list)
+    parent_slices: dict[JobName, set[str]] = defaultdict(set)
+    for task in running_tasks_info:
+        if task.already_preempted:
+            continue
+        slice_id = ledger.worker_slice.get(str(task.worker_id))
+        if slice_id is None:
+            continue
+        slice_members[slice_id].append(task)
+        parent = task.task_id.parent
+        if task.is_coscheduled and parent is not None:
+            parent_slices[parent].add(slice_id)
+
+    entangled = {sid for slice_ids in parent_slices.values() if len(slice_ids) > 1 for sid in slice_ids}
+
+    victims_by_pool: dict[str, list[_VictimSlice]] = defaultdict(list)
+    for slice_id, members in slice_members.items():
+        if slice_id in entangled:
+            continue
+        variant = members[0].device_variant
+        if variant is None or variant not in ledger.chips_per_variant:
+            continue
+        worker_pools = {ledger.worker_pool.get(str(m.worker_id)) for m in members}
+        pool = next(iter(worker_pools)) if len(worker_pools) == 1 else None
+        if pool is None:
+            continue
+        victims_by_pool[pool].append(
+            _VictimSlice(
+                slice_id=slice_id,
+                chips=ledger.chips_per_variant[variant],
+                band=min(m.band_sort_key for m in members),
+                workers=frozenset(m.worker_id for m in members),
+                tasks=tuple(m.task_id for m in members),
+            )
+        )
+    return victims_by_pool
+
+
+def run_reserved_pool_preemption(
+    unscheduled_tasks: list[PreemptionCandidate],
+    running_tasks_info: list[RunningTaskInfo],
+    ledger: ReservationLedger,
+) -> tuple[list[tuple[JobName, JobName]], set[WorkerId]]:
+    """Evict cross-variant victims on a full fungible reservation pool.
+
+    A fungible reservation's chips are interchangeable across slice sizes, so a
+    higher-band preemptor targeting a full reserved pool can evict the minimal
+    set of lowest-band victim slices of ANY variant in the SAME pool to free
+    enough chips. The same-variant preemption gate cannot do this; this pass
+    runs only over reserved pools and only on chip-count arithmetic.
+
+    The pass does not re-preempt a pool whose deficit is already being addressed:
+    its incoming chips (free now plus chips a drain is in the middle of freeing)
+    already cover the need, or a replacement slice of the preemptor's own variant
+    is already booting. That direct observation of in-flight recovery — not a
+    timer — is what holds further preemptions back across the drain-and-reprovision
+    window.
+
+    A preemptor evicts only strictly lower-priority victims
+    (``band_sort_key > candidate.band``), and a BATCH preemptor never preempts.
+    Victims are chosen lowest-priority-then-smallest so the eviction is minimal;
+    if no combination of evictable victims covers the deficit, nothing is evicted
+    (no partial work).
+
+    Returns ``(preemptor, victim)`` pairs (one per evicted member task) and the
+    set of worker ids whose slices the autoscaler must drain.
+    """
+    victims_by_pool = _victim_slices_by_pool(running_tasks_info, ledger)
+
+    # ``incoming`` (free now + draining chips) is what a deficit is measured
+    # against, so an already-draining victim isn't double-counted; ``replacement``
+    # lazily mirrors the ledger's in-flight slice count of each preemptor's own
+    # variant, marking a replacement that is already booting. Both are consumed as
+    # the pass commits preemptions within this tick.
+    incoming: dict[str, int] = {}
+    replacement: dict[str, dict[str, int]] = {}
+    claimed: set[str] = set()
+    pairs: list[tuple[JobName, JobName]] = []
+    drain_workers: set[WorkerId] = set()
+    handled_preemptor_jobs: set[JobName] = set()
+
+    for candidate in unscheduled_tasks:
+        # Batch never preempts.
+        if candidate.band >= job_pb2.PRIORITY_BAND_BATCH:
+            continue
+        # Dedup coscheduled preemptors: N task candidates are one job needing one
+        # slice's worth of chips. Mark the job handled up front so a later sibling
+        # candidate never re-consumes incoming/replacement capacity already spent
+        # on this job, regardless of which branch below this job resolves through.
+        preemptor_job = candidate.job_name.parent or candidate.job_name
+        if preemptor_job in handled_preemptor_jobs:
+            continue
+        handled_preemptor_jobs.add(preemptor_job)
+
+        variant = candidate.requirements.device_variant
+        if variant is None:
+            continue
+        pool = ledger.variant_pool.get(variant)
+        if pool is None:
+            continue
+        need = ledger.chips_per_variant[variant]
+        incoming.setdefault(pool, ledger.incoming_chips(pool))
+        pool_replacement = replacement.setdefault(pool, {})
+        pool_replacement.setdefault(variant, ledger.inflight_slices(pool, variant))
+
+        if incoming[pool] >= need:
+            # Covered by free chips or chips a drain is already freeing; no preemption.
+            incoming[pool] -= need
+            continue
+        if pool_replacement[variant] >= 1:
+            # A replacement slice of the preemptor's variant is already booting.
+            pool_replacement[variant] -= 1
+            continue
+
+        deficit = need - incoming[pool]
+        # Lowest priority (highest band) first, then smallest, for minimal eviction.
+        eligible = sorted(
+            (v for v in victims_by_pool.get(pool, []) if v.slice_id not in claimed and v.band > candidate.band),
+            key=lambda v: (-v.band, v.chips),
+        )
+        chosen: list[_VictimSlice] = []
+        freed = 0
+        for victim in eligible:
+            if freed >= deficit:
+                break
+            chosen.append(victim)
+            freed += victim.chips
+        if freed < deficit:
+            # Cannot cover the deficit even by evicting everything: do nothing.
+            continue
+
+        for victim in chosen:
+            claimed.add(victim.slice_id)
+            drain_workers.update(victim.workers)
+            pairs.extend((candidate.job_name, victim_task) for victim_task in victim.tasks)
+        # Surplus freed chips stay available to later, lower-priority preemptors.
+        incoming[pool] += freed - need
+
+    return pairs, drain_workers
 
 
 def _sort_pending_tasks_by_resolved_band(

--- a/lib/iris/tests/cluster/backends/test_rpc_backend.py
+++ b/lib/iris/tests/cluster/backends/test_rpc_backend.py
@@ -1,0 +1,145 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for RpcTaskBackend scheduling-tick behavior."""
+
+from pathlib import Path
+
+from iris.cluster.backends.rpc.backend import RpcTaskBackend
+from iris.cluster.controller import reads
+from iris.cluster.controller.autoscaler.reserved_pool import ReservationLedger, build_reservation_ledger
+from iris.cluster.controller.autoscaler.scaling_group import ScalingGroup
+from iris.cluster.controller.backend import BackendRuntime, ScheduleRequest
+from iris.cluster.controller.db import ControllerDB
+from iris.cluster.controller.projections.endpoints import EndpointsProjection
+from iris.cluster.controller.run_template import new_run_template_cache
+from iris.cluster.types import JobName, UserBudgetDefaults, WorkerId
+from iris.rpc import controller_pb2, job_pb2, vm_pb2
+from tests.cluster.backends.conftest import make_fake_slice_handle, make_mock_platform
+from tests.cluster.controller._test_support import ControllerTestState
+from tests.cluster.controller.conftest import (
+    dispatch_task,
+    make_scale_group_config,
+    make_test_entrypoint,
+    make_worker_metadata,
+    register_worker,
+    submit_job,
+)
+
+POOL = "v4-res/zone"
+BATCH = job_pb2.PRIORITY_BAND_BATCH
+PRODUCTION = job_pb2.PRIORITY_BAND_PRODUCTION
+
+
+class _StubAutoscaler:
+    """Stand-in autoscaler that builds a real ledger from real ``ScalingGroup`` state."""
+
+    def __init__(self, groups: list[ScalingGroup]):
+        self._groups = groups
+
+    def zone_capabilities(self) -> dict[str, frozenset[str]]:
+        return {}
+
+    def reservation_ledger(self) -> ReservationLedger:
+        return build_reservation_ledger(self._groups)
+
+
+def _bound_backend(db: ControllerDB, autoscaler: _StubAutoscaler) -> RpcTaskBackend:
+    backend = RpcTaskBackend(stub_factory=object())
+    backend.autoscaler = autoscaler
+    backend.bind_runtime(
+        BackendRuntime(
+            db=db,
+            endpoints=EndpointsProjection(db),
+            run_template_cache=new_run_template_cache(),
+            owns_scale_group=lambda _: True,
+            budget_defaults=UserBudgetDefaults(),
+        )
+    )
+    return backend
+
+
+def _tpu_job_request(name: str, variant: str, band: int) -> controller_pb2.Controller.LaunchJobRequest:
+    resources = job_pb2.ResourceSpecProto(cpu_millicores=1000, memory_bytes=1024**3)
+    resources.device.tpu.variant = variant
+    return controller_pb2.Controller.LaunchJobRequest(
+        name=JobName.root("test-user", name).to_wire(),
+        entrypoint=make_test_entrypoint(),
+        resources=resources,
+        environment=job_pb2.EnvironmentConfig(),
+        replicas=1,
+        priority_band=band,
+    )
+
+
+def _request(*, autoscale_runs: bool, pending_task_rows: list) -> ScheduleRequest:
+    return ScheduleRequest(
+        pending_task_rows=pending_task_rows,
+        requested_bands={},
+        user_spend={},
+        user_budget_limits={},
+        user_budget_defaults=UserBudgetDefaults(),
+        max_tasks_per_job_per_cycle=1,
+        autoscale_runs=autoscale_runs,
+    )
+
+
+def test_reserved_pool_drain_only_committed_when_autoscale_runs(tmp_path: Path):
+    """Cross-variant preemption is gated on the autoscaler running this tick.
+
+    A schedule-only mini-tick (a submit wake) commits its preemptions but never
+    runs the drain, so building the ledger there would let it finalize
+    cross-variant victims to PENDING with no slice teardown to reclaim their
+    reserved chips. The backend must consult the reservation ledger only when the
+    autoscaler will act on the resulting drain.
+
+    Scenario: an 8-chip fungible pool holds one running v4-8 BATCH task (4
+    chips) and a pending v4-16 PRODUCTION task (needs 8 chips, only 4 free).
+    Cross-variant preemption can free the deficit by evicting the BATCH slice.
+    """
+    db = ControllerDB(db_dir=tmp_path)
+    try:
+        test_state = ControllerTestState(db, run_template_cache=new_run_template_cache())
+
+        # A running v4-8 BATCH task on a worker belonging to the fungible pool.
+        register_worker(
+            test_state,
+            "batch1-vm-0",
+            "batch1-vm-0:8080",
+            make_worker_metadata(tpu_name="v4-8"),
+            scale_group="v4-8-batch",
+        )
+        batch_tasks = submit_job(test_state, "batch-job", _tpu_job_request("batch-job", "v4-8", BATCH))
+        dispatch_task(test_state, batch_tasks[0], WorkerId("batch1-vm-0"))
+
+        # A pending v4-16 PRODUCTION task; no v4-16 worker exists, so normal
+        # placement can't satisfy it and it falls to the reserved-pool pass.
+        submit_job(test_state, "prod-job", _tpu_job_request("prod-job", "v4-16", PRODUCTION))
+        with db.read_snapshot() as tx:
+            pending = reads.pending_tasks_with_jobs(tx)
+        assert len(pending) == 1  # the prod task; the batch task is RUNNING, not PENDING
+
+        # Real ScalingGroup state backing the ledger: the batch group's one READY
+        # slice matches the worker registered above; the prod group has none.
+        batch_config = make_scale_group_config(name="v4-8-batch", accelerator_variant="v4-8", max_slices=8)
+        batch_config.quota_pool = POOL
+        batch_config.reservation_chips = 8
+        batch_handle = make_fake_slice_handle("batch1", scale_group="v4-8-batch", vm_states=[vm_pb2.VM_STATE_READY])
+        batch_group = ScalingGroup(batch_config, make_mock_platform(slices_to_discover=[batch_handle]))
+        batch_group.reconcile()
+        batch_group.mark_slice_ready(batch_handle.slice_id, [w.worker_id for w in batch_handle.describe().workers])
+
+        prod_config = make_scale_group_config(name="v4-16-prod", accelerator_variant="v4-16", max_slices=8)
+        prod_config.quota_pool = POOL
+        prod_config.reservation_chips = 8
+        prod_group = ScalingGroup(prod_config, make_mock_platform())
+
+        backend = _bound_backend(db, _StubAutoscaler([batch_group, prod_group]))
+
+        schedule_only = backend.schedule(_request(autoscale_runs=False, pending_task_rows=pending))
+        assert schedule_only.reserved_drain_workers == []
+
+        with_autoscale = backend.schedule(_request(autoscale_runs=True, pending_task_rows=pending))
+        assert with_autoscale.reserved_drain_workers == [WorkerId("batch1-vm-0")]
+    finally:
+        db.close()

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -21,7 +21,7 @@ from iris.cluster.constraints import DeviceType, WellKnownAttribute
 from iris.cluster.controller.autoscaler import DEFAULT_UNRESOLVABLE_TIMEOUT, Autoscaler
 from iris.cluster.controller.autoscaler.backoff_detector import GroupHealth
 from iris.cluster.controller.autoscaler.models import ScalingAction, ScalingDecision
-from iris.cluster.controller.autoscaler.operations import drain_slices_for_workers
+from iris.cluster.controller.autoscaler.operations import SliceDrainCause, drain_slices_for_workers
 from iris.cluster.controller.autoscaler.routing import route_demand
 from iris.cluster.controller.autoscaler.scaling_group import GroupAvailability, ScalingGroup, SliceLifecycleState
 from iris.cluster.controller.worker_health import CONSECUTIVE_FAILURE_THRESHOLD
@@ -455,7 +455,7 @@ class TestAutoscalerExecution:
 
 
 class TestAutoscalerWorkerFailure:
-    """Tests for worker-liveness failure teardown (drains the slice)."""
+    """Tests for worker-liveness failure teardown (drains with cause WORKER_FAILED)."""
 
     def test_worker_failure_drains_slice(self, scale_group_config: ScaleGroupConfig):
         """A failed worker's slice drains: DRAINING, VMs terminated, still tracked until reaped."""
@@ -466,7 +466,7 @@ class TestAutoscalerWorkerFailure:
         autoscaler = make_autoscaler({"test-group": group})
         _mark_discovered_ready(group, [mock_handle])
 
-        autoscaler.drain_slices_for_workers(["slice-001-vm-0"])
+        autoscaler.drain_slices_for_workers(["slice-001-vm-0"], cause=SliceDrainCause.WORKER_FAILED)
 
         assert group.slice_count() == 1
         assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
@@ -480,7 +480,7 @@ class TestAutoscalerWorkerFailure:
         group.reconcile()
         autoscaler = make_autoscaler({"test-group": group})
 
-        autoscaler.drain_slices_for_workers(["unknown-worker-99"])
+        autoscaler.drain_slices_for_workers(["unknown-worker-99"], cause=SliceDrainCause.WORKER_FAILED)
 
         assert group.slice_count() == 1
 
@@ -497,7 +497,7 @@ class TestAutoscalerWorkerFailure:
         autoscaler = make_autoscaler({"test-group": group})
         _mark_discovered_ready(group, [mock_handle])
 
-        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0"])
+        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0"], cause=SliceDrainCause.WORKER_FAILED)
 
         assert sorted(siblings) == [f"slice-001-vm-{i}" for i in range(1, 4)]
         assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
@@ -511,7 +511,7 @@ class TestAutoscalerWorkerFailure:
         autoscaler = make_autoscaler({"test-group": group})
         _mark_discovered_ready(group, [mock_handle])
 
-        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0"])
+        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0"], cause=SliceDrainCause.WORKER_FAILED)
 
         assert siblings == []
 
@@ -528,7 +528,9 @@ class TestAutoscalerWorkerFailure:
         autoscaler = make_autoscaler({"test-group": group})
         _mark_discovered_ready(group, [mock_handle])
 
-        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0", "slice-001-vm-1"])
+        siblings = autoscaler.drain_slices_for_workers(
+            ["slice-001-vm-0", "slice-001-vm-1"], cause=SliceDrainCause.WORKER_FAILED
+        )
 
         assert siblings == ["slice-001-vm-2", "slice-001-vm-3"]
         assert group.slice_count() == 1
@@ -543,7 +545,7 @@ class TestAutoscalerWorkerFailure:
         autoscaler = make_autoscaler({"test-group": group})
         _mark_discovered_ready(group, [mock_handle])
 
-        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0"])
+        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0"], cause=SliceDrainCause.WORKER_FAILED)
 
         assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
         assert siblings == []
@@ -591,74 +593,63 @@ class TestAutoscalerWorkerFailure:
         assert twice_group.health(t1) == once_group.health(t1)
 
 
-class TestAutoscalerDrainReap:
-    """Tests for reaping a DRAINING slice once its VMs are confirmed gone."""
+class TestAutoscalerDrainSlices:
+    """Tests for intentional drain (cross-variant reserved-pool preemption)."""
 
-    def test_refresh_reaps_draining_slice_when_vms_gone(self, scale_group_config: ScaleGroupConfig):
-        handle = make_mock_slice_handle("slice-001", all_ready=True, vm_states=[vm_pb2.VM_STATE_READY] * 2)
+    def _fungible_group(self, slice_id: str = "slice-001", *, vms: int = 4) -> tuple[ScalingGroup, Autoscaler]:
+        """A fungible reserved group with one young READY multi-VM slice.
+
+        The slice's ``created_at`` is now so a PREEMPTED fate would be classified
+        short-lived and decay the detector — making the "drain does not feed
+        backoff" difference observable.
+        """
+        config = make_scale_group_config(name="v4-res-16", accelerator_variant="v4-16", max_slices=8)
+        config.reservation_chips = 1024
+        config.quota_pool = "v4-res/zone"
+        handle = make_mock_slice_handle(
+            slice_id,
+            all_ready=True,
+            vm_states=[vm_pb2.VM_STATE_READY] * vms,
+            created_at_ms=Timestamp.now().epoch_ms(),
+        )
         platform = make_mock_platform(slices_to_discover=[handle])
-        group = ScalingGroup(scale_group_config, platform)
-        group.reconcile()
-        autoscaler = make_autoscaler({"test-group": group})
-        _mark_discovered_ready(group, [handle])
-        group.drain_slice("slice-001")
-        assert isinstance(handle, FakeSliceHandle)
-
-        # The cloud now reports the allocation gone (zero workers): a clean reap.
-        handle._status = SliceStatus(state=CloudSliceState.READY, worker_count=0, workers=[])
-        before = group.health()
-        autoscaler.refresh({})
-
-        assert group.slice_count() == 0
-        # The reap is clean: it does NOT feed the churn detector.
-        assert group.health() == before
-
-    def test_refresh_keeps_draining_slice_while_vms_still_alive(self, scale_group_config: ScaleGroupConfig):
-        handle = make_mock_slice_handle("slice-001", all_ready=True, vm_states=[vm_pb2.VM_STATE_READY] * 2)
-        platform = make_mock_platform(slices_to_discover=[handle])
-        group = ScalingGroup(scale_group_config, platform)
-        group.reconcile()
-        autoscaler = make_autoscaler({"test-group": group})
-        _mark_discovered_ready(group, [handle])
-        group.drain_slice("slice-001")
-
-        # describe() still reports live VMs: the slice stays DRAINING (VMs deleting).
-        autoscaler.refresh({})
-
-        assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
-
-    def test_refresh_force_reaps_draining_slice_past_timeout(self, scale_group_config: ScaleGroupConfig):
-        handle = make_mock_slice_handle("slice-001", all_ready=True, vm_states=[vm_pb2.VM_STATE_READY] * 2)
-        platform = make_mock_platform(slices_to_discover=[handle])
-        group = ScalingGroup(scale_group_config, platform)
-        group.reconcile()
-        autoscaler = make_autoscaler({"test-group": group})
-        _mark_discovered_ready(group, [handle])
-        group.drain_slice("slice-001")
-
-        # The VMs never disappear; past the reap timeout the slice is force-reaped.
-        late = Timestamp.from_ms(Timestamp.now().epoch_ms() + DEFAULT_UNRESOLVABLE_TIMEOUT.to_ms() + 1000)
-        autoscaler.refresh({}, late)
-
-        assert group.slice_count() == 0
-
-    def test_drain_counts_slice_as_draining_in_ledger(self, scale_group_config: ScaleGroupConfig):
-        scale_group_config.quota_pool = "v4-res/zone"
-        scale_group_config.reservation_chips = 4
-        handle = make_mock_slice_handle("slice-001", all_ready=True, vm_states=[vm_pb2.VM_STATE_READY] * 2)
-        platform = make_mock_platform(slices_to_discover=[handle])
-        group = ScalingGroup(scale_group_config, platform)
+        group = ScalingGroup(config, platform)
         group.reconcile()
         autoscaler = make_autoscaler({group.name: group})
         _mark_discovered_ready(group, [handle])
+        return group, autoscaler
 
-        ledger_before = autoscaler.reservation_ledger()
-        assert ledger_before.pools["v4-res/zone"].draining_chips == 0
+    def test_drain_marks_slice_draining_terminates_vms_and_returns_siblings(self):
+        group, autoscaler = self._fungible_group(slice_id="slice-001", vms=4)
+        handle = group.get_slice("slice-001")
+        assert handle is not None
 
-        group.drain_slice("slice-001")
+        siblings = autoscaler.drain_slices_for_workers(["slice-001-vm-0"], cause=SliceDrainCause.PREEMPTED)
 
-        pool = autoscaler.reservation_ledger().pools["v4-res/zone"]
-        assert pool.draining_chips == pool.reservation_chips
+        # The slice lingers DRAINING (still counted) rather than being detached,
+        # but its VMs are terminated now and the siblings come back to be failed.
+        assert group.slice_count() == 1
+        assert group.slice_lifecycle("slice-001") == SliceLifecycleState.DRAINING
+        assert handle.terminated  # the drain issued the VM delete
+        assert sorted(siblings) == [f"slice-001-vm-{i}" for i in range(1, 4)]
+
+    def test_drain_does_not_decay_detector_health(self):
+        """A drain must not feed the churn detector, unlike a worker-failure teardown.
+
+        Reap timing and ledger accounting are cause-agnostic (see
+        ``TestAutoscalerDrainReap``); this covers what the PREEMPTED cause changes.
+        """
+        drained_group, drained_auto = self._fungible_group(vms=1)
+        failed_group, failed_auto = self._fungible_group(vms=1)
+
+        before = drained_group.health()
+        drained_auto.drain_slices_for_workers(["slice-001-vm-0"], cause=SliceDrainCause.PREEMPTED)
+        failed_auto.drain_slices_for_workers(["slice-001-vm-0"], cause=SliceDrainCause.WORKER_FAILED)
+
+        # Drain leaves health untouched; the worker-failure path decays it
+        # (the young slice is classified short-lived PREEMPTED).
+        assert drained_group.health() == before
+        assert failed_group.health() < before
 
 
 class TestAutoscalerIdleVerification:
@@ -931,7 +922,7 @@ class TestAutoscalerActionLogging:
         _mark_discovered_ready(group, [mock_handle])
 
         failed_worker_id = "slice-001-vm-0"
-        autoscaler.drain_slices_for_workers([failed_worker_id])
+        autoscaler.drain_slices_for_workers([failed_worker_id], cause=SliceDrainCause.WORKER_FAILED)
 
         status = autoscaler.get_status()
         actions_by_type = {a.action_type: a for a in status.recent_actions}

--- a/lib/iris/tests/cluster/controller/test_autoscaler.py
+++ b/lib/iris/tests/cluster/controller/test_autoscaler.py
@@ -572,11 +572,12 @@ class TestAutoscalerWorkerFailure:
 
         def drain(group: ScalingGroup, worker_id: str, timestamp: Timestamp) -> None:
             drain_slices_for_workers(
-                {group.name: group},
-                [worker_id],
-                lambda *_: None,
-                lambda *_, **__: vm_pb2.AutoscalerAction(),
-                timestamp,
+                groups={group.name: group},
+                worker_ids=[worker_id],
+                unregister_slice_workers=lambda *_: None,
+                log_action=lambda *_, **__: vm_pb2.AutoscalerAction(),
+                timestamp=timestamp,
+                cause=SliceDrainCause.WORKER_FAILED,
             )
 
         t0 = Timestamp.from_ms(1_000_000)

--- a/lib/iris/tests/cluster/controller/test_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_preemption.py
@@ -5,13 +5,16 @@
 
 from iris.cluster.constraints import AttributeValue, Constraint, ConstraintIndex, ConstraintOp, WellKnownAttribute
 from iris.cluster.controller import ops, reads
+from iris.cluster.controller.autoscaler.reserved_pool import PoolLedger, ReservationLedger
 from iris.cluster.controller.budget import compute_effective_band
 from iris.cluster.controller.ops.task import Assignment, finalize
 from iris.cluster.controller.reconcile.snapshot import TaskUpdate
 from iris.cluster.controller.reconcile.task import TerminalDecision, TerminalKind
 from iris.cluster.controller.reconcile.task import resolve_task_failure_state as _resolve_task_failure_state
+from iris.cluster.controller.scheduling.decision import apply_preemptions
 from iris.cluster.controller.scheduling.policy import (
     PreemptionCandidate,
+    SchedulingOrder,
     _sort_pending_tasks_by_resolved_band,
     get_running_tasks_with_band_and_value,
     run_preemption_pass,
@@ -599,6 +602,80 @@ def test_solo_preemptor_does_not_tear_down_slice():
 
     preemptions = run_preemption_pass(unscheduled, victims, ctx)
     assert preemptions == []
+
+
+# ---------------------------------------------------------------------------
+# apply_preemptions: handoff from the same-variant pass to the cross-variant
+# reserved-pool pass.
+# ---------------------------------------------------------------------------
+
+
+def test_apply_preemptions_unsatisfied_sibling_reaches_reserved_pass():
+    """Two non-coscheduled replicas of one job: the same-variant pass satisfies
+    replica 0 with a same-variant victim; replica 1 still needs its own slice's
+    worth of chips and must still reach the cross-variant reserved-pool pass,
+    not be excluded just because its sibling (same parent job) was satisfied."""
+    w_same = WorkerId("w-same")
+    ctx = _make_simple_context([_tpu_capacity(w_same)])
+
+    same_variant_victim = RunningTaskInfo(
+        task_id=JobName.from_wire("/carol/batch-job/0"),
+        worker_id=w_same,
+        band_sort_key=job_pb2.PRIORITY_BAND_BATCH,
+        resource_value=1000,
+        is_coscheduled=False,
+        cpu_millicores=1000,
+        memory_bytes=1024**3,
+        gpu_count=0,
+        tpu_count=4,
+        device_variant="v4-8",
+    )
+    w_reserved = WorkerId("w-reserved")
+    reserved_victim = RunningTaskInfo(
+        task_id=JobName.from_wire("/dave/batch-slice/0"),
+        worker_id=w_reserved,
+        band_sort_key=job_pb2.PRIORITY_BAND_BATCH,
+        resource_value=8,
+        is_coscheduled=False,
+        cpu_millicores=1000,
+        memory_bytes=1024**3,
+        gpu_count=0,
+        tpu_count=8,
+        device_variant="v4-16",
+    )
+
+    t0 = JobName.from_wire("/alice/prod-job/0")
+    t1 = JobName.from_wire("/alice/prod-job/1")
+    jobs = {JobName.from_wire("/alice/prod-job"): _tpu_requirements("v4-8", count=4, is_coscheduled=False)}
+    order = SchedulingOrder(
+        ordered_task_ids=[t0, t1],
+        task_band_map={t0: job_pb2.PRIORITY_BAND_PRODUCTION, t1: job_pb2.PRIORITY_BAND_PRODUCTION},
+        user_spend={},
+        user_budget_limits={},
+    )
+    pool = "v4-res/zone"
+    ledger = ReservationLedger(
+        pools={
+            pool: PoolLedger(
+                pool_id=pool,
+                reservation_chips=0,
+                live_chips=0,
+                inflight_chips=0,
+                draining_chips=0,
+                inflight_slices_by_variant={},
+            )
+        },
+        worker_pool={str(w_reserved): pool},
+        worker_slice={str(w_reserved): "s-reserved"},
+        variant_pool={"v4-8": pool, "v4-16": pool},
+        chips_per_variant={"v4-8": 4, "v4-16": 8},
+    )
+
+    pairs, drain_workers = apply_preemptions(order, jobs, [], [same_variant_victim, reserved_victim], ctx, ledger)
+
+    assert {preemptor for preemptor, _ in pairs} == {t0, t1}
+    assert {victim for _, victim in pairs} == {same_variant_victim.task_id, reserved_victim.task_id}
+    assert drain_workers == {w_reserved}
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/controller/test_provisioning.py
+++ b/lib/iris/tests/cluster/controller/test_provisioning.py
@@ -11,6 +11,7 @@ covered without driving a live controller.
 
 import pytest
 from iris.cluster.backends.types import InfraError, QuotaExhaustedError
+from iris.cluster.controller.autoscaler.operations import SliceDrainCause
 from iris.cluster.controller.autoscaler.provisioning import (
     ProvisioningOutcome,
     classify_create_failure,
@@ -146,7 +147,7 @@ def test_runtime_worker_loss_records_preempted():
     table = FakeTable()
     autoscaler = make_autoscaler({group.name: group}, provisioning_table=table)
     try:
-        autoscaler.drain_slices_for_workers(["slice-001-vm-0"])
+        autoscaler.drain_slices_for_workers(["slice-001-vm-0"], cause=SliceDrainCause.WORKER_FAILED)
     finally:
         autoscaler.shutdown()
 

--- a/lib/iris/tests/cluster/controller/test_reserved_pool_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_reserved_pool_preemption.py
@@ -353,6 +353,71 @@ def test_slice_with_a_higher_band_task_is_not_evicted():
     assert drain == set()
 
 
+def test_non_coscheduled_replicas_each_need_their_own_slice():
+    # Two replicas of the same non-coscheduled job are independent preemptors:
+    # each needs its own slice's worth of chips, unlike a coscheduled job's
+    # siblings which share one dedup key and one slice's worth of need.
+    preemptors = [
+        _candidate("/alice/prod/0", "v4-8", PRODUCTION),
+        _candidate("/alice/prod/1", "v4-8", PRODUCTION),
+    ]
+    victims = [
+        _running("/bob/batch-a/0", "wa", "v4-8", BATCH),
+        _running("/bob/batch-b/0", "wb", "v4-8", BATCH),
+    ]
+    ledger = _ledger(free_chips=0, worker_slice={"wa": "sa", "wb": "sb"})
+
+    pairs, drain = run_reserved_pool_preemption(preemptors, victims, ledger)
+
+    assert {p.to_wire() for p, _ in pairs} == {"/alice/prod/0", "/alice/prod/1"}
+    assert drain == {WorkerId("wa"), WorkerId("wb")}
+
+
+def test_own_replacement_preferred_over_shared_incoming_chips():
+    # A v4-8 preemptor's own replacement is already booting even though the pool
+    # also has free chips that would separately cover it. Spending the
+    # replacement first (not the shared free chips) leaves those free chips
+    # available to reduce a later v4-16 preemptor's deficit, letting a single
+    # v4-8 victim slice cover it instead of the eviction failing outright.
+    preemptors = [
+        _candidate("/alice/prod-a/0", "v4-8", PRODUCTION),
+        _candidate("/alice/prod-b/0", "v4-16", PRODUCTION),
+    ]
+    victims = [_running("/bob/batch/0", "w0", "v4-8", BATCH)]
+    ledger = _ledger(free_chips=4, worker_slice={"w0": "s0"}, inflight_slices={"v4-8": 1})
+
+    pairs, drain = run_reserved_pool_preemption(preemptors, victims, ledger)
+
+    assert {p.to_wire() for p, _ in pairs} == {"/alice/prod-b/0"}
+    assert drain == {WorkerId("w0")}
+
+
+def test_cpu_co_tenant_first_in_list_does_not_hide_tpu_victim():
+    # A CPU-only task (device_variant=None) shares a physical slice with a TPU
+    # task and sorts first. The slice must still be evictable via its TPU
+    # member's variant, not skipped because the first member has no variant.
+    preemptor = _candidate("/alice/prod/0", "v4-8", PRODUCTION)
+    cpu_task = RunningTaskInfo(
+        task_id=JobName.from_wire("/bob/cpu/0"),
+        worker_id=WorkerId("w0"),
+        band_sort_key=BATCH,
+        resource_value=1,
+        is_coscheduled=False,
+        cpu_millicores=500,
+        memory_bytes=1024,
+        gpu_count=0,
+        tpu_count=0,
+        device_variant=None,
+    )
+    tpu_task = _running("/bob/batch/0", "w0", "v4-8", BATCH)
+    ledger = _ledger(free_chips=0, worker_slice={"w0": "shared"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], [cpu_task, tpu_task], ledger)
+
+    assert {v.to_wire() for _, v in pairs} == {"/bob/cpu/0", "/bob/batch/0"}
+    assert drain == {WorkerId("w0")}
+
+
 def test_slice_chips_counted_once_for_colocated_tasks():
     # Two independent batch tasks on one physical slice free that slice's chips
     # once (not once per task). A v4-16 preemptor needs 8 chips; the shared v4-16

--- a/lib/iris/tests/cluster/controller/test_reserved_pool_preemption.py
+++ b/lib/iris/tests/cluster/controller/test_reserved_pool_preemption.py
@@ -1,0 +1,370 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for cross-variant preemption on a full fungible reservation pool."""
+
+from iris.cluster.controller.autoscaler.reserved_pool import PoolLedger, ReservationLedger
+from iris.cluster.controller.scheduling.policy import PreemptionCandidate, run_reserved_pool_preemption
+from iris.cluster.controller.scheduling.scheduler import JobRequirements, RunningTaskInfo
+from iris.cluster.types import JobName, WorkerId
+from iris.rpc import job_pb2
+
+POOL = "v4-res/zone"
+# Lower band_sort_key = higher priority.
+PRODUCTION = job_pb2.PRIORITY_BAND_PRODUCTION
+INTERACTIVE = job_pb2.PRIORITY_BAND_INTERACTIVE
+BATCH = job_pb2.PRIORITY_BAND_BATCH
+
+# Chip footprint per variant for these tests.
+CHIPS_PER_VARIANT = {"v4-8": 4, "v4-16": 8, "v4-32": 16}
+
+
+def _requirements(variant: str, *, coscheduled: bool = False) -> JobRequirements:
+    return JobRequirements(
+        req_cpu_millicores=1000,
+        req_memory_bytes=1024,
+        req_gpu_count=0,
+        req_tpu_count=CHIPS_PER_VARIANT[variant],
+        device_variant=variant,
+        constraints=[],
+        is_coscheduled=coscheduled,
+        coscheduling_group_by="tpu" if coscheduled else None,
+    )
+
+
+def _candidate(task_wire: str, variant: str, band: int, *, coscheduled: bool = False) -> PreemptionCandidate:
+    return PreemptionCandidate(
+        job_name=JobName.from_wire(task_wire),
+        requirements=_requirements(variant, coscheduled=coscheduled),
+        band=band,
+    )
+
+
+def _running(task_wire: str, worker: str, variant: str, band: int, *, coscheduled: bool = False) -> RunningTaskInfo:
+    return RunningTaskInfo(
+        task_id=JobName.from_wire(task_wire),
+        worker_id=WorkerId(worker),
+        band_sort_key=band,
+        resource_value=CHIPS_PER_VARIANT[variant],
+        is_coscheduled=coscheduled,
+        cpu_millicores=1000,
+        memory_bytes=1024,
+        gpu_count=0,
+        tpu_count=CHIPS_PER_VARIANT[variant],
+        device_variant=variant,
+    )
+
+
+def _ledger(
+    free_chips: int,
+    worker_slice: dict[str, str],
+    *,
+    draining_chips: int = 0,
+    inflight_slices: dict[str, int] | None = None,
+) -> ReservationLedger:
+    # worker_slice maps each victim worker to its physical slice id; coscheduled
+    # siblings share a slice so the drain reaps them together. Every worker here
+    # belongs to the single test pool. ``draining_chips`` are chips a drain is
+    # already freeing (incoming = free + draining); ``inflight_slices`` marks a
+    # replacement slice of a variant already booting.
+    pool = PoolLedger(
+        pool_id=POOL,
+        reservation_chips=free_chips + draining_chips,
+        live_chips=0,
+        inflight_chips=0,
+        draining_chips=draining_chips,
+        inflight_slices_by_variant=dict(inflight_slices or {}),
+    )
+    return ReservationLedger(
+        pools={POOL: pool},
+        worker_pool={worker: POOL for worker in worker_slice},
+        worker_slice=dict(worker_slice),
+        variant_pool={v: POOL for v in CHIPS_PER_VARIANT},
+        chips_per_variant=dict(CHIPS_PER_VARIANT),
+    )
+
+
+def test_production_v4_8_preempts_interactive_v4_16_when_pool_full():
+    # The issue scenario: a full pool, a production v4-8 (needs 4 chips), and an
+    # interactive v4-16 slice (8 chips) on two workers. The big slice is evicted.
+    preemptor = _candidate("/alice/prod/0", "v4-8", PRODUCTION)
+    victims = [
+        _running("/bob/inter/0", "w0", "v4-16", INTERACTIVE, coscheduled=True),
+        _running("/bob/inter/1", "w1", "v4-16", INTERACTIVE, coscheduled=True),
+    ]
+    ledger = _ledger(free_chips=0, worker_slice={"w0": "s-inter", "w1": "s-inter"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    assert {v.to_wire() for _, v in pairs} == {"/bob/inter/0", "/bob/inter/1"}
+    assert all(p.to_wire() == "/alice/prod/0" for p, _ in pairs)
+    assert drain == {WorkerId("w0"), WorkerId("w1")}
+
+
+def test_same_band_victim_not_evicted():
+    preemptor = _candidate("/alice/prod/0", "v4-8", INTERACTIVE)
+    victims = [_running("/bob/other/0", "w0", "v4-16", INTERACTIVE, coscheduled=True)]
+    ledger = _ledger(free_chips=0, worker_slice={"w0": "s0"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    assert pairs == []
+    assert drain == set()
+
+
+def test_higher_priority_victim_not_evicted():
+    # Preemptor is interactive; the only victim is production (higher priority).
+    preemptor = _candidate("/alice/inter/0", "v4-8", INTERACTIVE)
+    victims = [_running("/bob/prod/0", "w0", "v4-8", PRODUCTION)]
+    ledger = _ledger(free_chips=0, worker_slice={"w0": "s0"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    assert pairs == []
+    assert drain == set()
+
+
+def test_no_preemption_when_pool_has_enough_free_chips():
+    preemptor = _candidate("/alice/prod/0", "v4-8", PRODUCTION)
+    victims = [_running("/bob/inter/0", "w0", "v4-8", INTERACTIVE)]
+    # 4 free chips already satisfy the v4-8 (4-chip) preemptor.
+    ledger = _ledger(free_chips=4, worker_slice={"w0": "s0"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    assert pairs == []
+    assert drain == set()
+
+
+def test_minimal_eviction_picks_fewest_lowest_priority_slices():
+    # Need 16 chips (v4-32). Candidates: two batch v4-8 (4 each), one interactive
+    # v4-16 (8). The deficit is best covered by the single batch + interactive?
+    # Sort is lowest-priority-then-smallest: batch slices first (band higher).
+    # Two batch v4-8 = 8 chips, still short; the interactive v4-16 = 8 more -> 16.
+    preemptor = _candidate("/alice/prod/0", "v4-32", PRODUCTION)
+    victims = [
+        _running("/bob/batch-a/0", "wa", "v4-8", BATCH),
+        _running("/bob/batch-b/0", "wb", "v4-8", BATCH),
+        _running("/bob/inter/0", "wc", "v4-16", INTERACTIVE, coscheduled=True),
+        _running("/bob/inter/1", "wd", "v4-16", INTERACTIVE, coscheduled=True),
+    ]
+    ledger = _ledger(free_chips=0, worker_slice={"wa": "sa", "wb": "sb", "wc": "s-inter", "wd": "s-inter"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    # 2 batch v4-8 (8) + 1 interactive v4-16 (8) = 16 chips, covering the deficit.
+    assert drain == {WorkerId("wa"), WorkerId("wb"), WorkerId("wc"), WorkerId("wd")}
+    assert {v.to_wire() for _, v in pairs} == {
+        "/bob/batch-a/0",
+        "/bob/batch-b/0",
+        "/bob/inter/0",
+        "/bob/inter/1",
+    }
+
+
+def test_no_extra_slices_evicted_beyond_deficit():
+    # Need 4 chips (v4-8). The smallest evictable slice (a v4-8, 4 chips) covers
+    # the deficit exactly; the larger v4-16 slice must NOT also be evicted.
+    preemptor = _candidate("/alice/prod/0", "v4-8", PRODUCTION)
+    victims = [
+        _running("/bob/batch-small/0", "wsmall", "v4-8", BATCH),
+        _running("/bob/batch-big/0", "wbig0", "v4-16", BATCH, coscheduled=True),
+        _running("/bob/batch-big/1", "wbig1", "v4-16", BATCH, coscheduled=True),
+    ]
+    ledger = _ledger(free_chips=0, worker_slice={"wsmall": "s-small", "wbig0": "s-big", "wbig1": "s-big"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    # Smallest-first: the v4-8 (4 chips) covers the deficit alone; the v4-16 is spared.
+    assert drain == {WorkerId("wsmall")}
+    assert {v.to_wire() for _, v in pairs} == {"/bob/batch-small/0"}
+
+
+def test_nothing_evicted_when_total_evictable_below_deficit():
+    # Need 16 chips, only one evictable v4-8 (4 chips). Never partial-evict.
+    preemptor = _candidate("/alice/prod/0", "v4-32", PRODUCTION)
+    victims = [_running("/bob/batch/0", "wa", "v4-8", BATCH)]
+    ledger = _ledger(free_chips=0, worker_slice={"wa": "sa"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    assert pairs == []
+    assert drain == set()
+
+
+def test_draining_chips_cover_deficit_so_no_re_preempt():
+    # Window 1: the victim chosen on a prior tick is now DRAINING. Its chips show
+    # up as draining (not free), so incoming = free + draining covers the v4-8
+    # preemptor's 4-chip need. A second eviction would kill extra work for capacity
+    # already in flight, so nothing is evicted.
+    preemptor = _candidate("/alice/prod/0", "v4-8", PRODUCTION)
+    # An evictable batch victim still exists, but the deficit is already covered.
+    victims = [_running("/bob/batch/0", "w0", "v4-8", BATCH)]
+    ledger = _ledger(free_chips=0, draining_chips=4, worker_slice={"w0": "s0"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    assert pairs == []
+    assert drain == set()
+
+
+def test_replacement_slice_booting_skips_re_preempt():
+    # Window 2: the prior victim was already reaped and a replacement slice of the
+    # preemptor's own variant is booting (inflight_slices >= 1). Free+draining is 0,
+    # but the booting replacement covers the need, so no further eviction.
+    preemptor = _candidate("/alice/prod/0", "v4-8", PRODUCTION)
+    victims = [_running("/bob/batch/0", "w0", "v4-8", BATCH)]
+    ledger = _ledger(free_chips=0, worker_slice={"w0": "s0"}, inflight_slices={"v4-8": 1})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    assert pairs == []
+    assert drain == set()
+
+
+def test_replacement_slice_of_other_variant_does_not_skip():
+    # An in-flight slice of a DIFFERENT variant does not cover a v4-8 preemptor:
+    # only a replacement of the preemptor's own variant counts. With no free or
+    # draining chips and no v4-8 replacement, the batch victim is evicted.
+    preemptor = _candidate("/alice/prod/0", "v4-8", PRODUCTION)
+    victims = [_running("/bob/batch/0", "w0", "v4-8", BATCH)]
+    ledger = _ledger(free_chips=0, worker_slice={"w0": "s0"}, inflight_slices={"v4-16": 1})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    assert {v.to_wire() for _, v in pairs} == {"/bob/batch/0"}
+    assert drain == {WorkerId("w0")}
+
+
+def test_two_preemptors_one_replacement_slice_evicts_for_the_second():
+    # A single booting replacement slice covers exactly one preemptor. Two v4-8
+    # preemptors of distinct jobs: the first is satisfied by the booting
+    # replacement; the second has nothing left and must evict a victim.
+    preemptors = [
+        _candidate("/alice/prod-a/0", "v4-8", PRODUCTION),
+        _candidate("/alice/prod-b/0", "v4-8", PRODUCTION),
+    ]
+    victims = [_running("/bob/batch/0", "w0", "v4-8", BATCH)]
+    ledger = _ledger(free_chips=0, worker_slice={"w0": "s0"}, inflight_slices={"v4-8": 1})
+
+    pairs, drain = run_reserved_pool_preemption(preemptors, victims, ledger)
+
+    # First preemptor consumes the replacement; second evicts the batch victim.
+    assert {p.to_wire() for p, _ in pairs} == {"/alice/prod-b/0"}
+    assert drain == {WorkerId("w0")}
+
+
+def test_batch_preemptor_never_preempts():
+    preemptor = _candidate("/alice/batch/0", "v4-8", BATCH)
+    # A lower-priority victim does not exist below batch, but even a hypothetical
+    # one must not be evicted because batch never preempts.
+    victims = [_running("/bob/other/0", "w0", "v4-8", BATCH)]
+    ledger = _ledger(free_chips=0, worker_slice={"w0": "s0"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    assert pairs == []
+    assert drain == set()
+
+
+def test_two_preemptors_do_not_claim_the_same_victim():
+    # Two production v4-8 preemptors, only one v4-16 victim slice (8 chips). The
+    # first claims it; the second finds nothing left and evicts nothing more.
+    preemptors = [
+        _candidate("/alice/prod-a/0", "v4-8", PRODUCTION),
+        _candidate("/alice/prod-b/0", "v4-8", PRODUCTION),
+    ]
+    victims = [
+        _running("/bob/inter/0", "w0", "v4-16", INTERACTIVE, coscheduled=True),
+        _running("/bob/inter/1", "w1", "v4-16", INTERACTIVE, coscheduled=True),
+    ]
+    ledger = _ledger(free_chips=0, worker_slice={"w0": "s-inter", "w1": "s-inter"})
+
+    pairs, drain = run_reserved_pool_preemption(preemptors, victims, ledger)
+
+    # The single v4-16 slice is evicted once (freeing 8 chips); after the first
+    # preemptor takes 4, 4 remain — enough for the second, so it preempts nothing.
+    preemptors_in_pairs = {p.to_wire() for p, _ in pairs}
+    assert preemptors_in_pairs == {"/alice/prod-a/0"}
+    assert drain == {WorkerId("w0"), WorkerId("w1")}
+
+
+def test_coscheduled_preemptor_handled_once():
+    # A coscheduled v4-16 preemptor has two task candidates but is one job needing
+    # 8 chips total. It must evict exactly one victim slice, not two.
+    preemptors = [
+        _candidate("/alice/prod/0", "v4-16", PRODUCTION, coscheduled=True),
+        _candidate("/alice/prod/1", "v4-16", PRODUCTION, coscheduled=True),
+    ]
+    victims = [
+        _running("/bob/batch-a/0", "wa", "v4-16", BATCH, coscheduled=True),
+        _running("/bob/batch-a/1", "wb", "v4-16", BATCH, coscheduled=True),
+        _running("/bob/batch-c/0", "wc", "v4-16", BATCH, coscheduled=True),
+        _running("/bob/batch-c/1", "wd", "v4-16", BATCH, coscheduled=True),
+    ]
+    ledger = _ledger(free_chips=0, worker_slice={"wa": "s-a", "wb": "s-a", "wc": "s-c", "wd": "s-c"})
+
+    pairs, drain = run_reserved_pool_preemption(preemptors, victims, ledger)
+
+    # Exactly one victim slice (8 chips) is evicted to satisfy the 8-chip job.
+    assert drain == {WorkerId("wa"), WorkerId("wb")}
+    assert {v.to_wire() for _, v in pairs} == {"/bob/batch-a/0", "/bob/batch-a/1"}
+
+
+def test_coscheduled_preemptor_does_not_double_spend_free_chips():
+    # Pool already has exactly enough free chips (8) for the ONE v4-16 slice the
+    # coscheduled job needs. A separate evictable v4-16 BATCH victim slice also
+    # exists. Each host candidate must not independently re-charge the pool for
+    # the job's single slice need — that would deplete free chips once per host
+    # and evict the victim slice even though nothing needed to be freed.
+    preemptors = [
+        _candidate("/alice/prod/0", "v4-16", PRODUCTION, coscheduled=True),
+        _candidate("/alice/prod/1", "v4-16", PRODUCTION, coscheduled=True),
+    ]
+    victims = [
+        _running("/bob/batch/0", "wa", "v4-16", BATCH, coscheduled=True),
+        _running("/bob/batch/1", "wb", "v4-16", BATCH, coscheduled=True),
+    ]
+    ledger = _ledger(free_chips=8, worker_slice={"wa": "s-a", "wb": "s-a"})
+
+    pairs, drain = run_reserved_pool_preemption(preemptors, victims, ledger)
+
+    assert pairs == []
+    assert drain == set()
+
+
+def test_slice_with_a_higher_band_task_is_not_evicted():
+    # Two independent (non-coscheduled) tasks share one physical slice: a batch
+    # task and an interactive task. The drain tears down the whole slice, so the
+    # interactive task (equal priority to the preemptor) must protect it — the
+    # pass groups by slice, gates on the highest-priority member, and evicts
+    # nothing even though the batch task alone would be fair game.
+    preemptor = _candidate("/alice/prod/0", "v4-8", PRODUCTION)
+    victims = [
+        _running("/bob/batch/0", "w0", "v4-8", BATCH),
+        _running("/bob/inter/0", "w1", "v4-8", PRODUCTION),
+    ]
+    # Both workers belong to the same physical slice.
+    ledger = _ledger(free_chips=0, worker_slice={"w0": "shared", "w1": "shared"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    assert pairs == []
+    assert drain == set()
+
+
+def test_slice_chips_counted_once_for_colocated_tasks():
+    # Two independent batch tasks on one physical slice free that slice's chips
+    # once (not once per task). A v4-16 preemptor needs 8 chips; the shared v4-16
+    # slice supplies exactly 8, and both colocated tasks are preempted together.
+    preemptor = _candidate("/alice/prod/0", "v4-16", PRODUCTION, coscheduled=True)
+    victims = [
+        _running("/bob/batch-x/0", "w0", "v4-16", BATCH),
+        _running("/bob/batch-y/0", "w1", "v4-16", BATCH),
+    ]
+    ledger = _ledger(free_chips=0, worker_slice={"w0": "shared", "w1": "shared"})
+
+    pairs, drain = run_reserved_pool_preemption([preemptor], victims, ledger)
+
+    assert drain == {WorkerId("w0"), WorkerId("w1")}
+    assert {v.to_wire() for _, v in pairs} == {"/bob/batch-x/0", "/bob/batch-y/0"}

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -2656,6 +2656,55 @@ def test_worker_failed_from_running_counts_as_preemption(state):
     assert check_task_can_be_scheduled(_query_task(state, task.task_id))
 
 
+def test_failing_worker_after_preempt_keeps_task_pending(state):
+    """Drain teardown: a victim preempted to PENDING then has its worker failed.
+
+    Cross-variant reserved-pool preemption commits the PREEMPT (victim -> PENDING,
+    one preemption charge) and, in the same tick, drains the victim's whole slice
+    -> the controller fails those workers out of the registry. Failing a worker
+    whose task already moved to PENDING must NOT re-charge or re-terminate the
+    task: it stays a schedulable PENDING with its single preemption charge, and
+    the worker row is gone (so the scheduler stops seeing the deleted VM).
+    """
+    worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())
+
+    req = make_job_request("job1")
+    req.max_retries_preemption = 5
+    tasks = submit_job(state, "j1", req)
+    task = tasks[0]
+
+    dispatch_task(state, task, worker_id)
+    assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_RUNNING
+
+    # Cross-variant preemption: victim rolls back to PENDING with one charge.
+    with state._db.transaction() as cur:
+        finalize(
+            cur,
+            [TerminalDecision(TerminalKind.PREEMPT, task.task_id, "reclaim for v4-8")],
+            endpoints=state._endpoints,
+            now=Timestamp.now(),
+        )
+    assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_PENDING
+    assert _query_task(state, task.task_id).preemption_count == 1
+
+    # Drain teardown fails the now-deleted worker (mirrors _remove_drained_workers).
+    ops.worker.fail(
+        state._db,
+        worker_ids=["w1"],
+        reason="drained for cross-variant preemption",
+        health=state._health,
+        endpoints=state._endpoints,
+        worker_attrs=state._worker_attrs,
+    )
+
+    after = _query_task(state, task.task_id)
+    assert after.state == job_pb2.TASK_STATE_PENDING
+    assert after.preemption_count == 1, "worker failure must not re-charge an already-preempted task"
+    assert after.failure_count == 0
+    assert check_task_can_be_scheduled(after)
+    assert _query_worker(state, worker_id) is None
+
+
 def test_worker_failed_from_building_counts_as_preemption(state):
     """WORKER_FAILED on a task in BUILDING state counts as a preemption."""
     worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())


### PR DESCRIPTION
Stacked on #6818 (the reservation ledger and drain lifecycle) — review that one first; this PR's diff is just the commit on top.

Extends the scheduler's preemption pass with a cross-variant pass over fungible reservation pools: when a same-variant preemption cannot satisfy a higher-band task and its pool is on a fungible reservation, this pass evicts the minimal set of lowest-priority victim slices of ANY variant in the same pool to free enough physical chips. Victims are grouped by physical slice (evicting one tears down every task on it) and chosen lowest-priority-then-smallest; if no combination of evictable victims covers the deficit, nothing is evicted.

The pass does not re-preempt a pool whose deficit is already being addressed: its incoming chips (free now plus what a drain in flight is about to free) already cover the need, or a replacement slice of the preemptor's own variant is already booting.

Cross-variant preemption is only computed on ticks the autoscaler also runs (`ScheduleRequest.autoscale_runs`): the victim PREEMPT and the slice drain that reclaims its chips must commit together, so a schedule-only mini-tick (a submit wake) never emits a preemption the drain can't reap. The drained workers are threaded back through `reserved_drain_workers` / `AutoscaleRequest.drain_workers` to the autoscaler, which drains them with a PREEMPTED cause that leaves the group's health/backoff signals untouched (unlike a worker-liveness failure), and the controller fails their worker rows immediately rather than waiting for a ping timeout.

Fixes #6217