### PR TITLE
[docs] Document datakit testbed samples on CW S3

### DIFF
--- a/experiments/datakit/README.md
+++ b/experiments/datakit/README.md
@@ -92,15 +92,16 @@ flowchart TD
 
 Pre-built testbed samples live under `s3://marin-us-east-02a/marin/datakit/`
 (CoreWeave `us-east-02a`). Each is a tree of already-normalized sources named
-`sample_<tokens>_<hash>`, passable to `--sample-prefix`:
+`sample_<tokens>_<hash>`. Pass the full S3 root as `--sample-prefix` (it is used
+verbatim — the bucket prefix is not prepended):
 
-| Sample root | Approx. size |
+| `--sample-prefix` | Approx. size |
 | --- | --- |
-| `sample_0.1b_7d7d8fd7` | ~0.1B tokens (default `SAMPLE_PREFIX`) |
-| `sample_100b_8ae7a94f` | ~100B tokens |
-| `sample_100b_e273e96d` | ~100B tokens |
-| `sample_500b_32c52319` | ~500B tokens |
-| `sample_1t_733c8c5c` | ~1T tokens |
+| `s3://marin-us-east-02a/marin/datakit/sample_0.1b_7d7d8fd7` | ~0.1B tokens (default `SAMPLE_PREFIX`) |
+| `s3://marin-us-east-02a/marin/datakit/sample_100b_8ae7a94f` | ~100B tokens |
+| `s3://marin-us-east-02a/marin/datakit/sample_100b_e273e96d` | ~100B tokens |
+| `s3://marin-us-east-02a/marin/datakit/sample_500b_32c52319` | ~500B tokens |
+| `s3://marin-us-east-02a/marin/datakit/sample_1t_733c8c5c` | ~1T tokens |
 
 List them with:
 

--- a/experiments/datakit/README.md
+++ b/experiments/datakit/README.md
@@ -88,6 +88,26 @@ flowchart TD
     STORE -.-> RS
 ```
 
+## Testbed samples
+
+Pre-built testbed samples live under `s3://marin-us-east-02a/marin/datakit/`
+(CoreWeave `us-east-02a`). Each is a tree of already-normalized sources named
+`sample_<tokens>_<hash>`, passable to `--sample-prefix`:
+
+| Sample root | Approx. size |
+| --- | --- |
+| `sample_0.1b_7d7d8fd7` | ~0.1B tokens (default `SAMPLE_PREFIX`) |
+| `sample_100b_8ae7a94f` | ~100B tokens |
+| `sample_100b_e273e96d` | ~100B tokens |
+| `sample_500b_32c52319` | ~500B tokens |
+| `sample_1t_733c8c5c` | ~1T tokens |
+
+List them with:
+
+```bash
+aws s3 ls s3://marin-us-east-02a/marin/datakit/ | grep sample
+```
+
 ## Layout
 
 | Path | What it is |


### PR DESCRIPTION
Add a Testbed samples section to `experiments/datakit/README.md` listing the pre-built normalized-source samples under `s3://marin-us-east-02a/marin/datakit/` (0.1B–1T tokens) that `--sample-prefix` consumes, with the `aws s3 ls | grep sample` listing command. The sample roots were only discoverable by reading the pipeline code; this makes them findable from the docs.