### PR TITLE
Add IaC design doc

### DIFF
--- a/.agents/projects/iac/design.md
+++ b/.agents/projects/iac/design.md
@@ -1,0 +1,181 @@
+# Infrastructure as Code for Marin clusters
+
+_Why are we doing this? What's the benefit?_
+
+Bringing up and maintaining a cluster today means running a sequence of imperative
+Python scripts (`install_kueue.py`, `install_traefik_proxy.py`, `setup_iam.py`,
+`iap_gclb.py`, `configure_buckets.py`) in the right order, interleaved with manual
+console steps (create the CKS cluster, mint tokens, create NodePools, create object
+buckets) — and remembering which ones. As we add clusters this is increasingly
+error-prone and undocumented-in-code. We want the *static, low-churn* foundation of
+a cluster — the cluster/NodePools, the cluster-wide k8s add-ons, RBAC, and object
+storage — described declaratively so a cluster's prerequisites are one reviewable
+`preview`/`apply` with real drift detection, instead of tribal script-ordering.
+
+This is deliberately scoped: **IaC owns the static machine and access substrate;
+Iris keeps owning everything dynamic** (per-job Pod dispatch, and on GCP the
+autoscaler's TPU-slice lifecycle). We migrate **CoreWeave first** because that
+surface is largely greenfield (k8s add-ons + NodePools + buckets, no IAP/IAM edge),
+then bring GCP onto the same engine.
+
+## Background
+
+Marin has no IaC today. The #6879 research split cluster startup into two classes:
+**class 1** (foundational, per-cluster, low-churn — scripts/console) and **class 2**
+(per-job slice lifecycle — the in-process autoscaler, a scheduler hot path). Only class 1
+is an IaC candidate; class 2 stays imperative in Iris. The approved
+[cluster-admin-unification design](../2026-06-23_cluster_admin_unification.md) already adds
+a typed top-level **`provisioning:`** config section; the question #6879 raised is *what
+execution engine backs it* — this doc decides **Pulumi**, all-or-nothing (both clouds or
+neither, no half-Pulumi end state), CoreWeave migrated first as the proof. Full findings,
+resource inventory, and ownership boundary are in [research.md](research.md).
+
+## Challenges
+
+The hard part is drawing the **ownership boundary** cleanly. Resources created *today* by
+`iris cluster start` (`ensure_rbac()`, `ensure_nodepools()`) must be ceded to IaC — Iris
+verifies rather than double-creates. This cede is clean on CoreWeave: the reserved fleets
+are pinned-warm NodePools (`minNodes == maxNodes`) whose node counts are driven by
+*CoreWeave's* autoscaler inside those bounds, so Iris never managed them — but it does
+**not** generalize to GCP TPUs, where Iris's own autoscaler owns slice lifecycle. Second, a
+sharp hazard must survive the port: Kueue's admission webhooks must stay **scoped to the
+`iris` namespace**; the chart default fail-closed-intercepts CNI/system pods and deadlocks
+node delivery cluster-wide.
+
+## Costs / Risks
+
+- New operational surface: a Pulumi CLI, a **GCS state backend**, and a **GCP KMS secrets
+  provider** — the state bucket + KMS key a one-time *manual* bootstrap outside IaC
+  (chicken-and-egg).
+- **Adoption risk on live fleets:** the running CW clusters already hold Iris-created RBAC +
+  NodePools; the first apply must `pulumi import` them, not recreate — a botched adoption could
+  deprovision a reserved 256-GPU fleet. Gated behind an empty-preview check (Testing).
+- **Churn now, payoff deferred:** no user-visible behavior change, and CoreWeave alone doesn't
+  justify the tooling — the win lands only when the GCP surface also ports. **Approving this
+  is approving the GCP port in principle**, before its signatures exist. It supersedes the
+  approved GCP reconciler plan (keeps its `provisioning:` schema, swaps the executor for Pulumi).
+- **Bridge + coverage risk:** CKS cluster/VPC come via CoreWeave's official TF provider bridged
+  into Pulumi (add-ons + NodePools are k8s manifests either way); the bridge can lag upstream and
+  CKS *cluster-create* maturity is unproven by us (Open Questions).
+- **IaC can't cover everything:** R2/CoreWeave bucket *lifecycle* has no first-class provider, so
+  `configure_buckets.py` keeps it; IAP OAuth brand/clients stay external inputs
+  (`read_oauth_client`) — no regression only if that boundary holds.
+
+## Design
+
+**Tool: Pulumi (Python).** We weighed it against Terraform/OpenTofu on the axes that map to
+*our* stack, not in the abstract (full table + sources in [research.md](research.md)). Four
+favor Pulumi concretely: **(1) Python reuse** — import `rigging.filesystem` and read the
+cluster's `provisioning:` section directly, no config re-expression; **(2) CRD-then-CR in
+one apply** — our stack is CRD-heavy (cert-manager,
+Kueue, CoreWeave NodePool), and Terraform's `kubernetes_manifest` validates CRD schemas at
+plan time so it can't install a CRD and its CR in one run (our scripts already loop on
+`wait_for_crd_established`); **(3) encrypted secrets in state** — we're secret-heavy (SA
+keys, R2/CW/IAP secrets, finelog delegation key), Terraform stores them plaintext; **(4) the
+Automation API**, which lets `marin-cluster admin` drive `up`/`preview`/`destroy` in-process
+— the concrete mechanism for "IaC is the engine behind `provisioning:`". Pulumi **bridges the
+official CoreWeave TF provider** (`coreweave_cks_cluster` + VPC), reused from Python. The
+honest counterweights — Terraform's larger ecosystem and native (un-bridged) CoreWeave/
+Cloudflare providers — are real but general, and didn't outweigh the stack-specific wins.
+
+**Layout: a top-level `infra/iac/` directory in the monorepo**, next to `config/` and
+the CI that runs it. One Pulumi **project**, one **stack per cluster** (`cw-us-east-02a`,
+`cw-rno2a`, later `marin` for GCP). Component resources model the surface:
+
+- `CoreweaveCluster` — CKS cluster + reserved NodePools (via the CW TF provider).
+- `KueueAddon` — `cks-kueue` chart, Topology CRs, `cw-ib` ResourceFlavor, `iris-cq`
+  ClusterQueue, with **namespace-scoped webhooks** (the hazard above, asserted in tests).
+- `TraefikAddon` — Traefik + cert-manager + Let's Encrypt HTTP-01 ClusterIssuers.
+- `IrisRbac` — the `iris` Namespace, `iris-controller` ServiceAccount, ClusterRole,
+  ClusterRoleBinding (ceded from `ensure_rbac()`).
+- `ObjectStorage` — `s3://marin-*` buckets + access keys.
+
+**Config stays single-source.** The NodePool envelope (instance types, node counts) is
+*derived* from the Iris config's `scale_groups`, the namespace from
+`kubernetes_provider.namespace`, and the Kueue queue name from
+`kubernetes_provider.kueue.cluster_queue` — never re-declared. The new `provisioning:`
+section (in the per-cluster `lib/iris/config/<cluster>.yaml`) carries only the residual
+cluster facts not already in the Iris config: CKS cluster name, ResourceFlavor/topologies,
+ACME issuers, buckets. `Pulumi.<stack>.yaml` is just a cluster-name pointer; the program
+holds no Marin-specific constants. Deriving namespace from one source also makes the
+webhook-scope invariant (Kueue `pod_namespace` == RBAC namespace) structural, not just
+validated.
+
+**Iris cedes the migrated resources.** `start_controller()` drops `ensure_rbac()` and
+`ensure_nodepools()` and instead **verifies** they exist, failing with a clear "run
+`infra/iac` apply first" message. Everything else it creates is unchanged (controller
+Deployment + Service, ConfigMap, `iris-task-env` Secret, namespaced LocalQueue, per-job
+Pods). The CoreWeave boundary: **IaC owns the node-capacity envelope + access substrate;
+Iris owns the Pods inside it.** This boundary is *provider-shaped*, not universal — on GCP
+there are no reserved per-scale-group NodePools (Iris's autoscaler owns TPU slices), so
+`verify_prerequisites` is provider-scoped and checks a different GCP-arm set. NodePools are
+declared with `ignore_changes` on their runtime node count, so CoreWeave's own autoscaler
+moves capacity within the IaC-declared `[min, max]` without fighting Pulumi.
+
+GCP is **committed but sequenced after CoreWeave**: the layout reserves a `marin`/GCP
+stack, and this pass leaves the GCP `iris cluster start` path untouched. Once CoreWeave
+proves the pattern, `setup_iam.py`/`iap_gclb.py`/`configure_gcp_registry.py` port onto
+Pulumi as `GcpIam` / `GcpGclbIap` / `GcpRegistry` components reusing the same
+`provisioning:` contract — that port is part of the commitment, not an optional extra.
+
+## Deploying on your own infrastructure
+
+The IaC lives in the monorepo, but the real portability contract is **not** the Pulumi
+program — it's the prerequisite set `iris cluster start` now *verifies* (a usable
+namespace + RBAC, NodePools matching the config's scale groups, Kueue with
+namespace-scoped webhooks, an ingress for `/proxy`, an object bucket + creds). Because
+Iris verifies rather than creates these, the contract is explicit and a deployer can
+satisfy it however they like; our Pulumi program is a *reference implementation* of it, not
+a requirement. Two paths: if your topology matches ours (CKS, or GCP+IAP), **fork
+`infra/iac/` and bring your own `provisioning:` config + state/KMS backend** — the program
+holds no Marin-specific constants, so only config differs. If your topology differs (EKS,
+on-prem, a different object store), **satisfy the prerequisite contract with your own IaC**
+and run `iris cluster start` against it. Detail and the tradeoff analysis are in
+[research.md](research.md).
+
+## Testing
+
+Three levels, no paid CoreWeave in the default path:
+
+- **Unit / plan**: `pulumi preview` on the diff in CI (plan is the reviewable artifact).
+  Assert the rendered Kueue webhook `namespaceSelector` is scoped to `iris` — the single
+  most important regression, since an unscoped webhook deadlocks node delivery cluster-wide.
+- **kind**: the k8s-portable components (`KueueAddon` upstream variant, `IrisRbac`) apply
+  against a kind cluster, reusing the existing `tests/e2e/gpu_gang_smoke.py` harness path.
+- **Greenfield rollout check** (the acceptance test): on `ci-coreweave`, `infra/iac` apply
+  provisions RBAC + Kueue + Traefik + NodePools, then `iris cluster start` succeeds against
+  those prerequisites **without** its own `ensure_rbac()`/`ensure_nodepools()`, and a CPU
+  hello-world + 8-GPU `jax.devices()` job run. Proves the cede boundary end-to-end.
+- **Adoption check** (must run before touching the live fleets): `pulumi import` the existing
+  RBAC + NodePools on a live cluster, then `pulumi preview` must show an **empty/additive-only**
+  plan — a destructive NodePool diff is a stop-the-line bug (it would deprovision a reserved
+  256-GPU fleet). The migration procedure is pinned in `spec.md §4`.
+
+## Workflow
+
+IaC changes ship like code, with a human in the loop for the apply:
+
+1. **CI preview (every PR).** A GitHub Actions job authenticates to GCP via Workload Identity
+   Federation (keyless — no static SA keys) and runs `pulumi preview` for each affected stack,
+   posting the plan as a PR comment. The plan is the reviewable artifact; a destructive NodePool
+   diff blocks the PR (the same gate as the adoption check).
+2. **Manual apply.** After review/merge, an **operator** runs `pulumi up` from a trusted
+   environment, re-reading the preview. Apply stays human-driven because these stacks touch
+   reserved GPU fleets — CI holds *decrypt-only* KMS access (preview), operators hold *encrypt*
+   (apply).
+3. **Later: full CD.** Once trusted, promote to apply-on-merge behind a GitHub Environment with
+   required approval — same WIF identity, preview still the gate, the approval the checkpoint.
+
+State lives in `gs://marin-iac-state`, encrypted with a GCP KMS secrets provider; the CI job,
+IAM split, secrets model, and CD gate are pinned in `spec.md §9`.
+
+## Open Questions
+
+- **CoreWeave declarative coverage.** How much of CKS (esp. *cluster* creation vs just
+  NodePools/add-ons) is robust through the CW Terraform provider bridged into Pulumi at our
+  fleet sizes? If `coreweave_cks_cluster` create/update proves weak, do we start IaC at the
+  NodePool/add-on layer and leave cluster-create a documented console step until it matures?
+- **Verification strictness.** How strict should `iris cluster start`'s new prerequisite
+  check be — exact-match on NodePool specs/RBAC verbs (catches drift, brittle across Iris
+  versions) or presence-only (tolerant, misses drift)? This defines the portability contract's
+  edges.

--- a/.agents/projects/iac/research.md
+++ b/.agents/projects/iac/research.md
@@ -1,0 +1,112 @@
+# IaC for Marin — Research
+
+Prior work / seed material:
+- [Issue #6879 — investigate pulumi for organizing resource startup](https://github.com/marin-community/marin/issues/6879) (with a detailed bot research comment)
+- [`2026-06-23_cluster_admin_unification.md`](../2026-06-23_cluster_admin_unification.md) — approved A+B; adds a typed `provisioning:` section + `marin-cluster admin` config-driven reconcilers
+- [Issue #6961 — top-level marin admin scripts for cross-service key provisioning](https://github.com/marin-community/marin/issues/6961)
+
+## The two classes of "resource startup" (from #6879)
+
+Only **class 1** is a Pulumi candidate:
+
+1. **Foundational, per-cluster, low-churn** — created once, changed rarely; today done by hand or one-off Python scripts.
+2. **Runtime, per-job, high-churn** — TPU/GPU slices created/destroyed continuously by the in-process autoscaler; a scheduler hot path reconciled every few seconds. Declarative plan/apply is the wrong tool here — **stays imperative in Iris**. This matches the user's constraint: "Iris will still manage the dynamic configuration of workers and TPUs."
+
+## Marin has no IaC today
+
+No Terraform/Pulumi/Ansible/Helm-of-record. Foundational setup is a set of imperative Python scripts + manual console steps:
+
+| Concern | Today | Cloud |
+|---|---|---|
+| GCS/R2/CW bucket lifecycle | `infra/configure_buckets.py` | all |
+| Artifact Registry cleanup | `infra/configure_gcp_registry.py` | GCP |
+| Service accounts + IAM | `lib/iris/scripts/setup_iam.py` | GCP |
+| GCLB + IAP proxy | `lib/iris/scripts/iap_gclb.py` | GCP |
+| Kueue install (Helm) | `lib/iris/scripts/install_kueue.py` | CW + kind |
+| Traefik + cert-manager + ACME issuers | `lib/iris/scripts/install_traefik_proxy.py` | CW |
+| k8s Namespace + RBAC | `iris cluster start` → `CoreweavePlatform.ensure_rbac()` | CW |
+| CKS cluster + reserved NodePools | **manual** (Console, or CW Terraform provider) | CW |
+| CW object-storage buckets + access keys | **manual** (Console) | CW |
+
+## The CoreWeave surface (first migration target)
+
+Source of truth for the runbook: [`lib/iris/docs/coreweave.md`](../../../lib/iris/docs/coreweave.md). Active clusters `cw-us-east-02a`, `cw-rno2a` (reserved, pinned-warm H100 fleets).
+
+What is **static / install-once / manual** today and thus an IaC candidate:
+- **CKS cluster** itself + the **reserved NodePools** (pinned warm: `buffer_slices == max_slices` → `minNodes == maxNodes`, never scale to zero — effectively static machines). Today `ensure_nodepools()` in `iris cluster start` creates them, but for a reserved fleet this is really static provisioning.
+- **Kueue** — `install_kueue.py --variant coreweave --with-queues`: the `cks-kueue` chart, Topology CRs, cluster-scoped `cw-ib` ResourceFlavor + `iris-cq` ClusterQueue. Namespace-scoped webhooks (unscoped webhooks deadlock node delivery — a sharp operational hazard).
+- **Traefik + cert-manager + Let's Encrypt HTTP-01 issuers** — `install_traefik_proxy.py`. CKS ships no ingress controller / TLS issuer.
+- **Namespace + RBAC** (`iris` ns, `iris-controller` SA, ClusterRole/Binding) — created by `ensure_rbac()` on every `cluster start`.
+- **Object storage** buckets + access keys (`s3://marin-us-east-02a`, R2 endpoints).
+
+What **stays in Iris** (dynamic, per the user's constraint): controller Deployment + Service, ConfigMap, `iris-task-env` Secret, worker/task Pods, LocalQueue reconcile, per-job Pod dispatch (Pod-per-task), NHC preemption.
+
+Note: on CoreWeave there is **no IAP/JWT edge** — auth is by network location (`auth.trusted_cidrs`) + per-endpoint bearer for `/proxy`. So the GCP-specific `setup_iam.py`/`iap_gclb.py` provisioning does **not** apply to CoreWeave; the CoreWeave IaC surface is largely greenfield (k8s add-ons + cluster/nodepools + buckets), not a rewrite of the GCP admin scripts.
+
+## GCP surface (must keep working; not migrated first)
+
+GCP is the more complex arm: project/SAs/IAM (`setup_iam.py`), GCLB + IAP (`iap_gclb.py`), Artifact Registry (`configure_gcp_registry.py`), buckets (`configure_buckets.py`), controller VM. TPU slices are class-2 (autoscaler, stays imperative). GCP is **in scope** for IaC — the maintainer's framing is all-or-nothing (Pulumi for both clouds, or neither) — but CoreWeave is migrated first as the low-risk proof. The tool + repo layout must therefore leave a clean seat for the GCP stack from day one (see the reserved GCP stack in the layout), even though GCP resources are ported after CoreWeave lands.
+
+## Relationship to the approved cluster-admin-unification work
+
+`2026-06-23_cluster_admin_unification.md` (approved A+B) adds a typed top-level **`provisioning:`** section to `config/<cluster>.yaml` and refactors `setup_iam.py`/`iap_gclb.py` into config-driven idempotent Python reconcilers under `marin-cluster admin`. The #6879 bot comment's key point: the real question is not "Pulumi yes/no" but **what execution engine backs that `provisioning:` layer**. This design's position is decided: **Pulumi is that engine.** The typed `provisioning:` schema stays the config contract; Pulumi replaces the hand-rolled reconcilers as the executor, and `marin-cluster admin` drives it (via the Automation API) rather than shelling to `gcloud`. We keep the `provisioning:` schema work from that doc and fold its rollouts into Pulumi — a parallel Python-reconciler track is explicitly rejected (the bot warned against a competing design). This is all-or-nothing per the maintainer: either Pulumi is the IaC solution for **both** GCP and CoreWeave, or we keep the existing scripts unchanged — there is no half-Pulumi end state. CoreWeave (greenfield k8s add-ons, no IAP/IAM edge) is where we prove the pattern before porting the GCP `provisioning:` rollouts onto the same engine.
+
+## Tool choice: Pulumi vs Terraform (evidence)
+
+### What we provision today (concrete resource inventory)
+
+**GCP** (all via `gcloud`, imperative reconcilers):
+- `setup_iam.py` — `google_service_account` (controller/worker SAs), project IAM bindings (`roles/tpu.admin`, `storage.objectAdmin`, `artifactregistry.reader`, …), SA-on-SA bindings (`serviceAccountTokenCreator`/`User`). **Well-covered by both tools.**
+- `iap_gclb.py` (1387 lines) — the GCLB+IAP edge: zonal **NEG** → health check → global **backend-service** → **url-map** (with `path-matcher` surgery via `export`/`import` JSON edit) → target proxy → global **forwarding-rule**, managed **ssl-certificate**, **IAP enable** + `oauth_settings` (`clientId` + `programmaticClients`), and `iap.httpsResourceAccessor` IAM bindings. **Well-covered declaratively** — and the ugly `url-map export/import` surgery becomes a plain declarative `url_map` with `path_matcher` blocks (an IaC *win*). One caveat: **`google_iap_brand`/`google_iap_client` are create-only** in the TF provider (brand can't be updated/deleted). We already sidestep this — `read_oauth_client()` treats OAuth clients as **pre-created inputs read from secret files**; we never provision the brand. Keep that boundary.
+- `configure_gcp_registry.py` — Artifact Registry `set-cleanup-policies` → `google_artifact_registry_repository.cleanup_policies`. **Covered.**
+
+**Buckets** (`configure_buckets.py`): GCS lifecycle via `gcloud storage` (→ `google_storage_bucket.lifecycle_rule`, covered), but **R2 and CoreWeave object-storage lifecycle via the raw botocore S3 API**. Neither Pulumi nor Terraform has a first-class CoreWeave-object-storage provider, and Cloudflare's R2 lifecycle support is thin. This is a **weak spot for IaC regardless of tool** (see "What's harder" below).
+
+**CoreWeave** (`install_kueue.py`, `install_traefik_proxy.py`, `ensure_rbac`, `ensure_nodepools`): Helm releases (`cks-kueue`, `traefik`, `cert-manager`) + raw kubectl manifests (Topology CRs, `cw-ib` ResourceFlavor, `iris-cq` ClusterQueue, ClusterIssuers) + CRD-establishment waits + namespace-scoped webhook config. NodePools and RBAC are k8s objects.
+
+### CoreWeave provider reality
+
+CoreWeave ships an official **Terraform provider** (`coreweave/coreweave`, GA Feb 2025) with a first-class `coreweave_cks_cluster` resource (+ VPC). **NodePools are managed as Kubernetes manifests** through the cluster kubeconfig, *not* as native provider resources ([CKS Terraform docs](https://docs.coreweave.com/docs/products/cks/terraform/about), [`coreweave_cks_cluster`](https://registry.terraform.io/providers/coreweave/coreweave/latest/docs/resources/cks_cluster)). So on either tool: cluster+VPC = provider resource; NodePools + add-ons = k8s API. **Pulumi bridges any TF provider** (`pulumi package add terraform-provider coreweave/coreweave`), so a Pulumi program reuses the CoreWeave (and Cloudflare) TF providers from Python — Pulumi rides on the TF ecosystem rather than replacing it.
+
+### The comparison, weighted for *our* situation
+
+| Axis | Pulumi | Terraform / OpenTofu | Verdict for us |
+|---|---|---|---|
+| Language | Python (real) | HCL | **Pulumi** — reuse `rigging.filesystem.s3_data_buckets`, read `config/<cluster>.yaml` `provisioning:` directly, compute the served CRD apiVersion in-code (exactly what `install_kueue.py` does today). No re-expression of config. |
+| CRD-then-CR in one apply | Yes | **No** — `kubernetes_manifest` validates schema at plan time (two-apply problem); needs `kubectl` provider or split applies ([TF k8s CRD FAQ](https://developer.hashicorp.com/terraform/tutorials/kubernetes/kubernetes-crd-faas), [avoid kubernetes_manifest](https://medium.com/@danieljimgarcia/dont-use-the-terraform-kubernetes-manifest-resource-6c7ff4fe629a)) | **Pulumi** — our stack is CRD-heavy (cert-manager, Kueue, CoreWeave NodePool); scripts already loop on `wait_for_crd_established`. |
+| Secrets | First-class, encrypted in state by default | **Plaintext in state**; mitigate with Vault/backend | **Pulumi** — we're secret-heavy (SA keys, R2/CW access keys, IAP secrets, finelog delegation secret) and the admin design uses `gcp-secret://` refs. |
+| Embed in a CLI | **Automation API** (drive up/preview/destroy from Python) | None equivalent | **Pulumi** — lets `marin-cluster admin` call the engine in-process, matching "IaC is the engine behind `provisioning:`". |
+| Ecosystem / battle-testing | Smaller; ~45%/yr growth | ~76% market share; huge corpus; leaner at scale | **Terraform** — more GCLB/IAP examples, more contributors know HCL. |
+| Provider source | Bridges TF providers (CoreWeave/Cloudflare) — extra layer | Native | **Terraform** — CoreWeave/Cloudflare providers are TF-first; Pulumi adds a bridge that can lag. |
+| Licensing / backend | Open-core SDK; default backend is Pulumi Cloud (self-host `s3://` supported) | BSL since 2023; **OpenTofu** is the truly-OSS fork | Wash — both self-hostable; OpenTofu removes the BSL concern for TF. |
+
+Sources: [Pulumi vs Terraform (Pulumi)](https://www.pulumi.com/docs/iac/comparisons/terraform/), [spacelift](https://spacelift.io/blog/pulumi-vs-terraform), [env0](https://www.env0.com/blog/pulumi-vs-terraform-an-in-depth-comparison).
+
+**Net:** the axes that favor Pulumi (Python reuse of our config/rigging, CRD ergonomics our code already fights, first-class secrets, Automation API to back the umbrella) are the ones that map to *our specific stack*; the axes that favor Terraform (bigger ecosystem, native CoreWeave provider) are real but general. Recommend **Pulumi**, eyes open to the bridge-layer dependency on TF providers.
+
+## What's harder under IaC (either tool) — honest list
+
+- **R2 / CoreWeave object-storage bucket lifecycle.** No first-class provider; today it's a botocore S3 reconciler. Options: keep the botocore reconciler out of IaC (pragmatic), or drive it through the AWS S3 provider pointed at the CW/R2 endpoint (works for generic S3, non-AWS quirks). Lean: **leave bucket lifecycle as-is initially**; don't force it into the first cut.
+- **IAP OAuth brand/clients** are create-only declaratively — but we already treat them as external inputs, so no regression *if we hold that boundary*.
+- **Bridged-provider drift.** CoreWeave/Cloudflare are TF-native; a Pulumi bridge can lag upstream provider releases.
+- **CKS cluster-create maturity.** The provider is new (2025); how robust `coreweave_cks_cluster` create/update is at our fleet sizes is unproven by us — may start IaC at the NodePool/add-on layer and leave cluster-create a console step initially.
+
+## State & secrets backend
+
+Pulumi supports self-managed backends, so we avoid a Pulumi-Cloud dependency: **state in a GCS bucket** (`pulumi login gs://marin-iac-state`) and the **secrets provider a GCP KMS key** (`pulumi stack init --secrets-provider gcpkms://…`). GCS is the logical choice — we already run on GCP, it's the same trust domain as our other admin tooling, and it works uniformly for both the CoreWeave and GCP stacks (the state bucket need not live in the cloud a stack provisions; a CoreWeave stack keeping its state in GCS is fine and keeps one backend for everything). The backend + secrets provider are **stack configuration**, not baked into the program — a third party points their stacks at their own bucket/KMS key.
+
+## Deployability by others (monorepo; detailed)
+
+Decision: IaC lives in the monorepo (`infra/iac/`). The tradeoff, made concrete:
+
+- **For the monorepo:** the Pulumi program sits next to the `config/<cluster>.yaml` it reads and the CI that runs it; the `provisioning:` schema is versioned together with the Iris code that consumes it (no cross-repo version skew); a third party gets a working, runnable reference implementation by forking one tree.
+- **Against (and the mitigation):** our concrete values — project ids, `oa.dev` DNS, reserved fleet sizes, SA emails, bucket names — are checked into `config/*.yaml` and the per-stack `Pulumi.<stack>.yaml`. The risk is the program accidentally hard-coding *our* specifics. **Mitigation, load-bearing:** every concrete value lives in the `provisioning:` config or stack config; the Pulumi program is generic over the schema and contains no Marin-specific constants. This is the same discipline the admin-unification doc already imposes on `setup_iam.py`/`iap_gclb.py` (kill the `DEFAULT_PROJECT`/`DEFAULT_ZONE` constants).
+
+**The real portability contract is not the IaC — it's the set of prerequisites `iris cluster start` now *verifies*** (namespace + RBAC it can use, NodePools matching the config's scale groups, Kueue with namespace-scoped webhooks + the bound ClusterQueue, an ingress publishing `/proxy`, an object-storage bucket + creds). Because Iris verifies rather than creates these, the contract is explicit and testable, and a deployer can satisfy it *however they like*. Our Pulumi program is a reference implementation of that contract, not a requirement.
+
+Two personas:
+
+1. **"Run Iris as-is on my own CoreWeave/GCP account"** (topology matches ours). Workflow: copy a `config/cw-*.yaml` (or the GCP `marin.yaml`), edit its `identity:` + `provisioning:` to their project/region/fleet/DNS, `pulumi stack init <their-cluster>` pointing at *their* state bucket + KMS key, `pulumi up`, then `iris --cluster=<their-cluster> cluster start`. They reuse our program unchanged; only config differs. This is the happy path and the reason monorepo + schema-generic program matters.
+2. **"Run Iris on infra we don't support"** (AWS EKS, on-prem k8s, a different ingress/object store). Our Pulumi program doesn't fit their topology. Workflow: they provision the documented prerequisite contract with their own IaC (their own Pulumi program, Terraform, Helm, or by hand), then `iris cluster start` verifies the invariants and runs. They write their own IaC; the recommendation is *not* to bend ours to every backend. The Iris cluster config schema is what they target.
+
+So the recommendation to a would-be deployer is a decision tree: *topology matches → fork `infra/iac/`, bring your own `provisioning:` config + backend; topology differs → satisfy the prerequisite contract with your own IaC.* Either way the Iris cluster config is the stable boundary, and the monorepo location makes the reference implementation and the contract it satisfies discoverable in one place.

--- a/.agents/projects/iac/spec.md
+++ b/.agents/projects/iac/spec.md
@@ -135,9 +135,9 @@ provisioning:
 
 ```text
 infra/iac/
-├── Pulumi.yaml                     # project: name=marin-iac, runtime=python, secretsprovider=gcpkms://…
-├── Pulumi.cw-us-east-02a.yaml      # stack config: marin-iac:cluster = cw-us-east-02a
-├── Pulumi.cw-rno2a.yaml            # stack config: marin-iac:cluster = cw-rno2a
+├── Pulumi.yaml                     # project: name=marin-iac, runtime=python
+├── Pulumi.cw-us-east-02a.yaml      # stack config: marin-iac:cluster = cw-us-east-02a, secretsprovider = gcpkms://…
+├── Pulumi.cw-rno2a.yaml            # stack config: marin-iac:cluster = cw-rno2a, secretsprovider = gcpkms://…
 ├── Pulumi.gcp.yaml                 # RESERVED (GCP) — not populated this pass
 ├── __main__.py                     # entry: dispatch by provider → build components
 ├── pyproject.toml                  # marin-iac package; deps: pulumi, pulumi-kubernetes, marin-iris, marin-rigging
@@ -157,7 +157,7 @@ infra/iac/
 the KMS key that encrypts secrets are provisioned once, by hand, *before* any `pulumi up` — they
 cannot be IaC-managed without a chicken-and-egg. Documented as a two-command bootstrap in the
 `infra/iac/` README. `pulumi login gs://marin-iac-state`; `secretsprovider: gcpkms://…` in
-`Pulumi.yaml`. Both are operator/CI environment, overridable by third-party deployers.
+`Pulumi.<stack>.yaml`. Both are operator/CI environment, overridable by third-party deployers.
 
 **Who runs apply.** `pulumi up` is **operator-run**; CI runs `pulumi preview` and posts the plan
 to the PR (no CI apply in the first cut, because these stacks touch reserved GPU fleets). Full
@@ -196,7 +196,7 @@ edge (the Pulumi win over TF's `kubernetes_manifest` two-apply problem).
 @dataclass(frozen=True)
 class NodePoolSpec:
     """One CoreWeave NodePool, projected from an Iris scale group. Mirrors the manifest Iris
-    builds today (controller.py:_build_nodepool_manifest) so a port preserves behavior."""
+    builds today (controller.py:_ensure_one_nodepool) so a port preserves behavior."""
     name: str                    # normalized {label_prefix}-{scale_group} (RFC1123: lower, _→-)
     instance_type: str           # slice_template.coreweave.instance_type
     min_nodes: int               # buffer_slices * slice_template.num_vms
@@ -228,7 +228,8 @@ class IrisRbacArgs:
 class IrisRbac(pulumi.ComponentResource):
     """The Namespace, `iris-controller` ServiceAccount, and namespace-qualified ClusterRole +
     ClusterRoleBinding formerly created by ensure_rbac(). ClusterRole verbs reproduce
-    coreweave.md §5 exactly (nodepools; pods, pods/exec, pods/log; nodes; configmaps). This is
+    ensure_rbac() in controller.py exactly (nodepools; pods, pods/exec, pods/log; nodes;
+    configmaps; metrics/pods; poddisruptionbudgets; kueue workloads; priorityclasses). This is
     the contract Iris's verify_prerequisites() checks."""
     def __init__(self, name: str, args: IrisRbacArgs, *, k8s_provider: pulumi.ProviderResource,
                  opts: pulumi.ResourceOptions | None = None) -> None: ...
@@ -298,8 +299,8 @@ File: `lib/iris/src/iris/cluster/platforms/k8s/controller.py` (the K8s controlle
 
 - **Removed from `start_controller()`** (`controller.py:411`, `:435`): `self.ensure_rbac()` and
   `self.ensure_nodepools(config)`. The methods `ensure_rbac()` (`:669`) and `ensure_nodepools()`
-  (`:830`) are **deleted** (no back-compat). `_build_nodepool_manifest`/`_nodepool_name` logic
-  moves into `iac.nodepools` as the single owner of NodePool shape.
+  (`:830`) are **deleted** (no back-compat). The manifest construction in `_ensure_one_nodepool`
+  and the `_nodepool_name` logic move into `iac.nodepools` as the single owner of NodePool shape.
 - **Added**: `verify_prerequisites(config)`, called where `ensure_rbac()` was.
 
 ```python
@@ -423,9 +424,9 @@ Two phases; phase 1 is what this design builds.
   stack, and posts the plan as a PR comment (`pulumi/actions`). **CI never runs `pulumi up`.**
 - **CI identity** — service account `pulumi-ci@<proj>`, least-privilege for preview:
   - `roles/cloudkms.cryptoKeyDecrypter` on the state key (decrypt state secrets to compute the diff),
-  - `roles/storage.objectViewer` on `gs://marin-iac-state`,
+  - object write/delete permissions on the `gs://marin-iac-state` lock prefix (e.g. `roles/storage.objectUser` on the `.pulumi/locks` path to acquire/release stack locks),
   - `roles/secretmanager.secretAccessor` on referenced secrets (once `access_key_secret_ref` is wired),
-  - a read-only kubeconfig for the target cluster (the k8s SSA dry-run).
+  - a kubeconfig for the target cluster with write permissions (create/patch/update/delete) for the specific resources managed by the IaC stack, which is required for Kubernetes Server-Side Apply (SSA) dry-run validation.
 - **Gate.** Reviewers read the posted plan; a NodePool `replace`/`delete` blocks the PR — the
   same gate as §4/§6.
 - **Apply.** After review/merge an **operator** runs `pulumi up <stack>` from a trusted

--- a/.agents/projects/iac/spec.md
+++ b/.agents/projects/iac/spec.md
@@ -435,11 +435,13 @@ Two phases; phase 1 is what this design builds.
 
 ### Secrets model
 
-State is encrypted with the GCP **KMS** key that is the Pulumi `secretsprovider` — Secret Manager
-cannot serve this role. Secret *inputs* the program reads (object-storage keys, etc.) live in GCP
-**Secret Manager**, referenced via `gcp-secret://…` (`ObjectStorageSpec.access_key_secret_ref`).
-The self-managed GCS backend does per-stack locking, so a concurrent CI preview and operator
-apply cannot corrupt state.
+For configuration values specific to a stack/deployment, we use Pulumi's native secrets system:
+- Secrets are set locally using the CLI: `pulumi config set --secret <key> <value>`.
+- Pulumi encrypts these values using the GCP **KMS** key specified as the `secretsprovider` in `Pulumi.<stack>.yaml`.
+- The encrypted ciphertext is stored directly in the `Pulumi.<stack>.yaml` file, which is safe to check into git.
+- At runtime, `pulumi up` and `pulumi preview` decrypt these values using the KMS key (requiring `roles/cloudkms.cryptoKeyDecrypter` on the key).
+
+The self-managed GCS backend does per-stack locking, so a concurrent CI preview and operator apply cannot corrupt state.
 
 ### Phase 2 — full CD (later, not built now)
 

--- a/.agents/projects/iac/spec.md
+++ b/.agents/projects/iac/spec.md
@@ -1,0 +1,447 @@
+# IaC for Marin — Spec
+
+Contract layer for [design.md](design.md). Pins: the `provisioning:` config schema,
+the `infra/iac/` layout, the Pulumi component surface, the Iris cede/verify change,
+new error types, migration/failure semantics, and an explicit out-of-scope list.
+CoreWeave is fully specified; the GCP components are named (committed, sequenced after)
+and their ownership boundary sketched, but not signed here.
+
+**Config namespaces (read first).** Marin has two config files per CoreWeave cluster:
+
+- `config/coreweave.yaml` — per-*cloud* rigging/data config (`region_buckets`, keyed
+  `iris: coreweave`); shared by all CW clusters.
+- `lib/iris/config/<cluster>.yaml` — per-*cluster* Iris config (`scale_groups`,
+  `kubernetes_provider`, `platform.coreweave`, `controller.coreweave`).
+
+The new `provisioning:` section goes in the **per-cluster** file
+(`lib/iris/config/<cluster>.yaml`), because it is per-cluster (one CKS cluster, one
+NodePool set) and must sit alongside the `scale_groups` it is derived against. Both
+`load_provisioning(cluster)` and the Iris config loader resolve the same `<cluster>`
+key to that one file via the existing iris config search path.
+
+---
+
+## 1. `provisioning:` config schema
+
+A new **provider-discriminated** section in `lib/iris/config/<cluster>.yaml`, extending the schema the [cluster-admin-unification design](../2026-06-23_cluster_admin_unification.md) introduces (`provisioning.gcp`); this design adds the `coreweave` variant. Typed as pydantic.
+**Canonical home: `infra/iac/src/iac/config.py`** — this design operationalizes the
+section; `marin-cluster admin` imports the models from here. If `lib/cluster` lands its
+`ClusterConfig`, it embeds these by import, not re-definition.
+
+**Single-source rules (load-bearing).** `provisioning.coreweave` carries only cluster-level
+facts *absent* from the Iris config. Everything already in the Iris config is read from there,
+never re-declared:
+
+- **NodePools** derive from `scale_groups` (§3 `derive_nodepools`).
+- **Namespace** derives from `kubernetes_provider.namespace` — so RBAC namespace and the Kueue
+  webhook scope are structurally one value (the webhook-deadlock invariant is then guaranteed,
+  not merely validated).
+- **ClusterQueue name** derives from `kubernetes_provider.kueue.cluster_queue` (the queue Iris
+  binds its LocalQueue to). IaC creates the queue Iris expects; the name is not duplicated.
+
+```python
+# infra/iac/src/iac/config.py
+from enum import StrEnum
+from pydantic import BaseModel, Field
+
+class Provider(StrEnum):
+    COREWEAVE = "coreweave"
+    GCP = "gcp"
+
+class CksClusterSpec(BaseModel):
+    """The CoreWeave CKS cluster object (coreweave_cks_cluster)."""
+    name: str                       # e.g. "marin-gpu"
+    zone: str                       # e.g. "US-EAST-02A"
+    vpc: str | None = None          # existing VPC name; None => provider default
+    import_existing: bool = False   # True => adopt a console-created cluster (§4 migration)
+
+class KueueProvSpec(BaseModel):
+    """Cluster-scoped Kueue objects owned by IaC (KueueAddon). cluster_queue and pod_namespace
+    are NOT here — they derive from the Iris config (single-source rules above)."""
+    resource_flavor: str            # e.g. "cw-ib"
+    topologies: list[str]           # Topology CRs, e.g. ["infiniband", "multinode-nvlink-ib"]
+
+class IngressSpec(BaseModel):
+    """Traefik + cert-manager + ACME issuers (TraefikAddon)."""
+    ingress_class: str = "traefik"
+    acme_email: str
+    cluster_issuers: list[str]      # e.g. ["letsencrypt-http01-staging", "letsencrypt-http01-prod"]
+
+class RbacSpec(BaseModel):
+    """Controller RBAC ceded from ensure_rbac(). namespace derives from the Iris config."""
+    service_account: str = "iris-controller"
+
+class BucketSpec(BaseModel):
+    name: str                       # e.g. "marin-us-east-02a"
+    region: str                     # e.g. "US-EAST-02A"
+
+class ObjectStorageSpec(BaseModel):
+    """Buckets + access key(s). Bucket *lifecycle rules* are OUT OF SCOPE (§6)."""
+    buckets: list[BucketSpec] = Field(default_factory=list)
+    access_key_secret_ref: str | None = None   # gcp-secret://… ; None => keys managed out of band
+
+class CoreweaveProvisioning(BaseModel):
+    region: str
+    cluster: CksClusterSpec
+    kueue: KueueProvSpec
+    ingress: IngressSpec
+    rbac: RbacSpec = RbacSpec()
+    object_storage: ObjectStorageSpec = ObjectStorageSpec()
+
+class ProvisioningConfig(BaseModel):
+    """Top-level `provisioning:` section. Exactly one provider block is populated."""
+    provider: Provider
+    coreweave: CoreweaveProvisioning | None = None
+    # gcp: GcpProvisioning | None = None   # defined by admin-unification; ported after CoreWeave
+
+def load_provisioning(cluster: str) -> ProvisioningConfig:
+    """Load and validate `provisioning:` from lib/iris/config/<cluster>.yaml.
+
+    Resolves the file via the existing iris config search path (same resolution the Iris
+    cluster-config loader uses for the same `cluster` key). Raises pydantic.ValidationError on
+    a malformed section, and ValueError if `provider` is set without its matching block. No
+    namespace/queue cross-checks are needed — those values are single-sourced from the Iris
+    config, not duplicated here.
+    """
+```
+
+Example addition to `lib/iris/config/cw-us-east-02a.yaml` (values from that same file's existing
+`scale_groups` / `kubernetes_provider`):
+
+```yaml
+provisioning:
+  provider: coreweave
+  coreweave:
+    region: US-EAST-02A
+    cluster: { name: marin-gpu, zone: US-EAST-02A }
+    kueue:
+      resource_flavor: cw-ib
+      topologies: [infiniband, multinode-nvlink-ib]
+    ingress:
+      ingress_class: traefik
+      acme_email: ops@oa.dev
+      cluster_issuers: [letsencrypt-http01-staging, letsencrypt-http01-prod]
+    rbac: { service_account: iris-controller }
+    object_storage:
+      buckets:
+        - { name: marin-us-east-02a, region: US-EAST-02A }
+# namespace (iris) comes from kubernetes_provider.namespace;
+# cluster_queue (iris-cq) comes from kubernetes_provider.kueue.cluster_queue — not repeated here.
+```
+
+---
+
+## 2. `infra/iac/` layout
+
+```text
+infra/iac/
+├── Pulumi.yaml                     # project: name=marin-iac, runtime=python, secretsprovider=gcpkms://…
+├── Pulumi.cw-us-east-02a.yaml      # stack config: marin-iac:cluster = cw-us-east-02a
+├── Pulumi.cw-rno2a.yaml            # stack config: marin-iac:cluster = cw-rno2a
+├── Pulumi.gcp.yaml                 # RESERVED (GCP) — not populated this pass
+├── __main__.py                     # entry: dispatch by provider → build components
+├── pyproject.toml                  # marin-iac package; deps: pulumi, pulumi-kubernetes, marin-iris, marin-rigging
+└── src/iac/                        # src-layout package (import name `iac`), mirrors lib/*/src/<pkg>
+    ├── config.py                   # §1 schema + load_provisioning
+    ├── nodepools.py                # derive_nodepools(IrisClusterConfig) -> list[NodePoolSpec]
+    └── coreweave/
+        ├── cluster.py              # CoreweaveCluster
+        ├── rbac.py                 # IrisRbac
+        ├── kueue.py                # KueueAddon
+        ├── traefik.py              # TraefikAddon
+        └── storage.py              # ObjectStorage
+    # gcp/ added when the GCP surface ports (GcpIam, GcpGclbIap, GcpRegistry)
+```
+
+**Backend bootstrap (manual, out of IaC).** The GCS state bucket (`gs://marin-iac-state`) and
+the KMS key that encrypts secrets are provisioned once, by hand, *before* any `pulumi up` — they
+cannot be IaC-managed without a chicken-and-egg. Documented as a two-command bootstrap in the
+`infra/iac/` README. `pulumi login gs://marin-iac-state`; `secretsprovider: gcpkms://…` in
+`Pulumi.yaml`. Both are operator/CI environment, overridable by third-party deployers.
+
+**Who runs apply.** `pulumi up` is **operator-run**; CI runs `pulumi preview` and posts the plan
+to the PR (no CI apply in the first cut, because these stacks touch reserved GPU fleets). Full
+contract — CI job, WIF auth, IAM split, secrets model, and the later CD phase — is §9.
+
+### Entry contract (`__main__.py`)
+
+```python
+# Contract, not implementation.
+cluster  = pulumi.Config("marin-iac").require("cluster")       # e.g. "cw-us-east-02a"
+prov     = load_provisioning(cluster)                          # §1
+iris_cfg = load_iris_cluster_config(cluster)                   # iris.cluster.config loader
+if prov.provider is Provider.COREWEAVE:
+    ns    = iris_cfg.kubernetes_provider.namespace             # single-source namespace
+    cq    = iris_cfg.kubernetes_provider.kueue.cluster_queue   # single-source queue name
+    cw    = CoreweaveCluster("cluster", CoreweaveClusterArgs(
+                cluster=prov.coreweave.cluster, region=prov.coreweave.region,
+                nodepools=derive_nodepools(iris_cfg)))
+    k8s   = pulumi_kubernetes.Provider("cw-k8s", kubeconfig=cw.kubeconfig)
+    IrisRbac("rbac", IrisRbacArgs(namespace=ns, spec=prov.coreweave.rbac), k8s_provider=k8s)
+    KueueAddon("kueue", KueueAddonArgs(namespace=ns, cluster_queue=cq, spec=prov.coreweave.kueue),
+               k8s_provider=k8s)
+    TraefikAddon("traefik", TraefikAddonArgs(spec=prov.coreweave.ingress), k8s_provider=k8s)
+    ObjectStorage("storage", ObjectStorageArgs(spec=prov.coreweave.object_storage))
+```
+
+---
+
+## 3. Pulumi component surface (CoreWeave)
+
+`pulumi.ComponentResource` subclasses; args are frozen dataclasses. Each addon takes a
+`k8s_provider` built from `CoreweaveCluster.kubeconfig`, so CRD→CR ordering is a real dependency
+edge (the Pulumi win over TF's `kubernetes_manifest` two-apply problem).
+
+```python
+@dataclass(frozen=True)
+class NodePoolSpec:
+    """One CoreWeave NodePool, projected from an Iris scale group. Mirrors the manifest Iris
+    builds today (controller.py:_build_nodepool_manifest) so a port preserves behavior."""
+    name: str                    # normalized {label_prefix}-{scale_group} (RFC1123: lower, _→-)
+    instance_type: str           # slice_template.coreweave.instance_type
+    min_nodes: int               # buffer_slices * slice_template.num_vms
+    max_nodes: int               # max_slices   * slice_template.num_vms
+    node_labels: dict[str, str]  # iris scale-group/managed/region labels + worker.attributes (§below)
+    system_critical: bool        # min_nodes > 0 → cks.coreweave.cloud/system-critical
+    autoscaling: bool = True     # kept True as today; CoreWeave autoscaler owns runtime targetNodes
+    # NOTE: targetNodes is NOT part of the spec — the manifest omits it and CoreWeave owns the
+    # runtime count. Pulumi declares only the [min,max] envelope + labels.
+
+class CoreweaveCluster(pulumi.ComponentResource):
+    """The CKS cluster (coreweave_cks_cluster via the bridged CoreWeave TF provider — or adopted
+    via import when cluster.import_existing) plus the reserved NodePools. Reconciles the set of
+    IaC-managed NodePools to exactly `args.nodepools`. Each NodePool is declared with
+    `ignore_changes=["spec.targetNodes"]` so CoreWeave's autoscaler may move the runtime count
+    within [min,max] without Pulumi fighting it — IaC owns the envelope, not the live count.
+    Exports `kubeconfig`: from the provider output in create mode, or read from the Iris config's
+    `platform.coreweave.kubeconfig_path` in import mode.
+    """
+    kubeconfig: pulumi.Output[str]
+    def __init__(self, name: str, args: CoreweaveClusterArgs,
+                 opts: pulumi.ResourceOptions | None = None) -> None: ...
+
+@dataclass(frozen=True)
+class IrisRbacArgs:
+    namespace: str               # from kubernetes_provider.namespace
+    spec: RbacSpec
+
+class IrisRbac(pulumi.ComponentResource):
+    """The Namespace, `iris-controller` ServiceAccount, and namespace-qualified ClusterRole +
+    ClusterRoleBinding formerly created by ensure_rbac(). ClusterRole verbs reproduce
+    coreweave.md §5 exactly (nodepools; pods, pods/exec, pods/log; nodes; configmaps). This is
+    the contract Iris's verify_prerequisites() checks."""
+    def __init__(self, name: str, args: IrisRbacArgs, *, k8s_provider: pulumi.ProviderResource,
+                 opts: pulumi.ResourceOptions | None = None) -> None: ...
+
+@dataclass(frozen=True)
+class KueueAddonArgs:
+    namespace: str               # webhook scope (== rbac namespace, structurally)
+    cluster_queue: str           # from kubernetes_provider.kueue.cluster_queue
+    spec: KueueProvSpec
+
+class KueueAddon(pulumi.ComponentResource):
+    """The `cks-kueue` Helm release, Topology CRs, the cluster-scoped ResourceFlavor and the
+    ClusterQueue named `cluster_queue`, plus the controller-manager Configuration. Admission
+    webhooks are scoped to `namespace` (managedJobsNamespaceSelector) — an unscoped webhook
+    deadlocks node delivery cluster-wide, so this is asserted in tests. Does NOT create the
+    namespaced LocalQueue — Iris keeps reconciling that at controller start."""
+    def __init__(self, name: str, args: KueueAddonArgs, *, k8s_provider: pulumi.ProviderResource,
+                 opts: pulumi.ResourceOptions | None = None) -> None: ...
+
+@dataclass(frozen=True)
+class TraefikAddonArgs:
+    spec: IngressSpec
+
+class TraefikAddon(pulumi.ComponentResource):
+    """Traefik + cert-manager Helm releases and the HTTP-01 Let's Encrypt ClusterIssuers named in
+    `spec.cluster_issuers`. cert-manager CRDs are established before the ClusterIssuers apply (a
+    dependsOn edge, replacing install_traefik_proxy.py's wait_for_crd loop)."""
+    def __init__(self, name: str, args: TraefikAddonArgs, *, k8s_provider: pulumi.ProviderResource,
+                 opts: pulumi.ResourceOptions | None = None) -> None: ...
+
+@dataclass(frozen=True)
+class ObjectStorageArgs:
+    spec: ObjectStorageSpec
+
+class ObjectStorage(pulumi.ComponentResource):
+    """CoreWeave AI Object Storage buckets in `spec.buckets` and their access key(s). Bucket
+    *lifecycle rules* are NOT managed here (§6). Access-key material is a Pulumi secret
+    (encrypted in state) and/or read from `spec.access_key_secret_ref`."""
+    def __init__(self, name: str, args: ObjectStorageArgs,
+                 opts: pulumi.ResourceOptions | None = None) -> None: ...
+```
+
+```python
+# infra/iac/src/iac/nodepools.py
+def derive_nodepools(config: IrisClusterConfig) -> list[NodePoolSpec]:
+    """Project the Iris config's scale_groups onto CoreWeave NodePool specs, byte-compatible with
+    the manifests ensure_nodepools() builds today.
+
+    One NodePool per scale group that HAS a coreweave slice_template; groups without one are
+    SKIPPED (matching current ensure_nodepools, controller.py:841), not errored. For each:
+      name          = _nodepool_name(label_prefix, scale_group)   # lower(), '_'→'-'
+      instance_type = slice_template.coreweave.instance_type
+      min_nodes     = buffer_slices * slice_template.num_vms
+      max_nodes     = max_slices    * slice_template.num_vms
+      node_labels   = {iris scale-group label, iris managed label, region} + worker.attributes
+      system_critical = min_nodes > 0
+    verify_prerequisites (§4) MUST use this same function so expected names match created names.
+    """
+```
+
+---
+
+## 4. Iris-side change: cede, verify, migrate
+
+File: `lib/iris/src/iris/cluster/platforms/k8s/controller.py` (the K8s controller platform; the
+`providers/k8s/coreweave.py` path in the docs is stale).
+
+- **Removed from `start_controller()`** (`controller.py:411`, `:435`): `self.ensure_rbac()` and
+  `self.ensure_nodepools(config)`. The methods `ensure_rbac()` (`:669`) and `ensure_nodepools()`
+  (`:830`) are **deleted** (no back-compat). `_build_nodepool_manifest`/`_nodepool_name` logic
+  moves into `iac.nodepools` as the single owner of NodePool shape.
+- **Added**: `verify_prerequisites(config)`, called where `ensure_rbac()` was.
+
+```python
+def verify_prerequisites(self, config: IrisClusterConfig) -> None:
+    """Assert IaC-provisioned prerequisites exist before starting the controller.
+
+    Provider-scoped: on CoreWeave it checks presence (not exact spec — see design Open Questions
+    on strictness) of the Namespace + `iris-controller` SA + ClusterRole/Binding; one NodePool
+    per non-skipped scale group (names from derive_nodepools); the Kueue ClusterQueue (from
+    kubernetes_provider.kueue.cluster_queue) and the ResourceFlavor (from
+    provisioning.coreweave.kueue.resource_flavor); and the IngressClass (from
+    provisioning.coreweave.ingress.ingress_class). On GCP it checks the GCP-arm prerequisites
+    (§6) — there are no per-scale-group NodePools there, so the check is a different set, not a
+    reused CoreWeave shape. Presence only: it does not assert health (a running Kueue manager) —
+    that is `pulumi up`'s success gate, not cluster-start's. Raises PrerequisitesNotProvisionedError
+    enumerating every missing object with remediation `cd infra/iac && pulumi stack select
+    <cluster> && pulumi up`. Creates nothing.
+    """
+```
+
+Unchanged in `start_controller()` (still Iris-owned): ConfigMap, `iris-task-env` Secret
+(`ensure_task_env_secret`, `:968`), the namespaced LocalQueue (`ensure_kueue_queues`, `:436`),
+priority classes (`ensure_priority_classes`, `:437`), the state PVC, the controller Deployment,
+the Service.
+
+### Migration of the live clusters (adoption)
+
+`cw-us-east-02a` and `cw-rno2a` already run RBAC + NodePools that Iris created and labelled
+`iris-…-managed`. First managed apply must **adopt**, not recreate — a naive apply would
+conflict, and a reconcile-delete could deprovision a reserved 256-GPU fleet. Procedure, pinned:
+
+1. Bootstrap state bucket + KMS (§2).
+2. `pulumi import` the existing Namespace, RBAC objects, and each NodePool into the stack (an
+   `infra/iac/import/<cluster>.sh` mapping k8s object → Pulumi resource address), so state
+   reflects reality with **no diff**.
+3. `pulumi preview` must then show an **empty plan** (or only additive add-ons: Kueue
+   ResourceFlavor/ClusterQueue, Traefik, buckets). A non-empty destructive plan on NodePools is
+   a stop-the-line bug.
+4. Only after a clean preview, `pulumi up`, then deploy new Iris with `verify_prerequisites`.
+
+`cluster.import_existing` covers the CKS cluster object itself the same way.
+
+---
+
+## 5. New error types
+
+```python
+class PrerequisitesNotProvisionedError(InfraError):
+    """Raised by verify_prerequisites() when one or more IaC-provisioned prerequisites are absent.
+    Message enumerates every missing object and prints the `pulumi up` remediation. Subclass of
+    the existing iris InfraError so existing cluster-start handling still catches it."""
+```
+
+`load_provisioning` (§1) raises `pydantic.ValidationError` (malformed) and `ValueError`
+(provider/block mismatch). No new config-parse exception type.
+
+---
+
+## 6. Failure modes & partial apply
+
+- **Partial apply.** `pulumi up` is transactional per resource, not globally atomic; a failed run
+  can leave NodePools up but Kueue half-installed. `verify_prerequisites` is presence-only, so it
+  can pass against an unhealthy partial state — therefore the operator contract is: a failed
+  `pulumi up` must be re-run to green *before* `iris cluster start`, and CI preview never leaves a
+  half-applied stack. The specific hazard (a Kueue webhook installed but manager not Ready)
+  deadlocks node delivery; the webhook-namespace scoping (asserted in tests) bounds the blast
+  radius to the `iris` namespace regardless.
+- **Drift.** CoreWeave autoscaler moving `targetNodes` is *expected* drift, absorbed by
+  `ignore_changes` on NodePools; it never shows in `pulumi preview`. Any other drift surfaces in
+  preview and is reconciled on the next operator apply.
+
+---
+
+## 7. Out of scope
+
+Reviewers: do **not** push back on these being absent — they are deliberate.
+
+- **R2 / CoreWeave bucket *lifecycle* rules** — `infra/configure_buckets.py` keeps them; no
+  first-class provider exists. `ObjectStorage` does buckets + keys only.
+- **GCP components** (`GcpIam`, `GcpGclbIap`, `GcpRegistry`) — committed, sequenced after
+  CoreWeave; named + ownership-sketched (§4), not signed here. **Approving this design approves
+  the GCP port in principle** (all-or-nothing); the GCP component signatures are a follow-on spec.
+- **IAP OAuth brand / clients** — externally created, read as inputs (`read_oauth_client`).
+- **TPU / worker slice lifecycle** — Iris's autoscaler (class-2, imperative) on all clouds.
+- **Iris-owned runtime objects** — ConfigMap, `iris-task-env` Secret, LocalQueue, priority
+  classes, controller Deployment + Service stay in `start_controller()`.
+- **`marin-cluster admin` CLI wiring.** This spec pins the *invocation surface*: admin drives the
+  same `infra/iac` program **in-process via the Pulumi Automation API** (not by shelling to the
+  CLI); the acceptance test and operator flow shell `pulumi` directly against the same program.
+  The CLI wiring itself lands with admin-unification.
+- **CKS cluster-*create* maturity** — if `coreweave_cks_cluster` create proves weak (design Open
+  Questions), `import_existing: true` adopts a console-created cluster; the signature is unchanged.
+
+---
+
+## 8. File-path summary
+
+| Piece                                                | Path                                                                              |
+| ---------------------------------------------------- | --------------------------------------------------------------------------------- |
+| Provisioning schema + loader                         | `infra/iac/src/iac/config.py`                                               |
+| NodePool derivation (single owner of NodePool shape) | `infra/iac/src/iac/nodepools.py`                                            |
+| Pulumi entry / dispatch                              | `infra/iac/__main__.py`                                                           |
+| Project / stacks / backend bootstrap README          | `infra/iac/Pulumi.yaml`, `infra/iac/Pulumi.<cluster>.yaml`, `infra/iac/README.md` |
+| Import/adoption scripts                              | `infra/iac/import/<cluster>.sh`                                                   |
+| CoreWeave components                                 | `infra/iac/src/iac/coreweave/{cluster,rbac,kueue,traefik,storage}.py`       |
+| Iris cede/verify                                     | `lib/iris/src/iris/cluster/platforms/k8s/controller.py`                           |
+| New config section                                   | `lib/iris/config/<cluster>.yaml` → `provisioning:`                                |
+| GCP components (later)                               | `infra/iac/src/iac/gcp/`                                                    |
+
+---
+
+## 9. Deploy workflow
+
+Two phases; phase 1 is what this design builds.
+
+### Phase 1 — CI preview + manual apply
+
+- **CI (preview only).** A GitHub Actions workflow triggers on PRs touching `infra/iac/**` and
+  the cluster configs it reads. It authenticates to GCP via **Workload Identity Federation**
+  (keyless OIDC — no service-account JSON in GitHub secrets), runs `pulumi preview` per affected
+  stack, and posts the plan as a PR comment (`pulumi/actions`). **CI never runs `pulumi up`.**
+- **CI identity** — service account `pulumi-ci@<proj>`, least-privilege for preview:
+  - `roles/cloudkms.cryptoKeyDecrypter` on the state key (decrypt state secrets to compute the diff),
+  - `roles/storage.objectViewer` on `gs://marin-iac-state`,
+  - `roles/secretmanager.secretAccessor` on referenced secrets (once `access_key_secret_ref` is wired),
+  - a read-only kubeconfig for the target cluster (the k8s SSA dry-run).
+- **Gate.** Reviewers read the posted plan; a NodePool `replace`/`delete` blocks the PR — the
+  same gate as §4/§6.
+- **Apply.** After review/merge an **operator** runs `pulumi up <stack>` from a trusted
+  environment, re-reading the preview. Operators hold `roles/cloudkms.cryptoKeyEncrypterDecrypter`
+  + `roles/storage.objectAdmin` (write encrypted state).
+
+### Secrets model
+
+State is encrypted with the GCP **KMS** key that is the Pulumi `secretsprovider` — Secret Manager
+cannot serve this role. Secret *inputs* the program reads (object-storage keys, etc.) live in GCP
+**Secret Manager**, referenced via `gcp-secret://…` (`ObjectStorageSpec.access_key_secret_ref`).
+The self-managed GCS backend does per-stack locking, so a concurrent CI preview and operator
+apply cannot corrupt state.
+
+### Phase 2 — full CD (later, not built now)
+
+Promote apply into CI: `pulumi up` on merge to `main`, gated behind a **GitHub Environment** with
+required reviewers — the human checkpoint moves from "operator runs it" to "operator approves the
+deploy." Same WIF identity, now granted encrypt; the preview stays the artifact of record.


### PR DESCRIPTION
Proposes Pulumi (Python) as Marin's infrastructure-as-code engine for the static cluster substrate — CKS cluster + reserved NodePools, Kueue/Traefik k8s add-ons, namespace + RBAC, and object storage — with CoreWeave migrated first and GCP committed after. Iris keeps owning dynamic per-job Pod dispatch and the autoscaler's TPU-slice lifecycle. Positions Pulumi as the executor for the approved provisioning: config layer.

Adds design.md (1-pager), research.md (resource inventory, Pulumi-vs-Terraform evidence, deployability), and spec.md (CoreWeave contract, config schema, Iris cede/verify change, migration and failure modes).

Draft of the first step of the process here: https://github.com/marin-community/marin/pull/7153

### Will's non-agent-generated take
I think Pulumi will be helpful in the long run and my experience with deploying IaC is that you're quite happy once it's all said and done. That said, the process of getting https://github.com/marin-community/marin/pull/7153 to a reasonable place involved a lot of back and forth updating the generated code from the current state so that the first deploy of IaC is actually a noop. That's consistent with my experience as well, but just calling out that it will be a fiddle-y process to roll it out without blowing up the existing clusters (and probably far worse for GCP, given the amount of cruft that's been built up).

Tagging all of Infra since it seems like it impacts everyone, but obviously everyone is not required. to have an opinion, just want everyone to have a chance should they choose to :-)