### PR TITLE
iris: classify preempted k8s pods via the DisruptionTarget condition

### DIFF
--- a/lib/iris/src/iris/cluster/backends/k8s/tasks.py
+++ b/lib/iris/src/iris/cluster/backends/k8s/tasks.py
@@ -131,6 +131,18 @@ _POD_NOT_FOUND_GRACE_CYCLES = 3
 # (requesting too little memory), not transient infrastructure failure.
 _INFRASTRUCTURE_FAILURE_REASONS = frozenset({"Evicted", "DeadlineExceeded", "Preempting"})
 
+# The control plane stamps a ``DisruptionTarget`` pod condition (status "True")
+# whenever it disrupts a pod: scheduler preemption (PreemptionByScheduler),
+# node-pressure or graceful node shutdown (TerminationByKubelet), taint eviction
+# (DeletionByTaintManager), API eviction (EvictionByEvictionAPI), or pod GC
+# (DeletionByPodGC). It is authoritative and independent of the container exit
+# code, so it catches a preemption whose container was SIGKILLed after the grace
+# period — which surfaces as ``reason="Error"``, exit 137 and is missed by
+# _INFRASTRUCTURE_FAILURE_REASONS above. A container that OOMs against its own
+# cgroup limit gets no such condition, so it correctly stays an application
+# failure. GA since Kubernetes 1.26.
+_DISRUPTION_TARGET_CONDITION = "DisruptionTarget"
+
 # ---------------------------------------------------------------------------
 # Kueue gang admission (coscheduled jobs only)
 # ---------------------------------------------------------------------------
@@ -834,13 +846,33 @@ def _task_container_status(pod: dict) -> dict | None:
     return statuses[0]
 
 
-def _is_infrastructure_failure(pod: dict) -> bool:
-    """Check if the pod failure was caused by infrastructure (OOM, eviction, etc.).
+def _has_disruption_target_condition(pod: dict) -> bool:
+    """True if the control plane marked this pod for infrastructure disruption.
 
-    Returns True when the terminated reason indicates the failure was NOT caused
-    by the application itself, so it should be classified as a worker/preemption
-    failure rather than an application failure.
+    See :data:`_DISRUPTION_TARGET_CONDITION` — the authoritative preemption/
+    eviction/drain signal, independent of the container exit code.
     """
+    for condition in pod.get("status", {}).get("conditions", []):
+        if condition.get("type") == _DISRUPTION_TARGET_CONDITION and condition.get("status") == "True":
+            return True
+    return False
+
+
+def _is_infrastructure_failure(pod: dict) -> bool:
+    """Check if the pod failure was caused by infrastructure (preemption, eviction, etc.).
+
+    Returns True when the failure was NOT caused by the application itself, so it
+    should be classified as a worker/preemption failure rather than an
+    application failure.
+    """
+    # Authoritative first: the control plane explicitly disrupted this pod
+    # (preempted/evicted/drained), regardless of how the container exited. This
+    # catches a preemption SIGKILLed after the grace period — reason="Error",
+    # exit 137 — which the terminated-reason whitelist below misses. A container
+    # that OOMs on its own cgroup limit carries no such condition and correctly
+    # falls through to an application failure.
+    if _has_disruption_target_condition(pod):
+        return True
     status = _task_container_status(pod)
     if status is None:
         # Pod-level eviction: the pod status reason indicates infrastructure.

--- a/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
+++ b/lib/iris/tests/cluster/backends/k8s/test_pod_manifest.py
@@ -292,6 +292,41 @@ def test_is_infrastructure_failure_with_pod_level_reason():
     assert _is_infrastructure_failure(pod)
 
 
+def _add_condition(pod: dict, type_: str, status: str, reason: str = "") -> dict:
+    pod["status"].setdefault("conditions", []).append({"type": type_, "status": status, "reason": reason})
+    return pod
+
+
+@pytest.mark.parametrize("reason", ["PreemptionByScheduler", "TerminationByKubelet", "EvictionByEvictionAPI"])
+def test_task_update_disruption_target_is_worker_failed(reason):
+    """A preemption SIGKILLed after grace surfaces as reason='Error' exit 137 — not in
+    the reason whitelist — but the control plane's DisruptionTarget condition marks it
+    as infrastructure, so it must be WORKER_FAILED (preemption budget), not FAILED."""
+    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    pod = make_pod("iris-job-0-0", "Failed", exit_code=137, reason="Error")
+    _add_condition(pod, "DisruptionTarget", "True", reason)
+    update = _task_update_from_pod(entry, pod)
+    assert update.new_state == job_pb2.TASK_STATE_WORKER_FAILED
+    assert update.exit_code == 137
+
+
+def test_task_update_oom_killed_without_disruption_target_stays_application_failure():
+    """A self-inflicted cgroup OOM carries no DisruptionTarget condition, so it stays a
+    FAILED (misconfigured job) even though it also exits 137 — the condition, not the
+    exit code, is what distinguishes preemption from OOM guilt."""
+    entry = RunningTaskEntry(task_id=JobName.from_wire("/job/0"), attempt_id=0)
+    pod = make_pod("iris-job-0-0", "Failed", exit_code=137, reason="OOMKilled")
+    update = _task_update_from_pod(entry, pod)
+    assert update.new_state == job_pb2.TASK_STATE_FAILED
+
+
+def test_disruption_target_condition_status_false_is_not_infrastructure():
+    """A DisruptionTarget condition with status != 'True' does not mark a disruption."""
+    pod = make_pod("iris-job-0-0", "Failed", exit_code=1, reason="Error")
+    _add_condition(pod, "DisruptionTarget", "False", "")
+    assert not _is_infrastructure_failure(pod)
+
+
 # ---------------------------------------------------------------------------
 # Node resource parsing
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
The k8s backend classified a dead pod as infrastructure-vs-application failure purely by the container's `terminated.reason`, matched against a 3-item whitelist `{Evicted, DeadlineExceeded, Preempting}`. A real preemption on CoreWeave/Kueue terminates dirty — SIGKILL after the grace period surfaces as `reason=Error, exit 137` — which misses the whitelist and was charged to the application-failure budget. Those leaked failures accumulate in the cumulative `max_task_failures` gate (which is *designed* to exclude preemptions), killing preemptible gangs mid-run: a datakit dedup reduce was killed at 97% after ~13 preemption-induced failures against a budget of 10.

Check the control plane's `DisruptionTarget` pod condition first. Kubernetes stamps it (`status=True`) whenever it preempts (`PreemptionByScheduler`), node-drains (`TerminationByKubelet`), taint-evicts (`DeletionByTaintManager`), or API-evicts (`EvictionByEvictionAPI`) a pod, with an authoritative reason independent of the container exit code.

Why this is the right signal, not an exit-code heuristic:
- A SIGKILLed container is ambiguous by exit code alone (a preemption and a genuine crash both exit 137). The `DisruptionTarget` condition is the control plane explicitly recording *"I disrupted this pod."*
- **OOM guilt preserved:** a container that OOMs on its own cgroup limit carries no `DisruptionTarget` condition, so it stays a `FAILED` (misconfigured job), as before.
- **Crash-loop protection intact:** a genuine app crash has no condition, stays `FAILED`, still trips the cumulative gate.
- The fully-deleted-pod path (`tasks.py`, `WORKER_FAILED if coscheduled`) already handled preemptions whose pod vanishes before the poll; this closes the remaining window where the pod lingers in a dirty terminal state.

Verified on cw-rno2a (k8s v1.36): an Eviction-API eviction stamps `DisruptionTarget status=True reason=EvictionByEvictionAPI`, and it persists for the whole grace window, so the reconcile poll observes it before the pod is removed. Scheduler preemption uses the same condition type with `reason=PreemptionByScheduler`.

Fixes #7121
