### PR TITLE
[iris] Rework the log viewer: search vs filter, exception jump, context

### DIFF
--- a/lib/finelog/rust/proto/logging.proto
+++ b/lib/finelog/rust/proto/logging.proto
@@ -45,6 +45,12 @@ message LogEntry {
   int32 attempt_id = 4;   // Caller-defined; finelog stores and echoes it back
   LogLevel level = 5;     // Best-effort parsed level (UNKNOWN if unparseable)
   string key = 6;         // Log store key. Populated on multi-key (regex) queries.
+  // Store-assigned row id: a single counter shared by every key in the store,
+  // increasing in write order. Stable for the row's lifetime, so a reader can
+  // name a row it has already seen and page around it (see
+  // FetchLogsRequest.cursor / until_cursor). Ids of one key are not contiguous:
+  // interleaved writes to other keys consume ids in between.
+  int64 seq = 7;
 }
 
 // Collection of log entries for a single source.
@@ -83,6 +89,12 @@ enum MatchScope {
   MATCH_SCOPE_REGEX = 3;
 }
 
+// `cursor` and `until_cursor` bound the LogEntry.seq range from below and above.
+// Both are exclusive, so `cursor = X, until_cursor = Y` reads the open interval
+// (X, Y). Combined with `tail` and `max_lines` they page in either direction
+// around a known row: the N rows before seq X are
+// `{until_cursor: X, tail: true, max_lines: N}`, and the N rows after it are
+// `{cursor: X, tail: false, max_lines: N}`.
 message FetchLogsRequest {
   string source = 1;           // Log source key, prefix, or regex pattern (see match_scope)
   int64 since_ms = 2;          // Only return entries with epoch_ms > since_ms
@@ -97,6 +109,9 @@ message FetchLogsRequest {
   // cluster's logs. Empty = unfiltered (all origins) — the local single-cluster
   // read behavior.
   string cluster = 9;
+  // Stop before this autoincrement id (exclusive). 0 = unbounded above; the
+  // first row ever written has seq 1, so no row is excluded by the default.
+  int64 until_cursor = 10;
 }
 
 message FetchLogsResponse {

--- a/lib/finelog/rust/src/server/log_service.rs
+++ b/lib/finelog/rust/src/server/log_service.rs
@@ -15,8 +15,8 @@ use crate::query::fetch_log_rows;
 use crate::query::make_ctx;
 use crate::query::provider::NamespaceProvider;
 use crate::store::log_read::{
-    add_cluster_filter, add_common_filters, build_log_predicates, shape_log_read_result,
-    str_to_log_level, ShapedEntry,
+    add_cluster_filter, add_common_filters, add_seq_upper_bound, build_log_predicates,
+    shape_log_read_result, str_to_log_level, ShapedEntry,
 };
 use crate::store::namespace::DEFAULT_PERSIST_TIMEOUT;
 use crate::store::store::LOG_NAMESPACE_NAME;
@@ -155,6 +155,7 @@ impl LogService for LogServiceImpl {
         };
         let source = request.source.unwrap_or("");
         let cursor = request.cursor.unwrap_or(0);
+        let until_cursor = request.until_cursor.unwrap_or(0);
         let since_ms = request.since_ms.unwrap_or(0);
         let substring = request.substring.unwrap_or("");
         let tail = request.tail.unwrap_or(false);
@@ -170,6 +171,9 @@ impl LogService for LogServiceImpl {
         // Build predicates (pure). Empty PREFIX source -> invalid_argument.
         let mut predicates =
             build_log_predicates(source, cursor, scope).map_err(ConnectError::invalid_argument)?;
+        // Bracket the scope's `seq > cursor` from above so a reader can page
+        // backwards from a row it names (`until_cursor` + `tail`).
+        add_seq_upper_bound(&mut predicates.where_parts, until_cursor);
         add_common_filters(&mut predicates.where_parts, since_ms, substring, min_level);
         // Restrict to one origin cluster when the caller asks (the federated read
         // path filters `cluster = <peer>`); empty = unfiltered, so a local
@@ -230,6 +234,7 @@ impl LogService for LogServiceImpl {
 /// are populated per the scope's shaping rules.
 fn shaped_entry_to_proto(e: ShapedEntry) -> LogEntry {
     let mut entry = LogEntry::default()
+        .with_seq(e.seq)
         .with_source(e.source)
         .with_data(e.data)
         .with_attempt_id(e.attempt_id);

--- a/lib/finelog/rust/src/store/log_read.rs
+++ b/lib/finelog/rust/src/store/log_read.rs
@@ -14,6 +14,10 @@
 //!   non-pure-prefix pattern, `regexp_matches(key, <pattern>)`. `attempt_id` is
 //!   per-row.
 //!
+//! Every scope also takes an optional exclusive upper bound `seq < until_cursor`,
+//! so the two cursors bracket an open seq interval a reader can page in either
+//! direction (see `FetchLogsRequest` in `proto/logging.proto`).
+//!
 //! These builders emit the `prefix()` / `regexp_matches()` predicates as the
 //! user's intent. The `prefix()` UDF alone is opaque to statistics pruning, so
 //! the half-open key range that makes a prefix tail fast (`key >= P AND
@@ -198,6 +202,16 @@ pub fn add_common_filters(
     }
 }
 
+/// Append the exclusive `seq < until_cursor` upper bound to `where_parts`.
+///
+/// A non-positive `until_cursor` appends nothing and so reads as unbounded
+/// above: seq starts at 1, and no row can precede it.
+pub fn add_seq_upper_bound(where_parts: &mut Vec<String>, until_cursor: i64) {
+    if until_cursor > 0 {
+        where_parts.push(format!("seq < {until_cursor}"));
+    }
+}
+
 /// Append the origin-cluster filter to `where_parts`.
 ///
 /// The `cluster` column carries the writer-supplied origin of each push, so
@@ -227,6 +241,7 @@ pub struct LogRow {
 /// The shaped result: entry fields + the cursor for the next poll.
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ShapedEntry {
+    pub seq: i64,
     pub source: String,
     pub data: String,
     pub epoch_ms: i64,
@@ -277,6 +292,7 @@ pub fn shape_log_read_result(
                 exact_attempt
             };
             ShapedEntry {
+                seq: r.seq,
                 source: r.source,
                 data: r.data,
                 epoch_ms: r.epoch_ms,
@@ -431,6 +447,31 @@ mod tests {
                 "(level = 0 OR level >= 3)".to_string(),
             ]
         );
+    }
+
+    #[test]
+    fn seq_upper_bound_brackets_the_cursor_lower_bound() {
+        // (cursor, until_cursor) is an open interval: both bounds exclusive.
+        let mut p = build_log_predicates("/k", 10, MatchScope::MATCH_SCOPE_EXACT).unwrap();
+        add_seq_upper_bound(&mut p.where_parts, 20);
+        assert_eq!(
+            p.where_parts,
+            vec![
+                "key = '/k'".to_string(),
+                "seq > 10".to_string(),
+                "seq < 20".to_string(),
+            ]
+        );
+    }
+
+    #[test]
+    fn seq_upper_bound_unset_is_unbounded() {
+        // seq starts at 1, so 0 (and any non-positive) means "no upper bound".
+        let mut wp = vec!["seq > 0".to_string()];
+        add_seq_upper_bound(&mut wp, 0);
+        assert_eq!(wp, vec!["seq > 0".to_string()]);
+        add_seq_upper_bound(&mut wp, -1);
+        assert_eq!(wp, vec!["seq > 0".to_string()]);
     }
 
     #[test]

--- a/lib/finelog/src/finelog/proto/logging.proto
+++ b/lib/finelog/src/finelog/proto/logging.proto
@@ -45,6 +45,12 @@ message LogEntry {
   int32 attempt_id = 4;   // Caller-defined; finelog stores and echoes it back
   LogLevel level = 5;     // Best-effort parsed level (UNKNOWN if unparseable)
   string key = 6;         // Log store key. Populated on multi-key (regex) queries.
+  // Store-assigned row id: a single counter shared by every key in the store,
+  // increasing in write order. Stable for the row's lifetime, so a reader can
+  // name a row it has already seen and page around it (see
+  // FetchLogsRequest.cursor / until_cursor). Ids of one key are not contiguous:
+  // interleaved writes to other keys consume ids in between.
+  int64 seq = 7;
 }
 
 // Collection of log entries for a single source.
@@ -83,6 +89,12 @@ enum MatchScope {
   MATCH_SCOPE_REGEX = 3;
 }
 
+// `cursor` and `until_cursor` bound the LogEntry.seq range from below and above.
+// Both are exclusive, so `cursor = X, until_cursor = Y` reads the open interval
+// (X, Y). Combined with `tail` and `max_lines` they page in either direction
+// around a known row: the N rows before seq X are
+// `{until_cursor: X, tail: true, max_lines: N}`, and the N rows after it are
+// `{cursor: X, tail: false, max_lines: N}`.
 message FetchLogsRequest {
   string source = 1;           // Log source key, prefix, or regex pattern (see match_scope)
   int64 since_ms = 2;          // Only return entries with epoch_ms > since_ms
@@ -97,6 +109,9 @@ message FetchLogsRequest {
   // cluster's logs. Empty = unfiltered (all origins) — the local single-cluster
   // read behavior.
   string cluster = 9;
+  // Stop before this autoincrement id (exclusive). 0 = unbounded above; the
+  // first row ever written has seq 1, so no row is excluded by the default.
+  int64 until_cursor = 10;
 }
 
 message FetchLogsResponse {

--- a/lib/finelog/src/finelog/rpc/logging_pb2.py
+++ b/lib/finelog/src/finelog/rpc/logging_pb2.py
@@ -24,7 +24,7 @@ _sym_db = _symbol_database.Default()
 
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rlogging.proto\x12\x0f\x66inelog.logging\"&\n\tTimestamp\x12\x19\n\x08\x65poch_ms\x18\x01 \x01(\x03R\x07\x65pochMs\"\xd2\x01\n\x08LogEntry\x12\x38\n\ttimestamp\x18\x01 \x01(\x0b\x32\x1a.finelog.logging.TimestampR\ttimestamp\x12\x16\n\x06source\x18\x02 \x01(\tR\x06source\x12\x12\n\x04\x64\x61ta\x18\x03 \x01(\tR\x04\x64\x61ta\x12\x1d\n\nattempt_id\x18\x04 \x01(\x05R\tattemptId\x12/\n\x05level\x18\x05 \x01(\x0e\x32\x19.finelog.logging.LogLevelR\x05level\x12\x10\n\x03key\x18\x06 \x01(\tR\x03key\"?\n\x08LogBatch\x12\x33\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\"r\n\x0fPushLogsRequest\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x33\n\x07\x65ntries\x18\x02 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\x12\x18\n\x07\x63luster\x18\x03 \x01(\tR\x07\x63luster\"\x12\n\x10PushLogsResponse\"\xa1\x02\n\x10\x46\x65tchLogsRequest\x12\x16\n\x06source\x18\x01 \x01(\tR\x06source\x12\x19\n\x08since_ms\x18\x02 \x01(\x03R\x07sinceMs\x12\x16\n\x06\x63ursor\x18\x03 \x01(\x03R\x06\x63ursor\x12\x1c\n\tsubstring\x18\x04 \x01(\tR\tsubstring\x12\x1b\n\tmax_lines\x18\x05 \x01(\x05R\x08maxLines\x12\x12\n\x04tail\x18\x06 \x01(\x08R\x04tail\x12\x1b\n\tmin_level\x18\x07 \x01(\tR\x08minLevel\x12<\n\x0bmatch_scope\x18\x08 \x01(\x0e\x32\x1b.finelog.logging.MatchScopeR\nmatchScope\x12\x18\n\x07\x63luster\x18\t \x01(\tR\x07\x63luster\"`\n\x11\x46\x65tchLogsResponse\x12\x33\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\x12\x16\n\x06\x63ursor\x18\x02 \x01(\x03R\x06\x63ursor*\x8e\x01\n\x08LogLevel\x12\x15\n\x11LOG_LEVEL_UNKNOWN\x10\x00\x12\x13\n\x0fLOG_LEVEL_DEBUG\x10\x01\x12\x12\n\x0eLOG_LEVEL_INFO\x10\x02\x12\x15\n\x11LOG_LEVEL_WARNING\x10\x03\x12\x13\n\x0fLOG_LEVEL_ERROR\x10\x04\x12\x16\n\x12LOG_LEVEL_CRITICAL\x10\x05*o\n\nMatchScope\x12\x1b\n\x17MATCH_SCOPE_UNSPECIFIED\x10\x00\x12\x15\n\x11MATCH_SCOPE_EXACT\x10\x01\x12\x16\n\x12MATCH_SCOPE_PREFIX\x10\x02\x12\x15\n\x11MATCH_SCOPE_REGEX\x10\x03\x32\xb1\x01\n\nLogService\x12O\n\x08PushLogs\x12 .finelog.logging.PushLogsRequest\x1a!.finelog.logging.PushLogsResponse\x12R\n\tFetchLogs\x12!.finelog.logging.FetchLogsRequest\x1a\".finelog.logging.FetchLogsResponseB\x80\x01\n\x13\x63om.finelog.loggingB\x0cLoggingProtoP\x01\xa2\x02\x03\x46LX\xaa\x02\x0f\x46inelog.Logging\xca\x02\x0f\x46inelog\\Logging\xe2\x02\x1b\x46inelog\\Logging\\GPBMetadata\xea\x02\x10\x46inelog::Loggingb\x08\x65\x64itionsp\xe8\x07')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\rlogging.proto\x12\x0f\x66inelog.logging\"&\n\tTimestamp\x12\x19\n\x08\x65poch_ms\x18\x01 \x01(\x03R\x07\x65pochMs\"\xe4\x01\n\x08LogEntry\x12\x38\n\ttimestamp\x18\x01 \x01(\x0b\x32\x1a.finelog.logging.TimestampR\ttimestamp\x12\x16\n\x06source\x18\x02 \x01(\tR\x06source\x12\x12\n\x04\x64\x61ta\x18\x03 \x01(\tR\x04\x64\x61ta\x12\x1d\n\nattempt_id\x18\x04 \x01(\x05R\tattemptId\x12/\n\x05level\x18\x05 \x01(\x0e\x32\x19.finelog.logging.LogLevelR\x05level\x12\x10\n\x03key\x18\x06 \x01(\tR\x03key\x12\x10\n\x03seq\x18\x07 \x01(\x03R\x03seq\"?\n\x08LogBatch\x12\x33\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\"r\n\x0fPushLogsRequest\x12\x10\n\x03key\x18\x01 \x01(\tR\x03key\x12\x33\n\x07\x65ntries\x18\x02 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\x12\x18\n\x07\x63luster\x18\x03 \x01(\tR\x07\x63luster\"\x12\n\x10PushLogsResponse\"\xc4\x02\n\x10\x46\x65tchLogsRequest\x12\x16\n\x06source\x18\x01 \x01(\tR\x06source\x12\x19\n\x08since_ms\x18\x02 \x01(\x03R\x07sinceMs\x12\x16\n\x06\x63ursor\x18\x03 \x01(\x03R\x06\x63ursor\x12\x1c\n\tsubstring\x18\x04 \x01(\tR\tsubstring\x12\x1b\n\tmax_lines\x18\x05 \x01(\x05R\x08maxLines\x12\x12\n\x04tail\x18\x06 \x01(\x08R\x04tail\x12\x1b\n\tmin_level\x18\x07 \x01(\tR\x08minLevel\x12<\n\x0bmatch_scope\x18\x08 \x01(\x0e\x32\x1b.finelog.logging.MatchScopeR\nmatchScope\x12\x18\n\x07\x63luster\x18\t \x01(\tR\x07\x63luster\x12!\n\x0cuntil_cursor\x18\n \x01(\x03R\x0buntilCursor\"`\n\x11\x46\x65tchLogsResponse\x12\x33\n\x07\x65ntries\x18\x01 \x03(\x0b\x32\x19.finelog.logging.LogEntryR\x07\x65ntries\x12\x16\n\x06\x63ursor\x18\x02 \x01(\x03R\x06\x63ursor*\x8e\x01\n\x08LogLevel\x12\x15\n\x11LOG_LEVEL_UNKNOWN\x10\x00\x12\x13\n\x0fLOG_LEVEL_DEBUG\x10\x01\x12\x12\n\x0eLOG_LEVEL_INFO\x10\x02\x12\x15\n\x11LOG_LEVEL_WARNING\x10\x03\x12\x13\n\x0fLOG_LEVEL_ERROR\x10\x04\x12\x16\n\x12LOG_LEVEL_CRITICAL\x10\x05*o\n\nMatchScope\x12\x1b\n\x17MATCH_SCOPE_UNSPECIFIED\x10\x00\x12\x15\n\x11MATCH_SCOPE_EXACT\x10\x01\x12\x16\n\x12MATCH_SCOPE_PREFIX\x10\x02\x12\x15\n\x11MATCH_SCOPE_REGEX\x10\x03\x32\xb1\x01\n\nLogService\x12O\n\x08PushLogs\x12 .finelog.logging.PushLogsRequest\x1a!.finelog.logging.PushLogsResponse\x12R\n\tFetchLogs\x12!.finelog.logging.FetchLogsRequest\x1a\".finelog.logging.FetchLogsResponseB\x80\x01\n\x13\x63om.finelog.loggingB\x0cLoggingProtoP\x01\xa2\x02\x03\x46LX\xaa\x02\x0f\x46inelog.Logging\xca\x02\x0f\x46inelog\\Logging\xe2\x02\x1b\x46inelog\\Logging\\GPBMetadata\xea\x02\x10\x46inelog::Loggingb\x08\x65\x64itionsp\xe8\x07')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -32,24 +32,24 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'logging_pb2', _globals)
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\023com.finelog.loggingB\014LoggingProtoP\001\242\002\003FLX\252\002\017Finelog.Logging\312\002\017Finelog\\Logging\342\002\033Finelog\\Logging\\GPBMetadata\352\002\020Finelog::Logging'
-  _globals['_LOGLEVEL']._serialized_start=879
-  _globals['_LOGLEVEL']._serialized_end=1021
-  _globals['_MATCHSCOPE']._serialized_start=1023
-  _globals['_MATCHSCOPE']._serialized_end=1134
+  _globals['_LOGLEVEL']._serialized_start=932
+  _globals['_LOGLEVEL']._serialized_end=1074
+  _globals['_MATCHSCOPE']._serialized_start=1076
+  _globals['_MATCHSCOPE']._serialized_end=1187
   _globals['_TIMESTAMP']._serialized_start=34
   _globals['_TIMESTAMP']._serialized_end=72
   _globals['_LOGENTRY']._serialized_start=75
-  _globals['_LOGENTRY']._serialized_end=285
-  _globals['_LOGBATCH']._serialized_start=287
-  _globals['_LOGBATCH']._serialized_end=350
-  _globals['_PUSHLOGSREQUEST']._serialized_start=352
-  _globals['_PUSHLOGSREQUEST']._serialized_end=466
-  _globals['_PUSHLOGSRESPONSE']._serialized_start=468
-  _globals['_PUSHLOGSRESPONSE']._serialized_end=486
-  _globals['_FETCHLOGSREQUEST']._serialized_start=489
-  _globals['_FETCHLOGSREQUEST']._serialized_end=778
-  _globals['_FETCHLOGSRESPONSE']._serialized_start=780
-  _globals['_FETCHLOGSRESPONSE']._serialized_end=876
-  _globals['_LOGSERVICE']._serialized_start=1137
-  _globals['_LOGSERVICE']._serialized_end=1314
+  _globals['_LOGENTRY']._serialized_end=303
+  _globals['_LOGBATCH']._serialized_start=305
+  _globals['_LOGBATCH']._serialized_end=368
+  _globals['_PUSHLOGSREQUEST']._serialized_start=370
+  _globals['_PUSHLOGSREQUEST']._serialized_end=484
+  _globals['_PUSHLOGSRESPONSE']._serialized_start=486
+  _globals['_PUSHLOGSRESPONSE']._serialized_end=504
+  _globals['_FETCHLOGSREQUEST']._serialized_start=507
+  _globals['_FETCHLOGSREQUEST']._serialized_end=831
+  _globals['_FETCHLOGSRESPONSE']._serialized_start=833
+  _globals['_FETCHLOGSRESPONSE']._serialized_end=929
+  _globals['_LOGSERVICE']._serialized_start=1190
+  _globals['_LOGSERVICE']._serialized_end=1367
 # @@protoc_insertion_point(module_scope)

--- a/lib/finelog/src/finelog/rpc/logging_pb2.pyi
+++ b/lib/finelog/src/finelog/rpc/logging_pb2.pyi
@@ -40,20 +40,22 @@ class Timestamp(_message.Message):
     def __init__(self, epoch_ms: _Optional[int] = ...) -> None: ...
 
 class LogEntry(_message.Message):
-    __slots__ = ("timestamp", "source", "data", "attempt_id", "level", "key")
+    __slots__ = ("timestamp", "source", "data", "attempt_id", "level", "key", "seq")
     TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
     SOURCE_FIELD_NUMBER: _ClassVar[int]
     DATA_FIELD_NUMBER: _ClassVar[int]
     ATTEMPT_ID_FIELD_NUMBER: _ClassVar[int]
     LEVEL_FIELD_NUMBER: _ClassVar[int]
     KEY_FIELD_NUMBER: _ClassVar[int]
+    SEQ_FIELD_NUMBER: _ClassVar[int]
     timestamp: Timestamp
     source: str
     data: str
     attempt_id: int
     level: LogLevel
     key: str
-    def __init__(self, timestamp: _Optional[_Union[Timestamp, _Mapping]] = ..., source: _Optional[str] = ..., data: _Optional[str] = ..., attempt_id: _Optional[int] = ..., level: _Optional[_Union[LogLevel, str]] = ..., key: _Optional[str] = ...) -> None: ...
+    seq: int
+    def __init__(self, timestamp: _Optional[_Union[Timestamp, _Mapping]] = ..., source: _Optional[str] = ..., data: _Optional[str] = ..., attempt_id: _Optional[int] = ..., level: _Optional[_Union[LogLevel, str]] = ..., key: _Optional[str] = ..., seq: _Optional[int] = ...) -> None: ...
 
 class LogBatch(_message.Message):
     __slots__ = ("entries",)
@@ -76,7 +78,7 @@ class PushLogsResponse(_message.Message):
     def __init__(self) -> None: ...
 
 class FetchLogsRequest(_message.Message):
-    __slots__ = ("source", "since_ms", "cursor", "substring", "max_lines", "tail", "min_level", "match_scope", "cluster")
+    __slots__ = ("source", "since_ms", "cursor", "substring", "max_lines", "tail", "min_level", "match_scope", "cluster", "until_cursor")
     SOURCE_FIELD_NUMBER: _ClassVar[int]
     SINCE_MS_FIELD_NUMBER: _ClassVar[int]
     CURSOR_FIELD_NUMBER: _ClassVar[int]
@@ -86,6 +88,7 @@ class FetchLogsRequest(_message.Message):
     MIN_LEVEL_FIELD_NUMBER: _ClassVar[int]
     MATCH_SCOPE_FIELD_NUMBER: _ClassVar[int]
     CLUSTER_FIELD_NUMBER: _ClassVar[int]
+    UNTIL_CURSOR_FIELD_NUMBER: _ClassVar[int]
     source: str
     since_ms: int
     cursor: int
@@ -95,7 +98,8 @@ class FetchLogsRequest(_message.Message):
     min_level: str
     match_scope: MatchScope
     cluster: str
-    def __init__(self, source: _Optional[str] = ..., since_ms: _Optional[int] = ..., cursor: _Optional[int] = ..., substring: _Optional[str] = ..., max_lines: _Optional[int] = ..., tail: _Optional[bool] = ..., min_level: _Optional[str] = ..., match_scope: _Optional[_Union[MatchScope, str]] = ..., cluster: _Optional[str] = ...) -> None: ...
+    until_cursor: int
+    def __init__(self, source: _Optional[str] = ..., since_ms: _Optional[int] = ..., cursor: _Optional[int] = ..., substring: _Optional[str] = ..., max_lines: _Optional[int] = ..., tail: _Optional[bool] = ..., min_level: _Optional[str] = ..., match_scope: _Optional[_Union[MatchScope, str]] = ..., cluster: _Optional[str] = ..., until_cursor: _Optional[int] = ...) -> None: ...
 
 class FetchLogsResponse(_message.Message):
     __slots__ = ("entries", "cursor")

--- a/lib/finelog/tests/test_embedded.py
+++ b/lib/finelog/tests/test_embedded.py
@@ -50,3 +50,54 @@ def test_embedded_server_log_roundtrip(embedded_server):
         assert all(e.key == key for e in resp.entries)
     finally:
         client.close()
+
+
+def test_cursors_bracket_a_window_around_a_named_row(embedded_server):
+    """`cursor`/`until_cursor` page either side of a row named by its `seq`."""
+    client = LogClient.connect(embedded_server.address)
+    try:
+        key = "window-key"
+        client.write_batch(
+            key,
+            [
+                logging_pb2.LogEntry(
+                    timestamp=logging_pb2.Timestamp(epoch_ms=1_000 + i),
+                    source="stdout",
+                    data=f"line {i}",
+                )
+                for i in range(20)
+            ],
+        )
+        client.flush(timeout=5.0)
+
+        def fetch(**kwargs) -> list[str]:
+            request = logging_pb2.FetchLogsRequest(source=key, match_scope=logging_pb2.MATCH_SCOPE_EXACT, **kwargs)
+            return [e.data for e in client.fetch_logs(request).entries]
+
+        everything = client.fetch_logs(
+            logging_pb2.FetchLogsRequest(source=key, match_scope=logging_pb2.MATCH_SCOPE_EXACT, max_lines=100)
+        ).entries
+        seqs = [e.seq for e in everything]
+        if not all(seq > 0 for seq in seqs):
+            pytest.skip(
+                "the finelog_server extension predates LogEntry.seq. It installs from a pre-built "
+                "wheel by default; build it from this tree with "
+                "`python scripts/rust_mode.py dev && uv sync` to exercise the cursor contract."
+            )
+        assert seqs == sorted(seqs), "seq ascends in write order"
+        assert len(set(seqs)) == len(seqs), "seq uniquely names a row"
+
+        anchor = everything[10].seq
+        assert everything[10].data == "line 10"
+
+        # `until_cursor` is exclusive, so tailing it reads the rows *before* the anchor.
+        assert fetch(until_cursor=anchor, tail=True, max_lines=3) == ["line 7", "line 8", "line 9"]
+        # `cursor` is exclusive too, so `anchor - 1` is the first request that
+        # still includes the anchor row itself.
+        assert fetch(cursor=anchor - 1, max_lines=3) == ["line 10", "line 11", "line 12"]
+        # Together they bracket an open interval.
+        assert fetch(cursor=seqs[2], until_cursor=seqs[6], max_lines=100) == ["line 3", "line 4", "line 5"]
+        # An unset upper bound reads to the end: seq starts at 1, so 0 excludes nothing.
+        assert len(fetch(until_cursor=0, max_lines=100)) == 20
+    finally:
+        client.close()

--- a/lib/iris/dashboard/src/components/shared/LogViewer.vue
+++ b/lib/iris/dashboard/src/components/shared/LogViewer.vue
@@ -1,11 +1,15 @@
 <script setup lang="ts">
-import { ref, computed, onMounted, watch } from 'vue'
-import { RouterLink, useRoute } from 'vue-router'
+import { ref, computed, nextTick, onMounted, onUnmounted, watch } from 'vue'
+import { RouterLink, useRoute, useRouter } from 'vue-router'
 import { logServiceRpcCall } from '@/composables/useRpc'
 import { useAutoRefresh } from '@/composables/useAutoRefresh'
+import { useIndexCursor } from '@/composables/useIndexCursor'
+import { useLogSearch } from '@/composables/useLogSearch'
+import { CUSTOM_PRESET, SINCE_PRESETS, type TimeZoneName, useTimeWindow } from '@/composables/useTimeWindow'
 import { isFederated, type FetchLogsResponse, type LogEntry, type TaskAttempt } from '@/types/rpc'
-import { timestampMs, logLevelClass, formatLogTime } from '@/utils/formatting'
+import { timestampMs, logLevelName, formatLogTime } from '@/utils/formatting'
 import { parseLogLinks } from '@/utils/logLinks'
+import { groupNearbyIndices, highlightSegments, isExceptionEntry, type HighlightedSegment } from '@/utils/logSearch'
 
 const props = withDefaults(defineProps<{
   taskId?: string
@@ -36,8 +40,20 @@ const AUTO_REFRESH_MAX_LINES = 2000
 const POLL_INTERVAL_MS = 30_000
 // Retain at most this many rendered lines to keep the DOM bounded.
 const MAX_RETAINED_LINES = 20_000
+// Lines fetched either side of a row when expanding its context.
+const CONTEXT_LINES = 25
+// Bound the spliced-in context set; the oldest expansions are evicted first.
+const MAX_CONTEXT_ROWS = 5_000
+// Rows within this distance of each other count as one failure when stepping
+// through exceptions — a traceback trips several patterns a few lines apart.
+const EXCEPTION_GROUP_GAP = 5
+// Re-running the matcher over every loaded line on each keystroke is wasteful.
+const SEARCH_DEBOUNCE_MS = 120
+// Treat the viewport as "at the bottom" within this many pixels of the end.
+const FOLLOW_TAIL_SLACK_PX = 40
 
 const route = useRoute()
+const router = useRouter()
 
 type MatchScope = 'EXACT' | 'PREFIX' | 'REGEX'
 type WireMatchScope = 'MATCH_SCOPE_EXACT' | 'MATCH_SCOPE_PREFIX' | 'MATCH_SCOPE_REGEX'
@@ -47,20 +63,17 @@ const WIRE_SCOPE: Record<MatchScope, WireMatchScope> = {
   REGEX: 'MATCH_SCOPE_REGEX',
 }
 
-// Relative time windows for the "Since" selector. 0 = no lower bound.
-const SINCE_PRESETS: { label: string; ms: number }[] = [
-  { label: 'All time', ms: 0 },
-  { label: 'Last 15m', ms: 15 * 60_000 },
-  { label: 'Last 1h', ms: 60 * 60_000 },
-  { label: 'Last 6h', ms: 6 * 3_600_000 },
-  { label: 'Last 24h', ms: 24 * 3_600_000 },
-  { label: 'Last 7d', ms: 7 * 86_400_000 },
-]
-
+// Server-side narrowing: `filter` becomes FetchLogs.substring, so non-matching
+// lines never arrive. Distinct from `search` below, which only marks lines.
 const filter = ref('')
 const level = ref('info')
 const tailLines = ref(500)
 const selectedAttemptId = ref(props.currentAttemptId ?? -1)
+
+// Client-side find-in-loaded-lines: marks matches and steps between them without
+// removing their surrounding context.
+const search = useLogSearch(SEARCH_DEBOUNCE_MS)
+const searchInput = ref<HTMLInputElement | null>(null)
 
 // Editable query. Pre-filled from props (task/worker/controller context) but the
 // user is free to retype the source or widen the match scope — that's how you
@@ -69,30 +82,48 @@ const selectedAttemptId = ref(props.currentAttemptId ?? -1)
 const sourceInput = ref('')
 const matchScope = ref<MatchScope>('EXACT')
 
-// Lower time bound. A preset (relative window) and an absolute datetime-local
-// are mutually exclusive — setting one clears the other.
-const presetMs = ref(0)
-const customSince = ref('')
-
 // Timezone for rendering log timestamps and interpreting the date picker.
 // Stored timestamps are UTC epoch ms regardless; 'local' shows the browser's
 // zone (default), 'utc' lines the prefix up with the UTC timestamps processes
 // embed in their raw log lines.
-const timeZone = ref<'local' | 'utc'>('local')
+const timeZone = ref<TimeZoneName>('local')
+
+const { presetMs, customSince, absolute: absoluteSince, sinceMs, selectPreset } = useTimeWindow(timeZone)
 
 const entries = ref<LogEntry[]>([])
+// Lines pulled in by expanding a row's context, keyed by seq so they dedupe
+// against `entries` and splice into the right place. Iteration follows first
+// insertion, so `loadContext` evicts the earliest-expanded window first.
+const contextEntries = ref<Map<number, LogEntry>>(new Map())
+const contextPending = ref(false)
 const loading = ref(false)
 const errorMsg = ref<string | null>(null)
 // proto JSON encodes int64 as string; 0/"0" both mean "no cursor".
 const cursor = ref<string | number | null>(null)
 
+const wrap = ref(true)
+const followTail = ref(true)
+const selectedSeq = ref<number | null>(null)
+const scrollBox = ref<HTMLElement | null>(null)
+
 // Task IDs end with a numeric segment (e.g. /alice/job/0), job IDs don't.
 const isTask = computed(() => (sourceBase.value ? /\/\d+$/.test(sourceBase.value) : false))
+
+/** The store row id, as a number. proto JSON renders int64 as a string. */
+function seqOf(entry: LogEntry): number {
+  return Number(entry.seq ?? 0)
+}
 
 function attemptFromRoute(): number {
   const raw = route.query.attempt
   const n = typeof raw === 'string' ? Number(raw) : NaN
   return Number.isInteger(n) && n >= 0 ? n : -1
+}
+
+function seqFromRoute(): number | null {
+  const raw = route.query.logSeq
+  const n = typeof raw === 'string' ? Number(raw) : NaN
+  return Number.isInteger(n) && n > 0 ? n : null
 }
 
 // Derive the default (source, scope) for the current context. Standalone use
@@ -112,50 +143,122 @@ function defaultSource(): { source: string; scope: MatchScope } {
 
 // Reset the editable query to the context default, then refetch. Used on mount
 // and whenever the surrounding context changes (props, selected attempt).
-function applyDefaults() {
+function applyDefaults(): Promise<void> {
   const d = defaultSource()
   sourceInput.value = d.source
   matchScope.value = d.scope
-  resetAndFetch()
+  return resetAndFetch()
 }
 
-// A `datetime-local` value (e.g. "2026-06-30T02:08") carries no timezone, so
-// interpret it in the panel's selected zone. This keeps the lower bound aligned
-// with the timestamps the panel renders instead of silently assuming local.
-function parseDateTimeLocal(value: string): number {
-  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?/)
-  if (!m) return NaN
-  const [year, month, day, hour, minute, second] = m.slice(1).map((p) => Number(p ?? 0))
-  return timeZone.value === 'utc'
-    ? Date.UTC(year, month - 1, day, hour, minute, second)
-    : new Date(year, month - 1, day, hour, minute, second).getTime()
+// Job-aggregate mode shows logs from many tasks; render a per-line link to the
+// originating task. Single-task mode would link every line to itself, so skip.
+// A federated job's tasks are mirrored locally under the same ids, so the links
+// resolve for federated rows too.
+const showTaskLinks = computed(() => {
+  if (!props.taskId) return false
+  return !/\/\d+$/.test(props.taskId)
+})
+
+interface TaskRef {
+  taskId: string
+  taskIndex: string
 }
 
-// Resolve the lower time bound at request time. A relative preset must be
-// recomputed on every fetch (including auto-refresh polls) so the window stays
-// anchored to "now", not to when the preset was first selected.
-function computeSinceMs(): number | undefined {
-  if (customSince.value) {
-    const ms = parseDateTimeLocal(customSince.value)
-    return Number.isNaN(ms) ? undefined : ms
+function parseTaskFromKey(key: string | undefined): TaskRef | null {
+  if (!key) return null
+  const colonIdx = key.lastIndexOf(':')
+  const taskId = colonIdx > 0 ? key.slice(0, colonIdx) : key
+  const lastSlash = taskId.lastIndexOf('/')
+  if (lastSlash < 0) return null
+  const taskIndex = taskId.slice(lastSlash + 1)
+  if (!/^\d+$/.test(taskIndex)) return null
+  return { taskId, taskIndex }
+}
+
+interface LogRow {
+  entry: LogEntry
+  seq: number
+  isContext: boolean
+  isException: boolean
+  taskRef: TaskRef | null
+  segments: HighlightedSegment[]
+  hasMatch: boolean
+}
+
+// Context rows merge into the primary result set by seq. A row that is both a
+// filter hit and part of an expanded window renders as a hit.
+const mergedEntries = computed<{ entry: LogEntry; isContext: boolean }[]>(() => {
+  if (contextEntries.value.size === 0) {
+    return entries.value.map((entry) => ({ entry, isContext: false }))
   }
-  return presetMs.value > 0 ? Date.now() - presetMs.value : undefined
-}
+  const bySeq = new Map<number, { entry: LogEntry; isContext: boolean }>()
+  for (const [seq, entry] of contextEntries.value) bySeq.set(seq, { entry, isContext: true })
+  for (const entry of entries.value) bySeq.set(seqOf(entry), { entry, isContext: false })
+  return [...bySeq.entries()].sort((a, b) => a[0] - b[0]).map(([, row]) => row)
+})
 
+// Link parsing is independent of the search query, so it stays out of the
+// per-keystroke path below.
+const linkedRows = computed(() =>
+  mergedEntries.value.map(({ entry, isContext }) => ({
+    entry,
+    isContext,
+    seq: seqOf(entry),
+    isException: isExceptionEntry(entry),
+    taskRef: showTaskLinks.value ? parseTaskFromKey(entry.key) : null,
+    // proto3-JSON omits default scalars, so an empty log line arrives with
+    // `data` absent (undefined); coalesce so matchAll() doesn't throw.
+    segments: parseLogLinks(entry.data ?? ''),
+  })),
+)
+
+const logRows = computed<LogRow[]>(() => {
+  const matcher = search.matcher.value
+  if (!matcher) return linkedRows.value.map((row) => ({ ...row, hasMatch: false }))
+  return linkedRows.value.map((row) => {
+    const ranges = matcher.find(row.entry.data ?? '')
+    return { ...row, segments: highlightSegments(row.segments, ranges), hasMatch: ranges.length > 0 }
+  })
+})
+
+const matchIndices = computed(() => logRows.value.flatMap((row, i) => (row.hasMatch ? [i] : [])))
+const exceptionIndices = computed(() =>
+  groupNearbyIndices(logRows.value.flatMap((row, i) => (row.isException ? [i] : [])), EXCEPTION_GROUP_GAP),
+)
+
+const matchCursor = useIndexCursor(matchIndices)
+const exceptionCursor = useIndexCursor(exceptionIndices)
+const filterActive = computed(() => filter.value.length > 0)
+
+const exceptionLabel = computed(() => {
+  const total = exceptionIndices.value.length
+  if (total === 0) return 'No exceptions'
+  if (exceptionCursor.position.value < 0) {
+    return total === 1 ? 'Jump to exception' : `Jump to exception (${total})`
+  }
+  return `Exception ${exceptionCursor.position.value + 1} / ${total}`
+})
 // Monotonic generation to discard responses from superseded requests (e.g.
 // when the filter changes while a poll is in flight).
 let generation = 0
 
-function baseRequest() {
+/** The stream selector: which keys this panel reads. Shared by every request. */
+function sourceRequest() {
   return {
     source: sourceInput.value,
     matchScope: WIRE_SCOPE[matchScope.value],
-    substring: filter.value || undefined,
-    minLevel: level.value ? level.value.toUpperCase() : undefined,
-    sinceMs: computeSinceMs(),
     // Federated rows target the peer's relayed logs in the shared hub store; a
     // local row (or no cluster context) sends no filter and reads its own rows.
     cluster: isFederated(props.cluster) ? props.cluster : undefined,
+  }
+}
+
+function baseRequest() {
+  return {
+    ...sourceRequest(),
+    substring: filter.value || undefined,
+    minLevel: level.value ? level.value.toUpperCase() : undefined,
+    sinceMs: sinceMs(),
   }
 }
 
@@ -174,7 +277,7 @@ async function fetchTail() {
     const resp = await logServiceRpcCall<FetchLogsResponse>('FetchLogs', {
       ...baseRequest(),
       maxLines: tailLines.value || undefined,
-      tail: !customSince.value,
+      tail: !absoluteSince.value,
     })
     if (gen !== generation) return
     entries.value = resp.entries ?? []
@@ -229,13 +332,79 @@ async function doPoll() {
   await fetchIncremental()
 }
 
+/** Drop the pinned row and everything expanded around it. */
+function clearAnchor() {
+  selectedSeq.value = null
+  contextEntries.value = new Map()
+  if (route.query.logSeq !== undefined) {
+    const { logSeq: _dropped, ...rest } = route.query
+    router.replace({ query: rest })
+  }
+}
+
 // Reset the cursor and do a full tail fetch. Used whenever the query changes
 // (source, scope, substring, level, since, attempt, tail size) — the cursor
 // from the previous query isn't meaningful for the new criteria.
 async function resetAndFetch() {
   cursor.value = null
   entries.value = []
+  clearAnchor()
+  matchCursor.reset()
+  exceptionCursor.reset()
   await fetchTail()
+}
+
+/**
+ * Splice the neighbourhood of row `seq` into the view.
+ *
+ * The neighbourhood is unfiltered: only the stream selector is sent, so the
+ * spliced rows include the ones the active filter hides.
+ */
+async function loadContext(seq: number) {
+  if (seq <= 0 || contextPending.value) return
+  contextPending.value = true
+  try {
+    const [before, fromAnchor] = await Promise.all([
+      logServiceRpcCall<FetchLogsResponse>('FetchLogs', {
+        ...sourceRequest(),
+        // Exclusive, so tailing it yields the rows ending just before the anchor.
+        untilCursor: seq,
+        tail: true,
+        maxLines: CONTEXT_LINES,
+      }),
+      logServiceRpcCall<FetchLogsResponse>('FetchLogs', {
+        ...sourceRequest(),
+        // Also exclusive: seq - 1 is the tightest bound that still returns the anchor.
+        cursor: seq - 1,
+        tail: false,
+        maxLines: CONTEXT_LINES + 1,
+      }),
+    ])
+    const next = new Map(contextEntries.value)
+    for (const entry of [...(before.entries ?? []), ...(fromAnchor.entries ?? [])]) {
+      next.set(seqOf(entry), entry)
+    }
+    while (next.size > MAX_CONTEXT_ROWS) {
+      const oldest = next.keys().next().value
+      if (oldest === undefined) break
+      next.delete(oldest)
+    }
+    contextEntries.value = next
+    errorMsg.value = null
+  } catch (e) {
+    errorMsg.value = e instanceof Error ? e.message : String(e)
+  } finally {
+    contextPending.value = false
+  }
+}
+
+/** Pin a row, expand its context, and scroll it into view. */
+async function revealSeq(seq: number) {
+  followTail.value = false
+  await loadContext(seq)
+  selectRow(seq)
+  const index = logRows.value.findIndex((row) => row.seq === seq)
+  if (index >= 0) scrollToRow(index)
 }
 
 const { active: autoRefreshActive, toggle: toggleAutoRefresh } = useAutoRefresh(doPoll, POLL_INTERVAL_MS)
@@ -254,17 +423,9 @@ watch(timeZone, () => {
   if (customSince.value) resetAndFetch()
 })
 
-function selectPreset(ms: number) {
-  // The synthetic "Custom" option (-1) only appears while an absolute time is
-  // set; re-selecting it is a no-op so the datetime input stays in effect.
-  if (ms < 0) return
-  customSince.value = ''
-  presetMs.value = ms
-}
+// A different query means the old match position is meaningless.
+watch([search.applied, search.caseSensitive, search.useRegex], matchCursor.reset)
 
-watch(customSince, (val) => {
-  if (val) presetMs.value = 0
-})
 
 watch(
   () => [props.taskId, props.currentAttemptId] as const,
@@ -300,61 +461,139 @@ watch(() => route.query.attempt, () => {
   }
 })
 
-onMounted(() => {
+onMounted(async () => {
+  window.addEventListener('keydown', onKeydown)
+  // Capture the permalink before applyDefaults' reset strips it from the query.
+  const anchor = seqFromRoute()
   if (props.taskId) {
     const routeAttempt = attemptFromRoute()
     if (routeAttempt >= 0) selectedAttemptId.value = routeAttempt
   }
-  applyDefaults()
+  await applyDefaults()
+  if (anchor !== null) await revealSeq(anchor)
 })
 
-// Job-aggregate mode shows logs from many tasks; render a per-line link to the
-// originating task. Single-task mode would link every line to itself, so skip.
-// A federated job's tasks are mirrored locally under the same ids, so the links
-// resolve for federated rows too.
-const showTaskLinks = computed(() => {
-  if (!props.taskId) return false
-  return !/\/\d+$/.test(props.taskId)
+onUnmounted(() => window.removeEventListener('keydown', onKeydown))
+
+
+function scrollToRow(index: number) {
+  nextTick(() => {
+    const box = scrollBox.value
+    const el = box?.querySelector<HTMLElement>(`[data-row="${index}"]`)
+    if (!box || !el) return
+    box.scrollTop = el.offsetTop - box.clientHeight / 2 + el.clientHeight / 2
+  })
+}
+
+function scrollToBottom() {
+  nextTick(() => {
+    const box = scrollBox.value
+    if (box) box.scrollTop = box.scrollHeight
+  })
+}
+
+/** Pin a row by its index and bring it into view. */
+function focusRow(rowIndex: number | null) {
+  if (rowIndex === null) return
+  followTail.value = false
+  selectedSeq.value = logRows.value[rowIndex]?.seq ?? null
+  scrollToRow(rowIndex)
+}
+
+function gotoMatch(delta: number) {
+  focusRow(matchCursor.step(delta))
+}
+
+function gotoException(delta: number) {
+  focusRow(exceptionCursor.step(delta))
+}
+
+/** Pin a row and make the address bar a link back to it. */
+function selectRow(seq: number) {
+  if (seq <= 0) return
+  selectedSeq.value = seq
+  followTail.value = false
+  router.replace({ query: { ...route.query, logSeq: String(seq) } })
+}
+
+/** Promote the client-side search into the server-side filter over the whole log. */
+function promoteSearchToFilter() {
+  filter.value = search.query.value
+  resetAndFetch()
+}
+
+function clearFilter() {
+  filter.value = ''
+  resetAndFetch()
+}
+
+function onScroll() {
+  const box = scrollBox.value
+  if (!box) return
+  followTail.value = box.scrollHeight - box.scrollTop - box.clientHeight < FOLLOW_TAIL_SLACK_PX
+}
+
+// A start date means "read forward from here", so the interesting rows are at
+// the top; only a tailing view chases the end of the stream.
+watch(() => logRows.value.length, () => {
+  if (followTail.value && !absoluteSince.value) scrollToBottom()
 })
 
-interface TaskRef {
-  taskId: string
-  taskIndex: string
+function isoTimestamp(entry: LogEntry): string {
+  const ms = timestampMs(entry.timestamp)
+  return ms ? new Date(ms).toISOString() : ''
 }
 
-function parseTaskFromKey(key: string | undefined): TaskRef | null {
-  if (!key) return null
-  const colonIdx = key.lastIndexOf(':')
-  const taskId = colonIdx > 0 ? key.slice(0, colonIdx) : key
-  const lastSlash = taskId.lastIndexOf('/')
-  if (lastSlash < 0) return null
-  const taskIndex = taskId.slice(lastSlash + 1)
-  if (!/^\d+$/.test(taskIndex)) return null
-  return { taskId, taskIndex }
+function onKeydown(e: KeyboardEvent) {
+  // Only the visible viewer responds; a hidden tab keeps its handler inert.
+  if (!scrollBox.value?.offsetParent) return
+  if (e.metaKey || e.ctrlKey || e.altKey) return
+  const target = e.target as HTMLElement | null
+  const typing = !!target
+    && (target.tagName === 'INPUT' || target.tagName === 'TEXTAREA'
+      || target.tagName === 'SELECT' || target.isContentEditable)
+  if (e.key === '/' && !typing) {
+    e.preventDefault()
+    searchInput.value?.focus()
+    return
+  }
+  if (typing) return
+  const bindings: Record<string, () => void> = {
+    n: () => gotoMatch(1),
+    N: () => gotoMatch(-1),
+    e: () => gotoException(1),
+    E: () => gotoException(-1),
+  }
+  const action = bindings[e.key]
+  if (!action) return
+  e.preventDefault()
+  action()
 }
 
-interface LogRow {
-  entry: LogEntry
-  taskRef: TaskRef | null
-  segments: ReturnType<typeof parseLogLinks>
+function rowClasses(row: LogRow, index: number): string[] {
+  const classes = ['border-l-2']
+  if (row.isException) classes.push('border-status-danger', 'bg-status-danger-bg')
+  else {
+    const name = logLevelName(row.entry.level)
+    if (name === 'error' || name === 'critical') classes.push('border-status-danger')
+    else if (name === 'warning') classes.push('border-status-warning')
+    else classes.push('border-transparent')
+    // Zebra striping, dimmed for lines pulled in only as context.
+    if (row.isContext) classes.push('bg-surface-sunken', 'text-text-secondary')
+    else if (index % 2 === 1) classes.push('bg-surface-raised')
+  }
+  if (logLevelName(row.entry.level) === 'debug' && !row.isException) classes.push('text-text-muted')
+  if (row.seq > 0 && row.seq === selectedSeq.value) classes.push('ring-1', 'ring-inset', 'ring-accent')
+  else if (index === matchCursor.target.value) classes.push('ring-1', 'ring-inset', 'ring-accent-border')
+  return classes
 }
-
-const logRows = computed<LogRow[]>(() =>
-  entries.value.map(entry => ({
-    entry,
-    taskRef: showTaskLinks.value ? parseTaskFromKey(entry.key) : null,
-    // proto3-JSON omits default scalars, so an empty log line arrives with
-    // `data` absent (undefined); coalesce so matchAll() doesn't throw.
-    segments: parseLogLinks(entry.data ?? ''),
-  })),
-)
 
 defineExpose({ selectedAttemptId })
 </script>
 
 <template>
   <div class="space-y-2">
-    <!-- Query row: source + match scope (+ attempt picker on task pages) -->
+    <!-- Query row: which log stream to read (source + scope + attempt) -->
     <div class="flex flex-wrap items-center gap-2 sm:gap-3 text-sm">
       <input
         v-model="sourceInput"
@@ -388,33 +627,31 @@ defineExpose({ selectedAttemptId })
       </select>
     </div>
 
-    <!-- Filter row: text search + level + since + tail size + auto-refresh -->
+    <!-- Filter row: server-side narrowing — non-matching lines never arrive -->
     <div class="flex flex-wrap items-center gap-2 sm:gap-3 text-sm">
       <input
         v-model="filter"
         type="text"
-        placeholder="Filter text… (Enter to apply)"
+        title="Server-side filter: drops every line that does not contain this text"
+        placeholder="Filter: keep only lines containing… (Enter)"
         class="w-full sm:w-56 px-3 py-1.5 bg-surface border border-surface-border rounded
                text-sm font-mono placeholder:text-text-muted
                focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent"
         @keyup.enter="resetAndFetch"
       />
-      <select
-        v-model="level"
-        class="px-2 py-1.5 border border-surface-border rounded text-sm"
-      >
+      <select v-model="level" title="Minimum severity" class="px-2 py-1.5 border border-surface-border rounded text-sm">
         <option value="debug">Debug</option>
         <option value="info">Info</option>
         <option value="warning">Warning</option>
         <option value="error">Error</option>
       </select>
       <select
-        :value="customSince ? -1 : presetMs"
+        :value="absoluteSince ? CUSTOM_PRESET : presetMs"
         title="Only show logs newer than this"
         class="px-2 py-1.5 border border-surface-border rounded text-sm"
         @change="selectPreset(Number(($event.target as HTMLSelectElement).value))"
       >
-        <option v-if="customSince" :value="-1">Custom</option>
+        <option v-if="absoluteSince" :value="CUSTOM_PRESET">Custom</option>
         <option v-for="p in SINCE_PRESETS" :key="p.ms" :value="p.ms">{{ p.label }}</option>
       </select>
       <input
@@ -431,10 +668,7 @@ defineExpose({ selectedAttemptId })
         <option value="local">Local</option>
         <option value="utc">UTC</option>
       </select>
-      <select
-        v-model.number="tailLines"
-        class="px-2 py-1.5 border border-surface-border rounded text-sm"
-      >
+      <select v-model.number="tailLines" class="px-2 py-1.5 border border-surface-border rounded text-sm">
         <option :value="500">500 lines</option>
         <option :value="1000">1,000 lines</option>
         <option :value="5000">5,000 lines</option>
@@ -447,9 +681,7 @@ defineExpose({ selectedAttemptId })
       >
         {{ autoRefreshActive ? 'Auto ⟳' : 'Paused' }}
       </button>
-      <span class="ml-auto text-xs text-text-muted font-mono">
-        {{ logRows.length }} lines
-      </span>
+      <span class="ml-auto text-xs text-text-muted font-mono">{{ logRows.length }} lines</span>
     </div>
 
     <div
@@ -459,47 +691,184 @@ defineExpose({ selectedAttemptId })
       {{ errorMsg }}
     </div>
 
-    <div
-      class="overflow-y-auto rounded-lg border border-surface-border bg-surface"
-      :style="{ maxHeight: maxHeight }"
-    >
-      <div
-        v-if="loading && logRows.length === 0"
-        class="py-12 text-center text-text-muted text-sm"
-      >
-        Loading logs...
+    <!-- The find bar, the filter notice and the log body read as one panel, so
+         they share a border and sit outside the toolbar's vertical rhythm. -->
+    <div class="rounded-lg border border-surface-border overflow-hidden">
+    <!-- Find bar: client-side search over the loaded lines, plus failure nav -->
+    <div class="flex flex-wrap items-center gap-2 text-sm border-b border-surface-border
+                bg-surface-raised px-2 py-1.5">
+      <div class="relative">
+        <input
+          ref="searchInput"
+          v-model="search.query.value"
+          type="text"
+          spellcheck="false"
+          title="Highlights matches in the lines already loaded, keeping their context. Press / to focus, Enter or n for the next match."
+          placeholder="Search loaded lines… (/)"
+          class="w-56 pl-3 pr-16 py-1 bg-surface border border-surface-border rounded
+                 text-sm font-mono placeholder:text-text-muted
+                 focus:outline-none focus:ring-2 focus:ring-accent/20 focus:border-accent"
+          :class="search.error.value ? 'border-status-danger' : ''"
+          @keydown.enter.prevent="gotoMatch($event.shiftKey ? -1 : 1)"
+          @keydown.esc.prevent="search.query.value = ''"
+        />
+        <div class="absolute inset-y-0 right-1 flex items-center gap-0.5">
+          <button
+            title="Match case"
+            class="px-1 rounded text-xs font-mono hover:bg-surface-sunken"
+            :class="search.caseSensitive.value ? 'text-accent' : 'text-text-muted'"
+            @click="search.caseSensitive.value = !search.caseSensitive.value"
+          >Aa</button>
+          <button
+            title="Regular expression"
+            class="px-1 rounded text-xs font-mono hover:bg-surface-sunken"
+            :class="search.useRegex.value ? 'text-accent' : 'text-text-muted'"
+            @click="search.useRegex.value = !search.useRegex.value"
+          >.*</button>
+        </div>
       </div>
-      <div
-        v-else-if="logRows.length === 0"
-        class="py-12 text-center text-text-muted text-sm"
-      >
-        No log entries
-      </div>
-      <div
-        v-for="(row, i) in logRows"
-        :key="i"
-        :class="[
-          'px-3 py-0.5 font-mono text-xs leading-relaxed hover:bg-surface-sunken',
-          logLevelClass(row.entry.level),
-        ]"
-      >
-        <RouterLink
-          v-if="row.taskRef && props.taskId"
-          :to="`/job/${encodeURIComponent(props.taskId)}/task/${encodeURIComponent(row.taskRef.taskId)}`"
-          class="text-accent hover:underline mr-2"
-          :title="row.taskRef.taskId"
+
+      <template v-if="search.applied.value && !search.error.value">
+        <span class="text-xs font-mono text-text-muted tabular-nums">
+          {{ matchIndices.length
+            ? `${matchCursor.position.value >= 0 ? matchCursor.position.value + 1 : '–'} / ${matchIndices.length}`
+            : 'no matches' }}
+        </span>
+        <button
+          class="px-1.5 py-0.5 border border-surface-border rounded text-xs hover:bg-surface-sunken disabled:opacity-40"
+          title="Previous match (Shift+Enter or N)"
+          :disabled="!matchIndices.length"
+          @click="gotoMatch(-1)"
+        >↑</button>
+        <button
+          class="px-1.5 py-0.5 border border-surface-border rounded text-xs hover:bg-surface-sunken disabled:opacity-40"
+          title="Next match (Enter or n)"
+          :disabled="!matchIndices.length"
+          @click="gotoMatch(1)"
+        >↓</button>
+        <button
+          v-if="!matchIndices.length"
+          class="px-1.5 py-0.5 border border-surface-border rounded text-xs text-accent hover:bg-surface-sunken"
+          title="No match among the loaded lines. Re-query the whole log with this text as a server-side filter."
+          @click="promoteSearchToFilter"
+        >Filter the full log</button>
+      </template>
+      <span v-else-if="search.error.value" class="text-xs text-status-danger">{{ search.error.value }}</span>
+
+      <div class="flex items-center gap-1 ml-auto">
+        <button
+          class="px-1.5 py-0.5 border border-surface-border rounded text-xs hover:bg-surface-sunken
+                 disabled:opacity-40 disabled:hover:bg-transparent"
+          :class="exceptionIndices.length ? 'text-status-danger' : 'text-text-muted'"
+          :title="exceptionIndices.length
+            ? 'Jump to the next traceback or fatal error (e)'
+            : 'No traceback or fatal error among the loaded lines'"
+          :disabled="!exceptionIndices.length"
+          @click="gotoException(1)"
         >
-          T{{ row.taskRef.taskIndex }}
-        </RouterLink>
-        <span class="text-text-muted mr-2">{{ formatLogTime(timestampMs(row.entry.timestamp), timeZone === 'utc') }}</span>
-        <span class="whitespace-pre-wrap break-all"><template
-          v-for="(seg, j) in row.segments"
-          :key="j"
-        ><RouterLink
-          v-if="seg.to"
-          :to="seg.to"
-          class="text-accent hover:underline"
-        >{{ seg.text }}</RouterLink><template v-else>{{ seg.text }}</template></template></span>
+          ⚠ {{ exceptionLabel }}
+        </button>
+        <button
+          class="px-1.5 py-0.5 border border-surface-border rounded text-xs hover:bg-surface-sunken disabled:opacity-40"
+          title="Previous exception (E)"
+          :disabled="!exceptionIndices.length"
+          @click="gotoException(-1)"
+        >↑</button>
+        <button
+          class="px-2 py-0.5 border border-surface-border rounded text-xs hover:bg-surface-sunken"
+          :class="wrap ? 'text-accent' : 'text-text-muted'"
+          title="Wrap long lines"
+          @click="wrap = !wrap"
+        >Wrap</button>
+        <button
+          class="px-2 py-0.5 border border-surface-border rounded text-xs hover:bg-surface-sunken"
+          :class="followTail ? 'text-accent' : 'text-text-muted'"
+          title="Keep the newest line in view as logs arrive"
+          @click="followTail = true; scrollToBottom()"
+        >Follow</button>
+      </div>
+    </div>
+
+      <div
+        v-if="filterActive"
+        class="flex items-center gap-2 px-3 py-1 text-xs border-b border-surface-border
+               bg-surface-raised text-text-secondary"
+      >
+        <span>
+          Filtered to lines containing <code class="font-mono text-text">{{ filter }}</code> — surrounding
+          lines are hidden. Use <span class="font-mono">⋯</span> on a row to bring its context back.
+        </span>
+        <button class="ml-auto text-accent hover:underline" @click="clearFilter">Clear filter</button>
+      </div>
+
+      <div
+        ref="scrollBox"
+        class="relative overflow-auto bg-surface"
+        :style="{ maxHeight: maxHeight }"
+        @scroll.passive="onScroll"
+      >
+        <div v-if="loading && logRows.length === 0" class="py-12 text-center text-text-muted text-sm">
+          Loading logs...
+        </div>
+        <div v-else-if="logRows.length === 0" class="py-12 text-center text-text-muted text-sm">
+          No log entries
+        </div>
+        <!-- Sizing the list to its widest line (rather than each row to its own
+             content) keeps the zebra stripes full-width when scrolled right. -->
+        <div v-else :class="wrap ? '' : 'min-w-max'">
+          <div
+            v-for="(row, i) in logRows"
+            :key="row.seq > 0 ? row.seq : `i${i}`"
+            :data-row="i"
+            class="group flex items-start gap-2 px-2 py-0.5 font-mono text-xs leading-relaxed
+                   hover:bg-surface-sunken"
+            :class="rowClasses(row, i)"
+          >
+            <button
+              v-if="row.seq > 0"
+              class="shrink-0 w-4 text-text-muted opacity-0 group-hover:opacity-100
+                     focus-visible:opacity-100 hover:text-accent disabled:opacity-40"
+              :title="`Show the ${CONTEXT_LINES} lines either side of this one, unfiltered`"
+              :disabled="contextPending"
+              @click="loadContext(row.seq)"
+            >⋯</button>
+            <span v-else class="shrink-0 w-4" />
+            <RouterLink
+              v-if="row.taskRef && props.taskId"
+              :to="`/job/${encodeURIComponent(props.taskId)}/task/${encodeURIComponent(row.taskRef.taskId)}`"
+              class="shrink-0 text-accent hover:underline"
+              :title="row.taskRef.taskId"
+            >
+              T{{ row.taskRef.taskIndex }}
+            </RouterLink>
+            <button
+              class="shrink-0 text-text-muted tabular-nums hover:text-accent hover:underline"
+              :title="`${isoTimestamp(row.entry)} — click to pin and link to this line`"
+              @click="selectRow(row.seq)"
+            >{{ formatLogTime(timestampMs(row.entry.timestamp), timeZone === 'utc') }}</button>
+            <span
+              :class="wrap ? 'whitespace-pre-wrap break-words flex-1' : 'whitespace-pre'"
+            ><template
+              v-for="(seg, j) in row.segments"
+              :key="j"
+            ><RouterLink
+              v-if="seg.to"
+              :to="seg.to"
+              class="text-accent hover:underline"
+              :class="seg.match ? 'bg-status-warning-bg' : ''"
+            >{{ seg.text }}</RouterLink><a
+              v-else-if="seg.href"
+              :href="seg.href"
+              target="_blank"
+              rel="noopener noreferrer"
+              class="text-accent hover:underline"
+              :class="seg.match ? 'bg-status-warning-bg' : ''"
+            >{{ seg.text }}</a><mark
+              v-else-if="seg.match"
+              class="bg-status-warning-bg text-text rounded-sm"
+            >{{ seg.text }}</mark><template v-else>{{ seg.text }}</template></template></span>
+          </div>
+        </div>
       </div>
     </div>
   </div>

--- a/lib/iris/dashboard/src/composables/useIndexCursor.ts
+++ b/lib/iris/dashboard/src/composables/useIndexCursor.ts
@@ -1,0 +1,41 @@
+/**
+ * A wrapping cursor over a list of row indices.
+ *
+ * Backs the "next/previous match" and "next/previous exception" controls, which
+ * differ only in which rows they step through. `position` is an offset into
+ * `indices`, not a row index; -1 means nothing is selected yet, so the first
+ * forward step lands on the first entry and the first backward step on the last.
+ */
+import { computed, type ComputedRef, type Ref, ref } from 'vue'
+
+export interface IndexCursor {
+  /** Offset into `indices`; -1 when nothing is selected. */
+  position: Ref<number>
+  /** The row index the cursor currently points at, or -1. */
+  target: ComputedRef<number>
+  /** Step `delta` entries, wrapping. Returns the row index, or null if empty. */
+  step: (delta: number) => number | null
+  reset: () => void
+}
+
+export function useIndexCursor(indices: Ref<number[]>): IndexCursor {
+  const position = ref(-1)
+
+  // The list shrinks as the query changes, so a stale position reads as "none".
+  const target = computed(() => indices.value[position.value] ?? -1)
+
+  function step(delta: number): number | null {
+    const list = indices.value
+    if (list.length === 0) return null
+    position.value = position.value < 0
+      ? (delta > 0 ? 0 : list.length - 1)
+      : (position.value + delta + list.length) % list.length
+    return list[position.value]
+  }
+
+  function reset() {
+    position.value = -1
+  }
+
+  return { position, target, step, reset }
+}

--- a/lib/iris/dashboard/src/composables/useLogSearch.ts
+++ b/lib/iris/dashboard/src/composables/useLogSearch.ts
@@ -1,0 +1,44 @@
+/**
+ * Query state for find-in-loaded-lines: the text, its modifiers, and the matcher
+ * compiled from them.
+ *
+ * The query is debounced because every keystroke re-runs the matcher over every
+ * loaded line. `applied` is the settled query — components key their match lists
+ * off it, not off `query`.
+ */
+import { computed, type ComputedRef, onUnmounted, type Ref, ref, watch } from 'vue'
+import { compileSearch, type SearchMatcher } from '@/utils/logSearch'
+
+export interface LogSearch {
+  query: Ref<string>
+  caseSensitive: Ref<boolean>
+  useRegex: Ref<boolean>
+  /** The debounced query the matcher was built from. */
+  applied: Ref<string>
+  /** Null when the query is empty or does not compile. */
+  matcher: ComputedRef<SearchMatcher | null>
+  /** The regex compile error, when the query does not parse. */
+  error: ComputedRef<string | null>
+}
+
+export function useLogSearch(debounceMs: number): LogSearch {
+  const query = ref('')
+  const caseSensitive = ref(false)
+  const useRegex = ref(false)
+  const applied = ref('')
+
+  let timer: number | undefined
+  watch(query, (value) => {
+    window.clearTimeout(timer)
+    timer = window.setTimeout(() => { applied.value = value }, debounceMs)
+  })
+  onUnmounted(() => window.clearTimeout(timer))
+
+  const compiled = computed(() =>
+    compileSearch(applied.value, { caseSensitive: caseSensitive.value, useRegex: useRegex.value }),
+  )
+  const matcher = computed(() => (compiled.value.kind === 'ok' ? compiled.value.matcher : null))
+  const error = computed(() => (compiled.value.kind === 'invalid' ? compiled.value.message : null))
+
+  return { query, caseSensitive, useRegex, applied, matcher, error }
+}

--- a/lib/iris/dashboard/src/composables/useTimeWindow.ts
+++ b/lib/iris/dashboard/src/composables/useTimeWindow.ts
@@ -1,0 +1,80 @@
+/**
+ * The lower time bound of a log panel: a relative preset or an absolute instant,
+ * never both.
+ *
+ * A preset resolves against the clock on every read, so a window like "last 15m"
+ * stays anchored to now across auto-refresh polls rather than to the moment the
+ * preset was picked.
+ */
+import { computed, type ComputedRef, type Ref, ref, watch } from 'vue'
+
+export type TimeZoneName = 'local' | 'utc'
+
+/** Relative windows offered by the "Since" selector. 0 = no lower bound. */
+export const SINCE_PRESETS: { label: string; ms: number }[] = [
+  { label: 'All time', ms: 0 },
+  { label: 'Last 15m', ms: 15 * 60_000 },
+  { label: 'Last 1h', ms: 60 * 60_000 },
+  { label: 'Last 6h', ms: 6 * 3_600_000 },
+  { label: 'Last 24h', ms: 24 * 3_600_000 },
+  { label: 'Last 7d', ms: 7 * 86_400_000 },
+]
+
+/** The synthetic selector option shown while an absolute instant is in effect. */
+export const CUSTOM_PRESET = -1
+
+export interface TimeWindow {
+  /** Width of the relative window in ms; 0 when there is no lower bound. */
+  presetMs: Ref<number>
+  /** A `datetime-local` string; empty when a preset is in effect. */
+  customSince: Ref<string>
+  /** Whether the bound is an absolute instant rather than a relative preset. */
+  absolute: ComputedRef<boolean>
+  /** The bound as epoch ms, or undefined when unbounded. */
+  sinceMs: () => number | undefined
+  selectPreset: (ms: number) => void
+}
+
+/**
+ * Read a `datetime-local` value (e.g. "2026-06-30T02:08") as epoch ms in `zone`.
+ *
+ * The value carries no timezone, so it is read in the panel's selected zone
+ * rather than the browser's. Returns NaN when the value does not parse.
+ */
+function parseDateTimeLocal(value: string, zone: TimeZoneName): number {
+  const m = value.match(/^(\d{4})-(\d{2})-(\d{2})T(\d{2}):(\d{2})(?::(\d{2}))?/)
+  if (!m) return NaN
+  const [year, month, day, hour, minute, second] = m.slice(1).map((p) => Number(p ?? 0))
+  return zone === 'utc'
+    ? Date.UTC(year, month - 1, day, hour, minute, second)
+    : new Date(year, month - 1, day, hour, minute, second).getTime()
+}
+
+export function useTimeWindow(timeZone: Ref<TimeZoneName>): TimeWindow {
+  const presetMs = ref(0)
+  const customSince = ref('')
+
+  // The two forms are mutually exclusive: naming an instant drops the preset.
+  watch(customSince, (value) => {
+    if (value) presetMs.value = 0
+  })
+
+  const absolute = computed(() => customSince.value !== '')
+
+  function sinceMs(): number | undefined {
+    if (customSince.value) {
+      const ms = parseDateTimeLocal(customSince.value, timeZone.value)
+      return Number.isNaN(ms) ? undefined : ms
+    }
+    return presetMs.value > 0 ? Date.now() - presetMs.value : undefined
+  }
+
+  function selectPreset(ms: number) {
+    // Re-selecting the synthetic "Custom" option leaves the instant in effect.
+    if (ms === CUSTOM_PRESET) return
+    customSince.value = ''
+    presetMs.value = ms
+  }
+
+  return { presetMs, customSince, absolute, sinceMs, selectPreset }
+}

--- a/lib/iris/dashboard/src/types/rpc.ts
+++ b/lib/iris/dashboard/src/types/rpc.ts
@@ -512,6 +512,8 @@ export interface LogEntry {
   attemptId?: number
   level?: string
   key?: string
+  /** Store row id, ascending in write order. int64, so proto JSON sends a string. */
+  seq?: string
 }
 
 export interface FetchLogsResponse {

--- a/lib/iris/dashboard/src/utils/formatting.ts
+++ b/lib/iris/dashboard/src/utils/formatting.ts
@@ -92,10 +92,31 @@ export function formatUptime(uptimeMs?: string): string {
   return `${Math.floor(hours / 24)}d ${hours % 24}h`
 }
 
-/** CSS class for a log level string. */
+/** The severity names a `LogEntry.level` can normalize to. */
+export type LogLevelName = 'unknown' | 'debug' | 'info' | 'warning' | 'error' | 'critical'
+
+/**
+ * Normalize a wire `LogLevel` to its bare severity name.
+ *
+ * proto3 JSON renders an enum as its declared name, so the wire carries
+ * `"LOG_LEVEL_ERROR"`, not `"ERROR"`. Levels finelog could not parse from the
+ * line arrive as `LOG_LEVEL_UNKNOWN` and normalize to `'unknown'`.
+ */
+export function logLevelName(level: string | undefined): LogLevelName {
+  const name = (level ?? '').toLowerCase().replace(/^log_level_/, '')
+  switch (name) {
+    case 'debug':
+    case 'info':
+    case 'warning':
+    case 'error':
+    case 'critical': return name
+    default: return 'unknown'
+  }
+}
+
+/** Text color class for a log level string. */
 export function logLevelClass(level: string | undefined): string {
-  const lvl = (level ?? 'info').toLowerCase()
-  switch (lvl) {
+  switch (logLevelName(level)) {
     case 'debug': return 'text-text-muted'
     case 'warning': return 'text-status-warning'
     case 'error':

--- a/lib/iris/dashboard/src/utils/logLinks.ts
+++ b/lib/iris/dashboard/src/utils/logLinks.ts
@@ -1,12 +1,15 @@
-// Detect navigable iris identifiers inside free-form log text and turn them
-// into router links. These are deliberately quick regex checks against the
-// rendered line — no store lookups — so a stray false positive just yields a
-// dead-but-harmless link, never a wrong query.
+// Detect navigable identifiers inside free-form log text and turn them into
+// links. These are deliberately quick regex checks against the rendered line —
+// no store lookups — so a stray false positive just yields a dead-but-harmless
+// link, never a wrong query.
 
-/** A run of log text, optionally carrying a router target to link it to. */
+/** A run of log text, optionally carrying a link target. */
 export interface LogSegment {
   text: string
+  /** Router target, for identifiers that resolve to a dashboard page. */
   to?: string
+  /** Absolute URL, for targets outside the dashboard. */
+  href?: string
 }
 
 // worker-<slice>-<tpu_index>-<uuid8>. The slice id can itself contain dashes,
@@ -19,7 +22,27 @@ const WORKER_PATTERN = 'worker-[A-Za-z0-9]+(?:-[A-Za-z0-9]+)*-[0-9a-f]{8}'
 // file:line like foo.py:42 doesn't match.
 const TASK_PATTERN = '(?:/[A-Za-z0-9][A-Za-z0-9._-]*)+/\\d+(?::\\d+)?'
 
-const TOKEN_RE = new RegExp(`(?<worker>${WORKER_PATTERN})|(?<task>${TASK_PATTERN})`, 'g')
+// Anything up to whitespace or a delimiter that cannot appear unescaped in a
+// URL. Trailing sentence punctuation is trimmed by `trimTrailingPunctuation`.
+const URL_TAIL = '[^\\s<>"\'`]*'
+const URL_PATTERN = `https?://${URL_TAIL}`
+const GCS_PATTERN = `gs://[a-z0-9][a-z0-9._-]*(?:/${URL_TAIL})?`
+
+// Order matters: a URL and a GCS path both contain runs that look like task
+// paths, and JS alternation takes the first alternative that matches at the
+// earliest position. Both start before the `/…` a task pattern would latch onto.
+const TOKEN_RE = new RegExp(
+  `(?<url>${URL_PATTERN})|(?<gcs>${GCS_PATTERN})|(?<worker>${WORKER_PATTERN})|(?<task>${TASK_PATTERN})`,
+  'g',
+)
+
+// Punctuation that ends a sentence far more often than it ends a URL.
+const TRAILING_PUNCTUATION = /[.,;:!?)\]}>'"]+$/
+
+/** Strip sentence punctuation a greedy URL match swallowed (`see http://x/y.` ). */
+function trimTrailingPunctuation(match: string): string {
+  return match.replace(TRAILING_PUNCTUATION, '')
+}
 
 function jobIdOf(taskId: string): string {
   const slash = taskId.lastIndexOf('/')
@@ -40,24 +63,38 @@ function taskTargetFromMatch(match: string): string {
   return taskAttemptRoute(match)
 }
 
+/** Cloud-console browser URL for a `gs://bucket/prefix` path. */
+export function gcsConsoleUrl(uri: string): string {
+  return `https://console.cloud.google.com/storage/browser/${uri.slice('gs://'.length)}`
+}
+
 /**
  * Split a log line into plain-text and linked segments. Worker ids link to the
- * worker page; task/attempt paths link to the task (attempt) page. Returns a
- * single plain segment when nothing matches.
+ * worker page; task/attempt paths link to the task (attempt) page; `http(s)`
+ * URLs and `gs://` paths link out of the dashboard. Returns a single plain
+ * segment when nothing matches.
  */
 export function parseLogLinks(text: string): LogSegment[] {
   const segments: LogSegment[] = []
   let last = 0
   for (const m of text.matchAll(TOKEN_RE)) {
     const start = m.index ?? 0
-    if (start > last) segments.push({ text: text.slice(last, start) })
     const groups = m.groups ?? {}
-    if (groups.worker) {
-      segments.push({ text: m[0], to: `/worker/${groups.worker}` })
+    // A trimmed URL gives back the punctuation it swallowed, which must stay in
+    // the line as plain text rather than vanish into the link.
+    const matched = groups.url || groups.gcs ? trimTrailingPunctuation(m[0]) : m[0]
+    if (!matched) continue
+    if (start > last) segments.push({ text: text.slice(last, start) })
+    if (groups.url) {
+      segments.push({ text: matched, href: matched })
+    } else if (groups.gcs) {
+      segments.push({ text: matched, href: gcsConsoleUrl(matched) })
+    } else if (groups.worker) {
+      segments.push({ text: matched, to: `/worker/${groups.worker}` })
     } else {
-      segments.push({ text: m[0], to: taskTargetFromMatch(m[0]) })
+      segments.push({ text: matched, to: taskTargetFromMatch(matched) })
     }
-    last = start + m[0].length
+    last = start + matched.length
   }
   if (last < text.length) segments.push({ text: text.slice(last) })
   return segments

--- a/lib/iris/dashboard/src/utils/logSearch.ts
+++ b/lib/iris/dashboard/src/utils/logSearch.ts
@@ -1,0 +1,179 @@
+// Client-side search over the log lines already on screen, and detection of the
+// lines worth jumping to when hunting for a failure.
+//
+// Search is deliberately separate from the server-side `substring` filter: a
+// filter drops non-matching rows, while a search only marks them, so the
+// surrounding context stays visible. Both exist because they answer different
+// questions ("show me only these lines" vs "where in these lines is X").
+
+import type { LogSegment } from './logLinks'
+
+/** Half-open `[start, end)` character range of one match within a line. */
+export interface MatchRange {
+  start: number
+  end: number
+}
+
+export interface SearchMatcher {
+  /** Non-overlapping match ranges within `text`, in ascending order. */
+  find(text: string): MatchRange[]
+}
+
+/** A query that is blank, unparseable, or compiled and ready to run. */
+export type CompiledSearch =
+  | { kind: 'empty' }
+  | { kind: 'invalid'; message: string }
+  | { kind: 'ok'; matcher: SearchMatcher }
+
+// A single pathological line (a serialized tensor, a base64 blob) must not be
+// able to generate an unbounded highlight list.
+const MAX_MATCHES_PER_LINE = 200
+
+function literalMatcher(query: string, caseSensitive: boolean): SearchMatcher {
+  const needle = caseSensitive ? query : query.toLowerCase()
+  return {
+    find(text: string): MatchRange[] {
+      const haystack = caseSensitive ? text : text.toLowerCase()
+      const ranges: MatchRange[] = []
+      let from = 0
+      while (ranges.length < MAX_MATCHES_PER_LINE) {
+        const at = haystack.indexOf(needle, from)
+        if (at < 0) break
+        ranges.push({ start: at, end: at + needle.length })
+        from = at + needle.length
+      }
+      return ranges
+    },
+  }
+}
+
+function regexMatcher(pattern: RegExp): SearchMatcher {
+  return {
+    find(text: string): MatchRange[] {
+      pattern.lastIndex = 0
+      const ranges: MatchRange[] = []
+      let match: RegExpExecArray | null
+      while ((match = pattern.exec(text)) !== null && ranges.length < MAX_MATCHES_PER_LINE) {
+        // A zero-width match (`x*`, `^`) never advances lastIndex on its own.
+        if (match[0].length === 0) {
+          pattern.lastIndex += 1
+          continue
+        }
+        ranges.push({ start: match.index, end: match.index + match[0].length })
+      }
+      return ranges
+    },
+  }
+}
+
+/** Compile a search query, reporting an unparseable regex rather than throwing. */
+export function compileSearch(
+  query: string,
+  options: { caseSensitive: boolean; useRegex: boolean },
+): CompiledSearch {
+  if (!query) return { kind: 'empty' }
+  if (!options.useRegex) {
+    return { kind: 'ok', matcher: literalMatcher(query, options.caseSensitive) }
+  }
+  try {
+    const flags = options.caseSensitive ? 'g' : 'gi'
+    return { kind: 'ok', matcher: regexMatcher(new RegExp(query, flags)) }
+  } catch (e) {
+    return { kind: 'invalid', message: e instanceof Error ? e.message : String(e) }
+  }
+}
+
+/** A `LogSegment` that also records whether it is part of a search match. */
+export interface HighlightedSegment extends LogSegment {
+  match?: boolean
+}
+
+/**
+ * Re-split link `segments` at `ranges`, marking the pieces a search matched.
+ *
+ * `segments` must tile the original line in order (as `parseLogLinks` returns
+ * them) — the ranges are offsets into that line, not into any one segment. A
+ * match straddling a link boundary is split at the boundary, so the link stays
+ * clickable and both halves stay highlighted.
+ */
+export function highlightSegments(
+  segments: LogSegment[],
+  ranges: MatchRange[],
+): HighlightedSegment[] {
+  if (ranges.length === 0) return segments
+  const out: HighlightedSegment[] = []
+  let offset = 0
+  for (const segment of segments) {
+    const segStart = offset
+    const segEnd = offset + segment.text.length
+    offset = segEnd
+    // Cut points inside this segment, in ascending order, from every range edge
+    // that falls strictly within it.
+    const cuts = new Set<number>()
+    for (const range of ranges) {
+      if (range.start > segStart && range.start < segEnd) cuts.add(range.start)
+      if (range.end > segStart && range.end < segEnd) cuts.add(range.end)
+    }
+    const bounds = [segStart, ...[...cuts].sort((a, b) => a - b), segEnd]
+    for (let i = 0; i < bounds.length - 1; i++) {
+      const start = bounds[i]
+      const end = bounds[i + 1]
+      if (start === end) continue
+      const covered = ranges.some((r) => r.start <= start && r.end >= end)
+      out.push({
+        ...segment,
+        text: segment.text.slice(start - segStart, end - segStart),
+        ...(covered ? { match: true } : {}),
+      })
+    }
+  }
+  return out
+}
+
+// Lines that name a failure. Every match is a stop for jump-to-exception, so
+// the vocabulary is deliberately narrow: it recognizes the head of a traceback
+// or a fatal banner, never the frames beneath one and never prose that merely
+// names an exception type. A wider net would land the reader on retry chatter.
+const EXCEPTION_PATTERNS = [
+  /Traceback \(most recent call last\)/,
+  /Fatal Python error/,
+  /detected fatal errors/,
+  /Segmentation fault/,
+  /core dumped/,
+  /\bOOMKilled\b/,
+  /\bCUDA error\b/,
+  /\bNCCL\b.*\berror\b/i,
+  /\bRESOURCE_EXHAUSTED\b/,
+  /\bDEADLINE_EXCEEDED\b/,
+  /\bout of memory\b/i,
+  /\bCoscheduled sibling\b/,
+  // A bare terminal exception line, anchored so that prose mentioning an error
+  // type mid-sentence ("retrying after ConnectionError") does not match.
+  /^\s*\w*(?:Error|Exception):/,
+]
+
+/** The `source` iris stamps on the failure lines it injects into a task's log. */
+const INJECTED_ERROR_SOURCE = 'error'
+
+/** Whether a log entry is a place a failure hunt should stop. */
+export function isExceptionEntry(entry: { data?: string; source?: string }): boolean {
+  if (entry.source === INJECTED_ERROR_SOURCE) return true
+  const data = entry.data ?? ''
+  return EXCEPTION_PATTERNS.some((pattern) => pattern.test(data))
+}
+
+/**
+ * Collapse runs of indices closer together than `gap` to their first element.
+ *
+ * A traceback trips several exception patterns a few lines apart (its header,
+ * then its terminal `ValueError:`). They are one failure, so a jump-to-next
+ * walks failures, not lines.
+ */
+export function groupNearbyIndices(indices: number[], gap: number): number[] {
+  const grouped: number[] = []
+  for (const index of indices) {
+    const previous = grouped[grouped.length - 1]
+    if (previous === undefined || index - previous > gap) grouped.push(index)
+  }
+  return grouped
+}

--- a/lib/iris/src/iris/cluster/log_highlights.py
+++ b/lib/iris/src/iris/cluster/log_highlights.py
@@ -17,12 +17,30 @@ from collections.abc import Sequence
 
 _DEFAULT_MAX_LINES = 20
 
+# The two halves of a tqdm frame, either of which identifies one:
+#
+#   with a total:    "Loading:  45%|####5     | 450/1000 [00:12<00:15,  3.21it/s]"
+#   without a total: "450it [00:12,  3.21it/s]"
+#
+# The bracketed stats are the reliable half — an unknown total suppresses the
+# percentage and the bar, but never the elapsed clock and rate. The rate always
+# carries a slash, and tqdm inverts it below one iteration per second, so a slow
+# training step reads "1.20s/it" rather than "0.83it/s".
+#
+# Neither pattern is anchored to the start of the line: a description prefixes
+# the bar, and because tqdm redraws with a bare carriage return, one captured
+# line often holds several frames at once.
+_PROGRESS_BAR_PATTERNS = (
+    re.compile(r"\d+%\|[^|]*\|"),
+    re.compile(r"\[\d{1,2}:\d{2}(?::\d{2})?[^\]]*,\s*[\d.?]+[^\s\]]*/[^\s\],]+"),
+)
+
 # Lines that carry no diagnostic value and commonly flood task logs.
 _NOISE_PATTERNS = (
-    re.compile(r"^\s*\d+%\|.*\|\s*\d+/\d+\s*\["),  # tqdm progress bar
     re.compile(r'"(?:GET|POST|PUT|HEAD|DELETE) [^"]* HTTP/1\.\d"\s*\d{3}'),  # HTTP access log line
     re.compile(r"^Extension modules:"),  # CPython post-crash loaded-module dump
 )
+
 
 # Lines likely to name the actual failure. Matched against common
 # Python/JAX/NCCL/CUDA/Kueue/k8s fatal-error vocabulary.
@@ -46,6 +64,15 @@ _SIGNAL_PATTERNS = (
 )
 
 
+def is_progress_bar_line(line: str) -> bool:
+    """Whether ``line`` holds a tqdm-style progress bar frame anywhere in it."""
+    return any(pattern.search(line) for pattern in _PROGRESS_BAR_PATTERNS)
+
+
+def _is_noise(line: str) -> bool:
+    return is_progress_bar_line(line) or any(pattern.search(line) for pattern in _NOISE_PATTERNS)
+
+
 def extract_failure_highlights(lines: Sequence[str], max_lines: int = _DEFAULT_MAX_LINES) -> list[str]:
     """Return the most diagnostically useful lines from a batch of task logs.
 
@@ -61,7 +88,7 @@ def extract_failure_highlights(lines: Sequence[str], max_lines: int = _DEFAULT_M
     deduped: list[str] = []
     previous: str | None = None
     for line in lines:
-        if any(pattern.search(line) for pattern in _NOISE_PATTERNS):
+        if _is_noise(line):
             continue
         if line == previous:
             continue

--- a/lib/iris/src/iris/cluster/log_keys.py
+++ b/lib/iris/src/iris/cluster/log_keys.py
@@ -12,35 +12,44 @@ from finelog.rpc import logging_pb2
 from finelog.types import str_to_log_level
 from rigging.log_setup import parse_log_level
 
+from iris.cluster.log_highlights import is_progress_bar_line
 from iris.cluster.types import JobName, TaskAttempt
 
 CONTROLLER_LOG_KEY = "/system/controller"
 _WORKER_LOG_PREFIX = "/system/worker/"
 
+STDOUT_SOURCE = "stdout"
+STDERR_SOURCE = "stderr"
+# The synthetic source iris stamps on failure lines it injects itself (OOM kills,
+# infrastructure errors), as opposed to anything the task wrote.
+INJECTED_ERROR_SOURCE = "error"
+
 # Default level per capture stream when a line carries no parseable prefix.
-# "error" is the synthetic source iris uses for injected failure lines (OOM
-# kills, infrastructure errors). Streams not listed here (e.g. "build") fall
-# back to UNKNOWN, which stays visible under every min_level filter.
+# Streams not listed here (e.g. "build") fall back to UNKNOWN, which stays
+# visible under every min_level filter.
 _STREAM_DEFAULT_LEVEL = {
-    "stdout": logging_pb2.LOG_LEVEL_INFO,
-    "stderr": logging_pb2.LOG_LEVEL_ERROR,
-    "error": logging_pb2.LOG_LEVEL_ERROR,
+    STDOUT_SOURCE: logging_pb2.LOG_LEVEL_INFO,
+    STDERR_SOURCE: logging_pb2.LOG_LEVEL_ERROR,
 }
 
 
 def classify_log_level(source: str, data: str) -> int:
     """Assign a finelog ``LogLevel`` to a captured task log line.
 
-    A parseable glog-style level prefix in ``data`` always wins, so a prefixed
-    ``INFO`` line on ``stderr`` is classified ``INFO``, not ``ERROR``. Otherwise
-    the level defaults from ``source`` (the capture stream): ``stdout`` is
-    informational, ``stderr`` and iris's injected failure lines are errors. This
-    keeps mundane stdout out of the ``min_level``-filtered error view, where an
-    ``UNKNOWN`` line would otherwise pass through every filter.
+    Lines from ``INJECTED_ERROR_SOURCE`` are errors whatever they say. Otherwise
+    a glog-style level prefix in ``data`` wins, so a prefixed ``INFO`` line on
+    ``stderr`` classifies as ``INFO``. An unprefixed tqdm progress bar on
+    ``stderr`` classifies as ``INFO``. Any other unprefixed line takes its
+    stream's default: ``stdout`` informational, ``stderr`` error, and an
+    unrecognized stream ``UNKNOWN``, which passes every ``min_level`` filter.
     """
+    if source == INJECTED_ERROR_SOURCE:
+        return logging_pb2.LOG_LEVEL_ERROR
     parsed = str_to_log_level(parse_log_level(data))
     if parsed != logging_pb2.LOG_LEVEL_UNKNOWN:
         return parsed
+    if source == STDERR_SOURCE and is_progress_bar_line(data):
+        return logging_pb2.LOG_LEVEL_INFO
     return _STREAM_DEFAULT_LEVEL.get(source, logging_pb2.LOG_LEVEL_UNKNOWN)
 
 

--- a/lib/iris/src/iris/cluster/runtime/docker.py
+++ b/lib/iris/src/iris/cluster/runtime/docker.py
@@ -30,6 +30,7 @@ from pathlib import Path
 from rigging.timing import Timestamp
 
 from iris.cluster.bundle import BundleStore
+from iris.cluster.log_keys import STDERR_SOURCE, STDOUT_SOURCE
 from iris.cluster.runtime.env import VENV_PATH, render_setup_steps, write_workdir_files
 from iris.cluster.runtime.profile import (
     PROFILER_WATCHDOG_GRACE_SECONDS,
@@ -328,11 +329,11 @@ def _docker_logs(container_id: str, since: Timestamp | None = None) -> list[LogL
     for line in result.stdout.splitlines():
         if line:
             timestamp, data = _parse_docker_log_line(line)
-            logs.append(LogLine(timestamp=timestamp, source="stdout", data=data))
+            logs.append(LogLine(timestamp=timestamp, source=STDOUT_SOURCE, data=data))
     for line in result.stderr.splitlines():
         if line:
             timestamp, data = _parse_docker_log_line(line)
-            logs.append(LogLine(timestamp=timestamp, source="stderr", data=data))
+            logs.append(LogLine(timestamp=timestamp, source=STDERR_SOURCE, data=data))
     return logs
 
 

--- a/lib/iris/src/iris/cluster/runtime/process.py
+++ b/lib/iris/src/iris/cluster/runtime/process.py
@@ -31,6 +31,7 @@ from dataclasses import dataclass, field, replace
 from pathlib import Path
 
 from iris.cluster.bundle import BundleStore
+from iris.cluster.log_keys import STDERR_SOURCE, STDOUT_SOURCE
 from iris.cluster.runtime.env import write_workdir_files
 from iris.cluster.runtime.profile import (
     LocalProfileDispatch,
@@ -195,13 +196,13 @@ class ProcessContainer:
                 for stream in ready:
                     line = stream.readline()
                     if line:
-                        emit("stdout" if stream is stdout else "stderr", line)
+                        emit(STDOUT_SOURCE if stream is stdout else STDERR_SOURCE, line)
 
             # Process exited - drain remaining output
             for line in stdout:
-                emit("stdout", line)
+                emit(STDOUT_SOURCE, line)
             for line in stderr:
-                emit("stderr", line)
+                emit(STDERR_SOURCE, line)
 
             self._exit_code = self._process.returncode
             self._running = False

--- a/lib/iris/src/iris/cluster/worker/task_attempt.py
+++ b/lib/iris/src/iris/cluster/worker/task_attempt.py
@@ -25,7 +25,7 @@ from rigging.timing import Duration, ExponentialBackoff, Timestamp
 from iris.chaos import chaos, chaos_raise
 from iris.cluster.bundle import BundleStore
 from iris.cluster.constraints import WellKnownAttribute
-from iris.cluster.log_keys import classify_log_level, task_log_key
+from iris.cluster.log_keys import INJECTED_ERROR_SOURCE, STDERR_SOURCE, classify_log_level, task_log_key
 from iris.cluster.platforms.types import probe_outbound_ip
 from iris.cluster.runtime.docker import DockerContainerHandle
 from iris.cluster.runtime.env import build_common_iris_env
@@ -371,7 +371,7 @@ class TaskAttempt:
             self._monitor_loop(handle, log_reader)
         except Exception as e:
             error_msg = format_exception_with_traceback(e)
-            self._append_log(source="error", data=f"Monitoring failed:\n{error_msg}")
+            self._append_log(source=INJECTED_ERROR_SOURCE, data=f"Monitoring failed:\n{error_msg}")
             self.transition_to(job_pb2.TASK_STATE_FAILED, error=error_msg)
         finally:
             self._cleanup()
@@ -628,11 +628,11 @@ class TaskAttempt:
             self.transition_to(job_pb2.TASK_STATE_KILLED)
         except ContainerInfraError as e:
             error_msg = format_exception_with_traceback(e)
-            self._append_log(source="error", data=f"Infrastructure error:\n{error_msg}")
+            self._append_log(source=INJECTED_ERROR_SOURCE, data=f"Infrastructure error:\n{error_msg}")
             self.transition_to(job_pb2.TASK_STATE_WORKER_FAILED, error=error_msg)
         except Exception as e:
             error_msg = format_exception_with_traceback(e)
-            self._append_log(source="error", data=f"Task failed:\n{error_msg}")
+            self._append_log(source=INJECTED_ERROR_SOURCE, data=f"Task failed:\n{error_msg}")
             self.transition_to(job_pb2.TASK_STATE_FAILED, error=error_msg)
         finally:
             self._cleanup()
@@ -889,14 +889,14 @@ class TaskAttempt:
                     self.transition_to(job_pb2.TASK_STATE_SUCCEEDED, exit_code=0)
                 else:
                     stderr_tail: list[str] = [
-                        entry.data for entry in log_reader.read_all() if entry.source == "stderr" and entry.data
+                        entry.data for entry in log_reader.read_all() if entry.source == STDERR_SOURCE and entry.data
                     ]
                     stderr_line = stderr_tail[-1] if stderr_tail else None
                     error = _format_exit_error(status.exit_code, status.oom_killed)
                     if stderr_line:
                         error = f"{error}. stderr: {stderr_line}"
                     if status.oom_killed:
-                        self._append_log(source="error", data="Container was OOM killed by the kernel")
+                        self._append_log(source=INJECTED_ERROR_SOURCE, data="Container was OOM killed by the kernel")
                     # Promote known TPU bad-node signatures to WORKER_FAILED.
                     tpu_pattern = detect_tpu_init_failure(stderr_tail[-_TPU_STDERR_TAIL_LINES:])
                     if tpu_pattern is not None:
@@ -906,7 +906,7 @@ class TaskAttempt:
                             tpu_pattern,
                         )
                         self._append_log(
-                            source="error",
+                            source=INJECTED_ERROR_SOURCE,
                             data=f"iris: TPU bad-node signature detected ({tpu_pattern!r}); "
                             "reporting as worker failure",
                         )

--- a/lib/iris/src/iris/rpc/iris_logging.proto
+++ b/lib/iris/src/iris/rpc/iris_logging.proto
@@ -43,4 +43,5 @@ message LogEntry {
   int32 attempt_id = 4;
   LogLevel level = 5;
   string key = 6;
+  int64 seq = 7;
 }

--- a/lib/iris/src/iris/rpc/iris_logging_pb2.py
+++ b/lib/iris/src/iris/rpc/iris_logging_pb2.py
@@ -25,7 +25,7 @@ _sym_db = _symbol_database.Default()
 from . import time_pb2 as time__pb2
 
 
-DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12iris_logging.proto\x12\x0ciris.logging\x1a\ntime.proto\"\xc9\x01\n\x08LogEntry\x12\x32\n\ttimestamp\x18\x01 \x01(\x0b\x32\x14.iris.time.TimestampR\ttimestamp\x12\x16\n\x06source\x18\x02 \x01(\tR\x06source\x12\x12\n\x04\x64\x61ta\x18\x03 \x01(\tR\x04\x64\x61ta\x12\x1d\n\nattempt_id\x18\x04 \x01(\x05R\tattemptId\x12,\n\x05level\x18\x05 \x01(\x0e\x32\x16.iris.logging.LogLevelR\x05level\x12\x10\n\x03key\x18\x06 \x01(\tR\x03key*\x8e\x01\n\x08LogLevel\x12\x15\n\x11LOG_LEVEL_UNKNOWN\x10\x00\x12\x13\n\x0fLOG_LEVEL_DEBUG\x10\x01\x12\x12\n\x0eLOG_LEVEL_INFO\x10\x02\x12\x15\n\x11LOG_LEVEL_WARNING\x10\x03\x12\x13\n\x0fLOG_LEVEL_ERROR\x10\x04\x12\x16\n\x12LOG_LEVEL_CRITICAL\x10\x05\x42z\n\x10\x63om.iris.loggingB\x10IrisLoggingProtoP\x01\xa2\x02\x03ILX\xaa\x02\x0cIris.Logging\xca\x02\x0cIris\\Logging\xe2\x02\x18Iris\\Logging\\GPBMetadata\xea\x02\rIris::Logging\x92\x03\x02\x08\x01\x62\x08\x65\x64itionsp\xe8\x07')
+DESCRIPTOR = _descriptor_pool.Default().AddSerializedFile(b'\n\x12iris_logging.proto\x12\x0ciris.logging\x1a\ntime.proto\"\xdb\x01\n\x08LogEntry\x12\x32\n\ttimestamp\x18\x01 \x01(\x0b\x32\x14.iris.time.TimestampR\ttimestamp\x12\x16\n\x06source\x18\x02 \x01(\tR\x06source\x12\x12\n\x04\x64\x61ta\x18\x03 \x01(\tR\x04\x64\x61ta\x12\x1d\n\nattempt_id\x18\x04 \x01(\x05R\tattemptId\x12,\n\x05level\x18\x05 \x01(\x0e\x32\x16.iris.logging.LogLevelR\x05level\x12\x10\n\x03key\x18\x06 \x01(\tR\x03key\x12\x10\n\x03seq\x18\x07 \x01(\x03R\x03seq*\x8e\x01\n\x08LogLevel\x12\x15\n\x11LOG_LEVEL_UNKNOWN\x10\x00\x12\x13\n\x0fLOG_LEVEL_DEBUG\x10\x01\x12\x12\n\x0eLOG_LEVEL_INFO\x10\x02\x12\x15\n\x11LOG_LEVEL_WARNING\x10\x03\x12\x13\n\x0fLOG_LEVEL_ERROR\x10\x04\x12\x16\n\x12LOG_LEVEL_CRITICAL\x10\x05\x42z\n\x10\x63om.iris.loggingB\x10IrisLoggingProtoP\x01\xa2\x02\x03ILX\xaa\x02\x0cIris.Logging\xca\x02\x0cIris\\Logging\xe2\x02\x18Iris\\Logging\\GPBMetadata\xea\x02\rIris::Logging\x92\x03\x02\x08\x01\x62\x08\x65\x64itionsp\xe8\x07')
 
 _globals = globals()
 _builder.BuildMessageAndEnumDescriptors(DESCRIPTOR, _globals)
@@ -33,8 +33,8 @@ _builder.BuildTopDescriptorsAndMessages(DESCRIPTOR, 'iris_logging_pb2', _globals
 if not _descriptor._USE_C_DESCRIPTORS:
   _globals['DESCRIPTOR']._loaded_options = None
   _globals['DESCRIPTOR']._serialized_options = b'\n\020com.iris.loggingB\020IrisLoggingProtoP\001\242\002\003ILX\252\002\014Iris.Logging\312\002\014Iris\\Logging\342\002\030Iris\\Logging\\GPBMetadata\352\002\rIris::Logging\222\003\002\010\001'
-  _globals['_LOGLEVEL']._serialized_start=253
-  _globals['_LOGLEVEL']._serialized_end=395
+  _globals['_LOGLEVEL']._serialized_start=271
+  _globals['_LOGLEVEL']._serialized_end=413
   _globals['_LOGENTRY']._serialized_start=49
-  _globals['_LOGENTRY']._serialized_end=250
+  _globals['_LOGENTRY']._serialized_end=268
 # @@protoc_insertion_point(module_scope)

--- a/lib/iris/src/iris/rpc/iris_logging_pb2.pyi
+++ b/lib/iris/src/iris/rpc/iris_logging_pb2.pyi
@@ -23,17 +23,19 @@ LOG_LEVEL_ERROR: LogLevel
 LOG_LEVEL_CRITICAL: LogLevel
 
 class LogEntry(_message.Message):
-    __slots__ = ("timestamp", "source", "data", "attempt_id", "level", "key")
+    __slots__ = ("timestamp", "source", "data", "attempt_id", "level", "key", "seq")
     TIMESTAMP_FIELD_NUMBER: _ClassVar[int]
     SOURCE_FIELD_NUMBER: _ClassVar[int]
     DATA_FIELD_NUMBER: _ClassVar[int]
     ATTEMPT_ID_FIELD_NUMBER: _ClassVar[int]
     LEVEL_FIELD_NUMBER: _ClassVar[int]
     KEY_FIELD_NUMBER: _ClassVar[int]
+    SEQ_FIELD_NUMBER: _ClassVar[int]
     timestamp: _time_pb2.Timestamp
     source: str
     data: str
     attempt_id: int
     level: LogLevel
     key: str
-    def __init__(self, timestamp: _Optional[_Union[_time_pb2.Timestamp, _Mapping]] = ..., source: _Optional[str] = ..., data: _Optional[str] = ..., attempt_id: _Optional[int] = ..., level: _Optional[_Union[LogLevel, str]] = ..., key: _Optional[str] = ...) -> None: ...
+    seq: int
+    def __init__(self, timestamp: _Optional[_Union[_time_pb2.Timestamp, _Mapping]] = ..., source: _Optional[str] = ..., data: _Optional[str] = ..., attempt_id: _Optional[int] = ..., level: _Optional[_Union[LogLevel, str]] = ..., key: _Optional[str] = ..., seq: _Optional[int] = ...) -> None: ...

--- a/lib/iris/tests/cluster/test_log_highlights.py
+++ b/lib/iris/tests/cluster/test_log_highlights.py
@@ -65,6 +65,17 @@ _TRACEBACK = [
                 "Terminating process because the JAX distributed service detected fatal errors",
             ],
         ),
+        # A described bar and a totalless bar are noise too, wherever they sit
+        # on the line.
+        (
+            [
+                "Loading shards:  45%|####5     | 450/1000 [00:12<00:15,  1.20s/it]",
+                "450it [00:12,  3.21it/s]",
+                "RuntimeError: shard missing",
+            ],
+            20,
+            ["RuntimeError: shard missing"],
+        ),
         # No signal line → fall back to the de-noised tail so output is never empty.
         (["step 1", "step 2", "step 3"], 20, ["step 1", "step 2", "step 3"]),
         # Empty input → empty output.

--- a/lib/iris/tests/cluster/test_log_keys.py
+++ b/lib/iris/tests/cluster/test_log_keys.py
@@ -36,3 +36,60 @@ def test_stream_default_level(source, data, expected):
 )
 def test_parsed_prefix_overrides_stream_default(source, data, expected):
     assert classify_log_level(source, data) == expected
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        " 45%|####5     | 450/1000 [00:12<00:15,  3.21it/s]",
+        "100%|##########| 1000/1000 [05:12<00:00,  3.21it/s]",
+        # A description prefixes the bar, so the frame is not at the line start.
+        "Loading shards:  45%|####5     | 450/1000 [00:12<00:15,  3.21it/s]",
+        # An unstarted bar has no rate to report.
+        "  0%|          | 0/1000 [00:00<?, ?it/s]",
+        # tqdm without a known total renders no bar and no percentage.
+        "450it [00:12,  3.21it/s]",
+        # Below one iteration per second tqdm inverts the rate.
+        " 45%|####5     | 450/1000 [00:12<00:15,  1.20s/it]",
+        # A postfix trails the rate inside the brackets.
+        " 45%|####5     | 450/1000 [00:12<00:15,  3.21it/s, loss=1.23]",
+        # tqdm redraws with a bare carriage return, so one captured line can hold
+        # several frames.
+        "\r 10%|#         | 100/1000 [00:03<00:27,  3.21it/s]\r 20%|##        | 200/1000 [00:06<00:24,  3.21it/s]",
+        # An hour-long run's elapsed clock grows a third field.
+        " 45%|####5     | 450/1000 [1:00:12<1:13:20,  0.12it/s]",
+    ],
+)
+def test_progress_bar_on_stderr_is_informational(data):
+    assert classify_log_level("stderr", data) == logging_pb2.LOG_LEVEL_INFO
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        "450it [00:12,  3.21it/s]",
+        # A glog prefix reclassifies any other source, but not this one.
+        "I20260102 12:34:56 task exited with status 1",
+        "Task failed:\nI20260102 12:34:56 shutting down",
+    ],
+)
+def test_injected_failures_ignore_their_text(data):
+    # The "error" source is iris asserting the task failed; text never overrides it.
+    assert classify_log_level("error", data) == logging_pb2.LOG_LEVEL_ERROR
+
+
+@pytest.mark.parametrize(
+    "data",
+    [
+        "RuntimeError: shard missing",
+        "Traceback (most recent call last):",
+        # A percentage alone is not a progress bar.
+        "GPU utilization at 45% for the last 30s",
+        # Nor is a bracketed clock with no rate after it.
+        "worker heartbeat late [00:12]",
+        # A bracketed clock followed by prose, not a rate.
+        "checkpoint 2026-07-09 [12:34, restoring shards]",
+    ],
+)
+def test_real_stderr_lines_stay_errors(data):
+    assert classify_log_level("stderr", data) == logging_pb2.LOG_LEVEL_ERROR

--- a/lib/iris/tests/e2e/test_smoke.py
+++ b/lib/iris/tests/e2e/test_smoke.py
@@ -446,9 +446,30 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
         "Should have structural elements like a status card and resource info.",
     )
 
-    # "validation failed" only appears in ERROR lines. The text filter applies
-    # on Enter, not on every keystroke.
-    filter_input = "input[placeholder^='Filter text']"
+    # This job logs plenty of ERROR-level lines but never crashes. Exception
+    # navigation keys off tracebacks and fatal banners, not severity, so it must
+    # find nothing here.
+    assert_visible(smoke_page, "text=No exceptions")
+
+    # Search marks matching lines in place. "validation failed" only appears in
+    # ERROR lines, so the INFO lines around them must survive — that is the whole
+    # point of search being distinct from filter.
+    search_input = "input[placeholder^='Search loaded lines']"
+    smoke_page.fill(search_input, "validation failed")
+    smoke_page.wait_for_function(
+        "() => document.querySelectorAll('mark').length > 0 && "
+        "document.body.textContent.includes('processing data batch')",
+        timeout=5000,
+    )
+    smoke_screenshot(
+        "task-logs-searched",
+        "Task detail page with a log search box populated; matching text is highlighted in place "
+        "and non-matching log lines are still visible around the highlights.",
+    )
+
+    # The filter re-queries the server and drops non-matching lines entirely. It
+    # applies on Enter, not on every keystroke.
+    filter_input = "input[placeholder^='Filter:']"
     smoke_page.fill(filter_input, "validation failed")
     smoke_page.press(filter_input, "Enter")
     smoke_page.wait_for_function(
@@ -459,6 +480,33 @@ def test_dashboard_task_logs(smoke_cluster, verbose_job, smoke_page, smoke_scree
     smoke_screenshot(
         "task-logs-filtered",
         "Task detail page with log filter input populated and filtered log lines visible in the log viewer.",
+    )
+
+
+def test_dashboard_jump_to_exception(smoke_cluster, smoke_page, smoke_screenshot):
+    """A crashed task's log viewer finds and steps to the traceback."""
+    failed = smoke_cluster.submit(TestJobs.fail, "smoke-exception")
+    smoke_cluster.wait(failed, timeout=smoke_cluster.job_timeout)
+
+    task_status = smoke_cluster.task_status(failed)
+    _wait_for_task_log_marker(smoke_cluster, task_status.task_id, task_status.current_attempt_id, "Traceback")
+
+    dashboard_goto(
+        smoke_page,
+        f"{smoke_cluster.url}/job/{failed.job_id.to_wire()}/task/{task_status.task_id}",
+    )
+    wait_for_dashboard_ready(smoke_page)
+
+    # The control counts failures, not ERROR-level lines, and a whole traceback
+    # collapses to a single stop.
+    jump = smoke_page.locator("button", has_text="Jump to exception")
+    jump.wait_for(timeout=10000)
+    jump.click()
+    assert_visible(smoke_page, "text=/Exception 1 \\/ \\d+/")
+    smoke_screenshot(
+        "task-logs-exception",
+        "Task detail page for a failed task; the log viewer's exception control reads 'Exception 1 / N' "
+        "and a highlighted traceback line is visible in the log output.",
     )
 
 


### PR DESCRIPTION
The dashboard's log panel only offered a server-side substring filter, which hides exactly the lines you want when a hit is interesting. Search is now separate from filter: a search marks matches in the loaded lines and steps between them (`n` / `N`) while leaving their surrounding context on screen, and the filter still re-queries the server and drops non-matching lines. A search can be promoted to a filter in one click.

Jump-to-exception steps between failures rather than ERROR-level lines — every stderr line already classifies as ERROR, so severity is useless for this. It matches traceback headers and fatal banners, and collapses a whole traceback to one stop. Rows are zebra-striped and carry a severity border; timestamps are permalinks (`?logSeq=`); URLs, `gs://` paths, and worker/task ids inside a line become links.

To make "see the context around a filtered row" possible at all, finelog gained two additive fields: `LogEntry.seq`, the store's row id, and an exclusive `FetchLogsRequest.until_cursor`. Together with the existing `cursor` they bracket an open seq interval, so a reader can name a row and page in either direction around it. A `⋯` gutter button uses that to splice a row's *unfiltered* neighbourhood into the view. Neither field needs a version or pin bump: `lib/iris` already requires `marin-finelog-server >= 0.2.10` and the nightly wheel rebuilds on `lib/finelog/rust/**`. Against a server that predates them the viewer degrades cleanly — context expansion and permalinks are simply inert, and the e2e suite passes in that state today.

Two bugs fall out of the same area:

- `logLevelClass` compared a wire enum name (proto3 JSON sends `"LOG_LEVEL_ERROR"`, not `"ERROR"`) against bare severity names, so severity colouring silently never applied anywhere it was used, including `WorkerDetail.vue`.
- `classify_log_level` branded every tqdm redraw on stderr an ERROR, burying real failures under thousands of progress-bar frames. Progress bars on stderr are now INFO. It also let a glog level prefix downgrade a failure line iris injected itself, so an infrastructure error whose text happened to start with `I2026…` was filed as INFO and vanished from the error view.

I did not move the viewer into a finelog-served iframe. It depends on vue-router links into the task and worker pages, the attempt picker, the federated `cluster` filter, and the iris theme tokens; an iframe would lose in-app routing and duplicate the design system for no gain. The wire additions above are the part of the idea that pays off, and they live in finelog where they belong.
