### PR TITLE
[grug] Wire FP8 end-to-end into grug MoE: expert and dense GEMMs, wire collectives, config, and train step

### DIFF
--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -123,11 +123,17 @@ class GrugFp8Config:
     per-tensor scaling recipe ([haliax.quantization.Fp8DotGeneralOp][]). The
     router, attention gate, GatedNorm, embedding, and lm-head projections stay
     in full precision.
+
+    ``rev_dtype`` is the output-gradient FP8 dtype of the expert ragged GEMMs:
+    the default ``"e5m2"`` runs the numerically correct mixed ``e5m2 x e4m3``
+    backward and needs jax >= 0.11.0 (jax-ml/jax#38859); ``"e4m3"`` is the
+    uniform approximation that also lowers on jax 0.10.x.
     """
 
     wire: bool = True
     dense: bool = True
     amax_history_length: int = 1024
+    rev_dtype: Literal["e5m2", "e4m3"] = "e5m2"
 
 
 @dataclass(frozen=True)
@@ -699,9 +705,10 @@ class MoEMLP(eqx.Module):
 
         ragged_dot_ops = None
         if cfg.fp8 is not None:
+            rev_dtype = {"e5m2": jnp.float8_e5m2, "e4m3": jnp.float8_e4m3fn}[cfg.fp8.rev_dtype]
             ragged_dot_ops = MoeRaggedDotOps(
-                w13=Fp8RaggedDotOp.init(cfg.fp8.amax_history_length),
-                w2=Fp8RaggedDotOp.init(cfg.fp8.amax_history_length),
+                w13=Fp8RaggedDotOp.init(cfg.fp8.amax_history_length, rev_dtype=rev_dtype),
+                w2=Fp8RaggedDotOp.init(cfg.fp8.amax_history_length, rev_dtype=rev_dtype),
             )
 
         d, e = cfg.hidden_dim, cfg.num_experts

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -18,6 +18,7 @@ import jax.scipy as jsp
 from einops import rearrange
 from haliax import Axis
 from haliax.jax_utils import named_call
+from haliax.quantization import Fp8RaggedDotOp
 from jax import core, random
 from jax.sharding import NamedSharding, get_abstract_mesh, reshard
 from jax.sharding import PartitionSpec as P
@@ -41,6 +42,7 @@ from levanter.grug.grug_moe import (
     MoeActivation,
     MoEExpertMlp,
     MoeImplementation,
+    MoeRaggedDotOps,
     resolve_moe_implementation,
 )
 from levanter.grug.loss import fused_linear_softmax_cross_entropy_loss
@@ -105,6 +107,22 @@ def _hf_config_attr(config: HfConfig, names: tuple[str, ...], default: Any = Non
 
 
 @dataclass(frozen=True)
+class GrugFp8Config:
+    """FP8 for the routed expert path.
+
+    Enabling this runs both expert GEMMs as FP8 grouped matmuls with delayed
+    per-tensor scaling ([haliax.quantization.Fp8RaggedDotOp][], Hopper-only) and,
+    unless ``wire`` is disabled, carries the EP dispatch/combine collectives as
+    FP8 over the wire with per-token scaling. Requires expert parallelism
+    (expert axis size > 1) with the ring or ragged_all_to_all MoE backend; other
+    configurations raise on the first forward pass.
+    """
+
+    wire: bool = True
+    amax_history_length: int = 1024
+
+
+@dataclass(frozen=True)
 class GrugModelConfig:
     """Hyperparameters for the grug MoE transformer.
 
@@ -138,6 +156,8 @@ class GrugModelConfig:
     still apply half-RoPE. Set to False to keep RoPE on long layers."""
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
+    fp8: GrugFp8Config | None = None
+    """FP8 expert GEMMs + EP collectives (see [GrugFp8Config][]); None keeps bf16."""
     remat_mode: RematMode = "recompute_all"
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
     backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
@@ -553,6 +573,13 @@ class MoEMLP(eqx.Module):
         if cfg.num_experts % expert_axis_size != 0:
             raise ValueError(f"num_experts={cfg.num_experts} must be divisible by expert axis size={expert_axis_size}")
 
+        ragged_dot_ops = None
+        if cfg.fp8 is not None:
+            ragged_dot_ops = MoeRaggedDotOps(
+                w13=Fp8RaggedDotOp.init(cfg.fp8.amax_history_length),
+                w2=Fp8RaggedDotOp.init(cfg.fp8.amax_history_length),
+            )
+
         d, e = cfg.hidden_dim, cfg.num_experts
         return MoEMLP(
             router=reshard(_init_weight(k_router, (d, e), cfg.initializer_std), P(None, None)),
@@ -566,6 +593,8 @@ class MoEMLP(eqx.Module):
                 implementation=cfg.moe_implementation,
                 activation=ActivationFunctionEnum.silu,
                 capacity_factor=_DEFAULT_EP_CAPACITY_FACTOR,
+                ragged_dot_ops=ragged_dot_ops,
+                fp8_wire=cfg.fp8.wire if cfg.fp8 is not None else False,
             ),
             cfg=cfg,
         )
@@ -916,6 +945,7 @@ __all__ = [
     "CausalSelfAttention",
     "DenseMLP",
     "GatedNorm",
+    "GrugFp8Config",
     "GrugModelConfig",
     "GrugMoeHfConfig",
     "MoEMLP",

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -113,7 +113,8 @@ class GrugFp8Config:
     Enabling this runs both expert GEMMs as FP8 grouped matmuls with delayed
     per-tensor scaling ([haliax.quantization.Fp8RaggedDotOp][], Hopper-only) and,
     unless ``wire`` is disabled, carries the EP dispatch/combine collectives as
-    FP8 over the wire with per-token scaling. Requires expert parallelism
+    FP8 over the wire with per-token scaling. Requires 128-divisible hidden and
+    intermediate dims (checked at config time) and expert parallelism
     (expert axis size > 1) with the ring or ragged_all_to_all MoE backend; other
     configurations raise on the first forward pass.
     """
@@ -180,6 +181,12 @@ class GrugModelConfig:
             raise ValueError("num_experts_per_token must be <= num_experts")
         if self.shared_expert_intermediate_dim < 0:
             raise ValueError("shared_expert_intermediate_dim must be non-negative")
+        if self.fp8 is not None and (self.hidden_dim % 128 != 0 or self.intermediate_dim % 128 != 0):
+            raise ValueError(
+                "fp8 requires hidden_dim and intermediate_dim to be multiples of 128 (the FP8 ragged-dot "
+                f"kernel's GEMM alignment contract); got hidden_dim={self.hidden_dim}, "
+                f"intermediate_dim={self.intermediate_dim}"
+            )
         resolve_moe_implementation(self.moe_implementation)
 
     @property

--- a/experiments/grug/moe/model.py
+++ b/experiments/grug/moe/model.py
@@ -18,9 +18,9 @@ import jax.scipy as jsp
 from einops import rearrange
 from haliax import Axis
 from haliax.jax_utils import named_call
-from haliax.quantization import Fp8RaggedDotOp
+from haliax.quantization import Fp8DotGeneralOp, Fp8RaggedDotOp
 from jax import core, random
-from jax.sharding import NamedSharding, get_abstract_mesh, reshard
+from jax.sharding import NamedSharding, auto_axes, get_abstract_mesh, reshard
 from jax.sharding import PartitionSpec as P
 
 try:
@@ -108,7 +108,7 @@ def _hf_config_attr(config: HfConfig, names: tuple[str, ...], default: Any = Non
 
 @dataclass(frozen=True)
 class GrugFp8Config:
-    """FP8 for the routed expert path.
+    """FP8 for the quantizable GEMMs of the model.
 
     Enabling this runs both expert GEMMs as FP8 grouped matmuls with delayed
     per-tensor scaling ([haliax.quantization.Fp8RaggedDotOp][], Hopper-only) and,
@@ -117,9 +117,16 @@ class GrugFp8Config:
     intermediate dims (checked at config time) and expert parallelism
     (expert axis size > 1) with the ring or ragged_all_to_all MoE backend; other
     configurations raise on the first forward pass.
+
+    Unless ``dense`` is disabled, the dense GEMMs — attention q/k/v/o and the
+    shared-expert MLP — also run as FP8 cuBLASLt matmuls with the same delayed
+    per-tensor scaling recipe ([haliax.quantization.Fp8DotGeneralOp][]). The
+    router, attention gate, GatedNorm, embedding, and lm-head projections stay
+    in full precision.
     """
 
     wire: bool = True
+    dense: bool = True
     amax_history_length: int = 1024
 
 
@@ -158,7 +165,7 @@ class GrugModelConfig:
     attention_implementation: GrugAttentionImplementation | None = None
     moe_implementation: MoeImplementation | None = None
     fp8: GrugFp8Config | None = None
-    """FP8 expert GEMMs + EP collectives (see [GrugFp8Config][]); None keeps bf16."""
+    """FP8 expert GEMMs, EP collectives, and dense GEMMs (see [GrugFp8Config][]); None keeps bf16."""
     remat_mode: RematMode = "recompute_all"
     """Per-block gradient checkpointing. "recompute_all" reruns the whole block in
     backward (lowest memory); "save_moe" keeps the tagged MoE dispatch tensors so
@@ -187,6 +194,18 @@ class GrugModelConfig:
                 f"kernel's GEMM alignment contract); got hidden_dim={self.hidden_dim}, "
                 f"intermediate_dim={self.intermediate_dim}"
             )
+        if self.fp8 is not None and self.fp8.dense:
+            # cuBLASLt's FP8 GEMMs require 16-element-aligned contraction/output dims.
+            dense_dims = {
+                "num_heads * head_dim": self.num_heads * self.inferred_head_dim,
+                "num_kv_heads * head_dim": self.num_kv_heads * self.inferred_head_dim,
+                "shared_expert_intermediate_dim": self.shared_expert_intermediate_dim,
+            }
+            misaligned = {name: dim for name, dim in dense_dims.items() if dim % 16 != 0}
+            if misaligned:
+                raise ValueError(
+                    f"fp8.dense requires 16-aligned dense GEMM dims (cuBLASLt FP8 contract); got {misaligned}"
+                )
         resolve_moe_implementation(self.moe_implementation)
 
     @property
@@ -298,24 +317,91 @@ def rms_norm(x: jax.Array, eps: float = 1e-6) -> jax.Array:
     return (x * jax.lax.rsqrt(variance + eps)).astype(x.dtype)
 
 
+class AttnFp8Ops(eqx.Module):
+    """Stateful FP8 dot ops for the four attention projections.
+
+    Each projection gets its own op instance because delayed-scaling state
+    tracks per-tensor amax statistics, exactly as [MoeRaggedDotOps][] carries
+    one op per expert GEMM (q/k/v share an input but the kernel and output-grad
+    scales differ per projection; Flax's FP8 ``Linear`` makes the same call).
+    """
+
+    q: Fp8DotGeneralOp
+    k: Fp8DotGeneralOp
+    v: Fp8DotGeneralOp
+    o: Fp8DotGeneralOp
+
+    @staticmethod
+    def init(amax_history_length: int) -> "AttnFp8Ops":
+        return AttnFp8Ops(
+            q=Fp8DotGeneralOp.init(amax_history_length),
+            k=Fp8DotGeneralOp.init(amax_history_length),
+            v=Fp8DotGeneralOp.init(amax_history_length),
+            o=Fp8DotGeneralOp.init(amax_history_length),
+        )
+
+
+class SharedMlpFp8Ops(eqx.Module):
+    """Stateful FP8 dot ops for the shared-expert (dense) MLP GEMMs."""
+
+    gate: Fp8DotGeneralOp
+    up: Fp8DotGeneralOp
+    down: Fp8DotGeneralOp
+
+    @staticmethod
+    def init(amax_history_length: int) -> "SharedMlpFp8Ops":
+        return SharedMlpFp8Ops(
+            gate=Fp8DotGeneralOp.init(amax_history_length),
+            up=Fp8DotGeneralOp.init(amax_history_length),
+            down=Fp8DotGeneralOp.init(amax_history_length),
+        )
+
+
+def _fp8_dense_dot(op: Fp8DotGeneralOp, x: jax.Array, w: jax.Array, *, out_sharding: P) -> jax.Array:
+    """Contract ``x[..., K] @ w[K, N]`` through a stateful FP8 dot op.
+
+    Same contraction the ``jnp.einsum("...h,hd->...d")`` sites lower to; a 3D
+    lhs fires cuBLASLt FP8 GEMMs for all of fwd/dgrad/wgrad (verified on H100
+    at the production attention shapes), so no flatten to 2D is needed.
+
+    The op's internal (custom-VJP) dots take no ``out_sharding``, so under the
+    explicit-sharding mesh both the forward dot (o/down contract a
+    model-sharded dim) and the weight-grad dot (contracts the token-sharded
+    dim) would raise ``ShardingTypeError``. Run the whole op under
+    ``auto_axes`` — GSPMD infers the collectives for forward and backward, as
+    the einsum path's AD did — and pin the output to the spec the bf16 einsum
+    produced so downstream sharding is unchanged.
+    """
+
+    def dot(op: Fp8DotGeneralOp, x: jax.Array, w: jax.Array) -> jax.Array:
+        return op(x, w, (((x.ndim - 1,), (0,)), ((), ())))
+
+    return auto_axes(dot, out_sharding=out_sharding)(op, x, w)
+
+
 class CausalSelfAttention(eqx.Module):
     w_q: Float[Array, "D NH"]
     w_k: Float[Array, "D MH"]
     w_v: Float[Array, "D MH"]
     w_o: Float[Array, "NH D"]
     attn_gate: Float[Array, "D N"]
+    fp8_ops: AttnFp8Ops | None
     cfg: GrugModelConfig = eqx.field(static=True)
 
     @staticmethod
     def init(cfg: GrugModelConfig, *, key: PRNGKeyArray) -> "CausalSelfAttention":
         k_q, k_k, k_v, k_o = random.split(key, 4)
         d, n, m, h = cfg.hidden_dim, cfg.num_heads, cfg.num_kv_heads, cfg.inferred_head_dim
+        fp8_ops = None
+        if cfg.fp8 is not None and cfg.fp8.dense:
+            fp8_ops = AttnFp8Ops.init(cfg.fp8.amax_history_length)
         return CausalSelfAttention(
             w_q=reshard(_init_weight(k_q, (d, n * h), cfg.initializer_std), P("data", "model")),
             w_k=reshard(_init_weight(k_k, (d, m * h), cfg.initializer_std), P("data", "model")),
             w_v=reshard(_init_weight(k_v, (d, m * h), cfg.initializer_std), P("data", "model")),
             w_o=reshard(_init_weight(k_o, (n * h, d), cfg.initializer_std), P("model", "data")),
             attn_gate=reshard(jnp.zeros((d, n)), P(None, None)),
+            fp8_ops=fp8_ops,
             cfg=cfg,
         )
 
@@ -331,9 +417,18 @@ class CausalSelfAttention(eqx.Module):
         seq_len = x.shape[1]
         batch_spec = _batch_spec()
 
-        q = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_q), "... (n d) -> ... n d", d=head_dim)
-        k = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_k), "... (m d) -> ... m d", d=head_dim)
-        v = rearrange(jnp.einsum("bsh,hd->bsd", x, self.w_v), "... (m d) -> ... m d", d=head_dim)
+        if self.fp8_ops is None:
+            q_proj = jnp.einsum("bsh,hd->bsd", x, self.w_q)
+            k_proj = jnp.einsum("bsh,hd->bsd", x, self.w_k)
+            v_proj = jnp.einsum("bsh,hd->bsd", x, self.w_v)
+        else:
+            proj_spec = P(_BATCH_AXES, None, "model")
+            q_proj = _fp8_dense_dot(self.fp8_ops.q, x, self.w_q, out_sharding=proj_spec)
+            k_proj = _fp8_dense_dot(self.fp8_ops.k, x, self.w_k, out_sharding=proj_spec)
+            v_proj = _fp8_dense_dot(self.fp8_ops.v, x, self.w_v, out_sharding=proj_spec)
+        q = rearrange(q_proj, "... (n d) -> ... n d", d=head_dim)
+        k = rearrange(k_proj, "... (m d) -> ... m d", d=head_dim)
+        v = rearrange(v_proj, "... (m d) -> ... m d", d=head_dim)
 
         # Shift the second half of K's head_dim back by one position so the
         # query at position i sees K[i] on head_dim[:half] but K[i-1] on
@@ -395,7 +490,9 @@ class CausalSelfAttention(eqx.Module):
             (*attn_out.shape[:-2], attn_out.shape[-2] * attn_out.shape[-1]),
             out_sharding=P(_BATCH_AXES, None, "model"),
         )
-        return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=batch_spec)
+        if self.fp8_ops is None:
+            return jnp.einsum("bsh,hd->bsd", attn_out, self.w_o, out_sharding=batch_spec)
+        return _fp8_dense_dot(self.fp8_ops.o, attn_out, self.w_o, out_sharding=batch_spec)
 
 
 class RMSNorm(eqx.Module):
@@ -445,14 +542,26 @@ class DenseMLP(eqx.Module):
     w_gate: jax.Array
     w_up: jax.Array
     w_down: jax.Array
+    fp8_ops: SharedMlpFp8Ops | None
 
     @staticmethod
-    def init(hidden_dim: int, intermediate_dim: int, initializer_std: float, *, key: PRNGKeyArray) -> "DenseMLP":
+    def init(
+        hidden_dim: int,
+        intermediate_dim: int,
+        initializer_std: float,
+        *,
+        key: PRNGKeyArray,
+        fp8: GrugFp8Config | None = None,
+    ) -> "DenseMLP":
         k_gate, k_up, k_down = random.split(key, 3)
+        fp8_ops = None
+        if fp8 is not None and fp8.dense:
+            fp8_ops = SharedMlpFp8Ops.init(fp8.amax_history_length)
         return DenseMLP(
             w_gate=reshard(_init_weight(k_gate, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
             w_up=reshard(_init_weight(k_up, (hidden_dim, intermediate_dim), initializer_std), P("data", "model")),
             w_down=reshard(_init_weight(k_down, (intermediate_dim, hidden_dim), initializer_std), P("model", "data")),
+            fp8_ops=fp8_ops,
         )
 
     @named_call
@@ -469,9 +578,17 @@ class DenseMLP(eqx.Module):
 
         b, s, _ = x.shape
         x_flat = rearrange(x, "b s d -> (b s) d")
-        gate = jnp.einsum("td,dm->tm", x_flat, self.w_gate)
-        up = jnp.einsum("td,dm->tm", x_flat, self.w_up)
-        out_flat = jnp.einsum("tm,md->td", activation_fn(gate) * up, self.w_down, out_sharding=_batch_spec())
+        if self.fp8_ops is None:
+            gate = jnp.einsum("td,dm->tm", x_flat, self.w_gate)
+            up = jnp.einsum("td,dm->tm", x_flat, self.w_up)
+            out_flat = jnp.einsum("tm,md->td", activation_fn(gate) * up, self.w_down, out_sharding=_batch_spec())
+        else:
+            hidden_spec = P(_BATCH_AXES, "model")
+            gate = _fp8_dense_dot(self.fp8_ops.gate, x_flat, self.w_gate, out_sharding=hidden_spec)
+            up = _fp8_dense_dot(self.fp8_ops.up, x_flat, self.w_up, out_sharding=hidden_spec)
+            out_flat = _fp8_dense_dot(
+                self.fp8_ops.down, activation_fn(gate) * up, self.w_down, out_sharding=_batch_spec()
+            )
         # Reshard after the reshape so the shared-expert output carries the same
         # canonical batch sharding as the routed MoE output (MoEMLP reshards its
         # routed result identically). Splitting the fused
@@ -685,7 +802,7 @@ class Block(eqx.Module):
         shared = None
         if cfg.shared_expert_intermediate_dim > 0:
             shared = DenseMLP.init(
-                cfg.hidden_dim, cfg.shared_expert_intermediate_dim, cfg.initializer_std, key=shared_key
+                cfg.hidden_dim, cfg.shared_expert_intermediate_dim, cfg.initializer_std, key=shared_key, fp8=cfg.fp8
             )
         return Block(
             rms_attn=RMSNorm.init(cfg.hidden_dim, cfg.layer_norm_eps),

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -17,6 +17,7 @@ import optax
 from fray.cluster import ResourceConfig
 from haliax import Axis
 from haliax.partitioning import set_mesh
+from haliax.quantization import OverwriteWithGradient, apply_updates, partition_for_grad_overwrite
 from jax.sharding import Mesh, NamedSharding
 from jax.sharding import PartitionSpec as P
 from jax.tree_util import register_dataclass
@@ -269,6 +270,18 @@ def _apply_qb_betas(model: Transformer, qb_betas: jax.Array) -> Transformer:
     return eqx.tree_at(lambda t: t.blocks, model, tuple(new_blocks))
 
 
+def _ema_update(old: Transformer, new: Transformer, beta: float) -> Transformer:
+    """EMA of trainable weights; FP8 op state carries the current step's values.
+
+    Quantization statistics (amax histories, scales) are step-local state, not
+    parameters, so averaging them across steps is not meaningful.
+    """
+    new_overwrites, new_plain = partition_for_grad_overwrite(new)
+    _, old_plain = partition_for_grad_overwrite(old)
+    ema_plain = jax.tree_util.tree_map(lambda o, n: beta * o + (1.0 - beta) * n, old_plain, new_plain)
+    return eqx.combine(new_overwrites, ema_plain, is_leaf=lambda x: isinstance(x, OverwriteWithGradient))
+
+
 def initial_state(
     model_config: GrugModelConfig,
     *,
@@ -279,10 +292,13 @@ def initial_state(
 ) -> GrugTrainState:
     params = mp.cast_to_param(Transformer.init(model_config, key=key))
     num_moe_layers = sum(1 for b in params.blocks if b.mlp is not None)
+    # FP8 quantization state (OverwriteWithGradient) is overwritten each step,
+    # not optimized, so it gets no optimizer moments.
+    _, plain_params = partition_for_grad_overwrite(params)
     return GrugTrainState(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
-        opt_state=optimizer.init(params),
+        opt_state=optimizer.init(plain_params),
         ema_params=params if ema_beta is not None else None,
         pending_qb_betas=jnp.zeros((num_moe_layers, model_config.num_experts)),
     )
@@ -329,19 +345,19 @@ def _make_train_step(
 
         (loss, summarized_metrics), grads = jax.value_and_grad(loss_fn, has_aux=True)(qb_params)
         metrics = {"train/loss": loss, **summarized_metrics}
-        updates, opt_state = optimizer.update(grads, state.opt_state, qb_params)
-        params = optax.apply_updates(qb_params, updates)
+        # FP8 op state arrives as fake gradients: overwrite it in the params
+        # instead of feeding it to the optimizer.
+        overwrites, grads = partition_for_grad_overwrite(grads)
+        _, plain_params = partition_for_grad_overwrite(qb_params)
+        updates, opt_state = optimizer.update(grads, state.opt_state, plain_params)
+        params = apply_updates(qb_params, updates, overwrites)
 
         if ema_beta is None:
             ema_params = None
         else:
             if qb_ema_params is None:
                 raise ValueError("ema_params must be initialized when ema_beta is set.")
-            ema_params = jax.tree_util.tree_map(
-                lambda old, new: ema_beta * old + (1.0 - ema_beta) * new,
-                qb_ema_params,
-                params,
-            )
+            ema_params = _ema_update(qb_ema_params, params, ema_beta)
 
         watch_stats = None
         if watch_config is not None and compute_watch:

--- a/experiments/grug/moe/train.py
+++ b/experiments/grug/moe/train.py
@@ -35,6 +35,7 @@ from levanter.models.lm_model import LmExample
 from levanter.optim.config import AdamConfig, OptimizerConfig
 from levanter.schedule import BatchSchedule
 from levanter.trainer import TrainerConfig
+from levanter.trainer_state import init_optimizer_for_trainables
 from levanter.utils.flop_utils import lm_flops_per_token
 from levanter.utils.jax_utils import parameter_count
 from levanter.utils.logging import LoadingTimeTrackerIterator
@@ -270,16 +271,23 @@ def _apply_qb_betas(model: Transformer, qb_betas: jax.Array) -> Transformer:
     return eqx.tree_at(lambda t: t.blocks, model, tuple(new_blocks))
 
 
+def _is_overwrite(x) -> bool:
+    return isinstance(x, OverwriteWithGradient)
+
+
 def _ema_update(old: Transformer, new: Transformer, beta: float) -> Transformer:
     """EMA of trainable weights; FP8 op state carries the current step's values.
 
     Quantization statistics (amax histories, scales) are step-local state, not
-    parameters, so averaging them across steps is not meaningful.
+    parameters, so averaging them across steps is not meaningful. The carried
+    scales are calibrated on the raw training weights; EMA weights are assumed
+    close enough in magnitude that re-deriving scales from them is not worth
+    the machinery.
     """
     new_overwrites, new_plain = partition_for_grad_overwrite(new)
     _, old_plain = partition_for_grad_overwrite(old)
     ema_plain = jax.tree_util.tree_map(lambda o, n: beta * o + (1.0 - beta) * n, old_plain, new_plain)
-    return eqx.combine(new_overwrites, ema_plain, is_leaf=lambda x: isinstance(x, OverwriteWithGradient))
+    return eqx.combine(new_overwrites, ema_plain, is_leaf=_is_overwrite)
 
 
 def initial_state(
@@ -292,13 +300,11 @@ def initial_state(
 ) -> GrugTrainState:
     params = mp.cast_to_param(Transformer.init(model_config, key=key))
     num_moe_layers = sum(1 for b in params.blocks if b.mlp is not None)
-    # FP8 quantization state (OverwriteWithGradient) is overwritten each step,
-    # not optimized, so it gets no optimizer moments.
-    _, plain_params = partition_for_grad_overwrite(params)
     return GrugTrainState(
         step=jnp.array(0, dtype=jnp.int32),
         params=params,
-        opt_state=optimizer.init(plain_params),
+        # Excludes OverwriteWithGradient (FP8 op state) from optimizer moments.
+        opt_state=init_optimizer_for_trainables(optimizer, params),
         ema_params=params if ema_beta is not None else None,
         pending_qb_betas=jnp.zeros((num_moe_layers, model_config.num_experts)),
     )
@@ -333,7 +339,11 @@ def _make_train_step(
             qb_ema_params = None
 
         def loss_fn(params):
-            compute_params = mp.cast_to_compute(params)
+            # Cast only ordinary params to compute dtype: the FP8 ops' scales
+            # and amax histories must stay f32, or every step's state update
+            # rounds through bf16.
+            op_state, plain = partition_for_grad_overwrite(params)
+            compute_params = eqx.combine(op_state, mp.cast_to_compute(plain), is_leaf=_is_overwrite)
             return compute_params.next_token_loss(
                 batch.tokens,
                 batch.loss_weight,
@@ -350,6 +360,9 @@ def _make_train_step(
         overwrites, grads = partition_for_grad_overwrite(grads)
         _, plain_params = partition_for_grad_overwrite(qb_params)
         updates, opt_state = optimizer.update(grads, state.opt_state, plain_params)
+        # optax.apply_updates casts p + u back to the param dtype; haliax's
+        # overwrite-aware apply_updates does not, so keep that cast here.
+        updates = jax.tree_util.tree_map(lambda u, p: u.astype(p.dtype), updates, plain_params)
         params = apply_updates(qb_params, updates, overwrites)
 
         if ema_beta is None:
@@ -367,7 +380,7 @@ def _make_train_step(
                 include_per_parameter_norms=watch_config.include_per_parameter_norms,
                 include_histogram=watch_config.include_histograms,
                 split_scan_layers=watch_config.split_scan_layers,
-                params=qb_params,
+                params=plain_params,
                 grads=grads,
                 updates=updates,
                 opt_state=state.opt_state,
@@ -462,7 +475,8 @@ def _run_grug_local(config: GrugRunConfig) -> None:
             path_override=config.trainer.sharding_dump_path,
         )
 
-        levanter.tracker.log_summary({"parameter_count": parameter_count(state.params)})
+        _, plain_params = partition_for_grad_overwrite(state.params)
+        levanter.tracker.log_summary({"parameter_count": parameter_count(plain_params)})
 
         flops_per_example, flops_summary = _compute_flops(model_config=config.model)
         levanter.tracker.log_summary(flops_summary)

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -31,7 +31,8 @@ MoeImplementation: TypeAlias = Literal[
 ]
 _VALID_MOE_IMPLEMENTATIONS = get_args(MoeImplementation)
 _EP_MOE_IMPLEMENTATIONS = ("ring", "ragged_all_to_all", "deepep")
-# EP backends wired for injected ragged-dot ops (deepep resolves its own GEMMs).
+# EP backends wired for injected ragged-dot ops and FP8 wire collectives
+# (deepep resolves its own GEMMs and collectives).
 _QUANTIZED_EP_MOE_IMPLEMENTATIONS = ("ring", "ragged_all_to_all")
 # Local means no collectives over an expert axis. These backends can still run
 # under ordinary data/model sharding through the no-EP shard_map path.

--- a/lib/levanter/src/levanter/grug/_moe/common.py
+++ b/lib/levanter/src/levanter/grug/_moe/common.py
@@ -7,9 +7,11 @@ from collections.abc import Callable
 from dataclasses import dataclass
 from typing import Literal, TypeAlias, cast, get_args
 
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 from haliax.jax_utils import named_call
+from haliax.quantization import RaggedDotOp
 from jax.sharding import PartitionSpec as P
 from jaxtyping import Array, Float, Int, Key
 
@@ -29,6 +31,8 @@ MoeImplementation: TypeAlias = Literal[
 ]
 _VALID_MOE_IMPLEMENTATIONS = get_args(MoeImplementation)
 _EP_MOE_IMPLEMENTATIONS = ("ring", "ragged_all_to_all", "deepep")
+# EP backends wired for injected ragged-dot ops (deepep resolves its own GEMMs).
+_QUANTIZED_EP_MOE_IMPLEMENTATIONS = ("ring", "ragged_all_to_all")
 # Local means no collectives over an expert axis. These backends can still run
 # under ordinary data/model sharding through the no-EP shard_map path.
 _LOCAL_MOE_IMPLEMENTATIONS = (
@@ -51,6 +55,19 @@ MOE_REMAT_SAVE_NAMES = (
     _CHECKPOINT_DISPATCH_OUTPUT,
     _CHECKPOINT_MOE_OUTPUT,
 )
+
+
+class MoeRaggedDotOps(eqx.Module):
+    """Stateful grouped-matmul ops for the two expert GEMMs.
+
+    Each GEMM gets its own op instance (e.g. [haliax.quantization.Fp8RaggedDotOp][])
+    because delayed-scaling state tracks per-tensor amax statistics: the w13 input
+    (hidden states) and the w2 input (SwiGLU activations) have different
+    distributions, exactly as two `Linear` layers carry separate `Fp8DotGeneralOp`s.
+    """
+
+    w13: RaggedDotOp
+    w2: RaggedDotOp
 
 
 @dataclass(frozen=True)

--- a/lib/levanter/src/levanter/grug/_moe/ep_common.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_common.py
@@ -3,9 +3,16 @@
 
 """Shared expert-parallel routing helpers for Grug MoE."""
 
+from collections.abc import Callable
+from functools import partial
+
+import equinox as eqx
 import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Bool, Float, Int
+
+from haliax.nn.ragged_dot import ragged_dot
+from haliax.quantization import OverwriteWithGradient, partition_for_grad_overwrite
 
 
 def _sort_activations(inputs: Float[Array, "N *tail"], sort_indices: Int[Array, "N"]) -> Float[Array, "N *tail"]:
@@ -35,6 +42,53 @@ def _sort_activations_custom_bwd(
 
 
 _sort_activations_custom.defvjp(_sort_activations_custom_fwd, _sort_activations_custom_bwd)
+
+
+def _pmax_replicated_cotangent(tree):
+    """Identity on ``tree`` that makes ``OverwriteWithGradient`` cotangents combine as a max.
+
+    A replicated (``P()``) shard_map input gets its cotangent ``psum``-ed across
+    the mesh by the shard_map transpose. That is correct for ordinary trainable
+    parameters (the total gradient is the sum of per-shard partials), so those
+    leaves pass through untouched. Delayed-scaling quantization state (amax
+    histories / scales, carried as ``OverwriteWithGradient`` cotangents) must
+    instead combine as the *maximum* over shards — the global amax. Each such
+    leaf contributes ``pmax(ct)/mesh_size`` so the outer psum reconstructs
+    exactly ``pmax(ct)``.
+    """
+    mesh = jax.sharding.get_abstract_mesh()
+    axes = tuple(mesh.axis_names)
+    mesh_size = 1
+    for axis in axes:
+        mesh_size *= int(mesh.shape[axis])
+
+    @jax.custom_vjp
+    def _ident(t):
+        return t
+
+    def _fwd(t):
+        return t, None
+
+    def _bwd(_, ct):
+        overwrite, rest = partition_for_grad_overwrite(ct)
+        overwrite = jax.tree.map(lambda c: jax.lax.pmax(c, axes) / mesh_size, overwrite)
+        combined = eqx.combine(overwrite, rest, is_leaf=lambda x: isinstance(x, OverwriteWithGradient))
+        return (combined,)
+
+    _ident.defvjp(_fwd, _bwd)
+    return _ident(tree)
+
+
+def _resolve_ragged_dot_fns(ops) -> tuple[Callable, Callable]:
+    """Return the (w13, w2) grouped-matmul callables for an EP backend.
+
+    With ``ops`` set, each GEMM binds its stateful op and the op state's
+    shard_map cotangent combine is fixed up by ``_pmax_replicated_cotangent``.
+    """
+    if ops is None:
+        return ragged_dot, ragged_dot
+    ops = _pmax_replicated_cotangent(ops)
+    return partial(ragged_dot, op=ops.w13), partial(ragged_dot, op=ops.w2)
 
 
 def _prefix_cap_counts(counts: Int[Array, "E"], *, capacity: int) -> Int[Array, "E"]:

--- a/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_deepep.py
@@ -19,6 +19,7 @@ from levanter.grug._moe.common import (
     _CHECKPOINT_DISPATCH_INPUT,
     _CHECKPOINT_DISPATCH_OUTPUT,
     _CHECKPOINT_EXPERT_HIDDEN,
+    MoeRaggedDotOps,
     split_moe_w13_output,
 )
 from levanter.kernels.deepep import deepep_combine_intranode, deepep_dispatch_intranode, deepep_get_dispatch_layout
@@ -103,6 +104,7 @@ def _moe_mlp_ep_deepep_local(
     combine_weights_local: Float[Array, "Tlocal K"],
     moe_w13_local: Float[Array, "Elocal H I2"],
     moe_w2_local: Float[Array, "Elocal I H"],
+    ops: MoeRaggedDotOps | None = None,
     *,
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
@@ -110,6 +112,8 @@ def _moe_mlp_ep_deepep_local(
 ) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
     """DeepEP dispatch/combine path for an intranode expert mesh."""
     del capacity_factor
+    if ops is not None:
+        raise NotImplementedError("ragged-dot ops are not wired into the DeepEP backend")
     local_experts = moe_w13_local.shape[0]
     if num_experts % local_experts != 0:
         raise ValueError(

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -10,7 +10,7 @@ import jax
 import jax.numpy as jnp
 from jaxtyping import Array, Float, Int
 
-from haliax.nn.ragged_dot import ragged_dot
+from levanter.grug._moe.common import MoeRaggedDotOps
 from levanter.grug._moe.ep_common import (
     _clip_receiver_group_sizes,
     _compact_by_keep_mask,
@@ -18,6 +18,7 @@ from levanter.grug._moe.ep_common import (
     _expert_prefix_keep_mask,
     _local_permute_from_counts,
     _permute_by_global_expert,
+    _resolve_ragged_dot_fns,
     _shard_a2a_params,
     _sort_activations,
     _unpermute_from_global_expert,
@@ -31,6 +32,7 @@ def _moe_mlp_ep_ragged_a2a_local(
     combine_weights_local: Float[Array, "Tlocal K"],
     moe_w13_local: Float[Array, "Elocal H I2"],
     moe_w2_local: Float[Array, "Elocal I H"],
+    ops: MoeRaggedDotOps | None = None,
     *,
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
@@ -90,11 +92,13 @@ def _moe_mlp_ep_ragged_a2a_local(
             shard_index=shard_id,
         )
 
+    rd_w13, rd_w2 = _resolve_ragged_dot_fns(ops)
+
     with jax.named_scope("moe_up_down"):
-        w13_out = ragged_dot(x_dispatch, moe_w13_local, local_group_sizes)
+        w13_out = rd_w13(x_dispatch, moe_w13_local, local_group_sizes)
         moe_dim = moe_w2_local.shape[1]
         gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
-        out_dispatch = ragged_dot(activation_fn(gate) * up, moe_w2_local, local_group_sizes)
+        out_dispatch = rd_w2(activation_fn(gate) * up, moe_w2_local, local_group_sizes)
 
     with jax.named_scope("combine"):
         local_output = _sort_activations(out_dispatch, jnp.argsort(local_sorted_indices))

--- a/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ragged_all_to_all.py
@@ -11,6 +11,7 @@ import jax.numpy as jnp
 from jaxtyping import Array, Float, Int
 
 from levanter.grug._moe.common import MoeRaggedDotOps
+from levanter.grug._moe.fp8_wire import fp8_ragged_a2a
 from levanter.grug._moe.ep_common import (
     _clip_receiver_group_sizes,
     _compact_by_keep_mask,
@@ -37,6 +38,7 @@ def _moe_mlp_ep_ragged_a2a_local(
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
     capacity_factor: float,
+    fp8_wire: bool = False,
 ) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
     local_experts = moe_w13_local.shape[0]
     if num_experts % local_experts != 0:
@@ -74,17 +76,20 @@ def _moe_mlp_ep_ragged_a2a_local(
         sorted_x = _compact_by_keep_mask(sorted_x, keep_mask)
 
         all_shard_counts = jnp.sum(clipped_group_sizes.reshape(ep_size, ep_size, local_experts), axis=2)
-        input_offsets, send_sizes, output_offsets, recv_sizes = _shard_a2a_params(all_shard_counts, shard_id)
-        dispatch_out_shape = jnp.zeros((recv_capacity, x_local.shape[1]), dtype=x_local.dtype)
-        x_dispatched = jax.lax.ragged_all_to_all(
-            sorted_x,
-            dispatch_out_shape,
-            input_offsets,
-            send_sizes,
-            output_offsets,
-            recv_sizes,
-            axis_name="expert",
-        )
+        if fp8_wire:
+            x_dispatched = fp8_ragged_a2a(sorted_x, all_shard_counts, shard_id, recv_capacity, "expert")
+        else:
+            input_offsets, send_sizes, output_offsets, recv_sizes = _shard_a2a_params(all_shard_counts, shard_id)
+            dispatch_out_shape = jnp.zeros((recv_capacity, x_local.shape[1]), dtype=x_local.dtype)
+            x_dispatched = jax.lax.ragged_all_to_all(
+                sorted_x,
+                dispatch_out_shape,
+                input_offsets,
+                send_sizes,
+                output_offsets,
+                recv_sizes,
+                axis_name="expert",
+            )
         x_dispatch, local_sorted_indices, local_group_sizes = _local_permute_from_counts(
             x_dispatched,
             clipped_group_sizes,
@@ -102,19 +107,22 @@ def _moe_mlp_ep_ragged_a2a_local(
 
     with jax.named_scope("combine"):
         local_output = _sort_activations(out_dispatch, jnp.argsort(local_sorted_indices))
-        return_out_shape = jnp.zeros((assignments_per_shard, x_local.shape[1]), dtype=local_output.dtype)
-        return_input_offsets, return_send_sizes, return_output_offsets, return_recv_sizes = _shard_a2a_params(
-            all_shard_counts.T, shard_id
-        )
-        returned = jax.lax.ragged_all_to_all(
-            local_output,
-            return_out_shape,
-            return_input_offsets,
-            return_send_sizes,
-            return_output_offsets,
-            return_recv_sizes,
-            axis_name="expert",
-        )
+        if fp8_wire:
+            returned = fp8_ragged_a2a(local_output, all_shard_counts.T, shard_id, assignments_per_shard, "expert")
+        else:
+            return_out_shape = jnp.zeros((assignments_per_shard, x_local.shape[1]), dtype=local_output.dtype)
+            return_input_offsets, return_send_sizes, return_output_offsets, return_recv_sizes = _shard_a2a_params(
+                all_shard_counts.T, shard_id
+            )
+            returned = jax.lax.ragged_all_to_all(
+                local_output,
+                return_out_shape,
+                return_input_offsets,
+                return_send_sizes,
+                return_output_offsets,
+                return_recv_sizes,
+                axis_name="expert",
+            )
         returned = _expand_from_keep_mask(returned, keep_mask)
         out_local = _unpermute_from_global_expert(
             returned,

--- a/lib/levanter/src/levanter/grug/_moe/ep_ring.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ring.py
@@ -11,13 +11,13 @@ import jax.numpy as jnp
 from haliax.jax_utils import tree_checkpoint_name
 from jaxtyping import Array, Float, Int
 
-from haliax.nn.ragged_dot import ragged_dot
 from levanter.grug._moe.common import (
     _CHECKPOINT_DISPATCH_INPUT,
     _CHECKPOINT_DISPATCH_OUTPUT,
     _CHECKPOINT_EXPERT_HIDDEN,
+    MoeRaggedDotOps,
 )
-from levanter.grug._moe.ep_common import _prefix_cap_counts
+from levanter.grug._moe.ep_common import _prefix_cap_counts, _resolve_ragged_dot_fns
 from levanter.grug.sharding import _batch_axes
 
 
@@ -27,6 +27,7 @@ def _moe_mlp_ep_ring_local(
     combine_weights_local: Float[Array, "Tlocal K"],
     moe_w13_local: Float[Array, "Elocal H I2"],
     moe_w2_local: Float[Array, "Elocal I H"],
+    ops: MoeRaggedDotOps | None = None,
     *,
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
@@ -98,12 +99,14 @@ def _moe_mlp_ep_ring_local(
     # boundaries aligned by attributing padding to the final expert segment.
     group_sizes = group_sizes.at[-1].add(local_capacity - jnp.sum(group_sizes, dtype=jnp.int32))
 
+    rd_w13, rd_w2 = _resolve_ragged_dot_fns(ops)
+
     with jax.named_scope("moe_up_down"):
-        w13_out = tree_checkpoint_name(ragged_dot(x_dispatch, moe_w13_local, group_sizes), _CHECKPOINT_EXPERT_HIDDEN)
+        w13_out = tree_checkpoint_name(rd_w13(x_dispatch, moe_w13_local, group_sizes), _CHECKPOINT_EXPERT_HIDDEN)
         moe_dim = moe_w2_local.shape[1]
         gate, up = jnp.split(w13_out, [moe_dim], axis=-1)
         out_dispatch = tree_checkpoint_name(
-            ragged_dot(activation_fn(gate) * up, moe_w2_local, group_sizes),
+            rd_w2(activation_fn(gate) * up, moe_w2_local, group_sizes),
             _CHECKPOINT_DISPATCH_OUTPUT,
         )
 

--- a/lib/levanter/src/levanter/grug/_moe/ep_ring.py
+++ b/lib/levanter/src/levanter/grug/_moe/ep_ring.py
@@ -18,6 +18,7 @@ from levanter.grug._moe.common import (
     MoeRaggedDotOps,
 )
 from levanter.grug._moe.ep_common import _prefix_cap_counts, _resolve_ragged_dot_fns
+from levanter.grug._moe.fp8_wire import fp8_all_gather, fp8_psum_scatter
 from levanter.grug.sharding import _batch_axes
 
 
@@ -32,12 +33,16 @@ def _moe_mlp_ep_ring_local(
     activation_fn: Callable[[jax.Array], jax.Array],
     num_experts: int,
     capacity_factor: float,
+    fp8_wire: bool = False,
 ) -> tuple[Float[Array, "Tlocal H"], Int[Array, ""]]:
     """Ring-style EP routed path: all-gather dispatch + psum-scatter collect."""
     # #2710 ring EP strategy: gather tokens and their selected-expert routing
     # assignments across expert shards, then psum-scatter back to local tokens.
     with jax.named_scope("gather"):
-        x_global = jax.lax.all_gather(x_local, "expert", tiled=True)
+        if fp8_wire:
+            x_global = fp8_all_gather(x_local, "expert")
+        else:
+            x_global = jax.lax.all_gather(x_local, "expert", tiled=True)
         selected_experts_global = jax.lax.all_gather(selected_experts_local, "expert", tiled=True)
         combine_weights_global = jax.lax.all_gather(combine_weights_local, "expert", tiled=True)
 
@@ -114,6 +119,9 @@ def _moe_mlp_ep_ring_local(
         out_global = jnp.zeros_like(x_global).at[token_local].add(out_dispatch * weight_dispatch[:, None], mode="drop")
         # #2710 ring EP strategy: collect only this shard's token slice after
         # reducing contributions from experts across the EP mesh.
-        out_local = jax.lax.psum_scatter(out_global, "expert", scatter_dimension=0, tiled=True)
+        if fp8_wire:
+            out_local = fp8_psum_scatter(out_global, "expert")
+        else:
+            out_local = jax.lax.psum_scatter(out_global, "expert", scatter_dimension=0, tiled=True)
         dropped_total = jax.lax.psum(dropped_local, _batch_axes(jax.sharding.get_abstract_mesh()))
     return out_local, dropped_total

--- a/lib/levanter/src/levanter/grug/_moe/fp8_wire.py
+++ b/lib/levanter/src/levanter/grug/_moe/fp8_wire.py
@@ -1,0 +1,168 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""FP8 over-the-wire collectives for expert-parallel MoE dispatch/combine.
+
+Forward activations cross the wire as E4M3 and backward gradients as E5M2,
+with *current per-token* scaling: each row is quantized with its own
+amax-derived scale, and the scales travel alongside the payload. A shared
+per-tensor scale would couple a token's dequantized values to the content of
+other tokens in the buffer — including later sequence positions — so scales
+never span tokens.
+
+Only *permutation* legs carry FP8. Reduction legs (the ring backend's
+``psum_scatter`` combine and its transpose) stay native bf16: NCCL's
+hierarchical reduce-scatter performs the node-local reduction before
+crossing the inter-node fabric, and measured end-to-end that beats any
+byte-halved decomposition into all_to_all + local sum (which must ship
+every unreduced contribution across the wire).
+
+Payloads cross the collectives bitcast to uint8 — permutation collectives
+move bytes, and this keeps the wire format independent of backend FP8 dtype
+support.
+"""
+
+from functools import partial
+
+import jax
+import jax.numpy as jnp
+import numpy as np
+
+from levanter.grug._moe.ep_common import _shard_a2a_params
+
+_FP8_MAX = {
+    jnp.float8_e4m3fn: 448.0,
+    jnp.float8_e5m2: 57344.0,
+}
+_WIRE_EPS = 1e-12
+
+
+def _quantize(x, fp8_dtype):
+    """Quantize each row (token) with its own current scale; returns (q, scales[T])."""
+    xf = x.astype(jnp.float32)
+    amax = jnp.max(jnp.abs(xf), axis=tuple(range(1, xf.ndim)))
+    scale = jnp.maximum(amax, _WIRE_EPS) / _FP8_MAX[jnp.dtype(fp8_dtype).type]
+    expand = (slice(None),) + (None,) * (xf.ndim - 1)
+    q = (xf / scale[expand]).astype(fp8_dtype)
+    return q, scale
+
+
+def _as_wire(q):
+    return jax.lax.bitcast_convert_type(q, jnp.uint8)
+
+
+def _from_wire(bits, fp8_dtype):
+    return jax.lax.bitcast_convert_type(bits, fp8_dtype)
+
+
+def _fp8_all_gather_impl(x, axis_name, fp8_dtype, out_dtype):
+    """all_gather in FP8; returns the tiled bf16 gather [S*T, ...]."""
+    q, scale = _quantize(x, fp8_dtype)
+    bits = jax.lax.all_gather(_as_wire(q), axis_name)  # [S, T, ...]
+    scales = jax.lax.all_gather(scale, axis_name)  # [S, T]
+    qg = _from_wire(bits, fp8_dtype).astype(jnp.float32)
+    expand = (slice(None), slice(None)) + (None,) * (qg.ndim - 2)
+    out = (qg * scales[expand]).astype(out_dtype)
+    return out.reshape((-1,) + out.shape[2:])
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(1,))
+def fp8_all_gather(x, axis_name):
+    """Tiled ``all_gather`` carrying E4M3 over the wire.
+
+    Forward matches ``jax.lax.all_gather(x, axis_name, tiled=True)`` up to
+    per-token E4M3 quantization of the payload. The backward is the exact native transpose —
+    a bf16 ``psum_scatter`` (straight-through gradient across the QDQ) — so
+    the reduction keeps NCCL's hierarchical algorithm and full precision.
+    """
+    return _fp8_all_gather_impl(x, axis_name, jnp.float8_e4m3fn, x.dtype)
+
+
+def _fp8_all_gather_fwd(x, axis_name):
+    return fp8_all_gather(x, axis_name), None
+
+
+def _fp8_all_gather_bwd(axis_name, _res, ct):
+    return (jax.lax.psum_scatter(ct, axis_name, scatter_dimension=0, tiled=True),)
+
+
+fp8_all_gather.defvjp(_fp8_all_gather_fwd, _fp8_all_gather_bwd)
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(1,))
+def fp8_psum_scatter(y, axis_name):
+    """Tiled ``psum_scatter`` whose *backward* carries E5M2 over the wire.
+
+    The forward reduction stays a native bf16 ``psum_scatter`` (hierarchical,
+    full-precision accumulation); the backward — an all_gather of the output
+    gradient, a pure permutation — crosses as E5M2.
+    """
+    return jax.lax.psum_scatter(y, axis_name, scatter_dimension=0, tiled=True)
+
+
+def _fp8_psum_scatter_fwd(y, axis_name):
+    return fp8_psum_scatter(y, axis_name), None
+
+
+def _fp8_psum_scatter_bwd(axis_name, _res, ct):
+    return (_fp8_all_gather_impl(ct, axis_name, jnp.float8_e5m2, ct.dtype),)
+
+
+fp8_psum_scatter.defvjp(_fp8_psum_scatter_fwd, _fp8_psum_scatter_bwd)
+
+
+def _fp8_ragged_a2a_impl(x, shard_counts, shard_id, out_rows, axis_name, fp8_dtype):
+    input_offsets, send_sizes, output_offsets, recv_sizes = _shard_a2a_params(shard_counts, shard_id)
+    q, scale = _quantize(x, fp8_dtype)
+    out_buf = jnp.zeros((out_rows,) + x.shape[1:], dtype=jnp.uint8)
+    bits = jax.lax.ragged_all_to_all(
+        _as_wire(q),
+        out_buf,
+        input_offsets,
+        send_sizes,
+        output_offsets,
+        recv_sizes,
+        axis_name=axis_name,
+    )
+    # Per-token scales ride a second (tiny: 4 bytes/row) ragged_all_to_all with
+    # the same layout, so each received row dequantizes with its own scale.
+    scale_buf = jnp.zeros((out_rows, 1), dtype=jnp.float32)
+    scales = jax.lax.ragged_all_to_all(
+        scale[:, None],
+        scale_buf,
+        input_offsets,
+        send_sizes,
+        output_offsets,
+        recv_sizes,
+        axis_name=axis_name,
+    )
+    qr = _from_wire(bits, fp8_dtype).astype(jnp.float32)
+    return (qr * scales).astype(x.dtype)
+
+
+@partial(jax.custom_vjp, nondiff_argnums=(3, 4))
+def fp8_ragged_a2a(x, shard_counts, shard_id, out_rows, axis_name):
+    """``ragged_all_to_all`` carrying E4M3 forward / E5M2 backward over the wire.
+
+    ``shard_counts[sender, receiver]`` gives the ragged send matrix (rows this
+    shard sends to each peer live contiguously in ``x``, receiver-major); the
+    received buffer groups rows by sender. The backward runs the reverse
+    ragged_all_to_all (transposed counts) with the cotangent quantized to E5M2.
+    Per-token scales travel through a second ragged_all_to_all in the same layout.
+    """
+    return _fp8_ragged_a2a_impl(x, shard_counts, shard_id, out_rows, axis_name, jnp.float8_e4m3fn)
+
+
+def _fp8_ragged_a2a_fwd(x, shard_counts, shard_id, out_rows, axis_name):
+    return fp8_ragged_a2a(x, shard_counts, shard_id, out_rows, axis_name), (shard_counts, shard_id, x.shape[0])
+
+
+def _fp8_ragged_a2a_bwd(out_rows, axis_name, res, ct):
+    shard_counts, shard_id, in_rows = res
+    dx = _fp8_ragged_a2a_impl(ct, shard_counts.T, shard_id, in_rows, axis_name, jnp.float8_e5m2)
+    zero_counts = np.zeros(shard_counts.shape, dtype=jax.dtypes.float0)
+    zero_id = np.zeros(shard_id.shape, dtype=jax.dtypes.float0)
+    return dx, zero_counts, zero_id
+
+
+fp8_ragged_a2a.defvjp(_fp8_ragged_a2a_fwd, _fp8_ragged_a2a_bwd)

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -74,6 +74,7 @@ class MoEExpertMlp(eqx.Module):
     # so quantization state (OverwriteWithGradient) flows through the trainer's
     # partition_for_grad_overwrite / apply_updates like Linear's dot_general ops.
     ragged_dot_ops: MoeRaggedDotOps | None = None
+    fp8_wire: bool = eqx.field(static=True, default=False)
 
     @staticmethod
     def init(
@@ -88,6 +89,7 @@ class MoEExpertMlp(eqx.Module):
         capacity_factor: float = _DEFAULT_EP_CAPACITY_FACTOR,
         pspecs: MoEExpertMlpPspecs = MoEExpertMlpPspecs(),
         ragged_dot_ops: MoeRaggedDotOps | None = None,
+        fp8_wire: bool = False,
     ) -> "MoEExpertMlp":
         resolved_implementation = resolve_moe_implementation(implementation)
         k_gate, k_up, k_down = jax.random.split(key, 3)
@@ -105,6 +107,7 @@ class MoEExpertMlp(eqx.Module):
             activation=activation,
             capacity_factor=capacity_factor,
             ragged_dot_ops=ragged_dot_ops,
+            fp8_wire=fp8_wire,
         )
 
     @named_call
@@ -130,6 +133,7 @@ class MoEExpertMlp(eqx.Module):
             capacity_factor=self.capacity_factor,
             report_capacity_overflow=report_capacity_overflow,
             ragged_dot_ops=self.ragged_dot_ops,
+            fp8_wire=self.fp8_wire,
         )
 
 
@@ -147,6 +151,7 @@ def moe_mlp(
     capacity_factor: float = _DEFAULT_EP_CAPACITY_FACTOR,
     report_capacity_overflow: bool = False,
     ragged_dot_ops: MoeRaggedDotOps | None = None,
+    fp8_wire: bool = False,
 ) -> Float[Array, "T D"] | tuple[Float[Array, "T D"], Int[Array, ""]]:
     """Functional routed MoE MLP core used by Grug modules and benchmarks.
 
@@ -161,6 +166,10 @@ def moe_mlp(
     GEMMs (e.g. FP8 quantized ops, see [MoeRaggedDotOps][]); ``None`` keeps the
     default bf16 kernels. Only the EP ring / ragged_all_to_all backends support
     ops.
+
+    ``fp8_wire=True`` switches the EP dispatch/combine collectives to carry FP8
+    over the wire (E4M3 activations forward, E5M2 gradients backward; see
+    ``levanter.grug._moe.fp8_wire``). Ring and ragged_all_to_all backends only.
     """
     resolved_implementation = resolve_moe_implementation(implementation)
 
@@ -196,13 +205,17 @@ def moe_mlp(
     has_expert_axis = _mesh_has_axis(mesh, "expert")
     expert_axis_size = _mesh_axis_size(mesh, "expert")
 
-    if ragged_dot_ops is not None:
-        has_ep = has_expert_axis and expert_axis_size > 1
-        if not has_ep or resolved_implementation not in _QUANTIZED_EP_MOE_IMPLEMENTATIONS:
-            raise NotImplementedError(
-                "ragged_dot_ops is only wired into the EP ring / ragged_all_to_all backends; "
-                f"got implementation={resolved_implementation!r} with expert axis size={expert_axis_size}"
-            )
+    has_ep = has_expert_axis and expert_axis_size > 1
+    if ragged_dot_ops is not None and (not has_ep or resolved_implementation not in _QUANTIZED_EP_MOE_IMPLEMENTATIONS):
+        raise NotImplementedError(
+            "ragged_dot_ops is only wired into the EP ring / ragged_all_to_all backends; "
+            f"got implementation={resolved_implementation!r} with expert axis size={expert_axis_size}"
+        )
+    if fp8_wire and (not has_ep or resolved_implementation not in _QUANTIZED_EP_MOE_IMPLEMENTATIONS):
+        raise NotImplementedError(
+            "fp8_wire is only wired into the EP ring / ragged_all_to_all backends; "
+            f"got implementation={resolved_implementation!r} with expert axis size={expert_axis_size}"
+        )
 
     if mesh is None or mesh.empty:
         out, dropped = _moe_mlp_local(
@@ -253,12 +266,14 @@ def moe_mlp(
                 lambda a: _reshard_for_shard_map(a, mesh, P()) if eqx.is_array(a) else a, ragged_dot_ops
             )
 
+        backend_kwargs = {"fp8_wire": fp8_wire} if resolved_implementation in _QUANTIZED_EP_MOE_IMPLEMENTATIONS else {}
         shard_fn = shard_map(
             partial(
                 shard_local_fn,
                 activation_fn=activation_fn,
                 num_experts=num_experts,
                 capacity_factor=capacity_factor,
+                **backend_kwargs,
             ),
             mesh=mesh,
             in_specs=(

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -29,10 +29,12 @@ from levanter.grug._moe.common import (
     _DEFAULT_EP_CAPACITY_FACTOR,
     _EP_MOE_IMPLEMENTATIONS,
     _init_weight,
+    _QUANTIZED_EP_MOE_IMPLEMENTATIONS,
     MOE_REMAT_SAVE_NAMES as MOE_REMAT_SAVE_NAMES,
     MoEExpertMlpPspecs,
     MoeActivation,
     MoeImplementation,
+    MoeRaggedDotOps,
     PspecAxis,
     resolve_moe_implementation,
     split_moe_w13_output,
@@ -68,6 +70,10 @@ class MoEExpertMlp(eqx.Module):
     implementation: MoeImplementation = eqx.field(static=True)
     activation: MoeActivation = eqx.field(static=True)
     capacity_factor: float = eqx.field(static=True)
+    # Optional stateful grouped-matmul ops (e.g. FP8). Lives in the model pytree
+    # so quantization state (OverwriteWithGradient) flows through the trainer's
+    # partition_for_grad_overwrite / apply_updates like Linear's dot_general ops.
+    ragged_dot_ops: MoeRaggedDotOps | None = None
 
     @staticmethod
     def init(
@@ -81,6 +87,7 @@ class MoEExpertMlp(eqx.Module):
         activation: MoeActivation = ActivationFunctionEnum.silu,
         capacity_factor: float = _DEFAULT_EP_CAPACITY_FACTOR,
         pspecs: MoEExpertMlpPspecs = MoEExpertMlpPspecs(),
+        ragged_dot_ops: MoeRaggedDotOps | None = None,
     ) -> "MoEExpertMlp":
         resolved_implementation = resolve_moe_implementation(implementation)
         k_gate, k_up, k_down = jax.random.split(key, 3)
@@ -97,6 +104,7 @@ class MoEExpertMlp(eqx.Module):
             implementation=resolved_implementation,
             activation=activation,
             capacity_factor=capacity_factor,
+            ragged_dot_ops=ragged_dot_ops,
         )
 
     @named_call
@@ -121,6 +129,7 @@ class MoEExpertMlp(eqx.Module):
             mesh=mesh,
             capacity_factor=self.capacity_factor,
             report_capacity_overflow=report_capacity_overflow,
+            ragged_dot_ops=self.ragged_dot_ops,
         )
 
 
@@ -137,6 +146,7 @@ def moe_mlp(
     mesh: jax.sharding.Mesh | jax.sharding.AbstractMesh | None = None,
     capacity_factor: float = _DEFAULT_EP_CAPACITY_FACTOR,
     report_capacity_overflow: bool = False,
+    ragged_dot_ops: MoeRaggedDotOps | None = None,
 ) -> Float[Array, "T D"] | tuple[Float[Array, "T D"], Int[Array, ""]]:
     """Functional routed MoE MLP core used by Grug modules and benchmarks.
 
@@ -146,6 +156,11 @@ def moe_mlp(
 
     Set `report_capacity_overflow=True` to also return a scalar count of
     dropped expert assignments from EP capacity clipping.
+
+    ``ragged_dot_ops`` supplies stateful grouped-matmul ops for the two expert
+    GEMMs (e.g. FP8 quantized ops, see [MoeRaggedDotOps][]); ``None`` keeps the
+    default bf16 kernels. Only the EP ring / ragged_all_to_all backends support
+    ops.
     """
     resolved_implementation = resolve_moe_implementation(implementation)
 
@@ -180,6 +195,14 @@ def moe_mlp(
 
     has_expert_axis = _mesh_has_axis(mesh, "expert")
     expert_axis_size = _mesh_axis_size(mesh, "expert")
+
+    if ragged_dot_ops is not None:
+        has_ep = has_expert_axis and expert_axis_size > 1
+        if not has_ep or resolved_implementation not in _QUANTIZED_EP_MOE_IMPLEMENTATIONS:
+            raise NotImplementedError(
+                "ragged_dot_ops is only wired into the EP ring / ragged_all_to_all backends; "
+                f"got implementation={resolved_implementation!r} with expert axis size={expert_axis_size}"
+            )
 
     if mesh is None or mesh.empty:
         out, dropped = _moe_mlp_local(
@@ -225,6 +248,10 @@ def moe_mlp(
         combine_weights = _reshard_for_shard_map(combine_weights, mesh, batch_spec)
         w_up_gate = _reshard_for_shard_map(w_up_gate, mesh, w_up_gate_spec)
         w_down = _reshard_for_shard_map(w_down, mesh, w_down_spec)
+        if ragged_dot_ops is not None:
+            ragged_dot_ops = jax.tree.map(
+                lambda a: _reshard_for_shard_map(a, mesh, P()) if eqx.is_array(a) else a, ragged_dot_ops
+            )
 
         shard_fn = shard_map(
             partial(
@@ -240,11 +267,12 @@ def moe_mlp(
                 batch_spec,
                 w_up_gate_spec,
                 w_down_spec,
+                P(),  # ragged-dot op state is replicated across the mesh
             ),
             out_specs=(batch_spec, P()),
             check_vma=False,
         )
-        out, dropped = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down)
+        out, dropped = shard_fn(x, selected_experts, combine_weights, w_up_gate, w_down, ragged_dot_ops)
         if report_capacity_overflow:
             return out, dropped
         return out

--- a/lib/levanter/src/levanter/grug/grug_moe.py
+++ b/lib/levanter/src/levanter/grug/grug_moe.py
@@ -337,6 +337,7 @@ __all__ = [
     "MoEExpertMlp",
     "MoEExpertMlpPspecs",
     "MoeImplementation",
+    "MoeRaggedDotOps",
     "PspecAxis",
     "moe_mlp",
     "resolve_moe_implementation",

--- a/lib/levanter/tests/grug/test_moe_fp8_wire.py
+++ b/lib/levanter/tests/grug/test_moe_fp8_wire.py
@@ -1,0 +1,172 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for the FP8 over-the-wire MoE dispatch/combine collectives."""
+
+import numpy as np
+import pytest
+
+import jax
+import jax.numpy as jnp
+from jax import shard_map
+from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+from levanter.grug._moe.ep_common import _shard_a2a_params
+from levanter.grug._moe.fp8_wire import fp8_all_gather, fp8_psum_scatter, fp8_ragged_a2a
+
+
+def _expert_mesh_or_skip(min_shards: int = 2) -> Mesh:
+    devices = jax.devices()
+    if len(devices) < min_shards:
+        pytest.skip(f"needs >= {min_shards} devices")
+    mesh_devices = np.array(devices).reshape(len(devices))
+    return Mesh(mesh_devices, axis_names=("expert",), axis_types=(AxisType.Explicit,))
+
+
+def _relfrob(a, b):
+    a = np.asarray(a, dtype=np.float32)
+    b = np.asarray(b, dtype=np.float32)
+    return float(np.linalg.norm(a - b) / np.linalg.norm(b))
+
+
+def _shmap(fn, mesh, n_args=1):
+    return shard_map(
+        fn,
+        mesh=mesh,
+        in_specs=tuple(P("expert") for _ in range(n_args)),
+        out_specs=P("expert"),
+        check_vma=False,
+    )
+
+
+def test_fp8_all_gather_forward_matches_native_within_quant_tolerance():
+    mesh = _expert_mesh_or_skip()
+    n = len(jax.devices())
+    x = jax.random.normal(jax.random.key(0), (n * 8, 16), dtype=jnp.bfloat16)
+    with jax.set_mesh(mesh):
+        xs = jax.device_put(x, NamedSharding(mesh, P("expert")))
+        got = jax.jit(_shmap(lambda v: fp8_all_gather(v, "expert"), mesh))(xs)
+        want = jax.jit(_shmap(lambda v: jax.lax.all_gather(v, "expert", tiled=True), mesh))(xs)
+    # E4M3 per-tensor quantization error; well under 2^-3 relative for gaussian data.
+    assert _relfrob(got, want) < 0.05
+
+
+def test_fp8_all_gather_backward_is_exact_native_reduction():
+    # The gradient must be the exact bf16 psum_scatter (straight-through across
+    # QDQ): reductions never run in FP8.
+    mesh = _expert_mesh_or_skip()
+    n = len(jax.devices())
+    key = jax.random.key(1)
+    x = jax.random.normal(key, (n * 8, 16), dtype=jnp.float32)
+    cot = jax.random.normal(jax.random.key(2), (n * n * 8, 16), dtype=jnp.float32)
+
+    with jax.set_mesh(mesh):
+        xs = jax.device_put(x, NamedSharding(mesh, P("expert")))
+        cots = jax.device_put(cot, NamedSharding(mesh, P("expert")))
+
+        def loss_fp8(v, c):
+            return jnp.sum(fp8_all_gather(v, "expert") * c)[None]
+
+        def loss_native(v, c):
+            return jnp.sum(jax.lax.all_gather(v, "expert", tiled=True) * c)[None]
+
+        g_fp8 = jax.jit(jax.grad(lambda v: jnp.sum(_shmap(loss_fp8, mesh, n_args=2)(v, cots))))(xs)
+        g_native = jax.jit(jax.grad(lambda v: jnp.sum(_shmap(loss_native, mesh, n_args=2)(v, cots))))(xs)
+    np.testing.assert_allclose(np.asarray(g_fp8), np.asarray(g_native), rtol=1e-6)
+
+
+def test_fp8_psum_scatter_forward_is_exact_native():
+    # Contract: the forward reduction is bit-identical to the native psum_scatter
+    # (only the backward all_gather carries FP8).
+    mesh = _expert_mesh_or_skip()
+    n = len(jax.devices())
+    y = jax.random.normal(jax.random.key(3), (n * n * 8, 16), dtype=jnp.float32)
+    with jax.set_mesh(mesh):
+        ys = jax.device_put(y, NamedSharding(mesh, P("expert")))
+        got = jax.jit(_shmap(lambda v: fp8_psum_scatter(v, "expert"), mesh))(ys)
+        want = jax.jit(_shmap(lambda v: jax.lax.psum_scatter(v, "expert", scatter_dimension=0, tiled=True), mesh))(ys)
+    np.testing.assert_allclose(np.asarray(got), np.asarray(want), rtol=1e-6)
+
+
+def test_fp8_psum_scatter_backward_within_e5m2_tolerance():
+    mesh = _expert_mesh_or_skip()
+    n = len(jax.devices())
+    y = jax.random.normal(jax.random.key(4), (n * n * 8, 16), dtype=jnp.float32)
+    cot = jax.random.normal(jax.random.key(5), (n * 8, 16), dtype=jnp.float32)
+    with jax.set_mesh(mesh):
+        ys = jax.device_put(y, NamedSharding(mesh, P("expert")))
+        cots = jax.device_put(cot, NamedSharding(mesh, P("expert")))
+
+        def loss_fp8(v, c):
+            return jnp.sum(fp8_psum_scatter(v, "expert") * c)[None]
+
+        def loss_native(v, c):
+            return jnp.sum(jax.lax.psum_scatter(v, "expert", scatter_dimension=0, tiled=True) * c)[None]
+
+        g_fp8 = jax.jit(jax.grad(lambda v: jnp.sum(_shmap(loss_fp8, mesh, n_args=2)(v, cots))))(ys)
+        g_native = jax.jit(jax.grad(lambda v: jnp.sum(_shmap(loss_native, mesh, n_args=2)(v, cots))))(ys)
+    # E5M2 gradient wire: 2 mantissa bits => ~1e-1 worst-case relative rounding.
+    assert _relfrob(g_fp8, g_native) < 0.15
+
+
+def test_fp8_all_gather_scaling_is_token_independent():
+    # Per-token scaling: perturbing one token must not change any other token's
+    # dequantized value. A scale shared across rows would couple tokens (and leak
+    # later sequence positions into earlier ones through the quantization grid).
+    mesh = _expert_mesh_or_skip()
+    n = len(jax.devices())
+    x = jax.random.normal(jax.random.key(6), (n * 8, 16), dtype=jnp.float32)
+    x_perturbed = x.at[0, :].multiply(100.0)  # local row 0 of shard 0
+
+    with jax.set_mesh(mesh):
+        gather = jax.jit(_shmap(lambda v: fp8_all_gather(v, "expert"), mesh))
+        got = np.asarray(gather(jax.device_put(x, NamedSharding(mesh, P("expert")))))
+        got_perturbed = np.asarray(gather(jax.device_put(x_perturbed, NamedSharding(mesh, P("expert")))))
+
+    # Each shard's [n*8, 16] gather stacks into [n*n*8, 16]; the perturbed input
+    # row appears at position 0 of every shard's block.
+    affected = np.zeros(got.shape[0], dtype=bool)
+    affected[np.arange(n) * (n * 8)] = True
+    assert not np.array_equal(got[affected], got_perturbed[affected])
+    np.testing.assert_array_equal(got[~affected], got_perturbed[~affected])
+
+
+@pytest.mark.skipif(jax.default_backend() != "gpu", reason="ragged_all_to_all has no CPU lowering")
+def test_fp8_ragged_a2a_forward_and_backward_within_wire_tolerance():
+    # Forward parity within E4M3 tolerance and, through the custom VJP's reverse
+    # ragged_all_to_all (transposed counts, per-token E5M2), gradient parity
+    # within E5M2 tolerance against the native collective.
+    mesh = _expert_mesh_or_skip()
+    n = len(jax.devices())
+    rows_per_peer = 4
+    total = n * rows_per_peer
+    counts = jnp.full((n, n), rows_per_peer, dtype=jnp.int32)
+    x = jax.random.normal(jax.random.key(7), (n * total, 16), dtype=jnp.float32)
+    cot = jax.random.normal(jax.random.key(8), (n * total, 16), dtype=jnp.float32)
+
+    def wire(v):
+        return fp8_ragged_a2a(v, counts, jax.lax.axis_index("expert"), total, "expert")
+
+    def native(v):
+        offsets = _shard_a2a_params(counts, jax.lax.axis_index("expert"))
+        buf = jnp.zeros((total, v.shape[1]), dtype=v.dtype)
+        return jax.lax.ragged_all_to_all(v, buf, *offsets, axis_name="expert")
+
+    with jax.set_mesh(mesh):
+        xs = jax.device_put(x, NamedSharding(mesh, P("expert")))
+        cots = jax.device_put(cot, NamedSharding(mesh, P("expert")))
+
+        got = jax.jit(_shmap(wire, mesh))(xs)
+        want = jax.jit(_shmap(native, mesh))(xs)
+
+        def loss(fn):
+            def inner(v, c):
+                return jnp.sum(fn(v) * c)[None]
+
+            return jax.jit(jax.grad(lambda v: jnp.sum(_shmap(inner, mesh, n_args=2)(v, cots))))
+
+        g_wire = loss(wire)(xs)
+        g_native = loss(native)(xs)
+
+    assert _relfrob(got, want) < 0.05  # E4M3 forward
+    assert _relfrob(g_wire, g_native) < 0.15  # E5M2 backward

--- a/lib/levanter/tests/grug/test_moe_fp8_wire.py
+++ b/lib/levanter/tests/grug/test_moe_fp8_wire.py
@@ -13,6 +13,7 @@ from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
 
 from levanter.grug._moe.ep_common import _shard_a2a_params
 from levanter.grug._moe.fp8_wire import fp8_all_gather, fp8_psum_scatter, fp8_ragged_a2a
+from levanter.grug.grug_moe import moe_mlp
 
 
 def _expert_mesh_or_skip(min_shards: int = 2) -> Mesh:
@@ -170,3 +171,91 @@ def test_fp8_ragged_a2a_forward_and_backward_within_wire_tolerance():
 
     assert _relfrob(got, want) < 0.05  # E4M3 forward
     assert _relfrob(g_wire, g_native) < 0.15  # E5M2 backward
+
+
+def _ep_moe_mesh_or_skip(expert: int = 2) -> Mesh:
+    devices = jax.devices()
+    if len(devices) < expert or len(devices) % expert != 0:
+        pytest.skip(f"needs >= {expert} devices with expert-divisible count")
+    mesh_devices = np.array(devices).reshape(len(devices) // expert, expert, 1)
+    return Mesh(
+        mesh_devices,
+        axis_names=("data", "expert", "model"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit, AxisType.Explicit),
+    )
+
+
+def test_moe_mlp_ring_fp8_wire_parity():
+    # End-to-end: values and input gradients stay within FP8 wire tolerance of
+    # the bf16-wire path (E4M3 dispatch fwd, E5M2 combine-transpose bwd).
+    mesh = _ep_moe_mesh_or_skip()
+    t, d, i, e, k = 64, 32, 16, 16, 4
+    key = jax.random.key(0)
+    kx, ks, kw, k1, k2, kc = jax.random.split(key, 6)
+    batch = P(("data", "expert"))
+    with jax.set_mesh(mesh):
+        x = jax.device_put(jax.random.normal(kx, (t, d), dtype=jnp.float32), NamedSharding(mesh, batch))
+        sel = jax.device_put(
+            jnp.argsort(jax.random.uniform(ks, (t, e)), axis=-1)[:, :k].astype(jnp.int32),
+            NamedSharding(mesh, batch),
+        )
+        cw = jax.device_put(jax.nn.softmax(jax.random.normal(kw, (t, k))), NamedSharding(mesh, batch))
+        w13 = jax.device_put(jax.random.normal(k1, (e, d, 2 * i)) * 0.05, NamedSharding(mesh, P("expert", None, None)))
+        w2 = jax.device_put(jax.random.normal(k2, (e, i, d)) * 0.05, NamedSharding(mesh, P("expert", None, None)))
+        cot = jax.device_put(jax.random.normal(kc, (t, d), dtype=jnp.float32), NamedSharding(mesh, batch))
+
+        def loss(x_, *, wire):
+            out = moe_mlp(x_, sel, cw, w13, w2, implementation="ring", mesh=mesh, fp8_wire=wire)
+            return jnp.sum(out * cot)
+
+        out_wire = moe_mlp(x, sel, cw, w13, w2, implementation="ring", mesh=mesh, fp8_wire=True)
+        out_ref = moe_mlp(x, sel, cw, w13, w2, implementation="ring", mesh=mesh)
+        g_wire = jax.jit(jax.grad(lambda v: loss(v, wire=True)))(x)
+        g_ref = jax.jit(jax.grad(lambda v: loss(v, wire=False)))(x)
+
+    assert _relfrob(out_wire, out_ref) < 0.1
+    assert _relfrob(g_wire, g_ref) < 0.2
+
+
+@pytest.mark.skipif(jax.default_backend() != "gpu", reason="ragged_all_to_all has no CPU lowering")
+def test_moe_mlp_ragged_a2a_fp8_wire_parity():
+    mesh = _ep_moe_mesh_or_skip()
+    t, d, i, e, k = 64, 32, 16, 16, 4
+    key = jax.random.key(0)
+    kx, ks, kw, k1, k2 = jax.random.split(key, 5)
+    batch = P(("data", "expert"))
+    with jax.set_mesh(mesh):
+        x = jax.device_put(jax.random.normal(kx, (t, d), dtype=jnp.float32), NamedSharding(mesh, batch))
+        sel = jax.device_put(
+            jnp.argsort(jax.random.uniform(ks, (t, e)), axis=-1)[:, :k].astype(jnp.int32),
+            NamedSharding(mesh, batch),
+        )
+        cw = jax.device_put(jax.nn.softmax(jax.random.normal(kw, (t, k))), NamedSharding(mesh, batch))
+        w13 = jax.device_put(jax.random.normal(k1, (e, d, 2 * i)) * 0.05, NamedSharding(mesh, P("expert", None, None)))
+        w2 = jax.device_put(jax.random.normal(k2, (e, i, d)) * 0.05, NamedSharding(mesh, P("expert", None, None)))
+
+        out_wire = moe_mlp(x, sel, cw, w13, w2, implementation="ragged_all_to_all", mesh=mesh, fp8_wire=True)
+        out_ref = moe_mlp(x, sel, cw, w13, w2, implementation="ragged_all_to_all", mesh=mesh)
+    assert _relfrob(out_wire, out_ref) < 0.1
+
+
+def test_moe_mlp_rejects_fp8_wire_without_expert_axis():
+    # Contract: fp8_wire only exists on the EP dispatch/combine collectives; a
+    # silent bf16 fallback would let runs believe they measure the FP8 wire.
+    devices = jax.devices()
+    mesh_devices = np.array(devices).reshape(len(devices), 1)
+    mesh = Mesh(mesh_devices, axis_names=("data", "model"), axis_types=(AxisType.Explicit, AxisType.Explicit))
+    t, d, i, e, k = 16, 8, 4, 4, 2
+    key = jax.random.key(0)
+    kx, ks, kw, k1, k2 = jax.random.split(key, 5)
+    with jax.set_mesh(mesh):
+        x = jax.device_put(jax.random.normal(kx, (t, d), dtype=jnp.float32), NamedSharding(mesh, P("data")))
+        sel = jax.device_put(
+            jnp.argsort(jax.random.uniform(ks, (t, e)), axis=-1)[:, :k].astype(jnp.int32),
+            NamedSharding(mesh, P("data")),
+        )
+        cw = jax.device_put(jax.nn.softmax(jax.random.normal(kw, (t, k))), NamedSharding(mesh, P("data")))
+        w13 = jax.device_put(jax.random.normal(k1, (e, d, 2 * i)) * 0.05, NamedSharding(mesh, P(None, None, None)))
+        w2 = jax.device_put(jax.random.normal(k2, (e, i, d)) * 0.05, NamedSharding(mesh, P(None, None, None)))
+        with pytest.raises(NotImplementedError, match="fp8_wire"):
+            moe_mlp(x, sel, cw, w13, w2, implementation="ring", mesh=mesh, fp8_wire=True)

--- a/lib/levanter/tests/grug/test_moe_fp8_wire.py
+++ b/lib/levanter/tests/grug/test_moe_fp8_wire.py
@@ -188,8 +188,10 @@ def _ep_moe_mesh_or_skip(expert: int = 2) -> Mesh:
 def test_moe_mlp_ring_fp8_wire_parity():
     # End-to-end: values and input gradients stay within FP8 wire tolerance of
     # the bf16-wire path (E4M3 dispatch fwd, E5M2 combine-transpose bwd).
+    # d/i are TPU-tile-sized (128): the reference arm's grad runs the megablox
+    # ragged_dot on TPU, whose Pallas kernel needs 128-divisible trailing dims.
     mesh = _ep_moe_mesh_or_skip()
-    t, d, i, e, k = 64, 32, 16, 16, 4
+    t, d, i, e, k = 64, 128, 128, 16, 4
     key = jax.random.key(0)
     kx, ks, kw, k1, k2, kc = jax.random.split(key, 6)
     batch = P(("data", "expert"))

--- a/lib/levanter/tests/grug/test_moe_ragged_dot_ops.py
+++ b/lib/levanter/tests/grug/test_moe_ragged_dot_ops.py
@@ -1,0 +1,189 @@
+# Copyright The Levanter Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Tests for threading stateful ragged-dot ops through the EP MoE backends."""
+
+import equinox as eqx
+import numpy as np
+import pytest
+
+import jax
+import jax.numpy as jnp
+from jax import shard_map
+from jax.sharding import AxisType, Mesh, NamedSharding, PartitionSpec as P
+
+from haliax.quantization import OverwriteWithGradient
+from levanter.grug._moe.common import MoeRaggedDotOps
+from levanter.grug._moe.ep_common import _pmax_replicated_cotangent
+from levanter.grug.grug_moe import moe_mlp
+
+
+class _ScaledRaggedDotOp(eqx.Module):
+    """Stateful stand-in for a quantized op: scales the activations by a carried array."""
+
+    scale: jnp.ndarray
+
+    def __call__(self, lhs, rhs, group_sizes):
+        return jax.lax.ragged_dot(lhs * self.scale, rhs, group_sizes)
+
+
+@jax.custom_vjp
+def _amax_tracking_ragged_dot(amax, lhs, rhs, group_sizes):
+    del amax
+    return jax.lax.ragged_dot(lhs, rhs, group_sizes)
+
+
+def _amax_tracking_fwd(amax, lhs, rhs, group_sizes):
+    del amax
+    return jax.lax.ragged_dot(lhs, rhs, group_sizes), (lhs, rhs, group_sizes)
+
+
+def _amax_tracking_bwd(res, ct):
+    lhs, rhs, group_sizes = res
+    del ct
+    # The amax "gradient" is the new state (max |lhs| seen this step), mirroring
+    # how delayed-scaling ops emit their OverwriteWithGradient state updates.
+    d_amax = jnp.max(jnp.abs(lhs))
+    zero_group_sizes = np.zeros(group_sizes.shape, dtype=jax.dtypes.float0)
+    return d_amax, jnp.zeros_like(lhs), jnp.zeros_like(rhs), zero_group_sizes
+
+
+_amax_tracking_ragged_dot.defvjp(_amax_tracking_fwd, _amax_tracking_bwd)
+
+
+class _AmaxRaggedDotOp(OverwriteWithGradient):
+    """Overwrite-state stand-in: its state cotangent is the local amax of lhs."""
+
+    amax: jnp.ndarray
+
+    def __call__(self, lhs, rhs, group_sizes):
+        return _amax_tracking_ragged_dot(self.amax, lhs, rhs, group_sizes)
+
+
+def _ep_mesh_or_skip(expert: int = 2) -> Mesh:
+    devices = jax.devices()
+    if len(devices) < expert or len(devices) % expert != 0:
+        pytest.skip(f"needs >= {expert} devices with expert-divisible count")
+    mesh_devices = np.array(devices).reshape(len(devices) // expert, expert, 1)
+    return Mesh(
+        mesh_devices,
+        axis_names=("data", "expert", "model"),
+        axis_types=(AxisType.Explicit, AxisType.Explicit, AxisType.Explicit),
+    )
+
+
+def _moe_inputs(mesh, t=64, d=32, i=16, e=16, k=4, seed=0, batch=P(("data", "expert"))):
+    key = jax.random.key(seed)
+    kx, ks, kw, k1, k2 = jax.random.split(key, 5)
+    expert_spec = P("expert", None, None) if "expert" in mesh.shape else P(None, None, None)
+    x = jax.device_put(jax.random.normal(kx, (t, d), dtype=jnp.float32), NamedSharding(mesh, batch))
+    sel = jax.device_put(
+        jnp.argsort(jax.random.uniform(ks, (t, e)), axis=-1)[:, :k].astype(jnp.int32),
+        NamedSharding(mesh, batch),
+    )
+    cw = jax.device_put(jax.nn.softmax(jax.random.normal(kw, (t, k))), NamedSharding(mesh, batch))
+    w13 = jax.device_put(jax.random.normal(k1, (e, d, 2 * i)) * 0.05, NamedSharding(mesh, expert_spec))
+    w2 = jax.device_put(jax.random.normal(k2, (e, i, d)) * 0.05, NamedSharding(mesh, expert_spec))
+    return x, sel, cw, w13, w2
+
+
+@pytest.mark.parametrize("impl", ["ring", "ragged_all_to_all"])
+def test_moe_mlp_with_identity_scaled_op_matches_default(impl):
+    # An op with scale=1 must reproduce the default bf16 path: same contraction,
+    # same dispatch — only the GEMM callable is swapped, so outputs agree to
+    # float32 roundoff.
+    if impl == "ragged_all_to_all" and jax.default_backend() != "gpu":
+        pytest.skip("ragged_all_to_all has no CPU lowering")
+    mesh = _ep_mesh_or_skip()
+    x, sel, cw, w13, w2 = _moe_inputs(mesh)
+    ops = MoeRaggedDotOps(w13=_ScaledRaggedDotOp(jnp.ones(1)), w2=_ScaledRaggedDotOp(jnp.ones(1)))
+    with jax.set_mesh(mesh):
+        y_default = moe_mlp(x, sel, cw, w13, w2, implementation=impl, mesh=mesh)
+        y_ops = moe_mlp(x, sel, cw, w13, w2, implementation=impl, mesh=mesh, ragged_dot_ops=ops)
+    np.testing.assert_allclose(np.asarray(y_ops), np.asarray(y_default), rtol=1e-5, atol=1e-6)
+
+
+def test_moe_mlp_op_state_receives_cotangents(impl="ring"):
+    # An op's ordinary trainable state must receive a cotangent through shard_map
+    # (summed across shards by the transpose, like any replicated parameter).
+    mesh = _ep_mesh_or_skip()
+    x, sel, cw, w13, w2 = _moe_inputs(mesh)
+    ops = MoeRaggedDotOps(w13=_ScaledRaggedDotOp(jnp.ones(1)), w2=_ScaledRaggedDotOp(jnp.ones(1)))
+
+    def loss(ops_):
+        out = moe_mlp(x, sel, cw, w13, w2, implementation=impl, mesh=mesh, ragged_dot_ops=ops_)
+        return jnp.sum(out * out)
+
+    with jax.set_mesh(mesh):
+        grads = jax.jit(jax.grad(loss))(ops)
+    assert np.isfinite(np.asarray(grads.w13.scale)).all()
+    assert float(jnp.abs(grads.w13.scale).sum()) > 0.0
+    assert float(jnp.abs(grads.w2.scale).sum()) > 0.0
+
+
+def test_moe_mlp_overwrite_state_cotangent_is_global_amax(impl="ring"):
+    # Delayed-scaling state (OverwriteWithGradient) must combine as the max over
+    # shards: each op sees only locally dispatched rows, and the state cotangent
+    # reaching the optimizer must be the global amax. Every token row reaches
+    # some shard's w13 GEMM and padding rows are zeros, so the expected w13 amax
+    # is exactly max |x|. A dropped or double-applied pmax wrapper changes this.
+    mesh = _ep_mesh_or_skip()
+    x, sel, cw, w13, w2 = _moe_inputs(mesh)
+    ops = MoeRaggedDotOps(w13=_AmaxRaggedDotOp(jnp.zeros(())), w2=_AmaxRaggedDotOp(jnp.zeros(())))
+
+    def loss(ops_):
+        out = moe_mlp(x, sel, cw, w13, w2, implementation=impl, mesh=mesh, ragged_dot_ops=ops_)
+        return jnp.sum(out)
+
+    with jax.set_mesh(mesh):
+        grads = jax.jit(jax.grad(loss))(ops)
+    np.testing.assert_allclose(float(grads.w13.amax), float(jnp.max(jnp.abs(x))), rtol=1e-6)
+
+
+class _OwgState(OverwriteWithGradient):
+    value: jnp.ndarray
+
+
+def test_pmax_replicated_cotangent_maxes_overwrite_and_sums_plain():
+    # Replicated shard_map inputs get psum'ed cotangents by the transpose.
+    # OverwriteWithGradient state must instead combine as the max over shards,
+    # while ordinary trainable leaves keep the sum (the true total gradient).
+    mesh = _ep_mesh_or_skip()
+    n_shards = len(jax.devices())
+    per_shard = jnp.arange(1.0, n_shards + 1.0)  # shard i contributes weight i+1
+    w = jax.device_put(per_shard, NamedSharding(mesh, P(("data", "expert"))))
+
+    def shard_fn(tree, w_local):
+        tree = _pmax_replicated_cotangent(tree)
+        return (tree["overwrite"].value + tree["plain"]) * w_local
+
+    f = shard_map(
+        shard_fn,
+        mesh=mesh,
+        in_specs=(P(), P(("data", "expert"))),
+        out_specs=P(("data", "expert")),
+        check_vma=False,
+    )
+
+    def loss(tree):
+        return jnp.sum(f(tree, w))
+
+    tree = {"overwrite": _OwgState(jnp.ones(())), "plain": jnp.ones(())}
+    with jax.set_mesh(mesh):
+        grad = jax.jit(jax.grad(loss))(tree)
+    # Each shard's cotangent is w_local: overwrite state contributes pmax/n so
+    # the psum reconstructs the max; the plain leaf psums to the sum.
+    np.testing.assert_allclose(float(grad["overwrite"].value), float(per_shard.max()), rtol=1e-6)
+    np.testing.assert_allclose(float(grad["plain"]), float(per_shard.sum()), rtol=1e-6)
+
+
+def test_moe_mlp_rejects_ops_without_expert_axis():
+    # Contract: ops are only wired into the EP backends; a silent bf16 fallback
+    # would defeat the point of requesting quantized GEMMs.
+    devices = jax.devices()
+    mesh_devices = np.array(devices).reshape(len(devices), 1)
+    mesh = Mesh(mesh_devices, axis_names=("data", "model"), axis_types=(AxisType.Explicit, AxisType.Explicit))
+    x, sel, cw, w13, w2 = _moe_inputs(mesh, batch=P("data"))
+    ops = MoeRaggedDotOps(w13=_ScaledRaggedDotOp(jnp.ones(1)), w2=_ScaledRaggedDotOp(jnp.ones(1)))
+    with jax.set_mesh(mesh), pytest.raises(NotImplementedError, match="ragged_dot_ops"):
+        moe_mlp(x, sel, cw, w13, w2, implementation="ring", mesh=mesh, ragged_dot_ops=ops)

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -23,6 +23,7 @@ import jmp
 import optax
 import pytest
 from fray.cluster import ResourceConfig
+from haliax.quantization import Fp8RaggedDotOp
 from jax._src import config as jax_config
 from jax.sharding import use_abstract_mesh
 from levanter.checkpoint import CheckpointerConfig
@@ -302,6 +303,35 @@ def test_grug_moe_variant_threads_moe_implementation_to_kernel():
         closed_jaxpr, _, _ = eqx.filter_make_jaxpr(one_step)()
 
     assert "ragged_all_to_all" in str(closed_jaxpr)
+
+
+def test_grug_moe_fp8_config_threads_ops_into_expert_mlp():
+    model_module = importlib.import_module("experiments.grug.moe.model")
+    mesh, _ = model_module.debug_mesh_and_token_pspec(num_devices=4)
+
+    def build(fp8):
+        cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=1024, seq_len=4)
+        cfg = dataclasses.replace(cfg, fp8=fp8)
+        return model_module.Transformer.init(cfg, key=jax.random.PRNGKey(0))
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        fp8_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(amax_history_length=8))
+        gemm_only_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(wire=False))
+        bf16_model = eqx.filter_eval_shape(build, None)
+
+    fp8_mlp = fp8_model.blocks[0].mlp.expert_mlp
+    assert isinstance(fp8_mlp.ragged_dot_ops.w13, Fp8RaggedDotOp)
+    assert isinstance(fp8_mlp.ragged_dot_ops.w2, Fp8RaggedDotOp)
+    assert fp8_mlp.ragged_dot_ops.w13.input_amax_history.shape == (8,)
+    assert fp8_mlp.fp8_wire
+
+    gemm_only_mlp = gemm_only_model.blocks[0].mlp.expert_mlp
+    assert isinstance(gemm_only_mlp.ragged_dot_ops.w13, Fp8RaggedDotOp)
+    assert not gemm_only_mlp.fp8_wire
+
+    bf16_mlp = bf16_model.blocks[0].mlp.expert_mlp
+    assert bf16_mlp.ragged_dot_ops is None
+    assert not bf16_mlp.fp8_wire
 
 
 def test_grug_moe_data_loaders_build_against_single_expert_mesh():

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -334,6 +334,59 @@ def test_grug_moe_fp8_config_threads_ops_into_expert_mlp():
     assert not bf16_mlp.fp8_wire
 
 
+def test_grug_moe_fp8_state_gets_no_optimizer_moments():
+    train_module = importlib.import_module("experiments.grug.moe.train")
+    model_module = importlib.import_module("experiments.grug.moe.model")
+    mesh, _ = model_module.debug_mesh_and_token_pspec(num_devices=4)
+    optimizer = optax.adam(1e-2)
+    mp = jmp.get_policy("f32")
+
+    def build(fp8):
+        cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=1024, seq_len=4)
+        cfg = dataclasses.replace(cfg, fp8=fp8)
+        return train_module.initial_state(cfg, optimizer=optimizer, mp=mp, key=jax.random.PRNGKey(0), ema_beta=None)
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        fp8_state = eqx.filter_eval_shape(build, model_module.GrugFp8Config())
+        bf16_state = eqx.filter_eval_shape(build, None)
+
+    # The fp8 model carries extra quantization-state leaves in params, but none
+    # of them may get optimizer moments.
+    assert len(jax.tree.leaves(fp8_state.params)) > len(jax.tree.leaves(bf16_state.params))
+    assert len(jax.tree.leaves(fp8_state.opt_state)) == len(jax.tree.leaves(bf16_state.opt_state))
+
+
+def test_grug_moe_ema_update_carries_current_fp8_state():
+    train_module = importlib.import_module("experiments.grug.moe.train")
+    model_module = importlib.import_module("experiments.grug.moe.model")
+    compact_grug_mesh = importlib.import_module("levanter.grug.sharding").compact_grug_mesh
+    set_mesh = importlib.import_module("haliax.partitioning").set_mesh
+
+    cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=64, seq_len=4)
+    cfg = dataclasses.replace(cfg, fp8=model_module.GrugFp8Config(amax_history_length=4))
+
+    with set_mesh(compact_grug_mesh(expert_axis_size=1, replica_axis_size=1)):
+        old = jax.jit(lambda: model_module.Transformer.init(cfg, key=jax.random.PRNGKey(0)))()
+        new = jax.jit(lambda: model_module.Transformer.init(cfg, key=jax.random.PRNGKey(1)))()
+
+    ops_path = lambda t: t.blocks[0].mlp.expert_mlp.ragged_dot_ops.w13.input_scale  # noqa: E731
+    new = eqx.tree_at(ops_path, new, jnp.full((1,), 7.0))
+
+    ema = train_module._ema_update(old, new, 0.75)
+
+    # Plain weights blend; fp8 op state is the current step's, not an average
+    # (a blend with old's scale of 1.0 would give 2.5).
+    expected_router = 0.75 * old.blocks[0].mlp.router + 0.25 * new.blocks[0].mlp.router
+    assert jnp.allclose(ema.blocks[0].mlp.router, expected_router)
+    assert ops_path(ema) == 7.0
+    same_state = jax.tree.map(
+        jnp.array_equal,
+        ema.blocks[0].mlp.expert_mlp.ragged_dot_ops,
+        new.blocks[0].mlp.expert_mlp.ragged_dot_ops,
+    )
+    assert all(jax.tree.leaves(same_state))
+
+
 def test_grug_moe_data_loaders_build_against_single_expert_mesh():
     """Regression: build_train_loader / build_tagged_evaluator must work when the
     compact mesh's expert axis has size 1 (canary configuration).

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -24,7 +24,7 @@ import optax
 import pytest
 from fray.cluster import ResourceConfig
 from haliax.partitioning import set_mesh
-from haliax.quantization import Fp8RaggedDotOp
+from haliax.quantization import Fp8DotGeneralOp, Fp8RaggedDotOp
 from jax._src import config as jax_config
 from jax.sharding import use_abstract_mesh
 from levanter.checkpoint import CheckpointerConfig
@@ -341,6 +341,96 @@ def test_grug_moe_fp8_config_threads_ops_into_expert_mlp():
     bf16_mlp = bf16_model.blocks[0].mlp.expert_mlp
     assert bf16_mlp.ragged_dot_ops is None
     assert not bf16_mlp.fp8_wire
+
+
+def test_grug_moe_fp8_config_threads_dense_ops():
+    model_module = importlib.import_module("experiments.grug.moe.model")
+    mesh, _ = model_module.debug_mesh_and_token_pspec(num_devices=4)
+
+    def build(fp8):
+        cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=1024, seq_len=4)
+        cfg = dataclasses.replace(cfg, fp8=fp8, hidden_dim=128, intermediate_dim=128)
+        return model_module.Transformer.init(cfg, key=jax.random.PRNGKey(0))
+
+    with _reset_abstract_mesh(), use_abstract_mesh(mesh):
+        fp8_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(amax_history_length=8))
+        moe_only_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(dense=False))
+        bf16_model = eqx.filter_eval_shape(build, None)
+
+    attn = fp8_model.blocks[0].attn
+    for op in (attn.fp8_ops.q, attn.fp8_ops.k, attn.fp8_ops.v, attn.fp8_ops.o):
+        assert isinstance(op, Fp8DotGeneralOp)
+    assert attn.fp8_ops.q.input_amax_history.shape == (8,)
+    shared = fp8_model.blocks[0].shared
+    for op in (shared.fp8_ops.gate, shared.fp8_ops.up, shared.fp8_ops.down):
+        assert isinstance(op, Fp8DotGeneralOp)
+
+    # dense=False keeps the FP8 expert path but reverts every dense GEMM to bf16.
+    assert moe_only_model.blocks[0].attn.fp8_ops is None
+    assert moe_only_model.blocks[0].shared.fp8_ops is None
+    assert moe_only_model.blocks[0].mlp.expert_mlp.ragged_dot_ops is not None
+
+    assert bf16_model.blocks[0].attn.fp8_ops is None
+    assert bf16_model.blocks[0].shared.fp8_ops is None
+
+
+def test_grug_moe_fp8_dense_config_rejects_misaligned_dims():
+    model_module = importlib.import_module("experiments.grug.moe.model")
+    cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=1024, seq_len=4)
+    cfg = dataclasses.replace(cfg, hidden_dim=128, intermediate_dim=128, shared_expert_intermediate_dim=8)
+    with pytest.raises(ValueError, match="16-aligned"):
+        dataclasses.replace(cfg, fp8=model_module.GrugFp8Config())
+    # The misaligned shared-expert dim only matters when the dense GEMMs quantize.
+    dataclasses.replace(cfg, fp8=model_module.GrugFp8Config(dense=False))
+
+
+def _rel_frobenius(actual: jax.Array, reference: jax.Array) -> float:
+    ref = reference.astype(jnp.float32)
+    return float(jnp.linalg.norm(actual.astype(jnp.float32) - ref) / jnp.linalg.norm(ref))
+
+
+def test_grug_moe_fp8_dense_shared_expert_tracks_bf16():
+    model_module = importlib.import_module("experiments.grug.moe.model")
+    fp8_config = model_module.GrugFp8Config(amax_history_length=4)
+
+    with set_mesh(compact_grug_mesh(expert_axis_size=1, replica_axis_size=1)):
+        key = jax.random.PRNGKey(0)
+        bf16_mlp = jax.jit(lambda: model_module.DenseMLP.init(128, 64, 0.02, key=key))()
+        fp8_mlp = jax.jit(lambda: model_module.DenseMLP.init(128, 64, 0.02, key=key, fp8=fp8_config))()
+        x = jax.random.normal(jax.random.PRNGKey(1), (2, 8, 128), dtype=jnp.bfloat16)
+        y_bf16 = jax.jit(lambda m, x: m(x))(bf16_mlp, x)
+        y_fp8 = jax.jit(lambda m, x: m(x))(fp8_mlp, x)
+        # The weight-grad dot contracts the token-sharded dim; make sure the
+        # backward lowers and stays finite under the explicit mesh too.
+        grads = eqx.filter_jit(eqx.filter_grad(lambda m, x: jnp.sum(m(x).astype(jnp.float32) ** 2)))(fp8_mlp, x)
+
+    assert y_fp8.shape == y_bf16.shape
+    assert _rel_frobenius(y_fp8, y_bf16) < 0.1
+    assert all(bool(jnp.all(jnp.isfinite(leaf))) for leaf in jax.tree.leaves(eqx.filter(grads, eqx.is_array)))
+
+
+def test_grug_moe_fp8_dense_attention_tracks_bf16():
+    model_module = importlib.import_module("experiments.grug.moe.model")
+
+    def build_cfg(fp8):
+        cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=1024, seq_len=8)
+        return dataclasses.replace(cfg, fp8=fp8, hidden_dim=128, intermediate_dim=128)
+
+    with set_mesh(compact_grug_mesh(expert_axis_size=1, replica_axis_size=1)):
+        key = jax.random.PRNGKey(0)
+        bf16_cfg = build_cfg(None)
+        fp8_cfg = build_cfg(model_module.GrugFp8Config(amax_history_length=4))
+        bf16_attn = jax.jit(lambda: model_module.CausalSelfAttention.init(bf16_cfg, key=key))()
+        fp8_attn = jax.jit(lambda: model_module.CausalSelfAttention.init(fp8_cfg, key=key))()
+        x = jax.random.normal(jax.random.PRNGKey(1), (2, 8, 128), dtype=jnp.bfloat16)
+        mask = GrugAttentionMask.causal()
+        y_bf16 = jax.jit(lambda m, x: m(x, mask))(bf16_attn, x)
+        y_fp8 = jax.jit(lambda m, x: m(x, mask))(fp8_attn, x)
+        grads = eqx.filter_jit(eqx.filter_grad(lambda m, x: jnp.sum(m(x, mask).astype(jnp.float32) ** 2)))(fp8_attn, x)
+
+    assert y_fp8.shape == y_bf16.shape
+    assert _rel_frobenius(y_fp8, y_bf16) < 0.1
+    assert all(bool(jnp.all(jnp.isfinite(leaf))) for leaf in jax.tree.leaves(eqx.filter(grads, eqx.is_array)))
 
 
 def test_grug_moe_fp8_state_gets_no_optimizer_moments():

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -324,8 +324,10 @@ def test_grug_moe_fp8_config_threads_ops_into_expert_mlp():
         return model_module.Transformer.init(cfg, key=jax.random.PRNGKey(0))
 
     with _reset_abstract_mesh(), use_abstract_mesh(mesh):
-        fp8_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(amax_history_length=8))
-        gemm_only_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(wire=False))
+        # rev_dtype="e4m3" (uniform backward) so the op constructs on jax 0.10.x CPU
+        # CI; the threading/state contracts under test are dtype-recipe independent.
+        fp8_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(rev_dtype="e4m3", amax_history_length=8))
+        gemm_only_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(rev_dtype="e4m3", wire=False))
         bf16_model = eqx.filter_eval_shape(build, None)
 
     fp8_mlp = fp8_model.blocks[0].mlp.expert_mlp
@@ -353,8 +355,8 @@ def test_grug_moe_fp8_config_threads_dense_ops():
         return model_module.Transformer.init(cfg, key=jax.random.PRNGKey(0))
 
     with _reset_abstract_mesh(), use_abstract_mesh(mesh):
-        fp8_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(amax_history_length=8))
-        moe_only_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(dense=False))
+        fp8_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(rev_dtype="e4m3", amax_history_length=8))
+        moe_only_model = eqx.filter_eval_shape(build, model_module.GrugFp8Config(rev_dtype="e4m3", dense=False))
         bf16_model = eqx.filter_eval_shape(build, None)
 
     attn = fp8_model.blocks[0].attn
@@ -391,7 +393,7 @@ def _rel_frobenius(actual: jax.Array, reference: jax.Array) -> float:
 
 def test_grug_moe_fp8_dense_shared_expert_tracks_bf16():
     model_module = importlib.import_module("experiments.grug.moe.model")
-    fp8_config = model_module.GrugFp8Config(amax_history_length=4)
+    fp8_config = model_module.GrugFp8Config(rev_dtype="e4m3", amax_history_length=4)
 
     with set_mesh(compact_grug_mesh(expert_axis_size=1, replica_axis_size=1)):
         key = jax.random.PRNGKey(0)
@@ -419,7 +421,7 @@ def test_grug_moe_fp8_dense_attention_tracks_bf16():
     with set_mesh(compact_grug_mesh(expert_axis_size=1, replica_axis_size=1)):
         key = jax.random.PRNGKey(0)
         bf16_cfg = build_cfg(None)
-        fp8_cfg = build_cfg(model_module.GrugFp8Config(amax_history_length=4))
+        fp8_cfg = build_cfg(model_module.GrugFp8Config(rev_dtype="e4m3", amax_history_length=4))
         bf16_attn = jax.jit(lambda: model_module.CausalSelfAttention.init(bf16_cfg, key=key))()
         fp8_attn = jax.jit(lambda: model_module.CausalSelfAttention.init(fp8_cfg, key=key))()
         x = jax.random.normal(jax.random.PRNGKey(1), (2, 8, 128), dtype=jnp.bfloat16)
@@ -446,7 +448,7 @@ def test_grug_moe_fp8_state_gets_no_optimizer_moments():
         return train_module.initial_state(cfg, optimizer=optimizer, mp=mp, key=jax.random.PRNGKey(0), ema_beta=None)
 
     with _reset_abstract_mesh(), use_abstract_mesh(mesh):
-        fp8_state = eqx.filter_eval_shape(build, model_module.GrugFp8Config())
+        fp8_state = eqx.filter_eval_shape(build, model_module.GrugFp8Config(rev_dtype="e4m3"))
         bf16_state = eqx.filter_eval_shape(build, None)
 
     # The fp8 model carries extra quantization-state leaves in params, but none
@@ -461,7 +463,10 @@ def test_grug_moe_ema_update_carries_current_fp8_state():
 
     cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=64, seq_len=4)
     cfg = dataclasses.replace(
-        cfg, fp8=model_module.GrugFp8Config(amax_history_length=4), hidden_dim=128, intermediate_dim=128
+        cfg,
+        fp8=model_module.GrugFp8Config(rev_dtype="e4m3", amax_history_length=4),
+        hidden_dim=128,
+        intermediate_dim=128,
     )
 
     with set_mesh(compact_grug_mesh(expert_axis_size=1, replica_axis_size=1)):

--- a/tests/test_grug_variant_contracts.py
+++ b/tests/test_grug_variant_contracts.py
@@ -23,6 +23,7 @@ import jmp
 import optax
 import pytest
 from fray.cluster import ResourceConfig
+from haliax.partitioning import set_mesh
 from haliax.quantization import Fp8RaggedDotOp
 from jax._src import config as jax_config
 from jax.sharding import use_abstract_mesh
@@ -32,7 +33,7 @@ from levanter.data.text.datasets import DatasetComponent, DirectDatasetComponent
 from levanter.data.text.examples import GrugLmExample
 from levanter.distributed import DistributedConfig
 from levanter.grug.attention import AttentionMask as GrugAttentionMask
-from levanter.grug.sharding import _compact_grug_mesh_shape
+from levanter.grug.sharding import _compact_grug_mesh_shape, compact_grug_mesh
 from levanter.schedule import BatchSchedule
 from levanter.tracker.json_logger import JsonLoggerConfig
 from levanter.trainer import TrainerConfig
@@ -305,13 +306,21 @@ def test_grug_moe_variant_threads_moe_implementation_to_kernel():
     assert "ragged_all_to_all" in str(closed_jaxpr)
 
 
+def test_grug_moe_fp8_config_rejects_non_tile_aligned_dims():
+    model_module = importlib.import_module("experiments.grug.moe.model")
+    cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=1024, seq_len=4)
+    assert cfg.hidden_dim % 128 != 0, "fixture must violate the fp8 kernel's alignment contract"
+    with pytest.raises(ValueError, match="multiples of 128"):
+        dataclasses.replace(cfg, fp8=model_module.GrugFp8Config())
+
+
 def test_grug_moe_fp8_config_threads_ops_into_expert_mlp():
     model_module = importlib.import_module("experiments.grug.moe.model")
     mesh, _ = model_module.debug_mesh_and_token_pspec(num_devices=4)
 
     def build(fp8):
         cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=1024, seq_len=4)
-        cfg = dataclasses.replace(cfg, fp8=fp8)
+        cfg = dataclasses.replace(cfg, fp8=fp8, hidden_dim=128, intermediate_dim=128)
         return model_module.Transformer.init(cfg, key=jax.random.PRNGKey(0))
 
     with _reset_abstract_mesh(), use_abstract_mesh(mesh):
@@ -343,7 +352,7 @@ def test_grug_moe_fp8_state_gets_no_optimizer_moments():
 
     def build(fp8):
         cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=1024, seq_len=4)
-        cfg = dataclasses.replace(cfg, fp8=fp8)
+        cfg = dataclasses.replace(cfg, fp8=fp8, hidden_dim=128, intermediate_dim=128)
         return train_module.initial_state(cfg, optimizer=optimizer, mp=mp, key=jax.random.PRNGKey(0), ema_beta=None)
 
     with _reset_abstract_mesh(), use_abstract_mesh(mesh):
@@ -359,11 +368,11 @@ def test_grug_moe_fp8_state_gets_no_optimizer_moments():
 def test_grug_moe_ema_update_carries_current_fp8_state():
     train_module = importlib.import_module("experiments.grug.moe.train")
     model_module = importlib.import_module("experiments.grug.moe.model")
-    compact_grug_mesh = importlib.import_module("levanter.grug.sharding").compact_grug_mesh
-    set_mesh = importlib.import_module("haliax.partitioning").set_mesh
 
     cfg = _small_model_config(model_module.GrugModelConfig, vocab_size=64, seq_len=4)
-    cfg = dataclasses.replace(cfg, fp8=model_module.GrugFp8Config(amax_history_length=4))
+    cfg = dataclasses.replace(
+        cfg, fp8=model_module.GrugFp8Config(amax_history_length=4), hidden_dim=128, intermediate_dim=128
+    )
 
     with set_mesh(compact_grug_mesh(expert_axis_size=1, replica_axis_size=1)):
         old = jax.jit(lambda: model_module.Transformer.init(cfg, key=jax.random.PRNGKey(0)))()


### PR DESCRIPTION
Thread stateful FP8 ops into the grug MoE model — #6880's `Fp8RaggedDotOp` for the expert GEMMs and the merged `Fp8DotGeneralOp` (#6660) for the dense GEMMs — add opt-in FP8 over-the-wire collectives for the expert-parallel dispatch/combine, and wire everything up to a single `GrugModelConfig.fp8` switch with the matching train-step state handling. Everything is opt-in; defaults stay bf16.

- `MoEExpertMlp`/`moe_mlp` accept a `MoeRaggedDotOps` pair (`w13`/`w2`), threaded through the EP ring and `ragged_all_to_all` backends. Op state lives in the model pytree so delayed-scaling state flows through `partition_for_grad_overwrite`/`apply_updates`; a shard_map cotangent wrapper combines `OverwriteWithGradient` state as the max over shards (the global amax) while ordinary trainable leaves keep the psum.
- `fp8_wire.py`: E4M3-forward / E5M2-backward collectives for the permutation legs only — the dispatch `all_gather` and combine-transpose `all_gather` on ring, both `ragged_all_to_all` legs on a2a. Reductions stay native bf16: decomposing `psum_scatter` into fp8 `all_to_all` + local sum measured 0.885x against NCCL's hierarchical reduce-scatter. Quantization is current per-token — each row travels with its own scale — so no token's dequantized value depends on other sequence positions (a shared per-tensor scale would leak later-token amax through the causal mask).
- An `fp8_wire` flag from `MoEExpertMlp` through `moe_mlp` into both EP backends, rejected (like `ragged_dot_ops`) on meshes without an expert axis so a bf16 fallback can never run silently.
- Dense GEMMs: `CausalSelfAttention` carries per-projection `Fp8DotGeneralOp` state for q/k/v/o and the shared-expert `DenseMLP` for gate/up/down (`fp8.dense=False` opts out); the router, attention gate, GatedNorm, embedding, and lm-head stay full precision. The op's custom-VJP dots take no `out_sharding`, so each call runs under `auto_axes` with the output pinned to the spec the bf16 einsum produced — explicit mode would otherwise reject the model-sharded o/down forward contractions and every weight-grad dot. Dense dims are checked 16-aligned at config time (cuBLASLt's FP8 contract). On H100 the compiled train step lowers all dense GEMMs to `__cublas$lt$matmul$f8` for fwd/dgrad/wgrad — the 3D attention operands included, no flatten to 2D needed — alongside the Mosaic ragged kernels and the FP8 wire, with finite loss and updating amax histories.
- `GrugModelConfig.fp8: GrugFp8Config` builds the FP8 ops per layer and enables the FP8 wire (`wire=False` keeps the collectives bf16, `dense=False` keeps the dense GEMMs bf16), so a training run flips to FP8 with one config field.
- The moe train step partitions the ops' `OverwriteWithGradient` state out of the gradients: quantization state gets no optimizer moments, params update via `haliax.quantization.apply_updates`, and the EMA model carries the current step's quantization state instead of averaging amax histories. The dense ops are the same `OverwriteWithGradient` machinery, so they needed no train-step changes.

At the production d2560/E256/K4 shape the full MoE layer (GEMMs + wire) measures 1.53x vs bf16 at 2-node EP16 over InfiniBand on the ring backend (33.6 -> 22.0 ms/step; 1.65x on the a2a backend), with wire gradients within ~1e-1 rel-Frobenius of the bf16 wire. The dense op's isolated speedup is the merged #6660 measurement (+19% vs bf16 at d4096 forward); at this model's shape the step is expert-GEMM and comms dominated, so dense FP8 is primarily about covering every quantizable GEMM under the one switch. The remaining gate for flipping any default is loss-curve validation on a real training trajectory — which should now include a dense-FP8 arm — tracked in #6699.

Stacks on #6880 (`fp8-ragged-dot` is the base branch); commits after that base are new here.

Part of #6699.


`GrugFp8Config.rev_dtype` selects the expert-GEMM output-gradient dtype: the default `"e5m2"` is the numerically correct mixed backward (requires jax >= 0.11.0 via #6880's fail-fast guard); `"e4m3"` is the uniform approximation that also lowers on the current jax 0.10.1 pin.

Part of #6710.
