### PR TITLE
iris/finelog: bind coreweave kubectl operations to a pinned kube context

### DIFF
--- a/.agents/skills/reserve-gpu/SKILL.md
+++ b/.agents/skills/reserve-gpu/SKILL.md
@@ -24,7 +24,7 @@ A holder pod sits on an expensive 8×H100 node for the session's lifetime. Relea
 
 ## Prerequisites
 
-1. Place the cluster kubeconfig at the path the config expects. The tool passes `--kubeconfig <platform.coreweave.kubeconfig_path>` and `--context <platform.coreweave.kube_context>` to `kubectl` verbatim and fails fast if the file is absent. All CoreWeave clusters share the merged kubeconfig `~/.kube/coreweave-iris`; the per-cluster context (e.g. `marin-gpu_US-EAST-02A` for `cw-us-east-02a`) is pinned in the cluster yaml, per `lib/iris/docs/coreweave.md`.
+1. Place the cluster kubeconfig at the path the config expects. The tool passes `--kubeconfig <platform.coreweave.kubeconfig_path>` and `--context <platform.coreweave.kube_context>` to `kubectl` verbatim and fails fast if the file is absent. All CoreWeave clusters share the kubeconfig `~/.kube/coreweave-iris`; the per-cluster context (e.g. `marin-gpu_US-EAST-02A` for `cw-us-east-02a`) is pinned in the cluster yaml, per `lib/iris/docs/coreweave.md`.
 
 2. Ensure the Iris controller is running for the cluster. On the shared CoreWeave cluster this is usually already true; only start it yourself for a fresh cluster.
 

--- a/.agents/skills/reserve-gpu/SKILL.md
+++ b/.agents/skills/reserve-gpu/SKILL.md
@@ -24,7 +24,7 @@ A holder pod sits on an expensive 8×H100 node for the session's lifetime. Relea
 
 ## Prerequisites
 
-1. Place the cluster kubeconfig at the path the config expects. The tool passes `--kubeconfig <platform.coreweave.kubeconfig_path>` to `kubectl` verbatim and fails fast if the file is absent. For the production H100 fleet (`cw-us-east-02a`, the `marin-gpu` cluster) that path is `~/.kube/coreweave-iris-gpu`, per `lib/iris/docs/coreweave.md`.
+1. Place the cluster kubeconfig at the path the config expects. The tool passes `--kubeconfig <platform.coreweave.kubeconfig_path>` and `--context <platform.coreweave.kube_context>` to `kubectl` verbatim and fails fast if the file is absent. All CoreWeave clusters share the merged kubeconfig `~/.kube/coreweave-iris`; the per-cluster context (e.g. `marin-gpu_US-EAST-02A` for `cw-us-east-02a`) is pinned in the cluster yaml, per `lib/iris/docs/coreweave.md`.
 
 2. Ensure the Iris controller is running for the cluster. On the shared CoreWeave cluster this is usually already true; only start it yourself for a fresh cluster.
 
@@ -67,10 +67,11 @@ uv run iris --config=lib/iris/config/cw-us-east-02a.yaml job list --prefix /$USE
 uv run iris --config=lib/iris/config/cw-us-east-02a.yaml job logs /$USER/dev-gpu-<name>
 ```
 
-Inspect the pod directly with the same kubeconfig the tool uses:
+Inspect the pod directly with the same kubeconfig + context the tool uses:
 
 ```bash
-kubectl --kubeconfig ~/.kube/coreweave-iris-gpu --namespace iris get pods -l iris.task_id=<sanitized-task-id>
+kubectl --kubeconfig ~/.kube/coreweave-iris --context marin-gpu_US-EAST-02A \
+  --namespace iris get pods -l iris.task_id=<sanitized-task-id>
 ```
 
 ## Session behavior

--- a/lib/finelog/config/cw-rno2a.yaml
+++ b/lib/finelog/config/cw-rno2a.yaml
@@ -24,8 +24,6 @@ remote_log_dir: s3://marin-us-east-02a/finelog/cw-rno2a
 deployment:
   k8s:
     namespace: iris
-    # Same merged kubeconfig + context the iris cluster config pins
-    # (lib/iris/config/cw-rno2a.yaml); every kubectl call is context-bound.
     kubeconfig: ~/.kube/coreweave-iris
     kube_context: marin-rn02a_RNO2A
     # storage_class omitted -> the cluster's default StorageClass (shared-vast,

--- a/lib/finelog/config/cw-rno2a.yaml
+++ b/lib/finelog/config/cw-rno2a.yaml
@@ -12,8 +12,9 @@
 # R2_SECRET_ACCESS_KEY env vars, historical names) + object_storage_endpoint and
 # projects it into the pod via envFrom (see deploy/k8s/02-deployment).
 #
-# Deploy: export KUBECONFIG=~/.kube/coreweave-iris-rno2a and the CoreWeave
-# object-storage access key, then
+# Deploy: kubectl operations bind to deployment.k8s.kubeconfig/kube_context below
+# (no KUBECONFIG export needed). Export the CoreWeave object-storage access key,
+# then
 #   export R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=...
 #   uv run finelog deploy up cw-rno2a --no-build
 name: finelog-cw-rno2a
@@ -23,6 +24,10 @@ remote_log_dir: s3://marin-us-east-02a/finelog/cw-rno2a
 deployment:
   k8s:
     namespace: iris
+    # Same merged kubeconfig + context the iris cluster config pins
+    # (lib/iris/config/cw-rno2a.yaml); every kubectl call is context-bound.
+    kubeconfig: ~/.kube/coreweave-iris
+    kube_context: marin-rn02a_RNO2A
     # storage_class omitted -> the cluster's default StorageClass (shared-vast,
     # VAST CSI) backs the PVC. Segments offload to object storage, but size the
     # local cache generously to absorb ingest bursts + L0->L1 compaction before

--- a/lib/finelog/config/cw-us-east-02a.yaml
+++ b/lib/finelog/config/cw-us-east-02a.yaml
@@ -22,8 +22,6 @@ remote_log_dir: s3://marin-na/finelog/cw-us-east-02a
 deployment:
   k8s:
     namespace: iris
-    # Same merged kubeconfig + context the iris cluster config pins
-    # (lib/iris/config/cw-us-east-02a.yaml); every kubectl call is context-bound.
     kubeconfig: ~/.kube/coreweave-iris
     kube_context: marin-gpu_US-EAST-02A
     # storage_class omitted -> the cluster's default StorageClass (shared-vast,

--- a/lib/finelog/config/cw-us-east-02a.yaml
+++ b/lib/finelog/config/cw-us-east-02a.yaml
@@ -11,7 +11,8 @@
 # `finelog-cw-use02a-env` Secret from the operator's R2 creds + object_storage_endpoint
 # and projects it into the pod via envFrom (see deploy/k8s/02-deployment).
 #
-# Deploy: export KUBECONFIG=~/.kube/coreweave-iris-gpu and the R2 creds, then
+# Deploy: kubectl operations bind to deployment.k8s.kubeconfig/kube_context below
+# (no KUBECONFIG export needed). Export the R2 creds, then
 #   export R2_ACCESS_KEY_ID=... R2_SECRET_ACCESS_KEY=...
 #   uv run finelog deploy up cw-us-east-02a
 name: finelog-cw-use02a
@@ -21,6 +22,10 @@ remote_log_dir: s3://marin-na/finelog/cw-us-east-02a
 deployment:
   k8s:
     namespace: iris
+    # Same merged kubeconfig + context the iris cluster config pins
+    # (lib/iris/config/cw-us-east-02a.yaml); every kubectl call is context-bound.
+    kubeconfig: ~/.kube/coreweave-iris
+    kube_context: marin-gpu_US-EAST-02A
     # storage_class omitted -> the cluster's default StorageClass (shared-vast,
     # VAST CSI) backs the PVC. Segments offload to R2, but size the local cache
     # generously to absorb ingest bursts + L0->L1 compaction before offload.

--- a/lib/finelog/src/finelog/deploy/_k8s.py
+++ b/lib/finelog/src/finelog/deploy/_k8s.py
@@ -161,12 +161,30 @@ def _build_s3_secret_manifest(cfg: FinelogConfig) -> str | None:
     return json.dumps(manifest)
 
 
-def _kubectl(*args: str, stdin: str | None = None, check: bool = True) -> subprocess.CompletedProcess:
-    return subprocess.run(["kubectl", *args], input=stdin, text=True, check=check)
+def _kube_flags(cfg: FinelogConfig) -> list[str]:
+    """Global kubectl flags binding this deploy to its configured kubeconfig/context.
+
+    Empty when the config sets neither — kubectl then falls back to its own
+    resolution (KUBECONFIG env var or ~/.kube/config, current-context).
+    """
+    assert cfg.deployment.k8s is not None
+    k8s = cfg.deployment.k8s
+    flags: list[str] = []
+    if k8s.kubeconfig:
+        flags.extend(["--kubeconfig", str(Path(k8s.kubeconfig).expanduser())])
+    if k8s.kube_context:
+        flags.extend(["--context", k8s.kube_context])
+    return flags
 
 
-def _kubectl_apply(manifest: str) -> None:
-    _kubectl("apply", "-f", "-", stdin=manifest)
+def _kubectl(
+    cfg: FinelogConfig, *args: str, stdin: str | None = None, check: bool = True
+) -> subprocess.CompletedProcess:
+    return subprocess.run(["kubectl", *_kube_flags(cfg), *args], input=stdin, text=True, check=check)
+
+
+def _kubectl_apply(cfg: FinelogConfig, manifest: str) -> None:
+    _kubectl(cfg, "apply", "-f", "-", stdin=manifest)
 
 
 def _ensure_priority_class(cfg: FinelogConfig) -> None:
@@ -193,7 +211,7 @@ def _ensure_priority_class(cfg: FinelogConfig) -> None:
         "globalDefault": False,
     }
     click.echo(f"Ensuring PriorityClass {k8s.priority_class_name} (value {k8s.priority_class_value})...")
-    _kubectl_apply(json.dumps(manifest))
+    _kubectl_apply(cfg, json.dumps(manifest))
 
 
 def k8s_up(cfg: FinelogConfig) -> None:
@@ -210,13 +228,13 @@ def k8s_up(cfg: FinelogConfig) -> None:
     secret_manifest = _build_s3_secret_manifest(cfg)
     if secret_manifest is not None:
         click.echo(f"Applying Secret {_s3_secret_name(cfg)} (S3 credentials)...")
-        _kubectl_apply(secret_manifest)
+        _kubectl_apply(cfg, secret_manifest)
     for manifest_name in _MANIFESTS:
         rendered = _render_manifest(_K8S_MANIFEST_DIR / manifest_name, cfg)
         click.echo(f"Applying {manifest_name}...")
-        _kubectl_apply(rendered)
+        _kubectl_apply(cfg, rendered)
     click.echo(f"Waiting for deployment/{cfg.name} to become Ready...")
-    _kubectl("rollout", "status", f"deployment/{cfg.name}", "-n", k8s.namespace)
+    _kubectl(cfg, "rollout", "status", f"deployment/{cfg.name}", "-n", k8s.namespace)
     click.echo("finelog is healthy.")
 
 
@@ -225,6 +243,7 @@ def k8s_down(cfg: FinelogConfig, *, yes: bool) -> None:
     assert cfg.deployment.k8s is not None
     k8s = cfg.deployment.k8s
     _kubectl(
+        cfg,
         "delete",
         f"deployment/{cfg.name}",
         f"service/{cfg.name}",
@@ -234,6 +253,7 @@ def k8s_down(cfg: FinelogConfig, *, yes: bool) -> None:
     )
     if yes:
         _kubectl(
+            cfg,
             "delete",
             f"pvc/{cfg.name}-cache",
             "-n",
@@ -253,6 +273,7 @@ def k8s_restart(cfg: FinelogConfig) -> None:
     assert cfg.deployment.k8s is not None
     k8s = cfg.deployment.k8s
     _kubectl(
+        cfg,
         "set",
         "image",
         f"deployment/{cfg.name}",
@@ -260,7 +281,7 @@ def k8s_restart(cfg: FinelogConfig) -> None:
         "-n",
         k8s.namespace,
     )
-    _kubectl("rollout", "status", f"deployment/{cfg.name}", "-n", k8s.namespace)
+    _kubectl(cfg, "rollout", "status", f"deployment/{cfg.name}", "-n", k8s.namespace)
     click.echo("finelog is healthy.")
 
 
@@ -269,6 +290,7 @@ def k8s_status(cfg: FinelogConfig) -> None:
     assert cfg.deployment.k8s is not None
     k8s = cfg.deployment.k8s
     _kubectl(
+        cfg,
         "get",
         f"deployment/{cfg.name}",
         f"service/{cfg.name}",
@@ -291,4 +313,4 @@ def k8s_logs(cfg: FinelogConfig, *, tail: int, follow: bool) -> None:
     ]
     if follow:
         args.append("-f")
-    _kubectl(*args)
+    _kubectl(cfg, *args)

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -54,6 +54,12 @@ class K8sDeployment:
     """Kubernetes deployment knobs."""
 
     namespace: str
+    # Kubeconfig file and context every kubectl operation binds to. Unset falls
+    # back to kubectl's own resolution (KUBECONFIG env var or ~/.kube/config);
+    # setting both makes deploys independent of the operator's environment and
+    # of the file's current-context.
+    kubeconfig: str | None = None
+    kube_context: str | None = None
     storage_class: str | None = None
     storage_gb: int = 200
     # S3-compatible endpoint (e.g. Cloudflare R2) for an `s3://` remote_log_dir.
@@ -227,6 +233,8 @@ def _build_k8s(raw: dict) -> K8sDeployment:
     priority_class_value = raw.get("priority_class_value")
     return K8sDeployment(
         namespace=raw["namespace"],
+        kubeconfig=raw.get("kubeconfig"),
+        kube_context=raw.get("kube_context"),
         storage_class=raw.get("storage_class"),
         storage_gb=int(raw.get("storage_gb", 200)),
         object_storage_endpoint=raw.get("object_storage_endpoint"),
@@ -318,4 +326,10 @@ def tunnel_target_for(cfg: FinelogConfig) -> TunnelTarget:
         )
     assert cfg.deployment.k8s is not None  # guaranteed by Deployment.__post_init__
     k8s = cfg.deployment.k8s
-    return K8sPortForwardTarget(namespace=k8s.namespace, service=cfg.name, port=cfg.port)
+    return K8sPortForwardTarget(
+        namespace=k8s.namespace,
+        service=cfg.name,
+        port=cfg.port,
+        kubeconfig=str(Path(k8s.kubeconfig).expanduser()) if k8s.kubeconfig else None,
+        context=k8s.kube_context,
+    )

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -15,8 +15,9 @@
 #      Secret (addressing style is derived from the endpoint domain):
 #        export CW_KEY_ID=<coreweave-access-key-id>
 #        export CW_KEY_SECRET=<coreweave-access-key-secret>
-#   2. Point kubectl/iris at the region kubeconfig:
-#        export KUBECONFIG=~/.kube/coreweave-iris-rno2a   # context marin-rn02a_RNO2A
+#   2. Merge the region kubeconfigs (Console -> Tokens) into ~/.kube/coreweave-iris.
+#      Operations are bound to kube_context below, so no KUBECONFIG export and no
+#      current-context switching is needed.
 #   3. Start / inspect the cluster:
 #        uv run iris --cluster=cw-rno2a cluster start
 #        uv run iris --cluster=cw-rno2a cluster status
@@ -33,7 +34,8 @@ platform:
   coreweave:
     region: RNO2A
     namespace: iris
-    kubeconfig_path: ~/.kube/coreweave-iris-rno2a
+    kubeconfig_path: ~/.kube/coreweave-iris
+    kube_context: marin-rn02a_RNO2A
     # CoreWeave AI Object Storage via LOTA, the in-cluster local cache
     # endpoint (use https://cwobject.com from outside CoreWeave). Bare
     # endpoint only: buckets use virtual-hosted addressing

--- a/lib/iris/config/cw-rno2a.yaml
+++ b/lib/iris/config/cw-rno2a.yaml
@@ -15,7 +15,7 @@
 #      Secret (addressing style is derived from the endpoint domain):
 #        export CW_KEY_ID=<coreweave-access-key-id>
 #        export CW_KEY_SECRET=<coreweave-access-key-secret>
-#   2. Merge the region kubeconfigs (Console -> Tokens) into ~/.kube/coreweave-iris.
+#   2. Install the kubeconfig (Console -> Tokens) at ~/.kube/coreweave-iris.
 #      Operations are bound to kube_context below, so no KUBECONFIG export and no
 #      current-context switching is needed.
 #   3. Start / inspect the cluster:

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -16,7 +16,7 @@
 #      Secret (addressing style is derived from the endpoint domain):
 #        export CW_KEY_ID=<coreweave-access-key-id>
 #        export CW_KEY_SECRET=<coreweave-access-key-secret>
-#   2. Merge the region kubeconfigs (Console -> Tokens) into ~/.kube/coreweave-iris.
+#   2. Install the kubeconfig (Console -> Tokens) at ~/.kube/coreweave-iris.
 #      Operations are bound to kube_context below, so no KUBECONFIG export and no
 #      current-context switching is needed.
 #   3. Start / inspect the cluster:

--- a/lib/iris/config/cw-us-east-02a.yaml
+++ b/lib/iris/config/cw-us-east-02a.yaml
@@ -16,8 +16,9 @@
 #      Secret (addressing style is derived from the endpoint domain):
 #        export CW_KEY_ID=<coreweave-access-key-id>
 #        export CW_KEY_SECRET=<coreweave-access-key-secret>
-#   2. Point kubectl/iris at the region kubeconfig:
-#        export KUBECONFIG=~/.kube/coreweave-iris-gpu   # context marin-gpu_US-EAST-02A
+#   2. Merge the region kubeconfigs (Console -> Tokens) into ~/.kube/coreweave-iris.
+#      Operations are bound to kube_context below, so no KUBECONFIG export and no
+#      current-context switching is needed.
 #   3. Start / inspect the cluster:
 #        uv run iris --cluster=cw-us-east-02a cluster start
 #        uv run iris --cluster=cw-us-east-02a cluster status
@@ -39,7 +40,8 @@ platform:
   coreweave:
     region: US-EAST-02A
     namespace: iris
-    kubeconfig_path: ~/.kube/coreweave-iris-gpu
+    kubeconfig_path: ~/.kube/coreweave-iris
+    kube_context: marin-gpu_US-EAST-02A
     # CoreWeave AI Object Storage via LOTA, the in-cluster local cache
     # endpoint (use https://cwobject.com from outside CoreWeave). Bare
     # endpoint only: buckets use virtual-hosted addressing

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -9,10 +9,15 @@ the full operator runbook (RBAC, NodePools, Kueue, troubleshooting).
 
 Active clusters:
 
-| Iris cluster | CW cluster / region | Fleet | Kubeconfig |
-|--------------|---------------------|-------|------------|
-| `cw-us-east-02a` | `marin-gpu`, US-EAST-02A | 32× 8xH100 + 4× CPU Genoa, pinned warm | `~/.kube/coreweave-iris-gpu` |
-| `cw-rno2a` | `marin-rn02a`, RNO2A | 64× 8xH100 + 1× CPU Turin, pinned warm | `~/.kube/coreweave-iris-rno2a` |
+All clusters share one merged kubeconfig at `~/.kube/coreweave-iris`; each
+cluster config pins its own `kube_context` inside it, so iris/kubectl
+operations are context-bound per `--cluster` and never depend on the file's
+current-context or an exported `KUBECONFIG`.
+
+| Iris cluster | CW cluster / region | Fleet | Kube context |
+|--------------|---------------------|-------|--------------|
+| `cw-us-east-02a` | `marin-gpu`, US-EAST-02A | 32× 8xH100 + 4× CPU Genoa, pinned warm | `marin-gpu_US-EAST-02A` |
+| `cw-rno2a` | `marin-rn02a`, RNO2A | 64× 8xH100 + 1× CPU Turin, pinned warm | `marin-rn02a_RNO2A` |
 
 Console links:
 - Tokens (kubeconfig): https://console.coreweave.com/tokens
@@ -22,17 +27,25 @@ Console links:
 **1. Make a token / kubeconfig.** In the [Tokens console](https://console.coreweave.com/tokens),
 create a token for the cluster and download its kubeconfig.
 
-**2. Install the kubeconfig** at the path from the table above, plus controller
-extras:
+**2. Merge the kubeconfig** into `~/.kube/coreweave-iris` (CoreWeave-generated
+contexts are named `<cw-cluster>_<REGION>`, so region files merge without
+collisions), plus controller extras:
 
 ```bash
 mkdir -p ~/.kube
-mv ~/Downloads/kubeconfig.yaml ~/.kube/coreweave-iris-gpu
-export KUBECONFIG=~/.kube/coreweave-iris-gpu
-kubectl cluster-info   # sanity check
+# First cluster: just move it into place.
+mv ~/Downloads/kubeconfig.yaml ~/.kube/coreweave-iris
+# Additional clusters: merge into the existing file.
+KUBECONFIG=~/.kube/coreweave-iris:~/Downloads/kubeconfig.yaml \
+  kubectl config view --flatten > ~/.kube/coreweave-iris.merged \
+  && mv ~/.kube/coreweave-iris.merged ~/.kube/coreweave-iris
+kubectl --kubeconfig ~/.kube/coreweave-iris config get-contexts   # sanity check
 
 uv pip install 'marin-iris[controller]'
 ```
+
+No `KUBECONFIG` export is needed: the cluster configs pin `kubeconfig_path` and
+`kube_context`, and every operation binds to that context explicitly.
 
 That's all a job submitter needs. `CW_KEY_ID` / `CW_KEY_SECRET` (CoreWeave
 Object Storage access keys) are only required when running
@@ -386,11 +399,11 @@ re-run the install after it is Ready.
 
 ### Bringing up a new cluster
 
-1. Download the kubeconfig (§0) to `~/.kube/coreweave-iris-<region>` and export
-   `KUBECONFIG`, `CW_KEY_ID`, `CW_KEY_SECRET`.
+1. Download the kubeconfig (§0), merge it into `~/.kube/coreweave-iris`, and
+   export `CW_KEY_ID`, `CW_KEY_SECRET`.
 2. Copy an existing cluster config pair — `lib/iris/config/cw-*.yaml` and
-   `lib/finelog/config/cw-*.yaml` — and adjust region, instance types, and
-   fleet sizes. The console capacity view's display label is NOT the k8s
+   `lib/finelog/config/cw-*.yaml` — and adjust region, `kube_context`,
+   instance types, and fleet sizes. The console capacity view's display label is NOT the k8s
    `spec.instanceType` (e.g. "turin-gp-l4" vs `turin-gp-l`); to probe a SKU,
    create a NodePool with `minNodes: 0, maxNodes: 0, targetNodes: 0` and read
    its `Validated` condition (server dry-run accepts any string).
@@ -433,7 +446,7 @@ auto-tunneled CoreWeave commands fail before connecting:
 Fallback: manual port-forward if you need a long-lived tunnel:
 
 ```bash
-kubectl --kubeconfig ~/.kube/coreweave-iris \
+kubectl --kubeconfig ~/.kube/coreweave-iris --context <kube_context> \
   port-forward -n <namespace> svc/<service_name> 10000:10000 &
 iris --controller-url=http://localhost:10000 ...
 ```
@@ -593,6 +606,7 @@ in `CoreweavePlatform`):
 | `region` | string | — | CoreWeave region (e.g. `RNO2A`) |
 | `namespace` | string | `iris` | Kubernetes namespace for all resources |
 | `kubeconfig_path` | string | — | Only needed when running CLI outside the cluster |
+| `kube_context` | string | — | Kubeconfig context to bind every operation to; empty uses the file's current-context |
 | `object_storage_endpoint` | string | — | S3-compatible endpoint URL |
 
 ### CoreweaveControllerConfig
@@ -738,7 +752,7 @@ The platform detects fatal errors before the full timeout expires:
 
 | Variable | Purpose |
 |----------|---------|
-| `KUBECONFIG` | Path to kubeconfig (alternative to `kubeconfig_path` in config) |
+| `KUBECONFIG` | Overrides the config's `kubeconfig_path` (file only — the config's `kube_context` still binds the context) |
 | `CW_KEY_ID` | S3/CoreWeave Object Storage access key (required if storage uses `s3://`) |
 | `CW_KEY_SECRET` | S3/CoreWeave Object Storage secret key |
 | `CW_ACCESS_KEY_ID` | CoreWeave Object Storage key ID |
@@ -920,9 +934,10 @@ by polling.
 | Kubeconfig file | Operator's kubectl access | Console > Tokens > Download Kubeconfig |
 | CoreWeave Object Storage access key | S3-compatible access to CoreWeave buckets | Console > Object Storage > Access Keys |
 
-The `kubeconfig_path` config field is only needed when running the CLI
-**outside** the cluster (e.g., `iris cluster start` from a laptop). Inside the
-cluster, Pods use in-cluster auth automatically.
+The `kubeconfig_path` / `kube_context` config fields are only needed when
+running the CLI **outside** the cluster (e.g., `iris cluster start` from a
+laptop). Inside the cluster, Pods use in-cluster auth automatically (both
+fields are stripped from the `iris-cluster-config` ConfigMap).
 
 ## 15. Open Questions / Known Limitations
 

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -9,10 +9,10 @@ the full operator runbook (RBAC, NodePools, Kueue, troubleshooting).
 
 Active clusters:
 
-All clusters share one merged kubeconfig at `~/.kube/coreweave-iris`; each
-cluster config pins its own `kube_context` inside it, so iris/kubectl
-operations are context-bound per `--cluster` and never depend on the file's
-current-context or an exported `KUBECONFIG`.
+All clusters share one kubeconfig at `~/.kube/coreweave-iris`; each cluster
+config pins its own `kube_context` inside it, so iris/kubectl operations are
+context-bound per `--cluster` and never depend on the file's current-context
+or an exported `KUBECONFIG`.
 
 | Iris cluster | CW cluster / region | Fleet | Kube context |
 |--------------|---------------------|-------|--------------|
@@ -25,20 +25,15 @@ Console links:
 - Health dashboard: https://cks-grafana.coreweave.com/d/cluster-health/cluster-health?var-cluster-org=208261&var-cluster=marin-gpu&var-region=US-EAST-02
 
 **1. Make a token / kubeconfig.** In the [Tokens console](https://console.coreweave.com/tokens),
-create a token for the cluster and download its kubeconfig.
+create a token and download the kubeconfig — it carries a context per cluster
+(named `<cw-cluster>_<REGION>`).
 
-**2. Merge the kubeconfig** into `~/.kube/coreweave-iris` (CoreWeave-generated
-contexts are named `<cw-cluster>_<REGION>`, so region files merge without
-collisions), plus controller extras:
+**2. Install the kubeconfig** at `~/.kube/coreweave-iris`, plus controller
+extras:
 
 ```bash
 mkdir -p ~/.kube
-# First cluster: just move it into place.
 mv ~/Downloads/kubeconfig.yaml ~/.kube/coreweave-iris
-# Additional clusters: merge into the existing file.
-KUBECONFIG=~/.kube/coreweave-iris:~/Downloads/kubeconfig.yaml \
-  kubectl config view --flatten > ~/.kube/coreweave-iris.merged \
-  && mv ~/.kube/coreweave-iris.merged ~/.kube/coreweave-iris
 kubectl --kubeconfig ~/.kube/coreweave-iris config get-contexts   # sanity check
 
 uv pip install 'marin-iris[controller]'
@@ -399,8 +394,8 @@ re-run the install after it is Ready.
 
 ### Bringing up a new cluster
 
-1. Download the kubeconfig (§0), merge it into `~/.kube/coreweave-iris`, and
-   export `CW_KEY_ID`, `CW_KEY_SECRET`.
+1. Install the kubeconfig (§0) at `~/.kube/coreweave-iris` and export
+   `CW_KEY_ID`, `CW_KEY_SECRET`.
 2. Copy an existing cluster config pair — `lib/iris/config/cw-*.yaml` and
    `lib/finelog/config/cw-*.yaml` — and adjust region, `kube_context`,
    instance types, and fleet sizes. The console capacity view's display label is NOT the k8s

--- a/lib/iris/src/iris/cluster/composer.py
+++ b/lib/iris/src/iris/cluster/composer.py
@@ -108,7 +108,11 @@ def make_task_backend(
         local_queue = local_queue_name(label_prefix) if kp.kueue.cluster_queue else ""
         env_secret_name = TASK_ENV_SECRET_NAME if projects_task_env_secret(config) else ""
         return K8sTaskProvider(
-            kubectl=CloudK8sService(namespace=namespace, kubeconfig_path=kp.kubeconfig or None),
+            kubectl=CloudK8sService(
+                namespace=namespace,
+                kubeconfig_path=kp.kubeconfig or None,
+                context=kp.kube_context or None,
+            ),
             namespace=namespace,
             default_image=kp.default_image,
             logship_image=config.controller.image,

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -204,6 +204,7 @@ class CoreweavePlatformConfig(_Config):
     region: str = ""
     namespace: str = ""  # default: "iris"
     kubeconfig_path: str = ""  # optional; in-cluster auth if empty
+    kube_context: str = ""  # kubeconfig context to bind to; empty = the file's current-context
     object_storage_endpoint: str = ""  # S3 base endpoint, not bucket-specific
 
 
@@ -592,6 +593,7 @@ class KueueConfig(_Config):
 class KubernetesProviderConfig(_Config):
     namespace: str = ""  # default: "iris"
     kubeconfig: str = ""  # empty = in-cluster auth
+    kube_context: str = ""  # kubeconfig context to bind to; empty = the file's current-context
     default_image: str = ""
     service_account: str = ""
     host_network: bool = False

--- a/lib/iris/src/iris/cluster/platforms/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/controller.py
@@ -351,9 +351,13 @@ class K8sControllerProvider:
         if kubectl is not None:
             self._kubectl: K8sService = kubectl
         else:
+            # KUBECONFIG (when exported) picks the file, but the configured context
+            # always binds — so a stale env var cannot redirect operations to
+            # whatever cluster that file's current-context happens to point at.
             self._kubectl = CloudK8sService(
                 namespace=self._namespace,
                 kubeconfig_path=None if os.environ.get("KUBECONFIG") else (config.kubeconfig_path or None),
+                context=config.kube_context or None,
                 timeout=_KUBECTL_TIMEOUT,
             )
         self._poll_interval = poll_interval
@@ -1153,4 +1157,5 @@ class K8sControllerProvider:
         config_dict = config_to_dict(config)
         cw_dict = config_dict.get("platform", {}).get("coreweave", {})
         cw_dict.pop("kubeconfig_path", None)
+        cw_dict.pop("kube_context", None)
         return json.dumps(config_dict)

--- a/lib/iris/src/iris/cluster/platforms/k8s/service.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/service.py
@@ -182,6 +182,7 @@ class CloudK8sService:
 
     namespace: str
     kubeconfig_path: str | None = None
+    context: str | None = None  # kubeconfig context; None = the file's current-context
     timeout: float = DEFAULT_TIMEOUT
     _api_client: "kubernetes.client.ApiClient" = field(init=False, repr=False)
     _dyn: "DynamicClient" = field(init=False, repr=False)
@@ -205,12 +206,17 @@ class CloudK8sService:
         cmd = ["kubectl"]
         if self.kubeconfig_path:
             cmd.extend(["--kubeconfig", self.kubeconfig_path])
+        if self.context:
+            cmd.extend(["--context", self.context])
         self._kubectl_prefix = cmd
 
     def create_api_client(self) -> "kubernetes.client.ApiClient":
-        if self.kubeconfig_path:
+        # A bare context (no kubeconfig_path) binds the named context within the
+        # default kubeconfig resolution (KUBECONFIG env var or ~/.kube/config).
+        if self.kubeconfig_path or self.context:
             return kubernetes.config.new_client_from_config(
                 config_file=self.kubeconfig_path,
+                context=self.context,
             )
 
         try:

--- a/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_coreweave.py
@@ -547,17 +547,19 @@ def test_start_controller_deployment_command_references_config_json():
 
 
 def test_configmap_strips_kubeconfig_path():
-    """ConfigMap must not contain kubeconfig_path so pods use in-cluster auth."""
+    """ConfigMap must not contain kubeconfig_path/kube_context so pods use in-cluster auth."""
     k8s = InMemoryK8sService(namespace="iris")
     cw_config = CoreweavePlatformConfig(
         region="LGA1",
         namespace="iris",
         kubeconfig_path="/home/user/.kube/coreweave-iris",
+        kube_context="marin_LGA1",
     )
     provider = K8sControllerProvider(config=cw_config, label_prefix="iris", poll_interval=0.05, kubectl=k8s)
 
     cluster_config = _make_cluster_config()
     cluster_config.platform.coreweave.kubeconfig_path = "/home/user/.kube/coreweave-iris"
+    cluster_config.platform.coreweave.kube_context = "marin_LGA1"
 
     t = threading.Thread(target=_auto_ready_deployment, args=(k8s, "iris-controller"), daemon=True)
     t.start()
@@ -568,6 +570,7 @@ def test_configmap_strips_kubeconfig_path():
     cm_data = json.loads(cm["data"]["config.json"])
     cw_config_data = cm_data.get("platform", {}).get("coreweave", {})
     assert "kubeconfig_path" not in cw_config_data
+    assert "kube_context" not in cw_config_data
 
     t.join(timeout=5)
     provider.shutdown()

--- a/lib/iris/tests/e2e/gpu_gang_smoke.py
+++ b/lib/iris/tests/e2e/gpu_gang_smoke.py
@@ -178,7 +178,10 @@ class ControllerTarget:
         )
 
     def _kc(self, *args: str) -> list[str]:
-        return ["kubectl", "--kubeconfig", self.kubeconfig, *args]
+        cmd = ["kubectl", "--kubeconfig", self.kubeconfig]
+        if self.kube_context:
+            cmd.extend(["--context", self.kube_context])
+        return [*cmd, *args]
 
     def _ensure_namespace(self) -> None:
         # Teardown deletes the namespace asynchronously; if a prior run's namespace

--- a/lib/iris/tests/e2e/gpu_gang_smoke.py
+++ b/lib/iris/tests/e2e/gpu_gang_smoke.py
@@ -153,6 +153,7 @@ class ControllerTarget:
         self.namespace = cfg.kubernetes_provider.namespace
         self.label_prefix = cfg.platform.label_prefix
         self.kubeconfig = str(Path(cfg.platform.coreweave.kubeconfig_path).expanduser())
+        self.kube_context = cfg.platform.coreweave.kube_context or None
         # k8s clients are built lazily by _connect() AFTER setup() finalizes the
         # kubeconfig — kind assigns a fresh API-server port on each cluster create,
         # so a client built against a stale kubeconfig would hit a dead port.
@@ -162,10 +163,15 @@ class ControllerTarget:
 
     def _connect(self) -> None:
         """(Re)build the k8s clients against the current kubeconfig."""
-        self.kubectl = CloudK8sService(namespace=self.namespace, kubeconfig_path=self.kubeconfig)
+        self.kubectl = CloudK8sService(
+            namespace=self.namespace, kubeconfig_path=self.kubeconfig, context=self.kube_context
+        )
         self.controller = K8sControllerProvider(
             config=CoreweavePlatformConfig(
-                region=self.cfg.platform.coreweave.region, namespace=self.namespace, kubeconfig_path=self.kubeconfig
+                region=self.cfg.platform.coreweave.region,
+                namespace=self.namespace,
+                kubeconfig_path=self.kubeconfig,
+                kube_context=self.kube_context or "",
             ),
             label_prefix=self.label_prefix,
             kubectl=self.kubectl,

--- a/scripts/iris/dev_gpu.py
+++ b/scripts/iris/dev_gpu.py
@@ -63,10 +63,12 @@ class PodRef:
 
 @dataclass(frozen=True)
 class CoreweaveTarget:
-    """Cluster-level kubectl target. Empty kubeconfig_path => kubectl default resolution."""
+    """Cluster-level kubectl target. Empty kubeconfig_path => kubectl default resolution;
+    empty kube_context => the file's current-context."""
 
     namespace: str
     kubeconfig_path: str
+    kube_context: str = ""
 
 
 @dataclass(frozen=True)
@@ -116,7 +118,11 @@ def require_coreweave_platform(config: IrisClusterConfig) -> CoreweaveTarget:
     namespace = (kp.namespace if kp is not None else "") or "iris"
     cw_kubeconfig = config.platform.coreweave.kubeconfig_path
     kubeconfig_path = os.path.expanduser(cw_kubeconfig) if cw_kubeconfig else ""
-    return CoreweaveTarget(namespace=namespace, kubeconfig_path=kubeconfig_path)
+    return CoreweaveTarget(
+        namespace=namespace,
+        kubeconfig_path=kubeconfig_path,
+        kube_context=config.platform.coreweave.kube_context,
+    )
 
 
 def pod_label_selector(task_id: str) -> str:
@@ -128,6 +134,8 @@ def kubectl_base(target: CoreweaveTarget) -> list[str]:
     cmd = ["kubectl"]
     if target.kubeconfig_path:
         cmd.append(f"--kubeconfig={target.kubeconfig_path}")
+    if target.kube_context:
+        cmd.append(f"--context={target.kube_context}")
     cmd.append(f"--namespace={target.namespace}")
     return cmd
 


### PR DESCRIPTION
* all coreweave clusters now share one merged kubeconfig (`~/.kube/coreweave-iris`); each cluster yaml pins its own `kube_context`, so `--cluster=<name>` is context-bound and independent of the file's current-context
* previously `--cluster` operations used the kubeconfig's current-context, and an exported `KUBECONFIG` silently discarded the config's `kubeconfig_path` — e.g. `iris --cluster=cw-rno2a` could port-forward into the us-east-02a cluster
* add `kube_context` to `CoreweavePlatformConfig` and `KubernetesProviderConfig`; `CloudK8sService` binds it in the python k8s client (`new_client_from_config(context=...)`) and the `kubectl port-forward` prefix
  * `KUBECONFIG` (when exported) can still pick the *file*, but the configured context always binds
  * `kubeconfig_path`/`kube_context` are stripped from the in-cluster ConfigMap so pods keep in-cluster auth
* finelog: `deployment.k8s` gains `kubeconfig`/`kube_context`; every `kubectl` shell-out in `deploy/_k8s.py` and the deploy tunnel target now pass `--kubeconfig`/`--context` instead of relying on the operator's environment
* thread `--context` through `dev_gpu.py` and `gpu_gang_smoke.py` raw kubectl calls
* update `coreweave.md` quickstart + reserve-gpu skill for the merged-kubeconfig setup (no `KUBECONFIG` export needed)