### PR TITLE
ci: select only pytest-collectable test modules

### DIFF
--- a/infra/ci/select_tests.py
+++ b/infra/ci/select_tests.py
@@ -179,12 +179,23 @@ def build_reverse_deps(repo_root: Path) -> dict[str, set[str]]:
     return dict(reverse)
 
 
+def is_test_module(filename: str) -> bool:
+    """Whether pytest would collect this file by name (default ``python_files`` convention).
+
+    Only such files may be passed to pytest explicitly: an explicit path is imported even
+    when it does not match the collection convention, so handing pytest a helper module
+    (workload script, stub, generator) crashes the run if the helper's imports are not
+    installed in the lane's environment.
+    """
+    return (filename.startswith("test_") or filename.endswith("_test.py")) and filename.endswith(".py")
+
+
 def all_test_files(scope: str, repo_root: Path) -> list[Path]:
-    """All .py files in a scope's test directory, excluding conftest.py."""
+    """All pytest-collectable test modules in a scope's test directory."""
     test_dir = repo_root / "tests" if scope == "marin" else repo_root / f"lib/{scope}/tests"
     if not test_dir.exists():
         return []
-    return sorted(p for p in test_dir.rglob("*.py") if p.name != "conftest.py")
+    return sorted(p for p in test_dir.rglob("*.py") if is_test_module(p.name))
 
 
 # ---------------------------------------------------------------------------
@@ -247,13 +258,13 @@ def classify(
                 break
 
             if filepath.startswith(test_prefix):
-                if p.name == "conftest.py":
-                    forced.add(scope)
-                elif p.suffix == ".py":
+                if is_test_module(p.name):
                     direct_tests[scope].append(filepath)
                 else:
-                    # Non-Python test asset (snapshot, fixture, data file): run the full
-                    # scope so the tests that own this file are not missed.
+                    # conftest.py, helper modules (stubs, workload scripts, generators), and
+                    # non-Python assets (snapshots, fixtures, data files) can all change test
+                    # behavior without being directly collectable: run the full scope so the
+                    # tests that own this file are not missed.
                     forced.add(scope)
                 break
 

--- a/tests/ci/test_select_tests.py
+++ b/tests/ci/test_select_tests.py
@@ -1,0 +1,40 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the import-driven test selector (infra/ci/select_tests.py)."""
+
+from infra.ci.select_tests import all_test_files, classify, is_test_module
+
+
+def test_all_test_files_selects_only_pytest_collectable_modules(tmp_path):
+    """Helper modules under tests/ (workload scripts, stubs, generators) must never be
+    handed to pytest explicitly -- an explicit path is imported even when it does not match
+    the collection convention, crashing the lane when the helper's deps are absent."""
+    test_dir = tmp_path / "lib" / "iris" / "tests"
+    test_dir.mkdir(parents=True)
+    (test_dir / "test_client.py").touch()
+    (test_dir / "actor_test.py").touch()
+    (test_dir / "gang_jax_smoke_workload.py").touch()
+    (test_dir / "conftest.py").touch()
+
+    names = [p.name for p in all_test_files("iris", tmp_path)]
+    assert names == ["actor_test.py", "test_client.py"]
+
+
+def test_changed_helper_module_forces_full_scope(tmp_path):
+    """A changed non-collectable .py under tests/ runs the full scope (its dependents),
+    not the file itself; a changed test module still runs directly."""
+    result = classify(
+        ["lib/iris/tests/e2e/gang_jax_smoke_workload.py", "lib/iris/tests/cluster/test_types.py"],
+        tmp_path,
+    )
+    assert result.direct_tests == {"iris": ["lib/iris/tests/cluster/test_types.py"]}
+    assert result.forced == {"iris"}
+
+
+def test_is_test_module_matches_pytest_defaults():
+    assert is_test_module("test_client.py")
+    assert is_test_module("gpt2_test.py")
+    assert not is_test_module("conftest.py")
+    assert not is_test_module("openai_stub.py")
+    assert not is_test_module("test_data.json")


### PR DESCRIPTION
* the unified-unit selector (#6833) swept every `.py` under a scope's `tests/` dir into the matrix, including helper modules (workload scripts, stubs, generators)
* pytest imports an explicitly passed path even when it does not match the collection naming convention, so a helper whose deps are absent from the lane env crashes the run — first hit on #7000: touching `iris/cluster/types.py` selected `lib/iris/tests/e2e/gang_jax_smoke_workload.py`, which imports `jax` (not installed in the iris unit lane)
* filter both selection paths (import-driven sweep and changed-file) to pytest's default `python_files` convention (`test_*.py` / `*_test.py`) via a shared `is_test_module`
  * a changed helper module under `tests/` now forces its scope's full suite (like conftest/assets) instead of being passed to pytest directly