### PR TITLE
[iris] Run control plane at iris-system priority above user jobs

### DIFF
--- a/lib/finelog/config/cw-rno2a.yaml
+++ b/lib/finelog/config/cw-rno2a.yaml
@@ -34,9 +34,12 @@ deployment:
     object_storage_endpoint: http://cwlota.com
     # Run at control-plane priority: finelog is this cluster's log backend and
     # shares the single cpu-turin control node with the iris controller and the
-    # Kueue manager. iris-system (10000, created by `iris cluster start`) sits
-    # above every user band so a user job cannot preempt it off that node.
+    # Kueue manager. iris-system (10000) sits above every user band so a user job
+    # cannot preempt it off that node. `deploy up` creates the class if absent, so
+    # finelog can come up before Iris; keep the value in sync with iris's
+    # IRIS_PRIORITY_CLASSES (Iris is the canonical owner).
     priority_class_name: iris-system
+    priority_class_value: 10000
 # Authenticated-ingress policy. This LOCAL finelog is default-deny;
 # it admits its own cluster's private network (CoreWeave pods are 10.x) and
 # loopback (port-forward), never the public internet. No jwt layer — that is the

--- a/lib/finelog/config/cw-rno2a.yaml
+++ b/lib/finelog/config/cw-rno2a.yaml
@@ -32,6 +32,11 @@ deployment:
     # into the minted creds Secret. Virtual-hosted addressing is derived from
     # the domain.
     object_storage_endpoint: http://cwlota.com
+    # Run at control-plane priority: finelog is this cluster's log backend and
+    # shares the single cpu-turin control node with the iris controller and the
+    # Kueue manager. iris-system (10000, created by `iris cluster start`) sits
+    # above every user band so a user job cannot preempt it off that node.
+    priority_class_name: iris-system
 # Authenticated-ingress policy. This LOCAL finelog is default-deny;
 # it admits its own cluster's private network (CoreWeave pods are 10.x) and
 # loopback (port-forward), never the public internet. No jwt layer — that is the

--- a/lib/finelog/config/cw-us-east-02a.yaml
+++ b/lib/finelog/config/cw-us-east-02a.yaml
@@ -27,6 +27,10 @@ deployment:
     storage_gb: 250
     # R2 endpoint for the s3:// archive; folded into the minted creds Secret.
     object_storage_endpoint: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com
+    # Run at control-plane priority so a user job cannot preempt the log backend
+    # off the shared control node. iris-system (10000) is created by
+    # `iris cluster start`; see the iris controller's ensure_priority_classes.
+    priority_class_name: iris-system
 # Authenticated-ingress policy. This LOCAL finelog is default-deny;
 # it admits its own cluster's private network (CoreWeave pods are 10.x) and
 # loopback (port-forward), never the public internet. No jwt layer — that is the

--- a/lib/finelog/config/cw-us-east-02a.yaml
+++ b/lib/finelog/config/cw-us-east-02a.yaml
@@ -28,9 +28,11 @@ deployment:
     # R2 endpoint for the s3:// archive; folded into the minted creds Secret.
     object_storage_endpoint: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com
     # Run at control-plane priority so a user job cannot preempt the log backend
-    # off the shared control node. iris-system (10000) is created by
-    # `iris cluster start`; see the iris controller's ensure_priority_classes.
+    # off the shared control node. `deploy up` creates iris-system (10000) if
+    # absent; keep the value in sync with iris's IRIS_PRIORITY_CLASSES (Iris is
+    # the canonical owner — see the iris controller's ensure_priority_classes).
     priority_class_name: iris-system
+    priority_class_value: 10000
 # Authenticated-ingress policy. This LOCAL finelog is default-deny;
 # it admits its own cluster's private network (CoreWeave pods are 10.x) and
 # loopback (port-forward), never the public internet. No jwt layer — that is the

--- a/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
+++ b/lib/finelog/deploy/k8s/02-deployment.yaml.tmpl
@@ -26,6 +26,7 @@ spec:
       labels:
         app: {{ name }}
     spec:
+{{ priority_class_block }}
       # The container runs as UID 1000 (finelog). fsGroup makes kubelet
       # chown the mounted PV to GID 1000 so writes succeed; without this
       # the PV root inherits root:root and parquet flushes EACCES.

--- a/lib/finelog/src/finelog/deploy/_k8s.py
+++ b/lib/finelog/src/finelog/deploy/_k8s.py
@@ -170,20 +170,31 @@ def _kubectl_apply(manifest: str) -> None:
     _kubectl("apply", "-f", "-", stdin=manifest)
 
 
-def _assert_priority_class_exists(name: str | None) -> None:
-    """Fail fast if the configured PriorityClass is missing.
+def _ensure_priority_class(cfg: FinelogConfig) -> None:
+    """Create the configured PriorityClass (idempotently) before the Deployment.
 
-    A pod referencing a non-existent PriorityClass is rejected at admission, so
-    catch it here with an actionable message instead of a cryptic apply error.
-    Iris owns the iris-* classes and creates them at `iris cluster start`.
+    A pod referencing a missing PriorityClass is rejected at admission, and on a
+    fresh cluster finelog is brought up before Iris creates the iris-* bands. So
+    finelog provisions its own scheduling dependency rather than depending on
+    ordering. `kubectl apply` is a no-op when the class already exists with the
+    same immutable value/preemptionPolicy (e.g. Iris created it first), and fails
+    loudly on a real mismatch. PreemptLowerPriority matches the iris-system band:
+    the control plane may evict a lower-priority pod to stay scheduled.
     """
-    if not name:
+    assert cfg.deployment.k8s is not None
+    k8s = cfg.deployment.k8s
+    if k8s.priority_class_name is None:
         return
-    if _kubectl("get", "priorityclass", name, check=False).returncode != 0:
-        raise click.ClickException(
-            f"PriorityClass {name!r} not found. Iris provisions the iris-* PriorityClasses at "
-            "`iris cluster start`; run that (or create the class) before deploying finelog."
-        )
+    manifest = {
+        "apiVersion": "scheduling.k8s.io/v1",
+        "kind": "PriorityClass",
+        "metadata": {"name": k8s.priority_class_name},
+        "value": k8s.priority_class_value,
+        "preemptionPolicy": "PreemptLowerPriority",
+        "globalDefault": False,
+    }
+    click.echo(f"Ensuring PriorityClass {k8s.priority_class_name} (value {k8s.priority_class_value})...")
+    _kubectl_apply(json.dumps(manifest))
 
 
 def k8s_up(cfg: FinelogConfig) -> None:
@@ -196,7 +207,7 @@ def k8s_up(cfg: FinelogConfig) -> None:
     assert cfg.deployment.k8s is not None
     cfg = replace(cfg, image=resolve_image_digest(cfg.image))
     k8s = cfg.deployment.k8s
-    _assert_priority_class_exists(k8s.priority_class_name)
+    _ensure_priority_class(cfg)
     secret_manifest = _build_s3_secret_manifest(cfg)
     if secret_manifest is not None:
         click.echo(f"Applying Secret {_s3_secret_name(cfg)} (S3 credentials)...")

--- a/lib/finelog/src/finelog/deploy/_k8s.py
+++ b/lib/finelog/src/finelog/deploy/_k8s.py
@@ -57,6 +57,15 @@ def _auth_env_block(cfg: FinelogConfig) -> str:
     return f"            - name: FINELOG_AUTH_POLICY\n              value: '{policy}'"
 
 
+def _priority_class_block(cfg: FinelogConfig) -> str:
+    """Render the pod-spec `priorityClassName` line, or "" when none is configured."""
+    assert cfg.deployment.k8s is not None
+    name = cfg.deployment.k8s.priority_class_name
+    if not name:
+        return ""
+    return f"      priorityClassName: {name}"
+
+
 def _render_manifest(template_path: Path, cfg: FinelogConfig) -> str:
     """Render a single k8s manifest template against `cfg`.
 
@@ -80,6 +89,7 @@ def _render_manifest(template_path: Path, cfg: FinelogConfig) -> str:
         "storage_class_block": storage_class_block,
         "storage_gb": k8s.storage_gb,
         "auth_env_block": _auth_env_block(cfg),
+        "priority_class_block": _priority_class_block(cfg),
     }
     referenced = set(_TEMPLATE_VAR_RE.findall(template))
     return render_template(template, **{k: v for k, v in all_vars.items() if k in referenced})
@@ -160,6 +170,22 @@ def _kubectl_apply(manifest: str) -> None:
     _kubectl("apply", "-f", "-", stdin=manifest)
 
 
+def _assert_priority_class_exists(name: str | None) -> None:
+    """Fail fast if the configured PriorityClass is missing.
+
+    A pod referencing a non-existent PriorityClass is rejected at admission, so
+    catch it here with an actionable message instead of a cryptic apply error.
+    Iris owns the iris-* classes and creates them at `iris cluster start`.
+    """
+    if not name:
+        return
+    if _kubectl("get", "priorityclass", name, check=False).returncode != 0:
+        raise click.ClickException(
+            f"PriorityClass {name!r} not found. Iris provisions the iris-* PriorityClasses at "
+            "`iris cluster start`; run that (or create the class) before deploying finelog."
+        )
+
+
 def k8s_up(cfg: FinelogConfig) -> None:
     """Render manifests and apply them; wait for the deployment to roll out.
 
@@ -170,6 +196,7 @@ def k8s_up(cfg: FinelogConfig) -> None:
     assert cfg.deployment.k8s is not None
     cfg = replace(cfg, image=resolve_image_digest(cfg.image))
     k8s = cfg.deployment.k8s
+    _assert_priority_class_exists(k8s.priority_class_name)
     secret_manifest = _build_s3_secret_manifest(cfg)
     if secret_manifest is not None:
         click.echo(f"Applying Secret {_s3_secret_name(cfg)} (S3 credentials)...")

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -61,6 +61,12 @@ class K8sDeployment:
     # plus the operator's R2 creds, projected into the pod via envFrom so the
     # server can authenticate. Unused for `gs://` (GCS uses workload identity).
     object_storage_endpoint: str | None = None
+    # PriorityClass stamped on the finelog pod. When finelog is the log backend
+    # for an Iris control plane, set this to `iris-system` so a user job cannot
+    # preempt it off the shared control node. The class must already exist —
+    # Iris creates the iris-* PriorityClasses at `iris cluster start`; `deploy up`
+    # fails fast if it is missing rather than emitting an unschedulable pod.
+    priority_class_name: str | None = None
 
 
 @dataclass(frozen=True)
@@ -208,6 +214,7 @@ def _build_k8s(raw: dict) -> K8sDeployment:
         storage_class=raw.get("storage_class"),
         storage_gb=int(raw.get("storage_gb", 200)),
         object_storage_endpoint=raw.get("object_storage_endpoint"),
+        priority_class_name=raw.get("priority_class_name"),
     )
 
 

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -63,10 +63,18 @@ class K8sDeployment:
     object_storage_endpoint: str | None = None
     # PriorityClass stamped on the finelog pod. When finelog is the log backend
     # for an Iris control plane, set this to `iris-system` so a user job cannot
-    # preempt it off the shared control node. The class must already exist —
-    # Iris creates the iris-* PriorityClasses at `iris cluster start`; `deploy up`
-    # fails fast if it is missing rather than emitting an unschedulable pod.
+    # preempt it off the shared control node. `deploy up` creates the class
+    # (idempotently) from name+value before applying the Deployment, so finelog
+    # can still be brought up first on a fresh cluster. Iris is the canonical
+    # owner of the iris-* bands (see IRIS_PRIORITY_CLASSES); keep priority_class_value
+    # in sync with it — value/preemptionPolicy are immutable, so a mismatch makes
+    # one side's apply fail loudly rather than silently disagree.
     priority_class_name: str | None = None
+    priority_class_value: int | None = None
+
+    def __post_init__(self) -> None:
+        if (self.priority_class_name is None) != (self.priority_class_value is None):
+            raise ValueError("priority_class_name and priority_class_value must be set together")
 
 
 @dataclass(frozen=True)
@@ -209,12 +217,14 @@ def _build_auth_layers(raw: list, path: Path) -> tuple[AuthLayer, ...]:
 
 
 def _build_k8s(raw: dict) -> K8sDeployment:
+    priority_class_value = raw.get("priority_class_value")
     return K8sDeployment(
         namespace=raw["namespace"],
         storage_class=raw.get("storage_class"),
         storage_gb=int(raw.get("storage_gb", 200)),
         object_storage_endpoint=raw.get("object_storage_endpoint"),
         priority_class_name=raw.get("priority_class_name"),
+        priority_class_value=None if priority_class_value is None else int(priority_class_value),
     )
 
 

--- a/lib/finelog/tests/test_deploy_k8s.py
+++ b/lib/finelog/tests/test_deploy_k8s.py
@@ -80,6 +80,26 @@ def test_render_deployment_threads_port_to_env_and_probes(cfg: FinelogConfig) ->
     assert 'value: "gs://bucket/logs"' in rendered
 
 
+def test_render_deployment_omits_priority_class_by_default(cfg: FinelogConfig) -> None:
+    """No priority_class_name configured -> the pod carries no priorityClassName."""
+    rendered = _render_manifest(_K8S_MANIFEST_DIR / "02-deployment.yaml.tmpl", cfg)
+    assert "priorityClassName" not in rendered
+
+
+def test_render_deployment_stamps_priority_class_when_configured() -> None:
+    """A configured priority_class_name lands in the pod spec so the control-plane
+    finelog is not preemptible by user jobs on the shared node."""
+    cfg = FinelogConfig(
+        name="finelog",
+        port=20001,
+        image="ghcr.io/example/finelog:dev",
+        remote_log_dir="gs://bucket/logs",
+        deployment=Deployment(k8s=K8sDeployment(namespace="iris", priority_class_name="iris-system")),
+    )
+    rendered = _render_manifest(_K8S_MANIFEST_DIR / "02-deployment.yaml.tmpl", cfg)
+    assert "priorityClassName: iris-system" in rendered
+
+
 def test_render_deployment_inlines_cidr_auth_policy() -> None:
     cfg = FinelogConfig(
         name="finelog",

--- a/lib/finelog/tests/test_deploy_k8s.py
+++ b/lib/finelog/tests/test_deploy_k8s.py
@@ -94,10 +94,19 @@ def test_render_deployment_stamps_priority_class_when_configured() -> None:
         port=20001,
         image="ghcr.io/example/finelog:dev",
         remote_log_dir="gs://bucket/logs",
-        deployment=Deployment(k8s=K8sDeployment(namespace="iris", priority_class_name="iris-system")),
+        deployment=Deployment(
+            k8s=K8sDeployment(namespace="iris", priority_class_name="iris-system", priority_class_value=10000)
+        ),
     )
     rendered = _render_manifest(_K8S_MANIFEST_DIR / "02-deployment.yaml.tmpl", cfg)
     assert "priorityClassName: iris-system" in rendered
+
+
+def test_k8s_deployment_rejects_priority_class_name_without_value() -> None:
+    """Name and value are meaningless apart — deploy up needs the value to create
+    the class, so half a config must fail at construction, not at apply time."""
+    with pytest.raises(ValueError, match="must be set together"):
+        K8sDeployment(namespace="iris", priority_class_name="iris-system")
 
 
 def test_render_deployment_inlines_cidr_auth_policy() -> None:

--- a/lib/iris/scripts/install_kueue.py
+++ b/lib/iris/scripts/install_kueue.py
@@ -65,6 +65,7 @@ Why this exists / what the CoreWeave docs leave out:
   block this script injects via the chart's ``managerConfig``.
 """
 
+import json
 import os
 import subprocess
 import tempfile
@@ -81,6 +82,7 @@ from iris.cluster.platforms.k8s.coreweave_topology import (
     CW_LABEL_NVLINK_DOMAIN,
     CW_LABEL_SUPERPOD,
 )
+from iris.cluster.platforms.k8s.types import IRIS_PRIORITY_CLASS_SYSTEM, iris_priority_class_manifest
 
 # Right after a fresh install Kueue's internal cert manager has not yet populated
 # the webhook caBundle, so admission/conversion webhook calls fail transiently
@@ -525,6 +527,39 @@ def _helm_upgrade(chart: str, release: str, values_file: str, hflags: list[str],
     )
 
 
+def _pin_manager_priority(kflags: list[str]) -> None:
+    """Pin kueue-controller-manager to the iris-system PriorityClass.
+
+    The manager serves Kueue's admission webhook — a hard dependency of every pod
+    CREATE in the Iris namespace. The helm charts leave it at priority 0, below
+    every Iris user job (iris-interactive=10), so a user pod can legally preempt
+    it; when it dies the webhook loses its endpoint and all pod admission fails
+    clusterwide until it reschedules. Pinning it to iris-system (10000, above
+    iris-production) makes it non-preemptible.
+
+    Applied out of band because neither chart variant exposes a priorityClassName
+    value. Helm 3's 3-way merge preserves fields it never set, so this survives
+    later `helm upgrade`s; install_kueue also re-applies it on every run.
+    """
+    click.secho("==> Pinning kueue-controller-manager to the iris-system PriorityClass", fg="blue", bold=True)
+    kubectl_apply_docs([iris_priority_class_manifest(IRIS_PRIORITY_CLASS_SYSTEM)], kflags)
+    patch = json.dumps({"spec": {"template": {"spec": {"priorityClassName": IRIS_PRIORITY_CLASS_SYSTEM}}}})
+    run(
+        [
+            "kubectl",
+            *kflags,
+            "-n",
+            OPERATOR_NS,
+            "patch",
+            "deploy/kueue-controller-manager",
+            "--type=strategic",
+            "-p",
+            patch,
+        ],
+        check=True,
+    )
+
+
 def _wait_controller(kflags: list[str]) -> None:
     click.secho("==> Waiting for the Kueue controller to become available", fg="blue", bold=True)
     run(
@@ -560,6 +595,7 @@ def _apply(
         ["kubectl", *kflags, "wait", "--for=condition=Established", f"crd/{TOPOLOGY_CRD}", "--timeout=120s"],
         check=True,
     )
+    _pin_manager_priority(kflags)
     _wait_controller(kflags)
 
     api_version = topology_api_version(kflags)

--- a/lib/iris/src/iris/cluster/platforms/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/controller.py
@@ -32,10 +32,10 @@ from iris.cluster.inject_env import TASK_ENV_SECRET_NAME, collect_inject_env, pr
 from iris.cluster.platforms.k8s.constants import COREWEAVE_INTERRUPTABLE_TOLERATION, NVIDIA_GPU_TOLERATION
 from iris.cluster.platforms.k8s.service import CloudK8sService, K8sService
 from iris.cluster.platforms.k8s.types import (
-    IRIS_PRIORITY_CLASS_BATCH,
-    IRIS_PRIORITY_CLASS_INTERACTIVE,
-    IRIS_PRIORITY_CLASS_PRODUCTION,
+    IRIS_PRIORITY_CLASS_SYSTEM,
+    IRIS_PRIORITY_CLASSES,
     K8sResource,
+    build_priority_class_manifest,
     parse_k8s_timestamp,
 )
 from iris.cluster.platforms.types import InfraError, Labels, local_queue_name
@@ -146,6 +146,9 @@ def _build_controller_deployment(
             "metadata": {"labels": {"app": "iris-controller"}},
             "spec": {
                 "serviceAccountName": "iris-controller",
+                # Pin the controller above every user band so a user pod can never
+                # preempt it off the shared control node (see IRIS_PRIORITY_CLASSES).
+                "priorityClassName": IRIS_PRIORITY_CLASS_SYSTEM,
                 "nodeSelector": node_selector,
                 # Tolerate the NVIDIA GPU taint (so the controller can run on
                 # GPU-only clusters with no CPU NodePool) and CoreWeave's
@@ -740,31 +743,19 @@ class K8sControllerProvider:
         logger.info("LocalQueue %s applied (clusterQueue=%s)", name, cluster_queue)
 
     def ensure_priority_classes(self) -> None:
-        """Create or update the iris-{production,interactive,batch} PriorityClass objects.
+        """Create or update the iris-{system,production,interactive,batch} PriorityClass objects.
 
-        PriorityClass is cluster-scoped. Iris owns these three names; any cluster
+        PriorityClass is cluster-scoped. Iris owns these names; any cluster
         running Iris gets them so pods are stamped without manual admin setup.
 
-        Priority values:
+        Priority values (see IRIS_PRIORITY_CLASSES):
+          iris-system     10000  — control plane (controller, finelog, Kueue); never preempted by user work
           iris-production  1000  — preempts interactive/batch; never preempted
           iris-interactive   10  — normal user work
           iris-batch          0  — opportunistic; below interactive, above CoreWeave NHC
         """
-        priority_classes = [
-            (IRIS_PRIORITY_CLASS_PRODUCTION, 1000, "PreemptLowerPriority"),
-            (IRIS_PRIORITY_CLASS_INTERACTIVE, 10, "PreemptLowerPriority"),
-            (IRIS_PRIORITY_CLASS_BATCH, 0, "Never"),
-        ]
-        for name, value, preemption_policy in priority_classes:
-            manifest = {
-                "apiVersion": "scheduling.k8s.io/v1",
-                "kind": "PriorityClass",
-                "metadata": {"name": name},
-                "value": value,
-                "preemptionPolicy": preemption_policy,
-                "globalDefault": False,
-                "description": f"Iris {name.removeprefix('iris-')} priority band",
-            }
+        for name, value, preemption_policy in IRIS_PRIORITY_CLASSES:
+            manifest = build_priority_class_manifest(name, value, preemption_policy)
             existing = self._kubectl.get_json(K8sResource.PRIORITY_CLASSES, name)
             if existing and (existing.get("value") != value or existing.get("preemptionPolicy") != preemption_policy):
                 # PriorityClass.value and preemptionPolicy are immutable. Existing
@@ -775,7 +766,7 @@ class K8sControllerProvider:
             self._kubectl.apply_json(manifest)
         logger.info(
             "PriorityClasses applied: %s",
-            ", ".join(n for n, _, _ in priority_classes),
+            ", ".join(n for n, _, _ in IRIS_PRIORITY_CLASSES),
         )
 
     # -- NodePool Management ---------------------------------------------------

--- a/lib/iris/src/iris/cluster/platforms/k8s/types.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/types.py
@@ -10,9 +10,49 @@ from enum import Enum
 # Default PriorityClass names Iris creates at controller startup and uses when
 # the cluster config does not override priority_class_names. Override via
 # kubernetes_provider.priority_classes.
+#
+# iris-system is the control plane band (controller, finelog, Kueue manager). It
+# is NOT a user band and is never mapped from a PriorityBand — user jobs cannot
+# request it. It sits above every user band so a user pod can never preempt the
+# control plane off the shared control node; PreemptLowerPriority lets it evict a
+# lower-priority pod to stay scheduled when that node is full.
+IRIS_PRIORITY_CLASS_SYSTEM = "iris-system"
 IRIS_PRIORITY_CLASS_PRODUCTION = "iris-production"
 IRIS_PRIORITY_CLASS_INTERACTIVE = "iris-interactive"
 IRIS_PRIORITY_CLASS_BATCH = "iris-batch"
+
+# Canonical (name, value, preemptionPolicy) for every PriorityClass Iris owns.
+# Single source of truth: the controller applies all of them at startup and the
+# Kueue installer reuses the iris-system entry so the manager is pinned to the
+# same class. value/preemptionPolicy are immutable on a PriorityClass, so a
+# change here forces a delete+recreate (see ensure_priority_classes).
+IRIS_PRIORITY_CLASSES: tuple[tuple[str, int, str], ...] = (
+    (IRIS_PRIORITY_CLASS_SYSTEM, 10000, "PreemptLowerPriority"),
+    (IRIS_PRIORITY_CLASS_PRODUCTION, 1000, "PreemptLowerPriority"),
+    (IRIS_PRIORITY_CLASS_INTERACTIVE, 10, "PreemptLowerPriority"),
+    (IRIS_PRIORITY_CLASS_BATCH, 0, "Never"),
+)
+
+
+def build_priority_class_manifest(name: str, value: int, preemption_policy: str) -> dict:
+    """Build a cluster-scoped PriorityClass manifest dict."""
+    return {
+        "apiVersion": "scheduling.k8s.io/v1",
+        "kind": "PriorityClass",
+        "metadata": {"name": name},
+        "value": value,
+        "preemptionPolicy": preemption_policy,
+        "globalDefault": False,
+        "description": f"Iris {name.removeprefix('iris-')} priority band",
+    }
+
+
+def iris_priority_class_manifest(name: str) -> dict:
+    """PriorityClass manifest for one Iris-owned band, resolved from IRIS_PRIORITY_CLASSES."""
+    for class_name, value, preemption_policy in IRIS_PRIORITY_CLASSES:
+        if class_name == name:
+            return build_priority_class_manifest(class_name, value, preemption_policy)
+    raise ValueError(f"unknown Iris priority class {name!r}")
 
 
 class KubectlError(RuntimeError):

--- a/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
@@ -37,7 +37,6 @@ from iris.cluster.platforms.k8s.controller import (
 )
 from iris.cluster.platforms.k8s.fake import InMemoryK8sService
 from iris.cluster.platforms.k8s.types import (
-    IRIS_PRIORITY_CLASS_SYSTEM,
     K8sResource,
     iris_priority_class_manifest,
 )
@@ -185,11 +184,10 @@ def test_start_controller_creates_all_resources():
     node_selector = deploy_spec["template"]["spec"]["nodeSelector"]
     assert node_selector == {iris_labels.iris_scale_group: "cpu-erapids"}
 
-    # Controller runs at control-plane priority (iris-system, 10000) so a user
-    # job can never preempt it off the shared control node.
+    # Controller is stamped with the control-plane PriorityClass, and that class
+    # is provisioned so the reference resolves at admission.
     assert deploy_spec["template"]["spec"]["priorityClassName"] == "iris-system"
-    system_pc = k8s.get_json(K8sResource.PRIORITY_CLASSES, "iris-system")
-    assert system_pc is not None and system_pc["value"] == 10000
+    assert k8s.get_json(K8sResource.PRIORITY_CLASSES, "iris-system") is not None
 
     # Controller consumes that env via envFrom (S3 + injected, one flow).
     container = deploy_spec["template"]["spec"]["containers"][0]
@@ -884,30 +882,9 @@ def test_ensure_kueue_queues_noop_without_cluster_queue():
     provider.shutdown()
 
 
-def test_ensure_priority_classes_ranks_system_above_user_bands():
-    """iris-system must outrank every user band so the control plane is never
-    preemptible by a user job (a user pod at iris-interactive preempting the
-    Kueue manager is exactly the outage this guards against)."""
-    provider, k8s = _make_provider()
-
-    provider.ensure_priority_classes()
-
-    values = {}
-    for name in ("iris-system", "iris-production", "iris-interactive", "iris-batch"):
-        pc = k8s.get_json(K8sResource.PRIORITY_CLASSES, name)
-        assert pc is not None, f"{name} not created"
-        values[name] = pc["value"]
-    assert values["iris-system"] > values["iris-production"] > values["iris-interactive"] >= values["iris-batch"]
-    provider.shutdown()
-
-
-def test_iris_priority_class_manifest_resolves_system_and_rejects_unknown():
-    """The Kueue installer reuses this to pin its manager to iris-system; it must
-    return a well-formed manifest for a known band and reject a typo loudly."""
-    manifest = iris_priority_class_manifest(IRIS_PRIORITY_CLASS_SYSTEM)
-    assert manifest["kind"] == "PriorityClass"
-    assert manifest["metadata"]["name"] == "iris-system"
-    assert manifest["value"] == 10000
+def test_iris_priority_class_manifest_rejects_unknown_band():
+    """The Kueue installer pins its manager via this helper; an unknown band must
+    raise rather than silently return a wrong-priority (or empty) manifest."""
     with pytest.raises(ValueError, match="unknown Iris priority class"):
         iris_priority_class_manifest("iris-nonexistent")
 

--- a/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
@@ -36,7 +36,11 @@ from iris.cluster.platforms.k8s.controller import (
     K8sControllerProvider,
 )
 from iris.cluster.platforms.k8s.fake import InMemoryK8sService
-from iris.cluster.platforms.k8s.types import K8sResource
+from iris.cluster.platforms.k8s.types import (
+    IRIS_PRIORITY_CLASS_SYSTEM,
+    K8sResource,
+    iris_priority_class_manifest,
+)
 from iris.cluster.platforms.types import (
     InfraError,
     Labels,
@@ -180,6 +184,12 @@ def test_start_controller_creates_all_resources():
     deploy_spec = dep["spec"]
     node_selector = deploy_spec["template"]["spec"]["nodeSelector"]
     assert node_selector == {iris_labels.iris_scale_group: "cpu-erapids"}
+
+    # Controller runs at control-plane priority (iris-system, 10000) so a user
+    # job can never preempt it off the shared control node.
+    assert deploy_spec["template"]["spec"]["priorityClassName"] == "iris-system"
+    system_pc = k8s.get_json(K8sResource.PRIORITY_CLASSES, "iris-system")
+    assert system_pc is not None and system_pc["value"] == 10000
 
     # Controller consumes that env via envFrom (S3 + injected, one flow).
     container = deploy_spec["template"]["spec"]["containers"][0]
@@ -872,6 +882,34 @@ def test_ensure_kueue_queues_noop_without_cluster_queue():
     provider.ensure_kueue_queues(_make_cluster_config())
     assert k8s.get_json(K8sResource.LOCAL_QUEUES, "iris-lq") is None
     provider.shutdown()
+
+
+def test_ensure_priority_classes_ranks_system_above_user_bands():
+    """iris-system must outrank every user band so the control plane is never
+    preemptible by a user job (a user pod at iris-interactive preempting the
+    Kueue manager is exactly the outage this guards against)."""
+    provider, k8s = _make_provider()
+
+    provider.ensure_priority_classes()
+
+    values = {}
+    for name in ("iris-system", "iris-production", "iris-interactive", "iris-batch"):
+        pc = k8s.get_json(K8sResource.PRIORITY_CLASSES, name)
+        assert pc is not None, f"{name} not created"
+        values[name] = pc["value"]
+    assert values["iris-system"] > values["iris-production"] > values["iris-interactive"] >= values["iris-batch"]
+    provider.shutdown()
+
+
+def test_iris_priority_class_manifest_resolves_system_and_rejects_unknown():
+    """The Kueue installer reuses this to pin its manager to iris-system; it must
+    return a well-formed manifest for a known band and reject a typo loudly."""
+    manifest = iris_priority_class_manifest(IRIS_PRIORITY_CLASS_SYSTEM)
+    assert manifest["kind"] == "PriorityClass"
+    assert manifest["metadata"]["name"] == "iris-system"
+    assert manifest["value"] == 10000
+    with pytest.raises(ValueError, match="unknown Iris priority class"):
+        iris_priority_class_manifest("iris-nonexistent")
 
 
 # ============================================================================


### PR DESCRIPTION
Add an `iris-system` PriorityClass (10000, `PreemptLowerPriority`) that sits above every user band and stamp it on the whole control plane: the iris controller, the finelog log server, and the Kueue controller-manager.

Before this, the control plane ran at priority 0 with no PriorityClass while user task pods run at `iris-interactive` (10), so every user job outranked it. On the shared CoreWeave `cpu-turin` control node — a single node hosting the controller, finelog, the Kueue manager, and every CPU coordinator pod — this let a user pod legally preempt the Kueue manager off the node. Its admission webhook then lost its endpoint, so every pod CREATE in the namespace failed (`no endpoints available for service "kueue-webhook-service"`) until it rescheduled, briefly stranding the controller pod in `Pending`. This was observed on cw-rno2a.

`iris-system` is control-plane-only: it is not mapped from any `PriorityBand`, so a user job can never request it. `PreemptLowerPriority` lets it evict a lower-priority pod to stay scheduled when the control node is full.

The band values now live in one table (`IRIS_PRIORITY_CLASSES`). The controller applies all bands at startup and stamps `iris-system` on its own Deployment. The Kueue installer reuses the `iris-system` entry and pins the manager by patching the rendered Deployment — neither the cks nor upstream helm chart exposes a `priorityClassName` value, and Helm 3's 3-way merge preserves the field on later upgrades. finelog stamps the class from a new optional `priority_class_name` config field (set on both CoreWeave cluster configs) and fails fast at `deploy up` if the class is missing rather than emitting an unschedulable pod.

To take effect on a live cluster: land this, rebuild the iris images, restart the controller, and re-run `install_kueue.py --apply` / redeploy finelog.