### PR TITLE
[iris] Pipe query results into job kick/stop/kill via --stdin

### DIFF
--- a/lib/iris/OPS.md
+++ b/lib/iris/OPS.md
@@ -144,6 +144,10 @@ running on a worker (ASSIGNED / BUILDING / RUNNING) can be kicked; pending or
 already-terminal tasks are rejected with a reason. `preempted` charges the
 preemption budget; `failed` is terminal with no retry.
 
+`kick`, `stop`, and `kill` also read ids from **stdin** (`--stdin`, or a literal
+`-` target) and take `--dry-run`. This is the query→act bridge: select the
+targets with SQL, preview, then fire. See "Bulk actions: query → act" below.
+
 ## Process Inspection & Profiling
 
 ```bash
@@ -216,6 +220,56 @@ iris process logs --since 24h | grep 'event=worker_failed'
 ```
 
 Full table list: `iris query "SELECT name FROM sqlite_master WHERE type='table'"`.
+
+### Bulk actions: query → act
+
+`iris query` is admin-only and read-only, so it is the safe surface for *finding*
+the exact set of tasks/jobs you want to act on. `iris job kick`, `iris job stop`,
+and `iris job kill` read ids from **stdin** (`--stdin`, or a literal `-`), so a
+query pipes straight into an action — no hand-copying ids. Stdin parsing is
+CSV-tolerant: it takes the first field of each line and keeps only ids (leading
+`/`), so a `-f csv` header row and trailing columns are dropped automatically.
+
+**Always `--dry-run` first** to confirm the set, then re-run without it:
+
+```bash
+# Drain everything EXCEPT one protected job off a slice, so it can bind its ports.
+SLICE=marin-tpu-v4-reserved-2048-us-central2-b-...
+SEL="SELECT t.task_id FROM tasks t JOIN workers w ON t.current_worker_id=w.worker_id
+     WHERE w.slice_id='$SLICE' AND t.state IN (2,3,9) AND t.job_id NOT LIKE '/larry/%'"
+
+iris query -f csv "$SEL" | iris job kick --stdin --dry-run          # preview
+iris query -f csv "$SEL" | iris job kick --stdin --reason "drain slice for /larry"
+```
+
+`--state preempted` (default) reschedules the kicked tasks elsewhere; `--state
+failed` does not retry. Prefer kicking **tasks** (`t.task_id`, task index kept)
+over whole jobs when you only need to clear specific workers — a job target
+kicks *all* its active tasks, including ones on other slices.
+
+Canonical joins (the schema doesn't pre-wire these, so keep them here):
+
+```sql
+-- Which scale group is the size-N slice? (find the slice_id to target)
+SELECT scale_group, device_variant, count(*) AS workers, count(DISTINCT slice_id) AS slices
+FROM workers WHERE device_type='tpu' GROUP BY scale_group, device_variant;
+
+-- Everything occupying a slice's workers, by job and task state.
+SELECT t.job_id, t.state, count(*) FROM tasks t
+JOIN workers w ON t.current_worker_id=w.worker_id
+WHERE w.slice_id='<slice_id>' AND t.state IN (2,3,9) GROUP BY t.job_id, t.state;
+
+-- Co-tenants sharing a worker VM with a given job (CPU tasks bin-packed onto
+-- TPU hosts show up here — a common source of host-global port collisions).
+SELECT t.job_id, t.task_id, w.md_tpu_worker_id FROM tasks t
+JOIN workers w ON t.current_worker_id=w.worker_id
+WHERE w.worker_id IN (
+  SELECT current_worker_id FROM tasks WHERE job_id LIKE '/larry/%' AND state IN (2,3,9)
+) AND t.job_id NOT LIKE '/larry/%' AND t.state IN (2,3,9);
+```
+
+To *dump* rather than act, feed the same selection to `iris job logs` /
+`iris job summary` per id, or read the task rows directly with a wider `SELECT`.
 
 ### Offline checkpoint analysis
 

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -8,6 +8,7 @@ Usage:
     iris --config cluster.yaml job run --tpu v5litepod-16 -e WANDB_API_KEY $WANDB_API_KEY -- python train.py
 """
 
+import csv
 import difflib
 import logging
 import os
@@ -104,19 +105,20 @@ def _print_terminated(terminated: list[JobName]) -> None:
 def _read_targets_from_stdin() -> list[str]:
     """Read Iris job/task ids from stdin, one per line.
 
-    Tolerates ``iris query -f csv`` output directly: each line is reduced to its
-    first comma/whitespace-delimited field, and only fields that look like Iris
-    ids (leading ``/``) are kept — so a CSV header row and any trailing columns
-    are ignored. This is the glue for the query→act pattern:
+    Parses each line as a CSV record (symmetric with ``iris query -f csv``, which
+    quotes fields through ``csv.writer``) and keeps the first field when it looks
+    like an Iris id (leading ``/``). This consumes ``iris query -f csv`` output
+    directly — a header row and trailing columns are dropped, and ids that
+    contain a comma (quoted by the writer) or a space survive intact, since a
+    JobName component may hold either:
 
         iris query -f csv "SELECT task_id FROM tasks WHERE ..." | iris job kick --stdin
     """
     targets: list[str] = []
-    for raw in sys.stdin:
-        line = raw.strip()
-        if not line:
+    for row in csv.reader(sys.stdin):
+        if not row:
             continue
-        field = line.split(",", 1)[0].split()[0]
+        field = row[0].strip()
         if field.startswith("/"):
             targets.append(field)
     return targets

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -101,6 +101,41 @@ def _print_terminated(terminated: list[JobName]) -> None:
         click.echo("No running jobs matched.")
 
 
+def _read_targets_from_stdin() -> list[str]:
+    """Read Iris job/task ids from stdin, one per line.
+
+    Tolerates ``iris query -f csv`` output directly: each line is reduced to its
+    first comma/whitespace-delimited field, and only fields that look like Iris
+    ids (leading ``/``) are kept — so a CSV header row and any trailing columns
+    are ignored. This is the glue for the query→act pattern:
+
+        iris query -f csv "SELECT task_id FROM tasks WHERE ..." | iris job kick --stdin
+    """
+    targets: list[str] = []
+    for raw in sys.stdin:
+        line = raw.strip()
+        if not line:
+            continue
+        field = line.split(",", 1)[0].split()[0]
+        if field.startswith("/"):
+            targets.append(field)
+    return targets
+
+
+def _collect_targets(targets: tuple[str, ...], use_stdin: bool) -> list[str]:
+    """Merge positional targets with stdin ids for a bulk action.
+
+    A literal ``-`` among the positionals, or ``--stdin``, appends ids read from
+    stdin (see :func:`_read_targets_from_stdin`), letting a query pipe straight
+    into ``kick``/``stop``. Positional ids and stdin ids compose.
+    """
+    read_stdin = use_stdin or "-" in targets
+    collected = [t for t in targets if t != "-"]
+    if read_stdin:
+        collected.extend(_read_targets_from_stdin())
+    return collected
+
+
 def load_env_vars(env_flags: tuple[tuple[str, ...], ...] | list | None) -> dict[str, str]:
     """Load environment variables from .marin.yaml and merge with flags.
 
@@ -1009,34 +1044,55 @@ def run(
     sys.exit(exit_code)
 
 
+def _stop_jobs(ctx, job_id: tuple[str, ...], include_children: bool, stdin: bool, dry_run: bool) -> None:
+    targets = _collect_targets(job_id, stdin)
+    if not targets:
+        raise click.UsageError("No jobs given. Pass job ids, or --stdin (or '-') to read them from stdin.")
+    if dry_run:
+        click.echo(f"[dry-run] would terminate {len(targets)} job(s):")
+        for t in targets:
+            click.echo(f"  {t}")
+        return
+    client = _remote_client(ctx)
+    terminated = _terminate_jobs(client, tuple(targets), include_children)
+    _print_terminated(terminated)
+
+
 @job.command("stop")
-@click.argument("job_id", nargs=-1, required=True)
+@click.argument("job_id", nargs=-1, required=False)
 @click.option(
     "--include-children/--no-include-children",
     default=True,
     help="Terminate child jobs under the given job ID prefix (default: include).",
 )
+@click.option("--stdin", is_flag=True, default=False, help="Also read job ids from stdin (one per line; CSV-tolerant).")
+@click.option("--dry-run", is_flag=True, default=False, help="Print the jobs that would be terminated without sending.")
 @click.pass_context
-def stop(ctx, job_id: tuple[str, ...], include_children: bool) -> None:
-    """Terminate one or more jobs."""
-    client = _remote_client(ctx)
-    terminated = _terminate_jobs(client, job_id, include_children)
-    _print_terminated(terminated)
+def stop(ctx, job_id: tuple[str, ...], include_children: bool, stdin: bool, dry_run: bool) -> None:
+    """Terminate one or more jobs.
+
+    Pass ``-`` or ``--stdin`` to read job ids from stdin so a query can pipe in:
+
+    \b
+      iris query -f csv "SELECT job_id FROM jobs WHERE user_id='alice' AND state=3" \\
+        | iris job stop --stdin
+    """
+    _stop_jobs(ctx, job_id, include_children, stdin, dry_run)
 
 
 @job.command("kill")
-@click.argument("job_id", nargs=-1, required=True)
+@click.argument("job_id", nargs=-1, required=False)
 @click.option(
     "--include-children/--no-include-children",
     default=True,
     help="Terminate child jobs under the given job ID prefix (default: include).",
 )
+@click.option("--stdin", is_flag=True, default=False, help="Also read job ids from stdin (one per line; CSV-tolerant).")
+@click.option("--dry-run", is_flag=True, default=False, help="Print the jobs that would be terminated without sending.")
 @click.pass_context
-def kill(ctx, job_id: tuple[str, ...], include_children: bool) -> None:
+def kill(ctx, job_id: tuple[str, ...], include_children: bool, stdin: bool, dry_run: bool) -> None:
     """Terminate one or more jobs (alias for stop)."""
-    client = _remote_client(ctx)
-    terminated = _terminate_jobs(client, job_id, include_children)
-    _print_terminated(terminated)
+    _stop_jobs(ctx, job_id, include_children, stdin, dry_run)
 
 
 _KICK_STATE_MAP = {
@@ -1046,7 +1102,7 @@ _KICK_STATE_MAP = {
 
 
 @job.command("kick")
-@click.argument("target", nargs=-1, required=True)
+@click.argument("target", nargs=-1, required=False)
 @click.option(
     "--state",
     "-s",
@@ -1056,15 +1112,36 @@ _KICK_STATE_MAP = {
     help="Terminal state to force: 'preempted' retries if budget remains; 'failed' does not retry.",
 )
 @click.option("--reason", type=str, default="", help="Reason recorded on the kicked task attempts.")
+@click.option(
+    "--stdin", is_flag=True, default=False, help="Also read target ids from stdin (one per line; CSV-tolerant)."
+)
+@click.option("--dry-run", is_flag=True, default=False, help="Print the targets that would be kicked without sending.")
 @click.pass_context
-def kick(ctx, target: tuple[str, ...], state: str, reason: str) -> None:
+def kick(ctx, target: tuple[str, ...], state: str, reason: str, stdin: bool, dry_run: bool) -> None:
     """Force task attempts into a terminal state (emergency override).
 
     Each TARGET is a task id (/user/job/0), task-attempt id (/user/job/0:3), or a
-    job id (/user/job) that expands to the job's active tasks.
+    job id (/user/job) that expands to the job's active tasks. Pass ``-`` or
+    ``--stdin`` to read ids from stdin, so a query can pipe straight in:
+
+    \b
+      iris query -f csv "SELECT t.task_id FROM tasks t JOIN workers w
+        ON t.current_worker_id=w.worker_id
+        WHERE w.slice_id='<slice>' AND t.state IN (2,3,9)
+        AND t.job_id NOT LIKE '/keep/%'" | iris job kick --stdin --reason "drain slice"
     """
+    targets = _collect_targets(target, stdin)
+    if not targets:
+        raise click.UsageError("No targets given. Pass task/job ids, or --stdin (or '-') to read them from stdin.")
+
+    if dry_run:
+        click.echo(f"[dry-run] would kick {len(targets)} target(s) to {state}:")
+        for t in targets:
+            click.echo(f"  {t}")
+        return
+
     client = _remote_client(ctx)
-    results = client.kick_tasks(list(target), desired_state=_KICK_STATE_MAP[state], reason=reason)
+    results = client.kick_tasks(targets, desired_state=_KICK_STATE_MAP[state], reason=reason)
 
     queued = [r for r in results if r.queued]
     rejected = [r for r in results if not r.queued]

--- a/lib/iris/src/iris/cli/job.py
+++ b/lib/iris/src/iris/cli/job.py
@@ -125,9 +125,9 @@ def _read_targets_from_stdin() -> list[str]:
 def _collect_targets(targets: tuple[str, ...], use_stdin: bool) -> list[str]:
     """Merge positional targets with stdin ids for a bulk action.
 
-    A literal ``-`` among the positionals, or ``--stdin``, appends ids read from
-    stdin (see :func:`_read_targets_from_stdin`), letting a query pipe straight
-    into ``kick``/``stop``. Positional ids and stdin ids compose.
+    A literal ``-`` among the positionals, or ``use_stdin``, appends the ids read
+    from stdin to the positional ids, letting a query pipe straight into an
+    action. The ``-`` sentinel is consumed, not returned as a target.
     """
     read_stdin = use_stdin or "-" in targets
     collected = [t for t in targets if t != "-"]

--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -378,6 +378,22 @@ def test_read_targets_from_stdin_ignores_blank_and_non_id_lines(monkeypatch):
     assert _read_targets_from_stdin() == ["/alice/job/0", "/bob/job"]
 
 
+def test_read_targets_from_stdin_preserves_quoted_comma_and_space_ids(monkeypatch):
+    # JobName components may contain commas and spaces; iris query -f csv quotes
+    # comma-bearing fields via csv.writer, so a real CSV parse must round-trip them.
+    stdin = io.StringIO('task_id,state\n"/alice/a,b/0",3\n/alice/my job/1,3\n')
+    monkeypatch.setattr("iris.cli.job.sys.stdin", stdin)
+    assert _read_targets_from_stdin() == ["/alice/a,b/0", "/alice/my job/1"]
+
+
+def test_read_targets_from_stdin_skips_rows_with_empty_first_field(monkeypatch):
+    # A NULL first column (e.g. an unassigned current_worker_id) emits a leading
+    # comma; the empty field must be skipped, not crash the whole action.
+    stdin = io.StringIO(",3\n/alice/job/0,worker-1\n")
+    monkeypatch.setattr("iris.cli.job.sys.stdin", stdin)
+    assert _read_targets_from_stdin() == ["/alice/job/0"]
+
+
 def test_collect_targets_merges_positional_and_stdin(monkeypatch):
     monkeypatch.setattr("iris.cli.job.sys.stdin", io.StringIO("/from/stdin/0\n"))
     assert _collect_targets(("/pos/job/0",), use_stdin=True) == ["/pos/job/0", "/from/stdin/0"]

--- a/lib/iris/tests/cli/test_job.py
+++ b/lib/iris/tests/cli/test_job.py
@@ -3,17 +3,23 @@
 
 """Tests for iris.cli.job — validate_region_zone, executor heuristic, and related CLI validation."""
 
+import io
+
 import click
 import pytest
 from click.testing import CliRunner
 from iris.cli.job import (
+    _collect_targets,
     _parse_tpu_alternatives,
+    _read_targets_from_stdin,
     _render_job_summary_text,
     build_job_constraints,
     build_job_summary,
     build_resources,
     build_tpu_alternatives,
+    kick,
     run,
+    stop,
     validate_extra_resources,
     validate_region_zone,
 )
@@ -352,3 +358,103 @@ def test_render_job_summary_text_shows_peak_memory():
     assert "10 GB" in text
     assert "137" in text
     assert "OOM" in text
+
+
+# Bulk-action target collection (query→act bridge for kick/stop/kill)
+# ---------------------------------------------------------------------------
+
+
+def test_read_targets_from_stdin_drops_csv_header_and_extra_columns(monkeypatch):
+    # Exactly what `iris query -f csv "SELECT task_id, state FROM ..."` emits:
+    # a header line with no leading slash, then id + trailing columns per row.
+    stdin = io.StringIO("task_id,state\n/alice/job/0,3\n/bob/job/1,9\n")
+    monkeypatch.setattr("iris.cli.job.sys.stdin", stdin)
+    assert _read_targets_from_stdin() == ["/alice/job/0", "/bob/job/1"]
+
+
+def test_read_targets_from_stdin_ignores_blank_and_non_id_lines(monkeypatch):
+    stdin = io.StringIO("/alice/job/0\n\n   \nNo jobs found.\n/bob/job\n")
+    monkeypatch.setattr("iris.cli.job.sys.stdin", stdin)
+    assert _read_targets_from_stdin() == ["/alice/job/0", "/bob/job"]
+
+
+def test_collect_targets_merges_positional_and_stdin(monkeypatch):
+    monkeypatch.setattr("iris.cli.job.sys.stdin", io.StringIO("/from/stdin/0\n"))
+    assert _collect_targets(("/pos/job/0",), use_stdin=True) == ["/pos/job/0", "/from/stdin/0"]
+
+
+def test_collect_targets_dash_sentinel_reads_stdin(monkeypatch):
+    monkeypatch.setattr("iris.cli.job.sys.stdin", io.StringIO("/from/stdin/0\n"))
+    # '-' is consumed as the stdin sentinel, not passed through as a target.
+    assert _collect_targets(("/pos/job/0", "-"), use_stdin=False) == ["/pos/job/0", "/from/stdin/0"]
+
+
+def test_collect_targets_no_stdin_returns_positional_only():
+    assert _collect_targets(("/a/b/0", "/a/c/0"), use_stdin=False) == ["/a/b/0", "/a/c/0"]
+
+
+def test_kick_dry_run_lists_targets_without_sending(monkeypatch):
+    def _boom(_ctx):
+        raise AssertionError("dry-run must not open a client or send an RPC")
+
+    monkeypatch.setattr("iris.cli.job._remote_client", _boom)
+
+    result = CliRunner().invoke(
+        kick,
+        ["--stdin", "--dry-run"],
+        input="task_id\n/alice/job/0\n/bob/job/1\n",
+        obj={"controller_url": "http://controller.test", "config": None, "credentials": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert "would kick 2 target(s) to preempted" in result.output
+    assert "/alice/job/0" in result.output
+    assert "/bob/job/1" in result.output
+
+
+def test_kick_stdin_passes_collected_targets_to_client(monkeypatch):
+    captured: dict[str, object] = {}
+
+    class FakeClient:
+        def kick_tasks(self, targets, *, desired_state, reason):
+            captured["targets"] = targets
+            captured["desired_state"] = desired_state
+            captured["reason"] = reason
+            return []
+
+    monkeypatch.setattr("iris.cli.job._remote_client", lambda _ctx: FakeClient())
+
+    result = CliRunner().invoke(
+        kick,
+        ["--stdin", "--state", "failed", "--reason", "drain"],
+        input="/alice/job/0\n/bob/job/1\n",
+        obj={"controller_url": "http://controller.test", "config": None, "credentials": None},
+    )
+
+    assert result.exit_code == 0, result.output
+    assert captured["targets"] == ["/alice/job/0", "/bob/job/1"]
+    assert captured["desired_state"] == _job_pb2.TASK_STATE_FAILED
+    assert captured["reason"] == "drain"
+
+
+def test_kick_no_targets_is_usage_error(monkeypatch):
+    monkeypatch.setattr("iris.cli.job._remote_client", lambda _ctx: pytest.fail("should not reach client"))
+    result = CliRunner().invoke(kick, [], obj={"controller_url": "http://c.test", "config": None, "credentials": None})
+    assert result.exit_code != 0
+    assert "No targets given" in result.output
+
+
+def test_stop_dry_run_lists_jobs_without_sending(monkeypatch):
+    monkeypatch.setattr(
+        "iris.cli.job._remote_client",
+        lambda _ctx: pytest.fail("dry-run must not open a client"),
+    )
+    result = CliRunner().invoke(
+        stop,
+        ["--stdin", "--dry-run"],
+        input="job_id\n/alice/job\n",
+        obj={"controller_url": "http://c.test", "config": None, "credentials": None},
+    )
+    assert result.exit_code == 0, result.output
+    assert "would terminate 1 job(s)" in result.output
+    assert "/alice/job" in result.output


### PR DESCRIPTION
iris query is already an admin-only, read-only SQL surface over the whole controller schema (jobs, tasks, workers, slices, ...), but acting on a result set meant hand-copying task/job ids into a separate command. This closes that gap: kick, stop, and kill now read ids from stdin (--stdin, or a literal - target) and take --dry-run, so a query pipes straight into an action.

  iris query -f csv "SELECT t.task_id FROM tasks t
    JOIN workers w ON t.current_worker_id=w.worker_id
    WHERE w.slice_id='<slice>' AND t.state IN (2,3,9)
    AND t.job_id NOT LIKE '/keep/%'" | iris job kick --stdin --dry-run

Stdin parsing takes the first field of each line and keeps only ids (leading /), so a `-f csv` header row and any trailing columns are dropped automatically — query output pipes in with no massaging. --dry-run prints the resolved target set without touching the controller, so you confirm the set before firing.

This came out of an incident where the production v4-2048 MoE run couldn't bind its coordinator port because ~27 CPU tasks were bin-packed onto its worker VMs. Draining "everything on this slice except job X" required a three-table join, extracting ids by hand, and feeding them to kick one batch at a time. With --stdin it is one pipe.

OPS.md gains a "query -> act" cookbook documenting the pattern plus the canonical task->worker->slice joins (the schema does not pre-wire them), next to the existing kick guidance.