### PR TITLE
datakit/testbed: size-tagged sample roots + subset decon

### DIFF
--- a/experiments/datakit/testbed/decon_arm.py
+++ b/experiments/datakit/testbed/decon_arm.py
@@ -29,6 +29,7 @@ import os
 
 from fray import ResourceConfig
 from marin.datakit.decon import build_eval_bloom_step, decon_step
+from marin.datakit.sources import all_sources
 from marin.execution.step_runner import StepRunner
 from marin.execution.step_spec import StepSpec
 from rigging.filesystem import marin_prefix
@@ -54,16 +55,24 @@ WORKER_RESOURCES = ResourceConfig(cpu=2, ram="8g")
 def build_testbed_decon_steps(
     target_total_tokens_b: float = RAW_TARGET_TOTAL_TOKENS_B,
     only_sources: list[str] | None = None,
+    exclude_sources: frozenset[str] = frozenset(),
 ) -> list[StepSpec]:
     """Bloom (fixed) + one decon step per sampled source.
 
     ``only_sources`` restricts the decon fan-out to named sources (for smokes);
     StepRunner still walks each decon step's deps, so the matching sample +
-    normalize chains run on demand. Sample fractions are always the full 1T
-    proportional fractions, so a restricted run still decons a source's true
-    1T-share sample.
+    normalize chains run on demand.
+
+    ``exclude_sources`` drops sources from the sample *construction* — the
+    proportional fractions are recomputed over the kept set, so this must match
+    the exclusion used to build the samples being deconned (e.g. the
+    finetranslations + ghalogs/public exclusion behind the CoreWeave testbed's
+    115-source ``sample_{100b,500b,1t}_*`` roots). Leave empty for the full
+    117-source fractions. Mutually distinct from ``only_sources``, which only
+    narrows the fan-out without changing fractions.
     """
-    testbed_steps = build_testbed_steps(target_total_tokens_b=target_total_tokens_b)
+    sources = [s for n, s in all_sources().items() if n not in exclude_sources] if exclude_sources else None
+    testbed_steps = build_testbed_steps(target_total_tokens_b=target_total_tokens_b, sources=sources)
     sampled = {
         s.name.removeprefix(_SAMPLE_STEP_PREFIX): s for s in testbed_steps if s.name.startswith(_SAMPLE_STEP_PREFIX)
     }
@@ -108,9 +117,22 @@ def main() -> None:
     configure_logging(logging.INFO)
     ap = argparse.ArgumentParser()
     ap.add_argument("--only", nargs="*", default=None, help="restrict decon to these source names (smoke)")
+    ap.add_argument(
+        "--exclude",
+        nargs="*",
+        default=None,
+        help="drop these sources from the sample construction (recomputes fractions; "
+        "match the samples being deconned, e.g. finetranslations ghalogs/public for the CoreWeave testbed)",
+    )
     ap.add_argument("--target-tokens-b", type=float, default=RAW_TARGET_TOTAL_TOKENS_B)
     args = ap.parse_args()
-    StepRunner().run(build_testbed_decon_steps(target_total_tokens_b=args.target_tokens_b, only_sources=args.only))
+    StepRunner().run(
+        build_testbed_decon_steps(
+            target_total_tokens_b=args.target_tokens_b,
+            only_sources=args.only,
+            exclude_sources=frozenset(args.exclude or ()),
+        )
+    )
 
 
 if __name__ == "__main__":

--- a/experiments/datakit/testbed/sampler.py
+++ b/experiments/datakit/testbed/sampler.py
@@ -33,6 +33,7 @@ import math
 import os
 from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
+from dataclasses import replace
 
 import pyarrow.parquet as pq
 from fray import ResourceConfig
@@ -334,37 +335,42 @@ def _size_tag(target_total_tokens_b: float) -> str:
     return f"{int(tb)}b" if tb == int(tb) else f"{tb:g}b"
 
 
-def _sample_root(target_total_tokens_b: float, fractions: dict[str, float]) -> str:
+def _sample_root(target_total_tokens_b: float, sample_step_hashes: Sequence[str]) -> str:
     """Per-size output root ``{MARIN_PREFIX}/datakit/sample_{tag}_{hash}``.
 
-    ``hash`` is a deterministic digest of the token target and every source's
-    sample fraction, so a testbed size is content-addressed: change the target,
-    the source set, or any source's token count (which shifts the fractions) and
-    the whole sample lands at a fresh root. All sources for a size share the one
-    root and nest under it by name (``.../sample_1t_<hash>/<source>/``).
+    ``hash`` digests the token target plus every source's sample-step identity
+    (``StepSpec.name_with_hash``). A sample step already hashes its
+    ``sample_fraction`` and its ``normalized`` dependency, so seeding the root
+    with those identities makes the size fully content-addressed: change the
+    target, the source set, a source's token count (shifts a fraction), or a
+    source's normalize recipe (changes its dep hash) and the whole sample lands
+    at a fresh root. All sources for a size share the one root and nest under it
+    by name (``.../sample_1t_<hash>/<source>/``).
+
+    We fold the sample-step identity into the *root* rather than the per-source
+    path so the flat ``sample_<tag>_<hash>/<source>/`` layout is preserved while
+    still closing the stale-shard hole ``override_output_path`` would otherwise
+    open — it pins each sample to a fixed path, bypassing the step's own hash.
     """
-    key = repr((round(target_total_tokens_b, 6), tuple(sorted((n, round(f, 12)) for n, f in fractions.items()))))
+    key = repr((round(target_total_tokens_b, 6), tuple(sorted(sample_step_hashes))))
     digest = hashlib.sha256(key.encode()).hexdigest()[:8]
     return f"{marin_prefix()}/datakit/sample_{_size_tag(target_total_tokens_b)}_{digest}"
 
 
-def _sample_step_for(
-    src: DatakitSource,
-    normalized: StepSpec,
-    sample_fraction: float,
-    output_root: str,
-) -> StepSpec:
-    """Per-source post-normalize sampler. Copies first ceil(N * fraction) shards.
+def _sample_step_for(src: DatakitSource, normalized: StepSpec, sample_fraction: float) -> StepSpec:
+    """Per-source post-normalize sampler (bare; output routing applied later).
 
-    Step name stays ``data/datakit/normalized/{src.name}`` (consumers map
-    sources by step name), while the data is routed under the shared per-size
-    ``output_root`` via ``override_output_path``.
+    Copies the first ceil(N * fraction) shards. Step name stays
+    ``data/datakit/normalized/{src.name}`` (consumers map sources by step name).
+    Built without an output override: the returned step's ``name_with_hash``
+    already bundles ``sample_fraction`` + the ``normalized`` dep and is
+    independent of the final root, so it seeds the content-addressed root, which
+    is then routed back in via ``replace(override_output_path=...)``.
     """
     return sample_normalized_shards_step(
         name=f"data/datakit/normalized/{src.name}",
         normalized=normalized,
         sample_fraction=sample_fraction,
-        override_output_path=prefix_join(output_root, src.name),
     )
 
 
@@ -383,8 +389,9 @@ def build_testbed_steps(
     terminal normalize step. All sample outputs for a size land under one
     content-addressed root ``{MARIN_PREFIX}/datakit/sample_{tag}_{hash}/`` and
     nest under it by source name (see :func:`_sample_root`); the ``hash``
-    covers the token target + every source's fraction, so different sizes never
-    collide. Tokenize runs in the training executor graph (see
+    covers the token target + every source's sample-step identity (its fraction
+    and normalize dep), so different sizes never collide and an upstream
+    normalize change re-addresses the sample. Tokenize runs in the training executor graph (see
     :mod:`experiments.datakit.testbed.train`), not the ferry.
 
     Args:
@@ -407,16 +414,21 @@ def build_testbed_steps(
         raise ValueError("build_testbed_steps requires at least one source")
 
     fractions = proportional_sample_fractions(sources, target_total_tokens_b=target_total_tokens_b)
-    output_root = _sample_root(target_total_tokens_b, fractions)
+    # Build each source's sample step first; its name_with_hash already bundles
+    # sample_fraction + the normalized dep and is independent of the output root,
+    # so it seeds the content-addressed root before we route the step under it.
+    sample_steps = {src.name: _sample_step_for(src, src.normalized, fractions[src.name]) for src in sources}
+    output_root = _sample_root(target_total_tokens_b, [s.name_with_hash for s in sample_steps.values()])
 
-    # Flat list of every source's normalize chain + terminal sample step.
+    # Flat list of every source's normalize chain + terminal sample step, the
+    # latter re-routed under the shared per-size root via override_output_path.
     # StepRunner walks transitive deps and dedupes by output_path, so shared
     # family downloads (e.g. Nemotron v2 subsets) are safe to emit more than
     # once; hidden deps reached only through a step's ``.deps`` resolve too.
     all_steps: list[StepSpec] = []
     for src in sources:
         all_steps.extend(src.normalize_steps)
-        all_steps.append(_sample_step_for(src, src.normalized, fractions[src.name], output_root))
+        all_steps.append(replace(sample_steps[src.name], override_output_path=prefix_join(output_root, src.name)))
 
     logger.info(
         "Built testbed DAG: %d sources, %d steps (normalize chains + sample), target %.0fB tokens -> %s",

--- a/experiments/datakit/testbed/sampler.py
+++ b/experiments/datakit/testbed/sampler.py
@@ -27,6 +27,7 @@ Design choices:
   against ``RAW_TARGET_TOTAL_TOKENS_B`` via :func:`proportional_sample_fractions`.
 """
 
+import hashlib
 import logging
 import math
 import os
@@ -40,7 +41,7 @@ from marin.datakit.sources import DatakitSource, all_sources
 from marin.execution.artifact import read_artifact
 from marin.execution.remote import remote
 from marin.execution.step_spec import StepSpec
-from rigging.filesystem import StoragePath, url_to_fs
+from rigging.filesystem import StoragePath, marin_prefix, url_to_fs
 
 from experiments.datakit.testbed.settings import RAW_TARGET_TOTAL_TOKENS_B
 
@@ -325,16 +326,45 @@ def sample_normalized_shards_step(
     )
 
 
+def _size_tag(target_total_tokens_b: float) -> str:
+    """Short human label for a token target: ``1000.0`` -> ``1t``, ``100.0`` -> ``100b``."""
+    tb = target_total_tokens_b
+    if tb >= 1000 and tb % 1000 == 0:
+        return f"{int(tb // 1000)}t"
+    return f"{int(tb)}b" if tb == int(tb) else f"{tb:g}b"
+
+
+def _sample_root(target_total_tokens_b: float, fractions: dict[str, float]) -> str:
+    """Per-size output root ``{MARIN_PREFIX}/datakit/sample_{tag}_{hash}``.
+
+    ``hash`` is a deterministic digest of the token target and every source's
+    sample fraction, so a testbed size is content-addressed: change the target,
+    the source set, or any source's token count (which shifts the fractions) and
+    the whole sample lands at a fresh root. All sources for a size share the one
+    root and nest under it by name (``.../sample_1t_<hash>/<source>/``).
+    """
+    key = repr((round(target_total_tokens_b, 6), tuple(sorted((n, round(f, 12)) for n, f in fractions.items()))))
+    digest = hashlib.sha256(key.encode()).hexdigest()[:8]
+    return f"{marin_prefix()}/datakit/sample_{_size_tag(target_total_tokens_b)}_{digest}"
+
+
 def _sample_step_for(
     src: DatakitSource,
     normalized: StepSpec,
     sample_fraction: float,
+    output_root: str,
 ) -> StepSpec:
-    """Per-source post-normalize sampler. Copies first ceil(N * fraction) shards."""
+    """Per-source post-normalize sampler. Copies first ceil(N * fraction) shards.
+
+    Step name stays ``data/datakit/normalized/{src.name}`` (consumers map
+    sources by step name), while the data is routed under the shared per-size
+    ``output_root`` via ``override_output_path``.
+    """
     return sample_normalized_shards_step(
         name=f"data/datakit/normalized/{src.name}",
         normalized=normalized,
         sample_fraction=sample_fraction,
+        override_output_path=f"{output_root}/{src.name}",
     )
 
 
@@ -350,10 +380,11 @@ def build_testbed_steps(
     Each :class:`DatakitSource` already carries its full
     ``(download, ..., normalize)`` :class:`StepSpec` chain; this function
     appends the testbed-specific sample stage on top of every source's
-    terminal normalize step. Sample outputs land at hashed paths
-    (``data/datakit/normalized/{src.name}-{hash}/``) — the hash incorporates
-    ``sample_fraction`` so different fractions don't collide. Tokenize
-    runs in the training executor graph (see
+    terminal normalize step. All sample outputs for a size land under one
+    content-addressed root ``{MARIN_PREFIX}/datakit/sample_{tag}_{hash}/`` and
+    nest under it by source name (see :func:`_sample_root`); the ``hash``
+    covers the token target + every source's fraction, so different sizes never
+    collide. Tokenize runs in the training executor graph (see
     :mod:`experiments.datakit.testbed.train`), not the ferry.
 
     Args:
@@ -376,6 +407,7 @@ def build_testbed_steps(
         raise ValueError("build_testbed_steps requires at least one source")
 
     fractions = proportional_sample_fractions(sources, target_total_tokens_b=target_total_tokens_b)
+    output_root = _sample_root(target_total_tokens_b, fractions)
 
     # Flat list of every source's normalize chain + terminal sample step.
     # StepRunner walks transitive deps and dedupes by output_path, so shared
@@ -384,12 +416,13 @@ def build_testbed_steps(
     all_steps: list[StepSpec] = []
     for src in sources:
         all_steps.extend(src.normalize_steps)
-        all_steps.append(_sample_step_for(src, src.normalized, fractions[src.name]))
+        all_steps.append(_sample_step_for(src, src.normalized, fractions[src.name], output_root))
 
     logger.info(
-        "Built testbed DAG: %d sources, %d steps (normalize chains + sample), target %.0fB tokens",
+        "Built testbed DAG: %d sources, %d steps (normalize chains + sample), target %.0fB tokens -> %s",
         len(sources),
         len(all_steps),
         target_total_tokens_b,
+        output_root,
     )
     return all_steps

--- a/experiments/datakit/testbed/sampler.py
+++ b/experiments/datakit/testbed/sampler.py
@@ -41,7 +41,7 @@ from marin.datakit.sources import DatakitSource, all_sources
 from marin.execution.artifact import read_artifact
 from marin.execution.remote import remote
 from marin.execution.step_spec import StepSpec
-from rigging.filesystem import StoragePath, marin_prefix, url_to_fs
+from rigging.filesystem import StoragePath, marin_prefix, prefix_join, url_to_fs
 
 from experiments.datakit.testbed.settings import RAW_TARGET_TOTAL_TOKENS_B
 
@@ -364,7 +364,7 @@ def _sample_step_for(
         name=f"data/datakit/normalized/{src.name}",
         normalized=normalized,
         sample_fraction=sample_fraction,
-        override_output_path=f"{output_root}/{src.name}",
+        override_output_path=prefix_join(output_root, src.name),
     )
 
 

--- a/lib/marin/src/marin/datakit/download/finetranslations.py
+++ b/lib/marin/src/marin/datakit/download/finetranslations.py
@@ -83,6 +83,10 @@ def finetranslations_normalize_steps() -> tuple[StepSpec, ...]:
         hf_dataset_id=FINETRANSLATIONS_HF_ID,
         revision=FINETRANSLATIONS_REVISION,
         hf_urls_glob=["data/**/*.parquet"],
+        # ~7.1k parquet files; the default 8-way download crawls. 16 workers
+        # roughly halves wall-clock (not a hash_attr, so bumping it resumes the
+        # existing partial download rather than restarting it).
+        zephyr_max_parallelism=16,
     )
     processed = StepSpec(
         name="processed/finetranslations",

--- a/scripts/datakit/populate_finetranslations.py
+++ b/scripts/datakit/populate_finetranslations.py
@@ -1,0 +1,21 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Populate the finetranslations normalized output under the active MARIN_PREFIX.
+
+Runs the full download -> fold-parallel-text -> normalize chain; already-done
+sub-steps skip via the on-disk step cache.
+"""
+
+from marin.datakit.sources import all_sources
+from marin.execution.step_runner import StepRunner
+from rigging.log_setup import configure_logging
+
+
+def main() -> None:
+    configure_logging()
+    StepRunner().run([all_sources()["finetranslations"].normalized])
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
* size-tag the content-addressed testbed sample output roots — the three target sizes now land at distinct self-describing paths (`sample_100b_<digest>` / `sample_500b_<digest>` / `sample_1t_<digest>`) instead of colliding on one hash
* `decon_arm`: add `exclude_sources` (CLI `--exclude`) to target a source subset — drops sources from the sample *construction* so the proportional fractions match the samples being deconned
  * used for the CoreWeave testbed, whose 115-source `sample_*` roots exclude `finetranslations` + `ghalogs/public` (neither normalized on CW yet); smoke over the two numinamath sources flagged 0.26% / 0.60% against the 1.65M-record eval bloom
  * `only_sources` still just narrows the fan-out without changing fractions
* `finetranslations`: bump the hf download to 16-way parallelism — 7.1k parquet shards crawl at the default 8-way; not a `hash_attr`, so it resumes an existing partial download rather than restarting
  * add `scripts/datakit/populate_finetranslations.py` to run the `download → fold → normalize` chain under the active `MARIN_PREFIX`
