### PR TITLE
[iris] Disable XLA autotune sub-cache derivation for remote compilation cache dirs

### DIFF
--- a/lib/iris/src/iris/runtime/jax_init.py
+++ b/lib/iris/src/iris/runtime/jax_init.py
@@ -75,8 +75,16 @@ def configure_jax_compilation_cache() -> None:
     Without a cache dir, every process re-runs XLA compilation and kernel
     autotune sweeps at startup. An explicit setting (``JAX_COMPILATION_CACHE_DIR``
     or ``jax.config``) wins; otherwise the cache lands under the cluster's
-    region-local storage prefix, which may be a ``gs://``/``s3://`` URL that JAX
-    writes directly.
+    region-local storage prefix, which may be a ``gs://``/``s3://`` URL.
+
+    JAX's own compilation cache handles a remote URL fine (it reads/writes via
+    fsspec), but it also derives XLA's C++ per-fusion autotune cache path from
+    the same directory and hands it to XLA's `tsl::Env`, which has no
+    ``gs://``/``s3://`` support and crashes the first compile with
+    "UNIMPLEMENTED: File system scheme ... not implemented". Disable that
+    derivation when the cache dir is remote; the autotune cache is ephemeral
+    (skipped entirely on a compilation-cache hit), so losing it costs at most
+    a few minutes on a cold compile.
     """
     import jax  # noqa: PLC0415  # optional dep: jax (iris does not depend on jax)
 
@@ -87,6 +95,10 @@ def configure_jax_compilation_cache() -> None:
     os.environ["JAX_COMPILATION_CACHE_DIR"] = cache_dir
     jax.config.update("jax_compilation_cache_dir", cache_dir)
     logger.info("JAX compilation cache: %s", cache_dir)
+
+    if "://" in cache_dir and "JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES" not in os.environ:
+        jax.config.update("jax_persistent_cache_enable_xla_caches", "none")
+        logger.info("XLA autotune sub-cache disabled (compilation cache is remote: %s)", cache_dir)
 
 
 # An endpoint name that has not been registered yet surfaces differently across

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -375,32 +375,8 @@ def test_configure_compilation_cache_keeps_explicit_dir(source: str) -> None:
 
 
 @pytest.mark.parametrize("scheme", ["gs://", "s3://"])
-def test_configure_compilation_cache_disables_xla_autotune_for_remote_dir(scheme: str) -> None:
-    """A remote cache dir disables XLA's autotune sub-cache derivation.
-
-    XLA's C++ per-fusion autotune cache has no gs://s3:// support (it writes
-    through tsl::Env, a plain filesystem abstraction) and crashes the first
-    compile if JAX derives its path from a remote compilation_cache_dir.
-    """
-    with _isolated_jax_cache_config():
-        with patch("iris.runtime.jax_init.marin_prefix", return_value=f"{scheme}marin-eu/marin/"):
-            configure_jax_compilation_cache()
-
-        assert jax.config.jax_persistent_cache_enable_xla_caches == "none"
-
-
-def test_configure_compilation_cache_keeps_xla_autotune_for_local_dir() -> None:
-    """A local cache dir leaves XLA's autotune sub-cache derivation untouched."""
-    with _isolated_jax_cache_config():
-        original = jax.config.jax_persistent_cache_enable_xla_caches
-        with patch("iris.runtime.jax_init.marin_prefix", return_value="/mnt/local/marin/"):
-            configure_jax_compilation_cache()
-
-        assert jax.config.jax_persistent_cache_enable_xla_caches == original
-
-
-def test_configure_compilation_cache_clears_xla_autotune_compile_option() -> None:
-    """The remote-dir guard actually clears the compile option XLA would crash on.
+def test_configure_compilation_cache_clears_xla_autotune_compile_option(scheme: str) -> None:
+    """A remote cache dir clears the XLA compile option that would otherwise crash.
 
     Without the guard, JAX hands XLA's C++ debug_options a raw
     ``xla_gpu_per_fusion_autotune_cache_dir`` built from the remote URL, which
@@ -411,11 +387,23 @@ def test_configure_compilation_cache_clears_xla_autotune_compile_option() -> Non
     from jax._src import compiler as jax_compiler  # noqa: PLC0415
 
     with _isolated_jax_cache_config():
-        with patch("iris.runtime.jax_init.marin_prefix", return_value="s3://marin-eu/marin/"):
+        with patch("iris.runtime.jax_init.marin_prefix", return_value=f"{scheme}marin-eu/marin/"):
             configure_jax_compilation_cache()
 
         options = jax_compiler.get_compile_options(num_replicas=1, num_partitions=1)
         assert options.executable_build_options.debug_options.xla_gpu_per_fusion_autotune_cache_dir == ""
+
+
+def test_configure_compilation_cache_keeps_xla_autotune_for_local_dir() -> None:
+    """A local cache dir leaves XLA's autotune sub-cache derivation untouched."""
+    from jax._src import compiler as jax_compiler  # noqa: PLC0415
+
+    with _isolated_jax_cache_config():
+        with patch("iris.runtime.jax_init.marin_prefix", return_value="/mnt/local/marin/"):
+            configure_jax_compilation_cache()
+
+        options = jax_compiler.get_compile_options(num_replicas=1, num_partitions=1)
+        assert options.executable_build_options.debug_options.xla_gpu_per_fusion_autotune_cache_dir != ""
 
 
 def test_configure_compilation_cache_keeps_explicit_xla_autotune_setting() -> None:

--- a/lib/iris/tests/test_jax_init.py
+++ b/lib/iris/tests/test_jax_init.py
@@ -330,15 +330,18 @@ def test_poll_for_coordinator_propagates_real_connect_errors() -> None:
 
 @contextmanager
 def _isolated_jax_cache_config():
-    """Restore ``jax.config`` and a clean ``JAX_COMPILATION_CACHE_DIR`` around a test."""
-    original = jax.config.jax_compilation_cache_dir
+    """Restore ``jax.config`` and cache-related env vars around a test."""
+    original_cache_dir = jax.config.jax_compilation_cache_dir
+    original_enable_xla_caches = jax.config.jax_persistent_cache_enable_xla_caches
     jax.config.update("jax_compilation_cache_dir", None)
     try:
         with patch.dict(os.environ, {}, clear=False):
             os.environ.pop("JAX_COMPILATION_CACHE_DIR", None)
+            os.environ.pop("JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES", None)
             yield
     finally:
-        jax.config.update("jax_compilation_cache_dir", original)
+        jax.config.update("jax_compilation_cache_dir", original_cache_dir)
+        jax.config.update("jax_persistent_cache_enable_xla_caches", original_enable_xla_caches)
 
 
 def test_configure_compilation_cache_derives_from_marin_prefix() -> None:
@@ -369,6 +372,65 @@ def test_configure_compilation_cache_keeps_explicit_dir(source: str) -> None:
         else:
             assert jax.config.jax_compilation_cache_dir == "gs://explicit/cache"
             assert "JAX_COMPILATION_CACHE_DIR" not in os.environ
+
+
+@pytest.mark.parametrize("scheme", ["gs://", "s3://"])
+def test_configure_compilation_cache_disables_xla_autotune_for_remote_dir(scheme: str) -> None:
+    """A remote cache dir disables XLA's autotune sub-cache derivation.
+
+    XLA's C++ per-fusion autotune cache has no gs://s3:// support (it writes
+    through tsl::Env, a plain filesystem abstraction) and crashes the first
+    compile if JAX derives its path from a remote compilation_cache_dir.
+    """
+    with _isolated_jax_cache_config():
+        with patch("iris.runtime.jax_init.marin_prefix", return_value=f"{scheme}marin-eu/marin/"):
+            configure_jax_compilation_cache()
+
+        assert jax.config.jax_persistent_cache_enable_xla_caches == "none"
+
+
+def test_configure_compilation_cache_keeps_xla_autotune_for_local_dir() -> None:
+    """A local cache dir leaves XLA's autotune sub-cache derivation untouched."""
+    with _isolated_jax_cache_config():
+        original = jax.config.jax_persistent_cache_enable_xla_caches
+        with patch("iris.runtime.jax_init.marin_prefix", return_value="/mnt/local/marin/"):
+            configure_jax_compilation_cache()
+
+        assert jax.config.jax_persistent_cache_enable_xla_caches == original
+
+
+def test_configure_compilation_cache_clears_xla_autotune_compile_option() -> None:
+    """The remote-dir guard actually clears the compile option XLA would crash on.
+
+    Without the guard, JAX hands XLA's C++ debug_options a raw
+    ``xla_gpu_per_fusion_autotune_cache_dir`` built from the remote URL, which
+    XLA's `tsl::Env` cannot open (UNIMPLEMENTED: file system scheme not
+    implemented). This drives JAX's own compile-options builder to confirm the
+    field is empty after ``configure_jax_compilation_cache`` runs.
+    """
+    from jax._src import compiler as jax_compiler  # noqa: PLC0415
+
+    with _isolated_jax_cache_config():
+        with patch("iris.runtime.jax_init.marin_prefix", return_value="s3://marin-eu/marin/"):
+            configure_jax_compilation_cache()
+
+        options = jax_compiler.get_compile_options(num_replicas=1, num_partitions=1)
+        assert options.executable_build_options.debug_options.xla_gpu_per_fusion_autotune_cache_dir == ""
+
+
+def test_configure_compilation_cache_keeps_explicit_xla_autotune_setting() -> None:
+    """An explicit JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES env var is not overridden."""
+    with _isolated_jax_cache_config():
+        original = jax.config.jax_persistent_cache_enable_xla_caches
+        os.environ["JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES"] = "all"
+        with patch("iris.runtime.jax_init.marin_prefix", return_value="s3://marin-eu/marin/"):
+            configure_jax_compilation_cache()
+
+        # We never call jax.config.update for this setting when the env var is
+        # already present, so jax.config keeps whatever it already had; the env
+        # var itself (which JAX reads directly) is left as the caller set it.
+        assert jax.config.jax_persistent_cache_enable_xla_caches == original
+        assert os.environ["JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES"] == "all"
 
 
 def test_poll_for_coordinator_default_interval() -> None:


### PR DESCRIPTION
configure_jax_compilation_cache defaults JAX_COMPILATION_CACHE_DIR to a subdir of the cluster's storage prefix, which on CoreWeave clusters is an s3:// URL. JAX's own compilation cache handles that fine via fsspec, but it also derives XLA's C++ per-fusion autotune cache path from the same directory and hands it directly to XLA's tsl::Env, which has no gs://s3:// support. The first compile then crashes with `UNIMPLEMENTED: File system scheme ... not implemented` — after a multi-host NCCL collective has already succeeded, so the crash lands mid-job.

Disable that XLA-side derivation when the compilation cache dir is remote, unless the caller already set JAX_PERSISTENT_CACHE_ENABLE_XLA_CACHES explicitly. The autotune cache is ephemeral (skipped entirely on a compilation-cache hit), so this costs at most a few minutes on a cold compile; the persistent compilation cache itself is untouched and keeps working against remote storage. This mirrors the same guard `marin.training.training._disable_xla_autotune_subcache` already applies for the Levanter launch path — this fixes the same class of bug on the in-process Iris init path.

Found during #6950 debugging.