### PR TITLE
datakit/sync: enable R2 -> CoreWeave in a single job

### DIFF
--- a/scripts/datakit/sync_datakit.py
+++ b/scripts/datakit/sync_datakit.py
@@ -267,6 +267,9 @@ def _copy_shard(
     counters.pipeline.update_counter("upload/shards_copied", 1)
     counters.pipeline.update_counter("upload/files_copied", len(entries))
     counters.pipeline.update_counter("upload/bytes_copied", bytes_copied)
+    # Per-shard progress line so a long multi-shard sync is monitorable in the
+    # worker logs (the coordinator otherwise only dumps counters at shutdown).
+    logger.info("shard copied: %d files, %.1f MiB -> %s", len(entries), bytes_copied / 1024 / 1024, dst_dir)
     return {"shard_hash": _shard_hash(entries), "files": len(entries), "bytes": bytes_copied}
 
 
@@ -332,8 +335,8 @@ def _open_kwargs_for(path: str) -> dict:
 # This is what lets a single process copy R2 -> CoreWeave: the CW side uses the
 # ambient S3 config (the cluster default, e.g. cwlota) and the R2 side is pinned
 # to its own client via constructor kwargs, so the two never clobber each other
-# (fsspec caches filesystems by their kwargs). Set ``R2_ACCESS_KEY``,
-# ``R2_SECRET``, ``R2_ENDPOINT_URL`` in the job env.
+# (fsspec caches filesystems by their kwargs). Set ``R2_ACCESS_KEY_ID``,
+# ``R2_SECRET_ACCESS_KEY``, ``R2_ENDPOINT_URL`` in the job env.
 _R2_BUCKETS = frozenset({"marin-na"})
 
 
@@ -348,10 +351,17 @@ def _s3_creds_kwargs(path: str) -> dict:
         return {}
     bucket = path[len("s3://") :].split("/", 1)[0]
     if bucket in _R2_BUCKETS and os.environ.get("R2_ENDPOINT_URL"):
+        # ``endpoint_url`` must be a *top-level* s3fs kwarg, not inside
+        # ``client_kwargs``: fsspec shallow-merges the ambient ``FSSPEC_S3`` config
+        # (which carries the cluster's top-level ``endpoint_url``, e.g. cwlota) with
+        # ours. A top-level key overrides it; putting it in ``client_kwargs`` instead
+        # leaves the ambient top-level endpoint in place and s3fs then passes
+        # ``endpoint_url`` to ``create_client`` twice.
         return {
-            "key": os.environ["R2_ACCESS_KEY"],
-            "secret": os.environ["R2_SECRET"],
-            "client_kwargs": {"endpoint_url": os.environ["R2_ENDPOINT_URL"], "region_name": "auto"},
+            "key": os.environ["R2_ACCESS_KEY_ID"],
+            "secret": os.environ["R2_SECRET_ACCESS_KEY"],
+            "endpoint_url": os.environ["R2_ENDPOINT_URL"],
+            "client_kwargs": {"region_name": "auto"},
         }
     return {}
 
@@ -641,6 +651,13 @@ def _parse_args() -> argparse.Namespace:
         help=f"Where shard sentinels + step status live (default: {DEFAULT_STATUS_PREFIX!r}).",
     )
     parser.add_argument(
+        "--max-sources",
+        type=int,
+        default=8,
+        help="Max source-syncs run concurrently by StepRunner (default 8). Each source "
+        "further fans out into its own Zephyr copy workers.",
+    )
+    parser.add_argument(
         "--dry-run",
         action="store_true",
         help="Build StepSpecs and list them, but don't run.",
@@ -740,7 +757,7 @@ def main() -> None:
         print(f"{len(steps)} sync StepSpec(s) built (dry run).")
         return
 
-    StepRunner().run(steps)
+    StepRunner().run(steps, max_concurrent=args.max_sources)
     print(f"Synced {len(steps)} source(s): {src_prefix} -> {args.dest_prefix}.")
 
 


### PR DESCRIPTION
copy R2 (`marin-na`) → CoreWeave (`marin-us-east-02a`/cwlota) in one `sync_datakit` process — previously impossible because rigging configures S3 from a single global endpoint+creds, so source and dest could not use different S3 backends at once.

* build the marin-na (R2) filesystem from explicit `R2_ACCESS_KEY_ID`/`R2_SECRET_ACCESS_KEY`/`R2_ENDPOINT_URL` constructor kwargs while the dest keeps the ambient cluster config (cwlota); fsspec caches filesystems by kwargs so the two never clobber
  * `endpoint_url` is passed as a **top-level** s3fs kwarg (not inside `client_kwargs`) so it overrides the ambient top-level endpoint instead of being handed to `create_client` twice (that dup was the first failure mode)
* `--max-sources` bounds StepRunner concurrency (default 8); each source further fans out into its own Zephyr copy workers
* per-shard progress log line so a long multi-source sync is monitorable — the coordinator otherwise only dumps counters at shutdown
* verified byte-identical on a full-normalized R2→CW sample (`coderforge`: 101 objects / 12.85 GB, 0 missing / 0 mismatch); `--copy-threads 4` avoids OOM on the ~268 MB normalized shards

driving a full `--scope normalized` R2→CW sync of the datakit corpus with this (16 concurrent sources), so it is exercised at scale.