### PR TITLE
[iris] Move CoreWeave controller SQLite state to node-local NVMe

### DIFF
--- a/.github/workflows/iris-smoke-coreweave.yaml
+++ b/.github/workflows/iris-smoke-coreweave.yaml
@@ -88,8 +88,8 @@ jobs:
       # work without needing to tunnel to an existing controller first.
       - name: Start controller
         env:
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CW_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          CW_KEY_SECRET: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: |
           cd lib/iris && uv run --group dev iris -v \
             --config=config/ci-coreweave.yaml \

--- a/.github/workflows/marin-canary-ferry-coreweave.yaml
+++ b/.github/workflows/marin-canary-ferry-coreweave.yaml
@@ -121,8 +121,8 @@ jobs:
       - name: Start shared iris-ci controller
         env:
           BUILDKIT_PROGRESS: plain
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CW_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          CW_KEY_SECRET: ${{ secrets.R2_SECRET_ACCESS_KEY }}
         run: .venv/bin/iris -v --config=${{ env.IRIS_CONFIG }} cluster start --fresh
 
       - name: Submit canary ferry
@@ -145,8 +145,8 @@ jobs:
             -e WANDB_PROJECT "$WANDB_PROJECT" \
             -e WANDB_API_KEY "$WANDB_API_KEY" \
             -e HF_TOKEN "$HF_TOKEN" \
-            -e AWS_ACCESS_KEY_ID "$R2_ACCESS_KEY_ID" \
-            -e AWS_SECRET_ACCESS_KEY "$R2_SECRET_ACCESS_KEY" \
+            -e AWS_ACCESS_KEY_ID "$CW_KEY_ID" \
+            -e AWS_SECRET_ACCESS_KEY "$CW_KEY_SECRET" \
             -e AWS_ENDPOINT_URL "https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com" \
             -- python -m experiments.ferries.canary_ferry)
           echo "job_id=$JOB_ID" >> "$GITHUB_OUTPUT"
@@ -154,8 +154,8 @@ jobs:
         env:
           WANDB_API_KEY: ${{ secrets.WANDB_API_KEY }}
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-          R2_ACCESS_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
-          R2_SECRET_ACCESS_KEY: ${{ secrets.R2_SECRET_ACCESS_KEY }}
+          CW_KEY_ID: ${{ secrets.R2_ACCESS_KEY_ID }}
+          CW_KEY_SECRET: ${{ secrets.R2_SECRET_ACCESS_KEY }}
           CANARY_TARGET_TOKENS: ${{ inputs.target_tokens || env.CANARY_TARGET_TOKENS }}
 
       # Keep the wait below the job timeout (180) so a hung ferry fails this

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -11,12 +11,10 @@
 #
 # Workflow:
 #   1. Set CoreWeave AI Object Storage credentials (console -> Object Storage ->
-#      Access Keys). The env var names are historical — they feed any
-#      S3-compatible backend, and `iris cluster start` turns them into the
-#      iris-task-env Secret (addressing style is derived from the endpoint
-#      domain):
-#        export R2_ACCESS_KEY_ID=<coreweave-access-key-id>
-#        export R2_SECRET_ACCESS_KEY=<coreweave-access-key-secret>
+#      Access Keys). `iris cluster start` turns them into the iris-task-env
+#      Secret (addressing style is derived from the endpoint domain):
+#        export CW_KEY_ID=<coreweave-access-key-id>
+#        export CW_KEY_SECRET=<coreweave-access-key-secret>
 #   2. Point kubectl/iris at the region kubeconfig:
 #        export KUBECONFIG=~/.kube/coreweave-iris-rno2a   # context marin-rn02a_RNO2A
 #   3. Start / inspect the cluster:

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -44,14 +44,8 @@ platform:
 
 storage:
   remote_state_dir: s3://marin-us-east-02a/iris/cw-rno2a/state
-  # Node-local NVMe, not the default network-attached PVC (CoreWeave's default
-  # StorageClass here is an NFSv3 mount, `shared-vast`; SQLite WAL commits and
-  # lock round-trips over that network filesystem were the dominant cause of
-  # both the controller's RPC-handler thread pileups under load and a
-  # liveness-probe SIGKILL — see controller.coreweave.local_state_hostpath
-  # below). Safe because the cpu-turin scale group is pinned to exactly one
-  # node (buffer_slices == max_slices == 1); a node replacement finds this
-  # path empty and restores from the last remote checkpoint.
+  # Node-local NVMe for the controller's SQLite state, not the default
+  # network-attached PVC.
   local_state_dir: /mnt/local/iris-controller-state
 
 kubernetes_provider:
@@ -74,17 +68,11 @@ kubernetes_provider:
 
 controller:
   image: ghcr.io/marin-community/iris-controller:latest
-  # Node loses local state on replacement (no PVC redundancy under
-  # local_state_hostpath below); check in more often than the default hourly
-  # so a lost node costs at most this much recent state.
   checkpoint_interval_seconds: 600
   coreweave:
     port: 10000
     service_name: iris-controller-svc
     scale_group: cpu-turin
-    # See storage.local_state_dir above: mounts it from node-local NVMe via
-    # hostPath instead of the network-attached PVC.
-    local_state_hostpath: true
 
 defaults:
   autoscaler:

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -44,6 +44,15 @@ platform:
 
 storage:
   remote_state_dir: s3://marin-us-east-02a/iris/cw-rno2a/state
+  # Node-local NVMe, not the default network-attached PVC (CoreWeave's default
+  # StorageClass here is an NFSv3 mount, `shared-vast`; SQLite WAL commits and
+  # lock round-trips over that network filesystem were the dominant cause of
+  # both the controller's RPC-handler thread pileups under load and a
+  # liveness-probe SIGKILL — see controller.coreweave.local_state_hostpath
+  # below). Safe because the cpu-turin scale group is pinned to exactly one
+  # node (buffer_slices == max_slices == 1); a node replacement finds this
+  # path empty and restores from the last remote checkpoint.
+  local_state_dir: /mnt/local/iris-controller-state
 
 kubernetes_provider:
   namespace: iris
@@ -65,10 +74,17 @@ kubernetes_provider:
 
 controller:
   image: ghcr.io/marin-community/iris-controller:latest
+  # Node loses local state on replacement (no PVC redundancy under
+  # local_state_hostpath below); check in more often than the default hourly
+  # so a lost node costs at most this much recent state.
+  checkpoint_interval_seconds: 600
   coreweave:
     port: 10000
     service_name: iris-controller-svc
     scale_group: cpu-turin
+    # See storage.local_state_dir above: mounts it from node-local NVMe via
+    # hostPath instead of the network-attached PVC.
+    local_state_hostpath: true
 
 defaults:
   autoscaler:

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -11,9 +11,9 @@
 # whatever the NodePools hold. See lib/iris/docs/coreweave.md.
 #
 # Workflow:
-#   1. Set R2 object storage credentials (required for s3:// storage URIs):
-#        export R2_ACCESS_KEY_ID=<your-r2-access-key-id>
-#        export R2_SECRET_ACCESS_KEY=<your-r2-secret-access-key>
+#   1. Set CoreWeave AI Object Storage credentials (required for s3:// storage URIs):
+#        export CW_KEY_ID=<coreweave-access-key-id>
+#        export CW_KEY_SECRET=<coreweave-access-key-secret>
 #      `iris cluster start` turns these into the iris-task-env Secret.
 #   2. Point kubectl/iris at the region kubeconfig:
 #        export KUBECONFIG=~/.kube/coreweave-iris-gpu   # context marin-gpu_US-EAST-02A

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -43,6 +43,9 @@ platform:
 
 storage:
   remote_state_dir: s3://marin-na/iris/cw-us-east-02a/state
+  # Node-local NVMe for the controller's SQLite state, not the default
+  # network-attached PVC.
+  local_state_dir: /mnt/local/iris-controller-state
 
 # Request auth. No login arm — identity is by network location: direct
 # in-cluster peers (CKS pods/nodes are RFC1918; loopback covers kubectl
@@ -72,6 +75,7 @@ kubernetes_provider:
 
 controller:
   image: ghcr.io/marin-community/iris-controller:latest
+  checkpoint_interval_seconds: 600
   coreweave:
     port: 10000
     service_name: iris-controller-svc

--- a/lib/iris/config/examples/coreweave.yaml
+++ b/lib/iris/config/examples/coreweave.yaml
@@ -7,10 +7,10 @@
 #
 # Workflow:
 #
-#   1. Set S3 object storage credentials (required for s3:// storage URIs):
-#        export R2_ACCESS_KEY_ID=<your-r2-access-key-id>
-#        export R2_SECRET_ACCESS_KEY=<your-r2-secret-access-key>
-#      These are created in the Cloudflare dashboard under R2 > Manage R2 API Tokens.
+#   1. Set CoreWeave AI Object Storage credentials (required for s3:// storage URIs):
+#        export CW_KEY_ID=<coreweave-access-key-id>
+#        export CW_KEY_SECRET=<coreweave-access-key-secret>
+#      These are created in the CoreWeave console under Object Storage > Access Keys.
 #      `iris cluster start` creates a K8s Secret from these env vars automatically.
 #
 #   2. Start the cluster (creates RBAC, shared NodePools, ConfigMap, Deployment, Service):

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -23,7 +23,7 @@ Console links:
 create a token for the cluster and download its kubeconfig.
 
 **2. Install the kubeconfig** at the path from the table above, plus controller
-extras and R2 credentials:
+extras and CoreWeave Object Storage credentials:
 
 ```bash
 mkdir -p ~/.kube
@@ -32,8 +32,8 @@ export KUBECONFIG=~/.kube/coreweave-iris-gpu
 kubectl cluster-info   # sanity check
 
 uv pip install 'marin-iris[controller]'
-export R2_ACCESS_KEY_ID=<your-r2-access-key-id>
-export R2_SECRET_ACCESS_KEY=<your-r2-secret-access-key>
+export CW_KEY_ID=<coreweave-access-key-id>
+export CW_KEY_SECRET=<coreweave-access-key-secret>
 ```
 
 **3. Check cluster status.** `--cluster=cw-us-east-02a` resolves the in-tree
@@ -255,8 +255,7 @@ operator reference (any `--cluster=NAME`) and the lifecycle details behind it.
 - Images pushed to `ghcr.io/marin-community/`
 - Controller extras: `uv pip install 'marin-iris[controller]'`
 
-For S3 storage, export `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` (historical
-names — they feed any S3-compatible backend, including CoreWeave Object Storage
+For S3 storage, export `CW_KEY_ID` / `CW_KEY_SECRET` (CoreWeave Object Storage
 access keys); `iris cluster start` folds them — plus the derived
 endpoint/region/`FSSPEC_S3` config — into the `iris-task-env` Secret, projected
 into the controller and task pods via `envFrom`.
@@ -364,7 +363,7 @@ re-run the install after it is Ready.
 ### Bringing up a new cluster
 
 1. Download the kubeconfig (§0) to `~/.kube/coreweave-iris-<region>` and export
-   `KUBECONFIG`, `R2_ACCESS_KEY_ID`, `R2_SECRET_ACCESS_KEY`.
+   `KUBECONFIG`, `CW_KEY_ID`, `CW_KEY_SECRET`.
 2. Copy an existing cluster config pair — `lib/iris/config/cw-*.yaml` and
    `lib/finelog/config/cw-*.yaml` — and adjust region, instance types, and
    fleet sizes. The console capacity view's display label is NOT the k8s
@@ -712,8 +711,8 @@ The platform detects fatal errors before the full timeout expires:
 | Variable | Purpose |
 |----------|---------|
 | `KUBECONFIG` | Path to kubeconfig (alternative to `kubeconfig_path` in config) |
-| `R2_ACCESS_KEY_ID` | S3/R2 access key (required if storage uses `s3://`) |
-| `R2_SECRET_ACCESS_KEY` | S3/R2 secret key |
+| `CW_KEY_ID` | S3/CoreWeave Object Storage access key (required if storage uses `s3://`) |
+| `CW_KEY_SECRET` | S3/CoreWeave Object Storage secret key |
 | `CW_ACCESS_KEY_ID` | CoreWeave Object Storage key ID |
 | `CW_SECRET_ACCESS_KEY` | CoreWeave Object Storage secret key |
 
@@ -729,7 +728,7 @@ The platform detects fatal errors before the full timeout expires:
 | `AWS_ACCESS_KEY_ID` | `envFrom` | From the `iris-task-env` Secret |
 | `AWS_SECRET_ACCESS_KEY` | `envFrom` | From the `iris-task-env` Secret |
 | `AWS_ENDPOINT_URL` | `envFrom` | From `iris-task-env`; derived from `object_storage_endpoint` |
-| `AWS_REGION` / `AWS_DEFAULT_REGION` | `envFrom` | From `iris-task-env`; `auto` for R2 / CoreWeave endpoints |
+| `AWS_REGION` / `AWS_DEFAULT_REGION` | `envFrom` | From `iris-task-env`; `auto` for CoreWeave Object Storage endpoints |
 | `FSSPEC_S3` | `envFrom` | From `iris-task-env`; JSON-encoded fsspec S3 config (endpoint + addressing style) |
 
 ## 11. Timeouts
@@ -880,7 +879,7 @@ by polling.
 | Resource | Purpose | Created By |
 |----------|---------|------------|
 | `iris` Namespace + RBAC | K8s API auth and permissions | `start_controller()` via `ensure_rbac()` |
-| `iris-task-env` Secret | S3 object storage auth + operator-injected env (`defaults.inject_env`) | `start_controller()` via `ensure_task_env_secret()`, from `R2_ACCESS_KEY_ID` / `R2_SECRET_ACCESS_KEY` + the configured `object_storage_endpoint` |
+| `iris-task-env` Secret | S3 object storage auth + operator-injected env (`defaults.inject_env`) | `start_controller()` via `ensure_task_env_secret()`, from `CW_KEY_ID` / `CW_KEY_SECRET` + the configured `object_storage_endpoint` |
 | `iris-cluster-config` ConfigMap | Cluster config for controller and workers | `start_controller()` |
 | In-cluster ServiceAccount token | kubectl calls from controller Pod | Auto-mounted by Kubernetes |
 

--- a/lib/iris/scripts/fs-browser.py
+++ b/lib/iris/scripts/fs-browser.py
@@ -8,8 +8,8 @@ Supports both an interactive curses TUI and non-interactive CLI commands
 for listing, viewing, and copying files.
 
 Usage:
-    export R2_ACCESS_KEY_ID=<your-key-id>
-    export R2_SECRET_ACCESS_KEY=<your-key-secret>
+    export CW_KEY_ID=<your-key-id>
+    export CW_KEY_SECRET=<your-key-secret>
 
     # Interactive TUI (default)
     uv run lib/iris/scripts/fs-browser.py [prefix]
@@ -72,10 +72,10 @@ def normalize_path(arg: str, bucket: str) -> str:
 
 
 def connect(s3_config: S3Config) -> s3fs.S3FileSystem:
-    key_id = os.environ.get("R2_ACCESS_KEY_ID")
-    key_secret = os.environ.get("R2_SECRET_ACCESS_KEY")
+    key_id = os.environ.get("CW_KEY_ID")
+    key_secret = os.environ.get("CW_KEY_SECRET")
     if not key_id or not key_secret:
-        print("ERROR: R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY must be set", file=sys.stderr)
+        print("ERROR: CW_KEY_ID and CW_KEY_SECRET must be set", file=sys.stderr)
         sys.exit(1)
 
     return s3fs.S3FileSystem(

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -451,24 +451,12 @@ class CoreweaveControllerConfig(_Config):
     # cert-manager.io/cluster-issuer=<name> so cert-manager auto-issues the cert
     # into tls_secret. Empty = bring your own cert in tls_secret (or no TLS).
     cluster_issuer: str = ""
-    # Mount storage.local_state_dir from node-local disk (hostPath) instead of
-    # the default network-attached PersistentVolumeClaim. Requires
-    # storage.local_state_dir to be set explicitly (the hostPath target), and
-    # only safe when the controller's scale_group has max_slices == 1 — a
-    # rescheduled pod that lands back on a node with a stale local directory
-    # from an earlier run would resurrect out-of-date state instead of
-    # restoring from the latest remote checkpoint. start_controller enforces
-    # this. See lib/iris/docs/coreweave.md.
-    local_state_hostpath: bool = False
 
 
 class ControllerVmConfig(_OneofConfig):
     _ONEOF_ARMS = ("gcp", "manual", "local", "coreweave")
     image: str = ""  # controller docker image (shared by all controller types)
     # Periodic checkpoint interval (seconds); 0 = controller default (hourly).
-    # Tighten this when the controller's local state has no independent
-    # redundancy of its own (e.g. local_state_hostpath) to bound how much
-    # state a node replacement can lose.
     checkpoint_interval_seconds: float = 0
     gcp: GcpControllerConfig | None = None
     manual: ManualControllerConfig | None = None

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -451,11 +451,25 @@ class CoreweaveControllerConfig(_Config):
     # cert-manager.io/cluster-issuer=<name> so cert-manager auto-issues the cert
     # into tls_secret. Empty = bring your own cert in tls_secret (or no TLS).
     cluster_issuer: str = ""
+    # Mount storage.local_state_dir from node-local disk (hostPath) instead of
+    # the default network-attached PersistentVolumeClaim. Requires
+    # storage.local_state_dir to be set explicitly (the hostPath target), and
+    # only safe when the controller's scale_group has max_slices == 1 — a
+    # rescheduled pod that lands back on a node with a stale local directory
+    # from an earlier run would resurrect out-of-date state instead of
+    # restoring from the latest remote checkpoint. start_controller enforces
+    # this. See lib/iris/docs/coreweave.md.
+    local_state_hostpath: bool = False
 
 
 class ControllerVmConfig(_OneofConfig):
     _ONEOF_ARMS = ("gcp", "manual", "local", "coreweave")
     image: str = ""  # controller docker image (shared by all controller types)
+    # Periodic checkpoint interval (seconds); 0 = controller default (hourly).
+    # Tighten this when the controller's local state has no independent
+    # redundancy of its own (e.g. local_state_hostpath) to bound how much
+    # state a node replacement can lose.
+    checkpoint_interval_seconds: float = 0
     gcp: GcpControllerConfig | None = None
     manual: ManualControllerConfig | None = None
     local: LocalControllerConfig | None = None

--- a/lib/iris/src/iris/cluster/controller/checkpoint.py
+++ b/lib/iris/src/iris/cluster/controller/checkpoint.py
@@ -307,6 +307,14 @@ def _find_latest_checkpoint_dir(remote_state_dir: str) -> str | None:
     return _reconstruct_uri(remote_state_dir, latest_path)
 
 
+def latest_checkpoint_epoch_ms(remote_state_dir: str) -> int | None:
+    """Return the epoch_ms of the most recent remote checkpoint, or None if none exists."""
+    found = _find_latest_checkpoint_dir(remote_state_dir)
+    if found is None:
+        return None
+    return int(found.rstrip("/").rsplit("/", 1)[-1])
+
+
 def prune_old_checkpoints(
     remote_state_dir: str,
     max_age: Duration = DEFAULT_PRUNE_AGE,

--- a/lib/iris/src/iris/cluster/controller/main.py
+++ b/lib/iris/src/iris/cluster/controller/main.py
@@ -25,7 +25,7 @@ from iris.cluster.composer import make_backends
 from iris.cluster.config import IrisClusterConfig, load_config, resolve_backends
 from iris.cluster.controller.auth import create_controller_auth
 from iris.cluster.controller.budget import reconcile_user_budget_tiers
-from iris.cluster.controller.checkpoint import download_checkpoint_to_local
+from iris.cluster.controller.checkpoint import download_checkpoint_to_local, latest_checkpoint_epoch_ms
 from iris.cluster.controller.controller import Controller, ControllerConfig
 from iris.cluster.controller.db import ControllerDB
 from iris.cluster.controller.log_stack import build_log_stack
@@ -38,6 +38,26 @@ logger = logging.getLogger(__name__)
 LOCAL_STATE_DIR_DEFAULT = Path("/var/cache/iris/controller")
 DRY_RUN_STATE_DIR_ROOT = Path("/tmp/dry-run")
 HOURLY_CHECKPOINT_SECONDS = 3600.0
+
+
+def _local_db_epoch_ms(db_dir: Path) -> int | None:
+    """Newest mtime (epoch ms) among the local main/auth SQLite DBs, or None if either is missing.
+
+    Includes each DB's WAL/SHM sibling files — WAL-mode writes land there
+    first, so the main .sqlite3 file's own mtime can lag behind the DB's real
+    freshness.
+    """
+    db_path = db_dir / ControllerDB.DB_FILENAME
+    auth_db_path = db_dir / ControllerDB.AUTH_DB_FILENAME
+    if not db_path.exists() or not auth_db_path.exists():
+        return None
+    candidates = [
+        db_path,
+        auth_db_path,
+        *db_dir.glob(f"{ControllerDB.DB_FILENAME}-*"),
+        *db_dir.glob(f"{ControllerDB.AUTH_DB_FILENAME}-*"),
+    ]
+    return int(max(p.stat().st_mtime for p in candidates) * 1000)
 
 
 def _resolve_cluster_endpoints(cluster_config: IrisClusterConfig) -> dict[str, str]:
@@ -131,17 +151,29 @@ def run_controller_serve(
             shutil.rmtree(db_dir)
         logger.info("--fresh: starting with empty database, skipping checkpoint restore")
         db_dir.mkdir(parents=True, exist_ok=True)
-    elif db_path.exists() and auth_db_path.exists():
-        logger.info("Local DB exists at %s, skipping remote restore", db_dir)
     else:
-        if db_path.exists() and not auth_db_path.exists():
-            logger.warning(
-                "Main DB exists at %s but auth DB is missing — fetching from remote",
-                db_path,
-            )
-        restored = download_checkpoint_to_local(remote_state_dir, db_dir, checkpoint_dir=checkpoint_path)
-        if checkpoint_path and not restored:
-            raise ValueError(f"Checkpoint not found: {checkpoint_path}")
+        # Trust local only when both files are present AND at least as fresh as
+        # the latest remote checkpoint. This also covers a node-local volume
+        # that isn't guaranteed to be the same disk across restarts (e.g. one
+        # backed by a multi-node scale group): leftover files from an earlier
+        # stint on this same node are only trusted if nothing more recent has
+        # been checkpointed elsewhere since. This compares wall-clock mtimes
+        # across whichever nodes wrote each side, so it relies on nodes being
+        # NTP-synced to within the checkpoint interval (minutes) — true of
+        # every platform this runs on.
+        local_ms = _local_db_epoch_ms(db_dir)
+        remote_ms = latest_checkpoint_epoch_ms(remote_state_dir)
+        if local_ms is not None and (remote_ms is None or local_ms >= remote_ms):
+            logger.info("Local DB at %s is at least as fresh as the latest remote checkpoint, skipping restore", db_dir)
+        else:
+            if db_path.exists() and not auth_db_path.exists():
+                logger.warning(
+                    "Main DB exists at %s but auth DB is missing — fetching from remote",
+                    db_path,
+                )
+            restored = download_checkpoint_to_local(remote_state_dir, db_dir, checkpoint_dir=checkpoint_path)
+            if checkpoint_path and not restored:
+                raise ValueError(f"Checkpoint not found: {checkpoint_path}")
 
     db = ControllerDB(db_dir=db_dir)
 

--- a/lib/iris/src/iris/cluster/controller/migrations/0037_federation_fixup.py
+++ b/lib/iris/src/iris/cluster/controller/migrations/0037_federation_fixup.py
@@ -1,0 +1,63 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Reconcile DBs that recorded the pre-revision 0034/0035 federation shape.
+
+0034/0035 were revised in place after they had already been applied to a live
+controller: the federation coordinate was renamed ``child_cluster`` -> ``cluster``
+(default ``''`` -> ``'local'``) and the ``federated_jobs`` / ``federation_sync_state``
+bookkeeping columns ``remote_job_id`` / ``last_sync_ms`` / ``terminal_error`` /
+``last_full_resync_ms`` were dropped. A DB that recorded the old stems keeps the
+old shape forever, because a recorded migration is never re-run. This forward
+migration brings that shape to the current schema.
+
+Federation has never been enabled, so every row's coordinate is local: the added
+``cluster`` column defaults to ``'local'``, already the correct value for every
+existing row.
+
+Idempotent: a fresh DB (or one already on the current schema) has ``cluster`` and
+none of the dropped columns, so every step no-ops.
+"""
+
+# federated_jobs / federation_sync_state columns the revised design removed.
+_STALE_COLUMNS = (
+    ("federated_jobs", "remote_job_id"),
+    ("federated_jobs", "last_sync_ms"),
+    ("federated_jobs", "terminal_error"),
+    ("federation_sync_state", "last_full_resync_ms"),
+)
+
+
+def _has_column(raw_conn, table: str, column: str) -> bool:
+    # PRAGMA table_info columns: (cid, name, type, notnull, dflt_value, pk)
+    return any(row[1] == column for row in raw_conn.execute(f"PRAGMA table_info({table})").fetchall())
+
+
+def migrate(raw_conn) -> None:
+    for table, column in _STALE_COLUMNS:
+        if _has_column(raw_conn, table, column):
+            raw_conn.execute(f"ALTER TABLE {table} DROP COLUMN {column}")
+
+    # Rename the federation coordinate child_cluster -> cluster on jobs/tasks.
+    # The tasks "local" partial indexes filter on child_cluster and would block
+    # the column drop, so drop them first; they are recreated on cluster below.
+    if _has_column(raw_conn, "jobs", "child_cluster") or _has_column(raw_conn, "tasks", "child_cluster"):
+        raw_conn.execute("DROP INDEX IF EXISTS idx_tasks_pending_local")
+        raw_conn.execute("DROP INDEX IF EXISTS idx_tasks_state_local")
+        for table in ("jobs", "tasks"):
+            if not _has_column(raw_conn, table, "child_cluster"):
+                continue
+            if not _has_column(raw_conn, table, "cluster"):
+                # Clause order matches the baseline's SQLAlchemy-emitted DDL so the
+                # stored CREATE text is byte-identical to a fresh DB's.
+                raw_conn.execute(f"ALTER TABLE {table} ADD COLUMN cluster VARCHAR DEFAULT 'local' NOT NULL")
+            raw_conn.execute(f"ALTER TABLE {table} DROP COLUMN child_cluster")
+
+    # Ensure the local-scheduler partial indexes exist on the cluster column.
+    # No-op on a fresh DB where the baseline schema already created them.
+    raw_conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_tasks_pending_local ON tasks "
+        "(state, priority_band, priority_neg_depth, priority_root_submitted_ms, "
+        "submitted_at_ms, priority_insertion) WHERE cluster = 'local'"
+    )
+    raw_conn.execute("CREATE INDEX IF NOT EXISTS idx_tasks_state_local ON tasks (state) WHERE cluster = 'local'")

--- a/lib/iris/src/iris/cluster/platforms/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/controller.py
@@ -78,22 +78,22 @@ def _needs_virtual_host_addressing(endpoint_url: str) -> bool:
 
 
 def configure_client_s3(config: IrisClusterConfig) -> None:
-    """Configure S3 env vars for fsspec access on CoreWeave (R2 → AWS mapping).
+    """Configure S3 env vars for fsspec access on CoreWeave (CW_KEY_* → AWS mapping).
 
-    Maps R2_ACCESS_KEY_ID/R2_SECRET_ACCESS_KEY to their AWS equivalents and
-    sets FSSPEC_S3 with the correct endpoint and addressing style. No-op if the
-    config has no CoreWeave object storage endpoint.
+    Maps CW_KEY_ID/CW_KEY_SECRET to their AWS equivalents and sets FSSPEC_S3
+    with the correct endpoint and addressing style. No-op if the config has no
+    CoreWeave object storage endpoint.
     """
     coreweave = config.platform.coreweave
     if coreweave is None or not coreweave.object_storage_endpoint:
         return
     endpoint = coreweave.object_storage_endpoint
 
-    r2_key = os.environ.get("R2_ACCESS_KEY_ID", "")
-    r2_secret = os.environ.get("R2_SECRET_ACCESS_KEY", "")
-    if r2_key and r2_secret:
-        os.environ.setdefault("AWS_ACCESS_KEY_ID", r2_key)
-        os.environ.setdefault("AWS_SECRET_ACCESS_KEY", r2_secret)
+    cw_key = os.environ.get("CW_KEY_ID", "")
+    cw_secret = os.environ.get("CW_KEY_SECRET", "")
+    if cw_key and cw_secret:
+        os.environ.setdefault("AWS_ACCESS_KEY_ID", cw_key)
+        os.environ.setdefault("AWS_SECRET_ACCESS_KEY", cw_secret)
 
     os.environ.setdefault("AWS_ENDPOINT_URL", endpoint)
     os.environ.setdefault("AWS_REGION", "auto")
@@ -921,17 +921,17 @@ class K8sControllerProvider:
     def _s3_task_env(self) -> dict[str, str]:
         """Compute S3 storage env (creds + endpoint + FSSPEC) from the operator's shell.
 
-        Maps the operator's R2 credentials to the AWS names boto3/s3fs expect and
-        derives endpoint/region/FSSPEC_S3 from the configured object-storage
-        endpoint. Folded into the iris-task-env Secret so the controller and every
-        task authenticate to s3:// without per-call-site configuration.
+        Maps the operator's CoreWeave object-storage credentials to the AWS
+        names boto3/s3fs expect and derives endpoint/region/FSSPEC_S3 from the
+        configured object-storage endpoint. Folded into the iris-task-env
+        Secret so the controller and every task authenticate to s3:// without
+        per-call-site configuration.
         """
-        key_id = os.environ.get("R2_ACCESS_KEY_ID")
-        key_secret = os.environ.get("R2_SECRET_ACCESS_KEY")
+        key_id = os.environ.get("CW_KEY_ID")
+        key_secret = os.environ.get("CW_KEY_SECRET")
         if not key_id or not key_secret:
             raise InfraError(
-                "R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY environment variables are required "
-                "for S3-compatible object storage"
+                "CW_KEY_ID and CW_KEY_SECRET environment variables are required for S3-compatible object storage"
             )
         env = {"AWS_ACCESS_KEY_ID": key_id, "AWS_SECRET_ACCESS_KEY": key_secret}
         endpoint = self._config.object_storage_endpoint

--- a/lib/iris/src/iris/cluster/platforms/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/controller.py
@@ -60,6 +60,9 @@ _KUBECTL_TIMEOUT = 1800.0
 _CONTROLLER_CPU_REQUEST = "4"
 _CONTROLLER_MEMORY_REQUEST = "16Gi"
 _CONTROLLER_STATE_PVC_NAME = "iris-controller-state"
+# Must match main.py's LOCAL_STATE_DIR_DEFAULT — the path the controller
+# process falls back to when storage.local_state_dir is unset.
+_DEFAULT_STATE_MOUNT_PATH = "/var/cache/iris/controller"
 _CONTROLLER_STATE_PVC_SIZE = "50Gi"
 
 
@@ -125,7 +128,7 @@ def _build_controller_deployment(
     node_selector: dict[str, str],
     task_env_secret: bool = False,
     fresh: bool = False,
-    state_mount_path: str = "/var/cache/iris/controller",
+    state_mount_path: str = _DEFAULT_STATE_MOUNT_PATH,
     local_state_hostpath: bool = False,
     checkpoint_interval_seconds: float = 0,
 ) -> dict:
@@ -387,7 +390,7 @@ class K8sControllerProvider:
                 f"{list(config.scale_groups.keys())}"
             )
 
-        state_mount_path = config.storage.local_state_dir or "/var/cache/iris/controller"
+        state_mount_path = config.storage.local_state_dir or _DEFAULT_STATE_MOUNT_PATH
         if cw.local_state_hostpath:
             if not config.storage.local_state_dir:
                 raise InfraError(

--- a/lib/iris/src/iris/cluster/platforms/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/controller.py
@@ -58,7 +58,7 @@ _DEPLOYMENT_DELETE_TIMEOUT = 120.0
 _KUBECTL_TIMEOUT = 1800.0
 
 _CONTROLLER_CPU_REQUEST = "4"
-_CONTROLLER_MEMORY_REQUEST = "16Gi"
+_CONTROLLER_MEMORY_REQUEST = "64Gi"
 _CONTROLLER_STATE_PVC_NAME = "iris-controller-state"
 # Must match main.py's LOCAL_STATE_DIR_DEFAULT — the path the controller
 # process falls back to when storage.local_state_dir is unset.
@@ -208,12 +208,9 @@ def _build_controller_deployment(
                             "httpGet": {"path": "/health", "port": port},
                             "initialDelaySeconds": 30,
                             "periodSeconds": 30,
-                            # Default 1s is tight for a Python/GIL process under a burst
-                            # of concurrent RPC handlers; give it headroom so a transient
-                            # scheduling hiccup doesn't trip a hard kubelet SIGKILL. A
-                            # genuinely wedged controller is still caught within
-                            # periodSeconds * failureThreshold.
-                            "timeoutSeconds": 5,
+                            # Default 1s is tight under load; give it headroom so a
+                            # transient hiccup doesn't trip a hard kubelet SIGKILL.
+                            "timeoutSeconds": 10,
                         },
                     },
                 ],
@@ -390,22 +387,10 @@ class K8sControllerProvider:
                 f"{list(config.scale_groups.keys())}"
             )
 
+        # storage.local_state_dir set => mount it from node-local hostPath rather
+        # than the default network-attached PVC.
+        local_state_hostpath = bool(config.storage.local_state_dir)
         state_mount_path = config.storage.local_state_dir or _DEFAULT_STATE_MOUNT_PATH
-        if cw.local_state_hostpath:
-            if not config.storage.local_state_dir:
-                raise InfraError(
-                    "controller.coreweave.local_state_hostpath requires storage.local_state_dir "
-                    "to be set explicitly (the node-local path to mount, e.g. /mnt/local/iris-controller-state)"
-                )
-            max_slices = config.scale_groups[cw.scale_group].max_slices
-            if max_slices != 1:
-                raise InfraError(
-                    f"controller.coreweave.local_state_hostpath requires scale_group {cw.scale_group!r} "
-                    f"to have max_slices == 1 (got {max_slices}): a controller pod rescheduled onto a "
-                    "different node in a multi-node pool would find that node's hostPath dir empty (fine, "
-                    "restores from checkpoint) but a pod rescheduled BACK onto a node it previously ran on "
-                    "would find its own stale local DB and skip the restore, resurrecting out-of-date state."
-                )
 
         self.ensure_rbac()
 
@@ -434,7 +419,7 @@ class K8sControllerProvider:
         self.ensure_nodepools(config)
         self.ensure_kueue_queues(config)
         self.ensure_priority_classes()
-        if cw.local_state_hostpath:
+        if local_state_hostpath:
             logger.info("controller local state uses node-local hostPath %s (no PVC)", state_mount_path)
         else:
             self._kubectl.apply_json(_build_controller_state_pvc(namespace=self._namespace))
@@ -447,7 +432,7 @@ class K8sControllerProvider:
             node_selector={self._iris_labels.iris_scale_group: cw.scale_group},
             task_env_secret=projects_task_env_secret(config),
             state_mount_path=state_mount_path,
-            local_state_hostpath=cw.local_state_hostpath,
+            local_state_hostpath=local_state_hostpath,
             checkpoint_interval_seconds=config.controller.checkpoint_interval_seconds,
         )
         deploy_manifest = _build_controller_deployment(**deploy_kwargs, fresh=fresh)

--- a/lib/iris/src/iris/cluster/platforms/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/controller.py
@@ -125,6 +125,9 @@ def _build_controller_deployment(
     node_selector: dict[str, str],
     task_env_secret: bool = False,
     fresh: bool = False,
+    state_mount_path: str = "/var/cache/iris/controller",
+    local_state_hostpath: bool = False,
+    checkpoint_interval_seconds: float = 0,
 ) -> dict:
     """Build the controller Deployment manifest as a dict."""
     # Reserve controller CPU/memory so Kubernetes doesn't classify this Pod
@@ -133,11 +136,12 @@ def _build_controller_deployment(
         "requests": {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST},
         "limits": {"cpu": _CONTROLLER_CPU_REQUEST, "memory": _CONTROLLER_MEMORY_REQUEST},
     }
-    # The controller SQLite DB lives on a PersistentVolumeClaim, so two
-    # controller pods must never mount the same local state dir at once. We
-    # guarantee that by tearing the old Deployment down and waiting for it to
-    # fully disappear before applying the new one (see start_controller); the
-    # Recreate strategy is belt-and-suspenders for any in-place apply path.
+    # The controller SQLite DB lives on a PersistentVolumeClaim (or, with
+    # local_state_hostpath, a node-local directory), so two controller pods
+    # must never mount the same local state dir at once. We guarantee that by
+    # tearing the old Deployment down and waiting for it to fully disappear
+    # before applying the new one (see start_controller); the Recreate
+    # strategy is belt-and-suspenders for any in-place apply path.
     deploy_spec: dict = {
         "replicas": 1,
         "selector": {"matchLabels": {"app": "iris-controller"}},
@@ -171,6 +175,11 @@ def _build_controller_deployment(
                             f"--port={port}",
                             "--config=/etc/iris/config.json",
                             *(["--fresh"] if fresh else []),
+                            *(
+                                [f"--checkpoint-interval={checkpoint_interval_seconds}"]
+                                if checkpoint_interval_seconds
+                                else []
+                            ),
                         ],
                         "ports": [{"containerPort": port}],
                         # The cluster default env (S3 storage auth + operator-injected
@@ -185,7 +194,7 @@ def _build_controller_deployment(
                         "resources": controller_resources,
                         "volumeMounts": [
                             {"name": "config", "mountPath": "/etc/iris", "readOnly": True},
-                            {"name": "local-state", "mountPath": "/var/cache/iris/controller"},
+                            {"name": "local-state", "mountPath": state_mount_path},
                         ],
                         "readinessProbe": {
                             "httpGet": {"path": "/health", "port": port},
@@ -196,15 +205,25 @@ def _build_controller_deployment(
                             "httpGet": {"path": "/health", "port": port},
                             "initialDelaySeconds": 30,
                             "periodSeconds": 30,
+                            # Default 1s is tight for a Python/GIL process under a burst
+                            # of concurrent RPC handlers; give it headroom so a transient
+                            # scheduling hiccup doesn't trip a hard kubelet SIGKILL. A
+                            # genuinely wedged controller is still caught within
+                            # periodSeconds * failureThreshold.
+                            "timeoutSeconds": 5,
                         },
                     },
                 ],
                 "volumes": [
                     {"name": "config", "configMap": {"name": "iris-cluster-config"}},
-                    {
-                        "name": "local-state",
-                        "persistentVolumeClaim": {"claimName": _CONTROLLER_STATE_PVC_NAME},
-                    },
+                    (
+                        {"name": "local-state", "hostPath": {"path": state_mount_path, "type": "DirectoryOrCreate"}}
+                        if local_state_hostpath
+                        else {
+                            "name": "local-state",
+                            "persistentVolumeClaim": {"claimName": _CONTROLLER_STATE_PVC_NAME},
+                        }
+                    ),
                 ],
             },
         },
@@ -368,6 +387,23 @@ class K8sControllerProvider:
                 f"{list(config.scale_groups.keys())}"
             )
 
+        state_mount_path = config.storage.local_state_dir or "/var/cache/iris/controller"
+        if cw.local_state_hostpath:
+            if not config.storage.local_state_dir:
+                raise InfraError(
+                    "controller.coreweave.local_state_hostpath requires storage.local_state_dir "
+                    "to be set explicitly (the node-local path to mount, e.g. /mnt/local/iris-controller-state)"
+                )
+            max_slices = config.scale_groups[cw.scale_group].max_slices
+            if max_slices != 1:
+                raise InfraError(
+                    f"controller.coreweave.local_state_hostpath requires scale_group {cw.scale_group!r} "
+                    f"to have max_slices == 1 (got {max_slices}): a controller pod rescheduled onto a "
+                    "different node in a multi-node pool would find that node's hostPath dir empty (fine, "
+                    "restores from checkpoint) but a pod rescheduled BACK onto a node it previously ran on "
+                    "would find its own stale local DB and skip the restore, resurrecting out-of-date state."
+                )
+
         self.ensure_rbac()
 
         # Build the cluster default env and project it into the controller and
@@ -395,8 +431,11 @@ class K8sControllerProvider:
         self.ensure_nodepools(config)
         self.ensure_kueue_queues(config)
         self.ensure_priority_classes()
-        self._kubectl.apply_json(_build_controller_state_pvc(namespace=self._namespace))
-        logger.info("PersistentVolumeClaim %s applied", _CONTROLLER_STATE_PVC_NAME)
+        if cw.local_state_hostpath:
+            logger.info("controller local state uses node-local hostPath %s (no PVC)", state_mount_path)
+        else:
+            self._kubectl.apply_json(_build_controller_state_pvc(namespace=self._namespace))
+            logger.info("PersistentVolumeClaim %s applied", _CONTROLLER_STATE_PVC_NAME)
 
         deploy_kwargs = dict(
             namespace=self._namespace,
@@ -404,6 +443,9 @@ class K8sControllerProvider:
             port=port,
             node_selector={self._iris_labels.iris_scale_group: cw.scale_group},
             task_env_secret=projects_task_env_secret(config),
+            state_mount_path=state_mount_path,
+            local_state_hostpath=cw.local_state_hostpath,
+            checkpoint_interval_seconds=config.controller.checkpoint_interval_seconds,
         )
         deploy_manifest = _build_controller_deployment(**deploy_kwargs, fresh=fresh)
         # Always stop the old controller before starting the new one. The

--- a/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
@@ -216,13 +216,11 @@ def test_start_controller_creates_all_resources():
     provider.shutdown()
 
 
-def test_start_controller_local_state_hostpath_skips_pvc():
-    """local_state_hostpath mounts a hostPath volume at storage.local_state_dir and creates no PVC."""
+def test_start_controller_local_state_dir_uses_hostpath_not_pvc():
+    """Setting storage.local_state_dir mounts it via hostPath and creates no PVC."""
     provider, k8s = _make_provider()
     cluster_config = _make_cluster_config(remote_state_dir="s3://test-bucket/bundles")
     cluster_config.storage.local_state_dir = "/mnt/local/iris-controller-state"
-    cluster_config.controller.coreweave.local_state_hostpath = True
-    cluster_config.scale_groups[cluster_config.controller.coreweave.scale_group].max_slices = 1
 
     t = threading.Thread(target=_auto_ready_deployment, args=(k8s, "iris-controller"), daemon=True)
     t.start()
@@ -240,31 +238,6 @@ def test_start_controller_local_state_hostpath_skips_pvc():
     } in spec["volumes"]
 
     t.join(timeout=5)
-    provider.shutdown()
-
-
-def test_start_controller_local_state_hostpath_requires_local_state_dir():
-    """local_state_hostpath without storage.local_state_dir set fails fast — there's no path to mount."""
-    provider, _ = _make_provider()
-    cluster_config = _make_cluster_config()
-    cluster_config.controller.coreweave.local_state_hostpath = True
-    cluster_config.scale_groups[cluster_config.controller.coreweave.scale_group].max_slices = 1
-
-    with pytest.raises(InfraError, match="storage\\.local_state_dir"):
-        provider.start_controller(cluster_config)
-    provider.shutdown()
-
-
-def test_start_controller_local_state_hostpath_requires_single_slice():
-    """local_state_hostpath on a multi-node scale group risks reviving stale state on reschedule."""
-    provider, _ = _make_provider()
-    cluster_config = _make_cluster_config()
-    cluster_config.storage.local_state_dir = "/mnt/local/iris-controller-state"
-    cluster_config.controller.coreweave.local_state_hostpath = True
-    cluster_config.scale_groups[cluster_config.controller.coreweave.scale_group].max_slices = 10
-
-    with pytest.raises(InfraError, match="max_slices == 1"):
-        provider.start_controller(cluster_config)
     provider.shutdown()
 
 

--- a/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
@@ -216,6 +216,58 @@ def test_start_controller_creates_all_resources():
     provider.shutdown()
 
 
+def test_start_controller_local_state_hostpath_skips_pvc():
+    """local_state_hostpath mounts a hostPath volume at storage.local_state_dir and creates no PVC."""
+    provider, k8s = _make_provider()
+    cluster_config = _make_cluster_config(remote_state_dir="s3://test-bucket/bundles")
+    cluster_config.storage.local_state_dir = "/mnt/local/iris-controller-state"
+    cluster_config.controller.coreweave.local_state_hostpath = True
+    cluster_config.scale_groups[cluster_config.controller.coreweave.scale_group].max_slices = 1
+
+    t = threading.Thread(target=_auto_ready_deployment, args=(k8s, "iris-controller"), daemon=True)
+    t.start()
+
+    provider.start_controller(cluster_config)
+
+    assert k8s.get_json(K8sResource.PERSISTENT_VOLUME_CLAIMS, _CONTROLLER_STATE_PVC_NAME) is None
+    dep = k8s.get_json(K8sResource.DEPLOYMENTS, "iris-controller")
+    spec = dep["spec"]["template"]["spec"]
+    container = spec["containers"][0]
+    assert {"name": "local-state", "mountPath": "/mnt/local/iris-controller-state"} in container["volumeMounts"]
+    assert {
+        "name": "local-state",
+        "hostPath": {"path": "/mnt/local/iris-controller-state", "type": "DirectoryOrCreate"},
+    } in spec["volumes"]
+
+    t.join(timeout=5)
+    provider.shutdown()
+
+
+def test_start_controller_local_state_hostpath_requires_local_state_dir():
+    """local_state_hostpath without storage.local_state_dir set fails fast — there's no path to mount."""
+    provider, _ = _make_provider()
+    cluster_config = _make_cluster_config()
+    cluster_config.controller.coreweave.local_state_hostpath = True
+    cluster_config.scale_groups[cluster_config.controller.coreweave.scale_group].max_slices = 1
+
+    with pytest.raises(InfraError, match="storage\\.local_state_dir"):
+        provider.start_controller(cluster_config)
+    provider.shutdown()
+
+
+def test_start_controller_local_state_hostpath_requires_single_slice():
+    """local_state_hostpath on a multi-node scale group risks reviving stale state on reschedule."""
+    provider, _ = _make_provider()
+    cluster_config = _make_cluster_config()
+    cluster_config.storage.local_state_dir = "/mnt/local/iris-controller-state"
+    cluster_config.controller.coreweave.local_state_hostpath = True
+    cluster_config.scale_groups[cluster_config.controller.coreweave.scale_group].max_slices = 10
+
+    with pytest.raises(InfraError, match="max_slices == 1"):
+        provider.start_controller(cluster_config)
+    provider.shutdown()
+
+
 def test_start_controller_injects_operator_env(monkeypatch):
     """inject_env writes the iris-task-env Secret and wires the controller envFrom."""
     monkeypatch.setenv("WANDB_API_KEY", "wb-secret")

--- a/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
@@ -74,9 +74,9 @@ def _auto_ready_deployment(k8s: InMemoryK8sService, name: str, timeout: float = 
 
 @pytest.fixture(autouse=True)
 def _s3_env_vars(monkeypatch):
-    """Set R2_ACCESS_KEY_ID / R2_SECRET_ACCESS_KEY so the S3 task-env build succeeds."""
-    monkeypatch.setenv("R2_ACCESS_KEY_ID", "test-key-id")
-    monkeypatch.setenv("R2_SECRET_ACCESS_KEY", "test-key-secret")
+    """Set CW_KEY_ID / CW_KEY_SECRET so the S3 task-env build succeeds."""
+    monkeypatch.setenv("CW_KEY_ID", "test-key-id")
+    monkeypatch.setenv("CW_KEY_SECRET", "test-key-secret")
 
 
 # ============================================================================
@@ -638,12 +638,12 @@ def test_start_controller_errors_with_invalid_scale_group():
 
 def test_start_controller_errors_without_s3_credentials(monkeypatch):
     """start_controller raises when S3 storage is configured but R2 credentials are not set."""
-    monkeypatch.delenv("R2_ACCESS_KEY_ID", raising=False)
-    monkeypatch.delenv("R2_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("CW_KEY_ID", raising=False)
+    monkeypatch.delenv("CW_KEY_SECRET", raising=False)
     provider, _ = _make_provider()
     cluster_config = _make_cluster_config(remote_state_dir="s3://my-bucket/bundles")
 
-    with pytest.raises(InfraError, match="R2_ACCESS_KEY_ID and R2_SECRET_ACCESS_KEY"):
+    with pytest.raises(InfraError, match="CW_KEY_ID and CW_KEY_SECRET"):
         provider.start_controller(cluster_config)
     provider.shutdown()
 
@@ -797,8 +797,8 @@ def test_start_controller_crash_loop_includes_logs():
 
 def test_start_controller_skips_s3_for_gs_storage(monkeypatch):
     """start_controller succeeds without S3 credentials when using gs:// storage."""
-    monkeypatch.delenv("R2_ACCESS_KEY_ID", raising=False)
-    monkeypatch.delenv("R2_SECRET_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("CW_KEY_ID", raising=False)
+    monkeypatch.delenv("CW_KEY_SECRET", raising=False)
     provider, k8s = _make_provider()
     cluster_config = _make_cluster_config(remote_state_dir="gs://test-bucket/bundles")
 

--- a/lib/iris/tests/cluster/controller/test_checkpoint.py
+++ b/lib/iris/tests/cluster/controller/test_checkpoint.py
@@ -5,6 +5,7 @@
 
 from iris.cluster.controller.checkpoint import (
     download_checkpoint_to_local,
+    latest_checkpoint_epoch_ms,
     prune_old_checkpoints,
     write_checkpoint,
 )
@@ -75,6 +76,21 @@ def test_download_checkpoint_returns_false_when_missing(tmp_path):
     result = download_checkpoint_to_local(f"file://{tmp_path}/nonexistent", local_db_dir)
     assert result is False
     assert not (local_db_dir / "controller.sqlite3").exists()
+
+
+def test_latest_checkpoint_epoch_ms_none_when_missing(tmp_path):
+    assert latest_checkpoint_epoch_ms(f"file://{tmp_path}/nonexistent") is None
+
+
+def test_latest_checkpoint_epoch_ms_matches_written_checkpoint(tmp_path, make_controller):
+    remote_dir = f"file://{tmp_path}/remote"
+    controller = make_controller(remote_state_dir=remote_dir)
+
+    path, _ = write_checkpoint(controller._db, remote_dir)
+
+    epoch_ms = latest_checkpoint_epoch_ms(remote_dir)
+    assert epoch_ms is not None
+    assert path == f"file://{tmp_path}/remote/controller-state/{epoch_ms}"
 
 
 def test_download_from_explicit_path(tmp_path):

--- a/lib/iris/tests/cluster/controller/test_main_endpoints.py
+++ b/lib/iris/tests/cluster/controller/test_main_endpoints.py
@@ -4,6 +4,7 @@
 """Tests for endpoint resolution in the controller daemon entrypoint."""
 
 import json
+import os
 import subprocess
 from pathlib import Path
 from unittest.mock import patch
@@ -11,7 +12,8 @@ from unittest.mock import patch
 import pytest
 import yaml
 from iris.cluster.config import ClusterFinelogConfig, EndpointSpec, IrisClusterConfig
-from iris.cluster.controller.main import LOG_SERVER_ENDPOINT_NAME, _resolve_cluster_endpoints
+from iris.cluster.controller.db import ControllerDB
+from iris.cluster.controller.main import LOG_SERVER_ENDPOINT_NAME, _local_db_epoch_ms, _resolve_cluster_endpoints
 
 
 def test_resolve_returns_empty_for_empty_config():
@@ -125,3 +127,39 @@ def test_finelog_config_missing_file_raises():
 
     with pytest.raises(FileNotFoundError):
         _resolve_cluster_endpoints(cfg)
+
+
+def test_local_db_epoch_ms_none_when_absent(tmp_path: Path):
+    assert _local_db_epoch_ms(tmp_path / "db") is None
+
+
+def test_local_db_epoch_ms_none_when_auth_db_missing(tmp_path: Path):
+    """A partial local dir (main DB only) must not be trusted as a freshness signal."""
+    db_dir = tmp_path / "db"
+    db = ControllerDB(db_dir=db_dir)
+    db.close()
+    (db_dir / ControllerDB.AUTH_DB_FILENAME).unlink()
+
+    assert _local_db_epoch_ms(db_dir) is None
+
+
+def test_local_db_epoch_ms_reflects_wal_mtime(tmp_path: Path):
+    """A WAL-mode write lands in the -wal sibling first; its mtime must count."""
+    db_dir = tmp_path / "db"
+    db = ControllerDB(db_dir=db_dir)
+    with db.transaction():
+        pass  # commit an IMMEDIATE transaction so the WAL file is populated
+
+    db_path = db_dir / ControllerDB.DB_FILENAME
+    wal_path = db_dir / f"{ControllerDB.DB_FILENAME}-wal"
+    assert wal_path.exists(), "WAL file must exist while the connection is open"
+
+    older = db_path.stat().st_mtime - 100
+    newer = older + 50
+    # Backdate every file except the main WAL, so the newest mtime is unambiguous.
+    for path in db_dir.iterdir():
+        os.utime(path, (older, older))
+    os.utime(wal_path, (newer, newer))
+
+    assert _local_db_epoch_ms(db_dir) == int(newer * 1000)
+    db.close()

--- a/lib/iris/tests/cluster/controller/test_migration_0037.py
+++ b/lib/iris/tests/cluster/controller/test_migration_0037.py
@@ -1,0 +1,177 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for migration ``0037_federation_fixup``.
+
+Builds a DB in the pre-revision 0034/0035 shape — jobs/tasks carrying
+``child_cluster`` (default ``''``) instead of ``cluster``, the two tasks partial
+indexes filtering on ``child_cluster = ''``, and the extra ``federated_jobs`` /
+``federation_sync_state`` bookkeeping columns — and asserts the migration renames
+the coordinate to ``cluster`` (defaulting existing rows to ``'local'``), drops the
+stale columns, rebuilds the partial indexes on ``cluster = 'local'``, and is both
+idempotent and a no-op on a DB already in the current shape.
+"""
+
+import importlib.util
+import sqlite3
+from pathlib import Path
+
+_MIGRATION = Path(__file__).parents[3] / "src/iris/cluster/controller/migrations/0037_federation_fixup.py"
+
+# Pre-revision (post-#6821) shape of the tables 0037 reconciles: child_cluster on
+# jobs/tasks, the tasks partial indexes over child_cluster, and the extra
+# federated_jobs / federation_sync_state columns #6884 removed.
+_OLD_SCHEMA = """
+CREATE TABLE jobs (
+    job_id VARCHAR PRIMARY KEY,
+    state INTEGER NOT NULL,
+    child_cluster VARCHAR NOT NULL DEFAULT ''
+);
+CREATE TABLE tasks (
+    task_id VARCHAR PRIMARY KEY,
+    job_id VARCHAR NOT NULL,
+    state INTEGER NOT NULL,
+    priority_band INTEGER NOT NULL DEFAULT 2,
+    priority_neg_depth INTEGER NOT NULL DEFAULT 0,
+    priority_root_submitted_ms INTEGER NOT NULL DEFAULT 0,
+    submitted_at_ms INTEGER NOT NULL DEFAULT 0,
+    priority_insertion INTEGER NOT NULL DEFAULT 0,
+    child_cluster VARCHAR NOT NULL DEFAULT ''
+);
+CREATE INDEX idx_tasks_pending_local ON tasks
+    (state, priority_band, priority_neg_depth, priority_root_submitted_ms,
+     submitted_at_ms, priority_insertion) WHERE child_cluster = '';
+CREATE INDEX idx_tasks_state_local ON tasks (state) WHERE child_cluster = '';
+CREATE TABLE federated_jobs (
+    job_id VARCHAR PRIMARY KEY,
+    direction INTEGER NOT NULL,
+    peer_id VARCHAR NOT NULL,
+    owner_principal VARCHAR NOT NULL DEFAULT '',
+    remote_job_id VARCHAR,
+    handoff_state INTEGER,
+    cancel_intent_version INTEGER NOT NULL DEFAULT 0,
+    last_sync_ms INTEGER,
+    terminal_error VARCHAR
+);
+CREATE TABLE federation_sync_state (
+    peer_id VARCHAR PRIMARY KEY,
+    cursor VARCHAR NOT NULL DEFAULT '',
+    last_full_resync_ms INTEGER
+);
+"""
+
+# The current (post-#6884) shape, built the way a fresh baseline DB is: cluster
+# instead of child_cluster, partial indexes over cluster, no stale columns.
+_CURRENT_SCHEMA = """
+CREATE TABLE jobs (
+    job_id VARCHAR PRIMARY KEY,
+    state INTEGER NOT NULL,
+    cluster VARCHAR NOT NULL DEFAULT 'local'
+);
+CREATE TABLE tasks (
+    task_id VARCHAR PRIMARY KEY,
+    job_id VARCHAR NOT NULL,
+    state INTEGER NOT NULL,
+    priority_band INTEGER NOT NULL DEFAULT 2,
+    priority_neg_depth INTEGER NOT NULL DEFAULT 0,
+    priority_root_submitted_ms INTEGER NOT NULL DEFAULT 0,
+    submitted_at_ms INTEGER NOT NULL DEFAULT 0,
+    priority_insertion INTEGER NOT NULL DEFAULT 0,
+    cluster VARCHAR NOT NULL DEFAULT 'local'
+);
+CREATE INDEX idx_tasks_pending_local ON tasks
+    (state, priority_band, priority_neg_depth, priority_root_submitted_ms,
+     submitted_at_ms, priority_insertion) WHERE cluster = 'local';
+CREATE INDEX idx_tasks_state_local ON tasks (state) WHERE cluster = 'local';
+CREATE TABLE federated_jobs (
+    job_id VARCHAR PRIMARY KEY,
+    direction INTEGER NOT NULL,
+    peer_id VARCHAR NOT NULL,
+    owner_principal VARCHAR NOT NULL DEFAULT '',
+    handoff_state INTEGER,
+    cancel_intent_version INTEGER NOT NULL DEFAULT 0
+);
+CREATE TABLE federation_sync_state (
+    peer_id VARCHAR PRIMARY KEY,
+    cursor VARCHAR NOT NULL DEFAULT ''
+);
+"""
+
+
+def _load_migration():
+    spec = importlib.util.spec_from_file_location("m0037", _MIGRATION)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+    return module
+
+
+def _columns(conn: sqlite3.Connection, table: str) -> set[str]:
+    return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _index_sql(conn: sqlite3.Connection, name: str) -> str:
+    return conn.execute("SELECT sql FROM sqlite_master WHERE type='index' AND name=?", (name,)).fetchone()[0]
+
+
+def test_migration_0037_reconciles_child_cluster_and_drops_stale_columns():
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_OLD_SCHEMA)
+    conn.execute("INSERT INTO jobs (job_id, state) VALUES ('/u1/a', 1), ('/u1/b', 1)")
+    conn.execute("INSERT INTO tasks (task_id, job_id, state) VALUES ('/u1/a/0', '/u1/a', 1), ('/u1/b/0', '/u1/b', 1)")
+    conn.commit()
+
+    _load_migration().migrate(conn)
+    conn.commit()
+
+    # child_cluster is gone; cluster is present and every existing (local) row is 'local'.
+    for table in ("jobs", "tasks"):
+        assert "child_cluster" not in _columns(conn, table), table
+        assert "cluster" in _columns(conn, table), table
+        assert {row[0] for row in conn.execute(f"SELECT DISTINCT cluster FROM {table}")} == {"local"}, table
+
+    # Stale federation bookkeeping columns are dropped.
+    assert {"remote_job_id", "last_sync_ms", "terminal_error"}.isdisjoint(_columns(conn, "federated_jobs"))
+    assert "last_full_resync_ms" not in _columns(conn, "federation_sync_state")
+
+    # The partial indexes now filter on cluster='local', not child_cluster.
+    for name in ("idx_tasks_pending_local", "idx_tasks_state_local"):
+        sql = _index_sql(conn, name)
+        assert "cluster = 'local'" in sql, name
+        assert "child_cluster" not in sql, name
+
+    conn.close()
+
+
+def test_migration_0037_is_idempotent_on_repeat():
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_OLD_SCHEMA)
+    conn.commit()
+
+    migration = _load_migration()
+    migration.migrate(conn)
+    conn.commit()
+    migration.migrate(conn)  # second run must not error
+    conn.commit()
+
+    assert "cluster" in _columns(conn, "tasks")
+    assert "child_cluster" not in _columns(conn, "tasks")
+    conn.close()
+
+
+def test_migration_0037_is_noop_on_current_schema():
+    conn = sqlite3.connect(":memory:")
+    conn.executescript(_CURRENT_SCHEMA)
+    conn.commit()
+
+    before = {
+        row[0]: row[1] for row in conn.execute("SELECT name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%'")
+    }
+
+    _load_migration().migrate(conn)
+    conn.commit()
+
+    after = {
+        row[0]: row[1] for row in conn.execute("SELECT name, sql FROM sqlite_master WHERE name NOT LIKE 'sqlite_%'")
+    }
+    assert before == after
+    conn.close()

--- a/lib/iris/tests/cluster/test_inject_env.py
+++ b/lib/iris/tests/cluster/test_inject_env.py
@@ -88,7 +88,7 @@ platform:
 defaults:
   inject_env:
     - MARIN_PREFIX
-    - R2_ACCESS_KEY_ID
+    - CW_KEY_ID
   worker:
     docker_image: gcr.io/project/iris-worker:latest
     port: 10001
@@ -111,4 +111,4 @@ scale_groups:
 """
     )
     config = load_config(config_path)
-    assert list(config.defaults.inject_env) == ["MARIN_PREFIX", "R2_ACCESS_KEY_ID"]
+    assert list(config.defaults.inject_env) == ["MARIN_PREFIX", "CW_KEY_ID"]


### PR DESCRIPTION
The CoreWeave controllers mounted their SQLite state from a PersistentVolumeClaim backed by the default `shared-vast` StorageClass, which is an NFSv3 mount (`local_lock=none`: every SQLite lock round-trips to the NFS server instead of resolving locally). Combined with the pod's 4-CPU limit, that produced the RPC-handler thread pileups on `write_transaction`/`read_snapshot` seen under load, and is the likely cause of a recent liveness-probe SIGKILL (exit 137, no OOM or disk-pressure signal). GCP's equivalent controller path deliberately picks `pd-ssd` for exactly this IOPS reason; the k8s/CoreWeave path had no fast-storage option at all.

CoreWeave nodes have multi-TB local NVMe at `/mnt/local`, already used for the worker task cache but never wired up for the controller's own state. Setting `storage.local_state_dir` now mounts that path from node-local `hostPath` instead of the PVC (no separate flag — the presence of `local_state_dir` selects it).

A `hostPath` follows whatever node the pod lands on, so on a multi-node scale group a rescheduled pod could find a stale local DB from an earlier stint. Startup handles this by trusting the local DB only when it is at least as fresh (by file mtime, including the WAL/SHM siblings of both the main and auth DBs) as the latest remote checkpoint; otherwise it wipes and restores from the checkpoint. Same-node crash-restarts keep SQLite's own WAL recovery with zero restore latency, and the check is topology-agnostic, so `cw-us-east-02a` (4-node `cpu-genoa`) gets node-local disk too, not just single-node `cw-rno2a`.

Two bugs that only surfaced once a controller actually restarted onto this path:

- **Credentials.** The task-env Secret and client fsspec config read `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`, but these clusters authenticate to CoreWeave AI Object Storage with `CW_KEY_ID`/`CW_KEY_SECRET`. The wrong keys baked stale credentials into the Secret and the controller got 403 on every `s3://` read. Switched to the CoreWeave keys across the code, configs, example, docs, and `fs-browser`.
- **Schema.** `0034_federation`/`0035_federation_unify` were revised in place (#6884) after an earlier form (#6821) had already been applied to a live controller DB. A recorded migration never re-runs, so that DB kept the old shape (`child_cluster` instead of `cluster`, plus dropped `federated_jobs`/`federation_sync_state` bookkeeping columns) and the control loop crashed on `no such column: tasks.cluster`. Federation was never enabled, so `0037_federation_fixup` renames `child_cluster` → `cluster` (defaulting existing rows to `local`), drops the stale columns, and rebuilds the local partial indexes on `cluster`. It is idempotent and a no-op on a fresh DB; against the live DB the schema becomes byte-identical to a fresh baseline with all 1316 jobs / 5288 tasks preserved.

Also tightens the CoreWeave checkpoint interval to 10 minutes (local disk lacks the PVC's own redundancy), raises the controller memory request to 64Gi, and gives the liveness probe a 10s timeout instead of Kubernetes' 1s default so a transient hiccup under load doesn't trigger a hard restart.
