### PR TITLE
[iris] Exempt federated handoffs from the client-freshness gate

### DIFF
--- a/lib/iris/docs/federation.md
+++ b/lib/iris/docs/federation.md
@@ -98,6 +98,20 @@ identity is refused before the handoff. In-cluster workers authenticate by netwo
 so a job submitted by a worker is `local_admin` — a root submitted by a logged-in user is the
 only thing that federates.
 
+## What the peer checks when a handoff arrives
+
+A handoff is authorized as a peer-to-peer delivery, not as a user submission. The peer
+verifies the requesting cluster's signed identity and its own `allowed_submitters` against the
+principal the parent asserts, then admits the job under the parent's job id.
+
+What it does *not* re-run is the client-freshness gate. That gate makes humans upgrade a stale
+`marin-iris` CLI, and the wire client here is the parent controller, which re-encodes the
+request from its own stored job state — the submitter's `client_revision_date` is not part of
+that state and does not survive the round-trip. The parent already gated the submitter's client
+when it accepted the job, and a queued job may wait longer than the freshness window before it
+is delivered, so gating on arrival would reject handoffs for a staleness the peer cannot
+actually observe.
+
 ## What travels with the job
 
 `FederationManager._inline_blobs` (`cluster/federation/manager.py`) carries the workspace
@@ -124,17 +138,36 @@ Every artifact a federated job touches must live in the peer's object store.
 
 ## Observing federation
 
-There is no `iris peers` command. Reachability and advertised shapes come from the
-`ListPeers` RPC; handoff state lives in the parent's `federated_jobs` table.
+There is no `iris peers` command. Reachability, advertised shapes, and free capacity come
+from the `ListPeers` RPC; handoff state lives in the parent's `federated_jobs` table.
 
 ```bash
-# Which peers are reachable, and what each advertises
+# Which peers are reachable, what each advertises, and how much is free
 uv run iris --cluster=marin rpc controller list-peers
 
 # Where a job was handed off, to whom, and under which principal
 uv run iris --cluster=marin query \
   "SELECT job_id, peer_id, owner_principal, handoff_state FROM federated_jobs"
 ```
+
+Each backend in the `list-peers` output carries an `availability` block — the free-capacity
+metric the queue gates on (`{"version": 1, "observation_epoch_ms": …, "amounts": {"h100": 504}}`).
+A backend with **no** `availability` block supplies no metric and is matched on shape alone,
+so jobs route to it without a capacity check.
+
+A queued job and a delivered one are both `pending` on the parent, but they are waiting on
+different things, and `job list` says which:
+
+| Pending reason | Meaning |
+| --- | --- |
+| `Queued for a federation peer to report free capacity` | In the queue, no peer chosen yet |
+| `Queued for peer X to report free capacity` | In the queue, pinned to `X` (`--target-cluster`) |
+| `Awaiting acceptance by peer X` | Promoted and delivered; awaiting the peer's admission |
+| `Handed off to peer X; awaiting first status report` | Admitted; the first sync has not landed |
+
+A job that sits on the first two lines is waiting for capacity, not stuck: compare its device
+request against the peer's advertised `amounts`. A job cancelled while queued never reaches the
+peer and terminates as `Cancelled before handoff`.
 
 A federated job's tasks live on the peer and are mirrored back, so `iris job summary` reports
 its state from `marin`. Its logs are relayed asynchronously into `marin`'s finelog and lag

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -725,15 +725,20 @@ def _peer_status(cluster: str, handoff_state: int | None, has_reported_tasks: bo
     return job_pb2.PEER_STATUS_ASSIGNED
 
 
-def _federated_pending_reason(cluster: str, peer_status: int) -> str:
+def _federated_pending_reason(cluster: str, handoff_state: int | None, peer_status: int) -> str:
     """Pending reason for a federated job, which the local scheduler never sees.
 
     A handed-off job's tasks live on the peer and are excluded from the local
     fold, so the local scheduling diagnostic is meaningless for it. Derive the
-    message from the handoff posture (single source of truth): awaiting the
-    peer's acceptance, awaiting its first status report, or pending on the peer
-    once it has reported tasks.
+    message from the handoff posture (single source of truth): waiting in the
+    federation queue for a peer with free capacity, awaiting the peer's acceptance,
+    awaiting its first status report, or pending on the peer once it has reported
+    tasks. A queued job names a peer only when it is pinned to one.
     """
+    if handoff_state == int(HandoffState.QUEUED_HANDOFF):
+        if not cluster:
+            return "Queued for a federation peer to report free capacity"
+        return f"Queued for peer {cluster} to report free capacity"
     if peer_status == job_pb2.PEER_STATUS_PENDING_SCHEDULING:
         return f"Awaiting acceptance by peer {cluster}"
     if peer_status == job_pb2.PEER_STATUS_ASSIGNED:
@@ -1308,14 +1313,6 @@ class ControllerServiceImpl:
 
         job_id = JobName.from_wire(request.name)
 
-        # Reject root RPC submissions from stale clients. Direct in-process
-        # calls have no wire client; tests and harnesses use ctx=None.
-        # Nested submissions are exempt because they come from an already
-        # running workload, which would otherwise crash mid-flight as the
-        # freshness window slides forward.
-        if job_id.is_root and ctx is not None:
-            _check_client_freshness(request.client_revision_date, date.today())
-
         # Reconcile the requested job owner with the authenticated principal.
         #
         # The job name's user segment names the *acting* owner the job is
@@ -1343,6 +1340,20 @@ class ControllerServiceImpl:
         # trusts the name, so there is nothing to forge.
         if is_received_handoff and self._auth.provider:
             self._authorize_federation_handoff(identity, request, job_id)
+
+        # Reject root RPC submissions from stale clients. Direct in-process calls have
+        # no wire client; tests and harnesses use ctx=None. Nested submissions are
+        # exempt because they come from an already running workload, which would
+        # otherwise crash mid-flight as the freshness window slides forward. A received
+        # handoff is exempt for the same reason and one more: the wire client is the
+        # parent controller, which re-encodes the request from its own stored job state
+        # (the submitter's ``client_revision_date`` is not part of that state), and the
+        # parent already gated that submitter's client at its own LaunchJob. Gating here
+        # would reject every handoff, and a job may wait in the parent's federation
+        # queue for longer than the window before it is delivered. Runs after the
+        # handoff is authorized, so a forged ``federation`` field cannot dodge the gate.
+        if job_id.is_root and ctx is not None and not is_received_handoff:
+            _check_client_freshness(request.client_revision_date, date.today())
 
         # A received handoff carries the acting owner in its handoff name (from the
         # parent's signed ``owner_principal``), so it is exempt from re-pinning — the
@@ -1755,10 +1766,11 @@ class ControllerServiceImpl:
         # hint dict is cached per evaluate() cycle (#4848), so the lookup here
         # is a single dict get — we only attach this job's hint, never the
         # full routing decision.
-        peer_status = _peer_status(job.cluster, handle.handoff_state if handle else None, summary is not None)
+        handoff_state = handle.handoff_state if handle else None
+        peer_status = _peer_status(job.cluster, handoff_state, summary is not None)
         pending_reason = ""
         if job.state == job_pb2.JOB_STATE_PENDING and is_federated(job.cluster):
-            pending_reason = _federated_pending_reason(job.cluster, peer_status)
+            pending_reason = _federated_pending_reason(job.cluster, handoff_state, peer_status)
         elif job.state == job_pb2.JOB_STATE_PENDING:
             sched_reason = self._controller.get_job_scheduling_diagnostics(job.job_id.to_wire())
             pending_reason = sched_reason or "Pending scheduler feedback"
@@ -1878,7 +1890,7 @@ class ControllerServiceImpl:
         peer_status = _peer_status(j.cluster, handoff_state, task_summary is not None)
         pending_reason = j.error or ""
         if j.state == job_pb2.JOB_STATE_PENDING and is_federated(j.cluster):
-            pending_reason = _federated_pending_reason(j.cluster, peer_status)
+            pending_reason = _federated_pending_reason(j.cluster, handoff_state, peer_status)
         elif j.state == job_pb2.JOB_STATE_PENDING:
             sched_reason = self._controller.get_job_scheduling_diagnostics(j.job_id.to_wire())
             pending_reason = sched_reason or "Pending scheduler feedback"

--- a/lib/iris/tests/cluster/controller/test_federation_handoff.py
+++ b/lib/iris/tests/cluster/controller/test_federation_handoff.py
@@ -13,6 +13,7 @@ full-resync set-replacement path.
 """
 
 from contextlib import ExitStack
+from unittest.mock import Mock
 
 import pytest
 from connectrpc.code import Code
@@ -24,11 +25,16 @@ from iris.cluster.controller import reads, writes
 from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.federation_store import ControllerFederationStore
-from iris.cluster.controller.service import WORKDIR_FILE_OFFLOAD_THRESHOLD, ControllerServiceImpl, _peer_status
+from iris.cluster.controller.service import (
+    AVAILABILITY_METRIC_VERSION,
+    WORKDIR_FILE_OFFLOAD_THRESHOLD,
+    ControllerServiceImpl,
+    _peer_status,
+)
 from iris.cluster.federation.manager import FederationManager
 from iris.cluster.federation.peer import FederationPeer
 from iris.cluster.federation.store import HandoffAdmission, HandoffSpec, HandoffState
-from iris.cluster.types import LOCAL_ADMIN_SUBMITTER, LOCAL_CLUSTER, AttemptUid, JobName
+from iris.cluster.types import LOCAL_ADMIN_SUBMITTER, LOCAL_CLUSTER, AttemptUid, JobName, WellKnownAttribute
 from iris.managed_thread import get_thread_container
 from iris.rpc import controller_pb2, job_pb2
 from iris.rpc.auth import FEDERATION_PEER_ROLE
@@ -55,6 +61,11 @@ _PEER_IDENTITY = VerifiedIdentity(user_id="parent-cluster", role="admin")
 
 _USER = "test-user"
 
+# A handoff reaches the peer over the wire, so the peer's ``launch_job`` sees a
+# non-None ctx and runs the checks it reserves for wire clients (the client-freshness
+# gate). Delivering with ctx=None would model an in-process call and hide them.
+_WIRE_CTX = object()
+
 
 class _InProcessPeerConnection:
     """A ``PeerConnection`` that delegates straight to a peer's in-process service.
@@ -78,7 +89,7 @@ class _InProcessPeerConnection:
     ) -> controller_pb2.Controller.LaunchJobResponse:
         self.launch_calls += 1
         with identity_scope(_PEER_IDENTITY):
-            return self._service.launch_job(request, None)
+            return self._service.launch_job(request, _WIRE_CTX)
 
     def federation_sync(
         self, request: controller_pb2.Controller.FederationSyncRequest
@@ -103,6 +114,28 @@ class _UnreachablePeerConnection(_InProcessPeerConnection):
 
     def terminate_job(self, job_id: JobName) -> None:
         raise ConnectError(Code.NOT_FOUND, "no such job")
+
+
+class _FullGpuPeerConnection(_InProcessPeerConnection):
+    """A reachable peer advertising an H100 backend with no free chips.
+
+    The queue's waiting case: the peer can host the shape (so submit queues the job
+    instead of rejecting it as unschedulable), but its availability metric reports
+    nothing free, so the tick's federation pass never promotes it.
+    """
+
+    def list_backends(self) -> list[controller_pb2.Controller.BackendSummary]:
+        summary = controller_pb2.Controller.BackendSummary(
+            backend_id="default",
+            advertised_attributes={
+                WellKnownAttribute.DEVICE_TYPE: controller_pb2.StringList(values=["gpu"]),
+                WellKnownAttribute.DEVICE_VARIANT: controller_pb2.StringList(values=["h100"]),
+            },
+        )
+        summary.availability.version = AVAILABILITY_METRIC_VERSION
+        summary.availability.observation_epoch_ms = 1
+        summary.availability.amounts["h100"] = 0
+        return [summary]
 
 
 class _RefusingPeerConnection(_InProcessPeerConnection):
@@ -561,39 +594,86 @@ def test_dashboard_reads_expose_cluster_and_filter_by_it(tmp_path, log_client):
         assert _list("no-such-peer") == set()
 
 
-def test_federated_pending_reason_reflects_awaiting_acceptance(tmp_path, log_client):
-    """While a federated job is still queued (its pinned peer is unreachable, so it is
-    never promoted/delivered), the status RPCs expose the pre-registration state: the
-    posture says the peer has not accepted, the task count is the requested replica
-    count (there are no task rows yet), and the pending reason says the job is awaiting
-    the peer — on both the detail path and the batch-loading list path."""
+def test_federated_pending_reason_distinguishes_queued_from_delivered(tmp_path, log_client):
+    """A job waiting in the federation queue reads as queued, not as awaiting the peer.
+
+    Both postures are ``PENDING_SCHEDULING``, but they are the two sides of the queue:
+    a queued job waits for a peer to report free capacity (nothing has been sent), while
+    a promoted one waits for the peer to accept what was sent. An operator watching a
+    job that sits for hours needs to know which. The task count is the requested replica
+    count in both (no task rows yet) — checked on the detail path and the batch-loading
+    list path.
+    """
     with ExitStack() as stack:
         parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
         peer_service, _ = _make_service(stack, "peer", tmp_path, log_client)
-        _attach_federation(parent_service, _UnreachablePeerConnection(peer_service))
+        manager = _attach_federation(parent_service, _UnreachablePeerConnection(peer_service))
 
         response = parent_service.launch_job(_cluster_pinned_request("awaiting-ack", replicas=3), None)
         job_id = JobName.from_wire(response.job_id)
-        # The pinned peer is unreachable, so the job stays QUEUED (never promoted).
+        # Submit only queues: no tick has run, so the job is not assigned to a peer yet.
         assert _handle(parent_state, job_id).handoff_state == int(HandoffState.QUEUED_HANDOFF)
         assert query_tasks_for_job(parent_state, job_id) == []
+
+        def _detail():
+            return parent_service.get_job_status(
+                controller_pb2.Controller.GetJobStatusRequest(job_id=response.job_id), None
+            ).job
+
+        def _listed():
+            (job,) = parent_service.list_jobs(
+                controller_pb2.Controller.ListJobsRequest(query=controller_pb2.Controller.JobQuery(cluster="cw")),
+                None,
+            ).jobs
+            return job
+
+        for status in (_detail(), _listed()):
+            assert status.peer_status == job_pb2.PEER_STATUS_PENDING_SCHEDULING
+            assert status.task_count == 3
+            assert status.pending_reason == "Queued for peer cw to report free capacity"
+
+        # The tick promotes it to its pinned peer, whose delivery then fails transiently.
+        # The same job now reads as awaiting the peer's acceptance: it has been sent.
+        promote_queued_federation(manager, parent_state)
+        assert _handle(parent_state, job_id).handoff_state == int(HandoffState.PENDING_HANDOFF)
+        for status in (_detail(), _listed()):
+            assert status.peer_status == job_pb2.PEER_STATUS_PENDING_SCHEDULING
+            assert status.pending_reason == "Awaiting acceptance by peer cw"
+
+
+def test_a_job_the_peer_has_no_room_for_waits_in_the_queue_unassigned(tmp_path, log_client):
+    """A GPU job the peer advertises but has no free chips for stays queued, undelivered.
+
+    The point of the queue: the peer can host the shape (so submit admits the job rather
+    than failing it as unschedulable), but its availability metric says nothing is free,
+    so the tick's pass places it nowhere. Nothing is sent to the peer, and the job names
+    no peer — the tick stamps a cluster coordinate only when it promotes.
+    """
+    with ExitStack() as stack:
+        parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, _ = _make_service(stack, "peer", tmp_path, log_client)
+        connection = _FullGpuPeerConnection(peer_service)
+        manager = _attach_federation(parent_service, connection)
+        # No local backend can host an H100 job, so the unpinned job classifies as QUEUE
+        # (a locally feasible job would just run here).
+        parent_service._controller.provider.autoscaler = Mock(job_feasibility=Mock(return_value="no local GPU backend"))
+
+        request = make_direct_job_request("no-room", replicas=1)
+        request.resources.device.CopyFrom(job_pb2.DeviceConfig(gpu=job_pb2.GpuDevice(variant="h100", count=8)))
+        response = parent_service.launch_job(request, None)
+        job_id = JobName.from_wire(response.job_id)
+
+        promote_queued_federation(manager, parent_state)
+
+        handle = _handle(parent_state, job_id)
+        assert handle.handoff_state == int(HandoffState.QUEUED_HANDOFF)
+        assert handle.peer_id == ""
+        assert connection.launch_calls == 0
 
         status = parent_service.get_job_status(
             controller_pb2.Controller.GetJobStatusRequest(job_id=response.job_id), None
         ).job
-        assert status.peer_status == job_pb2.PEER_STATUS_PENDING_SCHEDULING
-        assert status.task_count == 3
-        assert status.pending_reason == "Awaiting acceptance by peer cw"
-
-        # The list path loads the handles in bulk and reports the same posture,
-        # count, and reason.
-        (listed,) = parent_service.list_jobs(
-            controller_pb2.Controller.ListJobsRequest(query=controller_pb2.Controller.JobQuery(cluster="cw")),
-            None,
-        ).jobs
-        assert listed.peer_status == job_pb2.PEER_STATUS_PENDING_SCHEDULING
-        assert listed.task_count == 3
-        assert listed.pending_reason == "Awaiting acceptance by peer cw"
+        assert status.pending_reason == "Queued for a federation peer to report free capacity"
 
 
 @pytest.mark.parametrize(
@@ -873,14 +953,14 @@ def test_peer_admission_dedups_a_redrive_and_rejects_a_collision(tmp_path, log_c
         # First receipt from requester "parent": the peer materializes it locally as
         # an ordinary job with a RECEIVED handle recording the requester.
         with identity_scope(_PEER_IDENTITY):
-            first = peer_service.launch_job(_received_handoff_request("fed-job", "parent"), None)
+            first = peer_service.launch_job(_received_handoff_request("fed-job", "parent"), _WIRE_CTX)
         job_id = JobName.from_wire(first.job_id)
         assert len(query_tasks_for_job(peer_state, job_id)) == 1
 
         # (a) A re-drive from the SAME requester is idempotent: same job, no dup tasks
         # (the boot-recovery / retry path).
         with identity_scope(_PEER_IDENTITY):
-            again = peer_service.launch_job(_received_handoff_request("fed-job", "parent"), None)
+            again = peer_service.launch_job(_received_handoff_request("fed-job", "parent"), _WIRE_CTX)
         assert again.job_id == first.job_id
         assert len(query_tasks_for_job(peer_state, job_id)) == 1
 
@@ -888,7 +968,7 @@ def test_peer_admission_dedups_a_redrive_and_rejects_a_collision(tmp_path, log_c
         # collision the parent must see — rejected, not silently bound to the wrong job.
         with identity_scope(_PEER_IDENTITY):
             with pytest.raises(ConnectError) as exc:
-                peer_service.launch_job(_received_handoff_request("fed-job", "other-parent"), None)
+                peer_service.launch_job(_received_handoff_request("fed-job", "other-parent"), _WIRE_CTX)
         assert exc.value.code == Code.ALREADY_EXISTS
 
         # (c) A handoff colliding with a purely LOCAL job (no RECEIVED handle) is
@@ -896,7 +976,7 @@ def test_peer_admission_dedups_a_redrive_and_rejects_a_collision(tmp_path, log_c
         peer_service.launch_job(make_direct_job_request("local-job", replicas=1), None)
         with identity_scope(_PEER_IDENTITY):
             with pytest.raises(ConnectError) as exc:
-                peer_service.launch_job(_received_handoff_request("local-job", "parent"), None)
+                peer_service.launch_job(_received_handoff_request("local-job", "parent"), _WIRE_CTX)
         assert exc.value.code == Code.ALREADY_EXISTS
 
 

--- a/lib/iris/tests/cluster/controller/test_service.py
+++ b/lib/iris/tests/cluster/controller/test_service.py
@@ -1810,6 +1810,24 @@ def test_launch_job_root_with_stale_client_date(service):
     assert exc_info.value.code == Code.FAILED_PRECONDITION
 
 
+def test_launch_job_received_handoff_is_exempt_from_client_freshness(service):
+    """A federated handoff carries no client date and must still be admitted.
+
+    The parent rebuilds a handoff from its stored job state, which does not carry the
+    submitter's ``client_revision_date`` — so every delivered handoff arrives with the
+    field empty, which the freshness check would otherwise read as the (long past)
+    feature-introduction date and reject. The parent already gated the submitter's
+    client at its own LaunchJob.
+    """
+    request = make_job_request("received-handoff")
+    request.federation.requester_id = "parent-cluster"
+    request.federation.owner_principal = "test-user"
+    assert not request.client_revision_date
+
+    response = service.launch_job(request, object())
+    assert response.job_id == JobName.root("test-user", "received-handoff").to_wire()
+
+
 def test_launch_job_nested_with_stale_client_date_is_exempt(service):
     """Nested submissions bypass the freshness check (parent already running)."""
     service.launch_job(make_job_request("parent-job"), None)


### PR DESCRIPTION
#7108 moved every handoff onto the federation queue, so a handoff is now always rebuilt from the parent's stored job state (`reconstruct_launch_job_request`) rather than forwarded from the live submit RPC. That state does not carry the submitter's `client_revision_date`, so every delivered handoff arrives at the peer with the field empty — which the peer's freshness gate reads as the feature-introduction date (2026-04-22) and rejects:

```
Handoff of /power/fedq-legacy-1 to peer cw-rno2a failed (will retry):
marin-iris client is too old (build 2026-04-22; minimum 2026-06-28)
```

`FAILED_PRECONDITION` is not a terminal handoff code (a peer legitimately answers it for a job it cannot schedule *yet*), so the parent retries forever and the job sits `pending` indefinitely. Rolling marin-dev onto #7108 reproduced this on the first federated submit: federation to cw-rno2a was dead. Any parent rolled past #7108 would take its federation down with it.

The gate exists to make humans upgrade a stale `marin-iris` CLI. The wire client of a handoff is the parent controller, which re-encodes the request from its own current proto build; the parent already gated the submitter's client when it accepted the job; and a queued job may now wait longer than the freshness window before it is delivered — the same sliding-window hazard that already exempts nested submissions. So the peer no longer runs the gate on a received handoff. It runs after the handoff is authorized, so a forged `federation` field cannot dodge it.

The in-process peer in the handoff tests delivered with `ctx=None`, which reads as an in-process call and skips every check the controller reserves for wire clients — that is why no test caught this. It now delivers with a wire ctx, which reproduces the production failure across 12 handoff tests and keeps them honest.

## Making the queue legible

A queued job and a delivered one are both `PENDING_SCHEDULING`, so both reported `Awaiting acceptance by peer X`. An operator could not tell a job waiting on capacity — the whole point of the queue — from one waiting on the peer's ack, and an unpinned queued job, which has no peer yet, named an empty one. The pending reason now distinguishes them, and `docs/federation.md` documents the postures and the `availability` block in `list-peers`.

## Validated live on every cluster

Rolled peers first, then parents — a peer without this fix rejects every rebuilt handoff, so the parent must never lead the rollout.

marin-dev → cw-rno2a:

- A queued GPU job promotes on the tick and runs on a real H100 (`NVIDIA H100 80GB HBM3`), then succeeds.
- cw-rno2a advertises `availability {"h100": N}` that tracks reality exactly (512 allocatable − 8 in use by another user's pipeline − 2 mine = 502).
- A job demanding 512 H100s against 503 advertised free stays queued and is never delivered; cancelling it reports `Cancelled before handoff`.
- Local CPU submission and autoscaling on marin-dev are unaffected (VM booted, job ran, succeeded), and a third party's live 100B datakit pipeline on cw-rno2a survived both controller rolls.

marin (prod) → cw-us-east-02a:

- cw-us-east-02a advertises `{"h100": 32}`, matching its k8s state exactly (32 nodes × 8 = 256 allocatable, 224 held by 28 running 8-GPU pods). Two multi-week jobs on it kept running across the roll without a task restart.
- An unpinned `H100x1` job submitted to `marin` queues, promotes, is delivered to cw-us-east-02a, and succeeds on a real H100 — the path that was dead under #7108 alone. Handoff failures since the roll: zero.
- An 80×`H100x8` job (640 GPUs, more than either peer advertises free) stays `QUEUED_HANDOFF` with no peer assigned and is never delivered; its pending reason reads `Queued for a federation peer to report free capacity`.
- Local CPU submission on `marin` is unaffected; all 50 running jobs and 324 workers came through the roll.
