### PR TITLE
[iris] Stop setup after dependency sync failure

### DIFF
--- a/lib/iris/src/iris/cluster/setup_scripts.py
+++ b/lib/iris/src/iris/cluster/setup_scripts.py
@@ -104,6 +104,7 @@ def default_setup_script(
     )
 
     lines = [
+        "set -e",
         'cd "$IRIS_WORKDIR"',
         "echo 'syncing deps'",
         sync_cmd,


### PR DESCRIPTION
Make Iris's generated default setup script exit immediately when uv sync or a subsequent build command fails. This prevents the trailing rust-dev conditional from masking dependency setup failures and allowing tasks to start in a partial virtual environment, where they surface misleading import errors such as a missing zephyr module.