### PR TITLE
Make shard consolidation tolerant of duplicate slashes in output path

### DIFF
--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -9,6 +9,7 @@ import gc
 import logging as pylogging
 import operator
 import os
+import re
 import threading
 import time
 from collections.abc import Iterable, Iterator, Mapping
@@ -1378,7 +1379,19 @@ async def _consolidate_metadata(dest_path: str, exemplar: dict, shard_infos: lis
                 raise
 
 
+def _collapse_duplicate_slashes(path: str) -> str:
+    """Collapse duplicate ``/`` in a path while preserving a URL scheme's ``://``.
+
+    Matches the normalization ``zephyr.dataset.format_shard_path`` applies when
+    writing shards, so consolidation is insensitive to a trailing slash in
+    ``MARIN_PREFIX`` (which yields ``//`` after the ``StepSpec`` path join).
+    """
+    return re.sub(r"(?<!:)//+", "/", path)
+
+
 def _relative_shard_path(output_path: str, shard_path: str) -> str:
+    output_path = _collapse_duplicate_slashes(output_path)
+    shard_path = _collapse_duplicate_slashes(shard_path)
     if "://" in output_path or "://" in shard_path:
         prefix = output_path.rstrip("/") + "/"
         if shard_path.startswith(prefix):

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -112,6 +112,16 @@ def test_relative_shard_path_requires_child_uri_paths():
         _relative_shard_path(output_path, external_shard)
 
 
+def test_relative_shard_path_tolerates_double_slash_output():
+    # A trailing slash in MARIN_PREFIX yields a `//` after the StepSpec path join,
+    # while shard writes normalize `//`->`/`. Consolidation must treat both as the
+    # same location instead of raising "not under output path".
+    output_path = "s3://marin-na/marin//slimpajama-6b/2026.06.28/train"
+    shard_path = "s3://marin-na/marin/slimpajama-6b/2026.06.28/train/part-00000-of-00048"
+
+    assert _relative_shard_path(output_path, shard_path) == "part-00000-of-00048"
+
+
 @pytest.mark.asyncio
 async def test_consolidate_external_shards_rejected():
     with tempfile.TemporaryDirectory(prefix="levanter-test-external-shards-") as tmpdir:


### PR DESCRIPTION
Closes #6838.

A trailing slash in `MARIN_PREFIX` produces a `//` after the `StepSpec` path join, while shard writes normalize `//`->`/` via `format_shard_path`. The resulting asymmetry made `_relative_shard_path` reject shards as 'not under output path', crashing tokenize consolidation.

Collapse duplicate slashes (preserving the URL scheme's `://`) on both inputs so consolidation matches the write path's normalization.