### PR TITLE
iris: cw-us-east-02a default object store R2 → CoreWeave

### DIFF
--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -11,10 +11,11 @@
 # whatever the NodePools hold. See lib/iris/docs/coreweave.md.
 #
 # Workflow:
-#   1. Set CoreWeave AI Object Storage credentials (required for s3:// storage URIs):
+#   1. Set CoreWeave AI Object Storage credentials (console -> Object Storage ->
+#      Access Keys). `iris cluster start` turns them into the iris-task-env
+#      Secret (addressing style is derived from the endpoint domain):
 #        export CW_KEY_ID=<coreweave-access-key-id>
 #        export CW_KEY_SECRET=<coreweave-access-key-secret>
-#      `iris cluster start` turns these into the iris-task-env Secret.
 #   2. Point kubectl/iris at the region kubeconfig:
 #        export KUBECONFIG=~/.kube/coreweave-iris-gpu   # context marin-gpu_US-EAST-02A
 #   3. Start / inspect the cluster:
@@ -39,10 +40,14 @@ platform:
     region: US-EAST-02A
     namespace: iris
     kubeconfig_path: ~/.kube/coreweave-iris-gpu
-    object_storage_endpoint: https://74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com
+    # CoreWeave AI Object Storage via LOTA, the in-cluster local cache
+    # endpoint (use https://cwobject.com from outside CoreWeave). Bare
+    # endpoint only: buckets use virtual-hosted addressing
+    # (http://<bucket>.cwlota.com), which iris detects from this domain.
+    object_storage_endpoint: http://cwlota.com
 
 storage:
-  remote_state_dir: s3://marin-na/iris/cw-us-east-02a/state
+  remote_state_dir: s3://marin-us-east-02a/iris/cw-us-east-02a/state
   # Node-local NVMe for the controller's SQLite state, not the default
   # network-attached PVC.
   local_state_dir: /mnt/local/iris-controller-state
@@ -97,7 +102,11 @@ defaults:
     scale_down_delay:
       milliseconds: 300000
   task_env:
-    MARIN_PREFIX: s3://marin-na/marin
+    # The shared CoreWeave bucket (everything lives in marin-us-east-02a; LOTA
+    # caches reads locally). Task pods carry ONE endpoint/credential set, so R2
+    # data under s3://marin-na/ is not reachable from jobs unless they override
+    # AWS_ENDPOINT_URL and credentials themselves.
+    MARIN_PREFIX: s3://marin-us-east-02a/marin
     # H100 hostNetwork pods also see IB and SR-IOV link-local interfaces. Exclude
     # IB/IPoIB (ibs*, ibp*) and virtual interfaces so NCCL's bootstrap socket falls
     # back to the host ethernet PF that carries the node IP. The exact PF name


### PR DESCRIPTION
* switch the `cw-us-east-02a` default object store from Cloudflare R2 to CoreWeave AI Object Storage, matching `cw-rno2a`
* `object_storage_endpoint` → `http://cwlota.com` (in-cluster LOTA cache endpoint; `https://cwobject.com` from outside) — iris derives virtual-hosted addressing from the domain
* `storage.remote_state_dir` and `MARIN_PREFIX` move to the shared `marin-us-east-02a` bucket
* config-only: takes effect at the next `iris cluster start` with CoreWeave access keys exported as `CW_KEY_ID`/`CW_KEY_SECRET`; until then the running cluster keeps serving the R2-based `iris-task-env` Secret [^1]
* task pods carry ONE endpoint/credential set, so R2 data under `s3://marin-na/` stops being reachable by default — jobs that need it must override `AWS_*`/`FSSPEC_S3` themselves

[^1]: nothing migrates by itself: controller remote state under `s3://marin-na/iris/cw-us-east-02a/state` and job data under `s3://marin-na/marin` stay on R2 until moved.