### PR TITLE
Fix Grug MoE XSA GQA sharding

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -18,9 +18,9 @@ import jax.scipy as jsp
 from einops import rearrange
 from haliax import Axis
 from haliax.jax_utils import named_call
-from jax import random
+from jax import core, random
+from jax.sharding import NamedSharding, get_abstract_mesh, reshard
 from jax.sharding import PartitionSpec as P
-from jax.sharding import get_abstract_mesh, reshard
 
 try:
     from jax.shard_map import shard_map
@@ -80,6 +80,13 @@ def _batch_spec() -> P:
 
 def _batch_reshard(x: jax.Array) -> jax.Array:
     return reshard(x, _batch_spec())
+
+
+def _partition_spec_of(x: jax.Array) -> P | None:
+    sharding = jax.typeof(x).sharding if isinstance(x, core.Tracer) else x.sharding
+    if isinstance(sharding, NamedSharding):
+        return sharding.spec
+    return None
 
 
 def _layer_attention_masks(mask: AttentionMask, *, sliding_window: int) -> tuple[AttentionMask, AttentionMask]:
@@ -343,12 +350,10 @@ class CausalSelfAttention(eqx.Module):
             k = jnp.concatenate([k_rot, k[..., half:]], axis=-1)
         q = q * self.cfg.qk_mult
         attn_out = attention(q, k, v, mask, implementation=self.cfg.attention_implementation)
-        # Half-RoPE's slice+concat on the head_dim axis can leave the explicit-mesh
-        # propagator with ``model`` annotated on ``head_dim`` rather than
-        # ``num_q_heads``; force the canonical TP layout so it matches ``aligned_v``.
-        attn_out = reshard(attn_out, P(_BATCH_AXES, None, "model", None))
         aligned_v = align_kv_heads(v, num_q_heads=attn_out.shape[2])
-        aligned_v = reshard(aligned_v, P(_BATCH_AXES, None, "model", None))
+        # GPU XSA with GQA can give attn_out a backend-specific head sharding;
+        # match v to that dynamic sharding before the per-head projection math.
+        aligned_v = reshard(aligned_v, _partition_spec_of(attn_out) or P(_BATCH_AXES, None, None, "model"))
         # Exclusive Self Attention: subtract the component of yᵢ parallel to vᵢ.
         # zᵢ = yᵢ - (yᵢᵀvᵢ / ‖vᵢ‖²) vᵢ, per head.
         dot = jnp.sum(attn_out * aligned_v, axis=-1, keepdims=True)
@@ -357,7 +362,12 @@ class CausalSelfAttention(eqx.Module):
         # Headwise gating: sigmoid(x @ attn_gate) produces one scalar per head.
         gate = 2 * jax.nn.sigmoid(jnp.einsum("bsd,dn->bsn", x, self.attn_gate))[..., None]
         attn_out = gate * attn_out
-        attn_out = rearrange(attn_out, "... n d -> ... (n d)")
+        # Merge heads into hidden dim while keeping model-axis sharding for w_o.
+        attn_out = jnp.reshape(
+            attn_out,
+            (*attn_out.shape[:-2], attn_out.shape[-2] * attn_out.shape[-1]),
+            out_sharding=P(_BATCH_AXES, None, "model"),
+        )
         return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=batch_spec)
 
 

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -153,12 +153,15 @@ def test_grug_moe_layer_masks_preserve_thd_segment_metadata():
     assert long_mask.segment_ids is mask.segment_ids
 
 
-def test_grug_moe_xsa_forward_lowers_with_gqa_sharding():
+def test_grug_moe_xsa_forward_lowers_with_gpu_fa4_thd_gqa_sharding():
+    if jax.default_backend() != "gpu":
+        pytest.skip("gpu_fa4_thd requires the JAX GPU backend")
+
     model_module = importlib.import_module("experiments.grug.moe.model")
-    mesh, _ = model_module.debug_mesh_and_token_pspec(num_devices=4)
+    mesh, _ = model_module.debug_mesh_and_token_pspec(num_devices=8)
     cfg = model_module.GrugModelConfig(
         vocab_size=128,
-        hidden_dim=32,
+        hidden_dim=512,
         intermediate_dim=64,
         shared_expert_intermediate_dim=64,
         num_layers=1,
@@ -168,21 +171,23 @@ def test_grug_moe_xsa_forward_lowers_with_gqa_sharding():
         sliding_window=8,
         num_experts=4,
         num_experts_per_token=2,
-        attention_implementation="reference",
+        attention_implementation="gpu_fa4_thd",
     )
 
     def forward():
         attn = model_module.CausalSelfAttention.init(cfg, key=jax.random.PRNGKey(0))
         x = jax.sharding.reshard(
-            jnp.zeros((4, 8, cfg.hidden_dim), dtype=jnp.float32),
+            jnp.zeros((8, 16, cfg.hidden_dim), dtype=jnp.bfloat16),
             jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None, None),
         )
-        return attn(x, GrugAttentionMask.causal())
+        segment_ids = jnp.zeros((8, 16), dtype=jnp.int32)
+        mask = GrugAttentionMask.causal().with_segment_ids(segment_ids, max_segments=1)
+        return attn(x, mask)
 
     with _reset_abstract_mesh(), use_abstract_mesh(mesh):
         out_shape = eqx.filter_eval_shape(forward)
 
-    assert out_shape.shape == (4, 8, cfg.hidden_dim)
+    assert out_shape.shape == (8, 16, cfg.hidden_dim)
 
 
 def _seed_cache_records(step, prefix: str) -> None:

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -153,6 +153,38 @@ def test_grug_moe_layer_masks_preserve_thd_segment_metadata():
     assert long_mask.segment_ids is mask.segment_ids
 
 
+def test_grug_moe_xsa_forward_lowers_with_gqa_sharding():
+    model_module = importlib.import_module("experiments.grug.moe.model")
+    mesh, _ = model_module.debug_mesh_and_token_pspec(num_devices=4)
+    cfg = model_module.GrugModelConfig(
+        vocab_size=128,
+        hidden_dim=32,
+        intermediate_dim=64,
+        shared_expert_intermediate_dim=64,
+        num_layers=1,
+        num_heads=4,
+        num_kv_heads=1,
+        max_seq_len=8,
+        sliding_window=8,
+        num_experts=4,
+        num_experts_per_token=2,
+        attention_implementation="reference",
+    )
+
+    def forward():
+        attn = model_module.CausalSelfAttention.init(cfg, key=jax.random.PRNGKey(0))
+        x = jax.sharding.reshard(
+            jnp.zeros((4, 8, cfg.hidden_dim), dtype=jnp.float32),
+            jax.sharding.PartitionSpec(("replica_dcn", "data", "expert"), None, None),
+        )
+        return attn(x, GrugAttentionMask.causal())
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        out_shape = eqx.filter_eval_shape(forward)
+
+    assert out_shape.shape == (4, 8, cfg.hidden_dim)
+
+
 def _seed_cache_records(step, prefix: str) -> None:
     """Write the minimal record a built ``TokenizedCache`` dep would leave, so the run-time
     ``mixture`` can read each dataset's tokenizer/format offline (mirrors a real run, where the


### PR DESCRIPTION
Make Grug MoE's XSA value correction follow the actual attention-output partition spec instead of forcing `model` onto query heads before aligning `v`. GPU attention backends can expose either head-sharded or head-dim-sharded outputs; matching `aligned_v` to `attn_out` keeps the per-head XSA math layout-compatible, and the explicit flatten sharding preserves the projected hidden layout.

Adds a focused lowering contract for XSA with GQA on the compact Grug mesh so this path stays covered.

Fixes #6964
