### PR TITLE
[zephyr] Fix conftest imports

### DIFF
--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -15,6 +15,7 @@ from unittest.mock import MagicMock
 
 import cloudpickle
 import pytest
+from conftest import _TEST_TASK_COST, _TEST_WORKER_AVAILABLE
 from fray import ResourceConfig
 from fray.actor import ActorContext
 from fray.local_backend import LocalClient
@@ -42,8 +43,6 @@ from zephyr.stage_io import (
 )
 from zephyr.stats import ZEPHYR_STAGE_BYTES_PROCESSED_KEY, ZEPHYR_STAGE_ITEM_COUNT_KEY
 from zephyr.worker_context import CounterEntry, CounterSnapshot, zephyr_worker_ctx
-
-from tests.conftest import _TEST_TASK_COST, _TEST_WORKER_AVAILABLE
 
 
 class _UnpicklableError(Exception):

--- a/lib/zephyr/tests/test_worker_group_race.py
+++ b/lib/zephyr/tests/test_worker_group_race.py
@@ -18,11 +18,10 @@ import threading
 import time
 from unittest.mock import MagicMock
 
+from conftest import _TEST_TASK_COST
 from zephyr.shuffle import ListShard
 from zephyr.stage_io import ShardTask, TaskResult
 from zephyr.worker_context import CounterSnapshot
-
-from tests.conftest import _TEST_TASK_COST
 
 
 def test_check_worker_group_skips_after_completed_stage(coordinator):


### PR DESCRIPTION
Introduced in https://github.com/marin-community/marin/pull/6831. This previously worked under pytest but an agent review noted that this is slightly more correct since it works not under pytest as well. Not a big deal, but why not.