### PR TITLE
execution: don't serve a schedule-time StepRunner .executor_info stub as a record

### DIFF
--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -51,6 +51,13 @@ RECORD_FILENAME = ".artifact.json"
 # so we read it as a last resort to recover the record. Never written.
 _LEGACY_EXECUTOR_INFO_FILENAME = ".executor_info"
 
+# The lazy ``StepRunner`` also writes a ``.executor_info`` — but at *schedule* time, before the
+# step runs — tagged with this ``executor_version``. Unlike a genuine legacy Ray sidecar, its
+# ``config`` is the identity ``hash_attrs`` (deps/fingerprint/version), not the materialized
+# config. ``read_record`` ignores it so an incomplete step's stub can never be served as a
+# record — which would present, e.g., a tokenizer-less tokenized cache (#6836).
+STEP_RUNNER_EXECUTOR_VERSION = "step_runner"
+
 # Keys under ``StepSpec.hash_attrs`` carrying the artifact's identity, so the runner can
 # apply the drift check without knowing about the lazy layer.
 FINGERPRINT_KEY = "fingerprint"
@@ -189,15 +196,22 @@ def _read_text(output_path: str, filename: str) -> str | None:
         return f.read()
 
 
-def _record_from_executor_info(text: str) -> ArtifactRecord:
+def _record_from_executor_info(text: str) -> ArtifactRecord | None:
     """Map an old Ray executor ``.executor_info`` sidecar into an :class:`ArtifactRecord`.
 
     Only the fields a consumer reads back are carried across: ``name``, the materialized
     ``config`` (where a tokenized cache keeps its tokenizer/format/tags), ``output_path``, and
     ``dependencies`` (recorded as output paths, not ``name@version``). The legacy ``version`` is a
     per-dependency dict rather than a string, so it is dropped rather than coerced.
+
+    Returns ``None`` for a schedule-time ``StepRunner`` stub (``executor_version`` is
+    ``STEP_RUNNER_EXECUTOR_VERSION``): that file predates the step's own record and carries only
+    the identity ``hash_attrs`` under ``config``, so serving it would present a config-less (e.g.
+    tokenizer-less) record for a cache that may never have finished (#6836).
     """
     info = json.loads(text)
+    if info.get("executor_version") == STEP_RUNNER_EXECUTOR_VERSION:
+        return None
     return ArtifactRecord(
         name=info.get("name") or "",
         config=info.get("config"),
@@ -233,9 +247,11 @@ def _parse_record(text: str) -> ArtifactRecord:
 def read_record(output_path: str) -> ArtifactRecord | None:
     """The record at ``{output_path}/.artifact.json``, else ``None``.
 
-    Falls back to an old Ray executor ``.executor_info`` sidecar when no record file is present, so
-    caches built before the record file existed still resolve their config. A corrupt/partial file
-    raises :class:`pydantic.ValidationError`.
+    Falls back to a genuine legacy Ray executor ``.executor_info`` sidecar when no record file is
+    present, so caches built before the record file existed still resolve their config. A
+    schedule-time ``StepRunner`` stub (see :data:`STEP_RUNNER_EXECUTOR_VERSION`) is *not* honored:
+    it carries no materialized config, so such an output reads back as having no record. A
+    corrupt/partial file raises :class:`pydantic.ValidationError`.
     """
     output_path = _resolved(output_path)
     text = _read_text(output_path, RECORD_FILENAME)

--- a/lib/marin/src/marin/execution/step_runner.py
+++ b/lib/marin/src/marin/execution/step_runner.py
@@ -29,7 +29,14 @@ from fray.types import Entrypoint, JobRequest, ResourceConfig, create_environmen
 from rigging.filesystem import open_url, url_to_fs
 from rigging.log_setup import configure_logging
 
-from marin.execution.artifact import FINGERPRINT_KEY, VERSION_KEY, check_drift, is_mutable_version, write_artifact
+from marin.execution.artifact import (
+    FINGERPRINT_KEY,
+    STEP_RUNNER_EXECUTOR_VERSION,
+    VERSION_KEY,
+    check_drift,
+    is_mutable_version,
+    write_artifact,
+)
 from marin.execution.remote import RemoteCallable, _sanitize_job_name
 from marin.execution.step_spec import StepSpec
 
@@ -60,13 +67,18 @@ def _write_executor_info(step: StepSpec) -> None:
 
     Skips writing if the file already exists (e.g. ``Executor.write_infos()``
     wrote a richer version before this step launched).
+
+    This runs at schedule time, before the step produces its ``.artifact.json``, and its
+    ``config`` is the identity ``hash_attrs`` — not the materialized config. It is tagged
+    ``STEP_RUNNER_EXECUTOR_VERSION`` so ``read_record`` ignores it as a record source and never
+    mistakes the stub for a completed cache (#6836).
     """
     info_path = os.path.join(step.output_path, ".executor_info")
     fs = url_to_fs(info_path, use_listings_cache=False)[0]
     if fs.exists(info_path):
         return
     info = {
-        "executor_version": "step_runner",
+        "executor_version": STEP_RUNNER_EXECUTOR_VERSION,
         "name": step.name,
         "fn_name": str(step.fn) if step.fn is not None else "None",
         "config": step.hash_attrs,

--- a/tests/execution/test_artifact.py
+++ b/tests/execution/test_artifact.py
@@ -244,3 +244,26 @@ def test_read_record_leaves_a_genuine_data_record_untouched(tmp_path):
     record = read_record(tmp_path.as_posix())
     assert record.name == "datasets/x"
     assert record.result is None
+
+
+# --- the schedule-time StepRunner .executor_info stub --------------------------
+
+# A schedule-time ``StepRunner`` stub: same filename, but ``executor_version == "step_runner"`` and
+# a ``config`` that is the identity ``hash_attrs`` (no materialized tokenizer/format/tags).
+_STEP_RUNNER_STUB = json.dumps(
+    {
+        "executor_version": "step_runner",
+        "name": "paloma/4chan-llama3",
+        "config": {"fingerprint": "449bd131", "version": "2026.06.28", "deps": []},
+        "output_path": "gs://bucket/paloma/4chan-llama3/2026.06.28",
+    }
+)
+
+
+def test_read_record_ignores_step_runner_stub(tmp_path):
+    """A schedule-time ``StepRunner`` ``.executor_info`` stub is not served as a record — it
+    carries no materialized config, so the output reads back as record-less rather than as a
+    tokenizer-less cache (#6836)."""
+    (tmp_path / ".executor_info").write_text(_STEP_RUNNER_STUB)
+
+    assert read_record(tmp_path.as_posix()) is None


### PR DESCRIPTION
* fixes marin-community/marin#6836
* `read_record` falls back to the `.executor_info` sidecar when a step's `.artifact.json` is missing; for a **schedule-time `StepRunner` stub** — written before the step runs — that sidecar's `config` is the identity `hash_attrs` (`deps`/`fingerprint`/`version`), not a materialized config, so the fallback served a tokenizer-less `TokenizedCache` and broke `mixture()` for any consumer
* tag the stub with `STEP_RUNNER_EXECUTOR_VERSION` and skip it in `read_record`, so an incomplete / record-less output reads back as *no record* instead of a bogus one
  * genuine legacy Ray `.executor_info` sidecars — which carry the real materialized config (e.g. the pinned llama3 Nemotron-CC caches) — are still honored
* the orphaned canary caches (`paloma`/`uncheatable_eval` `@2026.06.28`) were the trigger, but their root cause was #6813 dropping the un-dotted `artifact.json` read name; the 1287 undotted-only records across all six buckets were re-dotted out-of-band [^1], so the canary is already green — this PR is the durable guard the issue called out separately

[^1]: re-dotting verified end-to-end via a manual `Marin - Canary Ferry` dispatch (run `28631882215`): `mixture()` resolved, trained 476/476 (loss 7.62→3.94), `paloma`/`uncheatable` evals produced metrics, GHA green
