### PR TITLE
ducky: fix deploy against the IAP-fronted marin controller

### DIFF
--- a/.github/workflows/ducky-deploy.yaml
+++ b/.github/workflows/ducky-deploy.yaml
@@ -55,8 +55,6 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 30
     env:
-      # ducky's tunnel spawns the iris CLI; drive it through uv from the repo.
-      DUCKY_IRIS_CMD: "uv run iris"
       # Deploy defaults — single source of truth; dispatch inputs override.
       DEF_CLUSTER: "marin"
       DEF_NAME: "ducky"
@@ -96,6 +94,8 @@ jobs:
         with:
           enable-cache: true
 
+      # marin is IAP-fronted, so the deploy reaches the controller over its HTTPS ingress and
+      # mints the IAP OIDC token from these service-account credentials (ADC) — no SSH tunnel.
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v3
         with:
@@ -105,21 +105,6 @@ jobs:
         uses: google-github-actions/setup-gcloud@v3
         with:
           project_id: ${{ secrets.GCP_PROJECT_ID }}
-
-      # Persistent CI keypair already registered on the prod controller — the
-      # same key the canary ferry uses to tunnel to lib/iris/config/marin.yaml.
-      # A freshly-generated `os-login ssh-keys add` key is not honored by the
-      # prod controller in time, so ducky's tunnel never comes up.
-      - name: Install SSH key
-        env:
-          SSH_KEY: ${{ secrets.IRIS_CI_GCP_SSH_KEY }}
-          SSH_KEY_PUB: ${{ secrets.IRIS_CI_GCP_SSH_KEY_PUB }}
-        run: |
-          mkdir -p ~/.ssh
-          printf '%s\n' "$SSH_KEY" > ~/.ssh/google_compute_engine
-          printf '%s\n' "$SSH_KEY_PUB" > ~/.ssh/google_compute_engine.pub
-          chmod 600 ~/.ssh/google_compute_engine
-          chmod 644 ~/.ssh/google_compute_engine.pub
 
       - name: Deploy ducky
         env:

--- a/lib/ducky/src/ducky/deploy.py
+++ b/lib/ducky/src/ducky/deploy.py
@@ -10,9 +10,11 @@ uses. The job is pinned to a single region and grabs a whole v6e-4 host (or a
 smaller CPU-only shape for a smoke); the ``DUCKY_*`` config env vars are forwarded
 to the task.
 
-Connect to the controller by passing ``--controller-url`` (e.g. a tunnel opened by
-``iris --cluster=<name> ...``). Deploy keeps no cluster-resolution/auth logic of its
-own — that lives in the iris CLI.
+Connect to the controller with ``--cluster <name>`` (resolved through the iris CLI's
+``open_iris_client``, which handles both IAP-fronted clusters — a direct HTTPS ingress
+with a service-account-minted IAP token — and SSH-tunnelled ones) or an explicit
+``--controller-url``. Deploy keeps no cluster-resolution/auth logic of its own — that
+lives in the iris CLI.
 """
 
 from __future__ import annotations
@@ -24,13 +26,13 @@ import subprocess
 from pathlib import Path
 
 import click
+from iris.cli.connect import open_iris_client
 from iris.client.client import IrisClient, Job
 from iris.cluster.constraints import region_constraint
 from iris.cluster.types import Entrypoint, EnvironmentSpec, ResourceSpec, tpu_device
 from iris.rpc import job_pb2
 
 from ducky.config import PORT_NAME
-from ducky.tunnel import cluster_tunnel
 
 logger = logging.getLogger(__name__)
 
@@ -120,7 +122,8 @@ def _build_dashboard() -> None:
 @click.option(
     "--cluster",
     default=None,
-    help="Iris cluster to auto-tunnel to (opens `iris cluster dashboard`); exclusive with --controller-url.",
+    help="Iris cluster to connect to (resolves the controller URL and auth via the iris CLI); "
+    "exclusive with --controller-url.",
 )
 @click.option(
     "--controller-url",
@@ -156,16 +159,17 @@ def cli(
 ) -> None:
     """Submit the best-effort-always-on ducky service to an Iris cluster.
 
-    Pass ``--cluster <name>`` to auto-open a controller tunnel, or ``--controller-url``
-    to target one you already have. By default a running instance is replaced (RECREATE);
-    ``--keep`` leaves a healthy instance alone and only recreates a gone/terminal one — run
-    it on a schedule as a watchdog so the service comes back if its Iris job is ever lost.
+    Pass ``--cluster <name>`` to resolve the controller through the iris CLI (IAP ingress or
+    SSH tunnel, with auth), or ``--controller-url`` to target one you already have. By default
+    a running instance is replaced (RECREATE); ``--keep`` leaves a healthy instance alone and
+    only recreates a gone/terminal one — run it on a schedule as a watchdog so the service
+    comes back if its Iris job is ever lost.
     """
     logging.basicConfig(level=logging.INFO)
     if cluster and controller_url:
         raise click.UsageError("Pass --cluster or --controller-url, not both.")
     if not cluster and not controller_url:
-        raise click.UsageError("Pass --cluster <name> to auto-tunnel, or --controller-url <url>.")
+        raise click.UsageError("Pass --cluster <name>, or --controller-url <url>.")
     env_vars = _ducky_env_vars()
     if "DUCKY_SCRATCH_BUCKET" not in env_vars:
         raise click.UsageError("DUCKY_* env vars not set — export ducky config before deploying.")
@@ -175,8 +179,12 @@ def cli(
 
     policy = job_pb2.EXISTING_JOB_POLICY_KEEP if keep else job_pb2.EXISTING_JOB_POLICY_RECREATE
 
-    def _submit(url: str) -> None:
-        client = IrisClient.remote(url, workspace=Path.cwd(), extra_bundle_includes=[DASHBOARD_DIST_INCLUDE])
+    with open_iris_client(
+        cluster_name=cluster,
+        controller_url=controller_url,
+        workspace=Path.cwd(),
+        extra_bundle_includes=[DASHBOARD_DIST_INCLUDE],
+    ) as client:
         job = submit_ducky(
             client,
             name=name,
@@ -192,13 +200,6 @@ def cli(
             job.job_id,
             PORT_NAME,
         )
-
-    if cluster:
-        with cluster_tunnel(cluster) as url:
-            _submit(url)
-    else:
-        assert controller_url is not None  # guarded above
-        _submit(controller_url)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
* the marin cluster is now IAP-fronted (`auth.iap` in `lib/iris/config/marin.yaml`), so iris no longer opens an SSH tunnel — `require_controller_url` returns the HTTPS ingress directly and the client must present a service-account-minted IAP token
* the ducky deploy still scraped `iris cluster dashboard` output for a `127.0.0.1` tunnel URL and submitted with **no credentials**, so it failed with `Could not open a tunnel to cluster 'marin'` [^1]
* route the deploy through iris's `open_iris_client`, which resolves the controller URL and builds credentials for both IAP-fronted and SSH-tunnelled clusters uniformly — the IAP OIDC token is minted from the CI service-account ADC (`IapServiceAccountTokenProvider` → `fetch_id_token`), so ducky reimplements neither the URL resolution nor either auth path
* drop the now-dead `Install SSH key` step and `DUCKY_IRIS_CMD` from `ducky-deploy.yaml` (no tunnel is opened anymore; the `Authenticate to Google Cloud` step already provides the ADC the IAP token needs)

[^1]: `ducky query --cluster <iap-cluster>` is broken the same way — `cluster_tunnel` matches only a loopback URL and `_run_query` passes `token_provider=None` — but fixing it needs the IAP token wired into `DuckyClient`, so it's left for a separate change rather than a half-fix here.