### PR TITLE
[iris] Carry inline workdir files and the container profile through a queued handoff

### DIFF
--- a/lib/iris/src/iris/cluster/controller/codec.py
+++ b/lib/iris/src/iris/cluster/controller/codec.py
@@ -92,7 +92,12 @@ def constraints_from_json(constraints_json: str | None) -> list[Constraint]:
 
 
 def entrypoint_to_json(ep: job_pb2.RuntimeEntrypoint) -> str:
-    """Serialize a RuntimeEntrypoint, excluding inline workdir_files (stored separately)."""
+    """Serialize a RuntimeEntrypoint, excluding inline workdir_files.
+
+    The files live in ``job_workdir_files``, keyed by job id, so the JSON column stays
+    small.  Every path that rebuilds an entrypoint from this JSON must name them again
+    (see :func:`reconstruct_launch_job_request` and ``build_run_request_fields``).
+    """
     d = json_format.MessageToDict(ep, **_TO_DICT_OPTS)
     d.pop("workdir_files", None)
     return json.dumps(d)
@@ -145,8 +150,21 @@ def resource_spec_from_job_row(job: Any) -> job_pb2.ResourceSpecProto:
     )
 
 
-def reconstruct_launch_job_request(job) -> controller_pb2.Controller.LaunchJobRequest:
-    """Reconstruct a LaunchJobRequest proto from native job columns."""
+def reconstruct_launch_job_request(
+    job, *, workdir_files: dict[str, bytes]
+) -> controller_pb2.Controller.LaunchJobRequest:
+    """Reconstruct a LaunchJobRequest proto from native job columns.
+
+    ``job.entrypoint_json`` carries no inline workdir files, so the caller names them:
+    ``reads.get_workdir_files(tx, job_id)`` for a request that will be *run* — a
+    federated handoff delivers this request to the peer, and without the files the peer
+    has no ``_callable_runner.py`` to exec — or ``{}`` for a request that only describes
+    the job's shape.
+
+    ``bundle_blob``, ``client_revision_date`` and ``federation`` are not stored (the
+    bundle survives as ``bundle_id``; the other two belong to the submitting hop), so a
+    reconstruction never carries them.
+    """
     req = controller_pb2.Controller.LaunchJobRequest(
         name=job.name,
         bundle_id=job.bundle_id,
@@ -158,9 +176,12 @@ def reconstruct_launch_job_request(job) -> controller_pb2.Controller.LaunchJobRe
         existing_job_policy=job.existing_job_policy,
         priority_band=job.priority_band,
         task_image=job.task_image,
+        container_profile=job.container_profile,
         fail_if_exists=job.fail_if_exists,
     )
     req.entrypoint.CopyFrom(proto_from_json(job.entrypoint_json, job_pb2.RuntimeEntrypoint))
+    for filename, data in workdir_files.items():
+        req.entrypoint.workdir_files[filename] = data
     req.environment.CopyFrom(proto_from_json(job.environment_json, job_pb2.EnvironmentConfig))
     req.resources.CopyFrom(
         resource_spec_from_scalars(job.res_cpu_millicores, job.res_memory_bytes, job.res_disk_bytes, job.res_device_json)

--- a/lib/iris/src/iris/cluster/controller/codec.py
+++ b/lib/iris/src/iris/cluster/controller/codec.py
@@ -95,8 +95,8 @@ def entrypoint_to_json(ep: job_pb2.RuntimeEntrypoint) -> str:
     """Serialize a RuntimeEntrypoint, excluding inline workdir_files.
 
     The files live in ``job_workdir_files``, keyed by job id, so the JSON column stays
-    small.  Every path that rebuilds an entrypoint from this JSON must name them again
-    (see :func:`reconstruct_launch_job_request` and ``build_run_request_fields``).
+    small. An entrypoint rebuilt from this JSON therefore has no inline files until
+    they are re-attached from that table.
     """
     d = json_format.MessageToDict(ep, **_TO_DICT_OPTS)
     d.pop("workdir_files", None)

--- a/lib/iris/src/iris/cluster/controller/federation_store.py
+++ b/lib/iris/src/iris/cluster/controller/federation_store.py
@@ -63,7 +63,8 @@ def build_queued_candidates(tx: Tx) -> list[QueuedCandidate]:
         # promoted — the promotion CAS would reject it anyway.
         if job is None or job.state in TERMINAL_JOB_STATES:
             continue
-        request = reconstruct_launch_job_request(job)
+        # Shape only — this pass reads constraints and resources, never the payload.
+        request = reconstruct_launch_job_request(job, workdir_files={})
         constraints = [Constraint.from_proto(c) for c in request.constraints]
         shape = routing_constraints(strip_cluster_constraints(strip_backend_constraints(constraints)))
         band = (
@@ -167,6 +168,12 @@ class ControllerFederationStore:
             writes.mark_federated_job_killed(cur, local_job_id, now_ms=Timestamp.now().epoch_ms(), error=reason)
 
     def pending_handoffs(self) -> list[HandoffSpec]:
+        """The handles awaiting delivery, each with the full request the peer will run.
+
+        The peer executes this request, so it carries the job's inline workdir files
+        (the small ones the offload threshold kept out of the blob store, e.g. a
+        ``from_callable`` job's ``_callable_runner.py``) alongside the stored config.
+        """
         with self._db.read_snapshot() as tx:
             handles = reads.pending_handoff_handles(tx)
             pending = []
@@ -180,7 +187,9 @@ class ControllerFederationStore:
                         peer_id=handle.peer_id,
                         owner_principal=handle.owner_principal,
                         submitting_user=job.submitting_user,
-                        request=reconstruct_launch_job_request(job),
+                        request=reconstruct_launch_job_request(
+                            job, workdir_files=reads.get_workdir_files(tx, handle.job_id)
+                        ),
                     )
                 )
         return pending

--- a/lib/iris/src/iris/cluster/controller/projections/run_templates.py
+++ b/lib/iris/src/iris/cluster/controller/projections/run_templates.py
@@ -46,6 +46,7 @@ def build_run_request_fields(
     *,
     num_tasks: int,
     entrypoint_json: str,
+    workdir_files: dict[str, bytes],
     environment_json: str,
     bundle_id: str,
     resources: job_pb2.ResourceSpecProto,
@@ -60,13 +61,17 @@ def build_run_request_fields(
     """Build a RunTaskRequest carrying the per-job fields shared by the template
     and per-attempt construction paths.
 
+    ``entrypoint_json`` carries no inline workdir files (they live in
+    ``job_workdir_files``), so the caller supplies them via ``workdir_files`` —
+    ``reads.get_workdir_files(tx, job_id)`` — and they are re-attached here.
+
     The template path leaves ``task_id``/``attempt_id``/``priority`` at their
     proto defaults; the per-attempt path stamps them. proto_from_json returns
     shared cached instances — set via constructor kwarg so RunTaskRequest
-    copies them; callers then mutate the copy's workdir_files (never the cached
+    copies them, and the workdir files land on that copy (never the cached
     source).
     """
-    return job_pb2.RunTaskRequest(
+    request = job_pb2.RunTaskRequest(
         num_tasks=num_tasks,
         entrypoint=proto_from_json(entrypoint_json, job_pb2.RuntimeEntrypoint),
         environment=proto_from_json(environment_json, job_pb2.EnvironmentConfig),
@@ -80,6 +85,9 @@ def build_run_request_fields(
         priority=priority,
         container_profile=container_profile,
     )
+    for filename, data in workdir_files.items():
+        request.entrypoint.workdir_files[filename] = data
+    return request
 
 
 class RunTemplatesProjection(Projection):
@@ -136,6 +144,7 @@ class RunTemplatesProjection(Projection):
         template = build_run_request_fields(
             num_tasks=job.num_tasks,
             entrypoint_json=job.entrypoint_json,
+            workdir_files=reads.get_workdir_files(tx, job_id),
             environment_json=job.environment_json,
             bundle_id=job.bundle_id,
             resources=resources,
@@ -144,8 +153,6 @@ class RunTemplatesProjection(Projection):
             task_image=job.task_image,
             container_profile=job.container_profile,
         )
-        for filename, data in reads.get_workdir_files(tx, job_id).items():
-            template.entrypoint.workdir_files[filename] = data
 
         with self._lock:
             if self._guard.may_store(tx.seq, wire):

--- a/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/dispatch.py
@@ -63,6 +63,7 @@ def build_run_request(
     run_req = build_run_request_fields(
         num_tasks=row.num_tasks,
         entrypoint_json=row.entrypoint_json,
+        workdir_files=reads.get_workdir_files(cur, row.job_id),
         environment_json=row.environment_json,
         bundle_id=row.bundle_id,
         resources=row.resources,
@@ -75,9 +76,6 @@ def build_run_request(
         priority=row.priority_band,
         container_profile=row.container_profile,
     )
-    # Load inline workdir files from the job_workdir_files table.
-    for filename, data in reads.get_workdir_files(cur, row.job_id).items():
-        run_req.entrypoint.workdir_files[filename] = data
     # Propagate timeout for K8s activeDeadlineSeconds (Kubernetes-native enforcement).
     if row.timeout_ms is not None and row.timeout_ms > 0:
         run_req.timeout.milliseconds = row.timeout_ms

--- a/lib/iris/src/iris/cluster/controller/service.py
+++ b/lib/iris/src/iris/cluster/controller/service.py
@@ -1805,7 +1805,9 @@ class ControllerServiceImpl:
         if job.submitted_at_ms:
             proto_job_status.submitted_at.CopyFrom(timestamp_to_proto(job.submitted_at_ms))
 
-        reconstructed_request = reconstruct_launch_job_request(job)
+        # Status describes the job's shape; the workdir file bytes are payload no
+        # client of this RPC reads, so they stay out of the response.
+        reconstructed_request = reconstruct_launch_job_request(job, workdir_files={})
         return controller_pb2.Controller.GetJobStatusResponse(
             job=proto_job_status,
             request=redact_request_env_vars(reconstructed_request),

--- a/lib/iris/tests/cluster/controller/test_codec.py
+++ b/lib/iris/tests/cluster/controller/test_codec.py
@@ -1,0 +1,93 @@
+# Copyright The Marin Authors
+# SPDX-License-Identifier: Apache-2.0
+
+"""Fidelity of the stored-job -> LaunchJobRequest reconstruction.
+
+A queued federated handoff is rebuilt from the parent's stored job state and delivered
+to the peer, so a request field this round trip drops is a field the peer never runs
+with. Two federation outages came from exactly that: a dropped ``client_revision_date``
+(the peer's freshness gate rejected every handoff) and dropped inline ``workdir_files``
+(the peer ran a ``from_callable`` task with no ``_callable_runner.py``).
+"""
+
+from iris.cluster.constraints import Constraint, ConstraintOp
+from iris.cluster.controller import ops, reads
+from iris.cluster.controller.codec import reconstruct_launch_job_request
+from iris.cluster.types import JobName, tpu_device
+from iris.rpc import controller_pb2, job_pb2
+from rigging.timing import Timestamp
+
+# The only LaunchJobRequest fields the job store deliberately does not keep.
+NOT_PERSISTED = {
+    # Uploaded to the bundle store at submit; survives as ``bundle_id``.
+    "bundle_blob",
+    # Describes the client of the hop that submitted the request: the parent gates the
+    # user's CLI build at submit, and a peer exempts a received handoff (whose wire
+    # client is the parent controller, not a CLI).
+    "client_revision_date",
+    # Stamped by the federation manager onto the request it delivers to a peer.
+    "federation",
+}
+
+
+def _fully_populated_request(job_id: JobName) -> controller_pb2.Controller.LaunchJobRequest:
+    """A LaunchJobRequest with every field set to a non-default value."""
+    request = controller_pb2.Controller.LaunchJobRequest(
+        name=job_id.to_wire(),
+        resources=job_pb2.ResourceSpecProto(
+            cpu_millicores=2000, memory_bytes=8 * 1024**3, disk_bytes=64 * 1024**3, device=tpu_device("v6e-8")
+        ),
+        environment=job_pb2.EnvironmentConfig(env_vars={"LOG_LEVEL": "info"}),
+        bundle_id="a" * 64,
+        bundle_blob=b"PK\x03\x04",
+        ports=["http"],
+        max_task_failures=3,
+        max_retries_failure=2,
+        max_retries_preemption=7,
+        replicas=2,
+        fail_if_exists=True,
+        preemption_policy=job_pb2.JOB_PREEMPTION_POLICY_PRESERVE_CHILDREN,
+        existing_job_policy=job_pb2.EXISTING_JOB_POLICY_RECREATE,
+        priority_band=job_pb2.PRIORITY_BAND_BATCH,
+        task_image="custom/image:dev",
+        submit_argv=["iris", "job", "run", "--", "python", "train.py"],
+        client_revision_date="2026-07-12",
+        container_profile=job_pb2.CONTAINER_PROFILE_PRIVILEGED,
+    )
+    request.entrypoint.setup_commands.append("uv sync")
+    request.entrypoint.run_command.argv[:] = ["python", "train.py"]
+    request.entrypoint.workdir_files["_callable_runner.py"] = b"import pickle"
+    request.entrypoint.workdir_file_refs["_callable.pkl"] = "b" * 64
+    request.constraints.append(Constraint.create(key="device-variant", op=ConstraintOp.EQ, value="v6e-8").to_proto())
+    request.coscheduling.group_by = "tpu-name"
+    request.scheduling_timeout.milliseconds = 60_000
+    request.timeout.milliseconds = 3_600_000
+    request.federation.requester_id = "parent"
+    return request
+
+
+def test_every_launch_request_field_survives_storage(state):
+    """Every field of a submitted request comes back out of the job store.
+
+    The reconstruction rebuilds the request field by field, so it silently drifts from
+    the proto whenever a field is added. Adding one fails this test until it is either
+    persisted or named (with its reason) in ``NOT_PERSISTED``.
+    """
+    job_id = JobName.root("test-user", "codec-fidelity")
+    request = _fully_populated_request(job_id)
+
+    unset = {f.name for f in request.DESCRIPTOR.fields} - {f.name for f, _ in request.ListFields()}
+    assert not unset, f"_fully_populated_request must set every field; missing {sorted(unset)}"
+
+    with state._db.transaction() as cur:
+        ops.job.insert_job_and_config(cur, job_id=job_id, request=request, ts=Timestamp.now())
+
+    with state._db.read_snapshot() as tx:
+        job = reads.get_job_detail(tx, job_id)
+        reconstructed = reconstruct_launch_job_request(job, workdir_files=reads.get_workdir_files(tx, job_id))
+
+    expected = controller_pb2.Controller.LaunchJobRequest()
+    expected.CopyFrom(request)
+    for field in NOT_PERSISTED:
+        expected.ClearField(field)
+    assert reconstructed == expected

--- a/lib/iris/tests/cluster/controller/test_federation_handoff.py
+++ b/lib/iris/tests/cluster/controller/test_federation_handoff.py
@@ -25,6 +25,7 @@ from iris.cluster.controller import reads, writes
 from iris.cluster.controller.auth import ControllerAuth
 from iris.cluster.controller.endpoint_service import EndpointServiceImpl
 from iris.cluster.controller.federation_store import ControllerFederationStore
+from iris.cluster.controller.projections.run_templates import RunTemplatesProjection
 from iris.cluster.controller.service import (
     AVAILABILITY_METRIC_VERSION,
     WORKDIR_FILE_OFFLOAD_THRESHOLD,
@@ -272,6 +273,60 @@ def test_a_federated_job_carries_its_externalized_workdir_files_to_the_peer(tmp_
         manager.sync_once()
 
         assert peer_service._bundle_store.get(content_id(big)) == big
+
+
+def test_a_federated_job_carries_its_inline_workdir_files_to_the_peer(tmp_path, log_client):
+    """A workdir file small enough to stay inline is in no blob store, so only the
+    handoff request itself can carry it.
+
+    A queued handoff is rebuilt from the parent's stored job state, which keeps these
+    files outside ``entrypoint_json``; a reconstruction that forgets them delivers a
+    ``from_callable`` job with no ``_callable_runner.py`` and the peer's task dies on
+    ``can't open file '/app/_callable_runner.py'``.
+    """
+    runner = b"import pickle; pickle.load(open('_callable.pkl', 'rb'))()"
+    with ExitStack() as stack:
+        parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _InProcessPeerConnection(peer_service))
+
+        request = _cluster_pinned_request("fed-inline-workdir")
+        request.entrypoint.workdir_files["_callable_runner.py"] = runner
+        parent_service.launch_job(request, None)
+        promote_queued_federation(manager, parent_state)
+        manager.sync_once()
+
+        job_id = JobName.root(_USER, "fed-inline-workdir")
+        with peer_state._db.read_snapshot() as tx:
+            template = tx.caches[RunTemplatesProjection].get(tx, job_id)
+        assert template is not None
+        assert dict(template.entrypoint.workdir_files) == {"_callable_runner.py": runner}
+
+
+def test_a_federated_job_carries_its_container_profile_to_the_peer(tmp_path, log_client):
+    """The peer runs the job under the profile the parent authorized.
+
+    An elevated profile is the parent's decision (it gated the submitter), and the peer
+    trusts it on a received handoff — so the handoff must state it. Losing it silently
+    downgrades the task to the default profile, and a nested runtime (gVisor) that needs
+    it fails on the peer.
+    """
+    with ExitStack() as stack:
+        parent_service, parent_state = _make_service(stack, "parent", tmp_path, log_client)
+        peer_service, peer_state = _make_service(stack, "peer", tmp_path, log_client)
+        manager = _attach_federation(parent_service, _InProcessPeerConnection(peer_service))
+
+        request = _cluster_pinned_request("fed-profile")
+        request.container_profile = job_pb2.CONTAINER_PROFILE_PRIVILEGED
+        parent_service.launch_job(request, None)
+        promote_queued_federation(manager, parent_state)
+        manager.sync_once()
+
+        job_id = JobName.root(_USER, "fed-profile")
+        with peer_state._db.read_snapshot() as tx:
+            template = tx.caches[RunTemplatesProjection].get(tx, job_id)
+        assert template is not None
+        assert template.container_profile == job_pb2.CONTAINER_PROFILE_PRIVILEGED
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
#7108 moved every federated handoff onto the federation queue, so a handoff is now rebuilt from the parent's stored job state (`reconstruct_launch_job_request`) rather than forwarded from the live submit RPC. That reconstruction drops two fields the peer needs.

**Inline workdir files.** `entrypoint_to_json` stores them in `job_workdir_files` rather than in the entrypoint JSON, and the reconstruction never read them back, so a delivered handoff arrives with an empty `workdir_files` map. Files above the 10KB offload threshold survive as blob refs the manager re-inlines; the small ones do not. A `from_callable` job's 1.4KB `_callable_runner.py` is exactly that class of file, so every queued handoff of one reaches the peer with no runner and the task dies on `python: can't open file '/app/_callable_runner.py'`. Local dispatch and the run-template projection both re-attach the files from the table; only the federated delivery path did not.

**`container_profile`.** Never reconstructed at all, so an elevated profile the parent authorized arrives as `UNSPECIFIED` and the peer runs the task under the default profile — even though the peer has an explicit branch to trust a received handoff's profile.

Both are the same failure as `client_revision_date` in #7132: a field the hand-written, field-by-field reconstruction quietly forgot. So beyond the two fixes, every path that rebuilds an entrypoint from stored job state now has to name its workdir files — `reconstruct_launch_job_request` and `build_run_request_fields` take them as a required argument, and a caller must choose between `reads.get_workdir_files(...)` (the request will be run) and `{}` (the request only describes the job's shape) instead of silently receiving a file-less entrypoint. That also collapses the attach loop that dispatch and the projection each carried.

`test_codec.py` pins the reconstruction against further drift: a request with every field populated must survive storage, so adding a proto field fails the test until it is either persisted or listed, with its reason, as deliberately not persisted (`bundle_blob`, `client_revision_date`, `federation`).