### PR TITLE
[levanter] Shard FA4 metadata before shard_map

### DIFF
--- a/.agents/skills/add-pallas-kernel/SKILL.md
+++ b/.agents/skills/add-pallas-kernel/SKILL.md
@@ -87,6 +87,15 @@ Use existing kernels for structure and API inspiration. Read
 specific kernel to follow. Unless there is a stronger local pattern, start by
 reimplementing the reference in Pallas.
 
+Wrap accelerator kernel boundaries in an explicit `jax.shard_map` by default.
+This applies to `pl.pallas_call`, Mosaic GPU kernels, and custom FFI calls.
+Reshard inputs to the intended local `PartitionSpec` before the `shard_map`,
+keep the sequence or other nonlocal dimensions unsharded unless the kernel is
+explicitly written for them, and add a regression check that the lowered JAXPR
+or HLO contains the expected `shard_map`. Do not rely on XLA to infer a good
+sharding for an opaque kernel call boundary. Exceptions are limited to wrappers
+whose inputs are explicitly documented and tested as fully local or replicated.
+
 Check correctness against the harness and reference implementation before
 tuning. Once the kernel is correct, run a performance harness on representative
 shapes/dtypes and compare against the roofline. If performance is not near the
@@ -137,6 +146,10 @@ def _cost_estimate(
   applicable.
 - Public API, fallback semantics, block-size config, and tuned table behavior
   match [API patterns](docs/api-patterns.md).
+- Every Pallas, Mosaic, or FFI kernel call is inside an explicit `shard_map`, or
+  its wrapper documents and tests why the inputs are fully local or replicated.
+  Tests or profile evidence show it did not lower through unintended
+  all-gathers.
 - Each `pl.pallas_call` has a reviewed `cost_estimate=`.
 - Benchmark/tuning artifacts include the required schema from
   [Performance workflow](docs/performance-workflow.md).
@@ -153,6 +166,8 @@ def _cost_estimate(
 - Reference implementation and public wrapper are in place.
 - Correctness tests cover values, gradients, and relevant backend paths.
 - Pallas implementation has explicit backend/shape validation.
+- Pallas, Mosaic, and FFI calls use an explicit `shard_map` boundary when
+  operating on sharded inputs.
 - Fallback behavior is tested for explicit and ordered implementation choices.
 - Cost estimates are attached to Pallas calls.
 - Benchmark or tuning script emits machine-readable rows.

--- a/.agents/skills/add-pallas-kernel/docs/reference/profiling.md
+++ b/.agents/skills/add-pallas-kernel/docs/reference/profiling.md
@@ -39,7 +39,14 @@ uv run ... \
 ```
 
 Notes:
-- this captures profiles consistently and uploads `jax_profile` artifacts to trackers,
+- this captures profiles consistently under
+  `<trainer.log_dir>/<run_id>/profiler/process_<rank>/`,
+- durable W&B retrieval requires a logged `jax_profile` artifact; a relative
+  `trainer.log_dir` on Iris is task-local unless code explicitly copies or
+  mirrors the profiler directory to the run output path,
+- current Grug MoE launchers mirror completed profiles to
+  `<ctx.output_path>/profiler/`; use that as the durable default for new Grug
+  profile runs,
 - tune `start_step` to skip compile/warmup noise,
 - keep `num_steps` large enough for stable steady-state signal.
 
@@ -63,6 +70,11 @@ Primary artifact:
 
 Typical path inside artifact:
 - `plugins/profile/<timestamp>/perfetto_trace.json.gz`
+
+Run-output profile directories are durable only when the launcher copies or
+mirrors `<trainer.log_dir>/<run_id>/profiler/` to a durable path such as S3.
+`profile_summary.py summarize --run-target` mirrors from `trainer.log_dir`; it
+is not a fallback lookup for missing W&B profile artifacts.
 
 Primary tools:
 - Perfetto: detailed timeline and host/device gaps,

--- a/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
+++ b/lib/levanter/src/levanter/grug/attention/_fa4_cute.py
@@ -9,7 +9,7 @@ import jax
 from jax import shard_map
 from jax import numpy as jnp
 from jax.sharding import NamedSharding, PartitionSpec as P
-from jax.sharding import get_abstract_mesh
+from jax.sharding import get_abstract_mesh, reshard
 from jaxtyping import Array, Bool, Float, Int
 
 from levanter.grug.attention._core import AttentionMask
@@ -232,11 +232,14 @@ def _fa4_cute_attention_forward_sharded(
         )
 
     qkv_spec = P(batch_axes, None, _head_axis(mesh), None)
+    metadata_spec = P(batch_axes, None)
     _assert_sequence_axis_unsharded("q", q)
     _assert_sequence_axis_unsharded("k", k)
     _assert_sequence_axis_unsharded("v", v)
     _assert_sequence_axis_unsharded("lower_bounds", lower_bounds)
     _assert_sequence_axis_unsharded("valid", valid)
+    lower_bounds = reshard(lower_bounds, metadata_spec)
+    valid = reshard(valid, metadata_spec)
 
     @shard_map(
         mesh=mesh,

--- a/lib/levanter/tests/grug/test_fa4_cute_attention.py
+++ b/lib/levanter/tests/grug/test_fa4_cute_attention.py
@@ -5,6 +5,8 @@ import jax
 import jax.numpy as jnp
 import numpy as np
 import pytest
+from jax._src import config as jax_config
+from jax.sharding import AbstractMesh, AxisType, NamedSharding, PartitionSpec as P, use_abstract_mesh
 
 import levanter.grug.attention._fa4_cute as fa4_cute
 import levanter.grug.attention._fa4_cute_backend as fa4_cute_backend
@@ -14,6 +16,16 @@ from levanter.grug.attention import (
     reference_attention,
 )
 from levanter.grug.attention._fa4_cute import _simple_causal_lower_bounds
+
+
+class _reset_abstract_mesh:
+    def __enter__(self):
+        self._prev = jax_config.abstract_mesh_context_manager.swap_local(jax_config.config_ext.unset)
+        return self
+
+    def __exit__(self, exc_type, exc, tb):
+        jax_config.abstract_mesh_context_manager.set_local(self._prev)
+        return False
 
 
 def _make_qkv(*, batch: int = 2, q_len: int = 6, k_len: int = 6, q_heads: int = 4, kv_heads: int = 2):
@@ -112,6 +124,40 @@ def test_simple_causal_lower_bounds_match_full_causal_semantics():
 
     np.testing.assert_array_equal(lower_bounds, np.zeros((2, 4), dtype=np.int32))
     np.testing.assert_array_equal(valid, np.ones((2, 4), dtype=np.bool_))
+
+
+def test_fa4_frontend_shards_metadata_with_qkv_batch_axis(monkeypatch):
+    def fake_forward(q, k, v, lower_bounds, valid, *, sm_scale, kernel_config):
+        del k, v, sm_scale, kernel_config
+        if q.shape[:2] != lower_bounds.shape:
+            raise ValueError(f"local lower_bounds shape {lower_bounds.shape} does not match q {q.shape}")
+        if q.shape[:2] != valid.shape:
+            raise ValueError(f"local valid shape {valid.shape} does not match q {q.shape}")
+        return q
+
+    monkeypatch.setattr(jax, "default_backend", lambda: "gpu")
+    monkeypatch.setattr(fa4_cute, "_segmented_kernel_config", lambda head_dim: object())
+    monkeypatch.setattr(fa4_cute, "fa4_cute_attention_forward", fake_forward)
+    mesh = AbstractMesh(
+        axis_sizes=(1, 2, 8, 1),
+        axis_names=("replica_dcn", "data", "expert", "model"),
+        axis_types=(AxisType.Explicit,) * 4,
+    )
+    qkv_sharding = NamedSharding(mesh, P(("replica_dcn", "data", "expert"), None, "model", None))
+    q = jax.ShapeDtypeStruct((16, 4, 2, 8), jnp.bfloat16, sharding=qkv_sharding)
+    k = jax.ShapeDtypeStruct((16, 4, 1, 8), jnp.bfloat16, sharding=qkv_sharding)
+    v = jax.ShapeDtypeStruct((16, 4, 1, 8), jnp.bfloat16, sharding=qkv_sharding)
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        out = jax.eval_shape(
+            lambda q_arg, k_arg, v_arg: gpu_fa4_cute_attention(q_arg, k_arg, v_arg, AttentionMask.causal()),
+            q,
+            k,
+            v,
+        )
+
+    assert out.shape == q.shape
+    assert out.sharding.spec == qkv_sharding.spec
 
 
 def _assert_real_gpu_fa4_cute_matches_reference(q, k, v, mask, cotangent, *, valid_tokens=None):


### PR DESCRIPTION
Keep FA4/CuTe metadata tensors shard-local before entering the shard_map by resharing lower_bounds and valid onto the active batch axes. This preserves the FA4 shard_map wrapper from main while avoiding the global-metadata mismatch seen during abstract-mesh lowering. The regression test checks that the FA4 frontend sees local metadata shapes matching local q under data/expert batch sharding.

Also updates the Pallas-kernel guidance to require explicit shard_map boundaries for Pallas, Mosaic, and FFI calls on sharded inputs, and records that current Grug MoE profile mirrors should be read from <ctx.output_path>/profiler.