### PR TITLE
[iris] Remove legacy finelog LogService compatibility bridge

### DIFF
--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -39,7 +39,6 @@ from rigging.server_auth import (
     RouteAuthMiddleware,
     extract_bearer_token,
     public,
-    requires_auth,
 )
 from starlette.applications import Starlette
 from starlette.requests import Request
@@ -59,7 +58,6 @@ from iris.cluster.dashboard_common import (
     on_shutdown,
     static_files_mount,
 )
-from iris.cluster.endpoints import LOG_SERVER_ENDPOINT_NAME
 from iris.cluster.types import EndpointAccess
 from iris.rpc.async_adapter import AsyncServiceAdapter
 from iris.rpc.auth import SESSION_COOKIE, authorize_method
@@ -199,15 +197,6 @@ def _set_session_cookie(response: Response, token: str, request: Request) -> Non
 # route). Base-domain-agnostic: works for ``iris-dev.oa.dev``,
 # ``iris.oa.dev``, or any other public host.
 PROXY_HOST_LABEL = "proxy"
-
-# Backward-compat for finelog clients built before logs moved behind the generic
-# endpoint proxy: they resolve /system/log-server to the bare controller URL and
-# POST to /finelog.logging.LogService/<method> directly. We forward those to the
-# log server through the same EndpointProxy the dashboard uses, so no typed
-# LogService forwarding mount is needed on the controller. The encoded name is
-# the endpoint's wire name with the leading slash dropped and "/" -> ".".
-_LOG_SERVICE_RPC_PREFIX = "finelog.logging.LogService"
-_LOG_SERVER_PROXY_NAME = LOG_SERVER_ENDPOINT_NAME.strip("/").replace("/", ".")
 
 
 def _extract_proxy_subdomain(host: str) -> str | None:
@@ -441,18 +430,6 @@ class ControllerDashboard:
             query = f"?{request.url.query}" if request.url.query else ""
             return RedirectResponse(f"/proxy/{name}/{query}", status_code=307)
 
-        @requires_auth
-        async def _legacy_log_service(request: Request) -> Response:
-            # Forward pre-proxy clients' bare LogService calls to the log server
-            # through the generic endpoint proxy (see _LOG_SERVER_PROXY_NAME).
-            method = request.path_params["method"]
-            return await self._endpoint_proxy.dispatch(
-                request,
-                encoded_name=_LOG_SERVER_PROXY_NAME,
-                sub_path=f"{_LOG_SERVICE_RPC_PREFIX}/{method}",
-                proxy_prefix="",
-            )
-
         routes = [
             Route("/", self._dashboard),
             favicon_route(),
@@ -482,11 +459,6 @@ class ControllerDashboard:
                 endpoint_proxy.PROXY_ROUTE,
                 _proxy_endpoint,
                 methods=list(endpoint_proxy.ALLOWED_METHODS),
-            ),
-            Route(
-                f"/{_LOG_SERVICE_RPC_PREFIX}/{{method}}",
-                _legacy_log_service,
-                methods=["POST"],
             ),
             Mount(rpc_asgi_app.path, app=rpc_asgi_app),
             Mount(endpoint_rpc_app.path, app=endpoint_rpc_app),

--- a/lib/iris/tests/cluster/controller/test_dashboard.py
+++ b/lib/iris/tests/cluster/controller/test_dashboard.py
@@ -1282,27 +1282,13 @@ def test_fetch_logs_for_missing_task_returns_empty_entries(client):
     [
         "/iris.cluster.ControllerService/FetchLogs",
         "/iris.logging.LogService/FetchLogs",
+        "/finelog.logging.LogService/FetchLogs",
     ],
 )
 def test_fetch_logs_outside_endpoint_proxy_is_not_exposed(client, path):
     resp = client.post(path, json={}, headers={"Content-Type": "application/json"})
 
     assert resp.status_code == 404
-
-
-def test_fetch_logs_via_legacy_bare_path_is_bridged(client):
-    """Clients built before the proxy lift resolve /system/log-server to the bare
-    controller URL and call /finelog.logging.LogService/FetchLogs directly. That
-    bare path is bridged to the log server through the generic endpoint proxy.
-    """
-    task_id = JobName.root("test-user", "nonexistent").task(0).to_wire()
-    resp = client.post(
-        "/finelog.logging.LogService/FetchLogs",
-        json={"source": f"{task_id}:", "match_scope": "MATCH_SCOPE_PREFIX"},
-        headers={"Content-Type": "application/json"},
-    )
-    assert resp.status_code == 200
-    assert resp.json().get("entries", []) == []
 
 
 # =============================================================================


### PR DESCRIPTION
Removes the temporary backward-compat bridge added in PR #6543. That bridge allowed older clients — which POST to the bare /finelog.logging.LogService/<method> path after resolving /system/log-server to the bare controller URL — to keep working while they upgraded past the endpoint-proxy migration landed in PR #6536.

Now that clients have had two weeks to upgrade, the bridge is no longer needed. The bare /finelog.logging.LogService path now returns 404 like any other unmounted RPC prefix; clients must route log traffic through the generic /proxy/system.log-server endpoint that PR #6536 established.

Changes:

- Removes _LOG_SERVICE_RPC_PREFIX and _LOG_SERVER_PROXY_NAME module-level constants from dashboard.py
- Removes the _legacy_log_service route handler and its Route(...) entry from the routes list
- Removes the LOG_SERVER_ENDPOINT_NAME import (no longer referenced anywhere in the file)
- Deletes test_fetch_logs_via_legacy_bare_path_is_bridged from test_dashboard.py
- Adds /finelog.logging.LogService/FetchLogs to the parametrized 404 assertion in test_fetch_logs_outside_endpoint_proxy_is_not_exposed, confirming the path is once again unrouted