### PR TITLE
[docs] Clarify TPU-vLLM fork pin protocols

### DIFF
--- a/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
+++ b/.agents/skills/refresh-tpu-vllm-forks/SKILL.md
@@ -11,9 +11,12 @@ Read first:
 
 ## Mission
 
-Marin maintains forks of `vllm` and `tpu-inference` with required patches.
-Update those forks to the latest tested upstream pair, reconcile Marin overlay
-commits, then open the Marin PR that pins the refreshed fork tips.
+Marin maintains forks of `vllm` and `tpu-inference` with required patches. Use
+this skill to update those forks to the latest tested upstream pair, reconcile
+Marin overlay commits, then open the Marin PR that pins the refreshed fork tips.
+
+Manual fixed-base overlay changes are a separate workflow; see
+`docs/overlay-only-pr.md`.
 
 Example run: [marin-community/marin#6453](https://github.com/marin-community/marin/pull/6453).
 
@@ -166,9 +169,15 @@ Push the finished branch to the corresponding `marin-community` fork.
 
 Update Marin root `pyproject.toml` so `tool.uv.sources` pins exact fork branch
 tip SHAs. Add adjacent compare comments that show the retained overlay commits
-against the selected upstream base:
+against the selected upstream base. Keep the short workflow pointer immediately
+above the TPU-vLLM pins so future editors know which procedure owns the SHAs:
 
 ```toml
+# Changes to TPU-vLLM fork SHAs must follow one of these protocols: if this is a
+# release/LKG refresh, then follow .agents/skills/refresh-tpu-vllm-forks/SKILL.md;
+# if this is a fixed-base overlay PR, then follow
+# .agents/skills/refresh-tpu-vllm-forks/docs/overlay-only-pr.md. PR-head SHAs are
+# temporary and must be replaced by the landed fork main SHA.
 # https://github.com/marin-community/vllm/compare/<vllm-upstream-base-sha>...<vllm-branch-tip-sha>
 vllm = { git = "https://github.com/marin-community/vllm.git", rev = "<vllm-branch-tip-sha>" }
 # https://github.com/marin-community/tpu-inference/compare/<tpu-inference-upstream-base-sha>...<tpu-inference-branch-tip-sha>

--- a/.agents/skills/refresh-tpu-vllm-forks/docs/overlay-only-pr.md
+++ b/.agents/skills/refresh-tpu-vllm-forks/docs/overlay-only-pr.md
@@ -1,0 +1,18 @@
+# Fixed-Base Overlay Fork PR Protocol
+
+Use this when adding or fixing a Marin overlay commit while keeping the current
+upstream base fixed. Do not use it for automated release/LKG refreshes.
+
+1. Branch from the affected fork's current `main`, add the overlay commit(s), and
+   open a fork PR.
+2. If Marin validation is needed, open a Marin draft PR that pins the fork PR
+   head SHA and refreshes `uv.lock`. Treat this pin as temporary.
+3. Run the required Marin validation from the draft PR.
+4. Squash-merge the fork PR, fetch fork `main`, and read the landed squash SHA.
+   Do not assume it matches the pre-merge PR head SHA.
+5. Update the Marin draft PR to pin the landed fork `main` SHA, refresh
+   `uv.lock` and compare comments if needed, rerun focused validation, then
+   undraft.
+
+Final check: `git ls-remote <fork-url> main` must match the relevant
+`tool.uv.sources` `rev`. Repeat per fork when an overlay spans both forks.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -158,6 +158,11 @@ nvidia-cutlass-dsl-libs-cu13 = { index = "nvidia" }
 # NOTE: harbor is a pinned git dependency (not a workspace member).
 # harbor lives in marin-community/harbor as a pinned git dependency.
 harbor = { git = "https://github.com/marin-community/harbor.git", rev = "354692d9c0eab497b05f266aa0dff30e2a238d2e" }
+# Changes to TPU-vLLM fork SHAs must follow one of these protocols: if this is a
+# release/LKG refresh, then follow .agents/skills/refresh-tpu-vllm-forks/SKILL.md;
+# if this is a fixed-base overlay PR, then follow
+# .agents/skills/refresh-tpu-vllm-forks/docs/overlay-only-pr.md. PR-head SHAs are
+# temporary and must be replaced by the landed fork main SHA.
 # https://github.com/marin-community/vllm/compare/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c...04f7da7e26eacb4e8d7e7d2dce6347d2ff90af4d
 vllm = { git = "https://github.com/marin-community/vllm.git", rev = "04f7da7e26eacb4e8d7e7d2dce6347d2ff90af4d" }
 # https://github.com/marin-community/tpu-inference/compare/23d17a8120d9cc34890135599f42e1db4f947c10...808415f45bbfcb512e9c593c4a3330aed115917e


### PR DESCRIPTION
Clarify the TPU-vLLM fork refresh docs by keeping the release/LKG skill scoped to upstream refreshes and moving fixed-base overlay changes into a separate protocol. The root pin comments now make SHA edits conditional: release refreshes follow the refresh skill, overlay PRs follow the overlay protocol, and temporary PR-head SHAs must be replaced with landed fork main SHAs after squash merge.