### PR TITLE
Adopt StoragePath across storage-path manipulation hot spots

### DIFF
--- a/lib/levanter/src/levanter/analysis/model_perplexity.py
+++ b/lib/levanter/src/levanter/analysis/model_perplexity.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import json
-import os
 from collections import Counter
 from collections import defaultdict
 from dataclasses import dataclass, field
@@ -11,7 +10,7 @@ from typing import Any, Sequence
 import numpy as np
 import pyarrow as pa
 import pyarrow.parquet as pq
-from rigging.filesystem import open_url
+from rigging.filesystem import open_url, prefix_join
 
 from levanter.analysis.perplexity_gap import (
     LOG2E,
@@ -199,10 +198,10 @@ def write_model_score_files(
     vocab_size: int | None = None,
     token_id_to_text: dict[int, str] | None = None,
 ) -> None:
-    summary_path = os.path.join(output_path, SUMMARY_FILENAME)
-    scored_documents_path = os.path.join(output_path, SCORED_DOCUMENTS_FILENAME)
-    token_counts_path = os.path.join(output_path, TOKEN_COUNTS_FILENAME)
-    token_count_summary_path = os.path.join(output_path, TOKEN_COUNT_SUMMARY_FILENAME)
+    summary_path = prefix_join(output_path, SUMMARY_FILENAME)
+    scored_documents_path = prefix_join(output_path, SCORED_DOCUMENTS_FILENAME)
+    token_counts_path = prefix_join(output_path, TOKEN_COUNTS_FILENAME)
+    token_count_summary_path = prefix_join(output_path, TOKEN_COUNT_SUMMARY_FILENAME)
     mkdirs(output_path)
 
     with open_url(summary_path, "w") as f:
@@ -224,20 +223,20 @@ def write_model_score_files(
 
 
 def read_model_score_summary(output_path: str) -> dict[str, Any]:
-    summary_path = os.path.join(output_path, SUMMARY_FILENAME)
+    summary_path = prefix_join(output_path, SUMMARY_FILENAME)
     with open_url(summary_path) as f:
         return json.load(f)
 
 
 def read_scored_documents(output_path: str) -> list[ScoredDocument]:
-    scored_documents_path = os.path.join(output_path, SCORED_DOCUMENTS_FILENAME)
+    scored_documents_path = prefix_join(output_path, SCORED_DOCUMENTS_FILENAME)
     with open_url(scored_documents_path, "rb") as f:
         table = pq.read_table(f)
     return [_scored_document_from_row(row) for row in table.to_pylist()]
 
 
 def read_token_count_summary(output_path: str) -> dict[str, Any]:
-    token_count_summary_path = os.path.join(output_path, TOKEN_COUNT_SUMMARY_FILENAME)
+    token_count_summary_path = prefix_join(output_path, TOKEN_COUNT_SUMMARY_FILENAME)
     with open_url(token_count_summary_path) as f:
         return json.load(f)
 

--- a/lib/levanter/src/levanter/analysis/perplexity_gap.py
+++ b/lib/levanter/src/levanter/analysis/perplexity_gap.py
@@ -4,14 +4,13 @@
 import heapq
 import itertools
 import json
-import os
 from collections import defaultdict
 from dataclasses import dataclass, field
 from typing import Any, Iterator, Sequence
 
 import numpy as np
 import regex
-from rigging.filesystem import open_url
+from rigging.filesystem import open_url, prefix_join
 
 from levanter.data.sharded_datasource import ShardedDataSource
 from levanter.data.text import DatasetComponent, SupervisedLmDatasetFormat, TextLmDatasetFormat
@@ -881,9 +880,9 @@ def render_report_markdown(summary: dict[str, Any]) -> str:
 
 
 def write_report_files(output_path: str, summary: dict[str, Any]) -> tuple[str, str, str]:
-    summary_path = os.path.join(output_path, "summary.json")
-    report_path = os.path.join(output_path, "report.md")
-    worst_documents_path = os.path.join(output_path, "worst_documents.jsonl")
+    summary_path = prefix_join(output_path, "summary.json")
+    report_path = prefix_join(output_path, "report.md")
+    worst_documents_path = prefix_join(output_path, "worst_documents.jsonl")
     mkdirs(output_path)
 
     with open_url(summary_path, "w") as f:

--- a/lib/levanter/src/levanter/callbacks/labeled_eval.py
+++ b/lib/levanter/src/levanter/callbacks/labeled_eval.py
@@ -13,6 +13,8 @@ from jax.sharding import Mesh
 import haliax as hax
 from haliax.partitioning import ResourceMapping
 
+from rigging.filesystem import prefix_join
+
 import levanter.tracker
 from levanter.callbacks._core import StepInfo
 from levanter.data import AsyncDataset
@@ -67,10 +69,10 @@ def labeled_eval_cache_dir(
 
     cache_root = labeled_eval_config.cache_dir
     if cache_root is None and data_config.cache_dir is not None:
-        cache_root = os.path.join(data_config.cache_dir, "labeled_eval")
+        cache_root = prefix_join(data_config.cache_dir, "labeled_eval")
     if cache_root is None:
         raise ValueError(f"No cache_dir provided for labeled eval dataset {dataset_name}")
-    return os.path.join(cache_root, dataset_name)
+    return prefix_join(cache_root, dataset_name)
 
 
 def source_for_labeled_eval_dataset(dataset_config: LabeledLmEvalDatasetConfig) -> ShardedDataSource[dict]:

--- a/lib/levanter/src/levanter/data/text/datasets.py
+++ b/lib/levanter/src/levanter/data/text/datasets.py
@@ -5,7 +5,6 @@ import abc
 import dataclasses
 import functools
 import logging
-import os
 from collections.abc import Callable, Mapping, Sequence
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from dataclasses import dataclass
@@ -19,6 +18,7 @@ import numpy as np
 from draccus import ChoiceRegistry, field
 from haliax import Axis
 from jaxtyping import PRNGKeyArray
+from rigging.filesystem import prefix_join
 from rigging.timing import log_time
 
 import levanter
@@ -258,7 +258,7 @@ class LmDatasetSourceConfigBase(ChoiceRegistry):
         base_cache = override_cache_dir if override_cache_dir is not None else self.cache_dir
         if base_cache is None:
             raise ValueError("cache_dir must be set or override_cache_dir must be provided")
-        return load_lm_dataset_cache(os.path.join(base_cache, split), self.format, tokenizer, enforce_eos=enforce_eos)
+        return load_lm_dataset_cache(prefix_join(base_cache, split), self.format, tokenizer, enforce_eos=enforce_eos)
 
     @classmethod
     def default_choice_name(cls) -> str | None:
@@ -563,7 +563,7 @@ def _component_cache_dir(name: str, component: DatasetComponent, default_root: s
     if base is None:
         raise ValueError(f"No cache_dir provided for component {name}")
     if component.cache_dir is None:
-        return os.path.join(base, name)
+        return prefix_join(base, name)
     return base
 
 
@@ -932,7 +932,7 @@ class LmDataConfig:
                     return name, None, None
                 cache_path = cache_root
             else:
-                cache_path = os.path.join(cache_root, split)
+                cache_path = prefix_join(cache_root, split)
             source = component.source
 
             if source is None:

--- a/lib/levanter/src/levanter/dpo.py
+++ b/lib/levanter/src/levanter/dpo.py
@@ -6,7 +6,6 @@
 import hashlib
 import json
 import logging
-import os
 from dataclasses import dataclass
 from typing import Any, Literal, cast
 
@@ -17,6 +16,8 @@ import jax.numpy as jnp
 import jmp
 import numpy as np
 from haliax.partitioning import ResourceMapping, named_jit
+
+from rigging.filesystem import prefix_join
 
 from levanter.data.dataset import AsyncDataset
 from levanter.data.loader import DataLoader
@@ -234,11 +235,11 @@ def reference_eval_cache_path(
     ).hexdigest()[:8]
 
     if cache_dir is None:
-        cache_root = os.path.join(spec.source_cache_path.rsplit("/", 1)[0], "reference_logprobs")
+        cache_root = prefix_join(spec.source_cache_path.rsplit("/", 1)[0], "reference_logprobs")
     else:
         cache_root = cache_dir
 
-    return os.path.join(cache_root, cache_hash)
+    return prefix_join(cache_root, cache_hash)
 
 
 def load_reference_eval_cache(

--- a/lib/levanter/src/levanter/dpo.py
+++ b/lib/levanter/src/levanter/dpo.py
@@ -17,7 +17,7 @@ import jmp
 import numpy as np
 from haliax.partitioning import ResourceMapping, named_jit
 
-from rigging.filesystem import prefix_join
+from rigging.filesystem import StoragePath, prefix_join
 
 from levanter.data.dataset import AsyncDataset
 from levanter.data.loader import DataLoader
@@ -235,7 +235,7 @@ def reference_eval_cache_path(
     ).hexdigest()[:8]
 
     if cache_dir is None:
-        cache_root = prefix_join(spec.source_cache_path.rsplit("/", 1)[0], "reference_logprobs")
+        cache_root = str(StoragePath.parse(spec.source_cache_path).parent / "reference_logprobs")
     else:
         cache_root = cache_dir
 

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -57,6 +57,51 @@ LOG_FORMAT = "%(asctime)s - %(levelname)s - %(message)s"
 
 
 @dataclass(frozen=True)
+class ShardedCacheLayout:
+    """Storage paths of a sharded Levanter cache: its top-level ledger and per-shard subdirectories."""
+
+    root: StoragePath
+
+    @staticmethod
+    def parse(root: str) -> "ShardedCacheLayout":
+        return ShardedCacheLayout(StoragePath.parse(root))
+
+    def __str__(self) -> str:
+        return str(self.root)
+
+    @property
+    def ledger(self) -> str:
+        """Path of the top-level ledger that aggregates the per-shard ledgers."""
+        return str(self.root / LEDGER_FILE_NAME)
+
+    def child(self, name: str) -> "ShardedCacheLayout":
+        """The sub-cache rooted at ``root/name`` (e.g. a per-split cache)."""
+        return ShardedCacheLayout(self.root / name)
+
+    def shard(self, shard_name: str) -> str:
+        """Absolute path of the shard subdirectory ``shard_name`` under this cache."""
+        return str(self.root / shard_name)
+
+    def relative_shard(self, shard_path: str) -> str:
+        """``shard_path`` as the ledger key relative to this root; raises unless strictly under it.
+
+        Segment comparison keeps a trailing or doubled separator from forking writer and
+        reader; a ``..`` that escapes a scheme-less (local) root is also rejected.
+        """
+        try:
+            relative = StoragePath.parse(shard_path).relative_to(self.root)
+        except ValueError as exc:
+            raise ValueError(f"Sharded cache path {shard_path} is not under output path {self.root}") from exc
+        # A local relative key with a `..` segment escapes the cache directory when
+        # joined back; object-store keys treat `..` as a literal segment, so this only
+        # applies to scheme-less filesystem paths.
+        escapes = self.root.scheme is None and ".." in relative.split("/")
+        if not relative or escapes:
+            raise ValueError(f"Sharded cache path {shard_path} is not under output path {self.root}")
+        return relative
+
+
+@dataclass(frozen=True)
 class CacheOptions:
     batch_size: int = 128
 
@@ -100,6 +145,7 @@ class TreeCache(AsyncDataset[T_co]):
     ):
         super().__init__()
         self.cache_dir = cache_dir
+        self._layout = ShardedCacheLayout.parse(cache_dir)
         self.ledger = ledger
         self._exemplar = exemplar
         self._shard_stores: Dict[str, TreeStore[T_co]] = {}
@@ -129,7 +175,7 @@ class TreeCache(AsyncDataset[T_co]):
         return self.ledger.layout == CACHE_LAYOUT_SHARDED
 
     def _shard_path(self, shard_name: str) -> str:
-        return prefix_join(self.cache_dir, shard_name)
+        return self._layout.shard(shard_name)
 
     async def async_len(self) -> int:
         return await self._reader.async_len()
@@ -597,7 +643,7 @@ class CacheLedger:
 
     @staticmethod
     def load(cache_dir: str, metadata: Optional["CacheMetadata"] = None) -> "CacheLedger":
-        ledger_path = prefix_join(cache_dir, LEDGER_FILE_NAME)
+        ledger_path = ShardedCacheLayout.parse(cache_dir).ledger
         try:
             logger.info(f"Attempting to load cache ledger from {ledger_path}")
             with open_url(ledger_path) as file:
@@ -611,7 +657,7 @@ class CacheLedger:
             raise FileNotFoundError(f"Cache ledger not found at {ledger_path}") from exc
 
     def _serialize_and_commit(self, cache_dir):
-        path = prefix_join(cache_dir, LEDGER_FILE_NAME)
+        path = ShardedCacheLayout.parse(cache_dir).ledger
         return _serialize_json_and_commit(path, self)  # type: ignore[arg-type]
 
 
@@ -1136,8 +1182,9 @@ def consolidate_shard_cache_ledgers(
         ledger._serialize_and_commit(output_path)
         return ledger
 
+    layout = ShardedCacheLayout.parse(output_path)
     for shard_path in shard_cache_paths:
-        _relative_shard_path(output_path, shard_path)
+        layout.relative_shard(shard_path)
 
     logger.info(f"Consolidating {len(shard_cache_paths)} shard cache ledgers into {output_path}")
 
@@ -1211,8 +1258,9 @@ def _merge_sharded_ledgers(
         layout=CACHE_LAYOUT_SHARDED,
         metadata=metadata,
     )
+    layout = ShardedCacheLayout.parse(output_path)
     for shard_path, ledger, field_counts in zip(shard_cache_paths, shard_ledgers, per_shard_field_counts, strict=True):
-        shard_name = _relative_shard_path(output_path, shard_path)
+        shard_name = layout.relative_shard(shard_path)
         if shard_name in final_ledger.shard_rows:
             raise ValueError(f"Multiple shard cache paths resolve to the same ledger shard path: {shard_name}")
 
@@ -1376,27 +1424,6 @@ async def _consolidate_metadata(dest_path: str, exemplar: dict, shard_infos: lis
             delay *= 2
             if delay > 120:
                 raise
-
-
-def _relative_shard_path(output_path: str, shard_path: str) -> str:
-    """Return ``shard_path`` as a ledger key relative to ``output_path``.
-
-    Compares parsed path segments, so a trailing or doubled separator on either side
-    cannot fork the writer's shard path from the reader's. Raises ``ValueError`` unless
-    ``shard_path`` lies strictly under ``output_path``.
-    """
-    output = StoragePath.parse(output_path)
-    try:
-        relative = StoragePath.parse(shard_path).relative_to(output)
-    except ValueError as exc:
-        raise ValueError(f"Sharded cache path {shard_path} is not under output path {output_path}") from exc
-    # A local relative key with a `..` segment escapes the cache directory when joined
-    # back, so reject it. Object-store keys treat `..` as a literal segment, so this
-    # only applies to scheme-less filesystem paths.
-    escapes = output.scheme is None and ".." in relative.split("/")
-    if not relative or escapes:
-        raise ValueError(f"Sharded cache path {shard_path} is not under output path {output_path}")
-    return relative
 
 
 def _field_counts_from_store(store: TreeStore) -> Dict[str, int]:

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -174,9 +174,6 @@ class TreeCache(AsyncDataset[T_co]):
     def is_sharded(self) -> bool:
         return self.ledger.layout == CACHE_LAYOUT_SHARDED
 
-    def _shard_path(self, shard_name: str) -> str:
-        return self._layout.shard(shard_name)
-
     async def async_len(self) -> int:
         return await self._reader.async_len()
 
@@ -319,7 +316,7 @@ class TreeCache(AsyncDataset[T_co]):
     def _shard_store(self, shard_name: str) -> TreeStore[T_co]:
         store = self._shard_stores.get(shard_name)
         if store is None:
-            store = TreeStore.open(self._exemplar, self._shard_path(shard_name), mode="r", cache_metadata=True)
+            store = TreeStore.open(self._exemplar, self._layout.shard(shard_name), mode="r", cache_metadata=True)
             self._shard_stores[shard_name] = store
         return store
 
@@ -329,7 +326,7 @@ class TreeCache(AsyncDataset[T_co]):
         if store is None:
             tree_store = TreeStore.open(
                 _field_exemplar(self._exemplar, field),
-                self._shard_path(shard_name),
+                self._layout.shard(shard_name),
                 mode="r",
                 cache_metadata=True,
             )
@@ -343,7 +340,7 @@ class TreeCache(AsyncDataset[T_co]):
         if store is None:
             tree_store = await TreeStore.open_async(
                 _field_exemplar(self._exemplar, field),
-                self._shard_path(shard_name),
+                self._layout.shard(shard_name),
                 mode="r",
                 cache_metadata=True,
             )

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -597,7 +597,7 @@ class CacheLedger:
 
     @staticmethod
     def load(cache_dir: str, metadata: Optional["CacheMetadata"] = None) -> "CacheLedger":
-        ledger_path = os.path.join(cache_dir, LEDGER_FILE_NAME)
+        ledger_path = prefix_join(cache_dir, LEDGER_FILE_NAME)
         try:
             logger.info(f"Attempting to load cache ledger from {ledger_path}")
             with open_url(ledger_path) as file:
@@ -611,7 +611,7 @@ class CacheLedger:
             raise FileNotFoundError(f"Cache ledger not found at {ledger_path}") from exc
 
     def _serialize_and_commit(self, cache_dir):
-        path = os.path.join(cache_dir, LEDGER_FILE_NAME)
+        path = prefix_join(cache_dir, LEDGER_FILE_NAME)
         return _serialize_json_and_commit(path, self)  # type: ignore[arg-type]
 
 
@@ -961,7 +961,7 @@ def _build_single_shard_cache(
     options: CacheOptions,
     metadata: CacheMetadata,
 ):
-    shard_path = os.path.join(temp_root, f"{shard_index:05d}_{_sanitize_shard_name(shard_name)}")
+    shard_path = prefix_join(temp_root, f"{shard_index:05d}_{_sanitize_shard_name(shard_name)}")
     existing = _try_load(shard_path, metadata)
     if existing is not None:
         logger.info(f"Found existing shard cache for {shard_name} at {shard_path}. Skipping build.")

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -1382,8 +1382,8 @@ def _relative_shard_path(output_path: str, shard_path: str) -> str:
     """Return ``shard_path`` as a ledger key relative to ``output_path``.
 
     Compares parsed path segments, so a trailing or doubled separator on either side
-    cannot fork the writer's shard path from the reader's (#6838). Raises ``ValueError``
-    unless ``shard_path`` lies strictly under ``output_path``.
+    cannot fork the writer's shard path from the reader's. Raises ``ValueError`` unless
+    ``shard_path`` lies strictly under ``output_path``.
     """
     try:
         relative = StoragePath.parse(shard_path).relative_to(StoragePath.parse(output_path))

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -1385,11 +1385,16 @@ def _relative_shard_path(output_path: str, shard_path: str) -> str:
     cannot fork the writer's shard path from the reader's. Raises ``ValueError`` unless
     ``shard_path`` lies strictly under ``output_path``.
     """
+    output = StoragePath.parse(output_path)
     try:
-        relative = StoragePath.parse(shard_path).relative_to(StoragePath.parse(output_path))
+        relative = StoragePath.parse(shard_path).relative_to(output)
     except ValueError as exc:
         raise ValueError(f"Sharded cache path {shard_path} is not under output path {output_path}") from exc
-    if not relative:
+    # A local relative key with a `..` segment escapes the cache directory when joined
+    # back, so reject it. Object-store keys treat `..` as a literal segment, so this
+    # only applies to scheme-less filesystem paths.
+    escapes = output.scheme is None and ".." in relative.split("/")
+    if not relative or escapes:
         raise ValueError(f"Sharded cache path {shard_path} is not under output path {output_path}")
     return relative
 

--- a/lib/levanter/src/levanter/store/cache.py
+++ b/lib/levanter/src/levanter/store/cache.py
@@ -9,7 +9,6 @@ import gc
 import logging as pylogging
 import operator
 import os
-import re
 import threading
 import time
 from collections.abc import Iterable, Iterator, Mapping
@@ -19,7 +18,7 @@ from typing import Any, Dict, Generic, List, Optional, Protocol, Sequence, Tuple
 import deepdiff
 import jax
 import jax.tree_util as jtu
-from rigging.filesystem import open_url, url_to_fs
+from rigging.filesystem import StoragePath, open_url, prefix_join, url_to_fs
 import numpy as np
 import pyarrow as pa
 import tensorstore as ts
@@ -130,7 +129,7 @@ class TreeCache(AsyncDataset[T_co]):
         return self.ledger.layout == CACHE_LAYOUT_SHARDED
 
     def _shard_path(self, shard_name: str) -> str:
-        return os.path.join(self.cache_dir, shard_name)
+        return prefix_join(self.cache_dir, shard_name)
 
     async def async_len(self) -> int:
         return await self._reader.async_len()
@@ -1379,37 +1378,20 @@ async def _consolidate_metadata(dest_path: str, exemplar: dict, shard_infos: lis
                 raise
 
 
-def _collapse_duplicate_slashes(path: str) -> str:
-    """Collapse duplicate ``/`` in a path while preserving a URL scheme's ``://``.
-
-    Matches the normalization ``zephyr.dataset.format_shard_path`` applies when
-    writing shards, so consolidation is insensitive to a trailing slash in
-    ``MARIN_PREFIX`` (which yields ``//`` after the ``StepSpec`` path join).
-    """
-    return re.sub(r"(?<!:)//+", "/", path)
-
-
 def _relative_shard_path(output_path: str, shard_path: str) -> str:
-    output_path = _collapse_duplicate_slashes(output_path)
-    shard_path = _collapse_duplicate_slashes(shard_path)
-    if "://" in output_path or "://" in shard_path:
-        prefix = output_path.rstrip("/") + "/"
-        if shard_path.startswith(prefix):
-            return shard_path[len(prefix) :]
-        raise ValueError(f"Sharded cache path {shard_path} is not under output path {output_path}")
+    """Return ``shard_path`` as a ledger key relative to ``output_path``.
 
-    output_abs = os.path.abspath(output_path)
-    shard_abs = os.path.abspath(shard_path)
+    Compares parsed path segments, so a trailing or doubled separator on either side
+    cannot fork the writer's shard path from the reader's (#6838). Raises ``ValueError``
+    unless ``shard_path`` lies strictly under ``output_path``.
+    """
     try:
-        common_path = os.path.commonpath([output_abs, shard_abs])
+        relative = StoragePath.parse(shard_path).relative_to(StoragePath.parse(output_path))
     except ValueError as exc:
         raise ValueError(f"Sharded cache path {shard_path} is not under output path {output_path}") from exc
-
-    if shard_abs == output_abs or common_path != output_abs:
+    if not relative:
         raise ValueError(f"Sharded cache path {shard_path} is not under output path {output_path}")
-
-    relative_path = os.path.relpath(shard_abs, output_abs)
-    return relative_path
+    return relative
 
 
 def _field_counts_from_store(store: TreeStore) -> Dict[str, int]:

--- a/lib/levanter/src/levanter/tensorstore_serialization.py
+++ b/lib/levanter/src/levanter/tensorstore_serialization.py
@@ -29,7 +29,7 @@ from jax._src.mesh import get_concrete_mesh
 from jax.sharding import Mesh, Sharding
 from jaxtyping import PyTree
 
-from rigging.filesystem import record_transfer
+from rigging.filesystem import prefix_join, record_transfer
 
 from levanter._debug_logging import flush_debug_output
 from levanter.utils import fsspec_utils, jax_utils
@@ -393,7 +393,7 @@ def _restore_old_ts(
     Returns:
         Tuple of (deserialized_leaves, indices_to_load)
     """
-    paths = [os.path.join(checkpoint_dir, p) for p in paths]
+    paths = [prefix_join(checkpoint_dir, p) for p in paths]
 
     paths_to_load = []
     indices_to_load = []
@@ -493,14 +493,14 @@ def tree_deserialize_leaves_tensorstore(
         """Find the checkpoint root by looking for metadata.json"""
         current = path
         while current and current != os.path.dirname(current):
-            metadata_path = os.path.join(current, "metadata.json")
+            metadata_path = prefix_join(current, "metadata.json")
             if fsspec_utils.exists(metadata_path):
                 return current
             current = os.path.dirname(current)
         return path  # fallback to original path
 
     checkpoint_root = find_checkpoint_root(checkpoint_dir)
-    ocdbt_manifest_path = os.path.join(checkpoint_root, "manifest.ocdbt")
+    ocdbt_manifest_path = prefix_join(checkpoint_root, "manifest.ocdbt")
     is_ocdbt_checkpoint = fsspec_utils.exists(ocdbt_manifest_path)
 
     if is_ocdbt_checkpoint:

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -16,9 +16,9 @@ from levanter.store.cache import (
     CACHE_LAYOUT_SHARDED,
     CacheLedger,
     SerialCacheWriter,
+    ShardedCacheLayout,
     TreeCache,
     TreeStore,
-    _relative_shard_path,
     build_or_load_cache,
     write_levanter_cache,
 )
@@ -267,7 +267,7 @@ async def test_sharded_flat_field_offsets_share_in_flight_build(monkeypatch):
     ],
 )
 def test_relative_shard_path_structural(output_path, shard_path, expected):
-    assert _relative_shard_path(output_path, shard_path) == expected
+    assert ShardedCacheLayout.parse(output_path).relative_shard(shard_path) == expected
 
 
 @pytest.mark.parametrize(
@@ -286,7 +286,17 @@ def test_relative_shard_path_structural(output_path, shard_path, expected):
 )
 def test_relative_shard_path_rejects_non_descendants(output_path, shard_path):
     with pytest.raises(ValueError, match="not under output path"):
-        _relative_shard_path(output_path, shard_path)
+        ShardedCacheLayout.parse(output_path).relative_shard(shard_path)
+
+
+def test_sharded_cache_layout_members():
+    # A trailing slash on the root must not double the separator on any derived path.
+    layout = ShardedCacheLayout.parse("gs://bucket/cache/")
+    assert layout.ledger == "gs://bucket/cache/shard_ledger.json"
+    assert layout.shard("part-00000-of-00010") == "gs://bucket/cache/part-00000-of-00010"
+    child = layout.child("train")
+    assert str(child) == "gs://bucket/cache/train"
+    assert child.ledger == "gs://bucket/cache/train/shard_ledger.json"
 
 
 def test_sharded_cache_rejects_drifted_aggregate_field_counts():

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -261,6 +261,9 @@ async def test_sharded_flat_field_offsets_share_in_flight_build(monkeypatch):
         ("gs://bucket/cache", "gs://bucket/cache//train//shard_0", "train/shard_0"),
         # Local absolute paths.
         ("/tmp/cache", "/tmp/cache/shard_0", "shard_0"),
+        # An object-store key may contain a literal `..` segment (keys are not
+        # normalized), so it passes through rather than escaping a directory.
+        ("gs://bucket/cache", "gs://bucket/cache/../weird", "../weird"),
     ],
 )
 def test_relative_shard_path_structural(output_path, shard_path, expected):
@@ -276,6 +279,9 @@ def test_relative_shard_path_structural(output_path, shard_path, expected):
         ("gs://bucket/cache", "gs://other/cache/shard_0"),
         # shard_path equals output_path — no relative key to emit.
         ("gs://bucket/cache", "gs://bucket/cache"),
+        # A `..` segment in a local path escapes the cache directory once joined back.
+        ("/tmp/cache", "/tmp/cache/../outside/part"),
+        ("/tmp/cache", "/tmp/cache/a/../../etc"),
     ],
 )
 def test_relative_shard_path_rejects_non_descendants(output_path, shard_path):

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -18,6 +18,7 @@ from levanter.store.cache import (
     SerialCacheWriter,
     TreeCache,
     TreeStore,
+    _relative_shard_path,
     build_or_load_cache,
     write_levanter_cache,
 )
@@ -246,6 +247,40 @@ async def test_sharded_flat_field_offsets_share_in_flight_build(monkeypatch):
     cached_offsets = await cache._ensure_flat_field_offsets_async("data")
     np.testing.assert_array_equal(cached_offsets, expected_offsets)
     assert build_count == 1
+
+
+@pytest.mark.parametrize(
+    ("output_path", "shard_path", "expected"),
+    [
+        # gs:// shard strictly under output.
+        ("gs://bucket/cache", "gs://bucket/cache/train/shard_0", "train/shard_0"),
+        # A trailing slash on output_path (a trailing-slash MARIN_PREFIX) must not fork
+        # the relative key from the no-trailing-slash writer (marin-community/marin#6838).
+        ("gs://bucket/cache/", "gs://bucket/cache/train/shard_0", "train/shard_0"),
+        # A doubled interior separator on either side collapses structurally.
+        ("gs://bucket/cache", "gs://bucket/cache//train//shard_0", "train/shard_0"),
+        # Local absolute paths.
+        ("/tmp/cache", "/tmp/cache/shard_0", "shard_0"),
+    ],
+)
+def test_relative_shard_path_structural(output_path, shard_path, expected):
+    assert _relative_shard_path(output_path, shard_path) == expected
+
+
+@pytest.mark.parametrize(
+    ("output_path", "shard_path"),
+    [
+        # Sibling, not descendant.
+        ("gs://bucket/cache", "gs://bucket/other/shard_0"),
+        # Different bucket.
+        ("gs://bucket/cache", "gs://other/cache/shard_0"),
+        # shard_path equals output_path — no relative key to emit.
+        ("gs://bucket/cache", "gs://bucket/cache"),
+    ],
+)
+def test_relative_shard_path_rejects_non_descendants(output_path, shard_path):
+    with pytest.raises(ValueError, match="not under output path"):
+        _relative_shard_path(output_path, shard_path)
 
 
 def test_sharded_cache_rejects_drifted_aggregate_field_counts():

--- a/lib/levanter/tests/test_new_cache.py
+++ b/lib/levanter/tests/test_new_cache.py
@@ -255,7 +255,7 @@ async def test_sharded_flat_field_offsets_share_in_flight_build(monkeypatch):
         # gs:// shard strictly under output.
         ("gs://bucket/cache", "gs://bucket/cache/train/shard_0", "train/shard_0"),
         # A trailing slash on output_path (a trailing-slash MARIN_PREFIX) must not fork
-        # the relative key from the no-trailing-slash writer (marin-community/marin#6838).
+        # the relative key from the no-trailing-slash writer.
         ("gs://bucket/cache/", "gs://bucket/cache/train/shard_0", "train/shard_0"),
         # A doubled interior separator on either side collapses structurally.
         ("gs://bucket/cache", "gs://bucket/cache//train//shard_0", "train/shard_0"),

--- a/lib/marin/src/marin/datakit/download/common_corpus.py
+++ b/lib/marin/src/marin/datakit/download/common_corpus.py
@@ -3,9 +3,9 @@
 
 """Download, filter, and normalize PleIAs/common_corpus from HuggingFace."""
 
-import os
 
 from fray import ResourceConfig
+from rigging.filesystem import prefix_join
 from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.download.huggingface import download_hf_step
@@ -53,14 +53,14 @@ def download_common_corpus_raw_step() -> StepSpec:
 def filter_common_corpus(input_path: str, output_path: str) -> None:
     """Filter common_corpus to English + open types, writing parquet."""
     pipeline = (
-        Dataset.from_files(os.path.join(input_path, "**/*.parquet"))
+        Dataset.from_files(prefix_join(input_path, "**/*.parquet"))
         .load_parquet()
         .map(_count_total)
         .filter(_language_is_english)
         .filter(_open_type_allowed)
         .map(_count_kept)
         .write_parquet(
-            os.path.join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"),
+            prefix_join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"),
             skip_existing=True,
         )
     )

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -21,7 +21,7 @@ import fsspec
 import requests
 from fray import ResourceConfig
 from pydantic import BaseModel, ConfigDict
-from rigging.filesystem import marin_prefix, open_url, url_to_fs
+from rigging.filesystem import marin_prefix, open_url, prefix_join, url_to_fs
 from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.ingestion_manifest import (
@@ -517,7 +517,7 @@ def _write_source_metadata(
 def _normalize_input_path(path: str) -> str:
     if path.startswith("/") or "://" in path:
         return path
-    return os.path.join(marin_prefix(), path)
+    return prefix_join(marin_prefix(), path)
 
 
 def _path_exists(path: str) -> bool:
@@ -537,14 +537,14 @@ def _download_to_path(url: str, destination_path: str) -> None:
 
 
 def _stage_logchunks_if_missing(destination_dir: str) -> str:
-    archive_path = os.path.join(destination_dir, LOGCHUNKS_ZIP_FILENAME)
+    archive_path = prefix_join(destination_dir, LOGCHUNKS_ZIP_FILENAME)
     if not _path_exists(archive_path):
         _download_to_path(LOGCHUNKS_DOWNLOAD_URL, archive_path)
     return destination_dir
 
 
 def _stage_loghub_if_missing(destination_dir: str) -> str:
-    loghub_root = os.path.join(destination_dir, LOGHUB_DIRNAME)
+    loghub_root = prefix_join(destination_dir, LOGHUB_DIRNAME)
     if _list_loghub_files(loghub_root, 1):
         return destination_dir
 
@@ -558,7 +558,7 @@ def _stage_loghub_if_missing(destination_dir: str) -> str:
             _, _, relative_path = member.filename.partition("/")
             if not relative_path:
                 continue
-            destination_path = os.path.join(loghub_root, relative_path)
+            destination_path = prefix_join(loghub_root, relative_path)
             fsspec_mkdirs(os.path.dirname(destination_path), exist_ok=True)
             with archive.open(member, "r") as reader, open_url(destination_path, "wb") as writer:
                 shutil.copyfileobj(reader, writer)
@@ -567,7 +567,7 @@ def _stage_loghub_if_missing(destination_dir: str) -> str:
 
 def _resolve_ghalogs_archive_path(input_path: str) -> tuple[str, str]:
     normalized_input_path = _normalize_input_path(input_path)
-    archive_path = os.path.join(normalized_input_path, GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH)
+    archive_path = prefix_join(normalized_input_path, GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH)
     if not _path_exists(archive_path):
         raise FileNotFoundError(
             "Missing staged GHALogs archive. "
@@ -579,7 +579,7 @@ def _resolve_ghalogs_archive_path(input_path: str) -> tuple[str, str]:
 
 def _resolve_logchunks_input_path(input_path: str | None) -> str:
     normalized_input_path = _normalize_input_path(input_path or LOGCHUNKS_STAGED_PREFIX)
-    archive_path = os.path.join(normalized_input_path, LOGCHUNKS_ZIP_FILENAME)
+    archive_path = prefix_join(normalized_input_path, LOGCHUNKS_ZIP_FILENAME)
     if not _path_exists(archive_path):
         normalized_input_path = _stage_logchunks_if_missing(normalized_input_path)
     return normalized_input_path
@@ -587,7 +587,7 @@ def _resolve_logchunks_input_path(input_path: str | None) -> str:
 
 def _resolve_loghub_input_path(input_path: str | None) -> str:
     normalized_input_path = _normalize_input_path(input_path or LOGHUB_STAGED_PREFIX)
-    loghub_root = os.path.join(normalized_input_path, LOGHUB_DIRNAME)
+    loghub_root = prefix_join(normalized_input_path, LOGHUB_DIRNAME)
     if not _list_loghub_files(loghub_root, 1):
         normalized_input_path = _stage_loghub_if_missing(normalized_input_path)
     return normalized_input_path
@@ -664,7 +664,7 @@ def materialize_ghalogs_to_parquet(
         .reshard(num_shards)
         .flat_map(lambda batch: _process_ghalogs_member_batch(batch, archive_path))
         .write_parquet(
-            f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet",
+            prefix_join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"),
             skip_existing=True,
         )
     )
@@ -679,7 +679,7 @@ def materialize_ghalogs_to_parquet(
     return MaterializedDiagnosticLogParquet(
         source_label=manifest.source_label,
         output_dir=output_path,
-        data_glob=f"{output_path}/*.parquet",
+        data_glob=prefix_join(output_path, "*.parquet"),
         record_count=counters_dict.get("zephyr/records_out", 0),
         counters=counters_dict,
         content_fingerprint=manifest.fingerprint(),
@@ -710,11 +710,11 @@ def materialize_ghalogs_partition_to_parquet(
     output files.
     """
     pipeline = (
-        Dataset.from_files(f"{input_path}/*.parquet")
+        Dataset.from_files(prefix_join(input_path, "*.parquet"))
         .load_parquet()
         .filter(lambda record: record.get("partition") == partition.value)
         .map(lambda record: _count_partition_record(record, partition))
-        .write_parquet(f"{output_path}/data-{{shard:05d}}-of-{{total:05d}}.parquet", skip_existing=True)
+        .write_parquet(prefix_join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"), skip_existing=True)
     )
 
     resources = worker_resources or ResourceConfig(cpu=1, ram="8g", disk="10g")
@@ -727,7 +727,7 @@ def materialize_ghalogs_partition_to_parquet(
     return MaterializedDiagnosticLogParquet(
         source_label=manifest.source_label,
         output_dir=output_path,
-        data_glob=f"{output_path}/*.parquet",
+        data_glob=prefix_join(output_path, "*.parquet"),
         record_count=counters_dict.get("zephyr/records_out", 0),
         counters=counters_dict,
         content_fingerprint=manifest.fingerprint(),
@@ -751,9 +751,9 @@ def extract_ghalogs(
 
     output_file_paths: dict[str, str] = {}
     for partition in DiagnosticPartition:
-        partition_dir = os.path.join(output_path, partition.value)
+        partition_dir = prefix_join(output_path, partition.value)
         fsspec_mkdirs(partition_dir, exist_ok=True)
-        output_file_paths[partition.value] = os.path.join(partition_dir, "data-00000-of-00001.jsonl")
+        output_file_paths[partition.value] = prefix_join(partition_dir, "data-00000-of-00001.jsonl")
 
     logger.info("Extracting at most %d members from %s", max_members, archive_path)
     with open_url(archive_path, "rb") as archive_handle, zipfile.ZipFile(archive_handle) as archive:
@@ -849,11 +849,11 @@ def extract_logchunks(
         raise ValueError(f"max_examples must be positive, got {max_examples}")
 
     input_path = _resolve_logchunks_input_path(input_path)
-    archive_path = os.path.join(input_path, LOGCHUNKS_ZIP_FILENAME)
-    output_file = os.path.join(output_path, "eval_only", "logchunks", "data-00000-of-00001.jsonl")
+    archive_path = prefix_join(input_path, LOGCHUNKS_ZIP_FILENAME)
+    output_file = prefix_join(output_path, "eval_only/logchunks/data-00000-of-00001.jsonl")
     kept_records, bytes_written = _write_jsonl_records(output_file, _iter_logchunks_records(archive_path, max_examples))
     manifest = SOURCE_MANIFESTS["logchunks"]
-    slice_output_dir = os.path.join(output_path, "eval_only", "logchunks")
+    slice_output_dir = prefix_join(output_path, "eval_only/logchunks")
     metadata_path = _write_source_metadata(
         manifest=manifest,
         input_path=input_path,
@@ -912,11 +912,11 @@ def extract_loghub(
         raise ValueError(f"max_files must be positive, got {max_files}")
 
     input_path = _resolve_loghub_input_path(input_path)
-    loghub_path = os.path.join(input_path, LOGHUB_DIRNAME)
-    output_file = os.path.join(output_path, "eval_only", "loghub", "data-00000-of-00001.jsonl")
+    loghub_path = prefix_join(input_path, LOGHUB_DIRNAME)
+    output_file = prefix_join(output_path, "eval_only/loghub/data-00000-of-00001.jsonl")
     kept_records, bytes_written = _write_jsonl_records(output_file, _iter_loghub_records(loghub_path, max_files))
     manifest = SOURCE_MANIFESTS["loghub"]
-    slice_output_dir = os.path.join(output_path, "eval_only", "loghub")
+    slice_output_dir = prefix_join(output_path, "eval_only/loghub")
     metadata_path = _write_source_metadata(
         manifest=manifest,
         input_path=input_path,

--- a/lib/marin/src/marin/datakit/download/hplt.py
+++ b/lib/marin/src/marin/datakit/download/hplt.py
@@ -4,7 +4,6 @@
 """Download and filter HPLT v3.0 dataset, keeping only non-Common Crawl sources (WIDE, survey)."""
 
 import logging
-import os
 from collections.abc import Iterator
 from contextlib import closing
 from dataclasses import dataclass
@@ -12,6 +11,7 @@ from functools import cache
 
 import requests
 from fray import ResourceConfig
+from rigging.filesystem import prefix_join
 from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.download.http_session import build_retrying_session
@@ -204,7 +204,7 @@ def download_hplt_v3(output_path: str) -> None:
     pipeline = (
         Dataset.from_list(all_shards)
         .flat_map(_download_and_filter_shard)
-        .write_parquet(os.path.join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"), skip_existing=True)
+        .write_parquet(prefix_join(output_path, "data-{shard:05d}-of-{total:05d}.parquet"), skip_existing=True)
     )
 
     ctx = ZephyrContext(

--- a/lib/marin/src/marin/datakit/download/huggingface.py
+++ b/lib/marin/src/marin/datakit/download/huggingface.py
@@ -18,7 +18,7 @@ import huggingface_hub
 from fray import ResourceConfig
 from huggingface_hub.errors import HfHubHTTPError
 from packaging.version import Version
-from rigging.filesystem import atomic_rename, open_url, url_to_fs
+from rigging.filesystem import atomic_rename, open_url, prefix_join, url_to_fs
 from rigging.log_setup import configure_logging
 from zephyr import Dataset, ZephyrContext
 
@@ -164,7 +164,7 @@ def ensure_fsspec_path_writable(output_path: str) -> None:
     fs, _ = url_to_fs(output_path)
     try:
         fs.mkdirs(output_path, exist_ok=True)
-        test_path = os.path.join(output_path, "test_write_access")
+        test_path = prefix_join(output_path, "test_write_access")
         with fs.open(test_path, "w") as f:
             f.write("test")
         fs.rm(test_path)
@@ -298,7 +298,7 @@ def download_hf(cfg: DownloadConfig) -> None:
     # Some historical datasets were written that way, so this flag keeps backwards compatibility when needed.
 
     # Ensure the output path is writable
-    output_path = os.path.join(cfg.gcs_output_path, cfg.revision) if cfg.append_sha_to_path else cfg.gcs_output_path
+    output_path = prefix_join(cfg.gcs_output_path, cfg.revision) if cfg.append_sha_to_path else cfg.gcs_output_path
     ensure_fsspec_path_writable(output_path)
 
     # Resolve source URL and filesystem. For production this is an hf:// URL backed
@@ -343,7 +343,7 @@ def download_hf(cfg: DownloadConfig) -> None:
         relative_file_path = _relative_path_in_source(file, source_root)
         if relative_file_path.startswith(".."):
             raise ValueError(f"Computed path escapes source root: source={hf_source_path}, file={file}")
-        fsspec_file_path = os.path.join(output_path, relative_file_path)
+        fsspec_file_path = prefix_join(output_path, relative_file_path)
         expected_size = file_sizes.get(file)
         # Fully-qualify the source URL so subprocess workers can open it via fsspec
         # without having to reconstruct HfFileSystem / revision state.
@@ -368,7 +368,8 @@ def download_hf(cfg: DownloadConfig) -> None:
         Dataset.from_list(download_tasks)
         .map(lambda task: stream_file_to_fsspec(*task))
         .write_jsonl(
-            f"{cfg.gcs_output_path}/.metrics/success-part-{{shard:05d}}-of-{{total:05d}}.jsonl", skip_existing=True
+            prefix_join(cfg.gcs_output_path, ".metrics/success-part-{shard:05d}-of-{total:05d}.jsonl"),
+            skip_existing=True,
         )
     )
     ctx_kwargs: dict = {"name": "download-hf", "max_workers": cfg.zephyr_max_parallelism}

--- a/lib/marin/src/marin/datakit/download/nemotron_v1.py
+++ b/lib/marin/src/marin/datakit/download/nemotron_v1.py
@@ -5,10 +5,9 @@
 
 import json
 import logging
-import os
 
 from fray.cluster import ResourceConfig
-from rigging.filesystem import atomic_rename, open_url
+from rigging.filesystem import atomic_rename, open_url, prefix_join
 from zephyr import Dataset, ZephyrContext
 
 from marin.datakit.download.http_session import build_retrying_session
@@ -54,7 +53,7 @@ def download_single_nemotron_path(input_file_path: str, output_file_path: str, b
 def download_nemotron_cc(output_path: str, base_url: str = NCC_BASE_URL) -> None:
     """Download and process Nemotron-CC dataset from Common Crawl."""
 
-    paths_file_path = os.path.join(output_path, "data-jsonl.paths")
+    paths_file_path = prefix_join(output_path, "data-jsonl.paths")
     paths_file_url = f"{base_url}/{NCC_PATHS_SUFFIX}"
     logger.info(f"Downloading Nemotron CC path file {paths_file_path}")
 
@@ -66,7 +65,7 @@ def download_nemotron_cc(output_path: str, base_url: str = NCC_BASE_URL) -> None
     with open_url(paths_file_path, "r", compression="gzip") as f:
         for line in f:
             file = line.strip()
-            output_file_path = os.path.join(output_path, file).replace("jsonl.zstd", "jsonl.zst")
+            output_file_path = prefix_join(output_path, file).replace("jsonl.zstd", "jsonl.zst")
             all_files.append((file, output_file_path))
 
     logger.info(f"Processing {len(all_files)} Nemotron CC files")
@@ -75,7 +74,7 @@ def download_nemotron_cc(output_path: str, base_url: str = NCC_BASE_URL) -> None
         Dataset.from_list(all_files)
         .filter(lambda file_info: not fsspec_exists(file_info[1]))
         .map(lambda file_info: download_single_nemotron_path(file_info[0], file_info[1], base_url=base_url))
-        .write_jsonl(os.path.join(output_path, ".metrics/download-{shard:05d}.jsonl"), skip_existing=True)
+        .write_jsonl(prefix_join(output_path, ".metrics/download-{shard:05d}.jsonl"), skip_existing=True)
     )
 
     # Each worker downloads a ~350MB zstd file and decompresses to ~1.5-2GB in memory.

--- a/lib/marin/src/marin/datakit/download/nsf_awards.py
+++ b/lib/marin/src/marin/datakit/download/nsf_awards.py
@@ -10,11 +10,11 @@ single Parquet file per year.
 
 import json
 import logging
-import os
 import zipfile
 from io import BytesIO
 
 import requests
+from rigging.filesystem import prefix_join
 from zephyr import Dataset, ZephyrContext, counters
 from zephyr.writers import write_parquet_file
 
@@ -104,7 +104,7 @@ def download_and_convert_year(year: int, download_url: str, output_path: str) ->
         logger.warning(f"No awards with abstracts for {year}, skipping.")
         return {"year": year, "num_awards": 0}
 
-    output_file = os.path.join(output_path, f"{year}.parquet")
+    output_file = prefix_join(output_path, f"{year}.parquet")
     result = write_parquet_file(records, output_file)
 
     logger.info(f"Wrote {len(records)} awards for {year} to {output_file}")
@@ -130,7 +130,7 @@ def download_nsf_awards(min_year: int, max_year: int, output_path: str) -> None:
     pipeline = (
         Dataset.from_list(tasks)
         .map(lambda task: download_and_convert_year(task["year"], task["url"], task["output_path"]))
-        .write_jsonl(f"{output_path}/.metrics/download-{{shard:05d}}.jsonl", skip_existing=True)
+        .write_jsonl(prefix_join(output_path, ".metrics/download-{shard:05d}.jsonl"), skip_existing=True)
     )
     ctx = ZephyrContext(name="download-nsf-awards")
     ctx.execute(pipeline)

--- a/lib/marin/src/marin/datakit/download/wikipedia.py
+++ b/lib/marin/src/marin/datakit/download/wikipedia.py
@@ -11,12 +11,11 @@ Note: The enwiki-NS0 file (English Wikipedia, namespace 0 = articles) is approxi
 """
 
 import logging
-import os
 import tarfile
 from collections.abc import Iterable
 
 import requests
-from rigging.filesystem import atomic_rename, open_url
+from rigging.filesystem import atomic_rename, open_url, prefix_join
 from tqdm_loggable.auto import tqdm
 from zephyr import Dataset, ZephyrContext, load_jsonl
 
@@ -28,7 +27,7 @@ logger = logging.getLogger(__name__)
 
 def download_tar(url: str, output_prefix: str) -> str:
     shard_filename = url.split("/")[-1]
-    output_filename = os.path.join(output_prefix, shard_filename)
+    output_filename = prefix_join(output_prefix, shard_filename)
     logger.info(f"Downloading URL: {url} to {output_filename}")
 
     try:
@@ -65,7 +64,7 @@ def process_file(input_file: str, output_path: str) -> Iterable[str]:
                         continue
                     with file:
                         file_content = file.read()
-                        file_path = os.path.join(output_path, info.name + ".gz")
+                        file_path = prefix_join(output_path, info.name + ".gz")
 
                     # Each file is a .ndjson file, which contains about 18k-21k articles
                     # per file with size ranging from 200MB to 300MB
@@ -84,13 +83,13 @@ def process_file(input_file: str, output_path: str) -> Iterable[str]:
 def download_wikipedia(input_urls: list[str], revision: str, output_path: str) -> None:
     """Download and process Wikipedia data."""
     logger.info("Starting transfer of Wikipedia dump...")
-    output_base = os.path.join(output_path, revision)
+    output_base = prefix_join(output_path, revision)
 
     ctx = ZephyrContext(name="download-wikipedia")
     download_metrics = ctx.execute(
         Dataset.from_list(input_urls)
         .map(lambda url: download_tar(url, output_base))
-        .write_jsonl(f"{output_base}/.metrics/download-{{shard:05d}}.jsonl", skip_existing=True),
+        .write_jsonl(prefix_join(output_base, ".metrics/download-{shard:05d}.jsonl"), skip_existing=True),
     ).results
 
     # load all of the output filenames to process
@@ -99,7 +98,7 @@ def download_wikipedia(input_urls: list[str], revision: str, output_path: str) -
     extracted = ctx.execute(
         Dataset.from_list(downloads)
         .flat_map(lambda file: process_file(file, output_base))
-        .write_jsonl(f"{output_base}/.metrics/process-{{shard:05d}}.jsonl", skip_existing=True),
+        .write_jsonl(prefix_join(output_base, ".metrics/process-{shard:05d}.jsonl"), skip_existing=True),
     ).results
 
     logger.info("Wikipedia dump transfer complete, wrote: %s", extracted)

--- a/lib/marin/src/marin/datakit/normalize.py
+++ b/lib/marin/src/marin/datakit/normalize.py
@@ -25,7 +25,7 @@ from typing import Any
 import dupekit
 from fray import ResourceConfig
 from pydantic import BaseModel
-from rigging.filesystem import url_to_fs
+from rigging.filesystem import prefix_join, url_to_fs
 from zephyr import Dataset, ShardInfo, ZephyrContext, counters, write_parquet_file
 from zephyr.readers import SUPPORTED_EXTENSIONS, load_file
 from zephyr.writers import ThreadedBatchWriter
@@ -270,8 +270,8 @@ def _make_split_writer(
     ) -> Iterator[dict[str, dict[str, Any]]]:
         # NOTE: we could add support for split_existing - but we intentionally don't
         shard_filename = partition_filename(shard.shard_idx, shard.total_shards)
-        main_path = f"{output_dir}/outputs/main/{shard_filename}"
-        dup_path = f"{output_dir}/outputs/dups/{shard_filename}"
+        main_path = prefix_join(output_dir, f"outputs/main/{shard_filename}")
+        dup_path = prefix_join(output_dir, f"outputs/dups/{shard_filename}")
 
         # Results are populated by each writer thread. Safe to read only after
         # the ThreadedBatchWriter context exits (which joins the thread).
@@ -458,8 +458,8 @@ def normalize_to_parquet(
         )
 
     return NormalizedData(
-        main_output_dir=os.path.join(output_path, "outputs/main"),
-        dup_output_dir=os.path.join(output_path, "outputs/dups"),
+        main_output_dir=prefix_join(output_path, "outputs/main"),
+        dup_output_dir=prefix_join(output_path, "outputs/dups"),
         counters=counters_dict,
     )
 
@@ -504,11 +504,10 @@ def normalize_step(
             Defaults to ``DedupMode.EXACT``; use ``DedupMode.NONE`` to skip.
     """
     if relative_input_path:
-        # ``os.path.join`` collapses redundant separators when ``download.output_path``
-        # ends with ``/`` (e.g. ``override_output_path="gs://.../nemotro-cc-eeb783/"``);
-        # naive f-string concatenation would yield ``gs://.../nemotro-cc-eeb783//<rel>``,
-        # which ``_discover_files`` then fails to resolve on GCS.
-        resolved_input = os.path.join(download.output_path, relative_input_path)
+        # ``prefix_join`` yields exactly one separator even when ``download.output_path``
+        # ends with ``/`` (e.g. ``gs://.../nemotro-cc-eeb783/``); a naive f-string join
+        # would leave the doubled ``//`` that ``_discover_files`` then fails to resolve on GCS.
+        resolved_input = prefix_join(download.output_path, relative_input_path)
     else:
         resolved_input = download.output_path
 

--- a/lib/marin/src/marin/evaluation/evaluators/evalchemy_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/evalchemy_evaluator.py
@@ -36,7 +36,7 @@ from typing import ClassVar
 
 import wandb
 from rigging.filesystem import filesystem as marin_filesystem
-from rigging.filesystem import is_remote_path
+from rigging.filesystem import is_remote_path, prefix_join
 
 from marin.evaluation.evaluation_config import WANDB_PROJECT, EvalTaskConfig
 from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig
@@ -600,7 +600,7 @@ _enable_vllm_stat_logging()
         gcs_path_clean = gcs_path.rstrip("/")
 
         for filename in self.CONFIG_FILES:
-            remote = f"{gcs_path_clean}/{filename}"
+            remote = prefix_join(gcs_path_clean, filename)
             local = os.path.join(local_dir, filename)
             try:
                 if fs.exists(remote):

--- a/lib/marin/src/marin/evaluation/evaluators/harbor_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/harbor_evaluator.py
@@ -27,7 +27,7 @@ from typing import Any
 import pandas as pd
 import wandb
 from huggingface_hub import snapshot_download
-from rigging.filesystem import is_remote_path, open_url
+from rigging.filesystem import is_remote_path, open_url, prefix_join
 
 from marin.evaluation.evaluation_config import EvalTaskConfig
 from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig
@@ -140,12 +140,12 @@ def _restore_trials_from_gcs(gcs_output_path: str, local_job_dir: Path) -> int:
 
     Returns the number of trials restored.
     """
-    trials_gcs_path = os.path.join(gcs_output_path, "harbor_trials")
+    trials_gcs_path = prefix_join(gcs_output_path, "harbor_trials")
     if not fsspec_exists(trials_gcs_path):
         return 0
 
     # Find completed trials (those with result.json)
-    result_files = fsspec_glob(os.path.join(trials_gcs_path, "*/result.json"))
+    result_files = fsspec_glob(prefix_join(trials_gcs_path, "*/result.json"))
 
     restored = 0
     for result_file in result_files:
@@ -187,7 +187,7 @@ def _create_trial_upload_hook(gcs_output_path: str, local_job_dir: Path):
         _fix_docker_permissions(local_trial_dir)
 
         # Upload to GCS: {output_path}/harbor_trials/{trial_name}/
-        trial_gcs_path = os.path.join(gcs_output_path, "harbor_trials", trial_name)
+        trial_gcs_path = prefix_join(gcs_output_path, f"harbor_trials/{trial_name}")
         try:
             upload_to_gcs(str(local_trial_dir), trial_gcs_path)
             logger.info(f"Uploaded trial {trial_name} to GCS")

--- a/lib/marin/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/levanter_lm_eval_evaluator.py
@@ -4,7 +4,6 @@
 import dataclasses
 import json
 import logging
-import os
 
 import jmp
 import levanter
@@ -13,6 +12,7 @@ from levanter.compat.hf_checkpoints import HFCheckpointConverter
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer import TrainerConfig
 from rigging.filesystem import filesystem as marin_filesystem
+from rigging.filesystem import prefix_join
 
 from marin.evaluation.evaluation_config import EvalTaskConfig, convert_to_levanter_task_config
 from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig
@@ -89,7 +89,7 @@ class LevanterLmEvalEvaluator(Evaluator):
 
         # Upload is best-effort: a transient GCS failure should not throw away an
         # otherwise successful (and very expensive) eval run.
-        results_path = os.path.join(output_path, "results.json")
+        results_path = prefix_join(output_path, "results.json")
         logger.info(f"Uploading results to GCS: {results_path}")
         try:
             fs = marin_filesystem("gcs")

--- a/lib/marin/src/marin/evaluation/evaluators/lm_evaluation_harness_evaluator.py
+++ b/lib/marin/src/marin/evaluation/evaluators/lm_evaluation_harness_evaluator.py
@@ -8,7 +8,7 @@ import tempfile
 from collections.abc import Iterator
 from contextlib import contextmanager
 
-from rigging.filesystem import is_remote_path, open_url, url_to_fs
+from rigging.filesystem import is_remote_path, open_url, prefix_join, url_to_fs
 
 from marin.evaluation.evaluation_config import EvalTaskConfig
 from marin.evaluation.evaluators.evaluator import Evaluator, ModelConfig
@@ -43,7 +43,7 @@ class LMEvaluationHarnessEvaluator(Evaluator):
         with tempfile.TemporaryDirectory(prefix="marin-tokenizer-") as local_dir:
             copied_any = False
             for filename in cls.TOKENIZER_FILENAMES:
-                remote_path = f"{remote_dir.rstrip('/')}/{filename}"
+                remote_path = prefix_join(remote_dir, filename)
                 if not is_remote_path(remote_path):
                     continue
                 fs, fs_path = url_to_fs(remote_path)

--- a/lib/marin/src/marin/execution/step_status.py
+++ b/lib/marin/src/marin/execution/step_status.py
@@ -27,7 +27,7 @@ from rigging.distributed_lock import (
     create_lock,
     default_worker_id,
 )
-from rigging.filesystem import url_to_fs
+from rigging.filesystem import prefix_join, url_to_fs
 
 logger = logging.getLogger(__name__)
 
@@ -41,7 +41,7 @@ STATUS_DEP_FAILED = "DEP_FAILED"  # Dependency failed
 
 def get_status_path(output_path: str) -> str:
     """Return the path of the status file associated with `output_path`."""
-    return os.path.join(output_path, ".executor_status")
+    return prefix_join(output_path, ".executor_status")
 
 
 class StatusFile:

--- a/lib/marin/src/marin/execution/sweep.py
+++ b/lib/marin/src/marin/execution/sweep.py
@@ -25,10 +25,11 @@ announcements are inert because no followers exist.
 """
 
 import logging
-import os
 from collections.abc import Callable, Iterable
 from dataclasses import dataclass
 from typing import Any
+
+from rigging.filesystem import prefix_join
 
 from marin.execution.step_status import (
     STATUS_FAILED,
@@ -129,7 +130,7 @@ def _lead(
     """
     seq = 0
     for target in targets:
-        target_path = os.path.join(sweep_root, target.target_id)
+        target_path = prefix_join(sweep_root, target.target_id)
         try:
             with step_lock(target_path, target.target_id) as status_file:
                 # Announce before training so the gang enters run_fn together;

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -22,12 +22,12 @@ from dataclasses import dataclass
 from enum import StrEnum
 
 from fray import ResourceConfig
+from rigging.filesystem import rebase_file_path
 from zephyr import Dataset, ZephyrContext, ZephyrExecutionResult
 
 from marin.utils import (
     fsspec_exists,
     fsspec_glob,
-    rebase_file_path,
 )
 
 

--- a/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/dedup_commons.py
@@ -10,11 +10,12 @@ import pyarrow as pa
 import pyarrow.json as pa_json
 import pyarrow.parquet as pq
 import wandb
+from rigging.filesystem import rebase_file_path
 from zephyr import counters, write_parquet_file
 from zephyr.readers import SUPPORTED_EXTENSIONS, open_file
 
 from marin.utilities.wandb_utils import init_wandb
-from marin.utils import fsspec_glob, rebase_file_path
+from marin.utils import fsspec_glob
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -9,6 +9,7 @@ import dupekit
 import humanfriendly
 import pyarrow as pa
 from fray import ResourceConfig
+from rigging.filesystem import rebase_file_path
 from zephyr import DEFAULT_FILE_PATH_COLUMN, ZephyrContext, counters, write_parquet_file
 from zephyr.dataset import Dataset
 
@@ -23,7 +24,6 @@ from marin.processing.classification.deduplication.dedup_commons import (
     finalize_dedup,
     make_document_dedup_aggregator,
 )
-from marin.utils import rebase_file_path
 
 logger = logging.getLogger(__name__)
 

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -22,6 +22,7 @@ import dupekit
 import pyarrow as pa
 from fray import ResourceConfig
 from pydantic import BaseModel
+from rigging.filesystem import prefix_join
 from zephyr import Dataset, ZephyrContext, counters
 
 from marin.datakit.normalize import NormalizedData
@@ -201,9 +202,9 @@ def compute_minhash_attrs(
         seed=seed,
         text_cap_chars=text_cap_chars,
     )
-    attr_dir = os.path.join(output_path, "outputs")
+    attr_dir = prefix_join(output_path, "outputs")
 
-    source_shards = sorted(fsspec_glob(f"{source.main_output_dir.rstrip('/')}/*.parquet"))
+    source_shards = sorted(fsspec_glob(prefix_join(source.main_output_dir, "*.parquet")))
     if not source_shards:
         raise FileNotFoundError(f"No parquet shards found under {source.main_output_dir}")
 
@@ -229,7 +230,7 @@ def compute_minhash_attrs(
     output_basenames = tuple(os.path.basename(p) for p in source_shards)
 
     def _output_path(shard_idx: int, total_shards: int, ad: str = attr_dir, bn: tuple = output_basenames) -> str:
-        return f"{ad}/{bn[shard_idx]}"
+        return prefix_join(ad, bn[shard_idx])
 
     pipeline = (
         Dataset.from_list(source_shards)

--- a/lib/marin/src/marin/processing/tokenize/attributes.py
+++ b/lib/marin/src/marin/processing/tokenize/attributes.py
@@ -31,6 +31,7 @@ from fray import ResourceConfig
 from levanter.data.text import LmDatasetFormatBase, TextLmDatasetFormat
 from levanter.tokenizers import TokenizerBackend
 from pydantic import BaseModel
+from rigging.filesystem import prefix_join
 from zephyr import Dataset, ZephyrContext
 from zephyr.readers import load_file
 
@@ -80,7 +81,7 @@ class TokenizedAttrData(BaseModel):
         d = self.output_dirs.get(split)
         if d is None:
             return []
-        return sorted(fsspec_glob(f"{d.rstrip('/')}/*.parquet"))
+        return sorted(fsspec_glob(prefix_join(d, "*.parquet")))
 
 
 @dataclasses.dataclass(frozen=True, kw_only=True)
@@ -126,15 +127,15 @@ def _process_split(
 
     Returns ``(split_output_dir, counters)``.
     """
-    source_shards = sorted(fsspec_glob(f"{source.main_output_dir.rstrip('/')}/*.parquet"))
+    source_shards = sorted(fsspec_glob(prefix_join(source.main_output_dir, "*.parquet")))
     if not source_shards:
         raise FileNotFoundError(f"No parquet shards found under {source.main_output_dir}")
 
-    split_dir = os.path.join(config.output_path, split)
+    split_dir = prefix_join(config.output_path, split)
     output_basenames = tuple(os.path.basename(p) for p in source_shards)
 
     def _output_path(shard_idx: int, total_shards: int, sd: str = split_dir, bn: tuple = output_basenames) -> str:
-        return f"{sd}/{bn[shard_idx]}"
+        return prefix_join(sd, bn[shard_idx])
 
     logger.info(
         "Tokenizing %s (split=%s): %d source shards → %s",

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -25,14 +25,13 @@ dispatches on the sharded layout.
 import dataclasses
 import json
 import logging
-import os
 import time
 
 import numpy as np
 from fray import ResourceConfig
 from levanter.store.cache import CacheLedger, consolidate_shard_cache_ledgers, write_levanter_cache
 from pydantic import BaseModel
-from rigging.filesystem import open_url, url_to_fs
+from rigging.filesystem import open_url, prefix_join, url_to_fs
 from zephyr import Dataset, ZephyrContext
 from zephyr.dataset import format_shard_path
 from zephyr.readers import load_file
@@ -143,7 +142,7 @@ def build_from_datasets(
     """
     pipeline_start = time.monotonic()
 
-    output_pattern = f"{output_path}/part-{{shard:05d}}-of-{{total:05d}}"
+    output_pattern = prefix_join(output_path, "part-{shard:05d}-of-{total:05d}")
     write_kwargs: dict = {"metadata": {}}
     if batch_size is not None:
         write_kwargs["batch_size"] = batch_size
@@ -157,7 +156,7 @@ def build_from_datasets(
         shard_path = format_shard_path(output_pattern, shard_info.shard_idx, shard_info.total_shards)
         if skip_existing:
             fs = url_to_fs(shard_path)[0]
-            if fs.exists(f"{shard_path}/.success"):
+            if fs.exists(prefix_join(shard_path, ".success")):
                 logger.info("Skipping write, output exists: %s", shard_path)
                 yield (shard_path, None)
                 return
@@ -203,7 +202,7 @@ def write_stats_json(output_path: str, ledger: CacheLedger) -> tuple[str, dict[s
     """
     total_tokens = ledger.field_counts.get("input_ids", 0)
     stats = {"total_tokens": total_tokens, "total_elements": ledger.total_num_rows}
-    stats_path = os.path.join(output_path, ".stats.json")
+    stats_path = prefix_join(output_path, ".stats.json")
     with open_url(stats_path, "w") as f:
         json.dump(stats, f)
     return stats_path, stats
@@ -268,7 +267,7 @@ def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
             logger.info("No shards for split %s; skipping", split)
             continue
 
-        split_output = os.path.join(config.cache_path, split)
+        split_output = prefix_join(config.cache_path, split)
 
         if _ledger_exists(split_output):
             logger.info("Shard ledger already exists for %s at %s; loading", split, split_output)
@@ -314,7 +313,7 @@ def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
 
 def _ledger_exists(cache_path: str) -> bool:
     """Return whether a Levanter cache ledger already exists at ``cache_path``."""
-    return fsspec_exists(os.path.join(cache_path, "shard_ledger.json"))
+    return fsspec_exists(prefix_join(cache_path, "shard_ledger.json"))
 
 
 def build_levanter_store_step(

--- a/lib/marin/src/marin/processing/tokenize/store_builder.py
+++ b/lib/marin/src/marin/processing/tokenize/store_builder.py
@@ -29,7 +29,12 @@ import time
 
 import numpy as np
 from fray import ResourceConfig
-from levanter.store.cache import CacheLedger, consolidate_shard_cache_ledgers, write_levanter_cache
+from levanter.store.cache import (
+    CacheLedger,
+    ShardedCacheLayout,
+    consolidate_shard_cache_ledgers,
+    write_levanter_cache,
+)
 from pydantic import BaseModel
 from rigging.filesystem import open_url, prefix_join, url_to_fs
 from zephyr import Dataset, ZephyrContext
@@ -313,7 +318,7 @@ def build_levanter_store(config: BuildLevanterStoreConfig) -> LevanterStoreData:
 
 def _ledger_exists(cache_path: str) -> bool:
     """Return whether a Levanter cache ledger already exists at ``cache_path``."""
-    return fsspec_exists(prefix_join(cache_path, "shard_ledger.json"))
+    return fsspec_exists(ShardedCacheLayout.parse(cache_path).ledger)
 
 
 def build_levanter_store_step(

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -17,7 +17,6 @@ The shared tokenization core lives in :mod:`marin.processing.tokenize._core`.
 import abc
 import dataclasses
 import logging
-import os
 import re
 import time
 from collections.abc import Sequence
@@ -33,6 +32,7 @@ from levanter.data.text import (
     UrlDatasetSourceConfig,
 )
 from levanter.tokenizers import TokenizerBackend
+from rigging.filesystem import StoragePath, prefix_join
 from zephyr import Dataset, ZephyrContext
 from zephyr.dataset import FileEntry
 from zephyr.readers import load_file
@@ -283,7 +283,7 @@ def _local_preprocess_paths(files: list[FileEntry], config: TokenizeConfigBase) 
 
 
 def _split_already_done(cache_path: str, split_name: str) -> bool:
-    ledger_path = os.path.join(cache_path, split_name, "shard_ledger.json")
+    ledger_path = str(StoragePath.parse(cache_path) / split_name / "shard_ledger.json")
     if fsspec_exists(ledger_path):
         logger.info("Shard ledger already exists for %s at %s; skipping", split_name, ledger_path)
         return True
@@ -297,7 +297,7 @@ def _run_split(
     split_name: str,
 ) -> None:
     """End-to-end pipeline for one split: glob → tokenize → consolidate → stats."""
-    prefix = os.path.join(config.cache_path, split_name)
+    prefix = prefix_join(config.cache_path, split_name)
     pipeline_start = time.monotonic()
 
     sample_path = parquet_window_hint(file_groups)

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -31,8 +31,9 @@ from levanter.data.text import (
     TextLmDatasetFormat,
     UrlDatasetSourceConfig,
 )
+from levanter.store.cache import ShardedCacheLayout
 from levanter.tokenizers import TokenizerBackend
-from rigging.filesystem import StoragePath, prefix_join
+from rigging.filesystem import prefix_join
 from zephyr import Dataset, ZephyrContext
 from zephyr.dataset import FileEntry
 from zephyr.readers import load_file
@@ -283,7 +284,7 @@ def _local_preprocess_paths(files: list[FileEntry], config: TokenizeConfigBase) 
 
 
 def _split_already_done(cache_path: str, split_name: str) -> bool:
-    ledger_path = str(StoragePath.parse(cache_path) / split_name / "shard_ledger.json")
+    ledger_path = ShardedCacheLayout.parse(cache_path).child(split_name).ledger
     if fsspec_exists(ledger_path):
         logger.info("Shard ledger already exists for %s at %s; skipping", split_name, ledger_path)
         return True

--- a/lib/marin/src/marin/scaling_laws/scaling_plots.py
+++ b/lib/marin/src/marin/scaling_laws/scaling_plots.py
@@ -9,7 +9,6 @@ module free of visualization dependencies.
 """
 
 import logging
-import os
 
 import fsspec
 import jax.numpy as jnp
@@ -17,6 +16,7 @@ import pandas as pd
 import plotly.graph_objects as go
 import plotly.io as pio
 import wandb
+from rigging.filesystem import prefix_join
 
 from marin.scaling_laws.isoflop_analysis import QuadraticFitCoeffs, ScalingFit
 from marin.utilities.wandb_utils import WANDB_ENTITY, WANDB_PROJECT
@@ -267,8 +267,8 @@ def save_plots(
     fs, _, _ = fsspec.get_fs_token_paths(output_path)
     fs.makedirs(output_path, exist_ok=True)
 
-    iso_path = os.path.join(output_path, "isoflop_plot.html")
-    scaling_path = os.path.join(output_path, "scaling_plot.html")
+    iso_path = prefix_join(output_path, "isoflop_plot.html")
+    scaling_path = prefix_join(output_path, "scaling_plot.html")
 
     with fs.open(iso_path, "w") as f:
         f.write(fig_isoflop.to_html())

--- a/lib/marin/src/marin/training/training.py
+++ b/lib/marin/src/marin/training/training.py
@@ -22,7 +22,7 @@ from levanter.main.train_lm import TrainLmConfig
 from levanter.schedule import BatchSchedule
 from mergedeep import mergedeep
 from pydantic import BaseModel
-from rigging.filesystem import check_gcs_paths_same_region, marin_temp_bucket, open_url, url_to_fs
+from rigging.filesystem import check_gcs_paths_same_region, marin_temp_bucket, open_url, prefix_join, url_to_fs
 
 from marin.execution.artifact import Artifact
 from marin.processing.tokenize import read_tokenized_cache_stats
@@ -64,14 +64,14 @@ class LevanterCheckpoint(Artifact):
     @property
     def checkpoint_dir(self) -> str:
         """The directory holding this run's rolling checkpoints."""
-        return f"{self.path}/{_CHECKPOINTS_SUBDIR}"
+        return prefix_join(self.path, _CHECKPOINTS_SUBDIR)
 
     def training_metrics(self) -> TrainMetrics:
         """This run's final metrics, parsed from ``tracker_metrics.jsonl`` under its output.
 
         Raises :class:`FileNotFoundError` if the run wrote no metrics file.
         """
-        path = f"{self.path}/{_TRACKER_METRICS_FILE}"
+        path = prefix_join(self.path, _TRACKER_METRICS_FILE)
         if not url_to_fs(path, use_listings_cache=False)[0].exists(path):
             raise FileNotFoundError(f"no {_TRACKER_METRICS_FILE} for checkpoint at {self.path}")
         with open_url(path, "r") as f:
@@ -170,7 +170,7 @@ def resolve_checkpointer_output_path(checkpointer: CheckpointerConfig, output_pa
     """
     return replace(
         checkpointer,
-        base_path=os.path.join(output_path, DEFAULT_CHECKPOINTS_PATH),
+        base_path=prefix_join(output_path, DEFAULT_CHECKPOINTS_PATH),
         temporary_base_path=temporary_checkpoint_base_path(output_path),
         append_run_id_to_base_path=False,
     )
@@ -189,7 +189,7 @@ def apply_output_path(train_config: TrainConfigT, output_path: str) -> TrainConf
             train_config.trainer,
             checkpointer=resolve_checkpointer_output_path(train_config.trainer.checkpointer, output_path),
         ),
-        hf_save_path=os.path.join(output_path, DEFAULT_HF_CHECKPOINTS_PATH),
+        hf_save_path=prefix_join(output_path, DEFAULT_HF_CHECKPOINTS_PATH),
     )
 
     if isinstance(config, (TrainDpoConfig, TrainLmConfig)) and not isinstance(config.adapter, NoAdaptorConfig):

--- a/lib/marin/src/marin/transform/conversation/transform_conversation.py
+++ b/lib/marin/src/marin/transform/conversation/transform_conversation.py
@@ -12,7 +12,6 @@ Usage Instructions:
 import hashlib
 import json
 import logging
-import os
 from collections import defaultdict
 from collections.abc import Sequence
 from dataclasses import dataclass, field
@@ -25,7 +24,7 @@ import draccus
 import fsspec
 from marin.core.conversation import DolmaConversationOutput, OpenAIChatMessage
 from marin.utils import fsspec_mkdirs, load_dataset_with_backoff
-from rigging.filesystem import url_to_fs
+from rigging.filesystem import StoragePath, prefix_join, url_to_fs
 from zephyr import Dataset, ZephyrContext, load_jsonl, write_jsonl_file
 
 from .adapters import TransformAdapter
@@ -219,7 +218,7 @@ def _get_available_splits(cfg: TransformSFTDatasetConfig, subset: str | None) ->
 
 
 def _shard_filename(output_path: str, shard_idx: int) -> str:
-    return os.path.join(output_path, f"shard_{shard_idx:05d}.jsonl.gz")
+    return prefix_join(output_path, f"shard_{shard_idx:05d}.jsonl.gz")
 
 
 def _streaming_dataset_kwargs(source: str, split: str, revision: str, subset: str | None) -> dict[str, object]:
@@ -239,13 +238,13 @@ def _streaming_dataset_kwargs(source: str, split: str, revision: str, subset: st
     return kwargs
 
 
-def get_shard_dir(dir_name: os.PathLike, subset_name: str | None, split: str) -> os.PathLike | str:
+def get_shard_dir(dir_name: str, subset_name: str | None, split: str) -> str:
     """Creates a new path with the subset and split names.
     e.g., create_subset_name('gs://thisserver/testfolder-a982374', 'subset', 'train') -> 'gs://thisserver/testfolder-a982374/subset/train'
     """
     if (subset_name == "default") or (subset_name is None):
-        return os.path.join(dir_name, split)
-    return os.path.join(dir_name, subset_name, split)
+        return prefix_join(dir_name, split)
+    return str(StoragePath.parse(dir_name) / subset_name / split)
 
 
 def get_dataset_tasks(cfg: TransformSFTDatasetConfig):
@@ -380,7 +379,7 @@ def transform_hf_dataset(cfg: TransformSFTDatasetConfig):
     all_tasks = list(get_dataset_tasks(cfg))
     logger.info(f"Found {len(all_tasks)} total shards across all subset/split combinations")
 
-    metrics_path = os.path.join(cfg.output_path, "metrics")
+    metrics_path = prefix_join(cfg.output_path, "metrics")
     pipeline = (
         Dataset.from_list(all_tasks)
         .map(process_shard_task)

--- a/lib/marin/src/marin/utils.py
+++ b/lib/marin/src/marin/utils.py
@@ -165,52 +165,6 @@ def is_path_like(path: str) -> bool:
     return os.path.exists(path)
 
 
-def rebase_file_path(
-    base_in_path: str,
-    file_path: str,
-    base_out_path: str,
-    new_extension: str | None = None,
-    old_extension: str | None = None,
-) -> str:
-    """
-    Rebase a file path from one directory to another, with an option to change the file extension.
-
-    Args:
-        base_in_path (str): The base directory of the input file
-        file_path (str): The path of the file
-        base_out_path (str): The base directory of the output file
-        new_extension (str, optional): If provided, the new file extension to use (including the dot, e.g., '.txt')
-        old_extension (str, optional): If provided along with new_extension, specifies the old extension to replace.
-                                       Must be the actual suffix of ``file_path``; a ``ValueError`` is raised if not.
-                                       If not provided (but `new_extension` is), the function will replace everything
-                                       after the last dot. If there is no dot, ``new_extension`` is appended.
-
-    Returns:
-        str: The rebased file path
-    """
-
-    rel_path = os.path.relpath(file_path, base_in_path)
-
-    if old_extension and not new_extension:
-        raise ValueError("old_extension requires new_extension to be set")
-
-    if new_extension:
-        if old_extension:
-            # Use endswith rather than rfind so we fail loudly on a mismatch instead of
-            # silently truncating the path (rfind returns -1, and rel_path[:-1] drops
-            # the last character).
-            if not rel_path.endswith(old_extension):
-                raise ValueError(
-                    f"Cannot rebase {file_path!r}: relative path {rel_path!r} does not end with "
-                    f"old_extension={old_extension!r}"
-                )
-            rel_path = rel_path[: -len(old_extension)] + new_extension
-        else:
-            dot_idx = rel_path.rfind(".")
-            rel_path = (rel_path[:dot_idx] if dot_idx != -1 else rel_path) + new_extension
-    return os.path.join(base_out_path, rel_path)
-
-
 def get_directory_friendly_name(name: str) -> str:
     """Convert a huggingface repo name to a directory friendly name."""
     return name.replace("/", "--").replace(".", "-").replace("#", "-")

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -154,7 +154,7 @@ class DataConfig:
 
         The env/explicit value is canonicalized through :class:`StoragePath` (trailing
         ``/`` stripped, interior ``//`` collapsed) so downstream joins never double the
-        separator (#6904).
+        separator.
         """
         env_prefix = os.environ.get(_MARIN_PREFIX_ENV)
         if env_prefix:
@@ -343,7 +343,7 @@ class StoragePath:
 
     Object-store keys are not normalized — a doubled ``/`` addresses a *different* key —
     so joins here are structural: a segment never contains a separator, which makes a
-    doubled or trailing separator unrepresentable (#6904). ``parse`` -> ``str`` is
+    doubled or trailing separator unrepresentable. ``parse`` -> ``str`` is
     therefore canonicalizing (interior ``//`` collapsed, trailing ``/`` stripped), not
     byte-preserving.
 
@@ -389,7 +389,7 @@ class StoragePath:
         """The ``/``-joined segments of this path under ``base``.
 
         Structural containment — compares parsed segments, not string prefixes, so a
-        doubled separator on either side cannot fork the answer (#6838).
+        doubled separator on either side cannot fork the answer.
         """
         same_root = (self.scheme, self.netloc, self.rooted) == (base.scheme, base.netloc, base.rooted)
         if not same_root or self.segments[: len(base.segments)] != base.segments:
@@ -435,7 +435,7 @@ def prefix_join(prefix: str, relative: str) -> str:
 
     Object-store keys are not normalized: a naive ``f"{prefix}/{relative}"`` join of a
     trailing-slash prefix produces a doubled separator — a *different* key — silently
-    splitting writers from slash-collapsing readers (#6904). ``str``-in/``str``-out
+    splitting writers from slash-collapsing readers. ``str``-in/``str``-out
     convenience over :class:`StoragePath` for a single join; parse once and use ``/``
     for repeated manipulation.
     """
@@ -629,7 +629,7 @@ def rebase_file_path(
     The path below ``base_in_path`` is preserved beneath ``base_out_path``, optionally
     swapping the file extension. Containment and joins are structural (via
     :class:`StoragePath`), so a trailing or doubled separator on any argument cannot
-    double the output separator (#6904). ``file_path`` must lie under ``base_in_path``;
+    double the output separator. ``file_path`` must lie under ``base_in_path``;
     otherwise a ``ValueError`` is raised.
 
     Args:

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -617,6 +617,52 @@ def split_gcs_path(gs_uri: str) -> tuple[str, pathlib.Path]:
     return parsed.bucket, pathlib.Path(key) if key else pathlib.Path(".")
 
 
+def rebase_file_path(
+    base_in_path: str,
+    file_path: str,
+    base_out_path: str,
+    new_extension: str | None = None,
+    old_extension: str | None = None,
+) -> str:
+    """Rebase ``file_path`` from under ``base_in_path`` to under ``base_out_path``.
+
+    The path below ``base_in_path`` is preserved beneath ``base_out_path``, optionally
+    swapping the file extension. Containment and joins are structural (via
+    :class:`StoragePath`), so a trailing or doubled separator on any argument cannot
+    double the output separator (#6904). ``file_path`` must lie under ``base_in_path``;
+    otherwise a ``ValueError`` is raised.
+
+    Args:
+        base_in_path: The base directory of the input file.
+        file_path: The path of the input file, under ``base_in_path``.
+        base_out_path: The base directory of the output file.
+        new_extension: New file extension including the dot (e.g. ``".parquet"``).
+        old_extension: When given with ``new_extension``, the suffix of ``file_path`` to
+            replace; a ``ValueError`` is raised if ``file_path`` does not end with it.
+            When omitted (but ``new_extension`` is set), everything after the last dot is
+            replaced; with no dot, ``new_extension`` is appended.
+    """
+    rel_path = StoragePath.parse(file_path).relative_to(StoragePath.parse(base_in_path))
+
+    if old_extension and not new_extension:
+        raise ValueError("old_extension requires new_extension to be set")
+
+    if new_extension:
+        if old_extension:
+            # endswith (not rfind) so a mismatch fails loudly instead of silently
+            # truncating: rfind returns -1 and rel_path[:-1] would drop a character.
+            if not rel_path.endswith(old_extension):
+                raise ValueError(
+                    f"Cannot rebase {file_path!r}: relative path {rel_path!r} does not end with "
+                    f"old_extension={old_extension!r}"
+                )
+            rel_path = rel_path[: -len(old_extension)] + new_extension
+        else:
+            dot_idx = rel_path.rfind(".")
+            rel_path = (rel_path[:dot_idx] if dot_idx != -1 else rel_path) + new_extension
+    return prefix_join(base_out_path, rel_path)
+
+
 def get_bucket_location(bucket_name_or_path: str) -> str:
     """Return the GCS bucket's location (lower-cased region string)."""
     if bucket_name_or_path.startswith("gs://"):

--- a/lib/rigging/src/rigging/filesystem.py
+++ b/lib/rigging/src/rigging/filesystem.py
@@ -38,7 +38,6 @@ import functools
 import logging
 import os
 import pathlib
-import re
 import threading
 import time
 import urllib.error
@@ -312,10 +311,10 @@ def region_from_prefix(prefix: str) -> str | None:
     (e.g. ``gs://marin-eu-west4`` -> ``europe-west4``); unknown ``marin-``
     buckets fall back to stripping the ``marin-`` prefix.
     """
-    m = re.match(r"gs://([^/]+)", prefix)
-    if not m:
+    parsed = StoragePath.parse(prefix)
+    if parsed.scheme != "gs" or not parsed.bucket:
         return None
-    bucket = m.group(1)
+    bucket = parsed.bucket
     for region, spec in data_config().region_buckets.items():
         if spec.name == bucket:
             return region
@@ -397,6 +396,28 @@ class StoragePath:
             raise ValueError(f"{self} is not under {base}")
         return "/".join(self.segments[len(base.segments) :])
 
+    @property
+    def bucket(self) -> str:
+        """The object-store bucket (the authority); empty for a local or empty-authority path."""
+        return self.netloc
+
+    @property
+    def key(self) -> str:
+        """The ``/``-joined key segments beneath the authority (no leading or trailing ``/``)."""
+        return "/".join(self.segments)
+
+    @property
+    def name(self) -> str:
+        """The last key segment (basename), or ``""`` at the authority/filesystem root."""
+        return self.segments[-1] if self.segments else ""
+
+    @property
+    def parent(self) -> "StoragePath":
+        """This path with its last key segment removed; unchanged once at the root."""
+        if not self.segments:
+            return self
+        return dataclasses.replace(self, segments=self.segments[:-1])
+
     def __str__(self) -> str:
         key = "/".join(self.segments)
         if self.scheme is None:
@@ -467,10 +488,12 @@ def _s3_bucket_from_prefix(prefix: str | None) -> str | None:
     S3 buckets fall through to the flat non-TTL fallback instead of getting a
     ``tmp/ttl=Nd/`` path that would never be cleaned up.
     """
-    if not prefix or not prefix.startswith("s3://"):
+    if not prefix:
         return None
-    bucket = prefix[len("s3://") :].split("/", 1)[0]
-    return bucket if bucket in s3_data_buckets() else None
+    parsed = StoragePath.parse(prefix)
+    if parsed.scheme != "s3":
+        return None
+    return parsed.bucket if parsed.bucket in s3_data_buckets() else None
 
 
 # ---------------------------------------------------------------------------
@@ -586,13 +609,12 @@ def split_gcs_path(gs_uri: str) -> tuple[str, pathlib.Path]:
 
     Returns ``(bucket, Path("."))`` when the URI has no object path component.
     """
-    if not gs_uri.startswith("gs://"):
+    parsed = StoragePath.parse(gs_uri)
+    if parsed.scheme != "gs":
         raise ValueError(f"Invalid GCS URI `{gs_uri}`; expected URI of form `gs://BUCKET/path/to/resource`")
 
-    parts = gs_uri[len("gs://") :].split("/", 1)
-    if len(parts) == 1:
-        return parts[0], pathlib.Path(".")
-    return parts[0], pathlib.Path(parts[1])
+    key = parsed.key
+    return parsed.bucket, pathlib.Path(key) if key else pathlib.Path(".")
 
 
 def get_bucket_location(bucket_name_or_path: str) -> str:
@@ -927,9 +949,9 @@ def _is_gcs_protocol(protocol: str) -> bool:
 
 def _bucket_from_gcs_url(url: str) -> str | None:
     """Return the bucket name from a ``gs://``/``gcs://`` URL, or ``None``."""
-    for scheme in ("gs://", "gcs://"):
-        if url.startswith(scheme):
-            return url[len(scheme) :].split("/", 1)[0]
+    parsed = StoragePath.parse(url)
+    if parsed.scheme in ("gs", "gcs"):
+        return parsed.bucket
     return None
 
 
@@ -1325,14 +1347,18 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
         """Return (fsspec_fs, path) for a full URL or local path."""
         return fsspec.core.url_to_fs(url)
 
+    @property
+    def _local_root(self) -> StoragePath:
+        return StoragePath.parse(self._local_prefix)
+
     def _local_url(self, path: str) -> str:
-        return f"{self._local_prefix}/{path}"
+        return str(self._local_root / path)
 
     def _remote_url(self, prefix: str, path: str) -> str:
-        return f"{prefix}/{path}"
+        return prefix_join(prefix, path)
 
     def _lock_path_for(self, path: str) -> str:
-        return f"{self._local_prefix}/.mirror_locks/{path}.lock"
+        return str(self._local_root / ".mirror_locks" / f"{path}.lock")
 
     def _fs_exists(self, url: str) -> bool:
         fs, fspath = self._get_fs_and_path(url)
@@ -1433,7 +1459,7 @@ class MirrorFileSystem(fsspec.AbstractFileSystem):
         seen: dict[str, dict[str, Any]] = {}
 
         for prefix in [self._local_prefix, *self._remote_prefixes]:
-            url = f"{prefix}/{path}"
+            url = prefix_join(prefix, path)
             fs, fspath = self._get_fs_and_path(url)
             try:
                 entries = fs.ls(fspath, detail=True, **kwargs)

--- a/lib/rigging/tests/test_filesystem.py
+++ b/lib/rigging/tests/test_filesystem.py
@@ -6,7 +6,14 @@
 from pathlib import Path
 
 import pytest
-from rigging.filesystem import StoragePath, atomic_rename, prefix_join, unique_temp_path
+from rigging.filesystem import (
+    StoragePath,
+    _bucket_from_gcs_url,
+    atomic_rename,
+    prefix_join,
+    split_gcs_path,
+    unique_temp_path,
+)
 
 
 @pytest.mark.parametrize(
@@ -68,6 +75,60 @@ def test_storage_path_relative_to_is_structural():
 
     with pytest.raises(ValueError, match="not under"):
         StoragePath.parse("gs://other/cache/x").relative_to(base)
+
+
+@pytest.mark.parametrize(
+    ("raw", "bucket", "key", "name", "parent"),
+    [
+        ("gs://bucket/a/b/c", "bucket", "a/b/c", "c", "gs://bucket/a/b"),
+        ("gs://bucket/a//b/", "bucket", "a/b", "b", "gs://bucket/a"),
+        ("gs://bucket/only", "bucket", "only", "only", "gs://bucket"),
+        ("gs://bucket", "bucket", "", "", "gs://bucket"),
+        ("/tmp/x/y", "", "tmp/x/y", "y", "/tmp/x"),
+        ("/", "", "", "", "/"),
+        ("rel/path", "", "rel/path", "path", "rel"),
+    ],
+)
+def test_storage_path_accessors(raw, bucket, key, name, parent):
+    sp = StoragePath.parse(raw)
+    assert sp.bucket == bucket
+    assert sp.key == key
+    assert sp.name == name
+    assert str(sp.parent) == parent
+
+
+@pytest.mark.parametrize(
+    ("uri", "bucket", "path"),
+    [
+        ("gs://bucket/path/to/resource", "bucket", "path/to/resource"),
+        ("gs://bucket/a//b/", "bucket", "a/b"),
+        ("gs://bucket", "bucket", "."),
+        ("gs://bucket/", "bucket", "."),
+    ],
+)
+def test_split_gcs_path(uri, bucket, path):
+    got_bucket, got_path = split_gcs_path(uri)
+    assert got_bucket == bucket
+    assert got_path == Path(path)
+
+
+def test_split_gcs_path_rejects_non_gcs():
+    with pytest.raises(ValueError, match="Invalid GCS URI"):
+        split_gcs_path("s3://bucket/x")
+
+
+@pytest.mark.parametrize(
+    ("url", "bucket"),
+    [
+        ("gs://bucket/path", "bucket"),
+        ("gcs://bucket/path", "bucket"),
+        ("gs://bucket", "bucket"),
+        ("s3://bucket/path", None),
+        ("/local/path", None),
+    ],
+)
+def test_bucket_from_gcs_url(url, bucket):
+    assert _bucket_from_gcs_url(url) == bucket
 
 
 def test_unique_temp_path_produces_distinct_paths():

--- a/lib/rigging/tests/test_filesystem.py
+++ b/lib/rigging/tests/test_filesystem.py
@@ -11,6 +11,7 @@ from rigging.filesystem import (
     _bucket_from_gcs_url,
     atomic_rename,
     prefix_join,
+    rebase_file_path,
     split_gcs_path,
     unique_temp_path,
 )
@@ -129,6 +130,49 @@ def test_split_gcs_path_rejects_non_gcs():
 )
 def test_bucket_from_gcs_url(url, bucket):
     assert _bucket_from_gcs_url(url) == bucket
+
+
+@pytest.mark.parametrize(
+    ("base_in", "file_path", "base_out", "new_ext", "old_ext", "expected"),
+    [
+        # Extension swap under a trailing-slash output base (a common caller pattern).
+        (
+            "gs://b/in",
+            "gs://b/in/sub/doc.jsonl.gz",
+            "gs://b/out/data/",
+            ".parquet",
+            ".jsonl.gz",
+            "gs://b/out/data/sub/doc.parquet",
+        ),
+        # Trailing slash on the input base collapses structurally.
+        ("gs://b/in/", "gs://b/in/a/b/doc.json", "gs://b/out", ".parquet", ".json", "gs://b/out/a/b/doc.parquet"),
+        # Without old_extension, everything after the last dot is replaced.
+        ("gs://b/in", "gs://b/in/doc.jsonl.zst", "gs://b/out", ".parquet", None, "gs://b/out/doc.jsonl.parquet"),
+        # Without old_extension and no dot in the name, new_extension is appended.
+        ("gs://b/in", "gs://b/in/noext", "gs://b/out", ".txt", None, "gs://b/out/noext.txt"),
+        # No extension change — pure rebase.
+        ("gs://b/in", "gs://b/in/x/doc", "gs://b/out", None, None, "gs://b/out/x/doc"),
+        # Local paths.
+        ("/tmp/in", "/tmp/in/x/doc.jsonl", "/tmp/out", ".parquet", ".jsonl", "/tmp/out/x/doc.parquet"),
+    ],
+)
+def test_rebase_file_path(base_in, file_path, base_out, new_ext, old_ext, expected):
+    assert rebase_file_path(base_in, file_path, base_out, new_ext, old_ext) == expected
+
+
+def test_rebase_file_path_rejects_file_outside_base():
+    with pytest.raises(ValueError, match="not under"):
+        rebase_file_path("gs://b/in", "gs://b/other/doc.jsonl", "gs://b/out")
+
+
+def test_rebase_file_path_wrong_old_extension():
+    with pytest.raises(ValueError, match="does not end with"):
+        rebase_file_path("gs://b/in", "gs://b/in/doc.jsonl", "gs://b/out", ".parquet", ".csv")
+
+
+def test_rebase_file_path_old_extension_requires_new():
+    with pytest.raises(ValueError, match="requires new_extension"):
+        rebase_file_path("gs://b/in", "gs://b/in/doc.jsonl", "gs://b/out", old_extension=".jsonl")
 
 
 def test_unique_temp_path_produces_distinct_paths():

--- a/lib/zephyr/src/zephyr/dataset.py
+++ b/lib/zephyr/src/zephyr/dataset.py
@@ -5,7 +5,6 @@
 
 import functools
 import logging
-import re
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass, field
 from enum import StrEnum
@@ -14,22 +13,12 @@ from typing import Any, Generic, Literal, TypeVar, cast, overload
 import fsspec
 from braceexpand import braceexpand
 from pyarrow import RecordBatch
-from rigging.filesystem import url_to_fs
+from rigging.filesystem import StoragePath, url_to_fs
 
 from zephyr.expr import Expr
 from zephyr.readers import DEFAULT_FILE_PATH_COLUMN, InputFileSpec
 
 logger = logging.getLogger(__name__)
-
-
-def _collapse_double_slashes(path: str) -> str:
-    """Collapse repeated slashes in ``path`` while preserving the ``://`` protocol separator.
-
-    The ``(?<!:)`` lookbehind keeps ``gs://``, ``s3://``, ``http://`` etc. intact
-    while normalizing accidental ``//`` elsewhere (e.g. from joining a prefix that
-    ends in ``/`` with a pattern that starts with ``/``).
-    """
-    return re.sub(r"(?<!:)//+", "/", path)
 
 
 @dataclass(frozen=True)
@@ -67,7 +56,7 @@ def resolve_glob(source: GlobSource) -> list[FileEntry]:
     Uses fsspec glob(detail=True) which returns file metadata from the same
     list-objects API call — no extra per-file stat RPCs.
     """
-    pattern = _collapse_double_slashes(source.pattern)
+    pattern = StoragePath.normalize(source.pattern)
 
     fs, _ = url_to_fs(pattern)
     protocol = fsspec.core.split_protocol(pattern)[0]
@@ -121,7 +110,7 @@ def format_shard_path(pattern: str, shard_idx: int, total: int) -> str:
     basename = f"shard_{shard_idx}"
     formatted = pattern.format(shard=shard_idx, total=total, basename=basename)
 
-    return _collapse_double_slashes(formatted)
+    return StoragePath.normalize(formatted)
 
 
 def _normalize_output_pattern(output_pattern: str | Callable[[int, int], str]) -> Callable[[int, int], str]:

--- a/tests/test_consolidate_metadata.py
+++ b/tests/test_consolidate_metadata.py
@@ -14,9 +14,9 @@ from levanter.store.cache import (
     CACHE_LAYOUT_CONSOLIDATED,
     CACHE_LAYOUT_SHARDED,
     CacheLedger,
+    ShardedCacheLayout,
     TreeCache,
     _expose_cache_rows,
-    _relative_shard_path,
     consolidate_shard_cache_ledgers,
     consolidate_shard_caches,
 )
@@ -97,9 +97,10 @@ def test_relative_shard_path_requires_child_paths():
         internal_shard = os.path.join(output_path, "part-00000")
         external_shard = os.path.join(tmpdir, "source", "part-00000")
 
-        assert _relative_shard_path(output_path, internal_shard) == "part-00000"
+        layout = ShardedCacheLayout.parse(output_path)
+        assert layout.relative_shard(internal_shard) == "part-00000"
         with pytest.raises(ValueError, match="not under output path"):
-            _relative_shard_path(output_path, external_shard)
+            layout.relative_shard(external_shard)
 
 
 def test_relative_shard_path_requires_child_uri_paths():
@@ -107,9 +108,10 @@ def test_relative_shard_path_requires_child_uri_paths():
     internal_shard = "gs://bucket/cache/train/part-00000"
     external_shard = "gs://bucket/other/train/part-00000"
 
-    assert _relative_shard_path(output_path, internal_shard) == "part-00000"
+    layout = ShardedCacheLayout.parse(output_path)
+    assert layout.relative_shard(internal_shard) == "part-00000"
     with pytest.raises(ValueError, match="not under output path"):
-        _relative_shard_path(output_path, external_shard)
+        layout.relative_shard(external_shard)
 
 
 def test_relative_shard_path_tolerates_double_slash_output():
@@ -119,7 +121,7 @@ def test_relative_shard_path_tolerates_double_slash_output():
     output_path = "s3://marin-na/marin//slimpajama-6b/2026.06.28/train"
     shard_path = "s3://marin-na/marin/slimpajama-6b/2026.06.28/train/part-00000-of-00048"
 
-    assert _relative_shard_path(output_path, shard_path) == "part-00000-of-00048"
+    assert ShardedCacheLayout.parse(output_path).relative_shard(shard_path) == "part-00000-of-00048"
 
 
 @pytest.mark.asyncio

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -5,7 +5,6 @@ import os
 
 import draccus
 import pytest
-from marin.utils import rebase_file_path
 
 
 def check_load_config(config_class: type, config_file: str) -> None:
@@ -46,61 +45,3 @@ def skip_in_ci(fn_or_msg):
         return decorator
 
     return pytest.mark.skipif("CI" in os.environ, reason="skipped in CI")(fn_or_msg)
-
-
-# rebase_file_path is pure string manipulation (os.path.relpath + string ops),
-# so these tests use string paths directly rather than materialising files via tmp_path.
-_REBASE_BASE_IN = "/in"
-_REBASE_BASE_OUT = "/out"
-
-
-@pytest.mark.parametrize(
-    ("rel_path", "kwargs", "expected_rel"),
-    [
-        pytest.param(
-            "nested/sample.parquet",
-            {"new_extension": ".parquet", "old_extension": ".parquet"},
-            "nested/sample.parquet",
-            id="matching_extension",
-        ),
-        pytest.param(
-            "sample.jsonl.gz",
-            {"new_extension": ".parquet", "old_extension": ".jsonl.gz"},
-            "sample.parquet",
-            id="compound_old_extension_replaced",
-        ),
-        pytest.param(
-            "noext",
-            {"new_extension": ".txt"},
-            "noext.txt",
-            id="no_dot_appends_new_extension",
-        ),
-    ],
-)
-def test_rebase_file_path(rel_path, kwargs, expected_rel):
-    file_path = os.path.join(_REBASE_BASE_IN, rel_path)
-    rebased = rebase_file_path(_REBASE_BASE_IN, file_path, _REBASE_BASE_OUT, **kwargs)
-    assert rebased == os.path.join(_REBASE_BASE_OUT, expected_rel)
-
-
-@pytest.mark.parametrize(
-    ("rel_path", "kwargs", "match"),
-    [
-        pytest.param(
-            "sample.parquet",
-            {"old_extension": ".parquet"},
-            "old_extension requires new_extension",
-            id="old_without_new",
-        ),
-        pytest.param(
-            "sample.jsonl",
-            {"new_extension": ".parquet", "old_extension": ".jsonl.gz"},
-            "does not end with old_extension",
-            id="mismatched_old_extension",
-        ),
-    ],
-)
-def test_rebase_file_path_raises(rel_path, kwargs, match):
-    file_path = os.path.join(_REBASE_BASE_IN, rel_path)
-    with pytest.raises(ValueError, match=match):
-        rebase_file_path(_REBASE_BASE_IN, file_path, _REBASE_BASE_OUT, **kwargs)


### PR DESCRIPTION
Route storage-path string surgery through `rigging.filesystem` so a trailing or doubled separator can no longer fork a writer's path from a reader's (#6904, #6838). Object-store keys are not normalized — `gs://b/x//y` and `gs://b/x/y` are different objects — so every hand-rolled `os.path.join` / f-string / `rstrip("/")` join on a `gs://`-bound base is a latent divergence between whoever writes a key and whoever reconstructs it to read.

Core additions to `StoragePath`:

- `bucket` / `key` / `name` / `parent` accessors, and the bucket/key parse family (`region_from_prefix`, `_s3_bucket_from_prefix`, `split_gcs_path`, `_bucket_from_gcs_url`) delegates to them.
- `prefix_join(prefix, relative)` for the common single-join case; `rebase_file_path` moves here from `marin.utils` (its natural home) and is now structural via `relative_to`.
- `ShardedCacheLayout` — a typed path family for the sharded Levanter cache. It owns the `shard_ledger.json` name (previously hardcoded three times across levanter and marin) and derives the ledger, per-shard subdirectories, and relative-shard keys from one parsed root. `TreeCache` holds its layout natively.

Migrations:

- `MirrorFileSystem` local/remote/lock/`ls` paths, and the shard-path trio (levanter `_shard_path` + `_relative_shard_path`, zephyr `format_shard_path`) drop three copies of the `re.sub(r"(?<!:)//+", "/")` collapse-regex for structural `StoragePath`.
- The URL-carrying tail — datakit download pipelines, datakit normalize, levanter analysis writers, tensorstore checkpoint-path assembly, dpo/labeled-eval/text cache dirs, training checkpoint outputs, gs://-confirmed evaluator result paths, and assorted execution/transform/dedup sites — now joins via `prefix_join`.

Purely local paths (temp dirs, `os.makedirs` targets, `__file__`-relative and `CACHE_PATH` constants, HF repo ids, metric labels) are deliberately left on `os.path`.

The shard-path change is byte-identical to the old regex for every real input (`gs://` URLs and absolute local paths, no trailing slash); the only divergence is stripping a trailing slash, which never occurs on a shard file or a real glob. `_relative_shard_path` additionally rejects a `..` that would escape a scheme-less cache root. Regression tests pin the trailing-slash / doubled-slash / different-bucket / equal-path / dot-dot-escape cases so a writer and reader cannot drift.

Fixes #6926
