### PR TITLE
datakit: add zenodo download step for ghalogs

### DIFF
--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -1010,7 +1010,7 @@ def stage_ghalogs_archive(output_path: str) -> None:
         logger.info("GHALogs archive already staged (%d bytes): %s", GHALOGS_ARCHIVE_BYTES, archive_path)
         return
 
-    fsspec_mkdirs(os.path.dirname(archive_path), exist_ok=True)
+    StoragePath(os.path.dirname(archive_path)).mkdirs(exist_ok=True)
     logger.info("Streaming %s -> %s (%d bytes expected)", GHALOGS_DOWNLOAD_URL, archive_path, GHALOGS_ARCHIVE_BYTES)
     total = 0
     next_log = _GHALOGS_LOG_EVERY_BYTES

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -1139,10 +1139,13 @@ def ghalogs_public_normalize_steps(
     ``download`` streams the Zenodo archive to ``source_path`` and is wired as a
     dependency of ``materialize`` so the ~142 GB archive is auto-staged before
     materialization reads it (idempotent — a no-op when already staged).
+    ``materialize`` reads from the download step's resolved ``output_path`` so
+    the two always agree on the archive location, even when ``output_path_prefix``
+    differs from ``marin_prefix()``.
     """
     download = download_ghalogs_step(source_path=source_path, output_path_prefix=output_path_prefix)
     materialized = materialize_ghalogs_step(
-        source_path=source_path,
+        source_path=download.output_path,
         max_members=max_members,
         num_shards=num_materialize_shards,
         deps=[download],

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -21,11 +21,12 @@ import fsspec
 import requests
 from fray.types import ResourceConfig
 from pydantic import BaseModel, ConfigDict
-from rigging.filesystem import StoragePath, marin_prefix, open_url, prefix_join, url_to_fs
+from rigging.filesystem import StoragePath, atomic_rename, marin_prefix, open_url, prefix_join, url_to_fs
 from zephyr import counters
 from zephyr.dataset import Dataset
 from zephyr.execution import ZephyrContext
 
+from marin.datakit.download.http_session import build_retrying_session
 from marin.datakit.ingestion_manifest import (
     IdentityTreatment,
     IngestionPolicy,
@@ -46,6 +47,7 @@ logger = logging.getLogger(__name__)
 GHALOGS_RECORD_URL = "https://zenodo.org/records/14796970"
 LOGCHUNKS_RECORD_URL = "https://zenodo.org/records/3632351"
 LOGHUB_REPO_URL = "https://github.com/logpai/loghub"
+GHALOGS_DOWNLOAD_URL = "https://zenodo.org/records/14796970/files/github_run_logs.zip?download=1"
 LOGCHUNKS_DOWNLOAD_URL = "https://zenodo.org/records/3632351/files/LogChunks.zip?download=1"
 LOGHUB_SNAPSHOT_URL = "https://github.com/logpai/loghub/archive/refs/heads/master.zip"
 GHALOGS_ZIP_FILENAME = "github_run_logs.zip"
@@ -63,6 +65,10 @@ GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH = os.path.join(
 )
 
 GHALOGS_TOTAL_BYTES = 143_425_404_506
+# Exact byte length of the published ``github_run_logs.zip`` on Zenodo. Used as
+# the skip-if-staged check; differs from ``GHALOGS_TOTAL_BYTES`` (the manifest's
+# advertised compressed size) because that figure is a rough catalog estimate.
+GHALOGS_ARCHIVE_BYTES = 142_292_965_496
 LOGCHUNKS_TOTAL_BYTES = 24_108_826
 LOGHUB_REPO_SIZE_BYTES = 7_513_088
 GHALOGS_ROUGH_TOKENS_B = 150.0
@@ -74,6 +80,12 @@ LONG_TAIL_PPL_EPIC_ISSUE = 5005
 PUBLIC_DIAGNOSTIC_LOGS_ISSUE = 5094
 _DOWNLOAD_CHUNK_BYTES = 1 << 20
 _DOWNLOAD_TIMEOUT = 300
+# GHALogs archive is ~142 GB; stream it in large chunks straight to the object
+# store without buffering the whole file locally.
+_GHALOGS_HTTP_CHUNK_BYTES = 64 * 1024 * 1024
+_GHALOGS_S3_BLOCK_BYTES = 256 * 1024 * 1024  # multipart part size (~558 parts)
+_GHALOGS_LOG_EVERY_BYTES = 4 * 1024 * 1024 * 1024  # progress line every ~4 GB
+_GHALOGS_DOWNLOAD_TIMEOUT = (30, 600)  # (connect, read) seconds
 
 _PARTITION_BUCKETS = 10_000
 _ISSUE_5093_HOLDOUT_BUCKETS = 100
@@ -981,17 +993,93 @@ def extract_ghalogs_step(
     )
 
 
+def stage_ghalogs_archive(output_path: str) -> None:
+    """Stream the ~142 GB GHALogs Zenodo archive under ``output_path`` (idempotent).
+
+    Idempotent: a correctly-sized copy is left untouched, so re-running is a
+    cheap no-op once staged; a partial or truncated download never becomes the
+    published archive. The archive is written to
+    ``{output_path}/{GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH}`` — the path
+    :func:`materialize_ghalogs_to_parquet` reads from. Bytes stream straight to
+    the object store without buffering the whole file locally.
+    """
+    archive_path = prefix_join(output_path, GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH)
+    fs, path = url_to_fs(archive_path)
+
+    if fs.exists(path) and fs.size(path) == GHALOGS_ARCHIVE_BYTES:
+        logger.info("GHALogs archive already staged (%d bytes): %s", GHALOGS_ARCHIVE_BYTES, archive_path)
+        return
+
+    fsspec_mkdirs(os.path.dirname(archive_path), exist_ok=True)
+    logger.info("Streaming %s -> %s (%d bytes expected)", GHALOGS_DOWNLOAD_URL, archive_path, GHALOGS_ARCHIVE_BYTES)
+    total = 0
+    next_log = _GHALOGS_LOG_EVERY_BYTES
+    session = build_retrying_session()
+    with session.get(GHALOGS_DOWNLOAD_URL, stream=True, timeout=_GHALOGS_DOWNLOAD_TIMEOUT) as response:
+        response.raise_for_status()
+        with atomic_rename(path, fs=fs) as tmp:
+            with fs.open(tmp, "wb", block_size=_GHALOGS_S3_BLOCK_BYTES) as out:
+                for chunk in response.iter_content(chunk_size=_GHALOGS_HTTP_CHUNK_BYTES):
+                    if not chunk:
+                        continue
+                    out.write(chunk)
+                    total += len(chunk)
+                    if total >= next_log:
+                        logger.info("staged %.1f / %.1f GB", total / 1e9, GHALOGS_ARCHIVE_BYTES / 1e9)
+                        next_log += _GHALOGS_LOG_EVERY_BYTES
+            # Verify before atomic_rename publishes: a truncated stream raises
+            # here and the temp key is cleaned up, so no partial archive lands
+            # at the final path.
+            if total != GHALOGS_ARCHIVE_BYTES:
+                raise RuntimeError(
+                    f"GHALogs archive size mismatch after staging: got {total}, expected {GHALOGS_ARCHIVE_BYTES}"
+                )
+    logger.info("Staged GHALogs archive: %d bytes -> %s", total, archive_path)
+
+
+def download_ghalogs_step(
+    *,
+    source_path: str = GHALOGS_STAGED_PREFIX,
+    output_path_prefix: str | None = None,
+) -> StepSpec:
+    """Return a StepSpec that stages the GHALogs Zenodo archive at ``source_path``.
+
+    The step's output path is pinned to ``source_path`` (via
+    ``override_output_path``) so the archive lands exactly where the paired
+    :func:`materialize_ghalogs_step` reads it. Idempotent: the step no-ops once
+    the ~142 GB archive is present.
+    """
+    source = SOURCE_MANIFESTS["ghalogs"]
+    return StepSpec(
+        name="raw/diagnostic_logs/ghalogs_public_archive",
+        output_path_prefix=output_path_prefix,
+        override_output_path=source_path,
+        fn=lambda output_path: stage_ghalogs_archive(output_path),
+        hash_attrs={
+            "version": "v1",
+            "download_url": GHALOGS_DOWNLOAD_URL,
+            "archive_bytes": GHALOGS_ARCHIVE_BYTES,
+            "archive_relative_path": GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH,
+            "source_path": source_path,
+            "source_label": source.source_label,
+            "source_content_fingerprint": source.fingerprint(),
+        },
+    )
+
+
 def materialize_ghalogs_step(
     *,
     source_path: str = GHALOGS_STAGED_PREFIX,
     max_members: int | None = None,
     num_shards: int = DEFAULT_GHALOGS_MATERIALIZE_SHARDS,
+    deps: list[StepSpec] | None = None,
     output_path_prefix: str | None = None,
 ) -> StepSpec:
     """Return a StepSpec that materializes GHALogs into reusable parquet shards."""
     source = SOURCE_MANIFESTS["ghalogs"]
     return StepSpec(
         name="processed/diagnostic_logs/ghalogs_public_parquet",
+        deps=deps or [],
         output_path_prefix=output_path_prefix,
         fn=lambda output_path: materialize_ghalogs_to_parquet(
             source_path,
@@ -1045,12 +1133,19 @@ def ghalogs_public_normalize_steps(
     max_members: int | None = None,
     num_materialize_shards: int = DEFAULT_GHALOGS_MATERIALIZE_SHARDS,
     output_path_prefix: str | None = None,
-) -> tuple[StepSpec, StepSpec, StepSpec]:
-    """Return the Datakit ``(materialize, train-partition, normalize)`` chain for GHALogs."""
+) -> tuple[StepSpec, StepSpec, StepSpec, StepSpec]:
+    """Return the Datakit ``(download, materialize, train-partition, normalize)`` chain for GHALogs.
+
+    ``download`` streams the Zenodo archive to ``source_path`` and is wired as a
+    dependency of ``materialize`` so the ~142 GB archive is auto-staged before
+    materialization reads it (idempotent — a no-op when already staged).
+    """
+    download = download_ghalogs_step(source_path=source_path, output_path_prefix=output_path_prefix)
     materialized = materialize_ghalogs_step(
         source_path=source_path,
         max_members=max_members,
         num_shards=num_materialize_shards,
+        deps=[download],
         output_path_prefix=output_path_prefix,
     )
     train_partition = materialize_ghalogs_partition_step(
@@ -1066,7 +1161,7 @@ def ghalogs_public_normalize_steps(
         file_extensions=(".parquet",),
         output_path_prefix=output_path_prefix,
     )
-    return (materialized, train_partition, normalized)
+    return (download, materialized, train_partition, normalized)
 
 
 def extract_logchunks_step(

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -7,14 +7,19 @@ import zipfile
 from pathlib import Path
 
 import pyarrow.parquet as pq
+import pytest
+from marin.datakit.download import diagnostic_logs
 from marin.datakit.download.diagnostic_logs import (
     GHALOGS_ROUGH_TOKENS_B,
+    GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH,
+    GHALOGS_STAGED_PREFIX,
     SOURCE_INVENTORY,
     DiagnosticPartition,
     ExtractedDiagnosticLogs,
     ExtractedPartitionedDiagnosticLogs,
     MaterializedDiagnosticLogParquet,
     assign_partition,
+    download_ghalogs_step,
     extract_diagnostic_logs,
     extract_ghalogs_step,
     ghalogs_member_to_record,
@@ -24,6 +29,7 @@ from marin.datakit.download.diagnostic_logs import (
     materialize_ghalogs_partition_to_parquet,
     materialize_ghalogs_to_parquet,
     sanitize_diagnostic_log_text,
+    stage_ghalogs_archive,
 )
 from marin.datakit.normalize import NormalizedData
 from marin.datakit.sources import all_sources
@@ -135,11 +141,15 @@ def test_all_sources_includes_normalized_ghalogs_public():
 
     assert source.rough_token_count_b == GHALOGS_ROUGH_TOKENS_B
     assert [step.name for step in source.normalize_steps] == [
+        "raw/diagnostic_logs/ghalogs_public_archive",
         "processed/diagnostic_logs/ghalogs_public_parquet",
         "processed/diagnostic_logs/ghalogs_public_train_parquet",
         "normalized/ghalogs/public",
     ]
-    assert source.normalized.deps == [source.normalize_steps[1]]
+    # normalize depends on the train partition; the parquet materialize depends
+    # on the archive download so the ~142 GB archive is auto-staged first.
+    assert source.normalized.deps == [source.normalize_steps[-2]]
+    assert source.normalize_steps[1].deps == [source.normalize_steps[0]]
 
 
 def test_ghalogs_dataset_reads_datakit_normalized_output():
@@ -376,7 +386,7 @@ def test_materialize_ghalogs_partition_to_parquet_filters_one_partition(tmp_path
     assert all(row["partition"] == DiagnosticPartition.TRAIN.value for row in train_rows)
 
 
-def test_ghalogs_public_normalize_steps_write_datakit_normalized_train_partition(tmp_path):
+def test_ghalogs_public_normalize_steps_write_datakit_normalized_train_partition(tmp_path, monkeypatch):
     input_dir = tmp_path / "input" / "ghalogs" / "zenodo-14796970"
     archive_dir = input_dir / "zenodo.org" / "records" / "14796970" / "files"
     archive_dir.mkdir(parents=True)
@@ -386,6 +396,10 @@ def test_ghalogs_public_normalize_steps_write_datakit_normalized_train_partition
     with zipfile.ZipFile(archive_dir / "github_run_logs.zip", "w") as archive:
         archive.writestr(train_member, "ERROR token=abc123456789 traceback")
         archive.writestr(dev_member, "FAILED validation-only log")
+
+    # The archive is already staged at ``source_path``; no-op the Zenodo stream
+    # so the download step doesn't try to fetch the real ~142 GB archive.
+    monkeypatch.setattr(diagnostic_logs, "stage_ghalogs_archive", lambda output_path: None)
 
     steps = ghalogs_public_normalize_steps(
         source_path=str(input_dir),
@@ -404,3 +418,89 @@ def test_ghalogs_public_normalize_steps_write_datakit_normalized_train_partition
     assert rows[0]["partition"] == DiagnosticPartition.TRAIN.value
     assert "abc123456789" not in rows[0]["text"]
     assert rows[0]["source_id"] != rows[0]["id"]
+
+
+class _FakeStreamResponse:
+    """Minimal stand-in for a streamed ``requests`` response."""
+
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = chunks
+
+    def __enter__(self) -> "_FakeStreamResponse":
+        return self
+
+    def __exit__(self, *exc: object) -> bool:
+        return False
+
+    def raise_for_status(self) -> None:
+        return None
+
+    def iter_content(self, chunk_size: int):
+        yield from self._chunks
+
+
+class _FakeSession:
+    def __init__(self, chunks: list[bytes]):
+        self._chunks = chunks
+        self.get_calls = 0
+
+    def get(self, url: str, *, stream: bool, timeout) -> _FakeStreamResponse:
+        self.get_calls += 1
+        return _FakeStreamResponse(self._chunks)
+
+
+def _patch_zenodo_stream(monkeypatch, payload: bytes, chunks: list[bytes]) -> _FakeSession:
+    session = _FakeSession(chunks)
+    monkeypatch.setattr(diagnostic_logs, "build_retrying_session", lambda: session)
+    monkeypatch.setattr(diagnostic_logs, "GHALOGS_ARCHIVE_BYTES", len(payload))
+    return session
+
+
+def test_stage_ghalogs_archive_streams_to_expected_path(tmp_path, monkeypatch):
+    payload = b"PK\x03\x04" + b"github-run-log-bytes" * 32
+    _patch_zenodo_stream(monkeypatch, payload, [payload[:40], payload[40:]])
+
+    stage_ghalogs_archive(str(tmp_path))
+
+    staged = tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
+    assert staged.read_bytes() == payload
+
+
+def test_stage_ghalogs_archive_skips_when_correctly_sized_copy_exists(tmp_path, monkeypatch):
+    payload = b"already-staged-archive-bytes"
+    session = _patch_zenodo_stream(monkeypatch, payload, [payload])
+
+    staged = tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
+    staged.parent.mkdir(parents=True)
+    staged.write_bytes(payload)
+
+    stage_ghalogs_archive(str(tmp_path))
+
+    # A correctly-sized copy short-circuits before any HTTP request.
+    assert session.get_calls == 0
+    assert staged.read_bytes() == payload
+
+
+def test_stage_ghalogs_archive_raises_on_size_mismatch(tmp_path, monkeypatch):
+    payload = b"the-full-expected-archive"
+    # Server truncates the stream: streamed bytes fall short of the expected size.
+    _patch_zenodo_stream(monkeypatch, payload, [payload[:10]])
+
+    with pytest.raises(RuntimeError, match="size mismatch"):
+        stage_ghalogs_archive(str(tmp_path))
+
+    # Failed staging must not publish a partial archive at the final path.
+    assert not (tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH).exists()
+
+
+def test_download_ghalogs_step_targets_staged_prefix_and_streams_archive(tmp_path, monkeypatch):
+    payload = b"downloaded-archive-payload"
+    _patch_zenodo_stream(monkeypatch, payload, [payload])
+
+    step = download_ghalogs_step(output_path_prefix=str(tmp_path))
+    assert step.output_path == f"{tmp_path}/{GHALOGS_STAGED_PREFIX}"
+
+    StepRunner().run([step])
+
+    staged = Path(step.output_path) / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
+    assert staged.read_bytes() == payload

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -420,6 +420,34 @@ def test_ghalogs_public_normalize_steps_write_datakit_normalized_train_partition
     assert rows[0]["source_id"] != rows[0]["id"]
 
 
+def test_ghalogs_public_normalize_steps_read_where_download_wrote(tmp_path, monkeypatch):
+    # Regression: with a custom output_path_prefix and the default relative
+    # source_path, the download step resolves its output under output_path_prefix
+    # while materialize must read from that same location (not marin_prefix()).
+    steps_prefix = tmp_path / "steps"
+    download, materialized, _train, _normalized = ghalogs_public_normalize_steps(
+        max_members=1,
+        num_materialize_shards=1,
+        output_path_prefix=str(steps_prefix),
+    )
+
+    # Stage the fixture archive exactly where the download step resolves its
+    # output — a location distinct from marin_prefix(), which the misaligned
+    # version read from and would have missed.
+    staged_archive = Path(download.output_path) / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
+    staged_archive.parent.mkdir(parents=True)
+    train_member = _member_path_for_partition(DiagnosticPartition.TRAIN)
+    with zipfile.ZipFile(staged_archive, "w") as archive:
+        archive.writestr(train_member, "ERROR token=abc123456789 traceback")
+
+    # Archive is pre-staged; no-op the Zenodo stream.
+    monkeypatch.setattr(diagnostic_logs, "stage_ghalogs_archive", lambda output_path: None)
+    StepRunner().run([download, materialized])
+
+    rows = _read_parquet_rows(Path(materialized.output_path))
+    assert [row["archive_path"] for row in rows] == [train_member]
+
+
 class _FakeStreamResponse:
     """Minimal stand-in for a streamed ``requests`` response."""
 


### PR DESCRIPTION
* `ghalogs/public` had no download step: normalize (`materialize_ghalogs_step`) read a manually pre-staged ~142 GB Zenodo archive (`github_run_logs.zip`, record 14796970) from `GHALOGS_STAGED_PREFIX` and raised `FileNotFoundError` when it was missing — nothing in the pipeline fetched it (HF sources use `download_hf_step`; ghalogs had no equivalent)
* add `stage_ghalogs_archive` + `download_ghalogs_step` that stream the archive from Zenodo straight to the object store, and wire it into the datakit chain
  * streams in 64 MB chunks with a 256 MB S3 multipart block — no full-file local buffering
  * publishes atomically via `rigging.filesystem.atomic_rename` (`.tmp` + rename); verifies the exact `GHALOGS_ARCHIVE_BYTES` **before** the rename, so a truncated stream is cleaned up instead of becoming the published archive
  * idempotent: skips when a correctly-sized copy already exists, so the step no-ops once staged
* `download_ghalogs_step` pins its output to `source_path` via `override_output_path`, is prepended to `ghalogs_public_normalize_steps`, and is wired as a dep of `materialize` — so the chain auto-stages the archive before materialization reads it, and download/materialize always agree on the location
* `GHALOGS_ARCHIVE_BYTES` (142292965496) is the real published length from Zenodo's `content-length`, kept distinct from the manifest's rougher `GHALOGS_TOTAL_BYTES` catalog estimate
* meant to run in the destination region (as an in-region iris job) — Zenodo throughput from outside is slow [^1]

[^1]: verified the streaming path end-to-end against real Zenodo + a `tmp/ttl=1d/` GCS bucket (real `atomic_rename` gcsfs write of a bounded 1 GB range slice, final object size correct). Transatlantic throughput from a us-west box was ~4.5 MB/s, so a full 142 GB pull is ~9 h — it belongs in-region, not on a dev box. Unit tests mock the HTTP stream (never download 142 GB): streamed write to the expected path, skip-if-correctly-sized, truncated-stream cleanup, and the step wiring/dep graph.
