### PR TITLE
datakit/decon: apply the eval-task exclusion at bloom-build time

### DIFF
--- a/experiments/datakit/decontam/all_sources_decon.py
+++ b/experiments/datakit/decontam/all_sources_decon.py
@@ -44,6 +44,8 @@ from marin.execution.step_spec import StepSpec
 from rigging.filesystem import marin_prefix
 from rigging.log_setup import configure_logging
 
+from experiments.datakit.decontam.prepare_eval_corpus import DECON_EXCLUDED_EVAL_TASKS
+
 logger = logging.getLogger(__name__)
 
 
@@ -72,7 +74,11 @@ WORKER_RESOURCES = ResourceConfig(cpu=2, ram="8g")
 
 def build_decon_steps() -> list[StepSpec]:
     # One combined bloom from the parquet tree under EVAL_ROOT. Decon
-    # workers consume this directly — no merge step.
+    # workers consume this directly — no merge step. ``exclude_eval_dirs``
+    # drops the answerless corpus-material eval tasks at read time, so an
+    # already-materialized eval corpus that still contains those dirs is
+    # excluded without regenerating it (see marin#6852). Because the set is
+    # folded into the step hash, the bloom rebuilds at a fresh path.
     combined_bloom = build_eval_bloom_step(
         name="datakit/bloom/_combined",
         eval_data_sources=[EVAL_ROOT],
@@ -80,6 +86,7 @@ def build_decon_steps() -> list[StepSpec]:
         overlap_threshold=OVERLAP_THRESHOLD,
         estimated_doc_count=ESTIMATED_DOC_COUNT,
         false_positive_rate=FALSE_POSITIVE_RATE,
+        exclude_eval_dirs=DECON_EXCLUDED_EVAL_TASKS,
     )
 
     # Per-corpus decon steps, all consuming the same combined bloom.

--- a/experiments/datakit/decontam/prepare_eval_corpus.py
+++ b/experiments/datakit/decontam/prepare_eval_corpus.py
@@ -356,7 +356,7 @@ def _prepare_aa() -> None:
 #   - realtoxicityprompts: documents are random spans of open web text.
 # Confirmed empirically as dominant false-positive drivers on code/web
 # corpora (see marin#6852).
-_DECON_EXCLUDED_TASKS: frozenset[str] = frozenset(
+DECON_EXCLUDED_EVAL_TASKS: frozenset[str] = frozenset(
     {
         "code2text_go",
         "code2text_java",
@@ -400,7 +400,7 @@ def _lmh_task_names() -> list[str]:
     for bundle in bundles:
         for cfg in bundle:
             names.add(cfg.name)
-    return sorted(names - _DECON_EXCLUDED_TASKS)
+    return sorted(names - DECON_EXCLUDED_EVAL_TASKS)
 
 
 def _prepare_lmh() -> None:

--- a/experiments/datakit/testbed/decon_arm.py
+++ b/experiments/datakit/testbed/decon_arm.py
@@ -1,0 +1,115 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Decontamination arm for the Datakit Testbed 1T sample.
+
+Wires a per-source ``decon_step`` over the testbed's sampled normalized
+shards, consuming a single combined bloom built with the eval-task
+exclusion applied at read time (``exclude_eval_dirs=DECON_EXCLUDED_EVAL_TASKS``,
+see marin#6852 / #7007). Used to measure the fixed decon's flag rates on the
+~1T-token by-provenance sample.
+
+Prereq: the eval corpus must be staged in the run region
+(``{marin_prefix()}/datakit/decontam/evals``). It is ~240 MiB; stage once:
+
+    gsutil -m rsync -r gs://marin-eu-west4/datakit/decontam/evals \\
+        gs://marin-us-central1/datakit/decontam/evals
+
+Submit on iris (us-central1, same region as the sample — no egress):
+
+    uv run iris --cluster=marin job run --region us-central1 \\
+        --extra=cpu --priority interactive \\
+        --memory 8GB --cpu 2 --enable-extra-resources \\
+        -- python experiments/datakit/testbed/decon_arm.py [--only <source> ...]
+"""
+
+import argparse
+import logging
+import os
+
+from fray import ResourceConfig
+from marin.datakit.decon import build_eval_bloom_step, decon_step
+from marin.execution.step_runner import StepRunner
+from marin.execution.step_spec import StepSpec
+from rigging.filesystem import marin_prefix
+from rigging.log_setup import configure_logging
+
+from experiments.datakit.decontam.prepare_eval_corpus import DECON_EXCLUDED_EVAL_TASKS
+from experiments.datakit.testbed.sampler import build_testbed_steps
+from experiments.datakit.testbed.settings import RAW_TARGET_TOTAL_TOKENS_B
+
+logger = logging.getLogger(__name__)
+
+STAGING_PREFIX = "gs://marin-us-central1"
+_SAMPLE_STEP_PREFIX = "data/datakit/normalized/"
+
+# Bloom sizing mirrors experiments/datakit/decontam/all_sources_decon.py.
+ESTIMATED_DOC_COUNT = 50_000_000
+FALSE_POSITIVE_RATE = 1e-9
+NGRAM_LENGTH = 13
+OVERLAP_THRESHOLD = 0.5
+WORKER_RESOURCES = ResourceConfig(cpu=2, ram="8g")
+
+
+def build_testbed_decon_steps(
+    target_total_tokens_b: float = RAW_TARGET_TOTAL_TOKENS_B,
+    only_sources: list[str] | None = None,
+) -> list[StepSpec]:
+    """Bloom (fixed) + one decon step per sampled source.
+
+    ``only_sources`` restricts the decon fan-out to named sources (for smokes);
+    StepRunner still walks each decon step's deps, so the matching sample +
+    normalize chains run on demand. Sample fractions are always the full 1T
+    proportional fractions, so a restricted run still decons a source's true
+    1T-share sample.
+    """
+    testbed_steps = build_testbed_steps(target_total_tokens_b=target_total_tokens_b)
+    sampled = {
+        s.name.removeprefix(_SAMPLE_STEP_PREFIX): s for s in testbed_steps if s.name.startswith(_SAMPLE_STEP_PREFIX)
+    }
+    if only_sources:
+        missing = [s for s in only_sources if s not in sampled]
+        if missing:
+            raise ValueError(f"unknown sources: {missing}; have {sorted(sampled)[:5]}…")
+        sampled = {k: v for k, v in sampled.items() if k in only_sources}
+
+    bloom = build_eval_bloom_step(
+        name="datakit/bloom/_combined_fixed",
+        eval_data_sources=[f"{marin_prefix()}/datakit/decontam/evals"],
+        ngram_length=NGRAM_LENGTH,
+        overlap_threshold=OVERLAP_THRESHOLD,
+        estimated_doc_count=ESTIMATED_DOC_COUNT,
+        false_positive_rate=FALSE_POSITIVE_RATE,
+        exclude_eval_dirs=DECON_EXCLUDED_EVAL_TASKS,
+    )
+
+    steps: list[StepSpec] = [bloom]
+    for name, sample_step in sampled.items():
+        steps.append(
+            decon_step(
+                name=f"datakit/testbed_decon/{name}",
+                normalized=sample_step,
+                prebuilt_bloom=bloom,
+                ngram_length=NGRAM_LENGTH,
+                overlap_threshold=OVERLAP_THRESHOLD,
+                estimated_doc_count=ESTIMATED_DOC_COUNT,
+                false_positive_rate=FALSE_POSITIVE_RATE,
+                worker_resources=WORKER_RESOURCES,
+            )
+        )
+    logger.info("testbed decon: %d sources, %d steps (bloom + decon; deps pull sample/normalize)", len(sampled), len(steps))
+    return steps
+
+
+def main() -> None:
+    os.environ.setdefault("MARIN_PREFIX", STAGING_PREFIX)
+    configure_logging(logging.INFO)
+    ap = argparse.ArgumentParser()
+    ap.add_argument("--only", nargs="*", default=None, help="restrict decon to these source names (smoke)")
+    ap.add_argument("--target-tokens-b", type=float, default=RAW_TARGET_TOTAL_TOKENS_B)
+    args = ap.parse_args()
+    StepRunner().run(build_testbed_decon_steps(target_total_tokens_b=args.target_tokens_b, only_sources=args.only))
+
+
+if __name__ == "__main__":
+    main()

--- a/experiments/datakit/testbed/decon_arm.py
+++ b/experiments/datakit/testbed/decon_arm.py
@@ -97,7 +97,9 @@ def build_testbed_decon_steps(
                 worker_resources=WORKER_RESOURCES,
             )
         )
-    logger.info("testbed decon: %d sources, %d steps (bloom + decon; deps pull sample/normalize)", len(sampled), len(steps))
+    logger.info(
+        "testbed decon: %d sources, %d steps (bloom + decon; deps pull sample/normalize)", len(sampled), len(steps)
+    )
     return steps
 
 

--- a/lib/marin/src/marin/datakit/decon.py
+++ b/lib/marin/src/marin/datakit/decon.py
@@ -208,19 +208,27 @@ def _is_hidden_dir(root: str, resolved: str) -> bool:
     return any(p.startswith(".") for p in rel.split(os.sep))
 
 
-def _discover_eval_files(eval_paths: list[str]) -> Iterator[str]:
+def _discover_eval_files(eval_paths: list[str], exclude_dir_names: frozenset[str] = frozenset()) -> Iterator[str]:
     """Walk all *eval_paths* recursively and yield zephyr-readable data files.
 
     Filters by ``zephyr.readers.SUPPORTED_EXTENSIONS`` so common sidecars
     (``README``, ``_SUCCESS``, ``provenance.json``, ``.executor_info``, …)
     that live alongside eval data don't kill the whole decon step when
     ``load_file`` later rejects their extension. Mirrors ``normalize._discover_files``.
+
+    *exclude_dir_names* skips any file whose immediate parent directory name is
+    in the set (the eval-corpus layout is ``<root>/<split>/<task>/<file>``, so the
+    task name is the parent dir). This lets a caller drop specific eval tasks from
+    the bloom *at read time*, so an already-materialized eval corpus that still
+    contains those task dirs is excluded without regenerating it.
     """
     for source in eval_paths:
         fs, resolved = url_to_fs(source)
         protocol = source.split("://")[0] if "://" in source else ""
         for root, _dirs, files in fs.walk(resolved):
             if _is_hidden_dir(root, resolved):
+                continue
+            if os.path.basename(root.rstrip("/")) in exclude_dir_names:
                 continue
             for fname in files:
                 if fname.startswith(".") or not fname.endswith(SUPPORTED_EXTENSIONS):
@@ -240,6 +248,7 @@ def _build_filter(
     ngram: NGramConfig | None,
     estimated_doc_count: int,
     false_positive_rate: float,
+    exclude_dir_names: frozenset[str] = frozenset(),
 ) -> int:
     """Build a bloom filter and a streaming hash → eval_id sidecar.
 
@@ -261,7 +270,7 @@ def _build_filter(
     stats = {"n_records": 0, "n_index_rows": 0}
 
     def emit_index_rows() -> Iterator[dict[str, Any]]:
-        for path in _discover_eval_files(eval_paths):
+        for path in _discover_eval_files(eval_paths, exclude_dir_names):
             for idx, record in enumerate(load_file(path)):
                 text = record.get(text_field)
                 if not text:
@@ -496,6 +505,7 @@ def build_eval_bloom(
     ngram: NGramConfig | None = None,
     estimated_doc_count: int = 1_000_000,
     false_positive_rate: float = 1e-9,
+    exclude_eval_dirs: frozenset[str] = frozenset(),
 ) -> EvalBloom:
     """Build a reusable bloom + hash-index sidecar from one or more eval sources.
 
@@ -520,6 +530,9 @@ def build_eval_bloom(
             blooms intended for :func:`merge_eval_blooms` MUST share both
             values across all per-eval builds — ``dupekit.Bloom.update``
             requires identical sizing.
+        exclude_eval_dirs: Eval task directory names to skip while walking
+            ``eval_data_sources`` (see :func:`_discover_eval_files`). Excludes
+            those tasks from the bloom without regenerating the eval corpus.
 
     Returns:
         :class:`EvalBloom` artifact pointing at the produced files.
@@ -537,6 +550,7 @@ def build_eval_bloom(
         ngram=ngram,
         estimated_doc_count=estimated_doc_count,
         false_positive_rate=false_positive_rate,
+        exclude_dir_names=exclude_eval_dirs,
     )
     return EvalBloom(
         bloom_dir=output_path,
@@ -641,6 +655,7 @@ def build_eval_bloom_step(
     overlap_threshold: float = 0.5,
     estimated_doc_count: int = 1_000_000,
     false_positive_rate: float = 1e-9,
+    exclude_eval_dirs: frozenset[str] = frozenset(),
     output_path_prefix: str | None = None,
     override_output_path: str | None = None,
 ) -> StepSpec:
@@ -653,6 +668,9 @@ def build_eval_bloom_step(
             cache); StepSpec entries become DAG deps.
         text_field, ngram_length, overlap_threshold: ngram config.
         estimated_doc_count, false_positive_rate: bloom sizing.
+        exclude_eval_dirs: Eval task directory names to drop from the bloom
+            (see :func:`build_eval_bloom`). Folded into ``hash_attrs`` so
+            changing the exclusion set rebuilds the bloom at a fresh path.
         output_path_prefix, override_output_path: StepSpec routing.
     """
     raw_paths: list[str] = []
@@ -677,6 +695,7 @@ def build_eval_bloom_step(
         # Raw paths aren't deps — fingerprint them so swapping a path
         # invalidates the cache.
         "eval_data_sources": tuple(sorted(s for s in raw_paths if s not in (d.output_path for d in step_deps))),
+        "exclude_eval_dirs": tuple(sorted(exclude_eval_dirs)),
     }
 
     return StepSpec(
@@ -688,6 +707,7 @@ def build_eval_bloom_step(
             ngram=ngram,
             estimated_doc_count=estimated_doc_count,
             false_positive_rate=false_positive_rate,
+            exclude_eval_dirs=exclude_eval_dirs,
         ),
         deps=step_deps,
         hash_attrs=hash_attrs,

--- a/scripts/datakit/sync_datakit.py
+++ b/scripts/datakit/sync_datakit.py
@@ -71,6 +71,7 @@ Usage::
 
 import argparse
 import logging
+import os
 import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from enum import StrEnum
@@ -243,13 +244,13 @@ def _copy_shard(
     is safe — fsspec funnels async ops onto a single dedicated event loop,
     and synchronous APIs are reentrant.
     """
-    src_fs, _ = fsspec.core.url_to_fs(src_dir)
+    src_fs, _ = _url_to_fs(src_dir)
     # ``fixed_upload_size=True`` (set inside ``_open_kwargs_for`` for s3 dests)
     # is required for Cloudflare R2's multipart PUT and harmless on AWS S3.
     # It only matters for the write through ``dst_fs.open(..., "wb")``; the
     # ``fs.mv`` inside atomic_rename is a single ``CopyObject`` and can use
     # any S3 client config.
-    dst_fs, _ = fsspec.core.url_to_fs(dst_dir, **_open_kwargs_for(dst_dir))
+    dst_fs, _ = _url_to_fs(dst_dir, **_open_kwargs_for(dst_dir))
     src_base = src_dir.rstrip("/")
     dst_base = dst_dir.rstrip("/")
 
@@ -287,7 +288,7 @@ def _list_relative_files(src_dir: str) -> list[tuple[str, str]]:
       last step (see ``_finalize_executor_status``) so its presence on dst
       cleanly signals "this leaf is fully synced".
     """
-    src_fs, _ = fsspec.core.url_to_fs(src_dir)
+    src_fs, _ = _url_to_fs(src_dir)
     stripped_root = src_fs._strip_protocol(src_dir).rstrip("/")
     entries: list[tuple[str, str]] = []
     skipped_tmp = 0
@@ -326,6 +327,40 @@ def _open_kwargs_for(path: str) -> dict:
     return {"fixed_upload_size": True} if path.startswith("s3://") else {}
 
 
+# R2 data buckets whose filesystem must be built with *explicit* R2 endpoint +
+# credentials from ``R2_*`` env vars, rather than the process-global S3 config.
+# This is what lets a single process copy R2 -> CoreWeave: the CW side uses the
+# ambient S3 config (the cluster default, e.g. cwlota) and the R2 side is pinned
+# to its own client via constructor kwargs, so the two never clobber each other
+# (fsspec caches filesystems by their kwargs). Set ``R2_ACCESS_KEY``,
+# ``R2_SECRET``, ``R2_ENDPOINT_URL`` in the job env.
+_R2_BUCKETS = frozenset({"marin-na"})
+
+
+def _s3_creds_kwargs(path: str) -> dict:
+    """Explicit R2 endpoint+creds for an ``s3://marin-na/...`` path, else ``{}``.
+
+    Returns empty for any non-R2 path so it keeps using the ambient S3 config
+    (the cluster's default object store). Only activates when the ``R2_*`` env
+    vars are present, so the script still works unchanged in single-backend runs.
+    """
+    if not path.startswith("s3://"):
+        return {}
+    bucket = path[len("s3://") :].split("/", 1)[0]
+    if bucket in _R2_BUCKETS and os.environ.get("R2_ENDPOINT_URL"):
+        return {
+            "key": os.environ["R2_ACCESS_KEY"],
+            "secret": os.environ["R2_SECRET"],
+            "client_kwargs": {"endpoint_url": os.environ["R2_ENDPOINT_URL"], "region_name": "auto"},
+        }
+    return {}
+
+
+def _url_to_fs(path: str, **extra):
+    """``fsspec.core.url_to_fs`` with per-bucket R2 creds injected (see :func:`_s3_creds_kwargs`)."""
+    return fsspec.core.url_to_fs(path, **_s3_creds_kwargs(path), **extra)
+
+
 def _finalize_executor_status(src_dir: str, dst_dir: str) -> None:
     """Copy ``.executor_status`` from ``src_dir`` to ``dst_dir`` as a single op.
 
@@ -335,11 +370,11 @@ def _finalize_executor_status(src_dir: str, dst_dir: str) -> None:
     """
     src = _executor_status_path(src_dir)
     dst = _executor_status_path(dst_dir)
-    src_fs, _ = fsspec.core.url_to_fs(src)
+    src_fs, _ = _url_to_fs(src)
     if not src_fs.exists(src):
         logger.warning("source has no %s — not finalizing %s", _EXECUTOR_STATUS_FILENAME, dst_dir)
         return
-    dst_fs, _ = fsspec.core.url_to_fs(dst, **_open_kwargs_for(dst))
+    dst_fs, _ = _url_to_fs(dst, **_open_kwargs_for(dst))
     _copy_one(src_fs, dst_fs, src, dst)
     logger.info("Finalized %s", dst)
 
@@ -364,7 +399,7 @@ def _remove_tmp_orphans(dst_dir: str) -> None:
     them around would make a byte-for-byte src/dst comparison fail despite
     the real data matching.
     """
-    dst_fs, _ = fsspec.core.url_to_fs(dst_dir)
+    dst_fs, _ = _url_to_fs(dst_dir)
     if not dst_fs.exists(dst_dir):
         return
     orphans = [full for full in dst_fs.find(dst_dir) if _ATOMIC_RENAME_TMP_RE.search(full)]

--- a/tests/datakit/test_decon.py
+++ b/tests/datakit/test_decon.py
@@ -770,6 +770,56 @@ def test_build_eval_bloom_then_decon_matches_inline(fox_corpus):
         assert sorted(pre["matched_hashes"]) == sorted(inline["matched_hashes"])
 
 
+def test_build_eval_bloom_excludes_named_task_dirs(tmp_path: Path):
+    """``exclude_eval_dirs`` drops matching task dirs at read time.
+
+    An already-materialized eval corpus can be pruned without regenerating it:
+    the excluded task's records never enter the bloom or the hash index, while a
+    kept task in the same tree still drives contamination matches.
+    """
+    eval_root = tmp_path / "evals"
+    _write_eval_jsonl(
+        eval_root / "lmh" / "kept_task" / "eval.jsonl.gz", [{"id": "kept-1", "text": "alpha beta gamma delta"}]
+    )
+    _write_eval_jsonl(
+        eval_root / "lmh" / "code2text_python" / "eval.jsonl.gz",
+        [{"id": "excl-1", "text": "epsilon zeta eta theta"}],
+    )
+
+    bloom_dir = tmp_path / "bloom"
+    build_eval_bloom(
+        eval_data_sources=str(eval_root),
+        output_path=str(bloom_dir),
+        ngram=NGramConfig(ngram_length=3, overlap_threshold=0.5),
+        estimated_doc_count=1_000,
+        false_positive_rate=1e-9,
+        exclude_eval_dirs=frozenset({"code2text_python"}),
+    )
+    _, index_path = bloom_paths(str(bloom_dir))
+    eval_ids = set(pq.read_table(index_path).column("eval_id").to_pylist())
+    assert eval_ids == {"kept-1"}, "excluded task dir must not contribute to the hash index"
+
+    # A doc matching the excluded eval text is NOT flagged; the kept one is.
+    input_dir = tmp_path / "input"
+    output_dir = tmp_path / "output"
+    _write_input_parquet(
+        input_dir / "part-00000-of-00001.parquet",
+        [
+            {"id": "hits-kept", "text": "alpha beta gamma delta", "partition_id": 0},
+            {"id": "hits-excluded", "text": "epsilon zeta eta theta", "partition_id": 0},
+        ],
+    )
+    decon_to_parquet(
+        normalized_data=_as_source(input_dir),
+        prebuilt_bloom_dir=str(bloom_dir),
+        output_path=str(output_dir),
+        ngram=NGramConfig(ngram_length=3, overlap_threshold=0.5),
+    )
+    rows = _read_attributes(output_dir)
+    assert rows["hits-kept"]["contaminated"] is True
+    assert rows["hits-excluded"]["contaminated"] is False
+
+
 def test_merge_eval_blooms_equals_single_build(tmp_path: Path):
     """merge_eval_blooms over N per-eval builds detects everything a single combined build does.
 


### PR DESCRIPTION
follow-up to #7005, which was inert on the bloom.

* #7005 filtered the excluded eval tasks (`code2text_*`, `swde`, `jsonschema_bench_*`, `realtoxicityprompts`) only from what `prepare_eval_corpus` *writes*. but `build_eval_bloom` globs the whole eval tree via `_discover_eval_files` and never consults `_lmh_task_names`, so an already-materialized eval corpus still fed those tasks into the bloom — the exclusion did nothing until the corpus was regenerated from scratch
* thread `exclude_eval_dirs` through `build_eval_bloom` / `build_eval_bloom_step` → `_build_filter` → `_discover_eval_files`, which skips any file whose parent dir name is in the set. the exclusion now applies at *read* time, so a stale corpus is pruned without regenerating it
  * folded into the step `hash_attrs`, so changing the exclusion set rebuilds the bloom at a fresh path rather than reusing the stale one
* `_DECON_EXCLUDED_TASKS` → `DECON_EXCLUDED_EVAL_TASKS`, now the single source of truth, passed from `all_sources_decon.py`; the set stays in the experiments layer and is passed down (no reverse import into `marin`)
* test asserts an excluded task dir contributes nothing to the bloom/index while a kept task in the same tree still flags

verified effect (exact re-scoring off the current store decon output, marin#6852): removing these 4 families drops 25% of bloom hashes (5.48M/21.78M, only 2 shared with kept evals) and de-flags ≥77–97% of code-source false positives (stackv2 ≥96.6%, coderforge ≥89.3%, swe-rebench ≥84.9%) while leaving genuine leakage untouched (`cp/data_provenance` 0%, `synthetic-1` 4.8%) and passage-driven FPs untouched (need a separate question+answer-only fix)