### PR TITLE
[levanter] Make fsspec hub downloads atomic

### DIFF
--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -13,6 +13,7 @@ import shutil
 import tempfile
 import time
 import urllib.parse
+import uuid
 import warnings
 from dataclasses import dataclass
 from functools import cached_property
@@ -1571,6 +1572,25 @@ def _shard_best_effort(array_or_slice, dtype) -> jax.Array:
     return jax.make_array_from_callback(tuple(shape), sharding, get_slice)
 
 
+def _download_atomic(remote_path: StoragePath, local_path: str) -> None:
+    """Download to a unique temp file, then atomically move into place.
+
+    ``local_path`` never holds a partial file: readers see the previous
+    complete file or the new one, and a download killed midway leaves only an
+    orphaned temp file instead of poisoning a shared cache.
+    """
+    parent = os.path.dirname(local_path)
+    if parent:
+        os.makedirs(parent, exist_ok=True)
+    tmp_path = f"{local_path}.{uuid.uuid4().hex}.tmp"
+    try:
+        remote_path.download_to(tmp_path)
+        os.replace(tmp_path, local_path)
+    finally:
+        if os.path.exists(tmp_path):
+            os.remove(tmp_path)
+
+
 @contextlib.contextmanager
 def _patch_hf_hub_download():
     """
@@ -1607,7 +1627,7 @@ def _patch_hf_hub_download():
                 if not remote_path.exists():
                     raise EntryNotFoundError(f"File {remote_path} not found")
 
-                remote_path.download_to(local_path)
+                _download_atomic(remote_path, local_path)
                 return local_path
 
             # Fallback to the original implementation

--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -46,14 +46,14 @@ from jax._src.mesh import get_concrete_mesh
 from jax._src.partition_spec import PartitionSpec
 from jax.random import PRNGKey
 from jaxtyping import Array, PRNGKeyArray
-from rigging.filesystem import StoragePath, url_to_fs
+from rigging.filesystem import StoragePath, fetch_file_atomic, url_to_fs
 from tqdm_loggable.auto import tqdm
 
 from levanter.callbacks import StepInfo
 from levanter.compat.fsspec_safetensor import read_safetensors_fsspec
 from levanter.models.asr_model import ASRMixin
 from levanter.models.lm_model import LmConfig, LmHeadModel
-from levanter.tokenizers import MarinTokenizer, _fetch_file_atomic
+from levanter.tokenizers import MarinTokenizer
 from levanter.utils.cloud_utils import temp_dir_before_upload
 from levanter.utils.hf_utils import HfTokenizer
 from levanter.utils.jax_utils import best_effort_sharding, use_cpu_device
@@ -1604,7 +1604,7 @@ def _patch_hf_hub_download():
                 )
                 os.makedirs(os.path.dirname(local_path), exist_ok=True)
 
-                if not _fetch_file_atomic(str(remote_path), local_path):
+                if not fetch_file_atomic(str(remote_path), local_path):
                     raise EntryNotFoundError(f"File {remote_path} not found")
                 return local_path
 

--- a/lib/levanter/src/levanter/compat/hf_checkpoints.py
+++ b/lib/levanter/src/levanter/compat/hf_checkpoints.py
@@ -13,7 +13,6 @@ import shutil
 import tempfile
 import time
 import urllib.parse
-import uuid
 import warnings
 from dataclasses import dataclass
 from functools import cached_property
@@ -54,7 +53,7 @@ from levanter.callbacks import StepInfo
 from levanter.compat.fsspec_safetensor import read_safetensors_fsspec
 from levanter.models.asr_model import ASRMixin
 from levanter.models.lm_model import LmConfig, LmHeadModel
-from levanter.tokenizers import MarinTokenizer
+from levanter.tokenizers import MarinTokenizer, _fetch_file_atomic
 from levanter.utils.cloud_utils import temp_dir_before_upload
 from levanter.utils.hf_utils import HfTokenizer
 from levanter.utils.jax_utils import best_effort_sharding, use_cpu_device
@@ -1572,25 +1571,6 @@ def _shard_best_effort(array_or_slice, dtype) -> jax.Array:
     return jax.make_array_from_callback(tuple(shape), sharding, get_slice)
 
 
-def _download_atomic(remote_path: StoragePath, local_path: str) -> None:
-    """Download to a unique temp file, then atomically move into place.
-
-    ``local_path`` never holds a partial file: readers see the previous
-    complete file or the new one, and a download killed midway leaves only an
-    orphaned temp file instead of poisoning a shared cache.
-    """
-    parent = os.path.dirname(local_path)
-    if parent:
-        os.makedirs(parent, exist_ok=True)
-    tmp_path = f"{local_path}.{uuid.uuid4().hex}.tmp"
-    try:
-        remote_path.download_to(tmp_path)
-        os.replace(tmp_path, local_path)
-    finally:
-        if os.path.exists(tmp_path):
-            os.remove(tmp_path)
-
-
 @contextlib.contextmanager
 def _patch_hf_hub_download():
     """
@@ -1619,15 +1599,13 @@ def _patch_hf_hub_download():
 
             if repo_id and filename and _is_url_like(repo_id):
                 remote_path = StoragePath(repo_id) / filename
-                # local_path = os.path.join(tmpdir, filename)
                 local_path = os.path.join(
                     cache_dir, repo_folder_name(repo_id=repo_id, repo_type=repo_type), "snapshots", revision, filename
                 )
+                os.makedirs(os.path.dirname(local_path), exist_ok=True)
 
-                if not remote_path.exists():
+                if not _fetch_file_atomic(str(remote_path), local_path):
                     raise EntryNotFoundError(f"File {remote_path} not found")
-
-                _download_atomic(remote_path, local_path)
                 return local_path
 
             # Fallback to the original implementation

--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -25,6 +25,7 @@ import shutil
 import tempfile
 import threading
 import time
+import uuid
 from enum import StrEnum
 from typing import Any, Protocol, runtime_checkable
 
@@ -676,12 +677,14 @@ _TOKENIZER_ALLOW_PATTERNS = [
 
 
 def _fetch_file_atomic(src_url: str, dest_path: str) -> bool:
-    """Atomically fetch src_url to dest_path via a .tmp sibling.
+    """Atomically fetch src_url to dest_path via a unique temp sibling.
 
     Returns False if the source does not exist; re-raises all other errors.
-    Prevents partial writes from poisoning the local cache on any failure.
+    A partial file is never observable at dest_path, and the unique temp name
+    keeps concurrent fetches of the same dest from clobbering each other's
+    in-flight files.
     """
-    tmp = dest_path + ".tmp"
+    tmp = f"{dest_path}.{uuid.uuid4().hex}.tmp"
     try:
         data = StoragePath(src_url).read_bytes()
         with open(tmp, "wb") as dst:

--- a/lib/levanter/src/levanter/tokenizers.py
+++ b/lib/levanter/src/levanter/tokenizers.py
@@ -25,7 +25,6 @@ import shutil
 import tempfile
 import threading
 import time
-import uuid
 from enum import StrEnum
 from typing import Any, Protocol, runtime_checkable
 
@@ -35,7 +34,7 @@ import jinja2.sandbox
 from huggingface_hub import __version__ as _hf_hub_version
 from huggingface_hub import hf_hub_download, snapshot_download
 from huggingface_hub.utils import EntryNotFoundError, RepositoryNotFoundError
-from rigging.filesystem import StoragePath, filesystem, open_url
+from rigging.filesystem import fetch_file_atomic, filesystem, open_url
 from tokenizers import Tokenizer as HfBaseTokenizer
 
 logger = logging.getLogger(__name__)
@@ -676,29 +675,6 @@ _TOKENIZER_ALLOW_PATTERNS = [
 ]
 
 
-def _fetch_file_atomic(src_url: str, dest_path: str) -> bool:
-    """Atomically fetch src_url to dest_path via a unique temp sibling.
-
-    Returns False if the source does not exist; re-raises all other errors.
-    A partial file is never observable at dest_path, and the unique temp name
-    keeps concurrent fetches of the same dest from clobbering each other's
-    in-flight files.
-    """
-    tmp = f"{dest_path}.{uuid.uuid4().hex}.tmp"
-    try:
-        data = StoragePath(src_url).read_bytes()
-        with open(tmp, "wb") as dst:
-            dst.write(data)
-        os.replace(tmp, dest_path)
-        return True
-    except FileNotFoundError:
-        return False
-    except Exception:
-        with contextlib.suppress(FileNotFoundError):
-            os.unlink(tmp)
-        raise
-
-
 def _copy_file_atomic(src_path: str, dest_path: str) -> None:
     """Atomically copy a local file via a .tmp sibling."""
     tmp = dest_path + ".tmp"
@@ -755,7 +731,7 @@ def _stage_from_mirror(name_or_path: str, local_dir: str) -> bool:
                 filename = os.path.basename(entry.rstrip("/"))
                 if not filename:
                     continue
-                if _fetch_file_atomic(f"{mirror_base}/{filename}", os.path.join(local_dir, filename)):
+                if fetch_file_atomic(f"{mirror_base}/{filename}", os.path.join(local_dir, filename)):
                     copied = True
             if copied:
                 logger.info(

--- a/lib/levanter/tests/test_hf_checkpoints.py
+++ b/lib/levanter/tests/test_hf_checkpoints.py
@@ -21,12 +21,15 @@ from jax.random import PRNGKey
 from test_utils import skip_if_no_torch
 from transformers import GPT2Config as HfGpt2Config
 
+from rigging.filesystem import StoragePath
+
 from levanter.compat.hf_checkpoints import (
     SAFE_TENSORS_INDEX_NAME,
     SAFE_TENSORS_MODEL,
     ModelWithHfSerializationMixin,
     _causal_lm_architecture_name,
     _convert_to_jnp,
+    _download_atomic,
 )
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
 from test_utils import use_test_mesh
@@ -312,3 +315,41 @@ def test_build_hf_config_dict_degrades_when_reference_unreachable(local_gpt2_tok
 
     assert dict_config["model_type"] == "gpt2"
     assert dict_config["architectures"] == ["GPT2LMHeadModel"]
+
+
+class _InterruptedDownloadPath(StoragePath):
+    """Fake remote whose transfer writes partial bytes and then dies."""
+
+    def download_to(self, local_path: str, *, recursive: bool = False) -> None:
+        with open(local_path, "wb") as f:
+            f.write(b'{"trunc')
+        raise ConnectionError("simulated mid-download failure")
+
+
+def test_interrupted_download_leaves_no_partial_file(tmp_path):
+    # Regression for marin#7167: a download killed midway must not leave a
+    # truncated file at the final path, where it poisons the HF cache.
+    dest = tmp_path / "cache" / "tokenizer.json"
+    with pytest.raises(ConnectionError):
+        _download_atomic(_InterruptedDownloadPath("interrupted://remote/tokenizer.json"), str(dest))
+    assert not dest.exists()
+
+
+def test_failed_redownload_keeps_previous_complete_file(tmp_path):
+    dest = tmp_path / "cache" / "tokenizer.json"
+    dest.parent.mkdir(parents=True)
+    dest.write_bytes(b'{"ok": true}')
+    with pytest.raises(ConnectionError):
+        _download_atomic(_InterruptedDownloadPath("interrupted://remote/tokenizer.json"), str(dest))
+    assert dest.read_bytes() == b'{"ok": true}'
+
+
+def test_download_atomic_fetches_file(tmp_path):
+    # Happy path: without this, the failure tests above could pass with a
+    # helper that never writes anything.
+    src = tmp_path / "remote" / "tokenizer.json"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b'{"version": 1}')
+    dest = tmp_path / "cache" / "tokenizer.json"
+    _download_atomic(StoragePath(str(src)), str(dest))
+    assert dest.read_bytes() == b'{"version": 1}'

--- a/lib/levanter/tests/test_hf_checkpoints.py
+++ b/lib/levanter/tests/test_hf_checkpoints.py
@@ -21,15 +21,12 @@ from jax.random import PRNGKey
 from test_utils import skip_if_no_torch
 from transformers import GPT2Config as HfGpt2Config
 
-from rigging.filesystem import StoragePath
-
 from levanter.compat.hf_checkpoints import (
     SAFE_TENSORS_INDEX_NAME,
     SAFE_TENSORS_MODEL,
     ModelWithHfSerializationMixin,
     _causal_lm_architecture_name,
     _convert_to_jnp,
-    _download_atomic,
 )
 from levanter.models.gpt2 import Gpt2Config, Gpt2LMHeadModel
 from test_utils import use_test_mesh
@@ -315,41 +312,3 @@ def test_build_hf_config_dict_degrades_when_reference_unreachable(local_gpt2_tok
 
     assert dict_config["model_type"] == "gpt2"
     assert dict_config["architectures"] == ["GPT2LMHeadModel"]
-
-
-class _InterruptedDownloadPath(StoragePath):
-    """Fake remote whose transfer writes partial bytes and then dies."""
-
-    def download_to(self, local_path: str, *, recursive: bool = False) -> None:
-        with open(local_path, "wb") as f:
-            f.write(b'{"trunc')
-        raise ConnectionError("simulated mid-download failure")
-
-
-def test_interrupted_download_leaves_no_partial_file(tmp_path):
-    # Regression for marin#7167: a download killed midway must not leave a
-    # truncated file at the final path, where it poisons the HF cache.
-    dest = tmp_path / "cache" / "tokenizer.json"
-    with pytest.raises(ConnectionError):
-        _download_atomic(_InterruptedDownloadPath("interrupted://remote/tokenizer.json"), str(dest))
-    assert not dest.exists()
-
-
-def test_failed_redownload_keeps_previous_complete_file(tmp_path):
-    dest = tmp_path / "cache" / "tokenizer.json"
-    dest.parent.mkdir(parents=True)
-    dest.write_bytes(b'{"ok": true}')
-    with pytest.raises(ConnectionError):
-        _download_atomic(_InterruptedDownloadPath("interrupted://remote/tokenizer.json"), str(dest))
-    assert dest.read_bytes() == b'{"ok": true}'
-
-
-def test_download_atomic_fetches_file(tmp_path):
-    # Happy path: without this, the failure tests above could pass with a
-    # helper that never writes anything.
-    src = tmp_path / "remote" / "tokenizer.json"
-    src.parent.mkdir(parents=True)
-    src.write_bytes(b'{"version": 1}')
-    dest = tmp_path / "cache" / "tokenizer.json"
-    _download_atomic(StoragePath(str(src)), str(dest))
-    assert dest.read_bytes() == b'{"version": 1}'

--- a/lib/levanter/tests/test_tokenizers.py
+++ b/lib/levanter/tests/test_tokenizers.py
@@ -28,6 +28,7 @@ from levanter.tokenizers import (
     HfMarinTokenizer,
     MarinTokenizer,
     TokenizerBackend,
+    _fetch_file_atomic,
     _load_tokenizer_config,
     _stage_from_hf,
     _stage_from_mirror,
@@ -1470,6 +1471,42 @@ def test_stage_from_mirror_absent(tmp_path):
 
     assert result is False
     assert not list(local_dir.iterdir())
+
+
+def test_fetch_file_atomic_fetches_file(tmp_path):
+    src = tmp_path / "remote" / "tokenizer.json"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b'{"version": 1}')
+    dest = tmp_path / "cache" / "tokenizer.json"
+    dest.parent.mkdir(parents=True)
+
+    assert _fetch_file_atomic(str(src), str(dest)) is True
+    assert dest.read_bytes() == b'{"version": 1}'
+
+
+def test_fetch_file_atomic_missing_source_returns_false(tmp_path):
+    dest = tmp_path / "cache" / "tokenizer.json"
+    dest.parent.mkdir(parents=True)
+
+    assert _fetch_file_atomic(str(tmp_path / "remote" / "absent.json"), str(dest)) is False
+    assert not dest.exists()
+
+
+def test_fetch_file_atomic_ignores_other_fetchers_temp_file(tmp_path):
+    # Concurrency contract: another fetcher's in-flight temp file (here: a
+    # stale leftover at the old fixed-suffix name) is never consumed,
+    # clobbered, or promoted to dest.
+    src = tmp_path / "remote" / "tokenizer.json"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b'{"version": 1}')
+    dest = tmp_path / "cache" / "tokenizer.json"
+    dest.parent.mkdir(parents=True)
+    stale_tmp = dest.parent / "tokenizer.json.tmp"
+    stale_tmp.write_bytes(b'{"trunc')
+
+    assert _fetch_file_atomic(str(src), str(dest)) is True
+    assert dest.read_bytes() == b'{"version": 1}'
+    assert stale_tmp.read_bytes() == b'{"trunc'
 
 
 def test_stage_tokenizer_local_cache_hit(tmp_path, fake_tokenizer_dir, clear_stage_cache):

--- a/lib/levanter/tests/test_tokenizers.py
+++ b/lib/levanter/tests/test_tokenizers.py
@@ -28,7 +28,6 @@ from levanter.tokenizers import (
     HfMarinTokenizer,
     MarinTokenizer,
     TokenizerBackend,
-    _fetch_file_atomic,
     _load_tokenizer_config,
     _stage_from_hf,
     _stage_from_mirror,
@@ -1446,7 +1445,7 @@ def test_stage_from_mirror_copies_files(tmp_path, fake_tokenizer_dir):
 
     with (
         patch("levanter.tokenizers.filesystem", return_value=FakeMirrorFS()),
-        patch("levanter.tokenizers._fetch_file_atomic", side_effect=fake_fetch),
+        patch("levanter.tokenizers.fetch_file_atomic", side_effect=fake_fetch),
     ):
         result = _stage_from_mirror("org/model", str(local_dir))
 
@@ -1471,42 +1470,6 @@ def test_stage_from_mirror_absent(tmp_path):
 
     assert result is False
     assert not list(local_dir.iterdir())
-
-
-def test_fetch_file_atomic_fetches_file(tmp_path):
-    src = tmp_path / "remote" / "tokenizer.json"
-    src.parent.mkdir(parents=True)
-    src.write_bytes(b'{"version": 1}')
-    dest = tmp_path / "cache" / "tokenizer.json"
-    dest.parent.mkdir(parents=True)
-
-    assert _fetch_file_atomic(str(src), str(dest)) is True
-    assert dest.read_bytes() == b'{"version": 1}'
-
-
-def test_fetch_file_atomic_missing_source_returns_false(tmp_path):
-    dest = tmp_path / "cache" / "tokenizer.json"
-    dest.parent.mkdir(parents=True)
-
-    assert _fetch_file_atomic(str(tmp_path / "remote" / "absent.json"), str(dest)) is False
-    assert not dest.exists()
-
-
-def test_fetch_file_atomic_ignores_other_fetchers_temp_file(tmp_path):
-    # Concurrency contract: another fetcher's in-flight temp file (here: a
-    # stale leftover at the old fixed-suffix name) is never consumed,
-    # clobbered, or promoted to dest.
-    src = tmp_path / "remote" / "tokenizer.json"
-    src.parent.mkdir(parents=True)
-    src.write_bytes(b'{"version": 1}')
-    dest = tmp_path / "cache" / "tokenizer.json"
-    dest.parent.mkdir(parents=True)
-    stale_tmp = dest.parent / "tokenizer.json.tmp"
-    stale_tmp.write_bytes(b'{"trunc')
-
-    assert _fetch_file_atomic(str(src), str(dest)) is True
-    assert dest.read_bytes() == b'{"version": 1}'
-    assert stale_tmp.read_bytes() == b'{"trunc'
 
 
 def test_stage_tokenizer_local_cache_hit(tmp_path, fake_tokenizer_dir, clear_stage_cache):

--- a/lib/rigging/src/rigging/filesystem/__init__.py
+++ b/lib/rigging/src/rigging/filesystem/__init__.py
@@ -11,7 +11,7 @@ Focused submodules with one-directional imports:
   region-local temp storage, and GCS-location utils.
 - ``cross_region`` — the :class:`TransferBudget` and :class:`CrossRegionGuardedFS`.
 - ``factory`` — the guarded ``url_to_fs`` / ``open_url`` / ``filesystem`` entry
-  points and ``atomic_rename``.
+  points, ``atomic_rename``, and ``fetch_file_atomic``.
 - ``mirror`` — the ``mirror://`` :class:`MirrorFileSystem`.
 - ``distributed_lock`` — lease-based distributed locks (used by ``mirror``).
 
@@ -61,6 +61,7 @@ from rigging.filesystem.cross_region import (
 )
 from rigging.filesystem.factory import (
     atomic_rename,
+    fetch_file_atomic,
     filesystem,
     is_remote_path,
     open_url,

--- a/lib/rigging/src/rigging/filesystem/factory.py
+++ b/lib/rigging/src/rigging/filesystem/factory.py
@@ -7,11 +7,13 @@
 ``fsspec.core.url_to_fs``, ``fsspec.open``, and ``fsspec.filesystem`` that
 automatically wrap GCS filesystems in a :class:`CrossRegionGuardedFS` and inject
 finite botocore timeouts into S3/R2 filesystems (#6487). ``atomic_rename``
-provides write-and-rename semantics via a sibling temp key.
+provides write-and-rename semantics via a sibling temp key, and
+``fetch_file_atomic`` downloads a remote file to a local path the same way.
 """
 
 import contextlib
 import logging
+import os
 import uuid
 from collections.abc import Generator
 from typing import Any, cast
@@ -199,4 +201,32 @@ def atomic_rename(output_path: str, fs: Any = None) -> Generator[str, None, None
         # creating it) so we tolerate any rm error and re-raise the original.
         with contextlib.suppress(Exception):
             fs.rm(temp_path)
+        raise
+
+
+def fetch_file_atomic(src_url: str, dest_path: str) -> bool:
+    """Fetch ``src_url`` down to local ``dest_path`` atomically via a unique temp sibling.
+
+    Reads the source and writes it to a unique ``dest_path`` sibling temp file, then
+    ``os.replace``s it into place. ``dest_path`` therefore never holds a partial file —
+    a concurrent reader sees the previous complete file or the new one — and a fetch
+    killed midway leaves only an orphaned temp file instead of poisoning the destination
+    (e.g. a shared cache). The unique temp name keeps concurrent fetches of the same
+    destination from clobbering each other's in-flight files.
+
+    Returns ``False`` if the source does not exist; re-raises all other errors.
+    """
+    tmp = unique_temp_path(dest_path)
+    try:
+        with open_url(src_url, "rb") as src:
+            data = src.read()
+        with open(tmp, "wb") as dst:
+            dst.write(data)
+        os.replace(tmp, dest_path)
+        return True
+    except FileNotFoundError:
+        return False
+    except Exception:
+        with contextlib.suppress(FileNotFoundError):
+            os.unlink(tmp)
         raise

--- a/lib/rigging/src/rigging/filesystem/factory.py
+++ b/lib/rigging/src/rigging/filesystem/factory.py
@@ -207,12 +207,11 @@ def atomic_rename(output_path: str, fs: Any = None) -> Generator[str, None, None
 def fetch_file_atomic(src_url: str, dest_path: str) -> bool:
     """Fetch ``src_url`` down to local ``dest_path`` atomically via a unique temp sibling.
 
-    Reads the source and writes it to a unique ``dest_path`` sibling temp file, then
-    ``os.replace``s it into place. ``dest_path`` therefore never holds a partial file —
-    a concurrent reader sees the previous complete file or the new one — and a fetch
-    killed midway leaves only an orphaned temp file instead of poisoning the destination
-    (e.g. a shared cache). The unique temp name keeps concurrent fetches of the same
-    destination from clobbering each other's in-flight files.
+    ``dest_path`` never holds a partial file — a concurrent reader sees the previous
+    complete file or the new one, and a fetch killed midway leaves only an orphaned temp
+    file instead of poisoning the destination (e.g. a shared cache). The unique temp name
+    keeps concurrent fetches of the same destination from clobbering each other's
+    in-flight files.
 
     Returns ``False`` if the source does not exist; re-raises all other errors.
     """

--- a/lib/rigging/tests/test_factory.py
+++ b/lib/rigging/tests/test_factory.py
@@ -2,13 +2,20 @@
 # SPDX-License-Identifier: Apache-2.0
 
 """Tests for the guarded fsspec factory: the url_to_fs/open_url/filesystem entry
-points, unique_temp_path, and atomic_rename."""
+points, unique_temp_path, atomic_rename, and fetch_file_atomic."""
 
 from pathlib import Path
 
 import pytest
 from rigging.filesystem.cross_region import CrossRegionGuardedFS
-from rigging.filesystem.factory import atomic_rename, filesystem, open_url, unique_temp_path, url_to_fs
+from rigging.filesystem.factory import (
+    atomic_rename,
+    fetch_file_atomic,
+    filesystem,
+    open_url,
+    unique_temp_path,
+    url_to_fs,
+)
 
 
 def test_unique_temp_path_produces_distinct_paths():
@@ -45,6 +52,68 @@ def test_atomic_rename_cleans_up_on_error(tmp_path):
 
     assert not Path(temp_path).exists()
     assert not Path(output).exists()
+
+
+# ---------------------------------------------------------------------------
+# fetch_file_atomic
+# ---------------------------------------------------------------------------
+
+
+def test_fetch_file_atomic_copies_source(tmp_path):
+    src = tmp_path / "remote" / "tokenizer.json"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b'{"version": 1}')
+    dest = tmp_path / "cache" / "tokenizer.json"
+    dest.parent.mkdir(parents=True)
+
+    assert fetch_file_atomic(str(src), str(dest)) is True
+    assert dest.read_bytes() == b'{"version": 1}'
+
+
+def test_fetch_file_atomic_missing_source_returns_false(tmp_path):
+    dest = tmp_path / "cache" / "tokenizer.json"
+    dest.parent.mkdir(parents=True)
+
+    assert fetch_file_atomic(str(tmp_path / "remote" / "absent.json"), str(dest)) is False
+    assert not dest.exists()
+
+
+def test_fetch_file_atomic_failure_preserves_dest_and_cleans_temp(tmp_path, monkeypatch):
+    # Regression for marin#7167: a fetch that dies mid-finalize must not leave a
+    # partial file at dest (poisoning a shared cache) and must not orphan its temp.
+    src = tmp_path / "remote" / "tokenizer.json"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b'{"version": 2}')
+    dest = tmp_path / "cache" / "tokenizer.json"
+    dest.parent.mkdir(parents=True)
+    dest.write_bytes(b'{"version": 1}')  # a previous complete file
+
+    def boom(*args, **kwargs):
+        raise OSError("simulated failure finalizing the fetch")
+
+    monkeypatch.setattr("os.replace", boom)
+
+    with pytest.raises(OSError, match="simulated failure"):
+        fetch_file_atomic(str(src), str(dest))
+
+    assert dest.read_bytes() == b'{"version": 1}'
+    assert [p.name for p in dest.parent.iterdir()] == ["tokenizer.json"]
+
+
+def test_fetch_file_atomic_leaves_unrelated_temp_untouched(tmp_path):
+    # Concurrency contract: another fetcher's in-flight temp sibling must never
+    # be consumed, clobbered, or promoted to dest.
+    src = tmp_path / "remote" / "tokenizer.json"
+    src.parent.mkdir(parents=True)
+    src.write_bytes(b'{"version": 1}')
+    dest = tmp_path / "cache" / "tokenizer.json"
+    dest.parent.mkdir(parents=True)
+    other_temp = dest.parent / "tokenizer.json.tmp.0123456789abcdef"
+    other_temp.write_bytes(b'{"trunc')
+
+    assert fetch_file_atomic(str(src), str(dest)) is True
+    assert dest.read_bytes() == b'{"version": 1}'
+    assert other_temp.read_bytes() == b'{"trunc'
 
 
 # ---------------------------------------------------------------------------

--- a/lib/rigging/tests/test_factory.py
+++ b/lib/rigging/tests/test_factory.py
@@ -100,22 +100,6 @@ def test_fetch_file_atomic_failure_preserves_dest_and_cleans_temp(tmp_path, monk
     assert [p.name for p in dest.parent.iterdir()] == ["tokenizer.json"]
 
 
-def test_fetch_file_atomic_leaves_unrelated_temp_untouched(tmp_path):
-    # Concurrency contract: another fetcher's in-flight temp sibling must never
-    # be consumed, clobbered, or promoted to dest.
-    src = tmp_path / "remote" / "tokenizer.json"
-    src.parent.mkdir(parents=True)
-    src.write_bytes(b'{"version": 1}')
-    dest = tmp_path / "cache" / "tokenizer.json"
-    dest.parent.mkdir(parents=True)
-    other_temp = dest.parent / "tokenizer.json.tmp.0123456789abcdef"
-    other_temp.write_bytes(b'{"trunc')
-
-    assert fetch_file_atomic(str(src), str(dest)) is True
-    assert dest.read_bytes() == b'{"version": 1}'
-    assert other_temp.read_bytes() == b'{"trunc'
-
-
 # ---------------------------------------------------------------------------
 # Guarded entry point tests
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
_patch_hf_hub_download wrote gs:// files directly to their final path in the
shared HF cache (transformers resolves cache_dir=None to HF_HUB_CACHE before
calling hf_hub_download), so a concurrent reader on the same host could observe
a half-written tokenizer.json, and a process killed mid-download left a
truncated file that failed every subsequent load with "EOF while parsing a
value at line 1 column 0". Each TPU eval VM runs several worker children that
load the same tokenizers simultaneously at startup, so once a truncated file
landed, shard retries on that worker failed deterministically.

Route the shim through a shared fetch_file_atomic helper in rigging.filesystem,
promoted from tokenizers.py's private _fetch_file_atomic and now used by both
the tokenizer mirror staging and the hub-download shim. It writes to a unique
temp sibling (via unique_temp_path) and os.replaces it into place, so a partial
file is never observable at the final path and concurrent fetches of one
destination cannot clobber each other's in-flight files; a killed fetch leaves
only an orphaned temp file. The shim's separate exists() probe is folded into
the fetch's missing-source result, saving a remote round-trip.

Fixes #7167