### PR TITLE
[iris] Skip June TPU 67B checkpoint test when CoreWeave kube-config is absent

### DIFF
--- a/.github/workflows/unified-unit.yaml
+++ b/.github/workflows/unified-unit.yaml
@@ -69,13 +69,21 @@ jobs:
 
       - env:
           HF_TOKEN: ${{ secrets.HF_TOKEN }}
-        run: >-
-          uv run
-          --package ${{ matrix.package }}
-          ${{ matrix.extras }}
-          --group test
-          pytest --durations=5 -n auto --dist=worksteal --tb=short
-          ${{ matrix.test_paths }}
+        # pytest exits 5 when it collects no tests. The diff-based selector can hand a lane
+        # only tests that its default marker filter deselects (integration, slow,
+        # requires_cluster, ...) — e.g. a PR that touches just an integration test file —
+        # which is not a failure. Those tests run in their own dedicated workflow. Treat
+        # exit 5 as success; every other non-zero status still fails the lane.
+        run: |
+          status=0
+          uv run \
+            --package ${{ matrix.package }} \
+            ${{ matrix.extras }} \
+            --group test \
+            pytest --durations=5 -n auto --dist=worksteal --tb=short \
+            ${{ matrix.test_paths }} || status=$?
+          [ "$status" -eq 5 ] && exit 0
+          exit "$status"
 
   levanter_torch:
     name: levanter-torch

--- a/tests/integration/iris/test_june_tpu_67b_a2b_checkpoint.py
+++ b/tests/integration/iris/test_june_tpu_67b_a2b_checkpoint.py
@@ -33,7 +33,6 @@ from iris.client import IrisClient
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
 from iris.test_util import wait_for_condition
-from kubernetes.config.config_exception import ConfigException
 from levanter.checkpoint import load_checkpoint
 from levanter.grug.sharding import compact_grug_mesh
 from levanter.tokenizers import load_tokenizer
@@ -70,6 +69,10 @@ def marin_gpu_client() -> Iterator[IrisClient]:
     # This test drives a live CoreWeave GPU node; it can only run where the cluster's
     # kube credentials are present. In CI (and any workstation without them) opening the
     # client raises ConfigException, so skip rather than error the whole integration run.
+    # Import kubernetes lazily: it ships with iris[controller] and is absent from the
+    # unit-test env, which still collects (imports) this module before deselecting it.
+    from kubernetes.config.config_exception import ConfigException  # noqa: PLC0415
+
     with contextlib.ExitStack() as stack:
         try:
             client = stack.enter_context(open_iris_client(cluster_name=CLUSTER_NAME, workspace=MARIN_ROOT))

--- a/tests/integration/iris/test_june_tpu_67b_a2b_checkpoint.py
+++ b/tests/integration/iris/test_june_tpu_67b_a2b_checkpoint.py
@@ -9,6 +9,7 @@ Run from the repository root:
     uv run pytest tests/integration/iris/test_june_tpu_67b_a2b_checkpoint.py -o addopts= -vv -s
 """
 
+import contextlib
 import dataclasses
 import json
 import logging
@@ -32,6 +33,7 @@ from iris.client import IrisClient
 from iris.cluster.types import JobName
 from iris.rpc import job_pb2
 from iris.test_util import wait_for_condition
+from kubernetes.config.config_exception import ConfigException
 from levanter.checkpoint import load_checkpoint
 from levanter.grug.sharding import compact_grug_mesh
 from levanter.tokenizers import load_tokenizer
@@ -65,7 +67,14 @@ pytestmark = [pytest.mark.integration, pytest.mark.slow, pytest.mark.timeout(PEN
 
 @pytest.fixture
 def marin_gpu_client() -> Iterator[IrisClient]:
-    with open_iris_client(cluster_name=CLUSTER_NAME, workspace=MARIN_ROOT) as client:
+    # This test drives a live CoreWeave GPU node; it can only run where the cluster's
+    # kube credentials are present. In CI (and any workstation without them) opening the
+    # client raises ConfigException, so skip rather than error the whole integration run.
+    with contextlib.ExitStack() as stack:
+        try:
+            client = stack.enter_context(open_iris_client(cluster_name=CLUSTER_NAME, workspace=MARIN_ROOT))
+        except ConfigException as exc:
+            pytest.skip(f"CoreWeave cluster {CLUSTER_NAME!r} unavailable (no kube-config): {exc}")
         yield client
 
 


### PR DESCRIPTION
Two CI-red fixes, both surfaced by the June TPU 67B checkpoint test that #7116 added.

`Marin - Integration` was red on main: the `marin_gpu_client` fixture opens a client against the live `cw-us-east-02a` cluster, which needs kube credentials CI doesn't have. That raised `ConfigException` at fixture setup, and because the iris integration step runs with `-x`, the one error failed the whole job. Catch `ConfigException` and `pytest.skip` instead, so the test runs where the cluster credentials exist and is skipped everywhere else. It's the only integration test that talks to a live CoreWeave cluster; the rest connect to a local controller via `--controller-url`. The kubernetes import is done inside the fixture so the unit env — which collects this module before deselecting it by marker, and lacks `iris[controller]` — can still import it.

The second fix addresses a pre-existing gap this exposed. The diff-based test selector adds any changed test file to its unit lane. A PR that touches only a marker-deselected test (integration, slow, requires_cluster, ...) leaves the lane with nothing to run after the default marker filter, so pytest exits 5 ("no tests collected") and the lane goes red — even though those tests run in their own dedicated workflow. Treat exit 5 as success in the unit run step; every other non-zero status still fails the lane.