### PR TITLE
status-page: draw chart lines without smoothing or gap bridging

### DIFF
--- a/infra/status-page/web/src/components/ControlPlanePanel.tsx
+++ b/infra/status-page/web/src/components/ControlPlanePanel.tsx
@@ -152,7 +152,7 @@ export function ControlPlanePanel() {
                     METRICS.map((metric) => (
                       <Line
                         key={lineKey(s.id, metric)}
-                        type="monotone"
+                        type="linear"
                         dataKey={lineKey(s.id, metric)}
                         name={`${s.name} ${metric}`}
                         stroke={SERIES_COLORS[s.id] ?? "#94a3b8"}
@@ -160,7 +160,6 @@ export function ControlPlanePanel() {
                         strokeDasharray={METRIC_STYLES[metric].strokeDasharray}
                         dot={false}
                         isAnimationActive={false}
-                        connectNulls
                       />
                     )),
                   )}

--- a/infra/status-page/web/src/components/ProvisioningHistoryChart.tsx
+++ b/infra/status-page/web/src/components/ProvisioningHistoryChart.tsx
@@ -132,25 +132,23 @@ export function ProvisioningHistoryChart({
               {regions.map((region) => (
                 <Line
                   key={region}
-                  type="monotone"
+                  type="linear"
                   dataKey={region}
                   name={region}
                   stroke={colorByRegion.get(region) ?? FALLBACK_REGION_COLOR}
                   strokeWidth={1.5}
                   dot={false}
                   isAnimationActive={false}
-                  connectNulls
                 />
               ))}
               <Line
-                type="monotone"
+                type="linear"
                 dataKey={FLEET_KEY}
                 name="average"
                 stroke={FLEET_COLOR}
                 strokeWidth={2.5}
                 dot={false}
                 isAnimationActive={false}
-                connectNulls
               />
             </LineChart>
           ) : (

--- a/infra/status-page/web/src/components/WorkersPanel.tsx
+++ b/infra/status-page/web/src/components/WorkersPanel.tsx
@@ -227,14 +227,13 @@ export function WorkersPanel() {
                   {chartRegions.map((region) => (
                     <Line
                       key={region}
-                      type="monotone"
+                      type="linear"
                       dataKey={region}
                       name={region}
                       stroke={colorByRegion.get(region)}
                       strokeWidth={2}
                       dot={false}
                       isAnimationActive={false}
-                      connectNulls
                     />
                   ))}
                 </LineChart>


### PR DESCRIPTION
* switch all chart `Line`s from `type="monotone"` to `type="linear"` — monotone interpolation swoops between distant points, which reads as fake data when samples are sparse
* drop `connectNulls` so missing samples show as breaks in the line instead of being bridged
* applies to `ControlPlanePanel`, `WorkersPanel`, and `ProvisioningHistoryChart`