### PR TITLE
datakit: complete + region-independent reference-pipeline step hashes

### DIFF
--- a/experiments/datakit/embeddings/luxical/pipeline.py
+++ b/experiments/datakit/embeddings/luxical/pipeline.py
@@ -53,6 +53,10 @@ logger = logging.getLogger(__name__)
 
 LUXICAL_REPO = "DatologyAI/luxical-one"
 LUXICAL_WEIGHTS_FILE = "luxical_one_rc4.npz"
+# Immutable HF commit for the weights. Passed to ``hf_hub_download`` so every region
+# fetches identical bytes, and folded into the staging path + embed hash so a retag
+# re-stages and re-keys rather than silently changing embeddings under a fixed hash.
+LUXICAL_REVISION = "474cfeb959dd473b3d1cd61da630f566037e69e2"
 LUXICAL_DIM = 192
 
 # Records per ``embedder(texts)`` call. The native
@@ -105,6 +109,7 @@ class EmbeddingAttrData(BaseModel):
     output_dir: str
     source_main_dir: str
     model_name: str
+    model_revision: str = ""
     embedding_dim: int
     quantization_scale: float
     quantization_range: float
@@ -149,20 +154,22 @@ def _load_embedder_from_shared() -> Any:
     return Embedder.load(local)
 
 
-def _stage_luxical_to_gcs(repo_id: str, weights_filename: str) -> str:
+def _stage_luxical_to_gcs(repo_id: str, weights_filename: str, revision: str) -> str:
     """Download the .npz from HF on the driver and upload it to an in-region TTL'd
     GCS path. Returns the GCS URL workers will read from. Stable per
-    ``(region, repo_id, weights_filename)`` so concurrent / consecutive pipeline
-    runs share the staged file."""
+    ``(region, repo_id, weights_filename, revision)`` so concurrent / consecutive
+    pipeline runs share the staged file, and a revision bump stages to a distinct path."""
     sanitized_repo = repo_id.replace("/", "__")
-    staged_url = f"{marin_temp_bucket(ttl_days=1, prefix='luxical-staging')}/{sanitized_repo}/{weights_filename}"
+    staged_url = (
+        f"{marin_temp_bucket(ttl_days=1, prefix='luxical-staging')}/{sanitized_repo}/{revision}/{weights_filename}"
+    )
     staged = StoragePath(staged_url)
     if staged.exists():
         logger.info("Luxical weights already staged at %s (cache hit)", staged_url)
         return staged_url
 
-    logger.info("Fetching luxical weights %s/%s on driver", repo_id, weights_filename)
-    npz_local = hf_hub_download(repo_id=repo_id, filename=weights_filename)
+    logger.info("Fetching luxical weights %s/%s@%s on driver", repo_id, weights_filename, revision)
+    npz_local = hf_hub_download(repo_id=repo_id, filename=weights_filename, revision=revision)
     size_mb = os.path.getsize(npz_local) / 1e6
     logger.info("Uploading %.1f MB of luxical weights to %s", size_mb, staged_url)
     staged.parent.mkdirs()
@@ -219,6 +226,7 @@ def embed_source(
     *,
     repo_id: str = LUXICAL_REPO,
     weights_filename: str = LUXICAL_WEIGHTS_FILE,
+    revision: str = LUXICAL_REVISION,
     batch_size: int = DEFAULT_BATCH_SIZE,
     max_shards: int | None = None,
     worker_resources: ResourceConfig | None = None,
@@ -255,7 +263,7 @@ def embed_source(
     # will pull the file via fs.get; we only broadcast the URL through
     # Zephyr shared data, so no 880 MB ever touches coordinator RAM or
     # cloudpickle.
-    staged_url = _stage_luxical_to_gcs(repo_id, weights_filename)
+    staged_url = _stage_luxical_to_gcs(repo_id, weights_filename, revision)
 
     # Project columns at read time — partition_id (~8 B/row) is ~120 GB of
     # extra read at 15 B-doc scale, and we don't need it.
@@ -287,6 +295,7 @@ def embed_source(
         output_dir=output_path,
         source_main_dir=normalized.main_output_dir,
         model_name=f"{repo_id}/{weights_filename}",
+        model_revision=revision,
         embedding_dim=LUXICAL_DIM,
         quantization_scale=QUANT_SCALE,
         quantization_range=QUANT_RANGE,

--- a/experiments/datakit/reference_pipeline.py
+++ b/experiments/datakit/reference_pipeline.py
@@ -50,7 +50,32 @@ Submit the sample-mode end-to-end run on iris::
         --enable-extra-resources -e MARIN_PREFIX s3://marin-us-east-02a/marin \\
         -- python -m experiments.datakit.reference_pipeline \\
             --mode sample --sample-prefix s3://.../datakit/sample_100b_8ae7a94f \\
-            --sources all --pool-workers 512
+            --sources all --pool-workers 512 \\
+            --quality-model-version pooled-junkgate2 \\
+            --domain-centroids-version <run-id>
+
+Reproducibility contract
+------------------------
+A step's ``hash_attrs`` is its cross-region identity: it must contain every
+parameter its fn reads, and no region-specific ``gs://`` path (else byte-identical
+data gets a different output path per region). Two consequences:
+
+* External inputs enter the hash as a caller-supplied *version tag*, never their
+  absolute path -- ``quality_model_version`` for the quality model dir and
+  ``centroids_version`` for pre-staged centroids. The HF luxical weights and the
+  tokenizer are pinned to immutable commits (``LUXICAL_REVISION`` /
+  ``TOKENIZER_REVISION``).
+* ``embed`` and ``train_centroids`` are *train-once / replicate* artifacts, not
+  per-region recomputes: luxical inference (float + int8 quantization on
+  heterogeneous CPUs) and faiss K-means (seeded but not bit-stable across machine
+  types / thread counts) can differ bit-for-bit between regions. To reproduce a
+  store exactly, replicate those bytes (pass the trained centroids as
+  ``domain_centroids``) rather than recomputing inline.
+
+Known gap: ``EVAL_ROOT`` (the decontam bloom's eval corpus) is still hashed as a
+``marin_prefix()``-derived path via ``build_eval_bloom_step``, so the bloom (and
+its decontam consumers) re-key per region -- tracked as a follow-up to give the
+eval corpus a version tag.
 """
 
 import argparse
@@ -97,6 +122,7 @@ from experiments.datakit.cluster.quality.fast_transformer.score import score_nor
 from experiments.datakit.decontam.prepare_eval_corpus import DECON_EXCLUDED_EVAL_TASKS
 from experiments.datakit.embeddings.luxical.pipeline import (
     LUXICAL_REPO,
+    LUXICAL_REVISION,
     LUXICAL_WEIGHTS_FILE,
     EmbeddingAttrData,
     embed_source,
@@ -108,16 +134,20 @@ from experiments.datakit.reports.normalize import normalize_report
 from experiments.datakit.reports.quality import quality_report
 from experiments.datakit.reports.store import store_report
 from experiments.datakit.reports.tokenize import tokenize_report
-from experiments.datakit.store.datakit_store import (
-    ClusteredStoreData,
-    build_clustered_store,
-)
+from experiments.datakit.store.datakit_store import ClusteredStoreData, build_clustered_store
 
 logger = logging.getLogger(__name__)
 
 
 # Tokenize: canonical Marin tokenizer. Not scale-sensitive.
 TOKENIZER = "marin-community/marin-tokenizer"
+# Immutable HF commit for the tokenizer. Hashed into the tokenize step so a silent
+# upstream retag invalidates the cache instead of changing token ids under a fixed
+# hash. NOTE: ``levanter.tokenizers.load_tokenizer`` does not yet accept a revision
+# (it stages from a Marin GCS mirror, then HF), so this pins the *recipe identity*;
+# byte-level enforcement is tracked in a follow-up to thread ``revision`` through the
+# loader.
+TOKENIZER_REVISION = "a5ca45f2feb6c959bd87b81689aa7279b5bdcaa2"
 TOKENIZER_BACKEND = TokenizerBackend.HF
 SPLIT = "train"
 
@@ -144,11 +174,21 @@ class ClusterConfig:
     and must be ``k_train`` or one of ``k_views`` -- the assign stage only
     materializes a ``cluster_<K>`` column for those. ``k_train`` must not exceed
     the centroid-training sample size, so shrink it for small inline runs.
+
+    The ``*_seed`` / ``train_n_*`` fields pin the centroid-training recipe so it enters
+    the sample/train hashes. faiss K-means is seeded but not bit-reproducible across
+    machine types / thread counts, so identical bytes across regions require
+    *replicating* the trained centroids (pass them as ``domain_centroids``), not
+    recomputing inline -- see the module docstring's reproducibility note.
     """
 
     k_train: int = 5000
     k_views: tuple[int, ...] = (40, 1000)
     cluster_view: int = 40
+    sample_seed: int = 42
+    train_seed: int = 42
+    train_n_iter: int = 20
+    train_n_redo: int = 3
 
     def __post_init__(self) -> None:
         if self.cluster_view not in (self.k_train, *self.k_views):
@@ -179,6 +219,22 @@ class PoolConfig:
 
 
 @dataclass(frozen=True)
+class MinhashConfig:
+    """Content-determining MinHash / LSH knobs for the fuzzy-dedup stage.
+
+    Not scale-sensitive (a smoke and a full run must agree), but every field shapes
+    the emitted signatures and buckets, so all are hashed into the minhash step -- and
+    thereby, via the minhash deps, into dedup and the store.
+    """
+
+    num_perms: int = 286
+    num_bands: int = 26
+    ngram_size: int = 5
+    text_cap_chars: int | None = 500_000
+    seed: int = 42
+
+
+@dataclass(frozen=True)
 class PipelineScale:
     """Non-resource sizing for :func:`reference_datakit_steps`.
 
@@ -189,6 +245,7 @@ class PipelineScale:
 
     cluster: ClusterConfig = field(default_factory=ClusterConfig)
     pool: PoolConfig = field(default_factory=PoolConfig)
+    minhash: MinhashConfig = field(default_factory=MinhashConfig)
     embed_batch_size: int = 4096
     assign_batch_size: int = 4096
     # Inline domain training: ~100 sources x 100k = ~10M-row centroid sample.
@@ -246,6 +303,7 @@ def _build_embed_step(name: str, normalize_step: StepSpec, scale: PipelineScale)
         hash_attrs={
             "luxical_repo": LUXICAL_REPO,
             "luxical_weights": LUXICAL_WEIGHTS_FILE,
+            "luxical_revision": LUXICAL_REVISION,
             "batch_size": scale.embed_batch_size,
             "v": 1,
         },
@@ -253,6 +311,7 @@ def _build_embed_step(name: str, normalize_step: StepSpec, scale: PipelineScale)
             lambda output_path, np=normalize_step.output_path: embed_source(
                 output_path=output_path,
                 normalized=read_artifact(np, NormalizedData),
+                revision=LUXICAL_REVISION,
                 batch_size=scale.embed_batch_size,
                 worker_resources=scale.pool.worker,
                 max_workers=scale.pool.n_workers,
@@ -288,12 +347,18 @@ def build_train_centroids_step(embed_steps: dict[str, StepSpec], scale: Pipeline
     sample_step = StepSpec(
         name="datakit/cluster/sample_centroids",
         deps=list(embed_steps.values()),
-        hash_attrs={"n_per_source": scale.n_per_source_for_sample, "format": "parquet", "v": 1},
+        hash_attrs={
+            "n_per_source": scale.n_per_source_for_sample,
+            "seed": cluster.sample_seed,
+            "format": "parquet",
+            "v": 1,
+        },
         fn=remote(
             lambda output_path, es={n: s.output_path for n, s in embed_steps.items()}: sample_centroid_inputs(
                 output_path=output_path,
                 embeddings={n: read_artifact(p, EmbeddingAttrData) for n, p in es.items()},
                 n_per_source=scale.n_per_source_for_sample,
+                seed=cluster.sample_seed,
                 worker_resources=scale.pool.worker,
                 max_workers=scale.pool.n_workers,
                 parallel_sources=scale.sample_parallel_sources,
@@ -309,7 +374,15 @@ def build_train_centroids_step(embed_steps: dict[str, StepSpec], scale: Pipeline
     return StepSpec(
         name="datakit/cluster/train_centroids",
         deps=[sample_step],
-        hash_attrs={"k_train": cluster.k_train, "k_views": list(cluster.k_views), "n_threads": n_threads, "v": 1},
+        hash_attrs={
+            "k_train": cluster.k_train,
+            "k_views": list(cluster.k_views),
+            "n_threads": n_threads,
+            "seed": cluster.train_seed,
+            "n_iter": cluster.train_n_iter,
+            "n_redo": cluster.train_n_redo,
+            "v": 1,
+        },
         fn=remote(
             lambda output_path, sp=sample_step.output_path: train_centroids(
                 output_path=output_path,
@@ -317,6 +390,9 @@ def build_train_centroids_step(embed_steps: dict[str, StepSpec], scale: Pipeline
                 k_train=cluster.k_train,
                 k_views=cluster.k_views,
                 n_threads=n_threads,
+                n_iter=cluster.train_n_iter,
+                n_redo=cluster.train_n_redo,
+                seed=cluster.train_seed,
             ),
             resources=scale.train_centroids_resources,
             pip_dependency_groups=["datakit"],
@@ -327,23 +403,48 @@ def build_train_centroids_step(embed_steps: dict[str, StepSpec], scale: Pipeline
 def _resolve_centroids(
     domain_centroids: str | StepSpec,
     cluster: ClusterConfig,
-) -> tuple[str, dict[int, str], list[StepSpec], object]:
-    """Return ``(centroids_uri, lookup_uris, extra_deps, hash_value)`` for assign."""
+    centroids_version: str | None,
+) -> tuple[str, dict[int, str], list[StepSpec], str]:
+    """Return ``(centroids_uri, lookup_uris, extra_deps, hash_value)`` for assign.
+
+    ``hash_value`` is the region-independent identity string mixed into the assign
+    hash by construction: an inline StepSpec contributes its ``name_with_hash``
+    (identity, not the ``MARIN_PREFIX``-rooted output path), and a pre-staged path
+    contributes the caller's ``centroids_version`` tag -- never the absolute ``gs://``
+    path -- so identical centroids resolve to the same assign output path in any region.
+    """
     if isinstance(domain_centroids, StepSpec):
         base = domain_centroids.output_path
         return (
             f"{base}/centroids_{cluster.k_train}.npy",
             {k: f"{base}/lookup_{cluster.k_train}_to_{k}.npy" for k in cluster.k_views},
             [domain_centroids],
-            base,  # already includes a content hash; safe in hash_attrs
+            domain_centroids.name_with_hash,  # region-independent identity (also captured via the dep)
+        )
+    if not centroids_version:
+        raise ValueError(
+            "centroids_version is required when domain_centroids is a pre-staged path: "
+            "the absolute path is region-specific and must not enter the cache hash. "
+            "Pass a stable tag identifying the centroid bytes (e.g. the training run id)."
         )
     base = domain_centroids.rstrip("/")
     return (
         f"{base}/centroids_{cluster.k_train}.npy",
         {k: f"{base}/lookup_{cluster.k_train}_to_{k}.npy" for k in cluster.k_views},
         [],
-        domain_centroids,
+        centroids_version,
     )
+
+
+def _resolve_quality_model_version(quality_model: str, quality_model_version: str | None) -> str:
+    """Return the region-independent identity tag hashed into the quality step."""
+    if not quality_model_version:
+        raise ValueError(
+            f"quality_model_version is required: the quality model dir ({quality_model}) is "
+            "region-specific and must not enter the cache hash. Pass a stable tag "
+            "identifying the model bytes (e.g. 'pooled-junkgate2')."
+        )
+    return quality_model_version
 
 
 @dataclass(frozen=True)
@@ -365,7 +466,9 @@ def reference_datakit_steps(
     sources: dict[str, StepSpec],
     *,
     quality_model: str,
+    quality_model_version: str | None = None,
     domain_centroids: str | StepSpec | None = None,
+    centroids_version: str | None = None,
     scale: PipelineScale = DEFAULT_SCALE,
 ) -> DatakitSteps:
     """Build the reference Datakit DAG over the given normalize steps.
@@ -381,8 +484,11 @@ def reference_datakit_steps(
             misuse fails loudly the first time a downstream step tries
             ``read_artifact(step.output_path, NormalizedData)``.
         quality_model: Directory holding the pooled fast-transformer scorer
-            artifacts plus the calibration json (immutable by convention --
-            the step hash covers the path, not the bytes).
+            artifacts plus the calibration json (immutable by convention).
+        quality_model_version: Required. A stable tag identifying the model bytes
+            (e.g. ``'pooled-junkgate2'``) -- hashed into the quality step in place
+            of the region-specific ``quality_model`` dir, so the same scorer
+            resolves to one output path across regions.
         domain_centroids: A GCS directory holding ``centroids_<k_train>.npy``
             and ``lookup_<k_train>_to_<k>.npy`` for each ``k`` in
             ``scale.cluster.k_views``; a StepSpec whose ``output_path`` will
@@ -391,16 +497,26 @@ def reference_datakit_steps(
             from the per-source embeds. When training inline, ``scale.cluster.k_train``
             must not exceed the centroid sample size -- use a smaller K
             (e.g. ``SMOKE_SCALE``) on small source sets.
+        centroids_version: Required when ``domain_centroids`` is a pre-staged
+            path. A stable tag identifying the centroid bytes (e.g. the training
+            run id) -- hashed into the assign step in place of the region-specific
+            path so identical centroids resolve to one output path across regions.
+            Ignored (and unneeded) for the StepSpec / inline-training case, whose
+            identity comes from the step hash.
         scale: K / fan-out sizing plus the per-stage worker :class:`PoolConfig`.
             ``DEFAULT_SCALE`` is the production full-fleet shape; ``SMOKE_SCALE``
             runs the same DAG end-to-end on a testbed sample.
     """
     cluster = scale.cluster
+    mh = scale.minhash
     embed_steps = build_per_source_embed_steps(sources, scale)
     if domain_centroids is None:
         domain_centroids = build_train_centroids_step(embed_steps, scale)
 
-    centroids_uri, lookup_uris, centroids_deps, centroids_hash = _resolve_centroids(domain_centroids, cluster)
+    centroids_uri, lookup_uris, centroids_deps, centroids_hash = _resolve_centroids(
+        domain_centroids, cluster, centroids_version
+    )
+    quality_model_hash = _resolve_quality_model_version(quality_model, quality_model_version)
 
     # One combined decontam bloom (no merge step); every per-source decon
     # consumes it directly. Same name/params as the testbed decon arm, so runs
@@ -427,6 +543,7 @@ def reference_datakit_steps(
             train_normalize=normalize_step,
             tokenizer=TOKENIZER,
             tokenizer_backend=TOKENIZER_BACKEND,
+            tokenizer_revision=TOKENIZER_REVISION,
             max_workers=scale.pool.n_workers,
             worker_resources=scale.pool.worker,
         )
@@ -462,7 +579,7 @@ def reference_datakit_steps(
         quality = StepSpec(
             name=f"datakit/quality/{name}",
             deps=[normalize_step],
-            hash_attrs={"model_dir": quality_model, "v": 1},
+            hash_attrs={"model_version": quality_model_hash, "v": 1},
             fn=remote(
                 lambda output_path, np=normalize_step.output_path, src=name: score_normalized(
                     output_path=output_path,
@@ -491,9 +608,22 @@ def reference_datakit_steps(
         minhash = StepSpec(
             name=f"datakit/minhash/{name}",
             deps=[normalize_step],
+            hash_attrs={
+                "num_perms": mh.num_perms,
+                "num_bands": mh.num_bands,
+                "ngram_size": mh.ngram_size,
+                "text_cap_chars": mh.text_cap_chars,
+                "seed": mh.seed,
+                "v": 1,
+            },
             fn=lambda op, n=normalize_step: compute_minhash_attrs(
                 source=read_artifact(n.output_path, NormalizedData),
                 output_path=op,
+                num_perms=mh.num_perms,
+                num_bands=mh.num_bands,
+                ngram_size=mh.ngram_size,
+                text_cap_chars=mh.text_cap_chars,
+                seed=mh.seed,
                 worker_resources=scale.pool.worker,
             ),
         )
@@ -509,9 +639,13 @@ def reference_datakit_steps(
         }
 
     # ---- Cross-source dedup ----------------------------------------------------
+    # No content params of its own -- the MinHash params live in the minhash deps
+    # (so a param change re-keys minhash, then dedup via dep names); connected
+    # components is deterministic given those inputs. ``v`` is a manual salt.
     dedup = StepSpec(
         name="datakit/dedup",
         deps=minhash_steps,
+        hash_attrs={"v": 1},
         fn=lambda op: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(s.output_path, MinHashAttrData) for s in minhash_steps],
             output_path=op,
@@ -544,6 +678,11 @@ def reference_datakit_steps(
         store_deps += [s["tokenize"], s["decontam"], s["assign"], s["quality"]]
     store_deps.append(dedup)
 
+    # ``cluster_view`` / ``split`` are read directly by the store fn and are NOT
+    # captured by any dep (the assign step materializes every ``cluster_<K>`` column
+    # regardless of view), so they must be hashed here. The tokenizer is captured via
+    # the tokenize deps, and the quality bucket edges via the quality deps, so both
+    # are intentionally absent.
     store = StepSpec(
         name="datakit/store",
         deps=store_deps,
@@ -720,6 +859,23 @@ def main() -> None:
         help="dir with centroids_<K>.npy + lookup_<K>_to_<k>.npy. Omit to train centroids inline from the embeds.",
     )
     parser.add_argument(
+        "--domain-centroids-version",
+        default=None,
+        help=(
+            "Stable identity tag for --domain-centroids (e.g. the training run id). "
+            "Required with --domain-centroids: hashed in place of the region-specific "
+            "path so identical centroids resolve to one output path across regions."
+        ),
+    )
+    parser.add_argument(
+        "--quality-model-version",
+        required=True,
+        help=(
+            "Stable identity tag for --quality-model (e.g. 'pooled-junkgate2'). Hashed in "
+            "place of the region-specific model dir for cross-region reproducibility."
+        ),
+    )
+    parser.add_argument(
         "--sources",
         default=None,
         help="comma-separated source names, or 'all' for every source. Omit: full=all, sample=curated subset.",
@@ -748,7 +904,9 @@ def main() -> None:
     result = reference_datakit_steps(
         sources,
         quality_model=args.quality_model,
+        quality_model_version=args.quality_model_version,
         domain_centroids=args.domain_centroids,
+        centroids_version=args.domain_centroids_version,
         scale=scale,
     )
     StepRunner().run(result.all_steps, max_concurrent=args.max_concurrent)

--- a/lib/marin/src/marin/processing/tokenize/attributes.py
+++ b/lib/marin/src/marin/processing/tokenize/attributes.py
@@ -234,6 +234,7 @@ def tokenize_attributes_step(
     validation_normalize: StepSpec | None = None,
     tokenizer: str,
     tokenizer_backend: TokenizerBackend = TokenizerBackend.HF,
+    tokenizer_revision: str | None = None,
     data_format: LmDatasetFormatBase | None = None,
     sample_count: int | None = None,
     text_field: str = "text",
@@ -254,6 +255,10 @@ def tokenize_attributes_step(
         validation_normalize: Upstream normalize step whose output feeds the validation split.
         tokenizer: Tokenizer name/path forwarded to :class:`TokenizeAttributesConfig`.
         tokenizer_backend: Tokenizer backend.
+        tokenizer_revision: Optional immutable HF commit to pin. When set it is folded
+            into the step hash so a retag invalidates the cache. NOTE: identity-only
+            today -- ``levanter.tokenizers.load_tokenizer`` does not yet accept a
+            revision, so it does not change which bytes are fetched (tracked follow-up).
         data_format: Levanter :class:`LmDatasetFormatBase`. Defaults to ``TextLmDatasetFormat()``.
         sample_count: Per-shard sample cap, or ``None`` for full data.
         text_field: Record field used for id fallback when input lacks ``id``.
@@ -287,16 +292,21 @@ def tokenize_attributes_step(
             kwargs["worker_resources"] = worker_resources
         return tokenize_attributes(TokenizeAttributesConfig(**kwargs))
 
+    hash_attrs: dict = {
+        "tokenizer": tokenizer,
+        "tokenizer_backend": tokenizer_backend.value,
+        "format": repr(fmt),
+        "sample_count": sample_count,
+        "text_field": text_field,
+    }
+    # Only add the key when pinned, so existing callers keep their current hash.
+    if tokenizer_revision is not None:
+        hash_attrs["tokenizer_revision"] = tokenizer_revision
+
     return StepSpec(
         name=name,
         deps=deps,
         fn=_fn,
-        hash_attrs={
-            "tokenizer": tokenizer,
-            "tokenizer_backend": tokenizer_backend.value,
-            "format": repr(fmt),
-            "sample_count": sample_count,
-            "text_field": text_field,
-        },
+        hash_attrs=hash_attrs,
         override_output_path=override_output_path,
     )

--- a/tests/datakit/test_reference_pipeline_hashing.py
+++ b/tests/datakit/test_reference_pipeline_hashing.py
@@ -1,0 +1,126 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Cache-identity (``hash_attrs``) regression tests for the reference Datakit DAG.
+
+These are pure StepSpec-construction tests -- no cluster, no data. They lock in the
+cache-identity contract: every content-determining parameter enters the step hash, no
+region-specific ``gs://`` path does, and external inputs are pinned by a caller
+version tag rather than their absolute path.
+"""
+
+import dataclasses
+import json
+
+import pytest
+from marin.execution.step_spec import StepSpec
+
+from experiments.datakit import reference_pipeline
+from experiments.datakit.reference_pipeline import SMOKE_SCALE, PoolConfig, reference_datakit_steps
+
+
+@pytest.fixture(autouse=True)
+def _marin_prefix(monkeypatch):
+    # ``StepSpec.output_path`` resolves ``marin_prefix()``; pin it so the test never
+    # depends on ambient GCS metadata. (``hash_id`` itself excludes the prefix.)
+    monkeypatch.setenv("MARIN_PREFIX", "gs://marin-test-region")
+
+
+def _sources() -> dict[str, StepSpec]:
+    return {name: StepSpec(name=f"datakit/normalize/{name}", fn=lambda op: None) for name in ("a", "b")}
+
+
+def _build(*, scale=SMOKE_SCALE, **kw):
+    return reference_datakit_steps(
+        _sources(),
+        quality_model="gs://some-region/quality/pooled_junkgate2",
+        quality_model_version="pooled-junkgate2",
+        scale=scale,
+        **kw,
+    )
+
+
+def _steps_by_name(result) -> dict[str, StepSpec]:
+    return {s.name: s for s in result.all_steps}
+
+
+def test_no_region_path_in_hash_attrs_except_known_bloom_gap():
+    # A region-specific gs:// path in a hash means byte-identical data gets a
+    # different output path per region. The only remaining leak is the decontam
+    # bloom's EVAL_ROOT (tracked follow-up); everything else must be clean.
+    for step in _build().all_steps:
+        if step.name == "datakit/bloom/_combined_fixed":
+            continue
+        assert "gs://" not in json.dumps(step.hash_attrs, default=str), f"{step.name} leaks a gs:// path into its hash"
+
+
+def test_store_hash_tracks_content_not_resources():
+    base = _build().output_buckets.hash_id
+    # cluster_view is read by the store fn and NOT captured by any dep -> must re-key.
+    cv = dataclasses.replace(SMOKE_SCALE.cluster, cluster_view=16)
+    changed = _build(scale=dataclasses.replace(SMOKE_SCALE, cluster=cv)).output_buckets.hash_id
+    # The worker fleet is execution policy -> must NOT re-key.
+    pool = dataclasses.replace(SMOKE_SCALE, pool=PoolConfig(n_workers=999))
+    resourced = _build(scale=pool).output_buckets.hash_id
+    assert changed != base
+    assert resourced == base
+
+
+def test_minhash_params_rekey_minhash_and_dedup():
+    base = _steps_by_name(_build())
+    mh = dataclasses.replace(SMOKE_SCALE.minhash, num_bands=13)
+    changed = _steps_by_name(_build(scale=dataclasses.replace(SMOKE_SCALE, minhash=mh)))
+    assert changed["datakit/minhash/a"].hash_id != base["datakit/minhash/a"].hash_id
+    # dedup has no params of its own; it must re-key via its minhash deps.
+    assert changed["datakit/dedup"].hash_id != base["datakit/dedup"].hash_id
+
+
+def test_centroid_seed_rekeys_training():
+    base = _steps_by_name(_build())["datakit/cluster/train_centroids"].hash_id
+    seeded = dataclasses.replace(SMOKE_SCALE.cluster, train_seed=7)
+    changed = _steps_by_name(_build(scale=dataclasses.replace(SMOKE_SCALE, cluster=seeded)))
+    assert changed["datakit/cluster/train_centroids"].hash_id != base
+
+
+@pytest.mark.parametrize(
+    ("constant", "step"),
+    [("LUXICAL_REVISION", "datakit/embed/a"), ("TOKENIZER_REVISION", "datakit/tokenize/a")],
+)
+def test_upstream_revision_bump_rekeys_its_step(monkeypatch, constant, step):
+    # The pins exist so a retagged upstream artifact invalidates the cache rather than
+    # silently serving bytes built from the old revision.
+    base = _steps_by_name(_build())[step].hash_id
+    monkeypatch.setattr(reference_pipeline, constant, "deadbeef")
+    assert _steps_by_name(_build())[step].hash_id != base
+
+
+def test_external_path_requires_version_tag():
+    with pytest.raises(ValueError, match="quality_model_version is required"):
+        reference_datakit_steps(_sources(), quality_model="gs://r/model", quality_model_version=None)
+    with pytest.raises(ValueError, match="centroids_version is required"):
+        reference_datakit_steps(
+            _sources(),
+            quality_model="gs://r/model",
+            quality_model_version="v",
+            domain_centroids="gs://r/centroids",
+            centroids_version=None,
+        )
+
+
+def test_quality_model_version_not_path_drives_identity():
+    # Same model bytes staged at two region paths, same version tag -> one output path.
+    def quality_hash(model_dir: str) -> str:
+        result = reference_datakit_steps(
+            _sources(), quality_model=model_dir, quality_model_version="pooled-junkgate2", scale=SMOKE_SCALE
+        )
+        return _steps_by_name(result)["datakit/quality/a"].hash_id
+
+    assert quality_hash("gs://region-a/quality/m") == quality_hash("gs://region-b/quality/m")
+
+
+def test_centroids_version_not_path_drives_identity():
+    def assign_hash(centroids_dir: str) -> str:
+        result = _build(domain_centroids=centroids_dir, centroids_version="run-42")
+        return _steps_by_name(result)["datakit/cluster_assign/a"].hash_id
+
+    assert assign_hash("gs://region-a/centroids") == assign_hash("gs://region-b/centroids")


### PR DESCRIPTION
* every reference-pipeline step's `hash_attrs` is now a complete, region-independent cache identity: it carries every parameter its `fn` reads, and no region-specific `gs://` path
* content params that were silently un-hashed (changing them served a stale cache):
  * `minhash` — the step had **no** `hash_attrs` at all; `num_perms`/`num_bands`/`ngram_size`/`text_cap_chars`/`seed` were `fn` defaults [^1]
  * `dedup` inherits them via its minhash deps
  * `sample`/`train` centroids — hash `sample_seed`, `train_seed`, `n_iter`, `n_redo` (`train.py` docstring claimed the result was pinned to `(sample, seed, n_threads)`; `seed` was exactly the one not hashed)
* region paths / unpinned externals (broke cross-region reproducibility):
  * external inputs enter the hash as a caller-supplied version tag, never their absolute path — `quality_model_version` / `centroids_version`, both fail fast when the model/centroids come in as a path; an inline-centroids `StepSpec` contributes its region-independent `name_with_hash`
  * pin luxical (`LUXICAL_REVISION`, threaded through `hf_hub_download(revision=)` + the staging path) and the tokenizer (`TOKENIZER_REVISION`, into the tokenize hash) [^2]
* new config: `MinhashConfig` + `sample_seed`/`train_seed`/`train_n_iter`/`train_n_redo` on `ClusterConfig` (small frozen sub-configs on `PipelineScale`)
* **breaking**: `--quality-model-version` is now required
* adds `tests/datakit/test_reference_pipeline_hashing.py` — pure StepSpec-construction tests locking the contract (content re-keys, resources don't, no `gs://` in hashes, version-tag fail-fast, revision bumps re-key)

follow-ups, not in this PR:
* thread `revision` through `levanter.tokenizers.load_tokenizer` for a true tokenizer byte-pin
* `BUCKET_EDGES` (`cluster/quality/fast_transformer/artifact.py`) is an unhashed module constant — editing it re-buckets every doc against a warm cache
* give `EVAL_ROOT` / `build_eval_bloom_step` a version tag so the decontam bloom stops re-keying per region [^3]

[^1]: `compute_minhash_attrs_step` at `lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py:256` already hashes exactly these five keys — the reference pipeline hand-rolled its own `StepSpec` and lost the hashing. Collapsing onto the helper is the cleaner fix and is flagged by lint (`ml-reinvents-existing-helper`); kept separate to keep this diff to hash semantics.
[^2]: `tokenizer_revision` enters the tokenize hash but `load_tokenizer` does not consume it, so a bump re-keys the cache without by itself changing which bytes are fetched. Flagged by lint (`ml-config-not-threaded`); kept as a cross-layer follow-up rather than expanding this PR into `levanter`.
[^3]: `EVAL_ROOT` is a `marin_prefix()`-derived path hashed via the shared `build_eval_bloom_step`; fixing it means giving the eval corpus a content/version tag in the decontam subsystem.
