### PR TITLE
[iris] Proxy exec/profile for federated jobs through the peer controller

### DIFF
--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -2115,6 +2115,12 @@ class ControllerServiceImpl:
         empty or unknown — the single-backend case and any pre-routing rows."""
         return self._controller.backends.get(backend_id) or self._controller.provider
 
+    def _federated_handle_for_task(self, task_id: JobName) -> reads.FederatedHandle | None:
+        """The SENT federated handle owning ``task_id``'s root job, or ``None`` if
+        that root job runs locally."""
+        with self._db.read_snapshot() as snap:
+            return reads.federated_handle(snap, task_id.root_job)
+
     @property
     def endpoint_service(self) -> EndpointServiceImpl:
         """The leased endpoint registry these RPCs delegate to (shared with the dashboard)."""
@@ -2339,6 +2345,18 @@ class ControllerServiceImpl:
         task = _read_task_with_attempts(self._db, target.task_id)
         if not task:
             raise ConnectError(Code.NOT_FOUND, f"Task {request.target} not found")
+
+        # A federated task's subtree runs on a peer — it has no local worker or
+        # attempt rows. Proxy the profile through the peer controller (which does
+        # its own task->worker resolution) before the local resolution below, so
+        # it is never dispatched to _backend_for_id's local fallback.
+        handle = self._federated_handle_for_task(target.task_id)
+        if handle is not None:
+            return self._controller.federation.proxy_profile(
+                peer_id=handle.peer_id,
+                remote_job_id=handle.remote_job_id,
+                request=request,
+            )
 
         attempt_id = target.attempt_id if target.attempt_id is not None else task.current_attempt_id
         task_worker_id = _task_worker_id(task)
@@ -2673,6 +2691,18 @@ class ControllerServiceImpl:
         task = _read_task_with_attempts(self._db, task_id)
         if not task:
             raise ConnectError(Code.NOT_FOUND, f"Task {request.task_id} not found")
+
+        # A federated task's subtree runs on a peer — it has no local worker or
+        # attempt rows. Proxy the exec through the peer controller (which does its
+        # own task->worker resolution) before the local resolution below, so it is
+        # never dispatched to _backend_for_id's local fallback.
+        handle = self._federated_handle_for_task(task_id)
+        if handle is not None:
+            return self._controller.federation.proxy_exec(
+                peer_id=handle.peer_id,
+                remote_job_id=handle.remote_job_id,
+                request=request,
+            )
 
         worker_request = worker_pb2.Worker.ExecInContainerRequest(
             task_id=request.task_id,

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -87,6 +87,7 @@ from iris.cluster.runtime.profile import (
     profile_local_process,
 )
 from iris.cluster.types import (
+    FEDERATION_DELIMITER,
     TERMINAL_JOB_STATES,
     TERMINAL_TASK_STATES,
     JobName,
@@ -1156,6 +1157,18 @@ class ControllerServiceImpl:
             )
 
         job_id = JobName.from_wire(request.name)
+
+        # '~' is reserved as the federation cluster-dispatch delimiter (it joins a
+        # cluster id to a root name in a handed-off job's remote id), so a user may
+        # not name a job with it — that would be ambiguous with a handed-off root.
+        # Only the job's own leaf name is checked, so a child spawned on a peer under
+        # a '~'-bearing federated root is fine; a received handoff, whose root name IS
+        # the encoded cluster~name, is exempt.
+        if FEDERATION_DELIMITER in job_id.name and not request.HasField("federation"):
+            raise ConnectError(
+                Code.INVALID_ARGUMENT,
+                f"Job name {job_id.name!r} may not contain {FEDERATION_DELIMITER!r} (reserved for federation).",
+            )
 
         # Reject root RPC submissions from stale clients. Direct in-process
         # calls have no wire client; tests and harnesses use ctx=None.

--- a/lib/iris/src/iris/cluster/federation/manager.py
+++ b/lib/iris/src/iris/cluster/federation/manager.py
@@ -33,7 +33,7 @@ from iris.cluster.federation.store import (
     HandoffAdmission,
     HandoffSpec,
 )
-from iris.cluster.types import JobName
+from iris.cluster.types import JobName, TaskAttempt
 from iris.managed_thread import ManagedThread, ThreadContainer
 from iris.rpc import controller_pb2, job_pb2
 
@@ -62,6 +62,21 @@ def encode_remote_job_id(cluster_id: str, parent_job_id: JobName) -> str:
         raise ValueError(f"federation cluster_id must not contain '~' (got {cluster_id!r})")
     root = parent_job_id.root_job
     return JobName.root(root.user, f"{cluster_id}~{root.name}").to_wire()
+
+
+def _rebase_target(target: str, remote_job_id: str) -> str:
+    """Rewrite a task/attempt wire id onto the peer's ``remote_job_id`` root job.
+
+    ``target`` is a :class:`~iris.cluster.types.TaskAttempt` wire string — a full
+    task id (``/user/job/0``) or one with an attempt qualifier (``/user/job/0:3``).
+    Its root job is replaced by ``remote_job_id`` while the child path, task index,
+    and any attempt qualifier are preserved, so the peer resolves the same task in
+    its own tree.
+    """
+    parsed = TaskAttempt.from_wire(target)
+    remote_root = JobName.from_wire(remote_job_id)
+    rebased = TaskAttempt(task_id=parsed.task_id.with_root_job(remote_root), attempt_id=parsed.attempt_id)
+    return rebased.to_wire()
 
 
 class FederationManager:
@@ -147,9 +162,7 @@ class FederationManager:
         """
         if self._store is None:
             raise RuntimeError("federation handoff requires a store")
-        peer = self._peers.get(peer_id)
-        if peer is None:
-            raise ValueError(f"unknown federation peer {peer_id!r}")
+        self._require_peer(peer_id)
 
         remote_job_id = encode_remote_job_id(self._cluster_id, parent_job_id)
         spec = HandoffSpec(
@@ -213,7 +226,57 @@ class FederationManager:
                 exc,
             )
 
+    # -- on-demand proxy (parent side) ---------------------------------------
+
+    def proxy_profile(
+        self,
+        *,
+        peer_id: str,
+        remote_job_id: str,
+        request: job_pb2.ProfileTaskRequest,
+    ) -> job_pb2.ProfileTaskResponse:
+        """Forward a profile RPC for a federated task to its peer controller.
+
+        Rewrites the request's target onto the peer's remote root job (preserving
+        the task index and any attempt qualifier) so the peer resolves the same
+        task in its own tree, then proxies to the peer's ``ProfileTask``. The peer
+        is authoritative: its answer — including a ``NOT_FOUND`` for a task it has
+        since moved or finished — propagates back verbatim.
+        """
+        peer = self._require_peer(peer_id)
+        forwarded = job_pb2.ProfileTaskRequest()
+        forwarded.CopyFrom(request)
+        forwarded.target = _rebase_target(request.target, remote_job_id)
+        return peer.profile_task(forwarded)
+
+    def proxy_exec(
+        self,
+        *,
+        peer_id: str,
+        remote_job_id: str,
+        request: controller_pb2.Controller.ExecInContainerRequest,
+    ) -> controller_pb2.Controller.ExecInContainerResponse:
+        """Forward an exec RPC for a federated task to its peer controller.
+
+        Rewrites the request's task id onto the peer's remote root job (preserving
+        the task index) so the peer resolves the same task in its own tree, then
+        proxies to the peer's ``ExecInContainer``. The peer is authoritative: its
+        answer — including a ``NOT_FOUND`` — propagates back verbatim.
+        """
+        peer = self._require_peer(peer_id)
+        forwarded = controller_pb2.Controller.ExecInContainerRequest()
+        forwarded.CopyFrom(request)
+        forwarded.task_id = _rebase_target(request.task_id, remote_job_id)
+        return peer.exec_in_container(forwarded)
+
     # -- background loops ----------------------------------------------------
+
+    def _require_peer(self, peer_id: str) -> FederationPeer:
+        """The configured peer named ``peer_id``, or raise if it is unknown."""
+        peer = self._peers.get(peer_id)
+        if peer is None:
+            raise ValueError(f"unknown federation peer {peer_id!r}")
+        return peer
 
     def _run_loop(self, stop_event: threading.Event, step: Callable[[], None], interval: float) -> None:
         """Run ``step`` every ``interval`` seconds until ``stop_event`` is set."""

--- a/lib/iris/src/iris/cluster/federation/manager.py
+++ b/lib/iris/src/iris/cluster/federation/manager.py
@@ -47,33 +47,17 @@ _PEER_RPC_ERRORS = (ConnectError, ConnectionError, OSError)
 
 
 def encode_remote_job_id(cluster_id: str, parent_job_id: JobName) -> str:
-    """The deterministic, globally-unique job id a peer runs a handoff under.
-
-    Folds this cluster's id into the root job-name component, keeping a valid
-    two-component root ``JobName`` (``/<user>/<cluster>~<name>``): globally unique
-    because ``cluster_id`` is, deterministic so a re-sent handoff is a same-name
-    submit the peer's KEEP policy dedups, and a legal name component (a name may
-    not contain ``/``). Ownership is never parsed back out of it — the peer reads
-    it from the explicit ``FederationHandoff`` field.
-    """
-    if not cluster_id:
-        raise ValueError("federation cluster_id is required to hand a job off")
-    if "~" in cluster_id:
-        raise ValueError(f"federation cluster_id must not contain '~' (got {cluster_id!r})")
-    root = parent_job_id.root_job
-    return JobName.root(root.user, f"{cluster_id}~{root.name}").to_wire()
+    """The deterministic, globally-unique wire id a peer runs a handoff under:
+    ``parent_job_id``'s root folded under ``cluster_id`` (``/<user>/<cluster>~<name>``)."""
+    return JobName.federated_remote_root(cluster_id, parent_job_id.root_job).to_wire()
 
 
 def _rebase_task_id(task_id: str, remote_job_id: str) -> str:
-    """Rewrite a full task wire id onto the peer's ``remote_job_id`` root job.
-
-    ``task_id`` is a plain task :class:`~iris.cluster.types.JobName`
-    (``/user/job/0``), whose components may legally contain ``:`` — so it is parsed
-    as a ``JobName``, never a ``TaskAttempt`` (which would mis-split a ``:`` in a
-    job name as an attempt qualifier). Its root job is replaced by ``remote_job_id``
-    while the child path and task index are preserved.
-    """
+    """Rewrite a full task wire id (``/user/job/0``) onto ``remote_job_id``'s root job,
+    preserving the child path and task index."""
     remote_root = JobName.from_wire(remote_job_id)
+    # Parse as a JobName, not a TaskAttempt: a ':' is legal in a job-name component,
+    # and TaskAttempt.from_wire would mis-split it as an attempt qualifier.
     return JobName.from_wire(task_id).with_root_job(remote_root).to_wire()
 
 

--- a/lib/iris/src/iris/cluster/federation/manager.py
+++ b/lib/iris/src/iris/cluster/federation/manager.py
@@ -64,14 +64,25 @@ def encode_remote_job_id(cluster_id: str, parent_job_id: JobName) -> str:
     return JobName.root(root.user, f"{cluster_id}~{root.name}").to_wire()
 
 
-def _rebase_target(target: str, remote_job_id: str) -> str:
-    """Rewrite a task/attempt wire id onto the peer's ``remote_job_id`` root job.
+def _rebase_task_id(task_id: str, remote_job_id: str) -> str:
+    """Rewrite a full task wire id onto the peer's ``remote_job_id`` root job.
 
-    ``target`` is a :class:`~iris.cluster.types.TaskAttempt` wire string — a full
-    task id (``/user/job/0``) or one with an attempt qualifier (``/user/job/0:3``).
-    Its root job is replaced by ``remote_job_id`` while the child path, task index,
-    and any attempt qualifier are preserved, so the peer resolves the same task in
-    its own tree.
+    ``task_id`` is a plain task :class:`~iris.cluster.types.JobName`
+    (``/user/job/0``), whose components may legally contain ``:`` — so it is parsed
+    as a ``JobName``, never a ``TaskAttempt`` (which would mis-split a ``:`` in a
+    job name as an attempt qualifier). Its root job is replaced by ``remote_job_id``
+    while the child path and task index are preserved.
+    """
+    remote_root = JobName.from_wire(remote_job_id)
+    return JobName.from_wire(task_id).with_root_job(remote_root).to_wire()
+
+
+def _rebase_profile_target(target: str, remote_job_id: str) -> str:
+    """Rewrite a profile ``target`` onto the peer's ``remote_job_id`` root job.
+
+    ``target`` is a :class:`~iris.cluster.types.TaskAttempt` wire string — a task id
+    with an optional ``:attempt`` qualifier — so the root job is replaced while the
+    child path, task index, and any attempt qualifier are preserved.
     """
     parsed = TaskAttempt.from_wire(target)
     remote_root = JobName.from_wire(remote_job_id)
@@ -246,7 +257,7 @@ class FederationManager:
         peer = self._require_peer(peer_id)
         forwarded = job_pb2.ProfileTaskRequest()
         forwarded.CopyFrom(request)
-        forwarded.target = _rebase_target(request.target, remote_job_id)
+        forwarded.target = _rebase_profile_target(request.target, remote_job_id)
         return peer.profile_task(forwarded)
 
     def proxy_exec(
@@ -266,7 +277,7 @@ class FederationManager:
         peer = self._require_peer(peer_id)
         forwarded = controller_pb2.Controller.ExecInContainerRequest()
         forwarded.CopyFrom(request)
-        forwarded.task_id = _rebase_target(request.task_id, remote_job_id)
+        forwarded.task_id = _rebase_task_id(request.task_id, remote_job_id)
         return peer.exec_in_container(forwarded)
 
     # -- background loops ----------------------------------------------------

--- a/lib/iris/src/iris/cluster/federation/peer.py
+++ b/lib/iris/src/iris/cluster/federation/peer.py
@@ -25,26 +25,38 @@ from rigging.cluster_manifest import load_manifest
 from rigging.credentials import ClientCredentials, credentials_for
 from rigging.timing import Timestamp
 
+from iris.cluster.backends.rpc.backend import EXEC_IN_CONTAINER_MAX_TIMEOUT
 from iris.cluster.config import PeerConfig
 from iris.cluster.types import JobName
-from iris.rpc import controller_pb2
+from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
 
 # A handoff carries a full request and a peer's cold boot can outrun the default
 # RPC deadline, so deliver LaunchJob with this floor to avoid spurious failures.
 _LAUNCH_JOB_TIMEOUT_FLOOR_MS = 180_000
 
+# A proxied exec/profile does the parent's own local-dispatch work on the peer:
+# the peer resolves task->worker and runs the operation for its full duration.
+# Give the parent->peer hop the peer's own budget plus margin for the extra
+# controller hop, so the parent waits out the peer rather than timing out first.
+_PROFILE_PROXY_TIMEOUT_MARGIN_MS = 60_000
+_EXEC_PROXY_TIMEOUT_MARGIN_MS = 60_000
+_DEFAULT_PROFILE_DURATION = 10
+_DEFAULT_EXEC_TIMEOUT = 60
+
 logger = logging.getLogger(__name__)
 
 
 class PeerConnection(Protocol):
     """The peer-controller surface federation drives: capability heartbeat plus
-    the handoff, delta-sync, and routed-cancel RPCs.
+    the handoff, delta-sync, routed-cancel, and proxied on-demand RPCs.
 
     Handoff reuses the ordinary ``LaunchJob`` (the request carries the remote job
     name and federation attribution); a routed cancel reuses ``TerminateJob``
     (targeting the remote job id); ``federation_sync`` is federation's one
-    purpose-built endpoint.
+    purpose-built endpoint; ``profile_task``/``exec_in_container`` proxy an
+    on-demand RPC against a handed-off task through the peer controller, which
+    does its own task->worker resolution.
     """
 
     def list_backends(self) -> list[controller_pb2.Controller.BackendSummary]: ...
@@ -58,6 +70,12 @@ class PeerConnection(Protocol):
     def federation_sync(
         self, request: controller_pb2.Controller.FederationSyncRequest
     ) -> controller_pb2.Controller.FederationSyncResponse: ...
+
+    def profile_task(self, request: job_pb2.ProfileTaskRequest) -> job_pb2.ProfileTaskResponse: ...
+
+    def exec_in_container(
+        self, request: controller_pb2.Controller.ExecInContainerRequest
+    ) -> controller_pb2.Controller.ExecInContainerResponse: ...
 
     def shutdown(self) -> None: ...
 
@@ -116,6 +134,23 @@ class _PeerRpcConnection:
         self, request: controller_pb2.Controller.FederationSyncRequest
     ) -> controller_pb2.Controller.FederationSyncResponse:
         return self._client.federation_sync(request)
+
+    def profile_task(self, request: job_pb2.ProfileTaskRequest) -> job_pb2.ProfileTaskResponse:
+        timeout_ms = (request.duration_seconds or _DEFAULT_PROFILE_DURATION) * 1000 + _PROFILE_PROXY_TIMEOUT_MARGIN_MS
+        return self._client.profile_task(request, timeout_ms=timeout_ms)
+
+    def exec_in_container(
+        self, request: controller_pb2.Controller.ExecInContainerRequest
+    ) -> controller_pb2.Controller.ExecInContainerResponse:
+        # Mirror the worker backend's exec timeout contract (backend.py): a
+        # negative timeout is "no caller limit", which the peer caps at
+        # EXEC_IN_CONTAINER_MAX_TIMEOUT, so the parent->peer hop must outlast that
+        # cap rather than collapse to the margin.
+        if request.timeout_seconds < 0:
+            budget_ms = EXEC_IN_CONTAINER_MAX_TIMEOUT.to_ms()
+        else:
+            budget_ms = (request.timeout_seconds or _DEFAULT_EXEC_TIMEOUT) * 1000
+        return self._client.exec_in_container(request, timeout_ms=budget_ms + _EXEC_PROXY_TIMEOUT_MARGIN_MS)
 
     def shutdown(self) -> None:
         self._client.close()
@@ -182,6 +217,16 @@ class FederationPeer:
     ) -> controller_pb2.Controller.FederationSyncResponse:
         """Run one delta-sync round against the peer."""
         return self._connection.federation_sync(request)
+
+    def profile_task(self, request: job_pb2.ProfileTaskRequest) -> job_pb2.ProfileTaskResponse:
+        """Proxy a profile RPC for a handed-off task to the peer (reuses its ``ProfileTask``)."""
+        return self._connection.profile_task(request)
+
+    def exec_in_container(
+        self, request: controller_pb2.Controller.ExecInContainerRequest
+    ) -> controller_pb2.Controller.ExecInContainerResponse:
+        """Proxy an exec RPC for a handed-off task to the peer (reuses its ``ExecInContainer``)."""
+        return self._connection.exec_in_container(request)
 
     def close(self) -> None:
         """Release the peer connection."""

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -88,6 +88,13 @@ class WellKnownAttribute(StrEnum):
     GPU_COUNT = "gpu-count"
 
 
+# Joins a federation cluster id to a root job name in the globally-unique id a
+# handed-off job runs under on its peer (``/<user>/<cluster>~<name>``, see
+# ``JobName.federated_remote_root``). Reserved: a user-submitted job name may not
+# contain it, so ``cluster~name`` is unambiguous and losslessly reversible.
+FEDERATION_DELIMITER = "~"
+
+
 @dataclass(frozen=True, slots=True)
 class JobName:
     """Structured hierarchical job name.
@@ -163,6 +170,48 @@ class JobName:
         if not root.is_root:
             raise ValueError(f"with_root_job requires a root job, got {root}")
         return JobName((*root._parts, *self._parts[2:]))
+
+    @classmethod
+    def federated_remote_root(cls, cluster_id: str, root: "JobName") -> "JobName":
+        """The remote root a peer runs ``root`` under: ``/<user>/<cluster_id>~<name>``.
+
+        Joins ``cluster_id`` into ``root``'s name with the reserved
+        ``FEDERATION_DELIMITER``, keeping a legal two-component root. ``cluster_id``
+        must be non-empty and delimiter-free and ``root`` must be a root job.
+
+        Example:
+            JobName.federated_remote_root("cw", JobName.from_string("/alice/train"))
+                -> JobName(("alice", "cw~train"))
+        """
+        if not cluster_id:
+            raise ValueError("cluster_id is required to build a federated remote root")
+        if FEDERATION_DELIMITER in cluster_id:
+            raise ValueError(f"cluster_id must not contain {FEDERATION_DELIMITER!r} (got {cluster_id!r})")
+        if not root.is_root:
+            raise ValueError(f"federated_remote_root requires a root job, got {root}")
+        return cls.root(root.user, f"{cluster_id}{FEDERATION_DELIMITER}{root.name}")
+
+    @property
+    def is_federated_remote(self) -> bool:
+        """Whether this name's root was assigned by federation dispatch.
+
+        True iff the root name carries the reserved delimiter — a reliable signal
+        because a user-submitted job name may not contain it.
+        """
+        return FEDERATION_DELIMITER in self.root_job.name
+
+    def split_federated_root(self) -> "tuple[str, JobName]":
+        """The owning cluster id and original pre-handoff root of a federated remote
+        root. Raises ``ValueError`` if this name is not a federated remote root.
+
+        The split is on the first delimiter — ``cluster_id`` is delimiter-free, so a
+        ``~`` in the original name (were one ever allowed) stays with the name.
+        """
+        root = self.root_job
+        cluster_id, sep, name = root.name.partition(FEDERATION_DELIMITER)
+        if not sep:
+            raise ValueError(f"{self} is not a federated remote root")
+        return cluster_id, JobName.root(root.user, name)
 
     @property
     def parent(self) -> "JobName | None":

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -148,6 +148,22 @@ class JobName:
         """
         return JobName((*self._parts, str(index)))
 
+    def with_root_job(self, root: "JobName") -> "JobName":
+        """Return this name with its root job replaced by ``root``.
+
+        Keeps every component below the root — the child path and any task index —
+        so a task or child name resolves to the same node under a differently-named
+        root. ``root`` must itself be a root job (``/<user>/<name>``).
+
+        Example:
+            JobName.from_string("/alice/job/child/0").with_root_job(
+                JobName.from_string("/alice/peer~job")
+            ) -> JobName(("alice", "peer~job", "child", "0"))
+        """
+        if not root.is_root:
+            raise ValueError(f"with_root_job requires a root job, got {root}")
+        return JobName((*root._parts, *self._parts[2:]))
+
     @property
     def parent(self) -> "JobName | None":
         """Get parent job name, or None if this is a root job."""

--- a/lib/iris/tests/cluster/controller/test_federation_exec_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_federation_exec_proxy.py
@@ -140,6 +140,7 @@ def _handoff_and_mirror_running_task(
     parent_service: ControllerServiceImpl,
     peer_state: ControllerTestState,
     manager: FederationManager,
+    name: str = "fed-job",
 ) -> tuple[JobName, JobName]:
     """Hand off a job, drive its peer task to RUNNING, and mirror it back.
 
@@ -147,7 +148,7 @@ def _handoff_and_mirror_running_task(
     then holds a live federated task (``child_cluster`` set, no local worker), the
     exact row an on-demand RPC must proxy rather than resolve locally.
     """
-    response = parent_service.launch_job(_cluster_pinned_request("fed-job"), None)
+    response = parent_service.launch_job(_cluster_pinned_request(name), None)
     parent_job_id = JobName.from_wire(response.job_id)
     remote_job_id = JobName.from_wire(encode_remote_job_id("parent", parent_job_id))
 
@@ -238,6 +239,30 @@ def test_exec_against_a_federated_task_runs_on_the_peer(tmp_path, log_client):
         (call,) = peer_service._controller.provider.exec_in_container.call_args_list
         assert call.args[0].task_id == remote_job_id.task(0).to_wire()
         assert call.args[1].task_id == remote_job_id.task(0).to_wire()
+
+
+def test_exec_rebases_a_task_id_whose_job_name_contains_a_colon(tmp_path, log_client):
+    """A ':' in a job-name component is a legal name char, not an attempt separator
+    for an exec task id — the rebase must parse it as a JobName, not a TaskAttempt."""
+    with ExitStack() as stack:
+        parent_service, _parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _ProxyPeerConnection(peer_service))
+        parent_job_id, remote_job_id = _handoff_and_mirror_running_task(
+            parent_service, peer_state, manager, name="train:debug"
+        )
+
+        peer_service._controller.provider.exec_in_container.return_value = worker_pb2.Worker.ExecInContainerResponse(
+            exit_code=0
+        )
+        resp = parent_service.exec_in_container(
+            controller_pb2.Controller.ExecInContainerRequest(task_id=parent_job_id.task(0).to_wire(), command=["true"]),
+            None,
+        )
+
+        assert resp.exit_code == 0
+        (call,) = peer_service._controller.provider.exec_in_container.call_args_list
+        assert call.args[0].task_id == remote_job_id.task(0).to_wire()
 
 
 def test_exec_surfaces_the_peers_not_found_for_a_stale_mirror(tmp_path, log_client):

--- a/lib/iris/tests/cluster/controller/test_federation_exec_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_federation_exec_proxy.py
@@ -1,0 +1,296 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Exec / profile against a federated job proxy through the peer controller.
+
+Wires two in-process controllers — a parent and a peer — through a delegating
+``PeerConnection`` and drives the on-demand RPC path: a job is handed off, its
+task runs on the peer and mirrors back onto the parent, and a profile / exec
+issued against the parent's mirrored task is forwarded to the peer under the
+peer's own root job id (not run locally). Also covers the race outcomes: the
+peer's live ``NOT_FOUND`` for a task it has since dropped is surfaced verbatim,
+and a tombstoned handle resolves to ``NOT_FOUND`` with no peer round-trip.
+"""
+
+from contextlib import ExitStack
+
+import pytest
+from connectrpc.code import Code
+from connectrpc.errors import ConnectError
+from iris.cluster.bundle import BundleStore
+from iris.cluster.config import PeerConfig
+from iris.cluster.constraints import CLUSTER_CONSTRAINT_KEY, Constraint, ConstraintOp
+from iris.cluster.controller import reads, writes
+from iris.cluster.controller.endpoint_service import EndpointServiceImpl
+from iris.cluster.controller.federation_store import ControllerFederationStore
+from iris.cluster.controller.run_template import RunTemplateCache
+from iris.cluster.controller.service import ControllerServiceImpl
+from iris.cluster.federation.manager import FederationManager, encode_remote_job_id
+from iris.cluster.federation.peer import FederationPeer
+from iris.cluster.types import JobName
+from iris.managed_thread import get_thread_container
+from iris.rpc import controller_pb2, job_pb2, worker_pb2
+from rigging.server_auth import VerifiedIdentity, identity_scope
+
+from ._test_support import ControllerTestState
+from .conftest import (
+    MockController,
+    dispatch_task,
+    make_controller_state,
+    make_direct_job_request,
+    query_tasks_for_job,
+    register_worker,
+)
+
+# The parent authenticates to the peer as itself; the peer trusts it and runs the
+# delegated RPC under the asserted identity (profiling/exec never run anonymously).
+_PEER_IDENTITY = VerifiedIdentity(user_id="parent-cluster", role="admin")
+
+_CPU_PROFILE = job_pb2.ProfileType(cpu=job_pb2.CpuProfile())
+
+
+class _ProxyPeerConnection:
+    """A ``PeerConnection`` that delegates straight to a peer's in-process service.
+
+    Counts the proxied on-demand calls so a test can assert a tombstoned handle
+    short-circuits without a peer round-trip.
+    """
+
+    def __init__(self, service: ControllerServiceImpl):
+        self._service = service
+        self.profile_calls = 0
+        self.exec_calls = 0
+
+    def list_backends(self) -> list[controller_pb2.Controller.BackendSummary]:
+        return []
+
+    def shutdown(self) -> None:
+        pass
+
+    def launch_job(
+        self, request: controller_pb2.Controller.LaunchJobRequest
+    ) -> controller_pb2.Controller.LaunchJobResponse:
+        with identity_scope(_PEER_IDENTITY):
+            return self._service.launch_job(request, None)
+
+    def federation_sync(
+        self, request: controller_pb2.Controller.FederationSyncRequest
+    ) -> controller_pb2.Controller.FederationSyncResponse:
+        with identity_scope(_PEER_IDENTITY):
+            return self._service.federation_sync(request, None)
+
+    def terminate_job(self, job_id: JobName) -> None:
+        with identity_scope(_PEER_IDENTITY):
+            self._service.terminate_job(controller_pb2.Controller.TerminateJobRequest(job_id=job_id.to_wire()), None)
+
+    def profile_task(self, request: job_pb2.ProfileTaskRequest) -> job_pb2.ProfileTaskResponse:
+        self.profile_calls += 1
+        with identity_scope(_PEER_IDENTITY):
+            return self._service.profile_task(request, None)
+
+    def exec_in_container(
+        self, request: controller_pb2.Controller.ExecInContainerRequest
+    ) -> controller_pb2.Controller.ExecInContainerResponse:
+        self.exec_calls += 1
+        with identity_scope(_PEER_IDENTITY):
+            return self._service.exec_in_container(request, None)
+
+
+def _make_service(
+    stack: ExitStack, subdir: str, tmp_path, log_client
+) -> tuple[ControllerServiceImpl, ControllerTestState]:
+    state = stack.enter_context(make_controller_state())
+    mock = MockController()
+    mock.provider.health = state._health
+    mock.provider.worker_attrs = state._worker_attrs
+    service = ControllerServiceImpl(
+        controller=mock,
+        bundle_store=BundleStore(storage_dir=str(tmp_path / subdir / "bundles")),
+        log_client=log_client,
+        db=state._db,
+        endpoints=state._endpoints,
+        endpoint_service=EndpointServiceImpl(db=state._db, endpoints=state._endpoints),
+    )
+    return service, state
+
+
+def _attach_federation(parent_service: ControllerServiceImpl, connection: _ProxyPeerConnection) -> FederationManager:
+    peer = FederationPeer(
+        "cw", PeerConfig(controller_address="http://peer:10000", dashboard_url="https://cw.dev"), connection
+    )
+    peer.probe()
+    store = ControllerFederationStore(parent_service._db, run_template_cache=RunTemplateCache(256))
+    manager = FederationManager([peer], threads=get_thread_container(), store=store, cluster_id="parent")
+    parent_service._controller.federation = manager
+    return manager
+
+
+def _cluster_pinned_request(name: str, peer: str = "cw") -> controller_pb2.Controller.LaunchJobRequest:
+    request = make_direct_job_request(name, replicas=1)
+    request.constraints.append(Constraint.create(key=CLUSTER_CONSTRAINT_KEY, op=ConstraintOp.EQ, value=peer).to_proto())
+    return request
+
+
+def _handle(state: ControllerTestState, job_id: JobName):
+    with state._db.read_snapshot() as tx:
+        return reads.federated_handle(tx, job_id)
+
+
+def _handoff_and_mirror_running_task(
+    parent_service: ControllerServiceImpl,
+    peer_state: ControllerTestState,
+    manager: FederationManager,
+) -> tuple[JobName, JobName]:
+    """Hand off a job, drive its peer task to RUNNING, and mirror it back.
+
+    Returns the parent job id and the peer's remote job id. The parent's mirror
+    then holds a live federated task (``child_cluster`` set, no local worker), the
+    exact row an on-demand RPC must proxy rather than resolve locally.
+    """
+    response = parent_service.launch_job(_cluster_pinned_request("fed-job"), None)
+    parent_job_id = JobName.from_wire(response.job_id)
+    remote_job_id = JobName.from_wire(encode_remote_job_id("parent", parent_job_id))
+
+    worker = register_worker(peer_state, "w1", "w1:8080", job_pb2.WorkerMetadata(hostname="w1"))
+    (task,) = query_tasks_for_job(peer_state, remote_job_id)
+    dispatch_task(peer_state, task, worker)
+    manager.sync_once()
+    return parent_job_id, remote_job_id
+
+
+def test_profile_against_a_federated_task_runs_on_the_peer(tmp_path, log_client):
+    with ExitStack() as stack:
+        parent_service, _parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _ProxyPeerConnection(peer_service))
+        parent_job_id, remote_job_id = _handoff_and_mirror_running_task(parent_service, peer_state, manager)
+
+        peer_service._controller.provider.profile_task.return_value = job_pb2.ProfileTaskResponse(
+            profile_data=b"peer-profile"
+        )
+        resp = parent_service.profile_task(
+            job_pb2.ProfileTaskRequest(
+                target=parent_job_id.task(0).to_wire(),
+                duration_seconds=1,
+                profile_type=_CPU_PROFILE,
+            ),
+            None,
+        )
+
+        # The bytes could only have come from the peer's backend.
+        assert resp.profile_data == b"peer-profile"
+        # The federated task was never dispatched to the parent's local fallback backend.
+        parent_service._controller.provider.profile_task.assert_not_called()
+        # The peer resolved the task under its own root job id, not the parent's.
+        (call,) = peer_service._controller.provider.profile_task.call_args_list
+        assert call.args[0].task_id == remote_job_id.task(0).to_wire()
+
+
+def test_profile_preserves_the_attempt_qualifier_when_proxying(tmp_path, log_client):
+    """A ``:attempt`` target rewrites the root but keeps the task index + attempt,
+    so the peer profiles the exact attempt the user named."""
+    with ExitStack() as stack:
+        parent_service, _parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _ProxyPeerConnection(peer_service))
+        parent_job_id, remote_job_id = _handoff_and_mirror_running_task(parent_service, peer_state, manager)
+
+        peer_service._controller.provider.profile_task.return_value = job_pb2.ProfileTaskResponse(profile_data=b"ok")
+        parent_service.profile_task(
+            job_pb2.ProfileTaskRequest(
+                target=f"{parent_job_id.task(0).to_wire()}:0",
+                duration_seconds=1,
+                profile_type=_CPU_PROFILE,
+            ),
+            None,
+        )
+
+        (call,) = peer_service._controller.provider.profile_task.call_args_list
+        # The forwarded request carries the rewritten target with the attempt kept.
+        assert call.args[1].target == f"{remote_job_id.task(0).to_wire()}:0"
+
+
+def test_exec_against_a_federated_task_runs_on_the_peer(tmp_path, log_client):
+    with ExitStack() as stack:
+        parent_service, _parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _ProxyPeerConnection(peer_service))
+        parent_job_id, remote_job_id = _handoff_and_mirror_running_task(parent_service, peer_state, manager)
+
+        peer_service._controller.provider.exec_in_container.return_value = worker_pb2.Worker.ExecInContainerResponse(
+            exit_code=0, stdout="hello"
+        )
+        resp = parent_service.exec_in_container(
+            controller_pb2.Controller.ExecInContainerRequest(
+                task_id=parent_job_id.task(0).to_wire(),
+                command=["echo", "hi"],
+                timeout_seconds=5,
+            ),
+            None,
+        )
+
+        assert resp.exit_code == 0
+        assert resp.stdout == "hello"
+        # Never dispatched to the parent's local fallback backend.
+        parent_service._controller.provider.exec_in_container.assert_not_called()
+        # The peer resolved the task, and its forwarded worker request both carry the
+        # rewritten remote task id.
+        (call,) = peer_service._controller.provider.exec_in_container.call_args_list
+        assert call.args[0].task_id == remote_job_id.task(0).to_wire()
+        assert call.args[1].task_id == remote_job_id.task(0).to_wire()
+
+
+def test_exec_surfaces_the_peers_not_found_for_a_stale_mirror(tmp_path, log_client):
+    """The parent's mirror is last-sync stale: an exec may target a task the peer has
+    dropped. The peer is authoritative — its ``NOT_FOUND`` is surfaced verbatim, not
+    guessed from the still-present cached row."""
+    with ExitStack() as stack:
+        parent_service, _parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _ProxyPeerConnection(peer_service))
+        parent_job_id, remote_job_id = _handoff_and_mirror_running_task(parent_service, peer_state, manager)
+
+        # The peer drops the job; the parent does NOT sync, so its mirror still shows
+        # the task running.
+        with peer_state._db.transaction() as cur:
+            writes.delete_job(cur, remote_job_id)
+
+        with pytest.raises(ConnectError) as exc:
+            parent_service.exec_in_container(
+                controller_pb2.Controller.ExecInContainerRequest(
+                    task_id=parent_job_id.task(0).to_wire(), command=["true"]
+                ),
+                None,
+            )
+        assert exc.value.code == Code.NOT_FOUND
+        # The peer's local backend was never reached — the task is gone on the peer.
+        peer_service._controller.provider.exec_in_container.assert_not_called()
+
+
+def test_tombstoned_handle_resolves_not_found_without_a_peer_round_trip(tmp_path, log_client):
+    with ExitStack() as stack:
+        parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        connection = _ProxyPeerConnection(peer_service)
+        manager = _attach_federation(parent_service, connection)
+        parent_job_id, remote_job_id = _handoff_and_mirror_running_task(parent_service, peer_state, manager)
+
+        # The peer prunes the job and the parent syncs the tombstone: its handle and
+        # the mirrored task rows are dropped.
+        with peer_state._db.transaction() as cur:
+            writes.delete_job(cur, remote_job_id)
+        manager.sync_once()
+        assert _handle(parent_state, parent_job_id) is None
+
+        with pytest.raises(ConnectError) as exc:
+            parent_service.profile_task(
+                job_pb2.ProfileTaskRequest(
+                    target=parent_job_id.task(0).to_wire(),
+                    duration_seconds=1,
+                    profile_type=_CPU_PROFILE,
+                ),
+                None,
+            )
+        assert exc.value.code == Code.NOT_FOUND
+        # The dropped mirror short-circuits to NOT_FOUND before any peer call.
+        assert connection.profile_calls == 0

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -161,6 +161,16 @@ def test_launch_job_returns_job_id(service):
     assert status_response.job.state == job_pb2.JOB_STATE_PENDING
 
 
+def test_launch_job_rejects_a_tilde_in_the_job_name(service):
+    """'~' is reserved as the federation cluster-dispatch delimiter, so a user may
+    not name a job with it — it would be ambiguous with a handed-off remote root.
+    (A received handoff, whose name IS the encoded cluster~name, is exempt; that
+    path is covered by the federation handoff tests.)"""
+    with pytest.raises(ConnectError) as exc_info:
+        service.launch_job(make_job_request("cw~forged"), None)
+    assert exc_info.value.code == Code.INVALID_ARGUMENT
+
+
 class _FeasibilityAutoscaler:
     """Autoscaler stub whose job_feasibility returns a fixed verdict."""
 

--- a/lib/iris/tests/cluster/test_federation.py
+++ b/lib/iris/tests/cluster/test_federation.py
@@ -10,8 +10,10 @@ live backends, the ListPeers view, and the submit router's decision matrix
 
 import pydantic
 import pytest
+from iris.cluster.backends.rpc.backend import EXEC_IN_CONTAINER_MAX_TIMEOUT
 from iris.cluster.config import PeerConfig, config_to_dict, parse_config
 from iris.cluster.constraints import Constraint, ConstraintOp, WellKnownAttribute
+from iris.cluster.federation import peer as peer_module
 from iris.cluster.federation.manager import FederationManager
 from iris.cluster.federation.peer import FederationPeer, build_peers
 from iris.cluster.federation.router import PeerRouter, RoutingRequest
@@ -153,6 +155,38 @@ def test_list_peers_view_surfaces_heartbeat_backends():
     assert forwarded.kind == "worker-daemon"
     assert forwarded.worker_count == 3
     assert summary.last_sync_ms > 0
+
+
+class _RecordingStub:
+    """A controller stub that records the deadline each on-demand RPC was given."""
+
+    def __init__(self):
+        self.exec_timeout_ms = 0
+
+    def exec_in_container(self, request, timeout_ms):
+        self.exec_timeout_ms = timeout_ms
+        return controller_pb2.Controller.ExecInContainerResponse()
+
+    def close(self):
+        pass
+
+
+def test_exec_proxy_deadline_outlasts_the_peer(monkeypatch):
+    """The parent->peer exec hop must give the peer at least its own exec budget.
+
+    A negative ("no caller limit") timeout is capped at EXEC_IN_CONTAINER_MAX_TIMEOUT
+    on the peer, so the parent's deadline must clear that cap rather than collapse to
+    the proxy margin; a positive timeout carries the caller's budget plus margin.
+    """
+    stub = _RecordingStub()
+    monkeypatch.setattr(peer_module, "ControllerServiceClientSync", lambda **kwargs: stub)
+    connection = peer_module._PeerRpcConnection("http://peer:10000", [])
+
+    connection.exec_in_container(controller_pb2.Controller.ExecInContainerRequest(task_id="/u/j/0", timeout_seconds=-1))
+    assert stub.exec_timeout_ms >= EXEC_IN_CONTAINER_MAX_TIMEOUT.to_ms()
+
+    connection.exec_in_container(controller_pb2.Controller.ExecInContainerRequest(task_id="/u/j/0", timeout_seconds=30))
+    assert stub.exec_timeout_ms > 30 * 1000
 
 
 def test_heartbeat_loop_refreshes_backends_and_stop_releases_connections():

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -93,6 +93,22 @@ def test_job_name_roundtrip_and_hierarchy():
     assert not parsed.is_ancestor_of(JobName.root("test-user", "root"), include_self=False)
 
 
+def test_job_name_with_root_job_rebases_below_the_root():
+    # A direct task and a nested-child task both keep everything below the root.
+    remote_root = JobName.from_string("/alice/cw~job")
+    assert JobName.from_string("/alice/job/0").with_root_job(remote_root) == JobName.from_string("/alice/cw~job/0")
+    assert JobName.from_string("/alice/job/child/0").with_root_job(remote_root) == JobName.from_string(
+        "/alice/cw~job/child/0"
+    )
+    # The root itself rebases to the new root.
+    assert JobName.from_string("/alice/job").with_root_job(remote_root) == remote_root
+
+
+def test_job_name_with_root_job_requires_a_root():
+    with pytest.raises(ValueError):
+        JobName.from_string("/alice/job/0").with_root_job(JobName.from_string("/alice/cw~job/child"))
+
+
 @pytest.mark.parametrize("base", ["https://iris.oa.dev", "https://iris.oa.dev/"])
 def test_job_name_dashboard_url(base: str):
     job = JobName.from_string("/rav/datakit-ref-smoke-20260604-135004")

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -109,6 +109,34 @@ def test_job_name_with_root_job_requires_a_root():
         JobName.from_string("/alice/job/0").with_root_job(JobName.from_string("/alice/cw~job/child"))
 
 
+def test_federated_remote_root_encodes_and_reverses():
+    root = JobName.from_string("/alice/train")
+    remote = JobName.federated_remote_root("cw", root)
+    assert remote == JobName.from_string("/alice/cw~train")
+    assert remote.is_federated_remote
+    assert remote.split_federated_root() == ("cw", root)
+    # Reversible even when the original name itself contains the delimiter: the
+    # cluster id is delimiter-free, so the first '~' is the join.
+    weird = JobName.federated_remote_root("cw", JobName.from_string("/alice/a~b"))
+    assert weird.split_federated_root() == ("cw", JobName.from_string("/alice/a~b"))
+
+
+def test_federated_remote_root_rejects_bad_cluster_id_and_non_root():
+    with pytest.raises(ValueError):
+        JobName.federated_remote_root("", JobName.from_string("/alice/train"))
+    with pytest.raises(ValueError):
+        JobName.federated_remote_root("c~w", JobName.from_string("/alice/train"))
+    with pytest.raises(ValueError):
+        JobName.federated_remote_root("cw", JobName.from_string("/alice/train/child"))
+
+
+def test_split_federated_root_rejects_a_local_name():
+    local = JobName.from_string("/alice/train/0")
+    assert not local.is_federated_remote
+    with pytest.raises(ValueError):
+        local.split_federated_root()
+
+
 @pytest.mark.parametrize("base", ["https://iris.oa.dev", "https://iris.oa.dev/"])
 def test_job_name_dashboard_url(base: str):
     job = JobName.from_string("/rav/datakit-ref-smoke-20260604-135004")


### PR DESCRIPTION
An on-demand `ProfileTask`/`ExecInContainer` against a federated job cannot be resolved locally: the target task lives in the peer's DAG, so the parent holds no worker or attempt rows for it. Left alone, `_backend_for_id("")` falls back to the representative local backend and the request would run against the wrong cluster.

Both handlers now branch before local `task -> worker` resolution: if the target task's root job resolves to a SENT federated handle, the request is forwarded to the owning peer controller, which does its own resolution and returns the result verbatim. The task id is rewritten onto the peer's remote root job — the tilde-joined `JobName` from `encode_remote_job_id` — preserving the task index and any attempt qualifier (new `JobName.with_root_job`). Forwarding goes through a public `FederationManager.proxy_profile`/`proxy_exec` helper, never the private peer dict, mirroring `cancel_federated`. The backend seam never learns federation exists; there is no `RemoteTaskBackend`.

The peer stays authoritative: a proxied call to a task it has since moved or finished surfaces the peer's live answer or `NOT_FOUND`, and a tombstoned handle (its rows already gone) resolves `NOT_FOUND` locally with no peer round-trip. The parent remains the trust boundary — the client never reaches the peer. With no peers configured the branch never fires, so a single-cluster deployment is a byte-identical no-op.

The tilde convention this proxy rewrites onto is now a first-class, reversible API rather than an ad-hoc string. `JobName.federated_remote_root(cluster_id, root)` builds the `/<user>/<cluster>~<name>` remote root and `split_federated_root` recovers `(cluster_id, root)` losslessly, with the delimiter a single `FEDERATION_DELIMITER` constant that `encode_remote_job_id` delegates to. To keep `cluster~name` unambiguous, `~` is reserved: `launch_job` rejects it in a job's own name unless the submit is a received handoff (whose root name IS the encoded id). Only the leaf name is checked, so a child spawned on a peer under a `~`-bearing federated root still submits.

Two placement choices worth flagging for review:

- The branch sits *after* the local task read, so the parent's mirror gates existence: a not-yet-synced task returns `NOT_FOUND` rather than proxying blindly. This is symmetric with the tombstone case and avoids a wasted peer round-trip for unknown/invalid task indices; the window where a task is running on the peer but unmirrored is negligible (an unmirrored task is still pending, hence not exec-able).
- The parent→peer exec hop mirrors the worker backend's timeout contract: a negative ("no caller limit") timeout is capped at `EXEC_IN_CONTAINER_MAX_TIMEOUT` on the peer, so the proxy deadline clears that cap rather than collapsing to the margin.

`get_process_status` is scoped out: it has no per-task target today, and a federated job's workers are peer-siloed, so a task-target process-status API is net-new rather than a proxy branch. Filed as #6845.

Part of #6718 — PR4a of the federation rollout (exec/profile proxy; process-status follow-up filed).
