### PR TITLE
[zephyr] Support separate map and reduce stage resource configurations

### DIFF
--- a/experiments/datakit/dedup/fineweb_10bt_exact.py
+++ b/experiments/datakit/dedup/fineweb_10bt_exact.py
@@ -5,7 +5,7 @@
 
 Usage:
     MARIN_PREFIX=/tmp/marin uv run iris --config=lib/iris/config/examples/local.yaml job run -- \\
-        python experiments/datakit/dedup/fineweb_10bt_exact.py [--max-parallelism N]
+        python experiments/datakit/dedup/fineweb_10bt_exact.py
 """
 
 import argparse

--- a/experiments/datakit/dedup/fineweb_10bt_exact.py
+++ b/experiments/datakit/dedup/fineweb_10bt_exact.py
@@ -25,7 +25,7 @@ logger = logging.getLogger(__name__)
 OUTPUT_PREFIX = os.environ.get("OUTPUT_PREFIX", "exact-para-dedup-fineweb-10bt")
 
 
-def build_steps(max_parallelism: int) -> list[StepSpec]:
+def build_steps() -> list[StepSpec]:
     download = fineweb_edu.download(
         hf_urls_glob=["sample/10BT/*.parquet"],
         worker_resources=ResourceConfig(cpu=2, ram="8g"),
@@ -38,8 +38,6 @@ def build_steps(max_parallelism: int) -> list[StepSpec]:
         fn=lambda op: dedup_exact_paragraph(
             input_paths=os.path.join(download.output_path, "sample/10BT"),
             output_path=op,
-            max_parallelism=max_parallelism,
-            worker_resources=ResourceConfig(cpu=3.5, ram="32g", disk="5g"),
         ),
     )
     return [download, dedup_step]
@@ -47,16 +45,9 @@ def build_steps(max_parallelism: int) -> list[StepSpec]:
 
 def main() -> None:
     parser = argparse.ArgumentParser(description=__doc__)
-    parser.add_argument(
-        "--max-parallelism",
-        type=int,
-        default=64,
-        metavar="N",
-        help="Maximum parallelism passed to dedup_exact_paragraph (default: %(default)s).",
-    )
-    args = parser.parse_args()
+    parser.parse_args()
     configure_logging(logging.INFO)
-    StepRunner().run(build_steps(max_parallelism=args.max_parallelism))
+    StepRunner().run(build_steps())
 
 
 if __name__ == "__main__":

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -102,21 +102,19 @@ def build_steps(run_id: str) -> list[StepSpec]:
         override_output_path=f"{base}/normalize",
     )  # ~1,380 output shards
 
-    minhash_map = ResourceConfig(cpu=1, ram="4g", disk="2g")
     minhash = StepSpec(
         name="datakit-nemotron-smoke/minhash",
         deps=[normalized],
         fn=lambda output_path: compute_minhash_attrs(
             source=read_artifact(normalized.output_path, NormalizedData),
             output_path=output_path,
-            worker_resources=minhash_map.scale(16),
-            map_task_resources=minhash_map,
-            reduce_task_resources=minhash_map.scale(3),
+            worker_resources=(resources := ResourceConfig(cpu=16, ram="64g", disk="32g")),
+            map_task_resources=resources.scale(1 / 16),
+            reduce_task_resources=resources.scale(3 / 16),
         ),
         override_output_path=f"{base}/minhash",
     )  # ~1,380 output shards
 
-    fuzzy_map = ResourceConfig(cpu=1, ram="10g", disk="2g")
     deduped = StepSpec(
         name="datakit-nemotron-smoke/fuzzy_dups",
         deps=[minhash],
@@ -125,14 +123,13 @@ def build_steps(run_id: str) -> list[StepSpec]:
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
             cc_max_iterations=3,
-            worker_resources=fuzzy_map.scale(16),
-            map_task_resources=fuzzy_map,
-            reduce_task_resources=fuzzy_map.scale(3),
+            worker_resources=(resources := ResourceConfig(cpu=16, ram="160g", disk="32g")),
+            map_task_resources=resources.scale(1 / 16),
+            reduce_task_resources=resources.scale(3 / 16),
         ),
         override_output_path=f"{base}/fuzzy_dups",
     )  # ~1,380 output shards
 
-    consolidate_map = ResourceConfig(cpu=1, ram="2g", disk="1g")
     consolidated = StepSpec(
         name="datakit-nemotron-smoke/consolidate",
         deps=[normalized, deduped],
@@ -151,13 +148,12 @@ def build_steps(run_id: str) -> list[StepSpec]:
                     keep_if_missing=True,
                 ),
             ],
-            worker_resources=consolidate_map.scale(16),
-            map_task_resources=consolidate_map,
+            worker_resources=(resources := ResourceConfig(cpu=16, ram="32g", disk="16g")),
+            map_task_resources=resources.scale(1 / 16),
         ),
         override_output_path=f"{base}/consolidate",
     )  # ~1,380 output shards
 
-    tokenize_map = ResourceConfig(cpu=1, ram="5g", disk="1g")
     tokenized = StepSpec(
         name="datakit-nemotron-smoke/tokenize",
         deps=[consolidated],
@@ -168,8 +164,8 @@ def build_steps(run_id: str) -> list[StepSpec]:
                 validation_paths=[],
                 cache_path=output_path,
                 tokenizer="gpt2",
-                worker_resources=tokenize_map.scale(16),
-                map_task_resources=tokenize_map,
+                worker_resources=(resources := ResourceConfig(cpu=16, ram="80g", disk="16g")),
+                map_task_resources=resources.scale(1 / 16),
             )
         ),
         override_output_path=f"{base}/tokens",

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -102,18 +102,21 @@ def build_steps(run_id: str) -> list[StepSpec]:
         override_output_path=f"{base}/normalize",
     )  # ~1,380 output shards
 
+    minhash_map = ResourceConfig(cpu=1, ram="4g", disk="2g")
     minhash = StepSpec(
         name="datakit-nemotron-smoke/minhash",
         deps=[normalized],
         fn=lambda output_path: compute_minhash_attrs(
             source=read_artifact(normalized.output_path, NormalizedData),
             output_path=output_path,
-            map_worker_resources=ResourceConfig(cpu=1, ram="4g", disk="2g"),
-            reduce_worker_resources=ResourceConfig(cpu=3, ram="12g", disk="5g"),
+            worker_resources=minhash_map.scale(16),
+            map_task_resources=minhash_map,
+            reduce_task_resources=minhash_map.scale(3),
         ),
         override_output_path=f"{base}/minhash",
     )  # ~1,380 output shards
 
+    fuzzy_map = ResourceConfig(cpu=1, ram="10g", disk="2g")
     deduped = StepSpec(
         name="datakit-nemotron-smoke/fuzzy_dups",
         deps=[minhash],
@@ -122,12 +125,14 @@ def build_steps(run_id: str) -> list[StepSpec]:
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
             cc_max_iterations=3,
-            map_worker_resources=ResourceConfig(cpu=1, ram="10g", disk="2g"),
-            reduce_worker_resources=ResourceConfig(cpu=3, ram="24g", disk="5g"),
+            worker_resources=fuzzy_map.scale(16),
+            map_task_resources=fuzzy_map,
+            reduce_task_resources=fuzzy_map.scale(3),
         ),
         override_output_path=f"{base}/fuzzy_dups",
     )  # ~1,380 output shards
 
+    consolidate_map = ResourceConfig(cpu=1, ram="2g", disk="1g")
     consolidated = StepSpec(
         name="datakit-nemotron-smoke/consolidate",
         deps=[normalized, deduped],
@@ -146,11 +151,13 @@ def build_steps(run_id: str) -> list[StepSpec]:
                     keep_if_missing=True,
                 ),
             ],
-            map_worker_resources=ResourceConfig(cpu=1, ram="2g", disk="1g"),
+            worker_resources=consolidate_map.scale(16),
+            map_task_resources=consolidate_map,
         ),
         override_output_path=f"{base}/consolidate",
     )  # ~1,380 output shards
 
+    tokenize_map = ResourceConfig(cpu=1, ram="5g", disk="1g")
     tokenized = StepSpec(
         name="datakit-nemotron-smoke/tokenize",
         deps=[consolidated],
@@ -161,7 +168,8 @@ def build_steps(run_id: str) -> list[StepSpec]:
                 validation_paths=[],
                 cache_path=output_path,
                 tokenizer="gpt2",
-                map_worker_resources=ResourceConfig(cpu=1, ram="5g", disk="1g"),
+                worker_resources=tokenize_map.scale(16),
+                map_task_resources=tokenize_map,
             )
         ),
         override_output_path=f"{base}/tokens",

--- a/experiments/ferries/datakit_nemotron_ferry.py
+++ b/experiments/ferries/datakit_nemotron_ferry.py
@@ -108,9 +108,8 @@ def build_steps(run_id: str) -> list[StepSpec]:
         fn=lambda output_path: compute_minhash_attrs(
             source=read_artifact(normalized.output_path, NormalizedData),
             output_path=output_path,
-            worker_resources=ResourceConfig(cpu=3.5, ram="12g", disk="5g"),
-            max_workers=460,
-            map_workers_per_actor=3,
+            map_worker_resources=ResourceConfig(cpu=1, ram="4g", disk="2g"),
+            reduce_worker_resources=ResourceConfig(cpu=3, ram="12g", disk="5g"),
         ),
         override_output_path=f"{base}/minhash",
     )  # ~1,380 output shards
@@ -122,10 +121,9 @@ def build_steps(run_id: str) -> list[StepSpec]:
         fn=lambda output_path: compute_fuzzy_dups_attrs(
             inputs=[read_artifact(minhash.output_path, MinHashAttrData)],
             output_path=output_path,
-            max_parallelism=690,
             cc_max_iterations=3,
-            worker_resources=ResourceConfig(cpu=2.5, ram="20g", disk="5g"),
-            map_workers_per_actor=2,
+            map_worker_resources=ResourceConfig(cpu=1, ram="10g", disk="2g"),
+            reduce_worker_resources=ResourceConfig(cpu=3, ram="24g", disk="5g"),
         ),
         override_output_path=f"{base}/fuzzy_dups",
     )  # ~1,380 output shards
@@ -148,9 +146,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
                     keep_if_missing=True,
                 ),
             ],
-            worker_resources=ResourceConfig(cpu=8.5, ram="16g", disk="5g"),
-            max_workers=173,
-            map_workers_per_actor=8,
+            map_worker_resources=ResourceConfig(cpu=1, ram="2g", disk="1g"),
         ),
         override_output_path=f"{base}/consolidate",
     )  # ~1,380 output shards
@@ -165,9 +161,7 @@ def build_steps(run_id: str) -> list[StepSpec]:
                 validation_paths=[],
                 cache_path=output_path,
                 tokenizer="gpt2",
-                max_workers=460,
-                worker_resources=ResourceConfig(cpu=3.5, ram="15g", disk="5g"),
-                map_workers_per_actor=3,
+                map_worker_resources=ResourceConfig(cpu=1, ram="5g", disk="1g"),
             )
         ),
         override_output_path=f"{base}/tokens",

--- a/lib/fray/pyproject.toml
+++ b/lib/fray/pyproject.toml
@@ -8,6 +8,7 @@ version = "0.2.0"
 requires-python = ">=3.12,<3.14"
 dependencies = [
     "cloudpickle>=3.1.2",
+    "humanfriendly>=10.0",
     "marin-iris",
     "marin-rigging",
 ]

--- a/lib/fray/src/fray/types.py
+++ b/lib/fray/src/fray/types.py
@@ -427,11 +427,13 @@ class ResourceConfig:
         ram: float | None = None,
         disk: float | None = None,
     ) -> "ResourceConfig":
-        """Return a copy with cpu/ram/disk scaled by the given factors.
+        """Return a copy with cpu/ram/disk multiplied by the given factors.
 
-        ``rc.scale(2)`` multiplies cpu, ram, and disk by 2. Keyword factors
-        scale individual dimensions (omitted dimensions keep their current
-        value). ``factor`` cannot be combined with keyword factors.
+        ``rc.scale(2)`` multiplies cpu, ram, and disk by 2; ``rc.scale(0.5)``
+        halves all three. Keyword args ``cpu``, ``ram``, and ``disk`` are
+        multiplicative factors for individual dimensions (e.g. ``cpu=0.5``
+        halves CPU); omitted dimensions keep their current value. ``factor``
+        cannot be combined with keyword factors.
         """
         if factor is not None and (cpu is not None or ram is not None or disk is not None):
             raise ValueError("Pass either a single factor or cpu/ram/disk keyword factors, not both.")

--- a/lib/fray/src/fray/types.py
+++ b/lib/fray/src/fray/types.py
@@ -11,11 +11,28 @@ not a per-task resource requirement).
 
 import os
 from collections.abc import Callable, Sequence
-from dataclasses import dataclass, field
+from dataclasses import dataclass, field, replace
 from enum import StrEnum
 from typing import Any, Literal
 
+import humanfriendly
+
 from fray.device_flops import device_flops as _device_flops
+
+
+def _scale_byte_size(size: str, factor: float) -> str:
+    """Scale a human-readable byte size, preserving compact binary unit suffixes."""
+    if factor == 1.0:
+        return size
+    scaled = humanfriendly.parse_size(size, binary=True) * factor
+    for suffix, unit in (("t", 1024**4), ("g", 1024**3), ("m", 1024**2), ("k", 1024)):
+        if scaled >= unit:
+            value = scaled / unit
+            if abs(value - round(value)) < 1e-9:
+                return f"{round(value)}{suffix}"
+            return f"{value:g}{suffix}"
+    return f"{round(scaled)}B"
+
 
 # ---------------------------------------------------------------------------
 # TPU topology
@@ -400,6 +417,37 @@ class ResourceConfig:
         if isinstance(self.device, CpuConfig):
             return 100e9
         return self.device_flops(dtype) * self.chip_count()
+
+    def scale(
+        self,
+        factor: float | None = None,
+        /,
+        *,
+        cpu: float | None = None,
+        ram: float | None = None,
+        disk: float | None = None,
+    ) -> "ResourceConfig":
+        """Return a copy with cpu/ram/disk scaled by the given factors.
+
+        ``rc.scale(2)`` multiplies cpu, ram, and disk by 2. Keyword factors
+        scale individual dimensions (omitted dimensions keep their current
+        value). ``factor`` cannot be combined with keyword factors.
+        """
+        if factor is not None and (cpu is not None or ram is not None or disk is not None):
+            raise ValueError("Pass either a single factor or cpu/ram/disk keyword factors, not both.")
+        if factor is not None:
+            cpu_factor = ram_factor = disk_factor = factor
+        else:
+            cpu_factor = 1.0 if cpu is None else cpu
+            ram_factor = 1.0 if ram is None else ram
+            disk_factor = 1.0 if disk is None else disk
+
+        return replace(
+            self,
+            cpu=self.cpu * cpu_factor,
+            ram=_scale_byte_size(self.ram, ram_factor),
+            disk=_scale_byte_size(self.disk, disk_factor),
+        )
 
     @staticmethod
     def with_tpu(tpu_type: str | Sequence[str], *, slice_count: int = 1, **kwargs: Any) -> "ResourceConfig":

--- a/lib/fray/tests/test_iris.py
+++ b/lib/fray/tests/test_iris.py
@@ -139,6 +139,12 @@ class TestResourceConfigScale:
         assert scaled.ram == "8g"
         assert scaled.disk == "4g"
 
+    def test_scale_with_fractional_factor_scales_all_dimensions_down(self):
+        scaled = ResourceConfig(cpu=2, ram="8g", disk="4g").scale(0.5)
+        assert scaled.cpu == 1
+        assert scaled.ram == "4g"
+        assert scaled.disk == "2g"
+
     def test_scale_with_individual_factors_scales_specified_dimensions(self):
         base = ResourceConfig(cpu=1, ram="4g", disk="2g")
         scaled = base.scale(cpu=3, ram=3, disk=2.5)

--- a/lib/fray/tests/test_iris.py
+++ b/lib/fray/tests/test_iris.py
@@ -132,6 +132,37 @@ class TestIrisActorHandlePickle:
         assert restored._client is None
 
 
+class TestResourceConfigScale:
+    def test_scale_with_uniform_factor_scales_all_dimensions(self):
+        scaled = ResourceConfig(cpu=1, ram="4g", disk="2g").scale(2)
+        assert scaled.cpu == 2
+        assert scaled.ram == "8g"
+        assert scaled.disk == "4g"
+
+    def test_scale_with_individual_factors_scales_specified_dimensions(self):
+        base = ResourceConfig(cpu=1, ram="4g", disk="2g")
+        scaled = base.scale(cpu=3, ram=3, disk=2.5)
+        assert scaled.cpu == 3
+        assert scaled.ram == "12g"
+        assert scaled.disk == "5g"
+
+    def test_scale_with_omitted_kwargs_leaves_unspecified_dimensions_unchanged(self):
+        scaled = ResourceConfig(cpu=1, ram="10g", disk="2g").scale(cpu=2, ram=2.4)
+        assert scaled.cpu == 2
+        assert scaled.ram == "24g"
+        assert scaled.disk == "2g"
+
+    def test_scale_with_factor_preserves_non_size_fields(self):
+        base = ResourceConfig(cpu=1, ram="4g", disk="2g", preemptible=False, image="custom")
+        scaled = base.scale(2)
+        assert scaled.preemptible is False
+        assert scaled.image == "custom"
+
+    def test_scale_with_mixed_factor_and_kwargs_raises_value_error(self):
+        with pytest.raises(ValueError, match="either a single factor"):
+            ResourceConfig(cpu=1, ram="4g").scale(2, cpu=3)
+
+
 class TestImagePlumbing:
     def test_resource_config_image_default_is_none(self):
         rc = ResourceConfig()

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -144,7 +144,7 @@ def consolidate(
     filetype: str = "jsonl.gz",
     worker_resources: ResourceConfig | None = None,
     max_workers: int | None = None,
-    map_worker_resources: ResourceConfig | None = None,
+    map_task_resources: ResourceConfig | None = None,
 ) -> ZephyrExecutionResult:
     """Consolidate documents by applying filters based on attributes.
 
@@ -160,9 +160,10 @@ def consolidate(
         worker_resources: Optional Zephyr worker resource config. Defaults to
             ``ResourceConfig(cpu=2, ram="4g")`` — Zephyr's 1 CPU / 1 GB default
             packs multiple workers per VM and OOMs on heavy-tailed inputs where
-            a single doc can blow past the per-worker share.
+            a single doc can blow past the per-worker share. Required when
+            ``map_task_resources`` is set.
         max_workers: Maximum number of Zephyr workers (defaults to Zephyr's default).
-        map_worker_resources: ResourceConfig for the map stage.
+        map_task_resources: ResourceConfig for map-stage tasks.
     """
     input_paths = sorted(str(m) for m in StoragePath(os.path.join(input_path, f"**/*.{filetype}")).glob())
     if not input_paths:
@@ -190,11 +191,10 @@ def consolidate(
     ctx_kwargs: dict = {
         "name": "consolidate-filter",
         "max_workers": max_workers,
+        "resources": worker_resources or ResourceConfig(cpu=2, ram="4g"),
     }
-    if map_worker_resources is not None:
-        ctx_kwargs["map_worker_resources"] = map_worker_resources
-    else:
-        ctx_kwargs["resources"] = worker_resources or ResourceConfig(cpu=2, ram="4g")
+    if map_task_resources is not None:
+        ctx_kwargs["map_task_resources"] = map_task_resources
 
     ctx = ZephyrContext(**ctx_kwargs)
     return ctx.execute(ds.write_parquet(f"{output_path}/part-{{shard:05d}}-of-{{total:05d}}.parquet"))

--- a/lib/marin/src/marin/processing/classification/consolidate.py
+++ b/lib/marin/src/marin/processing/classification/consolidate.py
@@ -144,7 +144,7 @@ def consolidate(
     filetype: str = "jsonl.gz",
     worker_resources: ResourceConfig | None = None,
     max_workers: int | None = None,
-    map_workers_per_actor: int | None = None,
+    map_worker_resources: ResourceConfig | None = None,
 ) -> ZephyrExecutionResult:
     """Consolidate documents by applying filters based on attributes.
 
@@ -162,7 +162,7 @@ def consolidate(
             packs multiple workers per VM and OOMs on heavy-tailed inputs where
             a single doc can blow past the per-worker share.
         max_workers: Maximum number of Zephyr workers (defaults to Zephyr's default).
-        map_workers_per_actor: Number of workers per actor for the map stage.
+        map_worker_resources: ResourceConfig for the map stage.
     """
     input_paths = sorted(str(m) for m in StoragePath(os.path.join(input_path, f"**/*.{filetype}")).glob())
     if not input_paths:
@@ -187,12 +187,14 @@ def consolidate(
         # Drop rejected docs before the next join so its key extractor never sees None.
         ds = ds.filter(lambda r: r is not None)
 
-    if worker_resources is None:
-        worker_resources = ResourceConfig(cpu=2, ram="4g")
-    ctx_kwargs: dict = {"name": "consolidate-filter", "resources": worker_resources}
-    if map_workers_per_actor is not None:
-        ctx_kwargs["map_workers_per_actor"] = map_workers_per_actor
-    if max_workers is not None:
-        ctx_kwargs["max_workers"] = max_workers
+    ctx_kwargs: dict = {
+        "name": "consolidate-filter",
+        "max_workers": max_workers,
+    }
+    if map_worker_resources is not None:
+        ctx_kwargs["map_worker_resources"] = map_worker_resources
+    else:
+        ctx_kwargs["resources"] = worker_resources or ResourceConfig(cpu=2, ram="4g")
+
     ctx = ZephyrContext(**ctx_kwargs)
     return ctx.execute(ds.write_parquet(f"{output_path}/part-{{shard:05d}}-of-{{total:05d}}.parquet"))

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -76,9 +76,6 @@ def dedup_exact_paragraph(
     input_paths: str | list[str],
     output_path: str,
     text_field: str = "text",
-    max_parallelism: int,
-    worker_resources: ResourceConfig | None = None,
-    coordinator_resources: ResourceConfig | None = None,
 ) -> dict:
     input_files = _collect_input_files(input_paths=input_paths, filetypes=["parquet"])
     idx_to_path = dict(list(enumerate(input_files)))
@@ -101,12 +98,9 @@ def dedup_exact_paragraph(
 
     ctx_kwargs: dict = {
         "name": "exact-para-dedup",
-        "max_workers": max_parallelism,
-        "resources": worker_resources or ResourceConfig(cpu=1, ram="32g", disk="5g"),
-        "map_workers_per_actor": 3,
+        "map_worker_resources": ResourceConfig(cpu=0.5, ram="10g", disk="2g"),
+        "reduce_worker_resources": ResourceConfig(cpu=1, ram="24g", disk="2g"),
     }
-    if coordinator_resources is not None:
-        ctx_kwargs["coordinator_resources"] = coordinator_resources
     ctx = ZephyrContext(**ctx_kwargs)
 
     def aggregate_and_write_to_corresponding_files(file_idx: int, records: Iterator[dict]) -> dict:

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -96,12 +96,11 @@ def dedup_exact_paragraph(
         result = dupekit.transform(batch, pipeline)
         return result.append_column(DEFAULT_FILE_PATH_COLUMN, pa.array([source] * result.num_rows, type=pa.string()))
 
-    map_task_resources = ResourceConfig(cpu=0.5, ram="10g", disk="2g")
     ctx_kwargs: dict = {
         "name": "exact-para-dedup",
-        "resources": map_task_resources.scale(10),
-        "map_task_resources": map_task_resources,
-        "reduce_task_resources": map_task_resources.scale(cpu=2, ram=2),
+        "resources": (resources := ResourceConfig(cpu=10, ram="100g", disk="20g")),
+        "map_task_resources": resources.scale(0.1),  # 1 cpu / 10g / 2g
+        "reduce_task_resources": resources.scale(cpu=0.1, ram=0.2, disk=0.1),  # 1 cpu / 20g / 2g
     }
     ctx = ZephyrContext(**ctx_kwargs)
 

--- a/lib/marin/src/marin/processing/classification/deduplication/exact.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/exact.py
@@ -96,10 +96,12 @@ def dedup_exact_paragraph(
         result = dupekit.transform(batch, pipeline)
         return result.append_column(DEFAULT_FILE_PATH_COLUMN, pa.array([source] * result.num_rows, type=pa.string()))
 
+    map_task_resources = ResourceConfig(cpu=0.5, ram="10g", disk="2g")
     ctx_kwargs: dict = {
         "name": "exact-para-dedup",
-        "map_worker_resources": ResourceConfig(cpu=0.5, ram="10g", disk="2g"),
-        "reduce_worker_resources": ResourceConfig(cpu=1, ram="24g", disk="2g"),
+        "resources": map_task_resources.scale(10),
+        "map_task_resources": map_task_resources,
+        "reduce_task_resources": map_task_resources.scale(cpu=2, ram=2),
     }
     ctx = ZephyrContext(**ctx_kwargs)
 

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -41,7 +41,7 @@ from pydantic import BaseModel
 from rigging.filesystem import StoragePath
 from zephyr import counters
 from zephyr.dataset import Dataset
-from zephyr.execution import ZephyrContext
+from zephyr.execution import MAX_WORKERS_PER_JOB, ZephyrContext
 from zephyr.worker_context import zephyr_worker_ctx
 from zephyr.writers import write_parquet_file
 
@@ -250,10 +250,11 @@ def compute_fuzzy_dups_attrs(
     output_path: str,
     cc_max_iterations: int = 10,
     cc_resume: bool = False,
-    max_parallelism: int,
+    max_parallelism: int = MAX_WORKERS_PER_JOB,
     worker_resources: ResourceConfig | None = None,
     coordinator_resources: ResourceConfig | None = None,
-    map_workers_per_actor: int | None = None,
+    map_worker_resources: ResourceConfig | None = None,
+    reduce_worker_resources: ResourceConfig | None = None,
 ) -> FuzzyDupsAttrData:
     """Mark fuzzy-duplicate cluster membership across one or more ``MinHashAttrData`` inputs.
 
@@ -278,6 +279,9 @@ def compute_fuzzy_dups_attrs(
         max_parallelism: Worker count for the ZephyrContext.
         worker_resources: Per-worker resource request.
         coordinator_resources: Coordinator resource request.
+        map_worker_resources: ResourceConfig for map-stage tasks.
+        reduce_worker_resources: ResourceConfig for reduce-stage tasks (e.g.
+            the per-shard ``group_by`` writer).
 
     Returns:
         :class:`FuzzyDupsAttrData` describing per-source attr directories,
@@ -301,12 +305,15 @@ def compute_fuzzy_dups_attrs(
     ctx_kwargs: dict = {
         "name": "fuzzy-dups",
         "max_workers": max_parallelism,
-        "resources": worker_resources or ResourceConfig(cpu=1, ram="32g", disk="5g"),
     }
     if coordinator_resources is not None:
         ctx_kwargs["coordinator_resources"] = coordinator_resources
-    if map_workers_per_actor is not None:
-        ctx_kwargs["map_workers_per_actor"] = map_workers_per_actor
+    if map_worker_resources is not None:
+        ctx_kwargs["map_worker_resources"] = map_worker_resources
+    if reduce_worker_resources is not None:
+        ctx_kwargs["reduce_worker_resources"] = reduce_worker_resources
+    if map_worker_resources is None and reduce_worker_resources is None:
+        ctx_kwargs["resources"] = worker_resources or ResourceConfig(cpu=1, ram="32g", disk="5g")
     ctx = ZephyrContext(**ctx_kwargs)
 
     # Cap shard count at max_parallelism. Each group reads its attr files

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_dups.py
@@ -253,8 +253,8 @@ def compute_fuzzy_dups_attrs(
     max_parallelism: int = MAX_WORKERS_PER_JOB,
     worker_resources: ResourceConfig | None = None,
     coordinator_resources: ResourceConfig | None = None,
-    map_worker_resources: ResourceConfig | None = None,
-    reduce_worker_resources: ResourceConfig | None = None,
+    map_task_resources: ResourceConfig | None = None,
+    reduce_task_resources: ResourceConfig | None = None,
 ) -> FuzzyDupsAttrData:
     """Mark fuzzy-duplicate cluster membership across one or more ``MinHashAttrData`` inputs.
 
@@ -277,10 +277,11 @@ def compute_fuzzy_dups_attrs(
             ``<output_path>/outputs/source_NNN/``.
         cc_max_iterations: Max iterations for connected components.
         max_parallelism: Worker count for the ZephyrContext.
-        worker_resources: Per-worker resource request.
+        worker_resources: Per-worker resource request. Required when
+            ``map_task_resources`` is set.
         coordinator_resources: Coordinator resource request.
-        map_worker_resources: ResourceConfig for map-stage tasks.
-        reduce_worker_resources: ResourceConfig for reduce-stage tasks (e.g.
+        map_task_resources: ResourceConfig for map-stage tasks.
+        reduce_task_resources: ResourceConfig for reduce-stage tasks (e.g.
             the per-shard ``group_by`` writer).
 
     Returns:
@@ -305,15 +306,14 @@ def compute_fuzzy_dups_attrs(
     ctx_kwargs: dict = {
         "name": "fuzzy-dups",
         "max_workers": max_parallelism,
+        "resources": worker_resources or ResourceConfig(cpu=1, ram="32g", disk="5g"),
     }
     if coordinator_resources is not None:
         ctx_kwargs["coordinator_resources"] = coordinator_resources
-    if map_worker_resources is not None:
-        ctx_kwargs["map_worker_resources"] = map_worker_resources
-    if reduce_worker_resources is not None:
-        ctx_kwargs["reduce_worker_resources"] = reduce_worker_resources
-    if map_worker_resources is None and reduce_worker_resources is None:
-        ctx_kwargs["resources"] = worker_resources or ResourceConfig(cpu=1, ram="32g", disk="5g")
+    if map_task_resources is not None:
+        ctx_kwargs["map_task_resources"] = map_task_resources
+    if reduce_task_resources is not None:
+        ctx_kwargs["reduce_task_resources"] = reduce_task_resources
     ctx = ZephyrContext(**ctx_kwargs)
 
     # Cap shard count at max_parallelism. Each group reads its attr files

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -160,7 +160,8 @@ def compute_minhash_attrs(
     seed: int = 42,
     worker_resources: ResourceConfig | None = None,
     max_workers: int | None = None,
-    map_workers_per_actor: int | None = None,
+    map_worker_resources: ResourceConfig | None = None,
+    reduce_worker_resources: ResourceConfig | None = None,
 ) -> MinHashAttrData:
     """Compute MinHash bucket attributes for *source* and persist as Parquet.
 
@@ -189,6 +190,8 @@ def compute_minhash_attrs(
             a native thread pool and may consume up to ~2 cores beyond the
             Python thread.
         max_workers: Max Zephyr workers. Defaults to Zephyr's own default.
+        map_worker_resources: ResourceConfig for map-stage tasks.
+        reduce_worker_resources: ResourceConfig for reduce-stage tasks.
 
     Returns:
         :class:`MinHashAttrData` describing the attr directory and counters.
@@ -219,12 +222,15 @@ def compute_minhash_attrs(
 
     ctx_kwargs: dict = {
         "name": "minhash-attrs",
-        "resources": worker_resources or ResourceConfig(cpu=5, ram="32g", disk="5g"),
     }
     if max_workers is not None:
         ctx_kwargs["max_workers"] = max_workers
-    if map_workers_per_actor is not None:
-        ctx_kwargs["map_workers_per_actor"] = map_workers_per_actor
+    if map_worker_resources is not None:
+        ctx_kwargs["map_worker_resources"] = map_worker_resources
+    if reduce_worker_resources is not None:
+        ctx_kwargs["reduce_worker_resources"] = reduce_worker_resources
+    if map_worker_resources is None and reduce_worker_resources is None:
+        ctx_kwargs["resources"] = worker_resources or ResourceConfig(cpu=5, ram="32g", disk="5g")
     ctx = ZephyrContext(**ctx_kwargs)
 
     # Preserve source basenames; zephyr's `{basename}` placeholder is synthetic.

--- a/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
+++ b/lib/marin/src/marin/processing/classification/deduplication/fuzzy_minhash.py
@@ -160,8 +160,8 @@ def compute_minhash_attrs(
     seed: int = 42,
     worker_resources: ResourceConfig | None = None,
     max_workers: int | None = None,
-    map_worker_resources: ResourceConfig | None = None,
-    reduce_worker_resources: ResourceConfig | None = None,
+    map_task_resources: ResourceConfig | None = None,
+    reduce_task_resources: ResourceConfig | None = None,
 ) -> MinHashAttrData:
     """Compute MinHash bucket attributes for *source* and persist as Parquet.
 
@@ -188,10 +188,10 @@ def compute_minhash_attrs(
         worker_resources: Per-worker resource request. Sized similarly to the
             old ``dedup_fuzzy_document``: dupekit's Rust MinHash pipeline uses
             a native thread pool and may consume up to ~2 cores beyond the
-            Python thread.
+            Python thread. Required when ``map_task_resources`` is set.
         max_workers: Max Zephyr workers. Defaults to Zephyr's own default.
-        map_worker_resources: ResourceConfig for map-stage tasks.
-        reduce_worker_resources: ResourceConfig for reduce-stage tasks.
+        map_task_resources: ResourceConfig for map-stage tasks.
+        reduce_task_resources: ResourceConfig for reduce-stage tasks.
 
     Returns:
         :class:`MinHashAttrData` describing the attr directory and counters.
@@ -222,15 +222,14 @@ def compute_minhash_attrs(
 
     ctx_kwargs: dict = {
         "name": "minhash-attrs",
+        "resources": worker_resources or ResourceConfig(cpu=5, ram="32g", disk="5g"),
     }
     if max_workers is not None:
         ctx_kwargs["max_workers"] = max_workers
-    if map_worker_resources is not None:
-        ctx_kwargs["map_worker_resources"] = map_worker_resources
-    if reduce_worker_resources is not None:
-        ctx_kwargs["reduce_worker_resources"] = reduce_worker_resources
-    if map_worker_resources is None and reduce_worker_resources is None:
-        ctx_kwargs["resources"] = worker_resources or ResourceConfig(cpu=5, ram="32g", disk="5g")
+    if map_task_resources is not None:
+        ctx_kwargs["map_task_resources"] = map_task_resources
+    if reduce_task_resources is not None:
+        ctx_kwargs["reduce_task_resources"] = reduce_task_resources
     ctx = ZephyrContext(**ctx_kwargs)
 
     # Preserve source basenames; zephyr's `{basename}` placeholder is synthetic.

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -135,7 +135,7 @@ class TokenizeConfigBase(abc.ABC):
 
     max_workers: int = 4096
     worker_resources: ResourceConfig = dataclasses.field(default_factory=lambda: ResourceConfig(ram="10g", disk="5g"))
-    map_workers_per_actor: int | None = None
+    map_worker_resources: ResourceConfig | None = None
 
     tokenizer_backend: TokenizerBackend = TokenizerBackend.HF
     """Backend to use for tokenization. HF uses the HuggingFace tokenizers library directly."""
@@ -311,11 +311,10 @@ def _run_split(
 
     ctx = ZephyrContext(
         resources=config.worker_resources,
+        map_worker_resources=config.map_worker_resources,
         max_workers=min(config.max_workers, len(file_groups)),
         name=f"tokenize-{split_name}",
     )
-    if config.map_workers_per_actor is not None:
-        ctx.map_workers_per_actor = config.map_workers_per_actor
     # Broadcast tokenizer config to workers. We send name + backend rather than
     # the tokenizer object because not all backends support pickling.
     ctx.put("tokenizer_name", config.tokenizer)

--- a/lib/marin/src/marin/processing/tokenize/tokenize.py
+++ b/lib/marin/src/marin/processing/tokenize/tokenize.py
@@ -135,7 +135,7 @@ class TokenizeConfigBase(abc.ABC):
 
     max_workers: int = 4096
     worker_resources: ResourceConfig = dataclasses.field(default_factory=lambda: ResourceConfig(ram="10g", disk="5g"))
-    map_worker_resources: ResourceConfig | None = None
+    map_task_resources: ResourceConfig | None = None
 
     tokenizer_backend: TokenizerBackend = TokenizerBackend.HF
     """Backend to use for tokenization. HF uses the HuggingFace tokenizers library directly."""
@@ -311,7 +311,7 @@ def _run_split(
 
     ctx = ZephyrContext(
         resources=config.worker_resources,
-        map_worker_resources=config.map_worker_resources,
+        map_task_resources=config.map_task_resources,
         max_workers=min(config.max_workers, len(file_groups)),
         name=f"tokenize-{split_name}",
     )

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -13,6 +13,7 @@ bugs where orphaned coordinators and workers consume resources indefinitely.
 
 import enum
 import logging
+import math
 import os
 import sys
 import threading
@@ -86,6 +87,11 @@ MAX_SHARD_INFRA_FAILURES = 20
 
 # Typical status text for a 6-stage pipeline is ~300 chars.
 MAX_STATUS_TEXT_LENGTH = 1000
+
+# V5P machine specifications
+V5P_RESOURCES = ResourceConfig(cpu=32.0, ram="256g", disk="50g")
+
+MAX_WORKERS_PER_JOB = 2_048
 
 
 class ShardFailureKind(enum.StrEnum):
@@ -1493,8 +1499,8 @@ class _CoordinatorJobConfig:
     # Cloudpickled and re-invoked per worker slot, so per-runner mutable
     # state is per-slot.
     stage_runner_factory: Callable[[], StageRunner]
-    map_workers_per_actor: int = 1
-    reduce_workers_per_actor: int = 1
+    map_worker_resources: ResourceConfig
+    reduce_worker_resources: ResourceConfig
     heartbeat_timeout: float = 120.0
     max_shard_failures: int = MAX_SHARD_FAILURES
     max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES
@@ -1524,19 +1530,10 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
 
     client = current_client()
 
-    # Compute per-task resource costs from worker spec and concurrency limits.
-    total = ZephyrTaskResources(
-        cpu=config.worker_resources.cpu,
-        memory=int(humanfriendly.parse_size(config.worker_resources.ram, binary=True)),
-    )
-    map_cost = ZephyrTaskResources(
-        cpu=total.cpu / max(1, config.map_workers_per_actor),
-        memory=total.memory // max(1, config.map_workers_per_actor),
-    )
-    reduce_cost = ZephyrTaskResources(
-        cpu=total.cpu / max(1, config.reduce_workers_per_actor),
-        memory=total.memory // max(1, config.reduce_workers_per_actor),
-    )
+    # Compute per-task resource costs.
+    total = ZephyrTaskResources.from_resource_config(config.worker_resources)
+    map_cost = ZephyrTaskResources.from_resource_config(config.map_worker_resources)
+    reduce_cost = ZephyrTaskResources.from_resource_config(config.reduce_worker_resources)
 
     # Host coordinator actor in this process (no child job needed)
     coord_name = f"zephyr-{config.name}-p{config.pipeline_id}-coord"
@@ -1559,22 +1556,20 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
     # body raises and the Iris task will be stuck RUNNING.
     try:
         # Create workers (child jobs)
-        num_shards = config.plan.num_shards
-        actual_workers = min(config.max_workers, num_shards) if num_shards > 0 else 0
 
-        if actual_workers > 0:
+        if config.max_workers > 0:
             # Worker name includes attempt ID so that if a stale coordinator
             # process from a previous attempt is still running, its shutdown
             # targets the old name and cannot kill this attempt's workers.
             worker_name = f"zephyr-{config.name}-p{config.pipeline_id}-workers-a{attempt_id}"
-            logger.info("Starting %d workers (max=%d, shards=%d)", actual_workers, config.max_workers, num_shards)
+            logger.info("Starting %d workers (shards=%d)", config.max_workers, config.plan.num_shards)
             worker_group = client.create_actor_group(
                 ZephyrWorker,
                 coordinator,
                 config.stage_runner_factory,
                 total,
                 name=worker_name,
-                count=actual_workers,
+                count=config.max_workers,
                 resources=config.worker_resources,
                 actor_config=ActorConfig(max_task_retries=10),
             )
@@ -1655,6 +1650,78 @@ def _try_read_coordinator_result(result_path: str) -> Any:
         return None
 
 
+def _compute_overall_worker_resources(
+    map_resources: ResourceConfig,
+    reduce_resources: ResourceConfig,
+) -> tuple[ResourceConfig, int]:
+    """Compute overall worker resources based on map/reduce task resources and V5P size constraints.
+
+    The algorithm aims to satisfy three main design goals:
+    1. Perfect Fit (No Waste): The computed worker capacity is a multiple of the task resource requirements
+       (both map and reduce tasks fit exactly with zero remainder on bottleneck resources).
+    2. Sizing Target: The overall worker size is targeted to be approximately 1/4 of the overall V5P
+       machine (32 CPU, 256 GB RAM, 50 GB Disk), ensuring a balanced resource footprint.
+    3. Multi-task Multiplexing: The long-lived worker is sized to accommodate the resource requirements
+       for both map stages and reduce stages concurrently.
+    """
+    for field_name in ["device", "preemptible", "regions", "zone", "replicas", "image", "device_alternatives"]:
+        map_val = getattr(map_resources, field_name)
+        reduce_val = getattr(reduce_resources, field_name)
+        if map_val != reduce_val:
+            raise ValueError(
+                f"Field '{field_name}' cannot differ between map_worker_resources ({map_val}) "
+                f"and reduce_worker_resources ({reduce_val}). Set the same value on both."
+            )
+
+    # 1. Parse target sizes (1/4 of V5P machine)
+    target_cpu = V5P_RESOURCES.cpu / 4.0
+    target_ram = humanfriendly.parse_size(V5P_RESOURCES.ram, binary=True) // 4
+    target_disk = humanfriendly.parse_size(V5P_RESOURCES.disk, binary=True) // 4
+
+    # 2. Parse map / reduce task resources
+    map_cpu = map_resources.cpu
+    map_ram = humanfriendly.parse_size(map_resources.ram, binary=True)
+    map_disk = humanfriendly.parse_size(map_resources.disk, binary=True)
+
+    reduce_cpu = reduce_resources.cpu
+    reduce_ram = humanfriendly.parse_size(reduce_resources.ram, binary=True)
+    reduce_disk = humanfriendly.parse_size(reduce_resources.disk, binary=True)
+
+    # 3. Compute number of concurrent tasks per worker (N)
+    map_ratios = [target_cpu / map_cpu]
+    if map_ram > 0:
+        map_ratios.append(target_ram / map_ram)
+    if map_disk > 0:
+        map_ratios.append(target_disk / map_disk)
+    n_map = max(1, round(min(map_ratios)))
+
+    reduce_ratios = [target_cpu / reduce_cpu]
+    if reduce_ram > 0:
+        reduce_ratios.append(target_ram / reduce_ram)
+    if reduce_disk > 0:
+        reduce_ratios.append(target_disk / reduce_disk)
+    n_reduce = max(1, round(min(reduce_ratios)))
+
+    # 4. Compute overall worker resources
+    worker_cpu = max(n_map * map_cpu, n_reduce * reduce_cpu)
+    worker_ram_bytes = max(n_map * map_ram, n_reduce * reduce_ram)
+    worker_disk_bytes = max(n_map * map_disk, n_reduce * reduce_disk)
+
+    worker_resources = ResourceConfig(
+        cpu=worker_cpu,
+        ram=humanfriendly.format_size(worker_ram_bytes, binary=True),
+        disk=humanfriendly.format_size(worker_disk_bytes, binary=True),
+        device=map_resources.device,
+        preemptible=map_resources.preemptible,
+        regions=map_resources.regions,
+        zone=map_resources.zone,
+        replicas=map_resources.replicas,
+        image=map_resources.image,
+        device_alternatives=map_resources.device_alternatives,
+    )
+    return worker_resources, min(n_map, n_reduce)
+
+
 @dataclass
 class ZephyrContext:
     """Execution context for Zephyr pipelines.
@@ -1684,13 +1751,8 @@ class ZephyrContext:
         stage_runner_factory: Callable ``() -> StageRunner``.
             Defaults to ``InlineRunner`` for ``LocalClient`` and ``SubprocessRunner``
             for distributed clients.
-        map_workers_per_actor: Maximum number of concurrent map tasks per actor.
-            Each accepted task deducts ``total_resources / map_workers_per_actor``
-            from the worker's available resource pool, so N tasks can run in
-            parallel before the pool is exhausted. Defaults to 1.
-        reduce_workers_per_actor: Maximum number of concurrent reduce tasks per actor.
-            Same resource-cost model as map_workers_per_actor applied to reduce-type
-            stages (Scatter, Reduce, Fold, Join). Defaults to 1.
+        map_worker_resources: ResourceConfig specifying resources required by a single map task.
+        reduce_worker_resources: ResourceConfig specifying resources required by a single reduce task.
         heartbeat_timeout: Seconds without a worker heartbeat before the coordinator
             marks the worker FAILED and requeues its in-flight shard. Defaults to 120.
             Long-running stages (e.g. vLLM inference with cold XLA compile) may need
@@ -1705,7 +1767,7 @@ class ZephyrContext:
 
     client: Client | None = None
     max_workers: int | None = None
-    resources: ResourceConfig = field(default_factory=lambda: ResourceConfig(cpu=1, ram="1g"))
+    resources: ResourceConfig | None = None
     coordinator_resources: ResourceConfig = field(
         default_factory=lambda: ResourceConfig(cpu=0.1, ram="1g", preemptible=False)
     )
@@ -1715,8 +1777,8 @@ class ZephyrContext:
     # NOTE: 100 is fairly aggressive but it fits the preemptible env better
     max_execution_retries: int = 100
     stage_runner_factory: Callable[[], StageRunner] | None = None
-    map_workers_per_actor: int = 1
-    reduce_workers_per_actor: int = 1
+    map_worker_resources: ResourceConfig | None = None
+    reduce_worker_resources: ResourceConfig | None = None
     heartbeat_timeout: float = 120.0
     max_shard_failures: int = MAX_SHARD_FAILURES
     max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES
@@ -1727,18 +1789,52 @@ class ZephyrContext:
     _coordinator_job: JobHandle | None = field(default=None, repr=False)
     # NOTE: execute calls increment this at the very beginning
     _pipeline_id: int = field(default=-1, repr=False)
+    _min_tasks_per_worker: int = field(init=False, default=1, repr=False)
 
     def __post_init__(self):
         if self.client is None:
             self.client = current_client()
 
-        if self.max_workers is None:
-            if isinstance(self.client, LocalClient):
-                self.max_workers = os.cpu_count() or 1
+        if env_val := os.environ.get("ZEPHYR_MAX_WORKERS"):
+            if self.max_workers is None:
+                try:
+                    self.max_workers = int(env_val)
+                except ValueError as e:
+                    raise ValueError(f"Invalid ZEPHYR_MAX_WORKERS environment variable value: {env_val}") from e
             else:
-                # Default to 128 for distributed, but allow override
-                env_val = os.environ.get("ZEPHYR_MAX_WORKERS")
-                self.max_workers = int(env_val) if env_val else 128
+                logger.info("Ignoring ZEPHYR_MAX_WORKERS environment variable in favor of max_workers variable.")
+
+        if self.map_worker_resources is None and self.reduce_worker_resources is not None:
+            raise ValueError("Setting reduce_worker_resources without setting map_worker_resources is an error.")
+
+        if self.resources is None and self.map_worker_resources is None:
+            self.resources = ResourceConfig(cpu=1, ram="1g")
+        if self.map_worker_resources is None:
+            self.map_worker_resources = self.resources
+        if self.reduce_worker_resources is None:
+            self.reduce_worker_resources = self.map_worker_resources
+        if self.resources is None:
+            # resources was not set and map_worker_resources was set, so compute the overall worker resources
+            self.resources, self._min_tasks_per_worker = _compute_overall_worker_resources(
+                self.map_worker_resources, self.reduce_worker_resources
+            )
+        else:
+            self._min_tasks_per_worker = 1
+
+        # Sizing checks
+        resources_ram = humanfriendly.parse_size(self.resources.ram, binary=True)
+        resources_disk = humanfriendly.parse_size(self.resources.disk, binary=True)
+        for task_resources, name in [
+            (self.map_worker_resources, "map_worker"),
+            (self.reduce_worker_resources, "reduce_worker"),
+        ]:
+            task_ram = humanfriendly.parse_size(task_resources.ram, binary=True)
+            task_disk = humanfriendly.parse_size(task_resources.disk, binary=True)
+            if self.resources.cpu < task_resources.cpu or resources_ram < task_ram or resources_disk < task_disk:
+                raise ValueError(
+                    f"Overall resources ({self.resources}) must be larger than or equal to "
+                    f"{name} resources ({task_resources}) on all dimensions (cpu, ram, disk)."
+                )
 
         if self.no_workers_timeout is None:
             self.no_workers_timeout = 6 * 60 * 60  # 6 hours
@@ -1809,6 +1905,10 @@ class ZephyrContext:
         if dry_run:
             return ZephyrExecutionResult(results=[], counters={})
 
+        if plan.num_shards <= 0:
+            logger.warning("No shards in plan, returning empty results.")
+            return ZephyrExecutionResult(results=[], counters={})
+
         # NOTE: pipeline ID incremented on clean completion only
         self._pipeline_id += 1
         last_exception: Exception | None = None
@@ -1827,17 +1927,26 @@ class ZephyrContext:
             try:
                 self._upload_shared_data(execution_id)
 
+                assert self.resources is not None
+
+                limit = self.max_workers
+                if limit is None and isinstance(self.client, LocalClient):
+                    limit = os.cpu_count() or 1
+
+                needed_workers = math.ceil(plan.num_shards / self._min_tasks_per_worker)
+                actual_workers = min((limit or MAX_WORKERS_PER_JOB), needed_workers)
+
                 config = _CoordinatorJobConfig(
                     plan=plan,
                     execution_id=execution_id,
                     chunk_storage_prefix=self.chunk_storage_prefix,
                     no_workers_timeout=self.no_workers_timeout,
-                    max_workers=self.max_workers,
+                    max_workers=actual_workers,
                     worker_resources=self.resources,
                     name=self.name,
                     pipeline_id=self._pipeline_id,
-                    map_workers_per_actor=self.map_workers_per_actor,
-                    reduce_workers_per_actor=self.reduce_workers_per_actor,
+                    map_worker_resources=self.map_worker_resources,
+                    reduce_worker_resources=self.reduce_worker_resources,
                     stage_runner_factory=self.stage_runner_factory,
                     heartbeat_timeout=self.heartbeat_timeout,
                     max_shard_failures=self.max_shard_failures,

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -88,7 +88,7 @@ MAX_SHARD_INFRA_FAILURES = 20
 # Typical status text for a 6-stage pipeline is ~300 chars.
 MAX_STATUS_TEXT_LENGTH = 1000
 
-MAX_WORKERS_PER_JOB = 2_048
+MAX_WORKERS_PER_JOB = 1_024
 
 
 class ShardFailureKind(enum.StrEnum):
@@ -1648,16 +1648,17 @@ def _try_read_coordinator_result(result_path: str) -> Any:
 
 
 def _tasks_per_worker(worker_resources: ResourceConfig, task_resources: ResourceConfig) -> int:
-    """Return how many concurrent copies of *task_resources* fit in *worker_resources*."""
+    """Return how many concurrent copies of *task_resources* fit in *worker_resources*.
+
+    Packing uses cpu and ram only. Zephyr does not track disk in runtime
+    admission (``ZephyrTaskResources`` is cpu+memory), so disk is ignored here
+    even though it still applies to Iris worker sizing.
+    """
     ratios = [worker_resources.cpu / task_resources.cpu]
     worker_ram = humanfriendly.parse_size(worker_resources.ram, binary=True)
     task_ram = humanfriendly.parse_size(task_resources.ram, binary=True)
     if task_ram > 0:
         ratios.append(worker_ram / task_ram)
-    worker_disk = humanfriendly.parse_size(worker_resources.disk, binary=True)
-    task_disk = humanfriendly.parse_size(task_resources.disk, binary=True)
-    if task_disk > 0:
-        ratios.append(worker_disk / task_disk)
     return max(1, math.floor(min(ratios)))
 
 
@@ -1700,7 +1701,8 @@ class ZephyrContext:
         client: The fray client to use. If None, auto-detects using current_client().
         max_workers: Upper bound on worker count. The actual count is
             min(max_workers, num_shards), computed at first execute(). If None,
-            defaults to os.cpu_count() for LocalClient, or 128 for distributed clients.
+            defaults to os.cpu_count() for LocalClient, or ``MAX_WORKERS_PER_JOB``
+            (1024) for distributed clients.
         resources: Resource config per worker.
         coordinator_resources: Resource config for the coordinator job. Defaults to 2 GB.
         chunk_storage_prefix: Storage prefix for intermediate chunks. If None, defaults

--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -88,9 +88,6 @@ MAX_SHARD_INFRA_FAILURES = 20
 # Typical status text for a 6-stage pipeline is ~300 chars.
 MAX_STATUS_TEXT_LENGTH = 1000
 
-# V5P machine specifications
-V5P_RESOURCES = ResourceConfig(cpu=32.0, ram="256g", disk="50g")
-
 MAX_WORKERS_PER_JOB = 2_048
 
 
@@ -1499,8 +1496,8 @@ class _CoordinatorJobConfig:
     # Cloudpickled and re-invoked per worker slot, so per-runner mutable
     # state is per-slot.
     stage_runner_factory: Callable[[], StageRunner]
-    map_worker_resources: ResourceConfig
-    reduce_worker_resources: ResourceConfig
+    map_task_resources: ResourceConfig
+    reduce_task_resources: ResourceConfig
     heartbeat_timeout: float = 120.0
     max_shard_failures: int = MAX_SHARD_FAILURES
     max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES
@@ -1532,8 +1529,8 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
 
     # Compute per-task resource costs.
     total = ZephyrTaskResources.from_resource_config(config.worker_resources)
-    map_cost = ZephyrTaskResources.from_resource_config(config.map_worker_resources)
-    reduce_cost = ZephyrTaskResources.from_resource_config(config.reduce_worker_resources)
+    map_cost = ZephyrTaskResources.from_resource_config(config.map_task_resources)
+    reduce_cost = ZephyrTaskResources.from_resource_config(config.reduce_task_resources)
 
     # Host coordinator actor in this process (no child job needed)
     coord_name = f"zephyr-{config.name}-p{config.pipeline_id}-coord"
@@ -1650,76 +1647,43 @@ def _try_read_coordinator_result(result_path: str) -> Any:
         return None
 
 
-def _compute_overall_worker_resources(
+def _tasks_per_worker(worker_resources: ResourceConfig, task_resources: ResourceConfig) -> int:
+    """Return how many concurrent copies of *task_resources* fit in *worker_resources*."""
+    ratios = [worker_resources.cpu / task_resources.cpu]
+    worker_ram = humanfriendly.parse_size(worker_resources.ram, binary=True)
+    task_ram = humanfriendly.parse_size(task_resources.ram, binary=True)
+    if task_ram > 0:
+        ratios.append(worker_ram / task_ram)
+    worker_disk = humanfriendly.parse_size(worker_resources.disk, binary=True)
+    task_disk = humanfriendly.parse_size(task_resources.disk, binary=True)
+    if task_disk > 0:
+        ratios.append(worker_disk / task_disk)
+    return max(1, math.floor(min(ratios)))
+
+
+def _compute_min_tasks_per_worker(
+    worker_resources: ResourceConfig,
     map_resources: ResourceConfig,
     reduce_resources: ResourceConfig,
-) -> tuple[ResourceConfig, int]:
-    """Compute overall worker resources based on map/reduce task resources and V5P size constraints.
+) -> int:
+    """Compute how many concurrent tasks fit on one worker given map/reduce task costs.
 
-    The algorithm aims to satisfy three main design goals:
-    1. Perfect Fit (No Waste): The computed worker capacity is a multiple of the task resource requirements
-       (both map and reduce tasks fit exactly with zero remainder on bottleneck resources).
-    2. Sizing Target: The overall worker size is targeted to be approximately 1/4 of the overall V5P
-       machine (32 CPU, 256 GB RAM, 50 GB Disk), ensuring a balanced resource footprint.
-    3. Multi-task Multiplexing: The long-lived worker is sized to accommodate the resource requirements
-       for both map stages and reduce stages concurrently.
+    Uses the tighter of the map and reduce packing densities so workers sized for
+    both stage types can keep enough tasks in flight for either.
     """
     for field_name in ["device", "preemptible", "regions", "zone", "replicas", "image", "device_alternatives"]:
         map_val = getattr(map_resources, field_name)
         reduce_val = getattr(reduce_resources, field_name)
         if map_val != reduce_val:
             raise ValueError(
-                f"Field '{field_name}' cannot differ between map_worker_resources ({map_val}) "
-                f"and reduce_worker_resources ({reduce_val}). Set the same value on both."
+                f"Field '{field_name}' cannot differ between map_task_resources ({map_val}) "
+                f"and reduce_task_resources ({reduce_val}). Set the same value on both."
             )
 
-    # 1. Parse target sizes (1/4 of V5P machine)
-    target_cpu = V5P_RESOURCES.cpu / 4.0
-    target_ram = humanfriendly.parse_size(V5P_RESOURCES.ram, binary=True) // 4
-    target_disk = humanfriendly.parse_size(V5P_RESOURCES.disk, binary=True) // 4
-
-    # 2. Parse map / reduce task resources
-    map_cpu = map_resources.cpu
-    map_ram = humanfriendly.parse_size(map_resources.ram, binary=True)
-    map_disk = humanfriendly.parse_size(map_resources.disk, binary=True)
-
-    reduce_cpu = reduce_resources.cpu
-    reduce_ram = humanfriendly.parse_size(reduce_resources.ram, binary=True)
-    reduce_disk = humanfriendly.parse_size(reduce_resources.disk, binary=True)
-
-    # 3. Compute number of concurrent tasks per worker (N)
-    map_ratios = [target_cpu / map_cpu]
-    if map_ram > 0:
-        map_ratios.append(target_ram / map_ram)
-    if map_disk > 0:
-        map_ratios.append(target_disk / map_disk)
-    n_map = max(1, round(min(map_ratios)))
-
-    reduce_ratios = [target_cpu / reduce_cpu]
-    if reduce_ram > 0:
-        reduce_ratios.append(target_ram / reduce_ram)
-    if reduce_disk > 0:
-        reduce_ratios.append(target_disk / reduce_disk)
-    n_reduce = max(1, round(min(reduce_ratios)))
-
-    # 4. Compute overall worker resources
-    worker_cpu = max(n_map * map_cpu, n_reduce * reduce_cpu)
-    worker_ram_bytes = max(n_map * map_ram, n_reduce * reduce_ram)
-    worker_disk_bytes = max(n_map * map_disk, n_reduce * reduce_disk)
-
-    worker_resources = ResourceConfig(
-        cpu=worker_cpu,
-        ram=humanfriendly.format_size(worker_ram_bytes, binary=True),
-        disk=humanfriendly.format_size(worker_disk_bytes, binary=True),
-        device=map_resources.device,
-        preemptible=map_resources.preemptible,
-        regions=map_resources.regions,
-        zone=map_resources.zone,
-        replicas=map_resources.replicas,
-        image=map_resources.image,
-        device_alternatives=map_resources.device_alternatives,
+    return min(
+        _tasks_per_worker(worker_resources, map_resources),
+        _tasks_per_worker(worker_resources, reduce_resources),
     )
-    return worker_resources, min(n_map, n_reduce)
 
 
 @dataclass
@@ -1751,8 +1715,10 @@ class ZephyrContext:
         stage_runner_factory: Callable ``() -> StageRunner``.
             Defaults to ``InlineRunner`` for ``LocalClient`` and ``SubprocessRunner``
             for distributed clients.
-        map_worker_resources: ResourceConfig specifying resources required by a single map task.
-        reduce_worker_resources: ResourceConfig specifying resources required by a single reduce task.
+        map_task_resources: ResourceConfig specifying resources required by a single map task.
+            Defaults to ``resources``. Requires ``resources`` to be set explicitly.
+        reduce_task_resources: ResourceConfig specifying resources required by a single reduce task.
+            Defaults to ``map_task_resources``.
         heartbeat_timeout: Seconds without a worker heartbeat before the coordinator
             marks the worker FAILED and requeues its in-flight shard. Defaults to 120.
             Long-running stages (e.g. vLLM inference with cold XLA compile) may need
@@ -1777,8 +1743,8 @@ class ZephyrContext:
     # NOTE: 100 is fairly aggressive but it fits the preemptible env better
     max_execution_retries: int = 100
     stage_runner_factory: Callable[[], StageRunner] | None = None
-    map_worker_resources: ResourceConfig | None = None
-    reduce_worker_resources: ResourceConfig | None = None
+    map_task_resources: ResourceConfig | None = None
+    reduce_task_resources: ResourceConfig | None = None
     heartbeat_timeout: float = 120.0
     max_shard_failures: int = MAX_SHARD_FAILURES
     max_shard_infra_failures: int = MAX_SHARD_INFRA_FAILURES
@@ -1789,7 +1755,7 @@ class ZephyrContext:
     _coordinator_job: JobHandle | None = field(default=None, repr=False)
     # NOTE: execute calls increment this at the very beginning
     _pipeline_id: int = field(default=-1, repr=False)
-    _min_tasks_per_worker: int = field(init=False, default=1, repr=False)
+    min_tasks_per_worker: int = field(init=False, default=1, repr=False)
 
     def __post_init__(self):
         if self.client is None:
@@ -1804,29 +1770,24 @@ class ZephyrContext:
             else:
                 logger.info("Ignoring ZEPHYR_MAX_WORKERS environment variable in favor of max_workers variable.")
 
-        if self.map_worker_resources is None and self.reduce_worker_resources is not None:
-            raise ValueError("Setting reduce_worker_resources without setting map_worker_resources is an error.")
+        if self.map_task_resources is not None and self.resources is None:
+            raise ValueError("Setting map_task_resources without setting resources is an error.")
+        if self.reduce_task_resources is not None and self.map_task_resources is None:
+            raise ValueError("Setting reduce_task_resources without setting map_task_resources is an error.")
 
-        if self.resources is None and self.map_worker_resources is None:
-            self.resources = ResourceConfig(cpu=1, ram="1g")
-        if self.map_worker_resources is None:
-            self.map_worker_resources = self.resources
-        if self.reduce_worker_resources is None:
-            self.reduce_worker_resources = self.map_worker_resources
         if self.resources is None:
-            # resources was not set and map_worker_resources was set, so compute the overall worker resources
-            self.resources, self._min_tasks_per_worker = _compute_overall_worker_resources(
-                self.map_worker_resources, self.reduce_worker_resources
-            )
-        else:
-            self._min_tasks_per_worker = 1
+            self.resources = ResourceConfig(cpu=1, ram="1g")
+        if self.map_task_resources is None:
+            self.map_task_resources = self.resources
+        if self.reduce_task_resources is None:
+            self.reduce_task_resources = self.map_task_resources
 
         # Sizing checks
         resources_ram = humanfriendly.parse_size(self.resources.ram, binary=True)
         resources_disk = humanfriendly.parse_size(self.resources.disk, binary=True)
         for task_resources, name in [
-            (self.map_worker_resources, "map_worker"),
-            (self.reduce_worker_resources, "reduce_worker"),
+            (self.map_task_resources, "map_task"),
+            (self.reduce_task_resources, "reduce_task"),
         ]:
             task_ram = humanfriendly.parse_size(task_resources.ram, binary=True)
             task_disk = humanfriendly.parse_size(task_resources.disk, binary=True)
@@ -1835,6 +1796,10 @@ class ZephyrContext:
                     f"Overall resources ({self.resources}) must be larger than or equal to "
                     f"{name} resources ({task_resources}) on all dimensions (cpu, ram, disk)."
                 )
+
+        self.min_tasks_per_worker = _compute_min_tasks_per_worker(
+            self.resources, self.map_task_resources, self.reduce_task_resources
+        )
 
         if self.no_workers_timeout is None:
             self.no_workers_timeout = 6 * 60 * 60  # 6 hours
@@ -1933,7 +1898,7 @@ class ZephyrContext:
                 if limit is None and isinstance(self.client, LocalClient):
                     limit = os.cpu_count() or 1
 
-                needed_workers = math.ceil(plan.num_shards / self._min_tasks_per_worker)
+                needed_workers = math.ceil(plan.num_shards / self.min_tasks_per_worker)
                 actual_workers = min((limit or MAX_WORKERS_PER_JOB), needed_workers)
 
                 config = _CoordinatorJobConfig(
@@ -1945,8 +1910,8 @@ class ZephyrContext:
                     worker_resources=self.resources,
                     name=self.name,
                     pipeline_id=self._pipeline_id,
-                    map_worker_resources=self.map_worker_resources,
-                    reduce_worker_resources=self.reduce_worker_resources,
+                    map_task_resources=self.map_task_resources,
+                    reduce_task_resources=self.reduce_task_resources,
                     stage_runner_factory=self.stage_runner_factory,
                     heartbeat_timeout=self.heartbeat_timeout,
                     max_shard_failures=self.max_shard_failures,

--- a/lib/zephyr/src/zephyr/stage_io.py
+++ b/lib/zephyr/src/zephyr/stage_io.py
@@ -18,7 +18,7 @@ from typing import Protocol
 
 import cloudpickle
 import humanfriendly
-from fray import ResourceConfig
+from fray.types import ResourceConfig
 from rigging.filesystem import open_url, unique_temp_path
 
 from zephyr.plan import PhysicalOp, Scatter, Shard

--- a/lib/zephyr/src/zephyr/stage_io.py
+++ b/lib/zephyr/src/zephyr/stage_io.py
@@ -18,6 +18,7 @@ from typing import Protocol
 
 import cloudpickle
 import humanfriendly
+from fray import ResourceConfig
 from rigging.filesystem import open_url, unique_temp_path
 
 from zephyr.plan import PhysicalOp, Scatter, Shard
@@ -268,6 +269,13 @@ class ZephyrTaskResources:
 
     def can_fit(self, cost: "ZephyrTaskResources") -> bool:
         return self.cpu >= cost.cpu and (cost.memory == 0 or self.memory >= cost.memory)
+
+    @classmethod
+    def from_resource_config(cls, config: ResourceConfig) -> "ZephyrTaskResources":
+        return cls(
+            cpu=config.cpu,
+            memory=int(humanfriendly.parse_size(config.ram, binary=True)),
+        )
 
 
 @dataclass

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -1384,3 +1384,78 @@ def test_simple_map_integration(integration_ctx):
 def test_multi_stage_integration(integration_ctx):
     ds = Dataset.from_list([1, 2, 3, 4, 5]).map(lambda x: x * 2).filter(lambda x: x > 5)
     assert sorted(integration_ctx.execute(ds).results) == [6, 8, 10]
+
+
+def test_zephyr_context_only_resources_set_propagates_resources():
+    # 1. Propagate resources when only resources is set
+    ctx = ZephyrContext(resources=ResourceConfig(cpu=2, ram="4g"))
+    assert ctx.map_worker_resources == ResourceConfig(cpu=2, ram="4g")
+    assert ctx.reduce_worker_resources == ResourceConfig(cpu=2, ram="4g")
+
+
+def test_zephyr_context_map_worker_resources_smaller_than_resources_propagates_correctly():
+    # 2. Both resources and map_worker_resources can be set, but raises ValueError if resources is smaller
+    ctx = ZephyrContext(resources=ResourceConfig(cpu=2, ram="4g"), map_worker_resources=ResourceConfig(cpu=1, ram="2g"))
+    assert ctx.map_worker_resources == ResourceConfig(cpu=1, ram="2g")
+    assert ctx.reduce_worker_resources == ResourceConfig(cpu=1, ram="2g")
+
+
+def test_zephyr_context_map_worker_resources_larger_than_resources_raises_value_error():
+    with pytest.raises(ValueError, match="must be larger than or equal to"):
+        ZephyrContext(resources=ResourceConfig(cpu=2, ram="4g"), map_worker_resources=ResourceConfig(cpu=3, ram="2g"))
+
+
+def test_zephyr_context_only_reduce_worker_resources_set_raises_value_error():
+    # 3. Only reduce_worker_resources raises ValueError
+    with pytest.raises(ValueError, match="Setting reduce_worker_resources"):
+        ZephyrContext(reduce_worker_resources=ResourceConfig(cpu=1))
+
+
+def test_zephyr_context_only_map_worker_resources_set_propagates_to_reduce_resources():
+    # 4. Only map_worker_resources propagates to reduce_worker_resources
+    ctx = ZephyrContext(map_worker_resources=ResourceConfig(cpu=3, ram="6g"))
+    assert ctx.reduce_worker_resources == ResourceConfig(cpu=3, ram="6g")
+
+
+def test_zephyr_context_no_resources_set_propagates_default_resources():
+    # 5. Default resources propagate when none is set
+    ctx = ZephyrContext()
+    assert ctx.resources == ResourceConfig(cpu=1, ram="1g")
+    assert ctx.map_worker_resources == ResourceConfig(cpu=1, ram="1g")
+    assert ctx.reduce_worker_resources == ResourceConfig(cpu=1, ram="1g")
+
+
+def test_zephyr_context_custom_map_and_reduce_resources_executes_successfully(local_client):
+    ctx = ZephyrContext(
+        client=local_client,
+        max_workers=2,
+        map_worker_resources=ResourceConfig(cpu=1, ram="2g", disk="2g"),
+        reduce_worker_resources=ResourceConfig(cpu=2, ram="4g", disk="4g"),
+        name="test-resources-exec",
+    )
+    ds = Dataset.from_list([1, 2, 3]).map(lambda x: x * 2)
+    result = ctx.execute(ds)
+    assert sorted(result.results) == [2, 4, 6]
+
+
+def test_zephyr_context_mismatching_optional_parameters_raises_value_error():
+    # Setting mismatching optional parameters between map and reduce should raise ValueError
+    with pytest.raises(ValueError, match=r"Field 'preemptible' cannot differ"):
+        ZephyrContext(
+            map_worker_resources=ResourceConfig(cpu=1, preemptible=False),
+            reduce_worker_resources=ResourceConfig(cpu=2, preemptible=True),
+        )
+
+    with pytest.raises(ValueError, match=r"Field 'image' cannot differ"):
+        ZephyrContext(
+            map_worker_resources=ResourceConfig(cpu=1, image="custom-image"),
+            reduce_worker_resources=ResourceConfig(cpu=2, image=None),
+        )
+
+    # If optional parameters match, it should succeed and propagate them
+    ctx = ZephyrContext(
+        map_worker_resources=ResourceConfig(cpu=1, preemptible=False, image="custom-image"),
+        reduce_worker_resources=ResourceConfig(cpu=2, preemptible=False, image="custom-image"),
+    )
+    assert ctx.resources.preemptible is False
+    assert ctx.resources.image == "custom-image"

--- a/lib/zephyr/tests/test_execution.py
+++ b/lib/zephyr/tests/test_execution.py
@@ -1389,48 +1389,46 @@ def test_multi_stage_integration(integration_ctx):
 def test_zephyr_context_only_resources_set_propagates_resources():
     # 1. Propagate resources when only resources is set
     ctx = ZephyrContext(resources=ResourceConfig(cpu=2, ram="4g"))
-    assert ctx.map_worker_resources == ResourceConfig(cpu=2, ram="4g")
-    assert ctx.reduce_worker_resources == ResourceConfig(cpu=2, ram="4g")
+    assert ctx.map_task_resources == ResourceConfig(cpu=2, ram="4g")
+    assert ctx.reduce_task_resources == ResourceConfig(cpu=2, ram="4g")
 
 
-def test_zephyr_context_map_worker_resources_smaller_than_resources_propagates_correctly():
-    # 2. Both resources and map_worker_resources can be set, but raises ValueError if resources is smaller
-    ctx = ZephyrContext(resources=ResourceConfig(cpu=2, ram="4g"), map_worker_resources=ResourceConfig(cpu=1, ram="2g"))
-    assert ctx.map_worker_resources == ResourceConfig(cpu=1, ram="2g")
-    assert ctx.reduce_worker_resources == ResourceConfig(cpu=1, ram="2g")
+def test_zephyr_context_map_task_resources_smaller_than_resources_propagates_correctly():
+    # 2. Both resources and map_task_resources can be set, but raises ValueError if resources is smaller
+    ctx = ZephyrContext(resources=ResourceConfig(cpu=2, ram="4g"), map_task_resources=ResourceConfig(cpu=1, ram="2g"))
+    assert ctx.map_task_resources == ResourceConfig(cpu=1, ram="2g")
+    assert ctx.reduce_task_resources == ResourceConfig(cpu=1, ram="2g")
 
 
-def test_zephyr_context_map_worker_resources_larger_than_resources_raises_value_error():
+def test_zephyr_context_map_task_resources_larger_than_resources_raises_value_error():
     with pytest.raises(ValueError, match="must be larger than or equal to"):
-        ZephyrContext(resources=ResourceConfig(cpu=2, ram="4g"), map_worker_resources=ResourceConfig(cpu=3, ram="2g"))
+        ZephyrContext(resources=ResourceConfig(cpu=2, ram="4g"), map_task_resources=ResourceConfig(cpu=3, ram="2g"))
 
 
-def test_zephyr_context_only_reduce_worker_resources_set_raises_value_error():
-    # 3. Only reduce_worker_resources raises ValueError
-    with pytest.raises(ValueError, match="Setting reduce_worker_resources"):
-        ZephyrContext(reduce_worker_resources=ResourceConfig(cpu=1))
+def test_zephyr_context_only_reduce_task_resources_set_raises_value_error():
+    # 3. Only reduce_task_resources raises ValueError
+    with pytest.raises(ValueError, match="Setting reduce_task_resources"):
+        ZephyrContext(resources=ResourceConfig(cpu=2, ram="4g"), reduce_task_resources=ResourceConfig(cpu=1))
 
 
-def test_zephyr_context_only_map_worker_resources_set_propagates_to_reduce_resources():
-    # 4. Only map_worker_resources propagates to reduce_worker_resources
-    ctx = ZephyrContext(map_worker_resources=ResourceConfig(cpu=3, ram="6g"))
-    assert ctx.reduce_worker_resources == ResourceConfig(cpu=3, ram="6g")
+def test_zephyr_context_map_task_resources_without_resources_raises_value_error():
+    with pytest.raises(ValueError, match="Setting map_task_resources without setting resources"):
+        ZephyrContext(map_task_resources=ResourceConfig(cpu=3, ram="6g"))
 
 
-def test_zephyr_context_no_resources_set_propagates_default_resources():
-    # 5. Default resources propagate when none is set
-    ctx = ZephyrContext()
-    assert ctx.resources == ResourceConfig(cpu=1, ram="1g")
-    assert ctx.map_worker_resources == ResourceConfig(cpu=1, ram="1g")
-    assert ctx.reduce_worker_resources == ResourceConfig(cpu=1, ram="1g")
+def test_zephyr_context_map_task_resources_propagates_to_reduce_resources():
+    # 4. map_task_resources propagates to reduce_task_resources when reduce is unset
+    ctx = ZephyrContext(resources=ResourceConfig(cpu=6, ram="12g"), map_task_resources=ResourceConfig(cpu=3, ram="6g"))
+    assert ctx.reduce_task_resources == ResourceConfig(cpu=3, ram="6g")
 
 
 def test_zephyr_context_custom_map_and_reduce_resources_executes_successfully(local_client):
     ctx = ZephyrContext(
         client=local_client,
         max_workers=2,
-        map_worker_resources=ResourceConfig(cpu=1, ram="2g", disk="2g"),
-        reduce_worker_resources=ResourceConfig(cpu=2, ram="4g", disk="4g"),
+        resources=ResourceConfig(cpu=4, ram="8g", disk="8g"),
+        map_task_resources=ResourceConfig(cpu=1, ram="2g", disk="2g"),
+        reduce_task_resources=ResourceConfig(cpu=2, ram="4g", disk="4g"),
         name="test-resources-exec",
     )
     ds = Dataset.from_list([1, 2, 3]).map(lambda x: x * 2)
@@ -1438,24 +1436,35 @@ def test_zephyr_context_custom_map_and_reduce_resources_executes_successfully(lo
     assert sorted(result.results) == [2, 4, 6]
 
 
+def test_zephyr_context_min_tasks_per_worker_from_packing_computes_expected_tighter_factor():
+    ctx = ZephyrContext(
+        resources=ResourceConfig(cpu=8, ram="16g", disk="16g"),
+        map_task_resources=ResourceConfig(cpu=2, ram="4g", disk="4g"),
+        reduce_task_resources=ResourceConfig(cpu=4, ram="8g", disk="8g"),
+    )
+    # map fits 4x, reduce fits 2x → min is 2
+    assert ctx.min_tasks_per_worker == 2
+
+
 def test_zephyr_context_mismatching_optional_parameters_raises_value_error():
     # Setting mismatching optional parameters between map and reduce should raise ValueError
     with pytest.raises(ValueError, match=r"Field 'preemptible' cannot differ"):
         ZephyrContext(
-            map_worker_resources=ResourceConfig(cpu=1, preemptible=False),
-            reduce_worker_resources=ResourceConfig(cpu=2, preemptible=True),
+            resources=ResourceConfig(cpu=4, ram="8g"),
+            map_task_resources=ResourceConfig(cpu=1, preemptible=False),
+            reduce_task_resources=ResourceConfig(cpu=2, preemptible=True),
         )
 
     with pytest.raises(ValueError, match=r"Field 'image' cannot differ"):
         ZephyrContext(
-            map_worker_resources=ResourceConfig(cpu=1, image="custom-image"),
-            reduce_worker_resources=ResourceConfig(cpu=2, image=None),
+            resources=ResourceConfig(cpu=4, ram="8g"),
+            map_task_resources=ResourceConfig(cpu=1, image="custom-image"),
+            reduce_task_resources=ResourceConfig(cpu=2, image=None),
         )
 
-    # If optional parameters match, it should succeed and propagate them
-    ctx = ZephyrContext(
-        map_worker_resources=ResourceConfig(cpu=1, preemptible=False, image="custom-image"),
-        reduce_worker_resources=ResourceConfig(cpu=2, preemptible=False, image="custom-image"),
+    # If optional parameters match, it should succeed
+    ZephyrContext(
+        resources=ResourceConfig(cpu=4, ram="8g"),
+        map_task_resources=ResourceConfig(cpu=1, preemptible=False, image="custom-image"),
+        reduce_task_resources=ResourceConfig(cpu=2, preemptible=False, image="custom-image"),
     )
-    assert ctx.resources.preemptible is False
-    assert ctx.resources.image == "custom-image"

--- a/tests/integration_test.py
+++ b/tests/integration_test.py
@@ -112,8 +112,6 @@ def create_steps(prefix: str, synth_data: str, tokenizer: str) -> list[StepSpec]
         fn=lambda output_path: dedup_exact_paragraph(
             input_paths=[read_artifact(normalize_hq_spec.output_path, NormalizedData).main_output_dir],
             output_path=output_path,
-            max_parallelism=4,
-            worker_resources=ResourceConfig(cpu=1, ram="1g"),
         ),
     )
 

--- a/tests/processing/classification/deduplication/test_exact.py
+++ b/tests/processing/classification/deduplication/test_exact.py
@@ -12,7 +12,6 @@ def test_exact_paragraph_deduplication(fox_corpus):
     result = dedup_exact_paragraph(
         input_paths=fox_corpus["test_dir"],
         output_path=fox_corpus["output_dir"],
-        max_parallelism=4,
     )
     assert result["success"]
     assert result["mode"] == DedupMode.EXACT_PARAGRAPH

--- a/tests/processing/classification/test_consolidate.py
+++ b/tests/processing/classification/test_consolidate.py
@@ -29,7 +29,6 @@ def test_dedupe_consolidate_integration(fox_corpus):
     result = dedup_exact_paragraph(
         input_paths=fox_corpus["test_dir"],
         output_path=dedupe_output_dir,
-        max_parallelism=4,
     )
     assert result["success"]
     assert result["mode"] == DedupMode.EXACT_PARAGRAPH

--- a/uv.lock
+++ b/uv.lock
@@ -4889,6 +4889,7 @@ version = "0.2.0"
 source = { editable = "lib/fray" }
 dependencies = [
     { name = "cloudpickle" },
+    { name = "humanfriendly" },
     { name = "marin-iris" },
     { name = "marin-rigging" },
 ]
@@ -4916,6 +4917,7 @@ test = [
 [package.metadata]
 requires-dist = [
     { name = "cloudpickle", specifier = ">=3.1.2" },
+    { name = "humanfriendly", specifier = ">=10.0" },
     { name = "marin-iris", editable = "lib/iris" },
     { name = "marin-rigging", editable = "lib/rigging" },
 ]


### PR DESCRIPTION
Add map_worker_resources and reduce_worker_resources to ZephyrContext to configure map and reduce task resources independently. Automatically compute overall worker resource limits and multiplexing factors based on these configs. Update tokenization and deduplication steps and their callsites across marin-core and experiments to use the new parameters.

## Overall Idea
 - A user provides map_resources and reduce_resources (optional: defaults to map_resources) to tell Zephyr what resources the job needs
 - Zephyr computes the worker size that is approximately the thing that best fits those resources and is approximately 1/4 of a V5P (this is an rather arbitrary heuristic, but simple)
 - max_workers is computed from the number of shards in the plan, the resource requests and the worker size (bounded by a max of 2048)

### Backwards compatibility 
- `resources` stays around to allow for overriding the default computation. This, therefore, does _not_ change the logic for existing jobs around resources
- This changes the maximum for `max_workers` from 128 to the computed value. Seems okay to me, but calling out this change.