### PR TITLE
ducky: restart-survivable result caching

### DIFF
--- a/lib/ducky/README.md
+++ b/lib/ducky/README.md
@@ -22,15 +22,14 @@ GET  /proxy/ducky/result/<id>
 Pass `{"use_cache": false}` on the POST to force a fresh run (by default an identical prior
 query's result is reused).
 
-Result caching is two-tier and **survives restarts**. An exact-SQL repeat is served first from a
-process-local in-memory cache (`DUCKY_MAX_CACHE_ENTRIES`), and on a miss from a small
-`ducky/cache/<sql_hash>.meta.parquet` sidecar ducky writes next to each spilled result — so a
-repeat query returns instantly without re-scanning the source even after the (preemptible) service
-restarts and drops its in-memory cache. The sidecar shares the `ducky/` prefix, so the scratch
-bucket's lifecycle rule reaps it alongside the result it points at; a hit older than
-`result_ttl_days` is ignored. Set `DUCKY_PERSIST_CACHE=0` to disable the persistent tier. Caching
-keys on the exact SQL text, so identical SQL reuses a prior result even if the underlying data
-changed — use `use_cache: false` to force a fresh read.
+Result caching lives in the scratch bucket, so it **survives restarts**. Next to each spilled
+result ducky writes a small `ducky/cache/<sql_hash>.meta.parquet` sidecar; on an exact-SQL repeat
+it reads that sidecar back and returns the result without re-scanning the source — even after the
+(preemptible) service restarts. The sidecar shares the `ducky/` prefix, so the scratch bucket's
+lifecycle rule reaps it alongside the result it points at; a hit older than `result_ttl_days` is
+ignored. Set `DUCKY_PERSIST_CACHE=0` to disable caching. Caching keys on the exact SQL text, so
+identical SQL reuses a prior result even if the underlying data changed — use `use_cache: false`
+to force a fresh read.
 
 ### From the CLI (auto-tunnel)
 

--- a/lib/ducky/README.md
+++ b/lib/ducky/README.md
@@ -22,6 +22,16 @@ GET  /proxy/ducky/result/<id>
 Pass `{"use_cache": false}` on the POST to force a fresh run (by default an identical prior
 query's result is reused).
 
+Result caching is two-tier and **survives restarts**. An exact-SQL repeat is served first from a
+process-local in-memory cache (`DUCKY_MAX_CACHE_ENTRIES`), and on a miss from a small
+`ducky/cache/<sql_hash>.meta.parquet` sidecar ducky writes next to each spilled result — so a
+repeat query returns instantly without re-scanning the source even after the (preemptible) service
+restarts and drops its in-memory cache. The sidecar shares the `ducky/` prefix, so the scratch
+bucket's lifecycle rule reaps it alongside the result it points at; a hit older than
+`result_ttl_days` is ignored. Set `DUCKY_PERSIST_CACHE=0` to disable the persistent tier. Caching
+keys on the exact SQL text, so identical SQL reuses a prior result even if the underlying data
+changed — use `use_cache: false` to force a fresh read.
+
 ### From the CLI (auto-tunnel)
 
 ```bash

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -62,6 +62,15 @@ DEFAULT_DATAKIT_ROOT = "gs://marin-us-east5/normalized"
 _MARIN_PREFIX_ENV = "MARIN_PREFIX"
 
 
+def _env_bool(name: str, default: bool) -> bool:
+    """Parse a boolean ``DUCKY_*`` env var; unset returns ``default``, anything else is
+    truthy unless it is a recognized false token."""
+    value = os.environ.get(name)
+    if value is None:
+        return default
+    return value.strip().lower() not in ("", "0", "false", "no", "off")
+
+
 def _resolve_datakit_root() -> str | None:
     """Datakit normalized-parquet root: explicit DUCKY_DATAKIT_ROOT wins (empty disables),
     else ``<MARIN_PREFIX>/normalized`` when MARIN_PREFIX is set, else the fallback constant."""
@@ -140,6 +149,16 @@ class DuckyConfig:
     """How many queries run at once. Each gets its own DuckDB cursor (sharing the instance's
     secrets/settings); they share the host's thread pool and memory budget."""
 
+    max_cache_entries: int = 2048
+    """LRU capacity of the in-memory result cache (identical-SQL → prior result). The workload
+    is heavily repeat-query (historically ~60% of submissions re-run an earlier exact SQL) and
+    dominated by high-latency object-store scans, so a hit turns a multi-second re-scan into an
+    instant reply. Each entry is cheap — it holds only the capped preview plus the spilled
+    result's GCS path (the full result already lives in the scratch bucket), not the full
+    result — so this can be large on the big-RAM host without meaningful memory cost. Sized well
+    above the distinct-query working set between restarts; the cache is process-local and drops
+    on restart."""
+
     query_timeout: int = 600
     """Hard per-query wall-clock limit (seconds). A query exceeding it is interrupted and
     fails — so a runaway (e.g. a recursive glob over millions of objects) frees its slot
@@ -147,6 +166,16 @@ class DuckyConfig:
 
     result_ttl_days: int = 7
     """Informational — enforced by the scratch bucket's lifecycle rule, not by ducky (ducky only writes)."""
+
+    persist_cache: bool = True
+    """Whether to back the in-memory result cache with a restart-survivable tier in the scratch
+    bucket. On a fresh run ducky writes a small ``<sql_hash>.meta.parquet`` sidecar next to the
+    spilled result; on a miss in the (process-local) in-memory cache it reads that sidecar back,
+    turning a repeat query into an instant reply without re-scanning the source — even across the
+    restarts that drop the in-memory cache. The sidecar shares the ``ducky/`` prefix, so the
+    scratch bucket's lifecycle rule reaps it with the result it points at; a read past
+    ``result_ttl_days`` is dropped. Best-effort: any sidecar read/write failure falls back to a
+    normal run and never fails a user query."""
 
     @property
     def catalog_root_prefixes(self) -> tuple[str, ...]:
@@ -215,10 +244,12 @@ class DuckyConfig:
             max_concurrent_queries=int(
                 os.environ.get(f"{_ENV_PREFIX}MAX_CONCURRENT_QUERIES", cls.max_concurrent_queries)
             ),
+            max_cache_entries=int(os.environ.get(f"{_ENV_PREFIX}MAX_CACHE_ENTRIES", cls.max_cache_entries)),
             spill_directory=os.environ.get(f"{_ENV_PREFIX}SPILL_DIR", cls.spill_directory),
             spill_limit=os.environ.get(f"{_ENV_PREFIX}SPILL_LIMIT", cls.spill_limit),
             query_timeout=int(os.environ.get(f"{_ENV_PREFIX}QUERY_TIMEOUT", cls.query_timeout)),
             result_ttl_days=int(os.environ.get(f"{_ENV_PREFIX}RESULT_TTL_DAYS", cls.result_ttl_days)),
+            persist_cache=_env_bool(f"{_ENV_PREFIX}PERSIST_CACHE", cls.persist_cache),
             r2_scope=os.environ.get(f"{_ENV_PREFIX}R2_SCOPE", cls.r2_scope),
             cw_scope=os.environ.get(f"{_ENV_PREFIX}CW_SCOPE", cls.cw_scope),
             finelog_root=os.environ.get(f"{_ENV_PREFIX}FINELOG_ROOT", DEFAULT_FINELOG_ROOT) or None,

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -149,16 +149,6 @@ class DuckyConfig:
     """How many queries run at once. Each gets its own DuckDB cursor (sharing the instance's
     secrets/settings); they share the host's thread pool and memory budget."""
 
-    max_cache_entries: int = 2048
-    """LRU capacity of the in-memory result cache (identical-SQL → prior result). The workload
-    is heavily repeat-query (historically ~60% of submissions re-run an earlier exact SQL) and
-    dominated by high-latency object-store scans, so a hit turns a multi-second re-scan into an
-    instant reply. Each entry is cheap — it holds only the capped preview plus the spilled
-    result's GCS path (the full result already lives in the scratch bucket), not the full
-    result — so this can be large on the big-RAM host without meaningful memory cost. Sized well
-    above the distinct-query working set between restarts; the cache is process-local and drops
-    on restart."""
-
     query_timeout: int = 600
     """Hard per-query wall-clock limit (seconds). A query exceeding it is interrupted and
     fails — so a runaway (e.g. a recursive glob over millions of objects) frees its slot
@@ -167,8 +157,8 @@ class DuckyConfig:
     result_ttl_days: int = 7
     """Retention of spilled results: ducky never deletes them — the scratch bucket's lifecycle
     rule does — but ducky reads this to bound cache reuse against that reaping. It's the max age of
-    a persistent-cache hit (a sidecar older than this is ignored, since its spilled result may
-    already be gone) and, as ``result_ttl_days * 86400``, the in-memory result cache's TTL."""
+    a cache hit: a sidecar older than this is ignored, since its spilled result may already be
+    reaped."""
 
     persist_cache: bool = True
     """Whether to back the in-memory result cache with a restart-survivable tier in the scratch
@@ -247,7 +237,6 @@ class DuckyConfig:
             max_concurrent_queries=int(
                 os.environ.get(f"{_ENV_PREFIX}MAX_CONCURRENT_QUERIES", cls.max_concurrent_queries)
             ),
-            max_cache_entries=int(os.environ.get(f"{_ENV_PREFIX}MAX_CACHE_ENTRIES", cls.max_cache_entries)),
             spill_directory=os.environ.get(f"{_ENV_PREFIX}SPILL_DIR", cls.spill_directory),
             spill_limit=os.environ.get(f"{_ENV_PREFIX}SPILL_LIMIT", cls.spill_limit),
             query_timeout=int(os.environ.get(f"{_ENV_PREFIX}QUERY_TIMEOUT", cls.query_timeout)),

--- a/lib/ducky/src/ducky/config.py
+++ b/lib/ducky/src/ducky/config.py
@@ -165,7 +165,10 @@ class DuckyConfig:
     instead of holding it forever."""
 
     result_ttl_days: int = 7
-    """Informational — enforced by the scratch bucket's lifecycle rule, not by ducky (ducky only writes)."""
+    """Retention of spilled results: ducky never deletes them — the scratch bucket's lifecycle
+    rule does — but ducky reads this to bound cache reuse against that reaping. It's the max age of
+    a persistent-cache hit (a sidecar older than this is ignored, since its spilled result may
+    already be gone) and, as ``result_ttl_days * 86400``, the in-memory result cache's TTL."""
 
     persist_cache: bool = True
     """Whether to back the in-memory result cache with a restart-survivable tier in the scratch

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -17,6 +17,8 @@ exceeds ``query_timeout``.
 from __future__ import annotations
 
 import dataclasses
+import hashlib
+import json
 import logging
 import math
 import os
@@ -27,6 +29,7 @@ import time
 from collections.abc import Callable
 
 import duckdb
+import pyarrow as pa
 from iris.env_resources import TaskResources
 from rigging.filesystem import (
     MARIN_CROSS_REGION_OVERRIDE_ENV,
@@ -43,6 +46,19 @@ logger = logging.getLogger(__name__)
 
 # query_id is interpolated into the result path, so it must be a bare uuid4 hex.
 _QUERY_ID_RE = re.compile(r"^[0-9a-f]{32}$")
+
+# Sub-prefix under `<scratch>/ducky/` for the restart-survivable cache sidecars — one small
+# parquet per distinct SQL, named by its hash, holding the metadata needed to rebuild a
+# QueryResult without re-executing. Kept under the same `ducky/` prefix so the scratch bucket's
+# lifecycle rule reaps a sidecar together with the result it points at.
+_CACHE_SUBDIR = "cache"
+
+
+def _sql_hash(sql: str) -> str:
+    """Content-address a query by the exact SQL text — the same identity the in-memory cache
+    keys on. A hex digest is filesystem-safe, so it can't inject into the sidecar path."""
+    return hashlib.sha256(sql.encode("utf-8")).hexdigest()
+
 
 # Object-store URIs referenced in the SQL (read_parquet('gs://…'), etc.). Stops at the
 # closing quote/paren/whitespace of the SQL literal.
@@ -271,11 +287,11 @@ class QueryRunner:
         self._con.execute(f"SET max_temp_directory_size = {_sql_literal(config.spill_limit)}")
         logger.info("DuckDB configured: threads=%d memory_limit_bytes=%d", threads, memory_limit_bytes)
         self._install_secrets()
-        # A local scratch dir (smoke deploy / tests) needs the ducky/ subdir to exist;
+        # A local scratch dir (smoke deploy / tests) needs the ducky/ subdirs to exist;
         # object stores create the prefix implicitly.
         scratch_is_remote = "://" in config.scratch_bucket
         if not scratch_is_remote:
-            os.makedirs(f"{config.scratch_bucket.rstrip('/')}/ducky", exist_ok=True)
+            os.makedirs(f"{config.scratch_bucket.rstrip('/')}/ducky/{_CACHE_SUBDIR}", exist_ok=True)
         # Harden: when results go to object storage, block user SQL from touching the local
         # filesystem (e.g. read_text('/proc/self/environ') to exfil the injected creds). Object
         # stores are separate DuckDB filesystems and spilling is internal, so both still work.
@@ -442,7 +458,7 @@ class QueryRunner:
 
         columns = list(preview.column_names)
         preview_rows = [[_coerce_cell(row[col]) for col in columns] for row in preview.to_pylist()]
-        return QueryResult(
+        result = QueryResult(
             columns=columns,
             preview_rows=preview_rows,
             total_rows=total_rows,
@@ -450,6 +466,77 @@ class QueryRunner:
             result_path=result_path,
             elapsed_ms=elapsed_ms,
             result_bytes=result_bytes,
+        )
+        if self._config.persist_cache:
+            self._write_persistent_cache(sql, result)
+        return result
+
+    def _sidecar_path(self, sql: str) -> str:
+        """Scratch-bucket path of the cache sidecar for ``sql`` (content-addressed by SQL hash)."""
+        return f"{self._config.scratch_bucket.rstrip('/')}/ducky/{_CACHE_SUBDIR}/{_sql_hash(sql)}.meta.parquet"
+
+    def _write_persistent_cache(self, sql: str, result: QueryResult) -> None:
+        """Write the restart-survivable cache sidecar for ``sql`` (best-effort).
+
+        Stores everything needed to rebuild ``result`` without re-running the query: the capped
+        preview (already JSON-coercible scalars) and stats as a one-row parquet, plus the
+        wall-clock write time so a stale entry can be dropped on read. Written after the result
+        parquet, so its presence marks a complete result; a failure here only forfeits the future
+        cache hit — it must never fail the query that just succeeded."""
+        sidecar = pa.table(
+            {
+                "written_at": [time.time()],
+                "columns_json": [json.dumps(result.columns)],
+                "preview_json": [json.dumps(result.preview_rows)],
+                "total_rows": [result.total_rows],
+                "truncated": [result.truncated],
+                "result_path": [result.result_path],
+                "elapsed_ms": [result.elapsed_ms],
+                "result_bytes": [result.result_bytes],
+            }
+        )
+        try:
+            cursor = self._con.cursor()
+            try:
+                cursor.from_arrow(sidecar).write_parquet(self._sidecar_path(sql))
+            finally:
+                cursor.close()
+        except (duckdb.Error, OSError) as e:
+            logger.warning("failed to write persistent cache sidecar: %s", str(e).splitlines()[0])
+
+    def lookup_persistent(self, sql: str) -> QueryResult | None:
+        """Return a restart-survivable cached result for ``sql``, or None on miss/staleness.
+
+        Reads the sidecar written by a prior run (surviving the restarts that clear the in-memory
+        cache) and rebuilds the ``QueryResult`` — no source scan. Returns None if the sidecar is
+        absent, unreadable, or older than ``result_ttl_days`` (its result parquet may have been
+        reaped by the scratch bucket's lifecycle rule). Fails open: any error is a miss, so a
+        hiccup here just falls back to a normal run."""
+        if not self._config.persist_cache:
+            return None
+        try:
+            cursor = self._con.cursor()
+            try:
+                row = cursor.execute(
+                    "SELECT written_at, columns_json, preview_json, total_rows, truncated, "
+                    f"result_path, elapsed_ms, result_bytes FROM read_parquet({_sql_literal(self._sidecar_path(sql))})"
+                ).fetchone()
+            finally:
+                cursor.close()
+        except duckdb.Error:
+            return None  # absent or unreadable sidecar → miss
+        if row is None:
+            return None
+        if (time.time() - float(row[0])) > self._config.result_ttl_days * 86400:
+            return None  # past the TTL; the spilled result may already be gone
+        return QueryResult(
+            columns=json.loads(row[1]),
+            preview_rows=json.loads(row[2]),
+            total_rows=int(row[3]),
+            truncated=bool(row[4]),
+            result_path=row[5],
+            elapsed_ms=int(row[6]),
+            result_bytes=int(row[7]),
         )
 
     def close(self) -> None:

--- a/lib/ducky/src/ducky/runner.py
+++ b/lib/ducky/src/ducky/runner.py
@@ -37,6 +37,7 @@ from rigging.filesystem import (
     cached_marin_region,
     get_bucket_location,
     is_cross_region_url,
+    prefix_join,
 )
 
 from ducky.catalog import DATAKIT_SCHEMA, FINELOG_SCHEMA, View, build_catalog
@@ -291,7 +292,7 @@ class QueryRunner:
         # object stores create the prefix implicitly.
         scratch_is_remote = "://" in config.scratch_bucket
         if not scratch_is_remote:
-            os.makedirs(f"{config.scratch_bucket.rstrip('/')}/ducky/{_CACHE_SUBDIR}", exist_ok=True)
+            os.makedirs(prefix_join(config.scratch_bucket, f"ducky/{_CACHE_SUBDIR}"), exist_ok=True)
         # Harden: when results go to object storage, block user SQL from touching the local
         # filesystem (e.g. read_text('/proc/self/environ') to exfil the injected creds). Object
         # stores are separate DuckDB filesystems and spilling is internal, so both still work.
@@ -418,7 +419,7 @@ class QueryRunner:
             needs_cross_region_optin,
         )
 
-        result_path = f"{self._config.scratch_bucket.rstrip('/')}/ducky/{query_id}.parquet"
+        result_path = prefix_join(self._config.scratch_bucket, f"ducky/{query_id}.parquet")
         path_literal = _sql_literal(result_path)
         # hive_partitioning=false: the scratch path embeds a `tmp/ttl=Nd/` segment, which
         # DuckDB would otherwise read back as a phantom `ttl` partition column.
@@ -473,7 +474,7 @@ class QueryRunner:
 
     def _sidecar_path(self, sql: str) -> str:
         """Scratch-bucket path of the cache sidecar for ``sql`` (content-addressed by SQL hash)."""
-        return f"{self._config.scratch_bucket.rstrip('/')}/ducky/{_CACHE_SUBDIR}/{_sql_hash(sql)}.meta.parquet"
+        return prefix_join(self._config.scratch_bucket, f"ducky/{_CACHE_SUBDIR}/{_sql_hash(sql)}.meta.parquet")
 
     def _write_persistent_cache(self, sql: str, result: QueryResult) -> None:
         """Write the restart-survivable cache sidecar for ``sql`` (best-effort).
@@ -511,7 +512,13 @@ class QueryRunner:
         cache) and rebuilds the ``QueryResult`` — no source scan. Returns None if the sidecar is
         absent, unreadable, or older than ``result_ttl_days`` (its result parquet may have been
         reaped by the scratch bucket's lifecycle rule). Fails open: any error is a miss, so a
-        hiccup here just falls back to a normal run."""
+        hiccup here just falls back to a normal run.
+
+        A hit is served only if the SQL still passes the *current* access policy: because the
+        persistent tier outlives the restart that re-reads config, a sidecar written under a looser
+        policy must not keep serving SQL that a tightened ``allowed_buckets``/region policy would
+        now refuse. The check runs against live config and raises (as a fresh run would) rather
+        than returning a stale-authorized result."""
         if not self._config.persist_cache:
             return None
         try:
@@ -529,6 +536,13 @@ class QueryRunner:
             return None
         if (time.time() - float(row[0])) > self._config.result_ttl_days * 86400:
             return None  # past the TTL; the spilled result may already be gone
+        # Re-enforce the current egress/region policy on the cached SQL before serving it.
+        check_query_access(
+            sql,
+            self._config.effective_allowed_buckets,
+            self._config.catalog_root_prefixes,
+            needs_cross_region_optin,
+        )
         return QueryResult(
             columns=json.loads(row[1]),
             preview_rows=json.loads(row[2]),

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -152,7 +152,7 @@ class QueryManager:
             self._record(query_id, sql, hit_state)
             return query_id
         logger.info("query %s submitted: %s", query_id, _log_sql(sql))
-        self._executor.submit(self._run, sql, query_id)
+        self._executor.submit(self._run, sql, query_id, use_cache)
         return query_id
 
     def get(self, query_id: str) -> QueryState | None:
@@ -176,9 +176,15 @@ class QueryManager:
         self._cache.move_to_end(sql)  # LRU: a hit keeps the entry fresh against eviction
         return result
 
-    def _run(self, sql: str, query_id: str) -> None:
+    def _run(self, sql: str, query_id: str, use_cache: bool = True) -> None:
         try:
-            result = self._runner.run_query(sql, query_id)
+            # Restart-survivable tier: on an in-memory miss, a sidecar left by a prior run (before
+            # the restart that cleared the in-memory cache) rebuilds the result without re-scanning
+            # the source. A hit here is still a "cached" reply; a miss falls through to a fresh run.
+            result = self._runner.lookup_persistent(sql) if use_cache else None
+            from_cache = result is not None
+            if result is None:
+                result = self._runner.run_query(sql, query_id)
         except DuckyError as e:
             logger.warning("query %s failed: %s", query_id, str(e).splitlines()[0])
             error_state = QueryState(QueryStatus.ERROR, error=str(e))
@@ -194,13 +200,14 @@ class QueryManager:
             self._record(query_id, sql, error_state)
             return
         logger.info(
-            "query %s done: %d rows, %s, %d ms",
+            "query %s %s: %d rows, %s, %d ms",
             query_id,
+            "persistent-cache hit" if from_cache else "done",
             result.total_rows,
             _human_bytes(result.result_bytes),
             result.elapsed_ms,
         )
-        done_state = QueryState(QueryStatus.DONE, result=result, cached=False)
+        done_state = QueryState(QueryStatus.DONE, result=result, cached=from_cache)
         with self._lock:
             self._store_cache(sql, result)
             self._set_state(query_id, done_state)
@@ -329,6 +336,7 @@ def create_app(
         executor=executor,
         max_workers=config.max_concurrent_queries,
         cache_ttl=config.result_ttl_days * 86400,
+        max_cache_entries=config.max_cache_entries,
         query_log=query_log,
     )
 

--- a/lib/ducky/src/ducky/server.py
+++ b/lib/ducky/src/ducky/server.py
@@ -92,9 +92,7 @@ class QueryManager:
         runner: QueryRunner,
         executor: Executor | None = None,
         max_workers: int = 8,
-        cache_ttl: float = 0.0,
         max_retained_states: int = 1024,
-        max_cache_entries: int = 256,
         query_log: QueryLog | None = None,
     ) -> None:
         self._runner = runner
@@ -103,14 +101,12 @@ class QueryManager:
         # (tests, and any deploy without an in-cluster finelog endpoint).
         self._query_log = query_log
         self._executor = executor or ThreadPoolExecutor(max_workers=max_workers, thread_name_prefix="ducky-query")
-        # Bounded LRU maps: an always-on service would otherwise grow the heap unbounded,
-        # since each result retains up to preview_row_cap rows. Oldest entries are evicted;
-        # an evicted query_id just 404s on /result (results also live on GCS).
+        # Bounded LRU of recent query states: an always-on service would otherwise grow the heap
+        # unbounded, since each result retains up to preview_row_cap rows. Oldest entries are
+        # evicted; an evicted query_id just 404s on /result (results also live on GCS). Result
+        # *reuse* across identical SQL is served by the runner's scratch-bucket cache, not here.
         self._states: OrderedDict[str, QueryState] = OrderedDict()
-        self._cache: OrderedDict[str, tuple[QueryResult, float]] = OrderedDict()  # sql -> (result, monotonic ts)
-        self._cache_ttl = cache_ttl  # seconds; entries older than this are re-run (their parquet may be gone)
         self._max_retained_states = max_retained_states
-        self._max_cache_entries = max_cache_entries
         self._lock = threading.Lock()
 
     def _set_state(self, query_id: str, state: QueryState) -> None:
@@ -120,37 +116,14 @@ class QueryManager:
         while len(self._states) > self._max_retained_states:
             self._states.popitem(last=False)
 
-    def _store_cache(self, sql: str, result: QueryResult) -> None:
-        """Cache a result (most-recent-last), evicting the oldest past the cap. Under the lock."""
-        self._cache[sql] = (result, time.monotonic())
-        self._cache.move_to_end(sql)
-        while len(self._cache) > self._max_cache_entries:
-            self._cache.popitem(last=False)
-
     def submit(self, sql: str, use_cache: bool = True) -> str:
-        """Submit ``sql`` and return a query_id. With ``use_cache`` (default), identical SQL
-        served earlier returns instantly from the cache; pass ``use_cache=False`` to force a
-        fresh run (e.g. when the underlying data changed) — it still refreshes the cache."""
+        """Submit ``sql`` and return a query_id. With ``use_cache`` (default), a result cached in
+        the scratch bucket by an earlier identical query is reused instead of re-running; pass
+        ``use_cache=False`` to force a fresh run (e.g. when the underlying data changed) — it still
+        refreshes the cache. The cache lookup runs on the worker, so submit always returns quickly."""
         query_id = uuid.uuid4().hex
-        hit_state: QueryState | None = None
         with self._lock:
-            cached = self._cached_result(sql) if use_cache else None
-            if cached is not None:
-                hit_state = QueryState(QueryStatus.DONE, result=cached, cached=True)
-                self._set_state(query_id, hit_state)
-            else:
-                self._set_state(query_id, QueryState(QueryStatus.RUNNING))
-        if hit_state is not None:
-            assert cached is not None
-            logger.info(
-                "query %s cache hit (%d rows, %s): %s",
-                query_id,
-                cached.total_rows,
-                _human_bytes(cached.result_bytes),
-                _log_sql(sql),
-            )
-            self._record(query_id, sql, hit_state)
-            return query_id
+            self._set_state(query_id, QueryState(QueryStatus.RUNNING))
         logger.info("query %s submitted: %s", query_id, _log_sql(sql))
         self._executor.submit(self._run, sql, query_id, use_cache)
         return query_id
@@ -159,28 +132,11 @@ class QueryManager:
         with self._lock:
             return self._states.get(query_id)
 
-    def _cached_result(self, sql: str) -> QueryResult | None:
-        """Return a still-valid cached result, or None. Call under the lock.
-
-        Entries older than the cache TTL are dropped — their spilled parquet may have
-        been deleted by the scratch bucket's lifecycle rule, so the cached result_path
-        would dangle.
-        """
-        entry = self._cache.get(sql)
-        if entry is None:
-            return None
-        result, created = entry
-        if self._cache_ttl and (time.monotonic() - created) > self._cache_ttl:
-            del self._cache[sql]
-            return None
-        self._cache.move_to_end(sql)  # LRU: a hit keeps the entry fresh against eviction
-        return result
-
     def _run(self, sql: str, query_id: str, use_cache: bool = True) -> None:
         try:
-            # Restart-survivable tier: on an in-memory miss, a sidecar left by a prior run (before
-            # the restart that cleared the in-memory cache) rebuilds the result without re-scanning
-            # the source. A hit here is still a "cached" reply; a miss falls through to a fresh run.
+            # Reuse a prior identical query's result from the scratch-bucket cache (which survives
+            # the restarts an in-process cache wouldn't) instead of re-scanning the source. A hit
+            # here is still a "cached" reply; a miss falls through to a fresh run.
             result = self._runner.lookup_persistent(sql) if use_cache else None
             from_cache = result is not None
             if result is None:
@@ -209,7 +165,6 @@ class QueryManager:
         )
         done_state = QueryState(QueryStatus.DONE, result=result, cached=from_cache)
         with self._lock:
-            self._store_cache(sql, result)
             self._set_state(query_id, done_state)
         self._record(query_id, sql, done_state)
 
@@ -335,8 +290,6 @@ def create_app(
         runner,
         executor=executor,
         max_workers=config.max_concurrent_queries,
-        cache_ttl=config.result_ttl_days * 86400,
-        max_cache_entries=config.max_cache_entries,
         query_log=query_log,
     )
 

--- a/lib/ducky/tests/test_config.py
+++ b/lib/ducky/tests/test_config.py
@@ -110,6 +110,23 @@ def test_allowed_buckets_parsed_from_env(monkeypatch):
     assert config.allowed_buckets == ("gs://marin-", "s3://marin-")
 
 
+def test_max_cache_entries_default_and_override(monkeypatch):
+    _set(monkeypatch, _BASE_ENV)
+    assert DuckyConfig.from_environment().max_cache_entries == 2048
+    _set(monkeypatch, {"DUCKY_MAX_CACHE_ENTRIES": "8192"})
+    assert DuckyConfig.from_environment().max_cache_entries == 8192
+
+
+def test_persist_cache_defaults_on_and_parses_falsey(monkeypatch):
+    _set(monkeypatch, _BASE_ENV)
+    assert DuckyConfig.from_environment().persist_cache is True
+    for falsey in ("0", "false", "no", "off", ""):
+        _set(monkeypatch, {"DUCKY_PERSIST_CACHE": falsey})
+        assert DuckyConfig.from_environment().persist_cache is False
+    _set(monkeypatch, {"DUCKY_PERSIST_CACHE": "1"})
+    assert DuckyConfig.from_environment().persist_cache is True
+
+
 def test_catalog_root_prefixes_are_exempt_roots():
     # the configured catalog roots are surfaced for cross-region exemption
     config = DuckyConfig(

--- a/lib/ducky/tests/test_config.py
+++ b/lib/ducky/tests/test_config.py
@@ -110,13 +110,6 @@ def test_allowed_buckets_parsed_from_env(monkeypatch):
     assert config.allowed_buckets == ("gs://marin-", "s3://marin-")
 
 
-def test_max_cache_entries_default_and_override(monkeypatch):
-    _set(monkeypatch, _BASE_ENV)
-    assert DuckyConfig.from_environment().max_cache_entries == 2048
-    _set(monkeypatch, {"DUCKY_MAX_CACHE_ENTRIES": "8192"})
-    assert DuckyConfig.from_environment().max_cache_entries == 8192
-
-
 def test_persist_cache_defaults_on_and_parses_falsey(monkeypatch):
     _set(monkeypatch, _BASE_ENV)
     assert DuckyConfig.from_environment().persist_cache is True

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -14,6 +14,7 @@ from ducky.runner import (
     BucketNotAllowedError,
     CrossRegionNotAllowedError,
     QueryError,
+    QueryResult,
     QueryRunner,
     _opts_in_cross_region,
     check_query_access,
@@ -115,6 +116,19 @@ def test_persistent_cache_drops_entry_past_ttl(make_runner):
     runner = make_runner(result_ttl_days=0)  # any positive age is already stale
     runner.run_query("SELECT 1 AS x", uuid.uuid4().hex)
     assert runner.lookup_persistent("SELECT 1 AS x") is None
+
+
+def test_persistent_hit_reenforces_current_access_policy(make_runner):
+    """A sidecar written under a looser policy must not keep serving SQL a tightened allowlist
+    now refuses — the persistent tier outlives the restart that re-applies policy."""
+    sql = "SELECT * FROM read_parquet('s3://marin-na/some/data/*.parquet')"
+    cached = QueryResult(["x"], [[1]], 1, False, "gs://marin-us-east5/tmp/r.parquet", 1, 1)
+    # Plant a sidecar as if this SQL had run when marin-na was allowed (allow-all default).
+    make_runner()._write_persistent_cache(sql, cached)
+    # A runner whose current allowlist excludes marin-na must refuse the cached hit, not serve it.
+    strict = make_runner(allowed_buckets=("gs://marin-",))
+    with pytest.raises(BucketNotAllowedError):
+        strict.lookup_persistent(sql)
 
 
 def test_remote_scratch_blocks_local_filesystem_access(tmp_path):

--- a/lib/ducky/tests/test_runner.py
+++ b/lib/ducky/tests/test_runner.py
@@ -81,6 +81,42 @@ def test_run_query_full_result_not_truncated(make_runner):
     assert result.truncated is False
 
 
+def test_persistent_cache_rebuilds_result_without_rerun(make_runner):
+    """A run leaves a sidecar; lookup_persistent rebuilds the result (as after a restart that
+    dropped the in-memory cache) without re-executing the query."""
+    runner = make_runner(preview_row_cap=2)
+    sql = "SELECT * FROM range(5) t(x)"
+    original = runner.run_query(sql, uuid.uuid4().hex)
+
+    restored = runner.lookup_persistent(sql)
+    assert restored is not None
+    assert restored.columns == original.columns
+    assert restored.preview_rows == original.preview_rows  # capped preview round-trips
+    assert restored.total_rows == original.total_rows == 5
+    assert restored.truncated is True
+    assert restored.result_path == original.result_path
+    assert restored.result_bytes == original.result_bytes
+    assert restored.elapsed_ms == original.elapsed_ms
+
+
+def test_persistent_cache_miss_for_unseen_sql(make_runner):
+    assert make_runner().lookup_persistent("SELECT 'never ran'") is None
+
+
+def test_persistent_cache_disabled_writes_no_sidecar(make_runner, tmp_path):
+    runner = make_runner(persist_cache=False)
+    runner.run_query("SELECT 1 AS x", uuid.uuid4().hex)
+    assert not list((tmp_path / "ducky" / "cache").glob("*.meta.parquet"))
+    assert runner.lookup_persistent("SELECT 1 AS x") is None
+
+
+def test_persistent_cache_drops_entry_past_ttl(make_runner):
+    """A sidecar older than result_ttl_days is ignored — its spilled result may be reaped."""
+    runner = make_runner(result_ttl_days=0)  # any positive age is already stale
+    runner.run_query("SELECT 1 AS x", uuid.uuid4().hex)
+    assert runner.lookup_persistent("SELECT 1 AS x") is None
+
+
 def test_remote_scratch_blocks_local_filesystem_access(tmp_path):
     # results to object storage → user SQL must not read local files (e.g. /proc/self/environ)
     config = _make_config("gs://marin-us-east5/tmp/ttl=7d", spill_directory=str(tmp_path / "spill"))

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -2,7 +2,6 @@
 # SPDX-License-Identifier: Apache-2.0
 
 import dataclasses
-import time
 
 import pytest
 from ducky.config import DuckyConfig
@@ -165,15 +164,22 @@ def test_query_result_delivered_via_result_endpoint():
 
 
 class _CountingRunner(_FakeRunner):
-    """A _FakeRunner that counts how many times it actually executed (to tell cache hits apart)."""
+    """Counts real executions and simulates the scratch-bucket cache: run_query 'writes a sidecar'
+    that a later lookup_persistent reads back, so a repeated query is served without re-running."""
 
     def __init__(self, result):
         super().__init__(result=result)
         self.calls = 0
+        self._persisted: dict[str, QueryResult] = {}
 
     def run_query(self, sql, query_id):
         self.calls += 1
-        return super().run_query(sql, query_id)
+        result = super().run_query(sql, query_id)
+        self._persisted[sql] = result
+        return result
+
+    def lookup_persistent(self, sql):
+        return self._persisted.get(sql)
 
 
 def test_identical_sql_served_from_cache():
@@ -271,24 +277,6 @@ def test_retained_states_are_bounded_lru():
     assert all(manager.get(qid) is not None for qid in ids[2:])  # newest three kept
 
 
-def test_cache_is_bounded_lru():
-    runner = _FakeRunner(QueryResult(["x"], [[1]], 1, False, "gs://b/x.parquet", 1, 1))
-    manager = QueryManager(runner, executor=_InlineExecutor(), max_cache_entries=2)
-    for i in range(4):
-        manager.submit(f"SELECT {i}")
-    assert len(manager._cache) == 2  # capped
-
-
-def test_cache_entry_expires_after_ttl():
-    """A cached result older than the TTL is dropped (its spilled parquet may be gone)."""
-    manager = QueryManager(_FakeRunner(), executor=_InlineExecutor(), cache_ttl=10)
-    result = QueryResult(["a"], [[1]], 1, False, "gs://b/x.parquet", 1, 1)
-    manager._cache["SELECT 1"] = (result, time.monotonic() - 100)  # stale
-    manager._cache["SELECT 2"] = (result, time.monotonic())  # fresh
-    assert manager._cached_result("SELECT 1") is None
-    assert manager._cached_result("SELECT 2") is result
-
-
 class _RecordingQueryLog:
     """Captures the rows a QueryManager would persist to finelog (duck-types QueryLog.record)."""
 
@@ -300,22 +288,26 @@ class _RecordingQueryLog:
 
 
 class _ScriptedRunner:
-    """Returns a result or raises, chosen by the SQL text; counts real executions."""
+    """Returns a result or raises, chosen by the SQL text; counts real executions and simulates
+    the scratch-bucket cache so a repeated successful query is served without re-running."""
 
     def __init__(self, results: dict, errors: dict):
         self._results = results
         self._errors = errors
         self.created_view_names: frozenset[str] = frozenset()
         self.calls = 0
+        self._persisted: dict[str, QueryResult] = {}
 
     def run_query(self, sql: str, query_id: str) -> QueryResult:
         self.calls += 1
         if sql in self._errors:
             raise self._errors[sql]
-        return self._results[sql]
+        result = self._results[sql]
+        self._persisted[sql] = result
+        return result
 
     def lookup_persistent(self, sql: str) -> QueryResult | None:
-        return None
+        return self._persisted.get(sql)
 
 
 def test_every_submission_is_recorded():

--- a/lib/ducky/tests/test_server.py
+++ b/lib/ducky/tests/test_server.py
@@ -46,6 +46,9 @@ class _FakeRunner:
         assert self._result is not None
         return self._result
 
+    def lookup_persistent(self, sql: str) -> QueryResult | None:
+        return None  # no restart-survivable sidecar by default
+
 
 def _client(runner) -> TestClient:
     return TestClient(create_app(runner, _CONFIG, executor=_InlineExecutor()))
@@ -199,6 +202,46 @@ def test_use_cache_false_forces_fresh_run():
     assert runner.calls == 2
 
 
+class _PersistentRunner(_FakeRunner):
+    """Serves every SQL from a restart-survivable sidecar; counts lookups and executions."""
+
+    def __init__(self, result):
+        super().__init__(result=result)
+        self._persistent = result
+        self.run_calls = 0
+        self.lookup_calls = 0
+
+    def run_query(self, sql, query_id):
+        self.run_calls += 1
+        return super().run_query(sql, query_id)
+
+    def lookup_persistent(self, sql):
+        self.lookup_calls += 1
+        return self._persistent
+
+
+def test_persistent_cache_hit_serves_without_executing():
+    """On an in-memory miss, a sidecar hit returns cached=True without running the query —
+    the path that survives the restarts that drop the in-memory cache."""
+    runner = _PersistentRunner(QueryResult(["x"], [[1]], 1, False, "gs://b/ducky/prior.parquet", 42, 7))
+    payload = _run(_client(runner), "SELECT 1")
+
+    assert payload["status"] == "done"
+    assert payload["cached"] is True
+    assert payload["result_path"] == "gs://b/ducky/prior.parquet"
+    assert runner.lookup_calls == 1 and runner.run_calls == 0  # served from the sidecar, not executed
+
+
+def test_use_cache_false_bypasses_persistent_cache():
+    """A forced fresh run skips the persistent tier too, then executes."""
+    runner = _PersistentRunner(QueryResult(["x"], [[1]], 1, False, "gs://b/x.parquet", 1, 1))
+    manager = QueryManager(runner, executor=_InlineExecutor())
+
+    manager.submit("SELECT 1", use_cache=False)
+    assert runner.lookup_calls == 0  # persistent tier not consulted
+    assert runner.run_calls == 1  # ran fresh
+
+
 def test_query_error_surfaces_in_result():
     fake = _FakeRunner(error=QueryError("Catalog Error: table not found"))
     payload = _run(_client(fake), "SELECT * FROM nope")
@@ -270,6 +313,9 @@ class _ScriptedRunner:
         if sql in self._errors:
             raise self._errors[sql]
         return self._results[sql]
+
+    def lookup_persistent(self, sql: str) -> QueryResult | None:
+        return None
 
 
 def test_every_submission_is_recorded():


### PR DESCRIPTION
* restart-survivable result caching for ducky
* ducky's workload is overwhelmingly repeat queries over high-latency object storage: in the `ducky.query` log ~60% of submissions re-run an earlier exact SQL, and ~40% of all execution time was spent re-scanning R2 for results already computed but lost on the preemptible service's restarts
* cache results in the scratch bucket, keyed by exact-SQL hash:
  * each fresh run writes a small `ducky/cache/<sql_sha256>.meta.parquet` sidecar next to the spilled result (capped preview + stats + `written_at`)
  * on an identical repeat `QueryRunner.lookup_persistent(sql)` reads it back and rebuilds the `QueryResult` with no source scan — instant even across the restarts that would drop an in-process cache
  * `submit` always enqueues; `_run` consults the cache as the single reuse path (the lookup runs on the worker, so `submit` stays fast)
* re-runs `check_query_access` before serving a hit, so a sidecar written under a looser `allowed_buckets`/region policy can't keep serving SQL a tightened config would now refuse [^1]
* best-effort and fail-open: any sidecar read/write error falls back to a normal run and never fails a query
* sidecar shares the `ducky/` prefix so the bucket lifecycle reaps it with the result it points at; a hit older than `result_ttl_days` is dropped
* gated by `DUCKY_PERSIST_CACHE` (default on); all object i/o goes through duckdb httpfs

[^1]: caching keys on the exact SQL text, so identical SQL reuses a prior result even if the underlying data changed — `use_cache: false` forces a fresh read and refreshes the cache
