### PR TITLE
[iris] Fix k8s task logs invisible in the per-task view

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/logship.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/logship.py
@@ -36,8 +36,7 @@ from finelog.rpc import logging_pb2
 from rigging.timing import Timestamp
 
 from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
-from iris.cluster.log_keys import classify_log_level, task_log_key
-from iris.cluster.types import TaskAttempt
+from iris.cluster.log_keys import classify_log_level
 from iris.rpc import controller_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
 
@@ -140,17 +139,20 @@ def _make_log_entry(line: CriLogLine, attempt_id: int) -> logging_pb2.LogEntry:
 def log_key_and_attempt(task_id: str) -> tuple[str, int]:
     """Resolve ``IRIS_TASK_ID`` to the finelog log key and the attempt id.
 
-    ``IRIS_TASK_ID`` is the bare task wire id for attempt 0 (``/user/job/0``) and
-    carries a ``:N`` suffix for retries (``/user/job/0:3``). The finelog key must
-    always include the attempt suffix — ``/user/job/0:0`` for the first attempt —
-    so it matches the per-task log query, which is EXACT ``…:<attempt>`` for one
-    attempt or PREFIX ``…:`` for all attempts. A bare attempt-0 key only matches
-    the job-level ``/user/job/`` prefix scan, so its logs appear under the job
-    but never under the task.
+    The finelog key must carry the attempt suffix — ``/user/job/0:0`` for the
+    first attempt — so it matches the per-task log query, which is EXACT
+    ``…:<attempt>`` for one attempt or PREFIX ``…:`` for all attempts. A bare key
+    without the suffix only matches the job-level ``/user/job/`` prefix scan, so
+    its logs would show under the job but never under the task.
+
+    Only a trailing ``:<digits>`` is the attempt; a colon elsewhere is part of the
+    job name (a legal name char) and stays in the key. A wire id that arrives
+    without an attempt suffix is normalized to attempt 0.
     """
-    parsed = TaskAttempt.from_wire(task_id)
-    task_attempt = parsed.with_attempt(parsed.attempt_id or 0)
-    return task_log_key(task_attempt), task_attempt.require_attempt()
+    _base, sep, suffix = task_id.rpartition(":")
+    if sep and suffix.isdigit():
+        return task_id, int(suffix)
+    return f"{task_id}:0", 0
 
 
 def _log_dir_glob(namespace: str, pod_name: str) -> str:

--- a/lib/iris/src/iris/cluster/backends/k8s/logship.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/logship.py
@@ -12,7 +12,8 @@ apiserver.
 Run as ``python -m iris.cluster.backends.k8s.logship``. Configuration comes from
 the environment the pod manifest sets:
 
-- ``IRIS_TASK_ID`` — the wire ``task:attempt`` id; it is the finelog key.
+- ``IRIS_TASK_ID`` — the wire ``task:attempt`` id; the finelog key is derived
+  from it with the attempt suffix always present (``/user/job/0:0``).
 - ``IRIS_CONTROLLER_ADDRESS`` — resolves the log server endpoint.
 - ``IRIS_POD_NAMESPACE`` / ``IRIS_POD_NAME`` — locate the CRI log directory.
 
@@ -35,7 +36,8 @@ from finelog.rpc import logging_pb2
 from rigging.timing import Timestamp
 
 from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
-from iris.cluster.log_keys import classify_log_level
+from iris.cluster.log_keys import classify_log_level, task_log_key
+from iris.cluster.types import TaskAttempt
 from iris.rpc import controller_pb2
 from iris.rpc.controller_connect import ControllerServiceClientSync
 
@@ -135,17 +137,21 @@ def _make_log_entry(line: CriLogLine, attempt_id: int) -> logging_pb2.LogEntry:
     return entry
 
 
-def split_key_attempt(task_id: str) -> tuple[str, int]:
-    """Split ``IRIS_TASK_ID`` into the finelog key and attempt id.
+def log_key_and_attempt(task_id: str) -> tuple[str, int]:
+    """Resolve ``IRIS_TASK_ID`` to the finelog log key and the attempt id.
 
-    The wire id is ``task:attempt`` for retries and bare ``task`` for the first
-    attempt (attempt 0). The key written to finelog is the full wire id; the
-    attempt is parsed off the ``:`` suffix for the LogEntry's ``attempt_id``.
+    ``IRIS_TASK_ID`` is the bare task wire id for attempt 0 (``/user/job/0``) and
+    carries a ``:N`` suffix for retries (``/user/job/0:3``). The finelog key must
+    always include the attempt suffix — ``/user/job/0:0`` for the first attempt —
+    so it matches the per-task log query, which is EXACT ``…:<attempt>`` for one
+    attempt or PREFIX ``…:`` for all attempts. A bare attempt-0 key only matches
+    the job-level ``/user/job/`` prefix scan, so its logs appear under the job
+    but never under the task. Building the key via ``task_log_key`` keeps it
+    byte-for-byte identical to the worker backend's own task-log writes.
     """
-    _base, sep, attempt = task_id.rpartition(":")
-    if sep and attempt.isdigit():
-        return task_id, int(attempt)
-    return task_id, 0
+    parsed = TaskAttempt.from_wire(task_id)
+    task_attempt = parsed.with_attempt(parsed.attempt_id or 0)
+    return task_log_key(task_attempt), task_attempt.require_attempt()
 
 
 def _log_dir_glob(namespace: str, pod_name: str) -> str:
@@ -344,7 +350,7 @@ def _ship(stop: threading.Event) -> None:
     namespace = os.environ["IRIS_POD_NAMESPACE"]
     pod_name = os.environ["IRIS_POD_NAME"]
 
-    key, attempt_id = split_key_attempt(task_id)
+    key, attempt_id = log_key_and_attempt(task_id)
     client = _connect_log_client(controller_address)
     shipper = LogShipper(client, _log_dir_glob(namespace, pod_name), key, attempt_id, stop)
 

--- a/lib/iris/src/iris/cluster/backends/k8s/logship.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/logship.py
@@ -146,8 +146,7 @@ def log_key_and_attempt(task_id: str) -> tuple[str, int]:
     so it matches the per-task log query, which is EXACT ``…:<attempt>`` for one
     attempt or PREFIX ``…:`` for all attempts. A bare attempt-0 key only matches
     the job-level ``/user/job/`` prefix scan, so its logs appear under the job
-    but never under the task. Building the key via ``task_log_key`` keeps it
-    byte-for-byte identical to the worker backend's own task-log writes.
+    but never under the task.
     """
     parsed = TaskAttempt.from_wire(task_id)
     task_attempt = parsed.with_attempt(parsed.attempt_id or 0)

--- a/lib/iris/src/iris/cluster/runtime/env.py
+++ b/lib/iris/src/iris/cluster/runtime/env.py
@@ -140,9 +140,11 @@ def build_common_iris_env(
     """
     env: dict[str, str] = {}
 
-    # Task identity. Append :attempt_id for retries so tasks see the correct
-    # attempt via JobInfo (matches TaskAttemptIdentity.to_wire()).
-    wire_task_id = f"{task_id}:{attempt_id}" if attempt_id else task_id
+    # Task identity in canonical TaskAttempt wire form, always carrying the
+    # attempt suffix (/user/job/0:0 for the first attempt) so the id — and the
+    # finelog log key derived from it — is identical across attempts and every
+    # backend.
+    wire_task_id = f"{task_id}:{attempt_id}"
     env["IRIS_TASK_ID"] = wire_task_id
     env["IRIS_NUM_TASKS"] = str(num_tasks)
     env["IRIS_BUNDLE_ID"] = bundle_id

--- a/lib/iris/tests/cluster/backends/k8s/test_logship.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_logship.py
@@ -114,6 +114,19 @@ def test_log_key_and_attempt_first_attempt_gets_zero_suffix():
     assert attempt == 0
 
 
+def test_log_key_and_attempt_tolerates_colon_in_job_name():
+    """A colon is a legal job-name char (used by federated job names); only a
+    trailing ``:<digits>`` is the attempt, so an interior colon stays in the key
+    and the id still gains the ``:0`` suffix when no attempt is present."""
+    key, attempt = log_key_and_attempt("/u/train:debug/0")
+    assert key == "/u/train:debug/0:0"
+    assert attempt == 0
+
+    key, attempt = log_key_and_attempt("/u/train:debug/0:2")
+    assert key == "/u/train:debug/0:2"
+    assert attempt == 2
+
+
 def test_log_dir_glob_targets_task_container():
     assert _log_dir_glob("iris", "iris-job-0-abc-0") == "/var/log/pods/iris_iris-job-0-abc-0_*/task"
 

--- a/lib/iris/tests/cluster/backends/k8s/test_logship.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_logship.py
@@ -13,8 +13,8 @@ from iris.cluster.backends.k8s.logship import (
     _LineBuffer,
     _log_dir_glob,
     _make_log_entry,
+    log_key_and_attempt,
     parse_cri_line,
-    split_key_attempt,
 )
 
 
@@ -100,15 +100,17 @@ def test_partial_lines_join_onto_following_full_line():
 # ---------------------------------------------------------------------------
 
 
-def test_split_key_attempt_with_retry_suffix():
-    key, attempt = split_key_attempt("/u/job/0:2")
+def test_log_key_and_attempt_with_retry_suffix():
+    key, attempt = log_key_and_attempt("/u/job/0:2")
     assert key == "/u/job/0:2"
     assert attempt == 2
 
 
-def test_split_key_attempt_first_attempt_has_no_suffix():
-    key, attempt = split_key_attempt("/u/job/0")
-    assert key == "/u/job/0"
+def test_log_key_and_attempt_first_attempt_gets_zero_suffix():
+    """Attempt 0 arrives as the bare wire id but must be keyed with the ``:0``
+    suffix so it matches the per-task log query, not just the job-level scan."""
+    key, attempt = log_key_and_attempt("/u/job/0")
+    assert key == "/u/job/0:0"
     assert attempt == 0
 
 

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -664,7 +664,7 @@ def test_iris_env_vars_injected():
     manifest = _build_pod_manifest(req, pod_config(controller_address="http://ctrl:8080"))
 
     env_by_name = {e["name"]: e for e in manifest["spec"]["containers"][0]["env"]}
-    assert env_by_name["IRIS_TASK_ID"]["value"] == "/test-job/0"
+    assert env_by_name["IRIS_TASK_ID"]["value"] == "/test-job/0:0"
     assert env_by_name["IRIS_NUM_TASKS"]["value"] == "4"
     assert env_by_name["IRIS_BUNDLE_ID"]["value"] == "bundle-abc"
     assert env_by_name["IRIS_CONTROLLER_ADDRESS"]["value"] == "http://ctrl:8080"
@@ -706,7 +706,7 @@ def test_iris_env_overrides_user_env():
     manifest = _build_pod_manifest(req, pod_config())
 
     env_by_name = {e["name"]: e.get("value") for e in manifest["spec"]["containers"][0]["env"]}
-    assert env_by_name["IRIS_TASK_ID"] == "/test-job/0"
+    assert env_by_name["IRIS_TASK_ID"] == "/test-job/0:0"
 
 
 def test_task_script_runs_each_setup_command_before_exec():
@@ -754,11 +754,11 @@ def test_build_common_iris_env_includes_attempt_suffix_on_retry():
     assert env["IRIS_TASK_ID"] == "/test-job/0:3"
 
 
-def test_build_common_iris_env_no_attempt_suffix_for_first_attempt():
-    """IRIS_TASK_ID has no suffix when attempt_id is 0."""
+def test_build_common_iris_env_includes_attempt_suffix_for_first_attempt():
+    """IRIS_TASK_ID carries the :0 suffix on the first attempt, matching retries."""
     req = make_run_req("/test-job/0", attempt_id=0)
     env = common_env_from_req(req, controller_address=None)
-    assert env["IRIS_TASK_ID"] == "/test-job/0"
+    assert env["IRIS_TASK_ID"] == "/test-job/0:0"
 
 
 # ---------------------------------------------------------------------------

--- a/lib/iris/tests/cluster/runtime/test_env_parity.py
+++ b/lib/iris/tests/cluster/runtime/test_env_parity.py
@@ -150,9 +150,9 @@ def test_k8s_env_values_match_common_env(parity_req_and_ctrl):
 # ---------------------------------------------------------------------------
 
 
-def test_attempt_id_zero_no_suffix():
+def test_attempt_id_zero_includes_suffix():
     env = _common_env(_make_req(attempt_id=0))
-    assert env["IRIS_TASK_ID"] == "/my-job/task-0"
+    assert env["IRIS_TASK_ID"] == "/my-job/task-0:0"
 
 
 def test_attempt_id_nonzero_gets_suffix():

--- a/lib/iris/tests/e2e/test_local_client.py
+++ b/lib/iris/tests/e2e/test_local_client.py
@@ -54,9 +54,9 @@ def test_command_entrypoint_preserves_env_vars(client):
 
     assert status.state == job_pb2.JOB_STATE_SUCCEEDED
 
-    # For attempt 0, build_common_iris_env omits the :attempt_id suffix
-    # (only appended for retries), so expect just the task_id wire format.
-    expected = job_id.task(0).to_wire()
+    # IRIS_TASK_ID is the canonical TaskAttempt wire form, so the first attempt
+    # carries the :0 suffix.
+    expected = f"{job_id.task(0).to_wire()}:0"
     response = client.fetch_logs(
         f"{job_id.task(0).to_wire()}:",
         match_scope=logging_pb2.MATCH_SCOPE_PREFIX,


### PR DESCRIPTION
On a k8s cluster, a job's log page shows the merged logs of all its
sub-tasks, but clicking into an individual task shows nothing — even though
the task links are live.

The log-shipping sidecar keyed a first-attempt task's logs under the bare
task wire id (`/user/job/0`), dropping the `:0` attempt suffix, because
`build_common_iris_env` omitted the suffix from `IRIS_TASK_ID` for attempt 0.
The per-task view queries `EXACT /user/job/0:0` or `PREFIX /user/job/0:`,
neither of which matches the bare key, so a task's logs never surfaced when
you clicked into it. The job view queries `PREFIX /user/job/`, which *does*
match the bare key — hence logs appeared under the job but not the individual
tasks. Retries (attempt >= 1) already carried the suffix and worked.

Two changes:

- `build_common_iris_env` now always writes `IRIS_TASK_ID` in canonical
  `TaskAttempt` wire form (`/user/job/0:0` on the first attempt) rather than
  omitting the `:0` for attempt 0. Every consumer already parses it through
  `TaskAttempt.from_wire` or reads it only for logging, so this is a pure
  consistency fix that makes the log key correct at the source.

- logship derives the finelog key by stripping only a trailing `:<digits>` as
  the attempt. A colon is a legal job-name character (federated job names such
  as `train:debug` use one), so routing through `TaskAttempt.from_wire` — which
  treats the last colon as the attempt separator and raises on a non-digit —
  would idle the sidecar and ship no logs for such names. The trailing-digits
  parse tolerates interior colons, never raises, and still emits the
  `:0`-suffixed key the per-task query matches.