### PR TITLE
[iris/finelog] Federated global-finelog log relay + authenticated ingress

### DIFF
--- a/lib/finelog/config/cw-us-east-02a.yaml
+++ b/lib/finelog/config/cw-us-east-02a.yaml
@@ -2,7 +2,7 @@
 #
 # Deployed as an in-cluster k8s Deployment + ClusterIP Service in the `iris`
 # namespace, the same namespace as the iris controller. iris references it from
-# its cluster config via `log_server_config: cw-us-east-02a`, which resolves to
+# its cluster config via `finelog.config: cw-us-east-02a`, which resolves to
 # the endpoint `k8s://finelog-cw-use02a.iris` ->
 # finelog-cw-use02a.iris.svc.cluster.local:10001.
 #

--- a/lib/finelog/config/cw-us-east-02a.yaml
+++ b/lib/finelog/config/cw-us-east-02a.yaml
@@ -27,3 +27,10 @@ deployment:
     storage_gb: 250
     # R2 endpoint for the s3:// archive; folded into the minted creds Secret.
     object_storage_endpoint: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com
+# Authenticated-ingress policy. This LOCAL finelog is default-deny;
+# it admits its own cluster's private network (CoreWeave pods are 10.x) and
+# loopback (port-forward), never the public internet. No jwt layer — that is the
+# GLOBAL finelog's job, for cross-cluster relay pushes.
+auth:
+  - type: cidr
+    cidrs: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, "::1/128"]

--- a/lib/finelog/config/marin-dev.yaml
+++ b/lib/finelog/config/marin-dev.yaml
@@ -9,3 +9,10 @@ deployment:
     machine_type: n2-standard-4
     boot_disk_size_gb: 200
     service_account: iris-controller@hai-gcp-models.iam.gserviceaccount.com
+# Authenticated-ingress policy. This LOCAL finelog is default-deny;
+# it admits its own cluster's private network (VPC + pod ranges) and loopback (SSH
+# tunnel / controller proxy), never the public internet. No jwt layer — that is
+# the GLOBAL finelog's job, for cross-cluster relay pushes.
+auth:
+  - type: cidr
+    cidrs: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, "::1/128"]

--- a/lib/finelog/config/marin.yaml
+++ b/lib/finelog/config/marin.yaml
@@ -10,3 +10,10 @@ deployment:
     machine_type: n2-highmem-4
     boot_disk_size_gb: 200
     service_account: iris-controller@hai-gcp-models.iam.gserviceaccount.com
+# Authenticated-ingress policy. This LOCAL finelog is default-deny;
+# it admits its own cluster's private network (VPC + pod ranges) and loopback (SSH
+# tunnel / controller proxy), never the public internet. No jwt layer — that is
+# the GLOBAL finelog's job, for cross-cluster relay pushes.
+auth:
+  - type: cidr
+    cidrs: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, "::1/128"]

--- a/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
+++ b/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
@@ -57,11 +57,16 @@ spec:
             - secretRef:
                 name: {{ name }}-env
                 optional: true
+          # FINELOG_AUTH_POLICY is injected inline below for a
+          # cidr-only policy (no secrets). A policy carrying jwt keys must instead
+          # be supplied through the `{{ name }}-env` Secret so key material never
+          # lands in a plaintext manifest (the deploy path rejects inline jwt).
           env:
             - name: FINELOG_PORT
               value: "{{ port }}"
             - name: FINELOG_REMOTE_DIR
               value: "{{ remote_log_dir }}"
+{{ auth_env_block }}
           volumeMounts:
             - name: cache
               mountPath: /var/cache/finelog

--- a/lib/finelog/rust/Cargo.lock
+++ b/lib/finelog/rust/Cargo.lock
@@ -1726,6 +1726,7 @@ dependencies = [
  "arrow",
  "async-trait",
  "axum 0.7.9",
+ "base64",
  "buffa",
  "buffa-types",
  "bytes",
@@ -1736,6 +1737,7 @@ dependencies = [
  "datafusion-datasource",
  "datafusion-datasource-parquet",
  "futures",
+ "hmac",
  "http-body",
  "object_store",
  "parquet",
@@ -1744,6 +1746,7 @@ dependencies = [
  "rusqlite",
  "serde",
  "serde_json",
+ "sha2",
  "tikv-jemallocator",
  "tokio",
  "tower",
@@ -2049,6 +2052,15 @@ name = "hex"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
+
+[[package]]
+name = "hmac"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
+dependencies = [
+ "digest",
+]
 
 [[package]]
 name = "http"

--- a/lib/finelog/rust/Cargo.toml
+++ b/lib/finelog/rust/Cargo.toml
@@ -46,6 +46,13 @@ buffa = { version = "0.6", features = ["json"] }
 buffa-types = { version = "0.6", features = ["json"] }
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"
+# HS256 JWT verification for the authenticated ingress front. We
+# use the RustCrypto primitives directly (constant-time `verify_slice`) rather
+# than a full JWT crate to avoid a `ring` build dependency; the only non-crypto
+# work is base64url-splitting the token envelope.
+hmac = "0.12"
+sha2 = "0.10"
+base64 = "0.22"
 axum = "0.7"
 # Phase 5d: ServeDir static-file service for the Vue SPA `/static` mount. The
 # `fs` feature is the only one needed; tower-http 0.6 is compatible with the

--- a/lib/finelog/rust/pyext/src/lib.rs
+++ b/lib/finelog/rust/pyext/src/lib.rs
@@ -15,7 +15,7 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::time::Duration;
 
-use finelog::server::build_app;
+use finelog::server::{build_app_with_config, AuthPolicy, ServerConfig};
 use finelog::store::Store;
 use pyo3::exceptions::PyRuntimeError;
 use pyo3::prelude::*;
@@ -46,13 +46,14 @@ struct EmbeddedServer {
 #[pymethods]
 impl EmbeddedServer {
     #[new]
-    #[pyo3(signature = (log_dir=None, remote_log_dir=String::new(), host=String::from("127.0.0.1"), port=0, debug_admin=false))]
+    #[pyo3(signature = (log_dir=None, remote_log_dir=String::new(), host=String::from("127.0.0.1"), port=0, debug_admin=false, auth_policy=None))]
     fn new(
         log_dir: Option<String>,
         remote_log_dir: String,
         host: String,
         port: u16,
         debug_admin: bool,
+        auth_policy: Option<String>,
     ) -> PyResult<Self> {
         let runtime = tokio::runtime::Builder::new_multi_thread()
             .enable_all()
@@ -75,7 +76,15 @@ impl EmbeddedServer {
                     .map_err(|e| PyRuntimeError::new_err(format!("failed to open store: {e}")))?,
             );
             store.bootstrap_maintenance();
-            let app = build_app(Arc::clone(&store), debug_admin);
+            // No policy → the private allow-localhost default (loopback only); a
+            // JSON layer list configures a global finelog's cidr+jwt stack.
+            let auth = match auth_policy.as_deref() {
+                Some(json) if !json.trim().is_empty() => AuthPolicy::parse(json)
+                    .map_err(|e| PyRuntimeError::new_err(format!("invalid auth_policy: {e}")))?,
+                _ => AuthPolicy::allow_localhost(),
+            };
+            let config = ServerConfig::with_debug_admin(debug_admin).with_auth(auth);
+            let app = build_app_with_config(Arc::clone(&store), config);
             let listener = tokio::net::TcpListener::bind(bind)
                 .await
                 .map_err(|e| PyRuntimeError::new_err(format!("failed to bind {bind}: {e}")))?;
@@ -90,9 +99,14 @@ impl EmbeddedServer {
             let shutdown = async move {
                 let _ = shutdown_rx.await;
             };
-            let _ = axum::serve(listener, app)
-                .with_graceful_shutdown(shutdown)
-                .await;
+            // `into_make_service_with_connect_info` records each connection's peer
+            // address so the auth CIDR rule can read it.
+            let _ = axum::serve(
+                listener,
+                app.into_make_service_with_connect_info::<SocketAddr>(),
+            )
+            .with_graceful_shutdown(shutdown)
+            .await;
             store.shutdown(Duration::from_secs(5)).await;
         });
 

--- a/lib/finelog/rust/src/main.rs
+++ b/lib/finelog/rust/src/main.rs
@@ -10,8 +10,8 @@ use std::sync::Arc;
 use std::time::Duration;
 
 use clap::Parser;
-use finelog::server::build_app;
 use finelog::server::diagnostics::spawn_pool_diagnostics;
+use finelog::server::{build_app_with_config, AuthPolicy, ServerConfig};
 use finelog::store::Store;
 use tokio::sync::Notify;
 
@@ -52,6 +52,16 @@ struct Args {
     /// production.
     #[arg(long, env = "FINELOG_DEBUG_ADMIN", default_value_t = false)]
     debug_admin: bool,
+
+    /// Authenticated-ingress policy as a JSON list of layers (env
+    /// `FINELOG_AUTH_POLICY`), e.g.
+    /// `[{"type":"cidr","cidrs":["10.0.0.0/8","127.0.0.0/8"]},{"type":"jwt","keys":[{"cluster":"marin","secret":"<hex>"}]}]`.
+    /// List order is evaluation order (first Allow admits, first Reject denies,
+    /// none → deny). Empty (the default) installs the private allow-localhost
+    /// policy: reachable from loopback for local debugging, never open to the
+    /// network. A shared global finelog sets a `cidr`+`jwt` stack.
+    #[arg(long = "auth-policy", env = "FINELOG_AUTH_POLICY", default_value = "")]
+    auth_policy: String,
 }
 
 #[tokio::main]
@@ -80,7 +90,19 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // below. The server serves — and /health is green — while archived rows are
     // still being reconciled into the catalog.
     store.bootstrap_maintenance();
-    let app = build_app(Arc::clone(&store), args.debug_admin);
+    // Auth is ALWAYS enforced (default-deny). No policy → the private
+    // allow-localhost default (loopback only); a shared global finelog sets a
+    // cidr+jwt stack. A malformed policy fails startup rather than mis-admitting.
+    // The /debug/* admin routes are gated by this same policy (see `build_app`).
+    let auth = if args.auth_policy.trim().is_empty() {
+        AuthPolicy::allow_localhost()
+    } else {
+        AuthPolicy::parse(&args.auth_policy)
+            .map_err(|e| format!("invalid FINELOG_AUTH_POLICY: {e}"))?
+    };
+    tracing::info!(policy = %auth.describe(), "finelog-server: auth policy active");
+    let config = ServerConfig::with_debug_admin(args.debug_admin).with_auth(auth);
+    let app = build_app_with_config(Arc::clone(&store), config);
 
     // Periodic pool/RSS diagnostics task; cancelled on shutdown via a latched
     // stop flag (set before the Notify, so a notify that races the task's emit
@@ -98,9 +120,14 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
     let listener = tokio::net::TcpListener::bind(addr).await?;
     // Graceful shutdown: stop accepting and drain in-flight requests on the
     // first SIGTERM/SIGINT, then shut the store's background tasks down.
-    axum::serve(listener, app)
-        .with_graceful_shutdown(shutdown_signal())
-        .await?;
+    // `into_make_service_with_connect_info` records each connection's peer
+    // address so the auth CIDR rule can read it.
+    axum::serve(
+        listener,
+        app.into_make_service_with_connect_info::<SocketAddr>(),
+    )
+    .with_graceful_shutdown(shutdown_signal())
+    .await?;
     tracing::info!("finelog-server draining background tasks");
 
     // Stop the diagnostics task, then cooperatively cancel + join the

--- a/lib/finelog/rust/src/server/app.rs
+++ b/lib/finelog/rust/src/server/app.rs
@@ -30,6 +30,7 @@ use connectrpc::{ConnectRpcService, Limits, Router as ConnectRouter};
 
 use crate::proto::finelog::logging::LogServiceExt;
 use crate::proto::finelog::stats::StatsServiceExt;
+use crate::server::auth::{auth_gate, AuthInterceptor, AuthPolicy};
 use crate::server::interceptors::{
     ConcurrencyInterceptor, SlowRpcInterceptor, DEFAULT_SLOW_RPC_THRESHOLD_MS,
     MAX_CONCURRENT_FETCH_LOGS, MAX_CONCURRENT_QUERY,
@@ -43,7 +44,7 @@ use super::MAX_MESSAGE_BYTES;
 
 /// Server-shell tuning. The interceptor caps + slow threshold are fields so a
 /// cargo/parity test can lower them; production uses [`ServerConfig::default`].
-#[derive(Debug, Clone, Copy)]
+#[derive(Debug, Clone)]
 pub struct ServerConfig {
     /// Mount the non-proto `--debug-admin` `/debug/*` routes.
     pub debug_admin: bool,
@@ -53,6 +54,12 @@ pub struct ServerConfig {
     pub max_concurrent_query: usize,
     /// Default per-method slow-RPC threshold (ms); `<= 0` disables.
     pub slow_rpc_threshold_ms: i64,
+    /// The authenticated-ingress policy. Always enforced — the
+    /// interceptor gates every RPC and the policy is default-deny. The default
+    /// ([`AuthPolicy::allow_localhost`]) admits loopback only, so a bare finelog
+    /// is reachable for local debugging but never open to its network; a shared
+    /// global finelog sets a `cidr`+`jwt` stack.
+    pub auth: Arc<AuthPolicy>,
 }
 
 impl Default for ServerConfig {
@@ -62,6 +69,7 @@ impl Default for ServerConfig {
             max_concurrent_fetch_logs: MAX_CONCURRENT_FETCH_LOGS,
             max_concurrent_query: MAX_CONCURRENT_QUERY,
             slow_rpc_threshold_ms: DEFAULT_SLOW_RPC_THRESHOLD_MS,
+            auth: Arc::new(AuthPolicy::allow_localhost()),
         }
     }
 }
@@ -73,6 +81,13 @@ impl ServerConfig {
             debug_admin,
             ..Self::default()
         }
+    }
+
+    /// Set the authenticated-ingress policy (chainable). Replaces the
+    /// allow-localhost default; the policy is always default-deny.
+    pub fn with_auth(mut self, policy: AuthPolicy) -> Self {
+        self.auth = Arc::new(policy);
+        self
     }
 }
 
@@ -98,6 +113,10 @@ fn build_connect_service(
         // SlowRpc registered FIRST -> outermost -> times the whole chain
         // including the concurrency wait.
         .with_interceptor(SlowRpcInterceptor::new(config.slow_rpc_threshold_ms))
+        // Auth sits just inside SlowRpc (so a rejected request is still timed) and
+        // outside Concurrency (so it is rejected before consuming a permit). Always
+        // installed; the default policy admits loopback only.
+        .with_interceptor(AuthInterceptor::new(Arc::clone(&config.auth)))
         .with_interceptor(ConcurrencyInterceptor::new(
             config.max_concurrent_fetch_logs,
             config.max_concurrent_query,
@@ -113,8 +132,14 @@ pub fn build_app(store: Arc<Store>, config: ServerConfig) -> Router {
 
     let mut app = Router::new().route("/health", get(|| async { "ok" }));
     if config.debug_admin {
-        // Mounted BEFORE the connect fallback so /debug/* is not shadowed.
-        app = app.merge(debug::debug_router(Arc::clone(&store)));
+        // Mounted BEFORE the connect fallback so /debug/* is not shadowed. These
+        // admin routes bypass the Connect interceptor chain, so they are gated by
+        // the same auth policy here via `auth_gate` (default-deny, loopback-only
+        // by default) — the admin surface is never more open than the RPCs.
+        let debug = debug::debug_router(Arc::clone(&store)).layer(
+            axum::middleware::from_fn_with_state(Arc::clone(&config.auth), auth_gate),
+        );
+        app = app.merge(debug);
     }
     // SPA routes BEFORE the connect fallback so unmatched GETs serve index.html.
     // The SPA catch-all forwards NON-GET (RPC POSTs) to a clone of the connect

--- a/lib/finelog/rust/src/server/auth.rs
+++ b/lib/finelog/rust/src/server/auth.rs
@@ -1,0 +1,867 @@
+// Copyright The Marin Authors
+// SPDX-License-Identifier: Apache-2.0
+
+//! Authenticated ingress front for the finelog server.
+//!
+//! A globally shared finelog receives pushes from many controllers across the
+//! internet, so it can no longer rely on being private behind one controller's
+//! proxy. This module gates every RPC with an ordered stack of auth *layers*,
+//! mirroring rigging's `server_auth` (each layer *allows*, *falls through*, or
+//! *rejects*).
+//!
+//! The policy is **default-deny**: a request no layer *allows* is rejected
+//! `Unauthenticated`. Auth is a stack of allow-layers on top of that deny —
+//! there is no "empty means open" path. The interceptor is *always* installed
+//! (see `ServerConfig`); the only variable is the layer list. When nothing is
+//! configured the default is [`AuthPolicy::allow_localhost`] (loopback only), so
+//! a bare finelog is reachable for local debugging but never open to its network.
+//! Two layer kinds compose:
+//! - [`AuthLayer::Jwt`] — a bearer whose HS256 signature verifies against one of a
+//!   set of trusted per-cluster keys, and which has not expired, admits the
+//!   request. This mirrors marin's own token model (`JwtTokenManager` mints
+//!   `HS256` JWTs signed with a per-cluster HMAC key); each relaying controller
+//!   mints a short-lived finelog-delegation JWT and the store verifies it against
+//!   that cluster's key — the same JWT mechanism the control plane uses, so the
+//!   log plane adds no second credential *system*. The store holds only
+//!   delegation keys (a key that grants finelog access, not control-plane token
+//!   minting), and checks signature + `exp` only (it cannot reach a controller's
+//!   revocation table, so exposure is TTL-bounded). Every configured key admits
+//!   equally — federation members are mutually trusted for the log plane.
+//! - [`AuthLayer::Cidr`] — a request whose transport peer is in a trusted network
+//!   is admitted without a token. This reproduces today's intra-cluster
+//!   reachability explicitly: a global finelog that also serves its own cluster
+//!   lists that cluster's loopback/VPC ranges (e.g. `127.0.0.0/8`, `10.0.0.0/8`)
+//!   so local clients keep working without a JWT, while remote pushes must sign.
+//!   CIDR matches the transport peer only (never a forwarded header), the same
+//!   distrust of spoofable `X-Forwarded-For` that rigging's loopback check applies.
+//!
+//! The layers are walked in order: the first `Allow` admits, the first `Reject`
+//! denies, and a request no layer claims is denied. Order matters — the CIDR
+//! layer is placed first so a trusted-network client is admitted before the JWT
+//! layer would reject a token it cannot verify (e.g. the home controller's
+//! control-plane `worker_token`, which a global finelog holding only delegation
+//! keys cannot check).
+
+use std::fmt;
+use std::net::{IpAddr, SocketAddr};
+use std::sync::Arc;
+use std::time::{SystemTime, UNIX_EPOCH};
+
+use axum::extract::{ConnectInfo, Request, State};
+use axum::http::StatusCode;
+use axum::middleware::Next as AxumNext;
+use axum::response::{IntoResponse, Response};
+use base64::engine::general_purpose::URL_SAFE_NO_PAD;
+use base64::Engine;
+use connectrpc::{
+    async_trait, ConnectError, Interceptor, Next, RequestContext, UnaryRequest, UnaryResponse,
+};
+use hmac::{Hmac, Mac};
+use serde::Deserialize;
+use sha2::Sha256;
+
+type HmacSha256 = Hmac<Sha256>;
+
+/// Accept a token whose `exp` is at most this far in the past, to tolerate small
+/// clock skew between a minting controller and the store.
+const EXP_LEEWAY_SECONDS: i64 = 60;
+
+/// Reject an HS256 delegation secret shorter than this (a too-short HMAC key is a
+/// misconfiguration, not a valid key). marin's own keys are `token_hex(32)` = 64
+/// ASCII bytes, well above this floor.
+const MIN_SECRET_BYTES: usize = 16;
+
+/// One rule's verdict over a request, mirroring rigging's
+/// AUTHENTICATED / ABSENT / REJECTED.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+enum Verdict {
+    /// This rule admits the request; stop and admit.
+    Allow,
+    /// This rule does not claim the request; try the next.
+    Fallthrough,
+    /// A credential was presented but is invalid; stop and deny.
+    Reject,
+}
+
+/// An IPv4/IPv6 network in CIDR form (`10.0.0.0/8`, `2001:db8::/32`).
+#[derive(Debug, Clone)]
+pub struct Cidr {
+    network: IpAddr,
+    prefix_len: u8,
+}
+
+impl Cidr {
+    /// Parse `"<addr>/<prefix_len>"`. A bare address (no `/`) is a host route
+    /// (full-length prefix). Errors on a malformed address or an out-of-range
+    /// prefix so a bad config fails the server at startup rather than silently
+    /// admitting nothing.
+    pub fn parse(spec: &str) -> Result<Self, String> {
+        let (addr_str, prefix_str) = match spec.split_once('/') {
+            Some((a, p)) => (a, Some(p)),
+            None => (spec, None),
+        };
+        let network: IpAddr = addr_str
+            .parse()
+            .map_err(|_| format!("invalid CIDR address {addr_str:?} in {spec:?}"))?;
+        let max = if network.is_ipv4() { 32 } else { 128 };
+        let prefix_len = match prefix_str {
+            Some(p) => p
+                .parse::<u8>()
+                .map_err(|_| format!("invalid CIDR prefix {p:?} in {spec:?}"))?,
+            None => max,
+        };
+        if prefix_len > max {
+            return Err(format!(
+                "CIDR prefix /{prefix_len} exceeds /{max} in {spec:?}"
+            ));
+        }
+        Ok(Self {
+            network,
+            prefix_len,
+        })
+    }
+
+    /// Whether `addr` falls within this network (same family, matching prefix).
+    pub fn contains(&self, addr: IpAddr) -> bool {
+        match (self.network, addr) {
+            (IpAddr::V4(net), IpAddr::V4(ip)) => {
+                prefix_matches(&net.octets(), &ip.octets(), self.prefix_len)
+            }
+            (IpAddr::V6(net), IpAddr::V6(ip)) => {
+                prefix_matches(&net.octets(), &ip.octets(), self.prefix_len)
+            }
+            // A v4-mapped v6 peer (`::ffff:a.b.c.d`, common when a dual-stack
+            // listener accepts a v4 client) is matched against a v4 rule on its
+            // embedded v4 address.
+            (IpAddr::V4(net), IpAddr::V6(ip)) => ip
+                .to_ipv4_mapped()
+                .is_some_and(|v4| prefix_matches(&net.octets(), &v4.octets(), self.prefix_len)),
+            (IpAddr::V6(_), IpAddr::V4(_)) => false,
+        }
+    }
+}
+
+/// Whether the first `prefix_len` bits of `net` and `addr` are equal.
+fn prefix_matches(net: &[u8], addr: &[u8], prefix_len: u8) -> bool {
+    let mut bits = prefix_len as usize;
+    for (n, a) in net.iter().zip(addr.iter()) {
+        if bits == 0 {
+            break;
+        }
+        if bits >= 8 {
+            if n != a {
+                return false;
+            }
+            bits -= 8;
+        } else {
+            let mask = 0xffu8 << (8 - bits);
+            return (n & mask) == (a & mask);
+        }
+    }
+    true
+}
+
+/// A trusted per-cluster delegation key: the cluster it authenticates and the
+/// HS256 secret (the JWT signing key's raw bytes). `Debug` renders the cluster
+/// but never the secret.
+struct JwtKey {
+    cluster: String,
+    secret: Vec<u8>,
+}
+
+impl fmt::Debug for JwtKey {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_struct("JwtKey")
+            .field("cluster", &self.cluster)
+            .finish_non_exhaustive()
+    }
+}
+
+/// Verifies HS256 JWTs against a set of trusted per-cluster delegation keys.
+///
+/// A token is accepted iff its signature verifies against one configured key
+/// (constant-time HMAC compare) and its `exp` is in the future within
+/// [`EXP_LEEWAY_SECONDS`]. Only delegation keys are held — never a controller's
+/// control-plane signing key — so the store can verify a cluster's tokens
+/// without gaining the power to mint control-plane ones. On success the matching
+/// cluster is returned for attribution. Every configured delegation key admits
+/// equally: federation members are mutually trusted for the log plane, so a
+/// valid token may write under any namespace (per-cluster write isolation is not
+/// enforced in v1).
+#[derive(Debug)]
+pub struct JwtVerifier {
+    keys: Vec<JwtKey>,
+}
+
+impl JwtVerifier {
+    /// Build from `(cluster, secret)` pairs. The secret is HMAC-keyed as raw
+    /// ASCII bytes to match PyJWT (`jwt.encode(payload, signing_key, "HS256")`
+    /// HMACs the signing-key STRING's bytes), so a hex `secrets.token_hex(32)`
+    /// key is passed through verbatim, never hex-decoded. Rejects an empty
+    /// cluster or a secret shorter than [`MIN_SECRET_BYTES`].
+    fn new(keys: Vec<(String, String)>) -> Result<Self, String> {
+        let mut compiled = Vec::with_capacity(keys.len());
+        for (cluster, secret) in keys {
+            if cluster.is_empty() {
+                return Err("jwt key entry has an empty cluster".to_string());
+            }
+            if secret.len() < MIN_SECRET_BYTES {
+                return Err(format!(
+                    "jwt delegation secret for cluster {cluster:?} is too short \
+                     ({} bytes; need >= {MIN_SECRET_BYTES})",
+                    secret.len()
+                ));
+            }
+            compiled.push(JwtKey {
+                cluster,
+                secret: secret.into_bytes(),
+            });
+        }
+        Ok(Self { keys: compiled })
+    }
+
+    /// The cluster whose key verifies `token` (HS256 signature valid + unexpired
+    /// at `now_unix` within the skew leeway), or `None` if none does. Decodes the
+    /// JWS envelope once, then tries each trusted key against the same bytes.
+    fn verify(&self, token: &str, now_unix: i64) -> Option<&str> {
+        let parts = JwtParts::split(token)?;
+        if !parts.is_hs256() {
+            return None;
+        }
+        let claims = parts.claims()?;
+        if claims.exp + EXP_LEEWAY_SECONDS < now_unix {
+            return None; // expired beyond the skew allowance
+        }
+        self.keys
+            .iter()
+            .find(|k| parts.signature_valid(&k.secret))
+            .map(|k| k.cluster.as_str())
+    }
+}
+
+/// The declarative shape of one auth layer, deserialized from the
+/// `FINELOG_AUTH_POLICY` JSON (== the finelog config's `auth:` list). List order
+/// is evaluation order.
+#[derive(Debug, Deserialize)]
+#[serde(tag = "type", rename_all = "snake_case")]
+enum AuthLayerConfig {
+    /// Admit a request whose transport peer is in one of these networks.
+    Cidr { cidrs: Vec<String> },
+    /// Admit a request bearing a JWT that verifies against one of these
+    /// per-cluster delegation keys.
+    Jwt { keys: Vec<JwtKeyConfig> },
+}
+
+#[derive(Debug, Deserialize)]
+struct JwtKeyConfig {
+    cluster: String,
+    secret: String,
+}
+
+/// One compiled entry in the ordered auth stack.
+#[derive(Debug)]
+enum AuthLayer {
+    Cidr(Vec<Cidr>),
+    Jwt(JwtVerifier),
+}
+
+impl AuthLayer {
+    /// Compile a config layer into its runtime form, validating CIDRs and keys.
+    fn compile(config: AuthLayerConfig) -> Result<Self, String> {
+        match config {
+            AuthLayerConfig::Cidr { cidrs } => {
+                if cidrs.is_empty() {
+                    return Err("cidr layer has no networks".to_string());
+                }
+                let nets = cidrs
+                    .iter()
+                    .map(|s| Cidr::parse(s))
+                    .collect::<Result<Vec<_>, _>>()?;
+                Ok(AuthLayer::Cidr(nets))
+            }
+            AuthLayerConfig::Jwt { keys } => {
+                if keys.is_empty() {
+                    return Err("jwt layer has no keys".to_string());
+                }
+                let pairs = keys.into_iter().map(|k| (k.cluster, k.secret)).collect();
+                Ok(AuthLayer::Jwt(JwtVerifier::new(pairs)?))
+            }
+        }
+    }
+
+    /// Evaluate this layer against extracted request facts: the bearer token
+    /// (already stripped of `Bearer `) and the transport peer IP.
+    fn check(&self, bearer: Option<&str>, peer_ip: Option<IpAddr>) -> Verdict {
+        match self {
+            AuthLayer::Cidr(nets) => match peer_ip {
+                Some(ip) if nets.iter().any(|n| n.contains(ip)) => Verdict::Allow,
+                _ => Verdict::Fallthrough,
+            },
+            // rigging JwtAuthenticator parity: no bearer → fall through (a later
+            // layer may claim it); a valid bearer → allow; a present-but-invalid
+            // bearer → reject, never downgraded to a weaker layer.
+            AuthLayer::Jwt(verifier) => match bearer {
+                None => Verdict::Fallthrough,
+                Some(tok) => match verifier.verify(tok, now_unix()) {
+                    Some(cluster) => {
+                        tracing::trace!(cluster, "finelog: admitted jwt-authenticated request");
+                        Verdict::Allow
+                    }
+                    None => Verdict::Reject,
+                },
+            },
+        }
+    }
+}
+
+/// The three dot-separated base64url segments of a JWT, plus the signing input.
+struct JwtParts<'a> {
+    header_b64: &'a str,
+    payload_b64: &'a str,
+    signature: Vec<u8>,
+}
+
+impl<'a> JwtParts<'a> {
+    fn split(token: &'a str) -> Option<Self> {
+        let mut it = token.split('.');
+        let header_b64 = it.next()?;
+        let payload_b64 = it.next()?;
+        let sig_b64 = it.next()?;
+        if it.next().is_some() {
+            return None; // a JWS has exactly three segments
+        }
+        let signature = URL_SAFE_NO_PAD.decode(sig_b64).ok()?;
+        Some(Self {
+            header_b64,
+            payload_b64,
+            signature,
+        })
+    }
+
+    /// Reject anything but HS256 up front (guards against `alg: none` and
+    /// algorithm-confusion tokens, even though we only ever HMAC-verify).
+    fn is_hs256(&self) -> bool {
+        let Ok(bytes) = URL_SAFE_NO_PAD.decode(self.header_b64) else {
+            return false;
+        };
+        let Ok(header) = serde_json::from_slice::<JwtHeader>(&bytes) else {
+            return false;
+        };
+        header.alg.eq_ignore_ascii_case("HS256")
+    }
+
+    fn claims(&self) -> Option<JwtClaims> {
+        let bytes = URL_SAFE_NO_PAD.decode(self.payload_b64).ok()?;
+        serde_json::from_slice(&bytes).ok()
+    }
+
+    /// Constant-time HMAC-SHA256 check of `header.payload` against `key`.
+    fn signature_valid(&self, key: &[u8]) -> bool {
+        let Ok(mut mac) = HmacSha256::new_from_slice(key) else {
+            return false;
+        };
+        mac.update(self.header_b64.as_bytes());
+        mac.update(b".");
+        mac.update(self.payload_b64.as_bytes());
+        mac.verify_slice(&self.signature).is_ok()
+    }
+}
+
+#[derive(serde::Deserialize)]
+struct JwtHeader {
+    #[serde(default)]
+    alg: String,
+}
+
+#[derive(serde::Deserialize)]
+struct JwtClaims {
+    exp: i64,
+}
+
+fn now_unix() -> i64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs() as i64)
+        .unwrap_or(0)
+}
+
+/// An ordered stack of auth layers with a **default-deny** terminal. Always
+/// installed (see `ServerConfig`); the private default is [`allow_localhost`].
+///
+/// [`allow_localhost`]: AuthPolicy::allow_localhost
+#[derive(Debug)]
+pub struct AuthPolicy {
+    layers: Vec<AuthLayer>,
+}
+
+impl AuthPolicy {
+    /// The private default: admit loopback only, deny everything else. Used when
+    /// no `auth:` policy is configured, so a bare finelog is reachable for local
+    /// debugging but never open to its network.
+    pub fn allow_localhost() -> Self {
+        Self {
+            layers: vec![AuthLayer::Cidr(vec![
+                Cidr::parse("127.0.0.0/8").expect("valid loopback CIDR"),
+                Cidr::parse("::1/128").expect("valid loopback CIDR"),
+            ])],
+        }
+    }
+
+    /// Parse an ordered layer list from JSON (the `FINELOG_AUTH_POLICY` value):
+    /// `[{"type":"cidr","cidrs":[..]},{"type":"jwt","keys":[{"cluster":..,"secret":..}]}]`.
+    /// An empty list is rejected (that is a total lockout — omit the policy
+    /// entirely for the allow-localhost default). A malformed entry, CIDR, or
+    /// too-short secret errors so the server fails at startup rather than silently
+    /// mis-admitting.
+    pub fn parse(json: &str) -> Result<Self, String> {
+        let configs: Vec<AuthLayerConfig> =
+            serde_json::from_str(json).map_err(|e| format!("invalid auth policy JSON: {e}"))?;
+        if configs.is_empty() {
+            return Err(
+                "auth policy is an empty list (omit it for the allow-localhost default)"
+                    .to_string(),
+            );
+        }
+        let layers = configs
+            .into_iter()
+            .map(AuthLayer::compile)
+            .collect::<Result<Vec<_>, _>>()?;
+        Ok(Self { layers })
+    }
+
+    /// A one-line, secret-free description of the stack for a startup log line
+    /// (e.g. `cidr[3], jwt[2]`).
+    pub fn describe(&self) -> String {
+        self.layers
+            .iter()
+            .map(|l| match l {
+                AuthLayer::Cidr(nets) => format!("cidr[{}]", nets.len()),
+                AuthLayer::Jwt(v) => format!("jwt[{}]", v.keys.len()),
+            })
+            .collect::<Vec<_>>()
+            .join(", ")
+    }
+
+    /// The core decision over already-extracted request facts: the bearer token
+    /// (no `Bearer ` prefix) and the transport peer IP. `true` = admit. Walks the
+    /// stack: first `Allow` admits, first `Reject` denies, an unclaimed request is
+    /// denied (default-deny). Shared by the Connect interceptor and the axum
+    /// [`auth_gate`] middleware so both surfaces enforce the identical policy.
+    fn admits(&self, bearer: Option<&str>, peer_ip: Option<IpAddr>) -> bool {
+        for layer in &self.layers {
+            match layer.check(bearer, peer_ip) {
+                Verdict::Allow => return true,
+                Verdict::Reject => return false,
+                Verdict::Fallthrough => {}
+            }
+        }
+        false
+    }
+
+    /// Connect-interceptor entry point: extract the bearer + peer IP from the RPC
+    /// context and apply the policy.
+    fn authorize(&self, ctx: &RequestContext) -> Result<(), ConnectError> {
+        if self.admits(bearer_token(ctx), peer_ip(ctx)) {
+            Ok(())
+        } else {
+            Err(unauthenticated())
+        }
+    }
+}
+
+fn unauthenticated() -> ConnectError {
+    ConnectError::unauthenticated("finelog: request not authorized (no auth layer admitted it)")
+}
+
+/// The token from an `Authorization` header value, with or without the `Bearer `
+/// scheme prefix. `None` when empty.
+fn strip_bearer(header: &str) -> Option<&str> {
+    let token = header.strip_prefix("Bearer ").unwrap_or(header).trim();
+    (!token.is_empty()).then_some(token)
+}
+
+/// The bearer token from an RPC's `Authorization` header. `None` when absent or
+/// empty.
+fn bearer_token(ctx: &RequestContext) -> Option<&str> {
+    strip_bearer(ctx.header("authorization")?.to_str().ok()?)
+}
+
+/// The request's transport peer IP. `axum::serve` records it as
+/// `ConnectInfo<SocketAddr>` in the request extensions (see
+/// `into_make_service_with_connect_info` at the server bind sites), which the
+/// connect service copies into the `RequestContext`.
+fn peer_ip(ctx: &RequestContext) -> Option<IpAddr> {
+    ctx.extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|c| c.0.ip())
+}
+
+/// Server interceptor enforcing an [`AuthPolicy`] over every unary RPC.
+///
+/// Always installed (see `build_connect_service`); the private default policy is
+/// [`AuthPolicy::allow_localhost`]. Gates every method on both services — ingest
+/// (`PushLogs`/`WriteRows`/`RegisterTable`) and reads (`FetchLogs`/`Query`) alike.
+pub struct AuthInterceptor {
+    policy: Arc<AuthPolicy>,
+}
+
+impl AuthInterceptor {
+    pub fn new(policy: Arc<AuthPolicy>) -> Self {
+        Self { policy }
+    }
+}
+
+#[async_trait]
+impl Interceptor for AuthInterceptor {
+    async fn intercept_unary(
+        &self,
+        req: UnaryRequest,
+        next: Next<'_>,
+    ) -> Result<UnaryResponse, ConnectError> {
+        self.policy.authorize(&req.ctx)?;
+        next.run(req).await
+    }
+}
+
+/// axum middleware enforcing the same [`AuthPolicy`] over a route group that does
+/// NOT pass through the Connect interceptor chain — the `/debug/*` admin routes.
+/// Those are plain axum routes (mounted before the Connect fallback), so without
+/// this they would be reachable regardless of the policy; gating them here means
+/// the admin surface obeys the identical stack (default-deny, loopback-only by
+/// default) as every RPC. `/health` is deliberately left ungated for liveness
+/// probes, and the SPA serves only static assets (its data arrives over gated
+/// RPCs), so only the admin routes need this.
+pub async fn auth_gate(
+    State(policy): State<Arc<AuthPolicy>>,
+    request: Request,
+    next: AxumNext,
+) -> Response {
+    let bearer = request
+        .headers()
+        .get("authorization")
+        .and_then(|v| v.to_str().ok())
+        .and_then(strip_bearer);
+    let peer_ip = request
+        .extensions()
+        .get::<ConnectInfo<SocketAddr>>()
+        .map(|c| c.0.ip());
+    if policy.admits(bearer, peer_ip) {
+        next.run(request).await
+    } else {
+        (StatusCode::UNAUTHORIZED, "finelog: unauthorized").into_response()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::net::SocketAddr;
+    use std::sync::atomic::{AtomicUsize, Ordering};
+
+    use axum::http::{Extensions, HeaderMap};
+    use bytes::Bytes;
+    use connectrpc::codec::CodecFormat;
+    use connectrpc::interceptor::run_chain;
+    use connectrpc::response::EncodedResponse;
+    use connectrpc::spec::{Spec, StreamType};
+
+    use super::*;
+
+    fn cidr(spec: &str) -> Cidr {
+        Cidr::parse(spec).unwrap()
+    }
+
+    #[test]
+    fn cidr_ipv4_containment() {
+        let net = cidr("10.0.0.0/8");
+        assert!(net.contains("10.1.2.3".parse().unwrap()));
+        assert!(net.contains("10.255.255.255".parse().unwrap()));
+        assert!(!net.contains("11.0.0.1".parse().unwrap()));
+        assert!(!net.contains("9.255.255.255".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_non_byte_aligned_prefix() {
+        let net = cidr("192.168.16.0/20");
+        assert!(net.contains("192.168.31.255".parse().unwrap()));
+        assert!(!net.contains("192.168.32.0".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_host_route_and_ipv6() {
+        assert!(cidr("127.0.0.1").contains("127.0.0.1".parse().unwrap()));
+        assert!(!cidr("127.0.0.1").contains("127.0.0.2".parse().unwrap()));
+        let v6 = cidr("2001:db8::/32");
+        assert!(v6.contains("2001:db8:abcd::1".parse().unwrap()));
+        assert!(!v6.contains("2001:db9::1".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_v4_mapped_v6_peer() {
+        // A dual-stack listener reports a v4 client as ::ffff:10.0.0.5.
+        let net = cidr("10.0.0.0/8");
+        assert!(net.contains("::ffff:10.0.0.5".parse().unwrap()));
+    }
+
+    #[test]
+    fn cidr_rejects_bad_spec() {
+        assert!(Cidr::parse("not-an-ip/8").is_err());
+        assert!(Cidr::parse("10.0.0.0/40").is_err());
+    }
+
+    /// A request context carrying an optional Authorization header and optional
+    /// transport peer address.
+    fn ctx(authorization: Option<&str>, peer: Option<SocketAddr>) -> RequestContext {
+        let mut headers = HeaderMap::new();
+        if let Some(value) = authorization {
+            headers.insert("authorization", value.parse().unwrap());
+        }
+        let mut extensions = Extensions::new();
+        if let Some(addr) = peer {
+            extensions.insert(ConnectInfo(addr));
+        }
+        RequestContext::new(headers)
+            .with_spec(Some(Spec::server(
+                "/finelog.logging.LogService/PushLogs",
+                StreamType::Unary,
+            )))
+            .with_path("/finelog.logging.LogService/PushLogs")
+            .with_extensions(extensions)
+    }
+
+    // Delegation secrets (>= MIN_SECRET_BYTES) and the cluster names they map to.
+    const KEY_A: &str = "delegation-key-cluster-a";
+    const KEY_B: &str = "delegation-key-cluster-b";
+    // Year 2286 / 1970+100s — fixed so exp checks never flake on wall-clock.
+    const FUTURE: i64 = 9_999_999_999;
+    const PAST: i64 = 100;
+
+    /// Mint an HS256 JWT (`{"sub":"c","exp":<exp>}`) signed with `key`.
+    fn mint(key: &str, exp: i64) -> String {
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"HS256","typ":"JWT"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"sub":"c","exp":{exp}}}"#).as_bytes());
+        let signing_input = format!("{header}.{payload}");
+        let mut mac = HmacSha256::new_from_slice(key.as_bytes()).unwrap();
+        mac.update(signing_input.as_bytes());
+        let sig = URL_SAFE_NO_PAD.encode(mac.finalize().into_bytes());
+        format!("{signing_input}.{sig}")
+    }
+
+    fn bearer(token: &str) -> String {
+        format!("Bearer {token}")
+    }
+
+    fn verifier(pairs: &[(&str, &str)]) -> JwtVerifier {
+        JwtVerifier::new(
+            pairs
+                .iter()
+                .map(|(c, s)| (c.to_string(), s.to_string()))
+                .collect(),
+        )
+        .unwrap()
+    }
+
+    #[test]
+    fn jwt_verifier_returns_cluster_rejects_forged_and_expired() {
+        let v = verifier(&[("alpha", KEY_A), ("bravo", KEY_B)]);
+        // Signed by a trusted key, unexpired → returns the matching cluster.
+        assert_eq!(v.verify(&mint(KEY_A, FUTURE), 1_000), Some("alpha"));
+        assert_eq!(v.verify(&mint(KEY_B, FUTURE), 1_000), Some("bravo"));
+        // Signed by an untrusted key → None (signature fails against all keys).
+        assert_eq!(
+            v.verify(&mint("an-untrusted-signing-key", FUTURE), 1_000),
+            None
+        );
+        // Trusted key but long-expired → None.
+        assert_eq!(v.verify(&mint(KEY_A, PAST), 1_000), None);
+        // Malformed → None, never panics.
+        assert_eq!(v.verify("not-a-jwt", 1_000), None);
+        assert_eq!(v.verify("a.b", 1_000), None);
+    }
+
+    #[test]
+    fn jwt_verifier_accepts_pyjwt_minted_token() {
+        // Cross-language contract: a token minted by PyJWT (`JwtTokenManager` on the
+        // relaying controller) must verify here. Pinned so a change to either side's
+        // base64url/HMAC/claims handling is caught. Minted with:
+        //   jwt.encode({"sub":"marin","role":"finelog-relay","jti":"fixedjti0001",
+        //               "iat":1000000000,"exp":4102444800}, KEY, algorithm="HS256")
+        const KEY: &str = "delegation-key-0123456789abcdefX";
+        const TOKEN: &str = "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJzdWIiOiJtYXJpbiIsInJvbGUiOiJmaW5lbG9nLXJlbGF5IiwianRpIjoiZml4ZWRqdGkwMDAxIiwiaWF0IjoxMDAwMDAwMDAwLCJleHAiOjQxMDI0NDQ4MDB9.kTVu3jf6JUbqdHe8WYswdHWzw7WBNT1NfyCxtMoiaPE";
+        let v = verifier(&[("marin", KEY)]);
+        // exp is 4102444800 (2100-01-01); verify at a 2020-era clock.
+        assert_eq!(v.verify(TOKEN, 1_600_000_000), Some("marin"));
+        // A one-byte-different key must not verify (guards against a trivial match).
+        let wrong = verifier(&[("marin", "delegation-key-0123456789abcdefY")]);
+        assert_eq!(wrong.verify(TOKEN, 1_600_000_000), None);
+    }
+
+    #[test]
+    fn jwt_verifier_exp_leeway_tolerates_small_skew() {
+        let v = verifier(&[("alpha", KEY_A)]);
+        let now = 1_000_000;
+        // Expired by less than the leeway → still accepted (clock skew).
+        assert_eq!(
+            v.verify(&mint(KEY_A, now - (EXP_LEEWAY_SECONDS - 5)), now),
+            Some("alpha")
+        );
+        // Expired well beyond the leeway → rejected.
+        assert_eq!(
+            v.verify(&mint(KEY_A, now - (EXP_LEEWAY_SECONDS + 60)), now),
+            None
+        );
+    }
+
+    #[test]
+    fn jwt_verifier_new_rejects_short_secret_and_empty_cluster() {
+        assert!(JwtVerifier::new(vec![("alpha".into(), "short".into())]).is_err());
+        assert!(JwtVerifier::new(vec![(String::new(), KEY_A.into())]).is_err());
+        assert!(JwtVerifier::new(vec![("alpha".into(), KEY_A.into())]).is_ok());
+    }
+
+    #[test]
+    fn jwt_verifier_rejects_alg_none_forgery() {
+        // A token whose header claims `alg: none` (unsigned) must be rejected even
+        // with an empty signature segment.
+        let header = URL_SAFE_NO_PAD.encode(br#"{"alg":"none","typ":"JWT"}"#);
+        let payload = URL_SAFE_NO_PAD.encode(format!(r#"{{"exp":{FUTURE}}}"#).as_bytes());
+        let forged = format!("{header}.{payload}.");
+        assert_eq!(verifier(&[("alpha", KEY_A)]).verify(&forged, 1_000), None);
+    }
+
+    fn jwt_policy_json(cluster: &str, secret: &str) -> String {
+        format!(r#"[{{"type":"jwt","keys":[{{"cluster":"{cluster}","secret":"{secret}"}}]}}]"#)
+    }
+
+    fn stacked_policy_json(cidr: &str, cluster: &str, secret: &str) -> String {
+        format!(
+            r#"[{{"type":"cidr","cidrs":["{cidr}"]}},{{"type":"jwt","keys":[{{"cluster":"{cluster}","secret":"{secret}"}}]}}]"#
+        )
+    }
+
+    fn token_policy() -> AuthPolicy {
+        AuthPolicy::parse(&jwt_policy_json("alpha", KEY_A)).unwrap()
+    }
+
+    fn stacked_policy() -> AuthPolicy {
+        AuthPolicy::parse(&stacked_policy_json("10.0.0.0/8", "alpha", KEY_A)).unwrap()
+    }
+
+    #[test]
+    fn parse_rejects_empty_and_malformed() {
+        // Empty list = total lockout; callers must omit the policy for the default.
+        assert!(AuthPolicy::parse("[]").is_err());
+        assert!(AuthPolicy::parse("not json").is_err());
+        assert!(AuthPolicy::parse(r#"[{"type":"cidr","cidrs":["nope/8"]}]"#).is_err());
+        assert!(AuthPolicy::parse(r#"[{"type":"cidr","cidrs":[]}]"#).is_err());
+        assert!(AuthPolicy::parse(r#"[{"type":"jwt","keys":[]}]"#).is_err());
+        // A too-short delegation secret fails the whole policy at parse time.
+        assert!(AuthPolicy::parse(&jwt_policy_json("alpha", "short")).is_err());
+    }
+
+    #[test]
+    fn allow_localhost_admits_loopback_denies_lan() {
+        let p = AuthPolicy::allow_localhost();
+        assert!(p
+            .authorize(&ctx(None, Some("127.0.0.1:5555".parse().unwrap())))
+            .is_ok());
+        assert!(p
+            .authorize(&ctx(None, Some("[::1]:5555".parse().unwrap())))
+            .is_ok());
+        assert!(p
+            .authorize(&ctx(None, Some("10.1.2.3:5555".parse().unwrap())))
+            .is_err());
+        // No peer info → default-deny.
+        assert!(p.authorize(&ctx(None, None)).is_err());
+    }
+
+    #[test]
+    fn jwt_layer_admits_valid_denies_others() {
+        let p = token_policy();
+        assert!(p
+            .authorize(&ctx(Some(&bearer(&mint(KEY_A, FUTURE))), None))
+            .is_ok());
+        // Present but forged → rejected (not downgraded).
+        assert!(p
+            .authorize(&ctx(
+                Some(&bearer(&mint("an-untrusted-signing-key", FUTURE))),
+                None
+            ))
+            .is_err());
+        // Absent → rejected by the default-deny terminal.
+        assert!(p.authorize(&ctx(None, None)).is_err());
+    }
+
+    #[test]
+    fn cidr_first_admits_trusted_peer_over_unverifiable_token() {
+        // Order (cidr before jwt) is load-bearing: a trusted-network client whose
+        // token the jwt layer cannot verify is still admitted by CIDR, because the
+        // CIDR layer wins before jwt would reject. This is the home controller's
+        // control-plane worker_token case.
+        let p = stacked_policy();
+        let trusted: SocketAddr = "10.1.2.3:5555".parse().unwrap();
+        let untrusted: SocketAddr = "192.0.2.1:5555".parse().unwrap();
+        assert!(p.authorize(&ctx(None, Some(trusted))).is_ok());
+        assert!(p
+            .authorize(&ctx(
+                Some(&bearer(&mint("an-untrusted-signing-key", FUTURE))),
+                Some(trusted)
+            ))
+            .is_ok());
+        // Out-of-VPC client must present a valid JWT.
+        assert!(p
+            .authorize(&ctx(Some(&bearer(&mint(KEY_A, FUTURE))), Some(untrusted)))
+            .is_ok());
+        assert!(p.authorize(&ctx(None, Some(untrusted))).is_err());
+        assert!(p
+            .authorize(&ctx(
+                Some(&bearer(&mint("an-untrusted-signing-key", FUTURE))),
+                Some(untrusted)
+            ))
+            .is_err());
+    }
+
+    fn ok_response() -> UnaryResponse {
+        UnaryResponse::from_encoded(EncodedResponse::new(Bytes::new()), CodecFormat::Proto)
+    }
+
+    async fn run_through(
+        policy: AuthPolicy,
+        request: RequestContext,
+    ) -> (bool, Result<UnaryResponse, ConnectError>) {
+        let interceptor: Arc<dyn Interceptor> = Arc::new(AuthInterceptor::new(Arc::new(policy)));
+        let chain: Vec<Arc<dyn Interceptor>> = vec![interceptor];
+        let ran = Arc::new(AtomicUsize::new(0));
+        let ran2 = Arc::clone(&ran);
+        let req = UnaryRequest::new(request, Bytes::new(), CodecFormat::Proto);
+        let result = run_chain(&chain, req, move |_req| {
+            let ran2 = Arc::clone(&ran2);
+            async move {
+                ran2.fetch_add(1, Ordering::SeqCst);
+                Ok(ok_response())
+            }
+        })
+        .await;
+        (ran.load(Ordering::SeqCst) == 1, result)
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn interceptor_admits_valid_token() {
+        let (ran, result) = run_through(
+            token_policy(),
+            ctx(Some(&bearer(&mint(KEY_A, FUTURE))), None),
+        )
+        .await;
+        assert!(result.is_ok());
+        assert!(ran, "handler ran for an authenticated request");
+    }
+
+    #[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+    async fn interceptor_rejects_unauthenticated() {
+        let (ran, result) = run_through(token_policy(), ctx(None, None)).await;
+        assert_eq!(
+            result.unwrap_err().code,
+            connectrpc::ErrorCode::Unauthenticated
+        );
+        assert!(!ran, "handler never ran for an unauthenticated request");
+    }
+}

--- a/lib/finelog/rust/src/server/mod.rs
+++ b/lib/finelog/rust/src/server/mod.rs
@@ -10,6 +10,7 @@
 //! GET routes take precedence.
 
 pub mod app;
+pub mod auth;
 pub mod debug;
 pub mod diagnostics;
 pub mod forwarded_prefix;
@@ -19,22 +20,11 @@ pub mod log_service;
 pub mod spa;
 pub mod stats_service;
 
-use std::sync::Arc;
-
-use axum::Router;
-
-use crate::store::Store;
-
 pub use app::build_app as build_app_with_config;
 pub use app::ServerConfig;
+pub use auth::AuthPolicy;
 
 /// 64 MiB request/message limits (default is 4 MB — too small for WriteRows /
 /// large query IPC). The Query handler reuses it as the result-size bound ->
 /// `resource_exhausted`.
 pub(crate) const MAX_MESSAGE_BYTES: usize = 64 << 20;
-
-/// Build the axum app with production defaults and the given `--debug-admin`
-/// flag. Thin convenience over [`app::build_app`] for the binary entry point.
-pub fn build_app(store: Arc<Store>, debug_admin: bool) -> Router {
-    app::build_app(store, ServerConfig::with_debug_admin(debug_admin))
-}

--- a/lib/finelog/src/finelog/client/log_client.py
+++ b/lib/finelog/src/finelog/client/log_client.py
@@ -540,6 +540,28 @@ class LogClient:
         table = self._get_log_table()
         table.write(_log_entries_to_rows(key, messages))
 
+    def push_batch(self, key: str, entries: Sequence[logging_pb2.LogEntry]) -> None:
+        """Append ``entries`` under ``key`` via ``LogService.PushLogs``, synchronously.
+
+        Unlike :meth:`write_batch` (which enqueues to a lossy in-memory Table and
+        acks nothing), this awaits the server's response, which the store returns
+        only after the batch is durably persisted. It therefore raises on any
+        failure and a successful return means the batch landed — the ack the
+        durable log relay needs to advance its watermark.
+        """
+        if not entries:
+            return
+        client = self._get_log_service_client()
+        try:
+            client.push_logs(logging_pb2.PushLogsRequest(key=key, entries=list(entries)))
+        except ConnectError as exc:
+            if is_retryable_error(exc):
+                self._invalidate(_format_exc_summary(exc))
+            raise _translate_connect_error(exc) from exc
+        except (ConnectionError, OSError, TimeoutError) as exc:
+            self._invalidate(_format_exc_summary(exc))
+            raise
+
     def fetch_logs(self, request: logging_pb2.FetchLogsRequest) -> logging_pb2.FetchLogsResponse:
         """Read from the ``log`` namespace via ``LogService.FetchLogs``.
 

--- a/lib/finelog/src/finelog/deploy/_gcp.py
+++ b/lib/finelog/src/finelog/deploy/_gcp.py
@@ -18,7 +18,7 @@ import time
 import click
 
 from finelog.deploy.bootstrap import CONTAINER_NAME, render_bootstrap
-from finelog.deploy.config import FinelogConfig
+from finelog.deploy.config import FinelogConfig, assert_inlineable_auth, auth_policy_json
 from finelog.deploy.image import resolve_image_digest
 
 LABEL_KEY = "finelog-name"
@@ -97,6 +97,27 @@ def _wait_health_via_ssh(cfg: FinelogConfig, port: int, max_attempts: int = 90) 
     return False
 
 
+def _render_bootstrap(cfg: FinelogConfig) -> str:
+    """Pin the image and render the VM bootstrap script for ``cfg``.
+
+    The script becomes startup-script metadata (readable to anyone with instance-
+    metadata access), so an auth stack carrying jwt secrets is rejected — those must
+    come through an operator-managed metadata secret, never inline.
+    """
+    pinned = resolve_image_digest(cfg.image)
+    if pinned != cfg.image:
+        click.echo(f"Pinned image: {cfg.image} -> {pinned}")
+    else:
+        click.echo(f"Using image: {pinned}")
+    assert_inlineable_auth(cfg)
+    return render_bootstrap(
+        image=pinned,
+        port=cfg.port,
+        remote_log_dir=cfg.remote_log_dir,
+        auth_policy=auth_policy_json(cfg.auth) if cfg.auth else "",
+    )
+
+
 def gcp_up(cfg: FinelogConfig) -> None:
     """Create a finelog GCE VM. Idempotent: errors out cleanly if the VM exists."""
     assert cfg.deployment.gcp is not None
@@ -108,13 +129,7 @@ def gcp_up(cfg: FinelogConfig) -> None:
         click.echo("Run `finelog deploy restart <name>` to refresh the container in place.")
         return
 
-    pinned = resolve_image_digest(cfg.image)
-    if pinned != cfg.image:
-        click.echo(f"Pinned image: {cfg.image} -> {pinned}")
-    else:
-        click.echo(f"Using image: {pinned}")
-
-    bootstrap = render_bootstrap(image=pinned, port=cfg.port, remote_log_dir=cfg.remote_log_dir)
+    bootstrap = _render_bootstrap(cfg)
 
     with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as f:
         f.write(bootstrap)
@@ -176,13 +191,7 @@ def gcp_restart(cfg: FinelogConfig) -> None:
     assert cfg.deployment.gcp is not None
     gcp = cfg.deployment.gcp
 
-    pinned = resolve_image_digest(cfg.image)
-    if pinned != cfg.image:
-        click.echo(f"Pinned image: {cfg.image} -> {pinned}")
-    else:
-        click.echo(f"Using image: {pinned}")
-
-    bootstrap = render_bootstrap(image=pinned, port=cfg.port, remote_log_dir=cfg.remote_log_dir)
+    bootstrap = _render_bootstrap(cfg)
 
     # Update the instance's startup-script metadata so that a future VM reboot
     # (host maintenance, manual reset) brings up the same image we're about to

--- a/lib/finelog/src/finelog/deploy/_k8s.py
+++ b/lib/finelog/src/finelog/deploy/_k8s.py
@@ -19,7 +19,7 @@ from pathlib import Path
 import click
 
 from finelog.deploy.bootstrap import render_template
-from finelog.deploy.config import FinelogConfig
+from finelog.deploy.config import FinelogConfig, assert_inlineable_auth, auth_policy_json
 from finelog.deploy.image import resolve_image_digest
 
 _TEMPLATE_VAR_RE = re.compile(r"\{\{ (\w+) \}\}")
@@ -34,6 +34,22 @@ _S3_SECRET_SUFFIX = "-env"
 _K8S_MANIFEST_DIR = Path(__file__).resolve().parents[3] / "deploy" / "k8s"
 
 _MANIFESTS = ("01-pvc.yaml.tmpl", "02-deployment.yaml.tmpl", "03-service.yaml.tmpl")
+
+
+def _auth_env_block(cfg: FinelogConfig) -> str:
+    """Render the `FINELOG_AUTH_POLICY` container-env entry, or "" for no policy.
+
+    A cidr-only policy carries no secrets and is injected inline. A policy with a
+    jwt layer carries key material, so it is rejected here — it must be supplied
+    through the `{name}-env` Secret rather than baked into a plaintext manifest.
+    """
+    if not cfg.auth:
+        return ""
+    assert_inlineable_auth(cfg)
+    policy = auth_policy_json(cfg.auth)
+    if "'" in policy:
+        raise ValueError("auth policy must not contain a single quote")
+    return f"            - name: FINELOG_AUTH_POLICY\n              value: '{policy}'"
 
 
 def _render_manifest(template_path: Path, cfg: FinelogConfig) -> str:
@@ -58,6 +74,7 @@ def _render_manifest(template_path: Path, cfg: FinelogConfig) -> str:
         "remote_log_dir": cfg.remote_log_dir,
         "storage_class_block": storage_class_block,
         "storage_gb": k8s.storage_gb,
+        "auth_env_block": _auth_env_block(cfg),
     }
     referenced = set(_TEMPLATE_VAR_RE.findall(template))
     return render_template(template, **{k: v for k, v in all_vars.items() if k in referenced})

--- a/lib/finelog/src/finelog/deploy/bootstrap.py
+++ b/lib/finelog/src/finelog/deploy/bootstrap.py
@@ -102,7 +102,7 @@ sudo docker run -d --name {{ container_name }} \\
     --memory="${container_mem_mib}m" \\
     -e FINELOG_PORT={{ port }} \\
     -e FINELOG_REMOTE_DIR={{ remote_log_dir }} \\
-    -v {{ cache_dir }}:{{ cache_dir }} \\
+    {{ auth_env }}-v {{ cache_dir }}:{{ cache_dir }} \\
     {{ docker_image }}
 
 echo "[finelog-init] Container started; waiting for /health on port {{ port }}..."
@@ -129,17 +129,27 @@ exit 1
 """
 
 
-def render_bootstrap(image: str, port: int, remote_log_dir: str) -> str:
-    """Render the finelog bootstrap script."""
+def render_bootstrap(image: str, port: int, remote_log_dir: str, auth_policy: str = "") -> str:
+    """Render the finelog bootstrap script.
+
+    ``auth_policy`` is the ``FINELOG_AUTH_POLICY`` JSON (see
+    ``deploy.config.auth_policy_json``); empty leaves the server on its private
+    allow-localhost default. It is passed single-quoted, so it must not contain a
+    single quote (the JSON never does — hex secrets, identifiers, CIDRs).
+    """
     if not image:
         raise ValueError("image is required")
     if port <= 0:
         raise ValueError("port must be > 0")
+    if "'" in auth_policy:
+        raise ValueError("auth_policy must not contain a single quote")
+    auth_env = f"-e FINELOG_AUTH_POLICY='{auth_policy}' " if auth_policy else ""
     return render_template(
         BOOTSTRAP_SCRIPT,
         docker_image=image,
         port=port,
         remote_log_dir=remote_log_dir,
+        auth_env=auth_env,
         cache_dir=CACHE_DIR,
         container_name=CONTAINER_NAME,
     )

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -10,6 +10,7 @@ and explicit; finelog owns its deployment knobs so iris's cluster yaml only
 has to reference the config by name.
 """
 
+import json
 from dataclasses import dataclass
 from importlib.resources import files
 from pathlib import Path
@@ -63,6 +64,72 @@ class K8sDeployment:
 
 
 @dataclass(frozen=True)
+class CidrAuthLayer:
+    """Admit a request whose transport peer is in one of ``cidrs``.
+
+    Reproduces intra-cluster reachability: a finelog serving its own cluster lists
+    that cluster's loopback/VPC ranges (e.g. ``10.0.0.0/8``, ``127.0.0.0/8``) so
+    local clients keep working without a token. Matches the transport peer only,
+    never a spoofable forwarded header.
+    """
+
+    cidrs: tuple[str, ...]
+
+    def to_policy_dict(self) -> dict:
+        return {"type": "cidr", "cidrs": list(self.cidrs)}
+
+
+@dataclass(frozen=True)
+class JwtKeyEntry:
+    """A trusted cluster and its HS256 delegation secret."""
+
+    cluster: str
+    secret: str
+
+
+@dataclass(frozen=True)
+class JwtAuthLayer:
+    """Admit a bearer JWT whose HS256 signature verifies against one of ``keys``.
+
+    Each key is a trusted cluster's HS256 delegation secret; every configured key
+    admits equally. The keys are secret material, so a jwt layer may not be inlined
+    into a plaintext deploy artifact — the deploy path rejects it and requires a
+    secret source instead.
+    """
+
+    keys: tuple[JwtKeyEntry, ...]
+
+    def to_policy_dict(self) -> dict:
+        return {"type": "jwt", "keys": [{"cluster": k.cluster, "secret": k.secret} for k in self.keys]}
+
+
+# One entry in the ordered auth stack. Evaluation order == list order (first
+# Allow admits, first Reject denies, none → deny; see the Rust `AuthPolicy`).
+AuthLayer = CidrAuthLayer | JwtAuthLayer
+
+
+def auth_policy_json(layers: tuple[AuthLayer, ...]) -> str:
+    """Serialize an ordered auth-layer stack to the `FINELOG_AUTH_POLICY` JSON the
+    finelog server parses."""
+    return json.dumps([layer.to_policy_dict() for layer in layers], separators=(",", ":"))
+
+
+def assert_inlineable_auth(cfg: "FinelogConfig") -> None:
+    """Raise if the auth stack carries secret material that must not be inlined.
+
+    A `jwt` layer holds HS256 delegation keys; both deploy paths bake the policy into a
+    plaintext artifact (GCE startup-script metadata, a k8s manifest), so jwt keys must
+    instead come through a secret source (the finelog-env Secret, or an operator-managed
+    metadata secret). A cidr-only policy carries no secrets and inlines safely.
+    """
+    if any(isinstance(layer, JwtAuthLayer) for layer in cfg.auth):
+        raise ValueError(
+            f"{cfg.name}: jwt auth layers carry secret keys and cannot be inlined into a plaintext "
+            "deploy artifact; supply FINELOG_AUTH_POLICY through a secret source instead"
+        )
+
+
+@dataclass(frozen=True)
 class Deployment:
     """Backend selector. Exactly one of `gcp` or `k8s` must be set."""
 
@@ -89,6 +156,9 @@ class FinelogConfig:
     # Rigging transport URL clients use to reach this server through the controller proxy
     # (e.g. `iap+https://iris.oa.dev/proxy/system.log-server`); unset = fall back to SSH/k8s tunnel.
     client_url: str | None = None
+    # Ordered authenticated-ingress layer stack. Empty leaves the server on its
+    # allow-localhost default (loopback only, never open).
+    auth: tuple[AuthLayer, ...] = ()
 
 
 def _config_search_paths(name_or_path: str) -> list[Path]:
@@ -112,6 +182,24 @@ def _build_gcp(raw: dict) -> GcpDeployment:
         service_account=raw.get("service_account"),
         network_tags=tuple(tags),
     )
+
+
+def _build_auth_layers(raw: list, path: Path) -> tuple[AuthLayer, ...]:
+    """Parse the `auth:` YAML list into an ordered layer stack. List order is
+    evaluation order (see the Rust `AuthPolicy`)."""
+    layers: list[AuthLayer] = []
+    for i, item in enumerate(raw):
+        if not isinstance(item, dict) or "type" not in item:
+            raise ValueError(f"{path}: auth[{i}] must be a mapping with a `type` key")
+        layer_type = item["type"]
+        if layer_type == "cidr":
+            layers.append(CidrAuthLayer(cidrs=tuple(item.get("cidrs") or ())))
+        elif layer_type == "jwt":
+            keys = tuple(JwtKeyEntry(cluster=k["cluster"], secret=k["secret"]) for k in item.get("keys") or ())
+            layers.append(JwtAuthLayer(keys=keys))
+        else:
+            raise ValueError(f"{path}: auth[{i}] has unknown type {layer_type!r} (expected cidr|jwt)")
+    return tuple(layers)
 
 
 def _build_k8s(raw: dict) -> K8sDeployment:
@@ -153,6 +241,11 @@ def _load_from_path(path: Path) -> FinelogConfig:
     k8s = _build_k8s(deploy_raw["k8s"]) if "k8s" in deploy_raw else None
     deployment = Deployment(gcp=gcp, k8s=k8s)
 
+    auth_raw = raw.get("auth")
+    if auth_raw is not None and not isinstance(auth_raw, list):
+        raise ValueError(f"{path}: `auth` must be a list of layers")
+    auth = _build_auth_layers(auth_raw, path) if auth_raw else ()
+
     return FinelogConfig(
         name=raw["name"],
         port=int(raw["port"]),
@@ -160,6 +253,7 @@ def _load_from_path(path: Path) -> FinelogConfig:
         remote_log_dir=raw.get("remote_log_dir", ""),
         deployment=deployment,
         client_url=raw.get("client_url"),
+        auth=auth,
     )
 
 

--- a/lib/finelog/src/finelog/forwarder.py
+++ b/lib/finelog/src/finelog/forwarder.py
@@ -22,6 +22,13 @@ On first run the watermark is seeded at the source's current max cursor, so enab
 forwarder ships new logs going forward without backfilling the whole retention window.
 The state file also records the target it tracks; pointing a forwarder at a different
 target reseeds rather than replaying stale cursors into a new store's id space.
+
+The watermark is deliberately local best-effort state: it is fsync'd so it survives a
+process restart on the same host, but it is not part of any external checkpoint. If the
+state file is lost (e.g. the host is replaced), the forwarder reseeds at the source's
+current max — accepting a bounded gap of un-forwarded logs rather than replaying the
+retention window. That trade suits a log relay, where a gap degrades observability, not
+correctness.
 """
 
 import json
@@ -142,6 +149,11 @@ class LogForwarder:
                 # A keyless entry can't be namespaced; drop it rather than stall the
                 # watermark (the source always keys its writes).
                 continue
+            if self._key_prefix and entry.key.startswith(self._key_prefix):
+                # Already under our prefix — a row this forwarder produced (source and
+                # target are the same store, or otherwise share one). Skipping it stops
+                # an unbounded /c/x/c/x/... re-forward loop; the watermark still advances.
+                continue
             groups[entry.key].append(entry)
 
         try:
@@ -157,7 +169,9 @@ class LogForwarder:
             )
             return 0
 
-        forwarded = len(response.entries)
+        # Count what was actually pushed, not what was fetched: keyless and
+        # already-namespaced entries are skipped above but still advance the watermark.
+        forwarded = sum(len(entries) for entries in groups.values())
         self._forwarded += forwarded
         self._write_watermark(response.cursor)
         return forwarded

--- a/lib/finelog/src/finelog/forwarder.py
+++ b/lib/finelog/src/finelog/forwarder.py
@@ -1,0 +1,233 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Durable log forwarder: tail one finelog, forward to another (the "log-proxy").
+
+A :class:`LogForwarder` reads a source finelog's log store and re-appends each batch
+to a target finelog under a caller-supplied key prefix. It is the mechanism behind
+Iris federation's global-finelog relay (each cluster forwards its logs to one shared
+store under a ``/c/<cluster>`` prefix), but it is generic: source, target, and prefix
+are all injected, and it holds no Iris concepts.
+
+Durability leans on the source, which is itself durable (finelog persists to parquet
+with a retention window). The forwarder therefore stores only a forward *watermark* —
+the max source autoincrement id confirmed landed at the target — in a small JSON state
+file, not a second copy of the log data. Forwarding uses :meth:`LogClient.push_batch`,
+which returns only after the target durably persists the batch; the watermark advances
+only after that ack, so a crash or transient failure re-forwards the in-flight batch on
+the next tick rather than losing it (at-least-once; duplicate lines are bounded to the
+failure boundary and tolerable for logs).
+
+On first run the watermark is seeded at the source's current max cursor, so enabling a
+forwarder ships new logs going forward without backfilling the whole retention window.
+The state file also records the target it tracks; pointing a forwarder at a different
+target reseeds rather than replaying stale cursors into a new store's id space.
+"""
+
+import json
+import logging
+import os
+import threading
+from collections import defaultdict
+from pathlib import Path
+
+from finelog.client.log_client import LogClient
+from finelog.rpc import logging_pb2
+
+logger = logging.getLogger(__name__)
+
+# All finelog log keys are absolute (`/user/...`, `/system/...`), so a PREFIX read on
+# "/" tails the entire source store.
+_ALL_KEYS_PREFIX = "/"
+
+_DEFAULT_BATCH_LINES = 1000
+_DEFAULT_POLL_INTERVAL_SECONDS = 5.0
+_DEFAULT_STOP_TIMEOUT_SECONDS = 5.0
+
+
+class CorruptForwarderStateError(RuntimeError):
+    """The state file exists but is unreadable or malformed.
+
+    Kept distinct from an absent file (a genuine first run): a corrupt watermark must
+    not be treated as first-run, or the forwarder would seed at the source's current
+    max and permanently skip the logs between the lost watermark and now. The operator
+    repairs or removes the file; until then the forwarder refuses to advance.
+    """
+
+
+class LogForwarder:
+    """Tails ``source`` and forwards new log batches to ``target`` under ``key_prefix``.
+
+    The forwarder owns ``target`` (created for it) and closes it on :meth:`stop`; it
+    never closes ``source`` (owned by the caller). ``key_prefix`` is prepended to every
+    forwarded key (e.g. ``/c/marin``); empty forwards keys unchanged.
+    """
+
+    def __init__(
+        self,
+        *,
+        source: LogClient,
+        target: LogClient,
+        target_label: str,
+        key_prefix: str,
+        state_path: Path,
+        batch_lines: int = _DEFAULT_BATCH_LINES,
+        poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
+    ):
+        self._source = source
+        self._target = target
+        self._target_label = target_label
+        self._key_prefix = key_prefix
+        self._state_path = Path(state_path)
+        self._batch_lines = batch_lines
+        self._poll_interval = poll_interval_seconds
+        self._stop = threading.Event()
+        self._thread: threading.Thread | None = None
+        # In-memory observability counters (the state file only needs the cursor).
+        self._forwarded = 0
+        self._failed = 0
+
+    def start(self) -> None:
+        self._thread = threading.Thread(target=self._run, name="finelog-forwarder", daemon=False)
+        self._thread.start()
+
+    def stop(self, timeout_seconds: float = _DEFAULT_STOP_TIMEOUT_SECONDS) -> None:
+        self._stop.set()
+        if self._thread is not None:
+            self._thread.join(timeout=timeout_seconds)
+            self._thread = None
+        self._target.close()
+
+    def _run(self) -> None:
+        while not self._stop.is_set():
+            try:
+                self.forward_once()
+            except Exception:
+                # A failed forward is already recorded and retried; an unexpected error
+                # (e.g. a source read) must not kill the loop and silently stop shipping.
+                logger.exception("finelog forwarder: unexpected error in tick")
+            self._stop.wait(timeout=self._poll_interval)
+
+    def forward_once(self) -> int:
+        """Forward one batch of newly-ingested source logs to the target.
+
+        Returns the number of entries forwarded this tick (0 = nothing new, or the
+        initial seed). Exposed so a test can drive one tick deterministically.
+        """
+        cursor = self._read_watermark()
+        if cursor is None:
+            seed = self._source_max_cursor()
+            self._write_watermark(seed)
+            logger.info(
+                "finelog forwarder: seeded watermark at source cursor %d for %s (new logs only)",
+                seed,
+                self._target_label,
+            )
+            return 0
+
+        response = self._source.fetch_logs(
+            logging_pb2.FetchLogsRequest(
+                source=_ALL_KEYS_PREFIX,
+                match_scope=logging_pb2.MATCH_SCOPE_PREFIX,
+                cursor=cursor,
+                max_lines=self._batch_lines,
+            )
+        )
+        if not response.entries:
+            return 0
+
+        groups: dict[str, list[logging_pb2.LogEntry]] = defaultdict(list)
+        for entry in response.entries:
+            if not entry.key:
+                # A keyless entry can't be namespaced; drop it rather than stall the
+                # watermark (the source always keys its writes).
+                continue
+            groups[entry.key].append(entry)
+
+        try:
+            for key, entries in groups.items():
+                self._target.push_batch(self._key_prefix + key, entries)
+        except Exception as exc:
+            self._failed += 1
+            logger.warning(
+                "finelog forwarder: forward failed at cursor %d (%s: %s); retrying next tick",
+                cursor,
+                type(exc).__name__,
+                exc,
+            )
+            return 0
+
+        forwarded = len(response.entries)
+        self._forwarded += forwarded
+        self._write_watermark(response.cursor)
+        return forwarded
+
+    def _source_max_cursor(self) -> int:
+        """The source's current max autoincrement id (the seed watermark)."""
+        response = self._source.fetch_logs(
+            logging_pb2.FetchLogsRequest(
+                source=_ALL_KEYS_PREFIX,
+                match_scope=logging_pb2.MATCH_SCOPE_PREFIX,
+                tail=True,
+                max_lines=1,
+            )
+        )
+        return response.cursor
+
+    def _read_watermark(self) -> int | None:
+        """The persisted watermark, or ``None`` on a genuine first run / intentional repoint.
+
+        Returns ``None`` only when the state file is absent (first run) or tracks a
+        different target (an intentional repoint — reseed rather than replay stale
+        cursors into a new store's id space). A file that exists but is malformed raises
+        :class:`CorruptForwarderStateError` so a damaged watermark surfaces loudly
+        instead of silently reseeding past un-forwarded logs.
+        """
+        try:
+            raw = self._state_path.read_text()
+        except FileNotFoundError:
+            return None
+        try:
+            state = json.loads(raw)
+        except ValueError as exc:
+            raise CorruptForwarderStateError(f"forwarder state file {self._state_path} is not valid JSON") from exc
+        if not isinstance(state, dict):
+            raise CorruptForwarderStateError(f"forwarder state file {self._state_path} is not a JSON object")
+        if state.get("target") != self._target_label:
+            logger.warning(
+                "finelog forwarder: state file %s tracks target %r, not %r; reseeding for the new target",
+                self._state_path,
+                state.get("target"),
+                self._target_label,
+            )
+            return None
+        cursor = state.get("cursor")
+        if not isinstance(cursor, int) or isinstance(cursor, bool):
+            raise CorruptForwarderStateError(f"forwarder state file {self._state_path} has no integer cursor")
+        return cursor
+
+    def _write_watermark(self, cursor: int) -> None:
+        """Atomically and durably persist the watermark (write-temp, fsync, rename).
+
+        fsync of the temp file and the parent directory makes the watermark survive a
+        crash: a lost state file reads as a first run and would reseed past un-forwarded
+        logs, so its durability is what bounds forwarding to at-least-once.
+        """
+        payload = {
+            "target": self._target_label,
+            "cursor": cursor,
+            "forwarded": self._forwarded,
+            "failed": self._failed,
+        }
+        self._state_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._state_path.with_suffix(self._state_path.suffix + ".tmp")
+        with open(tmp, "w") as f:
+            f.write(json.dumps(payload))
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp, self._state_path)
+        dir_fd = os.open(self._state_path.parent, os.O_RDONLY)
+        try:
+            os.fsync(dir_fd)
+        finally:
+            os.close(dir_fd)

--- a/lib/finelog/src/finelog/forwarder.py
+++ b/lib/finelog/src/finelog/forwarder.py
@@ -1,13 +1,14 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""Durable log forwarder: tail one finelog, forward to another (the "log-proxy").
+"""Durable log forwarder: tail one finelog, replicate it into another (the "log-proxy").
 
-A :class:`LogForwarder` reads a source finelog's log store and re-appends each batch
-to a target finelog under a caller-supplied key prefix. It is the mechanism behind
-Iris federation's global-finelog relay (each cluster forwards its logs to one shared
-store under a ``/c/<cluster>`` prefix), but it is generic: source, target, and prefix
-are all injected, and it holds no Iris concepts.
+A :class:`LogForwarder` reads a source finelog's log store and re-appends each new batch
+to a target finelog under the same keys. It is the mechanism behind Iris federation's
+global-finelog relay (each cluster forwards its logs to one shared store), but it is
+generic: source and target are injected and it holds no Iris concepts. Source and target
+must be distinct stores — it does not dedupe its own writes, so forwarding a store into
+itself would loop.
 
 Durability leans on the source, which is itself durable (finelog persists to parquet
 with a retention window). The forwarder therefore stores only a forward *watermark* —
@@ -63,11 +64,10 @@ class CorruptForwarderStateError(RuntimeError):
 
 
 class LogForwarder:
-    """Tails ``source`` and forwards new log batches to ``target`` under ``key_prefix``.
+    """Tails ``source`` and forwards new log batches to ``target`` under the same keys.
 
     The forwarder owns ``target`` (created for it) and closes it on :meth:`stop`; it
-    never closes ``source`` (owned by the caller). ``key_prefix`` is prepended to every
-    forwarded key (e.g. ``/c/marin``); empty forwards keys unchanged.
+    never closes ``source`` (owned by the caller).
     """
 
     def __init__(
@@ -76,7 +76,6 @@ class LogForwarder:
         source: LogClient,
         target: LogClient,
         target_label: str,
-        key_prefix: str,
         state_path: Path,
         batch_lines: int = _DEFAULT_BATCH_LINES,
         poll_interval_seconds: float = _DEFAULT_POLL_INTERVAL_SECONDS,
@@ -84,7 +83,6 @@ class LogForwarder:
         self._source = source
         self._target = target
         self._target_label = target_label
-        self._key_prefix = key_prefix
         self._state_path = Path(state_path)
         self._batch_lines = batch_lines
         self._poll_interval = poll_interval_seconds
@@ -164,20 +162,14 @@ class LogForwarder:
         groups: dict[str, list[logging_pb2.LogEntry]] = defaultdict(list)
         for entry in response.entries:
             if not entry.key:
-                # A keyless entry can't be namespaced; drop it rather than stall the
-                # watermark (the source always keys its writes).
-                continue
-            if self._key_prefix and entry.key.startswith(self._key_prefix + "/"):
-                # Already under our prefix — a row this forwarder produced (source and
-                # target are the same store, or otherwise share one). Skipping it stops
-                # an unbounded /c/x/c/x/... re-forward loop; the watermark still advances.
-                # The trailing "/" keeps a sibling prefix (/c/x-dev) from matching /c/x.
+                # A keyless entry has no key to replicate under; drop it rather than
+                # stall the watermark (the source always keys its writes).
                 continue
             groups[entry.key].append(entry)
 
         try:
             for key, entries in groups.items():
-                self._target.push_batch(self._key_prefix + key, entries)
+                self._target.push_batch(key, entries)
         except Exception as exc:
             self._failed += 1
             logger.warning(
@@ -193,8 +185,8 @@ class LogForwarder:
         # poll interval. Reset to 0 on every non-forwarding path (seed, empty, failure).
         self._last_fetched = len(response.entries)
 
-        # Count what was actually pushed, not what was fetched: keyless and
-        # already-namespaced entries are skipped above but still advance the watermark.
+        # Count what was actually pushed, not what was fetched: keyless entries are
+        # skipped above but still advance the watermark.
         forwarded = sum(len(entries) for entries in groups.values())
         self._forwarded += forwarded
         self._write_watermark(response.cursor)

--- a/lib/finelog/src/finelog/forwarder.py
+++ b/lib/finelog/src/finelog/forwarder.py
@@ -93,6 +93,8 @@ class LogForwarder:
         # In-memory observability counters (the state file only needs the cursor).
         self._forwarded = 0
         self._failed = 0
+        # Rows fetched in the last `forward_once`; a full batch drives the drain loop.
+        self._last_fetched = 0
 
     def start(self) -> None:
         self._thread = threading.Thread(target=self._run, name="finelog-forwarder", daemon=False)
@@ -108,12 +110,27 @@ class LogForwarder:
     def _run(self) -> None:
         while not self._stop.is_set():
             try:
-                self.forward_once()
+                self._drain()
             except Exception:
                 # A failed forward is already recorded and retried; an unexpected error
                 # (e.g. a source read) must not kill the loop and silently stop shipping.
                 logger.exception("finelog forwarder: unexpected error in tick")
             self._stop.wait(timeout=self._poll_interval)
+
+    def _drain(self) -> int:
+        """Forward batches until caught up, then return the total forwarded this pass.
+
+        Shipping only one ``batch_lines`` batch per poll interval caps the forward rate; a
+        cluster producing faster than that would fall behind until source retention evicts
+        un-forwarded rows (silent loss). So we keep forwarding while each batch comes back
+        full (more pending), and stop on a short batch (caught up), a failure, or stop.
+        """
+        total = 0
+        while not self._stop.is_set():
+            total += self.forward_once()
+            if self._last_fetched < self._batch_lines:
+                return total
+        return total
 
     def forward_once(self) -> int:
         """Forward one batch of newly-ingested source logs to the target.
@@ -121,6 +138,7 @@ class LogForwarder:
         Returns the number of entries forwarded this tick (0 = nothing new, or the
         initial seed). Exposed so a test can drive one tick deterministically.
         """
+        self._last_fetched = 0
         cursor = self._read_watermark()
         if cursor is None:
             seed = self._source_max_cursor()
@@ -149,10 +167,11 @@ class LogForwarder:
                 # A keyless entry can't be namespaced; drop it rather than stall the
                 # watermark (the source always keys its writes).
                 continue
-            if self._key_prefix and entry.key.startswith(self._key_prefix):
+            if self._key_prefix and entry.key.startswith(self._key_prefix + "/"):
                 # Already under our prefix — a row this forwarder produced (source and
                 # target are the same store, or otherwise share one). Skipping it stops
                 # an unbounded /c/x/c/x/... re-forward loop; the watermark still advances.
+                # The trailing "/" keeps a sibling prefix (/c/x-dev) from matching /c/x.
                 continue
             groups[entry.key].append(entry)
 
@@ -168,6 +187,11 @@ class LogForwarder:
                 exc,
             )
             return 0
+
+        # A full fetch means the source has more pending past this batch — the drain loop
+        # in `_run` reads this to keep forwarding within the tick instead of one batch per
+        # poll interval. Reset to 0 on every non-forwarding path (seed, empty, failure).
+        self._last_fetched = len(response.entries)
 
         # Count what was actually pushed, not what was fetched: keyless and
         # already-namespaced entries are skipped above but still advance the watermark.

--- a/lib/finelog/tests/test_config.py
+++ b/lib/finelog/tests/test_config.py
@@ -9,12 +9,9 @@ from pathlib import Path
 
 import pytest
 from finelog.deploy.config import (
-    CidrAuthLayer,
     Deployment,
     FinelogConfig,
     GcpDeployment,
-    JwtAuthLayer,
-    JwtKeyEntry,
     K8sDeployment,
     auth_policy_json,
     derive_endpoint_uri,
@@ -136,9 +133,9 @@ def test_derive_endpoint_uri_k8s() -> None:
     assert metadata == {"port": "10001"}
 
 
-def test_auth_layers_parse_and_serialize(tmp_path: Path) -> None:
-    """An ordered cidr+jwt `auth:` list parses to typed layers and serializes to the
-    `FINELOG_AUTH_POLICY` JSON the finelog server reads, order preserved."""
+def test_auth_layers_serialize_to_finelog_policy_json(tmp_path: Path) -> None:
+    """An ordered cidr+jwt `auth:` list serializes to the exact `FINELOG_AUTH_POLICY`
+    JSON the finelog Rust server parses — order preserved, snake_case tags."""
     cfg_path = tmp_path / "authed.yaml"
     _write_config(
         cfg_path,
@@ -160,10 +157,6 @@ def test_auth_layers_parse_and_serialize(tmp_path: Path) -> None:
         """,
     )
     cfg = load_finelog_config(str(cfg_path))
-    assert cfg.auth == (
-        CidrAuthLayer(cidrs=("10.0.0.0/8", "::1/128")),
-        JwtAuthLayer(keys=(JwtKeyEntry(cluster="marin", secret="0123456789abcdef0123456789abcdef"),)),
-    )
     assert json.loads(auth_policy_json(cfg.auth)) == [
         {"type": "cidr", "cidrs": ["10.0.0.0/8", "::1/128"]},
         {"type": "jwt", "keys": [{"cluster": "marin", "secret": "0123456789abcdef0123456789abcdef"}]},

--- a/lib/finelog/tests/test_config.py
+++ b/lib/finelog/tests/test_config.py
@@ -3,15 +3,20 @@
 
 """Tests for `finelog.deploy.config`."""
 
+import json
 import textwrap
 from pathlib import Path
 
 import pytest
 from finelog.deploy.config import (
+    CidrAuthLayer,
     Deployment,
     FinelogConfig,
     GcpDeployment,
+    JwtAuthLayer,
+    JwtKeyEntry,
     K8sDeployment,
+    auth_policy_json,
     derive_endpoint_uri,
     load_finelog_config,
 )
@@ -129,3 +134,58 @@ def test_derive_endpoint_uri_k8s() -> None:
     uri, metadata = derive_endpoint_uri(cfg)
     assert uri == "k8s://finelog-x.iris"
     assert metadata == {"port": "10001"}
+
+
+def test_auth_layers_parse_and_serialize(tmp_path: Path) -> None:
+    """An ordered cidr+jwt `auth:` list parses to typed layers and serializes to the
+    `FINELOG_AUTH_POLICY` JSON the finelog server reads, order preserved."""
+    cfg_path = tmp_path / "authed.yaml"
+    _write_config(
+        cfg_path,
+        """
+        name: finelog-authed
+        port: 10001
+        image: ghcr.io/test/finelog:latest
+        remote_log_dir: gs://bucket/x
+        deployment:
+          gcp:
+            project: p
+            zone: us-central1-a
+        auth:
+          - type: cidr
+            cidrs: [10.0.0.0/8, "::1/128"]
+          - type: jwt
+            keys:
+              - {cluster: marin, secret: 0123456789abcdef0123456789abcdef}
+        """,
+    )
+    cfg = load_finelog_config(str(cfg_path))
+    assert cfg.auth == (
+        CidrAuthLayer(cidrs=("10.0.0.0/8", "::1/128")),
+        JwtAuthLayer(keys=(JwtKeyEntry(cluster="marin", secret="0123456789abcdef0123456789abcdef"),)),
+    )
+    assert json.loads(auth_policy_json(cfg.auth)) == [
+        {"type": "cidr", "cidrs": ["10.0.0.0/8", "::1/128"]},
+        {"type": "jwt", "keys": [{"cluster": "marin", "secret": "0123456789abcdef0123456789abcdef"}]},
+    ]
+
+
+def test_auth_unknown_layer_type_rejected(tmp_path: Path) -> None:
+    cfg_path = tmp_path / "bad.yaml"
+    _write_config(
+        cfg_path,
+        """
+        name: finelog-bad
+        port: 10001
+        image: ghcr.io/test/finelog:latest
+        remote_log_dir: gs://bucket/x
+        deployment:
+          gcp:
+            project: p
+            zone: us-central1-a
+        auth:
+          - type: mtls
+        """,
+    )
+    with pytest.raises(ValueError, match="unknown type 'mtls'"):
+        load_finelog_config(str(cfg_path))

--- a/lib/finelog/tests/test_deploy_k8s.py
+++ b/lib/finelog/tests/test_deploy_k8s.py
@@ -15,7 +15,14 @@ from finelog.deploy._k8s import (
     _render_manifest,
     _s3_secret_name,
 )
-from finelog.deploy.config import Deployment, FinelogConfig, K8sDeployment
+from finelog.deploy.config import (
+    CidrAuthLayer,
+    Deployment,
+    FinelogConfig,
+    JwtAuthLayer,
+    JwtKeyEntry,
+    K8sDeployment,
+)
 
 
 def _s3_cfg(**k8s_overrides) -> FinelogConfig:
@@ -71,6 +78,35 @@ def test_render_deployment_threads_port_to_env_and_probes(cfg: FinelogConfig) ->
     assert "name: FINELOG_PORT" in rendered
     assert 'value: "20001"' in rendered
     assert 'value: "gs://bucket/logs"' in rendered
+
+
+def test_render_deployment_inlines_cidr_auth_policy() -> None:
+    cfg = FinelogConfig(
+        name="finelog",
+        port=10001,
+        image="img",
+        remote_log_dir="gs://bucket/logs",
+        deployment=Deployment(k8s=K8sDeployment(namespace="iris")),
+        auth=(CidrAuthLayer(cidrs=("10.0.0.0/8",)),),
+    )
+    rendered = _render_manifest(_K8S_MANIFEST_DIR / "02-deployment.yaml.tmpl", cfg)
+    assert "name: FINELOG_AUTH_POLICY" in rendered
+    assert '"type":"cidr"' in rendered
+
+
+def test_render_deployment_rejects_inline_jwt_secret() -> None:
+    # jwt keys are secret material; the manifest is plaintext, so the deploy path must
+    # refuse to inline them (they belong in the finelog-env Secret).
+    cfg = FinelogConfig(
+        name="finelog",
+        port=10001,
+        image="img",
+        remote_log_dir="gs://bucket/logs",
+        deployment=Deployment(k8s=K8sDeployment(namespace="iris")),
+        auth=(JwtAuthLayer(keys=(JwtKeyEntry(cluster="marin", secret="0123456789abcdef0123456789abcdef"),)),),
+    )
+    with pytest.raises(ValueError, match="jwt auth layers carry secret"):
+        _render_manifest(_K8S_MANIFEST_DIR / "02-deployment.yaml.tmpl", cfg)
 
 
 def test_render_service_uses_configured_port(cfg: FinelogConfig) -> None:

--- a/lib/finelog/tests/test_forwarder.py
+++ b/lib/finelog/tests/test_forwarder.py
@@ -1,0 +1,194 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""End-to-end smoke for :class:`finelog.forwarder.LogForwarder`.
+
+Boots two real embedded finelog servers — a source (loopback-admitting default) and a
+target fronted by a jwt-only auth policy — and drives the forwarder through the native
+wire contract. Covers the federation relay's guarantees: a batch ingested at the source
+is forwarded to the target under a cluster-namespaced key and readable there with auth;
+and a forward that fails (an unauthenticated push) advances no watermark, so a later
+authed forwarder ships the same batch exactly once (durable, at-least-once, no loss).
+
+Skips when the native extension is not built.
+"""
+
+import json
+
+import pytest
+from finelog.client import LogClient
+from finelog.embedded import is_available, require_embedded_server
+from finelog.forwarder import CorruptForwarderStateError, LogForwarder
+from finelog.rpc import logging_pb2
+from rigging.auth import BearerTokenInjector, StaticTokenProvider
+
+# A pinned HS256 delegation key + token (exp = 2100-01-01), matching the Rust verifier's
+# interop test. A static token keeps this test free of a JWT-minting dependency; token
+# refresh/minting is covered separately (iris `_DelegationTokenProvider`, Rust interop).
+_KEY = "delegation-key-0123456789abcdefX"
+_TOKEN = (
+    "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9"
+    ".eyJzdWIiOiJtYXJpbiIsInJvbGUiOiJmaW5lbG9nLXJlbGF5IiwianRpIjoiZml4ZWRqdGkwMDAxIiwiaWF0IjoxMDAwMDAwMDAwLCJleHAiOjQxMDI0NDQ4MDB9"
+    ".kTVu3jf6JUbqdHe8WYswdHWzw7WBNT1NfyCxtMoiaPE"
+)
+_JWT_POLICY = json.dumps([{"type": "jwt", "keys": [{"cluster": "marin", "secret": _KEY}]}])
+
+_PREFIX = "/c/marin"
+
+
+def _entries(n: int, base_ms: int = 1_000) -> list[logging_pb2.LogEntry]:
+    return [
+        logging_pb2.LogEntry(
+            timestamp=logging_pb2.Timestamp(epoch_ms=base_ms + i),
+            source="stdout",
+            data=f"line {i}",
+        )
+        for i in range(n)
+    ]
+
+
+def _authed_client(address: str) -> LogClient:
+    return LogClient.connect(address, interceptors=(BearerTokenInjector(StaticTokenProvider(_TOKEN), "authorization"),))
+
+
+@pytest.fixture
+def servers(tmp_path):
+    if not is_available():
+        pytest.skip("finelog native server extension (finelog_server) not available")
+    embedded = require_embedded_server()
+    source = embedded(log_dir=str(tmp_path / "source"))  # default policy admits loopback
+    target = embedded(log_dir=str(tmp_path / "target"), auth_policy=_JWT_POLICY)  # jwt-only
+    try:
+        yield source, target
+    finally:
+        source.stop()
+        target.stop()
+
+
+def _read_namespaced(reader: LogClient, key: str) -> list[logging_pb2.LogEntry]:
+    resp = reader.fetch_logs(
+        logging_pb2.FetchLogsRequest(
+            source=_PREFIX + key,
+            match_scope=logging_pb2.MATCH_SCOPE_PREFIX,
+            max_lines=100,
+        )
+    )
+    return list(resp.entries)
+
+
+def test_forwarder_forwards_under_namespaced_key_with_auth(tmp_path, servers):
+    source_server, target_server = servers
+    state = tmp_path / "watermark.json"
+    source = LogClient.connect(source_server.address)
+    target = _authed_client(target_server.address)
+    forwarder = LogForwarder(
+        source=source,
+        target=target,
+        target_label=target_server.address,
+        key_prefix=_PREFIX,
+        state_path=state,
+    )
+
+    # First tick seeds the watermark at the (empty) source's max cursor; forwards nothing.
+    assert forwarder.forward_once() == 0
+    assert "cursor" in json.loads(state.read_text())
+
+    key = "/user/job-1/task-0:0"
+    writer = LogClient.connect(source_server.address)
+    writer.push_batch(key, _entries(5))
+    writer.close()
+
+    # Next tick forwards the newly-ingested batch.
+    assert forwarder.forward_once() == 5
+
+    reader = _authed_client(target_server.address)
+    entries = _read_namespaced(reader, key)
+    assert {e.data for e in entries} == {f"line {i}" for i in range(5)}
+    assert all(e.key == _PREFIX + key for e in entries)
+
+    reader.close()
+    source.close()
+    target.close()
+
+
+def test_forwarder_retries_after_failed_push_without_loss(tmp_path, servers):
+    source_server, target_server = servers
+    state = tmp_path / "watermark.json"
+    source = LogClient.connect(source_server.address)
+
+    # Seed, then ingest a batch at the source.
+    good_target = _authed_client(target_server.address)
+    seeder = LogForwarder(
+        source=source, target=good_target, target_label=target_server.address, key_prefix=_PREFIX, state_path=state
+    )
+    assert seeder.forward_once() == 0  # seed
+
+    key = "/user/job-2/task-0:0"
+    writer = LogClient.connect(source_server.address)
+    writer.push_batch(key, _entries(3))
+    writer.close()
+
+    watermark_before = json.loads(state.read_text())["cursor"]
+
+    # A forwarder with no credential: the jwt-only target rejects the push, so the
+    # watermark must not advance (the batch is not lost — it stays pending).
+    unauthed_target = LogClient.connect(target_server.address)
+    failing = LogForwarder(
+        source=source,
+        target=unauthed_target,
+        target_label=target_server.address,
+        key_prefix=_PREFIX,
+        state_path=state,
+    )
+    assert failing.forward_once() == 0
+    assert json.loads(state.read_text())["cursor"] == watermark_before, "failed push must not advance"
+
+    # A fresh authed forwarder over the same state file (a restart) ships the pending
+    # batch — exactly once, no loss and no duplication from the failed attempt.
+    recovered_target = _authed_client(target_server.address)
+    recovered = LogForwarder(
+        source=source,
+        target=recovered_target,
+        target_label=target_server.address,
+        key_prefix=_PREFIX,
+        state_path=state,
+    )
+    assert recovered.forward_once() == 3
+
+    reader = _authed_client(target_server.address)
+    entries = _read_namespaced(reader, key)
+    assert {e.data for e in entries} == {f"line {i}" for i in range(3)}
+    assert len(entries) == 3, "batch forwarded exactly once despite the earlier failure"
+
+    reader.close()
+    unauthed_target.close()
+    good_target.close()
+    recovered_target.close()
+    source.close()
+
+
+def test_forwarder_refuses_corrupt_state_instead_of_skipping(tmp_path, servers):
+    source_server, target_server = servers
+    state = tmp_path / "watermark.json"
+    source = LogClient.connect(source_server.address)
+    target = _authed_client(target_server.address)
+    forwarder = LogForwarder(
+        source=source, target=target, target_label=target_server.address, key_prefix=_PREFIX, state_path=state
+    )
+    assert forwarder.forward_once() == 0  # seed at the empty source
+
+    # Ingest a batch that is now pending forwarding.
+    writer = LogClient.connect(source_server.address)
+    writer.push_batch("/user/job-3/task-0:0", _entries(4))
+    writer.close()
+
+    # A corrupt (not absent) state file must NOT be read as a first run: seeding at the
+    # source's current max here would skip the pending batch forever.
+    state.write_text("{ truncated json")
+    with pytest.raises(CorruptForwarderStateError):
+        forwarder.forward_once()
+    # The forwarder refused to advance — the corrupt file is left untouched, not reseeded.
+    assert state.read_text() == "{ truncated json"
+
+    source.close()
+    target.close()

--- a/lib/finelog/tests/test_forwarder.py
+++ b/lib/finelog/tests/test_forwarder.py
@@ -6,9 +6,9 @@
 Boots two real embedded finelog servers — a source (loopback-admitting default) and a
 target fronted by a jwt-only auth policy — and drives the forwarder through the native
 wire contract. Covers the federation relay's guarantees: a batch ingested at the source
-is forwarded to the target under a cluster-namespaced key and readable there with auth;
-and a forward that fails (an unauthenticated push) advances no watermark, so a later
-authed forwarder ships the same batch exactly once (durable, at-least-once, no loss).
+is forwarded to the target under the same key and readable there with auth; and a forward
+that fails (an unauthenticated push) advances no watermark, so a later authed forwarder
+ships the same batch exactly once (durable, at-least-once, no loss).
 
 Skips when the native extension is not built.
 """
@@ -32,8 +32,6 @@ _TOKEN = (
     ".kTVu3jf6JUbqdHe8WYswdHWzw7WBNT1NfyCxtMoiaPE"
 )
 _JWT_POLICY = json.dumps([{"type": "jwt", "keys": [{"cluster": "marin", "secret": _KEY}]}])
-
-_PREFIX = "/c/marin"
 
 
 def _entries(n: int, base_ms: int = 1_000) -> list[logging_pb2.LogEntry]:
@@ -65,10 +63,10 @@ def servers(tmp_path):
         target.stop()
 
 
-def _read_namespaced(reader: LogClient, key: str) -> list[logging_pb2.LogEntry]:
+def _read_key(reader: LogClient, key: str) -> list[logging_pb2.LogEntry]:
     resp = reader.fetch_logs(
         logging_pb2.FetchLogsRequest(
-            source=_PREFIX + key,
+            source=key,
             match_scope=logging_pb2.MATCH_SCOPE_PREFIX,
             max_lines=100,
         )
@@ -76,7 +74,7 @@ def _read_namespaced(reader: LogClient, key: str) -> list[logging_pb2.LogEntry]:
     return list(resp.entries)
 
 
-def test_forwarder_forwards_under_namespaced_key_with_auth(tmp_path, servers):
+def test_forwarder_forwards_with_auth(tmp_path, servers):
     source_server, target_server = servers
     state = tmp_path / "watermark.json"
     source = LogClient.connect(source_server.address)
@@ -85,7 +83,6 @@ def test_forwarder_forwards_under_namespaced_key_with_auth(tmp_path, servers):
         source=source,
         target=target,
         target_label=target_server.address,
-        key_prefix=_PREFIX,
         state_path=state,
     )
 
@@ -98,13 +95,13 @@ def test_forwarder_forwards_under_namespaced_key_with_auth(tmp_path, servers):
     writer.push_batch(key, _entries(5))
     writer.close()
 
-    # Next tick forwards the newly-ingested batch.
+    # Next tick forwards the newly-ingested batch under the same key.
     assert forwarder.forward_once() == 5
 
     reader = _authed_client(target_server.address)
-    entries = _read_namespaced(reader, key)
+    entries = _read_key(reader, key)
     assert {e.data for e in entries} == {f"line {i}" for i in range(5)}
-    assert all(e.key == _PREFIX + key for e in entries)
+    assert all(e.key == key for e in entries)
 
     reader.close()
     source.close()
@@ -118,9 +115,7 @@ def test_forwarder_retries_after_failed_push_without_loss(tmp_path, servers):
 
     # Seed, then ingest a batch at the source.
     good_target = _authed_client(target_server.address)
-    seeder = LogForwarder(
-        source=source, target=good_target, target_label=target_server.address, key_prefix=_PREFIX, state_path=state
-    )
+    seeder = LogForwarder(source=source, target=good_target, target_label=target_server.address, state_path=state)
     assert seeder.forward_once() == 0  # seed
 
     key = "/user/job-2/task-0:0"
@@ -137,7 +132,6 @@ def test_forwarder_retries_after_failed_push_without_loss(tmp_path, servers):
         source=source,
         target=unauthed_target,
         target_label=target_server.address,
-        key_prefix=_PREFIX,
         state_path=state,
     )
     assert failing.forward_once() == 0
@@ -150,13 +144,12 @@ def test_forwarder_retries_after_failed_push_without_loss(tmp_path, servers):
         source=source,
         target=recovered_target,
         target_label=target_server.address,
-        key_prefix=_PREFIX,
         state_path=state,
     )
     assert recovered.forward_once() == 3
 
     reader = _authed_client(target_server.address)
-    entries = _read_namespaced(reader, key)
+    entries = _read_key(reader, key)
     assert {e.data for e in entries} == {f"line {i}" for i in range(3)}
     assert len(entries) == 3, "batch forwarded exactly once despite the earlier failure"
 
@@ -172,9 +165,7 @@ def test_forwarder_refuses_corrupt_state_instead_of_skipping(tmp_path, servers):
     state = tmp_path / "watermark.json"
     source = LogClient.connect(source_server.address)
     target = _authed_client(target_server.address)
-    forwarder = LogForwarder(
-        source=source, target=target, target_label=target_server.address, key_prefix=_PREFIX, state_path=state
-    )
+    forwarder = LogForwarder(source=source, target=target, target_label=target_server.address, state_path=state)
     assert forwarder.forward_once() == 0  # seed at the empty source
 
     # Ingest a batch that is now pending forwarding.
@@ -194,54 +185,6 @@ def test_forwarder_refuses_corrupt_state_instead_of_skipping(tmp_path, servers):
     target.close()
 
 
-def test_forwarder_skips_already_namespaced_keys_no_amplification(tmp_path):
-    if not is_available():
-        pytest.skip("finelog native server extension (finelog_server) not available")
-    embedded = require_embedded_server()
-    # source == target: a shared store that is also its own source. Without the guard the
-    # forwarder would re-read its own /c/marin/... rows and re-push them as /c/marin/c/marin/...
-    store = embedded(log_dir=str(tmp_path / "store"))  # default policy admits loopback
-    try:
-        source = LogClient.connect(store.address)
-        target = LogClient.connect(store.address)
-        state = tmp_path / "watermark.json"
-        forwarder = LogForwarder(
-            source=source, target=target, target_label=store.address, key_prefix=_PREFIX, state_path=state
-        )
-        assert forwarder.forward_once() == 0  # seed
-
-        writer = LogClient.connect(store.address)
-        writer.push_batch("/user/job-9/task-0:0", _entries(3))
-        writer.close()
-
-        # Forwards the /user/... rows into the same store as /c/marin/user/...
-        assert forwarder.forward_once() == 3
-        # The next tick sees those /c/marin/... rows; the guard skips them, so nothing is
-        # re-forwarded — no /c/marin/c/marin/... amplification.
-        assert forwarder.forward_once() == 0
-
-        reader = LogClient.connect(store.address)
-        doubled = reader.fetch_logs(
-            logging_pb2.FetchLogsRequest(
-                source=_PREFIX + _PREFIX, match_scope=logging_pb2.MATCH_SCOPE_PREFIX, max_lines=100
-            )
-        )
-        assert list(doubled.entries) == [], "already-namespaced rows must not be re-forwarded"
-
-        # A sibling cluster's namespace (/c/marin-dev) shares the /c/marin text but is a
-        # different prefix: the trailing-separator guard must forward it, not false-skip it.
-        sibling = LogClient.connect(store.address)
-        sibling.push_batch("/c/marin-dev/user/job-1/task-0:0", _entries(2))
-        sibling.close()
-        assert forwarder.forward_once() == 2
-
-        reader.close()
-        source.close()
-        target.close()
-    finally:
-        store.stop()
-
-
 def test_forwarder_drains_backlog_beyond_one_batch(tmp_path, servers):
     # A backlog larger than batch_lines must fully drain in one pass, not ship only
     # batch_lines per poll interval — that cap would let a busy cluster outrun the
@@ -254,7 +197,6 @@ def test_forwarder_drains_backlog_beyond_one_batch(tmp_path, servers):
         source=source,
         target=target,
         target_label=target_server.address,
-        key_prefix=_PREFIX,
         state_path=state,
         batch_lines=2,
     )
@@ -268,7 +210,7 @@ def test_forwarder_drains_backlog_beyond_one_batch(tmp_path, servers):
     # batch_lines=2 over a 5-row backlog → 3 fetch cycles (2+2+1); one drain ships all 5.
     assert forwarder._drain() == 5
     reader = _authed_client(target_server.address)
-    assert len(_read_namespaced(reader, key)) == 5
+    assert len(_read_key(reader, key)) == 5
 
     reader.close()
     source.close()

--- a/lib/finelog/tests/test_forwarder.py
+++ b/lib/finelog/tests/test_forwarder.py
@@ -228,8 +228,48 @@ def test_forwarder_skips_already_namespaced_keys_no_amplification(tmp_path):
         )
         assert list(doubled.entries) == [], "already-namespaced rows must not be re-forwarded"
 
+        # A sibling cluster's namespace (/c/marin-dev) shares the /c/marin text but is a
+        # different prefix: the trailing-separator guard must forward it, not false-skip it.
+        sibling = LogClient.connect(store.address)
+        sibling.push_batch("/c/marin-dev/user/job-1/task-0:0", _entries(2))
+        sibling.close()
+        assert forwarder.forward_once() == 2
+
         reader.close()
         source.close()
         target.close()
     finally:
         store.stop()
+
+
+def test_forwarder_drains_backlog_beyond_one_batch(tmp_path, servers):
+    # A backlog larger than batch_lines must fully drain in one pass, not ship only
+    # batch_lines per poll interval — that cap would let a busy cluster outrun the
+    # forwarder until source retention drops the un-forwarded rows (silent loss).
+    source_server, target_server = servers
+    state = tmp_path / "watermark.json"
+    source = LogClient.connect(source_server.address)
+    target = _authed_client(target_server.address)
+    forwarder = LogForwarder(
+        source=source,
+        target=target,
+        target_label=target_server.address,
+        key_prefix=_PREFIX,
+        state_path=state,
+        batch_lines=2,
+    )
+    assert forwarder.forward_once() == 0  # seed
+
+    key = "/user/job-7/task-0:0"
+    writer = LogClient.connect(source_server.address)
+    writer.push_batch(key, _entries(5))
+    writer.close()
+
+    # batch_lines=2 over a 5-row backlog → 3 fetch cycles (2+2+1); one drain ships all 5.
+    assert forwarder._drain() == 5
+    reader = _authed_client(target_server.address)
+    assert len(_read_namespaced(reader, key)) == 5
+
+    reader.close()
+    source.close()
+    target.close()

--- a/lib/finelog/tests/test_forwarder.py
+++ b/lib/finelog/tests/test_forwarder.py
@@ -192,3 +192,44 @@ def test_forwarder_refuses_corrupt_state_instead_of_skipping(tmp_path, servers):
 
     source.close()
     target.close()
+
+
+def test_forwarder_skips_already_namespaced_keys_no_amplification(tmp_path):
+    if not is_available():
+        pytest.skip("finelog native server extension (finelog_server) not available")
+    embedded = require_embedded_server()
+    # source == target: a shared store that is also its own source. Without the guard the
+    # forwarder would re-read its own /c/marin/... rows and re-push them as /c/marin/c/marin/...
+    store = embedded(log_dir=str(tmp_path / "store"))  # default policy admits loopback
+    try:
+        source = LogClient.connect(store.address)
+        target = LogClient.connect(store.address)
+        state = tmp_path / "watermark.json"
+        forwarder = LogForwarder(
+            source=source, target=target, target_label=store.address, key_prefix=_PREFIX, state_path=state
+        )
+        assert forwarder.forward_once() == 0  # seed
+
+        writer = LogClient.connect(store.address)
+        writer.push_batch("/user/job-9/task-0:0", _entries(3))
+        writer.close()
+
+        # Forwards the /user/... rows into the same store as /c/marin/user/...
+        assert forwarder.forward_once() == 3
+        # The next tick sees those /c/marin/... rows; the guard skips them, so nothing is
+        # re-forwarded — no /c/marin/c/marin/... amplification.
+        assert forwarder.forward_once() == 0
+
+        reader = LogClient.connect(store.address)
+        doubled = reader.fetch_logs(
+            logging_pb2.FetchLogsRequest(
+                source=_PREFIX + _PREFIX, match_scope=logging_pb2.MATCH_SCOPE_PREFIX, max_lines=100
+            )
+        )
+        assert list(doubled.entries) == [], "already-namespaced rows must not be re-forwarded"
+
+        reader.close()
+        source.close()
+        target.close()
+    finally:
+        store.stop()

--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -248,7 +248,7 @@ Get a profile for a task — open the dashboard task page and use the "Profile h
 
 Profiles are written by the worker (periodic CPU + on-demand all types), by `K8sTaskProvider` (on-demand only), and by the controller for `/system/controller` self-captures.
 
-Query the namespace directly with the finelog CLI (opens a tunnel to the cluster's finelog deployment named by `log_server_config`):
+Query the namespace directly with the finelog CLI (opens a tunnel to the cluster's finelog deployment named by `finelog.config`):
 
 ```bash
 cd lib/finelog

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -25,7 +25,8 @@
 # Resolves to k8s://finelog-cw-use02a.iris; see lib/finelog/config/cw-us-east-02a.yaml.
 # Without this the controller falls back to an in-process MemStore (logs lost on
 # restart). Deploy the server first: `uv run finelog deploy up cw-us-east-02a`.
-log_server_config: cw-us-east-02a
+finelog:
+  config: cw-us-east-02a
 
 platform:
   label_prefix: cw-use02a

--- a/lib/iris/config/marin-dev.yaml
+++ b/lib/iris/config/marin-dev.yaml
@@ -2,7 +2,8 @@
 # Mirrors production marin.yaml with isolated state and smaller scale caps.
 # Usage: uv run iris --cluster=marin-dev cluster start
 
-log_server_config: marin-dev
+finelog:
+  config: marin-dev
 dashboard_url: https://iris-dev.oa.dev
 
 platform:

--- a/lib/iris/config/marin.yaml
+++ b/lib/iris/config/marin.yaml
@@ -1,7 +1,8 @@
 # Iris production configuration for Marin cluster
 # Usage: uv run iris --cluster=marin cluster start
 
-log_server_config: marin
+finelog:
+  config: marin
 dashboard_url: https://iris.oa.dev
 
 platform:

--- a/lib/iris/scripts/job_profile_summary.py
+++ b/lib/iris/scripts/job_profile_summary.py
@@ -12,7 +12,7 @@ Each row carries a ``source`` (the task path ``/user/job/.../<index>``), a
 
 This script:
 
-1. Resolves the cluster's finelog deployment (``log_server_config`` in
+1. Resolves the cluster's finelog deployment (``finelog.config`` in
    ``config/<cluster>.yaml``; defaults to the cluster name) and opens a tunnel
    to it, exactly as ``finelog query`` does.
 2. Queries every CPU profile whose ``source`` is the given job or a descendant
@@ -67,7 +67,7 @@ SUBJOB_DETAIL_MIN_SHARE = 0.01
 def finelog_config_for_cluster(cluster: str) -> str:
     """Return the finelog deployment name for an Iris cluster.
 
-    Reads ``log_server_config`` from ``config/<cluster>.yaml`` (the field that
+    Reads ``finelog.config`` from ``config/<cluster>.yaml`` (the field that
     names the cluster's finelog deployment); falls back to the cluster name.
     """
     config_path = CONFIG_DIR / f"{cluster}.yaml"
@@ -75,7 +75,7 @@ def finelog_config_for_cluster(cluster: str) -> str:
         raise FileNotFoundError(f"No cluster config at {config_path}")
     with open(config_path) as f:
         cfg = yaml.safe_load(f)
-    return cfg.get("log_server_config") or cluster
+    return cfg.get("finelog", {}).get("config") or cluster
 
 
 def tunnel_target(cfg: FinelogConfig) -> TunnelTarget:

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -448,19 +448,18 @@ def cluster_restart(ctx):
 
 @cluster.group("log-server")
 def log_server() -> None:
-    """Manage the log server referenced by this cluster's log_server_config."""
+    """Manage the log server referenced by this cluster's finelog.config."""
 
 
 def _require_log_server_config(ctx: click.Context) -> str:
     cfg = ctx.obj.get("config")
     if cfg is None:
         raise click.ClickException("--config is required for cluster log-server commands")
-    if not cfg.log_server_config:
+    if not cfg.finelog.config:
         raise click.ClickException(
-            "cluster does not declare log_server_config; "
-            "set it or manage the log server via `finelog deploy` directly"
+            "cluster does not declare finelog.config; " "set it or manage the log server via `finelog deploy` directly"
         )
-    return cfg.log_server_config
+    return cfg.finelog.config
 
 
 @log_server.command("up")

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -624,6 +624,42 @@ class PeerConfig(_Config):
     static_token: str = ""  # client token for a peer whose manifest uses static auth
 
 
+class GlobalFinelogConfig(_Config):
+    """The shared global finelog this cluster relays its logs to and reads from.
+
+    Federation lands every cluster's logs in one store. When this is set, the
+    controller runs a durable relay that forwards its local finelog out to
+    ``address`` (cluster-namespacing every key) and serves log reads from that
+    store instead of the local one. Absent leaves the log plane single-cluster:
+    no relay, local reads, byte-identical behavior.
+
+    ``address`` is the global finelog's RPC endpoint. The controller authenticates
+    its pushes with a per-cluster delegation credential the global finelog verifies
+    on ingress:
+
+    - ``delegation_key`` — a shared HS256 secret. When set, the relay mints a
+      short-lived JWT signed with it (via the same ``JwtTokenManager`` the control
+      plane uses), and the global finelog carries a matching ``jwt`` layer keyed on
+      ``{cluster: <cluster>, secret: <delegation_key>}``. Dedicated (not the
+      control-plane signing key) so the shared store can *verify* this cluster's
+      tokens without gaining the power to *mint* control-plane tokens. This is the
+      cross-region path; the finelog verifier is HS256-only, so an IAP/GCP token
+      would not verify.
+    - ``static_token`` — a pre-minted bearer used verbatim, for a simple/local
+      deployment. Lower-preference than ``delegation_key``.
+    - Neither set — no bearer; the global finelog must admit this controller by a
+      ``cidr`` layer (e.g. a same-VPC/loopback dev store).
+
+    ``cluster`` names this cluster's identity: the JWT ``sub`` the relay mints and
+    the ``cluster`` the global finelog's ``jwt`` key entry is labelled with.
+    """
+
+    address: str  # global finelog RPC endpoint (relay target + read source)
+    cluster: str = ""  # this cluster's delegation identity (JWT sub / jwt-key label)
+    delegation_key: str = ""  # shared HS256 secret; relay mints short-lived JWTs with it
+    static_token: str = ""  # pre-minted static bearer (alternative to delegation_key)
+
+
 # ---------------------------------------------------------------------------
 # Root
 # ---------------------------------------------------------------------------
@@ -654,6 +690,9 @@ class IrisClusterConfig(_OneofConfig):
     # cluster may delegate whole jobs to. Absent/empty leaves federation inert —
     # a single-cluster deployment is unchanged.
     peers: dict[str, PeerConfig] = Field(default_factory=dict)
+    # Shared global finelog for federated log relay + cross-cluster reads. Absent
+    # leaves the log plane single-cluster (local relay off, local reads).
+    global_finelog: GlobalFinelogConfig | None = None
     # When set, iris auto-derives /system/log-server from this finelog config name.
     log_server_config: str = ""
     # Public dashboard origin (e.g. "https://iris.oa.dev"); enables clickable job URLs.
@@ -923,10 +962,29 @@ def _validate_peers(config: IrisClusterConfig) -> None:
             )
 
 
+def _validate_global_finelog(config: IrisClusterConfig) -> None:
+    """Validate the ``global_finelog:`` relay target."""
+    gf = config.global_finelog
+    if gf is None:
+        return
+    if not gf.address.strip():
+        raise ValueError("global_finelog: address is required.")
+    if gf.delegation_key and not gf.cluster:
+        raise ValueError(
+            "global_finelog: delegation_key requires cluster to be set (the identity the "
+            "minted JWT carries and the global finelog's jwt key entry is labelled with)."
+        )
+    # The finelog HS256 verifier rejects a delegation secret shorter than 16 bytes
+    # (MIN_SECRET_BYTES); fail fast here rather than at the store on first push.
+    if gf.delegation_key and len(gf.delegation_key.encode()) < 16:
+        raise ValueError("global_finelog: delegation_key must be at least 16 bytes.")
+
+
 def validate_config(config: IrisClusterConfig) -> None:
     """Validate cluster config; raises ValueError on the first violation."""
     _validate_backends(config)
     _validate_peers(config)
+    _validate_global_finelog(config)
     _validate_provider_platform_compat(config)
     _validate_accelerator_types(config)
     validate_scale_group_resources(config.scale_groups)

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -973,6 +973,13 @@ def _validate_finelog_relay(config: IrisClusterConfig) -> None:
     relay = config.finelog.relay
     if relay is None:
         return
+    # The relay stamps `/c/<cluster-name>` on every forwarded key, so the cluster needs a
+    # slash-free name. Check here so a missing name fails at config load, not as a
+    # controller-startup crash on the remote host.
+    if not config.name.strip():
+        raise ValueError("finelog.relay: the cluster must set a top-level name (used as the /c/<name> log namespace).")
+    if "/" in config.name:
+        raise ValueError(f"finelog.relay: cluster name must not contain '/' (got {config.name!r}).")
     if not relay.address.strip():
         raise ValueError("finelog.relay: address is required.")
     # The finelog HS256 verifier rejects a delegation secret shorter than 16 bytes

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -624,40 +624,47 @@ class PeerConfig(_Config):
     static_token: str = ""  # client token for a peer whose manifest uses static auth
 
 
-class GlobalFinelogConfig(_Config):
-    """The shared global finelog this cluster relays its logs to and reads from.
+class FinelogRelayConfig(_Config):
+    """The shared global finelog this cluster relays its logs to (and, later, reads from).
 
-    Federation lands every cluster's logs in one store. When this is set, the
-    controller runs a durable relay that forwards its local finelog out to
-    ``address`` (cluster-namespacing every key) and serves log reads from that
-    store instead of the local one. Absent leaves the log plane single-cluster:
-    no relay, local reads, byte-identical behavior.
+    Federation lands every cluster's logs in one store. When ``finelog.relay`` is set,
+    the controller runs a durable relay that forwards its local finelog out to
+    ``address`` under this cluster's ``/c/<name>`` key prefix. Absent leaves the log
+    plane single-cluster: no relay, local reads, byte-identical behavior.
 
-    ``address`` is the global finelog's RPC endpoint. The controller authenticates
-    its pushes with a per-cluster delegation credential the global finelog verifies
-    on ingress:
+    ``address`` is the global finelog's RPC endpoint. The controller authenticates its
+    pushes with a delegation credential the global finelog verifies on ingress; the
+    identity carried is the cluster's own ``name``, so nothing is restated here:
 
     - ``delegation_key`` — a shared HS256 secret. When set, the relay mints a
-      short-lived JWT signed with it (via the same ``JwtTokenManager`` the control
-      plane uses), and the global finelog carries a matching ``jwt`` layer keyed on
-      ``{cluster: <cluster>, secret: <delegation_key>}``. Dedicated (not the
-      control-plane signing key) so the shared store can *verify* this cluster's
-      tokens without gaining the power to *mint* control-plane tokens. This is the
-      cross-region path; the finelog verifier is HS256-only, so an IAP/GCP token
-      would not verify.
+      short-lived JWT signed with it, and the global finelog carries a matching ``jwt``
+      layer keyed on ``{cluster: <this cluster's name>, secret: <delegation_key>}``.
+      Dedicated (not the control-plane signing key) so the shared store can *verify*
+      this cluster's tokens without gaining the power to *mint* control-plane tokens.
+      This is the cross-region path; the finelog verifier is HS256-only, so an IAP/GCP
+      token would not verify.
     - ``static_token`` — a pre-minted bearer used verbatim, for a simple/local
       deployment. Lower-preference than ``delegation_key``.
     - Neither set — no bearer; the global finelog must admit this controller by a
       ``cidr`` layer (e.g. a same-VPC/loopback dev store).
-
-    ``cluster`` names this cluster's identity: the JWT ``sub`` the relay mints and
-    the ``cluster`` the global finelog's ``jwt`` key entry is labelled with.
     """
 
     address: str  # global finelog RPC endpoint (relay target + read source)
-    cluster: str = ""  # this cluster's delegation identity (JWT sub / jwt-key label)
     delegation_key: str = ""  # shared HS256 secret; relay mints short-lived JWTs with it
     static_token: str = ""  # pre-minted static bearer (alternative to delegation_key)
+
+
+class ClusterFinelogConfig(_Config):
+    """This cluster's finelog: the local log store, and optionally a relay to a shared one.
+
+    ``config`` names the finelog deployment that serves this cluster (iris derives
+    ``/system/log-server`` from it). ``relay``, when present, points at a shared global
+    finelog and makes the controller forward this cluster's logs there — set it and the
+    forwarder runs; omit it and the log plane stays single-cluster.
+    """
+
+    config: str = ""  # finelog deploy-config name; iris derives /system/log-server from it
+    relay: FinelogRelayConfig | None = None  # shared global finelog to forward logs to
 
 
 # ---------------------------------------------------------------------------
@@ -690,11 +697,10 @@ class IrisClusterConfig(_OneofConfig):
     # cluster may delegate whole jobs to. Absent/empty leaves federation inert —
     # a single-cluster deployment is unchanged.
     peers: dict[str, PeerConfig] = Field(default_factory=dict)
-    # Shared global finelog for federated log relay + cross-cluster reads. Absent
-    # leaves the log plane single-cluster (local relay off, local reads).
-    global_finelog: GlobalFinelogConfig | None = None
-    # When set, iris auto-derives /system/log-server from this finelog config name.
-    log_server_config: str = ""
+    # This cluster's finelog: the local log store (`finelog.config` names the deploy
+    # config iris derives /system/log-server from) and an optional `finelog.relay` to a
+    # shared global finelog. Setting `finelog.relay` turns on the forwarder.
+    finelog: ClusterFinelogConfig = Field(default_factory=ClusterFinelogConfig)
     # Public dashboard origin (e.g. "https://iris.oa.dev"); enables clickable job URLs.
     dashboard_url: str = ""
 
@@ -962,29 +968,24 @@ def _validate_peers(config: IrisClusterConfig) -> None:
             )
 
 
-def _validate_global_finelog(config: IrisClusterConfig) -> None:
-    """Validate the ``global_finelog:`` relay target."""
-    gf = config.global_finelog
-    if gf is None:
+def _validate_finelog_relay(config: IrisClusterConfig) -> None:
+    """Validate the ``finelog.relay:`` target."""
+    relay = config.finelog.relay
+    if relay is None:
         return
-    if not gf.address.strip():
-        raise ValueError("global_finelog: address is required.")
-    if gf.delegation_key and not gf.cluster:
-        raise ValueError(
-            "global_finelog: delegation_key requires cluster to be set (the identity the "
-            "minted JWT carries and the global finelog's jwt key entry is labelled with)."
-        )
+    if not relay.address.strip():
+        raise ValueError("finelog.relay: address is required.")
     # The finelog HS256 verifier rejects a delegation secret shorter than 16 bytes
     # (MIN_SECRET_BYTES); fail fast here rather than at the store on first push.
-    if gf.delegation_key and len(gf.delegation_key.encode()) < 16:
-        raise ValueError("global_finelog: delegation_key must be at least 16 bytes.")
+    if relay.delegation_key and len(relay.delegation_key.encode()) < 16:
+        raise ValueError("finelog.relay: delegation_key must be at least 16 bytes.")
 
 
 def validate_config(config: IrisClusterConfig) -> None:
     """Validate cluster config; raises ValueError on the first violation."""
     _validate_backends(config)
     _validate_peers(config)
-    _validate_global_finelog(config)
+    _validate_finelog_relay(config)
     _validate_provider_platform_compat(config)
     _validate_accelerator_types(config)
     validate_scale_group_resources(config.scale_groups)

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -624,47 +624,33 @@ class PeerConfig(_Config):
     static_token: str = ""  # client token for a peer whose manifest uses static auth
 
 
-class FinelogRelayConfig(_Config):
-    """The shared global finelog this cluster relays its logs to (and, later, reads from).
-
-    Federation lands every cluster's logs in one store. When ``finelog.relay`` is set,
-    the controller runs a durable relay that forwards its local finelog out to
-    ``address`` under this cluster's ``/c/<name>`` key prefix. Absent leaves the log
-    plane single-cluster: no relay, local reads, byte-identical behavior.
-
-    ``address`` is the global finelog's RPC endpoint. The controller authenticates its
-    pushes with a delegation credential the global finelog verifies on ingress; the
-    identity carried is the cluster's own ``name``, so nothing is restated here:
-
-    - ``delegation_key`` — a shared HS256 secret. When set, the relay mints a
-      short-lived JWT signed with it, and the global finelog carries a matching ``jwt``
-      layer keyed on ``{cluster: <this cluster's name>, secret: <delegation_key>}``.
-      Dedicated (not the control-plane signing key) so the shared store can *verify*
-      this cluster's tokens without gaining the power to *mint* control-plane tokens.
-      This is the cross-region path; the finelog verifier is HS256-only, so an IAP/GCP
-      token would not verify.
-    - ``static_token`` — a pre-minted bearer used verbatim, for a simple/local
-      deployment. Lower-preference than ``delegation_key``.
-    - Neither set — no bearer; the global finelog must admit this controller by a
-      ``cidr`` layer (e.g. a same-VPC/loopback dev store).
-    """
-
-    address: str  # global finelog RPC endpoint (relay target + read source)
-    delegation_key: str = ""  # shared HS256 secret; relay mints short-lived JWTs with it
-    static_token: str = ""  # pre-minted static bearer (alternative to delegation_key)
-
-
 class ClusterFinelogConfig(_Config):
     """This cluster's finelog: the local log store, and optionally a relay to a shared one.
 
     ``config`` names the finelog deployment that serves this cluster (iris derives
-    ``/system/log-server`` from it). ``relay``, when present, points at a shared global
-    finelog and makes the controller forward this cluster's logs there — set it and the
-    forwarder runs; omit it and the log plane stays single-cluster.
+    ``/system/log-server`` from it). Set ``relay_address`` to also run a durable relay
+    that forwards this cluster's logs to a shared global finelog; leave it empty and the
+    log plane stays single-cluster (no relay, local reads, byte-identical behavior).
+
+    The relay authenticates its pushes with a delegation credential the global finelog
+    verifies on ingress:
+
+    - ``delegation_key`` — a shared HS256 secret. When set, the relay mints a short-lived
+      JWT signed with it, and the global finelog carries a matching ``jwt`` layer keyed on
+      ``{cluster: <this cluster's name>, secret: <delegation_key>}``. Dedicated (not the
+      control-plane signing key), so the shared store can *verify* this cluster's tokens
+      without gaining the power to *mint* control-plane tokens. HS256-only: an IAP/GCP
+      token would not verify.
+    - ``static_token`` — a pre-minted bearer used verbatim, for a simple/local deployment.
+      Lower-preference than ``delegation_key``.
+    - Neither — no bearer; the global finelog must admit this controller by a ``cidr``
+      layer (a same-VPC/loopback dev store).
     """
 
     config: str = ""  # finelog deploy-config name; iris derives /system/log-server from it
-    relay: FinelogRelayConfig | None = None  # shared global finelog to forward logs to
+    relay_address: str = ""  # shared global finelog to forward logs to (empty = single-cluster)
+    delegation_key: str = ""  # shared HS256 secret; the relay mints short-lived JWTs with it
+    static_token: str = ""  # pre-minted static bearer (alternative to delegation_key)
 
 
 # ---------------------------------------------------------------------------
@@ -698,8 +684,8 @@ class IrisClusterConfig(_OneofConfig):
     # a single-cluster deployment is unchanged.
     peers: dict[str, PeerConfig] = Field(default_factory=dict)
     # This cluster's finelog: the local log store (`finelog.config` names the deploy
-    # config iris derives /system/log-server from) and an optional `finelog.relay` to a
-    # shared global finelog. Setting `finelog.relay` turns on the forwarder.
+    # config iris derives /system/log-server from) and an optional `finelog.relay_address`
+    # for a shared global finelog. Setting `finelog.relay_address` turns on the forwarder.
     finelog: ClusterFinelogConfig = Field(default_factory=ClusterFinelogConfig)
     # Public dashboard origin (e.g. "https://iris.oa.dev"); enables clickable job URLs.
     dashboard_url: str = ""
@@ -969,23 +955,14 @@ def _validate_peers(config: IrisClusterConfig) -> None:
 
 
 def _validate_finelog_relay(config: IrisClusterConfig) -> None:
-    """Validate the ``finelog.relay:`` target."""
-    relay = config.finelog.relay
-    if relay is None:
+    """Validate the finelog relay credential (only when ``finelog.relay_address`` is set)."""
+    finelog = config.finelog
+    if not finelog.relay_address.strip():
         return
-    # The relay stamps `/c/<cluster-name>` on every forwarded key, so the cluster needs a
-    # slash-free name. Check here so a missing name fails at config load, not as a
-    # controller-startup crash on the remote host.
-    if not config.name.strip():
-        raise ValueError("finelog.relay: the cluster must set a top-level name (used as the /c/<name> log namespace).")
-    if "/" in config.name:
-        raise ValueError(f"finelog.relay: cluster name must not contain '/' (got {config.name!r}).")
-    if not relay.address.strip():
-        raise ValueError("finelog.relay: address is required.")
     # The finelog HS256 verifier rejects a delegation secret shorter than 16 bytes
     # (MIN_SECRET_BYTES); fail fast here rather than at the store on first push.
-    if relay.delegation_key and len(relay.delegation_key.encode()) < 16:
-        raise ValueError("finelog.relay: delegation_key must be at least 16 bytes.")
+    if finelog.delegation_key and len(finelog.delegation_key.encode()) < 16:
+        raise ValueError("finelog.delegation_key must be at least 16 bytes.")
 
 
 def validate_config(config: IrisClusterConfig) -> None:

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -24,7 +24,7 @@ from sqlalchemy import Row
 
 from iris.cluster.backends.types import resolve_external_host
 from iris.cluster.bundle import BundleStore
-from iris.cluster.config import BackendConfig, FinelogRelayConfig, PeerConfig
+from iris.cluster.config import BackendConfig, ClusterFinelogConfig, PeerConfig
 from iris.cluster.controller import ops, reads, writes
 from iris.cluster.controller.audit_logging import log_event
 from iris.cluster.controller.auth import ControllerAuth
@@ -268,9 +268,9 @@ class ControllerConfig:
     """Federation peers (peer id -> declaration). Empty leaves federation inert:
     no peer connections, no heartbeat, an empty ListPeers view."""
 
-    finelog_relay: FinelogRelayConfig | None = None
-    """The shared global finelog to relay logs out to and read federated logs from.
-    ``None`` leaves the log plane single-cluster: no relay, local reads."""
+    finelog: ClusterFinelogConfig = field(default_factory=ClusterFinelogConfig)
+    """This cluster's finelog config. An empty ``relay_address`` leaves the log plane
+    single-cluster: no relay, local reads. Set it to forward logs to a shared store."""
 
     federation_heartbeat_interval: Duration = field(default_factory=lambda: DEFAULT_HEARTBEAT_INTERVAL)
     """How often the federation capability heartbeat probes each peer."""
@@ -404,19 +404,19 @@ class Controller:
         self._log_handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(message)s"))
         logging.getLogger("iris").addHandler(self._log_handler)
 
-        # Finelog relay: when configured, durably forwards this cluster's local finelog
-        # to the shared global store under cluster-namespaced keys. The forwarding
-        # mechanism lives in finelog; this only supplies the local client, the cluster
-        # credential, and a state path. None (no finelog.relay) leaves the log plane
-        # single-cluster — no forwarder thread, no egress, byte-identical behavior.
+        # Finelog relay: when a relay target is configured, durably forwards this cluster's
+        # local finelog to the shared global store. The forwarding mechanism lives in
+        # finelog; this only supplies the local client, the cluster credential, and a state
+        # path. An empty relay_address leaves the log plane single-cluster — no forwarder
+        # thread, no egress, byte-identical behavior.
         self._log_forwarder = (
             build_log_forwarder(
-                config=config.finelog_relay,
+                config=config.finelog,
                 cluster_id=config.cluster_id,
                 source_client=self._log_client,
                 state_dir=self._db.db_dir,
             )
-            if config.finelog_relay is not None
+            if config.finelog.relay_address
             else None
         )
 

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -24,7 +24,7 @@ from sqlalchemy import Row
 
 from iris.cluster.backends.types import resolve_external_host
 from iris.cluster.bundle import BundleStore
-from iris.cluster.config import BackendConfig, PeerConfig
+from iris.cluster.config import BackendConfig, GlobalFinelogConfig, PeerConfig
 from iris.cluster.controller import ops, reads, writes
 from iris.cluster.controller.audit_logging import log_event
 from iris.cluster.controller.auth import ControllerAuth
@@ -52,6 +52,7 @@ from iris.cluster.controller.dashboard import ControllerDashboard
 from iris.cluster.controller.db import ControllerDB, Tx
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.federation_store import ControllerFederationStore
+from iris.cluster.controller.global_finelog import build_log_forwarder
 from iris.cluster.controller.log_stack import LogStack
 from iris.cluster.controller.ops.task import (
     Assignment,
@@ -267,6 +268,10 @@ class ControllerConfig:
     """Federation peers (peer id -> declaration). Empty leaves federation inert:
     no peer connections, no heartbeat, an empty ListPeers view."""
 
+    global_finelog: GlobalFinelogConfig | None = None
+    """The shared global finelog to relay logs out to and read federated logs from.
+    ``None`` leaves the log plane single-cluster: no relay, local reads."""
+
     federation_heartbeat_interval: Duration = field(default_factory=lambda: DEFAULT_HEARTBEAT_INTERVAL)
     """How often the federation capability heartbeat probes each peer."""
 
@@ -398,6 +403,22 @@ class Controller:
         self._log_handler.setLevel(logging.DEBUG)
         self._log_handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(message)s"))
         logging.getLogger("iris").addHandler(self._log_handler)
+
+        # Global-finelog log forwarder: when configured, durably forwards this cluster's
+        # local finelog to the shared global store under cluster-namespaced keys. The
+        # forwarding mechanism lives in finelog; this only supplies the local client, the
+        # cluster credential, and a state path. None (no global_finelog) leaves the log
+        # plane single-cluster — no forwarder thread, no egress, byte-identical behavior.
+        self._log_forwarder = (
+            build_log_forwarder(
+                config=config.global_finelog,
+                cluster_id=config.cluster_id,
+                source_client=self._log_client,
+                state_dir=self._db.db_dir,
+            )
+            if config.global_finelog is not None
+            else None
+        )
 
         # Give each worker-daemon backend its own scale-group-scoped view of the DB
         # so it sources its own workers (the controller never partitions a worker
@@ -650,6 +671,10 @@ class Controller:
         # Start the federation capability heartbeat (a no-op with no peers).
         self._federation.start()
 
+        # Start the global-finelog log forwarder (only when a relay target is configured).
+        if self._log_forwarder is not None:
+            self._log_forwarder.start()
+
         # Register atexit hook to capture final state for post-mortem analysis.
         # Unregistered in stop() so it doesn't fire against a closed DB.
         self._atexit_registered = True
@@ -689,6 +714,11 @@ class Controller:
             self._checkpoint_thread.stop()
             self._checkpoint_thread.join(timeout=join_timeout)
         self._federation.stop()
+
+        # Stop the forwarder (joins its thread, closes its egress client) before
+        # log_stack.close() below tears down the local client it reads from.
+        if self._log_forwarder is not None:
+            self._log_forwarder.stop()
 
         self._threads.stop()
         # Each backend owns its autoscaler; close() shuts it down (terminates VMs,

--- a/lib/iris/src/iris/cluster/controller/controller.py
+++ b/lib/iris/src/iris/cluster/controller/controller.py
@@ -24,7 +24,7 @@ from sqlalchemy import Row
 
 from iris.cluster.backends.types import resolve_external_host
 from iris.cluster.bundle import BundleStore
-from iris.cluster.config import BackendConfig, GlobalFinelogConfig, PeerConfig
+from iris.cluster.config import BackendConfig, FinelogRelayConfig, PeerConfig
 from iris.cluster.controller import ops, reads, writes
 from iris.cluster.controller.audit_logging import log_event
 from iris.cluster.controller.auth import ControllerAuth
@@ -52,7 +52,7 @@ from iris.cluster.controller.dashboard import ControllerDashboard
 from iris.cluster.controller.db import ControllerDB, Tx
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.federation_store import ControllerFederationStore
-from iris.cluster.controller.global_finelog import build_log_forwarder
+from iris.cluster.controller.finelog_relay import build_log_forwarder
 from iris.cluster.controller.log_stack import LogStack
 from iris.cluster.controller.ops.task import (
     Assignment,
@@ -268,7 +268,7 @@ class ControllerConfig:
     """Federation peers (peer id -> declaration). Empty leaves federation inert:
     no peer connections, no heartbeat, an empty ListPeers view."""
 
-    global_finelog: GlobalFinelogConfig | None = None
+    finelog_relay: FinelogRelayConfig | None = None
     """The shared global finelog to relay logs out to and read federated logs from.
     ``None`` leaves the log plane single-cluster: no relay, local reads."""
 
@@ -404,19 +404,19 @@ class Controller:
         self._log_handler.setFormatter(logging.Formatter("%(asctime)s %(name)s %(message)s"))
         logging.getLogger("iris").addHandler(self._log_handler)
 
-        # Global-finelog log forwarder: when configured, durably forwards this cluster's
-        # local finelog to the shared global store under cluster-namespaced keys. The
-        # forwarding mechanism lives in finelog; this only supplies the local client, the
-        # cluster credential, and a state path. None (no global_finelog) leaves the log
-        # plane single-cluster — no forwarder thread, no egress, byte-identical behavior.
+        # Finelog relay: when configured, durably forwards this cluster's local finelog
+        # to the shared global store under cluster-namespaced keys. The forwarding
+        # mechanism lives in finelog; this only supplies the local client, the cluster
+        # credential, and a state path. None (no finelog.relay) leaves the log plane
+        # single-cluster — no forwarder thread, no egress, byte-identical behavior.
         self._log_forwarder = (
             build_log_forwarder(
-                config=config.global_finelog,
+                config=config.finelog_relay,
                 cluster_id=config.cluster_id,
                 source_client=self._log_client,
                 state_dir=self._db.db_dir,
             )
-            if config.global_finelog is not None
+            if config.finelog_relay is not None
             else None
         )
 

--- a/lib/iris/src/iris/cluster/controller/finelog_relay.py
+++ b/lib/iris/src/iris/cluster/controller/finelog_relay.py
@@ -20,7 +20,7 @@ from finelog.client.log_client import LogClient
 from finelog.forwarder import LogForwarder
 from rigging.auth import BearerTokenInjector, StaticTokenProvider
 
-from iris.cluster.config import GlobalFinelogConfig
+from iris.cluster.config import FinelogRelayConfig
 from iris.cluster.controller.auth import JwtTokenManager
 from iris.cluster.log_keys import cluster_namespace_prefix
 
@@ -70,15 +70,16 @@ class _DelegationTokenProvider:
             return self._token
 
 
-def global_finelog_interceptors(config: GlobalFinelogConfig) -> tuple:
+def finelog_relay_interceptors(config: FinelogRelayConfig, subject: str) -> tuple:
     """Resolve the client interceptors the forwarder presents to the global finelog.
 
-    ``delegation_key`` (preferred) mints short-lived JWTs the store verifies against its
-    ``jwt`` layer; ``static_token`` is a pre-minted bearer; neither means the store must
-    admit this controller by a ``cidr`` layer (a same-VPC/loopback store).
+    ``delegation_key`` (preferred) mints short-lived JWTs — under ``subject`` (this
+    cluster's name) — that the store verifies against its ``jwt`` layer; ``static_token``
+    is a pre-minted bearer; neither means the store must admit this controller by a
+    ``cidr`` layer (a same-VPC/loopback store).
     """
     if config.delegation_key:
-        provider = _DelegationTokenProvider(subject=config.cluster or "relay", signing_key=config.delegation_key)
+        provider = _DelegationTokenProvider(subject=subject, signing_key=config.delegation_key)
         return (BearerTokenInjector(provider, "authorization"),)
     if config.static_token:
         return (BearerTokenInjector(StaticTokenProvider(config.static_token), "authorization"),)
@@ -87,18 +88,19 @@ def global_finelog_interceptors(config: GlobalFinelogConfig) -> tuple:
 
 def build_log_forwarder(
     *,
-    config: GlobalFinelogConfig,
+    config: FinelogRelayConfig,
     cluster_id: str,
     source_client: LogClient,
     state_dir: Path,
 ) -> LogForwarder:
     """Construct a forwarder from ``source_client`` to ``config.address``.
 
-    The target client is authenticated with this cluster's delegation credential and
-    owned by the forwarder (closed on its ``stop``); ``source_client`` is the controller's
-    local finelog client and is not. Keys are stamped with ``/c/<cluster_id>``.
+    The target client is authenticated with this cluster's delegation credential (minted
+    under ``cluster_id``) and owned by the forwarder (closed on its ``stop``);
+    ``source_client`` is the controller's local finelog client and is not. Keys are
+    stamped with ``/c/<cluster_id>``.
     """
-    target = LogClient.connect(config.address, interceptors=global_finelog_interceptors(config))
+    target = LogClient.connect(config.address, interceptors=finelog_relay_interceptors(config, cluster_id))
     return LogForwarder(
         source=source_client,
         target=target,

--- a/lib/iris/src/iris/cluster/controller/finelog_relay.py
+++ b/lib/iris/src/iris/cluster/controller/finelog_relay.py
@@ -20,9 +20,8 @@ from finelog.client.log_client import LogClient
 from finelog.forwarder import LogForwarder
 from rigging.auth import BearerTokenInjector, StaticTokenProvider
 
-from iris.cluster.config import FinelogRelayConfig
+from iris.cluster.config import ClusterFinelogConfig
 from iris.cluster.controller.auth import JwtTokenManager
-from iris.cluster.log_keys import cluster_namespace_prefix
 
 logger = logging.getLogger(__name__)
 
@@ -70,7 +69,7 @@ class _DelegationTokenProvider:
             return self._token
 
 
-def finelog_relay_interceptors(config: FinelogRelayConfig, subject: str) -> tuple:
+def finelog_relay_interceptors(config: ClusterFinelogConfig, subject: str) -> tuple:
     """Resolve the client interceptors the forwarder presents to the global finelog.
 
     ``delegation_key`` (preferred) mints short-lived JWTs — under ``subject`` (this
@@ -88,23 +87,21 @@ def finelog_relay_interceptors(config: FinelogRelayConfig, subject: str) -> tupl
 
 def build_log_forwarder(
     *,
-    config: FinelogRelayConfig,
+    config: ClusterFinelogConfig,
     cluster_id: str,
     source_client: LogClient,
     state_dir: Path,
 ) -> LogForwarder:
-    """Construct a forwarder from ``source_client`` to ``config.address``.
+    """Construct a forwarder from ``source_client`` to ``config.relay_address``.
 
     The target client is authenticated with this cluster's delegation credential (minted
     under ``cluster_id``) and owned by the forwarder (closed on its ``stop``);
-    ``source_client`` is the controller's local finelog client and is not. Keys are
-    stamped with ``/c/<cluster_id>``.
+    ``source_client`` is the controller's local finelog client and is not.
     """
-    target = LogClient.connect(config.address, interceptors=finelog_relay_interceptors(config, cluster_id))
+    target = LogClient.connect(config.relay_address, interceptors=finelog_relay_interceptors(config, cluster_id))
     return LogForwarder(
         source=source_client,
         target=target,
-        target_label=config.address,
-        key_prefix=cluster_namespace_prefix(cluster_id),
+        target_label=config.relay_address,
         state_path=state_dir / _STATE_FILENAME,
     )

--- a/lib/iris/src/iris/cluster/controller/global_finelog.py
+++ b/lib/iris/src/iris/cluster/controller/global_finelog.py
@@ -1,0 +1,108 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Wire this cluster's finelog to a shared global finelog.
+
+The log-forwarding mechanism itself lives in finelog (:class:`finelog.forwarder.LogForwarder`).
+This module is the thin Iris glue: it resolves the delegation credential this cluster
+presents to the global store and constructs a forwarder from the controller's local
+finelog client to that store. No forwarding, namespacing, or watermark logic lives
+here — only credential + wiring.
+"""
+
+import logging
+import secrets
+import threading
+import time
+from pathlib import Path
+
+from finelog.client.log_client import LogClient
+from finelog.forwarder import LogForwarder
+from rigging.auth import BearerTokenInjector, StaticTokenProvider
+
+from iris.cluster.config import GlobalFinelogConfig
+from iris.cluster.controller.auth import JwtTokenManager
+from iris.cluster.log_keys import cluster_namespace_prefix
+
+logger = logging.getLogger(__name__)
+
+# Delegation-JWT lifetime and how early to re-mint before expiry. Short-lived so a
+# leaked token's blast radius is TTL-bounded (the global store checks only signature +
+# exp; it cannot reach a controller's revocation table).
+_DELEGATION_TTL_SECONDS = 3600
+_DELEGATION_REFRESH_MARGIN_SECONDS = 300
+_RELAY_ROLE = "finelog-relay"
+
+_STATE_FILENAME = "finelog_forwarder_state.json"
+
+
+class _DelegationTokenProvider:
+    """Mints short-lived HS256 delegation JWTs, re-minting each before it expires.
+
+    Signs with the cluster's delegation key, which must be dedicated (not the
+    control-plane signing key): a token the global store can verify then never grants
+    the power to mint control-plane tokens.
+    """
+
+    def __init__(
+        self,
+        *,
+        subject: str,
+        signing_key: str,
+        ttl_seconds: int = _DELEGATION_TTL_SECONDS,
+        refresh_margin_seconds: int = _DELEGATION_REFRESH_MARGIN_SECONDS,
+    ):
+        self._jwt = JwtTokenManager(signing_key)
+        self._subject = subject
+        self._ttl = ttl_seconds
+        self._margin = refresh_margin_seconds
+        self._lock = threading.Lock()
+        self._token: str | None = None
+        self._expiry = 0.0
+
+    def get_token(self) -> str | None:
+        with self._lock:
+            now = time.time()
+            if self._token is None or now >= self._expiry - self._margin:
+                jti = secrets.token_hex(8)
+                self._token = self._jwt.create_token(self._subject, _RELAY_ROLE, jti, ttl_seconds=self._ttl)
+                self._expiry = now + self._ttl
+            return self._token
+
+
+def global_finelog_interceptors(config: GlobalFinelogConfig) -> tuple:
+    """Resolve the client interceptors the forwarder presents to the global finelog.
+
+    ``delegation_key`` (preferred) mints short-lived JWTs the store verifies against its
+    ``jwt`` layer; ``static_token`` is a pre-minted bearer; neither means the store must
+    admit this controller by a ``cidr`` layer (a same-VPC/loopback store).
+    """
+    if config.delegation_key:
+        provider = _DelegationTokenProvider(subject=config.cluster or "relay", signing_key=config.delegation_key)
+        return (BearerTokenInjector(provider, "authorization"),)
+    if config.static_token:
+        return (BearerTokenInjector(StaticTokenProvider(config.static_token), "authorization"),)
+    return ()
+
+
+def build_log_forwarder(
+    *,
+    config: GlobalFinelogConfig,
+    cluster_id: str,
+    source_client: LogClient,
+    state_dir: Path,
+) -> LogForwarder:
+    """Construct a forwarder from ``source_client`` to ``config.address``.
+
+    The target client is authenticated with this cluster's delegation credential and
+    owned by the forwarder (closed on its ``stop``); ``source_client`` is the controller's
+    local finelog client and is not. Keys are stamped with ``/c/<cluster_id>``.
+    """
+    target = LogClient.connect(config.address, interceptors=global_finelog_interceptors(config))
+    return LogForwarder(
+        source=source_client,
+        target=target,
+        target_label=config.address,
+        key_prefix=cluster_namespace_prefix(cluster_id),
+        state_path=state_dir / _STATE_FILENAME,
+    )

--- a/lib/iris/src/iris/cluster/controller/main.py
+++ b/lib/iris/src/iris/cluster/controller/main.py
@@ -170,7 +170,7 @@ def run_controller_serve(
         autoscaler_evaluation_interval=cluster_config.defaults.autoscaler.evaluation_interval,
         cluster_id=cluster_config.name,
         peers=cluster_config.peers,
-        finelog_relay=cluster_config.finelog.relay,
+        finelog=cluster_config.finelog,
     )
 
     # Each worker-daemon backend constructs and owns its liveness tracker, sized by

--- a/lib/iris/src/iris/cluster/controller/main.py
+++ b/lib/iris/src/iris/cluster/controller/main.py
@@ -170,6 +170,7 @@ def run_controller_serve(
         autoscaler_evaluation_interval=cluster_config.defaults.autoscaler.evaluation_interval,
         cluster_id=cluster_config.name,
         peers=cluster_config.peers,
+        global_finelog=cluster_config.global_finelog,
     )
 
     # Each worker-daemon backend constructs and owns its liveness tracker, sized by

--- a/lib/iris/src/iris/cluster/controller/main.py
+++ b/lib/iris/src/iris/cluster/controller/main.py
@@ -55,13 +55,13 @@ def _resolve_cluster_endpoints(cluster_config: IrisClusterConfig) -> dict[str, s
     for name, spec in cluster_config.endpoints.items():
         resolved[name] = resolve_endpoint_uri(spec.uri, dict(spec.metadata))
 
-    if cluster_config.log_server_config:
+    if cluster_config.finelog.config:
         if LOG_SERVER_ENDPOINT_NAME in cluster_config.endpoints:
             raise ValueError(
-                f"cannot set both log_server_config={cluster_config.log_server_config!r} "
+                f"cannot set both finelog.config={cluster_config.finelog.config!r} "
                 f"and endpoints[{LOG_SERVER_ENDPOINT_NAME}] in the same cluster config"
             )
-        fcfg = load_finelog_config(cluster_config.log_server_config)
+        fcfg = load_finelog_config(cluster_config.finelog.config)
         uri, meta = derive_endpoint_uri(fcfg)
         resolved[LOG_SERVER_ENDPOINT_NAME] = resolve_endpoint_uri(uri, meta)
     return resolved
@@ -170,7 +170,7 @@ def run_controller_serve(
         autoscaler_evaluation_interval=cluster_config.defaults.autoscaler.evaluation_interval,
         cluster_id=cluster_config.name,
         peers=cluster_config.peers,
-        global_finelog=cluster_config.global_finelog,
+        finelog_relay=cluster_config.finelog.relay,
     )
 
     # Each worker-daemon backend constructs and owns its liveness tracker, sized by

--- a/lib/iris/src/iris/cluster/log_keys.py
+++ b/lib/iris/src/iris/cluster/log_keys.py
@@ -17,11 +17,6 @@ from iris.cluster.types import JobName, TaskAttempt
 CONTROLLER_LOG_KEY = "/system/controller"
 _WORKER_LOG_PREFIX = "/system/worker/"
 
-# Prefix a relay stamps on every key it forwards to the shared global finelog, so
-# the bare per-cluster keys below (`/user/...`, `/system/...`) don't collide when
-# many clusters land in one store: `/c/<cluster_id><key>`.
-CLUSTER_NAMESPACE_PREFIX = "/c/"
-
 # Default level per capture stream when a line carries no parseable prefix.
 # "error" is the synthetic source iris uses for injected failure lines (OOM
 # kills, infrastructure errors). Streams not listed here (e.g. "build") fall
@@ -76,17 +71,3 @@ def build_log_source(target: JobName, attempt_id: int = -1) -> tuple[str, loggin
             return f"{wire}:{attempt_id}", logging_pb2.MATCH_SCOPE_EXACT
         return f"{wire}:", logging_pb2.MATCH_SCOPE_PREFIX
     return f"{wire}/", logging_pb2.MATCH_SCOPE_PREFIX
-
-
-def cluster_namespace_prefix(cluster_id: str) -> str:
-    """The key prefix stamped on every log a cluster forwards: ``/c/<cluster_id>``.
-
-    Bare iris keys are per-cluster and collide across clusters in one global finelog,
-    so the forwarder prefixes every forwarded key with this. ``cluster_id`` may not
-    contain ``/`` (it would break the hierarchical prefix).
-    """
-    if not cluster_id:
-        raise ValueError("cluster_id is required to namespace a log key")
-    if "/" in cluster_id:
-        raise ValueError(f"cluster_id must not contain '/' (got {cluster_id!r})")
-    return f"{CLUSTER_NAMESPACE_PREFIX}{cluster_id}"

--- a/lib/iris/src/iris/cluster/log_keys.py
+++ b/lib/iris/src/iris/cluster/log_keys.py
@@ -17,6 +17,11 @@ from iris.cluster.types import JobName, TaskAttempt
 CONTROLLER_LOG_KEY = "/system/controller"
 _WORKER_LOG_PREFIX = "/system/worker/"
 
+# Prefix a relay stamps on every key it forwards to the shared global finelog, so
+# the bare per-cluster keys below (`/user/...`, `/system/...`) don't collide when
+# many clusters land in one store: `/c/<cluster_id><key>`.
+CLUSTER_NAMESPACE_PREFIX = "/c/"
+
 # Default level per capture stream when a line carries no parseable prefix.
 # "error" is the synthetic source iris uses for injected failure lines (OOM
 # kills, infrastructure errors). Streams not listed here (e.g. "build") fall
@@ -71,3 +76,17 @@ def build_log_source(target: JobName, attempt_id: int = -1) -> tuple[str, loggin
             return f"{wire}:{attempt_id}", logging_pb2.MATCH_SCOPE_EXACT
         return f"{wire}:", logging_pb2.MATCH_SCOPE_PREFIX
     return f"{wire}/", logging_pb2.MATCH_SCOPE_PREFIX
+
+
+def cluster_namespace_prefix(cluster_id: str) -> str:
+    """The key prefix stamped on every log a cluster forwards: ``/c/<cluster_id>``.
+
+    Bare iris keys are per-cluster and collide across clusters in one global finelog,
+    so the forwarder prefixes every forwarded key with this. ``cluster_id`` may not
+    contain ``/`` (it would break the hierarchical prefix).
+    """
+    if not cluster_id:
+        raise ValueError("cluster_id is required to namespace a log key")
+    if "/" in cluster_id:
+        raise ValueError(f"cluster_id must not contain '/' (got {cluster_id!r})")
+    return f"{CLUSTER_NAMESPACE_PREFIX}{cluster_id}"

--- a/lib/iris/tests/cluster/controller/test_main_endpoints.py
+++ b/lib/iris/tests/cluster/controller/test_main_endpoints.py
@@ -10,7 +10,7 @@ from unittest.mock import patch
 
 import pytest
 import yaml
-from iris.cluster.config import EndpointSpec, IrisClusterConfig
+from iris.cluster.config import ClusterFinelogConfig, EndpointSpec, IrisClusterConfig
 from iris.cluster.controller.main import LOG_SERVER_ENDPOINT_NAME, _resolve_cluster_endpoints
 
 
@@ -39,7 +39,7 @@ def _write_finelog_config(path: Path, body: dict) -> None:
     path.write_text(yaml.safe_dump(body))
 
 
-def test_log_server_config_synthesizes_gcp_endpoint(tmp_path: Path):
+def test_finelog_config_synthesizes_gcp_endpoint(tmp_path: Path):
     finelog_path = tmp_path / "test.yaml"
     _write_finelog_config(
         finelog_path,
@@ -57,7 +57,7 @@ def test_log_server_config_synthesizes_gcp_endpoint(tmp_path: Path):
         },
     )
 
-    cfg = IrisClusterConfig(log_server_config=str(finelog_path))
+    cfg = IrisClusterConfig(finelog=ClusterFinelogConfig(config=str(finelog_path)))
 
     fake = subprocess.CompletedProcess(
         args=[],
@@ -72,7 +72,7 @@ def test_log_server_config_synthesizes_gcp_endpoint(tmp_path: Path):
     assert mock_run.call_count == 1
 
 
-def test_log_server_config_synthesizes_k8s_endpoint(tmp_path: Path):
+def test_finelog_config_synthesizes_k8s_endpoint(tmp_path: Path):
     finelog_path = tmp_path / "test.yaml"
     _write_finelog_config(
         finelog_path,
@@ -89,7 +89,7 @@ def test_log_server_config_synthesizes_k8s_endpoint(tmp_path: Path):
         },
     )
 
-    cfg = IrisClusterConfig(log_server_config=str(finelog_path))
+    cfg = IrisClusterConfig(finelog=ClusterFinelogConfig(config=str(finelog_path)))
 
     with patch("iris.cluster.endpoints.subprocess.run") as mock_run:
         resolved = _resolve_cluster_endpoints(cfg)
@@ -98,7 +98,7 @@ def test_log_server_config_synthesizes_k8s_endpoint(tmp_path: Path):
     assert mock_run.call_count == 0
 
 
-def test_log_server_config_with_explicit_endpoint_raises(tmp_path: Path):
+def test_finelog_config_with_explicit_endpoint_raises(tmp_path: Path):
     finelog_path = tmp_path / "test.yaml"
     _write_finelog_config(
         finelog_path,
@@ -112,7 +112,7 @@ def test_log_server_config_with_explicit_endpoint_raises(tmp_path: Path):
     )
 
     cfg = IrisClusterConfig(
-        log_server_config=str(finelog_path),
+        finelog=ClusterFinelogConfig(config=str(finelog_path)),
         endpoints={LOG_SERVER_ENDPOINT_NAME: EndpointSpec(uri="http://logs.example:10001")},
     )
 
@@ -120,8 +120,8 @@ def test_log_server_config_with_explicit_endpoint_raises(tmp_path: Path):
         _resolve_cluster_endpoints(cfg)
 
 
-def test_log_server_config_missing_file_raises():
-    cfg = IrisClusterConfig(log_server_config="definitely-not-a-real-config-name-xyz")
+def test_finelog_config_missing_file_raises():
+    cfg = IrisClusterConfig(finelog=ClusterFinelogConfig(config="definitely-not-a-real-config-name-xyz"))
 
     with pytest.raises(FileNotFoundError):
         _resolve_cluster_endpoints(cfg)

--- a/lib/iris/tests/cluster/test_federation.py
+++ b/lib/iris/tests/cluster/test_federation.py
@@ -87,31 +87,8 @@ def test_peers_config_rejects_static_token_without_cluster():
 
 
 # ---------------------------------------------------------------------------
-# finelog.relay: config parse + validation
+# finelog.relay: validation
 # ---------------------------------------------------------------------------
-
-
-def test_finelog_relay_config_round_trips():
-    config = parse_config(
-        _config(
-            finelog={
-                "config": "marin",
-                "relay": {
-                    "address": "dns:///global-finelog:10001",
-                    "delegation_key": "0123456789abcdef0123456789abcdef",
-                },
-            }
-        )
-    )
-    reparsed = parse_config(config_to_dict(config))
-    assert reparsed.finelog.config == "marin"
-    assert reparsed.finelog.relay.address == "dns:///global-finelog:10001"
-    assert reparsed.finelog.relay.delegation_key == "0123456789abcdef0123456789abcdef"
-
-
-def test_finelog_relay_absent_leaves_log_plane_single_cluster():
-    cfg = parse_config(_config(finelog={"config": "marin"}))
-    assert cfg.finelog.relay is None
 
 
 def test_finelog_relay_rejects_short_delegation_key():

--- a/lib/iris/tests/cluster/test_federation.py
+++ b/lib/iris/tests/cluster/test_federation.py
@@ -87,25 +87,13 @@ def test_peers_config_rejects_static_token_without_cluster():
 
 
 # ---------------------------------------------------------------------------
-# finelog.relay: validation
+# finelog relay: validation
 # ---------------------------------------------------------------------------
-
-
-def test_finelog_relay_rejects_missing_cluster_name():
-    # The relay namespaces forwarded logs under /c/<name>; without a name the forwarder
-    # would raise at controller startup, so validation must catch it at config load.
-    with pytest.raises(ValueError, match="cluster must set a top-level name"):
-        parse_config(_config(name="", finelog={"relay": {"address": "dns:///g:1"}}))
 
 
 def test_finelog_relay_rejects_short_delegation_key():
     with pytest.raises(ValueError, match="delegation_key must be at least 16 bytes"):
-        parse_config(_config(finelog={"relay": {"address": "dns:///g:1", "delegation_key": "short"}}))
-
-
-def test_finelog_relay_rejects_empty_address():
-    with pytest.raises(ValueError, match="address is required"):
-        parse_config(_config(finelog={"relay": {"address": "  "}}))
+        parse_config(_config(finelog={"relay_address": "dns:///g:1", "delegation_key": "short"}))
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/test_federation.py
+++ b/lib/iris/tests/cluster/test_federation.py
@@ -91,6 +91,13 @@ def test_peers_config_rejects_static_token_without_cluster():
 # ---------------------------------------------------------------------------
 
 
+def test_finelog_relay_rejects_missing_cluster_name():
+    # The relay namespaces forwarded logs under /c/<name>; without a name the forwarder
+    # would raise at controller startup, so validation must catch it at config load.
+    with pytest.raises(ValueError, match="cluster must set a top-level name"):
+        parse_config(_config(name="", finelog={"relay": {"address": "dns:///g:1"}}))
+
+
 def test_finelog_relay_rejects_short_delegation_key():
     with pytest.raises(ValueError, match="delegation_key must be at least 16 bytes"):
         parse_config(_config(finelog={"relay": {"address": "dns:///g:1", "delegation_key": "short"}}))

--- a/lib/iris/tests/cluster/test_federation.py
+++ b/lib/iris/tests/cluster/test_federation.py
@@ -87,39 +87,41 @@ def test_peers_config_rejects_static_token_without_cluster():
 
 
 # ---------------------------------------------------------------------------
-# global_finelog: config parse + validation
+# finelog.relay: config parse + validation
 # ---------------------------------------------------------------------------
 
 
-def test_global_finelog_config_round_trips():
+def test_finelog_relay_config_round_trips():
     config = parse_config(
         _config(
-            global_finelog={
-                "address": "dns:///global-finelog:10001",
-                "cluster": "cw-east",
-                "delegation_key": "0123456789abcdef0123456789abcdef",
+            finelog={
+                "config": "marin",
+                "relay": {
+                    "address": "dns:///global-finelog:10001",
+                    "delegation_key": "0123456789abcdef0123456789abcdef",
+                },
             }
         )
     )
     reparsed = parse_config(config_to_dict(config))
-    assert reparsed.global_finelog.address == "dns:///global-finelog:10001"
-    assert reparsed.global_finelog.cluster == "cw-east"
-    assert reparsed.global_finelog.delegation_key == "0123456789abcdef0123456789abcdef"
+    assert reparsed.finelog.config == "marin"
+    assert reparsed.finelog.relay.address == "dns:///global-finelog:10001"
+    assert reparsed.finelog.relay.delegation_key == "0123456789abcdef0123456789abcdef"
 
 
-def test_global_finelog_rejects_delegation_key_without_cluster():
-    with pytest.raises(ValueError, match="delegation_key requires cluster"):
-        parse_config(_config(global_finelog={"address": "dns:///g:1", "delegation_key": "k" * 32}))
+def test_finelog_relay_absent_leaves_log_plane_single_cluster():
+    cfg = parse_config(_config(finelog={"config": "marin"}))
+    assert cfg.finelog.relay is None
 
 
-def test_global_finelog_rejects_short_delegation_key():
+def test_finelog_relay_rejects_short_delegation_key():
     with pytest.raises(ValueError, match="delegation_key must be at least 16 bytes"):
-        parse_config(_config(global_finelog={"address": "dns:///g:1", "cluster": "cw", "delegation_key": "short"}))
+        parse_config(_config(finelog={"relay": {"address": "dns:///g:1", "delegation_key": "short"}}))
 
 
-def test_global_finelog_rejects_empty_address():
+def test_finelog_relay_rejects_empty_address():
     with pytest.raises(ValueError, match="address is required"):
-        parse_config(_config(global_finelog={"address": "  "}))
+        parse_config(_config(finelog={"relay": {"address": "  "}}))
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/test_federation.py
+++ b/lib/iris/tests/cluster/test_federation.py
@@ -87,6 +87,42 @@ def test_peers_config_rejects_static_token_without_cluster():
 
 
 # ---------------------------------------------------------------------------
+# global_finelog: config parse + validation
+# ---------------------------------------------------------------------------
+
+
+def test_global_finelog_config_round_trips():
+    config = parse_config(
+        _config(
+            global_finelog={
+                "address": "dns:///global-finelog:10001",
+                "cluster": "cw-east",
+                "delegation_key": "0123456789abcdef0123456789abcdef",
+            }
+        )
+    )
+    reparsed = parse_config(config_to_dict(config))
+    assert reparsed.global_finelog.address == "dns:///global-finelog:10001"
+    assert reparsed.global_finelog.cluster == "cw-east"
+    assert reparsed.global_finelog.delegation_key == "0123456789abcdef0123456789abcdef"
+
+
+def test_global_finelog_rejects_delegation_key_without_cluster():
+    with pytest.raises(ValueError, match="delegation_key requires cluster"):
+        parse_config(_config(global_finelog={"address": "dns:///g:1", "delegation_key": "k" * 32}))
+
+
+def test_global_finelog_rejects_short_delegation_key():
+    with pytest.raises(ValueError, match="delegation_key must be at least 16 bytes"):
+        parse_config(_config(global_finelog={"address": "dns:///g:1", "cluster": "cw", "delegation_key": "short"}))
+
+
+def test_global_finelog_rejects_empty_address():
+    with pytest.raises(ValueError, match="address is required"):
+        parse_config(_config(global_finelog={"address": "  "}))
+
+
+# ---------------------------------------------------------------------------
 # peer heartbeat + ListPeers view (the parent side)
 # ---------------------------------------------------------------------------
 

--- a/scripts/ops/cross_region.py
+++ b/scripts/ops/cross_region.py
@@ -918,14 +918,13 @@ def main(
     logging.info(f"Output directory: {out_path}")
 
     cfg = load_config(config)
-    if not cfg.log_server_config:
+    if not cfg.finelog.config:
         raise click.ClickException(
-            f"Iris config {config!r} has no log_server_config; cross-region analysis "
-            "requires logs shipped via finelog."
+            f"Iris config {config!r} has no finelog.config; cross-region analysis " "requires logs shipped via finelog."
         )
-    finelog_cfg = load_finelog_config(cfg.log_server_config)
+    finelog_cfg = load_finelog_config(cfg.finelog.config)
     if not finelog_cfg.remote_log_dir:
-        raise click.ClickException(f"finelog config {cfg.log_server_config!r} has no remote_log_dir.")
+        raise click.ClickException(f"finelog config {cfg.finelog.config!r} has no remote_log_dir.")
     remote_logs_dir = f"{finelog_cfg.remote_log_dir.rstrip('/')}/log"
 
     log_entries = choose_log_objects(remote_logs_dir, window, download_lookback_hours)


### PR DESCRIPTION
Adds the write side of the federation global-log plane (design §6): each cluster's controller durably forwards its local finelog to one shared **global finelog**, and finelog gains a **mandatory authenticated ingress** front.

## Log forwarding
A new `finelog.forwarder.LogForwarder` (in finelog, generic) tails a source finelog and re-appends each new batch to a target under the same keys. Durability leans on the source finelog already being durable (parquet + retention): the forwarder persists only a forward **watermark** in a small JSON state file — not a second copy of the data — and advances it only after an ack'd `PushLogs` (which returns once the global store has durably persisted the batch). A crash or transient egress failure re-forwards the in-flight batch (at-least-once; duplicate lines are bounded to the failure boundary — federation degrades observability, never job correctness). First run seeds the watermark at the source's current cursor, so enabling it ships new logs without backfilling the whole retention window; a busy cluster's backlog drains within a tick rather than one batch per poll interval.

The iris controller wires this up thinly (`controller/finelog_relay.py`): it supplies its local client, a per-cluster delegation credential, and a state path on its persistent dir; the forwarding/watermark logic lives entirely in finelog. A cluster's finelog is one flat config block — `finelog.config` names the local store; `finelog.relay_address` (optional) points at the shared global one, with `delegation_key`/`static_token` for the credential — and setting `relay_address` is what turns the forwarder on. Inert until then: no forwarder thread, no egress, byte-identical single-cluster behavior.

**Cross-cluster log namespacing is deferred.** Bare per-cluster keys (`/user/<job>/...`) collide when many clusters land in one store; rather than have the relay rewrite keys mid-stream, namespacing will be done on the write side (tasks/controller write the namespaced key directly) or via a finelog `cluster` column, in a follow-up. This PR ships the durable relay + auth mechanism; a single cluster relaying to a global store works today.

## Authenticated ingress (new security surface)
finelog's server (`lib/finelog/rust/src/server/auth.rs`) now gates every RPC with an ordered stack of typed auth **layers** — `cidr` (admit by transport-peer network) and `jwt` (HS256 bearer verified against per-cluster delegation keys) — that is **default-deny** and **always installed**. An unconfigured server falls back to allow-localhost (loopback only), never open. HS256 verification uses vetted RustCrypto primitives (constant-time HMAC, no `ring`), rejects `alg:none`/algorithm-confusion, and tolerates a small `exp` clock-skew leeway. The `/debug/*` admin routes are gated by the same policy. It is configured by a single `FINELOG_AUTH_POLICY` JSON layer list, which the finelog deploy config, GCP bootstrap script, and k8s manifest all plumb (k8s refuses to inline jwt secrets — those must come through a Secret).

Each relaying controller authenticates its pushes with a short-lived HS256 delegation JWT, minted via the same `JwtTokenManager` the control plane uses but signed with a **dedicated** per-cluster key the global store verifies — so the shared store can verify a cluster's tokens without gaining the power to mint control-plane tokens.

Because auth is always installed, the three committed local finelog configs (`marin`, `marin-dev`, `cw-us-east-02a`) gain an explicit `cidr` layer (RFC1918 + loopback) so intra-cluster/pod ingest keeps working — reachable from the private network, never the public internet.

## Cost
Relaying every cluster's logs to one region is deliberate cross-region **egress** — the trade for a uniform, always-available, cross-cluster-queryable log surface. finelog already batches/compresses and tiers cold segments to object storage, which bounds steady-state cost.

The read side (surfacing a federated job's logs through the parent: `job_id`→peer-namespace remap + read-through auth) is deferred to a follow-up (#6862).

Part of #6718 — PR4b of the federation rollout (global finelog + relay + authed ingress).
