### PR TITLE
ducky: metadata-based cross-region read guard; collapse examples

### DIFF
--- a/.github/workflows/ducky-deploy.yaml
+++ b/.github/workflows/ducky-deploy.yaml
@@ -35,7 +35,7 @@ on:
       result_ttl_days:
         description: "DUCKY_RESULT_TTL_DAYS (default: 7)"
       allowed_buckets:
-        description: "DUCKY_ALLOWED_BUCKETS, comma-separated read allowlist prefixes (default: gs://marin-us-east,s3://marin-na,s3://marin-us-east-02a)"
+        description: "DUCKY_ALLOWED_BUCKETS, comma-separated readable prefixes (default: gs://marin-,s3://marin-). Cross-region GCS reads among these need a '-- cross-region: allow' comment; S3 is always allowed."
       r2_endpoint:
         description: "DUCKY_R2_ENDPOINT, host only (default: 74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com)"
       cw_endpoint:
@@ -66,7 +66,12 @@ jobs:
       DEF_MEMORY: "690GB"
       DEF_SCRATCH_BUCKET: "gs://marin-us-east5/tmp/ttl=7d"
       DEF_RESULT_TTL_DAYS: "7"
-      DEF_ALLOWED_BUCKETS: "gs://marin-us-east,s3://marin-na,s3://marin-us-east-02a"
+      # Outer read bound: any marin bucket on either backend (gs://marin-* and the s3://marin-*
+      # R2/CoreWeave stores). This is region-agnostic — whether an allowed *GCS* read is
+      # cross-region is decided at query time from live bucket-location metadata
+      # (rigging.filesystem.is_cross_region_url) and gated by a `-- cross-region: allow` comment;
+      # S3 reads are never cross-region-gated. So this default needs no per-region tuning.
+      DEF_ALLOWED_BUCKETS: "gs://marin-,s3://marin-"
       DEF_R2_ENDPOINT: "74981a43be0de7712369306c7b19133d.r2.cloudflarestorage.com"
       DEF_CW_ENDPOINT: "cwobject.com"
       DEF_CW_ACCESS_KEY: "CWXSLOAORRUJOJKH"

--- a/lib/ducky/README.md
+++ b/lib/ducky/README.md
@@ -137,8 +137,15 @@ never appear literally in the SQL), and a literal `read_parquet` of a configured
 so the view and the literal read behave identically. An empty `DUCKY_ALLOWED_BUCKETS` disables
 enforcement entirely (allow-all), which also makes the cross-region gate inert. Because region
 is resolved from live metadata, no per-region tuning of the allowlist is needed when ducky is
-deployed to a different region; off-GCP (local smoke) the region is unknown, so nothing is
-cross-region-gated and only the outer allowlist applies.
+deployed to a different region.
+
+The gate **fails closed**: on a GCP VM, if a bucket's location can't be resolved (e.g. the
+service account lacks `storage.buckets.get`, or a transient metadata failure), the read is
+treated as cross-region and requires the opt-in — a metadata failure can't silently bypass the
+gate. Only off-GCP (local smoke), where there is no VM region to compare against, is region
+gating skipped entirely, leaving just the outer allowlist. So the deployed task's service
+account needs `storage.buckets.get` on the marin buckets, or every GCS read will demand the
+opt-in comment.
 
 Views are bound (and their parquet footers cached) at startup; a view over an
 absent/unreachable dataset is logged and skipped rather than failing the service. The

--- a/lib/ducky/README.md
+++ b/lib/ducky/README.md
@@ -104,9 +104,41 @@ Configuring a catalog root **declares that prefix readable**: the roots join
 literal `read_parquet` of the same prefix behave identically (a view can't reach a bucket a
 literal URI couldn't). This is how finelog stays queryable even though it lives in
 us-central2, cross-region from a us-east5 ducky — the egress is a deliberate choice encoded
-in `finelog_root`, not a silent bypass, and *other* buckets in that region stay gated. To
-avoid the finelog egress entirely, set `DUCKY_FINELOG_ROOT=` (empty) or point it at a
-same-region copy. (An empty `DUCKY_ALLOWED_BUCKETS` still means allow-all.)
+in `finelog_root`, not a silent bypass. To avoid the finelog egress entirely, set
+`DUCKY_FINELOG_ROOT=` (empty) or point it at a same-region copy. (An empty
+`DUCKY_ALLOWED_BUCKETS` still means allow-all.)
+
+### Cross-region reads are opt-in
+
+Read access on the literal URIs in a query is enforced in two stages:
+
+- **`DUCKY_ALLOWED_BUCKETS`** is the outer bound — the prefixes ducky may read at all
+  (default `gs://marin-,s3://marin-`, i.e. any marin GCS bucket plus the R2/CoreWeave S3
+  stores). A URI outside it is hard-refused.
+- Among the allowed URIs, whether a **GCS** read is same-region or egress-costly cross-region
+  is decided at query time by `rigging.filesystem.is_cross_region_url`, which compares the
+  bucket's live GCS location metadata against this VM's region (multi-region aware, and
+  honoring the `MARIN_I_WILL_PAY_FOR_ALL_FEES` override). A cross-region GCS read must **opt
+  in** with a leading comment:
+
+  ```sql
+  -- cross-region: allow
+  select count(*) from read_parquet('gs://marin-us-central2/some/data/*.parquet');
+  ```
+
+  Without the comment the query is refused with a message telling you to add it. The directive
+  must sit in the query's leading comment block (before the first statement line); `cross
+  region` and `allowed` are accepted too.
+
+**S3 reads (R2/CoreWeave) are never cross-region-gated** — rigging models GCS regions only, so
+any allowed `s3://` URI is read freely. Pre-baked catalog views bypass the opt-in (their URIs
+never appear literally in the SQL), and a literal `read_parquet` of a configured catalog root
+(`finelog_root`/`datakit_root`) is likewise exempt — that egress is a deliberate config choice,
+so the view and the literal read behave identically. An empty `DUCKY_ALLOWED_BUCKETS` disables
+enforcement entirely (allow-all), which also makes the cross-region gate inert. Because region
+is resolved from live metadata, no per-region tuning of the allowlist is needed when ducky is
+deployed to a different region; off-GCP (local smoke) the region is unknown, so nothing is
+cross-region-gated and only the outer allowlist applies.
 
 Views are bound (and their parquet footers cached) at startup; a view over an
 absent/unreachable dataset is logged and skipped rather than failing the service. The
@@ -133,9 +165,10 @@ Replaces a running instance by default; `--keep` makes it an idempotent watchdog
 
 ## Notes
 
-- ducky reads only object-store URIs on the bucket allowlist (`DUCKY_ALLOWED_BUCKETS`);
-  local-file access is blocked. Queries against buckets outside the allowlist are refused
-  before execution.
+- ducky reads only object-store URIs on the bucket allowlist (`DUCKY_ALLOWED_BUCKETS`); local-file
+  access is blocked. Queries against buckets outside it are refused before execution, and
+  cross-region GCS reads among the allowed buckets need a `-- cross-region: allow` opt-in comment
+  (see above).
 - A datakit **clustered-store** bucket (`…/cluster=C/quality=Q/`) holds levanter
   `JaggedArrayStore` (zarr) caches, not parquet — `read_parquet` finds nothing there. Query
   the upstream parquet attribute datasets instead.

--- a/lib/ducky/dashboard/src/components/Catalog.vue
+++ b/lib/ducky/dashboard/src/components/Catalog.vue
@@ -19,6 +19,8 @@ const emit = defineEmits<{ select: [string] }>()
 const views = ref<CatalogView[]>([])
 const examples = ref<CatalogExample[]>([])
 const open = ref(true)
+// Examples are collapsed by default (they're a long list); expand to browse them.
+const examplesOpen = ref(false)
 
 // Group views by their schema (finelog, datakit, …) so the panel reads as one block per
 // data source rather than a flat list.
@@ -72,8 +74,14 @@ onMounted(async () => {
       </div>
 
       <div v-if="examples.length" class="flex flex-col gap-1.5">
-        <h3 class="text-xs font-semibold uppercase tracking-wide text-text-muted">Example queries</h3>
-        <div class="flex flex-wrap gap-1.5">
+        <button
+          class="flex items-center gap-1 text-xs font-semibold uppercase tracking-wide text-text-muted hover:text-text-secondary"
+          @click="examplesOpen = !examplesOpen"
+        >
+          <span>{{ examplesOpen ? '▾' : '▸' }}</span>
+          <span>Example queries</span>
+        </button>
+        <div v-if="examplesOpen" class="flex flex-wrap gap-1.5">
           <button
             v-for="example in examples"
             :key="example.title"

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -82,9 +82,12 @@ class DuckyConfig:
     """Prefix where full results spill (``gs://…`` in prod, a local dir for smoke). Carries a lifecycle TTL rule."""
 
     allowed_buckets: tuple[str, ...] = ()
-    """Object-store URI prefixes a query may read, e.g. ``("gs://marin-us-east5", "r2://")``.
-    A query referencing a ``gs://``/``s3://``/``r2://`` URI outside the allowlist is refused
-    before execution — the same-region guardrail. Empty disables enforcement (allow all).
+    """Object-store URI prefixes a query may read at all, e.g. ``("gs://marin-", "s3://marin-")``
+    — the outer bound that keeps queries on marin buckets. A URI outside it is refused before
+    execution. Whether an *allowed* GCS URI is same-region or egress-costly cross-region is a
+    separate decision made at query time by :func:`rigging.filesystem.is_cross_region_url`
+    (live bucket-location metadata), gated by the ``-- cross-region: allow`` opt-in comment; S3
+    URIs (R2/CoreWeave) are never cross-region-gated. Empty disables enforcement (allow all).
     Catches literal URIs in the SQL, not paths hidden behind views/macros."""
 
     # Optional per-backend credentials. A backend is enabled only when its full set is present.
@@ -146,6 +149,13 @@ class DuckyConfig:
     """Informational — enforced by the scratch bucket's lifecycle rule, not by ducky (ducky only writes)."""
 
     @property
+    def catalog_root_prefixes(self) -> tuple[str, ...]:
+        """The configured catalog roots (``finelog_root``/``datakit_root``). These are a
+        deliberate always-on egress, so a literal ``read_parquet`` of a root is exempt from the
+        cross-region opt-in — it behaves like the pre-baked view over the same prefix."""
+        return tuple(root for root in (self.finelog_root, self.datakit_root) if root)
+
+    @property
     def effective_allowed_buckets(self) -> tuple[str, ...]:
         """Object-store prefixes a query may read: the configured allowlist plus the catalog
         roots. Configuring a catalog root (``finelog_root``/``datakit_root``) declares that
@@ -155,8 +165,7 @@ class DuckyConfig:
         restrictive list)."""
         if not self.allowed_buckets:
             return ()
-        roots = tuple(root for root in (self.finelog_root, self.datakit_root) if root)
-        return self.allowed_buckets + roots
+        return self.allowed_buckets + self.catalog_root_prefixes
 
     @property
     def gcs_enabled(self) -> bool:

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -24,9 +24,11 @@ import re
 import shutil
 import threading
 import time
+from collections.abc import Callable
 
 import duckdb
 from iris.env_resources import TaskResources
+from rigging.filesystem import is_cross_region_url
 
 from ducky.catalog import DATAKIT_SCHEMA, FINELOG_SCHEMA, View, build_catalog
 from ducky.config import DuckyConfig
@@ -40,10 +42,37 @@ _QUERY_ID_RE = re.compile(r"^[0-9a-f]{32}$")
 # closing quote/paren/whitespace of the SQL literal.
 _OBJECT_URI_RE = re.compile(r"""(?:gs|s3|r2)://[^\s'")]+""", re.IGNORECASE)
 
+# The opt-in directive for reading cross-region buckets: a leading SQL line comment such as
+# `-- cross-region: allow`. Accepts `cross-region`/`cross region` and `allow`/`allowed`.
+_CROSS_REGION_DIRECTIVE_RE = re.compile(r"^\s*--\s*cross[- ]region\s*:?\s*allow(ed)?\b", re.IGNORECASE)
+
+
+def _opts_in_cross_region(sql: str) -> bool:
+    """True if the SQL's leading comment block opts in to cross-region reads.
+
+    Only the header is scanned — the run of blank/``--`` comment lines before the first
+    statement line — so the directive can't hide inside a string literal further down.
+    """
+    for line in sql.splitlines():
+        stripped = line.strip()
+        if not stripped:
+            continue
+        if not stripped.startswith("--"):
+            return False  # first real statement line ends the header
+        if _CROSS_REGION_DIRECTIVE_RE.match(line):
+            return True
+    return False
+
 
 def _object_uris(sql: str) -> list[str]:
     """Distinct gs://, s3://, r2:// URIs referenced literally in the SQL (order-preserving)."""
     return list(dict.fromkeys(_OBJECT_URI_RE.findall(sql)))
+
+
+def _is_gcs_uri(uri: str) -> bool:
+    """True for a ``gs://``/``gcs://`` URI. Only GCS is subject to the cross-region guard —
+    the S3 backends (R2, CoreWeave) are region-agnostic to us and always allowed."""
+    return uri.lower().startswith(("gs://", "gcs://"))
 
 
 def _is_allowed(uri: str, allowed: tuple[str, ...]) -> bool:
@@ -63,6 +92,47 @@ def disallowed_uris(sql: str, allowed: tuple[str, ...]) -> list[str]:
     return [uri for uri in _object_uris(sql) if not _is_allowed(uri, allowed)]
 
 
+def check_query_access(
+    sql: str,
+    allowed: tuple[str, ...],
+    exempt_prefixes: tuple[str, ...],
+    is_cross_region: Callable[[str], bool],
+) -> None:
+    """Raise if ``sql`` references object-store URIs it may not read.
+
+    ``allowed`` is the outer bound — the object-store prefixes ducky may read at all (marin
+    buckets on either backend). A URI outside it is hard-refused. Among the allowed URIs, a
+    *GCS* URI that ``is_cross_region`` reports lives in a different region than this VM is
+    egress-costly, so it's read only when the query opts in with a leading ``-- cross-region:
+    allow`` comment. S3 URIs (R2/CoreWeave) are never cross-region-gated. ``exempt_prefixes``
+    (the configured catalog roots) are deliberate always-on egress and skip the opt-in, so a
+    literal read of a root behaves like its pre-baked view. An empty ``allowed`` disables all
+    enforcement (allow-all).
+
+    ``is_cross_region`` is injected (:func:`rigging.filesystem.is_cross_region_url` in prod) so
+    the region decision uses live GCS bucket-location metadata rather than a naming convention;
+    off-GCP it reports everything same-region, leaving only the outer allowlist in force.
+
+    :raises BucketNotAllowedError: a URI is outside ``allowed``.
+    :raises CrossRegionNotAllowedError: a cross-region GCS URI wasn't opted in.
+    """
+    if not allowed:
+        return
+    uris = _object_uris(sql)
+    forbidden = [uri for uri in uris if not _is_allowed(uri, allowed)]
+    if forbidden:
+        raise BucketNotAllowedError(
+            f"query references buckets outside the allowlist: {', '.join(forbidden)}; "
+            f"allowed prefixes: {', '.join(allowed)}"
+        )
+    cross = [uri for uri in uris if _is_gcs_uri(uri) and not _is_allowed(uri, exempt_prefixes) and is_cross_region(uri)]
+    if cross and not _opts_in_cross_region(sql):
+        raise CrossRegionNotAllowedError(
+            f"query reads cross-region buckets: {', '.join(cross)}; "
+            f"add a leading '-- cross-region: allow' comment to opt in to the egress"
+        )
+
+
 class DuckyError(Exception):
     """Base for ducky errors surfaced to the dashboard as a clean message."""
 
@@ -72,11 +142,21 @@ class QueryError(DuckyError):
 
 
 class BucketNotAllowedError(DuckyError):
-    """The query references an object-store URI outside the configured allowlist.
+    """The query references an object-store URI outside every configured allowlist.
 
-    This is ducky's same-region guardrail: GCS HMAC keys are region-agnostic, so the
-    only way to keep queries in-region (avoiding cross-region egress) is to refuse
-    URIs whose bucket isn't allowlisted. Raised before any execution.
+    This is ducky's egress guardrail: GCS HMAC keys are region-agnostic, so the only way to
+    bound what a query can read (and avoid unexpected cross-region/cross-cloud egress) is to
+    refuse URIs whose bucket isn't allowlisted. Raised before any execution.
+    """
+
+
+class CrossRegionNotAllowedError(DuckyError):
+    """The query reads a cross-region GCS bucket without opting in.
+
+    The referenced bucket lives in a different region than this VM (per
+    :func:`rigging.filesystem.is_cross_region_url`) — reachable, but egress-costly — and the
+    query lacks the leading ``-- cross-region: allow`` comment. Raised before execution; the
+    user opts in by adding the comment.
     """
 
 
@@ -265,12 +345,12 @@ class QueryRunner:
         if not _QUERY_ID_RE.match(query_id):
             raise ValueError(f"query_id must be a uuid4 hex, got {query_id!r}")
 
-        blocked = disallowed_uris(sql, self._config.effective_allowed_buckets)
-        if blocked:
-            raise BucketNotAllowedError(
-                f"query references buckets outside the allowlist: {', '.join(blocked)}; "
-                f"allowed prefixes: {', '.join(self._config.effective_allowed_buckets)}"
-            )
+        check_query_access(
+            sql,
+            self._config.effective_allowed_buckets,
+            self._config.catalog_root_prefixes,
+            is_cross_region_url,
+        )
 
         result_path = f"{self._config.scratch_bucket.rstrip('/')}/ducky/{query_id}.parquet"
         path_literal = _sql_literal(result_path)

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -25,10 +25,16 @@ import shutil
 import threading
 import time
 from collections.abc import Callable
+from functools import lru_cache
 
 import duckdb
 from iris.env_resources import TaskResources
-from rigging.filesystem import is_cross_region_url
+from rigging.filesystem import (
+    MARIN_CROSS_REGION_OVERRIDE_ENV,
+    get_bucket_location,
+    is_cross_region_url,
+    marin_region,
+)
 
 from ducky.catalog import DATAKIT_SCHEMA, FINELOG_SCHEMA, View, build_catalog
 from ducky.config import DuckyConfig
@@ -75,6 +81,60 @@ def _is_gcs_uri(uri: str) -> bool:
     return uri.lower().startswith(("gs://", "gcs://"))
 
 
+# Buckets whose GCS location we've successfully resolved once — cached so a same-region read
+# doesn't re-probe metadata every query. Only *successes* are cached: a failed lookup retries
+# so a transient blip can't wedge a bucket into fail-closed for the whole process lifetime.
+_region_confirmed_buckets: set[str] = set()
+
+
+@lru_cache(maxsize=1)
+def _vm_region() -> str | None:
+    """This VM's region (from GCP metadata), cached for the process. ``None`` off-GCP."""
+    return marin_region()
+
+
+def _gcs_bucket(uri: str) -> str | None:
+    """Bucket name from a ``gs://``/``gcs://`` URI, else ``None``."""
+    for scheme in ("gs://", "gcs://"):
+        if uri.lower().startswith(scheme):
+            return uri[len(scheme) :].split("/", 1)[0]
+    return None
+
+
+def _region_resolvable(bucket: str) -> bool:
+    """Whether ``bucket``'s GCS location metadata is readable. Successes are cached; failures
+    retry (not cached) so a transient error or permission blip self-heals."""
+    if bucket in _region_confirmed_buckets:
+        return True
+    try:
+        get_bucket_location(bucket)
+    except Exception:
+        return False
+    _region_confirmed_buckets.add(bucket)
+    return True
+
+
+def needs_cross_region_optin(uri: str) -> bool:
+    """Whether reading GCS ``uri`` requires the ``-- cross-region: allow`` opt-in.
+
+    Fails closed on uncertainty. A GCS URI needs the opt-in if it's confirmed cross-region by
+    :func:`rigging.filesystem.is_cross_region_url`, or — on a GCP VM — if we cannot resolve the
+    bucket's region at all, so a missing ``storage.buckets.get`` permission or a metadata lookup
+    failure can't silently bypass the gate (``is_cross_region_url`` returns ``False`` on such
+    failures). Off-GCP (no VM region) region gating doesn't apply and the fee override disables
+    it, so both return ``False``.
+    """
+    if is_cross_region_url(uri):
+        return True
+    if _vm_region() is None or os.environ.get(MARIN_CROSS_REGION_OVERRIDE_ENV):
+        return False
+    bucket = _gcs_bucket(uri)
+    if bucket is None or _region_resolvable(bucket):
+        return False
+    logger.warning("cross-region guard: could not resolve region for gs://%s; requiring opt-in", bucket)
+    return True
+
+
 def _is_allowed(uri: str, allowed: tuple[str, ...]) -> bool:
     """True if ``uri`` starts with any allowlist entry.
 
@@ -96,25 +156,25 @@ def check_query_access(
     sql: str,
     allowed: tuple[str, ...],
     exempt_prefixes: tuple[str, ...],
-    is_cross_region: Callable[[str], bool],
+    needs_opt_in: Callable[[str], bool],
 ) -> None:
     """Raise if ``sql`` references object-store URIs it may not read.
 
     ``allowed`` is the outer bound — the object-store prefixes ducky may read at all (marin
     buckets on either backend). A URI outside it is hard-refused. Among the allowed URIs, a
-    *GCS* URI that ``is_cross_region`` reports lives in a different region than this VM is
-    egress-costly, so it's read only when the query opts in with a leading ``-- cross-region:
-    allow`` comment. S3 URIs (R2/CoreWeave) are never cross-region-gated. ``exempt_prefixes``
-    (the configured catalog roots) are deliberate always-on egress and skip the opt-in, so a
-    literal read of a root behaves like its pre-baked view. An empty ``allowed`` disables all
-    enforcement (allow-all).
+    *GCS* URI for which ``needs_opt_in`` returns True is egress-costly (cross-region, or a
+    region we couldn't confirm), so it's read only when the query opts in with a leading
+    ``-- cross-region: allow`` comment. S3 URIs (R2/CoreWeave) are never cross-region-gated.
+    ``exempt_prefixes`` (the configured catalog roots) are deliberate always-on egress and skip
+    the opt-in, so a literal read of a root behaves like its pre-baked view. An empty
+    ``allowed`` disables all enforcement (allow-all).
 
-    ``is_cross_region`` is injected (:func:`rigging.filesystem.is_cross_region_url` in prod) so
-    the region decision uses live GCS bucket-location metadata rather than a naming convention;
-    off-GCP it reports everything same-region, leaving only the outer allowlist in force.
+    ``needs_opt_in`` is injected (:func:`needs_cross_region_optin` in prod) so the region
+    decision uses live GCS bucket-location metadata rather than a naming convention, and fails
+    closed when the region can't be resolved.
 
     :raises BucketNotAllowedError: a URI is outside ``allowed``.
-    :raises CrossRegionNotAllowedError: a cross-region GCS URI wasn't opted in.
+    :raises CrossRegionNotAllowedError: a cross-region (or region-unconfirmed) GCS URI wasn't opted in.
     """
     if not allowed:
         return
@@ -128,7 +188,7 @@ def check_query_access(
     cross = [
         uri
         for uri in _object_uris(sql)
-        if _is_gcs_uri(uri) and not _is_allowed(uri, exempt_prefixes) and is_cross_region(uri)
+        if _is_gcs_uri(uri) and not _is_allowed(uri, exempt_prefixes) and needs_opt_in(uri)
     ]
     if cross and not _opts_in_cross_region(sql):
         raise CrossRegionNotAllowedError(
@@ -155,12 +215,12 @@ class BucketNotAllowedError(DuckyError):
 
 
 class CrossRegionNotAllowedError(DuckyError):
-    """The query reads a cross-region GCS bucket without opting in.
+    """The query reads an egress-costly GCS bucket without opting in.
 
-    The referenced bucket lives in a different region than this VM (per
-    :func:`rigging.filesystem.is_cross_region_url`) — reachable, but egress-costly — and the
-    query lacks the leading ``-- cross-region: allow`` comment. Raised before execution; the
-    user opts in by adding the comment.
+    The referenced bucket lives in a different region than this VM, or (failing closed) its
+    region couldn't be confirmed — see :func:`needs_cross_region_optin` — and the query lacks
+    the leading ``-- cross-region: allow`` comment. Raised before execution; the user opts in by
+    adding the comment.
     """
 
 
@@ -353,7 +413,7 @@ class QueryRunner:
             sql,
             self._config.effective_allowed_buckets,
             self._config.catalog_root_prefixes,
-            is_cross_region_url,
+            needs_cross_region_optin,
         )
 
         result_path = f"{self._config.scratch_bucket.rstrip('/')}/ducky/{query_id}.parquet"

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -118,14 +118,18 @@ def check_query_access(
     """
     if not allowed:
         return
-    uris = _object_uris(sql)
-    forbidden = [uri for uri in uris if not _is_allowed(uri, allowed)]
+    forbidden = disallowed_uris(sql, allowed)
     if forbidden:
         raise BucketNotAllowedError(
             f"query references buckets outside the allowlist: {', '.join(forbidden)}; "
             f"allowed prefixes: {', '.join(allowed)}"
         )
-    cross = [uri for uri in uris if _is_gcs_uri(uri) and not _is_allowed(uri, exempt_prefixes) and is_cross_region(uri)]
+    # Every referenced URI is allowed at this point; gate cross-region GCS reads.
+    cross = [
+        uri
+        for uri in _object_uris(sql)
+        if _is_gcs_uri(uri) and not _is_allowed(uri, exempt_prefixes) and is_cross_region(uri)
+    ]
     if cross and not _opts_in_cross_region(sql):
         raise CrossRegionNotAllowedError(
             f"query reads cross-region buckets: {', '.join(cross)}; "

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -25,15 +25,15 @@ import shutil
 import threading
 import time
 from collections.abc import Callable
-from functools import lru_cache
 
 import duckdb
 from iris.env_resources import TaskResources
 from rigging.filesystem import (
     MARIN_CROSS_REGION_OVERRIDE_ENV,
+    StoragePath,
+    cached_marin_region,
     get_bucket_location,
     is_cross_region_url,
-    marin_region,
 )
 
 from ducky.catalog import DATAKIT_SCHEMA, FINELOG_SCHEMA, View, build_catalog
@@ -87,20 +87,6 @@ def _is_gcs_uri(uri: str) -> bool:
 _region_confirmed_buckets: set[str] = set()
 
 
-@lru_cache(maxsize=1)
-def _vm_region() -> str | None:
-    """This VM's region (from GCP metadata), cached for the process. ``None`` off-GCP."""
-    return marin_region()
-
-
-def _gcs_bucket(uri: str) -> str | None:
-    """Bucket name from a ``gs://``/``gcs://`` URI, else ``None``."""
-    for scheme in ("gs://", "gcs://"):
-        if uri.lower().startswith(scheme):
-            return uri[len(scheme) :].split("/", 1)[0]
-    return None
-
-
 def _region_resolvable(bucket: str) -> bool:
     """Whether ``bucket``'s GCS location metadata is readable. Successes are cached; failures
     retry (not cached) so a transient error or permission blip self-heals."""
@@ -126,10 +112,10 @@ def needs_cross_region_optin(uri: str) -> bool:
     """
     if is_cross_region_url(uri):
         return True
-    if _vm_region() is None or os.environ.get(MARIN_CROSS_REGION_OVERRIDE_ENV):
+    if cached_marin_region() is None or os.environ.get(MARIN_CROSS_REGION_OVERRIDE_ENV):
         return False
-    bucket = _gcs_bucket(uri)
-    if bucket is None or _region_resolvable(bucket):
+    bucket = StoragePath.parse(uri).netloc
+    if not bucket or _region_resolvable(bucket):
         return False
     logger.warning("cross-region guard: could not resolve region for gs://%s; requiring opt-in", bucket)
     return True

--- a/lib/ducky/tests/test_config.py
+++ b/lib/ducky/tests/test_config.py
@@ -102,3 +102,22 @@ def test_effective_allowlist_empty_stays_allow_all():
     # an empty allowlist means allow-all; adding roots must not turn it into a restrictive list
     config = DuckyConfig(scratch_bucket="/tmp/ducky", allowed_buckets=(), finelog_root="gs://x/finelog")
     assert config.effective_allowed_buckets == ()
+
+
+def test_allowed_buckets_parsed_from_env(monkeypatch):
+    _set(monkeypatch, {**_BASE_ENV, "DUCKY_ALLOWED_BUCKETS": "gs://marin-,s3://marin-"})
+    config = DuckyConfig.from_environment()
+    assert config.allowed_buckets == ("gs://marin-", "s3://marin-")
+
+
+def test_catalog_root_prefixes_are_exempt_roots():
+    # the configured catalog roots are surfaced for cross-region exemption
+    config = DuckyConfig(
+        scratch_bucket="/tmp/ducky",
+        allowed_buckets=("gs://marin-",),
+        finelog_root="gs://marin-us-central2/finelog/marin",
+        datakit_root="gs://marin-eu-west4/normalized",
+    )
+    assert config.catalog_root_prefixes == ("gs://marin-us-central2/finelog/marin", "gs://marin-eu-west4/normalized")
+    # None roots are dropped
+    assert DuckyConfig(scratch_bucket="/tmp/ducky").catalog_root_prefixes == ()

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -211,7 +211,7 @@ def _region_probe(monkeypatch):
     runner_module._region_confirmed_buckets.clear()
 
     def _configure(vm_region, bucket_location):
-        monkeypatch.setattr(runner_module, "_vm_region", lambda: vm_region)
+        monkeypatch.setattr(runner_module, "cached_marin_region", lambda: vm_region)
 
         def _lookup(_bucket):
             if isinstance(bucket_location, Exception):

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -9,7 +9,15 @@ from pathlib import Path
 import duckdb
 import pytest
 from ducky.config import DuckyConfig
-from ducky.runner import BucketNotAllowedError, QueryError, QueryRunner, disallowed_uris
+from ducky.runner import (
+    BucketNotAllowedError,
+    CrossRegionNotAllowedError,
+    QueryError,
+    QueryRunner,
+    _opts_in_cross_region,
+    check_query_access,
+    disallowed_uris,
+)
 from iris.env_resources import TaskResources
 
 _SMALL_HOST = TaskResources(memory_bytes=2 * 1024**3, cpu_cores=2, gpu_count=0, tpu_count=0)
@@ -108,6 +116,83 @@ def test_disallowed_uris(sql, allowed, expected):
 def test_run_query_refuses_bucket_outside_allowlist(make_runner):
     runner = make_runner(allowed_buckets=("gs://marin-us-east5",))
     with pytest.raises(BucketNotAllowedError, match="us-central2"):
+        runner.run_query("SELECT * FROM read_parquet('gs://marin-us-central2/x.parquet')", uuid.uuid4().hex)
+
+
+@pytest.mark.parametrize(
+    "sql, opted_in",
+    [
+        ("-- cross-region: allow\nSELECT 1", True),
+        ("-- cross-region allow\nSELECT 1", True),  # colon optional
+        ("-- cross region: allowed\nSELECT 1", True),  # space + 'allowed'
+        ("\n\n  -- Cross-Region: Allow\nSELECT 1", True),  # blank lines + case
+        ("SELECT 1 -- cross-region: allow", False),  # not in the leading comment block
+        ("SELECT 'cross-region: allow'", False),  # inside a string, not a comment
+        ("-- just a normal comment\nSELECT 1", False),
+        ("SELECT 1", False),
+    ],
+)
+def test_opts_in_cross_region(sql, opted_in):
+    assert _opts_in_cross_region(sql) is opted_in
+
+
+# Stub region checker: any GCS bucket other than us-east5 counts as cross-region. Stands in for
+# rigging.filesystem.is_cross_region_url so the tests don't depend on live GCS metadata.
+def _stub_cross_region(url: str) -> bool:
+    return url.lower().startswith(("gs://", "gcs://")) and "us-east5" not in url
+
+
+_ALLOW_ALL_MARIN = ("gs://marin-", "s3://marin-")
+
+
+def test_check_query_access_cross_region_requires_opt_in():
+    sql = "SELECT * FROM read_parquet('gs://marin-us-central2/x.parquet')"
+    with pytest.raises(CrossRegionNotAllowedError, match="cross-region: allow"):
+        check_query_access(sql, _ALLOW_ALL_MARIN, (), _stub_cross_region)
+    # the same query with the opt-in comment passes the guard (no raise)
+    check_query_access(f"-- cross-region: allow\n{sql}", _ALLOW_ALL_MARIN, (), _stub_cross_region)
+
+
+def test_check_query_access_forbidden_bucket_hard_refused():
+    # a bucket outside the allowlist is refused even with the opt-in comment
+    sql = "-- cross-region: allow\nSELECT * FROM read_parquet('gs://other-corp/x.parquet')"
+    with pytest.raises(BucketNotAllowedError, match="other-corp"):
+        check_query_access(sql, _ALLOW_ALL_MARIN, (), _stub_cross_region)
+
+
+def test_check_query_access_same_region_needs_no_opt_in():
+    # us-east5 is same-region per the stub → no opt-in comment required
+    check_query_access(
+        "SELECT * FROM read_parquet('gs://marin-us-east5/x.parquet')", _ALLOW_ALL_MARIN, (), _stub_cross_region
+    )
+
+
+def test_check_query_access_s3_never_cross_region_gated():
+    # S3 (R2/CoreWeave) reads are always allowed and never cross-region-gated, even if the
+    # checker would flag everything — rigging models GCS regions only.
+    check_query_access("SELECT * FROM read_parquet('s3://marin-na/x.parquet')", _ALLOW_ALL_MARIN, (), lambda _url: True)
+
+
+def test_check_query_access_catalog_root_exempt_from_opt_in():
+    # a literal read of a configured catalog root skips the opt-in (deliberate always-on egress)
+    root = "gs://marin-us-central2/finelog"
+    check_query_access(
+        f"SELECT * FROM read_parquet('{root}/marin/x.parquet')",
+        _ALLOW_ALL_MARIN,
+        (root,),
+        lambda _url: True,
+    )
+
+
+def test_check_query_access_empty_allowlist_disables_enforcement():
+    # allow-all: neither the bucket bound nor the cross-region gate applies
+    check_query_access("SELECT * FROM read_parquet('gs://anywhere/x.parquet')", (), (), lambda _url: True)
+
+
+def test_run_query_refuses_cross_region_without_opt_in(make_runner, monkeypatch):
+    monkeypatch.setattr("ducky.runner.is_cross_region_url", lambda url: "us-central2" in url)
+    runner = make_runner(allowed_buckets=("gs://marin-",))
+    with pytest.raises(CrossRegionNotAllowedError, match="us-central2"):
         runner.run_query("SELECT * FROM read_parquet('gs://marin-us-central2/x.parquet')", uuid.uuid4().hex)
 
 

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -7,6 +7,7 @@ from concurrent.futures import ThreadPoolExecutor
 from pathlib import Path
 
 import duckdb
+import ducky.runner as runner_module
 import pytest
 from ducky.config import DuckyConfig
 from ducky.runner import (
@@ -17,6 +18,7 @@ from ducky.runner import (
     _opts_in_cross_region,
     check_query_access,
     disallowed_uris,
+    needs_cross_region_optin,
 )
 from iris.env_resources import TaskResources
 
@@ -194,6 +196,61 @@ def test_run_query_refuses_cross_region_without_opt_in(make_runner, monkeypatch)
     runner = make_runner(allowed_buckets=("gs://marin-",))
     with pytest.raises(CrossRegionNotAllowedError, match="us-central2"):
         runner.run_query("SELECT * FROM read_parquet('gs://marin-us-central2/x.parquet')", uuid.uuid4().hex)
+
+
+@pytest.fixture
+def _region_probe(monkeypatch):
+    """Patch the region primitives needs_cross_region_optin depends on, and clear its cache.
+
+    Yields a setter (vm_region, bucket_location) where bucket_location can be an exception
+    instance to simulate a failed metadata lookup."""
+    monkeypatch.delenv("MARIN_I_WILL_PAY_FOR_ALL_FEES", raising=False)
+    # is_cross_region_url positively confirms *different* region; here nothing is confirmed
+    # cross-region so the fail-closed path is what's under test.
+    monkeypatch.setattr(runner_module, "is_cross_region_url", lambda _uri: False)
+    runner_module._region_confirmed_buckets.clear()
+
+    def _configure(vm_region, bucket_location):
+        monkeypatch.setattr(runner_module, "_vm_region", lambda: vm_region)
+
+        def _lookup(_bucket):
+            if isinstance(bucket_location, Exception):
+                raise bucket_location
+            return bucket_location
+
+        monkeypatch.setattr(runner_module, "get_bucket_location", _lookup)
+
+    return _configure
+
+
+def test_needs_cross_region_optin_fails_closed_when_region_unresolvable(_region_probe):
+
+    # on a GCP VM but the bucket-location lookup fails (e.g. missing storage.buckets.get)
+    _region_probe(vm_region="us-east5", bucket_location=PermissionError("denied"))
+    assert needs_cross_region_optin("gs://marin-us-central2/x.parquet") is True
+
+
+def test_needs_cross_region_optin_allows_confirmed_same_region(_region_probe):
+
+    _region_probe(vm_region="us-east5", bucket_location="us-east5")
+    assert needs_cross_region_optin("gs://marin-us-east5/x.parquet") is False
+
+
+def test_needs_cross_region_optin_off_gcp_disables_gating(_region_probe):
+
+    # no VM region (local/smoke) → gating not applicable even if metadata is unreadable
+    _region_probe(vm_region=None, bucket_location=RuntimeError("unreachable"))
+    assert needs_cross_region_optin("gs://marin-us-central2/x.parquet") is False
+
+
+def test_needs_cross_region_optin_confirmed_cross_region_short_circuits(monkeypatch):
+
+    # is_cross_region_url positively True → needs opt-in without any bucket-location probe
+    monkeypatch.setattr(runner_module, "is_cross_region_url", lambda _uri: True)
+    monkeypatch.setattr(
+        runner_module, "get_bucket_location", lambda _b: pytest.fail("should not probe when confirmed cross-region")
+    )
+    assert needs_cross_region_optin("gs://marin-eu-west4/x.parquet") is True
 
 
 def test_run_query_allowlist_does_not_block_non_object_queries(make_runner):

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -876,8 +876,8 @@ def mirror_budget(budget_gb: float) -> Generator[None, None, None]:
 
 
 @functools.lru_cache(maxsize=1)
-def _cached_marin_region() -> str | None:
-    """Return the current VM region, cached for the process lifetime."""
+def cached_marin_region() -> str | None:
+    """Return the current VM region, cached for the process lifetime (the VM region is stable)."""
     return marin_region()
 
 
@@ -940,7 +940,7 @@ def _is_cross_region_url(url: str) -> bool:
     bucket = _bucket_from_gcs_url(url)
     if bucket is None:
         return False
-    vm_region = _cached_marin_region()
+    vm_region = cached_marin_region()
     if vm_region is None:
         return False
     bucket_location = _cached_bucket_location(bucket)
@@ -1017,7 +1017,7 @@ class CrossRegionGuardedFS:
     ):
         self._fs = fs
         self._cross_region_checker = cross_region_checker
-        self._current_region = None if cross_region_checker else _cached_marin_region()
+        self._current_region = None if cross_region_checker else cached_marin_region()
         self._budget = budget if budget is not None else _global_transfer_budget
 
     # -- cross-region detection ----------------------------------------------

--- a/lib/rigging/tests/test_record_transfer.py
+++ b/lib/rigging/tests/test_record_transfer.py
@@ -11,7 +11,7 @@ from rigging.filesystem import TransferBudget, TransferBudgetExceeded, record_tr
 @pytest.fixture()
 def patched_regions(monkeypatch):
     """VM is in us-central1; bucket lookup is faked from the URL."""
-    monkeypatch.setattr(rfs, "_cached_marin_region", lambda: "us-central1")
+    monkeypatch.setattr(rfs, "cached_marin_region", lambda: "us-central1")
     monkeypatch.setattr(
         rfs,
         "_cached_bucket_location",


### PR DESCRIPTION
* switch ducky's cross-region read guard from a bucket-name prefix heuristic to `rigging.filesystem.is_cross_region_url` (live GCS bucket-location metadata vs the VM region), and collapse the dashboard example queries by default
* `DUCKY_ALLOWED_BUCKETS` is now a single outer read bound (default `gs://marin-,s3://marin-` — all marin buckets on both backends); whether an *allowed* GCS read is same-region or egress-costly cross-region is decided at query time by rigging, not a naming convention [^1]
  * a cross-region GCS read still needs a leading `-- cross-region: allow` comment
  * S3 reads (R2/CoreWeave) are never cross-region-gated — rigging models GCS regions only, so any allowed `s3://` URI reads freely
  * configured catalog roots (`finelog_root`/`datakit_root`) are exempt, so a literal `read_parquet` of a root behaves like its pre-baked view
* drop the `DUCKY_CROSS_REGION_BUCKETS` knob and the `cross_region_buckets` config field — rigging replaces them; add `catalog_root_prefixes` and `CrossRegionNotAllowedError`
* allowlist is region-agnostic now, so no per-region tuning on a different-region deploy; off-GCP (local smoke) the region is unknown so only the outer allowlist applies
* `check_query_access` reuses `disallowed_uris` as the single source of truth for the allowlist filter
* dashboard: `Example queries` is collapsed by default behind its own `▸`/`▾` toggle; the source-views list stays visible

[^1]: DuckDB reads object stores through its native `httpfs` (C++), which bypasses rigging's fsspec-based `CrossRegionGuardedFS`/`TransferBudget` entirely — so ducky needs this separate SQL-level check. rigging's region lookup uses `storage.Client()` (ADC / the VM service account), not the HMAC keys DuckDB uses, so the deployed task's SA needs `storage.buckets.get`.