### PR TITLE
datakit/web_explorer: compute source summary in-app at startup

### DIFF
--- a/experiments/datakit/web_explorer/dashboard/src/App.vue
+++ b/experiments/datakit/web_explorer/dashboard/src/App.vue
@@ -37,7 +37,27 @@ function toggleDark() {
 }
 
 const DUCKY_POLL_MS = 20_000
+const SUMMARY_POLL_MS = 3_000
 let duckyTimer: ReturnType<typeof setInterval> | undefined
+let summaryTimer: ReturnType<typeof setInterval> | undefined
+
+// The app counts per-source sizes in the background; poll until it's done,
+// folding each partial result into `ov` so the leaderboard fills in live.
+async function pollSourceSummary() {
+  if (!ov.value) return
+  try {
+    const resp = await fetch('api/source-summary')
+    const data = await resp.json()
+    if (!resp.ok) return
+    ov.value = { ...ov.value, source_summary: data.rows, source_summary_ready: data.ready }
+    if (data.ready) {
+      clearInterval(summaryTimer)
+      summaryTimer = undefined
+    }
+  } catch (e) {
+    /* transient; keep polling */
+  }
+}
 
 onMounted(async () => {
   try {
@@ -48,11 +68,17 @@ onMounted(async () => {
   } catch (e) {
     loadError.value = e instanceof Error ? e.message : String(e)
   }
+  if (ov.value && !ov.value.source_summary_ready) {
+    summaryTimer = setInterval(pollSourceSummary, SUMMARY_POLL_MS)
+  }
   void checkDuckyStatus()
   duckyTimer = setInterval(checkDuckyStatus, DUCKY_POLL_MS)
 })
 
-onUnmounted(() => clearInterval(duckyTimer))
+onUnmounted(() => {
+  clearInterval(duckyTimer)
+  clearInterval(summaryTimer)
+})
 </script>
 
 <template>

--- a/experiments/datakit/web_explorer/dashboard/src/components/SourcesTab.vue
+++ b/experiments/datakit/web_explorer/dashboard/src/components/SourcesTab.vue
@@ -57,6 +57,9 @@ function display(key: SortKey, value: unknown): string {
 
 <template>
   <div class="rounded-lg border border-surface-border bg-surface p-4">
+    <p v-if="!ov.source_summary_ready" class="mb-2 text-sm text-accent">
+      computing per-source sizes in the background… {{ rows.length }}/{{ ov.source_summary_total }}
+    </p>
     <template v-if="rows.length">
       <h3 class="mb-1 font-semibold">
         Per-source pipeline summary
@@ -93,6 +96,6 @@ function display(key: SortKey, value: unknown): string {
         </tbody>
       </table>
     </template>
-    <p v-else class="text-sm text-text-muted">no source summary baked in (set WEB_EXPLORER_SOURCE_SUMMARY)</p>
+    <p v-else-if="ov.source_summary_ready" class="text-sm text-text-muted">no source summary available</p>
   </div>
 </template>

--- a/experiments/datakit/web_explorer/dashboard/src/components/SourcesTab.vue
+++ b/experiments/datakit/web_explorer/dashboard/src/components/SourcesTab.vue
@@ -38,6 +38,10 @@ const rows = computed(() => {
   })
 })
 
+// While the background computation runs, count sources that already have their
+// full stats (quality present) so the banner shows real progress.
+const withStats = computed(() => (props.ov.source_summary || []).filter((r) => r.q_avg != null).length)
+
 // Same thresholds as the legacy dashboard: red for pathological values, orange for suspect ones.
 function warnClass(key: SortKey, value: unknown): string {
   if (value == null || typeof value !== 'number') return ''
@@ -58,7 +62,7 @@ function display(key: SortKey, value: unknown): string {
 <template>
   <div class="rounded-lg border border-surface-border bg-surface p-4">
     <p v-if="!ov.source_summary_ready" class="mb-2 text-sm text-accent">
-      computing per-source sizes in the background… {{ rows.length }}/{{ ov.source_summary_total }}
+      computing per-source stats in the background… {{ withStats }}/{{ ov.source_summary_total }}
     </p>
     <template v-if="rows.length">
       <h3 class="mb-1 font-semibold">

--- a/experiments/datakit/web_explorer/dashboard/src/types.ts
+++ b/experiments/datakit/web_explorer/dashboard/src/types.ts
@@ -40,6 +40,9 @@ export interface Overview {
   counters: Record<string, number>
   buckets: Bucket[]
   source_summary: SourceSummaryRow[]
+  /** false while the app is still counting per-source sizes in the background. */
+  source_summary_ready: boolean
+  source_summary_total: number
 }
 
 export interface HistBucket {

--- a/experiments/datakit/web_explorer/queries.py
+++ b/experiments/datakit/web_explorer/queries.py
@@ -34,6 +34,7 @@ DEFAULT_SEED = 7
 _POOL_BROAD = 4000  # unfiltered / broad-search sampling
 _POOL_FILTER = 500  # selective filters (a cluster, a quality-score range)
 _POOL_RARE = 200  # rare filters (contamination)
+_DEDUP_WINDOW = 500_000  # bounded window for per-source dedup cluster stats (avoids OOM on full attr)
 
 
 def _sql_str(value: str) -> str:
@@ -77,6 +78,54 @@ class WebExplorer:
             "cluster_assign": source in self.lineage.cluster_assign,
             "quality": source in self.lineage.quality,
         }
+
+    # -- per-source summary -------------------------------------------------
+    def source_summary_stats(self, source: str) -> dict:
+        """Per-source pipeline stats for the Sources leaderboard, one source at a time.
+
+        Returns the columns beyond ``docs_est``: quality score distribution
+        (avg / sd / fraction≈0), contamination rate, and dedup cluster stats +
+        drop rate. Quality and contamination are sampled (``_SAMPLE``); dedup
+        cluster stats use a bounded window (``_DEDUP_WINDOW``) like the dedup
+        drill-down. ``docs_est`` here is the *exact* doc count (parquet metadata),
+        which also anchors the drop-rate denominator.
+        """
+        stats: dict = {
+            "docs_est": self.ducky.run(f"SELECT count(*) FROM read_parquet('{self._normalize_glob(source)}')").scalar()
+        }
+        if source in self.lineage.quality:
+            stats.update(
+                self.ducky.run(
+                    f"SELECT round(avg(score), 4) AS q_avg, round(stddev(score), 4) AS q_sd, "
+                    f"round(avg((score < 0.01)::int), 4) AS q_zero "
+                    f"FROM (SELECT score FROM read_parquet('{self._flat_glob(self.lineage.quality, source)}') "
+                    f"LIMIT {self._SAMPLE})"
+                ).dicts()[0]
+            )
+        if source in self.lineage.decontam:
+            stats["decon_pct"] = self.ducky.run(
+                f"SELECT round(100.0 * avg(attributes.contaminated::int), 4) "
+                f"FROM (SELECT attributes FROM read_parquet('{self._flat_glob(self.lineage.decontam, source)}') "
+                f"LIMIT {self._SAMPLE})"
+            ).scalar()
+        if source in self.dedup_attr:
+            attr = self._dedup_glob(source)
+            n_dup = self.ducky.run(f"SELECT count(*) FROM read_parquet('{attr}')").scalar()
+            win = self.ducky.run(
+                f"WITH w AS (SELECT attributes.dup_cluster_id AS d, attributes.is_cluster_canonical AS c "
+                f"FROM read_parquet('{attr}') LIMIT {_DEDUP_WINDOW}), "
+                f"cl AS (SELECT d, count(*) AS sz FROM w GROUP BY d) "
+                f"SELECT (SELECT max(sz) FROM cl) AS dup_largest, (SELECT round(avg(sz), 2) FROM cl) AS dup_avg_size, "
+                f"(SELECT avg((NOT c)::int) FROM w) AS frac_nc"
+            ).dicts()[0]
+            stats["dup_largest"] = win["dup_largest"]
+            stats["dup_avg_size"] = win["dup_avg_size"]
+            # overall drop rate = (dropped non-canonical docs) / total docs, where
+            # dropped ≈ all dup docs x windowed non-canonical fraction.
+            docs = stats.get("docs_est")
+            if docs and n_dup and win["frac_nc"] is not None:
+                stats["drop_rate"] = round(n_dup * win["frac_nc"] / docs, 4)
+        return stats
 
     # -- normalized ---------------------------------------------------------
     # Char-length aggregates over the whole source would scan all text (multi-TB

--- a/experiments/datakit/web_explorer/server.py
+++ b/experiments/datakit/web_explorer/server.py
@@ -144,29 +144,50 @@ class _SourceSummary:
 
 
 def _start_source_summary(dv: WebExplorer, lineage: StoreLineage, ducky: DuckyClient, state: _SourceSummary) -> None:
-    """Count each source's parquet files in the background, feeding the store
-    sampler's ``source_docs`` and ``state`` progressively as results arrive.
+    """Compute the Sources leaderboard in the background, in two progressive passes.
 
-    A glob file-count is a fast listing (bounded regardless of file count), unlike
-    an exact ``count(*)`` that reads every parquet footer; it is monotonic in source
-    size, which is all the sampler's smallest-source-first ordering needs.
+    Pass 1 counts each source's parquet *files* (a fast, bounded glob listing) and
+    installs them as ``source_docs`` so the store sampler's smallest-source-first
+    ordering is ready within seconds. Pass 2 computes the full per-source stats
+    (exact doc count, quality distribution, contamination, dedup) one source at a
+    time, filling the leaderboard columns live; the exact doc counts replace the
+    file-count proxy in ``source_docs`` only once all are in, to keep the sampler's
+    size ordering on a single consistent scale throughout.
     """
 
     def _run() -> None:
-        docs: dict[str, int] = {}
-        rows: list[dict] = []
+        rows: dict[str, dict] = {}
+        # pass 1: file-count sizes -> sampler ordering (consistent scale, fast)
+        sizes: dict[str, int] = {}
         for src, base in sorted(lineage.normalize.items()):
             try:
                 n = ducky.run(f"SELECT count(*) FROM glob('{base}/outputs/main/*.parquet')").scalar()
             except DuckyError:
                 n = None
             if n:
-                docs[src] = n
-            rows.append({"source": src, "docs_est": n})
-            dv.source_docs = dict(docs)  # atomic swap; the sampler reads source_docs.get(...)
-            state.rows = list(rows)
+                sizes[src] = n
+            rows[src] = {"source": src, "docs_est": n}
+            dv.source_docs = dict(sizes)  # atomic swap; the sampler reads source_docs.get(...)
+            state.rows = list(rows.values())
+        logger.info("source sizes counted: %d sources", len(rows))
+        # pass 2: full per-source stats -> leaderboard columns, progressive.
+        # Smallest sources first (by the pass-1 sizes) so most columns fill fast,
+        # leaving the few huge sources (slow exact counts) for last.
+        exact: dict[str, int] = {}
+        for src in sorted(lineage.normalize, key=lambda s: sizes.get(s, 1 << 62)):
+            try:
+                stats = dv.source_summary_stats(src)
+            except DuckyError as e:
+                logger.warning("source stats for %s failed: %s", src, e)
+                continue
+            rows[src] = {**rows[src], **stats}
+            if stats.get("docs_est"):
+                exact[src] = stats["docs_est"]
+            state.rows = list(rows.values())
+        if exact:
+            dv.source_docs = exact  # exact counts, one consistent scale for ordering + display
         state.ready = True
-        logger.info("source summary computed: %d sources", len(rows))
+        logger.info("source summary fully computed: %d sources", len(rows))
 
     threading.Thread(target=_run, name="source-summary", daemon=True).start()
 

--- a/experiments/datakit/web_explorer/server.py
+++ b/experiments/datakit/web_explorer/server.py
@@ -130,6 +130,47 @@ def _source_docs(source_summary: list[dict] | None) -> dict[str, int]:
     return {r["source"]: r["docs_est"] for r in source_summary or [] if r.get("docs_est")}
 
 
+@dataclasses.dataclass
+class _SourceSummary:
+    """Per-source doc-count summary, filled progressively by a background thread.
+
+    ``docs_est`` is a parquet file-count — a fast, bounded size proxy that drives
+    the store sampler's cheapest-source-first ordering; the leaderboard displays it
+    as it fills in. ``ready`` flips true once every source has been counted.
+    """
+
+    rows: list[dict] = dataclasses.field(default_factory=list)
+    ready: bool = False
+
+
+def _start_source_summary(dv: WebExplorer, lineage: StoreLineage, ducky: DuckyClient, state: _SourceSummary) -> None:
+    """Count each source's parquet files in the background, feeding the store
+    sampler's ``source_docs`` and ``state`` progressively as results arrive.
+
+    A glob file-count is a fast listing (bounded regardless of file count), unlike
+    an exact ``count(*)`` that reads every parquet footer; it is monotonic in source
+    size, which is all the sampler's smallest-source-first ordering needs.
+    """
+
+    def _run() -> None:
+        docs: dict[str, int] = {}
+        rows: list[dict] = []
+        for src, base in sorted(lineage.normalize.items()):
+            try:
+                n = ducky.run(f"SELECT count(*) FROM glob('{base}/outputs/main/*.parquet')").scalar()
+            except DuckyError:
+                n = None
+            if n:
+                docs[src] = n
+            rows.append({"source": src, "docs_est": n})
+            dv.source_docs = dict(docs)  # atomic swap; the sampler reads source_docs.get(...)
+            state.rows = list(rows)
+        state.ready = True
+        logger.info("source summary computed: %d sources", len(rows))
+
+    threading.Thread(target=_run, name="source-summary", daemon=True).start()
+
+
 def _dedup_attr_map(ducky: DuckyClient, lineage: StoreLineage) -> dict[str, str]:
     """Map source -> per-source fuzzy-dup attr dir, from the dedup artifact (via ducky).
 
@@ -227,6 +268,11 @@ def build_app(
     dist = _dashboard_dist()
     dv = WebExplorer(lineage, ducky, _source_docs(source_summary), _dedup_attr_map(ducky, lineage))
     manager = QueryManager(_build_views(dv))
+    # A pre-baked WEB_EXPLORER_SOURCE_SUMMARY is used as-is; otherwise the app
+    # computes per-source sizes itself in the background and fills them in live.
+    summary = _SourceSummary(rows=source_summary or [], ready=source_summary is not None)
+    if source_summary is None:
+        _start_source_summary(dv, lineage, ducky, summary)
 
     def overview() -> dict:
         buckets = [
@@ -257,7 +303,9 @@ def build_app(
             "dedup": lineage.dedup,
             "counters": payload.counters,
             "buckets": buckets,
-            "source_summary": source_summary or [],
+            "source_summary": summary.rows,
+            "source_summary_ready": summary.ready,
+            "source_summary_total": len(lineage.normalize),
         }
 
     async def index(request: Request) -> HTMLResponse:
@@ -265,6 +313,10 @@ def build_app(
 
     async def api_overview(_request: Request) -> JSONResponse:
         return JSONResponse(overview())
+
+    async def api_source_summary(_request: Request) -> JSONResponse:
+        # Lightweight endpoint the dashboard polls while the background count fills in.
+        return JSONResponse({"ready": summary.ready, "rows": summary.rows, "total": len(lineage.normalize)})
 
     async def api_query(request: Request) -> JSONResponse:
         body = await request.json()
@@ -297,6 +349,7 @@ def build_app(
         routes=[
             Route("/", index),
             Route("/api/overview", api_overview),
+            Route("/api/source-summary", api_source_summary),
             Route("/api/query", api_query, methods=["POST"]),
             Route("/api/result/{query_id:str}", api_result),
             Route("/api/ducky-status", api_ducky_status),


### PR DESCRIPTION
* the datakit explorer computes its **Sources leaderboard** itself, in the background at startup, instead of relying on a pre-baked `WEB_EXPLORER_SOURCE_SUMMARY` file
* the store sampler orders sources smallest-first so each per-source join is cheap; with no per-source counts it joins arbitrary huge sources and `store_bucket_samples` times out (>45s)[^1]
* the background thread runs **two progressive passes**:
  * pass 1 — a fast, bounded `glob` file-count per source → installs `source_docs` so the sampler's size ordering is ready within seconds (bucket sampling drops from >45s to ~2s)
  * pass 2 — `WebExplorer.source_summary_stats` per source (smallest first): exact doc count, quality score distribution (avg / sd / frac≈0), contamination rate, and dedup cluster stats + overall drop rate — filling the leaderboard columns live
* **non-blocking**: the app serves immediately (`Application startup complete` precedes the counts), and it's always fresh — no file to bake or let go stale
* new `GET /api/source-summary` → `{ready, rows, total}`; the dashboard polls it and shows a `computing N/total` banner on the Sources tab until ready
* a pre-baked `WEB_EXPLORER_SOURCE_SUMMARY` is still honored as-is when provided — the in-app computation only runs when it's absent
* quality / contamination are sampled and dedup stats use a bounded window (like the per-stage views); the exact doc count anchors the drop-rate denominator
* verified on marin (iris prod): `store_samples` / `store_bucket_samples` ~2s (was >45s), and every leaderboard column populates with real values (warn thresholds fire, e.g. `cp/libretexts` drop 0.64 + contam 1.08)

[^1]: pass-1 `docs_est` is a parquet file-count — a monotonic size proxy, all the ordering needs; pass 2 replaces it with the exact document count
