### PR TITLE
[iris] Derive backend device routing attrs from scale_groups

### DIFF
--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -639,9 +639,10 @@ class BackendConfig(_Config):
     (``kubernetes_provider``). ``transport`` must be ``in_process``; ``remote`` is
     rejected by :func:`validate_config`.
 
-    ``attributes`` values are comma-split into sets by
-    :func:`backend_attribute_sets` for the task→backend meta-scheduler (for
-    example ``device-variant: "v5e-4,v5p-8"``).
+    ``attributes`` holds any extra routing attributes as comma-split value sets
+    (for example ``device-variant: "v5e-4,v5p-8"``). Device attributes need not be
+    listed here: ``backend_attribute_sets`` derives ``device-type``/``device-variant``
+    from ``scale_groups`` and unions them in.
     """
 
     kind: Literal["worker_daemon", "k8s"]
@@ -1119,14 +1120,48 @@ def assert_no_inlined_secrets(config: IrisClusterConfig) -> None:
 # ===========================================================================
 
 
-def backend_attribute_sets(backend: BackendConfig) -> dict[str, set[str]]:
-    """Comma-split each ``attributes`` value into a normalized set.
+def _scale_group_device_attributes(scale_groups: Mapping[str, ScaleGroupConfig]) -> dict[str, set[str]]:
+    """Collect the ``device-type``/``device-variant`` a backend's scale groups offer.
 
-    ``device-variant: "v5e-4, v5p-8"`` becomes ``{"device-variant": {"v5e-4", "v5p-8"}}``.
-    Empty and whitespace-only entries are dropped. The task→backend meta-scheduler
-    uses this to expand set-valued attributes into posting lists.
+    Only accelerator scale groups contribute: a CPU (or unset) device type emits
+    nothing, matching a job's resource spec, whose CPU resources carry no device
+    constraint — so a CPU-only backend advertises no device attribute and stays a
+    catch-all. A blank or ``auto`` variant emits no ``device-variant``. Values are
+    lowercased so an advertised value equals the constraint literal a job matches
+    with, which is lowercased on construction. Scale groups of different variants
+    union into one set, e.g. ``device-variant: {"h100", "a100"}``.
     """
-    return {key: {part.strip() for part in raw.split(",") if part.strip()} for key, raw in backend.attributes.items()}
+    derived: dict[str, set[str]] = {}
+    for sg in scale_groups.values():
+        resources = sg.resources
+        if resources is None:
+            continue
+        device_type = resources.device_type
+        if device_type is None or device_type == AcceleratorType.CPU:
+            continue
+        derived.setdefault(WellKnownAttribute.DEVICE_TYPE.value, set()).add(device_type.value)
+        variant = resources.device_variant.strip().lower()
+        if variant and variant != "auto":
+            derived.setdefault(WellKnownAttribute.DEVICE_VARIANT.value, set()).add(variant)
+    return derived
+
+
+def backend_attribute_sets(backend: BackendConfig) -> dict[str, set[str]]:
+    """The routing attributes a backend advertises to the meta-scheduler and peers.
+
+    Explicit ``attributes`` values are comma-split into sets (``device-variant:
+    "v5e-4, v5p-8"`` becomes ``{"device-variant": {"v5e-4", "v5p-8"}}``); empty and
+    whitespace-only entries are dropped. ``device-type`` and ``device-variant`` are
+    additionally derived from ``scale_groups[*].resources`` and unioned in, so a
+    backend advertises the devices its scale groups offer without the operator
+    restating them in ``attributes``.
+    """
+    attributes = {
+        key: {part.strip() for part in raw.split(",") if part.strip()} for key, raw in backend.attributes.items()
+    }
+    for key, values in _scale_group_device_attributes(backend.scale_groups).items():
+        attributes.setdefault(key, set()).update(values)
+    return attributes
 
 
 def resolve_backends(config: IrisClusterConfig) -> dict[str, BackendConfig]:

--- a/lib/iris/src/iris/cluster/config.py
+++ b/lib/iris/src/iris/cluster/config.py
@@ -33,6 +33,7 @@ from rigging.timing import Duration
 
 from iris.cluster.tpu_topology import TPU_FAMILY_VARIANT_PREFIX, get_tpu_topology, tpu_variant_name
 from iris.cluster.types import (
+    AUTO_DEVICE_VARIANT,
     DEFAULT_BACKEND_ID,
     LOCAL_CLUSTER,
     AcceleratorType,
@@ -1141,7 +1142,7 @@ def _scale_group_device_attributes(scale_groups: Mapping[str, ScaleGroupConfig])
             continue
         derived.setdefault(WellKnownAttribute.DEVICE_TYPE.value, set()).add(device_type.value)
         variant = resources.device_variant.strip().lower()
-        if variant and variant != "auto":
+        if variant and variant != AUTO_DEVICE_VARIANT:
             derived.setdefault(WellKnownAttribute.DEVICE_VARIANT.value, set()).add(variant)
     return derived
 

--- a/lib/iris/src/iris/cluster/constraints.py
+++ b/lib/iris/src/iris/cluster/constraints.py
@@ -40,7 +40,7 @@ from typing import Any, ClassVar
 
 from iris.cluster.config import ScaleGroupResources
 from iris.cluster.tpu_topology import TpuTopologyInfo, get_tpu_topology
-from iris.cluster.types import AcceleratorType, CapacityType, WellKnownAttribute
+from iris.cluster.types import AUTO_DEVICE_VARIANT, AcceleratorType, CapacityType, WellKnownAttribute
 from iris.rpc import job_pb2
 
 # ---------------------------------------------------------------------------
@@ -747,7 +747,7 @@ def constraints_from_resources(resources: job_pb2.ResourceSpecProto) -> list[Con
         constraints.append(Constraint.create(key=WellKnownAttribute.DEVICE_TYPE, op=ConstraintOp.EQ, value=device_type))
 
     variant = get_device_variant(resources.device)
-    if variant and variant != "auto":
+    if variant and variant != AUTO_DEVICE_VARIANT:
         constraints.append(Constraint.create(key=WellKnownAttribute.DEVICE_VARIANT, op=ConstraintOp.EQ, value=variant))
 
     return constraints
@@ -782,7 +782,7 @@ def validate_tpu_request(
         return None
 
     primary = resources.device.tpu.variant
-    if not primary or primary == "auto":
+    if not primary or primary == AUTO_DEVICE_VARIANT:
         return None
 
     chips_requested = resources.device.tpu.count

--- a/lib/iris/src/iris/cluster/controller/scheduling/meta_scheduler.py
+++ b/lib/iris/src/iris/cluster/controller/scheduling/meta_scheduler.py
@@ -19,14 +19,22 @@ without any change to ``evaluate_constraint``.
 A backend with no advertised attributes matches every job (it is a catch-all):
 only constraint keys that *some* backend advertises participate in routing;
 all other constraints are left to the per-backend scheduler. This makes the
-implicit single backend an identity router.
+implicit single backend an identity router. A ``device-type=cpu`` constraint
+never participates either — CPU is fungible across every backend, so like the
+federation and scaling-group routers this one drops it before matching.
 """
 
 import logging
 from collections.abc import Callable, Sequence
 from dataclasses import dataclass, field
 
-from iris.cluster.constraints import AttributeValue, Constraint, ConstraintIndex, backend_directive
+from iris.cluster.constraints import (
+    AttributeValue,
+    Constraint,
+    ConstraintIndex,
+    backend_directive,
+    is_cpu_device_type_constraint,
+)
 from iris.cluster.types import JobName
 
 logger = logging.getLogger(__name__)
@@ -107,8 +115,9 @@ def route_jobs_to_backends(
     id). No static match finalizes the job UNSCHEDULABLE.
 
     Only constraint keys some backend advertises participate in matching; the
-    rest are left to the per-backend scheduler. The unschedulable reason never
-    names a backend the user may not see.
+    rest are left to the per-backend scheduler, and a ``device-type=cpu``
+    constraint is dropped because CPU is fungible across all backends. The
+    unschedulable reason never names a backend the user may not see.
     """
     routing_keys = {key for route in routing.values() for key in route.advertised}
     result = RoutingResult()
@@ -128,7 +137,9 @@ def route_jobs_to_backends(
                 result.unschedulable[job.job_id] = f"backend '{directive}' does not exist"
             continue
 
-        routing_constraints = [c for c in job.constraints if c.key in routing_keys]
+        routing_constraints = [
+            c for c in job.constraints if c.key in routing_keys and not is_cpu_device_type_constraint(c)
+        ]
         matched = index.matching_entities(routing_constraints) & allowed
         if not matched:
             result.unschedulable[job.job_id] = "no backend matches the job's constraints"

--- a/lib/iris/src/iris/cluster/types.py
+++ b/lib/iris/src/iris/cluster/types.py
@@ -89,6 +89,14 @@ class WellKnownAttribute(StrEnum):
     GPU_COUNT = "gpu-count"
 
 
+AUTO_DEVICE_VARIANT = "auto"
+"""Device-variant sentinel meaning "unspecified — let the platform pick a variant".
+
+A resource spec or scale group carrying this variant emits no ``device-variant``
+routing constraint or advertised attribute, so the job matches any variant.
+"""
+
+
 # The reserved cluster name for work this controller owns and runs itself. Every
 # ``jobs``/``tasks`` row carries a ``cluster`` column that defaults to
 # ``LOCAL_CLUSTER`` and holds a peer's id once the job is handed off, so the

--- a/lib/iris/tests/cluster/backends/test_config.py
+++ b/lib/iris/tests/cluster/backends/test_config.py
@@ -1909,6 +1909,21 @@ def _worker_daemon_backend(**overrides) -> BackendConfig:
     return BackendConfig(**fields)
 
 
+def _accel_scale_group(device_type: AcceleratorType, device_variant: str = "") -> ScaleGroupConfig:
+    """A scale group carrying the device fields backend attribute derivation reads."""
+    return ScaleGroupConfig(
+        name="accel",
+        num_vms=1,
+        resources=ScaleGroupResources(
+            cpu_millicores=8000,
+            memory_bytes=16 * 1024**3,
+            device_type=device_type,
+            device_variant=device_variant,
+            capacity_type=CapacityType.ON_DEMAND,
+        ),
+    )
+
+
 class TestBackendsConfig:
     """The explicit ``backends:`` map and the implicit single-backend synthesis."""
 
@@ -2001,3 +2016,63 @@ class TestBackendsConfig:
             "device-variant": {"v5e-4", "v5p-8"},
             "device-type": {"tpu"},
         }
+
+    def test_device_attrs_derived_from_scale_group_resources(self):
+        # A GPU scale group with no explicit backend attributes advertises the
+        # device-type/device-variant its resources declare, lowercased ('H100' -> 'h100')
+        # so the value equals the constraint literal a GPU job matches with.
+        backend = _worker_daemon_backend(scale_groups={"h100-8x": _accel_scale_group(AcceleratorType.GPU, "H100")})
+        assert backend_attribute_sets(backend) == {"device-type": {"gpu"}, "device-variant": {"h100"}}
+
+    def test_cpu_scale_group_advertises_no_device_attrs(self):
+        # A CPU-only backend derives nothing, staying a routing catch-all as before.
+        backend = _worker_daemon_backend(scale_groups={"cpu": _accel_scale_group(AcceleratorType.CPU)})
+        assert backend_attribute_sets(backend) == {}
+
+    def test_multi_scale_group_backend_advertises_variant_union(self):
+        # Several accelerator groups union their variants; a CPU group adds nothing.
+        backend = _worker_daemon_backend(
+            scale_groups={
+                "h100": _accel_scale_group(AcceleratorType.GPU, "H100"),
+                "a100": _accel_scale_group(AcceleratorType.GPU, "A100"),
+                "cpu": _accel_scale_group(AcceleratorType.CPU),
+            }
+        )
+        assert backend_attribute_sets(backend) == {"device-type": {"gpu"}, "device-variant": {"h100", "a100"}}
+
+    def test_derived_device_attrs_union_with_explicit_attributes(self):
+        # Explicit non-device attributes are preserved; an explicit device-variant
+        # unions with the derived one rather than being overwritten.
+        backend = _worker_daemon_backend(
+            attributes={"pool": "h100-8x", "device-variant": "a100"},
+            scale_groups={"h100": _accel_scale_group(AcceleratorType.GPU, "H100")},
+        )
+        assert backend_attribute_sets(backend) == {
+            "pool": {"h100-8x"},
+            "device-type": {"gpu"},
+            "device-variant": {"a100", "h100"},
+        }
+
+    def test_auto_variant_derives_device_type_only(self):
+        # A blank or 'auto' variant yields device-type but no device-variant,
+        # matching constraints_from_resources which emits no variant constraint.
+        backend = _worker_daemon_backend(scale_groups={"tpu": _accel_scale_group(AcceleratorType.TPU, "auto")})
+        assert backend_attribute_sets(backend) == {"device-type": {"tpu"}}
+
+    def test_coreweave_implicit_config_advertises_gpu_attrs(self):
+        # The CoreWeave configs use the implicit single-backend shape (no backends:).
+        # resolve_backends synthesizes one backend whose GPU scale group must
+        # advertise device-type/device-variant, else a GPU job can neither route to
+        # it locally nor federate to it as a peer.
+        iris_root = Path(__file__).parent.parent.parent.parent
+        for rel in ("config/examples/coreweave.yaml", "config/cw-us-east-02a.yaml"):
+            config_path = iris_root / rel
+            if not config_path.exists():
+                pytest.skip(f"Config not found: {rel}")
+            config = load_config(config_path)
+            resolved = resolve_backends(config)
+            assert list(resolved) == [DEFAULT_BACKEND_ID]
+            assert backend_attribute_sets(resolved[DEFAULT_BACKEND_ID]) == {
+                "device-type": {"gpu"},
+                "device-variant": {"h100"},
+            }

--- a/lib/iris/tests/cluster/controller/test_meta_scheduler.py
+++ b/lib/iris/tests/cluster/controller/test_meta_scheduler.py
@@ -8,7 +8,13 @@ decide which backend each job pins to (or why it cannot be placed). No DB, no
 scheduler, no controller.
 """
 
-from iris.cluster.config import AllowPolicy, BackendConfig, backend_attribute_sets
+from iris.cluster.config import (
+    AllowPolicy,
+    BackendConfig,
+    ScaleGroupConfig,
+    ScaleGroupResources,
+    backend_attribute_sets,
+)
 from iris.cluster.constraints import Constraint, ConstraintOp
 from iris.cluster.controller.scheduling.meta_scheduler import (
     BackendRouting,
@@ -16,7 +22,7 @@ from iris.cluster.controller.scheduling.meta_scheduler import (
     build_backend_index,
     route_jobs_to_backends,
 )
-from iris.cluster.types import JobName
+from iris.cluster.types import AcceleratorType, JobName
 
 
 def _eq(key: str, value: str) -> Constraint:
@@ -25,6 +31,22 @@ def _eq(key: str, value: str) -> Constraint:
 
 def _backend(kind: str = "worker_daemon", **attributes: str) -> BackendConfig:
     return BackendConfig(kind=kind, attributes=dict(attributes))
+
+
+def _accel_backend(*groups: tuple[str, str]) -> BackendConfig:
+    """A backend in the composer-synthesized shape: device attributes come from
+    scale_groups (as ``resolve_backends`` builds them), not literal ``attributes``.
+    Each group is a ``(device_type, device_variant)`` pair.
+    """
+    scale_groups = {
+        f"sg{i}": ScaleGroupConfig(
+            name=f"sg{i}",
+            num_vms=1,
+            resources=ScaleGroupResources(device_type=AcceleratorType(dt), device_variant=dv),
+        )
+        for i, (dt, dv) in enumerate(groups)
+    }
+    return BackendConfig(kind="worker_daemon", scale_groups=scale_groups)
 
 
 def _job(name: str, *constraints: Constraint, user: str = "alice") -> RoutableJob:
@@ -168,3 +190,67 @@ def test_multiple_matches_break_ties_deterministically():
 
     # Default tie-break is the lexicographically smallest backend id.
     assert result.pins == {job.job_id: "a-first"}
+
+
+# --- Attributes auto-derived from scale_groups (no literal `attributes`) --------
+# The same backend_attribute_sets map that these exercise also feeds the
+# federation router, so routing here mirrors what a peer advertises live.
+
+
+def test_scale_group_derived_attrs_route_a_matching_job():
+    # A backend synthesized from a GPU scale group advertises device-type and
+    # device-variant with no literal attributes; a job requesting them routes to it.
+    configs = {"cw": _accel_backend(("gpu", "H100"))}
+    job = _job("j", _eq("device-type", "gpu"), _eq("device-variant", "h100"))
+
+    result = _route(configs, job)
+
+    assert result.pins == {job.job_id: "cw"}
+
+
+def test_multi_scale_group_backend_routes_either_variant():
+    # Two GPU scale groups on one backend advertise the union of their variants.
+    configs = {"cw": _accel_backend(("gpu", "H100"), ("gpu", "A100"))}
+    to_h100 = _job("h", _eq("device-variant", "h100"))
+    to_a100 = _job("a", _eq("device-variant", "a100"))
+
+    result = _route(configs, to_h100, to_a100)
+
+    assert result.pins == {to_h100.job_id: "cw", to_a100.job_id: "cw"}
+
+
+def test_cpu_only_backend_derives_nothing_and_stays_catch_all():
+    # An existing CPU-only single-backend cluster derives no device attributes, so
+    # it keeps matching every job regardless of constraints (unchanged behavior).
+    configs = {"default": _accel_backend(("cpu", ""))}
+    job = _job("j", _eq("device-variant", "anything"), _eq("zone", "z"))
+
+    result = _route(configs, job)
+
+    assert result.pins == {job.job_id: "default"}
+
+
+def test_mixed_cpu_gpu_backend_routes_both_cpu_and_gpu_jobs():
+    # The CoreWeave shape: a CPU group plus a GPU group. The backend advertises
+    # only the GPU attributes; a GPU job matches them and a CPU job (no device
+    # constraints) still routes because those keys never appear in its constraints.
+    configs = {"default": _accel_backend(("cpu", ""), ("gpu", "H100"))}
+    gpu_job = _job("g", _eq("device-type", "gpu"), _eq("device-variant", "h100"))
+    cpu_job = _job("c")
+
+    result = _route(configs, gpu_job, cpu_job)
+
+    assert result.pins == {gpu_job.job_id: "default", cpu_job.job_id: "default"}
+
+
+def test_single_backend_rejects_a_variant_it_does_not_provide():
+    # Behavior change (fail fast): a single GPU backend advertises its variant, so a
+    # job requesting a different variant is unschedulable at meta-scheduling rather
+    # than dispatched and then failed by the per-backend scheduler.
+    configs = {"default": _accel_backend(("gpu", "H100"))}
+    job = _job("j", _eq("device-type", "gpu"), _eq("device-variant", "a100"))
+
+    result = _route(configs, job)
+
+    assert job.job_id not in result.pins
+    assert "no backend matches" in result.unschedulable[job.job_id]

--- a/lib/iris/tests/cluster/controller/test_meta_scheduler.py
+++ b/lib/iris/tests/cluster/controller/test_meta_scheduler.py
@@ -254,3 +254,34 @@ def test_single_backend_rejects_a_variant_it_does_not_provide():
 
     assert job.job_id not in result.pins
     assert "no backend matches" in result.unschedulable[job.job_id]
+
+
+def test_explicit_cpu_device_type_constraint_stays_routable():
+    # A GPU backend advertises device-type, making it a routing key. A CPU-pinned
+    # job (explicit device-type=cpu) must not be rejected: CPU is fungible, so the
+    # constraint is dropped before matching — as the federation and scaling-group
+    # routers already do — and the job routes to a backend.
+    configs = {
+        "cpu": _accel_backend(("cpu", "")),
+        "gpu": _accel_backend(("gpu", "H100")),
+    }
+    job = _job("j", _eq("device-type", "cpu"))
+
+    result = _route(configs, job)
+
+    assert job.job_id in result.pins
+    assert result.unschedulable == {}
+
+
+def test_cpu_constraint_alongside_gpu_variant_still_routes_by_variant():
+    # Dropping device-type=cpu must not drop the other routing constraints: a job
+    # carrying both device-type=cpu and device-variant=h100 still routes by variant.
+    configs = {
+        "cw": _accel_backend(("gpu", "H100")),
+        "gcp": _accel_backend(("gpu", "A100")),
+    }
+    job = _job("j", _eq("device-type", "cpu"), _eq("device-variant", "h100"))
+
+    result = _route(configs, job)
+
+    assert result.pins == {job.job_id: "cw"}


### PR DESCRIPTION
`backend_attribute_sets()` advertised only the literal `BackendConfig.attributes` dict, which is empty for every implicit single-backend config — the shape all CoreWeave clusters use. So a CoreWeave k8s backend advertised `{}`, the federation router's `device-type`/`device-variant` match against it always failed, and a GPU job never auto-routed to a CoreWeave peer: it fell back to local and failed unschedulable. Only an explicit `--target-cluster` pin worked, because that bypasses the capability check.

Now `backend_attribute_sets()` derives `device-type`/`device-variant` from `scale_groups[*].resources` and unions them with any explicit attributes, so a backend advertises the devices its scale groups offer without the operator restating them (the same auto-derivation the codebase already applies to worker attributes). Values are lowercased to equal the constraint literal a job matches with; CPU scale groups contribute nothing, so CPU-only clusters stay routing catch-alls.

### For an existing config

`config/cw-us-east-02a.yaml` is an implicit single-backend config (no `backends:`) with two scale groups:

```yaml
scale_groups:
  cpu-erapids:
    resources: { device_type: cpu, ... }
  h100-8x:
    resources: { device_type: gpu, device_variant: H100, device_count: 8, ... }
```

`resolve_backends()` synthesizes one backend (`default`) with `attributes={}`, so:

| | `backend_attribute_sets(default)` |
|---|---|
| before | `{}` (advertises nothing → invisible to federation, catch-all locally) |
| after | `{device-type: {gpu}, device-variant: {h100}}` |

The CPU group adds nothing; `H100` is lowercased to `h100` so it equals the constraint a GPU job carries. No config edit was needed — the device attrs come straight from the resources the group already declares.

### How the advertised map flows

The one map from `backend_attribute_sets()` feeds both routing layers — the local meta-scheduler index and the capability heartbeat a remote controller's federation router reads:

```mermaid
flowchart TD
    SG["scale_groups[*].resources<br/>(device_type=gpu, device_variant=H100)"] --> BAS["backend_attribute_sets()"]
    EXP["explicit BackendConfig.attributes"] --> BAS
    BAS --> ADV["advertised = {device-type:{gpu}, device-variant:{h100}}"]
    ADV -->|configure_routing → advertised_attributes| MS["local meta-scheduler index<br/>(build_backend_index)"]
    ADV -->|capability heartbeat| PEER["remote controller's federation router<br/>(_peer_can_host / _backend_satisfies)"]
```

### Submit path for a GPU job

A user submits an `H100` job to a marin (TPU-only) controller. The job's constraints are derived from its resource spec, made visible to routing, matched against peers' advertised capabilities to pick CoreWeave, handed off, then routed to a backend and scheduled there:

```mermaid
sequenceDiagram
    actor User
    participant Local as marin controller (TPU)
    participant Router as Federation router
    participant CW as CoreWeave controller
    participant Meta as CW meta-scheduler
    participant Sched as CW per-backend scheduler

    User->>Local: submit job (device=gpu, variant=H100)
    Note over Local: constraint visibility<br/>constraints_from_resources → device-type=gpu, device-variant=h100
    Local->>Router: decide(constraints, local_feasible=false)
    Note over Router: federation / peer selection<br/>no local TPU backend hosts gpu → match constraints vs each peer's heartbeat
    Router->>CW: _peer_can_host? {device-type:{gpu}, device-variant:{h100}} satisfies both ✓
    Router-->>Local: route to CoreWeave
    Local->>CW: hand off whole job
    Note over Meta: meta-scheduler<br/>match constraints vs advertised → pin job to `default`
    CW->>Meta: route unpinned job to a backend
    Meta->>Sched: pinned to `default`
    Sched->>Sched: scheduling<br/>place task on an h100-8x worker
```

Stage by stage: **constraint visibility** — only keys some backend advertises participate in routing, so before this change `device-variant` was never a routing key on a single-backend cluster; **federation** — the router matches the job's routing constraints against each reachable peer's live heartbeat; **peer selection** — CoreWeave's `default` backend now satisfies `device-type=gpu` and `device-variant=h100`, so the job is handed off (previously it stayed local and failed); **meta-scheduler** — on CoreWeave, the same advertised map pins the job to `default`; **scheduling** — the per-backend scheduler places the task on an `h100-8x` worker.

### Blast radius

The same map also feeds the local meta-scheduler, so an accelerator cluster now advertises its variants there too. A job requesting a variant no scale group provides is rejected at meta-scheduling rather than dispatched and then failed by the per-backend scheduler — arguably more correct, and a behavior change for every accelerator cluster. Jobs that can actually run are unaffected: workers already advertise the same scale-group-derived `device-variant`, so anything that matched a worker still matches the backend.

Advertising `device-type` also makes it a meta-scheduler routing key, so the meta-scheduler now drops explicit `device-type=cpu` constraints before matching — CPU is fungible across all backends, and the federation router (`routing_constraints`) and scaling-group router (`matches_constraints`) already strip it. Without this, a CPU-pinned job on a cluster with an accelerator backend would match no backend (CPU groups advertise nothing).

Also hoists the `"auto"` device-variant sentinel to a named `AUTO_DEVICE_VARIANT` constant shared by the config derivation and `constraints.py`.

Part of #7034 (marin↔CoreWeave Iris federation rollout).
