### PR TITLE
[TPU] Pin vLLM without default Rust artifacts

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,8 +171,8 @@ harbor = { git = "https://github.com/marin-community/harbor.git", rev = "354692d
 # if this is a fixed-base overlay PR, then follow
 # .agents/skills/refresh-tpu-vllm-forks/docs/overlay-only-pr.md. PR-head SHAs are
 # temporary and must be replaced by the landed fork main SHA.
-# https://github.com/marin-community/vllm/compare/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c...912fb118c18c2eb8143a188ddb31838202bd8521
-vllm = { git = "https://github.com/marin-community/vllm.git", rev = "912fb118c18c2eb8143a188ddb31838202bd8521" }
+# https://github.com/marin-community/vllm/compare/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c...96e34a877839ff7508cf174d4fa2ab62e6a43a21
+vllm = { git = "https://github.com/marin-community/vllm.git", rev = "96e34a877839ff7508cf174d4fa2ab62e6a43a21" }
 # https://github.com/marin-community/tpu-inference/compare/23d17a8120d9cc34890135599f42e1db4f947c10...734d2842aa883c8f7bcff87a4b437a366f3adbc0
 tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "734d2842aa883c8f7bcff87a4b437a366f3adbc0" }
 # ### BEGIN RUST-DEV SOURCES ###

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -171,8 +171,8 @@ harbor = { git = "https://github.com/marin-community/harbor.git", rev = "354692d
 # if this is a fixed-base overlay PR, then follow
 # .agents/skills/refresh-tpu-vllm-forks/docs/overlay-only-pr.md. PR-head SHAs are
 # temporary and must be replaced by the landed fork main SHA.
-# https://github.com/marin-community/vllm/compare/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c...96e34a877839ff7508cf174d4fa2ab62e6a43a21
-vllm = { git = "https://github.com/marin-community/vllm.git", rev = "96e34a877839ff7508cf174d4fa2ab62e6a43a21" }
+# https://github.com/marin-community/vllm/compare/a30addc7548a9a8b9b3323a7bc3eb7d7c4895d1c...82b5c9be5cef68503d7cf1588aca869cbbcc78ac
+vllm = { git = "https://github.com/marin-community/vllm.git", rev = "82b5c9be5cef68503d7cf1588aca869cbbcc78ac" }
 # https://github.com/marin-community/tpu-inference/compare/23d17a8120d9cc34890135599f42e1db4f947c10...734d2842aa883c8f7bcff87a4b437a366f3adbc0
 tpu-inference = { git = "https://github.com/marin-community/tpu-inference.git", rev = "734d2842aa883c8f7bcff87a4b437a366f3adbc0" }
 # ### BEGIN RUST-DEV SOURCES ###

--- a/uv.lock
+++ b/uv.lock
@@ -4698,7 +4698,7 @@ requires-dist = [
     { name = "transformers", specifier = ">=5.5.3,<6.0" },
     { name = "triton", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=3.6.0,<3.7" },
     { name = "verifiers", marker = "extra == 'rl'", specifier = "==0.1.5" },
-    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=912fb118c18c2eb8143a188ddb31838202bd8521" },
+    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=96e34a877839ff7508cf174d4fa2ab62e6a43a21" },
     { name = "wandb", specifier = ">0.24.0" },
 ]
 provides-extras = ["gpu", "tpu", "cpu", "rl", "eval", "evalchemy", "vizier", "vllm", "harbor", "dedup", "datakit", "math"]
@@ -11296,8 +11296,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.20.1rc1.dev1460+g912fb118c.tpu"
-source = { git = "https://github.com/marin-community/vllm.git?rev=912fb118c18c2eb8143a188ddb31838202bd8521#912fb118c18c2eb8143a188ddb31838202bd8521" }
+version = "0.20.1rc1.dev1461+g96e34a877.tpu"
+source = { git = "https://github.com/marin-community/vllm.git?rev=96e34a877839ff7508cf174d4fa2ab62e6a43a21#96e34a877839ff7508cf174d4fa2ab62e6a43a21" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },

--- a/uv.lock
+++ b/uv.lock
@@ -4698,7 +4698,7 @@ requires-dist = [
     { name = "transformers", specifier = ">=5.5.3,<6.0" },
     { name = "triton", marker = "sys_platform == 'linux' and extra == 'gpu'", specifier = ">=3.6.0,<3.7" },
     { name = "verifiers", marker = "extra == 'rl'", specifier = "==0.1.5" },
-    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=96e34a877839ff7508cf174d4fa2ab62e6a43a21" },
+    { name = "vllm", marker = "extra == 'vllm'", git = "https://github.com/marin-community/vllm.git?rev=82b5c9be5cef68503d7cf1588aca869cbbcc78ac" },
     { name = "wandb", specifier = ">0.24.0" },
 ]
 provides-extras = ["gpu", "tpu", "cpu", "rl", "eval", "evalchemy", "vizier", "vllm", "harbor", "dedup", "datakit", "math"]
@@ -11296,8 +11296,8 @@ wheels = [
 
 [[package]]
 name = "vllm"
-version = "0.20.1rc1.dev1461+g96e34a877.tpu"
-source = { git = "https://github.com/marin-community/vllm.git?rev=96e34a877839ff7508cf174d4fa2ab62e6a43a21#96e34a877839ff7508cf174d4fa2ab62e6a43a21" }
+version = "0.20.1rc1.dev1461+g82b5c9be5.tpu"
+source = { git = "https://github.com/marin-community/vllm.git?rev=82b5c9be5cef68503d7cf1588aca869cbbcc78ac#82b5c9be5cef68503d7cf1588aca869cbbcc78ac" }
 dependencies = [
     { name = "aiohttp" },
     { name = "anthropic" },


### PR DESCRIPTION
Pin the landed [marin-community/vllm#9](https://github.com/marin-community/vllm/pull/9) overlay from fork `main`. TPU builds now skip `vllm-rs` and `_rust_tool_parser` by default while preserving the existing `VLLM_REQUIRE_RUST_FRONTEND=1` opt-in.

This replaces the temporary PR-head SHA used for TPU validation with squash commit `82b5c9be5cef68503d7cf1588aca869cbbcc78ac`.
