### PR TITLE
[iris] Restore CUDA 13 cuDNN precedence for GPU jobs

### DIFF
--- a/lib/iris/src/iris/cluster/setup_scripts.py
+++ b/lib/iris/src/iris/cluster/setup_scripts.py
@@ -177,6 +177,7 @@ fi
 if [ -n "$_cudnn_cu13_version" ]; then
   echo 'restoring CUDA 13 cuDNN library precedence'
   uv pip install --python "$IRIS_VENV/bin/python" \
+    --offline \
     --link-mode symlink \
     --reinstall-package "$_cudnn_cu13_package" \
     "$_cudnn_cu13_package==$_cudnn_cu13_version"

--- a/lib/iris/src/iris/cluster/setup_scripts.py
+++ b/lib/iris/src/iris/cluster/setup_scripts.py
@@ -134,6 +134,7 @@ def wants_gpu_extra(extras: Sequence[str]) -> bool:
 _LIBDEVICE_FILE = "libdevice.10.bc"
 # XLA's built-in default --xla_gpu_cuda_data_dir, resolved relative to the workdir.
 _XLA_CUDA_DATA_DIR = "cuda_sdk_lib"
+CUDNN_CU13_PACKAGE = "nvidia-cudnn-cu13"
 
 
 def cuda_toolchain_setup_script() -> str:
@@ -157,6 +158,28 @@ if [ -f "$_libdevice" ]; then
   mkdir -p "$IRIS_WORKDIR/{_XLA_CUDA_DATA_DIR}/nvvm/libdevice"
   cp -f "$_libdevice" "$IRIS_WORKDIR/{_XLA_CUDA_DATA_DIR}/nvvm/libdevice/{_LIBDEVICE_FILE}"
   cp -f "$_libdevice" "$IRIS_WORKDIR/{_LIBDEVICE_FILE}"
+fi
+_cudnn_cu13_package="{CUDNN_CU13_PACKAGE}"
+_cudnn_cu13_version=""
+if [ -x "$IRIS_VENV/bin/python" ]; then
+  _cudnn_cu13_version="$(
+    "$IRIS_VENV/bin/python" - "$_cudnn_cu13_package" <<'PY'
+import importlib.metadata as md
+import sys
+
+try:
+    print(md.version(sys.argv[1]))
+except md.PackageNotFoundError:
+    pass
+PY
+  )"
+fi
+if [ -n "$_cudnn_cu13_version" ]; then
+  echo 'restoring CUDA 13 cuDNN library precedence'
+  uv pip install --python "$IRIS_VENV/bin/python" \
+    --link-mode symlink \
+    --reinstall-package "$_cudnn_cu13_package" \
+    "$_cudnn_cu13_package==$_cudnn_cu13_version"
 fi
 """
 

--- a/lib/iris/src/iris/cluster/setup_scripts.py
+++ b/lib/iris/src/iris/cluster/setup_scripts.py
@@ -140,10 +140,12 @@ CUDNN_CU13_PACKAGE = "nvidia-cudnn-cu13"
 def cuda_toolchain_setup_script() -> str:
     """Return a setup script that exposes the venv's CUDA toolchain to JAX/Pallas.
 
-    Appended to a GPU job's setup so Mosaic GPU kernels compile: it puts the
-    ``jax[cuda13]`` toolchain (``ptxas``/``nvlink``) on ``PATH`` by symlinking it
-    into the venv's ``bin``, and stages ``libdevice.10.bc`` where XLA looks, with no
-    run-phase changes. A no-op when the venv carries no CUDA toolchain.
+    Appended to a GPU job's setup so Mosaic GPU kernels compile and JAX sees the
+    CUDA 13 cuDNN wheel after mixed CUDA package installs. It puts the
+    ``jax[cuda13]`` toolchain (``ptxas``/``nvlink``) on ``PATH``, stages
+    ``libdevice.10.bc`` where XLA looks, and restores CUDA 13 cuDNN library
+    precedence when that package is installed. A no-op when the venv carries no
+    CUDA toolchain.
     """
     return rf"""set -e
 cuda_bin=""

--- a/lib/iris/tests/cluster/runtime/test_cuda_staging.py
+++ b/lib/iris/tests/cluster/runtime/test_cuda_staging.py
@@ -8,19 +8,21 @@ and inspect the resulting symlinks and staged files rather than asserting on its
 source text. The GPU extra wires it into the resolved setup scripts.
 """
 
+import os
 import subprocess
+import sys
+import zipfile
 from pathlib import Path
 
 import pytest
-from iris.cluster.setup_scripts import cuda_toolchain_setup_script, wants_gpu_extra
+from iris.cluster.setup_scripts import CUDNN_CU13_PACKAGE, cuda_toolchain_setup_script, wants_gpu_extra
 from iris.cluster.types import EnvironmentSpec
 
+_CUDNN_CU13_TEST_VERSION = "9.19.0.56"
 
-def _make_venv(tmp_path: Path, *, cuda_major: str, with_ptxas: bool, with_libdevice: bool) -> Path:
-    """Create a fake venv tree mirroring what jax[cuda*] installs."""
-    venv = tmp_path / "venv"
-    (venv / "bin").mkdir(parents=True)
-    cuda = venv / "lib" / "python3.12" / "site-packages" / "nvidia" / cuda_major
+
+def _add_cuda_toolchain(site_packages: Path, *, cuda_major: str, with_ptxas: bool, with_libdevice: bool) -> None:
+    cuda = site_packages / "nvidia" / cuda_major
     (cuda / "bin").mkdir(parents=True)
     if with_ptxas:
         for tool in ("ptxas", "nvlink"):
@@ -31,11 +33,63 @@ def _make_venv(tmp_path: Path, *, cuda_major: str, with_ptxas: bool, with_libdev
         libdevice = cuda / "nvvm" / "libdevice"
         libdevice.mkdir(parents=True)
         (libdevice / "libdevice.10.bc").write_bytes(b"BC\xc0\xde")
+
+
+def _make_venv(tmp_path: Path, *, cuda_major: str, with_ptxas: bool, with_libdevice: bool) -> Path:
+    """Create a fake venv tree mirroring what jax[cuda*] installs."""
+    venv = tmp_path / "venv"
+    (venv / "bin").mkdir(parents=True)
+    site_packages = venv / "lib" / "python3.12" / "site-packages"
+    _add_cuda_toolchain(
+        site_packages,
+        cuda_major=cuda_major,
+        with_ptxas=with_ptxas,
+        with_libdevice=with_libdevice,
+    )
     return venv
 
 
-def _run_script(script: str, venv: Path, workdir: Path) -> None:
-    env = {"IRIS_VENV": str(venv), "IRIS_WORKDIR": str(workdir), "PATH": "/usr/bin:/bin"}
+def _site_packages(venv: Path) -> Path:
+    return next((venv / "lib").glob("python*/site-packages"))
+
+
+def _write_cudnn_cu13_wheel(wheelhouse: Path) -> None:
+    normalized_package = CUDNN_CU13_PACKAGE.replace("-", "_")
+    dist_info = f"{normalized_package}-{_CUDNN_CU13_TEST_VERSION}.dist-info"
+    wheel = wheelhouse / f"{normalized_package}-{_CUDNN_CU13_TEST_VERSION}-py3-none-any.whl"
+    wheelhouse.mkdir()
+    with zipfile.ZipFile(wheel, "w") as zf:
+        zf.writestr(
+            f"{dist_info}/METADATA",
+            "\n".join(
+                [
+                    "Metadata-Version: 2.1",
+                    f"Name: {CUDNN_CU13_PACKAGE}",
+                    f"Version: {_CUDNN_CU13_TEST_VERSION}",
+                    "",
+                ]
+            ),
+        )
+        zf.writestr(
+            f"{dist_info}/WHEEL",
+            "\n".join(
+                [
+                    "Wheel-Version: 1.0",
+                    "Generator: iris-test",
+                    "Root-Is-Purelib: true",
+                    "Tag: py3-none-any",
+                    "",
+                ]
+            ),
+        )
+        zf.writestr("nvidia/cudnn/lib/libcudnn.so.9", "cu13\n")
+        zf.writestr(f"{dist_info}/RECORD", "")
+
+
+def _run_script(script: str, venv: Path, workdir: Path, *, path: str = "/usr/bin:/bin", extra_env=None) -> None:
+    env = {"IRIS_VENV": str(venv), "IRIS_WORKDIR": str(workdir), "PATH": path}
+    if extra_env:
+        env.update(extra_env)
     subprocess.run(["bash", "-c", script], env=env, capture_output=True, text=True, check=True)
 
 
@@ -97,6 +151,50 @@ def test_stages_when_libdevice_missing(tmp_path):
 
     assert (venv / "bin" / "ptxas").is_symlink()
     assert not (workdir / "libdevice.10.bc").exists()
+
+
+def test_restores_cuda13_cudnn_package_when_present(tmp_path):
+    venv = tmp_path / "venv"
+    subprocess.run(["uv", "venv", "--python", sys.executable, str(venv)], capture_output=True, text=True, check=True)
+    site_packages = _site_packages(venv)
+    _add_cuda_toolchain(site_packages, cuda_major="cu13", with_ptxas=True, with_libdevice=True)
+
+    wheelhouse = tmp_path / "wheelhouse"
+    _write_cudnn_cu13_wheel(wheelhouse)
+    subprocess.run(
+        [
+            "uv",
+            "pip",
+            "install",
+            "--python",
+            str(venv / "bin" / "python"),
+            "--no-index",
+            "--find-links",
+            str(wheelhouse),
+            f"{CUDNN_CU13_PACKAGE}=={_CUDNN_CU13_TEST_VERSION}",
+        ],
+        capture_output=True,
+        text=True,
+        check=True,
+    )
+
+    workdir = tmp_path / "work"
+    workdir.mkdir()
+    cudnn_library = site_packages / "nvidia" / "cudnn" / "lib" / "libcudnn.so.9"
+    cudnn_library.write_text("cu12\n")
+
+    _run_script(
+        cuda_toolchain_setup_script(),
+        venv,
+        workdir,
+        path=os.environ["PATH"],
+        extra_env={
+            "UV_FIND_LINKS": str(wheelhouse),
+            "UV_OFFLINE": "1",
+        },
+    )
+
+    assert cudnn_library.read_text() == "cu13\n"
 
 
 def test_wants_gpu_extra():


### PR DESCRIPTION
Restore GPU task setup so CUDA 13 JAX jobs keep the CUDA 13 cuDNN wheel in control of the shared `nvidia/cudnn` library path after CUDA toolchain staging. CoreWeave H100 probes for #6597 showed `jaxlib==0.10.1` loading cuDNN runtime 9.10.2 from CUDA 12 torch dependencies even though the JAX CUDA 13 stack had installed `nvidia-cudnn-cu13==9.19.0.56`.

The setup script now detects the installed CUDA 13 cuDNN package version and reinstalls that same wheel offline after staging `ptxas`, `nvlink`, and `libdevice`, using the cache populated by the preceding sync rather than refreshing from the index. The regression test uses a real local wheel in a real venv, poisons the shared `libcudnn.so.9` file to mimic CUDA 12 precedence, and verifies setup restores the CUDA 13 file.

Part of #6597