### PR TITLE
[iris] Surface a refused upstream's error in the dashboard log pane

### DIFF
--- a/lib/iris/dashboard/src/composables/useRpc.ts
+++ b/lib/iris/dashboard/src/composables/useRpc.ts
@@ -10,7 +10,12 @@
  */
 import { ref, type Ref } from 'vue'
 
+const CONTROLLER_SERVICE_PATH = 'iris.cluster.ControllerService'
+const WORKER_SERVICE_PATH = 'iris.cluster.WorkerService'
 const LOG_SERVICE_PATH = 'proxy/system.log-server/finelog.logging.LogService'
+
+// Cap on how much of an error body is folded into an RpcError message.
+const MAX_ERROR_DETAIL_CHARS = 500
 
 export type RpcBody = Record<string, unknown> | (() => Record<string, unknown>)
 
@@ -21,6 +26,43 @@ export interface RpcState<T> {
   refresh: () => Promise<void>
 }
 
+/** Error thrown by RPC calls when the HTTP response is non-OK. Carries the HTTP
+ *  status so callers can branch on specific failures (e.g. 404 NOT_FOUND from
+ *  Connect RPC), and the server's own message as `detail`. */
+export class RpcError extends Error {
+  constructor(
+    public readonly method: string,
+    public readonly status: number,
+    public readonly statusText: string,
+    public readonly detail: string | null = null,
+  ) {
+    super(detail === null
+      ? `${method}: ${status} ${statusText}`
+      : `${method}: ${status} ${statusText} — ${detail}`)
+    this.name = 'RpcError'
+  }
+}
+
+/** Extract the server's message from a non-OK response body. The controller
+ *  answers with `{"error": ...}` and Connect RPC with `{"message": ...}`;
+ *  anything else surfaces as raw text. Null when the body carries nothing. */
+async function readErrorDetail(resp: Response): Promise<string | null> {
+  const text = (await resp.text()).trim()
+  if (!text) return null
+  let detail = text
+  try {
+    const body = JSON.parse(text) as { error?: unknown; message?: unknown }
+    const message = body.error ?? body.message
+    if (typeof message === 'string' && message) detail = message
+  } catch {
+    // Body is not JSON; surface it raw.
+  }
+  return detail.slice(0, MAX_ERROR_DETAIL_CHARS)
+}
+
+/** Send the browser to the iris login page on an iris auth challenge.
+ *  Only iris itself answers 401 here: the endpoint proxy reports a rejected
+ *  upstream as a 502, so a proxied service can never trigger this. */
 function handleUnauthorized(resp: Response): void {
   if (resp.status === 401) {
     window.dispatchEvent(new CustomEvent('iris-auth-required'))
@@ -33,24 +75,16 @@ function useRpc<T>(service: string, method: string, body?: RpcBody): RpcState<T>
   const error = ref<string | null>(null)
   let generation = 0
 
+  // A superseded request still reports an auth challenge (rpcCall calls
+  // handleUnauthorized), but never writes data or error: only the newest
+  // generation owns the reactive state.
   async function refresh() {
     const gen = ++generation
     loading.value = true
     error.value = null
     try {
-      const resolvedBody = typeof body === 'function' ? body() : (body ?? {})
-      const resp = await fetch(`/${service}/${method}`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(resolvedBody),
-      })
+      const payload = await rpcCall<T>(service, method, typeof body === 'function' ? body() : body)
       if (gen !== generation) return  // superseded by a newer refresh()
-      handleUnauthorized(resp)
-      if (!resp.ok) {
-        throw new Error(`${method}: ${resp.status} ${resp.statusText}`)
-      }
-      const payload = await resp.json() as T
-      if (gen !== generation) return  // superseded while reading the response body
       data.value = payload
     } catch (e) {
       if (gen !== generation) return  // superseded by a newer refresh()
@@ -70,7 +104,7 @@ export function useControllerRpc<T>(
   method: string,
   body?: RpcBody,
 ): RpcState<T> {
-  return useRpc<T>('iris.cluster.ControllerService', method, body)
+  return useRpc<T>(CONTROLLER_SERVICE_PATH, method, body)
 }
 
 /** RPC composable for WorkerService endpoints. */
@@ -78,30 +112,26 @@ export function useWorkerRpc<T>(
   method: string,
   body?: RpcBody,
 ): RpcState<T> {
-  return useRpc<T>('iris.cluster.WorkerService', method, body)
+  return useRpc<T>(WORKER_SERVICE_PATH, method, body)
 }
 
-/** Error thrown by one-shot RPC calls when the HTTP response is non-OK.
- *  Carries the HTTP status so callers can branch on specific failures
- *  (e.g. 404 NOT_FOUND from Connect RPC). */
-export class RpcError extends Error {
-  constructor(public readonly method: string, public readonly status: number, public readonly statusText: string) {
-    super(`${method}: ${status} ${statusText}`)
-    this.name = 'RpcError'
-  }
-}
-
-/** One-shot RPC call returning a Promise. For use in async functions that
- *  need to call multiple RPCs or handle the response imperatively. */
-export async function controllerRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
-  const resp = await fetch(`/iris.cluster.ControllerService/${method}`, {
+/** POST a Connect RPC to `/<service>/<method>` and decode its response.
+ *  Throws RpcError carrying the server's message on a non-OK response, and
+ *  sends the browser to the login page on an iris auth challenge. */
+async function rpcCall<T>(service: string, method: string, body?: Record<string, unknown>): Promise<T> {
+  const resp = await fetch(`/${service}/${method}`, {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body ?? {}),
   })
   handleUnauthorized(resp)
-  if (!resp.ok) throw new RpcError(method, resp.status, resp.statusText)
+  if (!resp.ok) throw new RpcError(method, resp.status, resp.statusText, await readErrorDetail(resp))
   return resp.json() as Promise<T>
+}
+
+/** One-shot RPC call for ControllerService. */
+export function controllerRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
+  return rpcCall<T>(CONTROLLER_SERVICE_PATH, method, body)
 }
 
 /** RPC composable for LogService endpoints. */
@@ -132,24 +162,11 @@ export function useLogServerStatsRpc<T>(
 }
 
 /** One-shot RPC call for LogService. */
-export async function logServiceRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
-  const resp = await fetch(`/${LOG_SERVICE_PATH}/${method}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body ?? {}),
-  })
-  handleUnauthorized(resp)
-  if (!resp.ok) throw new Error(`${method}: ${resp.status} ${resp.statusText}`)
-  return resp.json() as Promise<T>
+export function logServiceRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
+  return rpcCall<T>(LOG_SERVICE_PATH, method, body)
 }
 
-export async function workerRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
-  const resp = await fetch(`/iris.cluster.WorkerService/${method}`, {
-    method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: JSON.stringify(body ?? {}),
-  })
-  handleUnauthorized(resp)
-  if (!resp.ok) throw new Error(`${method}: ${resp.status} ${resp.statusText}`)
-  return resp.json() as Promise<T>
+/** One-shot RPC call for WorkerService. */
+export function workerRpcCall<T>(method: string, body?: Record<string, unknown>): Promise<T> {
+  return rpcCall<T>(WORKER_SERVICE_PATH, method, body)
 }

--- a/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
+++ b/lib/iris/src/iris/cluster/controller/endpoint_proxy.py
@@ -41,10 +41,13 @@ modern Python frameworks honor to mount themselves under the ``/proxy/<name>``
 prefix. Subdomain-style mode does not set ``X-Forwarded-Prefix``: the
 upstream effectively owns the whole origin.
 
-An upstream ``401`` is translated to a ``502`` (upstream body kept as the error
-detail). The browser never authenticates to the upstream directly, so an
+An upstream ``401`` is translated to a ``502``, keeping the first
+:data:`_MAX_UPSTREAM_ERROR_DETAIL_BYTES` of the upstream body as the error
+detail. The browser never authenticates to the upstream directly, so an
 upstream 401 is not an auth challenge to the browser; relaying it verbatim makes
-the dashboard mistake it for an iris auth challenge and pop its login modal.
+the dashboard mistake it for an iris auth challenge and pop its login modal. The
+controller's own ``/proxy`` access check runs before a request reaches this
+module, so a genuine iris auth challenge still reaches the browser as a ``401``.
 
 ``Location`` and ``Content-Location`` response headers are rewritten so 3xx
 redirects (and any other absolute-URL hints) keep the browser inside the
@@ -119,6 +122,23 @@ _LOCATION_HEADERS: frozenset[str] = frozenset({"location", "content-location"})
 # surfaces as an uncaught 500. Dashboard-proxy traffic is low, so a fresh
 # connection per request is a fine trade for eliminating that flakiness.
 _HTTPX_LIMITS = httpx.Limits(max_connections=100, max_keepalive_connections=0)
+
+# How much of a rejected upstream's response body is echoed back as the proxy's
+# error detail. Bounds the buffering an upstream can force on the controller.
+_MAX_UPSTREAM_ERROR_DETAIL_BYTES = 2048
+
+
+async def _read_error_detail(response: httpx.Response) -> str:
+    """Read the head of a streamed error body as text, capped and stripped."""
+    chunks: list[bytes] = []
+    read = 0
+    async for chunk in response.aiter_bytes():
+        chunks.append(chunk)
+        read += len(chunk)
+        if read >= _MAX_UPSTREAM_ERROR_DETAIL_BYTES:
+            break
+    body = b"".join(chunks)[:_MAX_UPSTREAM_ERROR_DETAIL_BYTES]
+    return body.decode("utf-8", errors="replace").strip()
 
 
 def _build_forwarded_headers(request: Request, *, proxy_prefix: str) -> dict[str, str]:
@@ -314,13 +334,14 @@ class EndpointProxy:
         # never authenticated to the upstream (Authorization is stripped
         # client -> upstream), so a verbatim relay misdirects the user. Translate
         # it to a 502 — the controller was authorized; its gateway call upstream
-        # was refused — keeping the upstream body as the error detail.
+        # was refused — folding the upstream body into the error the client reads.
         if upstream_resp.status_code == 401:
-            detail = (await upstream_resp.aread()).decode("utf-8", errors="replace")
+            detail = await _read_error_detail(upstream_resp)
             await upstream_resp.aclose()
             logger.warning("Proxy upstream 401 for %s -> 502: %s", encoded_name, detail)
+            refused = f"Upstream '{encoded_name}' refused the controller (401)"
             return JSONResponse(
-                {"error": f"Upstream '{encoded_name}' refused the controller (401)", "detail": detail},
+                {"error": f"{refused}: {detail}" if detail else refused},
                 status_code=502,
             )
 

--- a/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
+++ b/lib/iris/tests/cluster/controller/test_endpoint_proxy.py
@@ -92,7 +92,11 @@ def _build_upstream_app(handle: UpstreamHandle) -> Starlette:
 
     async def unauthorized(request: Request) -> Response:
         await _record(request)
-        return PlainTextResponse("finelog rejected the controller", status_code=401)
+        return PlainTextResponse(
+            "finelog rejected the controller",
+            status_code=401,
+            headers={"www-authenticate": 'Bearer realm="upstream"'},
+        )
 
     async def slow(request: Request) -> Response:
         await _record(request)
@@ -358,13 +362,18 @@ def test_upstream_401_translated_to_502(proxy: ProxyHandle) -> None:
     The dashboard treats any 401 as an iris auth challenge and pops its login
     modal. A 401 from a proxied upstream (e.g. finelog refusing the controller)
     is not a browser auth challenge — the browser never authenticated to the
-    upstream — so the proxy rewrites it to 502 with the upstream body preserved
-    as the error detail.
+    upstream — so the proxy rewrites it to 502, folding the upstream body into
+    the error the client reads and dropping the upstream's challenge header.
     """
     with httpx.Client() as client:
         resp = client.get(f"{proxy.base_url}/proxy/{ENDPOINT_URL_NAME}/401")
     assert resp.status_code == 502
-    assert "finelog rejected the controller" in resp.json()["detail"]
+    error = resp.json()["error"]
+    # Names the refusing upstream and carries its body, so the real cause is visible.
+    assert ENDPOINT_URL_NAME in error
+    assert "finelog rejected the controller" in error
+    # The upstream's challenge must not reach the client alongside the translated status.
+    assert "www-authenticate" not in {k.lower() for k in resp.headers}
 
 
 def test_upstream_connection_refused_returns_502(threads: ThreadContainer) -> None:


### PR DESCRIPTION
#7060 landed the proxy half of #7059: a proxied upstream's 401 becomes a 502, so the dashboard no longer mistakes it for an iris auth challenge and pops the login modal. The operator still cannot see *why* the log pane is empty, though — `useRpc` throws away non-OK response bodies, so a finelog that refuses the controller renders as `FetchLogs: 502 Bad Gateway` and nothing else.

This reads the server's message out of the error body and carries it on `RpcError`, so the log pane shows what the upstream actually said:

```
FetchLogs: 502 Bad Gateway — Upstream 'system.log-server' refused the controller (401): finelog rejected the controller
```

Two adjustments to the proxy support that. It folds the upstream body into its single `error` key, matching the payload shape its other errors (404/502/504) already use and that the dashboard's error extractor reads; and it caps the body read at 2 KiB instead of `aread()`-ing an unbounded response from a misbehaving upstream into the controller. The test additionally pins that the upstream's `WWW-Authenticate` challenge does not reach a browser that could never answer it.

One clarification on the reasoning in #7060: iris *does* answer 401 on `/proxy/...` paths — `_authorize_proxy` in `dashboard.py` returns `{"error": "authentication required"}` with a 401 before a request ever reaches the proxy. That doesn't affect either change (the proxy only translates the *upstream's* 401, which happens after authorization), but it means the login modal is reachable from a `/proxy` path, so gating the dashboard on a path prefix would have been wrong. Translating at the proxy is the right seam, and `handleUnauthorized` can stay as-is.

Finally, `refresh()` and the three one-shot `*RpcCall` functions each re-implemented the same fetch/auth/error/decode flow. They now share one `rpcCall` helper; `refresh()` keeps its generation guard on the reactive writes, so a superseded response still reports an auth challenge but never clobbers `data` or `error`.

Fixes #7059