### PR TITLE
[iris] Fix controller secret-resolution crash and IAP dashboard login

### DIFF
--- a/lib/iris/dashboard/src/App.vue
+++ b/lib/iris/dashboard/src/App.vue
@@ -81,9 +81,13 @@ onMounted(async () => {
   try {
     // fetchConfig fetches /auth/config once, populates capabilities + backends,
     // and returns auth-related fields for login redirection.
-    const { authEnabled: ae, hasSession, authOptional } = await fetchConfig()
+    const { authEnabled: ae, authenticated, authOptional } = await fetchConfig()
     authEnabled.value = ae
-    if (ae && !authOptional && !hasSession && route.path !== '/login') {
+    // Only send the browser to the login page when auth is required and this
+    // request is not already authenticated. Behind IAP the caller is
+    // authenticated at the edge (no session cookie), so `authenticated` is true
+    // and the bearer-token login page is skipped.
+    if (ae && !authOptional && !authenticated && route.path !== '/login') {
       router.push('/login')
     }
   } catch {

--- a/lib/iris/dashboard/src/composables/useBackends.ts
+++ b/lib/iris/dashboard/src/composables/useBackends.ts
@@ -44,7 +44,7 @@ let _peersPromise: Promise<void> | null = null
 
 export interface AuthConfig {
   authEnabled: boolean
-  hasSession: boolean
+  authenticated: boolean
   authOptional: boolean
 }
 
@@ -58,7 +58,7 @@ export function useBackends() {
    * without a second fetch.
    */
   async function fetchConfig(): Promise<AuthConfig> {
-    const authDefaults: AuthConfig = { authEnabled: false, hasSession: false, authOptional: false }
+    const authDefaults: AuthConfig = { authEnabled: false, authenticated: false, authOptional: false }
     if (_configFetched) return authDefaults
     _configFetched = true
     try {
@@ -66,7 +66,7 @@ export function useBackends() {
       if (!resp.ok) return authDefaults
       const config = await resp.json() as {
         auth_enabled?: boolean
-        has_session?: boolean
+        authenticated?: boolean
         optional?: boolean
         capabilities?: string[]
         backends?: Array<{ id: string; name?: string; capabilities?: string[] }>
@@ -85,7 +85,7 @@ export function useBackends() {
       }
       return {
         authEnabled: config.auth_enabled ?? false,
-        hasSession: config.has_session ?? false,
+        authenticated: config.authenticated ?? false,
         authOptional: config.optional ?? false,
       }
     } catch {

--- a/lib/iris/pyproject.toml
+++ b/lib/iris/pyproject.toml
@@ -41,6 +41,11 @@ dependencies = [
 [project.optional-dependencies]
 controller = [
     "kubernetes>=31.0.0,<36",
+    # The controller resolves `gcp-secret://` config references (e.g. the auth
+    # signing key) at startup via rigging.secrets, which imports the Secret
+    # Manager client. Only the controller runs resolve_config_secrets, so this
+    # stays off the worker/CLI import path.
+    "marin-rigging[secrets]",
 ]
 worker = []
 # Interactive `iris login` against an IAP-fronted cluster (desktop OAuth flow).

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -539,8 +539,27 @@ class ControllerDashboard:
 
     @public
     def _auth_config(self, request: Request) -> JSONResponse:
-        """Unauthenticated endpoint telling the frontend whether auth is required."""
-        has_session = SESSION_COOKIE in request.cookies
+        """Unauthenticated endpoint telling the frontend whether auth is required
+        and whether this request is already authenticated.
+
+        ``authenticated`` resolves the request through the same policy the RPC
+        surface enforces, so an IAP-fronted caller — authenticated by the signed
+        edge header and holding no session cookie — is recognized without a login
+        round-trip. A cookie-only check would send every IAP user to the
+        bearer-token login page even though IAP already admitted them.
+        """
+        headers = dict(request.headers)
+        token = extract_bearer_token(headers, cookie_name=SESSION_COOKIE)
+        client = request.client
+        try:
+            self._auth_policy.resolve(
+                token,
+                client_address=f"{client.host}:{client.port}" if client else None,
+                headers=headers,
+            )
+            authenticated = True
+        except ValueError:
+            authenticated = False
         descriptors = {bid: backend_descriptor(b) for bid, b in self._service.backends.items()}
         union_capabilities = sorted({cap for d in descriptors.values() for cap in d.capabilities})
         representative = backend_descriptor(self._service.provider)
@@ -548,7 +567,7 @@ class ControllerDashboard:
             {
                 "auth_enabled": self._auth_provider is not None,
                 "provider": self._auth_provider,
-                "has_session": has_session,
+                "authenticated": authenticated,
                 # Union of every backend's capabilities gates which tabs the dashboard shows.
                 "capabilities": union_capabilities,
                 "backends": [

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -37,6 +37,7 @@ from rigging.server_auth import (
     PolicyAuthInterceptor,
     RequestAuthPolicy,
     RouteAuthMiddleware,
+    VerifiedIdentity,
     extract_bearer_token,
     public,
     requires_auth,
@@ -73,6 +74,25 @@ from iris.rpc.stats_service import RpcStatsService
 logger = logging.getLogger(__name__)
 
 
+def _resolve_request_identity(policy: RequestAuthPolicy, request: Request, token: str | None = None) -> VerifiedIdentity:
+    """Resolve a Starlette request to a cluster identity via the auth policy.
+
+    Lifts the bearer token from the Authorization header or session cookie when no
+    explicit ``token`` is given, and forwards the peer address and headers the
+    policy's authenticators need (the signed IAP header, CIDR, loopback). Raises
+    ``ValueError`` when the request cannot be authenticated.
+    """
+    headers = dict(request.headers)
+    if token is None:
+        token = extract_bearer_token(headers, cookie_name=SESSION_COOKIE)
+    client = request.client
+    return policy.resolve(
+        token,
+        client_address=f"{client.host}:{client.port}" if client else None,
+        headers=headers,
+    )
+
+
 def _authorize_proxy(
     request: Request,
     resolved: ResolvedEndpoint | None,
@@ -100,16 +120,8 @@ def _authorize_proxy(
     access = resolved.access if resolved is not None else EndpointAccess.ENDPOINT_ACCESS_PRIVATE
     if access == EndpointAccess.ENDPOINT_ACCESS_PUBLIC:
         return None
-    headers = dict(request.headers)
-    if token is None:
-        token = extract_bearer_token(headers, cookie_name=SESSION_COOKIE)
-    client = request.client
     try:
-        identity = policy.resolve(
-            token,
-            client_address=f"{client.host}:{client.port}" if client else None,
-            headers=headers,
-        )
+        identity = _resolve_request_identity(policy, request, token)
     except ValueError:
         return JSONResponse({"error": "authentication required"}, status_code=401)
 
@@ -548,15 +560,8 @@ class ControllerDashboard:
         round-trip. A cookie-only check would send every IAP user to the
         bearer-token login page even though IAP already admitted them.
         """
-        headers = dict(request.headers)
-        token = extract_bearer_token(headers, cookie_name=SESSION_COOKIE)
-        client = request.client
         try:
-            self._auth_policy.resolve(
-                token,
-                client_address=f"{client.host}:{client.port}" if client else None,
-                headers=headers,
-            )
+            _resolve_request_identity(self._auth_policy, request)
             authenticated = True
         except ValueError:
             authenticated = False

--- a/lib/iris/src/iris/cluster/controller/dashboard.py
+++ b/lib/iris/src/iris/cluster/controller/dashboard.py
@@ -551,14 +551,13 @@ class ControllerDashboard:
 
     @public
     def _auth_config(self, request: Request) -> JSONResponse:
-        """Unauthenticated endpoint telling the frontend whether auth is required
-        and whether this request is already authenticated.
+        """Report whether auth is required and whether this request is authenticated.
 
-        ``authenticated`` resolves the request through the same policy the RPC
-        surface enforces, so an IAP-fronted caller — authenticated by the signed
-        edge header and holding no session cookie — is recognized without a login
-        round-trip. A cookie-only check would send every IAP user to the
-        bearer-token login page even though IAP already admitted them.
+        Public endpoint the frontend reads before rendering to decide whether to
+        show the login page. ``authenticated`` resolves the request through the
+        same policy the RPC surface enforces, so a request carrying any accepted
+        credential — a session cookie, a bearer token, or the signed IAP edge
+        header — is reported as authenticated.
         """
         try:
             _resolve_request_identity(self._auth_policy, request)

--- a/uv.lock
+++ b/uv.lock
@@ -5039,6 +5039,7 @@ dependencies = [
 [package.optional-dependencies]
 controller = [
     { name = "kubernetes" },
+    { name = "marin-rigging", extra = ["secrets"] },
 ]
 iap = [
     { name = "marin-rigging", extra = ["iap"] },
@@ -5093,6 +5094,7 @@ requires-dist = [
     { name = "marin-finelog-server", specifier = ">=0.2.10" },
     { name = "marin-rigging", editable = "lib/rigging" },
     { name = "marin-rigging", extras = ["iap"], marker = "extra == 'iap'", editable = "lib/rigging" },
+    { name = "marin-rigging", extras = ["secrets"], marker = "extra == 'controller'", editable = "lib/rigging" },
     { name = "pydantic", specifier = ">=2.0" },
     { name = "pyjwt", extras = ["crypto"], specifier = ">=2.12.0" },
     { name = "pyyaml", specifier = ">=6.0" },


### PR DESCRIPTION
Two regressions from the unified-auth change (#6948), found point-testing marin-dev.

Controller image was missing the Secret Manager client. The controller resolves
`gcp-secret://` config references at startup (`resolve_config_secrets` ->
`rigging.secrets`, which imports `google.cloud.secretmanager`), but the image
installed `marin-iris[controller]` (kubernetes only), not `marin-rigging[secrets]`.
Both `marin.yaml` and `marin-dev.yaml` resolve their auth `signing_key` that way, so
the next controller restart on either crash-loops at startup. Add
`marin-rigging[secrets]` to the controller extra, mirroring the existing `iap`
extra; it stays off the worker/CLI import path since only the controller runs
`resolve_config_secrets`.

Dashboard forced IAP users to the bearer-token login page. `_auth_config` reported
`has_session = (SESSION_COOKIE in cookies)`, a cookie-only check, and behind IAP the
caller holds no session cookie (auth is the signed edge header) — so the SPA
redirected every IAP-authenticated user to the login page. It now resolves the
request through the same policy the RPC surface enforces and reports `authenticated`
(renamed from `has_session`), so cookie, bearer-token, and IAP callers are all
recognized; the frontend redirects only when auth is required and the request is not
already authenticated. The request->identity resolve scaffold shared with the proxy
authorizer is factored into a helper.