### PR TITLE
[iris] Record delta migrations as applied on a fresh controller DB

### DIFF
--- a/lib/iris/AGENTS.md
+++ b/lib/iris/AGENTS.md
@@ -55,7 +55,11 @@ design notes:
 
 - `controller/schema.py` — table definitions and indexes.
 - `controller/migrations/` — on-disk schema changes. Add a migration whenever
-  changing persisted schema.
+  changing persisted schema. A migration only ever runs against a DB created
+  before it: a fresh DB is materialized from `schema.py` and records every
+  migration as already applied. So write each one to carry the *previous* schema
+  forward, and to be re-runnable after a mid-migration crash — never to depend on
+  the current `schema.py`, which will keep moving.
 - `controller/db.py` — engine setup, transaction wrappers, and `Tx.execute`.
 - `controller/reads.py` / `controller/writes.py` — shared read/write helpers.
 - `controller/projections/` — write-through caches; do not write projection

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -579,7 +579,7 @@ class ControllerDB:
             raise
 
     def _record_migrations(self, names: Sequence[str]) -> None:
-        """Mark ``names`` applied on a freshly checked-out write connection."""
+        """Mark ``names`` applied — all or none. Callers must not hold the write connection."""
         raw_conn = self._sa_write_engine.raw_connection()
         try:
             self._insert_migration_rows(raw_conn, names)

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -563,21 +563,26 @@ class ControllerDB:
             return []
         return [path for path in sorted(migrations_dir.glob("*.py")) if not path.name.startswith("__")]
 
+    @staticmethod
+    def _insert_migration_rows(raw_conn, names: Sequence[str]) -> None:
+        """Mark ``names`` applied on ``raw_conn`` in one transaction — all or none."""
+        raw_conn.execute("BEGIN IMMEDIATE")
+        try:
+            now_ms = Timestamp.now().epoch_ms()
+            raw_conn.executemany(
+                "INSERT INTO schema_migrations(name, applied_at_ms) VALUES (?, ?)",
+                [(name, now_ms) for name in names],
+            )
+            raw_conn.commit()
+        except Exception:
+            raw_conn.execute("ROLLBACK")
+            raise
+
     def _record_migrations(self, names: Sequence[str]) -> None:
-        """Mark ``names`` applied in one transaction — all or none."""
+        """Mark ``names`` applied on a freshly checked-out write connection."""
         raw_conn = self._sa_write_engine.raw_connection()
         try:
-            raw_conn.execute("BEGIN IMMEDIATE")
-            try:
-                now_ms = Timestamp.now().epoch_ms()
-                raw_conn.executemany(
-                    "INSERT INTO schema_migrations(name, applied_at_ms) VALUES (?, ?)",
-                    [(name, now_ms) for name in names],
-                )
-                raw_conn.commit()
-            except Exception:
-                raw_conn.execute("ROLLBACK")
-                raise
+            self._insert_migration_rows(raw_conn, names)
         finally:
             raw_conn.close()
 
@@ -606,16 +611,9 @@ class ControllerDB:
                 raw_conn.commit()
                 logger.info("Migration %s applied in %.2fs", path.name, time.monotonic() - t0)
 
-                raw_conn.execute("BEGIN IMMEDIATE")
-                try:
-                    raw_conn.execute(
-                        "INSERT INTO schema_migrations(name, applied_at_ms) VALUES (?, ?)",
-                        (path.name, Timestamp.now().epoch_ms()),
-                    )
-                    raw_conn.commit()
-                except Exception:
-                    raw_conn.execute("ROLLBACK")
-                    raise
+                # Reuse the held connection: the pool_size=1 write pool cannot
+                # hand out a second one while this migration run holds it.
+                self._insert_migration_rows(raw_conn, [path.name])
         finally:
             raw_conn.commit()
             raw_conn.execute("PRAGMA synchronous=NORMAL")

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -455,11 +455,10 @@ class ControllerDB:
 
         The current schema is materialized declaratively from ``schema.py``'s
         ``metadata`` / ``auth_metadata`` via ``Table.create_all`` — a single
-        ``0001_baseline`` step that runs once per DB. Pre-baseline history
-        (the original ``0001_init`` through the last pre-baseline migration)
-        is no longer carried as files; any prod DB seeded under that scheme
-        already has the schema, and we detect that case and self-heal by
-        recording the baseline marker without recreating anything.
+        ``0001_baseline`` step that runs once per DB. ``migrations/`` carries no
+        pre-baseline files; a prod DB seeded under that scheme already has the
+        schema, and we detect that case and self-heal by recording the baseline
+        marker without recreating anything.
 
         Anything in ``migrations/`` after baseline is a delta — a small Python
         module exposing ``migrate(raw_conn)`` — applied in lexicographic order
@@ -503,15 +502,11 @@ class ControllerDB:
                 finally:
                     auth_write.dispose()
                 logger.info("Baseline schema created in %.2fs", time.monotonic() - t0)
-                # The schema now matches every delta's post-state, so mark them
-                # applied in the same transaction as the baseline marker: a crash
-                # here leaves a DB that is either fully marked or unmarked, never
-                # one that replays deltas against the baseline.
+                # The baseline schema subsumes every delta's post-state.
                 recorded = [self.BASELINE_MIGRATION, *(path.name for path in self._delta_migration_paths())]
             else:
                 logger.info("Legacy DB detected; recording baseline marker without recreating schema")
-                # Pre-baseline prod DB: its schema predates the deltas, so record
-                # only the baseline marker and let the deltas it has not recorded run.
+                # A pre-baseline schema, so the deltas still have work to do.
                 recorded = [self.BASELINE_MIGRATION]
             self._record_migrations(recorded)
             applied_stems.update(Path(name).stem for name in recorded)
@@ -611,8 +606,7 @@ class ControllerDB:
                 raw_conn.commit()
                 logger.info("Migration %s applied in %.2fs", path.name, time.monotonic() - t0)
 
-                # Reuse the held connection: the pool_size=1 write pool cannot
-                # hand out a second one while this migration run holds it.
+                # The write pool has a single connection, already checked out here.
                 self._insert_migration_rows(raw_conn, [path.name])
         finally:
             raw_conn.commit()

--- a/lib/iris/src/iris/cluster/controller/db.py
+++ b/lib/iris/src/iris/cluster/controller/db.py
@@ -44,7 +44,7 @@ import logging
 import sqlite3
 import threading
 import time
-from collections.abc import Callable, Iterator
+from collections.abc import Callable, Iterator, Sequence
 from contextlib import contextmanager
 from pathlib import Path
 from threading import RLock
@@ -467,6 +467,10 @@ class ControllerDB:
         are skipped (including legacy pre-baseline stems on upgraded prod DBs).
         Deltas must be idempotent under ``IF [NOT] EXISTS`` so a crash mid-run
         is safe to retry.
+
+        A DB created from the baseline is already at the current schema, so its
+        deltas are recorded as applied without running. A delta runs only against
+        a DB created before it.
         """
         baseline_stem = Path(self.BASELINE_MIGRATION).stem
 
@@ -499,10 +503,18 @@ class ControllerDB:
                 finally:
                     auth_write.dispose()
                 logger.info("Baseline schema created in %.2fs", time.monotonic() - t0)
+                # The schema now matches every delta's post-state, so mark them
+                # applied in the same transaction as the baseline marker: a crash
+                # here leaves a DB that is either fully marked or unmarked, never
+                # one that replays deltas against the baseline.
+                recorded = [self.BASELINE_MIGRATION, *(path.name for path in self._delta_migration_paths())]
             else:
                 logger.info("Legacy DB detected; recording baseline marker without recreating schema")
-            self._record_migration(self.BASELINE_MIGRATION)
-            applied_stems.add(baseline_stem)
+                # Pre-baseline prod DB: its schema predates the deltas, so record
+                # only the baseline marker and let the deltas it has not recorded run.
+                recorded = [self.BASELINE_MIGRATION]
+            self._record_migrations(recorded)
+            applied_stems.update(Path(name).stem for name in recorded)
 
         # Delta migrations.
         raw_conn = self._sa_write_engine.raw_connection()
@@ -543,27 +555,34 @@ class ControllerDB:
             is not None
         )
 
-    def _record_migration(self, name: str) -> None:
+    @staticmethod
+    def _delta_migration_paths() -> list[Path]:
+        """Every delta migration module, in application order."""
+        migrations_dir = Path(__file__).with_name("migrations")
+        if not migrations_dir.exists():
+            return []
+        return [path for path in sorted(migrations_dir.glob("*.py")) if not path.name.startswith("__")]
+
+    def _record_migrations(self, names: Sequence[str]) -> None:
+        """Mark ``names`` applied in one transaction — all or none."""
         raw_conn = self._sa_write_engine.raw_connection()
         try:
-            raw_conn.execute(
-                "INSERT INTO schema_migrations(name, applied_at_ms) VALUES (?, ?)",
-                (name, Timestamp.now().epoch_ms()),
-            )
-            raw_conn.commit()
+            raw_conn.execute("BEGIN IMMEDIATE")
+            try:
+                now_ms = Timestamp.now().epoch_ms()
+                raw_conn.executemany(
+                    "INSERT INTO schema_migrations(name, applied_at_ms) VALUES (?, ?)",
+                    [(name, now_ms) for name in names],
+                )
+                raw_conn.commit()
+            except Exception:
+                raw_conn.execute("ROLLBACK")
+                raise
         finally:
             raw_conn.close()
 
     def _apply_delta_migrations(self, raw_conn, applied_stems: set[str]) -> None:
-        migrations_dir = Path(__file__).with_name("migrations")
-        if not migrations_dir.exists():
-            return
-
-        pending = [
-            path
-            for path in sorted(migrations_dir.glob("*.py"))
-            if not path.name.startswith("__") and path.stem not in applied_stems
-        ]
+        pending = [path for path in self._delta_migration_paths() if path.stem not in applied_stems]
         if not pending:
             return
 

--- a/lib/iris/src/iris/cluster/controller/migrations/0033_backend_id.py
+++ b/lib/iris/src/iris/cluster/controller/migrations/0033_backend_id.py
@@ -10,9 +10,7 @@ ACTIVE). The same literal is used by the runtime config synthesis
 (``iris.cluster.config.resolve_backends``), so upgraded rows match what the
 controller resolves at startup.
 
-Idempotent: re-run from scratch if the controller crashes mid-migration. On a
-fresh DB the columns/table already exist from the baseline schema, so the adds
-and creates no-op while the default ``backends`` row is still inserted.
+Idempotent: re-run from scratch if the controller crashes mid-migration.
 """
 
 from iris.cluster.types import DEFAULT_BACKEND_ID, BackendStatus

--- a/lib/iris/tests/cluster/controller/replay/golden/cancel_running_job.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/cancel_running_job.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/coscheduled_failure_retry_bounces_siblings.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/coscheduled_failure_retry_bounces_siblings.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/coscheduled_five_tasks_one_fails_all_terminal.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/coscheduled_five_tasks_one_fails_all_terminal.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/coscheduled_preempt_retry_bounces_siblings.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/coscheduled_preempt_retry_bounces_siblings.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/coscheduled_preempt_terminal_cascades_siblings.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/coscheduled_preempt_terminal_cascades_siblings.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/coscheduled_timeout.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/coscheduled_timeout.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/dispatch_cycle.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/dispatch_cycle.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/endpoint_register_remove.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/endpoint_register_remove.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/independent_five_tasks_one_fails.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/independent_five_tasks_one_fails.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/preempt_task.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/preempt_task.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/prune_old_data.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/prune_old_data.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/register_assign_run_succeed.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/register_assign_run_succeed.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/submit_simple.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/submit_simple.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/task_failure_with_retry.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/task_failure_with_retry.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/replay/golden/worker_failure_cascade.json
+++ b/lib/iris/tests/cluster/controller/replay/golden/worker_failure_cascade.json
@@ -1,14 +1,5 @@
 {
-  "backends": [
-    {
-      "allow_policy_json": "{}",
-      "attributes_json": "{}",
-      "backend_id": "default",
-      "kind": "",
-      "last_seen_ms": null,
-      "status": 0
-    }
-  ],
+  "backends": [],
   "endpoints": [],
   "federated_jobs": [],
   "federated_tasks": [],

--- a/lib/iris/tests/cluster/controller/test_migration_runner.py
+++ b/lib/iris/tests/cluster/controller/test_migration_runner.py
@@ -97,13 +97,8 @@ def _objects(conn: sqlite3.Connection, schema: str) -> list[tuple[str, str]]:
 def _schema(db_dir: Path) -> dict[str, object]:
     """Semantic shape of every table and index across both DB files.
 
-    Tables map each column name to its ``PRAGMA table_info`` type, nullability,
-    default, and primary-key flag — not to the stored ``CREATE`` text, which an
-    upgraded DB spells differently: ``ALTER TABLE ... ADD COLUMN`` appends the
-    clause verbatim, so ``0041`` writes ``NOT NULL DEFAULT ''`` where
-    SQLAlchemy's baseline writes the equivalent ``DEFAULT '' NOT NULL``.
-
-    Indexes are compared by ``CREATE`` text, which carries the partial-index
+    Tables map each column name to its type, nullability, default, and primary-key
+    flag. Indexes map to their ``CREATE`` text, which carries the partial-index
     ``WHERE`` clause that no pragma exposes.
     """
     shape: dict[str, object] = {}
@@ -116,6 +111,9 @@ def _schema(db_dir: Path) -> dict[str, object]:
                         f"SELECT sql FROM {schema}.sqlite_master WHERE name = ?", (name,)
                     ).fetchone()[0]
                 else:
+                    # Column facts, not the table's CREATE text: ALTER TABLE ADD COLUMN
+                    # appends its clause verbatim, so an upgraded DB spells a column
+                    # "NOT NULL DEFAULT ''" where the baseline spells it "DEFAULT '' NOT NULL".
                     # table_info columns: (cid, name, type, notnull, dflt_value, pk)
                     shape[key] = {
                         row[1]: row[2:] for row in conn.execute(f"PRAGMA {schema}.table_info({name})").fetchall()

--- a/lib/iris/tests/cluster/controller/test_migration_runner.py
+++ b/lib/iris/tests/cluster/controller/test_migration_runner.py
@@ -161,8 +161,11 @@ def test_fresh_db_schema_matches_replaying_every_delta(tmp_path: Path) -> None:
     """The correctness claim: skipping the deltas loses no schema.
 
     Each delta only moved an older DB toward a state the baseline now declares
-    outright, so replaying them over a fresh baseline changes nothing. A delta
-    that adds schema the baseline does not declare fails here.
+    outright, so replaying them over a fresh baseline yields the same tables and
+    indexes. A delta that adds schema the baseline does not declare fails here.
+
+    Only schema is compared. Row data diverges by one row: ``0033`` seeds a
+    ``backends`` row that a fresh DB no longer gets, and no code reads that table.
     """
     skipped = tmp_path / "skipped"
     _migrate(skipped)

--- a/lib/iris/tests/cluster/controller/test_migration_runner.py
+++ b/lib/iris/tests/cluster/controller/test_migration_runner.py
@@ -8,9 +8,9 @@ at the current schema; its deltas are recorded as applied without running. A DB
 that predates the baseline still runs every delta it has not recorded. These
 tests pin both halves and pin that the two paths converge on the same schema.
 
-Each test boots a real ``ControllerDB``, which migrates on construction. Whether a
-given delta ran is read back as persisted state — canary modules injected into the
-runner's module list create a table when they execute — rather than as a call count.
+Each test boots a real ``ControllerDB``, which migrates on construction. Canary
+modules injected into the runner's module list create a table when they execute, so
+whether a given delta ran is read back as persisted state.
 """
 
 import sqlite3
@@ -135,9 +135,9 @@ def _column_order(db_dir: Path) -> dict[str, list[str]]:
 def _make_legacy(db_dir: Path) -> None:
     """Regress a baseline DB into one that predates the baseline scheme.
 
-    Wipes the migration ledger while the user tables survive — exactly what
-    ``apply_migrations`` sniffs for. ``jobs.submitting_user`` is dropped so that
-    a delta (``0041``) has real forward work to do rather than merely no-opping.
+    An empty migration ledger alongside surviving user tables is what
+    ``apply_migrations`` reads as a pre-baseline DB. Dropping
+    ``jobs.submitting_user`` gives one delta (``0041``) real forward work.
     """
     with closing(_connect(db_dir)) as conn:
         conn.execute("DELETE FROM schema_migrations")
@@ -158,12 +158,12 @@ def test_fresh_db_marks_every_delta_applied_without_running_it(tmp_path: Path, c
 def test_fresh_db_schema_matches_replaying_every_delta(tmp_path: Path) -> None:
     """The correctness claim: skipping the deltas loses no schema.
 
-    Each delta only moved an older DB toward a state the baseline now declares
-    outright, so replaying them over a fresh baseline yields the same tables and
-    indexes. A delta that adds schema the baseline does not declare fails here.
+    Every delta carries an older DB toward a state the baseline declares outright,
+    so replaying them over a fresh baseline yields the same tables and indexes. A
+    delta that adds schema the baseline does not declare fails here.
 
-    Only schema is compared. Row data diverges by one row: ``0033`` seeds a
-    ``backends`` row that a fresh DB no longer gets, and no code reads that table.
+    The comparison covers schema alone. The two DBs differ by one row: ``0033``
+    seeds a ``backends`` row on the replayed DB, and no code reads that table.
     """
     skipped = tmp_path / "skipped"
     _migrate(skipped)
@@ -175,16 +175,16 @@ def test_fresh_db_schema_matches_replaying_every_delta(tmp_path: Path) -> None:
 
     assert _recorded_migrations(replayed) == _recorded_migrations(skipped)
     assert _schema(replayed) == _schema(skipped)
-    # Both were built from the baseline, so no delta may even reorder a column.
+    # Both come from the baseline, so column order holds too.
     assert _column_order(replayed) == _column_order(skipped)
 
 
 def test_legacy_db_runs_every_unrecorded_delta(tmp_path: Path) -> None:
     """A DB seeded before the baseline scheme existed still migrates forward.
 
-    Column order is deliberately not compared: ``0041`` re-adds ``submitting_user``
-    with ``ALTER TABLE ... ADD COLUMN``, which appends it, while the baseline
-    declares it third.
+    The comparison covers column facts, not column order: ``0041`` re-adds
+    ``submitting_user`` with ``ALTER TABLE ... ADD COLUMN``, which appends it,
+    while the baseline declares it third.
     """
     fresh = tmp_path / "fresh"
     _migrate(fresh)

--- a/lib/iris/tests/cluster/controller/test_migration_runner.py
+++ b/lib/iris/tests/cluster/controller/test_migration_runner.py
@@ -1,0 +1,224 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the ``ControllerDB.apply_migrations`` runner.
+
+A fresh DB is materialized from ``schema.py``'s metadata and is therefore already
+at the current schema; its deltas are recorded as applied without running. A DB
+that predates the baseline still runs every delta it has not recorded. These
+tests pin both halves and pin that the two paths converge on the same schema.
+
+Each test boots a real ``ControllerDB``, which migrates on construction. Whether a
+given delta ran is read back as persisted state — canary modules injected into the
+runner's module list create a table when they execute — rather than as a call count.
+"""
+
+import sqlite3
+from contextlib import closing
+from pathlib import Path
+
+import pytest
+from iris.cluster.controller import db as controller_db
+from iris.cluster.controller.db import ControllerDB
+
+MIGRATIONS_DIR = Path(controller_db.__file__).with_name("migrations")
+
+# Every delta module on disk, enumerated independently of the runner's own glob.
+REAL_DELTA_PATHS = sorted(path for path in MIGRATIONS_DIR.glob("*.py") if not path.name.startswith("__"))
+DELTA_NAMES = {path.name for path in REAL_DELTA_PATHS}
+
+CANARY_TEMPLATE = '''\
+"""Records its own execution by creating a table no baseline declares."""
+
+
+def migrate(raw_conn) -> None:
+    raw_conn.execute("CREATE TABLE IF NOT EXISTS {table} (id INTEGER PRIMARY KEY)")
+'''
+
+
+def _ran_table(canary: Path) -> str:
+    """The table a canary creates when it runs. SQLite identifiers cannot lead with a digit."""
+    return f"ran_{canary.stem}"
+
+
+def _write_canary(directory: Path, stem: str) -> Path:
+    path = directory / f"{stem}.py"
+    path.write_text(CANARY_TEMPLATE.format(table=_ran_table(path)))
+    return path
+
+
+@pytest.fixture
+def canaries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[Path]:
+    """Append two canary deltas, which no baseline declares, after the real ones."""
+    paths = [_write_canary(tmp_path, "9998_canary_a"), _write_canary(tmp_path, "9999_canary_b")]
+    monkeypatch.setattr(ControllerDB, "_delta_migration_paths", staticmethod(lambda: [*REAL_DELTA_PATHS, *paths]))
+    return paths
+
+
+def _open(db_dir: Path) -> None:
+    """Boot a controller DB against ``db_dir``, which migrates it, then close it."""
+    ControllerDB(db_dir=db_dir).close()
+
+
+def _connect(db_dir: Path) -> sqlite3.Connection:
+    conn = sqlite3.connect(db_dir / ControllerDB.DB_FILENAME)
+    conn.execute("ATTACH DATABASE ? AS auth", (str(db_dir / ControllerDB.AUTH_DB_FILENAME),))
+    return conn
+
+
+def _recorded_migrations(db_dir: Path) -> set[str]:
+    with closing(_connect(db_dir)) as conn:
+        return {row[0] for row in conn.execute("SELECT name FROM schema_migrations")}
+
+
+def _forget_migrations(db_dir: Path, names: set[str]) -> None:
+    with closing(_connect(db_dir)) as conn:
+        conn.executemany("DELETE FROM schema_migrations WHERE name = ?", [(name,) for name in names])
+        conn.commit()
+
+
+def _table_exists(db_dir: Path, table: str) -> bool:
+    with closing(_connect(db_dir)) as conn:
+        return conn.execute("SELECT 1 FROM sqlite_master WHERE type='table' AND name=?", (table,)).fetchone() is not None
+
+
+def _column_names(db_dir: Path, table: str) -> set[str]:
+    with closing(_connect(db_dir)) as conn:
+        return {row[1] for row in conn.execute(f"PRAGMA table_info({table})")}
+
+
+def _objects(conn: sqlite3.Connection, schema: str) -> list[tuple[str, str]]:
+    return conn.execute(
+        f"SELECT type, name FROM {schema}.sqlite_master "
+        "WHERE type IN ('table', 'index') AND name NOT LIKE 'sqlite_%' ORDER BY name"
+    ).fetchall()
+
+
+def _schema(db_dir: Path) -> dict[str, object]:
+    """Semantic shape of every table and index across both DB files.
+
+    Tables map each column name to its ``PRAGMA table_info`` type, nullability,
+    default, and primary-key flag — not to the stored ``CREATE`` text, which an
+    upgraded DB spells differently: ``ALTER TABLE ... ADD COLUMN`` appends the
+    clause verbatim, so ``0041`` writes ``NOT NULL DEFAULT ''`` where
+    SQLAlchemy's baseline writes the equivalent ``DEFAULT '' NOT NULL``.
+
+    Indexes are compared by ``CREATE`` text, which carries the partial-index
+    ``WHERE`` clause that no pragma exposes.
+    """
+    shape: dict[str, object] = {}
+    with closing(_connect(db_dir)) as conn:
+        for schema in ("main", "auth"):
+            for kind, name in _objects(conn, schema):
+                key = f"{schema}.{name}"
+                if kind == "index":
+                    shape[key] = conn.execute(
+                        f"SELECT sql FROM {schema}.sqlite_master WHERE name = ?", (name,)
+                    ).fetchone()[0]
+                else:
+                    # table_info columns: (cid, name, type, notnull, dflt_value, pk)
+                    shape[key] = {
+                        row[1]: row[2:] for row in conn.execute(f"PRAGMA {schema}.table_info({name})").fetchall()
+                    }
+    return shape
+
+
+def _column_order(db_dir: Path) -> dict[str, list[str]]:
+    """Declared column order per table — stable only among DBs built from the baseline."""
+    with closing(_connect(db_dir)) as conn:
+        return {
+            f"{schema}.{name}": [row[1] for row in conn.execute(f"PRAGMA {schema}.table_info({name})")]
+            for schema in ("main", "auth")
+            for kind, name in _objects(conn, schema)
+            if kind == "table"
+        }
+
+
+def _make_legacy(db_dir: Path) -> None:
+    """Regress a baseline DB into one that predates the baseline scheme.
+
+    Wipes the migration ledger while the user tables survive — exactly what
+    ``apply_migrations`` sniffs for. ``jobs.submitting_user`` is dropped so that
+    a delta (``0041``) has real forward work to do rather than merely no-opping.
+    """
+    with closing(_connect(db_dir)) as conn:
+        conn.execute("DELETE FROM schema_migrations")
+        conn.execute("ALTER TABLE jobs DROP COLUMN submitting_user")
+        conn.commit()
+
+
+def test_fresh_db_marks_every_delta_applied_without_running_it(tmp_path: Path, canaries: list[Path]) -> None:
+    db_dir = tmp_path / "fresh"
+    _open(db_dir)
+
+    expected = {ControllerDB.BASELINE_MIGRATION, *DELTA_NAMES, *(path.name for path in canaries)}
+    assert _recorded_migrations(db_dir) == expected
+    for canary in canaries:
+        assert not _table_exists(db_dir, _ran_table(canary)), f"{canary.name} ran against a freshly created baseline"
+
+
+def test_fresh_db_schema_matches_replaying_every_delta(tmp_path: Path) -> None:
+    """The correctness claim: skipping the deltas loses no schema.
+
+    Each delta only moved an older DB toward a state the baseline now declares
+    outright, so replaying them over a fresh baseline changes nothing. A delta
+    that adds schema the baseline does not declare fails here.
+    """
+    skipped = tmp_path / "skipped"
+    _open(skipped)
+
+    replayed = tmp_path / "replayed"
+    _open(replayed)
+    _forget_migrations(replayed, DELTA_NAMES)
+    _open(replayed)
+
+    assert _recorded_migrations(replayed) == _recorded_migrations(skipped)
+    assert _schema(replayed) == _schema(skipped)
+    # Both were built from the baseline, so no delta may even reorder a column.
+    assert _column_order(replayed) == _column_order(skipped)
+
+
+def test_legacy_db_runs_every_unrecorded_delta(tmp_path: Path) -> None:
+    """A DB seeded before the baseline scheme existed still migrates forward.
+
+    Column order is deliberately not compared: ``0041`` re-adds ``submitting_user``
+    with ``ALTER TABLE ... ADD COLUMN``, which appends it, while the baseline
+    declares it third.
+    """
+    fresh = tmp_path / "fresh"
+    _open(fresh)
+
+    legacy = tmp_path / "legacy"
+    _open(legacy)
+    _make_legacy(legacy)
+    assert "submitting_user" not in _column_names(legacy, "jobs")
+
+    _open(legacy)
+
+    assert "submitting_user" in _column_names(legacy, "jobs")
+    assert _recorded_migrations(legacy) == {ControllerDB.BASELINE_MIGRATION, *DELTA_NAMES}
+    assert _schema(legacy) == _schema(fresh)
+
+
+def test_only_unrecorded_deltas_run(tmp_path: Path, canaries: list[Path]) -> None:
+    """A DB behind by one delta runs that delta and no other."""
+    first, last = canaries
+    db_dir = tmp_path / "one_behind"
+    _open(db_dir)
+
+    _forget_migrations(db_dir, {last.name})
+    _open(db_dir)
+
+    assert _table_exists(db_dir, _ran_table(last))
+    assert not _table_exists(db_dir, _ran_table(first)), "an already-recorded delta re-ran"
+
+
+def test_reopening_a_migrated_db_changes_nothing(tmp_path: Path) -> None:
+    """Every controller restart re-runs ``apply_migrations`` against its own DB."""
+    db_dir = tmp_path / "twice"
+    _open(db_dir)
+    before = _schema(db_dir), _recorded_migrations(db_dir)
+
+    _open(db_dir)
+
+    assert (_schema(db_dir), _recorded_migrations(db_dir)) == before

--- a/lib/iris/tests/cluster/controller/test_migration_runner.py
+++ b/lib/iris/tests/cluster/controller/test_migration_runner.py
@@ -55,8 +55,8 @@ def canaries(tmp_path: Path, monkeypatch: pytest.MonkeyPatch) -> list[Path]:
     return paths
 
 
-def _open(db_dir: Path) -> None:
-    """Boot a controller DB against ``db_dir``, which migrates it, then close it."""
+def _migrate(db_dir: Path) -> None:
+    """Migrate ``db_dir`` the way a controller boot does — construction applies migrations."""
     ControllerDB(db_dir=db_dir).close()
 
 
@@ -149,7 +149,7 @@ def _make_legacy(db_dir: Path) -> None:
 
 def test_fresh_db_marks_every_delta_applied_without_running_it(tmp_path: Path, canaries: list[Path]) -> None:
     db_dir = tmp_path / "fresh"
-    _open(db_dir)
+    _migrate(db_dir)
 
     expected = {ControllerDB.BASELINE_MIGRATION, *DELTA_NAMES, *(path.name for path in canaries)}
     assert _recorded_migrations(db_dir) == expected
@@ -165,12 +165,12 @@ def test_fresh_db_schema_matches_replaying_every_delta(tmp_path: Path) -> None:
     that adds schema the baseline does not declare fails here.
     """
     skipped = tmp_path / "skipped"
-    _open(skipped)
+    _migrate(skipped)
 
     replayed = tmp_path / "replayed"
-    _open(replayed)
+    _migrate(replayed)
     _forget_migrations(replayed, DELTA_NAMES)
-    _open(replayed)
+    _migrate(replayed)
 
     assert _recorded_migrations(replayed) == _recorded_migrations(skipped)
     assert _schema(replayed) == _schema(skipped)
@@ -186,14 +186,14 @@ def test_legacy_db_runs_every_unrecorded_delta(tmp_path: Path) -> None:
     declares it third.
     """
     fresh = tmp_path / "fresh"
-    _open(fresh)
+    _migrate(fresh)
 
     legacy = tmp_path / "legacy"
-    _open(legacy)
+    _migrate(legacy)
     _make_legacy(legacy)
     assert "submitting_user" not in _column_names(legacy, "jobs")
 
-    _open(legacy)
+    _migrate(legacy)
 
     assert "submitting_user" in _column_names(legacy, "jobs")
     assert _recorded_migrations(legacy) == {ControllerDB.BASELINE_MIGRATION, *DELTA_NAMES}
@@ -204,10 +204,10 @@ def test_only_unrecorded_deltas_run(tmp_path: Path, canaries: list[Path]) -> Non
     """A DB behind by one delta runs that delta and no other."""
     first, last = canaries
     db_dir = tmp_path / "one_behind"
-    _open(db_dir)
+    _migrate(db_dir)
 
     _forget_migrations(db_dir, {last.name})
-    _open(db_dir)
+    _migrate(db_dir)
 
     assert _table_exists(db_dir, _ran_table(last))
     assert not _table_exists(db_dir, _ran_table(first)), "an already-recorded delta re-ran"
@@ -216,9 +216,9 @@ def test_only_unrecorded_deltas_run(tmp_path: Path, canaries: list[Path]) -> Non
 def test_reopening_a_migrated_db_changes_nothing(tmp_path: Path) -> None:
     """Every controller restart re-runs ``apply_migrations`` against its own DB."""
     db_dir = tmp_path / "twice"
-    _open(db_dir)
+    _migrate(db_dir)
     before = _schema(db_dir), _recorded_migrations(db_dir)
 
-    _open(db_dir)
+    _migrate(db_dir)
 
     assert (_schema(db_dir), _recorded_migrations(db_dir)) == before


### PR DESCRIPTION
`apply_migrations` materializes the current schema declaratively from `schema.py` via
`Table.create_all` (the `0001_baseline` step), and then runs every delta in `migrations/`
that `schema_migrations` does not record. On a fresh DB that ledger is empty, so all 15
deltas (0027..0041) replay against a baseline that already contains everything they were
written to add. They only survive because each was hand-written to no-op — `CREATE TABLE IF
NOT EXISTS`, `PRAGMA table_info` guards, `INSERT OR IGNORE`.

That makes every historical delta permanently live code coupled to a baseline that keeps
moving, and each new schema change can break an old delta. It already bites in two places:
`0033_backend_id` names `allow_policy_json` explicitly in an `INSERT`, so the moment that
column leaves `schema.py` every fresh DB — every CI run, every new cluster — fails at startup
with `OperationalError: table backends has no column named allow_policy_json`.
`0040_drop_users` documents that its rebuild DDL must match the baseline byte-for-byte.

A DB created from the current baseline is by definition already at the current schema, so it
now records every delta as applied alongside the baseline marker — in one transaction — and
runs none of them. Recording them together also closes a crash window: previously a crash
between `create_all` and the single baseline `INSERT` left a DB that would replay deltas.

The legacy path is deliberately untouched. `needs_baseline and has_user_tables` is a prod DB
seeded before the baseline scheme existed; it still records only the baseline marker and runs
whatever deltas it has not recorded.

Skipping deltas is sound only if none carries an effect a fresh baseline does not already
produce. Auditing all 15 against a freshly created baseline:

| Delta | Behavior on a fresh baseline |
| --- | --- |
| 0027_attempt_uid | column present and `NOT NULL`, backfill selects nothing, rebuild guard short-circuits, index already declared |
| 0028_drop_api_keys_key_hash | `key_hash` absent; returns early |
| 0029_drop_reservations | reservation columns/table absent, so its `DELETE`/`UPDATE`/rebuild are never reached |
| 0030_container_profile | column present |
| 0031_endpoint_lease | column present |
| 0032_worker_provenance | `md_provenance_json` present, `md_git_hash` absent |
| **0033_backend_id** | columns/table/indexes present, backfill matches no rows — **but seeds a `backends` row** |
| 0034_federation | columns, sidecar tables, partial indexes present |
| 0035_federation_unify | changelog present; `direction` present, so the rebuild is skipped |
| 0036_endpoint_access | column present |
| 0037_federation_fixup | no stale columns, no `child_cluster`; indexes present |
| 0038_derive_task_counts | dropped indexes and columns already absent; new index present |
| 0039_drop_api_keys | `DROP TABLE IF EXISTS auth.api_keys`, which the baseline never creates |
| 0040_drop_users | no `users` FK, so the rebuild is skipped and `DROP TABLE IF EXISTS users` no-ops |
| 0041_job_submitting_user | column present |

`0033`'s seed is the sole divergence. Diffing a baseline-only DB against a baseline-plus-replay
DB confirms it: the DDL of all 19 tables and 27 indexes is byte-identical, and that one
`backends` row is the only differing data. Losing it is safe — `backends` has no reader or
writer anywhere in the codebase (`ListBackends` builds its summaries from the in-memory
`self._controller.backends`), and the replay goldens are regenerated to drop it.

The dead `backends` table and `allow_policy_json` stay for now: weaver #412 removes
`allow_policy` and depends on this landing first. Once it does, that branch can drop the
column from `schema.py` and add one guarded `DROP COLUMN` migration with no edit to `0033`.
