### PR TITLE
[iris] Don't let a stray IRIS_SIGNING_KEY become a cluster's identity

### DIFF
--- a/lib/finelog/config/marin-dev.yaml
+++ b/lib/finelog/config/marin-dev.yaml
@@ -17,11 +17,17 @@ deployment:
 # through the load balancer carries a Google front-end source address, falls past this
 # layer, and must present a token.
 #
-# The jwt layer admits the federated iris controllers that relay their logs here, each
-# by its own Ed25519 public key, verifying the aud="finelog" delegation token their
-# controller mints hourly. Only clusters that arrive over the load balancer need an
-# entry; marin-dev's own controller is admitted by cidr above. Cloud Armor narrows the
-# edge to those clusters' egress prefixes first (lib/iris/scripts/iap_gclb.py).
+# The jwt layer admits a federated iris controller that relays its logs here, by its own
+# Ed25519 public key, verifying the aud="finelog" delegation token that controller mints
+# hourly. Only a cluster arriving over the load balancer needs an entry; marin-dev's own
+# controller is admitted by cidr above. Cloud Armor narrows the edge to that cluster's
+# egress prefixes first (lib/iris/scripts/iap_gclb.py).
+#
+# No cluster relays here by default — marin's finelog is the federation's global sink, and
+# every CoreWeave `finelog.relay_address` names it. This entry keeps finelog-dev.oa.dev a
+# working target, so a change to the relay or to this auth stack can be rehearsed end to
+# end against a dev log server before it reaches prod. Point a cluster's relay_address at
+# finelog-dev.oa.dev to use it.
 auth:
   - type: cidr
     cidrs: [10.0.0.0/8, 172.16.0.0/12, 192.168.0.0/16, 127.0.0.0/8, "::1/128"]

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -198,11 +198,7 @@ def _config_search_paths(name_or_path: str) -> list[Path]:
 
 
 def find_finelog_config(name_or_path: str) -> Path | None:
-    """Return the path `name_or_path` resolves to, or None when no such config exists.
-
-    Callers that treat a finelog deployment as optional — not every iris cluster runs one —
-    use this to decide, rather than provoking :func:`load_finelog_config` into raising.
-    """
+    """Return the path `name_or_path` resolves to, or None when no such config exists."""
     return next((path for path in _config_search_paths(name_or_path) if path.is_file()), None)
 
 

--- a/lib/finelog/src/finelog/deploy/config.py
+++ b/lib/finelog/src/finelog/deploy/config.py
@@ -197,6 +197,15 @@ def _config_search_paths(name_or_path: str) -> list[Path]:
     ]
 
 
+def find_finelog_config(name_or_path: str) -> Path | None:
+    """Return the path `name_or_path` resolves to, or None when no such config exists.
+
+    Callers that treat a finelog deployment as optional — not every iris cluster runs one —
+    use this to decide, rather than provoking :func:`load_finelog_config` into raising.
+    """
+    return next((path for path in _config_search_paths(name_or_path) if path.is_file()), None)
+
+
 def _build_gcp(raw: dict) -> GcpDeployment:
     tags = raw.get("network_tags") or ()
     return GcpDeployment(
@@ -251,11 +260,10 @@ def load_finelog_config(name_or_path: str) -> FinelogConfig:
       2. `~/.config/marin/finelog/<name>.yaml`.
       3. Repo-bundled `lib/finelog/config/<name>.yaml`.
     """
-    candidates = _config_search_paths(name_or_path)
-    for path in candidates:
-        if path.is_file():
-            return _load_from_path(path)
-    searched = "\n  ".join(str(p) for p in candidates)
+    path = find_finelog_config(name_or_path)
+    if path is not None:
+        return _load_from_path(path)
+    searched = "\n  ".join(str(p) for p in _config_search_paths(name_or_path))
     raise FileNotFoundError(f"finelog config '{name_or_path}' not found; searched:\n  {searched}")
 
 

--- a/lib/iris/docs/coreweave.md
+++ b/lib/iris/docs/coreweave.md
@@ -179,8 +179,9 @@ pull model — CoreWeave must be reachable *inbound*; a peer behind NAT with no
 ingress is out of scope). The auth surface is two factors, both required and
 neither alone sufficient:
 
-1. **IP allowlist** — a Traefik `ipAllowList` Middleware admits only the marin
-   controller's egress IP. The *network* factor.
+1. **IP allowlist** — a Traefik `ipAllowList` Middleware admits only the egress IPs
+   of the marin-side controllers that federate here (`FEDERATION_ALLOW_SOURCES` in
+   `install_cw_network.py`). The *network* factor.
 2. **The controller's own auth** — the `aud="federation"` verifier for the handoff
    RPCs, the general auth chain for the rest. The *identity* factor.
 
@@ -243,14 +244,15 @@ its own unrestricted Ingress, so the IP allowlist does not block ACME validation
 - the same call **without** the JWT (controller enforcing) -> `UNAUTHENTICATED`.
 - the same call from a **non-allowlisted IP** -> refused (`403`).
 
-#### Stable egress IP for the marin controller
+#### Stable egress IPs for the marin controllers
 
-CoreWeave allowlists exactly one address, so the marin controller needs a
-**stable** egress IP. Its GCE VM (`iris-controller-marin`, zone `us-central1-a`,
-project `hai-gcp-models`) is created with an *ephemeral* external IP, which
-changes on stop/start. Make it stable **without touching the VM** by promoting
-that in-use address to a reserved static IP — same address, no access-config
-change, no restart:
+The allowlist names each federating controller by address, so every one of them
+needs a **stable** egress IP: `iris-controller-marin` and `iris-controller-marin-dev`,
+reserved as `iris-marin-fed-egress` and `iris-marin-dev-fed-egress`. A controller's
+GCE VM (zone `us-central1-a`, project `hai-gcp-models`) is created with an
+*ephemeral* external IP, which changes on stop/start. Make it stable **without
+touching the VM** by promoting that in-use address to a reserved static IP — same
+address, no access-config change, no restart:
 
 ```bash
 PROJECT=hai-gcp-models ZONE=us-central1-a REGION=us-central1 VM=iris-controller-marin
@@ -264,9 +266,12 @@ gcloud compute addresses create iris-marin-fed-egress --project "$PROJECT" \
   --region "$REGION" --addresses "$EGRESS_IP"
 ```
 
-Allowlist `$EGRESS_IP` in `--allow-source`. Reserving an in-use address is safe
-and reversible (`gcloud compute addresses delete iris-marin-fed-egress` releases
-it back to ephemeral). **Alternative** (only if the controller is later moved to
+Add `$EGRESS_IP` to `FEDERATION_ALLOW_SOURCES`, which is what `--allow-source`
+defaults to. The Middleware's `sourceRange` is replaced wholesale on every install
+rather than merged, so an install naming a subset strands the omitted controller at
+a `403` the peer never logs. Reserving an in-use address is safe and reversible
+(`gcloud compute addresses delete iris-marin-fed-egress` releases it back to
+ephemeral). **Alternative** (only if the controller is later moved to
 IAP-only inbound with *no* external IP, so egress goes through Cloud NAT): reserve
 a regional static IP and pin Cloud NAT to it (`gcloud compute routers nats update
 … --nat-external-ip-pool=iris-marin-fed-egress`). Removing the VM's external IP is

--- a/lib/iris/scripts/iap_gclb.py
+++ b/lib/iris/scripts/iap_gclb.py
@@ -92,7 +92,7 @@ from pathlib import Path
 
 import click
 import yaml
-from finelog.deploy.config import load_finelog_config
+from finelog.deploy.config import find_finelog_config, load_finelog_config
 
 logger = logging.getLogger("iap-gclb")
 
@@ -1823,20 +1823,13 @@ def status(cluster: str, project: str, zone: str, dry_run: bool, frontend_name: 
     """Report which resources exist for the shared frontend and the cluster's backend."""
     fe = Frontend(name=frontend_name, project=project)
     backend = Backend(cluster=cluster, project=project, zone=zone)
-    finelog = _finelog_backend(cluster=cluster, project=project, zone=zone)
+    # A cluster need not deploy a finelog; the ones that do not simply have no section to report.
+    finelog = _finelog_backend(cluster=cluster, project=project, zone=zone) if find_finelog_config(cluster) else None
     frontend_checks = [
         ("static IP", _compute(project, "addresses", "describe", fe.address, "--global")),
         ("URL map", _compute(project, "url-maps", "describe", fe.url_map, "--global")),
         ("HTTPS proxy", _compute(project, "target-https-proxies", "describe", fe.https_proxy, "--global")),
         ("forwarding rule", _compute(project, "forwarding-rules", "describe", fe.forwarding_rule, "--global")),
-    ]
-    finelog_checks = [
-        ("allow-LB firewall", _compute(project, "firewall-rules", "describe", finelog.allow_firewall)),
-        ("deny-public firewall", _compute(project, "firewall-rules", "describe", finelog.deny_firewall)),
-        ("NEG", _compute(project, "network-endpoint-groups", "describe", finelog.neg, f"--zone={zone}")),
-        ("health check", _compute(project, "health-checks", "describe", finelog.health_check, "--global")),
-        ("backend service", _compute(project, "backend-services", "describe", finelog.service, "--global")),
-        ("Cloud Armor policy", _compute(project, "security-policies", "describe", finelog.armor_policy)),
     ]
     backend_checks = [
         ("allow-LB firewall", _compute(project, "firewall-rules", "describe", backend.allow_firewall)),
@@ -1870,6 +1863,17 @@ def status(cluster: str, project: str, zone: str, dry_run: bool, frontend_name: 
     if audience:
         click.echo(f"  iap jwt aud : {audience}  (auth.iap.signed_header_audience)")
 
+    if finelog is None:
+        click.echo(f"finelog: no deploy config for {cluster}")
+        return
+    finelog_checks = [
+        ("allow-LB firewall", _compute(project, "firewall-rules", "describe", finelog.allow_firewall)),
+        ("deny-public firewall", _compute(project, "firewall-rules", "describe", finelog.deny_firewall)),
+        ("NEG", _compute(project, "network-endpoint-groups", "describe", finelog.neg, f"--zone={zone}")),
+        ("health check", _compute(project, "health-checks", "describe", finelog.health_check, "--global")),
+        ("backend service", _compute(project, "backend-services", "describe", finelog.service, "--global")),
+        ("Cloud Armor policy", _compute(project, "security-policies", "describe", finelog.armor_policy)),
+    ]
     click.echo(f"finelog {finelog.vm} (IAP-free; relay ingress):")
     for label, describe in finelog_checks:
         click.echo(f"  [{'OK ' if _exists(describe) else 'off '}] {label}")

--- a/lib/iris/scripts/iap_gclb.py
+++ b/lib/iris/scripts/iap_gclb.py
@@ -80,6 +80,7 @@ Usage:
 """
 
 import dataclasses
+import functools
 import json
 import logging
 import os
@@ -91,6 +92,7 @@ from pathlib import Path
 
 import click
 import yaml
+from finelog.deploy.config import load_finelog_config
 
 logger = logging.getLogger("iap-gclb")
 
@@ -116,9 +118,8 @@ SHARED_FRONTEND = "marin"
 GOOGLE_LB_RANGES = "130.211.0.0/22,35.191.0.0/16"
 IAP_ACCESSOR_ROLE = "roles/iap.httpsResourceAccessor"
 
-# The finelog log server's port on its own VM, and the GCE label ``finelog deploy``
-# stamps on that VM.
-FINELOG_PORT = 10001
+# The GCE label ``finelog deploy`` stamps on the VM it creates. The port finelog serves
+# is read from that cluster's finelog deploy config, which is where it is declared.
 FINELOG_LABEL_KEY = "finelog-name"
 
 # Every subnet of the ``default`` network sits inside this range, including the
@@ -264,9 +265,14 @@ class FinelogBackend:
 
     ``finelog deploy`` creates the VM as ``finelog-<cluster>`` and labels it
     ``finelog-name=<vm>``.
+
+    ``port`` is read from the cluster's finelog deploy config rather than assumed, so
+    the NEG endpoint, the health check and the firewall rules address the port finelog
+    actually serves.
     """
 
     cluster: str
+    port: int
     project: str = DEFAULT_PROJECT
     zone: str = DEFAULT_ZONE
     domain: str | None = None
@@ -307,7 +313,7 @@ class FinelogBackend:
 
     @property
     def deny_firewall(self) -> str:
-        return f"{self.vm}-deny-public-{FINELOG_PORT}"
+        return f"{self.vm}-deny-public-{self.port}"
 
     @property
     def cert(self) -> str:
@@ -1160,6 +1166,17 @@ def relay_source_ranges() -> list[str]:
     return ranges
 
 
+def _finelog_backend(*, cluster: str, project: str, zone: str, domain: str | None = None) -> FinelogBackend:
+    """Build a :class:`FinelogBackend`, reading the served port from the finelog config."""
+    return FinelogBackend(
+        cluster=cluster,
+        port=load_finelog_config(cluster).port,
+        project=project,
+        zone=zone,
+        domain=domain,
+    )
+
+
 def discover_finelog_ip(finelog: FinelogBackend) -> str:
     """Resolve the finelog VM's internal IP from the label ``finelog deploy`` set."""
     result = _run(
@@ -1204,7 +1221,7 @@ def ensure_finelog_allow_firewall(finelog: FinelogBackend, *, dry_run: bool) -> 
         project=finelog.project,
         name=finelog.allow_firewall,
         action="ALLOW",
-        port=FINELOG_PORT,
+        port=finelog.port,
         source_ranges=f"{VPC_PRIVATE_RANGE},{GOOGLE_LB_RANGES}",
         target_tag=finelog.tag,
         priority=FIREWALL_ALLOW_PRIORITY,
@@ -1224,7 +1241,7 @@ def ensure_finelog_deny_firewall(finelog: FinelogBackend, *, dry_run: bool) -> N
         project=finelog.project,
         name=finelog.deny_firewall,
         action="DENY",
-        port=FINELOG_PORT,
+        port=finelog.port,
         source_ranges="0.0.0.0/0",
         target_tag=finelog.tag,
         priority=FIREWALL_DENY_PRIORITY,
@@ -1744,7 +1761,7 @@ def finelog_cmd(
     and re-run; the allow rule is rewritten in place.
     """
     fe = Frontend(name=frontend_name, project=project)
-    finelog = FinelogBackend(cluster=cluster, project=project, zone=zone, domain=domain)
+    finelog = _finelog_backend(cluster=cluster, project=project, zone=zone, domain=domain)
     ranges = relay_source_ranges()
     vm_ip = finelog_ip or discover_finelog_ip(finelog)
 
@@ -1757,7 +1774,7 @@ def finelog_cmd(
         service=finelog.service,
         instance=finelog.vm,
         ip=vm_ip,
-        port=FINELOG_PORT,
+        port=finelog.port,
         dry_run=dry_run,
     )
     ensure_armor_policy(finelog, ranges, dry_run=dry_run)
@@ -1792,7 +1809,7 @@ def finelog_teardown_cmd(cluster: str, project: str, zone: str, dry_run: bool, f
     their path to it. Inverse of the ``finelog`` stage.
     """
     fe = Frontend(name=frontend_name, project=project)
-    finelog = FinelogBackend(cluster=cluster, project=project, zone=zone, domain=domain)
+    finelog = _finelog_backend(cluster=cluster, project=project, zone=zone, domain=domain)
     remove_finelog(fe, finelog, dry_run=dry_run)
     click.echo()
     click.echo(f"finelog {finelog.vm} is no longer reachable at https://{domain}.")
@@ -1806,7 +1823,7 @@ def status(cluster: str, project: str, zone: str, dry_run: bool, frontend_name: 
     """Report which resources exist for the shared frontend and the cluster's backend."""
     fe = Frontend(name=frontend_name, project=project)
     backend = Backend(cluster=cluster, project=project, zone=zone)
-    finelog = FinelogBackend(cluster=cluster, project=project, zone=zone)
+    finelog = _finelog_backend(cluster=cluster, project=project, zone=zone)
     frontend_checks = [
         ("static IP", _compute(project, "addresses", "describe", fe.address, "--global")),
         ("URL map", _compute(project, "url-maps", "describe", fe.url_map, "--global")),
@@ -1887,11 +1904,7 @@ def teardown(
     fe = Frontend(name=frontend_name, project=project)
     backend = Backend(cluster=cluster, project=project, zone=zone, domain=domain)
 
-    def _delete(label: str, cmd: Sequence[str]) -> None:
-        logger.info("→ deleting %s", label)
-        result = _run([*cmd, "--quiet"], dry_run=dry_run, check=False, capture=True)
-        if not dry_run and result.returncode != 0:
-            logger.info("  (skip: %s missing or already deleted)", label)
+    _delete = functools.partial(_delete_resource, dry_run=dry_run)
 
     # Drop this cluster's host route first so the URL map stops referencing it.
     if backend.cluster != frontend_name and _url_map_has_matcher(fe, backend.path_matcher):

--- a/lib/iris/scripts/iap_gclb.py
+++ b/lib/iris/scripts/iap_gclb.py
@@ -266,9 +266,8 @@ class FinelogBackend:
     ``finelog deploy`` creates the VM as ``finelog-<cluster>`` and labels it
     ``finelog-name=<vm>``.
 
-    ``port`` is read from the cluster's finelog deploy config rather than assumed, so
-    the NEG endpoint, the health check and the firewall rules address the port finelog
-    actually serves.
+    ``port`` is the port finelog serves, and addresses the NEG endpoint, the health check
+    and the firewall rules alike.
     """
 
     cluster: str

--- a/lib/iris/src/iris/cli/cluster.py
+++ b/lib/iris/src/iris/cli/cluster.py
@@ -354,12 +354,6 @@ def _create_secret_if_absent(client, project: str, name: str) -> None:
         click.echo(f"No permission to create {name}; adding a version to the existing secret.")
 
 
-def _add_signing_key_version(client, resource: str, private_pem: str) -> str:
-    """Add `private_pem` as a new version of `resource`; return that version's name."""
-    version = client.add_secret_version(request={"parent": resource, "payload": {"data": private_pem.encode("utf-8")}})
-    return version.name
-
-
 def _grant_secret_accessor(client, resource: str, name: str, accessor: str) -> None:
     """Grant `accessor` roles/secretmanager.secretAccessor on `resource`."""
     from google.api_core.exceptions import PermissionDenied  # noqa: PLC0415  # optional dep
@@ -454,7 +448,9 @@ def cluster_init_keys(out_file: Path | None, gcp_secret: str | None, accessor: s
         project, name = _split_secret_resource(gcp_secret)
         if reference is None:
             _create_secret_if_absent(client, project, name)
-            reference = f"gcp-secret://{_add_signing_key_version(client, gcp_secret, key.private_pem)}"
+            payload = {"data": key.private_pem.encode("utf-8")}
+            version = client.add_secret_version(request={"parent": gcp_secret, "payload": payload})
+            reference = f"gcp-secret://{version.name}"
             click.echo(f"Stored PRIVATE key in Secret Manager ({gcp_secret}).")
         if accessor is not None:
             _grant_secret_accessor(client, gcp_secret, name, accessor)

--- a/lib/iris/src/iris/cluster/platforms/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/controller.py
@@ -164,12 +164,6 @@ def _controller_env(config: IrisClusterConfig) -> dict[str, str]:
     as ``IRIS_SIGNING_KEY`` through the iris-controller-env Secret. The cluster config
     must therefore name ``env:IRIS_SIGNING_KEY`` among its references, so the pod reads
     the projected value instead of re-resolving a source it cannot reach.
-
-    That ``env:`` reference addresses the pod, not this deploy, so it is skipped here:
-    :func:`resolve_secret_spec` takes the first source that is present, and an
-    ``IRIS_SIGNING_KEY`` left over in the operator's shell would otherwise outrank the
-    pinned reference and be projected as the cluster's identity. A spec that names no
-    persistent source falls back to it, which is how an operator supplies the key directly.
     """
     if not _projects_controller_env_secret(config):
         return {}
@@ -182,6 +176,10 @@ def _controller_env(config: IrisClusterConfig) -> dict[str, str]:
             f"its key from the {CONTROLLER_ENV_SECRET_NAME} Secret, which this deploy populates by "
             f"resolving the remaining references in the operator's shell. Got {list(refs)}."
         )
+    # The env: reference addresses the pod, not this deploy, and resolve_secret_spec takes the
+    # first source that is present: an IRIS_SIGNING_KEY in the operator's shell must never
+    # outrank the pinned reference and become the cluster's identity. A spec that names no
+    # persistent source falls back to it, which is how an operator supplies the key directly.
     persistent = tuple(ref for ref in refs if ref != env_ref)
     return {SIGNING_KEY_ENV_VAR: resolve_secret_spec(persistent or refs).value}
 

--- a/lib/iris/src/iris/cluster/platforms/k8s/controller.py
+++ b/lib/iris/src/iris/cluster/platforms/k8s/controller.py
@@ -13,6 +13,7 @@ import logging
 import os
 import threading
 import time
+from collections.abc import Sequence
 from concurrent.futures import ThreadPoolExecutor
 from contextlib import AbstractContextManager
 from urllib.parse import urlparse
@@ -163,6 +164,12 @@ def _controller_env(config: IrisClusterConfig) -> dict[str, str]:
     as ``IRIS_SIGNING_KEY`` through the iris-controller-env Secret. The cluster config
     must therefore name ``env:IRIS_SIGNING_KEY`` among its references, so the pod reads
     the projected value instead of re-resolving a source it cannot reach.
+
+    That ``env:`` reference addresses the pod, not this deploy, so it is skipped here:
+    :func:`resolve_secret_spec` takes the first source that is present, and an
+    ``IRIS_SIGNING_KEY`` left over in the operator's shell would otherwise outrank the
+    pinned reference and be projected as the cluster's identity. A spec that names no
+    persistent source falls back to it, which is how an operator supplies the key directly.
     """
     if not _projects_controller_env_secret(config):
         return {}
@@ -175,7 +182,8 @@ def _controller_env(config: IrisClusterConfig) -> dict[str, str]:
             f"its key from the {CONTROLLER_ENV_SECRET_NAME} Secret, which this deploy populates by "
             f"resolving the remaining references in the operator's shell. Got {list(refs)}."
         )
-    return {SIGNING_KEY_ENV_VAR: resolve_secret_spec(refs).value}
+    persistent = tuple(ref for ref in refs if ref != env_ref)
+    return {SIGNING_KEY_ENV_VAR: resolve_secret_spec(persistent or refs).value}
 
 
 def _build_controller_deployment(
@@ -184,23 +192,22 @@ def _build_controller_deployment(
     image: str,
     port: int,
     node_selector: dict[str, str],
-    task_env_secret: bool = False,
-    controller_env_secret: bool = False,
+    env_from_secrets: Sequence[str] = (),
     fresh: bool = False,
     state_mount_path: str = _DEFAULT_STATE_MOUNT_PATH,
     local_state_hostpath: bool = False,
     checkpoint_interval_seconds: float = 0,
 ) -> dict:
-    """Build the controller Deployment manifest as a dict."""
+    """Build the controller Deployment manifest as a dict.
+
+    ``env_from_secrets`` names the Secrets the controller container sources its
+    environment from, in order.
+    """
     # The cluster default env (S3 storage auth + operator-injected vars) arrives via
     # the iris-task-env Secret, which task pods mount too; the controller's own
     # credentials arrive via iris-controller-env, which they do not. optional=true so
     # a controller-only restart that predates either Secret does not crash-loop.
-    env_from: list[dict] = []
-    if task_env_secret:
-        env_from.append({"secretRef": {"name": TASK_ENV_SECRET_NAME, "optional": True}})
-    if controller_env_secret:
-        env_from.append({"secretRef": {"name": CONTROLLER_ENV_SECRET_NAME, "optional": True}})
+    env_from = [{"secretRef": {"name": secret, "optional": True}} for secret in env_from_secrets]
     # Reserve controller CPU/memory so Kubernetes doesn't classify this Pod as
     # BestEffort. Only memory has a limit, so the Pod is Burstable (not
     # Guaranteed): the controller can burst onto spare node CPU during reconcile
@@ -446,13 +453,20 @@ class K8sControllerProvider:
             self._kubectl.apply_json(_build_controller_state_pvc(namespace=self._namespace))
             logger.info("PersistentVolumeClaim %s applied", _CONTROLLER_STATE_PVC_NAME)
 
+        env_from_secrets = [
+            secret
+            for secret, projected in (
+                (TASK_ENV_SECRET_NAME, projects_task_env_secret(config)),
+                (CONTROLLER_ENV_SECRET_NAME, _projects_controller_env_secret(config)),
+            )
+            if projected
+        ]
         deploy_kwargs = dict(
             namespace=self._namespace,
             image=config.controller.image,
             port=port,
             node_selector={self._iris_labels.iris_scale_group: cw.scale_group},
-            task_env_secret=projects_task_env_secret(config),
-            controller_env_secret=_projects_controller_env_secret(config),
+            env_from_secrets=env_from_secrets,
             state_mount_path=state_mount_path,
             local_state_hostpath=local_state_hostpath,
             checkpoint_interval_seconds=config.controller.checkpoint_interval_seconds,

--- a/lib/iris/tests/e2e/gpu_gang_smoke.py
+++ b/lib/iris/tests/e2e/gpu_gang_smoke.py
@@ -231,7 +231,6 @@ class ControllerTarget:
             image=cfg.controller.image,
             port=port,
             node_selector=node_selector,
-            task_env_secret=False,
             fresh=False,
         )
         if local_image:


### PR DESCRIPTION
A Kubernetes cluster's `auth.signing_key` lists `env:IRIS_SIGNING_KEY` ahead of its `gcp-secret://` reference, because that env var is where the controller pod reads the key the deploy projects for it. But `_controller_env` resolved the whole list, and `resolve_secret_spec` takes the first source that is *present*. An `IRIS_SIGNING_KEY` left over in the operator's shell therefore outranked the pinned Secret Manager version and was projected into `iris-controller-env` as the cluster's identity — silently, at deploy time. The controller would then sign its `aud="federation"` and `aud="finelog"` tokens with a key no peer trusts, and every handoff and log relay would fail authentication with nothing pointing back at the deploying shell.

Reproduced against the shipped `cw-rno2a` config: with `IRIS_SIGNING_KEY` set to any value, that value is what reaches the Secret. The docstring already described the intended behavior — "resolving the *remaining* references" — so this is the code catching up to it.

The `env:` reference addresses the pod, not the deploy, so it is skipped when resolving. A spec that names no persistent source still falls back to it, which is how an operator supplies the key directly.

The rest addresses the lint review of #7064, which finished after that PR merged:

- `iap_gclb.py` assumed finelog listens on 10001 while `lib/finelog/config/<cluster>.yaml` declares `port:` as a required knob. The NEG endpoint, health check and firewall rules now read it from that config. Verified as a no-op against live prod: every resource still reports already-exists, including `finelog-marin-deny-public-10001`, whose name embeds the port.
- `teardown` carried a byte-identical copy of `_delete_resource` as a local closure; it now uses the helper.
- `_build_controller_deployment` took two presence-bools that only ever built a list of Secret names. It takes the `Sequence[str]` they encoded.
- `_add_signing_key_version` was a single-caller wrapper around `client.add_secret_version`.
- `lib/iris/docs/coreweave.md` still said the federation ingress "admits only the marin controller's egress IP" and that "CoreWeave allowlists exactly one address". Both were true until `FEDERATION_ALLOW_SOURCES` grew the marin-dev egress, and the second was the belief that stranded marin-dev at a 403.
- `lib/finelog/config/marin-dev.yaml`'s `jwt` layer trusts cw-rno2a, but no cluster's `relay_address` names marin-dev any more. The layer is kept deliberately — `finelog-dev.oa.dev` is the target a relay or auth-stack change can be rehearsed against before prod — and the comment now says so instead of implying a relay arrives there.
