### PR TITLE
[iris] Tighten endpoint lease to 10m and remove task/attempt endpoint culling

### DIFF
--- a/lib/iris/src/iris/cluster/controller/endpoint_service.py
+++ b/lib/iris/src/iris/cluster/controller/endpoint_service.py
@@ -32,12 +32,13 @@ from iris.time_proto import duration_from_proto, duration_to_proto
 
 logger = logging.getLogger(__name__)
 
-# Lease granted when the client does not request one. Long so an old client that
-# registers once and never renews keeps its endpoint served; a renewing client
-# requests a much shorter lease and gets it (see MIN_ENDPOINT_LEASE). This only
-# bounds the dead-but-non-terminal backstop case — a task's endpoints are still
-# reclaimed promptly when it goes terminal — so it is sized generously (5 days).
-ENDPOINT_LEASE = Duration.from_hours(120)
+# Default lease granted when the client does not request one, and the ceiling a
+# requested lease is clamped to. Endpoint registrations renew on a cadence
+# (register-or-renew), so the lease governs liveness: a crashed or unrenewed
+# endpoint expires within one lease. Renewal runs at 1/3 of the granted lease, so
+# 10m yields a ~3.3m cadence and a ~10m worst-case expiry for a registrant that
+# stops renewing.
+ENDPOINT_LEASE = Duration.from_minutes(10)
 # Floor on a granted lease: bounds how often a client may force the controller to
 # re-register by capping the renewal rate a short requested lease can ask for.
 MIN_ENDPOINT_LEASE = Duration.from_minutes(3)
@@ -114,10 +115,10 @@ class EndpointServiceImpl:
     ) -> controller_pb2.Controller.RegisterEndpointResponse:
         """Register or renew a service endpoint, returning the granted lease.
 
-        Re-registering with the same ``endpoint_id`` renews the lease. The
-        endpoint is bound to ``request.task_id`` so retry cleanup removes
-        endpoints from superseded attempts. It is visible to lookup/list only
-        while that task is non-terminal and the lease is unexpired.
+        Re-registering with the same ``endpoint_id`` renews the lease.
+        Registration is refused if the task is already terminal (see
+        :meth:`EndpointsProjection.add`); once registered, the endpoint is served
+        to lookup/list until its lease lapses.
         """
         endpoint_id = request.endpoint_id or str(uuid.uuid4())
 
@@ -138,16 +139,11 @@ class EndpointServiceImpl:
 
         # Validation runs inside the writer transaction in
         # ``EndpointsProjection.add``: NOT_FOUND if the task row is missing,
-        # FAILED_PRECONDITION if the task is terminal or the attempt is stale.
+        # FAILED_PRECONDITION if the task is terminal.
         with self._db.transaction() as cur:
-            outcome = cur.caches[EndpointsProjection].add(cur, endpoint, expected_attempt_id=request.attempt_id)
+            outcome = cur.caches[EndpointsProjection].add(cur, endpoint)
         if outcome is AddEndpointOutcome.NOT_FOUND:
             raise ConnectError(Code.NOT_FOUND, f"Task {request.task_id} not found")
-        if outcome is AddEndpointOutcome.STALE_ATTEMPT:
-            raise ConnectError(
-                Code.FAILED_PRECONDITION,
-                f"Stale attempt for task {request.task_id} (attempt {request.attempt_id})",
-            )
         if outcome is AddEndpointOutcome.TERMINAL:
             raise ConnectError(
                 Code.FAILED_PRECONDITION,

--- a/lib/iris/src/iris/cluster/controller/ops/job.py
+++ b/lib/iris/src/iris/cluster/controller/ops/job.py
@@ -336,10 +336,10 @@ def cancel(
     # terminal rows (excluding WORKER_FAILED, which cancel overwrites).
     effects = ReconcileState.open(snapshot).cancel_job(job_id, reason, now)
     commit_effects(cur, effects)
-    # Sweep endpoints that survived because their owning task was already
-    # terminal before cancel ran (kernel only emits EndpointDeletion for
-    # tasks we actively killed). Derive the same subtree the kernel cancelled
-    # from the snapshot's transitive descendants.
+    # Fast-path clear of the cancelled subtree's endpoints (the FK CASCADE
+    # backstop): cancellation stops routing to these endpoints at once rather
+    # than waiting out their lease. Derive the subtree from the snapshot's
+    # transitive descendants.
     subtree = [job_id, *snapshot.job_descendants[job_id].descendants]
     cur.caches[EndpointsProjection].remove_by_job_ids(cur, subtree)
 

--- a/lib/iris/src/iris/cluster/controller/projections/endpoints.py
+++ b/lib/iris/src/iris/cluster/controller/projections/endpoints.py
@@ -80,7 +80,7 @@ _INSERT_OR_REPLACE_ENDPOINT = insert(endpoints_table).prefix_with("OR REPLACE")
 
 # Built once so the SELECT cache key is computed at import time; rebuilding it
 # inside ``add()`` paid a ~50µs cache-key tax per call on burst writes.
-_TASK_STATE_FOR_ENDPOINT = select(tasks_table.c.state, tasks_table.c.current_attempt_id).where(
+_TASK_STATE_FOR_ENDPOINT = select(tasks_table.c.state).where(
     tasks_table.c.task_id == bindparam("task_id", type_=tasks_table.c.task_id.type)
 )
 
@@ -94,7 +94,6 @@ class AddEndpointOutcome(StrEnum):
 
     OK = "ok"
     NOT_FOUND = "not_found"
-    STALE_ATTEMPT = "stale_attempt"
     TERMINAL = "terminal"
 
 
@@ -253,18 +252,15 @@ class EndpointsProjection(Projection):
         self,
         cur: db.Tx,
         endpoint: EndpointRow,
-        *,
-        expected_attempt_id: int | None = None,
     ) -> AddEndpointOutcome:
         """Insert ``endpoint`` into the DB and schedule the memory update.
 
-        All task validation runs inside this transaction so the RPC handler
-        does not need a separate read snapshot. Returns:
+        Task validation runs inside this transaction so the RPC handler does
+        not need a separate read snapshot. Returns:
 
         - ``NOT_FOUND`` if the task row does not exist.
-        - ``TERMINAL`` if the task is in a terminal state.
-        - ``STALE_ATTEMPT`` if ``expected_attempt_id`` doesn't match the
-          task's current attempt.
+        - ``TERMINAL`` if the task is in a terminal state; registration is
+          refused so an endpoint isn't served for a task that is already gone.
         - ``OK`` after a successful upsert; the in-memory index is updated
           via a post-commit hook.
         """
@@ -275,8 +271,6 @@ class EndpointsProjection(Projection):
             return AddEndpointOutcome.NOT_FOUND
         if int(task_row.state) in TERMINAL_TASK_STATES:
             return AddEndpointOutcome.TERMINAL
-        if expected_attempt_id is not None and int(task_row.current_attempt_id) != int(expected_attempt_id):
-            return AddEndpointOutcome.STALE_ATTEMPT
 
         cur.execute(
             _INSERT_OR_REPLACE_ENDPOINT,
@@ -386,25 +380,6 @@ class EndpointsProjection(Projection):
 
         cur.register(apply)
         return existing
-
-    def remove_by_task(self, cur: db.Tx, task_id: JobName) -> list[str]:
-        """Remove all endpoints owned by a task. Returns the removed endpoint_ids."""
-        with self._lock:
-            ids = list(self._by_task.get(task_id, ()))
-        # Empty index means no committed rows (the index mirrors committed state
-        # under the write lock), so the DELETE would be a no-op — skip it, as
-        # remove() does.
-        if not ids:
-            return []
-        cur.execute(delete(endpoints_table).where(endpoints_table.c.task_id == task_id))
-
-        def apply() -> None:
-            with self._lock:
-                for eid in ids:
-                    self._unindex(eid)
-
-        cur.register(apply)
-        return ids
 
     def remove_by_job_ids(self, cur: db.Tx, job_ids: Sequence[JobName]) -> list[str]:
         """Remove all endpoints owned by any of ``job_ids``. Returns the removed endpoint_ids."""

--- a/lib/iris/src/iris/cluster/controller/reconcile/commit.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/commit.py
@@ -10,10 +10,9 @@ that drains it into the caller's write transaction. Kept separate from
 ``db``/``schema``/``projections``.
 
 Row deltas flush via bulk ``executemany`` statements (one per entity group);
-endpoint deletions write within the Tx; audit log lines are deferred to ``cur``'s
-post-commit hooks so a rolled-back transaction leaves no observable trace. Health
-is owned by the controller and folded through a single ``apply`` site, so this
-sink never touches it.
+audit log lines are deferred to ``cur``'s post-commit hooks so a rolled-back
+transaction leaves no observable trace. Health is owned by the controller and
+folded through a single ``apply`` site, so this sink never touches it.
 """
 
 from sqlalchemy import bindparam, func
@@ -22,7 +21,6 @@ from sqlalchemy import update as sa_update
 from iris.cluster.controller.audit_logging import log_event
 from iris.cluster.controller.db import Tx
 from iris.cluster.controller.projections.attempt_counts import AttemptCountsProjection
-from iris.cluster.controller.projections.endpoints import EndpointsProjection
 from iris.cluster.controller.reconcile.effects import (
     AttemptRowDelta,
     ControllerEffects,
@@ -224,15 +222,11 @@ def commit_effects(
     events) through the single ``WorkerHealthTracker.apply`` site.
 
     Attempt writes invalidate the derived-count cache through the cursor
-    (``cur.caches[AttemptCountsProjection]``); endpoint deletions reach the
-    projection the same way — no cache reference is threaded here.
+    (``cur.caches[AttemptCountsProjection]``) — no cache reference is threaded here.
     """
     _flush_tasks(cur, list(effects.tasks.values()))
     _flush_attempts(cur, list(effects.attempts.values()))
     _flush_jobs(cur, list(effects.jobs.values()))
-
-    for d in effects.endpoint_deletions:
-        cur.caches[EndpointsProjection].remove_by_task(cur, d.task_id)
 
     log_events = effects.log_events
     if log_events:

--- a/lib/iris/src/iris/cluster/controller/reconcile/effects.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/effects.py
@@ -81,11 +81,6 @@ class JobRowDelta:
 # ---------------------------------------------------------------------------
 
 
-@dataclass(frozen=True, slots=True)
-class EndpointDeletion:
-    task_id: JobName
-
-
 @dataclass(slots=True)
 class WorkerHealthEffect:
     """Kernel-derived health signal surfaced to the controller (not applied here).
@@ -127,7 +122,6 @@ class ControllerEffects:
     attempts: dict[tuple[JobName, int], AttemptRowDelta] = field(default_factory=dict)
     jobs: dict[JobName, JobRowDelta] = field(default_factory=dict)
 
-    endpoint_deletions: list[EndpointDeletion] = field(default_factory=list)
     health: WorkerHealthEffect = field(default_factory=WorkerHealthEffect)
     log_events: list[LogEvent] = field(default_factory=list)
 
@@ -138,4 +132,4 @@ class ControllerEffects:
         ``health.build_failed`` is excluded: it is folded into the liveness
         tracker by the backend, never persisted by ``commit_effects``.
         """
-        return not (self.tasks or self.attempts or self.jobs or self.endpoint_deletions or self.log_events)
+        return not (self.tasks or self.attempts or self.jobs or self.log_events)

--- a/lib/iris/src/iris/cluster/controller/reconcile/overlay.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/overlay.py
@@ -14,7 +14,6 @@ from rigging.timing import Timestamp
 from iris.cluster.controller.reconcile.effects import (
     AttemptRowDelta,
     ControllerEffects,
-    EndpointDeletion,
     JobRowDelta,
     LogEvent,
     TaskRowDelta,
@@ -58,9 +57,9 @@ class Overlay:
       the per-field rules (see each method). Reads (:meth:`task_state`,
       :meth:`job_basis`, ...) consult the accumulator, so prospective state and
       the persisted SQL cannot drift.
-    * ``emit_*`` appends a cross-aggregate effect category (endpoint deletions,
-      worker health, structured audit log events). These fire after commit and
-      so are not row deltas.
+    * ``emit_*`` appends a cross-aggregate effect category (worker health,
+      structured audit log events). These fire after commit and so are not row
+      deltas.
     """
 
     def __init__(self, snapshot: TransitionSnapshot) -> None:
@@ -338,9 +337,6 @@ class Overlay:
     # Cross-aggregate effect emitters. NOT row deltas — these are
     # post-commit categories, kept separate from the row-delta setters.
     # ------------------------------------------------------------------
-
-    def emit_endpoint_deletion(self, task_id: JobName) -> None:
-        self._effects.endpoint_deletions.append(EndpointDeletion(task_id=task_id))
 
     def emit_log_event(self, event: LogEvent) -> None:
         self._effects.log_events.append(event)

--- a/lib/iris/src/iris/cluster/controller/reconcile/task.py
+++ b/lib/iris/src/iris/cluster/controller/reconcile/task.py
@@ -147,7 +147,7 @@ def merge_task_termination(
     stamp_attempt_finished: bool,
     attempt_state: int | None = None,
 ) -> None:
-    """Move a task to ``task_state`` and record its attempt + endpoint deletion.
+    """Move a task to ``task_state`` and record its attempt.
 
     ``stamp_attempt_finished`` controls whether the attempt's ``finished_at_ms``
     is stamped: finalizing callers stamp it (the attempt is truly done);
@@ -190,7 +190,6 @@ def merge_task_termination(
             finished_at=task_finished_at,
         )
     )
-    state.emit_endpoint_deletion(task_name)
 
 
 # ─── Per-task decision helpers ───
@@ -505,9 +504,6 @@ def apply_one_transition(
             container_id=update.container_id,
         )
     )
-
-    if update.new_state in TERMINAL_TASK_STATES:
-        state.emit_endpoint_deletion(update.task_id)
 
     jc = state.job_config(task.job_id)
     has_cosched = bool(jc is not None and jc.has_coscheduling and update.new_state in PEER_CASCADE_TRIGGER_STATES)

--- a/lib/iris/tests/cluster/controller/test_endpoints_projection.py
+++ b/lib/iris/tests/cluster/controller/test_endpoints_projection.py
@@ -106,22 +106,6 @@ def test_remove_drops_endpoint_by_id(state):
     assert {r.endpoint_id for r in state._endpoints.query()} == {"e2"}
 
 
-def test_remove_by_task_drops_all_task_endpoints(state):
-    tasks = submit_job(state, "j", make_job_request("j", replicas=2))
-    t1, t2 = tasks[0].task_id, tasks[1].task_id
-
-    with state._db.transaction() as cur:
-        state._endpoints.add(cur, _make_row("e1", "alpha", t1))
-        state._endpoints.add(cur, _make_row("e2", "beta", t1))
-        state._endpoints.add(cur, _make_row("e3", "gamma", t2))
-
-    with state._db.transaction() as cur:
-        removed = state._endpoints.remove_by_task(cur, t1)
-
-    assert set(removed) == {"e1", "e2"}
-    assert {r.endpoint_id for r in state._endpoints.query()} == {"e3"}
-
-
 def test_remove_by_job_ids_drops_subtree(state):
     tasks_a = submit_job(state, "a", make_job_request("a"))
     tasks_b = submit_job(state, "b", make_job_request("b"))

--- a/lib/iris/tests/cluster/controller/test_transitions.py
+++ b/lib/iris/tests/cluster/controller/test_transitions.py
@@ -18,7 +18,7 @@ from iris.cluster.constraints import DeviceType, WellKnownAttribute
 from iris.cluster.controller import ops, reads, writes
 from iris.cluster.controller.codec import constraints_from_json, device_counts_from_json, device_variant_from_json
 from iris.cluster.controller.ops.task import Assignment, finalize
-from iris.cluster.controller.projections.endpoints import EndpointQuery, EndpointRow
+from iris.cluster.controller.projections.endpoints import AddEndpointOutcome, EndpointQuery, EndpointRow
 from iris.cluster.controller.projections.run_templates import RunTemplatesProjection
 from iris.cluster.controller.pruner import PruneResult, prune_old_data
 from iris.cluster.controller.reads import WorkerResourceUsage
@@ -996,8 +996,13 @@ def test_timeout_charges_cumulative_failure_budget(state):
 # =============================================================================
 
 
-def test_terminal_states_clean_up_endpoints(state):
-    """E2E: Task reaching terminal state removes associated endpoints."""
+def test_endpoint_survives_terminal_and_clears_on_prune(state):
+    """A terminal task keeps its endpoints; a job prune clears them.
+
+    Endpoint liveness is the lease: a task reaching a terminal state leaves its
+    endpoints in place until the lease lapses or the owning job is pruned or
+    cancelled through the FK CASCADE backstop.
+    """
 
     worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())
 
@@ -1021,15 +1026,30 @@ def test_terminal_states_clean_up_endpoints(state):
     # Verify endpoint visible while running
     assert len(_endpoints(state, EndpointQuery(exact_name="j1/actor"))) == 1
 
-    # Task succeeds
+    # Task succeeds; the endpoint stays served.
     transition_task(state, task.task_id, job_pb2.TASK_STATE_SUCCEEDED)
+    assert len(_endpoints(state, EndpointQuery(exact_name="j1/actor"))) == 1
 
-    # Endpoint removed
+    # Pruning the terminal job clears the endpoint via the FK CASCADE backstop.
+    job_id = JobName.root("test-user", "j1")
+    with state._db.transaction() as _tx:
+        _tx.execute(sa_update(jobs_table).where(jobs_table.c.job_id == job_id).values(finished_at_ms=1000))
+    prune_old_data(
+        state._db,
+        worker_daemon_backends_for_prune(state),
+        job_retention=Duration.from_seconds(86400),
+        worker_retention=Duration.from_seconds(86400),
+        slice_retention=Duration.from_seconds(86400),
+    )
     assert _endpoints(state, EndpointQuery(exact_name="j1/actor")) == []
 
 
-def test_endpoint_visibility_by_job_state(state):
-    """Endpoints associated with a task are deleted when the task reaches a terminal state."""
+def test_endpoint_visible_regardless_of_task_state(state):
+    """An endpoint stays visible while its lease is live, independent of task state.
+
+    Liveness is the lease alone, so pending, running, and terminal tasks all keep
+    their endpoints served until the lease lapses.
+    """
 
     worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())
 
@@ -1057,14 +1077,19 @@ def test_endpoint_visibility_by_job_state(state):
     assert _query_job(state, job.job_id).state == job_pb2.JOB_STATE_RUNNING
     assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 1
 
-    # Deleted when task reaches terminal state
+    # Still visible after the task reaches a terminal state; the lease governs
+    # visibility.
     transition_task(state, task.task_id, job_pb2.TASK_STATE_SUCCEEDED)
     assert _query_job(state, job.job_id).state == job_pb2.JOB_STATE_SUCCEEDED
-    assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 0
+    assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 1
 
 
-def test_endpoint_deleted_on_task_failure_with_retry(state):
-    """Endpoints are cleaned up when a task fails even if it retries back to PENDING."""
+def test_endpoint_survives_task_failure_retry(state):
+    """A prior attempt's endpoint survives a task failure and retry.
+
+    The endpoint lingers until its lease lapses; in production the crashed attempt
+    stops renewing, so its lease expires within ~10m.
+    """
 
     worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())
 
@@ -1092,12 +1117,16 @@ def test_endpoint_deleted_on_task_failure_with_retry(state):
     transition_task(state, task.task_id, job_pb2.TASK_STATE_FAILED, error="crash")
     assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_PENDING
 
-    # Stale endpoints should be deleted even though the task retried
-    assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 0
+    # The endpoint persists across the retry until its lease lapses.
+    assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 1
 
 
-def test_endpoint_deleted_on_worker_failure(state):
-    """Endpoints are cleaned up when the worker dies, even if the task retries."""
+def test_endpoint_survives_worker_failure_retry(state):
+    """An endpoint survives a worker death and task retry.
+
+    Liveness is the lease: the endpoint from the dead worker's attempt lingers
+    until its lease lapses.
+    """
 
     worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())
 
@@ -1124,8 +1153,8 @@ def test_endpoint_deleted_on_worker_failure(state):
     fail_worker(state, worker_id, "Connection lost")
     assert _query_task(state, task.task_id).state == job_pb2.TASK_STATE_PENDING
 
-    # Endpoints should be cleaned up because the worker is dead
-    assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 0
+    # The endpoint persists across the retry until its lease lapses.
+    assert len(_endpoints(state, EndpointQuery(exact_name="ns-1/actor"))) == 1
 
 
 def test_endpoint_survives_building_state(state):
@@ -3554,13 +3583,12 @@ def test_reconcile_worker_failed_pending_rollback_cascades_children(state):
     assert child_job.state == job_pb2.JOB_STATE_KILLED
 
 
-def test_endpoint_registered_after_task_terminal_is_orphaned(state):
-    """Reproduce endpoint leak: register_endpoint succeeds for already-terminal tasks.
+def test_endpoint_registered_after_task_terminal_is_rejected(state):
+    """``add`` refuses to insert an endpoint for an already-terminal task.
 
-    When a task completes, apply_task_observations deletes its endpoints. But
-    register_endpoint doesn't check task state — only attempt_id. So a slow
-    register_endpoint call arriving after the task is terminal inserts an
-    orphaned endpoint that is never cleaned up.
+    A terminal task never renews, so its endpoint would be served for its full
+    lease even though the task is already gone. ``EndpointsProjection.add``
+    rejects the insert instead.
     """
     worker_id = register_worker(state, "w1", "host:8080", make_worker_metadata())
 
@@ -3570,14 +3598,12 @@ def test_endpoint_registered_after_task_terminal_is_orphaned(state):
 
     dispatch_task(state, task, worker_id)
 
-    # Task succeeds — any existing endpoints would be cleaned up here.
     transition_task(state, task.task_id, job_pb2.TASK_STATE_SUCCEEDED)
     task_after = _query_task(state, task.task_id)
     assert task_after.state == job_pb2.TASK_STATE_SUCCEEDED
 
-    # Now a slow register_endpoint arrives AFTER the task is terminal.
-    # This simulates the task process still alive briefly after the
-    # controller processed the terminal heartbeat.
+    # A slow register_endpoint arrives AFTER the task is terminal (the task
+    # process was still briefly alive after the terminal heartbeat).
     ep = EndpointRow(
         endpoint_id="orphan-ep",
         name="leak/actor",
@@ -3587,15 +3613,11 @@ def test_endpoint_registered_after_task_terminal_is_orphaned(state):
         registered_at=Timestamp.now(),
     )
     with state._db.transaction() as cur:
-        state._endpoints.add(cur, ep)
+        outcome = state._endpoints.add(cur, ep)
+    assert outcome is AddEndpointOutcome.TERMINAL
 
-    # BUG: The endpoint is now orphaned — the task is terminal so no
-    # future transition will clean it up.
-    leaked = _endpoints(state, EndpointQuery(exact_name="leak/actor"))
-    assert leaked == [], (
-        f"Expected no endpoints for terminal task, but found {len(leaked)}. "
-        "register_endpoint/add_endpoint must reject inserts for terminal tasks."
-    )
+    # The terminal guard rejected the insert, so no endpoint leaks.
+    assert _endpoints(state, EndpointQuery(exact_name="leak/actor")) == []
 
 
 # =============================================================================


### PR DESCRIPTION
Endpoints are leased and every endpoint-registering client now renews on a cadence, so the lease — not the task row — governs endpoint liveness. This drops the deliberately conservative configuration PR #6728 shipped to stay backward-compatible while clients picked up the renewer.

- `ENDPOINT_LEASE` 120h → 10m, so a crashed or unrenewed endpoint expires within ~10m instead of days. The 3m floor (`MIN_ENDPOINT_LEASE`) is unchanged, so a granted lease is clamped to `[3m, 10m]`.
- The `attempt_id` stale-attempt rejection on register is removed: `EndpointsProjection.add` no longer takes `expected_attempt_id` and `AddEndpointOutcome.STALE_ATTEMPT` is gone. A superseded attempt's endpoint now lingers until its lease lapses rather than being rejected on renewal.
- Terminal-task endpoint pruning is removed: the `EndpointDeletion` effect, `Overlay.emit_endpoint_deletion`, the commit-time `remove_by_task` path, and the now-dead `EndpointsProjection.remove_by_task`. A terminal task no longer culls its endpoints; the lease reclaims them.

The FK `CASCADE` stays as the fast-path backstop: pruning a terminal job and cancelling a job subtree still clear endpoints immediately (`remove_by_job_ids`), and registration for an already-terminal task is still refused (`AddEndpointOutcome.TERMINAL`) so a late register cannot leak a row that no task transition would reclaim.

One deliberate scoping note: the `RegisterEndpointRequest.attempt_id` wire field is retained but no longer read server-side. Removing it cleanly requires regenerating the protobuf stubs, and the buf codegen plugins (`buf.build/...`) are unreachable from the environment this change was prepared in, so dropping the field is left as a safe follow-up once a proto regen can run.

Rollout precondition: this is only safe once controllers and all endpoint-registering clients (workers, actors, `jax_init` coordinators) are renewing on a cadence rather than registering once. Opening as a draft for human review to confirm that before merge.

Fixes #6729.
Follow-up to #6728; part of #6722.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UTkgUs1wxa47QM2wwkaxsH)_