### PR TITLE
[grug] Dump train state sharding specs

### DIFF
--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -50,6 +50,7 @@ from levanter.utils.logging import LoadingTimeTrackerIterator
 from experiments.grug.base.model import GrugModelConfig, Transformer
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
+from experiments.grug.sharding_dump import dump_grug_state_sharding_artifact
 
 logger = logging.getLogger(__name__)
 _BACKWARD_FLOW_METRICS_KEY = "_backward_flow"
@@ -70,6 +71,7 @@ class GrugTrainerConfig:
         default_factory=lambda: BackwardFlowConfig(interval=_BACKWARD_FLOW_DEFAULT_INTERVAL)
     )
     loss_implementation: str | tuple[str, ...] | None = None
+    sharding_dump_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -479,6 +481,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             mesh=mesh,
             allow_partial=trainer.allow_partial_checkpoint,
         )
+        if config.trainer.sharding_dump_path is not None:
+            dump_grug_state_sharding_artifact(state, config.trainer.sharding_dump_path)
 
         levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
 

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -50,7 +50,7 @@ from levanter.utils.logging import LoadingTimeTrackerIterator
 from experiments.grug.base.model import GrugModelConfig, Transformer
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
-from experiments.grug.sharding_dump import dump_grug_state_sharding_artifact
+from experiments.grug.sharding_dump import default_grug_sharding_dump_path, dump_grug_state_sharding_artifact
 
 logger = logging.getLogger(__name__)
 _BACKWARD_FLOW_METRICS_KEY = "_backward_flow"
@@ -481,8 +481,10 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             mesh=mesh,
             allow_partial=trainer.allow_partial_checkpoint,
         )
-        if config.trainer.sharding_dump_path is not None:
-            dump_grug_state_sharding_artifact(state, config.trainer.sharding_dump_path)
+        sharding_dump_path = config.trainer.sharding_dump_path
+        if sharding_dump_path is None:
+            sharding_dump_path = default_grug_sharding_dump_path(trainer.log_dir, run_id)
+        dump_grug_state_sharding_artifact(state, sharding_dump_path)
 
         levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
 

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import equinox as eqx
 import jax
@@ -322,6 +323,17 @@ def initial_state(
     )
 
 
+def _dump_state_sharding(
+    state: GrugTrainState,
+    *,
+    trainer: TrainerConfig,
+    run_id: str,
+    path_override: str | None,
+) -> None:
+    path = Path(path_override) if path_override is not None else default_grug_sharding_dump_path(trainer.log_dir, run_id)
+    dump_grug_state_sharding_artifact(state, path)
+
+
 def _make_train_step(
     optimizer: optax.GradientTransformation,
     mp: jmp.Policy,
@@ -481,10 +493,12 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             mesh=mesh,
             allow_partial=trainer.allow_partial_checkpoint,
         )
-        sharding_dump_path = config.trainer.sharding_dump_path
-        if sharding_dump_path is None:
-            sharding_dump_path = default_grug_sharding_dump_path(trainer.log_dir, run_id)
-        dump_grug_state_sharding_artifact(state, sharding_dump_path)
+        _dump_state_sharding(
+            state,
+            trainer=trainer,
+            run_id=run_id,
+            path_override=config.trainer.sharding_dump_path,
+        )
 
         levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
 

--- a/experiments/grug/base/train.py
+++ b/experiments/grug/base/train.py
@@ -6,7 +6,6 @@ import functools
 import logging
 import time
 from dataclasses import dataclass, field
-from pathlib import Path
 
 import equinox as eqx
 import jax
@@ -51,7 +50,7 @@ from levanter.utils.logging import LoadingTimeTrackerIterator
 from experiments.grug.base.model import GrugModelConfig, Transformer
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
-from experiments.grug.sharding_dump import default_grug_sharding_dump_path, dump_grug_state_sharding_artifact
+from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 
 logger = logging.getLogger(__name__)
 _BACKWARD_FLOW_METRICS_KEY = "_backward_flow"
@@ -323,17 +322,6 @@ def initial_state(
     )
 
 
-def _dump_state_sharding(
-    state: GrugTrainState,
-    *,
-    trainer: TrainerConfig,
-    run_id: str,
-    path_override: str | None,
-) -> None:
-    path = Path(path_override) if path_override is not None else default_grug_sharding_dump_path(trainer.log_dir, run_id)
-    dump_grug_state_sharding_artifact(state, path)
-
-
 def _make_train_step(
     optimizer: optax.GradientTransformation,
     mp: jmp.Policy,
@@ -493,9 +481,9 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             mesh=mesh,
             allow_partial=trainer.allow_partial_checkpoint,
         )
-        _dump_state_sharding(
+        dump_grug_state_sharding_run_artifact(
             state,
-            trainer=trainer,
+            log_dir=trainer.log_dir,
             run_id=run_id,
             path_override=config.trainer.sharding_dump_path,
         )

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -40,6 +40,7 @@ from levanter.utils.logging import LoadingTimeTrackerIterator
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
 from experiments.grug.moe.model import GrugModelConfig, Transformer
+from experiments.grug.sharding_dump import dump_grug_state_sharding_artifact
 
 # This file intentionally mirrors `experiments/grug/base/train.py` with
 # variant-specific model/loss/FLOP wiring, per the grug copy-first workflow in
@@ -67,6 +68,7 @@ class GrugTrainerConfig:
     # slice) and expert_axis_size>1 (expert parallelism over the intra-slice devices).
     expert_axis_size: int = 1
     replica_axis_size: int | None = None
+    sharding_dump_path: str | None = None
 
 
 @dataclass(frozen=True)
@@ -436,6 +438,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             mesh=mesh,
             allow_partial=trainer.allow_partial_checkpoint,
         )
+        if config.trainer.sharding_dump_path is not None:
+            dump_grug_state_sharding_artifact(state, config.trainer.sharding_dump_path)
 
         levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
 

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -6,7 +6,6 @@ import functools
 import logging
 import time
 from dataclasses import dataclass, field
-from pathlib import Path
 
 import equinox as eqx
 import jax
@@ -41,7 +40,7 @@ from levanter.utils.logging import LoadingTimeTrackerIterator
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
 from experiments.grug.moe.model import GrugModelConfig, Transformer
-from experiments.grug.sharding_dump import default_grug_sharding_dump_path, dump_grug_state_sharding_artifact
+from experiments.grug.sharding_dump import dump_grug_state_sharding_run_artifact
 
 # This file intentionally mirrors `experiments/grug/base/train.py` with
 # variant-specific model/loss/FLOP wiring, per the grug copy-first workflow in
@@ -269,17 +268,6 @@ def _apply_qb_betas(model: Transformer, qb_betas: jax.Array) -> Transformer:
     return eqx.tree_at(lambda t: t.blocks, model, tuple(new_blocks))
 
 
-def _dump_state_sharding(
-    state: GrugTrainState,
-    *,
-    trainer: TrainerConfig,
-    run_id: str,
-    path_override: str | None,
-) -> None:
-    path = Path(path_override) if path_override is not None else default_grug_sharding_dump_path(trainer.log_dir, run_id)
-    dump_grug_state_sharding_artifact(state, path)
-
-
 def initial_state(
     model_config: GrugModelConfig,
     *,
@@ -450,9 +438,9 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             mesh=mesh,
             allow_partial=trainer.allow_partial_checkpoint,
         )
-        _dump_state_sharding(
+        dump_grug_state_sharding_run_artifact(
             state,
-            trainer=trainer,
+            log_dir=trainer.log_dir,
             run_id=run_id,
             path_override=config.trainer.sharding_dump_path,
         )

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -40,7 +40,7 @@ from levanter.utils.logging import LoadingTimeTrackerIterator
 from experiments.grug.checkpointing import restore_grug_state_from_checkpoint
 from experiments.grug.dispatch import dispatch_grug_training_run
 from experiments.grug.moe.model import GrugModelConfig, Transformer
-from experiments.grug.sharding_dump import dump_grug_state_sharding_artifact
+from experiments.grug.sharding_dump import default_grug_sharding_dump_path, dump_grug_state_sharding_artifact
 
 # This file intentionally mirrors `experiments/grug/base/train.py` with
 # variant-specific model/loss/FLOP wiring, per the grug copy-first workflow in
@@ -438,8 +438,10 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             mesh=mesh,
             allow_partial=trainer.allow_partial_checkpoint,
         )
-        if config.trainer.sharding_dump_path is not None:
-            dump_grug_state_sharding_artifact(state, config.trainer.sharding_dump_path)
+        sharding_dump_path = config.trainer.sharding_dump_path
+        if sharding_dump_path is None:
+            sharding_dump_path = default_grug_sharding_dump_path(trainer.log_dir, run_id)
+        dump_grug_state_sharding_artifact(state, sharding_dump_path)
 
         levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
 

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -6,6 +6,7 @@ import functools
 import logging
 import time
 from dataclasses import dataclass, field
+from pathlib import Path
 
 import equinox as eqx
 import jax
@@ -268,6 +269,17 @@ def _apply_qb_betas(model: Transformer, qb_betas: jax.Array) -> Transformer:
     return eqx.tree_at(lambda t: t.blocks, model, tuple(new_blocks))
 
 
+def _dump_state_sharding(
+    state: GrugTrainState,
+    *,
+    trainer: TrainerConfig,
+    run_id: str,
+    path_override: str | None,
+) -> None:
+    path = Path(path_override) if path_override is not None else default_grug_sharding_dump_path(trainer.log_dir, run_id)
+    dump_grug_state_sharding_artifact(state, path)
+
+
 def initial_state(
     model_config: GrugModelConfig,
     *,
@@ -438,10 +450,12 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             mesh=mesh,
             allow_partial=trainer.allow_partial_checkpoint,
         )
-        sharding_dump_path = config.trainer.sharding_dump_path
-        if sharding_dump_path is None:
-            sharding_dump_path = default_grug_sharding_dump_path(trainer.log_dir, run_id)
-        dump_grug_state_sharding_artifact(state, sharding_dump_path)
+        _dump_state_sharding(
+            state,
+            trainer=trainer,
+            run_id=run_id,
+            path_override=config.trainer.sharding_dump_path,
+        )
 
         levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
 

--- a/experiments/grug/sharding_dump.py
+++ b/experiments/grug/sharding_dump.py
@@ -44,6 +44,17 @@ def dump_grug_state_sharding_artifact(state: GrugStateWithSharding, path: Path) 
     current_tracker().log_artifact(path, name=GRUG_SHARDING_ARTIFACT_NAME, type="sharding")
 
 
+def dump_grug_state_sharding_run_artifact(
+    state: GrugStateWithSharding,
+    *,
+    log_dir: Path,
+    run_id: str,
+    path_override: str | None,
+) -> None:
+    path = Path(path_override) if path_override is not None else default_grug_sharding_dump_path(log_dir, run_id)
+    dump_grug_state_sharding_artifact(state, path)
+
+
 def default_grug_sharding_dump_path(log_dir: Path, run_id: str) -> Path:
     return Path(log_dir) / run_id / "artifacts" / GRUG_SHARDING_DUMP_FILENAME
 

--- a/experiments/grug/sharding_dump.py
+++ b/experiments/grug/sharding_dump.py
@@ -3,7 +3,7 @@
 
 import json
 from pathlib import Path
-from typing import Any
+from typing import Any, Protocol
 
 import fsspec
 import jax
@@ -11,7 +11,12 @@ from haliax.jax_utils import is_jax_array_like
 from levanter.tracker import current_tracker
 
 
-def grug_state_sharding_dict(state: Any) -> dict[str, dict[str, str]]:
+class GrugStateWithSharding(Protocol):
+    params: object
+    opt_state: object
+
+
+def grug_state_sharding_dict(state: GrugStateWithSharding) -> dict[str, dict[str, str]]:
     """Return sharding specs for Grug parameters and optimizer state."""
     return {
         "params": tree_sharding_dict(state.params),
@@ -19,7 +24,7 @@ def grug_state_sharding_dict(state: Any) -> dict[str, dict[str, str]]:
     }
 
 
-def dump_grug_state_sharding(state: Any, path: str | Path) -> None:
+def dump_grug_state_sharding(state: GrugStateWithSharding, path: str | Path) -> None:
     """Write Grug parameter and optimizer-state sharding specs as JSON."""
     output = grug_state_sharding_dict(state)
     serialized = json.dumps(output, indent=2, sort_keys=True)
@@ -28,7 +33,7 @@ def dump_grug_state_sharding(state: Any, path: str | Path) -> None:
         out.write("\n")
 
 
-def dump_grug_state_sharding_artifact(state: Any, path: str | Path) -> None:
+def dump_grug_state_sharding_artifact(state: GrugStateWithSharding, path: str | Path) -> None:
     """Write Grug sharding specs and log them to the active tracker."""
     dump_grug_state_sharding(state, path)
     current_tracker().log_artifact(path, name="grug_sharding_spec", type="sharding")

--- a/experiments/grug/sharding_dump.py
+++ b/experiments/grug/sharding_dump.py
@@ -1,0 +1,55 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from pathlib import Path
+from typing import Any
+
+import fsspec
+import jax
+from haliax.jax_utils import is_jax_array_like
+from levanter.tracker import current_tracker
+
+
+def grug_state_sharding_dict(state: Any) -> dict[str, dict[str, str]]:
+    """Return sharding specs for Grug parameters and optimizer state."""
+    return {
+        "params": tree_sharding_dict(state.params),
+        "opt_state": tree_sharding_dict(state.opt_state),
+    }
+
+
+def dump_grug_state_sharding(state: Any, path: str | Path) -> None:
+    """Write Grug parameter and optimizer-state sharding specs as JSON."""
+    output = grug_state_sharding_dict(state)
+    serialized = json.dumps(output, indent=2, sort_keys=True)
+    with fsspec.open(str(path), "w") as out:
+        out.write(serialized)
+        out.write("\n")
+
+
+def dump_grug_state_sharding_artifact(state: Any, path: str | Path) -> None:
+    """Write Grug sharding specs and log them to the active tracker."""
+    dump_grug_state_sharding(state, path)
+    current_tracker().log_artifact(path, name="grug_sharding_spec", type="sharding")
+
+
+def tree_sharding_dict(tree: Any) -> dict[str, str]:
+    """Return a full PyTree path dict with each array value replaced by its sharding spec."""
+    shardings: dict[str, str] = {}
+    for path, value in jax.tree_util.tree_leaves_with_path(tree):
+        if is_jax_array_like(value):
+            shardings[jax.tree_util.keystr(path)] = _sharding_spec(value)
+    return shardings
+
+
+def _sharding_spec(value: Any) -> str:
+    sharding = getattr(value, "sharding", None)
+    if sharding is None:
+        return "None"
+
+    spec = getattr(sharding, "spec", None)
+    if spec is not None:
+        return repr(spec)
+
+    return repr(sharding)

--- a/experiments/grug/sharding_dump.py
+++ b/experiments/grug/sharding_dump.py
@@ -28,7 +28,7 @@ def grug_state_sharding_dict(state: GrugStateWithSharding) -> dict[str, dict[str
     }
 
 
-def dump_grug_state_sharding(state: GrugStateWithSharding, path: str | Path) -> None:
+def dump_grug_state_sharding(state: GrugStateWithSharding, path: Path) -> None:
     """Write Grug parameter and optimizer-state sharding specs as JSON."""
     output = grug_state_sharding_dict(state)
     serialized = json.dumps(output, indent=2, sort_keys=True)
@@ -38,14 +38,13 @@ def dump_grug_state_sharding(state: GrugStateWithSharding, path: str | Path) -> 
         out.write("\n")
 
 
-def dump_grug_state_sharding_artifact(state: GrugStateWithSharding, path: str | Path) -> None:
+def dump_grug_state_sharding_artifact(state: GrugStateWithSharding, path: Path) -> None:
     """Write Grug sharding specs and log them to the active tracker."""
     dump_grug_state_sharding(state, path)
     current_tracker().log_artifact(path, name=GRUG_SHARDING_ARTIFACT_NAME, type="sharding")
 
 
-def default_grug_sharding_dump_path(log_dir: str | Path, run_id: str) -> Path:
-    """Return the default run-local Grug sharding dump path."""
+def default_grug_sharding_dump_path(log_dir: Path, run_id: str) -> Path:
     return Path(log_dir) / run_id / "artifacts" / GRUG_SHARDING_DUMP_FILENAME
 
 
@@ -70,7 +69,7 @@ def _sharding_spec(value: Any) -> str:
     return repr(sharding)
 
 
-def _ensure_parent_dir(path: str | Path) -> None:
+def _ensure_parent_dir(path: Path) -> None:
     fs, _, paths = fsspec.get_fs_token_paths(str(path))
     plain_path = paths[0]
     parent = posixpath.dirname(plain_path)

--- a/experiments/grug/sharding_dump.py
+++ b/experiments/grug/sharding_dump.py
@@ -2,6 +2,7 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
+import posixpath
 from pathlib import Path
 from typing import Any, Protocol
 
@@ -9,6 +10,9 @@ import fsspec
 import jax
 from haliax.jax_utils import is_jax_array_like
 from levanter.tracker import current_tracker
+
+GRUG_SHARDING_ARTIFACT_NAME = "grug_sharding_spec"
+GRUG_SHARDING_DUMP_FILENAME = f"{GRUG_SHARDING_ARTIFACT_NAME}.json"
 
 
 class GrugStateWithSharding(Protocol):
@@ -28,6 +32,7 @@ def dump_grug_state_sharding(state: GrugStateWithSharding, path: str | Path) -> 
     """Write Grug parameter and optimizer-state sharding specs as JSON."""
     output = grug_state_sharding_dict(state)
     serialized = json.dumps(output, indent=2, sort_keys=True)
+    _ensure_parent_dir(path)
     with fsspec.open(str(path), "w") as out:
         out.write(serialized)
         out.write("\n")
@@ -36,7 +41,12 @@ def dump_grug_state_sharding(state: GrugStateWithSharding, path: str | Path) -> 
 def dump_grug_state_sharding_artifact(state: GrugStateWithSharding, path: str | Path) -> None:
     """Write Grug sharding specs and log them to the active tracker."""
     dump_grug_state_sharding(state, path)
-    current_tracker().log_artifact(path, name="grug_sharding_spec", type="sharding")
+    current_tracker().log_artifact(path, name=GRUG_SHARDING_ARTIFACT_NAME, type="sharding")
+
+
+def default_grug_sharding_dump_path(log_dir: str | Path, run_id: str) -> Path:
+    """Return the default run-local Grug sharding dump path."""
+    return Path(log_dir) / run_id / "artifacts" / GRUG_SHARDING_DUMP_FILENAME
 
 
 def tree_sharding_dict(tree: Any) -> dict[str, str]:
@@ -58,3 +68,11 @@ def _sharding_spec(value: Any) -> str:
         return repr(spec)
 
     return repr(sharding)
+
+
+def _ensure_parent_dir(path: str | Path) -> None:
+    fs, _, paths = fsspec.get_fs_token_paths(str(path))
+    plain_path = paths[0]
+    parent = posixpath.dirname(plain_path)
+    if parent:
+        fs.makedirs(parent, exist_ok=True)

--- a/tests/test_grug_sharding_dump.py
+++ b/tests/test_grug_sharding_dump.py
@@ -9,12 +9,10 @@ import jax.numpy as jnp
 import numpy as np
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
-from levanter.tracker import current_tracker
-from levanter.tracker.tracker import DictTracker
 
 from experiments.grug.sharding_dump import (
+    default_grug_sharding_dump_path,
     dump_grug_state_sharding,
-    dump_grug_state_sharding_artifact,
     grug_state_sharding_dict,
 )
 
@@ -46,27 +44,14 @@ def test_dump_grug_state_sharding_writes_json(tmp_path) -> None:
         params={"weight": jnp.ones((1,), dtype=jnp.float32)},
         opt_state={"moment": jnp.zeros((1,), dtype=jnp.float32)},
     )
-    path = tmp_path / "sharding.json"
+    path = tmp_path / "run" / "artifacts" / "sharding.json"
 
     dump_grug_state_sharding(state, path)
 
     assert json.loads(path.read_text()) == grug_state_sharding_dict(state)
 
 
-def test_dump_grug_state_sharding_artifact_logs_tracker_artifact(tmp_path) -> None:
-    state = _State(
-        params={"weight": jnp.ones((1,), dtype=jnp.float32)},
-        opt_state={"moment": jnp.zeros((1,), dtype=jnp.float32)},
+def test_default_grug_sharding_dump_path_uses_run_artifacts_dir(tmp_path) -> None:
+    assert default_grug_sharding_dump_path(tmp_path / "logs", "run-123") == (
+        tmp_path / "logs" / "run-123" / "artifacts" / "grug_sharding_spec.json"
     )
-    path = tmp_path / "sharding.json"
-    tracker = DictTracker()
-
-    with current_tracker(tracker):
-        dump_grug_state_sharding_artifact(state, path)
-
-    assert json.loads(path.read_text()) == grug_state_sharding_dict(state)
-    assert tracker.metrics["artifact"] == {
-        "path": path,
-        "name": "grug_sharding_spec",
-        "type": "sharding",
-    }

--- a/tests/test_grug_sharding_dump.py
+++ b/tests/test_grug_sharding_dump.py
@@ -11,7 +11,6 @@ from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 
 from experiments.grug.sharding_dump import (
-    default_grug_sharding_dump_path,
     dump_grug_state_sharding,
     grug_state_sharding_dict,
 )
@@ -54,9 +53,3 @@ def test_dump_grug_state_sharding_writes_json(tmp_path) -> None:
         "params": {"['weight']": "P('data',)"},
         "opt_state": {"['moment']": "P('data',)"},
     }
-
-
-def test_default_grug_sharding_dump_path_uses_run_artifacts_dir(tmp_path) -> None:
-    assert default_grug_sharding_dump_path(tmp_path / "logs", "run-123") == (
-        tmp_path / "logs" / "run-123" / "artifacts" / "grug_sharding_spec.json"
-    )

--- a/tests/test_grug_sharding_dump.py
+++ b/tests/test_grug_sharding_dump.py
@@ -40,15 +40,20 @@ def test_grug_state_sharding_dict_reports_params_and_opt_state() -> None:
 
 
 def test_dump_grug_state_sharding_writes_json(tmp_path) -> None:
+    mesh = Mesh(np.array(jax.devices()), ("data",))
+    sharding = NamedSharding(mesh, P("data"))
     state = _State(
-        params={"weight": jnp.ones((1,), dtype=jnp.float32)},
-        opt_state={"moment": jnp.zeros((1,), dtype=jnp.float32)},
+        params={"weight": jax.device_put(jnp.ones((jax.device_count(),), dtype=jnp.float32), sharding)},
+        opt_state={"moment": jax.device_put(jnp.zeros((jax.device_count(),), dtype=jnp.float32), sharding)},
     )
     path = tmp_path / "run" / "artifacts" / "sharding.json"
 
     dump_grug_state_sharding(state, path)
 
-    assert json.loads(path.read_text()) == grug_state_sharding_dict(state)
+    assert json.loads(path.read_text()) == {
+        "params": {"['weight']": "P('data',)"},
+        "opt_state": {"['moment']": "P('data',)"},
+    }
 
 
 def test_default_grug_sharding_dump_path_uses_run_artifacts_dir(tmp_path) -> None:

--- a/tests/test_grug_sharding_dump.py
+++ b/tests/test_grug_sharding_dump.py
@@ -1,0 +1,72 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+import json
+from dataclasses import dataclass
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+from jax.sharding import Mesh, NamedSharding
+from jax.sharding import PartitionSpec as P
+from levanter.tracker import current_tracker
+from levanter.tracker.tracker import DictTracker
+
+from experiments.grug.sharding_dump import (
+    dump_grug_state_sharding,
+    dump_grug_state_sharding_artifact,
+    grug_state_sharding_dict,
+)
+
+
+@dataclass(frozen=True)
+class _State:
+    params: dict[str, jax.Array]
+    opt_state: dict[str, jax.Array]
+
+
+def test_grug_state_sharding_dict_reports_params_and_opt_state() -> None:
+    mesh = Mesh(np.array(jax.devices()), ("data",))
+    sharding = NamedSharding(mesh, P("data"))
+    state = _State(
+        params={"weight": jax.device_put(jnp.ones((jax.device_count(),), dtype=jnp.float32), sharding)},
+        opt_state={"moment": jax.device_put(jnp.zeros((jax.device_count(),), dtype=jnp.float32), sharding)},
+    )
+
+    shardings = grug_state_sharding_dict(state)
+
+    assert shardings == {
+        "params": {"['weight']": "P('data',)"},
+        "opt_state": {"['moment']": "P('data',)"},
+    }
+
+
+def test_dump_grug_state_sharding_writes_json(tmp_path) -> None:
+    state = _State(
+        params={"weight": jnp.ones((1,), dtype=jnp.float32)},
+        opt_state={"moment": jnp.zeros((1,), dtype=jnp.float32)},
+    )
+    path = tmp_path / "sharding.json"
+
+    dump_grug_state_sharding(state, path)
+
+    assert json.loads(path.read_text()) == grug_state_sharding_dict(state)
+
+
+def test_dump_grug_state_sharding_artifact_logs_tracker_artifact(tmp_path) -> None:
+    state = _State(
+        params={"weight": jnp.ones((1,), dtype=jnp.float32)},
+        opt_state={"moment": jnp.zeros((1,), dtype=jnp.float32)},
+    )
+    path = tmp_path / "sharding.json"
+    tracker = DictTracker()
+
+    with current_tracker(tracker):
+        dump_grug_state_sharding_artifact(state, path)
+
+    assert json.loads(path.read_text()) == grug_state_sharding_dict(state)
+    assert tracker.metrics["artifact"] == {
+        "path": path,
+        "name": "grug_sharding_spec",
+        "type": "sharding",
+    }


### PR DESCRIPTION
Add a Grug train-state sharding dump after initialization or checkpoint restore. By default it writes grug_sharding_spec.json under the Levanter run artifacts directory, and sharding_dump_path can override that location when needed.

The dump records both parameter and optimizer-state leaves using JAX PyTree paths, then logs the same JSON file as a tracker artifact named grug_sharding_spec so runs preserve the layout alongside other artifacts.