### PR TITLE
Bump marin-finelog-server to 0.2.12.dev202607090934

### DIFF
--- a/uv.lock
+++ b/uv.lock
@@ -4873,14 +4873,14 @@ test = [
 
 [[package]]
 name = "marin-finelog-server"
-version = "0.2.12.dev202607040833"
+version = "0.2.12.dev202607090934"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/62/d1/f14370ea0b88d2cf0232723f90509619439b4e7e2ada6786175370f13d32/marin_finelog_server-0.2.12.dev202607040833.tar.gz", hash = "sha256:211a004163f41ab0b602066a278b521540ffef94022246b4c56c27858077484d", size = 218973, upload-time = "2026-07-04T09:03:26.257Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/51/b1/f6691e5c0c00260b7cb386a3ca075d6b38e60822e8f82c3e6e73c352ad68/marin_finelog_server-0.2.12.dev202607090934.tar.gz", hash = "sha256:de52360f17371a88404d440cdd6211c3e4716fac7183f0805e9db80245d2d345", size = 223389, upload-time = "2026-07-09T10:09:22.627Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/6a/1f/7beaf16931b0b08747679bc23e5fbfb230c0a32481b748cb2a15cf454877/marin_finelog_server-0.2.12.dev202607040833-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:004f35272ba8cecb97f1eb73070d70235143181c3a1ff81230246037d09b9697", size = 41783290, upload-time = "2026-07-04T09:03:13.992Z" },
-    { url = "https://files.pythonhosted.org/packages/e0/ef/e648579b0b51f390cc353b7e9eb3db23ab26176f10aa3db88d90a3241c13/marin_finelog_server-0.2.12.dev202607040833-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:c8937afc6fa72070de90d81150716860d84d53a9312df4bc0952a89968393c6e", size = 39342790, upload-time = "2026-07-04T09:03:17.243Z" },
-    { url = "https://files.pythonhosted.org/packages/29/79/e390376d005b06f2257001262b433b58ce743e0dc744f0ade6ec032f94e6/marin_finelog_server-0.2.12.dev202607040833-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:81aca89bb825a6165ea0fc3f952e5a5c5e02d219c68388c852dab654a0d6c853", size = 40789253, upload-time = "2026-07-04T09:03:20.027Z" },
-    { url = "https://files.pythonhosted.org/packages/11/b5/5385247529c60369d4d7706c5e64fb35a4c9cca2c06e589254999c5fae24/marin_finelog_server-0.2.12.dev202607040833-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:77f6f4e881e0de27d145636b46466517f75a3ff4ad8f85d70284e672ede774f7", size = 43343003, upload-time = "2026-07-04T09:03:23.052Z" },
+    { url = "https://files.pythonhosted.org/packages/86/d9/6b07c81bbd9f9a2e0f5da7437d556e40a8e72a544adccd61119b0c7cbbe6/marin_finelog_server-0.2.12.dev202607090934-cp312-abi3-macosx_10_12_x86_64.whl", hash = "sha256:c6a3e396a7801591e93a6e56525babcae3f1e34ecef2070c854b551b15417feb", size = 42268254, upload-time = "2026-07-09T10:09:07.736Z" },
+    { url = "https://files.pythonhosted.org/packages/8b/bf/e0254ffea5cedf3912bda03820aacd7299530811d49a08cce48bf38b6823/marin_finelog_server-0.2.12.dev202607090934-cp312-abi3-macosx_11_0_arm64.whl", hash = "sha256:a2cee80d1366df9454fa1de3f309544f07c62001fcf93af98c144cacd45dd60a", size = 39767175, upload-time = "2026-07-09T10:09:11.27Z" },
+    { url = "https://files.pythonhosted.org/packages/77/19/aeda9deb1fc7689fec120a461980dc25c3bf83dbd742375e6a41fa28fef9/marin_finelog_server-0.2.12.dev202607090934-cp312-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:73304b41560c81a24ea51452e1030862690b78cfe6f289524cdf361459de32a2", size = 41222043, upload-time = "2026-07-09T10:09:15.255Z" },
+    { url = "https://files.pythonhosted.org/packages/55/17/e22b91a595dd03b1ec65c71ab2af93ee5b963ccb20834cd04b823a12cfb6/marin_finelog_server-0.2.12.dev202607090934-cp312-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:81b593d4fd146bcc8266c1f661e51b5e5eeb76aa9ac58f5c941bcdbea9eb20b3", size = 43789685, upload-time = "2026-07-09T10:09:19.177Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
The pinned wheel was built 2026-07-04, before #6948 replaced the jwt auth layer's `secret` field with `public_keys`. Its native policy parser still rejected the new shape, so every test that stands up an embedded server with a jwt policy errored with ``missing field `secret` `` — the four tests in `lib/finelog/tests/test_forwarder.py`. They pass on the newer wheel, taking `lib/finelog` from 70 passed / 4 errors to 74 passed.

Deployed finelog servers build the Rust from source in their Docker image and were never affected; only the embedded/in-process server comes from this wheel.

A full `uv lock --upgrade-package` also rewrites every torch/torchvision URL from `download.pytorch.org` to `download-r2.pytorch.org` (identical paths and hashes — upstream moved CDNs). That is unrelated to this bump and would quietly introduce a new download host into the lock, so it is reverted here; someone should land it deliberately after checking egress allowlists.