### PR TITLE
[finelog] Restore the configured auth policy on GCE deploys

### DIFF
--- a/lib/finelog/scripts/safe_deploy.py
+++ b/lib/finelog/scripts/safe_deploy.py
@@ -24,8 +24,8 @@ from datetime import UTC, datetime
 from pathlib import Path
 
 import click
-from finelog.deploy._gcp import _ssh_args, _wait_health_via_ssh
-from finelog.deploy.bootstrap import CONTAINER_NAME, render_bootstrap
+from finelog.deploy._gcp import _ssh_args, _wait_health_via_ssh, apply_bootstrap, render_bootstrap_for
+from finelog.deploy.bootstrap import CONTAINER_NAME
 from finelog.deploy.build import build_image as build_finelog_image
 from finelog.deploy.config import FinelogConfig, load_finelog_config
 from finelog.deploy.image import resolve_image_digest
@@ -88,18 +88,8 @@ def _require_gcp(cfg: FinelogConfig) -> None:
 
 
 def _bootstrap_with_image(cfg: FinelogConfig, image: str) -> bool:
-    """Re-render and re-run the bootstrap with an explicit image (no pinning).
-
-    Returns whether the remote bootstrap exited 0. The bootstrap script polls
-    ``/health`` itself and exits non-zero when the container never becomes
-    healthy (crash-loop or timeout), so a ``False`` return means the image
-    failed to come up. The caller decides what that means: for the new image it
-    triggers the auto-rollback; for the rollback target it is itself the
-    failure.
-    """
-    bootstrap = render_bootstrap(image=image, port=cfg.port, remote_log_dir=cfg.remote_log_dir)
-    result = subprocess.run(_ssh_args(cfg, "bash -s"), input=bootstrap, text=True)
-    return result.returncode == 0
+    """Bootstrap the VM onto ``image``. Returns whether it came up healthy."""
+    return apply_bootstrap(cfg, render_bootstrap_for(cfg, image))
 
 
 def _verify_health(cfg: FinelogConfig) -> bool:

--- a/lib/finelog/src/finelog/deploy/_gcp.py
+++ b/lib/finelog/src/finelog/deploy/_gcp.py
@@ -230,8 +230,6 @@ def apply_bootstrap(cfg: FinelogConfig, bootstrap: str) -> bool:
 
 def gcp_restart(cfg: FinelogConfig) -> None:
     """Restart finelog in-place by re-running the bootstrap over SSH."""
-    assert cfg.deployment.gcp is not None
-
     bootstrap = _pinned_bootstrap(cfg)
     click.echo(f"Re-running bootstrap on {cfg.name} via SSH...")
     if not apply_bootstrap(cfg, bootstrap):

--- a/lib/finelog/src/finelog/deploy/_gcp.py
+++ b/lib/finelog/src/finelog/deploy/_gcp.py
@@ -96,25 +96,32 @@ def _wait_health_via_ssh(cfg: FinelogConfig, port: int, max_attempts: int = 90) 
     return False
 
 
-def _render_bootstrap(cfg: FinelogConfig) -> str:
-    """Pin the image and render the VM bootstrap script for ``cfg``.
+def render_bootstrap_for(cfg: FinelogConfig, image: str) -> str:
+    """Render the VM bootstrap script running ``image`` under ``cfg``'s port,
+    remote archive, and auth policy.
 
-    The script becomes startup-script metadata (readable to anyone with instance-
-    metadata access). Every auth layer is inline-safe — a jwt layer carries only
-    Ed25519 public keys and a cidr layer only network prefixes — so the policy inlines
-    directly.
+    ``image`` is separate from ``cfg.image`` so callers can supply an
+    already-pinned digest.
     """
+    return render_bootstrap(
+        image=image,
+        port=cfg.port,
+        remote_log_dir=cfg.remote_log_dir,
+        # The rendered script is world-readable to anyone with instance-metadata
+        # access, and every layer is inline-safe: a jwt layer carries only Ed25519
+        # public keys, a cidr layer only network prefixes.
+        auth_policy=auth_policy_json(cfg.auth) if cfg.auth else "",
+    )
+
+
+def _pinned_bootstrap(cfg: FinelogConfig) -> str:
+    """Pin ``cfg.image`` to a content digest and render the bootstrap for it."""
     pinned = resolve_image_digest(cfg.image)
     if pinned != cfg.image:
         click.echo(f"Pinned image: {cfg.image} -> {pinned}")
     else:
         click.echo(f"Using image: {pinned}")
-    return render_bootstrap(
-        image=pinned,
-        port=cfg.port,
-        remote_log_dir=cfg.remote_log_dir,
-        auth_policy=auth_policy_json(cfg.auth) if cfg.auth else "",
-    )
+    return render_bootstrap_for(cfg, pinned)
 
 
 def gcp_up(cfg: FinelogConfig) -> None:
@@ -128,7 +135,7 @@ def gcp_up(cfg: FinelogConfig) -> None:
         click.echo("Run `finelog deploy restart <name>` to refresh the container in place.")
         return
 
-    bootstrap = _render_bootstrap(cfg)
+    bootstrap = _pinned_bootstrap(cfg)
 
     with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as f:
         f.write(bootstrap)
@@ -185,17 +192,11 @@ def gcp_down(cfg: FinelogConfig, *, yes: bool) -> None:
     click.echo(f"Deleted {cfg.name}.")
 
 
-def gcp_restart(cfg: FinelogConfig) -> None:
-    """Restart finelog in-place by re-running the bootstrap over SSH."""
+def _set_startup_script(cfg: FinelogConfig, bootstrap: str) -> None:
+    """Persist ``bootstrap`` as the instance's startup-script metadata, which a VM
+    reboot (host maintenance, manual reset) re-runs."""
     assert cfg.deployment.gcp is not None
     gcp = cfg.deployment.gcp
-
-    bootstrap = _render_bootstrap(cfg)
-
-    # Update the instance's startup-script metadata so that a future VM reboot
-    # (host maintenance, manual reset) brings up the same image we're about to
-    # restart into — otherwise GCE would re-run the bootstrap baked in at
-    # `gcp_up` time, pinning the VM to whatever image was current on day one.
     with tempfile.NamedTemporaryFile("w", suffix=".sh", delete=False) as f:
         f.write(bootstrap)
         startup_path = f.name
@@ -210,13 +211,30 @@ def gcp_restart(cfg: FinelogConfig) -> None:
         f"--metadata-from-file=startup-script={startup_path}",
     )
 
-    click.echo(f"Re-running bootstrap on {cfg.name} via SSH...")
-    result = subprocess.run(
-        _ssh_args(cfg, "bash -s"),
-        input=bootstrap,
-        text=True,
-    )
+
+def apply_bootstrap(cfg: FinelogConfig, bootstrap: str) -> bool:
+    """Run ``bootstrap`` on the VM over SSH, then persist it as startup-script
+    metadata. Returns whether the container came up.
+
+    The script polls ``/health`` itself and exits non-zero on a crash-loop or
+    timeout, so a ``False`` return means the image never became healthy. Metadata
+    is written only on success, so a reboot re-runs the last bootstrap known to
+    boot rather than one that just failed.
+    """
+    result = subprocess.run(_ssh_args(cfg, "bash -s"), input=bootstrap, text=True)
     if result.returncode != 0:
+        return False
+    _set_startup_script(cfg, bootstrap)
+    return True
+
+
+def gcp_restart(cfg: FinelogConfig) -> None:
+    """Restart finelog in-place by re-running the bootstrap over SSH."""
+    assert cfg.deployment.gcp is not None
+
+    bootstrap = _pinned_bootstrap(cfg)
+    click.echo(f"Re-running bootstrap on {cfg.name} via SSH...")
+    if not apply_bootstrap(cfg, bootstrap):
         raise click.ClickException("Bootstrap re-run failed; see SSH output above")
     click.echo("Bootstrap re-applied. Verifying health...")
     if not _wait_health_via_ssh(cfg, cfg.port):

--- a/lib/finelog/src/finelog/deploy/bootstrap.py
+++ b/lib/finelog/src/finelog/deploy/bootstrap.py
@@ -129,13 +129,14 @@ exit 1
 """
 
 
-def render_bootstrap(image: str, port: int, remote_log_dir: str, auth_policy: str = "") -> str:
+def render_bootstrap(image: str, port: int, remote_log_dir: str, auth_policy: str) -> str:
     """Render the finelog bootstrap script.
 
     ``auth_policy`` is the ``FINELOG_AUTH_POLICY`` JSON (see
     ``deploy.config.auth_policy_json``); empty leaves the server on its private
-    allow-localhost default. It is passed single-quoted, so it must not contain a
-    single quote (the JSON never does — hex secrets, identifiers, CIDRs).
+    allow-localhost default, which on a remote VM admits nothing but an SSH
+    tunnel. It is passed single-quoted, so it must not contain a single quote
+    (the JSON never does — CIDR prefixes, cluster names, PEM public keys).
     """
     if not image:
         raise ValueError("image is required")

--- a/lib/finelog/tests/test_deploy_gcp.py
+++ b/lib/finelog/tests/test_deploy_gcp.py
@@ -1,0 +1,42 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for GCE bootstrap rendering in `finelog.deploy._gcp`."""
+
+from finelog.deploy._gcp import render_bootstrap_for
+from finelog.deploy.config import (
+    CidrAuthLayer,
+    Deployment,
+    FinelogConfig,
+    GcpDeployment,
+)
+
+
+def _cfg(auth: tuple = (CidrAuthLayer(cidrs=("10.0.0.0/8", "127.0.0.0/8")),)) -> FinelogConfig:
+    return FinelogConfig(
+        name="finelog-marin",
+        port=10001,
+        image="ghcr.io/example/finelog:latest",
+        remote_log_dir="gs://bucket/finelog/marin",
+        deployment=Deployment(gcp=GcpDeployment(project="proj", zone="us-central1-a")),
+        auth=auth,
+    )
+
+
+def test_render_bootstrap_for_inlines_the_configured_auth_policy() -> None:
+    """The rendered `docker run` must carry FINELOG_AUTH_POLICY. A bootstrap that
+    omits it strands the server on its allow-localhost default, where every
+    in-VPC client — including the iris controller relaying through its proxy —
+    is rejected with `no auth layer admitted it`."""
+    rendered = render_bootstrap_for(_cfg(), "ghcr.io/example/finelog@sha256:abc")
+
+    assert '-e FINELOG_AUTH_POLICY=\'[{"type":"cidr","cidrs":["10.0.0.0/8","127.0.0.0/8"]}]\'' in rendered
+    assert "ghcr.io/example/finelog@sha256:abc" in rendered
+
+
+def test_render_bootstrap_for_omits_policy_env_when_no_auth_configured() -> None:
+    """No `auth:` block leaves the env var unset, which the server reads as its
+    private allow-localhost default rather than as an empty (lock-out) policy."""
+    rendered = render_bootstrap_for(_cfg(auth=()), "img")
+
+    assert "FINELOG_AUTH_POLICY" not in rendered


### PR DESCRIPTION
safe_deploy rendered the VM bootstrap without an auth policy, so every rollout and rollback launched the container with no `FINELOG_AUTH_POLICY`. The server then fell back to its private allow-localhost default (`policy=cidr[2]`, loopback only) and rejected every non-loopback caller with `no auth layer admitted it` — including the iris controller relaying through its endpoint proxy. Because the proxy relays the upstream status verbatim and the iris dashboard treats any 401 as an iris auth challenge, that surfaced to users as the dashboard's own bearer-token login prompt whenever they opened a job.

`render_bootstrap` now requires `auth_policy`, and both GCE deploy paths render through one `render_bootstrap_for` helper that derives it from the config, so a caller cannot omit it.

safe_deploy also never wrote back the instance startup-script metadata, leaving a rebooted VM to re-run whatever bootstrap was baked in at create time — on `finelog-marin` that was a months-old image digest, likewise with no auth policy. Both paths now persist it through `apply_bootstrap`, and only once the container is healthy, so a reboot re-runs the last bootstrap known to boot rather than one that just crash-looped.

Deployed to `finelog-marin` and `finelog-marin-dev` (same image digest, `--force`, env-only change). Both now report `auth policy active policy=cidr[5]`, `ListNamespaces` and `FetchLogs` return 200 through `https://iris.oa.dev/proxy/system.log-server/`, and log rows are landing again.

The dashboard's 401 misattribution is a separate latent bug and is not addressed here — a 401 from a proxied upstream should not read as "your iris session expired".