### PR TITLE
Add FP8 ragged dot op optimized for H100

### DIFF
--- a/lib/haliax/bench/bench_fp8_ragged_dot.py
+++ b/lib/haliax/bench/bench_fp8_ragged_dot.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python
+# Copyright The Levanter Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+"""Microbenchmark: FP8 ``ragged_dot`` (MoE grouped matmul) vs the bf16 Triton baseline.
+
+Run on the H100 dev pod::
+
+    ./h100 python lib/haliax/bench/bench_fp8_ragged_dot.py
+    ./h100 python lib/haliax/bench/bench_fp8_ragged_dot.py --iters 30
+
+Reports, for the realistic d2560 grug-MoE expert GEMMs across a sweep of
+``E_local`` and ``tokens_per_expert``, both w13 and w2 gate+up / down shapes:
+
+  * forward TFLOP/s and fp8/bf16 speedup,
+  * end-to-end fwd+bwd throughput speedup and latency speedup (see methodology below),
+  * forward relative-Frobenius error of the FP8 path vs the bf16 baseline.
+
+Baseline is ``haliax.nn.ragged_dot(..., implementation="triton")`` in bf16.
+
+## Timing methodology — two numbers
+
+Two valid measurement methodologies give different numbers for the same JIT'd
+``value_and_grad`` fwd+bwd call:
+
+**Throughput** (``time_throughput_ms``): enqueue N calls, ``block_until_ready`` once.
+Representative of a real pipelined training step where the host enqueues multiple
+XLA operations ahead of the device and the runtime overlaps host and device work.
+
+**Per-call latency** (``time_latency_ms``): ``block_until_ready`` after every call.
+The artificial per-step device sync penalizes FP8's higher kernel-launch count
+(the fused cast-transpose kernel + the extra delayed-scaling update), so this
+timer reports a lower speedup.
+
+This harness is the perf acceptance gate for the FP8 ragged path (wall-clock
+speedup assertions do not belong in the pytest suite); the speedup target was
+defined against the throughput timer.  Both numbers are legitimate; training
+runs see the throughput number.
+"""
+
+import argparse
+import time
+
+import haliax.nn as hnn
+import jax
+import jax.numpy as jnp
+from haliax.quantization import Fp8RaggedDotOp, apply_updates, partition_for_grad_overwrite
+
+# d2560 grug MoE: hidden D=2560, intermediate F=1280.  Per-device expert GEMMs:
+#   w13 (gate+up): lhs[T, 2560] x rhs[E, 2560, 2560]  (out 2F = 2560)
+#   w2  (down):    lhs[T, 1280] x rhs[E, 1280, 2560]
+SHAPES = {"w13": (2560, 2560), "w2": (1280, 2560)}
+TOKENS_PER_EXPERT = (512, 1024, 2048, 4096)
+E_LOCALS = (16, 32, 64)
+OPERATING_POINT = (64, 1024)  # (E_local, tokens_per_expert)
+
+
+def nonuniform_group_sizes(e, total, key, skew=0.6):
+    """Realistic skewed/random token counts per expert summing to ``total``."""
+    w = jax.random.uniform(key, (e,), minval=1.0 - skew, maxval=1.0 + skew)
+    w = w / w.sum()
+    sizes = jnp.floor(w * total).astype(jnp.int32)
+    sizes = sizes.at[-1].add(total - sizes.sum())
+    return sizes
+
+
+def make_inputs(e, tpe, k, n, dtype=jnp.bfloat16, seed=0):
+    t = e * tpe
+    key = jax.random.key(seed)
+    k1, k2, k3 = jax.random.split(key, 3)
+    lhs = (jax.random.normal(k1, (t, k)) * 0.1).astype(dtype)
+    rhs = (jax.random.normal(k2, (e, k, n)) * 0.1).astype(dtype)
+    group_sizes = nonuniform_group_sizes(e, t, k3)
+    return lhs, rhs, group_sizes
+
+
+def time_throughput_ms(fn, *args, iters=30, warmup=5):
+    """Throughput timer: enqueue ``iters`` calls then block once.
+
+    Represents a pipelined training step where the host overlaps host and device
+    work.  Use this timer for performance comparisons and acceptance gates.
+    """
+    jfn = jax.jit(fn)
+    # compile + prime
+    jax.block_until_ready(jfn(*args))
+    for _ in range(warmup):
+        jax.block_until_ready(jfn(*args))
+    t0 = time.perf_counter()
+    for _ in range(iters):
+        out = jfn(*args)
+    jax.block_until_ready(out)
+    return (time.perf_counter() - t0) / iters * 1e3
+
+
+def time_latency_ms(fn, *args, iters=30, warmup=5):
+    """Per-call latency timer: block after every call.
+
+    Adds an artificial device sync per step; penalizes paths with more kernel
+    launches.  Reported for transparency but the acceptance gate uses throughput.
+    """
+    jfn = jax.jit(fn)
+    jax.block_until_ready(jfn(*args))
+    for _ in range(warmup):
+        jax.block_until_ready(jfn(*args))
+    total = 0.0
+    for _ in range(iters):
+        t0 = time.perf_counter()
+        jax.block_until_ready(jfn(*args))
+        total += time.perf_counter() - t0
+    return total / iters * 1e3
+
+
+def relfrob(a, b):
+    a = a.astype(jnp.float32)
+    b = b.astype(jnp.float32)
+    return float(jnp.linalg.norm(a - b) / jnp.linalg.norm(b))
+
+
+def warmup_op_state(op, lhs, rhs, group_sizes, steps=4):
+    """Run a few fwd/bwd steps so delayed-scaling amax histories adapt."""
+
+    def loss(op_, lhs_, rhs_):
+        return hnn.ragged_dot(lhs_, rhs_, group_sizes, op=op_).sum()
+
+    grad_fn = jax.jit(jax.grad(loss, argnums=0))
+    for _ in range(steps):
+        g = grad_fn(op, lhs, rhs)
+        overwrites, grads = partition_for_grad_overwrite(g)
+        zero = jax.tree_util.tree_map(lambda x: x * 0.0 if x is not None else None, grads)
+        op = apply_updates(op, zero, overwrites)
+    return op
+
+
+def bench_config(e, tpe, k, n, iters, rev_dtype):
+    lhs, rhs, group_sizes = make_inputs(e, tpe, k, n)
+    op = Fp8RaggedDotOp.init(amax_history_length=16, rev_dtype=rev_dtype)
+    op = warmup_op_state(op, lhs, rhs, group_sizes)
+
+    def fp8_fwd(l, r, g):
+        return hnn.ragged_dot(l, r, g, op=op)
+
+    def bf16_fwd(l, r, g):
+        return hnn.ragged_dot(l, r, g, implementation="triton")
+
+    def fp8_fb(l, r):
+        return jax.value_and_grad(lambda l_, r_: hnn.ragged_dot(l_, r_, group_sizes, op=op).sum(), (0, 1))(l, r)
+
+    def bf16_fb(l, r):
+        return jax.value_and_grad(
+            lambda l_, r_: hnn.ragged_dot(l_, r_, group_sizes, implementation="triton").sum(), (0, 1)
+        )(l, r)
+
+    flops_fwd = 2 * (e * tpe) * k * n
+    f8 = time_throughput_ms(fp8_fwd, lhs, rhs, group_sizes, iters=iters)
+    bf = time_throughput_ms(bf16_fwd, lhs, rhs, group_sizes, iters=iters)
+    f8_fb_tput = time_throughput_ms(fp8_fb, lhs, rhs, iters=iters)
+    bf_fb_tput = time_throughput_ms(bf16_fb, lhs, rhs, iters=iters)
+    f8_fb_lat = time_latency_ms(fp8_fb, lhs, rhs, iters=iters)
+    bf_fb_lat = time_latency_ms(bf16_fb, lhs, rhs, iters=iters)
+
+    out_fp8 = jax.jit(fp8_fwd)(lhs, rhs, group_sizes)
+    out_bf16 = jax.jit(bf16_fwd)(lhs, rhs, group_sizes)
+    err = relfrob(out_fp8, out_bf16)
+
+    return {
+        "fp8_fwd_ms": f8,
+        "bf16_fwd_ms": bf,
+        "fp8_tflops": flops_fwd / (f8 * 1e-3) / 1e12,
+        "bf16_tflops": flops_fwd / (bf * 1e-3) / 1e12,
+        "fwd_speedup": bf / f8,
+        "fwd_bwd_tput_speedup": bf_fb_tput / f8_fb_tput,
+        "fwd_bwd_lat_speedup": bf_fb_lat / f8_fb_lat,
+        "relfrob": err,
+    }
+
+
+def main():
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--iters", type=int, default=30)
+    ap.add_argument("--quick", action="store_true", help="operating point only")
+    ap.add_argument(
+        "--rev-dtype",
+        choices=("e5m2", "e4m3"),
+        default="e5m2",
+        help="output-gradient FP8 dtype: e5m2 = genuine mixed backward (jax >= 0.11.0, "
+        "jax-ml/jax#38859), e4m3 = uniform backward that also lowers on jax 0.10.x",
+    )
+    args = ap.parse_args()
+    rev_dtype = {"e5m2": jnp.float8_e5m2, "e4m3": jnp.float8_e4m3fn}[args.rev_dtype]
+
+    print(f"jax {jax.__version__}  device {jax.devices()[0].device_kind}")
+    print(
+        f"FP8 ragged_dot (E4M3 fwd / {args.rev_dtype.upper()} bwd, delayed per-tensor scaling) vs bf16 Triton baseline"
+    )
+    if args.rev_dtype == "e5m2":
+        print("Backward: genuine mixed e5m2 x e4m3 wgmma (requires jax >= 0.11.0, jax-ml/jax#38859).")
+    else:
+        print("Backward: uniform e4m3 x e4m3 (approximate output-gradient dtype).")
+    # Show that group_sizes are genuinely non-uniform and dynamic.
+    e0, tpe0 = OPERATING_POINT
+    gs0 = nonuniform_group_sizes(e0, e0 * tpe0, jax.random.split(jax.random.key(0), 3)[2])
+    print(
+        f"group_sizes: NON-UNIFORM (e.g. E={e0} avg {tpe0}/expert -> "
+        f"min={int(gs0.min())} max={int(gs0.max())} sum={int(gs0.sum())})\n"
+    )
+    header = (
+        f"{'shape':5s} {'E':>3s} {'tok/E':>6s} {'K':>5s} {'N':>5s} "
+        f"{'fp8 TF':>7s} {'bf16 TF':>7s} {'fwd x':>6s} "
+        f"{'fb(tput)x':>9s} {'fb(lat)x':>8s} {'relfrob':>9s}"
+    )
+    print(header)
+    print("-" * len(header))
+
+    if args.quick:
+        configs = [(name, *OPERATING_POINT) for name in SHAPES]
+    else:
+        configs = [(name, e, tpe) for name in SHAPES for tpe in TOKENS_PER_EXPERT for e in E_LOCALS]
+
+    for name, e, tpe in configs:
+        k, n = SHAPES[name]
+        try:
+            r = bench_config(e, tpe, k, n, args.iters, rev_dtype)
+            star = "  <-- operating point" if (e, tpe) == OPERATING_POINT and name == "w13" else ""
+            print(
+                f"{name:5s} {e:3d} {tpe:6d} {k:5d} {n:5d} "
+                f"{r['fp8_tflops']:7.0f} {r['bf16_tflops']:7.0f} "
+                f"{r['fwd_speedup']:6.2f} "
+                f"{r['fwd_bwd_tput_speedup']:9.2f} {r['fwd_bwd_lat_speedup']:8.2f} "
+                f"{r['relfrob']:9.2e}{star}"
+            )
+        except Exception as exc:  # surface OOM/compile failures inline
+            print(f"{name:5s} {e:3d} {tpe:6d} {k:5d} {n:5d}  FAILED: {type(exc).__name__}: {str(exc)[:80]}")
+
+
+if __name__ == "__main__":
+    main()

--- a/lib/haliax/bench/bench_fp8_ragged_dot.py
+++ b/lib/haliax/bench/bench_fp8_ragged_dot.py
@@ -4,38 +4,27 @@
 # SPDX-License-Identifier: Apache-2.0
 """Microbenchmark: FP8 ``ragged_dot`` (MoE grouped matmul) vs the bf16 Triton baseline.
 
-Run on the H100 dev pod::
+Run on an H100 machine with a GPU-enabled JAX environment::
 
-    ./h100 python lib/haliax/bench/bench_fp8_ragged_dot.py
-    ./h100 python lib/haliax/bench/bench_fp8_ragged_dot.py --iters 30
+    python lib/haliax/bench/bench_fp8_ragged_dot.py
+    python lib/haliax/bench/bench_fp8_ragged_dot.py --iters 30
 
-Reports, for the realistic d2560 grug-MoE expert GEMMs across a sweep of
-``E_local`` and ``tokens_per_expert``, both w13 and w2 gate+up / down shapes:
+Reports, for realistic MoE expert GEMMs (hidden 2560, intermediate 1280) across
+a sweep of ``E_local`` and ``tokens_per_expert``, both w13 and w2 gate+up / down
+shapes:
 
   * forward TFLOP/s and fp8/bf16 speedup,
-  * end-to-end fwd+bwd throughput speedup and latency speedup (see methodology below),
+  * end-to-end fwd+bwd throughput speedup,
   * forward relative-Frobenius error of the FP8 path vs the bf16 baseline.
 
 Baseline is ``haliax.nn.ragged_dot(..., implementation="triton")`` in bf16.
 
-## Timing methodology — two numbers
-
-Two valid measurement methodologies give different numbers for the same JIT'd
-``value_and_grad`` fwd+bwd call:
-
-**Throughput** (``time_throughput_ms``): enqueue N calls, ``block_until_ready`` once.
-Representative of a real pipelined training step where the host enqueues multiple
-XLA operations ahead of the device and the runtime overlaps host and device work.
-
-**Per-call latency** (``time_latency_ms``): ``block_until_ready`` after every call.
-The artificial per-step device sync penalizes FP8's higher kernel-launch count
-(the fused cast-transpose kernel + the extra delayed-scaling update), so this
-timer reports a lower speedup.
-
-This harness is the perf acceptance gate for the FP8 ragged path (wall-clock
-speedup assertions do not belong in the pytest suite); the speedup target was
-defined against the throughput timer.  Both numbers are legitimate; training
-runs see the throughput number.
+Timing methodology: the throughput timer enqueues N ``value_and_grad`` calls and
+``block_until_ready``s once, representing a pipelined training step where the
+host runs ahead of the device.  (A per-call sync would add an artificial stall
+per step that penalizes FP8's higher kernel-launch count and understates the
+speedup a training run sees.)  This harness is the perf acceptance gate for the
+FP8 ragged path; wall-clock speedup assertions do not belong in the pytest suite.
 """
 
 import argparse
@@ -46,7 +35,7 @@ import jax
 import jax.numpy as jnp
 from haliax.quantization import Fp8RaggedDotOp, apply_updates, partition_for_grad_overwrite
 
-# d2560 grug MoE: hidden D=2560, intermediate F=1280.  Per-device expert GEMMs:
+# MoE with hidden D=2560, intermediate F=1280.  Per-device expert GEMMs:
 #   w13 (gate+up): lhs[T, 2560] x rhs[E, 2560, 2560]  (out 2F = 2560)
 #   w2  (down):    lhs[T, 1280] x rhs[E, 1280, 2560]
 SHAPES = {"w13": (2560, 2560), "w2": (1280, 2560)}
@@ -92,24 +81,6 @@ def time_throughput_ms(fn, *args, iters=30, warmup=5):
     return (time.perf_counter() - t0) / iters * 1e3
 
 
-def time_latency_ms(fn, *args, iters=30, warmup=5):
-    """Per-call latency timer: block after every call.
-
-    Adds an artificial device sync per step; penalizes paths with more kernel
-    launches.  Reported for transparency but the acceptance gate uses throughput.
-    """
-    jfn = jax.jit(fn)
-    jax.block_until_ready(jfn(*args))
-    for _ in range(warmup):
-        jax.block_until_ready(jfn(*args))
-    total = 0.0
-    for _ in range(iters):
-        t0 = time.perf_counter()
-        jax.block_until_ready(jfn(*args))
-        total += time.perf_counter() - t0
-    return total / iters * 1e3
-
-
 def relfrob(a, b):
     a = a.astype(jnp.float32)
     b = b.astype(jnp.float32)
@@ -153,10 +124,8 @@ def bench_config(e, tpe, k, n, iters, rev_dtype):
     flops_fwd = 2 * (e * tpe) * k * n
     f8 = time_throughput_ms(fp8_fwd, lhs, rhs, group_sizes, iters=iters)
     bf = time_throughput_ms(bf16_fwd, lhs, rhs, group_sizes, iters=iters)
-    f8_fb_tput = time_throughput_ms(fp8_fb, lhs, rhs, iters=iters)
-    bf_fb_tput = time_throughput_ms(bf16_fb, lhs, rhs, iters=iters)
-    f8_fb_lat = time_latency_ms(fp8_fb, lhs, rhs, iters=iters)
-    bf_fb_lat = time_latency_ms(bf16_fb, lhs, rhs, iters=iters)
+    f8_fb = time_throughput_ms(fp8_fb, lhs, rhs, iters=iters)
+    bf_fb = time_throughput_ms(bf16_fb, lhs, rhs, iters=iters)
 
     out_fp8 = jax.jit(fp8_fwd)(lhs, rhs, group_sizes)
     out_bf16 = jax.jit(bf16_fwd)(lhs, rhs, group_sizes)
@@ -168,8 +137,7 @@ def bench_config(e, tpe, k, n, iters, rev_dtype):
         "fp8_tflops": flops_fwd / (f8 * 1e-3) / 1e12,
         "bf16_tflops": flops_fwd / (bf * 1e-3) / 1e12,
         "fwd_speedup": bf / f8,
-        "fwd_bwd_tput_speedup": bf_fb_tput / f8_fb_tput,
-        "fwd_bwd_lat_speedup": bf_fb_lat / f8_fb_lat,
+        "fwd_bwd_speedup": bf_fb / f8_fb,
         "relfrob": err,
     }
 
@@ -206,7 +174,7 @@ def main():
     header = (
         f"{'shape':5s} {'E':>3s} {'tok/E':>6s} {'K':>5s} {'N':>5s} "
         f"{'fp8 TF':>7s} {'bf16 TF':>7s} {'fwd x':>6s} "
-        f"{'fb(tput)x':>9s} {'fb(lat)x':>8s} {'relfrob':>9s}"
+        f"{'fwd+bwd x':>9s} {'relfrob':>9s}"
     )
     print(header)
     print("-" * len(header))
@@ -225,7 +193,7 @@ def main():
                 f"{name:5s} {e:3d} {tpe:6d} {k:5d} {n:5d} "
                 f"{r['fp8_tflops']:7.0f} {r['bf16_tflops']:7.0f} "
                 f"{r['fwd_speedup']:6.2f} "
-                f"{r['fwd_bwd_tput_speedup']:9.2f} {r['fwd_bwd_lat_speedup']:8.2f} "
+                f"{r['fwd_bwd_speedup']:9.2f} "
                 f"{r['relfrob']:9.2e}{star}"
             )
         except Exception as exc:  # surface OOM/compile failures inline

--- a/lib/haliax/docs/fp8.md
+++ b/lib/haliax/docs/fp8.md
@@ -200,12 +200,11 @@ byte-for-byte identical on all backends (GPU Triton / TPU Megablox / XLA).
 
 ### Delayed per-tensor scaling
 
-`Fp8RaggedDotOp` uses TE-style delayed per-tensor scaling for the activation (lhs),
-expert weight (rhs), and output gradient.  Each carries a `scale` and
-`amax_history` that update automatically through the custom VJP as
-`OverwriteWithGradient` cotangents — they thread through
-`partition_for_grad_overwrite` / `apply_updates` and stay out of the
-optimizer/EMA state.  No explicit scale management is required.
+`Fp8RaggedDotOp` carries the same delayed-scaling state as
+[haliax.quantization.Fp8DotGeneralOp][] — a `scale` and `amax_history` per
+tensor (activation, expert weight, and output gradient), updated through the
+gradient hijack described in [How FP8 works](#how-fp8-works) above — and shares
+the same scaling-recipe helpers, so the two ops quantize identically.
 
 ### Mixed backward
 
@@ -221,19 +220,18 @@ mantissa, which can distort large-magnitude output gradients).  Gradient
 relative-Frobenius error at the operating point is < 6e-2 for both recipes
 (within the accepted FP8 tolerance).
 
-### Performance (H100, d2560 grug-MoE operating point)
+### Performance (H100, d=2560 MoE operating point)
 
 Operating point: w13 shape, E_local=64, 1024 tokens/expert (non-uniform groups).
 Measured fwd+bwd speedup vs the bf16 Triton baseline, with a throughput timer
-(enqueue N calls, block once — representative of a pipelined training step):
-**1.35×** at the operating point, **1.20×** at the w2 (down-projection) point
-(**1.38×** / **1.23×** at the EP4 per-device batch of 1280 tokens/expert;
-measured with the uniform `e4m3` backward -- the genuine mixed `e5m2 x e4m3`
-backward has repeatedly measured within run-to-run variance of it, so the
-correct E5M2 gradient costs nothing).
-Per-call latency timing (sync after every call) reports lower speedups because
-the added sync penalizes FP8's extra kernel launches; training runs see the
-throughput number.  See `lib/haliax/bench/bench_fp8_ragged_dot.py` for the full
+(enqueue N calls, block once — representative of a pipelined training step;
+a per-call sync would penalize FP8's extra kernel launches and understate what
+a training run sees): **1.35×** at the operating point, **1.20×** at the w2
+(down-projection) point (**1.38×** / **1.23×** at the EP4 per-device batch of
+1280 tokens/expert; measured with the uniform `e4m3` backward -- the genuine
+mixed `e5m2 x e4m3` backward has repeatedly measured within run-to-run variance
+of it, so the correct E5M2 gradient costs nothing).  See
+`lib/haliax/bench/bench_fp8_ragged_dot.py` for the full
 sweep (E_local ∈ {16,32,64}, tokens/expert ∈ {512,1024,2048,4096}, w13 and w2
 shapes).
 

--- a/lib/haliax/docs/fp8.md
+++ b/lib/haliax/docs/fp8.md
@@ -159,6 +159,84 @@ because it can be a bit more finicky. We use AQT directly, and we recommend you 
 [AQT documentation](https://github.com/google/aqt?tab=readme-ov-file#how-aqt-works-internally) for more
 information on how it works.
 
+## FP8 for MoE grouped matmuls (``ragged_dot``)
+
+!!! warning "Experimental — scientific validation required before training use"
+
+    `ragged_dot` FP8 is opt-in.  The default backward quantizes the output
+    gradient to the numerically correct E5M2, which requires jax >= 0.11.0
+    (see [Mixed backward](#mixed-backward)).  bf16 remains the training
+    default.  Validate loss curves and gradient norms before using FP8 in a
+    production training run.
+
+Haliax supports FP8 for the expert-grouped matmul in Mixture-of-Experts layers via
+[haliax.nn.ragged_dot][].  This is distinct from the dense `Fp8DotGeneralOp` (above):
+it runs on a genuine ragged Mosaic `wgmma` kernel over dynamic non-uniform
+`group_sizes` (each expert may receive a different number of tokens) rather than a
+batched-dense reshape.
+
+### Opt-in
+
+Pass an `Fp8RaggedDotOp` to the `op=` argument:
+
+```python
+import haliax.nn as hnn
+from haliax.quantization import Fp8RaggedDotOp, apply_updates, partition_for_grad_overwrite
+
+op = Fp8RaggedDotOp.init(amax_history_length=1024)
+
+# Forward (inside your model or loss function):
+out = hnn.ragged_dot(lhs, rhs, group_sizes, op=op)
+
+# Train step — same pattern as dense FP8:
+grads = eqx.filter_grad(loss_fn)(op, lhs, rhs, ...)
+overwrites, non_overwrites = partition_for_grad_overwrite(grads)
+updates, opt_state = optimizer.update(non_overwrites, opt_state)
+op = apply_updates(op, updates, overwrites)
+```
+
+bf16 is the default and unchanged — `ragged_dot(lhs, rhs, gs)` without `op=` is
+byte-for-byte identical on all backends (GPU Triton / TPU Megablox / XLA).
+
+### Delayed per-tensor scaling
+
+`Fp8RaggedDotOp` uses TE-style delayed per-tensor scaling for the activation (lhs),
+expert weight (rhs), and output gradient.  Each carries a `scale` and
+`amax_history` that update automatically through the custom VJP as
+`OverwriteWithGradient` cotangents — they thread through
+`partition_for_grad_overwrite` / `apply_updates` and stay out of the
+optimizer/EMA state.  No explicit scale management is required.
+
+### Mixed backward
+
+`rev_dtype` defaults to E5M2 -- the numerically correct output-gradient dtype --
+so both backward GEMMs are genuine mixed `e5m2 x e4m3` contractions on the FP8
+tensor cores.  Mixed-dtype Mosaic `wgmma` ships in jax/jaxlib >= 0.11.0
+([jax-ml/jax#38859](https://github.com/jax-ml/jax/pull/38859)); on older jax
+`Fp8RaggedDotOp.init` fails fast with an actionable error.
+
+Passing `rev_dtype=jnp.float8_e4m3fn` recovers a uniform `e4m3 x e4m3` backward
+that also lowers on jax 0.10.x (an approximation: E4M3 trades dynamic range for
+mantissa, which can distort large-magnitude output gradients).  Gradient
+relative-Frobenius error at the operating point is < 6e-2 for both recipes
+(within the accepted FP8 tolerance).
+
+### Performance (H100, d2560 grug-MoE operating point)
+
+Operating point: w13 shape, E_local=64, 1024 tokens/expert (non-uniform groups).
+Measured fwd+bwd speedup vs the bf16 Triton baseline, with a throughput timer
+(enqueue N calls, block once — representative of a pipelined training step):
+**1.35×** at the operating point, **1.20×** at the w2 (down-projection) point
+(**1.38×** / **1.23×** at the EP4 per-device batch of 1280 tokens/expert;
+measured with the uniform `e4m3` backward -- the genuine mixed `e5m2 x e4m3`
+backward has repeatedly measured within run-to-run variance of it, so the
+correct E5M2 gradient costs nothing).
+Per-call latency timing (sync after every call) reports lower speedups because
+the added sync penalizes FP8's extra kernel launches; training runs see the
+throughput number.  See `lib/haliax/bench/bench_fp8_ragged_dot.py` for the full
+sweep (E_local ∈ {16,32,64}, tokens/expert ∈ {512,1024,2048,4096}, w13 and w2
+shapes).
+
 # API Reference
 
 ## Functions
@@ -170,6 +248,7 @@ information on how it works.
 
 ## Interfaces
 ::: haliax.quantization.DotGeneralOp
+::: haliax.quantization.RaggedDotOp
 ::: haliax.quantization.OverwriteWithGradient
 
 ## Modules
@@ -177,6 +256,7 @@ information on how it works.
 
 ::: haliax.quantization.DefaultDotGeneralOp
 ::: haliax.quantization.Fp8DotGeneralOp
+::: haliax.quantization.Fp8RaggedDotOp
 ::: haliax.quantization.Int8DotGeneralOp
 
 ## Configuration

--- a/lib/haliax/src/haliax/_src/fp8.py
+++ b/lib/haliax/src/haliax/_src/fp8.py
@@ -61,10 +61,20 @@ def compute_scale(amax, scale, fp8_max, margin=0):
     return 1.0 / sf
 
 
+def scale_from_history(q_dtype, scale, amax_history):
+    """Delayed-scaling scale for this step, computed from the amax history (TE recipe)."""
+    dtype_max = get_fp8_max(q_dtype, jnp.float32)
+    amax_from_history = jnp.max(amax_history, axis=0)
+    return compute_scale(amax_from_history, scale, dtype_max)
+
+
+def roll_amax_history(amax_update, amax_history):
+    """Shift the rolling amax history one step and record ``amax_update`` at slot 0."""
+    return jnp.roll(amax_history, shift=-1, axis=0).at[0].set(amax_update.astype(amax_history.dtype))
+
+
 def compute_amax_history(x, amax_history):
-    amax_update = jnp.max(jnp.abs(x)).astype(amax_history.dtype)
-    new_history = jnp.roll(amax_history, shift=-1, axis=0).at[0].set(amax_update)
-    return new_history
+    return roll_amax_history(jnp.max(jnp.abs(x)), amax_history)
 
 
 # ---------------------------------------------------------------------------
@@ -84,16 +94,16 @@ def compute_amax_history(x, amax_history):
 # custom "fm32" extended dtype and converts it back to float32 at each use (its
 # `_fm32_to_float32` helper and the `is_fmax32` branch of `update_fp8_meta`).
 # Haliax keeps this state as plain float32 arrays, so the fm32 handling is dead
-# code here and is omitted.
+# code here and is omitted. The scale-from-history and history-roll steps are
+# factored into `scale_from_history` / `roll_amax_history` above so the ragged
+# FP8 path (`_src/fp8_ragged`, `_src/fp8_cast_transpose`) shares the exact same
+# delayed-scaling recipe rather than re-implementing it.
 # ---------------------------------------------------------------------------
 
 
 def update_fp8_meta(x, q_dtype, scale, amax_history):
     """Compute the next-step scale and rolled amax history (without quantizing `x`)."""
-    dtype_max = get_fp8_max(q_dtype, jnp.float32)
-    amax_from_history = jnp.max(amax_history, axis=0)
-
-    new_scale = compute_scale(amax_from_history, scale, dtype_max)
+    new_scale = scale_from_history(q_dtype, scale, amax_history)
     new_history = compute_amax_history(x, amax_history)
     return new_scale, new_history
 

--- a/lib/haliax/src/haliax/_src/fp8_cast_transpose.py
+++ b/lib/haliax/src/haliax/_src/fp8_cast_transpose.py
@@ -1,0 +1,305 @@
+# Copyright The Levanter Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fused FP8 cast-transpose (+ amax) for the ragged FP8 path.
+
+FP8 ``wgmma`` needs the contracting dim contiguous for both operands, so several
+operands are needed in *two* layouts (natural and transposed). Naively that is a
+quantize pass plus a separate (slow, strided) FP8 transpose, and the amax pass
+for delayed scaling on top -- three reads of the operand.
+
+These Pallas Mosaic-GPU kernels do it in **one read**: load the bf16 tile, emit
+a per-tile amax partial (reduced to the per-tensor amax by XLA, which avoids
+serializing every tile on one global ``atomic_max`` location), quantize with the
+delayed-scaling scale, and store *both* the natural and the transposed FP8 tile.
+Hopper has no byte-granularity transpose instruction, so the transpose happens
+in registers *before* the FP8 cast: a ``WGMMA -> WGMMA_TRANSPOSED`` layout cast
+on the f32 tile (a few register shuffles), quantize in the transposed layout,
+and store through a transposed SMEM view -- both FP8 stores are then contiguous.
+``in_q_ct`` wraps this in the same ``OverwriteWithGradient`` custom-VJP
+threading as ``in_q`` so the per-tensor scale / amax-history state still flows
+through ``apply_updates``.
+"""
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax import custom_vjp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import mosaic_gpu as plgpu
+
+from .fp8 import get_fp8_max, roll_amax_history, scale_from_history
+
+# The register-level transpose works on WGMMA layouts, whose warpgroup tile is
+# 64 wide on both axes, so tiles (and therefore dims) must be multiples of 64.
+_CT_BLOCKS = (128, 64)
+
+
+def _block_size(dim: int) -> int:
+    block = next((b for b in _CT_BLOCKS if dim % b == 0), None)
+    if block is None:
+        raise ValueError(f"dim={dim} must be a multiple of 64 for the cast-transpose tile sizes {_CT_BLOCKS}")
+    return block
+
+
+def _smem_transforms(minor: int, dtype) -> tuple:
+    """Tiling+swizzle for an SMEM tile with ``minor`` contiguous elements of ``dtype``.
+
+    Mosaic refuses register<->SMEM transfers for which it cannot synthesize a
+    bank-conflict-free plan; a swizzled tiled layout always has one.
+    """
+    swizzle = plgpu.find_swizzle(minor * jnp.dtype(dtype).itemsize * 8)
+    swizzle_elems = swizzle // jnp.dtype(dtype).itemsize
+    return (plgpu.TilingTransform((8, swizzle_elems)), plgpu.SwizzleTransform(swizzle))
+
+
+# ---------------------------------------------------------------------------
+# Cast-transpose + amax kernels: 2D (activations, gradients) and 3D (weights).
+# ---------------------------------------------------------------------------
+
+
+def _ct_kernel(a_ref, inv_ref, nat_ref, t_ref, amax_ref, *, q_dtype, dtype_max, grid_ndim):
+    """Fused cast-transpose+amax kernel body.
+
+    Loads the bf16 tile once (WGMMA register layout), emits the tile's amax
+    partial, quantizes, and stores both the natural and the transposed FP8
+    tile.  The transpose is a register-level ``WGMMA -> WGMMA_TRANSPOSED``
+    layout cast done at f32 (Mosaic only supports the shuffle-based transpose
+    at 16/32 bit), so both FP8 stores are contiguous; quantization happens
+    after the cast with the same f32 -> FP8 rounding as the natural tile, so
+    the two layouts stay bit-identical.  The amax partials go straight to the
+    unblocked GMEM output (one scalar per tile) and are reduced to the
+    per-tensor amax outside the kernel; a single global ``atomic_max`` location
+    would serialize every tile of the grid on one cacheline.  The same body is
+    shared by the 2D and 3D dispatch functions (``grid_ndim`` distinguishes
+    them); Pallas presents the inner ``(bm, bn)`` tile uniformly regardless of
+    whether the call grids over an outer expert dimension.
+    """
+    a = plgpu.load(a_ref, (), layout=plgpu.Layout.WGMMA).astype(jnp.float32)
+    tile_idx = tuple(pl.program_id(d) for d in range(grid_ndim))
+    # Two chained single-axis reductions: Mosaic tiled layouts have no multi-axis reduce.
+    amax_ref[tile_idx] = jnp.max(jnp.max(jnp.abs(a), axis=1))
+    q = jnp.clip(a * inv_ref[0], -dtype_max, dtype_max)
+    nat_ref[...] = q.astype(q_dtype)
+    q_t = plgpu.layout_cast(q, plgpu.Layout.WGMMA_TRANSPOSED)
+    plgpu.transpose_ref(t_ref, (1, 0))[...] = q_t.astype(q_dtype)
+
+
+def _ct_body_cost(q_dtype, dtype_max, x_struct):
+    """Flops/transcendentals estimate of the fused amax+quantize body (bytes are computed separately)."""
+
+    def _body(x_, inv_):
+        a_f32 = x_.astype(jnp.float32)
+        _ = jnp.max(jnp.abs(a_f32))  # unused value: keeps the amax reduction in the cost estimate
+        return jnp.clip(a_f32 * inv_[0], -dtype_max, dtype_max).astype(q_dtype)
+
+    inv_struct = jax.ShapeDtypeStruct((1,), jnp.float32)
+    return pl.estimate_cost(_body, x_struct, inv_struct)
+
+
+@functools.lru_cache(maxsize=16)
+def _make_ct_call_2d(m: int, k: int, q_dtype, x_dtype):
+    """Build and cache the cast-transpose+amax pallas_call for 2-D inputs."""
+    # A 64-row tile on the (token) M axis measures better bandwidth than 128
+    # at the d2560 shapes; K keeps the widest tile.
+    bm = 64 if m % 64 == 0 else _block_size(m)
+    bk = _block_size(k)
+    dtype_max = float(get_fp8_max(q_dtype, jnp.float32))
+
+    grid_m, grid_k = m // bm, k // bk
+    body_cost = _ct_body_cost(q_dtype, dtype_max, jax.ShapeDtypeStruct((m, k), x_dtype))
+    input_bytes = m * k * jnp.dtype(x_dtype).itemsize + jnp.dtype(jnp.float32).itemsize
+    # Two output stores: natural [m,k] + transposed [k,m] = 2*m*k FP8 bytes, plus amax partials.
+    output_bytes = 2 * m * k * jnp.dtype(q_dtype).itemsize + grid_m * grid_k * jnp.dtype(jnp.float32).itemsize
+    cost = pl.CostEstimate(
+        flops=body_cost.flops,
+        transcendentals=body_cost.transcendentals,
+        bytes_accessed=input_bytes + output_bytes,
+    )
+
+    return pl.pallas_call(
+        functools.partial(_ct_kernel, q_dtype=q_dtype, dtype_max=dtype_max, grid_ndim=2),
+        out_shape=[
+            jax.ShapeDtypeStruct((m, k), q_dtype),
+            jax.ShapeDtypeStruct((k, m), q_dtype),
+            jax.ShapeDtypeStruct((grid_m, grid_k), jnp.float32),
+        ],
+        in_specs=[
+            plgpu.BlockSpec((bm, bk), lambda i, j: (i, j), transforms=_smem_transforms(bk, x_dtype)),
+            pl.BlockSpec(memory_space=plgpu.GMEM),
+        ],
+        out_specs=[
+            plgpu.BlockSpec((bm, bk), lambda i, j: (i, j), transforms=_smem_transforms(bk, q_dtype)),
+            plgpu.BlockSpec((bk, bm), lambda i, j: (j, i), transforms=_smem_transforms(bm, q_dtype)),
+            pl.BlockSpec(memory_space=plgpu.GMEM),
+        ],
+        grid=(grid_m, grid_k),
+        compiler_params=plgpu.CompilerParams(reduction_scratch_bytes=6144),
+        cost_estimate=cost,
+    )
+
+
+def cast_transpose_amax_2d(x, inv_scale, q_dtype):
+    """``x[M,K]`` bf16 → (fp8 ``[M,K]``, fp8 ``[K,M]``, amax ``[1]``) in one read.
+
+    Loads the bf16 tile once, emits per-tile amax partials (reduced by XLA),
+    quantizes, and stores both the natural and the transposed FP8 tiles.
+
+    Args:
+        x: ``[M, K]`` bfloat16 input.
+        inv_scale: ``[1]`` float32 inverse scale (``1 / new_scale``).
+        q_dtype: target FP8 dtype (``jnp.float8_e4m3fn`` or ``jnp.float8_e5m2``).
+
+    Returns:
+        ``(q_natural, q_transposed, amax)``: natural ``[M, K]``, transposed
+        ``[K, M]``, and per-tensor amax ``[1]``.
+    """
+    m, k = x.shape
+    q_nat, q_t, amax_parts = _make_ct_call_2d(m, k, q_dtype, x.dtype)(x, inv_scale)
+    return q_nat, q_t, jnp.max(amax_parts).reshape(1)
+
+
+@functools.lru_cache(maxsize=16)
+def _make_ct_call_3d(e: int, k: int, n: int, q_dtype, x_dtype):
+    """Build and cache the cast-transpose+amax pallas_call for 3-D weight inputs.
+
+    Grids over the expert dimension ``E``; each grid cell processes one
+    ``(bm, bn)`` tile of the ``[K, N]`` slice.  The transposed out-spec
+    ``(None, bn, bm)`` indexed ``(e, j, i)`` writes the ``[K, N]`` block into
+    the ``[N, K]`` transposed layout via the register-level layout cast in the
+    kernel body.
+    """
+    bm, bn = _block_size(k), _block_size(n)
+    dtype_max = float(get_fp8_max(q_dtype, jnp.float32))
+
+    grid_k, grid_n = k // bm, n // bn
+    body_cost = _ct_body_cost(q_dtype, dtype_max, jax.ShapeDtypeStruct((e, k, n), x_dtype))
+    input_bytes = e * k * n * jnp.dtype(x_dtype).itemsize + jnp.dtype(jnp.float32).itemsize
+    # Two output stores: natural [e,k,n] + transposed [e,n,k] = 2*e*k*n FP8 bytes, plus amax partials.
+    output_bytes = 2 * e * k * n * jnp.dtype(q_dtype).itemsize + e * grid_k * grid_n * jnp.dtype(jnp.float32).itemsize
+    cost = pl.CostEstimate(
+        flops=body_cost.flops,
+        transcendentals=body_cost.transcendentals,
+        bytes_accessed=input_bytes + output_bytes,
+    )
+
+    return pl.pallas_call(
+        functools.partial(_ct_kernel, q_dtype=q_dtype, dtype_max=dtype_max, grid_ndim=3),
+        out_shape=[
+            jax.ShapeDtypeStruct((e, k, n), q_dtype),
+            jax.ShapeDtypeStruct((e, n, k), q_dtype),
+            jax.ShapeDtypeStruct((e, grid_k, grid_n), jnp.float32),
+        ],
+        in_specs=[
+            plgpu.BlockSpec((None, bm, bn), lambda e, i, j: (e, i, j), transforms=_smem_transforms(bn, x_dtype)),
+            pl.BlockSpec(memory_space=plgpu.GMEM),
+        ],
+        out_specs=[
+            plgpu.BlockSpec((None, bm, bn), lambda e, i, j: (e, i, j), transforms=_smem_transforms(bn, q_dtype)),
+            plgpu.BlockSpec((None, bn, bm), lambda e, i, j: (e, j, i), transforms=_smem_transforms(bm, q_dtype)),
+            pl.BlockSpec(memory_space=plgpu.GMEM),
+        ],
+        grid=(e, k // bm, n // bn),
+        compiler_params=plgpu.CompilerParams(reduction_scratch_bytes=6144),
+        cost_estimate=cost,
+    )
+
+
+def cast_transpose_amax_3d(x, inv_scale, q_dtype):
+    """``x[E,K,N]`` bf16 → (fp8 ``[E,K,N]``, fp8 ``[E,N,K]``, amax ``[1]``) in one read.
+
+    Like ``cast_transpose_amax_2d`` but grids over the expert dimension ``E``.
+
+    Args:
+        x: ``[E, K, N]`` bfloat16 weight tensor.
+        inv_scale: ``[1]`` float32 inverse scale (``1 / new_scale``).
+        q_dtype: target FP8 dtype.
+
+    Returns:
+        ``(q_natural, q_transposed, amax)``: natural ``[E, K, N]``, transposed
+        ``[E, N, K]``, and per-tensor amax ``[1]``.
+    """
+    e, k, n = x.shape
+    q_nat, q_t, amax_parts = _make_ct_call_3d(e, k, n, q_dtype, x.dtype)(x, inv_scale)
+    return q_nat, q_t, jnp.max(amax_parts).reshape(1)
+
+
+# ---------------------------------------------------------------------------
+# Delayed-scaling helper.
+# ---------------------------------------------------------------------------
+
+
+def _next_scale_and_inv(q_dtype, scale, amax_history):
+    """Delayed-scaling scale for this step (shared TE recipe from ``_src/fp8``) + its reciprocal."""
+    new_scale = scale_from_history(q_dtype, scale, amax_history)
+    inv_scale = (1.0 / new_scale).astype(jnp.float32).reshape(1)
+    return new_scale, inv_scale
+
+
+# ---------------------------------------------------------------------------
+# Cast-transpose analog of in_q: produces both layouts + threads delayed-scaling state.
+# ---------------------------------------------------------------------------
+
+
+def cast_transpose_delayed(q_dtype, mode, inp, scale, amax_history):
+    """Cast-transpose ``inp`` with delayed scaling.
+
+    Returns ``(q_natural, q_transposed, new_scale, new_history)``.  The amax is
+    folded into the kernel (per-tile partials reduced by XLA), so
+    ``new_history`` reflects the current step's observed magnitude without a
+    separate read of the input.
+
+    Args:
+        q_dtype: target FP8 dtype.
+        mode: ``"2d"`` for activations ``[M, K]`` or ``"3d"`` for weights ``[E, K, N]``.
+        inp: bf16 tensor to quantize.
+        scale: current delayed-scaling scale ``[1]``.
+        amax_history: rolling amax history.
+    """
+    new_scale, inv_scale = _next_scale_and_inv(q_dtype, scale, amax_history)
+    if mode == "3d":
+        q_nat, q_t, cur_amax = cast_transpose_amax_3d(inp, inv_scale, q_dtype)
+    else:
+        q_nat, q_t, cur_amax = cast_transpose_amax_2d(inp, inv_scale, q_dtype)
+    new_history = roll_amax_history(cur_amax[0], amax_history)
+    return q_nat, q_t, new_scale, new_history
+
+
+@functools.partial(custom_vjp, nondiff_argnums=(0, 1))
+def in_q_ct(q_dtype, mode, inp, scale, amax_history):
+    """Cast-transpose analog of ``in_q``: returns ``(q_natural, q_transposed, new_scale)``.
+
+    Produces both FP8 layouts (natural and transposed) in a single bf16 read
+    and threads the delayed-scaling ``OverwriteWithGradient`` state (``scale``
+    and ``amax_history`` are overwritten by the backward via the returned
+    cotangents, just like ``in_q``).
+
+    Args:
+        q_dtype: target FP8 dtype (non-differentiable static arg).
+        mode: ``"2d"`` or ``"3d"`` (non-differentiable static arg).
+        inp: bf16 tensor to quantize.
+        scale: current delayed-scaling scale ``[1]``.
+        amax_history: rolling amax history.
+
+    Returns:
+        ``(q_natural, q_transposed, new_scale)``.
+    """
+    q_nat, q_t, new_scale, _ = cast_transpose_delayed(q_dtype, mode, inp, scale, amax_history)
+    return q_nat, q_t, new_scale
+
+
+def _in_q_ct_fwd(q_dtype, mode, inp, scale, amax_history):
+    q_nat, q_t, new_scale, new_history = cast_transpose_delayed(q_dtype, mode, inp, scale, amax_history)
+    return (q_nat, q_t, new_scale), (new_scale, new_history)
+
+
+def _in_q_ct_bwd(q_dtype, mode, res, _cts):
+    new_scale, new_history = res
+    # No grad to inp; pass updated scale/history through as cotangents so
+    # OverwriteWithGradient overwrites the persisted delayed-scaling state.
+    return None, new_scale, new_history
+
+
+in_q_ct.defvjp(_in_q_ct_fwd, _in_q_ct_bwd)

--- a/lib/haliax/src/haliax/_src/fp8_cast_transpose.py
+++ b/lib/haliax/src/haliax/_src/fp8_cast_transpose.py
@@ -20,6 +20,12 @@ and store through a transposed SMEM view -- both FP8 stores are then contiguous.
 ``in_q_ct`` wraps this in the same ``OverwriteWithGradient`` custom-VJP
 threading as ``in_q`` so the per-tensor scale / amax-history state still flows
 through ``apply_updates``.
+
+HBM cost of the dual layout: both FP8 copies persist in HBM (the forward and
+each backward GEMM consume different layouts), but at 1 byte/element the two
+copies together equal the footprint of the single bf16 operand they quantize
+-- materializing the transpose is what lets all three GEMMs run genuine FP8
+``wgmma``, which cannot transpose an operand at runtime.
 """
 
 import functools

--- a/lib/haliax/src/haliax/_src/fp8_cast_transpose.py
+++ b/lib/haliax/src/haliax/_src/fp8_cast_transpose.py
@@ -100,8 +100,13 @@ def _ct_body_cost(q_dtype, dtype_max, x_struct):
 
 
 @functools.lru_cache(maxsize=16)
-def _make_ct_call_2d(m: int, k: int, q_dtype, x_dtype):
-    """Build and cache the cast-transpose+amax pallas_call for 2-D inputs."""
+def _make_ct_call_2d(m: int, k: int, q_dtype, x_dtype, t_extra: int = 0):
+    """Build and cache the cast-transpose+amax pallas_call for 2-D inputs.
+
+    ``t_extra`` widens the transposed output to ``[k, m + t_extra]``; the extra
+    columns are left unwritten (the wgrad boundary appendix fills them, see
+    ``write_boundary_appendix``).
+    """
     # A 64-row tile on the (token) M axis measures better bandwidth than 128
     # at the d2560 shapes; K keeps the widest tile.
     bm = 64 if m % 64 == 0 else _block_size(m)
@@ -123,7 +128,7 @@ def _make_ct_call_2d(m: int, k: int, q_dtype, x_dtype):
         functools.partial(_ct_kernel, q_dtype=q_dtype, dtype_max=dtype_max, grid_ndim=2),
         out_shape=[
             jax.ShapeDtypeStruct((m, k), q_dtype),
-            jax.ShapeDtypeStruct((k, m), q_dtype),
+            jax.ShapeDtypeStruct((k, m + t_extra), q_dtype),
             jax.ShapeDtypeStruct((grid_m, grid_k), jnp.float32),
         ],
         in_specs=[
@@ -141,8 +146,8 @@ def _make_ct_call_2d(m: int, k: int, q_dtype, x_dtype):
     )
 
 
-def cast_transpose_amax_2d(x, inv_scale, q_dtype):
-    """``x[M,K]`` bf16 → (fp8 ``[M,K]``, fp8 ``[K,M]``, amax ``[1]``) in one read.
+def cast_transpose_amax_2d(x, inv_scale, q_dtype, t_extra=0):
+    """``x[M,K]`` bf16 → (fp8 ``[M,K]``, fp8 ``[K,M+t_extra]``, amax ``[1]``) in one read.
 
     Loads the bf16 tile once, emits per-tile amax partials (reduced by XLA),
     quantizes, and stores both the natural and the transposed FP8 tiles.
@@ -151,13 +156,15 @@ def cast_transpose_amax_2d(x, inv_scale, q_dtype):
         x: ``[M, K]`` bfloat16 input.
         inv_scale: ``[1]`` float32 inverse scale (``1 / new_scale``).
         q_dtype: target FP8 dtype (``jnp.float8_e4m3fn`` or ``jnp.float8_e5m2``).
+        t_extra: extra (unwritten) columns appended to the transposed output for
+            the wgrad boundary appendix (``write_boundary_appendix``).
 
     Returns:
         ``(q_natural, q_transposed, amax)``: natural ``[M, K]``, transposed
-        ``[K, M]``, and per-tensor amax ``[1]``.
+        ``[K, M + t_extra]``, and per-tensor amax ``[1]``.
     """
     m, k = x.shape
-    q_nat, q_t, amax_parts = _make_ct_call_2d(m, k, q_dtype, x.dtype)(x, inv_scale)
+    q_nat, q_t, amax_parts = _make_ct_call_2d(m, k, q_dtype, x.dtype, t_extra)(x, inv_scale)
     return q_nat, q_t, jnp.max(amax_parts).reshape(1)
 
 
@@ -243,7 +250,7 @@ def _next_scale_and_inv(q_dtype, scale, amax_history):
 # ---------------------------------------------------------------------------
 
 
-def cast_transpose_delayed(q_dtype, mode, inp, scale, amax_history):
+def cast_transpose_delayed(q_dtype, mode, t_extra, inp, scale, amax_history):
     """Cast-transpose ``inp`` with delayed scaling.
 
     Returns ``(q_natural, q_transposed, new_scale, new_history)``.  The amax is
@@ -254,21 +261,25 @@ def cast_transpose_delayed(q_dtype, mode, inp, scale, amax_history):
     Args:
         q_dtype: target FP8 dtype.
         mode: ``"2d"`` for activations ``[M, K]`` or ``"3d"`` for weights ``[E, K, N]``.
+        t_extra: extra transposed-output columns for the wgrad boundary appendix
+            (2-D mode only; pass 0 when unused).
         inp: bf16 tensor to quantize.
         scale: current delayed-scaling scale ``[1]``.
         amax_history: rolling amax history.
     """
     new_scale, inv_scale = _next_scale_and_inv(q_dtype, scale, amax_history)
     if mode == "3d":
+        if t_extra:
+            raise ValueError("t_extra is only supported for 2-D cast-transpose (wgrad appendix)")
         q_nat, q_t, cur_amax = cast_transpose_amax_3d(inp, inv_scale, q_dtype)
     else:
-        q_nat, q_t, cur_amax = cast_transpose_amax_2d(inp, inv_scale, q_dtype)
+        q_nat, q_t, cur_amax = cast_transpose_amax_2d(inp, inv_scale, q_dtype, t_extra)
     new_history = roll_amax_history(cur_amax[0], amax_history)
     return q_nat, q_t, new_scale, new_history
 
 
-@functools.partial(custom_vjp, nondiff_argnums=(0, 1))
-def in_q_ct(q_dtype, mode, inp, scale, amax_history):
+@functools.partial(custom_vjp, nondiff_argnums=(0, 1, 2))
+def in_q_ct(q_dtype, mode, t_extra, inp, scale, amax_history):
     """Cast-transpose analog of ``in_q``: returns ``(q_natural, q_transposed, new_scale)``.
 
     Produces both FP8 layouts (natural and transposed) in a single bf16 read
@@ -279,6 +290,8 @@ def in_q_ct(q_dtype, mode, inp, scale, amax_history):
     Args:
         q_dtype: target FP8 dtype (non-differentiable static arg).
         mode: ``"2d"`` or ``"3d"`` (non-differentiable static arg).
+        t_extra: extra transposed-output columns for the wgrad boundary appendix
+            (non-differentiable static arg; 2-D mode only).
         inp: bf16 tensor to quantize.
         scale: current delayed-scaling scale ``[1]``.
         amax_history: rolling amax history.
@@ -286,16 +299,16 @@ def in_q_ct(q_dtype, mode, inp, scale, amax_history):
     Returns:
         ``(q_natural, q_transposed, new_scale)``.
     """
-    q_nat, q_t, new_scale, _ = cast_transpose_delayed(q_dtype, mode, inp, scale, amax_history)
+    q_nat, q_t, new_scale, _ = cast_transpose_delayed(q_dtype, mode, t_extra, inp, scale, amax_history)
     return q_nat, q_t, new_scale
 
 
-def _in_q_ct_fwd(q_dtype, mode, inp, scale, amax_history):
-    q_nat, q_t, new_scale, new_history = cast_transpose_delayed(q_dtype, mode, inp, scale, amax_history)
+def _in_q_ct_fwd(q_dtype, mode, t_extra, inp, scale, amax_history):
+    q_nat, q_t, new_scale, new_history = cast_transpose_delayed(q_dtype, mode, t_extra, inp, scale, amax_history)
     return (q_nat, q_t, new_scale), (new_scale, new_history)
 
 
-def _in_q_ct_bwd(q_dtype, mode, res, _cts):
+def _in_q_ct_bwd(q_dtype, mode, t_extra, res, _cts):
     new_scale, new_history = res
     # No grad to inp; pass updated scale/history through as cotangents so
     # OverwriteWithGradient overwrites the persisted delayed-scaling state.
@@ -303,3 +316,94 @@ def _in_q_ct_bwd(q_dtype, mode, res, _cts):
 
 
 in_q_ct.defvjp(_in_q_ct_fwd, _in_q_ct_bwd)
+
+
+# ---------------------------------------------------------------------------
+# Wgrad boundary appendix: pre-masked group-boundary token blocks.
+# ---------------------------------------------------------------------------
+
+# Token-block width of the wgrad pipeline (== the wgrad kernel's block_k) and of
+# the appendix slots: each group owns two 128-token slots (first / last block).
+WGRAD_TOKEN_BLOCK = 128
+
+
+def _boundary_appendix_kernel(start_ref, end_ref, q_ref, out_ref, smem_ref, barrier_ref, *, block_rows, t_real):
+    """Write group ``g``'s pre-masked first/last token blocks into its appendix slots.
+
+    Grid ``(G, K // block_rows)``.  Reads the boundary blocks from the main
+    region ``[:, :t_real]`` and stores masked copies at columns
+    ``t_real + g*2*B + {0, B}`` (``B = WGRAD_TOKEN_BLOCK``).  The universal keep
+    predicate ``start <= token < end`` makes single-block groups (first == last)
+    correct in either slot, and empty groups write all-zero blocks that the
+    wgrad never reads.
+    """
+    b = WGRAD_TOKEN_BLOCK
+    g = pl.program_id(0)
+    i = pl.program_id(1)
+    start = start_ref[g]
+    end = end_ref[g]
+    rows = pl.ds(i * block_rows, block_rows)
+    first_blk = start // b * b
+    last_blk = jnp.maximum(end - 1, 0) // b * b
+    blks = (first_blk, last_blk)
+    # Stage through SMEM: TMA both boundary blocks in, mask in registers, TMA out.
+    for slot in (0, 1):
+        plgpu.copy_gmem_to_smem(q_ref.at[rows, pl.ds(blks[slot], b)], smem_ref.at[slot], barrier_ref.at[slot])
+    cols = plgpu.broadcasted_iota(jnp.int32, (block_rows, b), 1, layout=plgpu.Layout.WGMMA)
+    for slot in (0, 1):
+        plgpu.barrier_wait(barrier_ref.at[slot])
+        src = plgpu.load(smem_ref.at[slot], (), layout=plgpu.Layout.WGMMA)
+        keep = (blks[slot] + cols >= start) & (blks[slot] + cols < end)
+        val = jnp.where(keep, src.astype(jnp.float16), jnp.float16(0)).astype(src.dtype)
+        smem_ref.at[slot][...] = val
+        plgpu.commit_smem()
+        plgpu.copy_smem_to_gmem(smem_ref.at[slot], out_ref.at[rows, pl.ds(t_real + g * 2 * b + slot * b, b)])
+    plgpu.wait_smem_to_gmem(0, wait_read_only=True)
+
+
+def write_boundary_appendix(q_t, group_sizes):
+    """Fill the wgrad boundary appendix of a widened transposed operand, in place.
+
+    ``q_t`` is ``[K, T + G*256]`` (from ``cast_transpose_amax_2d(..., t_extra=G*256)``):
+    the main region ``[:, :T]`` holds the token-contiguous FP8 operand and the
+    appendix holds, per group, its first and last ``WGRAD_TOKEN_BLOCK``-token
+    blocks with out-of-group tokens zeroed.  The wgrad kernel reads boundary
+    pipeline steps from the appendix instead of masking in SMEM
+    (``mgpu_dwgrad``), which keeps its pipeline body branch-free.
+
+    The buffer is aliased through the kernel (no copy of the main region).
+
+    Args:
+        q_t: ``[K, T + G*2*WGRAD_TOKEN_BLOCK]`` FP8, token dim contiguous.
+        group_sizes: ``[G]`` int32 token count per group (``sum == T``).
+
+    Returns:
+        The same-shape array with the appendix written.
+    """
+    g = group_sizes.shape[0]
+    k_dim, t_wide = q_t.shape
+    b = WGRAD_TOKEN_BLOCK
+    t_real = t_wide - g * 2 * b
+    if t_real <= 0 or t_real % b != 0:
+        raise ValueError(f"q_t width {t_wide} does not contain a {b}-aligned main region for {g} groups")
+    if k_dim % b != 0:
+        raise ValueError(f"K={k_dim} must be a multiple of {b} for the boundary-appendix writer")
+    ends = jnp.cumsum(group_sizes.astype(jnp.int32))
+    starts = ends - group_sizes.astype(jnp.int32)
+    return pl.pallas_call(
+        functools.partial(_boundary_appendix_kernel, block_rows=b, t_real=t_real),
+        out_shape=jax.ShapeDtypeStruct(q_t.shape, q_t.dtype),
+        grid=(g, k_dim // b),
+        in_specs=[
+            pl.BlockSpec(memory_space=plgpu.GMEM),
+            pl.BlockSpec(memory_space=plgpu.GMEM),
+            pl.BlockSpec(memory_space=plgpu.GMEM),
+        ],
+        out_specs=pl.BlockSpec(memory_space=plgpu.GMEM),
+        scratch_shapes=[
+            plgpu.SMEM((2, b, b), q_t.dtype, transforms=_smem_transforms(b, q_t.dtype)),
+            plgpu.Barrier(num_barriers=2),
+        ],
+        input_output_aliases={2: 0},
+        compiler_params=plgpu.CompilerParams(),
+    )(starts, ends, q_t)

--- a/lib/haliax/src/haliax/_src/fp8_ragged.py
+++ b/lib/haliax/src/haliax/_src/fp8_ragged.py
@@ -2,45 +2,32 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""FP8 grouped matmul (``ragged_dot``) for Hopper H100 -- FP8 forward + FP8 dgrad.
+"""FP8 grouped matmul (``ragged_dot``) for Hopper -- all three GEMMs on FP8.
 
 The MoE-grouped analog of the dense ``fp8_scaled_dot_general`` in ``_src/fp8.py``.
-The forward contracts activations and expert weights as same-dtype ``e4m3 x e4m3``
-on the Hopper FP8 tensor cores via the genuine ragged Mosaic ``wgmma`` kernel
-(``_src/ragged_dot_mgpu``), which handles genuinely **non-uniform, dynamic**
-``group_sizes`` (no equal-size / batched-dense reshape).
+All three contractions run on the FP8 tensor cores via the ragged Mosaic ``wgmma``
+kernels in ``_src/ragged_dot_mgpu``, which handle non-uniform dynamic
+``group_sizes`` (no equal-size / batched-dense reshape):
 
-The backward runs the input gradient (dgrad) on the FP8 tensor cores as well:
+  * forward   ``out[T,N]  = lhs[T,K] . rhs[E,K,N]``  -- ``mgpu_ragged_dot``
+  * grad_lhs  ``dl[T,K]   = g[T,N] . rhs[E,K,N]``    -- ``mgpu_ragged_dot``
+  * grad_rhs  ``dr[E,K,N] = lhs[T,K] . g[T,N]``      -- ``mgpu_dwgrad``
 
-  * grad_lhs  ``dl[T,K] = g[T,N] . rhs[E,K,N]`` (contract N) -- FP8 ``wgmma``.
+FP8 ``wgmma`` needs the contracting dim contiguous in both operands and cannot
+transpose an operand at runtime, so each bf16 input is quantized into *both* the
+natural and the transposed FP8 layout by one fused cast-transpose+amax read
+(``in_q_ct`` in ``_src/fp8_cast_transpose``): the forward consumes ``q_lhs [T,K]``
+and ``q_rhs_t [E,N,K]``, the dgrad consumes ``q_rhs [E,K,N]``, and the wgrad
+consumes ``q_lhs_t [K,T]`` and ``q_g_t [N,T]``.
 
-The output gradient ``g`` is quantized to ``rev_dtype`` with delayed per-tensor
-scaling; ``rev_dtype`` defaults to E5M2 (the numerically correct output-gradient
-dtype), so the dgrad is a genuine mixed ``e5m2 x e4m3`` contraction (mixed
-``wgmma`` needs jax >= 0.11.0, jax-ml/jax#38859). It consumes the
-**pre-produced natural weight layout** ``q_rhs [E,K,N]`` cast once by the
-forward (no re-cast).
+Delayed per-tensor scaling (TE-style scale + amax history) follows the dense
+helpers in ``_src/fp8.py``: activation, weight, and output-gradient scale +
+amax-history state all update through the custom VJPs as ``OverwriteWithGradient``
+cotangents.
 
-  * grad_rhs  ``dr[E,K,N] = lhs[T,K] . g[T,N]`` (contract the ragged token dim)
-
-still runs in **bf16** (numerically exact) via the Triton kernel from the bf16
-``ragged_dot`` backward (``_DRHS_DIM_NUMS`` through ``_triton_pallas_call``); the
-FP8 weight gradient is the next step.
-
-Delayed per-tensor scaling (TE-style scale + amax history) is reused verbatim from
-the dense helpers in ``_src/fp8.py``: the input and kernel scale + amax_history
-update through ``in_q_ct``'s custom VJP as ``OverwriteWithGradient`` overwrites.
-The output-gradient scale + amax history now update too -- the backward quantizes
-``g`` with delayed scaling and returns the rolled ``grad_scale`` / ``grad_amax_history``
-as the ``OverwriteWithGradient`` cotangents.
-
-Both the activation (lhs) and expert weight (rhs) quantize go through ``in_q_ct``
-(``_src/fp8_cast_transpose``), a fused Pallas-Triton kernel that reads the bf16 tile
-once, folds the amax reduction via ``atomic_max``, and stores **both** the natural
-and the transposed FP8 tile in one pass.  The forward consumes the transposed-weight
-layout (``[E,N,K]``); the dgrad consumes the natural-weight layout (``[E,K,N]``). The
-transposed-activation layout (``[K,T]``) is produced but deferred to the FP8 weight
-gradient follow-up.
+``rev_dtype`` defaults to E5M2 (the numerically correct output-gradient dtype),
+so both backward GEMMs are genuine mixed ``e5m2 x e4m3`` contractions.  Mixed
+``wgmma`` needs jax >= 0.11.0 (jax-ml/jax#38859; see ``Fp8RaggedDotOp``).
 """
 
 import functools
@@ -51,13 +38,14 @@ from jax import custom_vjp
 
 from .fp8 import roll_amax_history
 from .fp8_cast_transpose import _next_scale_and_inv, cast_transpose_amax_2d, in_q_ct
-from .ragged_dot_mgpu import mgpu_ragged_dot
+from .ragged_dot_mgpu import mgpu_dwgrad, mgpu_ragged_dot
 
 _E4M3 = jnp.float8_e4m3fn
 _E5M2 = jnp.float8_e5m2
 
 # H100 per-block SMEM ceiling (bytes) for the Mosaic operand pipeline; see the
-# forward config note.
+# forward config note. The wgrad operand tiles are FP8 (1 byte), so the pipeline
+# footprint is ``(block_m + block_n) * block_k * max_concurrent_steps`` bytes.
 _H100_SMEM_LIMIT = 232448
 
 # Candidate wgmma block sizes, largest first; a dim picks the largest that
@@ -81,6 +69,41 @@ def _autotuned_config(m: int, n: int, k: int) -> dict:
     block_n = next((b for b in _GEMM_BLOCKS if n % b == 0), 16)
     block_k = next((b for b in _GEMM_BLOCKS if k % b == 0), 16)
     grid_block_n = next((gb for gb in (4, 2, 1) if n % (gb * block_n) == 0), 1)
+    max_concurrent_steps = 6
+    while max_concurrent_steps > 1 and (block_m + block_n) * block_k * max_concurrent_steps > _H100_SMEM_LIMIT:
+        max_concurrent_steps -= 1
+    return dict(
+        block_m=block_m,
+        block_n=block_n,
+        block_k=block_k,
+        max_concurrent_steps=max_concurrent_steps,
+        grid_block_n=grid_block_n,
+    )
+
+
+def _dwgrad_config(k: int, n: int) -> dict:
+    """Static Mosaic block config for the ragged FP8 weight-gradient kernel.
+
+    Tuned on H100 at the d2560 grug-MoE shapes. ``block_m`` tiles the output K,
+    ``block_n`` the output N, and ``block_k=128`` the ragged token (contracting)
+    dim. The tile *pair* matters more than either dimension alone: wide-N
+    ``(64, 256)`` beats ``(128, 128)``, but ``(128, 256)`` collapses, so the
+    wide-N tile is only taken with the short 64-row block. Tile pairs that
+    exceed the H100 per-block SMEM ceiling drop ``max_concurrent_steps`` (as
+    the forward config does at ``block_k=128``); the ``next(..., fallback)``
+    guards keep the config valid when K/N are not multiples of the preferred
+    tile.
+    """
+    if k % 64 == 0 and n % 256 == 0:
+        block_m, block_n = 64, 256
+    else:
+        block_m = next((b for b in _GEMM_BLOCKS if k % b == 0), 16)
+        block_n = next((b for b in _GEMM_BLOCKS if n % b == 0), 16)
+    # Plain row-major tile order (no n-snake) wins at the d2560 shapes: the wgrad's
+    # operand slices for one expert group fit L2 anyway, and the snake's split n-walk
+    # costs more in lhs re-reads than it saves (measured ~6-8%).
+    grid_block_n = 1
+    block_k = 128
     max_concurrent_steps = 6
     while max_concurrent_steps > 1 and (block_m + block_n) * block_k * max_concurrent_steps > _H100_SMEM_LIMIT:
         max_concurrent_steps -= 1
@@ -125,7 +148,7 @@ def _ragged_fp8(lhs, rhs_nk, group_sizes, out_dtype, out_scale):
 @functools.partial(custom_vjp, nondiff_argnums=(11,))
 def quantized_ragged_dot(
     q_lhs,  # [T, K] e4m3      -- forward A
-    q_lhs_t,  # [K, T] e4m3    -- grad_rhs A (FP8 weight-grad follow-up; unused here)
+    q_lhs_t,  # [K, T] e4m3    -- grad_rhs A (token-contiguous)
     q_rhs,  # [E, K, N] e4m3   -- grad_lhs B (natural layout)
     q_rhs_t,  # [E, N, K] e4m3 -- forward B (transpose_rhs layout)
     lhs_scale,  # [1] delayed-scaling scale for the activation quantize
@@ -137,16 +160,16 @@ def quantized_ragged_dot(
     group_sizes,  # [E]
     rev_dtype,  # static: output-gradient FP8 dtype (E4M3 here)
 ):
-    """FP8 ragged forward of pre-quantized E4M3 operands; FP8 dgrad, bf16 wgrad.
+    """FP8 ragged forward of pre-quantized E4M3 operands; FP8 dgrad and wgrad.
 
-    Every FP8 operand layout is precomputed once by the fused cast-transpose+amax
-    kernel, so no transpose happens here. The forward contracts ``q_lhs`` against the
-    transpose_rhs layout ``q_rhs_t`` (E4M3 x E4M3) and dequantizes by the folded
-    ``lhs_scale*rhs_scale``. The backward quantizes the output gradient to
-    ``rev_dtype`` (static arg 11; E4M3 here) with delayed scaling and contracts it
-    against the pre-produced natural weight layout ``q_rhs`` for grad_lhs; grad_rhs
-    stays bf16. ``grad_scale``/``grad_amax_history`` are differentiable so the backward
-    can return the rolled delayed-scaling state as ``OverwriteWithGradient`` cotangents.
+    All FP8 layouts are precomputed by ``in_q_ct``, so no transpose happens here
+    (see the module docstring for which GEMM consumes which layout). ``lhs`` and
+    ``rhs`` are the differentiable args -- the operand gradients flow to them --
+    and also supply the compute dtype; the ``q_*`` and scale args get ``None``
+    cotangents (their state updates through ``in_q_ct``'s VJP). The backward
+    quantizes the output gradient to ``rev_dtype`` with delayed scaling and
+    returns the rolled ``grad_scale`` / ``grad_amax_history`` as
+    ``OverwriteWithGradient`` cotangents.
     """
     combined = (lhs_scale * rhs_scale).astype(jnp.float32)
     return _ragged_fp8(q_lhs, q_rhs_t, group_sizes, lhs.dtype, combined)
@@ -168,21 +191,20 @@ def _qrd_fwd(
 ):
     combined = (lhs_scale * rhs_scale).astype(jnp.float32)
     out = _ragged_fp8(q_lhs, q_rhs_t, group_sizes, lhs.dtype, combined)
-    res = (q_rhs, rhs_scale, grad_scale, grad_amax_history, lhs, rhs, group_sizes)
+    res = (q_lhs_t, q_rhs, lhs_scale, rhs_scale, grad_scale, grad_amax_history, lhs, rhs, group_sizes)
     return out, res
 
 
 def _qrd_bwd(rev_dtype, res, g):
-    q_rhs, rhs_scale, grad_scale, grad_amax_history, lhs, rhs, group_sizes = res
+    q_lhs_t, q_rhs, lhs_scale, rhs_scale, grad_scale, grad_amax_history, lhs, rhs, group_sizes = res
     out_dtype = lhs.dtype
 
     # Delayed scaling for the output gradient: one fused cast-transpose+amax read
-    # produces the natural [T,N] layout q_g (for the dgrad) plus the current-step
-    # amax to roll into the history -- a single bf16 read of ``g``. The transposed
-    # [N,T] layout q_g_t comes out of the same read; it is consumed by the FP8
-    # weight gradient in the next commit (grad_rhs is still bf16 here).
+    # produces both the natural [T,N] layout q_g (for the dgrad) and the transposed
+    # [N,T] layout q_g_t (for the wgrad) plus the current-step amax to roll into
+    # the history -- a single bf16 read of ``g``.
     new_g_scale, inv_g = _next_scale_and_inv(rev_dtype, grad_scale, grad_amax_history)
-    q_g, _q_g_t, cur_amax = cast_transpose_amax_2d(g, inv_g, rev_dtype)  # [T,N], [N,T]
+    q_g, q_g_t, cur_amax = cast_transpose_amax_2d(g, inv_g, rev_dtype)  # [T,N], [N,T]
     new_g_hist = roll_amax_history(cur_amax[0], grad_amax_history)
 
     # grad_lhs[T,K] = g[T,N] . rhs[E,K,N] (contract N), on the pre-cast natural
@@ -191,20 +213,32 @@ def _qrd_bwd(rev_dtype, res, g):
     dlhs_scale = (rhs_scale * new_g_scale).astype(jnp.float32)
     grad_lhs = _ragged_fp8(q_g, q_rhs, group_sizes, out_dtype, dlhs_scale)
 
-    # grad_rhs[E,K,N] = lhs[T,K] . g[T,N]  (contracts the ragged token dim) -- still
-    # bf16 via the Triton kernel from the bf16 ragged_dot backward. lhs/g are the
-    # compute-dtype operands, so there is no forward recompute.
-    # Local import breaks the quantization <-> nn.ragged_dot import cycle.
-    from haliax.nn.ragged_dot import _DRHS_DIM_NUMS, _triton_pallas_call  # noqa: PLC0415
-
-    grad_rhs = _triton_pallas_call(lhs, g, group_sizes, _DRHS_DIM_NUMS)
+    # grad_rhs[E,K,N] = lhs[T,K] . g[T,N] (contracts the ragged token dim) via
+    # mgpu_dwgrad on the pre-cast token-contiguous layouts q_lhs_t [K,T] and
+    # q_g_t [N,T]. The kernel's boundary mask zeros tokens outside each group,
+    # so group boundaries falling mid-block_k-tile are handled correctly.
+    t = lhs.shape[0]
+    if t % 128 != 0:
+        raise ValueError(
+            f"T={t} (token count) must be a multiple of 128 for the FP8 weight-gradient kernel: "
+            "the token dim is the wgmma contracting dim and its GMEM/TMA tile is 128 tokens wide."
+        )
+    _, k, n = rhs.shape
+    drhs_cfg = _dwgrad_config(k, n)
+    drhs_scale = (lhs_scale * new_g_scale).astype(jnp.float32)
+    grad_rhs = mgpu_dwgrad(
+        q_lhs_t,
+        q_g_t,
+        group_sizes=group_sizes,
+        out_dtype=out_dtype,
+        out_scale=drhs_scale,
+        **drhs_cfg,
+    )
     grad_rhs = grad_rhs.astype(rhs.dtype)
 
-    # Cotangents for the 11 differentiable args (q_lhs, q_lhs_t, q_rhs, q_rhs_t,
-    # lhs_scale, rhs_scale, grad_scale, grad_amax_history, lhs, rhs, group_sizes):
-    # the q's are intermediate (overwrites handled by in_q_ct); lhs_scale/rhs_scale
-    # overwrite via in_q_ct; operand grads flow to lhs/rhs; the output-grad scale and
-    # amax history are overwritten here with the rolled delayed-scaling state.
+    # Operand grads flow to lhs/rhs; the output-grad scale and amax history are
+    # overwritten with the rolled delayed-scaling state; everything else (handled
+    # by in_q_ct's VJP) gets None.
     return (None, None, None, None, None, None, new_g_scale, new_g_hist, grad_lhs, grad_rhs, None)
 
 
@@ -225,7 +259,7 @@ def fp8_scaled_ragged_dot(
     fwd_dtype=_E4M3,
     rev_dtype=_E5M2,
 ):
-    """FP8 ``ragged_dot`` with an E4M3 forward and an FP8 dgrad / bf16 wgrad backward.
+    """FP8 ``ragged_dot`` with an E4M3 forward and an all-FP8 (dgrad + wgrad) backward.
 
     Args:
         lhs: ``[T, K]`` activations (rows sorted by expert / contiguous groups).
@@ -235,29 +269,52 @@ def fp8_scaled_ragged_dot(
         lhs_scale, rhs_scale, grad_scale: ``[1]`` delayed-scaling scales.
         lhs_amax_history, rhs_amax_history, grad_amax_history: amax histories.
         fwd_dtype: forward-operand FP8 dtype (E4M3).
-        rev_dtype: output-gradient FP8 dtype. Defaults to E5M2, making the dgrad
-            a mixed ``e5m2 x e4m3`` contraction (needs jax >= 0.11.0,
-            jax-ml/jax#38859); E4M3 gives a uniform GEMM that lowers on jax 0.10.x.
+        rev_dtype: output-gradient FP8 dtype. Defaults to E5M2, making both
+            gradients mixed ``e5m2 x e4m3`` contractions (needs jax >= 0.11.0,
+            jax-ml/jax#38859); E4M3 gives uniform GEMMs that lower on jax 0.10.x.
 
     Quantizes activations and expert weights to ``fwd_dtype`` with delayed
-    per-tensor scaling and contracts them on the FP8 tensor cores via the genuine
-    ragged ``wgmma`` kernel, then dequantizes. The input gradient runs on the FP8
-    tensor cores against the pre-cast natural weight layout (gradient quantized to
-    ``rev_dtype`` with delayed scaling); the weight gradient stays bf16. The input,
-    kernel, and output-gradient scale / amax-history all update through the custom
-    VJPs as ``OverwriteWithGradient`` overwrites.
+    per-tensor scaling and runs the forward and both gradients on the FP8 tensor
+    cores (see the module docstring for the kernel/layout mapping). All scale /
+    amax-history state updates through the custom VJPs as
+    ``OverwriteWithGradient`` overwrites.
+
+    The dual-layout quantize runs unconditionally, so a forward that is never
+    differentiated still pays the extra transposed-layout write. This op targets
+    training, where the backward consumes every layout; a single-layout
+    inference path would need its own cast kernel and is not worth the extra
+    machinery here.
     """
+    t, k = lhs.shape
+    _, _, n = rhs.shape
+    # Fail fast on the whole op's alignment contract -- forward AND backward --
+    # at call time. The op= path bypasses ragged_dot's 512-row padding, and the
+    # backward's constraints are stricter than the forward's (T % 64), so
+    # without this check a forward-only run would succeed and the first
+    # jax.grad would fail at trace time. Checked before the device check so the
+    # shape contract surfaces on any backend.
+    if t % 128 != 0:
+        raise ValueError(
+            f"T={t} (token count) must be a multiple of 128 for fp8_scaled_ragged_dot: the FP8 "
+            "weight-gradient kernel contracts the token dim in 128-token TMA tiles."
+        )
+    if k % 128 != 0:
+        raise ValueError(
+            f"K={k} must be a multiple of 128 for fp8_scaled_ragged_dot: K is the dgrad output's "
+            "minor dim and needs bf16 TMA swizzle alignment in the Mosaic ragged wgmma kernel."
+        )
+    if n % 128 != 0:
+        raise ValueError(
+            f"N={n} must be a multiple of 128 for fp8_scaled_ragged_dot: bf16 TMA swizzle "
+            "alignment of the forward output store in the Mosaic ragged wgmma kernel."
+        )
     device = jax.devices()[0]
     if device.platform != "gpu" or not device.compute_capability.startswith("9."):
         raise NotImplementedError(
             f"fp8_scaled_ragged_dot requires Hopper (SM90): the Mosaic wgmma kernels are "
             f"sm_90a-specific. Got {device.device_kind}."
         )
-    # Fused cast-transpose+amax: reads each bf16 tile once, folds the amax reduction, and
-    # stores both the natural and the transposed FP8 tile in one pass.  VJP threading matches in_q.
-    # The forward uses q_lhs [T,K] and q_rhs_t [E,N,K]; the dgrad uses q_rhs [E,K,N] (natural
-    # weight layout).  q_lhs_t [K,T] is produced in the same fused read but consumed only by the
-    # FP8 weight-gradient follow-up.
+    # One fused cast-transpose+amax read per operand produces both FP8 layouts.
     q_lhs, q_lhs_t, new_lhs_scale = in_q_ct(fwd_dtype, "2d", lhs, lhs_scale, lhs_amax_history)
     q_rhs, q_rhs_t, new_rhs_scale = in_q_ct(fwd_dtype, "3d", rhs, rhs_scale, rhs_amax_history)
     return quantized_ragged_dot(

--- a/lib/haliax/src/haliax/_src/fp8_ragged.py
+++ b/lib/haliax/src/haliax/_src/fp8_ragged.py
@@ -1,0 +1,184 @@
+# Copyright The Levanter Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+"""FP8 grouped matmul (``ragged_dot``) for Hopper H100 -- FP8 forward, bf16 backward.
+
+The MoE-grouped analog of the dense ``fp8_scaled_dot_general`` in ``_src/fp8.py``.
+The forward contracts activations and expert weights as same-dtype ``e4m3 x e4m3``
+on the Hopper FP8 tensor cores via the genuine ragged Mosaic ``wgmma`` kernel
+(``_src/ragged_dot_mgpu``), which handles genuinely **non-uniform, dynamic**
+``group_sizes`` (no equal-size / batched-dense reshape). The backward is computed
+in **bf16** (numerically exact) by directly invoking the Triton kernels from the
+bf16 ``ragged_dot`` backward (``_DLHS_DIM_NUMS`` / ``_DRHS_DIM_NUMS`` via
+``_triton_pallas_call``), so the operand gradients match the bf16 training default
+bit-for-bit with no forward recompute.
+
+Delayed per-tensor scaling (TE-style scale + amax history) is reused verbatim
+from the dense helpers in ``_src/fp8.py`` (``in_q`` / ``quantize``): the input and
+kernel scale + amax_history update through ``in_q``'s custom VJP as
+``OverwriteWithGradient`` overwrites. The output-gradient scaling state is unused
+here (the backward is bf16) and threads through unchanged.
+
+To get the expert weights contracting-dim-contiguous -- as FP8 ``wgmma`` requires
+-- the weight is transposed in **bf16** (a hardware-legal transpose) and only then
+cast to FP8; no strided FP8 transpose or fused cast-transpose kernel is used yet.
+"""
+
+import functools
+
+import jax
+import jax.numpy as jnp
+from jax import custom_vjp
+
+from .fp8 import in_q, quantize
+from .ragged_dot_mgpu import mgpu_ragged_dot
+
+_E4M3 = jnp.float8_e4m3fn
+_E5M2 = jnp.float8_e5m2
+
+
+def _fixed_config(m: int, n: int, k: int) -> dict:
+    """Conservative (untuned) Mosaic block config for the ragged FP8 wgmma kernel.
+
+    Block sizes divide the operand shapes: ``block_k`` must divide ``k``; ``block_n``
+    must divide ``n`` (and ``n`` must be swizzle-aligned -- a multiple of 128 for the
+    bf16 output store's TMA descriptor); ``block_m`` divides ``m`` here, though the
+    ragged kernel also masks a non-dividing final m-tile. Tuning the block sizes
+    and pipeline depth is a follow-up change.
+    """
+    block_m = next((b for b in (128, 64, 32, 16) if m % b == 0), 16)
+    block_n = next((b for b in (128, 64, 32, 16) if n % b == 0), 16)
+    block_k = next((b for b in (64, 32, 16) if k % b == 0), 16)
+    grid_block_n = next((gb for gb in (4, 2, 1) if n % (gb * block_n) == 0), 1)
+    return dict(
+        block_m=block_m,
+        block_n=block_n,
+        block_k=block_k,
+        max_concurrent_steps=6,
+        grid_block_n=grid_block_n,
+    )
+
+
+def _ragged_fp8(lhs, rhs_nk, group_sizes, out_dtype, out_scale):
+    """Genuine ragged FP8 wgmma: ``lhs[M,K] . rhs[G,K,N]`` contracting K.
+
+    ``rhs_nk`` is laid out ``[G, N, K]`` (the ``transpose_rhs`` layout) so the
+    contracting dim K is contiguous for both operands, as FP8 ``wgmma`` requires.
+    The per-tensor dequant ``out_scale`` is folded into the kernel store.
+    """
+    g, n, k = rhs_nk.shape
+    m = lhs.shape[0]
+    if n % 128 != 0:
+        raise ValueError(
+            f"n={n} must be a multiple of 128 for bf16 TMA swizzle alignment in the Mosaic ragged wgmma kernel"
+        )
+    cfg = _fixed_config(m, n, k)
+    return mgpu_ragged_dot(
+        lhs,
+        rhs_nk,
+        group_sizes=group_sizes,
+        transpose_rhs=True,
+        out_dtype=out_dtype,
+        out_scale=out_scale,
+        **cfg,
+    )
+
+
+@custom_vjp
+def quantized_ragged_dot(q_lhs, q_rhs_t, out_scale, lhs, rhs, grad_scale, grad_amax_history, group_sizes):
+    """FP8 ragged forward of pre-quantized E4M3 operands; bf16 (exact) backward.
+
+    ``q_lhs`` is ``[T,K]`` E4M3, ``q_rhs_t`` is ``[E,N,K]`` E4M3 (the transpose_rhs
+    layout). ``out_scale`` is the folded per-tensor dequant ``lhs_scale*rhs_scale``.
+    ``lhs``/``rhs`` are the original compute-dtype (bf16) operands, carried so the
+    backward can compute gradients directly with the bf16 Triton kernels.
+    ``grad_scale``/``grad_amax_history`` are the output-gradient delayed-scaling state;
+    threaded as differentiable args so the backward can return identity cotangents
+    (preserving the current values) until the FP8-backward step updates them.
+    ``group_sizes`` is a regular operand with a ``None`` cotangent rather than a
+    ``nondiff_argnums`` entry: nondiff positions reject traced arrays under ``jit``.
+    """
+    return _ragged_fp8(q_lhs, q_rhs_t, group_sizes, lhs.dtype, out_scale)
+
+
+def _qrd_fwd(q_lhs, q_rhs_t, out_scale, lhs, rhs, grad_scale, grad_amax_history, group_sizes):
+    out = _ragged_fp8(q_lhs, q_rhs_t, group_sizes, lhs.dtype, out_scale)
+    return out, (lhs, rhs, grad_scale, grad_amax_history, group_sizes)
+
+
+def _qrd_bwd(res, g):
+    lhs, rhs, grad_scale, grad_amax_history, group_sizes = res
+    # Direct bf16 operand gradients: call the same Triton kernels used by the bf16
+    # ragged_dot backward. lhs/rhs are already in the residuals, so there is no
+    # forward recompute.
+    # Local import breaks the quantization <-> nn.ragged_dot import cycle.
+    from haliax.nn.ragged_dot import _DLHS_DIM_NUMS, _DRHS_DIM_NUMS, _triton_pallas_call  # noqa: PLC0415
+
+    # dlhs[M,K] = dout[M,N] @ rhs[G,K,N]^T  (contracts N)
+    grad_lhs = _triton_pallas_call(g, rhs, group_sizes, _DLHS_DIM_NUMS)
+    # drhs[G,K,N] = lhs[M,K]^T @ dout[M,N]  (contracts M, ragged)
+    grad_rhs = _triton_pallas_call(lhs, g, group_sizes, _DRHS_DIM_NUMS)
+    # Cotangents for (q_lhs, q_rhs_t, out_scale, lhs, rhs, grad_scale,
+    # grad_amax_history, group_sizes):
+    # - quantized operands and the folded scale are intermediate (overwrites handled by in_q)
+    # - operand grads flow to lhs/rhs
+    # - grad_scale/grad_amax_history are preserved unchanged (bf16 backward; the
+    #   FP8-backward follow-up will update them to new_scale/new_history instead)
+    return (None, None, None, grad_lhs, grad_rhs, grad_scale, grad_amax_history, None)
+
+
+quantized_ragged_dot.defvjp(_qrd_fwd, _qrd_bwd)
+
+
+def fp8_scaled_ragged_dot(
+    lhs,
+    rhs,
+    group_sizes,
+    *,
+    lhs_scale,
+    rhs_scale,
+    grad_scale,
+    lhs_amax_history,
+    rhs_amax_history,
+    grad_amax_history,
+    quantize_compute_type=jnp.float32,
+    fwd_dtype=_E4M3,
+    rev_dtype=_E5M2,
+):
+    """FP8 ``ragged_dot`` with an E4M3 forward and a bf16 (exact) backward.
+
+    Args:
+        lhs: ``[T, K]`` activations (rows sorted by expert / contiguous groups).
+        rhs: ``[E, K, N]`` expert weights.
+        group_sizes: ``[E]`` token count per expert (``sum == T``); fully dynamic
+            and non-uniform.
+        lhs_scale, rhs_scale, grad_scale: ``[1]`` delayed-scaling scales.
+        lhs_amax_history, rhs_amax_history, grad_amax_history: amax histories.
+        fwd_dtype: forward-operand FP8 dtype (E4M3).
+        rev_dtype: output-gradient FP8 dtype; unused here (backward is bf16), kept
+            for interface parity with the dense op and the FP8-backward follow-up.
+
+    Quantizes activations and expert weights to ``fwd_dtype`` with delayed
+    per-tensor scaling and contracts them on the FP8 tensor cores via the genuine
+    ragged ``wgmma`` kernel, then dequantizes. The input and kernel scale /
+    amax-history update through ``in_q``'s custom VJP as ``OverwriteWithGradient``
+    overwrites; the output-gradient state passes through unchanged.
+    """
+    device = jax.devices()[0]
+    if device.platform != "gpu" or not device.compute_capability.startswith("9."):
+        raise NotImplementedError(
+            f"fp8_scaled_ragged_dot requires Hopper (SM90): the Mosaic wgmma kernels are "
+            f"sm_90a-specific. Got {device.device_kind}."
+        )
+    del rev_dtype  # FP8 output-grad dtype is reserved for the FP8-backward path; unused while backward is bf16.
+    comp = quantize_compute_type
+    q_lhs, new_lhs_scale = in_q(comp, fwd_dtype, lhs, lhs_scale, lhs_amax_history)
+    # in_q on rhs threads the kernel scale + amax_history overwrite; the naturally
+    # quantized weight it returns is unused (the forward needs the transposed
+    # layout), so it is dropped and DCE'd.
+    _q_rhs, new_rhs_scale = in_q(comp, fwd_dtype, rhs, rhs_scale, rhs_amax_history)
+    # bf16-transpose-then-cast: transpose in bf16 (hardware-legal), then cast to FP8.
+    q_rhs_t = quantize(jnp.swapaxes(rhs, 1, 2), fwd_dtype, new_rhs_scale, comp)
+    out_scale = (new_lhs_scale * new_rhs_scale).astype(jnp.float32)
+    return quantized_ragged_dot(q_lhs, q_rhs_t, out_scale, lhs, rhs, grad_scale, grad_amax_history, group_sizes)

--- a/lib/haliax/src/haliax/_src/fp8_ragged.py
+++ b/lib/haliax/src/haliax/_src/fp8_ragged.py
@@ -2,31 +2,45 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
-"""FP8 grouped matmul (``ragged_dot``) for Hopper H100 -- FP8 forward, bf16 backward.
+"""FP8 grouped matmul (``ragged_dot``) for Hopper H100 -- FP8 forward + FP8 dgrad.
 
 The MoE-grouped analog of the dense ``fp8_scaled_dot_general`` in ``_src/fp8.py``.
 The forward contracts activations and expert weights as same-dtype ``e4m3 x e4m3``
 on the Hopper FP8 tensor cores via the genuine ragged Mosaic ``wgmma`` kernel
 (``_src/ragged_dot_mgpu``), which handles genuinely **non-uniform, dynamic**
-``group_sizes`` (no equal-size / batched-dense reshape). The backward is computed
-in **bf16** (numerically exact) by directly invoking the Triton kernels from the
-bf16 ``ragged_dot`` backward (``_DLHS_DIM_NUMS`` / ``_DRHS_DIM_NUMS`` via
-``_triton_pallas_call``), so the operand gradients match the bf16 training default
-bit-for-bit with no forward recompute.
+``group_sizes`` (no equal-size / batched-dense reshape).
 
-Delayed per-tensor scaling (TE-style scale + amax history) is reused verbatim
-from the dense helpers in ``_src/fp8.py``: the input and kernel scale + amax_history
+The backward runs the input gradient (dgrad) on the FP8 tensor cores as well:
+
+  * grad_lhs  ``dl[T,K] = g[T,N] . rhs[E,K,N]`` (contract N) -- FP8 ``wgmma``.
+
+The output gradient ``g`` is quantized to ``rev_dtype`` with delayed per-tensor
+scaling; ``rev_dtype`` defaults to E5M2 (the numerically correct output-gradient
+dtype), so the dgrad is a genuine mixed ``e5m2 x e4m3`` contraction (mixed
+``wgmma`` needs jax >= 0.11.0, jax-ml/jax#38859). It consumes the
+**pre-produced natural weight layout** ``q_rhs [E,K,N]`` cast once by the
+forward (no re-cast).
+
+  * grad_rhs  ``dr[E,K,N] = lhs[T,K] . g[T,N]`` (contract the ragged token dim)
+
+still runs in **bf16** (numerically exact) via the Triton kernel from the bf16
+``ragged_dot`` backward (``_DRHS_DIM_NUMS`` through ``_triton_pallas_call``); the
+FP8 weight gradient is the next step.
+
+Delayed per-tensor scaling (TE-style scale + amax history) is reused verbatim from
+the dense helpers in ``_src/fp8.py``: the input and kernel scale + amax_history
 update through ``in_q_ct``'s custom VJP as ``OverwriteWithGradient`` overwrites.
-The output-gradient scaling state is unused here (the backward is bf16) and threads
-through unchanged.
+The output-gradient scale + amax history now update too -- the backward quantizes
+``g`` with delayed scaling and returns the rolled ``grad_scale`` / ``grad_amax_history``
+as the ``OverwriteWithGradient`` cotangents.
 
 Both the activation (lhs) and expert weight (rhs) quantize go through ``in_q_ct``
 (``_src/fp8_cast_transpose``), a fused Pallas-Triton kernel that reads the bf16 tile
 once, folds the amax reduction via ``atomic_max``, and stores **both** the natural
-and the transposed FP8 tile in one pass.  The transposed-weight layout (``[E,N,K]``)
-is consumed by the forward; the natural-weight layout (``[E,K,N]``) and the
-transposed-activation layout (``[K,T]``) are produced but deferred to the FP8
-backward follow-up.
+and the transposed FP8 tile in one pass.  The forward consumes the transposed-weight
+layout (``[E,N,K]``); the dgrad consumes the natural-weight layout (``[E,K,N]``). The
+transposed-activation layout (``[K,T]``) is produced but deferred to the FP8 weight
+gradient follow-up.
 """
 
 import functools
@@ -35,7 +49,8 @@ import jax
 import jax.numpy as jnp
 from jax import custom_vjp
 
-from .fp8_cast_transpose import in_q_ct
+from .fp8 import roll_amax_history
+from .fp8_cast_transpose import _next_scale_and_inv, cast_transpose_amax_2d, in_q_ct
 from .ragged_dot_mgpu import mgpu_ragged_dot
 
 _E4M3 = jnp.float8_e4m3fn
@@ -51,11 +66,12 @@ _GEMM_BLOCKS = (128, 64, 32, 16)
 
 
 def _autotuned_config(m: int, n: int, k: int) -> dict:
-    """Static Mosaic block config for the ragged FP8 wgmma forward kernel.
+    """Static Mosaic block config for the ragged FP8 wgmma forward/dgrad kernel.
 
-    Tuned on H100 at the d2560 grug-MoE shapes (per-leg sweeps):
-    ``(block_m, block_n, block_k) = (128, 128, 128)`` with a six-step pipeline
-    beats a ``192 x 5`` block/pipeline by ~10-14% -- the shorter accumulator
+    Tuned on H100 at the d2560 grug-MoE shapes (per-leg sweeps, both the
+    forward and the dgrad orientation): ``(block_m, block_n, block_k) =
+    (128, 128, 128)`` with a six-step pipeline beats a ``192 x 5``
+    block/pipeline by ~10-14% -- the shorter accumulator
     halves register pressure, buying a deeper pipeline. Operand tiles are FP8
     (1 byte), so the pipeline SMEM footprint is
     ``(block_m + block_n) * block_k * max_concurrent_steps``
@@ -86,6 +102,10 @@ def _ragged_fp8(lhs, rhs_nk, group_sizes, out_dtype, out_scale):
     """
     g, n, k = rhs_nk.shape
     m = lhs.shape[0]
+    if m % 64 != 0:
+        raise ValueError(
+            f"m={m} (token count) must be a multiple of 64 for the FP8 wgmma accumulator tiling in the Mosaic ragged kernel"
+        )
     if n % 128 != 0:
         raise ValueError(
             f"n={n} must be a multiple of 128 for bf16 TMA swizzle alignment in the Mosaic ragged wgmma kernel"
@@ -102,47 +122,90 @@ def _ragged_fp8(lhs, rhs_nk, group_sizes, out_dtype, out_scale):
     )
 
 
-@custom_vjp
-def quantized_ragged_dot(q_lhs, q_rhs_t, out_scale, lhs, rhs, grad_scale, grad_amax_history, group_sizes):
-    """FP8 ragged forward of pre-quantized E4M3 operands; bf16 (exact) backward.
+@functools.partial(custom_vjp, nondiff_argnums=(11,))
+def quantized_ragged_dot(
+    q_lhs,  # [T, K] e4m3      -- forward A
+    q_lhs_t,  # [K, T] e4m3    -- grad_rhs A (FP8 weight-grad follow-up; unused here)
+    q_rhs,  # [E, K, N] e4m3   -- grad_lhs B (natural layout)
+    q_rhs_t,  # [E, N, K] e4m3 -- forward B (transpose_rhs layout)
+    lhs_scale,  # [1] delayed-scaling scale for the activation quantize
+    rhs_scale,  # [1] delayed-scaling scale for the weight quantize
+    grad_scale,  # [1] output-grad scale from the previous step
+    grad_amax_history,  # output-grad amax history from the previous step
+    lhs,  # [T, K] original operand: differentiable, receives grad_lhs
+    rhs,  # [E, K, N] original operand: differentiable, receives grad_rhs
+    group_sizes,  # [E]
+    rev_dtype,  # static: output-gradient FP8 dtype (E4M3 here)
+):
+    """FP8 ragged forward of pre-quantized E4M3 operands; FP8 dgrad, bf16 wgrad.
 
-    ``q_lhs`` is ``[T,K]`` E4M3, ``q_rhs_t`` is ``[E,N,K]`` E4M3 (the transpose_rhs
-    layout). ``out_scale`` is the folded per-tensor dequant ``lhs_scale*rhs_scale``.
-    ``lhs``/``rhs`` are the original compute-dtype (bf16) operands, carried so the
-    backward can compute gradients directly with the bf16 Triton kernels.
-    ``grad_scale``/``grad_amax_history`` are the output-gradient delayed-scaling state;
-    threaded as differentiable args so the backward can return identity cotangents
-    (preserving the current values) until the FP8-backward step updates them.
-    ``group_sizes`` is a regular operand with a ``None`` cotangent rather than a
-    ``nondiff_argnums`` entry: nondiff positions reject traced arrays under ``jit``.
+    Every FP8 operand layout is precomputed once by the fused cast-transpose+amax
+    kernel, so no transpose happens here. The forward contracts ``q_lhs`` against the
+    transpose_rhs layout ``q_rhs_t`` (E4M3 x E4M3) and dequantizes by the folded
+    ``lhs_scale*rhs_scale``. The backward quantizes the output gradient to
+    ``rev_dtype`` (static arg 11; E4M3 here) with delayed scaling and contracts it
+    against the pre-produced natural weight layout ``q_rhs`` for grad_lhs; grad_rhs
+    stays bf16. ``grad_scale``/``grad_amax_history`` are differentiable so the backward
+    can return the rolled delayed-scaling state as ``OverwriteWithGradient`` cotangents.
     """
-    return _ragged_fp8(q_lhs, q_rhs_t, group_sizes, lhs.dtype, out_scale)
+    combined = (lhs_scale * rhs_scale).astype(jnp.float32)
+    return _ragged_fp8(q_lhs, q_rhs_t, group_sizes, lhs.dtype, combined)
 
 
-def _qrd_fwd(q_lhs, q_rhs_t, out_scale, lhs, rhs, grad_scale, grad_amax_history, group_sizes):
-    out = _ragged_fp8(q_lhs, q_rhs_t, group_sizes, lhs.dtype, out_scale)
-    return out, (lhs, rhs, grad_scale, grad_amax_history, group_sizes)
+def _qrd_fwd(
+    q_lhs,
+    q_lhs_t,
+    q_rhs,
+    q_rhs_t,
+    lhs_scale,
+    rhs_scale,
+    grad_scale,
+    grad_amax_history,
+    lhs,
+    rhs,
+    group_sizes,
+    rev_dtype,
+):
+    combined = (lhs_scale * rhs_scale).astype(jnp.float32)
+    out = _ragged_fp8(q_lhs, q_rhs_t, group_sizes, lhs.dtype, combined)
+    res = (q_rhs, rhs_scale, grad_scale, grad_amax_history, lhs, rhs, group_sizes)
+    return out, res
 
 
-def _qrd_bwd(res, g):
-    lhs, rhs, grad_scale, grad_amax_history, group_sizes = res
-    # Direct bf16 operand gradients: call the same Triton kernels used by the bf16
-    # ragged_dot backward. lhs/rhs are already in the residuals, so there is no
-    # forward recompute.
+def _qrd_bwd(rev_dtype, res, g):
+    q_rhs, rhs_scale, grad_scale, grad_amax_history, lhs, rhs, group_sizes = res
+    out_dtype = lhs.dtype
+
+    # Delayed scaling for the output gradient: one fused cast-transpose+amax read
+    # produces the natural [T,N] layout q_g (for the dgrad) plus the current-step
+    # amax to roll into the history -- a single bf16 read of ``g``. The transposed
+    # [N,T] layout q_g_t comes out of the same read; it is consumed by the FP8
+    # weight gradient in the next commit (grad_rhs is still bf16 here).
+    new_g_scale, inv_g = _next_scale_and_inv(rev_dtype, grad_scale, grad_amax_history)
+    q_g, _q_g_t, cur_amax = cast_transpose_amax_2d(g, inv_g, rev_dtype)  # [T,N], [N,T]
+    new_g_hist = roll_amax_history(cur_amax[0], grad_amax_history)
+
+    # grad_lhs[T,K] = g[T,N] . rhs[E,K,N] (contract N), on the pre-cast natural
+    # weight layout q_rhs. The dgrad has the same shape structure as the forward,
+    # so _autotuned_config applies unchanged.
+    dlhs_scale = (rhs_scale * new_g_scale).astype(jnp.float32)
+    grad_lhs = _ragged_fp8(q_g, q_rhs, group_sizes, out_dtype, dlhs_scale)
+
+    # grad_rhs[E,K,N] = lhs[T,K] . g[T,N]  (contracts the ragged token dim) -- still
+    # bf16 via the Triton kernel from the bf16 ragged_dot backward. lhs/g are the
+    # compute-dtype operands, so there is no forward recompute.
     # Local import breaks the quantization <-> nn.ragged_dot import cycle.
-    from haliax.nn.ragged_dot import _DLHS_DIM_NUMS, _DRHS_DIM_NUMS, _triton_pallas_call  # noqa: PLC0415
+    from haliax.nn.ragged_dot import _DRHS_DIM_NUMS, _triton_pallas_call  # noqa: PLC0415
 
-    # dlhs[M,K] = dout[M,N] @ rhs[G,K,N]^T  (contracts N)
-    grad_lhs = _triton_pallas_call(g, rhs, group_sizes, _DLHS_DIM_NUMS)
-    # drhs[G,K,N] = lhs[M,K]^T @ dout[M,N]  (contracts M, ragged)
     grad_rhs = _triton_pallas_call(lhs, g, group_sizes, _DRHS_DIM_NUMS)
-    # Cotangents for (q_lhs, q_rhs_t, out_scale, lhs, rhs, grad_scale,
-    # grad_amax_history, group_sizes):
-    # - quantized operands and the folded scale are intermediate (overwrites handled by in_q)
-    # - operand grads flow to lhs/rhs
-    # - grad_scale/grad_amax_history are preserved unchanged (bf16 backward; the
-    #   FP8-backward follow-up will update them to new_scale/new_history instead)
-    return (None, None, None, grad_lhs, grad_rhs, grad_scale, grad_amax_history, None)
+    grad_rhs = grad_rhs.astype(rhs.dtype)
+
+    # Cotangents for the 11 differentiable args (q_lhs, q_lhs_t, q_rhs, q_rhs_t,
+    # lhs_scale, rhs_scale, grad_scale, grad_amax_history, lhs, rhs, group_sizes):
+    # the q's are intermediate (overwrites handled by in_q_ct); lhs_scale/rhs_scale
+    # overwrite via in_q_ct; operand grads flow to lhs/rhs; the output-grad scale and
+    # amax history are overwritten here with the rolled delayed-scaling state.
+    return (None, None, None, None, None, None, new_g_scale, new_g_hist, grad_lhs, grad_rhs, None)
 
 
 quantized_ragged_dot.defvjp(_qrd_fwd, _qrd_bwd)
@@ -162,7 +225,7 @@ def fp8_scaled_ragged_dot(
     fwd_dtype=_E4M3,
     rev_dtype=_E5M2,
 ):
-    """FP8 ``ragged_dot`` with an E4M3 forward and a bf16 (exact) backward.
+    """FP8 ``ragged_dot`` with an E4M3 forward and an FP8 dgrad / bf16 wgrad backward.
 
     Args:
         lhs: ``[T, K]`` activations (rows sorted by expert / contiguous groups).
@@ -172,14 +235,17 @@ def fp8_scaled_ragged_dot(
         lhs_scale, rhs_scale, grad_scale: ``[1]`` delayed-scaling scales.
         lhs_amax_history, rhs_amax_history, grad_amax_history: amax histories.
         fwd_dtype: forward-operand FP8 dtype (E4M3).
-        rev_dtype: output-gradient FP8 dtype; unused here (backward is bf16), kept
-            for interface parity with the dense op and the FP8-backward follow-up.
+        rev_dtype: output-gradient FP8 dtype. Defaults to E5M2, making the dgrad
+            a mixed ``e5m2 x e4m3`` contraction (needs jax >= 0.11.0,
+            jax-ml/jax#38859); E4M3 gives a uniform GEMM that lowers on jax 0.10.x.
 
     Quantizes activations and expert weights to ``fwd_dtype`` with delayed
     per-tensor scaling and contracts them on the FP8 tensor cores via the genuine
-    ragged ``wgmma`` kernel, then dequantizes. The input and kernel scale /
-    amax-history update through ``in_q_ct``'s custom VJP as ``OverwriteWithGradient``
-    overwrites; the output-gradient state passes through unchanged.
+    ragged ``wgmma`` kernel, then dequantizes. The input gradient runs on the FP8
+    tensor cores against the pre-cast natural weight layout (gradient quantized to
+    ``rev_dtype`` with delayed scaling); the weight gradient stays bf16. The input,
+    kernel, and output-gradient scale / amax-history all update through the custom
+    VJPs as ``OverwriteWithGradient`` overwrites.
     """
     device = jax.devices()[0]
     if device.platform != "gpu" or not device.compute_capability.startswith("9."):
@@ -187,12 +253,24 @@ def fp8_scaled_ragged_dot(
             f"fp8_scaled_ragged_dot requires Hopper (SM90): the Mosaic wgmma kernels are "
             f"sm_90a-specific. Got {device.device_kind}."
         )
-    del rev_dtype  # FP8 output-grad dtype is reserved for the FP8-backward path; unused while backward is bf16.
     # Fused cast-transpose+amax: reads each bf16 tile once, folds the amax reduction, and
     # stores both the natural and the transposed FP8 tile in one pass.  VJP threading matches in_q.
-    # _q_lhs_t [K,T] and _q_rhs [E,K,N] are produced in the same fused read as the used layouts;
-    # they will be wired into the FP8 backward in the follow-up commit.
-    q_lhs, _q_lhs_t, new_lhs_scale = in_q_ct(fwd_dtype, "2d", lhs, lhs_scale, lhs_amax_history)
-    _q_rhs, q_rhs_t, new_rhs_scale = in_q_ct(fwd_dtype, "3d", rhs, rhs_scale, rhs_amax_history)
-    out_scale = (new_lhs_scale * new_rhs_scale).astype(jnp.float32)
-    return quantized_ragged_dot(q_lhs, q_rhs_t, out_scale, lhs, rhs, grad_scale, grad_amax_history, group_sizes)
+    # The forward uses q_lhs [T,K] and q_rhs_t [E,N,K]; the dgrad uses q_rhs [E,K,N] (natural
+    # weight layout).  q_lhs_t [K,T] is produced in the same fused read but consumed only by the
+    # FP8 weight-gradient follow-up.
+    q_lhs, q_lhs_t, new_lhs_scale = in_q_ct(fwd_dtype, "2d", lhs, lhs_scale, lhs_amax_history)
+    q_rhs, q_rhs_t, new_rhs_scale = in_q_ct(fwd_dtype, "3d", rhs, rhs_scale, rhs_amax_history)
+    return quantized_ragged_dot(
+        q_lhs,
+        q_lhs_t,
+        q_rhs,
+        q_rhs_t,
+        new_lhs_scale,
+        new_rhs_scale,
+        grad_scale,
+        grad_amax_history,
+        lhs,
+        rhs,
+        group_sizes,
+        rev_dtype,
+    )

--- a/lib/haliax/src/haliax/_src/fp8_ragged.py
+++ b/lib/haliax/src/haliax/_src/fp8_ragged.py
@@ -63,7 +63,7 @@ _GEMM_BLOCKS = (128, 64, 32, 16)
 def _autotuned_config(m: int, n: int, k: int) -> dict:
     """Static Mosaic block config for the ragged FP8 wgmma forward/dgrad kernel.
 
-    Tuned on H100 at the d2560 grug-MoE shapes (per-leg sweeps, both the
+    Tuned on H100 at the d=2560 MoE shapes (hidden 2560, intermediate 1280) (per-leg sweeps, both the
     forward and the dgrad orientation): ``(block_m, block_n, block_k) =
     (128, 128, 128)`` with a six-step pipeline beats a ``192 x 5``
     block/pipeline by ~10-14% -- the shorter accumulator
@@ -91,7 +91,7 @@ def _autotuned_config(m: int, n: int, k: int) -> dict:
 def _dwgrad_config(k: int, n: int) -> dict:
     """Static Mosaic block config for the ragged FP8 weight-gradient kernel.
 
-    Tuned on H100 at the d2560 grug-MoE shapes. ``block_m`` tiles the output K,
+    Tuned on H100 at the d=2560 MoE shapes (hidden 2560, intermediate 1280). ``block_m`` tiles the output K,
     ``block_n`` the output N, and ``block_k=128`` the ragged token (contracting)
     dim. The tile *pair* matters more than either dimension alone: wide-N
     ``(64, 256)`` beats ``(128, 128)``, but ``(128, 256)`` collapses, so the
@@ -165,7 +165,7 @@ def quantized_ragged_dot(
     lhs,  # [T, K] original operand: differentiable, receives grad_lhs
     rhs,  # [E, K, N] original operand: differentiable, receives grad_rhs
     group_sizes,  # [E]
-    rev_dtype,  # static: output-gradient FP8 dtype (E4M3 here)
+    rev_dtype,  # static: output-gradient FP8 dtype (E5M2 by default)
 ):
     """FP8 ragged forward of pre-quantized E4M3 operands; FP8 dgrad and wgrad.
 

--- a/lib/haliax/src/haliax/_src/fp8_ragged.py
+++ b/lib/haliax/src/haliax/_src/fp8_ragged.py
@@ -18,7 +18,8 @@ transpose an operand at runtime, so each bf16 input is quantized into *both* the
 natural and the transposed FP8 layout by one fused cast-transpose+amax read
 (``in_q_ct`` in ``_src/fp8_cast_transpose``): the forward consumes ``q_lhs [T,K]``
 and ``q_rhs_t [E,N,K]``, the dgrad consumes ``q_rhs [E,K,N]``, and the wgrad
-consumes ``q_lhs_t [K,T]`` and ``q_g_t [N,T]``.
+consumes ``q_lhs_t [K, T+E*256]`` (with the boundary appendix, see
+``write_boundary_appendix``) and ``q_g_t [N,T]``.
 
 Delayed per-tensor scaling (TE-style scale + amax history) follows the dense
 helpers in ``_src/fp8.py``: activation, weight, and output-gradient scale +
@@ -37,7 +38,13 @@ import jax.numpy as jnp
 from jax import custom_vjp
 
 from .fp8 import roll_amax_history
-from .fp8_cast_transpose import _next_scale_and_inv, cast_transpose_amax_2d, in_q_ct
+from .fp8_cast_transpose import (
+    WGRAD_TOKEN_BLOCK,
+    _next_scale_and_inv,
+    cast_transpose_amax_2d,
+    in_q_ct,
+    write_boundary_appendix,
+)
 from .ragged_dot_mgpu import mgpu_dwgrad, mgpu_ragged_dot
 
 _E4M3 = jnp.float8_e4m3fn
@@ -148,7 +155,7 @@ def _ragged_fp8(lhs, rhs_nk, group_sizes, out_dtype, out_scale):
 @functools.partial(custom_vjp, nondiff_argnums=(11,))
 def quantized_ragged_dot(
     q_lhs,  # [T, K] e4m3      -- forward A
-    q_lhs_t,  # [K, T] e4m3    -- grad_rhs A (token-contiguous)
+    q_lhs_t,  # [K, T+E*256] e4m3 -- grad_rhs A (token-contiguous, + boundary appendix)
     q_rhs,  # [E, K, N] e4m3   -- grad_lhs B (natural layout)
     q_rhs_t,  # [E, N, K] e4m3 -- forward B (transpose_rhs layout)
     lhs_scale,  # [1] delayed-scaling scale for the activation quantize
@@ -208,15 +215,17 @@ def _qrd_bwd(rev_dtype, res, g):
     new_g_hist = roll_amax_history(cur_amax[0], grad_amax_history)
 
     # grad_lhs[T,K] = g[T,N] . rhs[E,K,N] (contract N), on the pre-cast natural
-    # weight layout q_rhs. The dgrad has the same shape structure as the forward,
-    # so _autotuned_config applies unchanged.
+    # weight layout q_rhs. The dgrad has the same shape structure as the forward
+    # and shares its tuned config (per-leg sweeps: the same block config wins both).
     dlhs_scale = (rhs_scale * new_g_scale).astype(jnp.float32)
     grad_lhs = _ragged_fp8(q_g, q_rhs, group_sizes, out_dtype, dlhs_scale)
 
     # grad_rhs[E,K,N] = lhs[T,K] . g[T,N] (contracts the ragged token dim) via
-    # mgpu_dwgrad on the pre-cast token-contiguous layouts q_lhs_t [K,T] and
-    # q_g_t [N,T]. The kernel's boundary mask zeros tokens outside each group,
-    # so group boundaries falling mid-block_k-tile are handled correctly.
+    # mgpu_dwgrad on the pre-cast token-contiguous layouts q_lhs_t [K, T+E*256]
+    # and q_g_t [N,T]. Group boundaries falling mid-token-tile are handled by the
+    # boundary appendix: fill q_lhs_t's appendix slots with pre-masked boundary
+    # blocks (in place) and the kernel's index_map reads them for the first/last
+    # pipeline step of each group.
     t = lhs.shape[0]
     if t % 128 != 0:
         raise ValueError(
@@ -226,6 +235,7 @@ def _qrd_bwd(rev_dtype, res, g):
     _, k, n = rhs.shape
     drhs_cfg = _dwgrad_config(k, n)
     drhs_scale = (lhs_scale * new_g_scale).astype(jnp.float32)
+    q_lhs_t = write_boundary_appendix(q_lhs_t, group_sizes)
     grad_rhs = mgpu_dwgrad(
         q_lhs_t,
         q_g_t,
@@ -315,8 +325,13 @@ def fp8_scaled_ragged_dot(
             f"sm_90a-specific. Got {device.device_kind}."
         )
     # One fused cast-transpose+amax read per operand produces both FP8 layouts.
-    q_lhs, q_lhs_t, new_lhs_scale = in_q_ct(fwd_dtype, "2d", lhs, lhs_scale, lhs_amax_history)
-    q_rhs, q_rhs_t, new_rhs_scale = in_q_ct(fwd_dtype, "3d", rhs, rhs_scale, rhs_amax_history)
+    # The activation's transposed layout carries the wgrad boundary appendix
+    # (2*WGRAD_TOKEN_BLOCK extra columns per expert), filled in the backward.
+    e = rhs.shape[0]
+    q_lhs, q_lhs_t, new_lhs_scale = in_q_ct(
+        fwd_dtype, "2d", e * 2 * WGRAD_TOKEN_BLOCK, lhs, lhs_scale, lhs_amax_history
+    )
+    q_rhs, q_rhs_t, new_rhs_scale = in_q_ct(fwd_dtype, "3d", 0, rhs, rhs_scale, rhs_amax_history)
     return quantized_ragged_dot(
         q_lhs,
         q_lhs_t,

--- a/lib/haliax/src/haliax/_src/fp8_ragged.py
+++ b/lib/haliax/src/haliax/_src/fp8_ragged.py
@@ -15,14 +15,18 @@ bf16 ``ragged_dot`` backward (``_DLHS_DIM_NUMS`` / ``_DRHS_DIM_NUMS`` via
 bit-for-bit with no forward recompute.
 
 Delayed per-tensor scaling (TE-style scale + amax history) is reused verbatim
-from the dense helpers in ``_src/fp8.py`` (``in_q`` / ``quantize``): the input and
-kernel scale + amax_history update through ``in_q``'s custom VJP as
-``OverwriteWithGradient`` overwrites. The output-gradient scaling state is unused
-here (the backward is bf16) and threads through unchanged.
+from the dense helpers in ``_src/fp8.py``: the input and kernel scale + amax_history
+update through ``in_q_ct``'s custom VJP as ``OverwriteWithGradient`` overwrites.
+The output-gradient scaling state is unused here (the backward is bf16) and threads
+through unchanged.
 
-To get the expert weights contracting-dim-contiguous -- as FP8 ``wgmma`` requires
--- the weight is transposed in **bf16** (a hardware-legal transpose) and only then
-cast to FP8; no strided FP8 transpose or fused cast-transpose kernel is used yet.
+Both the activation (lhs) and expert weight (rhs) quantize go through ``in_q_ct``
+(``_src/fp8_cast_transpose``), a fused Pallas-Triton kernel that reads the bf16 tile
+once, folds the amax reduction via ``atomic_max``, and stores **both** the natural
+and the transposed FP8 tile in one pass.  The transposed-weight layout (``[E,N,K]``)
+is consumed by the forward; the natural-weight layout (``[E,K,N]``) and the
+transposed-activation layout (``[K,T]``) are produced but deferred to the FP8
+backward follow-up.
 """
 
 import functools
@@ -31,7 +35,7 @@ import jax
 import jax.numpy as jnp
 from jax import custom_vjp
 
-from .fp8 import in_q, quantize
+from .fp8_cast_transpose import in_q_ct
 from .ragged_dot_mgpu import mgpu_ragged_dot
 
 _E4M3 = jnp.float8_e4m3fn
@@ -155,7 +159,6 @@ def fp8_scaled_ragged_dot(
     lhs_amax_history,
     rhs_amax_history,
     grad_amax_history,
-    quantize_compute_type=jnp.float32,
     fwd_dtype=_E4M3,
     rev_dtype=_E5M2,
 ):
@@ -175,7 +178,7 @@ def fp8_scaled_ragged_dot(
     Quantizes activations and expert weights to ``fwd_dtype`` with delayed
     per-tensor scaling and contracts them on the FP8 tensor cores via the genuine
     ragged ``wgmma`` kernel, then dequantizes. The input and kernel scale /
-    amax-history update through ``in_q``'s custom VJP as ``OverwriteWithGradient``
+    amax-history update through ``in_q_ct``'s custom VJP as ``OverwriteWithGradient``
     overwrites; the output-gradient state passes through unchanged.
     """
     device = jax.devices()[0]
@@ -185,13 +188,11 @@ def fp8_scaled_ragged_dot(
             f"sm_90a-specific. Got {device.device_kind}."
         )
     del rev_dtype  # FP8 output-grad dtype is reserved for the FP8-backward path; unused while backward is bf16.
-    comp = quantize_compute_type
-    q_lhs, new_lhs_scale = in_q(comp, fwd_dtype, lhs, lhs_scale, lhs_amax_history)
-    # in_q on rhs threads the kernel scale + amax_history overwrite; the naturally
-    # quantized weight it returns is unused (the forward needs the transposed
-    # layout), so it is dropped and DCE'd.
-    _q_rhs, new_rhs_scale = in_q(comp, fwd_dtype, rhs, rhs_scale, rhs_amax_history)
-    # bf16-transpose-then-cast: transpose in bf16 (hardware-legal), then cast to FP8.
-    q_rhs_t = quantize(jnp.swapaxes(rhs, 1, 2), fwd_dtype, new_rhs_scale, comp)
+    # Fused cast-transpose+amax: reads each bf16 tile once, folds the amax reduction, and
+    # stores both the natural and the transposed FP8 tile in one pass.  VJP threading matches in_q.
+    # _q_lhs_t [K,T] and _q_rhs [E,K,N] are produced in the same fused read as the used layouts;
+    # they will be wired into the FP8 backward in the follow-up commit.
+    q_lhs, _q_lhs_t, new_lhs_scale = in_q_ct(fwd_dtype, "2d", lhs, lhs_scale, lhs_amax_history)
+    _q_rhs, q_rhs_t, new_rhs_scale = in_q_ct(fwd_dtype, "3d", rhs, rhs_scale, rhs_amax_history)
     out_scale = (new_lhs_scale * new_rhs_scale).astype(jnp.float32)
     return quantized_ragged_dot(q_lhs, q_rhs_t, out_scale, lhs, rhs, grad_scale, grad_amax_history, group_sizes)

--- a/lib/haliax/src/haliax/_src/fp8_ragged.py
+++ b/lib/haliax/src/haliax/_src/fp8_ragged.py
@@ -37,25 +37,38 @@ from .ragged_dot_mgpu import mgpu_ragged_dot
 _E4M3 = jnp.float8_e4m3fn
 _E5M2 = jnp.float8_e5m2
 
+# H100 per-block SMEM ceiling (bytes) for the Mosaic operand pipeline; see the
+# forward config note.
+_H100_SMEM_LIMIT = 232448
 
-def _fixed_config(m: int, n: int, k: int) -> dict:
-    """Conservative (untuned) Mosaic block config for the ragged FP8 wgmma kernel.
+# Candidate wgmma block sizes, largest first; a dim picks the largest that
+# divides it (falling back to 16 when none does).
+_GEMM_BLOCKS = (128, 64, 32, 16)
 
-    Block sizes divide the operand shapes: ``block_k`` must divide ``k``; ``block_n``
-    must divide ``n`` (and ``n`` must be swizzle-aligned -- a multiple of 128 for the
-    bf16 output store's TMA descriptor); ``block_m`` divides ``m`` here, though the
-    ragged kernel also masks a non-dividing final m-tile. Tuning the block sizes
-    and pipeline depth is a follow-up change.
+
+def _autotuned_config(m: int, n: int, k: int) -> dict:
+    """Static Mosaic block config for the ragged FP8 wgmma forward kernel.
+
+    Tuned on H100 at the d2560 grug-MoE shapes (per-leg sweeps):
+    ``(block_m, block_n, block_k) = (128, 128, 128)`` with a six-step pipeline
+    beats a ``192 x 5`` block/pipeline by ~10-14% -- the shorter accumulator
+    halves register pressure, buying a deeper pipeline. Operand tiles are FP8
+    (1 byte), so the pipeline SMEM footprint is
+    ``(block_m + block_n) * block_k * max_concurrent_steps``
+    bytes; the loop drops steps until it fits the H100 per-block limit.
     """
-    block_m = next((b for b in (128, 64, 32, 16) if m % b == 0), 16)
-    block_n = next((b for b in (128, 64, 32, 16) if n % b == 0), 16)
-    block_k = next((b for b in (64, 32, 16) if k % b == 0), 16)
+    block_m = 128 if m >= 128 else next((b for b in _GEMM_BLOCKS if m % b == 0), 16)
+    block_n = next((b for b in _GEMM_BLOCKS if n % b == 0), 16)
+    block_k = next((b for b in _GEMM_BLOCKS if k % b == 0), 16)
     grid_block_n = next((gb for gb in (4, 2, 1) if n % (gb * block_n) == 0), 1)
+    max_concurrent_steps = 6
+    while max_concurrent_steps > 1 and (block_m + block_n) * block_k * max_concurrent_steps > _H100_SMEM_LIMIT:
+        max_concurrent_steps -= 1
     return dict(
         block_m=block_m,
         block_n=block_n,
         block_k=block_k,
-        max_concurrent_steps=6,
+        max_concurrent_steps=max_concurrent_steps,
         grid_block_n=grid_block_n,
     )
 
@@ -73,7 +86,7 @@ def _ragged_fp8(lhs, rhs_nk, group_sizes, out_dtype, out_scale):
         raise ValueError(
             f"n={n} must be a multiple of 128 for bf16 TMA swizzle alignment in the Mosaic ragged wgmma kernel"
         )
-    cfg = _fixed_config(m, n, k)
+    cfg = _autotuned_config(m, n, k)
     return mgpu_ragged_dot(
         lhs,
         rhs_nk,

--- a/lib/haliax/src/haliax/_src/ragged_dot_mgpu.py
+++ b/lib/haliax/src/haliax/_src/ragged_dot_mgpu.py
@@ -20,6 +20,9 @@
 # B operand -- FP8 wgmma cannot transpose A at runtime, so the caller
 # pre-transposes both operands via the fused cast-transpose (upstream contracts
 # token-major [K,M] x [K,N] tiles and transposes the lhs descriptor instead).
+# Upstream's in-SMEM masking of group-boundary tiles is replaced by the
+# pre-masked boundary appendix (``write_boundary_appendix`` in
+# ``_src/fp8_cast_transpose``) so the pipeline body stays branch-free.
 
 import dataclasses
 import functools
@@ -243,7 +246,7 @@ def mgpu_ragged_dot(
 
 
 def mgpu_dwgrad(
-    lhs_t,  # (K, T) fp8 -- weight-grad lhs, token dim T contiguous (dim 1)
+    lhs_t,  # (K, T + G*256) fp8 -- weight-grad lhs + boundary appendix (token dim contiguous)
     grad_t,  # (N, T) fp8 -- output gradient, token dim T contiguous (dim 1)
     *,
     group_sizes,  # (G,)
@@ -263,24 +266,39 @@ def mgpu_dwgrad(
     ``grad -> [N, T]`` out of kernel.  Inside, ``A = lhs_t`` is used natively
     (token-contiguous) and ``B = transpose_ref(grad_t) = [T, N]`` uses the
     B-operand transpose that FP8 ``wgmma`` does support.
+
+    Group boundaries falling mid-token-tile are handled with the **boundary
+    appendix**: ``lhs_t`` carries, after the ``T`` real columns, two pre-masked
+    128-token blocks per group (``write_boundary_appendix`` in
+    ``_src/fp8_cast_transpose``), and the pipeline's ``index_map`` redirects the
+    first and last step of each group there.  This keeps the pipeline body
+    branch-free -- the previous in-SMEM register masking serialized every
+    boundary step and cost ~12% of the kernel.  Only ``lhs_t`` needs
+    the appendix: zeroing one operand of the ``wgmma`` zeroes the contribution.
     """
     if lhs_t.dtype not in _FP8_DTYPES or grad_t.dtype not in _FP8_DTYPES:
         raise NotImplementedError(f"mgpu_dwgrad expects FP8 operands, got {lhs_t.dtype}, {grad_t.dtype}")
-    k_dim, t = lhs_t.shape
-    n_dim, t2 = grad_t.shape
-    if t != t2:
-        raise ValueError(f"token dim mismatch: {t} vs {t2}")
+    g = group_sizes.shape[0]
+    k_dim, t_wide = lhs_t.shape
+    n_dim, t = grad_t.shape
+    appendix_block = 128
+    if t_wide != t + g * 2 * appendix_block:
+        raise ValueError(
+            f"lhs_t width {t_wide} must be T + G*256 = {t + g * 2 * appendix_block} "
+            "(the wgrad boundary appendix; see write_boundary_appendix)"
+        )
+    if block_k != appendix_block:
+        raise ValueError(f"block_k={block_k} must equal the {appendix_block}-token appendix block")
     if k_dim % block_m != 0:
         raise ValueError(f"K={k_dim} must be a multiple of block_m={block_m}")
     if n_dim % block_n != 0:
         raise ValueError(f"N={n_dim} must be a multiple of block_n={block_n}")
-    g = group_sizes.shape[0]
     _od = jnp.bfloat16 if out_dtype is None else out_dtype
     _scale = jnp.ones((1,), jnp.float32) if out_scale is None else jnp.asarray(out_scale, jnp.float32).reshape(1)
 
     group_sizes = group_sizes.astype(int)
-    group_starts = jnp.concatenate([jnp.zeros(1, dtype=int), jnp.cumsum(group_sizes)[:-1]]).astype(int)
     group_ends = jnp.cumsum(group_sizes)
+    group_starts = group_ends - group_sizes
     group_block_starts = group_starts // block_k * block_k
     group_block_ends = -(group_ends // -block_k) * block_k
     group_num_blocks = (group_block_ends - group_block_starts) // block_k
@@ -302,8 +320,6 @@ def mgpu_dwgrad(
 
     def body(
         group_sizes_gmem,
-        group_starts_gmem,
-        group_ends_gmem,
         group_num_blocks_gmem,
         group_block_starts_gmem,
         lhs_gmem,
@@ -319,45 +335,26 @@ def mgpu_dwgrad(
             g_i = loop_info.index[0]
             m_i, n_i = plgpu.planar_snake(loop_info.index[1], (grid_m, grid_n), 1, grid_block_n)
             # Slice the ragged token dimension (dim 1).  Potentially out of bounds,
-            # but the out-of-bounds tail is never accessed in emit_pipeline.
-            tok_slice = pl.ds(group_block_starts_gmem[g_i], t)
+            # but the out-of-bounds tail is never accessed in emit_pipeline.  The
+            # lhs window is t_wide long so the appendix stays addressable.
+            block_start = group_block_starts_gmem[g_i]
+            lhs_tok_slice = pl.ds(block_start, t_wide)
+            grad_tok_slice = pl.ds(block_start, t)
+            num_blocks = group_num_blocks_gmem[g_i]
+            # Window-relative block index of this group's appendix slot 0; both
+            # t + g_i*256 and block_start are multiples of block_k.
+            appendix_idx = (t + g_i * 2 * appendix_block - block_start) // block_k
+
+            def lhs_index(k_i):
+                idx = jnp.where(
+                    k_i == 0,
+                    appendix_idx,
+                    jnp.where(k_i == num_blocks - 1, appendix_idx + 1, k_i),
+                )
+                return (m_i, idx)
 
             def acc_scope(acc_ref):
-                def block_matmul(block_idx, lhs_smem, grad_smem):
-                    block_idx = block_idx[0]
-
-                    @pl.when(block_idx == 0)
-                    def _():
-                        reg = lhs_smem[...]
-                        start_index = lax.rem(group_starts_gmem[g_i], block_k)
-                        indices = plgpu.layout_cast(
-                            jax.lax.broadcasted_iota(jnp.int32, (block_m, block_k), 1),
-                            plgpu.Layout.WGMMA,
-                        )
-                        reg = jnp.where(
-                            indices >= start_index,
-                            reg.astype(jnp.float16),
-                            jnp.float16(0),
-                        ).astype(lhs_smem.dtype)
-                        lhs_smem[...] = reg
-                        plgpu.commit_smem()
-
-                    @pl.when(block_idx == group_num_blocks_gmem[g_i] - 1)
-                    def _():
-                        reg = lhs_smem[...]
-                        last_index = lax.rem(group_ends_gmem[g_i] - 1, block_k)
-                        indices = plgpu.layout_cast(
-                            jax.lax.broadcasted_iota(jnp.int32, (block_m, block_k), 1),
-                            plgpu.Layout.WGMMA,
-                        )
-                        reg = jnp.where(
-                            indices <= last_index,
-                            reg.astype(jnp.float16),
-                            jnp.float16(0),
-                        ).astype(lhs_smem.dtype)
-                        lhs_smem[...] = reg
-                        plgpu.commit_smem()
-
+                def block_matmul(_, lhs_smem, grad_smem):
                     # A = lhs[K, T] native (token-contiguous); B = grad[N, T] -> [T, N].
                     plgpu.wgmma(acc_ref, lhs_smem, plgpu.transpose_ref(grad_smem, (1, 0)))
                     if max_concurrent_steps == 1:
@@ -367,11 +364,11 @@ def mgpu_dwgrad(
                 def _():
                     plgpu.emit_pipeline(
                         block_matmul,
-                        grid=(group_num_blocks_gmem[g_i],),
+                        grid=(num_blocks,),
                         in_specs=[
                             plgpu.BlockSpec(
                                 (block_m, block_k),
-                                lambda k_i: (m_i, k_i),
+                                lhs_index,
                                 delay_release=1 if max_concurrent_steps > 1 else 0,
                                 transforms=transforms,
                             ),
@@ -383,7 +380,7 @@ def mgpu_dwgrad(
                             ),
                         ],
                         max_concurrent_steps=max_concurrent_steps,
-                    )(lhs_gmem.at[:, tok_slice], grad_gmem.at[:, tok_slice])
+                    )(lhs_gmem.at[:, lhs_tok_slice], grad_gmem.at[:, grad_tok_slice])
 
                 return acc_ref[...]
 
@@ -415,8 +412,6 @@ def mgpu_dwgrad(
     )
     return kernel(
         group_sizes,
-        group_starts,
-        group_ends,
         group_num_blocks,
         group_block_starts,
         lhs_t,

--- a/lib/haliax/src/haliax/_src/ragged_dot_mgpu.py
+++ b/lib/haliax/src/haliax/_src/ragged_dot_mgpu.py
@@ -1,0 +1,236 @@
+# Copyright The Levanter Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+#
+# Vendored and lightly modified from JAX (Apache-2.0):
+#   jax/experimental/pallas/ops/gpu/ragged_dot_mgpu.py
+# (jax 0.10.0).  These Pallas-Mosaic-GPU grouped matmuls drive the Hopper FP8
+# tensor cores (wgmma.fp8) and handle non-uniform, dynamic group_sizes.
+# Modifications vs upstream:
+#   * `out_dtype` parameter so an FP8 contraction can emit a BF16/FP32 result
+#     (upstream hardcodes the output dtype to ``lhs.dtype``);
+#   * `out_scale` parameter: per-tensor dequant scale folded into the store;
+#   * `num_sms` read from the device instead of hardcoded;
+#   * mixed FP8 operand pairs (E5M2 x E4M3) are accepted; lowering them needs
+#     jax >= 0.11.0 (mixed-dtype wgmma, jax-ml/jax#38859);
+#   * the ``main``/``ref_``/profiling helpers are dropped.
+
+import dataclasses
+import functools
+import math
+
+import jax
+from jax import lax
+from jax import numpy as jnp
+from jax.experimental import pallas as pl
+from jax.experimental.pallas import mosaic_gpu as plgpu
+
+_FP8_DTYPES = (jnp.float8_e4m3fn, jnp.float8_e5m2)
+
+
+@dataclasses.dataclass(frozen=True)
+class GroupInfo:
+    """Information regarding the group being processed in a block."""
+
+    group_id: jax.Array
+    block: jax.Array
+    block_start: jax.Array
+    actual_start: jax.Array
+    actual_end: jax.Array
+    start_within_block: jax.Array
+    actual_size: jax.Array
+
+    @classmethod
+    def create(cls, group_lengths, tile, tid):
+        """Get the group info for the current block."""
+
+        tile = jnp.int32(tile)
+        group_boundaries = [group_lengths[i] for i in range(len(group_lengths))]
+
+        # We usually only have very few groups, so we unroll the loop processing
+        # them. Normally we'd break out of the loop early, once we'd have found our
+        # boundary, but we can't do that when unrolling, so we rely on many selects
+        # to mask out the epilogue of the loop.
+        group_end = group_start = block = group = end = jnp.array(0, dtype=jnp.int32)
+
+        for i, b in enumerate(group_boundaries):
+            # Start/end are inclusive
+            start = end
+            end = start + b
+            final = end - 1
+            start_block = lax.div(start, tile)
+            final_block = lax.div(final, tile)
+            block_end = final_block + 1
+            tid_begin = start_block + i
+            tid_end = block_end + i
+            # How many blocks after is our block?
+            this_is_group = (tid_begin <= tid) & (tid < tid_end)
+            block = lax.select(this_is_group, tid - tid_begin + start_block, block)
+            group = lax.select(this_is_group, jnp.int32(i), group)
+            group_start = lax.select(this_is_group, start, group_start)
+            group_end = lax.select(this_is_group, end, group_end)
+
+        block_start = block * tile
+        actual_start = jnp.maximum(group_start, block_start)
+        actual_end = jnp.minimum(group_end, block_start + tile)
+        start_within_block = actual_start - block_start
+        actual_size = actual_end - actual_start
+        return cls(
+            group_id=group,
+            block=block,
+            block_start=block_start,
+            actual_start=actual_start,
+            actual_end=actual_end,
+            start_within_block=start_within_block,
+            actual_size=actual_size,
+        )
+
+
+def mgpu_ragged_dot(
+    lhs,  # (M, K)
+    rhs,  # (G, K, N)
+    *,
+    group_sizes,  # (G,)
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    max_concurrent_steps: int,
+    grid_block_n: int,
+    transpose_rhs: bool = False,
+    out_dtype=None,
+    out_scale=None,
+) -> jax.Array:
+    if lhs.dtype != rhs.dtype and not (lhs.dtype in _FP8_DTYPES and rhs.dtype in _FP8_DTYPES):
+        raise NotImplementedError(
+            f"lhs and rhs must have the same dtype or both be FP8 (mixed wgmma), got {lhs.dtype} and {rhs.dtype}"
+        )
+    m, k = lhs.shape
+    g, k2, n = rhs.shape
+    _od = lhs.dtype if out_dtype is None else out_dtype
+    # Per-tensor dequant scale, folded into the output store (saves a full pass).
+    _scale = jnp.ones((1,), jnp.float32) if out_scale is None else jnp.asarray(out_scale, jnp.float32).reshape(1)
+
+    if transpose_rhs:
+        k2, n = n, k2
+
+    if group_sizes.shape[0] != g:
+        raise ValueError(f"Expected group_sizes to have shape {g} but got {group_sizes.shape}")
+
+    if k != k2:
+        raise ValueError(f"lhs.shape={k} must match rhs.shape={k2}")
+
+    if k % block_k != 0:
+        raise ValueError(f"k={k} must be a multiple of block_k={block_k}")
+
+    def body(rows_per_expert_gmem, lhs_gmem, rhs_gmem, scale_gmem, o_gmem):
+        grid_m = pl.cdiv(m, block_m) + g - 1
+        grid_n = pl.cdiv(n, block_n)
+        grid = (grid_m * grid_n,)
+
+        @plgpu.nd_loop(grid, collective_axes="sm")
+        def mn_loop(loop_info: plgpu.NDLoopInfo):
+            mi, ni = plgpu.planar_snake(
+                loop_info.index[0],
+                (grid_m, grid_n),
+                1,
+                grid_block_n,
+            )
+            group_info = GroupInfo.create(rows_per_expert_gmem, block_m, mi)
+
+            def acc_scope(acc_ref):
+                plgpu.emit_pipeline(
+                    lambda _, lhs_smem, rhs_smem: plgpu.wgmma(
+                        acc_ref,
+                        lhs_smem,
+                        plgpu.transpose_ref(rhs_smem, (1, 0)) if transpose_rhs else rhs_smem,
+                    ),
+                    grid=(k // block_k,),
+                    in_specs=[
+                        plgpu.BlockSpec(
+                            (block_m, block_k),
+                            lambda k: (group_info.block, k),
+                            delay_release=1,
+                        ),
+                        plgpu.BlockSpec(
+                            (block_n, block_k) if transpose_rhs else (block_k, block_n),
+                            lambda k: (ni, k) if transpose_rhs else (k, ni),
+                            delay_release=1,
+                        ),
+                    ],
+                    max_concurrent_steps=max_concurrent_steps,
+                )(lhs_gmem, rhs_gmem.at[group_info.group_id])
+                return acc_ref[...]
+
+            acc = pl.run_scoped(acc_scope, plgpu.ACC((block_m, block_n)))
+
+            @functools.partial(pl.run_scoped, o_smem=plgpu.SMEM((block_m, block_n), dtype=o_gmem.dtype))
+            def store_scope(o_smem):
+                o_smem[...] = (acc * scale_gmem[0]).astype(o_smem.dtype)
+                plgpu.commit_smem()
+
+                smem_start = group_info.start_within_block
+                remaining_rows = min(block_m, m)
+                # TMA descriptors need to be generated with static tile sizes along each
+                # axis, but we do not know at compile time how many rows we will need to
+                # store. We only know that the number of rows to store is bounded by
+                # min(block_m, m).
+                #
+                # In order to work around that, we construct a logarithmic ladder of
+                # TMA descriptors, where each descriptor can store 2**i rows for some
+                # i between 0 and log2(min(block_m, m)). This allows storing any
+                # number of rows we will need to store, so long as this number of rows
+                # is between `1` and `min(block_m, m)`.
+                #
+                # E.g., imagine we have block_m = 8, m = 16. The loop below will be
+                # unrolled into 4 iterations, where the first one will generate a TMA
+                # descriptor that can store 8 rows, the second one will generate a TMA
+                # descriptor that can store 4 rows, etc. all the way to 1 row.
+                #
+                # At run time, we finally know the actual number of rows we need to
+                # store as we go through the unrolled loop iterations. Let's imagine
+                # that we need to store 5 rows.
+                #
+                # The first unrolled iteration will check whether we can store 8 rows.
+                # Since we only need to store 5 rows, we won't store anything then.
+                #
+                # The second unrolled iteration will check whether we can store 4 rows.
+                # We're able to store 4 rows, and are left with a single remaining row.
+                #
+                # The fourth unrolled iteration will store the single remaining row, and
+                # we end up with a storing scheme as follows for our 5 rows:
+                #
+                #     -----------------------------------------------------------
+                #  0  |                                                         |
+                #  1  |                                                         |
+                #  2  |                       Store 4 rows                      |
+                #  3  |                                                         |
+                #     -----------------------------------------------------------
+                #  4  |                       Store 1 row                       |
+                #     -----------------------------------------------------------
+                while remaining_rows > 0:
+                    const_rows_len = 1 << int(math.log2(remaining_rows))
+                    remaining_rows //= 2
+
+                    @pl.when(group_info.actual_size & const_rows_len != 0)
+                    def _():
+                        o_smem_slice = o_smem.at[pl.ds(smem_start, const_rows_len)]
+                        o_gref_slice = o_gmem.at[
+                            pl.ds(group_info.block_start + smem_start, const_rows_len),
+                            pl.ds(ni * block_n, block_n),
+                        ]
+                        plgpu.copy_smem_to_gmem(o_smem_slice, o_gref_slice)
+
+                    smem_start += group_info.actual_size & const_rows_len
+                plgpu.wait_smem_to_gmem(0, wait_read_only=True)
+
+    num_sms = jax.devices()[0].core_count
+    kernel = plgpu.kernel(
+        body,
+        out_shape=jax.ShapeDtypeStruct((m, n), _od),
+        grid=(num_sms,),
+        grid_names=("sm",),
+        compiler_params=plgpu.CompilerParams(
+            lowering_semantics=plgpu.LoweringSemantics.Warpgroup,
+        ),
+    )
+    return kernel(group_sizes, lhs, rhs, _scale)

--- a/lib/haliax/src/haliax/_src/ragged_dot_mgpu.py
+++ b/lib/haliax/src/haliax/_src/ragged_dot_mgpu.py
@@ -2,11 +2,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 #
-# Vendored and lightly modified from JAX (Apache-2.0):
-#   jax/experimental/pallas/ops/gpu/ragged_dot_mgpu.py
-# (jax 0.10.0).  These Pallas-Mosaic-GPU grouped matmuls drive the Hopper FP8
-# tensor cores (wgmma.fp8) and handle non-uniform, dynamic group_sizes.
-# Modifications vs upstream:
+# Vendored and lightly modified from JAX (Apache-2.0), jax 0.10.0:
+#   jax/experimental/pallas/ops/gpu/ragged_dot_mgpu.py            -> mgpu_ragged_dot
+#   jax/experimental/pallas/ops/gpu/transposed_ragged_dot_mgpu.py -> mgpu_dwgrad
+# These Pallas-Mosaic-GPU grouped matmuls drive the Hopper FP8 tensor cores
+# (wgmma.fp8) and handle non-uniform, dynamic group_sizes.
+# Modifications vs upstream (both kernels):
 #   * `out_dtype` parameter so an FP8 contraction can emit a BF16/FP32 result
 #     (upstream hardcodes the output dtype to ``lhs.dtype``);
 #   * `out_scale` parameter: per-tensor dequant scale folded into the store;
@@ -14,6 +15,11 @@
 #   * mixed FP8 operand pairs (E5M2 x E4M3) are accepted; lowering them needs
 #     jax >= 0.11.0 (mixed-dtype wgmma, jax-ml/jax#38859);
 #   * the ``main``/``ref_``/profiling helpers are dropped.
+# ``mgpu_dwgrad`` additionally adapts ``transposed_ragged_dot`` for FP8: the
+# operands are token-contiguous ([K,T] x [N,T]) with the wgmma transpose on the
+# B operand -- FP8 wgmma cannot transpose A at runtime, so the caller
+# pre-transposes both operands via the fused cast-transpose (upstream contracts
+# token-major [K,M] x [K,N] tiles and transposes the lhs descriptor instead).
 
 import dataclasses
 import functools
@@ -234,3 +240,186 @@ def mgpu_ragged_dot(
         ),
     )
     return kernel(group_sizes, lhs, rhs, _scale)
+
+
+def mgpu_dwgrad(
+    lhs_t,  # (K, T) fp8 -- weight-grad lhs, token dim T contiguous (dim 1)
+    grad_t,  # (N, T) fp8 -- output gradient, token dim T contiguous (dim 1)
+    *,
+    group_sizes,  # (G,)
+    block_m: int,
+    block_n: int,
+    block_k: int,
+    max_concurrent_steps: int,
+    grid_block_n: int,
+    out_dtype=None,
+    out_scale=None,
+) -> jax.Array:
+    """Ragged FP8 weight gradient: ``dr[G,K,N] = sum_{t in g} lhs[t,K] grad[t,N]``.
+
+    Contracts the *ragged* token dimension.  FP8 ``wgmma`` cannot transpose an
+    operand at runtime, so the token (contracting) dimension must be contiguous
+    for both operands: the caller cast-transposes ``lhs -> [K, T]`` and
+    ``grad -> [N, T]`` out of kernel.  Inside, ``A = lhs_t`` is used natively
+    (token-contiguous) and ``B = transpose_ref(grad_t) = [T, N]`` uses the
+    B-operand transpose that FP8 ``wgmma`` does support.
+    """
+    if lhs_t.dtype not in _FP8_DTYPES or grad_t.dtype not in _FP8_DTYPES:
+        raise NotImplementedError(f"mgpu_dwgrad expects FP8 operands, got {lhs_t.dtype}, {grad_t.dtype}")
+    k_dim, t = lhs_t.shape
+    n_dim, t2 = grad_t.shape
+    if t != t2:
+        raise ValueError(f"token dim mismatch: {t} vs {t2}")
+    if k_dim % block_m != 0:
+        raise ValueError(f"K={k_dim} must be a multiple of block_m={block_m}")
+    if n_dim % block_n != 0:
+        raise ValueError(f"N={n_dim} must be a multiple of block_n={block_n}")
+    g = group_sizes.shape[0]
+    _od = jnp.bfloat16 if out_dtype is None else out_dtype
+    _scale = jnp.ones((1,), jnp.float32) if out_scale is None else jnp.asarray(out_scale, jnp.float32).reshape(1)
+
+    group_sizes = group_sizes.astype(int)
+    group_starts = jnp.concatenate([jnp.zeros(1, dtype=int), jnp.cumsum(group_sizes)[:-1]]).astype(int)
+    group_ends = jnp.cumsum(group_sizes)
+    group_block_starts = group_starts // block_k * block_k
+    group_block_ends = -(group_ends // -block_k) * block_k
+    group_num_blocks = (group_block_ends - group_block_starts) // block_k
+
+    # Operand SMEM tiles are token-contiguous (trailing dim = block_k tokens).
+    swizzle = plgpu.find_swizzle(block_k * jnp.dtype(lhs_t.dtype).itemsize * 8)
+    swizzle_elems = swizzle // jnp.dtype(lhs_t.dtype).itemsize
+    transforms = (
+        plgpu.TilingTransform((8, swizzle_elems)),
+        plgpu.SwizzleTransform(swizzle),
+    )
+    # Output tile [block_m(K), block_n(N)] is N-contiguous; swizzle from block_n.
+    o_swizzle = plgpu.find_swizzle(block_n * jnp.dtype(_od).itemsize * 8)
+    o_swizzle_elems = o_swizzle // jnp.dtype(_od).itemsize
+    o_transforms = (
+        plgpu.TilingTransform((8, o_swizzle_elems)),
+        plgpu.SwizzleTransform(o_swizzle),
+    )
+
+    def body(
+        group_sizes_gmem,
+        group_starts_gmem,
+        group_ends_gmem,
+        group_num_blocks_gmem,
+        group_block_starts_gmem,
+        lhs_gmem,
+        grad_gmem,
+        scale_gmem,
+        o_gmem,
+    ):
+        grid_m = pl.cdiv(k_dim, block_m)
+        grid_n = pl.cdiv(n_dim, block_n)
+
+        @plgpu.nd_loop((g, grid_m * grid_n), collective_axes="sm")
+        def mn_loop(loop_info: plgpu.NDLoopInfo):
+            g_i = loop_info.index[0]
+            m_i, n_i = plgpu.planar_snake(loop_info.index[1], (grid_m, grid_n), 1, grid_block_n)
+            # Slice the ragged token dimension (dim 1).  Potentially out of bounds,
+            # but the out-of-bounds tail is never accessed in emit_pipeline.
+            tok_slice = pl.ds(group_block_starts_gmem[g_i], t)
+
+            def acc_scope(acc_ref):
+                def block_matmul(block_idx, lhs_smem, grad_smem):
+                    block_idx = block_idx[0]
+
+                    @pl.when(block_idx == 0)
+                    def _():
+                        reg = lhs_smem[...]
+                        start_index = lax.rem(group_starts_gmem[g_i], block_k)
+                        indices = plgpu.layout_cast(
+                            jax.lax.broadcasted_iota(jnp.int32, (block_m, block_k), 1),
+                            plgpu.Layout.WGMMA,
+                        )
+                        reg = jnp.where(
+                            indices >= start_index,
+                            reg.astype(jnp.float16),
+                            jnp.float16(0),
+                        ).astype(lhs_smem.dtype)
+                        lhs_smem[...] = reg
+                        plgpu.commit_smem()
+
+                    @pl.when(block_idx == group_num_blocks_gmem[g_i] - 1)
+                    def _():
+                        reg = lhs_smem[...]
+                        last_index = lax.rem(group_ends_gmem[g_i] - 1, block_k)
+                        indices = plgpu.layout_cast(
+                            jax.lax.broadcasted_iota(jnp.int32, (block_m, block_k), 1),
+                            plgpu.Layout.WGMMA,
+                        )
+                        reg = jnp.where(
+                            indices <= last_index,
+                            reg.astype(jnp.float16),
+                            jnp.float16(0),
+                        ).astype(lhs_smem.dtype)
+                        lhs_smem[...] = reg
+                        plgpu.commit_smem()
+
+                    # A = lhs[K, T] native (token-contiguous); B = grad[N, T] -> [T, N].
+                    plgpu.wgmma(acc_ref, lhs_smem, plgpu.transpose_ref(grad_smem, (1, 0)))
+                    if max_concurrent_steps == 1:
+                        plgpu.wgmma_wait(0)
+
+                @pl.when(group_sizes_gmem[g_i] > 0)
+                def _():
+                    plgpu.emit_pipeline(
+                        block_matmul,
+                        grid=(group_num_blocks_gmem[g_i],),
+                        in_specs=[
+                            plgpu.BlockSpec(
+                                (block_m, block_k),
+                                lambda k_i: (m_i, k_i),
+                                delay_release=1 if max_concurrent_steps > 1 else 0,
+                                transforms=transforms,
+                            ),
+                            plgpu.BlockSpec(
+                                (block_n, block_k),
+                                lambda k_i: (n_i, k_i),
+                                delay_release=1 if max_concurrent_steps > 1 else 0,
+                                transforms=transforms,
+                            ),
+                        ],
+                        max_concurrent_steps=max_concurrent_steps,
+                    )(lhs_gmem.at[:, tok_slice], grad_gmem.at[:, tok_slice])
+
+                return acc_ref[...]
+
+            acc = pl.run_scoped(acc_scope, plgpu.ACC((block_m, block_n)))
+
+            @functools.partial(
+                pl.run_scoped,
+                o_smem=plgpu.SMEM((block_m, block_n), dtype=o_gmem.dtype, transforms=o_transforms),
+            )
+            def store_scope(o_smem):
+                o_smem[...] = (acc * scale_gmem[0]).astype(o_smem.dtype)
+                plgpu.commit_smem()
+                plgpu.copy_smem_to_gmem(
+                    o_smem,
+                    o_gmem.at[
+                        g_i,
+                        pl.ds(m_i * block_m, block_m),
+                        pl.ds(n_i * block_n, block_n),
+                    ],
+                )
+                plgpu.wait_smem_to_gmem(0, wait_read_only=True)
+
+    num_sms = jax.devices()[0].core_count
+    kernel = plgpu.kernel(
+        body,
+        out_shape=jax.ShapeDtypeStruct((g, k_dim, n_dim), _od),
+        grid=(num_sms,),
+        grid_names=("sm",),
+    )
+    return kernel(
+        group_sizes,
+        group_starts,
+        group_ends,
+        group_num_blocks,
+        group_block_starts,
+        lhs_t,
+        grad_t,
+        _scale,
+    )

--- a/lib/haliax/src/haliax/nn/ragged_dot.py
+++ b/lib/haliax/src/haliax/nn/ragged_dot.py
@@ -12,6 +12,7 @@ import jax
 import jax.numpy as jnp
 
 from haliax.partitioning import ResourceAxis
+from haliax.quantization import RaggedDotOp
 
 logger = logging.getLogger(__name__)
 
@@ -363,6 +364,7 @@ def ragged_dot(
     group_sizes_: jax.Array,
     ar: bool = False,
     implementation: Implementation = "auto",
+    op: RaggedDotOp | None = None,
 ) -> jax.Array:
     """Grouped matrix multiply with backend-dispatched ragged dot implementations.
 
@@ -374,10 +376,30 @@ def ragged_dot(
         implementation: Backend selection. ``"auto"`` selects per-platform default.
             ``"triton"`` forces GPU Pallas Triton kernel. ``"megablox"`` forces
             TPU megablox. ``"xla"`` forces ``jax.lax.ragged_dot_general``.
+        op: Optional stateful grouped-matmul op (e.g.
+            [haliax.quantization.Fp8RaggedDotOp][]). Analogous to passing a
+            ``dot_general`` op such as ``Fp8DotGeneralOp`` to ``Linear``: the op
+            owns the full contraction (forward, backward, and its own
+            layout/padding requirements), so it is called as
+            ``op(lhs, rhs, group_sizes)`` on the unpadded inputs and the backend
+            dispatch below — including the 512-row padding, a Triton kernel
+            requirement — is bypassed. Mutually exclusive with an explicit
+            ``implementation``.
 
     Returns:
         A [tokens, out] array.
     """
+    if op is not None:
+        if implementation != "auto":
+            raise ValueError(
+                f"ragged_dot: op= and implementation={implementation!r} are mutually exclusive; "
+                "the op owns its kernel selection."
+            )
+        out = op(lhs_, rhs_, group_sizes_)
+        if ar:
+            out = jax.lax.psum(out, ResourceAxis.MODEL)
+        return out
+
     hs_shape = lhs_.shape
     if hs_shape[0] % 512:
         pad_length = 512 - hs_shape[0] % 512

--- a/lib/haliax/src/haliax/quantization.py
+++ b/lib/haliax/src/haliax/quantization.py
@@ -264,16 +264,14 @@ class Fp8RaggedDotOp(OverwriteWithGradient):
     non-uniform ``group_sizes`` (each expert may receive a different number of
     tokens), then dequantizes the result.
 
-    The input gradient (grad_lhs) runs on the FP8 tensor cores: the output gradient
-    is quantized to ``rev_dtype`` with delayed scaling and contracted against the
-    pre-cast natural weight layout as a mixed ``e5m2 x e4m3`` ``wgmma``
-    contraction. The weight gradient (grad_rhs) stays **bf16**
-    (numerically exact) via the bf16 ``ragged_dot`` Triton kernel; FP8 weight
-    gradient is a follow-up. All state (per-tensor scale + amax history for the
-    input, kernel, and output gradient) is carried as [OverwriteWithGradient][] so
-    it threads through ``partition_for_grad_overwrite`` / ``apply_updates`` and
-    stays out of the optimizer/EMA state; the output-gradient scale + amax history
-    now update from the gradient magnitudes each step.
+    Both gradients run on the FP8 tensor cores: the output gradient is quantized to
+    ``rev_dtype`` with delayed scaling and contracted against the pre-cast natural
+    weight layout (grad_lhs), and the pre-cast transposed activation and transposed
+    output gradient are contracted for grad_rhs via ``mgpu_dwgrad``.  All state
+    (per-tensor scale + amax history for the input, kernel, and output gradient) is
+    carried as [OverwriteWithGradient][] so it threads through
+    ``partition_for_grad_overwrite`` / ``apply_updates`` and stays out of the
+    optimizer/EMA state.
 
     The FP8 fast path is a Mosaic-GPU ``wgmma`` kernel and therefore requires
     Hopper (SM90). Ports of this recipe to other architectures should plug in
@@ -283,12 +281,12 @@ class Fp8RaggedDotOp(OverwriteWithGradient):
     state) is a new op class.
 
     Like [Fp8DotGeneralOp][], ``rev_dtype`` defaults to E5M2 -- the numerically
-    correct output-gradient dtype -- so the backward GEMMs run as mixed
-    ``e5m2 x e4m3`` contractions once they move to FP8.  Mixed-dtype ``wgmma``
-    requires jax/jaxlib >= 0.11.0 (jax-ml/jax#38859); ``init`` fails fast on
-    older jax.  Passing ``rev_dtype=jnp.float8_e4m3fn`` recovers a uniform
-    backward that lowers on jax 0.10.x (an approximation: E4M3 trades dynamic
-    range for mantissa on the output gradient).
+    correct output-gradient dtype -- so both backward GEMMs are genuine mixed
+    ``e5m2 x e4m3`` contractions on the FP8 tensor cores.  Mixed-dtype
+    ``wgmma`` requires jax/jaxlib >= 0.11.0 (jax-ml/jax#38859); ``init``
+    fails fast on older jax.  Passing ``rev_dtype=jnp.float8_e4m3fn`` recovers
+    a uniform backward that lowers on jax 0.10.x (an approximation: E4M3
+    trades dynamic range for mantissa on the output gradient).
     """
 
     input_scale: jnp.ndarray

--- a/lib/haliax/src/haliax/quantization.py
+++ b/lib/haliax/src/haliax/quantization.py
@@ -264,14 +264,16 @@ class Fp8RaggedDotOp(OverwriteWithGradient):
     non-uniform ``group_sizes`` (each expert may receive a different number of
     tokens), then dequantizes the result.
 
-    The backward is computed in **bf16** (numerically exact) by differentiating
-    the reference bf16 ``ragged_dot``. Output-gradient FP8 quantization is
-    reserved for a follow-up change; for now the output-gradient scaling state
-    (``output_grad_scale`` / ``output_grad_amax_history``) is preserved unchanged
-    across steps. All state (per-tensor scale + amax history for the input, kernel,
-    and output gradient) is carried as [OverwriteWithGradient][] so it threads
-    through ``partition_for_grad_overwrite`` / ``apply_updates`` and stays out of
-    the optimizer/EMA state.
+    The input gradient (grad_lhs) runs on the FP8 tensor cores: the output gradient
+    is quantized to ``rev_dtype`` with delayed scaling and contracted against the
+    pre-cast natural weight layout as a mixed ``e5m2 x e4m3`` ``wgmma``
+    contraction. The weight gradient (grad_rhs) stays **bf16**
+    (numerically exact) via the bf16 ``ragged_dot`` Triton kernel; FP8 weight
+    gradient is a follow-up. All state (per-tensor scale + amax history for the
+    input, kernel, and output gradient) is carried as [OverwriteWithGradient][] so
+    it threads through ``partition_for_grad_overwrite`` / ``apply_updates`` and
+    stays out of the optimizer/EMA state; the output-gradient scale + amax history
+    now update from the gradient magnitudes each step.
 
     The FP8 fast path is a Mosaic-GPU ``wgmma`` kernel and therefore requires
     Hopper (SM90). Ports of this recipe to other architectures should plug in

--- a/lib/haliax/src/haliax/quantization.py
+++ b/lib/haliax/src/haliax/quantization.py
@@ -260,13 +260,18 @@ class Fp8RaggedDotOp(OverwriteWithGradient):
 
     The expert-grouped analog of [Fp8DotGeneralOp][]. Casts activations (``lhs``)
     and expert weights (``rhs``) to FP8 with delayed per-tensor scaling and
-    contracts them over dynamic non-uniform ``group_sizes`` (each expert may
-    receive a different number of tokens), then dequantizes the result. Output
-    gradients are quantized to FP8 in the custom VJP. All state (per-tensor
-    scale + amax history for the input, kernel, and output gradient) is carried
-    as [OverwriteWithGradient][] so it threads through
-    ``partition_for_grad_overwrite`` / ``apply_updates`` and stays out of the
-    optimizer/EMA state.
+    contracts them via a genuine ragged Mosaic ``wgmma`` over dynamic
+    non-uniform ``group_sizes`` (each expert may receive a different number of
+    tokens), then dequantizes the result.
+
+    The backward is computed in **bf16** (numerically exact) by differentiating
+    the reference bf16 ``ragged_dot``. Output-gradient FP8 quantization is
+    reserved for a follow-up change; for now the output-gradient scaling state
+    (``output_grad_scale`` / ``output_grad_amax_history``) is preserved unchanged
+    across steps. All state (per-tensor scale + amax history for the input, kernel,
+    and output gradient) is carried as [OverwriteWithGradient][] so it threads
+    through ``partition_for_grad_overwrite`` / ``apply_updates`` and stays out of
+    the optimizer/EMA state.
 
     The FP8 fast path is a Mosaic-GPU ``wgmma`` kernel and therefore requires
     Hopper (SM90). Ports of this recipe to other architectures should plug in
@@ -326,12 +331,24 @@ class Fp8RaggedDotOp(OverwriteWithGradient):
         comp_dtype = rhs.dtype if self.compute_dtype is None else self.compute_dtype
         lhs = jnp.asarray(lhs, comp_dtype)
         rhs = jnp.asarray(rhs, comp_dtype)
-        # Local import to break the quantization ↔ nn.ragged_dot import cycle;
-        # this is the sanctioned exception to the all-imports-at-top rule.
-        from .nn.ragged_dot import ragged_dot as _ragged_dot  # noqa: PLC0415
+        # Local import to keep the Mosaic-GPU FP8 kernel (imported by fp8_ragged)
+        # off the CPU/TPU import path; sanctioned exception to imports-at-top.
+        from ._src.fp8_ragged import fp8_scaled_ragged_dot  # noqa: PLC0415
 
-        # TODO: swap this bf16 matmul for fp8_scaled_ragged_dot (delayed-scaling FP8) in a follow-up.
-        return _ragged_dot(lhs, rhs, group_sizes, op=None)
+        return fp8_scaled_ragged_dot(
+            lhs,
+            rhs,
+            group_sizes,
+            lhs_scale=self.input_scale,
+            rhs_scale=self.kernel_scale,
+            grad_scale=self.output_grad_scale,
+            lhs_amax_history=self.input_amax_history,
+            rhs_amax_history=self.kernel_amax_history,
+            grad_amax_history=self.output_grad_amax_history,
+            quantize_compute_type=comp_dtype,
+            fwd_dtype=self.fwd_dtype,
+            rev_dtype=self.rev_dtype,
+        )
 
 
 class Int8DotGeneralOp(OverwriteWithGradient):

--- a/lib/haliax/src/haliax/quantization.py
+++ b/lib/haliax/src/haliax/quantization.py
@@ -234,8 +234,107 @@ class Fp8DotGeneralOp(OverwriteWithGradient):
         )
 
 
-class Int8DotGeneralOp(OverwriteWithGradient):
+class RaggedDotOp(Protocol):
+    """Signature of the optional ``op=`` argument to [haliax.nn.ragged_dot][].
 
+    The grouped-matmul analog of [DotGeneralOp][]: an implementation owns the
+    entire contraction (forward, backward, and its own layout/padding
+    requirements) and is called with the genuine non-uniform per-expert
+    ``group_sizes``.
+    """
+
+    def __call__(self, lhs, rhs, group_sizes) -> jnp.ndarray: ...
+
+
+# Mosaic-GPU wgmma accepts mixed E4M3/E5M2 operand dtypes from jax/jaxlib 0.11.0
+# (jax-ml/jax#38859); older releases reject them in the dialect verifier.
+_MIXED_WGMMA_MIN_JAX = (0, 11)
+
+
+def _jax_supports_mixed_fp8_wgmma() -> bool:
+    return tuple(int(p) for p in jax.__version__.split(".")[:2]) >= _MIXED_WGMMA_MIN_JAX
+
+
+class Fp8RaggedDotOp(OverwriteWithGradient):
+    """Direct-quantization FP8 ``ragged_dot`` op for MoE grouped matmuls.
+
+    The expert-grouped analog of [Fp8DotGeneralOp][]. Casts activations (``lhs``)
+    and expert weights (``rhs``) to FP8 with delayed per-tensor scaling and
+    contracts them over dynamic non-uniform ``group_sizes`` (each expert may
+    receive a different number of tokens), then dequantizes the result. Output
+    gradients are quantized to FP8 in the custom VJP. All state (per-tensor
+    scale + amax history for the input, kernel, and output gradient) is carried
+    as [OverwriteWithGradient][] so it threads through
+    ``partition_for_grad_overwrite`` / ``apply_updates`` and stays out of the
+    optimizer/EMA state.
+
+    The FP8 fast path is a Mosaic-GPU ``wgmma`` kernel and therefore requires
+    Hopper (SM90). Ports of this recipe to other architectures should plug in
+    as additional kernels dispatched behind this same op (analogous to
+    ``ragged_dot``'s ``implementation="auto"``); a different scaling recipe
+    (e.g. Blackwell hardware block scaling, which carries no delayed-scaling
+    state) is a new op class.
+
+    Like [Fp8DotGeneralOp][], ``rev_dtype`` defaults to E5M2 -- the numerically
+    correct output-gradient dtype -- so the backward GEMMs run as mixed
+    ``e5m2 x e4m3`` contractions once they move to FP8.  Mixed-dtype ``wgmma``
+    requires jax/jaxlib >= 0.11.0 (jax-ml/jax#38859); ``init`` fails fast on
+    older jax.  Passing ``rev_dtype=jnp.float8_e4m3fn`` recovers a uniform
+    backward that lowers on jax 0.10.x (an approximation: E4M3 trades dynamic
+    range for mantissa on the output gradient).
+    """
+
+    input_scale: jnp.ndarray
+    output_grad_scale: jnp.ndarray
+    kernel_scale: jnp.ndarray
+    input_amax_history: jnp.ndarray
+    output_grad_amax_history: jnp.ndarray
+    kernel_amax_history: jnp.ndarray
+    compute_dtype: DTypeLike | None = eqx.field(static=True)
+    fwd_dtype: DTypeLike = eqx.field(static=True)
+    rev_dtype: DTypeLike = eqx.field(static=True)
+
+    @classmethod
+    def init(
+        cls,
+        amax_history_length: int = 1024,
+        compute_dtype: DTypeLike | None = None,
+        fwd_dtype: DTypeLike = jnp.float8_e4m3fn,
+        rev_dtype: DTypeLike = jnp.float8_e5m2,
+    ):
+        if jnp.dtype(fwd_dtype) != jnp.dtype(rev_dtype) and not _jax_supports_mixed_fp8_wgmma():
+            raise ValueError(
+                f"Mixed FP8 operand dtypes (fwd_dtype={jnp.dtype(fwd_dtype).name}, "
+                f"rev_dtype={jnp.dtype(rev_dtype).name}) need the mixed-dtype wgmma shipped in "
+                f"jax >= {'.'.join(str(v) for v in _MIXED_WGMMA_MIN_JAX)} (jax-ml/jax#38859); "
+                f"this is jax {jax.__version__}. Pass rev_dtype=jnp.float8_e4m3fn for the "
+                "uniform-backward approximation."
+            )
+        return cls(
+            input_scale=jnp.ones(1, dtype=jnp.float32),
+            output_grad_scale=jnp.ones(1, dtype=jnp.float32),
+            kernel_scale=jnp.ones(1, dtype=jnp.float32),
+            input_amax_history=jnp.zeros(amax_history_length, dtype=jnp.float32),
+            output_grad_amax_history=jnp.zeros(amax_history_length, dtype=jnp.float32),
+            kernel_amax_history=jnp.zeros(amax_history_length, dtype=jnp.float32),
+            compute_dtype=compute_dtype,
+            fwd_dtype=fwd_dtype,
+            rev_dtype=rev_dtype,
+        )
+
+    def __call__(self, lhs, rhs, group_sizes):
+        comp_dtype = rhs.dtype if self.compute_dtype is None else self.compute_dtype
+        lhs = jnp.asarray(lhs, comp_dtype)
+        rhs = jnp.asarray(rhs, comp_dtype)
+        # Local import to break the quantization ↔ nn.ragged_dot import cycle;
+        # this is the sanctioned exception to the all-imports-at-top rule.
+        from .nn.ragged_dot import ragged_dot as _ragged_dot  # noqa: PLC0415
+
+        # TODO: swap this bf16 matmul for fp8_scaled_ragged_dot (delayed-scaling FP8) in a follow-up.
+        return _ragged_dot(lhs, rhs, group_sizes, op=None)
+
+
+class Int8DotGeneralOp(OverwriteWithGradient):
     cfg: DotGeneral
 
     @classmethod
@@ -311,7 +410,9 @@ def _quantize_linear_layers(tree: T, config: QuantizationConfig, dot_general_cls
         path = path_prefix + path
         if isinstance(module, hnn.Stacked):
             new_inner = jax.tree_util.tree_map_with_path(
-                functools.partial(quantize_module, path_prefix + (GetAttrKey("stacked"),), batch_dims + (module.Block,)),  # type: ignore
+                functools.partial(
+                    quantize_module, path_prefix + (GetAttrKey("stacked"),), batch_dims + (module.Block,)
+                ),  # type: ignore
                 module.stacked,
                 is_leaf=_is_special_module,
             )

--- a/lib/haliax/src/haliax/quantization.py
+++ b/lib/haliax/src/haliax/quantization.py
@@ -345,7 +345,6 @@ class Fp8RaggedDotOp(OverwriteWithGradient):
             lhs_amax_history=self.input_amax_history,
             rhs_amax_history=self.kernel_amax_history,
             grad_amax_history=self.output_grad_amax_history,
-            quantize_compute_type=comp_dtype,
             fwd_dtype=self.fwd_dtype,
             rev_dtype=self.rev_dtype,
         )

--- a/lib/haliax/tests/test_fp8_cast_transpose.py
+++ b/lib/haliax/tests/test_fp8_cast_transpose.py
@@ -1,0 +1,67 @@
+# Copyright The Levanter Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from haliax._src.fp8_cast_transpose import cast_transpose_amax_2d, cast_transpose_amax_3d
+from haliax._src.fp8 import get_fp8_max
+
+
+def _fp8_capable_gpu() -> bool:
+    if jax.default_backend() != "gpu":
+        return False
+    major, minor = (int(part) for part in jax.devices()[0].compute_capability.split("."))
+    return (major, minor) >= (9, 0)
+
+
+# The Mosaic-GPU backend targets Hopper (sm_90+); on older GPUs these tests
+# must skip, not error.
+fp8_gpu_only = pytest.mark.skipif(
+    not _fp8_capable_gpu(), reason="fused quantize+amax needs a Hopper+ GPU (Mosaic-GPU backend)"
+)
+
+
+@fp8_gpu_only
+def test_cast_transpose_natural_matches_reference():
+    """cast_transpose_amax_2d natural output matches naive clip-and-cast; transposed == natural.T; amax matches."""
+    rng = np.random.default_rng(1)
+    x = jnp.asarray(rng.standard_normal((256, 128)) * 3.0, jnp.bfloat16)
+    inv = jnp.asarray([0.5], jnp.float32)
+    q_nat, q_t, amax = cast_transpose_amax_2d(x, inv, jnp.float8_e4m3fn)
+    dtype_max = float(get_fp8_max(jnp.float8_e4m3fn, jnp.float32))
+    naive = jnp.clip(x.astype(jnp.float32) * inv[0], -dtype_max, dtype_max).astype(jnp.float8_e4m3fn)
+    np.testing.assert_array_equal(np.asarray(q_nat), np.asarray(naive))  # natural bit-for-bit
+    np.testing.assert_array_equal(np.asarray(q_t), np.asarray(naive).T)  # transposed == natural.T
+    np.testing.assert_allclose(float(amax[0]), float(jnp.max(jnp.abs(x.astype(jnp.float32)))), rtol=1e-5)
+
+
+@fp8_gpu_only
+def test_cast_transpose_3d_natural_and_transposed():
+    """cast_transpose_amax_3d: natural == naive quantize bit-for-bit; q_t[ei] == q_nat[ei].T; amax matches."""
+    rng = np.random.default_rng(2)
+    e, k, n = 4, 128, 64
+    x = jnp.asarray(rng.standard_normal((e, k, n)) * 3.0, jnp.bfloat16)
+    inv = jnp.asarray([0.5], jnp.float32)
+    q_nat, q_t, amax = cast_transpose_amax_3d(x, inv, jnp.float8_e4m3fn)
+
+    assert q_nat.shape == (e, k, n), f"natural shape mismatch: {q_nat.shape}"
+    assert q_t.shape == (e, n, k), f"transposed shape mismatch: {q_t.shape}"
+
+    # Natural output must match naive element-wise quantization bit-for-bit.
+    dtype_max = float(get_fp8_max(jnp.float8_e4m3fn, jnp.float32))
+    naive = jnp.clip(x.astype(jnp.float32) * inv[0], -dtype_max, dtype_max).astype(jnp.float8_e4m3fn)
+    np.testing.assert_array_equal(np.asarray(q_nat), np.asarray(naive))
+
+    # Transposed layout: q_t[ei] must equal q_nat[ei].T for every expert.
+    q_nat_np = np.asarray(q_nat)
+    q_t_np = np.asarray(q_t)
+    for ei in range(e):
+        np.testing.assert_array_equal(q_t_np[ei], q_nat_np[ei].T)
+
+    # Amax: max absolute value of the float32-cast input across all experts.
+    expected_amax = float(jnp.max(jnp.abs(x.astype(jnp.float32))))
+    np.testing.assert_allclose(float(amax[0]), expected_amax, rtol=1e-5)

--- a/lib/haliax/tests/test_fp8_ragged.py
+++ b/lib/haliax/tests/test_fp8_ragged.py
@@ -2,13 +2,14 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
 
 from haliax.nn.ragged_dot import ragged_dot
-from haliax.quantization import Fp8RaggedDotOp
+from haliax.quantization import Fp8RaggedDotOp, _jax_supports_mixed_fp8_wgmma, apply_updates, partition_for_grad_overwrite
 
 
 def _on_hopper_gpu() -> bool:
@@ -20,6 +21,12 @@ def _on_hopper_gpu() -> bool:
 # Mirrors fp8_scaled_ragged_dot's own precondition: the Mosaic wgmma kernels are
 # sm_90a-specific, so on any non-Hopper GPU these tests must skip, not error.
 hopper_only = pytest.mark.skipif(not _on_hopper_gpu(), reason="fp8 ragged wgmma kernels require Hopper (SM90)")
+
+# The default mixed e5m2 x e4m3 backward lowers only on jax >= 0.11.0
+# (jax-ml/jax#38859); Fp8RaggedDotOp.init with defaults fails fast on older jax.
+mixed_wgmma = pytest.mark.skipif(
+    not _jax_supports_mixed_fp8_wgmma(), reason="mixed e5m2 x e4m3 wgmma needs jax >= 0.11.0 (jax-ml/jax#38859)"
+)
 
 
 def _reference_ragged_dot(lhs, rhs, group_sizes):
@@ -83,14 +90,16 @@ def test_fp8_forward_parity_with_empty_groups():
 
 
 @hopper_only
+@mixed_wgmma
 def test_fp8_grads_parity_vs_reference():
-    # The backward runs the exact bf16 Triton kernels on the saved residuals, so
-    # both gradients match the f32 reference within bf16 rounding; the loose
-    # FP8 tolerance keeps the assertion stable as the backward moves to FP8
-    # GEMMs. The groups are non-uniform, including a small 5-token expert.
+    # grad_lhs now runs as a mixed FP8 GEMM (e5m2-grad x e4m3-weight) and is
+    # approximate vs the f32 reference
+    # grad, held to the 6e-2 FP8 tolerance; grad_rhs is still the exact bf16
+    # Triton kernel and passes with plenty of margin. The groups are
+    # non-uniform, including a small 5-token expert.
     lhs, rhs, _ = _nonuniform(128, 128, 4, 128, seed=3)
     gs = jnp.asarray([13, 5, 47, 63], jnp.int32)  # non-uniform, sums to T=128
-    op = Fp8RaggedDotOp.init(rev_dtype=jnp.float8_e4m3fn)  # backward is exact bf16 here
+    op = Fp8RaggedDotOp.init()  # rev_dtype defaults to e5m2 (mixed dgrad)
 
     def loss(l, r):
         return ragged_dot(l, r, gs, op=op).astype(jnp.float32).sum()
@@ -103,3 +112,38 @@ def test_fp8_grads_parity_vs_reference():
 
     _assert_close_fp8(g_lhs_fp8, g_lhs_ref, rel_fro_tol=6e-2, max_dev_tol=0.15, what="grad_lhs")
     _assert_close_fp8(g_rhs_fp8, g_rhs_ref, rel_fro_tol=6e-2, max_dev_tol=0.15, what="grad_rhs")
+
+
+@hopper_only
+def test_output_grad_scale_updates_across_steps():
+    """The backward's delayed scaling updates output_grad_scale from gradient magnitudes.
+
+    The backward returns the rolled grad_scale/grad_amax_history as
+    OverwriteWithGradient cotangents, so after steps with non-zero gradients all
+    three scales move away from 1.0 and none are zeroed.
+    """
+    lhs, rhs, gs = _nonuniform(128, 128, 4, 128)
+    op = Fp8RaggedDotOp.init()
+
+    def loss(op_, l, r):
+        return ragged_dot(l, r, gs, op=op_).astype(jnp.float32).sum()
+
+    def step(op_):
+        grads = eqx.filter_grad(loss)(op_, lhs, rhs)
+        overwrites, non_overwrites = partition_for_grad_overwrite(grads)
+        updates = jax.tree_util.tree_map(lambda g: jnp.zeros_like(g), non_overwrites)
+        return apply_updates(op_, updates, overwrites)
+
+    op1 = step(op)
+    op2 = step(op1)
+
+    # output_grad_scale must not be zeroed (the delayed-scaling state stays valid).
+    assert not np.allclose(np.asarray(op2.output_grad_scale), 0.0), "output_grad_scale was zeroed (state corruption)"
+    # input_scale, kernel_scale, and output_grad_scale must all have moved away from
+    # 1.0 — the input/kernel via in_q_ct, the output gradient via the FP8 dgrad's delayed
+    # scaling. Require all three so a regression in any delayed-scaling path is caught.
+    assert (
+        not np.allclose(np.asarray(op2.input_scale), 1.0, atol=1e-6)
+        and not np.allclose(np.asarray(op2.kernel_scale), 1.0, atol=1e-6)
+        and not np.allclose(np.asarray(op2.output_grad_scale), 1.0, atol=1e-6)
+    ), "input_scale, kernel_scale, and output_grad_scale should all update from 1.0 via delayed scaling"

--- a/lib/haliax/tests/test_fp8_ragged.py
+++ b/lib/haliax/tests/test_fp8_ragged.py
@@ -58,6 +58,8 @@ def _assert_close_fp8(actual, ref, rel_fro_tol, max_dev_tol, what):
 
 
 def _nonuniform(T, K, E, N, seed=0):
+    # T, K, N are multiples of 128: fp8_scaled_ragged_dot's alignment contract
+    # (wgrad token tile, dgrad/forward TMA swizzle).
     rng = np.random.default_rng(seed)
     lhs = jnp.asarray(rng.standard_normal((T, K)) * 0.1, jnp.bfloat16)
     rhs = jnp.asarray(rng.standard_normal((E, K, N)) * 0.1, jnp.bfloat16)
@@ -92,14 +94,13 @@ def test_fp8_forward_parity_with_empty_groups():
 @hopper_only
 @mixed_wgmma
 def test_fp8_grads_parity_vs_reference():
-    # grad_lhs now runs as a mixed FP8 GEMM (e5m2-grad x e4m3-weight) and is
-    # approximate vs the f32 reference
-    # grad, held to the 6e-2 FP8 tolerance; grad_rhs is still the exact bf16
-    # Triton kernel and passes with plenty of margin. The groups are
-    # non-uniform, including a small 5-token expert.
+    # Both gradients run as FP8 GEMMs and are approximate vs the f32 reference
+    # grad, held to the 6e-2 FP8 tolerance. T is a multiple of 128 (the wgrad's
+    # token-dim TMA tile); the groups are non-uniform, including a small
+    # 5-token expert.
     lhs, rhs, _ = _nonuniform(128, 128, 4, 128, seed=3)
     gs = jnp.asarray([13, 5, 47, 63], jnp.int32)  # non-uniform, sums to T=128
-    op = Fp8RaggedDotOp.init()  # rev_dtype defaults to e5m2 (mixed dgrad)
+    op = Fp8RaggedDotOp.init()  # rev_dtype defaults to e5m2 (mixed backward)
 
     def loss(l, r):
         return ragged_dot(l, r, gs, op=op).astype(jnp.float32).sum()
@@ -110,11 +111,40 @@ def test_fp8_grads_parity_vs_reference():
     g_lhs_fp8, g_rhs_fp8 = jax.grad(loss, argnums=(0, 1))(lhs, rhs)
     g_lhs_ref, g_rhs_ref = jax.grad(ref_loss, argnums=(0, 1))(lhs, rhs)
 
-    _assert_close_fp8(g_lhs_fp8, g_lhs_ref, rel_fro_tol=6e-2, max_dev_tol=0.15, what="grad_lhs")
-    _assert_close_fp8(g_rhs_fp8, g_rhs_ref, rel_fro_tol=6e-2, max_dev_tol=0.15, what="grad_rhs")
+    _assert_close_fp8(g_lhs_fp8, g_lhs_ref, rel_fro_tol=6e-2, max_dev_tol=0.15, what="FP8 dgrad grad_lhs")
+    _assert_close_fp8(g_rhs_fp8, g_rhs_ref, rel_fro_tol=6e-2, max_dev_tol=0.15, what="FP8 wgrad grad_rhs")
 
 
 @hopper_only
+@mixed_wgmma
+def test_fp8_grad_rhs_parity_incl_boundaries():
+    # The weight gradient (grad_rhs) contracts the ragged token dim in block_k=128
+    # tiles via mgpu_dwgrad. This exercises the f16-upcast group-boundary mask:
+    # the token groups are chosen so boundaries fall mid-tile and one group
+    # straddles the 128-token block boundary (start 100, end 180). T is a multiple
+    # of 128 (the wgrad's contracting-dim TMA tile), K and N multiples of 128
+    # (the dgrad/forward alignment).
+    lhs, rhs, _ = _nonuniform(256, 128, 4, 128, seed=4)
+    gs = jnp.asarray([60, 40, 80, 76], jnp.int32)  # boundaries 60, 100, 180 (mid-block_k)
+    assert int(gs.sum()) == 256
+    op = Fp8RaggedDotOp.init()
+
+    def loss(w):
+        return ragged_dot(lhs, w, gs, op=op).astype(jnp.float32).sum()
+
+    def ref_loss(w):
+        return _reference_ragged_dot(lhs, w, gs).sum()
+
+    g_rhs_fp8 = jax.grad(loss)(rhs)
+    g_rhs_ref = jax.grad(ref_loss)(rhs)
+
+    _assert_close_fp8(
+        g_rhs_fp8, g_rhs_ref, rel_fro_tol=6e-2, max_dev_tol=0.15, what="FP8 wgrad grad_rhs at mid-tile boundaries"
+    )
+
+
+@hopper_only
+@mixed_wgmma
 def test_output_grad_scale_updates_across_steps():
     """The backward's delayed scaling updates output_grad_scale from gradient magnitudes.
 
@@ -147,3 +177,29 @@ def test_output_grad_scale_updates_across_steps():
         and not np.allclose(np.asarray(op2.kernel_scale), 1.0, atol=1e-6)
         and not np.allclose(np.asarray(op2.output_grad_scale), 1.0, atol=1e-6)
     ), "input_scale, kernel_scale, and output_grad_scale should all update from 1.0 via delayed scaling"
+
+
+@pytest.mark.parametrize(
+    "t,k,n,match",
+    [
+        (192, 128, 128, "T=192"),  # multiple of 64 (forward tile) but not of 128 (wgrad tile)
+        (128, 192, 128, "K=192"),
+        (128, 128, 192, "N=192"),
+    ],
+)
+def test_fp8_misaligned_shape_fails_fast(t, k, n, match):
+    """Misaligned shapes raise ValueError at call time, naming the offending dim.
+
+    Regression: the op= path bypasses ragged_dot's 512-row padding, and the
+    backward's alignment constraints are stricter than the forward's, so without
+    up-front validation a forward-only run would succeed and the first jax.grad
+    would crash at trace time. Runs on all backends: the shape contract is
+    checked before the Hopper device check.
+    """
+    lhs = jnp.zeros((t, k), jnp.bfloat16)
+    rhs = jnp.zeros((4, k, n), jnp.bfloat16)
+    gs = jnp.asarray([t // 4] * 4, jnp.int32)
+    # Uniform rev_dtype so the op constructs on jax 0.10.x (incl. CPU CI); the
+    # shape contract under test is independent of the backward dtype recipe.
+    with pytest.raises(ValueError, match=match):
+        ragged_dot(lhs, rhs, gs, op=Fp8RaggedDotOp.init(rev_dtype=jnp.float8_e4m3fn))

--- a/lib/haliax/tests/test_fp8_ragged.py
+++ b/lib/haliax/tests/test_fp8_ragged.py
@@ -9,7 +9,12 @@ import numpy as np
 import pytest
 
 from haliax.nn.ragged_dot import ragged_dot
-from haliax.quantization import Fp8RaggedDotOp, _jax_supports_mixed_fp8_wgmma, apply_updates, partition_for_grad_overwrite
+from haliax.quantization import (
+    Fp8RaggedDotOp,
+    _jax_supports_mixed_fp8_wgmma,
+    apply_updates,
+    partition_for_grad_overwrite,
+)
 
 
 def _on_hopper_gpu() -> bool:

--- a/lib/haliax/tests/test_fp8_ragged.py
+++ b/lib/haliax/tests/test_fp8_ragged.py
@@ -1,0 +1,105 @@
+# Copyright The Levanter Authors
+#
+# SPDX-License-Identifier: Apache-2.0
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+import pytest
+
+from haliax.nn.ragged_dot import ragged_dot
+from haliax.quantization import Fp8RaggedDotOp
+
+
+def _on_hopper_gpu() -> bool:
+    if jax.default_backend() != "gpu":
+        return False
+    return jax.devices()[0].compute_capability.startswith("9.")
+
+
+# Mirrors fp8_scaled_ragged_dot's own precondition: the Mosaic wgmma kernels are
+# sm_90a-specific, so on any non-Hopper GPU these tests must skip, not error.
+hopper_only = pytest.mark.skipif(not _on_hopper_gpu(), reason="fp8 ragged wgmma kernels require Hopper (SM90)")
+
+
+def _reference_ragged_dot(lhs, rhs, group_sizes):
+    """Independent f32 reference: per-token expert gather + einsum.
+
+    Deliberately shares no code with the in-repo Triton/Mosaic ragged kernels or
+    with ``jax.lax.ragged_dot_general``, so a bug shared by the production
+    kernels cannot cancel out of the comparison. Differentiable, so ``jax.grad``
+    of it is the gradient reference as well.
+    """
+    ids = jnp.repeat(jnp.arange(group_sizes.shape[0]), group_sizes, total_repeat_length=lhs.shape[0])
+    return jnp.einsum("tk,tkn->tn", lhs.astype(jnp.float32), rhs.astype(jnp.float32)[ids])
+
+
+def _assert_close_fp8(actual, ref, rel_fro_tol, max_dev_tol, what):
+    """FP8-vs-reference parity with an aggregate and a pointwise metric.
+
+    The relative Frobenius norm bounds the overall quantization error; the max
+    pointwise deviation (scaled by the reference's max magnitude) catches
+    localized corruption -- e.g. a few bad tokens at a group boundary -- that a
+    whole-tensor norm averages away.
+    """
+    a = np.asarray(actual, np.float32)
+    r = np.asarray(ref, np.float32)
+    rel_fro = np.linalg.norm(a - r) / (np.linalg.norm(r) + 1e-12)
+    max_dev = np.max(np.abs(a - r)) / (np.max(np.abs(r)) + 1e-12)
+    assert rel_fro < rel_fro_tol, f"{what}: relative Frobenius error {rel_fro:.4f} >= {rel_fro_tol}"
+    assert max_dev < max_dev_tol, f"{what}: max pointwise deviation {max_dev:.4f} >= {max_dev_tol} of ref max"
+
+
+def _nonuniform(T, K, E, N, seed=0):
+    rng = np.random.default_rng(seed)
+    lhs = jnp.asarray(rng.standard_normal((T, K)) * 0.1, jnp.bfloat16)
+    rhs = jnp.asarray(rng.standard_normal((E, K, N)) * 0.1, jnp.bfloat16)
+    # genuine non-uniform groups summing to T
+    parts = rng.multinomial(T, np.ones(E) / E)
+    return lhs, rhs, jnp.asarray(parts, jnp.int32)
+
+
+@hopper_only
+def test_fp8_forward_parity_vs_reference():
+    lhs, rhs, gs = _nonuniform(128, 128, 4, 128)
+    # rev_dtype only affects the backward; uniform e4m3 keeps the forward
+    # parity tests runnable on jax 0.10.x Hopper pods.
+    op = Fp8RaggedDotOp.init(rev_dtype=jnp.float8_e4m3fn)
+    out = ragged_dot(lhs, rhs, gs, op=op)
+    ref = _reference_ragged_dot(lhs, rhs, gs)
+    _assert_close_fp8(out, ref, rel_fro_tol=5e-2, max_dev_tol=0.15, what="FP8 forward")
+
+
+@hopper_only
+def test_fp8_forward_parity_with_empty_groups():
+    # Zero-token experts: boundary case for the ragged group iteration. The
+    # empty experts' weights must not contaminate neighboring groups' outputs.
+    lhs, rhs, _ = _nonuniform(128, 128, 4, 128, seed=5)
+    gs = jnp.asarray([0, 64, 0, 64], jnp.int32)
+    op = Fp8RaggedDotOp.init(rev_dtype=jnp.float8_e4m3fn)  # forward-only; see above
+    out = ragged_dot(lhs, rhs, gs, op=op)
+    ref = _reference_ragged_dot(lhs, rhs, gs)
+    _assert_close_fp8(out, ref, rel_fro_tol=5e-2, max_dev_tol=0.15, what="FP8 forward (empty groups)")
+
+
+@hopper_only
+def test_fp8_grads_parity_vs_reference():
+    # The backward runs the exact bf16 Triton kernels on the saved residuals, so
+    # both gradients match the f32 reference within bf16 rounding; the loose
+    # FP8 tolerance keeps the assertion stable as the backward moves to FP8
+    # GEMMs. The groups are non-uniform, including a small 5-token expert.
+    lhs, rhs, _ = _nonuniform(128, 128, 4, 128, seed=3)
+    gs = jnp.asarray([13, 5, 47, 63], jnp.int32)  # non-uniform, sums to T=128
+    op = Fp8RaggedDotOp.init(rev_dtype=jnp.float8_e4m3fn)  # backward is exact bf16 here
+
+    def loss(l, r):
+        return ragged_dot(l, r, gs, op=op).astype(jnp.float32).sum()
+
+    def ref_loss(l, r):
+        return _reference_ragged_dot(l, r, gs).sum()
+
+    g_lhs_fp8, g_rhs_fp8 = jax.grad(loss, argnums=(0, 1))(lhs, rhs)
+    g_lhs_ref, g_rhs_ref = jax.grad(ref_loss, argnums=(0, 1))(lhs, rhs)
+
+    _assert_close_fp8(g_lhs_fp8, g_lhs_ref, rel_fro_tol=6e-2, max_dev_tol=0.15, what="grad_lhs")
+    _assert_close_fp8(g_rhs_fp8, g_rhs_ref, rel_fro_tol=6e-2, max_dev_tol=0.15, what="grad_rhs")

--- a/lib/haliax/tests/test_fp8_ragged.py
+++ b/lib/haliax/tests/test_fp8_ragged.py
@@ -119,13 +119,15 @@ def test_fp8_grads_parity_vs_reference():
 @mixed_wgmma
 def test_fp8_grad_rhs_parity_incl_boundaries():
     # The weight gradient (grad_rhs) contracts the ragged token dim in block_k=128
-    # tiles via mgpu_dwgrad. This exercises the f16-upcast group-boundary mask:
-    # the token groups are chosen so boundaries fall mid-tile and one group
-    # straddles the 128-token block boundary (start 100, end 180). T is a multiple
-    # of 128 (the wgrad's contracting-dim TMA tile), K and N multiples of 128
-    # (the dgrad/forward alignment).
-    lhs, rhs, _ = _nonuniform(256, 128, 4, 128, seed=4)
-    gs = jnp.asarray([60, 40, 80, 76], jnp.int32)  # boundaries 60, 100, 180 (mid-block_k)
+    # tiles via mgpu_dwgrad. This exercises the boundary appendix (pre-masked
+    # first/last token blocks, write_boundary_appendix): the token groups are
+    # chosen so boundaries fall mid-tile, one group straddles the 128-token block
+    # boundary (start 100, end 180), one group is empty, and one group is fully
+    # contained in a single tile (the appendix's dual-masked single-block case).
+    # T is a multiple of 128 (the wgrad's contracting-dim TMA tile), K and N
+    # multiples of 128 (the dgrad/forward alignment).
+    lhs, rhs, _ = _nonuniform(256, 128, 5, 128, seed=4)
+    gs = jnp.asarray([60, 40, 0, 80, 76], jnp.int32)  # boundaries 60, 100, 100, 180 (mid-block_k)
     assert int(gs.sum()) == 256
     op = Fp8RaggedDotOp.init()
 

--- a/lib/haliax/tests/test_ragged_dot_dispatch.py
+++ b/lib/haliax/tests/test_ragged_dot_dispatch.py
@@ -9,6 +9,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+from haliax._src.ragged_dot_mgpu import mgpu_dwgrad, mgpu_ragged_dot
 from haliax.nn import ragged_dot
 from haliax.quantization import Fp8RaggedDotOp, _jax_supports_mixed_fp8_wgmma, partition_for_grad_overwrite
 
@@ -165,6 +166,38 @@ def test_init_defaults_to_mixed_backward():
     op = Fp8RaggedDotOp.init()
     assert jnp.dtype(op.fwd_dtype) == jnp.dtype(jnp.float8_e4m3fn)
     assert jnp.dtype(op.rev_dtype) == jnp.dtype(jnp.float8_e5m2)
+
+
+# Dummy tile config: the dtype gates under test fire before any tile-shape or
+# kernel work, so the values never matter.
+_KERNEL_KW = dict(block_m=64, block_n=64, block_k=64, max_concurrent_steps=2, grid_block_n=1)
+
+
+def test_mgpu_ragged_dot_rejects_non_fp8_mixed_dtypes():
+    lhs = jnp.zeros((64, 64), jnp.bfloat16)
+    rhs = jnp.zeros((2, 64, 64), jnp.float8_e4m3fn)
+    gs = jnp.asarray([32, 32], jnp.int32)
+    with pytest.raises(NotImplementedError, match="same dtype or both be FP8"):
+        mgpu_ragged_dot(lhs, rhs, group_sizes=gs, **_KERNEL_KW)
+
+
+def test_mgpu_ragged_dot_accepts_mixed_fp8_pair_past_dtype_gate():
+    # k != k2 so the call dies on the later shape check -- reaching it proves
+    # the e5m2 x e4m3 pair passed the dtype gate that used to reject any
+    # mismatch, without needing a Hopper GPU to run the kernel.
+    lhs = jnp.zeros((64, 64), jnp.float8_e5m2)
+    rhs = jnp.zeros((2, 128, 64), jnp.float8_e4m3fn)
+    gs = jnp.asarray([32, 32], jnp.int32)
+    with pytest.raises(ValueError, match="must match"):
+        mgpu_ragged_dot(lhs, rhs, group_sizes=gs, **_KERNEL_KW)
+
+
+def test_mgpu_dwgrad_rejects_non_fp8_operands():
+    lhs_t = jnp.zeros((64, 128), jnp.bfloat16)
+    grad_t = jnp.zeros((64, 128), jnp.float8_e5m2)
+    gs = jnp.asarray([64, 64], jnp.int32)
+    with pytest.raises(NotImplementedError, match="expects FP8 operands"):
+        mgpu_dwgrad(lhs_t, grad_t, group_sizes=gs, **_KERNEL_KW)
 
 
 def test_op_state_partitions_as_overwrite():

--- a/lib/haliax/tests/test_ragged_dot_dispatch.py
+++ b/lib/haliax/tests/test_ragged_dot_dispatch.py
@@ -11,7 +11,7 @@ import pytest
 
 from haliax._src.ragged_dot_mgpu import mgpu_dwgrad, mgpu_ragged_dot
 from haliax.nn import ragged_dot
-from haliax.quantization import Fp8RaggedDotOp, _jax_supports_mixed_fp8_wgmma, partition_for_grad_overwrite
+from haliax.quantization import Fp8RaggedDotOp, _jax_supports_mixed_fp8_wgmma
 
 ragged_dot_module = importlib.import_module("haliax.nn.ragged_dot")
 
@@ -198,21 +198,3 @@ def test_mgpu_dwgrad_rejects_non_fp8_operands():
     gs = jnp.asarray([64, 64], jnp.int32)
     with pytest.raises(NotImplementedError, match="expects FP8 operands"):
         mgpu_dwgrad(lhs_t, grad_t, group_sizes=gs, **_KERNEL_KW)
-
-
-def test_op_state_partitions_as_overwrite():
-    """Fp8RaggedDotOp's scale/amax state goes to the overwrite partition, not the optimizer gradient."""
-    op = Fp8RaggedDotOp.init(amax_history_length=4, rev_dtype=jnp.float8_e4m3fn)
-    regular_param = jnp.array([1.0, 2.0])
-
-    # Partition a tree containing both the op and a regular parameter.
-    tree = {"op": op, "weight": regular_param}
-    overwrites, grads = partition_for_grad_overwrite(tree)
-
-    # The op (OverwriteWithGradient) lands in overwrites, not in grads.
-    assert isinstance(overwrites["op"], Fp8RaggedDotOp)
-    assert grads["op"] is None
-
-    # Regular parameters are not overwritten; they stay in the grad/optimizer partition.
-    assert overwrites["weight"] is None
-    np.testing.assert_array_equal(np.asarray(grads["weight"]), np.asarray(regular_param))

--- a/lib/haliax/tests/test_ragged_dot_dispatch.py
+++ b/lib/haliax/tests/test_ragged_dot_dispatch.py
@@ -128,43 +128,16 @@ def test_triton_custom_vjp_routes_backward_through_triton_layouts(monkeypatch):
 
 
 # ---------------------------------------------------------------------------
-# FP8 op dispatch tests (routing, op=None reference, state plumbing)
+# FP8 op dispatch tests (op=/implementation= routing, init contract)
 # ---------------------------------------------------------------------------
 
 
-def _fp8_inputs(T=48, K=16, E=4, N=24, seed=0):
+def _fp8_inputs(T=64, K=128, E=4, N=128, seed=0):
     rng = np.random.default_rng(seed)
-    lhs = jnp.asarray(rng.standard_normal((T, K)), jnp.bfloat16)
-    rhs = jnp.asarray(rng.standard_normal((E, K, N)), jnp.bfloat16)
-    group_sizes = jnp.asarray([13, 5, 17, 13], jnp.int32)  # non-uniform, sums to T
+    lhs = jnp.asarray(rng.standard_normal((T, K)) * 0.1, jnp.bfloat16)
+    rhs = jnp.asarray(rng.standard_normal((E, K, N)) * 0.1, jnp.bfloat16)
+    group_sizes = jnp.asarray(rng.multinomial(T, np.ones(E) / E), jnp.int32)  # non-uniform, sums to T
     return lhs, rhs, group_sizes
-
-
-def test_op_none_matches_xla_reference():
-    """The default path (op=None) matches jax.lax.ragged_dot_general on non-uniform groups."""
-    lhs, rhs, gs = _fp8_inputs()
-    out = ragged_dot(lhs, rhs, gs, op=None)
-    ref = jax.lax.ragged_dot_general(
-        lhs=lhs,
-        rhs=rhs,
-        group_sizes=gs,
-        ragged_dot_dimension_numbers=jax.lax.RaggedDotDimensionNumbers(
-            dot_dimension_numbers=(((1,), (1,)), ((), ())),
-            lhs_ragged_dimensions=(0,),
-            rhs_group_dimensions=(0,),
-        ),
-    )
-    np.testing.assert_allclose(np.asarray(out), np.asarray(ref), rtol=2e-2, atol=2e-2)
-
-
-def test_op_routes_to_op_and_runs_end_to_end():
-    lhs, rhs, gs = _fp8_inputs()
-    op = Fp8RaggedDotOp.init(rev_dtype=jnp.float8_e4m3fn)
-    # The op is still a bf16 placeholder at this point; FP8 kernels land in later commits.
-    out = ragged_dot(lhs, rhs, gs, op=op)
-    ref = ragged_dot(lhs, rhs, gs, op=None)
-    assert out.shape == ref.shape
-    np.testing.assert_allclose(np.asarray(out), np.asarray(ref), rtol=2e-2, atol=2e-2)
 
 
 def test_op_with_explicit_implementation_raises():

--- a/lib/haliax/tests/test_ragged_dot_dispatch.py
+++ b/lib/haliax/tests/test_ragged_dot_dispatch.py
@@ -6,9 +6,11 @@ import importlib
 
 import jax
 import jax.numpy as jnp
+import numpy as np
 import pytest
 
 from haliax.nn import ragged_dot
+from haliax.quantization import Fp8RaggedDotOp, _jax_supports_mixed_fp8_wgmma, partition_for_grad_overwrite
 
 ragged_dot_module = importlib.import_module("haliax.nn.ragged_dot")
 
@@ -123,3 +125,88 @@ def test_triton_custom_vjp_routes_backward_through_triton_layouts(monkeypatch):
         ragged_dot_module._DLHS_DIM_NUMS,
         ragged_dot_module._DRHS_DIM_NUMS,
     ]
+
+
+# ---------------------------------------------------------------------------
+# FP8 op dispatch tests (routing, op=None reference, state plumbing)
+# ---------------------------------------------------------------------------
+
+
+def _fp8_inputs(T=48, K=16, E=4, N=24, seed=0):
+    rng = np.random.default_rng(seed)
+    lhs = jnp.asarray(rng.standard_normal((T, K)), jnp.bfloat16)
+    rhs = jnp.asarray(rng.standard_normal((E, K, N)), jnp.bfloat16)
+    group_sizes = jnp.asarray([13, 5, 17, 13], jnp.int32)  # non-uniform, sums to T
+    return lhs, rhs, group_sizes
+
+
+def test_op_none_matches_xla_reference():
+    """The default path (op=None) matches jax.lax.ragged_dot_general on non-uniform groups."""
+    lhs, rhs, gs = _fp8_inputs()
+    out = ragged_dot(lhs, rhs, gs, op=None)
+    ref = jax.lax.ragged_dot_general(
+        lhs=lhs,
+        rhs=rhs,
+        group_sizes=gs,
+        ragged_dot_dimension_numbers=jax.lax.RaggedDotDimensionNumbers(
+            dot_dimension_numbers=(((1,), (1,)), ((), ())),
+            lhs_ragged_dimensions=(0,),
+            rhs_group_dimensions=(0,),
+        ),
+    )
+    np.testing.assert_allclose(np.asarray(out), np.asarray(ref), rtol=2e-2, atol=2e-2)
+
+
+def test_op_routes_to_op_and_runs_end_to_end():
+    lhs, rhs, gs = _fp8_inputs()
+    op = Fp8RaggedDotOp.init(rev_dtype=jnp.float8_e4m3fn)
+    # The op is still a bf16 placeholder at this point; FP8 kernels land in later commits.
+    out = ragged_dot(lhs, rhs, gs, op=op)
+    ref = ragged_dot(lhs, rhs, gs, op=None)
+    assert out.shape == ref.shape
+    np.testing.assert_allclose(np.asarray(out), np.asarray(ref), rtol=2e-2, atol=2e-2)
+
+
+def test_op_with_explicit_implementation_raises():
+    lhs, rhs, gs = _fp8_inputs()
+    # Uniform rev_dtype so the op constructs on jax 0.10.x too; the dtype
+    # recipe is irrelevant to the dispatch contract under test.
+    op = Fp8RaggedDotOp.init(rev_dtype=jnp.float8_e4m3fn)
+    with pytest.raises(ValueError, match="mutually exclusive"):
+        ragged_dot(lhs, rhs, gs, implementation="xla", op=op)
+
+
+@pytest.mark.skipif(_jax_supports_mixed_fp8_wgmma(), reason="guard only fires on jax < 0.11.0")
+def test_init_mixed_rev_dtype_fails_fast_on_old_jax():
+    # On jax without mixed-dtype wgmma (jax-ml/jax#38859) the default mixed
+    # recipe must fail at init with an actionable error, not deep inside
+    # Mosaic lowering on the first backward pass.
+    with pytest.raises(ValueError, match="38859"):
+        Fp8RaggedDotOp.init()
+    # The uniform approximation stays constructible.
+    Fp8RaggedDotOp.init(rev_dtype=jnp.float8_e4m3fn)
+
+
+@pytest.mark.skipif(not _jax_supports_mixed_fp8_wgmma(), reason="mixed wgmma needs jax >= 0.11.0")
+def test_init_defaults_to_mixed_backward():
+    op = Fp8RaggedDotOp.init()
+    assert jnp.dtype(op.fwd_dtype) == jnp.dtype(jnp.float8_e4m3fn)
+    assert jnp.dtype(op.rev_dtype) == jnp.dtype(jnp.float8_e5m2)
+
+
+def test_op_state_partitions_as_overwrite():
+    """Fp8RaggedDotOp's scale/amax state goes to the overwrite partition, not the optimizer gradient."""
+    op = Fp8RaggedDotOp.init(amax_history_length=4, rev_dtype=jnp.float8_e4m3fn)
+    regular_param = jnp.array([1.0, 2.0])
+
+    # Partition a tree containing both the op and a regular parameter.
+    tree = {"op": op, "weight": regular_param}
+    overwrites, grads = partition_for_grad_overwrite(tree)
+
+    # The op (OverwriteWithGradient) lands in overwrites, not in grads.
+    assert isinstance(overwrites["op"], Fp8RaggedDotOp)
+    assert grads["op"] is None
+
+    # Regular parameters are not overwritten; they stay in the grad/optimizer partition.
+    assert overwrites["weight"] is None
+    np.testing.assert_array_equal(np.asarray(grads["weight"]), np.asarray(regular_param))


### PR DESCRIPTION
Adds `Fp8RaggedDotOp`, an analog of `Fp8DotGeneralOp` for ragged/grouped GEMMs, optimized for H100s. This is the FP8 analog of `haliax.nn.ragged_dot` currently used in MoE layers. Like `Fp8DotGeneralOp`, the new op uses delayed scaling with configurable `amax_history_length`, and supports mixed FP8 sub-formats for forward and backward: `rev_dtype` defaults to E5M2, the numerically correct output-gradient dtype ([recommended](https://arxiv.org/abs/2209.05433) by [NVIDIA](https://docs.nvidia.com/deeplearning/transformer-engine/user-guide/examples/fp8_primer.html)), so both backward GEMMs run as genuine mixed `e5m2 x e4m3` wgmma contractions.

Note: **the default mixed recipe requires a jax upgrade to >= 0.11.0** (which ships the mixed-wgmma support from https://github.com/jax-ml/jax/pull/38859, released 2026-07-16). On the repo's current jax 0.10.1 pin, `Fp8RaggedDotOp.init()` with defaults fails fast with an actionable error; passing `rev_dtype=jnp.float8_e4m3fn` recovers a uniform `e4m3 x e4m3` backward that lowers on 0.10.x (an approximation that trades output-gradient dynamic range for mantissa). The Hopper gradient tests version-skip on pre-0.11 jax, so CI is green on both sides of the upgrade.

This gives a 1.38× (w13) / 1.23× (w2) fwd+bwd speedup per GEMM relative to the tuned bf16 Triton baseline (D=2560, F=1280, 1280 tokens/expert; 1.35× / 1.20× at 1024 tokens/expert), or **~1.33× for the expert MLP** as a whole (flops-weighted combination of the two GEMMs). Speedups were measured with the uniform `e4m3` backward; the mixed `e5m2 x e4m3` backward has repeatedly measured within run-to-run variance of it, so the correct E5M2 gradient costs nothing.

This PR completes (other than wiring) end-to-end FP8 _compute_ for MoE layers. FP8 comms and MoE layer config wiring are left for future PRs.

Tracking issue: #6699

## Merge order

1. The jax >= 0.11.0 upgrade (for the default mixed backward; the op itself imports and dispatches fine on 0.10.x).
2. This PR (#6880).
3. #7079: wires FP8 end-to-end into the grug MoE (expert and dense GEMMs, wire collectives, config, train step) on top.

(#7433, a previously stacked mixed-backward follow-up, was folded into this PR and closed.)

## Review notes

This branch is structured as a sequence of self-contained commits. The initial commit (80d66d0d) adds a "fake" bf16 implementation of `Fp8RaggedDotOp`; the remaining commits progressively move computation to FP8 and apply optimizations, generally trading off simplicity for performance.

### Per-commit benchmarks

MoE block speedup vs the tuned bf16 Triton baseline, H100, at the d=2560 operating point (E_local=64, tokens/expert=1280; w13: `[T,2560]×[E,2560,2560]`, w2: `[T,1280]×[E,1280,2560]`; throughput timing, 20 iters).

| Commit | Summary | fwd (w13 / w2) | fwd+bwd (w13 / w2) |
|---|---|---|---|
| 80d66d0d | `Fp8RaggedDotOp` + `op=` opt-in (bf16 placeholder) | 1.01 / 1.00 | 1.00 / 1.00 |
| d995b09b | FP8 e4m3 forward, bf16 backward | 1.02 / 0.96 | 1.01 / 0.98 |
| 7b7f6aa4 | Autotuned forward block config | 1.09 / 1.02 | 1.02 / 1.00 |
| d9373659 | Fused cast-transpose+amax quantize (both layouts, one read) | 1.02 / 0.95 | 1.01 / 0.99 |
| 7211a528 | FP8 dgrad (grad_lhs) | 1.02 / 0.96 | 1.21 / 1.10 |
| dd79f31d | FP8 wgrad — all three GEMMs on FP8 | 1.02 / 0.95 | 1.35 / 1.22 |
| 3923206c | Wgrad boundary appendix replaces the in-SMEM group mask | 1.02 / 0.95 | 1.38 / 1.23 |

Backward-bearing rows were benchmarked with the uniform `e4m3` backward (`--rev-dtype e4m3` on the bench); mixed measures within run-to-run variance.

Note: Forward-only perf dips at the fused cast-transpose commit (d9373659) because it begins writing the second (transposed) FP8 layout that only pays off once FP8 wgrad consumes it; this enables backward perf gains landing in the dgrad/wgrad commits.

Part of #6710.
