### PR TITLE
[levanter] Add host-side data-loading barrier to survive slow-loader stalls

### DIFF
--- a/lib/levanter/src/levanter/checkpoint.py
+++ b/lib/levanter/src/levanter/checkpoint.py
@@ -506,6 +506,15 @@ class Checkpointer:
                     [record.path for record in self._temporary_checkpoints],
                 )
 
+    @property
+    def last_save_step(self) -> int:
+        """The step of the most recent checkpoint save, or 0 if none has been saved.
+
+        The save decision is broadcast from process 0, so this value is identical on every
+        process — safe to drive a collective-arming decision off of.
+        """
+        return self._last_save_step
+
     def load_checkpoint(
         self,
         state: M,

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -69,7 +69,7 @@ from levanter.tracker import TrackerConfig, capture_time
 from levanter.tracker.wandb import WandbConfig
 from levanter.trainer_state import InsideJitInfo, TrainerState, saveable_training_mask
 from levanter.utils import cloud_utils
-from levanter.utils.jax_utils import zeros_like_tree
+from levanter.utils.jax_utils import data_loading_barrier, zeros_like_tree
 from levanter.utils.mesh import MeshConfig, create_mesh_from_axis_specs
 from levanter.utils.tree_utils import inference_mode
 from levanter.utils.types import ComputeLossFunction, FilterSpec
@@ -535,6 +535,9 @@ class Trainer:
                     loading_time(),
                 )
 
+            if self.config.data_loading_barrier_timeout is not None:
+                data_loading_barrier(int(state.step), timeout=self.config.data_loading_barrier_timeout)
+
             info = self.train_step(state, example)
             state = info.state
 
@@ -846,6 +849,18 @@ class TrainerConfig:
     num_train_steps: int = 400_000  # number of training steps
     steps_per_eval: int = 1_000  # how often to evaluate
     max_eval_batches: Optional[int] = None  # max number of batches to evaluate on. None means all batches
+
+    data_loading_barrier_timeout: Optional[float] = None
+    """If set, all processes rendezvous on the coordination service before each train step to
+    confirm their input batch is loaded, waiting up to this many seconds for stragglers.
+
+    This protects large multi-host runs from a slow data loader (e.g. a transient GCS slowdown)
+    taking down the whole job: without it, processes that already have their batch enter the
+    train-step collective and block on the straggler on the device path, where a timeout is
+    fatal and shuts down the job opaquely. With it, the wait happens host-side where a slow
+    loader merely delays its peers. None (default) disables the barrier. Recommended for large
+    multislice runs; leave off for small fast-stepping runs where a per-step coordination
+    round-trip is a meaningful fraction of step time."""
 
     checkpointer: CheckpointerConfig = field(default_factory=CheckpointerConfig)
     load_checkpoint: Optional[bool] = None

--- a/lib/levanter/src/levanter/trainer.py
+++ b/lib/levanter/src/levanter/trainer.py
@@ -278,6 +278,9 @@ class Trainer:
         self.config = config
         self.optimizer = optimizer
         self._raw_loss_function = loss_fn
+        # Set when default hooks install the checkpointer; drives the data-loading barrier's
+        # post-checkpoint arming window. None when the trainer runs without a checkpointer.
+        self._checkpointer: Optional[levanter.checkpoint.Checkpointer] = None
 
         # Use existing global tracker if available (e.g., from levanter.initialize()),
         # otherwise create a new one. This avoids calling wandb.init() twice.
@@ -521,6 +524,10 @@ class Trainer:
         iter_data = iter(train_loader)
         is_first_step = True
 
+        barrier_config = self.config.data_loading_barrier
+        run_start_step = int(state.step)
+        last_barrier_step: Optional[int] = None
+
         while int(state.step) < self.num_train_steps:
             with capture_time() as loading_time:
                 try:
@@ -535,8 +542,10 @@ class Trainer:
                     loading_time(),
                 )
 
-            if self.config.data_loading_barrier_timeout is not None:
-                data_loading_barrier(int(state.step), timeout=self.config.data_loading_barrier_timeout)
+            step = int(state.step)
+            if barrier_config.enabled and self._data_loading_barrier_active(step, run_start_step):
+                data_loading_barrier(step, timeout=barrier_config.timeout, previous_step=last_barrier_step)
+                last_barrier_step = step
 
             info = self.train_step(state, example)
             state = info.state
@@ -548,6 +557,11 @@ class Trainer:
             levanter.tracker.log({"throughput/loading_time": loading_time()}, step=info.step)
 
             yield info
+
+    def _data_loading_barrier_active(self, step: int, run_start_step: int) -> bool:
+        """Whether the data-loading barrier should gate ``step`` (see [_barrier_active][])."""
+        last_save_step = self._checkpointer.last_save_step if self._checkpointer is not None else 0
+        return _barrier_active(step, run_start_step, last_save_step, self.config.data_loading_barrier.active_steps)
 
     def train(self, state: S, train_loader: Iterable[X]) -> StepInfo[S]:
         """
@@ -584,6 +598,7 @@ class Trainer:
         )
         # engine.add_hook(callbacks.log_memory_usage(), every=1)
         checkpointer = self.config.checkpointer.create(self.run_id)
+        self._checkpointer = checkpointer
 
         def checkpoint_hook(info, force=False):
             checkpointer.on_step(tree=info.state.saveable_state, step=info.step, force=force)
@@ -793,6 +808,47 @@ def _initialize_global_tracker(config, run_id):
     levanter.tracker.set_global_tracker(tracker)
 
 
+@dataclass(frozen=True)
+class DataLoadingBarrierConfig:
+    """Gates entry to the train step on all processes having their batch loaded.
+
+    A train step is a cross-host collective: every process must feed its data shard and enter
+    together. When one process's data loader stalls (typically a transient GCS slowdown), the
+    processes that already have their batch enter the on-device collective and block on the
+    straggler — a wait that is fatal on timeout and tears the whole job down with an opaque
+    coordination-service shutdown. This barrier moves that wait host-side, where a slow loader
+    merely delays its peers, names the laggards in the logs, and fails (if ever) with a
+    ``TimeoutError`` that names the stuck processes.
+
+    To keep steady-state cost at zero, the barrier runs only in the windows where the prefetch
+    buffer is cold and a peer is most likely to fall behind: the first ``active_steps`` of the
+    run (empty buffer at start/resume) and the ``active_steps`` after each checkpoint save (the
+    async upload contends with data reads for GCS bandwidth). It is a no-op on single-process
+    jobs regardless of ``enabled``.
+    """
+
+    enabled: bool = True
+    timeout: float = 300.0
+    """Seconds to wait for all processes at the barrier before raising ``TimeoutError``."""
+    active_steps: int = 10
+    """How many steps to keep the barrier active after the run starts and after each checkpoint
+    save. A run whose checkpoint upload spans more than this many steps may want a larger value."""
+
+
+def _barrier_active(step: int, run_start_step: int, last_save_step: int, active_steps: int) -> bool:
+    """Whether the data-loading barrier should gate ``step``.
+
+    True in the two cold-buffer windows: the first ``active_steps`` of the run (empty prefetch
+    buffer at start/resume) and the ``active_steps`` after a checkpoint save (the async upload
+    contends with data reads for GCS bandwidth). A pure function of globally-consistent inputs —
+    ``step``, the resumed start step, and the checkpointer's last save step — so every process
+    arms identically and none is stranded waiting at the barrier for a peer that never arrives.
+    """
+    if step < run_start_step + active_steps:
+        return True
+    return 0 < step - last_save_step <= active_steps
+
+
 @dataclass
 class TrainerConfig:
     seed: int = 0  # random seed
@@ -850,17 +906,7 @@ class TrainerConfig:
     steps_per_eval: int = 1_000  # how often to evaluate
     max_eval_batches: Optional[int] = None  # max number of batches to evaluate on. None means all batches
 
-    data_loading_barrier_timeout: Optional[float] = None
-    """If set, all processes rendezvous on the coordination service before each train step to
-    confirm their input batch is loaded, waiting up to this many seconds for stragglers.
-
-    This protects large multi-host runs from a slow data loader (e.g. a transient GCS slowdown)
-    taking down the whole job: without it, processes that already have their batch enter the
-    train-step collective and block on the straggler on the device path, where a timeout is
-    fatal and shuts down the job opaquely. With it, the wait happens host-side where a slow
-    loader merely delays its peers. None (default) disables the barrier. Recommended for large
-    multislice runs; leave off for small fast-stepping runs where a per-step coordination
-    round-trip is a meaningful fraction of step time."""
+    data_loading_barrier: DataLoadingBarrierConfig = field(default_factory=DataLoadingBarrierConfig)
 
     checkpointer: CheckpointerConfig = field(default_factory=CheckpointerConfig)
     load_checkpoint: Optional[bool] = None

--- a/lib/levanter/src/levanter/utils/jax_utils.py
+++ b/lib/levanter/src/levanter/utils/jax_utils.py
@@ -4,6 +4,8 @@
 import contextlib
 import functools
 import json
+import logging
+import time
 import warnings
 from dataclasses import fields
 from typing import Any, Callable, Optional, TypeVar
@@ -22,9 +24,12 @@ from jax import numpy as jnp
 from jax._src.mesh import get_concrete_mesh
 from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec
 from jaxtyping import PRNGKeyArray, PyTree
+from rigging.timing import Deadline, Duration, ExponentialBackoff
 
 from levanter.utils.mesh import create_mesh_from_axis_specs
 from levanter.utils.tree_utils import key_path_to_str, tree_flatten_one_level_with_keys
+
+logger = logging.getLogger(__name__)
 
 X = TypeVar("X")
 T = TypeVar("T", bound=PyTree)
@@ -181,6 +186,92 @@ def barrier_sync(timeout: float = 200):
 
     _sync_counter += 1
     client.wait_at_barrier(f"levanter_barrier_sync_{_sync_counter}", timeout_in_ms=int(timeout * 1000.0))
+
+
+_DATA_READY_PREFIX = "levanter/data_ready"
+_last_data_ready_step: int | None = None
+
+
+def data_loading_barrier(step: int, *, timeout: float, warn_interval: float = 30.0) -> None:
+    """Wait until every process has its input batch for ``step`` in hand before the train step.
+
+    A Levanter train step is a cross-host collective: every process must feed its data
+    shard and enter the step together. When one process's loader stalls (e.g. a slow GCS
+    read), the processes that already have data enter the on-device collective and block
+    on the straggler. That wait lives on the device/collective path, where a timeout is
+    fatal and takes down the whole job with an opaque coordination-service shutdown.
+
+    This barrier moves the wait onto JAX's coordination service instead. Each process
+    publishes a readiness key once its batch is loaded, then polls until all processes
+    have published (or ``timeout`` elapses). While waiting, a process is idle host-side
+    and keeps heartbeating, so a slow loader merely delays its peers rather than tripping
+    a fatal collective timeout. Lagging processes are named in the logs, and if the
+    barrier never clears the raised ``TimeoutError`` names the processes that never
+    signalled — a real hang still fails, but legibly.
+
+    Args:
+        step: The training step whose batch must be ready. Used to namespace the keys;
+            must advance monotonically across calls.
+        timeout: Maximum seconds to wait for all processes before raising.
+        warn_interval: How often (seconds) process 0 logs the still-missing processes.
+    """
+    global _last_data_ready_step
+
+    num_processes = jax.process_count()
+    if num_processes == 1:
+        return
+
+    client = jax_distributed.global_state.client
+    if client is None:
+        raise RuntimeError("data_loading_barrier requires jax distributed client to be initialized")
+
+    process_id = jax.process_index()
+    is_leader = process_id == 0
+
+    # A train step is a global collective, so no process can reach the barrier for `step`
+    # until every process has cleared the previous one. That makes it safe for the leader
+    # to delete the previous step's keys here, bounding growth of the coordination store.
+    if is_leader and _last_data_ready_step is not None:
+        client.key_value_delete(f"{_DATA_READY_PREFIX}/{_last_data_ready_step}/")
+    _last_data_ready_step = step
+
+    prefix = f"{_DATA_READY_PREFIX}/{step}"
+    client.key_value_set(f"{prefix}/{process_id}", "1")
+
+    deadline = Deadline.from_now(Duration.from_seconds(timeout))
+    backoff = ExponentialBackoff(initial=0.05, maximum=min(warn_interval, 5.0))
+    ready: set[int] = set()
+    next_warn = warn_interval
+    elapsed = 0.0
+
+    while True:
+        ready |= {int(key.rsplit("/", 1)[1]) for key, _ in client.key_value_dir_get(f"{prefix}/")}
+        if len(ready) >= num_processes:
+            return
+
+        if deadline.expired():
+            missing = sorted(set(range(num_processes)) - ready)
+            raise TimeoutError(
+                f"data_loading_barrier timed out after {timeout:.0f}s at step {step}: "
+                f"{len(missing)}/{num_processes} processes never signalled data-ready. "
+                f"Missing (first 32): {missing[:32]}"
+            )
+
+        interval = backoff.next_interval()
+        time.sleep(interval)
+        elapsed += interval
+
+        if is_leader and elapsed >= next_warn:
+            missing = sorted(set(range(num_processes)) - ready)
+            logger.warning(
+                "data_loading_barrier: %.0fs waiting on %d/%d processes to load step %d. Missing (first 32): %s",
+                elapsed,
+                len(missing),
+                num_processes,
+                step,
+                missing[:32],
+            )
+            next_warn += warn_interval
 
 
 # from https://stackoverflow.com/questions/2166818/how-to-check-if-an-object-is-an-instance-of-a-namedtuple

--- a/lib/levanter/src/levanter/utils/jax_utils.py
+++ b/lib/levanter/src/levanter/utils/jax_utils.py
@@ -189,34 +189,26 @@ def barrier_sync(timeout: float = 200):
 
 
 _DATA_READY_PREFIX = "levanter/data_ready"
-_last_data_ready_step: int | None = None
+_MAX_LOGGED_LAGGARDS = 32
 
 
 def data_loading_barrier(step: int, *, timeout: float, warn_interval: float = 30.0) -> None:
-    """Wait until every process has its input batch for ``step`` in hand before the train step.
+    """Block until every process has loaded its batch for ``step``, then return.
 
-    A Levanter train step is a cross-host collective: every process must feed its data
-    shard and enter the step together. When one process's loader stalls (e.g. a slow GCS
-    read), the processes that already have data enter the on-device collective and block
-    on the straggler. That wait lives on the device/collective path, where a timeout is
-    fatal and takes down the whole job with an opaque coordination-service shutdown.
-
-    This barrier moves the wait onto JAX's coordination service instead. Each process
-    publishes a readiness key once its batch is loaded, then polls until all processes
-    have published (or ``timeout`` elapses). While waiting, a process is idle host-side
-    and keeps heartbeating, so a slow loader merely delays its peers rather than tripping
-    a fatal collective timeout. Lagging processes are named in the logs, and if the
-    barrier never clears the raised ``TimeoutError`` names the processes that never
-    signalled — a real hang still fails, but legibly.
+    Call this between fetching a batch and the collective train step. It gates entry to the
+    step on all processes being ready, so a process whose data loader stalls (e.g. a slow
+    GCS read) delays its peers host-side instead of stalling them inside the on-device
+    collective, where the wait is fatal on timeout and takes down the whole job. Processes
+    still missing after ``warn_interval`` seconds are named in a log line by process 0; if
+    any are still missing after ``timeout`` seconds, raises ``TimeoutError`` naming them.
 
     Args:
-        step: The training step whose batch must be ready. Used to namespace the keys;
-            must advance monotonically across calls.
+        step: The training step whose batch must be ready. Must increase by one on each
+            call: it namespaces the coordination keys, and entering ``step`` cleans up the
+            keys from ``step - 1``.
         timeout: Maximum seconds to wait for all processes before raising.
         warn_interval: How often (seconds) process 0 logs the still-missing processes.
     """
-    global _last_data_ready_step
-
     num_processes = jax.process_count()
     if num_processes == 1:
         return
@@ -229,11 +221,10 @@ def data_loading_barrier(step: int, *, timeout: float, warn_interval: float = 30
     is_leader = process_id == 0
 
     # A train step is a global collective, so no process can reach the barrier for `step`
-    # until every process has cleared the previous one. That makes it safe for the leader
-    # to delete the previous step's keys here, bounding growth of the coordination store.
-    if is_leader and _last_data_ready_step is not None:
-        client.key_value_delete(f"{_DATA_READY_PREFIX}/{_last_data_ready_step}/")
-    _last_data_ready_step = step
+    # until every process cleared `step - 1`. That makes it safe for the leader to delete
+    # the previous step's keys here, bounding growth of the coordination store.
+    if is_leader and step > 0:
+        client.key_value_delete(f"{_DATA_READY_PREFIX}/{step - 1}/")
 
     prefix = f"{_DATA_READY_PREFIX}/{step}"
     client.key_value_set(f"{prefix}/{process_id}", "1")
@@ -249,12 +240,12 @@ def data_loading_barrier(step: int, *, timeout: float, warn_interval: float = 30
         if len(ready) >= num_processes:
             return
 
+        missing = sorted(set(range(num_processes)) - ready)
         if deadline.expired():
-            missing = sorted(set(range(num_processes)) - ready)
             raise TimeoutError(
                 f"data_loading_barrier timed out after {timeout:.0f}s at step {step}: "
                 f"{len(missing)}/{num_processes} processes never signalled data-ready. "
-                f"Missing (first 32): {missing[:32]}"
+                f"Missing (first {_MAX_LOGGED_LAGGARDS}): {missing[:_MAX_LOGGED_LAGGARDS]}"
             )
 
         interval = backoff.next_interval()
@@ -262,14 +253,14 @@ def data_loading_barrier(step: int, *, timeout: float, warn_interval: float = 30
         elapsed += interval
 
         if is_leader and elapsed >= next_warn:
-            missing = sorted(set(range(num_processes)) - ready)
             logger.warning(
-                "data_loading_barrier: %.0fs waiting on %d/%d processes to load step %d. Missing (first 32): %s",
+                "data_loading_barrier: %.0fs waiting on %d/%d processes to load step %d. Missing (first %d): %s",
                 elapsed,
                 len(missing),
                 num_processes,
                 step,
-                missing[:32],
+                _MAX_LOGGED_LAGGARDS,
+                missing[:_MAX_LOGGED_LAGGARDS],
             )
             next_warn += warn_interval
 

--- a/lib/levanter/src/levanter/utils/jax_utils.py
+++ b/lib/levanter/src/levanter/utils/jax_utils.py
@@ -24,7 +24,7 @@ from jax import numpy as jnp
 from jax._src.mesh import get_concrete_mesh
 from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec
 from jaxtyping import PRNGKeyArray, PyTree
-from rigging.timing import Deadline, Duration, ExponentialBackoff
+from rigging.timing import ExponentialBackoff
 
 from levanter.utils.mesh import create_mesh_from_axis_specs
 from levanter.utils.tree_utils import key_path_to_str, tree_flatten_one_level_with_keys
@@ -192,7 +192,13 @@ _DATA_READY_PREFIX = "levanter/data_ready"
 _MAX_LOGGED_LAGGARDS = 32
 
 
-def data_loading_barrier(step: int, *, timeout: float, warn_interval: float = 30.0) -> None:
+def data_loading_barrier(
+    step: int,
+    *,
+    timeout: float,
+    warn_interval: float = 30.0,
+    sleep: Callable[[float], None] = time.sleep,
+) -> None:
     """Block until every process has loaded its batch for ``step``, then return.
 
     Call this between fetching a batch and the collective train step. It gates entry to the
@@ -208,6 +214,8 @@ def data_loading_barrier(step: int, *, timeout: float, warn_interval: float = 30
             keys from ``step - 1``.
         timeout: Maximum seconds to wait for all processes before raising.
         warn_interval: How often (seconds) process 0 logs the still-missing processes.
+        sleep: Injection seam for the inter-poll delay; the clock advances only through it,
+            so tests pass a no-op to run the loop without a real wait.
     """
     num_processes = jax.process_count()
     if num_processes == 1:
@@ -229,7 +237,6 @@ def data_loading_barrier(step: int, *, timeout: float, warn_interval: float = 30
     prefix = f"{_DATA_READY_PREFIX}/{step}"
     client.key_value_set(f"{prefix}/{process_id}", "1")
 
-    deadline = Deadline.from_now(Duration.from_seconds(timeout))
     backoff = ExponentialBackoff(initial=0.05, maximum=min(warn_interval, 5.0))
     ready: set[int] = set()
     next_warn = warn_interval
@@ -241,7 +248,7 @@ def data_loading_barrier(step: int, *, timeout: float, warn_interval: float = 30
             return
 
         missing = sorted(set(range(num_processes)) - ready)
-        if deadline.expired():
+        if elapsed >= timeout:
             raise TimeoutError(
                 f"data_loading_barrier timed out after {timeout:.0f}s at step {step}: "
                 f"{len(missing)}/{num_processes} processes never signalled data-ready. "
@@ -249,7 +256,7 @@ def data_loading_barrier(step: int, *, timeout: float, warn_interval: float = 30
             )
 
         interval = backoff.next_interval()
-        time.sleep(interval)
+        sleep(interval)
         elapsed += interval
 
         if is_leader and elapsed >= next_warn:

--- a/lib/levanter/src/levanter/utils/jax_utils.py
+++ b/lib/levanter/src/levanter/utils/jax_utils.py
@@ -196,6 +196,7 @@ def data_loading_barrier(
     step: int,
     *,
     timeout: float,
+    previous_step: int | None = None,
     warn_interval: float = 30.0,
     sleep: Callable[[float], None] = time.sleep,
 ) -> None:
@@ -208,11 +209,16 @@ def data_loading_barrier(
     still missing after ``warn_interval`` seconds are named in a log line by process 0; if
     any are still missing after ``timeout`` seconds, raises ``TimeoutError`` naming them.
 
+    Callers must invoke this on the same ``step`` on every process, or a process that skips
+    it will strand the others until they time out.
+
     Args:
-        step: The training step whose batch must be ready. Must increase by one on each
-            call: it namespaces the coordination keys, and entering ``step`` cleans up the
-            keys from ``step - 1``.
+        step: The training step whose batch must be ready. Namespaces the coordination keys.
         timeout: Maximum seconds to wait for all processes before raising.
+        previous_step: The step passed on the prior call, whose keys the leader deletes to
+            bound coordination-store growth. None on the first call. Safe because a train
+            step is a global collective, so every process cleared ``previous_step`` before
+            any process reaches this one.
         warn_interval: How often (seconds) process 0 logs the still-missing processes.
         sleep: Injection seam for the inter-poll delay; the clock advances only through it,
             so tests pass a no-op to run the loop without a real wait.
@@ -228,11 +234,8 @@ def data_loading_barrier(
     process_id = jax.process_index()
     is_leader = process_id == 0
 
-    # A train step is a global collective, so no process can reach the barrier for `step`
-    # until every process cleared `step - 1`. That makes it safe for the leader to delete
-    # the previous step's keys here, bounding growth of the coordination store.
-    if is_leader and step > 0:
-        client.key_value_delete(f"{_DATA_READY_PREFIX}/{step - 1}/")
+    if is_leader and previous_step is not None:
+        client.key_value_delete(f"{_DATA_READY_PREFIX}/{previous_step}/")
 
     prefix = f"{_DATA_READY_PREFIX}/{step}"
     client.key_value_set(f"{prefix}/{process_id}", "1")

--- a/lib/levanter/tests/test_data_loading_barrier.py
+++ b/lib/levanter/tests/test_data_loading_barrier.py
@@ -1,0 +1,116 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the host-side data-loading rendezvous barrier.
+
+These exercise the real rendezvous/timeout/cleanup logic against an in-memory fake of
+JAX's coordination key-value store. The fake mirrors the observable contract of the
+coordination client that was verified against a live service: ``key_value_dir_get``
+returns ``(key, value)`` pairs under a prefix, and ``key_value_delete`` removes either a
+single key or, when the argument ends in ``/``, every key under that directory.
+"""
+
+import threading
+
+import jax
+import jax._src.distributed as jax_distributed
+import pytest
+
+import levanter.utils.jax_utils as jax_utils
+from levanter.utils.jax_utils import data_loading_barrier
+
+
+class _FakeKVClient:
+    def __init__(self):
+        self.store: dict[str, str] = {}
+
+    def key_value_set(self, key: str, value: str) -> None:
+        self.store[key] = value
+
+    def key_value_dir_get(self, prefix: str):
+        return [(k, v) for k, v in self.store.items() if k.startswith(prefix)]
+
+    def key_value_delete(self, key: str) -> None:
+        if key.endswith("/"):
+            for k in [k for k in self.store if k.startswith(key)]:
+                del self.store[k]
+        else:
+            self.store.pop(key, None)
+
+
+@pytest.fixture
+def coordination(monkeypatch):
+    """Install a fake coordination client and reset the module's cleanup cursor."""
+    client = _FakeKVClient()
+    monkeypatch.setattr(jax_distributed.global_state, "client", client)
+    monkeypatch.setattr(jax_utils, "_last_data_ready_step", None)
+    return client
+
+
+def _set_world(monkeypatch, *, num_processes: int, process_id: int) -> None:
+    monkeypatch.setattr(jax, "process_count", lambda: num_processes)
+    monkeypatch.setattr(jax, "process_index", lambda: process_id)
+
+
+def test_returns_when_all_processes_ready(coordination, monkeypatch):
+    _set_world(monkeypatch, num_processes=3, process_id=0)
+    # peers 1 and 2 have already published; this process publishes its own key on entry
+    coordination.store["levanter/data_ready/7/1"] = "1"
+    coordination.store["levanter/data_ready/7/2"] = "1"
+
+    data_loading_barrier(7, timeout=5.0)
+
+    assert coordination.store["levanter/data_ready/7/0"] == "1"
+
+
+def test_waits_for_a_lagging_process(coordination, monkeypatch):
+    _set_world(monkeypatch, num_processes=2, process_id=0)
+
+    def publish_late():
+        # peer 1 shows up after this process is already polling
+        coordination.store["levanter/data_ready/3/1"] = "1"
+
+    timer = threading.Timer(0.2, publish_late)
+    timer.start()
+    try:
+        # small warn_interval exercises the leader's periodic still-waiting log path
+        data_loading_barrier(3, timeout=5.0, warn_interval=0.05)
+    finally:
+        timer.cancel()
+
+
+def test_timeout_names_the_missing_process(coordination, monkeypatch):
+    _set_world(monkeypatch, num_processes=3, process_id=0)
+    coordination.store["levanter/data_ready/9/1"] = "1"
+    # process 2 never publishes
+
+    with pytest.raises(TimeoutError) as exc:
+        data_loading_barrier(9, timeout=0.3, warn_interval=0.05)
+
+    assert "2" in str(exc.value)
+
+
+def test_single_process_is_a_noop(monkeypatch):
+    # No coordination client installed: a single-process job must not touch it.
+    monkeypatch.setattr(jax_distributed.global_state, "client", None)
+    _set_world(monkeypatch, num_processes=1, process_id=0)
+
+    data_loading_barrier(0, timeout=5.0)
+
+
+def test_leader_cleans_up_previous_step(coordination, monkeypatch):
+    _set_world(monkeypatch, num_processes=1, process_id=0)
+    # single-process short-circuits, so drive with a 1-process world but a real client by
+    # calling with a 2-process world where the peer is pre-published.
+    monkeypatch.setattr(jax, "process_count", lambda: 2)
+
+    coordination.store["levanter/data_ready/10/1"] = "1"
+    data_loading_barrier(10, timeout=5.0)
+    assert "levanter/data_ready/10/0" in coordination.store
+
+    coordination.store["levanter/data_ready/11/1"] = "1"
+    data_loading_barrier(11, timeout=5.0)
+
+    # entering step 11 deletes step 10's directory
+    assert not any(k.startswith("levanter/data_ready/10/") for k in coordination.store)
+    assert "levanter/data_ready/11/0" in coordination.store

--- a/lib/levanter/tests/test_data_loading_barrier.py
+++ b/lib/levanter/tests/test_data_loading_barrier.py
@@ -14,6 +14,7 @@ import jax
 import jax._src.distributed as jax_distributed
 import pytest
 
+from levanter.trainer import _barrier_active
 from levanter.utils.jax_utils import data_loading_barrier
 
 
@@ -122,8 +123,25 @@ def test_leader_cleans_up_previous_step(coordination, monkeypatch):
     assert "levanter/data_ready/10/0" in coordination.store
 
     coordination.store["levanter/data_ready/11/1"] = "1"
-    data_loading_barrier(11, timeout=5.0)
+    data_loading_barrier(11, timeout=5.0, previous_step=10)
 
-    # entering step 11 deletes step 10's directory
+    # entering step 11 with previous_step=10 deletes step 10's directory
     assert not any(k.startswith("levanter/data_ready/10/") for k in coordination.store)
     assert "levanter/data_ready/11/0" in coordination.store
+
+
+@pytest.mark.parametrize(
+    "step, expected",
+    [
+        (100, True),  # run start: within the first active_steps
+        (104, True),  # last step of the cold-start window
+        (105, False),  # cold-start window closed, no recent save
+        (140, False),  # steady state, far from any save
+        (201, True),  # first step after a save at 200
+        (205, True),  # last step of the post-save window
+        (206, False),  # post-save window closed
+    ],
+)
+def test_barrier_active_windows(step, expected):
+    # run resumed at step 100, most recent checkpoint saved at step 200, active_steps=5
+    assert _barrier_active(step, run_start_step=100, last_save_step=200, active_steps=5) is expected

--- a/lib/levanter/tests/test_data_loading_barrier.py
+++ b/lib/levanter/tests/test_data_loading_barrier.py
@@ -10,24 +10,30 @@ returns ``(key, value)`` pairs under a prefix, and ``key_value_delete`` removes 
 single key or, when the argument ends in ``/``, every key under that directory.
 """
 
-import threading
-
 import jax
 import jax._src.distributed as jax_distributed
 import pytest
 
-import levanter.utils.jax_utils as jax_utils
 from levanter.utils.jax_utils import data_loading_barrier
 
 
 class _FakeKVClient:
-    def __init__(self):
+    """In-memory stand-in for JAX's coordination key-value store.
+
+    ``on_dir_get`` is an optional hook invoked before each directory read, letting a test
+    reveal a lagging peer after a set number of polls without racing on wall-clock time.
+    """
+
+    def __init__(self, on_dir_get=None):
         self.store: dict[str, str] = {}
+        self._on_dir_get = on_dir_get
 
     def key_value_set(self, key: str, value: str) -> None:
         self.store[key] = value
 
     def key_value_dir_get(self, prefix: str):
+        if self._on_dir_get is not None:
+            self._on_dir_get(self.store)
         return [(k, v) for k, v in self.store.items() if k.startswith(prefix)]
 
     def key_value_delete(self, key: str) -> None:
@@ -40,10 +46,9 @@ class _FakeKVClient:
 
 @pytest.fixture
 def coordination(monkeypatch):
-    """Install a fake coordination client and reset the module's cleanup cursor."""
+    """Install a fake coordination client for the duration of a test."""
     client = _FakeKVClient()
     monkeypatch.setattr(jax_distributed.global_state, "client", client)
-    monkeypatch.setattr(jax_utils, "_last_data_ready_step", None)
     return client
 
 
@@ -63,20 +68,26 @@ def test_returns_when_all_processes_ready(coordination, monkeypatch):
     assert coordination.store["levanter/data_ready/7/0"] == "1"
 
 
-def test_waits_for_a_lagging_process(coordination, monkeypatch):
+def test_waits_for_a_lagging_process(monkeypatch):
     _set_world(monkeypatch, num_processes=2, process_id=0)
 
-    def publish_late():
-        # peer 1 shows up after this process is already polling
-        coordination.store["levanter/data_ready/3/1"] = "1"
+    # peer 1 is absent for the first two polls, then appears — deterministic, no wall clock.
+    polls = 0
 
-    timer = threading.Timer(0.2, publish_late)
-    timer.start()
-    try:
-        # small warn_interval exercises the leader's periodic still-waiting log path
-        data_loading_barrier(3, timeout=5.0, warn_interval=0.05)
-    finally:
-        timer.cancel()
+    def reveal_peer_on_third_poll(store):
+        nonlocal polls
+        polls += 1
+        if polls >= 3:
+            store["levanter/data_ready/3/1"] = "1"
+
+    client = _FakeKVClient(on_dir_get=reveal_peer_on_third_poll)
+    monkeypatch.setattr(jax_distributed.global_state, "client", client)
+
+    data_loading_barrier(3, timeout=5.0)
+
+    # returned only after polling until the lagging peer showed up
+    assert polls >= 3
+    assert client.store["levanter/data_ready/3/0"] == "1"
 
 
 def test_timeout_names_the_missing_process(coordination, monkeypatch):
@@ -99,10 +110,7 @@ def test_single_process_is_a_noop(monkeypatch):
 
 
 def test_leader_cleans_up_previous_step(coordination, monkeypatch):
-    _set_world(monkeypatch, num_processes=1, process_id=0)
-    # single-process short-circuits, so drive with a 1-process world but a real client by
-    # calling with a 2-process world where the peer is pre-published.
-    monkeypatch.setattr(jax, "process_count", lambda: 2)
+    _set_world(monkeypatch, num_processes=2, process_id=0)
 
     coordination.store["levanter/data_ready/10/1"] = "1"
     data_loading_barrier(10, timeout=5.0)

--- a/lib/levanter/tests/test_data_loading_barrier.py
+++ b/lib/levanter/tests/test_data_loading_barrier.py
@@ -52,6 +52,10 @@ def coordination(monkeypatch):
     return client
 
 
+def _no_sleep(_interval: float) -> None:
+    """Inter-poll sleep replacement so the barrier loop runs on no real wall-clock time."""
+
+
 def _set_world(monkeypatch, *, num_processes: int, process_id: int) -> None:
     monkeypatch.setattr(jax, "process_count", lambda: num_processes)
     monkeypatch.setattr(jax, "process_index", lambda: process_id)
@@ -83,7 +87,7 @@ def test_waits_for_a_lagging_process(monkeypatch):
     client = _FakeKVClient(on_dir_get=reveal_peer_on_third_poll)
     monkeypatch.setattr(jax_distributed.global_state, "client", client)
 
-    data_loading_barrier(3, timeout=5.0)
+    data_loading_barrier(3, timeout=5.0, sleep=_no_sleep)
 
     # returned only after polling until the lagging peer showed up
     assert polls >= 3
@@ -96,17 +100,18 @@ def test_timeout_names_the_missing_process(coordination, monkeypatch):
     # process 2 never publishes
 
     with pytest.raises(TimeoutError) as exc:
-        data_loading_barrier(9, timeout=0.3, warn_interval=0.05)
+        data_loading_barrier(9, timeout=0.3, warn_interval=0.05, sleep=_no_sleep)
 
     assert "2" in str(exc.value)
 
 
-def test_single_process_is_a_noop(monkeypatch):
-    # No coordination client installed: a single-process job must not touch it.
-    monkeypatch.setattr(jax_distributed.global_state, "client", None)
+def test_single_process_is_a_noop(coordination, monkeypatch):
     _set_world(monkeypatch, num_processes=1, process_id=0)
 
     data_loading_barrier(0, timeout=5.0)
+
+    # a single-process job returns before touching the coordination store
+    assert coordination.store == {}
 
 
 def test_leader_cleans_up_previous_step(coordination, monkeypatch):


### PR DESCRIPTION
A train step is a cross-host collective — every process must feed its data shard and enter the step together. When one process's data loader stalls (a transient GCS slowdown is the usual cause; it clusters right after a checkpoint, when the async checkpoint upload contends with data reads for GCS bandwidth and drains the prefetch buffer), the processes that already have their batch enter the on-device collective and block on the straggler. That wait lives on the device path, where a timeout is fatal: the job dies with an opaque coordination-service shutdown — e.g. `Shutdown barrier has failed; 1/256 tasks reached the barrier` — because the surviving processes are wedged in the collective and cannot even join a clean shutdown.

This adds a `DataLoadingBarrier`: before entering the train step, each process publishes a readiness key on JAX's coordination service after loading its batch, then waits there until all processes are ready. The wait moves off the device collective and onto the host, where a lagging loader merely delays its peers (idle and heartbeating) instead of tripping a fatal collective timeout. Process 0 logs the still-missing processes periodically, and a genuine hang fails with a `TimeoutError` that names the stuck processes rather than the current 1/N mystery.

It is enabled by default but runs only in the two windows where a process's prefetch buffer is cold and a peer is most likely to fall behind, so steady-state training pays nothing:

- the first `active_steps` of the run — the buffer starts empty (and on resume the loader also seeks), and
- the `active_steps` after each checkpoint save — the async upload contends for GCS bandwidth.

The arming decision is a pure function of globally-consistent state — the step, the resumed start step, and the checkpointer's `last_save_step` (broadcast from process 0) — so every process arms identically. This matters: a per-process signal like "is my upload still in flight" varies across hosts, and any process that skipped the barrier while others armed would strand them until timeout. It is a no-op on single-process jobs.

Config lives in `TrainerConfig.data_loading_barrier` (`enabled`, `timeout`, `active_steps`). The step-count window assumes checkpoint upload time roughly tracks step time (both scale with model size); a run with an unusually large checkpoint relative to step time can raise `active_steps`.

Alternatives considered: bumping the collective/heartbeat timeouts (blunt, delays real-failure detection); a larger prefetch buffer (absorbs short jitter but not a multi-minute slowdown); staggering checkpoint uploads against data reads (reduces the trigger but leaves the fatal-collective mode intact — orthogonal follow-up).