### PR TITLE
[Design] mixing_via_embeddings

### DIFF
--- a/.agents/projects/mixing_via_embeddings/design.md
+++ b/.agents/projects/mixing_via_embeddings/design.md
@@ -1,0 +1,158 @@
+# Mixing via embeddings: bucket-independent mixture surrogates
+
+_Why are we doing this? What's the benefit?_
+
+Our data-mixture surrogates (DSP/GRP/LightGBM fit on the ~242-run qsplit240 swarm,
+[PR #2393](https://github.com/marin-community/marin/pull/2393)) take **bucket-indexed weight vectors**
+as input, so every fit is welded to one fixed bucket vocabulary. Bucket definitions churn constantly —
+the quality relabel (#6739), the domain-cluster hill-climb (#6491), new sources — and every
+redefinition strands the sweep and forces new proxy runs, which must run near-full-length because
+early-checkpoint rankings are unstable (60M Spearman 0.298 at 22% progress). This design re-featurizes
+a mixture by the **distribution it induces over a frozen embedding-space basis** — a token-weighted
+histogram over the existing datakit micro-cluster vocabulary — so the surrogate `g(features) → metric`
+is defined for *any* bucket whose contents we can embed. Adding or redefining buckets then costs one
+map-only embedding job instead of a sweep. Validation is retrodictive on the existing runs: **zero new
+proxy training** before the premise is proven.
+
+## Background
+
+Full brief: [research.md](research.md) (including review addenda). Domain2Vec (arXiv:2506.10952) is
+the existence proof — regress performance on the mixture's meta-domain histogram `V·w` and adapt to
+unseen datasets without refitting — but only at ≤1B over a coarse 260-cell taxonomy. CLIMB
+(arXiv:2504.13161) is the counterexample: embedding-derived clusters but a *positional* predictor, so
+re-clustering re-triggers its 112-run sweep — exactly our current trap. Cheap published baselines
+exist (Olmix mixture-reuse, Chameleon leverage scores) that any deployment must beat. Two-stage
+sampled distribution regression theory (arXiv:1402.1754) says regressing a scalar on a sampled
+distribution is well-posed. Internally, #6326 is the cautionary precedent: features derivable from the
+weights are a reparameterization and add nothing.
+
+## Challenges
+
+_What's hard?_
+
+**The linear-reparameterization trap.** On a fixed bucket set the mixture histogram is `h = V·w` with
+`V` the (cells × buckets) composition matrix — a fixed linear map of the weights. In-distribution fit
+parity is therefore expected and uninformative (the #6326 failure mode); extrapolation to a new column
+of `V` is carried entirely by the model's *smoothness prior over content space*. The success criterion
+is therefore not "histograms beat weights" but "**the true semantic `V` beats matched non-semantic
+reparameterizations**" — random projections with matched rank/spectrum and shuffled domain↔column
+mappings are mandatory controls in every experiment.
+
+**Honest estimand.** With ~242 Dirichlet runs, nearly every run touches every domain, so no
+retrodiction on this sweep is truly zero-shot. The primary estimand is **held-out-dose retrodiction**:
+train only on runs where domain k's exposure is ≈ 0, predict runs where it is dominant, with correct
+(full) featurization throughout — never the column-drop variant, which biases outcomes produced with
+domain k against features that pretend it wasn't there. Design-support diagnostics (convex-hull
+distance per test run, content novelty of `V_k` vs the cone of the others) are first-class outputs.
+
+**Exposure features are themselves bucket-indexed.** DSP's per-domain exposure/epoch features live in
+the same vocabulary we are trying to escape, and a held-out domain's exposure leaks the dose split.
+Exposure splits into *transferable* features (scale, phase lengths, total tokens, per-cell exposure,
+bucket size/repetition summaries — all computable for a new bucket) and *bucket-indexed* features
+(per-domain epochs), which are excluded from the primary transfer model and reported only as a
+diagnostic ceiling.
+
+**Measure mismatch.** Mixture weights govern sampled *tokens*; a histogram from uniformly sampled
+*documents* is a different measure, badly so for SFT/math/code with very different document lengths.
+`V` is estimated token-weighted under the swarm tokenizer's actual eligibility (truncation, loss
+masking). Relatedly, embeddings miss quality/dedup/repetition axes (DCLM; #6739), so cluster-only
+histograms are the primary features, the web-text quality scorer is treated as an uncalibrated
+descriptor pending a per-domain audit, and per-bucket size/dedup/length summaries are added as
+features that remain computable for new buckets.
+
+## Costs / Risks
+
+- The premise may be false — content may not predict marginal training value once format, duplication,
+  and repetition are accounted for. The precursor experiment (H2a) is designed to reveal this for
+  ~zero compute; the fallback is Olmix-style reuse plus targeted mini-sweeps, and the featurization
+  infra still serves the hill-climb thread.
+- Held-out-dose retrodiction is weaker than a genuinely novel bucket; a passing result still needs one
+  small live validation (H3) before production use.
+- This does nothing for proxy→target *scale* transfer (60M→300M Spearman 0.777) — that ceiling binds
+  regardless of featurization; results are computed per scale, never pooled.
+- Statistical power is thin (~20 test runs per split → Spearman CI ≈ ±0.3): all comparisons are paired
+  with bootstrap CIs, split feasibility is enumerated before any model is fit, and domain eligibility
+  is pre-registered without looking at outcomes.
+- The area is hot (CausalMix, Olmix, Chameleon, all 2025–26): partly scoop risk, partly validation.
+
+## Design
+
+_How are we doing this?_
+
+**Frozen basis.** The datakit Luxical vocabulary: 192-dim embeddings
+([`pipeline.py`](https://github.com/marin-community/marin/blob/a20220e4bab5acae88b52b0dab0cc9b5b65a8d03/experiments/datakit/embeddings/luxical/pipeline.py)),
+FAISS spherical k-means K=5000 with K=1000/40 coarse views
+([`train.py`](https://github.com/marin-community/marin/blob/a20220e4bab5acae88b52b0dab0cc9b5b65a8d03/experiments/datakit/cluster/domain/v0/train.py)).
+Basis identity is content-hashed and versioned; re-featurizing under a new basis (e.g. the
+hill-climb's stronger embedder) is a first-class, cheap operation. **K=40 is the primary granularity**
+(242 runs cannot identify a free 5000-cell response; R&B's granularity U-shape); K=1000/5000 enter
+only via smoothness-regularized models and ablations.
+
+**Featurization.** Per swarm domain
+([`domains.py`](https://github.com/marin-community/marin/blob/bf26b666a/experiments/domain_phase_mix/domains.py)):
+sample documents, embed, assign, accumulate **token-weighted** cluster histograms (a column of `V`).
+Run features per phase: `h = V·w` at the chosen granularity, optional mean-embedding moments,
+transferable exposure features, bucket-stats features. Predictors are chosen for their extrapolation
+prior, not raw capacity: kernel ridge on histogram distances (Hellinger/Jensen–Shannon) and ridge on
+K=40 cells as primaries; LightGBM-on-cells only as a stress ablation. A **cluster-free arm**
+(token-weighted random-Fourier-feature mean maps over raw embeddings ≈ MMD-kernel regression) runs
+alongside the clustered arm in every experiment: it bypasses the k-means codebook entirely, so
+disagreement between the arms localizes a failure to the codebook rather than the embedder or the
+premise.
+
+**Experiments, gated.**
+
+1. **H1 — information audit** (sanity): rank/conditioning of `V`, reconstruction of `w` from `h`,
+   nested-CV fit comparison of histogram vs weights features on identical splits, and the #6326
+   control (R² of `h` from `w`, trivially ~1 by construction — reported to keep everyone honest about
+   what in-distribution parity does and doesn't mean).
+2. **H2a — does content predict domain value?** (decisive premise test, cheapest): from the existing
+   sweep, estimate each domain's phase-specific marginal-value/saturation parameters with uncertainty
+   (incumbent DSP/GRP structure); leave-one-domain-out predict those parameters from content
+   histograms across the other 38, in both the clustered and cluster-free arms; score against
+   semantic-shuffle and matched-random controls. If content cannot predict domain-level response
+   here, stop — `g(V·w)` transfer has no chance. **Interpretation rule (pre-committed):** a negative
+   H2a under one basis is "inconclusive pending a second basis," not "premise falsified"; the kill
+   decision requires failure under two bases (e.g. Luxical + the hill-climb's candidate embedder) and
+   in the cluster-free arm, so a bad codebook or a weak embedder cannot masquerade as a refuted
+   premise. H2a is cheap enough (one featurization pass + CPU fits per basis) that this costs little.
+3. **H2b — held-out-dose mixture retrodiction** (the response-surface test): for pre-registered
+   domains k, train on bottom-dose runs, test on vertex/high-dose runs, per scale, paired against
+   weights-features and the control featurizations; success = semantic `V` beats controls with CI
+   separation on most eligible k, with design-support diagnostics reported per test run.
+4. **H3 — live validation** (only if H2a+H2b pass): one genuinely new bucket; the surrogate *proposes*
+   a mixture; ≤4 proxy runs at 60M/300M vs Olmix-style reuse and token-proportional proposals
+   (policy-regret comparison — proposers are evaluated here, not as H2 predictors).
+5. **H4 — ablations** (piggyback): granularity {40, 1000, 5000}; quality axis on/off (after the
+   scorer audit); histogram vs KME vs both; per-phase vs pooled; kernel geometry.
+
+Code lives at `experiments/datakit/mixture_features/` on this branch as self-contained scripts (in the
+style of the swarm's `exploratory/regmix_regression.py`), reading swarm run histories from W&B and
+mixture configs from the swarm branch as *data*, never importing branch code.
+
+## Testing
+
+_Agents make mistakes — how do we catch them?_
+
+- Unit tests on featurization algebra: `h = V·w` composition, token-weighting, invariance of `h` under
+  bucket relabeling/permutation, per-phase ordering, int8 dequantization round-trip.
+- Synthetic recovery test for the retrodiction harness: plant a known smooth `g*` over content space,
+  generate fake outcomes, verify the protocol recovers held-out-dose rankings, that the shuffled-`V`
+  control fails, and that a planted content-blind `g*` (value depends on bucket identity only) makes
+  the semantic model fail — the harness must be able to return "no" (mirrors `dsp-synthetic-recovery`).
+- Split feasibility enumeration (per-domain eligible train/test counts, per scale) runs before any
+  model fit and is checked into the results artifact.
+- Histogram stability: bootstrap over source shards (not documents), sample-size sensitivity
+  (100k vs 10k docs), and per-domain quality-scorer degeneracy report before quality features unlock.
+- All fits store per-run predictions (not just correlations) so any headline number can be re-derived.
+
+## Open Questions
+
+- Is held-out-dose + merged-domain pseudo-new-buckets (train with two domains fused into one column,
+  split at test) enough to claim "new bucket" transfer, or does the claim have to wait for H3?
+- Negative results require a second basis by the pre-committed rule; does a *positive* result under
+  Luxical int8 192-dim also need confirmation under the hill-climb's candidate embedder before H3, or
+  is the semantic-vs-control separation enough on its own?
+- Retrodiction target: `eval/uncheatable_eval/bpb` only, or also the #5416 aggregate — must the result
+  hold on both?
+- Where does this live long-term given the swarm assets are still branch-only (PR #2393 unmerged)?

--- a/.agents/projects/mixing_via_embeddings/design.md
+++ b/.agents/projects/mixing_via_embeddings/design.md
@@ -35,8 +35,8 @@ _What's hard?_
 parity is therefore expected and uninformative (the #6326 failure mode); extrapolation to a new column
 of `V` is carried entirely by the model's *smoothness prior over content space*. The success criterion
 is therefore not "histograms beat weights" but "**the true semantic `V` beats matched non-semantic
-reparameterizations**" — random projections with matched rank/spectrum and shuffled domain↔column
-mappings are mandatory controls in every experiment.
+reparameterizations**" — per-column cell-permutation controls (mass-profile-matched, simplex-valid)
+and shuffled domain↔column mappings are mandatory in every experiment.
 
 **Honest estimand.** With ~242 Dirichlet runs, nearly every run touches every domain, so no
 retrodiction on this sweep is truly zero-shot. The primary estimand is **held-out-dose retrodiction**:

--- a/.agents/projects/mixing_via_embeddings/research.md
+++ b/.agents/projects/mixing_via_embeddings/research.md
@@ -1,0 +1,395 @@
+# Background Research Brief — mixture optimization via embedding-space featurization
+
+- Effort: high (3 parallel tracks: core external anchors, adversarial/adjacent external, internal Marin)
+- Stop rule: stopped when new sources stopped changing the ranked hypotheses; remaining unverified items flagged in the source ledger
+- Date: 2026-07-05
+
+## Question
+
+Our RegMix-style mixture surrogates take bucket-indexed weight vectors as input, so the surrogate is only
+defined for a fixed bucket vocabulary: adding a bucket, re-clustering domains, or relabeling quality
+invalidates the fit and forces a new proxy sweep. Can we instead featurize a mixture by the **distribution
+it induces over a frozen embedding-space basis** (micro-cluster histograms / kernel mean embeddings), so
+the surrogate `g(features(mixture)) → metric` transfers to new or changed buckets without re-sweeping?
+The candidate first experiment: re-featurize the existing swarm runs and test leave-one-bucket-out (LOBO)
+retrodiction.
+
+## Current Marin Context
+
+- **The RegMix/swarm program lives on branch `calvin/swarm-olmo3-regmix-test`** (PR
+  [#2393](https://github.com/marin-community/marin/pull/2393), open; nothing named regmix is on `main`).
+  Main asset: the **qsplit240 swarm** — ~240–242 proxy runs, two phases, **39 hand-defined domains**
+  (`experiments/domain_phase_mix/domains.py` on that branch: Dolma 3 + Dolmino + Nemotron splits + SFT
+  sets), run at 60M and 300M with Dirichlet + vertex-biased weight sampling
+  (`experiments/domain_phase_mix/experiment.py`, `weight_sampler.py`). Target metric: primarily
+  `eval/uncheatable_eval/bpb`; also the #5416 aggregate and OLMoBaseEval Easy/Uncheatable (#6602/#6603).
+- **Surrogates**: literal RegMix (LightGBM on weights,
+  `experiments/domain_phase_mix/exploratory/regmix_regression.py`) is the weak baseline; production fits
+  are **DSP** (parametric benefit/saturation/penalty form with epoch/exposure features; OOF Spearman
+  **0.914** on uncheatable BPB) and **GRP** (power-family-penalty), fitters under
+  `exploratory/two_phase_many/`. Optimized-mixture CSVs in
+  `experiments/domain_phase_mix/assets/delphi_optimized_mixtures/`; checkpoints under
+  `gs://marin-us-east5/checkpoints/pinlin_calvin_xu/data_mixture/`.
+- **Datakit buckets (current, on main)**: store partitions on (domain cluster × quality bucket) — Luxical
+  192-dim embeddings → FAISS spherical k-means **K=5000 micro-clusters** with agglomerative coarse views
+  at K=1000 and K=40 (`experiments/datakit/cluster/domain/v0/{train,assign,summarize}.py`), × 5 quality
+  buckets at fixed cutoffs (`experiments/datakit/store/datakit_store.py:84-89`) → up to 200 buckets
+  (`datakit_store.py:28-34`). ~113 normalized sources (`lib/marin/src/marin/datakit/sources.py`).
+- **The featurization substrate already exists**: every datakit source is embedded (Luxical map-only
+  zephyr pipeline, `experiments/datakit/embeddings/luxical/pipeline.py`) and assigned to the frozen K=5000
+  vocabulary; **per-source cluster histograms are already computed** (`domain/v0/summarize.py`). Corpus
+  mismatch caveat: the qsplit240 swarm's 39 domains are a different corpus than datakit — re-featurizing
+  those runs needs embed+assign over the swarm domains (cheap: histogram estimation needs only a document
+  sample per domain, not full-corpus inference).
+- **Bucket churn is live motivation**: quality buckets are domain-biased (source predicts oracle label at
+  AUC 0.852, #6739; type-aware relabel validated small-scale) and the domain-cluster hill-climb (#6491,
+  PR #6476) wants a stronger embedder at K=40 — both would redefine buckets and strand any bucket-indexed
+  surrogate.
+
+## Internal Prior Work
+
+- **#6326 (closed) — MDE-style checkpoint-likelihood features failed**: 900-column feature set had
+  effective rank ~22 ≈ the mixture/exposure geometry; projecting from `phase_log_exposure` reproduced the
+  features (median R² ≈ 0.9998); DSP stayed stronger (0.914 vs 0.86). **This is the direct internal
+  precedent for the central failure mode**: a re-featurization of the same sweep that is (nearly) a
+  reparameterization of the weights adds nothing.
+- **Swarm-branch logbooks** (`.agents/logbooks/` on the swarm branch):
+  `partition-swarm-data-mixing-theory.md` — partition-expressivity analysis (coarse partitions limit
+  achievable mixtures; exactly the gap embedding-space parameterization addresses); repetition-aware
+  literal forms are weak (shared half-life Spearman 0.51; per-domain 0.925 but 39 fragile params);
+  `swarm-transfer-calibration.md` — 60M→300M identity Spearman only **0.777**; anchored `y60 + Δ(scale)`
+  beats a continuous law; early-rank instability (60M Spearman 0.298 at 22% progress vs final) means proxy
+  runs must run near-full-length — that is the re-sweep cost this proposal attacks.
+- **Domain-cluster hill-climb** (#6491): v0 K=40 coherence ≈ 0.75 by LLM intruder test, ~1.8× better than
+  WebOrganizer labels; next lever is a stronger fp32 embedder — i.e., the embedding space itself is
+  expected to change, so the design should treat "re-featurize under a new basis" as a first-class
+  operation, not an exception.
+- No internal attempt at continuous/embedding-space mixture parameterization found; no LOBO/leave-one-domain
+  retrodiction on the swarm; closest are #6326 and the partition-expressivity theory notes.
+
+## External Prior Art
+
+Anchors (all verified against arXiv/full text unless flagged):
+
+- **RegMix** (Liu et al., arXiv:2407.01492, ICLR 2025): 512 × 1M-param proxies × 1B tokens over 17 fixed
+  Pile domains; LightGBM on raw weights; 97.12% Spearman rank transfer to 1B/25B models. Input
+  dimensionality tied to the domain set; no new-domain mechanism; own stated limitation is the
+  domain-partition assumption.
+- **Domain2Vec** (Zhang et al., arXiv:2506.10952, ICML 2025) — **the existence proof for our featurization**:
+  vectorize any dataset as a distribution over 260 meta-domains (k-means over bge-small embeddings +
+  a Qwen2-1.5B classifier at 74.7% accuracy); regress performance on `V_train · r` (histogram of the
+  mixture) instead of one-hot weights; explicit claim of no-cost adaptation to unseen training sets /
+  validation sets / dataset counts; ~0.26% of DoReMi FLOPs for comparable quality. Validated only ≤1B
+  scale, coarse taxonomy, no classifier-error-propagation analysis.
+- **CLIMB** (Diao et al., NVIDIA, arXiv:2504.13161, NeurIPS 2025) — the cautionary mirror image:
+  stella_en_400M_v5 embeddings, FAISS k-means K=1000 → pruned/merged to ~20 superclusters, LightGBM on
+  **positional** cluster-weight vectors, 112 proxy runs over 3 iterations. No content featurization → no
+  transfer story; re-clustering implies re-sweeping. Notably they *collapsed* 1000 clusters to ~20 to make
+  search tractable — regression over fine histograms is the unsolved part.
+- **WebOrganizer** (Wettig et al., arXiv:2502.10341, ICML 2025): 24 topics × 24 formats, RegMix over
+  constructed domains (512 × 50M proxies). Key result for us: re-weighting domains to imitate
+  FineWeb-Edu's induced domain distribution recovers **73% of its MMLU gain / 84% on average** — a
+  domain-histogram match captures most of a pointwise quality filter. Explicitly cautions predictions are
+  noise-sensitive and scale transfer uncertain.
+- **Chameleon** (Xie et al., arXiv:2505.24844, ICML 2025): kernel ridge leverage scores over learned
+  domain embeddings; explicitly transfers to new domains at ~1% of proxy-retraining cost — but a scoring
+  heuristic, not a learned mixture→metric predictor; no what-if capability.
+- **CausalMix** (arXiv:2607.01104, Jul 2026): our motivating problem verbatim ("regression fit on old
+  proxy runs no longer predicts when the pool shifts"); pool statistics as covariates + CausalForestDML on
+  512 proxy runs; claims extrapolation to unseen pools. Post-training-flavored setting (Qwen2.5,
+  OpenDataArena); covariates are scalar quality metrics, not embedding distributions. [abstract-depth]
+- **Olmix** (Ai2, arXiv:2602.12237): names the evolving-domain-set problem; "mixture reuse" heuristic
+  (keep old ratios, recompute only affected domains) matches full recomputation with 74% less compute over
+  5 sequential domain-set updates. **This is the cheap baseline LOBO must beat.** [abstract-depth]
+- **MDE** (Google, arXiv:2502.15950): adding per-domain expert cross-entropy features to the regressor
+  substantially beats weights-only regression — external proof that richer mixture featurization improves
+  sample-efficiency (contrast with our #6326 variant, which failed because the features were
+  weight-derivable).
+- **Aioli** (Chen et al., arXiv:2411.05735, ICLR 2025): no existing method consistently beats stratified
+  sampling; mixture→loss is well-fit by simple laws (R² 0.969) but methods set law parameters inaccurately
+  from cheap static estimation. Regression target is learnable; proxy→target parameter transfer is the
+  bottleneck.
+- **DoReMi / DSIR / Data Mixing Laws / MATES**: DoReMi (arXiv:2305.10429) — group-DRO weights are
+  proxy-size unstable (280M proxy → Pile-CC 0.67 vs 1B proxy → <0.20). DSIR (arXiv:2302.03169) — hashed
+  n-gram importance resampling toward a chosen target; KL-reduction correlates r=0.82 with downstream;
+  assumes the target distribution is already right. Data Mixing Laws (arXiv:2403.16952) — exponential law
+  + nested scaling laws; O(M×K) params; rankings depend on scale and steps. MATES (arXiv:2406.06046) —
+  pointwise influence model (BERT fine-tuned on one-step-influence labels), continuous per-example
+  selection, no mixture-level interactions; connects to our MATES ICL-influence POC.
+- **Theory + adjacent featurization**: two-stage sampled distribution regression is provably consistent —
+  regressing a scalar on a kernel mean embedding of a *sampled* distribution is exactly our setting (Szabó
+  et al., arXiv:1402.1754, arXiv:1411.2066; improved bounds arXiv:2308.14335). Bag-of-Prototypes
+  (arXiv:2303.13251) — histogram over a frozen k-means codebook as a dataset representation, beats
+  global-mean/Fréchet representations for dataset-level prediction (vision). R&B (arXiv:2505.00358) —
+  ModernBERT + k-means regrouping; performance is U-shaped in cluster count; silhouette score is their
+  granularity heuristic; balancing via online gradient Gram matrix (0.009% overhead) with no proxy sweeps
+  at all — a rival philosophy.
+- **Practical priors**: embedding-at-scale precedents — SemDeDup (OPT-125M embeddings, K≈11k for C4,
+  K≈√N heuristic), D4 (re-cluster after dedup — duplicates distort cluster geometry), CLIMB (stella-400M
+  over 1.2T tokens), FineWeb-Edu (Snowflake-arctic-embed-m + linear head, ~6k H100-hours over FineWeb).
+  Proxy budgets: RegMix 512 runs / 17 domains; CLIMB 112 / ~20 clusters; CausalMix 512.
+
+**Novelty check (negative result)**: no paper found that feeds fine micro-cluster histograms or kernel
+mean embeddings of mixtures into a *learned performance predictor* for pretraining mixture optimization.
+Domain2Vec is closest (coarse 260-meta-domain histogram); CLIMB has fine clusters but a positional
+predictor. As of 2026-07, the specific combination appears unoccupied — and so does any
+design-of-experiments treatment of mixture proxy sweeps (no D-optimal/active-design paper for LLM
+mixtures found despite targeted searches).
+
+## Negative / Failed Leads
+
+- Internal #6326: weight-derivable features are a reparameterization; no gain over DSP.
+- DCLM (arXiv:2406.11794): fastText lexical filtering beat BGE-embedding classifiers, SemDeDup, AskLLM,
+  perplexity filters (~3.5 pt Core) — semantic embeddings alone are not sufficient statistics for
+  pretraining value.
+- Data-Quality Illusion (arXiv:2510.00866): classifier-based quality filtering works by *excluding*
+  low-quality data, not by matching the high-quality set; quality classifiers learn spurious features —
+  "distance to HQ clusters" is not a reliable value signal.
+- Proxy reliability: arXiv:2512.24503 — proxy→target recipe-rank Spearman often <0.75, sometimes ~0/negative
+  at standard LRs (near-perfect at tiny LRs — actionable protocol check); DataDecide (arXiv:2504.11393) —
+  small-scale ranking gets only ~80% of pairwise decisions right at 1B, and no scaling-law method beat that.
+- Aioli: cheap static estimation of mixing-law parameters transfers poorly to the target run.
+- No LLM mixture-DoE literature exists to lean on for the identifiability question (genuine gap).
+
+## Evidence Map
+
+#### Claim: On a fixed bucket set, histogram featurization is information-equivalent to bucket weights; its value is exclusively in generalization to new/changed buckets
+- Support:
+  - Linear algebra: the mixture histogram is `h = V·w` with `V` the (cells × buckets) bucket-composition
+    matrix — a fixed linear map of `w`. Rank ≤ #buckets.
+  - Internal #6326: weight-derivable features (effective rank ≈ mixture geometry) added nothing over DSP.
+  - Domain2Vec regresses on exactly `V_train · r` and gets its wins from *transfer*, not in-distribution fit.
+- Contradictions:
+  - MDE (Google) shows richer features can improve *sample-efficiency* even in-distribution — but their
+    features (expert losses) are not weight-derivable; histograms on a fixed bucket set are.
+- Directness to Marin: exact — same sweep (qsplit240), same trap (#6326).
+- Confidence: high (mathematical + replicated internally).
+- Action: design the experiment around LOBO/new-direction transfer, and always report the
+  weights-baseline on identical train/test splits; in-distribution parity is a sanity check, not a result.
+
+#### Claim: Distributional featurization can transfer a mixture surrogate to unseen buckets
+- Support:
+  - Domain2Vec (2506.10952): no-cost adaptation to unseen training sets at ≤1B scale, 0.26% of DoReMi FLOPs.
+  - Chameleon (2505.24844): domain-embedding representation transfers to new domains at ~1% cost.
+  - CausalMix (2607.01104): covariate-based predictor extrapolates to unseen pools [abstract-depth].
+  - WebOrganizer: matching an induced domain histogram recovers 73–84% of a quality filter's gain.
+  - Distribution-regression theory (1402.1754/1411.2066): the estimation problem is well-posed.
+- Contradictions:
+  - Nobody has done it with fine (10³–10⁴ cell) histograms; CLIMB collapsed 1000→~20 clusters to cope.
+  - Classical mixture DoE: extrapolation off the sweep's design support is model-assumption-bound; the
+    qsplit240 Dirichlet sweep was not designed to span new-bucket directions.
+- Directness to Marin: high for the mechanism; medium for scale (all external validation ≤1B).
+- Confidence: exploratory — plausible mechanism with one direct existence proof, unreplicated in our regime.
+- Action: run LOBO retrodiction on qsplit240 (H2 below) before building anything.
+
+#### Claim: Semantic embeddings miss value axes that move our metric (quality, dedup, noise)
+- Support:
+  - DCLM: fastText beat BGE-embedding classifiers for filtering.
+  - Data-Quality Illusion: quality-classifier signal is spurious-feature-laden and task-specific.
+  - Internal: datakit quality buckets are domain-confounded (AUC 0.852 source→label, #6739); D4: duplicates
+    distort embedding-cluster geometry.
+- Contradictions:
+  - FineWeb-Edu: a linear head on frozen embeddings carried enough signal to curate 1.3T tokens.
+  - Luxical + K=40 won the intruder-test coherence eval vs WebOrganizer (#6491) — topically the space is good.
+- Directness to Marin: high — our own quality relabel work exists because of this confound.
+- Confidence: replicated.
+- Action: cluster-only histograms are the primary features; the quality axis is gated behind a
+  per-domain audit (the web-text fasttext scorer is OOD on SFT/math/code and fixed cutoffs may
+  degenerate there — see review addenda) and enters via the H4 ablation; add bucket-stats features
+  (size/dedup/length/loss-mask) that embeddings cannot see but remain computable for new buckets.
+
+#### Claim: Proxy→target scale transfer, not surrogate fit, bounds what any featurization can deliver
+- Support:
+  - Internal: 60M→300M Spearman 0.777; early-rank instability 0.298 at 22% progress.
+  - arXiv:2512.24503: proxy rankings <0.75 Spearman at standard LRs, flip with hyperparameters.
+  - DataDecide: ~80% pairwise-decision ceiling; DoReMi proxy-size weight flip (0.67 → <0.20).
+  - Data Mixing Laws: mixture rankings depend on model size and steps.
+- Contradictions:
+  - RegMix: 97.1% Spearman 1M→1B (their setting); tiny-LR protocol gives near-perfect transfer (2512.24503).
+- Directness to Marin: exact — measured on our own swarm.
+- Confidence: replicated.
+- Action: scope the proposal to "reuse the sweep across *bucket* changes"; scale transfer stays whatever
+  DSP/anchored-delta already delivers. Don't claim the featurization fixes scale transfer.
+
+#### Claim: Simple reuse heuristics are the bar to beat, not full re-sweeps
+- Support:
+  - Olmix (2602.12237): keep-old-ratios + recompute-affected matches full recomputation at 26% compute.
+  - Chameleon: new-domain adaptation at ~1% cost with no predictor at all.
+  - DSIR/DA²-style alignment: training-free distribution matching as a zero-run baseline.
+- Contradictions: none found — these baselines are cheap and must be included.
+- Directness to Marin: high — trivially implementable on our sweep.
+- Confidence: exploratory (abstract-depth for Olmix).
+- Action: H3 evaluates *proposed mixtures* against (a) token-proportional weight for the new bucket,
+  (b) Olmix-style reuse, (c) DA² alignment — not only against "re-run the sweep". (These are mixture
+  proposers, not metric predictors, so they belong in H3's policy comparison, not H2's rank test —
+  see review addenda.)
+
+## Recommended Next Experiments
+
+#### 1. H2 — content→value retrodiction on qsplit240 (the decisive test; two stages, see addenda)
+- Minimum experiment: embed+assign a ~100k-document sample per swarm domain into the frozen datakit K=5000
+  vocabulary (map-only zephyr job; histograms converge fast on samples) → per-domain **token-weighted**
+  histograms `V`. Then two stages. **H2a**: fit per-domain per-phase response parameters (incumbent
+  DSP/GRP structure, with uncertainty) and leave-one-domain-out predict them from content histograms
+  across the other 38 — the direct test of "content predicts domain value". **H2b**: held-out-dose
+  retrodiction — per pre-registered domain k and per scale, train `g` only on runs where k's dose ≈ 0
+  (full, physically correct `h = V·w` featurization throughout), predict the high-dose/vertex runs.
+  In both stages, compare semantic `V` against shuffled-column and matched-random-projection controls
+  and against the weights-surrogate, on identical paired splits.
+  *(Superseded protocol note: an earlier draft proposed dropping domain k's column and training on
+  `h = V_{-k}·w_{-k}`. Review found this biased — outcomes were produced with k present
+  (omitted-variable bias) and `w_{-k}` is no longer a distribution. The honest estimand on this sweep
+  is held-out-dose extrapolation, not zero-shot; see review addenda.)*
+- Baseline/control: shuffled/matched-random featurizations and the weights-model on identical splits;
+  the #6326-style control — R² of predicting `h` from `w` (expected ~1 by construction, reported for
+  honesty about what in-distribution parity means).
+- Expected signal: semantic featurization beats both non-semantic controls with paired-bootstrap CI
+  separation on most eligible held-out domains (H2b) and across the 39 LODO folds (H2a).
+- Falsifier: semantic ≈ shuffled/matched-random, or H2a shows content does not predict domain response
+  parameters — then `g(V·w)` transfer has no chance; stop before any live runs.
+- Cost/risk: no proxy training; one map-only embedding job over domain samples + CPU fitting. Risks:
+  (a) qsplit240's Dirichlet design may not support held-out-dose extrapolation — report content novelty
+  (cone distance of `V_k`) and per-test-run convex-hull design support; (b) ~20 test runs/split →
+  Spearman CI ≈ ±0.3 — enumerate split feasibility per scale before fitting anything.
+- Sources: Domain2Vec 2506.10952; internal #6326; swarm branch `exploratory/two_phase_many/`;
+  `domain/v0/{train,assign}.py`; review addenda below.
+- Confidence: exploratory.
+
+#### 2. H1 — Information audit (prerequisite sanity check, same infra as H2)
+- Minimum experiment: numerical rank and condition spectrum of `V`; linear reconstruction error of `w`
+  from `h`; nested-CV fit comparison of histogram-featurized vs weights-featurized learners on
+  identical splits over the full 242-run set.
+- Baseline/control: DSP OOF Spearman 0.914 as a reference line (not a parity target — DSP's parametric
+  per-domain form cannot ingest histograms directly; see review addenda).
+- Expected signal: near-parity for comparable learner classes; any gap is attributed among compression,
+  conditioning, and model-class mismatch (each measured separately).
+- Falsifier: large unexplained fit loss → the histogram compresses away identity information the
+  surrogate needs (e.g., two content-similar domains with very different value — a quality-axis
+  failure, see claim 3).
+- Cost/risk: trivial once V exists.
+- Sources: #6326 protocol; DSP fitters.
+- Confidence: stable prediction (linear-map argument), with the parity claim appropriately weakened.
+
+#### 3. H3 — Live new-bucket validation (only if H2 passes)
+- Minimum experiment: pick a genuinely new bucket (e.g., a datakit source outside the 39 swarm domains, or
+  a post-relabel quality bucket). Optimize the mixture with the histogram surrogate; run 2–4 proxy models
+  at 60M/300M: g-optimum vs Olmix-reuse vs token-proportional vs (budget permitting) a mini-sweep optimum.
+- Baseline/control: Olmix-style reuse is the primary comparator.
+- Expected signal: g-optimum ≥ reuse baselines on uncheatable BPB at 300M.
+- Falsifier: g-optimum indistinguishable from token-proportional, or worse than reuse.
+- Cost/risk: a few 300M proxy runs (the thing we are trying to amortize — keep to ≤4).
+- Sources: Olmix 2602.12237; swarm launch scaffolding.
+- Confidence: exploratory.
+
+#### 4. Ablations (piggyback on H2)
+- Basis granularity K ∈ {40 primary, 1000, 5000} (R&B's U-shape says don't assume finer is better; 242
+  runs cannot identify a free 5000-cell response — fine granularities only via smoothness-regularized
+  models); quality-score features per cell on/off (gated on the scorer audit); KME (mean Luxical
+  embedding) vs histogram vs both; per-phase histograms vs pooled; kernel geometry
+  (Hellinger/Jensen–Shannon vs Euclidean).
+- Falsifier for the "fine basis" story: K=40 matches K=5000 on held-out-dose — then the coarse view
+  suffices and the design simplifies.
+- Sources: R&B 2505.00358; Bag-of-Prototypes 2303.13251; Szabó et al. distribution regression.
+
+## Hypothesis Queue Update
+
+- Add: H1 (information audit), H2a (content→domain-response LODO), H2b (held-out-dose retrodiction),
+  H3 (live new-bucket validation, policy comparison), H4 (granularity/feature ablations) — as above.
+- Revise: the original framing "refit the surrogate on histograms and check held-out-run R²" is
+  insufficient — on a fixed bucket set it is a linear reparameterization (see claim 1). The original
+  LOBO column-drop protocol is superseded (biased; see addenda). The queue centers on H2a → H2b with
+  semantic-vs-control comparisons.
+- Falsify / stop: if H2a fails (content does not predict domain response), or H2b fails across most
+  eligible domains after the design-support check, stop; fall back to Olmix-style reuse + targeted
+  mini-sweeps (active-learning direction remains open).
+- Promote: nothing yet (no experiment run).
+
+## Review addenda (2026-07-05)
+
+Two independent pre-publication reviews reshaped the protocol: an internal architect pass and an
+external Codex (GPT-5.5) pass acting as research colleague. Convergent findings (both reviewers):
+Olmix-reuse/token-proportional are mixture *proposers*, not metric predictors — comparing them by
+test-run Spearman was a category error (moved to H3 as policy-regret comparison); the LOBO
+column-drop protocol contradicted the design's run-split and is statistically biased; `SwarmRun`
+needed model scale, phase durations, and token counts (scale pooling would silently exploit the 0.777
+cross-scale ceiling); p≫n at K=5000 needs pinned regularization with K=40 primary; the web-text
+quality scorer is OOD on SFT/math domains (quality axis gated behind a per-domain degeneracy audit);
+span diagnostics must use convex-hull/cone distance, not linear span (linear span over-covers and is
+near-zero by construction once any train run touches the domain).
+
+Codex-only contributions adopted into the design: (1) **exposure features are themselves
+bucket-indexed** — per-domain epoch/exposure features quietly reintroduce the bucket vocabulary and
+leak the dose split; split into transferable-global vs bucket-indexed (the latter diagnostic-only);
+(2) **token-weighted histograms** — mixture weights govern sampled tokens, so document-uniform
+histograms are the wrong measure, badly so for SFT/math/code (document length, packing, loss
+masking); (3) **honest estimand renaming** — "held-out-dose retrodiction", not zero-shot LOBO;
+(4) **semantic-shuffle and matched-random-projection controls** as the criterion (the claim is
+"semantic alignment beats equally-regularized non-semantic reparameterizations", not "histograms beat
+weights"); (5) **H2a two-stage domain-response experiment** as the cheapest decisive premise test;
+(6) bucket-stats features (size/dedup/length/loss-mask fractions) that stay computable for new
+buckets; (7) content-hash basis identity; (8) synthetic-recovery tests must include must-fail cases.
+
+Architect-only contributions adopted: split-feasibility enumeration before any fit; pre-registered
+domain eligibility; paired bootstrap CIs and stored per-run predictions; explicit phase reducer for
+dose; the middle dose band is discarded by declared thresholds (absolute, not quantiles); DSP-parity
+claim weakened in H1 (DSP cannot ingest histograms; attribute any gap among compression/conditioning/
+model class).
+
+Post-review author addition (basis sensitivity, 2026-07-05): the experiments depend on the frozen
+basis only as a quantizer, but a negative result under one basis cannot distinguish "premise false"
+from "basis blind". Two changes: (1) a mandatory **cluster-free arm** (token-weighted RFF mean maps ≈
+MMD-kernel regression over raw embeddings) runs alongside the clustered arm in every experiment,
+localizing failures to the codebook vs the embedder vs the premise; (2) a pre-committed
+**interpretation rule** — killing the premise requires the H2a gate to fail under two `MixtureBasis`
+versions (different embedders) and in the cluster-free arm.
+
+## Source Ledger
+
+| Source | Type | Location | Claim used for | Confidence | Notes |
+|---|---|---|---|---|---|
+| RegMix 2407.01492 | paper | arxiv.org/abs/2407.01492 | weights-only regression, 512-run budget, rank invariance | high | full text |
+| Domain2Vec 2506.10952 | paper | arxiv.org/abs/2506.10952 | histogram featurization transfers to unseen sets | high | ≤1B scale; Spearman 0.9743/0.6657 medium confidence |
+| CLIMB 2504.13161 | paper | arxiv.org/abs/2504.13161 | fine clusters + positional predictor = no transfer | high | per-proxy token budget unverified |
+| WebOrganizer 2502.10341 | paper | arxiv.org/abs/2502.10341 | histogram-matching recovers 73–84% of filter gain | high | 80K vs 100K annotation count unresolved |
+| Chameleon 2505.24844 | paper | arxiv.org/abs/2505.24844 | new-domain adaptation at ~1% cost, no predictor | high | |
+| CausalMix 2607.01104 | paper | arxiv.org/abs/2607.01104 | pool-shift failure + covariate fix | medium | abstract-depth; post-training setting |
+| Olmix 2602.12237 | paper | arxiv.org/pdf/2602.12237 | mixture-reuse baseline, 74% compute saving | medium | abstract-depth |
+| MDE (Google) 2502.15950 | paper | arxiv.org/abs/2502.15950 | richer features beat weights-only regression | high | |
+| Aioli 2411.05735 | paper | arxiv.org/abs/2411.05735 | laws well-specified, parameters set badly; stratified hard to beat | high | |
+| DoReMi 2305.10429 | paper | arxiv.org/abs/2305.10429 | proxy-size weight instability | high | 280M vs 1B flip partly secondhand via RegMix |
+| DSIR 2302.03169 | paper | arxiv.org/abs/2302.03169 | distribution-matching baseline; KL↔downstream r=0.82 | high | |
+| Data Mixing Laws 2403.16952 | paper | arxiv.org/abs/2403.16952 | rankings scale/step-dependent; O(M×K) params | high | run counts not pinned |
+| MATES 2406.06046 | paper | arxiv.org/abs/2406.06046 | pointwise influence alternative; no mixture interactions | high | pooling detail unconfirmed |
+| Small-runs reliability 2512.24503 | paper | arxiv.org/abs/2512.24503 | proxy rank transfer <0.75; tiny-LR fix | high | |
+| DataDecide 2504.11393 | paper | arxiv.org/abs/2504.11393 | ~80% pairwise-decision ceiling | high | |
+| DCLM 2406.11794 | paper | arxiv.org/abs/2406.11794 | fastText beat embedding classifiers | high | |
+| Data-Quality Illusion 2510.00866 | paper | arxiv.org/abs/2510.00866 | quality ≠ proximity to HQ set in embedding space | high | |
+| R&B 2505.00358 | paper | arxiv.org/abs/2505.00358 | U-shape in cluster count; silhouette heuristic; online gradient rival | high | |
+| SemDeDup 2303.09540 / D4 2308.12284 | paper | arxiv | K≈√N; re-cluster after dedup | high | |
+| Distribution regression 1402.1754 / 1411.2066 / 2308.14335 | paper | arxiv | two-stage sampled KME regression is consistent | high | exact theoretical setting |
+| Bag-of-Prototypes 2303.13251 | paper | arxiv.org/abs/2303.13251 | frozen-codebook histogram as dataset representation | high | vision |
+| Scaling Laws for Optimal Data Mixtures 2507.09404 | paper | arxiv | law extrapolates across scale, within domain simplex | medium | |
+| Survey 2604.16380 | paper | arxiv.org/pdf/2604.16380 | partition-scheme transferability is open | medium | |
+| PR #2393 / swarm branch | Marin code | `calvin/swarm-olmo3-regmix-test`, `experiments/domain_phase_mix/` | qsplit240 assets, DSP/GRP fitters | high | branch-only, not on main |
+| #6326 | GitHub issue | marin#6326 | weight-derivable features fail | high | retrospective TL;DR |
+| Swarm logbooks | logbook | `.agents/logbooks/` (swarm branch) | transfer 0.777; early-rank instability; partition expressivity | high | |
+| Datakit cluster/store code | Marin code | `experiments/datakit/cluster/`, `experiments/datakit/store/datakit_store.py` | K=5000 basis, per-source histograms, 200 buckets | high | on main |
+| #6491 / PR #6476 | GitHub issue/PR | marin#6491 | cluster coherence; embedder churn expected | high | |
+| #6739 | GitHub issue | marin#6739 | quality buckets domain-confounded | high | |
+| Unverified leads | paper | RegMix-D 2606.18663, FastMix 2606.14971, Topic-over-Source 2502.16802, CAMEL 2603.08022, HERMES 2607.02266 | adjacent, not load-bearing | low | abstract-only |
+
+## Handoff
+
+- Suggested issue `Prior work` block: Domain2Vec (2506.10952) = existence proof for histogram-featurized
+  mixture regression transferring to unseen sets; CLIMB (2504.13161) = fine embedding clusters but
+  positional predictor (no transfer); Chameleon (2505.24844) + Olmix (2602.12237) = cheap
+  new-domain baselines to beat; internal #6326 = weight-derivable features are a reparameterization
+  (the control every result must pass); distribution-regression theory (1402.1754) = the estimation
+  problem is well-posed.
+- Suggested logbook entry: this brief (research.md) + design.md in the same directory.
+- Open questions: (1) how far outside the qsplit240 design span are realistic new buckets (measure, don't
+  assume); (2) does the two-phase structure need per-phase histograms or do pooled + exposure features
+  suffice; (3) is Luxical (192-dim, int8) good enough as the frozen basis or should H2 be repeated under
+  the hill-climb's stronger embedder; (4) who owns re-running embed+assign when the basis version bumps.
+- Stop reason: new sources stopped changing the hypothesis ranking; remaining unknowns are empirical
+  (H1/H2), not literature gaps.

--- a/.agents/projects/mixing_via_embeddings/spec.md
+++ b/.agents/projects/mixing_via_embeddings/spec.md
@@ -29,11 +29,16 @@ class MixtureBasis:
     view_sha256: Mapping[int, str]
     quality_scorer: str | None     # e.g. "datakit-quality-v0-fasttext"; None = no quality axis
     quality_scorer_sha256: str | None
+    rff_dim: int                   # cluster-free RFF map identity — part of basis equality so
+    rff_seed: int                  # histograms built with different RFF maps can never be
+    rff_bandwidth: float           # concatenated (median-heuristic value frozen at basis creation)
 ```
 
 v0 binds to the existing datakit artifacts: Luxical-One embedder, `train_centroids_22d1e89d`
-centroids, K=5000 with 1000/40 agglomerative views, the qsplit240 run tokenizer, and (behind the
-audit gate, see H4) the datakit v0 fasttext quality scorer with the store cutoffs `[0.2,0.4,0.6,0.8]`.
+centroids, K=5000 with 1000/40 agglomerative views, the qsplit240 run tokenizer, RFF map (dim 2048,
+seed 0, bandwidth = median heuristic on the codebook training sample, frozen at basis creation), and
+(behind the audit gate, see H4) the datakit v0 fasttext quality scorer with the store cutoffs
+`[0.2,0.4,0.6,0.8]`.
 Sampling metadata (sample size, seed) identifies an *estimate*, and lives on `DomainHistogram`, not on
 the basis.
 
@@ -123,9 +128,10 @@ class FeatureFamily(StrEnum):
     HIST_K5000 = "hist_k5000"              # ablation/stress only
     KME_MEAN = "kme_mean"                  # mass-weighted mean of dequantized centroid vectors (192 dims)
     RFF_MEAN = "rff_mean"                  # cluster-free arm: token-weighted mean of random Fourier
-                                           # features of raw document embeddings (dim 2048, median-heuristic
-                                           # bandwidth on the codebook training sample, seed 0; all three
-                                           # recorded in _meta.json). Bypasses the k-means codebook.
+                                           # features of raw document embeddings. Map identity
+                                           # (rff_dim/rff_seed/rff_bandwidth) lives on MixtureBasis, so
+                                           # mismatched maps raise BasisMismatchError. Bypasses the
+                                           # k-means codebook.
     QUALITY_MASS = "quality_mass"          # mass per quality bucket; locked until the scorer audit passes
     BUCKET_STATS = "bucket_stats"          # mixture-weighted BucketStats scalars
     EXPOSURE_GLOBAL = "exposure_global"    # transferable: model_size, phase_tokens, per-cell exposure
@@ -164,7 +170,12 @@ def shuffled_columns_v(v: np.ndarray, seed: int) -> np.ndarray
     marginal geometry."""
 
 def matched_random_v(v: np.ndarray, seed: int) -> np.ndarray
-    """Random V with matched rank and singular spectrum. Destroys content, preserves conditioning."""
+    """Independent random permutation of cell indices within each column. Every column keeps its
+    exact mass profile (non-negative, sums to 1, same entropy/sparsity — valid input for the
+    Hellinger/JS predictors), but the shared cell coordinate system, and hence all cross-column
+    content similarity, is destroyed. (An earlier draft matched rank/singular spectrum with a
+    generic random matrix; that control leaves the simplex and would feed invalid histograms to
+    distance-based predictors.)"""
 ```
 
 ## H2a — domain response from content (`domain_response.py`)

--- a/.agents/projects/mixing_via_embeddings/spec.md
+++ b/.agents/projects/mixing_via_embeddings/spec.md
@@ -142,14 +142,17 @@ def mixture_histogram(weights: Mapping[str, float], v: np.ndarray, domain_order:
     """h = V @ w. Missing domains get weight 0; raises ValueError on unknown domain or if weights
     do not sum to 1 (atol 1e-6)."""
 
+class PhaseHandling(StrEnum):
+    PER_PHASE = "per_phase"   # per-phase features, concatenated in phase order (default)
+    POOLED = "pooled"         # phase-token-weighted average mixture (from run.phase_tokens)
+
 def run_features(
     run: SwarmRun,
     histograms: Sequence[DomainHistogram],
     families: Sequence[FeatureFamily],
-    per_phase: bool = True,
+    phases: PhaseHandling = PhaseHandling.PER_PHASE,
 ) -> np.ndarray:
-    """Concatenate the requested families. Histogram families are per-phase and concatenated when
-    per_phase; else computed on the phase-token-weighted average mixture (from run.phase_tokens).
+    """Concatenate the requested families under the given phase handling.
     Deterministic ordering: families as given, cells in index order, phases in order."""
 ```
 

--- a/.agents/projects/mixing_via_embeddings/spec.md
+++ b/.agents/projects/mixing_via_embeddings/spec.md
@@ -1,0 +1,291 @@
+# Spec — mixing_via_embeddings
+
+Contracts for the experiment code and persisted artifacts. Scope: H1/H2a/H2b/H4 (retrodiction on
+existing swarm runs) plus the featurization job they share. H3 (live validation) reuses swarm launch
+scaffolding and adds no new contracts beyond the policy-proposal note at the end.
+
+All new code lives under `experiments/datakit/mixture_features/` as self-contained scripts + a small
+importable module. Nothing imports from the swarm branch; swarm run histories (W&B) and mixture
+configs (CSVs from `calvin/swarm-olmo3-regmix-test`) are consumed as data.
+
+## Basis identity
+
+```python
+@dataclass(frozen=True)
+class MixtureBasis:
+    """Identity of the frozen space a histogram is expressed in.
+
+    Two histograms are comparable iff their MixtureBasis is equal. Identity is by content
+    hash, not path: a re-uploaded centroid file with different bytes is a different basis.
+    Every persisted artifact embeds this identity; every function that combines histograms
+    raises BasisMismatchError on inequality rather than silently mixing spaces.
+    """
+    embedder: str                  # e.g. "luxical-one-v0" (192-dim, int8 quantized)
+    tokenizer: str                 # tokenizer defining the token measure (must match the swarm runs')
+    centroids_path: str            # GCS path to the K=5000 spherical k-means centroids
+    centroids_sha256: str
+    k: int                         # fine cluster count (5000)
+    view_paths: Mapping[int, str]  # coarse-view lookup tables, e.g. {1000: ..., 40: ...}
+    view_sha256: Mapping[int, str]
+    quality_scorer: str | None     # e.g. "datakit-quality-v0-fasttext"; None = no quality axis
+    quality_scorer_sha256: str | None
+```
+
+v0 binds to the existing datakit artifacts: Luxical-One embedder, `train_centroids_22d1e89d`
+centroids, K=5000 with 1000/40 agglomerative views, the qsplit240 run tokenizer, and (behind the
+audit gate, see H4) the datakit v0 fasttext quality scorer with the store cutoffs `[0.2,0.4,0.6,0.8]`.
+Sampling metadata (sample size, seed) identifies an *estimate*, and lives on `DomainHistogram`, not on
+the basis.
+
+## Domain histograms (`build_domain_histograms.py`)
+
+Zephyr map-only job, one shard per swarm domain. Histograms are **token-weighted**: each sampled
+document contributes mass equal to its count of training-eligible tokens under `basis.tokenizer`
+(post truncation and loss-masking, using the same serialization the swarm loader applied — for SFT
+domains, the rendered prompt+response string with only loss-bearing tokens counted).
+
+```python
+def build_domain_histogram(
+    domain: str,
+    documents: Iterable[Document],   # (text, serialization already applied by the per-domain loader shim)
+    basis: MixtureBasis,
+    sample_size: int = 100_000,
+    seed: int = 0,
+) -> DomainHistogram:
+    """Embed a uniform document sample, assign to basis centroids (and quality buckets when
+    basis.quality_scorer is set), and accumulate token-weighted cell mass.
+
+    Samples exactly `sample_size` documents (seeded reservoir); raises InsufficientSampleError
+    below `min_sample_size` (10_000). `frac` sums to 1 over occupied cells. Also accumulates
+    the bucket-stats summary (below).
+    """
+
+@dataclass(frozen=True)
+class DomainHistogram:
+    domain: str
+    basis: MixtureBasis
+    sample_size: int          # documents sampled
+    token_count: int          # eligible tokens over the sample (the histogram's total mass)
+    seed: int
+    counts: Mapping[tuple[int, int], int]   # (cluster_id, quality_bucket) -> eligible tokens; quality_bucket = -1 when no quality axis
+    rff_mean: tuple[float, ...]             # cluster-free summary (dim 2048), accumulated in the same pass
+    stats: BucketStats
+
+@dataclass(frozen=True)
+class BucketStats:
+    """Per-bucket scalars that embeddings cannot see but that remain computable for any new
+    bucket; used as features alongside histogram mass."""
+    total_tokens_available: int       # corpus size, from source metadata (not the sample)
+    mean_doc_tokens: float
+    duplicate_frac: float | None      # within-sample near-dup rate (minhash); None if not computed
+    loss_masked_frac: float           # fraction of serialized tokens excluded from loss (0 for web)
+```
+
+**Persisted shape** — parquet at
+`gs://marin-eu-west4/datakit/mixture_features/v0/domain_histograms/part-<domain>.parquet` with columns
+`domain` (string), `cluster_id` (int32), `quality_bucket` (int8, -1 when absent), `token_count`
+(int64), `frac` (float64). Sidecar `_meta.json` per prefix: the full `MixtureBasis` (with hashes),
+per-domain `sample_size`/`seed`/`token_count`/`BucketStats`, `created_at`, git SHA of the producing
+script. Coarse views are derived at load time via the view tables (`composition_matrix` below), never
+persisted, so K=40/1000 histograms cannot drift from the K=5000 source.
+
+## Swarm run loading (`swarm_runs.py`)
+
+```python
+@dataclass(frozen=True)
+class SwarmRun:
+    """One proxy run re-read from W&B."""
+    run_id: str
+    model_size: int                                   # parameters, e.g. 60_000_000 / 300_000_000
+    phase_weights: tuple[Mapping[str, float], ...]    # per-phase mixture, keys = domain names
+    phase_tokens: tuple[int, ...]                     # tokens trained in each phase
+    domain_tokens: tuple[Mapping[str, float], ...]    # per-phase per-domain consumed tokens (weights x phase_tokens)
+    is_vertex: bool                                   # sampled by the vertex-biased strategy
+    vertex_domain: str | None                         # the dominant domain if is_vertex (weight >= 0.7 per weight_sampler.py)
+    metrics: Mapping[str, float]                      # e.g. {"eval/uncheatable_eval/bpb": ...}
+
+def load_qsplit240(expected_missing: Collection[str] = ()) -> list[SwarmRun]:
+    """Load all qsplit240 histories. Runs with missing/incomplete required fields fail loudly:
+    the loader raises listing the offending run_ids unless they appear in `expected_missing`."""
+```
+
+Exposure features are **derived**, not stored, and are split into two families (see below): per-domain
+epochs/exposure are computable from `domain_tokens` + `BucketStats.total_tokens_available`.
+
+## Featurization (`featurize.py`)
+
+Pure functions; no I/O.
+
+```python
+class FeatureFamily(StrEnum):
+    HIST_K40 = "hist_k40"                  # primary granularity
+    HIST_K1000 = "hist_k1000"              # ablation, smoothness-regularized models only
+    HIST_K5000 = "hist_k5000"              # ablation/stress only
+    KME_MEAN = "kme_mean"                  # mass-weighted mean of dequantized centroid vectors (192 dims)
+    RFF_MEAN = "rff_mean"                  # cluster-free arm: token-weighted mean of random Fourier
+                                           # features of raw document embeddings (dim 2048, median-heuristic
+                                           # bandwidth on the codebook training sample, seed 0; all three
+                                           # recorded in _meta.json). Bypasses the k-means codebook.
+    QUALITY_MASS = "quality_mass"          # mass per quality bucket; locked until the scorer audit passes
+    BUCKET_STATS = "bucket_stats"          # mixture-weighted BucketStats scalars
+    EXPOSURE_GLOBAL = "exposure_global"    # transferable: model_size, phase_tokens, per-cell exposure
+    EXPOSURE_BUCKET = "exposure_bucket"    # bucket-indexed per-domain epochs; DIAGNOSTIC-CEILING ONLY,
+                                           # never valid in a transfer model (leaks bucket identity)
+
+def composition_matrix(histograms: Sequence[DomainHistogram], k: int) -> tuple[np.ndarray, list[str]]:
+    """Stack per-domain fracs into V of shape (cells, n_domains) at granularity k (coarsened from
+    K=5000 via the basis views when k < 5000). Raises BasisMismatchError on basis disagreement.
+    Column order = sorted(domain). Also returns rank/condition diagnostics via .diagnostics on the
+    returned array wrapper (numerical rank, singular spectrum) — H1 consumes these."""
+
+def mixture_histogram(weights: Mapping[str, float], v: np.ndarray, domain_order: list[str]) -> np.ndarray:
+    """h = V @ w. Missing domains get weight 0; raises ValueError on unknown domain or if weights
+    do not sum to 1 (atol 1e-6)."""
+
+def run_features(
+    run: SwarmRun,
+    histograms: Sequence[DomainHistogram],
+    families: Sequence[FeatureFamily],
+    per_phase: bool = True,
+) -> np.ndarray:
+    """Concatenate the requested families. Histogram families are per-phase and concatenated when
+    per_phase; else computed on the phase-token-weighted average mixture (from run.phase_tokens).
+    Deterministic ordering: families as given, cells in index order, phases in order."""
+```
+
+**Control featurizations** (mandatory wherever a semantic result is claimed):
+
+```python
+def shuffled_columns_v(v: np.ndarray, seed: int) -> np.ndarray
+    """Permute the domain -> histogram-column mapping. Destroys semantic alignment, preserves
+    marginal geometry."""
+
+def matched_random_v(v: np.ndarray, seed: int) -> np.ndarray
+    """Random V with matched rank and singular spectrum. Destroys content, preserves conditioning."""
+```
+
+## H2a — domain response from content (`domain_response.py`)
+
+```python
+@dataclass(frozen=True)
+class DomainResponse:
+    """Per-domain, per-phase marginal-value/saturation parameters extracted from the sweep with the
+    incumbent DSP/GRP structure, with bootstrap uncertainty."""
+    domain: str
+    phase: int
+    params: Mapping[str, float]
+    params_se: Mapping[str, float]
+
+def fit_domain_responses(runs: Sequence[SwarmRun], target_metric: str, model_size: int, seed: int = 0) -> list[DomainResponse]
+
+def lodo_response_prediction(
+    responses: Sequence[DomainResponse],
+    histograms: Sequence[DomainHistogram],
+    holdout_domain: str,
+    featurization: Literal["semantic", "shuffled", "matched_random", "cluster_free"],
+    seed: int = 0,
+) -> Mapping[str, float]:
+    """Predict holdout_domain's response params from its content features using the other 38 domains.
+    "cluster_free" uses RFF_MEAN features (codebook-bypassing); the other three use clustered
+    histograms. The H2a headline: predicted-vs-fit correlation (uncertainty-weighted) for semantic vs
+    control featurizations across all 39 folds, reported for both arms. Gate: if neither the semantic
+    clustered arm nor the cluster-free arm beats both controls with CI separation, H2b does not run.
+    Kill rule (pre-committed, see design.md): a negative gate under one MixtureBasis is inconclusive;
+    abandoning the premise requires the gate to fail under a second basis (different embedder) as
+    well."""
+```
+
+## H2b — held-out-dose retrodiction (`retrodiction.py`)
+
+The estimand is **held-out-dose extrapolation** (train where domain k's dose ≈ 0, test where it
+dominates), *not* zero-shot new-domain prediction. Featurization is always the full, physically
+correct `V·w` — no column dropping.
+
+```python
+class PhaseReducer(StrEnum):
+    MAX = "max"                        # dose(run, k) = max over phases of w_k (default)
+    TOKEN_WEIGHTED = "token_weighted"  # phase-token-weighted mean of w_k
+
+@dataclass(frozen=True)
+class DoseSplit:
+    holdout_domain: str
+    model_size: int                # splits are per-scale; pooling scales is a contract violation
+    phase_reducer: PhaseReducer = PhaseReducer.MAX
+    train_max_dose: float = 0.02   # absolute dose threshold for train membership (not a quantile)
+    test_min_dose: float = 0.30    # test = runs above this, plus vertex runs with vertex_domain == k
+    # The band between the thresholds is intentionally discarded; sensitivity over
+    # train_max_dose in {0.01, 0.02, 0.05} is part of the standard report.
+
+class PredictorKind(StrEnum):
+    HIST_RIDGE_K40 = "hist_ridge_k40"      # ridge on K=40 cells (+EXPOSURE_GLOBAL), primary
+    KERNEL_HELLINGER = "kernel_hellinger"  # dual kernel ridge on per-phase Hellinger distances, primary
+    KME_RIDGE = "kme_ridge"                # ridge on 192-dim mean embeddings (the theory-backed object)
+    RFF_RIDGE = "rff_ridge"                # ridge on RFF mean maps (≈ MMD-kernel regression), cluster-free primary
+    WEIGHTS_LGBM = "weights_lgbm"          # LightGBM on raw weights (+EXPOSURE_GLOBAL): the incumbent
+    HIST_LGBM_K5000 = "hist_lgbm_k5000"    # stress ablation only
+    MEAN_BASELINE = "mean_baseline"        # predicts the train-set mean metric (null floor)
+    NN_HIST = "nn_hist"                    # 1-NN in Hellinger distance (cheap non-parametric floor)
+
+@dataclass(frozen=True)
+class RetrodictionResult:
+    split: DoseSplit
+    n_train: int
+    n_test: int
+    spearman: Mapping[str, float]          # key = f"{predictor}:{featurization}" over {semantic, shuffled, matched_random}
+    spearman_ci: Mapping[str, tuple[float, float]]   # paired bootstrap 95% CI vs HIST_RIDGE_K40:semantic
+    content_novelty: float                 # distance of V_k to the convex cone of V_{-k} (Hellinger geometry)
+    design_support: tuple[float, ...]      # per-test-run distance to the convex hull of train feature vectors
+    derivability_r2: float                 # mean R^2 predicting train h from train w (linear) — expected ~1, reported for honesty
+    predictions_path: str                  # parquet of per-run predictions for every predictor
+```
+
+Contracts: all predictors fit on identical train rows and scored on identical test rows;
+hyperparameters chosen by nested CV *inside train only*; `target_metric` direction is bpb
+(lower-is-better) and `spearman` is computed on (-metric) so higher = better everywhere;
+`run_retrodiction(...)` raises ValueError if `n_test < 20` or `n_train < 60`.
+
+```python
+def enumerate_splits(runs: Sequence[SwarmRun], candidate_domains: Sequence[str]) -> pd.DataFrame:
+    """Feasibility table (n_train/n_test per domain x scale x reducer x thresholds). MUST be
+    generated and committed to the results prefix before any model fit; the pre-registered
+    eligible-domain list is derived from it without reference to outcomes."""
+```
+
+Driver `run_retrodiction_suite.py` executes the pre-registered grid and writes one row per
+`RetrodictionResult` to `gs://marin-eu-west4/datakit/mixture_features/v0/retrodiction/results.parquet`
+(flattened + `families`, `k`, `target_metric`, git SHA), plus the W&B report.
+
+## Errors
+
+- `BasisMismatchError(ValueError)` — combining histograms/features under unequal `MixtureBasis`
+  (including tokenizer).
+- `InsufficientSampleError(ValueError)` — domain yielded < 10k sampled documents.
+- `ValueError` — unknown domain in weights; weights not a distribution; infeasible split
+  (`n_test < 20` / `n_train < 60`); pooled `model_size` in one split.
+- W&B loader fails loudly listing dropped run ids; `expected_missing` is the only silence mechanism.
+
+## File map
+
+| path | contents |
+|---|---|
+| `experiments/datakit/mixture_features/build_domain_histograms.py` | zephyr job: sample → embed → assign → token-weighted V columns + BucketStats |
+| `experiments/datakit/mixture_features/featurize.py` | `MixtureBasis`, `DomainHistogram`, `FeatureFamily`, `composition_matrix`, `mixture_histogram`, `run_features`, control featurizations |
+| `experiments/datakit/mixture_features/swarm_runs.py` | `SwarmRun`, `load_qsplit240` |
+| `experiments/datakit/mixture_features/domain_response.py` | H2a: `DomainResponse`, `fit_domain_responses`, `lodo_response_prediction` |
+| `experiments/datakit/mixture_features/retrodiction.py` | H2b: `DoseSplit`, `PredictorKind`, `RetrodictionResult`, `enumerate_splits`, predictor fits |
+| `experiments/datakit/mixture_features/run_retrodiction_suite.py` | driver: pre-registered grid, results parquet, W&B report |
+| `tests/datakit/mixture_features/` | featurization algebra, synthetic recovery (incl. must-fail cases), control tests |
+| `gs://marin-eu-west4/datakit/mixture_features/v0/` | `domain_histograms/`, `_meta.json`, `retrodiction/results.parquet`, `retrodiction/feasibility.parquet` |
+
+## Out of scope
+
+- Any change to production mixtures, the datakit store layout, or `domains.py`.
+- Scale-transfer modeling (results are per-scale; 60M→300M anchoring stays as-is).
+- Training or selecting a new embedder (hill-climb thread owns that; a basis bump re-runs
+  `build_domain_histograms.py` under a new `MixtureBasis`).
+- Online/in-run mixing methods (Aioli/R&B-style) and pointwise selection (MATES thread).
+- Merging or modifying PR #2393.
+- H3 launch configs. Note the category distinction H3 must respect: Olmix-style reuse and
+  token-proportional are mixture *proposers*, not metric predictors — they are compared by realized
+  metric / policy regret of proposed mixtures (specified after H2 results), never by `spearman` on
+  arbitrary test runs.

--- a/.agents/projects/mixing_via_embeddings/spec.md
+++ b/.agents/projects/mixing_via_embeddings/spec.md
@@ -87,7 +87,7 @@ class BucketStats:
 ```
 
 **Persisted shape** — parquet at
-`gs://marin-eu-west4/datakit/mixture_features/v0/domain_histograms/part-<domain>.parquet` with columns
+`gs://marin-eu-west4/user/rav/projects/mixing_via_embeddings/v0/domain_histograms/part-<domain>.parquet` with columns
 `domain` (string), `cluster_id` (int32), `quality_bucket` (int8, -1 when absent), `token_count`
 (int64), `frac` (float64). Sidecar `_meta.json` per prefix: the full `MixtureBasis` (with hashes),
 per-domain `sample_size`/`seed`/`token_count`/`BucketStats`, `created_at`, git SHA of the producing
@@ -266,7 +266,7 @@ def enumerate_splits(runs: Sequence[SwarmRun], candidate_domains: Sequence[str])
 ```
 
 Driver `run_retrodiction_suite.py` executes the pre-registered grid and writes one row per
-`RetrodictionResult` to `gs://marin-eu-west4/datakit/mixture_features/v0/retrodiction/results.parquet`
+`RetrodictionResult` to `gs://marin-eu-west4/user/rav/projects/mixing_via_embeddings/v0/retrodiction/results.parquet`
 (flattened + `families`, `k`, `target_metric`, git SHA), plus the W&B report.
 
 ## Errors
@@ -289,7 +289,7 @@ Driver `run_retrodiction_suite.py` executes the pre-registered grid and writes o
 | `experiments/datakit/mixture_features/retrodiction.py` | H2b: `DoseSplit`, `PredictorKind`, `RetrodictionResult`, `enumerate_splits`, predictor fits |
 | `experiments/datakit/mixture_features/run_retrodiction_suite.py` | driver: pre-registered grid, results parquet, W&B report |
 | `tests/datakit/mixture_features/` | featurization algebra, synthetic recovery (incl. must-fail cases), control tests |
-| `gs://marin-eu-west4/datakit/mixture_features/v0/` | `domain_histograms/`, `_meta.json`, `retrodiction/results.parquet`, `retrodiction/feasibility.parquet` |
+| `gs://marin-eu-west4/user/rav/projects/mixing_via_embeddings/v0/` | `domain_histograms/`, `_meta.json`, `retrodiction/results.parquet`, `retrodiction/feasibility.parquet` |
 
 ## Out of scope
 


### PR DESCRIPTION
Our data-mixture surrogates (DSP/GRP/LightGBM on the ~242-run qsplit240 swarm, PR #2393) take bucket-indexed weight vectors, so every bucket redefinition — quality relabel (#6739), domain re-clustering (#6491), new sources — strands the sweep and forces new near-full-length proxy runs. This design re-featurizes a mixture as the token-weighted histogram it induces over the frozen datakit micro-cluster basis (h = V·w), making the surrogate defined for any bucket whose contents we can embed: adding or redefining buckets then costs one map-only embedding job instead of a re-sweep. Validation is retrodictive on the existing swarm runs with zero new proxy training — an information audit (H1), a content→domain-value LODO gate (H2a), and held-out-dose retrodiction (H2b), each judged by semantic-V-vs-shuffled/matched-random controls, with a mandatory cluster-free (RFF/MMD) arm and a pre-committed two-basis kill rule so a bad codebook cannot masquerade as a refuted premise.

- [design.md](https://github.com/marin-community/marin/blob/design/mixing_via_embeddings/.agents/projects/mixing_via_embeddings/design.md)
- [research.md](https://github.com/marin-community/marin/blob/design/mixing_via_embeddings/.agents/projects/mixing_via_embeddings/research.md)
- [spec.md](https://github.com/marin-community/marin/blob/design/mixing_via_embeddings/.agents/projects/mixing_via_embeddings/spec.md)

Discussion welcome — see Open Questions in `design.md`.