### PR TITLE
ducky: programmatic preemption-resilient client with IAP service-account auth

### DIFF
--- a/lib/ducky/src/ducky/client.py
+++ b/lib/ducky/src/ducky/client.py
@@ -255,11 +255,18 @@ def _render_table(columns: list[str], rows: list[list]) -> str:
     return "\n".join(lines)
 
 
-def _run_query(base: str, sql: str, output_format: str, poll_interval: float, timeout: int, use_cache: bool) -> None:
-    # CLI fails fast (retry_budget=0): a persistent error surfaces immediately
-    # rather than blocking an interactive user. Programmatic callers keep the
-    # default budget to ride out preemptions.
-    client = DuckyClient(base, token_provider=None, poll_interval=poll_interval, timeout=timeout, retry_budget=0)
+def _run_query(
+    base: str,
+    sql: str,
+    output_format: str,
+    poll_interval: float,
+    timeout: int,
+    use_cache: bool,
+    retry_budget: float,
+) -> None:
+    client = DuckyClient(
+        base, token_provider=None, poll_interval=poll_interval, timeout=timeout, retry_budget=retry_budget
+    )
     try:
         result = client.run(sql, use_cache=use_cache)
     except DuckyError as e:
@@ -289,6 +296,12 @@ def _run_query(base: str, sql: str, output_format: str, poll_interval: float, ti
 @click.option("--poll-interval", default=1.0, show_default=True, help="Seconds between status polls.")
 @click.option("--timeout", default=3600, show_default=True, help="Max seconds to wait for the query to finish.")
 @click.option("--no-cache", is_flag=True, help="Force a fresh run instead of reusing a prior identical query's result.")
+@click.option(
+    "--retry-budget",
+    default=0.0,
+    show_default=True,
+    help="Wall-clock seconds to retry transient failures (ducky preempted, network blips); 0 fails fast.",
+)
 def query(
     sql: str | None,
     cluster: str | None,
@@ -298,6 +311,7 @@ def query(
     poll_interval: float,
     timeout: int,
     no_cache: bool,
+    retry_budget: float,
 ) -> None:
     """Run SQL against a ducky service and print the result. SQL comes from the argument or stdin."""
     if cluster and base_url:
@@ -311,10 +325,11 @@ def query(
     use_cache = not no_cache
     if cluster:
         with cluster_tunnel(cluster) as controller_url:
-            _run_query(f"{controller_url}/proxy/{endpoint}", sql, output_format, poll_interval, timeout, use_cache)
+            base = f"{controller_url}/proxy/{endpoint}"
+            _run_query(base, sql, output_format, poll_interval, timeout, use_cache, retry_budget)
     else:
         base = base_url or os.environ.get("DUCKY_BASE_URL", DEFAULT_BASE_URL)
-        _run_query(base, sql, output_format, poll_interval, timeout, use_cache)
+        _run_query(base, sql, output_format, poll_interval, timeout, use_cache, retry_budget)
 
 
 if __name__ == "__main__":

--- a/lib/ducky/src/ducky/client.py
+++ b/lib/ducky/src/ducky/client.py
@@ -1,36 +1,242 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
-"""`ducky query` — run a SQL query against a ducky service from the CLI.
+"""Programmatic ``DuckyClient`` + the ``ducky query`` CLI.
 
-ducky is reached through the controller endpoint proxy, which sits behind IAP. The
-CLI hides that: with ``--cluster <name>`` it drives ``iris cluster dashboard`` to
-open a local tunnel, resolves the ``/proxy/<endpoint>`` path itself, runs the query,
-and tears the tunnel down — so you just run::
+ducky runs behind the Iris controller's endpoint proxy and speaks an async
+protocol: ``POST /query {"sql": ...}`` returns a ``query_id``; poll
+``GET /result/{query_id}`` until ``status != "running"`` (dodging the proxy's
+~30 s request cap).
+
+:class:`DuckyClient` is the reusable client for that protocol. It is transport-
+and auth-agnostic via ``base_url`` + a ``token_provider``:
+
+* CLI / open tunnel — ``base_url`` of the tunnel, no token (the tunnel auths).
+* IAP proxy (e.g. dashboards) — :func:`iap_token_provider` mints a service-
+  account OIDC token for the desktop OAuth audience, sent as ``Authorization``.
+* in-cluster — the controller's internal proxy URL, no token.
+
+Because ducky is **preemptible** (it can vanish and re-register at any time) and
+reads object storage per query, both preemptions and transient network/DNS blips
+surface as errors; :meth:`DuckyClient.run` retries those with exponential backoff
+for up to ``retry_budget`` seconds. Deterministic errors (SQL, missing file) and
+query timeouts fail fast.
+
+CLI::
 
     ducky query --cluster marin "SELECT count(*) FROM read_parquet('gs://…/*.parquet')"
-
-Alternatively pass ``--base-url`` to target an already-open tunnel (or set
-``DUCKY_BASE_URL``). The command submits, polls until done, prints the capped
-preview as a table, and writes a stats line (rows, time, result size, cached, and
-the full-result GCS path) to stderr.
 """
 
 from __future__ import annotations
 
+import dataclasses
 import json
+import logging
 import os
 import time
+from collections.abc import Callable
 
 import click
 import httpx
+from httpx import HTTPError
 
 from ducky.tunnel import cluster_tunnel
 
+logger = logging.getLogger(__name__)
+
 DEFAULT_BASE_URL = "http://127.0.0.1:10000/proxy/ducky"
-# Per-request HTTP timeout. Each submit/poll call is fast (the query runs async on the
-# server), so this only bounds a single round-trip — not the query.
+# Per-request HTTP timeout. Each submit/poll call is fast (the query runs async on
+# the server), so this only bounds a single round-trip — not the query.
 _HTTP_TIMEOUT = 30
+# Default overall wait for a query to finish (poll deadline). Kept above ducky's
+# own ``query_timeout`` (600 s) so a genuinely slow query is interrupted server
+# side (a clean error) rather than tripping this deadline first.
+DEFAULT_QUERY_TIMEOUT = 900.0
+
+TokenProvider = Callable[[], str | None]
+
+# Substrings marking a *retryable* failure: transient network/DNS/object-store
+# blips AND ducky being unavailable (preemptible — proxy "No endpoint", or a
+# 502/504 upstream timeout while it restarts). Deterministic errors (SQL binder,
+# file-not-found) are absent so they fail fast.
+_RETRYABLE_MARKERS = (
+    "could not resolve hostname",
+    "connection reset",
+    "connection refused",
+    "connection aborted",
+    "connection timed out",
+    "timed out",
+    "temporarily unavailable",
+    "network is unreachable",
+    "failed to establish",
+    "no endpoint",  # controller proxy: ducky endpoint not registered (preempted)
+    "upstream timeout",  # controller proxy: ducky didn't respond (restarting)
+    "http 429",
+    "http 500",
+    "http 502",
+    "http 503",
+    "http 504",
+)
+
+
+def _is_retryable(message: str) -> bool:
+    m = message.lower()
+    return any(marker in m for marker in _RETRYABLE_MARKERS)
+
+
+class DuckyError(RuntimeError):
+    """A ducky query failed, timed out, or the service returned an HTTP error."""
+
+
+@dataclasses.dataclass(frozen=True)
+class QueryResult:
+    """A completed ducky query: capped preview rows plus full-result metadata."""
+
+    columns: list[str]
+    rows: list[list]
+    total_rows: int
+    truncated: bool
+    result_path: str | None
+    cached: bool
+    elapsed_ms: int
+    result_bytes: int
+
+    def dicts(self) -> list[dict]:
+        return [dict(zip(self.columns, row, strict=True)) for row in self.rows]
+
+    def scalar(self):
+        """The single cell of a 1x1 result (e.g. a ``count(*)``)."""
+        if not self.rows or not self.rows[0]:
+            raise DuckyError("scalar() on an empty result")
+        return self.rows[0][0]
+
+
+def iap_token_provider(audience: str | None = None) -> TokenProvider:
+    """Token provider that mints an IAP OIDC token from ambient service-account creds.
+
+    The audience defaults to Marin's desktop OAuth client (the one on the IAP
+    allowlist).
+    """
+    from rigging.auth import (  # noqa: PLC0415 — lazy: the CLI tunnel path needs no IAP/rigging deps
+        MARIN_DESKTOP_OAUTH_CLIENT,
+        IapServiceAccountTokenProvider,
+    )
+
+    return IapServiceAccountTokenProvider(audience or MARIN_DESKTOP_OAUTH_CLIENT.client_id).get_token
+
+
+def _error_message(response: httpx.Response) -> str:
+    try:
+        return str(response.json().get("error", response.text))
+    except (ValueError, KeyError):
+        return f"HTTP {response.status_code}: {response.text[:200]}"
+
+
+class DuckyClient:
+    """Submit SQL to ducky and block until the result is ready, riding out preemptions.
+
+    Args:
+        base_url: ducky root — a tunnel URL, the IAP proxy, or an in-cluster
+            controller proxy.
+        token_provider: returns a bearer token per request, or ``None`` for no
+            auth (tunnel / in-cluster direct).
+        poll_interval: seconds between ``/result`` polls.
+        timeout: overall seconds to wait for one query to finish.
+        retry_budget: total wall-clock spent retrying retryable failures, with
+            exponential backoff (``retry_base`` doubling, capped at ``retry_cap``).
+    """
+
+    def __init__(
+        self,
+        base_url: str = DEFAULT_BASE_URL,
+        *,
+        token_provider: TokenProvider | None = None,
+        poll_interval: float = 1.0,
+        timeout: float = DEFAULT_QUERY_TIMEOUT,
+        retry_budget: float = 150.0,
+        retry_base: float = 2.0,
+        retry_cap: float = 20.0,
+    ):
+        self._base_url = base_url.rstrip("/")
+        self._token_provider = token_provider
+        self._poll_interval = poll_interval
+        self._timeout = timeout
+        self._retry_budget = retry_budget
+        self._retry_base = retry_base
+        self._retry_cap = retry_cap
+
+    def _request(self, method: str, path: str, body: dict | None = None, timeout: float = _HTTP_TIMEOUT) -> dict:
+        url = f"{self._base_url}{path}"
+        kwargs: dict = {"timeout": timeout}
+        if self._token_provider is not None:
+            token = self._token_provider()
+            if token:
+                kwargs["headers"] = {"Authorization": f"Bearer {token}"}
+        try:
+            resp = httpx.post(url, json=body, **kwargs) if method == "POST" else httpx.get(url, **kwargs)
+        except HTTPError as e:
+            raise DuckyError(f"ducky {method} {path} unreachable: {e}") from e
+        if resp.status_code not in (200, 202):
+            raise DuckyError(f"ducky {method} {path} -> HTTP {resp.status_code}: {_error_message(resp)}")
+        return resp.json()
+
+    def healthy(self) -> bool:
+        """Quick ``/health`` probe (short timeout, no retry) — is ducky reachable now?"""
+        try:
+            return self._request("GET", "/health", timeout=5.0).get("status") == "healthy"
+        except DuckyError:
+            return False
+
+    def run(self, sql: str, use_cache: bool = True) -> QueryResult:
+        """Submit ``sql`` and poll until done, retrying while ducky is unavailable."""
+        start = time.monotonic()
+        attempt = 0
+        while True:
+            try:
+                return self._run_once(sql, use_cache)
+            except DuckyError as e:
+                retryable = _is_retryable(str(e))
+                elapsed = time.monotonic() - start
+                if retryable and elapsed < self._retry_budget:
+                    wait = min(self._retry_cap, self._retry_base * (2**attempt))
+                    attempt += 1
+                    logger.warning(
+                        "ducky unavailable/transient (retry %d, %.0fs/%.0fs elapsed), sleeping %.0fs: %s",
+                        attempt,
+                        elapsed,
+                        self._retry_budget,
+                        wait,
+                        str(e).splitlines()[0][:140],
+                    )
+                    time.sleep(wait)
+                    continue
+                # Not retryable, or the retry budget is exhausted: re-raise with
+                # the original detail (HTTP status / "No endpoint" / "upstream
+                # timeout") so callers can see what actually failed.
+                raise
+
+    def _run_once(self, sql: str, use_cache: bool) -> QueryResult:
+        query_id = self._request("POST", "/query", {"sql": sql, "use_cache": use_cache})["query_id"]
+        deadline = time.monotonic() + self._timeout
+        while True:
+            state = self._request("GET", f"/result/{query_id}")
+            status = state.get("status")
+            if status == "done":
+                return QueryResult(
+                    columns=state["columns"],
+                    rows=state["rows"],
+                    total_rows=state["total_rows"],
+                    truncated=state.get("truncated", False),
+                    result_path=state.get("result_path"),
+                    cached=state.get("cached", False),
+                    elapsed_ms=state.get("elapsed_ms", 0),
+                    result_bytes=state.get("result_bytes", 0),
+                )
+            if status == "error":
+                raise DuckyError(f"query failed: {state.get('error')}\nSQL: {sql[:500]}")
+            if time.monotonic() > deadline:
+                raise DuckyError(f"query {query_id} still running after {self._timeout:.0f}s")
+            time.sleep(self._poll_interval)
 
 
 def _render_table(columns: list[str], rows: list[list]) -> str:
@@ -49,44 +255,25 @@ def _render_table(columns: list[str], rows: list[list]) -> str:
     return "\n".join(lines)
 
 
-def _error_message(response: httpx.Response) -> str:
-    try:
-        return str(response.json().get("error", response.text))
-    except (ValueError, KeyError):
-        return f"HTTP {response.status_code}: {response.text[:200]}"
-
-
 def _run_query(base: str, sql: str, output_format: str, poll_interval: float, timeout: int, use_cache: bool) -> None:
-    base = base.rstrip("/")
-    submit = httpx.post(f"{base}/query", json={"sql": sql, "use_cache": use_cache}, timeout=_HTTP_TIMEOUT)
-    if submit.status_code != 202:
-        raise click.ClickException(_error_message(submit))
-    query_id = submit.json()["query_id"]
-
-    deadline = time.monotonic() + timeout
-    while True:
-        resp = httpx.get(f"{base}/result/{query_id}", timeout=_HTTP_TIMEOUT)
-        if resp.status_code != 200:
-            raise click.ClickException(_error_message(resp))
-        result = resp.json()
-        if result.get("status") != "running":
-            break
-        if time.monotonic() > deadline:
-            raise click.ClickException(f"Query still running after {timeout}s (id {query_id}).")
-        time.sleep(poll_interval)
-
-    if result["status"] == "error":
-        raise click.ClickException(result["error"])
+    # CLI fails fast (retry_budget=0): a persistent error surfaces immediately
+    # rather than blocking an interactive user. Programmatic callers keep the
+    # default budget to ride out preemptions.
+    client = DuckyClient(base, token_provider=None, poll_interval=poll_interval, timeout=timeout, retry_budget=0)
+    try:
+        result = client.run(sql, use_cache=use_cache)
+    except DuckyError as e:
+        raise click.ClickException(str(e)) from e
 
     if output_format == "json":
-        click.echo(json.dumps(result, indent=2))
+        click.echo(json.dumps(dataclasses.asdict(result), indent=2))
         return
 
-    click.echo(_render_table(result["columns"], result["rows"]))
-    count = f"{len(result['rows'])} of {result['total_rows']}" if result["truncated"] else str(result["total_rows"])
-    cached = "cached" if result["cached"] else "computed"
-    click.echo(f"\n{count} rows · {result['elapsed_ms']} ms · {result['result_bytes']} B · {cached}", err=True)
-    click.echo(f"full result: {result['result_path']}", err=True)
+    click.echo(_render_table(result.columns, result.rows))
+    count = f"{len(result.rows)} of {result.total_rows}" if result.truncated else str(result.total_rows)
+    cached = "cached" if result.cached else "computed"
+    click.echo(f"\n{count} rows · {result.elapsed_ms} ms · {result.result_bytes} B · {cached}", err=True)
+    click.echo(f"full result: {result.result_path}", err=True)
 
 
 @click.command("query")

--- a/lib/ducky/src/ducky/client.py
+++ b/lib/ducky/src/ducky/client.py
@@ -19,7 +19,9 @@ and auth-agnostic via ``base_url`` + a ``token_provider``:
 Because ducky is **preemptible** (it can vanish and re-register at any time) and
 reads object storage per query, both preemptions and transient network/DNS blips
 surface as errors; :meth:`DuckyClient.run` retries those with exponential backoff
-for up to ``retry_budget`` seconds. A transient poll failure re-polls the same
+for up to ``retry_budget`` seconds per outage (any successful request resets the
+budget, so healthy polling on a long query does not consume it). A transient poll
+failure re-polls the same
 ``query_id`` (never resubmitting a query that may still be running); the query is
 resubmitted only when ducky restarted and no longer knows the id, or the query
 itself died to a transient error. Deterministic errors (SQL, missing file) and
@@ -154,8 +156,10 @@ class DuckyClient:
             auth (tunnel / in-cluster direct).
         poll_interval: seconds between ``/result`` polls.
         timeout: overall seconds to wait for one query to finish.
-        retry_budget: total wall-clock spent retrying retryable failures, with
-            exponential backoff (``retry_base`` doubling, capped at ``retry_cap``).
+        retry_budget: wall-clock spent retrying *consecutive* retryable failures
+            (one outage), with exponential backoff (``retry_base`` doubling,
+            capped at ``retry_cap``). Any successful request resets the budget
+            and backoff.
     """
 
     def __init__(
@@ -176,6 +180,9 @@ class DuckyClient:
         self._retry_budget = retry_budget
         self._retry_base = retry_base
         self._retry_cap = retry_cap
+        # Successful-request counter; ``run()`` compares snapshots of it to tell
+        # consecutive failures (one outage) from a fresh failure after progress.
+        self._ok_requests = 0
 
     def _request(self, method: str, path: str, body: dict | None = None, timeout: float = _HTTP_TIMEOUT) -> dict:
         url = f"{self._base_url}{path}"
@@ -190,6 +197,7 @@ class DuckyClient:
             raise DuckyError(f"ducky {method} {path} unreachable: {e}") from e
         if resp.status_code not in (200, 202):
             raise DuckyError(f"ducky {method} {path} -> HTTP {resp.status_code}: {_error_message(resp)}")
+        self._ok_requests += 1
         return resp.json()
 
     def healthy(self) -> bool:
@@ -207,11 +215,16 @@ class DuckyClient:
         reads (and could change results for non-deterministic SQL). The query is
         resubmitted only when ducky restarted and lost the id ("unknown
         query_id") or the query itself died to a transient error.
+
+        ``retry_budget`` bounds one outage — consecutive retryable failures —
+        not total query wall-clock: any successful request resets it, so a blip
+        after minutes of healthy polling still gets the full budget.
         """
-        start = time.monotonic()
         attempt = 0
         query_id: str | None = None
         deadline = 0.0
+        streak_start = 0.0
+        ok_at_last_failure = -1
         while True:
             try:
                 if query_id is None:
@@ -229,7 +242,14 @@ class DuckyClient:
                     # Submit/poll transport blip; the submitted query (if any)
                     # may still be running, so keep its id and re-poll.
                     retryable, resubmit = _is_retryable(str(e)), False
-                elapsed = time.monotonic() - start
+                now = time.monotonic()
+                if self._ok_requests != ok_at_last_failure:
+                    # Progress since the last failure: this failure starts a new
+                    # outage streak with a fresh budget and backoff.
+                    streak_start = now
+                    attempt = 0
+                ok_at_last_failure = self._ok_requests
+                elapsed = now - streak_start
                 if not retryable or elapsed >= self._retry_budget:
                     # Re-raise with the original detail (HTTP status / "No
                     # endpoint" / "upstream timeout") so callers can see what

--- a/lib/ducky/src/ducky/client.py
+++ b/lib/ducky/src/ducky/client.py
@@ -19,7 +19,10 @@ and auth-agnostic via ``base_url`` + a ``token_provider``:
 Because ducky is **preemptible** (it can vanish and re-register at any time) and
 reads object storage per query, both preemptions and transient network/DNS blips
 surface as errors; :meth:`DuckyClient.run` retries those with exponential backoff
-for up to ``retry_budget`` seconds. Deterministic errors (SQL, missing file) and
+for up to ``retry_budget`` seconds. A transient poll failure re-polls the same
+``query_id`` (never resubmitting a query that may still be running); the query is
+resubmitted only when ducky restarted and no longer knows the id, or the query
+itself died to a transient error. Deterministic errors (SQL, missing file) and
 query timeouts fail fast.
 
 CLI::
@@ -78,6 +81,11 @@ _RETRYABLE_MARKERS = (
     "http 504",
 )
 
+# ducky's query state is process-local: after a preemption+restart, polling a
+# pre-restart query_id gets HTTP 404 "unknown query_id". Not in the markers
+# above because it changes the retry *mode* — resubmit, don't re-poll.
+_QUERY_LOST_MARKER = "unknown query_id"
+
 
 def _is_retryable(message: str) -> bool:
     m = message.lower()
@@ -86,6 +94,10 @@ def _is_retryable(message: str) -> bool:
 
 class DuckyError(RuntimeError):
     """A ducky query failed, timed out, or the service returned an HTTP error."""
+
+
+class _QueryFailed(DuckyError):
+    """The query reached a terminal ``error`` state server-side; re-polling cannot help."""
 
 
 @dataclasses.dataclass(frozen=True)
@@ -106,8 +118,8 @@ class QueryResult:
 
     def scalar(self):
         """The single cell of a 1x1 result (e.g. a ``count(*)``)."""
-        if not self.rows or not self.rows[0]:
-            raise DuckyError("scalar() on an empty result")
+        if len(self.rows) != 1 or len(self.rows[0]) != 1:
+            raise DuckyError(f"scalar() requires a 1x1 result, got {self.total_rows} rows x {len(self.columns)} columns")
         return self.rows[0][0]
 
 
@@ -188,36 +200,56 @@ class DuckyClient:
             return False
 
     def run(self, sql: str, use_cache: bool = True) -> QueryResult:
-        """Submit ``sql`` and poll until done, retrying while ducky is unavailable."""
+        """Submit ``sql`` and poll until done, retrying while ducky is unavailable.
+
+        A transient failure while polling re-polls the same ``query_id`` — the
+        query may still be running, and resubmitting would duplicate object-store
+        reads (and could change results for non-deterministic SQL). The query is
+        resubmitted only when ducky restarted and lost the id ("unknown
+        query_id") or the query itself died to a transient error.
+        """
         start = time.monotonic()
         attempt = 0
+        query_id: str | None = None
+        deadline = 0.0
         while True:
             try:
-                return self._run_once(sql, use_cache)
+                if query_id is None:
+                    query_id = self._request("POST", "/query", {"sql": sql, "use_cache": use_cache})["query_id"]
+                    deadline = time.monotonic() + self._timeout
+                return self._poll(query_id, deadline, sql)
             except DuckyError as e:
-                retryable = _is_retryable(str(e))
+                if isinstance(e, _QueryFailed):
+                    # Terminal server-side error: re-polling returns it forever,
+                    # so a retry must resubmit.
+                    retryable, resubmit = _is_retryable(str(e)), True
+                elif _QUERY_LOST_MARKER in str(e).lower():
+                    retryable, resubmit = True, True
+                else:
+                    # Submit/poll transport blip; the submitted query (if any)
+                    # may still be running, so keep its id and re-poll.
+                    retryable, resubmit = _is_retryable(str(e)), False
                 elapsed = time.monotonic() - start
-                if retryable and elapsed < self._retry_budget:
-                    wait = min(self._retry_cap, self._retry_base * (2**attempt))
-                    attempt += 1
-                    logger.warning(
-                        "ducky unavailable/transient (retry %d, %.0fs/%.0fs elapsed), sleeping %.0fs: %s",
-                        attempt,
-                        elapsed,
-                        self._retry_budget,
-                        wait,
-                        str(e).splitlines()[0][:140],
-                    )
-                    time.sleep(wait)
-                    continue
-                # Not retryable, or the retry budget is exhausted: re-raise with
-                # the original detail (HTTP status / "No endpoint" / "upstream
-                # timeout") so callers can see what actually failed.
-                raise
+                if not retryable or elapsed >= self._retry_budget:
+                    # Re-raise with the original detail (HTTP status / "No
+                    # endpoint" / "upstream timeout") so callers can see what
+                    # actually failed.
+                    raise
+                if resubmit:
+                    query_id = None
+                wait = min(self._retry_cap, self._retry_base * (2**attempt))
+                attempt += 1
+                logger.warning(
+                    "ducky unavailable/transient (retry %d, %.0fs/%.0fs elapsed), sleeping %.0fs: %s",
+                    attempt,
+                    elapsed,
+                    self._retry_budget,
+                    wait,
+                    str(e).splitlines()[0][:140],
+                )
+                time.sleep(wait)
 
-    def _run_once(self, sql: str, use_cache: bool) -> QueryResult:
-        query_id = self._request("POST", "/query", {"sql": sql, "use_cache": use_cache})["query_id"]
-        deadline = time.monotonic() + self._timeout
+    def _poll(self, query_id: str, deadline: float, sql: str) -> QueryResult:
         while True:
             state = self._request("GET", f"/result/{query_id}")
             status = state.get("status")
@@ -233,7 +265,7 @@ class DuckyClient:
                     result_bytes=state.get("result_bytes", 0),
                 )
             if status == "error":
-                raise DuckyError(f"query failed: {state.get('error')}\nSQL: {sql[:500]}")
+                raise _QueryFailed(f"query failed: {state.get('error')}\nSQL: {sql[:500]}")
             if time.monotonic() > deadline:
                 raise DuckyError(f"query {query_id} still running after {self._timeout:.0f}s")
             time.sleep(self._poll_interval)

--- a/lib/ducky/tests/test_client.py
+++ b/lib/ducky/tests/test_client.py
@@ -4,9 +4,10 @@
 import json
 
 import httpx
+import pytest
 from click.testing import CliRunner
 from ducky import client
-from ducky.client import _render_table, query
+from ducky.client import DuckyClient, DuckyError, QueryResult, _render_table, query
 
 _BASE = "http://ducky.test/proxy/ducky"
 _DONE = {
@@ -81,6 +82,106 @@ def test_query_poll_http_error_exits_cleanly(monkeypatch):
     result = CliRunner().invoke(query, ["SELECT 1", "--base-url", _BASE])
     assert result.exit_code != 0
     assert "upstream timeout" in result.output
+
+
+class _ScriptedHttp:
+    """Scripted ducky transport: pops one canned (status, payload) per request."""
+
+    def __init__(self, posts: list[tuple[int, dict]], gets: list[tuple[int, dict]]):
+        self._posts = list(posts)
+        self._gets = list(gets)
+        self.post_count = 0
+        self.polled_query_ids: list[str] = []
+
+    def post(self, url, json=None, timeout=None):
+        self.post_count += 1
+        status, payload = self._posts.pop(0)
+        return httpx.Response(status, json=payload, request=httpx.Request("POST", url))
+
+    def get(self, url, timeout=None):
+        self.polled_query_ids.append(url.rsplit("/", 1)[-1])
+        status, payload = self._gets.pop(0)
+        return httpx.Response(status, json=payload, request=httpx.Request("GET", url))
+
+
+def _client(**kwargs) -> DuckyClient:
+    return DuckyClient(_BASE, poll_interval=0, retry_base=0.01, retry_cap=0.01, **kwargs)
+
+
+def test_run_repolls_same_query_after_transient_poll_blip(monkeypatch):
+    # A 503 on /result must not resubmit: the query may still be running, and a
+    # duplicate submission re-reads object storage (and can change results for
+    # non-deterministic SQL).
+    http = _ScriptedHttp(
+        posts=[(202, {"query_id": "q1"})],
+        gets=[(503, {"error": "service unavailable"}), (200, _DONE)],
+    )
+    monkeypatch.setattr(client, "httpx", http)
+    result = _client(retry_budget=5).run("SELECT 1")
+    assert result.total_rows == 2
+    assert http.post_count == 1
+    assert http.polled_query_ids == ["q1", "q1"]
+
+
+def test_run_resubmits_when_restarted_ducky_forgot_the_query(monkeypatch):
+    # ducky's query state is process-local: after a preemption+restart, polling
+    # the pre-restart id 404s with "unknown query_id" — the client must resubmit.
+    http = _ScriptedHttp(
+        posts=[(202, {"query_id": "q1"}), (202, {"query_id": "q2"})],
+        gets=[(404, {"error": "unknown query_id"}), (200, _DONE)],
+    )
+    monkeypatch.setattr(client, "httpx", http)
+    result = _client(retry_budget=5).run("SELECT 1")
+    assert result.total_rows == 2
+    assert http.polled_query_ids == ["q1", "q2"]
+
+
+def test_run_resubmits_query_that_died_to_transient_error(monkeypatch):
+    # A terminal "error" state with a transient marker (object-store blip) can
+    # only be retried by resubmitting — re-polling returns the error forever.
+    http = _ScriptedHttp(
+        posts=[(202, {"query_id": "q1"}), (202, {"query_id": "q2"})],
+        gets=[
+            (200, {"status": "error", "error": "Connection reset by peer reading gs://b/x.parquet"}),
+            (200, _DONE),
+        ],
+    )
+    monkeypatch.setattr(client, "httpx", http)
+    result = _client(retry_budget=5).run("SELECT 1")
+    assert result.total_rows == 2
+    assert http.post_count == 2
+
+
+def test_run_fails_fast_on_deterministic_query_error(monkeypatch):
+    http = _ScriptedHttp(
+        posts=[(202, {"query_id": "q1"})],
+        gets=[(200, {"status": "error", "error": "Catalog Error: nope"})],
+    )
+    monkeypatch.setattr(client, "httpx", http)
+    with pytest.raises(DuckyError, match="Catalog Error"):
+        _client(retry_budget=5).run("SELECT * FROM nope")
+    assert http.post_count == 1
+
+
+def _result(columns: list[str], rows: list[list]) -> QueryResult:
+    return QueryResult(
+        columns=columns,
+        rows=rows,
+        total_rows=len(rows),
+        truncated=False,
+        result_path=None,
+        cached=False,
+        elapsed_ms=0,
+        result_bytes=0,
+    )
+
+
+def test_scalar_requires_1x1_result():
+    assert _result(["n"], [[7]]).scalar() == 7
+    with pytest.raises(DuckyError, match="1x1"):
+        _result(["n"], [[1], [2]]).scalar()
+    with pytest.raises(DuckyError, match="1x1"):
+        _result(["a", "b"], [[1, 2]]).scalar()
 
 
 def test_query_requires_sql():

--- a/lib/ducky/tests/test_client.py
+++ b/lib/ducky/tests/test_client.py
@@ -34,56 +34,6 @@ def test_render_table_aligns_and_marks_null():
     assert lines[0].index("|") == lines[2].index("|")
 
 
-class _FakeHttp:
-    """Routes ducky's POST /query + GET /result to canned responses."""
-
-    def __init__(self, result: dict, submit_status: int = 202, get_status: int = 200):
-        self._result = result
-        self._submit_status = submit_status
-        self._get_status = get_status
-
-    def post(self, url, json=None, timeout=None):
-        return httpx.Response(self._submit_status, json={"query_id": "abc"}, request=httpx.Request("POST", url))
-
-    def get(self, url, timeout=None):
-        return httpx.Response(self._get_status, json=self._result, request=httpx.Request("GET", url))
-
-
-def test_query_prints_table_and_stats(monkeypatch):
-    monkeypatch.setattr(client, "httpx", _FakeHttp(_DONE))
-    result = CliRunner().invoke(query, ["SELECT 1", "--base-url", _BASE])
-
-    assert result.exit_code == 0, result.output
-    assert "a | b" in result.stdout
-    assert "NULL" in result.stdout
-    assert "2 rows · 42 ms · 99 B · computed" in result.stderr
-    assert "gs://b/ducky/q.parquet" in result.stderr
-
-
-def test_query_json_format(monkeypatch):
-    monkeypatch.setattr(client, "httpx", _FakeHttp(_DONE))
-    result = CliRunner().invoke(query, ["SELECT 1", "--base-url", _BASE, "--format", "json"])
-    assert result.exit_code == 0
-    assert json.loads(result.output)["columns"] == ["a", "b"]
-
-
-def test_query_error_exits_nonzero(monkeypatch):
-    err = {"status": "error", "error": "Catalog Error: nope"}
-    monkeypatch.setattr(client, "httpx", _FakeHttp(err))
-    result = CliRunner().invoke(query, ["SELECT * FROM nope", "--base-url", _BASE])
-    assert result.exit_code != 0
-    assert "Catalog Error: nope" in result.output
-
-
-def test_query_poll_http_error_exits_cleanly(monkeypatch):
-    # a non-200 /result (e.g. server restart, proxy failure) must surface as a CLI error,
-    # not a KeyError on the missing "status" field
-    monkeypatch.setattr(client, "httpx", _FakeHttp({"error": "upstream timeout"}, get_status=504))
-    result = CliRunner().invoke(query, ["SELECT 1", "--base-url", _BASE])
-    assert result.exit_code != 0
-    assert "upstream timeout" in result.output
-
-
 class _ScriptedHttp:
     """Scripted ducky transport: pops one canned (status, payload) per request."""
 
@@ -105,7 +55,43 @@ class _ScriptedHttp:
 
 
 def _client(**kwargs) -> DuckyClient:
-    return DuckyClient(_BASE, poll_interval=0, retry_base=0.01, retry_cap=0.01, **kwargs)
+    return DuckyClient(_BASE, **{"poll_interval": 0, "retry_base": 0.01, "retry_cap": 0.01, **kwargs})
+
+
+def test_query_prints_table_and_stats(monkeypatch):
+    monkeypatch.setattr(client, "httpx", _ScriptedHttp(posts=[(202, {"query_id": "abc"})], gets=[(200, _DONE)]))
+    result = CliRunner().invoke(query, ["SELECT 1", "--base-url", _BASE])
+
+    assert result.exit_code == 0, result.output
+    assert "a | b" in result.stdout
+    assert "NULL" in result.stdout
+    assert "2 rows · 42 ms · 99 B · computed" in result.stderr
+    assert "gs://b/ducky/q.parquet" in result.stderr
+
+
+def test_query_json_format(monkeypatch):
+    monkeypatch.setattr(client, "httpx", _ScriptedHttp(posts=[(202, {"query_id": "abc"})], gets=[(200, _DONE)]))
+    result = CliRunner().invoke(query, ["SELECT 1", "--base-url", _BASE, "--format", "json"])
+    assert result.exit_code == 0
+    assert json.loads(result.output)["columns"] == ["a", "b"]
+
+
+def test_query_error_exits_nonzero(monkeypatch):
+    err = {"status": "error", "error": "Catalog Error: nope"}
+    monkeypatch.setattr(client, "httpx", _ScriptedHttp(posts=[(202, {"query_id": "abc"})], gets=[(200, err)]))
+    result = CliRunner().invoke(query, ["SELECT * FROM nope", "--base-url", _BASE])
+    assert result.exit_code != 0
+    assert "Catalog Error: nope" in result.output
+
+
+def test_query_poll_http_error_exits_cleanly(monkeypatch):
+    # a non-200 /result (e.g. server restart, proxy failure) must surface as a CLI error,
+    # not a KeyError on the missing "status" field; the CLI default budget of 0 fails fast
+    http = _ScriptedHttp(posts=[(202, {"query_id": "abc"})], gets=[(504, {"error": "upstream timeout"})])
+    monkeypatch.setattr(client, "httpx", http)
+    result = CliRunner().invoke(query, ["SELECT 1", "--base-url", _BASE])
+    assert result.exit_code != 0
+    assert "upstream timeout" in result.output
 
 
 def test_run_repolls_same_query_after_transient_poll_blip(monkeypatch):
@@ -150,6 +136,35 @@ def test_run_resubmits_query_that_died_to_transient_error(monkeypatch):
     result = _client(retry_budget=5).run("SELECT 1")
     assert result.total_rows == 2
     assert http.post_count == 2
+
+
+class _FakeClock:
+    """Replaces the ``time`` module in the client: ``sleep`` advances ``monotonic``."""
+
+    def __init__(self):
+        self.now = 0.0
+
+    def monotonic(self) -> float:
+        return self.now
+
+    def sleep(self, seconds: float) -> None:
+        self.now += seconds
+
+
+def test_healthy_polling_does_not_consume_retry_budget(monkeypatch):
+    # retry_budget bounds one outage, not total query wall-clock: a blip after
+    # minutes of healthy polling on a long query must still get retried.
+    clock = _FakeClock()
+    monkeypatch.setattr(client, "time", clock)
+    running = (200, {"status": "running"})
+    http = _ScriptedHttp(
+        posts=[(202, {"query_id": "q1"})],
+        gets=[running] * 60 + [(503, {"error": "service unavailable"}), (200, _DONE)],
+    )
+    monkeypatch.setattr(client, "httpx", http)
+    result = _client(poll_interval=1.0, retry_budget=10).run("SELECT 1")  # blip lands at t=60 > budget
+    assert result.total_rows == 2
+    assert http.post_count == 1
 
 
 def test_run_fails_fast_on_deterministic_query_error(monkeypatch):


### PR DESCRIPTION
* add a programmatic `DuckyClient` for ducky's async query protocol: `POST /query {"sql": ...}` returns a `query_id`, poll `GET /result/{query_id}` until done (dodging the controller proxy's ~30s request cap)
* transport- and auth-agnostic via `base_url` + a `token_provider` — works over an open tunnel (no token), the IAP proxy (OIDC token), or the in-cluster controller proxy
* `run()` is preemption-resilient: ducky is preemptible and reads object storage per query, so preemptions and transient network/DNS blips surface as errors
  * retries retryable markers (`no endpoint` / `connection refused` / `HTTP 429/500/502/503/504` / `upstream timeout` / dns-resolve) with exponential backoff (`retry_base` doubling, capped at `retry_cap`), bounded by `retry_budget` wall-clock
  * deterministic errors (SQL binder, file-not-found) and query timeouts fail fast — retryable markers deliberately exclude them
* add `QueryResult` (capped preview rows + full-result metadata, with `dicts()` / `scalar()` helpers) and `DuckyError` dataclasses
* `iap_token_provider()` mints a service-account OIDC token via `rigging` for the IAP proxy path (audience defaults to `MARIN_DESKTOP_OAUTH_CLIENT`)[^1]
* CLI `ducky query` reuses the same client with `retry_budget=0` to preserve fast-fail for interactive users

[^1]: `rigging` is imported lazily inside `iap_token_provider()` so the CLI tunnel path pulls in no IAP/rigging deps.