### PR TITLE
[ci] add unified unit test workflow with import-driven test selection

### DIFF
--- a/.github/workflows/unified-unit.yaml
+++ b/.github/workflows/unified-unit.yaml
@@ -1,0 +1,83 @@
+name: "Marin - Unit (unified)"
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+  workflow_dispatch:
+    inputs:
+      force_run_all:
+        description: "Bypass the analyzer; run every package's full suite."
+        type: boolean
+        default: false
+
+concurrency:
+  group: unified-unit-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+permissions:
+  contents: read
+
+jobs:
+  select:
+    runs-on: ubuntu-latest
+    outputs:
+      matrix: ${{ steps.analyze.outputs.matrix }}
+    steps:
+      - uses: actions/checkout@v5
+        with:
+          fetch-depth: 0
+
+      - id: analyze
+        run: |
+          BASE_REF="${{ github.event.pull_request.base.sha || github.event.before }}"
+          ARGS=(--emit-github-output)
+          if [ "${{ inputs.force_run_all }}" = "true" ] \
+              || [ -z "$BASE_REF" ] \
+              || [ "$BASE_REF" = "0000000000000000000000000000000000000000" ]; then
+            ARGS+=(--force-run-all)
+          else
+            ARGS+=(--base-ref "$BASE_REF")
+          fi
+          python3 infra/ci/select_tests.py "${ARGS[@]}"
+
+  unit:
+    needs: select
+    if: ${{ needs.select.outputs.matrix != '[]' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        include: ${{ fromJSON(needs.select.outputs.matrix) }}
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: astral-sh/setup-uv@v7
+        with:
+          python-version: "3.12"
+
+      - id: prepare
+        run: |
+          python3 infra/ci/prepare.py \
+            "${{ matrix.package }}" \
+            --tests "${{ join(matrix.tests, ' ') }}"
+
+      - run: >-
+          uv run
+          --package ${{ steps.prepare.outputs.package }}
+          ${{ steps.prepare.outputs.extras }}
+          --group test
+          pytest --durations=5 -n auto --dist=worksteal --tb=short
+          ${{ steps.prepare.outputs.test_paths }}
+
+  aggregate:
+    needs: unit
+    if: always()
+    runs-on: ubuntu-latest
+    steps:
+      - run: |
+          case "${{ needs.unit.result }}" in
+            success|skipped) exit 0 ;;
+            *) exit 1 ;;
+          esac

--- a/infra/ci/__init__.py
+++ b/infra/ci/__init__.py
@@ -1,0 +1,2 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0

--- a/infra/ci/prepare.py
+++ b/infra/ci/prepare.py
@@ -1,0 +1,63 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Emit uv/pytest arguments for a unified-unit.yaml leg as GitHub Actions step outputs.
+
+Usage:
+    python infra/ci/prepare.py <scope> [--tests "path1 path2 ..."]
+
+Outputs (to $GITHUB_OUTPUT or stdout):
+    package     uv package name (e.g. marin-core)
+    extras      --extra flags (e.g. "--extra cpu --extra dedup"), may be empty
+    test_paths  space-separated test paths, or the full suite dir if none given
+"""
+
+import argparse
+import os
+
+SYNC_PACKAGE: dict[str, str] = {
+    "rigging": "marin-rigging",
+    "finelog": "marin-finelog",
+    "haliax": "marin-haliax",
+    "iris": "marin-iris",
+    "fray": "marin-fray",
+    "levanter": "marin-levanter",
+    "zephyr": "marin-zephyr",
+    "marin": "marin-core",
+}
+
+# levanter's torch_test extra is intentionally omitted: torch/TPU legs stay in levanter-unit.yaml.
+SYNC_EXTRAS: dict[str, list[str]] = {
+    "marin": ["cpu", "dedup"],
+}
+
+TEST_DIR: dict[str, str] = {
+    **{s: f"lib/{s}/tests" for s in SYNC_PACKAGE if s != "marin"},
+    "marin": "tests",
+}
+
+
+def emit_outputs(outputs: dict[str, str]) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT", "")
+    if github_output:
+        with open(github_output, "a") as f:
+            for k, v in outputs.items():
+                f.write(f"{k}={v}\n")
+    else:
+        for k, v in outputs.items():
+            print(f"{k}={v}")
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Emit uv/pytest args for a CI leg.")
+    parser.add_argument("scope", choices=list(SYNC_PACKAGE))
+    parser.add_argument("--tests", default="", help="Space-separated test file paths")
+    args = parser.parse_args()
+
+    extras = " ".join(f"--extra {e}" for e in SYNC_EXTRAS.get(args.scope, []))
+    test_paths = args.tests.strip() or TEST_DIR[args.scope]
+
+    emit_outputs({"package": SYNC_PACKAGE[args.scope], "extras": extras, "test_paths": test_paths})
+
+
+if __name__ == "__main__":
+    main()

--- a/infra/ci/select_tests.py
+++ b/infra/ci/select_tests.py
@@ -1,0 +1,352 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+"""Select which tests to run based on changed files.
+
+Computes a precise test matrix from the diff between HEAD and a base ref using
+top-level import analysis: only imports at module scope (not inside def/class bodies
+or TYPE_CHECKING blocks) propagate test impact, matching the codebase's "no lazy
+imports" convention.
+
+Usage:
+    python infra/ci/select_tests.py --base-ref <SHA> [--emit-github-output]
+    python infra/ci/select_tests.py --force-run-all [--emit-github-output]
+"""
+
+import argparse
+import ast
+import json
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+
+# Ordered list of workspace member short names.
+SCOPES: tuple[str, ...] = (
+    "rigging",
+    "finelog",
+    "haliax",
+    "iris",
+    "fray",
+    "levanter",
+    "zephyr",
+    "marin",
+)
+
+# Files whose change triggers running every package's full test suite.
+BROAD_TRIGGERS: frozenset[str] = frozenset(
+    {
+        "uv.lock",
+        "pyproject.toml",
+        "infra/ci/select_tests.py",
+        "infra/ci/prepare.py",
+        ".github/workflows/unified-unit.yaml",
+    }
+)
+
+
+# ---------------------------------------------------------------------------
+# Pure helpers
+# ---------------------------------------------------------------------------
+
+
+def top_level_imports(path: Path, module_name: str | None = None) -> set[str]:
+    """Dotted module names from top-level import statements only.
+
+    Skips imports inside def/class bodies and if TYPE_CHECKING blocks.
+    Returns empty set on parse errors.
+    """
+    try:
+        tree = ast.parse(path.read_text(encoding="utf-8", errors="replace"), filename=str(path))
+    except SyntaxError:
+        return set()
+    result: set[str] = set()
+    for node in tree.body:
+        if isinstance(node, ast.Import):
+            for alias in node.names:
+                result.add(alias.name)
+        elif isinstance(node, ast.ImportFrom):
+            if node.level > 0:
+                if module_name is not None:
+                    # Determine parent package
+                    if path.name == "__init__.py":
+                        package = module_name
+                    else:
+                        package = module_name.rsplit(".", 1)[0] if "." in module_name else ""
+
+                    parts = package.split(".") if package else []
+                    up = node.level - 1
+                    if up <= len(parts):
+                        base_parts = parts[:-up] if up > 0 else parts
+                        if node.module:
+                            result.add(".".join(base_parts + node.module.split(".")))
+                        else:
+                            for alias in node.names:
+                                result.add(".".join([*base_parts, alias.name]))
+                else:
+                    if node.module:
+                        result.add(node.module)
+            elif node.module:
+                result.add(node.module)
+    return result
+
+
+def path_to_module(path: Path, scope: str, repo_root: Path) -> str | None:
+    """Map a source .py file to its dotted module name, or None if not applicable.
+
+    lib/levanter/src/levanter/store/cache.py -> levanter.store.cache
+    """
+    src_root = repo_root / f"lib/{scope}/src"
+    try:
+        rel = path.relative_to(src_root)
+    except ValueError:
+        return None
+    parts = list(rel.with_suffix("").parts)
+    if parts and parts[-1] == "__init__":
+        parts = parts[:-1]
+    return ".".join(parts) if parts else None
+
+
+def imports_touch_affected(imports: set[str], affected: set[str]) -> bool:
+    """True if any imported name overlaps with an affected module.
+
+    Three cases:
+    - exact match: imp == aff
+    - imp is a parent package: aff.startswith(imp + ".")  e.g. imp="levanter.store", aff="levanter.store.cache"
+    - imp is a child of aff: imp.startswith(aff + ".")  e.g. imp="levanter.store.cache", aff="levanter.store"
+      (Python executes __init__.py of every parent package when loading a child, so a change
+      to levanter/store/__init__.py affects anything that imports levanter.store.cache)
+    """
+    for imp in imports:
+        for aff in affected:
+            if aff == imp or aff.startswith(imp + ".") or imp.startswith(aff + "."):
+                return True
+    return False
+
+
+def downstream_modules(seeds: set[str], reverse: dict[str, set[str]]) -> set[str]:
+    """BFS: all modules that transitively depend on any seed module."""
+    visited = set(seeds)
+    queue = list(seeds)
+    while queue:
+        mod = queue.pop()
+        for dep in reverse.get(mod, ()):
+            if dep not in visited:
+                visited.add(dep)
+                queue.append(dep)
+    return visited
+
+
+# ---------------------------------------------------------------------------
+# Workspace graph
+# ---------------------------------------------------------------------------
+
+
+def build_reverse_deps(repo_root: Path) -> dict[str, set[str]]:
+    """Build a top-level-import reverse-dependency map across all workspace source files.
+
+    reverse[M] = {modules that import M at the top level of their source files}
+    """
+    reverse: dict[str, set[str]] = defaultdict(set)
+    for scope in SCOPES:
+        src = repo_root / f"lib/{scope}/src"
+        if not src.exists():
+            continue
+        for py in src.rglob("*.py"):
+            mod = path_to_module(py, scope, repo_root)
+            if mod is None:
+                continue
+            for imp in top_level_imports(py, module_name=mod):
+                reverse[imp].add(mod)
+    return dict(reverse)
+
+
+def all_test_files(scope: str, repo_root: Path) -> list[Path]:
+    """All .py files in a scope's test directory, excluding conftest.py."""
+    test_dir = repo_root / "tests" if scope == "marin" else repo_root / f"lib/{scope}/tests"
+    if not test_dir.exists():
+        return []
+    return sorted(p for p in test_dir.rglob("*.py") if p.name != "conftest.py")
+
+
+# ---------------------------------------------------------------------------
+# Diff analysis
+# ---------------------------------------------------------------------------
+
+
+def git_changed_files(base_ref: str, repo_root: Path) -> list[str]:
+    """Files changed between base_ref and HEAD (repo-root-relative POSIX paths)."""
+    result = subprocess.run(
+        ["git", "diff", "--name-only", f"{base_ref}...HEAD"],
+        capture_output=True,
+        text=True,
+        cwd=repo_root,
+        check=True,
+    )
+    return [line for line in result.stdout.splitlines() if line.strip()]
+
+
+def classify(
+    changed_files: list[str],
+    repo_root: Path,
+) -> tuple[bool, set[str], dict[str, list[str]], set[str]]:
+    """Classify repo-root-relative changed file paths.
+
+    Returns:
+        broad: True if any broad trigger was found (run everything)
+        src_modules: dotted module names of changed source files
+        direct_tests: {scope: [repo-root-relative test file paths]}
+        forced: scopes that must run their full test suite
+    """
+    broad = False
+    src_modules: set[str] = set()
+    direct_tests: dict[str, list[str]] = defaultdict(list)
+    forced: set[str] = set()
+
+    for filepath in changed_files:
+        p = Path(filepath)
+
+        if filepath in BROAD_TRIGGERS:
+            broad = True
+            continue
+
+        # Scope-specific paths
+        for scope in SCOPES:
+            src_prefix = f"lib/{scope}/src/"
+            test_prefix = "tests/" if scope == "marin" else f"lib/{scope}/tests/"
+
+            if filepath.startswith(src_prefix) and filepath.endswith(".py"):
+                mod = path_to_module(repo_root / filepath, scope, repo_root)
+                if mod:
+                    src_modules.add(mod)
+                break
+
+            if filepath.startswith(test_prefix):
+                if p.name == "conftest.py":
+                    forced.add(scope)
+                elif p.suffix == ".py":
+                    direct_tests[scope].append(filepath)
+                else:
+                    # Non-Python test asset (snapshot, fixture, data file): run the full
+                    # scope so the tests that own this file are not missed.
+                    forced.add(scope)
+                break
+
+            # Per-package root files that can change test behavior
+            if filepath in (f"lib/{scope}/conftest.py", f"lib/{scope}/pyproject.toml"):
+                forced.add(scope)
+                break
+
+    return broad, src_modules, dict(direct_tests), forced
+
+
+# ---------------------------------------------------------------------------
+# Test selection
+# ---------------------------------------------------------------------------
+
+
+def compute_matrix(
+    src_modules: set[str],
+    direct_tests: dict[str, list[str]],
+    forced_scopes: set[str],
+    repo_root: Path,
+) -> list[dict]:
+    """Compute the test matrix.
+
+    Returns a list of {package, tests} dicts. tests=[] means run the full suite.
+    """
+    if not (src_modules or direct_tests or forced_scopes):
+        return []
+
+    reverse = build_reverse_deps(repo_root)
+    affected = downstream_modules(src_modules, reverse) if src_modules else set()
+
+    forced_set = set(forced_scopes)
+    matrix: list[dict] = []
+
+    for scope in SCOPES:
+        if scope in forced_set:
+            matrix.append({"package": scope, "tests": []})
+            continue
+
+        selected: list[str] = []
+
+        for t in direct_tests.get(scope, []):
+            if t not in selected:
+                selected.append(t)
+
+        if affected:
+            for test_file in all_test_files(scope, repo_root):
+                rel = str(test_file.relative_to(repo_root))
+                if rel in selected:
+                    continue
+                if imports_touch_affected(top_level_imports(test_file), affected):
+                    selected.append(rel)
+
+        if selected:
+            matrix.append({"package": scope, "tests": sorted(selected)})
+
+    return matrix
+
+
+def full_matrix() -> list[dict]:
+    """Matrix for --force-run-all: every scope with tests=[] (full suite)."""
+    return [{"package": scope, "tests": []} for scope in SCOPES]
+
+
+# ---------------------------------------------------------------------------
+# Output
+# ---------------------------------------------------------------------------
+
+
+def write_github_output(matrix_json: str) -> None:
+    github_output = os.environ.get("GITHUB_OUTPUT", "")
+    if github_output:
+        with open(github_output, "a") as f:
+            f.write(f"matrix={matrix_json}\n")
+    else:
+        print(f"matrix={matrix_json}", file=sys.stderr)
+
+
+# ---------------------------------------------------------------------------
+# Entry point
+# ---------------------------------------------------------------------------
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Select tests to run from a diff against a base ref.")
+    mode = parser.add_mutually_exclusive_group(required=True)
+    mode.add_argument("--base-ref", metavar="SHA", help="Git SHA or ref to diff HEAD against")
+    mode.add_argument(
+        "--force-run-all",
+        action="store_true",
+        help="Bypass the analyzer; run every package's full suite",
+    )
+    parser.add_argument(
+        "--emit-github-output",
+        action="store_true",
+        help="Write matrix=<json> to $GITHUB_OUTPUT",
+    )
+    args = parser.parse_args()
+
+    repo_root = Path(__file__).parent.parent.parent
+
+    if args.force_run_all:
+        result = {"run_all": True, "reason": "force-run-all", "matrix": full_matrix()}
+    else:
+        changed = git_changed_files(args.base_ref, repo_root)
+        broad, src_modules, direct_tests, forced_scopes = classify(changed, repo_root)
+        if broad:
+            result = {"run_all": True, "reason": "broad-trigger", "matrix": full_matrix()}
+        else:
+            matrix = compute_matrix(src_modules, direct_tests, forced_scopes, repo_root)
+            result = {"run_all": False, "reason": "diff-driven", "matrix": matrix}
+
+    print(json.dumps(result, indent=2))
+
+    if args.emit_github_output:
+        write_github_output(json.dumps(result["matrix"]))
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/finelog/tests/test_deploy_cli.py
+++ b/lib/finelog/tests/test_deploy_cli.py
@@ -7,8 +7,9 @@ The CLI command itself opens a real connection (gcsfs in production); these
 tests cover the testable seams against a local parquet directory.
 """
 
-import os
+from contextlib import contextmanager
 from pathlib import Path
+from unittest.mock import patch
 
 import duckdb
 import fsspec
@@ -27,6 +28,22 @@ def _write_segment(path: Path, level: int, seq: int, rows: list[dict[str, object
     out = path / f"seg_L{level}_{seq:019d}.parquet"
     pq.write_table(pa.Table.from_pylist(rows), out)
     return out
+
+
+@contextmanager
+def _stub_file_timestamps(timestamps: dict[str, int]):
+    """Stub _info_time_created_ms to return fixed epoch_ms values keyed by filename.
+
+    os.utime controls mtime but not ctime on Linux (the kernel always resets ctime
+    to now on any metadata change), so tests that rely on time-window filtering must
+    inject timestamps at the abstraction boundary instead of via the filesystem.
+    """
+
+    def _stubbed(info: dict) -> int | None:
+        return timestamps.get(Path(str(info.get("name", ""))).name)
+
+    with patch("finelog.deploy.cli._info_time_created_ms", side_effect=_stubbed):
+        yield
 
 
 def test_list_namespace_dirs_keeps_only_dirs_with_segments(tmp_path: Path) -> None:
@@ -58,13 +75,12 @@ def test_list_namespace_segments_filters_by_time_created(tmp_path: Path) -> None
     ns_dir = tmp_path / "log"
     old = _write_segment(ns_dir, level=1, seq=1, rows=[{"x": 1}])
     new = _write_segment(ns_dir, level=1, seq=2, rows=[{"x": 2}])
-    os.utime(old, (1_700_000_000.0, 1_700_000_000.0))
-    os.utime(new, (1_800_000_000.0, 1_800_000_000.0))
 
     fs, _ = fsspec.url_to_fs(str(tmp_path))
-    after = _list_namespace_segments(
-        str(tmp_path), "log", fs, created_since_ms=1_750_000_000 * 1000, created_until_ms=None
-    )
+    with _stub_file_timestamps({old.name: 1_700_000_000_000, new.name: 1_800_000_000_000}):
+        after = _list_namespace_segments(
+            str(tmp_path), "log", fs, created_since_ms=1_750_000_000 * 1000, created_until_ms=None
+        )
     assert [p.split("/")[-1] for p in after] == [new.name]
 
 
@@ -74,19 +90,18 @@ def test_register_namespace_views_with_time_window_only_reads_matching_files(tmp
     ns_dir = tmp_path / "log"
     old = _write_segment(ns_dir, level=1, seq=1, rows=[{"key": "/old", "data": "old"}])
     new = _write_segment(ns_dir, level=1, seq=2, rows=[{"key": "/new", "data": "new"}])
-    os.utime(old, (1_700_000_000.0, 1_700_000_000.0))
-    os.utime(new, (1_800_000_000.0, 1_800_000_000.0))
 
     fs, _ = fsspec.url_to_fs(str(tmp_path))
     conn = duckdb.connect()
-    _register_namespace_views(
-        conn,
-        str(tmp_path),
-        ["log"],
-        fs=fs,
-        created_since_ms=1_750_000_000 * 1000,
-        created_until_ms=None,
-    )
+    with _stub_file_timestamps({old.name: 1_700_000_000_000, new.name: 1_800_000_000_000}):
+        _register_namespace_views(
+            conn,
+            str(tmp_path),
+            ["log"],
+            fs=fs,
+            created_since_ms=1_750_000_000 * 1000,
+            created_until_ms=None,
+        )
     assert conn.execute("SELECT key FROM log").fetchall() == [("/new",)]
 
 
@@ -94,17 +109,17 @@ def test_register_namespace_views_empty_filter_skips_view(tmp_path: Path) -> Non
     """When the filter drops every file, no view is created and a SELECT
     fails — better than silently scanning all files."""
     f = _write_segment(tmp_path / "log", level=1, seq=1, rows=[{"key": "/k", "data": "v"}])
-    os.utime(f, (1_700_000_000.0, 1_700_000_000.0))
 
     fs, _ = fsspec.url_to_fs(str(tmp_path))
     conn = duckdb.connect()
-    _register_namespace_views(
-        conn,
-        str(tmp_path),
-        ["log"],
-        fs=fs,
-        created_since_ms=1_800_000_000 * 1000,
-        created_until_ms=None,
-    )
+    with _stub_file_timestamps({f.name: 1_700_000_000_000}):
+        _register_namespace_views(
+            conn,
+            str(tmp_path),
+            ["log"],
+            fs=fs,
+            created_since_ms=1_800_000_000 * 1000,
+            created_until_ms=None,
+        )
     with pytest.raises(duckdb.CatalogException):
         conn.execute("SELECT * FROM log").fetchall()

--- a/lib/fray/pyproject.toml
+++ b/lib/fray/pyproject.toml
@@ -16,6 +16,7 @@ dependencies = [
 test = [
     "pytest-timeout",
     "pytest>=8.3.2",
+    "pytest-xdist",
 ]
 fray_tpu_test = ["jax==0.10.1", "jaxlib==0.10.1", "libtpu==0.0.41", { include-group = "test" }]
 

--- a/lib/rigging/pyproject.toml
+++ b/lib/rigging/pyproject.toml
@@ -27,6 +27,7 @@ test = [
     "pytest>=8.3.2",
     "pytest-asyncio",
     "pytest-timeout",
+    "pytest-xdist",
 ]
 dev = [{ include-group = "test" }]
 

--- a/tests/infra/ci/test_select_tests.py
+++ b/tests/infra/ci/test_select_tests.py
@@ -1,0 +1,366 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+import textwrap
+from pathlib import Path
+
+from infra.ci.select_tests import (
+    SCOPES,
+    classify,
+    compute_matrix,
+    downstream_modules,
+    full_matrix,
+    imports_touch_affected,
+    path_to_module,
+    top_level_imports,
+)
+
+# ---------------------------------------------------------------------------
+# top_level_imports
+# ---------------------------------------------------------------------------
+
+
+def test_top_level_imports_regular_import(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text("import os\nimport sys\n")
+    assert top_level_imports(f) == {"os", "sys"}
+
+
+def test_top_level_imports_from_import(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text("from pathlib import Path\nfrom levanter.store import cache\n")
+    assert top_level_imports(f) == {"pathlib", "levanter.store"}
+
+
+def test_top_level_imports_skips_function_body(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text(
+        textwrap.dedent(
+            """\
+        import os
+        def foo():
+            import sys
+            from levanter import store
+        """
+        )
+    )
+    assert top_level_imports(f) == {"os"}
+
+
+def test_top_level_imports_skips_type_checking(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text(
+        textwrap.dedent(
+            """\
+        from __future__ import annotations
+        from typing import TYPE_CHECKING
+        if TYPE_CHECKING:
+            from levanter.store import cache
+        """
+        )
+    )
+    assert "levanter.store" not in top_level_imports(f)
+
+
+def test_top_level_imports_skips_class_body(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text(
+        textwrap.dedent(
+            """\
+        import os
+        class Foo:
+            import bar
+        """
+        )
+    )
+    assert top_level_imports(f) == {"os"}
+
+
+def test_top_level_imports_syntax_error_returns_empty(tmp_path):
+    f = tmp_path / "mod.py"
+    f.write_text("def (broken:\n")
+    assert top_level_imports(f) == set()
+
+
+def test_top_level_imports_relative_imports(tmp_path):
+    # Case 1: normal module, level 1 relative import
+    f1 = tmp_path / "core.py"
+    f1.write_text("from .axis import Axis\n")
+    assert top_level_imports(f1, module_name="haliax.core") == {"haliax.axis"}
+
+    # Case 2: __init__.py, level 1 relative import with module None
+    f2 = tmp_path / "__init__.py"
+    f2.write_text("from . import axis\n")
+    assert top_level_imports(f2, module_name="haliax") == {"haliax.axis"}
+
+    # Case 3: nested module, level 2 relative import
+    f3 = tmp_path / "einsum.py"
+    f3.write_text("from ..core import NamedArray\n")
+    assert top_level_imports(f3, module_name="haliax._src.einsum") == {"haliax.core"}
+
+    # Case 4: __init__.py, level 1 relative import of a sub-module
+    f4 = tmp_path / "__init__.py"
+    f4.write_text("from ._src.dot import dot\n")
+    assert top_level_imports(f4, module_name="haliax") == {"haliax._src.dot"}
+
+    # Fallback when module_name is None
+    assert top_level_imports(f1, module_name=None) == {"axis"}
+
+
+# ---------------------------------------------------------------------------
+# path_to_module
+# ---------------------------------------------------------------------------
+
+
+def test_path_to_module_basic(tmp_path):
+    path = tmp_path / "lib/levanter/src/levanter/store/cache.py"
+    path.parent.mkdir(parents=True)
+    path.touch()
+    assert path_to_module(path, "levanter", tmp_path) == "levanter.store.cache"
+
+
+def test_path_to_module_init_file(tmp_path):
+    path = tmp_path / "lib/iris/src/iris/__init__.py"
+    path.parent.mkdir(parents=True)
+    path.touch()
+    assert path_to_module(path, "iris", tmp_path) == "iris"
+
+
+def test_path_to_module_nested(tmp_path):
+    path = tmp_path / "lib/marin/src/marin/training/trainer.py"
+    path.parent.mkdir(parents=True)
+    path.touch()
+    assert path_to_module(path, "marin", tmp_path) == "marin.training.trainer"
+
+
+def test_path_to_module_wrong_scope_returns_none(tmp_path):
+    path = tmp_path / "lib/iris/src/iris/controller.py"
+    path.parent.mkdir(parents=True)
+    path.touch()
+    assert path_to_module(path, "levanter", tmp_path) is None
+
+
+# ---------------------------------------------------------------------------
+# imports_touch_affected
+# ---------------------------------------------------------------------------
+
+
+def test_imports_touch_affected_exact_match():
+    assert imports_touch_affected({"levanter.store.cache"}, {"levanter.store.cache"})
+
+
+def test_imports_touch_affected_parent_package():
+    # "from levanter.store import cache" gives imp="levanter.store"; affected="levanter.store.cache"
+    assert imports_touch_affected({"levanter.store"}, {"levanter.store.cache"})
+
+
+def test_imports_touch_affected_top_level_package():
+    assert imports_touch_affected({"levanter"}, {"levanter.store.cache"})
+
+
+def test_imports_touch_affected_no_match():
+    assert not imports_touch_affected({"zephyr.writers"}, {"levanter.store.cache"})
+
+
+def test_imports_touch_affected_empty_imports():
+    assert not imports_touch_affected(set(), {"levanter.store.cache"})
+
+
+def test_imports_touch_affected_child_of_affected():
+    # __init__.py change: affected="levanter.store"; test imports "levanter.store.cache"
+    # Python runs levanter/store/__init__.py before loading cache, so test must be selected.
+    assert imports_touch_affected({"levanter.store.cache"}, {"levanter.store"})
+
+
+# ---------------------------------------------------------------------------
+# downstream_modules
+# ---------------------------------------------------------------------------
+
+
+def test_downstream_modules_direct():
+    reverse = {"a": {"b"}}
+    assert downstream_modules({"a"}, reverse) >= {"a", "b"}
+
+
+def test_downstream_modules_transitive():
+    reverse = {"a": {"b"}, "b": {"c"}}
+    assert downstream_modules({"a"}, reverse) == {"a", "b", "c"}
+
+
+def test_downstream_modules_no_downstream():
+    result = downstream_modules({"z"}, {"x": {"y"}})
+    assert result == {"z"}
+
+
+# ---------------------------------------------------------------------------
+# classify
+# ---------------------------------------------------------------------------
+
+
+def test_classify_uv_lock_is_broad_trigger(tmp_path):
+    broad, _, _, _ = classify(["uv.lock"], tmp_path)
+    assert broad
+
+
+def test_classify_root_pyproject_is_broad_trigger(tmp_path):
+    broad, _, _, _ = classify(["pyproject.toml"], tmp_path)
+    assert broad
+
+
+def test_classify_self_is_broad_trigger(tmp_path):
+    broad, _, _, _ = classify(["infra/ci/select_tests.py"], tmp_path)
+    assert broad
+
+
+def test_classify_unified_unit_workflow_is_broad_trigger(tmp_path):
+    broad, _, _, _ = classify([".github/workflows/unified-unit.yaml"], tmp_path)
+    assert broad
+
+
+def test_classify_other_workflow_is_ignored(tmp_path):
+    broad, modules, direct, forced = classify([".github/workflows/marin-unit.yaml"], tmp_path)
+    assert not broad
+    assert not modules
+    assert not direct
+    assert not forced
+
+
+def test_classify_source_file_extracts_module(tmp_path):
+    src = tmp_path / "lib/levanter/src/levanter/store/cache.py"
+    src.parent.mkdir(parents=True)
+    src.touch()
+    _, modules, _, _ = classify(["lib/levanter/src/levanter/store/cache.py"], tmp_path)
+    assert "levanter.store.cache" in modules
+
+
+def test_classify_direct_test_file(tmp_path):
+    _, _, direct, _ = classify(["lib/iris/tests/test_cluster.py"], tmp_path)
+    assert "lib/iris/tests/test_cluster.py" in direct.get("iris", [])
+
+
+def test_classify_non_python_test_asset_forces_scope(tmp_path):
+    # A snapshot or fixture file under tests/ must force the full scope, not be
+    # passed as a pytest target (which would cause a collection error).
+    broad, _, direct, forced = classify(["tests/snapshots/expected/simple.md"], tmp_path)
+    assert not broad
+    assert "marin" in forced
+    assert "simple.md" not in str(direct)
+
+
+def test_classify_marin_direct_test(tmp_path):
+    _, _, direct, _ = classify(["tests/test_something.py"], tmp_path)
+    assert "tests/test_something.py" in direct.get("marin", [])
+
+
+def test_classify_scope_conftest_forces_scope(tmp_path):
+    _, _, _, forced = classify(["lib/iris/conftest.py"], tmp_path)
+    assert "iris" in forced
+
+
+def test_classify_tests_conftest_forces_scope(tmp_path):
+    _, _, _, forced = classify(["lib/iris/tests/conftest.py"], tmp_path)
+    assert "iris" in forced
+
+
+def test_classify_empty_diff(tmp_path):
+    broad, modules, direct, forced = classify([], tmp_path)
+    assert not broad
+    assert not modules
+    assert not direct
+    assert not forced
+
+
+# ---------------------------------------------------------------------------
+# full_matrix
+# ---------------------------------------------------------------------------
+
+
+def test_full_matrix_contains_all_scopes():
+    matrix = full_matrix()
+    packages = {e["package"] for e in matrix}
+    assert packages == set(SCOPES)
+
+
+def test_full_matrix_all_tests_empty():
+    for entry in full_matrix():
+        assert entry["tests"] == []
+
+
+# ---------------------------------------------------------------------------
+# compute_matrix integration
+# ---------------------------------------------------------------------------
+
+
+def _make_workspace(tmp_path: Path) -> None:
+    """Create a minimal fake workspace for integration tests."""
+    # rigging: timing.py (source), test_timing.py (imports it), test_other.py (doesn't)
+    (tmp_path / "lib/rigging/src/rigging").mkdir(parents=True)
+    (tmp_path / "lib/rigging/src/rigging/timing.py").write_text("# timing\n")
+    (tmp_path / "lib/rigging/src/rigging/other.py").write_text("# other\n")
+
+    (tmp_path / "lib/rigging/tests").mkdir(parents=True)
+    (tmp_path / "lib/rigging/tests/test_timing.py").write_text("from rigging import timing\n")
+    (tmp_path / "lib/rigging/tests/test_other.py").write_text("import rigging.other\n")
+
+    # iris: controller.py imports rigging.timing
+    (tmp_path / "lib/iris/src/iris").mkdir(parents=True)
+    (tmp_path / "lib/iris/src/iris/controller.py").write_text("import rigging.timing\n")
+    (tmp_path / "lib/iris/tests").mkdir(parents=True)
+    (tmp_path / "lib/iris/tests/test_controller.py").write_text("from iris import controller\n")
+
+
+def test_compute_matrix_empty_returns_empty(tmp_path):
+    assert compute_matrix(set(), {}, set(), tmp_path) == []
+
+
+def test_compute_matrix_direct_test(tmp_path):
+    direct = {"iris": ["lib/iris/tests/test_foo.py"]}
+    matrix = compute_matrix(set(), direct, set(), tmp_path)
+    assert len(matrix) == 1
+    assert matrix[0]["package"] == "iris"
+    assert "lib/iris/tests/test_foo.py" in matrix[0]["tests"]
+
+
+def test_compute_matrix_forced_scope(tmp_path):
+    matrix = compute_matrix(set(), {}, {"levanter"}, tmp_path)
+    assert len(matrix) == 1
+    assert matrix[0] == {"package": "levanter", "tests": []}
+
+
+def test_compute_matrix_import_driven(tmp_path):
+    _make_workspace(tmp_path)
+    # rigging.timing changed: test_timing.py imports it (selected); test_other.py doesn't (skipped)
+    matrix = compute_matrix({"rigging.timing"}, {}, set(), tmp_path)
+    rigging = next((e for e in matrix if e["package"] == "rigging"), None)
+    assert rigging is not None
+    assert "lib/rigging/tests/test_timing.py" in rigging["tests"]
+    assert "lib/rigging/tests/test_other.py" not in rigging["tests"]
+
+
+def test_compute_matrix_transitive_cross_scope(tmp_path):
+    _make_workspace(tmp_path)
+    # rigging.timing changed; iris.controller imports rigging.timing;
+    # test_controller.py imports iris.controller -> selected
+    matrix = compute_matrix({"rigging.timing"}, {}, set(), tmp_path)
+    iris = next((e for e in matrix if e["package"] == "iris"), None)
+    assert iris is not None
+    assert "lib/iris/tests/test_controller.py" in iris["tests"]
+
+
+def test_compute_matrix_lazy_import_not_propagated(tmp_path):
+    # zephyr.writers has a lazy import of rigging.timing inside a function
+    (tmp_path / "lib/rigging/src/rigging").mkdir(parents=True)
+    (tmp_path / "lib/rigging/src/rigging/timing.py").write_text("# timing\n")
+    (tmp_path / "lib/zephyr/src/zephyr").mkdir(parents=True)
+    (tmp_path / "lib/zephyr/src/zephyr/writers.py").write_text(
+        textwrap.dedent(
+            """\
+        def write():
+            from rigging import timing  # lazy import
+        """
+        )
+    )
+    (tmp_path / "lib/zephyr/tests").mkdir(parents=True)
+    (tmp_path / "lib/zephyr/tests/test_writers.py").write_text("from zephyr import writers\n")
+    matrix = compute_matrix({"rigging.timing"}, {}, set(), tmp_path)
+    zephyr = next((e for e in matrix if e["package"] == "zephyr"), None)
+    assert zephyr is None, "lazy import should not propagate to zephyr tests"

--- a/tests/infra/conftest.py
+++ b/tests/infra/conftest.py
@@ -1,0 +1,11 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+import sys
+from pathlib import Path
+
+# Ensure repo root is on sys.path so `infra.ci.*` is importable.
+# Needed because pytest's --import-mode=importlib doesn't guarantee this even
+# with `pythonpath = ["."]` in pyproject.toml during the collection phase.
+_repo_root = str(Path(__file__).parent.parent.parent)
+if _repo_root not in sys.path:
+    sys.path.insert(0, _repo_root)

--- a/uv.lock
+++ b/uv.lock
@@ -4842,6 +4842,7 @@ dependencies = [
 dev = [
     { name = "pytest" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 fray-tpu-test = [
     { name = "jax" },
@@ -4849,10 +4850,12 @@ fray-tpu-test = [
     { name = "libtpu" },
     { name = "pytest" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 test = [
     { name = "pytest" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -4866,6 +4869,7 @@ requires-dist = [
 dev = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 fray-tpu-test = [
     { name = "jax", specifier = "==0.10.1" },
@@ -4873,10 +4877,12 @@ fray-tpu-test = [
     { name = "libtpu", specifier = "==0.0.41" },
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 test = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 
 [[package]]
@@ -5333,11 +5339,13 @@ dev = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 test = [
     { name = "pytest" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 
 [package.metadata]
@@ -5359,11 +5367,13 @@ dev = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 test = [
     { name = "pytest", specifier = ">=8.3.2" },
     { name = "pytest-asyncio" },
     { name = "pytest-timeout" },
+    { name = "pytest-xdist" },
 ]
 
 [[package]]


### PR DESCRIPTION
Creates a diff-driven analyzer (infra/ci/select_tests.py) that builds a reverse import-dependency graph from top-level AST imports and selects only the tests transitively affected by changed source modules. infra/ci/select_tests.py walks lib/*/src/ to build the reverse-dep map, classifies changed files into source modules / direct tests / forced scopes / broad triggers, then BFS-expands the affected module set and selects test files whose top-level imports touch it. Changes to uv.lock, pyproject.toml, or the infra/ci scripts themselves are broad triggers that run every scope. Other workflow files are ignored; only unified-unit.yaml triggers a broad run.

Creates .github/workflows/unified-unit.yaml is the new orchestrator that fans out a JSON matrix to parallel unit jobs. infra/ci/prepare.py emits three GitHub Actions step outputs (package, extras, test_paths) consumed directly by a uv run command in the unit job

The existing per-package workflows are left in place so we can test this in parallel. They will be removed once this is stable.