### PR TITLE
[execution] adopt pre-#6649 bare .artifact.json as result payload

### DIFF
--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -206,6 +206,30 @@ def _record_from_executor_info(text: str) -> ArtifactRecord:
     )
 
 
+# Record-native identity fields a genuine ArtifactRecord sets; a pre-#6649 bare payload has none.
+_RECORD_IDENTITY_FIELDS = ("name", "fingerprint", "result_type", "result")
+_RECORD_FIELDS = frozenset(ArtifactRecord.model_fields)
+
+
+def _parse_record(text: str) -> ArtifactRecord:
+    """Parse an ``.artifact.json``, adopting a pre-#6649 bare payload as the record's ``result``.
+
+    Before #6649 the value model was serialized straight into ``.artifact.json`` (e.g.
+    ``{"version": "v1", "output_dir": ..., "counters": ...}``), so it parses as an
+    :class:`ArtifactRecord` with every native field defaulted and the real payload dropped as
+    ignored extras — leaving ``read_artifact`` with no ``result``. Detect that shape (no record
+    identity, but keys foreign to the record schema) and take the whole document as ``result`` so
+    those caches load. A genuine record never carries foreign keys, so it is untouched.
+    """
+    record = ArtifactRecord.model_validate_json(text)
+    if any(getattr(record, field) for field in _RECORD_IDENTITY_FIELDS):
+        return record
+    document = json.loads(text)
+    if isinstance(document, dict) and document.keys() - _RECORD_FIELDS:
+        return ArtifactRecord(result=document)
+    return record
+
+
 def read_record(output_path: str) -> ArtifactRecord | None:
     """The record at ``{output_path}/.artifact.json``, else ``None``.
 
@@ -216,7 +240,7 @@ def read_record(output_path: str) -> ArtifactRecord | None:
     output_path = _resolved(output_path)
     text = _read_text(output_path, RECORD_FILENAME)
     if text is not None:
-        return ArtifactRecord.model_validate_json(text)
+        return _parse_record(text)
     executor_info = _read_text(output_path, _LEGACY_EXECUTOR_INFO_FILENAME)
     if executor_info is not None:
         return _record_from_executor_info(executor_info)

--- a/tests/execution/test_artifact.py
+++ b/tests/execution/test_artifact.py
@@ -208,3 +208,39 @@ def test_read_record_prefers_modern_record_over_executor_info(tmp_path):
     record = read_record(tmp_path.as_posix())
     assert record.name == "modern"
     assert record.config == {"tokenizer": "gpt2"}
+
+
+# --- the pre-#6649 bare-payload .artifact.json ---------------------------------
+
+# Before #6649 the value model was serialized straight into ``.artifact.json`` with no record
+# wrapper: every payload field sits at top level and there is no name/fingerprint/result_type/result.
+_LEGACY_BARE_PAYLOAD = json.dumps(
+    {"version": "v1", "output_dir": "gs://bucket/datakit/embed/cp/peps_52c03790", "counters": {"rows": 128}}
+)
+
+
+class _EmbedPayload(BaseModel):
+    version: str
+    output_dir: str
+    counters: dict
+
+
+def test_read_artifact_adopts_pre_6649_bare_payload(tmp_path):
+    """A pre-#6649 bare ``.artifact.json`` loads: the whole document becomes the result payload."""
+    (tmp_path / ".artifact.json").write_text(_LEGACY_BARE_PAYLOAD)
+
+    loaded = read_artifact(tmp_path.as_posix(), _EmbedPayload)
+    assert loaded == _EmbedPayload(
+        version="v1", output_dir="gs://bucket/datakit/embed/cp/peps_52c03790", counters={"rows": 128}
+    )
+
+
+def test_read_record_leaves_a_genuine_data_record_untouched(tmp_path):
+    """A modern record with identity but no ``result`` is not mistaken for a bare payload."""
+    (tmp_path / ".artifact.json").write_text(
+        '{"name": "datasets/x", "version": "v1", "fingerprint": "abc", "result": null}'
+    )
+
+    record = read_record(tmp_path.as_posix())
+    assert record.name == "datasets/x"
+    assert record.result is None


### PR DESCRIPTION
Restore reads of value artifacts written before #6649.

Before #6649 `Artifact.save` serialized the value model straight into `.artifact.json` with no record wrapper, so the current `read_record` parsed it as an `ArtifactRecord` with `result=None` and the real payload dropped as ignored extras. `read_artifact` then raised `FileNotFoundError: no artifact payload` on caches that visibly hold data and a `SUCCESS` marker, and the missing `result_type` bypassed the drift/version gate so the step was pruned as already-succeeded instead of rebuilt.

`read_record` now detects a legacy bare payload — no record identity (`name`/`fingerprint`/`result_type`/`result` all empty) yet carrying keys foreign to `ArtifactRecord` — and adopts the whole document as the record's `result`, restoring every pre-#6649 value cache with zero data movement. Genuine records never carry foreign keys, so they are untouched.

Closes #6888.
