### PR TITLE
datakit: shard the ghalogs zenodo download into ranged zephyr tasks with server-side concat

### DIFF
--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -18,7 +18,7 @@ from contextlib import ExitStack
 from dataclasses import dataclass
 from enum import StrEnum, auto
 from io import BytesIO
-from typing import IO
+from typing import IO, NamedTuple
 
 import fsspec
 import requests
@@ -87,7 +87,7 @@ _DOWNLOAD_TIMEOUT = 300
 # GHALogs archive is ~142 GB; stream it in large chunks straight to the object
 # store without buffering the whole file locally.
 _GHALOGS_HTTP_CHUNK_BYTES = 64 * 1024 * 1024
-_GHALOGS_S3_BLOCK_BYTES = 256 * 1024 * 1024  # multipart part size (~558 parts)
+_GHALOGS_S3_BLOCK_BYTES = 256 * 1024 * 1024  # multipart upload part size (~17 parts per ~4.4 GB shard)
 _GHALOGS_LOG_EVERY_BYTES = 4 * 1024 * 1024 * 1024  # progress line every ~4 GB
 _GHALOGS_DOWNLOAD_TIMEOUT = (30, 600)  # (connect, read) seconds
 # The archive is downloaded as independent byte-range shards (zephyr tasks)
@@ -1089,17 +1089,25 @@ def _stream_range_resumable(session: requests.Session, out: IO[bytes], start: in
     return written
 
 
-def _ghalogs_shard_ranges(total_bytes: int, num_shards: int) -> list[tuple[int, int, int]]:
-    """Split ``[0, total_bytes)`` into up to ``num_shards`` contiguous ``(index, start, stop)`` ranges."""
+class _ShardRange(NamedTuple):
+    """One contiguous byte range ``[start, stop)`` of the archive, downloaded as its own zephyr task."""
+
+    index: int
+    start: int
+    stop: int
+
+
+def _ghalogs_shard_ranges(total_bytes: int, num_shards: int) -> list[_ShardRange]:
+    """Split ``[0, total_bytes)`` into up to ``num_shards`` contiguous ranges."""
     bounds = [total_bytes * i // num_shards for i in range(num_shards + 1)]
-    return [(i, bounds[i], bounds[i + 1]) for i in range(num_shards) if bounds[i] < bounds[i + 1]]
+    return [_ShardRange(i, bounds[i], bounds[i + 1]) for i in range(num_shards) if bounds[i] < bounds[i + 1]]
 
 
 def _ghalogs_part_path(parts_prefix: str, index: int) -> str:
     return prefix_join(parts_prefix, f"part-{index:05d}")
 
 
-def _download_ghalogs_shard(parts_prefix: str, shard: tuple[int, int, int]) -> str:
+def _download_ghalogs_shard(parts_prefix: str, shard: _ShardRange) -> str:
     """Download one byte range of the archive to its part object (idempotent).
 
     A part already present at its exact range length is reused, so a retried

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -1206,7 +1206,7 @@ def stage_ghalogs_archive(
     if total != GHALOGS_ARCHIVE_BYTES:
         fs.rm(path)
         raise RuntimeError(f"GHALogs archive size mismatch after merge: got {total}, expected {GHALOGS_ARCHIVE_BYTES}")
-    fs.rm(f"{path}.parts", recursive=True)
+    fs.rm(parts_prefix, recursive=True)
     logger.info("Staged GHALogs archive: %d bytes -> %s", total, archive_path)
 
 

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -25,7 +25,15 @@ import requests
 from fray.types import ResourceConfig
 from fsspec.implementations.local import LocalFileSystem
 from pydantic import BaseModel, ConfigDict
-from rigging.filesystem import StoragePath, atomic_rename, marin_prefix, open_url, prefix_join, url_to_fs
+from rigging.filesystem import (
+    StoragePath,
+    atomic_rename,
+    marin_prefix,
+    marin_temp_bucket,
+    open_url,
+    prefix_join,
+    url_to_fs,
+)
 from zephyr import counters
 from zephyr.dataset import Dataset
 from zephyr.execution import ZephyrContext
@@ -98,6 +106,10 @@ _GHALOGS_DOWNLOAD_SHARDS = 32
 # uneven (~1-17 MB/s observed), so parallel shards both add bandwidth and limit
 # the damage of an unlucky slow connection to a single shard.
 _GHALOGS_DOWNLOAD_MAX_WORKERS = 8
+# Lifecycle TTL on the parts prefix: long enough to cover realistic retry
+# windows after a failed staging run, bounded so an abandoned run cannot
+# strand ~142 GB of parts indefinitely.
+_GHALOGS_PARTS_TTL_DAYS = 7
 # A long stream reliably breaks mid-body (server-side idle/connection resets);
 # Zenodo serves the archive with Accept-Ranges: bytes, so each shard resumes
 # from its last written offset instead of restarting from zero. Give up only
@@ -1025,6 +1037,26 @@ def _ghalogs_shard_ranges(total_bytes: int, num_shards: int) -> list[_ShardRange
     return [_ShardRange(bounds[i], bounds[i + 1]) for i in range(num_shards) if bounds[i] < bounds[i + 1]]
 
 
+def _ghalogs_parts_prefix(archive_path: str) -> str:
+    """Return the prefix holding the range parts while staging ``archive_path``.
+
+    Parts go to the bucket's ``tmp/ttl=Nd/`` lifecycle prefix so a failed run
+    that is never retried cannot strand ~142 GB of parts; retries within the
+    TTL still reuse completed parts. The prefix must share the archive's bucket
+    (GCS compose cannot cross buckets), so when the temp helper cannot place it
+    there — local paths in tests, buckets outside the marin config — parts fall
+    back to a ``.parts`` sibling of the archive instead.
+    """
+    parsed = StoragePath.parse(archive_path)
+    if parsed.scheme in ("gs", "s3") and parsed.bucket:
+        temp_prefix = marin_temp_bucket(
+            _GHALOGS_PARTS_TTL_DAYS, prefix=f"ghalogs-parts/{parsed.key}", source_prefix=archive_path
+        )
+        if StoragePath.parse(temp_prefix).bucket == parsed.bucket:
+            return temp_prefix
+    return f"{archive_path}.parts"
+
+
 def _ghalogs_part_path(parts_prefix: str, shard: _ShardRange) -> str:
     # Zero-padded starts keep lexicographic order equal to byte order, and the
     # explicit range means a part left behind by a different shard layout has a
@@ -1144,10 +1176,11 @@ def stage_ghalogs_archive(
     as independent zephyr tasks — each resuming across mid-stream drops (see
     :func:`_iter_ghalogs_range`) — then assembled server-side into
     ``{output_path}/{GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH}``, the path
-    :func:`materialize_ghalogs_to_parquet` reads from. Parts publish through an
-    atomic rename and re-runs skip existing ones, so a worker/pod death costs
-    at most the shards in flight. Idempotent: a correctly-sized copy is left
-    untouched, and a partial download never becomes the published archive.
+    :func:`materialize_ghalogs_to_parquet` reads from. Parts live on the
+    bucket's TTL'd temp prefix, publish through an atomic rename, and re-runs
+    skip existing ones, so a worker/pod death costs at most the shards in
+    flight. Idempotent: a correctly-sized copy is left untouched, and a partial
+    download never becomes the published archive.
     """
     # Enforced up front: a shard count the merge cannot handle would otherwise
     # only fail after the full archive has been downloaded.
@@ -1160,10 +1193,10 @@ def stage_ghalogs_archive(
         logger.info("GHALogs archive already staged (%d bytes): %s", GHALOGS_ARCHIVE_BYTES, archive_path)
         return
 
-    # Parts must live in the same bucket as the archive (GCS compose cannot
-    # cross buckets). They sit next to the final object and are removed after
-    # a successful merge; a failed run leaves them for the next run to reuse.
-    parts_prefix = f"{archive_path}.parts"
+    # Parts are removed after a successful merge; a failed run leaves them for
+    # the next run to reuse, and the temp prefix's TTL sweeps them if that run
+    # never comes (see _ghalogs_parts_prefix).
+    parts_prefix = _ghalogs_parts_prefix(archive_path)
     shards = _ghalogs_shard_ranges(GHALOGS_ARCHIVE_BYTES, num_shards)
     logger.info(
         "Staging %s -> %s: %d bytes as %d range shards",

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -1133,20 +1133,20 @@ def _download_ghalogs_shard(parts_prefix: str, shard: _ShardRange) -> str:
 
 
 def _concat_parts_server_side(fs: fsspec.AbstractFileSystem, target: str, parts: list[str]) -> None:
-    """Assemble ``target`` from ``parts`` without streaming bytes through this process.
+    """Assemble ``target`` from ``parts`` in order, without streaming bytes through this process.
 
-    Object stores concatenate server-side via ``fs.merge`` — S3 UploadPartCopy
-    on R2/CoreWeave, compose on GCS — and materialize the target atomically on
-    completion. The local filesystem (tests) has no such primitive, so parts
-    are byte-appended and published with an atomic rename.
+    ``target`` appears only once fully assembled; the source parts are left in place.
     """
     if isinstance(fs, LocalFileSystem):
+        # No server to concatenate on: byte-append, publish with an atomic rename.
         with atomic_rename(target, fs=fs) as tmp:
             with fs.open(tmp, "wb") as out:
                 for part in parts:
                     with fs.open(part, "rb") as src:
                         shutil.copyfileobj(src, out, _GHALOGS_HTTP_CHUNK_BYTES)
         return
+    # Server-side concat — S3 UploadPartCopy on R2/CoreWeave, compose on GCS —
+    # which materializes the target atomically on completion.
     fs.merge(target, parts)
 
 

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -1172,15 +1172,13 @@ def stage_ghalogs_archive(
 ) -> None:
     """Stage the ~142 GB GHALogs Zenodo archive under ``output_path`` (idempotent).
 
-    The archive is split into ``num_shards`` contiguous byte ranges downloaded
-    as independent zephyr tasks — each resuming across mid-stream drops (see
-    :func:`_iter_ghalogs_range`) — then assembled server-side into
+    The archive is downloaded as ``num_shards`` byte-range shards (independent
+    zephyr tasks) and assembled server-side into
     ``{output_path}/{GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH}``, the path
-    :func:`materialize_ghalogs_to_parquet` reads from. Parts live on the
-    bucket's TTL'd temp prefix, publish through an atomic rename, and re-runs
-    skip existing ones, so a worker/pod death costs at most the shards in
-    flight. Idempotent: a correctly-sized copy is left untouched, and a partial
-    download never becomes the published archive.
+    :func:`materialize_ghalogs_to_parquet` reads from. A worker/pod death costs
+    at most the shards in flight: re-runs reuse completed parts. Idempotent: a
+    correctly-sized copy is left untouched, and a partial download never
+    becomes the published archive.
     """
     # Enforced up front: a shard count the merge cannot handle would otherwise
     # only fail after the full archive has been downloaded.

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -1132,8 +1132,8 @@ def _download_ghalogs_shard(parts_prefix: str, shard: _ShardRange) -> str:
     return part_path
 
 
-def _concat_parts_server_side(fs: fsspec.AbstractFileSystem, target: str, parts: list[str]) -> None:
-    """Assemble ``target`` from ``parts`` in order, without streaming bytes through this process.
+def _concat_archive_parts(fs: fsspec.AbstractFileSystem, target: str, parts: list[str]) -> None:
+    """Assemble ``target`` from ``parts`` in order.
 
     ``target`` appears only once fully assembled; the source parts are left in place.
     """
@@ -1200,7 +1200,7 @@ def stage_ghalogs_archive(
     # Parts are zero-padded so lexicographic order is range order; every shard
     # verified its part's exact size before returning it.
     part_paths = sorted(outcome.results)
-    _concat_parts_server_side(fs, archive_path, part_paths)
+    _concat_archive_parts(fs, archive_path, part_paths)
     fs.invalidate_cache(os.path.dirname(path))  # exists() above may have cached the target as absent
     total = fs.size(path)
     if total != GHALOGS_ARCHIVE_BYTES:

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -18,7 +18,7 @@ from contextlib import ExitStack
 from dataclasses import dataclass
 from enum import StrEnum, auto
 from io import BytesIO
-from typing import IO, NamedTuple
+from typing import NamedTuple
 
 import fsspec
 import requests
@@ -87,7 +87,6 @@ _DOWNLOAD_TIMEOUT = 300
 # GHALogs archive is ~142 GB; stream it in large chunks straight to the object
 # store without buffering the whole file locally.
 _GHALOGS_HTTP_CHUNK_BYTES = 64 * 1024 * 1024
-_GHALOGS_S3_BLOCK_BYTES = 256 * 1024 * 1024  # multipart upload part size (~17 parts per ~4.4 GB shard)
 _GHALOGS_LOG_EVERY_BYTES = 4 * 1024 * 1024 * 1024  # progress line every ~4 GB
 _GHALOGS_DOWNLOAD_TIMEOUT = (30, 600)  # (connect, read) seconds
 # The archive is downloaded as independent byte-range shards (zephyr tasks)
@@ -1013,17 +1012,39 @@ def extract_ghalogs_step(
     )
 
 
-def _stream_range_resumable(session: requests.Session, out: IO[bytes], start: int, stop: int) -> int:
-    """Stream bytes ``[start, stop)`` of ``GHALOGS_DOWNLOAD_URL`` into ``out``.
+class _ShardRange(NamedTuple):
+    """One contiguous byte range ``[start, stop)`` of the archive, downloaded as its own zephyr task."""
+
+    start: int
+    stop: int
+
+
+def _ghalogs_shard_ranges(total_bytes: int, num_shards: int) -> list[_ShardRange]:
+    """Split ``[0, total_bytes)`` into up to ``num_shards`` contiguous ranges."""
+    bounds = [total_bytes * i // num_shards for i in range(num_shards + 1)]
+    return [_ShardRange(bounds[i], bounds[i + 1]) for i in range(num_shards) if bounds[i] < bounds[i + 1]]
+
+
+def _ghalogs_part_path(parts_prefix: str, shard: _ShardRange) -> str:
+    # Zero-padded starts keep lexicographic order equal to byte order, and the
+    # explicit range means a part left behind by a different shard layout has a
+    # different name — it can never be mistaken for a completed current part.
+    return prefix_join(parts_prefix, f"part-{shard.start:012d}-{shard.stop:012d}")
+
+
+def _iter_ghalogs_range(shard: _ShardRange) -> Iterator[bytes]:
+    """Yield bytes ``[shard.start, shard.stop)`` of ``GHALOGS_DOWNLOAD_URL``.
 
     Resumes across mid-stream drops via HTTP Range: on any mid-body failure or
     early EOF it re-requests ``Range: bytes={start + written}-{stop - 1}`` and
-    keeps appending to ``out`` rather than restarting the range. Returns the
-    bytes written, which is short of ``stop - start`` only when the server has
-    less data than declared (a ranged request past the last byte returns 416).
-    Raises if the download stalls without progress or a reply ignores Range.
+    keeps yielding from there rather than restarting the range. Raises if the
+    download stalls without progress, if a reply ignores Range, or if the
+    server delivers fewer bytes than the range length (a ranged request past
+    the last byte returns 416).
     """
+    start, stop = shard
     length = stop - start
+    session = build_retrying_session()
     written = 0
     next_log = _GHALOGS_LOG_EVERY_BYTES
     stalls = 0
@@ -1035,9 +1056,8 @@ def _stream_range_resumable(session: requests.Session, out: IO[bytes], start: in
             with session.get(
                 GHALOGS_DOWNLOAD_URL, stream=True, headers=headers, timeout=_GHALOGS_DOWNLOAD_TIMEOUT
             ) as response:
-                # A ranged request past the last byte returns 416: the server has
-                # nothing more to send. Stop and let the caller's size check flag
-                # the shortfall against the declared archive size.
+                # A ranged request past the last byte returns 416: the server
+                # has nothing more to send, so the shortfall check below fires.
                 if response.status_code == http.client.REQUESTED_RANGE_NOT_SATISFIABLE:
                     break
                 response.raise_for_status()
@@ -1052,7 +1072,7 @@ def _stream_range_resumable(session: requests.Session, out: IO[bytes], start: in
                 for chunk in response.iter_content(chunk_size=_GHALOGS_HTTP_CHUNK_BYTES):
                     if not chunk:
                         continue
-                    out.write(chunk)
+                    yield chunk
                     written += len(chunk)
                     if written >= next_log:
                         logger.info("range %d-%d: %.1f / %.1f GB", start, stop - 1, written / 1e9, length / 1e9)
@@ -1060,7 +1080,7 @@ def _stream_range_resumable(session: requests.Session, out: IO[bytes], start: in
         except (requests.exceptions.RequestException, http.client.IncompleteRead) as e:
             error = e
 
-        # Gate on bytes written this attempt, not on whether an exception fired:
+        # Gate on bytes yielded this attempt, not on whether an exception fired:
         # a clean response that yields zero bytes at the current offset (empty
         # body, early close) makes no progress either and must route through the
         # stall budget, or the outer loop would re-request the same offset forever.
@@ -1086,50 +1106,11 @@ def _stream_range_resumable(session: requests.Session, out: IO[bytes], start: in
             error,
         )
         time.sleep(backoff)
-    return written
-
-
-class _ShardRange(NamedTuple):
-    """One contiguous byte range ``[start, stop)`` of the archive, downloaded as its own zephyr task."""
-
-    index: int
-    start: int
-    stop: int
-
-
-def _ghalogs_shard_ranges(total_bytes: int, num_shards: int) -> list[_ShardRange]:
-    """Split ``[0, total_bytes)`` into up to ``num_shards`` contiguous ranges."""
-    bounds = [total_bytes * i // num_shards for i in range(num_shards + 1)]
-    return [_ShardRange(i, bounds[i], bounds[i + 1]) for i in range(num_shards) if bounds[i] < bounds[i + 1]]
-
-
-def _ghalogs_part_path(parts_prefix: str, index: int) -> str:
-    return prefix_join(parts_prefix, f"part-{index:05d}")
-
-
-def _download_ghalogs_shard(parts_prefix: str, shard: _ShardRange) -> str:
-    """Download one byte range of the archive to its part object (idempotent).
-
-    A part already present at its exact range length is reused, so a retried
-    shard or a re-run staging job only re-downloads missing or partial parts.
-    """
-    index, start, stop = shard
-    part_path = _ghalogs_part_path(parts_prefix, index)
-    length = stop - start
-    fs, path = url_to_fs(part_path)
-    if fs.exists(path) and fs.size(path) == length:
-        counters.pipeline.update_counter("ghalogs_stage/parts_reused", 1)
-        return part_path
-    session = build_retrying_session()
-    with fs.open(path, "wb", block_size=_GHALOGS_S3_BLOCK_BYTES) as out:
-        written = _stream_range_resumable(session, out, start, stop)
+    # Raising here aborts the surrounding write before it publishes, so a short
+    # range never becomes a completed part.
     if written != length:
-        raise RuntimeError(
-            f"GHALogs shard {index} (bytes {start}-{stop - 1}) size mismatch: got {written}, expected {length}"
-        )
-    counters.pipeline.update_counter("ghalogs_stage/parts_downloaded", 1)
+        raise RuntimeError(f"GHALogs range {start}-{stop - 1} size mismatch: got {written}, expected {length}")
     counters.pipeline.update_counter("ghalogs_stage/bytes_downloaded", written)
-    return part_path
 
 
 def _concat_archive_parts(fs: fsspec.AbstractFileSystem, target: str, parts: list[str]) -> None:
@@ -1161,11 +1142,11 @@ def stage_ghalogs_archive(
 
     The archive is split into ``num_shards`` contiguous byte ranges downloaded
     as independent zephyr tasks — each resuming across mid-stream drops (see
-    :func:`_stream_range_resumable`) — then assembled server-side into
+    :func:`_iter_ghalogs_range`) — then assembled server-side into
     ``{output_path}/{GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH}``, the path
-    :func:`materialize_ghalogs_to_parquet` reads from. Completed parts are
-    reused across shard retries and re-runs, so a worker/pod death costs at
-    most the shards in flight. Idempotent: a correctly-sized copy is left
+    :func:`materialize_ghalogs_to_parquet` reads from. Parts publish through an
+    atomic rename and re-runs skip existing ones, so a worker/pod death costs
+    at most the shards in flight. Idempotent: a correctly-sized copy is left
     untouched, and a partial download never becomes the published archive.
     """
     # Enforced up front: a shard count the merge cannot handle would otherwise
@@ -1183,7 +1164,6 @@ def stage_ghalogs_archive(
     # cross buckets). They sit next to the final object and are removed after
     # a successful merge; a failed run leaves them for the next run to reuse.
     parts_prefix = f"{archive_path}.parts"
-    StoragePath(parts_prefix).mkdirs(exist_ok=True)
     shards = _ghalogs_shard_ranges(GHALOGS_ARCHIVE_BYTES, num_shards)
     logger.info(
         "Staging %s -> %s: %d bytes as %d range shards",
@@ -1192,13 +1172,21 @@ def stage_ghalogs_archive(
         GHALOGS_ARCHIVE_BYTES,
         len(shards),
     )
+    # ``from_list`` puts item i in shard i, so each range is its own zephyr
+    # shard and ``shard_idx`` indexes straight back into ``shards``. The write
+    # stage skips a shard — the range request never starts — when its part
+    # already exists, which is sound because parts publish via atomic rename:
+    # existing implies complete, and short ranges raise before publishing.
     pipeline = (
-        Dataset.from_list(shards).reshard(len(shards)).map(lambda shard: _download_ghalogs_shard(parts_prefix, shard))
+        Dataset.from_list(shards)
+        .flat_map(_iter_ghalogs_range)
+        .write_binary(
+            lambda shard_idx, total_shards: _ghalogs_part_path(parts_prefix, shards[shard_idx]),
+            skip_existing=True,
+        )
     )
     resources = worker_resources or ResourceConfig(cpu=1, ram="4g", disk="10g")
     outcome = ZephyrContext(name="stage-ghalogs", resources=resources, max_workers=max_workers).execute(pipeline)
-    # Parts are zero-padded so lexicographic order is range order; every shard
-    # verified its part's exact size before returning it.
     part_paths = sorted(outcome.results)
     _concat_archive_parts(fs, archive_path, part_paths)
     fs.invalidate_cache(os.path.dirname(path))  # exists() above may have cached the target as absent

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -23,6 +23,7 @@ from typing import IO
 import fsspec
 import requests
 from fray.types import ResourceConfig
+from fsspec.implementations.local import LocalFileSystem
 from pydantic import BaseModel, ConfigDict
 from rigging.filesystem import StoragePath, atomic_rename, marin_prefix, open_url, prefix_join, url_to_fs
 from zephyr import counters
@@ -89,9 +90,18 @@ _GHALOGS_HTTP_CHUNK_BYTES = 64 * 1024 * 1024
 _GHALOGS_S3_BLOCK_BYTES = 256 * 1024 * 1024  # multipart part size (~558 parts)
 _GHALOGS_LOG_EVERY_BYTES = 4 * 1024 * 1024 * 1024  # progress line every ~4 GB
 _GHALOGS_DOWNLOAD_TIMEOUT = (30, 600)  # (connect, read) seconds
-# A single 142 GB stream reliably breaks mid-body (server-side idle/connection
-# resets); Zenodo serves the archive with Accept-Ranges: bytes, so we resume
-# from the last written offset instead of restarting from zero. Give up only
+# The archive is downloaded as independent byte-range shards (zephyr tasks)
+# and assembled server-side. 32 shards (~4.4 GB each) sits inside both concat
+# limits: GCS compose accepts at most 32 source objects per call, and S3
+# UploadPartCopy caps a copied part at 5 GiB.
+_GHALOGS_DOWNLOAD_SHARDS = 32
+# Concurrent connections to Zenodo. Per-connection throughput is throttled and
+# uneven (~1-17 MB/s observed), so parallel shards both add bandwidth and limit
+# the damage of an unlucky slow connection to a single shard.
+_GHALOGS_DOWNLOAD_MAX_WORKERS = 8
+# A long stream reliably breaks mid-body (server-side idle/connection resets);
+# Zenodo serves the archive with Accept-Ranges: bytes, so each shard resumes
+# from its last written offset instead of restarting from zero. Give up only
 # after this many *consecutive* reconnects that make no forward progress.
 _GHALOGS_MAX_RESUME_STALLS = 8
 _GHALOGS_RESUME_BACKOFF_BASE = 5.0  # seconds; doubles per consecutive stall
@@ -1003,22 +1013,23 @@ def extract_ghalogs_step(
     )
 
 
-def _stream_archive_resumable(session: requests.Session, out: IO[bytes], expected_bytes: int) -> int:
-    """Stream ``GHALOGS_DOWNLOAD_URL`` into ``out`` and return the bytes written.
+def _stream_range_resumable(session: requests.Session, out: IO[bytes], start: int, stop: int) -> int:
+    """Stream bytes ``[start, stop)`` of ``GHALOGS_DOWNLOAD_URL`` into ``out``.
 
     Resumes across mid-stream drops via HTTP Range: on any mid-body failure or
-    early EOF it re-requests ``Range: bytes={written}-`` and keeps appending to
-    ``out`` rather than restarting. Raises if the download stalls without
-    progress, if a resume reply ignores Range, or (via the caller) if the final
-    size is short. Resume is in-process only — ``out`` holds the multipart
-    upload, so a task/pod death restarts from zero.
+    early EOF it re-requests ``Range: bytes={start + written}-{stop - 1}`` and
+    keeps appending to ``out`` rather than restarting the range. Returns the
+    bytes written, which is short of ``stop - start`` only when the server has
+    less data than declared (a ranged request past the last byte returns 416).
+    Raises if the download stalls without progress or a reply ignores Range.
     """
-    total = 0
+    length = stop - start
+    written = 0
     next_log = _GHALOGS_LOG_EVERY_BYTES
     stalls = 0
-    while total < expected_bytes:
-        start = total
-        headers = {"Range": f"bytes={total}-"} if total else {}
+    while written < length:
+        attempt_start = written
+        headers = {"Range": f"bytes={start + written}-{stop - 1}"}
         error: Exception | None = None
         try:
             with session.get(
@@ -1026,25 +1037,25 @@ def _stream_archive_resumable(session: requests.Session, out: IO[bytes], expecte
             ) as response:
                 # A ranged request past the last byte returns 416: the server has
                 # nothing more to send. Stop and let the caller's size check flag
-                # any shortfall against the declared archive size.
-                if total and response.status_code == http.client.REQUESTED_RANGE_NOT_SATISFIABLE:
+                # the shortfall against the declared archive size.
+                if response.status_code == http.client.REQUESTED_RANGE_NOT_SATISFIABLE:
                     break
                 response.raise_for_status()
-                # If we asked to resume but the server ignored Range (200 instead
-                # of 206), the body restarts at byte 0; appending it would corrupt
-                # the archive, so refuse rather than silently double-write.
-                if total and response.status_code != http.client.PARTIAL_CONTENT:
+                # If the server ignored Range (200 instead of 206), the body is
+                # the whole archive from byte 0; appending it would corrupt the
+                # range, so refuse rather than silently double-write.
+                if response.status_code != http.client.PARTIAL_CONTENT:
                     raise RuntimeError(
-                        f"GHALogs resume from byte {total} expected HTTP 206, got {response.status_code}; "
-                        "server ignored Range — aborting to avoid corrupting the archive"
+                        f"GHALogs range request for bytes {start + written}-{stop - 1} expected HTTP 206, "
+                        f"got {response.status_code}; server ignored Range — aborting to avoid corruption"
                     )
                 for chunk in response.iter_content(chunk_size=_GHALOGS_HTTP_CHUNK_BYTES):
                     if not chunk:
                         continue
                     out.write(chunk)
-                    total += len(chunk)
-                    if total >= next_log:
-                        logger.info("staged %.1f / %.1f GB", total / 1e9, expected_bytes / 1e9)
+                    written += len(chunk)
+                    if written >= next_log:
+                        logger.info("range %d-%d: %.1f / %.1f GB", start, stop - 1, written / 1e9, length / 1e9)
                         next_log += _GHALOGS_LOG_EVERY_BYTES
         except (requests.exceptions.RequestException, http.client.IncompleteRead) as e:
             error = e
@@ -1053,40 +1064,106 @@ def _stream_archive_resumable(session: requests.Session, out: IO[bytes], expecte
         # a clean response that yields zero bytes at the current offset (empty
         # body, early close) makes no progress either and must route through the
         # stall budget, or the outer loop would re-request the same offset forever.
-        if total > start:
+        if written > attempt_start:
             stalls = 0
             continue
         stalls += 1
         if stalls > _GHALOGS_MAX_RESUME_STALLS:
             raise RuntimeError(
-                f"GHALogs download stalled at {total}/{expected_bytes} bytes after "
+                f"GHALogs download stalled at {written}/{length} bytes of range {start}-{stop - 1} after "
                 f"{stalls} consecutive attempts without progress"
             ) from error
         backoff = min(_GHALOGS_RESUME_BACKOFF_CAP, _GHALOGS_RESUME_BACKOFF_BASE * 2 ** (stalls - 1))
         logger.warning(
-            "GHALogs stream made no progress at %.1f / %.1f GB (stall %d/%d), retrying in %.0fs: %s",
-            total / 1e9,
-            expected_bytes / 1e9,
+            "GHALogs stream made no progress on range %d-%d at %.1f / %.1f GB (stall %d/%d), retrying in %.0fs: %s",
+            start,
+            stop - 1,
+            written / 1e9,
+            length / 1e9,
             stalls,
             _GHALOGS_MAX_RESUME_STALLS,
             backoff,
             error,
         )
         time.sleep(backoff)
-    return total
+    return written
 
 
-def stage_ghalogs_archive(output_path: str) -> None:
-    """Stream the ~142 GB GHALogs Zenodo archive under ``output_path`` (idempotent).
+def _ghalogs_shard_ranges(total_bytes: int, num_shards: int) -> list[tuple[int, int, int]]:
+    """Split ``[0, total_bytes)`` into up to ``num_shards`` contiguous ``(index, start, stop)`` ranges."""
+    bounds = [total_bytes * i // num_shards for i in range(num_shards + 1)]
+    return [(i, bounds[i], bounds[i + 1]) for i in range(num_shards) if bounds[i] < bounds[i + 1]]
 
-    Idempotent: a correctly-sized copy is left untouched, so re-running is a
-    cheap no-op once staged; a partial or truncated download never becomes the
-    published archive. The archive is written to
-    ``{output_path}/{GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH}`` — the path
-    :func:`materialize_ghalogs_to_parquet` reads from. Bytes stream straight to
-    the object store without buffering the whole file locally, resuming across
-    mid-stream connection drops (see :func:`_stream_archive_resumable`).
+
+def _ghalogs_part_path(parts_prefix: str, index: int) -> str:
+    return prefix_join(parts_prefix, f"part-{index:05d}")
+
+
+def _download_ghalogs_shard(parts_prefix: str, shard: tuple[int, int, int]) -> str:
+    """Download one byte range of the archive to its part object (idempotent).
+
+    A part already present at its exact range length is reused, so a retried
+    shard or a re-run staging job only re-downloads missing or partial parts.
     """
+    index, start, stop = shard
+    part_path = _ghalogs_part_path(parts_prefix, index)
+    length = stop - start
+    fs, path = url_to_fs(part_path)
+    if fs.exists(path) and fs.size(path) == length:
+        counters.pipeline.update_counter("ghalogs_stage/parts_reused", 1)
+        return part_path
+    session = build_retrying_session()
+    with fs.open(path, "wb", block_size=_GHALOGS_S3_BLOCK_BYTES) as out:
+        written = _stream_range_resumable(session, out, start, stop)
+    if written != length:
+        raise RuntimeError(
+            f"GHALogs shard {index} (bytes {start}-{stop - 1}) size mismatch: got {written}, expected {length}"
+        )
+    counters.pipeline.update_counter("ghalogs_stage/parts_downloaded", 1)
+    counters.pipeline.update_counter("ghalogs_stage/bytes_downloaded", written)
+    return part_path
+
+
+def _concat_parts_server_side(fs: fsspec.AbstractFileSystem, target: str, parts: list[str]) -> None:
+    """Assemble ``target`` from ``parts`` without streaming bytes through this process.
+
+    Object stores concatenate server-side via ``fs.merge`` — S3 UploadPartCopy
+    on R2/CoreWeave, compose on GCS — and materialize the target atomically on
+    completion. The local filesystem (tests) has no such primitive, so parts
+    are byte-appended and published with an atomic rename.
+    """
+    if isinstance(fs, LocalFileSystem):
+        with atomic_rename(target, fs=fs) as tmp:
+            with fs.open(tmp, "wb") as out:
+                for part in parts:
+                    with fs.open(part, "rb") as src:
+                        shutil.copyfileobj(src, out, _GHALOGS_HTTP_CHUNK_BYTES)
+        return
+    fs.merge(target, parts)
+
+
+def stage_ghalogs_archive(
+    output_path: str,
+    *,
+    num_shards: int = _GHALOGS_DOWNLOAD_SHARDS,
+    max_workers: int = _GHALOGS_DOWNLOAD_MAX_WORKERS,
+    worker_resources: ResourceConfig | None = None,
+) -> None:
+    """Stage the ~142 GB GHALogs Zenodo archive under ``output_path`` (idempotent).
+
+    The archive is split into ``num_shards`` contiguous byte ranges downloaded
+    as independent zephyr tasks — each resuming across mid-stream drops (see
+    :func:`_stream_range_resumable`) — then assembled server-side into
+    ``{output_path}/{GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH}``, the path
+    :func:`materialize_ghalogs_to_parquet` reads from. Completed parts are
+    reused across shard retries and re-runs, so a worker/pod death costs at
+    most the shards in flight. Idempotent: a correctly-sized copy is left
+    untouched, and a partial download never becomes the published archive.
+    """
+    # Enforced up front: a shard count the merge cannot handle would otherwise
+    # only fail after the full archive has been downloaded.
+    if not 0 < num_shards <= _GHALOGS_DOWNLOAD_SHARDS:
+        raise ValueError(f"num_shards must be in [1, {_GHALOGS_DOWNLOAD_SHARDS}] (GCS compose cap), got {num_shards}")
     archive_path = prefix_join(output_path, GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH)
     fs, path = url_to_fs(archive_path)
 
@@ -1094,18 +1171,34 @@ def stage_ghalogs_archive(output_path: str) -> None:
         logger.info("GHALogs archive already staged (%d bytes): %s", GHALOGS_ARCHIVE_BYTES, archive_path)
         return
 
-    StoragePath(os.path.dirname(archive_path)).mkdirs(exist_ok=True)
-    logger.info("Streaming %s -> %s (%d bytes expected)", GHALOGS_DOWNLOAD_URL, archive_path, GHALOGS_ARCHIVE_BYTES)
-    session = build_retrying_session()
-    with atomic_rename(path, fs=fs) as tmp:
-        with fs.open(tmp, "wb", block_size=_GHALOGS_S3_BLOCK_BYTES) as out:
-            total = _stream_archive_resumable(session, out, GHALOGS_ARCHIVE_BYTES)
-        # Verify before atomic_rename publishes: a short download raises here and
-        # the temp key is cleaned up, so no partial archive lands at the final path.
-        if total != GHALOGS_ARCHIVE_BYTES:
-            raise RuntimeError(
-                f"GHALogs archive size mismatch after staging: got {total}, expected {GHALOGS_ARCHIVE_BYTES}"
-            )
+    # Parts must live in the same bucket as the archive (GCS compose cannot
+    # cross buckets). They sit next to the final object and are removed after
+    # a successful merge; a failed run leaves them for the next run to reuse.
+    parts_prefix = f"{archive_path}.parts"
+    StoragePath(parts_prefix).mkdirs(exist_ok=True)
+    shards = _ghalogs_shard_ranges(GHALOGS_ARCHIVE_BYTES, num_shards)
+    logger.info(
+        "Staging %s -> %s: %d bytes as %d range shards",
+        GHALOGS_DOWNLOAD_URL,
+        archive_path,
+        GHALOGS_ARCHIVE_BYTES,
+        len(shards),
+    )
+    pipeline = (
+        Dataset.from_list(shards).reshard(len(shards)).map(lambda shard: _download_ghalogs_shard(parts_prefix, shard))
+    )
+    resources = worker_resources or ResourceConfig(cpu=1, ram="4g", disk="10g")
+    outcome = ZephyrContext(name="stage-ghalogs", resources=resources, max_workers=max_workers).execute(pipeline)
+    # Parts are zero-padded so lexicographic order is range order; every shard
+    # verified its part's exact size before returning it.
+    part_paths = sorted(outcome.results)
+    _concat_parts_server_side(fs, archive_path, part_paths)
+    fs.invalidate_cache(os.path.dirname(path))  # exists() above may have cached the target as absent
+    total = fs.size(path)
+    if total != GHALOGS_ARCHIVE_BYTES:
+        fs.rm(path)
+        raise RuntimeError(f"GHALogs archive size mismatch after merge: got {total}, expected {GHALOGS_ARCHIVE_BYTES}")
+    fs.rm(f"{path}.parts", recursive=True)
     logger.info("Staged GHALogs archive: %d bytes -> %s", total, archive_path)
 
 

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -4,11 +4,13 @@
 """Public diagnostic-log source inventory and GHALogs extraction helpers."""
 
 import hashlib
+import http.client
 import json
 import logging
 import os.path
 import re
 import shutil
+import time
 import xml.etree.ElementTree as ET
 import zipfile
 from collections.abc import Iterable, Iterator
@@ -86,6 +88,13 @@ _GHALOGS_HTTP_CHUNK_BYTES = 64 * 1024 * 1024
 _GHALOGS_S3_BLOCK_BYTES = 256 * 1024 * 1024  # multipart part size (~558 parts)
 _GHALOGS_LOG_EVERY_BYTES = 4 * 1024 * 1024 * 1024  # progress line every ~4 GB
 _GHALOGS_DOWNLOAD_TIMEOUT = (30, 600)  # (connect, read) seconds
+# A single 142 GB stream reliably breaks mid-body (server-side idle/connection
+# resets); Zenodo serves the archive with Accept-Ranges: bytes, so we resume
+# from the last written offset instead of restarting from zero. Give up only
+# after this many *consecutive* reconnects that make no forward progress.
+_GHALOGS_MAX_RESUME_STALLS = 8
+_GHALOGS_RESUME_BACKOFF_BASE = 5.0  # seconds; doubles per consecutive stall
+_GHALOGS_RESUME_BACKOFF_CAP = 120.0
 
 _PARTITION_BUCKETS = 10_000
 _ISSUE_5093_HOLDOUT_BUCKETS = 100
@@ -993,6 +1002,84 @@ def extract_ghalogs_step(
     )
 
 
+def _stream_archive_resumable(session: requests.Session, out, expected_bytes: int) -> int:
+    """Stream ``GHALOGS_DOWNLOAD_URL`` into the open file ``out``, resuming across
+    mid-stream connection drops via HTTP Range. Return the total bytes written.
+
+    A single GET over a 142 GB body reliably fails partway with
+    ``ChunkedEncodingError``/``IncompleteRead`` (the urllib3 ``Retry`` on the
+    session only covers connection setup and the initial response, not the
+    streamed body). Zenodo advertises ``Accept-Ranges: bytes``, so on any
+    mid-body failure — or a clean-but-early EOF — we re-request
+    ``Range: bytes={total}-`` and keep appending to the *same* object-store
+    multipart upload, rather than restarting from zero.
+
+    The failure budget resets whenever a reconnect makes forward progress, so an
+    arbitrarily long download survives many drops as long as it keeps advancing;
+    it aborts only after ``_GHALOGS_MAX_RESUME_STALLS`` consecutive reconnects
+    that write nothing.
+
+    Note: resume is in-process only — the multipart upload lives in ``out``. If
+    the whole task/pod dies, a fresh run restarts from zero.
+    """
+    total = 0
+    next_log = _GHALOGS_LOG_EVERY_BYTES
+    stalls = 0
+    progress_at_last_stall = 0
+    while total < expected_bytes:
+        headers = {"Range": f"bytes={total}-"} if total else {}
+        try:
+            with session.get(
+                GHALOGS_DOWNLOAD_URL, stream=True, headers=headers, timeout=_GHALOGS_DOWNLOAD_TIMEOUT
+            ) as response:
+                # A ranged request past the last byte returns 416: the server has
+                # nothing more to send. Stop and let the caller's size check flag
+                # any shortfall against the declared archive size.
+                if total and response.status_code == http.client.REQUESTED_RANGE_NOT_SATISFIABLE:
+                    break
+                response.raise_for_status()
+                # If we asked to resume but the server ignored Range (200 instead
+                # of 206), the body restarts at byte 0; appending it would corrupt
+                # the archive, so refuse rather than silently double-write.
+                if total and response.status_code != http.client.PARTIAL_CONTENT:
+                    raise RuntimeError(
+                        f"GHALogs resume from byte {total} expected HTTP 206, got {response.status_code}; "
+                        "server ignored Range — aborting to avoid corrupting the archive"
+                    )
+                for chunk in response.iter_content(chunk_size=_GHALOGS_HTTP_CHUNK_BYTES):
+                    if not chunk:
+                        continue
+                    out.write(chunk)
+                    total += len(chunk)
+                    if total >= next_log:
+                        logger.info("staged %.1f / %.1f GB", total / 1e9, expected_bytes / 1e9)
+                        next_log += _GHALOGS_LOG_EVERY_BYTES
+        except (requests.exceptions.RequestException, http.client.IncompleteRead) as e:
+            if total >= expected_bytes:
+                break
+            if total > progress_at_last_stall:
+                stalls = 0
+                progress_at_last_stall = total
+            stalls += 1
+            if stalls > _GHALOGS_MAX_RESUME_STALLS:
+                raise RuntimeError(
+                    f"GHALogs download stalled at {total}/{expected_bytes} bytes after "
+                    f"{stalls} consecutive reconnects without progress"
+                ) from e
+            backoff = min(_GHALOGS_RESUME_BACKOFF_CAP, _GHALOGS_RESUME_BACKOFF_BASE * 2 ** (stalls - 1))
+            logger.warning(
+                "GHALogs stream broke at %.1f / %.1f GB (stall %d/%d), resuming in %.0fs: %s",
+                total / 1e9,
+                expected_bytes / 1e9,
+                stalls,
+                _GHALOGS_MAX_RESUME_STALLS,
+                backoff,
+                e,
+            )
+            time.sleep(backoff)
+    return total
+
+
 def stage_ghalogs_archive(output_path: str) -> None:
     """Stream the ~142 GB GHALogs Zenodo archive under ``output_path`` (idempotent).
 
@@ -1001,7 +1088,8 @@ def stage_ghalogs_archive(output_path: str) -> None:
     published archive. The archive is written to
     ``{output_path}/{GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH}`` — the path
     :func:`materialize_ghalogs_to_parquet` reads from. Bytes stream straight to
-    the object store without buffering the whole file locally.
+    the object store without buffering the whole file locally, resuming across
+    mid-stream connection drops (see :func:`_stream_archive_resumable`).
     """
     archive_path = prefix_join(output_path, GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH)
     fs, path = url_to_fs(archive_path)
@@ -1012,28 +1100,16 @@ def stage_ghalogs_archive(output_path: str) -> None:
 
     StoragePath(os.path.dirname(archive_path)).mkdirs(exist_ok=True)
     logger.info("Streaming %s -> %s (%d bytes expected)", GHALOGS_DOWNLOAD_URL, archive_path, GHALOGS_ARCHIVE_BYTES)
-    total = 0
-    next_log = _GHALOGS_LOG_EVERY_BYTES
     session = build_retrying_session()
-    with session.get(GHALOGS_DOWNLOAD_URL, stream=True, timeout=_GHALOGS_DOWNLOAD_TIMEOUT) as response:
-        response.raise_for_status()
-        with atomic_rename(path, fs=fs) as tmp:
-            with fs.open(tmp, "wb", block_size=_GHALOGS_S3_BLOCK_BYTES) as out:
-                for chunk in response.iter_content(chunk_size=_GHALOGS_HTTP_CHUNK_BYTES):
-                    if not chunk:
-                        continue
-                    out.write(chunk)
-                    total += len(chunk)
-                    if total >= next_log:
-                        logger.info("staged %.1f / %.1f GB", total / 1e9, GHALOGS_ARCHIVE_BYTES / 1e9)
-                        next_log += _GHALOGS_LOG_EVERY_BYTES
-            # Verify before atomic_rename publishes: a truncated stream raises
-            # here and the temp key is cleaned up, so no partial archive lands
-            # at the final path.
-            if total != GHALOGS_ARCHIVE_BYTES:
-                raise RuntimeError(
-                    f"GHALogs archive size mismatch after staging: got {total}, expected {GHALOGS_ARCHIVE_BYTES}"
-                )
+    with atomic_rename(path, fs=fs) as tmp:
+        with fs.open(tmp, "wb", block_size=_GHALOGS_S3_BLOCK_BYTES) as out:
+            total = _stream_archive_resumable(session, out, GHALOGS_ARCHIVE_BYTES)
+        # Verify before atomic_rename publishes: a short download raises here and
+        # the temp key is cleaned up, so no partial archive lands at the final path.
+        if total != GHALOGS_ARCHIVE_BYTES:
+            raise RuntimeError(
+                f"GHALogs archive size mismatch after staging: got {total}, expected {GHALOGS_ARCHIVE_BYTES}"
+            )
     logger.info("Staged GHALogs archive: %d bytes -> %s", total, archive_path)
 
 

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -1016,9 +1016,10 @@ def _stream_archive_resumable(session: requests.Session, out: IO[bytes], expecte
     total = 0
     next_log = _GHALOGS_LOG_EVERY_BYTES
     stalls = 0
-    progress_at_last_stall = 0
     while total < expected_bytes:
+        start = total
         headers = {"Range": f"bytes={total}-"} if total else {}
+        error: Exception | None = None
         try:
             with session.get(
                 GHALOGS_DOWNLOAD_URL, stream=True, headers=headers, timeout=_GHALOGS_DOWNLOAD_TIMEOUT
@@ -1046,28 +1047,32 @@ def _stream_archive_resumable(session: requests.Session, out: IO[bytes], expecte
                         logger.info("staged %.1f / %.1f GB", total / 1e9, expected_bytes / 1e9)
                         next_log += _GHALOGS_LOG_EVERY_BYTES
         except (requests.exceptions.RequestException, http.client.IncompleteRead) as e:
-            if total >= expected_bytes:
-                break
-            if total > progress_at_last_stall:
-                stalls = 0
-                progress_at_last_stall = total
-            stalls += 1
-            if stalls > _GHALOGS_MAX_RESUME_STALLS:
-                raise RuntimeError(
-                    f"GHALogs download stalled at {total}/{expected_bytes} bytes after "
-                    f"{stalls} consecutive reconnects without progress"
-                ) from e
-            backoff = min(_GHALOGS_RESUME_BACKOFF_CAP, _GHALOGS_RESUME_BACKOFF_BASE * 2 ** (stalls - 1))
-            logger.warning(
-                "GHALogs stream broke at %.1f / %.1f GB (stall %d/%d), resuming in %.0fs: %s",
-                total / 1e9,
-                expected_bytes / 1e9,
-                stalls,
-                _GHALOGS_MAX_RESUME_STALLS,
-                backoff,
-                e,
-            )
-            time.sleep(backoff)
+            error = e
+
+        # Gate on bytes written this attempt, not on whether an exception fired:
+        # a clean response that yields zero bytes at the current offset (empty
+        # body, early close) makes no progress either and must route through the
+        # stall budget, or the outer loop would re-request the same offset forever.
+        if total > start:
+            stalls = 0
+            continue
+        stalls += 1
+        if stalls > _GHALOGS_MAX_RESUME_STALLS:
+            raise RuntimeError(
+                f"GHALogs download stalled at {total}/{expected_bytes} bytes after "
+                f"{stalls} consecutive attempts without progress"
+            ) from error
+        backoff = min(_GHALOGS_RESUME_BACKOFF_CAP, _GHALOGS_RESUME_BACKOFF_BASE * 2 ** (stalls - 1))
+        logger.warning(
+            "GHALogs stream made no progress at %.1f / %.1f GB (stall %d/%d), retrying in %.0fs: %s",
+            total / 1e9,
+            expected_bytes / 1e9,
+            stalls,
+            _GHALOGS_MAX_RESUME_STALLS,
+            backoff,
+            error,
+        )
+        time.sleep(backoff)
     return total
 
 

--- a/lib/marin/src/marin/datakit/download/diagnostic_logs.py
+++ b/lib/marin/src/marin/datakit/download/diagnostic_logs.py
@@ -18,6 +18,7 @@ from contextlib import ExitStack
 from dataclasses import dataclass
 from enum import StrEnum, auto
 from io import BytesIO
+from typing import IO
 
 import fsspec
 import requests
@@ -1002,25 +1003,15 @@ def extract_ghalogs_step(
     )
 
 
-def _stream_archive_resumable(session: requests.Session, out, expected_bytes: int) -> int:
-    """Stream ``GHALOGS_DOWNLOAD_URL`` into the open file ``out``, resuming across
-    mid-stream connection drops via HTTP Range. Return the total bytes written.
+def _stream_archive_resumable(session: requests.Session, out: IO[bytes], expected_bytes: int) -> int:
+    """Stream ``GHALOGS_DOWNLOAD_URL`` into ``out`` and return the bytes written.
 
-    A single GET over a 142 GB body reliably fails partway with
-    ``ChunkedEncodingError``/``IncompleteRead`` (the urllib3 ``Retry`` on the
-    session only covers connection setup and the initial response, not the
-    streamed body). Zenodo advertises ``Accept-Ranges: bytes``, so on any
-    mid-body failure — or a clean-but-early EOF — we re-request
-    ``Range: bytes={total}-`` and keep appending to the *same* object-store
-    multipart upload, rather than restarting from zero.
-
-    The failure budget resets whenever a reconnect makes forward progress, so an
-    arbitrarily long download survives many drops as long as it keeps advancing;
-    it aborts only after ``_GHALOGS_MAX_RESUME_STALLS`` consecutive reconnects
-    that write nothing.
-
-    Note: resume is in-process only — the multipart upload lives in ``out``. If
-    the whole task/pod dies, a fresh run restarts from zero.
+    Resumes across mid-stream drops via HTTP Range: on any mid-body failure or
+    early EOF it re-requests ``Range: bytes={written}-`` and keeps appending to
+    ``out`` rather than restarting. Raises if the download stalls without
+    progress, if a resume reply ignores Range, or (via the caller) if the final
+    size is short. Resume is in-process only — ``out`` holds the multipart
+    upload, so a task/pod death restarts from zero.
     """
     total = 0
     next_log = _GHALOGS_LOG_EVERY_BYTES

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -524,10 +524,12 @@ class _FakeZenodoServer:
             body = self.available[start:stop]
             status = http.client.PARTIAL_CONTENT if ranged else http.client.OK
 
-        brk = self.breaks.pop(0) if self.breaks else None
-        if brk is not None:
+        break_after_bytes = self.breaks.pop(0) if self.breaks else None
+        if break_after_bytes is not None:
             return _FakeStreamResponse(
-                status, [body[:brk]], break_exc=requests.exceptions.ChunkedEncodingError("connection broken")
+                status,
+                [body[:break_after_bytes]],
+                break_exc=requests.exceptions.ChunkedEncodingError("connection broken"),
             )
         chunks = [body[i : i + self.out_chunk] for i in range(0, len(body), self.out_chunk)] or [b""]
         return _FakeStreamResponse(status, chunks)

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -595,11 +595,13 @@ def test_stage_ghalogs_archive_reuses_completed_parts(tmp_path, monkeypatch):
     server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload), len(payload))
 
     # A prior run already downloaded the first shard (bytes 0-427); a re-run
-    # must reuse it instead of re-requesting that range.
+    # must skip it (write_binary skip_existing) instead of re-requesting the range.
     staged = tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
     parts_dir = staged.with_name(f"{staged.name}.parts")
     parts_dir.mkdir(parents=True)
-    (parts_dir / "part-00000").write_bytes(payload[:428])
+    first = diagnostic_logs._ShardRange(0, 428)
+    part_name = Path(diagnostic_logs._ghalogs_part_path(str(parts_dir), first)).name
+    (parts_dir / part_name).write_bytes(payload[:428])
 
     stage_ghalogs_archive(str(tmp_path), num_shards=3, max_workers=1)
 
@@ -607,36 +609,36 @@ def test_stage_ghalogs_archive_reuses_completed_parts(tmp_path, monkeypatch):
     assert sorted(server.ranges) == [428, 856]
 
 
-def test_download_ghalogs_shard_aborts_if_server_ignores_range(tmp_path, monkeypatch):
+def test_ghalogs_range_aborts_if_server_ignores_range(monkeypatch):
     payload = b"resume-must-not-corrupt" * 16
     # Reply 200 (full body) to the bounded range request — the body would not
-    # match the requested slice, so the shard must refuse rather than corrupt.
+    # match the requested slice, so the range must refuse rather than corrupt.
     server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload, ignore_range=True), len(payload))
 
     with pytest.raises(RuntimeError, match="ignored Range"):
-        diagnostic_logs._download_ghalogs_shard(str(tmp_path), diagnostic_logs._ShardRange(0, 0, len(payload)))
+        b"".join(diagnostic_logs._iter_ghalogs_range(diagnostic_logs._ShardRange(0, len(payload))))
 
     assert server.ranges == [0]
 
 
-def test_download_ghalogs_shard_gives_up_after_stalls_without_progress(tmp_path, monkeypatch):
+def test_ghalogs_range_gives_up_after_stalls_without_progress(monkeypatch):
     payload = b"never-fully-delivered" * 8
     # Every ranged resume yields zero bytes then drops: no forward progress, so
-    # the stall budget must be exhausted and the shard must fail (not loop forever).
+    # the stall budget must be exhausted and the range must fail (not loop forever).
     _patch_zenodo(monkeypatch, _FakeZenodoServer(payload, breaks=[50] + [0] * 20), len(payload))
 
     with pytest.raises(RuntimeError, match="stalled"):
-        diagnostic_logs._download_ghalogs_shard(str(tmp_path), diagnostic_logs._ShardRange(0, 0, len(payload)))
+        b"".join(diagnostic_logs._iter_ghalogs_range(diagnostic_logs._ShardRange(0, len(payload))))
 
 
-def test_download_ghalogs_shard_gives_up_on_clean_empty_responses(tmp_path, monkeypatch):
+def test_ghalogs_range_gives_up_on_clean_empty_responses(monkeypatch):
     # A server that keeps returning a successful but empty body makes no forward
     # progress and raises no exception; the loop must still give up via the stall
     # budget instead of re-requesting the same offset forever.
     server = _patch_zenodo(monkeypatch, _EmptyBodyServer(), declared_bytes=64)
 
     with pytest.raises(RuntimeError, match="stalled"):
-        diagnostic_logs._download_ghalogs_shard(str(tmp_path), diagnostic_logs._ShardRange(0, 0, 64))
+        b"".join(diagnostic_logs._iter_ghalogs_range(diagnostic_logs._ShardRange(0, 64)))
 
     # Bounded by the stall budget rather than looping unboundedly.
     assert server.get_calls <= diagnostic_logs._GHALOGS_MAX_RESUME_STALLS + 1

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -612,7 +612,7 @@ def test_download_ghalogs_shard_aborts_if_server_ignores_range(tmp_path, monkeyp
     server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload, ignore_range=True), len(payload))
 
     with pytest.raises(RuntimeError, match="ignored Range"):
-        diagnostic_logs._download_ghalogs_shard(str(tmp_path), (0, 0, len(payload)))
+        diagnostic_logs._download_ghalogs_shard(str(tmp_path), diagnostic_logs._ShardRange(0, 0, len(payload)))
 
     assert server.ranges == [0]
 
@@ -624,7 +624,7 @@ def test_download_ghalogs_shard_gives_up_after_stalls_without_progress(tmp_path,
     _patch_zenodo(monkeypatch, _FakeZenodoServer(payload, breaks=[50] + [0] * 20), len(payload))
 
     with pytest.raises(RuntimeError, match="stalled"):
-        diagnostic_logs._download_ghalogs_shard(str(tmp_path), (0, 0, len(payload)))
+        diagnostic_logs._download_ghalogs_shard(str(tmp_path), diagnostic_logs._ShardRange(0, 0, len(payload)))
 
 
 def test_download_ghalogs_shard_gives_up_on_clean_empty_responses(tmp_path, monkeypatch):
@@ -634,7 +634,7 @@ def test_download_ghalogs_shard_gives_up_on_clean_empty_responses(tmp_path, monk
     server = _patch_zenodo(monkeypatch, _EmptyBodyServer(), declared_bytes=64)
 
     with pytest.raises(RuntimeError, match="stalled"):
-        diagnostic_logs._download_ghalogs_shard(str(tmp_path), (0, 0, 64))
+        diagnostic_logs._download_ghalogs_shard(str(tmp_path), diagnostic_logs._ShardRange(0, 0, 64))
 
     # Bounded by the stall budget rather than looping unboundedly.
     assert server.get_calls <= diagnostic_logs._GHALOGS_MAX_RESUME_STALLS + 1

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -477,13 +477,15 @@ class _FakeStreamResponse:
 class _FakeZenodoServer:
     """Range-aware fake of the Zenodo archive endpoint.
 
-    Serves ``available`` bytes. ``breaks`` is a per-GET plan: the i-th GET yields
-    at most ``breaks[i]`` bytes of its requested range and then raises
-    ``ChunkedEncodingError`` (``None`` = serve the range to completion),
-    simulating a mid-stream drop. A ``Range`` request at/beyond ``available``
-    returns 416 so the caller sees "no more data". ``ignore_range`` forces a 200
-    (full-body) reply even to a ``Range`` request, modeling a server that drops
-    resume support. Records every requested start offset in ``ranges``.
+    Serves ``available`` bytes, honoring bounded ``Range: bytes=a-b`` requests
+    the way Zenodo does (206 with exactly the requested slice). ``breaks`` is
+    a per-GET plan: the i-th GET yields at most ``breaks[i]`` bytes of its
+    requested range and then raises ``ChunkedEncodingError`` (``None`` = serve
+    the range to completion), simulating a mid-stream drop. A ``Range`` request
+    at/beyond ``available`` returns 416 so the caller sees "no more data".
+    ``ignore_range`` forces a 200 (full-body) reply even to a ``Range`` request,
+    modeling a server that drops resume support. Records every requested start
+    offset in ``ranges``.
     """
 
     def __init__(
@@ -504,7 +506,11 @@ class _FakeZenodoServer:
     def get(self, url: str, *, stream: bool, timeout, headers=None) -> _FakeStreamResponse:
         headers = headers or {}
         ranged = "Range" in headers
-        start = int(headers["Range"].split("=")[1].split("-")[0]) if ranged else 0
+        start, end = 0, None
+        if ranged:
+            start_spec, _, end_spec = headers["Range"].split("=")[1].partition("-")
+            start = int(start_spec)
+            end = int(end_spec) if end_spec else None
         self.get_calls += 1
         self.ranges.append(start)
 
@@ -512,9 +518,10 @@ class _FakeZenodoServer:
             return _FakeStreamResponse(http.client.REQUESTED_RANGE_NOT_SATISFIABLE, [])
 
         if ranged and self.ignore_range:
-            body, status, start = self.available, http.client.OK, 0
+            body, status = self.available, http.client.OK
         else:
-            body = self.available[start:]
+            stop = len(self.available) if end is None else min(end + 1, len(self.available))
+            body = self.available[start:stop]
             status = http.client.PARTIAL_CONTENT if ranged else http.client.OK
 
         brk = self.breaks.pop(0) if self.breaks else None
@@ -546,20 +553,25 @@ class _EmptyBodyServer:
 def _patch_zenodo(monkeypatch, server, declared_bytes: int):
     monkeypatch.setattr(diagnostic_logs, "build_retrying_session", lambda: server)
     monkeypatch.setattr(diagnostic_logs, "GHALOGS_ARCHIVE_BYTES", declared_bytes)
-    monkeypatch.setattr(diagnostic_logs.time, "sleep", lambda _s: None)
+    # Make stall retries instant without patching time.sleep process-wide (the
+    # zephyr coordinator running the staging pipeline relies on real sleeps).
+    monkeypatch.setattr(diagnostic_logs, "_GHALOGS_RESUME_BACKOFF_BASE", 0.0)
+    monkeypatch.setattr(diagnostic_logs, "_GHALOGS_RESUME_BACKOFF_CAP", 0.0)
     return server
 
 
-def test_stage_ghalogs_archive_streams_to_expected_path(tmp_path, monkeypatch):
-    payload = b"PK\x03\x04" + b"github-run-log-bytes" * 32
+def test_stage_ghalogs_archive_shards_merges_and_cleans_up(tmp_path, monkeypatch):
+    payload = b"PK\x03\x04" + b"github-run-log-bytes" * 64  # 1284 bytes
     server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload), len(payload))
 
-    stage_ghalogs_archive(str(tmp_path))
+    stage_ghalogs_archive(str(tmp_path), num_shards=3, max_workers=1)
 
     staged = tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
     assert staged.read_bytes() == payload
-    # A clean stream needs exactly one request — no Range resume.
-    assert server.ranges == [0]
+    # One bounded range request per shard, starting at each shard boundary.
+    assert sorted(server.ranges) == [0, 428, 856]
+    # The intermediate parts are removed once the merged archive is verified.
+    assert not staged.with_name(f"{staged.name}.parts").exists()
 
 
 def test_stage_ghalogs_archive_resumes_after_midstream_break(tmp_path, monkeypatch):
@@ -567,52 +579,65 @@ def test_stage_ghalogs_archive_resumes_after_midstream_break(tmp_path, monkeypat
     # First GET yields 500 bytes then drops; second drops again at 900; third completes.
     server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload, breaks=[500, 400]), len(payload))
 
-    stage_ghalogs_archive(str(tmp_path))
+    stage_ghalogs_archive(str(tmp_path), num_shards=1, max_workers=1)
 
     staged = tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
     assert staged.read_bytes() == payload
-    # Resumed from the last written offset each time (Range: bytes=500-, then 900-),
-    # never restarting from zero.
+    # Resumed from the last written offset each time (Range: bytes=500-, then
+    # 900-), never restarting the shard from zero.
     assert server.ranges == [0, 500, 900]
 
 
-def test_stage_ghalogs_archive_aborts_if_server_ignores_range(tmp_path, monkeypatch):
+def test_stage_ghalogs_archive_reuses_completed_parts(tmp_path, monkeypatch):
+    payload = b"PK\x03\x04" + b"github-run-log-bytes" * 64  # 1284 bytes
+    server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload), len(payload))
+
+    # A prior run already downloaded the first shard (bytes 0-427); a re-run
+    # must reuse it instead of re-requesting that range.
+    staged = tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
+    parts_dir = staged.with_name(f"{staged.name}.parts")
+    parts_dir.mkdir(parents=True)
+    (parts_dir / "part-00000").write_bytes(payload[:428])
+
+    stage_ghalogs_archive(str(tmp_path), num_shards=3, max_workers=1)
+
+    assert staged.read_bytes() == payload
+    assert sorted(server.ranges) == [428, 856]
+
+
+def test_download_ghalogs_shard_aborts_if_server_ignores_range(tmp_path, monkeypatch):
     payload = b"resume-must-not-corrupt" * 16
-    # Break once, then reply 200 (full body) to the ranged resume — appending it
-    # would duplicate the prefix, so staging must refuse rather than corrupt.
-    server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload, breaks=[80], ignore_range=True), len(payload))
+    # Reply 200 (full body) to the bounded range request — the body would not
+    # match the requested slice, so the shard must refuse rather than corrupt.
+    server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload, ignore_range=True), len(payload))
 
     with pytest.raises(RuntimeError, match="ignored Range"):
-        stage_ghalogs_archive(str(tmp_path))
+        diagnostic_logs._download_ghalogs_shard(str(tmp_path), (0, 0, len(payload)))
 
-    assert not (tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH).exists()
-    assert server.ranges == [0, 80]
+    assert server.ranges == [0]
 
 
-def test_stage_ghalogs_archive_gives_up_after_stalls_without_progress(tmp_path, monkeypatch):
+def test_download_ghalogs_shard_gives_up_after_stalls_without_progress(tmp_path, monkeypatch):
     payload = b"never-fully-delivered" * 8
     # Every ranged resume yields zero bytes then drops: no forward progress, so
-    # the stall budget must be exhausted and staging must fail (not loop forever).
+    # the stall budget must be exhausted and the shard must fail (not loop forever).
     _patch_zenodo(monkeypatch, _FakeZenodoServer(payload, breaks=[50] + [0] * 20), len(payload))
 
     with pytest.raises(RuntimeError, match="stalled"):
-        stage_ghalogs_archive(str(tmp_path))
-
-    assert not (tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH).exists()
+        diagnostic_logs._download_ghalogs_shard(str(tmp_path), (0, 0, len(payload)))
 
 
-def test_stage_ghalogs_archive_gives_up_on_clean_empty_responses(tmp_path, monkeypatch):
+def test_download_ghalogs_shard_gives_up_on_clean_empty_responses(tmp_path, monkeypatch):
     # A server that keeps returning a successful but empty body makes no forward
     # progress and raises no exception; the loop must still give up via the stall
     # budget instead of re-requesting the same offset forever.
     server = _patch_zenodo(monkeypatch, _EmptyBodyServer(), declared_bytes=64)
 
     with pytest.raises(RuntimeError, match="stalled"):
-        stage_ghalogs_archive(str(tmp_path))
+        diagnostic_logs._download_ghalogs_shard(str(tmp_path), (0, 0, 64))
 
     # Bounded by the stall budget rather than looping unboundedly.
     assert server.get_calls <= diagnostic_logs._GHALOGS_MAX_RESUME_STALLS + 1
-    assert not (tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH).exists()
 
 
 def test_stage_ghalogs_archive_skips_when_correctly_sized_copy_exists(tmp_path, monkeypatch):
@@ -632,12 +657,13 @@ def test_stage_ghalogs_archive_skips_when_correctly_sized_copy_exists(tmp_path, 
 
 def test_stage_ghalogs_archive_raises_on_size_mismatch(tmp_path, monkeypatch):
     # Server only ever has 10 bytes but the manifest declares 25; the ranged
-    # resume past EOF returns 416, so staging stops short and flags the shortfall.
+    # request past EOF returns 416, so the shard stops short and flags the
+    # shortfall, failing the staging pipeline.
     available = b"only-ten!!"
     _patch_zenodo(monkeypatch, _FakeZenodoServer(available), declared_bytes=25)
 
     with pytest.raises(RuntimeError, match="size mismatch"):
-        stage_ghalogs_archive(str(tmp_path))
+        stage_ghalogs_archive(str(tmp_path), num_shards=1, max_workers=1)
 
     # Failed staging must not publish a partial archive at the final path.
     assert not (tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH).exists()

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -644,6 +644,37 @@ def test_ghalogs_range_gives_up_on_clean_empty_responses(monkeypatch):
     assert server.get_calls <= diagnostic_logs._GHALOGS_MAX_RESUME_STALLS + 1
 
 
+def test_ghalogs_parts_prefix_uses_same_bucket_ttl_temp(monkeypatch):
+    archive = "gs://marin-eu-west4/raw/diagnostic_logs/ghalogs/files/github_run_logs.zip"
+    monkeypatch.setattr(
+        diagnostic_logs,
+        "marin_temp_bucket",
+        lambda ttl_days, prefix="", *, source_prefix=None: f"gs://marin-eu-west4/tmp/ttl={ttl_days}d/{prefix}",
+    )
+
+    parts = diagnostic_logs._ghalogs_parts_prefix(archive)
+
+    # Same bucket (GCS compose cannot cross buckets), under the TTL'd temp
+    # prefix, keyed by the archive path so the location is stable across runs.
+    assert parts == "gs://marin-eu-west4/tmp/ttl=7d/ghalogs-parts/raw/diagnostic_logs/ghalogs/files/github_run_logs.zip"
+
+
+def test_ghalogs_parts_prefix_falls_back_beside_archive_when_temp_bucket_differs(tmp_path, monkeypatch):
+    # The temp helper routes unknown buckets to the marin prefix, which lives in
+    # a different bucket — compose could not merge from there, so parts must
+    # stay next to the archive. Local paths (no bucket) fall back the same way.
+    archive = "gs://not-a-marin-bucket/data/github_run_logs.zip"
+    monkeypatch.setattr(
+        diagnostic_logs,
+        "marin_temp_bucket",
+        lambda ttl_days, prefix="", *, source_prefix=None: f"gs://marin-us-central2/tmp/ttl={ttl_days}d/{prefix}",
+    )
+
+    assert diagnostic_logs._ghalogs_parts_prefix(archive) == f"{archive}.parts"
+    local_archive = str(tmp_path / "github_run_logs.zip")
+    assert diagnostic_logs._ghalogs_parts_prefix(local_archive) == f"{local_archive}.parts"
+
+
 def test_stage_ghalogs_archive_skips_when_correctly_sized_copy_exists(tmp_path, monkeypatch):
     payload = b"already-staged-archive-bytes"
     server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload), len(payload))

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -526,7 +526,24 @@ class _FakeZenodoServer:
         return _FakeStreamResponse(status, chunks)
 
 
-def _patch_zenodo(monkeypatch, server: _FakeZenodoServer, declared_bytes: int) -> _FakeZenodoServer:
+class _EmptyBodyServer:
+    """Always replies successfully with an empty body and a clean close.
+
+    Models a proxy/CDN that keeps acknowledging the (ranged) request but never
+    delivers bytes — no exception is raised, so the caller must detect the lack
+    of progress itself rather than re-request the same offset forever.
+    """
+
+    def __init__(self):
+        self.get_calls = 0
+
+    def get(self, url: str, *, stream: bool, timeout, headers=None) -> _FakeStreamResponse:
+        self.get_calls += 1
+        status = http.client.PARTIAL_CONTENT if (headers and "Range" in headers) else http.client.OK
+        return _FakeStreamResponse(status, [])
+
+
+def _patch_zenodo(monkeypatch, server, declared_bytes: int):
     monkeypatch.setattr(diagnostic_logs, "build_retrying_session", lambda: server)
     monkeypatch.setattr(diagnostic_logs, "GHALOGS_ARCHIVE_BYTES", declared_bytes)
     monkeypatch.setattr(diagnostic_logs.time, "sleep", lambda _s: None)
@@ -581,6 +598,20 @@ def test_stage_ghalogs_archive_gives_up_after_stalls_without_progress(tmp_path, 
     with pytest.raises(RuntimeError, match="stalled"):
         stage_ghalogs_archive(str(tmp_path))
 
+    assert not (tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH).exists()
+
+
+def test_stage_ghalogs_archive_gives_up_on_clean_empty_responses(tmp_path, monkeypatch):
+    # A server that keeps returning a successful but empty body makes no forward
+    # progress and raises no exception; the loop must still give up via the stall
+    # budget instead of re-requesting the same offset forever.
+    server = _patch_zenodo(monkeypatch, _EmptyBodyServer(), declared_bytes=64)
+
+    with pytest.raises(RuntimeError, match="stalled"):
+        stage_ghalogs_archive(str(tmp_path))
+
+    # Bounded by the stall budget rather than looping unboundedly.
+    assert server.get_calls <= diagnostic_logs._GHALOGS_MAX_RESUME_STALLS + 1
     assert not (tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH).exists()
 
 

--- a/tests/datakit/download/test_diagnostic_logs.py
+++ b/tests/datakit/download/test_diagnostic_logs.py
@@ -1,6 +1,7 @@
 # Copyright The Marin Authors
 # SPDX-License-Identifier: Apache-2.0
 
+import http.client
 import json
 import xml.etree.ElementTree as ET
 import zipfile
@@ -8,6 +9,7 @@ from pathlib import Path
 
 import pyarrow.parquet as pq
 import pytest
+import requests
 from marin.datakit.download import diagnostic_logs
 from marin.datakit.download.diagnostic_logs import (
     GHALOGS_ROUGH_TOKENS_B,
@@ -451,8 +453,10 @@ def test_ghalogs_public_normalize_steps_read_where_download_wrote(tmp_path, monk
 class _FakeStreamResponse:
     """Minimal stand-in for a streamed ``requests`` response."""
 
-    def __init__(self, chunks: list[bytes]):
+    def __init__(self, status_code: int, chunks: list[bytes], break_exc: Exception | None = None):
+        self.status_code = status_code
         self._chunks = chunks
+        self._break_exc = break_exc
 
     def __enter__(self) -> "_FakeStreamResponse":
         return self
@@ -461,42 +465,128 @@ class _FakeStreamResponse:
         return False
 
     def raise_for_status(self) -> None:
-        return None
+        if self.status_code >= 400:
+            raise requests.exceptions.HTTPError(f"status {self.status_code}")
 
     def iter_content(self, chunk_size: int):
         yield from self._chunks
+        if self._break_exc is not None:
+            raise self._break_exc
 
 
-class _FakeSession:
-    def __init__(self, chunks: list[bytes]):
-        self._chunks = chunks
+class _FakeZenodoServer:
+    """Range-aware fake of the Zenodo archive endpoint.
+
+    Serves ``available`` bytes. ``breaks`` is a per-GET plan: the i-th GET yields
+    at most ``breaks[i]`` bytes of its requested range and then raises
+    ``ChunkedEncodingError`` (``None`` = serve the range to completion),
+    simulating a mid-stream drop. A ``Range`` request at/beyond ``available``
+    returns 416 so the caller sees "no more data". ``ignore_range`` forces a 200
+    (full-body) reply even to a ``Range`` request, modeling a server that drops
+    resume support. Records every requested start offset in ``ranges``.
+    """
+
+    def __init__(
+        self,
+        available: bytes,
+        *,
+        breaks: list[int | None] | None = None,
+        ignore_range: bool = False,
+        out_chunk: int = 40,
+    ):
+        self.available = available
+        self.breaks = list(breaks or [])
+        self.ignore_range = ignore_range
+        self.out_chunk = out_chunk
         self.get_calls = 0
+        self.ranges: list[int] = []
 
-    def get(self, url: str, *, stream: bool, timeout) -> _FakeStreamResponse:
+    def get(self, url: str, *, stream: bool, timeout, headers=None) -> _FakeStreamResponse:
+        headers = headers or {}
+        ranged = "Range" in headers
+        start = int(headers["Range"].split("=")[1].split("-")[0]) if ranged else 0
         self.get_calls += 1
-        return _FakeStreamResponse(self._chunks)
+        self.ranges.append(start)
+
+        if ranged and start >= len(self.available):
+            return _FakeStreamResponse(http.client.REQUESTED_RANGE_NOT_SATISFIABLE, [])
+
+        if ranged and self.ignore_range:
+            body, status, start = self.available, http.client.OK, 0
+        else:
+            body = self.available[start:]
+            status = http.client.PARTIAL_CONTENT if ranged else http.client.OK
+
+        brk = self.breaks.pop(0) if self.breaks else None
+        if brk is not None:
+            return _FakeStreamResponse(
+                status, [body[:brk]], break_exc=requests.exceptions.ChunkedEncodingError("connection broken")
+            )
+        chunks = [body[i : i + self.out_chunk] for i in range(0, len(body), self.out_chunk)] or [b""]
+        return _FakeStreamResponse(status, chunks)
 
 
-def _patch_zenodo_stream(monkeypatch, payload: bytes, chunks: list[bytes]) -> _FakeSession:
-    session = _FakeSession(chunks)
-    monkeypatch.setattr(diagnostic_logs, "build_retrying_session", lambda: session)
-    monkeypatch.setattr(diagnostic_logs, "GHALOGS_ARCHIVE_BYTES", len(payload))
-    return session
+def _patch_zenodo(monkeypatch, server: _FakeZenodoServer, declared_bytes: int) -> _FakeZenodoServer:
+    monkeypatch.setattr(diagnostic_logs, "build_retrying_session", lambda: server)
+    monkeypatch.setattr(diagnostic_logs, "GHALOGS_ARCHIVE_BYTES", declared_bytes)
+    monkeypatch.setattr(diagnostic_logs.time, "sleep", lambda _s: None)
+    return server
 
 
 def test_stage_ghalogs_archive_streams_to_expected_path(tmp_path, monkeypatch):
     payload = b"PK\x03\x04" + b"github-run-log-bytes" * 32
-    _patch_zenodo_stream(monkeypatch, payload, [payload[:40], payload[40:]])
+    server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload), len(payload))
 
     stage_ghalogs_archive(str(tmp_path))
 
     staged = tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
     assert staged.read_bytes() == payload
+    # A clean stream needs exactly one request — no Range resume.
+    assert server.ranges == [0]
+
+
+def test_stage_ghalogs_archive_resumes_after_midstream_break(tmp_path, monkeypatch):
+    payload = b"PK\x03\x04" + b"github-run-log-bytes" * 64  # 1284 bytes
+    # First GET yields 500 bytes then drops; second drops again at 900; third completes.
+    server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload, breaks=[500, 400]), len(payload))
+
+    stage_ghalogs_archive(str(tmp_path))
+
+    staged = tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
+    assert staged.read_bytes() == payload
+    # Resumed from the last written offset each time (Range: bytes=500-, then 900-),
+    # never restarting from zero.
+    assert server.ranges == [0, 500, 900]
+
+
+def test_stage_ghalogs_archive_aborts_if_server_ignores_range(tmp_path, monkeypatch):
+    payload = b"resume-must-not-corrupt" * 16
+    # Break once, then reply 200 (full body) to the ranged resume — appending it
+    # would duplicate the prefix, so staging must refuse rather than corrupt.
+    server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload, breaks=[80], ignore_range=True), len(payload))
+
+    with pytest.raises(RuntimeError, match="ignored Range"):
+        stage_ghalogs_archive(str(tmp_path))
+
+    assert not (tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH).exists()
+    assert server.ranges == [0, 80]
+
+
+def test_stage_ghalogs_archive_gives_up_after_stalls_without_progress(tmp_path, monkeypatch):
+    payload = b"never-fully-delivered" * 8
+    # Every ranged resume yields zero bytes then drops: no forward progress, so
+    # the stall budget must be exhausted and staging must fail (not loop forever).
+    _patch_zenodo(monkeypatch, _FakeZenodoServer(payload, breaks=[50] + [0] * 20), len(payload))
+
+    with pytest.raises(RuntimeError, match="stalled"):
+        stage_ghalogs_archive(str(tmp_path))
+
+    assert not (tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH).exists()
 
 
 def test_stage_ghalogs_archive_skips_when_correctly_sized_copy_exists(tmp_path, monkeypatch):
     payload = b"already-staged-archive-bytes"
-    session = _patch_zenodo_stream(monkeypatch, payload, [payload])
+    server = _patch_zenodo(monkeypatch, _FakeZenodoServer(payload), len(payload))
 
     staged = tmp_path / GHALOGS_STAGED_ARCHIVE_RELATIVE_PATH
     staged.parent.mkdir(parents=True)
@@ -505,14 +595,15 @@ def test_stage_ghalogs_archive_skips_when_correctly_sized_copy_exists(tmp_path, 
     stage_ghalogs_archive(str(tmp_path))
 
     # A correctly-sized copy short-circuits before any HTTP request.
-    assert session.get_calls == 0
+    assert server.get_calls == 0
     assert staged.read_bytes() == payload
 
 
 def test_stage_ghalogs_archive_raises_on_size_mismatch(tmp_path, monkeypatch):
-    payload = b"the-full-expected-archive"
-    # Server truncates the stream: streamed bytes fall short of the expected size.
-    _patch_zenodo_stream(monkeypatch, payload, [payload[:10]])
+    # Server only ever has 10 bytes but the manifest declares 25; the ranged
+    # resume past EOF returns 416, so staging stops short and flags the shortfall.
+    available = b"only-ten!!"
+    _patch_zenodo(monkeypatch, _FakeZenodoServer(available), declared_bytes=25)
 
     with pytest.raises(RuntimeError, match="size mismatch"):
         stage_ghalogs_archive(str(tmp_path))
@@ -523,7 +614,7 @@ def test_stage_ghalogs_archive_raises_on_size_mismatch(tmp_path, monkeypatch):
 
 def test_download_ghalogs_step_targets_staged_prefix_and_streams_archive(tmp_path, monkeypatch):
     payload = b"downloaded-archive-payload"
-    _patch_zenodo_stream(monkeypatch, payload, [payload])
+    _patch_zenodo(monkeypatch, _FakeZenodoServer(payload), len(payload))
 
     step = download_ghalogs_step(output_path_prefix=str(tmp_path))
     assert step.output_path == f"{tmp_path}/{GHALOGS_STAGED_PREFIX}"


### PR DESCRIPTION
The GHALogs staging step streamed the ~142 GB Zenodo archive over a single connection. That failed two ways in a real staging run: the stream broke mid-body at ~8 GB (`IncompleteRead`) and restarted from byte 0, and the connection was throttled to ~1.1 MB/s, projecting ~36 h for the full archive. Zenodo throttles per connection, not per client — concurrent probes show some connections sustaining 10–17 MB/s while others are capped at ~1 MB/s — so a single stream is one unlucky dice roll held for 142 GB.

Split the download into 32 contiguous byte-range shards, run as a zephyr pipeline (`from_list(ranges).flat_map(iter_range).write_binary(part, skip_existing=True)`), and assemble the archive server-side:

- Each shard issues bounded `Range: bytes=a-b` requests (Zenodo honors them: 206 + exact slice) and yields chunks into zephyr's binary writer, which publishes its part object via atomic rename on the bucket's TTL'd temp prefix (`tmp/ttl=7d/ghalogs-parts/{archive key}/part-{start}-{stop}`). The temp prefix shares the archive's bucket — required for the server-side merge — and its lifecycle rule sweeps parts a failed run leaves behind if no retry ever comes; unknown buckets and local paths fall back to a `.parts` sibling of the archive. On a mid-body drop or clean early EOF the generator re-requests from its last yielded offset; a bounded budget of consecutive no-progress reconnects fails the shard, and a short range raises before the part publishes.
- `skip_existing=True` skips a shard — the range request never starts — when its part already exists. Existing implies complete because parts publish atomically, and the range embedded in the name means parts from a different shard layout are never mistaken for current ones. Shard retries, pod deaths, and whole re-runs only re-download missing shards — resume now survives process death, which the previous in-process design could not.
- After all shards complete, the archive is concatenated *server-side* — no bytes flow back through the client: `fs.merge` maps to S3 `UploadPartCopy` on R2/CoreWeave and `compose` on GCS (both verified against `marin-na` and `marin-eu-west4`; the merged object materializes atomically). 32 shards (~4.4 GB) sits inside both concat limits: GCS compose accepts at most 32 sources per call and S3 part copies cap at 5 GiB; `num_shards` is validated up front so a bad value cannot fail only after the full download.
- Concurrency is capped at 8 zephyr workers to stay polite to Zenodo (request rate is a rounding error against its per-window limit; shard resumes re-roll throttled connections instead of keeping them).

The guards from the single-stream design carry over per shard: a reply that ignores `Range` (200 instead of 206) is refused rather than appended, a `416` past EOF is a clean stop so the exact-size checks flag a genuine shortfall, and a short merge result is deleted rather than published.

Verified end-to-end on the marin cluster: from eu-west4 the 8 workers sustained ~50 MB/s per connection (Zenodo is at CERN), staging all 32 parts in ~8 min; the 32-part GCS compose plus verification took seconds, and the archive landed at its canonical path at exactly 142,292,965,496 bytes with the parts prefix cleaned up. The original single-stream run projected ~36 h and died at 8 GB.
