### PR TITLE
datakit/sync: finite S3 timeouts (fix wedged CoreWeave commit hang)

### DIFF
--- a/scripts/datakit/sync_datakit.py
+++ b/scripts/datakit/sync_datakit.py
@@ -76,13 +76,13 @@ import re
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from enum import StrEnum
 
-import fsspec
 from fray import ResourceConfig
 from marin.datakit.sources import DatakitSource, all_sources
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from marin.execution.step_status import STATUS_SUCCESS, StatusFile, StepAlreadyDone, step_lock
 from rigging.filesystem import atomic_rename, marin_prefix
+from rigging.filesystem import url_to_fs as _rigging_url_to_fs
 from rigging.log_setup import configure_logging
 from zephyr import Dataset, ZephyrContext, counters
 from zephyr.shard_keys import deterministic_hash
@@ -367,8 +367,15 @@ def _s3_creds_kwargs(path: str) -> dict:
 
 
 def _url_to_fs(path: str, **extra):
-    """``fsspec.core.url_to_fs`` with per-bucket R2 creds injected (see :func:`_s3_creds_kwargs`)."""
-    return fsspec.core.url_to_fs(path, **_s3_creds_kwargs(path), **extra)
+    """``url_to_fs`` with per-bucket R2 creds injected (see :func:`_s3_creds_kwargs`).
+
+    Goes through rigging's ``url_to_fs`` rather than raw fsspec so every S3
+    filesystem (both the R2 source and the CoreWeave dest) gets finite
+    ``connect_timeout``/``read_timeout`` + bounded retries. Without them a wedged
+    R2/CoreWeave socket (e.g. a hung ``CompleteMultipartUpload``) blocks
+    ``fsspec.asyn.sync`` forever and the copy thread never returns (#6487).
+    """
+    return _rigging_url_to_fs(path, **_s3_creds_kwargs(path), **extra)
 
 
 def _finalize_executor_status(src_dir: str, dst_dir: str) -> None:


### PR DESCRIPTION
follow-up to #7011 (which merged without this).

route `sync_datakit`'s filesystem construction through rigging's `url_to_fs` instead of raw `fsspec.core.url_to_fs`, so every S3 filesystem — the R2 source **and** the CoreWeave dest — gets finite `connect_timeout`/`read_timeout` + bounded retries.

* without them a wedged R2/CoreWeave socket blocks `fsspec.asyn.sync().wait()` forever and the copy thread never returns (#6487)
* observed live: a source hung ~110 min on a `CompleteMultipartUpload` to cwlota — stack bottomed out in `s3fs commit() -> _call_s3 -> fsspec.asyn.sync -> wait()` inside `_copy_one`, while `MainThread` blocked in `as_completed`; the shard never finished so the source never finalized
* resubmitting the R2->CW sync on the fixed build let the wedged commit time out + retry, and the source (`rqa`) completed — full 117-source normalized sync then finished