### PR TITLE
zephyr: raise worker-gang cumulative failure budget from 10 to 200

### DIFF
--- a/lib/zephyr/src/zephyr/execution.py
+++ b/lib/zephyr/src/zephyr/execution.py
@@ -84,6 +84,16 @@ MAX_SHARD_FAILURES = 3
 # storms for any one shard in a multi-shard pipeline.
 MAX_SHARD_INFRA_FAILURES = 20
 
+# Cumulative failed worker-task attempts the iris worker gang tolerates before it
+# kills the whole group (maps to iris ``max_task_failures``). Preemptions that
+# exit uncleanly are counted here, so on a contended cluster a multi-hour
+# pipeline accumulates them steadily; a small budget trips mid-run and discards
+# hours of near-complete work (observed: a 7-hour dedup reduce killed at 97% by
+# ~13 preemption-induced failures against the old budget of 10). Set well above a
+# realistic preemption storm — genuinely deterministic crashes are still caught,
+# faster and per-shard, by MAX_SHARD_FAILURES / MAX_SHARD_INFRA_FAILURES.
+WORKER_GANG_MAX_TASK_RETRIES = 200
+
 # Typical status text for a 6-stage pipeline is ~300 chars.
 MAX_STATUS_TEXT_LENGTH = 1000
 
@@ -1576,7 +1586,7 @@ def _run_coordinator_job(config_path: str, result_path: str) -> None:
                 name=worker_name,
                 count=actual_workers,
                 resources=config.worker_resources,
-                actor_config=ActorConfig(max_task_retries=10),
+                actor_config=ActorConfig(max_task_retries=WORKER_GANG_MAX_TASK_RETRIES),
             )
             ready_wait_s = float(os.environ.get("ZEPHYR_WORKERS_READY_WAIT") or 12 * 60 * 60)
             worker_group.wait_ready(count=1, timeout=ready_wait_s)


### PR DESCRIPTION
Interim mitigation for #7121.

The iris worker gang is created with `max_task_retries=10`, which maps to iris `max_task_failures` — the cumulative failed-task budget before iris kills the whole gang. On a contended cluster, preemptions that terminate uncleanly (SIGKILL-after-grace surfaces as `reason=Error, exit=137`) are misclassified as application failures and charged to this budget, so a multi-hour pipeline accumulates them and trips a budget of 10 mid-run — observed killing the datakit finetranslations dedup reduce at 97% (25072/25962) after ~13 preemption-induced failures.

Raise the budget to 200 via a named constant so the gang rides out a realistic preemption storm. This only widens tolerance for infra churn: genuinely deterministic crashes are still caught faster and per-shard by `MAX_SHARD_FAILURES` / `MAX_SHARD_INFRA_FAILURES`.

This is a stopgap, not the real fix. The root cause is the k8s backend misclassifying preemptions (#7121: `_is_infrastructure_failure` ignores the `DisruptionTarget` pod condition). Once that lands, preemptions are correctly excluded from the cumulative gate and this constant should revert to a small value — leaving 200 in place weakens the gate's legitimate protection against a gang that crash-loops with a different task failing each round.

Part of #7121
