### PR TITLE
execution: StepRunner persists full artifact records (name, deps, config, provenance)

### DIFF
--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -24,7 +24,7 @@ import functools
 import json
 import logging
 import threading
-from dataclasses import asdict, is_dataclass
+from dataclasses import asdict, dataclass, is_dataclass
 from typing import Self, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field
@@ -318,34 +318,40 @@ def _best_effort_provenance() -> Provenance:
         return _capture_provenance_once()
 
 
-def write_step_record(
-    *,
-    name: str,
-    output_path: str,
-    deps: list[str],
-    dep_paths: list[str],
-    config: dict[str, JSONValue] | None,
-    result: object,
-    fingerprint_payload: str | None = None,
-) -> None:
+@dataclass(frozen=True)
+class StepRecordIdentity:
+    """Identity + lineage of a ``StepRunner`` step, as plain data (no callable) so a remote
+    write site can serialize it into a worker closure."""
+
+    name: str
+    deps: list[str]
+    """Dependency identities, each a ``name_with_hash``."""
+    dep_paths: list[str]
+    """Resolved dependency locations, aligned index-wise with ``deps``."""
+    config: dict[str, JSONValue] | None
+    """The step's ``hash_attrs`` -- its materialized identity params."""
+    fingerprint_payload: str | None = None
+
+
+def write_step_record(identity: StepRecordIdentity, *, output_path: str, result: object) -> None:
     """Persist a ``StepRunner`` step's full record: identity + lineage + payload + provenance.
 
     Unlike :func:`write_artifact` (which records only ``output_path`` + ``result``), this carries
     the ``name``, the dependency identities (``deps`` -- each a ``name_with_hash``) alongside their
     resolved locations (``dep_paths`` -- where each dep's record actually lives, even when the dep
-    overrode its output path), the ``config`` that determined the output (a StepSpec's
-    ``hash_attrs``), and best-effort provenance -- so a produced directory answers "what made me,
-    from what" on its own, walkable recursively through ``dep_paths``.
+    overrode its output path), the ``config`` that determined the output, and best-effort
+    provenance -- so a produced directory answers "what made me, from what" on its own, walkable
+    recursively through ``dep_paths``.
     """
     write_record(
         ArtifactRecord(
-            name=name,
+            name=identity.name,
             output_path=output_path,
-            deps=deps,
-            dep_paths=dep_paths,
-            config=config,
+            deps=identity.deps,
+            dep_paths=identity.dep_paths,
+            config=identity.config,
             result=_payload_json(result) if result is not None else None,
-            fingerprint_payload=fingerprint_payload,
+            fingerprint_payload=identity.fingerprint_payload,
             provenance=_best_effort_provenance(),
         )
     )

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -158,6 +158,10 @@ class ArtifactRecord(BaseModel):
     output_path: str = ""
     deps: list[str] = Field(default_factory=list)
     """Dependency identities as ``name@version`` strings."""
+    dep_paths: list[str] = Field(default_factory=list)
+    """Resolved output paths of the dependencies, aligned index-wise with ``deps``. ``deps`` is
+    the portable identity; this is where each dep's record actually lives, which differs from a
+    reconstruction off the identity when the dep overrode its output path."""
     config: dict[str, JSONValue] | None = None
     """The materialized config that ran (canonical-encoded), for humans and consumer metadata."""
     source: str | None = None
@@ -294,30 +298,21 @@ def write_artifact(value: object, output_path: str) -> None:
 
 
 @functools.cache
-def _capture_provenance_once() -> Provenance | None:
-    """``Provenance.capture()`` or ``None`` when the ``git`` binary is absent.
-
-    ``capture()`` degrades every git field to empty *outside* a checkout, but still shells out to
-    ``git`` -- a missing binary raises ``FileNotFoundError``, which it does not catch. A step often
-    runs from a ``.git``-less bundle (or an image without git at all), so guard it: a record must
-    never fail to write because provenance could not be stamped.
-    """
-    try:
-        return Provenance.capture()
-    except FileNotFoundError:
-        return None
+def _capture_provenance_once() -> Provenance:
+    return Provenance.capture()
 
 
 _provenance_lock = threading.Lock()
 
 
-def _best_effort_provenance() -> Provenance | None:
+def _best_effort_provenance() -> Provenance:
     """The run's provenance, captured once per process.
 
     Provenance is constant within a run, so capture it once: the runner writes records from many
     worker threads, and calling ``capture()`` per step would both repeat the work and race on the
     repo's ``index.lock`` (``git stash create``) when the driver runs from a real checkout. The
-    lock serializes the first, cache-filling call across those threads.
+    lock serializes the first, cache-filling call across those threads. ``capture()`` itself never
+    raises -- git fields degrade to empty outside a checkout or without a ``git`` binary.
     """
     with _provenance_lock:
         return _capture_provenance_once()
@@ -328,6 +323,7 @@ def write_step_record(
     name: str,
     output_path: str,
     deps: list[str],
+    dep_paths: list[str],
     config: dict[str, JSONValue] | None,
     result: object,
     fingerprint_payload: str | None = None,
@@ -335,16 +331,18 @@ def write_step_record(
     """Persist a ``StepRunner`` step's full record: identity + lineage + payload + provenance.
 
     Unlike :func:`write_artifact` (which records only ``output_path`` + ``result``), this carries
-    the ``name``, the dependency identities (``deps`` -- each a ``name_with_hash`` that reconstructs
-    the dep's output directory under ``marin_prefix()``), the ``config`` that determined the output
-    (a StepSpec's ``hash_attrs``), and best-effort provenance -- so a produced directory answers
-    "what made me, from what" on its own, walkable recursively through ``deps``.
+    the ``name``, the dependency identities (``deps`` -- each a ``name_with_hash``) alongside their
+    resolved locations (``dep_paths`` -- where each dep's record actually lives, even when the dep
+    overrode its output path), the ``config`` that determined the output (a StepSpec's
+    ``hash_attrs``), and best-effort provenance -- so a produced directory answers "what made me,
+    from what" on its own, walkable recursively through ``dep_paths``.
     """
     write_record(
         ArtifactRecord(
             name=name,
             output_path=output_path,
             deps=deps,
+            dep_paths=dep_paths,
             config=config,
             result=_payload_json(result) if result is not None else None,
             fingerprint_payload=fingerprint_payload,

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -23,6 +23,7 @@ their producers (``LevanterCheckpoint`` in ``marin.training.training``, ``Tokeni
 import functools
 import json
 import logging
+import threading
 from dataclasses import asdict, is_dataclass
 from typing import Self, TypeVar, cast
 
@@ -290,6 +291,66 @@ def read_artifact(output_path: str, schema: type[M]) -> M:
 def write_artifact(value: object, output_path: str) -> None:
     """Write a minimal record carrying ``value`` as its ``result`` — the manual save API."""
     write_record(ArtifactRecord(output_path=output_path, result=_payload_json(value)))
+
+
+@functools.cache
+def _capture_provenance_once() -> Provenance | None:
+    """``Provenance.capture()`` or ``None`` when the ``git`` binary is absent.
+
+    ``capture()`` degrades every git field to empty *outside* a checkout, but still shells out to
+    ``git`` -- a missing binary raises ``FileNotFoundError``, which it does not catch. A step often
+    runs from a ``.git``-less bundle (or an image without git at all), so guard it: a record must
+    never fail to write because provenance could not be stamped.
+    """
+    try:
+        return Provenance.capture()
+    except FileNotFoundError:
+        return None
+
+
+_provenance_lock = threading.Lock()
+
+
+def _best_effort_provenance() -> Provenance | None:
+    """The run's provenance, captured once per process.
+
+    Provenance is constant within a run, so capture it once: the runner writes records from many
+    worker threads, and calling ``capture()`` per step would both repeat the work and race on the
+    repo's ``index.lock`` (``git stash create``) when the driver runs from a real checkout. The
+    lock serializes the first, cache-filling call across those threads.
+    """
+    with _provenance_lock:
+        return _capture_provenance_once()
+
+
+def write_step_record(
+    *,
+    name: str,
+    output_path: str,
+    deps: list[str],
+    config: dict[str, JSONValue] | None,
+    result: object,
+    fingerprint_payload: str | None = None,
+) -> None:
+    """Persist a ``StepRunner`` step's full record: identity + lineage + payload + provenance.
+
+    Unlike :func:`write_artifact` (which records only ``output_path`` + ``result``), this carries
+    the ``name``, the dependency identities (``deps`` -- each a ``name_with_hash`` that reconstructs
+    the dep's output directory under ``marin_prefix()``), the ``config`` that determined the output
+    (a StepSpec's ``hash_attrs``), and best-effort provenance -- so a produced directory answers
+    "what made me, from what" on its own, walkable recursively through ``deps``.
+    """
+    write_record(
+        ArtifactRecord(
+            name=name,
+            output_path=output_path,
+            deps=deps,
+            config=config,
+            result=_payload_json(result) if result is not None else None,
+            fingerprint_payload=fingerprint_payload,
+            provenance=_best_effort_provenance(),
+        )
+    )
 
 
 def check_drift(step: StepSpec) -> bool:

--- a/lib/marin/src/marin/execution/step_runner.py
+++ b/lib/marin/src/marin/execution/step_runner.py
@@ -35,7 +35,7 @@ from marin.execution.artifact import (
     VERSION_KEY,
     check_drift,
     is_mutable_version,
-    write_artifact,
+    write_step_record,
 )
 from marin.execution.remote import RemoteCallable, _sanitize_job_name
 from marin.execution.step_spec import StepSpec
@@ -390,13 +390,28 @@ def check_cache(output_path: str) -> bool:
     return False
 
 
+def _step_record_identity(step: StepSpec) -> dict[str, Any]:
+    """The step's record identity (name, dep refs, config, fingerprint) as a plain dict.
+
+    One mapping for both write sites, and plain/serializable so the remote worker closure
+    captures only this -- never the ``StepSpec`` (which carries ``fn``).
+    """
+    return {
+        "name": step.name,
+        "deps": step.dep_names,
+        "config": step.hash_attrs,
+        "fingerprint_payload": step.fingerprint_payload,
+    }
+
+
 def run_step(step: StepSpec) -> None:
     """Execute a single step with explicit cache check, locking, heartbeat, and artifact saving.
 
     An inline step that does not write its own record (``writes_record=False``) has its
-    return saved via :func:`~marin.execution.artifact.write_artifact`. For ``RemoteCallable``
-    steps (or any step with explicit ``resources``), the raw function + artifact save are
-    submitted as a Fray job; the runner process only manages the lock and status file.
+    return saved via :func:`~marin.execution.artifact.write_step_record` (identity + lineage +
+    payload). For ``RemoteCallable`` steps (or any step with explicit ``resources``), the raw
+    function + artifact save are submitted as a Fray job; the runner process only manages the
+    lock and status file.
     """
     output_path = step.output_path
     step_label = step.name_with_hash
@@ -420,9 +435,10 @@ def run_step(step: StepSpec) -> None:
                     _run_remote_step(step, output_path)
                 else:
                     result = step.fn(output_path)  # pyrefly: ignore[not-callable]
-                    # A lazy step writes its own full record; a plain step's return is saved.
+                    # A lazy step writes its own full record; a plain step's return is saved
+                    # with its identity + lineage (name, deps, config) so the output is traceable.
                     if not step.writes_record:
-                        write_artifact(result, output_path)
+                        write_step_record(output_path=output_path, result=result, **_step_record_identity(step))
                 elapsed = timedelta(seconds=time.monotonic() - t0)
 
                 # 4. Mark success
@@ -447,13 +463,16 @@ def _submit_iris_job(
     """Submit ``raw_fn(output_path)`` as a Fray job and block until completion.
 
     ``raw_fn`` is wrapped to also persist its return value via
-    :func:`~marin.execution.artifact.write_artifact` inside the submitted job, since Fray
+    :func:`~marin.execution.artifact.write_step_record` inside the submitted job, since Fray
     jobs cannot return values back to the caller.
     """
+    # Extract identity as plain data (not the StepSpec, which carries ``fn``) so the worker
+    # closure serializes only JSON-able fields.
+    identity = _step_record_identity(step)
 
     def _fn_with_artifact_save() -> None:
         result = raw_fn(output_path)
-        write_artifact(result, output_path)
+        write_step_record(output_path=output_path, result=result, **identity)
 
     job_name = _sanitize_job_name(f"{step.name_with_hash}-{uuid.uuid4().hex[:8]}")
     dependency_groups = dependency_groups_for_resources(resources, pip_dependency_groups)

--- a/lib/marin/src/marin/execution/step_runner.py
+++ b/lib/marin/src/marin/execution/step_runner.py
@@ -399,6 +399,7 @@ def _step_record_identity(step: StepSpec) -> dict[str, Any]:
     return {
         "name": step.name,
         "deps": step.dep_names,
+        "dep_paths": step.dep_paths,
         "config": step.hash_attrs,
         "fingerprint_payload": step.fingerprint_payload,
     }

--- a/lib/marin/src/marin/execution/step_runner.py
+++ b/lib/marin/src/marin/execution/step_runner.py
@@ -33,6 +33,7 @@ from marin.execution.artifact import (
     FINGERPRINT_KEY,
     STEP_RUNNER_EXECUTOR_VERSION,
     VERSION_KEY,
+    StepRecordIdentity,
     check_drift,
     is_mutable_version,
     write_step_record,
@@ -390,19 +391,15 @@ def check_cache(output_path: str) -> bool:
     return False
 
 
-def _step_record_identity(step: StepSpec) -> dict[str, Any]:
-    """The step's record identity (name, dep refs, config, fingerprint) as a plain dict.
-
-    One mapping for both write sites, and plain/serializable so the remote worker closure
-    captures only this -- never the ``StepSpec`` (which carries ``fn``).
-    """
-    return {
-        "name": step.name,
-        "deps": step.dep_names,
-        "dep_paths": step.dep_paths,
-        "config": step.hash_attrs,
-        "fingerprint_payload": step.fingerprint_payload,
-    }
+def _step_record_identity(step: StepSpec) -> StepRecordIdentity:
+    """The step's record identity, safe to serialize -- never the ``StepSpec``, which carries ``fn``."""
+    return StepRecordIdentity(
+        name=step.name,
+        deps=step.dep_names,
+        dep_paths=step.dep_paths,
+        config=step.hash_attrs,
+        fingerprint_payload=step.fingerprint_payload,
+    )
 
 
 def run_step(step: StepSpec) -> None:
@@ -439,7 +436,7 @@ def run_step(step: StepSpec) -> None:
                     # A lazy step writes its own full record; a plain step's return is saved
                     # with its identity + lineage (name, deps, config) so the output is traceable.
                     if not step.writes_record:
-                        write_step_record(output_path=output_path, result=result, **_step_record_identity(step))
+                        write_step_record(_step_record_identity(step), output_path=output_path, result=result)
                 elapsed = timedelta(seconds=time.monotonic() - t0)
 
                 # 4. Mark success
@@ -467,13 +464,11 @@ def _submit_iris_job(
     :func:`~marin.execution.artifact.write_step_record` inside the submitted job, since Fray
     jobs cannot return values back to the caller.
     """
-    # Extract identity as plain data (not the StepSpec, which carries ``fn``) so the worker
-    # closure serializes only JSON-able fields.
     identity = _step_record_identity(step)
 
     def _fn_with_artifact_save() -> None:
         result = raw_fn(output_path)
-        write_step_record(output_path=output_path, result=result, **identity)
+        write_step_record(identity, output_path=output_path, result=result)
 
     job_name = _sanitize_job_name(f"{step.name_with_hash}-{uuid.uuid4().hex[:8]}")
     dependency_groups = dependency_groups_for_resources(resources, pip_dependency_groups)

--- a/lib/rigging/src/rigging/provenance.py
+++ b/lib/rigging/src/rigging/provenance.py
@@ -79,13 +79,19 @@ class Provenance:
         """Best-effort provenance of the current launch: git context plus the origin
         remote, capture time, and argv.
 
-        Tolerant: every git field degrades to empty/``None`` outside a checkout, so
-        it never raises. Use to stamp an artifact built by an arbitrary run.
+        Tolerant: every git field degrades to empty/``None`` outside a checkout or when
+        the ``git`` binary is absent, so it never raises. Use to stamp an artifact built
+        by an arbitrary run.
         """
         cwd = str(repo_dir) if repo_dir is not None else None
 
         def g(*args: str) -> str:
-            return _git(list(args), cwd, check=False)
+            # A missing `git` binary (bundle image without git) degrades like being outside
+            # a checkout: git fields empty, launch context still captured.
+            try:
+                return _git(list(args), cwd, check=False)
+            except FileNotFoundError:
+                return ""
 
         stash = g("stash", "create")
         ref = stash or "HEAD"

--- a/lib/rigging/tests/test_provenance.py
+++ b/lib/rigging/tests/test_provenance.py
@@ -92,6 +92,18 @@ def test_capture_is_best_effort_outside_a_repo(tmp_path):
     assert p.created_at  # timestamp, captured regardless of git
 
 
+def test_capture_tolerates_missing_git_binary(tmp_path, monkeypatch):
+    # A bundle image may lack git entirely: subprocess raises FileNotFoundError instead of
+    # returning a nonzero exit. capture degrades like being outside a checkout.
+    monkeypatch.setenv("PATH", "")
+    p = Provenance.capture(tmp_path)
+    assert p.tree_hash == ""
+    assert p.base_commit == ""
+    assert p.dirty is False
+    assert p.command_line  # argv, captured regardless of git
+    assert p.created_at  # timestamp, captured regardless of git
+
+
 def test_json_round_trip_preserves_run_fields():
     p = Provenance(
         tree_hash="aaaa",

--- a/tests/execution/test_artifact.py
+++ b/tests/execution/test_artifact.py
@@ -16,6 +16,7 @@ import pytest
 from marin.execution.artifact import (
     Artifact,
     FingerprintMismatchError,
+    StepRecordIdentity,
     read_artifact,
     read_record,
     write_artifact,
@@ -280,13 +281,15 @@ def test_write_step_record_roundtrips_identity_and_payload(tmp_path):
     stamps best-effort provenance without failing when git is unavailable."""
     out = tmp_path.as_posix()
     write_step_record(
-        name="child",
+        StepRecordIdentity(
+            name="child",
+            deps=["parent_ab12cd34"],
+            dep_paths=[f"{out}/normalize"],
+            config={"tokenizer": "gpt2"},
+            fingerprint_payload="fp-json",
+        ),
         output_path=out,
-        deps=["parent_ab12cd34"],
-        dep_paths=[f"{out}/normalize"],
-        config={"tokenizer": "gpt2"},
         result=_Meta(path=out, n=7),
-        fingerprint_payload="fp-json",
     )
 
     rec = read_record(out)
@@ -304,7 +307,8 @@ def test_write_step_record_roundtrips_identity_and_payload(tmp_path):
 def test_write_step_record_tolerates_none_result(tmp_path):
     """A side-effect step (fn returns None) records identity + lineage with a null payload."""
     out = tmp_path.as_posix()
-    write_step_record(name="train", output_path=out, deps=[], dep_paths=[], config={"seed": 42}, result=None)
+    identity = StepRecordIdentity(name="train", deps=[], dep_paths=[], config={"seed": 42})
+    write_step_record(identity, output_path=out, result=None)
 
     rec = read_record(out)
     assert rec is not None

--- a/tests/execution/test_artifact.py
+++ b/tests/execution/test_artifact.py
@@ -283,6 +283,7 @@ def test_write_step_record_roundtrips_identity_and_payload(tmp_path):
         name="child",
         output_path=out,
         deps=["parent_ab12cd34"],
+        dep_paths=[f"{out}/normalize"],
         config={"tokenizer": "gpt2"},
         result=_Meta(path=out, n=7),
         fingerprint_payload="fp-json",
@@ -292,17 +293,18 @@ def test_write_step_record_roundtrips_identity_and_payload(tmp_path):
     assert rec is not None
     assert rec.name == "child"
     assert rec.deps == ["parent_ab12cd34"]
+    assert rec.dep_paths == [f"{out}/normalize"]
     assert rec.config == {"tokenizer": "gpt2"}
     assert rec.fingerprint_payload == "fp-json"
     assert rec.result == {"path": out, "n": 7}
-    # provenance is best-effort: a value in a checkout, None on a git-less bundle; never raises
+    # provenance is best-effort: git fields degrade to empty on a git-less bundle; never raises
     assert read_artifact(out, _Meta).n == 7
 
 
 def test_write_step_record_tolerates_none_result(tmp_path):
     """A side-effect step (fn returns None) records identity + lineage with a null payload."""
     out = tmp_path.as_posix()
-    write_step_record(name="train", output_path=out, deps=[], config={"seed": 42}, result=None)
+    write_step_record(name="train", output_path=out, deps=[], dep_paths=[], config={"seed": 42}, result=None)
 
     rec = read_record(out)
     assert rec is not None

--- a/tests/execution/test_artifact.py
+++ b/tests/execution/test_artifact.py
@@ -19,6 +19,7 @@ from marin.execution.artifact import (
     read_artifact,
     read_record,
     write_artifact,
+    write_step_record,
 )
 from marin.execution.lazy import ArtifactStep, run
 from pydantic import BaseModel
@@ -267,3 +268,44 @@ def test_read_record_ignores_step_runner_stub(tmp_path):
     (tmp_path / ".executor_info").write_text(_STEP_RUNNER_STUB)
 
     assert read_record(tmp_path.as_posix()) is None
+
+
+class _Meta(BaseModel):
+    path: str
+    n: int
+
+
+def test_write_step_record_roundtrips_identity_and_payload(tmp_path):
+    """The full step record carries name/deps/config/fingerprint_payload + the typed payload, and
+    stamps best-effort provenance without failing when git is unavailable."""
+    out = tmp_path.as_posix()
+    write_step_record(
+        name="child",
+        output_path=out,
+        deps=["parent_ab12cd34"],
+        config={"tokenizer": "gpt2"},
+        result=_Meta(path=out, n=7),
+        fingerprint_payload="fp-json",
+    )
+
+    rec = read_record(out)
+    assert rec is not None
+    assert rec.name == "child"
+    assert rec.deps == ["parent_ab12cd34"]
+    assert rec.config == {"tokenizer": "gpt2"}
+    assert rec.fingerprint_payload == "fp-json"
+    assert rec.result == {"path": out, "n": 7}
+    # provenance is best-effort: a value in a checkout, None on a git-less bundle; never raises
+    assert read_artifact(out, _Meta).n == 7
+
+
+def test_write_step_record_tolerates_none_result(tmp_path):
+    """A side-effect step (fn returns None) records identity + lineage with a null payload."""
+    out = tmp_path.as_posix()
+    write_step_record(name="train", output_path=out, deps=[], config={"seed": 42}, result=None)
+
+    rec = read_record(out)
+    assert rec is not None
+    assert rec.name == "train"
+    assert rec.config == {"seed": 42}
+    assert rec.result is None

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -11,7 +11,14 @@ import marin.execution.step_runner as step_runner_module
 import pytest
 from fray.current_client import current_client, set_current_client
 from fray.types import ResourceConfig
-from marin.execution.artifact import FINGERPRINT_KEY, VERSION_KEY, Artifact, read_artifact, write_artifact
+from marin.execution.artifact import (
+    FINGERPRINT_KEY,
+    VERSION_KEY,
+    Artifact,
+    read_artifact,
+    read_record,
+    write_artifact,
+)
 from marin.execution.remote import RemoteCallable, remote
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
@@ -147,6 +154,39 @@ def test_runner_saves_artifact_automatically(tmp_path):
 
     loaded = read_artifact(out, Artifact)
     assert loaded.path == out
+
+
+def test_runner_record_carries_lineage(tmp_path):
+    """A runner-saved record carries identity + lineage (name, deps, config), not just the payload.
+
+    ``deps`` holds each parent's ``name_with_hash`` -- the region-independent identity that
+    reconstructs the parent's output directory -- so a produced artifact is walkable back to its
+    inputs by reading records alone.
+    """
+    prefix = tmp_path.as_posix()
+    parent = StepSpec(
+        name="parent",
+        output_path_prefix=prefix,
+        hash_attrs={"source": "fineweb"},
+        fn=lambda output_path: TokenizeMetadata(path=output_path, num_tokens=5),
+    )
+    child = StepSpec(
+        name="child",
+        output_path_prefix=prefix,
+        deps=[parent],
+        hash_attrs={"tokenizer": "gpt2"},
+        fn=lambda output_path: TokenizeMetadata(path=output_path, num_tokens=7),
+    )
+
+    StepRunner().run([child])  # runs parent, then child
+
+    rec = read_record(child.output_path)
+    assert rec is not None
+    assert rec.name == "child"
+    assert rec.config == {"tokenizer": "gpt2"}
+    assert parent.name_with_hash in rec.deps
+    # payload still round-trips, and provenance is best-effort (a value or None, never a crash)
+    assert read_artifact(child.output_path, TokenizeMetadata).num_tokens == 7
 
 
 def _build_three_level_dag(prefix: str) -> tuple[StepSpec, StepSpec, StepSpec]:

--- a/tests/execution/test_step_runner.py
+++ b/tests/execution/test_step_runner.py
@@ -185,8 +185,43 @@ def test_runner_record_carries_lineage(tmp_path):
     assert rec.name == "child"
     assert rec.config == {"tokenizer": "gpt2"}
     assert parent.name_with_hash in rec.deps
-    # payload still round-trips, and provenance is best-effort (a value or None, never a crash)
+    assert rec.dep_paths == [parent.output_path]
+    # payload still round-trips, and provenance is best-effort (git fields may be empty, never a crash)
     assert read_artifact(child.output_path, TokenizeMetadata).num_tokens == 7
+
+
+def test_runner_record_dep_paths_survive_output_override(tmp_path):
+    """``dep_paths`` records where each dep's record actually lives.
+
+    A dep with ``override_output_path`` writes to that location, not to the hashed directory
+    its ``name_with_hash`` identity would reconstruct -- so the walk must follow ``dep_paths``.
+    """
+    prefix = tmp_path.as_posix()
+    parent = StepSpec(
+        name="parent",
+        output_path_prefix=prefix,
+        override_output_path="normalize",
+        hash_attrs={"source": "fineweb"},
+        fn=lambda output_path: TokenizeMetadata(path=output_path, num_tokens=5),
+    )
+    child = StepSpec(
+        name="child",
+        output_path_prefix=prefix,
+        deps=[parent],
+        hash_attrs={"tokenizer": "gpt2"},
+        fn=lambda output_path: TokenizeMetadata(path=output_path, num_tokens=7),
+    )
+
+    StepRunner().run([child])
+
+    rec = read_record(child.output_path)
+    assert rec is not None
+    assert rec.dep_paths == [f"{prefix}/normalize"]
+    assert parent.name_with_hash not in rec.dep_paths[0]  # identity would reconstruct the wrong place
+    # the recorded path is walkable: the parent's own record lives there
+    parent_rec = read_record(rec.dep_paths[0])
+    assert parent_rec is not None
+    assert parent_rec.name == "parent"
 
 
 def _build_three_level_dag(prefix: str) -> tuple[StepSpec, StepSpec, StepSpec]:


### PR DESCRIPTION
* makes `StepRunner` persist a **full** artifact record on success, so a produced directory is traceable to its inputs by reading records alone — previously the minimal `write_artifact` wrote only `{output_path, result}`, leaving `name`/`deps`/`config`/`provenance` empty
  * the schedule-time `.executor_info` stub does hold identity `hash_attrs`, but #6892 makes `read_record` ignore it (it is not a materialized record) — so the success record is where lineage must live
* adds `write_step_record` (mirrors the lazy layer's `ArtifactRecord`) and uses it at both StepRunner write sites — `run_step` (inline) and `_submit_iris_job` (remote, worker-side), via a shared `_step_record_identity` mapping:
  * `name` = `step.name`; `config` = `step.hash_attrs` (a StepSpec's materialized config *is* its identity params); `result` = the payload
  * `deps` = `step.dep_names` (each a `name_with_hash`) — the region-independent identity of each parent
  * `dep_paths` = `step.dep_paths` — the **resolved** output paths, aligned index-wise with `deps`; this is what a record-only lineage walk follows, since a dep with `override_output_path` / its own `output_path_prefix` lives somewhere the identity alone cannot reconstruct [^3]
* provenance is best-effort and crash-safe: captured **once per process** (cached + lock-guarded) [^1], with the missing-`git`-binary tolerance moved into `Provenance.capture()` itself [^2] — git fields degrade to empty, `created_at`/argv/`built_by` are always stamped
* the remote closure captures only the plain `_step_record_identity` dict, never the `StepSpec` (which carries `fn`), so nothing extra is serialized to the worker
* verified e2e on the datakit smoke: the `store` (inline) and `cluster_assign`/`train_centroids` (remote) records carry `deps`, and lineage walks `store → cluster_assign → train_centroids` from records alone; pre-existing minimal records still read back fine (empty `deps`/`dep_paths`)

follow-up: #6902 — stamp the real git commit into the job env at iris-submission time (where `.git` exists) so provenance records the code version even for remote runs; with the tolerance now inside `capture()`, that change only touches `rigging`/iris

[^1]: `Provenance.capture()` shells out to git; calling it per step from the runner's worker threads would repeat the work and race on the repo's `index.lock` (`git stash create`) when the driver runs from a real checkout. Provenance is constant within a run, so capture it once.
[^2]: a missing `git` binary raises `FileNotFoundError` from `subprocess.run`, which `capture()` previously did not catch — common on a `.git`-less remote bundle. `capture()` now degrades it like being outside a checkout; the strict `from_git` (image builds) still raises. A record must never fail to write because provenance could not be stamped.
[^3]: `dep_paths` is prefix/region-dependent (absolute URLs), which is why the portable `deps` identities stay alongside it — identity for hashing/portability, paths for walking.
