### PR TITLE
[ducky] Record submitted queries to finelog

### DIFF
--- a/lib/ducky/README.md
+++ b/lib/ducky/README.md
@@ -63,6 +63,19 @@ print(result["columns"], result["rows"])
 `gcloud auth print-identity-token --audiences=$AUD` mints the same token for a service-account
 credential. `Proxy-Authorization: Bearer …` works interchangeably with `Authorization`.
 
+## Query log
+
+Every submitted query is recorded to finelog under ducky's own namespace, `ducky.query` —
+one row per query with its SQL text and terminal outcome (`status`, `cached`, `elapsed_ms`,
+`total_rows`, `result_bytes`, `result_path`, `error`). It's a durable, queryable record of
+what runs through ducky, so the query mix can be reviewed later for hot paths and
+optimization opportunities. Writes are fire-and-forget (finelog buffers on a background
+thread and swallows transport failures), so logging never blocks or fails a user's query;
+if there's no in-cluster finelog endpoint it's disabled with a warning. The namespace is
+itself queryable via the pre-baked `finelog."ducky.query"` view (see the **ducky query
+history** example) — note the view only materializes once at least one segment exists and
+ducky has (re)started to bind it.
+
 ## Pre-baked views & queries
 
 ducky ships a small catalog of named views over common Marin data sources, plus
@@ -72,7 +85,7 @@ are ordinary DuckDB views, so you can `SELECT` from them without spelling out a
 
 - **finelog** (`finelog.log`, `finelog."iris.task"`, `finelog."iris.worker"`,
   `finelog."iris.task_status"`, `finelog."iris.profile"`, `finelog."iris.provisioning"`,
-  `finelog."zephyr.stage"`, `finelog."zephyr.worker"`) over
+  `finelog."zephyr.stage"`, `finelog."zephyr.worker"`, `finelog."ducky.query"`) over
   `DUCKY_FINELOG_ROOT/<namespace>/seg_L*.parquet`. The namespace directory names contain
   dots, so quote them: `SELECT * FROM finelog."iris.task"`.
 - **datakit** normalized parquet — a curated subset (`datakit.finetranslations`,

--- a/lib/ducky/src/ducky/catalog.py
+++ b/lib/ducky/src/ducky/catalog.py
@@ -46,6 +46,7 @@ _FINELOG_NAMESPACES: tuple[tuple[str, str], ...] = (
     ("iris.provisioning", "Slice provisioning outcomes (ready/stockout/error/preempted)."),
     ("zephyr.stage", "Per-stage completion stats: throughput + aggregated resource usage."),
     ("zephyr.worker", "Per-shard stats emitted at start / sample interval / end."),
+    ("ducky.query", "Every SQL query submitted to ducky: text, outcome, and cost (rows/bytes/elapsed)."),
 )
 
 # Curated datakit normalized datasets (view name, step-name path segment, description).
@@ -164,6 +165,13 @@ def _finelog_examples(views: list[View]) -> list[ExampleQuery]:
             "Completed zephyr stages ranked by byte rate.",
             f"SELECT execution_id, stage_name, status, elapsed, items, item_rate, byte_rate\n"
             f"FROM {by_name['zephyr.stage']}\nORDER BY ts DESC\nLIMIT 100",
+        ),
+        ExampleQuery(
+            "ducky query history",
+            "Recent queries submitted to ducky with their cost — the log ducky keeps of itself. "
+            "Sort by elapsed_ms or result_bytes to find the expensive ones worth optimizing.",
+            f"SELECT ts, status, cached, elapsed_ms, total_rows, result_bytes, left(sql, 200) AS sql\n"
+            f"FROM {by_name['ducky.query']}\nORDER BY ts DESC\nLIMIT 100",
         ),
     ]
 

--- a/lib/ducky/src/ducky/query_log.py
+++ b/lib/ducky/src/ducky/query_log.py
@@ -1,0 +1,116 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Persist every submitted query to a finelog namespace (``ducky.query``).
+
+ducky records one row per submitted query — the SQL text plus its terminal
+outcome and cost (rows, bytes, wall-clock, cache hit) — to finelog under its own
+namespace. The result is a durable, queryable log of what ran through ducky, so
+the query mix can be reviewed later for hot paths and optimization opportunities.
+The namespace is itself queryable from the dashboard via the pre-baked
+``finelog."ducky.query"`` view (see ``catalog.py``).
+
+Writes are fire-and-forget: finelog's ``Table`` buffers rows on a background
+flush thread and swallows transport failures, so a finelog outage never blocks
+or fails a user's query. Recording is best-effort by design.
+"""
+
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from datetime import datetime
+from typing import ClassVar
+
+from finelog.client import LogClient, StoragePolicy, Table
+from iris.client.client import IrisContext
+from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
+from rigging.timing import Timestamp
+
+logger = logging.getLogger(__name__)
+
+QUERY_LOG_NAMESPACE = "ducky.query"
+
+# ducky's query log is an audit / optimization record, so it is kept far longer
+# than the transient iris.* stats namespaces: ~180 days, capped at 2 GiB (rows are
+# small — SQL text plus a handful of scalars, so this holds many millions of them).
+# Both caps are explicit so retention is deterministic regardless of the cluster-wide
+# compaction defaults.
+QUERY_LOG_STORAGE_POLICY = StoragePolicy(
+    max_bytes=2 * 1024 * 1024 * 1024,
+    max_age_seconds=180 * 86400,
+)
+
+
+@dataclass
+class QueryLogRow:
+    """One row per submitted query: the SQL and its terminal outcome/cost.
+
+    ``ts`` is when the query reached a terminal state (done/error); it keys the
+    finelog segments so time-range analytics prune to a few row groups. Cost
+    columns are ``None`` for a failed query; ``error`` is ``None`` for a
+    successful one. ``cached`` marks a submission served from ducky's in-memory
+    result cache (no DuckDB execution).
+    """
+
+    key_column: ClassVar[str] = "ts"
+
+    ts: datetime  # tz-naive UTC (see now_utc)
+    query_id: str
+    sql: str
+    status: str
+    cached: bool
+    elapsed_ms: int | None = None
+    total_rows: int | None = None
+    result_bytes: int | None = None
+    result_path: str | None = None
+    error: str | None = None
+
+
+class QueryLog:
+    """Records submitted queries to the ``ducky.query`` finelog namespace.
+
+    Wraps a finelog ``Table`` whose background flush thread does the network I/O;
+    :meth:`record` only enqueues a row and never raises, so it is safe to call on
+    the query manager's hot path.
+    """
+
+    def __init__(self, log_client: LogClient, table: Table) -> None:
+        self._log_client = log_client
+        self._table = table
+
+    @classmethod
+    def connect(cls, ctx: IrisContext) -> QueryLog:
+        """Open a finelog client against the cluster log server and bind the table.
+
+        Resolves the finelog endpoint through ``ctx.client`` (an in-cluster iris
+        client that returns the log server's direct address, bypassing the
+        controller proxy). The namespace is registered lazily by the Table's
+        flush thread on its first write, so this never blocks on the server.
+        """
+        if ctx.client is None:
+            raise RuntimeError("QueryLog requires an in-cluster iris client to resolve the finelog endpoint")
+        log_client = LogClient.connect(LOG_SERVER_ENDPOINT_NAME, resolver=ctx.client.resolve_endpoint)
+        table = log_client.get_table(QUERY_LOG_NAMESPACE, QueryLogRow, storage_policy=QUERY_LOG_STORAGE_POLICY)
+        return cls(log_client, table)
+
+    def record(self, row: QueryLogRow) -> None:
+        """Enqueue one query record.
+
+        Best-effort telemetry on the query hot path: a failure here (e.g. the
+        table closed mid-shutdown) must never surface to the caller running the
+        query, so it is logged and swallowed rather than raised.
+        """
+        try:
+            self._table.write([row])
+        except Exception:
+            logger.warning("failed to enqueue query-log row for %s", row.query_id, exc_info=True)
+
+    def close(self) -> None:
+        """Drain the table's flush thread and close the finelog client."""
+        self._log_client.close()
+
+
+def now_utc() -> datetime:
+    """Current tz-naive UTC datetime for the ``ts`` segment key (matches iris stats)."""
+    return Timestamp.now().as_naive_utc()

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -41,6 +41,7 @@ from starlette.staticfiles import StaticFiles
 
 from ducky.catalog import Catalog, build_catalog
 from ducky.config import ENDPOINT_NAME, PORT_NAME, DuckyConfig
+from ducky.query_log import QueryLog, QueryLogRow, now_utc
 from ducky.runner import DuckyError, QueryResult, QueryRunner
 
 logger = logging.getLogger(__name__)
@@ -93,8 +94,13 @@ class QueryManager:
         cache_ttl: float = 0.0,
         max_retained_states: int = 1024,
         max_cache_entries: int = 256,
+        query_log: QueryLog | None = None,
     ) -> None:
         self._runner = runner
+        # Optional finelog sink: every submitted query (done, error, or cache hit) is
+        # recorded to the `ducky.query` namespace for later analysis. None disables it
+        # (tests, and any deploy without an in-cluster finelog endpoint).
+        self._query_log = query_log
         self._executor = executor or ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ducky-query")
         # Bounded LRU maps: an always-on service would otherwise grow the heap unbounded,
         # since each result retains up to preview_row_cap rows. Oldest entries are evicted;
@@ -125,19 +131,25 @@ class QueryManager:
         served earlier returns instantly from the cache; pass ``use_cache=False`` to force a
         fresh run (e.g. when the underlying data changed) — it still refreshes the cache."""
         query_id = uuid.uuid4().hex
+        hit_state: QueryState | None = None
         with self._lock:
             cached = self._cached_result(sql) if use_cache else None
             if cached is not None:
-                self._set_state(query_id, QueryState(QueryStatus.DONE, result=cached, cached=True))
-                logger.info(
-                    "query %s cache hit (%d rows, %s): %s",
-                    query_id,
-                    cached.total_rows,
-                    _human_bytes(cached.result_bytes),
-                    _log_sql(sql),
-                )
-                return query_id
-            self._set_state(query_id, QueryState(QueryStatus.RUNNING))
+                hit_state = QueryState(QueryStatus.DONE, result=cached, cached=True)
+                self._set_state(query_id, hit_state)
+            else:
+                self._set_state(query_id, QueryState(QueryStatus.RUNNING))
+        if hit_state is not None:
+            assert cached is not None
+            logger.info(
+                "query %s cache hit (%d rows, %s): %s",
+                query_id,
+                cached.total_rows,
+                _human_bytes(cached.result_bytes),
+                _log_sql(sql),
+            )
+            self._record(query_id, sql, hit_state)
+            return query_id
         logger.info("query %s submitted: %s", query_id, _log_sql(sql))
         self._executor.submit(self._run, sql, query_id)
         return query_id
@@ -168,13 +180,17 @@ class QueryManager:
             result = self._runner.run_query(sql, query_id)
         except DuckyError as e:
             logger.warning("query %s failed: %s", query_id, str(e).splitlines()[0])
+            error_state = QueryState(QueryStatus.ERROR, error=str(e))
             with self._lock:
-                self._set_state(query_id, QueryState(QueryStatus.ERROR, error=str(e)))
+                self._set_state(query_id, error_state)
+            self._record(query_id, sql, error_state)
             return
         except Exception as e:  # background task: record instead of hanging in RUNNING forever
             logger.exception("query %s crashed", query_id)
+            error_state = QueryState(QueryStatus.ERROR, error=f"internal error: {e}")
             with self._lock:
-                self._set_state(query_id, QueryState(QueryStatus.ERROR, error=f"internal error: {e}"))
+                self._set_state(query_id, error_state)
+            self._record(query_id, sql, error_state)
             return
         logger.info(
             "query %s done: %d rows, %s, %d ms",
@@ -183,9 +199,31 @@ class QueryManager:
             _human_bytes(result.result_bytes),
             result.elapsed_ms,
         )
+        done_state = QueryState(QueryStatus.DONE, result=result, cached=False)
         with self._lock:
             self._store_cache(sql, result)
-            self._set_state(query_id, QueryState(QueryStatus.DONE, result=result, cached=False))
+            self._set_state(query_id, done_state)
+        self._record(query_id, sql, done_state)
+
+    def _record(self, query_id: str, sql: str, state: QueryState) -> None:
+        """Persist one terminal query state to the finelog query log (best-effort no-op if disabled)."""
+        if self._query_log is None:
+            return
+        result = state.result
+        self._query_log.record(
+            QueryLogRow(
+                ts=now_utc(),
+                query_id=query_id,
+                sql=sql,
+                status=state.status.value,
+                cached=state.cached,
+                elapsed_ms=result.elapsed_ms if result is not None else None,
+                total_rows=result.total_rows if result is not None else None,
+                result_bytes=result.result_bytes if result is not None else None,
+                result_path=result.result_path if result is not None else None,
+                error=state.error,
+            )
+        )
 
     def shutdown(self) -> None:
         self._executor.shutdown(wait=False)
@@ -270,10 +308,16 @@ def _catalog_payload(catalog: Catalog) -> dict:
     }
 
 
-def create_app(runner: QueryRunner, config: DuckyConfig, executor: Executor | None = None) -> Starlette:
+def create_app(
+    runner: QueryRunner,
+    config: DuckyConfig,
+    executor: Executor | None = None,
+    query_log: QueryLog | None = None,
+) -> Starlette:
     """Build the ducky Starlette app over a query runner. No Iris context required.
 
     ``executor`` overrides the query executor (tests inject a synchronous one).
+    ``query_log``, when given, records every submitted query to finelog.
     """
     dist = _dashboard_dist()
     # Advertise only the views the runner actually created — an absent dataset or a root
@@ -284,6 +328,7 @@ def create_app(runner: QueryRunner, config: DuckyConfig, executor: Executor | No
         executor=executor,
         max_workers=config.max_concurrent_queries,
         cache_ttl=config.result_ttl_days * 86400,
+        query_log=query_log,
     )
 
     @requires_auth
@@ -352,12 +397,19 @@ def _serve() -> None:
     logging.getLogger("uvicorn.access").addFilter(_QuietPolls())
     config = DuckyConfig.from_environment()
     runner = QueryRunner(config)
-    app = create_app(runner, config)
 
     ctx = iris_ctx()
     job_info = get_job_info()
     if job_info is None:
         raise RuntimeError("No Iris job info available — ducky must run inside an Iris job")
+
+    # Persist submitted queries to finelog (best-effort). Needs an in-cluster iris client to
+    # resolve the log server; if absent (e.g. a standalone smoke), skip the sink rather than fail.
+    query_log = QueryLog.connect(ctx) if ctx.client is not None else None
+    if query_log is None:
+        logger.warning("no in-cluster iris client — query logging to finelog disabled")
+    app = create_app(runner, config, query_log=query_log)
+
     port = ctx.get_port(PORT_NAME)
     address = f"http://{job_info.advertise_host}:{port}"
 
@@ -367,6 +419,8 @@ def _serve() -> None:
     async def _on_shutdown() -> None:
         ctx.registry.unregister(endpoint_id)
         app.state.query_manager.shutdown()
+        if query_log is not None:
+            query_log.close()
         logger.info("ducky endpoint unregistered")
 
     app.router.lifespan_context = on_shutdown(_on_shutdown)

--- a/lib/ducky/tests/test_query_log.py
+++ b/lib/ducky/tests/test_query_log.py
@@ -1,0 +1,48 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+from datetime import datetime
+
+from ducky.query_log import QUERY_LOG_NAMESPACE, QueryLog, QueryLogRow, now_utc
+from finelog.client.log_client import schema_from_dataclass
+
+
+def test_row_is_a_valid_finelog_schema():
+    """QueryLogRow must infer a finelog schema, else registration/writes silently fail."""
+    schema = schema_from_dataclass(QueryLogRow)
+    assert schema.key_column == "ts"  # segments keyed on time for range-scan pruning
+    by_name = {c.name: c for c in schema.columns}
+    assert set(by_name) == {
+        "ts",
+        "query_id",
+        "sql",
+        "status",
+        "cached",
+        "elapsed_ms",
+        "total_rows",
+        "result_bytes",
+        "result_path",
+        "error",
+    }
+    assert all(c.nullable for c in schema.columns)  # finelog registers every column nullable
+
+
+def test_now_utc_is_naive():
+    assert now_utc().tzinfo is None
+    assert isinstance(now_utc(), datetime)
+
+
+def test_record_swallows_table_write_failures():
+    """A finelog write blowing up must not propagate to the query path."""
+
+    class _BoomTable:
+        def write(self, rows):
+            raise RuntimeError("finelog down")
+
+    log = QueryLog(log_client=None, table=_BoomTable())  # type: ignore[arg-type]
+    row = QueryLogRow(ts=now_utc(), query_id="a" * 32, sql="SELECT 1", status="done", cached=False)
+    log.record(row)  # does not raise
+
+
+def test_namespace_is_dotted():
+    assert QUERY_LOG_NAMESPACE == "ducky.query"

--- a/lib/ducky/tests/test_query_log.py
+++ b/lib/ducky/tests/test_query_log.py
@@ -3,7 +3,7 @@
 
 from datetime import datetime
 
-from ducky.query_log import QUERY_LOG_NAMESPACE, QueryLog, QueryLogRow, now_utc
+from ducky.query_log import QueryLog, QueryLogRow, now_utc
 from finelog.client.log_client import schema_from_dataclass
 
 
@@ -42,7 +42,3 @@ def test_record_swallows_table_write_failures():
     log = QueryLog(log_client=None, table=_BoomTable())  # type: ignore[arg-type]
     row = QueryLogRow(ts=now_utc(), query_id="a" * 32, sql="SELECT 1", status="done", cached=False)
     log.record(row)  # does not raise
-
-
-def test_namespace_is_dotted():
-    assert QUERY_LOG_NAMESPACE == "ducky.query"

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -256,41 +256,44 @@ class _RecordingQueryLog:
         self.rows.append(row)
 
 
-def test_successful_query_is_recorded_with_cost():
+class _ScriptedRunner:
+    """Returns a result or raises, chosen by the SQL text; counts real executions."""
+
+    def __init__(self, results: dict, errors: dict):
+        self._results = results
+        self._errors = errors
+        self.created_view_names: frozenset[str] = frozenset()
+        self.calls = 0
+
+    def run_query(self, sql: str, query_id: str) -> QueryResult:
+        self.calls += 1
+        if sql in self._errors:
+            raise self._errors[sql]
+        return self._results[sql]
+
+
+def test_every_submission_is_recorded():
+    """One row per submission — a run (with cost), a cache hit, and an error — is logged."""
     log = _RecordingQueryLog()
-    runner = _FakeRunner(QueryResult(["x"], [[1]], 7, False, "gs://b/ducky/q.parquet", 50, 99))
+    runner = _ScriptedRunner(
+        results={"SELECT 1": QueryResult(["x"], [[1]], 7, False, "gs://b/ducky/q.parquet", 50, 99)},
+        errors={"SELECT * FROM nope": QueryError("Catalog Error: table not found")},
+    )
     manager = QueryManager(runner, executor=_InlineExecutor(), query_log=log)
 
-    query_id = manager.submit("SELECT 1")
+    manager.submit("SELECT 1")  # executed → done, cached=False, with cost
+    manager.submit("SELECT 1")  # cache hit → done, cached=True
+    manager.submit("SELECT * FROM nope")  # error
 
-    (row,) = log.rows
-    assert (row.query_id, row.sql, row.status, row.cached) == (query_id, "SELECT 1", "done", False)
-    assert (row.total_rows, row.result_bytes, row.elapsed_ms) == (7, 99, 50)
-    assert row.result_path == "gs://b/ducky/q.parquet"
-    assert row.error is None
+    assert runner.calls == 2  # SELECT 1 + the error query; the repeated SELECT 1 was cached, not re-run
 
+    done, cached, error = log.rows
+    assert (done.sql, done.status, done.cached, done.error) == ("SELECT 1", "done", False, None)
+    assert (done.total_rows, done.result_bytes, done.elapsed_ms) == (7, 99, 50)
+    assert done.result_path == "gs://b/ducky/q.parquet"
 
-def test_failed_query_is_recorded_with_error():
-    log = _RecordingQueryLog()
-    runner = _FakeRunner(error=QueryError("Catalog Error: table not found"))
-    manager = QueryManager(runner, executor=_InlineExecutor(), query_log=log)
+    assert (cached.status, cached.cached) == ("done", True)
+    assert cached.result_path == "gs://b/ducky/q.parquet"  # reuses the spilled result
 
-    manager.submit("SELECT * FROM nope")
-
-    (row,) = log.rows
-    assert row.status == "error"
-    assert row.error == "Catalog Error: table not found"
-    assert row.total_rows is None and row.result_bytes is None and row.result_path is None
-
-
-def test_cache_hit_is_recorded_as_cached():
-    log = _RecordingQueryLog()
-    runner = _CountingRunner(QueryResult(["x"], [[1]], 1, False, "gs://b/x.parquet", 1, 1))
-    manager = QueryManager(runner, executor=_InlineExecutor(), query_log=log)
-
-    manager.submit("SELECT 1")  # executed + recorded (cached=False)
-    manager.submit("SELECT 1")  # cache hit + recorded (cached=True)
-
-    assert runner.calls == 1
-    assert [r.cached for r in log.rows] == [False, True]
-    assert {r.status for r in log.rows} == {"done"}
+    assert (error.status, error.cached, error.error) == ("error", False, "Catalog Error: table not found")
+    assert error.total_rows is None and error.result_bytes is None and error.result_path is None

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -244,3 +244,53 @@ def test_cache_entry_expires_after_ttl():
     manager._cache["SELECT 2"] = (result, time.monotonic())  # fresh
     assert manager._cached_result("SELECT 1") is None
     assert manager._cached_result("SELECT 2") is result
+
+
+class _RecordingQueryLog:
+    """Captures the rows a QueryManager would persist to finelog (duck-types QueryLog.record)."""
+
+    def __init__(self):
+        self.rows = []
+
+    def record(self, row):
+        self.rows.append(row)
+
+
+def test_successful_query_is_recorded_with_cost():
+    log = _RecordingQueryLog()
+    runner = _FakeRunner(QueryResult(["x"], [[1]], 7, False, "gs://b/ducky/q.parquet", 50, 99))
+    manager = QueryManager(runner, executor=_InlineExecutor(), query_log=log)
+
+    query_id = manager.submit("SELECT 1")
+
+    (row,) = log.rows
+    assert (row.query_id, row.sql, row.status, row.cached) == (query_id, "SELECT 1", "done", False)
+    assert (row.total_rows, row.result_bytes, row.elapsed_ms) == (7, 99, 50)
+    assert row.result_path == "gs://b/ducky/q.parquet"
+    assert row.error is None
+
+
+def test_failed_query_is_recorded_with_error():
+    log = _RecordingQueryLog()
+    runner = _FakeRunner(error=QueryError("Catalog Error: table not found"))
+    manager = QueryManager(runner, executor=_InlineExecutor(), query_log=log)
+
+    manager.submit("SELECT * FROM nope")
+
+    (row,) = log.rows
+    assert row.status == "error"
+    assert row.error == "Catalog Error: table not found"
+    assert row.total_rows is None and row.result_bytes is None and row.result_path is None
+
+
+def test_cache_hit_is_recorded_as_cached():
+    log = _RecordingQueryLog()
+    runner = _CountingRunner(QueryResult(["x"], [[1]], 1, False, "gs://b/x.parquet", 1, 1))
+    manager = QueryManager(runner, executor=_InlineExecutor(), query_log=log)
+
+    manager.submit("SELECT 1")  # executed + recorded (cached=False)
+    manager.submit("SELECT 1")  # cache hit + recorded (cached=True)
+
+    assert runner.calls == 1
+    assert [r.cached for r in log.rows] == [False, True]
+    assert {r.status for r in log.rows} == {"done"}


### PR DESCRIPTION
* record every submitted query to finelog under ducky's own namespace, `ducky.query`
* one row per query — `sql` text plus terminal outcome/cost: `status`, `cached`, `elapsed_ms`, `total_rows`, `result_bytes`, `result_path`, `error` — as a durable, queryable record of what runs through ducky, to later spot hot paths / optimization targets
* `QueryManager` records on every terminal state: success (`done`), failure (`error`), and cache hit [^1]
* new `ducky/query_log.py`: `QueryLog` wraps a finelog `Table`; `QueryLogRow` is the schema; `connect(ctx)` resolves `/system/log-server` via the in-cluster iris client [^2]
  * writes are fire-and-forget — finelog buffers on a bg flush thread and swallows transport failures, so `record()` never blocks or fails a user's query
  * disabled with a warning when there's no in-cluster iris client (e.g. standalone smoke)
* retention is explicit ~180 days / 2 GiB — an audit/optimization record, kept far longer than the transient `iris.*` stats namespaces
* queryable from the dashboard via the pre-baked `finelog."ducky.query"` view + a `ducky query history` example query [^3]

[^1]: only queries that reach a terminal state are recorded; a query still `RUNNING` when the server process dies (OOM-kill / task restart mid-flight) is not — the 600s `query_timeout` is captured as an `error`
[^2]: no auth interceptors needed in-cluster, matching iris's own in-cluster task-status writes; ducky owns its own `LogClient`
[^3]: finelog views bind at startup, so the view materializes only once a first segment exists and ducky (re)starts to bind it
