### PR TITLE
provenance: stamp launch identity into the job env

### DIFF
--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -25,6 +25,7 @@ from typing import Any, NewType
 
 import cloudpickle
 import humanfriendly
+from rigging.provenance import LAUNCH_PROVENANCE_ENV, launch_provenance
 from rigging.timing import Timestamp
 
 from iris.cluster.setup_scripts import cuda_toolchain_setup_script, default_setup_script, setup_is_quiet, wants_gpu_extra
@@ -692,6 +693,9 @@ class EnvironmentSpec:
     - TOKENIZERS_PARALLELISM: "false" (avoids tokenizer deadlocks)
     - HF_TOKEN: from os.environ (if set)
     - WANDB_API_KEY: from os.environ (if set)
+    - MARIN_PROVENANCE: the launch's ``rigging.provenance.Provenance`` as JSON, captured
+      at submission (or forwarded from this process's own env when re-submitting inside
+      a task), so tasks stamp artifacts with the submitter's git identity
 
     Setup:
     - ``setup_scripts=None`` builds the default uv-sync script. ``sync_packages``
@@ -726,6 +730,10 @@ class EnvironmentSpec:
             "TOKENIZERS_PARALLELISM": "false",
             "HF_TOKEN": os.getenv("HF_TOKEN"),
             "WANDB_API_KEY": os.getenv("WANDB_API_KEY"),
+            # Launch provenance: a task running from a git-less bundle inherits the
+            # submitter's identity via Provenance.capture(); transitive, since a task
+            # re-submitting captures this same env value.
+            LAUNCH_PROVENANCE_ENV: launch_provenance().to_json(),
         }
 
         merged_env_vars = {k: v for k, v in {**default_env_vars, **(self.env_vars or {})}.items() if v is not None}

--- a/lib/iris/tests/cluster/test_types.py
+++ b/lib/iris/tests/cluster/test_types.py
@@ -20,6 +20,7 @@ from iris.cluster.constraints import (
 from iris.cluster.types import (
     LOCAL_CLUSTER,
     Entrypoint,
+    EnvironmentSpec,
     JobName,
     TaskAttempt,
     adjust_tpu_replicas,
@@ -28,10 +29,41 @@ from iris.cluster.types import (
     tpu_device,
 )
 from iris.rpc import job_pb2
+from rigging.provenance import LAUNCH_PROVENANCE_ENV, Provenance, _capture_once
 
 
 def _add(a, b):
     return a + b
+
+
+@pytest.fixture
+def fresh_launch_provenance():
+    """Reset the per-process capture cache around a test that manipulates MARIN_PROVENANCE."""
+    _capture_once.cache_clear()
+    yield
+    _capture_once.cache_clear()
+
+
+def test_environment_to_proto_stamps_launch_provenance(monkeypatch, fresh_launch_provenance):
+    """Every submission's env carries the launch provenance so a git-less task can stamp
+    records with the submitter's identity. Re-submitting from inside a task forwards the
+    inherited value verbatim; an explicit caller value wins over the default."""
+    submitted = Provenance(tree_hash="feed", base_commit="beef", dirty=False, branch="rav/pipeline", built_by="rav")
+    monkeypatch.setenv(LAUNCH_PROVENANCE_ENV, submitted.to_json())
+
+    stamped = EnvironmentSpec().to_proto().env_vars[LAUNCH_PROVENANCE_ENV]
+    assert Provenance.from_json(stamped) == submitted
+
+    explicit = EnvironmentSpec(env_vars={LAUNCH_PROVENANCE_ENV: "caller-value"}).to_proto()
+    assert explicit.env_vars[LAUNCH_PROVENANCE_ENV] == "caller-value"
+
+
+def test_environment_to_proto_captures_local_checkout(monkeypatch, fresh_launch_provenance):
+    """A local submission (no env var) stamps provenance captured from the checkout."""
+    monkeypatch.delenv(LAUNCH_PROVENANCE_ENV, raising=False)
+
+    stamped = Provenance.from_json(EnvironmentSpec().to_proto().env_vars[LAUNCH_PROVENANCE_ENV])
+    assert stamped.created_at  # launch context always captured; git fields best-effort
 
 
 def test_entrypoint_from_callable_resolve_roundtrip():

--- a/lib/marin/src/marin/execution/artifact.py
+++ b/lib/marin/src/marin/execution/artifact.py
@@ -23,13 +23,12 @@ their producers (``LevanterCheckpoint`` in ``marin.training.training``, ``Tokeni
 import functools
 import json
 import logging
-import threading
 from dataclasses import asdict, dataclass, is_dataclass
 from typing import Self, TypeVar, cast
 
 from pydantic import BaseModel, ConfigDict, Field
 from rigging.filesystem import marin_prefix, open_url, prefix_join, url_to_fs
-from rigging.provenance import Provenance
+from rigging.provenance import Provenance, launch_provenance
 
 from marin.execution.fingerprint import describe_drift
 from marin.execution.step_spec import StepSpec, _is_relative_path
@@ -297,27 +296,6 @@ def write_artifact(value: object, output_path: str) -> None:
     write_record(ArtifactRecord(output_path=output_path, result=_payload_json(value)))
 
 
-@functools.cache
-def _capture_provenance_once() -> Provenance:
-    return Provenance.capture()
-
-
-_provenance_lock = threading.Lock()
-
-
-def _best_effort_provenance() -> Provenance:
-    """The run's provenance, captured once per process.
-
-    Provenance is constant within a run, so capture it once: the runner writes records from many
-    worker threads, and calling ``capture()`` per step would both repeat the work and race on the
-    repo's ``index.lock`` (``git stash create``) when the driver runs from a real checkout. The
-    lock serializes the first, cache-filling call across those threads. ``capture()`` itself never
-    raises -- git fields degrade to empty outside a checkout or without a ``git`` binary.
-    """
-    with _provenance_lock:
-        return _capture_provenance_once()
-
-
 @dataclass(frozen=True)
 class StepRecordIdentity:
     """Identity + lineage of a ``StepRunner`` step, as plain data (no callable) so a remote
@@ -352,7 +330,7 @@ def write_step_record(identity: StepRecordIdentity, *, output_path: str, result:
             config=identity.config,
             result=_payload_json(result) if result is not None else None,
             fingerprint_payload=identity.fingerprint_payload,
-            provenance=_best_effort_provenance(),
+            provenance=launch_provenance(),
         )
     )
 

--- a/lib/rigging/src/rigging/provenance.py
+++ b/lib/rigging/src/rigging/provenance.py
@@ -20,6 +20,7 @@ import dataclasses
 import functools
 import getpass
 import json
+import logging
 import os
 import re
 import subprocess
@@ -28,6 +29,8 @@ import threading
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+
+logger = logging.getLogger(__name__)
 
 LAUNCH_PROVENANCE_ENV = "MARIN_PROVENANCE"
 """Env var carrying the launch's :class:`Provenance` as JSON.
@@ -102,7 +105,7 @@ class Provenance:
             try:
                 return cls.from_json(raw)
             except (json.JSONDecodeError, KeyError, TypeError):
-                pass
+                logger.warning("Ignoring malformed %s value: %r", LAUNCH_PROVENANCE_ENV, raw)
 
         cwd = str(repo_dir) if repo_dir is not None else None
 
@@ -165,17 +168,14 @@ def _capture_once() -> Provenance:
     return Provenance.capture()
 
 
+# functools.cache does not serialize concurrent first calls, and two concurrent
+# `git stash create` runs race on the repo's index.lock — the loser silently stamps
+# a dirty tree as clean HEAD. The lock makes the cache-filling capture exclusive.
 _capture_lock = threading.Lock()
 
 
 def launch_provenance() -> Provenance:
-    """The current launch's provenance, captured once per process.
-
-    Provenance is constant within a launch, so capture it once: callers stamping many
-    artifacts from worker threads would otherwise repeat the git shell-outs and race on the
-    repo's ``index.lock`` (``git stash create``). The lock serializes the first,
-    cache-filling call.
-    """
+    """The current launch's provenance, captured once per process (thread-safe)."""
     with _capture_lock:
         return _capture_once()
 

--- a/lib/rigging/src/rigging/provenance.py
+++ b/lib/rigging/src/rigging/provenance.py
@@ -17,14 +17,25 @@ outside a checkout — for stamping an artifact built by an arbitrary launch.
 """
 
 import dataclasses
+import functools
 import getpass
 import json
+import os
 import re
 import subprocess
 import sys
+import threading
 from dataclasses import dataclass
 from datetime import datetime
 from pathlib import Path
+
+LAUNCH_PROVENANCE_ENV = "MARIN_PROVENANCE"
+"""Env var carrying the launch's :class:`Provenance` as JSON.
+
+A submitting client stamps it into a job's environment (see iris
+``EnvironmentSpec.to_proto``), so a process running from a ``.git``-less bundle inherits the
+submission's provenance — :meth:`Provenance.capture` prefers it over shelling out to git.
+"""
 
 
 @dataclass(frozen=True)
@@ -79,10 +90,20 @@ class Provenance:
         """Best-effort provenance of the current launch: git context plus the origin
         remote, capture time, and argv.
 
-        Tolerant: every git field degrades to empty/``None`` outside a checkout or when
-        the ``git`` binary is absent, so it never raises. Use to stamp an artifact built
-        by an arbitrary run.
+        Prefers the provenance published in ``MARIN_PROVENANCE`` (stamped by the submitting
+        client) — returned verbatim, so a remote process reports the launch that produced it,
+        not itself. Otherwise tolerant git capture: every git field degrades to empty/``None``
+        outside a checkout or when the ``git`` binary is absent, so it never raises. Use to
+        stamp an artifact built by an arbitrary run.
         """
+        raw = os.environ.get(LAUNCH_PROVENANCE_ENV)
+        if raw:
+            # A malformed value must not break stamping; fall through to the git path.
+            try:
+                return cls.from_json(raw)
+            except (json.JSONDecodeError, KeyError, TypeError):
+                pass
+
         cwd = str(repo_dir) if repo_dir is not None else None
 
         def g(*args: str) -> str:
@@ -137,6 +158,26 @@ class Provenance:
         if self.dirty:
             return f"{self.tree_hash} (off of {self.base_commit}){suffix}"
         return f"{self.base_commit}{suffix}"
+
+
+@functools.cache
+def _capture_once() -> Provenance:
+    return Provenance.capture()
+
+
+_capture_lock = threading.Lock()
+
+
+def launch_provenance() -> Provenance:
+    """The current launch's provenance, captured once per process.
+
+    Provenance is constant within a launch, so capture it once: callers stamping many
+    artifacts from worker threads would otherwise repeat the git shell-outs and race on the
+    repo's ``index.lock`` (``git stash create``). The lock serializes the first,
+    cache-filling call.
+    """
+    with _capture_lock:
+        return _capture_once()
 
 
 def _git(args: list[str], cwd: str | None, check: bool = True) -> str:

--- a/lib/rigging/tests/test_provenance.py
+++ b/lib/rigging/tests/test_provenance.py
@@ -5,7 +5,7 @@ import subprocess
 from pathlib import Path
 
 import pytest
-from rigging.provenance import Provenance, username_segment
+from rigging.provenance import LAUNCH_PROVENANCE_ENV, Provenance, username_segment
 
 
 def test_str_clean_shows_commit_branch_user():
@@ -102,6 +102,32 @@ def test_capture_tolerates_missing_git_binary(tmp_path, monkeypatch):
     assert p.dirty is False
     assert p.command_line  # argv, captured regardless of git
     assert p.created_at  # timestamp, captured regardless of git
+
+
+def test_capture_prefers_launch_provenance_env(monkeypatch):
+    # A submitting client publishes its provenance in MARIN_PROVENANCE; a process running
+    # from a git-less bundle (or anywhere) inherits the launch's provenance verbatim,
+    # including built_by and argv, instead of describing itself.
+    submitted = Provenance(
+        tree_hash="feed",
+        base_commit="beef",
+        dirty=True,
+        branch="rav/pipeline",
+        built_by="rav",
+        git_remote="git@github.com:o/r.git",
+        created_at="2026-07-07T00:00:00",
+        command_line=("python", "experiments/foo.py"),
+    )
+    monkeypatch.setenv(LAUNCH_PROVENANCE_ENV, submitted.to_json())
+    assert Provenance.capture() == submitted
+
+
+def test_capture_ignores_malformed_launch_provenance_env(tmp_path, monkeypatch):
+    # A corrupt env value must not break record stamping; capture falls back to the git path.
+    monkeypatch.setenv(LAUNCH_PROVENANCE_ENV, "not json")
+    p = Provenance.capture(tmp_path)
+    assert p.tree_hash == ""
+    assert p.created_at
 
 
 def test_json_round_trip_preserves_run_fields():


### PR DESCRIPTION
* fixes https://github.com/marin-community/marin/issues/6902
* threads the submitter's git identity into every job so records written from a `.git`-less bundle carry real provenance instead of blank git fields and the worker's argv
* iris `EnvironmentSpec.to_proto` stamps `MARIN_PROVENANCE` — the launch `Provenance` as JSON — into the default job env vars at submission (same merge that injects `HF_TOKEN`/`WANDB_API_KEY`), so every submit path (CLI, fray, nested) gets it; an explicit caller value wins
* `Provenance.capture()` prefers `MARIN_PROVENANCE` when set, returned **verbatim** — a remote process reports the launch that produced it (submitter's `tree_hash`/`base_commit`/`branch`/`built_by`/argv), not itself [^1]
  * propagation is transitive: a task re-submitting captures its own env value and re-stamps child jobs (the client's parent-env inheritance covers it too)
* adds `launch_provenance()` to `rigging.provenance` — `capture()` cached once per process behind a lock [^2] — and replaces marin's private `_best_effort_provenance` with it, so iris and marin share one implementation
* local runs are unchanged: no env var → the existing tolerant git capture

[^1]: a malformed env value falls through to the git path rather than failing the record write.
[^2]: hoisted from `marin.execution.artifact` (#6901): `functools.cache` does not serialize concurrent first calls, and two concurrent `git stash create` invocations race on the repo's `index.lock` — the loser would silently stamp a dirty tree as clean `HEAD`. The first wave of a threaded StepRunner run is exactly this case.
